### PR TITLE
Preserve empty tool schema properties

### DIFF
--- a/inc/Engine/AI/ProviderRequestAssembler.php
+++ b/inc/Engine/AI/ProviderRequestAssembler.php
@@ -114,14 +114,14 @@ class ProviderRequestAssembler {
 		if ( ! is_array( $parameters ) || empty( $parameters ) ) {
 			return array(
 				'type'       => 'object',
-				'properties' => self::noArgumentToolProperties(),
+				'properties' => (object) array(),
 			);
 		}
 
 		if ( isset( $parameters['type'] ) || isset( $parameters['properties'] ) || isset( $parameters['required'] ) ) {
 			$parameters['type'] = $parameters['type'] ?? 'object';
 			if ( isset( $parameters['properties'] ) && is_array( $parameters['properties'] ) && empty( $parameters['properties'] ) ) {
-				$parameters['properties'] = self::noArgumentToolProperties();
+				$parameters['properties'] = (object) array();
 			}
 			return $parameters;
 		}
@@ -144,29 +144,14 @@ class ProviderRequestAssembler {
 		}
 
 		$normalized = array(
-			'type' => 'object',
+			'type'       => 'object',
+			'properties' => ! empty( $properties ) ? $properties : (object) array(),
 		);
-
-		if ( ! empty( $properties ) ) {
-			$normalized['properties'] = $properties;
-		}
 
 		if ( ! empty( $required ) ) {
 			$normalized['required'] = $required;
 		}
 
 		return $normalized;
-	}
-
-	/**
-	 * @return array<string, array<string, string>>
-	 */
-	private static function noArgumentToolProperties(): array {
-		return array(
-			'_unused' => array(
-				'type'        => 'boolean',
-				'description' => 'Ignored placeholder for providers that require at least one object property.',
-			),
-		);
 	}
 }

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -773,12 +773,7 @@ class RequestBuilder {
 		}
 
 		if ( isset( $parameters['properties'] ) && is_array( $parameters['properties'] ) && empty( $parameters['properties'] ) ) {
-			$parameters['properties'] = array(
-				'_unused' => array(
-					'type'        => 'boolean',
-					'description' => 'Ignored placeholder for providers that require at least one object property.',
-				),
-			);
+			$parameters['properties'] = (object) array();
 		}
 
 		return $parameters;

--- a/tests/wp-ai-client-tool-schema-smoke.php
+++ b/tests/wp-ai-client-tool-schema-smoke.php
@@ -309,7 +309,9 @@ $captured_request = array();
 $empty_schema = $captured_request['tools']['client/no_arg_tool']['parameters'] ?? null;
 $assert( is_array( $empty_schema ), 'no-argument tools use a parameter schema array' );
 $assert( 'object' === ( $empty_schema['type'] ?? null ), 'no-argument tools use object parameter schemas' );
-$assert( isset( $empty_schema['properties']['_unused'] ), 'no-argument tool properties include an ignored provider-compatible placeholder' );
+$assert( isset( $empty_schema['properties'] ), 'no-argument tool schemas keep explicit properties for strict providers' );
+$assert( $empty_schema['properties'] instanceof stdClass, 'no-argument tool properties encode as a JSON object' );
+$assert( ! str_contains( json_encode( $empty_schema ), '[]' ), 'no-argument tool schema avoids PHP empty-array JSON encoding' );
 
 echo "\n{$assertions} assertions, " . count( $failures ) . " failures\n";
 


### PR DESCRIPTION
## Summary
- Replaces the `_unused` no-argument tool placeholder with an explicit empty JSON object map for `properties`.
- Keeps no-argument and empty object schemas provider-compatible without changing the tool argument contract visible to the model.
- Extends the wp-ai-client schema smoke to assert `properties` remains present and JSON-encodes as `{}` rather than `[]`.

## Testing
- `php tests/wp-ai-client-tool-schema-smoke.php`
- `php tests/global-tool-array-items-smoke.php`
- Direct `workspace_list` schema reproduction: `{"type":"object","properties":{},"required":[]}`
- `homeboy test --path . --extension wordpress --changed-since origin/main --summary`
- `homeboy lint --path . --extension wordpress --changed-since origin/main --summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the strict tool schema failure, drafted the focused Data Machine fix, and ran local validation. Chris remains responsible for review and merge.