### PR TITLE
Fix focused Data Machine release blockers

### DIFF
--- a/inc/Abilities/Chat/SendMessageAbility.php
+++ b/inc/Abilities/Chat/SendMessageAbility.php
@@ -169,7 +169,7 @@ class SendMessageAbility {
 		$model    = $input['model'] ?? '';
 
 		if ( empty( $provider ) || empty( $model ) ) {
-			$agent_config = PluginSettings::resolveModelForAgentMode( $agent_id ?: null, 'chat' );
+			$agent_config = PluginSettings::resolveModelForAgentMode( $agent_id > 0 ? $agent_id : null, 'chat' );
 			if ( empty( $provider ) ) {
 				$provider = $agent_config['provider'];
 			}

--- a/inc/Abilities/Publish/SendEmailAbility.php
+++ b/inc/Abilities/Publish/SendEmailAbility.php
@@ -140,7 +140,10 @@ class SendEmailAbility {
 
 		// 1. Parse and validate recipients.
 		$to = array_map( 'trim', explode( ',', $config['to'] ) );
-		$to = array_filter( $to, 'is_email' );
+		$to = array_filter(
+			$to,
+			static fn( string $email ): bool => false !== is_email( $email )
+		);
 
 		if ( empty( $to ) ) {
 			$logs[] = array(
@@ -166,8 +169,8 @@ class SendEmailAbility {
 		$headers[] = "Content-Type: {$content_type}; charset=UTF-8";
 
 		// From.
-		$from_name  = $config['from_name'] ?: get_bloginfo( 'name' );
-		$from_email = $config['from_email'] ?: get_option( 'admin_email' );
+		$from_name  = ! empty( $config['from_name'] ) ? $config['from_name'] : get_bloginfo( 'name' );
+		$from_email = ! empty( $config['from_email'] ) ? $config['from_email'] : get_option( 'admin_email' );
 		if ( $from_name && $from_email ) {
 			$headers[] = sprintf( 'From: %s <%s>', $from_name, $from_email );
 		}
@@ -258,7 +261,7 @@ class SendEmailAbility {
 		global $phpmailer;
 		$error_msg = 'wp_mail() returned false';
 		if ( isset( $phpmailer ) && $phpmailer instanceof \PHPMailer\PHPMailer\PHPMailer ) {
-			$error_msg = $phpmailer->ErrorInfo ?: $error_msg;
+			$error_msg = ! empty( $phpmailer->ErrorInfo ) ? $phpmailer->ErrorInfo : $error_msg;
 		}
 
 		$logs[] = array(
@@ -313,6 +316,6 @@ class SendEmailAbility {
 			'{admin_email}' => get_option( 'admin_email' ),
 		);
 
-		return str_replace( array_keys( $replacements ), array_values( $replacements ), $text );
+		return str_replace( array_keys( $replacements ), array_map( 'strval', array_values( $replacements ) ), $text );
 	}
 }

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -18,6 +18,7 @@ use DataMachine\Engine\Bundle\AgentBundleArtifactRebase;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
 use DataMachine\Engine\Bundle\AgentBundleRuntimeDrift;
+use DataMachine\Engine\Bundle\BundleStepIdRemapper;
 use DataMachine\Engine\Bundle\BundleValidationException;
 use DataMachine\Engine\Bundle\BundleSource;
 use DataMachine\Engine\Bundle\BundleSourceAuth;
@@ -578,7 +579,7 @@ class AgentBundleCommand extends BaseCommand {
 			$target_flow = array_merge(
 				$flow,
 				array(
-					'flow_config' => $this->remap_flow_step_ids(
+					'flow_config' => BundleStepIdRemapper::remap_flow_step_ids(
 						is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array(),
 						$old_pipeline_id,
 						$new_pipeline_id,
@@ -601,11 +602,12 @@ class AgentBundleCommand extends BaseCommand {
 			WP_CLI::error( 'Bundle source is required.' );
 		}
 
-		$context  = $this->build_resolve_context( $assoc_args );
+		$context  = $this->build_cli_resolve_context( $assoc_args );
 		$resolved = BundleSource::resolve( $source, $context );
 		if ( is_wp_error( $resolved ) ) {
 			WP_CLI::error( $resolved->get_error_message() );
 		}
+		/** @var string $resolved */
 
 		// Snapshot the revision before any downstream resolve() call
 		// resets it (e.g. via re-entry through abilities).
@@ -656,7 +658,7 @@ class AgentBundleCommand extends BaseCommand {
 	 * @param array $assoc_args WP_CLI assoc args.
 	 * @return array
 	 */
-	private function build_resolve_context( array $assoc_args ): array {
+	private function build_cli_resolve_context( array $assoc_args ): array {
 		$token     = isset( $assoc_args['token'] ) ? (string) $assoc_args['token'] : null;
 		$token_env = isset( $assoc_args['token-env'] ) ? (string) $assoc_args['token-env'] : null;
 
@@ -724,7 +726,7 @@ class AgentBundleCommand extends BaseCommand {
 				$new_id = (int) ( $existing_pipelines_by_slug[ $slug ]['pipeline_id'] ?? 0 );
 
 				$pipeline_id_map[ $old_id ]  = $new_id;
-				$pipeline['pipeline_config'] = $this->remap_pipeline_step_ids(
+				$pipeline['pipeline_config'] = BundleStepIdRemapper::remap_pipeline_step_ids(
 					is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(),
 					$old_id,
 					$new_id
@@ -749,7 +751,7 @@ class AgentBundleCommand extends BaseCommand {
 			$existing_flow   = $new_pipeline_id > 0 ? $this->flows()->get_by_portable_slug( $new_pipeline_id, $slug ) : null;
 
 			if ( $existing_flow ) {
-				$flow['flow_config'] = $this->remap_flow_step_ids(
+				$flow['flow_config'] = BundleStepIdRemapper::remap_flow_step_ids(
 					is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array(),
 					$old_pipeline_id,
 					$new_pipeline_id,
@@ -868,53 +870,6 @@ class AgentBundleCommand extends BaseCommand {
 		unset( $step );
 
 		return $flow_config;
-	}
-
-	private function remap_pipeline_step_ids( array $pipeline_config, int $old_pipeline_id, int $new_pipeline_id ): array {
-		$remapped = array();
-
-		foreach ( $pipeline_config as $pipeline_step_id => $step_config ) {
-			$new_pipeline_step_id = $this->remap_step_id_prefix( (string) $pipeline_step_id, $old_pipeline_id, $new_pipeline_id );
-			if ( is_array( $step_config ) ) {
-				$step_config['pipeline_step_id'] = $new_pipeline_step_id;
-			}
-
-			$remapped[ $new_pipeline_step_id ] = $step_config;
-		}
-
-		return $remapped;
-	}
-
-	private function remap_flow_step_ids( array $flow_config, int $old_pipeline_id, int $new_pipeline_id, int $new_flow_id ): array {
-		$remapped = array();
-
-		foreach ( $flow_config as $flow_step_id => $step_config ) {
-			$pipeline_step_id = is_array( $step_config ) && is_string( $step_config['pipeline_step_id'] ?? null )
-				? $step_config['pipeline_step_id']
-				: preg_replace( '/_\d+$/', '', (string) $flow_step_id );
-			$pipeline_step_id = $this->remap_step_id_prefix( (string) $pipeline_step_id, $old_pipeline_id, $new_pipeline_id );
-			$new_flow_step_id = $pipeline_step_id . '_' . $new_flow_id;
-
-			if ( is_array( $step_config ) ) {
-				$step_config['pipeline_step_id'] = $pipeline_step_id;
-				$step_config['pipeline_id']      = $new_pipeline_id;
-				$step_config['flow_id']          = $new_flow_id;
-				$step_config['flow_step_id']     = $new_flow_step_id;
-			}
-
-			$remapped[ $new_flow_step_id ] = $step_config;
-		}
-
-		return $remapped;
-	}
-
-	private function remap_step_id_prefix( string $step_id, int $old_pipeline_id, int $new_pipeline_id ): string {
-		$prefix = $old_pipeline_id . '_';
-		if ( $old_pipeline_id === $new_pipeline_id || ! str_starts_with( $step_id, $prefix ) ) {
-			return $step_id;
-		}
-
-		return $new_pipeline_id . '_' . substr( $step_id, strlen( $prefix ) );
 	}
 
 	private function resolve_bundle_agent( array $bundle, string $slug = '' ): ?array {

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -22,6 +22,7 @@ use DataMachine\Api\Flows\FlowScheduling;
 use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
 use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
 use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
+use DataMachine\Engine\Bundle\BundleStepIdRemapper;
 use DataMachine\Engine\Bundle\AgentBundleDirectory;
 use DataMachine\Engine\Bundle\AgentBundleFlowFile;
 use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
@@ -693,7 +694,7 @@ class AgentBundler {
 				$existing_pipeline = $this->pipelines_repo->get_by_portable_slug( $agent_id, $portable_slug );
 				$target_pipeline   = $pipeline_data;
 				if ( $existing_pipeline ) {
-					$target_pipeline['pipeline_config'] = $this->remap_pipeline_step_ids( $pipeline_config, $old_id, (int) $existing_pipeline['pipeline_id'] );
+					$target_pipeline['pipeline_config'] = BundleStepIdRemapper::remap_pipeline_step_ids( $pipeline_config, $old_id, (int) $existing_pipeline['pipeline_id'] );
 				}
 				$payload = $this->pipeline_artifact_payload( $target_pipeline, $portable_slug );
 
@@ -733,7 +734,7 @@ class AgentBundler {
 					$created_pipeline_ids[] = (int) $new_pipeline_id;
 				}
 
-				$pipeline_config = $this->remap_pipeline_step_ids( $pipeline_config, $old_id, (int) $new_pipeline_id );
+				$pipeline_config = BundleStepIdRemapper::remap_pipeline_step_ids( $pipeline_config, $old_id, (int) $new_pipeline_id );
 				if ( ! $this->pipelines_repo->update_pipeline(
 				(int) $new_pipeline_id,
 				array(
@@ -786,7 +787,7 @@ class AgentBundler {
 				$flow_config         = is_array( $flow_data['flow_config'] ?? null ) ? $flow_data['flow_config'] : array();
 				$existing_flow       = $this->flows_repo->get_by_portable_slug( (int) $new_pipeline_id, $portable_slug );
 				$target_flow_config  = $existing_flow
-				? $this->remap_flow_step_ids( $flow_config, $old_pipeline_id, (int) $new_pipeline_id, (int) $existing_flow['flow_id'] )
+				? BundleStepIdRemapper::remap_flow_step_ids( $flow_config, $old_pipeline_id, (int) $new_pipeline_id, (int) $existing_flow['flow_id'] )
 				: $flow_config;
 				$flow_payload_source = array_merge(
 				$flow_data,
@@ -831,7 +832,7 @@ class AgentBundler {
 				if ( $existing_flow ) {
 					$new_flow_id          = (int) $existing_flow['flow_id'];
 					$scheduling_to_ensure = is_array( $existing_flow['scheduling_config'] ?? null ) ? $existing_flow['scheduling_config'] : array();
-					$flow_config          = $this->remap_flow_step_ids( $flow_config, $old_pipeline_id, (int) $new_pipeline_id, $new_flow_id );
+					$flow_config          = BundleStepIdRemapper::remap_flow_step_ids( $flow_config, $old_pipeline_id, (int) $new_pipeline_id, $new_flow_id );
 					$flow_config          = $reconcile_runtime
 					? AgentBundleRuntimeDrift::replace_runtime_queue_fields( $flow_config, $target_flow_config )
 					: $this->preserve_runtime_queue_fields( $flow_config, $existing_flow['flow_config'] ?? array() );
@@ -869,7 +870,7 @@ class AgentBundler {
 					}
 					$created_flow_ids[] = (int) $new_flow_id;
 
-					$flow_config = $this->remap_flow_step_ids( $flow_config, $old_pipeline_id, (int) $new_pipeline_id, (int) $new_flow_id );
+					$flow_config = BundleStepIdRemapper::remap_flow_step_ids( $flow_config, $old_pipeline_id, (int) $new_pipeline_id, (int) $new_flow_id );
 					if ( ! $this->flows_repo->update_flow(
 					(int) $new_flow_id,
 					array(
@@ -1344,7 +1345,7 @@ class AgentBundler {
 
 			$old_pipeline_id = (int) $step_config['pipeline_id'];
 			if ( $old_pipeline_id > 0 && $flow_id > 0 ) {
-				$flow['flow_config'] = $this->remap_flow_step_ids( $flow_config, $old_pipeline_id, $new_pipeline_id, $flow_id );
+				$flow['flow_config'] = BundleStepIdRemapper::remap_flow_step_ids( $flow_config, $old_pipeline_id, $new_pipeline_id, $flow_id );
 			}
 
 			break;
@@ -1627,82 +1628,6 @@ class AgentBundler {
 			}
 			file_put_contents( $full_path, $content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		}
-	}
-
-	/**
-	 * Remap pipeline step IDs inside a pipeline config.
-	 *
-	 * @param array $pipeline_config Pipeline config.
-	 * @param int   $old_pipeline_id Original pipeline ID.
-	 * @param int   $new_pipeline_id New pipeline ID.
-	 * @return array Updated pipeline config.
-	 */
-	private function remap_pipeline_step_ids( array $pipeline_config, int $old_pipeline_id, int $new_pipeline_id ): array {
-		$remapped = array();
-
-		foreach ( $pipeline_config as $pipeline_step_id => $step_config ) {
-			$new_pipeline_step_id = $this->remap_step_id_prefix( (string) $pipeline_step_id, $old_pipeline_id, $new_pipeline_id );
-			if ( is_array( $step_config ) ) {
-				$step_config['pipeline_step_id'] = $new_pipeline_step_id;
-			}
-
-			$remapped[ $new_pipeline_step_id ] = $step_config;
-		}
-
-		return $remapped;
-	}
-
-	/**
-	 * Remap pipeline step IDs inside a flow config.
-	 *
-	 * Pipeline step IDs have the format {pipeline_id}_{uuid}. Flow step IDs add
-	 * the installed flow ID as the final suffix. Bundle-local IDs must be
-	 * rewritten after install or runtime lookups resolve the wrong pipeline.
-	 *
-	 * @param array $flow_config     Flow config.
-	 * @param int   $old_pipeline_id Original pipeline ID.
-	 * @param int   $new_pipeline_id New pipeline ID.
-	 * @param int   $new_flow_id     New flow ID.
-	 * @return array Updated flow config.
-	 */
-	private function remap_flow_step_ids( array $flow_config, int $old_pipeline_id, int $new_pipeline_id, int $new_flow_id ): array {
-		$remapped = array();
-
-		foreach ( $flow_config as $flow_step_id => $step_config ) {
-			$pipeline_step_id = is_array( $step_config ) && is_string( $step_config['pipeline_step_id'] ?? null )
-				? $step_config['pipeline_step_id']
-				: preg_replace( '/_\d+$/', '', (string) $flow_step_id );
-			$pipeline_step_id = $this->remap_step_id_prefix( (string) $pipeline_step_id, $old_pipeline_id, $new_pipeline_id );
-			$new_flow_step_id = $pipeline_step_id . '_' . $new_flow_id;
-
-			if ( is_array( $step_config ) ) {
-				$step_config['pipeline_step_id'] = $pipeline_step_id;
-				$step_config['pipeline_id']      = $new_pipeline_id;
-				$step_config['flow_id']          = $new_flow_id;
-				$step_config['flow_step_id']     = $new_flow_step_id;
-			}
-
-			$remapped[ $new_flow_step_id ] = $step_config;
-		}
-
-		return $remapped;
-	}
-
-	/**
-	 * Remap the pipeline ID prefix of a step ID.
-	 *
-	 * @param string $step_id         Step ID.
-	 * @param int    $old_pipeline_id Original pipeline ID.
-	 * @param int    $new_pipeline_id New pipeline ID.
-	 * @return string Remapped step ID.
-	 */
-	private function remap_step_id_prefix( string $step_id, int $old_pipeline_id, int $new_pipeline_id ): string {
-		$prefix = $old_pipeline_id . '_';
-		if ( $old_pipeline_id === $new_pipeline_id || ! str_starts_with( $step_id, $prefix ) ) {
-			return $step_id;
-		}
-
-		return $new_pipeline_id . '_' . substr( $step_id, strlen( $prefix ) );
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentBundlePipelineFile.php
+++ b/inc/Engine/Bundle/AgentBundlePipelineFile.php
@@ -29,7 +29,7 @@ final class AgentBundlePipelineFile {
 		BundleSchema::assert_supported_version( $data, 'pipeline file' );
 		foreach ( array( 'slug', 'name', 'steps' ) as $field ) {
 			if ( ! array_key_exists( $field, $data ) ) {
-				throw new BundleValidationException( "pipeline file is missing required field {$field}." );
+				throw new BundleValidationException( sprintf( 'pipeline file is missing required field %s.', esc_html( $field ) ) );
 			}
 		}
 
@@ -57,7 +57,7 @@ final class AgentBundlePipelineFile {
 			}
 			foreach ( array( 'step_position', 'step_type', 'step_config' ) as $field ) {
 				if ( ! array_key_exists( $field, $step ) ) {
-					throw new BundleValidationException( "pipeline file step is missing required field {$field}." );
+					throw new BundleValidationException( sprintf( 'pipeline file step is missing required field %s.', esc_html( $field ) ) );
 				}
 			}
 			if ( ! is_array( $step['step_config'] ) ) {

--- a/inc/Engine/Bundle/AgentTemplateMetadata.php
+++ b/inc/Engine/Bundle/AgentTemplateMetadata.php
@@ -55,12 +55,16 @@ final class AgentTemplateMetadata {
 	}
 
 	public static function from_manifest( AgentBundleManifest $manifest, string $template_slug = '', string $template_version = '', array $installed_hashes = array() ): self {
-		$manifest_data = $manifest->to_array();
-		$agent_slug    = (string) ( $manifest_data['agent']['slug'] ?? 'template' );
+		$manifest_data     = $manifest->to_array();
+		$agent_slug        = (string) ( $manifest_data['agent']['slug'] ?? 'template' );
+		$template_slug     = trim( $template_slug );
+		$template_version  = trim( $template_version );
+		$effective_slug    = '' !== $template_slug ? $template_slug : $agent_slug;
+		$effective_version = '' !== $template_version ? $template_version : $manifest->bundle_version();
 
 		return new self(
-			'' !== trim( $template_slug ) ? $template_slug : $agent_slug,
-			'' !== trim( $template_version ) ? $template_version : $manifest->bundle_version(),
+			$effective_slug,
+			$effective_version,
 			$manifest->bundle_slug(),
 			$manifest->bundle_version(),
 			$manifest->source_ref(),

--- a/inc/Engine/Bundle/BundleStepIdRemapper.php
+++ b/inc/Engine/Bundle/BundleStepIdRemapper.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Bundle step ID remapping helpers.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Rewrites bundle-local pipeline and flow step IDs after import.
+ */
+class BundleStepIdRemapper {
+
+	/**
+	 * Remap pipeline step IDs inside a pipeline config.
+	 *
+	 * @param array $pipeline_config Pipeline config.
+	 * @param int   $old_pipeline_id Original pipeline ID.
+	 * @param int   $new_pipeline_id New pipeline ID.
+	 * @return array Updated pipeline config.
+	 */
+	public static function remap_pipeline_step_ids( array $pipeline_config, int $old_pipeline_id, int $new_pipeline_id ): array {
+		$remapped = array();
+
+		foreach ( $pipeline_config as $pipeline_step_id => $step_config ) {
+			$new_pipeline_step_id = self::remap_step_id_prefix( (string) $pipeline_step_id, $old_pipeline_id, $new_pipeline_id );
+			if ( is_array( $step_config ) ) {
+				$step_config['pipeline_step_id'] = $new_pipeline_step_id;
+			}
+
+			$remapped[ $new_pipeline_step_id ] = $step_config;
+		}
+
+		return $remapped;
+	}
+
+	/**
+	 * Remap pipeline step IDs inside a flow config.
+	 *
+	 * Pipeline step IDs have the format {pipeline_id}_{uuid}. Flow step IDs add
+	 * the installed flow ID as the final suffix. Bundle-local IDs must be
+	 * rewritten after install or runtime lookups resolve the wrong pipeline.
+	 *
+	 * @param array $flow_config     Flow config.
+	 * @param int   $old_pipeline_id Original pipeline ID.
+	 * @param int   $new_pipeline_id New pipeline ID.
+	 * @param int   $new_flow_id     New flow ID.
+	 * @return array Updated flow config.
+	 */
+	public static function remap_flow_step_ids( array $flow_config, int $old_pipeline_id, int $new_pipeline_id, int $new_flow_id ): array {
+		$remapped = array();
+
+		foreach ( $flow_config as $flow_step_id => $step_config ) {
+			$pipeline_step_id = is_array( $step_config ) && is_string( $step_config['pipeline_step_id'] ?? null )
+				? $step_config['pipeline_step_id']
+				: preg_replace( '/_\d+$/', '', (string) $flow_step_id );
+			$pipeline_step_id = self::remap_step_id_prefix( (string) $pipeline_step_id, $old_pipeline_id, $new_pipeline_id );
+			$new_flow_step_id = $pipeline_step_id . '_' . $new_flow_id;
+
+			if ( is_array( $step_config ) ) {
+				$step_config['pipeline_step_id'] = $pipeline_step_id;
+				$step_config['pipeline_id']      = $new_pipeline_id;
+				$step_config['flow_id']          = $new_flow_id;
+				$step_config['flow_step_id']     = $new_flow_step_id;
+			}
+
+			$remapped[ $new_flow_step_id ] = $step_config;
+		}
+
+		return $remapped;
+	}
+
+	/**
+	 * Remap the pipeline ID prefix of a step ID.
+	 *
+	 * @param string $step_id         Step ID.
+	 * @param int    $old_pipeline_id Original pipeline ID.
+	 * @param int    $new_pipeline_id New pipeline ID.
+	 * @return string Remapped step ID.
+	 */
+	public static function remap_step_id_prefix( string $step_id, int $old_pipeline_id, int $new_pipeline_id ): string {
+		$prefix = $old_pipeline_id . '_';
+		if ( $old_pipeline_id === $new_pipeline_id || ! str_starts_with( $step_id, $prefix ) ) {
+			return $step_id;
+		}
+
+		return $new_pipeline_id . '_' . substr( $step_id, strlen( $prefix ) );
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "datamachine",
-	"version": "0.83.0",
+	"version": "0.106.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "datamachine",
-			"version": "0.83.0",
+			"version": "0.106.1",
 			"dependencies": {
 				"@extrachill/chat": "^0.11.0",
 				"@tanstack/react-query": "^5.90.12",

--- a/tests/agent-bundle-portable-update-smoke.php
+++ b/tests/agent-bundle-portable-update-smoke.php
@@ -59,6 +59,7 @@ use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
 use DataMachine\Engine\Bundle\AgentBundleFlowFile;
+use DataMachine\Engine\Bundle\BundleStepIdRemapper;
 
 $failures = array();
 $passes   = 0;
@@ -207,39 +208,31 @@ $runtime_stripped_payload = call_bundle_private(
 );
 assert_bundle_update( 'flow artifact hashing ignores queue consume revision', ! isset( $runtime_stripped_payload['flow_config']['2_bundle_step_0_4']['_queue_consume_revision'] ) );
 
-$remapped_pipeline = call_bundle_private(
-	$bundler,
-	'remap_pipeline_step_ids',
+$remapped_pipeline = BundleStepIdRemapper::remap_pipeline_step_ids(
 	array(
-		array(
-			'2_bundle_step_0' => array(
-				'pipeline_step_id' => '2_bundle_step_0',
-				'step_type'        => 'fetch',
-			),
+		'2_bundle_step_0' => array(
+			'pipeline_step_id' => '2_bundle_step_0',
+			'step_type'        => 'fetch',
 		),
-		2,
-		3,
-	)
+	),
+	2,
+	3
 );
 assert_bundle_update( 'pipeline step key remaps to installed pipeline ID', isset( $remapped_pipeline['3_bundle_step_0'] ) );
 assert_bundle_update_equals( 'pipeline step metadata remaps to installed pipeline ID', '3_bundle_step_0', $remapped_pipeline['3_bundle_step_0']['pipeline_step_id'] ?? null );
 
-$remapped_flow = call_bundle_private(
-	$bundler,
-	'remap_flow_step_ids',
+$remapped_flow = BundleStepIdRemapper::remap_flow_step_ids(
 	array(
-		array(
-			'2_bundle_step_0_4' => array(
-				'flow_step_id'     => '2_bundle_step_0_4',
-				'pipeline_step_id' => '2_bundle_step_0',
-				'pipeline_id'      => 2,
-				'flow_id'          => 4,
-			),
+		'2_bundle_step_0_4' => array(
+			'flow_step_id'     => '2_bundle_step_0_4',
+			'pipeline_step_id' => '2_bundle_step_0',
+			'pipeline_id'      => 2,
+			'flow_id'          => 4,
 		),
-		2,
-		3,
-		9,
-	)
+	),
+	2,
+	3,
+	9
 );
 assert_bundle_update( 'flow step key remaps to installed pipeline and flow IDs', isset( $remapped_flow['3_bundle_step_0_9'] ) );
 assert_bundle_update_equals( 'flow step metadata pipeline_step_id remaps', '3_bundle_step_0', $remapped_flow['3_bundle_step_0_9']['pipeline_step_id'] ?? null );


### PR DESCRIPTION
## Summary
- Extract bundle step ID remapping into a shared helper so CLI and runtime bundle import paths no longer duplicate the same logic.
- Apply small focused lint fixes in touched bundle/ability code and refresh the package lock root version to match `package.json`.
- Update the bundle portable update smoke coverage to exercise the shared remapper directly.

## Testing
- `homeboy lint --changed-only --errors-only`
- `homeboy lint --errors-only --glob 'inc/Engine/Bundle/*.php'`
- `homeboy audit --only duplicate_function --only parallel_runner_setup --json-summary`
- `php tests/agent-bundle-portable-update-smoke.php`
- `homeboy test --json-summary`

## Notes
- Full `homeboy audit --json-summary` still reports broad pre-existing audit findings plus the now-closed Homeboy false positive tracked in Extra-Chill/homeboy#2380 on local `homeboy 0.163.1`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused release-blocker code changes, ran local verification, and prepared the PR description for Chris to review.