### PR TITLE
Add cycle flow runner

### DIFF
--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -21,6 +21,8 @@ WP_CLI::add_command( 'datamachine settings', Commands\SettingsCommand::class );
 WP_CLI::add_command( 'datamachine flows', Commands\Flows\FlowsCommand::class );
 WP_CLI::add_command( 'datamachine alt-text', Commands\AltTextCommand::class );
 WP_CLI::add_command( 'datamachine jobs', Commands\JobsCommand::class );
+WP_CLI::add_command( 'datamachine cycle', Commands\CycleCommand::class );
+WP_CLI::add_command( 'datamachine cycles', Commands\CycleCommand::class );
 WP_CLI::add_command( 'datamachine drain', Commands\DrainCommand::class );
 WP_CLI::add_command( 'datamachine ai', Commands\AICommand::class );
 WP_CLI::add_command( 'datamachine pipelines', Commands\PipelinesCommand::class );

--- a/inc/Cli/Commands/CycleCommand.php
+++ b/inc/Cli/Commands/CycleCommand.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * WP-CLI Data Machine cycle command.
+ *
+ * @package DataMachine\Cli\Commands
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Flows\CycleFlowSelector;
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Run flows that are due during an external cycle.
+ */
+class CycleCommand extends BaseCommand {
+
+	/**
+	 * Run all flows due for an external cycle.
+	 *
+	 * This is the orchestration primitive for environments that wake on a single
+	 * external trigger, such as a CI or Playground day cycle. Interval and cron
+	 * flows use Data Machine's existing jobs-table readiness logic. Manual flows
+	 * only join the cycle when their scheduling config explicitly includes
+	 * `cycle_policy: every_cycle`.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<cycle>]
+	 * : Human-readable cycle slug for logs/output.
+	 * ---
+	 * default: default
+	 * ---
+	 *
+	 * [--dry-run]
+	 * : Select due flows without starting jobs.
+	 *
+	 * [--[no-]drain]
+	 * : Drain due Data Machine actions after starting due flows.
+	 * ---
+	 * default: true
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine cycle run world-of-wordpress
+	 *     wp datamachine cycle run world-of-wordpress --dry-run --format=json
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		if ( ! empty( $args ) && 'run' === $args[0] ) {
+			array_shift( $args );
+		}
+
+		$cycle  = sanitize_key( (string) ( $args[0] ?? 'default' ) );
+		$format = (string) ( $assoc_args['format'] ?? 'table' );
+		$dry_run = isset( $assoc_args['dry-run'] );
+		$drain   = ! $dry_run && \WP_CLI\Utils\get_flag_value( $assoc_args, 'drain', true );
+
+		$flows_repo            = new Flows();
+		$scheduled_ready_flows = $flows_repo->get_flows_ready_for_execution();
+		$all_flows             = $flows_repo->get_all_flows();
+		$selected              = CycleFlowSelector::select_due_flows( $scheduled_ready_flows, $all_flows );
+
+		$rows = array();
+		foreach ( $selected as $item ) {
+			$flow = $item['flow'];
+			$rows[] = array(
+				'flow_id'       => (int) ( $flow['flow_id'] ?? 0 ),
+				'flow_name'     => (string) ( $flow['flow_name'] ?? '' ),
+				'portable_slug' => (string) ( $flow['portable_slug'] ?? '' ),
+				'reason'        => $item['reason'],
+				'status'        => $dry_run ? 'would_run' : 'pending',
+				'job_id'        => null,
+			);
+		}
+
+		if ( ! $dry_run && ! empty( $rows ) ) {
+			$ability = wp_get_ability( 'datamachine/run-flow' );
+			if ( ! $ability ) {
+				WP_CLI::error( 'Run flow ability not registered.' );
+				return;
+			}
+
+			foreach ( $rows as &$row ) {
+				$result = $ability->execute( array( 'flow_id' => (int) $row['flow_id'] ) );
+				if ( ! ( $result['success'] ?? false ) ) {
+					$row['status'] = 'failed_to_start';
+					$row['error']  = (string) ( $result['error'] ?? 'Failed to run flow' );
+					continue;
+				}
+
+				$row['status'] = 'started';
+				$row['job_id'] = isset( $result['job_id'] ) ? (int) $result['job_id'] : null;
+			}
+			unset( $row );
+		}
+
+		$drain_stats = null;
+		if ( $drain ) {
+			$drain_stats = DrainCommand::drain(
+				array(
+					'hooks' => array(
+						DrainCommand::HOOK_BATCH_CHUNK,
+						DrainCommand::HOOK_EXECUTE_STEP,
+					),
+				)
+			);
+		}
+
+		$summary = array(
+			'cycle'       => $cycle,
+			'dry_run'     => $dry_run,
+			'selected'    => count( $rows ),
+			'flows'       => $rows,
+			'drain_stats' => $drain_stats,
+		);
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( (string) wp_json_encode( $summary, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		WP_CLI::log( sprintf( 'Cycle: %s', $cycle ) );
+		if ( empty( $rows ) ) {
+			WP_CLI::success( 'No flows due for this cycle.' );
+		} else {
+			$this->format_items( $rows, array( 'flow_id', 'flow_name', 'portable_slug', 'reason', 'status', 'job_id' ), array( 'format' => 'table' ) );
+		}
+
+		if ( null !== $drain_stats ) {
+			WP_CLI::log(
+				sprintf(
+					'Drained Data Machine actions: %d batch chunks, %d step executions, %d completions, %d failures, %d due pending remain.',
+					$drain_stats['batch_chunks'],
+					$drain_stats['step_executions'],
+					$drain_stats['completions'],
+					$drain_stats['failures'],
+					$drain_stats['remaining_pending']
+				)
+			);
+		}
+	}
+}

--- a/inc/Cli/Commands/CycleCommand.php
+++ b/inc/Cli/Commands/CycleCommand.php
@@ -67,8 +67,8 @@ class CycleCommand extends BaseCommand {
 			array_shift( $args );
 		}
 
-		$cycle  = sanitize_key( (string) ( $args[0] ?? 'default' ) );
-		$format = (string) ( $assoc_args['format'] ?? 'table' );
+		$cycle   = sanitize_key( (string) ( $args[0] ?? 'default' ) );
+		$format  = (string) ( $assoc_args['format'] ?? 'table' );
 		$dry_run = isset( $assoc_args['dry-run'] );
 		$drain   = ! $dry_run && \WP_CLI\Utils\get_flag_value( $assoc_args, 'drain', true );
 
@@ -79,7 +79,7 @@ class CycleCommand extends BaseCommand {
 
 		$rows = array();
 		foreach ( $selected as $item ) {
-			$flow = $item['flow'];
+			$flow   = $item['flow'];
 			$rows[] = array(
 				'flow_id'       => (int) ( $flow['flow_id'] ?? 0 ),
 				'flow_name'     => (string) ( $flow['flow_name'] ?? '' ),

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -1207,7 +1207,7 @@ class AgentBundler {
 
 		$config['interval'] = $interval;
 		if ( ! array_key_exists( 'enabled', $config ) ) {
-			$config['enabled'] = 'manual' !== $interval;
+			$config['enabled'] = 'manual' !== $interval || 'every_cycle' === (string) ( $config['cycle_policy'] ?? '' );
 		}
 
 		return $config;

--- a/inc/Core/Flows/CycleFlowSelector.php
+++ b/inc/Core/Flows/CycleFlowSelector.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Select flows due during an external cycle.
+ *
+ * @package DataMachine\Core\Flows
+ */
+
+namespace DataMachine\Core\Flows;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Combines scheduler-due flows with explicit cycle-policy flows.
+ */
+class CycleFlowSelector {
+
+	public const POLICY_EVERY_CYCLE = 'every_cycle';
+
+	/**
+	 * Select flows that should run during this cycle.
+	 *
+	 * Scheduled interval/cron flows are passed in already filtered by the existing
+	 * jobs-table due logic. This selector adds manual flows that explicitly opt in
+	 * to every-cycle execution.
+	 *
+	 * @param array<int,array<string,mixed>> $scheduled_ready_flows Non-manual flows already due by schedule.
+	 * @param array<int,array<string,mixed>> $all_flows             All flows with decoded scheduling_config.
+	 * @return array<int,array{flow:array<string,mixed>,reason:string}> Selected flows with reasons.
+	 */
+	public static function select_due_flows( array $scheduled_ready_flows, array $all_flows ): array {
+		$selected = array();
+		$seen     = array();
+
+		foreach ( $scheduled_ready_flows as $flow ) {
+			$flow_id = (int) ( $flow['flow_id'] ?? 0 );
+			if ( $flow_id <= 0 ) {
+				continue;
+			}
+
+			$selected[]       = array(
+				'flow'   => $flow,
+				'reason' => 'schedule_due',
+			);
+			$seen[ $flow_id ] = true;
+		}
+
+		foreach ( $all_flows as $flow ) {
+			$flow_id = (int) ( $flow['flow_id'] ?? 0 );
+			if ( $flow_id <= 0 || isset( $seen[ $flow_id ] ) ) {
+				continue;
+			}
+
+			$scheduling = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
+			if ( ! self::is_every_cycle_flow( $scheduling ) ) {
+				continue;
+			}
+
+			$selected[]       = array(
+				'flow'   => $flow,
+				'reason' => 'cycle_policy:every_cycle',
+			);
+			$seen[ $flow_id ] = true;
+		}
+
+		return $selected;
+	}
+
+	/**
+	 * Check whether a flow opts in to every external cycle.
+	 *
+	 * @param array<string,mixed> $scheduling Scheduling config.
+	 * @return bool True when the flow should run every cycle.
+	 */
+	public static function is_every_cycle_flow( array $scheduling ): bool {
+		if ( false === ( $scheduling['enabled'] ?? true ) ) {
+			return false;
+		}
+
+		return 'manual' === (string) ( $scheduling['interval'] ?? 'manual' )
+			&& self::POLICY_EVERY_CYCLE === (string) ( $scheduling['cycle_policy'] ?? '' );
+	}
+}

--- a/tests/smoke-cycle-flow-selector.php
+++ b/tests/smoke-cycle-flow-selector.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Smoke tests for cycle flow selection.
+ *
+ * Usage: php tests/smoke-cycle-flow-selector.php
+ *
+ * @package DataMachine
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../inc/Core/Flows/CycleFlowSelector.php';
+
+use DataMachine\Core\Flows\CycleFlowSelector;
+
+$passed = 0;
+$failed = 0;
+
+function datamachine_cycle_assert_eq( mixed $actual, mixed $expected, string $label ): void {
+	global $passed, $failed;
+	if ( $actual === $expected ) {
+		echo '✓ ' . $label . PHP_EOL;
+		$passed++;
+		return;
+	}
+
+	echo '✗ ' . $label . PHP_EOL;
+	echo '  expected: ' . var_export( $expected, true ) . PHP_EOL;
+	echo '  actual:   ' . var_export( $actual, true ) . PHP_EOL;
+	$failed++;
+}
+
+$scheduled_ready = array(
+	array(
+		'flow_id'           => 10,
+		'flow_name'         => 'Daily Archivist',
+		'scheduling_config' => array(
+			'interval' => 'daily',
+			'enabled'  => true,
+		),
+	),
+);
+
+$all_flows = array(
+	$scheduled_ready[0],
+	array(
+		'flow_id'           => 20,
+		'flow_name'         => 'World Creator',
+		'scheduling_config' => array(
+			'interval'     => 'manual',
+			'cycle_policy' => 'every_cycle',
+			'enabled'      => true,
+		),
+	),
+	array(
+		'flow_id'           => 30,
+		'flow_name'         => 'Manual Draft',
+		'scheduling_config' => array(
+			'interval' => 'manual',
+			'enabled'  => true,
+		),
+	),
+	array(
+		'flow_id'           => 40,
+		'flow_name'         => 'Paused Cycle Flow',
+		'scheduling_config' => array(
+			'interval'     => 'manual',
+			'cycle_policy' => 'every_cycle',
+			'enabled'      => false,
+		),
+	),
+);
+
+$selected = CycleFlowSelector::select_due_flows( $scheduled_ready, $all_flows );
+
+datamachine_cycle_assert_eq( array_column( array_column( $selected, 'flow' ), 'flow_id' ), array( 10, 20 ), 'selects scheduled due plus every-cycle manual flow' );
+datamachine_cycle_assert_eq( array_column( $selected, 'reason' ), array( 'schedule_due', 'cycle_policy:every_cycle' ), 'records selection reasons' );
+datamachine_cycle_assert_eq( CycleFlowSelector::is_every_cycle_flow( $all_flows[1]['scheduling_config'] ), true, 'manual every_cycle flow is cycle due' );
+datamachine_cycle_assert_eq( CycleFlowSelector::is_every_cycle_flow( $all_flows[2]['scheduling_config'] ), false, 'plain manual flow is not cycle due' );
+datamachine_cycle_assert_eq( CycleFlowSelector::is_every_cycle_flow( $all_flows[3]['scheduling_config'] ), false, 'disabled every-cycle flow is skipped' );
+
+if ( $failed > 0 ) {
+	echo PHP_EOL . "Failed: {$failed}" . PHP_EOL;
+	exit( 1 );
+}
+
+echo PHP_EOL . "All {$passed} assertions passed." . PHP_EOL;


### PR DESCRIPTION
## Summary
- Add `wp datamachine cycle run <cycle>` / `cycles` as a generic external-cycle runner for due flows.
- Reuse existing jobs-table interval/cron readiness via `Flows::get_flows_ready_for_execution()` and add explicit `manual + cycle_policy=every_cycle` selection.
- Default imported `manual + cycle_policy=every_cycle` bundle flows to enabled while preserving normal manual-flow behavior.

## Testing
- `php -l inc/Cli/Commands/CycleCommand.php`
- `php -l inc/Core/Flows/CycleFlowSelector.php`
- `php -l inc/Core/Agents/AgentBundler.php`
- `php -l tests/smoke-cycle-flow-selector.php`
- `php tests/smoke-cycle-flow-selector.php`
- `git diff --check`

Note: `homeboy lint --changed-since origin/main` returned success but reported `No files changed since origin/main`, so targeted lint/smoke checks are the useful evidence for this branch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the cycle runner implementation and smoke coverage from Chris's requested architecture; Chris directed the design and remains responsible for review/testing.