### PR TITLE
Fix composable memory first-read injection

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -820,12 +820,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "ed6ffa82eb374dd431a54291eba6138b870d4cef"
+                "reference": "4c9c94989ca152056c96ea3030a017b3433178c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/ed6ffa82eb374dd431a54291eba6138b870d4cef",
-                "reference": "ed6ffa82eb374dd431a54291eba6138b870d4cef",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/4c9c94989ca152056c96ea3030a017b3433178c9",
+                "reference": "4c9c94989ca152056c96ea3030a017b3433178c9",
                 "shasum": ""
             },
             "require": {
@@ -879,6 +879,8 @@
                     "php tests/workflow-spec-validator-smoke.php",
                     "php tests/workflow-runner-smoke.php",
                     "php tests/agents-workflow-ability-smoke.php",
+                    "php tests/routine-smoke.php",
+                    "php tests/subagents-smoke.php",
                     "php tests/no-product-imports-smoke.php"
                 ]
             },
@@ -891,7 +893,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-09T17:26:05+00:00"
+            "time": "2026-05-09T18:04:53+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -30,6 +30,7 @@ use AgentsAPI\AI\Context\WP_Agent_Default_Context_Conflict_Resolver;
 use AgentsAPI\AI\Context\WP_Agent_Context_Item;
 use DataMachine\Core\FilesRepository\AgentMemory;
 use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Engine\AI\ComposableFileGenerator;
 use DataMachine\Engine\AI\Memory\MemoryPolicyResolver;
 use DataMachine\Engine\AI\MemoryFileRegistry;
 
@@ -83,6 +84,10 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 			$memory = new AgentMemory( $user_id, $agent_id, $filename, $layer );
 			$read   = $memory->read();
 
+			if ( ! $read->exists && self::maybe_regenerate_composable_file( $filename, $meta, $user_id, $agent_id ) ) {
+				$read = $memory->read();
+			}
+
 			if ( ! $read->exists ) {
 				continue;
 			}
@@ -109,6 +114,35 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 		}
 
 		return self::items_to_outputs( self::resolve_context_conflicts( $items, $payload ) );
+	}
+
+	/**
+	 * Regenerate a missing composable file just-in-time for prompt injection.
+	 *
+	 * Ephemeral runtimes can miss the normal invalidation hooks that write files
+	 * like SITE.md to disk. A first-read repair keeps composable context available
+	 * without regenerating existing files on every AI call.
+	 *
+	 * @param string $filename Memory filename.
+	 * @param array  $meta     Memory registry metadata.
+	 * @param int    $user_id  Effective user ID.
+	 * @param int    $agent_id Agent ID.
+	 * @return bool True when regeneration succeeded and callers should retry the read.
+	 */
+	private static function maybe_regenerate_composable_file( string $filename, array $meta, int $user_id, int $agent_id ): bool {
+		if ( empty( $meta['composable'] ) || ! class_exists( ComposableFileGenerator::class ) ) {
+			return false;
+		}
+
+		$result = ComposableFileGenerator::regenerate(
+			$filename,
+			array(
+				'user_id'  => $user_id,
+				'agent_id' => $agent_id,
+			)
+		);
+
+		return ! empty( $result['success'] );
 	}
 
 	/**

--- a/tests/core-memory-composable-first-read-smoke.php
+++ b/tests/core-memory-composable-first-read-smoke.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Pure-PHP smoke test for first-read composable memory regeneration.
+ *
+ * Run with: php tests/core-memory-composable-first-read-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace AgentsAPI\AI\Context {
+	interface WP_Agent_Context_Conflict_Resolver {
+		public function resolve( array $items, array $payload ): array;
+	}
+
+	class WP_Agent_Context_Conflict_Kind {
+		public const AUTHORITATIVE_FACT = 'authoritative_fact';
+	}
+
+	class WP_Agent_Context_Authority_Tier {
+		public const AGENT_MEMORY = 'agent_memory';
+	}
+
+	class WP_Agent_Context_Item {
+		public string $content;
+
+		public function __construct( string $content ) {
+			$this->content = $content;
+		}
+	}
+
+	class WP_Agent_Default_Context_Conflict_Resolver implements WP_Agent_Context_Conflict_Resolver {
+		public function resolve( array $items, array $payload ): array {
+			return array();
+		}
+	}
+}
+
+namespace DataMachine\Core\FilesRepository {
+	class DirectoryManager {
+		public static function ensure_agent_files(): void {}
+
+		public function get_effective_user_id( int $user_id ): int {
+			return $user_id;
+		}
+	}
+
+	class AgentMemory {
+		public const MAX_FILE_SIZE = 8192;
+
+		private string $filename;
+
+		public function __construct( int $user_id = 0, int $agent_id = 0, string $filename = 'MEMORY.md', ?string $layer = null ) {
+			$this->filename = $filename;
+		}
+
+		public function read(): object {
+			$content = $GLOBALS['__core_memory_composable_files'][ $this->filename ] ?? null;
+
+			return (object) array(
+				'exists'  => null !== $content,
+				'content' => (string) $content,
+				'bytes'   => strlen( (string) $content ),
+			);
+		}
+	}
+}
+
+namespace DataMachine\Abilities\File {
+	class ScaffoldAbilities {
+		public static function get_ability() {
+			return null;
+		}
+	}
+}
+
+namespace DataMachine\Engine\AI\Memory {
+	class MemoryPolicyResolver {
+		public function resolveRegistered( array $context ): array {
+			return $GLOBALS['__core_memory_composable_registry'];
+		}
+	}
+}
+
+namespace DataMachine\Engine\AI {
+	class MemoryFileRegistry {
+		public const LAYER_AGENT = 'agent';
+
+		public static function get( string $filename ): ?array {
+			return $GLOBALS['__core_memory_composable_registry'][ $filename ] ?? null;
+		}
+	}
+
+	class ComposableFileGenerator {
+		public static function regenerate( string $filename, array $context = array() ): array {
+			$GLOBALS['__core_memory_composable_regenerated'][] = array(
+				'filename' => $filename,
+				'context'  => $context,
+			);
+			$GLOBALS['__core_memory_composable_files'][ $filename ] = '# Site Context\n\nGenerated on first read.';
+
+			return array( 'success' => true );
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! function_exists( 'add_filter' ) ) {
+		function add_filter( string $_hook, callable $_callback, int $_priority = 10, int $_accepted_args = 1 ): void {}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $_hook, $value ) {
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( string $_hook, ...$_args ): void {}
+	}
+
+	require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectiveInterface.php';
+	require_once __DIR__ . '/../inc/Engine/AI/Directives/CoreMemoryFilesDirective.php';
+
+	$failures   = 0;
+	$assertions = 0;
+
+	function core_memory_composable_assert( bool $condition, string $message ): void {
+		global $failures, $assertions;
+		++$assertions;
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		echo "  [FAIL] {$message}\n";
+		++$failures;
+	}
+
+	$GLOBALS['__core_memory_composable_files']       = array();
+	$GLOBALS['__core_memory_composable_regenerated'] = array();
+	$GLOBALS['__core_memory_composable_registry']    = array(
+		'SITE.md' => array(
+			'layer'      => 'shared',
+			'priority'   => 10,
+			'composable' => true,
+		),
+	);
+
+	$outputs = \DataMachine\Engine\AI\Directives\CoreMemoryFilesDirective::get_outputs(
+		'openai',
+		array(),
+		null,
+		array(
+			'agent_mode' => 'pipeline',
+			'user_id'    => 123,
+			'agent_id'   => 456,
+		)
+	);
+
+	core_memory_composable_assert( 1 === count( $outputs ), 'missing composable file is injected after first-read regeneration' );
+	core_memory_composable_assert( false !== strpos( $outputs[0]['content'] ?? '', 'Generated on first read.' ), 'injected content comes from regenerated file' );
+	core_memory_composable_assert( 1 === count( $GLOBALS['__core_memory_composable_regenerated'] ), 'composable file is regenerated once' );
+	core_memory_composable_assert(
+		array( 'user_id' => 123, 'agent_id' => 456 ) === $GLOBALS['__core_memory_composable_regenerated'][0]['context'],
+		'regeneration receives prompt scope'
+	);
+
+	echo "\n{$assertions} assertions, {$failures} failures\n";
+	if ( $failures > 0 ) {
+		exit( 1 );
+	}
+}


### PR DESCRIPTION
## Summary
- Regenerate missing composable memory files on first prompt read so `SITE.md` and similar generated context are injected in ephemeral runtimes.
- Add a pure-PHP smoke test covering first-read regeneration and prompt-scope propagation.
- Refresh the Agents API lock entry so changed-file PHPStan uses the context-item constructor already expected by Data Machine.

## Testing
- `php -l inc/Engine/AI/Directives/CoreMemoryFilesDirective.php`
- `php -l tests/core-memory-composable-first-read-smoke.php`
- `php tests/core-memory-composable-first-read-smoke.php`
- `homeboy lint --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the missing composable memory context path, drafting the code/test changes, and running validation. Chris remains responsible for review and merge.