### PR TITLE
fix: apply ai request timeouts during model discovery

### DIFF
--- a/inc/Engine/AI/DefaultOptionsHttpTransporter.php
+++ b/inc/Engine/AI/DefaultOptionsHttpTransporter.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * wp-ai-client transporter wrapper with default request options.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+if ( interface_exists( '\WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface' ) && ! class_exists( __NAMESPACE__ . '\DefaultOptionsHttpTransporter', false ) ) {
+	/**
+	 * Applies default RequestOptions when wp-ai-client sends a request without them.
+	 */
+	class DefaultOptionsHttpTransporter implements \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface {
+
+		/**
+		 * @param \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface $inner           Wrapped transporter.
+		 * @param mixed                                                                 $default_options Default RequestOptions instance.
+		 */
+		public function __construct(
+			private \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface $inner,
+			private $default_options
+		) {}
+
+		/**
+		 * Replace the default request options used by this wrapper.
+		 *
+		 * @param mixed $default_options wp-ai-client RequestOptions instance.
+		 * @return void
+		 */
+		public function setDefaultOptions( $default_options ): void {
+			$this->default_options = $default_options;
+		}
+
+		/**
+		 * Send the request, supplying Data Machine's defaults when none are provided.
+		 *
+		 * @param \WordPress\AiClient\Providers\Http\DTO\Request        $request Request object.
+		 * @param \WordPress\AiClient\Providers\Http\DTO\RequestOptions|null $options Explicit RequestOptions.
+		 * @return \WordPress\AiClient\Providers\Http\DTO\Response
+		 */
+		public function send( \WordPress\AiClient\Providers\Http\DTO\Request $request, ?\WordPress\AiClient\Providers\Http\DTO\RequestOptions $options = null ): \WordPress\AiClient\Providers\Http\DTO\Response {
+			return $this->inner->send( $request, $options ?? $this->default_options );
+		}
+	}
+}

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -18,6 +18,7 @@ use DataMachine\Engine\AI\Directives\DirectivePolicyResolver;
 defined( 'ABSPATH' ) || exit;
 
 require_once __DIR__ . '/WpAiClientCache.php';
+require_once __DIR__ . '/DefaultOptionsHttpTransporter.php';
 
 class RequestBuilder {
 
@@ -144,10 +145,17 @@ class RequestBuilder {
 		$request_timeout               = (float) $transport_profile['request_timeout'];
 		$connect_timeout               = (float) $transport_profile['connect_timeout'];
 		$request_metadata['transport'] = $transport_profile;
-		$timeout_filter                = static function ( $default_timeout ) use ( $request_timeout ) {
+		if ( class_exists( '\WordPress\AiClient\Providers\Http\DTO\RequestOptions' ) ) {
+			$request_options = new \WordPress\AiClient\Providers\Http\DTO\RequestOptions();
+			$request_options->setTimeout( $request_timeout );
+			$request_options->setConnectTimeout( $connect_timeout );
+			$transport_profile['request_options_used'] = true;
+			$request_metadata['transport']             = $transport_profile;
+		}
+		$timeout_filter = static function ( $default_timeout ) use ( $request_timeout ) {
 			return max( (float) $default_timeout, $request_timeout );
 		};
-		$curl_filter                   = static function ( $handle ) use ( $request_timeout, $connect_timeout ) {
+		$curl_filter    = static function ( $handle ) use ( $request_timeout, $connect_timeout ) {
 			if ( defined( 'CURLOPT_CONNECTTIMEOUT' ) ) {
 				curl_setopt( $handle, CURLOPT_CONNECTTIMEOUT, (int) ceil( $connect_timeout ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_setopt -- WordPress exposes the cURL handle only through this hook.
 			}
@@ -185,18 +193,13 @@ class RequestBuilder {
 				);
 			}
 
+			self::installDefaultRequestOptionsTransporter( $registry, $request_options );
+
 			/** @var callable $model_resolver wp-ai-client exposes this through __call() in some versions. */
 			$model_resolver = array( $registry, 'getProviderModel' );
 			$model_instance = call_user_func( $model_resolver, $provider_id, $model, null );
-			if ( class_exists( '\WordPress\AiClient\Providers\Http\DTO\RequestOptions' ) ) {
-				$request_options = new \WordPress\AiClient\Providers\Http\DTO\RequestOptions();
-				$request_options->setTimeout( $request_timeout );
-				$request_options->setConnectTimeout( $connect_timeout );
-				$transport_profile['request_options_used'] = true;
-				$request_metadata['transport']             = $transport_profile;
-				if ( is_object( $model_instance ) && method_exists( $model_instance, 'setRequestOptions' ) ) {
-					$model_instance->setRequestOptions( $request_options );
-				}
+			if ( null !== $request_options && is_object( $model_instance ) && method_exists( $model_instance, 'setRequestOptions' ) ) {
+				$model_instance->setRequestOptions( $request_options );
 			}
 
 			do_action(
@@ -514,6 +517,49 @@ class RequestBuilder {
 			'request_options_used'            => false,
 			'curl_hook_installed'             => false,
 		);
+	}
+
+	/**
+	 * Install a transporter that applies request options to provider metadata calls.
+	 *
+	 * wp-ai-client resolves API-backed models by listing provider models before a
+	 * model instance exists, so model-level RequestOptions are too late for that
+	 * discovery request. Wrap the registry transporter so model discovery and the
+	 * final generation request share Data Machine's timeout profile.
+	 *
+	 * @param object $registry        wp-ai-client provider registry.
+	 * @param mixed  $request_options wp-ai-client RequestOptions instance.
+	 * @return void
+	 */
+	private static function installDefaultRequestOptionsTransporter( object $registry, $request_options ): void {
+		if ( null === $request_options || ! method_exists( $registry, 'getHttpTransporter' ) || ! method_exists( $registry, 'setHttpTransporter' ) ) {
+			return;
+		}
+
+		if ( ! interface_exists( '\WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface' ) || ! class_exists( '\DataMachine\Engine\AI\DefaultOptionsHttpTransporter' ) ) {
+			return;
+		}
+
+		try {
+			$current = $registry->getHttpTransporter();
+		} catch ( \Throwable $e ) {
+			if ( ! class_exists( '\WordPress\AiClient\Providers\Http\HttpTransporterFactory' ) ) {
+				return;
+			}
+
+			try {
+				$current = \WordPress\AiClient\Providers\Http\HttpTransporterFactory::createTransporter();
+			} catch ( \Throwable $inner ) {
+				return;
+			}
+		}
+
+		if ( $current instanceof DefaultOptionsHttpTransporter ) {
+			$current->setDefaultOptions( $request_options );
+			return;
+		}
+
+		$registry->setHttpTransporter( new DefaultOptionsHttpTransporter( $current, $request_options ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Applies configured wp-ai-client timeout options before provider model discovery, not only after the model object is resolved.
- Wraps the HTTP transporter with default request options so OpenAI model-list requests can use the same timeout settings as prompt requests.
- Adds smoke coverage for transporter default options and model discovery timeout plumbing.

## Testing
- `php -l inc/Engine/AI/RequestBuilder.php`
- `php -l inc/Engine/AI/DefaultOptionsHttpTransporter.php`
- `php tests/wp-ai-client-request-timeout-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-wp-ai-client-model-timeout --extension wordpress --changed-only --force-hot`
- `homeboy build --path /Users/chubes/Developer/data-machine@fix-wp-ai-client-model-timeout data-machine --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the live wp-ai-client timeout path, drafting the transporter/request-builder fix, adding smoke coverage, and running local verification. Chris remains responsible for review and merge.