### PR TITLE
fix(publish-handlers): canonical JSON Schema for wordpress_publish and email_publish

### DIFF
--- a/inc/Core/Steps/Publish/Handlers/Email/Email.php
+++ b/inc/Core/Steps/Publish/Handlers/Email/Email.php
@@ -44,27 +44,27 @@ class Email extends PublishHandler {
 						'handler'        => 'email_publish',
 						'description'    => 'Send an email. Compose the subject and body (HTML). Optionally override recipients and attach files by providing server file paths.',
 						'parameters'     => array(
-							'to'          => array(
-								'type'        => 'string',
-								'required'    => false,
-								'description' => 'Comma-separated recipient emails. Leave empty to use the default recipients from handler settings.',
+							'type'       => 'object',
+							'properties' => array(
+								'to'          => array(
+									'type'        => 'string',
+									'description' => 'Comma-separated recipient emails. Leave empty to use the default recipients from handler settings.',
+								),
+								'subject'     => array(
+									'type'        => 'string',
+									'description' => 'Email subject. Supports {month}, {year}, {site_name} placeholders.',
+								),
+								'body'        => array(
+									'type'        => 'string',
+									'description' => 'Email body content in HTML format.',
+								),
+								'attachments' => array(
+									'type'        => 'array',
+									'items'       => array( 'type' => 'string' ),
+									'description' => 'Array of server file paths to attach to the email.',
+								),
 							),
-							'subject'     => array(
-								'type'        => 'string',
-								'required'    => true,
-								'description' => 'Email subject. Supports {month}, {year}, {site_name} placeholders.',
-							),
-							'body'        => array(
-								'type'        => 'string',
-								'required'    => true,
-								'description' => 'Email body content in HTML format.',
-							),
-							'attachments' => array(
-								'type'        => 'array',
-								'items'       => array( 'type' => 'string' ),
-								'required'    => false,
-								'description' => 'Array of server file paths to attach to the email.',
-							),
+							'required'   => array( 'subject', 'body' ),
 						),
 						'handler_config' => $handler_config,
 					);

--- a/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php
+++ b/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php
@@ -43,39 +43,45 @@ class WordPress extends PublishHandler {
 			WordPressSettings::class,
 			function ( $tools, $handler_slug, $handler_config ) {
 				if ( 'wordpress_publish' === $handler_slug ) {
-					// Base parameters (always present)
-					$base_parameters = array(
+					// Base parameters (canonical JSON Schema fragment: bare properties + top-level required[]).
+					$base_properties = array(
 						'title'          => array(
 							'type'        => 'string',
-							'required'    => true,
 							'description' => 'The title of the WordPress post or page',
 						),
 						'content'        => array(
 							'type'        => 'string',
-							'required'    => true,
 							'description' => 'The main content of the post in the requested content_format. Markdown is preferred for AI-authored prose unless the workflow asks for HTML or blocks. Do not include source URL attribution or images - these are handled automatically by the system.',
 						),
 						'content_format' => array(
 							'type'        => 'string',
-							'required'    => false,
 							'enum'        => array( 'html', 'markdown', 'blocks' ),
 							'default'     => 'html',
 							'description' => 'Format of the supplied content before Data Machine converts it to the post type storage format.',
 						),
 					);
+					$base_required   = array( 'title', 'content' );
 
-					// Dynamic taxonomy parameters based on "AI Decides" selections
+					// Dynamic taxonomy parameters based on "AI Decides" selections.
+					// TaxonomyHandler::getTaxonomyToolParameters() already returns canonical-shape
+					// bare properties (no per-property required flags, items present on arrays),
+					// so it is safe to merge into properties as-is.
 					$taxonomy_parameters = TaxonomyHandler::getTaxonomyToolParameters( $handler_config );
 
-					// Merge base + dynamic parameters
-					$all_parameters = array_merge( $base_parameters, $taxonomy_parameters );
+					$tool_parameters = array(
+						'type'       => 'object',
+						'properties' => array_merge( $base_properties, $taxonomy_parameters ),
+					);
+					if ( ! empty( $base_required ) ) {
+						$tool_parameters['required'] = $base_required;
+					}
 
 					$tools['wordpress_publish'] = array(
 						'class'          => self::class,
 						'method'         => 'handle_tool_call',
 						'handler'        => 'wordpress_publish',
 						'description'    => 'Create WordPress posts and pages with automatic taxonomy assignment, featured image processing, and source URL attribution.',
-						'parameters'     => $all_parameters,
+						'parameters'     => $tool_parameters,
 						'handler_config' => $handler_config,
 					);
 				}


### PR DESCRIPTION
Closes part of #1921.

## Summary

PR #1900 removed `RequestBuilder::normalizeToolParameters` auto-normalization, so handler-stage tools registered via the `dm_handlers` filter now ship their `parameters` block to OpenAI as the literal schema. Both publish handlers in scope here emitted the legacy property-keyed shape with per-property `required: true|false` flags — that shape fails OpenAI strict validation post-0.106.1.

This converts both to canonical JSON Schema:

```
{ type: object, properties: {...}, required: [...] }
```

## Files changed (2)

- `inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php` — `wordpress_publish` tool
- `inc/Core/Steps/Publish/Handlers/Email/Email.php` — `email_send` tool

## TaxonomyHandler verified safe-as-is — intentionally not touched

`TaxonomyHandler::getTaxonomyToolParameters()` (in `inc/Core/WordPress/TaxonomyHandler.php`) already returns shape-compatible bare properties:
- no per-property `required` flags
- `items: { type: string }` already present on non-hierarchical (array-typed) taxonomy parameters
- `description`, `type` preserved

The WordPress handler's registration site now wraps `array_merge( $base_properties, $taxonomy_parameters )` in the canonical envelope and hoists base required keys to top-level `required[]`. **TaxonomyHandler itself is intentionally not modified** — it would be a strictly larger change, no functional improvement, and PR #1921 explicitly scopes it out.

## Conversion rules applied (mirrors extra-chill/data-machine-events#232 / #235)

1. Wrap properties under `{ type: 'object', properties: array(...), required: array(...) }`.
2. Move every `required => true` property name into top-level `required[]`.
3. Drop `required => false` (no-op).
4. Omit `required` if empty (in practice both files have required keys, so always present).
5. Every `type: array` property declares `items` (Email's `attachments` already had `items: { type: string }`; preserved).
6. Preserve `description`, `enum`, `default`.

### WordPress.php specifics
- `title` → required
- `content` → required
- `content_format` → optional, retains `enum` and `default: html`
- Taxonomy parameters merged as-is from `TaxonomyHandler::getTaxonomyToolParameters()`

### Email.php specifics
- `subject` → required
- `body` → required
- `to` → optional (handler resolves from config defaults)
- `attachments` → optional, `type: array` with `items: { type: string }`

## Backwards compatibility

Canonical schemas are accepted by both DM 0.103.x (passthrough through the still-present normalizer in older versions) and DM 0.106.1+ (literal passthrough). Safe to merge ahead of any deploy. No behavioral change — runtime tool execution still reads parameter values out of the LLM-provided arguments map; only the shape of the schema sent to the provider changes.

## Test plan

- `php -l` clean on both files.
- `homeboy lint --path . --changed-since main` — passed with no findings.
- Searched `tests/` for `wordpress_publish`, `email_publish`, `email_send`: all matches reference handler **slugs** (registry/policy/factory tests), none pin the `parameters` schema shape. No test updates needed in this PR.
- Existing chat-tool / handler-tool precedents (extra-chill/data-machine-events#232, #235) merged with the same conversion pattern and ran cleanly in production.

## Out of scope

Per #1921, the other two scopes (chat tools in `inc/Api/Chat/Tools/` ~30 files, and global AI tools in `inc/Engine/AI/Tools/Global/` ~7 files) are tracked as separate parallel PRs. This PR is **only** the 2 handler files.

## References

- Closes part of #1921
- DM PR #1900 (the change that removed the normalizer)
- extra-chill/data-machine-events#232 (chat tools precedent — merged)
- extra-chill/data-machine-events#235 (handler-tool merge precedent — merged)

cc <@532385681268408341>