### PR TITLE
fix(chat-tools): canonical JSON Schema across inc/Api/Chat/Tools/

### DIFF
--- a/inc/Api/Chat/Tools/AddPipelineStep.php
+++ b/inc/Api/Chat/Tools/AddPipelineStep.php
@@ -43,16 +43,18 @@ class AddPipelineStep extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Add a step to a pipeline. Automatically syncs to all flows on that pipeline.',
 			'parameters'  => array(
-				'pipeline_id' => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Pipeline ID to add the step to',
+				'type'       => 'object',
+				'properties' => array(
+					'pipeline_id' => array(
+						'type'        => 'integer',
+						'description' => 'Pipeline ID to add the step to',
+					),
+					'step_type'   => array(
+						'type'        => 'string',
+						'description' => "Type of step: {$types_list}",
+					),
 				),
-				'step_type'   => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => "Type of step: {$types_list}",
-				),
+				'required'   => array( 'pipeline_id', 'step_type' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/ApiQuery.php
+++ b/inc/Api/Chat/Tools/ApiQuery.php
@@ -39,15 +39,17 @@ class ApiQuery extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => $this->buildApiDocumentation(),
 			'parameters'  => array(
-				'endpoint' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Single mode: REST API endpoint path (e.g., /datamachine/v1/handlers)',
-				),
-				'requests' => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Batch mode: Array of {endpoint, key?}. Results keyed by endpoint or custom key.',
+				'type'       => 'object',
+				'properties' => array(
+					'endpoint' => array(
+						'type'        => 'string',
+						'description' => 'Single mode: REST API endpoint path (e.g., /datamachine/v1/handlers)',
+					),
+					'requests' => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'object' ),
+						'description' => 'Batch mode: Array of {endpoint, key?}. Results keyed by endpoint or custom key.',
+					),
 				),
 			),
 		);

--- a/inc/Api/Chat/Tools/AssignTaxonomyTerm.php
+++ b/inc/Api/Chat/Tools/AssignTaxonomyTerm.php
@@ -30,26 +30,27 @@ class AssignTaxonomyTerm extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Assign a taxonomy term to one or more posts. Can append to existing terms or replace them.',
 			'parameters'  => array(
-				'term'     => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Term to assign - ID, name, or slug',
+				'type'       => 'object',
+				'properties' => array(
+					'term'     => array(
+						'type'        => 'string',
+						'description' => 'Term to assign - ID, name, or slug',
+					),
+					'taxonomy' => array(
+						'type'        => 'string',
+						'description' => 'Taxonomy slug (venue, artist, category, post_tag, etc.)',
+					),
+					'post_ids' => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'integer' ),
+						'description' => 'Array of post IDs to assign the term to',
+					),
+					'append'   => array(
+						'type'        => 'boolean',
+						'description' => 'true = add to existing terms, false = replace existing terms (default: true)',
+					),
 				),
-				'taxonomy' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Taxonomy slug (venue, artist, category, post_tag, etc.)',
-				),
-				'post_ids' => array(
-					'type'        => 'array',
-					'required'    => true,
-					'description' => 'Array of post IDs to assign the term to',
-				),
-				'append'   => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'true = add to existing terms, false = replace existing terms (default: true)',
-				),
+				'required'   => array( 'term', 'taxonomy', 'post_ids' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/AuthenticateHandler.php
+++ b/inc/Api/Chat/Tools/AuthenticateHandler.php
@@ -38,22 +38,23 @@ class AuthenticateHandler extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => $this->buildDescription(),
 			'parameters'  => array(
-				'action'       => array(
-					'type'        => 'string',
-					'required'    => true,
-					'enum'        => array( 'list', 'status', 'configure', 'get_oauth_url', 'disconnect' ),
-					'description' => 'Action to perform: list (all statuses), status (specific handler), configure (save credentials), get_oauth_url (for OAuth), disconnect (clear auth)',
+				'type'       => 'object',
+				'properties' => array(
+					'action'       => array(
+						'type'        => 'string',
+						'enum'        => array( 'list', 'status', 'configure', 'get_oauth_url', 'disconnect' ),
+						'description' => 'Action to perform: list (all statuses), status (specific handler), configure (save credentials), get_oauth_url (for OAuth), disconnect (clear auth)',
+					),
+					'handler_slug' => array(
+						'type'        => 'string',
+						'description' => 'Handler identifier (required for all actions except list)',
+					),
+					'credentials'  => array(
+						'type'        => 'object',
+						'description' => 'Credentials object for configure action. For OAuth: {client_id, client_secret}. For simple auth: handler-specific fields.',
+					),
 				),
-				'handler_slug' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Handler identifier (required for all actions except list)',
-				),
-				'credentials'  => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Credentials object for configure action. For OAuth: {client_id, client_secret}. For simple auth: handler-specific fields.',
-				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/ConfigureFlowSteps.php
+++ b/inc/Api/Chat/Tools/ConfigureFlowSteps.php
@@ -56,75 +56,67 @@ class ConfigureFlowSteps extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => $description,
 			'parameters'  => array(
-				'flow_step_id'        => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Single flow step ID (format: {pipeline_step_id}_{flow_id})',
-				),
-				'flow_step_ids'       => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Array of flow step IDs for batch updates on specific steps',
-				),
-				'pipeline_id'         => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Pipeline scope. REQUIRES either handler_slug (filter) or all_flows=true',
-				),
-				'all_flows'           => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'When true with pipeline_id, applies to ALL flows in pipeline. Explicit opt-in required for bulk operations.',
-				),
-				'step_type'           => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Filter by step type (fetch, publish, upsert, ai)',
-				),
-				'handler_slug'        => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Handler slug to set (single mode) OR filter by existing handler (bulk mode). Works with or without pipeline_id scope.',
-				),
-				'target_handler_slug' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Handler to switch TO. When provided, handler_slug filters existing handlers (bulk) and target_handler_slug sets the new handler.',
-				),
-				'field_map'           => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Field mappings when switching handlers, e.g. {"endpoint_url": "source_url"}. Fields with matching names auto-map by default.',
-				),
-				'handler_config'      => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Handler-specific configuration to merge into existing config',
-				),
-				'flow_configs'        => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Per-flow configurations for bulk mode. Array of {flow_id: int, handler_config: object}. Merged with shared handler_config (per-flow takes precedence).',
-				),
-				'user_message'        => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'User message/prompt for AI steps',
-				),
-				'updates'             => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Cross-pipeline mode: configure multiple flows with different settings. Each item: {flow_id, step_configs (keyed by step_type: {handler_slug?, handler_config?, user_message?})}',
-				),
-				'shared_config'       => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Shared step config for cross-pipeline mode (keyed by step_type). Per-flow step_configs override these.',
-				),
-				'validate_only'       => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Dry-run mode: validate configuration without executing. Returns what would be updated.',
+				'type'       => 'object',
+				'properties' => array(
+					'flow_step_id'        => array(
+						'type'        => 'string',
+						'description' => 'Single flow step ID (format: {pipeline_step_id}_{flow_id})',
+					),
+					'flow_step_ids'       => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'Array of flow step IDs for batch updates on specific steps',
+					),
+					'pipeline_id'         => array(
+						'type'        => 'integer',
+						'description' => 'Pipeline scope. REQUIRES either handler_slug (filter) or all_flows=true',
+					),
+					'all_flows'           => array(
+						'type'        => 'boolean',
+						'description' => 'When true with pipeline_id, applies to ALL flows in pipeline. Explicit opt-in required for bulk operations.',
+					),
+					'step_type'           => array(
+						'type'        => 'string',
+						'description' => 'Filter by step type (fetch, publish, upsert, ai)',
+					),
+					'handler_slug'        => array(
+						'type'        => 'string',
+						'description' => 'Handler slug to set (single mode) OR filter by existing handler (bulk mode). Works with or without pipeline_id scope.',
+					),
+					'target_handler_slug' => array(
+						'type'        => 'string',
+						'description' => 'Handler to switch TO. When provided, handler_slug filters existing handlers (bulk) and target_handler_slug sets the new handler.',
+					),
+					'field_map'           => array(
+						'type'        => 'object',
+						'description' => 'Field mappings when switching handlers, e.g. {"endpoint_url": "source_url"}. Fields with matching names auto-map by default.',
+					),
+					'handler_config'      => array(
+						'type'        => 'object',
+						'description' => 'Handler-specific configuration to merge into existing config',
+					),
+					'flow_configs'        => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'object' ),
+						'description' => 'Per-flow configurations for bulk mode. Array of {flow_id: int, handler_config: object}. Merged with shared handler_config (per-flow takes precedence).',
+					),
+					'user_message'        => array(
+						'type'        => 'string',
+						'description' => 'User message/prompt for AI steps',
+					),
+					'updates'             => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'object' ),
+						'description' => 'Cross-pipeline mode: configure multiple flows with different settings. Each item: {flow_id, step_configs (keyed by step_type: {handler_slug?, handler_config?, user_message?})}',
+					),
+					'shared_config'       => array(
+						'type'        => 'object',
+						'description' => 'Shared step config for cross-pipeline mode (keyed by step_type). Per-flow step_configs override these.',
+					),
+					'validate_only'       => array(
+						'type'        => 'boolean',
+						'description' => 'Dry-run mode: validate configuration without executing. Returns what would be updated.',
+					),
 				),
 			),
 		);

--- a/inc/Api/Chat/Tools/ConfigurePipelineStep.php
+++ b/inc/Api/Chat/Tools/ConfigurePipelineStep.php
@@ -35,26 +35,28 @@ class ConfigurePipelineStep extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Configure pipeline-level AI step settings: system prompt and tool policy. Model/provider are managed via the mode_models site setting, not per-pipeline. For flow-level settings (handler, handler_config, user_message), use configure_flow_steps instead.',
 			'parameters'  => array(
-				'pipeline_step_id' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Pipeline step ID to configure (e.g., "123_uuid4")',
+				'type'       => 'object',
+				'properties' => array(
+					'pipeline_step_id' => array(
+						'type'        => 'string',
+						'description' => 'Pipeline step ID to configure (e.g., "123_uuid4")',
+					),
+					'system_prompt'    => array(
+						'type'        => 'string',
+						'description' => 'System prompt for the AI step - defines the AI persona and instructions',
+					),
+					'disabled_tools'   => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'Array of tool slugs to disable for this AI step',
+					),
+					'tool_categories'  => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'Array of ability categories allowed for this AI step',
+					),
 				),
-				'system_prompt'    => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'System prompt for the AI step - defines the AI persona and instructions',
-				),
-				'disabled_tools'   => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Array of tool slugs to disable for this AI step',
-				),
-				'tool_categories'  => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Array of ability categories allowed for this AI step',
-				),
+				'required'   => array( 'pipeline_step_id' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/CopyFlow.php
+++ b/inc/Api/Chat/Tools/CopyFlow.php
@@ -36,31 +36,30 @@ class CopyFlow extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Copy a flow to the same or different pipeline. Cross-pipeline requires compatible step structures. Copies handlers, messages, and schedule.',
 			'parameters'  => array(
-				'source_flow_id'        => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Flow ID to copy',
+				'type'       => 'object',
+				'properties' => array(
+					'source_flow_id'        => array(
+						'type'        => 'integer',
+						'description' => 'Flow ID to copy',
+					),
+					'target_pipeline_id'    => array(
+						'type'        => 'integer',
+						'description' => 'Destination pipeline ID',
+					),
+					'flow_name'             => array(
+						'type'        => 'string',
+						'description' => 'New flow name',
+					),
+					'scheduling_config'     => array(
+						'type'        => 'object',
+						'description' => 'Override schedule (defaults to source). Format: {interval: value}. Valid intervals:' . "\n" . SchedulingDocumentation::getIntervalsJson(),
+					),
+					'step_config_overrides' => array(
+						'type'        => 'object',
+						'description' => 'Override steps by step_type or execution_order: {handler_slug?, handler_config?, user_message?}',
+					),
 				),
-				'target_pipeline_id'    => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Destination pipeline ID',
-				),
-				'flow_name'             => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'New flow name',
-				),
-				'scheduling_config'     => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Override schedule (defaults to source). Format: {interval: value}. Valid intervals:' . "\n" . SchedulingDocumentation::getIntervalsJson(),
-				),
-				'step_config_overrides' => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Override steps by step_type or execution_order: {handler_slug?, handler_config?, user_message?}',
-				),
+				'required'   => array( 'source_flow_id', 'target_pipeline_id', 'flow_name' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/CreateFlow.php
+++ b/inc/Api/Chat/Tools/CreateFlow.php
@@ -36,40 +36,37 @@ class CreateFlow extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Create a new flow for a pipeline with optional step configurations. Query existing flows first to learn established patterns. Supports bulk mode via flows array.',
 			'parameters'  => array(
-				'pipeline_id'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Pipeline ID (single mode - required unless using bulk mode)',
-				),
-				'flow_name'          => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Flow name (defaults to "Flow")',
-				),
-				'scheduling_config'  => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Schedule: {interval: value}. Valid intervals:' . "\n" . SchedulingDocumentation::getIntervalsJson(),
-				),
-				'step_configs'       => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Step configurations keyed by step_type: {handler_slug?, handler_config?, user_message?}',
-				),
-				'flows'              => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Bulk mode: create multiple flows. Each item: {pipeline_id, flow_name, step_configs?, scheduling_config?}. Uses shared_step_config as base.',
-				),
-				'shared_step_config' => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Shared step config for bulk mode (keyed by step_type). Per-flow step_configs override these.',
-				),
-				'validate_only'      => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Dry-run mode: validate configuration without creating. Returns what would be created.',
+				'type'       => 'object',
+				'properties' => array(
+					'pipeline_id'        => array(
+						'type'        => 'integer',
+						'description' => 'Pipeline ID (single mode - required unless using bulk mode)',
+					),
+					'flow_name'          => array(
+						'type'        => 'string',
+						'description' => 'Flow name (defaults to "Flow")',
+					),
+					'scheduling_config'  => array(
+						'type'        => 'object',
+						'description' => 'Schedule: {interval: value}. Valid intervals:' . "\n" . SchedulingDocumentation::getIntervalsJson(),
+					),
+					'step_configs'       => array(
+						'type'        => 'object',
+						'description' => 'Step configurations keyed by step_type: {handler_slug?, handler_config?, user_message?}',
+					),
+					'flows'              => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'object' ),
+						'description' => 'Bulk mode: create multiple flows. Each item: {pipeline_id, flow_name, step_configs?, scheduling_config?}. Uses shared_step_config as base.',
+					),
+					'shared_step_config' => array(
+						'type'        => 'object',
+						'description' => 'Shared step config for bulk mode (keyed by step_type). Per-flow step_configs override these.',
+					),
+					'validate_only'      => array(
+						'type'        => 'boolean',
+						'description' => 'Dry-run mode: validate configuration without creating. Returns what would be created.',
+					),
 				),
 			),
 		);

--- a/inc/Api/Chat/Tools/CreatePipeline.php
+++ b/inc/Api/Chat/Tools/CreatePipeline.php
@@ -43,40 +43,38 @@ class CreatePipeline extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Create a pipeline with optional steps. Automatically creates a flow - do NOT call create_flow afterward. Supports bulk mode via pipelines array.',
 			'parameters'  => array(
-				'pipeline_name'     => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Pipeline name (single mode - required unless using bulk mode)',
-				),
-				'steps'             => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => "Steps in execution order: {step_type: \"{$types_list}\", handler_slug, handler_config}. AI steps: add provider, model, system_prompt.",
-				),
-				'flow_name'         => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Flow name (defaults to pipeline_name)',
-				),
-				'scheduling_config' => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Schedule: {interval: value}. Valid intervals:' . "\n" . SchedulingDocumentation::getIntervalsJson(),
-				),
-				'pipelines'         => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Bulk mode: create multiple pipelines. Each item: {name, steps?, flow_name?, scheduling_config?}. Uses template for shared config.',
-				),
-				'template'          => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Shared config for bulk mode: {steps, scheduling_config}. Individual pipeline configs override template.',
-				),
-				'validate_only'     => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Dry-run mode: validate configuration without creating. Returns what would be created.',
+				'type'       => 'object',
+				'properties' => array(
+					'pipeline_name'     => array(
+						'type'        => 'string',
+						'description' => 'Pipeline name (single mode - required unless using bulk mode)',
+					),
+					'steps'             => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'object' ),
+						'description' => "Steps in execution order: {step_type: \"{$types_list}\", handler_slug, handler_config}. AI steps: add provider, model, system_prompt.",
+					),
+					'flow_name'         => array(
+						'type'        => 'string',
+						'description' => 'Flow name (defaults to pipeline_name)',
+					),
+					'scheduling_config' => array(
+						'type'        => 'object',
+						'description' => 'Schedule: {interval: value}. Valid intervals:' . "\n" . SchedulingDocumentation::getIntervalsJson(),
+					),
+					'pipelines'         => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'object' ),
+						'description' => 'Bulk mode: create multiple pipelines. Each item: {name, steps?, flow_name?, scheduling_config?}. Uses template for shared config.',
+					),
+					'template'          => array(
+						'type'        => 'object',
+						'description' => 'Shared config for bulk mode: {steps, scheduling_config}. Individual pipeline configs override template.',
+					),
+					'validate_only'     => array(
+						'type'        => 'boolean',
+						'description' => 'Dry-run mode: validate configuration without creating. Returns what would be created.',
+					),
 				),
 			),
 		);

--- a/inc/Api/Chat/Tools/CreateTaxonomyTerm.php
+++ b/inc/Api/Chat/Tools/CreateTaxonomyTerm.php
@@ -30,26 +30,26 @@ class CreateTaxonomyTerm extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Create a taxonomy term if it does not exist. Use when configuring flows that need categories, tags, or custom taxonomy terms that are not yet on the site.',
 			'parameters'  => array(
-				'taxonomy'    => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Taxonomy slug (category, post_tag, or custom taxonomy slug)',
+				'type'       => 'object',
+				'properties' => array(
+					'taxonomy'    => array(
+						'type'        => 'string',
+						'description' => 'Taxonomy slug (category, post_tag, or custom taxonomy slug)',
+					),
+					'name'        => array(
+						'type'        => 'string',
+						'description' => 'Term name to create',
+					),
+					'parent'      => array(
+						'type'        => 'string',
+						'description' => 'Parent term name, slug, or ID (hierarchical taxonomies only)',
+					),
+					'description' => array(
+						'type'        => 'string',
+						'description' => 'Term description',
+					),
 				),
-				'name'        => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Term name to create',
-				),
-				'parent'      => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Parent term name, slug, or ID (hierarchical taxonomies only)',
-				),
-				'description' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Term description',
-				),
+				'required'   => array( 'taxonomy', 'name' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/DeleteFile.php
+++ b/inc/Api/Chat/Tools/DeleteFile.php
@@ -33,16 +33,18 @@ class DeleteFile extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Delete an uploaded file. Requires flow_step_id to identify the file scope.',
 			'parameters'  => array(
-				'filename'     => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Name of the file to delete',
+				'type'       => 'object',
+				'properties' => array(
+					'filename'     => array(
+						'type'        => 'string',
+						'description' => 'Name of the file to delete',
+					),
+					'flow_step_id' => array(
+						'type'        => 'string',
+						'description' => 'Flow step ID for flow-level files (e.g., "1-2" for pipeline 1, flow 2)',
+					),
 				),
-				'flow_step_id' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Flow step ID for flow-level files (e.g., "1-2" for pipeline 1, flow 2)',
-				),
+				'required'   => array( 'filename' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/DeleteFlow.php
+++ b/inc/Api/Chat/Tools/DeleteFlow.php
@@ -32,11 +32,14 @@ class DeleteFlow extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Delete a flow.',
 			'parameters'  => array(
-				'flow_id' => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'ID of the flow to delete',
+				'type'       => 'object',
+				'properties' => array(
+					'flow_id' => array(
+						'type'        => 'integer',
+						'description' => 'ID of the flow to delete',
+					),
 				),
+				'required'   => array( 'flow_id' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/DeletePipeline.php
+++ b/inc/Api/Chat/Tools/DeletePipeline.php
@@ -33,11 +33,14 @@ class DeletePipeline extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Delete a pipeline and all its associated flows.',
 			'parameters'  => array(
-				'pipeline_id' => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'ID of the pipeline to delete',
+				'type'       => 'object',
+				'properties' => array(
+					'pipeline_id' => array(
+						'type'        => 'integer',
+						'description' => 'ID of the pipeline to delete',
+					),
 				),
+				'required'   => array( 'pipeline_id' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/DeletePipelineStep.php
+++ b/inc/Api/Chat/Tools/DeletePipelineStep.php
@@ -33,16 +33,18 @@ class DeletePipelineStep extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Remove a step from a pipeline. This removes the step from all flows on the pipeline.',
 			'parameters'  => array(
-				'pipeline_id'      => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'ID of the pipeline containing the step',
+				'type'       => 'object',
+				'properties' => array(
+					'pipeline_id'      => array(
+						'type'        => 'integer',
+						'description' => 'ID of the pipeline containing the step',
+					),
+					'pipeline_step_id' => array(
+						'type'        => 'string',
+						'description' => 'ID of the pipeline step to remove',
+					),
 				),
-				'pipeline_step_id' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'ID of the pipeline step to remove',
-				),
+				'required'   => array( 'pipeline_id', 'pipeline_step_id' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
+++ b/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
@@ -60,16 +60,19 @@ EXAMPLE:
 			'method'      => 'handle_tool_call',
 			'description' => $description,
 			'parameters'  => array(
-				'steps'   => array(
-					'type'        => 'array',
-					'required'    => true,
-					'description' => 'Step objects: {type, handler_slug, handler_config}. AI steps: {type: "ai", user_message}.',
+				'type'       => 'object',
+				'properties' => array(
+					'steps'   => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'object' ),
+						'description' => 'Step objects: {type, handler_slug, handler_config}. AI steps: {type: "ai", user_message}.',
+					),
+					'dry_run' => array(
+						'type'        => 'boolean',
+						'description' => 'Preview execution without creating posts. Returns what would be published instead of actually publishing.',
+					),
 				),
-				'dry_run' => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Preview execution without creating posts. Returns what would be published instead of actually publishing.',
-				),
+				'required'   => array( 'steps' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/GetHandlerDefaults.php
+++ b/inc/Api/Chat/Tools/GetHandlerDefaults.php
@@ -28,10 +28,12 @@ class GetHandlerDefaults extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Get site-wide handler defaults. Use before configuring flows to learn the established configuration standards for this site. Returns defaults for a specific handler or all handlers.',
 			'parameters'  => array(
-				'handler_slug' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Handler slug to get defaults for (e.g., upsert_event, eventbrite). If omitted, returns defaults for all handlers.',
+				'type'       => 'object',
+				'properties' => array(
+					'handler_slug' => array(
+						'type'        => 'string',
+						'description' => 'Handler slug to get defaults for (e.g., upsert_event, eventbrite). If omitted, returns defaults for all handlers.',
+					),
 				),
 			),
 		);

--- a/inc/Api/Chat/Tools/GetProblemFlows.php
+++ b/inc/Api/Chat/Tools/GetProblemFlows.php
@@ -40,10 +40,12 @@ class GetProblemFlows extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => "Identify flows with issues: consecutive failures (broken) or consecutive no-items runs (source exhausted). Default threshold: {$default_threshold}.",
 			'parameters'  => array(
-				'threshold' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => "Minimum consecutive count to report (default: {$default_threshold} from settings)",
+				'type'       => 'object',
+				'properties' => array(
+					'threshold' => array(
+						'type'        => 'integer',
+						'description' => "Minimum consecutive count to report (default: {$default_threshold} from settings)",
+					),
 				),
 			),
 		);

--- a/inc/Api/Chat/Tools/ListFlows.php
+++ b/inc/Api/Chat/Tools/ListFlows.php
@@ -26,25 +26,24 @@ class ListFlows extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'List flows with optional filtering by pipeline ID or handler slug. Supports pagination.',
 			'parameters'  => array(
-				'pipeline_id'  => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Filter flows by pipeline ID',
-				),
-				'handler_slug' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Filter flows using this handler slug (any step that uses this handler)',
-				),
-				'per_page'     => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Number of flows per page (default: 20, max: 100)',
-				),
-				'offset'       => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Offset for pagination (default: 0)',
+				'type'       => 'object',
+				'properties' => array(
+					'pipeline_id'  => array(
+						'type'        => 'integer',
+						'description' => 'Filter flows by pipeline ID',
+					),
+					'handler_slug' => array(
+						'type'        => 'string',
+						'description' => 'Filter flows using this handler slug (any step that uses this handler)',
+					),
+					'per_page'     => array(
+						'type'        => 'integer',
+						'description' => 'Number of flows per page (default: 20, max: 100)',
+					),
+					'offset'       => array(
+						'type'        => 'integer',
+						'description' => 'Offset for pagination (default: 0)',
+					),
 				),
 			),
 		);

--- a/inc/Api/Chat/Tools/ManageJobs.php
+++ b/inc/Api/Chat/Tools/ManageJobs.php
@@ -34,51 +34,46 @@ class ManageJobs extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => $this->buildDescription(),
 			'parameters'  => array(
-				'action'      => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Action to perform: "list", "summary", "delete", "fail", "retry", or "recover"',
+				'type'       => 'object',
+				'properties' => array(
+					'action'      => array(
+						'type'        => 'string',
+						'description' => 'Action to perform: "list", "summary", "delete", "fail", "retry", or "recover"',
+					),
+					'flow_id'     => array(
+						'type'        => 'integer',
+						'description' => 'Filter jobs by flow ID (for list action)',
+					),
+					'pipeline_id' => array(
+						'type'        => 'integer',
+						'description' => 'Filter jobs by pipeline ID (for list action)',
+					),
+					'status'      => array(
+						'type'        => 'string',
+						'description' => 'Filter jobs by status: pending, processing, completed, failed, completed_no_items, agent_skipped (for list action)',
+					),
+					'limit'       => array(
+						'type'        => 'integer',
+						'description' => 'Number of jobs to return (for list action, default 50, max 100)',
+					),
+					'offset'      => array(
+						'type'        => 'integer',
+						'description' => 'Offset for pagination (for list action)',
+					),
+					'type'        => array(
+						'type'        => 'string',
+						'description' => 'For delete action: "all" or "failed". Required for delete.',
+					),
+					'job_id'      => array(
+						'type'        => 'integer',
+						'description' => 'Job ID (for fail and retry actions)',
+					),
+					'reason'      => array(
+						'type'        => 'string',
+						'description' => 'Reason for failure (for fail action)',
+					),
 				),
-				'flow_id'     => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Filter jobs by flow ID (for list action)',
-				),
-				'pipeline_id' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Filter jobs by pipeline ID (for list action)',
-				),
-				'status'      => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Filter jobs by status: pending, processing, completed, failed, completed_no_items, agent_skipped (for list action)',
-				),
-				'limit'       => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Number of jobs to return (for list action, default 50, max 100)',
-				),
-				'offset'      => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Offset for pagination (for list action)',
-				),
-				'type'        => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'For delete action: "all" or "failed". Required for delete.',
-				),
-				'job_id'      => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Job ID (for fail and retry actions)',
-				),
-				'reason'      => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Reason for failure (for fail action)',
-				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/ManageLogs.php
+++ b/inc/Api/Chat/Tools/ManageLogs.php
@@ -34,21 +34,22 @@ class ManageLogs extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => $this->buildDescription(),
 			'parameters'  => array(
-				'action'   => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Action to perform: "clear" or "get_metadata"',
+				'type'       => 'object',
+				'properties' => array(
+					'action'   => array(
+						'type'        => 'string',
+						'description' => 'Action to perform: "clear" or "get_metadata"',
+					),
+					'agent_id' => array(
+						'type'        => 'integer',
+						'description' => 'Agent ID to target. Omit to target all logs.',
+					),
+					'context'  => array(
+						'type'        => 'string',
+						'description' => 'Deprecated label only. Use agent_id instead.',
+					),
 				),
-				'agent_id' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Agent ID to target. Omit to target all logs.',
-				),
-				'context'  => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Deprecated label only. Use agent_id instead.',
-				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/ManageQueue.php
+++ b/inc/Api/Chat/Tools/ManageQueue.php
@@ -35,47 +35,43 @@ class ManageQueue extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => $this->buildDescription(),
 			'parameters'  => array(
-				'action'       => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Action to perform: "add", "list", "clear", "remove", "update", "move", or "mode"',
+				'type'       => 'object',
+				'properties' => array(
+					'action'       => array(
+						'type'        => 'string',
+						'description' => 'Action to perform: "add", "list", "clear", "remove", "update", "move", or "mode"',
+					),
+					'flow_id'      => array(
+						'type'        => 'integer',
+						'description' => 'Flow ID',
+					),
+					'flow_step_id' => array(
+						'type'        => 'string',
+						'description' => 'Flow step ID',
+					),
+					'prompt'       => array(
+						'type'        => 'string',
+						'description' => 'Prompt text (for add and update actions)',
+					),
+					'index'        => array(
+						'type'        => 'integer',
+						'description' => 'Queue index, 0-based (for remove and update actions)',
+					),
+					'from_index'   => array(
+						'type'        => 'integer',
+						'description' => 'Source index for move action (0-based)',
+					),
+					'to_index'     => array(
+						'type'        => 'integer',
+						'description' => 'Destination index for move action (0-based)',
+					),
+					'mode'         => array(
+						'type'        => 'string',
+						'enum'        => array( 'drain', 'loop', 'static' ),
+						'description' => 'Queue access mode for the "mode" action: drain (pop+discard), loop (pop+append-to-tail), static (peek-only).',
+					),
 				),
-				'flow_id'      => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Flow ID',
-				),
-				'flow_step_id' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Flow step ID',
-				),
-				'prompt'       => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Prompt text (for add and update actions)',
-				),
-				'index'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Queue index, 0-based (for remove and update actions)',
-				),
-				'from_index'   => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Source index for move action (0-based)',
-				),
-				'to_index'     => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Destination index for move action (0-based)',
-				),
-				'mode'         => array(
-					'type'        => 'string',
-					'required'    => false,
-					'enum'        => array( 'drain', 'loop', 'static' ),
-					'description' => 'Queue access mode for the "mode" action: drain (pop+discard), loop (pop+append-to-tail), static (peek-only).',
-				),
+				'required'   => array( 'action', 'flow_id', 'flow_step_id' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/MergeTaxonomyTerms.php
+++ b/inc/Api/Chat/Tools/MergeTaxonomyTerms.php
@@ -29,26 +29,26 @@ class MergeTaxonomyTerms extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Merge two taxonomy terms into one. Reassigns all posts from source term to target term, optionally merges meta data, then deletes the source term. Useful for consolidating duplicates.',
 			'parameters'  => array(
-				'source_term' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Term to merge FROM (will be deleted) - ID, name, or slug',
+				'type'       => 'object',
+				'properties' => array(
+					'source_term' => array(
+						'type'        => 'string',
+						'description' => 'Term to merge FROM (will be deleted) - ID, name, or slug',
+					),
+					'target_term' => array(
+						'type'        => 'string',
+						'description' => 'Term to merge INTO (will be kept) - ID, name, or slug',
+					),
+					'taxonomy'    => array(
+						'type'        => 'string',
+						'description' => 'Taxonomy slug (venue, artist, category, post_tag, etc.)',
+					),
+					'merge_meta'  => array(
+						'type'        => 'boolean',
+						'description' => 'Fill empty target meta from source (default: true)',
+					),
 				),
-				'target_term' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Term to merge INTO (will be kept) - ID, name, or slug',
-				),
-				'taxonomy'    => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Taxonomy slug (venue, artist, category, post_tag, etc.)',
-				),
-				'merge_meta'  => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Fill empty target meta from source (default: true)',
-				),
+				'required'   => array( 'source_term', 'target_term', 'taxonomy' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/ReadLogs.php
+++ b/inc/Api/Chat/Tools/ReadLogs.php
@@ -34,40 +34,36 @@ class ReadLogs extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => $this->buildDescription(),
 			'parameters'  => array(
-				'agent_id'    => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Agent ID to read logs for. Omit for all agents.',
-				),
-				'context'     => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Deprecated label only. Use agent_id instead.',
-				),
-				'mode'        => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Content mode: "recent" (default) or "full"',
-				),
-				'limit'       => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Max entries for recent mode (default: 200, max: 10000)',
-				),
-				'job_id'      => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Filter logs by job ID',
-				),
-				'pipeline_id' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Filter logs by pipeline ID',
-				),
-				'flow_id'     => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Filter logs by flow ID',
+				'type'       => 'object',
+				'properties' => array(
+					'agent_id'    => array(
+						'type'        => 'integer',
+						'description' => 'Agent ID to read logs for. Omit for all agents.',
+					),
+					'context'     => array(
+						'type'        => 'string',
+						'description' => 'Deprecated label only. Use agent_id instead.',
+					),
+					'mode'        => array(
+						'type'        => 'string',
+						'description' => 'Content mode: "recent" (default) or "full"',
+					),
+					'limit'       => array(
+						'type'        => 'integer',
+						'description' => 'Max entries for recent mode (default: 200, max: 10000)',
+					),
+					'job_id'      => array(
+						'type'        => 'integer',
+						'description' => 'Filter logs by job ID',
+					),
+					'pipeline_id' => array(
+						'type'        => 'integer',
+						'description' => 'Filter logs by pipeline ID',
+					),
+					'flow_id'     => array(
+						'type'        => 'integer',
+						'description' => 'Filter logs by flow ID',
+					),
 				),
 			),
 		);

--- a/inc/Api/Chat/Tools/ReorderPipelineSteps.php
+++ b/inc/Api/Chat/Tools/ReorderPipelineSteps.php
@@ -33,16 +33,19 @@ class ReorderPipelineSteps extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Reorder steps within a pipeline.',
 			'parameters'  => array(
-				'pipeline_id' => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'ID of the pipeline',
+				'type'       => 'object',
+				'properties' => array(
+					'pipeline_id' => array(
+						'type'        => 'integer',
+						'description' => 'ID of the pipeline',
+					),
+					'step_order'  => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'object' ),
+						'description' => 'Array of step order objects: [{pipeline_step_id: "...", execution_order: 0}, ...]',
+					),
 				),
-				'step_order'  => array(
-					'type'        => 'array',
-					'required'    => true,
-					'description' => 'Array of step order objects: [{pipeline_step_id: "...", execution_order: 0}, ...]',
-				),
+				'required'   => array( 'pipeline_id', 'step_order' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/RunFlow.php
+++ b/inc/Api/Chat/Tools/RunFlow.php
@@ -35,21 +35,22 @@ class RunFlow extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Execute an existing flow immediately or schedule it for later. For IMMEDIATE execution: provide only flow_id (do NOT include timestamp). For SCHEDULED execution: provide flow_id AND a future Unix timestamp. Flows run asynchronously in the background. Use api_query with GET /datamachine/v1/jobs/{job_id} to check execution status.',
 			'parameters'  => array(
-				'flow_id'   => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Flow ID to execute',
+				'type'       => 'object',
+				'properties' => array(
+					'flow_id'   => array(
+						'type'        => 'integer',
+						'description' => 'Flow ID to execute',
+					),
+					'count'     => array(
+						'type'        => 'integer',
+						'description' => 'Number of times to run the flow (1-10, default 1). Each run spawns an independent job. Use this to process multiple items from a source.',
+					),
+					'timestamp' => array(
+						'type'        => 'integer',
+						'description' => 'ONLY for scheduled execution: a future Unix timestamp. OMIT this parameter entirely for immediate execution. Cannot be combined with count > 1.',
+					),
 				),
-				'count'     => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Number of times to run the flow (1-10, default 1). Each run spawns an independent job. Use this to process multiple items from a source.',
-				),
-				'timestamp' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'ONLY for scheduled execution: a future Unix timestamp. OMIT this parameter entirely for immediate execution. Cannot be combined with count > 1.',
-				),
+				'required'   => array( 'flow_id' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/SearchTaxonomyTerms.php
+++ b/inc/Api/Chat/Tools/SearchTaxonomyTerms.php
@@ -29,21 +29,22 @@ class SearchTaxonomyTerms extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Search existing taxonomy terms. Use to discover what terms exist before creating new ones or when configuring handler term assignments.',
 			'parameters'  => array(
-				'taxonomy' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Taxonomy slug (category, post_tag, venue, artist, or other custom taxonomy)',
+				'type'       => 'object',
+				'properties' => array(
+					'taxonomy' => array(
+						'type'        => 'string',
+						'description' => 'Taxonomy slug (category, post_tag, venue, artist, or other custom taxonomy)',
+					),
+					'search'   => array(
+						'type'        => 'string',
+						'description' => 'Search string to filter terms by name (partial match)',
+					),
+					'limit'    => array(
+						'type'        => 'integer',
+						'description' => 'Maximum number of terms to return (default 20, max 100)',
+					),
 				),
-				'search'   => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Search string to filter terms by name (partial match)',
-				),
-				'limit'    => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum number of terms to return (default 20, max 100)',
-				),
+				'required'   => array( 'taxonomy' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/SendPing.php
+++ b/inc/Api/Chat/Tools/SendPing.php
@@ -34,26 +34,26 @@ class SendPing extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Send a ping to one or more webhook URLs. Useful for triggering external agents or notifying services.',
 			'parameters'  => array(
-				'webhook_url' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'URL(s) to POST data to. Accepts a single URL or newline-separated string of URLs.',
+				'type'       => 'object',
+				'properties' => array(
+					'webhook_url' => array(
+						'type'        => 'string',
+						'description' => 'URL(s) to POST data to. Accepts a single URL or newline-separated string of URLs.',
+					),
+					'prompt'      => array(
+						'type'        => 'string',
+						'description' => 'Optional instructions for the receiving agent',
+					),
+					'flow_id'     => array(
+						'type'        => 'integer',
+						'description' => 'Flow ID for context',
+					),
+					'pipeline_id' => array(
+						'type'        => 'integer',
+						'description' => 'Pipeline ID for context',
+					),
 				),
-				'prompt'      => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Optional instructions for the receiving agent',
-				),
-				'flow_id'     => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Flow ID for context',
-				),
-				'pipeline_id' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Pipeline ID for context',
-				),
+				'required'   => array( 'webhook_url' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/SetHandlerDefaults.php
+++ b/inc/Api/Chat/Tools/SetHandlerDefaults.php
@@ -29,16 +29,18 @@ class SetHandlerDefaults extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Set site-wide handler defaults. Use to establish standard configuration values that apply to all new flows. For example, setting post_author and include_images defaults for upsert_event.',
 			'parameters'  => array(
-				'handler_slug' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Handler slug to set defaults for (e.g., upsert_event, eventbrite)',
+				'type'       => 'object',
+				'properties' => array(
+					'handler_slug' => array(
+						'type'        => 'string',
+						'description' => 'Handler slug to set defaults for (e.g., upsert_event, eventbrite)',
+					),
+					'defaults'     => array(
+						'type'        => 'object',
+						'description' => 'Default configuration values to set. Keys should match handler config fields.',
+					),
 				),
-				'defaults'     => array(
-					'type'        => 'object',
-					'required'    => true,
-					'description' => 'Default configuration values to set. Keys should match handler config fields.',
-				),
+				'required'   => array( 'handler_slug', 'defaults' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/SystemHealthCheck.php
+++ b/inc/Api/Chat/Tools/SystemHealthCheck.php
@@ -34,15 +34,17 @@ class SystemHealthCheck extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Run unified health diagnostics for Data Machine and extensions. Returns status of various system components.',
 			'parameters'  => array(
-				'types'   => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Check types to run. Use "all" for all default checks, or specific type IDs. Omit for all checks.',
-				),
-				'options' => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Type-specific options (scope, limit, url, etc.)',
+				'type'       => 'object',
+				'properties' => array(
+					'types'   => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'Check types to run. Use "all" for all default checks, or specific type IDs. Omit for all checks.',
+					),
+					'options' => array(
+						'type'        => 'object',
+						'description' => 'Type-specific options (scope, limit, url, etc.)',
+					),
 				),
 			),
 		);

--- a/inc/Api/Chat/Tools/UpdateFlow.php
+++ b/inc/Api/Chat/Tools/UpdateFlow.php
@@ -33,21 +33,22 @@ class UpdateFlow extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Update flow title and/or scheduling.',
 			'parameters'  => array(
-				'flow_id'           => array(
-					'type'        => 'integer',
-					'required'    => true,
-					'description' => 'Flow ID',
+				'type'       => 'object',
+				'properties' => array(
+					'flow_id'           => array(
+						'type'        => 'integer',
+						'description' => 'Flow ID',
+					),
+					'flow_name'         => array(
+						'type'        => 'string',
+						'description' => 'New flow title',
+					),
+					'scheduling_config' => array(
+						'type'        => 'object',
+						'description' => 'Schedule: {interval: value}. Valid intervals:' . "\n" . SchedulingDocumentation::getIntervalsJson(),
+					),
 				),
-				'flow_name'         => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'New flow title',
-				),
-				'scheduling_config' => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Schedule: {interval: value}. Valid intervals:' . "\n" . SchedulingDocumentation::getIntervalsJson(),
-				),
+				'required'   => array( 'flow_id' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/UpdateTaxonomyTerm.php
+++ b/inc/Api/Chat/Tools/UpdateTaxonomyTerm.php
@@ -29,41 +29,38 @@ class UpdateTaxonomyTerm extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Update an existing taxonomy term. Can modify core fields (name, slug, description, parent) and custom term meta (venue_address, venue_capacity, etc.). Use search_taxonomy_terms first to find the term to update.',
 			'parameters'  => array(
-				'term'        => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Term identifier - can be term ID, name, or slug',
+				'type'       => 'object',
+				'properties' => array(
+					'term'        => array(
+						'type'        => 'string',
+						'description' => 'Term identifier - can be term ID, name, or slug',
+					),
+					'taxonomy'    => array(
+						'type'        => 'string',
+						'description' => 'Taxonomy slug (venue, artist, category, post_tag, or custom taxonomy)',
+					),
+					'name'        => array(
+						'type'        => 'string',
+						'description' => 'New term name',
+					),
+					'slug'        => array(
+						'type'        => 'string',
+						'description' => 'New term slug (URL-friendly identifier)',
+					),
+					'description' => array(
+						'type'        => 'string',
+						'description' => 'New term description',
+					),
+					'parent'      => array(
+						'type'        => 'string',
+						'description' => 'New parent term (ID, name, or slug) - hierarchical taxonomies only',
+					),
+					'meta'        => array(
+						'type'        => 'object',
+						'description' => 'Key-value pairs of term meta to update (e.g., venue_address, venue_capacity). Keys starting with "_" are protected and cannot be modified.',
+					),
 				),
-				'taxonomy'    => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Taxonomy slug (venue, artist, category, post_tag, or custom taxonomy)',
-				),
-				'name'        => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'New term name',
-				),
-				'slug'        => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'New term slug (URL-friendly identifier)',
-				),
-				'description' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'New term description',
-				),
-				'parent'      => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'New parent term (ID, name, or slug) - hierarchical taxonomies only',
-				),
-				'meta'        => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Key-value pairs of term meta to update (e.g., venue_address, venue_capacity). Keys starting with "_" are protected and cannot be modified.',
-				),
+				'required'   => array( 'term', 'taxonomy' ),
 			),
 		);
 	}


### PR DESCRIPTION
## Why

[DM 0.106.1 PR #1900](https://github.com/Extra-Chill/data-machine/pull/1900) ("Require canonical AI tool schemas") removed the auto-normalization layer in `RequestBuilder::normalizeToolParameters`. Tool registrations now go to OpenAI as the schema literal — anything still emitting the legacy `{name => {type, required: true|false, description}}` shape gets rejected by provider strict-mode validation.

This PR sweeps **all chat tools in `inc/Api/Chat/Tools/`**. Two parallel PRs cover the other in-scope buckets identified by issue #1921: Global tools (`inc/Engine/AI/Tools/Global/`) and handler tools (`inc/Core/Steps/Publish/Handlers/{WordPress,Email}/`). This PR stays out of those directories.

Closes part of #1921.

## What changed

Converted 31 chat tool definitions from the legacy shape:

```php
// Legacy
'parameters' => array(
    'flow_id' => array( 'type' => 'integer', 'required' => true, 'description' => 'Flow ID' ),
    'flow_name' => array( 'type' => 'string', 'required' => false, 'description' => 'Flow name' ),
)
```

…to canonical JSON Schema:

```php
// Canonical
'parameters' => array(
    'type'       => 'object',
    'properties' => array(
        'flow_id'   => array( 'type' => 'integer', 'description' => 'Flow ID' ),
        'flow_name' => array( 'type' => 'string',  'description' => 'Flow name' ),
    ),
    'required'   => array( 'flow_id' ),
)
```

### Files

- `inc/Api/Chat/Tools/AddPipelineStep.php`
- `inc/Api/Chat/Tools/ApiQuery.php`
- `inc/Api/Chat/Tools/AssignTaxonomyTerm.php`
- `inc/Api/Chat/Tools/AuthenticateHandler.php`
- `inc/Api/Chat/Tools/ConfigureFlowSteps.php`
- `inc/Api/Chat/Tools/ConfigurePipelineStep.php`
- `inc/Api/Chat/Tools/CopyFlow.php`
- `inc/Api/Chat/Tools/CreateFlow.php`
- `inc/Api/Chat/Tools/CreatePipeline.php`
- `inc/Api/Chat/Tools/CreateTaxonomyTerm.php`
- `inc/Api/Chat/Tools/DeleteFile.php`
- `inc/Api/Chat/Tools/DeleteFlow.php`
- `inc/Api/Chat/Tools/DeletePipeline.php`
- `inc/Api/Chat/Tools/DeletePipelineStep.php`
- `inc/Api/Chat/Tools/ExecuteWorkflowTool.php`
- `inc/Api/Chat/Tools/GetHandlerDefaults.php`
- `inc/Api/Chat/Tools/GetProblemFlows.php`
- `inc/Api/Chat/Tools/ListFlows.php`
- `inc/Api/Chat/Tools/ManageJobs.php`
- `inc/Api/Chat/Tools/ManageLogs.php`
- `inc/Api/Chat/Tools/ManageQueue.php`
- `inc/Api/Chat/Tools/MergeTaxonomyTerms.php`
- `inc/Api/Chat/Tools/ReadLogs.php`
- `inc/Api/Chat/Tools/ReorderPipelineSteps.php`
- `inc/Api/Chat/Tools/RunFlow.php`
- `inc/Api/Chat/Tools/SearchTaxonomyTerms.php`
- `inc/Api/Chat/Tools/SendPing.php`
- `inc/Api/Chat/Tools/SetHandlerDefaults.php`
- `inc/Api/Chat/Tools/SystemHealthCheck.php`
- `inc/Api/Chat/Tools/UpdateFlow.php`
- `inc/Api/Chat/Tools/UpdateTaxonomyTerm.php`

`SchedulingDocumentation.php` is a helper class with no tool parameters and was not modified.

### Conversion rules applied

Identical to the rules used in extra-chill/data-machine-events#232 / #235:

1. Wrap properties under `{ type: 'object', properties: {...} }`.
2. Move every property where `required => true` into a top-level `required[]` string list.
3. Drop `required => false` entirely (it was a no-op).
4. Omit the `required` key when no properties are required (don't emit empty arrays).
5. **Every `type: array` property declares an `items` schema** (required by OpenAI strict tool-schema validation, see MEMORY.md). Choices made:
   - `step_order`, `pipelines`, `steps` (workflow steps), `flows`, `flow_configs`, `updates`, `requests` → `items: { type: object }` (arrays of structured objects)
   - `disabled_tools`, `tool_categories`, `flow_step_ids`, `types` (health-check types) → `items: { type: string }` (string lists)
   - `post_ids` (AssignTaxonomyTerm) → `items: { type: integer }` (post ID list)
6. All other property keys (`description`, `enum`) preserved verbatim.

### Required fields summary

- No required: `ListFlows`, `GetProblemFlows`, `GetHandlerDefaults`, `ReadLogs`, `SystemHealthCheck`, `CreatePipeline`, `CreateFlow`, `ConfigureFlowSteps`, `ApiQuery` (validated at handler level — multiple selection modes)
- `action`: `ManageQueue`, `ManageJobs`, `ManageLogs`, `AuthenticateHandler`
- `flow_id`: `DeleteFlow`, `UpdateFlow`, `RunFlow`
- `pipeline_id`: `DeletePipeline`
- `pipeline_id` + `step_type`: `AddPipelineStep`
- `pipeline_id` + `pipeline_step_id`: `DeletePipelineStep`
- `pipeline_id` + `step_order`: `ReorderPipelineSteps`
- `pipeline_step_id`: `ConfigurePipelineStep`
- `source_flow_id` + `target_pipeline_id` + `flow_name`: `CopyFlow`
- `webhook_url`: `SendPing`
- `filename`: `DeleteFile`
- `steps`: `ExecuteWorkflowTool`
- `taxonomy`: `SearchTaxonomyTerms`
- `taxonomy` + `name`: `CreateTaxonomyTerm`
- `term` + `taxonomy`: `UpdateTaxonomyTerm`
- `term` + `taxonomy` + `post_ids`: `AssignTaxonomyTerm`
- `source_term` + `target_term` + `taxonomy`: `MergeTaxonomyTerms`
- `handler_slug` + `defaults`: `SetHandlerDefaults`

## Out of scope (intentionally)

- Global tools (`inc/Engine/AI/Tools/Global/`) — handled by parallel PR per issue #1921.
- Handler tool registrations (`inc/Core/Steps/Publish/Handlers/{WordPress,Email}/`) — handled by parallel PR per issue #1921.
- WP REST API `args` definitions (`inc/Api/**` non-Chat) — out of scope per issue #1921 (legitimate WP REST contract).
- Settings/Auth definitions, Abilities API schemas — out of scope per issue #1921 (separate conventions, not sent to OpenAI).

## Test plan

- [x] PHP syntax check (`php -l`) passes on all 31 modified files.
- [x] `homeboy lint --path . --changed-since main` returns no findings.
- [x] Verified zero `'required' => true|false` references remain in `inc/Api/Chat/Tools/`.
- [x] `tests/Unit/Api/Chat/Tools/ListFlowsTest.php` (only test in this directory) does not pin schema shape — tests behavior via `handle_tool_call`, unaffected by parameter schema changes.
- [ ] Live tool calls in production chat post-merge (manual sanity check on a representative subset: `list_flows`, `create_flow`, `manage_jobs`, `assign_taxonomy_term`).

## Constraints honored

- Branched off `main`, no commits to `main`.
- No `CHANGELOG.md` edits, no version constant bumps — homeboy owns those.
- No deploy, no release.
- Only `inc/Api/Chat/Tools/` modified — no Global tools, handler tools, REST API args, settings UI, or Abilities schemas touched.
