### PR TITLE
refactor: drop dead scan_and_instantiate + redundant per-request migration callback

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -469,32 +469,6 @@ function datamachine_load_handlers() {
 	new \DataMachine\Core\Steps\Upsert\Handlers\WordPress\WordPress();
 }
 
-/**
- * Scan directory for PHP files and instantiate classes.
- * Classes are expected to self-register in their constructors.
- */
-function datamachine_scan_and_instantiate( $directory ) {
-	$files = glob( $directory . '/*.php' );
-	if ( false === $files ) {
-		return;
-	}
-
-	foreach ( $files as $file ) {
-		// Skip if it's a *Filters.php file (will be deleted)
-		if ( strpos( basename( $file ), 'Filters.php' ) !== false ) {
-			continue;
-		}
-
-		// Skip if it's a *Settings.php file
-		if ( strpos( basename( $file ), 'Settings.php' ) !== false ) {
-			continue;
-		}
-
-		// Include the file - classes will auto-instantiate
-		include_once $file;
-	}
-}
-
 function datamachine_allow_json_upload( $mimes ) {
 	$mimes['json'] = 'application/json';
 	return $mimes;
@@ -502,23 +476,6 @@ function datamachine_allow_json_upload( $mimes ) {
 add_filter( 'upload_mimes', 'datamachine_allow_json_upload' );
 
 add_action( 'update_option_datamachine_settings', array( \DataMachine\Core\PluginSettings::class, 'clearCache' ) );
-
-// @phpstan-ignore-next-line WordPress stubs in CI omit the optional priority argument.
-add_action(
-	'plugins_loaded',
-	function () {
-		if ( ! \DataMachine\Core\Database\Chat\Chat::table_exists() ) {
-			return;
-		}
-		\DataMachine\Core\Database\Chat\Chat::ensure_mode_column();
-		\DataMachine\Core\Database\Chat\Chat::ensure_workspace_columns();
-		\DataMachine\Core\Database\Chat\Chat::ensure_agent_id_column();
-		\DataMachine\Core\Database\Chat\Chat::ensure_last_read_at_column();
-		\DataMachine\Core\Database\Chat\Chat::ensure_transcript_lock_columns();
-		\DataMachine\Engine\AI\Actions\PendingActionStore::ensure_workspace_columns();
-	},
-	6
-);
 
 register_activation_hook( __FILE__, 'datamachine_activate_plugin' );
 register_deactivation_hook( __FILE__, 'datamachine_deactivate_plugin' );

--- a/inc/migrations/pending-actions.php
+++ b/inc/migrations/pending-actions.php
@@ -9,7 +9,13 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Ensure the durable pending-action table exists on upgraded installs.
+ *
+ * Also runs the workspace column ensure to backfill the
+ * `workspace_type`/`workspace_id` columns on installs that pre-date them.
+ * dbDelta inside `create_table()` covers fresh installs; the explicit
+ * ensure handles installs created before the columns landed.
  */
 function datamachine_migrate_pending_actions_table(): void {
 	\DataMachine\Engine\AI\Actions\PendingActionStore::create_table();
+	\DataMachine\Engine\AI\Actions\PendingActionStore::ensure_workspace_columns();
 }


### PR DESCRIPTION
## Summary

Two related cleanups in `data-machine.php` plus one supporting tweak in the migration runner. Net -37 lines, no functional regression, removes 12 SQL queries per request from every Data Machine page load.

## What's removed

### 1. Dead function `datamachine_scan_and_instantiate()` (-23 lines)

```diff
-function datamachine_scan_and_instantiate( $directory ) {
-    $files = glob( $directory . '/*.php' );
-    if ( false === $files ) {
-        return;
-    }
-    foreach ( $files as $file ) {
-        // Skip if it's a *Filters.php file (will be deleted)
-        if ( strpos( basename( $file ), 'Filters.php' ) !== false ) continue;
-        if ( strpos( basename( $file ), 'Settings.php' ) !== false ) continue;
-        include_once $file;
-    }
-}
```

Never called anywhere in the codebase. Hand-rolled directory autoloader from an earlier architecture, superseded by Composer PSR-4. The `// will be deleted` comment on the `Filters.php` skip rule suggests this was already mid-cleanup at some point.

### 2. Redundant per-request migration callback (-20 lines)

```diff
-add_action(
-    'plugins_loaded',
-    function () {
-        if ( ! \DataMachine\Core\Database\Chat\Chat::table_exists() ) return;
-        \DataMachine\Core\Database\Chat\Chat::ensure_mode_column();
-        \DataMachine\Core\Database\Chat\Chat::ensure_workspace_columns();
-        \DataMachine\Core\Database\Chat\Chat::ensure_agent_id_column();
-        \DataMachine\Core\Database\Chat\Chat::ensure_last_read_at_column();
-        \DataMachine\Core\Database\Chat\Chat::ensure_transcript_lock_columns();
-        \DataMachine\Engine\AI\Actions\PendingActionStore::ensure_workspace_columns();
-    },
-    6
-);
```

This callback ran on **every page load** (after a `Chat::table_exists()` guard). Each `ensure_X_column()` issues 2 SQL queries — `column_exists` lookup + `SHOW INDEX FROM` — for **12 SQL queries per request** producing zero schema changes on stable installs.

The proper version-gated migration runner already exists at `inc/migrations/runtime.php`:

| Hook | Priority | What it does |
|---|---|---|
| `plugins_loaded` | **5** | `datamachine_maybe_run_deferred_migrations` — option-gate on `datamachine_db_version === DATAMACHINE_VERSION`, early-return on cheap path |
| `plugins_loaded` | ~~6~~ | ~~the redundant callback this PR deletes~~ |
| `plugins_loaded` | 20 | `datamachine_run_datamachine_plugin` — full runtime |

The runner at priority 5 already calls `datamachine_run_schema_migrations` → `datamachine_ensure_all_tables` (which calls every `Chat::ensure_X_column()` method). The deleted callback at priority 6 was duplicating the same work without the version-stamp early-return.

## Compensating change

`PendingActionStore::ensure_workspace_columns()` was the one method only called from the deleted callback — `datamachine_ensure_all_tables` doesn't reference it. Added it to `datamachine_migrate_pending_actions_table()` (in `inc/migrations/pending-actions.php`) so existing installs that pre-date the workspace columns still get them backfilled when the migration runner fires:

```diff
 function datamachine_migrate_pending_actions_table(): void {
     \DataMachine\Engine\AI\Actions\PendingActionStore::create_table();
+    \DataMachine\Engine\AI\Actions\PendingActionStore::ensure_workspace_columns();
 }
```

`create_table()`'s dbDelta already declares `workspace_type` and `workspace_id` columns for fresh installs; the explicit ensure handles the upgrade path for installs created before workspace columns landed.

## Test plan

| Scenario | Expected | Verified |
|---|---|---|
| Stable install (no version bump) | priority-5 runner option-gate hits cheap path; zero schema queries per request | option-gate logic was already in place; this PR removes the redundant queries that bypassed it |
| Version bump (`DATAMACHINE_VERSION` advances) | priority-5 runner detects mismatch, runs `datamachine_run_schema_migrations` → all `ensure_X_column` methods → bumps option | unchanged |
| Fresh install (activation) | `datamachine_activate_for_site` → `datamachine_ensure_all_tables` → all schemas via dbDelta | unchanged |
| Upgrade from pre-workspace-columns install | priority-5 runner → `datamachine_run_schema_migrations` → `datamachine_migrate_pending_actions_table` → both `create_table` and `ensure_workspace_columns` run | covered by the compensating change |
| `php -l data-machine.php` | no syntax errors | ✓ |
| `php -l inc/migrations/pending-actions.php` | no syntax errors | ✓ |

## Performance impact

Stable installs (no schema changes pending): **-12 SQL queries per request** on every Data Machine-loaded page. On a multi-site network with regular admin / chat / pipeline traffic, this compounds quickly.

## Related pattern note

`datamachine_check_requirements()` was deleted in #1924 (yesterday's session) for the same reason: redundant reimplementation of work that's already done correctly elsewhere. This PR continues the same theme — when DM has both an ad-hoc bolt-on and a proper structured system for the same job, the bolt-on usually loses on review.