### PR TITLE
Enhance completion outcome assertions

### DIFF
--- a/docs/core-system/ai-conversation-loop.md
+++ b/docs/core-system/ai-conversation-loop.md
@@ -80,6 +80,47 @@ if (empty($tool_calls)) {
 }
 ```
 
+Pipeline steps can also declare `completion_assertions` to keep the loop running until required runtime signals are present. Simple assertions require all named tools to have succeeded:
+
+```json
+{
+  "completion_assertions": {
+    "required_tool_names": ["create_or_update_github_file", "create_github_pull_request"]
+  }
+}
+```
+
+For agents with multiple valid completion shapes, use `complete_when_any`. Each outcome is generic and tool-driven: the run completes when any named outcome has all of its required successful tool calls, optional output fields, optional parameter matches, and optional minimum call counts.
+
+```json
+{
+  "completion_assertions": {
+    "required_tool_names": ["agent_daily_memory"],
+    "complete_when_any": [
+      {
+        "name": "content_proposal",
+        "tools": [
+          { "name": "create_or_update_github_file", "min_successful_calls": 2 },
+          { "name": "create_github_pull_request", "required_output": ["html_url"] }
+        ]
+      },
+      {
+        "name": "issue_reply",
+        "tools": [
+          {
+            "name": "manage_github_issue",
+            "required_parameters": { "action": "comment" },
+            "required_output": ["comment.html_url"]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Outcome names appear in completion diagnostics and nudges, so operators can tell which path was satisfied or what remains missing without decoding `outcome_1` style placeholders.
+
 ### State Management
 
 The loop maintains conversation state across turns, tracking:

--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -237,7 +237,7 @@ class DataMachineCompletionAssertions {
 	private function missingOutcomeRequirements( array $outcome ): array {
 		$missing = array();
 		foreach ( $outcome['tools'] as $tool ) {
-			$name = $tool['name'];
+			$name             = $tool['name'];
 			$matching_results = $this->matchingToolResults( $tool );
 			if ( empty( $matching_results ) ) {
 				$missing[] = $name;

--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -23,7 +23,7 @@ class DataMachineCompletionAssertions {
 	/** @var array<int, string> */
 	private array $required_output_packet_types;
 
-	/** @var array<int, array{tools: array<int, array{name: string, required_output: array<int, string>}>}> */
+	/** @var array<int, array{name: string, tools: array<int, array{name: string, required_output: array<int, string>, required_parameters: array<string, mixed>, min_successful_calls: int}>}> */
 	private array $complete_when_any;
 
 	/** @var array<int, string> */
@@ -60,14 +60,16 @@ class DataMachineCompletionAssertions {
 	/**
 	 * Record a tool result as a possible completion signal.
 	 *
-	 * @param string     $tool_name   Tool name.
-	 * @param array|null $tool_def    Tool definition.
-	 * @param array      $tool_result Tool result.
+	 * @param string     $tool_name       Tool name.
+	 * @param array|null $tool_def        Tool definition.
+	 * @param array      $tool_result     Tool result.
+	 * @param array      $tool_parameters Tool parameters.
 	 */
-	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result ): void {
+	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, array $tool_parameters = array() ): void {
 		$tool_succeeded = true === ( $tool_result['success'] ?? false );
 
 		if ( '' !== $tool_name && $tool_succeeded ) {
+			$tool_result['_parameters']                    = $tool_parameters;
 			$this->executed_tool_names[]                   = $tool_name;
 			$this->successful_tool_results[ $tool_name ][] = $tool_result;
 		}
@@ -214,12 +216,12 @@ class DataMachineCompletionAssertions {
 			$outcome_missing = $this->missingOutcomeRequirements( $outcome );
 			if ( empty( $outcome_missing ) ) {
 				return array(
-					'satisfied' => array( 'outcome_' . ( $index + 1 ) ),
+					'satisfied' => array( $outcome['name'] ),
 					'missing'   => array(),
 				);
 			}
 
-			$missing[] = 'outcome_' . ( $index + 1 ) . ': ' . implode( ', ', $outcome_missing );
+			$missing[] = $outcome['name'] . ': ' . implode( ', ', $outcome_missing );
 		}
 
 		return array(
@@ -229,20 +231,25 @@ class DataMachineCompletionAssertions {
 	}
 
 	/**
-	 * @param array{tools: array<int, array{name: string, required_output: array<int, string>}>} $outcome Outcome assertion.
+	 * @param array{name: string, tools: array<int, array{name: string, required_output: array<int, string>, required_parameters: array<string, mixed>, min_successful_calls: int}>} $outcome Outcome assertion.
 	 * @return array<int, string>
 	 */
 	private function missingOutcomeRequirements( array $outcome ): array {
 		$missing = array();
 		foreach ( $outcome['tools'] as $tool ) {
 			$name = $tool['name'];
-			if ( empty( $this->successful_tool_results[ $name ] ) ) {
+			$matching_results = $this->matchingToolResults( $tool );
+			if ( empty( $matching_results ) ) {
 				$missing[] = $name;
+				continue;
+			}
+			if ( count( $matching_results ) < $tool['min_successful_calls'] ) {
+				$missing[] = $name . ' x' . $tool['min_successful_calls'];
 				continue;
 			}
 
 			foreach ( $tool['required_output'] as $field ) {
-				if ( ! $this->toolHasOutputField( $name, $field ) ) {
+				if ( ! $this->resultsHaveOutputField( $matching_results, $field ) ) {
 					$missing[] = $name . '.' . $field;
 				}
 			}
@@ -251,8 +258,50 @@ class DataMachineCompletionAssertions {
 		return array_values( array_unique( $missing ) );
 	}
 
-	private function toolHasOutputField( string $tool_name, string $field ): bool {
-		foreach ( $this->successful_tool_results[ $tool_name ] ?? array() as $result ) {
+	/**
+	 * @param array{name: string, required_parameters: array<string, mixed>} $tool Tool assertion.
+	 * @return array<int, array>
+	 */
+	private function matchingToolResults( array $tool ): array {
+		$results = $this->successful_tool_results[ $tool['name'] ] ?? array();
+		if ( empty( $tool['required_parameters'] ) ) {
+			return $results;
+		}
+
+		return array_values(
+			array_filter(
+				$results,
+				fn( array $result ): bool => $this->parametersMatch( is_array( $result['_parameters'] ?? null ) ? $result['_parameters'] : array(), $tool['required_parameters'] )
+			)
+		);
+	}
+
+	private function parametersMatch( array $parameters, array $required_parameters ): bool {
+		foreach ( $required_parameters as $path => $expected ) {
+			if ( ! $this->hasPathValue( $parameters, (string) $path, $expected ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private function hasPathValue( array $data, string $path, mixed $expected ): bool {
+		$segments = explode( '.', $path );
+		$value    = $data;
+		foreach ( $segments as $segment ) {
+			if ( ! is_array( $value ) || ! array_key_exists( $segment, $value ) ) {
+				return false;
+			}
+
+			$value = $value[ $segment ];
+		}
+
+		return $value === $expected;
+	}
+
+	private function resultsHaveOutputField( array $results, string $field ): bool {
+		foreach ( $results as $result ) {
 			if ( $this->hasNonEmptyPath( $result, $field ) ) {
 				return true;
 			}
@@ -329,7 +378,7 @@ class DataMachineCompletionAssertions {
 
 	/**
 	 * @param mixed $value Raw outcome assertions.
-	 * @return array<int, array{tools: array<int, array{name: string, required_output: array<int, string>}>}>
+	 * @return array<int, array{name: string, tools: array<int, array{name: string, required_output: array<int, string>, required_parameters: array<string, mixed>, min_successful_calls: int}>}>
 	 */
 	private function sanitizeOutcomeAssertions( $value ): array {
 		if ( ! is_array( $value ) ) {
@@ -337,7 +386,7 @@ class DataMachineCompletionAssertions {
 		}
 
 		$outcomes = array();
-		foreach ( $value as $outcome ) {
+		foreach ( $value as $index => $outcome ) {
 			if ( ! is_array( $outcome ) || ! is_array( $outcome['tools'] ?? null ) ) {
 				continue;
 			}
@@ -354,17 +403,48 @@ class DataMachineCompletionAssertions {
 				}
 
 				$tools[] = array(
-					'name'            => $name,
-					'required_output' => $this->sanitizeList( $tool['required_output'] ?? array() ),
+					'name'                 => $name,
+					'required_output'      => $this->sanitizeList( $tool['required_output'] ?? array() ),
+					'required_parameters'  => $this->sanitizeRequiredParameters( $tool['required_parameters'] ?? array() ),
+					'min_successful_calls' => max( 1, (int) ( $tool['min_successful_calls'] ?? 1 ) ),
 				);
 			}
 
 			if ( ! empty( $tools ) ) {
-				$outcomes[] = array( 'tools' => $tools );
+				$outcomes[] = array(
+					'name'  => $this->sanitizeOutcomeName( $outcome['name'] ?? 'outcome_' . ( (int) $index + 1 ) ),
+					'tools' => $tools,
+				);
 			}
 		}
 
 		return $outcomes;
+	}
+
+	private function sanitizeOutcomeName( mixed $value ): string {
+		$name = strtolower( trim( (string) $value ) );
+		$name = preg_replace( '/[^a-z0-9_\-]+/', '_', $name );
+		$name = trim( is_string( $name ) ? $name : '', '_' );
+		return '' !== $name ? $name : 'outcome';
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private function sanitizeRequiredParameters( mixed $value ): array {
+		if ( ! is_array( $value ) || array_is_list( $value ) ) {
+			return array();
+		}
+
+		$parameters = array();
+		foreach ( $value as $path => $expected ) {
+			$path = trim( (string) $path );
+			if ( '' !== $path ) {
+				$parameters[ $path ] = $expected;
+			}
+		}
+
+		return $parameters;
 	}
 
 	/**

--- a/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
+++ b/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
@@ -39,7 +39,12 @@ class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Comple
 	 * @inheritDoc
 	 */
 	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, array $runtime_context, int $turn_count ): WP_Agent_Conversation_Completion_Decision {
-		$this->assertions->recordToolResult( $tool_name, $tool_def, $tool_result );
+		$this->assertions->recordToolResult(
+			$tool_name,
+			$tool_def,
+			$tool_result,
+			is_array( $runtime_context['tool_parameters'] ?? null ) ? $runtime_context['tool_parameters'] : array()
+		);
 
 		$is_handler_tool = is_array( $tool_def ) && isset( $tool_def['handler'] );
 		$mode            = (string) ( $runtime_context['mode'] ?? '' );

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -543,7 +543,14 @@ function datamachine_build_turn_runner(
 					$tool_name,
 					is_array( $tool_def ) ? $tool_def : null,
 					$tool_result,
-					array_merge( $turn_context, $loop_payload, array( 'mode' => $mode ) ),
+					array_merge(
+						$turn_context,
+						$loop_payload,
+						array(
+							'mode'            => $mode,
+							'tool_parameters' => $tool_parameters,
+						)
+					),
 					$turn_count
 				);
 				$conversation_complete = $completion_decision->isComplete();

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -784,6 +784,7 @@ assert_runtime_policy( array( 'workspace_edit', 'workspace_git_commit' ) === ( $
 $outcome_assertions_config = array(
 	'complete_when_any' => array(
 		array(
+			'name'  => 'pull_request_path',
 			'tools' => array(
 				array(
 					'name'            => 'create_github_pull_request',
@@ -797,6 +798,7 @@ $outcome_assertions_config = array(
 			),
 		),
 		array(
+			'name'  => 'issue_fallback_path',
 			'tools' => array(
 				array(
 					'name'            => 'create_github_issue',
@@ -840,6 +842,7 @@ $pr_outcome_decision = $pr_outcome_policy->recordNaturalCompletion(
 	3
 );
 assert_runtime_policy( $pr_outcome_decision->isComplete(), 'complete_when_any PR path satisfies completion assertion' );
+assert_runtime_policy( array( 'pull_request_path' ) === ( $pr_outcome_decision->context()['satisfied']['complete_when_any'] ?? null ), 'named complete_when_any PR path is reported as satisfied' );
 
 $issue_outcome_policy = new DataMachineHandlerCompletionPolicy(
 	array(),
@@ -869,6 +872,7 @@ $issue_outcome_decision = $issue_outcome_policy->recordNaturalCompletion(
 	3
 );
 assert_runtime_policy( $issue_outcome_decision->isComplete(), 'complete_when_any issue fallback path satisfies completion assertion' );
+assert_runtime_policy( array( 'issue_fallback_path' ) === ( $issue_outcome_decision->context()['satisfied']['complete_when_any'] ?? null ), 'named complete_when_any issue path is reported as satisfied' );
 
 $failed_outcome_policy = new DataMachineHandlerCompletionPolicy(
 	array(),
@@ -899,6 +903,96 @@ $failed_outcome_decision = $failed_outcome_policy->recordNaturalCompletion(
 );
 assert_runtime_policy( ! $failed_outcome_decision->isComplete(), 'failed complete_when_any tool result does not satisfy completion assertion' );
 assert_runtime_policy( isset( $failed_outcome_decision->context()['missing']['complete_when_any'] ), 'failed complete_when_any path reports missing outcome assertion' );
+
+$parameter_outcome_policy = new DataMachineHandlerCompletionPolicy(
+	array(),
+	new \DataMachine\Engine\AI\DataMachineCompletionAssertions(
+		array(
+			'complete_when_any' => array(
+				array(
+					'name'  => 'mailbox_return',
+					'tools' => array(
+						array(
+							'name'                => 'manage_github_issue',
+							'required_parameters' => array( 'action' => 'comment' ),
+							'required_output'     => array( 'comment.html_url' ),
+						),
+					),
+				),
+			),
+		)
+	)
+);
+$parameter_outcome_policy->recordToolResult(
+	'manage_github_issue',
+	array( 'name' => 'manage_github_issue' ),
+	array(
+		'success' => true,
+		'data'    => array( 'comment' => array( 'html_url' => 'https://github.com/Extra-Chill/data-machine/issues/1#issuecomment-1' ) ),
+	),
+	array( 'mode' => 'pipeline', 'tool_parameters' => array( 'action' => 'close' ) ),
+	1
+);
+$parameter_outcome_missing_decision = $parameter_outcome_policy->recordNaturalCompletion(
+	array( array( 'role' => 'user', 'content' => 'return to mailbox' ) ),
+	'Close is not a mailbox reply.',
+	array( 'mode' => 'pipeline' ),
+	2
+);
+assert_runtime_policy( ! $parameter_outcome_missing_decision->isComplete(), 'complete_when_any required_parameters reject wrong tool arguments' );
+$parameter_outcome_policy->recordToolResult(
+	'manage_github_issue',
+	array( 'name' => 'manage_github_issue' ),
+	array(
+		'success' => true,
+		'data'    => array( 'comment' => array( 'html_url' => 'https://github.com/Extra-Chill/data-machine/issues/1#issuecomment-2' ) ),
+	),
+	array( 'mode' => 'pipeline', 'tool_parameters' => array( 'action' => 'comment' ) ),
+	3
+);
+$parameter_outcome_decision = $parameter_outcome_policy->recordNaturalCompletion(
+	array( array( 'role' => 'user', 'content' => 'return to mailbox' ) ),
+	'Commented on the mailbox issue.',
+	array( 'mode' => 'pipeline' ),
+	4
+);
+assert_runtime_policy( $parameter_outcome_decision->isComplete(), 'complete_when_any required_parameters accept matching tool arguments' );
+assert_runtime_policy( array( 'mailbox_return' ) === ( $parameter_outcome_decision->context()['satisfied']['complete_when_any'] ?? null ), 'parameter-matched outcome name is reported as satisfied' );
+
+$multi_call_outcome_policy = new DataMachineHandlerCompletionPolicy(
+	array(),
+	new \DataMachine\Engine\AI\DataMachineCompletionAssertions(
+		array(
+			'complete_when_any' => array(
+				array(
+					'name'  => 'multi_file_change',
+					'tools' => array(
+						array(
+							'name'                 => 'create_or_update_github_file',
+							'min_successful_calls' => 2,
+						),
+					),
+				),
+			),
+		)
+	)
+);
+$multi_call_outcome_policy->recordToolResult( 'create_or_update_github_file', array( 'name' => 'create_or_update_github_file' ), array( 'success' => true ), array( 'mode' => 'pipeline' ), 1 );
+$multi_call_missing_decision = $multi_call_outcome_policy->recordNaturalCompletion(
+	array( array( 'role' => 'user', 'content' => 'make a multi-file change' ) ),
+	'One file changed.',
+	array( 'mode' => 'pipeline' ),
+	2
+);
+assert_runtime_policy( ! $multi_call_missing_decision->isComplete(), 'complete_when_any min_successful_calls requires enough matching successful calls' );
+$multi_call_outcome_policy->recordToolResult( 'create_or_update_github_file', array( 'name' => 'create_or_update_github_file' ), array( 'success' => true ), array( 'mode' => 'pipeline' ), 3 );
+$multi_call_decision = $multi_call_outcome_policy->recordNaturalCompletion(
+	array( array( 'role' => 'user', 'content' => 'make a multi-file change' ) ),
+	'Two files changed.',
+	array( 'mode' => 'pipeline' ),
+	4
+);
+assert_runtime_policy( $multi_call_decision->isComplete(), 'complete_when_any min_successful_calls accepts enough matching successful calls' );
 
 $daily_memory_unavailable_dispatch_count = 0;
 $daily_memory_unavailable_sink           = new RuntimePolicySmokeEventSink();


### PR DESCRIPTION
## Summary
- Add named `complete_when_any` outcomes for clearer completion diagnostics.
- Allow outcome tool assertions to match required tool parameters and minimum successful call counts.
- Document plural completion paths and cover the behavior in the runtime policy smoke test.

## Testing
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `php -l inc/Engine/AI/DataMachineCompletionAssertions.php && php -l inc/Engine/AI/DataMachineHandlerCompletionPolicy.php && php -l inc/Engine/AI/conversation-loop.php`
- `homeboy lint --path . --extension wordpress --changed-only --errors-only`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the completion assertion implementation, tests, and documentation; Chris remains responsible for review and merge.