### PR TITLE
Persist AI request metadata in pipeline transcripts

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -820,12 +820,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "4c9c94989ca152056c96ea3030a017b3433178c9"
+                "reference": "ec834af9394af25ba11a4d4f09b65f1474d3eec3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/4c9c94989ca152056c96ea3030a017b3433178c9",
-                "reference": "4c9c94989ca152056c96ea3030a017b3433178c9",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/ec834af9394af25ba11a4d4f09b65f1474d3eec3",
+                "reference": "ec834af9394af25ba11a4d4f09b65f1474d3eec3",
                 "shasum": ""
             },
             "require": {
@@ -893,7 +893,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-09T18:04:53+00:00"
+            "time": "2026-05-10T14:56:05+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -640,6 +640,7 @@ function datamachine_build_turn_runner(
 		return array(
 			'messages'                     => $messages,
 			'tool_execution_results'       => $tool_execution_results,
+			'request_metadata'             => $last_request_metadata,
 			'conversation_complete'        => $conversation_complete,
 			'completion_nudge'             => $completion_nudge ?? '',
 			'duplicate_tool_call_rejected' => $duplicate_rejected,

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -1082,6 +1082,8 @@ $result = datamachine_run_conversation(
 assert_runtime_policy( 1 === $dispatch_count, 'custom completion policy stopped the loop after one provider request' );
 assert_runtime_policy( 1 === count( $result['tool_execution_results'] ?? array() ), 'custom completion policy returned one tool result' );
 assert_runtime_policy( 1588 === ( $transcript_policy->calls[0]['payload']['job_id'] ?? null ), 'custom transcript persister receives runtime context' );
+assert_runtime_policy( isset( $result['request_metadata']['request_json_bytes'] ), 'conversation result carries request metadata' );
+assert_runtime_policy( isset( $transcript_policy->calls[0]['result']['request_metadata']['request_json_bytes'] ), 'custom transcript persister receives request metadata' );
 assert_runtime_policy( 1 === count( $completion_policy->calls ), 'custom completion policy received one tool result' );
 assert_runtime_policy( 'runtime_policy_tool' === ( $completion_policy->calls[0]['tool_name'] ?? null ), 'custom completion policy receives tool name' );
 assert_runtime_policy( 1 === count( $transcript_policy->calls ), 'custom transcript persister was called once on success' );


### PR DESCRIPTION
## Summary
- Carries Data Machine request metadata through the caller-managed conversation loop result so Agents API can persist it in pipeline transcript metadata.
- Updates the locked Agents API dependency to the merged metadata-preservation commit from Automattic/agents-api#127.
- Extends the runtime policy smoke test to assert both the loop result and transcript persister receive request metadata.

## Testing
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `php -l inc/Engine/AI/conversation-loop.php && php -l tests/agent-conversation-runtime-policy-smoke.php`

## Notes
- `homeboy lint --path . --extension wordpress` still fails on pre-existing admin JS lint/dependency findings unrelated to this PHP change.
- `php tests/ai-request-metadata-guardrails-smoke.php` currently fatals before this path on missing `WordPress\\AiClient\\Messages\\DTO\\MessagePart` in the local test dependency setup.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the transcript metadata propagation gap, drafting the PHP/test patch, and running targeted verification. Chris remains responsible for review and merge.