### PR TITLE
Harden daily memory tool schema

### DIFF
--- a/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
@@ -108,6 +108,14 @@ class AgentDailyMemory extends BaseTool {
 		}
 
 		$ability = wp_get_ability( 'datamachine/daily-memory-write' );
+		$mode    = $parameters['mode'] ?? 'append';
+
+		if ( ! in_array( $mode, array( 'append', 'write' ), true ) ) {
+			return $this->buildErrorResponse(
+				'Invalid mode "' . $mode . '". Use "append" or "write".',
+				'agent_daily_memory'
+			);
+		}
 
 		if ( ! $ability ) {
 			return $this->buildErrorResponse(
@@ -122,7 +130,7 @@ class AgentDailyMemory extends BaseTool {
 				'agent_id' => $scope['agent_id'],
 				'content'  => $content,
 				'date'     => $parameters['date'] ?? gmdate( 'Y-m-d' ),
-				'mode'     => $parameters['mode'] ?? 'append',
+				'mode'     => $mode,
 			)
 		);
 
@@ -258,6 +266,7 @@ class AgentDailyMemory extends BaseTool {
 				),
 					'action'  => array(
 					'type'        => 'string',
+					'enum'        => array( 'read', 'write', 'list', 'search' ),
 					'description' => 'Action to perform: "read" (get daily file), "write" (add to daily file), "list" (show all daily files), or "search" (find entries by keyword).',
 				),
 					'date'    => array(
@@ -270,6 +279,7 @@ class AgentDailyMemory extends BaseTool {
 				),
 					'mode'    => array(
 					'type'        => 'string',
+					'enum'        => array( 'append', 'write' ),
 					'description' => 'Write mode: "append" adds to end of file (default), "write" replaces the entire file. Prefer "append" to preserve earlier entries from the same day.',
 				),
 					'query'   => array(

--- a/tests/agent-daily-memory-pipeline-scope-smoke.php
+++ b/tests/agent-daily-memory-pipeline-scope-smoke.php
@@ -107,6 +107,22 @@ namespace {
 	echo "agent-daily-memory-pipeline-scope-smoke (#1877)\n";
 
 	$tool = new AgentDailyMemory();
+	$definition = $tool->getToolDefinition();
+	assert_daily_memory_scope(
+		array( 'read', 'write', 'list', 'search' ),
+		$definition['parameters']['properties']['action']['enum'] ?? null,
+		'action schema exposes valid enum values',
+		$failures,
+		$passes
+	);
+	assert_daily_memory_scope(
+		array( 'append', 'write' ),
+		$definition['parameters']['properties']['mode']['enum'] ?? null,
+		'mode schema exposes valid enum values',
+		$failures,
+		$passes
+	);
+
 	PermissionHelper::set_agent_context( 42, 77 );
 
 	$tool->handle_tool_call( array( 'action' => 'write', 'content' => 'entry', 'user_id' => 999 ) );
@@ -120,6 +136,30 @@ namespace {
 		),
 		$agent_daily_memory_ability_inputs['datamachine/daily-memory-write'] ?? null,
 		'write ignores model user_id and uses executing agent scope',
+		$failures,
+		$passes
+	);
+
+	$last_write_input = $agent_daily_memory_ability_inputs['datamachine/daily-memory-write'] ?? null;
+	$invalid_result   = $tool->handle_tool_call( array( 'action' => 'write', 'content' => 'bad mode', 'mode' => 'append()} bad tool args' ) );
+	assert_daily_memory_scope(
+		false,
+		$invalid_result['success'] ?? null,
+		'invalid write mode is rejected by the tool',
+		$failures,
+		$passes
+	);
+	assert_daily_memory_scope(
+		'Invalid mode "append()} bad tool args". Use "append" or "write".',
+		$invalid_result['error'] ?? null,
+		'invalid write mode returns a corrective error',
+		$failures,
+		$passes
+	);
+	assert_daily_memory_scope(
+		$last_write_input,
+		$agent_daily_memory_ability_inputs['datamachine/daily-memory-write'] ?? null,
+		'invalid write mode does not call the write ability',
 		$failures,
 		$passes
 	);


### PR DESCRIPTION
## Summary
- Adds explicit enum values to the `agent_daily_memory` tool schema for `action` and `mode` so providers receive machine-readable constraints.
- Rejects invalid write modes in the tool wrapper before dispatching to `datamachine/daily-memory-write`.
- Extends the daily-memory smoke test to cover schema enums, corrective errors, and no write ability call for malformed modes.

## Testing
- `php tests/agent-daily-memory-pipeline-scope-smoke.php`
- `php tests/global-tool-pipeline-modes-smoke.php`
- `php -l inc/Engine/AI/Tools/Global/AgentDailyMemory.php && php -l tests/agent-daily-memory-pipeline-scope-smoke.php`

## Context
A fresh World Creator transcript showed one failed `agent_daily_memory` attempt where malformed analysis-like text leaked into the `mode` argument before retrying successfully. This patch narrows the schema exposed to the model and catches malformed `mode` values at the tool boundary.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the malformed tool-call argument path, drafting the schema/guard patch, and running targeted verification. Chris remains responsible for review and merge.