### PR TITLE
Export durable agent memory artifacts

### DIFF
--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -10,7 +10,9 @@ namespace DataMachine\Core;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\FilesRepository\AgentMemory as AgentMemoryFile;
 use DataMachine\Core\FilesRepository\DailyMemory;
+use DataMachine\Engine\AI\MemoryFileRegistry;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -54,6 +56,7 @@ class JobArtifacts {
 			'satisfied_tool_names'   => $this->tool_names_from_assertions( $engine_data['completion_assertions_satisfied'] ?? array() ),
 			'successful_tool_calls'  => $tool_calls,
 			'transcript'             => $this->transcript_metadata( $job_id, $engine_data ),
+			'agent_memory_artifacts' => $this->agent_memory_artifacts( $job, $agent, $tool_calls ),
 			'daily_memory_artifacts' => $this->daily_memory_artifacts( $job, $agent, $tool_calls ),
 		);
 
@@ -112,6 +115,8 @@ class JobArtifacts {
 					'action'     => isset( $summary['action'] ) ? sanitize_key( (string) $summary['action'] ) : null,
 					'date'       => isset( $summary['date'] ) ? sanitize_text_field( (string) $summary['date'] ) : null,
 					'mode'       => isset( $summary['mode'] ) ? sanitize_key( (string) $summary['mode'] ) : null,
+					'file'       => isset( $summary['file'] ) ? sanitize_file_name( (string) $summary['file'] ) : null,
+					'section'    => isset( $summary['section'] ) ? sanitize_text_field( (string) $summary['section'] ) : null,
 					'content'    => isset( $summary['content'] ) ? (string) $summary['content'] : null,
 					'summary'    => isset( $summary['summary'] ) ? sanitize_text_field( (string) $summary['summary'] ) : null,
 				),
@@ -201,6 +206,96 @@ class JobArtifacts {
 		);
 
 		return is_string( $row ) ? $row : '';
+	}
+
+	/**
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function agent_memory_artifacts( array $job, array $agent, array $tool_calls ): array {
+		$default_agent_id = (int) ( $agent['agent_id'] ?? 0 );
+		$files            = array();
+
+		foreach ( $tool_calls as $tool_call ) {
+			if ( 'agent_memory' !== ( $tool_call['tool_name'] ?? '' ) || 'update' !== ( $tool_call['action'] ?? '' ) ) {
+				continue;
+			}
+
+			$filename = sanitize_file_name( (string) ( $tool_call['file'] ?? 'MEMORY.md' ) );
+			if ( '' === $filename ) {
+				continue;
+			}
+
+			$agent_id = (int) ( $tool_call['agent_id'] ?? $default_agent_id );
+			$user_id  = (int) ( $tool_call['user_id'] ?? ( $job['user_id'] ?? 0 ) );
+			$layer    = AgentMemoryFile::resolve_layer_for( $filename );
+			$key      = $layer . ':' . $agent_id . ':' . $user_id . ':' . $filename;
+
+			$files[ $key ] = array(
+				'agent_id' => $agent_id,
+				'user_id'  => $user_id,
+				'file'     => $filename,
+				'layer'    => $layer,
+				'section'  => isset( $tool_call['section'] ) ? (string) $tool_call['section'] : '',
+				'mode'     => isset( $tool_call['mode'] ) ? (string) $tool_call['mode'] : '',
+				'content'  => isset( $tool_call['content'] ) ? (string) $tool_call['content'] : '',
+			);
+		}
+
+		$artifacts = array();
+		foreach ( $files as $memory_scope ) {
+			$filename = (string) $memory_scope['file'];
+			$memory   = new AgentMemoryFile( (int) $memory_scope['user_id'], (int) $memory_scope['agent_id'], $filename );
+			$read     = $memory->get_all();
+			$content  = empty( $read['success'] ) ? $this->agent_memory_fallback_content( $memory_scope ) : (string) ( $read['content'] ?? '' );
+			if ( '' === $content ) {
+				continue;
+			}
+
+			$bundle_relative_path = $this->agent_memory_bundle_relative_path( (string) $memory_scope['layer'], $filename );
+			if ( '' === $bundle_relative_path ) {
+				continue;
+			}
+
+			$artifacts[] = array(
+				'type'                 => 'agent_memory',
+				'agent_id'             => (int) $memory_scope['agent_id'],
+				'agent_slug'           => $agent['agent_slug'],
+				'file'                 => $filename,
+				'layer'                => (string) $memory_scope['layer'],
+				'section'              => (string) $memory_scope['section'],
+				'source'               => 'agent-memory',
+				'bundle_relative_path' => $bundle_relative_path,
+				'content'              => $content,
+			);
+		}
+
+		return $artifacts;
+	}
+
+	private function agent_memory_bundle_relative_path( string $layer, string $filename ): string {
+		if ( MemoryFileRegistry::LAYER_AGENT === $layer ) {
+			return 'memory/agent/' . $filename;
+		}
+
+		if ( MemoryFileRegistry::LAYER_USER === $layer && 'USER.md' === $filename ) {
+			return 'memory/USER.md';
+		}
+
+		return '';
+	}
+
+	private function agent_memory_fallback_content( array $memory_scope ): string {
+		$content = trim( (string) ( $memory_scope['content'] ?? '' ) );
+		$section = trim( (string) ( $memory_scope['section'] ?? '' ) );
+		if ( '' === $content ) {
+			return '';
+		}
+
+		if ( '' === $section ) {
+			return $content . "\n";
+		}
+
+		return sprintf( "## %s\n%s\n", $section, $content );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/AgentMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentMemory.php
@@ -17,11 +17,12 @@ defined( 'ABSPATH' ) || exit;
 
 use DataMachine\Engine\AI\Tools\BaseTool;
 use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Abilities\PermissionHelper;
 
 class AgentMemory extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'agent_memory', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'abilities' => array( 'datamachine/get-agent-memory', 'datamachine/update-agent-memory', 'datamachine/list-agent-memory-sections' ) ) );
+		$this->registerTool( 'agent_memory', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline_policy' ), array( 'abilities' => array( 'datamachine/get-agent-memory', 'datamachine/update-agent-memory', 'datamachine/list-agent-memory-sections' ) ) );
 	}
 
 	/**
@@ -53,7 +54,7 @@ class AgentMemory extends BaseTool {
 	 */
 	private function handleGet( array $parameters ): array {
 		$ability = wp_get_ability( 'datamachine/get-agent-memory' );
-		$user_id = $this->resolve_user_id( $parameters );
+		$scope   = $this->resolve_scope( $parameters );
 
 		if ( ! $ability ) {
 			return $this->buildErrorResponse(
@@ -63,8 +64,9 @@ class AgentMemory extends BaseTool {
 		}
 
 		$input = array(
-			'user_id' => $user_id,
-			'section' => $parameters['section'] ?? '',
+			'user_id'  => $scope['user_id'],
+			'agent_id' => $scope['agent_id'],
+			'section'  => $parameters['section'] ?? '',
 		);
 
 		if ( ! empty( $parameters['file'] ) ) {
@@ -101,7 +103,7 @@ class AgentMemory extends BaseTool {
 		$section = $parameters['section'] ?? '';
 		$content = $parameters['content'] ?? '';
 		$mode    = $parameters['mode'] ?? 'set';
-		$user_id = $this->resolve_user_id( $parameters );
+		$scope   = $this->resolve_scope( $parameters );
 
 		if ( '' === $section ) {
 			return $this->buildErrorResponse(
@@ -127,10 +129,11 @@ class AgentMemory extends BaseTool {
 		}
 
 		$input = array(
-			'user_id' => $user_id,
-			'section' => $section,
-			'content' => $content,
-			'mode'    => $mode,
+			'user_id'  => $scope['user_id'],
+			'agent_id' => $scope['agent_id'],
+			'section'  => $section,
+			'content'  => $content,
+			'mode'     => $mode,
 		);
 
 		if ( ! empty( $parameters['file'] ) ) {
@@ -164,7 +167,7 @@ class AgentMemory extends BaseTool {
 	 */
 	private function handleListSections( array $parameters = array() ): array {
 		$ability = wp_get_ability( 'datamachine/list-agent-memory-sections' );
-		$user_id = $this->resolve_user_id( $parameters );
+		$scope   = $this->resolve_scope( $parameters );
 
 		if ( ! $ability ) {
 			return $this->buildErrorResponse(
@@ -173,7 +176,10 @@ class AgentMemory extends BaseTool {
 			);
 		}
 
-		$input = array( 'user_id' => $user_id );
+		$input = array(
+			'user_id'  => $scope['user_id'],
+			'agent_id' => $scope['agent_id'],
+		);
 
 		if ( ! empty( $parameters['file'] ) ) {
 			$input['file'] = $parameters['file'];
@@ -214,29 +220,34 @@ class AgentMemory extends BaseTool {
 				'type'       => 'object',
 				'properties' => array(
 					'user_id' => array(
-					'type'        => 'integer',
-					'description' => 'Optional WordPress user ID for layered memory context. Defaults to current user context.',
-				),
+						'type'        => 'integer',
+						'description' => 'Optional WordPress user ID for layered memory context. Defaults to current user context.',
+					),
+					'agent_id' => array(
+						'type'        => 'integer',
+						'description' => 'Optional agent ID for agent-scoped memory. In agent context, the executing agent scope is used.',
+					),
 					'action'  => array(
-					'type'        => 'string',
-					'description' => 'Action to perform: "get" (read file/section), "update" (write to section), or "list_sections" (show all section headers).',
-				),
+						'type'        => 'string',
+						'description' => 'Action to perform: "get" (read file/section), "update" (write to section), or "list_sections" (show all section headers).',
+					),
 					'file'    => array(
-					'type'        => 'string',
-					'description' => 'Target file. Defaults to MEMORY.md. Use SOUL.md, USER.md, SITE.md, etc. for other agent files.',
-				),
+						'type'        => 'string',
+						'description' => 'Target file. Defaults to MEMORY.md. Use SOUL.md, USER.md, SITE.md, etc. for other agent files.',
+					),
 					'section' => array(
-					'type'        => 'string',
-					'description' => 'Section name without "##" prefix. Required for "update". Optional for "get" (omit to read full file).',
-				),
+						'type'        => 'string',
+						'description' => 'Section name without "##" prefix. Required for "update". Optional for "get" (omit to read full file).',
+					),
 					'content' => array(
-					'type'        => 'string',
-					'description' => 'Content to write. Required for "update" action.',
-				),
+						'type'        => 'string',
+						'description' => 'Content to write. Required for "update" action.',
+					),
 					'mode'    => array(
-					'type'        => 'string',
-					'description' => 'Write mode for "update": "set" replaces section content (default), "append" adds to end of section.',
-				),
+						'type'        => 'string',
+						'description' => 'Write mode for "update": "set" replaces section content (default), "append" adds to end of section.',
+						'enum'        => array( 'set', 'append' ),
+					),
 				),
 				'required'   => array( 'action' ),
 			),
@@ -244,25 +255,35 @@ class AgentMemory extends BaseTool {
 	}
 
 	/**
-	 * Resolve scoped user ID from tool parameters.
+	 * Resolve scoped user and agent IDs from tool parameters.
 	 *
 	 * @param array $parameters Tool parameters.
-	 * @return int
+	 * @return array{user_id:int, agent_id:int}
 	 */
-	private function resolve_user_id( array $parameters ): int {
+	private function resolve_scope( array $parameters ): array {
 		$directory_manager = new DirectoryManager();
-		$raw_user_id       = (int) ( $parameters['user_id'] ?? 0 );
+
+		if ( PermissionHelper::in_agent_context() ) {
+			return array(
+				'user_id'  => PermissionHelper::acting_user_id(),
+				'agent_id' => PermissionHelper::get_acting_agent_id() ?? 0,
+			);
+		}
+
+		$raw_user_id = (int) ( $parameters['user_id'] ?? 0 );
+		$agent_id    = (int) ( $parameters['agent_id'] ?? 0 );
 
 		if ( $raw_user_id > 0 ) {
-			return $directory_manager->get_effective_user_id( $raw_user_id );
+			$user_id = $directory_manager->get_effective_user_id( $raw_user_id );
+		} else {
+			$current_user_id = get_current_user_id();
+			$user_id         = $current_user_id > 0 ? $directory_manager->get_effective_user_id( $current_user_id ) : $directory_manager->get_effective_user_id( 0 );
 		}
 
-		$current_user_id = get_current_user_id();
-		if ( $current_user_id > 0 ) {
-			return $directory_manager->get_effective_user_id( $current_user_id );
-		}
-
-		return $directory_manager->get_effective_user_id( 0 );
+		return array(
+			'user_id'  => $user_id,
+			'agent_id' => $agent_id,
+		);
 	}
 
 	/**

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -954,6 +954,18 @@ function datamachine_summarize_tool_execution_results( array $tool_execution_res
 			}
 		}
 
+		if ( 'agent_memory' === $tool_name ) {
+			$summary['user_id']  = isset( $parameters['user_id'] ) ? (int) $parameters['user_id'] : null;
+			$summary['agent_id'] = isset( $parameters['agent_id'] ) ? (int) $parameters['agent_id'] : null;
+			$summary['action']   = isset( $parameters['action'] ) ? sanitize_key( (string) $parameters['action'] ) : null;
+			$summary['file']     = isset( $parameters['file'] ) ? sanitize_file_name( (string) $parameters['file'] ) : 'MEMORY.md';
+			$summary['section']  = isset( $parameters['section'] ) ? sanitize_text_field( (string) $parameters['section'] ) : null;
+			$summary['mode']     = isset( $parameters['mode'] ) ? sanitize_key( (string) $parameters['mode'] ) : null;
+			if ( $include_content && 'update' === $summary['action'] && isset( $parameters['content'] ) ) {
+				$summary['content'] = (string) $parameters['content'];
+			}
+		}
+
 		$summaries[] = array_filter(
 			$summary,
 			static fn( $value ) => null !== $value && '' !== $value

--- a/tests/global-tool-pipeline-modes-smoke.php
+++ b/tests/global-tool-pipeline-modes-smoke.php
@@ -81,7 +81,6 @@ echo "---------------------------------------\n";
 
 $chat_only = array(
 	'queue_validator' => array( 'inc/Engine/AI/Tools/Global/QueueValidator.php', 'DataMachine\Engine\AI\Tools\Global\QueueValidator' ),
-	'agent_memory'    => array( 'inc/Engine/AI/Tools/Global/AgentMemory.php', 'DataMachine\Engine\AI\Tools\Global\AgentMemory' ),
 );
 
 foreach ( $chat_only as $tool => [ $path, $class_name ] ) {
@@ -105,6 +104,7 @@ foreach ( $chat_only as $tool => [ $path, $class_name ] ) {
 }
 
 load_global_tool_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentDailyMemory.php', 'DataMachine\Engine\AI\Tools\Global\AgentDailyMemory' );
+load_global_tool_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentMemory.php', 'DataMachine\Engine\AI\Tools\Global\AgentMemory' );
 
 $chat_tools     = resolve_tools_for_pipeline_modes( 'chat' );
 $pipeline_tools = resolve_tools_for_pipeline_modes( 'pipeline' );
@@ -123,6 +123,24 @@ assert_true_for_pipeline_modes(
 assert_true_for_pipeline_modes(
 	file_contains_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentDailyMemory.php', "array( 'chat', 'pipeline_policy' )" ),
 	'agent_daily_memory declares policy-controlled pipeline availability',
+	$failures,
+	$passes
+);
+assert_true_for_pipeline_modes(
+	isset( $chat_tools['agent_memory'] ),
+	'agent_memory resolves in chat mode',
+	$failures,
+	$passes
+);
+assert_true_for_pipeline_modes(
+	! isset( $pipeline_tools['agent_memory'] ),
+	'agent_memory does not resolve in default pipeline mode',
+	$failures,
+	$passes
+);
+assert_true_for_pipeline_modes(
+	file_contains_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentMemory.php', "array( 'chat', 'pipeline_policy' )" ),
+	'agent_memory declares policy-controlled pipeline availability',
 	$failures,
 	$passes
 );

--- a/tests/job-artifacts-daily-memory-smoke.php
+++ b/tests/job-artifacts-daily-memory-smoke.php
@@ -86,6 +86,35 @@ $assert(
 );
 
 $assert(
+	false !== strpos( $loop, "'agent_memory' === \$tool_name" )
+		&& false !== strpos( $loop, "\$summary['file']" )
+		&& false !== strpos( $loop, "\$summary['section']" )
+		&& false !== strpos( $loop, "'update' === \$summary['action']" ),
+	'agent memory update summaries preserve file, section, action, and content for artifact export'
+);
+
+$assert(
+	false !== strpos( $job_artifacts, "'agent_memory_artifacts'" )
+		&& false !== strpos( $job_artifacts, 'private function agent_memory_artifacts' )
+		&& false !== strpos( $job_artifacts, "'type'                 => 'agent_memory'" ),
+	'artifact payload includes durable agent memory artifacts'
+);
+
+$assert(
+	false !== strpos( $job_artifacts, "memory/agent/' . \$filename" )
+		&& false !== strpos( $job_artifacts, "'memory/USER.md'" )
+		&& false !== strpos( $job_artifacts, 'AgentMemoryFile::resolve_layer_for' ),
+	'agent memory artifacts map memory layers to canonical bundle-relative paths'
+);
+
+$assert(
+	false !== strpos( $job_artifacts, 'new AgentMemoryFile' )
+		&& false !== strpos( $job_artifacts, 'get_all()' )
+		&& false !== strpos( $job_artifacts, 'agent_memory_fallback_content' ),
+	'agent memory artifacts export the full updated file content with a write-content fallback'
+);
+
+$assert(
 	false !== strpos( $job_artifacts, "'type'                 => 'agent_daily_memory'" )
 		&& false !== strpos( $job_artifacts, "memory/agent/daily/%s/%s/%s.md" )
 		&& false !== strpos( $job_artifacts, "'content'              =>" ),

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -88,6 +88,7 @@ class SnapshotPolicyToolManager extends ToolManager {
 			'beta_tool'          => array( 'modes' => array( 'pipeline' ) ),
 			'danger_tool'        => array( 'modes' => array( 'pipeline' ) ),
 			'agent_daily_memory' => array( 'modes' => array( 'chat', 'pipeline_policy' ) ),
+			'agent_memory'       => array( 'modes' => array( 'chat', 'pipeline_policy' ) ),
 			'chat_only'          => array( 'modes' => array( 'chat' ) ),
 		);
 	}
@@ -158,13 +159,13 @@ $tools   = resolve_policy_tools_for_test(
 	array(
 		'step_type'        => 'ai',
 		'pipeline_step_id' => 'ephemeral_pipeline_0',
-		'enabled_tools'    => array( 'agent_daily_memory' ),
+		'enabled_tools'    => array( 'agent_daily_memory', 'agent_memory' ),
 	),
 	array(),
 	$manager
 );
-assert_policy_equals( array( 'agent_daily_memory' ), array_keys( $tools ), 'allowlist can intentionally grant policy-controlled daily memory tool', $failures, $passes );
-assert_policy_equals( array( null, null, null, null ), $manager->availability_contexts, 'policy-controlled daily memory still uses pipeline availability checks', $failures, $passes );
+assert_policy_equals( array( 'agent_daily_memory', 'agent_memory' ), array_keys( $tools ), 'allowlist can intentionally grant policy-controlled memory tools', $failures, $passes );
+assert_policy_equals( array( null, null, null, null, null ), $manager->availability_contexts, 'policy-controlled memory tools still use pipeline availability checks', $failures, $passes );
 
 echo "\n[2] ephemeral workflow disabled_tools deny from snapshot:\n";
 $ephemeral = WorkflowConfigFactory::buildEphemeralConfigs(


### PR DESCRIPTION
## Summary
- Allow `agent_memory` to be granted explicitly to pipeline AI steps through the existing policy-controlled tool path.
- Preserve successful `agent_memory` update summaries and export full durable memory files as bundle-relative job artifacts.
- Extend smoke coverage for policy-controlled memory tools and durable memory artifact metadata.

## Testing
- `php -l inc/Engine/AI/Tools/Global/AgentMemory.php`
- `php -l inc/Engine/AI/conversation-loop.php`
- `php -l inc/Core/JobArtifacts.php`
- `php tests/global-tool-pipeline-modes-smoke.php`
- `php tests/pipeline-tool-policy-snapshot-smoke.php`
- `php tests/job-artifacts-daily-memory-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and smoke coverage; Chris remains responsible for review and merge.