### PR TITLE
fix: render JSON handler settings

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepHandler.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepHandler.jsx
@@ -16,6 +16,18 @@ import { __ } from '@wordpress/i18n';
 import { useHandlers } from '../../queries/handlers';
 import { useStepTypes } from '../../queries/config';
 
+const formatDisplayValue = ( value ) => {
+	if ( value === undefined || value === null ) {
+		return '';
+	}
+
+	if ( typeof value === 'object' ) {
+		return JSON.stringify( value );
+	}
+
+	return value;
+};
+
 export default function FlowStepHandler( {
 	handlerSlug,
 	handlerSlugs,
@@ -73,7 +85,7 @@ export default function FlowStepHandler( {
 			? settings.reduce( ( acc, s ) => {
 					acc[ s.key ] = {
 						label: s.label,
-						value: s.display_value ?? s.value,
+						value: formatDisplayValue( s.display_value ?? s.value ),
 					};
 					return acc;
 			  }, {} )
@@ -90,7 +102,9 @@ export default function FlowStepHandler( {
 			return settingsDisplay.reduce( ( acc, setting ) => {
 				acc[ setting.key ] = {
 					label: setting.label,
-					value: setting.display_value ?? setting.value,
+					value: formatDisplayValue(
+						setting.display_value ?? setting.value
+					),
 				};
 				return acc;
 			}, {} );

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/handler-settings/HandlerSettingField.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/handler-settings/HandlerSettingField.jsx
@@ -15,6 +15,18 @@ import { applyFilters } from '@wordpress/hooks';
  */
 import UrlListField from './UrlListField';
 
+const formatJsonValue = ( value ) => {
+	if ( value === undefined || value === null || value === '' ) {
+		return '';
+	}
+
+	if ( typeof value === 'string' ) {
+		return value;
+	}
+
+	return JSON.stringify( value, null, 2 );
+};
+
 /**
  * Shared renderer for handler schema-driven fields.
  *
@@ -96,6 +108,20 @@ export default function HandlerSettingField( {
 						rows={ fieldConfig.rows || 4 }
 						help={ help }
 						placeholder={ fieldConfig.placeholder }
+					/>
+				</div>
+			);
+
+		case 'json':
+			return (
+				<div className={ wrapperClassName }>
+					<TextareaControl
+						label={ label }
+						value={ formatJsonValue( resolvedValue ) }
+						onChange={ handleChange }
+						rows={ fieldConfig.rows || 6 }
+						help={ help }
+						placeholder={ fieldConfig.placeholder || '{}' }
 					/>
 				</div>
 			);

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/models/HandlerModel.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/models/HandlerModel.js
@@ -3,6 +3,18 @@
  */
 import { resolveFieldValue } from '../utils/handlerSettings';
 
+const formatDisplayValue = ( value ) => {
+	if ( value === undefined || value === null ) {
+		return '';
+	}
+
+	if ( typeof value === 'object' ) {
+		return JSON.stringify( value );
+	}
+
+	return value;
+};
+
 export default class HandlerModel {
 	constructor( slug, descriptor = {}, details = {} ) {
 		this.slug = slug;
@@ -38,7 +50,9 @@ export default class HandlerModel {
 			settingsDisplay.forEach( ( setting ) => {
 				display[ setting.key ] = {
 					label: setting.label,
-					value: setting.display_value || setting.value,
+					value: formatDisplayValue(
+						setting.display_value || setting.value
+					),
 				};
 			} );
 
@@ -51,7 +65,9 @@ export default class HandlerModel {
 		Object.entries( schema ).forEach( ( [ key, config ] ) => {
 			display[ key ] = {
 				label: config.label || key,
-				value: resolveFieldValue( key, config, handlerConfig ),
+				value: formatDisplayValue(
+					resolveFieldValue( key, config, handlerConfig )
+				),
 			};
 		} );
 
@@ -97,6 +113,26 @@ export default class HandlerModel {
 			switch ( fieldConfig.type ) {
 				case 'checkbox':
 					sanitized[ key ] = !! value;
+					break;
+
+				case 'json':
+					if ( value === '' || value === undefined || value === null ) {
+						sanitized[ key ] = {};
+						break;
+					}
+
+					if ( typeof value === 'string' ) {
+						try {
+							sanitized[ key ] = JSON.parse( value );
+						} catch ( error ) {
+							throw new Error(
+								`Invalid JSON for ${ fieldConfig.label || key }.`
+							);
+						}
+						break;
+					}
+
+					sanitized[ key ] = value;
 					break;
 
 				case 'select':


### PR DESCRIPTION
## Summary
- Render schema-driven `json` fields as editable JSON textareas instead of coercing objects to `[object Object]`.
- Parse JSON field values before saving so handler settings keep object payloads.
- Format object-valued settings summaries as JSON for flow step display.

## Testing
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the frontend fix, ran the build, and prepared this PR for Chris to review.