### PR TITLE
fix: attribute system task jobs

### DIFF
--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -120,11 +120,20 @@ class ExecuteWorkflowAbility {
 		// fan-out children, scheduleBatch passing through caller
 		// linkage) can stamp the indexed parent_job_id column — the
 		// path Jobs::get_children walks for status / undo.
+		$requested_job_source = $initial_data['job_source'] ?? null;
+		$requested_job_label  = $initial_data['job_label'] ?? null;
+		$job_source           = is_string( $requested_job_source ) && '' !== $requested_job_source
+			? $requested_job_source
+			: 'chat';
+		$job_label            = is_string( $requested_job_label ) && '' !== $requested_job_label
+			? $requested_job_label
+			: 'Chat Workflow';
+
 		$create_args = array(
 			'pipeline_id' => 'direct',
 			'flow_id'     => 'direct',
-			'source'      => 'chat',
-			'label'       => 'Chat Workflow',
+			'source'      => $job_source,
+			'label'       => $job_label,
 		);
 
 		$initial_parent_job_id = (int) ( $initial_data['parent_job_id'] ?? 0 );

--- a/inc/Engine/Tasks/TaskScheduler.php
+++ b/inc/Engine/Tasks/TaskScheduler.php
@@ -142,6 +142,13 @@ class TaskScheduler {
 			$job_snapshot['agent_slug'] = $context_agent_slug;
 		}
 
+		$task_meta = method_exists( $handler_class, 'getTaskMeta' )
+			? $handler_class::getTaskMeta()
+			: array();
+		$job_label = ! empty( $task_meta['label'] )
+			? $task_meta['label']
+			: ucfirst( str_replace( '_', ' ', $taskType ) );
+
 		$result = $ability->execute( array(
 			'workflow'     => $workflow,
 			'timestamp'    => $params['scheduled_at'] ?? null,
@@ -149,6 +156,8 @@ class TaskScheduler {
 				'task_type'     => $taskType,
 				'task_params'   => $params,
 				'task_context'  => $context,
+				'job_source'    => 'system',
+				'job_label'     => $job_label,
 				'parent_job_id' => $parentJobId,
 				'user_id'       => $context_user_id,
 				'agent_id'      => $context_agent_id,

--- a/tests/system-run-task-params-smoke.php
+++ b/tests/system-run-task-params-smoke.php
@@ -150,6 +150,8 @@ function smoke_build_task_scheduler_initial_data( string $task_type, array $para
 		'task_type'     => $task_type,
 		'task_params'   => $params,
 		'task_context'  => array(),
+		'job_source'    => 'system',
+		'job_label'     => ucfirst( str_replace( '_', ' ', $task_type ) ),
 		'parent_job_id' => 0,
 		'user_id'       => 0,
 		'agent_id'      => 0,
@@ -225,6 +227,8 @@ $scheduled_params = array(
 );
 $initial          = smoke_build_task_scheduler_initial_data( 'wiki_maintain', $scheduled_params );
 $assert( 'TaskScheduler initial_data stores task_params', $scheduled_params === $initial['task_params'] );
+$assert( 'TaskScheduler marks run-now jobs as system jobs', 'system' === $initial['job_source'] );
+$assert( 'TaskScheduler labels system task jobs from task type', 'Wiki maintain' === $initial['job_label'] );
 $workflow = smoke_default_system_task_workflow( 'wiki_maintain', $initial['task_params'] );
 $assert( 'SystemTask workflow stores params in flow_step_settings', $scheduled_params === $workflow['steps'][0]['flow_step_settings']['params'] );
 
@@ -232,6 +236,8 @@ echo "\n[4] Source tripwires\n";
 $system_command = file_get_contents( __DIR__ . '/../inc/Cli/Commands/SystemCommand.php' );
 $abilities      = file_get_contents( __DIR__ . '/../inc/Abilities/SystemAbilities.php' );
 $registry       = file_get_contents( __DIR__ . '/../inc/Engine/Tasks/TaskRegistry.php' );
+$scheduler        = file_get_contents( __DIR__ . '/../inc/Engine/Tasks/TaskScheduler.php' );
+$workflow_ability = file_get_contents( __DIR__ . '/../inc/Abilities/Job/ExecuteWorkflowAbility.php' );
 $assert( 'CLI avoids invalid --param key=value synopsis placeholder', ! str_contains( $system_command, '[--param=<key=value>]' ) );
 $assert( 'CLI documents valid --param synopsis placeholder', str_contains( $system_command, '[--param=<param>]' ) );
 $assert( 'CLI documents --param key=value semantics', str_contains( $system_command, 'Structured task param as key=value. Repeatable.' ) );
@@ -240,6 +246,8 @@ $assert( 'run-task ability schema accepts task_params', str_contains( $abilities
 $assert( 'run-task ability schedules merged task params', str_contains( $abilities, 'array_merge( $task_params' ) );
 $assert( 'TaskRegistry exposes mutates metadata', str_contains( $registry, "'mutates'" ) );
 $assert( 'TaskRegistry exposes requires_scope metadata', str_contains( $registry, "'requires_scope'" ) );
+$assert( 'TaskScheduler passes system job source to execute-workflow', str_contains( $scheduler, "'job_source'    => 'system'" ) );
+$assert( 'execute-workflow honors caller job source', str_contains( $workflow_ability, "'source'      => $" . 'job_source' ) );
 
 echo "\nAssertions: {$total}, Failures: {$failures}\n";
 if ( $failures > 0 ) {


### PR DESCRIPTION
## Summary
- Mark manually scheduled system tasks as `system` jobs instead of generic chat/direct jobs.
- Let `execute-workflow` honor caller-provided job source and label while preserving existing defaults for other callers.
- Add smoke-test tripwires for system task job attribution.

## Testing
- `php tests/system-run-task-params-smoke.php`
- `php tests/system-task-agent-context-smoke.php`
- `php -l inc/Engine/Tasks/TaskScheduler.php`
- `php -l inc/Abilities/Job/ExecuteWorkflowAbility.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the system task Run Now job attribution path, implemented the focused PHP/test changes, and ran verification commands.