### PR TITLE
Fix pipelines page AI handler request

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/PipelinesFilters.php
+++ b/inc/Core/Admin/Pages/Pipelines/PipelinesFilters.php
@@ -67,7 +67,7 @@ function datamachine_register_pipelines_admin_page_filters() {
 						// React bundle (only script needed)
 						'datamachine-pipelines-react' => array(
 							'file'      => 'inc/Core/Admin/assets/build/pipelines-react.js',
-							'deps'      => array( 'wp-element', 'wp-components', 'wp-i18n', 'wp-api-fetch', 'wp-data', 'wp-dom-ready', 'wp-notices', 'wp-hooks' ),
+							'deps'      => array( 'wp-element', 'wp-components', 'wp-i18n', 'wp-api-fetch', 'wp-dom-ready', 'wp-hooks' ),
 							'in_footer' => true,
 							'localize'  => array(
 								'object' => 'dataMachineConfig',

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx
@@ -8,7 +8,14 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useCallback, useState, useMemo } from '@wordpress/element';
+import {
+	useEffect,
+	useCallback,
+	useState,
+	useMemo,
+	lazy,
+	Suspense,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Spinner, Notice, Button } from '@wordpress/components';
 /**
@@ -27,12 +34,13 @@ import { useSettings } from '@shared/queries/settings';
 import { useUIStore } from './stores/uiStore';
 import PipelineCard from './components/pipelines/PipelineCard';
 import PipelineSelector from './components/pipelines/PipelineSelector';
-import ModalManager from './components/shared/ModalManager';
 import ChatToggle from './components/chat/ChatToggle';
-import ChatSidebar from './components/chat/ChatSidebar';
 import AgentSwitcher from '@shared/components/AgentSwitcher';
 import { MODAL_TYPES } from './utils/constants';
 import { isSameId } from './utils/ids';
+
+const ModalManager = lazy( () => import( './components/shared/ModalManager' ) );
+const ChatSidebar = lazy( () => import( './components/chat/ChatSidebar' ) );
 
 /**
  * Root application component
@@ -46,6 +54,7 @@ export default function PipelinesApp() {
 		setSelectedPipelineId,
 		openModal,
 		isChatOpen,
+		activeModal,
 	} = useUIStore();
 
 	// Check if Zustand has finished hydrating from localStorage
@@ -252,7 +261,11 @@ export default function PipelinesApp() {
 					onFlowsPageChange={ setFlowsPage }
 				/>
 
-				<ModalManager />
+				{ activeModal && (
+					<Suspense fallback={ null }>
+						<ModalManager />
+					</Suspense>
+				) }
 			</>
 		);
 	};
@@ -290,7 +303,11 @@ export default function PipelinesApp() {
 				{ renderMainContent() }
 			</div>
 
-			{ isChatOpen && <ChatSidebar /> }
+			{ isChatOpen && (
+				<Suspense fallback={ null }>
+					<ChatSidebar />
+				</Suspense>
+			) }
 		</div>
 	);
 }

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
@@ -53,12 +53,14 @@ export default function FlowStepCard( {
 	const usesHandler = stepTypeInfo.uses_handler === true;
 	const isMultiHandlerStep = stepTypeInfo.multi_handler === true;
 	const handlerSlugs = isMultiHandlerStep
-		? ( flowStepConfig?.handler_slugs || [] )
-		: ( flowStepConfig?.handler_slug ? [ flowStepConfig.handler_slug ] : [] );
-	const primarySlug = handlerSlugs[0] || '';
+		? flowStepConfig?.handler_slugs || []
+		: flowStepConfig?.handler_slug
+		? [ flowStepConfig.handler_slug ]
+		: [];
+	const primarySlug = handlerSlugs[ 0 ] || '';
 	const primaryConfig = isMultiHandlerStep
-		? ( primarySlug && flowStepConfig?.handler_configs?.[primarySlug] )
-		: ( flowStepConfig?.handler_config || {} );
+		? primarySlug && flowStepConfig?.handler_configs?.[ primarySlug ]
+		: flowStepConfig?.handler_config || {};
 
 	const promptQueue = flowStepConfig.prompt_queue || [];
 	const rawQueueMode = flowStepConfig.queue_mode;
@@ -85,10 +87,10 @@ export default function FlowStepCard( {
 	// Determine if this step type shows a prompt field.
 	// AI steps always get it. Other steps get it if they have a prompt in handler_config
 	// or if queue is enabled/has items.
-	const hasPromptConfig = primaryConfig && (
-		primaryConfig.prompt !== undefined ||
-		primaryConfig.params?.prompt !== undefined
-	);
+	const hasPromptConfig =
+		primaryConfig &&
+		( primaryConfig.prompt !== undefined ||
+			primaryConfig.params?.prompt !== undefined );
 	const showPromptField = isAiStep || shouldShowQueue || hasPromptConfig;
 
 	// Fields to exclude from inline config (handled by QueueablePromptField).
@@ -128,20 +130,32 @@ export default function FlowStepCard( {
 					};
 				}
 
-				const response = await updateFlowStepConfig( flowStepId, config );
+				const response = await updateFlowStepConfig(
+					flowStepId,
+					config
+				);
 				if ( ! response?.success ) {
-					setError( response?.message || __( 'Failed to save', 'data-machine' ) );
+					setError(
+						response?.message ||
+							__( 'Failed to save', 'data-machine' )
+					);
 				}
 			} catch ( err ) {
 				// eslint-disable-next-line no-console
 				console.error( 'Prompt save error:', err );
-				setError( err.message || __( 'An error occurred', 'data-machine' ) );
+				setError(
+					err.message || __( 'An error occurred', 'data-machine' )
+				);
 			}
 		},
 		[ flowStepId, isAiStep, primaryConfig ]
 	);
 
-	const effectiveHandlerSlug = usesHandler ? primarySlug : pipelineStep.step_type;
+	const effectiveHandlerSlug = usesHandler
+		? primarySlug
+		: pipelineStep.step_type;
+	const shouldShowInlineConfig =
+		! usesHandler && ! isAiStep && effectiveHandlerSlug;
 
 	return (
 		<Card
@@ -175,11 +189,13 @@ export default function FlowStepCard( {
 					   Handler-based steps show their settings in the configuration modal,
 					   not inline on the card. Non-handler step types (Agent Ping, Webhook Gate)
 					   render their fields here via the handler details API fallback. */ }
-					{ ! usesHandler && effectiveHandlerSlug && (
-					<InlineStepConfig
-						flowStepId={ flowStepId }
-						handlerConfig={ flowStepConfig?.handler_config || {} }
-						handlerSlug={ effectiveHandlerSlug }
+					{ shouldShowInlineConfig && (
+						<InlineStepConfig
+							flowStepId={ flowStepId }
+							handlerConfig={
+								flowStepConfig?.handler_config || {}
+							}
+							handlerSlug={ effectiveHandlerSlug }
 							excludeFields={ excludeFields }
 							onError={ setError }
 							pipelineId={ pipelineId }
@@ -198,8 +214,14 @@ export default function FlowStepCard( {
 							queueMode={ queueMode }
 							placeholder={
 								isAiStep
-									? __( 'Enter user message for AI processing…', 'data-machine' )
-									: __( 'Enter instructions…', 'data-machine' )
+									? __(
+											'Enter user message for AI processing…',
+											'data-machine'
+									  )
+									: __(
+											'Enter instructions…',
+											'data-machine'
+									  )
 							}
 							label={ __( 'User Message', 'data-machine' ) }
 							onSave={ handlePromptSave }
@@ -210,17 +232,31 @@ export default function FlowStepCard( {
 
 					{ /* Handler Configuration (handler-based steps only) */ }
 					{ usesHandler && (
-					<FlowStepHandler
-						handlerSlug={ primarySlug || null }
-							handlerSlugs={ handlerSlugs.length ? handlerSlugs : null }
-							settingsDisplay={ flowStepConfig.settings_display || [] }
-							handlerSettingsDisplays={ flowStepConfig.handler_settings_displays || null }
+						<FlowStepHandler
+							handlerSlug={ primarySlug || null }
+							handlerSlugs={
+								handlerSlugs.length ? handlerSlugs : null
+							}
+							settingsDisplay={
+								flowStepConfig.settings_display || []
+							}
+							handlerSettingsDisplays={
+								flowStepConfig.handler_settings_displays || null
+							}
 							onConfigure={ ( slug ) =>
 								onConfigure && onConfigure( flowStepId, slug )
 							}
-							onAddHandler={ isMultiHandlerStep ? () =>
-								onConfigure && onConfigure( flowStepId, null, true )
-							: undefined }
+							onAddHandler={
+								isMultiHandlerStep
+									? () =>
+											onConfigure &&
+											onConfigure(
+												flowStepId,
+												null,
+												true
+											)
+									: undefined
+							}
 							showConfigureButton
 							showBadge
 						/>


### PR DESCRIPTION
## Summary
- Prevent AI flow steps from rendering inline handler settings, avoiding an invalid `/handlers/ai` REST request.
- Lazy-load the pipelines modal manager and chat sidebar so initial page load does not include those heavier surfaces.
- Remove unused `wp-data` and `wp-notices` script dependencies from the pipelines page registration.

## Testing
- `npm run build`
- `php -l inc/Core/Admin/Pages/Pipelines/PipelinesFilters.php`
- `git diff --check`
- `npx wp-scripts lint-js inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx` (fails on pre-existing lint issues in these files: invalid `@pattern` JSDoc, JSDoc alignment/undefined JSX, unused `pipelineConfig`, nested ternary, hook dependency warnings)
- Profiled the fixed worktree against `intelligence-chubes4` with the Homeboy Rigs WordPress page profiler existing-site workflow; `/wp-json/datamachine/v1/handlers/ai` no longer appears, page status was 200.

## Evidence
- Raw profile artifact: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-rig-existing-site/studio-wordpress-page-diagnostics-artifacts/studio-combined-existing-site-datamachine-pipelines-diagnostics-33807-1778450934113-1dhhivrs173/result-studio-combined-existing-site-datamachine-pipelines-diagnostics-33807-1778450934113-1dhhivrs173.json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the pipelines page profiler findings, drafted the code changes, ran build/static checks, and captured profiler evidence for Chris to review.