### PR TITLE
Fix completion assertion assignment alignment

### DIFF
--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -42,11 +42,11 @@ class DataMachineCompletionAssertions {
 	 * @param array $config Assertion config.
 	 */
 	public function __construct( array $config = array() ) {
-		$this->required_engine_data_keys       = $this->sanitizeList( $config['required_engine_data_keys'] ?? array() );
-		$this->required_tool_names             = $this->sanitizeList( $config['required_tool_names'] ?? array() );
+		$this->required_engine_data_keys      = $this->sanitizeList( $config['required_engine_data_keys'] ?? array() );
+		$this->required_tool_names            = $this->sanitizeList( $config['required_tool_names'] ?? array() );
 		$this->minimum_successful_tool_counts = $this->sanitizeToolCountMap( $config['minimum_successful_tool_counts'] ?? array() );
-		$this->required_output_packet_types    = $this->sanitizeList( $config['required_output_packet_types'] ?? array() );
-		$this->complete_when_any               = $this->sanitizeOutcomeAssertions( $config['complete_when_any'] ?? array() );
+		$this->required_output_packet_types   = $this->sanitizeList( $config['required_output_packet_types'] ?? array() );
+		$this->complete_when_any              = $this->sanitizeOutcomeAssertions( $config['complete_when_any'] ?? array() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Fix PHPCS assignment alignment warnings introduced by the minimum tool-count completion assertion change.

## Testing
- `php -l inc/Engine/AI/DataMachineCompletionAssertions.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-tool-count-lint --changed-since origin/main`

## Notes
- `php tests/agent-conversation-runtime-policy-smoke.php` was not rerun in this fresh worktree because composer dependencies were not installed there; the same smoke test passed on the implementation branch before merge.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the formatting-only follow-up fix for human review.