### PR TITLE
Fix handler-backed flow step rendering during config load

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
@@ -50,7 +50,7 @@ export default function FlowStepCard( {
 	const stepTypeInfo = stepTypes[ pipelineStep.step_type ] || {};
 
 	const isAiStep = pipelineStep.step_type === 'ai';
-	const usesHandler = stepTypeInfo.uses_handler === true;
+	const usesHandler = stepTypeInfo.uses_handler !== false;
 	const isMultiHandlerStep = stepTypeInfo.multi_handler === true;
 	const handlerSlugs = isMultiHandlerStep
 		? flowStepConfig?.handler_slugs || []


### PR DESCRIPTION
## Summary
- Treat flow steps as handler-backed unless their loaded step type explicitly says `uses_handler: false`.
- Prevent handler-backed step types like `fetch` and `upsert` from briefly rendering through the non-handler inline config path while step type metadata is still loading.
- Removes the remaining `/handlers/fetch` and `/handlers/upsert` 404s from the Pipelines admin page waterfall.

## Testing
- `npm run build`
- `php -l inc/Core/Admin/Pages/Pipelines/PipelinesFilters.php`
- `git diff --check`
- Re-profiled Pipelines with Homeboy Rigs existing-site profiler and network-idle readiness: `failed: 0`.

## Evidence
- Raw profile artifact: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/dm-admin-pages-networkidle-fixed/studio-wordpress-page-diagnostics-artifacts/dm-admin-pages-networkidle-fixed-datamachine-pipelines-diagnostics-66701-1778460597668-tvanujw5lb/result-dm-admin-pages-networkidle-fixed-datamachine-pipelines-diagnostics-66701-1778460597668-tvanujw5lb.json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the remaining Pipelines waterfall 404s, drafted the one-line rendering fix, ran build/static checks, and captured profiler evidence for Chris to review.