### PR TITLE
fix: preserve minimum tool count assertions

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -611,6 +611,14 @@ class AIStep extends Step {
 			}
 		}
 
+		$minimum_successful_tool_counts = array_merge(
+			self::normalizeCompletionAssertionCountMap( $pipeline_assertions['minimum_successful_tool_counts'] ?? array() ),
+			self::normalizeCompletionAssertionCountMap( $flow_assertions['minimum_successful_tool_counts'] ?? array() )
+		);
+		if ( ! empty( $minimum_successful_tool_counts ) ) {
+			$merged['minimum_successful_tool_counts'] = $minimum_successful_tool_counts;
+		}
+
 		$complete_when_any = array_merge(
 			is_array( $pipeline_assertions['complete_when_any'] ?? null ) ? $pipeline_assertions['complete_when_any'] : array(),
 			is_array( $flow_assertions['complete_when_any'] ?? null ) ? $flow_assertions['complete_when_any'] : array()
@@ -643,6 +651,27 @@ class AIStep extends Step {
 		}
 
 		return $items;
+	}
+
+	/**
+	 * @param mixed $value Raw assertion count map.
+	 * @return array<string, int>
+	 */
+	private static function normalizeCompletionAssertionCountMap( $value ): array {
+		if ( ! is_array( $value ) || array_is_list( $value ) ) {
+			return array();
+		}
+
+		$counts = array();
+		foreach ( $value as $tool_name => $minimum_count ) {
+			$tool_name     = trim( (string) $tool_name );
+			$minimum_count = (int) $minimum_count;
+			if ( '' !== $tool_name && $minimum_count > 0 ) {
+				$counts[ $tool_name ] = $minimum_count;
+			}
+		}
+
+		return $counts;
 	}
 
 	/**

--- a/tests/Unit/Core/Steps/AI/AIStepTest.php
+++ b/tests/Unit/Core/Steps/AI/AIStepTest.php
@@ -80,6 +80,41 @@ class AIStepTest extends TestCase {
 		$this->assertSame( $data_packets, AIStep::sanitizeDataPacketsForAi( $data_packets ) );
 	}
 
+	public function test_merge_completion_assertions_preserves_minimum_successful_tool_counts(): void {
+		$method = new ReflectionMethod( AIStep::class, 'mergeCompletionAssertions' );
+		$method->setAccessible( true );
+
+		$merged = $method->invoke(
+			null,
+			array(
+				'required_tool_names'             => array( 'create_github_pull_request' ),
+				'minimum_successful_tool_counts' => array(
+					'create_or_update_github_file' => 3,
+					'ignored_zero_count'           => 0,
+				),
+			),
+			array(
+				'required_tool_names'             => array( 'comment_github_pull_request' ),
+				'minimum_successful_tool_counts' => array(
+					'create_or_update_github_file' => 6,
+					'custom_tool'                  => '2',
+				),
+			)
+		);
+
+		$this->assertSame(
+			array( 'create_github_pull_request', 'comment_github_pull_request' ),
+			$merged['required_tool_names']
+		);
+		$this->assertSame(
+			array(
+				'create_or_update_github_file' => 6,
+				'custom_tool'                  => 2,
+			),
+			$merged['minimum_successful_tool_counts']
+		);
+	}
+
 	public function test_prompt_projection_generic_fallback_preserves_unknown_packet_shape(): void {
 		$canonical = array(
 			array(


### PR DESCRIPTION
## Summary
- Preserve `minimum_successful_tool_counts` when AIStep merges pipeline-level and flow-level completion assertions.
- Normalize count assertions before passing them to the generic completion assertion engine.
- Add regression coverage for count assertion merging and flow override behavior.

## Testing
- `composer test -- --filter AIStepTest`
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `composer lint`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the assertion propagation gap, drafted the patch and regression test, and ran focused validation. Chris remains responsible for review and merge.