### PR TITLE
Avoid embedded flows during pipeline hydration

### DIFF
--- a/inc/Abilities/Pipeline/GetPipelinesAbility.php
+++ b/inc/Abilities/Pipeline/GetPipelinesAbility.php
@@ -125,9 +125,9 @@ class GetPipelinesAbility {
 				$output_mode = 'full';
 			}
 
-			// Direct pipeline lookup by ID - bypasses pagination.
-			// Single-pipeline fetches always embed flows for backward compatibility
-			// (this is what callers like the REST /pipelines/{id} endpoint rely on).
+			// Direct pipeline lookup by ID bypasses pagination. It embeds flows by
+			// default for existing callers, while list-style hydration can explicitly
+			// opt out with include_flows=false.
 			if ( null !== $pipeline_id ) {
 				if ( ! is_numeric( $pipeline_id ) || (int) $pipeline_id <= 0 ) {
 					return array(
@@ -152,7 +152,7 @@ class GetPipelinesAbility {
 				$formatted_pipeline = $this->formatPipelineByMode(
 					$pipeline,
 					$output_mode,
-					true
+					$include_flows
 				);
 
 				return array(

--- a/inc/Abilities/Pipeline/GetPipelinesAbility.php
+++ b/inc/Abilities/Pipeline/GetPipelinesAbility.php
@@ -35,37 +35,37 @@ class GetPipelinesAbility {
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
-							'pipeline_id' => array(
+							'pipeline_id'   => array(
 								'type'        => array( 'integer', 'null' ),
 								'description' => __( 'Get a specific pipeline by ID (ignores pagination when provided)', 'data-machine' ),
 							),
-							'user_id'     => array(
+							'user_id'       => array(
 								'type'        => 'integer',
 								'description' => __( 'Filter pipelines by WordPress user ID. Defaults to 0 (shared/legacy).', 'data-machine' ),
 								'default'     => 0,
 							),
-							'agent_id'    => array(
+							'agent_id'      => array(
 								'type'        => array( 'integer', 'null' ),
 								'description' => __( 'Filter pipelines by agent ID. Takes priority over user_id when provided.', 'data-machine' ),
 							),
-							'per_page'    => array(
+							'per_page'      => array(
 								'type'        => 'integer',
 								'default'     => self::DEFAULT_PER_PAGE,
 								'minimum'     => 1,
 								'maximum'     => 100,
 								'description' => __( 'Number of pipelines per page', 'data-machine' ),
 							),
-							'offset'      => array(
+							'offset'        => array(
 								'type'        => 'integer',
 								'default'     => 0,
 								'minimum'     => 0,
 								'description' => __( 'Offset for pagination', 'data-machine' ),
 							),
-							'search'      => array(
+							'search'        => array(
 								'type'        => array( 'string', 'null' ),
 								'description' => __( 'Search pipelines by name (SQL LIKE match)', 'data-machine' ),
 							),
-							'output_mode' => array(
+							'output_mode'   => array(
 								'type'        => 'string',
 								'enum'        => array( 'full', 'summary', 'ids' ),
 								'default'     => 'full',

--- a/inc/Api/Pipelines/Pipelines.php
+++ b/inc/Api/Pipelines/Pipelines.php
@@ -46,13 +46,13 @@ class Pipelines {
 					'callback'            => array( self::class, 'handle_get_pipelines' ),
 					'permission_callback' => array( self::class, 'check_permission' ),
 					'args'                => array(
-						'pipeline_id' => array(
+						'pipeline_id'   => array(
 							'required'          => false,
 							'type'              => 'integer',
 							'description'       => __( 'Pipeline ID to retrieve (omit for all pipelines)', 'data-machine' ),
 							'sanitize_callback' => 'absint',
 						),
-						'fields'      => array(
+						'fields'        => array(
 							'required'          => false,
 							'type'              => 'string',
 							'description'       => __( 'Comma-separated list of fields to return', 'data-machine' ),
@@ -60,7 +60,7 @@ class Pipelines {
 								return sanitize_text_field( $param );
 							},
 						),
-						'format'      => array(
+						'format'        => array(
 							'required'          => false,
 							'type'              => 'string',
 							'default'           => 'json',
@@ -68,25 +68,25 @@ class Pipelines {
 							'description'       => __( 'Response format (json or csv)', 'data-machine' ),
 							'sanitize_callback' => 'sanitize_text_field',
 						),
-						'ids'         => array(
+						'ids'           => array(
 							'required'          => false,
 							'type'              => 'string',
 							'description'       => __( 'Comma-separated pipeline IDs for export', 'data-machine' ),
 							'sanitize_callback' => 'sanitize_text_field',
 						),
-						'user_id'     => array(
+						'user_id'       => array(
 							'required'          => false,
 							'type'              => 'integer',
 							'description'       => __( 'Filter by user ID (admin only, non-admins always see own data)', 'data-machine' ),
 							'sanitize_callback' => 'absint',
 						),
-						'search'      => array(
+						'search'        => array(
 							'required'          => false,
 							'type'              => 'string',
 							'description'       => __( 'Filter pipelines by name (substring match)', 'data-machine' ),
 							'sanitize_callback' => 'sanitize_text_field',
 						),
-						'per_page'    => array(
+						'per_page'      => array(
 							'required'          => false,
 							'type'              => 'integer',
 							'default'           => 20,
@@ -95,7 +95,7 @@ class Pipelines {
 							'description'       => __( 'Number of pipelines per page', 'data-machine' ),
 							'sanitize_callback' => 'absint',
 						),
-						'offset'      => array(
+						'offset'        => array(
 							'required'          => false,
 							'type'              => 'integer',
 							'default'           => 0,
@@ -278,16 +278,16 @@ class Pipelines {
 	 * Handle pipeline retrieval request
 	 */
 	public static function handle_get_pipelines( $request ) {
-		$pipeline_id     = $request->get_param( 'pipeline_id' );
-		$fields          = $request->get_param( 'fields' );
-		$format          = $request->get_param( 'format' ) ?? 'json';
-		$ids             = $request->get_param( 'ids' );
-		$search          = $request->get_param( 'search' );
-		$per_page_param  = $request->get_param( 'per_page' );
-		$offset_param    = $request->get_param( 'offset' );
+		$pipeline_id         = $request->get_param( 'pipeline_id' );
+		$fields              = $request->get_param( 'fields' );
+		$format              = $request->get_param( 'format' ) ?? 'json';
+		$ids                 = $request->get_param( 'ids' );
+		$search              = $request->get_param( 'search' );
+		$per_page_param      = $request->get_param( 'per_page' );
+		$offset_param        = $request->get_param( 'offset' );
 		$include_flows_param = $request->get_param( 'include_flows' );
-		$scoped_user_id  = PermissionHelper::resolve_scoped_user_id( $request );
-		$scoped_agent_id = PermissionHelper::resolve_scoped_agent_id( $request );
+		$scoped_user_id      = PermissionHelper::resolve_scoped_user_id( $request );
+		$scoped_agent_id     = PermissionHelper::resolve_scoped_agent_id( $request );
 
 		// Handle CSV export
 		if ( 'csv' === $format ) {

--- a/inc/Api/Pipelines/Pipelines.php
+++ b/inc/Api/Pipelines/Pipelines.php
@@ -331,6 +331,9 @@ class Pipelines {
 				'pipeline_id' => (int) $pipeline_id,
 				'output_mode' => 'full',
 			);
+			if ( null !== $include_flows_param ) {
+				$input['include_flows'] = (bool) $include_flows_param;
+			}
 			if ( null !== $scoped_agent_id ) {
 				$input['agent_id'] = $scoped_agent_id;
 			} elseif ( null !== $scoped_user_id ) {

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineSelector.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineSelector.jsx
@@ -19,7 +19,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { usePipelineSearch, usePipeline } from '../../queries/pipelines';
+import {
+	usePipelines,
+	usePipelineSearch,
+	usePipeline,
+} from '../../queries/pipelines';
 import { useUIStore } from '../../stores/uiStore';
 import { isSameId } from '../../utils/ids';
 
@@ -53,13 +57,16 @@ export default function PipelineSelector() {
 		};
 	}, [ inputValue ] );
 
-	const {
-		data: searchData,
-		isLoading: searchLoading,
-	} = usePipelineSearch( { search: debouncedSearch } );
+	const normalizedSearch = debouncedSearch.trim();
+	const { data: pipelines = [], isLoading: pipelinesLoading } = usePipelines();
+	const { data: searchData, isLoading: searchLoading } = usePipelineSearch( {
+		search: normalizedSearch,
+		enabled: normalizedSearch !== '',
+	} );
 
-	const results = searchData?.pipelines ?? [];
-	const total = searchData?.total ?? 0;
+	const results = normalizedSearch ? searchData?.pipelines ?? [] : pipelines;
+	const total = normalizedSearch ? searchData?.total ?? 0 : results.length;
+	const isLoading = normalizedSearch ? searchLoading : pipelinesLoading;
 
 	// Keep the selected pipeline visible in the list even when the search
 	// filters it out. Falls back to a single-pipeline fetch if the selection
@@ -120,7 +127,7 @@ export default function PipelineSelector() {
 	 * keep the selector visible while a search is in-flight so the UI does not
 	 * flicker between states.
 	 */
-	if ( ! selectedPipelineId && options.length === 0 && ! searchLoading ) {
+	if ( ! selectedPipelineId && options.length === 0 && ! isLoading ) {
 		return null;
 	}
 
@@ -137,7 +144,9 @@ export default function PipelineSelector() {
 
 	// When results are capped, surface a hint so users know to refine search.
 	const showOverflowHint =
-		total > results.length && options.length >= results.length;
+		normalizedSearch &&
+		total > results.length &&
+		options.length >= results.length;
 
 	return (
 		<div className="datamachine-pipeline-selector-wrapper datamachine-spacing--margin-bottom-20">

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineSelector.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineSelector.jsx
@@ -15,7 +15,7 @@
  */
 import { ComboboxControl } from '@wordpress/components';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -28,6 +28,7 @@ import { useUIStore } from '../../stores/uiStore';
 import { isSameId } from '../../utils/ids';
 
 const SEARCH_DEBOUNCE_MS = 200;
+const EMPTY_PIPELINES = [];
 
 /**
  * Pipeline combobox selector with server-side search.
@@ -64,7 +65,11 @@ export default function PipelineSelector() {
 		enabled: normalizedSearch !== '',
 	} );
 
-	const results = normalizedSearch ? searchData?.pipelines ?? [] : pipelines;
+	const searchResults = searchData?.pipelines ?? EMPTY_PIPELINES;
+	const results = useMemo(
+		() => ( normalizedSearch ? searchResults : pipelines ),
+		[ normalizedSearch, searchResults, pipelines ]
+	);
 	const total = normalizedSearch ? searchData?.total ?? 0 : results.length;
 	const isLoading = normalizedSearch ? searchLoading : pipelinesLoading;
 
@@ -162,12 +167,15 @@ export default function PipelineSelector() {
 			/>
 			{ showOverflowHint && (
 				<p className="datamachine-pipeline-selector__hint datamachine-color--text-muted">
-					{ __(
-						'Showing first %1$d of %2$d pipelines. Keep typing to narrow the list.',
-						'data-machine'
-					)
-						.replace( '%1$d', results.length )
-						.replace( '%2$d', total ) }
+					{ sprintf(
+						/* translators: 1: displayed pipeline count, 2: total matching pipeline count. */
+						__(
+							'Showing first %1$d of %2$d pipelines. Keep typing to narrow the list.',
+							'data-machine'
+						),
+						results.length,
+						total
+					) }
 				</p>
 			) }
 		</div>

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
@@ -59,9 +59,14 @@ export const usePipelines = () =>
  *
  * @param {Object} [options]
  * @param {string} [options.search]  Filter by pipeline_name substring.
- * @param {number} [options.perPage] Items per page (default 50).
+ * @param {number}  [options.perPage] Items per page (default 50).
+ * @param {boolean} [options.enabled] Whether the search query should run.
  */
-export const usePipelineSearch = ( { search = '', perPage = 50 } = {} ) => {
+export const usePipelineSearch = ( {
+	search = '',
+	perPage = 50,
+	enabled = true,
+} = {} ) => {
 	const normalizedSearch = search ? search.trim() : '';
 
 	return useQuery( {
@@ -81,6 +86,7 @@ export const usePipelineSearch = ( { search = '', perPage = 50 } = {} ) => {
 				total: response.total ?? response.data.total ?? 0,
 			};
 		},
+		enabled,
 		keepPreviousData: true,
 		staleTime: 5_000,
 	} );

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
@@ -57,8 +57,8 @@ export const usePipelines = () =>
  * Server-side search for pipelines — debounce the `search` argument in the
  * caller. Designed for the PipelineSelector and similar typeahead UIs.
  *
- * @param {Object} [options]
- * @param {string} [options.search]  Filter by pipeline_name substring.
+ * @param {Object}  [options]         Search options.
+ * @param {string}  [options.search]  Filter by pipeline_name substring.
  * @param {number}  [options.perPage] Items per page (default 50).
  * @param {boolean} [options.enabled] Whether the search query should run.
  */

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
@@ -113,7 +113,9 @@ export const usePipeline = ( pipelineId ) => {
 				}
 			}
 
-			const response = await fetchPipelines( pipelineId );
+			const response = await fetchPipelines( pipelineId, {
+				includeFlows: false,
+			} );
 			if ( ! response.success ) {
 				return null;
 			}

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
@@ -47,7 +47,10 @@ export const fetchPipelines = async (
 	{ perPage = 100, offset = 0, includeFlows = false, search = null } = {}
 ) => {
 	if ( pipelineId ) {
-		return await client.get( '/pipelines', { pipeline_id: pipelineId } );
+		return await client.get( '/pipelines', {
+			pipeline_id: pipelineId,
+			include_flows: includeFlows,
+		} );
 	}
 
 	const params = {

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
@@ -6,7 +6,7 @@
  */
 
 /**
- * Internal dependencies
+ * External dependencies
  */
 import { client } from '@shared/utils/api';
 import { useAgentStore } from '@shared/stores/agentStore';
@@ -158,13 +158,10 @@ export const reorderPipelineSteps = async ( pipelineId, steps ) => {
 /**
  * Update AI step configuration
  *
- * @param {string}        stepId        - Pipeline step ID
- * @param {string}        prompt        - System prompt content
- * @param {string}        provider      - AI provider
- * @param {string}        model         - AI model
- * @param {Array<string>} disabledTools - Tools to disable for this step (exclusion list)
- * @param {string}        stepType      - Step type (currently only 'ai' supported)
- * @param {number}        pipelineId    - Pipeline ID for context
+ * @param {string} stepId     - Pipeline step ID
+ * @param {string} prompt     - System prompt content
+ * @param {string} stepType   - Step type (currently only 'ai' supported)
+ * @param {number} pipelineId - Pipeline ID for context
  * @return {Promise<Object>} Updated step data
  */
 export const updateSystemPrompt = async (
@@ -282,8 +279,8 @@ export const runFlow = async ( flowId ) => {
  * @param {Object} settings           - Handler settings
  * @param {number} pipelineId         - Pipeline ID
  * @param {string} stepType           - Step type
- * @param          flowConfig
- * @param          pipelineStepConfig
+ * @param {Object} flowConfig         - Flow configuration
+ * @param {Object} pipelineStepConfig - Pipeline step configuration
  * @return {Promise<Object>} Updated flow step data
  */
 export const updateFlowHandler = async (
@@ -489,8 +486,8 @@ export const fetchFlowMemoryFiles = async ( flowId ) => {
 /**
  * Update memory files for a flow
  *
- * @param {number}        flowId       - Flow ID
- * @param {Array<string>} memoryFiles  - Array of filenames
+ * @param {number}        flowId      - Flow ID
+ * @param {Array<string>} memoryFiles - Array of filenames
  * @return {Promise<Object>} Update confirmation
  */
 export const updateFlowMemoryFiles = async ( flowId, memoryFiles ) => {


### PR DESCRIPTION
## Summary
- Let single-pipeline REST reads honor `include_flows=false` while preserving embedded flows as the default for existing callers.
- Have the Pipelines admin hydration path opt out of embedded flows because the page already fetches flows through the paginated `/flows` endpoint.
- Reduces selected-pipeline hydration payload size for large pipelines and avoids redundant flow decoding during page load.

## Testing
- `npm run build`
- `php -l inc/Api/Pipelines/Pipelines.php`
- `php -l inc/Abilities/Pipeline/GetPipelinesAbility.php`
- `git diff --check`
- Seeded 500 pipelines x 25 flows on the Studio site, profiled the Pipelines admin page with the Homeboy Rigs WordPress page diagnostics workload, then removed the seeded rows.

## Evidence
- Before fix: selected pipeline hydration used `/wp-json/datamachine/v1/pipelines?agent_id=1&pipeline_id=510&_locale=user` and transferred `5330` decoded bytes.
- After fix: selected pipeline hydration used `/wp-json/datamachine/v1/pipelines?agent_id=1&pipeline_id=510&include_flows=false&_locale=user` and transferred `381` decoded bytes.
- Before profile artifact: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/dm-scale-profile/studio-wordpress-page-diagnostics-artifacts/dm-scale-500x25-datamachine-pipelines-scale-diagnostics-97410-1778463661986-krxqd108xjo/result-dm-scale-500x25-datamachine-pipelines-scale-diagnostics-97410-1778463661986-krxqd108xjo.json`
- After profile artifact: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/dm-scale-profile-fixed/studio-wordpress-page-diagnostics-artifacts/dm-scale-500x25-fixed-datamachine-pipelines-scale-diagnostics-97688-1778463754768-3zvdapyz0rv/result-dm-scale-500x25-fixed-datamachine-pipelines-scale-diagnostics-97688-1778463754768-3zvdapyz0rv.json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Seeded and profiled the Pipelines admin scale scenario, identified the redundant embedded-flow hydration path, drafted the REST/frontend fix, and ran build/static checks for Chris to review.