### PR TITLE
Preload Pipelines flow page size

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/PipelinesFilters.php
+++ b/inc/Core/Admin/Pages/Pipelines/PipelinesFilters.php
@@ -75,6 +75,7 @@ function datamachine_register_pipelines_admin_page_filters() {
 									'restNamespace' => 'datamachine/v1',
 									'restNonce'     => wp_create_nonce( 'wp_rest' ),
 									'maxUploadSize' => wp_max_upload_size(),
+									'flowsPerPage'  => max( 5, min( 100, absint( get_option( 'datamachine_settings', array() )['flows_per_page'] ?? 20 ) ) ),
 									// stepTypes: Loaded via REST API in PipelineContext
 									// handlers: Loaded via REST API in PipelineContext
 									// handlerSettings: Lazy-loaded via REST API in HandlerSettingsModal

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx
@@ -30,7 +30,6 @@ import { useFlows } from './queries/flows';
 /**
  * External dependencies
  */
-import { useSettings } from '@shared/queries/settings';
 import { useUIStore } from './stores/uiStore';
 import PipelineCard from './components/pipelines/PipelineCard';
 import PipelineSelector from './components/pipelines/PipelineSelector';
@@ -74,8 +73,7 @@ export default function PipelinesApp() {
 		isLoading: pipelinesLoading,
 		error: pipelinesError,
 	} = usePipelines();
-	const { data: settingsData } = useSettings();
-	const flowsPerPage = settingsData?.settings?.flows_per_page ?? 20;
+	const flowsPerPage = window.dataMachineConfig?.flowsPerPage ?? 20;
 
 	const {
 		data: flowsData,


### PR DESCRIPTION
## Summary
- Pass the Pipelines page's `flowsPerPage` value through the localized admin config.
- Stop fetching the full `/settings` REST payload during Pipelines page startup when the page only needs this one value.
- Removes one critical-path REST request from the Pipelines admin page waterfall.

## Testing
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-pipelines-page-profile --extension wordpress --changed-since origin/main`
- `php -l inc/Core/Admin/Pages/Pipelines/PipelinesFilters.php`
- `npm run build`
- `git diff --check`
- Seeded 5000 pipelines on the Studio site, profiled the Pipelines admin page with the Homeboy Rigs WordPress page diagnostics workload, then removed the seeded rows.

## Evidence
- Before: measured 5000-pipeline run had `6` REST resources and slowest REST resource `2675ms`.
- After: measured 5000-pipeline run has `5` REST resources and slowest REST resource `1509ms`.
- Overall `readyMs` was noisy (`4423ms` before, `5198ms` after), so this PR claims request-count and worst-REST-resource reduction rather than a proven full-page ready-time win.
- Before profile artifact: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/dm-scale-profile-5000p/studio-wordpress-page-diagnostics-artifacts/dm-scale-5000p-datamachine-pipelines-scale-diagnostics-26142-1778466479835-6muif7848s5/result-dm-scale-5000p-datamachine-pipelines-scale-diagnostics-26142-1778466479835-6muif7848s5.json`
- After profile artifact: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/dm-scale-profile-no-settings/studio-wordpress-page-diagnostics-artifacts/dm-scale-no-settings-datamachine-pipelines-scale-diagnostics-26752-1778466801311-gnpva9yab8/result-dm-scale-no-settings-datamachine-pipelines-scale-diagnostics-26752-1778466801311-gnpva9yab8.json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Ran scale profiles, identified the settings request as avoidable startup REST work, drafted the preload change, and ran build/static checks for Chris to review.