### PR TITLE
Centralize policy-gated pipeline tool mode

### DIFF
--- a/inc/Engine/AI/Tools/BaseTool.php
+++ b/inc/Engine/AI/Tools/BaseTool.php
@@ -27,7 +27,8 @@ abstract class BaseTool {
 	 *
 	 * All tools register via the single `datamachine_tools` filter. Each tool
 	 * must declare its modes — the agent modes where it's available (e.g.
-	 * 'chat', 'pipeline').
+	 * 'chat', 'pipeline'). Tools that should be available to pipeline runs only
+	 * when explicitly allowlisted may declare 'pipeline_policy'.
 	 *
 	 * Tools should also declare which ability they wrap via the `ability` key
 	 * (or `abilities` for composed tools). The ToolPolicyResolver uses this to

--- a/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
@@ -16,13 +16,14 @@ namespace DataMachine\Engine\AI\Tools\Global;
 defined( 'ABSPATH' ) || exit;
 
 use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Abilities\PermissionHelper;
 
 class AgentDailyMemory extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'agent_daily_memory', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline_policy' ), array( 'abilities' => array( 'datamachine/daily-memory-read', 'datamachine/daily-memory-write', 'datamachine/daily-memory-list', 'datamachine/search-daily-memory' ) ) );
+		$this->registerTool( 'agent_daily_memory', array( $this, 'getToolDefinition' ), array( 'chat', ToolPolicyResolver::MODE_PIPELINE_POLICY ), array( 'abilities' => array( 'datamachine/daily-memory-read', 'datamachine/daily-memory-write', 'datamachine/daily-memory-list', 'datamachine/search-daily-memory' ) ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/AgentMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentMemory.php
@@ -16,13 +16,14 @@
 defined( 'ABSPATH' ) || exit;
 
 use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Abilities\PermissionHelper;
 
 class AgentMemory extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'agent_memory', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline_policy' ), array( 'abilities' => array( 'datamachine/get-agent-memory', 'datamachine/update-agent-memory', 'datamachine/list-agent-memory-sections' ) ) );
+		$this->registerTool( 'agent_memory', array( $this, 'getToolDefinition' ), array( 'chat', ToolPolicyResolver::MODE_PIPELINE_POLICY ), array( 'abilities' => array( 'datamachine/get-agent-memory', 'datamachine/update-agent-memory', 'datamachine/list-agent-memory-sections' ) ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php
+++ b/inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php
@@ -41,7 +41,7 @@ final class DataMachineToolRegistrySource {
 				continue;
 			}
 
-			if ( ToolPolicyResolver::MODE_PIPELINE === $mode && in_array( 'pipeline_policy', $tool_config['modes'] ?? array(), true ) ) {
+			if ( ToolPolicyResolver::MODE_PIPELINE === $mode && ToolPolicyResolver::isPipelinePolicyToolAllowed( $tool_config, $tool_name, $args ) ) {
 				$tool_config['modes'] = array_values( array_unique( array_merge( $tool_config['modes'], array( ToolPolicyResolver::MODE_PIPELINE ) ) ) );
 			}
 
@@ -86,8 +86,7 @@ final class DataMachineToolRegistrySource {
 			static function ( $tool, string $tool_name ) use ( $mode, $args ) {
 				$modes = $tool['modes'] ?? array();
 				if ( ToolPolicyResolver::MODE_PIPELINE === $mode
-					&& in_array( 'pipeline_policy', $modes, true )
-					&& in_array( $tool_name, $args['allow_only'] ?? array(), true ) ) {
+					&& ToolPolicyResolver::isPipelinePolicyToolAllowed( $tool, $tool_name, $args ) ) {
 					return true;
 				}
 

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -36,6 +36,12 @@ class ToolPolicyResolver {
 	public const MODE_CHAT     = 'chat';
 	public const MODE_SYSTEM   = 'system';
 
+	/**
+	 * Opt-in pipeline mode for tools that should never be exposed to pipeline
+	 * agents by default, but may be explicitly enabled by a flow/tool policy.
+	 */
+	public const MODE_PIPELINE_POLICY = 'pipeline_policy';
+
 	private ToolManager $tool_manager;
 	private ToolSourceRegistry $tool_source_registry;
 	private DataMachineAgentToolPolicyProvider $agent_policy_provider;
@@ -207,5 +213,23 @@ class ToolPolicyResolver {
 			self::MODE_CHAT     => 'Chat interaction with full management tools',
 			self::MODE_SYSTEM   => 'System task execution with minimal toolset',
 		);
+	}
+
+	/**
+	 * Whether a tool is available to a pipeline only by explicit policy opt-in.
+	 *
+	 * Policy-gated pipeline tools stay out of the default pipeline tool pool, but
+	 * can be granted by a flow's `enabled_tools` allowlist or equivalent tool
+	 * policy. This is intended for powerful-but-automatable tools such as durable
+	 * agent memory writes.
+	 *
+	 * @param array  $tool_config Tool definition.
+	 * @param string $tool_name   Tool identifier.
+	 * @param array  $args        Resolver args, including optional allow_only.
+	 * @return bool True when the tool should be included for this pipeline pass.
+	 */
+	public static function isPipelinePolicyToolAllowed( array $tool_config, string $tool_name, array $args ): bool {
+		return in_array( self::MODE_PIPELINE_POLICY, $tool_config['modes'] ?? array(), true )
+			&& in_array( $tool_name, $args['allow_only'] ?? array(), true );
 	}
 }

--- a/tests/global-tool-pipeline-modes-smoke.php
+++ b/tests/global-tool-pipeline-modes-smoke.php
@@ -40,6 +40,7 @@ function apply_filters( string $tag, $value ) {
 }
 
 require_once __DIR__ . '/../inc/Engine/AI/Tools/BaseTool.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
 
 $failures = array();
 $passes   = 0;
@@ -121,7 +122,7 @@ assert_true_for_pipeline_modes(
 	$passes
 );
 assert_true_for_pipeline_modes(
-	file_contains_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentDailyMemory.php', "array( 'chat', 'pipeline_policy' )" ),
+	file_contains_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentDailyMemory.php', 'ToolPolicyResolver::MODE_PIPELINE_POLICY' ),
 	'agent_daily_memory declares policy-controlled pipeline availability',
 	$failures,
 	$passes
@@ -139,7 +140,7 @@ assert_true_for_pipeline_modes(
 	$passes
 );
 assert_true_for_pipeline_modes(
-	file_contains_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentMemory.php', "array( 'chat', 'pipeline_policy' )" ),
+	file_contains_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentMemory.php', 'ToolPolicyResolver::MODE_PIPELINE_POLICY' ),
 	'agent_memory declares policy-controlled pipeline availability',
 	$failures,
 	$passes

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -87,8 +87,8 @@ class SnapshotPolicyToolManager extends ToolManager {
 			'alpha_tool'         => array( 'modes' => array( 'pipeline' ) ),
 			'beta_tool'          => array( 'modes' => array( 'pipeline' ) ),
 			'danger_tool'        => array( 'modes' => array( 'pipeline' ) ),
-			'agent_daily_memory' => array( 'modes' => array( 'chat', 'pipeline_policy' ) ),
-			'agent_memory'       => array( 'modes' => array( 'chat', 'pipeline_policy' ) ),
+			'agent_daily_memory' => array( 'modes' => array( 'chat', ToolPolicyResolver::MODE_PIPELINE_POLICY ) ),
+			'agent_memory'       => array( 'modes' => array( 'chat', ToolPolicyResolver::MODE_PIPELINE_POLICY ) ),
 			'chat_only'          => array( 'modes' => array( 'chat' ) ),
 		);
 	}


### PR DESCRIPTION
## Summary
- Adds a named `MODE_PIPELINE_POLICY` primitive for tools that are pipeline-capable only when explicitly allowlisted.
- Routes policy-gated pipeline inclusion through `ToolPolicyResolver::isPipelinePolicyToolAllowed()` instead of ad hoc string checks.
- Updates memory tool declarations and smoke tests so durable/daily memory tools remain absent by default but grantable via `enabled_tools`.

## Verification
- `php tests/pipeline-tool-policy-snapshot-smoke.php`
- `php tests/global-tool-pipeline-modes-smoke.php`
- `php -l inc/Engine/AI/Tools/ToolPolicyResolver.php`
- `php -l inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php`
- `php -l inc/Engine/AI/Tools/Global/AgentMemory.php`
- `php -l inc/Engine/AI/Tools/Global/AgentDailyMemory.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Reviewing the tool policy internals, drafting the refactor, and running targeted smoke tests; Chris directed the design goal and remains responsible for review.