### PR TITLE
fix: raise conversation turn ceiling

### DIFF
--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -88,7 +88,7 @@ add_action( 'plugins_loaded', array( WpAiClientCache::class, 'install' ), 20 );
 IterationBudgetRegistry::register( 'conversation_turns', array(
 	'default' => PluginSettings::DEFAULT_MAX_TURNS,
 	'min'     => 1,
-	'max'     => 50,
+	'max'     => 200,
 	'setting' => 'max_turns',
 ) );
 

--- a/tests/Unit/AI/IterationBudgetTest.php
+++ b/tests/Unit/AI/IterationBudgetTest.php
@@ -164,6 +164,6 @@ class IterationBudgetTest extends WP_UnitTestCase {
 		$config = IterationBudgetRegistry::get_config( 'conversation_turns' );
 		$this->assertSame( 'max_turns', $config['setting'] );
 		$this->assertSame( 1, $config['min'] );
-		$this->assertSame( 50, $config['max'] );
+		$this->assertSame( 200, $config['max'] );
 	}
 }


### PR DESCRIPTION
## Summary
- Raise the registered conversation turn budget ceiling from 50 to 200 so long-running agent workflows can request larger turn budgets through `max_turns`.
- Update the iteration budget registration test to document the new ceiling.

## Testing
- `php -l inc/bootstrap.php`
- `php -l tests/Unit/AI/IterationBudgetTest.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Locating the hardcoded turn ceiling and drafting the ceiling/test update.