### PR TITLE
Reduce agent loop tool friction

### DIFF
--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -298,6 +298,13 @@ class ConversationManager {
 			);
 		}
 
+		if ( self::isRepeatableInspectionTool( $tool_name ) ) {
+			return array(
+				'is_duplicate' => false,
+				'message'      => '',
+			);
+		}
+
 		// Scan ALL previous tool_call messages, not just the most recent one.
 		for ( $i = count( $conversation_messages ) - 1; $i >= 0; $i-- ) {
 			$message = WP_Agent_Message::normalize( $conversation_messages[ $i ] );
@@ -329,6 +336,31 @@ class ConversationManager {
 		return array(
 			'is_duplicate' => false,
 			'message'      => '',
+		);
+	}
+
+	private static function isRepeatableInspectionTool( string $tool_name ): bool {
+		return in_array(
+			$tool_name,
+			array(
+				'workspace_show',
+				'workspace_ls',
+				'workspace_read',
+				'workspace_grep',
+				'workspace_git_status',
+				'workspace_git_log',
+				'workspace_git_diff',
+				'list_github_issues',
+				'get_github_issue',
+				'list_github_pulls',
+				'get_github_pull',
+				'get_github_pull_files',
+				'get_github_pull_review_context',
+				'wordpress_runtime_inventory',
+				'wordpress_runtime_ls',
+				'wordpress_runtime_read',
+			),
+			true
 		);
 	}
 

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -264,6 +264,10 @@ function datamachine_run_conversation(
 		$result['completion_assertions_required']  = $assertions->required();
 		$result['completion_assertions_missing']   = $evaluation['missing'];
 		$result['completion_assertions_satisfied'] = $evaluation['satisfied'];
+		$result['completion_assertions_complete']  = ! empty( $evaluation['complete'] );
+		if ( ! empty( $evaluation['complete'] ) && 'budget_exceeded' !== ( $result['status'] ?? '' ) ) {
+			$result['completed'] = true;
+		}
 	}
 	// Map upstream budget_exceeded status to DM's max_turns_reached flag
 	// for backward compatibility with ChatOrchestrator response shaping.
@@ -580,7 +584,7 @@ function datamachine_build_turn_runner(
 				}
 			}
 
-			if ( '' !== $completion_nudge ) {
+			if ( '' !== $completion_nudge && datamachine_should_append_tool_completion_nudge( $tool_execution_results, $completion_decision->context() ) ) {
 				$messages[] = ConversationManager::buildConversationMessage( 'user', $completion_nudge );
 				datamachine_record_completion_nudge(
 					$completion_nudges,
@@ -644,6 +648,71 @@ function datamachine_build_turn_runner(
 			'tool_runtime_rule_rejected'   => $runtime_rule_rejected,
 		);
 	};
+}
+
+/**
+ * Decide whether an assertion nudge is useful immediately after tool calls.
+ *
+ * Inspection-heavy agents can spend many turns reading files and runtime state.
+ * Repeating the same missing-assertion nudge after every read wastes context and
+ * pressures the model into completion mechanics too early. Keep immediate
+ * nudges for turns that changed state, attempted completion, or made direct
+ * assertion progress; natural completions still receive nudges elsewhere.
+ *
+ * @param array<int,array<string,mixed>> $tool_execution_results Tool results from the current turn.
+ * @param array<string,mixed>            $decision_context       Completion decision context.
+ */
+function datamachine_should_append_tool_completion_nudge( array $tool_execution_results, array $decision_context ): bool {
+	$progress_tools = array_merge(
+		array_values( (array) ( $decision_context['satisfied']['tool_names'] ?? array() ) ),
+		datamachine_completion_outcome_tool_names( (array) ( $decision_context['completion_assertions_required']['complete_when_any'] ?? array() ) )
+	);
+
+	foreach ( $tool_execution_results as $entry ) {
+		$tool_name = (string) ( $entry['tool_name'] ?? '' );
+		if ( in_array( $tool_name, $progress_tools, true ) || datamachine_tool_name_is_mutating( $tool_name ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/** @return array<int,string> */
+function datamachine_completion_outcome_tool_names( array $outcomes ): array {
+	$tools = array();
+	foreach ( $outcomes as $outcome ) {
+		foreach ( (array) ( is_array( $outcome ) ? ( $outcome['tools'] ?? array() ) : array() ) as $tool ) {
+			if ( is_array( $tool ) && isset( $tool['name'] ) && is_string( $tool['name'] ) ) {
+				$tools[] = $tool['name'];
+			}
+		}
+	}
+
+	return array_values( array_unique( $tools ) );
+}
+
+function datamachine_tool_name_is_mutating( string $tool_name ): bool {
+	return in_array(
+		$tool_name,
+		array(
+			'workspace_write',
+			'workspace_edit',
+			'workspace_apply_patch',
+			'workspace_delete',
+			'workspace_git_add',
+			'workspace_git_commit',
+			'workspace_git_push',
+			'workspace_git_pull',
+			'workspace_worktree_add',
+			'create_github_pull_request',
+			'comment_github_pull_request',
+			'create_github_issue',
+			'manage_github_issue',
+			'agent_daily_memory',
+		),
+		true
+	);
 }
 
 /**

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -518,6 +518,129 @@ assert_runtime_policy( 2 === count( $duplicate_result['tool_execution_results'] 
 assert_runtime_policy( 'second_policy_tool' === ( $duplicate_result['tool_execution_results'][1]['tool_name'] ?? '' ), 'duplicate recovery reaches next required tool' );
 assert_runtime_policy( str_contains( wp_json_encode( $duplicate_transcript->calls[0]['messages'] ?? array() ), 'DUPLICATE REJECTED' ), 'duplicate recovery transcript includes correction message' );
 
+$repeatable_dispatch_count = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$repeatable_dispatch_count ) {
+		++$repeatable_dispatch_count;
+
+		if ( in_array( $repeatable_dispatch_count, array( 1, 2 ), true ) ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => '',
+					'tool_calls' => array(
+						array(
+							'name'       => 'workspace_git_status',
+							'parameters' => array( 'name' => 'demo@branch' ),
+						),
+					),
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => 'Done after repeatable inspection.',
+				'tool_calls' => array(),
+			),
+		);
+	}
+);
+
+$repeatable_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'inspect status twice' ) ),
+	array(
+		'workspace_git_status' => array(
+			'name'        => 'workspace_git_status',
+			'description' => 'Repeatable status smoke tool',
+			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	'pipeline',
+	array(),
+	4
+);
+
+assert_runtime_policy( 2 === count( $repeatable_result['tool_execution_results'] ?? array() ), 'repeatable inspection tool can be called twice with identical parameters' );
+assert_runtime_policy( empty( $repeatable_result['duplicate_tool_call_rejected'] ), 'repeatable inspection tool bypasses duplicate rejection' );
+
+$inspection_nudge_dispatch_count = 0;
+$inspection_nudge_transcript     = new RuntimePolicySmokeTranscriptPersister();
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$inspection_nudge_dispatch_count ) {
+		++$inspection_nudge_dispatch_count;
+
+		if ( 1 === $inspection_nudge_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => '',
+					'tool_calls' => array(
+						array(
+							'name'       => 'workspace_read',
+							'parameters' => array( 'repo' => 'demo@branch', 'path' => 'README.md' ),
+						),
+					),
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => '',
+				'tool_calls' => array(
+					array(
+						'name'       => 'agent_daily_memory',
+						'parameters' => array( 'action' => 'write' ),
+					),
+				),
+			),
+		);
+	}
+);
+
+$inspection_nudge_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'read before writing memory' ) ),
+	array(
+		'workspace_read'     => array(
+			'name'        => 'workspace_read',
+			'description' => 'Inspection smoke tool',
+			'parameters'  => array( 'repo' => array( 'type' => 'string' ), 'path' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+		'agent_daily_memory' => array(
+			'name'        => 'agent_daily_memory',
+			'description' => 'Memory smoke tool',
+			'parameters'  => array( 'action' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	'pipeline',
+	array(
+		'transcript_persister'  => $inspection_nudge_transcript,
+		'completion_assertions' => array(
+			'required_tool_names' => array( 'agent_daily_memory' ),
+		),
+	),
+	4
+);
+
+assert_runtime_policy( $inspection_nudge_dispatch_count >= 2, 'inspection-only turn continues without immediate completion nudge' );
+assert_runtime_policy( 2 === count( $inspection_nudge_result['tool_execution_results'] ?? array() ), 'inspection-only nudge suppression still reaches required tool' );
+assert_runtime_policy( ! str_contains( wp_json_encode( $inspection_nudge_transcript->calls[0]['messages'] ?? array() ), 'completion signals are still missing' ), 'inspection-only transcript avoids assertion nudge spam' );
+
 $runtime_rule_dispatch_count = 0;
 $runtime_rule_transcript     = new RuntimePolicySmokeTranscriptPersister();
 WpAiClientTestDouble::reset();


### PR DESCRIPTION
## Summary
- Allows repeatable inspection tools like `workspace_git_status`, `workspace_read`, and runtime/GitHub reads to be called multiple times with the same parameters instead of tripping duplicate-call rejection.
- Suppresses immediate completion-assertion nudges after inspection-only turns so pipeline agents can explore without repeated nudge spam.
- Marks assertion-satisfied loop results completed when the run did not exceed its budget.

## Testing
- `php -l inc/Engine/AI/ConversationManager.php`
- `php -l inc/Engine/AI/conversation-loop.php`
- `php -l tests/agent-conversation-runtime-policy-smoke.php`
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed World Creator transcript tool friction, drafted the loop policy changes, and ran targeted smoke validation.