### PR TITLE
Use tool runtime metadata in agent loop

### DIFF
--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -298,6 +298,13 @@ class ConversationManager {
 			);
 		}
 
+		if ( self::isRepeatableInspectionTool( $tool_name ) ) {
+			return array(
+				'is_duplicate' => false,
+				'message'      => '',
+			);
+		}
+
 		// Scan ALL previous tool_call messages, not just the most recent one.
 		for ( $i = count( $conversation_messages ) - 1; $i >= 0; $i-- ) {
 			$message = WP_Agent_Message::normalize( $conversation_messages[ $i ] );
@@ -329,6 +336,31 @@ class ConversationManager {
 		return array(
 			'is_duplicate' => false,
 			'message'      => '',
+		);
+	}
+
+	private static function isRepeatableInspectionTool( string $tool_name ): bool {
+		return in_array(
+			$tool_name,
+			array(
+				'workspace_show',
+				'workspace_ls',
+				'workspace_read',
+				'workspace_grep',
+				'workspace_git_status',
+				'workspace_git_log',
+				'workspace_git_diff',
+				'list_github_issues',
+				'get_github_issue',
+				'list_github_pulls',
+				'get_github_pull',
+				'get_github_pull_files',
+				'get_github_pull_review_context',
+				'wordpress_runtime_inventory',
+				'wordpress_runtime_ls',
+				'wordpress_runtime_read',
+			),
+			true
 		);
 	}
 

--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -285,12 +285,13 @@ class ConversationManager {
 	 * the immediately previous call and would miss this. This broader check prevents
 	 * wasted AI credits on duplicate tool executions.
 	 *
-	 * @param string $tool_name Tool name to validate
-	 * @param array  $tool_parameters Tool parameters to validate
-	 * @param array  $conversation_messages Conversation history
+	 * @param string     $tool_name Tool name to validate
+	 * @param array      $tool_parameters Tool parameters to validate
+	 * @param array      $conversation_messages Conversation history
+	 * @param array|null $tool_definition Tool definition, when available.
 	 * @return array Validation result with is_duplicate and message
 	 */
-	public static function validateToolCall( string $tool_name, array $tool_parameters, array $conversation_messages ): array {
+	public static function validateToolCall( string $tool_name, array $tool_parameters, array $conversation_messages, ?array $tool_definition = null ): array {
 		if ( empty( $conversation_messages ) ) {
 			return array(
 				'is_duplicate' => false,
@@ -298,7 +299,7 @@ class ConversationManager {
 			);
 		}
 
-		if ( self::isRepeatableInspectionTool( $tool_name ) ) {
+		if ( self::toolAllowsRepeatCalls( $tool_definition ) ) {
 			return array(
 				'is_duplicate' => false,
 				'message'      => '',
@@ -339,29 +340,10 @@ class ConversationManager {
 		);
 	}
 
-	private static function isRepeatableInspectionTool( string $tool_name ): bool {
-		return in_array(
-			$tool_name,
-			array(
-				'workspace_show',
-				'workspace_ls',
-				'workspace_read',
-				'workspace_grep',
-				'workspace_git_status',
-				'workspace_git_log',
-				'workspace_git_diff',
-				'list_github_issues',
-				'get_github_issue',
-				'list_github_pulls',
-				'get_github_pull',
-				'get_github_pull_files',
-				'get_github_pull_review_context',
-				'wordpress_runtime_inventory',
-				'wordpress_runtime_ls',
-				'wordpress_runtime_read',
-			),
-			true
-		);
+	private static function toolAllowsRepeatCalls( ?array $tool_definition ): bool {
+		$runtime = is_array( $tool_definition['runtime'] ?? null ) ? $tool_definition['runtime'] : array();
+
+		return 'repeatable' === ( $runtime['duplicate_policy'] ?? '' );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/BaseTool.php
+++ b/inc/Engine/AI/Tools/BaseTool.php
@@ -35,6 +35,12 @@ abstract class BaseTool {
 	 * check the ability's permission_callback before offering the tool to AI agents.
 	 * Tools without an ability declaration default to admin-only access.
 	 *
+	 * Tools may also expose top-level `runtime` metadata in their definition to
+	 * describe loop behavior without hardcoding tool names in core. Supported keys
+	 * include `duplicate_policy => repeatable` for safe repeated calls and
+	 * `completion_signal => progress` for results that should trigger immediate
+	 * completion-assertion nudges when assertions are still missing.
+	 *
 	 * When the definition is a callable (for lazy evaluation), the modes
 	 * are stored alongside so they're available before the callable is resolved.
 	 * The ToolManager merges modes into the resolved definition.

--- a/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
@@ -87,6 +87,9 @@ class AgentDailyMemory extends BaseTool {
 		return array(
 			'success'   => true,
 			'data'      => $result,
+			'runtime'   => array(
+				'completion_signal' => 'progress',
+			),
 			'tool_name' => 'agent_daily_memory',
 		);
 	}

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -264,6 +264,10 @@ function datamachine_run_conversation(
 		$result['completion_assertions_required']  = $assertions->required();
 		$result['completion_assertions_missing']   = $evaluation['missing'];
 		$result['completion_assertions_satisfied'] = $evaluation['satisfied'];
+		$result['completion_assertions_complete']  = ! empty( $evaluation['complete'] );
+		if ( ! empty( $evaluation['complete'] ) && 'budget_exceeded' !== ( $result['status'] ?? '' ) ) {
+			$result['completed'] = true;
+		}
 	}
 	// Map upstream budget_exceeded status to DM's max_turns_reached flag
 	// for backward compatibility with ChatOrchestrator response shaping.
@@ -580,7 +584,7 @@ function datamachine_build_turn_runner(
 				}
 			}
 
-			if ( '' !== $completion_nudge ) {
+			if ( '' !== $completion_nudge && datamachine_should_append_tool_completion_nudge( $tool_execution_results, $completion_decision->context() ) ) {
 				$messages[] = ConversationManager::buildConversationMessage( 'user', $completion_nudge );
 				datamachine_record_completion_nudge(
 					$completion_nudges,
@@ -644,6 +648,71 @@ function datamachine_build_turn_runner(
 			'tool_runtime_rule_rejected'   => $runtime_rule_rejected,
 		);
 	};
+}
+
+/**
+ * Decide whether an assertion nudge is useful immediately after tool calls.
+ *
+ * Inspection-heavy agents can spend many turns reading files and runtime state.
+ * Repeating the same missing-assertion nudge after every read wastes context and
+ * pressures the model into completion mechanics too early. Keep immediate
+ * nudges for turns that changed state, attempted completion, or made direct
+ * assertion progress; natural completions still receive nudges elsewhere.
+ *
+ * @param array<int,array<string,mixed>> $tool_execution_results Tool results from the current turn.
+ * @param array<string,mixed>            $decision_context       Completion decision context.
+ */
+function datamachine_should_append_tool_completion_nudge( array $tool_execution_results, array $decision_context ): bool {
+	$progress_tools = array_merge(
+		array_values( (array) ( $decision_context['satisfied']['tool_names'] ?? array() ) ),
+		datamachine_completion_outcome_tool_names( (array) ( $decision_context['completion_assertions_required']['complete_when_any'] ?? array() ) )
+	);
+
+	foreach ( $tool_execution_results as $entry ) {
+		$tool_name = (string) ( $entry['tool_name'] ?? '' );
+		if ( in_array( $tool_name, $progress_tools, true ) || datamachine_tool_name_is_mutating( $tool_name ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/** @return array<int,string> */
+function datamachine_completion_outcome_tool_names( array $outcomes ): array {
+	$tools = array();
+	foreach ( $outcomes as $outcome ) {
+		foreach ( (array) ( is_array( $outcome ) ? ( $outcome['tools'] ?? array() ) : array() ) as $tool ) {
+			if ( is_array( $tool ) && isset( $tool['name'] ) && is_string( $tool['name'] ) ) {
+				$tools[] = $tool['name'];
+			}
+		}
+	}
+
+	return array_values( array_unique( $tools ) );
+}
+
+function datamachine_tool_name_is_mutating( string $tool_name ): bool {
+	return in_array(
+		$tool_name,
+		array(
+			'workspace_write',
+			'workspace_edit',
+			'workspace_apply_patch',
+			'workspace_delete',
+			'workspace_git_add',
+			'workspace_git_commit',
+			'workspace_git_push',
+			'workspace_git_pull',
+			'workspace_worktree_add',
+			'create_github_pull_request',
+			'comment_github_pull_request',
+			'create_github_issue',
+			'manage_github_issue',
+			'agent_daily_memory',
+		),
+		true
+	);
 }
 
 /**

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -454,8 +454,10 @@ function datamachine_build_turn_runner(
 					)
 				);
 
+				$tool_def = $tools[ $tool_name ] ?? null;
+
 				// Validate for duplicate tool calls.
-				$validation_result = ConversationManager::validateToolCall( $tool_name, $tool_parameters, $messages );
+				$validation_result = ConversationManager::validateToolCall( $tool_name, $tool_parameters, $messages, is_array( $tool_def ) ? $tool_def : null );
 				if ( $validation_result['is_duplicate'] ) {
 					$messages[]         = ConversationManager::generateDuplicateToolCallMessage( $tool_name, $turn_count, $mode );
 					$duplicate_rejected = true;
@@ -528,7 +530,6 @@ function datamachine_build_turn_runner(
 					)
 				);
 
-				$tool_def        = $tools[ $tool_name ] ?? null;
 				$is_handler_tool = is_array( $tool_def ) && isset( $tool_def['handler'] );
 
 				// Evaluate the DM completion policy.
@@ -561,6 +562,7 @@ function datamachine_build_turn_runner(
 					'result'          => $tool_result,
 					'parameters'      => $tool_parameters,
 					'is_handler_tool' => $is_handler_tool,
+					'runtime'         => datamachine_tool_runtime_metadata( is_array( $tool_def ) ? $tool_def : null, $tool_result ),
 					'turn_count'      => $turn_count,
 				);
 				datamachine_persist_inflight_tool_summary( $loop_payload, $tool_execution_results );
@@ -670,12 +672,30 @@ function datamachine_should_append_tool_completion_nudge( array $tool_execution_
 
 	foreach ( $tool_execution_results as $entry ) {
 		$tool_name = (string) ( $entry['tool_name'] ?? '' );
-		if ( in_array( $tool_name, $progress_tools, true ) || datamachine_tool_name_is_mutating( $tool_name ) ) {
+		$runtime   = is_array( $entry['runtime'] ?? null ) ? $entry['runtime'] : array();
+		if ( in_array( $tool_name, $progress_tools, true ) || 'progress' === ( $runtime['completion_signal'] ?? '' ) ) {
 			return true;
 		}
 	}
 
 	return false;
+}
+
+/**
+ * Return Data Machine runtime metadata from a tool definition/result pair.
+ *
+ * Tool providers can declare top-level `runtime` metadata without requiring
+ * Data Machine core to know extension-specific tool names.
+ *
+ * @param array<string,mixed>|null $tool_definition Tool definition.
+ * @param array<string,mixed>      $tool_result     Tool execution result.
+ * @return array<string,mixed>
+ */
+function datamachine_tool_runtime_metadata( ?array $tool_definition, array $tool_result = array() ): array {
+	$definition_runtime = is_array( $tool_definition['runtime'] ?? null ) ? $tool_definition['runtime'] : array();
+	$result_runtime     = is_array( $tool_result['runtime'] ?? null ) ? $tool_result['runtime'] : array();
+
+	return array_merge( $definition_runtime, $result_runtime );
 }
 
 /** @return array<int,string> */
@@ -690,29 +710,6 @@ function datamachine_completion_outcome_tool_names( array $outcomes ): array {
 	}
 
 	return array_values( array_unique( $tools ) );
-}
-
-function datamachine_tool_name_is_mutating( string $tool_name ): bool {
-	return in_array(
-		$tool_name,
-		array(
-			'workspace_write',
-			'workspace_edit',
-			'workspace_apply_patch',
-			'workspace_delete',
-			'workspace_git_add',
-			'workspace_git_commit',
-			'workspace_git_push',
-			'workspace_git_pull',
-			'workspace_worktree_add',
-			'create_github_pull_request',
-			'comment_github_pull_request',
-			'create_github_issue',
-			'manage_github_issue',
-			'agent_daily_memory',
-		),
-		true
-	);
 }
 
 /**

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -518,6 +518,129 @@ assert_runtime_policy( 2 === count( $duplicate_result['tool_execution_results'] 
 assert_runtime_policy( 'second_policy_tool' === ( $duplicate_result['tool_execution_results'][1]['tool_name'] ?? '' ), 'duplicate recovery reaches next required tool' );
 assert_runtime_policy( str_contains( wp_json_encode( $duplicate_transcript->calls[0]['messages'] ?? array() ), 'DUPLICATE REJECTED' ), 'duplicate recovery transcript includes correction message' );
 
+$repeatable_dispatch_count = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$repeatable_dispatch_count ) {
+		++$repeatable_dispatch_count;
+
+		if ( in_array( $repeatable_dispatch_count, array( 1, 2 ), true ) ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => '',
+					'tool_calls' => array(
+						array(
+							'name'       => 'workspace_git_status',
+							'parameters' => array( 'name' => 'demo@branch' ),
+						),
+					),
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => 'Done after repeatable inspection.',
+				'tool_calls' => array(),
+			),
+		);
+	}
+);
+
+$repeatable_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'inspect status twice' ) ),
+	array(
+		'workspace_git_status' => array(
+			'name'        => 'workspace_git_status',
+			'description' => 'Repeatable status smoke tool',
+			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	'pipeline',
+	array(),
+	4
+);
+
+assert_runtime_policy( 2 === count( $repeatable_result['tool_execution_results'] ?? array() ), 'repeatable inspection tool can be called twice with identical parameters' );
+assert_runtime_policy( empty( $repeatable_result['duplicate_tool_call_rejected'] ), 'repeatable inspection tool bypasses duplicate rejection' );
+
+$inspection_nudge_dispatch_count = 0;
+$inspection_nudge_transcript     = new RuntimePolicySmokeTranscriptPersister();
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$inspection_nudge_dispatch_count ) {
+		++$inspection_nudge_dispatch_count;
+
+		if ( 1 === $inspection_nudge_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => '',
+					'tool_calls' => array(
+						array(
+							'name'       => 'workspace_read',
+							'parameters' => array( 'repo' => 'demo@branch', 'path' => 'README.md' ),
+						),
+					),
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => '',
+				'tool_calls' => array(
+					array(
+						'name'       => 'agent_daily_memory',
+						'parameters' => array( 'action' => 'write' ),
+					),
+				),
+			),
+		);
+	}
+);
+
+$inspection_nudge_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'read before writing memory' ) ),
+	array(
+		'workspace_read'     => array(
+			'name'        => 'workspace_read',
+			'description' => 'Inspection smoke tool',
+			'parameters'  => array( 'repo' => array( 'type' => 'string' ), 'path' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+		'agent_daily_memory' => array(
+			'name'        => 'agent_daily_memory',
+			'description' => 'Memory smoke tool',
+			'parameters'  => array( 'action' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	'pipeline',
+	array(
+		'transcript_persister'  => $inspection_nudge_transcript,
+		'completion_assertions' => array(
+			'required_tool_names' => array( 'agent_daily_memory' ),
+		),
+	),
+	4
+);
+
+assert_runtime_policy( $inspection_nudge_dispatch_count >= 2, 'inspection-only turn continues without immediate completion nudge' );
+assert_runtime_policy( 2 === count( $inspection_nudge_result['tool_execution_results'] ?? array() ), 'inspection-only nudge suppression still reaches required tool' );
+assert_runtime_policy( ! str_contains( wp_json_encode( $inspection_nudge_transcript->calls[0]['messages'] ?? array() ), 'completion signals are still missing' ), 'inspection-only transcript avoids assertion nudge spam' );
+
 $runtime_rule_dispatch_count = 0;
 $runtime_rule_transcript     = new RuntimePolicySmokeTranscriptPersister();
 WpAiClientTestDouble::reset();

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -531,7 +531,7 @@ WpAiClientTestDouble::set_response_callback(
 					'content'    => '',
 					'tool_calls' => array(
 						array(
-							'name'       => 'workspace_git_status',
+							'name'       => 'repeatable_inspection_tool',
 							'parameters' => array( 'name' => 'demo@branch' ),
 						),
 					),
@@ -552,12 +552,15 @@ WpAiClientTestDouble::set_response_callback(
 $repeatable_result = datamachine_run_conversation(
 	array( array( 'role' => 'user', 'content' => 'inspect status twice' ) ),
 	array(
-		'workspace_git_status' => array(
-			'name'        => 'workspace_git_status',
+		'repeatable_inspection_tool' => array(
+			'name'        => 'repeatable_inspection_tool',
 			'description' => 'Repeatable status smoke tool',
 			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
 			'class'       => RuntimePolicySmokeTool::class,
 			'method'      => 'execute',
+			'runtime'     => array(
+				'duplicate_policy' => 'repeatable',
+			),
 		),
 	),
 	'openai',
@@ -584,7 +587,7 @@ WpAiClientTestDouble::set_response_callback(
 					'content'    => '',
 					'tool_calls' => array(
 						array(
-							'name'       => 'workspace_read',
+							'name'       => 'inspection_tool',
 							'parameters' => array( 'repo' => 'demo@branch', 'path' => 'README.md' ),
 						),
 					),
@@ -598,7 +601,7 @@ WpAiClientTestDouble::set_response_callback(
 				'content'    => '',
 				'tool_calls' => array(
 					array(
-						'name'       => 'agent_daily_memory',
+						'name'       => 'memory_write_tool',
 						'parameters' => array( 'action' => 'write' ),
 					),
 				),
@@ -610,19 +613,22 @@ WpAiClientTestDouble::set_response_callback(
 $inspection_nudge_result = datamachine_run_conversation(
 	array( array( 'role' => 'user', 'content' => 'read before writing memory' ) ),
 	array(
-		'workspace_read'     => array(
-			'name'        => 'workspace_read',
+		'inspection_tool'    => array(
+			'name'        => 'inspection_tool',
 			'description' => 'Inspection smoke tool',
 			'parameters'  => array( 'repo' => array( 'type' => 'string' ), 'path' => array( 'type' => 'string' ) ),
 			'class'       => RuntimePolicySmokeTool::class,
 			'method'      => 'execute',
 		),
-		'agent_daily_memory' => array(
-			'name'        => 'agent_daily_memory',
+		'memory_write_tool'  => array(
+			'name'        => 'memory_write_tool',
 			'description' => 'Memory smoke tool',
 			'parameters'  => array( 'action' => array( 'type' => 'string' ) ),
 			'class'       => RuntimePolicySmokeTool::class,
 			'method'      => 'execute',
+			'runtime'     => array(
+				'completion_signal' => 'progress',
+			),
 		),
 	),
 	'openai',
@@ -631,7 +637,7 @@ $inspection_nudge_result = datamachine_run_conversation(
 	array(
 		'transcript_persister'  => $inspection_nudge_transcript,
 		'completion_assertions' => array(
-			'required_tool_names' => array( 'agent_daily_memory' ),
+			'required_tool_names' => array( 'memory_write_tool' ),
 		),
 	),
 	4


### PR DESCRIPTION
## Summary
- Replaces Data Machine core's hardcoded extension tool-name lists with generic `runtime` metadata on tool definitions/results.
- Uses `duplicate_policy: repeatable` to allow safe repeated inspection calls and `completion_signal: progress` to decide when missing completion assertions should nudge immediately.
- Marks successful daily memory writes as progress and updates smoke coverage with generic tool names.

## Testing
- `php -l inc/Engine/AI/ConversationManager.php`
- `php -l inc/Engine/AI/conversation-loop.php`
- `php -l inc/Engine/AI/Tools/BaseTool.php`
- `php -l inc/Engine/AI/Tools/Global/AgentDailyMemory.php`
- `php -l tests/agent-conversation-runtime-policy-smoke.php`
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic runtime metadata contract, implementation, and focused smoke test updates; Chris directed the architecture away from hardcoded extension names.