### PR TITLE
Drain pipeline batch actions

### DIFF
--- a/inc/Abilities/Engine/DrainJobAbility.php
+++ b/inc/Abilities/Engine/DrainJobAbility.php
@@ -227,6 +227,17 @@ class DrainJobAbility {
 
 		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
 		$groups_table  = $wpdb->prefix . 'actionscheduler_groups';
+		$hooks         = array( self::HOOK_EXECUTE_STEP, PipelineBatchScheduler::BATCH_HOOK );
+		$placeholders  = implode( ',', array_fill( 0, count( $hooks ), '%s' ) );
+		$query_args    = array_merge(
+			$hooks,
+			array(
+				self::GROUP,
+				gmdate( 'Y-m-d H:i:s' ),
+				'%"job_id"%',
+				'%"parent_job_id"%',
+			)
+		);
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names are generated from the WP prefix.
 		$rows = $wpdb->get_results(
@@ -234,16 +245,13 @@ class DrainJobAbility {
 				"SELECT a.action_id, a.args
 				 FROM {$actions_table} a
 				 INNER JOIN {$groups_table} g ON g.group_id = a.group_id
-				 WHERE a.hook = %s
+				 WHERE a.hook IN ({$placeholders})
 				 AND a.status = 'pending'
 				 AND g.slug = %s
 				 AND a.scheduled_date_gmt <= %s
-				 AND a.args LIKE %s
+				 AND (a.args LIKE %s OR a.args LIKE %s)
 				 ORDER BY a.scheduled_date_gmt ASC, a.action_id ASC",
-				self::HOOK_EXECUTE_STEP,
-				self::GROUP,
-				gmdate( 'Y-m-d H:i:s' ),
-				'%"job_id"%'
+				...$query_args
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
@@ -273,9 +281,17 @@ class DrainJobAbility {
 			return (int) $args['job_id'];
 		}
 
+		if ( isset( $args['parent_job_id'] ) ) {
+			return (int) $args['parent_job_id'];
+		}
+
 		foreach ( $args as $value ) {
 			if ( is_array( $value ) && isset( $value['job_id'] ) ) {
 				return (int) $value['job_id'];
+			}
+
+			if ( is_array( $value ) && isset( $value['parent_job_id'] ) ) {
+				return (int) $value['parent_job_id'];
 			}
 		}
 

--- a/inc/Abilities/Engine/DrainJobAbility.php
+++ b/inc/Abilities/Engine/DrainJobAbility.php
@@ -227,17 +227,6 @@ class DrainJobAbility {
 
 		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
 		$groups_table  = $wpdb->prefix . 'actionscheduler_groups';
-		$hooks         = array( self::HOOK_EXECUTE_STEP, PipelineBatchScheduler::BATCH_HOOK );
-		$placeholders  = implode( ',', array_fill( 0, count( $hooks ), '%s' ) );
-		$query_args    = array_merge(
-			$hooks,
-			array(
-				self::GROUP,
-				gmdate( 'Y-m-d H:i:s' ),
-				'%"job_id"%',
-				'%"parent_job_id"%',
-			)
-		);
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names are generated from the WP prefix.
 		$rows = $wpdb->get_results(
@@ -245,13 +234,18 @@ class DrainJobAbility {
 				"SELECT a.action_id, a.args
 				 FROM {$actions_table} a
 				 INNER JOIN {$groups_table} g ON g.group_id = a.group_id
-				 WHERE a.hook IN ({$placeholders})
+				 WHERE a.hook IN (%s, %s)
 				 AND a.status = 'pending'
 				 AND g.slug = %s
 				 AND a.scheduled_date_gmt <= %s
 				 AND (a.args LIKE %s OR a.args LIKE %s)
 				 ORDER BY a.scheduled_date_gmt ASC, a.action_id ASC",
-				...$query_args
+				self::HOOK_EXECUTE_STEP,
+				PipelineBatchScheduler::BATCH_HOOK,
+				self::GROUP,
+				gmdate( 'Y-m-d H:i:s' ),
+				'%"job_id"%',
+				'%"parent_job_id"%'
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/tests/drain-job-ability-smoke.php
+++ b/tests/drain-job-ability-smoke.php
@@ -39,10 +39,12 @@ assert_drain_job_contains( "'step_budget'", $ability_source, 'step budget is exp
 assert_drain_job_contains( "'time_budget_ms'", $ability_source, 'wall-clock budget is exposed in input schema' );
 assert_drain_job_contains( "'error_type' => 'action_scheduler_unavailable'", $ability_source, 'AS unavailability returns a typed error' );
 assert_drain_job_contains( "\\ActionScheduler::runner()->process_action", $ability_source, 'ability uses Action Scheduler public action processor' );
-assert_drain_job_contains( "WHERE a.hook = %s", $ability_source, 'query scopes to execute-step actions' );
+assert_drain_job_contains( 'PipelineBatchScheduler::BATCH_HOOK', $ability_source, 'query includes pipeline batch chunk actions' );
+assert_drain_job_contains( 'WHERE a.hook IN', $ability_source, 'query scopes to drainable Data Machine actions' );
 assert_drain_job_contains( "AND a.status = 'pending'", $ability_source, 'query ignores already-claimed in-progress actions' );
 assert_drain_job_contains( "AND g.slug = %s", $ability_source, 'query scopes to Data Machine AS group' );
 assert_drain_job_contains( "extractActionJobId", $ability_source, 'query results are filtered to one job_id' );
+assert_drain_job_contains( "'parent_job_id'", $ability_source, 'query can match batch chunk parent_job_id args' );
 assert_drain_job_contains( 'JobStatus::isStatusFinal', $ability_source, 'drain stops on terminal job status' );
 assert_drain_job_contains( "'actions_drained'", $ability_source, 'output reports actions drained' );
 assert_drain_job_contains( "'wall_time_ms'", $ability_source, 'output reports elapsed wall time' );


### PR DESCRIPTION
## Summary
- Extend `datamachine/drain-job` to process pipeline batch chunk actions in addition to execute-step actions.
- Match both `job_id` and `parent_job_id` Action Scheduler args so synchronous callers can drive fetch fan-out batches to completion.
- Update the drain-job smoke assertions for the batch-action contract.

## Testing
- `php -l inc/Abilities/Engine/DrainJobAbility.php`
- `php tests/drain-job-ability-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@drain-pipeline-batch-actions --extension wordpress -- --filter=DrainJobAbilityTest`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the synchronous fan-out drain gap, drafted the targeted drain-job fix, and ran focused validation for Chris to review.