### PR TITLE
Fix flow settings display formatting lookups

### DIFF
--- a/inc/Core/Admin/FlowFormatter.php
+++ b/inc/Core/Admin/FlowFormatter.php
@@ -53,16 +53,14 @@ class FlowFormatter {
 				continue;
 			}
 
-			$step_data['settings_display'] = apply_filters(
-				'datamachine_get_handler_settings_display',
-				array(),
-				$flow_step_id,
+			$step_data['settings_display'] = $settings_display_service->getDisplaySettingsForStepConfig(
+				$step_data,
 				$step_type
 			);
 
 			// Multi-handler: per-handler settings displays keyed by slug.
-			$step_data['handler_settings_displays'] = $settings_display_service->getDisplaySettingsForHandlers(
-				$flow_step_id,
+			$step_data['handler_settings_displays'] = $settings_display_service->getDisplaySettingsForHandlersConfig(
+				$step_data,
 				$step_type
 			);
 

--- a/inc/Core/Admin/FlowFormatter.php
+++ b/inc/Core/Admin/FlowFormatter.php
@@ -74,8 +74,8 @@ class FlowFormatter {
 					if ( ! in_array( $effective_slug, $handler_slugs, true ) ) {
 						$handler_slugs[] = $effective_slug;
 					}
-					$step_data['handler_slugs']                          = $handler_slugs;
-					$step_data['handler_configs'][ $effective_slug ]     = $with_defaults;
+					$step_data['handler_slugs']                      = $handler_slugs;
+					$step_data['handler_configs'][ $effective_slug ] = $with_defaults;
 					unset( $step_data['handler_slug'], $step_data['handler_config'] );
 				} else {
 					$step_data['handler_config'] = $with_defaults;

--- a/inc/Core/Steps/Settings/SettingsDisplayService.php
+++ b/inc/Core/Steps/Settings/SettingsDisplayService.php
@@ -37,14 +37,30 @@ class SettingsDisplayService {
 	 * @return array Formatted settings display array
 	 */
 	public function getDisplaySettings( string $flow_step_id, string $step_type ): array {
-		if ( ! $this->shouldShowSettingsDisplay( $step_type ) ) {
-			return array();
-		}
-
 		// Get flow step configuration
 		$db_flows         = new \DataMachine\Core\Database\Flows\Flows();
 		$flow_step_config = $db_flows->get_flow_step_config( $flow_step_id );
 		if ( empty( $flow_step_config ) ) {
+			return array();
+		}
+
+		return $this->getDisplaySettingsForStepConfig( $flow_step_config, $step_type );
+	}
+
+	/**
+	 * Get formatted settings display from an already-loaded flow step config.
+	 *
+	 * Use this in batch/full-flow formatting paths that already have the step
+	 * configuration in memory to avoid re-reading it by flow step ID.
+	 *
+	 * @param array  $flow_step_config Flow step configuration array.
+	 * @param string $step_type Step type override (optional; falls back to config).
+	 * @return array Formatted settings display array.
+	 */
+	public function getDisplaySettingsForStepConfig( array $flow_step_config, string $step_type = '' ): array {
+		$step_type = '' !== $step_type ? $step_type : ( $flow_step_config['step_type'] ?? '' );
+
+		if ( ! $this->shouldShowSettingsDisplay( $step_type ) ) {
 			return array();
 		}
 
@@ -65,13 +81,26 @@ class SettingsDisplayService {
 	 * @return array<string, array> Map of handler_slug => settings display array.
 	 */
 	public function getDisplaySettingsForHandlers( string $flow_step_id, string $step_type ): array {
-		if ( ! $this->shouldShowSettingsDisplay( $step_type ) ) {
-			return array();
-		}
-
 		$db_flows         = new \DataMachine\Core\Database\Flows\Flows();
 		$flow_step_config = $db_flows->get_flow_step_config( $flow_step_id );
 		if ( empty( $flow_step_config ) ) {
+			return array();
+		}
+
+		return $this->getDisplaySettingsForHandlersConfig( $flow_step_config, $step_type );
+	}
+
+	/**
+	 * Get formatted settings display for all handlers from loaded step config.
+	 *
+	 * @param array  $flow_step_config Flow step configuration array.
+	 * @param string $step_type        Step type override (optional; falls back to config).
+	 * @return array<string, array> Map of handler_slug => settings display array.
+	 */
+	public function getDisplaySettingsForHandlersConfig( array $flow_step_config, string $step_type = '' ): array {
+		$step_type = '' !== $step_type ? $step_type : ( $flow_step_config['step_type'] ?? '' );
+
+		if ( ! $this->shouldShowSettingsDisplay( $step_type ) ) {
 			return array();
 		}
 

--- a/tests/flow-formatter-loaded-settings-display-smoke.php
+++ b/tests/flow-formatter-loaded-settings-display-smoke.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Smoke test for full-flow formatting settings displays from loaded config.
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core\Database\Flows {
+	class Flows {
+		public function get_flow_step_config( string $flow_step_id ): array {
+			throw new \RuntimeException( "Unexpected flow step config lookup for {$flow_step_id}." );
+		}
+
+		public static function is_flow_enabled( array $scheduling_config ): bool {
+			return (bool) ( $scheduling_config['enabled'] ?? false );
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ );
+	define( 'WPINC', 'wp-includes' );
+
+	require_once __DIR__ . '/smoke-wp-stubs.php';
+
+	if ( ! function_exists( '__' ) ) {
+		function __( string $text, string $domain = 'default' ): string {
+			return $text;
+		}
+	}
+
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( string $hook, ...$args ): void {
+			// no-op
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, $value, ...$args ) {
+			if ( 'datamachine_step_types' === $hook ) {
+				return array(
+					'fetch'   => array(
+						'uses_handler'          => true,
+						'multi_handler'         => false,
+						'show_settings_display' => true,
+					),
+					'publish' => array(
+						'uses_handler'          => true,
+						'multi_handler'         => true,
+						'show_settings_display' => true,
+					),
+				);
+			}
+
+			if ( 'datamachine_handler_settings' === $hook ) {
+				$handler_slug = $args[0] ?? '';
+				return array(
+					$handler_slug => new FlowFormatterLoadedConfigSettings(),
+				);
+			}
+
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $option, $default = false ) {
+			return $default;
+		}
+	}
+
+	if ( ! function_exists( 'wp_date' ) ) {
+		function wp_date( string $format, int $timestamp, ?\DateTimeZone $timezone = null ): string {
+			$date = new \DateTimeImmutable( '@' . $timestamp );
+			return $date->setTimezone( $timezone ?? new \DateTimeZone( 'UTC' ) )->format( $format );
+		}
+	}
+
+	require_once __DIR__ . '/../inc/Abilities/HandlerAbilities.php';
+	require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+	require_once __DIR__ . '/../inc/Core/Steps/Settings/SettingsDisplayService.php';
+	require_once __DIR__ . '/../inc/Core/Admin/DateFormatter.php';
+	require_once __DIR__ . '/../inc/Core/Admin/FlowFormatter.php';
+
+	class FlowFormatterLoadedConfigSettings {
+		public static function get_fields(): array {
+			return array(
+				'choice' => array(
+					'label'   => 'Choice',
+					'type'    => 'select',
+					'options' => array(
+						'a' => 'Aye',
+						'b' => 'Bee',
+					),
+				),
+				'flag'   => array(
+					'label' => 'Flag',
+					'type'  => 'checkbox',
+				),
+			);
+		}
+	}
+
+	function flow_formatter_loaded_config_expect( bool $condition, string $message ): void {
+		if ( ! $condition ) {
+			throw new \RuntimeException( $message );
+		}
+	}
+
+	$flow = array(
+		'flow_id'           => 123,
+		'flow_name'         => 'Loaded settings display smoke',
+		'pipeline_id'       => 456,
+		'scheduling_config' => array( 'enabled' => true ),
+		'flow_config'       => array(
+			'fetch_123'   => array(
+				'step_type'       => 'fetch',
+				'handler_slugs'   => array( 'alpha' ),
+				'handler_configs' => array(
+					'alpha' => array(
+						'choice' => 'b',
+						'flag'   => true,
+					),
+				),
+			),
+			'publish_123' => array(
+				'step_type'       => 'publish',
+				'handler_slugs'   => array( 'alpha', 'beta' ),
+				'handler_configs' => array(
+					'alpha' => array( 'choice' => 'a' ),
+					'beta'  => array( 'choice' => 'b' ),
+				),
+			),
+		),
+	);
+
+	$formatted = \DataMachine\Core\Admin\FlowFormatter::format_flow_for_response( $flow, null, array( 123 => null ) );
+	$config    = $formatted['flow_config'];
+
+	flow_formatter_loaded_config_expect( 'Choice: Bee | Flag: True' === $config['fetch_123']['settings_summary'], 'Single-handler settings summary should match loaded config.' );
+	flow_formatter_loaded_config_expect( 'Bee' === $config['fetch_123']['settings_display'][0]['display_value'], 'Single-handler settings display should use option labels.' );
+	flow_formatter_loaded_config_expect( 'Aye' === $config['publish_123']['handler_settings_displays']['alpha'][0]['display_value'], 'Multi-handler alpha display should match loaded config.' );
+	flow_formatter_loaded_config_expect( 'Bee' === $config['publish_123']['handler_settings_displays']['beta'][0]['display_value'], 'Multi-handler beta display should match loaded config.' );
+
+	echo "flow-formatter-loaded-settings-display-smoke passed\n";
+}


### PR DESCRIPTION
## Summary
- Add loaded-config settings display methods so callers that already have flow step config can format single-handler and multi-handler settings without re-reading by flow step ID.
- Switch full flow response formatting to use the loaded step config already in memory while preserving the existing ID-based service APIs.
- Add a smoke test that fails if full flow formatting calls back into `get_flow_step_config()` for settings display output.

Fixes #1956

## Testing
- `php -l inc/Core/Admin/FlowFormatter.php && php -l inc/Core/Steps/Settings/SettingsDisplayService.php && php -l tests/flow-formatter-loaded-settings-display-smoke.php`
- `php tests/flow-formatter-loaded-settings-display-smoke.php`
- `php tests/flow-step-legacy-handler-field-smoke.php`
- `git diff --check`

## Known existing failure
- `php tests/flow-step-config-overlays-smoke.php` fails on existing handler-shape expectations unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the backend change and smoke test; Chris remains responsible for review and merge.