### PR TITLE
Render pipeline shell while flows load

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx
@@ -2,7 +2,7 @@
  * Pipelines App Root Component
  *
  * Container component that manages the entire pipeline interface state and data.
- * @pattern Container - Fetches all pipeline-related data and manages global state
+ * Pattern: Container - Fetches all pipeline-related data and manages global state
  */
 
 /**
@@ -83,8 +83,42 @@ export default function PipelinesApp() {
 		page: flowsPage,
 		perPage: flowsPerPage,
 	} );
-	const flows = useMemo( () => flowsData?.flows ?? [], [ flowsData ] );
-	const flowsTotal = flowsData?.total ?? 0;
+	const [ previousFlowsData, setPreviousFlowsData ] = useState( {
+		pipelineId: null,
+		data: null,
+	} );
+
+	useEffect( () => {
+		setPreviousFlowsData( {
+			pipelineId: selectedPipelineId,
+			data: null,
+		} );
+	}, [ selectedPipelineId ] );
+
+	useEffect( () => {
+		if ( flowsData ) {
+			setPreviousFlowsData( {
+				pipelineId: selectedPipelineId,
+				data: flowsData,
+			} );
+		}
+	}, [ flowsData, selectedPipelineId ] );
+
+	const previousFlowsForSelectedPipeline = isSameId(
+		previousFlowsData.pipelineId,
+		selectedPipelineId
+	)
+		? previousFlowsData.data
+		: null;
+	const displayFlowsData =
+		flowsData || ( flowsLoading ? previousFlowsForSelectedPipeline : null );
+	const flows = useMemo( () => {
+		return {
+			items: displayFlowsData?.flows ?? [],
+			isLoading: flowsLoading,
+		};
+	}, [ displayFlowsData, flowsLoading ] );
+	const flowsTotal = displayFlowsData?.total ?? 0;
 
 	const createPipelineMutation = useCreatePipeline( {
 		onSuccess: ( pipelineId ) => {
@@ -187,7 +221,7 @@ export default function PipelinesApp() {
 	 */
 	const renderMainContent = () => {
 		// Loading state
-		if ( pipelinesLoading || selectedPipelineLoading || flowsLoading ) {
+		if ( pipelinesLoading || selectedPipelineLoading ) {
 			return (
 				<div className="datamachine-pipelines-loading">
 					<Spinner />

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowsSection.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowsSection.jsx
@@ -7,6 +7,7 @@
  */
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Spinner } from '@wordpress/components';
 /**
  * Internal dependencies
  */
@@ -29,6 +30,9 @@ export default function FlowsSection( {
 } ) {
 	// Use mutations
 	const createFlowMutation = useCreateFlow();
+	const flowItems = Array.isArray( flows ) ? flows : flows?.items ?? [];
+	const isLoading = ! Array.isArray( flows ) && flows?.isLoading === true;
+	const hasFlows = flowItems.length > 0;
 
 	/**
 	 * Handle flow creation
@@ -71,7 +75,21 @@ export default function FlowsSection( {
 	/**
 	 * Empty state
 	 */
-	if ( ! flows || flows.length === 0 ) {
+	if ( isLoading && ! hasFlows ) {
+		return (
+			<div className="datamachine-flows-section datamachine-flows-section--loading">
+				<h3 className="datamachine-flows-section__title">
+					{ __( 'Flows', 'data-machine' ) }
+				</h3>
+				<div className="datamachine-pipelines-loading">
+					<Spinner />
+					<p>{ __( 'Loading flows…', 'data-machine' ) }</p>
+				</div>
+			</div>
+		);
+	}
+
+	if ( ! hasFlows ) {
 		return (
 			<div className="datamachine-flows-section datamachine-flows-section--empty">
 				<h3 className="datamachine-flows-section__title">
@@ -103,10 +121,16 @@ export default function FlowsSection( {
 						({ total })
 					</span>
 				</h3>
+				{ isLoading && (
+					<div className="datamachine-flows-section__loading">
+						<Spinner />
+						<span>{ __( 'Loading flows…', 'data-machine' ) }</span>
+					</div>
+				) }
 			</div>
 
 			<div className="datamachine-flows-list">
-				{ flows.map( ( flow ) => (
+				{ flowItems.map( ( flow ) => (
 					<FlowCard
 						key={ flow.flow_id }
 						flow={ flow }


### PR DESCRIPTION
## Summary
- Keeps the global Pipelines page loader scoped to pipeline metadata and selected-pipeline fetches.
- Moves flow fetch loading into `FlowsSection` so the selected pipeline header and steps render while `/flows` is still loading.
- Reuses the previous flow page for the selected pipeline during flow pagination/loading to avoid blanking the section.

Fixes #1953.

## Testing
- `npm exec wp-scripts lint-js -- inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowsSection.jsx`
- `npm exec wp-scripts format -- --check inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowsSection.jsx`
- `git diff --check`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the React loading-state change, ran focused lint/format/build checks, and prepared the PR. Chris remains responsible for review and merge.