### PR TITLE
Support flow output mode in REST

### DIFF
--- a/inc/Api/Flows/Flows.php
+++ b/inc/Api/Flows/Flows.php
@@ -103,6 +103,14 @@ class Flows {
 						'sanitize_callback' => 'absint',
 						'description'       => __( 'Offset for pagination', 'data-machine' ),
 					),
+					'output_mode' => array(
+						'required'          => false,
+						'type'              => 'string',
+						'enum'              => array( 'full', 'list', 'summary', 'ids' ),
+						'default'           => 'full',
+						'sanitize_callback' => 'sanitize_key',
+						'description'       => __( 'Output mode for returned flows: full, list, summary, or ids.', 'data-machine' ),
+					),
 					'user_id'     => array(
 						'required'          => false,
 						'type'              => 'integer',
@@ -496,6 +504,7 @@ class Flows {
 		$pipeline_id     = $request->get_param( 'pipeline_id' );
 		$per_page        = $request->get_param( 'per_page' ) ?? 20;
 		$offset          = $request->get_param( 'offset' ) ?? 0;
+		$output_mode     = $request->get_param( 'output_mode' ) ?? 'full';
 		$scoped_user_id  = PermissionHelper::resolve_scoped_user_id( $request );
 		$scoped_agent_id = PermissionHelper::resolve_scoped_agent_id( $request );
 
@@ -508,6 +517,7 @@ class Flows {
 			'pipeline_id' => $pipeline_id,
 			'per_page'    => $per_page,
 			'offset'      => $offset,
+			'output_mode' => $output_mode,
 		);
 		if ( null !== $scoped_agent_id ) {
 			$input['agent_id'] = $scoped_agent_id;

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
@@ -126,11 +126,12 @@ const patchFlowStepInCache = (
 // Queries
 export const useFlows = ( pipelineId, { page = 1, perPage = 20 } = {} ) => {
 	const cachedPipelineId = normalizeId( pipelineId );
+	const outputMode = 'list';
 
 	return useQuery( {
-		queryKey: [ 'flows', cachedPipelineId, { page, perPage } ],
+		queryKey: [ 'flows', cachedPipelineId, { page, perPage, outputMode } ],
 		queryFn: async () => {
-			const response = await fetchFlows( pipelineId, { page, perPage } );
+			const response = await fetchFlows( pipelineId, { page, perPage, outputMode } );
 			if ( ! response.success ) {
 				return { flows: [], total: 0, perPage, offset: 0 };
 			}

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
@@ -187,21 +187,23 @@ export const updateSystemPrompt = async (
 /**
  * Fetch flows for a pipeline with pagination
  *
- * @param {number} pipelineId      - Pipeline ID
- * @param {Object} options         - Pagination options
- * @param {number} options.page    - Current page (1-indexed)
- * @param {number} options.perPage - Items per page
+ * @param {number} pipelineId         - Pipeline ID
+ * @param {Object} options            - Pagination options
+ * @param {number} options.page       - Current page (1-indexed)
+ * @param {number} options.perPage    - Items per page
+ * @param {string} options.outputMode - Flow output mode (default list)
  * @return {Promise<Object>} Paginated flows response
  */
 export const fetchFlows = async (
 	pipelineId,
-	{ page = 1, perPage = 20 } = {}
+	{ page = 1, perPage = 20, outputMode = 'list' } = {}
 ) => {
 	const offset = ( page - 1 ) * perPage;
 	return await client.get( '/flows', {
 		pipeline_id: pipelineId,
 		per_page: perPage,
 		offset,
+		output_mode: outputMode,
 	} );
 };
 

--- a/tests/Unit/Api/Flows/FlowsEndpointTest.php
+++ b/tests/Unit/Api/Flows/FlowsEndpointTest.php
@@ -88,6 +88,21 @@ class FlowsEndpointTest extends WP_UnitTestCase {
 		$this->assertEquals(0, $data['offset']);
 	}
 
+	public function test_get_flows_accepts_output_mode(): void {
+		$request = new WP_REST_Request('GET', '/datamachine/v1/flows');
+		$request->set_param('pipeline_id', $this->test_pipeline_id);
+		$request->set_param('output_mode', 'ids');
+
+		$response = Flows::handle_get_flows($request);
+
+		$this->assertSame(200, $response->get_status());
+		$data = $response->get_data();
+		$this->assertTrue($data['success']);
+		$this->assertArrayHasKey('flows', $data['data']);
+		$this->assertContains($this->test_flow_id, $data['data']['flows']);
+		$this->assertContainsOnly('int', $data['data']['flows']);
+	}
+
 	public function test_response_structure(): void {
 		$request = new WP_REST_Request('GET', '/datamachine/v1/flows');
 


### PR DESCRIPTION
## Summary
- Adds `output_mode` to `GET /datamachine/v1/flows` and forwards it to `datamachine/get-flows`.
- Keeps omitted `output_mode` behavior defaulting to `full` for existing REST callers.
- Updates the Pipelines page flow fetcher to request `output_mode=list` for lighter flow list responses.

Fixes #1954.

## Tests
- `php -l inc/Api/Flows/Flows.php && php -l tests/Unit/Api/Flows/FlowsEndpointTest.php`
- `npm run build`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-flows-rest-output-mode --extension wordpress --skip-lint --changed-since origin/main` (7 passed)
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-flows-rest-output-mode --extension wordpress --changed-since origin/main` (passed; existing baseline JS warnings unchanged)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the scoped REST/frontend wiring, added the endpoint regression test, and ran targeted verification. Chris remains responsible for review and merge.