### PR TITLE
Use lightweight pipeline flow list queries

### DIFF
--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -438,7 +438,7 @@ trait FlowHelpers {
 			$override = $this->resolveOverride( $overrides, $step_type, $order );
 			if ( $override ) {
 				if ( ! empty( $override['handler_slug'] ) ) {
-					$handler_config = $override['handler_config'] ?? array();
+					$handler_config  = $override['handler_config'] ?? array();
 					$new_step_config = FlowStepConfigFactory::withHandlerConfig( $new_step_config, $override['handler_slug'], $handler_config );
 				} elseif ( ! empty( $override['handler_config'] ) ) {
 					$new_step_config = FlowStepConfigFactory::withHandlerConfig( $new_step_config, '', $override['handler_config'], true );

--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -206,8 +206,8 @@ trait FlowHelpers {
 	}
 
 	/**
-	 * Format flow for list views — includes flow_config and scheduling
-	 * but skips the expensive handler settings enrichment in FlowFormatter.
+	 * Format flow for list views with status fields but without the expensive
+	 * handler settings enrichment in FlowFormatter.
 	 *
 	 * @param array       $flow Flow data.
 	 * @param array|null  $latest_jobs Pre-fetched latest jobs keyed by flow_id.

--- a/inc/Abilities/Flow/GetFlowsAbility.php
+++ b/inc/Abilities/Flow/GetFlowsAbility.php
@@ -164,11 +164,14 @@ class GetFlowsAbility {
 			$flows = array();
 			$total = 0;
 
-			// Use lightweight summary query for modes that don't need flow_config.
-			$use_summary_query = in_array( $output_mode, array( 'summary', 'ids' ), true );
+			// Use lightweight summary queries for modes that don't need flow_config.
+			// Handler filtering still needs flow_config to inspect step handlers.
+			$use_summary_query = in_array( $output_mode, array( 'list', 'summary', 'ids' ), true ) && ! $handler_slug;
 
 			if ( $pipeline_id ) {
-				$flows = $this->db_flows->get_flows_for_pipeline_paginated( $pipeline_id, $effective_per_page, $offset );
+				$flows = $use_summary_query
+					? $this->db_flows->get_flows_for_pipeline_summary( $pipeline_id, $effective_per_page, $offset )
+					: $this->db_flows->get_flows_for_pipeline_paginated( $pipeline_id, $effective_per_page, $offset );
 				$total = $this->db_flows->count_flows_for_pipeline( $pipeline_id );
 			} elseif ( $use_summary_query ) {
 				$flows = $this->db_flows->get_all_flows_summary( $effective_per_page, $offset, $user_id, $agent_id );

--- a/inc/Api/Flows/Flows.php
+++ b/inc/Api/Flows/Flows.php
@@ -109,6 +109,14 @@ class Flows {
 						'description'       => __( 'Filter by user ID (admin only, non-admins always see own data)', 'data-machine' ),
 						'sanitize_callback' => 'absint',
 					),
+					'output_mode' => array(
+						'required'          => false,
+						'type'              => 'string',
+						'default'           => 'full',
+						'enum'              => array( 'full', 'list', 'summary', 'ids' ),
+						'description'       => __( 'Output mode for flow list responses.', 'data-machine' ),
+						'sanitize_callback' => 'sanitize_key',
+					),
 				),
 			)
 		);
@@ -496,6 +504,7 @@ class Flows {
 		$pipeline_id     = $request->get_param( 'pipeline_id' );
 		$per_page        = $request->get_param( 'per_page' ) ?? 20;
 		$offset          = $request->get_param( 'offset' ) ?? 0;
+		$output_mode     = $request->get_param( 'output_mode' ) ?? 'full';
 		$scoped_user_id  = PermissionHelper::resolve_scoped_user_id( $request );
 		$scoped_agent_id = PermissionHelper::resolve_scoped_agent_id( $request );
 
@@ -508,6 +517,7 @@ class Flows {
 			'pipeline_id' => $pipeline_id,
 			'per_page'    => $per_page,
 			'offset'      => $offset,
+			'output_mode' => $output_mode,
 		);
 		if ( null !== $scoped_agent_id ) {
 			$input['agent_id'] = $scoped_agent_id;

--- a/inc/Api/Flows/Flows.php
+++ b/inc/Api/Flows/Flows.php
@@ -117,14 +117,6 @@ class Flows {
 						'description'       => __( 'Filter by user ID (admin only, non-admins always see own data)', 'data-machine' ),
 						'sanitize_callback' => 'absint',
 					),
-					'output_mode' => array(
-						'required'          => false,
-						'type'              => 'string',
-						'default'           => 'full',
-						'enum'              => array( 'full', 'list', 'summary', 'ids' ),
-						'description'       => __( 'Output mode for flow list responses.', 'data-machine' ),
-						'sanitize_callback' => 'sanitize_key',
-					),
 				),
 			)
 		);

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -466,6 +466,43 @@ class Flows extends BaseRepository {
 	}
 
 	/**
+	 * Get paginated flows for a pipeline without loading flow_config longtext.
+	 *
+	 * @since 0.66.1
+	 *
+	 * @param int $pipeline_id Pipeline ID.
+	 * @param int $per_page    Number of flows per page.
+	 * @param int $offset      Offset for pagination.
+	 * @return array Flows array without decoded flow_config.
+	 */
+	public function get_flows_for_pipeline_summary( int $pipeline_id, int $per_page = 20, int $offset = 0 ): array {
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+		$flows = $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				'SELECT flow_id, flow_name, pipeline_id, scheduling_config, user_id, agent_id FROM %i WHERE pipeline_id = %d ORDER BY flow_id ASC LIMIT %d OFFSET %d',
+				$this->table_name,
+				$pipeline_id,
+				$per_page,
+				$offset
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL
+
+		if ( null === $flows ) {
+			return array();
+		}
+
+		foreach ( $flows as &$flow ) {
+			$flow['scheduling_config'] = json_decode( $flow['scheduling_config'], true ) ?? array();
+			$flow['flow_config']       = array(); // Not loaded — placeholder for consistent interface.
+		}
+
+		return $flows;
+	}
+
+	/**
 	 * Count total flows for a pipeline
 	 *
 	 * @param int $pipeline_id Pipeline ID

--- a/tests/flow-list-lightweight-query-smoke.php
+++ b/tests/flow-list-lightweight-query-smoke.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Smoke test for lightweight pipeline flow list queries.
+ *
+ * Verifies that list/summary pipeline requests can avoid selecting and
+ * decoding the large flow_config longtext blob.
+ */
+
+$root = dirname( __DIR__ );
+
+$get_flows = file_get_contents( $root . '/inc/Abilities/Flow/GetFlowsAbility.php' );
+$flows_db  = file_get_contents( $root . '/inc/Core/Database/Flows/Flows.php' );
+$rest_api  = file_get_contents( $root . '/inc/Api/Flows/Flows.php' );
+
+$failures = array();
+
+$assert = static function ( string $label, bool $condition ) use ( &$failures ): void {
+	if ( ! $condition ) {
+		$failures[] = $label;
+	}
+};
+
+$assert(
+	'pipeline list modes include list/summary/ids in lightweight query gate',
+	false !== strpos( $get_flows, "array( 'list', 'summary', 'ids' )" )
+);
+
+$assert(
+	'handler_slug disables lightweight query so handler filtering can inspect flow_config',
+	false !== strpos( $get_flows, '&& ! $handler_slug' )
+);
+
+$assert(
+	'pipeline-scoped list path calls get_flows_for_pipeline_summary',
+	false !== strpos( $get_flows, 'get_flows_for_pipeline_summary' )
+);
+
+$summary_method_pos = strpos( $flows_db, 'function get_flows_for_pipeline_summary' );
+$assert( 'pipeline summary query method exists', false !== $summary_method_pos );
+
+if ( false !== $summary_method_pos ) {
+	$summary_method = substr( $flows_db, $summary_method_pos, 1600 );
+	$assert(
+		'pipeline summary query selects explicit lightweight columns',
+		false !== strpos( $summary_method, 'SELECT flow_id, flow_name, pipeline_id, scheduling_config, user_id, agent_id' )
+	);
+	$assert(
+		'pipeline summary query does not select all columns',
+		false === strpos( $summary_method, 'SELECT *' )
+	);
+	$assert(
+		'pipeline summary query does not decode flow_config',
+		false === strpos( $summary_method, 'json_decode( ' . '$flow' . "['flow_config']" )
+	);
+}
+
+$assert(
+	'REST flows endpoint accepts output_mode',
+	false !== strpos( $rest_api, "'output_mode' => array(" ) && false !== strpos( $rest_api, "'output_mode' => " . '$output_mode' )
+);
+
+if ( $failures ) {
+	fwrite( STDERR, "Lightweight flow list query smoke failed:\n- " . implode( "\n- ", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo "Lightweight flow list query smoke passed.\n";


### PR DESCRIPTION
## Summary
- Add a pipeline-scoped flow summary query that selects explicit lightweight columns and leaves `flow_config` unloaded.
- Route `output_mode=list|summary|ids` pipeline list requests through the lightweight query unless `handler_slug` filtering requires full config inspection.
- Expose the existing `output_mode` contract on the `/datamachine/v1/flows` REST list endpoint.

Refs #1955
Fixes #1957

## Tests
- `php -l inc/Abilities/Flow/GetFlowsAbility.php && php -l inc/Abilities/Flow/FlowHelpers.php && php -l inc/Core/Database/Flows/Flows.php && php -l inc/Api/Flows/Flows.php && php -l tests/flow-list-lightweight-query-smoke.php`
- `php tests/flow-list-lightweight-query-smoke.php`
- `vendor/bin/phpcs inc/Abilities/Flow/GetFlowsAbility.php inc/Abilities/Flow/FlowHelpers.php inc/Core/Database/Flows/Flows.php inc/Api/Flows/Flows.php tests/flow-list-lightweight-query-smoke.php`
- `homeboy test --path . --extension wordpress --changed-since origin/main`

## Notes
- `output_mode=full` still uses the existing full query and full formatting path.
- `handler_slug` filtering stays on the full query because it must inspect decoded flow step handler configuration.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the server-side query/routing change, smoke coverage, and test execution; Chris remains responsible for review and merge decisions.