### PR TITLE
Emit DataPackets from workflow system tasks

### DIFF
--- a/inc/Core/Steps/FlowStepConfigFactory.php
+++ b/inc/Core/Steps/FlowStepConfigFactory.php
@@ -112,6 +112,8 @@ class FlowStepConfigFactory {
 			'execution_order'                     => true,
 			'enabled_tools'                       => true,
 			'disabled_tools'                      => true,
+			'completion_assertions'               => true,
+			'tool_runtime_rules'                  => true,
 			QueueAbility::SLOT_PROMPT_QUEUE       => true,
 			QueueAbility::SLOT_CONFIG_PATCH_QUEUE => true,
 			'queue_mode'                          => true,

--- a/inc/Core/Steps/SystemTask/SystemTaskStep.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskStep.php
@@ -381,9 +381,22 @@ class SystemTaskStep extends Step {
 			$error_msg = $child_data['error'] ?? 'Task reported failure';
 		}
 
+		if ( ! empty( $child_data['job_status'] ) && is_string( $child_data['job_status'] ) ) {
+			$this->engine->set( 'job_status', $child_data['job_status'] );
+		}
+
 		$skipped = ! empty( $child_data['skipped'] );
 		if ( $skipped ) {
 			$success = true;
+		}
+
+		$result = ! empty( $child_data['replace_data_packets'] ) ? array() : $this->dataPackets;
+		foreach ( $this->normalizeOutputDataPackets( $child_data['output_data_packets'] ?? array(), $task_type, (int) $child_job_id ) as $packet ) {
+			$result = $packet->addTo( $result );
+		}
+
+		if ( ! empty( $child_data['suppress_result_packet'] ) ) {
+			return $result;
 		}
 
 		$body = $success
@@ -409,6 +422,50 @@ class SystemTaskStep extends Step {
 			'system_task_result'
 		);
 
-		return $result_packet->addTo( $this->dataPackets );
+		return $result_packet->addTo( $result );
+	}
+
+	/**
+	 * Normalize task-emitted packet arrays into DataPacket objects.
+	 *
+	 * System tasks can set output_data_packets in child job engine_data to
+	 * hand precise packets to downstream workflow steps. This keeps the
+	 * pipeline handoff contract on DataPackets instead of task-specific fields.
+	 *
+	 * @param mixed  $packets      Raw output packet declarations.
+	 * @param string $task_type    Task type for default metadata.
+	 * @param int    $child_job_id Child job ID for default metadata.
+	 * @return array<int, DataPacket>
+	 */
+	private function normalizeOutputDataPackets( $packets, string $task_type, int $child_job_id ): array {
+		if ( ! is_array( $packets ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $packets as $packet ) {
+			if ( ! is_array( $packet ) ) {
+				continue;
+			}
+
+			$data     = is_array( $packet['data'] ?? null ) ? $packet['data'] : $packet;
+			$type     = isset( $packet['type'] ) && is_string( $packet['type'] ) && '' !== $packet['type']
+				? $packet['type']
+				: 'system_task_output';
+			$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+			$metadata = array_merge(
+				array(
+					'source_type'  => 'system_task',
+					'task_type'    => $task_type,
+					'child_job_id' => $child_job_id,
+					'success'      => true,
+				),
+				$metadata
+			);
+
+			$normalized[] = new DataPacket( $data, $metadata, $type );
+		}
+
+		return $normalized;
 	}
 }

--- a/inc/Core/Steps/WorkflowConfigFactory.php
+++ b/inc/Core/Steps/WorkflowConfigFactory.php
@@ -137,6 +137,13 @@ class WorkflowConfigFactory {
 		if ( 'ai' === $step_type ) {
 			$pipeline_step['system_prompt']  = $step['system_prompt'] ?? '';
 			$pipeline_step['disabled_tools'] = is_array( $step['disabled_tools'] ?? null ) ? array_values( $step['disabled_tools'] ) : array();
+			foreach ( array( 'completion_assertions', 'tool_runtime_rules', 'tool_categories' ) as $field ) {
+				if ( is_array( $step[ $field ] ?? null ) ) {
+					$pipeline_step[ $field ] = 'completion_assertions' === $field
+						? $step[ $field ]
+						: array_values( $step[ $field ] );
+				}
+			}
 		}
 
 		return $pipeline_step;

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -19,6 +19,7 @@ use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Engine\AI\System\Tasks\AgentCallTask;
 use DataMachine\Engine\AI\System\Tasks\AltTextTask;
 use DataMachine\Engine\AI\System\Tasks\DailyMemoryTask;
+use DataMachine\Engine\AI\System\Tasks\EmitDataPacketsTask;
 use DataMachine\Engine\AI\System\Tasks\ImageGenerationTask;
 use DataMachine\Engine\AI\System\Tasks\ImageOptimizationTask;
 use DataMachine\Engine\AI\System\Tasks\InternalLinkingTask;
@@ -73,6 +74,7 @@ class SystemAgentServiceProvider {
 	 */
 	public function getBuiltInTasks( array $tasks ): array {
 		$tasks['agent_call']                             = AgentCallTask::class;
+		$tasks['emit_data_packets']                      = EmitDataPacketsTask::class;
 		$tasks['image_generation']                       = ImageGenerationTask::class;
 		$tasks['image_optimization']                     = ImageOptimizationTask::class;
 		$tasks['alt_text_generation']                    = AltTextTask::class;
@@ -256,6 +258,9 @@ class SystemAgentServiceProvider {
 			$hook        = RecurringScheduleRegistry::hookFor( $schedule );
 			$task_type   = $schedule['task_type'];
 			$schedule_id = $schedule['schedule_id'];
+			if ( '' === $hook ) {
+				continue;
+			}
 
 			add_action(
 				$hook,

--- a/inc/Engine/AI/System/Tasks/EmitDataPacketsTask.php
+++ b/inc/Engine/AI/System/Tasks/EmitDataPacketsTask.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Emit Data Packets System Task.
+ *
+ * Bridges deterministic task output into the pipeline DataPacket handoff
+ * contract. Useful for workflow boundaries where a task produces zero or
+ * more packets that should drive downstream continuation/fan-out.
+ *
+ * @package DataMachine\Engine\AI\System\Tasks
+ */
+
+namespace DataMachine\Engine\AI\System\Tasks;
+
+use DataMachine\Core\JobStatus;
+
+defined( 'ABSPATH' ) || exit;
+
+class EmitDataPacketsTask extends SystemTask {
+
+	public function getTaskType(): string {
+		return 'emit_data_packets';
+	}
+
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Emit Data Packets',
+			'description'     => 'Emit configured DataPackets for downstream workflow continuation or fan-out.',
+			'setting_key'     => null,
+			'default_enabled' => true,
+			'trigger'         => 'On-demand via workflow system_task step',
+			'trigger_type'    => 'manual',
+			'supports_run'    => true,
+		);
+	}
+
+	public function executeTask( int $jobId, array $params ): void {
+		$packets = is_array( $params['packets'] ?? null ) ? array_values( $params['packets'] ) : array();
+
+		$result = array(
+			'output_data_packets'    => $packets,
+			'replace_data_packets'   => array_key_exists( 'replace_data_packets', $params ) ? (bool) $params['replace_data_packets'] : true,
+			'suppress_result_packet' => array_key_exists( 'suppress_result_packet', $params ) ? (bool) $params['suppress_result_packet'] : true,
+			'packet_count'           => count( $packets ),
+			'completed_at'           => current_time( 'mysql' ),
+		);
+
+		if ( empty( $packets ) && ! empty( $params['complete_no_items'] ) ) {
+			$result['job_status'] = JobStatus::COMPLETED_NO_ITEMS;
+		}
+
+		$this->completeJob( $jobId, $result );
+	}
+}

--- a/tests/system-task-output-packets-smoke.php
+++ b/tests/system-task-output-packets-smoke.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Pure-PHP smoke test for system task DataPacket output handoff.
+ *
+ * Run with: php tests/system-task-output-packets-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$root = dirname( __DIR__ );
+
+$sources = array(
+	'step'     => file_get_contents( $root . '/inc/Core/Steps/SystemTask/SystemTaskStep.php' ) ?: '',
+	'task'     => file_get_contents( $root . '/inc/Engine/AI/System/Tasks/EmitDataPacketsTask.php' ) ?: '',
+	'provider' => file_get_contents( $root . '/inc/Engine/AI/System/SystemAgentServiceProvider.php' ) ?: '',
+	'engine'   => file_get_contents( $root . '/inc/Abilities/Engine/ExecuteStepAbility.php' ) ?: '',
+);
+
+$failures = array();
+$passes   = 0;
+
+function assert_system_task_output_contains( string $haystack, string $needle, string $message, array &$failures, int &$passes ): void {
+	if ( str_contains( $haystack, $needle ) ) {
+		++$passes;
+		echo "  [PASS] {$message}\n";
+		return;
+	}
+
+	$failures[] = $message;
+	echo "  [FAIL] {$message}\n";
+	echo "    missing: {$needle}\n";
+}
+
+echo "=== system-task-output-packets-smoke ===\n";
+
+echo "\n[1] SystemTaskStep exposes child task packet output\n";
+assert_system_task_output_contains( $sources['step'], 'output_data_packets', 'SystemTaskStep reads child output_data_packets', $failures, $passes );
+assert_system_task_output_contains( $sources['step'], 'replace_data_packets', 'SystemTaskStep can replace incoming packets', $failures, $passes );
+assert_system_task_output_contains( $sources['step'], 'suppress_result_packet', 'SystemTaskStep can suppress synthetic result packet', $failures, $passes );
+assert_system_task_output_contains( $sources['step'], "\$this->engine->set( 'job_status'", 'SystemTaskStep propagates child job_status override to parent engine', $failures, $passes );
+assert_system_task_output_contains( $sources['step'], 'normalizeOutputDataPackets', 'SystemTaskStep normalizes task packet declarations', $failures, $passes );
+
+echo "\n[2] emit_data_packets task provides generic workflow boundary\n";
+assert_system_task_output_contains( $sources['task'], "return 'emit_data_packets';", 'EmitDataPacketsTask declares task type', $failures, $passes );
+assert_system_task_output_contains( $sources['task'], "'output_data_packets'", 'EmitDataPacketsTask writes output_data_packets', $failures, $passes );
+assert_system_task_output_contains( $sources['task'], "'replace_data_packets'", 'EmitDataPacketsTask controls packet replacement', $failures, $passes );
+assert_system_task_output_contains( $sources['task'], "'suppress_result_packet'", 'EmitDataPacketsTask controls result packet suppression', $failures, $passes );
+assert_system_task_output_contains( $sources['task'], 'JobStatus::COMPLETED_NO_ITEMS', 'EmitDataPacketsTask can mark zero-output stages completed_no_items', $failures, $passes );
+
+echo "\n[3] task is registered for execute-workflow system_task steps\n";
+assert_system_task_output_contains( $sources['provider'], 'use DataMachine\\Engine\\AI\\System\\Tasks\\EmitDataPacketsTask;', 'SystemAgentServiceProvider imports EmitDataPacketsTask', $failures, $passes );
+assert_system_task_output_contains( $sources['provider'], "\$tasks['emit_data_packets']", 'SystemAgentServiceProvider registers emit_data_packets', $failures, $passes );
+
+echo "\n[4] engine status override can stop after zero emitted packets\n";
+assert_system_task_output_contains( $sources['engine'], 'if ( $status_override )', 'ExecuteStepAbility honors status override before normal continuation', $failures, $passes );
+assert_system_task_output_contains( $sources['engine'], 'JobStatus::COMPLETED_NO_ITEMS', 'ExecuteStepAbility recognizes completed_no_items statuses', $failures, $passes );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " system task output packet assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} system task output packet assertions passed.\n";

--- a/tests/workflow-spec-contract-smoke.php
+++ b/tests/workflow-spec-contract-smoke.php
@@ -162,6 +162,15 @@ $configs         = WorkflowConfigFactory::buildEphemeralConfigs(
 				'label'          => 'Summarize',
 				'system_prompt'  => 'Be concise.',
 				'disabled_tools' => array( 'danger_tool' ),
+				'completion_assertions' => array(
+					'required_tool_names' => array( 'publish_result' ),
+				),
+				'tool_runtime_rules' => array(
+					array(
+						'id'        => 'after-worktree',
+						'max_calls' => 4,
+					),
+				),
 			),
 			array(
 				'type'           => 'system_task',
@@ -180,6 +189,8 @@ assert_workflow_spec_equals( array( 0, 1, 2 ), array_column( $pipeline_steps, 'e
 assert_workflow_spec_equals( 'Fetch Source', $pipeline_steps[0]['label'] ?? null, 'ephemeral pipeline_config preserves fetch label', $failures, $passes );
 assert_workflow_spec_equals( 'Be concise.', $pipeline_steps[1]['system_prompt'] ?? null, 'ephemeral pipeline_config preserves AI system prompt', $failures, $passes );
 assert_workflow_spec_equals( array( 'danger_tool' ), $pipeline_steps[1]['disabled_tools'] ?? null, 'ephemeral pipeline_config preserves AI disabled tools', $failures, $passes );
+assert_workflow_spec_equals( array( 'required_tool_names' => array( 'publish_result' ) ), $pipeline_steps[1]['completion_assertions'] ?? null, 'ephemeral pipeline_config preserves AI completion assertions', $failures, $passes );
+assert_workflow_spec_equals( array( array( 'id' => 'after-worktree', 'max_calls' => 4 ) ), $pipeline_steps[1]['tool_runtime_rules'] ?? null, 'ephemeral pipeline_config preserves AI tool runtime rules', $failures, $passes );
 assert_workflow_spec_equals( 'Cleanup', $pipeline_steps[2]['label'] ?? null, 'ephemeral pipeline_config preserves system_task label', $failures, $passes );
 assert_workflow_spec_equals( false, array_key_exists( 'system_prompt', $pipeline_steps[2] ), 'non-AI ephemeral pipeline rows do not gain AI metadata', $failures, $passes );
 


### PR DESCRIPTION
## Summary
- Add an `emit_data_packets` system task so deterministic workflow stages can hand zero or more DataPackets to downstream steps.
- Allow `SystemTaskStep` to replace/suppress packets and propagate a child `job_status`, enabling zero-output stages to complete as `completed_no_items`.
- Preserve AI workflow metadata (`completion_assertions`, `tool_runtime_rules`, `tool_categories`) when building ephemeral `execute-workflow` configs.

## Testing
- `php tests/workflow-spec-contract-smoke.php`
- `php tests/system-task-output-packets-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@feat-execute-workflow-site-chain --extension wordpress --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting and implementing the DataPacket handoff task, workflow config preservation changes, and smoke coverage. Chris reviewed direction and requested the PR.