### PR TITLE
Use reusable Homeboy workflow

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -19,44 +19,9 @@ permissions:
 
 jobs:
   homeboy:
-    name: Homeboy (${{ matrix.command }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        command: [audit, lint, test]
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: ''
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-          MYSQL_DATABASE: homeboy_wptests
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        continue-on-error: true
-        with:
-          app-id: ${{ secrets.HOMEBOY_APP_ID }}
-          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
-
-      - name: Run Homeboy ${{ matrix.command }}
-        uses: Extra-Chill/homeboy-action@v2
-        with:
-          commands: ${{ matrix.command }}
-          expected-commands: audit,lint,test
-          args: ${{ matrix.command == 'test' && '--setting playground_wordpress_version=7.0' || '' }}
-          app-token: ${{ steps.app-token.outputs.token || '' }}
-          autofix: 'false'
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2
+    with:
+      commands: audit,lint,test
+      expected-commands: audit,lint,test
+      autofix: 'false'
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Replace Data Machine's hand-rolled Homeboy matrix workflow with the reusable `homeboy-action@v2` CI workflow.
- Let the upstream workflow aggregate `audit`, `lint`, and `test` in one Homeboy Action invocation.
- Drop local MySQL service and test-only WordPress version arg; WordPress runtime settings live in `homeboy.json` and are owned by the WordPress extension.

## Verification
- `git diff --check`
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/homeboy.yml\"); puts \"yaml ok\"'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Migrated the workflow to the reusable Homeboy Action CI wrapper and ran local syntax validation; Chris directed the migration and boundary between homeboy-action and homeboy-extensions.