### PR TITLE
docs: update handler extension references

### DIFF
--- a/docs/core-system/handler-registration-trait.md
+++ b/docs/core-system/handler-registration-trait.md
@@ -4,7 +4,7 @@ Standardized handler registration trait introduced in v0.2.2 that eliminates ~70
 
 ## Overview
 
-HandlerRegistrationTrait (`/inc/Core/Steps/HandlerRegistrationTrait.php`) provides a single `registerHandler()` method that automatically registers handlers with all required WordPress filters.
+[`HandlerRegistrationTrait`](../../inc/Core/Steps/HandlerRegistrationTrait.php) provides a single `registerHandler()` method that automatically registers handlers with the core WordPress filters Data Machine uses for handler discovery, settings, auth providers, and deferred handler tools.
 
 ## Architecture
 
@@ -29,14 +29,15 @@ protected static function registerHandler(
     ?string $auth_class = null,
     ?string $settings_class = null,
     ?callable $tools_callback = null,
-    ?string $authProviderKey = null
+    ?string $authProviderKey = null,
+    array $meta = []
 ): void
 ```
 
 ### Parameters
 
 - **$handler_slug**: Unique identifier for the handler (e.g., 'twitter', 'rss')
-- **$handler_type**: Handler type ('fetch', 'publish', 'update')
+- **$handler_type**: Handler type (`'fetch'`, `'publish'`, or `'upsert'`)
 - **$handler_class**: Fully qualified class name for the handler
 - **$label**: Display name for admin interface (translatable)
 - **$description**: Handler description for admin interface (translatable)
@@ -45,6 +46,7 @@ protected static function registerHandler(
 - **$settings_class**: Fully qualified settings class name
 - **$tools_callback**: Callback for AI tool registration
 - **$authProviderKey**: Optional auth provider key override for shared authentication. When set, the handler metadata includes `auth_provider_key`, and the auth provider is registered under this key.
+- **$meta**: Optional arbitrary metadata passed through to handler discovery APIs, for example character limits or media limits.
 
 ## Filters Registered
 
@@ -55,16 +57,22 @@ The trait automatically registers handlers with the following WordPress filters:
 Handler metadata registration (always registered).
 
 ```php
-add_filter('datamachine_handlers', function($handlers) {
+add_filter('datamachine_handlers', function($handlers, $step_type = null) {
+    if (null !== $step_type && $step_type !== $handler_type) {
+        return $handlers;
+    }
+
     $handlers[$handler_slug] = [
         'type' => $handler_type,
         'class' => $handler_class,
         'label' => $label,
         'description' => $description,
-        'requires_auth' => $requires_auth
+        'requires_auth' => $requires_auth,
+        'auth_provider_key' => $requires_auth ? $provider_key : null,
+        'meta' => $meta,
     ];
     return $handlers;
-});
+}, 10, 2);
 ```
 
 ### 2. datamachine_auth_providers
@@ -78,22 +86,26 @@ Auth providers are keyed by **provider key**, not necessarily the handler slug.
 
 ```php
 // Only registered if requires_auth is true
-add_filter('datamachine_auth_providers', function($providers) use ($provider_key) {
-    $providers[$provider_key] = new $auth_class();
+add_filter('datamachine_auth_providers', function($providers, $step_type = null) use ($provider_key) {
+    if (null === $step_type || $step_type === $handler_type) {
+        $providers[$provider_key] = $providers[$provider_key] ?? new $auth_class();
+    }
     return $providers;
-});
+}, 10, 2);
 ```
+
+Portable bundles may export credential-bearing handler config as `auth_ref`. Publish and upsert base classes resolve that reference at runtime with `AuthRefHandlerConfig::resolve_runtime_config()` before calling the handler-specific execution method. The registration trait only registers the provider and advertises `auth_provider_key`; it does not resolve credentials itself.
 
 ### 3. datamachine_handler_settings
 
 Settings class registration (always registered if settings_class provided).
 
 ```php
-add_filter('datamachine_handler_settings', function($settings, $handler_slug_param) {
-    if ($handler_slug_param === $handler_slug) {
-        return $settings_class;
+add_filter('datamachine_handler_settings', function($all_settings, $handler_slug_param = null) {
+    if (null === $handler_slug_param || $handler_slug_param === $handler_slug) {
+        $all_settings[$handler_slug] = new $settings_class();
     }
-    return $settings;
+    return $all_settings;
 }, 10, 2);
 ```
 
@@ -118,8 +130,13 @@ add_filter('datamachine_tools', function($tools) use ($slug, $tools_callback) {
 });
 ```
 
-The callback receives `(string $handler_slug, array $handler_config, array $engine_data)`
-and returns `['tool_name' => $tool_definition]` (empty array to opt out).
+The preferred direct-style callback receives `(string $handler_slug, array $handler_config, array $engine_data)` and returns `['tool_name' => $tool_definition]` (empty array to opt out).
+
+Existing filter-style callbacks are also supported. `ToolManager::resolveHandlerTools()` invokes callbacks with `($tools, $handler_slug, $handler_config, $engine_data)` when reflection detects four or more parameters, or a first parameter named `$tools` or `$all_tools`.
+
+Handler tool matching is exact by default: a registry entry with `'handler' => 'wordpress_publish'` is resolved only for adjacent steps whose handler slug is exactly `wordpress_publish`. Cross-cutting tools can use `'handler_types' => ['fetch', 'event_import']`; those are matched against `datamachine_handlers` metadata.
+
+`_handler_callable` entries are deferred registry entries. They are not directly executable tools and should not include normal tool parameters at the wrapper level. The callback returns the executable tool definitions.
 
 ## Usage Example
 
@@ -197,7 +214,7 @@ class WordPressUpdateFilters {
     public static function register(): void {
         self::registerHandler(
             'wordpress_update',
-            'update',
+            'upsert',
             WordPressUpdate::class,
             __('WordPress Update', 'datamachine'),
             __('Update existing WordPress content', 'datamachine'),
@@ -256,8 +273,8 @@ Custom handlers should adopt this pattern by:
 
 3. **Move tool registration to callback parameter**:
    ```php
-   // Receives (handler_slug, handler_config, engine_data) and returns
-   // [tool_name => definition]. The trait handles routing to the adjacent
+    // Receives (handler_slug, handler_config, engine_data) and returns
+    // [tool_name => definition]. The trait handles exact-slug routing to the adjacent
    // step's handler — no manual slug check needed.
    function($handler_slug, $handler_config, $engine_data) {
        return [
@@ -375,12 +392,21 @@ self::registerHandler(
 - IDE autocomplete support for all parameters
 - PHP type hints prevent registration errors
 
+## Core vs Extension Boundaries
+
+- Core owns `HandlerRegistrationTrait`, `datamachine_handlers`, `datamachine_handler_settings`, `datamachine_auth_providers`, and deferred `_handler_callable` resolution.
+- Extensions own concrete handler classes, settings classes, auth provider classes, and executable tool definitions.
+- Extensions should register exact handler slugs. Core does not perform fuzzy slug matching.
+- Extensions should use `handler_types` only for cross-cutting tools that intentionally apply to every handler of a registered type.
+- Extensions can export portable auth config as `auth_ref`; core resolves it at runtime before fetch, publish, and upsert handler execution.
+
 ## See Also
 
-- Core Filters - Complete filter reference
-- Fetch Handler - Fetch handler base class
-- Publish Handler - Publish handler base class
-- Settings Handler - Settings base classes
+- [Core Filters](../development/hooks/core-filters.md) - Complete filter reference
+- [`FetchHandler`](../../inc/Core/Steps/Fetch/Handlers/FetchHandler.php) - Fetch handler base class
+- [`PublishHandler`](../../inc/Core/Steps/Publish/Handlers/PublishHandler.php) - Publish handler base class
+- [`UpsertHandler`](../../inc/Core/Steps/Upsert/Handlers/UpsertHandler.php) - Upsert handler base class
+- [`SettingsHandler`](../../inc/Core/Steps/Settings/SettingsHandler.php) - Settings base class
 
 ## Related Documentation
 

--- a/docs/handlers/fetch/handlers-overview.md
+++ b/docs/handlers/fetch/handlers-overview.md
@@ -1,6 +1,6 @@
 # Fetch Handlers Overview
 
-Fetch handlers retrieve content from various sources and convert it into standardized DataPackets for pipeline processing.
+Fetch handlers retrieve content from various sources and convert it into standardized `DataPacket` objects for pipeline processing.
 
 ## Available Handlers
 
@@ -48,14 +48,15 @@ Fetch handlers retrieve content from various sources and convert it into standar
 
 **Base Class Architecture** (@since v0.2.1):
 
-All fetch handlers extend `FetchHandler` base class (`/inc/Core/Steps/Fetch/Handlers/FetchHandler.php`) which provides:
-- Deduplication checking via `isItemProcessed()` and `markItemProcessed()`
+All fetch handlers extend [`FetchHandler`](../../../inc/Core/Steps/Fetch/Handlers/FetchHandler.php), which provides:
+- Output normalization into `DataPacket` objects
+- Deduplication and in-flight claim checks through `ExecutionContext`
+- `max_items` capping after dedupe and before claims
 - Engine data storage via `storeEngineData()`
-- Remote file downloading via `downloadRemoteFile()`
+- Remote file downloading via `ExecutionContext::downloadFile()`
 - Timeframe filtering via `applyTimeframeFilter()`
 - Keyword search filtering via `applyKeywordSearch()`
 - Standardized logging via `log()`
-- Response formatting via `successResponse()` and `emptyResponse()`
 
 ### `get_fetch_data()` Method
 
@@ -65,35 +66,71 @@ All fetch handlers implement the same public interface:
 public function get_fetch_data(int|string $pipeline_id, array $handler_config, ?string $job_id = null): array
 ```
 
-Internally, the base class creates an `ExecutionContext` and calls:
+[`FetchStep`](../../../inc/Core/Steps/Fetch/FetchStep.php) resolves portable `auth_ref` handler config before invoking the handler. Internally, the final base-class entry point creates an [`ExecutionContext`](../../../inc/Core/ExecutionContext.php) and calls:
 ```php
 abstract protected function executeFetch(array $config, ExecutionContext $context): array
 ```
 
 **Parameters**:
-- `$pipeline_id` - Pipeline ID or `'direct'` for direct execution mode
-- `$handler_config` - Handler-specific configuration (must include `flow_id`, `flow_step_id`, `pipeline_id`)
-- `$job_id` - Job identifier for deduplication tracking and engine data storage
+- `$pipeline_id` - Pipeline ID, or `'direct'` for direct execution mode
+- `$handler_config` - Flat handler configuration. Flow execution adds `flow_id`, `flow_step_id`, and `pipeline_id`; direct mode may use the `'direct'` sentinel values.
+- `$job_id` - Job identifier for engine data storage and in-flight claims
 
 **ExecutionContext provides**:
 - `$context->getPipelineId()` - Returns `int|string` (numeric ID or `'direct'`)
 - `$context->getFlowId()` - Returns `int|string` (numeric ID or `'direct'`)
 - `$context->getJobId()` - Returns `?string`
 - `$context->isItemProcessed($id)` - Check deduplication (always false in direct mode)
-- `$context->markItemProcessed($id)` - Mark item processed (no-op in direct mode)
+- `$context->isItemClaimed($id)` - Check whether another in-flight run already claimed the item (always false in direct/standalone modes)
+- `$context->claimItemForProcessing($id)` - Atomically claim an item for this job (successful no-op in direct/standalone modes)
+- `$context->markItemProcessed($id)` - Mark item processed (no-op in direct/standalone modes)
 - `$context->log($level, $message, $extra)` - Contextual logging
 - `$context->storeEngineData($data)` - Store data for downstream steps
 - `$context->getFileContext()` - Get file storage context array
 - `$context->isDirect()` - Check if running in direct execution mode
 
-**Return**: Array of DataPacket objects
+**Return**: Array of `DataPacket` objects. Child handlers return plain arrays; `FetchHandler::get_fetch_data()` normalizes those arrays into packets.
+
+### Handler Output Shapes
+
+Child handlers should return one of these plain-array shapes from `executeFetch()`:
+
+```php
+// Preferred: explicit list, supports zero, one, or many items.
+return [
+    'items' => [
+        [
+            'title' => 'Content Title',
+            'content' => 'Content body...',
+            'file_info' => null,
+            'metadata' => [
+                'item_identifier' => 'stable-source-id',
+                'original_id' => 'source-id',
+            ],
+        ],
+    ],
+];
+
+// Also accepted: one item as the whole result.
+return [
+    'title' => 'Content Title',
+    'content' => 'Content body...',
+    'metadata' => [ 'item_identifier' => 'stable-source-id' ],
+];
+
+// Empty result.
+return [ 'items' => [] ];
+```
+
+Do not return legacy `processed_items` arrays. They are not the fetch base-class contract.
 
 ### Clean DataPacket Format (AI-visible)
 
 ```php
 [
     'data' => [
-        'content_string' => "Source: Site Name\n\nTitle: Content Title\n\nContent body...",
+        'title' => 'Content Title',
+        'body' => "Source: Site Name\n\nTitle: Content Title\n\nContent body...",
         'file_info' => null // or file information array
     ],
     'metadata' => [
@@ -146,11 +183,19 @@ if (!$context->isItemProcessed($item_identifier)) {
 }
 ```
 
-Fetch handlers identify candidate items; completed items are marked processed after the full pipeline finishes successfully so downstream failures do not permanently drop content.
+Fetch handlers identify candidate items. The base class filters already-processed items and active claims, applies `max_items`, then claims only the selected items for the current job. Completed items are marked processed after the full pipeline finishes successfully so downstream failures do not permanently drop content.
 
 **Scope**: Per-flow-step deduplication (same item can be processed by different flows)
 **Persistence**: Stored in `wp_datamachine_processed_items` table
 **Cleanup**: Automatic cleanup with job completion
+
+### `max_items` and Claims
+
+- `max_items` is a flat handler config value. If omitted, `FetchHandler::getDefaultMaxItems()` defaults to `1`.
+- `max_items = 0` means unlimited.
+- Claims are created after dedupe and after `max_items`, so items that do not fit in the current batch remain eligible for future runs.
+- Final processed marking is deferred to successful pipeline completion, not fetch completion.
+- Direct and standalone execution modes skip persisted dedupe and claims; the methods return safe no-op defaults.
 
 ### Source Type Identifiers
 
@@ -170,12 +215,15 @@ Extension plugins can register additional fetch handlers and source type identif
 ```php
 $handler_config = [
     'flow_step_id' => $flow_step_id, // Added by engine
-    'handler_specific_key' => [
-        'setting1' => 'value1',
-        'setting2' => 'value2'
-    ]
+    'pipeline_id' => $pipeline_id,   // Added by engine
+    'flow_id' => $flow_id,           // Added by engine
+    'setting1' => 'value1',          // Handler-specific settings are flat
+    'setting2' => 'value2',
+    'max_items' => 5,
 ];
 ```
+
+The base class passes this flat array to `executeFetch()` as `$config`. Do not wrap handler settings under the handler slug unless the handler explicitly documents that nested shape.
 
 ### Common Settings
 
@@ -204,7 +252,7 @@ if (empty($required_setting)) {
         'handler' => 'handler_name',
         'setting' => 'required_setting'
     ]);
-    return ['processed_items' => []];
+    return ['items' => []];
 }
 ```
 
@@ -224,13 +272,14 @@ if (empty($required_setting)) {
 
 ## Performance Considerations
 
-### Single Item Execution Model
+### Bounded Batch Execution Model
 
-All fetch handlers follow the system-wide **Single Item Execution Model**:
-- Finds first eligible unprocessed item.
-- Marks as processed immediately to prevent concurrency issues.
-- Returns exactly one DataPacket (or an empty array if no new content exists).
-- Ensures job-level isolation and reliability.
+Fetch handlers follow a bounded batch model:
+- Child handlers may return zero, one, or many candidate items.
+- The base class filters processed and claimed items.
+- The base class applies `max_items` before claiming work.
+- The base class returns one `DataPacket` per selected item.
+- Final processed marking happens only after the downstream pipeline completes successfully.
 
 ### Memory Optimization
 
@@ -255,6 +304,13 @@ Fetch handlers provide essential metadata that AI steps use for content processi
 **Content Structure**: All handlers structure content in consistent format that AI steps process through the modular AI directive system.
 
 **Metadata Preservation**: Handler metadata (original titles, dates) flows through pipeline to AI tools via WP_Agent_Tool_Parameters while URLs are accessed via engine data filter.
+
+## Core vs Extension Boundaries
+
+- Core owns the handler base classes, `ExecutionContext`, processed-item ledger, claims, engine data storage, `auth_ref` resolution, and handler-tool resolution.
+- Extensions own source/platform-specific API calls, settings classes, auth providers, and handler registration.
+- Extensions should register handlers and tools through `HandlerRegistrationTrait` where possible instead of reimplementing core filters.
+- Extensions should return plain handler output arrays and let core normalize packets, apply dedupe, create claims, resolve `auth_ref`, and track posts.
 
 ### Tool-First Architecture Support
 
@@ -285,7 +341,7 @@ $result = $wordpress_handler->get_fetch_data(
     ['wordpress_posts' => ['post_type' => 'post']],
     $job_id
 );
-// Returns: ['processed_items' => [...]]
+// Returns: DataPacket[]
 // Engine data stored separately in database via centralized datamachine_engine_data filter
 ```
 
@@ -305,7 +361,7 @@ foreach ($potential_items as $item) {
         ];
     }
 }
-return ['processed_items' => []]; // No unprocessed items
+return ['items' => []]; // No unprocessed items
 ```
 
 ## Extension Development
@@ -324,31 +380,24 @@ class CustomFetchHandler extends FetchHandler {
         // Fetch data from source
         $items = $this->fetch_from_source($source_config);
 
-        // Process first unprocessed item
+        // Return candidate items. The base class applies dedupe, max_items, and claims.
+        $candidates = [];
         foreach ($items as $item) {
-            if ($context->isItemProcessed((string) $item['id'])) {
-                continue;
-            }
-
             // Store engine data via centralized filter (array storage)
             $context->storeEngineData([
                 'source_url' => $item['url'],
                 'image_url' => $item['image'] ?? ''
             ]);
 
-            return [
-                'items' => [
-                    [
-                        'title' => $item['title'],
-                        'content' => $item['content'],
-                        'metadata' => [
-                            'item_identifier' => (string) $item['id'],
-                        ],
-                    ],
+            $candidates[] = [
+                'title' => $item['title'],
+                'content' => $item['content'],
+                'metadata' => [
+                    'item_identifier' => (string) $item['id'],
                 ],
             ];
         }
 
-        return ['items' => []];
+        return ['items' => $candidates];
     }
 }

--- a/docs/handlers/publish/handlers-overview.md
+++ b/docs/handlers/publish/handlers-overview.md
@@ -1,6 +1,6 @@
 # Publish Handlers Overview
 
-Publish handlers distribute processed content to external platforms using AI tool calling architecture. All handlers implement the `handle_tool_call()` method for agentic execution.
+Publish handlers distribute processed content to external platforms using the AI tool-calling architecture. Custom handlers extend the publish base class and implement `executePublish()`; the base class owns the final `handle_tool_call()` entry point.
 
 ## Available Handlers
 
@@ -54,14 +54,16 @@ if ($link_handling === 'append' && !empty($source_url) && filter_var($source_url
 
 **Base Class Architecture** (@since v0.2.1):
 
-All publish handlers extend `PublishHandler` base class (`/inc/Core/Steps/Publish/Handlers/PublishHandler.php`) which provides:
+All publish handlers extend [`PublishHandler`](../../../inc/Core/Steps/Publish/Handlers/PublishHandler.php), which provides:
 - Engine data retrieval via `getEngineData()`, `getSourceUrl()`, `getImageFilePath()`
 - Image validation via `validateImage()`
+- `auth_ref` runtime resolution via `AuthRefHandlerConfig::resolve_runtime_config()`
+- Dry-run preview handling
 - Response formatting via `successResponse()` and `errorResponse()`
 - Centralized logging via `log()`
 - Standardized error handling
 
-The base class provides `handle_tool_call()` as the final public entry point, calling abstract `executePublish()` method in child classes.
+The base class provides `handle_tool_call()` as the final public entry point and calls the abstract `executePublish()` method in child classes. Do not override `handle_tool_call()` in extension handlers unless the base class is not being used.
 
 ### `handle_tool_call()` Interface
 
@@ -78,7 +80,16 @@ abstract protected function executePublish(array $parameters, array $handler_con
 
 **Parameters Structure**:
 - `$parameters` - AI-provided parameters (content, etc.)
-- `$tool_def` - Tool definition with handler configuration
+- `$tool_def` - Tool definition with handler configuration and handler slug
+
+Before `executePublish()` runs, the base class:
+
+- Requires `job_id`.
+- Loads job engine data and injects an `EngineData` object as `$parameters['engine']`.
+- Resolves portable `auth_ref` handler config into runtime credentials when present.
+- Returns a dry-run preview when engine data contains `dry_run_mode`.
+
+Post-origin tracking is centralized in [`ToolExecutor`](../../../inc/Engine/AI/Tools/ToolExecutor.php). Handler base classes and extensions should return an extractable post ID in the tool result; they should not call post-tracking helpers directly.
 
 **Return Structure**:
 ```php
@@ -96,9 +107,7 @@ abstract protected function executePublish(array $parameters, array $handler_con
 
 ### AI Tool Registration
 
-Each handler registers its tool through the unified `datamachine_tools` registry.
-The preferred path is `HandlerRegistrationTrait::registerHandler()` which wires
-the callback for you; the equivalent manual registration shape is:
+Each handler registers its tool through the unified `datamachine_tools` registry. The preferred path is [`HandlerRegistrationTrait::registerHandler()`](../../../inc/Core/Steps/HandlerRegistrationTrait.php), which wires the callback for you. The equivalent manual registration shape is:
 
 ```php
 add_filter('datamachine_tools', function($tools) {
@@ -129,6 +138,15 @@ add_filter('datamachine_tools', function($tools) {
 });
 ```
 
+Handler tool entries are deferred registry entries, not directly executable tools. `ToolManager::resolveHandlerTools()` resolves entries whose `handler` exactly matches the adjacent step handler slug. Cross-cutting tools may use `handler_types`, for example `['fetch', 'event_import']`, which matches against `datamachine_handlers` metadata.
+
+Callback conventions supported by `ToolManager`:
+
+- **Direct-style** callbacks receive `($handler_slug, $handler_config, $engine_data)` and return `['tool_name' => $tool_definition]`.
+- **Filter-style** callbacks receive `($tools, $handler_slug, $handler_config, $engine_data)` and return the updated tool map.
+
+The resolver detects filter-style callbacks by reflection: callbacks with four or more parameters, or a first parameter named `$tools` or `$all_tools`, are invoked with the filter-style shape. New code should prefer direct-style callbacks unless it is migrating an existing filter-style tool builder.
+
 ## Common Features
 
 ### Handler Configuration
@@ -136,19 +154,18 @@ add_filter('datamachine_tools', function($tools) {
 **Configuration Structure**:
 ```php
 $handler_config = [
-    'handler_name' => [
-        'setting1' => 'value1',
-        'enable_feature' => true,
-        'platform_specific_option' => 'option_value'
-    ]
+    'setting1' => 'value1',
+    'enable_feature' => true,
+    'platform_specific_option' => 'option_value',
 ];
 ```
 
 **Tool Definition Integration**:
 ```php
 $handler_config = $tool_def['handler_config'] ?? [];
-$platform_config = $handler_config['platform_name'] ?? $handler_config;
 ```
+
+Handler config is flat at runtime. `AuthRefHandlerConfig::resolve_runtime_config()` may merge local credentials into that flat config before `executePublish()` receives it.
 
 ### Content Processing
 
@@ -303,8 +320,14 @@ $pipeline_steps = [
 ### Custom Publish Handler
 
 ```php
-class CustomPublishHandler {
-    public function handle_tool_call(array $parameters, array $tool_def = []): array {
+use DataMachine\Core\Steps\Publish\Handlers\PublishHandler;
+
+class CustomPublishHandler extends PublishHandler {
+    public function __construct() {
+        parent::__construct('custom_platform');
+    }
+
+    protected function executePublish(array $parameters, array $handler_config): array {
         // Validate parameters
         if (empty($parameters['content'])) {
             return [
@@ -314,13 +337,13 @@ class CustomPublishHandler {
             ];
         }
 
-        // Get configuration
-        $handler_config = $tool_def['handler_config'] ?? [];
-        $custom_config = $handler_config['custom_platform'] ?? [];
+        $custom_config = $handler_config;
+        $engine = $parameters['engine'];
+        $source_url = $engine->getSourceUrl();
 
         // Publish to platform
         try {
-            $result = $this->publish_to_platform($parameters['content'], $custom_config);
+            $result = $this->publish_to_platform($parameters['content'], $custom_config, $source_url);
 
             return [
                 'success' => true,
@@ -372,3 +395,10 @@ add_filter('datamachine_tools', function($tools) {
     return $tools;
 });
 ```
+
+## Core vs Extension Boundaries
+
+- Core owns `PublishHandler::handle_tool_call()`, engine data loading, dry-run previews, `auth_ref` resolution, tool execution, and centralized post-origin tracking.
+- Extensions own platform-specific API clients, settings classes, auth providers, and `executePublish()` implementation details.
+- Extensions should return standard tool results and allow `ToolExecutor` to apply post tracking when a post ID is present.
+- Extensions should register handler tools as deferred `_handler_callable` entries and let `ToolManager` resolve exact-slug or `handler_types` matches at pipeline runtime.

--- a/docs/handlers/upsert/wordpress-update.md
+++ b/docs/handlers/upsert/wordpress-update.md
@@ -1,21 +1,27 @@
 # WordPress Update Handler
 
-Updates existing WordPress posts and pages in the local installation using native WordPress functions with selective field updates and taxonomy management.
+Updates existing WordPress posts and pages in the local installation using the `datamachine/update-wordpress` ability with selective field updates and taxonomy management.
 
 ## Architecture
 
-**Base Class**: Extends PublishHandler (@since v0.2.1)
+**Base Class**: Extends [`UpsertHandler`](../../../inc/Core/Steps/Upsert/Handlers/UpsertHandler.php)
 
 **Inherited Functionality**:
 - Engine data retrieval for source_url matching
 - Standardized response formatting
-- Centralized logging and error handling
+- Centralized error handling
+- Final `handle_tool_call()` entry point
+- Runtime `auth_ref` resolution via `AuthRefHandlerConfig::resolve_runtime_config()`
 
-**Requirements**: Requires `source_url` from engine data (provided by fetch handlers or AI tools)
+**Registration**: The handler registers as slug `wordpress_update` with handler type `upsert` via [`HandlerRegistrationTrait`](../../../inc/Core/Steps/HandlerRegistrationTrait.php).
+
+**Requirements**: Requires `job_id` and `source_url`. The `job_id` is added by tool execution; `source_url` is normally available from the prior fetch step's engine data and should be provided to the tool call for post identification.
 
 ## Local WordPress Integration
 
-**wp_update_post**: Uses WordPress's native `wp_update_post()` function for content modification.
+**Ability Delegation**: The handler delegates modification work to the `datamachine/update-wordpress` ability.
+
+**wp_update_post**: The ability uses WordPress's native `wp_update_post()` function for content modification.
 
 **URL-based Identification**: Extracts post ID from source URLs using `url_to_postid()` function.
 
@@ -24,7 +30,8 @@ Updates existing WordPress posts and pages in the local installation using nativ
 ## Required Parameters
 
 **Tool Call Parameters**:
-- `source_url`: WordPress post/page URL (required for post identification, provided by centralized engine data via datamachine_engine_data filter)
+- `job_id`: Required by `UpsertHandler::handle_tool_call()` and injected by the tool executor during pipeline runs
+- `source_url`: WordPress post/page URL, required for post identification
 
 **Optional Update Parameters**:
 - `title`: New post title (updates `post_title`)
@@ -40,6 +47,7 @@ Updates existing WordPress posts and pages in the local installation using nativ
 // Note: source_url is automatically provided via centralized datamachine_engine_data filter
 // from the fetch handler that originally retrieved the content
 $parameters = [
+    'job_id' => 456,
     'source_url' => 'https://site.com/existing-post/',  // From engine data
     'content' => 'Updated post content with <strong>HTML formatting</strong>.'
 ];
@@ -179,6 +187,10 @@ $parameters = [
 
 **Source URL Requirement**: Requires source URL from centralized engine data via datamachine_engine_data filter for post identification, making it suitable for content update workflows.
 
+**Base-Class Entry Point**: Upsert tools should route through `UpsertHandler::handle_tool_call()`. The base class validates `job_id`, creates an `EngineData` wrapper, resolves runtime `auth_ref` config, and then calls `executeUpsert()`.
+
+**Centralized Post Tracking**: Post origin tracking is applied centrally in `ToolExecutor::executeTool()` after successful tool calls. Upsert handlers should return an extractable post ID in their result and should not write origin tracking metadata themselves.
+
 **ToolResultFinder Integration** (@since v0.2.0): UpsertStep uses the `ToolResultFinder` utility class for locating handler tool execution results in data packets.
 
 **Tool Result Search Pattern**:
@@ -210,7 +222,7 @@ return [];
 - Centralizes search logic eliminating code duplication
 
 **Benefits**:
-- Universal search utility shared across all update handlers
+- Universal search utility shared across all upsert handlers
 - Consistent tool result detection across step types
 - Simplified upsert handler implementation
 - Centralized maintenance for search improvements
@@ -220,3 +232,10 @@ return [];
 **Selective Modification**: Allows targeted updates without affecting other post aspects.
 
 **Logging**: Detailed debug logging for URL resolution, update operations, taxonomy assignments, and error conditions.
+
+## Core vs Extension Boundaries
+
+- Core owns [`UpsertHandler`](../../../inc/Core/Steps/Upsert/Handlers/UpsertHandler.php), `UpsertStep`, handler-tool execution, runtime `auth_ref` resolution, and centralized post-origin tracking.
+- The WordPress upsert handler owns only the WordPress-specific tool definition and `executeUpsert()` implementation.
+- The handler delegates mutation logic to the `datamachine/update-wordpress` ability instead of duplicating post update behavior in the handler layer.
+- Extension upsert handlers should register with handler type `upsert`, expose tools through deferred `_handler_callable` entries, route execution through the base `handle_tool_call()`, and return standard success/error tool results.


### PR DESCRIPTION
## Summary
- Refreshes fetch, publish, upsert, and handler registration docs for the current handler base classes.
- Clarifies output shapes, item claiming, deduplication, execution context, registration callbacks, and core-vs-extension boundaries.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing handler docs against implementation, drafting updated extension guidance, and preparing the PR text for Chris to review.