### PR TITLE
docs: clarify memory and bundle artifacts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,9 @@ Complete user documentation for Data Machine, the AI-first WordPress plugin that
 - **Iteration Budget**: Shared bounded-iteration primitive backing `conversation_turns` and `chain_depth` budgets ([architecture/iteration-budget.md](architecture/iteration-budget.md)).
 
 ### Engine & Services
+- **Daily Memory System**: DailyMemoryTask lifecycle, deterministic overflow, opt-in daily injection, and daily memory artifacts ([core-system/daily-memory-system.md](core-system/daily-memory-system.md)).
+- **Memory Policy**: Per-agent memory injection policy and safe self-memory write gates ([core-system/memory-policy.md](core-system/memory-policy.md)).
+- **Agent Bundles**: Portable agent package schema, artifact tracking, extras, extension artifacts, run artifacts, and authenticated sources ([core-system/agent-bundles.md](core-system/agent-bundles.md)).
 - **Universal Engine**: Shared AI infrastructure for pipeline and chat agents.
 - **AI Conversation Loop**: Turn-based conversation execution with directive orchestration.
 - **AI Directives System**: Hierarchical directive injection for contextual AI behavior.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,11 +110,12 @@ See [WordPress as Agent Memory](core-system/wordpress-as-agent-memory.md) for fu
 Temporal knowledge management via date-organized files:
 
 - **DailyMemory**: File operations at `agents/{slug}/daily/YYYY/MM/DD.md`
-- **DailyMemoryTask**: System task with two phases:
-  - Phase 1: Synthesizes daily activity (jobs, chat) into daily file
-  - Phase 2: Prunes MEMORY.md when > 8KB, archiving session content to daily file
-- **DailyMemorySelectorDirective** (Priority 46): Injects daily memory into pipeline AI requests with configurable selection modes (recent days, specific dates, date range, months). Capped at 100KB total.
+- **DailyMemoryTask**: System task that maintains `MEMORY.md` with deterministic overflow handling, same-day `activity_section` context, the single `daily_memory` prompt, and conservation checks.
+- **AgentDailyMemoryDirective** (Priority 35): Opt-in recent daily memory injection for chat and pipeline requests via `agent_config.daily_memory`.
+- **AgentDailyMemory tool**: Policy-gated on-demand reads, writes, lists, and searches for exact dates, ranges, and historical lookups.
 - **DailyMemoryAbilities**: CRUD + search via Abilities API with multi-agent scoping
+
+See [Daily Memory System](core-system/daily-memory-system.md) for the current task lifecycle and artifact behavior.
 
 ### System Tasks Framework
 

--- a/docs/architecture/agent-memory-backends.md
+++ b/docs/architecture/agent-memory-backends.md
@@ -111,6 +111,24 @@ For example, the daily file for April 17, 2026 is the logical filename `daily/20
 
 Path helper methods such as `DailyMemory::get_base_path()` and `get_file_path()` are disk conveniences only. Non-disk stores may persist daily memory in posts, rows, or another physical shape.
 
+Daily memory availability is policy-gated at two layers:
+
+- `AgentDailyMemoryDirective` only injects recent files when `agent_config.daily_memory.enabled` is true for the resolved agent.
+- `AgentDailyMemory` tool access is still subject to tool policy and the underlying daily-memory abilities; write/delete operations also honor `daily_memory_enabled`.
+
+Run artifact collection can project daily memory writes into bundle-relative paths. When a successful `agent_daily_memory` write happens during a job, `JobArtifacts` reads the resulting day file and emits an `agent_daily_memory` artifact with `bundle_relative_path` shaped as `memory/agent/daily/YYYY/MM/DD.md`. If the file cannot be read yet, the artifact falls back to the write content with a `# Daily Memory: YYYY-MM-DD` heading.
+
+## Bundle Artifact Projection
+
+Memory backends store logical files; bundles and job artifacts provide portable projections of those files:
+
+- Agent memory writes become `agent_memory` run artifacts with paths such as `memory/agent/MEMORY.md` or `memory/USER.md`.
+- Daily memory writes become `agent_daily_memory` run artifacts under `memory/agent/daily/YYYY/MM/DD.md`.
+- Bundle-owned memory sections are tracked as section artifacts by `MemorySectionArtifact`, including owner, section type, source path, install hash, current hash, and local status.
+- Safe self-memory writes use section artifact ownership to decide whether to write directly or stage a PendingAction.
+
+The backend contract does not need to know about these bundle paths. The projection layer reads through `AgentMemory` and `DailyMemory`, then maps logical records to portable package paths for egress or upgrade review.
+
 ## Relationship To AI Framework
 
 The memory-store seam is not a replacement for AI Framework. Data Machine still owns its portable agent memory model and prompt assembly, while consumers can route storage to the backend that fits the host. AI Framework integration can coexist with this model; it does not require Data Machine to abandon `AgentMemory`, `MEMORY.md`, or the registry-driven directive stack.
@@ -129,4 +147,5 @@ The memory-store seam is not a replacement for AI Framework. Data Machine still 
 - [WordPress as Persistent Memory for AI Agents](../core-system/wordpress-as-agent-memory.md)
 - [Memory Policy](../core-system/memory-policy.md)
 - [Daily Memory System](../core-system/daily-memory-system.md)
+- [Agent Bundles](../core-system/agent-bundles.md)
 - [Core Filters: WP_Agent_Memory_Store](../development/hooks/core-filters.md#agentmemorystoreinterface-inccorefilesrepositoryagentmemorystoreinterfacephp)

--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -13,12 +13,13 @@ Agent bundles are portable, versioned packages for an agent's runtime behavior. 
 ├── prompts/<prompt-slug>.md
 ├── rubrics/<rubric-slug>.md
 ├── tool-policies/<policy-slug>.json
+├── auth-refs/<auth-ref-slug>.json
 ├── seed-queues/<queue-slug>.json
 ├── extensions/
 └── <extras-key>/                     # Plugin-owned opaque extras (e.g. wiki/, datasets/)
 ```
 
-Only `manifest.json`, `pipelines/`, `flows/`, and `memory/` have import/export adapters today. The remaining directories are reserved schema surface for prompts, rubrics, tool policies, auth references, seed queue artifacts, and plugin-owned extension artifacts.
+`manifest.json`, `memory/`, `pipelines/`, `flows/`, `prompts/`, `rubrics/`, `tool-policies/`, `auth-refs/`, `seed-queues/`, and `extensions/` are first-class bundle schema. Unknown top-level directories are transported as plugin-owned extras.
 
 ### Reserved Trees And Extras
 
@@ -93,6 +94,8 @@ See `Automattic/intelligence#467` for the reference consumer that claims the `wi
 - `full`: reserved for encrypted credential exports.
 - `omit`: omit handler auth material.
 
+`run_artifacts` is an optional manifest-level default egress policy. Individual flow files can also declare `run_artifacts`; flow-level policy wins for that flow. See [Run Artifact Egress](#run-artifact-egress).
+
 ## Artifact Tracking
 
 Bundle installs track artifacts independently of their runtime table. The foundation record shape is:
@@ -134,6 +137,13 @@ Memory artifacts can be tracked at section granularity. Section records extend t
 
 Self-memory writes are policy-constrained: the default target is the current acting agent, allowed section types are operational (`operating_note`, `source_quirk`, `run_lesson`, `task_note`), durable facts are rejected, and bundle-owned sections are staged through PendingActions instead of overwritten directly.
 
+Bundle section artifacts are the bridge between seed memory and safe runtime learning:
+
+- `MemorySectionArtifact::from_bundle_section()` records bundle-owned sections with install-time hashes.
+- `can_auto_update_from_bundle()` is true only while a bundle-owned section is still clean.
+- `should_stage_bundle_update()` is true when the section was locally modified after install.
+- Runtime self-memory writes that target a bundle-owned section stage a PendingAction instead of replacing the section.
+
 ## Pipeline And Flow Updates
 
 Bundle-installed pipelines and flows use stable `portable_slug` values as their runtime identity:
@@ -144,6 +154,15 @@ Bundle-installed pipelines and flows use stable `portable_slug` values as their 
 - Local edits are detected by comparing the current artifact hash with the install-time hash recorded in the owning agent's `datamachine_bundle.artifacts` config.
 - Installed artifact tracking is persisted in the site-scoped `datamachine_bundle_artifacts` table, keyed by `(agent_id, bundle_slug, artifact_type, artifact_id)`, so bundle state is independent of runtime tables.
 - Modified artifacts are reported as conflicts and are not overwritten by the import path.
+
+Upgrade planning groups artifacts into deterministic buckets:
+
+- `auto_apply`: new artifacts with no local value, or artifacts whose current hash still matches the installed hash.
+- `needs_approval`: untracked local artifacts or locally modified artifacts.
+- `warnings`: missing local artifacts and installed artifacts absent from the target bundle.
+- `no_op`: current artifact already matches the target.
+
+`install` creates new package-backed agents. `upgrade` applies clean updates and stages review-required changes through `AgentBundleUpgradePendingAction` with kind `bundle_upgrade`. `diff` runs the same planner without mutation. Applying a bundle PendingAction only applies explicitly approved artifact keys; unapproved entries are skipped, and consumers write storage through the registered artifact handlers or the `datamachine_bundle_upgrade_apply_artifact` filter.
 
 Schedule and queue policy is intentionally conservative:
 
@@ -158,6 +177,50 @@ Portable flow-step policy fields are explicit in `flows/<flow-slug>.json`:
 - `prompt_queue`: AI seed queue entries shaped as `{ "prompt": "...", "added_at": "..." }`.
 - `config_patch_queue`: fetch seed queue entries shaped as `{ "patch": { ... }, "added_at": "..." }`.
 - `queue_mode`: one of `drain`, `loop`, or `static`; shared by both queue slots on that flow step.
+
+## Run Artifact Egress
+
+`run_artifacts` declares which runtime artifacts a bundle consumer may surface after a job. Data Machine validates and stores the policy; downstream runtimes such as Data Machine Code decide how to materialize egress targets like PR bodies or bundle files.
+
+Supported sources:
+
+- `completion_assertions`
+- `daily_memory`
+- `transcript_summary`
+
+Supported egress targets:
+
+- `artifact` — retain in the job artifact payload.
+- `bundle-file` — allow a consumer to write the artifact into a bundle-relative file.
+- `pr-body` — allow a consumer to summarize the artifact in a PR body or review surface.
+
+Example:
+
+```json
+{
+  "run_artifacts": {
+    "daily_memory": {
+      "egress": ["artifact", "bundle-file", "pr-body"],
+      "bundle_relative_path": "memory/agent/daily/{yyyy}/{mm}/{dd}.md"
+    }
+  }
+}
+```
+
+Normalization drops unknown sources, unknown egress targets, duplicate targets, and unsafe bundle-relative paths. Data Machine does not execute GitHub-specific behavior from this policy; it only preserves a deterministic egress contract for consumers.
+
+During AI conversation loops, successful tool calls can add in-flight run artifacts before job persistence. `JobArtifacts` maps `agent_memory` and `agent_daily_memory` writes to canonical bundle-relative paths so DMC or other package consumers can export the evidence without scraping transcripts.
+
+## Extras Vs Extension Artifacts
+
+Bundles have two plugin-extension surfaces with different contracts:
+
+| Surface | Location | Shape | Data Machine behavior | Use when |
+|---|---|---|---|---|
+| Extras | Any unreserved top-level directory, exposed under `bundle["extras"]` | Opaque file map keyed by top-level directory | Transport only; consumer persists via `datamachine_bundle_install_succeeded` | A plugin owns a directory tree such as `wiki/` or `datasets/` |
+| Extension artifacts | `extensions/**/*.json`, exposed as `extension_artifacts` | Typed artifact envelopes with `artifact_type`, `artifact_id`, `source_path`, payload/hash fields | Normalized, included in package projection, upgrade planning, and artifact handlers | A plugin wants artifact diffing, upgrade conflict detection, and PendingAction apply semantics |
+
+Use extras for bulk opaque content where Data Machine should not inspect individual files. Use extension artifacts when each item needs stable identity, hashes, status, and upgrade behavior.
 
 ## CLI
 
@@ -185,6 +248,8 @@ Public archives install with no configuration. Private GitHub repositories, GitH
 5. **Generic per-request filter** — `datamachine_bundle_source_download_args` for arbitrary header injection (any host, any auth scheme).
 
 Data Machine **never persists tokens itself.** Storage and rotation live in the host plugin or operator's environment. Errors that surface from a failed download include the URL but never the `Authorization` header — see `BundleSourceAuth::redact_args_for_log()` if you log the args downstream.
+
+CLI token flags are resolved into the bundle-source context for that one import/diff/upgrade request only. `--token-env=<varname>` reads the token from the named environment variable and avoids placing the token in shell history. The internal download args carry private `datamachine_bundle_source` metadata until auth injection finishes; that metadata is stripped before the HTTP request is made.
 
 ### Example 1 — github.com private archive via env var
 
@@ -241,8 +306,9 @@ Or hook the lower-cost `datamachine_bundle_source_token_for_url` fallback when y
 
 For GitHub archive responses, `BundleSource::fetch_to_tempfile()` reads the response `ETag` header and parses the git SHA out of the `W/"<sha>:<format>"` (or bare `"<sha>"`) shape GitHub serves. When present and parseable the SHA is exposed via `BundleSource::last_resolved_revision()` and stamped onto the bundle as `source_revision`. Best-effort only — installs do not fail when the ETag is absent or unparseable.
 
-## Follow-Ups
+## See Also
 
-- Wire importer/exporter paths for prompts, rubrics, tool policies, auth refs, and seed queues.
-- Use artifact statuses during bundle upgrade planning: auto-update `clean`, stage PendingActions for `modified`, surface `missing` and `orphaned` explicitly.
-- Add registered bundle sources once bundles move beyond local paths.
+- [Memory Policy](./memory-policy.md) — policy gates for memory injection and self-memory writes.
+- [Daily Memory System](./daily-memory-system.md) — daily-memory storage, compaction, and artifacts.
+- [Pending Actions](./pending-actions.md) — approval envelopes used for bundle upgrades and protected memory writes.
+- [Agent Memory Backends](../architecture/agent-memory-backends.md) — logical memory identity and backend projection.

--- a/docs/core-system/daily-memory-system.md
+++ b/docs/core-system/daily-memory-system.md
@@ -78,58 +78,82 @@ $daily = new DailyMemory(user_id: 0, agent_id: 42);
 **Source:** `inc/Engine/AI/System/Tasks/DailyMemoryTask.php`
 **Since:** v0.32.0
 
-An AI-powered system task that runs daily via Action Scheduler. It has two phases:
+An AI-powered system task that runs daily via Action Scheduler. The task lifecycle is deterministic around one optional AI compaction call:
 
-### Phase 1: Activity Synthesis
+1. Exit cleanly when `daily_memory_enabled` is false.
+2. Resolve the target date, user, agent, and system-mode model.
+3. Read the agent's `MEMORY.md`; empty or missing memory is a skipped job.
+4. Run deterministic overflow handling when `MEMORY.md` is extremely large.
+5. Gather same-day Data Machine activity for the prompt's `activity_section`.
+6. Skip when `MEMORY.md` is within budget and there is no activity context.
+7. Run the single `daily_memory` prompt, parse `===PERSISTENT===` and `===ARCHIVED===`, apply safety gates, rewrite `MEMORY.md`, and append archived content to the daily file.
 
-Gathers the day's activity from Data Machine (completed jobs and chat sessions) and uses AI to synthesize a concise daily memory entry.
+### Activity Context
+
+The task gathers same-day Data Machine activity and injects it into the single maintenance prompt as `{{activity_section}}`. Activity context is supporting material for compaction; it is not a separate summary prompt.
 
 **Data sources:**
 - `datamachine_jobs` — pipeline and system jobs created on the target date (job_id, pipeline_id, flow_id, source, label, status)
 - `datamachine_chat_sessions` — chat sessions created on the target date (session_id, title, context)
 
 **Process:**
-1. Query jobs and chat sessions for the target date
-2. Format as structured context with `## Jobs completed on YYYY-MM-DD` and `## Chat sessions on YYYY-MM-DD` sections
-3. Send to AI with the `daily_summary` prompt template
-4. Append the AI-generated summary to the day's daily memory file
+1. Query jobs and chat sessions for the target date.
+2. Format as structured context with `## Jobs completed on YYYY-MM-DD` and `## Chat sessions on YYYY-MM-DD` sections.
+3. Wrap that context in `## Today's Activity` and pass it as `{{activity_section}}`.
 
-If no DM activity occurred (empty context), Phase 1 is skipped. Phase 2 still runs because most agent work happens via external tools (e.g. Kimaki sessions) that don't create DM jobs.
+If no Data Machine activity occurred and `MEMORY.md` is already within `AgentMemory::MAX_FILE_SIZE`, the task completes as a skipped no-op. External tools such as Kimaki can still write temporal details directly with `agent_daily_memory`.
 
-### Phase 2: MEMORY.md Cleanup
+### MEMORY.md Compaction
 
 Reads the full MEMORY.md file and uses AI to split it into persistent knowledge (stays) and session-specific content (archived to the daily file). This keeps MEMORY.md lean for the context window budget.
 
 **Process:**
 1. Read MEMORY.md via `AgentMemory` service
-2. **Skip if within budget** — if file size ≤ `AgentMemory::MAX_FILE_SIZE` (8192 bytes / 8 KB), no cleanup needed
-3. Send to AI with the `memory_cleanup` prompt template
-4. Parse AI response into `===PERSISTENT===` and `===ARCHIVED===` sections
-5. **Safety check** — verify the new content isn't suspiciously small:
+2. **Deterministic overflow first** — if the file is over `datamachine_daily_memory_overflow_threshold` (default: 4x `AgentMemory::MAX_FILE_SIZE`), archive whole tail sections verbatim and write an archive pointer without invoking AI
+3. **Skip if within budget and no activity** — if file size ≤ `AgentMemory::MAX_FILE_SIZE` (8192 bytes / 8 KB) and `activity_section` is empty, no cleanup needed
+4. Send to AI with the `daily_memory` prompt template
+5. Parse AI response into `===PERSISTENT===` and `===ARCHIVED===` sections
+6. **Safety check** — verify the new content isn't suspiciously small:
    - If file is >2x over budget: allow reduction down to half the target size (4 KB minimum)
    - If file is near budget: don't allow reduction below 10% of original size
-6. Write cleaned content back to MEMORY.md
-7. Append archived content to the daily file under `### Archived from MEMORY.md`
+7. **Conservation check** — verify persistent + archived output accounts for at least 85% of the original by byte size, unless `datamachine_daily_memory_conservation_threshold` changes the threshold
+8. Write cleaned content back to MEMORY.md
+9. Append archived content to the daily file under `### Archived from MEMORY.md`
 
-**Failure handling:** Cleanup failures are logged but never fail the overall job. The daily summary (Phase 1) is already written. Key safety rules:
+### Deterministic Overflow
+
+Very large `MEMORY.md` files can exceed provider request limits. Before the AI call, `maybeHandleDeterministicOverflow()` checks `datamachine_daily_memory_overflow_threshold` (default: `AgentMemory::MAX_FILE_SIZE * 4`). When the file is above that threshold, the task uses `WP_Agent_Markdown_Section_Compaction_Adapter` to split the markdown by sections:
+
+- Retained sections stay in `MEMORY.md` up to `datamachine_daily_memory_overflow_target_size` (default: `AgentMemory::MAX_FILE_SIZE`).
+- Archived sections are appended verbatim to `daily/YYYY/MM/DD.md` under `### Archived from oversized MEMORY.md`.
+- A persistent `Archived Memory Overflow` pointer remains in `MEMORY.md`, pointing to the daily artifact path.
+- Conservation is enabled in the section adapter so overflow handling preserves content instead of summarizing it.
+
+When deterministic overflow handles the file, the job completes with `overflow_split: true` and does not run the AI prompt.
+
+**Failure handling:** compaction failures leave `MEMORY.md` unchanged and fail the job so operators can inspect the reason. Key safety rules:
 - Never wipe MEMORY.md if the AI response can't be parsed
 - Never write if the persistent section is empty
 - Never write if the new content is suspiciously small (safety threshold check)
+- Never write if the conservation check indicates the model discarded too much content
 
 ### Editable Prompts
 
-DailyMemoryTask defines two customizable prompts via `getPromptDefinitions()`:
+DailyMemoryTask defines one customizable prompt via `getPromptDefinitions()`:
 
-**`daily_summary`** — Synthesizes the day's DM activity into a concise entry.
-- Variable: `{{context}}` — gathered activity from jobs and chat sessions
+**`daily_memory`** — Maintains `MEMORY.md`, splitting persistent vs. session-specific content while considering same-day activity.
 
-**`memory_cleanup`** — Splits MEMORY.md into persistent vs. session-specific content.
-- Variables: `{{memory_content}}` (current MEMORY.md), `{{date}}` (target date), `{{max_size}}` (recommended limit, e.g. "8 KB")
+Variables:
+
+- `{{memory_content}}` — current full `MEMORY.md` content.
+- `{{date}}` — target archive date in `YYYY-MM-DD` format.
+- `{{max_size}}` — recommended persistent memory limit, e.g. `8 KB`.
+- `{{activity_section}}` — optional `## Today's Activity` section generated from jobs and chat sessions.
 
 Prompts can be overridden via the System Tasks admin tab or programmatically:
 
 ```php
-SystemTask::setPromptOverride('daily_memory_generation', 'memory_cleanup', 'Your custom prompt...');
+SystemTask::setPromptOverride('daily_memory_generation', 'daily_memory', 'Your custom prompt...');
 ```
 
 ### Scheduling
@@ -155,7 +179,7 @@ Upgrading sites have any pending action under the pre-refactor hook
 ```php
 [
     'label'           => 'Daily Memory',
-    'description'     => 'AI-generated daily summary of activity and automatic MEMORY.md cleanup',
+    'description'     => 'Automated MEMORY.md maintenance -- archives session-specific content to daily files, compresses and cleans persistent knowledge.',
     'setting_key'     => 'daily_memory_enabled',
     'default_enabled' => false,
     'supports_run'    => true,
@@ -277,7 +301,7 @@ The directive only injects *recent* days on a rolling window. Anything beyond `r
 **Tool ID:** `agent_daily_memory`
 **Contexts:** `chat`, `pipeline`, `standalone`
 
-An AI chat tool that lets agents manage their own daily memory during conversations. Always available (no external configuration required).
+An AI chat tool that lets agents manage their own daily memory during conversations. It is registered for chat and pipeline-policy contexts, then gated by normal tool policy and by the underlying daily-memory abilities. Read/list/search availability follows the ability permission path; writes also respect `daily_memory_enabled` through `DailyMemoryAbilities`.
 
 ### Tool Schema
 
@@ -291,6 +315,8 @@ An AI chat tool that lets agents manage their own daily memory during conversati
 | `query` | string | no | Search term (required for `search`) |
 | `from` | string | no | Start date for search range |
 | `to` | string | no | End date for search range |
+
+The tool resolves the acting scope from the tool call plus the active agent context. It passes explicit `user_id` and `agent_id` to abilities so writes land in the selected agent's daily-memory tree rather than a global file.
 
 ### Delegation
 
@@ -306,6 +332,17 @@ The tool delegates to WordPress Abilities:
 ### Usage Guidance (from tool description)
 
 > Use for session activity, temporal events, and work logs. Daily memory captures WHAT HAPPENED — persistent knowledge belongs in agent_memory (MEMORY.md) instead.
+
+## Daily Memory Artifacts
+
+Daily memory writes can become job artifacts for package consumers. During the AI conversation loop, successful tool calls are summarized and passed into `JobArtifacts`. For each successful `agent_daily_memory` write, `JobArtifacts`:
+
+1. Resolves the target agent, user, and date.
+2. Reads the written `daily/YYYY/MM/DD.md` file through `DailyMemory`.
+3. Falls back to the tool-call content with a `# Daily Memory: YYYY-MM-DD` heading when the file cannot be read.
+4. Emits an artifact with `type: agent_daily_memory`, `source: daily-memory`, `bundle_relative_path: memory/agent/daily/YYYY/MM/DD.md`, and the file content.
+
+Bundles can declare `run_artifacts.daily_memory` egress policy to let downstream runtimes preserve these artifacts in bundle files, job artifacts, or PR bodies. Data Machine validates the policy and builds deterministic artifact payloads; consumers decide where those payloads leave the system.
 
 ## REST API
 

--- a/docs/core-system/memory-policy.md
+++ b/docs/core-system/memory-policy.md
@@ -15,6 +15,8 @@ Two shapes of agent:
 
 MemoryPolicy lets the stateless shape declare its posture in config, travel with the agent through bundle export/import, and apply uniformly across every memory injection surface.
 
+Daily memory has a separate opt-in switch at `agent_config.daily_memory`. MemoryPolicy controls registered and scoped memory files such as `MEMORY.md`, `SOUL.md`, `USER.md`, and configured context files; `AgentDailyMemoryDirective` separately decides whether recent daily archive files are injected at priority 35. Both settings travel in `agent_config` so bundles can preserve a stateful agent's memory posture without making daily memory a global default.
+
 ## How it fits
 
 Data Machine already has a layered memory injection system. MemoryPolicy does not replace it — it is a subtractive filter that applies across all three existing layers.
@@ -162,6 +164,21 @@ Parallel structure, parallel mental model:
 
 Same precedence model, same extension points, same per-agent config home. An agent's portable definition bundles both policies together with its pipelines, flows, and identity files.
 
+## Safe self-memory writes
+
+The `datamachine/agent-memory-self-write` ability is narrower than general file editing. It exists so an acting agent can record operational lessons without silently rewriting durable knowledge or another agent's memory.
+
+Policy gates in `SelfMemoryWritePolicy` are applied before `AgentMemory` writes:
+
+- An active acting-agent context is required.
+- The target defaults to the current agent; cross-agent writes require `datamachine_self_memory_allow_cross_agent_write` delegation.
+- Durable fact section types (`fact`, `domain_fact`, `wiki_fact`, `knowledge`) are rejected. Those belong in wiki or graph tools.
+- Allowed operational section types default to `operating_note`, `source_quirk`, `run_lesson`, and `task_note`, filterable through `datamachine_self_memory_allowed_section_types`.
+- Bundle-owned memory sections are staged as PendingActions instead of overwritten directly.
+- Sensitive section types or explicit `requires_approval` requests are also staged as PendingActions.
+
+Section ownership is represented by `MemorySectionArtifact` with owners `bundle`, `user`, `runtime`, and `compaction`. Bundle-owned sections carry `bundle_slug`, `bundle_version`, `installed_hash`, `current_hash`, and `local_status`, so clean bundle sections can auto-update while modified sections are preserved for review.
+
 ## See also
 
 - [WordPress as Agent Memory](./wordpress-as-agent-memory.md) — the full memory architecture
@@ -169,3 +186,5 @@ Same precedence model, same extension points, same per-agent config home. An age
 - [Tool Manager](./tool-manager.md) — tool resolution and ToolPolicy reference
 - [Multi-Agent Architecture](./multi-agent-architecture.md) — `agent_config` and per-agent settings
 - [Import/Export](./import-export.md) — `AgentBundler` and bundle round-trips
+- [Agent Bundles](./agent-bundles.md) — bundle artifact tracking, memory section artifacts, and upgrade conflict handling
+- [Daily Memory System](./daily-memory-system.md) — daily archive storage, directive opt-in, and the `agent_daily_memory` tool

--- a/docs/core-system/system-tasks.md
+++ b/docs/core-system/system-tasks.md
@@ -260,7 +260,7 @@ Defines the admin UI fields. The task dropdown is populated from `TaskRegistry::
 **Source:** `inc/Engine/AI/System/Tasks/DailyMemoryTask.php`
 **Undo:** No
 
-AI-generated daily summary of agent activity plus automatic MEMORY.md cleanup. Two-phase execution: Phase 1 synthesizes the day's jobs and chat sessions into a daily entry; Phase 2 uses AI to split MEMORY.md into persistent knowledge and session-specific content, archiving the latter to the daily file.
+Automated `MEMORY.md` maintenance. The task gathers same-day job/chat context into `activity_section`, performs deterministic overflow archiving for very large files, and otherwise uses the single `daily_memory` prompt to split persistent knowledge from session-specific content. Safety and conservation checks prevent lossy rewrites.
 
 See [Daily Memory System](daily-memory-system.md) for complete documentation.
 
@@ -269,7 +269,7 @@ See [Daily Memory System](daily-memory-system.md) for complete documentation.
 | Setting | `daily_memory_enabled` |
 | Trigger | Daily at midnight UTC (cron) |
 | Manual run | Yes |
-| Prompts | `daily_summary`, `memory_cleanup` |
+| Prompts | `daily_memory` |
 
 ### InternalLinkingTask
 

--- a/docs/core-system/wordpress-as-agent-memory.md
+++ b/docs/core-system/wordpress-as-agent-memory.md
@@ -62,25 +62,29 @@ The **CoreMemoryFilesDirective** loads all files from the **MemoryFileRegistry**
 
 **Location:** `agents/{agent_slug}/daily/YYYY/MM/DD.md`
 
-Daily memory files capture session-specific knowledge organized by date. Two-phase system:
+Daily memory files capture session-specific knowledge organized by date. Current lifecycle:
 
-1. **Daily Summary** (Phase 1): At the end of each day, Data Machine gathers completed jobs and chat sessions, synthesizes them via AI, and appends the result to the daily file.
-2. **MEMORY.md Cleanup** (Phase 2): If MEMORY.md exceeds the size threshold (`MAX_FILE_SIZE = 8KB`), AI splits content into persistent facts and session-specific details. Persistent content stays in MEMORY.md; archived content moves to the daily file.
+1. **Activity context**: Data Machine gathers same-day jobs and chat sessions into the `{{activity_section}}` variable.
+2. **Deterministic overflow**: Very large `MEMORY.md` files are split by section and archived verbatim before any AI call.
+3. **AI compaction**: The single `daily_memory` prompt splits `MEMORY.md` into `===PERSISTENT===` and `===ARCHIVED===` sections when size or activity requires maintenance.
+4. **Conservation checks**: Safety gates prevent empty, suspiciously small, or lossy rewrites.
 
 This keeps MEMORY.md lean while preserving the full temporal record in daily files.
 
-**DailyMemoryTask** runs as a system task (`daily_memory_generation`) on a daily cron schedule. Both phases use editable AI prompts via the `getPromptDefinitions()` system.
+**DailyMemoryTask** runs as a system task (`daily_memory_generation`) on a daily cron schedule. The `daily_memory` prompt is editable via the `getPromptDefinitions()` system.
 
-**Pipeline integration:** The **DailyMemorySelectorDirective** (Priority 46) injects daily memory into pipeline AI requests. Four selection modes:
+**Runtime integration:** The **AgentDailyMemoryDirective** (Priority 35) injects recent daily files into chat and pipeline AI requests only when the resolved agent opts in with `agent_config.daily_memory`:
 
-| Mode | Description |
-|------|-------------|
-| `recent_days` | Last N days (max 90) |
-| `specific_dates` | Explicit date list |
-| `date_range` | From/to date filtering |
-| `months` | All dates in selected months |
+```json
+{
+  "daily_memory": {
+    "enabled": true,
+    "recent_days": 3
+  }
+}
+```
 
-Total injection capped at 100KB. Files sorted newest-first.
+Historical date, range, and month queries are served on demand by the `agent_daily_memory` tool instead of pre-injecting large selector windows.
 
 ### 3. Chat Sessions — Conversation Memory
 
@@ -377,17 +381,17 @@ Each pipeline can select additional agent files beyond the core set. Configure v
 
 Each flow can independently select additional memory files, allowing flow-level customization beyond pipeline defaults.
 
-### Daily Memory Files (Priority 46)
+### Daily Memory Files (Priority 35)
 
-Flows can configure daily memory injection through the `daily_memory` flow config setting. See the [Daily Memory section](#2-daily-memory--temporal-knowledge) for selection modes.
+Agents can opt into recent daily memory injection through `agent_config.daily_memory`. `AgentDailyMemoryDirective` runs after core memory files and before pipeline/flow memory files, and it only injects the newest available daily files within the 8 KB memory budget.
 
 ```
-"Daily Music News"    -> [content-strategy.md] + recent 7 days daily memory
-"Social Media Posts"  -> []
-"Album Reviews"       -> [content-strategy.md, content-briefing.md] + specific dates
+"Personal Assistant"  -> recent 3 days daily memory
+"Social Media Posts"  -> no daily memory
+"Album Reviews"       -> no daily memory; uses agent_daily_memory for exact historical lookups
 ```
 
-Different workflows access different slices of knowledge. This is deliberate — selective memory injection over RAG means you know exactly what context the agent has, with no embedding cost and no hallucination from irrelevant similarity matches.
+Different agents access different slices of temporal knowledge. This is deliberate — opt-in recent daily memory keeps stateful assistants continuous without leaking yesterday's work into stateless pipeline workers.
 
 ## External Agent Integration
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -71,10 +71,10 @@ Markdown files organized in three layers:
 
 Temporal knowledge is preserved in date-organized daily memory files. The **DailyMemoryTask** system task automatically:
 
-1. Synthesizes daily activity into summary files
-2. Prunes MEMORY.md when it exceeds 8KB, archiving session-specific content to daily files
+1. Maintains `MEMORY.md` with the single `daily_memory` prompt when activity or size requires compaction
+2. Archives session-specific content to daily files, including deterministic overflow artifacts for very large memory files
 
-Pipelines can selectively inject daily memory via the **DailyMemorySelectorDirective** with modes: recent days, specific dates, date range, or by month.
+Agents can opt into recent daily memory injection via **AgentDailyMemoryDirective** (`agent_config.daily_memory`). Precise historical lookups use the `agent_daily_memory` tool.
 
 ### Memory Path Discovery
 


### PR DESCRIPTION
## Summary
- Updates daily memory, memory policy, and agent bundle docs around current artifact behavior.
- Clarifies compaction, conservation checks, policy-gated memory tools, bundle extras, extension artifacts, and pending-action upgrade handling.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing memory/bundle docs against implementation, drafting updated references, and preparing the PR text for Chris to review.