### PR TITLE
docs: add missing REST endpoint surfaces

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,8 +46,8 @@ Complete user documentation for Data Machine, the AI-first WordPress plugin that
 - **Chat Tools**: AddPipelineStep, ApiQuery, ConfigureFlowSteps, ConfigurePipelineStep, CreateFlow, CreatePipeline, RunFlow, UpdateFlow, and other workflow management tools.
 
 ### API Reference
-- **API Overview**: Catalog of REST endpoints for API consumers.
-- **Endpoints**: Auth, Execute, Files, Flows, Jobs, Logs, and other REST resources.
+- **API Overview**: Catalog of REST endpoints for API consumers ([api/index.md](api/index.md)).
+- **Endpoints**: Agents, Agent Ping, Auth, Email, Execute, Files, Flows, Internal Links, Jobs, Logs, and other REST resources.
 
 ### Development
 - **Hooks**: Core actions, filters, and engine hooks for extension development.

--- a/docs/api/endpoints/agent-ping.md
+++ b/docs/api/endpoints/agent-ping.md
@@ -1,0 +1,91 @@
+# Agent Ping Endpoints
+
+**Implementation**: `inc/Api/AgentPing.php`
+
+**Base URL**: `/wp-json/datamachine/v1/agent-ping`
+
+## Overview
+
+Agent ping endpoints let an external agent callback confirm completion of an asynchronous ping and let the originating site poll callback status.
+
+The callback data is stored in a WordPress transient. New callbacks default to a one-hour TTL; processed callbacks are retained for a short polling grace period.
+
+## Authentication
+
+Both routes require a bearer token in the `Authorization` header:
+
+```text
+Authorization: Bearer <datamachine_agent_ping_callback_token option value>
+```
+
+The expected token is read from the `datamachine_agent_ping_callback_token` option. If no token is configured, all requests are rejected with HTTP 403. Missing or invalid bearer tokens return HTTP 401.
+
+This token is separate from agent runtime bearer tokens created under `/agents/{agent}/tokens`.
+
+## Route Table
+
+| Method | Route | Purpose |
+|---|---|---|
+| POST | `/agent-ping/confirm` | Store the completion status for a callback ID and fire `datamachine_agent_ping_confirmed`. |
+| GET | `/agent-ping/callback/{callback_id}` | Poll the stored callback status. |
+
+## Core Parameters
+
+| Parameter | Route | Type | Required | Notes |
+|---|---|---|---|---|
+| `callback_id` | both | string | yes | Unique callback ID from the original ping. URL param for polling, body param for confirm. |
+| `status` | confirm | string | yes | `success`, `failed`, or `timeout`. |
+| `message_preview` | confirm | string | no | Short preview of the agent response. |
+| `error_message` | confirm | string | no | Error details when `status` is `failed`. |
+
+## Response Shape
+
+Confirmation response:
+
+```json
+{
+  "success": true,
+  "message": "Confirmation received.",
+  "callback_id": "cb_123",
+  "job_id": 456,
+  "flow_step_id": 789
+}
+```
+
+If the callback was already processed, confirm returns success with `processed: true` and the previous status.
+
+Polling response:
+
+```json
+{
+  "callback_id": "cb_123",
+  "job_id": 456,
+  "flow_step_id": 789,
+  "status": "pending",
+  "message_preview": "",
+  "error_message": "",
+  "processed_at": null,
+  "created_at": "2026-01-18 12:00:00",
+  "expires_at": "2026-01-18 13:00:00"
+}
+```
+
+Unknown or expired callback IDs return `callback_not_found` with HTTP 404.
+
+## Agent Usage Examples
+
+Confirm a successful run:
+
+```bash
+curl -X POST https://example.com/wp-json/datamachine/v1/agent-ping/confirm \
+  -H "Authorization: Bearer callback-secret" \
+  -H "Content-Type: application/json" \
+  -d '{"callback_id":"cb_123","status":"success","message_preview":"Task completed"}'
+```
+
+Poll for completion:
+
+```bash
+curl https://example.com/wp-json/datamachine/v1/agent-ping/callback/cb_123 \
+  -H "Authorization: Bearer callback-secret"
+```

--- a/docs/api/endpoints/agents.md
+++ b/docs/api/endpoints/agents.md
@@ -1,0 +1,144 @@
+# Agents Endpoints
+
+**Implementation**: `inc/Api/Agents.php`, `inc/Core/Auth/AgentAuthorize.php`, `inc/Core/Auth/AgentAuthCallback.php`
+
+**Base URL**: `/wp-json/datamachine/v1`
+
+## Overview
+
+Agent endpoints manage agent records, user access grants, runtime bearer tokens, and the browser authorization flow used by external agent clients.
+
+## Authentication
+
+There are three auth modes:
+
+- Agent CRUD, access, and token management use the current WordPress user and Data Machine agent capabilities.
+- `GET /agents/me` accepts either an agent bearer token context or a logged-in WordPress user.
+- `/agent/authorize` and `/agent/auth/callback` are browser-facing flow endpoints with open REST permissions, then validate login cookies, nonces, redirect URIs, or callback payloads inside the handler.
+
+Token values are sensitive. `POST /agents/{agent}/tokens` returns `raw_token` once; list endpoints return token metadata only.
+
+## Route Table
+
+| Method | Route | Auth model | Purpose |
+|---|---|---|---|
+| GET | `/agents` | Logged-in user | List agents visible to the caller. |
+| POST | `/agents` | `manage_agents` or `create_own_agent` | Create an agent. |
+| GET | `/agents/me` | Agent token or logged-in user | Discover the current agent identity. |
+| GET | `/agents/{agent}` | `manage_agents` | Fetch an agent by slug or numeric ID. |
+| PUT/PATCH | `/agents/{agent}` | `manage_agents` | Update agent display name or config. |
+| DELETE | `/agents/{agent}` | `manage_agents` | Delete an agent. |
+| GET | `/agents/{agent}/access` | `manage_agents` | List user access grants. |
+| POST | `/agents/{agent}/access` | `manage_agents` | Grant user access. |
+| DELETE | `/agents/{agent}/access/{user_id}` | `manage_agents` | Revoke user access. |
+| GET | `/agents/{agent}/tokens` | `manage_agents` plus agent access check | List token metadata. |
+| POST | `/agents/{agent}/tokens` | `manage_agents` plus admin access to agent | Create a bearer token. |
+| DELETE | `/agents/{agent}/tokens/{token_id}` | `manage_agents` plus admin access to agent | Revoke a token. |
+| GET | `/agent/authorize` | Browser session | Show consent or redirect to login. |
+| POST | `/agent/authorize` | Browser session plus nonce | Approve or deny authorization. |
+| GET | `/agent/auth/callback` | Callback payload | Receive and store an external token. |
+| GET | `/agent/auth/tokens` | `manage_options` | List stored external token metadata. |
+| GET | `/agent/auth/tokens/{key}` | `manage_options` | Return one stored external token record. |
+
+`{agent}` accepts an agent slug (`sarai`) or numeric agent ID (`42`). Slug routes are preferred.
+
+## Core Parameters
+
+### Agent CRUD
+
+| Parameter | Routes | Type | Notes |
+|---|---|---|---|
+| `agent_slug` | `POST /agents`, authorize flow | string | Required when creating or authorizing. Sanitized as a slug. |
+| `agent_name` | `POST /agents`, `PUT/PATCH /agents/{agent}` | string | Display name. Defaults to slug on create. |
+| `config` | `POST /agents` | object | Initial config object. |
+| `agent_config` | `PUT/PATCH /agents/{agent}` | object | Replaces existing config. |
+| `delete_files` | `DELETE /agents/{agent}` | boolean | Also remove the agent filesystem directory. Default `false`. |
+| `scope` | `GET /agents` | string | `mine` or `all`; `all` requires admin privileges. |
+| `user_id` | `GET /agents`, access routes | integer | Admin-only filter for list, required for grants/revokes. |
+| `include_role` | `GET /agents` | boolean | Include caller role data. Enabled by default for REST UI payloads. |
+
+### Access And Tokens
+
+| Parameter | Routes | Type | Notes |
+|---|---|---|---|
+| `role` | `POST /agents/{agent}/access` | string | `admin`, `operator`, or `viewer`. Default `viewer`. |
+| `label` | `POST /agents/{agent}/tokens`, authorize flow | string | Human-readable token label such as `kimaki-prod`. |
+| `capabilities` | `POST /agents/{agent}/tokens` | array | Optional allowed capability subset. Omit/null for all agent capabilities. |
+| `expires_in` | `POST /agents/{agent}/tokens` | integer | Expiry in seconds from now. Omit/null for no expiry. |
+| `token_id` | `DELETE /agents/{agent}/tokens/{token_id}` | integer | Token metadata ID to revoke. |
+
+### Browser Authorization
+
+| Parameter | Routes | Type | Notes |
+|---|---|---|---|
+| `redirect_uri` | `/agent/authorize` | string | Required. Validated against the agent allowlist or localhost rules. |
+| `action` | `POST /agent/authorize` | string | `authorize` or `deny`. |
+| `_authorize_nonce` | `POST /agent/authorize` | string | WordPress nonce from the consent form. |
+| `code_challenge` | `/agent/authorize` | string | Optional PKCE-style challenge. |
+| `code_challenge_method` | `/agent/authorize` | string | Optional challenge method. |
+| `state` | `/agent/authorize` | string | Optional opaque client state echoed through redirects. |
+| `token`, `agent_slug`, `agent_id`, `error` | `/agent/auth/callback` | mixed | Callback result fields from the remote authorizing site. |
+| `key` | `/agent/auth/tokens/{key}` | string | Storage key in the form `remote-site/agent-slug`. |
+
+## Response Shape
+
+Most agent management responses use:
+
+```json
+{
+  "success": true,
+  "data": {}
+}
+```
+
+List responses return `data` as an array of agent or grant objects. Token ability responses return ability-native objects such as:
+
+```json
+{
+  "success": true,
+  "token_id": 123,
+  "raw_token": "datamachine_...",
+  "token_prefix": "datamachine_abcd",
+  "message": "Token created. Save it now - it cannot be retrieved again."
+}
+```
+
+`GET /agents/me` returns identity metadata:
+
+```json
+{
+  "success": true,
+  "data": {
+    "agent_id": 2,
+    "agent_slug": "sarai",
+    "agent_name": "Sarai",
+    "owner_id": 1,
+    "site_url": "https://example.com",
+    "site_name": "Example"
+  }
+}
+```
+
+## Agent Usage Examples
+
+Create a token for an external agent client:
+
+```bash
+curl -X POST https://example.com/wp-json/datamachine/v1/agents/sarai/tokens \
+  -H "Content-Type: application/json" \
+  -u username:application_password \
+  -d '{"label":"kimaki-prod","expires_in":2592000}'
+```
+
+Use the returned bearer token to discover the active identity:
+
+```bash
+curl https://example.com/wp-json/datamachine/v1/agents/me \
+  -H "Authorization: Bearer datamachine_..."
+```
+
+Start the browser authorization flow for a local client:
+
+```text
+https://example.com/wp-json/datamachine/v1/agent/authorize?agent_slug=sarai&redirect_uri=http://localhost:31337/callback&label=local-cli&state=abc123
+```

--- a/docs/api/endpoints/email.md
+++ b/docs/api/endpoints/email.md
@@ -1,0 +1,126 @@
+# Email Endpoints
+
+**Implementation**: `inc/Api/Email.php`
+
+**Base URL**: `/wp-json/datamachine/v1/email`
+
+## Overview
+
+Email endpoints expose Data Machine email abilities over REST for sending mail, reading IMAP inboxes, replying, moving, flagging, deleting, unsubscribing, and testing the stored IMAP connection.
+
+## Authentication
+
+All email routes require Data Machine manage permission via `PermissionHelper::can_manage()`.
+
+External REST clients should use WordPress application passwords or cookie auth. Inbox operations also require a configured `email_imap` auth provider; missing IMAP credentials return `not_configured` with HTTP 400.
+
+## Route Table
+
+| Method | Route | Ability | Purpose |
+|---|---|---|---|
+| POST | `/email/send` | `datamachine/send-email` | Send an email with optional headers and attachments. |
+| GET | `/email/fetch` | `datamachine/fetch-email` | Fetch messages from an IMAP folder. |
+| GET | `/email/{uid}/read` | `datamachine/fetch-email` | Read one message by UID. |
+| POST | `/email/reply` | `datamachine/email-reply` | Reply with threading headers. |
+| DELETE | `/email/{uid}` | `datamachine/email-delete` | Delete one message by UID. |
+| POST | `/email/{uid}/move` | `datamachine/email-move` | Move one message to another folder. |
+| POST | `/email/{uid}/flag` | `datamachine/email-flag` | Set or clear an IMAP flag. |
+| POST | `/email/batch/move` | `datamachine/email-batch-move` | Move messages matching an IMAP search. |
+| POST | `/email/batch/flag` | `datamachine/email-batch-flag` | Flag messages matching an IMAP search. |
+| POST | `/email/batch/delete` | `datamachine/email-batch-delete` | Delete messages matching an IMAP search. |
+| POST | `/email/{uid}/unsubscribe` | `datamachine/email-unsubscribe` | Unsubscribe from a list using one message's headers. |
+| POST | `/email/batch/unsubscribe` | `datamachine/email-batch-unsubscribe` | Unsubscribe from lists matching an IMAP search. |
+| POST | `/email/test-connection` | `datamachine/email-test-connection` | Test stored IMAP credentials. |
+
+## Core Parameters
+
+### Send And Reply
+
+| Parameter | Type | Required | Notes |
+|---|---|---|---|
+| `to` | string | yes | Recipient email address or comma-separated addresses for send. |
+| `subject` | string | yes | Subject line. Send supports `{month}`, `{year}`, `{site_name}`, and `{date}` placeholders. |
+| `body` | string | yes | HTML or plain-text body. |
+| `cc`, `bcc` | string | no | Comma-separated addresses. `bcc` is send-only. |
+| `from_name`, `from_email`, `reply_to` | string | no | Send headers. Defaults use site name/admin email when omitted. |
+| `content_type` | string | no | `text/html` by default; `text/plain` is also supported. |
+| `attachments` | array | no | Server file paths for `wp_mail()` attachments. |
+| `in_reply_to` | string | reply only | Message-ID of the email being replied to. |
+| `references` | string | no | References header chain for threading. |
+
+### Fetch And Message Operations
+
+| Parameter | Type | Default | Notes |
+|---|---|---|---|
+| `folder` | string | `INBOX` | Source IMAP folder. |
+| `uid` | integer | route param | Message UID for read/delete/move/flag/unsubscribe. |
+| `search` | string | `UNSEEN` for fetch | IMAP search string, for example `ALL`, `UNSEEN`, `FROM "github.com"`, or `SINCE "1-Mar-2026"`. |
+| `max` | integer | route-specific | Safety limit for fetch or batch operations. |
+| `offset` | integer | `0` | Pagination offset for fetch. |
+| `headers_only` | boolean | `false` | Fast list mode; skips body parsing. |
+| `mark_as_read` | boolean | `false` | Mark fetched messages as read. |
+| `download_attachments` | boolean | `false` | Download attachments into local storage. |
+| `destination` | string | required for move | Target IMAP folder, such as `Archive` or `[Gmail]/All Mail`. |
+| `flag` | string | required for flag | IMAP flag such as `Seen`, `Flagged`, `Answered`, `Deleted`, or `Draft`. |
+| `action` | string | `set` | `set` or `clear` for flag endpoints. |
+
+## Response Shape
+
+Email endpoints return ability-native success objects. Failed ability results are normalized to an `email_error` REST error with HTTP 400.
+
+Send response shape:
+
+```json
+{
+  "success": true,
+  "message": "Email sent successfully",
+  "recipients": ["editor@example.com"],
+  "subject": "Weekly report",
+  "logs": []
+}
+```
+
+Fetch response shape:
+
+```json
+{
+  "success": true,
+  "data": {
+    "items": [],
+    "count": 10,
+    "total_matches": 42,
+    "offset": 0,
+    "has_more": true
+  },
+  "logs": []
+}
+```
+
+Batch operation response shapes include counters such as `moved_count`, `flagged_count`, `deleted_count`, `unsubscribed`, `failed`, or `no_header` depending on the route.
+
+## Agent Usage Examples
+
+List unread message headers without marking them read:
+
+```bash
+curl "https://example.com/wp-json/datamachine/v1/email/fetch?search=UNSEEN&headers_only=1&max=20" \
+  -u username:application_password
+```
+
+Move GitHub notifications to an archive folder:
+
+```bash
+curl -X POST https://example.com/wp-json/datamachine/v1/email/batch/move \
+  -H "Content-Type: application/json" \
+  -u username:application_password \
+  -d '{"search":"FROM \"github.com\"","destination":"Archive","max":100}'
+```
+
+Send a concise agent report:
+
+```bash
+curl -X POST https://example.com/wp-json/datamachine/v1/email/send \
+  -H "Content-Type: application/json" \
+  -u username:application_password \
+  -d '{"to":"editor@example.com","subject":"Daily agent summary","body":"<p>No blockers.</p>"}'
+```

--- a/docs/api/endpoints/internal-links.md
+++ b/docs/api/endpoints/internal-links.md
@@ -1,0 +1,109 @@
+# Internal Links Endpoints
+
+**Implementation**: `inc/Api/InternalLinks.php`
+
+**Base URL**: `/wp-json/datamachine/v1/links`
+
+## Overview
+
+Internal links endpoints expose the link graph abilities used by SEO audits and agents. They can build the cached graph, report orphaned posts, fetch backlinks, check broken URLs, and diagnose site-wide internal link coverage.
+
+## Authentication
+
+All routes require `PermissionHelper::can( 'manage_flows' )`. Requests can use WordPress application passwords or cookie auth.
+
+The controller delegates to WordPress Abilities API abilities. If an ability is not registered, the response is `ability_not_found` with HTTP 500.
+
+## Route Table
+
+| Method | Route | Ability | Purpose |
+|---|---|---|---|
+| POST | `/links/audit` | `datamachine/audit-internal-links` | Scan content, build/cache the link graph, and return aggregates. |
+| GET | `/links/orphans` | `datamachine/get-orphaned-posts` | Return posts with zero inbound internal links. |
+| GET | `/links/backlinks` | `datamachine/get-backlinks` | Return posts linking to a target post. |
+| POST | `/links/broken` | `datamachine/check-broken-links` | Check URLs from the cached graph with HTTP HEAD/GET fallback. |
+| GET | `/links/diagnose` | `datamachine/diagnose-internal-links` | Report internal link coverage from stored metadata. |
+
+GET routes read query parameters. POST routes read the JSON body.
+
+## Core Parameters
+
+| Parameter | Routes | Type | Default | Notes |
+|---|---|---|---|---|
+| `post_type` | audit, orphans, backlinks, broken | string | `post` | Post type scope for graph reads and scans. |
+| `category` | audit | string | none | Category slug to limit audit scope. |
+| `post_ids` | audit | array<int> | none | Specific posts to scan. |
+| `force` | audit | boolean | `false` | Rebuild even when cached data exists. |
+| `types` | audit, orphans, backlinks, broken | array<string> | all | Edge types to include, for example `html_anchor` or `wikilink`. GET accepts comma-separated values. |
+| `limit` | orphans, broken | integer | route-specific | Maximum results or URLs to process. |
+| `post_id` | backlinks | integer | required | Target post ID. |
+| `scope` | broken | string | `internal` | `internal`, `external`, or `all`. |
+| `timeout` | broken | integer | `5` | HTTP timeout per URL in seconds. |
+
+## Response Shape
+
+Successful responses return ability output directly after internal keys prefixed with `_` are stripped.
+
+Audit response shape:
+
+```json
+{
+  "success": true,
+  "total_scanned": 120,
+  "total_links": 640,
+  "orphaned_count": 8,
+  "avg_outbound": 5.3,
+  "avg_inbound": 5.3,
+  "orphaned_posts": [],
+  "top_linked": [],
+  "cached": false
+}
+```
+
+Backlinks response shape:
+
+```json
+{
+  "success": true,
+  "post_id": 123,
+  "backlink_count": 2,
+  "backlinks": [
+    {
+      "source_id": 45,
+      "title": "Related guide",
+      "permalink": "https://example.com/related-guide/",
+      "link_count": 1
+    }
+  ],
+  "from_cache": true
+}
+```
+
+Errors from abilities are returned as `internal_links_error` with HTTP 400 for ability-declared errors or HTTP 500 for `WP_Error` results.
+
+## Agent Usage Examples
+
+Run a fresh internal-link audit for posts:
+
+```bash
+curl -X POST https://example.com/wp-json/datamachine/v1/links/audit \
+  -H "Content-Type: application/json" \
+  -u username:application_password \
+  -d '{"post_type":"post","force":true,"types":["html_anchor"]}'
+```
+
+Find orphaned pages from the cached graph:
+
+```bash
+curl "https://example.com/wp-json/datamachine/v1/links/orphans?post_type=page&limit=25" \
+  -u username:application_password
+```
+
+Check external broken links with a conservative limit:
+
+```bash
+curl -X POST https://example.com/wp-json/datamachine/v1/links/broken \
+  -H "Content-Type: application/json" \
+  -u username:application_password \
+  -d '{"scope":"external","limit":50,"timeout":5}'
+```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -25,11 +25,15 @@ Complete REST API reference for Data Machine
 
 ### Content & Data
 - [Files](endpoints/files.md)
+- [Internal Links](endpoints/internal-links.md)
 - [Processed Items](endpoints/processed-items.md)
 
 ### AI & Chat
+- [Agents](endpoints/agents.md)
+- [Agent Ping](endpoints/agent-ping.md)
 - [Chat](endpoints/chat.md)
 - [Chat Sessions](endpoints/chat-sessions.md)
+- [Email](endpoints/email.md)
 - [Handlers](endpoints/handlers.md)
 - [Providers](endpoints/providers.md)
 - [Tools](endpoints/tools.md)


### PR DESCRIPTION
## Summary
- Adds compact documentation for agent, email, internal links, and agent ping REST surfaces.
- Links the new endpoint references into the API documentation for agent discoverability.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identifying undocumented route groups, drafting endpoint references, and preparing the PR text for Chris to review.