### PR TITLE
docs: refresh REST API inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,16 +161,21 @@ Agent executes → Agent queues next task → Loop continues
 ## WP-CLI
 
 ```bash
-wp datamachine agents           # Agent management and path discovery
+wp datamachine agents           # Agent identities, access, tokens, bundles
+wp datamachine memory           # Layered memory files and path discovery
 wp datamachine pipelines        # Pipeline CRUD
 wp datamachine flows            # Flow CRUD and queue management
 wp datamachine jobs             # Job management, monitoring, undo
+wp datamachine worker           # Headless worker loop
+wp datamachine drain            # Drain due Data Machine actions
+wp datamachine cycle            # Run due flows for an external cycle
+wp datamachine pending-actions  # Inspect approval queues
 wp datamachine settings         # Plugin settings
 wp datamachine posts            # Query Data Machine-created posts
 wp datamachine logs             # Log operations
-wp datamachine memory           # Agent memory read/write
 wp datamachine handlers         # List registered handlers
 wp datamachine step-types       # List registered step types
+wp datamachine processed-items  # Deduplication tracking
 wp datamachine chat             # Chat agent interface
 wp datamachine alt-text         # AI alt text generation
 wp datamachine links            # Internal linking
@@ -178,9 +183,14 @@ wp datamachine blocks           # Gutenberg block operations
 wp datamachine image            # Image generation
 wp datamachine meta-description # SEO meta descriptions
 wp datamachine auth             # OAuth provider management
+wp datamachine email            # Email send/fetch/reply operations
+wp datamachine external         # Remote Data Machine site connections
+wp datamachine indexnow         # IndexNow indexing integration
 wp datamachine taxonomy         # Taxonomy operations
 wp datamachine batch            # Batch operations
 wp datamachine system           # System task management
+wp datamachine retention        # Retention policies and cleanup scheduling
+wp datamachine test             # Fetch handler dry-runs
 wp datamachine analytics        # Analytics and tracking
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Complete user documentation for Data Machine, the AI-first WordPress plugin that
 ### Architecture Deep Dives
 - **Agent Memory Backends**: Store selection model for disk-backed memory, optional guideline-backed stores, and the DMC file-projection boundary ([architecture/agent-memory-backends.md](architecture/agent-memory-backends.md)).
 - **Pipeline Execution Axes**: Queue, fan-out, and per-step iteration semantics ([architecture/pipeline-execution-axes.md](architecture/pipeline-execution-axes.md)).
-- **Policy Resolvers**: Why `ToolPolicyResolver`, `MemoryPolicyResolver`, `ActionPolicyResolver`, and `PipelineTranscriptPolicy` stay as four single-purpose classes ([architecture/policy-resolvers.md](architecture/policy-resolvers.md)).
+- **Policy Resolvers**: Why tool, memory, directive, action, and transcript policies stay as single-purpose classes ([architecture/policy-resolvers.md](architecture/policy-resolvers.md)).
 - **Iteration Budget**: Shared bounded-iteration primitive backing `conversation_turns` and `chain_depth` budgets ([architecture/iteration-budget.md](architecture/iteration-budget.md)).
 
 ### Engine & Services
@@ -25,8 +25,8 @@ Complete user documentation for Data Machine, the AI-first WordPress plugin that
 - **Universal Engine**: Shared AI infrastructure for pipeline and chat agents.
 - **AI Conversation Loop**: Turn-based conversation execution with directive orchestration.
 - **AI Directives System**: Hierarchical directive injection for contextual AI behavior.
-- **Tool Execution**: Centralized discovery, validation, and execution of AI tools.
-- **Tool Manager**: Runtime tool enablement, provider checks, and contextual metadata.
+- **Tool Execution**: Resolved tool dispatch, action policy, ability-only execution, and approval staging.
+- **Tool Manager**: Data Machine tool registry, source-level availability checks, and handler tool expansion.
 - **Request Builder**: Directive-aware construction of provider requests.
 - **Conversation Manager**: Message normalization, logging, and tool call tracking.
 - **Prompt Builder**: Priority-based directive registration via filters.
@@ -43,10 +43,10 @@ Complete user documentation for Data Machine, the AI-first WordPress plugin that
 - **Upsert Handlers**: Identity-aware create-or-update operations — find existing content by identity strategy, update if changed, create if new.
 
 ### AI Tools
-- **Tools Overview**: Global and context-aware tools available to AI agents.
+- **Tools Overview**: Static, ability-backed, and adjacent handler tools available to AI agents.
 - **Execute Workflow**: Modular execution of multi-step workflows from the chat toolset.
-- **Global Tools**: Google Search, Local Search, Web Fetch, WordPress Post Reader, and others used across agents.
-- **Chat Tools**: AddPipelineStep, ApiQuery, ConfigureFlowSteps, ConfigurePipelineStep, CreateFlow, CreatePipeline, RunFlow, UpdateFlow, and other workflow management tools.
+- **Static Registry Tools**: Research, memory, workflow-management, and site-operation tools registered through `datamachine_tools`.
+- **Pipeline Handler Tools**: Runtime tools generated from adjacent fetch, publish, and upsert handlers.
 
 ### API Reference
 - **API Overview**: Catalog of REST endpoints for API consumers ([api/index.md](api/index.md)).

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,8 +49,8 @@ Complete user documentation for Data Machine, the AI-first WordPress plugin that
 - **Chat Tools**: AddPipelineStep, ApiQuery, ConfigureFlowSteps, ConfigurePipelineStep, CreateFlow, CreatePipeline, RunFlow, UpdateFlow, and other workflow management tools.
 
 ### API Reference
-- **API Overview**: Catalog of REST endpoints for API consumers.
-- **Endpoints**: Auth, Execute, Files, Flows, Jobs, Logs, and other REST resources.
+- **API Overview**: Catalog of REST endpoints for API consumers ([api/index.md](api/index.md)).
+- **Endpoints**: Agents, Agent Ping, Auth, Email, Execute, Files, Flows, Internal Links, Jobs, Logs, and other REST resources.
 
 ### Development
 - **Hooks**: Core actions, filters, and engine hooks for extension development.

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,8 +46,8 @@ Complete user documentation for Data Machine, the AI-first WordPress plugin that
 - **Chat Tools**: AddPipelineStep, ApiQuery, ConfigureFlowSteps, ConfigurePipelineStep, CreateFlow, CreatePipeline, RunFlow, UpdateFlow, and other workflow management tools.
 
 ### API Reference
-- **API Overview**: Catalog of REST endpoints for API consumers.
-- **Endpoints**: Auth, Execute, Files, Flows, Jobs, Logs, and other REST resources.
+- **API Overview**: Canonical REST route inventory sourced from `inc/Api` registrations.
+- **Endpoints**: Agents, Agent Ping, Analytics, Auth, Chat, Email, Execute, Files, Flows, Internal Links, Jobs, Logs, Pipelines, Settings, System, and other REST resources.
 
 ### Development
 - **Hooks**: Core actions, filters, and engine hooks for extension development.
@@ -79,6 +79,10 @@ docs/
 ├── api/                               # REST API for consumers
 │   ├── index.md                       # Complete API overview and common patterns
 │   └── endpoints/                     # Individual REST endpoint documentation
+│       ├── agents.md                  # Agent CRUD, access grants, and tokens
+│       ├── agent-ping.md              # Bearer-token ping callback routes
+│       ├── email.md                   # Email send/fetch/mailbox routes
+│       ├── internal-links.md          # Link audit and diagnostics routes
 │       └── errors.md                  # Error handling reference
 ├── development/                       # Developer-focused documentation
 │   ├── hooks/                         # Core actions, filters, and engine hooks

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,8 +49,8 @@ Complete user documentation for Data Machine, the AI-first WordPress plugin that
 - **Pipeline Handler Tools**: Runtime tools generated from adjacent fetch, publish, and upsert handlers.
 
 ### API Reference
-- **API Overview**: Catalog of REST endpoints for API consumers ([api/index.md](api/index.md)).
-- **Endpoints**: Agents, Agent Ping, Auth, Email, Execute, Files, Flows, Internal Links, Jobs, Logs, and other REST resources.
+- **API Overview**: Canonical REST route inventory sourced from `inc/Api` registrations ([api/index.md](api/index.md)).
+- **Endpoints**: Agents, Agent Ping, Analytics, Auth, Chat, Email, Execute, Files, Flows, Internal Links, Jobs, Logs, Pipelines, Settings, System, and other REST resources.
 
 ### Development
 - **Hooks**: Core actions, filters, and engine hooks for extension development.
@@ -82,6 +82,10 @@ docs/
 ├── api/                               # REST API for consumers
 │   ├── index.md                       # Complete API overview and common patterns
 │   └── endpoints/                     # Individual REST endpoint documentation
+│       ├── agents.md                  # Agent CRUD, access grants, and tokens
+│       ├── agent-ping.md              # Bearer-token ping callback routes
+│       ├── email.md                   # Email send/fetch/mailbox routes
+│       ├── internal-links.md          # Link audit and diagnostics routes
 │       └── errors.md                  # Error handling reference
 ├── development/                       # Developer-focused documentation
 │   ├── hooks/                         # Core actions, filters, and engine hooks

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,9 @@ Complete user documentation for Data Machine, the AI-first WordPress plugin that
 - **Iteration Budget**: Shared bounded-iteration primitive backing `conversation_turns` and `chain_depth` budgets ([architecture/iteration-budget.md](architecture/iteration-budget.md)).
 
 ### Engine & Services
+- **Daily Memory System**: DailyMemoryTask lifecycle, deterministic overflow, opt-in daily injection, and daily memory artifacts ([core-system/daily-memory-system.md](core-system/daily-memory-system.md)).
+- **Memory Policy**: Per-agent memory injection policy and safe self-memory write gates ([core-system/memory-policy.md](core-system/memory-policy.md)).
+- **Agent Bundles**: Portable agent package schema, artifact tracking, extras, extension artifacts, run artifacts, and authenticated sources ([core-system/agent-bundles.md](core-system/agent-bundles.md)).
 - **Universal Engine**: Shared AI infrastructure for pipeline and chat agents.
 - **AI Conversation Loop**: Turn-based conversation execution with directive orchestration.
 - **AI Directives System**: Hierarchical directive injection for contextual AI behavior.

--- a/docs/admin-interface/pipeline-builder.md
+++ b/docs/admin-interface/pipeline-builder.md
@@ -1,224 +1,220 @@
 # Pipeline Builder Interface
 
-React-based interface for creating and managing Pipelines and Flows, backed by the `/wp-json/datamachine/v1/` REST API.
+The Pipelines admin page is a React builder for Data Machine pipelines, flows, flow-step handlers, prompt queues, memory/context files, and the integrated chat sidebar. The current client source lives under `inc/Core/Admin/Pages/Pipelines/assets/react/` and all server operations are routed through `utils/api.js` unless noted.
 
-## Architecture
+## Source Map
 
-**TanStack Query** manages server state (pipelines, flows, handler metadata, chat sessions/messages) with caching + invalidation.
+| Area | Primary files |
+| --- | --- |
+| REST wrapper | `utils/api.js` |
+| Pipeline data | `queries/pipelines.js`, `components/pipelines/` |
+| Flow data | `queries/flows.js`, `components/flows/` |
+| Queue data | `queries/queue.js`, `components/modals/FlowQueueModal.jsx` |
+| Handler data | `queries/handlers.js`, `components/modals/HandlerSettingsModal.jsx`, `components/flows/FlowStepHandler.jsx` |
+| Config data | `queries/config.js`, `components/modals/StepSelectionModal.jsx`, `components/modals/HandlerSelectionModal.jsx` |
+| UI state | `stores/uiStore.js`, `components/shared/ModalSwitch.jsx`, `components/shared/ModalManager.jsx` |
+| Chat sidebar | `components/chat/`, `queries/chat.js` |
 
-**Zustand UI store** (`inc/Core/Admin/Pages/Pipelines/assets/react/stores/uiStore.js`) manages client UI state and persists a small subset to `localStorage`:
+## State Model
+
+**TanStack Query** owns server state and cache invalidation for pipelines, flows, handlers, queues, config, memory files, and chat data.
+
+**Zustand** owns local UI state in `stores/uiStore.js`. The persisted keys are intentionally small:
+
 - `selectedPipelineId`
 - `isChatOpen`
 - `chatSessionId`
 
-## Pipeline Management
+Modal state (`activeModal`, `modalData`) stays in the store but is not persisted.
 
-- **Pipeline selection** is stored as `selectedPipelineId` in the Zustand UI store.
-- **Pipeline CRUD** uses REST endpoints via `inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js` (wrapper around `@wordpress/api-fetch` + nonce).
+## Selected Agent Payload
 
-## Flow Management
+Pipeline and flow creation include the selected admin agent when one is active. `utils/api.js` reads `selectedAgentId` from `@shared/stores/agentStore` and adds `{ agent_id: selectedAgentId }` through `getAgentPayload()`.
 
-Flows are created under a pipeline and displayed with pagination.
+Current client mutations that include the selected agent payload:
 
-## Step Configuration
+- `createPipeline(name)` sends `POST /pipelines` with `pipeline_name` and optional `agent_id`.
+- `createFlow(pipelineId, flowName)` sends `POST /flows` with `pipeline_id`, `flow_name`, and optional `agent_id`.
 
-Step and handler configuration is driven by React modals and handler schemas from the REST API.
+Updates, deletes, queue changes, handler changes, and file operations do not add the selected agent payload in the client wrapper.
 
-- **Handler selection** uses `HandlerSelectionModal.jsx`.
-- **Handler settings** uses `HandlerSettingsModal.jsx` (not a PHP template). The modal renders fields from the handler schema and submits updates via the flow update mutation.
-- **OAuth connection** is surfaced through an OAuth modal (`OAuthAuthenticationModal.jsx`) and popup handler components in `inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/oauth/`.
+## Pipeline Operations
 
-## Integrated Chat Sidebar
+| Operation | Client function | Endpoint |
+| --- | --- | --- |
+| List pipelines | `fetchPipelines(null, { perPage, offset, includeFlows, search })` | `GET /pipelines` |
+| Fetch one pipeline | `fetchPipelines(pipelineId, { includeFlows })` | `GET /pipelines?pipeline_id=...` |
+| Create pipeline | `createPipeline(name)` | `POST /pipelines` |
+| Rename pipeline | `updatePipelineTitle(pipelineId, name)` | `PATCH /pipelines/{pipeline_id}` |
+| Delete pipeline | `deletePipeline(pipelineId)` | `DELETE /pipelines/{pipeline_id}` |
+| Export pipelines | `exportPipelines(pipelineIds)` | `GET /pipelines?format=csv&ids=...` |
+| Import pipelines | `importPipelines(csvContent)` | `POST /pipelines` with `batch_import`, `format=csv`, `data` |
 
-The Pipelines page includes a collapsible chat sidebar whose open/closed state, selected pipeline context, and active chat session are tracked in the Zustand UI store.
+List mode defaults to lightweight responses with `include_flows=false`; selected pipeline flows are loaded separately.
 
-## REST API integration
+## Pipeline Step Operations
 
-All Pipelines page operations are REST-driven through the Pipelines page API wrapper (`inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js`), including:
-- Pipelines: `GET /pipelines`, `POST /pipelines`, `PATCH /pipelines/{pipeline_id}`, `DELETE /pipelines/{pipeline_id}`
-- Pipeline steps: `POST /pipelines/{pipeline_id}/steps`, `DELETE /pipelines/{pipeline_id}/steps/{step_id}`, `PUT /pipelines/{pipeline_id}/steps/reorder`
-- Flows: `GET /flows?pipeline_id=...`, `POST /flows`, `GET /flows/{flow_id}`
+| Operation | Client function | Endpoint |
+| --- | --- | --- |
+| Add step | `addPipelineStep(pipelineId, stepType, executionOrder)` | `POST /pipelines/{pipeline_id}/steps` |
+| Delete step | `deletePipelineStep(pipelineId, stepId)` | `DELETE /pipelines/{pipeline_id}/steps/{step_id}` |
+| Reorder steps | `reorderPipelineSteps(pipelineId, steps)` | `PUT /pipelines/{pipeline_id}/steps/reorder` |
+| Update AI step system prompt | `updateSystemPrompt(stepId, prompt, stepType, pipelineId)` | `PUT /pipelines/steps/{step_id}/config` |
 
-(Endpoint surface evolves; treat this list as a starting point and confirm against `inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js` and the PHP REST controllers.)
+`updateSystemPrompt()` only sends `step_type`, `pipeline_id`, and `system_prompt`; provider, model, and tool policy are resolved by the current mode system rather than the pipeline builder client.
 
-**Performance note**: client caching and background refetching are provided by TanStack Query; UI-only state persistence is via Zustand `persist` to `localStorage`.
+## Flow Operations
 
-### Key React files
+| Operation | Client function | Endpoint |
+| --- | --- | --- |
+| List flows for pipeline | `fetchFlows(pipelineId, { page, perPage, outputMode })` | `GET /flows` |
+| Fetch one flow | `fetchFlow(flowId)` | `GET /flows/{flow_id}` |
+| Create flow | `createFlow(pipelineId, flowName)` | `POST /flows` |
+| Rename flow | `updateFlowTitle(flowId, name)` | `PATCH /flows/{flow_id}` |
+| Delete flow | `deleteFlow(flowId)` | `DELETE /flows/{flow_id}` |
+| Duplicate flow | `duplicateFlow(flowId)` | `POST /flows/{flow_id}/duplicate` |
+| Run flow now | `runFlow(flowId)` | `POST /execute` with `flow_id` |
+| Update schedule | `updateFlowSchedule(flowId, schedulingConfig)` | `PATCH /flows/{flow_id}` |
 
-- `inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx`
-- `inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalManager.jsx`
-- `inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/HandlerSettingsModal.jsx`
-- `inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/OAuthAuthenticationModal.jsx`
-- `inc/Core/Admin/Pages/Pipelines/assets/react/components/chat/`
-- `FlowCard` - Flow instance display with scheduling and status
-- `PipelineStepCard` - Individual pipeline step cards with handler info
-- `FlowStepCard` - Configured flow step display with settings
-- `EmptyStepCard` - Add new step interface
-- `EmptyFlowCard` - Create new flow interface
+Flow duplication invalidates the selected pipeline's flow query. It copies via the REST `duplicate` endpoint; the client does not build the duplicate payload itself.
 
-**Modal Components:**
+## Pagination
 
-- `ConfigureStepModal` - AI configuration, system prompts, and tool selection
-- `HandlerSettingsModal` - Handler-specific configuration with dynamic field rendering
-- `OAuthAuthenticationModal` - OAuth provider authentication with popup handling
-- `StepSelectionModal` - Step type selection interface
-- `HandlerSelectionModal` - Handler selection with capability display
-- `FlowScheduleModal` - Flow scheduling configuration
-- `ImportExportModal` - Pipeline import/export operations with CSV handling
+Pipeline lists use offset pagination through `fetchPipelines()` with `per_page` and `offset`.
 
-**Shared Components:**
+Flow lists use 1-indexed page state in React and convert it to REST offset in `fetchFlows()`:
 
-- `LoadingSpinner` - Loading state visualization
-- `StepTypeIcon` - Step type icons with consistent styling
-- `DataFlowArrow` - Visual data flow indicators between steps
-- `PipelineSelector` - Pipeline selection dropdown with preferences
-- `ModalManager` - Centralized modal rendering logic (@since v0.2.3)
-- `ModalSwitch` - Centralized modal routing component (@since v0.2.5)
-
-**Specialized Sub-Components:**
-
-- OAuth components: `ConnectionStatus`, `AccountDetails`, `APIConfigForm`, `OAuthPopupHandler`
-- Files handler components: `FilesHandlerSettings`, `FileUploadInterface`, `FileStatusTable`, `AutoCleanupOption`
-- Configure step components: `AIToolsSelector`, `ToolCheckbox`, `ConfigurationWarning`
-- Import/export components: `ImportTab`, `ExportTab`, `CSVDropzone`, `PipelineCheckboxTable`
-- File management components: `FileUploadDropzone`, `FileStatusTable`, `AutoCleanupOption`
-
-### State Management
-
-**Server state (TanStack Query)**
-
-Pipelines/Flows/Handlers/Chat are fetched and cached via query hooks under `inc/Core/Admin/Pages/Pipelines/assets/react/queries/`.
-
-**Client UI state (Zustand)**
-
-The UI store in `inc/Core/Admin/Pages/Pipelines/assets/react/stores/uiStore.js` is intentionally small and persists only:
-- `selectedPipelineId`
-- `isChatOpen`
-- `chatSessionId`
-
-Modal state is also held in the UI store (`activeModal`, `modalData`) but is not persisted.
-
-### REST API Integration
-
-The Pipelines UI calls REST endpoints through `inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js` (a wrapper around `@wordpress/api-fetch` that reads the nonce/namespace from `window.dataMachineConfig`).
-
-For the authoritative list of endpoints used by the UI, refer to `inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js` and the PHP REST controllers under `inc/Api/`.
-
-### Benefits of React Architecture
-
-**User Experience:**
-- Zero page reloads for all operations
-- Instant visual feedback
-- Optimistic UI updates
-- Real-time status updates
-- Modern, responsive interface
-
-**Developer Experience:**
-- Component reusability
-- Clear separation of concerns
-- Testable code structure
-- Maintainable state management
-- Type-safe operations (via PropTypes)
-
-**Performance:**
-- Client-side caching
-- Efficient re-renders via React optimization
-- Lazy loading of modal content
-- Reduced server load (REST API vs repeated page loads)
-
-**Extensibility:**
-- Easy to add new features
-- Filter-based handler discovery
-- Dynamic field rendering
-- Plugin-friendly architecture
-
-### Migration Impact
-
-**Eliminated Code:**
-
-
-**Simplified Maintenance:**
-- Single responsibility components
-- Declarative UI rendering
-- Centralized state management
-- Consistent error handling patterns
-
-## Advanced Architecture Patterns
-
-### Handler API Helpers
-
-Handler-related server state is fetched through TanStack Query hooks under `inc/Core/Admin/Pages/Pipelines/assets/react/queries/` and shared utility helpers under `inc/Core/Admin/Pages/Pipelines/assets/react/utils/`:
-
-- `inc/Core/Admin/Pages/Pipelines/assets/react/queries/handlers.js` - handler metadata queries
-- `inc/Core/Admin/Pages/Pipelines/assets/react/utils/handlerSettings.js` - field normalization and settings helpers
-
-### Service Layer Architecture
-
-**Handler queries** (`inc/Core/Admin/Pages/Pipelines/assets/react/queries/handlers.js`):
-- Query abstraction for handler-related API operations
-- Separates API communication from component logic
-- Provides reusable handler operation methods
-- Centralizes error handling for handler operations
-
-**Benefits**:
-- Clear separation between API calls, query state, and UI components
-- Consistent cache invalidation through TanStack Query
-- Reusable field-normalization helpers independent of modal rendering
-
-### Modal Management System
-
-**ModalSwitch** (`inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalSwitch.jsx`):
-- Centralized modal rendering component
-- Routes modal types to appropriate modal components
-- Replaces scattered conditional modal logic
-- Single source of truth for modal rendering
-
-**Pattern**:
-```javascript
-// Before: Multiple conditional modal renders scattered in components
-{showHandlerModal && <HandlerSettingsModal />}
-{showConfigModal && <ConfigureStepModal />}
-{showOAuthModal && <OAuthAuthenticationModal />}
-
-// After: Single centralized modal switch
-<ModalSwitch activeModal={activeModal} />
+```js
+offset = ( page - 1 ) * perPage;
 ```
 
-**Benefits**:
-- Reduced code duplication
-- Easier to add new modal types
-- Centralized modal state management
-- Consistent modal behavior
+`FlowsSection.jsx` renders `@shared/components/Pagination` with `page`, `perPage`, `total`, and `onPageChange`. The default flow page size is 20.
 
-### Component Directory Structure
+## Flow Step Configuration
 
+Flow steps render through `FlowStepCard.jsx`. Step type metadata comes from `GET /step-types` via `useStepTypes()`.
+
+The card distinguishes these cases:
+
+- AI steps show a queueable user-message field.
+- Handler-backed steps show handler badges and configure controls.
+- Non-handler step types render inline fields through `InlineStepConfig` and the handler details API fallback.
+
+`updateFlowStepConfig(flowStepId, config)` sends partial config patches to `PATCH /flows/steps/{flow_step_id}/config`.
+
+## Queue CRUD And Modes
+
+Prompt queues are flow-step scoped. `FlowQueueModal.jsx` and `queries/queue.js` expose these operations:
+
+| Operation | Client function | Endpoint |
+| --- | --- | --- |
+| Read queue | `fetchFlowQueue(flowId, flowStepId)` | `GET /flows/{flow_id}/queue?flow_step_id=...` |
+| Add prompt(s) | `addToFlowQueue(flowId, flowStepId, prompts)` | `POST /flows/{flow_id}/queue` |
+| Clear queue | `clearFlowQueue(flowId, flowStepId)` | `DELETE /flows/{flow_id}/queue?flow_step_id=...` |
+| Remove item | `removeFromFlowQueue(flowId, flowStepId, index)` | `DELETE /flows/{flow_id}/queue/{index}?flow_step_id=...` |
+| Update item | `updateFlowQueueItem(flowId, flowStepId, index, prompt)` | `PUT /flows/{flow_id}/queue/{index}` |
+| Update mode | `updateFlowQueueMode(flowId, flowStepId, mode)` | `PUT /flows/{flow_id}/queue/mode` |
+
+Queue modes are:
+
+- `static`: peek the head prompt on each run without mutating the queue.
+- `drain`: pop the head prompt on each run and discard it.
+- `loop`: pop the head prompt on each run and append it to the tail.
+
+The queue modal supports adding text, removing individual items, clearing all items after confirmation, and changing mode. It documents FIFO behavior in the UI.
+
+## Handler Details And Editing
+
+Handler discovery and details use:
+
+- `getHandlers(stepType)` -> `GET /handlers`, optionally filtered by `step_type`.
+- `fetchHandlerDetails(handlerSlug)` -> `GET /handlers/{handler_slug}`.
+
+`HandlerSettingsModal.jsx` receives full handler metadata and the selected handler details as props. It renders schema fields through `HandlerSettingField`, normalizes/sanitizes values through `useHandlerModel()`, and saves through `useUpdateFlowHandler()`.
+
+The save path calls `updateFlowHandler(flowStepId, handlerSlug, settings, pipelineId, stepType, flowConfig, pipelineStepConfig)` and sends:
+
+```json
+{
+  "handler_slug": "example_handler",
+  "pipeline_id": 123,
+  "step_type": "fetch",
+  "flow_config": {},
+  "pipeline_step": {},
+  "settings": {}
+}
 ```
-assets/react/
-├── components/           # UI components and modals
-├── queries/              # TanStack Query hooks
-├── stores/               # Zustand UI state
-└── utils/                # API and field helpers
-```
 
-### Pattern Benefits
+The endpoint is `PUT /flows/steps/{flow_step_id}/handler`.
 
-**Query/UI Separation**:
-- Server state isolated in query hooks
-- UI state isolated in the Zustand store
-- Field normalization isolated in utility helpers
+Handler settings can be enriched by plugins through these client-side filters:
 
-**Centralized Modal Management**:
-- Single modal rendering location
-- Reduced conditional logic in components
-- Easier modal state debugging
+- `datamachine.handlerSettings.init`
+- `datamachine.handlerSettings.fieldChange`
 
-**Custom Hooks**:
-- Reusable state management logic
-- Consistent data fetching patterns
-- Simplified component logic
+OAuth-capable handlers surface connection state in the settings modal and open `OAuthAuthenticationModal.jsx` for connection flows.
 
-**Implemented Features:**
-React architecture provides modern features including:
-- Drag-and-drop step reordering (implemented)
-- Advanced validation UI (easy to implement)
-- Keyboard shortcuts (event-based)
+## Multi-Handler Editing
+
+Multi-handler steps are driven by step type metadata where `multi_handler === true`.
+
+`FlowStepCard.jsx` derives:
+
+- `handler_slugs` for the ordered handler list.
+- `handler_configs` for per-handler config.
+- `handler_settings_displays` for per-handler display rows.
+
+`FlowStepHandler.jsx` renders one badge/configure button per handler when multiple handlers are present and shows a `+` badge when another handler can be added.
+
+`HandlerSettingsModal.jsx` supports per-handler editing by receiving `handlerSlugs` and `onRemoveHandler`. The destructive remove button is only shown when more than one handler is attached.
+
+Add/remove multi-handler operations use the WordPress Abilities API directly instead of the page REST client:
+
+| Operation | Client function | Ability endpoint | Payload |
+| --- | --- | --- | --- |
+| Add handler | `addFlowHandler(flowStepId, handlerSlug, settings)` | `POST /wp-abilities/v1/execute/datamachine/update-flow-step` | `flow_step_id`, `add_handler`, `add_handler_config` |
+| Remove handler | `removeFlowHandler(flowStepId, handlerSlug)` | `POST /wp-abilities/v1/execute/datamachine/update-flow-step` | `flow_step_id`, `remove_handler` |
+
+## Memory, Context, And Agent Files
+
+The builder exposes three file surfaces:
+
+| Surface | Client functions | Endpoints |
+| --- | --- | --- |
+| Pipeline context files | `fetchContextFiles`, `uploadContextFile`, `deleteContextFile` | `GET /files`, `POST /files`, `DELETE /files/{filename}` |
+| Pipeline memory files | `fetchPipelineMemoryFiles`, `updatePipelineMemoryFiles` | `GET/PUT /pipelines/{pipeline_id}/memory-files` |
+| Flow memory files | `fetchFlowMemoryFiles`, `updateFlowMemoryFiles` | `GET/PUT /flows/{flow_id}/memory-files` |
+| Available agent files | `fetchAgentFiles` | `GET /files/agent` |
+
+Context files are uploaded against a pipeline. Memory files are selected by filename at either pipeline or flow scope. Agent files are read as an inventory for the selector UI.
+
+## Handler And Tool Inventory Endpoints
+
+The builder also reads current configuration inventories:
+
+- `getStepTypes()` -> `GET /step-types`.
+- `getTools(context)` -> `GET /tools`, optionally filtered by `context` (`pipeline`, `chat`, or `system`).
+- `getHandlers(stepType)` -> `GET /handlers`, optionally filtered by step type.
+- `getSchedulingIntervals()` -> `GET /settings/scheduling-intervals`.
+
+## Current Modal Components
+
+The modal system is centralized through `ModalSwitch.jsx` and `ModalManager.jsx`. Current modal components include:
+
+- `ContextFilesModal.jsx`
+- `FlowMemoryFilesModal.jsx`
+- `FlowQueueModal.jsx`
+- `FlowScheduleModal.jsx`
+- `HandlerSelectionModal.jsx`
+- `HandlerSettingsModal.jsx`
+- `ImportExportModal.jsx`
+- `MemoryFilesModal.jsx`
+- `OAuthAuthenticationModal.jsx`
+- `StepSelectionModal.jsx`
+
+## Operational Notes
+
+- The builder is REST-first and avoids full page reloads.
+- Query hooks update or invalidate the smallest practical cache slice after mutations.
+- Flow rows are paginated independently of pipeline rows to keep large admin installs usable.
+- Handler UI is schema-driven; handler-specific rendering should be added through field metadata, handler models, or the handler settings filters before adding new bespoke modal branches.

--- a/docs/ai-tools/agent-daily-memory.md
+++ b/docs/ai-tools/agent-daily-memory.md
@@ -1,0 +1,19 @@
+# Agent Daily Memory
+
+`agent_daily_memory` manages daily memory journal files at `daily/YYYY/MM/DD.md`.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat, pipeline policy |
+| Mutation risk | Low mutation |
+| Registered in | `ToolServiceProvider.php` via `AgentDailyMemory` |
+| Backing abilities | `datamachine/daily-memory-read`, `datamachine/daily-memory-write`, `datamachine/daily-memory-list`, `datamachine/search-daily-memory` |
+
+## Actions
+
+- `read`: read a specific daily file.
+- `write`: append or replace daily notes.
+- `list`: list available daily files.
+- `search`: search daily memory over an optional date range.
+
+Use daily memory for temporal work logs and session activity. Use `agent_memory` for durable facts and preferences.

--- a/docs/ai-tools/agent-memory.md
+++ b/docs/ai-tools/agent-memory.md
@@ -1,0 +1,18 @@
+# Agent Memory
+
+`agent_memory` reads and updates agent markdown files such as `MEMORY.md`, `SOUL.md`, and `USER.md`.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat, pipeline policy |
+| Mutation risk | Low mutation |
+| Registered in | `ToolServiceProvider.php` via `AgentMemory` |
+| Backing abilities | `datamachine/get-agent-memory`, `datamachine/update-agent-memory`, `datamachine/list-agent-memory-sections` |
+
+## Actions
+
+- `list_sections`: list `##` sections in the target file.
+- `get`: read a full file or a section.
+- `update`: write a section with `set` or `append` mode.
+
+Use this for durable, cross-session knowledge. For session logs and time-bound events, use `agent_daily_memory`.

--- a/docs/ai-tools/amazon-affiliate-link.md
+++ b/docs/ai-tools/amazon-affiliate-link.md
@@ -1,0 +1,16 @@
+# Amazon Affiliate Link
+
+`amazon_affiliate_link` searches Amazon products and returns an affiliate link, product title, and thumbnail.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat, pipeline |
+| Mutation risk | Read-only |
+| Registered in | `ToolServiceProvider.php` via `AmazonAffiliateLink` |
+| Access | Admin |
+
+## Inputs
+
+- `query`: specific product search query.
+
+Use this only when a product reference is genuinely useful to the reader.

--- a/docs/ai-tools/assign-taxonomy-term.md
+++ b/docs/ai-tools/assign-taxonomy-term.md
@@ -1,0 +1,19 @@
+# Assign Taxonomy Term
+
+`assign_taxonomy_term` assigns a taxonomy term to one or more posts.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Content mutation |
+| Registered in | `ToolServiceProvider.php` via `AssignTaxonomyTerm` |
+| Access | Editor |
+
+## Inputs
+
+- `term`: term ID, name, or slug.
+- `taxonomy`: taxonomy slug.
+- `post_ids`: post IDs to update.
+- `append`: `true` to add to existing terms, `false` to replace.
+
+Use `search_taxonomy_terms` first when the exact term is uncertain.

--- a/docs/ai-tools/copy-flow.md
+++ b/docs/ai-tools/copy-flow.md
@@ -1,0 +1,20 @@
+# Copy Flow
+
+`copy_flow` duplicates a flow to the same pipeline or to another compatible pipeline.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Config mutation |
+| Registered in | `ToolServiceProvider.php` via `CopyFlow` |
+| Backing ability | `datamachine/duplicate-flow` |
+
+## Inputs
+
+- `flow_id`: source flow ID.
+- `destination_pipeline_id`: optional target pipeline.
+- `flow_name`: optional new name.
+- `scheduling_config`: optional schedule override.
+- `step_configs`: optional handler/message overrides by step type or execution order.
+
+Cross-pipeline copies require compatible step structures.

--- a/docs/ai-tools/create-taxonomy-term.md
+++ b/docs/ai-tools/create-taxonomy-term.md
@@ -1,0 +1,19 @@
+# Create Taxonomy Term
+
+`create_taxonomy_term` creates a taxonomy term if it does not already exist.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Content mutation |
+| Registered in | `ToolServiceProvider.php` via `CreateTaxonomyTerm` |
+| Access | Editor |
+
+## Inputs
+
+- `taxonomy`: taxonomy slug.
+- `name`: term name.
+- `parent`: optional parent term for hierarchical taxonomies.
+- `description`: optional term description.
+
+Use during flow setup when required terms are missing.

--- a/docs/ai-tools/delete-file.md
+++ b/docs/ai-tools/delete-file.md
@@ -1,0 +1,17 @@
+# Delete File
+
+`delete_file` deletes an uploaded flow-step file.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Destructive |
+| Registered in | `ToolServiceProvider.php` via `DeleteFile` |
+| Backing ability | `datamachine/delete-flow-file` |
+
+## Inputs
+
+- `filename`: file to delete.
+- `flow_step_id`: flow-step scope for the file.
+
+Use only when the file is no longer needed by the flow.

--- a/docs/ai-tools/delete-flow.md
+++ b/docs/ai-tools/delete-flow.md
@@ -1,0 +1,16 @@
+# Delete Flow
+
+`delete_flow` deletes a flow instance.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Destructive |
+| Registered in | `ToolServiceProvider.php` via `DeleteFlow` |
+| Backing ability | `datamachine/delete-flow` |
+
+## Inputs
+
+- `flow_id`: flow to delete.
+
+Use only after confirming the flow is no longer needed.

--- a/docs/ai-tools/delete-pipeline-step.md
+++ b/docs/ai-tools/delete-pipeline-step.md
@@ -1,0 +1,17 @@
+# Delete Pipeline Step
+
+`delete_pipeline_step` removes a step from a pipeline and cascades removal to all flows on that pipeline.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Destructive |
+| Registered in | `ToolServiceProvider.php` via `DeletePipelineStep` |
+| Backing ability | `datamachine/delete-pipeline-step` |
+
+## Inputs
+
+- `pipeline_id`: pipeline containing the step.
+- `pipeline_step_id`: step to remove.
+
+Use when simplifying or restructuring a workflow.

--- a/docs/ai-tools/delete-pipeline.md
+++ b/docs/ai-tools/delete-pipeline.md
@@ -1,0 +1,16 @@
+# Delete Pipeline
+
+`delete_pipeline` deletes a pipeline and all associated flows.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Destructive |
+| Registered in | `ToolServiceProvider.php` via `DeletePipeline` |
+| Backing ability | `datamachine/delete-pipeline` |
+
+## Inputs
+
+- `pipeline_id`: pipeline to delete.
+
+This removes durable workflow configuration. Use only with explicit intent.

--- a/docs/ai-tools/get-handler-defaults.md
+++ b/docs/ai-tools/get-handler-defaults.md
@@ -1,0 +1,16 @@
+# Get Handler Defaults
+
+`get_handler_defaults` reads site-wide handler defaults.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Read-only |
+| Registered in | `ToolServiceProvider.php` via `GetHandlerDefaults` |
+| Backing abilities | `datamachine/get-handler-site-defaults`, `datamachine/get-handlers`, `datamachine/get-handler-config-fields` |
+
+## Inputs
+
+- `handler_slug`: optional handler slug. Omit to read defaults for all handlers.
+
+Use before configuring flows to follow established site defaults.

--- a/docs/ai-tools/image-generation.md
+++ b/docs/ai-tools/image-generation.md
@@ -1,0 +1,19 @@
+# Image Generation
+
+`image_generation` creates an image-generation job through `wp-ai-client`, then sideloads the result as WordPress media.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat, pipeline |
+| Mutation risk | Low mutation |
+| Registered in | `ToolServiceProvider.php` via `ImageGeneration` |
+| Backing ability | `datamachine/generate-image` |
+
+## Inputs
+
+- `prompt`: detailed image prompt.
+- `provider`: optional `wp-ai-client` provider override.
+- `model`: optional image model override.
+- `aspect_ratio`: `1:1`, `3:4`, `4:3`, `9:16`, or `16:9`.
+
+Default aspect ratio is `3:4` for portrait blog/Pinterest images.

--- a/docs/ai-tools/internal-link-audit.md
+++ b/docs/ai-tools/internal-link-audit.md
@@ -1,0 +1,19 @@
+# Internal Link Audit
+
+`internal_link_audit` audits WordPress links and cached link graph data.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat, pipeline |
+| Mutation risk | Low mutation |
+| Registered in | `ToolServiceProvider.php` via `InternalLinkAudit` |
+| Backing abilities | `datamachine/audit-internal-links`, `datamachine/get-orphaned-posts`, `datamachine/get-backlinks`, `datamachine/check-broken-links` |
+
+## Actions
+
+- `audit`: scan content and cache the link graph.
+- `orphans`: list posts with no inbound links.
+- `backlinks`: list posts linking to a target post ID.
+- `broken`: check internal, external, or all links for broken URLs.
+
+Run `audit` before the other actions when current link data matters.

--- a/docs/ai-tools/list-flows.md
+++ b/docs/ai-tools/list-flows.md
@@ -1,0 +1,19 @@
+# List Flows
+
+`list_flows` lists flows with optional filters.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Read-only |
+| Registered in | `ToolServiceProvider.php` via `ListFlows` |
+| Backing ability | `datamachine/get-flows` |
+
+## Inputs
+
+- `pipeline_id`: optional pipeline filter.
+- `handler_slug`: optional filter for flows using a handler.
+- `per_page`: page size, default `20`, max `100`.
+- `offset`: pagination offset.
+
+Use for flow discovery and admin inventory.

--- a/docs/ai-tools/manage-jobs.md
+++ b/docs/ai-tools/manage-jobs.md
@@ -1,0 +1,21 @@
+# Manage Jobs
+
+`manage_jobs` manages Data Machine jobs.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Destructive |
+| Registered in | `ToolServiceProvider.php` via `ManageJobs` |
+| Backing abilities | `datamachine/get-jobs`, `datamachine/get-jobs-summary`, `datamachine/delete-jobs`, `datamachine/fail-job`, `datamachine/retry-job`, `datamachine/recover-stuck-jobs` |
+
+## Actions
+
+- `list`: list jobs with status, flow, and pipeline filters.
+- `summary`: count jobs by status.
+- `delete`: delete all or failed jobs.
+- `fail`: manually fail a job.
+- `retry`: retry a failed job.
+- `recover`: recover stuck processing jobs.
+
+Use read actions first before destructive job operations.

--- a/docs/ai-tools/manage-logs.md
+++ b/docs/ai-tools/manage-logs.md
@@ -1,0 +1,17 @@
+# Manage Logs
+
+`manage_logs` clears Data Machine logs or reads log metadata.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Destructive |
+| Registered in | `ToolServiceProvider.php` via `ManageLogs` |
+| Backing abilities | `datamachine/clear-logs`, `datamachine/get-log-metadata` |
+
+## Actions
+
+- `get_metadata`: read log counts and date ranges.
+- `clear`: delete logs for one agent or all agents.
+
+Use `read_logs` for log inspection before clearing.

--- a/docs/ai-tools/manage-queue.md
+++ b/docs/ai-tools/manage-queue.md
@@ -1,0 +1,16 @@
+# Manage Queue
+
+`manage_queue` manages prompt queues for flow steps.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Config mutation |
+| Registered in | `ToolServiceProvider.php` via `ManageQueue` |
+| Backing abilities | `datamachine/queue-add`, `datamachine/queue-list`, `datamachine/queue-clear`, `datamachine/queue-remove`, `datamachine/queue-update`, `datamachine/queue-move`, `datamachine/queue-mode` |
+
+## Actions
+
+- `add`, `list`, `clear`, `remove`, `update`, `move`, `mode`.
+
+All actions require `flow_id` and `flow_step_id`. Queue modes are `static`, `drain`, and `loop`.

--- a/docs/ai-tools/merge-taxonomy-terms.md
+++ b/docs/ai-tools/merge-taxonomy-terms.md
@@ -1,0 +1,19 @@
+# Merge Taxonomy Terms
+
+`merge_taxonomy_terms` consolidates duplicate taxonomy terms.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Destructive |
+| Registered in | `ToolServiceProvider.php` via `MergeTaxonomyTerms` |
+| Access | Editor |
+
+## Inputs
+
+- `source_term`: term ID, name, or slug to merge from and delete.
+- `target_term`: term ID, name, or slug to keep.
+- `taxonomy`: taxonomy slug.
+- `merge_meta`: whether to fill empty target meta from source meta.
+
+The tool reassigns posts from source to target before deleting the source term.

--- a/docs/ai-tools/queue-validator.md
+++ b/docs/ai-tools/queue-validator.md
@@ -1,0 +1,19 @@
+# Queue Validator
+
+`queue_validator` checks whether a topic already exists in published content or a Data Machine queue.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Read-only |
+| Registered in | `ToolServiceProvider.php` via `QueueValidator` |
+| Access | Admin |
+
+## Inputs
+
+- `topic`: topic or title to validate.
+- `post_type`: WordPress post type to check.
+- `flow_id` and `flow_step_id`: optional queue scope.
+- `threshold`: Jaccard similarity threshold, default `0.65`.
+
+Use before adding new content prompts to avoid duplicate work.

--- a/docs/ai-tools/read-logs.md
+++ b/docs/ai-tools/read-logs.md
@@ -1,0 +1,19 @@
+# Read Logs
+
+`read_logs` reads Data Machine logs for troubleshooting.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Read-only |
+| Registered in | `ToolServiceProvider.php` via `ReadLogs` |
+| Backing ability | `datamachine/read-logs` |
+
+## Inputs
+
+- `agent_id`: optional agent scope.
+- `mode`: `recent` or `full`.
+- `limit`: maximum recent entries.
+- `job_id`, `pipeline_id`, `flow_id`: optional filters combined with AND logic.
+
+Use for execution audits and failure diagnosis.

--- a/docs/ai-tools/reorder-pipeline-steps.md
+++ b/docs/ai-tools/reorder-pipeline-steps.md
@@ -1,0 +1,17 @@
+# Reorder Pipeline Steps
+
+`reorder_pipeline_steps` changes the execution order of steps in a pipeline.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Config mutation |
+| Registered in | `ToolServiceProvider.php` via `ReorderPipelineSteps` |
+| Backing ability | `datamachine/reorder-pipeline-steps` |
+
+## Inputs
+
+- `pipeline_id`: pipeline to update.
+- `step_order`: array of `{ pipeline_step_id, execution_order }` objects.
+
+Use after adding/removing steps or when changing workflow order.

--- a/docs/ai-tools/search-taxonomy-terms.md
+++ b/docs/ai-tools/search-taxonomy-terms.md
@@ -1,0 +1,18 @@
+# Search Taxonomy Terms
+
+`search_taxonomy_terms` searches existing taxonomy terms.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Read-only |
+| Registered in | `ToolServiceProvider.php` via `SearchTaxonomyTerms` |
+| Access | Editor |
+
+## Inputs
+
+- `taxonomy`: taxonomy slug.
+- `search`: optional partial name filter.
+- `limit`: maximum terms to return, default `20`, max `100`.
+
+Use before creating, updating, assigning, or merging terms.

--- a/docs/ai-tools/send-ping.md
+++ b/docs/ai-tools/send-ping.md
@@ -1,0 +1,19 @@
+# Send Ping
+
+`send_ping` sends a webhook ping to one or more URLs.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Low mutation |
+| Registered in | `ToolServiceProvider.php` via `SendPing` |
+| Backing ability | `datamachine/agent-call` |
+
+## Inputs
+
+- `url`: one URL or newline-separated URLs.
+- `prompt`: optional instructions for the receiving agent.
+- `flow_id`: optional flow context.
+- `pipeline_id`: optional pipeline context.
+
+Use for external agent orchestration and webhook notifications.

--- a/docs/ai-tools/set-handler-defaults.md
+++ b/docs/ai-tools/set-handler-defaults.md
@@ -1,0 +1,17 @@
+# Set Handler Defaults
+
+`set_handler_defaults` updates site-wide default configuration for a handler.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Config mutation |
+| Registered in | `ToolServiceProvider.php` via `SetHandlerDefaults` |
+| Backing ability | `datamachine/update-handler-defaults` |
+
+## Inputs
+
+- `handler_slug`: handler to update.
+- `defaults`: key/value handler configuration defaults.
+
+Use to standardize configuration for future flow setup.

--- a/docs/ai-tools/system-health-check.md
+++ b/docs/ai-tools/system-health-check.md
@@ -1,0 +1,17 @@
+# System Health Check
+
+`system_health_check` runs unified diagnostics for Data Machine and extensions.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Read-only |
+| Registered in | `ToolServiceProvider.php` via `SystemHealthCheck` |
+| Backing ability | `datamachine/system-health-check` |
+
+## Inputs
+
+- `types`: optional check type IDs, or `all`.
+- `options`: type-specific options such as scope, limit, or URL.
+
+Use for proactive health checks and support triage.

--- a/docs/ai-tools/tools-overview.md
+++ b/docs/ai-tools/tools-overview.md
@@ -1,835 +1,148 @@
 # AI Tools Overview
 
-AI tools provide capabilities to AI agents for interacting with external services, processing data, and performing research tasks. Data Machine supports both global tools and handler-specific tools.
+AI tools are registered by `inc/Engine/AI/Tools/ToolServiceProvider.php` into the unified Data Machine tool registry. Tools declare where they can run (`chat`, `pipeline`, or pipeline-policy mode) and the ability or access level required to execute them.
 
-## Tool Categories
+## Registered Tool Inventory
 
-### Global Tools (Universal)
+Mutation risk means what the tool can change when called successfully:
 
-Available to all AI agents (pipeline + chat + standalone) via `datamachine_global_tools` filter:
+- **Read-only**: reads data or runs diagnostics without changing site content/config.
+- **Low mutation**: writes agent memory, logs, queues, generated media, or external notifications.
+- **Config mutation**: changes pipeline, flow, handler, schedule, auth, or default configuration.
+- **Content mutation**: creates, updates, assigns, merges, or deletes WordPress content/taxonomy/files.
+- **Destructive**: deletes durable workflow objects, files, logs, jobs, or terms.
 
-**Google Search** (`google_search`)
-- **Purpose**: Search Google and return structured JSON results with titles, links, and snippets from external websites. Use for external information, current events, and fact-checking.
-- **Configuration**: API key + Custom Search Engine ID required
-- **Use Cases**: Fact-checking, research, external context gathering
+### Chat And Pipeline Tools
 
-**Local Search** (`local_search`)
-- **Purpose**: Search this WordPress site and return structured JSON results with post titles, excerpts, permalinks, and metadata. Use ONCE to find existing content before creating new content.
-- **Configuration**: None required (uses WordPress core)
-- **Use Cases**: Content discovery, internal link suggestions, avoiding duplicate content
+| Tool | Modes | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- | --- |
+| `amazon_affiliate_link` | chat, pipeline | Read-only | Search Amazon products and return affiliate links. | [Amazon Affiliate Link](amazon-affiliate-link.md) |
+| `bing_webmaster` | chat, pipeline | Read-only | Read Bing Webmaster search and crawl analytics. | [Bing Webmaster](bing-webmaster.md) |
+| `google_analytics` | chat, pipeline | Read-only | Read GA4 analytics, realtime, engagement, and comparison metrics. | [Google Analytics](google-analytics.md) |
+| `google_search` | chat, pipeline | Read-only | Search Google Custom Search results. | [Google Search](google-search.md) |
+| `google_search_console` | chat, pipeline | Low mutation | Read GSC data and submit sitemaps. | [Google Search Console](google-search-console.md) |
+| `image_generation` | chat, pipeline | Low mutation | Create image-generation jobs and sideload generated media. | [Image Generation](image-generation.md) |
+| `internal_link_audit` | chat, pipeline | Low mutation | Audit internal links, backlinks, orphans, and broken URLs. | [Internal Link Audit](internal-link-audit.md) |
+| `local_search` | chat, pipeline | Read-only | Search local WordPress posts/pages. | [Local Search](local-search.md) |
+| `pagespeed` | chat, pipeline | Read-only | Run PageSpeed Insights/Lighthouse audits. | [PageSpeed Insights](pagespeed-insights.md) |
+| `web_fetch` | chat, pipeline | Read-only | Fetch readable content from a URL. | [Web Fetch](web-fetch.md) |
+| `wordpress_post_reader` | chat, pipeline | Read-only | Read a WordPress post by permalink URL. | [WordPress Post Reader](wordpress-post-reader.md) |
 
-**WebFetch** (`web_fetch`)
-- **Purpose**: Fetch and extract readable content from web pages. Use after Google Search to retrieve full article content. Returns page title and cleaned text content from any HTTP/HTTPS URL.
-- **Configuration**: None required
-- **Features**: 50K character limit, HTML processing, URL validation
-- **Use Cases**: Web content analysis, reference material extraction, competitive research
+### Chat And Pipeline-Policy Tools
 
-**WordPress Post Reader** (`wordpress_post_reader`)
-- **Purpose**: Read full WordPress post content by URL for detailed analysis
-- **Configuration**: None required
-- **Features**: Complete post content retrieval, optional custom fields inclusion
-- **Use Cases**: Content analysis before WordPress Update operations, detailed post examination after Local Search
+Pipeline-policy tools are available while resolving pipeline tool policy, not as regular adjacent handler tools.
 
-**Update Taxonomy Term** (`update_taxonomy_term`) (@since v0.8.0)
-- **Purpose**: Update existing taxonomy terms including core fields and custom meta.
-- **Configuration**: None required
-- **Features**: Modifies name, slug, description, parent, and custom meta (e.g., venue_address).
-- **Use Cases**: Correcting venue details, updating artist bios, managing taxonomy hierarchies.
-- **Documentation**: [Update Taxonomy Term](update-taxonomy-term.md)
+| Tool | Modes | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- | --- |
+| `agent_daily_memory` | chat, pipeline policy | Low mutation | Read, write, list, and search daily memory journal files. | [Agent Daily Memory](agent-daily-memory.md) |
+| `agent_memory` | chat, pipeline policy | Low mutation | Read and update agent markdown files by section. | [Agent Memory](agent-memory.md) |
 
-**Agent Memory** (`agent_memory`) (@since v0.30.0)
-- **Purpose**: Manage persistent agent memory (MEMORY.md) — long-lived knowledge that survives across sessions. Stored as markdown sections (## headers).
-- **Configuration**: None required
-- **Features**: Actions: `list_sections` (see what exists), `get` (read content), `update` (write). Supports `append` mode to add without losing existing content and `set` mode to replace a section entirely. Optional `user_id` for layered memory context.
-- **Use Cases**: Persistent knowledge storage, cross-session state, agent self-improvement
+### Chat-Only Read And Diagnostics Tools
 
-**Agent Daily Memory** (`agent_daily_memory`) (@since v0.33.0)
-- **Purpose**: Manage daily memory journal entries (daily/YYYY/MM/DD.md). Use for session activity, temporal events, and work logs.
-- **Configuration**: None required
-- **Features**: Actions: `write` (record session notes, defaults to append), `read` (review a specific day), `search` (find past entries by keyword), `list` (see which days have entries). Date defaults to today. Supports `from`/`to` range for search.
-- **Use Cases**: Session logging, temporal event tracking, work history review
+| Tool | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- |
+| `api_query` | Read-only | Query documented Data Machine REST endpoints with mutation operations restricted. | [API Query](api-query.md) |
+| `get_handler_defaults` | Read-only | Read site-wide handler defaults for one handler or all handlers. | [Get Handler Defaults](get-handler-defaults.md) |
+| `list_flows` | Read-only | List flows with pipeline, handler, and pagination filters. | [List Flows](list-flows.md) |
+| `read_logs` | Read-only | Read Data Machine logs with agent/job/pipeline/flow filters. | [Read Logs](read-logs.md) |
+| `search_taxonomy_terms` | Read-only | Search taxonomy terms before create/update/assign operations. | [Search Taxonomy Terms](search-taxonomy-terms.md) |
+| `system_health_check` | Read-only | Run unified Data Machine and extension diagnostics. | [System Health Check](system-health-check.md) |
 
-**Internal Link Audit** (`internal_link_audit`) (@since v0.32.0)
-- **Purpose**: Audit links on the WordPress site. Three actions: `audit` scans post content to build a link graph (cached 24hr), `orphans` lists posts with zero inbound links, `broken` performs HTTP HEAD checks on cached links to find broken URLs.
-- **Configuration**: None required
-- **Features**: Post type and category filtering, force rebuild option, internal/external/all scope for broken link checks, configurable result limits
-- **Use Cases**: SEO link auditing, orphaned content discovery, broken link detection
+### Chat-Only Workflow Configuration Tools
 
-**GitHub Tools** — multi-tool class (@since v0.24.0, **data-machine-code extension only**)
-- `create_github_issue` — Create a GitHub issue in a repository. Async — uses System Agent for execution.
-- `list_github_issues` — List issues from a GitHub repository with state, label, and pagination filters
-- `get_github_issue` — Get a single GitHub issue with full details including body, labels, and comments
-- `manage_github_issue` — Update, close, or comment on a GitHub issue
-- `list_github_pulls` — List pull requests from a repository with state filtering
-- `list_github_repos` — List GitHub repositories for a user or organization
-- **Configuration**: GitHub PAT required in the `data-machine-code` extension
-- **Use Cases**: Bug reports, feature requests, task tracking from AI workflows
-- **Availability**: Not registered by Data Machine core.
+| Tool | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- |
+| `add_pipeline_step` | Config mutation | Add a step to a pipeline and sync flows. | [Add Pipeline Step](add-pipeline-step.md) |
+| `authenticate_handler` | Config mutation | Manage handler credentials and OAuth status. | [Authenticate Handler](authenticate-handler.md) |
+| `configure_flow_steps` | Config mutation | Configure handler settings and AI user messages for one or many flow steps. | [Configure Flow Steps](configure-flow-steps.md) |
+| `configure_pipeline_step` | Config mutation | Configure pipeline-level AI system prompt and tool policy. | [Configure Pipeline Step](configure-pipeline-step.md) |
+| `copy_flow` | Config mutation | Duplicate a flow within or across compatible pipelines. | [Copy Flow](copy-flow.md) |
+| `create_flow` | Config mutation | Create one or more flows with optional schedules and step configs. | [Create Flow](create-flow.md) |
+| `create_pipeline` | Config mutation | Create one or more pipelines and their initial flow. | [Create Pipeline](create-pipeline.md) |
+| `manage_queue` | Config mutation | Add/list/clear/remove/update/move prompt queue items and set queue mode. | [Manage Queue](manage-queue.md) |
+| `reorder_pipeline_steps` | Config mutation | Reorder pipeline steps. | [Reorder Pipeline Steps](reorder-pipeline-steps.md) |
+| `run_flow` | Low mutation | Run a flow now or schedule a future run. | [Run Flow](run-flow.md) |
+| `set_handler_defaults` | Config mutation | Update site-wide defaults for handler configs. | [Set Handler Defaults](set-handler-defaults.md) |
+| `update_flow` | Config mutation | Update flow title and/or schedule. | [Update Flow](update-flow.md) |
 
-**Workspace Tools** — multi-tool class (@since v0.37.0, **data-machine-code extension only**)
-- `workspace_path` — Get the Data Machine workspace path, optionally ensure it exists
-- `workspace_list` — List repositories currently present in the workspace
-- `workspace_show` — Show detailed repo info (branch, remote, latest commit, dirty count)
-- `workspace_ls` — List directory contents within a workspace repository
-- `workspace_read` — Read a text file from a workspace repo with optional offset/limit for large files
-- **Configuration**: Configure and operate through the `data-machine-code` extension
-- **Use Cases**: Repository browsing, code review, workspace navigation
-- **Availability**: Not registered by Data Machine core.
+### Chat-Only Content And File Mutation Tools
 
-**Image Generation** (`image_generation`)
-- **Purpose**: Generate images using AI models (Google Imagen 4, Flux, etc.) via Replicate. Returns a URL to the generated image. Async — uses System Agent.
-- **Configuration**: Replicate API key required
-- **Features**: Default aspect ratio 3:4 (portrait, ideal for Pinterest/blog featured images). Supports 1:1, 3:4, 4:3, 9:16, 16:9 ratios. Configurable model selection.
-- **Use Cases**: Featured image generation, visual content creation, illustration
+| Tool | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- |
+| `assign_taxonomy_term` | Content mutation | Assign a term to one or more posts. | [Assign Taxonomy Term](assign-taxonomy-term.md) |
+| `create_taxonomy_term` | Content mutation | Create a taxonomy term if it does not exist. | [Create Taxonomy Term](create-taxonomy-term.md) |
+| `delete_file` | Destructive | Delete an uploaded file scoped to a flow step. | [Delete File](delete-file.md) |
+| `merge_taxonomy_terms` | Destructive | Reassign posts from a source term to a target term and delete the source term. | [Merge Taxonomy Terms](merge-taxonomy-terms.md) |
+| `update_taxonomy_term` | Content mutation | Update taxonomy term fields and meta. | [Update Taxonomy Term](update-taxonomy-term.md) |
 
-**Amazon Affiliate Link** (`amazon_affiliate_link`) (@since v0.24.0)
-- **Purpose**: Search Amazon products and return an affiliate link with the product title, URL, and thumbnail.
-- **Configuration**: Amazon affiliate credentials required
-- **Features**: Single-query product search, returns product title + affiliate URL + thumbnail
-- **Use Cases**: Contextual product recommendations in content, affiliate monetization
+### Chat-Only Destructive Workflow Tools
 
-**Queue Validator** (`queue_validator`)
-- **Purpose**: Check if a topic already exists as a published post or in a Data Machine queue before generating content. Returns "clear" if no duplicates found, or "duplicate" with match details.
-- **Configuration**: None required
-- **Features**: Title similarity scoring via Jaccard threshold (configurable, default 0.65), checks both published posts and flow queues, supports post type filtering
-- **Use Cases**: Duplicate prevention before content generation, queue hygiene
+| Tool | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- |
+| `delete_flow` | Destructive | Delete a flow. | [Delete Flow](delete-flow.md) |
+| `delete_pipeline` | Destructive | Delete a pipeline and its associated flows. | [Delete Pipeline](delete-pipeline.md) |
+| `delete_pipeline_step` | Destructive | Remove a pipeline step and cascade to flows. | [Delete Pipeline Step](delete-pipeline-step.md) |
+| `manage_jobs` | Destructive | List/summarize jobs and delete, fail, retry, or recover jobs. | [Manage Jobs](manage-jobs.md) |
+| `manage_logs` | Destructive | Clear logs or read log metadata. | [Manage Logs](manage-logs.md) |
 
-**Google Search Console** (`google_search_console`) (@since v0.25.0)
-- **Purpose**: Fetch search analytics from Google Search Console — query performance, page stats, URL inspection, and sitemap management.
-- **Configuration**: Service account JSON + site URL required
-- **Features**: 8 actions (query_stats, page_stats, query_page_stats, date_stats, inspect_url, list_sitemaps, get_sitemap, submit_sitemap), URL and query filters, date range control
-- **Use Cases**: SEO monitoring, indexing verification, search performance analysis
-- **Documentation**: [Google Search Console](google-search-console.md)
+### Chat-Only External Execution Tools
 
-**Bing Webmaster Tools** (`bing_webmaster`) (@since v0.23.0)
-- **Purpose**: Fetch search analytics from Bing Webmaster Tools — query stats, traffic stats, page stats, and crawl stats.
-- **Configuration**: API key required
-- **Features**: 4 actions (query_stats, traffic_stats, page_stats, crawl_stats), configurable result limits
-- **Use Cases**: Bing search performance, crawl monitoring, multi-engine SEO
-- **Documentation**: [Bing Webmaster Tools](bing-webmaster.md)
+| Tool | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- |
+| `execute_workflow` | Content mutation | Execute an ephemeral workflow through the Execute API. | [Execute Workflow](execute-workflow.md) |
+| `send_ping` | Low mutation | POST a prompt/context payload to one or more webhook URLs. | [Send Ping](send-ping.md) |
 
-**Google Analytics** (`google_analytics`) (@since v0.31.0)
-- **Purpose**: Fetch visitor analytics from Google Analytics (GA4) — page performance, traffic sources, daily trends, real-time users, top events, demographics.
-- **Configuration**: Service account JSON + GA4 property ID required (can reuse GSC service account)
-- **Features**: 6 actions (page_stats, traffic_sources, date_stats, realtime, top_events, user_demographics), date range control, page path filtering
-- **Use Cases**: Traffic analysis, content performance, visitor behavior, real-time monitoring
-- **Documentation**: [Google Analytics (GA4)](google-analytics.md)
+### Chat-Only Duplicate Prevention Tool
 
-**PageSpeed Insights** (`pagespeed`) (@since v0.31.0)
-- **Purpose**: Run Lighthouse audits via PageSpeed Insights API — performance scores, Core Web Vitals, accessibility, SEO, and optimization opportunities.
-- **Configuration**: None required (optional API key for higher rate limits)
-- **Features**: 3 actions (analyze, performance, opportunities), mobile/desktop strategies, any public URL
-- **Use Cases**: Performance auditing, Core Web Vitals monitoring, optimization planning
-- **Documentation**: [PageSpeed Insights](pagespeed-insights.md)
+| Tool | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- |
+| `queue_validator` | Read-only | Check if a topic exists in published content or a flow queue. | [Queue Validator](queue-validator.md) |
 
-### Chat-Specific Tools
+## Handler-Specific Tools
 
-Available only to chat AI agents via `datamachine_chat_tools` filter. These specialized tools provide focused, operation-specific functionality for conversational workflow management:
+Handler tools are registered by handlers into the unified `datamachine_tools` registry as deferred `_handler_callable` entries. They become available at runtime when an adjacent step uses the matching handler or step type.
 
-**ExecuteWorkflow** (`execute_workflow`) (@since v0.3.0)
-- **Purpose**: Execute complete multi-step workflows in a single tool call with automatic provider/model defaults injection
-- **Configuration**: None required
-- **Architecture**: Streamlined single-file implementation at `/inc/Api/Chat/Tools/ExecuteWorkflowTool.php` that delegates execution to the Execute API, with shared handler documentation utilities
-- **Use Cases**: Direct workflow execution, ephemeral workflows without pipeline creation
+Examples include:
 
-**AddPipelineStep** (`add_pipeline_step`) (@since v0.4.3)
-- **Purpose**: Add steps to existing pipelines with automatic flow synchronization
-- **Configuration**: None required
-- **Features**: Automatically syncs new steps to all flows on the pipeline
-- **Use Cases**: Incrementally building pipelines through conversation
+- `wordpress_publish`: create WordPress posts; accepts `content_format` (`markdown`, `html`, or `blocks`).
+- `wordpress_update`: update existing WordPress content.
+- `twitter_publish`, `bluesky_publish`, `facebook_publish`, `threads_publish`: publish social posts.
+- `google_sheets_publish`: append rows to Google Sheets.
 
-**ApiQuery** (`api_query`) (@since v0.4.3)
-- **Purpose**: Strictly read-only REST API query tool for discovery, monitoring, and troubleshooting
-- **Configuration**: None required
-- **Features**: Complete API endpoint catalog with usage examples. Mutation operations are restricted.
-- **Use Cases**: System monitoring, handler discovery, job status checking, configuration verification.
+## Extension-Owned Tools
 
-**ConfigureFlowSteps** (`configure_flow_steps`) (@since v0.4.2)
-- **Purpose**: Configure handler settings and AI user messages for flow steps, supporting both single-step and bulk pipeline-scoped operations
-- **Configuration**: None required
-- **Features**: 
-  - **Single mode**: Configure individual steps.
-  - **Bulk mode**: Configure matching steps across all flows in a pipeline.
-  - **Handler Switching**: Use `target_handler_slug` to switch handlers with optional `field_map` for data migration.
-  - **Per-Flow Config**: Support for unique settings per flow in bulk mode via `flow_configs`.
-- **Use Cases**: Setting up fetch/publish/upsert handlers, customizing AI prompts, bulk configuration changes across pipelines, migrating handlers.
+GitHub and workspace tools are not registered by Data Machine core. They are provided by the `data-machine-code` extension when that extension is installed.
 
-**ConfigurePipelineStep** (`configure_pipeline_step`) (@since v0.4.4)
-- **Purpose**: Configure pipeline-level AI settings including system prompt, provider, model, and enabled tools
-- **Configuration**: None required
-- **Features**: Pipeline-wide AI configuration affecting all associated flows
-- **Use Cases**: Setting AI provider/model, system prompts, and tool enablement across workflows
+Common extension tools include:
 
-**CreateFlow** (`create_flow`) (@since v0.4.2)
-- **Purpose**: Create flow instances from existing pipelines with automatic step synchronization
-- **Configuration**: None required
-- **Features**: Supports manual, recurring, and one-time scheduling
-- **Use Cases**: Instantiating pipelines as executable, schedulable flows
+- `create_github_issue`, `list_github_issues`, `get_github_issue`, `manage_github_issue`
+- `list_github_pulls`, `list_github_repos`
+- `workspace_path`, `workspace_list`, `workspace_show`, `workspace_ls`, `workspace_read`
 
-**CreatePipeline** (`create_pipeline`) (@since v0.4.3)
-- **Purpose**: Create pipelines with optional predefined steps and automatic flow instantiation
-- **Configuration**: None required
-- **Features**: Automatically creates associated flow, supports AI step configuration in step definitions
-- **Use Cases**: Creating complete workflow templates through conversation
+## Unregistered Core Class
 
-**RunFlow** (`run_flow`) (@since v0.4.4)
-- **Purpose**: Execute existing flows immediately or schedule delayed execution with job tracking
-- **Configuration**: None required
-- **Features**: Asynchronous execution via WordPress Action Scheduler, comprehensive job monitoring
-- **Use Cases**: Immediate workflow execution, scheduled automation, manual testing
-
-**UpdateFlow** (`update_flow`) (@since v0.4.4)
-- **Purpose**: Update flow-level properties including title and scheduling configuration
-- **Configuration**: None required
-- **Features**: Modify flow names, change scheduling intervals, switch to manual execution
-- **Use Cases**: Workflow organization, schedule adjustments, maintenance operations
-
-**DeletePipeline** (`delete_pipeline`)
-- **Purpose**: Delete a pipeline and all its associated flows
-- **Configuration**: None required
-- **Use Cases**: Pipeline cleanup, workflow removal
-
-**DeleteFlow** (`delete_flow`)
-- **Purpose**: Delete a flow instance
-- **Configuration**: None required
-- **Use Cases**: Flow cleanup, removing unused workflow instances
-
-**CopyFlow** (`copy_flow`) (@since v0.6.25)
-- **Purpose**: Copy a flow to the same or different pipeline. Cross-pipeline requires compatible step structures. Copies handlers, messages, and schedule.
-- **Configuration**: None required
-- **Features**: Override schedule and step configs during copy via optional parameters
-- **Use Cases**: Flow duplication, cross-pipeline flow migration, template instantiation
-
-**ListFlows** (`list_flows`)
-- **Purpose**: List flows with optional filtering by pipeline ID or handler slug. Supports pagination.
-- **Configuration**: None required
-- **Use Cases**: Flow discovery, workflow inventory, dashboard queries
-
-**DeletePipelineStep** (`delete_pipeline_step`)
-- **Purpose**: Remove a step from a pipeline. Cascades removal to all flows on the pipeline.
-- **Configuration**: None required
-- **Use Cases**: Pipeline step cleanup, simplifying workflow structure
-
-**ReorderPipelineSteps** (`reorder_pipeline_steps`)
-- **Purpose**: Reorder steps within a pipeline by providing a new step order array
-- **Configuration**: None required
-- **Use Cases**: Pipeline restructuring, execution order adjustments
-
-**ManageJobs** (`manage_jobs`) (@since v0.24.0)
-- **Purpose**: Manage Data Machine jobs with actions: `list` (with filtering by flow_id, pipeline_id, status), `summary` (counts by status), `delete` (by type: all or failed), `fail` (manually fail a job), `retry` (retry a failed job), `recover` (recover stuck processing jobs).
-- **Configuration**: None required
-- **Use Cases**: Job monitoring, failure recovery, execution management
-
-**ManageLogs** (`manage_logs`) (@since v0.8.2)
-- **Purpose**: Manage Data Machine logs with actions: `clear` (clear logs for agent_id or all), `get_metadata` (get log counts and time range for agent_id or all). Logs are scoped by agent_id.
-- **Configuration**: None required
-- **Use Cases**: Log maintenance, storage management, log metadata inspection
-
-**ReadLogs** (`read_logs`) (@since v0.8.2)
-- **Purpose**: Read Data Machine logs for troubleshooting. Filter by agent_id, job_id, pipeline_id, flow_id (combined with AND logic). Modes: `recent` (default, limited) or `full`.
-- **Configuration**: None required
-- **Use Cases**: Troubleshooting, execution auditing, error investigation
-
-**ManageQueue** (`manage_queue`) (@since v0.24.0)
-- **Purpose**: Manage prompt queues for flow steps with actions: `add`, `list`, `clear`, `remove`, `update`, `move`, `settings`. All actions require flow_id and flow_step_id.
-- **Configuration**: None required
-- **Use Cases**: Queue management, prompt scheduling, content pipeline control
-
-**SendPing** (`send_ping`) (@since v0.24.0)
-- **Purpose**: Send a ping to one or more webhook URLs. Useful for triggering external agents or notifying services.
-- **Configuration**: None required
-- **Features**: Accepts single or newline-separated URLs, optional prompt for receiving agent
-- **Use Cases**: Agent orchestration, webhook notifications, external service triggers
-
-**SystemHealthCheck** (`system_health_check`) (@since v0.24.0)
-- **Purpose**: Run unified health diagnostics for Data Machine and extensions. Returns status of various system components.
-- **Configuration**: None required
-- **Features**: Supports specific check types or "all" for full diagnostics, type-specific options
-- **Use Cases**: System monitoring, proactive issue detection, health reporting
-
-**GetProblemFlows** (`get_problem_flows`)
-- **Purpose**: Identify flows with issues: consecutive failures (broken) or consecutive no-items runs (source exhausted). Configurable threshold.
-- **Configuration**: None required
-- **Use Cases**: Proactive flow monitoring, failure detection, source exhaustion alerts
-
-**GetHandlerDefaults** (`get_handler_defaults`)
-- **Purpose**: Get site-wide handler defaults. Returns defaults for a specific handler or all handlers.
-- **Configuration**: None required
-- **Use Cases**: Configuration discovery, understanding site standards before flow setup
-
-**SetHandlerDefaults** (`set_handler_defaults`)
-- **Purpose**: Set site-wide handler defaults. Establishes standard configuration values that apply to all new flows.
-- **Configuration**: None required
-- **Use Cases**: Standardizing handler configuration, site-wide defaults management
-
-**SearchTaxonomyTerms** (`search_taxonomy_terms`)
-- **Purpose**: Search existing taxonomy terms to discover what terms exist before creating new ones or configuring handler assignments.
-- **Configuration**: None required
-- **Use Cases**: Term discovery, duplicate prevention, handler configuration
-
-**CreateTaxonomyTerm** (`create_taxonomy_term`)
-- **Purpose**: Create a taxonomy term if it does not exist. Supports hierarchical terms with parent assignment.
-- **Configuration**: None required
-- **Use Cases**: Taxonomy setup during flow configuration, creating categories/tags on demand
-
-**AssignTaxonomyTerm** (`assign_taxonomy_term`)
-- **Purpose**: Assign a taxonomy term to one or more posts. Can append to existing terms or replace them.
-- **Configuration**: None required
-- **Use Cases**: Bulk term assignment, content categorization, taxonomy management
-
-**MergeTaxonomyTerms** (`merge_taxonomy_terms`)
-- **Purpose**: Merge two taxonomy terms into one. Reassigns all posts from source to target, optionally merges meta data, then deletes the source term.
-- **Configuration**: None required
-- **Use Cases**: Consolidating duplicate terms, taxonomy cleanup
-
-**AuthenticateHandler** (`authenticate_handler`) (@since v0.6.1)
-- **Purpose**: Manage authentication for handlers with actions: `list` (all handlers requiring auth), `status` (specific handler), `configure` (save credentials), `get_oauth_url` (authorization URL for OAuth), `disconnect` (remove auth).
-- **Configuration**: None required
-- **Use Cases**: Handler authentication setup, OAuth flow management, credential management
-
-**DeleteFile** (`delete_file`)
-- **Purpose**: Delete an uploaded file. Requires flow_step_id to identify the file scope.
-- **Configuration**: None required
-- **Use Cases**: File cleanup, storage management
-
-### Handler-Specific Tools
-
-Available only when the adjacent step matches the handler slug or type, registered into the unified `datamachine_tools` registry as `_handler_callable` entries:
-
-**Publishing Tools**:
-- `twitter_publish` - Post to Twitter (280 char limit)
-- `bluesky_publish` - Post to Bluesky (300 char limit)  
-- `facebook_publish` - Post to Facebook (no limit)
-- `threads_publish` - Post to Threads (500 char limit)
-- `wordpress_publish` - Create WordPress posts; accepts `content_format` (`markdown`, `html`, or `blocks`) and stores content in the post type's configured format
-- `google_sheets_publish` - Add data to Google Sheets
-
-**Update Tools**:
-- `wordpress_update` - Modify existing WordPress content
+`inc/Api/Chat/Tools/GetProblemFlows.php` defines `get_problem_flows`, but `ToolServiceProvider.php` does not instantiate it. It is not part of the registered core inventory until the provider registers it or another bootstrap path instantiates the class.
 
 ## Tool Architecture
 
-### Registration System
+Tool classes extend `BaseTool` and register themselves with `registerTool()`. Registration declares:
 
-**Global Tools** (available to all AI agents - pipeline + chat + standalone):
-```php
-// Registered via datamachine_global_tools filter
-add_filter('datamachine_global_tools', function($tools) {
-    $tools['google_search'] = [
-        'class' => 'DataMachine\\Engine\\AI\\Tools\\GoogleSearch',
-        'method' => 'handle_tool_call',
-        'description' => 'Search Google for information',
-        'requires_config' => true,
-        'parameters' => [
-            'query' => [
-                'type' => 'string',
-                'required' => true,
-                'description' => 'Search query'
-            ]
-        ]
-    ];
-    return $tools;
-}, 10, 1);
-```
+- tool slug
+- definition callback
+- mode list
+- required ability or access level
 
-## Tool Directory Structure
-
-Global tools are located in `/inc/Engine/AI/Tools/Global/`:
-- `AgentMemory.php` - Section-based persistent memory read/write (MEMORY.md)
-- `AgentDailyMemory.php` - Daily memory journal file access (daily/YYYY/MM/DD.md)
-- `AmazonAffiliateLink.php` - Amazon product search with affiliate links
-- `BingWebmaster.php` - Bing Webmaster Tools analytics (delegates to `BingWebmasterAbilities`)
-- `GitHubTools.php` - GitHub repository operations (issues, PRs, repos — multi-tool)
-- `GoogleAnalytics.php` - Google Analytics GA4 data (delegates to `GoogleAnalyticsAbilities`)
-- `GoogleSearch.php` - Web search with Custom Search API
-- `GoogleSearchConsole.php` - Google Search Console analytics (delegates to `GoogleSearchConsoleAbilities`)
-- `ImageGeneration.php` - AI image generation via Replicate (async, System Agent)
-- `InternalLinkAudit.php` - Internal link auditing, orphan detection, broken link checks
-- `LocalSearch.php` - WordPress internal search
-- `PageSpeed.php` - PageSpeed Insights Lighthouse audits (delegates to `PageSpeedAbilities`)
-- `QueueValidator.php` - Flow queue duplicate validation before content generation
-- `WebFetch.php` - Web page content retrieval
-- `WordPressPostReader.php` - Single post analysis
-- `WorkspaceTools.php` - Workspace repository operations (**moved to data-machine-code extension**)
-
-Additional global tools outside the Global directory:
-- `GitHubIssueTool.php` (`/inc/Engine/AI/Tools/`) - GitHub issue creation (**moved to data-machine-code extension**)
-
-Analytics abilities are located in `/inc/Abilities/Analytics/`:
-- `GoogleSearchConsoleAbilities.php` - GSC API integration and JWT auth
-- `BingWebmasterAbilities.php` - Bing Webmaster API integration
-- `GoogleAnalyticsAbilities.php` - GA4 Data API integration and JWT auth
-- `PageSpeedAbilities.php` - PageSpeed Insights API integration
-
-Chat-specific tools at `/inc/Api/Chat/Tools/`:
-- `AddPipelineStep.php` - Add steps to pipelines with flow synchronization
-- `ApiQuery.php` - REST API discovery and queries with comprehensive endpoint documentation
-- `AssignTaxonomyTerm.php` - Assign taxonomy terms to posts
-- `AuthenticateHandler.php` - Handler authentication management (OAuth, credentials)
-- `ConfigureFlowSteps.php` - Flow step configuration (single and bulk modes)
-- `ConfigurePipelineStep.php` - Pipeline-level AI settings configuration
-- `CopyFlow.php` - Flow duplication within or across pipelines
-- `CreateFlow.php` - Flow instance creation with scheduling support
-- `CreatePipeline.php` - Pipeline creation with optional predefined steps
-- `CreateTaxonomyTerm.php` - Taxonomy term creation
-- `DeleteFile.php` - Uploaded file deletion
-- `DeleteFlow.php` - Flow deletion
-- `DeletePipeline.php` - Pipeline and associated flows deletion
-- `DeletePipelineStep.php` - Pipeline step removal with flow cascade
-- `ExecuteWorkflowTool.php` - Direct workflow execution with Execute API delegation
-- `GetHandlerDefaults.php` - Site-wide handler defaults retrieval
-- `GetProblemFlows.php` - Problem flow detection (failures, exhausted sources)
-- `ListFlows.php` - Flow listing with filtering and pagination
-- `ManageJobs.php` - Job management (list, summary, delete, fail, retry, recover)
-- `ManageLogs.php` - Log management (clear, metadata)
-- `ManageQueue.php` - Flow step queue management (add, list, clear, remove, update, move)
-- `MergeTaxonomyTerms.php` - Taxonomy term merging and consolidation
-- `ReadLogs.php` - Log reading with filtering and mode selection
-- `ReorderPipelineSteps.php` - Pipeline step reordering
-- `RunFlow.php` - Flow execution and scheduling with job tracking
-- `SearchTaxonomyTerms.php` - Taxonomy term search and discovery
-- `SendPing.php` - Webhook ping for agent orchestration
-- `SetHandlerDefaults.php` - Site-wide handler defaults configuration
-- `SystemHealthCheck.php` - System health diagnostics
-- `UpdateFlow.php` - Flow property updates and scheduling modifications
-
-Handler-specific tools registered into the unified `datamachine_tools` registry using HandlerRegistrationTrait in each handler class. Each entry carries a `_handler_callable` that is resolved at pipeline execution time with the adjacent step's runtime handler config.
+`ToolPolicyResolver` resolves the active tool set for a context. `ToolExecutor` handles execution. Handler-specific tools are resolved from `_handler_callable` registry entries against adjacent step runtime configuration.
 
 ## Content Authoring Formats
 
-For normal prose, AI tools should write markdown and omit `content_format` unless
-a workflow explicitly asks for HTML or serialized blocks. Raw ability/API callers
-can still pass `content_format` explicitly; omitted raw `datamachine/upsert-post`
-calls keep the legacy block-markup default.
-
-## Tool Management
-
-**ToolManager** (`/inc/Engine/AI/Tools/ToolManager.php`) centralizes tool discovery and validation:
-- `get_all_tools()` - Discover all tools
-- `is_tool_available()` - Validate global and step-specific enablement
-- `is_tool_configured()` - Check configuration requirements
-- `get_opt_out_defaults()` - WordPress-native tools (no config needed)
-
-**BaseTool** (`/inc/Engine/AI/Tools/BaseTool.php`) provides unified base class for all AI tools with standardized registration and error handling.
-
-**Chat-Specific Tools** (available only to chat AI agents):
-```php
-// Registered via datamachine_chat_tools filter
-add_filter('datamachine_chat_tools', function($tools) {
-    $tools['create_pipeline'] = [
-        'class' => 'DataMachine\\Api\\Chat\\Tools\\CreatePipeline',
-        'method' => 'handle_tool_call',
-        'description' => 'Create a new pipeline with optional steps',
-        'parameters' => [/* ... */]
-    ];
-    return $tools;
-});
-```
-
-**Handler-Specific Tools** (available when adjacent step matches handler slug or type):
-```php
-// Registered into the unified datamachine_tools registry as a deferred
-// _handler_callable entry. Preferred path is HandlerRegistrationTrait.
-add_filter('datamachine_tools', function($tools) {
-    $tools['__handler_tools_twitter'] = [
-        '_handler_callable' => function($handler_slug, $handler_config, $engine_data) {
-            return [
-                'twitter_publish' => [
-                    'class'          => 'Twitter\\Handler',
-                    'method'         => 'handle_tool_call',
-                    'handler'        => $handler_slug,
-                    'description'    => 'Post to Twitter',
-                    'parameters'     => ['content' => ['type' => 'string', 'required' => true]],
-                    'handler_config' => $handler_config,
-                ],
-            ];
-        },
-        'handler'      => 'twitter',
-        'modes'        => ['pipeline'],
-        'access_level' => 'admin',
-    ];
-    return $tools;
-});
-```
-
-### Discovery Hierarchy
-
-**ToolManager** implements three-layer validation for tool availability:
-
-1. **Global Level**: Admin settings enable/disable tools site-wide
-2. **Modal Level**: Per-step tool selection in pipeline configuration
-3. **Runtime Level**: Configuration validation checks at execution
-
-**Validation Flow**:
-```php
-$tool_manager = new ToolManager();
-
-// Layer 1: Global enablement
-$is_globally_enabled = $tool_manager->is_globally_enabled('google_search');
-
-// Layer 2: Step-specific selection
-    $step_context_id = 'pipeline_step_id_here'; // Example placeholder step context ID
-    $is_step_enabled = $tool_manager->is_step_tool_enabled($step_context_id, 'google_search');
-
-// Layer 3: Configuration requirements
-    $is_configured = $tool_manager->is_tool_configured('google_search');
-
-// Final availability
-$is_available = $is_globally_enabled && $is_step_enabled && $is_configured;
-```
-
-See Tool Manager for complete documentation.
-
-## Tool Execution Architecture
-
-### ToolExecutor Pattern
-
-All tools integrate via the universal `ToolExecutor` class
-(`/inc/Engine/AI/Tools/ToolExecutor.php`) for execution, and the
-`ToolPolicyResolver` for discovery:
-
-```php
-// Tool discovery
-$resolver        = new \DataMachine\Engine\AI\Tools\ToolPolicyResolver();
-$available_tools = $resolver->resolve( array(
-    'mode'             => \DataMachine\Engine\AI\Tools\ToolPolicyResolver::MODE_PIPELINE,
-    'pipeline_step_id' => $flow_step_id,
-    'engine_data'      => $engine_data,
-) );
-```
-
-**Discovery Process**:
-1. **Handler Tools**: Retrieved from the `datamachine_tools` registry — `_handler_callable` entries resolved per adjacent step
-2. **Global Tools**: Retrieved via `datamachine_global_tools` filter
-3. **Chat Tools**: Retrieved via `datamachine_chat_tools` filter (chat agent only)
-4. **Enablement Check**: Each tool filtered through `datamachine_tool_enabled`
-
-### Filter-Based Enablement
-
-Tools can be enabled/disabled per agent type via filters:
-
-```php
-add_filter('datamachine_tool_enabled', function($enabled, $tool_id, $agent_type) {
-    if ($agent_type === 'chat' && $tool_id === 'create_pipeline') {
-        return true;  // Chat-only tool
-    }
-    return $enabled;
-}, 10, 3);
-```
-
-### Parameter Building
-
-`WP_Agent_Tool_Parameters` (`/inc/Engine/AI/Tools/ToolParameters.php`) provides unified parameter construction:
-
-**Standard Tools** (global tools):
-```php
-$parameters = \DataMachine\Engine\AI\WP_Agent_Tool_Parameters::buildParameters(
-    $data,
-    $job_id,
-    $flow_step_id
-);
-// Returns: ['content_string' => ..., 'title' => ..., 'job_id' => ..., 'flow_step_id' => ...]
-```
-
-**Handler Tools** (publish/upsert handlers):
-```php
-$parameters = \DataMachine\Engine\AI\WP_Agent_Tool_Parameters::buildForHandlerTool(
-    $data,
-    $tool_def,
-    $job_id,
-    $flow_step_id
-);
-// Returns: [...standard params, 'source_url' => ..., 'image_url' => ..., 'tool_definition' => ..., 'handler_config' => ...]
-```
-
-**Benefits**:
-- Handler tools receive engine data (source_url, image_url) for link attribution and post identification
-- Global tools receive clean data packets for content processing
-- All tools receive job_id and flow_step_id context for tracking
-- Unified flat parameter structure for AI simplicity
-
-## Tool Interface
-
-### `handle_tool_call()` Method
-
-All tools implement the same interface:
-
-```php
-public function handle_tool_call(array $parameters, array $tool_def = []): array
-```
-
-**Parameters**:
-- `$parameters` - AI-provided parameters (validated against tool definition)
-- `$tool_def` - Complete tool definition including configuration
-
-**Return Format**:
-```php
-[
-    'success' => true|false,
-    'data' => $result_data, // Tool-specific response data
-    'error' => 'error_message', // Only if success = false
-    'tool_name' => 'tool_identifier'
-]
-```
-
-### Parameter Validation
-
-**Required Parameters**:
-```php
-if (empty($parameters['query'])) {
-    return [
-        'success' => false,
-        'error' => 'Missing required query parameter',
-        'tool_name' => 'google_search'
-    ];
-}
-```
-
-**Type Validation**:
-- `string` - Text content, URLs, identifiers
-- `integer` - Numeric values, IDs, counts
-- `boolean` - True/false flags
-
-## Configuration Management
-
-### Configuration Requirements
-
-**Requires Config Flag**:
-```php
-'requires_config' => true // Shows configure link in UI
-```
-
-**Configuration Storage**:
-- Global tools: WordPress options table
-- Handler tools: Handler-specific configuration
-- OAuth tools: Separate OAuth storage system
-
-### Configuration Validation
-
-```php
-add_filter('datamachine_tool_configured', function($configured, $tool_id) {
-    switch ($tool_id) {
-        case 'google_search':
-            $config = get_option('datamachine_search_config', []);
-            $google_config = $config['google_search'] ?? [];
-            return !empty($google_config['api_key']) && !empty($google_config['search_engine_id']);
-        
-    }
-    return $configured;
-}, 10, 2);
-```
-
-## AI Integration
-
-### Tool Selection
-
-AI agents receive available tools based on:
-1. **Global Settings** - Admin-enabled tools
-2. **Step Configuration** - Modal-selected tools  
-3. **Handler Context** - Next step handler type
-4. **Configuration Status** - Tools with valid configuration
-
-### Tool Descriptions
-
-**AI-Optimized Descriptions**:
-- Clear purpose and capabilities
-- Usage instructions for AI
-- Parameter requirements and formats
-- Expected return data structure
-
-**Example**:
-```php
-'description' => 'Search Google for current information and context. Provides real-time web data to inform content creation, fact-checking, and research. Use max_results to control response size.'
-```
-
-### Conversation Integration
-
-**Universal Engine Architecture** - Tool execution flows through centralized Engine components:
-
-**AIConversationLoop** (`/inc/Engine/AI/AIConversationLoop.php`):
-- Multi-turn conversation execution with automatic tool calling
-- Executes tools returned by AI and appends results to conversation
-- Continues conversation loop until AI completes without tool calls
-- Prevents infinite loops with maximum turn counter
-
-**ToolExecutor** (`/inc/Engine/AI/Tools/ToolExecutor.php`):
-- Universal tool discovery via `getAvailableTools()` method
-- Filter-based tool enablement per agent type (pipeline vs chat)
-- Handler tool and global tool integration
-- Tool configuration validation
-
-**WP_Agent_Tool_Parameters** (`/inc/Engine/AI/Tools/ToolParameters.php`):
-- Centralized parameter building for all AI tools
-- `buildParameters()` for standard AI tools with clean data extraction
-- `buildForHandlerTool()` for handler tools with engine parameters (source_url, image_url)
-- Flat parameter structure for AI simplicity
-
-**ConversationManager** (`/inc/Engine/AI/ConversationManager.php`):
-- Message formatting utilities for AI providers
-- Tool call recording and tracking
-- Conversation message normalization
-- Chronological message ordering
-
-**RequestBuilder** (`/inc/Engine/AI/RequestBuilder.php`):
-- Centralized AI request construction for all agents
-- Directive application system (global, agent-specific, pipeline, chat)
-- Tool restructuring for AI provider compatibility
-- Integration with the wp-ai-client runtime adapter
-
-**Tool Results Processing**:
-- Tool responses formatted by ConversationManager for AI consumption
-- Structured data converted to human-readable success messages
-- Platform-specific messaging enables natural AI agent conversation termination
-- Multi-turn context preservation via AIConversationLoop
-
-## Tool Implementation Examples
-
-### Global Tool (Google Search)
-
-```php
-class GoogleSearch {
-    public function handle_tool_call(array $parameters, array $tool_def = []): array {
-        $config = apply_filters('datamachine_get_tool_config', [], 'google_search');
-        $api_key = $config['api_key'] ?? '';
-        $search_engine_id = $config['search_engine_id'] ?? '';
-        if (empty($api_key) || empty($search_engine_id)) {
-            return [ 'success' => false, 'error' => 'Google Search not configured', 'tool_name' => 'google_search' ];
-        }
-        $query = $parameters['query'];
-        $results = $this->perform_search($query, $api_key, $search_engine_id, 10); // Fixed size
-        return [
-            'success' => true,
-            'data' => [ 'results' => $results, 'query' => $query, 'total_results' => count($results) ],
-            'tool_name' => 'google_search'
-        ];
-    }
-}
-```
-
-### Handler Tool (Twitter Publish)
-
-```php
-class TwitterHandler {
-    public function handle_tool_call(array $parameters, array $tool_def = []): array {
-        // Get handler configuration
-        $handler_config = $tool_def['handler_config'] ?? [];
-        $twitter_config = $handler_config['twitter'] ?? [];
-        
-        // Process content
-        $content = $parameters['content'];
-        $formatted_content = $this->format_for_twitter($content, $twitter_config);
-        
-        // Publish to Twitter
-        $result = $this->publish_tweet($formatted_content);
-        
-        return [
-            'success' => true,
-            'data' => [
-                'tweet_id' => $result['id'],
-                'tweet_url' => $result['url'],
-                'content' => $formatted_content
-            ],
-            'tool_name' => 'twitter_publish'
-        ];
-    }
-}
-```
-
-## Error Handling
-
-### Configuration Errors
-
-**Missing Configuration**:
-- Tool returns error with configuration instructions
-- UI shows configure link for unconfigured tools
-- Runtime validation prevents broken tool calls
-
-**Invalid Configuration**:
-- API key validation during configuration save
-- OAuth token refresh on authentication errors
-- Clear error messages for troubleshooting
-
-### Runtime Errors
-
-**API Failures**:
-- Network errors logged and returned to AI
-- Rate limiting handled gracefully
-- Service outages communicated clearly
-
-**Parameter Errors**:
-- Type validation with specific error messages
-- Required parameter checking
-- Format validation for complex parameters
-
-## Performance Considerations
-
-### Request Optimization
-
-**External API Calls**:
-- Single request per tool execution
-- Timeout handling with WordPress defaults
-- No automatic retries (AI can retry if needed)
-
-**Data Processing**:
-- Minimal memory usage during processing
-- Streaming for large responses
-- Efficient JSON parsing and formatting
-
-### Caching Strategy
-
-**Search Results**: Not cached (real-time data priority)
-**Configuration Data**: Cached in WordPress options
-**OAuth Tokens**: Cached with automatic refresh
-
-## Extension Development
-
-### Custom Global Tool
-
-```php
-class CustomTool {
-    public function __construct() {
-        // Self-register via datamachine_global_tools filter
-        add_filter('datamachine_global_tools', [$this, 'register_tool'], 10, 1);
-    }
-
-    public function register_tool($tools) {
-        $tools['custom_tool'] = [
-            'class' => __CLASS__,
-            'method' => 'handle_tool_call',
-            'description' => 'Custom data processing tool',
-            'requires_config' => false,
-            'parameters' => [
-                'input' => [
-                    'type' => 'string',
-                    'required' => true,
-                    'description' => 'Data to process'
-                ]
-            ]
-        ];
-        return $tools;
-    }
-
-    public function handle_tool_call(array $parameters, array $tool_def = []): array {
-        // Validate parameters
-        if (empty($parameters['input'])) {
-            return [
-                'success' => false,
-                'error' => 'Missing input parameter',
-                'tool_name' => 'custom_tool'
-            ];
-        }
-
-        // Process data
-        $result = $this->process_data($parameters['input']);
-
-        return [
-            'success' => true,
-            'data' => ['processed_result' => $result],
-            'tool_name' => 'custom_tool'
-        ];
-    }
-}
-
-// Self-register the tool
-new CustomTool();
-```
+For normal prose, AI tools should write markdown and omit `content_format` unless a workflow explicitly asks for HTML or serialized blocks. Raw ability/API callers can still pass `content_format`; omitted raw `datamachine/upsert-post` calls keep the legacy block-markup default.
+
+## Directory Reference
+
+| Directory | Contents |
+| --- | --- |
+| `inc/Engine/AI/Tools/Global/` | Chat/pipeline global tools such as search, analytics, memory, image generation, and audits. |
+| `inc/Api/Chat/Tools/` | Chat-only admin/workflow/content tools. |
+| `inc/Engine/AI/Tools/` | Tool registration, policy resolution, execution, and shared base classes. |
+| `inc/Abilities/Analytics/` | Analytics ability implementations used by analytics tools. |

--- a/docs/api/endpoints/agent-ping.md
+++ b/docs/api/endpoints/agent-ping.md
@@ -1,0 +1,91 @@
+# Agent Ping Endpoints
+
+**Implementation**: `inc/Api/AgentPing.php`
+
+**Base URL**: `/wp-json/datamachine/v1/agent-ping`
+
+## Overview
+
+Agent ping endpoints let an external agent callback confirm completion of an asynchronous ping and let the originating site poll callback status.
+
+The callback data is stored in a WordPress transient. New callbacks default to a one-hour TTL; processed callbacks are retained for a short polling grace period.
+
+## Authentication
+
+Both routes require a bearer token in the `Authorization` header:
+
+```text
+Authorization: Bearer <datamachine_agent_ping_callback_token option value>
+```
+
+The expected token is read from the `datamachine_agent_ping_callback_token` option. If no token is configured, all requests are rejected with HTTP 403. Missing or invalid bearer tokens return HTTP 401.
+
+This token is separate from agent runtime bearer tokens created under `/agents/{agent}/tokens`.
+
+## Route Table
+
+| Method | Route | Purpose |
+|---|---|---|
+| POST | `/agent-ping/confirm` | Store the completion status for a callback ID and fire `datamachine_agent_ping_confirmed`. |
+| GET | `/agent-ping/callback/{callback_id}` | Poll the stored callback status. |
+
+## Core Parameters
+
+| Parameter | Route | Type | Required | Notes |
+|---|---|---|---|---|
+| `callback_id` | both | string | yes | Unique callback ID from the original ping. URL param for polling, body param for confirm. |
+| `status` | confirm | string | yes | `success`, `failed`, or `timeout`. |
+| `message_preview` | confirm | string | no | Short preview of the agent response. |
+| `error_message` | confirm | string | no | Error details when `status` is `failed`. |
+
+## Response Shape
+
+Confirmation response:
+
+```json
+{
+  "success": true,
+  "message": "Confirmation received.",
+  "callback_id": "cb_123",
+  "job_id": 456,
+  "flow_step_id": 789
+}
+```
+
+If the callback was already processed, confirm returns success with `processed: true` and the previous status.
+
+Polling response:
+
+```json
+{
+  "callback_id": "cb_123",
+  "job_id": 456,
+  "flow_step_id": 789,
+  "status": "pending",
+  "message_preview": "",
+  "error_message": "",
+  "processed_at": null,
+  "created_at": "2026-01-18 12:00:00",
+  "expires_at": "2026-01-18 13:00:00"
+}
+```
+
+Unknown or expired callback IDs return `callback_not_found` with HTTP 404.
+
+## Agent Usage Examples
+
+Confirm a successful run:
+
+```bash
+curl -X POST https://example.com/wp-json/datamachine/v1/agent-ping/confirm \
+  -H "Authorization: Bearer callback-secret" \
+  -H "Content-Type: application/json" \
+  -d '{"callback_id":"cb_123","status":"success","message_preview":"Task completed"}'
+```
+
+Poll for completion:
+
+```bash
+curl https://example.com/wp-json/datamachine/v1/agent-ping/callback/cb_123 \
+  -H "Authorization: Bearer callback-secret"
+```

--- a/docs/api/endpoints/agent-ping.md
+++ b/docs/api/endpoints/agent-ping.md
@@ -1,0 +1,31 @@
+# Agent Ping Endpoints
+
+**Implementation**: `inc/Api/AgentPing.php`
+
+**Base URL**: `/wp-json/datamachine/v1/agent-ping`
+
+Agent Ping endpoints receive and expose completion callbacks for outbound agent pings.
+
+## Endpoints
+
+| Method | Route | Purpose | Permission |
+|--------|-------|---------|------------|
+| `POST` | `/agent-ping/confirm` | Record a callback result for an agent ping. | Bearer token in `Authorization`. |
+| `GET` | `/agent-ping/callback/{callback_id}` | Poll callback status. | Bearer token in `Authorization`. |
+
+## Authentication
+
+These routes do not use WordPress capabilities. `AgentPing::check_permission()` validates an `Authorization: Bearer <token>` header against the configured `datamachine_agent_ping_callback_token` option.
+
+If the option is empty, callback requests are rejected. If the header is missing or the token does not match, the route returns `401` or `403` depending on the failure.
+
+## Callback Payload
+
+`POST /agent-ping/confirm` requires:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `callback_id` | string | Yes | Callback ID from the original ping. |
+| `status` | string | Yes | One of `success`, `failed`, or `timeout`. |
+| `message_preview` | string | No | Preview of the agent response. |
+| `error_message` | string | No | Error message when status is `failed`. |

--- a/docs/api/endpoints/agents.md
+++ b/docs/api/endpoints/agents.md
@@ -18,6 +18,8 @@ There are three auth modes:
 
 Token values are sensitive. `POST /agents/{agent}/tokens` returns `raw_token` once; list endpoints return token metadata only.
 
+Agent bearer-token requests populate `PermissionHelper` agent context. Token capabilities can be restricted by a capability ceiling, so a token can be narrower than the owning agent's full Data Machine capability set.
+
 ## Route Table
 
 | Method | Route | Auth model | Purpose |

--- a/docs/api/endpoints/agents.md
+++ b/docs/api/endpoints/agents.md
@@ -1,0 +1,39 @@
+# Agents Endpoints
+
+**Implementation**: `inc/Api/Agents.php`
+
+**Base URL**: `/wp-json/datamachine/v1`
+
+Agent CRUD, access grants, bearer-token management, and self-identity lookup.
+
+## Endpoints
+
+| Method | Route | Purpose | Permission |
+|--------|-------|---------|------------|
+| `GET` | `/agents` | List agents visible to the caller. | Logged-in user; response is scoped by ownership/access grants. |
+| `POST` | `/agents` | Create an agent. | `manage_agents` or `create_own_agent`. |
+| `GET` | `/agents/me` | Return the current agent/user identity. | Agent bearer-token context or logged-in user. |
+| `GET` | `/agents/{agent}` | Read an agent by slug. | `manage_agents`. |
+| `GET` | `/agents/{agent_id}` | Read an agent by ID. | `manage_agents`. |
+| `PUT/PATCH` | `/agents/{agent}` | Update an agent by slug. | `manage_agents`. |
+| `PUT/PATCH` | `/agents/{agent_id}` | Update an agent by ID. | `manage_agents`. |
+| `DELETE` | `/agents/{agent}` | Delete an agent by slug. | `manage_agents`. |
+| `DELETE` | `/agents/{agent_id}` | Delete an agent by ID. | `manage_agents`. |
+| `GET` | `/agents/{agent}/access` | List access grants. | `manage_agents`. |
+| `GET` | `/agents/{agent_id}/access` | List access grants. | `manage_agents`. |
+| `POST` | `/agents/{agent}/access` | Grant user access. | `manage_agents`. |
+| `POST` | `/agents/{agent_id}/access` | Grant user access. | `manage_agents`. |
+| `DELETE` | `/agents/{agent}/access/{user_id}` | Revoke user access. | `manage_agents`. |
+| `DELETE` | `/agents/{agent_id}/access/{user_id}` | Revoke user access. | `manage_agents`. |
+| `GET` | `/agents/{agent}/tokens` | List agent tokens. | `manage_agents`. |
+| `GET` | `/agents/{agent_id}/tokens` | List agent tokens. | `manage_agents`. |
+| `POST` | `/agents/{agent}/tokens` | Create an agent bearer token. | `manage_agents`. |
+| `POST` | `/agents/{agent_id}/tokens` | Create an agent bearer token. | `manage_agents`. |
+| `DELETE` | `/agents/{agent}/tokens/{token_id}` | Revoke an agent token. | `manage_agents`. |
+| `DELETE` | `/agents/{agent_id}/tokens/{token_id}` | Revoke an agent token. | `manage_agents`. |
+
+## Notes
+
+- Slug routes are preferred for portable integrations; numeric ID routes remain available for compatibility.
+- Bearer-token requests populate `PermissionHelper` agent context. Token capabilities can be restricted by a capability ceiling.
+- `/agents/me` is the discovery endpoint for external clients that need to validate a token and learn site/agent metadata.

--- a/docs/api/endpoints/agents.md
+++ b/docs/api/endpoints/agents.md
@@ -1,0 +1,144 @@
+# Agents Endpoints
+
+**Implementation**: `inc/Api/Agents.php`, `inc/Core/Auth/AgentAuthorize.php`, `inc/Core/Auth/AgentAuthCallback.php`
+
+**Base URL**: `/wp-json/datamachine/v1`
+
+## Overview
+
+Agent endpoints manage agent records, user access grants, runtime bearer tokens, and the browser authorization flow used by external agent clients.
+
+## Authentication
+
+There are three auth modes:
+
+- Agent CRUD, access, and token management use the current WordPress user and Data Machine agent capabilities.
+- `GET /agents/me` accepts either an agent bearer token context or a logged-in WordPress user.
+- `/agent/authorize` and `/agent/auth/callback` are browser-facing flow endpoints with open REST permissions, then validate login cookies, nonces, redirect URIs, or callback payloads inside the handler.
+
+Token values are sensitive. `POST /agents/{agent}/tokens` returns `raw_token` once; list endpoints return token metadata only.
+
+## Route Table
+
+| Method | Route | Auth model | Purpose |
+|---|---|---|---|
+| GET | `/agents` | Logged-in user | List agents visible to the caller. |
+| POST | `/agents` | `manage_agents` or `create_own_agent` | Create an agent. |
+| GET | `/agents/me` | Agent token or logged-in user | Discover the current agent identity. |
+| GET | `/agents/{agent}` | `manage_agents` | Fetch an agent by slug or numeric ID. |
+| PUT/PATCH | `/agents/{agent}` | `manage_agents` | Update agent display name or config. |
+| DELETE | `/agents/{agent}` | `manage_agents` | Delete an agent. |
+| GET | `/agents/{agent}/access` | `manage_agents` | List user access grants. |
+| POST | `/agents/{agent}/access` | `manage_agents` | Grant user access. |
+| DELETE | `/agents/{agent}/access/{user_id}` | `manage_agents` | Revoke user access. |
+| GET | `/agents/{agent}/tokens` | `manage_agents` plus agent access check | List token metadata. |
+| POST | `/agents/{agent}/tokens` | `manage_agents` plus admin access to agent | Create a bearer token. |
+| DELETE | `/agents/{agent}/tokens/{token_id}` | `manage_agents` plus admin access to agent | Revoke a token. |
+| GET | `/agent/authorize` | Browser session | Show consent or redirect to login. |
+| POST | `/agent/authorize` | Browser session plus nonce | Approve or deny authorization. |
+| GET | `/agent/auth/callback` | Callback payload | Receive and store an external token. |
+| GET | `/agent/auth/tokens` | `manage_options` | List stored external token metadata. |
+| GET | `/agent/auth/tokens/{key}` | `manage_options` | Return one stored external token record. |
+
+`{agent}` accepts an agent slug (`sarai`) or numeric agent ID (`42`). Slug routes are preferred.
+
+## Core Parameters
+
+### Agent CRUD
+
+| Parameter | Routes | Type | Notes |
+|---|---|---|---|
+| `agent_slug` | `POST /agents`, authorize flow | string | Required when creating or authorizing. Sanitized as a slug. |
+| `agent_name` | `POST /agents`, `PUT/PATCH /agents/{agent}` | string | Display name. Defaults to slug on create. |
+| `config` | `POST /agents` | object | Initial config object. |
+| `agent_config` | `PUT/PATCH /agents/{agent}` | object | Replaces existing config. |
+| `delete_files` | `DELETE /agents/{agent}` | boolean | Also remove the agent filesystem directory. Default `false`. |
+| `scope` | `GET /agents` | string | `mine` or `all`; `all` requires admin privileges. |
+| `user_id` | `GET /agents`, access routes | integer | Admin-only filter for list, required for grants/revokes. |
+| `include_role` | `GET /agents` | boolean | Include caller role data. Enabled by default for REST UI payloads. |
+
+### Access And Tokens
+
+| Parameter | Routes | Type | Notes |
+|---|---|---|---|
+| `role` | `POST /agents/{agent}/access` | string | `admin`, `operator`, or `viewer`. Default `viewer`. |
+| `label` | `POST /agents/{agent}/tokens`, authorize flow | string | Human-readable token label such as `kimaki-prod`. |
+| `capabilities` | `POST /agents/{agent}/tokens` | array | Optional allowed capability subset. Omit/null for all agent capabilities. |
+| `expires_in` | `POST /agents/{agent}/tokens` | integer | Expiry in seconds from now. Omit/null for no expiry. |
+| `token_id` | `DELETE /agents/{agent}/tokens/{token_id}` | integer | Token metadata ID to revoke. |
+
+### Browser Authorization
+
+| Parameter | Routes | Type | Notes |
+|---|---|---|---|
+| `redirect_uri` | `/agent/authorize` | string | Required. Validated against the agent allowlist or localhost rules. |
+| `action` | `POST /agent/authorize` | string | `authorize` or `deny`. |
+| `_authorize_nonce` | `POST /agent/authorize` | string | WordPress nonce from the consent form. |
+| `code_challenge` | `/agent/authorize` | string | Optional PKCE-style challenge. |
+| `code_challenge_method` | `/agent/authorize` | string | Optional challenge method. |
+| `state` | `/agent/authorize` | string | Optional opaque client state echoed through redirects. |
+| `token`, `agent_slug`, `agent_id`, `error` | `/agent/auth/callback` | mixed | Callback result fields from the remote authorizing site. |
+| `key` | `/agent/auth/tokens/{key}` | string | Storage key in the form `remote-site/agent-slug`. |
+
+## Response Shape
+
+Most agent management responses use:
+
+```json
+{
+  "success": true,
+  "data": {}
+}
+```
+
+List responses return `data` as an array of agent or grant objects. Token ability responses return ability-native objects such as:
+
+```json
+{
+  "success": true,
+  "token_id": 123,
+  "raw_token": "datamachine_...",
+  "token_prefix": "datamachine_abcd",
+  "message": "Token created. Save it now - it cannot be retrieved again."
+}
+```
+
+`GET /agents/me` returns identity metadata:
+
+```json
+{
+  "success": true,
+  "data": {
+    "agent_id": 2,
+    "agent_slug": "sarai",
+    "agent_name": "Sarai",
+    "owner_id": 1,
+    "site_url": "https://example.com",
+    "site_name": "Example"
+  }
+}
+```
+
+## Agent Usage Examples
+
+Create a token for an external agent client:
+
+```bash
+curl -X POST https://example.com/wp-json/datamachine/v1/agents/sarai/tokens \
+  -H "Content-Type: application/json" \
+  -u username:application_password \
+  -d '{"label":"kimaki-prod","expires_in":2592000}'
+```
+
+Use the returned bearer token to discover the active identity:
+
+```bash
+curl https://example.com/wp-json/datamachine/v1/agents/me \
+  -H "Authorization: Bearer datamachine_..."
+```
+
+Start the browser authorization flow for a local client:
+
+```text
+https://example.com/wp-json/datamachine/v1/agent/authorize?agent_slug=sarai&redirect_uri=http://localhost:31337/callback&label=local-cli&state=abc123
+```

--- a/docs/api/endpoints/analytics.md
+++ b/docs/api/endpoints/analytics.md
@@ -17,7 +17,7 @@ Unified REST API for all analytics integrations. Each endpoint delegates to its 
 
 ## Authentication
 
-All endpoints require `manage_options` capability. Returns HTTP 403 if the current user lacks permission.
+All endpoints require `PermissionHelper::can( 'manage_flows' )`. Administrators also pass through the `manage_options` fallback in `PermissionHelper`.
 
 ## Request Format
 
@@ -150,7 +150,7 @@ const ABILITY_MAP = [
 ### Execution Flow
 
 1. `register_routes()` registers all four POST routes
-2. `check_permission()` validates `manage_options` capability
+2. `check_permission()` validates the scoped `manage_flows` permission
 3. `handle_request()` extracts tool name from route, looks up ability slug
 4. Ability is retrieved via `wp_get_ability()` and executed with the JSON body
 5. Error responses use HTTP 422 for configuration errors, 400 for input errors

--- a/docs/api/endpoints/auth.md
+++ b/docs/api/endpoints/auth.md
@@ -4,549 +4,79 @@
 
 **Base URL**: `/wp-json/datamachine/v1/auth`
 
-## Overview
-
-Auth endpoints manage OAuth accounts and handler authentication for external services.
+Auth endpoints manage handler authentication and provider metadata. They are separate from WordPress REST authentication, which is documented in [Authentication](authentication.md).
 
 ## Authentication
 
-Requires `manage_options` capability. See Authentication Guide.
+Requires the Data Machine `manage_settings` permission (`PermissionHelper::can( 'manage_settings' )`).
 
-## Handler Auth Requirements (@since v0.3.1)
+## Response Envelope
 
-Handlers can declare whether they require authentication via the `requires_auth` flag. When a handler's `requires_auth` is `false`, the Auth API bypasses authentication validation for that handler, allowing handlers like public scrapers to operate without OAuth configuration.
-
-**Auth Bypass Behavior**:
-- GET `/auth/{handler_slug}/status` - Returns success with `requires_auth: false` without checking OAuth state
-- PUT `/auth/{handler_slug}` - Returns success without requiring credentials
-- DELETE `/auth/{handler_slug}` - Returns success without disconnection operations
-
-## Provider Key Resolution
-
-Auth endpoints accept `{handler_slug}` in the URL, but internally they resolve the auth provider via the handler's `auth_provider_key` (from the Handlers registry). This supports shared authentication across multiple handlers (for example, one set of Meta credentials used by multiple publish destinations).
-
-## Endpoints
-
-### GET /auth/{handler_slug}/status
-
-Check OAuth authentication status for a handler.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `handler_slug` (string, required): Handler identifier (e.g., `reddit`, `google_sheets`)
-
-**Returns**: Authentication status, account details, and OAuth error/success states
-
-**Example Request**:
-
-```bash
-curl https://example.com/wp-json/datamachine/v1/auth/reddit/status \
--u username:application_password
-```
-
-**Success Response - Authenticated (200 OK)**:
+Successful auth routes return either:
 
 ```json
 {
   "success": true,
-  "data": {
-    "authenticated": true,
-    "account_details": {
-      "username": "exampleuser",
-      "id": "1234567890"
-    },
-    "config_status": {
-      "api_key": "••••••••",
-      "api_secret": "••••••••"
-    },
-    "handler_slug": "reddit"
-  }
+  "data": {}
 }
 ```
 
-**Success Response - Not Authenticated (200 OK)**:
+or the successful ability result directly when the ability already includes `success` and related fields.
+
+Failures are `WP_Error` responses. Common statuses are 400 for invalid input, 404 for missing providers/handlers, 409 for not-authenticated refresh/disconnect states, and 500 for internal failures.
+
+## Routes
+
+### GET `/wp-json/datamachine/v1/auth/providers`
+
+List registered auth providers.
+
+**Success shape**:
 
 ```json
 {
   "success": true,
-  "data": {
-    "authenticated": false,
-    "error": false,
-    "config_status": {
-      "api_key": "",
-      "api_secret": ""
-    },
-    "handler_slug": "reddit"
-  }
+  "data": []
 }
 ```
 
-**Success Response - OAuth Error (200 OK)**:
-
-```json
-{
-  "success": true,
-  "data": {
-    "authenticated": false,
-    "error": true,
-    "error_code": "oauth_failed",
-    "error_message": "User denied authorization",
-    "config_status": {
-      "api_key": "",
-      "api_secret": ""
-    },
-    "handler_slug": "reddit"
-  }
-}
-```
-
-**Error Response (404 Not Found)**:
-
-```json
-{
-  "code": "auth_provider_not_found",
-  "message": "Authentication provider not found",
-  "data": {"status": 404}
-}
-```
-
-### PUT /auth/{handler_slug}
-
-Save authentication configuration for a handler.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `handler_slug` (string, required): Handler identifier (in URL path)
-- Additional parameters vary by handler (e.g., `api_key`, `api_secret`, `client_id`, `client_secret`)
-
-**Storage Behavior**:
-- **OAuth providers** (Reddit, Google Sheets): Stored to `oauth_keys`
-- **Simple auth providers**: Stored to `oauth_account`
-
-**Example Requests**:
-
-```bash
-# Save Reddit OAuth keys
-curl -X PUT https://example.com/wp-json/datamachine/v1/auth/reddit \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "client_id": "your_client_id",
-    "client_secret": "your_client_secret"
-  }'
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "message": "Configuration saved successfully"
-}
-```
-
-**Success Response - No Changes (200 OK)**:
-
-```json
-{
-  "success": true,
-  "message": "Configuration is already up to date - no changes detected"
-}
-```
+### GET `/wp-json/datamachine/v1/auth/{handler_slug}/status`
 
-**Error Response (400 Bad Request)**:
+Check auth status for a handler slug. The handler slug is resolved through `AuthAbilities`, including handlers that share an auth provider key.
 
-```json
-{
-  "code": "required_field_missing",
-  "message": "API Key is required",
-  "data": {"status": 400}
-}
-```
+**Response data may include**:
 
-### DELETE /auth/{handler_slug}
+- `handler_slug`
+- `authenticated`
+- `requires_auth`
+- `message`
+- `oauth_url`
+- `instructions`
 
-Disconnect an authenticated account.
+Handlers with `requires_auth: false` return success without OAuth state.
 
-**Permission**: `manage_options` capability required
+### PUT `/wp-json/datamachine/v1/auth/{handler_slug}`
 
-**Parameters**:
-- `handler_slug` (string, required): Handler identifier (in URL path)
+Save auth configuration for a handler.
 
-**Example Request**:
+**Body**: provider-specific config fields. All request params except `handler_slug` are passed as `config` to `AuthAbilities::executeSaveAuthConfig()`.
 
-```bash
-curl -X DELETE https://example.com/wp-json/datamachine/v1/auth/twitter \
-  -u username:application_password
-```
+### DELETE `/wp-json/datamachine/v1/auth/{handler_slug}`
 
-**Success Response (200 OK)**:
+Disconnect a handler account.
 
-```json
-{
-  "success": true,
-  "message": "Twitter account disconnected successfully"
-}
-```
+### PUT `/wp-json/datamachine/v1/auth/{handler_slug}/token`
 
-**Error Response (500 Internal Server Error)**:
+Set account/token data manually.
 
-```json
-{
-  "code": "disconnect_failed",
-  "message": "Failed to disconnect account",
-  "data": {"status": 500}
-}
-```
+**Body**: JSON object passed as `account_data` to `AuthAbilities::executeSetAuthToken()`.
 
-## Authentication Methods
+### POST `/wp-json/datamachine/v1/auth/{handler_slug}/refresh`
 
-### OAuth 1.0a
+Force a token refresh for a handler.
 
-Used by Twitter.
+## Notes for Agents
 
-**Configuration Requirements**:
-- `consumer_key` - Application consumer key
-- `consumer_secret` - Application consumer secret
-
-**OAuth Flow**:
-1. Save consumer key/secret via PUT endpoint
-2. User initiates OAuth via `/datamachine-auth/twitter/` URL
-3. Popup window handles OAuth callback
-4. Access tokens stored automatically
-5. Check status via GET endpoint
-
-### OAuth 2.0
-
-Used by Reddit, Facebook, Threads, Google Sheets.
-
-**Configuration Requirements**:
-- `client_id` - OAuth application client ID
-- `client_secret` - OAuth application client secret
-
-**OAuth Flow**:
-1. Save client ID/secret via PUT endpoint
-2. User initiates OAuth via `/datamachine-auth/{handler}/` URL
-3. Popup window handles OAuth callback
-4. Access tokens stored automatically
-5. Check status via GET endpoint
-
-### App Password
-
-Used by Bluesky.
-
-**Configuration Requirements**:
-- `username` - Bluesky username (e.g., `user.bsky.social`)
-- `app_password` - Bluesky app password
-
-**Authentication Flow**:
-1. Save credentials via PUT endpoint
-2. Credentials used directly (no OAuth flow)
-3. Check status via GET endpoint
-
-## Supported Handlers
-
-### Twitter
-
-**Handler Slug**: `twitter`
-
-**Auth Type**: OAuth 1.0a
-
-**Configuration**:
-```json
-{
-  "consumer_key": "your_consumer_key",
-  "consumer_secret": "your_consumer_secret"
-}
-```
-
-**OAuth URL**: `/datamachine-auth/twitter/`
-
-### Reddit
-
-**Handler Slug**: `reddit`
-
-**Auth Type**: OAuth 2.0
-
-**Configuration**:
-```json
-{
-  "client_id": "your_client_id",
-  "client_secret": "your_client_secret"
-}
-```
-
-**OAuth URL**: `/datamachine-auth/reddit/`
-
-### Facebook
-
-**Handler Slug**: `facebook`
-
-**Auth Type**: OAuth 2.0
-
-**Configuration**:
-```json
-{
-  "app_id": "your_app_id",
-  "app_secret": "your_app_secret"
-}
-```
-
-**OAuth URL**: `/datamachine-auth/facebook/`
-
-### Threads
-
-**Handler Slug**: `threads`
-
-**Auth Type**: OAuth 2.0 (uses Facebook credentials)
-
-**Configuration**:
-```json
-{
-  "app_id": "your_app_id",
-  "app_secret": "your_app_secret"
-}
-```
-
-**OAuth URL**: `/datamachine-auth/threads/`
-
-### Google Sheets
-
-**Handler Slug**: `google-sheets`
-
-**Auth Type**: OAuth 2.0
-
-**Configuration**:
-```json
-{
-  "client_id": "your_client_id",
-  "client_secret": "your_client_secret"
-}
-```
-
-**OAuth URL**: `/datamachine-auth/google-sheets/`
-
-### Bluesky
-
-**Handler Slug**: `bluesky`
-
-**Auth Type**: App Password
-
-**Configuration**:
-```json
-{
-  "username": "user.bsky.social",
-  "app_password": "your_app_password"
-}
-```
-
-**No OAuth Flow**: Credentials used directly
-
-## Integration Examples
-
-### Python Authentication Management
-
-```python
-import requests
-from requests.auth import HTTPBasicAuth
-
-base_url = "https://example.com/wp-json/datamachine/v1/auth"
-auth = HTTPBasicAuth("username", "application_password")
-
-# Check authentication status
-def check_auth_status(handler):
-    url = f"{base_url}/{handler}/status"
-    response = requests.get(url, auth=auth)
-    return response.json()
-
-# Save configuration
-def save_auth_config(handler, config):
-    url = f"{base_url}/{handler}"
-    response = requests.put(url, json=config, auth=auth)
-    return response.json()
-
-# Disconnect account
-def disconnect_account(handler):
-    url = f"{base_url}/{handler}"
-    response = requests.delete(url, auth=auth)
-    return response.json()
-
-# Usage
-status = check_auth_status('twitter')
-print(f"Twitter authenticated: {status['authenticated']}")
-
-# Save Twitter config
-config = {
-    "consumer_key": "your_key",
-    "consumer_secret": "your_secret"
-}
-result = save_auth_config('twitter', config)
-print(f"Config saved: {result['success']}")
-```
-
-### JavaScript OAuth Management
-
-```javascript
-const axios = require('axios');
-
-class AuthManager {
-  constructor(baseURL, auth) {
-    this.baseURL = `${baseURL}/auth`;
-    this.auth = auth;
-  }
-
-  async checkStatus(handler) {
-    const response = await axios.get(
-      `${this.baseURL}/${handler}/status`,
-      { auth: this.auth }
-    );
-    return response.data;
-  }
-
-  async saveConfig(handler, config) {
-    const response = await axios.put(
-      `${this.baseURL}/${handler}`,
-      config,
-      { auth: this.auth }
-    );
-    return response.data;
-  }
-
-  async disconnect(handler) {
-    const response = await axios.delete(
-      `${this.baseURL}/${handler}`,
-      { auth: this.auth }
-    );
-    return response.data;
-  }
-}
-
-// Usage
-const authManager = new AuthManager(
-  'https://example.com/wp-json/datamachine/v1',
-  { username: 'admin', password: 'application_password' }
-);
-
-const status = await authManager.checkStatus('twitter');
-console.log(`Authenticated: ${status.authenticated}`);
-
-if (status.authenticated) {
-  console.log(`Account: @${status.account_details.username}`);
-}
-```
-
-## Common Workflows
-
-### Setup Twitter Authentication
-
-```bash
-# 1. Save API keys
-curl -X PUT https://example.com/wp-json/datamachine/v1/auth/twitter \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "consumer_key": "your_consumer_key",
-    "consumer_secret": "your_consumer_secret"
-  }'
-
-# 2. User completes OAuth at /datamachine-auth/twitter/
-
-# 3. Check authentication status
-curl https://example.com/wp-json/datamachine/v1/auth/twitter/status \
-  -u username:application_password
-```
-
-### Disconnect and Reconnect
-
-```bash
-# Disconnect account
-curl -X DELETE https://example.com/wp-json/datamachine/v1/auth/twitter \
-  -u username:application_password
-
-# Reconnect via OAuth flow
-# User visits /datamachine-auth/twitter/
-```
-
-### Verify All Handler Authentication
-
-```bash
-# Check multiple handlers
-for handler in twitter facebook reddit bluesky; do
-  echo "Checking $handler..."
-  curl -s https://example.com/wp-json/datamachine/v1/auth/$handler/status \
-    -u username:application_password | jq '.authenticated'
-done
-```
-
-## Related Documentation
-
-- Handlers Endpoint - Handler information
-- Settings Endpoints - Configuration management
-- Authentication - API auth methods
-- Errors - Error handling
-
----
-
-**Base URL**: `/wp-json/datamachine/v1/auth`
-**Permission**: `manage_options` capability required
-**Implementation**: `inc/Api/Auth.php`
-**OAuth URLs**: `/datamachine-auth/{handler}/`
-
-## Additional Endpoints
-
-### GET /auth/{handler_slug}
-
-Get authentication details for a handler. Similar to /status but returns full configuration.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `handler_slug` (string, required): Handler identifier
-
-**Response**:
-```json
-{
-  "success": true,
-  "data": {
-    "handler_slug": "reddit",
-    "authenticated": true,
-    "account_details": {...},
-    "config_status": {...}
-  }
-}
-```
-
-### PUT /auth/{handler_slug}
-
-Update authentication credentials for a handler.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `handler_slug` (string, required): Handler identifier
-- `credentials` (object, required): Handler-specific credentials
-
-**Example**:
-```bash
-curl -X PUT https://example.com/wp-json/datamachine/v1/auth/reddit \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"credentials": {"client_id": "...", "client_secret": "..."}}'
-```
-
-### DELETE /auth/{handler_slug}
-
-Remove authentication for a handler (disconnect OAuth).
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `handler_slug` (string, required): Handler identifier
-
-**Example**:
-```bash
-curl -X DELETE https://example.com/wp-json/datamachine/v1/auth/reddit \
-  -u username:application_password
-```
+- There is no `/auth/{handler_slug}/callback` REST route in `inc/Api/Auth.php`.
+- Browser OAuth initiation/callback URLs are outside this REST controller, for example `/datamachine-auth/{handler}/`.
+- Do not document static provider field sets here; provider config comes from the registered auth provider/handler metadata.

--- a/docs/api/endpoints/authentication.md
+++ b/docs/api/endpoints/authentication.md
@@ -1,12 +1,12 @@
 # Authentication
 
-Data Machine REST API supports two authentication methods for secure access.
+Data Machine REST API supports WordPress REST authentication plus endpoint-specific callback authentication for webhook-style integrations.
 
 ## Authentication Methods
 
 This page describes authentication options, but it does not replace WordPress’s own authentication documentation.
 
-### 1. Application Password (Recommended)
+### 1. Application Password
 
 **Best For**: External integrations, non-browser applications, API clients
 
@@ -66,19 +66,38 @@ fetch('/wp-json/datamachine/v1/pipelines', {
 })
 ```
 
+### 3. Bearer or HMAC Callback Authentication
+
+Some routes are intentionally public at the WordPress REST layer and authenticate inside the callback:
+
+- `/trigger/{flow_id}` validates per-flow bearer tokens or HMAC signatures before executing the flow.
+- `/agent-ping/*` validates `Authorization: Bearer <token>` against the configured callback token.
+- Agent bearer tokens populate `PermissionHelper` agent context for routes such as `/agents/me`.
+
 ## Permission Model
 
-### manage_options Capability
+Data Machine routes use `DataMachine\Abilities\PermissionHelper` scoped actions. `manage_options` is an administrator fallback, not the canonical permission name for most endpoints.
 
-Most endpoints require `manage_options` capability (Administrator/Editor roles):
-- Execute, Pipelines, Flows, Jobs, Files
-- Settings, Logs, Processed Items
-- Handlers, Providers, Tools, Auth
+| Scoped action | Concrete WordPress capability | Common use |
+|---------------|------------------------------|------------|
+| `manage_agents` | `datamachine_manage_agents` | Agent CRUD, access grants, tokens, cross-user agent files. |
+| `manage_flows` | `datamachine_manage_flows` | Flow, pipeline, jobs, analytics, internal link tools, and workflow operations. |
+| `manage_settings` | `datamachine_manage_settings` | Settings and system operations. |
+| `chat` | `datamachine_chat` | Chat access where enforced by the chat layer. |
+| `use_tools` | `datamachine_use_tools` | Tool execution where enforced by the tool layer. |
+| `view_logs` | `datamachine_view_logs` | Log access where enforced by the logs layer. |
+| `create_own_agent` | `datamachine_create_own_agent` | Self-service agent creation. |
 
-### Authenticated Users
+`PermissionHelper::can_manage()` passes when the caller has `manage_flows`, `manage_settings`, or `manage_agents`.
 
-Some endpoints require authentication only (any logged-in user):
-- `/users/me` - Current user preferences
+### Authenticated Users and Scoped Resources
+
+Some routes accept any logged-in user and then scope data by the current user or agent context:
+
+- `/agents` lists agents visible to the current user.
+- `/agents/me` returns the active agent or user's default agent.
+- `/files/agent/*` allows a user to access their own files; `manage_agents` is required to access another user's files.
+- `/users/me` returns current-user preferences.
 
 ## Security Best Practices
 
@@ -112,20 +131,21 @@ curl -u username:app_password \
 ```
 
 **Solutions**:
-- Verify user has `manage_options` capability
+- Verify the user or agent token has the scoped Data Machine capability required by the endpoint.
 - Check application password is correct
 - Ensure WordPress user is active
 - Confirm HTTPS is being used
 
 ## Related Documentation
 
-- Execute Endpoint - Workflow execution
-- Auth Endpoints - OAuth account management
-- Errors - Authentication error codes
-- API Overview - Complete API documentation
+- [Execute Endpoint](execute.md) - Workflow execution
+- [Auth Endpoints](auth.md) - OAuth account management
+- [Webhook Triggers](webhook-triggers.md) - Bearer/HMAC callback auth
+- [Errors](errors.md) - Authentication error codes
+- [API Overview](../index.md) - Complete API documentation
 
 ---
 
-**Security Model**: `manage_options` capability required for admin endpoints
-**Supported Methods**: Application Password, Cookie Authentication
+**Security Model**: Scoped Data Machine capabilities via `PermissionHelper`
+**Supported Methods**: Application Password, Cookie Authentication, Bearer/HMAC callback auth
 **WordPress Version**: 5.6+ (Application Passwords)

--- a/docs/api/endpoints/authentication.md
+++ b/docs/api/endpoints/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-Data Machine REST API supports two authentication methods for secure access.
+Data Machine REST API requests use normal WordPress REST authentication. The separate [Auth Endpoints](auth.md) page documents handler/provider credentials such as OAuth tokens.
 
 ## Authentication Methods
 
@@ -68,12 +68,14 @@ fetch('/wp-json/datamachine/v1/pipelines', {
 
 ## Permission Model
 
-### manage_options Capability
+### Data Machine Permissions
 
-Most endpoints require `manage_options` capability (Administrator/Editor roles):
-- Execute, Pipelines, Flows, Jobs, Files
-- Settings, Logs, Processed Items
-- Handlers, Providers, Tools, Auth
+Endpoints check Data Machine permissions through `PermissionHelper`, not a single hardcoded WordPress capability:
+
+- `manage_flows`: pipelines, flows, jobs, execution-related administration.
+- `manage_settings`: settings and handler auth management.
+- `chat`: chat message/session routes.
+- Public read routes exist for discovery-style surfaces such as providers, tools, and step types.
 
 ### Authenticated Users
 
@@ -112,7 +114,7 @@ curl -u username:app_password \
 ```
 
 **Solutions**:
-- Verify user has `manage_options` capability
+- Verify the user or scoped agent has the endpoint's Data Machine permission
 - Check application password is correct
 - Ensure WordPress user is active
 - Confirm HTTPS is being used
@@ -126,6 +128,6 @@ curl -u username:app_password \
 
 ---
 
-**Security Model**: `manage_options` capability required for admin endpoints
+**Security Model**: Endpoint-specific Data Machine permissions via `PermissionHelper`
 **Supported Methods**: Application Password, Cookie Authentication
 **WordPress Version**: 5.6+ (Application Passwords)

--- a/docs/api/endpoints/authentication.md
+++ b/docs/api/endpoints/authentication.md
@@ -1,12 +1,12 @@
 # Authentication
 
-Data Machine REST API requests use normal WordPress REST authentication. The separate [Auth Endpoints](auth.md) page documents handler/provider credentials such as OAuth tokens.
+Data Machine REST API requests use normal WordPress REST authentication. Endpoint-specific callback routes add bearer or HMAC verification where a logged-in WordPress user does not fit the integration. The separate [Auth Endpoints](auth.md) page documents handler/provider credentials such as OAuth tokens.
 
 ## Authentication Methods
 
 This page describes authentication options, but it does not replace WordPress’s own authentication documentation.
 
-### 1. Application Password (Recommended)
+### 1. Application Password
 
 **Best For**: External integrations, non-browser applications, API clients
 
@@ -66,21 +66,42 @@ fetch('/wp-json/datamachine/v1/pipelines', {
 })
 ```
 
+### 3. Bearer or HMAC Callback Authentication
+
+Some routes are intentionally public at the WordPress REST layer and authenticate inside the callback:
+
+- `/trigger/{flow_id}` validates per-flow bearer tokens or HMAC signatures before executing the flow.
+- `/agent-ping/*` validates `Authorization: Bearer <token>` against the configured callback token.
+- Agent bearer tokens populate `PermissionHelper` agent context for routes such as `/agents/me`.
+
 ## Permission Model
 
 ### Data Machine Permissions
 
-Endpoints check Data Machine permissions through `PermissionHelper`, not a single hardcoded WordPress capability:
+Endpoints check Data Machine permissions through `PermissionHelper`, not a single hardcoded WordPress capability. `manage_options` is an administrator fallback, not the canonical permission name for most endpoints.
 
-- `manage_flows`: pipelines, flows, jobs, execution-related administration.
-- `manage_settings`: settings and handler auth management.
-- `chat`: chat message/session routes.
-- Public read routes exist for discovery-style surfaces such as providers, tools, and step types.
+| Scoped action | Concrete WordPress capability | Common use |
+|---------------|------------------------------|------------|
+| `manage_agents` | `datamachine_manage_agents` | Agent CRUD, access grants, tokens, cross-user agent files. |
+| `manage_flows` | `datamachine_manage_flows` | Flow, pipeline, jobs, analytics, internal link tools, and workflow operations. |
+| `manage_settings` | `datamachine_manage_settings` | Settings and system operations. |
+| `chat` | `datamachine_chat` | Chat access where enforced by the chat layer. |
+| `use_tools` | `datamachine_use_tools` | Tool execution where enforced by the tool layer. |
+| `view_logs` | `datamachine_view_logs` | Log access where enforced by the logs layer. |
+| `create_own_agent` | `datamachine_create_own_agent` | Self-service agent creation. |
 
-### Authenticated Users
+Public read routes exist for discovery-style surfaces such as providers, tools, and step types.
 
-Some endpoints require authentication only (any logged-in user):
-- `/users/me` - Current user preferences
+`PermissionHelper::can_manage()` passes when the caller has `manage_flows`, `manage_settings`, or `manage_agents`.
+
+### Authenticated Users and Scoped Resources
+
+Some routes accept any logged-in user and then scope data by the current user or agent context:
+
+- `/agents` lists agents visible to the current user.
+- `/agents/me` returns the active agent or user's default agent.
+- `/files/agent/*` allows a user to access their own files; `manage_agents` is required to access another user's files.
+- `/users/me` returns current-user preferences.
 
 ## Security Best Practices
 
@@ -114,20 +135,21 @@ curl -u username:app_password \
 ```
 
 **Solutions**:
-- Verify the user or scoped agent has the endpoint's Data Machine permission
+- Verify the user or scoped agent has the endpoint's Data Machine permission.
 - Check application password is correct
 - Ensure WordPress user is active
 - Confirm HTTPS is being used
 
 ## Related Documentation
 
-- Execute Endpoint - Workflow execution
-- Auth Endpoints - OAuth account management
-- Errors - Authentication error codes
-- API Overview - Complete API documentation
+- [Execute Endpoint](execute.md) - Workflow execution
+- [Auth Endpoints](auth.md) - OAuth account management
+- [Webhook Triggers](webhook-triggers.md) - Bearer/HMAC callback auth
+- [Errors](errors.md) - Authentication error codes
+- [API Overview](../index.md) - Complete API documentation
 
 ---
 
-**Security Model**: Endpoint-specific Data Machine permissions via `PermissionHelper`
-**Supported Methods**: Application Password, Cookie Authentication
+**Security Model**: Scoped Data Machine capabilities via `PermissionHelper`
+**Supported Methods**: Application Password, Cookie Authentication, Bearer/HMAC callback auth
 **WordPress Version**: 5.6+ (Application Passwords)

--- a/docs/api/endpoints/chat-sessions.md
+++ b/docs/api/endpoints/chat-sessions.md
@@ -2,74 +2,54 @@
 
 **Implementation**: `inc/Api/Chat/Chat.php`
 
-## Overview
-
-Data Machine persists chat conversations as sessions. Sessions are user-scoped and stored in `wp_datamachine_chat_sessions`.
+Data Machine stores chat conversations as user-scoped sessions in `wp_datamachine_chat_sessions`.
 
 ## Authentication
 
-Requires WordPress authentication with `manage_options` capability.
+Requires the Data Machine `chat` permission (`PermissionHelper::can( 'chat' )`).
 
-## Endpoints
+## Response Envelope
+
+Session routes return:
+
+```json
+{
+  "success": true,
+  "data": {}
+}
+```
+
+The `data` shape is the corresponding Chat Session ability result.
+
+## Routes
 
 ### GET `/wp-json/datamachine/v1/chat/sessions`
 
-List chat sessions for the current user.
+List sessions for the current user and scoped agent.
 
-**Query Parameters**:
-- `limit` (integer, optional, default: `20`): Maximum sessions to return (capped at 100)
-- `offset` (integer, optional, default: `0`): Pagination offset
-- `agent_type` (string, optional, default: `chat`): Deprecated. Use `agent_id` to filter by specific agent.
+**Query parameters**:
 
-**Success Response**:
+- `limit` (integer, optional, default `20`): maximum sessions to return.
+- `offset` (integer, optional, default `0`): pagination offset.
+- `mode` (string, optional): `chat`, `pipeline`, or `system`.
+- `agent_id` (integer, optional): filter sessions by agent.
 
-```json
-{
-  "success": true,
-  "data": {
-    "sessions": [],
-    "total": 0,
-    "limit": 20,
-    "offset": 0,
-    "agent_type": "chat"
-  }
-}
-```
+`agent_type` is not a REST parameter for this route.
 
 ### GET `/wp-json/datamachine/v1/chat/{session_id}`
 
-Retrieve a single session by ID.
-
-**Success Response**:
-
-```json
-{
-  "success": true,
-  "data": {
-    "session_id": "<uuid>",
-    "conversation": [],
-    "metadata": {}
-  }
-}
-```
+Retrieve one session by UUID-like session ID (`[a-f0-9-]+`).
 
 ### DELETE `/wp-json/datamachine/v1/chat/{session_id}`
 
-Delete a session by ID.
+Delete one session by UUID-like session ID.
 
-**Success Response**:
+### POST `/wp-json/datamachine/v1/chat/sessions/{session_id}/read`
 
-```json
-{
-  "success": true,
-  "data": {
-    "session_id": "<uuid>",
-    "deleted": true
-  }
-}
-```
+Mark a session read for the current user.
 
-**Errors**:
-- `session_not_found` (404): Session does not exist
-- `session_access_denied` (403): Session exists but belongs to a different user
-- `session_delete_failed` (500): Database deletion failed
+## Errors
+
+- `session_not_found` (404): session does not exist.
+- `session_access_denied` (403): session belongs to another user.
+- `ability_not_found` (500): session ability is not registered.

--- a/docs/api/endpoints/chat.md
+++ b/docs/api/endpoints/chat.md
@@ -4,614 +4,81 @@
 
 **Base URL**: `/wp-json/datamachine/v1/chat`
 
-## Overview
-
-The Chat endpoint provides a conversational AI interface for building and executing Data Machine workflows through natural language interaction with multi-turn conversation support.
-
-In addition to sending messages, it also supports listing, retrieving, and deleting persisted chat sessions.
+The chat API sends messages to the Data Machine chat agent and manages turn-by-turn continuation. Session CRUD is documented in [Chat Sessions](chat-sessions.md).
 
 ## Authentication
 
-Requires `manage_options` capability. See Authentication Guide.
+`POST /chat` and `POST /chat/continue` require the Data Machine `chat` permission (`PermissionHelper::can( 'chat' )`). `POST /chat/ping` uses a bearer token that must match the `chat_ping_secret` setting.
 
-## Endpoints
+## Response Envelope
 
-### POST /chat
-
-Send a message to the AI assistant.
-
-**Permission**: `manage_options` capability required
-
-**Purpose**: Natural language workflow building and Data Machine administration via conversational AI
-
-**Parameters**:
-- `message` (string, required): User message to send to AI
-- `session_id` (string, optional): Session ID for conversation continuity (omit to create new session)
-- `selected_pipeline_id` (int, optional): Active pipeline context for prioritized information awareness (@since v0.8.0)
-- `provider` (string, optional): AI provider (`openai`, `anthropic`, `google`, `grok`, `openrouter`) - uses default from settings if not provided
-- `model` (string, optional): Model identifier (e.g., `gpt-4`, `claude-sonnet-4`) - uses default from settings if not provided
-
-**Example Requests**:
-
-```bash
-# Start new conversation
-curl -X POST https://example.com/wp-json/datamachine/v1/chat \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "message": "Create a pipeline that fetches from RSS and publishes to Twitter",
-    "provider": "anthropic",
-    "model": "claude-sonnet-4"
-  }'
-
-# Continue existing conversation
-curl -X POST https://example.com/wp-json/datamachine/v1/chat \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "message": "Now add a flow for that pipeline",
-    "session_id": "session_abc123",
-    "provider": "anthropic",
-    "model": "claude-sonnet-4"
-  }'
-```
-
-**Success Response (200 OK)**:
+Chat routes return a REST envelope:
 
 ```json
 {
   "success": true,
-  "session_id": "session_abc123",
-  "response": "I'll help you create a pipeline with RSS fetch and Twitter publish steps...",
-  "tool_calls": [
-    {
-      "id": "call_abc123",
-      "type": "function",
-      "function": {
-        "name": "create_pipeline",
-        "arguments": "{\"name\":\"RSS to Twitter\",\"steps\":[{\"type\":\"fetch\",\"handler\":\"rss\"},{\"type\":\"ai\"},{\"type\":\"publish\",\"handler\":\"twitter\"}]}"
-      }
-    }
-  ],
-  "conversation": [
-    {"role": "user", "content": "Create a pipeline..."},
-    {"role": "assistant", "content": "I'll help you...", "tool_calls": [...]}
-  ],
-  "metadata": {
-    "last_activity": "2024-01-02 14:30:00",
-    "message_count": 2
-  }
+  "data": {}
 }
 ```
 
-**Response Fields**:
-- `success` (boolean): Request success status
-- `session_id` (string): Session identifier for conversation continuity
-- `response` (string): AI assistant response message
-- `tool_calls` (array, optional): Array of tool calls made by AI
-- `conversation` (array): Full conversation history
-- `metadata` (object): Session metadata
-  - `last_activity` (string): Last activity timestamp
-  - `message_count` (integer): Number of messages in conversation
+`data` is the send-message, continue, or ping result. The top-level response does not expose `session_id`, `response`, or `conversation`; read those from `data` when the underlying ability returns them.
 
-## Session Management
+## Routes
 
-### Session Creation
+### POST `/wp-json/datamachine/v1/chat`
 
-First message automatically creates a new session:
+Send a message. The first message creates a session; include `session_id` to continue a persisted session.
+
+**Body parameters**:
+
+- `message` (string, required): user message.
+- `session_id` (string, optional): existing session ID.
+- `provider` (string, optional): registered AI provider; defaults to resolved settings.
+- `model` (string, optional): model identifier; defaults to resolved settings.
+- `selected_pipeline_id` (integer, optional): pipeline context for chat directives.
+- `attachments` (array, optional): media attachments, each with `url`, `media_id`, `mime_type`, and/or `filename`.
+- `client_context` (object, optional): arbitrary client context injected as a system message.
+
+**Headers**:
+
+- `X-Request-Id` (string, optional): enables a 60-second idempotency cache for duplicate requests.
 
 ```bash
 curl -X POST https://example.com/wp-json/datamachine/v1/chat \
   -H "Content-Type: application/json" \
   -u username:application_password \
-  -d '{"message": "Hello"}'
+  -d '{"message":"Create a pipeline from RSS to Bluesky"}'
 ```
 
-Returns `session_id` for subsequent messages.
+### POST `/wp-json/datamachine/v1/chat/continue`
 
-### Session Continuity
+Continue turn-by-turn execution for a session.
 
-Use `session_id` to continue existing conversation:
+**Body parameters**:
 
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/chat \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"message": "Continue previous task", "session_id": "session_abc123"}'
-```
+- `session_id` (string, required): session ID to continue.
 
-### Session Storage
+### POST `/wp-json/datamachine/v1/chat/ping`
 
-Chat sessions are stored in the `wp_datamachine_chat_sessions` table.
+Send a bearer-token-authenticated ping to the chat agent. This route is intended for external webhook-style notifications, not normal WordPress user requests.
 
-**Implementation**: `inc/Core/Database/Chat/Chat.php`
+**Authorization**: `Authorization: Bearer <chat_ping_secret>`.
 
-**Database Table**: `wp_datamachine_chat_sessions`
+**Body parameters**:
 
-**Features**:
-- Persistent conversation history
-- User-scoped sessions (users can only access their own)
-- Message count tracking
-- Provider and model tracking
-- Agent type tracking (`agent_type`: `chat`, `cli`)
+- `message` (string, required): message for the chat agent.
+- `prompt` (string, optional): extra system-level instructions prepended to the message.
+- `context` (object, optional): flow, pipeline, job, or other context appended to the message.
 
-### Session Security
+**Errors**:
 
-**User Isolation**:
-- Sessions are user-scoped
-- Users can only access their own sessions
-- Invalid session returns 404 error
-- Access to another user's session returns 403 error
+- `ping_not_configured` (403): `chat_ping_secret` is empty.
+- `missing_authorization` (401): no authorization header.
+- `invalid_token` (403): bearer token mismatch.
 
-**Error Response (404 Not Found)** - Invalid session:
+## Session Routes
 
-```json
-{
-  "code": "session_not_found",
-  "message": "Session not found",
-  "data": {"status": 404}
-}
-```
-
-**Error Response (403 Forbidden)** - Access denied:
-
-```json
-{
-  "code": "session_access_denied",
-  "message": "Access denied to this session",
-  "data": {"status": 403}
-}
-```
-
-## Available Tools
-
-### Global Tools
-
-Available to all AI agents via `datamachine_global_tools` filter:
-
-- **google_search** - Web search with site restriction
-- **local_search** - WordPress content search
-- **web_fetch** - Web page content retrieval
-- **wordpress_post_reader** - Single post analysis
-
-### Chat-Specific Tools
-
-Available only to chat AI agents via `datamachine_chat_tools` filter (@since v0.4.3 specialized tools):
-
-- **execute_workflow** (@since v0.3.0) - Execute complete multi-step workflows with automatic defaults injection
-- **get_handler_defaults** (@since v0.6.25) - Retrieve site-wide handler defaults for reference
-- **set_handler_defaults** (@since v0.6.25) - Update site-wide handler defaults
-- **add_pipeline_step** (@since v0.4.3) - Add steps to existing pipelines
-- **api_query** (@since v0.4.3) - REST API query tool for discovery (supports batch requests @since v0.7.0)
-- **configure_flow_step** (@since v0.4.2) - Configure handler and AI messages
-- **configure_pipeline_step** (@since v0.4.4) - Configure pipeline-level AI settings
-- **copy_flow** (@since v0.6.25) - Copy flow to same or different pipeline with optional overrides
-- **create_flow** (@since v0.4.2) - Create flow instances from pipelines
-- **create_pipeline** (@since v0.4.3) - Create pipelines with optional steps
-- **handler_documentation** (@since v0.7.0) - Discover available handlers and their settings schema
-- **run_flow** (@since v0.4.4) - Execute or schedule flows
-- **update_flow** (@since v0.4.4) - Update flow properties
-- **validate_credentials** (@since v0.8.0) - Test authentication provider credentials during configuration
-
-## Universal Engine Architecture
-
-**Since**: v0.2.0
-
-The Chat endpoint uses the Universal Engine architecture at `/inc/Engine/AI/` for consistent AI request handling across Pipeline and Chat agents.
-
-### Core Components Used
-
-**AIConversationLoop**
-- Multi-turn conversation execution
-- Automatic tool call detection and execution
-- Completion detection (conversation ends when AI returns no tool calls)
-- Turn limiting (default: 8 turns)
-- Duplicate tool call prevention
-
-**RequestBuilder**
-- Centralized AI request construction
-- Hierarchical directive application (global → agent → chat-specific)
-- Tool restructuring for provider compatibility
-- Integration with the wp-ai-client runtime adapter
-
-**ToolExecutor**
-- Universal tool discovery via filters (`datamachine_global_tools`, `datamachine_chat_tools`)
-- Tool enablement validation
-- Execution with comprehensive error handling
-
-**ConversationManager**
-- Message formatting utilities
-- Tool call/result message generation
-- Duplicate detection logic
-
-**WP_Agent_Tool_Parameters**
-- Unified parameter building for tools
-- Automatic content/title extraction
-- Session context integration
-
-### Chat Agent Implementation
-
-**File**: `/inc/Api/Chat/ChatFilters.php`
-**Purpose**: Registers chat-specific behavior with Universal Engine
-
-**Chat Pipelines Inventory** (@since v0.7.0):
-The chat agent receives a lightweight inventory of all pipelines, their configured steps (ID, name, type), and flow summaries (ID, name, handlers) via the [ChatPipelinesDirective](../../core-system/ai-directives.md#chatpipelinesdirective-priority-45). When `selected_pipeline_id` is provided (e.g., from the Integrated Chat Sidebar), the agent prioritizes and expands context for that specific pipeline.
-
-**Tool Enablement** (chat-specific):
-```php
-add_filter('datamachine_tool_enabled', function($enabled, $tool_name, $tool_config, $context_id) {
-    // Chat agent: context_id = null (use global tool enablement)
-    if ($context_id === null) {
-        $tool_configured = apply_filters('datamachine_tool_configured', false, $tool_name);
-        $requires_config = !empty($tool_config['requires_config']);
-        return !$requires_config || $tool_configured;
-    }
-    return $enabled;
-}, 5, 4);
-```
-
-**Directive Registration** (@since v0.2.5):
-```php
-// Current: Unified directive registration with mode targeting
-add_filter('datamachine_directives', function($directives) {
-    $directives[] = [
-        'class' => MyChatDirective::class,
-        'priority' => 45,
-        'modes' => ['chat']
-    ];
-    return $directives;
-});
-```
-
-### Differences from Pipeline Agent
-
-**Chat Agent**:
-- Session-based conversation persistence
-- Global tool enablement (not step-specific)
-- No data packets from previous steps
-- Chat-specific specialized tools (create_pipeline, run_flow, etc.)
-- Session context instead of job context
-
-**Pipeline Agent**:
-- Job-based execution within workflows
-- Step-specific tool enablement
-- Data packets flow through steps
-- Handler tools for specific steps
-- Job context with engine data
-
-### Session Context Structure
-
-```php
-$context = [
-    'session_id' => $session_id  // Chat session identifier
-];
-```
-
-Used by:
-- RequestBuilder for directive application
-- ToolExecutor for tool execution
-- WP_Agent_Tool_Parameters for parameter building
-
-### Tool Discovery
-
-Chat agent discovers tools via three sources:
-
-1. **Global Tools** (`datamachine_global_tools` filter):
-   - google_search
-   - local_search
-   - web_fetch
-   - wordpress_post_reader
-
-2. **Chat Tools** (`datamachine_chat_tools` filter) (@since v0.4.3 specialized tools):
-   - execute_workflow, add_pipeline_step, api_query, configure_flow_step
-   - configure_pipeline_step, create_flow, create_pipeline, run_flow, update_flow
-
-3. **Filtered by Enablement** (`datamachine_tool_enabled` filter):
-   - Configuration validation
-   - Global enablement check
-
-### Conversation Flow
-
-```
-1. User sends message via POST /chat
-   ↓
-2. Chat endpoint loads or creates session
-   ↓
-3. AIConversationLoop executes:
-   a. RequestBuilder builds AI request with chat directives
-   b. AI responds with content and/or tool calls
-   c. ToolExecutor executes each tool call
-   d. ConversationManager formats tool results
-   e. Repeat until AI returns no tool calls (max 8 turns)
-   ↓
-4. Session updated with conversation history
-   ↓
-5. Response returned to user
-```
-
-## Filter-Based Architecture
-
-### Unified Directive System (@since v0.2.5)
-
-Directives are registered via the `datamachine_directives` filter with priority and mode targeting:
-
-```php
-add_filter('datamachine_directives', function($directives) {
-    // Global directive (applies to all agents)
-    $directives[] = [
-        'class' => MyDirective::class,
-        'priority' => 25,
-        'modes' => ['all']  // Applies to all agent modes
-    ];
-
-    // Chat-specific directive
-    $directives[] = [
-        'class' => MyChatDirective::class,
-        'priority' => 45,
-        'modes' => ['chat']  // Applies only to chat mode
-    ];
-
-    return $directives;
-});
-```
-
-**Priority Guidelines**:
-- **20**: Registered memory files
-- **22**: Runtime agent-mode guidance
-- **25-35**: Caller, daily memory, and client-reported context
-- **40-50**: Pipeline, flow, chat inventory, and workflow-specific directives
-
-
-
-## Integration Examples
-
-### Python Chat Integration
-
-```python
-import requests
-from requests.auth import HTTPBasicAuth
-
-url = "https://example.com/wp-json/datamachine/v1/chat"
-auth = HTTPBasicAuth("username", "application_password")
-
-# Start conversation
-initial_message = {
-    "message": "Create a pipeline that fetches from RSS",
-    "provider": "anthropic",
-    "model": "claude-sonnet-4"
-}
-
-response = requests.post(url, json=initial_message, auth=auth)
-data = response.json()
-
-session_id = data['session_id']
-print(f"AI: {data['response']}")
-
-# Continue conversation
-follow_up = {
-    "message": "Add a Twitter publish step",
-    "session_id": session_id
-}
-
-response2 = requests.post(url, json=follow_up, auth=auth)
-data2 = response2.json()
-
-print(f"AI: {data2['response']}")
-```
-
-### JavaScript Chat Interface
-
-```javascript
-const axios = require('axios');
-
-class ChatClient {
-  constructor(baseURL, auth) {
-    this.baseURL = baseURL;
-    this.auth = auth;
-    this.sessionId = null;
-  }
-
-  async sendMessage(message, provider = 'anthropic', model = 'claude-sonnet-4') {
-    const payload = {
-      message,
-      provider,
-      model
-    };
-
-    if (this.sessionId) {
-      payload.session_id = this.sessionId;
-    }
-
-    const response = await axios.post(this.baseURL, payload, {
-      auth: this.auth
-    });
-
-    // Store session ID from first message
-    if (!this.sessionId) {
-      this.sessionId = response.data.session_id;
-    }
-
-    return response.data;
-  }
-}
-
-// Usage
-const chat = new ChatClient(
-  'https://example.com/wp-json/datamachine/v1/chat',
-  { username: 'admin', password: 'application_password' }
-);
-
-const response1 = await chat.sendMessage('Create an RSS to Twitter pipeline');
-console.log(`AI: ${response1.response}`);
-
-const response2 = await chat.sendMessage('Execute the pipeline now');
-console.log(`AI: ${response2.response}`);
-```
-
-## Common Workflows
-
-### Create Pipeline via Chat
-
-```bash
-# 1. Start conversation
-curl -X POST https://example.com/wp-json/datamachine/v1/chat \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "message": "Create a pipeline with these steps: fetch from RSS, process with AI, publish to Twitter"
-  }'
-
-# AI will create pipeline using create_pipeline tool
-```
-
-### Monitor Jobs via Chat
-
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/chat \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "message": "Show me failed jobs from the last hour",
-    "session_id": "session_abc123"
-  }'
-```
-
-### Configure Handler via Chat
-
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/chat \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "message": "Configure the Twitter handler for flow 42 with max length 280",
-    "session_id": "session_abc123"
-  }'
-```
-
-## Use Cases
-
-### Conversational Pipeline Builder
-
-Build complex workflows through natural language conversation:
-
-```
-User: "Create a pipeline that imports recipes from an RSS feed"
-AI: [Creates pipeline with RSS fetch step]
-
-User: "Add AI processing to extract ingredients"
-AI: [Adds AI step with custom prompt]
-
-User: "Publish to WordPress"
-AI: [Adds WordPress publish step]
-```
-
-### Natural Language Debugging
-
-Debug workflows through conversational interface:
-
-```
-User: "Why did flow 42 fail?"
-AI: [Checks logs, identifies error, suggests fix]
-
-User: "Clear the failed jobs"
-AI: [Executes DELETE /jobs with type=failed]
-```
-
-### Interactive Configuration
-
-Configure Data Machine settings through chat:
-
-```
-User: "Set up Google Search API"
-AI: [Guides through configuration, saves settings]
-```
-
-## Related Documentation
-
-- Universal Engine Architecture - Shared AI infrastructure
-- AI Conversation Loop - Multi-turn conversation execution
-- Tool Execution Architecture - Tool discovery and execution
-- Universal Engine Filters - Directive and tool filters
-- Execute Endpoint - Workflow execution
-- Tools Endpoint - Available tools
-- Handlers Endpoint - Handler information
-- Authentication - Auth methods
-
----
-
-**Base URL**: `/wp-json/datamachine/v1/chat`
-**Permission**: `manage_options` capability required
-**Implementation**: `inc/Api/Chat/Chat.php`
-**Session Storage**: `wp_datamachine_chat_sessions` table
-**Session Expiration**: Not enforced by default (table supports an `expires_at` column for optional cleanup)
-
-## Additional Endpoints
-
-### POST /chat/continue
-
-Continue a chat session with additional context from external triggers (webhooks, scheduled jobs, etc.).
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `session_id` (string, required): Session ID to continue
-- `message` (string, required): Message to send
-- `provider` (string, optional): AI provider
-- `model` (string, optional): Model identifier
-
-**Example**:
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/chat/continue \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"session_id": "abc123", "message": "Process new RSS items"}'
-```
-
-### GET /chat/{session_id}
-
-Retrieve a chat session with its conversation history.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `session_id` (string, required): Session ID to retrieve
-
-**Response**:
-```json
-{
-  "id": "abc123",
-  "user_id": 1,
-  "session_id": "abc123",
-  "provider": "anthropic",
-  "model": "claude-sonnet-4",
-  "messages": [
-    {"role": "user", "content": "Hello"},
-    {"role": "assistant", "content": "Hi! How can I help?"}
-  ],
-  "message_count": 2,
-  "created_at": "2024-01-01 12:00:00",
-  "last_activity": "2024-01-01 12:05:00"
-}
-```
-
-### POST /chat/ping
-
-Receive external pings to trigger AI responses. Used for scheduled/recurring workflows.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `session_id` (string, required): Session ID to ping
-- `message` (string, required): Message to send
-- `provider` (string, optional): AI provider
-- `model` (string, optional): Model identifier
-
-**Use case**: Set up scheduled pings to trigger flow executions or periodic reviews.
-
-**Example**:
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/chat/ping \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"session_id": "abc123", "message": "Check for new RSS items and publish"}'
-```
+- `GET /chat/sessions`: list sessions.
+- `GET /chat/{session_id}`: get a session.
+- `DELETE /chat/{session_id}`: delete a session.
+- `POST /chat/sessions/{session_id}/read`: mark a session read.

--- a/docs/api/endpoints/email.md
+++ b/docs/api/endpoints/email.md
@@ -1,0 +1,39 @@
+# Email Endpoints
+
+**Implementation**: `inc/Api/Email.php`
+
+**Base URL**: `/wp-json/datamachine/v1/email`
+
+Thin REST wrappers around registered email abilities for SMTP sending and IMAP mailbox operations.
+
+## Endpoints
+
+| Method | Route | Purpose |
+|--------|-------|---------|
+| `POST` | `/email/send` | Send an email. |
+| `GET` | `/email/fetch` | Fetch messages from a folder/search. |
+| `GET` | `/email/{uid}/read` | Read a single message by UID. |
+| `POST` | `/email/reply` | Send a reply. |
+| `DELETE` | `/email/{uid}` | Delete a message. |
+| `POST` | `/email/{uid}/move` | Move a message to another folder. |
+| `POST` | `/email/{uid}/flag` | Set or clear a message flag. |
+| `POST` | `/email/batch/move` | Move messages matching an IMAP search. |
+| `POST` | `/email/batch/flag` | Set or clear flags on messages matching an IMAP search. |
+| `POST` | `/email/batch/delete` | Delete messages matching an IMAP search. |
+| `POST` | `/email/{uid}/unsubscribe` | Unsubscribe from a single message. |
+| `POST` | `/email/batch/unsubscribe` | Unsubscribe from messages matching an IMAP search. |
+| `POST` | `/email/test-connection` | Test configured email connectivity. |
+
+## Permission
+
+All email endpoints use `PermissionHelper::can_manage()`. A caller passes if they have any of these scoped Data Machine capabilities:
+
+- `manage_flows`
+- `manage_settings`
+- `manage_agents`
+
+Administrators also pass through the `manage_options` fallback built into `PermissionHelper`.
+
+## Ability Delegation
+
+The REST controller delegates behavior to email abilities such as `datamachine/send-email`, `datamachine/fetch-email`, and related mailbox actions. IMAP routes require an authenticated `email_imap` auth provider.

--- a/docs/api/endpoints/email.md
+++ b/docs/api/endpoints/email.md
@@ -1,0 +1,126 @@
+# Email Endpoints
+
+**Implementation**: `inc/Api/Email.php`
+
+**Base URL**: `/wp-json/datamachine/v1/email`
+
+## Overview
+
+Email endpoints expose Data Machine email abilities over REST for sending mail, reading IMAP inboxes, replying, moving, flagging, deleting, unsubscribing, and testing the stored IMAP connection.
+
+## Authentication
+
+All email routes require Data Machine manage permission via `PermissionHelper::can_manage()`.
+
+External REST clients should use WordPress application passwords or cookie auth. Inbox operations also require a configured `email_imap` auth provider; missing IMAP credentials return `not_configured` with HTTP 400.
+
+## Route Table
+
+| Method | Route | Ability | Purpose |
+|---|---|---|---|
+| POST | `/email/send` | `datamachine/send-email` | Send an email with optional headers and attachments. |
+| GET | `/email/fetch` | `datamachine/fetch-email` | Fetch messages from an IMAP folder. |
+| GET | `/email/{uid}/read` | `datamachine/fetch-email` | Read one message by UID. |
+| POST | `/email/reply` | `datamachine/email-reply` | Reply with threading headers. |
+| DELETE | `/email/{uid}` | `datamachine/email-delete` | Delete one message by UID. |
+| POST | `/email/{uid}/move` | `datamachine/email-move` | Move one message to another folder. |
+| POST | `/email/{uid}/flag` | `datamachine/email-flag` | Set or clear an IMAP flag. |
+| POST | `/email/batch/move` | `datamachine/email-batch-move` | Move messages matching an IMAP search. |
+| POST | `/email/batch/flag` | `datamachine/email-batch-flag` | Flag messages matching an IMAP search. |
+| POST | `/email/batch/delete` | `datamachine/email-batch-delete` | Delete messages matching an IMAP search. |
+| POST | `/email/{uid}/unsubscribe` | `datamachine/email-unsubscribe` | Unsubscribe from a list using one message's headers. |
+| POST | `/email/batch/unsubscribe` | `datamachine/email-batch-unsubscribe` | Unsubscribe from lists matching an IMAP search. |
+| POST | `/email/test-connection` | `datamachine/email-test-connection` | Test stored IMAP credentials. |
+
+## Core Parameters
+
+### Send And Reply
+
+| Parameter | Type | Required | Notes |
+|---|---|---|---|
+| `to` | string | yes | Recipient email address or comma-separated addresses for send. |
+| `subject` | string | yes | Subject line. Send supports `{month}`, `{year}`, `{site_name}`, and `{date}` placeholders. |
+| `body` | string | yes | HTML or plain-text body. |
+| `cc`, `bcc` | string | no | Comma-separated addresses. `bcc` is send-only. |
+| `from_name`, `from_email`, `reply_to` | string | no | Send headers. Defaults use site name/admin email when omitted. |
+| `content_type` | string | no | `text/html` by default; `text/plain` is also supported. |
+| `attachments` | array | no | Server file paths for `wp_mail()` attachments. |
+| `in_reply_to` | string | reply only | Message-ID of the email being replied to. |
+| `references` | string | no | References header chain for threading. |
+
+### Fetch And Message Operations
+
+| Parameter | Type | Default | Notes |
+|---|---|---|---|
+| `folder` | string | `INBOX` | Source IMAP folder. |
+| `uid` | integer | route param | Message UID for read/delete/move/flag/unsubscribe. |
+| `search` | string | `UNSEEN` for fetch | IMAP search string, for example `ALL`, `UNSEEN`, `FROM "github.com"`, or `SINCE "1-Mar-2026"`. |
+| `max` | integer | route-specific | Safety limit for fetch or batch operations. |
+| `offset` | integer | `0` | Pagination offset for fetch. |
+| `headers_only` | boolean | `false` | Fast list mode; skips body parsing. |
+| `mark_as_read` | boolean | `false` | Mark fetched messages as read. |
+| `download_attachments` | boolean | `false` | Download attachments into local storage. |
+| `destination` | string | required for move | Target IMAP folder, such as `Archive` or `[Gmail]/All Mail`. |
+| `flag` | string | required for flag | IMAP flag such as `Seen`, `Flagged`, `Answered`, `Deleted`, or `Draft`. |
+| `action` | string | `set` | `set` or `clear` for flag endpoints. |
+
+## Response Shape
+
+Email endpoints return ability-native success objects. Failed ability results are normalized to an `email_error` REST error with HTTP 400.
+
+Send response shape:
+
+```json
+{
+  "success": true,
+  "message": "Email sent successfully",
+  "recipients": ["editor@example.com"],
+  "subject": "Weekly report",
+  "logs": []
+}
+```
+
+Fetch response shape:
+
+```json
+{
+  "success": true,
+  "data": {
+    "items": [],
+    "count": 10,
+    "total_matches": 42,
+    "offset": 0,
+    "has_more": true
+  },
+  "logs": []
+}
+```
+
+Batch operation response shapes include counters such as `moved_count`, `flagged_count`, `deleted_count`, `unsubscribed`, `failed`, or `no_header` depending on the route.
+
+## Agent Usage Examples
+
+List unread message headers without marking them read:
+
+```bash
+curl "https://example.com/wp-json/datamachine/v1/email/fetch?search=UNSEEN&headers_only=1&max=20" \
+  -u username:application_password
+```
+
+Move GitHub notifications to an archive folder:
+
+```bash
+curl -X POST https://example.com/wp-json/datamachine/v1/email/batch/move \
+  -H "Content-Type: application/json" \
+  -u username:application_password \
+  -d '{"search":"FROM \"github.com\"","destination":"Archive","max":100}'
+```
+
+Send a concise agent report:
+
+```bash
+curl -X POST https://example.com/wp-json/datamachine/v1/email/send \
+  -H "Content-Type: application/json" \
+  -u username:application_password \
+  -d '{"to":"editor@example.com","subject":"Daily agent summary","body":"<p>No blockers.</p>"}'
+```

--- a/docs/api/endpoints/email.md
+++ b/docs/api/endpoints/email.md
@@ -12,6 +12,8 @@ Email endpoints expose Data Machine email abilities over REST for sending mail, 
 
 All email routes require Data Machine manage permission via `PermissionHelper::can_manage()`.
 
+`PermissionHelper::can_manage()` passes when the caller has `manage_flows`, `manage_settings`, or `manage_agents`. Administrators also pass through the `manage_options` fallback built into `PermissionHelper`.
+
 External REST clients should use WordPress application passwords or cookie auth. Inbox operations also require a configured `email_imap` auth provider; missing IMAP credentials return `not_configured` with HTTP 400.
 
 ## Route Table

--- a/docs/api/endpoints/files.md
+++ b/docs/api/endpoints/files.md
@@ -21,7 +21,7 @@ Requires authenticated user. Agent file endpoints use scoped permissions — use
 
 Upload a file for flow processing (`flow_step_id`).
 
-**Permission**: `manage_options` capability required
+**Permission**: Logged-in user plus `PermissionHelper::can_manage()`.
 
 **Parameters**:
 - `flow_step_id` (string, optional): Flow step ID for flow-level files
@@ -91,7 +91,7 @@ List files in a flow scope (`flow_step_id`).
 
 Download a file by filename.
 
-**Permission**: `manage_options` capability required
+**Permission**: Logged-in user plus `PermissionHelper::can_manage()`.
 
 **Parameters**:
 - `filename` (string, required): File to retrieve
@@ -105,7 +105,7 @@ Download a file by filename.
 
 Delete a file by filename.
 
-**Permission**: `manage_options` capability required
+**Permission**: Logged-in user plus `PermissionHelper::can_manage()`.
 
 **Parameters**:
 - `filename` (string, required): File to delete

--- a/docs/api/endpoints/flows.md
+++ b/docs/api/endpoints/flows.md
@@ -1,550 +1,261 @@
 # Flows Endpoints
 
-**Implementation**: `/inc/Api/Flows/` directory structure
-- `Flows.php` - Main flow CRUD operations
-- `FlowSteps.php` - Flow step configuration (`/flows/{id}/config`, `/flows/steps/{flow_step_id}/config`)
+**Implementation**: `inc/Api/Flows/`
 
 **Base URL**: `/wp-json/datamachine/v1/flows`
 
-## Overview
-
-Flow endpoints manage flow instances (configured and scheduled executions of pipeline templates).
+Flows are configured executions of pipeline templates.
 
 ## Authentication
 
-Requires `manage_options` capability.
+Requires the Data Machine `manage_flows` permission (`PermissionHelper::can( 'manage_flows' )`). Requests may be user-scoped or agent-scoped through `PermissionHelper`.
 
-## Endpoints
+## Response Envelope
 
-### GET /flows/problems
+Most flow routes return:
 
-Retrieve flows flagged as "problem flows" based on consecutive failures or no items found.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `threshold` (integer, optional): Override the site-wide `problem_flow_threshold` for this query.
-
-**Example Request**:
-
-```bash
-curl https://example.com/wp-json/datamachine/v1/flows/problems \
-  -u username:application_password
+```json
+{
+  "success": true,
+  "data": {}
+}
 ```
 
-**Success Response (200 OK)**:
+Some ability-backed mutation routes return the ability result directly when it already includes `success`.
+
+## Flow Routes
+
+### GET `/wp-json/datamachine/v1/flows`
+
+List flows.
+
+**Query parameters**:
+
+- `pipeline_id` (integer, optional): filter by pipeline.
+- `per_page` (integer, optional, default `20`, max `100`): page size.
+- `offset` (integer, optional, default `0`): pagination offset.
+- `output_mode` (string, optional, default `full`): `full`, `list`, `summary`, or `ids`.
+- `user_id` (integer, optional): filter by user when allowed by scope.
+
+Without `pipeline_id`, `data` is the flow array. With `pipeline_id`, `data` is `{ pipeline_id, flows }`.
+
+### POST `/wp-json/datamachine/v1/flows`
+
+Create a flow.
+
+**Body parameters**:
+
+- `pipeline_id` (integer, required): parent pipeline.
+- `flow_name` (string, optional, default `Flow`): flow name.
+- `flow_config` (array, optional): per-flow step settings.
+- `scheduling_config` (array, optional): scheduling config.
+
+### GET `/wp-json/datamachine/v1/flows/{flow_id}`
+
+Get one flow.
+
+### PATCH `/wp-json/datamachine/v1/flows/{flow_id}`
+
+Update a flow title and/or scheduling.
+
+**Body parameters**:
+
+- `flow_name` (string, optional): new flow title.
+- `scheduling_config` (object, optional): scheduling config.
+
+### DELETE `/wp-json/datamachine/v1/flows/{flow_id}`
+
+Delete a flow.
+
+### POST `/wp-json/datamachine/v1/flows/{flow_id}/duplicate`
+
+Duplicate a flow.
+
+### POST `/wp-json/datamachine/v1/flows/{flow_id}/pause`
+
+Pause one flow.
+
+### POST `/wp-json/datamachine/v1/flows/{flow_id}/resume`
+
+Resume one flow.
+
+### POST `/wp-json/datamachine/v1/flows/pause`
+
+Bulk-pause flows. Body must include `pipeline_id` or `agent_id`.
+
+### POST `/wp-json/datamachine/v1/flows/resume`
+
+Bulk-resume flows. Body must include `pipeline_id` or `agent_id`.
+
+### GET `/wp-json/datamachine/v1/flows/problems`
+
+List problem flows.
+
+**Query parameters**:
+
+- `threshold` (integer, optional): override the `problem_flow_threshold` setting.
+
+**Success response**:
 
 ```json
 {
   "success": true,
   "data": {
-    "problem_flows": [
-      {
-        "flow_id": 42,
-        "flow_name": "Broken RSS Flow",
-        "consecutive_failures": 5,
-        "consecutive_no_items": 0
-      }
-    ],
-    "total": 1,
-    "threshold": 3
+    "problem_flows": [],
+    "total": 0,
+    "threshold": 3,
+    "failing": [],
+    "idle": []
   }
 }
 ```
 
-### POST /flows
+## Flow Step Configuration Routes
 
-Create a new flow from an existing pipeline.
+### GET `/wp-json/datamachine/v1/flows/{flow_id}/config`
 
-**Permission**: `manage_options` capability required
+Return all configured steps for a flow.
 
-**Parameters**:
-- `pipeline_id` (integer, required): Parent pipeline ID
-- `flow_name` (string, optional): Flow name (default: "Flow")
-- `flow_config` (array, optional): Handler settings per step
-- `scheduling_config` (array, optional): Scheduling configuration
-
-**Example Request**:
-
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/flows \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "pipeline_id": 5,
-    "flow_name": "My Custom Flow",
-    "scheduling_config": {"interval": "daily"}
-  }'
-```
-
-**Success Response (200 OK)**:
+**Success shape**:
 
 ```json
 {
   "success": true,
   "data": {
     "flow_id": 42,
-    "pipeline_id": 5,
-    "flow_name": "My Custom Flow",
-    "flow_config": {},
-    "scheduling_config": {}
+    "flow_config": {}
   }
 }
 ```
 
-**Response Fields**:
-- `success` (boolean)
-- `data` (object): Created flow payload
+### GET `/wp-json/datamachine/v1/flows/steps/{flow_step_id}/config`
 
-### DELETE /flows/{flow_id}
+Return one flow step config.
 
-Delete a flow.
+**Success shape**:
 
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID to delete (in URL path)
-
-**Example Request**:
-
-```bash
-curl -X DELETE https://example.com/wp-json/datamachine/v1/flows/42 \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "data": {"flow_id": 42}
-}
-```
-
-**Response Fields**:
-- `success` (boolean)
-- `data.flow_id` (integer): Deleted flow ID
-
-**Error Response (404 Not Found)**:
-
-```json
-{
-  "code": "flow_not_found",
-  "message": "Flow not found.",
-  "data": {"status": 404}
-}
-```
-
-### POST /flows/{flow_id}/duplicate
-
-Duplicate an existing flow with all configuration.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Source flow ID to duplicate (in URL path)
-
-**Example Request**:
-
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/flows/42/duplicate \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "source_flow_id": 42,
-  "new_flow_id": 43,
-  "flow_name": "My Custom Flow (Copy)",
-  "pipeline_id": 5,
-  "flow_data": {...},
-  "pipeline_steps": [...]
-}
-```
-
-**Response Fields**:
-- `success` (boolean): Request success status
-- `source_flow_id` (integer): Original flow ID
-- `new_flow_id` (integer): Newly created duplicate flow ID
-- `flow_name` (string): Duplicate flow name (appends "(Copy)")
-- `pipeline_id` (integer): Parent pipeline ID
-- `flow_data` (object): Complete flow record
-- `pipeline_steps` (array): Pipeline step configuration
-
-**Error Response (404 Not Found)**:
-
-```json
-{
-  "code": "flow_not_found",
-  "message": "Flow not found.",
-  "data": {"status": 404}
-}
-```
-
-## Flow Configuration
-
-### Handler Settings
-
-Flow configuration stores handler-specific settings per step:
-
-```json
-{
-  "flow_step_id_123": {
-    "handler_slug": "rss",
-    "handler_config": {
-      "feed_url": "https://example.com/feed/",
-      "max_items": 10
-    }
-  },
-  "flow_step_id_456": {
-    "handler_slug": "twitter",
-    "handler_config": {
-      "max_length": 280
-    }
-  }
-}
-```
-
-### Scheduling Configuration
-
-Scheduling configuration defines execution intervals:
-
-```json
-{
-  "interval": "hourly"
-}
-```
-
-**Available Intervals**:
-- `manual` - No automatic execution
-- `one_time` - Execute once at a specific timestamp
-- `every_5_minutes` - Every 5 minutes
-- `hourly` - Every hour
-- `every_2_hours` - Every 2 hours
-- `every_4_hours` - Every 4 hours
-- `qtrdaily` - Every 6 hours
-- `twicedaily` - Twice per day (every 12 hours)
-- `daily` - Once per day
-- `weekly` - Once per week
-- Custom intervals via `datamachine_scheduler_intervals` filter
-
-## Flow Step Configuration
-
-### GET /flows/{flow_id}/config
-
-Retrieve complete flow configuration including all step settings.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID (in URL path)
-
-**Example Request**:
-
-```bash
-curl https://example.com/wp-json/datamachine/v1/flows/42/config \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "flow_id": 42,
-  "flow_config": {
-    "flow_step_id_123": {
-      "flow_step_id": "flow_step_id_123",
-      "pipeline_step_id": "step_uuid",
-      "step_type": "fetch",
-      "execution_order": 0,
-      "handler_slug": "rss",
-      "handler_config": {
-        "feed_url": "https://example.com/feed/",
-        "max_items": 10
-      },
-      "enabled": true
-    }
-  }
-}
-```
-
-### GET /flows/steps/{flow_step_id}/config
-
-Retrieve configuration for a specific flow step.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_step_id` (string, required): Flow step ID (in URL path)
-
-**Example Request**:
-
-```bash
-curl https://example.com/wp-json/datamachine/v1/flows/steps/flow_step_id_123/config \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "flow_step_id": "flow_step_id_123",
-  "config": {
-    "flow_step_id": "flow_step_id_123",
-    "pipeline_step_id": "step_uuid",
-    "step_type": "fetch",
-    "execution_order": 0,
-    "handler_slug": "rss",
-    "handler_config": {
-      "feed_url": "https://example.com/feed/",
-      "max_items": 10
-    },
-    "enabled": true
-  }
-}
-```
-
-**Error Response (404 Not Found)**:
-
-```json
-{
-  "code": "config_not_found",
-  "message": "Flow step configuration not found.",
-  "data": {"status": 404}
-}
-```
-
-## Related endpoints
-
-- [Execute](execute.md) for running flows or ephemeral workflows.
-- [Jobs](jobs.md) for monitoring executions.
-- [Settings](settings.md) for `problem_flow_threshold`.
-
----
-
-## Related Documentation
-
-```bash
-# 1. Create flow
-FLOW_ID=$(curl -X POST https://example.com/wp-json/datamachine/v1/flows \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"pipeline_id": 5}' | jq -r '.flow_id')
-
-# 2. Execute flow immediately
-curl -X POST https://example.com/wp-json/datamachine/v1/execute \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d "{\"flow_id\": $FLOW_ID}"
-```
-
-### Duplicate and Modify
-
-```bash
-# 1. Duplicate existing flow
-NEW_FLOW=$(curl -X POST https://example.com/wp-json/datamachine/v1/flows/42/duplicate \
-  -u username:application_password)
-
-# 2. Modify configuration via admin interface or additional API calls
-# 3. Execute new flow independently
-```
-
-### Cleanup Old Flows
-
-```bash
-# Delete flow and associated jobs
-curl -X DELETE https://example.com/wp-json/datamachine/v1/flows/42 \
-  -u username:application_password
-```
-
-## Integration Examples
-
-### Python Flow Management
-
-```python
-import requests
-from requests.auth import HTTPBasicAuth
-
-url = "https://example.com/wp-json/datamachine/v1/flows"
-auth = HTTPBasicAuth("username", "application_password")
-
-# Create flow
-payload = {
-    "pipeline_id": 5,
-    "flow_name": "Automated RSS to Twitter",
-    "scheduling_config": {"interval": "hourly"}
-}
-
-response = requests.post(url, json=payload, auth=auth)
-flow_data = response.json()
-
-print(f"Created flow {flow_data['flow_id']}: {flow_data['flow_name']}")
-
-# Duplicate flow
-duplicate_url = f"{url}/{flow_data['flow_id']}/duplicate"
-duplicate_response = requests.post(duplicate_url, auth=auth)
-duplicate_data = duplicate_response.json()
-
-print(f"Duplicated to flow {duplicate_data['new_flow_id']}")
-```
-
-### JavaScript Flow Operations
-
-```javascript
-const axios = require('axios');
-
-const flowAPI = {
-  baseURL: 'https://example.com/wp-json/datamachine/v1/flows',
-  auth: {
-    username: 'admin',
-    password: 'application_password'
-  }
-};
-
-// Create flow
-async function createFlow(pipelineId, flowName) {
-  const response = await axios.post(flowAPI.baseURL, {
-    pipeline_id: pipelineId,
-    flow_name: flowName
-  }, { auth: flowAPI.auth });
-
-  return response.data.flow_id;
-}
-
-// Delete flow
-async function deleteFlow(flowId) {
-  const response = await axios.delete(
-    `${flowAPI.baseURL}/${flowId}`,
-    { auth: flowAPI.auth }
-  );
-
-  return response.data.deleted_jobs;
-}
-
-// Usage
-const flowId = await createFlow(5, 'My Flow');
-const deletedJobs = await deleteFlow(flowId);
-```
-
-## Related Documentation
-
-- [Pipelines](pipelines.md)
-- [Execute](execute.md)
-- [Jobs](jobs.md)
-
-
----
-
-**Base URL**: `/wp-json/datamachine/v1/flows`
-**Permission**: `manage_options` capability required
-**Implementation**: `/inc/Api/Flows/` (Flows.php, FlowSteps.php)
-
-## Flow Queue Endpoints
-
-Flow queues enable step-level prompt queues for varied task instructions per execution.
-
-### GET /flows/{flow_id}/queue
-
-Get the queue for a flow.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID
-
-**Response**:
-```json
-{
-  "success": true,
-  "queue": ["First task", "Second task"],
-  "count": 2
-}
-```
-
-### POST /flows/{flow_id}/queue
-
-Add items to the flow queue.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID
-- `items` (array, required): Queue items to add
-- `position` (string, optional): "start" or "end" (default: "end")
-
-**Example**:
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/flows/5/queue \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"items": ["Task 1", "Task 2"]}'
-```
-
-### DELETE /flows/{flow_id}/queue
-
-Clear all items from the flow queue.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID
-
-### GET /flows/{flow_id}/queue/{index}
-
-Get a specific queue item.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID
-- `index` (integer, required): Queue position (0-based)
-
-### PUT /flows/{flow_id}/queue/{index}
-
-Update a specific queue item.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID
-- `index` (integer, required): Queue position
-- `item` (string, required): New item content
-
-### DELETE /flows/{flow_id}/queue/{index}
-
-Remove a specific queue item.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID
-- `index` (integer, required): Queue position
-
-### PUT /flows/{flow_id}/queue/mode
-
-Set the queue access mode for a flow step.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID
-- `flow_step_id` (string, required): Flow step ID
-- `mode` (string, required): One of `drain`, `loop`, or `static`
-
-**Response**:
 ```json
 {
   "success": true,
   "data": {
-    "flow_id": 10,
-    "flow_step_id": "ai_2",
-    "queue_mode": "static"
-  },
-  "message": "Queue mode updated."
+    "flow_step_id": "<pipeline_step_id>_<flow_id>",
+    "step_config": {}
+  }
 }
 ```
+
+### PATCH `/wp-json/datamachine/v1/flows/steps/{flow_step_id}/config`
+
+Patch one flow step config.
+
+**Body parameters**:
+
+- `handler_slug` (string, optional): handler identifier.
+- `handler_config` (object, optional): handler settings to merge.
+- `user_message` (string, optional): AI user message.
+
+### PUT `/wp-json/datamachine/v1/flows/steps/{flow_step_id}/handler`
+
+Save handler selection/settings for one flow step.
+
+**Body parameters**:
+
+- `handler_slug` (string, required): handler identifier.
+- `pipeline_id` (integer, required): pipeline context.
+- `step_type` (string, required): step type.
+- `settings` (object, optional): raw handler settings.
+
+### PATCH `/wp-json/datamachine/v1/flows/steps/{flow_step_id}/user-message`
+
+Save the AI user message for one flow step.
+
+**Body parameters**:
+
+- `user_message` (string, required): message text.
+
+## Queue Routes
+
+All queue routes require `flow_step_id` as a request parameter. The route path only carries `flow_id` and, where applicable, `index`.
+
+### GET `/wp-json/datamachine/v1/flows/{flow_id}/queue`
+
+List a queue.
+
+**Query parameters**:
+
+- `flow_step_id` (string, required): flow step ID.
+
+**Success shape**:
+
+```json
+{
+  "success": true,
+  "data": {
+    "flow_id": 42,
+    "flow_step_id": "<pipeline_step_id>_<flow_id>",
+    "queue": [],
+    "count": 0,
+    "queue_mode": "drain"
+  }
+}
+```
+
+### POST `/wp-json/datamachine/v1/flows/{flow_id}/queue`
+
+Add queue items.
+
+**Body parameters**:
+
+- `flow_step_id` (string, required): flow step ID.
+- `prompt` (string, optional): one prompt.
+- `prompts` (array of strings, optional): multiple prompts.
+
+At least one non-empty `prompt` or `prompts[]` entry is required.
+
+### DELETE `/wp-json/datamachine/v1/flows/{flow_id}/queue`
+
+Clear a queue.
+
+**Body/query parameters**:
+
+- `flow_step_id` (string, required): flow step ID.
+
+### POST/PUT/PATCH `/wp-json/datamachine/v1/flows/{flow_id}/queue/{index}`
+
+Update one queue item.
+
+**Body parameters**:
+
+- `flow_step_id` (string, required): flow step ID.
+- `prompt` (string, required): replacement prompt.
+
+### DELETE `/wp-json/datamachine/v1/flows/{flow_id}/queue/{index}`
+
+Remove one queue item.
+
+**Body/query parameters**:
+
+- `flow_step_id` (string, required): flow step ID.
+
+### POST/PUT/PATCH `/wp-json/datamachine/v1/flows/{flow_id}/queue/mode`
+
+Set queue mode.
+
+**Body parameters**:
+
+- `flow_step_id` (string, required): flow step ID.
+- `mode` (string, required): `drain`, `loop`, or `static`.
+
+## Flow Memory Routes
+
+### GET `/wp-json/datamachine/v1/flows/{flow_id}/memory-files`
+
+Return configured memory filenames for a flow.
+
+### POST/PUT/PATCH `/wp-json/datamachine/v1/flows/{flow_id}/memory-files`
+
+Replace configured memory filenames.
+
+**Body parameters**:
+
+- `memory_files` (array of strings, required): agent memory filenames. `daily_memory` is not accepted.

--- a/docs/api/endpoints/internal-links.md
+++ b/docs/api/endpoints/internal-links.md
@@ -1,0 +1,25 @@
+# Internal Links Endpoints
+
+**Implementation**: `inc/Api/InternalLinks.php`
+
+**Base URL**: `/wp-json/datamachine/v1/links`
+
+Internal link audit and diagnostics endpoints. Each route maps to a WordPress ability.
+
+## Endpoints
+
+| Method | Route | Ability | Purpose |
+|--------|-------|---------|---------|
+| `POST` | `/links/audit` | `datamachine/audit-internal-links` | Build and cache the internal link graph. |
+| `GET` | `/links/orphans` | `datamachine/get-orphaned-posts` | Return orphaned posts from the cached graph. |
+| `GET` | `/links/backlinks` | `datamachine/get-backlinks` | Return posts linking to a target post. |
+| `POST` | `/links/broken` | `datamachine/check-broken-links` | Check links for broken targets. |
+| `GET` | `/links/diagnose` | `datamachine/diagnose-internal-links` | Return meta/index coverage diagnostics. |
+
+## Permission
+
+All routes require `PermissionHelper::can( 'manage_flows' )`.
+
+## Request Shape
+
+GET routes read query parameters. POST routes read JSON request bodies. The controller normalizes comma-separated `types` query parameters into arrays before calling the ability.

--- a/docs/api/endpoints/internal-links.md
+++ b/docs/api/endpoints/internal-links.md
@@ -1,0 +1,109 @@
+# Internal Links Endpoints
+
+**Implementation**: `inc/Api/InternalLinks.php`
+
+**Base URL**: `/wp-json/datamachine/v1/links`
+
+## Overview
+
+Internal links endpoints expose the link graph abilities used by SEO audits and agents. They can build the cached graph, report orphaned posts, fetch backlinks, check broken URLs, and diagnose site-wide internal link coverage.
+
+## Authentication
+
+All routes require `PermissionHelper::can( 'manage_flows' )`. Requests can use WordPress application passwords or cookie auth.
+
+The controller delegates to WordPress Abilities API abilities. If an ability is not registered, the response is `ability_not_found` with HTTP 500.
+
+## Route Table
+
+| Method | Route | Ability | Purpose |
+|---|---|---|---|
+| POST | `/links/audit` | `datamachine/audit-internal-links` | Scan content, build/cache the link graph, and return aggregates. |
+| GET | `/links/orphans` | `datamachine/get-orphaned-posts` | Return posts with zero inbound internal links. |
+| GET | `/links/backlinks` | `datamachine/get-backlinks` | Return posts linking to a target post. |
+| POST | `/links/broken` | `datamachine/check-broken-links` | Check URLs from the cached graph with HTTP HEAD/GET fallback. |
+| GET | `/links/diagnose` | `datamachine/diagnose-internal-links` | Report internal link coverage from stored metadata. |
+
+GET routes read query parameters. POST routes read the JSON body.
+
+## Core Parameters
+
+| Parameter | Routes | Type | Default | Notes |
+|---|---|---|---|---|
+| `post_type` | audit, orphans, backlinks, broken | string | `post` | Post type scope for graph reads and scans. |
+| `category` | audit | string | none | Category slug to limit audit scope. |
+| `post_ids` | audit | array<int> | none | Specific posts to scan. |
+| `force` | audit | boolean | `false` | Rebuild even when cached data exists. |
+| `types` | audit, orphans, backlinks, broken | array<string> | all | Edge types to include, for example `html_anchor` or `wikilink`. GET accepts comma-separated values. |
+| `limit` | orphans, broken | integer | route-specific | Maximum results or URLs to process. |
+| `post_id` | backlinks | integer | required | Target post ID. |
+| `scope` | broken | string | `internal` | `internal`, `external`, or `all`. |
+| `timeout` | broken | integer | `5` | HTTP timeout per URL in seconds. |
+
+## Response Shape
+
+Successful responses return ability output directly after internal keys prefixed with `_` are stripped.
+
+Audit response shape:
+
+```json
+{
+  "success": true,
+  "total_scanned": 120,
+  "total_links": 640,
+  "orphaned_count": 8,
+  "avg_outbound": 5.3,
+  "avg_inbound": 5.3,
+  "orphaned_posts": [],
+  "top_linked": [],
+  "cached": false
+}
+```
+
+Backlinks response shape:
+
+```json
+{
+  "success": true,
+  "post_id": 123,
+  "backlink_count": 2,
+  "backlinks": [
+    {
+      "source_id": 45,
+      "title": "Related guide",
+      "permalink": "https://example.com/related-guide/",
+      "link_count": 1
+    }
+  ],
+  "from_cache": true
+}
+```
+
+Errors from abilities are returned as `internal_links_error` with HTTP 400 for ability-declared errors or HTTP 500 for `WP_Error` results.
+
+## Agent Usage Examples
+
+Run a fresh internal-link audit for posts:
+
+```bash
+curl -X POST https://example.com/wp-json/datamachine/v1/links/audit \
+  -H "Content-Type: application/json" \
+  -u username:application_password \
+  -d '{"post_type":"post","force":true,"types":["html_anchor"]}'
+```
+
+Find orphaned pages from the cached graph:
+
+```bash
+curl "https://example.com/wp-json/datamachine/v1/links/orphans?post_type=page&limit=25" \
+  -u username:application_password
+```
+
+Check external broken links with a conservative limit:
+
+```bash
+curl -X POST https://example.com/wp-json/datamachine/v1/links/broken \
+  -H "Content-Type: application/json" \
+  -u username:application_password \
+  -d '{"scope":"external","limit":50,"timeout":5}'
+```

--- a/docs/api/endpoints/jobs.md
+++ b/docs/api/endpoints/jobs.md
@@ -4,197 +4,70 @@
 
 **Base URL**: `/wp-json/datamachine/v1/jobs`
 
-## Overview
-
-Jobs endpoints provide monitoring and management of workflow executions. Jobs represent individual execution instances of flows, including batch job hierarchies where a parent job spawns child jobs for parallel processing.
+Jobs expose workflow execution history and cleanup operations.
 
 ## Authentication
 
-Requires `manage_flows` permission (checked via `PermissionHelper`). Supports user-scoped and agent-scoped filtering for multi-agent environments.
+Requires the Data Machine `manage_flows` permission (`PermissionHelper::can( 'manage_flows' )`). Requests may be user-scoped or agent-scoped through `PermissionHelper`.
 
-## React Interface
+## Routes
 
-The Jobs interface is a React-based management dashboard built on `@wordpress/components` and TanStack Query.
+### GET `/wp-json/datamachine/v1/jobs`
 
-## Endpoints
+List jobs with filtering, sorting, and pagination.
 
-### GET /jobs
+**Query parameters**:
 
-Retrieve jobs with filtering, sorting, and pagination.
+- `orderby` (string, optional, default `job_id`): field to order by.
+- `order` (string, optional, default `DESC`): `ASC` or `DESC`.
+- `per_page` (integer, optional, default `50`, max `100`): page size.
+- `offset` (integer, optional, default `0`): pagination offset.
+- `pipeline_id` (integer, optional): filter by pipeline.
+- `flow_id` (integer, optional): filter by flow.
+- `status` (string, optional): filter by job status.
+- `user_id` (integer, optional): filter by user when allowed by the permission scope.
+- `parent_job_id` (integer, optional): filter child jobs by parent job.
+- `hide_children` (boolean, optional, default `false`): omit child jobs from top-level lists.
 
-**Permission**: `manage_flows` capability required
-
-**Parameters**:
-- `orderby` (string, optional): Order jobs by field (default: `job_id`)
-- `order` (string, optional): Sort order - `ASC` or `DESC` (default: `DESC`)
-- `per_page` (integer, optional): Number of jobs per page (default: 50, max: 100)
-- `offset` (integer, optional): Offset for pagination (default: 0)
-- `pipeline_id` (integer, optional): Filter by pipeline ID
-- `flow_id` (integer, optional): Filter by flow ID
-- `status` (string, optional): Filter by job status (`completed`, `failed`, `processing`, etc.)
-- `user_id` (integer, optional): Filter by user ID (admin only; non-admins always see own data)
-
-**Example Requests**:
-
-```bash
-# Get all jobs (recent first)
-curl https://example.com/wp-json/datamachine/v1/jobs \
-  -u username:application_password
-
-# Get failed jobs only
-curl https://example.com/wp-json/datamachine/v1/jobs?status=failed \
-  -u username:application_password
-
-# Get jobs for specific flow with pagination
-curl https://example.com/wp-json/datamachine/v1/jobs?flow_id=42&per_page=25&offset=0 \
-  -u username:application_password
-
-# Get jobs for specific pipeline
-curl https://example.com/wp-json/datamachine/v1/jobs?pipeline_id=5 \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
+**Success response**:
 
 ```json
 {
   "success": true,
-  "data": [
-    {
-      "job_id": 1523,
-      "flow_id": 42,
-      "pipeline_id": 5,
-      "status": "completed",
-      "parent_job_id": null,
-      "source": "scheduler",
-      "started_at": "2024-01-02 14:30:00",
-      "completed_at": "2024-01-02 14:30:15",
-      "error_message": null
-    },
-    {
-      "job_id": 1522,
-      "flow_id": 42,
-      "pipeline_id": 5,
-      "status": "failed",
-      "parent_job_id": null,
-      "source": "manual",
-      "started_at": "2024-01-02 14:00:00",
-      "completed_at": "2024-01-02 14:00:05",
-      "error_message": "Handler configuration missing"
-    }
-  ],
-  "total": 1523,
+  "data": [],
+  "total": 0,
   "per_page": 50,
   "offset": 0
 }
 ```
 
-**Response Fields**:
-- `success` (boolean): Request success status
-- `data` (array): Array of job objects
-- `total` (integer): Total number of jobs matching filters
-- `per_page` (integer): Number of jobs per page
-- `offset` (integer): Pagination offset
+### GET `/wp-json/datamachine/v1/jobs/{id}`
 
-**Job Object Fields**:
-- `job_id` (integer): Unique job identifier
-- `flow_id` (integer): Associated flow ID
-- `pipeline_id` (integer): Associated pipeline ID
-- `status` (string): Job status (see statuses below)
-- `parent_job_id` (integer|null): Parent job ID for batch child jobs (null for top-level jobs)
-- `source` (string): Job trigger source (`scheduler`, `manual`, `system`, `pipeline_system_task`, `chat`)
-- `started_at` (string): Job start timestamp
-- `completed_at` (string|null): Job completion timestamp
-- `error_message` (string|null): Error message if failed
-- `engine_data` (object): Job execution data including task parameters and effects (for system tasks)
+Get one job by ID.
 
-**Job Statuses**:
-- `pending` - Job queued but not started
-- `processing` - Currently executing
-- `completed` - Successfully completed
-- `completed_no_items` - Completed successfully but no new items found to process
-- `agent_skipped` - Completed intentionally without processing the current item (supports compound statuses like `agent_skipped - {reason}`)
-- `failed` - Execution failed with error
-
-### GET /jobs/{id}
-
-Get a specific job by ID with full details.
-
-**Permission**: `manage_flows` capability required
-
-**Parameters**:
-- `id` (integer, required): Job ID
-
-**Example Request**:
-
-```bash
-curl https://example.com/wp-json/datamachine/v1/jobs/1523 \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
+**Success response**:
 
 ```json
 {
   "success": true,
-  "data": {
-    "job_id": 1523,
-    "flow_id": 42,
-    "pipeline_id": 5,
-    "status": "completed",
-    "parent_job_id": null,
-    "source": "scheduler",
-    "started_at": "2024-01-02 14:30:00",
-    "completed_at": "2024-01-02 14:30:15",
-    "error_message": null,
-    "engine_data": {}
-  }
+  "data": {}
 }
 ```
 
-**Error Response (404 Not Found)**:
+**Errors**:
 
-```json
-{
-  "code": "job_not_found",
-  "message": "Job not found.",
-  "data": {"status": 404}
-}
-```
+- `job_not_found` (404): no matching job.
 
-### DELETE /jobs
+### DELETE `/wp-json/datamachine/v1/jobs`
 
-Clear jobs from the database.
+Clear jobs.
 
-**Permission**: `manage_flows` capability required
+**Body parameters**:
 
-**Parameters**:
-- `type` (string, required): Which jobs to clear - `all` or `failed`
-- `cleanup_processed` (boolean, optional): Also clear processed items tracking (default: false)
+- `type` (string, required): `all` or `failed`.
+- `cleanup_processed` (boolean, optional, default `false`): also clear processed item tracking.
 
-**Example Requests**:
-
-```bash
-# Clear all jobs
-curl -X DELETE https://example.com/wp-json/datamachine/v1/jobs \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"type": "all"}'
-
-# Clear failed jobs only
-curl -X DELETE https://example.com/wp-json/datamachine/v1/jobs \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"type": "failed"}'
-
-# Clear all jobs and processed items
-curl -X DELETE https://example.com/wp-json/datamachine/v1/jobs \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"type": "all", "cleanup_processed": true}'
-```
-
-**Success Response (200 OK)**:
+**Success response**:
 
 ```json
 {
@@ -205,294 +78,16 @@ curl -X DELETE https://example.com/wp-json/datamachine/v1/jobs \
 }
 ```
 
-**Error Response (400 Bad Request)**:
+## Batch Jobs
 
-```json
-{
-  "code": "invalid_type",
-  "message": "Invalid type parameter. Must be 'all' or 'failed'.",
-  "data": {"status": 400}
-}
-```
-
-## Batch Job Hierarchy
-
-Jobs support parent-child relationships for batch processing. When a pipeline uses the `PipelineBatchScheduler`, a parent job spawns multiple child jobs that execute in parallel.
-
-### Structure
-
-```
-Parent Job (job_id: 100, parent_job_id: null)
-├── Child Job (job_id: 101, parent_job_id: 100)
-├── Child Job (job_id: 102, parent_job_id: 100)
-└── Child Job (job_id: 103, parent_job_id: 100)
-```
-
-**Key behaviors**:
-- Parent job status remains `processing` until all children complete
-- `parent_job_id` field links children to their parent
-- Child completion triggers `PipelineBatchScheduler::onChildComplete()` to check if all children are done
-- Batch size and chunk processing are configured at the pipeline level
-
-### Querying Batch Jobs
+Batch processing uses parent/child jobs. Use `parent_job_id` to list children and `hide_children=true` for a top-level-only job list.
 
 ```bash
-# Get children of a batch parent
 curl "https://example.com/wp-json/datamachine/v1/jobs?parent_job_id=100" \
   -u username:application_password
 ```
 
-## Job Undo System
+## Notes for Agents
 
-**Implementation**: `inc/Engine/AI/System/Tasks/SystemTask.php` (@since v0.33.0)
-
-System tasks that modify WordPress content can opt into undo support. The undo system reads a standardized `effects` array from the job's `engine_data` and reverses each effect in reverse order.
-
-### Supported Undo Effect Types
-
-| Effect Type | Reversal Action |
-|---|---|
-| `post_content_modified` | Restores from WordPress revision |
-| `post_meta_set` | Restores previous value or deletes meta |
-| `attachment_created` | Deletes the attachment |
-| `featured_image_set` | Removes or restores previous thumbnail |
-
-### How Undo Works
-
-1. During execution, tasks record effects in `engine_data.effects`:
-   ```json
-   {
-     "effects": [
-       {
-         "type": "post_content_modified",
-         "post_id": 42,
-         "revision_id": 123
-       },
-       {
-         "type": "post_meta_set",
-         "post_id": 42,
-         "meta_key": "description",
-         "previous_value": "old value"
-       }
-     ]
-   }
-   ```
-
-2. Tasks opt in by returning `true` from `supportsUndo()`
-3. Undo reverses effects in reverse order (last effect first)
-4. Unknown effect types are skipped (not failed) so tasks with mixed reversible/irreversible effects degrade gracefully
-
-### CLI Undo
-
-```bash
-# Undo a job's effects
-wp datamachine jobs undo <job_id> --allow-root
-
-# Dry run to preview what would be reverted
-wp datamachine jobs undo <job_id> --dry-run --allow-root
-
-# Undo specific task type only
-wp datamachine jobs undo <job_id> --task-type=alt_text_generation --allow-root
-
-# Force undo even on non-completed jobs
-wp datamachine jobs undo <job_id> --force --allow-root
-```
-
-### Undo Response Format
-
-```json
-{
-  "success": true,
-  "reverted": [
-    {
-      "type": "post_content_modified",
-      "post_id": 42,
-      "message": "Restored from revision 123"
-    }
-  ],
-  "skipped": [],
-  "failed": []
-}
-```
-
-## Common Workflows
-
-### Monitor Flow Execution
-
-```bash
-# Get recent jobs for specific flow
-curl https://example.com/wp-json/datamachine/v1/jobs?flow_id=42&per_page=10 \
-  -u username:application_password
-```
-
-### Debug Failed Executions
-
-```bash
-# Get all failed jobs
-curl https://example.com/wp-json/datamachine/v1/jobs?status=failed \
-  -u username:application_password
-```
-
-### Cleanup Job History
-
-```bash
-# Clear failed jobs to reset execution history
-curl -X DELETE https://example.com/wp-json/datamachine/v1/jobs \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"type": "failed"}'
-```
-
-## Integration Examples
-
-### Python Job Monitoring
-
-```python
-import requests
-from requests.auth import HTTPBasicAuth
-
-url = "https://example.com/wp-json/datamachine/v1/jobs"
-auth = HTTPBasicAuth("username", "application_password")
-
-# Get failed jobs
-params = {"status": "failed", "per_page": 100}
-response = requests.get(url, params=params, auth=auth)
-
-if response.status_code == 200:
-    data = response.json()
-    print(f"Found {len(data['data'])} failed jobs")
-
-    for job in data['data']: 
-        print(f"Job {job['job_id']}: {job['error_message']}")
-else:
-    print(f"Error: {response.json()['message']}")
-```
-
-### JavaScript Job Dashboard
-
-```javascript
-const axios = require('axios');
-
-const jobAPI = {
-  baseURL: 'https://example.com/wp-json/datamachine/v1/jobs',
-  auth: {
-    username: 'admin',
-    password: 'application_password'
-  }
-};
-
-// Get job statistics
-async function getJobStats(flowId) {
-  const params = { flow_id: flowId, per_page: 100 };
-  const response = await axios.get(jobAPI.baseURL, {
-    params,
-    auth: jobAPI.auth
-  });
-
-  const jobs = response.data.data;
-  const stats = {
-    total: jobs.length,
-    completed: jobs.filter(j => j.status === 'completed').length,
-    failed: jobs.filter(j => j.status === 'failed').length,
-    processing: jobs.filter(j => j.status === 'processing').length
-  };
-
-  return stats;
-}
-
-// Clear old jobs
-async function clearJobs(type = 'failed') {
-  const response = await axios.delete(jobAPI.baseURL, {
-    data: { type },
-    auth: jobAPI.auth
-  });
-
-  return response.data.success;
-}
-
-// Usage
-const stats = await getJobStats(42);
-console.log(`Flow 42: ${stats.completed} completed, ${stats.failed} failed`);
-
-await clearJobs('failed');
-console.log('Failed jobs cleared');
-```
-
-### PHP Job Monitoring
-
-```php
-$url = 'https://example.com/wp-json/datamachine/v1/jobs';
-$auth = base64_encode('username:application_password');
-
-// Get jobs for specific flow
-$params = http_build_query([
-    'flow_id' => 42,
-    'status' => 'failed',
-    'per_page' => 50
-]);
-
-$response = wp_remote_get($url . '?' . $params, [
-    'headers' => [
-        'Authorization' => 'Basic ' . $auth
-    ]
-]);
-
-if (!is_wp_error($response)) {
-    $data = json_decode(wp_remote_retrieve_body($response), true);
-
-    foreach ($data['data'] as $job) {
-        error_log(sprintf(
-            'Job %d failed: %s',
-            $job['job_id'],
-            $job['error_message']
-        ));
-    }
-}
-```
-
-## Use Cases
-
-### Execution Monitoring
-
-Monitor workflow success rates and identify failing patterns:
-
-```bash
-# Get all jobs ordered by completion time
-curl https://example.com/wp-json/datamachine/v1/jobs?orderby=completed_at&order=DESC \
-  -u username:application_password
-```
-
-### Performance Analysis
-
-Analyze execution duration and identify bottlenecks:
-
-```bash
-# Get recent completed jobs
-curl https://example.com/wp-json/datamachine/v1/jobs?status=completed&per_page=100 \
-  -u username:application_password
-```
-
-### Cleanup and Maintenance
-
-Regularly clear old job records to maintain database performance:
-
-```bash
-# Clear all jobs and reset processed items tracking
-curl -X DELETE https://example.com/wp-json/datamachine/v1/jobs \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"type": "all", "cleanup_processed": true}'
-```
-
-## Related Documentation
-
-- [Execute](execute.md) - Flow execution
-- [Flows](flows.md) - Flow management
-- [Processed Items](processed-items.md) - Deduplication tracking
-- [Logs](logs.md) - Detailed execution logs
-
----
-
-**Base URL**: `/wp-json/datamachine/v1/jobs`
-**Permission**: `manage_flows` capability required
-**Implementation**: `inc/Api/Jobs.php`
+- REST does not expose job undo. Undo is CLI-only via `wp datamachine jobs undo <job_id>`.
+- Job objects are returned by `GetJobsAbility`; fields depend on stored job data and may include `engine_data` for task effects.

--- a/docs/api/endpoints/pipelines.md
+++ b/docs/api/endpoints/pipelines.md
@@ -1,385 +1,194 @@
 # Pipelines Endpoints
 
-**Implementation**: `/inc/Api/Pipelines/` directory structure
-- `Pipelines.php` - Main pipeline CRUD operations
-- `PipelineSteps.php` - Step management (`/pipelines/{id}/steps`)
-- `PipelineFlows.php` - Pipeline-flow relationships (`/pipelines/{id}/flows`)
+**Implementation**: `inc/Api/Pipelines/`
 
 **Base URL**: `/wp-json/datamachine/v1/pipelines`
 
-## Overview
-
-Pipeline endpoints provide complete pipeline template management including creation, retrieval, modification, deletion, step management, and CSV import/export functionality. Directory-based structure (@since v0.2.0) organizes related operations with nested endpoints for steps and flows.
+Pipelines are reusable workflow templates. Flows are executable instances of pipelines.
 
 ## Authentication
 
-Requires `manage_options` capability. See Authentication Guide.
+Requires the Data Machine `manage_flows` permission (`PermissionHelper::can( 'manage_flows' )`). Requests may be user-scoped or agent-scoped through `PermissionHelper`.
 
-## Endpoints
+## Response Envelope
 
-### GET /pipelines
-
-Retrieve all pipelines or a specific pipeline with optional field filtering.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `pipeline_id` (integer, optional): Specific pipeline ID to retrieve
-- `fields` (string, optional): Comma-separated list of fields to return
-
-**Example Requests**:
-
-```bash
-# Get all pipelines
-curl https://example.com/wp-json/datamachine/v1/pipelines \
-  -u username:application_password
-
-# Get specific pipeline
-curl https://example.com/wp-json/datamachine/v1/pipelines?pipeline_id=5 \
-  -u username:application_password
-
-# Get specific fields only
-curl https://example.com/wp-json/datamachine/v1/pipelines?fields=pipeline_id,pipeline_name \
-  -u username:application_password
-```
-
-**Success Response (All Pipelines)**:
+Current JSON routes generally return:
 
 ```json
 {
   "success": true,
-  "pipelines": [
-    {
-      "pipeline_id": 5,
-      "pipeline_name": "Content Pipeline",
-      "pipeline_config": "{}",
-      "created_at": "2024-01-01 12:00:00",
-      "updated_at": "2024-01-02 14:30:00"
-    }
-  ],
-  "total": 1
+  "data": {}
 }
 ```
 
-**Success Response (Single Pipeline)**:
+List routes may also include top-level pagination fields. CSV export returns raw `text/csv`, not a JSON envelope.
+
+## Pipeline Routes
+
+### GET `/wp-json/datamachine/v1/pipelines`
+
+List pipelines or export CSV.
+
+**Query parameters**:
+
+- `pipeline_id` (integer, optional): retrieve one pipeline through the list route.
+- `fields` (string, optional): comma-separated fields to keep.
+- `format` (string, optional, default `json`): `json` or `csv`.
+- `ids` (string, optional): comma-separated pipeline IDs for CSV export.
+- `user_id` (integer, optional): filter by user when allowed by scope.
+- `search` (string, optional): substring match on pipeline name.
+- `per_page` (integer, optional, default `20`, max `100`): page size.
+- `offset` (integer, optional, default `0`): pagination offset.
+- `include_flows` (boolean, optional): include full flows. Defaults to `false` for list mode and `true` for single-pipeline lookups.
+
+**List success shape**:
 
 ```json
 {
   "success": true,
-  "pipeline": {
-    "pipeline_id": 5,
-    "pipeline_name": "Content Pipeline",
-    "pipeline_config": "{}",
-    "created_at": "2024-01-01 12:00:00",
-    "updated_at": "2024-01-02 14:30:00"
-  },
-  "flows": [...]
+  "per_page": 20,
+  "offset": 0,
+  "total": 0,
+  "data": {
+    "pipelines": [],
+    "total": 0
+  }
 }
 ```
 
-### POST /pipelines
+### GET `/wp-json/datamachine/v1/pipelines/{pipeline_id}`
 
-Create a new pipeline with optional step configuration.
+Get one pipeline.
 
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `pipeline_name` (string, optional): Pipeline name (default: "Pipeline")
-- `steps` (array, optional): Complete pipeline steps configuration for complete mode
-- `flow_config` (array, optional): Flow configuration
-
-**Creation Modes**:
-- **Simple Mode**: Only `pipeline_name` provided - creates empty pipeline
-- **Complete Mode**: `steps` array provided - creates pipeline with configured steps
-
-**Example Requests**:
-
-```bash
-# Simple mode - empty pipeline
-curl -X POST https://example.com/wp-json/datamachine/v1/pipelines \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"pipeline_name": "My Pipeline"}'
-
-# Complete mode - with steps
-curl -X POST https://example.com/wp-json/datamachine/v1/pipelines \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "pipeline_name": "Complete Pipeline",
-    "steps": [
-      {"step_type": "fetch"},
-      {"step_type": "ai"},
-      {"step_type": "publish"}
-    ]
-  }'
-```
-
-**Success Response**:
+**Success shape**:
 
 ```json
 {
   "success": true,
-  "pipeline_id": 6,
-  "pipeline_name": "My Pipeline",
-  "pipeline_data": {...},
-  "existing_flows": [],
-  "creation_mode": "simple"
+  "data": {
+    "pipeline": {},
+    "flows": []
+  }
 }
 ```
 
-### DELETE /pipelines/{pipeline_id}
+### POST `/wp-json/datamachine/v1/pipelines`
 
-Delete a pipeline and all associated flows and jobs.
+Create a pipeline. Despite the REST schema default, `pipeline_name` is required by the controller.
 
-**Permission**: `manage_options` capability required
+**Body parameters**:
 
-**Parameters**:
-- `pipeline_id` (integer, required): Pipeline ID to delete (in URL path)
+- `pipeline_name` (string, required): pipeline name.
+- `steps` (array, optional): pipeline step configuration.
+- `flow_config` (array, optional): initial flow configuration.
 
-**Example Request**:
-
-```bash
-curl -X DELETE https://example.com/wp-json/datamachine/v1/pipelines/6 \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
+**Success shape**:
 
 ```json
 {
   "success": true,
-  "pipeline_id": 6,
-  "message": "Pipeline deleted successfully.",
-  "deleted_flows": 2,
-  "deleted_jobs": 15
+  "data": {}
 }
 ```
 
-### POST /pipelines/{pipeline_id}/steps
+### PATCH `/wp-json/datamachine/v1/pipelines/{pipeline_id}`
 
-Add a step to an existing pipeline.
+Rename a pipeline.
 
-**Permission**: `manage_options` capability required
+**Body parameters**:
 
-**Parameters**:
-- `pipeline_id` (integer, required): Pipeline ID (in URL path)
-- `step_type` (string, required): Step type (`fetch`, `ai`, `publish`, `upsert`)
+- `pipeline_name` (string, required): new title.
 
-**Example Request**:
+### DELETE `/wp-json/datamachine/v1/pipelines/{pipeline_id}`
 
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/pipelines/6/steps \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"step_type": "fetch"}'
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "message": "Step \"Fetch\" added successfully",
-  "step_type": "fetch",
-  "step_config": {...},
-  "pipeline_id": 6,
-  "pipeline_step_id": "abc123-def456-789",
-  "step_data": {...},
-  "created_type": "step"
-}
-```
-
-### DELETE /pipelines/{pipeline_id}/steps/{step_id}
-
-Delete a step from a pipeline.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `pipeline_id` (integer, required): Pipeline ID (in URL path)
-- `step_id` (string, required): Pipeline step ID (in URL path)
-
-**Example Request**:
-
-```bash
-curl -X DELETE https://example.com/wp-json/datamachine/v1/pipelines/6/steps/abc123-def456-789 \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "pipeline_step_id": "abc123-def456-789",
-  "pipeline_id": 6,
-  "message": "Step deleted successfully."
-}
-```
+Delete a pipeline and related records.
 
 ## CSV Export
 
-### GET /pipelines?format=csv
+### GET `/wp-json/datamachine/v1/pipelines?format=csv`
 
-Export pipelines to CSV format for backup, migration, or version control.
+Export pipelines as CSV. Use `ids=1,2` or `pipeline_id=1` to limit the export. The response is raw CSV with `Content-Type: text/csv; charset=utf-8`.
 
-**Permission**: `manage_options` capability required
+CSV import is not wired through `inc/Api/Pipelines/Pipelines.php`. The REST schema still registers `batch_import`, `format`, and `data` args on `POST /pipelines`, but the controller currently ignores them and requires `pipeline_name` for normal creation.
 
-**Parameters**:
-- `format` (string, required): Must be `csv` for export
-- `ids` (string, optional): Comma-separated pipeline IDs to export
-- `pipeline_id` (integer, optional): Single pipeline ID to export
+## Pipeline Step Routes
 
-**Export Behavior**:
-- If `ids` provided → Export specified pipelines
-- If `pipeline_id` provided → Export single pipeline
-- If neither provided → Export all pipelines
+### POST `/wp-json/datamachine/v1/pipelines/{pipeline_id}/steps`
 
-**CSV Structure**:
+Add a step.
 
-The exported CSV includes 9 columns: `pipeline_id`, `pipeline_name`, `step_position`, `step_type`, `step_config`, `flow_id`, `flow_name`, `handler`, `settings`
+**Body parameters**:
 
-**Example Requests**:
+- `step_type` (string, required): registered step type.
 
-```bash
-# Export all pipelines
-curl https://example.com/wp-json/datamachine/v1/pipelines?format=csv \
-  -u username:application_password \
-  -o pipelines-export.csv
+### DELETE `/wp-json/datamachine/v1/pipelines/{pipeline_id}/steps/{step_id}`
 
-# Export specific pipelines
-curl "https://example.com/wp-json/datamachine/v1/pipelines?format=csv&ids=5,6,7" \
-  -u username:application_password \
-  -o pipelines-export.csv
+Delete a pipeline step.
 
-# Export single pipeline
-curl https://example.com/wp-json/datamachine/v1/pipelines?format=csv&pipeline_id=5 \
-  -u username:application_password \
-  -o pipeline-5.csv
-```
+### PUT `/wp-json/datamachine/v1/pipelines/{pipeline_id}/steps/reorder`
 
-**Success Response (200 OK)**:
+Reorder steps.
 
-```csv
-pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,handler,settings
-5,Content Pipeline,0,fetch,"{""pipeline_step_id"":""abc-123""}",,,""
-5,Content Pipeline,1,ai,"{""pipeline_step_id"":""def-456""}",,,""
-5,Content Pipeline,0,fetch,"{""pipeline_step_id"":""abc-123""}",42,My Flow,rss,"{""feed_url"":""https://example.com/feed""}"
-```
+**Body parameters**:
 
-**Response Headers**:
+- `step_order` (array, required): objects with `pipeline_step_id` and numeric `execution_order`.
 
-```
-Content-Type: text/csv; charset=utf-8
-Content-Disposition: attachment; filename="pipelines-export-2024-01-02-14-30-00.csv"
-```
+### PATCH `/wp-json/datamachine/v1/pipelines/steps/{pipeline_step_id}/system-prompt`
 
-**Use Cases**:
-- Backup pipeline configurations
-- Share workflows between Data Machine installations
-- Version control pipeline templates
-- Migrate pipelines from development to production
+Update the AI system prompt for a pipeline step.
 
-## CSV Import
+**Body parameters**:
 
-### POST /pipelines (CSV Import Mode)
+- `system_prompt` (string, required): system prompt text.
 
-Import pipelines from CSV format.
+### PUT `/wp-json/datamachine/v1/pipelines/steps/{pipeline_step_id}/config`
 
-**Permission**: `manage_options` capability required
+Upsert AI step configuration. `step_type` and `pipeline_id` are required for `PUT` unless they can be inferred from the step ID.
 
-**Parameters**:
-- `batch_import` (boolean, required): Must be `true` to enable import mode
-- `format` (string, required): Must be `csv` for CSV import
-- `data` (string, required): CSV content to import
+**Body parameters**:
 
-**Import Behavior**:
-- Creates pipelines if they don't exist (matched by name)
-- Adds steps with configuration from CSV
-- Reuses existing pipelines with matching names
-- Returns array of imported pipeline IDs
+- `step_type` (string, required for PUT): currently only `ai` supports this config route.
+- `pipeline_id` (integer, required for PUT): pipeline context.
+- `disabled_tools` (array, optional): disabled tool IDs.
+- `tool_categories` (array, optional): allowed ability categories.
+- `system_prompt` (string, optional): AI system prompt.
 
-**Example Request**:
+### PATCH `/wp-json/datamachine/v1/pipelines/steps/{pipeline_step_id}/config`
 
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/pipelines \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "batch_import": true,
-    "format": "csv",
-    "data": "pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,handler,settings\n5,Content Pipeline,0,fetch,\"{}\",,,\"\"\n5,Content Pipeline,1,ai,\"{}\",,,\"\""
-  }'
-```
+Patch AI step configuration. Only supplied fields are changed.
 
-**Success Response (200 OK)**:
+Accepted fields are `disabled_tools`, `tool_categories`, and `system_prompt`. `provider`, `model`, and `ai_api_key` are not accepted; model/provider resolution comes from the mode settings system.
+
+## Pipeline Flow Routes
+
+### GET `/wp-json/datamachine/v1/pipelines/{pipeline_id}/flows`
+
+List flows attached to a pipeline.
+
+**Success shape**:
 
 ```json
 {
   "success": true,
-  "imported_pipeline_ids": [5, 6, 7],
-  "count": 3,
-  "message": "Successfully imported 3 pipeline(s)"
+  "data": {
+    "pipeline_id": 5,
+    "flows": [],
+    "flow_count": 0,
+    "first_flow_id": null
+  }
 }
 ```
 
-**Error Response (500 Internal Server Error)**:
+## Pipeline Memory Routes
 
-```json
-{
-  "code": "import_failed",
-  "message": "Failed to import pipelines from CSV.",
-  "data": {"status": 500}
-}
-```
+### GET `/wp-json/datamachine/v1/pipelines/{pipeline_id}/memory-files`
 
-**CSV Format Requirements**:
-- Header row required with 9 columns
-- Pipeline rows: Include pipeline structure (empty flow columns)
-- Flow rows: Include flow configuration (populated flow columns)
-- JSON-encoded fields must be properly escaped
-- Steps sorted by execution_order for consistency
+Return configured memory filenames for a pipeline.
 
-**Integration Example (Python)**:
+### POST/PUT/PATCH `/wp-json/datamachine/v1/pipelines/{pipeline_id}/memory-files`
 
-```python
-import requests
-from requests.auth import HTTPBasicAuth
+Replace configured memory filenames.
 
-# Read CSV file
-with open('pipelines-export.csv', 'r') as f:
-    csv_content = f.read()
+**Body parameters**:
 
-# Import to Data Machine
-url = "https://example.com/wp-json/datamachine/v1/pipelines"
-auth = HTTPBasicAuth("username", "application_password")
-payload = {
-    "batch_import": True,
-    "format": "csv",
-    "data": csv_content
-}
-
-response = requests.post(url, json=payload, auth=auth)
-
-if response.status_code == 200:
-    result = response.json()
-    print(f"Imported {result['count']} pipeline(s)")
-    print(f"Pipeline IDs: {result['imported_pipeline_ids']}")
-else:
-    print(f"Import failed: {response.json()['message']}")
-```
-
-## Related Documentation
-
-- Flows Endpoints - Flow instance management
-- Execute Endpoint - Pipeline execution
-- StepTypes Endpoint - Available step types
-- Authentication - Auth methods
-
----
-
-**Base URL**: `/wp-json/datamachine/v1/pipelines`
-**Permission**: `manage_options` capability required
-**Implementation**: `/inc/Api/Pipelines/` directory (Pipelines.php, PipelineSteps.php, PipelineFlows.php)
-**Version**: Directory structure introduced in v0.2.1
+- `memory_files` (array of strings, required): agent memory filenames.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,102 +1,146 @@
 # Data Machine REST API
 
-Complete REST API reference for Data Machine
+Complete REST API reference for Data Machine.
 
 ## Overview
 
 **Base URL**: `/wp-json/datamachine/v1/`
 
-**Authentication**: WordPress application password or cookie authentication
+**Authentication**: WordPress application password, WordPress admin cookie authentication, or endpoint-specific bearer-token authentication where noted.
 
-**Permissions**: Most endpoints require `manage_options` capability
+**Permissions**: REST controllers use `DataMachine\Abilities\PermissionHelper`, not a single generic `manage_options` check. WordPress administrators still pass because `manage_options` grants the mapped Data Machine capabilities, but the canonical permissions are scoped actions such as `manage_flows`, `manage_agents`, `manage_settings`, `chat`, `use_tools`, `view_logs`, and `create_own_agent`.
 
-**Implementation**: All endpoints are implemented in `inc/Api/`. The project is migrating business logic to the WordPress 6.9 Abilities API; REST handlers should prefer calling abilities (via `wp_get_ability()` / `wp_ability_execute`) where available. Service managers may still be instantiated as a transitional implementation during migration.
+**Implementation**: All REST route registrations live in `inc/Api/`. This inventory is sourced from `register_routes()` implementations in that directory.
+
+## Route Inventory
+
+| Group | Routes | Permission model | Source | Docs |
+|-------|--------|------------------|--------|------|
+| Agents | `/agents`, `/agents/me`, `/agents/{agent}`, `/agents/{agent_id}`, `/agents/{agent}/access`, `/agents/{agent_id}/access`, `/agents/{agent}/access/{user_id}`, `/agents/{agent_id}/access/{user_id}`, `/agents/{agent}/tokens`, `/agents/{agent_id}/tokens`, `/agents/{agent}/tokens/{token_id}`, `/agents/{agent_id}/tokens/{token_id}` | Scoped agent management. Listing is available to logged-in users and scoped by ownership/access grants. Create requires `manage_agents` or `create_own_agent`. Single-agent, access, and token management require `manage_agents`. `/agents/me` accepts an agent bearer-token context or a logged-in user. | `inc/Api/Agents.php` | [Agents](endpoints/agents.md) |
+| Agent Ping | `/agent-ping/confirm`, `/agent-ping/callback/{callback_id}` | Bearer-token callback auth using the configured agent-ping callback token. No WordPress capability check. | `inc/Api/AgentPing.php` | [Agent Ping](endpoints/agent-ping.md) |
+| Analytics | `/analytics/gsc`, `/analytics/bing`, `/analytics/ga`, `/analytics/pagespeed` | `manage_flows` via `PermissionHelper::can( 'manage_flows' )`. | `inc/Api/Analytics.php` | [Analytics](endpoints/analytics.md) |
+| Auth | `/auth/providers`, `/auth/{handler_slug}`, `/auth/{handler_slug}/status`, `/auth/{handler_slug}/token`, `/auth/{handler_slug}/refresh` | `manage_settings` through `Auth::check_permission()`. | `inc/Api/Auth.php` | [Auth](endpoints/auth.md) |
+| Chat | `/chat`, `/chat/continue`, `/chat/{session_id}`, `/chat/sessions`, `/chat/sessions/{session_id}/read`; `/chat/ping` | Chat routes require `chat`. `/chat/ping` uses the chat ping token verifier. | `inc/Api/Chat/Chat.php` | [Chat](endpoints/chat.md), [Chat Sessions](endpoints/chat-sessions.md) |
+| Email | `/email/send`, `/email/fetch`, `/email/{uid}/read`, `/email/reply`, `/email/{uid}`, `/email/{uid}/move`, `/email/{uid}/flag`, `/email/batch/move`, `/email/batch/flag`, `/email/batch/delete`, `/email/{uid}/unsubscribe`, `/email/batch/unsubscribe`, `/email/test-connection` | `PermissionHelper::can_manage()`, meaning any Data Machine management capability: `manage_flows`, `manage_settings`, or `manage_agents`. | `inc/Api/Email.php` | [Email](endpoints/email.md) |
+| Execute | `/execute` | `manage_flows` through the execute controller. | `inc/Api/Execute.php` | [Execute](endpoints/execute.md) |
+| Files | `/files`, `/files/{filename}`, `/files/agent`, `/files/agent/{filename}`, `/files/agent/daily`, `/files/agent/daily/{year}/{month}/{day}` | Flow files require a logged-in user plus `PermissionHelper::can_manage()`. Agent files allow users to access their own files; `manage_agents` can access another user's files. | `inc/Api/FlowFiles.php`, `inc/Api/AgentFiles.php` | [Files](endpoints/files.md) |
+| Flows | `/flows`, `/flows/{flow_id}`, `/flows/{flow_id}/pause`, `/flows/{flow_id}/resume`, `/flows/pause`, `/flows/resume`, `/flows/{flow_id}/duplicate`, `/flows/{flow_id}/memory-files`, `/flows/problems`, `/flows/{flow_id}/queue`, `/flows/{flow_id}/queue/{index}`, `/flows/{flow_id}/queue/mode`, `/flows/{flow_id}/config`, `/flows/steps/{flow_step_id}/config`, `/flows/steps/{flow_step_id}/handler`, `/flows/steps/{flow_step_id}/user-message` | Flow management through scoped `PermissionHelper` checks in the flow controllers. | `inc/Api/Flows/*.php` | [Flows](endpoints/flows.md) |
+| Handlers | `/handlers`, `/handlers/{handler_slug}` | Public metadata endpoints. | `inc/Api/Handlers.php` | [Handlers](endpoints/handlers.md) |
+| Internal Links | `/links/audit`, `/links/orphans`, `/links/backlinks`, `/links/broken`, `/links/diagnose` | `manage_flows` via `PermissionHelper::can( 'manage_flows' )`. | `inc/Api/InternalLinks.php` | [Internal Links](endpoints/internal-links.md) |
+| Jobs | `/jobs`, `/jobs/{id}` | `manage_flows`, with scoped user/agent resolution in list handling. | `inc/Api/Jobs.php` | [Jobs](endpoints/jobs.md) |
+| Logs | `/logs`, `/logs/metadata` | `view_logs` through the logs controller permission callback. | `inc/Api/Logs.php` | [Logs](endpoints/logs.md) |
+| Pipelines | `/pipelines`, `/pipelines/{pipeline_id}`, `/pipelines/{pipeline_id}/memory-files`, `/pipelines/{pipeline_id}/flows`, `/pipelines/{pipeline_id}/steps`, `/pipelines/{pipeline_id}/steps/{step_id}`, `/pipelines/{pipeline_id}/steps/reorder`, `/pipelines/steps/{pipeline_step_id}/system-prompt`, `/pipelines/steps/{pipeline_step_id}/config` | Pipeline management through scoped `PermissionHelper` checks in the pipeline controllers. | `inc/Api/Pipelines/*.php` | [Pipelines](endpoints/pipelines.md) |
+| Processed Items | `/processed-items` | `manage_flows` through `ProcessedItems::check_permission()`. | `inc/Api/ProcessedItems.php` | [Processed Items](endpoints/processed-items.md) |
+| Providers | `/providers` | Public provider metadata endpoint. | `inc/Api/Providers.php` | [Providers](endpoints/providers.md) |
+| Settings | `/settings`, `/settings/scheduling-intervals`, `/settings/tools/{tool_id}`, `/settings/handler-defaults`, `/settings/generate-ping-secret`, `/settings/handler-defaults/{handler_slug}` | `manage_settings` through `Settings::check_permission()`. | `inc/Api/Settings.php` | [Settings](endpoints/settings.md), [Scheduling Intervals](endpoints/intervals.md) |
+| Step Types | `/step-types`, `/step-types/{step_type}` | Public step-type metadata endpoints. | `inc/Api/StepTypes.php` | [Step Types](endpoints/step-types.md) |
+| System | `/system/status`, `/system/tasks`, `/system/tasks/{task_type}/run`, `/system/tasks/prompts`, `/system/tasks/prompts/{task_type}/{prompt_key}` | `manage_settings` through inline `PermissionHelper::can( 'manage_settings' )` callbacks. | `inc/Api/System/System.php` | [System](endpoints/system.md) |
+| Tools | `/tools` | Public tool metadata endpoint. | `inc/Api/Tools.php` | [Tools](endpoints/tools.md) |
+| Users | `/users/{id}`, `/users/me` | User preferences and current-user context. Cross-user access uses `manage_flows`; agent-level access uses `manage_agents`. | `inc/Api/Users.php` | [Users](endpoints/users.md) |
+| Webhook Triggers | `/trigger/{flow_id}` | Public route with per-flow bearer or HMAC verification. The callback is `__return_true` because authorization is performed by `WebhookAuthResolver`/`WebhookVerifier`, then ability execution runs inside a bounded authenticated context. | `inc/Api/WebhookTrigger.php`, `inc/Api/WebhookAuthResolver.php`, `inc/Api/WebhookVerifier.php` | [Webhook Triggers](endpoints/webhook-triggers.md) |
 
 ## Endpoint Categories
 
 ### Workflow Execution
-- [Execute](endpoints/execute.md): Trigger flows and ephemeral workflows
-- [Scheduling Intervals](endpoints/intervals.md): Available scheduling intervals and configuration
+
+- [Execute](endpoints/execute.md): Trigger flows and ephemeral workflows.
+- [Webhook Triggers](endpoints/webhook-triggers.md): Trigger a flow through bearer or HMAC webhook authentication.
+- [Agent Ping](endpoints/agent-ping.md): Agent callback confirmation and polling endpoints.
+- [Scheduling Intervals](endpoints/intervals.md): Available scheduling intervals and configuration.
 
 ### Pipeline & Flow Management
+
 - [Pipelines](endpoints/pipelines.md)
 - [Flows](endpoints/flows.md)
 - [Jobs](endpoints/jobs.md)
-
-### Content & Data
-- [Files](endpoints/files.md)
-- [Internal Links](endpoints/internal-links.md)
 - [Processed Items](endpoints/processed-items.md)
 
-### AI & Chat
+### Agents, Memory & Chat
+
 - [Agents](endpoints/agents.md)
 - [Agent Ping](endpoints/agent-ping.md)
+- [Files](endpoints/files.md)
 - [Chat](endpoints/chat.md)
 - [Chat Sessions](endpoints/chat-sessions.md)
-- [Email](endpoints/email.md)
+
+### Tools, Providers & Handlers
+
 - [Handlers](endpoints/handlers.md)
 - [Providers](endpoints/providers.md)
 - [Tools](endpoints/tools.md)
-
-### Configuration
-- [Settings](endpoints/settings.md)
-- [Users](endpoints/users.md)
-- [Auth](endpoints/auth.md)
 - [Step Types](endpoints/step-types.md)
-- [System](endpoints/system.md)
 
-### Monitoring
+### Content, Email & Analytics
+
+- [Analytics](endpoints/analytics.md)
+- [Email](endpoints/email.md)
+- [Internal Links](endpoints/internal-links.md)
+
+### Configuration & Operations
+
+- [Auth](endpoints/auth.md)
+- [Authentication](endpoints/authentication.md)
+- [Settings](endpoints/settings.md)
+- [System](endpoints/system.md)
+- [Users](endpoints/users.md)
 - [Logs](endpoints/logs.md)
 - [AI Directives](../core-system/ai-directives.md)
-- [Jobs](endpoints/jobs.md)
 
 ## Common Patterns
 
 ### Authentication
 
-Data Machine supports two authentication methods:
+Data Machine supports three authentication shapes:
 
-1. **Application Password** (Recommended for external integrations)
-2. **Cookie Authentication** (WordPress admin sessions)
+1. **Application Password** for external WordPress REST clients.
+2. **Cookie Authentication** for WordPress admin sessions.
+3. **Endpoint-specific Bearer/HMAC auth** for webhook-style callbacks that do not map cleanly to a logged-in WordPress user.
 
 See [Authentication](endpoints/authentication.md).
+
+### Permission Resolution
+
+`PermissionHelper::can()` maps Data Machine actions to concrete WordPress capabilities:
+
+| Action | WordPress capability |
+|--------|----------------------|
+| `manage_agents` | `datamachine_manage_agents` |
+| `manage_flows` | `datamachine_manage_flows` |
+| `manage_settings` | `datamachine_manage_settings` |
+| `chat` | `datamachine_chat` |
+| `use_tools` | `datamachine_use_tools` |
+| `view_logs` | `datamachine_view_logs` |
+| `create_own_agent` | `datamachine_create_own_agent` |
+
+Administrators retain access through `manage_options`, but docs and integrations should refer to the scoped Data Machine actions above.
 
 ### Error Handling
 
 All endpoints return standardized error responses following WordPress REST API conventions. Common error codes include:
 
-- `rest_forbidden` (403) - Insufficient permissions
-- `rest_invalid_param` (400) - Invalid parameters
-- Resource-specific errors (404, 500)
+- `rest_forbidden` (403) - Insufficient permissions.
+- `rest_invalid_param` (400) - Invalid parameters.
+- Resource-specific errors (404, 422, 500).
 
 See [Error Handling Reference](endpoints/errors.md) for complete error code documentation.
 
 ### Pagination
 
-Endpoints returning lists support pagination parameters:
-- `per_page` - Number of items per page
-- `offset` or `page` - Pagination offset
+Endpoints returning lists commonly support pagination parameters:
+
+- `per_page` - Number of items per page.
+- `offset` or `page` - Pagination offset.
 
 ## Implementation Guide
 
-All endpoints are implemented in `inc/Api/` using the services layer architecture for direct method calls, with automatic registration via `rest_api_init`:
+REST handlers should stay thin: validate request shape, call the service or ability that owns the behavior, and return a WordPress REST response.
 
 ```php
-// Example endpoint registration using services layer
-register_rest_route('datamachine/v1', '/pipelines', [
-    'methods' => 'GET',
-    'callback' => [Pipelines::class, 'get_pipelines'],
-    'permission_callback' => [Pipelines::class, 'check_permission']
-]);
-
-// Abilities API usage in endpoint callbacks
-public function create_pipeline($request) {
-    $ability = wp_get_ability( 'datamachine/create-pipeline' );
-    return $ability->execute( [
-        'pipeline_name' => $request['name'],
-        'options'       => $request['options'] ?? [],
-    ] );
-}
+register_rest_route( 'datamachine/v1', '/pipelines', array(
+    'methods'             => 'GET',
+    'callback'            => array( Pipelines::class, 'get_pipelines' ),
+    'permission_callback' => array( Pipelines::class, 'check_permission' ),
+) );
 ```
 
 For detailed implementation patterns, see the [Development](../development/) section for hooks and extension guides.
@@ -107,9 +151,9 @@ For detailed implementation patterns, see the [Development](../development/) sec
 - [Errors](endpoints/errors.md)
 - [Engine Execution](../core-system/engine-execution.md)
 - [Settings](endpoints/settings.md)
-- [Development Guides](../development/) - Extension development and hooks
+- [Development Guides](../development/)
 
 ---
 
 **API Version**: v1
-**Last Updated**: 2026-01-18
+**Last Updated**: 2026-05-12

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -25,11 +25,15 @@ Complete REST API reference for Data Machine
 
 ### Content & Data
 - [Files](endpoints/files.md)
+- [Internal Links](endpoints/internal-links.md)
 - [Processed Items](endpoints/processed-items.md)
 
 ### AI & Chat
+- [Agents](endpoints/agents.md)
+- [Agent Ping](endpoints/agent-ping.md)
 - [Chat](endpoints/chat.md)
 - [Chat Sessions](endpoints/chat-sessions.md)
+- [Email](endpoints/email.md)
 - [Handlers](endpoints/handlers.md)
 - [Providers](endpoints/providers.md)
 - [Tools](endpoints/tools.md)

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,98 +1,145 @@
 # Data Machine REST API
 
-Complete REST API reference for Data Machine
+Complete REST API reference for Data Machine.
 
 ## Overview
 
 **Base URL**: `/wp-json/datamachine/v1/`
 
-**Authentication**: WordPress application password or cookie authentication
+**Authentication**: WordPress application password, WordPress admin cookie authentication, or endpoint-specific bearer-token authentication where noted.
 
-**Permissions**: Most endpoints require `manage_options` capability
+**Permissions**: REST controllers use `DataMachine\Abilities\PermissionHelper`, not a single generic `manage_options` check. WordPress administrators still pass because `manage_options` grants the mapped Data Machine capabilities, but the canonical permissions are scoped actions such as `manage_flows`, `manage_agents`, `manage_settings`, `chat`, `use_tools`, `view_logs`, and `create_own_agent`.
 
-**Implementation**: All endpoints are implemented in `inc/Api/`. The project is migrating business logic to the WordPress 6.9 Abilities API; REST handlers should prefer calling abilities (via `wp_get_ability()` / `wp_ability_execute`) where available. Service managers may still be instantiated as a transitional implementation during migration.
+**Implementation**: All REST route registrations live in `inc/Api/`. This inventory is sourced from `register_routes()` implementations in that directory.
+
+## Route Inventory
+
+| Group | Routes | Permission model | Source | Docs |
+|-------|--------|------------------|--------|------|
+| Agents | `/agents`, `/agents/me`, `/agents/{agent}`, `/agents/{agent_id}`, `/agents/{agent}/access`, `/agents/{agent_id}/access`, `/agents/{agent}/access/{user_id}`, `/agents/{agent_id}/access/{user_id}`, `/agents/{agent}/tokens`, `/agents/{agent_id}/tokens`, `/agents/{agent}/tokens/{token_id}`, `/agents/{agent_id}/tokens/{token_id}` | Scoped agent management. Listing is available to logged-in users and scoped by ownership/access grants. Create requires `manage_agents` or `create_own_agent`. Single-agent, access, and token management require `manage_agents`. `/agents/me` accepts an agent bearer-token context or a logged-in user. | `inc/Api/Agents.php` | [Agents](endpoints/agents.md) |
+| Agent Ping | `/agent-ping/confirm`, `/agent-ping/callback/{callback_id}` | Bearer-token callback auth using the configured agent-ping callback token. No WordPress capability check. | `inc/Api/AgentPing.php` | [Agent Ping](endpoints/agent-ping.md) |
+| Analytics | `/analytics/gsc`, `/analytics/bing`, `/analytics/ga`, `/analytics/pagespeed` | `manage_flows` via `PermissionHelper::can( 'manage_flows' )`. | `inc/Api/Analytics.php` | [Analytics](endpoints/analytics.md) |
+| Auth | `/auth/providers`, `/auth/{handler_slug}`, `/auth/{handler_slug}/status`, `/auth/{handler_slug}/token`, `/auth/{handler_slug}/refresh` | `manage_settings` through `Auth::check_permission()`. | `inc/Api/Auth.php` | [Auth](endpoints/auth.md) |
+| Chat | `/chat`, `/chat/continue`, `/chat/{session_id}`, `/chat/sessions`, `/chat/sessions/{session_id}/read`; `/chat/ping` | Chat routes require `chat`. `/chat/ping` uses the chat ping token verifier. | `inc/Api/Chat/Chat.php` | [Chat](endpoints/chat.md), [Chat Sessions](endpoints/chat-sessions.md) |
+| Email | `/email/send`, `/email/fetch`, `/email/{uid}/read`, `/email/reply`, `/email/{uid}`, `/email/{uid}/move`, `/email/{uid}/flag`, `/email/batch/move`, `/email/batch/flag`, `/email/batch/delete`, `/email/{uid}/unsubscribe`, `/email/batch/unsubscribe`, `/email/test-connection` | `PermissionHelper::can_manage()`, meaning any Data Machine management capability: `manage_flows`, `manage_settings`, or `manage_agents`. | `inc/Api/Email.php` | [Email](endpoints/email.md) |
+| Execute | `/execute` | `manage_flows` through the execute controller. | `inc/Api/Execute.php` | [Execute](endpoints/execute.md) |
+| Files | `/files`, `/files/{filename}`, `/files/agent`, `/files/agent/{filename}`, `/files/agent/daily`, `/files/agent/daily/{year}/{month}/{day}` | Flow files require a logged-in user plus `PermissionHelper::can_manage()`. Agent files allow users to access their own files; `manage_agents` can access another user's files. | `inc/Api/FlowFiles.php`, `inc/Api/AgentFiles.php` | [Files](endpoints/files.md) |
+| Flows | `/flows`, `/flows/{flow_id}`, `/flows/{flow_id}/pause`, `/flows/{flow_id}/resume`, `/flows/pause`, `/flows/resume`, `/flows/{flow_id}/duplicate`, `/flows/{flow_id}/memory-files`, `/flows/problems`, `/flows/{flow_id}/queue`, `/flows/{flow_id}/queue/{index}`, `/flows/{flow_id}/queue/mode`, `/flows/{flow_id}/config`, `/flows/steps/{flow_step_id}/config`, `/flows/steps/{flow_step_id}/handler`, `/flows/steps/{flow_step_id}/user-message` | Flow management through scoped `PermissionHelper` checks in the flow controllers. | `inc/Api/Flows/*.php` | [Flows](endpoints/flows.md) |
+| Handlers | `/handlers`, `/handlers/{handler_slug}` | Public metadata endpoints. | `inc/Api/Handlers.php` | [Handlers](endpoints/handlers.md) |
+| Internal Links | `/links/audit`, `/links/orphans`, `/links/backlinks`, `/links/broken`, `/links/diagnose` | `manage_flows` via `PermissionHelper::can( 'manage_flows' )`. | `inc/Api/InternalLinks.php` | [Internal Links](endpoints/internal-links.md) |
+| Jobs | `/jobs`, `/jobs/{id}` | `manage_flows`, with scoped user/agent resolution in list handling. | `inc/Api/Jobs.php` | [Jobs](endpoints/jobs.md) |
+| Logs | `/logs`, `/logs/metadata` | `view_logs` through the logs controller permission callback. | `inc/Api/Logs.php` | [Logs](endpoints/logs.md) |
+| Pipelines | `/pipelines`, `/pipelines/{pipeline_id}`, `/pipelines/{pipeline_id}/memory-files`, `/pipelines/{pipeline_id}/flows`, `/pipelines/{pipeline_id}/steps`, `/pipelines/{pipeline_id}/steps/{step_id}`, `/pipelines/{pipeline_id}/steps/reorder`, `/pipelines/steps/{pipeline_step_id}/system-prompt`, `/pipelines/steps/{pipeline_step_id}/config` | Pipeline management through scoped `PermissionHelper` checks in the pipeline controllers. | `inc/Api/Pipelines/*.php` | [Pipelines](endpoints/pipelines.md) |
+| Processed Items | `/processed-items` | `manage_flows` through `ProcessedItems::check_permission()`. | `inc/Api/ProcessedItems.php` | [Processed Items](endpoints/processed-items.md) |
+| Providers | `/providers` | Public provider metadata endpoint. | `inc/Api/Providers.php` | [Providers](endpoints/providers.md) |
+| Settings | `/settings`, `/settings/scheduling-intervals`, `/settings/tools/{tool_id}`, `/settings/handler-defaults`, `/settings/generate-ping-secret`, `/settings/handler-defaults/{handler_slug}` | `manage_settings` through `Settings::check_permission()`. | `inc/Api/Settings.php` | [Settings](endpoints/settings.md), [Scheduling Intervals](endpoints/intervals.md) |
+| Step Types | `/step-types`, `/step-types/{step_type}` | Public step-type metadata endpoints. | `inc/Api/StepTypes.php` | [Step Types](endpoints/step-types.md) |
+| System | `/system/status`, `/system/tasks`, `/system/tasks/{task_type}/run`, `/system/tasks/prompts`, `/system/tasks/prompts/{task_type}/{prompt_key}` | `manage_settings` through inline `PermissionHelper::can( 'manage_settings' )` callbacks. | `inc/Api/System/System.php` | [System](endpoints/system.md) |
+| Tools | `/tools` | Public tool metadata endpoint. | `inc/Api/Tools.php` | [Tools](endpoints/tools.md) |
+| Users | `/users/{id}`, `/users/me` | User preferences and current-user context. Cross-user access uses `manage_flows`; agent-level access uses `manage_agents`. | `inc/Api/Users.php` | [Users](endpoints/users.md) |
+| Webhook Triggers | `/trigger/{flow_id}` | Public route with per-flow bearer or HMAC verification. The callback is `__return_true` because authorization is performed by `WebhookAuthResolver`/`WebhookVerifier`, then ability execution runs inside a bounded authenticated context. | `inc/Api/WebhookTrigger.php`, `inc/Api/WebhookAuthResolver.php`, `inc/Api/WebhookVerifier.php` | [Webhook Triggers](endpoints/webhook-triggers.md) |
 
 ## Endpoint Categories
 
 ### Workflow Execution
-- [Execute](endpoints/execute.md): Trigger flows and ephemeral workflows
-- [Scheduling Intervals](endpoints/intervals.md): Available scheduling intervals and configuration
+
+- [Execute](endpoints/execute.md): Trigger flows and ephemeral workflows.
+- [Webhook Triggers](endpoints/webhook-triggers.md): Trigger a flow through bearer or HMAC webhook authentication.
+- [Agent Ping](endpoints/agent-ping.md): Agent callback confirmation and polling endpoints.
+- [Scheduling Intervals](endpoints/intervals.md): Available scheduling intervals and configuration.
 
 ### Pipeline & Flow Management
+
 - [Pipelines](endpoints/pipelines.md)
 - [Flows](endpoints/flows.md)
 - [Jobs](endpoints/jobs.md)
-
-### Content & Data
-- [Files](endpoints/files.md)
 - [Processed Items](endpoints/processed-items.md)
 
-### AI & Chat
+### Agents, Memory & Chat
+
+- [Agents](endpoints/agents.md)
+- [Files](endpoints/files.md)
 - [Chat](endpoints/chat.md)
 - [Chat Sessions](endpoints/chat-sessions.md)
+
+### Tools, Providers & Handlers
+
 - [Handlers](endpoints/handlers.md)
 - [Providers](endpoints/providers.md)
 - [Tools](endpoints/tools.md)
-
-### Configuration
-- [Settings](endpoints/settings.md)
-- [Users](endpoints/users.md)
-- [Auth](endpoints/auth.md)
 - [Step Types](endpoints/step-types.md)
-- [System](endpoints/system.md)
 
-### Monitoring
+### Content, Email & Analytics
+
+- [Analytics](endpoints/analytics.md)
+- [Email](endpoints/email.md)
+- [Internal Links](endpoints/internal-links.md)
+
+### Configuration & Operations
+
+- [Auth](endpoints/auth.md)
+- [Authentication](endpoints/authentication.md)
+- [Settings](endpoints/settings.md)
+- [System](endpoints/system.md)
+- [Users](endpoints/users.md)
 - [Logs](endpoints/logs.md)
 - [AI Directives](../core-system/ai-directives.md)
-- [Jobs](endpoints/jobs.md)
 
 ## Common Patterns
 
 ### Authentication
 
-Data Machine supports two authentication methods:
+Data Machine supports three authentication shapes:
 
-1. **Application Password** (Recommended for external integrations)
-2. **Cookie Authentication** (WordPress admin sessions)
+1. **Application Password** for external WordPress REST clients.
+2. **Cookie Authentication** for WordPress admin sessions.
+3. **Endpoint-specific Bearer/HMAC auth** for webhook-style callbacks that do not map cleanly to a logged-in WordPress user.
 
 See [Authentication](endpoints/authentication.md).
+
+### Permission Resolution
+
+`PermissionHelper::can()` maps Data Machine actions to concrete WordPress capabilities:
+
+| Action | WordPress capability |
+|--------|----------------------|
+| `manage_agents` | `datamachine_manage_agents` |
+| `manage_flows` | `datamachine_manage_flows` |
+| `manage_settings` | `datamachine_manage_settings` |
+| `chat` | `datamachine_chat` |
+| `use_tools` | `datamachine_use_tools` |
+| `view_logs` | `datamachine_view_logs` |
+| `create_own_agent` | `datamachine_create_own_agent` |
+
+Administrators retain access through `manage_options`, but docs and integrations should refer to the scoped Data Machine actions above.
 
 ### Error Handling
 
 All endpoints return standardized error responses following WordPress REST API conventions. Common error codes include:
 
-- `rest_forbidden` (403) - Insufficient permissions
-- `rest_invalid_param` (400) - Invalid parameters
-- Resource-specific errors (404, 500)
+- `rest_forbidden` (403) - Insufficient permissions.
+- `rest_invalid_param` (400) - Invalid parameters.
+- Resource-specific errors (404, 422, 500).
 
 See [Error Handling Reference](endpoints/errors.md) for complete error code documentation.
 
 ### Pagination
 
-Endpoints returning lists support pagination parameters:
-- `per_page` - Number of items per page
-- `offset` or `page` - Pagination offset
+Endpoints returning lists commonly support pagination parameters:
+
+- `per_page` - Number of items per page.
+- `offset` or `page` - Pagination offset.
 
 ## Implementation Guide
 
-All endpoints are implemented in `inc/Api/` using the services layer architecture for direct method calls, with automatic registration via `rest_api_init`:
+REST handlers should stay thin: validate request shape, call the service or ability that owns the behavior, and return a WordPress REST response.
 
 ```php
-// Example endpoint registration using services layer
-register_rest_route('datamachine/v1', '/pipelines', [
-    'methods' => 'GET',
-    'callback' => [Pipelines::class, 'get_pipelines'],
-    'permission_callback' => [Pipelines::class, 'check_permission']
-]);
-
-// Abilities API usage in endpoint callbacks
-public function create_pipeline($request) {
-    $ability = wp_get_ability( 'datamachine/create-pipeline' );
-    return $ability->execute( [
-        'pipeline_name' => $request['name'],
-        'options'       => $request['options'] ?? [],
-    ] );
-}
+register_rest_route( 'datamachine/v1', '/pipelines', array(
+    'methods'             => 'GET',
+    'callback'            => array( Pipelines::class, 'get_pipelines' ),
+    'permission_callback' => array( Pipelines::class, 'check_permission' ),
+) );
 ```
 
 For detailed implementation patterns, see the [Development](../development/) section for hooks and extension guides.
@@ -103,9 +150,9 @@ For detailed implementation patterns, see the [Development](../development/) sec
 - [Errors](endpoints/errors.md)
 - [Engine Execution](../core-system/engine-execution.md)
 - [Settings](endpoints/settings.md)
-- [Development Guides](../development/) - Extension development and hooks
+- [Development Guides](../development/)
 
 ---
 
 **API Version**: v1
-**Last Updated**: 2026-01-18
+**Last Updated**: 2026-05-12

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,11 +110,12 @@ See [WordPress as Agent Memory](core-system/wordpress-as-agent-memory.md) for fu
 Temporal knowledge management via date-organized files:
 
 - **DailyMemory**: File operations at `agents/{slug}/daily/YYYY/MM/DD.md`
-- **DailyMemoryTask**: System task with two phases:
-  - Phase 1: Synthesizes daily activity (jobs, chat) into daily file
-  - Phase 2: Prunes MEMORY.md when > 8KB, archiving session content to daily file
-- **DailyMemorySelectorDirective** (Priority 46): Injects daily memory into pipeline AI requests with configurable selection modes (recent days, specific dates, date range, months). Capped at 100KB total.
+- **DailyMemoryTask**: System task that maintains `MEMORY.md` with deterministic overflow handling, same-day `activity_section` context, the single `daily_memory` prompt, and conservation checks.
+- **AgentDailyMemoryDirective** (Priority 35): Opt-in recent daily memory injection for chat and pipeline requests via `agent_config.daily_memory`.
+- **AgentDailyMemory tool**: Policy-gated on-demand reads, writes, lists, and searches for exact dates, ranges, and historical lookups.
 - **DailyMemoryAbilities**: CRUD + search via Abilities API with multi-agent scoping
+
+See [Daily Memory System](core-system/daily-memory-system.md) for the current task lifecycle and artifact behavior.
 
 ### System Tasks Framework
 

--- a/docs/architecture/agent-memory-backends.md
+++ b/docs/architecture/agent-memory-backends.md
@@ -111,6 +111,24 @@ For example, the daily file for April 17, 2026 is the logical filename `daily/20
 
 Path helper methods such as `DailyMemory::get_base_path()` and `get_file_path()` are disk conveniences only. Non-disk stores may persist daily memory in posts, rows, or another physical shape.
 
+Daily memory availability is policy-gated at two layers:
+
+- `AgentDailyMemoryDirective` only injects recent files when `agent_config.daily_memory.enabled` is true for the resolved agent.
+- `AgentDailyMemory` tool access is still subject to tool policy and the underlying daily-memory abilities; write/delete operations also honor `daily_memory_enabled`.
+
+Run artifact collection can project daily memory writes into bundle-relative paths. When a successful `agent_daily_memory` write happens during a job, `JobArtifacts` reads the resulting day file and emits an `agent_daily_memory` artifact with `bundle_relative_path` shaped as `memory/agent/daily/YYYY/MM/DD.md`. If the file cannot be read yet, the artifact falls back to the write content with a `# Daily Memory: YYYY-MM-DD` heading.
+
+## Bundle Artifact Projection
+
+Memory backends store logical files; bundles and job artifacts provide portable projections of those files:
+
+- Agent memory writes become `agent_memory` run artifacts with paths such as `memory/agent/MEMORY.md` or `memory/USER.md`.
+- Daily memory writes become `agent_daily_memory` run artifacts under `memory/agent/daily/YYYY/MM/DD.md`.
+- Bundle-owned memory sections are tracked as section artifacts by `MemorySectionArtifact`, including owner, section type, source path, install hash, current hash, and local status.
+- Safe self-memory writes use section artifact ownership to decide whether to write directly or stage a PendingAction.
+
+The backend contract does not need to know about these bundle paths. The projection layer reads through `AgentMemory` and `DailyMemory`, then maps logical records to portable package paths for egress or upgrade review.
+
 ## Relationship To AI Framework
 
 The memory-store seam is not a replacement for AI Framework. Data Machine still owns its portable agent memory model and prompt assembly, while consumers can route storage to the backend that fits the host. AI Framework integration can coexist with this model; it does not require Data Machine to abandon `AgentMemory`, `MEMORY.md`, or the registry-driven directive stack.
@@ -129,4 +147,5 @@ The memory-store seam is not a replacement for AI Framework. Data Machine still 
 - [WordPress as Persistent Memory for AI Agents](../core-system/wordpress-as-agent-memory.md)
 - [Memory Policy](../core-system/memory-policy.md)
 - [Daily Memory System](../core-system/daily-memory-system.md)
+- [Agent Bundles](../core-system/agent-bundles.md)
 - [Core Filters: WP_Agent_Memory_Store](../development/hooks/core-filters.md#agentmemorystoreinterface-inccorefilesrepositoryagentmemorystoreinterfacephp)

--- a/docs/architecture/policy-resolvers.md
+++ b/docs/architecture/policy-resolvers.md
@@ -1,227 +1,203 @@
 # Policy Resolvers
 
-Data Machine has four policy resolvers — small classes that read per-agent declarative configuration and answer one specific question about how the agent should run. They look uniform from a docblock distance and divergent up close. This doc names the convention they share, the shapes they don't share, and how to add a fifth without breaking the pattern.
+Data Machine uses small policy resolvers instead of one shared policy base class. Each resolver reads declarative configuration near the thing it governs, normalizes that policy, and answers one runtime question.
 
-The four resolvers:
+| Resolver | Question | Primary input | Return shape |
+|---|---|---|---|
+| `ToolPolicyResolver` | Which tools can this request see? | Tool sources, request args, `agent_config.tool_policy` | `array<tool_name, tool_def>` |
+| `MemoryPolicyResolver` | Which memory files inject? | Memory registry/config, `agent_config.memory_policy` | `array<filename, metadata>` |
+| `DirectivePolicyResolver` | Which directives remain in the prompt stack? | Registered directives, `agent_config.directive_policy` | `array{directives: array, suppressed: array}` |
+| `ActionPolicyResolver` | How may one tool invocation execute? | Tool definition, mode, `agent_config.action_policy` | `direct`, `preview`, or `forbidden` |
+| `PipelineTranscriptPolicy` | Should the pipeline transcript persist? | Flow config, pipeline config, site option | `bool` |
 
-1. **`ToolPolicyResolver`** — *which* tools the agent can see.
-2. **`MemoryPolicyResolver`** — *which* memory files inject into the prompt.
-3. **`ActionPolicyResolver`** — *how* a single tool invocation executes (direct / preview / forbidden).
-4. **`PipelineTranscriptPolicy`** — *whether* the AI conversation transcript is persisted.
+The shared convention is policy normalization plus explicit precedence. The classes do not share a parent because their return values and call sites are intentionally different.
 
-All four read from `agent_config` on the agent row. All four use the same precedence ladder shape. None of them share a return type, and that's deliberate.
+## Tool Policy Resolver
 
-## Why this isn't a base class
-
-Each resolver answers a structurally different question:
-
-| Resolver | Question | Returns |
-|---|---|---|
-| `ToolPolicyResolver` | Which tools are visible? | `array<tool_name, tool_def>` (filtered set) |
-| `MemoryPolicyResolver` | Which memory files inject? | `array<filename, metadata>` (filtered set) |
-| `ActionPolicyResolver` | How does this invocation execute? | `string` — one of `direct` / `preview` / `forbidden` |
-| `PipelineTranscriptPolicy` | Persist this run's transcript? | `bool` |
-
-The method names give it away: `resolve()`, `resolveRegistered()`, `resolveForTool()`, `shouldPersist()`. Forcing all four through `AbstractAgentPolicy::resolve(): array` would either pick a useless lowest-common-denominator return, require generics PHP can't enforce at runtime, or distort `ActionPolicyResolver` and `PipelineTranscriptPolicy` into set-filter shapes they shouldn't be.
-
-What the four resolvers share is **a convention** — per-agent declarative config with layered precedence and a final filter hook. Conventions are documented; identities are inherited. These are not the same kind of thing.
-
-## The convention
-
-A policy resolver in Data Machine has six properties. Each property is reproduced explicitly in each resolver, not factored out into a parent class.
-
-### 1. Per-agent config under a named key
-
-The policy lives in the `agent_config` JSON blob on the agent row, under a key named `<thing>_policy`:
+`ToolPolicyResolver` is the single entry point for runtime tool visibility.
 
 ```php
-$config = $agent['agent_config'] ?? array();
-$policy = $config['tool_policy']      ?? null; // ToolPolicyResolver
-$policy = $config['memory_policy']    ?? null; // MemoryPolicyResolver
-$policy = $config['action_policy']    ?? null; // ActionPolicyResolver
-// PipelineTranscriptPolicy reads pipeline_config / flow_config keys instead
-// of agent_config — see "When to bend the convention" below.
+$tools = ( new ToolPolicyResolver() )->resolve( array(
+    'mode'       => ToolPolicyResolver::MODE_CHAT,
+    'agent_id'   => $agent_id,
+    'deny'       => array( 'dangerous_tool' ),
+    'allow_only' => array( 'safe_tool' ),
+    'categories' => array( 'content' ),
+) );
 ```
 
-The reader is a method on the resolver itself (`getAgentToolPolicy()`, `getAgentMemoryPolicy()`, `getAgentActionPolicy()`), not a shared utility. Each reader validates the policy shape and normalizes it before returning.
+Current implementation shape:
 
-### 2. Null = no-op
-
-`getAgent*Policy()` returns `null` when:
-
-- The agent doesn't exist.
-- The config key is missing or not an array.
-- The policy is structurally invalid (unknown mode, wrong shape).
-- The policy is a recognized but effectively-empty no-op (e.g. `mode=deny` with empty deny list).
-
-The caller short-circuits on `null` instead of running an empty filter pass. This is a small but real perf and clarity win — the hot path stays cheap when no policy is configured.
-
-### 3. Layered precedence, highest first
-
-Every resolver runs the same shape of ladder. Higher rules override lower ones. The exact rungs differ per resolver, but the order is always: explicit context → per-agent → category → tool/file default → mode preset → global default → final filter.
-
-`ToolPolicyResolver`:
-
-```
-1. Explicit deny list (always wins)
-2. Per-agent tool policy (deny/allow mode, supports categories)
-3. Ability category filter (narrows by linked ability category)
-4. Context-level allow_only (narrows to explicit subset)
-5. Context preset (pipeline / chat / system)
-6. Global enablement settings
-7. Tool configuration requirements
-8. apply_filters('datamachine_resolved_tools', ...)
+```text
+ToolPolicyResolver::resolve()
+    |
+    +--> chat gate via DataMachineToolAccessPolicy::passesChatGate()
+    |
+    +--> ToolSourceRegistry::gather()
+    |       - adjacent_handlers in pipeline mode
+    |       - static_registry in every mode
+    |
+    +--> WP_Agent_Tool_Policy::resolve()
+    |       - mandatory Data Machine tools are preserved
+    |       - generic allow/deny/category/mode filtering
+    |       - chat ability/access checks when applicable
+    |
+    +--> apply_filters( 'datamachine_resolved_tools', ... )
 ```
 
-`MemoryPolicyResolver`:
+Resolution concepts:
 
-```
-1. Explicit deny list passed in context (always wins)
-2. Per-agent policy deny list (from agent_config.memory_policy)
-3. Per-agent policy allow-only (narrows to subset)
-4. Context-level allow_only (narrows to subset)
-5. Mode preset (registry's get_for_mode)
-6. apply_filters('datamachine_resolved_memory_files', ...)
-```
+| Layer | Meaning |
+|---|---|
+| Explicit `deny` | Highest-precedence removal list. Pipeline `disabled_tools` becomes this arg. |
+| Per-agent `tool_policy` | Read from `agent_config.tool_policy` through `DataMachineAgentToolPolicyProvider`. |
+| Categories | Resolved through linked WordPress Abilities, not a separate Data Machine tool category registry. |
+| `allow_only` | Narrows optional/static tools. Pipeline `enabled_tools` becomes this arg. |
+| Mode preset | Tool definitions declare `modes`; source registry gathers sources by mode. |
+| Global/config checks | `DataMachineToolRegistrySource` calls `ToolManager::is_tool_available()` and `is_globally_enabled()`. |
+| Final filter | `datamachine_resolved_tools`. |
 
-`ActionPolicyResolver`:
+Adjacent handler tools are different from optional/static tools. They come from the previous and next pipeline steps and represent the workflow's required flow plumbing. They are gathered by `AdjacentHandlerToolSource` before generic policy filtering and are protected by Data Machine's mandatory-tool policy where appropriate. A required adjacent publish/upsert handler with no callable AI tool fails before the model call; request inspection reports the same missing-handler state.
 
-```
-1. Explicit deny list (any listed tool → 'forbidden')
-2. Per-agent action_policy.tools[<tool_name>] override
-3. Per-agent action_policy.categories[<category>] override
-4. Tool-declared default (tool_def['action_policy'])
-5. Mode preset (chat → 'preview' for publish-family, else 'direct')
-6. Global default: 'direct'
-7. apply_filters('datamachine_tool_action_policy', ...)
-```
+### Pipeline Policy-Gated Tools
 
-`PipelineTranscriptPolicy::shouldPersist()`:
-
-```
-1. flow.flow_config['persist_transcripts']
-2. pipeline.pipeline_config['persist_transcripts']
-3. get_option('datamachine_persist_pipeline_transcripts', false)
-   (no per-tool / per-category / per-agent layer in v1)
-```
-
-The ladders look similar because they are similar. They are not identical, and the differences matter — `PipelineTranscriptPolicy` has no per-agent layer because v1 is scoped to pipelines (see #1226 for the cross-mode generalization that adds one). Don't try to unify the ladder shapes; document each resolver's ladder in its class docblock and keep them visible.
-
-### 4. Categories follow ability linkage
-
-Resolvers that gate by category (`ToolPolicyResolver`, `ActionPolicyResolver`) walk a tool's `ability` and `abilities` keys, look up each slug in `WP_Abilities_Registry::get_instance()`, and read `get_category()` on the ability. A tool's category is whatever its linked ability declares — there is no separate "tool category" registry.
-
-Tools without a linked ability are excluded when category filtering is active (they cannot be categorized) unless explicitly allow-listed. Handler tools (those with a `handler` key but no `ability` key) are the exception: in pipeline mode they are required flow plumbing resolved from adjacent steps, so they bypass agent `tool_policy`, context category filtering, and context `allow_only` filtering. The flow shape decides whether they exist; optional/global tool policy only narrows research and utility tools.
-
-If a publish/upsert handler is required by the adjacent flow shape but no AI-callable handler tool is available, the AI step fails before the model call. Runtime and request inspection both use `FlowStepConfig::getMissingRequiredHandlerSlugsForAi()` so the inspector reports the same failure state the runtime would hit.
-
-### 5. Mode-aware (`pipeline` / `chat` / `system`)
-
-All four resolvers know about agent modes. The preset constants are duplicated across the resolvers on purpose:
+Some tools are safe for chat but too powerful for default pipeline exposure. They declare `pipeline_policy` mode instead of `pipeline` mode.
 
 ```php
-public const MODE_PIPELINE = 'pipeline';
-public const MODE_CHAT     = 'chat';
-public const MODE_SYSTEM   = 'system';
+'modes' => array( 'chat', ToolPolicyResolver::MODE_PIPELINE_POLICY )
 ```
 
-Each resolver applies the mode where it makes sense:
+`DataMachineToolRegistrySource` includes such a tool in a pipeline request only when `ToolPolicyResolver::isPipelinePolicyToolAllowed()` sees the tool name in `allow_only`. In practice, that means the flow-step snapshot's `enabled_tools` list opted in.
 
-- `ToolPolicyResolver` filters tools by their declared `modes` array.
-- `MemoryPolicyResolver` calls `MemoryFileRegistry::get_for_mode()`.
-- `ActionPolicyResolver` defaults publish-family tools to `preview` in `chat` and `direct` in `pipeline` / `system`.
-- `PipelineTranscriptPolicy` is currently pipeline-only; #1226 generalizes it across modes.
+### Pipeline Disabled Tools
 
-Custom mode slugs are allowed. Plugins can register tools / files / policies for arbitrary modes; the resolvers route them through the same paths.
+`PipelineToolPolicyArgs::fromConfigs()` converts snapshot config into resolver args:
 
-### 6. Final `apply_filters()` hook
+| Snapshot config | Resolver arg |
+|---|---|
+| `flow_step_config.enabled_tools` | `allow_only` |
+| `pipeline_step_config.disabled_tools` | `deny` |
+| `flow_step_config.disabled_tools` | `deny` |
 
-Every resolver ends with a `apply_filters()` call so plugins can override the resolved value without subclassing or replacing the resolver. The filter is the public extension point for third parties. The filter names are:
+This keeps direct workflows and historical job runs deterministic. Do not re-read persisted pipeline rows while resolving runtime policy.
 
-- `datamachine_resolved_tools`
-- `datamachine_resolved_memory_files`
-- `datamachine_resolved_scoped_memory_files` (pipeline/flow-scoped path)
-- `datamachine_tool_action_policy`
+## Tool Source Registry
 
-A new resolver follows suit: register a filter named `datamachine_resolved_<thing>` (or similar) and run it as the last step of `resolve()`. This is how DM stays generic — the filter is the only thing third parties have to know about.
+`ToolSourceRegistry` is a composition seam, not a policy resolver. It asks named sources for candidate tools before `ToolPolicyResolver` applies policy.
 
-## What divergence looks like in practice
+Default source order:
 
-Each resolver invented something the others don't have. None of those inventions are wrong — they're shaped to the question.
+| Mode | Sources |
+|---|---|
+| `pipeline` | `adjacent_handlers`, then `static_registry` |
+| `chat` | `static_registry` |
+| `system` | `static_registry` |
+| custom mode | `static_registry` unless `agents_api_tool_sources_for_mode` changes it |
 
-`ToolPolicyResolver` has:
+Extension hooks:
 
-- A `gatherByMode()` step that builds the tool pool differently for `pipeline` (handler tools from adjacent steps) vs other modes (registry filter by declared `modes`).
-- An ability-permission gate (`filterByAbilityPermissions()`) that runs only in `chat` mode.
-- An `access_level` fallback (`public` / `authenticated` / `author` / `editor` / `admin`) for tools without a linked ability.
-- A category-aware `applyAgentPolicy()` that supports `tools[]` and `categories[]` composing in either deny or allow mode.
-- A pipeline handler-tool exception: adjacent handler tools are preserved through agent allow/deny policy and context allow/category filters because they are required flow plumbing, not optional global tools.
+| Hook | Purpose |
+|---|---|
+| `agents_api_tool_sources` | Register source callbacks keyed by source slug. |
+| `agents_api_tool_sources_for_mode` | Select source slugs for a mode. |
 
-`MemoryPolicyResolver` has:
+Data Machine's `datamachine_tools` filter remains the product registry adapted by `DataMachineToolRegistrySource`. The old source filters with Data Machine-specific names are not mirrored.
 
-- Two entry points — `resolveRegistered()` for the core memory file registry and `filter()` for explicit filename lists from `pipeline_config` / `flow_config`. Both share the per-agent policy reader; their precedence ladders diverge slightly.
-- A `default` mode that's a no-op (returned as `null` by the reader).
-- File metadata preservation through filtering so downstream readers see the same `layer` / `priority` / `path` keys after policy is applied.
+## Directive Policy Resolver
 
-`ActionPolicyResolver` has:
+`DirectivePolicyResolver` applies per-agent directive suppression after directives are registered and before prompt assembly continues.
 
-- Three policy values, not a set: `direct` / `preview` / `forbidden`.
-- Tool-declared defaults via `tool_def['action_policy']` and per-mode overrides via `tool_def['action_policy_<mode>']`.
-- A normalization step that returns `''` for unrecognized values so callers can drop them safely.
-- A subtle interaction at step 4: the mode preset can *upgrade* a `direct` tool default to `preview` in chat mode if the tool opts in via `action_policy_chat`, but the tool default still wins for everything else. This is documented in `resolveForTool()` and worth preserving when the resolver evolves.
+Policy shape:
 
-`PipelineTranscriptPolicy` has:
-
-- One method (`shouldPersist()`) returning a `bool`.
-- Reads from flow + pipeline config snapshots already in memory (zero extra DB calls).
-- No per-agent layer in v1. No category. No tool-level opt-in. The transcript is persisted for the *whole step*, not per-invocation, so per-tool granularity isn't meaningful here.
-
-A future generalization (#1226) plausibly adds a `mode` argument and per-agent override but should *not* try to inherit the precedence ladder of any of the other three. Its question is yes/no, and the answer for a yes/no question lives in a different shape from the answer for "filter this set."
-
-## When to bend the convention
-
-The convention is a guide, not a contract. Two existing resolvers already bend it:
-
-- **`PipelineTranscriptPolicy`** reads `pipeline_config` and `flow_config`, not `agent_config`. The reason is that transcript persistence is a *flow-level* concern (different flows on the same agent should be able to opt in independently), and the resolution order is flow > pipeline > site option, not agent > anything. When the question's natural locus isn't the agent, store the policy where it actually belongs and document the deviation in the class docblock.
-- **`ActionPolicyResolver`** allows tools to declare per-mode defaults via `action_policy_chat` / `action_policy_pipeline` / `action_policy_system`. The other resolvers don't have an equivalent — tools don't declare per-mode visibility (`ToolPolicyResolver` reads `modes` on the tool def, but that's a static list, not per-mode behavior). When a tool's default behavior naturally varies by mode, `tool_def[<key>_<mode>]` is the right shape.
-
-Both deviations are documented in the resolver's class docblock. New resolvers should do the same: name what's different from the other three and why.
-
-## Adding a fifth resolver
-
-When a new policy question arises (directive suppression, transcript-across-modes, retention overrides, anything), the recipe is:
-
-1. **Pick the locus.** Where does the policy live? Agent config? Pipeline config? Flow config? Site option? More than one with a precedence ladder? The locus determines the reader.
-2. **Pick the shape of the answer.** Filtered set? Scalar enum? Boolean? Per-invocation classifier? Don't force it to match an existing resolver.
-3. **Write a single-purpose class** in `inc/Engine/AI/<Thing>/<Thing>Policy[Resolver].php` (the `Resolver` suffix is dropped for boolean-toggle resolvers like `PipelineTranscriptPolicy` — it would read awkwardly).
-4. **Write the precedence ladder in the class docblock** before writing code. Higher rules override lower. Document each rung.
-5. **Implement the reader** as a method on the class — `getAgent<Thing>Policy()` if agent-scoped, or whatever name fits the locus. Return `null` for no-op.
-6. **Implement the resolver method** with a clear name — the verb is the question. `shouldPersist()`, `resolveForTool()`, `resolve()` for set filters.
-7. **Register a final `datamachine_resolved_<thing>` filter** as the last step.
-8. **Call from one place** — directly from the call site that consumes the answer. Don't build a generic dispatcher unless multiple call sites would loop over registered policies (none currently do).
-
-Resist these temptations:
-
-- ❌ Extracting `AbstractAgentPolicy` / a base class. The resolvers don't share a return type. Inheritance enforces uniformity that the problems reject.
-- ❌ Building a "policy registry" or "policy dispatcher" before any consumer iterates over policies generically. Each call site knows which policy it cares about and calls it directly.
-- ❌ Forcing the new resolver's ladder shape to match an existing one. The shape should follow the question.
-- ❌ Reading from `agent_config` reflexively. If the natural locus is somewhere else, store it somewhere else.
-
-If two resolvers later turn out to share *both* the same return shape *and* the same input shape *and* are consumed polymorphically by some new system that loops over registered policies — *then* extract a trait. Even then, prefer a trait (mixin-style, additive) over a base class (locks the hierarchy).
-
-## Where the resolvers live
-
+```json
+{
+  "directive_policy": {
+    "mode": "deny",
+    "deny": ["CoreMemoryFilesDirective"],
+    "modes": ["pipeline"]
+  }
+}
 ```
+
+Supported modes are:
+
+| Policy mode | Effect |
+|---|---|
+| `default` | No-op. |
+| `deny` | Suppress matching directive classes. |
+| `allow_only` | Keep only matching directive classes. |
+
+Policy entries match either the fully-qualified class name or the short class name. The optional `modes` list scopes the directive policy to request modes. The resolver returns both the filtered directive list and the suppressed short names for observability.
+
+Final filter: `datamachine_resolved_directives`.
+
+## Action Policy Resolver
+
+`ActionPolicyResolver` answers a different question from tool policy. Tool policy decides whether the model can see a tool. Action policy decides what happens after the model calls it.
+
+Values use the Agents API vocabulary:
+
+| Value | Meaning |
+|---|---|
+| `direct` | Execute immediately. |
+| `preview` | Stage through `PendingActionHelper` and return an approval-required envelope. |
+| `forbidden` | Refuse the invocation. |
+
+Resolution order:
+
+1. Explicit `deny` context list.
+2. Per-agent `agent_config.action_policy.tools[tool_name]`.
+3. Per-agent `agent_config.action_policy.categories[category]`.
+4. Tool-declared default, including per-mode keys such as `action_policy_chat`.
+5. Mode provider default from `DataMachineModeActionPolicyProvider`.
+6. Agents API global default.
+7. `datamachine_tool_action_policy` filter.
+
+`ToolExecutor` enforces the result. `preview` requires the tool definition to declare `action_kind`; otherwise Data Machine logs a warning and falls back to direct execution because it cannot safely synthesize replay semantics.
+
+## Pending Action Helper
+
+`PendingActionHelper` is the staging helper used when action policy resolves to `preview`. It writes a pending action via `PendingActionStore`, fires `datamachine_pending_action_staged`, and returns an Agents API `approval_required` message.
+
+The approval envelope includes `pending_action`, `resolve_with`, `resolve_params`, and user-facing instructions. It also carries top-level `staged` and `action_id` compatibility fields for internal callers.
+
+Tools should provide self-contained `apply_input`. The accepted/rejected resolution path replays the stored input through the registered pending action handler, so preview staging must not depend on transient local variables.
+
+## Memory and Transcript Policies
+
+`MemoryPolicyResolver` keeps the same convention but filters memory file sets rather than tools. It has two paths: registered memory files for a mode and explicit memory lists from pipeline/flow configuration.
+
+`PipelineTranscriptPolicy` bends the convention because transcript persistence is scoped to a pipeline run, not to an individual agent tool or memory file. It reads flow config, then pipeline config, then the site option.
+
+## Adding Another Resolver
+
+Use this pattern when adding a new policy question:
+
+1. Pick the locus: agent config, flow config, pipeline config, site option, or request context.
+2. Pick the return shape that answers the question directly.
+3. Normalize invalid or no-op policy to `null` where possible.
+4. Write the precedence order in the class docblock before implementing it.
+5. Keep the public method named after the question, such as `resolve()`, `resolveForTool()`, or `shouldPersist()`.
+6. Add a final filter for extension points.
+7. Call the resolver from the one runtime path that consumes the answer.
+
+Avoid a shared base class unless a real consumer needs to handle multiple policies polymorphically and they share both input and output shapes. That is not true for the current resolvers.
+
+## Files
+
+```text
 inc/Engine/AI/Tools/ToolPolicyResolver.php
+inc/Engine/AI/Tools/ToolSourceRegistry.php
 inc/Engine/AI/Memory/MemoryPolicyResolver.php
+inc/Engine/AI/Directives/DirectivePolicyResolver.php
 inc/Engine/AI/Actions/ActionPolicyResolver.php
+inc/Engine/AI/Actions/PendingActionHelper.php
 inc/Engine/AI/PipelineTranscriptPolicy.php
+inc/Core/Steps/AI/ToolPolicy/PipelineToolPolicyArgs.php
 ```
 
-Each is a single file, single class, single responsibility. Class docblocks carry the precedence ladder. Class methods carry the per-step rationale. There is no shared parent, no shared interface, and no shared trait — only a shared shape that's documented here.
+## Related Docs
 
-## Related issues
-
-- #1101 — DirectivePolicy exploration. Names the "abstraction-on-N=2 risk" trap that this doc encodes at N=4. Keep the warning live; it applies to every Nth resolver.
-- #1226 — generalize `PipelineTranscriptPolicy` across agent modes. The PR for that issue is the next chance to set the cross-mode pattern; this doc is the design context for that work.
-- #972 — refactor chat tool policy for per-user dynamic toolsets. Belongs to `ToolPolicyResolver`'s evolution; doesn't touch the convention.
+- [Tool Manager](../core-system/tool-manager.md)
+- [Tool Execution Architecture](../core-system/tool-execution.md)
+- [Memory Policy](../core-system/memory-policy.md)

--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -13,12 +13,13 @@ Agent bundles are portable, versioned packages for an agent's runtime behavior. 
 ├── prompts/<prompt-slug>.md
 ├── rubrics/<rubric-slug>.md
 ├── tool-policies/<policy-slug>.json
+├── auth-refs/<auth-ref-slug>.json
 ├── seed-queues/<queue-slug>.json
 ├── extensions/
 └── <extras-key>/                     # Plugin-owned opaque extras (e.g. wiki/, datasets/)
 ```
 
-Only `manifest.json`, `pipelines/`, `flows/`, and `memory/` have import/export adapters today. The remaining directories are reserved schema surface for prompts, rubrics, tool policies, auth references, seed queue artifacts, and plugin-owned extension artifacts.
+`manifest.json`, `memory/`, `pipelines/`, `flows/`, `prompts/`, `rubrics/`, `tool-policies/`, `auth-refs/`, `seed-queues/`, and `extensions/` are first-class bundle schema. Unknown top-level directories are transported as plugin-owned extras.
 
 ### Reserved Trees And Extras
 
@@ -93,6 +94,8 @@ See `Automattic/intelligence#467` for the reference consumer that claims the `wi
 - `full`: reserved for encrypted credential exports.
 - `omit`: omit handler auth material.
 
+`run_artifacts` is an optional manifest-level default egress policy. Individual flow files can also declare `run_artifacts`; flow-level policy wins for that flow. See [Run Artifact Egress](#run-artifact-egress).
+
 ## Artifact Tracking
 
 Bundle installs track artifacts independently of their runtime table. The foundation record shape is:
@@ -134,6 +137,13 @@ Memory artifacts can be tracked at section granularity. Section records extend t
 
 Self-memory writes are policy-constrained: the default target is the current acting agent, allowed section types are operational (`operating_note`, `source_quirk`, `run_lesson`, `task_note`), durable facts are rejected, and bundle-owned sections are staged through PendingActions instead of overwritten directly.
 
+Bundle section artifacts are the bridge between seed memory and safe runtime learning:
+
+- `MemorySectionArtifact::from_bundle_section()` records bundle-owned sections with install-time hashes.
+- `can_auto_update_from_bundle()` is true only while a bundle-owned section is still clean.
+- `should_stage_bundle_update()` is true when the section was locally modified after install.
+- Runtime self-memory writes that target a bundle-owned section stage a PendingAction instead of replacing the section.
+
 ## Pipeline And Flow Updates
 
 Bundle-installed pipelines and flows use stable `portable_slug` values as their runtime identity:
@@ -144,6 +154,15 @@ Bundle-installed pipelines and flows use stable `portable_slug` values as their 
 - Local edits are detected by comparing the current artifact hash with the install-time hash recorded in the owning agent's `datamachine_bundle.artifacts` config.
 - Installed artifact tracking is persisted in the site-scoped `datamachine_bundle_artifacts` table, keyed by `(agent_id, bundle_slug, artifact_type, artifact_id)`, so bundle state is independent of runtime tables.
 - Modified artifacts are reported as conflicts and are not overwritten by the import path.
+
+Upgrade planning groups artifacts into deterministic buckets:
+
+- `auto_apply`: new artifacts with no local value, or artifacts whose current hash still matches the installed hash.
+- `needs_approval`: untracked local artifacts or locally modified artifacts.
+- `warnings`: missing local artifacts and installed artifacts absent from the target bundle.
+- `no_op`: current artifact already matches the target.
+
+`install` creates new package-backed agents. `upgrade` applies clean updates and stages review-required changes through `AgentBundleUpgradePendingAction` with kind `bundle_upgrade`. `diff` runs the same planner without mutation. Applying a bundle PendingAction only applies explicitly approved artifact keys; unapproved entries are skipped, and consumers write storage through the registered artifact handlers or the `datamachine_bundle_upgrade_apply_artifact` filter.
 
 Schedule and queue policy is intentionally conservative:
 
@@ -158,6 +177,50 @@ Portable flow-step policy fields are explicit in `flows/<flow-slug>.json`:
 - `prompt_queue`: AI seed queue entries shaped as `{ "prompt": "...", "added_at": "..." }`.
 - `config_patch_queue`: fetch seed queue entries shaped as `{ "patch": { ... }, "added_at": "..." }`.
 - `queue_mode`: one of `drain`, `loop`, or `static`; shared by both queue slots on that flow step.
+
+## Run Artifact Egress
+
+`run_artifacts` declares which runtime artifacts a bundle consumer may surface after a job. Data Machine validates and stores the policy; downstream runtimes such as Data Machine Code decide how to materialize egress targets like PR bodies or bundle files.
+
+Supported sources:
+
+- `completion_assertions`
+- `daily_memory`
+- `transcript_summary`
+
+Supported egress targets:
+
+- `artifact` — retain in the job artifact payload.
+- `bundle-file` — allow a consumer to write the artifact into a bundle-relative file.
+- `pr-body` — allow a consumer to summarize the artifact in a PR body or review surface.
+
+Example:
+
+```json
+{
+  "run_artifacts": {
+    "daily_memory": {
+      "egress": ["artifact", "bundle-file", "pr-body"],
+      "bundle_relative_path": "memory/agent/daily/{yyyy}/{mm}/{dd}.md"
+    }
+  }
+}
+```
+
+Normalization drops unknown sources, unknown egress targets, duplicate targets, and unsafe bundle-relative paths. Data Machine does not execute GitHub-specific behavior from this policy; it only preserves a deterministic egress contract for consumers.
+
+During AI conversation loops, successful tool calls can add in-flight run artifacts before job persistence. `JobArtifacts` maps `agent_memory` and `agent_daily_memory` writes to canonical bundle-relative paths so DMC or other package consumers can export the evidence without scraping transcripts.
+
+## Extras Vs Extension Artifacts
+
+Bundles have two plugin-extension surfaces with different contracts:
+
+| Surface | Location | Shape | Data Machine behavior | Use when |
+|---|---|---|---|---|
+| Extras | Any unreserved top-level directory, exposed under `bundle["extras"]` | Opaque file map keyed by top-level directory | Transport only; consumer persists via `datamachine_bundle_install_succeeded` | A plugin owns a directory tree such as `wiki/` or `datasets/` |
+| Extension artifacts | `extensions/**/*.json`, exposed as `extension_artifacts` | Typed artifact envelopes with `artifact_type`, `artifact_id`, `source_path`, payload/hash fields | Normalized, included in package projection, upgrade planning, and artifact handlers | A plugin wants artifact diffing, upgrade conflict detection, and PendingAction apply semantics |
+
+Use extras for bulk opaque content where Data Machine should not inspect individual files. Use extension artifacts when each item needs stable identity, hashes, status, and upgrade behavior.
 
 ## CLI
 
@@ -185,6 +248,8 @@ Public archives install with no configuration. Private GitHub repositories, GitH
 5. **Generic per-request filter** — `datamachine_bundle_source_download_args` for arbitrary header injection (any host, any auth scheme).
 
 Data Machine **never persists tokens itself.** Storage and rotation live in the host plugin or operator's environment. Errors that surface from a failed download include the URL but never the `Authorization` header — see `BundleSourceAuth::redact_args_for_log()` if you log the args downstream.
+
+CLI token flags are resolved into the bundle-source context for that one import/diff/upgrade request only. `--token-env=<varname>` reads the token from the named environment variable and avoids placing the token in shell history. The internal download args carry private `datamachine_bundle_source` metadata until auth injection finishes; that metadata is stripped before the HTTP request is made.
 
 ### Example 1 — github.com private archive via env var
 
@@ -241,8 +306,9 @@ Or hook the lower-cost `datamachine_bundle_source_token_for_url` fallback when y
 
 For GitHub archive responses, `BundleSource::fetch_to_tempfile()` reads the response `ETag` header and parses the git SHA out of the `W/"<sha>:<format>"` (or bare `"<sha>"`) shape GitHub serves. When present and parseable the SHA is exposed via `BundleSource::last_resolved_revision()` and stamped onto the bundle as `source_revision`. Best-effort only — installs do not fail when the ETag is absent or unparseable.
 
-## Follow-Ups
+## See Also
 
-- Wire importer/exporter paths for prompts, rubrics, tool policies, auth refs, and seed queues.
-- Use artifact statuses during bundle upgrade planning: auto-update `clean`, stage PendingActions for `modified`, surface `missing` and `orphaned` explicitly.
-- Add registered bundle sources once bundles move beyond local paths.
+- [Memory Policy](./memory-policy.md) — policy gates for memory injection and self-memory writes.
+- [Daily Memory System](./daily-memory-system.md) — daily-memory storage, compaction, and artifacts.
+- [Pending Actions](./pending-actions.md) — approval envelopes used for bundle upgrades and protected memory writes.
+- [Agent Memory Backends](../architecture/agent-memory-backends.md) — logical memory identity and backend projection.

--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -227,10 +227,13 @@ Use extras for bulk opaque content where Data Machine should not inspect individ
 Agent package operations live under `wp datamachine agent`:
 
 - `install <path|url>` imports a local bundle path (`.zip`, `.json`, or directory) or a remote URL.
+- `import <path|url>` imports a portable agent export and creates a new agent.
+- `export <agent>` writes an agent identity, memory, pipelines, and flows to a portable bundle.
 - `installed` reports installed package-backed agents without clobbering `agent list`.
 - `status <slug>` reports installed version and tracked artifact state by agent slug or bundle slug.
 - `diff <path|url>` builds a read-only upgrade plan.
 - `upgrade <path|url>` applies clean updates and stages locally modified artifacts as PendingActions.
+- `rebase <path|url>` previews 3-way merges for locally modified bundle artifacts.
 - `apply <pending_action_id>` accepts a staged bundle PendingAction.
 
 Every read/preview command supports `--format=json` for automation.

--- a/docs/core-system/ai-conversation-loop.md
+++ b/docs/core-system/ai-conversation-loop.md
@@ -520,6 +520,6 @@ Set appropriate max turns based on workflow complexity:
 ## Related Components
 
 - Universal Engine Architecture - Overall engine structure
-- Tool Execution Architecture - ToolExecutor details
+- [Tool Execution Architecture](tool-execution.md) - ToolExecutor details
 - RequestBuilder Pattern - AI request construction
 - [ConversationManager](universal-engine.md#conversationmanager) - Message formatting utilities

--- a/docs/core-system/daily-memory-system.md
+++ b/docs/core-system/daily-memory-system.md
@@ -78,58 +78,82 @@ $daily = new DailyMemory(user_id: 0, agent_id: 42);
 **Source:** `inc/Engine/AI/System/Tasks/DailyMemoryTask.php`
 **Since:** v0.32.0
 
-An AI-powered system task that runs daily via Action Scheduler. It has two phases:
+An AI-powered system task that runs daily via Action Scheduler. The task lifecycle is deterministic around one optional AI compaction call:
 
-### Phase 1: Activity Synthesis
+1. Exit cleanly when `daily_memory_enabled` is false.
+2. Resolve the target date, user, agent, and system-mode model.
+3. Read the agent's `MEMORY.md`; empty or missing memory is a skipped job.
+4. Run deterministic overflow handling when `MEMORY.md` is extremely large.
+5. Gather same-day Data Machine activity for the prompt's `activity_section`.
+6. Skip when `MEMORY.md` is within budget and there is no activity context.
+7. Run the single `daily_memory` prompt, parse `===PERSISTENT===` and `===ARCHIVED===`, apply safety gates, rewrite `MEMORY.md`, and append archived content to the daily file.
 
-Gathers the day's activity from Data Machine (completed jobs and chat sessions) and uses AI to synthesize a concise daily memory entry.
+### Activity Context
+
+The task gathers same-day Data Machine activity and injects it into the single maintenance prompt as `{{activity_section}}`. Activity context is supporting material for compaction; it is not a separate summary prompt.
 
 **Data sources:**
 - `datamachine_jobs` — pipeline and system jobs created on the target date (job_id, pipeline_id, flow_id, source, label, status)
 - `datamachine_chat_sessions` — chat sessions created on the target date (session_id, title, context)
 
 **Process:**
-1. Query jobs and chat sessions for the target date
-2. Format as structured context with `## Jobs completed on YYYY-MM-DD` and `## Chat sessions on YYYY-MM-DD` sections
-3. Send to AI with the `daily_summary` prompt template
-4. Append the AI-generated summary to the day's daily memory file
+1. Query jobs and chat sessions for the target date.
+2. Format as structured context with `## Jobs completed on YYYY-MM-DD` and `## Chat sessions on YYYY-MM-DD` sections.
+3. Wrap that context in `## Today's Activity` and pass it as `{{activity_section}}`.
 
-If no DM activity occurred (empty context), Phase 1 is skipped. Phase 2 still runs because most agent work happens via external tools (e.g. Kimaki sessions) that don't create DM jobs.
+If no Data Machine activity occurred and `MEMORY.md` is already within `AgentMemory::MAX_FILE_SIZE`, the task completes as a skipped no-op. External tools such as Kimaki can still write temporal details directly with `agent_daily_memory`.
 
-### Phase 2: MEMORY.md Cleanup
+### MEMORY.md Compaction
 
 Reads the full MEMORY.md file and uses AI to split it into persistent knowledge (stays) and session-specific content (archived to the daily file). This keeps MEMORY.md lean for the context window budget.
 
 **Process:**
 1. Read MEMORY.md via `AgentMemory` service
-2. **Skip if within budget** — if file size ≤ `AgentMemory::MAX_FILE_SIZE` (8192 bytes / 8 KB), no cleanup needed
-3. Send to AI with the `memory_cleanup` prompt template
-4. Parse AI response into `===PERSISTENT===` and `===ARCHIVED===` sections
-5. **Safety check** — verify the new content isn't suspiciously small:
+2. **Deterministic overflow first** — if the file is over `datamachine_daily_memory_overflow_threshold` (default: 4x `AgentMemory::MAX_FILE_SIZE`), archive whole tail sections verbatim and write an archive pointer without invoking AI
+3. **Skip if within budget and no activity** — if file size ≤ `AgentMemory::MAX_FILE_SIZE` (8192 bytes / 8 KB) and `activity_section` is empty, no cleanup needed
+4. Send to AI with the `daily_memory` prompt template
+5. Parse AI response into `===PERSISTENT===` and `===ARCHIVED===` sections
+6. **Safety check** — verify the new content isn't suspiciously small:
    - If file is >2x over budget: allow reduction down to half the target size (4 KB minimum)
    - If file is near budget: don't allow reduction below 10% of original size
-6. Write cleaned content back to MEMORY.md
-7. Append archived content to the daily file under `### Archived from MEMORY.md`
+7. **Conservation check** — verify persistent + archived output accounts for at least 85% of the original by byte size, unless `datamachine_daily_memory_conservation_threshold` changes the threshold
+8. Write cleaned content back to MEMORY.md
+9. Append archived content to the daily file under `### Archived from MEMORY.md`
 
-**Failure handling:** Cleanup failures are logged but never fail the overall job. The daily summary (Phase 1) is already written. Key safety rules:
+### Deterministic Overflow
+
+Very large `MEMORY.md` files can exceed provider request limits. Before the AI call, `maybeHandleDeterministicOverflow()` checks `datamachine_daily_memory_overflow_threshold` (default: `AgentMemory::MAX_FILE_SIZE * 4`). When the file is above that threshold, the task uses `WP_Agent_Markdown_Section_Compaction_Adapter` to split the markdown by sections:
+
+- Retained sections stay in `MEMORY.md` up to `datamachine_daily_memory_overflow_target_size` (default: `AgentMemory::MAX_FILE_SIZE`).
+- Archived sections are appended verbatim to `daily/YYYY/MM/DD.md` under `### Archived from oversized MEMORY.md`.
+- A persistent `Archived Memory Overflow` pointer remains in `MEMORY.md`, pointing to the daily artifact path.
+- Conservation is enabled in the section adapter so overflow handling preserves content instead of summarizing it.
+
+When deterministic overflow handles the file, the job completes with `overflow_split: true` and does not run the AI prompt.
+
+**Failure handling:** compaction failures leave `MEMORY.md` unchanged and fail the job so operators can inspect the reason. Key safety rules:
 - Never wipe MEMORY.md if the AI response can't be parsed
 - Never write if the persistent section is empty
 - Never write if the new content is suspiciously small (safety threshold check)
+- Never write if the conservation check indicates the model discarded too much content
 
 ### Editable Prompts
 
-DailyMemoryTask defines two customizable prompts via `getPromptDefinitions()`:
+DailyMemoryTask defines one customizable prompt via `getPromptDefinitions()`:
 
-**`daily_summary`** — Synthesizes the day's DM activity into a concise entry.
-- Variable: `{{context}}` — gathered activity from jobs and chat sessions
+**`daily_memory`** — Maintains `MEMORY.md`, splitting persistent vs. session-specific content while considering same-day activity.
 
-**`memory_cleanup`** — Splits MEMORY.md into persistent vs. session-specific content.
-- Variables: `{{memory_content}}` (current MEMORY.md), `{{date}}` (target date), `{{max_size}}` (recommended limit, e.g. "8 KB")
+Variables:
+
+- `{{memory_content}}` — current full `MEMORY.md` content.
+- `{{date}}` — target archive date in `YYYY-MM-DD` format.
+- `{{max_size}}` — recommended persistent memory limit, e.g. `8 KB`.
+- `{{activity_section}}` — optional `## Today's Activity` section generated from jobs and chat sessions.
 
 Prompts can be overridden via the System Tasks admin tab or programmatically:
 
 ```php
-SystemTask::setPromptOverride('daily_memory_generation', 'memory_cleanup', 'Your custom prompt...');
+SystemTask::setPromptOverride('daily_memory_generation', 'daily_memory', 'Your custom prompt...');
 ```
 
 ### Scheduling
@@ -155,7 +179,7 @@ Upgrading sites have any pending action under the pre-refactor hook
 ```php
 [
     'label'           => 'Daily Memory',
-    'description'     => 'AI-generated daily summary of activity and automatic MEMORY.md cleanup',
+    'description'     => 'Automated MEMORY.md maintenance -- archives session-specific content to daily files, compresses and cleans persistent knowledge.',
     'setting_key'     => 'daily_memory_enabled',
     'default_enabled' => false,
     'supports_run'    => true,
@@ -277,7 +301,7 @@ The directive only injects *recent* days on a rolling window. Anything beyond `r
 **Tool ID:** `agent_daily_memory`
 **Contexts:** `chat`, `pipeline`, `standalone`
 
-An AI chat tool that lets agents manage their own daily memory during conversations. Always available (no external configuration required).
+An AI chat tool that lets agents manage their own daily memory during conversations. It is registered for chat and pipeline-policy contexts, then gated by normal tool policy and by the underlying daily-memory abilities. Read/list/search availability follows the ability permission path; writes also respect `daily_memory_enabled` through `DailyMemoryAbilities`.
 
 ### Tool Schema
 
@@ -291,6 +315,8 @@ An AI chat tool that lets agents manage their own daily memory during conversati
 | `query` | string | no | Search term (required for `search`) |
 | `from` | string | no | Start date for search range |
 | `to` | string | no | End date for search range |
+
+The tool resolves the acting scope from the tool call plus the active agent context. It passes explicit `user_id` and `agent_id` to abilities so writes land in the selected agent's daily-memory tree rather than a global file.
 
 ### Delegation
 
@@ -306,6 +332,17 @@ The tool delegates to WordPress Abilities:
 ### Usage Guidance (from tool description)
 
 > Use for session activity, temporal events, and work logs. Daily memory captures WHAT HAPPENED — persistent knowledge belongs in agent_memory (MEMORY.md) instead.
+
+## Daily Memory Artifacts
+
+Daily memory writes can become job artifacts for package consumers. During the AI conversation loop, successful tool calls are summarized and passed into `JobArtifacts`. For each successful `agent_daily_memory` write, `JobArtifacts`:
+
+1. Resolves the target agent, user, and date.
+2. Reads the written `daily/YYYY/MM/DD.md` file through `DailyMemory`.
+3. Falls back to the tool-call content with a `# Daily Memory: YYYY-MM-DD` heading when the file cannot be read.
+4. Emits an artifact with `type: agent_daily_memory`, `source: daily-memory`, `bundle_relative_path: memory/agent/daily/YYYY/MM/DD.md`, and the file content.
+
+Bundles can declare `run_artifacts.daily_memory` egress policy to let downstream runtimes preserve these artifacts in bundle files, job artifacts, or PR bodies. Data Machine validates the policy and builds deterministic artifact payloads; consumers decide where those payloads leave the system.
 
 ## REST API
 

--- a/docs/core-system/handler-registration-trait.md
+++ b/docs/core-system/handler-registration-trait.md
@@ -4,7 +4,7 @@ Standardized handler registration trait introduced in v0.2.2 that eliminates ~70
 
 ## Overview
 
-HandlerRegistrationTrait (`/inc/Core/Steps/HandlerRegistrationTrait.php`) provides a single `registerHandler()` method that automatically registers handlers with all required WordPress filters.
+[`HandlerRegistrationTrait`](../../inc/Core/Steps/HandlerRegistrationTrait.php) provides a single `registerHandler()` method that automatically registers handlers with the core WordPress filters Data Machine uses for handler discovery, settings, auth providers, and deferred handler tools.
 
 ## Architecture
 
@@ -29,14 +29,15 @@ protected static function registerHandler(
     ?string $auth_class = null,
     ?string $settings_class = null,
     ?callable $tools_callback = null,
-    ?string $authProviderKey = null
+    ?string $authProviderKey = null,
+    array $meta = []
 ): void
 ```
 
 ### Parameters
 
 - **$handler_slug**: Unique identifier for the handler (e.g., 'twitter', 'rss')
-- **$handler_type**: Handler type ('fetch', 'publish', 'update')
+- **$handler_type**: Handler type (`'fetch'`, `'publish'`, or `'upsert'`)
 - **$handler_class**: Fully qualified class name for the handler
 - **$label**: Display name for admin interface (translatable)
 - **$description**: Handler description for admin interface (translatable)
@@ -45,6 +46,7 @@ protected static function registerHandler(
 - **$settings_class**: Fully qualified settings class name
 - **$tools_callback**: Callback for AI tool registration
 - **$authProviderKey**: Optional auth provider key override for shared authentication. When set, the handler metadata includes `auth_provider_key`, and the auth provider is registered under this key.
+- **$meta**: Optional arbitrary metadata passed through to handler discovery APIs, for example character limits or media limits.
 
 ## Filters Registered
 
@@ -55,16 +57,22 @@ The trait automatically registers handlers with the following WordPress filters:
 Handler metadata registration (always registered).
 
 ```php
-add_filter('datamachine_handlers', function($handlers) {
+add_filter('datamachine_handlers', function($handlers, $step_type = null) {
+    if (null !== $step_type && $step_type !== $handler_type) {
+        return $handlers;
+    }
+
     $handlers[$handler_slug] = [
         'type' => $handler_type,
         'class' => $handler_class,
         'label' => $label,
         'description' => $description,
-        'requires_auth' => $requires_auth
+        'requires_auth' => $requires_auth,
+        'auth_provider_key' => $requires_auth ? $provider_key : null,
+        'meta' => $meta,
     ];
     return $handlers;
-});
+}, 10, 2);
 ```
 
 ### 2. datamachine_auth_providers
@@ -78,22 +86,26 @@ Auth providers are keyed by **provider key**, not necessarily the handler slug.
 
 ```php
 // Only registered if requires_auth is true
-add_filter('datamachine_auth_providers', function($providers) use ($provider_key) {
-    $providers[$provider_key] = new $auth_class();
+add_filter('datamachine_auth_providers', function($providers, $step_type = null) use ($provider_key) {
+    if (null === $step_type || $step_type === $handler_type) {
+        $providers[$provider_key] = $providers[$provider_key] ?? new $auth_class();
+    }
     return $providers;
-});
+}, 10, 2);
 ```
+
+Portable bundles may export credential-bearing handler config as `auth_ref`. Publish and upsert base classes resolve that reference at runtime with `AuthRefHandlerConfig::resolve_runtime_config()` before calling the handler-specific execution method. The registration trait only registers the provider and advertises `auth_provider_key`; it does not resolve credentials itself.
 
 ### 3. datamachine_handler_settings
 
 Settings class registration (always registered if settings_class provided).
 
 ```php
-add_filter('datamachine_handler_settings', function($settings, $handler_slug_param) {
-    if ($handler_slug_param === $handler_slug) {
-        return $settings_class;
+add_filter('datamachine_handler_settings', function($all_settings, $handler_slug_param = null) {
+    if (null === $handler_slug_param || $handler_slug_param === $handler_slug) {
+        $all_settings[$handler_slug] = new $settings_class();
     }
-    return $settings;
+    return $all_settings;
 }, 10, 2);
 ```
 
@@ -118,8 +130,13 @@ add_filter('datamachine_tools', function($tools) use ($slug, $tools_callback) {
 });
 ```
 
-The callback receives `(string $handler_slug, array $handler_config, array $engine_data)`
-and returns `['tool_name' => $tool_definition]` (empty array to opt out).
+The preferred direct-style callback receives `(string $handler_slug, array $handler_config, array $engine_data)` and returns `['tool_name' => $tool_definition]` (empty array to opt out).
+
+Existing filter-style callbacks are also supported. `ToolManager::resolveHandlerTools()` invokes callbacks with `($tools, $handler_slug, $handler_config, $engine_data)` when reflection detects four or more parameters, or a first parameter named `$tools` or `$all_tools`.
+
+Handler tool matching is exact by default: a registry entry with `'handler' => 'wordpress_publish'` is resolved only for adjacent steps whose handler slug is exactly `wordpress_publish`. Cross-cutting tools can use `'handler_types' => ['fetch', 'event_import']`; those are matched against `datamachine_handlers` metadata.
+
+`_handler_callable` entries are deferred registry entries. They are not directly executable tools and should not include normal tool parameters at the wrapper level. The callback returns the executable tool definitions.
 
 ## Usage Example
 
@@ -197,7 +214,7 @@ class WordPressUpdateFilters {
     public static function register(): void {
         self::registerHandler(
             'wordpress_update',
-            'update',
+            'upsert',
             WordPressUpdate::class,
             __('WordPress Update', 'datamachine'),
             __('Update existing WordPress content', 'datamachine'),
@@ -256,8 +273,8 @@ Custom handlers should adopt this pattern by:
 
 3. **Move tool registration to callback parameter**:
    ```php
-   // Receives (handler_slug, handler_config, engine_data) and returns
-   // [tool_name => definition]. The trait handles routing to the adjacent
+    // Receives (handler_slug, handler_config, engine_data) and returns
+    // [tool_name => definition]. The trait handles exact-slug routing to the adjacent
    // step's handler — no manual slug check needed.
    function($handler_slug, $handler_config, $engine_data) {
        return [
@@ -375,12 +392,21 @@ self::registerHandler(
 - IDE autocomplete support for all parameters
 - PHP type hints prevent registration errors
 
+## Core vs Extension Boundaries
+
+- Core owns `HandlerRegistrationTrait`, `datamachine_handlers`, `datamachine_handler_settings`, `datamachine_auth_providers`, and deferred `_handler_callable` resolution.
+- Extensions own concrete handler classes, settings classes, auth provider classes, and executable tool definitions.
+- Extensions should register exact handler slugs. Core does not perform fuzzy slug matching.
+- Extensions should use `handler_types` only for cross-cutting tools that intentionally apply to every handler of a registered type.
+- Extensions can export portable auth config as `auth_ref`; core resolves it at runtime before fetch, publish, and upsert handler execution.
+
 ## See Also
 
-- Core Filters - Complete filter reference
-- Fetch Handler - Fetch handler base class
-- Publish Handler - Publish handler base class
-- Settings Handler - Settings base classes
+- [Core Filters](../development/hooks/core-filters.md) - Complete filter reference
+- [`FetchHandler`](../../inc/Core/Steps/Fetch/Handlers/FetchHandler.php) - Fetch handler base class
+- [`PublishHandler`](../../inc/Core/Steps/Publish/Handlers/PublishHandler.php) - Publish handler base class
+- [`UpsertHandler`](../../inc/Core/Steps/Upsert/Handlers/UpsertHandler.php) - Upsert handler base class
+- [`SettingsHandler`](../../inc/Core/Steps/Settings/SettingsHandler.php) - Settings base class
 
 ## Related Documentation
 

--- a/docs/core-system/memory-policy.md
+++ b/docs/core-system/memory-policy.md
@@ -15,6 +15,8 @@ Two shapes of agent:
 
 MemoryPolicy lets the stateless shape declare its posture in config, travel with the agent through bundle export/import, and apply uniformly across every memory injection surface.
 
+Daily memory has a separate opt-in switch at `agent_config.daily_memory`. MemoryPolicy controls registered and scoped memory files such as `MEMORY.md`, `SOUL.md`, `USER.md`, and configured context files; `AgentDailyMemoryDirective` separately decides whether recent daily archive files are injected at priority 35. Both settings travel in `agent_config` so bundles can preserve a stateful agent's memory posture without making daily memory a global default.
+
 ## How it fits
 
 Data Machine already has a layered memory injection system. MemoryPolicy does not replace it — it is a subtractive filter that applies across all three existing layers.
@@ -162,6 +164,21 @@ Parallel structure, parallel mental model:
 
 Same precedence model, same extension points, same per-agent config home. An agent's portable definition bundles both policies together with its pipelines, flows, and identity files.
 
+## Safe self-memory writes
+
+The `datamachine/agent-memory-self-write` ability is narrower than general file editing. It exists so an acting agent can record operational lessons without silently rewriting durable knowledge or another agent's memory.
+
+Policy gates in `SelfMemoryWritePolicy` are applied before `AgentMemory` writes:
+
+- An active acting-agent context is required.
+- The target defaults to the current agent; cross-agent writes require `datamachine_self_memory_allow_cross_agent_write` delegation.
+- Durable fact section types (`fact`, `domain_fact`, `wiki_fact`, `knowledge`) are rejected. Those belong in wiki or graph tools.
+- Allowed operational section types default to `operating_note`, `source_quirk`, `run_lesson`, and `task_note`, filterable through `datamachine_self_memory_allowed_section_types`.
+- Bundle-owned memory sections are staged as PendingActions instead of overwritten directly.
+- Sensitive section types or explicit `requires_approval` requests are also staged as PendingActions.
+
+Section ownership is represented by `MemorySectionArtifact` with owners `bundle`, `user`, `runtime`, and `compaction`. Bundle-owned sections carry `bundle_slug`, `bundle_version`, `installed_hash`, `current_hash`, and `local_status`, so clean bundle sections can auto-update while modified sections are preserved for review.
+
 ## See also
 
 - [WordPress as Agent Memory](./wordpress-as-agent-memory.md) — the full memory architecture
@@ -169,3 +186,5 @@ Same precedence model, same extension points, same per-agent config home. An age
 - [Tool Manager](./tool-manager.md) — tool resolution and ToolPolicy reference
 - [Multi-Agent Architecture](./multi-agent-architecture.md) — `agent_config` and per-agent settings
 - [Import/Export](./import-export.md) — `AgentBundler` and bundle round-trips
+- [Agent Bundles](./agent-bundles.md) — bundle artifact tracking, memory section artifacts, and upgrade conflict handling
+- [Daily Memory System](./daily-memory-system.md) — daily archive storage, directive opt-in, and the `agent_daily_memory` tool

--- a/docs/core-system/request-builder.md
+++ b/docs/core-system/request-builder.md
@@ -480,5 +480,5 @@ add_filter('datamachine_directives', function($directives) {
 - Universal Engine Architecture - Overall engine structure
 - AI Conversation Loop - Uses RequestBuilder for AI requests
 - PromptBuilder Pattern - Unified directive management
-- Tool Execution Architecture - Tool discovery and execution
+- [Tool Execution Architecture](tool-execution.md) - Tool discovery, execution, action policy, and approval staging
 - Universal Engine Filters - Complete filter reference

--- a/docs/core-system/system-tasks.md
+++ b/docs/core-system/system-tasks.md
@@ -260,7 +260,7 @@ Defines the admin UI fields. The task dropdown is populated from `TaskRegistry::
 **Source:** `inc/Engine/AI/System/Tasks/DailyMemoryTask.php`
 **Undo:** No
 
-AI-generated daily summary of agent activity plus automatic MEMORY.md cleanup. Two-phase execution: Phase 1 synthesizes the day's jobs and chat sessions into a daily entry; Phase 2 uses AI to split MEMORY.md into persistent knowledge and session-specific content, archiving the latter to the daily file.
+Automated `MEMORY.md` maintenance. The task gathers same-day job/chat context into `activity_section`, performs deterministic overflow archiving for very large files, and otherwise uses the single `daily_memory` prompt to split persistent knowledge from session-specific content. Safety and conservation checks prevent lossy rewrites.
 
 See [Daily Memory System](daily-memory-system.md) for complete documentation.
 
@@ -269,7 +269,7 @@ See [Daily Memory System](daily-memory-system.md) for complete documentation.
 | Setting | `daily_memory_enabled` |
 | Trigger | Daily at midnight UTC (cron) |
 | Manual run | Yes |
-| Prompts | `daily_summary`, `memory_cleanup` |
+| Prompts | `daily_memory` |
 
 ### InternalLinkingTask
 

--- a/docs/core-system/tool-execution.md
+++ b/docs/core-system/tool-execution.md
@@ -1,647 +1,251 @@
 # Tool Execution Architecture
 
-**Files**:
-- `/inc/Engine/AI/Tools/ToolExecutor.php`
-- `/inc/Engine/AI/Tools/ToolParameters.php`
+Tool execution is split into a generic execution core and a Data Machine product wrapper.
 
-**Since**: 0.2.0
+| Component | File | Responsibility |
+|---|---|---|
+| `ToolPolicyResolver` | `inc/Engine/AI/Tools/ToolPolicyResolver.php` | Builds the visible tool set for a request. |
+| `ToolExecutionCore` | `inc/Engine/AI/Tools/Execution/ToolExecutionCore.php` | Validates required parameters, builds complete parameters, executes ability-only or class/method tools. |
+| `ToolExecutor` | `inc/Engine/AI/Tools/ToolExecutor.php` | Applies action policy, stages preview actions, runs direct execution, records post-origin tracking. |
+| `ToolParameters` | `inc/Engine/AI/Tools/ToolParameters.php` | Merges AI arguments with payload, data packet, handler config, and tool metadata. |
+| `ActionPolicyResolver` | `inc/Engine/AI/Actions/ActionPolicyResolver.php` | Decides whether one invocation is `direct`, `preview`, or `forbidden`. |
+| `PendingActionHelper` | `inc/Engine/AI/Actions/PendingActionHelper.php` | Stores approval-required invocations and returns the Agents API approval envelope. |
 
-Universal tool discovery, enablement, and execution infrastructure shared by Pipeline AI and Chat API agents. Provides centralized tool management with filter-based registration and configuration validation.
+## Runtime Flow
 
-## Overview
+```text
+AI request setup
+    |
+    v
+ToolPolicyResolver::resolve()
+    |
+    v
+model tool call
+    |
+    v
+ToolExecutor::executeTool()
+    |
+    +--> ToolExecutionCore::prepareToolCall()
+    |       - tool exists in available tools
+    |       - required parameters are present
+    |       - ToolParameters::buildParameters()
+    |
+    +--> ActionPolicyResolver::resolveForTool()
+    |       - direct / preview / forbidden
+    |
+    +--> forbidden: return error
+    |
+    +--> preview: PendingActionHelper::stage()
+    |
+    +--> direct: ToolExecutionCore::executePreparedTool()
+            - ability-only tool: WP_Ability permissions + execute()
+            - class/method tool: instantiate class and call method
+```
 
-The tool execution architecture consists of two core components:
+## Resolving Tools Before Execution
 
-1. **ToolExecutor** - Tool discovery, validation, and execution
-2. **WP_Agent_Tool_Parameters** - Centralized parameter building and merging
+All runtime tool sets should come from `ToolPolicyResolver::resolve()`.
 
-Together, these components ensure consistent tool behavior across all AI agents while supporting flexible, filter-based tool registration.
-
-## ToolExecutor
-
-**File**: `/inc/Engine/AI/Tools/ToolExecutor.php`
-
-Handles tool discovery via filters, enablement validation, and execution with comprehensive error handling.
-
-### Tool Discovery
-
-Tools are discovered through three filter-based registration patterns, and
-resolved via `ToolPolicyResolver::resolve()` — the single entry point for
-both chat and pipeline modes:
+Pipeline example:
 
 ```php
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 
 $resolver = new ToolPolicyResolver();
-```
 
-**Pipeline Agent Usage** (with step context):
-```php
 $tools = $resolver->resolve( array(
     'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
+    'agent_id'             => $agent_id,
     'previous_step_config' => $previous_step_config,
     'next_step_config'     => $next_step_config,
-    'pipeline_step_id'     => $current_pipeline_step_id,
+    'pipeline_step_id'     => $flow_step_id,
     'engine_data'          => $engine_data,
+    'allow_only'           => $policy_args['allow_only'] ?? array(),
+    'deny'                 => $policy_args['deny'] ?? array(),
 ) );
 ```
 
-**Chat Agent Usage** (global tools only):
+Chat example:
+
 ```php
 $tools = $resolver->resolve( array(
-    'mode' => ToolPolicyResolver::MODE_CHAT,
+    'mode'           => ToolPolicyResolver::MODE_CHAT,
+    'agent_id'       => $agent_id,
+    'client_context' => array(
+        'session_id' => $session_id,
+    ),
 ) );
 ```
 
-### Tool Registration Patterns
+`ToolExecutor` expects the already-resolved `$available_tools` array. It does not rediscover tools.
 
-#### 1. Handler Tools (Step-Specific)
-
-Tools registered into the unified `datamachine_tools` registry as
-`_handler_callable` entries — runtime-resolved with the adjacent step's
-handler config so parameter shapes can adapt to per-step settings (e.g.
-AI-decides taxonomies, character limits, etc.). The preferred path is
-`HandlerRegistrationTrait::registerHandler()`; manual shape:
+## Executing a Tool
 
 ```php
-add_filter('datamachine_tools', function($tools) {
-    $tools['__handler_tools_twitter'] = [
-        '_handler_callable' => function($handler_slug, $handler_config, $engine_data) {
-            return [
-                'twitter_publish' => [
-                    'class'          => 'DataMachine\\Core\\Steps\\Publish\\Handlers\\Twitter\\Twitter',
-                    'method'         => 'handle_tool_call',
-                    'handler'        => $handler_slug,
-                    'description'    => 'Post content to Twitter (280 character limit)',
-                    'parameters'     => [
-                        'content' => [
-                            'type'        => 'string',
-                            'required'    => true,
-                            'description' => 'Tweet content (max 280 chars)',
-                        ],
-                    ],
-                    'handler_config' => $handler_config,
-                ],
-            ];
-        },
-        'handler'      => 'twitter',
-        'modes'        => ['pipeline'],
-        'access_level' => 'admin',
-    ];
-    return $tools;
-});
+use DataMachine\Engine\AI\Actions\ActionPolicyResolver;
+use DataMachine\Engine\AI\Tools\ToolExecutor;
+
+$result = ToolExecutor::executeTool(
+    $tool_name,
+    $tool_parameters,
+    $available_tools,
+    array(
+        'job_id'           => $job_id,
+        'data'             => $data_packets,
+        'flow_step_id'     => $flow_step_id,
+        'flow_step_config' => $flow_step_config,
+    ),
+    ActionPolicyResolver::MODE_PIPELINE,
+    $agent_id
+);
 ```
 
-**Key**: `ToolPolicyResolver::gatherPipelineTools()` resolves these entries
-against the adjacent pipeline step's `handler_slug` (or `handler_types` for
-cross-cutting tools like `skip_item`).
-
-Adjacent handler tools are **flow plumbing**, not optional global tools. In
-pipeline mode they bypass agent `tool_policy`, context `tool_categories`, and
-context `allow_only` filtering because the adjacent flow shape requires them for
-publish/upsert completion. Static/global pipeline tools still pass those policy
-layers normally.
-
-If a required adjacent publish/upsert handler has no AI-callable handler tool,
-the AI step fails before the model call with `required_handler_tool_unavailable`.
-The request inspector uses the same missing-handler check, so `wp datamachine ai
-inspect-request` reports the same unavailable-handler state without dispatching
-to a provider.
-
-#### 2. Global Tools (All Agents)
-
-Tools registered via `datamachine_global_tools` filter, available to all AI agents:
-
-```php
-add_filter('datamachine_global_tools', function($tools) {
-    $tools['google_search'] = [
-        'class' => 'DataMachine\\Engine\\AI\\Tools\\GoogleSearch',
-        'method' => 'handle_tool_call',
-        'description' => 'Search the web using Google Custom Search',
-        'parameters' => [
-            'query' => [
-                'type' => 'string',
-                'required' => true,
-                'description' => 'Search query'
-            ]
-        ],
-        'requires_config' => true
-    ];
-    return $tools;
-});
-```
-
-**Location**: `/inc/Engine/AI/Tools/`
-
-**Global Tools**:
-- `google_search` - Web search via Google Custom Search API
-- `local_search` - WordPress content search
-- `web_fetch` - Retrieve web page content
-- `wordpress_post_reader` - Read specific WordPress post by URL
-
-#### 3. Chat-Only Tools
-
-Tools registered via `datamachine_chat_tools` filter, available only to Chat agent. Since v0.4.3, these are specialized operation-specific tools:
-
-```php
-add_filter('datamachine_chat_tools', function($tools) {
-    $tools['create_pipeline'] = [
-        'class' => 'DataMachine\\Api\\Chat\\Tools\\CreatePipeline',
-        'method' => 'handle_tool_call',
-        'description' => 'Create a new pipeline with optional steps',
-        'parameters' => [
-            'name' => [
-                'type' => 'string',
-                'required' => true,
-                'description' => 'Pipeline name'
-            ],
-            'steps' => [
-                'type' => 'array',
-                'required' => false,
-                'description' => 'Optional initial steps'
-            ]
-        ]
-    ];
-    return $tools;
-});
-```
-
-**Chat Tools** (@since v0.4.3):
-- `execute_workflow` - Execute complete multi-step workflows
-- `add_pipeline_step` - Add steps to existing pipelines
-- `api_query` - REST API query for discovery
-- `configure_flow_step` - Configure flow step handlers and AI messages
-- `configure_pipeline_step` - Configure pipeline AI settings
-- `create_flow` - Create flow instances from pipelines
-- `create_pipeline` - Create pipelines with optional steps
-- `run_flow` - Execute or schedule flows
-- `update_flow` - Update flow properties
-
-### Tool Enablement Control
-
-Tools must pass enablement validation before being made available to AI agents:
-
-```php
-private static function getAllowedTools(
-    array $all_tools,
-    ?string $handler_slug,
-    ?string $pipeline_step_id = null
-): array
-```
-
-**Enablement Logic**:
-
-1. **Handler Tools**: Automatically enabled if handler matches
-2. **Global/Chat Tools**: Must pass two checks:
-   - `datamachine_tool_enabled` filter returns true
-   - `datamachine_tool_configured` filter returns true (if tool requires configuration)
-
-**Pipeline Agent Enablement** (step-specific):
-```php
-add_filter('datamachine_tool_enabled', function($enabled, $tool_name, $tool_config, $pipeline_step_id) {
-    if ($pipeline_step_id) {
-        // Check if tool is enabled for this specific pipeline step
-        $step_config = apply_filters('datamachine_get_flow_step_config', [], $pipeline_step_id);
-        $enabled_tools = $step_config['enabled_tools'] ?? [];
-        return in_array($tool_name, $enabled_tools);
-    }
-    return $enabled;
-}, 10, 4);
-```
-
-**Chat Agent Enablement** (global):
-```php
-add_filter('datamachine_tool_enabled', function($enabled, $tool_name, $tool_config, $context_id) {
-    if ($context_id === null) {
-        // Chat agent: use global tool enablement
-        $tool_configured = apply_filters('datamachine_tool_configured', false, $tool_name);
-        $requires_config = !empty($tool_config['requires_config']);
-        return !$requires_config || $tool_configured;
-    }
-    return $enabled;
-}, 5, 4); // Priority 5 so pipeline (priority 10) can override
-```
-
-### Configuration Validation
-
-Tools requiring external services or API keys use the `requires_config` flag:
-
-```php
-$tools['google_search'] = [
-    'class' => 'DataMachine\\Engine\\AI\\Tools\\GoogleSearch',
-    'method' => 'handle_tool_call',
-    'description' => 'Search the web using Google Custom Search',
-    'parameters' => [...],
-    'requires_config' => true  // Requires API key + search engine ID
-];
-```
-
-**Configuration Check**:
-```php
-add_filter('datamachine_tool_configured', function($configured, $tool_name) {
-    if ($tool_name === 'google_search') {
-        $settings = datamachine_get_data_machine_settings();
-        $api_key = $settings['google_search_api_key'] ?? '';
-        $search_engine_id = $settings['google_search_engine_id'] ?? '';
-        return !empty($api_key) && !empty($search_engine_id);
-    }
-    return $configured;
-}, 10, 2);
-```
-
-### Tool Execution
-
-Execute tools with automatic parameter building and error handling:
+Signature:
 
 ```php
 public static function executeTool(
     string $tool_name,
     array $tool_parameters,
     array $available_tools,
-    array $data,
-    ?string $flow_step_id,
-    array $payload
-): array
-```
-
-**Pipeline Agent Execution**:
-```php
-$result = ToolExecutor::executeTool(
-    $tool_name,           // 'twitter_publish'
-    $tool_parameters,     // ['content' => 'Tweet text']
-    $available_tools,     // All available tools array
-    $data,                // Data packets from previous steps
-    $flow_step_id,        // 'step_uuid_flow_123'
-    [
-        'job_id' => $job_id,
-        'data' => $data,
-        'handler_config' => $handler_config,
-        // ... additional engine parameters
-    ]
-);
-```
-
-**Chat Agent Execution**:
-```php
-$result = ToolExecutor::executeTool(
-    $tool_name,           // 'create_pipeline'
-    $tool_parameters,     // ['name' => 'My Pipeline', 'steps' => [...]]
-    $available_tools,     // All available tools array
-    [],                   // Empty data packets for chat
-    null,                 // No flow_step_id for chat
-    [
-        'session_id' => $session_id
-    ]
-);
-```
-
-**Execution Process**:
-
-1. Validate tool exists in available tools
-2. Build complete parameters via `WP_Agent_Tool_Parameters::buildParameters()`
-3. Instantiate tool class
-4. Call `handle_tool_call()` method with complete parameters
-5. Return standardized result array
-
-**Result Structure**:
-```php
-[
-    'success' => true,           // Execution status
-    'data' => [...],             // Tool-specific result data
-    'tool_name' => 'tool_name',  // Tool identifier
-    'error' => 'Error message'   // Only present if success=false
-]
-```
-
-### Error Handling
-
-Comprehensive error handling for tool execution failures:
-
-**Tool Not Found**:
-```php
-if (!$tool_def) {
-    return [
-        'success' => false,
-        'error' => "Tool '{$tool_name}' not found",
-        'tool_name' => $tool_name
-    ];
-}
-```
-
-**Class Not Found**:
-```php
-if (!class_exists($class_name)) {
-    return [
-        'success' => false,
-        'error' => "Tool class '{$class_name}' not found",
-        'tool_name' => $tool_name
-    ];
-}
-```
-
-**Execution Exception**:
-```php
-try {
-    $tool_handler = new $class_name();
-    $tool_result = $tool_handler->handle_tool_call($complete_parameters, $tool_def);
-    return $tool_result;
-} catch (\Exception $e) {
-    do_action('datamachine_log', 'error', 'ToolExecutor: Tool execution exception', [
-        'flow_step_id' => $flow_step_id,
-        'tool_name' => $tool_name,
-        'exception' => $e->getMessage(),
-        'trace' => $e->getTraceAsString()
-    ]);
-
-    return [
-        'success' => false,
-        'error' => 'Tool execution exception: ' . $e->getMessage(),
-        'tool_name' => $tool_name
-    ];
-}
-```
-
-## WP_Agent_Tool_Parameters
-
-**File**: `/inc/Engine/AI/Tools/ToolParameters.php`
-
-Centralized parameter building for AI tool execution. Merges AI-provided parameters with engine context to create complete parameter sets.
-
-### Standard Parameter Building
-
-Build unified flat parameter structure for tool execution:
-
-```php
-public static function buildParameters(
-    array $ai_tool_parameters,
     array $payload,
-    array $tool_definition
+    string $mode = ActionPolicyResolver::MODE_CHAT,
+    int $agent_id = 0,
+    array $client_context = array()
 ): array
 ```
 
-**Usage**:
-```php
-$complete_parameters = WP_Agent_Tool_Parameters::buildParameters(
-    ['query' => 'WordPress SEO tips'],  // AI parameters
-    ['session_id' => $session_id],      // Unified context
-    $tool_definition                     // Tool definition array
-);
+The `$mode`, `$agent_id`, and `$client_context` values only affect action policy. Tool visibility has already been resolved before execution.
 
-// Result:
-// [
-//     'session_id' => 'session_123',
-//     'content' => null,
-//     'title' => null,
-//     'tool_definition' => [...],
-//     'tool_name' => 'google_search',
-//     'handler_config' => [],
-//     'query' => 'WordPress SEO tips'
-// ]
-```
+## Generic Execution Core
 
-**Parameter Building Process**:
-
-1. Start with unified parameters (session_id, job_id, data, etc.)
-2. Extract `content` from data packet if tool requires it
-3. Extract `title` from data packet if tool requires it
-4. Add tool metadata (tool_definition, tool_name, handler_config)
-5. Merge AI-provided parameters (overwrites defaults)
-
-### Content Extraction
-
-Automatic content extraction from data packets for tools requiring content:
+`ToolExecutionCore::prepareToolCall()` returns either a normalized error or a prepared invocation:
 
 ```php
-private static function extractContent(array $data_packet, array $tool_definition): ?string
-{
-    $tool_params = $tool_definition['parameters'] ?? [];
-    if (!isset($tool_params['content'])) {
-        return null; // Tool doesn't require content
-    }
-
-    $latest_entry = !empty($data_packet) ? $data_packet[0] : [];
-    $content_data = $latest_entry['content'] ?? [];
-    return $content_data['body'] ?? null;
-}
+array(
+    'ready'      => true,
+    'tool_def'   => $tool_def,
+    'parameters' => $complete_parameters,
+)
 ```
 
-**Example**: Twitter publish tool receives content from AI step's data packet automatically.
+Preparation checks that the tool exists in `$available_tools`, validates required parameters declared in `parameters`, and calls `ToolParameters::buildParameters()`.
 
-### Title Extraction
+`ToolExecutionCore::executePreparedTool()` supports two executable shapes:
 
-Automatic title extraction from data packets for tools requiring title:
+| Shape | Required keys | Execution path |
+|---|---|---|
+| Ability-only | `ability`, no `class`, no `method` | Resolve ability from `WP_Abilities_Registry`, check permissions, call `execute()`. |
+| Class/method | `class`, `method` | Instantiate class and call the method with complete parameters and tool definition. |
+
+Ability-only tools are useful when the WordPress Ability is already the source of truth for permission and behavior. Class/method tools remain valid for Data Machine handler tools and product-specific adapters.
+
+## Parameter Building
+
+`ToolParameters::buildParameters()` merges model-provided arguments with Data Machine payload context.
+
+Common payload values include:
+
+| Payload key | Purpose |
+|---|---|
+| `job_id` | Job currently running. |
+| `data` | Data packets from previous steps. |
+| `flow_step_id` | Current flow-step identifier. |
+| `flow_step_config` | Current flow-step snapshot. |
+| `handler_config` | Handler-specific runtime configuration. |
+| `session_id` | Chat session identifier when called from chat. |
+
+The AI's tool parameters win over defaults extracted from the payload. Handler tools also receive `handler_config`, engine data such as `source_url` and `image_url`, and the resolved `tool_definition`.
+
+## Action Policy
+
+Visibility and execution are separate. A tool can be visible to the model and still be prevented from executing directly.
+
+`ActionPolicyResolver::resolveForTool()` returns the Agents API vocabulary:
+
+| Policy | Effect |
+|---|---|
+| `direct` | Execute immediately. |
+| `preview` | Stage the invocation and return an approval-required envelope. |
+| `forbidden` | Return a refusal error without running the tool. |
+
+Resolution inputs include `tool_name`, `tool_def`, `mode`, `agent_id`, `client_context`, and optional `deny`.
+
+Resolution order is:
+
+1. Explicit deny list.
+2. Per-agent `agent_config.action_policy.tools[tool_name]`.
+3. Per-agent `agent_config.action_policy.categories[category]`.
+4. Tool-declared default, including per-mode keys such as `action_policy_chat`.
+5. Mode preset from `DataMachineModeActionPolicyProvider`.
+6. Global default from Agents API.
+7. `datamachine_tool_action_policy` filter.
+
+Chat can stage publish-family tools for preview because a user is present. Pipeline and system modes default to direct for automation unless a tool or policy says otherwise.
+
+## Pending Actions
+
+When action policy resolves to `preview`, `ToolExecutor` stages the invocation if the tool declares `action_kind`. Staging uses `PendingActionHelper::stage()`.
 
 ```php
-private static function extractTitle(array $data_packet, array $tool_definition): ?string
-{
-    $tool_params = $tool_definition['parameters'] ?? [];
-    if (!isset($tool_params['title'])) {
-        return null; // Tool doesn't require title
-    }
-
-    $latest_entry = !empty($data_packet) ? $data_packet[0] : [];
-    $content_data = $latest_entry['content'] ?? [];
-    return $content_data['title'] ?? null;
-}
+$staged = PendingActionHelper::stage( array(
+    'kind'         => 'socials_publish_instagram',
+    'summary'      => 'Publish Instagram post: Spring menu is live',
+    'apply_input'  => $complete_parameters,
+    'preview_data' => array(
+        'caption' => $complete_parameters['caption'] ?? '',
+    ),
+    'agent_id'     => $agent_id,
+    'context'      => array(
+        'mode'      => 'chat',
+        'tool_name' => 'publish_instagram',
+        'session_id' => $session_id,
+    ),
+) );
 ```
 
-### Handler Tool Parameter Building
+The result is an Agents API `approval_required` message with:
 
-Build parameters for handler tools with engine data integration:
+| Field | Purpose |
+|---|---|
+| `payload.pending_action.action_id` | Identifier to resolve later. |
+| `payload.pending_action.summary` | Human-readable preview summary. |
+| `payload.pending_action.preview` | Renderable preview data. |
+| `payload.resolve_with` | Tool name to call for resolution, currently `resolve_pending_action`. |
+| `payload.resolve_params` | Required resolution arguments. |
+| top-level `staged` and `action_id` | Data Machine compatibility fields for internal callers. |
+
+Tools should not hand-roll this envelope. Use `PendingActionHelper` so the store shape, approval message, and compatibility fields stay aligned.
+
+## Post-Origin Tracking
+
+After direct execution succeeds, `ToolExecutor` calls `PostTracking::extractPostId()` and records origin metadata for results that created or modified a WordPress post. This applies to handler tools and ability-only tools when their result exposes an extractable post ID.
+
+## Error Shapes
+
+Common normalized failures:
 
 ```php
-public static function buildForHandlerTool(
-    array $ai_tool_parameters,
-    array $data,
-    array $tool_definition,
-    array $engine_parameters,
-    array $handler_config
-): array
+array(
+    'success'   => false,
+    'error'     => "Tool 'my_tool' not found",
+    'tool_name' => 'my_tool',
+)
 ```
-
-**Usage**:
-```php
-$complete_parameters = WP_Agent_Tool_Parameters::buildForHandlerTool(
-    ['content' => 'Tweet text'],           // AI parameters
-    $data,                                  // Data packets
-    $tool_definition,                       // Tool definition
-    [
-        'source_url' => 'https://example.com/post',
-        'image_url' => 'https://example.com/image.jpg'
-    ],                                      // Engine parameters
-    $handler_config                         // Handler configuration
-);
-
-// Result:
-// [
-//     'data' => [...],
-//     'handler_config' => [...],
-//     'content' => 'Generated content from AI step',
-//     'title' => 'Generated title from AI step',
-//     'tool_definition' => [...],
-//     'tool_name' => 'twitter_publish',
-//     'content' => 'Tweet text',  // AI parameter overwrites default
-//     'source_url' => 'https://example.com/post',
-//     'image_url' => 'https://example.com/image.jpg'
-// ]
-```
-
-**Engine Data Integration**:
-
-Handler tools receive engine parameters (source_url, image_url) from centralized storage:
 
 ```php
-// Merge engine data (source_url, image_url) from centralized access
-foreach ($engine_parameters as $key => $value) {
-    $parameters[$key] = $value;
-}
+array(
+    'success'       => false,
+    'error'         => 'Tool "publish_instagram" is not permitted in the current context (action_policy=forbidden).',
+    'tool_name'     => 'publish_instagram',
+    'action_policy' => 'forbidden',
+)
 ```
 
-## Tool Categories
+Ability-only failures include the linked `ability` slug when ability registration, permission, or execution fails.
 
-### Handler Tools
+## Related Docs
 
-**Registration**: `datamachine_tools` filter — `_handler_callable` entries
-**Scope**: Step-specific (publish, upsert handlers)
-**Enablement**: Automatic when adjacent step's handler slug or type matches
-**Examples**: `twitter_publish`, `wordpress_publish`, `bluesky_publish`
-
-**Characteristics**:
-- Registry entry carries `'handler' => 'slug'` (exact match) or
-  `'handler_types' => [...]` (cross-cutting tools like `skip_item`)
-- Resolved at pipeline execution time with the adjacent step's handler config
-- Receive data packets and engine parameters
-- Execute final workflow actions (publishing, updating)
-
-### Global Tools
-
-**Registration**: `datamachine_global_tools` filter
-**Scope**: All AI agents (pipeline + chat)
-**Enablement**: Via `datamachine_tool_enabled` filter + configuration check
-**Examples**: `google_search`, `local_search`, `web_fetch`, `wordpress_post_reader`
-
-**Characteristics**:
-- Available to all agents if enabled
-- May require configuration (`requires_config` flag)
-- Used for information gathering and research
-- Do not modify external systems
-
-### Chat-Only Tools
-
-**Registration**: `datamachine_chat_tools` filter
-**Scope**: Chat agent only
-**Enablement**: Via `datamachine_tool_enabled` filter
-**Examples** (@since v0.4.3): `execute_workflow`, `create_pipeline`, `run_flow`, `configure_flow_step`, etc.
-
-**Characteristics**:
-- Only available to chat agent
-- Enable conversational workflow building
-- Specialized operation-specific tools for pipeline/flow management
-- Bridge chat interface to system operations
-
-## Best Practices
-
-### Tool Registration
-
-**Handler Tools** (preferred path is `HandlerRegistrationTrait::registerHandler()`):
-```php
-add_filter('datamachine_tools', function($tools) {
-    $tools['__handler_tools_my_handler'] = [
-        '_handler_callable' => function($handler_slug, $handler_config, $engine_data) {
-            return [
-                'my_tool' => [
-                    'class'          => 'MyNamespace\\MyHandler',
-                    'method'         => 'handle_tool_call',
-                    'handler'        => $handler_slug,
-                    'description'    => 'Clear, concise tool description',
-                    'parameters'     => [
-                        'param_name' => [
-                            'type'        => 'string',
-                            'required'    => true,
-                            'description' => 'Parameter description for AI',
-                        ],
-                    ],
-                    'handler_config' => $handler_config,
-                ],
-            ];
-        },
-        'handler'      => 'my_handler',
-        'modes'        => ['pipeline'],
-        'access_level' => 'admin',
-    ];
-    return $tools;
-});
-```
-
-**Global Tools**:
-```php
-add_filter('datamachine_global_tools', function($tools) {
-    $tools['my_global_tool'] = [
-        'class' => 'DataMachine\\Engine\\AI\\Tools\\MyTool',
-        'method' => 'handle_tool_call',
-        'description' => 'Tool description visible to all agents',
-        'parameters' => [...],
-        'requires_config' => true  // If tool needs API keys/configuration
-    ];
-    return $tools;
-});
-```
-
-### Parameter Building
-
-**AI-Provided Parameters Override Defaults**:
-```php
-// AI provides: ['content' => 'Custom content']
-// Data packet has: ['content' => ['body' => 'Default content']]
-// Result: 'Custom content' (AI parameter wins)
-```
-
-**Access Engine Data in Tool Handler**:
-```php
-public function handle_tool_call(array $parameters, array $tool_def = []): array {
-    $source_url = $parameters['source_url'] ?? null;
-    $image_url = $parameters['image_url'] ?? null;
-    $handler_config = $parameters['handler_config'] ?? [];
-
-    // Use engine data for operations
-    return ['success' => true, 'data' => [...]];
-}
-```
-
-### Tool Execution
-
-**Always Check Tool Result**:
-```php
-$result = ToolExecutor::executeTool(...);
-
-if ($result['success']) {
-    $data = $result['data'];
-    // Process successful result
-} else {
-    $error = $result['error'];
-    // Handle failure
-}
-```
-
-**Provide Complete Payload Parameters**:
-```php
-// Pipeline
-$payload = [
-    'job_id' => $job_id,
-    'data' => $data,
-    'handler_config' => $handler_config,
-    // ... additional context
-];
-
-// Chat
-$payload = [
-    'session_id' => $session_id
-];
-```
-
-## Related Components
-
-- Universal Engine Architecture - Overall engine structure
-- AI Conversation Loop - Tool execution integration
-- RequestBuilder Pattern - AI request construction
-- Universal Engine Filters - Filter hook reference
+- [Tool Manager](tool-manager.md)
+- [Policy Resolvers](../architecture/policy-resolvers.md)
+- [AI Conversation Loop](ai-conversation-loop.md)
+- [Tool Result Finder](tool-result-finder.md)

--- a/docs/core-system/tool-manager.md
+++ b/docs/core-system/tool-manager.md
@@ -1,346 +1,188 @@
 # Tool Manager
 
-Centralized tool management system introduced in v0.2.1 that replaces distributed tool discovery and validation logic.
+`ToolManager` is the Data Machine adapter for the AI tool registry. It owns Data Machine's `datamachine_tools` compatibility registry, lazy definition resolution, handler-tool expansion, configuration checks, and global enablement checks. It does not decide the final per-request tool set by itself. Runtime visibility is resolved by `ToolPolicyResolver` through `ToolSourceRegistry`.
 
-## Overview
+## Current Shape
 
-ToolManager (`/inc/Engine/AI/Tools/ToolManager.php`) provides centralized methods for tool discovery, enablement validation, and configuration management across the entire system.
+```text
+datamachine_tools filter
+        |
+        v
+ToolManager
+  - get_all_tools()
+  - get_raw_tools()
+  - resolveHandlerTools()
+  - is_tool_available()
+        |
+        v
+ToolSourceRegistry
+  - static_registry
+  - adjacent_handlers
+        |
+        v
+ToolPolicyResolver::resolve()
+```
 
-## Architecture
+Use `ToolManager` when code needs to read Data Machine's registered tool definitions or resolve handler-owned tools. Use `ToolPolicyResolver::resolve()` when code needs the tool set an agent may actually see for a chat, pipeline, or system request.
 
-- **Location**: `/inc/Engine/AI/Tools/ToolManager.php`
-- **Purpose**: Centralize all tool-related operations
-- **Replaces**: Distributed filter logic for tool availability
-- **Benefits**:
-  - Single source of truth for tool availability
-  - Consistent validation patterns
-  - Performance optimization through centralized logic
-  - Easy extensibility for new validation rules
+## Registry Contract
 
-## Key Methods
-
-### get_all_tools()
-
-Returns all global tools available system-wide.
+All product and extension tools register through `datamachine_tools`.
 
 ```php
-public function get_all_tools(): array
-```
+add_filter( 'datamachine_tools', function ( array $tools ): array {
+    $tools['my_plugin/search'] = array(
+        '_callable'     => array( MyToolDefinitions::class, 'search' ),
+        'modes'         => array( 'chat' ),
+        'ability'       => 'my-plugin/search',
+        'access_level'  => 'admin',
+    );
 
-**Returns**: Array of global tool definitions
-
-**Usage**:
-```php
-$tool_manager = new ToolManager();
-$global_tools = $tool_manager->get_all_tools();
-```
-
-### is_tool_available()
-
-Validates if a tool is available for use based on global enablement, step configuration, and configuration status.
-
-```php
-public function is_tool_available(string $tool_id, ?string $context_id = null): bool
-```
-
-**Parameters**:
-- `$tool_id`: Tool identifier to validate
-- `$context_id`: Optional step context ID for step-specific validation
-
-**Returns**: Boolean indicating tool availability
-
-**Validation Layers**:
-1. Global settings check (tool must be enabled system-wide)
-2. Step configuration check (tool must be selected for specific step, if context provided)
-3. Configuration check (tool must have required credentials/API keys)
-
-### is_tool_configured()
-
-Checks if a tool has required configuration (API keys, OAuth, etc).
-
-```php
-public function is_tool_configured(string $tool_id): bool
-```
-
-**Parameters**:
-- `$tool_id`: Tool identifier to check
-
-**Returns**: Boolean indicating configuration status
-
-**Configuration Checks**:
-- API keys for third-party services
-- OAuth account credentials
-- Required settings validation
-- Auto-passes for WordPress-native tools
-
-### get_opt_out_defaults()
-
-Returns tools that don't require configuration (WordPress-native functionality).
-
-```php
-public function get_opt_out_defaults(): array
-```
-
-**Returns**: Array of tool IDs that are always considered "configured" if enabled
-
-**Default Opt-Out Tools**:
-- `local_search` - WordPress internal search
-- `wordpress_post_reader` - WordPress post content retrieval
-- `web_fetch` - Web page content fetching (no API required)
-
-**Usage**:
-```php
-$tool_manager = new ToolManager();
-$opt_out_tools = $tool_manager->get_opt_out_defaults();
-// Returns: ['local_search', 'wordpress_post_reader', 'web_fetch']
-```
-
-### get_tools_for_settings_page()
-
-Aggregates tool data for admin interface display.
-
-```php
-public function get_tools_for_settings_page(): array
-```
-
-**Returns**: Array of tool metadata for settings page
-
-**Usage**:
-```php
-$tool_manager = new ToolManager();
-$settings_data = $tool_manager->get_tools_for_settings_page();
-```
-
-## Tool Enablement Architecture
-
-### Three-Layer Validation
-
-ToolManager implements a three-layer validation system for tool availability:
-
-```
-┌─────────────────────────────────────────────┐
-│ Layer 1: Global Settings                    │
-│ - System-wide tool enablement toggle        │
-│ - Tools can be disabled globally            │
-└─────────────────────────────────────────────┘
-                    ↓
-┌─────────────────────────────────────────────┐
-│ Layer 2: Step Configuration                 │
-│ - Per-step tool selection in builder        │
-│ - Only selected tools available in step     │
-└─────────────────────────────────────────────┘
-                    ↓
-┌─────────────────────────────────────────────┐
-│ Layer 3: Runtime Validation                 │
-│ - Configuration requirements check          │
-│ - API key/OAuth credential validation       │
-│ - Tool execution readiness verification     │
-└─────────────────────────────────────────────┘
-```
-
-### Validation Flow
-
-```php
-// Complete validation flow
-$tool_manager = new ToolManager();
-
-// 1. Check tool availability (includes all validation layers)
-$is_available = $tool_manager->is_tool_available('google_search', $step_context_id);
-
-// 2. Check configuration requirements specifically
-$is_configured = $tool_manager->is_tool_configured('google_search');
-
-// 4. Final availability determination
-$is_available = $is_globally_enabled && $is_step_enabled && $is_configured;
-```
-
-## Opt-Out Pattern
-
-WordPress-native tools use an "opt-out" pattern for configuration:
-
-```php
-// Opt-out tools are always considered "configured"
-$tool_manager = new ToolManager();
-$opt_out_tools = $tool_manager->get_opt_out_defaults();
-
-// Configuration check auto-passes for these tools
-$is_configured = $tool_manager->is_tool_configured('local_search');
-// Returns: true (WordPress-native, no configuration needed)
-
-$is_configured = $tool_manager->is_tool_configured('google_search');
-// Returns: false (requires API key and Search Engine ID)
-```
-
-**Rationale**:
-- WordPress-native tools use built-in functionality
-- No external API keys or services required
-- Always available when WordPress is running
-- Reduces configuration burden for common tools
-
-## Usage in Components
-
-### ToolExecutor Integration
-
-```php
-use DataMachine\Engine\AI\Tools\ToolManager;
-
-class ToolExecutor {
-    private ToolManager $tool_manager;
-
-    public function __construct() {
-        $this->tool_manager = new ToolManager();
-    }
-
-    public function execute_tool(string $tool_id, array $parameters): array {
-        // Validate tool is available (includes enablement and configuration)
-        if (!$this->tool_manager->is_tool_available($tool_id)) {
-            return $this->error_response('Tool not available');
-        }
-
-        // Execute tool...
-    }
-}
-```
-
-### Settings UI Integration
-
-```php
-use DataMachine\Engine\AI\Tools\ToolManager;
-
-class SettingsPage {
-    public function render_tools_section(): void {
-        $tool_manager = new ToolManager();
-        $tools = $tool_manager->get_tools_for_settings_page();
-
-        foreach ($tools as $tool_id => $tool_data) {
-            // Render UI with:
-            // - Enable toggle (based on is_enabled)
-            // - Config button (if requires_config && !is_configured)
-            // - Status indicator (configured vs. needs setup)
-        }
-    }
-}
-```
-
-### Pipeline Builder Integration
-
-```php
-use DataMachine\Engine\AI\Tools\ToolManager;
-
-class AIStepModal {
-    public function get_available_tools(string $handler_slug): array {
-        $tool_manager = new ToolManager();
-
-        // Get global tools
-        $global_tools = $tool_manager->get_all_tools();
-
-        // Filter to only available tools for this context
-        return array_filter($global_tools, function($tool_id) use ($tool_manager) {
-            return $tool_manager->is_tool_available($tool_id);
-        });
-    }
-}
-```
-
-## Extension Integration
-
-Extensions can integrate with ToolManager through standard filter patterns:
-
-```php
-// Register custom tool
-add_filter('datamachine_global_tools', function($tools) {
-    $tools['my_custom_tool'] = [
-        'id' => 'my_custom_tool',
-        'class' => MyCustomTool::class,
-        'method' => 'execute',
-        'description' => 'Custom tool description',
-        'parameters' => [/* ... */]
-    ];
     return $tools;
-});
-
-// ToolManager automatically discovers and validates
-$tool_manager = new ToolManager();
-$is_available = $tool_manager->is_tool_available('my_custom_tool');
-$is_configured = $tool_manager->is_tool_configured('my_custom_tool');
+} );
 ```
 
-## Error Handling
-
-ToolManager provides consistent error handling:
+The `_callable` wrapper defers the full definition until a resolver needs it. The resolved definition must include the model-facing shape:
 
 ```php
-try {
-    $tools = $tool_manager->getAvailableTools('pipeline');
-} catch (Exception $e) {
-    do_action('datamachine_log', 'error', 'Tool discovery failed', [
-        'error' => $e->getMessage()
-    ]);
-    return [];
+array(
+    'description'     => 'Search the My Plugin index.',
+    'parameters'      => array(
+        'query' => array(
+            'type'        => 'string',
+            'required'    => true,
+            'description' => 'Search terms.',
+        ),
+    ),
+    'class'           => MySearchTool::class,
+    'method'          => 'handle_tool_call',
+    'modes'           => array( 'chat' ),
+    'requires_config' => false,
+)
+```
+
+Ability-only tools omit `class` and `method` and execute through the linked WordPress Ability:
+
+```php
+array(
+    'description' => 'Create a wiki note.',
+    'parameters'  => array( /* JSON-schema-like parameter map */ ),
+    'ability'     => 'intelligence/create-wiki-note',
+    'modes'       => array( 'chat' ),
+)
+```
+
+`ToolExecutionCore` treats a definition with `ability` and no `class`/`method` as ability-only. It checks ability permissions and calls `WP_Ability::execute()` directly.
+
+## Handler Tools
+
+Pipeline handler tools are dynamic because their parameter schemas depend on the adjacent flow-step handler config. Register them as `_handler_callable` entries in `datamachine_tools`, usually through `HandlerRegistrationTrait::registerHandler()`.
+
+```php
+add_filter( 'datamachine_tools', function ( array $tools ): array {
+    $tools['__handler_tools_wordpress_publish'] = array(
+        '_handler_callable' => function ( string $handler_slug, array $handler_config, array $engine_data ): array {
+            return array(
+                'wordpress_publish' => array(
+                    'class'          => WordPressPublishTool::class,
+                    'method'         => 'handle_tool_call',
+                    'handler'        => $handler_slug,
+                    'handler_config' => $handler_config,
+                    'description'    => 'Publish the processed item to WordPress.',
+                    'parameters'     => build_parameters_from_handler_config( $handler_config ),
+                ),
+            );
+        },
+        'handler'      => 'wordpress_publish',
+        'modes'        => array( 'pipeline' ),
+        'access_level' => 'admin',
+    );
+
+    return $tools;
+} );
+```
+
+`ToolManager::resolveHandlerTools()` supports two matching shapes:
+
+| Entry key | Meaning |
+|---|---|
+| `handler` | Exact adjacent handler slug match. |
+| `handler_types` | Match any adjacent handler whose registered type is in the list. Used by cross-cutting tools such as `skip_item`. |
+
+Resolved handler tools automatically receive `handler`, `handler_config`, inherited `access_level`, inherited `ability`, and `modes` when the callback omits them.
+
+## Source Registry
+
+`ToolSourceRegistry` composes named sources before policy filtering:
+
+| Source | Class | Used by default in |
+|---|---|---|
+| `static_registry` | `DataMachineToolRegistrySource` | `chat`, `pipeline`, `system`, custom modes |
+| `adjacent_handlers` | `AdjacentHandlerToolSource` | `pipeline` |
+
+`DataMachineToolRegistrySource` reads `ToolManager::get_all_tools()`, filters by each tool's `modes`, applies global enablement/configuration checks, and adapts policy-gated pipeline tools.
+
+`AdjacentHandlerToolSource` reads the previous and next step configs, gathers configured handler slugs through `FlowStepConfig`, and asks `ToolManager::resolveHandlerTools()` for each adjacent handler's dynamic tool definitions.
+
+The generic extension hooks are `agents_api_tool_sources` and `agents_api_tool_sources_for_mode`. Data Machine's legacy `datamachine_tool_sources` filters are not mirrored.
+
+## Modes
+
+Tool definitions declare the request modes that may see them:
+
+| Mode | Constant | Use |
+|---|---|---|
+| `pipeline` | `ToolPolicyResolver::MODE_PIPELINE` | Automated AI pipeline steps. Includes adjacent handler tools plus static registry tools explicitly marked for pipeline. |
+| `chat` | `ToolPolicyResolver::MODE_CHAT` | User-present chat sessions. Runs the chat access gate and ability permission checks. |
+| `system` | `ToolPolicyResolver::MODE_SYSTEM` | Background/system jobs with a small explicit tool set. |
+| `pipeline_policy` | `ToolPolicyResolver::MODE_PIPELINE_POLICY` | Opt-in marker for tools hidden from pipeline by default but grantable through pipeline tool policy. |
+
+`pipeline_policy` does not expose a tool by itself. A pipeline request must also include the tool in `allow_only`, usually from `enabled_tools` in the flow-step snapshot.
+
+## Availability Checks
+
+`ToolManager::is_tool_available( $tool_id, $context_id )` combines global enablement and configuration state. It is a source-level gate, not the full policy resolver.
+
+```php
+$manager = new ToolManager();
+
+if ( $manager->is_tool_available( 'google_search' ) ) {
+    // The static registry source may include it, subject to mode and policy.
 }
 ```
 
-## Migration from Legacy Patterns
-
-### Before (Distributed Logic)
+`requires_config => true` tools must pass `datamachine_tool_configured`:
 
 ```php
-// Old pattern: scattered tool validation
-$enabled_tools = get_option('datamachine_enabled_tools', []);
-$is_enabled = in_array('google_search', $enabled_tools);
+add_filter( 'datamachine_tool_configured', function ( bool $configured, string $tool_id ): bool {
+    if ( 'my_plugin/search' !== $tool_id ) {
+        return $configured;
+    }
 
-$google_config = get_option('datamachine_google_search_config', []);
-$is_configured = !empty($google_config['api_key']);
-
-// Validation logic duplicated across multiple files
+    $settings = get_option( 'my_plugin_settings', array() );
+    return ! empty( $settings['api_key'] );
+}, 10, 2 );
 ```
 
-### After (Centralized ToolManager)
+Tools without `requires_config` still pass through the global enablement check. The old public enablement filter is not part of the current runtime path.
 
-```php
-// New pattern: centralized validation
-$tool_manager = new ToolManager();
-$is_enabled = $tool_manager->is_globally_enabled('google_search');
-$is_configured = $tool_manager->is_tool_configured('google_search');
+## Pipeline Tool Policy Inputs
 
-// Single source of truth, consistent behavior
-```
+Pipeline AI steps build resolver policy args from the workflow snapshot through `PipelineToolPolicyArgs::fromConfigs()`:
 
-## Benefits
+| Config key | Resolver arg | Effect |
+|---|---|---|
+| `enabled_tools` on the flow step | `allow_only` | Narrows optional/static tools to the listed names and grants matching `pipeline_policy` tools. |
+| `disabled_tools` on the pipeline step | `deny` | Removes listed tools. |
+| `disabled_tools` on the flow step | `deny` | Removes listed tools. |
 
-### Code Reduction
+The snapshot is authoritative. Runtime pipeline resolution does not re-read persisted pipeline rows because direct workflows can have synthetic IDs and historical jobs must use the policy captured when they ran.
 
-- Eliminates ~60% of tool validation code throughout codebase
-- Centralizes tool discovery logic from multiple components
-- Reduces maintenance burden for tool-related operations
+Adjacent handler tools are mandatory flow plumbing. They are preserved through allow/category policy unless explicitly denied by the high-precedence deny list.
 
-### Consistency
+## Related Docs
 
-- Ensures uniform tool validation across all components
-- Prevents inconsistent enablement checking
-- Standardizes configuration validation patterns
-
-### Performance
-
-- Implements caching for tool discovery
-- Reduces redundant filter calls
-- Optimizes database queries for tool data
-
-### Maintainability
-
-- Single location for tool management logic
-- Easy to add new validation requirements
-- Simplified debugging of tool availability issues
-
-### Extensibility
-
-- Filter-based architecture for custom tools
-- Clear integration points for extensions
-- Supports future tool types and validation patterns
-
-## See Also
-
-- Universal Engine - Engine architecture overview
-- Tool Execution Architecture - Tool execution patterns
-- AI Tools Overview - Available tools catalog
-- Core Filters - Filter reference
+- [Tool Execution Architecture](tool-execution.md)
+- [Policy Resolvers](../architecture/policy-resolvers.md)
+- [Engine Filters](../development/hooks/engine-filters.md)
+- [Core Filters](../development/hooks/core-filters.md)

--- a/docs/core-system/tool-result-finder.md
+++ b/docs/core-system/tool-result-finder.md
@@ -329,7 +329,7 @@ $result = ToolResultFinder::findHandlerResult($data, 'twitter', $type = 'tool_re
 ## Related Components
 
 - Universal Engine Architecture - Overall engine structure
-- Tool Execution Architecture - Tool execution and result creation
+- [Tool Execution Architecture](tool-execution.md) - Tool execution and result creation
 - WordPress Update Handler - Primary ToolResultFinder user
 - Data Flow Architecture - Data packet structure and flow
 

--- a/docs/core-system/universal-engine.md
+++ b/docs/core-system/universal-engine.md
@@ -140,7 +140,7 @@ $ui_data = $tool_manager->getToolsForUI();
 - **Maintainability**: Single location for tool management logic
 - **Extensibility**: Filter-based architecture for custom tools
 
-See Tool Manager for complete documentation.
+See [Tool Manager](tool-manager.md) for the current registry/source/policy split.
 
 ### BaseTool (@since v0.14.10)
 

--- a/docs/core-system/wordpress-as-agent-memory.md
+++ b/docs/core-system/wordpress-as-agent-memory.md
@@ -62,25 +62,29 @@ The **CoreMemoryFilesDirective** loads all files from the **MemoryFileRegistry**
 
 **Location:** `agents/{agent_slug}/daily/YYYY/MM/DD.md`
 
-Daily memory files capture session-specific knowledge organized by date. Two-phase system:
+Daily memory files capture session-specific knowledge organized by date. Current lifecycle:
 
-1. **Daily Summary** (Phase 1): At the end of each day, Data Machine gathers completed jobs and chat sessions, synthesizes them via AI, and appends the result to the daily file.
-2. **MEMORY.md Cleanup** (Phase 2): If MEMORY.md exceeds the size threshold (`MAX_FILE_SIZE = 8KB`), AI splits content into persistent facts and session-specific details. Persistent content stays in MEMORY.md; archived content moves to the daily file.
+1. **Activity context**: Data Machine gathers same-day jobs and chat sessions into the `{{activity_section}}` variable.
+2. **Deterministic overflow**: Very large `MEMORY.md` files are split by section and archived verbatim before any AI call.
+3. **AI compaction**: The single `daily_memory` prompt splits `MEMORY.md` into `===PERSISTENT===` and `===ARCHIVED===` sections when size or activity requires maintenance.
+4. **Conservation checks**: Safety gates prevent empty, suspiciously small, or lossy rewrites.
 
 This keeps MEMORY.md lean while preserving the full temporal record in daily files.
 
-**DailyMemoryTask** runs as a system task (`daily_memory_generation`) on a daily cron schedule. Both phases use editable AI prompts via the `getPromptDefinitions()` system.
+**DailyMemoryTask** runs as a system task (`daily_memory_generation`) on a daily cron schedule. The `daily_memory` prompt is editable via the `getPromptDefinitions()` system.
 
-**Pipeline integration:** The **DailyMemorySelectorDirective** (Priority 46) injects daily memory into pipeline AI requests. Four selection modes:
+**Runtime integration:** The **AgentDailyMemoryDirective** (Priority 35) injects recent daily files into chat and pipeline AI requests only when the resolved agent opts in with `agent_config.daily_memory`:
 
-| Mode | Description |
-|------|-------------|
-| `recent_days` | Last N days (max 90) |
-| `specific_dates` | Explicit date list |
-| `date_range` | From/to date filtering |
-| `months` | All dates in selected months |
+```json
+{
+  "daily_memory": {
+    "enabled": true,
+    "recent_days": 3
+  }
+}
+```
 
-Total injection capped at 100KB. Files sorted newest-first.
+Historical date, range, and month queries are served on demand by the `agent_daily_memory` tool instead of pre-injecting large selector windows.
 
 ### 3. Chat Sessions — Conversation Memory
 
@@ -377,17 +381,17 @@ Each pipeline can select additional agent files beyond the core set. Configure v
 
 Each flow can independently select additional memory files, allowing flow-level customization beyond pipeline defaults.
 
-### Daily Memory Files (Priority 46)
+### Daily Memory Files (Priority 35)
 
-Flows can configure daily memory injection through the `daily_memory` flow config setting. See the [Daily Memory section](#2-daily-memory--temporal-knowledge) for selection modes.
+Agents can opt into recent daily memory injection through `agent_config.daily_memory`. `AgentDailyMemoryDirective` runs after core memory files and before pipeline/flow memory files, and it only injects the newest available daily files within the 8 KB memory budget.
 
 ```
-"Daily Music News"    -> [content-strategy.md] + recent 7 days daily memory
-"Social Media Posts"  -> []
-"Album Reviews"       -> [content-strategy.md, content-briefing.md] + specific dates
+"Personal Assistant"  -> recent 3 days daily memory
+"Social Media Posts"  -> no daily memory
+"Album Reviews"       -> no daily memory; uses agent_daily_memory for exact historical lookups
 ```
 
-Different workflows access different slices of knowledge. This is deliberate — selective memory injection over RAG means you know exactly what context the agent has, with no embedding cost and no hallucination from irrelevant similarity matches.
+Different agents access different slices of temporal knowledge. This is deliberate — opt-in recent daily memory keeps stateful assistants continuous without leaking yesterday's work into stateless pipeline workers.
 
 ## External Agent Integration
 

--- a/docs/core-system/wordpress-as-agent-memory.md
+++ b/docs/core-system/wordpress-as-agent-memory.md
@@ -481,8 +481,11 @@ Agents with shell access can use the `memory` command for structured access:
 wp datamachine memory paths --allow-root
 
 # Read memory file
-wp datamachine memory files read SOUL.md --allow-root
-wp datamachine memory files read MEMORY.md --allow-root
+wp datamachine memory read SOUL.md --allow-root
+wp datamachine memory read MEMORY.md --allow-root
+
+# Read a section. Pass section names without the leading ##.
+wp datamachine memory read SOUL.md "Identity" --allow-root
 
 # List agent directory contents
 wp datamachine memory files list --allow-root
@@ -668,7 +671,7 @@ wp datamachine memory paths --relative --allow-root
 
 ```bash
 wp datamachine agents list --allow-root
-wp datamachine agents create --slug=bot --name="My Bot" --allow-root
+wp datamachine agents create bot --name="My Bot" --owner=1 --allow-root
 wp datamachine agents rename old-slug new-slug --allow-root
 ```
 
@@ -677,9 +680,10 @@ wp datamachine agents rename old-slug new-slug --allow-root
 ```bash
 wp datamachine memory paths --allow-root
 wp datamachine memory files list --allow-root
-wp datamachine memory files read <file> --allow-root
-wp datamachine memory files write <file> --content="..." --allow-root
-wp datamachine memory files edit <file> --old="..." --new="..." --allow-root
+wp datamachine memory read <file> --allow-root
+wp datamachine memory read <file> "Section" --allow-root
+wp datamachine memory write <file> "Section" "Content" --allow-root
+wp datamachine memory write "Section" --from-file=/tmp/content.md --mode=append --allow-root
 ```
 
 > **Note:** For workspace/git operations, install the `data-machine-code` extension and use `wp datamachine-code workspace`.

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -18,13 +18,14 @@ wp datamachine pipelines list
 wp datamachine pipelines get 5
 
 # Create a pipeline with steps
-wp datamachine pipelines create --name="My Pipeline" --steps='[{"type":"fetch","name":"RSS Fetch"}]'
+wp datamachine pipelines create --name="My Pipeline" --steps='[{"step_type":"fetch","label":"RSS Fetch"}]'
 
 # Update pipeline name or config
 wp datamachine pipelines update 5 --name="New Name" --config='{"key":"value"}'
 
-# Update pipeline system prompt
-wp datamachine pipelines update 5 --set-system-prompt --step=fetch_1
+# Update an AI step system prompt. If the pipeline has one AI step, --step is optional.
+wp datamachine pipelines update 5 --set-system-prompt="Write concise summaries."
+wp datamachine pipelines update 5 --step=5_abc123 --set-system-prompt="Write concise summaries."
 
 # Delete a pipeline
 wp datamachine pipelines delete 5 --force
@@ -236,6 +237,10 @@ wp datamachine agents show my-agent
 # Create a new agent
 wp datamachine agents create my-agent --name="My Agent" --owner=1
 
+# Read or update agent config
+wp datamachine agents config my-agent
+wp datamachine agents config my-agent --set='model=gpt-4o'
+
 # Rename an agent (updates DB and filesystem)
 wp datamachine agents rename old-slug new-slug --dry-run
 
@@ -246,28 +251,57 @@ wp datamachine agents delete my-agent --delete-files --yes
 wp datamachine agents access grant my-agent 2 --role=operator
 wp datamachine agents access revoke my-agent 2
 wp datamachine agents access list my-agent
+
+# Manage runtime bearer tokens. Raw token values are shown only at creation time.
+wp datamachine agents token create my-agent --label="ci" --expires-in=7776000
+wp datamachine agents token list my-agent
+wp datamachine agents token revoke my-agent 3
+
+# Portable agent bundle lifecycle
+wp datamachine agents export my-agent --format=zip --destination=/tmp/my-agent.zip
+wp datamachine agents import /tmp/my-agent.zip --dry-run
+wp datamachine agents install /tmp/my-agent-bundle --slug=my-agent --dry-run
+wp datamachine agents installed
+wp datamachine agents status my-agent
+wp datamachine agents diff /tmp/my-agent-bundle --slug=my-agent --format=json
+wp datamachine agents upgrade /tmp/my-agent-bundle --slug=my-agent --dry-run
+wp datamachine agents upgrade /tmp/my-agent-bundle --slug=my-agent --rebase-local --dry-run
+wp datamachine agents rebase /tmp/my-agent-bundle --slug=my-agent --artifact=flow:weekly-digest
+wp datamachine agents apply act_123
 ```
+
+Use `agent` or `agents` for agent identities, access, tokens, config, import/export, and bundle lifecycle. Memory files live under the separate `memory` namespace.
 
 ### datamachine memory
 
 Agent memory-file operations. **Since**: 0.30.0
 
+`memory` reads and writes layered markdown files and sections. It is not an alias for agent identity management; use `agent` or `agents` for CRUD, access grants, tokens, and bundles.
+
 ```bash
-# Read full memory
+# Read full MEMORY.md
 wp datamachine memory read
 
-# Read a specific section
-wp datamachine memory read "## State"
+# Read a specific MEMORY.md section. Pass section names without leading ##.
+wp datamachine memory read "State"
+
+# Read full files or sections in specific files
+wp datamachine memory read SOUL.md
+wp datamachine memory read SOUL.md "Identity"
+wp datamachine memory read USER.md --agent=my-agent
 
 # List sections
 wp datamachine memory sections
 
-# Write to a section
-wp datamachine memory write "## State" "Active and running"
-wp datamachine memory write "## State" "New note" --mode=append
+# Write to a section. Pass section names without leading ##.
+wp datamachine memory write "State" "Active and running"
+wp datamachine memory write "State" "New note" --mode=append
+wp datamachine memory write SOUL.md "Voice" "Concise and direct" --agent=my-agent
+wp datamachine memory write "Session Notes" --from-file=/tmp/notes.md --mode=append
+echo "- New lesson" | wp datamachine memory write "Lessons Learned" - --mode=append
 
 # Search memory
-wp datamachine memory search "deployment" --section="## State"
+wp datamachine memory search "deployment" --section="State"
 
 # Daily memory operations
 wp datamachine memory daily list
@@ -277,10 +311,9 @@ wp datamachine memory daily append 2026-03-15 "More notes"
 wp datamachine memory daily delete 2026-03-15
 wp datamachine memory daily search "keyword" --from=2026-03-01 --to=2026-03-15
 
-# Agent file management
+# Agent file listing and staleness checks. File content read/write is handled
+# by `memory read` and `memory write`, not by `memory files`.
 wp datamachine memory files list
-wp datamachine memory files read SOUL.md
-echo "content" | wp datamachine memory files write CUSTOM.md
 wp datamachine memory files check --days=7
 
 # Show resolved file paths for all memory layers
@@ -326,6 +359,79 @@ wp datamachine batch status 42
 # Cancel a running batch
 wp datamachine batch cancel 42
 ```
+
+### datamachine worker
+
+Headless automation worker. Composes stuck-job recovery with the Data Machine drain loop.
+
+```bash
+# Run a bounded worker loop
+wp datamachine worker run --time-limit=3600 --sleep=30
+
+# Run one recovery/drain pass and stop if approval is required.
+wp datamachine worker run --once --stop-on-pending-actions
+
+# Leave margin before an external supervisor timeout
+wp datamachine worker run --time-limit=900 --max-passes=10 --stop-before-timeout=60
+
+# Inspect queue/job status without draining
+wp datamachine worker status
+wp datamachine worker status --format=json
+```
+
+**Options**: `--time-limit`, `--batch-size`, `--drain-limit`, `--drain-time-limit`, `--sleep`, `--stuck-timeout`, `--no-recover-stuck`, `--stop-on-pending-actions`, `--max-passes`, `--stop-before-timeout`, `--once`, `--format`
+
+### datamachine drain
+
+Drain due Data Machine Action Scheduler actions until the queue is empty or a budget is reached.
+
+```bash
+# Drain all due Data Machine actions
+wp datamachine drain
+
+# Bound work for cron/supervisors
+wp datamachine drain --limit=500 --batch-size=25 --time-limit=300
+wp datamachine drain --limit=500 --time-limit=300 --format=json
+```
+
+**Options**: `--limit`, `--batch-size`, `--time-limit`, `--format=table|json`
+
+### datamachine cycle / cycles
+
+Run flows that are due during an external cycle. Manual flows participate only when their scheduling config sets `cycle_policy: every_cycle`.
+
+```bash
+# Run due flows for a named cycle, then drain Data Machine actions
+wp datamachine cycle run world-of-wordpress
+wp datamachine cycles run world-of-wordpress
+
+# Preview selected flows without starting jobs
+wp datamachine cycle run world-of-wordpress --dry-run --format=json
+
+# Start due flows but leave draining to another worker
+wp datamachine cycle run world-of-wordpress --no-drain
+```
+
+**Options**: `[<cycle>]`, `--dry-run`, `--[no-]drain`, `--format=table|json`
+
+### datamachine pending-actions
+
+Inspect durable pending approval actions. **Alias**: `pending-action`
+
+```bash
+# List approval actions
+wp datamachine pending-actions list
+wp datamachine pending-actions list --status=pending --kind=bundle_upgrade --format=json
+
+# Inspect one action
+wp datamachine pending-actions get act_123
+
+# Summarize counts by kind/status
+wp datamachine pending-actions summary
+wp datamachine pending-actions summary --status=pending --format=json
+```
+
+**Options**: `--status`, `--kind`, `--agent_id`, `--created_by`, `--limit`, `--offset`, `--format`
 
 ### datamachine image
 
@@ -547,9 +653,19 @@ wp datamachine step-types validate ai
 Processed items (deduplication). **Alias**: `processed-item`. **Since**: 0.41.0
 
 ```bash
+# Audit processed-item rows by flow/handler
+wp datamachine processed-items audit
+wp datamachine processed-items audit --handler=ticketmaster --min-waste=0
+
 # Clear processed items for a pipeline or flow
 wp datamachine processed-items clear --pipeline=5 --yes
 wp datamachine processed-items clear --flow=10 --yes
+wp datamachine processed-items clear --handler=ticketmaster --after=2025-01-01 --dry-run
+wp datamachine processed-items clear --all --yes
+
+# Clean dedupe rows whose jobs have been purged
+wp datamachine processed-items cleanup-orphans --dry-run
+wp datamachine processed-items cleanup-orphans --flow=10 --yes
 
 # Check if an item was processed
 wp datamachine processed-items check --flow-step=fetch_1_10 --source=rss --item="https://example.com/feed/1"
@@ -557,7 +673,7 @@ wp datamachine processed-items check --flow-step=fetch_1_10 --source=rss --item=
 # Check if a flow step has processing history
 wp datamachine processed-items history --flow-step=fetch_1_10
 
-# Revisit semantics (since 0.71.0) — time-windowed reads on processed_timestamp
+# Revisit semantics: time-windowed reads on processed_timestamp.
 # When was this item last processed?
 wp datamachine processed-items get-processed-at \
   --flow-step-id=fetch_1_10 --source-type=wiki_post --item-identifier=42
@@ -572,6 +688,8 @@ wp datamachine processed-items find-never-processed \
   --flow-step-id=fetch_1_10 --source-type=wiki_post \
   --candidate-ids=1,2,3,4
 ```
+
+**Options**: `audit` supports `--handler`, `--pipeline`, `--min-waste`, `--format`; `clear` supports `--pipeline`, `--flow`, `--handler`, `--after`, `--before`, `--all`, `--dry-run`, `--yes`; revisit helpers support `--flow-step-id`, `--source-type`, `--candidate-ids`, `--limit`, `--format`.
 
 ### datamachine links
 
@@ -668,17 +786,93 @@ wp datamachine indexnow enable
 wp datamachine indexnow disable
 ```
 
+### datamachine retention
+
+Inspect and schedule retention cleanup for jobs, logs, processed items, Action Scheduler rows, stale claims, files, and chat sessions.
+
+```bash
+# Show policies and storage metrics
+wp datamachine retention show
+wp datamachine retention show --format=json
+
+# Preview or schedule cleanup jobs
+wp datamachine retention run --dry-run
+wp datamachine retention run --yes
+```
+
+**Options**: `show --format=table|json|yaml`; `run --dry-run`, `--yes`, `--format=table|json|yaml`
+
+### datamachine email
+
+Send email and operate on an IMAP mailbox through configured email auth.
+
+```bash
+# Send mail
+wp datamachine email send --to=user@example.com --subject="Report" --body="<p>Hello</p>"
+
+# Fetch and read mail
+wp datamachine email fetch --search=UNSEEN --max=10
+wp datamachine email fetch --search=ALL --headers-only --fields=uid,from,subject,date
+wp datamachine email read 12345 --format=json
+
+# Reply and manage messages
+wp datamachine email reply --to=sender@example.com --subject="Re: Hello" --body="Thanks" --in-reply-to="<msgid@example.com>"
+wp datamachine email move 12345 Archive
+wp datamachine email flag 12345 Seen --action=clear
+wp datamachine email delete 12345 --yes
+
+# Batch mailbox operations
+wp datamachine email batch-move --search='FROM "github.com"' --destination="[Gmail]/GitHub" --yes
+wp datamachine email batch-flag --search=UNSEEN Flagged --max=10
+wp datamachine email batch-delete --search='SUBJECT "unsubscribe" BEFORE "1-Jan-2025"' --yes
+wp datamachine email unsubscribe 83012
+wp datamachine email batch-unsubscribe --search='SUBJECT "newsletter"' --max=10 --yes
+```
+
+### datamachine external
+
+Manage bearer-token connections to other Data Machine sites.
+
+```bash
+# Start browser authorization flow with a remote site
+wp datamachine external connect chubes.net chubes-bot --label="local-agent"
+
+# Manually store or list a remote token
+echo "$TOKEN" | wp datamachine external add chubes.net chubes-bot --verify
+wp datamachine external list
+wp datamachine external show chubes.net/chubes-bot
+
+# Test or call the remote site with the stored token
+wp datamachine external test chubes.net/chubes-bot
+wp datamachine external call chubes.net/chubes-bot GET /wp-json/wp/v2/users/me
+wp datamachine external call chubes.net/chubes-bot POST /wp-json/datamachine/v1/chat --body='{"message":"hello"}'
+
+# Remove a connection
+wp datamachine external remove chubes.net/chubes-bot --yes
+```
+
+### datamachine test / fetch test
+
+Dry-run fetch handlers and inspect packet summaries without creating jobs.
+
+```bash
+# List fetch-capable handlers
+wp datamachine test --list
+
+# Show handler config fields
+wp datamachine test rss --describe
+
+# Test with explicit config or an existing flow config
+wp datamachine test rss --config='{"feed_url":"https://example.com/feed"}' --limit=3
+wp datamachine test --flow=42 --format=json
+
+# Alias useful when the handler is passed by flag
+wp datamachine fetch test --handler=rss --config='{"feed_url":"https://example.com/feed"}'
+```
+
 ### Other registered commands
 
-The root namespace also registers specialized commands that are documented most accurately by WP-CLI help in the running install:
-
-- `wp datamachine ai`
-- `wp datamachine drain`
-- `wp datamachine email`
-- `wp datamachine external`
-- `wp datamachine retention`
-- `wp datamachine test`
-- `wp datamachine fetch test`
+The root namespace also registers `wp datamachine ai`; use `wp help datamachine ai` in a running install for the provider-specific diagnostic surface.
 
 ## Global Options
 
@@ -705,9 +899,11 @@ Most commands have singular and plural forms:
 - `wp datamachine handler` / `wp datamachine handlers`
 - `wp datamachine step-type` / `wp datamachine step-types`
 - `wp datamachine processed-item` / `wp datamachine processed-items`
+- `wp datamachine pending-action` / `wp datamachine pending-actions`
 - `wp datamachine setting` / `wp datamachine settings`
 - `wp datamachine agent` / `wp datamachine agents` (agent management)
-- `wp datamachine memory` (agent memory-file operations)
+- `wp datamachine cycle` / `wp datamachine cycles`
+- `wp datamachine memory` (agent memory-file operations; no singular/plural agent alias)
 
 ## Examples
 
@@ -745,5 +941,5 @@ fi
 ```bash
 # Read current memory, update a section, verify
 wp datamachine memory read
-wp datamachine memory write "## Status" "All systems operational"
+wp datamachine memory write "Status" "All systems operational"
 wp datamachine memory search "operational"

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -1591,7 +1591,7 @@ arrays are projection shapes at provider boundaries, not the store contract.
 - `count_unread` — pure derivation from a messages array
 - `cleanup_expired_sessions / cleanup_old_sessions / cleanup_orphaned_sessions` — scheduled cleanup
 - `list_sessions_for_day` — day-scoped summary rows for the Daily Memory Task
-- `get_storage_metrics` — row count + on-disk size for the `wp datamachine retention status` CLI; return `null` to opt out
+- `get_storage_metrics` — row count + on-disk size for the `wp datamachine retention show` CLI; return `null` to opt out
 
 ### WP_Agent_Memory_Store (`/agents-api/inc/Core/FilesRepository/WP_Agent_Memory_Store.php`)
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -248,9 +248,7 @@ See Handler Registration Trait for complete documentation.
 
 ### `datamachine_tools`
 
-**Purpose**: Unified registry for every AI tool — static global tools AND per-handler
-runtime-generated tools. Consumed by `ToolPolicyResolver` when gathering the
-available tool set for a pipeline or chat context.
+**Purpose**: Unified Data Machine registry for AI tools — static registry tools and per-handler runtime-generated tools. Adapted by `DataMachineToolRegistrySource` and consumed through `ToolPolicyResolver::resolve()`.
 
 **Parameters**:
 
@@ -258,7 +256,7 @@ available tool set for a pipeline or chat context.
 
 **Return**: Modified tools array
 
-#### Static tool entry (global tools)
+#### Static tool entry
 
 ```php
 add_filter('datamachine_tools', function($tools) {
@@ -1428,9 +1426,7 @@ Builds parameters for handler-specific tools with engine data merging (source_ur
 
 #### `ToolPolicyResolver::resolve()`
 
-Tool discovery moved from `ToolExecutor::getAvailableTools()` (removed in 0.79)
-to `ToolPolicyResolver::resolve()`. Single entry point for chat and pipeline
-modes.
+Tool discovery uses `ToolPolicyResolver::resolve()`. This is the single entry point for chat, pipeline, system, and custom modes.
 
 ```php
 $resolver = new \DataMachine\Engine\AI\Tools\ToolPolicyResolver();
@@ -1446,10 +1442,11 @@ $tools = $resolver->resolve( array(
 
 **Discovery Process**:
 
-1. Handler Tools - Retrieved via `datamachine_tools` filter (runtime-resolved `_handler_callable` entries)
-2. Global Tools - Retrieved via `datamachine_global_tools` filter
-3. Chat Tools - Retrieved via `datamachine_chat_tools` filter (chat only)
-4. Enablement Check - Each tool filtered through `datamachine_tool_enabled`
+1. Source composition - `ToolSourceRegistry` gathers `adjacent_handlers` and/or `static_registry` for the mode.
+2. Static registry - `DataMachineToolRegistrySource` adapts `datamachine_tools`, filters by `modes`, and checks source-level availability/configuration.
+3. Adjacent handlers - `AdjacentHandlerToolSource` resolves `_handler_callable` entries from previous/next pipeline steps.
+4. Policy resolution - Agents API tool policy applies deny, allow-only, category, mode, mandatory-tool, and chat access rules.
+5. Final filter - `datamachine_resolved_tools` can adjust the resolved set.
 
 ### AIConversationLoop (`/inc/Engine/AI/AIConversationLoop.php`)
 

--- a/docs/development/hooks/engine-filters.md
+++ b/docs/development/hooks/engine-filters.md
@@ -81,7 +81,7 @@ Tools are registered via a single unified filter. Per-mode tool partitioning is 
 
 ### datamachine_tools
 
-Single registry for all AI tools. Used by `ToolManager::getRawToolsForMode()` to assemble the available tool set for a given execution mode.
+Single Data Machine registry for AI tools. `ToolManager` reads this registry, `ToolSourceRegistry` composes source pools, and `ToolPolicyResolver::resolve()` assembles the final request-visible tool set for a mode.
 
 **Hook usage**:
 
@@ -107,7 +107,8 @@ $tools = apply_filters( 'datamachine_tools', array() );
     ],
     'modes'            => ['chat'],             // which modes can see this tool
     'requires_config'  => true,                 // checked via datamachine_tool_configured
-    'category'         => 'search',             // optional grouping
+    'ability'          => 'my-plugin/search',   // optional Ability link for permissions/categories
+    'access_level'     => 'admin',              // fallback when no ability is linked
 ]
 ```
 
@@ -133,9 +134,9 @@ add_filter( 'datamachine_tools', function ( $tools ) {
 } );
 ```
 
-Use `pipeline` mode only when a static/global tool is useful inside an automated pipeline AI step. Chat affordances and tools that duplicate engine-level validation should stay `chat`-only; pipeline AI steps already receive step-scoped handler tools plus pipeline/flow memory directives.
+Use `pipeline` mode only when a static registry tool is useful inside an automated pipeline AI step. Use `pipeline_policy` for powerful tools that should stay hidden from pipeline by default but can be explicitly granted through `enabled_tools`. Chat affordances and tools that duplicate engine-level validation should stay `chat`-only; pipeline AI steps already receive adjacent handler tools plus pipeline/flow memory directives.
 
-> The legacy `datamachine_global_tools` and `datamachine_chat_tools` filters were consolidated into `datamachine_tools` in v0.68.0 (PR #1130). The old per-mode filters no longer exist.
+> Earlier per-mode tool filters were consolidated into `datamachine_tools` in v0.68.0 (PR #1130). Register current tools through the unified registry and declare `modes` on the tool definition.
 
 ### datamachine_tool_configured
 
@@ -166,7 +167,7 @@ add_filter( 'datamachine_tool_configured', function ( $configured, $tool_id ) {
 }, 10, 2 );
 ```
 
-> Tool *availability* (whether the AI sees the tool in this request) is now resolved by `ToolManager::is_tool_available()`, not by a public filter. The `datamachine_tool_enabled` filter from earlier versions has been removed in favour of `ToolManager`'s direct logic, which combines configuration state, mode membership, and per-step `enabled_tools` settings.
+> Tool *visibility* (whether the AI sees the tool in this request) is resolved by `ToolPolicyResolver::resolve()`. `ToolManager::is_tool_available()` is a source-level check for global enablement and configuration. The earlier public enablement filter is not part of the current runtime path.
 
 ## Handler Registration
 
@@ -203,6 +204,6 @@ Handlers (fetch / publish / upsert) are registered via the `HandlerRegistrationT
 ## Related Documentation
 
 - [AI Directives System](../../core-system/ai-directives.md) — Built-in directive list, priorities, modes
-- [Tool Manager](../../core-system/tool-manager.md) — Tool availability resolution
-- [Tool Execution](../../core-system/tool-execution.md) — Tool dispatch and result handling
+- [Tool Manager](../../core-system/tool-manager.md) — Data Machine registry, source-level availability, and handler tool expansion
+- [Tool Execution](../../core-system/tool-execution.md) — Tool dispatch, action policy, and approval staging
 - [Core Filters](core-filters.md) — Handler registration filters and OAuth service discovery

--- a/docs/handlers/fetch/handlers-overview.md
+++ b/docs/handlers/fetch/handlers-overview.md
@@ -1,6 +1,6 @@
 # Fetch Handlers Overview
 
-Fetch handlers retrieve content from various sources and convert it into standardized DataPackets for pipeline processing.
+Fetch handlers retrieve content from various sources and convert it into standardized `DataPacket` objects for pipeline processing.
 
 ## Available Handlers
 
@@ -48,14 +48,15 @@ Fetch handlers retrieve content from various sources and convert it into standar
 
 **Base Class Architecture** (@since v0.2.1):
 
-All fetch handlers extend `FetchHandler` base class (`/inc/Core/Steps/Fetch/Handlers/FetchHandler.php`) which provides:
-- Deduplication checking via `isItemProcessed()` and `markItemProcessed()`
+All fetch handlers extend [`FetchHandler`](../../../inc/Core/Steps/Fetch/Handlers/FetchHandler.php), which provides:
+- Output normalization into `DataPacket` objects
+- Deduplication and in-flight claim checks through `ExecutionContext`
+- `max_items` capping after dedupe and before claims
 - Engine data storage via `storeEngineData()`
-- Remote file downloading via `downloadRemoteFile()`
+- Remote file downloading via `ExecutionContext::downloadFile()`
 - Timeframe filtering via `applyTimeframeFilter()`
 - Keyword search filtering via `applyKeywordSearch()`
 - Standardized logging via `log()`
-- Response formatting via `successResponse()` and `emptyResponse()`
 
 ### `get_fetch_data()` Method
 
@@ -65,35 +66,71 @@ All fetch handlers implement the same public interface:
 public function get_fetch_data(int|string $pipeline_id, array $handler_config, ?string $job_id = null): array
 ```
 
-Internally, the base class creates an `ExecutionContext` and calls:
+[`FetchStep`](../../../inc/Core/Steps/Fetch/FetchStep.php) resolves portable `auth_ref` handler config before invoking the handler. Internally, the final base-class entry point creates an [`ExecutionContext`](../../../inc/Core/ExecutionContext.php) and calls:
 ```php
 abstract protected function executeFetch(array $config, ExecutionContext $context): array
 ```
 
 **Parameters**:
-- `$pipeline_id` - Pipeline ID or `'direct'` for direct execution mode
-- `$handler_config` - Handler-specific configuration (must include `flow_id`, `flow_step_id`, `pipeline_id`)
-- `$job_id` - Job identifier for deduplication tracking and engine data storage
+- `$pipeline_id` - Pipeline ID, or `'direct'` for direct execution mode
+- `$handler_config` - Flat handler configuration. Flow execution adds `flow_id`, `flow_step_id`, and `pipeline_id`; direct mode may use the `'direct'` sentinel values.
+- `$job_id` - Job identifier for engine data storage and in-flight claims
 
 **ExecutionContext provides**:
 - `$context->getPipelineId()` - Returns `int|string` (numeric ID or `'direct'`)
 - `$context->getFlowId()` - Returns `int|string` (numeric ID or `'direct'`)
 - `$context->getJobId()` - Returns `?string`
 - `$context->isItemProcessed($id)` - Check deduplication (always false in direct mode)
-- `$context->markItemProcessed($id)` - Mark item processed (no-op in direct mode)
+- `$context->isItemClaimed($id)` - Check whether another in-flight run already claimed the item (always false in direct/standalone modes)
+- `$context->claimItemForProcessing($id)` - Atomically claim an item for this job (successful no-op in direct/standalone modes)
+- `$context->markItemProcessed($id)` - Mark item processed (no-op in direct/standalone modes)
 - `$context->log($level, $message, $extra)` - Contextual logging
 - `$context->storeEngineData($data)` - Store data for downstream steps
 - `$context->getFileContext()` - Get file storage context array
 - `$context->isDirect()` - Check if running in direct execution mode
 
-**Return**: Array of DataPacket objects
+**Return**: Array of `DataPacket` objects. Child handlers return plain arrays; `FetchHandler::get_fetch_data()` normalizes those arrays into packets.
+
+### Handler Output Shapes
+
+Child handlers should return one of these plain-array shapes from `executeFetch()`:
+
+```php
+// Preferred: explicit list, supports zero, one, or many items.
+return [
+    'items' => [
+        [
+            'title' => 'Content Title',
+            'content' => 'Content body...',
+            'file_info' => null,
+            'metadata' => [
+                'item_identifier' => 'stable-source-id',
+                'original_id' => 'source-id',
+            ],
+        ],
+    ],
+];
+
+// Also accepted: one item as the whole result.
+return [
+    'title' => 'Content Title',
+    'content' => 'Content body...',
+    'metadata' => [ 'item_identifier' => 'stable-source-id' ],
+];
+
+// Empty result.
+return [ 'items' => [] ];
+```
+
+Do not return legacy `processed_items` arrays. They are not the fetch base-class contract.
 
 ### Clean DataPacket Format (AI-visible)
 
 ```php
 [
     'data' => [
-        'content_string' => "Source: Site Name\n\nTitle: Content Title\n\nContent body...",
+        'title' => 'Content Title',
+        'body' => "Source: Site Name\n\nTitle: Content Title\n\nContent body...",
         'file_info' => null // or file information array
     ],
     'metadata' => [
@@ -146,11 +183,19 @@ if (!$context->isItemProcessed($item_identifier)) {
 }
 ```
 
-Fetch handlers identify candidate items; completed items are marked processed after the full pipeline finishes successfully so downstream failures do not permanently drop content.
+Fetch handlers identify candidate items. The base class filters already-processed items and active claims, applies `max_items`, then claims only the selected items for the current job. Completed items are marked processed after the full pipeline finishes successfully so downstream failures do not permanently drop content.
 
 **Scope**: Per-flow-step deduplication (same item can be processed by different flows)
 **Persistence**: Stored in `wp_datamachine_processed_items` table
 **Cleanup**: Automatic cleanup with job completion
+
+### `max_items` and Claims
+
+- `max_items` is a flat handler config value. If omitted, `FetchHandler::getDefaultMaxItems()` defaults to `1`.
+- `max_items = 0` means unlimited.
+- Claims are created after dedupe and after `max_items`, so items that do not fit in the current batch remain eligible for future runs.
+- Final processed marking is deferred to successful pipeline completion, not fetch completion.
+- Direct and standalone execution modes skip persisted dedupe and claims; the methods return safe no-op defaults.
 
 ### Source Type Identifiers
 
@@ -170,12 +215,15 @@ Extension plugins can register additional fetch handlers and source type identif
 ```php
 $handler_config = [
     'flow_step_id' => $flow_step_id, // Added by engine
-    'handler_specific_key' => [
-        'setting1' => 'value1',
-        'setting2' => 'value2'
-    ]
+    'pipeline_id' => $pipeline_id,   // Added by engine
+    'flow_id' => $flow_id,           // Added by engine
+    'setting1' => 'value1',          // Handler-specific settings are flat
+    'setting2' => 'value2',
+    'max_items' => 5,
 ];
 ```
+
+The base class passes this flat array to `executeFetch()` as `$config`. Do not wrap handler settings under the handler slug unless the handler explicitly documents that nested shape.
 
 ### Common Settings
 
@@ -204,7 +252,7 @@ if (empty($required_setting)) {
         'handler' => 'handler_name',
         'setting' => 'required_setting'
     ]);
-    return ['processed_items' => []];
+    return ['items' => []];
 }
 ```
 
@@ -224,13 +272,14 @@ if (empty($required_setting)) {
 
 ## Performance Considerations
 
-### Single Item Execution Model
+### Bounded Batch Execution Model
 
-All fetch handlers follow the system-wide **Single Item Execution Model**:
-- Finds first eligible unprocessed item.
-- Marks as processed immediately to prevent concurrency issues.
-- Returns exactly one DataPacket (or an empty array if no new content exists).
-- Ensures job-level isolation and reliability.
+Fetch handlers follow a bounded batch model:
+- Child handlers may return zero, one, or many candidate items.
+- The base class filters processed and claimed items.
+- The base class applies `max_items` before claiming work.
+- The base class returns one `DataPacket` per selected item.
+- Final processed marking happens only after the downstream pipeline completes successfully.
 
 ### Memory Optimization
 
@@ -255,6 +304,13 @@ Fetch handlers provide essential metadata that AI steps use for content processi
 **Content Structure**: All handlers structure content in consistent format that AI steps process through the modular AI directive system.
 
 **Metadata Preservation**: Handler metadata (original titles, dates) flows through pipeline to AI tools via WP_Agent_Tool_Parameters while URLs are accessed via engine data filter.
+
+## Core vs Extension Boundaries
+
+- Core owns the handler base classes, `ExecutionContext`, processed-item ledger, claims, engine data storage, `auth_ref` resolution, and handler-tool resolution.
+- Extensions own source/platform-specific API calls, settings classes, auth providers, and handler registration.
+- Extensions should register handlers and tools through `HandlerRegistrationTrait` where possible instead of reimplementing core filters.
+- Extensions should return plain handler output arrays and let core normalize packets, apply dedupe, create claims, resolve `auth_ref`, and track posts.
 
 ### Tool-First Architecture Support
 
@@ -285,7 +341,7 @@ $result = $wordpress_handler->get_fetch_data(
     ['wordpress_posts' => ['post_type' => 'post']],
     $job_id
 );
-// Returns: ['processed_items' => [...]]
+// Returns: DataPacket[]
 // Engine data stored separately in database via centralized datamachine_engine_data filter
 ```
 
@@ -305,7 +361,7 @@ foreach ($potential_items as $item) {
         ];
     }
 }
-return ['processed_items' => []]; // No unprocessed items
+return ['items' => []]; // No unprocessed items
 ```
 
 ## Extension Development
@@ -324,31 +380,24 @@ class CustomFetchHandler extends FetchHandler {
         // Fetch data from source
         $items = $this->fetch_from_source($source_config);
 
-        // Process first unprocessed item
+        // Return candidate items. The base class applies dedupe, max_items, and claims.
+        $candidates = [];
         foreach ($items as $item) {
-            if ($context->isItemProcessed((string) $item['id'])) {
-                continue;
-            }
-
             // Store engine data via centralized filter (array storage)
             $context->storeEngineData([
                 'source_url' => $item['url'],
                 'image_url' => $item['image'] ?? ''
             ]);
 
-            return [
-                'items' => [
-                    [
-                        'title' => $item['title'],
-                        'content' => $item['content'],
-                        'metadata' => [
-                            'item_identifier' => (string) $item['id'],
-                        ],
-                    ],
+            $candidates[] = [
+                'title' => $item['title'],
+                'content' => $item['content'],
+                'metadata' => [
+                    'item_identifier' => (string) $item['id'],
                 ],
             ];
         }
 
-        return ['items' => []];
+        return ['items' => $candidates];
     }
 }

--- a/docs/handlers/publish/handlers-overview.md
+++ b/docs/handlers/publish/handlers-overview.md
@@ -1,6 +1,6 @@
 # Publish Handlers Overview
 
-Publish handlers distribute processed content to external platforms using AI tool calling architecture. All handlers implement the `handle_tool_call()` method for agentic execution.
+Publish handlers distribute processed content to external platforms using the AI tool-calling architecture. Custom handlers extend the publish base class and implement `executePublish()`; the base class owns the final `handle_tool_call()` entry point.
 
 ## Available Handlers
 
@@ -54,14 +54,16 @@ if ($link_handling === 'append' && !empty($source_url) && filter_var($source_url
 
 **Base Class Architecture** (@since v0.2.1):
 
-All publish handlers extend `PublishHandler` base class (`/inc/Core/Steps/Publish/Handlers/PublishHandler.php`) which provides:
+All publish handlers extend [`PublishHandler`](../../../inc/Core/Steps/Publish/Handlers/PublishHandler.php), which provides:
 - Engine data retrieval via `getEngineData()`, `getSourceUrl()`, `getImageFilePath()`
 - Image validation via `validateImage()`
+- `auth_ref` runtime resolution via `AuthRefHandlerConfig::resolve_runtime_config()`
+- Dry-run preview handling
 - Response formatting via `successResponse()` and `errorResponse()`
 - Centralized logging via `log()`
 - Standardized error handling
 
-The base class provides `handle_tool_call()` as the final public entry point, calling abstract `executePublish()` method in child classes.
+The base class provides `handle_tool_call()` as the final public entry point and calls the abstract `executePublish()` method in child classes. Do not override `handle_tool_call()` in extension handlers unless the base class is not being used.
 
 ### `handle_tool_call()` Interface
 
@@ -78,7 +80,16 @@ abstract protected function executePublish(array $parameters, array $handler_con
 
 **Parameters Structure**:
 - `$parameters` - AI-provided parameters (content, etc.)
-- `$tool_def` - Tool definition with handler configuration
+- `$tool_def` - Tool definition with handler configuration and handler slug
+
+Before `executePublish()` runs, the base class:
+
+- Requires `job_id`.
+- Loads job engine data and injects an `EngineData` object as `$parameters['engine']`.
+- Resolves portable `auth_ref` handler config into runtime credentials when present.
+- Returns a dry-run preview when engine data contains `dry_run_mode`.
+
+Post-origin tracking is centralized in [`ToolExecutor`](../../../inc/Engine/AI/Tools/ToolExecutor.php). Handler base classes and extensions should return an extractable post ID in the tool result; they should not call post-tracking helpers directly.
 
 **Return Structure**:
 ```php
@@ -96,9 +107,7 @@ abstract protected function executePublish(array $parameters, array $handler_con
 
 ### AI Tool Registration
 
-Each handler registers its tool through the unified `datamachine_tools` registry.
-The preferred path is `HandlerRegistrationTrait::registerHandler()` which wires
-the callback for you; the equivalent manual registration shape is:
+Each handler registers its tool through the unified `datamachine_tools` registry. The preferred path is [`HandlerRegistrationTrait::registerHandler()`](../../../inc/Core/Steps/HandlerRegistrationTrait.php), which wires the callback for you. The equivalent manual registration shape is:
 
 ```php
 add_filter('datamachine_tools', function($tools) {
@@ -129,6 +138,15 @@ add_filter('datamachine_tools', function($tools) {
 });
 ```
 
+Handler tool entries are deferred registry entries, not directly executable tools. `ToolManager::resolveHandlerTools()` resolves entries whose `handler` exactly matches the adjacent step handler slug. Cross-cutting tools may use `handler_types`, for example `['fetch', 'event_import']`, which matches against `datamachine_handlers` metadata.
+
+Callback conventions supported by `ToolManager`:
+
+- **Direct-style** callbacks receive `($handler_slug, $handler_config, $engine_data)` and return `['tool_name' => $tool_definition]`.
+- **Filter-style** callbacks receive `($tools, $handler_slug, $handler_config, $engine_data)` and return the updated tool map.
+
+The resolver detects filter-style callbacks by reflection: callbacks with four or more parameters, or a first parameter named `$tools` or `$all_tools`, are invoked with the filter-style shape. New code should prefer direct-style callbacks unless it is migrating an existing filter-style tool builder.
+
 ## Common Features
 
 ### Handler Configuration
@@ -136,19 +154,18 @@ add_filter('datamachine_tools', function($tools) {
 **Configuration Structure**:
 ```php
 $handler_config = [
-    'handler_name' => [
-        'setting1' => 'value1',
-        'enable_feature' => true,
-        'platform_specific_option' => 'option_value'
-    ]
+    'setting1' => 'value1',
+    'enable_feature' => true,
+    'platform_specific_option' => 'option_value',
 ];
 ```
 
 **Tool Definition Integration**:
 ```php
 $handler_config = $tool_def['handler_config'] ?? [];
-$platform_config = $handler_config['platform_name'] ?? $handler_config;
 ```
+
+Handler config is flat at runtime. `AuthRefHandlerConfig::resolve_runtime_config()` may merge local credentials into that flat config before `executePublish()` receives it.
 
 ### Content Processing
 
@@ -303,8 +320,14 @@ $pipeline_steps = [
 ### Custom Publish Handler
 
 ```php
-class CustomPublishHandler {
-    public function handle_tool_call(array $parameters, array $tool_def = []): array {
+use DataMachine\Core\Steps\Publish\Handlers\PublishHandler;
+
+class CustomPublishHandler extends PublishHandler {
+    public function __construct() {
+        parent::__construct('custom_platform');
+    }
+
+    protected function executePublish(array $parameters, array $handler_config): array {
         // Validate parameters
         if (empty($parameters['content'])) {
             return [
@@ -314,13 +337,13 @@ class CustomPublishHandler {
             ];
         }
 
-        // Get configuration
-        $handler_config = $tool_def['handler_config'] ?? [];
-        $custom_config = $handler_config['custom_platform'] ?? [];
+        $custom_config = $handler_config;
+        $engine = $parameters['engine'];
+        $source_url = $engine->getSourceUrl();
 
         // Publish to platform
         try {
-            $result = $this->publish_to_platform($parameters['content'], $custom_config);
+            $result = $this->publish_to_platform($parameters['content'], $custom_config, $source_url);
 
             return [
                 'success' => true,
@@ -372,3 +395,10 @@ add_filter('datamachine_tools', function($tools) {
     return $tools;
 });
 ```
+
+## Core vs Extension Boundaries
+
+- Core owns `PublishHandler::handle_tool_call()`, engine data loading, dry-run previews, `auth_ref` resolution, tool execution, and centralized post-origin tracking.
+- Extensions own platform-specific API clients, settings classes, auth providers, and `executePublish()` implementation details.
+- Extensions should return standard tool results and allow `ToolExecutor` to apply post tracking when a post ID is present.
+- Extensions should register handler tools as deferred `_handler_callable` entries and let `ToolManager` resolve exact-slug or `handler_types` matches at pipeline runtime.

--- a/docs/handlers/upsert/wordpress-update.md
+++ b/docs/handlers/upsert/wordpress-update.md
@@ -1,21 +1,27 @@
 # WordPress Update Handler
 
-Updates existing WordPress posts and pages in the local installation using native WordPress functions with selective field updates and taxonomy management.
+Updates existing WordPress posts and pages in the local installation using the `datamachine/update-wordpress` ability with selective field updates and taxonomy management.
 
 ## Architecture
 
-**Base Class**: Extends PublishHandler (@since v0.2.1)
+**Base Class**: Extends [`UpsertHandler`](../../../inc/Core/Steps/Upsert/Handlers/UpsertHandler.php)
 
 **Inherited Functionality**:
 - Engine data retrieval for source_url matching
 - Standardized response formatting
-- Centralized logging and error handling
+- Centralized error handling
+- Final `handle_tool_call()` entry point
+- Runtime `auth_ref` resolution via `AuthRefHandlerConfig::resolve_runtime_config()`
 
-**Requirements**: Requires `source_url` from engine data (provided by fetch handlers or AI tools)
+**Registration**: The handler registers as slug `wordpress_update` with handler type `upsert` via [`HandlerRegistrationTrait`](../../../inc/Core/Steps/HandlerRegistrationTrait.php).
+
+**Requirements**: Requires `job_id` and `source_url`. The `job_id` is added by tool execution; `source_url` is normally available from the prior fetch step's engine data and should be provided to the tool call for post identification.
 
 ## Local WordPress Integration
 
-**wp_update_post**: Uses WordPress's native `wp_update_post()` function for content modification.
+**Ability Delegation**: The handler delegates modification work to the `datamachine/update-wordpress` ability.
+
+**wp_update_post**: The ability uses WordPress's native `wp_update_post()` function for content modification.
 
 **URL-based Identification**: Extracts post ID from source URLs using `url_to_postid()` function.
 
@@ -24,7 +30,8 @@ Updates existing WordPress posts and pages in the local installation using nativ
 ## Required Parameters
 
 **Tool Call Parameters**:
-- `source_url`: WordPress post/page URL (required for post identification, provided by centralized engine data via datamachine_engine_data filter)
+- `job_id`: Required by `UpsertHandler::handle_tool_call()` and injected by the tool executor during pipeline runs
+- `source_url`: WordPress post/page URL, required for post identification
 
 **Optional Update Parameters**:
 - `title`: New post title (updates `post_title`)
@@ -40,6 +47,7 @@ Updates existing WordPress posts and pages in the local installation using nativ
 // Note: source_url is automatically provided via centralized datamachine_engine_data filter
 // from the fetch handler that originally retrieved the content
 $parameters = [
+    'job_id' => 456,
     'source_url' => 'https://site.com/existing-post/',  // From engine data
     'content' => 'Updated post content with <strong>HTML formatting</strong>.'
 ];
@@ -179,6 +187,10 @@ $parameters = [
 
 **Source URL Requirement**: Requires source URL from centralized engine data via datamachine_engine_data filter for post identification, making it suitable for content update workflows.
 
+**Base-Class Entry Point**: Upsert tools should route through `UpsertHandler::handle_tool_call()`. The base class validates `job_id`, creates an `EngineData` wrapper, resolves runtime `auth_ref` config, and then calls `executeUpsert()`.
+
+**Centralized Post Tracking**: Post origin tracking is applied centrally in `ToolExecutor::executeTool()` after successful tool calls. Upsert handlers should return an extractable post ID in their result and should not write origin tracking metadata themselves.
+
 **ToolResultFinder Integration** (@since v0.2.0): UpsertStep uses the `ToolResultFinder` utility class for locating handler tool execution results in data packets.
 
 **Tool Result Search Pattern**:
@@ -210,7 +222,7 @@ return [];
 - Centralizes search logic eliminating code duplication
 
 **Benefits**:
-- Universal search utility shared across all update handlers
+- Universal search utility shared across all upsert handlers
 - Consistent tool result detection across step types
 - Simplified upsert handler implementation
 - Centralized maintenance for search improvements
@@ -220,3 +232,10 @@ return [];
 **Selective Modification**: Allows targeted updates without affecting other post aspects.
 
 **Logging**: Detailed debug logging for URL resolution, update operations, taxonomy assignments, and error conditions.
+
+## Core vs Extension Boundaries
+
+- Core owns [`UpsertHandler`](../../../inc/Core/Steps/Upsert/Handlers/UpsertHandler.php), `UpsertStep`, handler-tool execution, runtime `auth_ref` resolution, and centralized post-origin tracking.
+- The WordPress upsert handler owns only the WordPress-specific tool definition and `executeUpsert()` implementation.
+- The handler delegates mutation logic to the `datamachine/update-wordpress` ability instead of duplicating post update behavior in the handler layer.
+- Extension upsert handlers should register with handler type `upsert`, expose tools through deferred `_handler_callable` entries, route execution through the base `handle_tool_call()`, and return standard success/error tool results.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -142,10 +142,10 @@ wp datamachine jobs undo <job_id> --dry-run --allow-root
 
 ## AI Integration
 
-- **Tool-first architecture** enables AI agents (pipeline and chat) to call tools that interact with handlers, external APIs, or workflow metadata.
+- **Tool-first architecture** enables AI agents (pipeline, chat, and system) to call tools resolved through `ToolPolicyResolver`, `ToolSourceRegistry`, and the Data Machine `datamachine_tools` registry.
 - **PromptBuilder + RequestBuilder** apply layered directives via the `datamachine_directives` filter so every request includes identity, context, and site-specific instructions.
-- **Global tools** (Google Search, Local Search, Web Fetch, WordPress Post Reader) are registered under `/inc/Engine/AI/Tools/` and available to all agents.
-- **Chat-specific tools** (AddPipelineStep, ApiQuery, AuthenticateHandler, ConfigureFlowSteps, ConfigurePipelineStep, CopyFlow, CreateFlow, CreatePipeline, CreateTaxonomyTerm, ExecuteWorkflowTool, GetHandlerDefaults, ManageLogs, ReadLogs, RunFlow, SearchTaxonomyTerms, SetHandlerDefaults, UpdateFlow) orchestrate pipeline and flow management within conversations.
+- **Static registry tools** include research, site operations, memory, and workflow-management tools whose `modes` decide whether they appear in chat, pipeline, or system requests.
+- **Adjacent handler tools** are generated from previous/next pipeline steps so AI steps can publish, upsert, or skip items using the neighboring handler configuration.
 - **WP_Agent_Tool_Parameters + ToolResultFinder** gather parameter metadata for tools and interpret results inside data packets to keep conversations consistent.
 
 ## Authentication & Security
@@ -180,6 +180,6 @@ wp datamachine jobs undo <job_id> --dry-run --allow-root
 - **Multi-platform publishing** via core fetch/publish/upsert handlers for files, RSS, email, and WordPress, plus extension-provided handlers for social, business, and event destinations.
 - **Daily memory system** for automatic temporal knowledge management with AI-driven pruning.
 - **System tasks** for background AI operations (image generation, alt text, internal linking, meta descriptions) with undo support.
-- **Extension points** through filters such as `datamachine_handlers`, `datamachine_tools`, `datamachine_step_types`, `datamachine_auth_providers`, and `datamachine_engine_data`.
+- **Extension points** through filters such as `datamachine_handlers`, `datamachine_tools`, `agents_api_tool_sources`, `datamachine_step_types`, `datamachine_auth_providers`, and `datamachine_engine_data`.
 - **Directive orchestration** ensures every AI request is context-aware, tool-enabled, and consistent with site policies.
 - **Chartable logging, deduplication, and error handling** keep operators informed about job outcomes and prevent duplicate processing.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -65,7 +65,7 @@ Markdown files organized in three layers:
 |-------|-----------|----------|
 | **Shared** | shared layer | SITE.md, RULES.md (site-wide context) |
 | **Agent** | agent slug layer | SOUL.md, MEMORY.md (agent identity and knowledge) |
-| **User** | user ID layer | USER.md, MEMORY.md (human preferences) |
+| **User** | user ID layer | USER.md (human preferences) |
 
 ### Daily Memory System
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -71,10 +71,10 @@ Markdown files organized in three layers:
 
 Temporal knowledge is preserved in date-organized daily memory files. The **DailyMemoryTask** system task automatically:
 
-1. Synthesizes daily activity into summary files
-2. Prunes MEMORY.md when it exceeds 8KB, archiving session-specific content to daily files
+1. Maintains `MEMORY.md` with the single `daily_memory` prompt when activity or size requires compaction
+2. Archives session-specific content to daily files, including deterministic overflow artifacts for very large memory files
 
-Pipelines can selectively inject daily memory via the **DailyMemorySelectorDirective** with modes: recent days, specific dates, date range, or by month.
+Agents can opt into recent daily memory injection via **AgentDailyMemoryDirective** (`agent_config.daily_memory`). Precise historical lookups use the `agent_daily_memory` tool.
 
 ### Memory Path Discovery
 


### PR DESCRIPTION
## Summary
- Refreshes the REST API index around the current route groups and permission model.
- Adds agent-facing navigation for missing or underdocumented API surfaces.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing route registration against docs, drafting the updated inventory, and preparing the PR text for Chris to review.