### PR TITLE
docs: reconcile WP-CLI command reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,16 +161,21 @@ Agent executes → Agent queues next task → Loop continues
 ## WP-CLI
 
 ```bash
-wp datamachine agents           # Agent management and path discovery
+wp datamachine agents           # Agent identities, access, tokens, bundles
+wp datamachine memory           # Layered memory files and path discovery
 wp datamachine pipelines        # Pipeline CRUD
 wp datamachine flows            # Flow CRUD and queue management
 wp datamachine jobs             # Job management, monitoring, undo
+wp datamachine worker           # Headless worker loop
+wp datamachine drain            # Drain due Data Machine actions
+wp datamachine cycle            # Run due flows for an external cycle
+wp datamachine pending-actions  # Inspect approval queues
 wp datamachine settings         # Plugin settings
 wp datamachine posts            # Query Data Machine-created posts
 wp datamachine logs             # Log operations
-wp datamachine memory           # Agent memory read/write
 wp datamachine handlers         # List registered handlers
 wp datamachine step-types       # List registered step types
+wp datamachine processed-items  # Deduplication tracking
 wp datamachine chat             # Chat agent interface
 wp datamachine alt-text         # AI alt text generation
 wp datamachine links            # Internal linking
@@ -178,9 +183,14 @@ wp datamachine blocks           # Gutenberg block operations
 wp datamachine image            # Image generation
 wp datamachine meta-description # SEO meta descriptions
 wp datamachine auth             # OAuth provider management
+wp datamachine email            # Email send/fetch/reply operations
+wp datamachine external         # Remote Data Machine site connections
+wp datamachine indexnow         # IndexNow indexing integration
 wp datamachine taxonomy         # Taxonomy operations
 wp datamachine batch            # Batch operations
 wp datamachine system           # System task management
+wp datamachine retention        # Retention policies and cleanup scheduling
+wp datamachine test             # Fetch handler dry-runs
 wp datamachine analytics        # Analytics and tracking
 ```
 

--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -164,10 +164,13 @@ Portable flow-step policy fields are explicit in `flows/<flow-slug>.json`:
 Agent package operations live under `wp datamachine agent`:
 
 - `install <path|url>` imports a local bundle path (`.zip`, `.json`, or directory) or a remote URL.
+- `import <path|url>` imports a portable agent export and creates a new agent.
+- `export <agent>` writes an agent identity, memory, pipelines, and flows to a portable bundle.
 - `installed` reports installed package-backed agents without clobbering `agent list`.
 - `status <slug>` reports installed version and tracked artifact state by agent slug or bundle slug.
 - `diff <path|url>` builds a read-only upgrade plan.
 - `upgrade <path|url>` applies clean updates and stages locally modified artifacts as PendingActions.
+- `rebase <path|url>` previews 3-way merges for locally modified bundle artifacts.
 - `apply <pending_action_id>` accepts a staged bundle PendingAction.
 
 Every read/preview command supports `--format=json` for automation.

--- a/docs/core-system/wordpress-as-agent-memory.md
+++ b/docs/core-system/wordpress-as-agent-memory.md
@@ -477,8 +477,11 @@ Agents with shell access can use the `memory` command for structured access:
 wp datamachine memory paths --allow-root
 
 # Read memory file
-wp datamachine memory files read SOUL.md --allow-root
-wp datamachine memory files read MEMORY.md --allow-root
+wp datamachine memory read SOUL.md --allow-root
+wp datamachine memory read MEMORY.md --allow-root
+
+# Read a section. Pass section names without the leading ##.
+wp datamachine memory read SOUL.md "Identity" --allow-root
 
 # List agent directory contents
 wp datamachine memory files list --allow-root
@@ -664,7 +667,7 @@ wp datamachine memory paths --relative --allow-root
 
 ```bash
 wp datamachine agents list --allow-root
-wp datamachine agents create --slug=bot --name="My Bot" --allow-root
+wp datamachine agents create bot --name="My Bot" --owner=1 --allow-root
 wp datamachine agents rename old-slug new-slug --allow-root
 ```
 
@@ -673,9 +676,10 @@ wp datamachine agents rename old-slug new-slug --allow-root
 ```bash
 wp datamachine memory paths --allow-root
 wp datamachine memory files list --allow-root
-wp datamachine memory files read <file> --allow-root
-wp datamachine memory files write <file> --content="..." --allow-root
-wp datamachine memory files edit <file> --old="..." --new="..." --allow-root
+wp datamachine memory read <file> --allow-root
+wp datamachine memory read <file> "Section" --allow-root
+wp datamachine memory write <file> "Section" "Content" --allow-root
+wp datamachine memory write "Section" --from-file=/tmp/content.md --mode=append --allow-root
 ```
 
 > **Note:** For workspace/git operations, install the `data-machine-code` extension and use `wp datamachine-code workspace`.

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -18,13 +18,14 @@ wp datamachine pipelines list
 wp datamachine pipelines get 5
 
 # Create a pipeline with steps
-wp datamachine pipelines create --name="My Pipeline" --steps='[{"type":"fetch","name":"RSS Fetch"}]'
+wp datamachine pipelines create --name="My Pipeline" --steps='[{"step_type":"fetch","label":"RSS Fetch"}]'
 
 # Update pipeline name or config
 wp datamachine pipelines update 5 --name="New Name" --config='{"key":"value"}'
 
-# Update pipeline system prompt
-wp datamachine pipelines update 5 --set-system-prompt --step=fetch_1
+# Update an AI step system prompt. If the pipeline has one AI step, --step is optional.
+wp datamachine pipelines update 5 --set-system-prompt="Write concise summaries."
+wp datamachine pipelines update 5 --step=5_abc123 --set-system-prompt="Write concise summaries."
 
 # Delete a pipeline
 wp datamachine pipelines delete 5 --force
@@ -236,6 +237,10 @@ wp datamachine agents show my-agent
 # Create a new agent
 wp datamachine agents create my-agent --name="My Agent" --owner=1
 
+# Read or update agent config
+wp datamachine agents config my-agent
+wp datamachine agents config my-agent --set='model=gpt-4o'
+
 # Rename an agent (updates DB and filesystem)
 wp datamachine agents rename old-slug new-slug --dry-run
 
@@ -246,28 +251,57 @@ wp datamachine agents delete my-agent --delete-files --yes
 wp datamachine agents access grant my-agent 2 --role=operator
 wp datamachine agents access revoke my-agent 2
 wp datamachine agents access list my-agent
+
+# Manage runtime bearer tokens. Raw token values are shown only at creation time.
+wp datamachine agents token create my-agent --label="ci" --expires-in=7776000
+wp datamachine agents token list my-agent
+wp datamachine agents token revoke my-agent 3
+
+# Portable agent bundle lifecycle
+wp datamachine agents export my-agent --format=zip --destination=/tmp/my-agent.zip
+wp datamachine agents import /tmp/my-agent.zip --dry-run
+wp datamachine agents install /tmp/my-agent-bundle --slug=my-agent --dry-run
+wp datamachine agents installed
+wp datamachine agents status my-agent
+wp datamachine agents diff /tmp/my-agent-bundle --slug=my-agent --format=json
+wp datamachine agents upgrade /tmp/my-agent-bundle --slug=my-agent --dry-run
+wp datamachine agents upgrade /tmp/my-agent-bundle --slug=my-agent --rebase-local --dry-run
+wp datamachine agents rebase /tmp/my-agent-bundle --slug=my-agent --artifact=flow:weekly-digest
+wp datamachine agents apply act_123
 ```
+
+Use `agent` or `agents` for agent identities, access, tokens, config, import/export, and bundle lifecycle. Memory files live under the separate `memory` namespace.
 
 ### datamachine memory
 
 Agent memory-file operations. **Since**: 0.30.0
 
+`memory` reads and writes layered markdown files and sections. It is not an alias for agent identity management; use `agent` or `agents` for CRUD, access grants, tokens, and bundles.
+
 ```bash
-# Read full memory
+# Read full MEMORY.md
 wp datamachine memory read
 
-# Read a specific section
-wp datamachine memory read "## State"
+# Read a specific MEMORY.md section. Pass section names without leading ##.
+wp datamachine memory read "State"
+
+# Read full files or sections in specific files
+wp datamachine memory read SOUL.md
+wp datamachine memory read SOUL.md "Identity"
+wp datamachine memory read USER.md --agent=my-agent
 
 # List sections
 wp datamachine memory sections
 
-# Write to a section
-wp datamachine memory write "## State" "Active and running"
-wp datamachine memory write "## State" "New note" --mode=append
+# Write to a section. Pass section names without leading ##.
+wp datamachine memory write "State" "Active and running"
+wp datamachine memory write "State" "New note" --mode=append
+wp datamachine memory write SOUL.md "Voice" "Concise and direct" --agent=my-agent
+wp datamachine memory write "Session Notes" --from-file=/tmp/notes.md --mode=append
+echo "- New lesson" | wp datamachine memory write "Lessons Learned" - --mode=append
 
 # Search memory
-wp datamachine memory search "deployment" --section="## State"
+wp datamachine memory search "deployment" --section="State"
 
 # Daily memory operations
 wp datamachine memory daily list
@@ -277,10 +311,9 @@ wp datamachine memory daily append 2026-03-15 "More notes"
 wp datamachine memory daily delete 2026-03-15
 wp datamachine memory daily search "keyword" --from=2026-03-01 --to=2026-03-15
 
-# Agent file management
+# Agent file listing and staleness checks. File content read/write is handled
+# by `memory read` and `memory write`, not by `memory files`.
 wp datamachine memory files list
-wp datamachine memory files read SOUL.md
-echo "content" | wp datamachine memory files write CUSTOM.md
 wp datamachine memory files check --days=7
 
 # Show resolved file paths for all memory layers
@@ -326,6 +359,79 @@ wp datamachine batch status 42
 # Cancel a running batch
 wp datamachine batch cancel 42
 ```
+
+### datamachine worker
+
+Headless automation worker. Composes stuck-job recovery with the Data Machine drain loop.
+
+```bash
+# Run a bounded worker loop
+wp datamachine worker run --time-limit=3600 --sleep=30
+
+# Run one recovery/drain pass and stop if approval is required.
+wp datamachine worker run --once --stop-on-pending-actions
+
+# Leave margin before an external supervisor timeout
+wp datamachine worker run --time-limit=900 --max-passes=10 --stop-before-timeout=60
+
+# Inspect queue/job status without draining
+wp datamachine worker status
+wp datamachine worker status --format=json
+```
+
+**Options**: `--time-limit`, `--batch-size`, `--drain-limit`, `--drain-time-limit`, `--sleep`, `--stuck-timeout`, `--no-recover-stuck`, `--stop-on-pending-actions`, `--max-passes`, `--stop-before-timeout`, `--once`, `--format`
+
+### datamachine drain
+
+Drain due Data Machine Action Scheduler actions until the queue is empty or a budget is reached.
+
+```bash
+# Drain all due Data Machine actions
+wp datamachine drain
+
+# Bound work for cron/supervisors
+wp datamachine drain --limit=500 --batch-size=25 --time-limit=300
+wp datamachine drain --limit=500 --time-limit=300 --format=json
+```
+
+**Options**: `--limit`, `--batch-size`, `--time-limit`, `--format=table|json`
+
+### datamachine cycle / cycles
+
+Run flows that are due during an external cycle. Manual flows participate only when their scheduling config sets `cycle_policy: every_cycle`.
+
+```bash
+# Run due flows for a named cycle, then drain Data Machine actions
+wp datamachine cycle run world-of-wordpress
+wp datamachine cycles run world-of-wordpress
+
+# Preview selected flows without starting jobs
+wp datamachine cycle run world-of-wordpress --dry-run --format=json
+
+# Start due flows but leave draining to another worker
+wp datamachine cycle run world-of-wordpress --no-drain
+```
+
+**Options**: `[<cycle>]`, `--dry-run`, `--[no-]drain`, `--format=table|json`
+
+### datamachine pending-actions
+
+Inspect durable pending approval actions. **Alias**: `pending-action`
+
+```bash
+# List approval actions
+wp datamachine pending-actions list
+wp datamachine pending-actions list --status=pending --kind=bundle_upgrade --format=json
+
+# Inspect one action
+wp datamachine pending-actions get act_123
+
+# Summarize counts by kind/status
+wp datamachine pending-actions summary
+wp datamachine pending-actions summary --status=pending --format=json
+```
+
+**Options**: `--status`, `--kind`, `--agent_id`, `--created_by`, `--limit`, `--offset`, `--format`
 
 ### datamachine image
 
@@ -547,9 +653,19 @@ wp datamachine step-types validate ai
 Processed items (deduplication). **Alias**: `processed-item`. **Since**: 0.41.0
 
 ```bash
+# Audit processed-item rows by flow/handler
+wp datamachine processed-items audit
+wp datamachine processed-items audit --handler=ticketmaster --min-waste=0
+
 # Clear processed items for a pipeline or flow
 wp datamachine processed-items clear --pipeline=5 --yes
 wp datamachine processed-items clear --flow=10 --yes
+wp datamachine processed-items clear --handler=ticketmaster --after=2025-01-01 --dry-run
+wp datamachine processed-items clear --all --yes
+
+# Clean dedupe rows whose jobs have been purged
+wp datamachine processed-items cleanup-orphans --dry-run
+wp datamachine processed-items cleanup-orphans --flow=10 --yes
 
 # Check if an item was processed
 wp datamachine processed-items check --flow-step=fetch_1_10 --source=rss --item="https://example.com/feed/1"
@@ -557,7 +673,7 @@ wp datamachine processed-items check --flow-step=fetch_1_10 --source=rss --item=
 # Check if a flow step has processing history
 wp datamachine processed-items history --flow-step=fetch_1_10
 
-# Revisit semantics (since 0.71.0) — time-windowed reads on processed_timestamp
+# Revisit semantics: time-windowed reads on processed_timestamp.
 # When was this item last processed?
 wp datamachine processed-items get-processed-at \
   --flow-step-id=fetch_1_10 --source-type=wiki_post --item-identifier=42
@@ -572,6 +688,8 @@ wp datamachine processed-items find-never-processed \
   --flow-step-id=fetch_1_10 --source-type=wiki_post \
   --candidate-ids=1,2,3,4
 ```
+
+**Options**: `audit` supports `--handler`, `--pipeline`, `--min-waste`, `--format`; `clear` supports `--pipeline`, `--flow`, `--handler`, `--after`, `--before`, `--all`, `--dry-run`, `--yes`; revisit helpers support `--flow-step-id`, `--source-type`, `--candidate-ids`, `--limit`, `--format`.
 
 ### datamachine links
 
@@ -668,17 +786,93 @@ wp datamachine indexnow enable
 wp datamachine indexnow disable
 ```
 
+### datamachine retention
+
+Inspect and schedule retention cleanup for jobs, logs, processed items, Action Scheduler rows, stale claims, files, and chat sessions.
+
+```bash
+# Show policies and storage metrics
+wp datamachine retention show
+wp datamachine retention show --format=json
+
+# Preview or schedule cleanup jobs
+wp datamachine retention run --dry-run
+wp datamachine retention run --yes
+```
+
+**Options**: `show --format=table|json|yaml`; `run --dry-run`, `--yes`, `--format=table|json|yaml`
+
+### datamachine email
+
+Send email and operate on an IMAP mailbox through configured email auth.
+
+```bash
+# Send mail
+wp datamachine email send --to=user@example.com --subject="Report" --body="<p>Hello</p>"
+
+# Fetch and read mail
+wp datamachine email fetch --search=UNSEEN --max=10
+wp datamachine email fetch --search=ALL --headers-only --fields=uid,from,subject,date
+wp datamachine email read 12345 --format=json
+
+# Reply and manage messages
+wp datamachine email reply --to=sender@example.com --subject="Re: Hello" --body="Thanks" --in-reply-to="<msgid@example.com>"
+wp datamachine email move 12345 Archive
+wp datamachine email flag 12345 Seen --action=clear
+wp datamachine email delete 12345 --yes
+
+# Batch mailbox operations
+wp datamachine email batch-move --search='FROM "github.com"' --destination="[Gmail]/GitHub" --yes
+wp datamachine email batch-flag --search=UNSEEN Flagged --max=10
+wp datamachine email batch-delete --search='SUBJECT "unsubscribe" BEFORE "1-Jan-2025"' --yes
+wp datamachine email unsubscribe 83012
+wp datamachine email batch-unsubscribe --search='SUBJECT "newsletter"' --max=10 --yes
+```
+
+### datamachine external
+
+Manage bearer-token connections to other Data Machine sites.
+
+```bash
+# Start browser authorization flow with a remote site
+wp datamachine external connect chubes.net chubes-bot --label="local-agent"
+
+# Manually store or list a remote token
+echo "$TOKEN" | wp datamachine external add chubes.net chubes-bot --verify
+wp datamachine external list
+wp datamachine external show chubes.net/chubes-bot
+
+# Test or call the remote site with the stored token
+wp datamachine external test chubes.net/chubes-bot
+wp datamachine external call chubes.net/chubes-bot GET /wp-json/wp/v2/users/me
+wp datamachine external call chubes.net/chubes-bot POST /wp-json/datamachine/v1/chat --body='{"message":"hello"}'
+
+# Remove a connection
+wp datamachine external remove chubes.net/chubes-bot --yes
+```
+
+### datamachine test / fetch test
+
+Dry-run fetch handlers and inspect packet summaries without creating jobs.
+
+```bash
+# List fetch-capable handlers
+wp datamachine test --list
+
+# Show handler config fields
+wp datamachine test rss --describe
+
+# Test with explicit config or an existing flow config
+wp datamachine test rss --config='{"feed_url":"https://example.com/feed"}' --limit=3
+wp datamachine test --flow=42 --format=json
+
+# Alias useful when the handler is passed by flag
+wp datamachine fetch test --handler=rss --config='{"feed_url":"https://example.com/feed"}'
+```
+
 ### Other registered commands
 
-The root namespace also registers specialized commands that are documented most accurately by WP-CLI help in the running install:
-
-- `wp datamachine ai`
-- `wp datamachine drain`
-- `wp datamachine email`
-- `wp datamachine external`
-- `wp datamachine retention`
-- `wp datamachine test`
-- `wp datamachine fetch test`
+The root namespace also registers `wp datamachine ai`; use `wp help datamachine ai` in a running install for the provider-specific diagnostic surface.
 
 ## Global Options
 
@@ -705,9 +899,11 @@ Most commands have singular and plural forms:
 - `wp datamachine handler` / `wp datamachine handlers`
 - `wp datamachine step-type` / `wp datamachine step-types`
 - `wp datamachine processed-item` / `wp datamachine processed-items`
+- `wp datamachine pending-action` / `wp datamachine pending-actions`
 - `wp datamachine setting` / `wp datamachine settings`
 - `wp datamachine agent` / `wp datamachine agents` (agent management)
-- `wp datamachine memory` (agent memory-file operations)
+- `wp datamachine cycle` / `wp datamachine cycles`
+- `wp datamachine memory` (agent memory-file operations; no singular/plural agent alias)
 
 ## Examples
 
@@ -745,5 +941,5 @@ fi
 ```bash
 # Read current memory, update a section, verify
 wp datamachine memory read
-wp datamachine memory write "## Status" "All systems operational"
+wp datamachine memory write "Status" "All systems operational"
 wp datamachine memory search "operational"

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -1591,7 +1591,7 @@ arrays are projection shapes at provider boundaries, not the store contract.
 - `count_unread` — pure derivation from a messages array
 - `cleanup_expired_sessions / cleanup_old_sessions / cleanup_orphaned_sessions` — scheduled cleanup
 - `list_sessions_for_day` — day-scoped summary rows for the Daily Memory Task
-- `get_storage_metrics` — row count + on-disk size for the `wp datamachine retention status` CLI; return `null` to opt out
+- `get_storage_metrics` — row count + on-disk size for the `wp datamachine retention show` CLI; return `null` to opt out
 
 ### WP_Agent_Memory_Store (`/agents-api/inc/Core/FilesRepository/WP_Agent_Memory_Store.php`)
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -65,7 +65,7 @@ Markdown files organized in three layers:
 |-------|-----------|----------|
 | **Shared** | shared layer | SITE.md, RULES.md (site-wide context) |
 | **Agent** | agent slug layer | SOUL.md, MEMORY.md (agent identity and knowledge) |
-| **User** | user ID layer | USER.md, MEMORY.md (human preferences) |
+| **User** | user ID layer | USER.md (human preferences) |
 
 ### Daily Memory System
 


### PR DESCRIPTION
## Summary
- Updates the Data Machine WP-CLI documentation to match the current command surface.
- Clarifies agent, memory, bundle, queue, worker, drain, and system command workflows for coding agents.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Comparing docs against CLI registration/help output, drafting documentation corrections, and preparing the PR text for Chris to review.