### PR TITLE
docs: document tool policy architecture

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,15 +15,15 @@ Complete user documentation for Data Machine, the AI-first WordPress plugin that
 ### Architecture Deep Dives
 - **Agent Memory Backends**: Store selection model for disk-backed memory, optional guideline-backed stores, and the DMC file-projection boundary ([architecture/agent-memory-backends.md](architecture/agent-memory-backends.md)).
 - **Pipeline Execution Axes**: Queue, fan-out, and per-step iteration semantics ([architecture/pipeline-execution-axes.md](architecture/pipeline-execution-axes.md)).
-- **Policy Resolvers**: Why `ToolPolicyResolver`, `MemoryPolicyResolver`, `ActionPolicyResolver`, and `PipelineTranscriptPolicy` stay as four single-purpose classes ([architecture/policy-resolvers.md](architecture/policy-resolvers.md)).
+- **Policy Resolvers**: Why tool, memory, directive, action, and transcript policies stay as single-purpose classes ([architecture/policy-resolvers.md](architecture/policy-resolvers.md)).
 - **Iteration Budget**: Shared bounded-iteration primitive backing `conversation_turns` and `chain_depth` budgets ([architecture/iteration-budget.md](architecture/iteration-budget.md)).
 
 ### Engine & Services
 - **Universal Engine**: Shared AI infrastructure for pipeline and chat agents.
 - **AI Conversation Loop**: Turn-based conversation execution with directive orchestration.
 - **AI Directives System**: Hierarchical directive injection for contextual AI behavior.
-- **Tool Execution**: Centralized discovery, validation, and execution of AI tools.
-- **Tool Manager**: Runtime tool enablement, provider checks, and contextual metadata.
+- **Tool Execution**: Resolved tool dispatch, action policy, ability-only execution, and approval staging.
+- **Tool Manager**: Data Machine tool registry, source-level availability checks, and handler tool expansion.
 - **Request Builder**: Directive-aware construction of provider requests.
 - **Conversation Manager**: Message normalization, logging, and tool call tracking.
 - **Prompt Builder**: Priority-based directive registration via filters.
@@ -40,10 +40,10 @@ Complete user documentation for Data Machine, the AI-first WordPress plugin that
 - **Upsert Handlers**: Identity-aware create-or-update operations — find existing content by identity strategy, update if changed, create if new.
 
 ### AI Tools
-- **Tools Overview**: Global and context-aware tools available to AI agents.
+- **Tools Overview**: Static, ability-backed, and adjacent handler tools available to AI agents.
 - **Execute Workflow**: Modular execution of multi-step workflows from the chat toolset.
-- **Global Tools**: Google Search, Local Search, Web Fetch, WordPress Post Reader, and others used across agents.
-- **Chat Tools**: AddPipelineStep, ApiQuery, ConfigureFlowSteps, ConfigurePipelineStep, CreateFlow, CreatePipeline, RunFlow, UpdateFlow, and other workflow management tools.
+- **Static Registry Tools**: Research, memory, workflow-management, and site-operation tools registered through `datamachine_tools`.
+- **Pipeline Handler Tools**: Runtime tools generated from adjacent fetch, publish, and upsert handlers.
 
 ### API Reference
 - **API Overview**: Catalog of REST endpoints for API consumers.

--- a/docs/architecture/policy-resolvers.md
+++ b/docs/architecture/policy-resolvers.md
@@ -1,227 +1,203 @@
 # Policy Resolvers
 
-Data Machine has four policy resolvers — small classes that read per-agent declarative configuration and answer one specific question about how the agent should run. They look uniform from a docblock distance and divergent up close. This doc names the convention they share, the shapes they don't share, and how to add a fifth without breaking the pattern.
+Data Machine uses small policy resolvers instead of one shared policy base class. Each resolver reads declarative configuration near the thing it governs, normalizes that policy, and answers one runtime question.
 
-The four resolvers:
+| Resolver | Question | Primary input | Return shape |
+|---|---|---|---|
+| `ToolPolicyResolver` | Which tools can this request see? | Tool sources, request args, `agent_config.tool_policy` | `array<tool_name, tool_def>` |
+| `MemoryPolicyResolver` | Which memory files inject? | Memory registry/config, `agent_config.memory_policy` | `array<filename, metadata>` |
+| `DirectivePolicyResolver` | Which directives remain in the prompt stack? | Registered directives, `agent_config.directive_policy` | `array{directives: array, suppressed: array}` |
+| `ActionPolicyResolver` | How may one tool invocation execute? | Tool definition, mode, `agent_config.action_policy` | `direct`, `preview`, or `forbidden` |
+| `PipelineTranscriptPolicy` | Should the pipeline transcript persist? | Flow config, pipeline config, site option | `bool` |
 
-1. **`ToolPolicyResolver`** — *which* tools the agent can see.
-2. **`MemoryPolicyResolver`** — *which* memory files inject into the prompt.
-3. **`ActionPolicyResolver`** — *how* a single tool invocation executes (direct / preview / forbidden).
-4. **`PipelineTranscriptPolicy`** — *whether* the AI conversation transcript is persisted.
+The shared convention is policy normalization plus explicit precedence. The classes do not share a parent because their return values and call sites are intentionally different.
 
-All four read from `agent_config` on the agent row. All four use the same precedence ladder shape. None of them share a return type, and that's deliberate.
+## Tool Policy Resolver
 
-## Why this isn't a base class
-
-Each resolver answers a structurally different question:
-
-| Resolver | Question | Returns |
-|---|---|---|
-| `ToolPolicyResolver` | Which tools are visible? | `array<tool_name, tool_def>` (filtered set) |
-| `MemoryPolicyResolver` | Which memory files inject? | `array<filename, metadata>` (filtered set) |
-| `ActionPolicyResolver` | How does this invocation execute? | `string` — one of `direct` / `preview` / `forbidden` |
-| `PipelineTranscriptPolicy` | Persist this run's transcript? | `bool` |
-
-The method names give it away: `resolve()`, `resolveRegistered()`, `resolveForTool()`, `shouldPersist()`. Forcing all four through `AbstractAgentPolicy::resolve(): array` would either pick a useless lowest-common-denominator return, require generics PHP can't enforce at runtime, or distort `ActionPolicyResolver` and `PipelineTranscriptPolicy` into set-filter shapes they shouldn't be.
-
-What the four resolvers share is **a convention** — per-agent declarative config with layered precedence and a final filter hook. Conventions are documented; identities are inherited. These are not the same kind of thing.
-
-## The convention
-
-A policy resolver in Data Machine has six properties. Each property is reproduced explicitly in each resolver, not factored out into a parent class.
-
-### 1. Per-agent config under a named key
-
-The policy lives in the `agent_config` JSON blob on the agent row, under a key named `<thing>_policy`:
+`ToolPolicyResolver` is the single entry point for runtime tool visibility.
 
 ```php
-$config = $agent['agent_config'] ?? array();
-$policy = $config['tool_policy']      ?? null; // ToolPolicyResolver
-$policy = $config['memory_policy']    ?? null; // MemoryPolicyResolver
-$policy = $config['action_policy']    ?? null; // ActionPolicyResolver
-// PipelineTranscriptPolicy reads pipeline_config / flow_config keys instead
-// of agent_config — see "When to bend the convention" below.
+$tools = ( new ToolPolicyResolver() )->resolve( array(
+    'mode'       => ToolPolicyResolver::MODE_CHAT,
+    'agent_id'   => $agent_id,
+    'deny'       => array( 'dangerous_tool' ),
+    'allow_only' => array( 'safe_tool' ),
+    'categories' => array( 'content' ),
+) );
 ```
 
-The reader is a method on the resolver itself (`getAgentToolPolicy()`, `getAgentMemoryPolicy()`, `getAgentActionPolicy()`), not a shared utility. Each reader validates the policy shape and normalizes it before returning.
+Current implementation shape:
 
-### 2. Null = no-op
-
-`getAgent*Policy()` returns `null` when:
-
-- The agent doesn't exist.
-- The config key is missing or not an array.
-- The policy is structurally invalid (unknown mode, wrong shape).
-- The policy is a recognized but effectively-empty no-op (e.g. `mode=deny` with empty deny list).
-
-The caller short-circuits on `null` instead of running an empty filter pass. This is a small but real perf and clarity win — the hot path stays cheap when no policy is configured.
-
-### 3. Layered precedence, highest first
-
-Every resolver runs the same shape of ladder. Higher rules override lower ones. The exact rungs differ per resolver, but the order is always: explicit context → per-agent → category → tool/file default → mode preset → global default → final filter.
-
-`ToolPolicyResolver`:
-
-```
-1. Explicit deny list (always wins)
-2. Per-agent tool policy (deny/allow mode, supports categories)
-3. Ability category filter (narrows by linked ability category)
-4. Context-level allow_only (narrows to explicit subset)
-5. Context preset (pipeline / chat / system)
-6. Global enablement settings
-7. Tool configuration requirements
-8. apply_filters('datamachine_resolved_tools', ...)
+```text
+ToolPolicyResolver::resolve()
+    |
+    +--> chat gate via DataMachineToolAccessPolicy::passesChatGate()
+    |
+    +--> ToolSourceRegistry::gather()
+    |       - adjacent_handlers in pipeline mode
+    |       - static_registry in every mode
+    |
+    +--> WP_Agent_Tool_Policy::resolve()
+    |       - mandatory Data Machine tools are preserved
+    |       - generic allow/deny/category/mode filtering
+    |       - chat ability/access checks when applicable
+    |
+    +--> apply_filters( 'datamachine_resolved_tools', ... )
 ```
 
-`MemoryPolicyResolver`:
+Resolution concepts:
 
-```
-1. Explicit deny list passed in context (always wins)
-2. Per-agent policy deny list (from agent_config.memory_policy)
-3. Per-agent policy allow-only (narrows to subset)
-4. Context-level allow_only (narrows to subset)
-5. Mode preset (registry's get_for_mode)
-6. apply_filters('datamachine_resolved_memory_files', ...)
-```
+| Layer | Meaning |
+|---|---|
+| Explicit `deny` | Highest-precedence removal list. Pipeline `disabled_tools` becomes this arg. |
+| Per-agent `tool_policy` | Read from `agent_config.tool_policy` through `DataMachineAgentToolPolicyProvider`. |
+| Categories | Resolved through linked WordPress Abilities, not a separate Data Machine tool category registry. |
+| `allow_only` | Narrows optional/static tools. Pipeline `enabled_tools` becomes this arg. |
+| Mode preset | Tool definitions declare `modes`; source registry gathers sources by mode. |
+| Global/config checks | `DataMachineToolRegistrySource` calls `ToolManager::is_tool_available()` and `is_globally_enabled()`. |
+| Final filter | `datamachine_resolved_tools`. |
 
-`ActionPolicyResolver`:
+Adjacent handler tools are different from optional/static tools. They come from the previous and next pipeline steps and represent the workflow's required flow plumbing. They are gathered by `AdjacentHandlerToolSource` before generic policy filtering and are protected by Data Machine's mandatory-tool policy where appropriate. A required adjacent publish/upsert handler with no callable AI tool fails before the model call; request inspection reports the same missing-handler state.
 
-```
-1. Explicit deny list (any listed tool → 'forbidden')
-2. Per-agent action_policy.tools[<tool_name>] override
-3. Per-agent action_policy.categories[<category>] override
-4. Tool-declared default (tool_def['action_policy'])
-5. Mode preset (chat → 'preview' for publish-family, else 'direct')
-6. Global default: 'direct'
-7. apply_filters('datamachine_tool_action_policy', ...)
-```
+### Pipeline Policy-Gated Tools
 
-`PipelineTranscriptPolicy::shouldPersist()`:
-
-```
-1. flow.flow_config['persist_transcripts']
-2. pipeline.pipeline_config['persist_transcripts']
-3. get_option('datamachine_persist_pipeline_transcripts', false)
-   (no per-tool / per-category / per-agent layer in v1)
-```
-
-The ladders look similar because they are similar. They are not identical, and the differences matter — `PipelineTranscriptPolicy` has no per-agent layer because v1 is scoped to pipelines (see #1226 for the cross-mode generalization that adds one). Don't try to unify the ladder shapes; document each resolver's ladder in its class docblock and keep them visible.
-
-### 4. Categories follow ability linkage
-
-Resolvers that gate by category (`ToolPolicyResolver`, `ActionPolicyResolver`) walk a tool's `ability` and `abilities` keys, look up each slug in `WP_Abilities_Registry::get_instance()`, and read `get_category()` on the ability. A tool's category is whatever its linked ability declares — there is no separate "tool category" registry.
-
-Tools without a linked ability are excluded when category filtering is active (they cannot be categorized) unless explicitly allow-listed. Handler tools (those with a `handler` key but no `ability` key) are the exception: in pipeline mode they are required flow plumbing resolved from adjacent steps, so they bypass agent `tool_policy`, context category filtering, and context `allow_only` filtering. The flow shape decides whether they exist; optional/global tool policy only narrows research and utility tools.
-
-If a publish/upsert handler is required by the adjacent flow shape but no AI-callable handler tool is available, the AI step fails before the model call. Runtime and request inspection both use `FlowStepConfig::getMissingRequiredHandlerSlugsForAi()` so the inspector reports the same failure state the runtime would hit.
-
-### 5. Mode-aware (`pipeline` / `chat` / `system`)
-
-All four resolvers know about agent modes. The preset constants are duplicated across the resolvers on purpose:
+Some tools are safe for chat but too powerful for default pipeline exposure. They declare `pipeline_policy` mode instead of `pipeline` mode.
 
 ```php
-public const MODE_PIPELINE = 'pipeline';
-public const MODE_CHAT     = 'chat';
-public const MODE_SYSTEM   = 'system';
+'modes' => array( 'chat', ToolPolicyResolver::MODE_PIPELINE_POLICY )
 ```
 
-Each resolver applies the mode where it makes sense:
+`DataMachineToolRegistrySource` includes such a tool in a pipeline request only when `ToolPolicyResolver::isPipelinePolicyToolAllowed()` sees the tool name in `allow_only`. In practice, that means the flow-step snapshot's `enabled_tools` list opted in.
 
-- `ToolPolicyResolver` filters tools by their declared `modes` array.
-- `MemoryPolicyResolver` calls `MemoryFileRegistry::get_for_mode()`.
-- `ActionPolicyResolver` defaults publish-family tools to `preview` in `chat` and `direct` in `pipeline` / `system`.
-- `PipelineTranscriptPolicy` is currently pipeline-only; #1226 generalizes it across modes.
+### Pipeline Disabled Tools
 
-Custom mode slugs are allowed. Plugins can register tools / files / policies for arbitrary modes; the resolvers route them through the same paths.
+`PipelineToolPolicyArgs::fromConfigs()` converts snapshot config into resolver args:
 
-### 6. Final `apply_filters()` hook
+| Snapshot config | Resolver arg |
+|---|---|
+| `flow_step_config.enabled_tools` | `allow_only` |
+| `pipeline_step_config.disabled_tools` | `deny` |
+| `flow_step_config.disabled_tools` | `deny` |
 
-Every resolver ends with a `apply_filters()` call so plugins can override the resolved value without subclassing or replacing the resolver. The filter is the public extension point for third parties. The filter names are:
+This keeps direct workflows and historical job runs deterministic. Do not re-read persisted pipeline rows while resolving runtime policy.
 
-- `datamachine_resolved_tools`
-- `datamachine_resolved_memory_files`
-- `datamachine_resolved_scoped_memory_files` (pipeline/flow-scoped path)
-- `datamachine_tool_action_policy`
+## Tool Source Registry
 
-A new resolver follows suit: register a filter named `datamachine_resolved_<thing>` (or similar) and run it as the last step of `resolve()`. This is how DM stays generic — the filter is the only thing third parties have to know about.
+`ToolSourceRegistry` is a composition seam, not a policy resolver. It asks named sources for candidate tools before `ToolPolicyResolver` applies policy.
 
-## What divergence looks like in practice
+Default source order:
 
-Each resolver invented something the others don't have. None of those inventions are wrong — they're shaped to the question.
+| Mode | Sources |
+|---|---|
+| `pipeline` | `adjacent_handlers`, then `static_registry` |
+| `chat` | `static_registry` |
+| `system` | `static_registry` |
+| custom mode | `static_registry` unless `agents_api_tool_sources_for_mode` changes it |
 
-`ToolPolicyResolver` has:
+Extension hooks:
 
-- A `gatherByMode()` step that builds the tool pool differently for `pipeline` (handler tools from adjacent steps) vs other modes (registry filter by declared `modes`).
-- An ability-permission gate (`filterByAbilityPermissions()`) that runs only in `chat` mode.
-- An `access_level` fallback (`public` / `authenticated` / `author` / `editor` / `admin`) for tools without a linked ability.
-- A category-aware `applyAgentPolicy()` that supports `tools[]` and `categories[]` composing in either deny or allow mode.
-- A pipeline handler-tool exception: adjacent handler tools are preserved through agent allow/deny policy and context allow/category filters because they are required flow plumbing, not optional global tools.
+| Hook | Purpose |
+|---|---|
+| `agents_api_tool_sources` | Register source callbacks keyed by source slug. |
+| `agents_api_tool_sources_for_mode` | Select source slugs for a mode. |
 
-`MemoryPolicyResolver` has:
+Data Machine's `datamachine_tools` filter remains the product registry adapted by `DataMachineToolRegistrySource`. The old source filters with Data Machine-specific names are not mirrored.
 
-- Two entry points — `resolveRegistered()` for the core memory file registry and `filter()` for explicit filename lists from `pipeline_config` / `flow_config`. Both share the per-agent policy reader; their precedence ladders diverge slightly.
-- A `default` mode that's a no-op (returned as `null` by the reader).
-- File metadata preservation through filtering so downstream readers see the same `layer` / `priority` / `path` keys after policy is applied.
+## Directive Policy Resolver
 
-`ActionPolicyResolver` has:
+`DirectivePolicyResolver` applies per-agent directive suppression after directives are registered and before prompt assembly continues.
 
-- Three policy values, not a set: `direct` / `preview` / `forbidden`.
-- Tool-declared defaults via `tool_def['action_policy']` and per-mode overrides via `tool_def['action_policy_<mode>']`.
-- A normalization step that returns `''` for unrecognized values so callers can drop them safely.
-- A subtle interaction at step 4: the mode preset can *upgrade* a `direct` tool default to `preview` in chat mode if the tool opts in via `action_policy_chat`, but the tool default still wins for everything else. This is documented in `resolveForTool()` and worth preserving when the resolver evolves.
+Policy shape:
 
-`PipelineTranscriptPolicy` has:
-
-- One method (`shouldPersist()`) returning a `bool`.
-- Reads from flow + pipeline config snapshots already in memory (zero extra DB calls).
-- No per-agent layer in v1. No category. No tool-level opt-in. The transcript is persisted for the *whole step*, not per-invocation, so per-tool granularity isn't meaningful here.
-
-A future generalization (#1226) plausibly adds a `mode` argument and per-agent override but should *not* try to inherit the precedence ladder of any of the other three. Its question is yes/no, and the answer for a yes/no question lives in a different shape from the answer for "filter this set."
-
-## When to bend the convention
-
-The convention is a guide, not a contract. Two existing resolvers already bend it:
-
-- **`PipelineTranscriptPolicy`** reads `pipeline_config` and `flow_config`, not `agent_config`. The reason is that transcript persistence is a *flow-level* concern (different flows on the same agent should be able to opt in independently), and the resolution order is flow > pipeline > site option, not agent > anything. When the question's natural locus isn't the agent, store the policy where it actually belongs and document the deviation in the class docblock.
-- **`ActionPolicyResolver`** allows tools to declare per-mode defaults via `action_policy_chat` / `action_policy_pipeline` / `action_policy_system`. The other resolvers don't have an equivalent — tools don't declare per-mode visibility (`ToolPolicyResolver` reads `modes` on the tool def, but that's a static list, not per-mode behavior). When a tool's default behavior naturally varies by mode, `tool_def[<key>_<mode>]` is the right shape.
-
-Both deviations are documented in the resolver's class docblock. New resolvers should do the same: name what's different from the other three and why.
-
-## Adding a fifth resolver
-
-When a new policy question arises (directive suppression, transcript-across-modes, retention overrides, anything), the recipe is:
-
-1. **Pick the locus.** Where does the policy live? Agent config? Pipeline config? Flow config? Site option? More than one with a precedence ladder? The locus determines the reader.
-2. **Pick the shape of the answer.** Filtered set? Scalar enum? Boolean? Per-invocation classifier? Don't force it to match an existing resolver.
-3. **Write a single-purpose class** in `inc/Engine/AI/<Thing>/<Thing>Policy[Resolver].php` (the `Resolver` suffix is dropped for boolean-toggle resolvers like `PipelineTranscriptPolicy` — it would read awkwardly).
-4. **Write the precedence ladder in the class docblock** before writing code. Higher rules override lower. Document each rung.
-5. **Implement the reader** as a method on the class — `getAgent<Thing>Policy()` if agent-scoped, or whatever name fits the locus. Return `null` for no-op.
-6. **Implement the resolver method** with a clear name — the verb is the question. `shouldPersist()`, `resolveForTool()`, `resolve()` for set filters.
-7. **Register a final `datamachine_resolved_<thing>` filter** as the last step.
-8. **Call from one place** — directly from the call site that consumes the answer. Don't build a generic dispatcher unless multiple call sites would loop over registered policies (none currently do).
-
-Resist these temptations:
-
-- ❌ Extracting `AbstractAgentPolicy` / a base class. The resolvers don't share a return type. Inheritance enforces uniformity that the problems reject.
-- ❌ Building a "policy registry" or "policy dispatcher" before any consumer iterates over policies generically. Each call site knows which policy it cares about and calls it directly.
-- ❌ Forcing the new resolver's ladder shape to match an existing one. The shape should follow the question.
-- ❌ Reading from `agent_config` reflexively. If the natural locus is somewhere else, store it somewhere else.
-
-If two resolvers later turn out to share *both* the same return shape *and* the same input shape *and* are consumed polymorphically by some new system that loops over registered policies — *then* extract a trait. Even then, prefer a trait (mixin-style, additive) over a base class (locks the hierarchy).
-
-## Where the resolvers live
-
+```json
+{
+  "directive_policy": {
+    "mode": "deny",
+    "deny": ["CoreMemoryFilesDirective"],
+    "modes": ["pipeline"]
+  }
+}
 ```
+
+Supported modes are:
+
+| Policy mode | Effect |
+|---|---|
+| `default` | No-op. |
+| `deny` | Suppress matching directive classes. |
+| `allow_only` | Keep only matching directive classes. |
+
+Policy entries match either the fully-qualified class name or the short class name. The optional `modes` list scopes the directive policy to request modes. The resolver returns both the filtered directive list and the suppressed short names for observability.
+
+Final filter: `datamachine_resolved_directives`.
+
+## Action Policy Resolver
+
+`ActionPolicyResolver` answers a different question from tool policy. Tool policy decides whether the model can see a tool. Action policy decides what happens after the model calls it.
+
+Values use the Agents API vocabulary:
+
+| Value | Meaning |
+|---|---|
+| `direct` | Execute immediately. |
+| `preview` | Stage through `PendingActionHelper` and return an approval-required envelope. |
+| `forbidden` | Refuse the invocation. |
+
+Resolution order:
+
+1. Explicit `deny` context list.
+2. Per-agent `agent_config.action_policy.tools[tool_name]`.
+3. Per-agent `agent_config.action_policy.categories[category]`.
+4. Tool-declared default, including per-mode keys such as `action_policy_chat`.
+5. Mode provider default from `DataMachineModeActionPolicyProvider`.
+6. Agents API global default.
+7. `datamachine_tool_action_policy` filter.
+
+`ToolExecutor` enforces the result. `preview` requires the tool definition to declare `action_kind`; otherwise Data Machine logs a warning and falls back to direct execution because it cannot safely synthesize replay semantics.
+
+## Pending Action Helper
+
+`PendingActionHelper` is the staging helper used when action policy resolves to `preview`. It writes a pending action via `PendingActionStore`, fires `datamachine_pending_action_staged`, and returns an Agents API `approval_required` message.
+
+The approval envelope includes `pending_action`, `resolve_with`, `resolve_params`, and user-facing instructions. It also carries top-level `staged` and `action_id` compatibility fields for internal callers.
+
+Tools should provide self-contained `apply_input`. The accepted/rejected resolution path replays the stored input through the registered pending action handler, so preview staging must not depend on transient local variables.
+
+## Memory and Transcript Policies
+
+`MemoryPolicyResolver` keeps the same convention but filters memory file sets rather than tools. It has two paths: registered memory files for a mode and explicit memory lists from pipeline/flow configuration.
+
+`PipelineTranscriptPolicy` bends the convention because transcript persistence is scoped to a pipeline run, not to an individual agent tool or memory file. It reads flow config, then pipeline config, then the site option.
+
+## Adding Another Resolver
+
+Use this pattern when adding a new policy question:
+
+1. Pick the locus: agent config, flow config, pipeline config, site option, or request context.
+2. Pick the return shape that answers the question directly.
+3. Normalize invalid or no-op policy to `null` where possible.
+4. Write the precedence order in the class docblock before implementing it.
+5. Keep the public method named after the question, such as `resolve()`, `resolveForTool()`, or `shouldPersist()`.
+6. Add a final filter for extension points.
+7. Call the resolver from the one runtime path that consumes the answer.
+
+Avoid a shared base class unless a real consumer needs to handle multiple policies polymorphically and they share both input and output shapes. That is not true for the current resolvers.
+
+## Files
+
+```text
 inc/Engine/AI/Tools/ToolPolicyResolver.php
+inc/Engine/AI/Tools/ToolSourceRegistry.php
 inc/Engine/AI/Memory/MemoryPolicyResolver.php
+inc/Engine/AI/Directives/DirectivePolicyResolver.php
 inc/Engine/AI/Actions/ActionPolicyResolver.php
+inc/Engine/AI/Actions/PendingActionHelper.php
 inc/Engine/AI/PipelineTranscriptPolicy.php
+inc/Core/Steps/AI/ToolPolicy/PipelineToolPolicyArgs.php
 ```
 
-Each is a single file, single class, single responsibility. Class docblocks carry the precedence ladder. Class methods carry the per-step rationale. There is no shared parent, no shared interface, and no shared trait — only a shared shape that's documented here.
+## Related Docs
 
-## Related issues
-
-- #1101 — DirectivePolicy exploration. Names the "abstraction-on-N=2 risk" trap that this doc encodes at N=4. Keep the warning live; it applies to every Nth resolver.
-- #1226 — generalize `PipelineTranscriptPolicy` across agent modes. The PR for that issue is the next chance to set the cross-mode pattern; this doc is the design context for that work.
-- #972 — refactor chat tool policy for per-user dynamic toolsets. Belongs to `ToolPolicyResolver`'s evolution; doesn't touch the convention.
+- [Tool Manager](../core-system/tool-manager.md)
+- [Tool Execution Architecture](../core-system/tool-execution.md)
+- [Memory Policy](../core-system/memory-policy.md)

--- a/docs/core-system/ai-conversation-loop.md
+++ b/docs/core-system/ai-conversation-loop.md
@@ -520,6 +520,6 @@ Set appropriate max turns based on workflow complexity:
 ## Related Components
 
 - Universal Engine Architecture - Overall engine structure
-- Tool Execution Architecture - ToolExecutor details
+- [Tool Execution Architecture](tool-execution.md) - ToolExecutor details
 - RequestBuilder Pattern - AI request construction
 - [ConversationManager](universal-engine.md#conversationmanager) - Message formatting utilities

--- a/docs/core-system/request-builder.md
+++ b/docs/core-system/request-builder.md
@@ -480,5 +480,5 @@ add_filter('datamachine_directives', function($directives) {
 - Universal Engine Architecture - Overall engine structure
 - AI Conversation Loop - Uses RequestBuilder for AI requests
 - PromptBuilder Pattern - Unified directive management
-- Tool Execution Architecture - Tool discovery and execution
+- [Tool Execution Architecture](tool-execution.md) - Tool discovery, execution, action policy, and approval staging
 - Universal Engine Filters - Complete filter reference

--- a/docs/core-system/tool-execution.md
+++ b/docs/core-system/tool-execution.md
@@ -1,647 +1,251 @@
 # Tool Execution Architecture
 
-**Files**:
-- `/inc/Engine/AI/Tools/ToolExecutor.php`
-- `/inc/Engine/AI/Tools/ToolParameters.php`
+Tool execution is split into a generic execution core and a Data Machine product wrapper.
 
-**Since**: 0.2.0
+| Component | File | Responsibility |
+|---|---|---|
+| `ToolPolicyResolver` | `inc/Engine/AI/Tools/ToolPolicyResolver.php` | Builds the visible tool set for a request. |
+| `ToolExecutionCore` | `inc/Engine/AI/Tools/Execution/ToolExecutionCore.php` | Validates required parameters, builds complete parameters, executes ability-only or class/method tools. |
+| `ToolExecutor` | `inc/Engine/AI/Tools/ToolExecutor.php` | Applies action policy, stages preview actions, runs direct execution, records post-origin tracking. |
+| `ToolParameters` | `inc/Engine/AI/Tools/ToolParameters.php` | Merges AI arguments with payload, data packet, handler config, and tool metadata. |
+| `ActionPolicyResolver` | `inc/Engine/AI/Actions/ActionPolicyResolver.php` | Decides whether one invocation is `direct`, `preview`, or `forbidden`. |
+| `PendingActionHelper` | `inc/Engine/AI/Actions/PendingActionHelper.php` | Stores approval-required invocations and returns the Agents API approval envelope. |
 
-Universal tool discovery, enablement, and execution infrastructure shared by Pipeline AI and Chat API agents. Provides centralized tool management with filter-based registration and configuration validation.
+## Runtime Flow
 
-## Overview
+```text
+AI request setup
+    |
+    v
+ToolPolicyResolver::resolve()
+    |
+    v
+model tool call
+    |
+    v
+ToolExecutor::executeTool()
+    |
+    +--> ToolExecutionCore::prepareToolCall()
+    |       - tool exists in available tools
+    |       - required parameters are present
+    |       - ToolParameters::buildParameters()
+    |
+    +--> ActionPolicyResolver::resolveForTool()
+    |       - direct / preview / forbidden
+    |
+    +--> forbidden: return error
+    |
+    +--> preview: PendingActionHelper::stage()
+    |
+    +--> direct: ToolExecutionCore::executePreparedTool()
+            - ability-only tool: WP_Ability permissions + execute()
+            - class/method tool: instantiate class and call method
+```
 
-The tool execution architecture consists of two core components:
+## Resolving Tools Before Execution
 
-1. **ToolExecutor** - Tool discovery, validation, and execution
-2. **WP_Agent_Tool_Parameters** - Centralized parameter building and merging
+All runtime tool sets should come from `ToolPolicyResolver::resolve()`.
 
-Together, these components ensure consistent tool behavior across all AI agents while supporting flexible, filter-based tool registration.
-
-## ToolExecutor
-
-**File**: `/inc/Engine/AI/Tools/ToolExecutor.php`
-
-Handles tool discovery via filters, enablement validation, and execution with comprehensive error handling.
-
-### Tool Discovery
-
-Tools are discovered through three filter-based registration patterns, and
-resolved via `ToolPolicyResolver::resolve()` — the single entry point for
-both chat and pipeline modes:
+Pipeline example:
 
 ```php
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 
 $resolver = new ToolPolicyResolver();
-```
 
-**Pipeline Agent Usage** (with step context):
-```php
 $tools = $resolver->resolve( array(
     'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
+    'agent_id'             => $agent_id,
     'previous_step_config' => $previous_step_config,
     'next_step_config'     => $next_step_config,
-    'pipeline_step_id'     => $current_pipeline_step_id,
+    'pipeline_step_id'     => $flow_step_id,
     'engine_data'          => $engine_data,
+    'allow_only'           => $policy_args['allow_only'] ?? array(),
+    'deny'                 => $policy_args['deny'] ?? array(),
 ) );
 ```
 
-**Chat Agent Usage** (global tools only):
+Chat example:
+
 ```php
 $tools = $resolver->resolve( array(
-    'mode' => ToolPolicyResolver::MODE_CHAT,
+    'mode'           => ToolPolicyResolver::MODE_CHAT,
+    'agent_id'       => $agent_id,
+    'client_context' => array(
+        'session_id' => $session_id,
+    ),
 ) );
 ```
 
-### Tool Registration Patterns
+`ToolExecutor` expects the already-resolved `$available_tools` array. It does not rediscover tools.
 
-#### 1. Handler Tools (Step-Specific)
-
-Tools registered into the unified `datamachine_tools` registry as
-`_handler_callable` entries — runtime-resolved with the adjacent step's
-handler config so parameter shapes can adapt to per-step settings (e.g.
-AI-decides taxonomies, character limits, etc.). The preferred path is
-`HandlerRegistrationTrait::registerHandler()`; manual shape:
+## Executing a Tool
 
 ```php
-add_filter('datamachine_tools', function($tools) {
-    $tools['__handler_tools_twitter'] = [
-        '_handler_callable' => function($handler_slug, $handler_config, $engine_data) {
-            return [
-                'twitter_publish' => [
-                    'class'          => 'DataMachine\\Core\\Steps\\Publish\\Handlers\\Twitter\\Twitter',
-                    'method'         => 'handle_tool_call',
-                    'handler'        => $handler_slug,
-                    'description'    => 'Post content to Twitter (280 character limit)',
-                    'parameters'     => [
-                        'content' => [
-                            'type'        => 'string',
-                            'required'    => true,
-                            'description' => 'Tweet content (max 280 chars)',
-                        ],
-                    ],
-                    'handler_config' => $handler_config,
-                ],
-            ];
-        },
-        'handler'      => 'twitter',
-        'modes'        => ['pipeline'],
-        'access_level' => 'admin',
-    ];
-    return $tools;
-});
+use DataMachine\Engine\AI\Actions\ActionPolicyResolver;
+use DataMachine\Engine\AI\Tools\ToolExecutor;
+
+$result = ToolExecutor::executeTool(
+    $tool_name,
+    $tool_parameters,
+    $available_tools,
+    array(
+        'job_id'           => $job_id,
+        'data'             => $data_packets,
+        'flow_step_id'     => $flow_step_id,
+        'flow_step_config' => $flow_step_config,
+    ),
+    ActionPolicyResolver::MODE_PIPELINE,
+    $agent_id
+);
 ```
 
-**Key**: `ToolPolicyResolver::gatherPipelineTools()` resolves these entries
-against the adjacent pipeline step's `handler_slug` (or `handler_types` for
-cross-cutting tools like `skip_item`).
-
-Adjacent handler tools are **flow plumbing**, not optional global tools. In
-pipeline mode they bypass agent `tool_policy`, context `tool_categories`, and
-context `allow_only` filtering because the adjacent flow shape requires them for
-publish/upsert completion. Static/global pipeline tools still pass those policy
-layers normally.
-
-If a required adjacent publish/upsert handler has no AI-callable handler tool,
-the AI step fails before the model call with `required_handler_tool_unavailable`.
-The request inspector uses the same missing-handler check, so `wp datamachine ai
-inspect-request` reports the same unavailable-handler state without dispatching
-to a provider.
-
-#### 2. Global Tools (All Agents)
-
-Tools registered via `datamachine_global_tools` filter, available to all AI agents:
-
-```php
-add_filter('datamachine_global_tools', function($tools) {
-    $tools['google_search'] = [
-        'class' => 'DataMachine\\Engine\\AI\\Tools\\GoogleSearch',
-        'method' => 'handle_tool_call',
-        'description' => 'Search the web using Google Custom Search',
-        'parameters' => [
-            'query' => [
-                'type' => 'string',
-                'required' => true,
-                'description' => 'Search query'
-            ]
-        ],
-        'requires_config' => true
-    ];
-    return $tools;
-});
-```
-
-**Location**: `/inc/Engine/AI/Tools/`
-
-**Global Tools**:
-- `google_search` - Web search via Google Custom Search API
-- `local_search` - WordPress content search
-- `web_fetch` - Retrieve web page content
-- `wordpress_post_reader` - Read specific WordPress post by URL
-
-#### 3. Chat-Only Tools
-
-Tools registered via `datamachine_chat_tools` filter, available only to Chat agent. Since v0.4.3, these are specialized operation-specific tools:
-
-```php
-add_filter('datamachine_chat_tools', function($tools) {
-    $tools['create_pipeline'] = [
-        'class' => 'DataMachine\\Api\\Chat\\Tools\\CreatePipeline',
-        'method' => 'handle_tool_call',
-        'description' => 'Create a new pipeline with optional steps',
-        'parameters' => [
-            'name' => [
-                'type' => 'string',
-                'required' => true,
-                'description' => 'Pipeline name'
-            ],
-            'steps' => [
-                'type' => 'array',
-                'required' => false,
-                'description' => 'Optional initial steps'
-            ]
-        ]
-    ];
-    return $tools;
-});
-```
-
-**Chat Tools** (@since v0.4.3):
-- `execute_workflow` - Execute complete multi-step workflows
-- `add_pipeline_step` - Add steps to existing pipelines
-- `api_query` - REST API query for discovery
-- `configure_flow_step` - Configure flow step handlers and AI messages
-- `configure_pipeline_step` - Configure pipeline AI settings
-- `create_flow` - Create flow instances from pipelines
-- `create_pipeline` - Create pipelines with optional steps
-- `run_flow` - Execute or schedule flows
-- `update_flow` - Update flow properties
-
-### Tool Enablement Control
-
-Tools must pass enablement validation before being made available to AI agents:
-
-```php
-private static function getAllowedTools(
-    array $all_tools,
-    ?string $handler_slug,
-    ?string $pipeline_step_id = null
-): array
-```
-
-**Enablement Logic**:
-
-1. **Handler Tools**: Automatically enabled if handler matches
-2. **Global/Chat Tools**: Must pass two checks:
-   - `datamachine_tool_enabled` filter returns true
-   - `datamachine_tool_configured` filter returns true (if tool requires configuration)
-
-**Pipeline Agent Enablement** (step-specific):
-```php
-add_filter('datamachine_tool_enabled', function($enabled, $tool_name, $tool_config, $pipeline_step_id) {
-    if ($pipeline_step_id) {
-        // Check if tool is enabled for this specific pipeline step
-        $step_config = apply_filters('datamachine_get_flow_step_config', [], $pipeline_step_id);
-        $enabled_tools = $step_config['enabled_tools'] ?? [];
-        return in_array($tool_name, $enabled_tools);
-    }
-    return $enabled;
-}, 10, 4);
-```
-
-**Chat Agent Enablement** (global):
-```php
-add_filter('datamachine_tool_enabled', function($enabled, $tool_name, $tool_config, $context_id) {
-    if ($context_id === null) {
-        // Chat agent: use global tool enablement
-        $tool_configured = apply_filters('datamachine_tool_configured', false, $tool_name);
-        $requires_config = !empty($tool_config['requires_config']);
-        return !$requires_config || $tool_configured;
-    }
-    return $enabled;
-}, 5, 4); // Priority 5 so pipeline (priority 10) can override
-```
-
-### Configuration Validation
-
-Tools requiring external services or API keys use the `requires_config` flag:
-
-```php
-$tools['google_search'] = [
-    'class' => 'DataMachine\\Engine\\AI\\Tools\\GoogleSearch',
-    'method' => 'handle_tool_call',
-    'description' => 'Search the web using Google Custom Search',
-    'parameters' => [...],
-    'requires_config' => true  // Requires API key + search engine ID
-];
-```
-
-**Configuration Check**:
-```php
-add_filter('datamachine_tool_configured', function($configured, $tool_name) {
-    if ($tool_name === 'google_search') {
-        $settings = datamachine_get_data_machine_settings();
-        $api_key = $settings['google_search_api_key'] ?? '';
-        $search_engine_id = $settings['google_search_engine_id'] ?? '';
-        return !empty($api_key) && !empty($search_engine_id);
-    }
-    return $configured;
-}, 10, 2);
-```
-
-### Tool Execution
-
-Execute tools with automatic parameter building and error handling:
+Signature:
 
 ```php
 public static function executeTool(
     string $tool_name,
     array $tool_parameters,
     array $available_tools,
-    array $data,
-    ?string $flow_step_id,
-    array $payload
-): array
-```
-
-**Pipeline Agent Execution**:
-```php
-$result = ToolExecutor::executeTool(
-    $tool_name,           // 'twitter_publish'
-    $tool_parameters,     // ['content' => 'Tweet text']
-    $available_tools,     // All available tools array
-    $data,                // Data packets from previous steps
-    $flow_step_id,        // 'step_uuid_flow_123'
-    [
-        'job_id' => $job_id,
-        'data' => $data,
-        'handler_config' => $handler_config,
-        // ... additional engine parameters
-    ]
-);
-```
-
-**Chat Agent Execution**:
-```php
-$result = ToolExecutor::executeTool(
-    $tool_name,           // 'create_pipeline'
-    $tool_parameters,     // ['name' => 'My Pipeline', 'steps' => [...]]
-    $available_tools,     // All available tools array
-    [],                   // Empty data packets for chat
-    null,                 // No flow_step_id for chat
-    [
-        'session_id' => $session_id
-    ]
-);
-```
-
-**Execution Process**:
-
-1. Validate tool exists in available tools
-2. Build complete parameters via `WP_Agent_Tool_Parameters::buildParameters()`
-3. Instantiate tool class
-4. Call `handle_tool_call()` method with complete parameters
-5. Return standardized result array
-
-**Result Structure**:
-```php
-[
-    'success' => true,           // Execution status
-    'data' => [...],             // Tool-specific result data
-    'tool_name' => 'tool_name',  // Tool identifier
-    'error' => 'Error message'   // Only present if success=false
-]
-```
-
-### Error Handling
-
-Comprehensive error handling for tool execution failures:
-
-**Tool Not Found**:
-```php
-if (!$tool_def) {
-    return [
-        'success' => false,
-        'error' => "Tool '{$tool_name}' not found",
-        'tool_name' => $tool_name
-    ];
-}
-```
-
-**Class Not Found**:
-```php
-if (!class_exists($class_name)) {
-    return [
-        'success' => false,
-        'error' => "Tool class '{$class_name}' not found",
-        'tool_name' => $tool_name
-    ];
-}
-```
-
-**Execution Exception**:
-```php
-try {
-    $tool_handler = new $class_name();
-    $tool_result = $tool_handler->handle_tool_call($complete_parameters, $tool_def);
-    return $tool_result;
-} catch (\Exception $e) {
-    do_action('datamachine_log', 'error', 'ToolExecutor: Tool execution exception', [
-        'flow_step_id' => $flow_step_id,
-        'tool_name' => $tool_name,
-        'exception' => $e->getMessage(),
-        'trace' => $e->getTraceAsString()
-    ]);
-
-    return [
-        'success' => false,
-        'error' => 'Tool execution exception: ' . $e->getMessage(),
-        'tool_name' => $tool_name
-    ];
-}
-```
-
-## WP_Agent_Tool_Parameters
-
-**File**: `/inc/Engine/AI/Tools/ToolParameters.php`
-
-Centralized parameter building for AI tool execution. Merges AI-provided parameters with engine context to create complete parameter sets.
-
-### Standard Parameter Building
-
-Build unified flat parameter structure for tool execution:
-
-```php
-public static function buildParameters(
-    array $ai_tool_parameters,
     array $payload,
-    array $tool_definition
+    string $mode = ActionPolicyResolver::MODE_CHAT,
+    int $agent_id = 0,
+    array $client_context = array()
 ): array
 ```
 
-**Usage**:
-```php
-$complete_parameters = WP_Agent_Tool_Parameters::buildParameters(
-    ['query' => 'WordPress SEO tips'],  // AI parameters
-    ['session_id' => $session_id],      // Unified context
-    $tool_definition                     // Tool definition array
-);
+The `$mode`, `$agent_id`, and `$client_context` values only affect action policy. Tool visibility has already been resolved before execution.
 
-// Result:
-// [
-//     'session_id' => 'session_123',
-//     'content' => null,
-//     'title' => null,
-//     'tool_definition' => [...],
-//     'tool_name' => 'google_search',
-//     'handler_config' => [],
-//     'query' => 'WordPress SEO tips'
-// ]
-```
+## Generic Execution Core
 
-**Parameter Building Process**:
-
-1. Start with unified parameters (session_id, job_id, data, etc.)
-2. Extract `content` from data packet if tool requires it
-3. Extract `title` from data packet if tool requires it
-4. Add tool metadata (tool_definition, tool_name, handler_config)
-5. Merge AI-provided parameters (overwrites defaults)
-
-### Content Extraction
-
-Automatic content extraction from data packets for tools requiring content:
+`ToolExecutionCore::prepareToolCall()` returns either a normalized error or a prepared invocation:
 
 ```php
-private static function extractContent(array $data_packet, array $tool_definition): ?string
-{
-    $tool_params = $tool_definition['parameters'] ?? [];
-    if (!isset($tool_params['content'])) {
-        return null; // Tool doesn't require content
-    }
-
-    $latest_entry = !empty($data_packet) ? $data_packet[0] : [];
-    $content_data = $latest_entry['content'] ?? [];
-    return $content_data['body'] ?? null;
-}
+array(
+    'ready'      => true,
+    'tool_def'   => $tool_def,
+    'parameters' => $complete_parameters,
+)
 ```
 
-**Example**: Twitter publish tool receives content from AI step's data packet automatically.
+Preparation checks that the tool exists in `$available_tools`, validates required parameters declared in `parameters`, and calls `ToolParameters::buildParameters()`.
 
-### Title Extraction
+`ToolExecutionCore::executePreparedTool()` supports two executable shapes:
 
-Automatic title extraction from data packets for tools requiring title:
+| Shape | Required keys | Execution path |
+|---|---|---|
+| Ability-only | `ability`, no `class`, no `method` | Resolve ability from `WP_Abilities_Registry`, check permissions, call `execute()`. |
+| Class/method | `class`, `method` | Instantiate class and call the method with complete parameters and tool definition. |
+
+Ability-only tools are useful when the WordPress Ability is already the source of truth for permission and behavior. Class/method tools remain valid for Data Machine handler tools and product-specific adapters.
+
+## Parameter Building
+
+`ToolParameters::buildParameters()` merges model-provided arguments with Data Machine payload context.
+
+Common payload values include:
+
+| Payload key | Purpose |
+|---|---|
+| `job_id` | Job currently running. |
+| `data` | Data packets from previous steps. |
+| `flow_step_id` | Current flow-step identifier. |
+| `flow_step_config` | Current flow-step snapshot. |
+| `handler_config` | Handler-specific runtime configuration. |
+| `session_id` | Chat session identifier when called from chat. |
+
+The AI's tool parameters win over defaults extracted from the payload. Handler tools also receive `handler_config`, engine data such as `source_url` and `image_url`, and the resolved `tool_definition`.
+
+## Action Policy
+
+Visibility and execution are separate. A tool can be visible to the model and still be prevented from executing directly.
+
+`ActionPolicyResolver::resolveForTool()` returns the Agents API vocabulary:
+
+| Policy | Effect |
+|---|---|
+| `direct` | Execute immediately. |
+| `preview` | Stage the invocation and return an approval-required envelope. |
+| `forbidden` | Return a refusal error without running the tool. |
+
+Resolution inputs include `tool_name`, `tool_def`, `mode`, `agent_id`, `client_context`, and optional `deny`.
+
+Resolution order is:
+
+1. Explicit deny list.
+2. Per-agent `agent_config.action_policy.tools[tool_name]`.
+3. Per-agent `agent_config.action_policy.categories[category]`.
+4. Tool-declared default, including per-mode keys such as `action_policy_chat`.
+5. Mode preset from `DataMachineModeActionPolicyProvider`.
+6. Global default from Agents API.
+7. `datamachine_tool_action_policy` filter.
+
+Chat can stage publish-family tools for preview because a user is present. Pipeline and system modes default to direct for automation unless a tool or policy says otherwise.
+
+## Pending Actions
+
+When action policy resolves to `preview`, `ToolExecutor` stages the invocation if the tool declares `action_kind`. Staging uses `PendingActionHelper::stage()`.
 
 ```php
-private static function extractTitle(array $data_packet, array $tool_definition): ?string
-{
-    $tool_params = $tool_definition['parameters'] ?? [];
-    if (!isset($tool_params['title'])) {
-        return null; // Tool doesn't require title
-    }
-
-    $latest_entry = !empty($data_packet) ? $data_packet[0] : [];
-    $content_data = $latest_entry['content'] ?? [];
-    return $content_data['title'] ?? null;
-}
+$staged = PendingActionHelper::stage( array(
+    'kind'         => 'socials_publish_instagram',
+    'summary'      => 'Publish Instagram post: Spring menu is live',
+    'apply_input'  => $complete_parameters,
+    'preview_data' => array(
+        'caption' => $complete_parameters['caption'] ?? '',
+    ),
+    'agent_id'     => $agent_id,
+    'context'      => array(
+        'mode'      => 'chat',
+        'tool_name' => 'publish_instagram',
+        'session_id' => $session_id,
+    ),
+) );
 ```
 
-### Handler Tool Parameter Building
+The result is an Agents API `approval_required` message with:
 
-Build parameters for handler tools with engine data integration:
+| Field | Purpose |
+|---|---|
+| `payload.pending_action.action_id` | Identifier to resolve later. |
+| `payload.pending_action.summary` | Human-readable preview summary. |
+| `payload.pending_action.preview` | Renderable preview data. |
+| `payload.resolve_with` | Tool name to call for resolution, currently `resolve_pending_action`. |
+| `payload.resolve_params` | Required resolution arguments. |
+| top-level `staged` and `action_id` | Data Machine compatibility fields for internal callers. |
+
+Tools should not hand-roll this envelope. Use `PendingActionHelper` so the store shape, approval message, and compatibility fields stay aligned.
+
+## Post-Origin Tracking
+
+After direct execution succeeds, `ToolExecutor` calls `PostTracking::extractPostId()` and records origin metadata for results that created or modified a WordPress post. This applies to handler tools and ability-only tools when their result exposes an extractable post ID.
+
+## Error Shapes
+
+Common normalized failures:
 
 ```php
-public static function buildForHandlerTool(
-    array $ai_tool_parameters,
-    array $data,
-    array $tool_definition,
-    array $engine_parameters,
-    array $handler_config
-): array
+array(
+    'success'   => false,
+    'error'     => "Tool 'my_tool' not found",
+    'tool_name' => 'my_tool',
+)
 ```
-
-**Usage**:
-```php
-$complete_parameters = WP_Agent_Tool_Parameters::buildForHandlerTool(
-    ['content' => 'Tweet text'],           // AI parameters
-    $data,                                  // Data packets
-    $tool_definition,                       // Tool definition
-    [
-        'source_url' => 'https://example.com/post',
-        'image_url' => 'https://example.com/image.jpg'
-    ],                                      // Engine parameters
-    $handler_config                         // Handler configuration
-);
-
-// Result:
-// [
-//     'data' => [...],
-//     'handler_config' => [...],
-//     'content' => 'Generated content from AI step',
-//     'title' => 'Generated title from AI step',
-//     'tool_definition' => [...],
-//     'tool_name' => 'twitter_publish',
-//     'content' => 'Tweet text',  // AI parameter overwrites default
-//     'source_url' => 'https://example.com/post',
-//     'image_url' => 'https://example.com/image.jpg'
-// ]
-```
-
-**Engine Data Integration**:
-
-Handler tools receive engine parameters (source_url, image_url) from centralized storage:
 
 ```php
-// Merge engine data (source_url, image_url) from centralized access
-foreach ($engine_parameters as $key => $value) {
-    $parameters[$key] = $value;
-}
+array(
+    'success'       => false,
+    'error'         => 'Tool "publish_instagram" is not permitted in the current context (action_policy=forbidden).',
+    'tool_name'     => 'publish_instagram',
+    'action_policy' => 'forbidden',
+)
 ```
 
-## Tool Categories
+Ability-only failures include the linked `ability` slug when ability registration, permission, or execution fails.
 
-### Handler Tools
+## Related Docs
 
-**Registration**: `datamachine_tools` filter — `_handler_callable` entries
-**Scope**: Step-specific (publish, upsert handlers)
-**Enablement**: Automatic when adjacent step's handler slug or type matches
-**Examples**: `twitter_publish`, `wordpress_publish`, `bluesky_publish`
-
-**Characteristics**:
-- Registry entry carries `'handler' => 'slug'` (exact match) or
-  `'handler_types' => [...]` (cross-cutting tools like `skip_item`)
-- Resolved at pipeline execution time with the adjacent step's handler config
-- Receive data packets and engine parameters
-- Execute final workflow actions (publishing, updating)
-
-### Global Tools
-
-**Registration**: `datamachine_global_tools` filter
-**Scope**: All AI agents (pipeline + chat)
-**Enablement**: Via `datamachine_tool_enabled` filter + configuration check
-**Examples**: `google_search`, `local_search`, `web_fetch`, `wordpress_post_reader`
-
-**Characteristics**:
-- Available to all agents if enabled
-- May require configuration (`requires_config` flag)
-- Used for information gathering and research
-- Do not modify external systems
-
-### Chat-Only Tools
-
-**Registration**: `datamachine_chat_tools` filter
-**Scope**: Chat agent only
-**Enablement**: Via `datamachine_tool_enabled` filter
-**Examples** (@since v0.4.3): `execute_workflow`, `create_pipeline`, `run_flow`, `configure_flow_step`, etc.
-
-**Characteristics**:
-- Only available to chat agent
-- Enable conversational workflow building
-- Specialized operation-specific tools for pipeline/flow management
-- Bridge chat interface to system operations
-
-## Best Practices
-
-### Tool Registration
-
-**Handler Tools** (preferred path is `HandlerRegistrationTrait::registerHandler()`):
-```php
-add_filter('datamachine_tools', function($tools) {
-    $tools['__handler_tools_my_handler'] = [
-        '_handler_callable' => function($handler_slug, $handler_config, $engine_data) {
-            return [
-                'my_tool' => [
-                    'class'          => 'MyNamespace\\MyHandler',
-                    'method'         => 'handle_tool_call',
-                    'handler'        => $handler_slug,
-                    'description'    => 'Clear, concise tool description',
-                    'parameters'     => [
-                        'param_name' => [
-                            'type'        => 'string',
-                            'required'    => true,
-                            'description' => 'Parameter description for AI',
-                        ],
-                    ],
-                    'handler_config' => $handler_config,
-                ],
-            ];
-        },
-        'handler'      => 'my_handler',
-        'modes'        => ['pipeline'],
-        'access_level' => 'admin',
-    ];
-    return $tools;
-});
-```
-
-**Global Tools**:
-```php
-add_filter('datamachine_global_tools', function($tools) {
-    $tools['my_global_tool'] = [
-        'class' => 'DataMachine\\Engine\\AI\\Tools\\MyTool',
-        'method' => 'handle_tool_call',
-        'description' => 'Tool description visible to all agents',
-        'parameters' => [...],
-        'requires_config' => true  // If tool needs API keys/configuration
-    ];
-    return $tools;
-});
-```
-
-### Parameter Building
-
-**AI-Provided Parameters Override Defaults**:
-```php
-// AI provides: ['content' => 'Custom content']
-// Data packet has: ['content' => ['body' => 'Default content']]
-// Result: 'Custom content' (AI parameter wins)
-```
-
-**Access Engine Data in Tool Handler**:
-```php
-public function handle_tool_call(array $parameters, array $tool_def = []): array {
-    $source_url = $parameters['source_url'] ?? null;
-    $image_url = $parameters['image_url'] ?? null;
-    $handler_config = $parameters['handler_config'] ?? [];
-
-    // Use engine data for operations
-    return ['success' => true, 'data' => [...]];
-}
-```
-
-### Tool Execution
-
-**Always Check Tool Result**:
-```php
-$result = ToolExecutor::executeTool(...);
-
-if ($result['success']) {
-    $data = $result['data'];
-    // Process successful result
-} else {
-    $error = $result['error'];
-    // Handle failure
-}
-```
-
-**Provide Complete Payload Parameters**:
-```php
-// Pipeline
-$payload = [
-    'job_id' => $job_id,
-    'data' => $data,
-    'handler_config' => $handler_config,
-    // ... additional context
-];
-
-// Chat
-$payload = [
-    'session_id' => $session_id
-];
-```
-
-## Related Components
-
-- Universal Engine Architecture - Overall engine structure
-- AI Conversation Loop - Tool execution integration
-- RequestBuilder Pattern - AI request construction
-- Universal Engine Filters - Filter hook reference
+- [Tool Manager](tool-manager.md)
+- [Policy Resolvers](../architecture/policy-resolvers.md)
+- [AI Conversation Loop](ai-conversation-loop.md)
+- [Tool Result Finder](tool-result-finder.md)

--- a/docs/core-system/tool-manager.md
+++ b/docs/core-system/tool-manager.md
@@ -1,346 +1,188 @@
 # Tool Manager
 
-Centralized tool management system introduced in v0.2.1 that replaces distributed tool discovery and validation logic.
+`ToolManager` is the Data Machine adapter for the AI tool registry. It owns Data Machine's `datamachine_tools` compatibility registry, lazy definition resolution, handler-tool expansion, configuration checks, and global enablement checks. It does not decide the final per-request tool set by itself. Runtime visibility is resolved by `ToolPolicyResolver` through `ToolSourceRegistry`.
 
-## Overview
+## Current Shape
 
-ToolManager (`/inc/Engine/AI/Tools/ToolManager.php`) provides centralized methods for tool discovery, enablement validation, and configuration management across the entire system.
+```text
+datamachine_tools filter
+        |
+        v
+ToolManager
+  - get_all_tools()
+  - get_raw_tools()
+  - resolveHandlerTools()
+  - is_tool_available()
+        |
+        v
+ToolSourceRegistry
+  - static_registry
+  - adjacent_handlers
+        |
+        v
+ToolPolicyResolver::resolve()
+```
 
-## Architecture
+Use `ToolManager` when code needs to read Data Machine's registered tool definitions or resolve handler-owned tools. Use `ToolPolicyResolver::resolve()` when code needs the tool set an agent may actually see for a chat, pipeline, or system request.
 
-- **Location**: `/inc/Engine/AI/Tools/ToolManager.php`
-- **Purpose**: Centralize all tool-related operations
-- **Replaces**: Distributed filter logic for tool availability
-- **Benefits**:
-  - Single source of truth for tool availability
-  - Consistent validation patterns
-  - Performance optimization through centralized logic
-  - Easy extensibility for new validation rules
+## Registry Contract
 
-## Key Methods
-
-### get_all_tools()
-
-Returns all global tools available system-wide.
+All product and extension tools register through `datamachine_tools`.
 
 ```php
-public function get_all_tools(): array
-```
+add_filter( 'datamachine_tools', function ( array $tools ): array {
+    $tools['my_plugin/search'] = array(
+        '_callable'     => array( MyToolDefinitions::class, 'search' ),
+        'modes'         => array( 'chat' ),
+        'ability'       => 'my-plugin/search',
+        'access_level'  => 'admin',
+    );
 
-**Returns**: Array of global tool definitions
-
-**Usage**:
-```php
-$tool_manager = new ToolManager();
-$global_tools = $tool_manager->get_all_tools();
-```
-
-### is_tool_available()
-
-Validates if a tool is available for use based on global enablement, step configuration, and configuration status.
-
-```php
-public function is_tool_available(string $tool_id, ?string $context_id = null): bool
-```
-
-**Parameters**:
-- `$tool_id`: Tool identifier to validate
-- `$context_id`: Optional step context ID for step-specific validation
-
-**Returns**: Boolean indicating tool availability
-
-**Validation Layers**:
-1. Global settings check (tool must be enabled system-wide)
-2. Step configuration check (tool must be selected for specific step, if context provided)
-3. Configuration check (tool must have required credentials/API keys)
-
-### is_tool_configured()
-
-Checks if a tool has required configuration (API keys, OAuth, etc).
-
-```php
-public function is_tool_configured(string $tool_id): bool
-```
-
-**Parameters**:
-- `$tool_id`: Tool identifier to check
-
-**Returns**: Boolean indicating configuration status
-
-**Configuration Checks**:
-- API keys for third-party services
-- OAuth account credentials
-- Required settings validation
-- Auto-passes for WordPress-native tools
-
-### get_opt_out_defaults()
-
-Returns tools that don't require configuration (WordPress-native functionality).
-
-```php
-public function get_opt_out_defaults(): array
-```
-
-**Returns**: Array of tool IDs that are always considered "configured" if enabled
-
-**Default Opt-Out Tools**:
-- `local_search` - WordPress internal search
-- `wordpress_post_reader` - WordPress post content retrieval
-- `web_fetch` - Web page content fetching (no API required)
-
-**Usage**:
-```php
-$tool_manager = new ToolManager();
-$opt_out_tools = $tool_manager->get_opt_out_defaults();
-// Returns: ['local_search', 'wordpress_post_reader', 'web_fetch']
-```
-
-### get_tools_for_settings_page()
-
-Aggregates tool data for admin interface display.
-
-```php
-public function get_tools_for_settings_page(): array
-```
-
-**Returns**: Array of tool metadata for settings page
-
-**Usage**:
-```php
-$tool_manager = new ToolManager();
-$settings_data = $tool_manager->get_tools_for_settings_page();
-```
-
-## Tool Enablement Architecture
-
-### Three-Layer Validation
-
-ToolManager implements a three-layer validation system for tool availability:
-
-```
-┌─────────────────────────────────────────────┐
-│ Layer 1: Global Settings                    │
-│ - System-wide tool enablement toggle        │
-│ - Tools can be disabled globally            │
-└─────────────────────────────────────────────┘
-                    ↓
-┌─────────────────────────────────────────────┐
-│ Layer 2: Step Configuration                 │
-│ - Per-step tool selection in builder        │
-│ - Only selected tools available in step     │
-└─────────────────────────────────────────────┘
-                    ↓
-┌─────────────────────────────────────────────┐
-│ Layer 3: Runtime Validation                 │
-│ - Configuration requirements check          │
-│ - API key/OAuth credential validation       │
-│ - Tool execution readiness verification     │
-└─────────────────────────────────────────────┘
-```
-
-### Validation Flow
-
-```php
-// Complete validation flow
-$tool_manager = new ToolManager();
-
-// 1. Check tool availability (includes all validation layers)
-$is_available = $tool_manager->is_tool_available('google_search', $step_context_id);
-
-// 2. Check configuration requirements specifically
-$is_configured = $tool_manager->is_tool_configured('google_search');
-
-// 4. Final availability determination
-$is_available = $is_globally_enabled && $is_step_enabled && $is_configured;
-```
-
-## Opt-Out Pattern
-
-WordPress-native tools use an "opt-out" pattern for configuration:
-
-```php
-// Opt-out tools are always considered "configured"
-$tool_manager = new ToolManager();
-$opt_out_tools = $tool_manager->get_opt_out_defaults();
-
-// Configuration check auto-passes for these tools
-$is_configured = $tool_manager->is_tool_configured('local_search');
-// Returns: true (WordPress-native, no configuration needed)
-
-$is_configured = $tool_manager->is_tool_configured('google_search');
-// Returns: false (requires API key and Search Engine ID)
-```
-
-**Rationale**:
-- WordPress-native tools use built-in functionality
-- No external API keys or services required
-- Always available when WordPress is running
-- Reduces configuration burden for common tools
-
-## Usage in Components
-
-### ToolExecutor Integration
-
-```php
-use DataMachine\Engine\AI\Tools\ToolManager;
-
-class ToolExecutor {
-    private ToolManager $tool_manager;
-
-    public function __construct() {
-        $this->tool_manager = new ToolManager();
-    }
-
-    public function execute_tool(string $tool_id, array $parameters): array {
-        // Validate tool is available (includes enablement and configuration)
-        if (!$this->tool_manager->is_tool_available($tool_id)) {
-            return $this->error_response('Tool not available');
-        }
-
-        // Execute tool...
-    }
-}
-```
-
-### Settings UI Integration
-
-```php
-use DataMachine\Engine\AI\Tools\ToolManager;
-
-class SettingsPage {
-    public function render_tools_section(): void {
-        $tool_manager = new ToolManager();
-        $tools = $tool_manager->get_tools_for_settings_page();
-
-        foreach ($tools as $tool_id => $tool_data) {
-            // Render UI with:
-            // - Enable toggle (based on is_enabled)
-            // - Config button (if requires_config && !is_configured)
-            // - Status indicator (configured vs. needs setup)
-        }
-    }
-}
-```
-
-### Pipeline Builder Integration
-
-```php
-use DataMachine\Engine\AI\Tools\ToolManager;
-
-class AIStepModal {
-    public function get_available_tools(string $handler_slug): array {
-        $tool_manager = new ToolManager();
-
-        // Get global tools
-        $global_tools = $tool_manager->get_all_tools();
-
-        // Filter to only available tools for this context
-        return array_filter($global_tools, function($tool_id) use ($tool_manager) {
-            return $tool_manager->is_tool_available($tool_id);
-        });
-    }
-}
-```
-
-## Extension Integration
-
-Extensions can integrate with ToolManager through standard filter patterns:
-
-```php
-// Register custom tool
-add_filter('datamachine_global_tools', function($tools) {
-    $tools['my_custom_tool'] = [
-        'id' => 'my_custom_tool',
-        'class' => MyCustomTool::class,
-        'method' => 'execute',
-        'description' => 'Custom tool description',
-        'parameters' => [/* ... */]
-    ];
     return $tools;
-});
-
-// ToolManager automatically discovers and validates
-$tool_manager = new ToolManager();
-$is_available = $tool_manager->is_tool_available('my_custom_tool');
-$is_configured = $tool_manager->is_tool_configured('my_custom_tool');
+} );
 ```
 
-## Error Handling
-
-ToolManager provides consistent error handling:
+The `_callable` wrapper defers the full definition until a resolver needs it. The resolved definition must include the model-facing shape:
 
 ```php
-try {
-    $tools = $tool_manager->getAvailableTools('pipeline');
-} catch (Exception $e) {
-    do_action('datamachine_log', 'error', 'Tool discovery failed', [
-        'error' => $e->getMessage()
-    ]);
-    return [];
+array(
+    'description'     => 'Search the My Plugin index.',
+    'parameters'      => array(
+        'query' => array(
+            'type'        => 'string',
+            'required'    => true,
+            'description' => 'Search terms.',
+        ),
+    ),
+    'class'           => MySearchTool::class,
+    'method'          => 'handle_tool_call',
+    'modes'           => array( 'chat' ),
+    'requires_config' => false,
+)
+```
+
+Ability-only tools omit `class` and `method` and execute through the linked WordPress Ability:
+
+```php
+array(
+    'description' => 'Create a wiki note.',
+    'parameters'  => array( /* JSON-schema-like parameter map */ ),
+    'ability'     => 'intelligence/create-wiki-note',
+    'modes'       => array( 'chat' ),
+)
+```
+
+`ToolExecutionCore` treats a definition with `ability` and no `class`/`method` as ability-only. It checks ability permissions and calls `WP_Ability::execute()` directly.
+
+## Handler Tools
+
+Pipeline handler tools are dynamic because their parameter schemas depend on the adjacent flow-step handler config. Register them as `_handler_callable` entries in `datamachine_tools`, usually through `HandlerRegistrationTrait::registerHandler()`.
+
+```php
+add_filter( 'datamachine_tools', function ( array $tools ): array {
+    $tools['__handler_tools_wordpress_publish'] = array(
+        '_handler_callable' => function ( string $handler_slug, array $handler_config, array $engine_data ): array {
+            return array(
+                'wordpress_publish' => array(
+                    'class'          => WordPressPublishTool::class,
+                    'method'         => 'handle_tool_call',
+                    'handler'        => $handler_slug,
+                    'handler_config' => $handler_config,
+                    'description'    => 'Publish the processed item to WordPress.',
+                    'parameters'     => build_parameters_from_handler_config( $handler_config ),
+                ),
+            );
+        },
+        'handler'      => 'wordpress_publish',
+        'modes'        => array( 'pipeline' ),
+        'access_level' => 'admin',
+    );
+
+    return $tools;
+} );
+```
+
+`ToolManager::resolveHandlerTools()` supports two matching shapes:
+
+| Entry key | Meaning |
+|---|---|
+| `handler` | Exact adjacent handler slug match. |
+| `handler_types` | Match any adjacent handler whose registered type is in the list. Used by cross-cutting tools such as `skip_item`. |
+
+Resolved handler tools automatically receive `handler`, `handler_config`, inherited `access_level`, inherited `ability`, and `modes` when the callback omits them.
+
+## Source Registry
+
+`ToolSourceRegistry` composes named sources before policy filtering:
+
+| Source | Class | Used by default in |
+|---|---|---|
+| `static_registry` | `DataMachineToolRegistrySource` | `chat`, `pipeline`, `system`, custom modes |
+| `adjacent_handlers` | `AdjacentHandlerToolSource` | `pipeline` |
+
+`DataMachineToolRegistrySource` reads `ToolManager::get_all_tools()`, filters by each tool's `modes`, applies global enablement/configuration checks, and adapts policy-gated pipeline tools.
+
+`AdjacentHandlerToolSource` reads the previous and next step configs, gathers configured handler slugs through `FlowStepConfig`, and asks `ToolManager::resolveHandlerTools()` for each adjacent handler's dynamic tool definitions.
+
+The generic extension hooks are `agents_api_tool_sources` and `agents_api_tool_sources_for_mode`. Data Machine's legacy `datamachine_tool_sources` filters are not mirrored.
+
+## Modes
+
+Tool definitions declare the request modes that may see them:
+
+| Mode | Constant | Use |
+|---|---|---|
+| `pipeline` | `ToolPolicyResolver::MODE_PIPELINE` | Automated AI pipeline steps. Includes adjacent handler tools plus static registry tools explicitly marked for pipeline. |
+| `chat` | `ToolPolicyResolver::MODE_CHAT` | User-present chat sessions. Runs the chat access gate and ability permission checks. |
+| `system` | `ToolPolicyResolver::MODE_SYSTEM` | Background/system jobs with a small explicit tool set. |
+| `pipeline_policy` | `ToolPolicyResolver::MODE_PIPELINE_POLICY` | Opt-in marker for tools hidden from pipeline by default but grantable through pipeline tool policy. |
+
+`pipeline_policy` does not expose a tool by itself. A pipeline request must also include the tool in `allow_only`, usually from `enabled_tools` in the flow-step snapshot.
+
+## Availability Checks
+
+`ToolManager::is_tool_available( $tool_id, $context_id )` combines global enablement and configuration state. It is a source-level gate, not the full policy resolver.
+
+```php
+$manager = new ToolManager();
+
+if ( $manager->is_tool_available( 'google_search' ) ) {
+    // The static registry source may include it, subject to mode and policy.
 }
 ```
 
-## Migration from Legacy Patterns
-
-### Before (Distributed Logic)
+`requires_config => true` tools must pass `datamachine_tool_configured`:
 
 ```php
-// Old pattern: scattered tool validation
-$enabled_tools = get_option('datamachine_enabled_tools', []);
-$is_enabled = in_array('google_search', $enabled_tools);
+add_filter( 'datamachine_tool_configured', function ( bool $configured, string $tool_id ): bool {
+    if ( 'my_plugin/search' !== $tool_id ) {
+        return $configured;
+    }
 
-$google_config = get_option('datamachine_google_search_config', []);
-$is_configured = !empty($google_config['api_key']);
-
-// Validation logic duplicated across multiple files
+    $settings = get_option( 'my_plugin_settings', array() );
+    return ! empty( $settings['api_key'] );
+}, 10, 2 );
 ```
 
-### After (Centralized ToolManager)
+Tools without `requires_config` still pass through the global enablement check. The old public enablement filter is not part of the current runtime path.
 
-```php
-// New pattern: centralized validation
-$tool_manager = new ToolManager();
-$is_enabled = $tool_manager->is_globally_enabled('google_search');
-$is_configured = $tool_manager->is_tool_configured('google_search');
+## Pipeline Tool Policy Inputs
 
-// Single source of truth, consistent behavior
-```
+Pipeline AI steps build resolver policy args from the workflow snapshot through `PipelineToolPolicyArgs::fromConfigs()`:
 
-## Benefits
+| Config key | Resolver arg | Effect |
+|---|---|---|
+| `enabled_tools` on the flow step | `allow_only` | Narrows optional/static tools to the listed names and grants matching `pipeline_policy` tools. |
+| `disabled_tools` on the pipeline step | `deny` | Removes listed tools. |
+| `disabled_tools` on the flow step | `deny` | Removes listed tools. |
 
-### Code Reduction
+The snapshot is authoritative. Runtime pipeline resolution does not re-read persisted pipeline rows because direct workflows can have synthetic IDs and historical jobs must use the policy captured when they ran.
 
-- Eliminates ~60% of tool validation code throughout codebase
-- Centralizes tool discovery logic from multiple components
-- Reduces maintenance burden for tool-related operations
+Adjacent handler tools are mandatory flow plumbing. They are preserved through allow/category policy unless explicitly denied by the high-precedence deny list.
 
-### Consistency
+## Related Docs
 
-- Ensures uniform tool validation across all components
-- Prevents inconsistent enablement checking
-- Standardizes configuration validation patterns
-
-### Performance
-
-- Implements caching for tool discovery
-- Reduces redundant filter calls
-- Optimizes database queries for tool data
-
-### Maintainability
-
-- Single location for tool management logic
-- Easy to add new validation requirements
-- Simplified debugging of tool availability issues
-
-### Extensibility
-
-- Filter-based architecture for custom tools
-- Clear integration points for extensions
-- Supports future tool types and validation patterns
-
-## See Also
-
-- Universal Engine - Engine architecture overview
-- Tool Execution Architecture - Tool execution patterns
-- AI Tools Overview - Available tools catalog
-- Core Filters - Filter reference
+- [Tool Execution Architecture](tool-execution.md)
+- [Policy Resolvers](../architecture/policy-resolvers.md)
+- [Engine Filters](../development/hooks/engine-filters.md)
+- [Core Filters](../development/hooks/core-filters.md)

--- a/docs/core-system/tool-result-finder.md
+++ b/docs/core-system/tool-result-finder.md
@@ -329,7 +329,7 @@ $result = ToolResultFinder::findHandlerResult($data, 'twitter', $type = 'tool_re
 ## Related Components
 
 - Universal Engine Architecture - Overall engine structure
-- Tool Execution Architecture - Tool execution and result creation
+- [Tool Execution Architecture](tool-execution.md) - Tool execution and result creation
 - WordPress Update Handler - Primary ToolResultFinder user
 - Data Flow Architecture - Data packet structure and flow
 

--- a/docs/core-system/universal-engine.md
+++ b/docs/core-system/universal-engine.md
@@ -140,7 +140,7 @@ $ui_data = $tool_manager->getToolsForUI();
 - **Maintainability**: Single location for tool management logic
 - **Extensibility**: Filter-based architecture for custom tools
 
-See Tool Manager for complete documentation.
+See [Tool Manager](tool-manager.md) for the current registry/source/policy split.
 
 ### BaseTool (@since v0.14.10)
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -248,9 +248,7 @@ See Handler Registration Trait for complete documentation.
 
 ### `datamachine_tools`
 
-**Purpose**: Unified registry for every AI tool — static global tools AND per-handler
-runtime-generated tools. Consumed by `ToolPolicyResolver` when gathering the
-available tool set for a pipeline or chat context.
+**Purpose**: Unified Data Machine registry for AI tools — static registry tools and per-handler runtime-generated tools. Adapted by `DataMachineToolRegistrySource` and consumed through `ToolPolicyResolver::resolve()`.
 
 **Parameters**:
 
@@ -258,7 +256,7 @@ available tool set for a pipeline or chat context.
 
 **Return**: Modified tools array
 
-#### Static tool entry (global tools)
+#### Static tool entry
 
 ```php
 add_filter('datamachine_tools', function($tools) {
@@ -1428,9 +1426,7 @@ Builds parameters for handler-specific tools with engine data merging (source_ur
 
 #### `ToolPolicyResolver::resolve()`
 
-Tool discovery moved from `ToolExecutor::getAvailableTools()` (removed in 0.79)
-to `ToolPolicyResolver::resolve()`. Single entry point for chat and pipeline
-modes.
+Tool discovery uses `ToolPolicyResolver::resolve()`. This is the single entry point for chat, pipeline, system, and custom modes.
 
 ```php
 $resolver = new \DataMachine\Engine\AI\Tools\ToolPolicyResolver();
@@ -1446,10 +1442,11 @@ $tools = $resolver->resolve( array(
 
 **Discovery Process**:
 
-1. Handler Tools - Retrieved via `datamachine_tools` filter (runtime-resolved `_handler_callable` entries)
-2. Global Tools - Retrieved via `datamachine_global_tools` filter
-3. Chat Tools - Retrieved via `datamachine_chat_tools` filter (chat only)
-4. Enablement Check - Each tool filtered through `datamachine_tool_enabled`
+1. Source composition - `ToolSourceRegistry` gathers `adjacent_handlers` and/or `static_registry` for the mode.
+2. Static registry - `DataMachineToolRegistrySource` adapts `datamachine_tools`, filters by `modes`, and checks source-level availability/configuration.
+3. Adjacent handlers - `AdjacentHandlerToolSource` resolves `_handler_callable` entries from previous/next pipeline steps.
+4. Policy resolution - Agents API tool policy applies deny, allow-only, category, mode, mandatory-tool, and chat access rules.
+5. Final filter - `datamachine_resolved_tools` can adjust the resolved set.
 
 ### AIConversationLoop (`/inc/Engine/AI/AIConversationLoop.php`)
 

--- a/docs/development/hooks/engine-filters.md
+++ b/docs/development/hooks/engine-filters.md
@@ -81,7 +81,7 @@ Tools are registered via a single unified filter. Per-mode tool partitioning is 
 
 ### datamachine_tools
 
-Single registry for all AI tools. Used by `ToolManager::getRawToolsForMode()` to assemble the available tool set for a given execution mode.
+Single Data Machine registry for AI tools. `ToolManager` reads this registry, `ToolSourceRegistry` composes source pools, and `ToolPolicyResolver::resolve()` assembles the final request-visible tool set for a mode.
 
 **Hook usage**:
 
@@ -107,7 +107,8 @@ $tools = apply_filters( 'datamachine_tools', array() );
     ],
     'modes'            => ['chat'],             // which modes can see this tool
     'requires_config'  => true,                 // checked via datamachine_tool_configured
-    'category'         => 'search',             // optional grouping
+    'ability'          => 'my-plugin/search',   // optional Ability link for permissions/categories
+    'access_level'     => 'admin',              // fallback when no ability is linked
 ]
 ```
 
@@ -133,9 +134,9 @@ add_filter( 'datamachine_tools', function ( $tools ) {
 } );
 ```
 
-Use `pipeline` mode only when a static/global tool is useful inside an automated pipeline AI step. Chat affordances and tools that duplicate engine-level validation should stay `chat`-only; pipeline AI steps already receive step-scoped handler tools plus pipeline/flow memory directives.
+Use `pipeline` mode only when a static registry tool is useful inside an automated pipeline AI step. Use `pipeline_policy` for powerful tools that should stay hidden from pipeline by default but can be explicitly granted through `enabled_tools`. Chat affordances and tools that duplicate engine-level validation should stay `chat`-only; pipeline AI steps already receive adjacent handler tools plus pipeline/flow memory directives.
 
-> The legacy `datamachine_global_tools` and `datamachine_chat_tools` filters were consolidated into `datamachine_tools` in v0.68.0 (PR #1130). The old per-mode filters no longer exist.
+> Earlier per-mode tool filters were consolidated into `datamachine_tools` in v0.68.0 (PR #1130). Register current tools through the unified registry and declare `modes` on the tool definition.
 
 ### datamachine_tool_configured
 
@@ -166,7 +167,7 @@ add_filter( 'datamachine_tool_configured', function ( $configured, $tool_id ) {
 }, 10, 2 );
 ```
 
-> Tool *availability* (whether the AI sees the tool in this request) is now resolved by `ToolManager::is_tool_available()`, not by a public filter. The `datamachine_tool_enabled` filter from earlier versions has been removed in favour of `ToolManager`'s direct logic, which combines configuration state, mode membership, and per-step `enabled_tools` settings.
+> Tool *visibility* (whether the AI sees the tool in this request) is resolved by `ToolPolicyResolver::resolve()`. `ToolManager::is_tool_available()` is a source-level check for global enablement and configuration. The earlier public enablement filter is not part of the current runtime path.
 
 ## Handler Registration
 
@@ -203,6 +204,6 @@ Handlers (fetch / publish / upsert) are registered via the `HandlerRegistrationT
 ## Related Documentation
 
 - [AI Directives System](../../core-system/ai-directives.md) — Built-in directive list, priorities, modes
-- [Tool Manager](../../core-system/tool-manager.md) — Tool availability resolution
-- [Tool Execution](../../core-system/tool-execution.md) — Tool dispatch and result handling
+- [Tool Manager](../../core-system/tool-manager.md) — Data Machine registry, source-level availability, and handler tool expansion
+- [Tool Execution](../../core-system/tool-execution.md) — Tool dispatch, action policy, and approval staging
 - [Core Filters](core-filters.md) — Handler registration filters and OAuth service discovery

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -142,10 +142,10 @@ wp datamachine jobs undo <job_id> --dry-run --allow-root
 
 ## AI Integration
 
-- **Tool-first architecture** enables AI agents (pipeline and chat) to call tools that interact with handlers, external APIs, or workflow metadata.
+- **Tool-first architecture** enables AI agents (pipeline, chat, and system) to call tools resolved through `ToolPolicyResolver`, `ToolSourceRegistry`, and the Data Machine `datamachine_tools` registry.
 - **PromptBuilder + RequestBuilder** apply layered directives via the `datamachine_directives` filter so every request includes identity, context, and site-specific instructions.
-- **Global tools** (Google Search, Local Search, Web Fetch, WordPress Post Reader) are registered under `/inc/Engine/AI/Tools/` and available to all agents.
-- **Chat-specific tools** (AddPipelineStep, ApiQuery, AuthenticateHandler, ConfigureFlowSteps, ConfigurePipelineStep, CopyFlow, CreateFlow, CreatePipeline, CreateTaxonomyTerm, ExecuteWorkflowTool, GetHandlerDefaults, ManageLogs, ReadLogs, RunFlow, SearchTaxonomyTerms, SetHandlerDefaults, UpdateFlow) orchestrate pipeline and flow management within conversations.
+- **Static registry tools** include research, site operations, memory, and workflow-management tools whose `modes` decide whether they appear in chat, pipeline, or system requests.
+- **Adjacent handler tools** are generated from previous/next pipeline steps so AI steps can publish, upsert, or skip items using the neighboring handler configuration.
 - **WP_Agent_Tool_Parameters + ToolResultFinder** gather parameter metadata for tools and interpret results inside data packets to keep conversations consistent.
 
 ## Authentication & Security
@@ -180,6 +180,6 @@ wp datamachine jobs undo <job_id> --dry-run --allow-root
 - **Multi-platform publishing** via core fetch/publish/upsert handlers for files, RSS, email, and WordPress, plus extension-provided handlers for social, business, and event destinations.
 - **Daily memory system** for automatic temporal knowledge management with AI-driven pruning.
 - **System tasks** for background AI operations (image generation, alt text, internal linking, meta descriptions) with undo support.
-- **Extension points** through filters such as `datamachine_handlers`, `datamachine_tools`, `datamachine_step_types`, `datamachine_auth_providers`, and `datamachine_engine_data`.
+- **Extension points** through filters such as `datamachine_handlers`, `datamachine_tools`, `agents_api_tool_sources`, `datamachine_step_types`, `datamachine_auth_providers`, and `datamachine_engine_data`.
 - **Directive orchestration** ensures every AI request is context-aware, tool-enabled, and consistent with site policies.
 - **Chartable logging, deduplication, and error handling** keep operators informed about job outcomes and prevent duplicate processing.


### PR DESCRIPTION
## Summary
- Updates tool manager, tool execution, and policy resolver docs for the current tool runtime.
- Documents policy-gated tools, source resolution, pending actions, ability-backed tools, and directive policy behavior.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing tool/runtime docs against implementation, drafting updated explanations, and preparing the PR text for Chris to review.