### PR TITLE
docs: correct REST endpoint references

### DIFF
--- a/docs/api/endpoints/auth.md
+++ b/docs/api/endpoints/auth.md
@@ -4,549 +4,79 @@
 
 **Base URL**: `/wp-json/datamachine/v1/auth`
 
-## Overview
-
-Auth endpoints manage OAuth accounts and handler authentication for external services.
+Auth endpoints manage handler authentication and provider metadata. They are separate from WordPress REST authentication, which is documented in [Authentication](authentication.md).
 
 ## Authentication
 
-Requires `manage_options` capability. See Authentication Guide.
+Requires the Data Machine `manage_settings` permission (`PermissionHelper::can( 'manage_settings' )`).
 
-## Handler Auth Requirements (@since v0.3.1)
+## Response Envelope
 
-Handlers can declare whether they require authentication via the `requires_auth` flag. When a handler's `requires_auth` is `false`, the Auth API bypasses authentication validation for that handler, allowing handlers like public scrapers to operate without OAuth configuration.
-
-**Auth Bypass Behavior**:
-- GET `/auth/{handler_slug}/status` - Returns success with `requires_auth: false` without checking OAuth state
-- PUT `/auth/{handler_slug}` - Returns success without requiring credentials
-- DELETE `/auth/{handler_slug}` - Returns success without disconnection operations
-
-## Provider Key Resolution
-
-Auth endpoints accept `{handler_slug}` in the URL, but internally they resolve the auth provider via the handler's `auth_provider_key` (from the Handlers registry). This supports shared authentication across multiple handlers (for example, one set of Meta credentials used by multiple publish destinations).
-
-## Endpoints
-
-### GET /auth/{handler_slug}/status
-
-Check OAuth authentication status for a handler.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `handler_slug` (string, required): Handler identifier (e.g., `reddit`, `google_sheets`)
-
-**Returns**: Authentication status, account details, and OAuth error/success states
-
-**Example Request**:
-
-```bash
-curl https://example.com/wp-json/datamachine/v1/auth/reddit/status \
--u username:application_password
-```
-
-**Success Response - Authenticated (200 OK)**:
+Successful auth routes return either:
 
 ```json
 {
   "success": true,
-  "data": {
-    "authenticated": true,
-    "account_details": {
-      "username": "exampleuser",
-      "id": "1234567890"
-    },
-    "config_status": {
-      "api_key": "••••••••",
-      "api_secret": "••••••••"
-    },
-    "handler_slug": "reddit"
-  }
+  "data": {}
 }
 ```
 
-**Success Response - Not Authenticated (200 OK)**:
+or the successful ability result directly when the ability already includes `success` and related fields.
+
+Failures are `WP_Error` responses. Common statuses are 400 for invalid input, 404 for missing providers/handlers, 409 for not-authenticated refresh/disconnect states, and 500 for internal failures.
+
+## Routes
+
+### GET `/wp-json/datamachine/v1/auth/providers`
+
+List registered auth providers.
+
+**Success shape**:
 
 ```json
 {
   "success": true,
-  "data": {
-    "authenticated": false,
-    "error": false,
-    "config_status": {
-      "api_key": "",
-      "api_secret": ""
-    },
-    "handler_slug": "reddit"
-  }
+  "data": []
 }
 ```
 
-**Success Response - OAuth Error (200 OK)**:
-
-```json
-{
-  "success": true,
-  "data": {
-    "authenticated": false,
-    "error": true,
-    "error_code": "oauth_failed",
-    "error_message": "User denied authorization",
-    "config_status": {
-      "api_key": "",
-      "api_secret": ""
-    },
-    "handler_slug": "reddit"
-  }
-}
-```
-
-**Error Response (404 Not Found)**:
-
-```json
-{
-  "code": "auth_provider_not_found",
-  "message": "Authentication provider not found",
-  "data": {"status": 404}
-}
-```
-
-### PUT /auth/{handler_slug}
-
-Save authentication configuration for a handler.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `handler_slug` (string, required): Handler identifier (in URL path)
-- Additional parameters vary by handler (e.g., `api_key`, `api_secret`, `client_id`, `client_secret`)
-
-**Storage Behavior**:
-- **OAuth providers** (Reddit, Google Sheets): Stored to `oauth_keys`
-- **Simple auth providers**: Stored to `oauth_account`
-
-**Example Requests**:
-
-```bash
-# Save Reddit OAuth keys
-curl -X PUT https://example.com/wp-json/datamachine/v1/auth/reddit \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "client_id": "your_client_id",
-    "client_secret": "your_client_secret"
-  }'
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "message": "Configuration saved successfully"
-}
-```
-
-**Success Response - No Changes (200 OK)**:
-
-```json
-{
-  "success": true,
-  "message": "Configuration is already up to date - no changes detected"
-}
-```
+### GET `/wp-json/datamachine/v1/auth/{handler_slug}/status`
 
-**Error Response (400 Bad Request)**:
+Check auth status for a handler slug. The handler slug is resolved through `AuthAbilities`, including handlers that share an auth provider key.
 
-```json
-{
-  "code": "required_field_missing",
-  "message": "API Key is required",
-  "data": {"status": 400}
-}
-```
+**Response data may include**:
 
-### DELETE /auth/{handler_slug}
+- `handler_slug`
+- `authenticated`
+- `requires_auth`
+- `message`
+- `oauth_url`
+- `instructions`
 
-Disconnect an authenticated account.
+Handlers with `requires_auth: false` return success without OAuth state.
 
-**Permission**: `manage_options` capability required
+### PUT `/wp-json/datamachine/v1/auth/{handler_slug}`
 
-**Parameters**:
-- `handler_slug` (string, required): Handler identifier (in URL path)
+Save auth configuration for a handler.
 
-**Example Request**:
+**Body**: provider-specific config fields. All request params except `handler_slug` are passed as `config` to `AuthAbilities::executeSaveAuthConfig()`.
 
-```bash
-curl -X DELETE https://example.com/wp-json/datamachine/v1/auth/twitter \
-  -u username:application_password
-```
+### DELETE `/wp-json/datamachine/v1/auth/{handler_slug}`
 
-**Success Response (200 OK)**:
+Disconnect a handler account.
 
-```json
-{
-  "success": true,
-  "message": "Twitter account disconnected successfully"
-}
-```
+### PUT `/wp-json/datamachine/v1/auth/{handler_slug}/token`
 
-**Error Response (500 Internal Server Error)**:
+Set account/token data manually.
 
-```json
-{
-  "code": "disconnect_failed",
-  "message": "Failed to disconnect account",
-  "data": {"status": 500}
-}
-```
+**Body**: JSON object passed as `account_data` to `AuthAbilities::executeSetAuthToken()`.
 
-## Authentication Methods
+### POST `/wp-json/datamachine/v1/auth/{handler_slug}/refresh`
 
-### OAuth 1.0a
+Force a token refresh for a handler.
 
-Used by Twitter.
+## Notes for Agents
 
-**Configuration Requirements**:
-- `consumer_key` - Application consumer key
-- `consumer_secret` - Application consumer secret
-
-**OAuth Flow**:
-1. Save consumer key/secret via PUT endpoint
-2. User initiates OAuth via `/datamachine-auth/twitter/` URL
-3. Popup window handles OAuth callback
-4. Access tokens stored automatically
-5. Check status via GET endpoint
-
-### OAuth 2.0
-
-Used by Reddit, Facebook, Threads, Google Sheets.
-
-**Configuration Requirements**:
-- `client_id` - OAuth application client ID
-- `client_secret` - OAuth application client secret
-
-**OAuth Flow**:
-1. Save client ID/secret via PUT endpoint
-2. User initiates OAuth via `/datamachine-auth/{handler}/` URL
-3. Popup window handles OAuth callback
-4. Access tokens stored automatically
-5. Check status via GET endpoint
-
-### App Password
-
-Used by Bluesky.
-
-**Configuration Requirements**:
-- `username` - Bluesky username (e.g., `user.bsky.social`)
-- `app_password` - Bluesky app password
-
-**Authentication Flow**:
-1. Save credentials via PUT endpoint
-2. Credentials used directly (no OAuth flow)
-3. Check status via GET endpoint
-
-## Supported Handlers
-
-### Twitter
-
-**Handler Slug**: `twitter`
-
-**Auth Type**: OAuth 1.0a
-
-**Configuration**:
-```json
-{
-  "consumer_key": "your_consumer_key",
-  "consumer_secret": "your_consumer_secret"
-}
-```
-
-**OAuth URL**: `/datamachine-auth/twitter/`
-
-### Reddit
-
-**Handler Slug**: `reddit`
-
-**Auth Type**: OAuth 2.0
-
-**Configuration**:
-```json
-{
-  "client_id": "your_client_id",
-  "client_secret": "your_client_secret"
-}
-```
-
-**OAuth URL**: `/datamachine-auth/reddit/`
-
-### Facebook
-
-**Handler Slug**: `facebook`
-
-**Auth Type**: OAuth 2.0
-
-**Configuration**:
-```json
-{
-  "app_id": "your_app_id",
-  "app_secret": "your_app_secret"
-}
-```
-
-**OAuth URL**: `/datamachine-auth/facebook/`
-
-### Threads
-
-**Handler Slug**: `threads`
-
-**Auth Type**: OAuth 2.0 (uses Facebook credentials)
-
-**Configuration**:
-```json
-{
-  "app_id": "your_app_id",
-  "app_secret": "your_app_secret"
-}
-```
-
-**OAuth URL**: `/datamachine-auth/threads/`
-
-### Google Sheets
-
-**Handler Slug**: `google-sheets`
-
-**Auth Type**: OAuth 2.0
-
-**Configuration**:
-```json
-{
-  "client_id": "your_client_id",
-  "client_secret": "your_client_secret"
-}
-```
-
-**OAuth URL**: `/datamachine-auth/google-sheets/`
-
-### Bluesky
-
-**Handler Slug**: `bluesky`
-
-**Auth Type**: App Password
-
-**Configuration**:
-```json
-{
-  "username": "user.bsky.social",
-  "app_password": "your_app_password"
-}
-```
-
-**No OAuth Flow**: Credentials used directly
-
-## Integration Examples
-
-### Python Authentication Management
-
-```python
-import requests
-from requests.auth import HTTPBasicAuth
-
-base_url = "https://example.com/wp-json/datamachine/v1/auth"
-auth = HTTPBasicAuth("username", "application_password")
-
-# Check authentication status
-def check_auth_status(handler):
-    url = f"{base_url}/{handler}/status"
-    response = requests.get(url, auth=auth)
-    return response.json()
-
-# Save configuration
-def save_auth_config(handler, config):
-    url = f"{base_url}/{handler}"
-    response = requests.put(url, json=config, auth=auth)
-    return response.json()
-
-# Disconnect account
-def disconnect_account(handler):
-    url = f"{base_url}/{handler}"
-    response = requests.delete(url, auth=auth)
-    return response.json()
-
-# Usage
-status = check_auth_status('twitter')
-print(f"Twitter authenticated: {status['authenticated']}")
-
-# Save Twitter config
-config = {
-    "consumer_key": "your_key",
-    "consumer_secret": "your_secret"
-}
-result = save_auth_config('twitter', config)
-print(f"Config saved: {result['success']}")
-```
-
-### JavaScript OAuth Management
-
-```javascript
-const axios = require('axios');
-
-class AuthManager {
-  constructor(baseURL, auth) {
-    this.baseURL = `${baseURL}/auth`;
-    this.auth = auth;
-  }
-
-  async checkStatus(handler) {
-    const response = await axios.get(
-      `${this.baseURL}/${handler}/status`,
-      { auth: this.auth }
-    );
-    return response.data;
-  }
-
-  async saveConfig(handler, config) {
-    const response = await axios.put(
-      `${this.baseURL}/${handler}`,
-      config,
-      { auth: this.auth }
-    );
-    return response.data;
-  }
-
-  async disconnect(handler) {
-    const response = await axios.delete(
-      `${this.baseURL}/${handler}`,
-      { auth: this.auth }
-    );
-    return response.data;
-  }
-}
-
-// Usage
-const authManager = new AuthManager(
-  'https://example.com/wp-json/datamachine/v1',
-  { username: 'admin', password: 'application_password' }
-);
-
-const status = await authManager.checkStatus('twitter');
-console.log(`Authenticated: ${status.authenticated}`);
-
-if (status.authenticated) {
-  console.log(`Account: @${status.account_details.username}`);
-}
-```
-
-## Common Workflows
-
-### Setup Twitter Authentication
-
-```bash
-# 1. Save API keys
-curl -X PUT https://example.com/wp-json/datamachine/v1/auth/twitter \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "consumer_key": "your_consumer_key",
-    "consumer_secret": "your_consumer_secret"
-  }'
-
-# 2. User completes OAuth at /datamachine-auth/twitter/
-
-# 3. Check authentication status
-curl https://example.com/wp-json/datamachine/v1/auth/twitter/status \
-  -u username:application_password
-```
-
-### Disconnect and Reconnect
-
-```bash
-# Disconnect account
-curl -X DELETE https://example.com/wp-json/datamachine/v1/auth/twitter \
-  -u username:application_password
-
-# Reconnect via OAuth flow
-# User visits /datamachine-auth/twitter/
-```
-
-### Verify All Handler Authentication
-
-```bash
-# Check multiple handlers
-for handler in twitter facebook reddit bluesky; do
-  echo "Checking $handler..."
-  curl -s https://example.com/wp-json/datamachine/v1/auth/$handler/status \
-    -u username:application_password | jq '.authenticated'
-done
-```
-
-## Related Documentation
-
-- Handlers Endpoint - Handler information
-- Settings Endpoints - Configuration management
-- Authentication - API auth methods
-- Errors - Error handling
-
----
-
-**Base URL**: `/wp-json/datamachine/v1/auth`
-**Permission**: `manage_options` capability required
-**Implementation**: `inc/Api/Auth.php`
-**OAuth URLs**: `/datamachine-auth/{handler}/`
-
-## Additional Endpoints
-
-### GET /auth/{handler_slug}
-
-Get authentication details for a handler. Similar to /status but returns full configuration.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `handler_slug` (string, required): Handler identifier
-
-**Response**:
-```json
-{
-  "success": true,
-  "data": {
-    "handler_slug": "reddit",
-    "authenticated": true,
-    "account_details": {...},
-    "config_status": {...}
-  }
-}
-```
-
-### PUT /auth/{handler_slug}
-
-Update authentication credentials for a handler.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `handler_slug` (string, required): Handler identifier
-- `credentials` (object, required): Handler-specific credentials
-
-**Example**:
-```bash
-curl -X PUT https://example.com/wp-json/datamachine/v1/auth/reddit \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"credentials": {"client_id": "...", "client_secret": "..."}}'
-```
-
-### DELETE /auth/{handler_slug}
-
-Remove authentication for a handler (disconnect OAuth).
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `handler_slug` (string, required): Handler identifier
-
-**Example**:
-```bash
-curl -X DELETE https://example.com/wp-json/datamachine/v1/auth/reddit \
-  -u username:application_password
-```
+- There is no `/auth/{handler_slug}/callback` REST route in `inc/Api/Auth.php`.
+- Browser OAuth initiation/callback URLs are outside this REST controller, for example `/datamachine-auth/{handler}/`.
+- Do not document static provider field sets here; provider config comes from the registered auth provider/handler metadata.

--- a/docs/api/endpoints/authentication.md
+++ b/docs/api/endpoints/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-Data Machine REST API supports two authentication methods for secure access.
+Data Machine REST API requests use normal WordPress REST authentication. The separate [Auth Endpoints](auth.md) page documents handler/provider credentials such as OAuth tokens.
 
 ## Authentication Methods
 
@@ -68,12 +68,14 @@ fetch('/wp-json/datamachine/v1/pipelines', {
 
 ## Permission Model
 
-### manage_options Capability
+### Data Machine Permissions
 
-Most endpoints require `manage_options` capability (Administrator/Editor roles):
-- Execute, Pipelines, Flows, Jobs, Files
-- Settings, Logs, Processed Items
-- Handlers, Providers, Tools, Auth
+Endpoints check Data Machine permissions through `PermissionHelper`, not a single hardcoded WordPress capability:
+
+- `manage_flows`: pipelines, flows, jobs, execution-related administration.
+- `manage_settings`: settings and handler auth management.
+- `chat`: chat message/session routes.
+- Public read routes exist for discovery-style surfaces such as providers, tools, and step types.
 
 ### Authenticated Users
 
@@ -112,7 +114,7 @@ curl -u username:app_password \
 ```
 
 **Solutions**:
-- Verify user has `manage_options` capability
+- Verify the user or scoped agent has the endpoint's Data Machine permission
 - Check application password is correct
 - Ensure WordPress user is active
 - Confirm HTTPS is being used
@@ -126,6 +128,6 @@ curl -u username:app_password \
 
 ---
 
-**Security Model**: `manage_options` capability required for admin endpoints
+**Security Model**: Endpoint-specific Data Machine permissions via `PermissionHelper`
 **Supported Methods**: Application Password, Cookie Authentication
 **WordPress Version**: 5.6+ (Application Passwords)

--- a/docs/api/endpoints/chat-sessions.md
+++ b/docs/api/endpoints/chat-sessions.md
@@ -2,74 +2,54 @@
 
 **Implementation**: `inc/Api/Chat/Chat.php`
 
-## Overview
-
-Data Machine persists chat conversations as sessions. Sessions are user-scoped and stored in `wp_datamachine_chat_sessions`.
+Data Machine stores chat conversations as user-scoped sessions in `wp_datamachine_chat_sessions`.
 
 ## Authentication
 
-Requires WordPress authentication with `manage_options` capability.
+Requires the Data Machine `chat` permission (`PermissionHelper::can( 'chat' )`).
 
-## Endpoints
+## Response Envelope
+
+Session routes return:
+
+```json
+{
+  "success": true,
+  "data": {}
+}
+```
+
+The `data` shape is the corresponding Chat Session ability result.
+
+## Routes
 
 ### GET `/wp-json/datamachine/v1/chat/sessions`
 
-List chat sessions for the current user.
+List sessions for the current user and scoped agent.
 
-**Query Parameters**:
-- `limit` (integer, optional, default: `20`): Maximum sessions to return (capped at 100)
-- `offset` (integer, optional, default: `0`): Pagination offset
-- `agent_type` (string, optional, default: `chat`): Deprecated. Use `agent_id` to filter by specific agent.
+**Query parameters**:
 
-**Success Response**:
+- `limit` (integer, optional, default `20`): maximum sessions to return.
+- `offset` (integer, optional, default `0`): pagination offset.
+- `mode` (string, optional): `chat`, `pipeline`, or `system`.
+- `agent_id` (integer, optional): filter sessions by agent.
 
-```json
-{
-  "success": true,
-  "data": {
-    "sessions": [],
-    "total": 0,
-    "limit": 20,
-    "offset": 0,
-    "agent_type": "chat"
-  }
-}
-```
+`agent_type` is not a REST parameter for this route.
 
 ### GET `/wp-json/datamachine/v1/chat/{session_id}`
 
-Retrieve a single session by ID.
-
-**Success Response**:
-
-```json
-{
-  "success": true,
-  "data": {
-    "session_id": "<uuid>",
-    "conversation": [],
-    "metadata": {}
-  }
-}
-```
+Retrieve one session by UUID-like session ID (`[a-f0-9-]+`).
 
 ### DELETE `/wp-json/datamachine/v1/chat/{session_id}`
 
-Delete a session by ID.
+Delete one session by UUID-like session ID.
 
-**Success Response**:
+### POST `/wp-json/datamachine/v1/chat/sessions/{session_id}/read`
 
-```json
-{
-  "success": true,
-  "data": {
-    "session_id": "<uuid>",
-    "deleted": true
-  }
-}
-```
+Mark a session read for the current user.
 
-**Errors**:
-- `session_not_found` (404): Session does not exist
-- `session_access_denied` (403): Session exists but belongs to a different user
-- `session_delete_failed` (500): Database deletion failed
+## Errors
+
+- `session_not_found` (404): session does not exist.
+- `session_access_denied` (403): session belongs to another user.
+- `ability_not_found` (500): session ability is not registered.

--- a/docs/api/endpoints/chat.md
+++ b/docs/api/endpoints/chat.md
@@ -4,614 +4,81 @@
 
 **Base URL**: `/wp-json/datamachine/v1/chat`
 
-## Overview
-
-The Chat endpoint provides a conversational AI interface for building and executing Data Machine workflows through natural language interaction with multi-turn conversation support.
-
-In addition to sending messages, it also supports listing, retrieving, and deleting persisted chat sessions.
+The chat API sends messages to the Data Machine chat agent and manages turn-by-turn continuation. Session CRUD is documented in [Chat Sessions](chat-sessions.md).
 
 ## Authentication
 
-Requires `manage_options` capability. See Authentication Guide.
+`POST /chat` and `POST /chat/continue` require the Data Machine `chat` permission (`PermissionHelper::can( 'chat' )`). `POST /chat/ping` uses a bearer token that must match the `chat_ping_secret` setting.
 
-## Endpoints
+## Response Envelope
 
-### POST /chat
-
-Send a message to the AI assistant.
-
-**Permission**: `manage_options` capability required
-
-**Purpose**: Natural language workflow building and Data Machine administration via conversational AI
-
-**Parameters**:
-- `message` (string, required): User message to send to AI
-- `session_id` (string, optional): Session ID for conversation continuity (omit to create new session)
-- `selected_pipeline_id` (int, optional): Active pipeline context for prioritized information awareness (@since v0.8.0)
-- `provider` (string, optional): AI provider (`openai`, `anthropic`, `google`, `grok`, `openrouter`) - uses default from settings if not provided
-- `model` (string, optional): Model identifier (e.g., `gpt-4`, `claude-sonnet-4`) - uses default from settings if not provided
-
-**Example Requests**:
-
-```bash
-# Start new conversation
-curl -X POST https://example.com/wp-json/datamachine/v1/chat \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "message": "Create a pipeline that fetches from RSS and publishes to Twitter",
-    "provider": "anthropic",
-    "model": "claude-sonnet-4"
-  }'
-
-# Continue existing conversation
-curl -X POST https://example.com/wp-json/datamachine/v1/chat \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "message": "Now add a flow for that pipeline",
-    "session_id": "session_abc123",
-    "provider": "anthropic",
-    "model": "claude-sonnet-4"
-  }'
-```
-
-**Success Response (200 OK)**:
+Chat routes return a REST envelope:
 
 ```json
 {
   "success": true,
-  "session_id": "session_abc123",
-  "response": "I'll help you create a pipeline with RSS fetch and Twitter publish steps...",
-  "tool_calls": [
-    {
-      "id": "call_abc123",
-      "type": "function",
-      "function": {
-        "name": "create_pipeline",
-        "arguments": "{\"name\":\"RSS to Twitter\",\"steps\":[{\"type\":\"fetch\",\"handler\":\"rss\"},{\"type\":\"ai\"},{\"type\":\"publish\",\"handler\":\"twitter\"}]}"
-      }
-    }
-  ],
-  "conversation": [
-    {"role": "user", "content": "Create a pipeline..."},
-    {"role": "assistant", "content": "I'll help you...", "tool_calls": [...]}
-  ],
-  "metadata": {
-    "last_activity": "2024-01-02 14:30:00",
-    "message_count": 2
-  }
+  "data": {}
 }
 ```
 
-**Response Fields**:
-- `success` (boolean): Request success status
-- `session_id` (string): Session identifier for conversation continuity
-- `response` (string): AI assistant response message
-- `tool_calls` (array, optional): Array of tool calls made by AI
-- `conversation` (array): Full conversation history
-- `metadata` (object): Session metadata
-  - `last_activity` (string): Last activity timestamp
-  - `message_count` (integer): Number of messages in conversation
+`data` is the send-message, continue, or ping result. The top-level response does not expose `session_id`, `response`, or `conversation`; read those from `data` when the underlying ability returns them.
 
-## Session Management
+## Routes
 
-### Session Creation
+### POST `/wp-json/datamachine/v1/chat`
 
-First message automatically creates a new session:
+Send a message. The first message creates a session; include `session_id` to continue a persisted session.
+
+**Body parameters**:
+
+- `message` (string, required): user message.
+- `session_id` (string, optional): existing session ID.
+- `provider` (string, optional): registered AI provider; defaults to resolved settings.
+- `model` (string, optional): model identifier; defaults to resolved settings.
+- `selected_pipeline_id` (integer, optional): pipeline context for chat directives.
+- `attachments` (array, optional): media attachments, each with `url`, `media_id`, `mime_type`, and/or `filename`.
+- `client_context` (object, optional): arbitrary client context injected as a system message.
+
+**Headers**:
+
+- `X-Request-Id` (string, optional): enables a 60-second idempotency cache for duplicate requests.
 
 ```bash
 curl -X POST https://example.com/wp-json/datamachine/v1/chat \
   -H "Content-Type: application/json" \
   -u username:application_password \
-  -d '{"message": "Hello"}'
+  -d '{"message":"Create a pipeline from RSS to Bluesky"}'
 ```
 
-Returns `session_id` for subsequent messages.
+### POST `/wp-json/datamachine/v1/chat/continue`
 
-### Session Continuity
+Continue turn-by-turn execution for a session.
 
-Use `session_id` to continue existing conversation:
+**Body parameters**:
 
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/chat \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"message": "Continue previous task", "session_id": "session_abc123"}'
-```
+- `session_id` (string, required): session ID to continue.
 
-### Session Storage
+### POST `/wp-json/datamachine/v1/chat/ping`
 
-Chat sessions are stored in the `wp_datamachine_chat_sessions` table.
+Send a bearer-token-authenticated ping to the chat agent. This route is intended for external webhook-style notifications, not normal WordPress user requests.
 
-**Implementation**: `inc/Core/Database/Chat/Chat.php`
+**Authorization**: `Authorization: Bearer <chat_ping_secret>`.
 
-**Database Table**: `wp_datamachine_chat_sessions`
+**Body parameters**:
 
-**Features**:
-- Persistent conversation history
-- User-scoped sessions (users can only access their own)
-- Message count tracking
-- Provider and model tracking
-- Agent type tracking (`agent_type`: `chat`, `cli`)
+- `message` (string, required): message for the chat agent.
+- `prompt` (string, optional): extra system-level instructions prepended to the message.
+- `context` (object, optional): flow, pipeline, job, or other context appended to the message.
 
-### Session Security
+**Errors**:
 
-**User Isolation**:
-- Sessions are user-scoped
-- Users can only access their own sessions
-- Invalid session returns 404 error
-- Access to another user's session returns 403 error
+- `ping_not_configured` (403): `chat_ping_secret` is empty.
+- `missing_authorization` (401): no authorization header.
+- `invalid_token` (403): bearer token mismatch.
 
-**Error Response (404 Not Found)** - Invalid session:
+## Session Routes
 
-```json
-{
-  "code": "session_not_found",
-  "message": "Session not found",
-  "data": {"status": 404}
-}
-```
-
-**Error Response (403 Forbidden)** - Access denied:
-
-```json
-{
-  "code": "session_access_denied",
-  "message": "Access denied to this session",
-  "data": {"status": 403}
-}
-```
-
-## Available Tools
-
-### Global Tools
-
-Available to all AI agents via `datamachine_global_tools` filter:
-
-- **google_search** - Web search with site restriction
-- **local_search** - WordPress content search
-- **web_fetch** - Web page content retrieval
-- **wordpress_post_reader** - Single post analysis
-
-### Chat-Specific Tools
-
-Available only to chat AI agents via `datamachine_chat_tools` filter (@since v0.4.3 specialized tools):
-
-- **execute_workflow** (@since v0.3.0) - Execute complete multi-step workflows with automatic defaults injection
-- **get_handler_defaults** (@since v0.6.25) - Retrieve site-wide handler defaults for reference
-- **set_handler_defaults** (@since v0.6.25) - Update site-wide handler defaults
-- **add_pipeline_step** (@since v0.4.3) - Add steps to existing pipelines
-- **api_query** (@since v0.4.3) - REST API query tool for discovery (supports batch requests @since v0.7.0)
-- **configure_flow_step** (@since v0.4.2) - Configure handler and AI messages
-- **configure_pipeline_step** (@since v0.4.4) - Configure pipeline-level AI settings
-- **copy_flow** (@since v0.6.25) - Copy flow to same or different pipeline with optional overrides
-- **create_flow** (@since v0.4.2) - Create flow instances from pipelines
-- **create_pipeline** (@since v0.4.3) - Create pipelines with optional steps
-- **handler_documentation** (@since v0.7.0) - Discover available handlers and their settings schema
-- **run_flow** (@since v0.4.4) - Execute or schedule flows
-- **update_flow** (@since v0.4.4) - Update flow properties
-- **validate_credentials** (@since v0.8.0) - Test authentication provider credentials during configuration
-
-## Universal Engine Architecture
-
-**Since**: v0.2.0
-
-The Chat endpoint uses the Universal Engine architecture at `/inc/Engine/AI/` for consistent AI request handling across Pipeline and Chat agents.
-
-### Core Components Used
-
-**AIConversationLoop**
-- Multi-turn conversation execution
-- Automatic tool call detection and execution
-- Completion detection (conversation ends when AI returns no tool calls)
-- Turn limiting (default: 8 turns)
-- Duplicate tool call prevention
-
-**RequestBuilder**
-- Centralized AI request construction
-- Hierarchical directive application (global → agent → chat-specific)
-- Tool restructuring for provider compatibility
-- Integration with the wp-ai-client runtime adapter
-
-**ToolExecutor**
-- Universal tool discovery via filters (`datamachine_global_tools`, `datamachine_chat_tools`)
-- Tool enablement validation
-- Execution with comprehensive error handling
-
-**ConversationManager**
-- Message formatting utilities
-- Tool call/result message generation
-- Duplicate detection logic
-
-**WP_Agent_Tool_Parameters**
-- Unified parameter building for tools
-- Automatic content/title extraction
-- Session context integration
-
-### Chat Agent Implementation
-
-**File**: `/inc/Api/Chat/ChatFilters.php`
-**Purpose**: Registers chat-specific behavior with Universal Engine
-
-**Chat Pipelines Inventory** (@since v0.7.0):
-The chat agent receives a lightweight inventory of all pipelines, their configured steps (ID, name, type), and flow summaries (ID, name, handlers) via the [ChatPipelinesDirective](../../core-system/ai-directives.md#chatpipelinesdirective-priority-45). When `selected_pipeline_id` is provided (e.g., from the Integrated Chat Sidebar), the agent prioritizes and expands context for that specific pipeline.
-
-**Tool Enablement** (chat-specific):
-```php
-add_filter('datamachine_tool_enabled', function($enabled, $tool_name, $tool_config, $context_id) {
-    // Chat agent: context_id = null (use global tool enablement)
-    if ($context_id === null) {
-        $tool_configured = apply_filters('datamachine_tool_configured', false, $tool_name);
-        $requires_config = !empty($tool_config['requires_config']);
-        return !$requires_config || $tool_configured;
-    }
-    return $enabled;
-}, 5, 4);
-```
-
-**Directive Registration** (@since v0.2.5):
-```php
-// Current: Unified directive registration with mode targeting
-add_filter('datamachine_directives', function($directives) {
-    $directives[] = [
-        'class' => MyChatDirective::class,
-        'priority' => 45,
-        'modes' => ['chat']
-    ];
-    return $directives;
-});
-```
-
-### Differences from Pipeline Agent
-
-**Chat Agent**:
-- Session-based conversation persistence
-- Global tool enablement (not step-specific)
-- No data packets from previous steps
-- Chat-specific specialized tools (create_pipeline, run_flow, etc.)
-- Session context instead of job context
-
-**Pipeline Agent**:
-- Job-based execution within workflows
-- Step-specific tool enablement
-- Data packets flow through steps
-- Handler tools for specific steps
-- Job context with engine data
-
-### Session Context Structure
-
-```php
-$context = [
-    'session_id' => $session_id  // Chat session identifier
-];
-```
-
-Used by:
-- RequestBuilder for directive application
-- ToolExecutor for tool execution
-- WP_Agent_Tool_Parameters for parameter building
-
-### Tool Discovery
-
-Chat agent discovers tools via three sources:
-
-1. **Global Tools** (`datamachine_global_tools` filter):
-   - google_search
-   - local_search
-   - web_fetch
-   - wordpress_post_reader
-
-2. **Chat Tools** (`datamachine_chat_tools` filter) (@since v0.4.3 specialized tools):
-   - execute_workflow, add_pipeline_step, api_query, configure_flow_step
-   - configure_pipeline_step, create_flow, create_pipeline, run_flow, update_flow
-
-3. **Filtered by Enablement** (`datamachine_tool_enabled` filter):
-   - Configuration validation
-   - Global enablement check
-
-### Conversation Flow
-
-```
-1. User sends message via POST /chat
-   ↓
-2. Chat endpoint loads or creates session
-   ↓
-3. AIConversationLoop executes:
-   a. RequestBuilder builds AI request with chat directives
-   b. AI responds with content and/or tool calls
-   c. ToolExecutor executes each tool call
-   d. ConversationManager formats tool results
-   e. Repeat until AI returns no tool calls (max 8 turns)
-   ↓
-4. Session updated with conversation history
-   ↓
-5. Response returned to user
-```
-
-## Filter-Based Architecture
-
-### Unified Directive System (@since v0.2.5)
-
-Directives are registered via the `datamachine_directives` filter with priority and mode targeting:
-
-```php
-add_filter('datamachine_directives', function($directives) {
-    // Global directive (applies to all agents)
-    $directives[] = [
-        'class' => MyDirective::class,
-        'priority' => 25,
-        'modes' => ['all']  // Applies to all agent modes
-    ];
-
-    // Chat-specific directive
-    $directives[] = [
-        'class' => MyChatDirective::class,
-        'priority' => 45,
-        'modes' => ['chat']  // Applies only to chat mode
-    ];
-
-    return $directives;
-});
-```
-
-**Priority Guidelines**:
-- **20**: Registered memory files
-- **22**: Runtime agent-mode guidance
-- **25-35**: Caller, daily memory, and client-reported context
-- **40-50**: Pipeline, flow, chat inventory, and workflow-specific directives
-
-
-
-## Integration Examples
-
-### Python Chat Integration
-
-```python
-import requests
-from requests.auth import HTTPBasicAuth
-
-url = "https://example.com/wp-json/datamachine/v1/chat"
-auth = HTTPBasicAuth("username", "application_password")
-
-# Start conversation
-initial_message = {
-    "message": "Create a pipeline that fetches from RSS",
-    "provider": "anthropic",
-    "model": "claude-sonnet-4"
-}
-
-response = requests.post(url, json=initial_message, auth=auth)
-data = response.json()
-
-session_id = data['session_id']
-print(f"AI: {data['response']}")
-
-# Continue conversation
-follow_up = {
-    "message": "Add a Twitter publish step",
-    "session_id": session_id
-}
-
-response2 = requests.post(url, json=follow_up, auth=auth)
-data2 = response2.json()
-
-print(f"AI: {data2['response']}")
-```
-
-### JavaScript Chat Interface
-
-```javascript
-const axios = require('axios');
-
-class ChatClient {
-  constructor(baseURL, auth) {
-    this.baseURL = baseURL;
-    this.auth = auth;
-    this.sessionId = null;
-  }
-
-  async sendMessage(message, provider = 'anthropic', model = 'claude-sonnet-4') {
-    const payload = {
-      message,
-      provider,
-      model
-    };
-
-    if (this.sessionId) {
-      payload.session_id = this.sessionId;
-    }
-
-    const response = await axios.post(this.baseURL, payload, {
-      auth: this.auth
-    });
-
-    // Store session ID from first message
-    if (!this.sessionId) {
-      this.sessionId = response.data.session_id;
-    }
-
-    return response.data;
-  }
-}
-
-// Usage
-const chat = new ChatClient(
-  'https://example.com/wp-json/datamachine/v1/chat',
-  { username: 'admin', password: 'application_password' }
-);
-
-const response1 = await chat.sendMessage('Create an RSS to Twitter pipeline');
-console.log(`AI: ${response1.response}`);
-
-const response2 = await chat.sendMessage('Execute the pipeline now');
-console.log(`AI: ${response2.response}`);
-```
-
-## Common Workflows
-
-### Create Pipeline via Chat
-
-```bash
-# 1. Start conversation
-curl -X POST https://example.com/wp-json/datamachine/v1/chat \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "message": "Create a pipeline with these steps: fetch from RSS, process with AI, publish to Twitter"
-  }'
-
-# AI will create pipeline using create_pipeline tool
-```
-
-### Monitor Jobs via Chat
-
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/chat \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "message": "Show me failed jobs from the last hour",
-    "session_id": "session_abc123"
-  }'
-```
-
-### Configure Handler via Chat
-
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/chat \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "message": "Configure the Twitter handler for flow 42 with max length 280",
-    "session_id": "session_abc123"
-  }'
-```
-
-## Use Cases
-
-### Conversational Pipeline Builder
-
-Build complex workflows through natural language conversation:
-
-```
-User: "Create a pipeline that imports recipes from an RSS feed"
-AI: [Creates pipeline with RSS fetch step]
-
-User: "Add AI processing to extract ingredients"
-AI: [Adds AI step with custom prompt]
-
-User: "Publish to WordPress"
-AI: [Adds WordPress publish step]
-```
-
-### Natural Language Debugging
-
-Debug workflows through conversational interface:
-
-```
-User: "Why did flow 42 fail?"
-AI: [Checks logs, identifies error, suggests fix]
-
-User: "Clear the failed jobs"
-AI: [Executes DELETE /jobs with type=failed]
-```
-
-### Interactive Configuration
-
-Configure Data Machine settings through chat:
-
-```
-User: "Set up Google Search API"
-AI: [Guides through configuration, saves settings]
-```
-
-## Related Documentation
-
-- Universal Engine Architecture - Shared AI infrastructure
-- AI Conversation Loop - Multi-turn conversation execution
-- Tool Execution Architecture - Tool discovery and execution
-- Universal Engine Filters - Directive and tool filters
-- Execute Endpoint - Workflow execution
-- Tools Endpoint - Available tools
-- Handlers Endpoint - Handler information
-- Authentication - Auth methods
-
----
-
-**Base URL**: `/wp-json/datamachine/v1/chat`
-**Permission**: `manage_options` capability required
-**Implementation**: `inc/Api/Chat/Chat.php`
-**Session Storage**: `wp_datamachine_chat_sessions` table
-**Session Expiration**: Not enforced by default (table supports an `expires_at` column for optional cleanup)
-
-## Additional Endpoints
-
-### POST /chat/continue
-
-Continue a chat session with additional context from external triggers (webhooks, scheduled jobs, etc.).
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `session_id` (string, required): Session ID to continue
-- `message` (string, required): Message to send
-- `provider` (string, optional): AI provider
-- `model` (string, optional): Model identifier
-
-**Example**:
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/chat/continue \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"session_id": "abc123", "message": "Process new RSS items"}'
-```
-
-### GET /chat/{session_id}
-
-Retrieve a chat session with its conversation history.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `session_id` (string, required): Session ID to retrieve
-
-**Response**:
-```json
-{
-  "id": "abc123",
-  "user_id": 1,
-  "session_id": "abc123",
-  "provider": "anthropic",
-  "model": "claude-sonnet-4",
-  "messages": [
-    {"role": "user", "content": "Hello"},
-    {"role": "assistant", "content": "Hi! How can I help?"}
-  ],
-  "message_count": 2,
-  "created_at": "2024-01-01 12:00:00",
-  "last_activity": "2024-01-01 12:05:00"
-}
-```
-
-### POST /chat/ping
-
-Receive external pings to trigger AI responses. Used for scheduled/recurring workflows.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `session_id` (string, required): Session ID to ping
-- `message` (string, required): Message to send
-- `provider` (string, optional): AI provider
-- `model` (string, optional): Model identifier
-
-**Use case**: Set up scheduled pings to trigger flow executions or periodic reviews.
-
-**Example**:
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/chat/ping \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"session_id": "abc123", "message": "Check for new RSS items and publish"}'
-```
+- `GET /chat/sessions`: list sessions.
+- `GET /chat/{session_id}`: get a session.
+- `DELETE /chat/{session_id}`: delete a session.
+- `POST /chat/sessions/{session_id}/read`: mark a session read.

--- a/docs/api/endpoints/flows.md
+++ b/docs/api/endpoints/flows.md
@@ -1,550 +1,261 @@
 # Flows Endpoints
 
-**Implementation**: `/inc/Api/Flows/` directory structure
-- `Flows.php` - Main flow CRUD operations
-- `FlowSteps.php` - Flow step configuration (`/flows/{id}/config`, `/flows/steps/{flow_step_id}/config`)
+**Implementation**: `inc/Api/Flows/`
 
 **Base URL**: `/wp-json/datamachine/v1/flows`
 
-## Overview
-
-Flow endpoints manage flow instances (configured and scheduled executions of pipeline templates).
+Flows are configured executions of pipeline templates.
 
 ## Authentication
 
-Requires `manage_options` capability.
+Requires the Data Machine `manage_flows` permission (`PermissionHelper::can( 'manage_flows' )`). Requests may be user-scoped or agent-scoped through `PermissionHelper`.
 
-## Endpoints
+## Response Envelope
 
-### GET /flows/problems
+Most flow routes return:
 
-Retrieve flows flagged as "problem flows" based on consecutive failures or no items found.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `threshold` (integer, optional): Override the site-wide `problem_flow_threshold` for this query.
-
-**Example Request**:
-
-```bash
-curl https://example.com/wp-json/datamachine/v1/flows/problems \
-  -u username:application_password
+```json
+{
+  "success": true,
+  "data": {}
+}
 ```
 
-**Success Response (200 OK)**:
+Some ability-backed mutation routes return the ability result directly when it already includes `success`.
+
+## Flow Routes
+
+### GET `/wp-json/datamachine/v1/flows`
+
+List flows.
+
+**Query parameters**:
+
+- `pipeline_id` (integer, optional): filter by pipeline.
+- `per_page` (integer, optional, default `20`, max `100`): page size.
+- `offset` (integer, optional, default `0`): pagination offset.
+- `output_mode` (string, optional, default `full`): `full`, `list`, `summary`, or `ids`.
+- `user_id` (integer, optional): filter by user when allowed by scope.
+
+Without `pipeline_id`, `data` is the flow array. With `pipeline_id`, `data` is `{ pipeline_id, flows }`.
+
+### POST `/wp-json/datamachine/v1/flows`
+
+Create a flow.
+
+**Body parameters**:
+
+- `pipeline_id` (integer, required): parent pipeline.
+- `flow_name` (string, optional, default `Flow`): flow name.
+- `flow_config` (array, optional): per-flow step settings.
+- `scheduling_config` (array, optional): scheduling config.
+
+### GET `/wp-json/datamachine/v1/flows/{flow_id}`
+
+Get one flow.
+
+### PATCH `/wp-json/datamachine/v1/flows/{flow_id}`
+
+Update a flow title and/or scheduling.
+
+**Body parameters**:
+
+- `flow_name` (string, optional): new flow title.
+- `scheduling_config` (object, optional): scheduling config.
+
+### DELETE `/wp-json/datamachine/v1/flows/{flow_id}`
+
+Delete a flow.
+
+### POST `/wp-json/datamachine/v1/flows/{flow_id}/duplicate`
+
+Duplicate a flow.
+
+### POST `/wp-json/datamachine/v1/flows/{flow_id}/pause`
+
+Pause one flow.
+
+### POST `/wp-json/datamachine/v1/flows/{flow_id}/resume`
+
+Resume one flow.
+
+### POST `/wp-json/datamachine/v1/flows/pause`
+
+Bulk-pause flows. Body must include `pipeline_id` or `agent_id`.
+
+### POST `/wp-json/datamachine/v1/flows/resume`
+
+Bulk-resume flows. Body must include `pipeline_id` or `agent_id`.
+
+### GET `/wp-json/datamachine/v1/flows/problems`
+
+List problem flows.
+
+**Query parameters**:
+
+- `threshold` (integer, optional): override the `problem_flow_threshold` setting.
+
+**Success response**:
 
 ```json
 {
   "success": true,
   "data": {
-    "problem_flows": [
-      {
-        "flow_id": 42,
-        "flow_name": "Broken RSS Flow",
-        "consecutive_failures": 5,
-        "consecutive_no_items": 0
-      }
-    ],
-    "total": 1,
-    "threshold": 3
+    "problem_flows": [],
+    "total": 0,
+    "threshold": 3,
+    "failing": [],
+    "idle": []
   }
 }
 ```
 
-### POST /flows
+## Flow Step Configuration Routes
 
-Create a new flow from an existing pipeline.
+### GET `/wp-json/datamachine/v1/flows/{flow_id}/config`
 
-**Permission**: `manage_options` capability required
+Return all configured steps for a flow.
 
-**Parameters**:
-- `pipeline_id` (integer, required): Parent pipeline ID
-- `flow_name` (string, optional): Flow name (default: "Flow")
-- `flow_config` (array, optional): Handler settings per step
-- `scheduling_config` (array, optional): Scheduling configuration
-
-**Example Request**:
-
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/flows \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "pipeline_id": 5,
-    "flow_name": "My Custom Flow",
-    "scheduling_config": {"interval": "daily"}
-  }'
-```
-
-**Success Response (200 OK)**:
+**Success shape**:
 
 ```json
 {
   "success": true,
   "data": {
     "flow_id": 42,
-    "pipeline_id": 5,
-    "flow_name": "My Custom Flow",
-    "flow_config": {},
-    "scheduling_config": {}
+    "flow_config": {}
   }
 }
 ```
 
-**Response Fields**:
-- `success` (boolean)
-- `data` (object): Created flow payload
+### GET `/wp-json/datamachine/v1/flows/steps/{flow_step_id}/config`
 
-### DELETE /flows/{flow_id}
+Return one flow step config.
 
-Delete a flow.
+**Success shape**:
 
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID to delete (in URL path)
-
-**Example Request**:
-
-```bash
-curl -X DELETE https://example.com/wp-json/datamachine/v1/flows/42 \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "data": {"flow_id": 42}
-}
-```
-
-**Response Fields**:
-- `success` (boolean)
-- `data.flow_id` (integer): Deleted flow ID
-
-**Error Response (404 Not Found)**:
-
-```json
-{
-  "code": "flow_not_found",
-  "message": "Flow not found.",
-  "data": {"status": 404}
-}
-```
-
-### POST /flows/{flow_id}/duplicate
-
-Duplicate an existing flow with all configuration.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Source flow ID to duplicate (in URL path)
-
-**Example Request**:
-
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/flows/42/duplicate \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "source_flow_id": 42,
-  "new_flow_id": 43,
-  "flow_name": "My Custom Flow (Copy)",
-  "pipeline_id": 5,
-  "flow_data": {...},
-  "pipeline_steps": [...]
-}
-```
-
-**Response Fields**:
-- `success` (boolean): Request success status
-- `source_flow_id` (integer): Original flow ID
-- `new_flow_id` (integer): Newly created duplicate flow ID
-- `flow_name` (string): Duplicate flow name (appends "(Copy)")
-- `pipeline_id` (integer): Parent pipeline ID
-- `flow_data` (object): Complete flow record
-- `pipeline_steps` (array): Pipeline step configuration
-
-**Error Response (404 Not Found)**:
-
-```json
-{
-  "code": "flow_not_found",
-  "message": "Flow not found.",
-  "data": {"status": 404}
-}
-```
-
-## Flow Configuration
-
-### Handler Settings
-
-Flow configuration stores handler-specific settings per step:
-
-```json
-{
-  "flow_step_id_123": {
-    "handler_slug": "rss",
-    "handler_config": {
-      "feed_url": "https://example.com/feed/",
-      "max_items": 10
-    }
-  },
-  "flow_step_id_456": {
-    "handler_slug": "twitter",
-    "handler_config": {
-      "max_length": 280
-    }
-  }
-}
-```
-
-### Scheduling Configuration
-
-Scheduling configuration defines execution intervals:
-
-```json
-{
-  "interval": "hourly"
-}
-```
-
-**Available Intervals**:
-- `manual` - No automatic execution
-- `one_time` - Execute once at a specific timestamp
-- `every_5_minutes` - Every 5 minutes
-- `hourly` - Every hour
-- `every_2_hours` - Every 2 hours
-- `every_4_hours` - Every 4 hours
-- `qtrdaily` - Every 6 hours
-- `twicedaily` - Twice per day (every 12 hours)
-- `daily` - Once per day
-- `weekly` - Once per week
-- Custom intervals via `datamachine_scheduler_intervals` filter
-
-## Flow Step Configuration
-
-### GET /flows/{flow_id}/config
-
-Retrieve complete flow configuration including all step settings.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID (in URL path)
-
-**Example Request**:
-
-```bash
-curl https://example.com/wp-json/datamachine/v1/flows/42/config \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "flow_id": 42,
-  "flow_config": {
-    "flow_step_id_123": {
-      "flow_step_id": "flow_step_id_123",
-      "pipeline_step_id": "step_uuid",
-      "step_type": "fetch",
-      "execution_order": 0,
-      "handler_slug": "rss",
-      "handler_config": {
-        "feed_url": "https://example.com/feed/",
-        "max_items": 10
-      },
-      "enabled": true
-    }
-  }
-}
-```
-
-### GET /flows/steps/{flow_step_id}/config
-
-Retrieve configuration for a specific flow step.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_step_id` (string, required): Flow step ID (in URL path)
-
-**Example Request**:
-
-```bash
-curl https://example.com/wp-json/datamachine/v1/flows/steps/flow_step_id_123/config \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "flow_step_id": "flow_step_id_123",
-  "config": {
-    "flow_step_id": "flow_step_id_123",
-    "pipeline_step_id": "step_uuid",
-    "step_type": "fetch",
-    "execution_order": 0,
-    "handler_slug": "rss",
-    "handler_config": {
-      "feed_url": "https://example.com/feed/",
-      "max_items": 10
-    },
-    "enabled": true
-  }
-}
-```
-
-**Error Response (404 Not Found)**:
-
-```json
-{
-  "code": "config_not_found",
-  "message": "Flow step configuration not found.",
-  "data": {"status": 404}
-}
-```
-
-## Related endpoints
-
-- [Execute](execute.md) for running flows or ephemeral workflows.
-- [Jobs](jobs.md) for monitoring executions.
-- [Settings](settings.md) for `problem_flow_threshold`.
-
----
-
-## Related Documentation
-
-```bash
-# 1. Create flow
-FLOW_ID=$(curl -X POST https://example.com/wp-json/datamachine/v1/flows \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"pipeline_id": 5}' | jq -r '.flow_id')
-
-# 2. Execute flow immediately
-curl -X POST https://example.com/wp-json/datamachine/v1/execute \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d "{\"flow_id\": $FLOW_ID}"
-```
-
-### Duplicate and Modify
-
-```bash
-# 1. Duplicate existing flow
-NEW_FLOW=$(curl -X POST https://example.com/wp-json/datamachine/v1/flows/42/duplicate \
-  -u username:application_password)
-
-# 2. Modify configuration via admin interface or additional API calls
-# 3. Execute new flow independently
-```
-
-### Cleanup Old Flows
-
-```bash
-# Delete flow and associated jobs
-curl -X DELETE https://example.com/wp-json/datamachine/v1/flows/42 \
-  -u username:application_password
-```
-
-## Integration Examples
-
-### Python Flow Management
-
-```python
-import requests
-from requests.auth import HTTPBasicAuth
-
-url = "https://example.com/wp-json/datamachine/v1/flows"
-auth = HTTPBasicAuth("username", "application_password")
-
-# Create flow
-payload = {
-    "pipeline_id": 5,
-    "flow_name": "Automated RSS to Twitter",
-    "scheduling_config": {"interval": "hourly"}
-}
-
-response = requests.post(url, json=payload, auth=auth)
-flow_data = response.json()
-
-print(f"Created flow {flow_data['flow_id']}: {flow_data['flow_name']}")
-
-# Duplicate flow
-duplicate_url = f"{url}/{flow_data['flow_id']}/duplicate"
-duplicate_response = requests.post(duplicate_url, auth=auth)
-duplicate_data = duplicate_response.json()
-
-print(f"Duplicated to flow {duplicate_data['new_flow_id']}")
-```
-
-### JavaScript Flow Operations
-
-```javascript
-const axios = require('axios');
-
-const flowAPI = {
-  baseURL: 'https://example.com/wp-json/datamachine/v1/flows',
-  auth: {
-    username: 'admin',
-    password: 'application_password'
-  }
-};
-
-// Create flow
-async function createFlow(pipelineId, flowName) {
-  const response = await axios.post(flowAPI.baseURL, {
-    pipeline_id: pipelineId,
-    flow_name: flowName
-  }, { auth: flowAPI.auth });
-
-  return response.data.flow_id;
-}
-
-// Delete flow
-async function deleteFlow(flowId) {
-  const response = await axios.delete(
-    `${flowAPI.baseURL}/${flowId}`,
-    { auth: flowAPI.auth }
-  );
-
-  return response.data.deleted_jobs;
-}
-
-// Usage
-const flowId = await createFlow(5, 'My Flow');
-const deletedJobs = await deleteFlow(flowId);
-```
-
-## Related Documentation
-
-- [Pipelines](pipelines.md)
-- [Execute](execute.md)
-- [Jobs](jobs.md)
-
-
----
-
-**Base URL**: `/wp-json/datamachine/v1/flows`
-**Permission**: `manage_options` capability required
-**Implementation**: `/inc/Api/Flows/` (Flows.php, FlowSteps.php)
-
-## Flow Queue Endpoints
-
-Flow queues enable step-level prompt queues for varied task instructions per execution.
-
-### GET /flows/{flow_id}/queue
-
-Get the queue for a flow.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID
-
-**Response**:
-```json
-{
-  "success": true,
-  "queue": ["First task", "Second task"],
-  "count": 2
-}
-```
-
-### POST /flows/{flow_id}/queue
-
-Add items to the flow queue.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID
-- `items` (array, required): Queue items to add
-- `position` (string, optional): "start" or "end" (default: "end")
-
-**Example**:
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/flows/5/queue \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"items": ["Task 1", "Task 2"]}'
-```
-
-### DELETE /flows/{flow_id}/queue
-
-Clear all items from the flow queue.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID
-
-### GET /flows/{flow_id}/queue/{index}
-
-Get a specific queue item.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID
-- `index` (integer, required): Queue position (0-based)
-
-### PUT /flows/{flow_id}/queue/{index}
-
-Update a specific queue item.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID
-- `index` (integer, required): Queue position
-- `item` (string, required): New item content
-
-### DELETE /flows/{flow_id}/queue/{index}
-
-Remove a specific queue item.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID
-- `index` (integer, required): Queue position
-
-### PUT /flows/{flow_id}/queue/mode
-
-Set the queue access mode for a flow step.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `flow_id` (integer, required): Flow ID
-- `flow_step_id` (string, required): Flow step ID
-- `mode` (string, required): One of `drain`, `loop`, or `static`
-
-**Response**:
 ```json
 {
   "success": true,
   "data": {
-    "flow_id": 10,
-    "flow_step_id": "ai_2",
-    "queue_mode": "static"
-  },
-  "message": "Queue mode updated."
+    "flow_step_id": "<pipeline_step_id>_<flow_id>",
+    "step_config": {}
+  }
 }
 ```
+
+### PATCH `/wp-json/datamachine/v1/flows/steps/{flow_step_id}/config`
+
+Patch one flow step config.
+
+**Body parameters**:
+
+- `handler_slug` (string, optional): handler identifier.
+- `handler_config` (object, optional): handler settings to merge.
+- `user_message` (string, optional): AI user message.
+
+### PUT `/wp-json/datamachine/v1/flows/steps/{flow_step_id}/handler`
+
+Save handler selection/settings for one flow step.
+
+**Body parameters**:
+
+- `handler_slug` (string, required): handler identifier.
+- `pipeline_id` (integer, required): pipeline context.
+- `step_type` (string, required): step type.
+- `settings` (object, optional): raw handler settings.
+
+### PATCH `/wp-json/datamachine/v1/flows/steps/{flow_step_id}/user-message`
+
+Save the AI user message for one flow step.
+
+**Body parameters**:
+
+- `user_message` (string, required): message text.
+
+## Queue Routes
+
+All queue routes require `flow_step_id` as a request parameter. The route path only carries `flow_id` and, where applicable, `index`.
+
+### GET `/wp-json/datamachine/v1/flows/{flow_id}/queue`
+
+List a queue.
+
+**Query parameters**:
+
+- `flow_step_id` (string, required): flow step ID.
+
+**Success shape**:
+
+```json
+{
+  "success": true,
+  "data": {
+    "flow_id": 42,
+    "flow_step_id": "<pipeline_step_id>_<flow_id>",
+    "queue": [],
+    "count": 0,
+    "queue_mode": "drain"
+  }
+}
+```
+
+### POST `/wp-json/datamachine/v1/flows/{flow_id}/queue`
+
+Add queue items.
+
+**Body parameters**:
+
+- `flow_step_id` (string, required): flow step ID.
+- `prompt` (string, optional): one prompt.
+- `prompts` (array of strings, optional): multiple prompts.
+
+At least one non-empty `prompt` or `prompts[]` entry is required.
+
+### DELETE `/wp-json/datamachine/v1/flows/{flow_id}/queue`
+
+Clear a queue.
+
+**Body/query parameters**:
+
+- `flow_step_id` (string, required): flow step ID.
+
+### POST/PUT/PATCH `/wp-json/datamachine/v1/flows/{flow_id}/queue/{index}`
+
+Update one queue item.
+
+**Body parameters**:
+
+- `flow_step_id` (string, required): flow step ID.
+- `prompt` (string, required): replacement prompt.
+
+### DELETE `/wp-json/datamachine/v1/flows/{flow_id}/queue/{index}`
+
+Remove one queue item.
+
+**Body/query parameters**:
+
+- `flow_step_id` (string, required): flow step ID.
+
+### POST/PUT/PATCH `/wp-json/datamachine/v1/flows/{flow_id}/queue/mode`
+
+Set queue mode.
+
+**Body parameters**:
+
+- `flow_step_id` (string, required): flow step ID.
+- `mode` (string, required): `drain`, `loop`, or `static`.
+
+## Flow Memory Routes
+
+### GET `/wp-json/datamachine/v1/flows/{flow_id}/memory-files`
+
+Return configured memory filenames for a flow.
+
+### POST/PUT/PATCH `/wp-json/datamachine/v1/flows/{flow_id}/memory-files`
+
+Replace configured memory filenames.
+
+**Body parameters**:
+
+- `memory_files` (array of strings, required): agent memory filenames. `daily_memory` is not accepted.

--- a/docs/api/endpoints/jobs.md
+++ b/docs/api/endpoints/jobs.md
@@ -4,197 +4,70 @@
 
 **Base URL**: `/wp-json/datamachine/v1/jobs`
 
-## Overview
-
-Jobs endpoints provide monitoring and management of workflow executions. Jobs represent individual execution instances of flows, including batch job hierarchies where a parent job spawns child jobs for parallel processing.
+Jobs expose workflow execution history and cleanup operations.
 
 ## Authentication
 
-Requires `manage_flows` permission (checked via `PermissionHelper`). Supports user-scoped and agent-scoped filtering for multi-agent environments.
+Requires the Data Machine `manage_flows` permission (`PermissionHelper::can( 'manage_flows' )`). Requests may be user-scoped or agent-scoped through `PermissionHelper`.
 
-## React Interface
+## Routes
 
-The Jobs interface is a React-based management dashboard built on `@wordpress/components` and TanStack Query.
+### GET `/wp-json/datamachine/v1/jobs`
 
-## Endpoints
+List jobs with filtering, sorting, and pagination.
 
-### GET /jobs
+**Query parameters**:
 
-Retrieve jobs with filtering, sorting, and pagination.
+- `orderby` (string, optional, default `job_id`): field to order by.
+- `order` (string, optional, default `DESC`): `ASC` or `DESC`.
+- `per_page` (integer, optional, default `50`, max `100`): page size.
+- `offset` (integer, optional, default `0`): pagination offset.
+- `pipeline_id` (integer, optional): filter by pipeline.
+- `flow_id` (integer, optional): filter by flow.
+- `status` (string, optional): filter by job status.
+- `user_id` (integer, optional): filter by user when allowed by the permission scope.
+- `parent_job_id` (integer, optional): filter child jobs by parent job.
+- `hide_children` (boolean, optional, default `false`): omit child jobs from top-level lists.
 
-**Permission**: `manage_flows` capability required
-
-**Parameters**:
-- `orderby` (string, optional): Order jobs by field (default: `job_id`)
-- `order` (string, optional): Sort order - `ASC` or `DESC` (default: `DESC`)
-- `per_page` (integer, optional): Number of jobs per page (default: 50, max: 100)
-- `offset` (integer, optional): Offset for pagination (default: 0)
-- `pipeline_id` (integer, optional): Filter by pipeline ID
-- `flow_id` (integer, optional): Filter by flow ID
-- `status` (string, optional): Filter by job status (`completed`, `failed`, `processing`, etc.)
-- `user_id` (integer, optional): Filter by user ID (admin only; non-admins always see own data)
-
-**Example Requests**:
-
-```bash
-# Get all jobs (recent first)
-curl https://example.com/wp-json/datamachine/v1/jobs \
-  -u username:application_password
-
-# Get failed jobs only
-curl https://example.com/wp-json/datamachine/v1/jobs?status=failed \
-  -u username:application_password
-
-# Get jobs for specific flow with pagination
-curl https://example.com/wp-json/datamachine/v1/jobs?flow_id=42&per_page=25&offset=0 \
-  -u username:application_password
-
-# Get jobs for specific pipeline
-curl https://example.com/wp-json/datamachine/v1/jobs?pipeline_id=5 \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
+**Success response**:
 
 ```json
 {
   "success": true,
-  "data": [
-    {
-      "job_id": 1523,
-      "flow_id": 42,
-      "pipeline_id": 5,
-      "status": "completed",
-      "parent_job_id": null,
-      "source": "scheduler",
-      "started_at": "2024-01-02 14:30:00",
-      "completed_at": "2024-01-02 14:30:15",
-      "error_message": null
-    },
-    {
-      "job_id": 1522,
-      "flow_id": 42,
-      "pipeline_id": 5,
-      "status": "failed",
-      "parent_job_id": null,
-      "source": "manual",
-      "started_at": "2024-01-02 14:00:00",
-      "completed_at": "2024-01-02 14:00:05",
-      "error_message": "Handler configuration missing"
-    }
-  ],
-  "total": 1523,
+  "data": [],
+  "total": 0,
   "per_page": 50,
   "offset": 0
 }
 ```
 
-**Response Fields**:
-- `success` (boolean): Request success status
-- `data` (array): Array of job objects
-- `total` (integer): Total number of jobs matching filters
-- `per_page` (integer): Number of jobs per page
-- `offset` (integer): Pagination offset
+### GET `/wp-json/datamachine/v1/jobs/{id}`
 
-**Job Object Fields**:
-- `job_id` (integer): Unique job identifier
-- `flow_id` (integer): Associated flow ID
-- `pipeline_id` (integer): Associated pipeline ID
-- `status` (string): Job status (see statuses below)
-- `parent_job_id` (integer|null): Parent job ID for batch child jobs (null for top-level jobs)
-- `source` (string): Job trigger source (`scheduler`, `manual`, `system`, `pipeline_system_task`, `chat`)
-- `started_at` (string): Job start timestamp
-- `completed_at` (string|null): Job completion timestamp
-- `error_message` (string|null): Error message if failed
-- `engine_data` (object): Job execution data including task parameters and effects (for system tasks)
+Get one job by ID.
 
-**Job Statuses**:
-- `pending` - Job queued but not started
-- `processing` - Currently executing
-- `completed` - Successfully completed
-- `completed_no_items` - Completed successfully but no new items found to process
-- `agent_skipped` - Completed intentionally without processing the current item (supports compound statuses like `agent_skipped - {reason}`)
-- `failed` - Execution failed with error
-
-### GET /jobs/{id}
-
-Get a specific job by ID with full details.
-
-**Permission**: `manage_flows` capability required
-
-**Parameters**:
-- `id` (integer, required): Job ID
-
-**Example Request**:
-
-```bash
-curl https://example.com/wp-json/datamachine/v1/jobs/1523 \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
+**Success response**:
 
 ```json
 {
   "success": true,
-  "data": {
-    "job_id": 1523,
-    "flow_id": 42,
-    "pipeline_id": 5,
-    "status": "completed",
-    "parent_job_id": null,
-    "source": "scheduler",
-    "started_at": "2024-01-02 14:30:00",
-    "completed_at": "2024-01-02 14:30:15",
-    "error_message": null,
-    "engine_data": {}
-  }
+  "data": {}
 }
 ```
 
-**Error Response (404 Not Found)**:
+**Errors**:
 
-```json
-{
-  "code": "job_not_found",
-  "message": "Job not found.",
-  "data": {"status": 404}
-}
-```
+- `job_not_found` (404): no matching job.
 
-### DELETE /jobs
+### DELETE `/wp-json/datamachine/v1/jobs`
 
-Clear jobs from the database.
+Clear jobs.
 
-**Permission**: `manage_flows` capability required
+**Body parameters**:
 
-**Parameters**:
-- `type` (string, required): Which jobs to clear - `all` or `failed`
-- `cleanup_processed` (boolean, optional): Also clear processed items tracking (default: false)
+- `type` (string, required): `all` or `failed`.
+- `cleanup_processed` (boolean, optional, default `false`): also clear processed item tracking.
 
-**Example Requests**:
-
-```bash
-# Clear all jobs
-curl -X DELETE https://example.com/wp-json/datamachine/v1/jobs \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"type": "all"}'
-
-# Clear failed jobs only
-curl -X DELETE https://example.com/wp-json/datamachine/v1/jobs \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"type": "failed"}'
-
-# Clear all jobs and processed items
-curl -X DELETE https://example.com/wp-json/datamachine/v1/jobs \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"type": "all", "cleanup_processed": true}'
-```
-
-**Success Response (200 OK)**:
+**Success response**:
 
 ```json
 {
@@ -205,294 +78,16 @@ curl -X DELETE https://example.com/wp-json/datamachine/v1/jobs \
 }
 ```
 
-**Error Response (400 Bad Request)**:
+## Batch Jobs
 
-```json
-{
-  "code": "invalid_type",
-  "message": "Invalid type parameter. Must be 'all' or 'failed'.",
-  "data": {"status": 400}
-}
-```
-
-## Batch Job Hierarchy
-
-Jobs support parent-child relationships for batch processing. When a pipeline uses the `PipelineBatchScheduler`, a parent job spawns multiple child jobs that execute in parallel.
-
-### Structure
-
-```
-Parent Job (job_id: 100, parent_job_id: null)
-├── Child Job (job_id: 101, parent_job_id: 100)
-├── Child Job (job_id: 102, parent_job_id: 100)
-└── Child Job (job_id: 103, parent_job_id: 100)
-```
-
-**Key behaviors**:
-- Parent job status remains `processing` until all children complete
-- `parent_job_id` field links children to their parent
-- Child completion triggers `PipelineBatchScheduler::onChildComplete()` to check if all children are done
-- Batch size and chunk processing are configured at the pipeline level
-
-### Querying Batch Jobs
+Batch processing uses parent/child jobs. Use `parent_job_id` to list children and `hide_children=true` for a top-level-only job list.
 
 ```bash
-# Get children of a batch parent
 curl "https://example.com/wp-json/datamachine/v1/jobs?parent_job_id=100" \
   -u username:application_password
 ```
 
-## Job Undo System
+## Notes for Agents
 
-**Implementation**: `inc/Engine/AI/System/Tasks/SystemTask.php` (@since v0.33.0)
-
-System tasks that modify WordPress content can opt into undo support. The undo system reads a standardized `effects` array from the job's `engine_data` and reverses each effect in reverse order.
-
-### Supported Undo Effect Types
-
-| Effect Type | Reversal Action |
-|---|---|
-| `post_content_modified` | Restores from WordPress revision |
-| `post_meta_set` | Restores previous value or deletes meta |
-| `attachment_created` | Deletes the attachment |
-| `featured_image_set` | Removes or restores previous thumbnail |
-
-### How Undo Works
-
-1. During execution, tasks record effects in `engine_data.effects`:
-   ```json
-   {
-     "effects": [
-       {
-         "type": "post_content_modified",
-         "post_id": 42,
-         "revision_id": 123
-       },
-       {
-         "type": "post_meta_set",
-         "post_id": 42,
-         "meta_key": "description",
-         "previous_value": "old value"
-       }
-     ]
-   }
-   ```
-
-2. Tasks opt in by returning `true` from `supportsUndo()`
-3. Undo reverses effects in reverse order (last effect first)
-4. Unknown effect types are skipped (not failed) so tasks with mixed reversible/irreversible effects degrade gracefully
-
-### CLI Undo
-
-```bash
-# Undo a job's effects
-wp datamachine jobs undo <job_id> --allow-root
-
-# Dry run to preview what would be reverted
-wp datamachine jobs undo <job_id> --dry-run --allow-root
-
-# Undo specific task type only
-wp datamachine jobs undo <job_id> --task-type=alt_text_generation --allow-root
-
-# Force undo even on non-completed jobs
-wp datamachine jobs undo <job_id> --force --allow-root
-```
-
-### Undo Response Format
-
-```json
-{
-  "success": true,
-  "reverted": [
-    {
-      "type": "post_content_modified",
-      "post_id": 42,
-      "message": "Restored from revision 123"
-    }
-  ],
-  "skipped": [],
-  "failed": []
-}
-```
-
-## Common Workflows
-
-### Monitor Flow Execution
-
-```bash
-# Get recent jobs for specific flow
-curl https://example.com/wp-json/datamachine/v1/jobs?flow_id=42&per_page=10 \
-  -u username:application_password
-```
-
-### Debug Failed Executions
-
-```bash
-# Get all failed jobs
-curl https://example.com/wp-json/datamachine/v1/jobs?status=failed \
-  -u username:application_password
-```
-
-### Cleanup Job History
-
-```bash
-# Clear failed jobs to reset execution history
-curl -X DELETE https://example.com/wp-json/datamachine/v1/jobs \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"type": "failed"}'
-```
-
-## Integration Examples
-
-### Python Job Monitoring
-
-```python
-import requests
-from requests.auth import HTTPBasicAuth
-
-url = "https://example.com/wp-json/datamachine/v1/jobs"
-auth = HTTPBasicAuth("username", "application_password")
-
-# Get failed jobs
-params = {"status": "failed", "per_page": 100}
-response = requests.get(url, params=params, auth=auth)
-
-if response.status_code == 200:
-    data = response.json()
-    print(f"Found {len(data['data'])} failed jobs")
-
-    for job in data['data']: 
-        print(f"Job {job['job_id']}: {job['error_message']}")
-else:
-    print(f"Error: {response.json()['message']}")
-```
-
-### JavaScript Job Dashboard
-
-```javascript
-const axios = require('axios');
-
-const jobAPI = {
-  baseURL: 'https://example.com/wp-json/datamachine/v1/jobs',
-  auth: {
-    username: 'admin',
-    password: 'application_password'
-  }
-};
-
-// Get job statistics
-async function getJobStats(flowId) {
-  const params = { flow_id: flowId, per_page: 100 };
-  const response = await axios.get(jobAPI.baseURL, {
-    params,
-    auth: jobAPI.auth
-  });
-
-  const jobs = response.data.data;
-  const stats = {
-    total: jobs.length,
-    completed: jobs.filter(j => j.status === 'completed').length,
-    failed: jobs.filter(j => j.status === 'failed').length,
-    processing: jobs.filter(j => j.status === 'processing').length
-  };
-
-  return stats;
-}
-
-// Clear old jobs
-async function clearJobs(type = 'failed') {
-  const response = await axios.delete(jobAPI.baseURL, {
-    data: { type },
-    auth: jobAPI.auth
-  });
-
-  return response.data.success;
-}
-
-// Usage
-const stats = await getJobStats(42);
-console.log(`Flow 42: ${stats.completed} completed, ${stats.failed} failed`);
-
-await clearJobs('failed');
-console.log('Failed jobs cleared');
-```
-
-### PHP Job Monitoring
-
-```php
-$url = 'https://example.com/wp-json/datamachine/v1/jobs';
-$auth = base64_encode('username:application_password');
-
-// Get jobs for specific flow
-$params = http_build_query([
-    'flow_id' => 42,
-    'status' => 'failed',
-    'per_page' => 50
-]);
-
-$response = wp_remote_get($url . '?' . $params, [
-    'headers' => [
-        'Authorization' => 'Basic ' . $auth
-    ]
-]);
-
-if (!is_wp_error($response)) {
-    $data = json_decode(wp_remote_retrieve_body($response), true);
-
-    foreach ($data['data'] as $job) {
-        error_log(sprintf(
-            'Job %d failed: %s',
-            $job['job_id'],
-            $job['error_message']
-        ));
-    }
-}
-```
-
-## Use Cases
-
-### Execution Monitoring
-
-Monitor workflow success rates and identify failing patterns:
-
-```bash
-# Get all jobs ordered by completion time
-curl https://example.com/wp-json/datamachine/v1/jobs?orderby=completed_at&order=DESC \
-  -u username:application_password
-```
-
-### Performance Analysis
-
-Analyze execution duration and identify bottlenecks:
-
-```bash
-# Get recent completed jobs
-curl https://example.com/wp-json/datamachine/v1/jobs?status=completed&per_page=100 \
-  -u username:application_password
-```
-
-### Cleanup and Maintenance
-
-Regularly clear old job records to maintain database performance:
-
-```bash
-# Clear all jobs and reset processed items tracking
-curl -X DELETE https://example.com/wp-json/datamachine/v1/jobs \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"type": "all", "cleanup_processed": true}'
-```
-
-## Related Documentation
-
-- [Execute](execute.md) - Flow execution
-- [Flows](flows.md) - Flow management
-- [Processed Items](processed-items.md) - Deduplication tracking
-- [Logs](logs.md) - Detailed execution logs
-
----
-
-**Base URL**: `/wp-json/datamachine/v1/jobs`
-**Permission**: `manage_flows` capability required
-**Implementation**: `inc/Api/Jobs.php`
+- REST does not expose job undo. Undo is CLI-only via `wp datamachine jobs undo <job_id>`.
+- Job objects are returned by `GetJobsAbility`; fields depend on stored job data and may include `engine_data` for task effects.

--- a/docs/api/endpoints/pipelines.md
+++ b/docs/api/endpoints/pipelines.md
@@ -1,385 +1,194 @@
 # Pipelines Endpoints
 
-**Implementation**: `/inc/Api/Pipelines/` directory structure
-- `Pipelines.php` - Main pipeline CRUD operations
-- `PipelineSteps.php` - Step management (`/pipelines/{id}/steps`)
-- `PipelineFlows.php` - Pipeline-flow relationships (`/pipelines/{id}/flows`)
+**Implementation**: `inc/Api/Pipelines/`
 
 **Base URL**: `/wp-json/datamachine/v1/pipelines`
 
-## Overview
-
-Pipeline endpoints provide complete pipeline template management including creation, retrieval, modification, deletion, step management, and CSV import/export functionality. Directory-based structure (@since v0.2.0) organizes related operations with nested endpoints for steps and flows.
+Pipelines are reusable workflow templates. Flows are executable instances of pipelines.
 
 ## Authentication
 
-Requires `manage_options` capability. See Authentication Guide.
+Requires the Data Machine `manage_flows` permission (`PermissionHelper::can( 'manage_flows' )`). Requests may be user-scoped or agent-scoped through `PermissionHelper`.
 
-## Endpoints
+## Response Envelope
 
-### GET /pipelines
-
-Retrieve all pipelines or a specific pipeline with optional field filtering.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `pipeline_id` (integer, optional): Specific pipeline ID to retrieve
-- `fields` (string, optional): Comma-separated list of fields to return
-
-**Example Requests**:
-
-```bash
-# Get all pipelines
-curl https://example.com/wp-json/datamachine/v1/pipelines \
-  -u username:application_password
-
-# Get specific pipeline
-curl https://example.com/wp-json/datamachine/v1/pipelines?pipeline_id=5 \
-  -u username:application_password
-
-# Get specific fields only
-curl https://example.com/wp-json/datamachine/v1/pipelines?fields=pipeline_id,pipeline_name \
-  -u username:application_password
-```
-
-**Success Response (All Pipelines)**:
+Current JSON routes generally return:
 
 ```json
 {
   "success": true,
-  "pipelines": [
-    {
-      "pipeline_id": 5,
-      "pipeline_name": "Content Pipeline",
-      "pipeline_config": "{}",
-      "created_at": "2024-01-01 12:00:00",
-      "updated_at": "2024-01-02 14:30:00"
-    }
-  ],
-  "total": 1
+  "data": {}
 }
 ```
 
-**Success Response (Single Pipeline)**:
+List routes may also include top-level pagination fields. CSV export returns raw `text/csv`, not a JSON envelope.
+
+## Pipeline Routes
+
+### GET `/wp-json/datamachine/v1/pipelines`
+
+List pipelines or export CSV.
+
+**Query parameters**:
+
+- `pipeline_id` (integer, optional): retrieve one pipeline through the list route.
+- `fields` (string, optional): comma-separated fields to keep.
+- `format` (string, optional, default `json`): `json` or `csv`.
+- `ids` (string, optional): comma-separated pipeline IDs for CSV export.
+- `user_id` (integer, optional): filter by user when allowed by scope.
+- `search` (string, optional): substring match on pipeline name.
+- `per_page` (integer, optional, default `20`, max `100`): page size.
+- `offset` (integer, optional, default `0`): pagination offset.
+- `include_flows` (boolean, optional): include full flows. Defaults to `false` for list mode and `true` for single-pipeline lookups.
+
+**List success shape**:
 
 ```json
 {
   "success": true,
-  "pipeline": {
-    "pipeline_id": 5,
-    "pipeline_name": "Content Pipeline",
-    "pipeline_config": "{}",
-    "created_at": "2024-01-01 12:00:00",
-    "updated_at": "2024-01-02 14:30:00"
-  },
-  "flows": [...]
+  "per_page": 20,
+  "offset": 0,
+  "total": 0,
+  "data": {
+    "pipelines": [],
+    "total": 0
+  }
 }
 ```
 
-### POST /pipelines
+### GET `/wp-json/datamachine/v1/pipelines/{pipeline_id}`
 
-Create a new pipeline with optional step configuration.
+Get one pipeline.
 
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `pipeline_name` (string, optional): Pipeline name (default: "Pipeline")
-- `steps` (array, optional): Complete pipeline steps configuration for complete mode
-- `flow_config` (array, optional): Flow configuration
-
-**Creation Modes**:
-- **Simple Mode**: Only `pipeline_name` provided - creates empty pipeline
-- **Complete Mode**: `steps` array provided - creates pipeline with configured steps
-
-**Example Requests**:
-
-```bash
-# Simple mode - empty pipeline
-curl -X POST https://example.com/wp-json/datamachine/v1/pipelines \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"pipeline_name": "My Pipeline"}'
-
-# Complete mode - with steps
-curl -X POST https://example.com/wp-json/datamachine/v1/pipelines \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "pipeline_name": "Complete Pipeline",
-    "steps": [
-      {"step_type": "fetch"},
-      {"step_type": "ai"},
-      {"step_type": "publish"}
-    ]
-  }'
-```
-
-**Success Response**:
+**Success shape**:
 
 ```json
 {
   "success": true,
-  "pipeline_id": 6,
-  "pipeline_name": "My Pipeline",
-  "pipeline_data": {...},
-  "existing_flows": [],
-  "creation_mode": "simple"
+  "data": {
+    "pipeline": {},
+    "flows": []
+  }
 }
 ```
 
-### DELETE /pipelines/{pipeline_id}
+### POST `/wp-json/datamachine/v1/pipelines`
 
-Delete a pipeline and all associated flows and jobs.
+Create a pipeline. Despite the REST schema default, `pipeline_name` is required by the controller.
 
-**Permission**: `manage_options` capability required
+**Body parameters**:
 
-**Parameters**:
-- `pipeline_id` (integer, required): Pipeline ID to delete (in URL path)
+- `pipeline_name` (string, required): pipeline name.
+- `steps` (array, optional): pipeline step configuration.
+- `flow_config` (array, optional): initial flow configuration.
 
-**Example Request**:
-
-```bash
-curl -X DELETE https://example.com/wp-json/datamachine/v1/pipelines/6 \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
+**Success shape**:
 
 ```json
 {
   "success": true,
-  "pipeline_id": 6,
-  "message": "Pipeline deleted successfully.",
-  "deleted_flows": 2,
-  "deleted_jobs": 15
+  "data": {}
 }
 ```
 
-### POST /pipelines/{pipeline_id}/steps
+### PATCH `/wp-json/datamachine/v1/pipelines/{pipeline_id}`
 
-Add a step to an existing pipeline.
+Rename a pipeline.
 
-**Permission**: `manage_options` capability required
+**Body parameters**:
 
-**Parameters**:
-- `pipeline_id` (integer, required): Pipeline ID (in URL path)
-- `step_type` (string, required): Step type (`fetch`, `ai`, `publish`, `upsert`)
+- `pipeline_name` (string, required): new title.
 
-**Example Request**:
+### DELETE `/wp-json/datamachine/v1/pipelines/{pipeline_id}`
 
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/pipelines/6/steps \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"step_type": "fetch"}'
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "message": "Step \"Fetch\" added successfully",
-  "step_type": "fetch",
-  "step_config": {...},
-  "pipeline_id": 6,
-  "pipeline_step_id": "abc123-def456-789",
-  "step_data": {...},
-  "created_type": "step"
-}
-```
-
-### DELETE /pipelines/{pipeline_id}/steps/{step_id}
-
-Delete a step from a pipeline.
-
-**Permission**: `manage_options` capability required
-
-**Parameters**:
-- `pipeline_id` (integer, required): Pipeline ID (in URL path)
-- `step_id` (string, required): Pipeline step ID (in URL path)
-
-**Example Request**:
-
-```bash
-curl -X DELETE https://example.com/wp-json/datamachine/v1/pipelines/6/steps/abc123-def456-789 \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "pipeline_step_id": "abc123-def456-789",
-  "pipeline_id": 6,
-  "message": "Step deleted successfully."
-}
-```
+Delete a pipeline and related records.
 
 ## CSV Export
 
-### GET /pipelines?format=csv
+### GET `/wp-json/datamachine/v1/pipelines?format=csv`
 
-Export pipelines to CSV format for backup, migration, or version control.
+Export pipelines as CSV. Use `ids=1,2` or `pipeline_id=1` to limit the export. The response is raw CSV with `Content-Type: text/csv; charset=utf-8`.
 
-**Permission**: `manage_options` capability required
+CSV import is not wired through `inc/Api/Pipelines/Pipelines.php`. The REST schema still registers `batch_import`, `format`, and `data` args on `POST /pipelines`, but the controller currently ignores them and requires `pipeline_name` for normal creation.
 
-**Parameters**:
-- `format` (string, required): Must be `csv` for export
-- `ids` (string, optional): Comma-separated pipeline IDs to export
-- `pipeline_id` (integer, optional): Single pipeline ID to export
+## Pipeline Step Routes
 
-**Export Behavior**:
-- If `ids` provided → Export specified pipelines
-- If `pipeline_id` provided → Export single pipeline
-- If neither provided → Export all pipelines
+### POST `/wp-json/datamachine/v1/pipelines/{pipeline_id}/steps`
 
-**CSV Structure**:
+Add a step.
 
-The exported CSV includes 9 columns: `pipeline_id`, `pipeline_name`, `step_position`, `step_type`, `step_config`, `flow_id`, `flow_name`, `handler`, `settings`
+**Body parameters**:
 
-**Example Requests**:
+- `step_type` (string, required): registered step type.
 
-```bash
-# Export all pipelines
-curl https://example.com/wp-json/datamachine/v1/pipelines?format=csv \
-  -u username:application_password \
-  -o pipelines-export.csv
+### DELETE `/wp-json/datamachine/v1/pipelines/{pipeline_id}/steps/{step_id}`
 
-# Export specific pipelines
-curl "https://example.com/wp-json/datamachine/v1/pipelines?format=csv&ids=5,6,7" \
-  -u username:application_password \
-  -o pipelines-export.csv
+Delete a pipeline step.
 
-# Export single pipeline
-curl https://example.com/wp-json/datamachine/v1/pipelines?format=csv&pipeline_id=5 \
-  -u username:application_password \
-  -o pipeline-5.csv
-```
+### PUT `/wp-json/datamachine/v1/pipelines/{pipeline_id}/steps/reorder`
 
-**Success Response (200 OK)**:
+Reorder steps.
 
-```csv
-pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,handler,settings
-5,Content Pipeline,0,fetch,"{""pipeline_step_id"":""abc-123""}",,,""
-5,Content Pipeline,1,ai,"{""pipeline_step_id"":""def-456""}",,,""
-5,Content Pipeline,0,fetch,"{""pipeline_step_id"":""abc-123""}",42,My Flow,rss,"{""feed_url"":""https://example.com/feed""}"
-```
+**Body parameters**:
 
-**Response Headers**:
+- `step_order` (array, required): objects with `pipeline_step_id` and numeric `execution_order`.
 
-```
-Content-Type: text/csv; charset=utf-8
-Content-Disposition: attachment; filename="pipelines-export-2024-01-02-14-30-00.csv"
-```
+### PATCH `/wp-json/datamachine/v1/pipelines/steps/{pipeline_step_id}/system-prompt`
 
-**Use Cases**:
-- Backup pipeline configurations
-- Share workflows between Data Machine installations
-- Version control pipeline templates
-- Migrate pipelines from development to production
+Update the AI system prompt for a pipeline step.
 
-## CSV Import
+**Body parameters**:
 
-### POST /pipelines (CSV Import Mode)
+- `system_prompt` (string, required): system prompt text.
 
-Import pipelines from CSV format.
+### PUT `/wp-json/datamachine/v1/pipelines/steps/{pipeline_step_id}/config`
 
-**Permission**: `manage_options` capability required
+Upsert AI step configuration. `step_type` and `pipeline_id` are required for `PUT` unless they can be inferred from the step ID.
 
-**Parameters**:
-- `batch_import` (boolean, required): Must be `true` to enable import mode
-- `format` (string, required): Must be `csv` for CSV import
-- `data` (string, required): CSV content to import
+**Body parameters**:
 
-**Import Behavior**:
-- Creates pipelines if they don't exist (matched by name)
-- Adds steps with configuration from CSV
-- Reuses existing pipelines with matching names
-- Returns array of imported pipeline IDs
+- `step_type` (string, required for PUT): currently only `ai` supports this config route.
+- `pipeline_id` (integer, required for PUT): pipeline context.
+- `disabled_tools` (array, optional): disabled tool IDs.
+- `tool_categories` (array, optional): allowed ability categories.
+- `system_prompt` (string, optional): AI system prompt.
 
-**Example Request**:
+### PATCH `/wp-json/datamachine/v1/pipelines/steps/{pipeline_step_id}/config`
 
-```bash
-curl -X POST https://example.com/wp-json/datamachine/v1/pipelines \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{
-    "batch_import": true,
-    "format": "csv",
-    "data": "pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,handler,settings\n5,Content Pipeline,0,fetch,\"{}\",,,\"\"\n5,Content Pipeline,1,ai,\"{}\",,,\"\""
-  }'
-```
+Patch AI step configuration. Only supplied fields are changed.
 
-**Success Response (200 OK)**:
+Accepted fields are `disabled_tools`, `tool_categories`, and `system_prompt`. `provider`, `model`, and `ai_api_key` are not accepted; model/provider resolution comes from the mode settings system.
+
+## Pipeline Flow Routes
+
+### GET `/wp-json/datamachine/v1/pipelines/{pipeline_id}/flows`
+
+List flows attached to a pipeline.
+
+**Success shape**:
 
 ```json
 {
   "success": true,
-  "imported_pipeline_ids": [5, 6, 7],
-  "count": 3,
-  "message": "Successfully imported 3 pipeline(s)"
+  "data": {
+    "pipeline_id": 5,
+    "flows": [],
+    "flow_count": 0,
+    "first_flow_id": null
+  }
 }
 ```
 
-**Error Response (500 Internal Server Error)**:
+## Pipeline Memory Routes
 
-```json
-{
-  "code": "import_failed",
-  "message": "Failed to import pipelines from CSV.",
-  "data": {"status": 500}
-}
-```
+### GET `/wp-json/datamachine/v1/pipelines/{pipeline_id}/memory-files`
 
-**CSV Format Requirements**:
-- Header row required with 9 columns
-- Pipeline rows: Include pipeline structure (empty flow columns)
-- Flow rows: Include flow configuration (populated flow columns)
-- JSON-encoded fields must be properly escaped
-- Steps sorted by execution_order for consistency
+Return configured memory filenames for a pipeline.
 
-**Integration Example (Python)**:
+### POST/PUT/PATCH `/wp-json/datamachine/v1/pipelines/{pipeline_id}/memory-files`
 
-```python
-import requests
-from requests.auth import HTTPBasicAuth
+Replace configured memory filenames.
 
-# Read CSV file
-with open('pipelines-export.csv', 'r') as f:
-    csv_content = f.read()
+**Body parameters**:
 
-# Import to Data Machine
-url = "https://example.com/wp-json/datamachine/v1/pipelines"
-auth = HTTPBasicAuth("username", "application_password")
-payload = {
-    "batch_import": True,
-    "format": "csv",
-    "data": csv_content
-}
-
-response = requests.post(url, json=payload, auth=auth)
-
-if response.status_code == 200:
-    result = response.json()
-    print(f"Imported {result['count']} pipeline(s)")
-    print(f"Pipeline IDs: {result['imported_pipeline_ids']}")
-else:
-    print(f"Import failed: {response.json()['message']}")
-```
-
-## Related Documentation
-
-- Flows Endpoints - Flow instance management
-- Execute Endpoint - Pipeline execution
-- StepTypes Endpoint - Available step types
-- Authentication - Auth methods
-
----
-
-**Base URL**: `/wp-json/datamachine/v1/pipelines`
-**Permission**: `manage_options` capability required
-**Implementation**: `/inc/Api/Pipelines/` directory (Pipelines.php, PipelineSteps.php, PipelineFlows.php)
-**Version**: Directory structure introduced in v0.2.1
+- `memory_files` (array of strings, required): agent memory filenames.


### PR DESCRIPTION
## Summary
- Corrects stale REST endpoint docs for chat, flows, pipelines, auth, and jobs.
- Aligns examples with current route parameters, response envelopes, permissions, and available operations.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Comparing endpoint docs to route implementations, drafting corrections, and preparing the PR text for Chris to review.