### PR TITLE
docs: refresh admin tools documentation

### DIFF
--- a/docs/admin-interface/pipeline-builder.md
+++ b/docs/admin-interface/pipeline-builder.md
@@ -1,224 +1,220 @@
 # Pipeline Builder Interface
 
-React-based interface for creating and managing Pipelines and Flows, backed by the `/wp-json/datamachine/v1/` REST API.
+The Pipelines admin page is a React builder for Data Machine pipelines, flows, flow-step handlers, prompt queues, memory/context files, and the integrated chat sidebar. The current client source lives under `inc/Core/Admin/Pages/Pipelines/assets/react/` and all server operations are routed through `utils/api.js` unless noted.
 
-## Architecture
+## Source Map
 
-**TanStack Query** manages server state (pipelines, flows, handler metadata, chat sessions/messages) with caching + invalidation.
+| Area | Primary files |
+| --- | --- |
+| REST wrapper | `utils/api.js` |
+| Pipeline data | `queries/pipelines.js`, `components/pipelines/` |
+| Flow data | `queries/flows.js`, `components/flows/` |
+| Queue data | `queries/queue.js`, `components/modals/FlowQueueModal.jsx` |
+| Handler data | `queries/handlers.js`, `components/modals/HandlerSettingsModal.jsx`, `components/flows/FlowStepHandler.jsx` |
+| Config data | `queries/config.js`, `components/modals/StepSelectionModal.jsx`, `components/modals/HandlerSelectionModal.jsx` |
+| UI state | `stores/uiStore.js`, `components/shared/ModalSwitch.jsx`, `components/shared/ModalManager.jsx` |
+| Chat sidebar | `components/chat/`, `queries/chat.js` |
 
-**Zustand UI store** (`inc/Core/Admin/Pages/Pipelines/assets/react/stores/uiStore.js`) manages client UI state and persists a small subset to `localStorage`:
+## State Model
+
+**TanStack Query** owns server state and cache invalidation for pipelines, flows, handlers, queues, config, memory files, and chat data.
+
+**Zustand** owns local UI state in `stores/uiStore.js`. The persisted keys are intentionally small:
+
 - `selectedPipelineId`
 - `isChatOpen`
 - `chatSessionId`
 
-## Pipeline Management
+Modal state (`activeModal`, `modalData`) stays in the store but is not persisted.
 
-- **Pipeline selection** is stored as `selectedPipelineId` in the Zustand UI store.
-- **Pipeline CRUD** uses REST endpoints via `inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js` (wrapper around `@wordpress/api-fetch` + nonce).
+## Selected Agent Payload
 
-## Flow Management
+Pipeline and flow creation include the selected admin agent when one is active. `utils/api.js` reads `selectedAgentId` from `@shared/stores/agentStore` and adds `{ agent_id: selectedAgentId }` through `getAgentPayload()`.
 
-Flows are created under a pipeline and displayed with pagination.
+Current client mutations that include the selected agent payload:
 
-## Step Configuration
+- `createPipeline(name)` sends `POST /pipelines` with `pipeline_name` and optional `agent_id`.
+- `createFlow(pipelineId, flowName)` sends `POST /flows` with `pipeline_id`, `flow_name`, and optional `agent_id`.
 
-Step and handler configuration is driven by React modals and handler schemas from the REST API.
+Updates, deletes, queue changes, handler changes, and file operations do not add the selected agent payload in the client wrapper.
 
-- **Handler selection** uses `HandlerSelectionModal.jsx`.
-- **Handler settings** uses `HandlerSettingsModal.jsx` (not a PHP template). The modal renders fields from the handler schema and submits updates via the flow update mutation.
-- **OAuth connection** is surfaced through an OAuth modal (`OAuthAuthenticationModal.jsx`) and popup handler components in `inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/oauth/`.
+## Pipeline Operations
 
-## Integrated Chat Sidebar
+| Operation | Client function | Endpoint |
+| --- | --- | --- |
+| List pipelines | `fetchPipelines(null, { perPage, offset, includeFlows, search })` | `GET /pipelines` |
+| Fetch one pipeline | `fetchPipelines(pipelineId, { includeFlows })` | `GET /pipelines?pipeline_id=...` |
+| Create pipeline | `createPipeline(name)` | `POST /pipelines` |
+| Rename pipeline | `updatePipelineTitle(pipelineId, name)` | `PATCH /pipelines/{pipeline_id}` |
+| Delete pipeline | `deletePipeline(pipelineId)` | `DELETE /pipelines/{pipeline_id}` |
+| Export pipelines | `exportPipelines(pipelineIds)` | `GET /pipelines?format=csv&ids=...` |
+| Import pipelines | `importPipelines(csvContent)` | `POST /pipelines` with `batch_import`, `format=csv`, `data` |
 
-The Pipelines page includes a collapsible chat sidebar whose open/closed state, selected pipeline context, and active chat session are tracked in the Zustand UI store.
+List mode defaults to lightweight responses with `include_flows=false`; selected pipeline flows are loaded separately.
 
-## REST API integration
+## Pipeline Step Operations
 
-All Pipelines page operations are REST-driven through the Pipelines page API wrapper (`inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js`), including:
-- Pipelines: `GET /pipelines`, `POST /pipelines`, `PATCH /pipelines/{pipeline_id}`, `DELETE /pipelines/{pipeline_id}`
-- Pipeline steps: `POST /pipelines/{pipeline_id}/steps`, `DELETE /pipelines/{pipeline_id}/steps/{step_id}`, `PUT /pipelines/{pipeline_id}/steps/reorder`
-- Flows: `GET /flows?pipeline_id=...`, `POST /flows`, `GET /flows/{flow_id}`
+| Operation | Client function | Endpoint |
+| --- | --- | --- |
+| Add step | `addPipelineStep(pipelineId, stepType, executionOrder)` | `POST /pipelines/{pipeline_id}/steps` |
+| Delete step | `deletePipelineStep(pipelineId, stepId)` | `DELETE /pipelines/{pipeline_id}/steps/{step_id}` |
+| Reorder steps | `reorderPipelineSteps(pipelineId, steps)` | `PUT /pipelines/{pipeline_id}/steps/reorder` |
+| Update AI step system prompt | `updateSystemPrompt(stepId, prompt, stepType, pipelineId)` | `PUT /pipelines/steps/{step_id}/config` |
 
-(Endpoint surface evolves; treat this list as a starting point and confirm against `inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js` and the PHP REST controllers.)
+`updateSystemPrompt()` only sends `step_type`, `pipeline_id`, and `system_prompt`; provider, model, and tool policy are resolved by the current mode system rather than the pipeline builder client.
 
-**Performance note**: client caching and background refetching are provided by TanStack Query; UI-only state persistence is via Zustand `persist` to `localStorage`.
+## Flow Operations
 
-### Key React files
+| Operation | Client function | Endpoint |
+| --- | --- | --- |
+| List flows for pipeline | `fetchFlows(pipelineId, { page, perPage, outputMode })` | `GET /flows` |
+| Fetch one flow | `fetchFlow(flowId)` | `GET /flows/{flow_id}` |
+| Create flow | `createFlow(pipelineId, flowName)` | `POST /flows` |
+| Rename flow | `updateFlowTitle(flowId, name)` | `PATCH /flows/{flow_id}` |
+| Delete flow | `deleteFlow(flowId)` | `DELETE /flows/{flow_id}` |
+| Duplicate flow | `duplicateFlow(flowId)` | `POST /flows/{flow_id}/duplicate` |
+| Run flow now | `runFlow(flowId)` | `POST /execute` with `flow_id` |
+| Update schedule | `updateFlowSchedule(flowId, schedulingConfig)` | `PATCH /flows/{flow_id}` |
 
-- `inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx`
-- `inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalManager.jsx`
-- `inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/HandlerSettingsModal.jsx`
-- `inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/OAuthAuthenticationModal.jsx`
-- `inc/Core/Admin/Pages/Pipelines/assets/react/components/chat/`
-- `FlowCard` - Flow instance display with scheduling and status
-- `PipelineStepCard` - Individual pipeline step cards with handler info
-- `FlowStepCard` - Configured flow step display with settings
-- `EmptyStepCard` - Add new step interface
-- `EmptyFlowCard` - Create new flow interface
+Flow duplication invalidates the selected pipeline's flow query. It copies via the REST `duplicate` endpoint; the client does not build the duplicate payload itself.
 
-**Modal Components:**
+## Pagination
 
-- `ConfigureStepModal` - AI configuration, system prompts, and tool selection
-- `HandlerSettingsModal` - Handler-specific configuration with dynamic field rendering
-- `OAuthAuthenticationModal` - OAuth provider authentication with popup handling
-- `StepSelectionModal` - Step type selection interface
-- `HandlerSelectionModal` - Handler selection with capability display
-- `FlowScheduleModal` - Flow scheduling configuration
-- `ImportExportModal` - Pipeline import/export operations with CSV handling
+Pipeline lists use offset pagination through `fetchPipelines()` with `per_page` and `offset`.
 
-**Shared Components:**
+Flow lists use 1-indexed page state in React and convert it to REST offset in `fetchFlows()`:
 
-- `LoadingSpinner` - Loading state visualization
-- `StepTypeIcon` - Step type icons with consistent styling
-- `DataFlowArrow` - Visual data flow indicators between steps
-- `PipelineSelector` - Pipeline selection dropdown with preferences
-- `ModalManager` - Centralized modal rendering logic (@since v0.2.3)
-- `ModalSwitch` - Centralized modal routing component (@since v0.2.5)
-
-**Specialized Sub-Components:**
-
-- OAuth components: `ConnectionStatus`, `AccountDetails`, `APIConfigForm`, `OAuthPopupHandler`
-- Files handler components: `FilesHandlerSettings`, `FileUploadInterface`, `FileStatusTable`, `AutoCleanupOption`
-- Configure step components: `AIToolsSelector`, `ToolCheckbox`, `ConfigurationWarning`
-- Import/export components: `ImportTab`, `ExportTab`, `CSVDropzone`, `PipelineCheckboxTable`
-- File management components: `FileUploadDropzone`, `FileStatusTable`, `AutoCleanupOption`
-
-### State Management
-
-**Server state (TanStack Query)**
-
-Pipelines/Flows/Handlers/Chat are fetched and cached via query hooks under `inc/Core/Admin/Pages/Pipelines/assets/react/queries/`.
-
-**Client UI state (Zustand)**
-
-The UI store in `inc/Core/Admin/Pages/Pipelines/assets/react/stores/uiStore.js` is intentionally small and persists only:
-- `selectedPipelineId`
-- `isChatOpen`
-- `chatSessionId`
-
-Modal state is also held in the UI store (`activeModal`, `modalData`) but is not persisted.
-
-### REST API Integration
-
-The Pipelines UI calls REST endpoints through `inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js` (a wrapper around `@wordpress/api-fetch` that reads the nonce/namespace from `window.dataMachineConfig`).
-
-For the authoritative list of endpoints used by the UI, refer to `inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js` and the PHP REST controllers under `inc/Api/`.
-
-### Benefits of React Architecture
-
-**User Experience:**
-- Zero page reloads for all operations
-- Instant visual feedback
-- Optimistic UI updates
-- Real-time status updates
-- Modern, responsive interface
-
-**Developer Experience:**
-- Component reusability
-- Clear separation of concerns
-- Testable code structure
-- Maintainable state management
-- Type-safe operations (via PropTypes)
-
-**Performance:**
-- Client-side caching
-- Efficient re-renders via React optimization
-- Lazy loading of modal content
-- Reduced server load (REST API vs repeated page loads)
-
-**Extensibility:**
-- Easy to add new features
-- Filter-based handler discovery
-- Dynamic field rendering
-- Plugin-friendly architecture
-
-### Migration Impact
-
-**Eliminated Code:**
-
-
-**Simplified Maintenance:**
-- Single responsibility components
-- Declarative UI rendering
-- Centralized state management
-- Consistent error handling patterns
-
-## Advanced Architecture Patterns
-
-### Handler API Helpers
-
-Handler-related server state is fetched through TanStack Query hooks under `inc/Core/Admin/Pages/Pipelines/assets/react/queries/` and shared utility helpers under `inc/Core/Admin/Pages/Pipelines/assets/react/utils/`:
-
-- `inc/Core/Admin/Pages/Pipelines/assets/react/queries/handlers.js` - handler metadata queries
-- `inc/Core/Admin/Pages/Pipelines/assets/react/utils/handlerSettings.js` - field normalization and settings helpers
-
-### Service Layer Architecture
-
-**Handler queries** (`inc/Core/Admin/Pages/Pipelines/assets/react/queries/handlers.js`):
-- Query abstraction for handler-related API operations
-- Separates API communication from component logic
-- Provides reusable handler operation methods
-- Centralizes error handling for handler operations
-
-**Benefits**:
-- Clear separation between API calls, query state, and UI components
-- Consistent cache invalidation through TanStack Query
-- Reusable field-normalization helpers independent of modal rendering
-
-### Modal Management System
-
-**ModalSwitch** (`inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalSwitch.jsx`):
-- Centralized modal rendering component
-- Routes modal types to appropriate modal components
-- Replaces scattered conditional modal logic
-- Single source of truth for modal rendering
-
-**Pattern**:
-```javascript
-// Before: Multiple conditional modal renders scattered in components
-{showHandlerModal && <HandlerSettingsModal />}
-{showConfigModal && <ConfigureStepModal />}
-{showOAuthModal && <OAuthAuthenticationModal />}
-
-// After: Single centralized modal switch
-<ModalSwitch activeModal={activeModal} />
+```js
+offset = ( page - 1 ) * perPage;
 ```
 
-**Benefits**:
-- Reduced code duplication
-- Easier to add new modal types
-- Centralized modal state management
-- Consistent modal behavior
+`FlowsSection.jsx` renders `@shared/components/Pagination` with `page`, `perPage`, `total`, and `onPageChange`. The default flow page size is 20.
 
-### Component Directory Structure
+## Flow Step Configuration
 
+Flow steps render through `FlowStepCard.jsx`. Step type metadata comes from `GET /step-types` via `useStepTypes()`.
+
+The card distinguishes these cases:
+
+- AI steps show a queueable user-message field.
+- Handler-backed steps show handler badges and configure controls.
+- Non-handler step types render inline fields through `InlineStepConfig` and the handler details API fallback.
+
+`updateFlowStepConfig(flowStepId, config)` sends partial config patches to `PATCH /flows/steps/{flow_step_id}/config`.
+
+## Queue CRUD And Modes
+
+Prompt queues are flow-step scoped. `FlowQueueModal.jsx` and `queries/queue.js` expose these operations:
+
+| Operation | Client function | Endpoint |
+| --- | --- | --- |
+| Read queue | `fetchFlowQueue(flowId, flowStepId)` | `GET /flows/{flow_id}/queue?flow_step_id=...` |
+| Add prompt(s) | `addToFlowQueue(flowId, flowStepId, prompts)` | `POST /flows/{flow_id}/queue` |
+| Clear queue | `clearFlowQueue(flowId, flowStepId)` | `DELETE /flows/{flow_id}/queue?flow_step_id=...` |
+| Remove item | `removeFromFlowQueue(flowId, flowStepId, index)` | `DELETE /flows/{flow_id}/queue/{index}?flow_step_id=...` |
+| Update item | `updateFlowQueueItem(flowId, flowStepId, index, prompt)` | `PUT /flows/{flow_id}/queue/{index}` |
+| Update mode | `updateFlowQueueMode(flowId, flowStepId, mode)` | `PUT /flows/{flow_id}/queue/mode` |
+
+Queue modes are:
+
+- `static`: peek the head prompt on each run without mutating the queue.
+- `drain`: pop the head prompt on each run and discard it.
+- `loop`: pop the head prompt on each run and append it to the tail.
+
+The queue modal supports adding text, removing individual items, clearing all items after confirmation, and changing mode. It documents FIFO behavior in the UI.
+
+## Handler Details And Editing
+
+Handler discovery and details use:
+
+- `getHandlers(stepType)` -> `GET /handlers`, optionally filtered by `step_type`.
+- `fetchHandlerDetails(handlerSlug)` -> `GET /handlers/{handler_slug}`.
+
+`HandlerSettingsModal.jsx` receives full handler metadata and the selected handler details as props. It renders schema fields through `HandlerSettingField`, normalizes/sanitizes values through `useHandlerModel()`, and saves through `useUpdateFlowHandler()`.
+
+The save path calls `updateFlowHandler(flowStepId, handlerSlug, settings, pipelineId, stepType, flowConfig, pipelineStepConfig)` and sends:
+
+```json
+{
+  "handler_slug": "example_handler",
+  "pipeline_id": 123,
+  "step_type": "fetch",
+  "flow_config": {},
+  "pipeline_step": {},
+  "settings": {}
+}
 ```
-assets/react/
-├── components/           # UI components and modals
-├── queries/              # TanStack Query hooks
-├── stores/               # Zustand UI state
-└── utils/                # API and field helpers
-```
 
-### Pattern Benefits
+The endpoint is `PUT /flows/steps/{flow_step_id}/handler`.
 
-**Query/UI Separation**:
-- Server state isolated in query hooks
-- UI state isolated in the Zustand store
-- Field normalization isolated in utility helpers
+Handler settings can be enriched by plugins through these client-side filters:
 
-**Centralized Modal Management**:
-- Single modal rendering location
-- Reduced conditional logic in components
-- Easier modal state debugging
+- `datamachine.handlerSettings.init`
+- `datamachine.handlerSettings.fieldChange`
 
-**Custom Hooks**:
-- Reusable state management logic
-- Consistent data fetching patterns
-- Simplified component logic
+OAuth-capable handlers surface connection state in the settings modal and open `OAuthAuthenticationModal.jsx` for connection flows.
 
-**Implemented Features:**
-React architecture provides modern features including:
-- Drag-and-drop step reordering (implemented)
-- Advanced validation UI (easy to implement)
-- Keyboard shortcuts (event-based)
+## Multi-Handler Editing
+
+Multi-handler steps are driven by step type metadata where `multi_handler === true`.
+
+`FlowStepCard.jsx` derives:
+
+- `handler_slugs` for the ordered handler list.
+- `handler_configs` for per-handler config.
+- `handler_settings_displays` for per-handler display rows.
+
+`FlowStepHandler.jsx` renders one badge/configure button per handler when multiple handlers are present and shows a `+` badge when another handler can be added.
+
+`HandlerSettingsModal.jsx` supports per-handler editing by receiving `handlerSlugs` and `onRemoveHandler`. The destructive remove button is only shown when more than one handler is attached.
+
+Add/remove multi-handler operations use the WordPress Abilities API directly instead of the page REST client:
+
+| Operation | Client function | Ability endpoint | Payload |
+| --- | --- | --- | --- |
+| Add handler | `addFlowHandler(flowStepId, handlerSlug, settings)` | `POST /wp-abilities/v1/execute/datamachine/update-flow-step` | `flow_step_id`, `add_handler`, `add_handler_config` |
+| Remove handler | `removeFlowHandler(flowStepId, handlerSlug)` | `POST /wp-abilities/v1/execute/datamachine/update-flow-step` | `flow_step_id`, `remove_handler` |
+
+## Memory, Context, And Agent Files
+
+The builder exposes three file surfaces:
+
+| Surface | Client functions | Endpoints |
+| --- | --- | --- |
+| Pipeline context files | `fetchContextFiles`, `uploadContextFile`, `deleteContextFile` | `GET /files`, `POST /files`, `DELETE /files/{filename}` |
+| Pipeline memory files | `fetchPipelineMemoryFiles`, `updatePipelineMemoryFiles` | `GET/PUT /pipelines/{pipeline_id}/memory-files` |
+| Flow memory files | `fetchFlowMemoryFiles`, `updateFlowMemoryFiles` | `GET/PUT /flows/{flow_id}/memory-files` |
+| Available agent files | `fetchAgentFiles` | `GET /files/agent` |
+
+Context files are uploaded against a pipeline. Memory files are selected by filename at either pipeline or flow scope. Agent files are read as an inventory for the selector UI.
+
+## Handler And Tool Inventory Endpoints
+
+The builder also reads current configuration inventories:
+
+- `getStepTypes()` -> `GET /step-types`.
+- `getTools(context)` -> `GET /tools`, optionally filtered by `context` (`pipeline`, `chat`, or `system`).
+- `getHandlers(stepType)` -> `GET /handlers`, optionally filtered by step type.
+- `getSchedulingIntervals()` -> `GET /settings/scheduling-intervals`.
+
+## Current Modal Components
+
+The modal system is centralized through `ModalSwitch.jsx` and `ModalManager.jsx`. Current modal components include:
+
+- `ContextFilesModal.jsx`
+- `FlowMemoryFilesModal.jsx`
+- `FlowQueueModal.jsx`
+- `FlowScheduleModal.jsx`
+- `HandlerSelectionModal.jsx`
+- `HandlerSettingsModal.jsx`
+- `ImportExportModal.jsx`
+- `MemoryFilesModal.jsx`
+- `OAuthAuthenticationModal.jsx`
+- `StepSelectionModal.jsx`
+
+## Operational Notes
+
+- The builder is REST-first and avoids full page reloads.
+- Query hooks update or invalidate the smallest practical cache slice after mutations.
+- Flow rows are paginated independently of pipeline rows to keep large admin installs usable.
+- Handler UI is schema-driven; handler-specific rendering should be added through field metadata, handler models, or the handler settings filters before adding new bespoke modal branches.

--- a/docs/ai-tools/agent-daily-memory.md
+++ b/docs/ai-tools/agent-daily-memory.md
@@ -1,0 +1,19 @@
+# Agent Daily Memory
+
+`agent_daily_memory` manages daily memory journal files at `daily/YYYY/MM/DD.md`.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat, pipeline policy |
+| Mutation risk | Low mutation |
+| Registered in | `ToolServiceProvider.php` via `AgentDailyMemory` |
+| Backing abilities | `datamachine/daily-memory-read`, `datamachine/daily-memory-write`, `datamachine/daily-memory-list`, `datamachine/search-daily-memory` |
+
+## Actions
+
+- `read`: read a specific daily file.
+- `write`: append or replace daily notes.
+- `list`: list available daily files.
+- `search`: search daily memory over an optional date range.
+
+Use daily memory for temporal work logs and session activity. Use `agent_memory` for durable facts and preferences.

--- a/docs/ai-tools/agent-memory.md
+++ b/docs/ai-tools/agent-memory.md
@@ -1,0 +1,18 @@
+# Agent Memory
+
+`agent_memory` reads and updates agent markdown files such as `MEMORY.md`, `SOUL.md`, and `USER.md`.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat, pipeline policy |
+| Mutation risk | Low mutation |
+| Registered in | `ToolServiceProvider.php` via `AgentMemory` |
+| Backing abilities | `datamachine/get-agent-memory`, `datamachine/update-agent-memory`, `datamachine/list-agent-memory-sections` |
+
+## Actions
+
+- `list_sections`: list `##` sections in the target file.
+- `get`: read a full file or a section.
+- `update`: write a section with `set` or `append` mode.
+
+Use this for durable, cross-session knowledge. For session logs and time-bound events, use `agent_daily_memory`.

--- a/docs/ai-tools/amazon-affiliate-link.md
+++ b/docs/ai-tools/amazon-affiliate-link.md
@@ -1,0 +1,16 @@
+# Amazon Affiliate Link
+
+`amazon_affiliate_link` searches Amazon products and returns an affiliate link, product title, and thumbnail.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat, pipeline |
+| Mutation risk | Read-only |
+| Registered in | `ToolServiceProvider.php` via `AmazonAffiliateLink` |
+| Access | Admin |
+
+## Inputs
+
+- `query`: specific product search query.
+
+Use this only when a product reference is genuinely useful to the reader.

--- a/docs/ai-tools/assign-taxonomy-term.md
+++ b/docs/ai-tools/assign-taxonomy-term.md
@@ -1,0 +1,19 @@
+# Assign Taxonomy Term
+
+`assign_taxonomy_term` assigns a taxonomy term to one or more posts.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Content mutation |
+| Registered in | `ToolServiceProvider.php` via `AssignTaxonomyTerm` |
+| Access | Editor |
+
+## Inputs
+
+- `term`: term ID, name, or slug.
+- `taxonomy`: taxonomy slug.
+- `post_ids`: post IDs to update.
+- `append`: `true` to add to existing terms, `false` to replace.
+
+Use `search_taxonomy_terms` first when the exact term is uncertain.

--- a/docs/ai-tools/copy-flow.md
+++ b/docs/ai-tools/copy-flow.md
@@ -1,0 +1,20 @@
+# Copy Flow
+
+`copy_flow` duplicates a flow to the same pipeline or to another compatible pipeline.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Config mutation |
+| Registered in | `ToolServiceProvider.php` via `CopyFlow` |
+| Backing ability | `datamachine/duplicate-flow` |
+
+## Inputs
+
+- `flow_id`: source flow ID.
+- `destination_pipeline_id`: optional target pipeline.
+- `flow_name`: optional new name.
+- `scheduling_config`: optional schedule override.
+- `step_configs`: optional handler/message overrides by step type or execution order.
+
+Cross-pipeline copies require compatible step structures.

--- a/docs/ai-tools/create-taxonomy-term.md
+++ b/docs/ai-tools/create-taxonomy-term.md
@@ -1,0 +1,19 @@
+# Create Taxonomy Term
+
+`create_taxonomy_term` creates a taxonomy term if it does not already exist.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Content mutation |
+| Registered in | `ToolServiceProvider.php` via `CreateTaxonomyTerm` |
+| Access | Editor |
+
+## Inputs
+
+- `taxonomy`: taxonomy slug.
+- `name`: term name.
+- `parent`: optional parent term for hierarchical taxonomies.
+- `description`: optional term description.
+
+Use during flow setup when required terms are missing.

--- a/docs/ai-tools/delete-file.md
+++ b/docs/ai-tools/delete-file.md
@@ -1,0 +1,17 @@
+# Delete File
+
+`delete_file` deletes an uploaded flow-step file.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Destructive |
+| Registered in | `ToolServiceProvider.php` via `DeleteFile` |
+| Backing ability | `datamachine/delete-flow-file` |
+
+## Inputs
+
+- `filename`: file to delete.
+- `flow_step_id`: flow-step scope for the file.
+
+Use only when the file is no longer needed by the flow.

--- a/docs/ai-tools/delete-flow.md
+++ b/docs/ai-tools/delete-flow.md
@@ -1,0 +1,16 @@
+# Delete Flow
+
+`delete_flow` deletes a flow instance.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Destructive |
+| Registered in | `ToolServiceProvider.php` via `DeleteFlow` |
+| Backing ability | `datamachine/delete-flow` |
+
+## Inputs
+
+- `flow_id`: flow to delete.
+
+Use only after confirming the flow is no longer needed.

--- a/docs/ai-tools/delete-pipeline-step.md
+++ b/docs/ai-tools/delete-pipeline-step.md
@@ -1,0 +1,17 @@
+# Delete Pipeline Step
+
+`delete_pipeline_step` removes a step from a pipeline and cascades removal to all flows on that pipeline.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Destructive |
+| Registered in | `ToolServiceProvider.php` via `DeletePipelineStep` |
+| Backing ability | `datamachine/delete-pipeline-step` |
+
+## Inputs
+
+- `pipeline_id`: pipeline containing the step.
+- `pipeline_step_id`: step to remove.
+
+Use when simplifying or restructuring a workflow.

--- a/docs/ai-tools/delete-pipeline.md
+++ b/docs/ai-tools/delete-pipeline.md
@@ -1,0 +1,16 @@
+# Delete Pipeline
+
+`delete_pipeline` deletes a pipeline and all associated flows.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Destructive |
+| Registered in | `ToolServiceProvider.php` via `DeletePipeline` |
+| Backing ability | `datamachine/delete-pipeline` |
+
+## Inputs
+
+- `pipeline_id`: pipeline to delete.
+
+This removes durable workflow configuration. Use only with explicit intent.

--- a/docs/ai-tools/get-handler-defaults.md
+++ b/docs/ai-tools/get-handler-defaults.md
@@ -1,0 +1,16 @@
+# Get Handler Defaults
+
+`get_handler_defaults` reads site-wide handler defaults.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Read-only |
+| Registered in | `ToolServiceProvider.php` via `GetHandlerDefaults` |
+| Backing abilities | `datamachine/get-handler-site-defaults`, `datamachine/get-handlers`, `datamachine/get-handler-config-fields` |
+
+## Inputs
+
+- `handler_slug`: optional handler slug. Omit to read defaults for all handlers.
+
+Use before configuring flows to follow established site defaults.

--- a/docs/ai-tools/image-generation.md
+++ b/docs/ai-tools/image-generation.md
@@ -1,0 +1,19 @@
+# Image Generation
+
+`image_generation` creates an image-generation job through `wp-ai-client`, then sideloads the result as WordPress media.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat, pipeline |
+| Mutation risk | Low mutation |
+| Registered in | `ToolServiceProvider.php` via `ImageGeneration` |
+| Backing ability | `datamachine/generate-image` |
+
+## Inputs
+
+- `prompt`: detailed image prompt.
+- `provider`: optional `wp-ai-client` provider override.
+- `model`: optional image model override.
+- `aspect_ratio`: `1:1`, `3:4`, `4:3`, `9:16`, or `16:9`.
+
+Default aspect ratio is `3:4` for portrait blog/Pinterest images.

--- a/docs/ai-tools/internal-link-audit.md
+++ b/docs/ai-tools/internal-link-audit.md
@@ -1,0 +1,19 @@
+# Internal Link Audit
+
+`internal_link_audit` audits WordPress links and cached link graph data.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat, pipeline |
+| Mutation risk | Low mutation |
+| Registered in | `ToolServiceProvider.php` via `InternalLinkAudit` |
+| Backing abilities | `datamachine/audit-internal-links`, `datamachine/get-orphaned-posts`, `datamachine/get-backlinks`, `datamachine/check-broken-links` |
+
+## Actions
+
+- `audit`: scan content and cache the link graph.
+- `orphans`: list posts with no inbound links.
+- `backlinks`: list posts linking to a target post ID.
+- `broken`: check internal, external, or all links for broken URLs.
+
+Run `audit` before the other actions when current link data matters.

--- a/docs/ai-tools/list-flows.md
+++ b/docs/ai-tools/list-flows.md
@@ -1,0 +1,19 @@
+# List Flows
+
+`list_flows` lists flows with optional filters.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Read-only |
+| Registered in | `ToolServiceProvider.php` via `ListFlows` |
+| Backing ability | `datamachine/get-flows` |
+
+## Inputs
+
+- `pipeline_id`: optional pipeline filter.
+- `handler_slug`: optional filter for flows using a handler.
+- `per_page`: page size, default `20`, max `100`.
+- `offset`: pagination offset.
+
+Use for flow discovery and admin inventory.

--- a/docs/ai-tools/manage-jobs.md
+++ b/docs/ai-tools/manage-jobs.md
@@ -1,0 +1,21 @@
+# Manage Jobs
+
+`manage_jobs` manages Data Machine jobs.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Destructive |
+| Registered in | `ToolServiceProvider.php` via `ManageJobs` |
+| Backing abilities | `datamachine/get-jobs`, `datamachine/get-jobs-summary`, `datamachine/delete-jobs`, `datamachine/fail-job`, `datamachine/retry-job`, `datamachine/recover-stuck-jobs` |
+
+## Actions
+
+- `list`: list jobs with status, flow, and pipeline filters.
+- `summary`: count jobs by status.
+- `delete`: delete all or failed jobs.
+- `fail`: manually fail a job.
+- `retry`: retry a failed job.
+- `recover`: recover stuck processing jobs.
+
+Use read actions first before destructive job operations.

--- a/docs/ai-tools/manage-logs.md
+++ b/docs/ai-tools/manage-logs.md
@@ -1,0 +1,17 @@
+# Manage Logs
+
+`manage_logs` clears Data Machine logs or reads log metadata.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Destructive |
+| Registered in | `ToolServiceProvider.php` via `ManageLogs` |
+| Backing abilities | `datamachine/clear-logs`, `datamachine/get-log-metadata` |
+
+## Actions
+
+- `get_metadata`: read log counts and date ranges.
+- `clear`: delete logs for one agent or all agents.
+
+Use `read_logs` for log inspection before clearing.

--- a/docs/ai-tools/manage-queue.md
+++ b/docs/ai-tools/manage-queue.md
@@ -1,0 +1,16 @@
+# Manage Queue
+
+`manage_queue` manages prompt queues for flow steps.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Config mutation |
+| Registered in | `ToolServiceProvider.php` via `ManageQueue` |
+| Backing abilities | `datamachine/queue-add`, `datamachine/queue-list`, `datamachine/queue-clear`, `datamachine/queue-remove`, `datamachine/queue-update`, `datamachine/queue-move`, `datamachine/queue-mode` |
+
+## Actions
+
+- `add`, `list`, `clear`, `remove`, `update`, `move`, `mode`.
+
+All actions require `flow_id` and `flow_step_id`. Queue modes are `static`, `drain`, and `loop`.

--- a/docs/ai-tools/merge-taxonomy-terms.md
+++ b/docs/ai-tools/merge-taxonomy-terms.md
@@ -1,0 +1,19 @@
+# Merge Taxonomy Terms
+
+`merge_taxonomy_terms` consolidates duplicate taxonomy terms.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Destructive |
+| Registered in | `ToolServiceProvider.php` via `MergeTaxonomyTerms` |
+| Access | Editor |
+
+## Inputs
+
+- `source_term`: term ID, name, or slug to merge from and delete.
+- `target_term`: term ID, name, or slug to keep.
+- `taxonomy`: taxonomy slug.
+- `merge_meta`: whether to fill empty target meta from source meta.
+
+The tool reassigns posts from source to target before deleting the source term.

--- a/docs/ai-tools/queue-validator.md
+++ b/docs/ai-tools/queue-validator.md
@@ -1,0 +1,19 @@
+# Queue Validator
+
+`queue_validator` checks whether a topic already exists in published content or a Data Machine queue.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Read-only |
+| Registered in | `ToolServiceProvider.php` via `QueueValidator` |
+| Access | Admin |
+
+## Inputs
+
+- `topic`: topic or title to validate.
+- `post_type`: WordPress post type to check.
+- `flow_id` and `flow_step_id`: optional queue scope.
+- `threshold`: Jaccard similarity threshold, default `0.65`.
+
+Use before adding new content prompts to avoid duplicate work.

--- a/docs/ai-tools/read-logs.md
+++ b/docs/ai-tools/read-logs.md
@@ -1,0 +1,19 @@
+# Read Logs
+
+`read_logs` reads Data Machine logs for troubleshooting.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Read-only |
+| Registered in | `ToolServiceProvider.php` via `ReadLogs` |
+| Backing ability | `datamachine/read-logs` |
+
+## Inputs
+
+- `agent_id`: optional agent scope.
+- `mode`: `recent` or `full`.
+- `limit`: maximum recent entries.
+- `job_id`, `pipeline_id`, `flow_id`: optional filters combined with AND logic.
+
+Use for execution audits and failure diagnosis.

--- a/docs/ai-tools/reorder-pipeline-steps.md
+++ b/docs/ai-tools/reorder-pipeline-steps.md
@@ -1,0 +1,17 @@
+# Reorder Pipeline Steps
+
+`reorder_pipeline_steps` changes the execution order of steps in a pipeline.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Config mutation |
+| Registered in | `ToolServiceProvider.php` via `ReorderPipelineSteps` |
+| Backing ability | `datamachine/reorder-pipeline-steps` |
+
+## Inputs
+
+- `pipeline_id`: pipeline to update.
+- `step_order`: array of `{ pipeline_step_id, execution_order }` objects.
+
+Use after adding/removing steps or when changing workflow order.

--- a/docs/ai-tools/search-taxonomy-terms.md
+++ b/docs/ai-tools/search-taxonomy-terms.md
@@ -1,0 +1,18 @@
+# Search Taxonomy Terms
+
+`search_taxonomy_terms` searches existing taxonomy terms.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Read-only |
+| Registered in | `ToolServiceProvider.php` via `SearchTaxonomyTerms` |
+| Access | Editor |
+
+## Inputs
+
+- `taxonomy`: taxonomy slug.
+- `search`: optional partial name filter.
+- `limit`: maximum terms to return, default `20`, max `100`.
+
+Use before creating, updating, assigning, or merging terms.

--- a/docs/ai-tools/send-ping.md
+++ b/docs/ai-tools/send-ping.md
@@ -1,0 +1,19 @@
+# Send Ping
+
+`send_ping` sends a webhook ping to one or more URLs.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Low mutation |
+| Registered in | `ToolServiceProvider.php` via `SendPing` |
+| Backing ability | `datamachine/agent-call` |
+
+## Inputs
+
+- `url`: one URL or newline-separated URLs.
+- `prompt`: optional instructions for the receiving agent.
+- `flow_id`: optional flow context.
+- `pipeline_id`: optional pipeline context.
+
+Use for external agent orchestration and webhook notifications.

--- a/docs/ai-tools/set-handler-defaults.md
+++ b/docs/ai-tools/set-handler-defaults.md
@@ -1,0 +1,17 @@
+# Set Handler Defaults
+
+`set_handler_defaults` updates site-wide default configuration for a handler.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Config mutation |
+| Registered in | `ToolServiceProvider.php` via `SetHandlerDefaults` |
+| Backing ability | `datamachine/update-handler-defaults` |
+
+## Inputs
+
+- `handler_slug`: handler to update.
+- `defaults`: key/value handler configuration defaults.
+
+Use to standardize configuration for future flow setup.

--- a/docs/ai-tools/system-health-check.md
+++ b/docs/ai-tools/system-health-check.md
@@ -1,0 +1,17 @@
+# System Health Check
+
+`system_health_check` runs unified diagnostics for Data Machine and extensions.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat |
+| Mutation risk | Read-only |
+| Registered in | `ToolServiceProvider.php` via `SystemHealthCheck` |
+| Backing ability | `datamachine/system-health-check` |
+
+## Inputs
+
+- `types`: optional check type IDs, or `all`.
+- `options`: type-specific options such as scope, limit, or URL.
+
+Use for proactive health checks and support triage.

--- a/docs/ai-tools/tools-overview.md
+++ b/docs/ai-tools/tools-overview.md
@@ -1,835 +1,148 @@
 # AI Tools Overview
 
-AI tools provide capabilities to AI agents for interacting with external services, processing data, and performing research tasks. Data Machine supports both global tools and handler-specific tools.
+AI tools are registered by `inc/Engine/AI/Tools/ToolServiceProvider.php` into the unified Data Machine tool registry. Tools declare where they can run (`chat`, `pipeline`, or pipeline-policy mode) and the ability or access level required to execute them.
 
-## Tool Categories
+## Registered Tool Inventory
 
-### Global Tools (Universal)
+Mutation risk means what the tool can change when called successfully:
 
-Available to all AI agents (pipeline + chat + standalone) via `datamachine_global_tools` filter:
+- **Read-only**: reads data or runs diagnostics without changing site content/config.
+- **Low mutation**: writes agent memory, logs, queues, generated media, or external notifications.
+- **Config mutation**: changes pipeline, flow, handler, schedule, auth, or default configuration.
+- **Content mutation**: creates, updates, assigns, merges, or deletes WordPress content/taxonomy/files.
+- **Destructive**: deletes durable workflow objects, files, logs, jobs, or terms.
 
-**Google Search** (`google_search`)
-- **Purpose**: Search Google and return structured JSON results with titles, links, and snippets from external websites. Use for external information, current events, and fact-checking.
-- **Configuration**: API key + Custom Search Engine ID required
-- **Use Cases**: Fact-checking, research, external context gathering
+### Chat And Pipeline Tools
 
-**Local Search** (`local_search`)
-- **Purpose**: Search this WordPress site and return structured JSON results with post titles, excerpts, permalinks, and metadata. Use ONCE to find existing content before creating new content.
-- **Configuration**: None required (uses WordPress core)
-- **Use Cases**: Content discovery, internal link suggestions, avoiding duplicate content
+| Tool | Modes | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- | --- |
+| `amazon_affiliate_link` | chat, pipeline | Read-only | Search Amazon products and return affiliate links. | [Amazon Affiliate Link](amazon-affiliate-link.md) |
+| `bing_webmaster` | chat, pipeline | Read-only | Read Bing Webmaster search and crawl analytics. | [Bing Webmaster](bing-webmaster.md) |
+| `google_analytics` | chat, pipeline | Read-only | Read GA4 analytics, realtime, engagement, and comparison metrics. | [Google Analytics](google-analytics.md) |
+| `google_search` | chat, pipeline | Read-only | Search Google Custom Search results. | [Google Search](google-search.md) |
+| `google_search_console` | chat, pipeline | Low mutation | Read GSC data and submit sitemaps. | [Google Search Console](google-search-console.md) |
+| `image_generation` | chat, pipeline | Low mutation | Create image-generation jobs and sideload generated media. | [Image Generation](image-generation.md) |
+| `internal_link_audit` | chat, pipeline | Low mutation | Audit internal links, backlinks, orphans, and broken URLs. | [Internal Link Audit](internal-link-audit.md) |
+| `local_search` | chat, pipeline | Read-only | Search local WordPress posts/pages. | [Local Search](local-search.md) |
+| `pagespeed` | chat, pipeline | Read-only | Run PageSpeed Insights/Lighthouse audits. | [PageSpeed Insights](pagespeed-insights.md) |
+| `web_fetch` | chat, pipeline | Read-only | Fetch readable content from a URL. | [Web Fetch](web-fetch.md) |
+| `wordpress_post_reader` | chat, pipeline | Read-only | Read a WordPress post by permalink URL. | [WordPress Post Reader](wordpress-post-reader.md) |
 
-**WebFetch** (`web_fetch`)
-- **Purpose**: Fetch and extract readable content from web pages. Use after Google Search to retrieve full article content. Returns page title and cleaned text content from any HTTP/HTTPS URL.
-- **Configuration**: None required
-- **Features**: 50K character limit, HTML processing, URL validation
-- **Use Cases**: Web content analysis, reference material extraction, competitive research
+### Chat And Pipeline-Policy Tools
 
-**WordPress Post Reader** (`wordpress_post_reader`)
-- **Purpose**: Read full WordPress post content by URL for detailed analysis
-- **Configuration**: None required
-- **Features**: Complete post content retrieval, optional custom fields inclusion
-- **Use Cases**: Content analysis before WordPress Update operations, detailed post examination after Local Search
+Pipeline-policy tools are available while resolving pipeline tool policy, not as regular adjacent handler tools.
 
-**Update Taxonomy Term** (`update_taxonomy_term`) (@since v0.8.0)
-- **Purpose**: Update existing taxonomy terms including core fields and custom meta.
-- **Configuration**: None required
-- **Features**: Modifies name, slug, description, parent, and custom meta (e.g., venue_address).
-- **Use Cases**: Correcting venue details, updating artist bios, managing taxonomy hierarchies.
-- **Documentation**: [Update Taxonomy Term](update-taxonomy-term.md)
+| Tool | Modes | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- | --- |
+| `agent_daily_memory` | chat, pipeline policy | Low mutation | Read, write, list, and search daily memory journal files. | [Agent Daily Memory](agent-daily-memory.md) |
+| `agent_memory` | chat, pipeline policy | Low mutation | Read and update agent markdown files by section. | [Agent Memory](agent-memory.md) |
 
-**Agent Memory** (`agent_memory`) (@since v0.30.0)
-- **Purpose**: Manage persistent agent memory (MEMORY.md) — long-lived knowledge that survives across sessions. Stored as markdown sections (## headers).
-- **Configuration**: None required
-- **Features**: Actions: `list_sections` (see what exists), `get` (read content), `update` (write). Supports `append` mode to add without losing existing content and `set` mode to replace a section entirely. Optional `user_id` for layered memory context.
-- **Use Cases**: Persistent knowledge storage, cross-session state, agent self-improvement
+### Chat-Only Read And Diagnostics Tools
 
-**Agent Daily Memory** (`agent_daily_memory`) (@since v0.33.0)
-- **Purpose**: Manage daily memory journal entries (daily/YYYY/MM/DD.md). Use for session activity, temporal events, and work logs.
-- **Configuration**: None required
-- **Features**: Actions: `write` (record session notes, defaults to append), `read` (review a specific day), `search` (find past entries by keyword), `list` (see which days have entries). Date defaults to today. Supports `from`/`to` range for search.
-- **Use Cases**: Session logging, temporal event tracking, work history review
+| Tool | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- |
+| `api_query` | Read-only | Query documented Data Machine REST endpoints with mutation operations restricted. | [API Query](api-query.md) |
+| `get_handler_defaults` | Read-only | Read site-wide handler defaults for one handler or all handlers. | [Get Handler Defaults](get-handler-defaults.md) |
+| `list_flows` | Read-only | List flows with pipeline, handler, and pagination filters. | [List Flows](list-flows.md) |
+| `read_logs` | Read-only | Read Data Machine logs with agent/job/pipeline/flow filters. | [Read Logs](read-logs.md) |
+| `search_taxonomy_terms` | Read-only | Search taxonomy terms before create/update/assign operations. | [Search Taxonomy Terms](search-taxonomy-terms.md) |
+| `system_health_check` | Read-only | Run unified Data Machine and extension diagnostics. | [System Health Check](system-health-check.md) |
 
-**Internal Link Audit** (`internal_link_audit`) (@since v0.32.0)
-- **Purpose**: Audit links on the WordPress site. Three actions: `audit` scans post content to build a link graph (cached 24hr), `orphans` lists posts with zero inbound links, `broken` performs HTTP HEAD checks on cached links to find broken URLs.
-- **Configuration**: None required
-- **Features**: Post type and category filtering, force rebuild option, internal/external/all scope for broken link checks, configurable result limits
-- **Use Cases**: SEO link auditing, orphaned content discovery, broken link detection
+### Chat-Only Workflow Configuration Tools
 
-**GitHub Tools** — multi-tool class (@since v0.24.0, **data-machine-code extension only**)
-- `create_github_issue` — Create a GitHub issue in a repository. Async — uses System Agent for execution.
-- `list_github_issues` — List issues from a GitHub repository with state, label, and pagination filters
-- `get_github_issue` — Get a single GitHub issue with full details including body, labels, and comments
-- `manage_github_issue` — Update, close, or comment on a GitHub issue
-- `list_github_pulls` — List pull requests from a repository with state filtering
-- `list_github_repos` — List GitHub repositories for a user or organization
-- **Configuration**: GitHub PAT required in the `data-machine-code` extension
-- **Use Cases**: Bug reports, feature requests, task tracking from AI workflows
-- **Availability**: Not registered by Data Machine core.
+| Tool | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- |
+| `add_pipeline_step` | Config mutation | Add a step to a pipeline and sync flows. | [Add Pipeline Step](add-pipeline-step.md) |
+| `authenticate_handler` | Config mutation | Manage handler credentials and OAuth status. | [Authenticate Handler](authenticate-handler.md) |
+| `configure_flow_steps` | Config mutation | Configure handler settings and AI user messages for one or many flow steps. | [Configure Flow Steps](configure-flow-steps.md) |
+| `configure_pipeline_step` | Config mutation | Configure pipeline-level AI system prompt and tool policy. | [Configure Pipeline Step](configure-pipeline-step.md) |
+| `copy_flow` | Config mutation | Duplicate a flow within or across compatible pipelines. | [Copy Flow](copy-flow.md) |
+| `create_flow` | Config mutation | Create one or more flows with optional schedules and step configs. | [Create Flow](create-flow.md) |
+| `create_pipeline` | Config mutation | Create one or more pipelines and their initial flow. | [Create Pipeline](create-pipeline.md) |
+| `manage_queue` | Config mutation | Add/list/clear/remove/update/move prompt queue items and set queue mode. | [Manage Queue](manage-queue.md) |
+| `reorder_pipeline_steps` | Config mutation | Reorder pipeline steps. | [Reorder Pipeline Steps](reorder-pipeline-steps.md) |
+| `run_flow` | Low mutation | Run a flow now or schedule a future run. | [Run Flow](run-flow.md) |
+| `set_handler_defaults` | Config mutation | Update site-wide defaults for handler configs. | [Set Handler Defaults](set-handler-defaults.md) |
+| `update_flow` | Config mutation | Update flow title and/or schedule. | [Update Flow](update-flow.md) |
 
-**Workspace Tools** — multi-tool class (@since v0.37.0, **data-machine-code extension only**)
-- `workspace_path` — Get the Data Machine workspace path, optionally ensure it exists
-- `workspace_list` — List repositories currently present in the workspace
-- `workspace_show` — Show detailed repo info (branch, remote, latest commit, dirty count)
-- `workspace_ls` — List directory contents within a workspace repository
-- `workspace_read` — Read a text file from a workspace repo with optional offset/limit for large files
-- **Configuration**: Configure and operate through the `data-machine-code` extension
-- **Use Cases**: Repository browsing, code review, workspace navigation
-- **Availability**: Not registered by Data Machine core.
+### Chat-Only Content And File Mutation Tools
 
-**Image Generation** (`image_generation`)
-- **Purpose**: Generate images using AI models (Google Imagen 4, Flux, etc.) via Replicate. Returns a URL to the generated image. Async — uses System Agent.
-- **Configuration**: Replicate API key required
-- **Features**: Default aspect ratio 3:4 (portrait, ideal for Pinterest/blog featured images). Supports 1:1, 3:4, 4:3, 9:16, 16:9 ratios. Configurable model selection.
-- **Use Cases**: Featured image generation, visual content creation, illustration
+| Tool | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- |
+| `assign_taxonomy_term` | Content mutation | Assign a term to one or more posts. | [Assign Taxonomy Term](assign-taxonomy-term.md) |
+| `create_taxonomy_term` | Content mutation | Create a taxonomy term if it does not exist. | [Create Taxonomy Term](create-taxonomy-term.md) |
+| `delete_file` | Destructive | Delete an uploaded file scoped to a flow step. | [Delete File](delete-file.md) |
+| `merge_taxonomy_terms` | Destructive | Reassign posts from a source term to a target term and delete the source term. | [Merge Taxonomy Terms](merge-taxonomy-terms.md) |
+| `update_taxonomy_term` | Content mutation | Update taxonomy term fields and meta. | [Update Taxonomy Term](update-taxonomy-term.md) |
 
-**Amazon Affiliate Link** (`amazon_affiliate_link`) (@since v0.24.0)
-- **Purpose**: Search Amazon products and return an affiliate link with the product title, URL, and thumbnail.
-- **Configuration**: Amazon affiliate credentials required
-- **Features**: Single-query product search, returns product title + affiliate URL + thumbnail
-- **Use Cases**: Contextual product recommendations in content, affiliate monetization
+### Chat-Only Destructive Workflow Tools
 
-**Queue Validator** (`queue_validator`)
-- **Purpose**: Check if a topic already exists as a published post or in a Data Machine queue before generating content. Returns "clear" if no duplicates found, or "duplicate" with match details.
-- **Configuration**: None required
-- **Features**: Title similarity scoring via Jaccard threshold (configurable, default 0.65), checks both published posts and flow queues, supports post type filtering
-- **Use Cases**: Duplicate prevention before content generation, queue hygiene
+| Tool | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- |
+| `delete_flow` | Destructive | Delete a flow. | [Delete Flow](delete-flow.md) |
+| `delete_pipeline` | Destructive | Delete a pipeline and its associated flows. | [Delete Pipeline](delete-pipeline.md) |
+| `delete_pipeline_step` | Destructive | Remove a pipeline step and cascade to flows. | [Delete Pipeline Step](delete-pipeline-step.md) |
+| `manage_jobs` | Destructive | List/summarize jobs and delete, fail, retry, or recover jobs. | [Manage Jobs](manage-jobs.md) |
+| `manage_logs` | Destructive | Clear logs or read log metadata. | [Manage Logs](manage-logs.md) |
 
-**Google Search Console** (`google_search_console`) (@since v0.25.0)
-- **Purpose**: Fetch search analytics from Google Search Console — query performance, page stats, URL inspection, and sitemap management.
-- **Configuration**: Service account JSON + site URL required
-- **Features**: 8 actions (query_stats, page_stats, query_page_stats, date_stats, inspect_url, list_sitemaps, get_sitemap, submit_sitemap), URL and query filters, date range control
-- **Use Cases**: SEO monitoring, indexing verification, search performance analysis
-- **Documentation**: [Google Search Console](google-search-console.md)
+### Chat-Only External Execution Tools
 
-**Bing Webmaster Tools** (`bing_webmaster`) (@since v0.23.0)
-- **Purpose**: Fetch search analytics from Bing Webmaster Tools — query stats, traffic stats, page stats, and crawl stats.
-- **Configuration**: API key required
-- **Features**: 4 actions (query_stats, traffic_stats, page_stats, crawl_stats), configurable result limits
-- **Use Cases**: Bing search performance, crawl monitoring, multi-engine SEO
-- **Documentation**: [Bing Webmaster Tools](bing-webmaster.md)
+| Tool | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- |
+| `execute_workflow` | Content mutation | Execute an ephemeral workflow through the Execute API. | [Execute Workflow](execute-workflow.md) |
+| `send_ping` | Low mutation | POST a prompt/context payload to one or more webhook URLs. | [Send Ping](send-ping.md) |
 
-**Google Analytics** (`google_analytics`) (@since v0.31.0)
-- **Purpose**: Fetch visitor analytics from Google Analytics (GA4) — page performance, traffic sources, daily trends, real-time users, top events, demographics.
-- **Configuration**: Service account JSON + GA4 property ID required (can reuse GSC service account)
-- **Features**: 6 actions (page_stats, traffic_sources, date_stats, realtime, top_events, user_demographics), date range control, page path filtering
-- **Use Cases**: Traffic analysis, content performance, visitor behavior, real-time monitoring
-- **Documentation**: [Google Analytics (GA4)](google-analytics.md)
+### Chat-Only Duplicate Prevention Tool
 
-**PageSpeed Insights** (`pagespeed`) (@since v0.31.0)
-- **Purpose**: Run Lighthouse audits via PageSpeed Insights API — performance scores, Core Web Vitals, accessibility, SEO, and optimization opportunities.
-- **Configuration**: None required (optional API key for higher rate limits)
-- **Features**: 3 actions (analyze, performance, opportunities), mobile/desktop strategies, any public URL
-- **Use Cases**: Performance auditing, Core Web Vitals monitoring, optimization planning
-- **Documentation**: [PageSpeed Insights](pagespeed-insights.md)
+| Tool | Mutation risk | Purpose | Docs |
+| --- | --- | --- | --- |
+| `queue_validator` | Read-only | Check if a topic exists in published content or a flow queue. | [Queue Validator](queue-validator.md) |
 
-### Chat-Specific Tools
+## Handler-Specific Tools
 
-Available only to chat AI agents via `datamachine_chat_tools` filter. These specialized tools provide focused, operation-specific functionality for conversational workflow management:
+Handler tools are registered by handlers into the unified `datamachine_tools` registry as deferred `_handler_callable` entries. They become available at runtime when an adjacent step uses the matching handler or step type.
 
-**ExecuteWorkflow** (`execute_workflow`) (@since v0.3.0)
-- **Purpose**: Execute complete multi-step workflows in a single tool call with automatic provider/model defaults injection
-- **Configuration**: None required
-- **Architecture**: Streamlined single-file implementation at `/inc/Api/Chat/Tools/ExecuteWorkflowTool.php` that delegates execution to the Execute API, with shared handler documentation utilities
-- **Use Cases**: Direct workflow execution, ephemeral workflows without pipeline creation
+Examples include:
 
-**AddPipelineStep** (`add_pipeline_step`) (@since v0.4.3)
-- **Purpose**: Add steps to existing pipelines with automatic flow synchronization
-- **Configuration**: None required
-- **Features**: Automatically syncs new steps to all flows on the pipeline
-- **Use Cases**: Incrementally building pipelines through conversation
+- `wordpress_publish`: create WordPress posts; accepts `content_format` (`markdown`, `html`, or `blocks`).
+- `wordpress_update`: update existing WordPress content.
+- `twitter_publish`, `bluesky_publish`, `facebook_publish`, `threads_publish`: publish social posts.
+- `google_sheets_publish`: append rows to Google Sheets.
 
-**ApiQuery** (`api_query`) (@since v0.4.3)
-- **Purpose**: Strictly read-only REST API query tool for discovery, monitoring, and troubleshooting
-- **Configuration**: None required
-- **Features**: Complete API endpoint catalog with usage examples. Mutation operations are restricted.
-- **Use Cases**: System monitoring, handler discovery, job status checking, configuration verification.
+## Extension-Owned Tools
 
-**ConfigureFlowSteps** (`configure_flow_steps`) (@since v0.4.2)
-- **Purpose**: Configure handler settings and AI user messages for flow steps, supporting both single-step and bulk pipeline-scoped operations
-- **Configuration**: None required
-- **Features**: 
-  - **Single mode**: Configure individual steps.
-  - **Bulk mode**: Configure matching steps across all flows in a pipeline.
-  - **Handler Switching**: Use `target_handler_slug` to switch handlers with optional `field_map` for data migration.
-  - **Per-Flow Config**: Support for unique settings per flow in bulk mode via `flow_configs`.
-- **Use Cases**: Setting up fetch/publish/upsert handlers, customizing AI prompts, bulk configuration changes across pipelines, migrating handlers.
+GitHub and workspace tools are not registered by Data Machine core. They are provided by the `data-machine-code` extension when that extension is installed.
 
-**ConfigurePipelineStep** (`configure_pipeline_step`) (@since v0.4.4)
-- **Purpose**: Configure pipeline-level AI settings including system prompt, provider, model, and enabled tools
-- **Configuration**: None required
-- **Features**: Pipeline-wide AI configuration affecting all associated flows
-- **Use Cases**: Setting AI provider/model, system prompts, and tool enablement across workflows
+Common extension tools include:
 
-**CreateFlow** (`create_flow`) (@since v0.4.2)
-- **Purpose**: Create flow instances from existing pipelines with automatic step synchronization
-- **Configuration**: None required
-- **Features**: Supports manual, recurring, and one-time scheduling
-- **Use Cases**: Instantiating pipelines as executable, schedulable flows
+- `create_github_issue`, `list_github_issues`, `get_github_issue`, `manage_github_issue`
+- `list_github_pulls`, `list_github_repos`
+- `workspace_path`, `workspace_list`, `workspace_show`, `workspace_ls`, `workspace_read`
 
-**CreatePipeline** (`create_pipeline`) (@since v0.4.3)
-- **Purpose**: Create pipelines with optional predefined steps and automatic flow instantiation
-- **Configuration**: None required
-- **Features**: Automatically creates associated flow, supports AI step configuration in step definitions
-- **Use Cases**: Creating complete workflow templates through conversation
+## Unregistered Core Class
 
-**RunFlow** (`run_flow`) (@since v0.4.4)
-- **Purpose**: Execute existing flows immediately or schedule delayed execution with job tracking
-- **Configuration**: None required
-- **Features**: Asynchronous execution via WordPress Action Scheduler, comprehensive job monitoring
-- **Use Cases**: Immediate workflow execution, scheduled automation, manual testing
-
-**UpdateFlow** (`update_flow`) (@since v0.4.4)
-- **Purpose**: Update flow-level properties including title and scheduling configuration
-- **Configuration**: None required
-- **Features**: Modify flow names, change scheduling intervals, switch to manual execution
-- **Use Cases**: Workflow organization, schedule adjustments, maintenance operations
-
-**DeletePipeline** (`delete_pipeline`)
-- **Purpose**: Delete a pipeline and all its associated flows
-- **Configuration**: None required
-- **Use Cases**: Pipeline cleanup, workflow removal
-
-**DeleteFlow** (`delete_flow`)
-- **Purpose**: Delete a flow instance
-- **Configuration**: None required
-- **Use Cases**: Flow cleanup, removing unused workflow instances
-
-**CopyFlow** (`copy_flow`) (@since v0.6.25)
-- **Purpose**: Copy a flow to the same or different pipeline. Cross-pipeline requires compatible step structures. Copies handlers, messages, and schedule.
-- **Configuration**: None required
-- **Features**: Override schedule and step configs during copy via optional parameters
-- **Use Cases**: Flow duplication, cross-pipeline flow migration, template instantiation
-
-**ListFlows** (`list_flows`)
-- **Purpose**: List flows with optional filtering by pipeline ID or handler slug. Supports pagination.
-- **Configuration**: None required
-- **Use Cases**: Flow discovery, workflow inventory, dashboard queries
-
-**DeletePipelineStep** (`delete_pipeline_step`)
-- **Purpose**: Remove a step from a pipeline. Cascades removal to all flows on the pipeline.
-- **Configuration**: None required
-- **Use Cases**: Pipeline step cleanup, simplifying workflow structure
-
-**ReorderPipelineSteps** (`reorder_pipeline_steps`)
-- **Purpose**: Reorder steps within a pipeline by providing a new step order array
-- **Configuration**: None required
-- **Use Cases**: Pipeline restructuring, execution order adjustments
-
-**ManageJobs** (`manage_jobs`) (@since v0.24.0)
-- **Purpose**: Manage Data Machine jobs with actions: `list` (with filtering by flow_id, pipeline_id, status), `summary` (counts by status), `delete` (by type: all or failed), `fail` (manually fail a job), `retry` (retry a failed job), `recover` (recover stuck processing jobs).
-- **Configuration**: None required
-- **Use Cases**: Job monitoring, failure recovery, execution management
-
-**ManageLogs** (`manage_logs`) (@since v0.8.2)
-- **Purpose**: Manage Data Machine logs with actions: `clear` (clear logs for agent_id or all), `get_metadata` (get log counts and time range for agent_id or all). Logs are scoped by agent_id.
-- **Configuration**: None required
-- **Use Cases**: Log maintenance, storage management, log metadata inspection
-
-**ReadLogs** (`read_logs`) (@since v0.8.2)
-- **Purpose**: Read Data Machine logs for troubleshooting. Filter by agent_id, job_id, pipeline_id, flow_id (combined with AND logic). Modes: `recent` (default, limited) or `full`.
-- **Configuration**: None required
-- **Use Cases**: Troubleshooting, execution auditing, error investigation
-
-**ManageQueue** (`manage_queue`) (@since v0.24.0)
-- **Purpose**: Manage prompt queues for flow steps with actions: `add`, `list`, `clear`, `remove`, `update`, `move`, `settings`. All actions require flow_id and flow_step_id.
-- **Configuration**: None required
-- **Use Cases**: Queue management, prompt scheduling, content pipeline control
-
-**SendPing** (`send_ping`) (@since v0.24.0)
-- **Purpose**: Send a ping to one or more webhook URLs. Useful for triggering external agents or notifying services.
-- **Configuration**: None required
-- **Features**: Accepts single or newline-separated URLs, optional prompt for receiving agent
-- **Use Cases**: Agent orchestration, webhook notifications, external service triggers
-
-**SystemHealthCheck** (`system_health_check`) (@since v0.24.0)
-- **Purpose**: Run unified health diagnostics for Data Machine and extensions. Returns status of various system components.
-- **Configuration**: None required
-- **Features**: Supports specific check types or "all" for full diagnostics, type-specific options
-- **Use Cases**: System monitoring, proactive issue detection, health reporting
-
-**GetProblemFlows** (`get_problem_flows`)
-- **Purpose**: Identify flows with issues: consecutive failures (broken) or consecutive no-items runs (source exhausted). Configurable threshold.
-- **Configuration**: None required
-- **Use Cases**: Proactive flow monitoring, failure detection, source exhaustion alerts
-
-**GetHandlerDefaults** (`get_handler_defaults`)
-- **Purpose**: Get site-wide handler defaults. Returns defaults for a specific handler or all handlers.
-- **Configuration**: None required
-- **Use Cases**: Configuration discovery, understanding site standards before flow setup
-
-**SetHandlerDefaults** (`set_handler_defaults`)
-- **Purpose**: Set site-wide handler defaults. Establishes standard configuration values that apply to all new flows.
-- **Configuration**: None required
-- **Use Cases**: Standardizing handler configuration, site-wide defaults management
-
-**SearchTaxonomyTerms** (`search_taxonomy_terms`)
-- **Purpose**: Search existing taxonomy terms to discover what terms exist before creating new ones or configuring handler assignments.
-- **Configuration**: None required
-- **Use Cases**: Term discovery, duplicate prevention, handler configuration
-
-**CreateTaxonomyTerm** (`create_taxonomy_term`)
-- **Purpose**: Create a taxonomy term if it does not exist. Supports hierarchical terms with parent assignment.
-- **Configuration**: None required
-- **Use Cases**: Taxonomy setup during flow configuration, creating categories/tags on demand
-
-**AssignTaxonomyTerm** (`assign_taxonomy_term`)
-- **Purpose**: Assign a taxonomy term to one or more posts. Can append to existing terms or replace them.
-- **Configuration**: None required
-- **Use Cases**: Bulk term assignment, content categorization, taxonomy management
-
-**MergeTaxonomyTerms** (`merge_taxonomy_terms`)
-- **Purpose**: Merge two taxonomy terms into one. Reassigns all posts from source to target, optionally merges meta data, then deletes the source term.
-- **Configuration**: None required
-- **Use Cases**: Consolidating duplicate terms, taxonomy cleanup
-
-**AuthenticateHandler** (`authenticate_handler`) (@since v0.6.1)
-- **Purpose**: Manage authentication for handlers with actions: `list` (all handlers requiring auth), `status` (specific handler), `configure` (save credentials), `get_oauth_url` (authorization URL for OAuth), `disconnect` (remove auth).
-- **Configuration**: None required
-- **Use Cases**: Handler authentication setup, OAuth flow management, credential management
-
-**DeleteFile** (`delete_file`)
-- **Purpose**: Delete an uploaded file. Requires flow_step_id to identify the file scope.
-- **Configuration**: None required
-- **Use Cases**: File cleanup, storage management
-
-### Handler-Specific Tools
-
-Available only when the adjacent step matches the handler slug or type, registered into the unified `datamachine_tools` registry as `_handler_callable` entries:
-
-**Publishing Tools**:
-- `twitter_publish` - Post to Twitter (280 char limit)
-- `bluesky_publish` - Post to Bluesky (300 char limit)  
-- `facebook_publish` - Post to Facebook (no limit)
-- `threads_publish` - Post to Threads (500 char limit)
-- `wordpress_publish` - Create WordPress posts; accepts `content_format` (`markdown`, `html`, or `blocks`) and stores content in the post type's configured format
-- `google_sheets_publish` - Add data to Google Sheets
-
-**Update Tools**:
-- `wordpress_update` - Modify existing WordPress content
+`inc/Api/Chat/Tools/GetProblemFlows.php` defines `get_problem_flows`, but `ToolServiceProvider.php` does not instantiate it. It is not part of the registered core inventory until the provider registers it or another bootstrap path instantiates the class.
 
 ## Tool Architecture
 
-### Registration System
+Tool classes extend `BaseTool` and register themselves with `registerTool()`. Registration declares:
 
-**Global Tools** (available to all AI agents - pipeline + chat + standalone):
-```php
-// Registered via datamachine_global_tools filter
-add_filter('datamachine_global_tools', function($tools) {
-    $tools['google_search'] = [
-        'class' => 'DataMachine\\Engine\\AI\\Tools\\GoogleSearch',
-        'method' => 'handle_tool_call',
-        'description' => 'Search Google for information',
-        'requires_config' => true,
-        'parameters' => [
-            'query' => [
-                'type' => 'string',
-                'required' => true,
-                'description' => 'Search query'
-            ]
-        ]
-    ];
-    return $tools;
-}, 10, 1);
-```
+- tool slug
+- definition callback
+- mode list
+- required ability or access level
 
-## Tool Directory Structure
-
-Global tools are located in `/inc/Engine/AI/Tools/Global/`:
-- `AgentMemory.php` - Section-based persistent memory read/write (MEMORY.md)
-- `AgentDailyMemory.php` - Daily memory journal file access (daily/YYYY/MM/DD.md)
-- `AmazonAffiliateLink.php` - Amazon product search with affiliate links
-- `BingWebmaster.php` - Bing Webmaster Tools analytics (delegates to `BingWebmasterAbilities`)
-- `GitHubTools.php` - GitHub repository operations (issues, PRs, repos — multi-tool)
-- `GoogleAnalytics.php` - Google Analytics GA4 data (delegates to `GoogleAnalyticsAbilities`)
-- `GoogleSearch.php` - Web search with Custom Search API
-- `GoogleSearchConsole.php` - Google Search Console analytics (delegates to `GoogleSearchConsoleAbilities`)
-- `ImageGeneration.php` - AI image generation via Replicate (async, System Agent)
-- `InternalLinkAudit.php` - Internal link auditing, orphan detection, broken link checks
-- `LocalSearch.php` - WordPress internal search
-- `PageSpeed.php` - PageSpeed Insights Lighthouse audits (delegates to `PageSpeedAbilities`)
-- `QueueValidator.php` - Flow queue duplicate validation before content generation
-- `WebFetch.php` - Web page content retrieval
-- `WordPressPostReader.php` - Single post analysis
-- `WorkspaceTools.php` - Workspace repository operations (**moved to data-machine-code extension**)
-
-Additional global tools outside the Global directory:
-- `GitHubIssueTool.php` (`/inc/Engine/AI/Tools/`) - GitHub issue creation (**moved to data-machine-code extension**)
-
-Analytics abilities are located in `/inc/Abilities/Analytics/`:
-- `GoogleSearchConsoleAbilities.php` - GSC API integration and JWT auth
-- `BingWebmasterAbilities.php` - Bing Webmaster API integration
-- `GoogleAnalyticsAbilities.php` - GA4 Data API integration and JWT auth
-- `PageSpeedAbilities.php` - PageSpeed Insights API integration
-
-Chat-specific tools at `/inc/Api/Chat/Tools/`:
-- `AddPipelineStep.php` - Add steps to pipelines with flow synchronization
-- `ApiQuery.php` - REST API discovery and queries with comprehensive endpoint documentation
-- `AssignTaxonomyTerm.php` - Assign taxonomy terms to posts
-- `AuthenticateHandler.php` - Handler authentication management (OAuth, credentials)
-- `ConfigureFlowSteps.php` - Flow step configuration (single and bulk modes)
-- `ConfigurePipelineStep.php` - Pipeline-level AI settings configuration
-- `CopyFlow.php` - Flow duplication within or across pipelines
-- `CreateFlow.php` - Flow instance creation with scheduling support
-- `CreatePipeline.php` - Pipeline creation with optional predefined steps
-- `CreateTaxonomyTerm.php` - Taxonomy term creation
-- `DeleteFile.php` - Uploaded file deletion
-- `DeleteFlow.php` - Flow deletion
-- `DeletePipeline.php` - Pipeline and associated flows deletion
-- `DeletePipelineStep.php` - Pipeline step removal with flow cascade
-- `ExecuteWorkflowTool.php` - Direct workflow execution with Execute API delegation
-- `GetHandlerDefaults.php` - Site-wide handler defaults retrieval
-- `GetProblemFlows.php` - Problem flow detection (failures, exhausted sources)
-- `ListFlows.php` - Flow listing with filtering and pagination
-- `ManageJobs.php` - Job management (list, summary, delete, fail, retry, recover)
-- `ManageLogs.php` - Log management (clear, metadata)
-- `ManageQueue.php` - Flow step queue management (add, list, clear, remove, update, move)
-- `MergeTaxonomyTerms.php` - Taxonomy term merging and consolidation
-- `ReadLogs.php` - Log reading with filtering and mode selection
-- `ReorderPipelineSteps.php` - Pipeline step reordering
-- `RunFlow.php` - Flow execution and scheduling with job tracking
-- `SearchTaxonomyTerms.php` - Taxonomy term search and discovery
-- `SendPing.php` - Webhook ping for agent orchestration
-- `SetHandlerDefaults.php` - Site-wide handler defaults configuration
-- `SystemHealthCheck.php` - System health diagnostics
-- `UpdateFlow.php` - Flow property updates and scheduling modifications
-
-Handler-specific tools registered into the unified `datamachine_tools` registry using HandlerRegistrationTrait in each handler class. Each entry carries a `_handler_callable` that is resolved at pipeline execution time with the adjacent step's runtime handler config.
+`ToolPolicyResolver` resolves the active tool set for a context. `ToolExecutor` handles execution. Handler-specific tools are resolved from `_handler_callable` registry entries against adjacent step runtime configuration.
 
 ## Content Authoring Formats
 
-For normal prose, AI tools should write markdown and omit `content_format` unless
-a workflow explicitly asks for HTML or serialized blocks. Raw ability/API callers
-can still pass `content_format` explicitly; omitted raw `datamachine/upsert-post`
-calls keep the legacy block-markup default.
-
-## Tool Management
-
-**ToolManager** (`/inc/Engine/AI/Tools/ToolManager.php`) centralizes tool discovery and validation:
-- `get_all_tools()` - Discover all tools
-- `is_tool_available()` - Validate global and step-specific enablement
-- `is_tool_configured()` - Check configuration requirements
-- `get_opt_out_defaults()` - WordPress-native tools (no config needed)
-
-**BaseTool** (`/inc/Engine/AI/Tools/BaseTool.php`) provides unified base class for all AI tools with standardized registration and error handling.
-
-**Chat-Specific Tools** (available only to chat AI agents):
-```php
-// Registered via datamachine_chat_tools filter
-add_filter('datamachine_chat_tools', function($tools) {
-    $tools['create_pipeline'] = [
-        'class' => 'DataMachine\\Api\\Chat\\Tools\\CreatePipeline',
-        'method' => 'handle_tool_call',
-        'description' => 'Create a new pipeline with optional steps',
-        'parameters' => [/* ... */]
-    ];
-    return $tools;
-});
-```
-
-**Handler-Specific Tools** (available when adjacent step matches handler slug or type):
-```php
-// Registered into the unified datamachine_tools registry as a deferred
-// _handler_callable entry. Preferred path is HandlerRegistrationTrait.
-add_filter('datamachine_tools', function($tools) {
-    $tools['__handler_tools_twitter'] = [
-        '_handler_callable' => function($handler_slug, $handler_config, $engine_data) {
-            return [
-                'twitter_publish' => [
-                    'class'          => 'Twitter\\Handler',
-                    'method'         => 'handle_tool_call',
-                    'handler'        => $handler_slug,
-                    'description'    => 'Post to Twitter',
-                    'parameters'     => ['content' => ['type' => 'string', 'required' => true]],
-                    'handler_config' => $handler_config,
-                ],
-            ];
-        },
-        'handler'      => 'twitter',
-        'modes'        => ['pipeline'],
-        'access_level' => 'admin',
-    ];
-    return $tools;
-});
-```
-
-### Discovery Hierarchy
-
-**ToolManager** implements three-layer validation for tool availability:
-
-1. **Global Level**: Admin settings enable/disable tools site-wide
-2. **Modal Level**: Per-step tool selection in pipeline configuration
-3. **Runtime Level**: Configuration validation checks at execution
-
-**Validation Flow**:
-```php
-$tool_manager = new ToolManager();
-
-// Layer 1: Global enablement
-$is_globally_enabled = $tool_manager->is_globally_enabled('google_search');
-
-// Layer 2: Step-specific selection
-    $step_context_id = 'pipeline_step_id_here'; // Example placeholder step context ID
-    $is_step_enabled = $tool_manager->is_step_tool_enabled($step_context_id, 'google_search');
-
-// Layer 3: Configuration requirements
-    $is_configured = $tool_manager->is_tool_configured('google_search');
-
-// Final availability
-$is_available = $is_globally_enabled && $is_step_enabled && $is_configured;
-```
-
-See Tool Manager for complete documentation.
-
-## Tool Execution Architecture
-
-### ToolExecutor Pattern
-
-All tools integrate via the universal `ToolExecutor` class
-(`/inc/Engine/AI/Tools/ToolExecutor.php`) for execution, and the
-`ToolPolicyResolver` for discovery:
-
-```php
-// Tool discovery
-$resolver        = new \DataMachine\Engine\AI\Tools\ToolPolicyResolver();
-$available_tools = $resolver->resolve( array(
-    'mode'             => \DataMachine\Engine\AI\Tools\ToolPolicyResolver::MODE_PIPELINE,
-    'pipeline_step_id' => $flow_step_id,
-    'engine_data'      => $engine_data,
-) );
-```
-
-**Discovery Process**:
-1. **Handler Tools**: Retrieved from the `datamachine_tools` registry — `_handler_callable` entries resolved per adjacent step
-2. **Global Tools**: Retrieved via `datamachine_global_tools` filter
-3. **Chat Tools**: Retrieved via `datamachine_chat_tools` filter (chat agent only)
-4. **Enablement Check**: Each tool filtered through `datamachine_tool_enabled`
-
-### Filter-Based Enablement
-
-Tools can be enabled/disabled per agent type via filters:
-
-```php
-add_filter('datamachine_tool_enabled', function($enabled, $tool_id, $agent_type) {
-    if ($agent_type === 'chat' && $tool_id === 'create_pipeline') {
-        return true;  // Chat-only tool
-    }
-    return $enabled;
-}, 10, 3);
-```
-
-### Parameter Building
-
-`WP_Agent_Tool_Parameters` (`/inc/Engine/AI/Tools/ToolParameters.php`) provides unified parameter construction:
-
-**Standard Tools** (global tools):
-```php
-$parameters = \DataMachine\Engine\AI\WP_Agent_Tool_Parameters::buildParameters(
-    $data,
-    $job_id,
-    $flow_step_id
-);
-// Returns: ['content_string' => ..., 'title' => ..., 'job_id' => ..., 'flow_step_id' => ...]
-```
-
-**Handler Tools** (publish/upsert handlers):
-```php
-$parameters = \DataMachine\Engine\AI\WP_Agent_Tool_Parameters::buildForHandlerTool(
-    $data,
-    $tool_def,
-    $job_id,
-    $flow_step_id
-);
-// Returns: [...standard params, 'source_url' => ..., 'image_url' => ..., 'tool_definition' => ..., 'handler_config' => ...]
-```
-
-**Benefits**:
-- Handler tools receive engine data (source_url, image_url) for link attribution and post identification
-- Global tools receive clean data packets for content processing
-- All tools receive job_id and flow_step_id context for tracking
-- Unified flat parameter structure for AI simplicity
-
-## Tool Interface
-
-### `handle_tool_call()` Method
-
-All tools implement the same interface:
-
-```php
-public function handle_tool_call(array $parameters, array $tool_def = []): array
-```
-
-**Parameters**:
-- `$parameters` - AI-provided parameters (validated against tool definition)
-- `$tool_def` - Complete tool definition including configuration
-
-**Return Format**:
-```php
-[
-    'success' => true|false,
-    'data' => $result_data, // Tool-specific response data
-    'error' => 'error_message', // Only if success = false
-    'tool_name' => 'tool_identifier'
-]
-```
-
-### Parameter Validation
-
-**Required Parameters**:
-```php
-if (empty($parameters['query'])) {
-    return [
-        'success' => false,
-        'error' => 'Missing required query parameter',
-        'tool_name' => 'google_search'
-    ];
-}
-```
-
-**Type Validation**:
-- `string` - Text content, URLs, identifiers
-- `integer` - Numeric values, IDs, counts
-- `boolean` - True/false flags
-
-## Configuration Management
-
-### Configuration Requirements
-
-**Requires Config Flag**:
-```php
-'requires_config' => true // Shows configure link in UI
-```
-
-**Configuration Storage**:
-- Global tools: WordPress options table
-- Handler tools: Handler-specific configuration
-- OAuth tools: Separate OAuth storage system
-
-### Configuration Validation
-
-```php
-add_filter('datamachine_tool_configured', function($configured, $tool_id) {
-    switch ($tool_id) {
-        case 'google_search':
-            $config = get_option('datamachine_search_config', []);
-            $google_config = $config['google_search'] ?? [];
-            return !empty($google_config['api_key']) && !empty($google_config['search_engine_id']);
-        
-    }
-    return $configured;
-}, 10, 2);
-```
-
-## AI Integration
-
-### Tool Selection
-
-AI agents receive available tools based on:
-1. **Global Settings** - Admin-enabled tools
-2. **Step Configuration** - Modal-selected tools  
-3. **Handler Context** - Next step handler type
-4. **Configuration Status** - Tools with valid configuration
-
-### Tool Descriptions
-
-**AI-Optimized Descriptions**:
-- Clear purpose and capabilities
-- Usage instructions for AI
-- Parameter requirements and formats
-- Expected return data structure
-
-**Example**:
-```php
-'description' => 'Search Google for current information and context. Provides real-time web data to inform content creation, fact-checking, and research. Use max_results to control response size.'
-```
-
-### Conversation Integration
-
-**Universal Engine Architecture** - Tool execution flows through centralized Engine components:
-
-**AIConversationLoop** (`/inc/Engine/AI/AIConversationLoop.php`):
-- Multi-turn conversation execution with automatic tool calling
-- Executes tools returned by AI and appends results to conversation
-- Continues conversation loop until AI completes without tool calls
-- Prevents infinite loops with maximum turn counter
-
-**ToolExecutor** (`/inc/Engine/AI/Tools/ToolExecutor.php`):
-- Universal tool discovery via `getAvailableTools()` method
-- Filter-based tool enablement per agent type (pipeline vs chat)
-- Handler tool and global tool integration
-- Tool configuration validation
-
-**WP_Agent_Tool_Parameters** (`/inc/Engine/AI/Tools/ToolParameters.php`):
-- Centralized parameter building for all AI tools
-- `buildParameters()` for standard AI tools with clean data extraction
-- `buildForHandlerTool()` for handler tools with engine parameters (source_url, image_url)
-- Flat parameter structure for AI simplicity
-
-**ConversationManager** (`/inc/Engine/AI/ConversationManager.php`):
-- Message formatting utilities for AI providers
-- Tool call recording and tracking
-- Conversation message normalization
-- Chronological message ordering
-
-**RequestBuilder** (`/inc/Engine/AI/RequestBuilder.php`):
-- Centralized AI request construction for all agents
-- Directive application system (global, agent-specific, pipeline, chat)
-- Tool restructuring for AI provider compatibility
-- Integration with the wp-ai-client runtime adapter
-
-**Tool Results Processing**:
-- Tool responses formatted by ConversationManager for AI consumption
-- Structured data converted to human-readable success messages
-- Platform-specific messaging enables natural AI agent conversation termination
-- Multi-turn context preservation via AIConversationLoop
-
-## Tool Implementation Examples
-
-### Global Tool (Google Search)
-
-```php
-class GoogleSearch {
-    public function handle_tool_call(array $parameters, array $tool_def = []): array {
-        $config = apply_filters('datamachine_get_tool_config', [], 'google_search');
-        $api_key = $config['api_key'] ?? '';
-        $search_engine_id = $config['search_engine_id'] ?? '';
-        if (empty($api_key) || empty($search_engine_id)) {
-            return [ 'success' => false, 'error' => 'Google Search not configured', 'tool_name' => 'google_search' ];
-        }
-        $query = $parameters['query'];
-        $results = $this->perform_search($query, $api_key, $search_engine_id, 10); // Fixed size
-        return [
-            'success' => true,
-            'data' => [ 'results' => $results, 'query' => $query, 'total_results' => count($results) ],
-            'tool_name' => 'google_search'
-        ];
-    }
-}
-```
-
-### Handler Tool (Twitter Publish)
-
-```php
-class TwitterHandler {
-    public function handle_tool_call(array $parameters, array $tool_def = []): array {
-        // Get handler configuration
-        $handler_config = $tool_def['handler_config'] ?? [];
-        $twitter_config = $handler_config['twitter'] ?? [];
-        
-        // Process content
-        $content = $parameters['content'];
-        $formatted_content = $this->format_for_twitter($content, $twitter_config);
-        
-        // Publish to Twitter
-        $result = $this->publish_tweet($formatted_content);
-        
-        return [
-            'success' => true,
-            'data' => [
-                'tweet_id' => $result['id'],
-                'tweet_url' => $result['url'],
-                'content' => $formatted_content
-            ],
-            'tool_name' => 'twitter_publish'
-        ];
-    }
-}
-```
-
-## Error Handling
-
-### Configuration Errors
-
-**Missing Configuration**:
-- Tool returns error with configuration instructions
-- UI shows configure link for unconfigured tools
-- Runtime validation prevents broken tool calls
-
-**Invalid Configuration**:
-- API key validation during configuration save
-- OAuth token refresh on authentication errors
-- Clear error messages for troubleshooting
-
-### Runtime Errors
-
-**API Failures**:
-- Network errors logged and returned to AI
-- Rate limiting handled gracefully
-- Service outages communicated clearly
-
-**Parameter Errors**:
-- Type validation with specific error messages
-- Required parameter checking
-- Format validation for complex parameters
-
-## Performance Considerations
-
-### Request Optimization
-
-**External API Calls**:
-- Single request per tool execution
-- Timeout handling with WordPress defaults
-- No automatic retries (AI can retry if needed)
-
-**Data Processing**:
-- Minimal memory usage during processing
-- Streaming for large responses
-- Efficient JSON parsing and formatting
-
-### Caching Strategy
-
-**Search Results**: Not cached (real-time data priority)
-**Configuration Data**: Cached in WordPress options
-**OAuth Tokens**: Cached with automatic refresh
-
-## Extension Development
-
-### Custom Global Tool
-
-```php
-class CustomTool {
-    public function __construct() {
-        // Self-register via datamachine_global_tools filter
-        add_filter('datamachine_global_tools', [$this, 'register_tool'], 10, 1);
-    }
-
-    public function register_tool($tools) {
-        $tools['custom_tool'] = [
-            'class' => __CLASS__,
-            'method' => 'handle_tool_call',
-            'description' => 'Custom data processing tool',
-            'requires_config' => false,
-            'parameters' => [
-                'input' => [
-                    'type' => 'string',
-                    'required' => true,
-                    'description' => 'Data to process'
-                ]
-            ]
-        ];
-        return $tools;
-    }
-
-    public function handle_tool_call(array $parameters, array $tool_def = []): array {
-        // Validate parameters
-        if (empty($parameters['input'])) {
-            return [
-                'success' => false,
-                'error' => 'Missing input parameter',
-                'tool_name' => 'custom_tool'
-            ];
-        }
-
-        // Process data
-        $result = $this->process_data($parameters['input']);
-
-        return [
-            'success' => true,
-            'data' => ['processed_result' => $result],
-            'tool_name' => 'custom_tool'
-        ];
-    }
-}
-
-// Self-register the tool
-new CustomTool();
-```
+For normal prose, AI tools should write markdown and omit `content_format` unless a workflow explicitly asks for HTML or serialized blocks. Raw ability/API callers can still pass `content_format`; omitted raw `datamachine/upsert-post` calls keep the legacy block-markup default.
+
+## Directory Reference
+
+| Directory | Contents |
+| --- | --- |
+| `inc/Engine/AI/Tools/Global/` | Chat/pipeline global tools such as search, analytics, memory, image generation, and audits. |
+| `inc/Api/Chat/Tools/` | Chat-only admin/workflow/content tools. |
+| `inc/Engine/AI/Tools/` | Tool registration, policy resolution, execution, and shared base classes. |
+| `inc/Abilities/Analytics/` | Analytics ability implementations used by analytics tools. |


### PR DESCRIPTION
## Summary
- Updates pipeline builder documentation around current admin UI operations and API usage.
- Refreshes AI tool inventory guidance for current modes, mutation risk, and agent-facing tool groups.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing admin/tool docs against implementation, drafting updated references, and preparing the PR text for Chris to review.