### PR TITLE
Add source inventory profiling ability

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -173,6 +173,8 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/StepTypeAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/LocalSearchAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/SourceAggregateAbility.php';
+	require_once __DIR__ . '/inc/Core/SourceAggregation/SourceInventoryProfiler.php';
+	require_once __DIR__ . '/inc/Abilities/SourceInventoryAbility.php';
 	require_once __DIR__ . '/inc/Abilities/SystemAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Media/AltTextAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Media/ImageGenerationAbilities.php';
@@ -270,6 +272,7 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\StepTypeAbilities();
 	new \DataMachine\Abilities\LocalSearchAbilities();
 	new \DataMachine\Abilities\SourceAggregateAbility();
+	new \DataMachine\Abilities\SourceInventoryAbility();
 	new \DataMachine\Abilities\SystemAbilities();
 	new \DataMachine\Abilities\Media\AltTextAbilities();
 	new \DataMachine\Abilities\Media\ImageGenerationAbilities();

--- a/inc/Abilities/SourceInventoryAbility.php
+++ b/inc/Abilities/SourceInventoryAbility.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Source inventory ability.
+ *
+ * @package DataMachine\Abilities
+ */
+
+namespace DataMachine\Abilities;
+
+use DataMachine\Core\SourceAggregation\PageableSourceAggregator;
+use DataMachine\Core\SourceAggregation\SourceInventoryProfiler;
+
+defined( 'ABSPATH' ) || exit;
+
+class SourceInventoryAbility {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbility();
+		self::$registered = true;
+	}
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/source-inventory',
+				array(
+					'label'               => __( 'Inspect Source Inventory', 'data-machine' ),
+					'description'         => __( 'Profile source inventory capabilities and optionally scan a pageable source for denominator diagnostics.', 'data-machine' ),
+					'category'            => 'datamachine-fetch',
+					'input_schema'        => $this->getInputSchema(),
+					'output_schema'       => $this->getOutputSchema(),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Execute source inventory profiling.
+	 *
+	 * @param array $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input ): array {
+		$source  = is_array( $input['source'] ?? null ) ? $input['source'] : array();
+		$profile = ( new SourceInventoryProfiler() )->profile( $source );
+		$result  = array(
+			'success' => true,
+			'profile' => $profile,
+		);
+
+		if ( ! empty( $input['scan'] ) ) {
+			$page_callback = $this->resolvePageCallback( $source, $input );
+			if ( ! is_callable( $page_callback ) ) {
+				$result['scan'] = array(
+					'success'     => false,
+					'error'       => 'No source inventory page executor is available for this source.',
+					'diagnostics' => array(
+						'source_kind' => (string) ( $source['kind'] ?? '' ),
+					),
+				);
+
+				return $result;
+			}
+
+			$config           = $input;
+			$config['params'] = is_array( $source['params'] ?? null ) ? $source['params'] : array();
+
+			$scan           = ( new PageableSourceAggregator() )->aggregate( $page_callback, $config );
+			$result['scan'] = array_merge( array( 'success' => true ), $scan );
+		}
+
+		return $result;
+	}
+
+	private function resolvePageCallback( array $source, array $input ): ?callable {
+		// @phpstan-ignore-next-line WP stubs expose a narrower apply_filters() signature than WordPress supports.
+		$callback = apply_filters( 'datamachine_source_inventory_page_callback', null, $source, $input );
+		if ( is_callable( $callback ) ) {
+			return $callback;
+		}
+
+		// Share the existing aggregation callback seam so adapters do not need to
+		// register two identical callbacks for simple pageable inventory scans.
+		// @phpstan-ignore-next-line WP stubs expose a narrower apply_filters() signature than WordPress supports.
+		$callback = apply_filters( 'datamachine_source_aggregate_page_callback', null, $source, $input );
+		if ( is_callable( $callback ) ) {
+			return $callback;
+		}
+
+		if ( 'static_pages' === ( $source['kind'] ?? '' ) && is_array( $source['pages'] ?? null ) ) {
+			$pages = array_values( $source['pages'] );
+			return static function ( array $params, array $state ) use ( $pages ): array {
+				$page_index = (int) ( $state['page_index'] ?? 0 );
+				return is_array( $pages[ $page_index ] ?? null ) ? $pages[ $page_index ] : array();
+			};
+		}
+
+		return null;
+	}
+
+	private function getInputSchema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'source' ),
+			'properties' => array(
+				'source'                  => array(
+					'type'        => 'object',
+					'description' => 'Source descriptor with optional capabilities. Core supports kind=static_pages for scans; extensions can provide inventory executors through datamachine_source_inventory_page_callback.',
+				),
+				'scan'                    => array(
+					'type'        => 'boolean',
+					'default'     => false,
+					'description' => 'When true, page through the source and return count/group diagnostics.',
+				),
+				'pagination'              => array(
+					'type'       => 'object',
+					'properties' => array(
+						'type'         => array( 'type' => 'string' ),
+						'limit'        => array( 'type' => 'integer' ),
+						'item_path'    => array( 'type' => 'string' ),
+						'total_path'   => array( 'type' => 'string' ),
+						'offset_param' => array( 'type' => 'string' ),
+						'limit_param'  => array( 'type' => 'string' ),
+					),
+				),
+				'group_by'                => array(
+					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
+					'description' => 'Top-level or dotted item fields to count when scan=true.',
+				),
+				'sample_limit_per_bucket' => array( 'type' => 'integer' ),
+				'max_items'               => array( 'type' => 'integer' ),
+				'max_pages'               => array( 'type' => 'integer' ),
+			),
+		);
+	}
+
+	private function getOutputSchema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success' => array( 'type' => 'boolean' ),
+				'profile' => array( 'type' => 'object' ),
+				'scan'    => array( 'type' => 'object' ),
+			),
+		);
+	}
+}

--- a/inc/Core/SourceAggregation/SourceInventoryProfiler.php
+++ b/inc/Core/SourceAggregation/SourceInventoryProfiler.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Source inventory capability profiler.
+ *
+ * @package DataMachine\Core\SourceAggregation
+ */
+
+namespace DataMachine\Core\SourceAggregation;
+
+defined( 'ABSPATH' ) || exit;
+
+class SourceInventoryProfiler {
+
+	/**
+	 * Build a generic inventory profile from a source descriptor.
+	 *
+	 * @param array $source Source descriptor.
+	 * @return array<string,mixed>
+	 */
+	public function profile( array $source ): array {
+		$capabilities = $this->normalizeCapabilities( $source['capabilities'] ?? array() );
+
+		/**
+		 * Filters source inventory capabilities for a source descriptor.
+		 *
+		 * Handlers/extensions can provide source-specific facts without Data Machine
+		 * core knowing provider semantics.
+		 *
+		 * @param array<string,mixed> $capabilities Normalized capabilities.
+		 * @param array<string,mixed> $source       Source descriptor.
+		 */
+		$filtered = apply_filters( 'datamachine_source_inventory_capabilities', $capabilities, $source );
+		if ( is_array( $filtered ) ) {
+			$capabilities = $this->normalizeCapabilities( $filtered );
+		}
+
+		$mode       = $this->coverageMode( $capabilities );
+		$confidence = $this->confidence( $capabilities, $mode );
+		$metric     = $this->metric( $mode );
+
+		return array(
+			'source_kind'          => (string) ( $source['kind'] ?? '' ),
+			'provider'             => (string) ( $source['provider'] ?? '' ),
+			'coverage_mode'        => $mode,
+			'confidence'           => $confidence,
+			'metric'               => $metric,
+			'has_denominator'      => in_array( $mode, array( 'inventory', 'counted_search', 'bounded_window' ), true ),
+			'denominator_reliable' => 'inventory' === $mode && ! empty( $capabilities['can_enumerate'] ) && ! empty( $capabilities['stable_ids'] ),
+			'capabilities'         => $capabilities,
+		);
+	}
+
+	/**
+	 * Normalize source capability flags and metadata.
+	 *
+	 * @param mixed $capabilities Raw capability metadata.
+	 * @return array<string,mixed>
+	 */
+	private function normalizeCapabilities( mixed $capabilities ): array {
+		if ( ! is_array( $capabilities ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $capabilities as $key => $value ) {
+			$key = $this->normalizeKey( (string) $key );
+			if ( '' === $key ) {
+				continue;
+			}
+
+			$normalized[ $key ] = $this->normalizeValue( $value );
+		}
+
+		return $normalized;
+	}
+
+	private function normalizeKey( string $key ): string {
+		$key = strtolower( trim( $key ) );
+		$key = preg_replace( '/[^a-z0-9_\-]+/', '_', $key );
+		$key = str_replace( '-', '_', (string) $key );
+
+		return trim( $key, '_' );
+	}
+
+	private function normalizeValue( mixed $value ): mixed {
+		if ( is_bool( $value ) || is_int( $value ) || is_float( $value ) || null === $value ) {
+			return $value;
+		}
+
+		if ( is_array( $value ) ) {
+			$normalized = array();
+			foreach ( $value as $key => $item ) {
+				if ( is_int( $key ) ) {
+					$normalized[] = $this->normalizeValue( $item );
+					continue;
+				}
+
+				$key = $this->normalizeKey( (string) $key );
+				if ( '' !== $key ) {
+					$normalized[ $key ] = $this->normalizeValue( $item );
+				}
+			}
+
+			return $normalized;
+		}
+
+		return trim( (string) $value );
+	}
+
+	private function coverageMode( array $capabilities ): string {
+		$explicit = $this->normalizeMode( (string) ( $capabilities['coverage_mode'] ?? '' ) );
+		if ( '' !== $explicit ) {
+			return $explicit;
+		}
+
+		if ( ! empty( $capabilities['can_enumerate'] ) && ! empty( $capabilities['stable_ids'] ) ) {
+			return 'inventory';
+		}
+
+		if ( ! empty( $capabilities['has_total_count'] ) ) {
+			return 'counted_search';
+		}
+
+		if ( ! empty( $capabilities['supports_time_windows'] ) && ! empty( $capabilities['stable_ids'] ) ) {
+			return 'bounded_window';
+		}
+
+		if ( ! empty( $capabilities['stable_ids'] ) || ! empty( $capabilities['supports_query_shards'] ) ) {
+			return 'sampled_discovery';
+		}
+
+		return 'unknown';
+	}
+
+	private function normalizeMode( string $mode ): string {
+		$mode = $this->normalizeKey( $mode );
+		return in_array( $mode, array( 'inventory', 'counted_search', 'bounded_window', 'sampled_discovery', 'unknown' ), true ) ? $mode : '';
+	}
+
+	private function confidence( array $capabilities, string $mode ): string {
+		$explicit = $this->normalizeKey( (string) ( $capabilities['confidence'] ?? '' ) );
+		if ( in_array( $explicit, array( 'high', 'medium', 'low' ), true ) ) {
+			return $explicit;
+		}
+
+		if ( 'inventory' === $mode && ! empty( $capabilities['stable_ids'] ) && ( ! empty( $capabilities['has_stable_cursor'] ) || ! empty( $capabilities['has_total_count'] ) ) ) {
+			return 'high';
+		}
+
+		if ( in_array( $mode, array( 'inventory', 'counted_search', 'bounded_window' ), true ) ) {
+			return 'medium';
+		}
+
+		return 'low';
+	}
+
+	private function metric( string $mode ): string {
+		if ( 'inventory' === $mode ) {
+			return 'known_denominator';
+		}
+		if ( 'counted_search' === $mode ) {
+			return 'reported_total_count';
+		}
+		if ( 'bounded_window' === $mode ) {
+			return 'window_seen_vs_evaluated';
+		}
+
+		return 'marginal_yield_saturation';
+	}
+}

--- a/tests/source-inventory-smoke.php
+++ b/tests/source-inventory-smoke.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Pure-PHP smoke for source inventory capability profiling.
+ *
+ * Run with: php tests/source-inventory-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ );
+	}
+
+	$GLOBALS['source_inventory_filters']              = array();
+	$GLOBALS['source_inventory_registered_abilities'] = array();
+
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $data, $flags = 0, $depth = 512 ) {
+			return json_encode( $data, $flags, $depth );
+		}
+	}
+
+	if ( ! function_exists( '__' ) ) {
+		function __( $text, $domain = 'default' ) {
+			return $text;
+		}
+	}
+
+	if ( ! function_exists( 'doing_action' ) ) {
+		function doing_action( $hook ) {
+			return 'wp_abilities_api_init' === $hook;
+		}
+	}
+
+	if ( ! function_exists( 'did_action' ) ) {
+		function did_action( $hook ) {
+			return 'wp_abilities_api_init' === $hook ? 1 : 0;
+		}
+	}
+
+	if ( ! function_exists( 'add_action' ) ) {
+		function add_action( $hook, $callback ) {}
+	}
+
+	if ( ! function_exists( 'add_filter' ) ) {
+		function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+			$GLOBALS['source_inventory_filters'][ $hook ][ $priority ][] = compact( 'callback', 'accepted_args' );
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( $hook, $value, ...$args ) {
+			if ( empty( $GLOBALS['source_inventory_filters'][ $hook ] ) ) {
+				return $value;
+			}
+
+			ksort( $GLOBALS['source_inventory_filters'][ $hook ] );
+			foreach ( $GLOBALS['source_inventory_filters'][ $hook ] as $callbacks ) {
+				foreach ( $callbacks as $entry ) {
+					$accepted = (int) $entry['accepted_args'];
+					$value    = call_user_func_array( $entry['callback'], array_slice( array_merge( array( $value ), $args ), 0, $accepted ) );
+				}
+			}
+
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'wp_register_ability' ) ) {
+		function wp_register_ability( $name, $args ) {
+			$GLOBALS['source_inventory_registered_abilities'][ $name ] = $args;
+		}
+	}
+}
+
+namespace DataMachine\Abilities {
+	if ( ! class_exists( PermissionHelper::class, false ) ) {
+		class PermissionHelper {
+			public static function can_manage(): bool {
+				return true;
+			}
+		}
+	}
+}
+
+namespace {
+	require_once __DIR__ . '/../inc/Core/SourceAggregation/PageableSourceAggregator.php';
+	require_once __DIR__ . '/../inc/Core/SourceAggregation/SourceInventoryProfiler.php';
+	require_once __DIR__ . '/../inc/Abilities/SourceInventoryAbility.php';
+
+	use DataMachine\Abilities\SourceInventoryAbility;
+	use DataMachine\Core\SourceAggregation\SourceInventoryProfiler;
+
+	$failed = 0;
+	$total  = 0;
+
+	function assert_source_inventory( string $name, bool $condition, string $detail = '' ): void {
+		global $failed, $total;
+		++$total;
+
+		if ( $condition ) {
+			echo "  [PASS] {$name}\n";
+			return;
+		}
+
+		++$failed;
+		echo "  [FAIL] {$name}" . ( $detail ? " - {$detail}" : '' ) . "\n";
+	}
+
+	function source_inventory_failed_count(): int {
+		global $failed;
+		return $failed;
+	}
+
+	echo "=== source-inventory-smoke ===\n";
+
+	$profiler = new SourceInventoryProfiler();
+	$profile  = $profiler->profile(
+		array(
+			'kind'         => 'search',
+			'provider'     => 'github',
+			'capabilities' => array(
+				'has-total-count'       => true,
+				'supports-time-windows' => true,
+				'stable-ids'            => true,
+			),
+		)
+	);
+
+	assert_source_inventory( 'counted source gets counted_search mode', 'counted_search' === $profile['coverage_mode'] );
+	assert_source_inventory( 'counted source uses reported total metric', 'reported_total_count' === $profile['metric'] );
+	assert_source_inventory( 'counted source has denominator', true === $profile['has_denominator'] );
+	assert_source_inventory( 'capability keys normalize to underscores', true === $profile['capabilities']['has_total_count'] );
+
+	$inventory = $profiler->profile(
+		array(
+			'kind'         => 'calendar',
+			'provider'     => 'events',
+			'capabilities' => array(
+				'can_enumerate'     => true,
+				'stable_ids'        => true,
+				'has_stable_cursor' => true,
+			),
+		)
+	);
+	assert_source_inventory( 'enumerable source gets inventory mode', 'inventory' === $inventory['coverage_mode'] );
+	assert_source_inventory( 'inventory source has high inferred confidence', 'high' === $inventory['confidence'] );
+	assert_source_inventory( 'inventory source denominator is reliable', true === $inventory['denominator_reliable'] );
+
+	$discovery = $profiler->profile(
+		array(
+			'kind'         => 'search',
+			'provider'     => 'mgs',
+			'capabilities' => array(
+				'supports_query_shards' => true,
+			),
+		)
+	);
+	assert_source_inventory( 'sharded search gets sampled discovery mode', 'sampled_discovery' === $discovery['coverage_mode'] );
+	assert_source_inventory( 'sampled discovery uses yield metric', 'marginal_yield_saturation' === $discovery['metric'] );
+
+	add_filter(
+		'datamachine_source_inventory_capabilities',
+		static function ( array $capabilities, array $source ): array {
+			if ( 'filtered' === ( $source['provider'] ?? '' ) ) {
+				$capabilities['coverage_mode'] = 'bounded_window';
+				$capabilities['confidence']    = 'medium';
+			}
+
+			return $capabilities;
+		},
+		10,
+		2
+	);
+
+	$filtered = $profiler->profile( array( 'provider' => 'filtered' ) );
+	assert_source_inventory( 'capability filter can provide provider facts', 'bounded_window' === $filtered['coverage_mode'] );
+	assert_source_inventory( 'capability filter confidence is preserved', 'medium' === $filtered['confidence'] );
+
+	$pages = array(
+		array(
+			'total' => 3,
+			'items' => array(
+				array( 'id' => 1, 'venue' => 'A' ),
+				array( 'id' => 2, 'venue' => 'A' ),
+			),
+		),
+		array(
+			'total' => 3,
+			'items' => array(
+				array( 'id' => 3, 'venue' => 'B' ),
+			),
+		),
+	);
+
+	$ability = new SourceInventoryAbility();
+	assert_source_inventory( 'ability registers datamachine/source-inventory', isset( $GLOBALS['source_inventory_registered_abilities']['datamachine/source-inventory'] ) );
+
+	$result = $ability->execute(
+		array(
+			'source'     => array(
+				'kind'         => 'static_pages',
+				'provider'     => 'fixture',
+				'pages'        => $pages,
+				'capabilities' => array(
+					'can_enumerate' => true,
+					'stable_ids'    => true,
+				),
+			),
+			'scan'       => true,
+			'pagination' => array( 'limit' => 2, 'item_path' => 'items', 'total_path' => 'total' ),
+			'group_by'   => array( 'venue' ),
+		)
+	);
+
+	assert_source_inventory( 'ability execute succeeds', true === ( $result['success'] ?? false ) );
+	assert_source_inventory( 'ability includes inventory profile', 'inventory' === ( $result['profile']['coverage_mode'] ?? '' ) );
+	assert_source_inventory( 'ability scan processes static pages', 3 === ( $result['scan']['processed'] ?? 0 ) );
+	assert_source_inventory( 'ability scan reports total denominator', 3 === ( $result['scan']['total'] ?? 0 ) );
+	assert_source_inventory( 'ability scan groups item fields', 2 === ( $result['scan']['groups']['venue']['A'] ?? 0 ) );
+
+	$unsupported = $ability->execute(
+		array(
+			'source' => array( 'kind' => 'live' ),
+			'scan'   => true,
+		)
+	);
+	assert_source_inventory( 'unsupported scan fails inside scan result only', true === ( $unsupported['success'] ?? false ) && false === ( $unsupported['scan']['success'] ?? true ) );
+
+	if ( source_inventory_failed_count() > 0 ) {
+		echo "\nsource-inventory-smoke failed: {$failed}/{$total} assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nsource-inventory-smoke passed: {$total} assertions.\n";
+}


### PR DESCRIPTION
## Summary

- Add a generic `datamachine/source-inventory` ability for source capability profiling and optional pageable inventory scans.
- Add `SourceInventoryProfiler` beside the existing pageable source aggregation primitive so source wells can declare coverage mode, confidence, denominator reliability, and recommended metrics without provider-specific hardcoding in consumers.
- Add a pure PHP smoke test covering inventory/count/window/discovery profiling, capability filters, ability registration, static-page scans, and unsupported live-source scan behavior.

## Testing

- `php -l inc/Core/SourceAggregation/SourceInventoryProfiler.php`
- `php -l inc/Abilities/SourceInventoryAbility.php`
- `php tests/source-inventory-smoke.php`
- `php tests/source-aggregate-smoke.php`
- `vendor/bin/phpcs --standard=phpcs.xml.dist data-machine.php inc/Core/SourceAggregation/SourceInventoryProfiler.php inc/Abilities/SourceInventoryAbility.php tests/source-inventory-smoke.php`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/data-machine@feature-source-inventory-primitive --extension wordpress --changed-only`

Note: `homeboy test --path /Users/chubes/Developer/data-machine@feature-source-inventory-primitive --extension wordpress` currently hits an existing `PipelineExecutionContractTest::test_fetch_ai_publish_pipeline_executes_with_fake_provider_only` token-usage assertion failure. The same single test fails on primary `/Users/chubes/Developer/data-machine`, so it appears unrelated to this branch.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the generic source inventory primitive, wiring the ability, adding smoke coverage, and running validation under Chris's direction.