### PR TITLE
Allow AI steps to choose agent mode

### DIFF
--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -153,7 +153,7 @@ class PipelineStepAbilities {
 			'datamachine/update-pipeline-step',
 			array(
 				'label'               => __( 'Update Pipeline Step', 'data-machine' ),
-				'description'         => __( 'Update pipeline step configuration (system prompt and AI tool policy). Model/provider are configured via mode_models setting.', 'data-machine' ),
+				'description'         => __( 'Update pipeline step configuration (system prompt, AI execution mode, and AI tool policy). Model/provider are configured via mode_models setting.', 'data-machine' ),
 				'category'            => 'datamachine-pipeline',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -166,6 +166,10 @@ class PipelineStepAbilities {
 						'system_prompt'    => array(
 							'type'        => 'string',
 							'description' => __( 'System prompt for AI step', 'data-machine' ),
+						),
+						'agent_mode'       => array(
+							'type'        => 'string',
+							'description' => __( 'Agent execution mode for this AI step. Defaults to pipeline.', 'data-machine' ),
 						),
 						'disabled_tools'   => array(
 							'type'        => 'array',
@@ -531,6 +535,7 @@ class PipelineStepAbilities {
 		}
 
 		$system_prompt = $input['system_prompt'] ?? null;
+		$agent_mode    = $input['agent_mode'] ?? null;
 		$policy_fields = array( 'disabled_tools', 'tool_categories' );
 
 		// provider/model are no longer configurable at the pipeline step level.
@@ -544,10 +549,10 @@ class PipelineStepAbilities {
 			}
 		}
 
-		if ( null === $system_prompt && ! $has_policy_field ) {
+		if ( null === $system_prompt && null === $agent_mode && ! $has_policy_field ) {
 			return array(
 				'success' => false,
-				'error'   => 'At least one of system_prompt, disabled_tools, or tool_categories is required',
+				'error'   => 'At least one of system_prompt, agent_mode, disabled_tools, or tool_categories is required',
 			);
 		}
 
@@ -579,6 +584,11 @@ class PipelineStepAbilities {
 		if ( null !== $system_prompt ) {
 			$step_config_data['system_prompt'] = wp_unslash( $system_prompt );
 			$updated_fields[]                  = 'system_prompt';
+		}
+
+		if ( null !== $agent_mode ) {
+			$step_config_data['agent_mode'] = sanitize_key( (string) $agent_mode );
+			$updated_fields[]               = 'agent_mode';
 		}
 
 		foreach ( $policy_fields as $field ) {

--- a/inc/Api/Chat/Tools/ConfigurePipelineStep.php
+++ b/inc/Api/Chat/Tools/ConfigurePipelineStep.php
@@ -33,7 +33,7 @@ class ConfigurePipelineStep extends BaseTool {
 		return array(
 			'class'       => self::class,
 			'method'      => 'handle_tool_call',
-			'description' => 'Configure pipeline-level AI step settings: system prompt and tool policy. Model/provider are managed via the mode_models site setting, not per-pipeline. For flow-level settings (handler, handler_config, user_message), use configure_flow_steps instead.',
+			'description' => 'Configure pipeline-level AI step settings: system prompt, execution mode, and tool policy. Model/provider are managed via the mode_models site setting, not per-pipeline. For flow-level settings (handler, handler_config, user_message), use configure_flow_steps instead.',
 			'parameters'  => array(
 				'type'       => 'object',
 				'properties' => array(
@@ -44,6 +44,10 @@ class ConfigurePipelineStep extends BaseTool {
 					'system_prompt'    => array(
 						'type'        => 'string',
 						'description' => 'System prompt for the AI step - defines the AI persona and instructions',
+					),
+					'agent_mode'       => array(
+						'type'        => 'string',
+						'description' => 'Agent execution mode for this AI step. Defaults to pipeline.',
 					),
 					'disabled_tools'   => array(
 						'type'        => 'array',

--- a/inc/Api/Chat/Tools/CreatePipeline.php
+++ b/inc/Api/Chat/Tools/CreatePipeline.php
@@ -346,6 +346,9 @@ class CreatePipeline extends BaseTool {
 			if ( isset( $step['system_prompt'] ) ) {
 				$normalized_step['system_prompt'] = $step['system_prompt'];
 			}
+			if ( isset( $step['agent_mode'] ) && is_scalar( $step['agent_mode'] ) ) {
+				$normalized_step['agent_mode'] = sanitize_key( (string) $step['agent_mode'] );
+			}
 
 			$normalized[] = $normalized_step;
 		}

--- a/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
+++ b/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
@@ -44,7 +44,7 @@ class ExecuteWorkflowTool extends BaseTool {
 
 		$description = 'Execute an ephemeral workflow (not saved to database).
 
-STEP FORMAT: {type: "' . $types_list . '", handler_slug, handler_config, user_message?, system_prompt?}
+STEP FORMAT: {type: "' . $types_list . '", handler_slug, handler_config, user_message?, system_prompt?, agent_mode?}
 
 Use api_query GET /datamachine/v1/handlers/{slug} for handler_config fields.
 

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -87,7 +87,8 @@ class AIStep extends Step {
 
 		// Model/provider resolved exclusively via mode system (agent → site → network).
 		// Pipeline-level model/provider fields are ignored — mode_models is the authority.
-		$mode_model    = PluginSettings::resolveModelForAgentMode( $agent_id, 'pipeline' );
+		$execution_mode = self::resolveExecutionMode( $pipeline_step_config, $this->flow_step_config );
+		$mode_model     = PluginSettings::resolveModelForAgentMode( $agent_id, $execution_mode );
 		$provider_name = $mode_model['provider'];
 		if ( empty( $provider_name ) ) {
 			do_action(
@@ -97,8 +98,9 @@ class AIStep extends Step {
 				array(
 					'flow_step_id'     => $this->flow_step_id,
 					'pipeline_step_id' => $pipeline_step_id,
-					'error_message'    => 'AI step requires provider configuration. Set a default provider in Data Machine settings or configure mode_models.',
-					'solution'         => 'Set default_provider in Data Machine settings or configure mode_models for the pipeline mode',
+					'agent_mode'       => $execution_mode,
+					'error_message'    => sprintf( 'AI step requires provider configuration for agent mode "%s". Set a default provider in Data Machine settings or configure mode_models.', $execution_mode ),
+					'solution'         => sprintf( 'Set default_provider in Data Machine settings or configure mode_models for the %s mode', $execution_mode ),
 				)
 			);
 			return false;
@@ -155,8 +157,11 @@ class AIStep extends Step {
 		$agent_slug   = $this->resolveAgentSlugFromJobSnapshot( $job_snapshot, $agent_id );
 		$user_id      = (int) ( $job_snapshot['user_id'] ?? 0 );
 
+		$pipeline_step_config = $this->engine->getPipelineStepConfig( $pipeline_step_id );
+		$execution_mode       = self::resolveExecutionMode( $pipeline_step_config, $this->flow_step_config );
+
 		// Model/provider resolved exclusively via mode system — pipeline config is ignored.
-		$mode_model    = PluginSettings::resolveModelForAgentMode( $agent_id, 'pipeline' );
+		$mode_model    = PluginSettings::resolveModelForAgentMode( $agent_id, $execution_mode );
 		$provider_name = $mode_model['provider'];
 		$model_name    = $mode_model['model'];
 
@@ -168,7 +173,7 @@ class AIStep extends Step {
 				'pipeline_step_id' => $pipeline_step_id,
 				'pipeline_id'      => $job_snapshot['pipeline_id'] ?? null,
 				'flow_id'          => $job_snapshot['flow_id'] ?? null,
-				'mode'             => 'pipeline',
+				'mode'             => $execution_mode,
 			)
 		);
 
@@ -259,8 +264,6 @@ class AIStep extends Step {
 				$messages[] = ConversationManager::buildConversationMessage( 'user', $user_message );
 			}
 
-			$pipeline_step_config = $this->engine->getPipelineStepConfig( $pipeline_step_id );
-
 			$max_turns = PluginSettings::get( 'max_turns', PluginSettings::DEFAULT_MAX_TURNS );
 
 			// Resolve transcript persistence policy once per AI step invocation.
@@ -280,6 +283,7 @@ class AIStep extends Step {
 				'user_id'                     => $user_id,
 				'agent_id'                    => $agent_id,
 				'agent_slug'                  => $agent_slug,
+				'agent_mode'                  => $execution_mode,
 				'pipeline_id'                 => $job_snapshot['pipeline_id'] ?? null,
 				'flow_id'                     => $job_snapshot['flow_id'] ?? null,
 				'persist_transcript'          => $persist_transcript,
@@ -326,7 +330,7 @@ class AIStep extends Step {
 			$available_tools = $resolver->resolve(
 				array_merge(
 					array(
-						'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
+						'mode'                 => $execution_mode,
 						'agent_id'             => $agent_id,
 						'agent_slug'           => $agent_slug,
 						'previous_step_config' => $previous_step_config,
@@ -415,7 +419,7 @@ class AIStep extends Step {
 					$available_tools,
 					$provider_name,
 					$model_name,
-					ToolPolicyResolver::MODE_PIPELINE,
+					$execution_mode,
 					$payload,
 					$max_turns
 				);
@@ -672,6 +676,27 @@ class AIStep extends Step {
 		}
 
 		return $counts;
+	}
+
+	/**
+	 * Resolve the agent execution mode for this AI step.
+	 *
+	 * @param array $pipeline_step_config Pipeline step config.
+	 * @param array $flow_step_config Flow step config.
+	 * @return string Agent mode slug.
+	 */
+	private static function resolveExecutionMode( array $pipeline_step_config, array $flow_step_config ): string {
+		$raw_mode = ToolPolicyResolver::MODE_PIPELINE;
+		foreach ( array( $flow_step_config['agent_mode'] ?? null, $pipeline_step_config['agent_mode'] ?? null ) as $candidate ) {
+			if ( is_scalar( $candidate ) && '' !== trim( (string) $candidate ) ) {
+				$raw_mode = $candidate;
+				break;
+			}
+		}
+
+		$mode = function_exists( 'sanitize_key' ) ? sanitize_key( (string) $raw_mode ) : strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $raw_mode ) ?? '' );
+
+		return '' !== $mode ? $mode : ToolPolicyResolver::MODE_PIPELINE;
 	}
 
 	/**

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -89,7 +89,7 @@ class AIStep extends Step {
 		// Pipeline-level model/provider fields are ignored — mode_models is the authority.
 		$execution_mode = self::resolveExecutionMode( $pipeline_step_config, $this->flow_step_config );
 		$mode_model     = PluginSettings::resolveModelForAgentMode( $agent_id, $execution_mode );
-		$provider_name = $mode_model['provider'];
+		$provider_name  = $mode_model['provider'];
 		if ( empty( $provider_name ) ) {
 			do_action(
 				'datamachine_fail_job',

--- a/inc/Core/Steps/FlowStepConfigFactory.php
+++ b/inc/Core/Steps/FlowStepConfigFactory.php
@@ -39,6 +39,7 @@ class FlowStepConfigFactory {
 				self::promptQueueFromWorkflowStep( $step ),
 				array(
 					'queue_mode'         => 'static',
+					'agent_mode'         => isset( $step['agent_mode'] ) && is_scalar( $step['agent_mode'] ) ? self::sanitizeAgentMode( (string) $step['agent_mode'] ) : '',
 					'disabled_tools'     => $step['disabled_tools'] ?? array(),
 					'pipeline_id'        => 'direct',
 					'flow_id'            => 'direct',
@@ -90,6 +91,7 @@ class FlowStepConfigFactory {
 					'pipeline_id'      => $pipeline_id,
 					'flow_id'          => $flow_id,
 					'execution_order'  => $step['execution_order'] ?? 0,
+					'agent_mode'       => isset( $pipeline_step_config['agent_mode'] ) && is_scalar( $pipeline_step_config['agent_mode'] ) ? self::sanitizeAgentMode( (string) $pipeline_step_config['agent_mode'] ) : '',
 					'disabled_tools'   => $pipeline_step_config['disabled_tools'] ?? array(),
 				),
 				self::queueDefaultsForStepType( $step_type )
@@ -111,6 +113,7 @@ class FlowStepConfigFactory {
 			'step_type'                           => true,
 			'execution_order'                     => true,
 			'enabled_tools'                       => true,
+			'agent_mode'                          => true,
 			'disabled_tools'                      => true,
 			'completion_assertions'               => true,
 			'tool_runtime_rules'                  => true,
@@ -312,5 +315,15 @@ class FlowStepConfigFactory {
 		$step_config['queue_mode']                      = 'static';
 
 		return $step_config;
+	}
+
+	/**
+	 * Sanitize an agent mode slug without requiring full WordPress bootstrap.
+	 *
+	 * @param string $mode Raw mode.
+	 * @return string Sanitized mode.
+	 */
+	private static function sanitizeAgentMode( string $mode ): string {
+		return function_exists( 'sanitize_key' ) ? sanitize_key( $mode ) : strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $mode ) ?? '' );
 	}
 }

--- a/inc/Core/Steps/WorkflowConfigFactory.php
+++ b/inc/Core/Steps/WorkflowConfigFactory.php
@@ -137,6 +137,9 @@ class WorkflowConfigFactory {
 		if ( 'ai' === $step_type ) {
 			$pipeline_step['system_prompt']  = $step['system_prompt'] ?? '';
 			$pipeline_step['disabled_tools'] = is_array( $step['disabled_tools'] ?? null ) ? array_values( $step['disabled_tools'] ) : array();
+			if ( isset( $step['agent_mode'] ) && is_scalar( $step['agent_mode'] ) ) {
+				$pipeline_step['agent_mode'] = self::sanitizeAgentMode( (string) $step['agent_mode'] );
+			}
 			foreach ( array( 'completion_assertions', 'tool_runtime_rules', 'tool_categories' ) as $field ) {
 				if ( is_array( $step[ $field ] ?? null ) ) {
 					$pipeline_step[ $field ] = 'completion_assertions' === $field
@@ -147,5 +150,15 @@ class WorkflowConfigFactory {
 		}
 
 		return $pipeline_step;
+	}
+
+	/**
+	 * Sanitize an agent mode slug without requiring full WordPress bootstrap.
+	 *
+	 * @param string $mode Raw mode.
+	 * @return string Sanitized mode.
+	 */
+	private static function sanitizeAgentMode( string $mode ): string {
+		return function_exists( 'sanitize_key' ) ? sanitize_key( $mode ) : strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $mode ) ?? '' );
 	}
 }

--- a/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
+++ b/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
@@ -528,7 +528,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 		);
 
 		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'system_prompt, disabled_tools, or tool_categories', $result['error'] );
+		$this->assertStringContainsString( 'system_prompt, agent_mode, disabled_tools, or tool_categories', $result['error'] );
 	}
 
 	public function test_update_pipeline_step_no_fields(): void {

--- a/tests/Unit/Core/Steps/AI/AIStepTest.php
+++ b/tests/Unit/Core/Steps/AI/AIStepTest.php
@@ -122,7 +122,7 @@ class AIStepTest extends TestCase {
 
 		$this->assertSame(
 			'rl_task',
-			$method->invoke( null, array( 'agent_mode' => 'pipeline' ), array( 'agent_mode' => 'RL Task' ) )
+			$method->invoke( null, array( 'agent_mode' => 'pipeline' ), array( 'agent_mode' => 'rl_task' ) )
 		);
 		$this->assertSame(
 			'eval',

--- a/tests/Unit/Core/Steps/AI/AIStepTest.php
+++ b/tests/Unit/Core/Steps/AI/AIStepTest.php
@@ -10,6 +10,7 @@ namespace DataMachine\Tests\Unit\Core\Steps\AI;
 use DataMachine\Core\Steps\AI\AIStep;
 use DataMachine\Engine\AI\DataPacketPromptProjector;
 use DataMachine\Engine\AI\Tools\ToolResultFinder;
+use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -112,6 +113,24 @@ class AIStepTest extends TestCase {
 				'custom_tool'                  => 2,
 			),
 			$merged['minimum_successful_tool_counts']
+		);
+	}
+
+	public function test_resolve_execution_mode_uses_flow_override_then_pipeline_config(): void {
+		$method = new ReflectionMethod( AIStep::class, 'resolveExecutionMode' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			'rl_task',
+			$method->invoke( null, array( 'agent_mode' => 'pipeline' ), array( 'agent_mode' => 'RL Task' ) )
+		);
+		$this->assertSame(
+			'eval',
+			$method->invoke( null, array( 'agent_mode' => 'Eval' ), array( 'agent_mode' => '' ) )
+		);
+		$this->assertSame(
+			ToolPolicyResolver::MODE_PIPELINE,
+			$method->invoke( null, array(), array() )
 		);
 	}
 

--- a/tests/ai-step-agent-mode-plumbing-smoke.php
+++ b/tests/ai-step-agent-mode-plumbing-smoke.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Smoke test for configurable AI step agent mode plumbing.
+ *
+ * Run with: php tests/ai-step-agent-mode-plumbing-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$source = file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' ) ?: '';
+
+$failures = array();
+$passes   = 0;
+
+$assert = static function ( string $message, bool $condition ) use ( &$failures, &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	$failures[] = $message;
+	echo "FAIL: {$message}\n";
+};
+
+$assert(
+	'AI step resolves execution mode from step configuration',
+	false !== strpos( $source, 'resolveExecutionMode( $pipeline_step_config, $this->flow_step_config )' )
+);
+
+$assert(
+	'model resolution uses resolved execution mode',
+	false !== strpos( $source, 'PluginSettings::resolveModelForAgentMode( $agent_id, $execution_mode )' )
+);
+
+$assert(
+	'tool policy receives resolved execution mode',
+	false !== strpos( $source, "'mode'                 => $" . 'execution_mode' )
+);
+
+$assert(
+	'conversation loop receives resolved execution mode',
+	false !== strpos( $source, "\n\t\t\t\t\t$" . 'execution_mode,' )
+);
+
+$assert(
+	'payload carries agent_mode for directives and runtime context',
+	false !== strpos( $source, "'agent_mode'                  => $" . 'execution_mode' )
+);
+
+$assert(
+	'AI step no longer hardcodes pipeline for model resolution',
+	false === strpos( $source, "resolveModelForAgentMode( $" . "agent_id, 'pipeline'" )
+);
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " AI step agent mode plumbing assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} AI step agent mode plumbing assertions passed.\n";

--- a/tests/workflow-spec-contract-smoke.php
+++ b/tests/workflow-spec-contract-smoke.php
@@ -160,6 +160,7 @@ $configs         = WorkflowConfigFactory::buildEphemeralConfigs(
 			array(
 				'type'           => 'ai',
 				'label'          => 'Summarize',
+				'agent_mode'     => 'rl_task',
 				'system_prompt'  => 'Be concise.',
 				'disabled_tools' => array( 'danger_tool' ),
 				'completion_assertions' => array(
@@ -187,6 +188,7 @@ assert_workflow_spec_equals( array( 'ephemeral_pipeline_0', 'ephemeral_pipeline_
 assert_workflow_spec_equals( array( 'fetch', 'ai', 'system_task' ), array_column( $pipeline_steps, 'step_type' ), 'ephemeral pipeline_config preserves step types', $failures, $passes );
 assert_workflow_spec_equals( array( 0, 1, 2 ), array_column( $pipeline_steps, 'execution_order' ), 'ephemeral pipeline_config preserves execution order', $failures, $passes );
 assert_workflow_spec_equals( 'Fetch Source', $pipeline_steps[0]['label'] ?? null, 'ephemeral pipeline_config preserves fetch label', $failures, $passes );
+assert_workflow_spec_equals( 'rl_task', $pipeline_steps[1]['agent_mode'] ?? null, 'ephemeral pipeline_config preserves AI agent mode', $failures, $passes );
 assert_workflow_spec_equals( 'Be concise.', $pipeline_steps[1]['system_prompt'] ?? null, 'ephemeral pipeline_config preserves AI system prompt', $failures, $passes );
 assert_workflow_spec_equals( array( 'danger_tool' ), $pipeline_steps[1]['disabled_tools'] ?? null, 'ephemeral pipeline_config preserves AI disabled tools', $failures, $passes );
 assert_workflow_spec_equals( array( 'required_tool_names' => array( 'publish_result' ) ), $pipeline_steps[1]['completion_assertions'] ?? null, 'ephemeral pipeline_config preserves AI completion assertions', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add `agent_mode` plumbing for AI steps so model resolution, tool policy, directives, and runtime context use the configured mode instead of always `pipeline`.
- Preserve `pipeline` as the default for existing steps and workflow specs.
- Expose `agent_mode` through workflow config factories and pipeline-step configuration surfaces.

## Testing
- `php tests/ai-step-agent-mode-plumbing-smoke.php`
- `php tests/workflow-spec-contract-smoke.php`
- `php -l` on changed PHP files
- `git diff --check`
- `homeboy test --path /Users/chubes/Developer/data-machine@ai-step-execution-mode --extension nodejs`
- `homeboy lint --path /Users/chubes/Developer/data-machine@ai-step-execution-mode --extension nodejs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the scoped implementation, tests, and validation commands; Chris directed the design target and remains responsible for review.