### PR TITLE
Use lightweight Jobs dropdown endpoints

### DIFF
--- a/inc/Core/Admin/Pages/Jobs/assets/react/api/jobs.js
+++ b/inc/Core/Admin/Pages/Jobs/assets/react/api/jobs.js
@@ -18,6 +18,7 @@ import { client } from '@shared/utils/api';
  * @param {number} params.page  Current page (1-based)
  * @param {number} params.perPage Items per page
  * @param {string} params.status Optional status filter
+ * @param {boolean} params.hideChildren Hide child jobs in the main list
  * @return {Promise<Object>} Jobs list response
  */
 export const fetchJobs = ( {

--- a/inc/Core/Admin/Pages/Jobs/assets/react/api/jobs.js
+++ b/inc/Core/Admin/Pages/Jobs/assets/react/api/jobs.js
@@ -89,7 +89,11 @@ export const clearProcessedItems = ( clearType, targetId ) =>
  *
  * @return {Promise<Object>} Pipelines list response
  */
-export const fetchPipelines = () => client.get( '/pipelines' );
+export const fetchPipelines = () =>
+	client.get( '/pipelines', {
+		include_flows: false,
+		per_page: 100,
+	} );
 
 /**
  * Fetch flows for a specific pipeline
@@ -98,4 +102,8 @@ export const fetchPipelines = () => client.get( '/pipelines' );
  * @return {Promise<Object>} Flows list response
  */
 export const fetchFlowsForPipeline = ( pipelineId ) =>
-	client.get( `/pipelines/${ pipelineId }/flows` );
+	client.get( '/flows', {
+		pipeline_id: pipelineId,
+		output_mode: 'list',
+		per_page: 100,
+	} );


### PR DESCRIPTION
## Summary
- Switches the Jobs admin processed-items modal to load pipeline dropdown data with `include_flows=false`.
- Switches the flow dropdown from the full `/pipelines/{id}/flows` payload to `/flows?output_mode=list`.
- Keeps initial Jobs page loading unchanged while avoiding multi-megabyte modal dropdown payloads on scaled installs.

## Evidence
Seeded Studio scale site:
- 80 pipelines
- 1108 flows
- 5000 jobs
- 20000 logs
- ~18.93 MB total flow config payload

Measured modal endpoint payloads before/after:
- `/datamachine/v1/pipelines`: 4,378,195 bytes
- `/datamachine/v1/pipelines?include_flows=false&per_page=100`: 112,079 bytes
- `/datamachine/v1/pipelines/80/flows`: 217,593 bytes
- `/datamachine/v1/flows?pipeline_id=80&output_mode=list&per_page=100`: 4,024 bytes

Homeboy profile after the change:
- Run ID: `1ddc5b5b-d340-4329-badd-8981688b5363`
- Jobs page ready: warmup 857ms, measure 766ms
- Initial load remains paginated jobs/settings/agents only.

## Testing
- `npm run build`
- `homeboy bench --path /Users/chubes/Developer/studio --extension nodejs --scenario studio-site-editor-diagnostics --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated scaled admin-page evidence, identified the Jobs modal payload issue, drafted the small client-side endpoint change, and ran local build/benchmark verification for Chris to review.