### PR TITLE
Fix engine data cache after job writes

### DIFF
--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -739,6 +739,8 @@ class Jobs extends BaseRepository {
 			return false;
 		}
 
+		wp_cache_set( $job_id, $data, 'datamachine_engine_data' );
+
 		do_action(
 			'datamachine_log',
 			'debug',

--- a/tests/system-task-output-packets-smoke.php
+++ b/tests/system-task-output-packets-smoke.php
@@ -14,6 +14,7 @@ $sources = array(
 	'task'     => file_get_contents( $root . '/inc/Engine/AI/System/Tasks/EmitDataPacketsTask.php' ) ?: '',
 	'provider' => file_get_contents( $root . '/inc/Engine/AI/System/SystemAgentServiceProvider.php' ) ?: '',
 	'engine'   => file_get_contents( $root . '/inc/Abilities/Engine/ExecuteStepAbility.php' ) ?: '',
+	'jobs'     => file_get_contents( $root . '/inc/Core/Database/Jobs/Jobs.php' ) ?: '',
 );
 
 $failures = array();
@@ -54,6 +55,9 @@ assert_system_task_output_contains( $sources['provider'], "\$tasks['emit_data_pa
 echo "\n[4] engine status override can stop after zero emitted packets\n";
 assert_system_task_output_contains( $sources['engine'], 'if ( $status_override )', 'ExecuteStepAbility honors status override before normal continuation', $failures, $passes );
 assert_system_task_output_contains( $sources['engine'], 'JobStatus::COMPLETED_NO_ITEMS', 'ExecuteStepAbility recognizes completed_no_items statuses', $failures, $passes );
+
+echo "\n[5] engine data writes refresh the shared cache\n";
+assert_system_task_output_contains( $sources['jobs'], "wp_cache_set( \$job_id, \$data, 'datamachine_engine_data'", 'Jobs::store_engine_data refreshes EngineData cache after direct writes', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " system task output packet assertions failed.\n";


### PR DESCRIPTION
## Summary
- Refresh the shared `datamachine_engine_data` object cache whenever `Jobs::store_engine_data()` writes a new snapshot.
- Covers the system task DataPacket handoff path so follow-up metrics/status writes do not resurrect stale engine data.

## Testing
- `php tests/system-task-output-packets-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the stale engine-data cache interaction, drafted the minimal fix, and ran the smoke test; Chris reviewed/approved opening the PR.