### PR TITLE
fix: preserve direct workflow step packets

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -136,6 +136,12 @@ class ExecuteStepAbility {
 			$context     = datamachine_get_file_context( $flow_id );
 			$retrieval   = new FileRetrieval();
 			$dataPackets = $retrieval->retrieve_data_by_job_id( $job_id, $context );
+			if ( empty( $dataPackets ) && 'direct' === $flow_id ) {
+				$direct_step_data_packets = is_array( $engine_snapshot['direct_step_data_packets'][ $flow_step_id ] ?? null ) ? $engine_snapshot['direct_step_data_packets'][ $flow_step_id ] : array();
+				if ( ! empty( $direct_step_data_packets ) ) {
+					$dataPackets = $direct_step_data_packets;
+				}
+			}
 
 			if ( ! isset( $flow_step_config['step_type'] ) || empty( $flow_step_config['step_type'] ) ) {
 				do_action(

--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -113,8 +113,16 @@ class ScheduleNextStepAbility {
 
 			$raw_flow_id = $flow_step_config['flow_id'] ?? ( $engine->getJobContext()['flow_id'] ?? null );
 
-			// Standalone jobs (null flow_id) skip file-based data storage.
-			if ( null !== $raw_flow_id && 'direct' !== $raw_flow_id ) {
+			// Direct workflows do not have a numeric flow file context, so keep
+			// step input packets on engine data for execute-step to reload.
+			if ( 'direct' === $raw_flow_id ) {
+				$direct_step_data_packets                    = is_array( $engine_snapshot['direct_step_data_packets'] ?? null ) ? $engine_snapshot['direct_step_data_packets'] : array();
+				$direct_step_data_packets[ $flow_step_id ] = $dataPackets;
+				datamachine_merge_engine_data(
+					$job_id,
+					array( 'direct_step_data_packets' => $direct_step_data_packets )
+				);
+			} elseif ( null !== $raw_flow_id ) {
 				$flow_id = (int) $raw_flow_id;
 
 				if ( $flow_id <= 0 ) {

--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -116,7 +116,7 @@ class ScheduleNextStepAbility {
 			// Direct workflows do not have a numeric flow file context, so keep
 			// step input packets on engine data for execute-step to reload.
 			if ( 'direct' === $raw_flow_id ) {
-				$direct_step_data_packets                    = is_array( $engine_snapshot['direct_step_data_packets'] ?? null ) ? $engine_snapshot['direct_step_data_packets'] : array();
+				$direct_step_data_packets                  = is_array( $engine_snapshot['direct_step_data_packets'] ?? null ) ? $engine_snapshot['direct_step_data_packets'] : array();
 				$direct_step_data_packets[ $flow_step_id ] = $dataPackets;
 				datamachine_merge_engine_data(
 					$job_id,

--- a/tests/execute-workflow-initial-data-contract-smoke.php
+++ b/tests/execute-workflow-initial-data-contract-smoke.php
@@ -144,4 +144,12 @@ dm_assert_same( 9, $engine_data_with_snapshot['job']['agent_id'], 'caller job.ag
 dm_assert_same( 8, $engine_data_with_snapshot['job']['user_id'], 'caller job.user_id remains authoritative over flat user_id' );
 dm_assert_same( 101, $engine_data_with_snapshot['job']['job_id'], 'engine job_id remains authoritative over caller job.job_id' );
 
+echo "\n[5] direct workflow packet handoff is engine-backed\n";
+$schedule_next_step_source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/Engine/ScheduleNextStepAbility.php' ) ?: '';
+$execute_step_source       = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/Engine/ExecuteStepAbility.php' ) ?: '';
+dm_assert_same( true, str_contains( $schedule_next_step_source, "'direct' === \$raw_flow_id" ), 'direct schedule path is detected before file storage' );
+dm_assert_same( true, str_contains( $schedule_next_step_source, 'direct_step_data_packets' ), 'direct schedule path stores data packets on engine data' );
+dm_assert_same( true, str_contains( $execute_step_source, "empty( \$dataPackets ) && 'direct' === \$flow_id" ), 'direct execute path falls back when file storage has no packets' );
+dm_assert_same( true, str_contains( $execute_step_source, 'direct_step_data_packets' ), 'direct execute path reloads engine-backed packets' );
+
 echo "\n=== execute-workflow-initial-data-contract-smoke: ALL PASS ===\n";


### PR DESCRIPTION
## Summary
- Preserve DataPackets scheduled between steps in direct/ephemeral workflows by storing them on job engine data.
- Reload those engine-backed packets in `execute-step` when direct workflows have no numeric flow file context.
- Extend the execute-workflow contract smoke test to cover the direct packet handoff path.

## Testing
- php tests/execute-workflow-initial-data-contract-smoke.php
- php -l inc/Abilities/Engine/ScheduleNextStepAbility.php
- php -l inc/Abilities/Engine/ExecuteStepAbility.php
- php -l tests/execute-workflow-initial-data-contract-smoke.php
- homeboy lint --path /Users/chubes/Developer/data-machine@fix-direct-workflow-packet-handoff --extension wordpress --changed-only --errors-only

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the direct workflow DataPacket handoff gap and drafted the minimal patch plus smoke coverage; Chris remains responsible for review and merge.