### PR TITLE
Make pipeline list responses explicit

### DIFF
--- a/docs/admin-interface/pipeline-builder.md
+++ b/docs/admin-interface/pipeline-builder.md
@@ -42,15 +42,15 @@ Updates, deletes, queue changes, handler changes, and file operations do not add
 
 | Operation | Client function | Endpoint |
 | --- | --- | --- |
-| List pipelines | `fetchPipelines(null, { perPage, offset, includeFlows, search })` | `GET /pipelines` |
-| Fetch one pipeline | `fetchPipelines(pipelineId, { includeFlows })` | `GET /pipelines?pipeline_id=...` |
+| List pipelines | `fetchPipelines(null, { perPage, offset, outputMode, includeFlows, search })` | `GET /pipelines` |
+| Fetch one pipeline | `fetchPipelines(pipelineId, { outputMode, includeFlows })` | `GET /pipelines?pipeline_id=...` |
 | Create pipeline | `createPipeline(name)` | `POST /pipelines` |
 | Rename pipeline | `updatePipelineTitle(pipelineId, name)` | `PATCH /pipelines/{pipeline_id}` |
 | Delete pipeline | `deletePipeline(pipelineId)` | `DELETE /pipelines/{pipeline_id}` |
 | Export pipelines | `exportPipelines(pipelineIds)` | `GET /pipelines?format=csv&ids=...` |
 | Import pipelines | `importPipelines(csvContent)` | `POST /pipelines` with `batch_import`, `format=csv`, `data` |
 
-List mode defaults to lightweight responses with `include_flows=false`; selected pipeline flows are loaded separately.
+List mode requests `output_mode=list` with `include_flows=false`; selected pipeline flows are loaded separately.
 
 ## Pipeline Step Operations
 

--- a/docs/api/endpoints/pipelines.md
+++ b/docs/api/endpoints/pipelines.md
@@ -39,7 +39,8 @@ List pipelines or export CSV.
 - `search` (string, optional): substring match on pipeline name.
 - `per_page` (integer, optional, default `20`, max `100`): page size.
 - `offset` (integer, optional, default `0`): pagination offset.
-- `include_flows` (boolean, optional): include full flows. Defaults to `false` for list mode and `true` for single-pipeline lookups.
+- `output_mode` (string, optional, default `list`): `full`, `list`, `summary`, or `ids`. `list` returns the pipeline shell plus `flow_count` without embedding flows.
+- `include_flows` (boolean, optional): include full flows when `output_mode=full`. Defaults to `false` for collection reads.
 
 **List success shape**:
 
@@ -49,6 +50,7 @@ List pipelines or export CSV.
   "per_page": 20,
   "offset": 0,
   "total": 0,
+  "output_mode": "list",
   "data": {
     "pipelines": [],
     "total": 0

--- a/inc/Abilities/Pipeline/GetPipelinesAbility.php
+++ b/inc/Abilities/Pipeline/GetPipelinesAbility.php
@@ -67,9 +67,9 @@ class GetPipelinesAbility {
 							),
 							'output_mode'   => array(
 								'type'        => 'string',
-								'enum'        => array( 'full', 'summary', 'ids' ),
+								'enum'        => array( 'full', 'list', 'summary', 'ids' ),
 								'default'     => 'full',
-								'description' => __( 'Output mode: full=all data with flows, summary=key fields only, ids=just pipeline_ids', 'data-machine' ),
+								'description' => __( 'Output mode: full=all data with flows, list=pipeline shell with flow_count and no embedded flows, summary=key fields only, ids=just pipeline_ids', 'data-machine' ),
 							),
 							'include_flows' => array(
 								'type'        => 'boolean',
@@ -121,8 +121,12 @@ class GetPipelinesAbility {
 			$search        = isset( $input['search'] ) && '' !== $input['search'] ? sanitize_text_field( $input['search'] ) : null;
 			$include_flows = array_key_exists( 'include_flows', $input ) ? (bool) $input['include_flows'] : true;
 
-			if ( ! in_array( $output_mode, array( 'full', 'summary', 'ids' ), true ) ) {
+			if ( ! in_array( $output_mode, array( 'full', 'list', 'summary', 'ids' ), true ) ) {
 				$output_mode = 'full';
+			}
+
+			if ( 'list' === $output_mode ) {
+				$include_flows = false;
 			}
 
 			// Direct pipeline lookup by ID bypasses pagination. It embeds flows by

--- a/inc/Abilities/Pipeline/PipelineHelpers.php
+++ b/inc/Abilities/Pipeline/PipelineHelpers.php
@@ -48,7 +48,7 @@ trait PipelineHelpers {
 	 * avoid N+1 per-pipeline lookups when formatting the admin list.
 	 *
 	 * @param array  $pipelines     Pipelines to format.
-	 * @param string $output_mode   Output mode (full, summary, ids).
+	 * @param string $output_mode   Output mode (full, list, summary, ids).
 	 * @param bool   $include_flows When true, embed the full flows array on each pipeline
 	 *                              (only honored in 'full' mode). Defaults to true for
 	 *                              backward compatibility.
@@ -131,6 +131,17 @@ trait PipelineHelpers {
 				'pipeline_name' => $pipeline['pipeline_name'] ?? '',
 				'flow_count'    => $count,
 			);
+		}
+
+		if ( 'list' === $output_mode ) {
+			$pipeline = $this->addDisplayFields( $pipeline );
+			unset( $pipeline['flows'] );
+
+			$pipeline['flow_count'] = array_key_exists( $pipeline_id, $flow_counts )
+				? (int) $flow_counts[ $pipeline_id ]
+				: $this->db_flows->count_flows_for_pipeline( $pipeline_id );
+
+			return $pipeline;
 		}
 
 		$pipeline = $this->addDisplayFields( $pipeline );

--- a/inc/Api/Pipelines/Pipelines.php
+++ b/inc/Api/Pipelines/Pipelines.php
@@ -372,7 +372,20 @@ class Pipelines {
 			}
 
 			$pipeline_data = $result['pipelines'][0];
-			$flows         = $pipeline_data['flows'] ?? array();
+			if ( 'ids' === ( $result['output_mode'] ?? $output_mode ) ) {
+				return rest_ensure_response(
+					array(
+						'success'     => true,
+						'output_mode' => 'ids',
+						'data'        => array(
+							'pipeline' => $pipeline_data,
+							'flows'    => array(),
+						),
+					)
+				);
+			}
+
+			$flows = $pipeline_data['flows'] ?? array();
 			unset( $pipeline_data['flows'] );
 			$pipeline = $pipeline_data;
 
@@ -425,7 +438,7 @@ class Pipelines {
 
 			$pipelines = $result['pipelines'];
 
-			if ( ! empty( $requested_fields ) ) {
+			if ( ! empty( $requested_fields ) && 'ids' !== ( $result['output_mode'] ?? $output_mode ) ) {
 				$pipelines = array_map(
 					function ( $pipeline ) use ( $requested_fields ) {
 						return array_intersect_key( $pipeline, array_flip( $requested_fields ) );

--- a/inc/Api/Pipelines/Pipelines.php
+++ b/inc/Api/Pipelines/Pipelines.php
@@ -68,6 +68,13 @@ class Pipelines {
 							'description'       => __( 'Response format (json or csv)', 'data-machine' ),
 							'sanitize_callback' => 'sanitize_text_field',
 						),
+						'output_mode'   => array(
+							'required'          => false,
+							'type'              => 'string',
+							'enum'              => array( 'full', 'list', 'summary', 'ids' ),
+							'description'       => __( 'Output mode for returned pipelines: full, list, summary, or ids.', 'data-machine' ),
+							'sanitize_callback' => 'sanitize_key',
+						),
 						'ids'           => array(
 							'required'          => false,
 							'type'              => 'string',
@@ -106,7 +113,6 @@ class Pipelines {
 						'include_flows' => array(
 							'required'          => false,
 							'type'              => 'boolean',
-							'default'           => true,
 							'description'       => __( 'Include full flows array per pipeline. Set false for list views — response returns flow_count only.', 'data-machine' ),
 							'sanitize_callback' => 'rest_sanitize_boolean',
 						),
@@ -173,11 +179,26 @@ class Pipelines {
 					'callback'            => array( self::class, 'handle_get_pipelines' ),
 					'permission_callback' => array( self::class, 'check_permission' ),
 					'args'                => array(
-						'pipeline_id' => array(
+						'pipeline_id'   => array(
 							'required'          => true,
 							'type'              => 'integer',
 							'sanitize_callback' => 'absint',
 							'description'       => __( 'Pipeline ID to retrieve', 'data-machine' ),
+						),
+						'output_mode'   => array(
+							'required'          => false,
+							'type'              => 'string',
+							'default'           => 'full',
+							'enum'              => array( 'full', 'list', 'summary', 'ids' ),
+							'description'       => __( 'Output mode for returned pipeline: full, list, summary, or ids.', 'data-machine' ),
+							'sanitize_callback' => 'sanitize_key',
+						),
+						'include_flows' => array(
+							'required'          => false,
+							'type'              => 'boolean',
+							'default'           => true,
+							'description'       => __( 'Include full flows array when output_mode=full.', 'data-machine' ),
+							'sanitize_callback' => 'rest_sanitize_boolean',
 						),
 					),
 				),
@@ -286,6 +307,7 @@ class Pipelines {
 		$per_page_param      = $request->get_param( 'per_page' );
 		$offset_param        = $request->get_param( 'offset' );
 		$include_flows_param = $request->get_param( 'include_flows' );
+		$output_mode         = $request->get_param( 'output_mode' ) ?? null;
 		$scoped_user_id      = PermissionHelper::resolve_scoped_user_id( $request );
 		$scoped_agent_id     = PermissionHelper::resolve_scoped_agent_id( $request );
 
@@ -329,7 +351,7 @@ class Pipelines {
 		if ( $pipeline_id ) {
 			$input = array(
 				'pipeline_id' => (int) $pipeline_id,
-				'output_mode' => 'full',
+				'output_mode' => $output_mode ? $output_mode : 'full',
 			);
 			if ( null !== $include_flows_param ) {
 				$input['include_flows'] = (bool) $include_flows_param;
@@ -370,9 +392,9 @@ class Pipelines {
 		} else {
 			$per_page = ( null !== $per_page_param ) ? max( 1, (int) $per_page_param ) : 20;
 			$offset   = ( null !== $offset_param ) ? max( 0, (int) $offset_param ) : 0;
-			// Default include_flows to false for list mode — callers explicitly
-			// opt-in when they need full flows embedded. This avoids the N+1
-			// flow query and the large payload on admin list loads.
+			// Default to explicit list mode for collection reads. Callers that need
+			// embedded flows must request output_mode=full and include_flows=true.
+			$output_mode   = $output_mode ? $output_mode : 'list';
 			$include_flows = ( null !== $include_flows_param )
 				? (bool) $include_flows_param
 				: false;
@@ -380,7 +402,7 @@ class Pipelines {
 			$input = array(
 				'per_page'      => $per_page,
 				'offset'        => $offset,
-				'output_mode'   => 'full',
+				'output_mode'   => $output_mode,
 				'include_flows' => $include_flows,
 			);
 			if ( null !== $scoped_agent_id ) {
@@ -414,11 +436,12 @@ class Pipelines {
 
 			return rest_ensure_response(
 				array(
-					'success'  => true,
-					'per_page' => $result['per_page'] ?? $per_page,
-					'offset'   => $result['offset'] ?? $offset,
-					'total'    => $result['total'],
-					'data'     => array(
+					'success'     => true,
+					'per_page'    => $result['per_page'] ?? $per_page,
+					'offset'      => $result['offset'] ?? $offset,
+					'total'       => $result['total'],
+					'output_mode' => $result['output_mode'] ?? $output_mode,
+					'data'        => array(
 						'pipelines' => $pipelines,
 						'total'     => $result['total'],
 					),

--- a/inc/Core/Admin/Pages/Jobs/assets/react/api/jobs.js
+++ b/inc/Core/Admin/Pages/Jobs/assets/react/api/jobs.js
@@ -92,6 +92,7 @@ export const clearProcessedItems = ( clearType, targetId ) =>
  */
 export const fetchPipelines = () =>
 	client.get( '/pipelines', {
+		output_mode: 'list',
 		include_flows: false,
 		per_page: 100,
 	} );

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
@@ -29,7 +29,7 @@ const getAgentPayload = () => {
 /**
  * Fetch pipelines list or a specific pipeline.
  *
- * In list mode, defaults to lightweight responses (include_flows=false) so the
+ * In list mode, requests explicit lightweight responses so the
  * admin UI can render hundreds of pipelines without the server embedding every
  * flow. Each pipeline still exposes flow_count for display purposes, and the
  * selected pipeline's flows are fetched separately via /flows.
@@ -39,16 +39,24 @@ const getAgentPayload = () => {
  * @param {number}      [options.perPage]      - Items per page (default 100)
  * @param {number}      [options.offset]       - Pagination offset (default 0)
  * @param {boolean}     [options.includeFlows] - Embed flows per pipeline (default false)
+ * @param {string}      [options.outputMode]   - Pipeline output mode (default list)
  * @param {string|null} [options.search]       - Filter by pipeline name (substring)
  * @return {Promise<Object>} Pipeline data
  */
 export const fetchPipelines = async (
 	pipelineId = null,
-	{ perPage = 100, offset = 0, includeFlows = false, search = null } = {}
+	{
+		perPage = 100,
+		offset = 0,
+		includeFlows = false,
+		outputMode = 'list',
+		search = null,
+	} = {}
 ) => {
 	if ( pipelineId ) {
 		return await client.get( '/pipelines', {
 			pipeline_id: pipelineId,
+			output_mode: outputMode,
 			include_flows: includeFlows,
 		} );
 	}
@@ -56,6 +64,7 @@ export const fetchPipelines = async (
 	const params = {
 		per_page: perPage,
 		offset,
+		output_mode: outputMode,
 		include_flows: includeFlows,
 	};
 

--- a/tests/pipeline-list-output-mode-smoke.php
+++ b/tests/pipeline-list-output-mode-smoke.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Smoke test for explicit lightweight pipeline list response shapes.
+ */
+
+$root = dirname( __DIR__ );
+
+$get_pipelines    = file_get_contents( $root . '/inc/Abilities/Pipeline/GetPipelinesAbility.php' );
+$pipeline_helpers = file_get_contents( $root . '/inc/Abilities/Pipeline/PipelineHelpers.php' );
+$rest_api         = file_get_contents( $root . '/inc/Api/Pipelines/Pipelines.php' );
+$pipelines_client = file_get_contents( $root . '/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js' );
+$jobs_client      = file_get_contents( $root . '/inc/Core/Admin/Pages/Jobs/assets/react/api/jobs.js' );
+
+$failures = array();
+
+$assert = static function ( string $label, bool $condition ) use ( &$failures ): void {
+	if ( ! $condition ) {
+		$failures[] = $label;
+	}
+};
+
+$assert(
+	'pipeline ability exposes list output mode',
+	false !== strpos( $get_pipelines, "array( 'full', 'list', 'summary', 'ids' )" )
+);
+
+$assert(
+	'pipeline list mode disables embedded flows',
+	false !== strpos( $get_pipelines, "if ( 'list' === \$output_mode )" ) && false !== strpos( $get_pipelines, '$include_flows = false;' )
+);
+
+$assert(
+	'pipeline helper has explicit list branch',
+	false !== strpos( $pipeline_helpers, "if ( 'list' === \$output_mode )" )
+);
+
+$assert(
+	'pipeline list branch unsets embedded flows',
+	false !== strpos( $pipeline_helpers, "unset( \$pipeline['flows'] );" )
+);
+
+$assert(
+	'REST pipelines endpoint accepts output_mode',
+	false !== strpos( $rest_api, "'output_mode'   => array(" ) && false !== strpos( $rest_api, "'output_mode'   => \$output_mode" )
+);
+
+$assert(
+	'pipelines admin client requests list output mode',
+	false !== strpos( $pipelines_client, "outputMode = 'list'" ) && false !== strpos( $pipelines_client, 'output_mode: outputMode' )
+);
+
+$assert(
+	'jobs admin dropdown requests list output mode',
+	false !== strpos( $jobs_client, "output_mode: 'list'" )
+);
+
+if ( $failures ) {
+	fwrite( STDERR, "Pipeline list output mode smoke failed:\n- " . implode( "\n- ", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo "Pipeline list output mode smoke passed.\n";

--- a/tests/pipeline-list-output-mode-smoke.php
+++ b/tests/pipeline-list-output-mode-smoke.php
@@ -45,6 +45,16 @@ $assert(
 );
 
 $assert(
+	'REST single pipeline ids mode returns before array shape handling',
+	false !== strpos( $rest_api, "if ( 'ids' === ( \$result['output_mode'] ?? \$output_mode ) )" )
+);
+
+$assert(
+	'REST collection ids mode skips fields filtering',
+	false !== strpos( $rest_api, "! empty( \$requested_fields ) && 'ids' !== ( \$result['output_mode'] ?? \$output_mode )" )
+);
+
+$assert(
 	'pipelines admin client requests list output mode',
 	false !== strpos( $pipelines_client, "outputMode = 'list'" ) && false !== strpos( $pipelines_client, 'output_mode: outputMode' )
 );


### PR DESCRIPTION
## Summary
- Add explicit `output_mode=list` support for pipeline responses so collection reads return the pipeline shell plus `flow_count` without embedded flows.
- Update Pipelines and Jobs admin clients to request the list shape directly, while preserving full single-pipeline lookups for existing callers.
- Document the pipeline response modes and add a smoke test that guards the lightweight list contract.

## Verification
- `npm run build`
- `homeboy lint --path /Users/chubes/Developer/data-machine@explicit-pipeline-response-shapes --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@explicit-pipeline-response-shapes --extension wordpress --changed-since origin/main`
- `php tests/pipeline-list-output-mode-smoke.php && php tests/flow-list-lightweight-query-smoke.php`
- Scaled Studio REST check: `/pipelines?per_page=100` returned `output_mode=list`, 112100 bytes, no embedded `flows`, and `flow_count` present.
- Compatibility REST check: `/pipelines?pipeline_id=1` still returned embedded flows for the legacy full single-pipeline shape.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the response-shape refactor, docs, smoke test, and verification commands; Chris remains responsible for review and merge.