### PR TITLE
Scope auth credentials by policy

### DIFF
--- a/inc/Abilities/AuthAbilities.php
+++ b/inc/Abilities/AuthAbilities.php
@@ -576,6 +576,7 @@ class AuthAbilities {
 	public function executeSaveAuthConfig( array $input ): array {
 		$handler_slug = sanitize_text_field( $input['handler_slug'] ?? '' );
 		$config_input = $input['config'] ?? array();
+		$principal_context = $this->getPrincipalContext( $input );
 
 		if ( empty( $handler_slug ) ) {
 			return array(
@@ -665,9 +666,9 @@ class AuthAbilities {
 				);
 			}
 		} elseif ( method_exists( $auth_instance, 'save_config' ) ) {
-			$saved = $auth_instance->save_config( $config_data );
+			$saved = $auth_instance->save_config( $config_data, $principal_context );
 		} elseif ( method_exists( $auth_instance, 'save_account' ) ) {
-			$saved = $auth_instance->save_account( $config_data );
+			$saved = $auth_instance->save_account( $config_data, $principal_context );
 		} else {
 			return array(
 				'success' => false,
@@ -703,6 +704,7 @@ class AuthAbilities {
 	public function executeSetAuthToken( array $input ): array {
 		$handler_slug = sanitize_text_field( $input['handler_slug'] ?? '' );
 		$account_data = $input['account_data'] ?? array();
+		$principal_context = $this->getPrincipalContext( $input );
 
 		if ( empty( $handler_slug ) ) {
 			return array(
@@ -753,7 +755,7 @@ class AuthAbilities {
 			}
 		}
 
-		$saved = $auth_instance->save_account( $sanitized );
+		$saved = $auth_instance->save_account( $sanitized, $principal_context );
 
 		if ( $saved ) {
 			// Schedule proactive refresh if the provider supports it.
@@ -861,5 +863,39 @@ class AuthAbilities {
 			'message'    => sprintf( __( '%s token refreshed successfully', 'data-machine' ), ucfirst( $handler_slug ) ),
 			'expires_at' => $expires_at,
 		);
+	}
+
+	/**
+	 * Extract explicit principal context from ability input.
+	 *
+	 * @param array $input Ability input.
+	 * @return array{user_id?:int,agent_id?:int}
+	 */
+	private function getPrincipalContext( array $input ): array {
+		$context = array();
+		if ( ! empty( $input['agent_id'] ) ) {
+			$context['agent_id'] = absint( $input['agent_id'] );
+		}
+		if ( ! empty( $input['user_id'] ) ) {
+			$context['user_id'] = absint( $input['user_id'] );
+		}
+		if ( empty( $context['agent_id'] ) ) {
+			$agent_id = absint( PermissionHelper::get_acting_agent_id() );
+			if ( $agent_id > 0 ) {
+				$context['agent_id'] = $agent_id;
+			}
+		}
+
+		if ( empty( $context['user_id'] ) ) {
+			$user_id = absint( PermissionHelper::acting_user_id() );
+			if ( $user_id <= 0 && function_exists( 'get_current_user_id' ) ) {
+				$user_id = absint( get_current_user_id() );
+			}
+			if ( $user_id > 0 ) {
+				$context['user_id'] = $user_id;
+			}
+		}
+
+		return array_filter( $context );
 	}
 }

--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -24,11 +24,18 @@
 
 namespace DataMachine\Core\OAuth;
 
+use DataMachine\Abilities\PermissionHelper;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 abstract class BaseAuthProvider {
+
+	public const AUTH_SCOPE_SITE      = 'site';
+	public const AUTH_SCOPE_USER      = 'user';
+	public const AUTH_SCOPE_AGENT     = 'agent';
+	public const AUTH_SCOPE_PRINCIPAL = 'principal';
 
 	/**
 	 * Encryption envelope prefix.
@@ -208,14 +215,26 @@ abstract class BaseAuthProvider {
 	/**
 	 * Get OAuth account data directly from options.
 	 *
-	 * Automatically decrypts any encrypted fields. Plaintext legacy values
-	 * pass through unchanged.
+	 * Automatically decrypts any encrypted fields. Principal-scoped credentials
+	 * are preferred when a user or agent context is available; legacy site-level
+	 * credentials remain readable as a fallback for existing installs.
 	 *
+	 * @param array $context Optional principal context, e.g. user_id or agent_id.
 	 * @return array Account data or empty array
 	 */
-	public function get_account(): array {
+	public function get_account( array $context = array() ): array {
 		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
-		$account       = $all_auth_data[ $this->provider_slug ]['account'] ?? array();
+		$provider_data = $all_auth_data[ $this->provider_slug ] ?? array();
+		$scope         = $this->get_principal_scope( $context, 'account' );
+
+		if ( null !== $scope ) {
+			$scoped_account = $provider_data['principals'][ $scope ]['account'] ?? array();
+			if ( ! empty( $scoped_account ) && is_array( $scoped_account ) ) {
+				return $this->decrypt_fields( $scoped_account );
+			}
+		}
+
+		$account = $provider_data['account'] ?? array();
 		return $this->decrypt_fields( $account );
 	}
 
@@ -227,26 +246,49 @@ abstract class BaseAuthProvider {
 	 *
 	 * @return array Configuration data or empty array
 	 */
-	public function get_config(): array {
+	public function get_config( array $context = array() ): array {
 		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
-		$config        = $all_auth_data[ $this->provider_slug ]['config'] ?? array();
+		$provider_data = $all_auth_data[ $this->provider_slug ] ?? array();
+		$scope         = $this->get_principal_scope( $context, 'config' );
+
+		if ( null !== $scope ) {
+			$scoped_config = $provider_data['principals'][ $scope ]['config'] ?? array();
+			if ( ! empty( $scoped_config ) && is_array( $scoped_config ) ) {
+				return $this->decrypt_fields( $scoped_config );
+			}
+		}
+
+		$config = $provider_data['config'] ?? array();
 		return $this->decrypt_fields( $config );
 	}
 
 	/**
 	 * Store OAuth account data directly in options.
 	 *
-	 * Sensitive fields are automatically encrypted before storage.
+	 * Sensitive fields are automatically encrypted before storage. Writes with a
+	 * resolvable user or agent context are stored under that principal; writes
+	 * without context preserve legacy site-level storage.
 	 *
 	 * @param array $data Account data to store
+	 * @param array $context Optional principal context, e.g. user_id or agent_id.
 	 * @return bool True on success
 	 */
-	public function save_account( array $data ): bool {
+	public function save_account( array $data, array $context = array() ): bool {
 		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
 		if ( ! isset( $all_auth_data[ $this->provider_slug ] ) ) {
 			$all_auth_data[ $this->provider_slug ] = array();
 		}
-		$all_auth_data[ $this->provider_slug ]['account'] = $this->encrypt_fields( $data );
+
+		$scope = $this->get_principal_scope( $context, 'account' );
+		if ( null !== $scope ) {
+			if ( ! isset( $all_auth_data[ $this->provider_slug ]['principals'] ) || ! is_array( $all_auth_data[ $this->provider_slug ]['principals'] ) ) {
+				$all_auth_data[ $this->provider_slug ]['principals'] = array();
+			}
+			$all_auth_data[ $this->provider_slug ]['principals'][ $scope ]['account'] = $this->encrypt_fields( $data );
+		} else {
+			$all_auth_data[ $this->provider_slug ]['account'] = $this->encrypt_fields( $data );
+		}
+
 		return update_site_option( 'datamachine_auth_data', $all_auth_data );
 	}
 
@@ -256,24 +298,46 @@ abstract class BaseAuthProvider {
 	 * Sensitive fields are automatically encrypted before storage.
 	 *
 	 * @param array $data Configuration data to store
+	 * @param array $context Optional principal context. Config writes only scope when context is explicit.
 	 * @return bool True on success
 	 */
-	public function save_config( array $data ): bool {
+	public function save_config( array $data, array $context = array() ): bool {
 		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
 		if ( ! isset( $all_auth_data[ $this->provider_slug ] ) ) {
 			$all_auth_data[ $this->provider_slug ] = array();
 		}
-		$all_auth_data[ $this->provider_slug ]['config'] = $this->encrypt_fields( $data );
+
+		$scope = $this->get_principal_scope( $context, 'config' );
+		if ( null !== $scope ) {
+			if ( ! isset( $all_auth_data[ $this->provider_slug ]['principals'] ) || ! is_array( $all_auth_data[ $this->provider_slug ]['principals'] ) ) {
+				$all_auth_data[ $this->provider_slug ]['principals'] = array();
+			}
+			$all_auth_data[ $this->provider_slug ]['principals'][ $scope ]['config'] = $this->encrypt_fields( $data );
+		} else {
+			$all_auth_data[ $this->provider_slug ]['config'] = $this->encrypt_fields( $data );
+		}
+
 		return update_site_option( 'datamachine_auth_data', $all_auth_data );
 	}
 
 	/**
 	 * Clear OAuth account data from options.
 	 *
+	 * @param array $context Optional principal context, e.g. user_id or agent_id.
 	 * @return bool True on success
 	 */
-	public function clear_account(): bool {
+	public function clear_account( array $context = array() ): bool {
 		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		$scope         = $this->get_principal_scope( $context, 'account' );
+
+		if ( null !== $scope ) {
+			if ( isset( $all_auth_data[ $this->provider_slug ]['principals'][ $scope ] ) ) {
+				unset( $all_auth_data[ $this->provider_slug ]['principals'][ $scope ] );
+				return update_site_option( 'datamachine_auth_data', $all_auth_data );
+			}
+			return true;
+		}
+
 		if ( isset( $all_auth_data[ $this->provider_slug ]['account'] ) ) {
 			unset( $all_auth_data[ $this->provider_slug ]['account'] );
 			return update_site_option( 'datamachine_auth_data', $all_auth_data );
@@ -303,6 +367,90 @@ abstract class BaseAuthProvider {
 	 */
 	public function get_account_details(): ?array {
 		return $this->get_account();
+	}
+
+	/**
+	 * Resolve the current credential scope.
+	 *
+	 * Agent context wins over user context so delegated agent execution cannot
+	 * accidentally read a broader owner credential when an agent credential exists.
+	 * Returning null intentionally preserves site-level behavior.
+	 *
+	 * @param array $context Optional explicit principal context.
+	 * @param string $credential_type Credential type: account or config.
+	 * @return string|null Scope key such as agent:12 or user:34, or null.
+	 */
+	protected function get_principal_scope( array $context = array(), string $credential_type = 'account' ): ?string {
+		$policy = $this->get_auth_scope_policy( $credential_type, $context );
+		if ( self::AUTH_SCOPE_SITE === $policy ) {
+			return null;
+		}
+
+		$agent_id = isset( $context['agent_id'] ) ? absint( $context['agent_id'] ) : 0;
+		if ( $agent_id > 0 && in_array( $policy, array( self::AUTH_SCOPE_AGENT, self::AUTH_SCOPE_PRINCIPAL ), true ) ) {
+			return 'agent:' . $agent_id;
+		}
+
+		$user_id = isset( $context['user_id'] ) ? absint( $context['user_id'] ) : 0;
+		if ( $user_id > 0 && in_array( $policy, array( self::AUTH_SCOPE_USER, self::AUTH_SCOPE_PRINCIPAL ), true ) ) {
+			return 'user:' . $user_id;
+		}
+
+		if ( class_exists( PermissionHelper::class ) ) {
+			$agent_id = absint( PermissionHelper::get_acting_agent_id() );
+			if ( $agent_id > 0 && in_array( $policy, array( self::AUTH_SCOPE_AGENT, self::AUTH_SCOPE_PRINCIPAL ), true ) ) {
+				return 'agent:' . $agent_id;
+			}
+
+			$user_id = absint( PermissionHelper::acting_user_id() );
+			if ( $user_id > 0 && in_array( $policy, array( self::AUTH_SCOPE_USER, self::AUTH_SCOPE_PRINCIPAL ), true ) ) {
+				return 'user:' . $user_id;
+			}
+		}
+
+		if ( function_exists( 'get_current_user_id' ) ) {
+			$user_id = absint( get_current_user_id() );
+			if ( $user_id > 0 && in_array( $policy, array( self::AUTH_SCOPE_USER, self::AUTH_SCOPE_PRINCIPAL ), true ) ) {
+				return 'user:' . $user_id;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Return the credential scope policy for this provider.
+	 *
+	 * The default preserves existing site-wide behavior for all providers. Providers
+	 * that represent a human browser/session identity can opt into user, agent, or
+	 * principal scoping by overriding this method or using the filter.
+	 *
+	 * @param string $credential_type Credential type: account or config.
+	 * @param array  $context Optional explicit principal context.
+	 * @return string One of site, user, agent, principal.
+	 */
+	protected function get_auth_scope_policy( string $credential_type = 'account', array $context = array() ): string {
+		$policy = self::AUTH_SCOPE_SITE;
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$policy = (string) apply_filters(
+				'datamachine_auth_scope_policy',
+				$policy,
+				$this->provider_slug,
+				$credential_type,
+				$context,
+				$this
+			);
+		}
+
+		$allowed = array(
+			self::AUTH_SCOPE_SITE,
+			self::AUTH_SCOPE_USER,
+			self::AUTH_SCOPE_AGENT,
+			self::AUTH_SCOPE_PRINCIPAL,
+		);
+
+		return in_array( $policy, $allowed, true ) ? $policy : self::AUTH_SCOPE_SITE;
 	}
 
 	// -------------------------------------------------------------------------

--- a/inc/Core/OAuth/BaseOAuth2Provider.php
+++ b/inc/Core/OAuth/BaseOAuth2Provider.php
@@ -505,9 +505,9 @@ abstract class BaseOAuth2Provider extends BaseAuthProvider {
 	 * @since 0.31.1
 	 * @return bool True on success
 	 */
-	public function clear_account(): bool {
+	public function clear_account( array $context = array() ): bool {
 		$this->clear_proactive_refresh();
-		return parent::clear_account();
+		return parent::clear_account( $context );
 	}
 
 	// -------------------------------------------------------------------------
@@ -590,14 +590,15 @@ abstract class BaseOAuth2Provider extends BaseAuthProvider {
 	 * @return array Query parameters for the authorization URL.
 	 */
 	protected function build_auth_url_params( array $state_payload = array() ): array {
+		$state = $this->oauth2->create_state( $this->provider_slug, $state_payload );
 		$params = array(
 			'response_type' => $this->get_oauth_response_type(),
 			'redirect_uri'  => $this->get_callback_url(),
-			'state'         => $this->oauth2->create_state( $this->provider_slug, $state_payload ),
+			'state'         => $state,
 		);
 
 		if ( $this->uses_pkce() ) {
-			$pkce                            = $this->oauth2->create_pkce( $this->provider_slug );
+			$pkce                            = $this->oauth2->create_pkce( $this->provider_slug, $state );
 			$params['code_challenge']        = $pkce['challenge'];
 			$params['code_challenge_method'] = $pkce['method'];
 		}

--- a/inc/Core/OAuth/OAuth2Handler.php
+++ b/inc/Core/OAuth/OAuth2Handler.php
@@ -84,7 +84,7 @@ class OAuth2Handler {
 			'created_at' => time(),
 		);
 
-		set_transient( "datamachine_{$provider_key}_oauth_state", $record, 15 * MINUTE_IN_SECONDS );
+		set_transient( $this->state_transient_key( $provider_key, $nonce ), $record, 15 * MINUTE_IN_SECONDS );
 
 		do_action(
 			'datamachine_log',
@@ -124,7 +124,12 @@ class OAuth2Handler {
 			return false;
 		}
 
-		$record = get_transient( "datamachine_{$provider_key}_oauth_state" );
+		$record = get_transient( $this->state_transient_key( $provider_key, $state ) );
+
+		if ( false === $record ) {
+			// Backward compatibility for states created before nonce-keyed storage.
+			$record = get_transient( "datamachine_{$provider_key}_oauth_state" );
+		}
 
 		if ( false === $record ) {
 			$this->log_state_verification( $provider_key, false );
@@ -141,6 +146,7 @@ class OAuth2Handler {
 			return false;
 		}
 
+		delete_transient( $this->state_transient_key( $provider_key, $state ) );
 		delete_transient( "datamachine_{$provider_key}_oauth_state" );
 		$this->log_state_verification( $provider_key, true );
 
@@ -178,6 +184,17 @@ class OAuth2Handler {
 		);
 	}
 
+	/**
+	 * Build a nonce-keyed OAuth state transient key.
+	 *
+	 * @param string $provider_key Provider identifier.
+	 * @param string $state OAuth state nonce.
+	 * @return string Transient key.
+	 */
+	private function state_transient_key( string $provider_key, string $state ): string {
+		return "datamachine_{$provider_key}_oauth_state_" . substr( hash( 'sha256', $state ), 0, 24 );
+	}
+
 	// -------------------------------------------------------------------------
 	// PKCE (Proof Key for Code Exchange)
 	// -------------------------------------------------------------------------
@@ -194,7 +211,7 @@ class OAuth2Handler {
 	 * @param string $provider_key Provider identifier.
 	 * @return array{verifier: string, challenge: string, method: string} PKCE parameters.
 	 */
-	public function create_pkce( string $provider_key ): array {
+	public function create_pkce( string $provider_key, string $state = '' ): array {
 		// Generate a random 32-byte verifier (43-128 chars when base64url-encoded per RFC 7636).
 		$verifier = $this->base64url_encode( random_bytes( 32 ) );
 
@@ -202,7 +219,7 @@ class OAuth2Handler {
 		$challenge = $this->base64url_encode( hash( 'sha256', $verifier, true ) );
 
 		// Store verifier for token exchange (15 minutes, same as state).
-		set_transient( "datamachine_{$provider_key}_pkce_verifier", $verifier, 15 * MINUTE_IN_SECONDS );
+		set_transient( $this->pkce_transient_key( $provider_key, $state ), $verifier, 15 * MINUTE_IN_SECONDS );
 
 		do_action(
 			'datamachine_log',
@@ -230,15 +247,36 @@ class OAuth2Handler {
 	 * @param string $provider_key Provider identifier.
 	 * @return string|null Code verifier, or null if not found/expired.
 	 */
-	public function get_pkce_verifier( string $provider_key ): ?string {
-		$verifier = get_transient( "datamachine_{$provider_key}_pkce_verifier" );
+	public function get_pkce_verifier( string $provider_key, string $state = '' ): ?string {
+		$verifier = get_transient( $this->pkce_transient_key( $provider_key, $state ) );
+
+		if ( false === $verifier && '' !== $state ) {
+			// Backward compatibility for verifiers created before nonce-keyed storage.
+			$verifier = get_transient( "datamachine_{$provider_key}_pkce_verifier" );
+		}
 
 		if ( false === $verifier ) {
 			return null;
 		}
 
+		delete_transient( $this->pkce_transient_key( $provider_key, $state ) );
 		delete_transient( "datamachine_{$provider_key}_pkce_verifier" );
 		return $verifier;
+	}
+
+	/**
+	 * Build a nonce-keyed PKCE transient key.
+	 *
+	 * @param string $provider_key Provider identifier.
+	 * @param string $state OAuth state nonce.
+	 * @return string Transient key.
+	 */
+	private function pkce_transient_key( string $provider_key, string $state = '' ): string {
+		if ( '' === $state ) {
+			return "datamachine_{$provider_key}_pkce_verifier";
+		}
+
+		return "datamachine_{$provider_key}_pkce_verifier_" . substr( hash( 'sha256', $state ), 0, 24 );
 	}
 
 	/**
@@ -361,7 +399,7 @@ class OAuth2Handler {
 		}
 
 		// Include PKCE code_verifier in token exchange if one was stored.
-		$verifier = $this->get_pkce_verifier( $provider_key );
+		$verifier = $this->get_pkce_verifier( $provider_key, $state );
 		if ( null !== $verifier ) {
 			$token_params['code_verifier'] = $verifier;
 

--- a/tests/auth-principal-scoped-smoke.php
+++ b/tests/auth-principal-scoped-smoke.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Smoke tests for principal-scoped auth provider storage.
+ *
+ *   php tests/auth-principal-scoped-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+if ( ! defined( 'WPINC' ) ) {
+	define( 'WPINC', 'wp-includes' );
+}
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+
+$GLOBALS['datamachine_auth_scope_options']    = array();
+$GLOBALS['datamachine_auth_scope_transients'] = array();
+$GLOBALS['datamachine_auth_scope_user_id']    = 0;
+$GLOBALS['datamachine_auth_scope_filters']    = array();
+
+function __( $text, $domain = null ) {
+	unset( $domain );
+	return $text;
+}
+
+function esc_html( $text ) {
+	return $text;
+}
+
+function absint( $value ) {
+	return abs( (int) $value );
+}
+
+function wp_salt( $scheme = 'auth' ) {
+	return 'principal-scoped-auth-smoke-' . $scheme;
+}
+
+function maybe_serialize( $value ) {
+	return serialize( $value );
+}
+
+function get_site_option( $name, $default = false ) {
+	return $GLOBALS['datamachine_auth_scope_options'][ $name ] ?? $default;
+}
+
+function update_site_option( $name, $value ) {
+	$GLOBALS['datamachine_auth_scope_options'][ $name ] = $value;
+	return true;
+}
+
+function get_current_user_id() {
+	return (int) $GLOBALS['datamachine_auth_scope_user_id'];
+}
+
+function apply_filters( $hook, $value, ...$args ) {
+	foreach ( $GLOBALS['datamachine_auth_scope_filters'][ $hook ] ?? array() as $callback ) {
+		$value = $callback( $value, ...$args );
+	}
+	return $value;
+}
+
+function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+	unset( $priority, $accepted_args );
+	$GLOBALS['datamachine_auth_scope_filters'][ $hook ][] = $callback;
+}
+
+function do_action( $hook, ...$args ) {
+	unset( $hook, $args );
+}
+
+function set_transient( $key, $value, $expiration = 0 ) {
+	unset( $expiration );
+	$GLOBALS['datamachine_auth_scope_transients'][ $key ] = $value;
+	return true;
+}
+
+function get_transient( $key ) {
+	return $GLOBALS['datamachine_auth_scope_transients'][ $key ] ?? false;
+}
+
+function delete_transient( $key ) {
+	unset( $GLOBALS['datamachine_auth_scope_transients'][ $key ] );
+	return true;
+}
+
+require_once dirname( __DIR__ ) . '/inc/Core/OAuth/OAuthRedirects.php';
+require_once dirname( __DIR__ ) . '/inc/Core/OAuth/BaseAuthProvider.php';
+require_once dirname( __DIR__ ) . '/inc/Core/OAuth/OAuth2Handler.php';
+
+class Principal_Scoped_Provider extends DataMachine\Core\OAuth\BaseAuthProvider {
+	public function __construct() {
+		parent::__construct( 'example' );
+	}
+
+	public function get_config_fields(): array {
+		return array();
+	}
+
+	public function is_authenticated(): bool {
+		$account = $this->get_account();
+		return ! empty( $account['access_token'] );
+	}
+}
+
+add_filter( 'datamachine_auth_scope_policy', function ( string $policy, string $provider_slug, string $credential_type ): string {
+	if ( 'example' === $provider_slug ) {
+		return DataMachine\Core\OAuth\BaseAuthProvider::AUTH_SCOPE_PRINCIPAL;
+	}
+	if ( 'direct_config' === $provider_slug && 'config' === $credential_type ) {
+		return DataMachine\Core\OAuth\BaseAuthProvider::AUTH_SCOPE_USER;
+	}
+	return $policy;
+}, 10, 3 );
+
+$pass     = 0;
+$fail     = 0;
+$failures = array();
+
+function smoke_assert( string $label, bool $condition, string $detail = '' ): void {
+	global $pass, $fail, $failures;
+	if ( $condition ) {
+		$pass++;
+		echo "  ✓ {$label}\n";
+		return;
+	}
+
+	$fail++;
+	$failures[] = array( $label, $detail );
+	echo "  ✗ {$label}" . ( $detail ? "\n      {$detail}" : '' ) . "\n";
+}
+
+echo "[1] two users store provider accounts without overwriting\n";
+$provider = new Principal_Scoped_Provider();
+$provider->save_account( array( 'access_token' => 'alice-token' ), array( 'user_id' => 101 ) );
+$provider->save_account( array( 'access_token' => 'bob-token' ), array( 'user_id' => 202 ) );
+
+smoke_assert( 'alice reads alice token', 'alice-token' === $provider->get_account( array( 'user_id' => 101 ) )['access_token'] );
+smoke_assert( 'bob reads bob token', 'bob-token' === $provider->get_account( array( 'user_id' => 202 ) )['access_token'] );
+
+$raw = get_site_option( 'datamachine_auth_data', array() );
+smoke_assert( 'alice account stored under user principal', isset( $raw['example']['principals']['user:101']['account'] ) );
+smoke_assert( 'bob account stored under user principal', isset( $raw['example']['principals']['user:202']['account'] ) );
+smoke_assert( 'legacy site account was not written', ! isset( $raw['example']['account'] ) );
+
+echo "\n[2] agent scope wins when explicitly provided\n";
+$provider->save_account( array( 'access_token' => 'agent-token' ), array( 'agent_id' => 303, 'user_id' => 101 ) );
+smoke_assert( 'agent reads agent token', 'agent-token' === $provider->get_account( array( 'agent_id' => 303, 'user_id' => 101 ) )['access_token'] );
+$raw = get_site_option( 'datamachine_auth_data', array() );
+smoke_assert( 'agent account stored under agent principal', isset( $raw['example']['principals']['agent:303']['account'] ) );
+
+echo "\n[3] legacy account remains readable as fallback\n";
+$GLOBALS['datamachine_auth_scope_options']['datamachine_auth_data']['legacy']['account'] = array( 'access_token' => 'legacy-token' );
+$legacy = new class() extends DataMachine\Core\OAuth\BaseAuthProvider {
+	public function __construct() { parent::__construct( 'legacy' ); }
+	public function get_config_fields(): array { return array(); }
+	public function is_authenticated(): bool { return ! empty( $this->get_account()['access_token'] ); }
+};
+smoke_assert( 'scoped lookup falls back to legacy account', 'legacy-token' === $legacy->get_account( array( 'user_id' => 404 ) )['access_token'] );
+
+echo "\n[4] site-wide policy remains the default\n";
+$site_provider = new class() extends DataMachine\Core\OAuth\BaseAuthProvider {
+	public function __construct() { parent::__construct( 'site_default' ); }
+	public function get_config_fields(): array { return array(); }
+	public function is_authenticated(): bool { return ! empty( $this->get_account()['access_token'] ); }
+};
+$site_provider->save_account( array( 'access_token' => 'site-token-a' ), array( 'user_id' => 101 ) );
+$site_provider->save_account( array( 'access_token' => 'site-token-b' ), array( 'user_id' => 202 ) );
+smoke_assert( 'default policy writes site account', 'site-token-b' === $site_provider->get_account( array( 'user_id' => 101 ) )['access_token'] );
+$raw = get_site_option( 'datamachine_auth_data', array() );
+smoke_assert( 'default policy does not create principal accounts', ! isset( $raw['site_default']['principals'] ) );
+
+echo "\n[5] direct config credentials can opt into user scoping\n";
+$config_provider = new class() extends DataMachine\Core\OAuth\BaseAuthProvider {
+	public function __construct() { parent::__construct( 'direct_config' ); }
+	public function get_config_fields(): array { return array(); }
+	public function is_authenticated(): bool { return ! empty( $this->get_config()['cookie'] ); }
+};
+$config_provider->save_config( array( 'cookie' => 'alice-cookie' ), array( 'user_id' => 101 ) );
+$config_provider->save_config( array( 'cookie' => 'bob-cookie' ), array( 'user_id' => 202 ) );
+smoke_assert( 'alice reads scoped config', 'alice-cookie' === $config_provider->get_config( array( 'user_id' => 101 ) )['cookie'] );
+smoke_assert( 'bob reads scoped config', 'bob-cookie' === $config_provider->get_config( array( 'user_id' => 202 ) )['cookie'] );
+
+echo "\n[6] concurrent OAuth state and PKCE entries do not overwrite\n";
+$oauth  = new DataMachine\Core\OAuth\OAuth2Handler();
+$state1 = $oauth->create_state( 'example', array( 'user_id' => 101 ) );
+$state2 = $oauth->create_state( 'example', array( 'user_id' => 202 ) );
+$pkce1  = $oauth->create_pkce( 'example', $state1 );
+$pkce2  = $oauth->create_pkce( 'example', $state2 );
+
+smoke_assert( 'first state returns first payload', 101 === $oauth->verify_state( 'example', $state1 )['user_id'] );
+smoke_assert( 'second state returns second payload', 202 === $oauth->verify_state( 'example', $state2 )['user_id'] );
+smoke_assert( 'first PKCE verifier survives second create', $pkce1['verifier'] === $oauth->get_pkce_verifier( 'example', $state1 ) );
+smoke_assert( 'second PKCE verifier survives first read', $pkce2['verifier'] === $oauth->get_pkce_verifier( 'example', $state2 ) );
+
+echo "\n{$pass} passed, {$fail} failed\n";
+if ( $fail > 0 ) {
+	echo "\nFailures:\n";
+	foreach ( $failures as $failure ) {
+		echo "  - {$failure[0]}" . ( $failure[1] ? ": {$failure[1]}" : '' ) . "\n";
+	}
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Add provider auth scope policies so credentials can remain site-wide by default or opt into user, agent, or principal scoping.
- Store scoped account/config credentials under provider principals while preserving legacy site-level fallback behavior.
- Key OAuth state and PKCE verifier transients by nonce so concurrent auth starts for the same provider do not overwrite each other.

Closes #1988.

## Testing
- `php tests/auth-principal-scoped-smoke.php`
- `php tests/auth-ref-handler-config-smoke.php`
- `php tests/bundle-source-auth-smoke.php`
- `php tests/prompt-auth-template-artifacts-smoke.php`
- `php -l inc/Core/OAuth/BaseAuthProvider.php && php -l inc/Core/OAuth/BaseOAuth2Provider.php && php -l inc/Core/OAuth/OAuth2Handler.php && php -l inc/Abilities/AuthAbilities.php && php -l tests/auth-principal-scoped-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the auth scoping implementation and PR description; Chris reviewed the design direction during the session.