### PR TITLE
Expose Data Machine agent access store

### DIFF
--- a/inc/Core/Auth/AgentAccessStoreAdapter.php
+++ b/inc/Core/Auth/AgentAccessStoreAdapter.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Agents API access-store adapter for Data Machine agent access grants.
+ *
+ * @package DataMachine\Core\Auth
+ * @since   0.110.2
+ */
+
+namespace DataMachine\Core\Auth;
+
+use DataMachine\Core\Database\Agents\AgentAccess;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Exposes Data Machine's existing agent access table through Agents API.
+ */
+class AgentAccessStoreAdapter implements \WP_Agent_Access_Store {
+
+	/**
+	 * Existing Data Machine access repository.
+	 *
+	 * @var AgentAccess
+	 */
+	private AgentAccess $access_repository;
+
+	/**
+	 * @param AgentAccess|null $access_repository Optional repository for tests.
+	 */
+	public function __construct( ?AgentAccess $access_repository = null ) {
+		$this->access_repository = $access_repository ?? new AgentAccess();
+	}
+
+	/**
+	 * Register this adapter as the Agents API access store when no host supplied one.
+	 */
+	public static function register(): void {
+		add_filter( 'wp_agent_access_store', array( self::class, 'filter_access_store' ) );
+	}
+
+	/**
+	 * Provide Data Machine's store unless another host already provided one.
+	 *
+	 * @param mixed $store Existing filtered store.
+	 * @return mixed
+	 */
+	public static function filter_access_store( $store ) {
+		if ( $store instanceof \WP_Agent_Access_Store ) {
+			return $store;
+		}
+
+		static $adapter = null;
+
+		if ( null === $adapter ) {
+			$adapter = new self();
+		}
+
+		return $adapter;
+	}
+
+	/**
+	 * Create or update an access grant.
+	 */
+	public function grant_access( \WP_Agent_Access_Grant $grant ): \WP_Agent_Access_Grant {
+		return $this->access_repository->grant_access( $grant );
+	}
+
+	/**
+	 * Revoke a user's access grant for an agent.
+	 */
+	public function revoke_access( string $agent_id, int $user_id, ?string $workspace_id = null ): bool {
+		return $this->access_repository->revoke_access( $agent_id, $user_id, $workspace_id );
+	}
+
+	/**
+	 * Fetch a user's access grant for an agent.
+	 */
+	public function get_access( string $agent_id, int $user_id, ?string $workspace_id = null ): ?\WP_Agent_Access_Grant {
+		return $this->access_repository->get_access( $agent_id, $user_id, $workspace_id );
+	}
+
+	/**
+	 * List agent IDs accessible to a user.
+	 *
+	 * @return string[]
+	 */
+	public function get_agent_ids_for_user( int $user_id, ?string $minimum_role = null, ?string $workspace_id = null ): array {
+		return array_map( 'strval', $this->access_repository->get_agent_ids_for_user( $user_id, $minimum_role, $workspace_id ) );
+	}
+
+	/**
+	 * List users with access to an agent.
+	 *
+	 * @return \WP_Agent_Access_Grant[]
+	 */
+	public function get_users_for_agent( string $agent_id, ?string $workspace_id = null ): array {
+		return $this->access_repository->get_users_for_agent( $agent_id, $workspace_id );
+	}
+}

--- a/inc/Core/Database/Agents/AgentAccess.php
+++ b/inc/Core/Database/Agents/AgentAccess.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class AgentAccess extends BaseRepository implements \WP_Agent_Access_Store {
+class AgentAccess extends BaseRepository {
 
 	/**
 	 * Table name (without prefix).
@@ -296,7 +296,7 @@ class AgentAccess extends BaseRepository implements \WP_Agent_Access_Store {
 	 * @return string[] Roles that meet or exceed the minimum.
 	 */
 	private function roles_at_or_above( string $role ): array {
-		$hierarchy = array( 'viewer', 'operator', 'admin' );
+		$hierarchy = \WP_Agent_Access_Grant::roles();
 		$index     = array_search( $role, $hierarchy, true );
 
 		if ( false === $index ) {
@@ -304,25 +304,5 @@ class AgentAccess extends BaseRepository implements \WP_Agent_Access_Store {
 		}
 
 		return array_slice( $hierarchy, $index );
-	}
-
-	/**
-	 * Check if a role meets the minimum requirement.
-	 *
-	 * @param string $actual_role   The role the user has.
-	 * @param string $minimum_role  The minimum required role.
-	 * @return bool
-	 */
-	private function role_meets_minimum( string $actual_role, string $minimum_role ): bool {
-		$hierarchy = array(
-			'viewer'   => 0,
-			'operator' => 1,
-			'admin'    => 2,
-		);
-
-		$actual_level  = $hierarchy[ $actual_role ] ?? -1;
-		$minimum_level = $hierarchy[ $minimum_role ] ?? 0;
-
-		return $actual_level >= $minimum_level;
 	}
 }

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -68,9 +68,14 @@ use DataMachine\Engine\AI\MemoryFileRegistry;
 use DataMachine\Engine\AI\AgentModeRegistry;
 use DataMachine\Engine\AI\IterationBudgetRegistry;
 use DataMachine\Engine\AI\WpAiClientCache;
+use DataMachine\Core\Auth\AgentAccessStoreAdapter;
 use DataMachine\Core\PluginSettings;
 
 add_action( 'plugins_loaded', array( WpAiClientCache::class, 'install' ), 20 );
+
+if ( interface_exists( 'WP_Agent_Access_Store' ) ) {
+	AgentAccessStoreAdapter::register();
+}
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/agents-api-access-store-adapter-smoke.php
+++ b/tests/agents-api-access-store-adapter-smoke.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Pure-PHP smoke test for the Data Machine Agents API access-store adapter.
+ *
+ * Run with: php tests/agents-api-access-store-adapter-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+require_once dirname( __DIR__ ) . '/inc/Core/Database/BaseRepository.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Database/Agents/AgentAccess.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Auth/AgentAccessStoreAdapter.php';
+
+use DataMachine\Core\Auth\AgentAccessStoreAdapter;
+use DataMachine\Core\Database\Agents\AgentAccess;
+
+$GLOBALS['wpdb'] = (object) array(
+	'base_prefix' => 'wp_',
+	'prefix'      => 'wp_',
+);
+
+$failures = array();
+$passes   = 0;
+
+class DataMachineAccessStoreAdapterFakeRepository extends AgentAccess {
+
+	/** @var array<string, WP_Agent_Access_Grant> */
+	private array $grants = array();
+
+	public function __construct() {}
+
+	public function grant_access( \WP_Agent_Access_Grant $grant ): \WP_Agent_Access_Grant {
+		$this->grants[ $this->key( $grant->agent_id, $grant->user_id ) ] = $grant;
+		return $grant;
+	}
+
+	public function revoke_access( string $agent_id, int $user_id, ?string $workspace_id = null ): bool {
+		unset( $workspace_id );
+		$key = $this->key( $agent_id, $user_id );
+		if ( ! isset( $this->grants[ $key ] ) ) {
+			return false;
+		}
+
+		unset( $this->grants[ $key ] );
+		return true;
+	}
+
+	public function get_access( string $agent_id, int $user_id, ?string $workspace_id = null ): ?\WP_Agent_Access_Grant {
+		unset( $workspace_id );
+		return $this->grants[ $this->key( $agent_id, $user_id ) ] ?? null;
+	}
+
+	public function get_agent_ids_for_user( int $user_id, ?string $minimum_role = null, ?string $workspace_id = null ): array {
+		unset( $workspace_id );
+		$agent_ids = array();
+
+		foreach ( $this->grants as $grant ) {
+			if ( $grant->user_id === $user_id && ( null === $minimum_role || $grant->role_meets( $minimum_role ) ) ) {
+				$agent_ids[] = (int) $grant->agent_id;
+			}
+		}
+
+		return $agent_ids;
+	}
+
+	public function get_users_for_agent( string $agent_id, ?string $workspace_id = null ): array {
+		unset( $workspace_id );
+		return array_values(
+			array_filter(
+				$this->grants,
+				static fn( \WP_Agent_Access_Grant $grant ): bool => $grant->agent_id === $agent_id
+			)
+		);
+	}
+
+	private function key( string $agent_id, int $user_id ): string {
+		return $agent_id . ':' . $user_id;
+	}
+}
+
+class DataMachineAccessStoreAdapterExistingStore implements \WP_Agent_Access_Store {
+	public function grant_access( \WP_Agent_Access_Grant $grant ): \WP_Agent_Access_Grant { return $grant; }
+	public function revoke_access( string $agent_id, int $user_id, ?string $workspace_id = null ): bool { unset( $agent_id, $user_id, $workspace_id ); return true; }
+	public function get_access( string $agent_id, int $user_id, ?string $workspace_id = null ): ?\WP_Agent_Access_Grant { unset( $agent_id, $user_id, $workspace_id ); return null; }
+	public function get_agent_ids_for_user( int $user_id, ?string $minimum_role = null, ?string $workspace_id = null ): array { unset( $user_id, $minimum_role, $workspace_id ); return array(); }
+	public function get_users_for_agent( string $agent_id, ?string $workspace_id = null ): array { unset( $agent_id, $workspace_id ); return array(); }
+}
+
+echo "agents-api-access-store-adapter-smoke\n";
+
+$repository = new DataMachineAccessStoreAdapterFakeRepository();
+$adapter    = new AgentAccessStoreAdapter( $repository );
+
+agents_api_smoke_assert_equals( true, $adapter instanceof \WP_Agent_Access_Store, 'adapter implements Agents API store contract', $failures, $passes );
+
+$existing = new DataMachineAccessStoreAdapterExistingStore();
+agents_api_smoke_assert_equals( $existing, AgentAccessStoreAdapter::filter_access_store( $existing ), 'filter preserves existing host store', $failures, $passes );
+agents_api_smoke_assert_equals( true, AgentAccessStoreAdapter::filter_access_store( null ) instanceof AgentAccessStoreAdapter, 'filter supplies Data Machine adapter when empty', $failures, $passes );
+agents_api_smoke_assert_equals( AgentAccessStoreAdapter::filter_access_store( null ), AgentAccessStoreAdapter::filter_access_store( null ), 'filter reuses default adapter instance', $failures, $passes );
+
+$grant = new \WP_Agent_Access_Grant( '42', 7, \WP_Agent_Access_Grant::ROLE_OPERATOR );
+agents_api_smoke_assert_equals( $grant, $adapter->grant_access( $grant ), 'grant delegates to repository', $failures, $passes );
+agents_api_smoke_assert_equals( $grant, $adapter->get_access( '42', 7 ), 'get_access delegates to repository', $failures, $passes );
+agents_api_smoke_assert_equals( array( '42' ), $adapter->get_agent_ids_for_user( 7, \WP_Agent_Access_Grant::ROLE_VIEWER ), 'agent ID list is contract string shape', $failures, $passes );
+agents_api_smoke_assert_equals( array( $grant ), $adapter->get_users_for_agent( '42' ), 'get_users_for_agent delegates to repository', $failures, $passes );
+agents_api_smoke_assert_equals( true, $adapter->revoke_access( '42', 7 ), 'revoke delegates to repository', $failures, $passes );
+agents_api_smoke_assert_equals( null, $adapter->get_access( '42', 7 ), 'revoke removes repository grant', $failures, $passes );
+
+agents_api_smoke_finish( 'access-store adapter smoke', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds a thin Agents API `WP_Agent_Access_Store` adapter for Data Machine's existing agent access grants.
- Registers the adapter on `wp_agent_access_store` while preserving any host-provided store.
- Adds a pure-PHP smoke test for filter behavior and repository delegation.

## Verification
- `php -l inc/Core/Auth/AgentAccessStoreAdapter.php`
- `php -l inc/Core/Database/Agents/AgentAccess.php`
- `php -l inc/bootstrap.php`
- `php -l tests/agents-api-access-store-adapter-smoke.php`
- `php tests/agents-api-access-store-adapter-smoke.php`
- `vendor/bin/phpcs inc/Core/Auth/AgentAccessStoreAdapter.php inc/Core/Database/Agents/AgentAccess.php inc/bootstrap.php tests/agents-api-access-store-adapter-smoke.php`
- `composer test` failed with 4 existing-looking failures outside this change: `PipelineExecutionContractTest::test_fetch_ai_publish_pipeline_executes_with_fake_provider_only` and three `OAuth2HandlerStateTest` transient assertions.
- `homeboy lint --path /Users/chubes/Developer/data-machine@agent-access-store-adapter --extension wordpress --errors-only` failed on existing repo-wide JS lint findings.
- `homeboy test --path /Users/chubes/Developer/data-machine@agent-access-store-adapter --extension wordpress` failed with the same 4 PHPUnit failures as `composer test`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the adapter, smoke coverage, cleanup, and verification commands; Chris remains responsible for review and merge.