### PR TITLE
test: align OAuth state coverage with nonce-keyed transients

### DIFF
--- a/tests/Unit/Core/OAuth/OAuth2HandlerStateTest.php
+++ b/tests/Unit/Core/OAuth/OAuth2HandlerStateTest.php
@@ -50,9 +50,9 @@ class OAuth2HandlerStateTest extends WP_UnitTestCase {
 	}
 
 	public function test_create_state_stores_structured_record_in_transient(): void {
-		$this->handler->create_state( 'test_provider', array( 'key' => 'value' ) );
+		$state = $this->handler->create_state( 'test_provider', array( 'key' => 'value' ) );
 
-		$record = get_transient( 'datamachine_test_provider_oauth_state' );
+		$record = get_transient( $this->state_transient_key( 'test_provider', $state ) );
 
 		$this->assertIsArray( $record );
 		$this->assertArrayHasKey( 'nonce', $record );
@@ -62,9 +62,9 @@ class OAuth2HandlerStateTest extends WP_UnitTestCase {
 	}
 
 	public function test_create_state_without_payload_stores_empty_array(): void {
-		$this->handler->create_state( 'test_provider' );
+		$state = $this->handler->create_state( 'test_provider' );
 
-		$record = get_transient( 'datamachine_test_provider_oauth_state' );
+		$record = get_transient( $this->state_transient_key( 'test_provider', $state ) );
 
 		$this->assertIsArray( $record );
 		$this->assertSame( array(), $record['payload'] );
@@ -209,7 +209,7 @@ class OAuth2HandlerStateTest extends WP_UnitTestCase {
 		$state = $this->handler->create_state( 'test_expired' );
 
 		// Simulate expiration by deleting the transient.
-		delete_transient( 'datamachine_test_expired_oauth_state' );
+		delete_transient( $this->state_transient_key( 'test_expired', $state ) );
 
 		$result = $this->handler->verify_state( 'test_expired', $state );
 
@@ -257,5 +257,9 @@ class OAuth2HandlerStateTest extends WP_UnitTestCase {
 
 	public function test_max_payload_size_constant_is_4096(): void {
 		$this->assertSame( 4096, OAuth2Handler::MAX_PAYLOAD_SIZE );
+	}
+
+	private function state_transient_key( string $provider_key, string $state ): string {
+		return "datamachine_{$provider_key}_oauth_state_" . substr( hash( 'sha256', $state ), 0, 24 );
 	}
 }


### PR DESCRIPTION
## Summary
- Updates OAuth state tests to inspect the nonce-keyed transient created by `OAuth2Handler::create_state()`.
- Updates the expiration simulation to delete the actual nonce-keyed transient before verification.

Fixes #1991.

## Testing
- `homeboy test data-machine -- --filter=OAuth2HandlerStateTest`
- `homeboy test data-machine --changed-since origin/main`
- `homeboy lint data-machine --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Reproducing the CI test failures, identifying stale transient-key assumptions in the tests, updating the focused coverage, and running verification. Chris remains responsible for review and final merge.