### PR TITLE
fix: surface pipeline fetch errors

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx
@@ -41,6 +41,14 @@ import { isSameId } from './utils/ids';
 const ModalManager = lazy( () => import( './components/shared/ModalManager' ) );
 const ChatSidebar = lazy( () => import( './components/chat/ChatSidebar' ) );
 
+const getErrorMessage = ( error ) => {
+	if ( ! error ) {
+		return null;
+	}
+
+	return error.message || String( error );
+};
+
 /**
  * Root application component
  *
@@ -220,6 +228,10 @@ export default function PipelinesApp() {
 	 * Determine main content based on state
 	 */
 	const renderMainContent = () => {
+		const errorMessage = getErrorMessage(
+			pipelinesError || selectedPipelineError || flowsError
+		);
+
 		// Loading state
 		if ( pipelinesLoading || selectedPipelineLoading ) {
 			return (
@@ -231,14 +243,10 @@ export default function PipelinesApp() {
 		}
 
 		// Error state
-		if ( pipelinesError || selectedPipelineError || flowsError ) {
+		if ( errorMessage ) {
 			return (
 				<Notice status="error" isDismissible={ false }>
-					<p>
-						{ pipelinesError ||
-							selectedPipelineError ||
-							flowsError }
-					</p>
+					<p>{ errorMessage }</p>
 				</Notice>
 			);
 		}

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
@@ -28,19 +28,23 @@ import {
 } from '../utils/api';
 import { isSameId, normalizeId } from '../utils/ids';
 
+const getFetchError = ( response, fallback ) =>
+	new Error( response?.message || fallback );
+
 const setFlowInCache = ( queryClient, flow ) => {
 	if ( ! flow?.flow_id ) {
 		return;
 	}
 
 	const cachedFlowId = normalizeId( flow.flow_id );
-	const cachedPipelineId = normalizeId( flow.pipeline_id );
 
 	if ( ! cachedFlowId ) {
 		return;
 	}
 
 	queryClient.setQueryData( [ 'flows', 'single', cachedFlowId ], flow );
+
+	const cachedPipelineId = normalizeId( flow.pipeline_id );
 
 	if ( cachedPipelineId ) {
 		queryClient.setQueriesData(
@@ -65,7 +69,6 @@ const setFlowInCache = ( queryClient, flow ) => {
 
 const patchFlowInCache = ( queryClient, { pipelineId, flowId, patchFlow } ) => {
 	const cachedFlowId = normalizeId( flowId );
-	const cachedPipelineId = normalizeId( pipelineId );
 
 	if ( ! cachedFlowId || typeof patchFlow !== 'function' ) {
 		return;
@@ -75,6 +78,8 @@ const patchFlowInCache = ( queryClient, { pipelineId, flowId, patchFlow } ) => {
 		[ 'flows', 'single', cachedFlowId ],
 		( oldFlow ) => ( oldFlow ? patchFlow( oldFlow ) : oldFlow )
 	);
+
+	const cachedPipelineId = normalizeId( pipelineId );
 
 	if ( cachedPipelineId ) {
 		queryClient.setQueriesData(
@@ -133,7 +138,7 @@ export const useFlows = ( pipelineId, { page = 1, perPage = 20 } = {} ) => {
 		queryFn: async () => {
 			const response = await fetchFlows( pipelineId, { page, perPage, outputMode } );
 			if ( ! response.success ) {
-				return { flows: [], total: 0, perPage, offset: 0 };
+				throw getFetchError( response, 'Failed to fetch flows' );
 			}
 			return {
 				flows: response.data.flows || [],

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
@@ -26,6 +26,9 @@ import {
 } from '../utils/api';
 import { isSameId } from '../utils/ids';
 
+const getFetchError = ( response, fallback ) =>
+	new Error( response?.message || fallback );
+
 // Queries
 
 /**
@@ -47,7 +50,7 @@ export const usePipelines = () =>
 		queryFn: async () => {
 			const response = await fetchPipelines();
 			if ( ! response.success ) {
-				return [];
+				throw getFetchError( response, 'Failed to fetch pipelines' );
 			}
 			return response.data.pipelines ?? [];
 		},
@@ -79,7 +82,7 @@ export const usePipelineSearch = ( {
 				search: normalizedSearch || null,
 			} );
 			if ( ! response.success ) {
-				return { pipelines: [], total: 0 };
+				throw getFetchError( response, 'Failed to search pipelines' );
 			}
 			return {
 				pipelines: response.data.pipelines ?? [],
@@ -123,7 +126,7 @@ export const usePipeline = ( pipelineId ) => {
 				includeFlows: false,
 			} );
 			if ( ! response.success ) {
-				return null;
+				throw getFetchError( response, 'Failed to fetch pipeline' );
 			}
 			const pipelineRecord = response.data?.pipeline ?? null;
 			const flows = response.data?.flows ?? [];


### PR DESCRIPTION
## Summary
- Surface failed pipeline list/search/detail fetches as TanStack Query errors instead of empty successful results.
- Surface failed flow fetches on the Pipelines page for the same error path.
- Render query error messages as strings in the Pipelines error notice.

Fixes #1963.

## Testing
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-pipelines-fetch-errors --changed-since origin/main`
- `npm run build`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-pipelines-fetch-errors --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Pipelines fetch error masking path, drafted the focused React query/UI fix, and ran local verification. Chris remains responsible for review and merge.