### PR TITLE
Register Agents API host stores

### DIFF
--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -68,6 +68,9 @@ use DataMachine\Engine\AI\MemoryFileRegistry;
 use DataMachine\Engine\AI\AgentModeRegistry;
 use DataMachine\Engine\AI\IterationBudgetRegistry;
 use DataMachine\Engine\AI\WpAiClientCache;
+use DataMachine\Engine\AI\Actions\PendingActionStore;
+use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Auth\AgentAccessStoreAdapter;
 use DataMachine\Core\PluginSettings;
 
@@ -76,6 +79,27 @@ add_action( 'plugins_loaded', array( WpAiClientCache::class, 'install' ), 20 );
 if ( interface_exists( 'WP_Agent_Access_Store' ) ) {
 	AgentAccessStoreAdapter::register();
 }
+
+add_filter(
+	'wp_agent_conversation_store',
+	static function () {
+		return ConversationStoreFactory::get_transcript_store();
+	}
+);
+
+add_filter(
+	'wp_agent_pending_action_store',
+	static function () {
+		return PendingActionStore::adapter();
+	}
+);
+
+add_filter(
+	'wp_agent_pending_action_resolver',
+	static function () {
+		return ResolvePendingActionAbility::adapter();
+	}
+);
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Register Data Machine's conversation store on `wp_agent_conversation_store`.
- Register the pending action store and resolver adapters on the canonical Agents API filters.
- Make the newly merged frontend chat/session/pending-action abilities usable without product-specific fallback code.

## Testing
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agent-access-store-adapter --changed-since origin/main`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@agent-access-store-adapter --changed-since origin/main`

## Notes
- `homeboy test --changed-since origin/main` found no impacted tests for this bootstrap-only change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Wired the Agents API host-store filters and ran validation commands. Chris requested removing legacy fallback paths and making upstream adoption the prerequisite.