### PR TITLE
fix: harden handlers API response

### DIFF
--- a/inc/Api/Handlers.php
+++ b/inc/Api/Handlers.php
@@ -110,9 +110,27 @@ class Handlers {
 
 		// Enrich handler data with auth_type, auth_fields, and authentication status
 		foreach ( $handlers as $slug => &$handler ) {
+			if ( ! is_array( $handler ) ) {
+				unset( $handlers[ $slug ] );
+				continue;
+			}
+
+			$handler = array_merge(
+				array(
+					'type'              => '',
+					'class'             => '',
+					'label'             => $slug,
+					'description'       => '',
+					'requires_auth'     => false,
+					'auth_provider_key' => null,
+					'meta'              => array(),
+				),
+				$handler
+			);
+
 			$auth_key      = $handler['auth_provider_key'] ?? $slug;
 			$auth_instance = $auth_abilities->getProvider( $auth_key );
-			if ( $handler['requires_auth'] && $auth_instance ) {
+			if ( ! empty( $handler['requires_auth'] ) && $auth_instance ) {
 				$auth_type            = self::detect_auth_type( $auth_instance );
 				$handler['auth_type'] = $auth_type;
 
@@ -138,6 +156,7 @@ class Handlers {
 				}
 			}
 		}
+		unset( $handler );
 
 		return rest_ensure_response(
 			array(

--- a/tests/handlers-api-json-safe-smoke.php
+++ b/tests/handlers-api-json-safe-smoke.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Smoke test for JSON-safe /handlers responses.
+ *
+ * @package DataMachine\Tests
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+require_once __DIR__ . '/smoke-wp-stubs.php';
+
+if ( ! function_exists( '__' ) ) {
+	function __( string $text, string $domain = 'default' ): string {
+		unset( $domain );
+		return $text;
+	}
+}
+
+$GLOBALS['handlers_api_smoke_filters'] = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['handlers_api_smoke_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		if ( empty( $GLOBALS['handlers_api_smoke_filters'][ $hook ] ) ) {
+			return $value;
+		}
+
+		ksort( $GLOBALS['handlers_api_smoke_filters'][ $hook ], SORT_NUMERIC );
+		foreach ( $GLOBALS['handlers_api_smoke_filters'][ $hook ] as $callbacks ) {
+			foreach ( $callbacks as [ $callback, $accepted_args ] ) {
+				$value = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+			}
+		}
+
+		return $value;
+	}
+}
+
+if ( ! class_exists( 'WP_REST_Request' ) ) {
+	class WP_REST_Request {
+		public function get_param( string $key ) {
+			unset( $key );
+			return null;
+		}
+	}
+}
+
+if ( ! function_exists( 'rest_ensure_response' ) ) {
+	function rest_ensure_response( $data ) {
+		return new class( $data ) {
+			private $data;
+
+			public function __construct( $data ) {
+				$this->data = $data;
+			}
+
+			public function get_data() {
+				return $this->data;
+			}
+		};
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value ): string {
+		return (string) json_encode( $value );
+	}
+}
+
+require_once __DIR__ . '/../inc/Abilities/HandlerAbilities.php';
+require_once __DIR__ . '/../inc/Abilities/AuthAbilities.php';
+require_once __DIR__ . '/../inc/Api/Handlers.php';
+
+use DataMachine\Abilities\AuthAbilities;
+use DataMachine\Abilities\HandlerAbilities;
+use DataMachine\Api\Handlers;
+
+$passes = 0;
+$fails  = 0;
+
+$assert = static function ( string $label, bool $condition ) use ( &$passes, &$fails ): void {
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		++$passes;
+		return;
+	}
+
+	echo "FAIL: {$label}\n";
+	++$fails;
+};
+
+$warnings = array();
+set_error_handler(
+	static function ( int $errno, string $errstr ) use ( &$warnings ): bool {
+		$warnings[] = array( $errno, $errstr );
+		return true;
+	}
+);
+
+add_filter(
+	'datamachine_handlers',
+	static function ( array $handlers ): array {
+		$handlers['minimal'] = array(
+			'type'  => 'fetch',
+			'label' => 'Minimal Handler',
+		);
+		$handlers['not_array'] = 'bad handler registration';
+		return $handlers;
+	},
+	10,
+	2
+);
+
+HandlerAbilities::clearCache();
+AuthAbilities::clearCache();
+
+$response = Handlers::handle_get_handlers( new WP_REST_Request() );
+restore_error_handler();
+
+$data     = $response->get_data();
+$handlers = $data['data'] ?? array();
+
+$assert( 'response succeeds', true === ( $data['success'] ?? false ) );
+$assert( 'minimal handler remains present', isset( $handlers['minimal'] ) );
+$assert( 'missing requires_auth defaults false', false === ( $handlers['minimal']['requires_auth'] ?? null ) );
+$assert( 'missing auth_provider_key defaults null', array_key_exists( 'auth_provider_key', $handlers['minimal'] ) && null === $handlers['minimal']['auth_provider_key'] );
+$assert( 'malformed non-array handler is omitted', ! isset( $handlers['not_array'] ) );
+$assert( 'handler enrichment emitted no PHP warnings', array() === $warnings );
+$assert( 'response is JSON encodable', '' !== wp_json_encode( $data ) );
+
+echo "\n=== Results ===\n";
+echo "Passed: {$passes}\n";
+echo "Failed: {$fails}\n";
+
+if ( $fails > 0 ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Normalize handler definitions before enriching `/datamachine/v1/handlers` responses so missing optional keys do not emit PHP notices into REST output.
- Drop malformed non-array handler registrations from the discovery response instead of letting them contaminate JSON output.
- Add a smoke regression covering JSON-safe `/handlers` output with incomplete and malformed handler registrations.

Fixes #1959.

## Testing
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-handlers-invalid-json --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-handlers-invalid-json --changed-since origin/main`
- `php tests/handlers-api-json-safe-smoke.php`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the `/handlers` invalid JSON evidence, drafted the focused REST response hardening and smoke coverage, and ran local verification. Chris remains responsible for review and merge.