### PR TITLE
Fix OAuth2 code token exchange

### DIFF
--- a/inc/Core/OAuth/OAuth2Handler.php
+++ b/inc/Core/OAuth/OAuth2Handler.php
@@ -399,6 +399,8 @@ class OAuth2Handler {
 		}
 
 		// Include PKCE code_verifier in token exchange if one was stored.
+		$token_params['code'] = $code;
+
 		$verifier = $this->get_pkce_verifier( $provider_key, $state );
 		if ( null !== $verifier ) {
 			$token_params['code_verifier'] = $verifier;


### PR DESCRIPTION
## Summary
- Include the OAuth authorization `code` in token exchange requests handled by `OAuth2Handler::handle_callback()`.
- Unblocks PKCE / authorization-code providers that do not use implicit fragment callbacks.

## Testing
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-oauth2-code-token-exchange --file inc/Core/OAuth/OAuth2Handler.php`
- Deployed to `intelligence-horse` and verified WP.com PKCE flow reaches the code callback path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the OAuth callback/token exchange path, drafting the fix, and running local/remote verification commands.