### PR TITLE
Add HTTP Basic auth refs

### DIFF
--- a/inc/Core/HttpClient.php
+++ b/inc/Core/HttpClient.php
@@ -42,6 +42,7 @@ class HttpClient {
 	 *                        - timeout: int - Request timeout (default 120)
 	 *                        - proxy_url: string - Optional per-request proxy URL (http, https, socks4, socks5, socks5h)
 	 *                        - auth: array - Optional standard auth config: {type: basic, username, password} or {type: bearer, token}
+	 *                        - auth_ref: string - Optional provider:account credential reference resolved through registered auth providers
 	 *                        - browser_mode: bool - Use browser-like headers (default false)
 	 *                        - context: string - Context for logging (default 'HTTP Request')
 	 * @return array Response array.
@@ -64,6 +65,14 @@ class HttpClient {
 			return array(
 				'success' => false,
 				'error'   => 'Invalid HTTP method',
+			);
+		}
+
+		$options = self::resolveAuthRefOptions( $options, $context );
+		if ( is_wp_error( $options ) ) {
+			return array(
+				'success' => false,
+				'error'   => $options->get_error_message(),
 			);
 		}
 
@@ -235,6 +244,59 @@ class HttpClient {
 		}
 
 		return $headers;
+	}
+
+	/**
+	 * Resolve a portable auth_ref into concrete request options for this install.
+	 */
+	private static function resolveAuthRefOptions( array $options, string $context ): array|\WP_Error {
+		$ref_string = $options['auth_ref'] ?? null;
+		if ( ! is_string( $ref_string ) || '' === trim( $ref_string ) ) {
+			return $options;
+		}
+
+		try {
+			$ref = \DataMachine\Engine\Bundle\AuthRef::from_string( $ref_string );
+		} catch ( \Throwable $e ) {
+			return new \WP_Error( 'http_auth_ref_invalid', $e->getMessage() );
+		}
+
+		$providers = apply_filters( 'datamachine_auth_providers', array() );
+		$provider  = is_array( $providers ) ? ( $providers[ $ref->provider() ] ?? null ) : null;
+		if ( ! $provider instanceof \DataMachine\Core\OAuth\BaseAuthProvider ) {
+			return new \WP_Error(
+				'http_auth_ref_unresolved',
+				sprintf(
+					/* translators: 1: auth ref, 2: provider slug. */
+					__( 'Auth ref "%1$s" cannot be resolved because provider "%2$s" is not registered on this install.', 'data-machine' ),
+					$ref->ref(),
+					$ref->provider()
+				)
+			);
+		}
+
+		$resolved = $provider->resolve_auth_ref(
+			$ref->account(),
+			'http',
+			array(
+				'context' => $context,
+				'runtime' => true,
+			)
+		);
+		if ( is_wp_error( $resolved ) ) {
+			$error_code = $resolved->get_error_code();
+			return new \WP_Error(
+				'' !== $error_code ? $error_code : 'http_auth_ref_unresolved',
+				sprintf(
+					/* translators: %s: auth ref. */
+					__( 'Auth ref "%s" could not be resolved on this install.', 'data-machine' ),
+					$ref->ref()
+				)
+			);
+		}
+
+		unset( $options['auth_ref'] );
+		return array_replace( $resolved, $options );
 	}
 
 	/**

--- a/inc/Core/OAuth/HttpBasicAuthProvider.php
+++ b/inc/Core/OAuth/HttpBasicAuthProvider.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Generic HTTP Basic authentication provider.
+ *
+ * @package DataMachine\Core\OAuth
+ */
+
+namespace DataMachine\Core\OAuth;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Stores one named HTTP Basic credential as an encrypted Data Machine auth ref.
+ */
+final class HttpBasicAuthProvider extends BaseAuthProvider {
+
+	public const PROVIDER_SLUG = 'http_basic';
+
+	public function __construct() {
+		parent::__construct( self::PROVIDER_SLUG );
+	}
+
+	/**
+	 * Get configuration fields for CLI/UI credential entry.
+	 */
+	public function get_config_fields(): array {
+		return array(
+			'account'   => array(
+				'label'       => __( 'Account', 'data-machine' ),
+				'type'        => 'text',
+				'required'    => true,
+				'description' => __( 'Local auth ref account name, for example logstash.', 'data-machine' ),
+			),
+			'username'  => array(
+				'label'    => __( 'Username', 'data-machine' ),
+				'type'     => 'text',
+				'required' => true,
+			),
+			'password'  => array(
+				'label'    => __( 'Password', 'data-machine' ),
+				'type'     => 'password',
+				'required' => true,
+			),
+			'proxy_url' => array(
+				'label'       => __( 'Proxy URL', 'data-machine' ),
+				'type'        => 'url',
+				'required'    => false,
+				'description' => __( 'Optional per-request proxy URL.', 'data-machine' ),
+			),
+		);
+	}
+
+	/**
+	 * Whether a usable credential is stored.
+	 */
+	public function is_authenticated(): bool {
+		$config = $this->get_config();
+		return ! empty( $config['account'] ) && ! empty( $config['username'] ) && ! empty( $config['password'] );
+	}
+
+	/**
+	 * Resolve http_basic:<account> into HttpClient auth/proxy options.
+	 */
+	public function resolve_auth_ref( string $account, string $handler_slug = '', array $context = array() ): array|\WP_Error {
+		unset( $handler_slug, $context );
+
+		$config = $this->get_config();
+		if ( (string) ( $config['account'] ?? '' ) !== $account || empty( $config['username'] ) || empty( $config['password'] ) ) {
+			return new \WP_Error(
+				'auth_ref_unresolved',
+				sprintf(
+					/* translators: %s: auth ref account. */
+					__( 'No HTTP Basic credential is configured for auth ref "%s".', 'data-machine' ),
+					$account
+				)
+			);
+		}
+
+		$resolved = array(
+			'auth' => array(
+				'type'     => 'basic',
+				'username' => (string) $config['username'],
+				'password' => (string) $config['password'],
+			),
+		);
+
+		if ( ! empty( $config['proxy_url'] ) ) {
+			$resolved['proxy_url'] = (string) $config['proxy_url'];
+		}
+
+		return $resolved;
+	}
+}

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -72,9 +72,31 @@ use DataMachine\Engine\AI\Actions\PendingActionStore;
 use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Auth\AgentAccessStoreAdapter;
+use DataMachine\Core\OAuth\HttpBasicAuthProvider;
 use DataMachine\Core\PluginSettings;
 
 add_action( 'plugins_loaded', array( WpAiClientCache::class, 'install' ), 20 );
+
+add_filter(
+	'datamachine_auth_providers',
+	static function ( array $providers ): array {
+		$providers[ HttpBasicAuthProvider::PROVIDER_SLUG ] ??= new HttpBasicAuthProvider();
+		return $providers;
+	}
+);
+
+add_filter(
+	'datamachine_auth_encrypted_fields',
+	static function ( array $fields, string $provider_slug ): array {
+		if ( HttpBasicAuthProvider::PROVIDER_SLUG === $provider_slug ) {
+			$fields[] = 'password';
+		}
+
+		return $fields;
+	},
+	10,
+	2
+);
 
 if ( interface_exists( 'WP_Agent_Access_Store' ) ) {
 	AgentAccessStoreAdapter::register();

--- a/tests/http-basic-auth-provider-smoke.php
+++ b/tests/http-basic-auth-provider-smoke.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Smoke coverage for the generic HTTP Basic auth provider.
+ *
+ * Run with: php tests/http-basic-auth-provider-smoke.php
+ */
+
+use DataMachine\Core\OAuth\BaseAuthProvider;
+use DataMachine\Core\OAuth\HttpBasicAuthProvider;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+function __( string $text, string $domain = '' ): string {
+	unset( $domain );
+	return $text;
+}
+
+function get_site_option( string $name, mixed $default = false ): mixed {
+	return $GLOBALS['datamachine_http_basic_options'][ $name ] ?? $default;
+}
+
+function update_site_option( string $name, mixed $value ): bool {
+	$GLOBALS['datamachine_http_basic_options'][ $name ] = $value;
+	return true;
+}
+
+function wp_salt( string $scheme = 'auth' ): string {
+	return 'http-basic-smoke-salt-' . $scheme;
+}
+
+function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+	if ( 'datamachine_auth_encrypted_fields' === $hook && 'http_basic' === ( $args[0] ?? '' ) ) {
+		$value[] = 'password';
+	}
+	return $value;
+}
+
+function is_wp_error( mixed $thing ): bool {
+	return $thing instanceof \WP_Error;
+}
+
+class WP_Error {
+	public function __construct(
+		private string $code = '',
+		private string $message = ''
+	) {}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Core/OAuth/BaseAuthProvider.php';
+require_once dirname( __DIR__ ) . '/inc/Core/OAuth/HttpBasicAuthProvider.php';
+
+$provider = new HttpBasicAuthProvider();
+$provider->save_config(
+	array(
+		'account'   => 'logstash',
+		'username'  => 'chubes4',
+		'password'  => 'secret-password',
+		'proxy_url' => 'socks5://127.0.0.1:8080',
+	)
+);
+
+$stored = $GLOBALS['datamachine_http_basic_options']['datamachine_auth_data']['http_basic']['config']['password'] ?? '';
+if ( ! is_string( $stored ) || ! str_starts_with( $stored, BaseAuthProvider::ENCRYPTION_PREFIX ) ) {
+	fwrite( STDERR, "password was not encrypted at rest\n" );
+	exit( 1 );
+}
+
+$resolved = $provider->resolve_auth_ref( 'logstash' );
+if ( is_wp_error( $resolved ) ) {
+	fwrite( STDERR, "auth ref unexpectedly failed\n" );
+	exit( 1 );
+}
+
+if ( 'basic' !== ( $resolved['auth']['type'] ?? '' ) || 'chubes4' !== ( $resolved['auth']['username'] ?? '' ) || 'secret-password' !== ( $resolved['auth']['password'] ?? '' ) ) {
+	fwrite( STDERR, "auth ref did not resolve Basic credentials\n" );
+	exit( 1 );
+}
+
+if ( 'socks5://127.0.0.1:8080' !== ( $resolved['proxy_url'] ?? '' ) ) {
+	fwrite( STDERR, "auth ref did not resolve proxy URL\n" );
+	exit( 1 );
+}
+
+echo "=== http-basic-auth-provider-smoke: ALL PASS ===\n";

--- a/tests/http-client-proxy-auth-smoke.php
+++ b/tests/http-client-proxy-auth-smoke.php
@@ -38,8 +38,76 @@ if ( ! function_exists( 'wp_parse_url' ) ) {
 	}
 }
 
+if ( ! function_exists( '__' ) ) {
+	function __( string $text, string $domain = '' ): string {
+		unset( $domain );
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+		if ( 'datamachine_auth_providers' === $hook ) {
+			return $GLOBALS['datamachine_http_client_auth_providers'] ?? $value;
+		}
+
+		if ( 'datamachine_auth_encrypted_fields' === $hook && 'http_basic' === ( $args[0] ?? '' ) ) {
+			$value[] = 'password';
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'get_site_option' ) ) {
+	function get_site_option( string $name, mixed $default = false ): mixed {
+		return $GLOBALS['datamachine_http_client_options'][ $name ] ?? $default;
+	}
+}
+
+if ( ! function_exists( 'update_site_option' ) ) {
+	function update_site_option( string $name, mixed $value ): bool {
+		$GLOBALS['datamachine_http_client_options'][ $name ] = $value;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_salt' ) ) {
+	function wp_salt( string $scheme = 'auth' ): string {
+		return 'http-client-smoke-salt-' . $scheme;
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct(
+			private string $code = '',
+			private string $message = ''
+		) {}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+require_once __DIR__ . '/../inc/Engine/Bundle/BundleValidationException.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AuthRef.php';
+require_once __DIR__ . '/../inc/Core/OAuth/BaseAuthProvider.php';
+require_once __DIR__ . '/../inc/Core/OAuth/HttpBasicAuthProvider.php';
 require_once __DIR__ . '/../inc/Core/HttpClient.php';
 
+use DataMachine\Core\OAuth\HttpBasicAuthProvider;
 use DataMachine\Core\HttpClient;
 
 $failed = 0;
@@ -115,7 +183,39 @@ http_client_smoke_assert(
 	'Custom manual' === ( $manual_args['headers']['authorization'] ?? null )
 );
 
-echo "\n[2] Redaction\n";
+echo "\n[2] Auth ref options\n";
+
+$provider = new HttpBasicAuthProvider();
+$provider->save_config(
+	array(
+		'account'   => 'logstash',
+		'username'  => 'chubes4',
+		'password'  => 'secret-password',
+		'proxy_url' => 'socks5://127.0.0.1:8080',
+	)
+);
+$GLOBALS['datamachine_http_client_auth_providers'] = array(
+	HttpBasicAuthProvider::PROVIDER_SLUG => $provider,
+);
+
+$resolved_options = http_client_private(
+	'resolveAuthRefOptions',
+	array(
+		'auth_ref' => 'http_basic:logstash',
+	),
+	'Logstash test'
+);
+
+http_client_smoke_assert( 'auth_ref resolves auth options', is_array( $resolved_options ) && 'basic' === ( $resolved_options['auth']['type'] ?? null ) );
+http_client_smoke_assert( 'auth_ref resolves proxy URL', is_array( $resolved_options ) && 'socks5://127.0.0.1:8080' === ( $resolved_options['proxy_url'] ?? null ) );
+
+$auth_ref_args = http_client_private( 'buildRequestArgs', 'GET', is_array( $resolved_options ) ? $resolved_options : array() );
+http_client_smoke_assert(
+	'auth_ref resolved Basic header is applied',
+	'Basic ' . base64_encode( 'chubes4:secret-password' ) === ( $auth_ref_args['headers']['Authorization'] ?? null )
+);
+
+echo "\n[3] Redaction\n";
 
 $redacted = http_client_private(
 	'redactRequestArgsForLog',
@@ -134,7 +234,7 @@ http_client_smoke_assert( 'Proxy-Authorization is redacted', '[redacted]' === ( 
 http_client_smoke_assert( 'Cookie is redacted', '[redacted]' === ( $redacted['headers']['Cookie'] ?? null ) );
 http_client_smoke_assert( 'Non-sensitive header remains visible', 'visible' === ( $redacted['headers']['X-Test'] ?? null ) );
 
-echo "\n[3] Proxy scheme mapping\n";
+echo "\n[4] Proxy scheme mapping\n";
 
 http_client_smoke_assert(
 	'socks5 proxy scheme is recognized when cURL exposes the constant',


### PR DESCRIPTION
## Summary
- Adds a generic `http_basic` auth provider that stores named Basic credentials with encrypted passwords.
- Allows `DataMachine\Core\HttpClient` callers to pass `auth_ref` values such as `http_basic:logstash` and receive resolved auth/proxy request options.
- Extends smoke coverage for encrypted credential storage and auth-ref HTTP request resolution.

## Testing
- `php tests/http-basic-auth-provider-smoke.php`
- `php tests/http-client-proxy-auth-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@http-basic-auth-provider --extension wordpress --changed-since origin/main`
- `homeboy audit --path /Users/chubes/Developer/data-machine@http-basic-auth-provider --extension wordpress --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, smoke coverage, and verification commands; Chris remains responsible for review and final merge.