### PR TITLE
fix: load full flow configs in pipelines admin

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
@@ -131,7 +131,7 @@ const patchFlowStepInCache = (
 // Queries
 export const useFlows = ( pipelineId, { page = 1, perPage = 20 } = {} ) => {
 	const cachedPipelineId = normalizeId( pipelineId );
-	const outputMode = 'list';
+	const outputMode = 'full';
 
 	return useQuery( {
 		queryKey: [ 'flows', cachedPipelineId, { page, perPage, outputMode } ],


### PR DESCRIPTION
## Summary
- Fixes the pipelines admin flow cards by requesting full flow records so `flow_config` is available for step rendering.
- Keeps the backend lightweight list mode intact for callers that only need flow summaries.

## Testing
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the React/API response mismatch, drafted the one-line fix, and ran the frontend build; Chris remains responsible for review and merge.