### PR TITLE
Fix chat tool schemas and support custom modes

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -88,8 +88,8 @@ class AgentsChatHandler {
 		$client_context = is_array( $input['client_context'] ?? null ) ? $input['client_context'] : array();
 		$mode           = $this->resolveMode( $input, $client_context );
 		$agent_config   = PluginSettings::resolveModelForAgentMode( 0 === $agent_id ? null : $agent_id, $mode );
-		$provider     = $agent_config['provider'] ?? '';
-		$model        = $agent_config['model'] ?? '';
+		$provider       = $agent_config['provider'] ?? '';
+		$model          = $agent_config['model'] ?? '';
 
 		if ( '' === $provider ) {
 			return new WP_Error( 'provider_required', __( 'AI provider is required. Set a default in Data Machine settings.', 'data-machine' ), array( 'status' => 400 ) );

--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -85,7 +85,9 @@ class AgentsChatHandler {
 			return $agent_id;
 		}
 
-		$agent_config = PluginSettings::resolveModelForAgentMode( 0 === $agent_id ? null : $agent_id, 'chat' );
+		$client_context = is_array( $input['client_context'] ?? null ) ? $input['client_context'] : array();
+		$mode           = $this->resolveMode( $input, $client_context );
+		$agent_config   = PluginSettings::resolveModelForAgentMode( 0 === $agent_id ? null : $agent_id, $mode );
 		$provider     = $agent_config['provider'] ?? '';
 		$model        = $agent_config['model'] ?? '';
 
@@ -104,9 +106,10 @@ class AgentsChatHandler {
 			$user_id,
 			array(
 				'session_id'     => $input['session_id'] ?? null,
+				'mode'           => $mode,
 				'agent_id'       => $agent_id,
 				'attachments'    => $input['attachments'] ?? array(),
-				'client_context' => $input['client_context'] ?? array(),
+				'client_context' => $client_context,
 			)
 		);
 
@@ -139,6 +142,20 @@ class AgentsChatHandler {
 		}
 
 		return (int) ( $row['agent_id'] ?? 0 );
+	}
+
+	/**
+	 * Resolve the Data Machine execution mode from canonical Agents API input.
+	 *
+	 * @param array $input Canonical agents/chat input.
+	 * @param array $client_context Transport-level client context.
+	 * @return string Sanitized mode slug.
+	 */
+	private function resolveMode( array $input, array $client_context ): string {
+		$mode = $input['mode'] ?? $client_context['agent_mode'] ?? $client_context['mode'] ?? 'chat';
+		$mode = sanitize_key( (string) $mode );
+
+		return '' !== $mode ? $mode : 'chat';
 	}
 
 	/**

--- a/inc/Abilities/Chat/SendMessageAbility.php
+++ b/inc/Abilities/Chat/SendMessageAbility.php
@@ -66,6 +66,10 @@ class SendMessageAbility {
 								'type'        => 'string',
 								'description' => __( 'AI model identifier. Resolved from agent/defaults if omitted.', 'data-machine' ),
 							),
+							'mode'                 => array(
+								'type'        => 'string',
+								'description' => __( 'Execution mode for tool/context resolution. Defaults to chat.', 'data-machine' ),
+							),
 							'selected_pipeline_id' => array(
 								'type'        => 'integer',
 								'description' => __( 'Currently selected pipeline ID for context.', 'data-machine' ),
@@ -163,13 +167,14 @@ class SendMessageAbility {
 		}
 
 		$agent_id = (int) ( $input['agent_id'] ?? 0 );
+		$mode     = ! empty( $input['mode'] ) ? sanitize_key( (string) $input['mode'] ) : 'chat';
 
 		// Resolve provider/model from input or agent context.
 		$provider = $input['provider'] ?? '';
 		$model    = $input['model'] ?? '';
 
 		if ( empty( $provider ) || empty( $model ) ) {
-			$agent_config = PluginSettings::resolveModelForAgentMode( $agent_id > 0 ? $agent_id : null, 'chat' );
+			$agent_config = PluginSettings::resolveModelForAgentMode( $agent_id > 0 ? $agent_id : null, $mode );
 			if ( empty( $provider ) ) {
 				$provider = $agent_config['provider'];
 			}
@@ -204,6 +209,7 @@ class SendMessageAbility {
 				'selected_pipeline_id' => (int) ( $input['selected_pipeline_id'] ?? 0 ),
 				'max_turns'            => $input['max_turns'] ?? null,
 				'request_id'           => $input['request_id'] ?? null,
+				'mode'                 => $mode,
 				'agent_id'             => $agent_id,
 				'attachments'          => $input['attachments'] ?? array(),
 				'client_context'       => $input['client_context'] ?? array(),

--- a/inc/Abilities/Content/EditPostBlocksAbility.php
+++ b/inc/Abilities/Content/EditPostBlocksAbility.php
@@ -136,6 +136,15 @@ class EditPostBlocksAbility {
 				),
 				'edits'   => array(
 					'type'        => 'array',
+					'items'       => array(
+						'type'       => 'object',
+						'required'   => array( 'block_index', 'find', 'replace' ),
+						'properties' => array(
+							'block_index' => array( 'type' => 'integer' ),
+							'find'        => array( 'type' => 'string' ),
+							'replace'     => array( 'type' => 'string' ),
+						),
+					),
 					'required'    => true,
 					'description' => 'Array of { block_index, find, replace } operations',
 				),

--- a/inc/Abilities/Content/GetPostBlocksAbility.php
+++ b/inc/Abilities/Content/GetPostBlocksAbility.php
@@ -124,6 +124,7 @@ class GetPostBlocksAbility {
 				),
 				'block_types' => array(
 					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
 					'required'    => false,
 					'description' => 'Filter to specific block types (e.g. ["core/paragraph"])',
 				),

--- a/inc/Abilities/Content/ReplacePostBlocksAbility.php
+++ b/inc/Abilities/Content/ReplacePostBlocksAbility.php
@@ -131,6 +131,14 @@ class ReplacePostBlocksAbility {
 				),
 				'replacements' => array(
 					'type'        => 'array',
+					'items'       => array(
+						'type'       => 'object',
+						'required'   => array( 'block_index', 'new_content' ),
+						'properties' => array(
+							'block_index' => array( 'type' => 'integer' ),
+							'new_content' => array( 'type' => 'string' ),
+						),
+					),
 					'required'    => true,
 					'description' => 'Array of { block_index, new_content } operations',
 				),

--- a/inc/Api/Chat/Chat.php
+++ b/inc/Api/Chat/Chat.php
@@ -86,6 +86,12 @@ class Chat {
 						'description'       => __( 'Model identifier (optional, uses default if not provided)', 'data-machine' ),
 						'sanitize_callback' => 'sanitize_text_field',
 					),
+					'mode'                 => array(
+						'type'              => 'string',
+						'required'          => false,
+						'description'       => __( 'Execution mode for tool/context resolution. Defaults to chat.', 'data-machine' ),
+						'sanitize_callback' => 'sanitize_key',
+					),
 					'selected_pipeline_id' => array(
 						'type'              => 'integer',
 						'required'          => false,
@@ -472,6 +478,7 @@ class Chat {
 			'agent_id'       => (int) $request->get_param( 'agent_id' ),
 			'provider'       => (string) ( $request->get_param( 'provider' ) ?? '' ),
 			'model'          => (string) ( $request->get_param( 'model' ) ?? '' ),
+			'mode'           => (string) ( $request->get_param( 'mode' ) ?? '' ),
 			'attachments'    => $attachments,
 			'client_context' => $client_context,
 		);

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -67,13 +67,14 @@ class ChatOrchestrator {
 		$request_id           = $options['request_id'] ?? null;
 		$agent_id             = (int) ( $options['agent_id'] ?? 0 );
 		$agent_slug           = (string) ( $options['agent_slug'] ?? '' );
+		$mode                 = ! empty( $options['mode'] ) ? sanitize_key( (string) $options['mode'] ) : ToolPolicyResolver::MODE_CHAT;
 
 		$chat_db                     = ConversationStoreFactory::get();
 		$session_metadata            = array();
 		$acting_token_id             = \DataMachine\Abilities\PermissionHelper::get_acting_token_id();
 		$transcript_consent_decision = DataMachineAgentConsentPolicy::get()->can_store_transcript(
 			array(
-				'mode'        => 'chat',
+				'mode'        => $mode,
 				'interactive' => true,
 				'user_id'     => $user_id,
 				'agent_id'    => $agent_id,
@@ -102,9 +103,12 @@ class ChatOrchestrator {
 
 			$messages         = $session['messages'];
 			$session_metadata = $session['metadata'] ?? array();
+			if ( empty( $options['mode'] ) && ! empty( $session['mode'] ) ) {
+				$mode = sanitize_key( (string) $session['mode'] );
+			}
 		} else {
 			// Check for recent pending session to prevent duplicates from timeout retries.
-			$pending_session = $chat_db->get_recent_pending_session( WordPressWorkspaceScope::current(), $user_id, 600, 'chat', $acting_token_id );
+			$pending_session = $chat_db->get_recent_pending_session( WordPressWorkspaceScope::current(), $user_id, 600, $mode, $acting_token_id );
 
 			if ( $pending_session ) {
 				$session_id       = $pending_session['session_id'];
@@ -119,11 +123,11 @@ class ChatOrchestrator {
 						'session_id'          => $session_id,
 						'user_id'             => $user_id,
 						'original_created_at' => $pending_session['created_at'],
-						'mode'                => 'chat',
+						'mode'                => $mode,
 					)
 				);
 			} else {
-				$create_result = self::createSession( $user_id, '', $agent_id );
+				$create_result = self::createSession( $user_id, '', $agent_id, $mode );
 
 				if ( is_wp_error( $create_result ) ) {
 					return $create_result;
@@ -195,7 +199,7 @@ class ChatOrchestrator {
 				'single_turn'          => true,
 				'max_turns'            => $max_turns,
 				'selected_pipeline_id' => $selected_pipeline_id ? $selected_pipeline_id : null,
-				'mode'                 => ToolPolicyResolver::MODE_CHAT,
+				'mode'                 => $mode,
 				'user_id'              => $user_id,
 				'agent_id'             => $agent_id,
 				'agent_slug'           => $agent_slug,
@@ -371,7 +375,7 @@ class ChatOrchestrator {
 				'single_turn'          => true,
 				'max_turns'            => $max_turns,
 				'selected_pipeline_id' => $selected_pipeline_id,
-				'mode'                 => ToolPolicyResolver::MODE_CHAT,
+				'mode'                 => (string) ( $session['mode'] ?? ToolPolicyResolver::MODE_CHAT ),
 				'user_id'              => (int) ( $session['user_id'] ?? 0 ),
 				'agent_id'             => (int) ( $session['agent_id'] ?? 0 ),
 				'agent_slug'           => (string) ( $session['agent_slug'] ?? '' ),
@@ -583,7 +587,9 @@ class ChatOrchestrator {
 	 * @param string $source  Optional source identifier.
 	 * @return string|WP_Error Session ID on success, WP_Error on failure.
 	 */
-	private static function createSession( int $user_id, string $source = '', int $agent_id = 0 ): string|WP_Error {
+	private static function createSession( int $user_id, string $source = '', int $agent_id = 0, string $mode = ToolPolicyResolver::MODE_CHAT ): string|WP_Error {
+		$mode = '' !== $mode ? sanitize_key( $mode ) : ToolPolicyResolver::MODE_CHAT;
+
 		if ( $agent_id <= 0 ) {
 			$agent_id = function_exists( 'datamachine_resolve_or_create_agent_id' )
 				? datamachine_resolve_or_create_agent_id( $user_id )
@@ -597,7 +603,7 @@ class ChatOrchestrator {
 			$input      = array(
 				'user_id'    => $user_id,
 				'agent_slug' => $agent_slug,
-				'mode'       => 'chat',
+				'mode'       => $mode,
 			);
 
 			if ( $source ) {
@@ -642,7 +648,7 @@ class ChatOrchestrator {
 		}
 
 		$agent_slug = ConversationStoreFactory::resolve_agent_slug_for_transcript( $agent_id );
-		$session_id = $chat_db->create_session( WordPressWorkspaceScope::current(), $user_id, $agent_slug, $metadata, 'chat' );
+		$session_id = $chat_db->create_session( WordPressWorkspaceScope::current(), $user_id, $agent_slug, $metadata, $mode );
 
 		if ( empty( $session_id ) ) {
 			return new WP_Error(
@@ -688,8 +694,9 @@ class ChatOrchestrator {
 		$single_turn          = $options['single_turn'] ?? false;
 		$max_turns            = $options['max_turns'] ?? PluginSettings::get( 'max_turns', PluginSettings::DEFAULT_MAX_TURNS );
 		$selected_pipeline_id = $options['selected_pipeline_id'] ?? null;
-		$mode                 = $options['mode'] ?? ToolPolicyResolver::MODE_CHAT;
+		$mode                 = ! empty( $options['mode'] ) ? sanitize_key( (string) $options['mode'] ) : ToolPolicyResolver::MODE_CHAT;
 		$agent_id             = (int) ( $options['agent_id'] ?? 0 );
+		$agent_slug           = (string) ( $options['agent_slug'] ?? '' );
 
 		$chat_db = ConversationStoreFactory::get();
 
@@ -707,8 +714,11 @@ class ChatOrchestrator {
 			$resolver       = new ToolPolicyResolver();
 			$all_tools      = $resolver->resolve(
 				array(
-					'mode'     => ToolPolicyResolver::MODE_CHAT,
-					'agent_id' => $agent_id,
+					'mode'        => $mode,
+					'agent_id'    => $agent_id,
+					'agent_slug'  => $agent_slug,
+					'user_id'     => $user_id,
+					'interactive' => true,
 				)
 			);
 			$client_context = $options['client_context'] ?? array();

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -98,7 +98,9 @@ class ToolPolicyResolver {
 		$mode     = $args['mode'] ?? self::MODE_PIPELINE;
 		$agent_id = isset( $args['agent_id'] ) ? (int) $args['agent_id'] : 0;
 
-		if ( self::MODE_CHAT === $mode && ! $this->tool_access_policy->passesChatGate( $args ) ) {
+		$is_interactive = self::MODE_CHAT === $mode || ! empty( $args['interactive'] );
+
+		if ( $is_interactive && ! $this->tool_access_policy->passesChatGate( $args ) ) {
 			return array();
 		}
 
@@ -121,8 +123,8 @@ class ToolPolicyResolver {
 			unset( $policy_context['agent_id'], $policy_context['agent_slug'] );
 		}
 
-		// Only chat is request-user scoped. Pipeline/system run as product automation.
-		if ( self::MODE_CHAT === $mode ) {
+		// Interactive modes are request-user scoped. Pipeline/system run as product automation.
+		if ( $is_interactive ) {
 			$policy_context['tool_access_checker'] = array( $this->tool_access_policy, 'canAccessTool' );
 		}
 


### PR DESCRIPTION
## Summary
- Add missing `items` schemas for block-oriented chat tool array parameters so OpenAI-compatible providers accept the tool list.
- Let chat requests carry a custom execution mode through REST, `datamachine/send-message`, `agents/chat`, session creation, model resolution, and tool resolution.
- Treat custom interactive modes as request-user-scoped for tool access checks.

## Testing
- `php -l inc/Abilities/Content/GetPostBlocksAbility.php`
- `php -l inc/Abilities/Content/EditPostBlocksAbility.php`
- `php -l inc/Abilities/Content/ReplacePostBlocksAbility.php`
- `php -l inc/Abilities/Chat/AgentsChatHandler.php`
- `php -l inc/Api/Chat/ChatOrchestrator.php`
- `php -l inc/Api/Chat/Chat.php`
- `php -l inc/Abilities/Chat/SendMessageAbility.php`
- `php -l inc/Engine/AI/Tools/ToolPolicyResolver.php`
- Local schema check for edited content block chat tools requiring `items` on array parameters.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the malformed chat tool schema, drafted the schema and custom-mode routing changes, and ran local verification. Chris remains responsible for review and merge.