### PR TITLE
Fix custom chat mode model fallback

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -88,8 +88,14 @@ class AgentsChatHandler {
 		$client_context = is_array( $input['client_context'] ?? null ) ? $input['client_context'] : array();
 		$mode           = $this->resolveMode( $input, $client_context );
 		$agent_config   = PluginSettings::resolveModelForAgentMode( 0 === $agent_id ? null : $agent_id, $mode );
-		$provider       = $agent_config['provider'] ?? '';
-		$model          = $agent_config['model'] ?? '';
+		$provider       = $agent_config['provider'];
+		$model          = $agent_config['model'];
+
+		if ( '' === $model && 'chat' !== $mode ) {
+			$chat_config = PluginSettings::resolveModelForAgentMode( 0 === $agent_id ? null : $agent_id, 'chat' );
+			$provider    = '' === $provider ? $chat_config['provider'] : $provider;
+			$model       = $chat_config['model'];
+		}
 
 		if ( '' === $provider ) {
 			return new WP_Error( 'provider_required', __( 'AI provider is required. Set a default in Data Machine settings.', 'data-machine' ), array( 'status' => 400 ) );

--- a/inc/Abilities/Chat/SendMessageAbility.php
+++ b/inc/Abilities/Chat/SendMessageAbility.php
@@ -183,6 +183,14 @@ class SendMessageAbility {
 			}
 		}
 
+		if ( empty( $model ) && 'chat' !== $mode ) {
+			$chat_config = PluginSettings::resolveModelForAgentMode( $agent_id > 0 ? $agent_id : null, 'chat' );
+			if ( empty( $provider ) ) {
+				$provider = $chat_config['provider'];
+			}
+			$model = $chat_config['model'];
+		}
+
 		if ( empty( $provider ) ) {
 			return new \WP_Error(
 				'provider_required',


### PR DESCRIPTION
## Summary
- Let custom chat execution modes inherit the configured chat model when the custom mode has no dedicated model.
- Apply the fallback in both canonical `agents/chat` and `datamachine/send-message` chat entrypoints.

## Testing
- `php -l inc/Abilities/Chat/AgentsChatHandler.php`
- `php -l inc/Abilities/Chat/SendMessageAbility.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-custom-chat-mode-model-fallback --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the deployed custom-mode model fallback gap, drafted the Data Machine fix, and ran local verification. Chris remains responsible for review and merge.