### PR TITLE
Expose pipeline AI concurrency settings

### DIFF
--- a/docs/admin-interface/settings-configuration.md
+++ b/docs/admin-interface/settings-configuration.md
@@ -15,6 +15,7 @@ React admin page for configuring Data Machine’s global settings, agent default
 The settings UI is a simple tabbed container (`SettingsApp.jsx`) that persists the active tab in `localStorage` (`datamachine_settings_active_tab`).
 
 - **General**: Non-AI operational settings (cleanup, retention, pagination).
+- **General / Queue Performance**: Action Scheduler and batch fan-out throughput (`queue_tuning.concurrent_batches`, `batch_size`, `time_limit`, `chunk_size`, and `chunk_delay`). Defaults stay local-safe, while high ceilings support managed workers and large queues.
 - **General / Pipeline AI Concurrency**: Pipeline AI provider backpressure (`pipeline_ai_concurrency_limit`, optional provider limits, and retry delay) separate from Action Scheduler queue throughput.
 - **Agent**: Global agent runtime defaults (global system prompt, site context toggle, max turns, enabled global tools).
 - **API Keys**: Provider API keys (masked on read; only updated when the user enters a new value).

--- a/docs/admin-interface/settings-configuration.md
+++ b/docs/admin-interface/settings-configuration.md
@@ -15,6 +15,7 @@ React admin page for configuring Data Machine’s global settings, agent default
 The settings UI is a simple tabbed container (`SettingsApp.jsx`) that persists the active tab in `localStorage` (`datamachine_settings_active_tab`).
 
 - **General**: Non-AI operational settings (cleanup, retention, pagination).
+- **General / Pipeline AI Concurrency**: Pipeline AI provider backpressure (`pipeline_ai_concurrency_limit`, optional provider limits, and retry delay) separate from Action Scheduler queue throughput.
 - **Agent**: Global agent runtime defaults (global system prompt, site context toggle, max turns, enabled global tools).
 - **API Keys**: Provider API keys (masked on read; only updated when the user enters a new value).
 - **Handler Defaults**: Site-wide handler default settings that seed new flow step configs.

--- a/docs/api/endpoints/settings.md
+++ b/docs/api/endpoints/settings.md
@@ -90,6 +90,10 @@ curl -X POST https://example.com/wp-json/datamachine/v1/settings/tools/google_se
 ### Global Settings
 
 - `problem_flow_threshold` (integer): Number of consecutive failures or "no items" results before a flow is flagged as a problem flow. Default: `3`.
+- `pipeline_ai_concurrency_limit` (integer): Site-wide maximum concurrent pipeline AI provider calls. Default: `3`.
+- `pipeline_ai_provider_concurrency_limits` (object): Optional per-provider caps keyed by provider slug, for example `{ "openai": 10 }`. Provider caps apply in addition to the site-wide cap.
+- `pipeline_ai_throttle_delay` (integer): Seconds before a pipeline AI job retries when the AI concurrency lane is saturated. Default: `10`.
+- `queue_tuning` (object): Local queue producer/consumer tuning for Action Scheduler and batch fan-out. These settings control job scheduling/draining, not provider-call concurrency.
 
 **Example Request**:
 
@@ -98,7 +102,10 @@ curl -X POST https://example.com/wp-json/datamachine/v1/settings \
   -H "Content-Type: application/json" \
   -u username:application_password \
   -d '{
-    "problem_flow_threshold": 5
+    "problem_flow_threshold": 5,
+    "pipeline_ai_concurrency_limit": 10,
+    "pipeline_ai_provider_concurrency_limits": { "openai": 10 },
+    "pipeline_ai_throttle_delay": 5
   }'
 ```
 

--- a/docs/api/endpoints/settings.md
+++ b/docs/api/endpoints/settings.md
@@ -93,7 +93,12 @@ curl -X POST https://example.com/wp-json/datamachine/v1/settings/tools/google_se
 - `pipeline_ai_concurrency_limit` (integer): Site-wide maximum concurrent pipeline AI provider calls. Default: `3`.
 - `pipeline_ai_provider_concurrency_limits` (object): Optional per-provider caps keyed by provider slug, for example `{ "openai": 10 }`. Provider caps apply in addition to the site-wide cap.
 - `pipeline_ai_throttle_delay` (integer): Seconds before a pipeline AI job retries when the AI concurrency lane is saturated. Default: `10`.
-- `queue_tuning` (object): Local queue producer/consumer tuning for Action Scheduler and batch fan-out. These settings control job scheduling/draining, not provider-call concurrency.
+- `queue_tuning` (object): Local queue producer/consumer tuning for Action Scheduler and batch fan-out. Defaults are conservative for self-hosted installs; operator ceilings support managed/high-throughput runtimes. These settings control job scheduling/draining, not provider-call concurrency.
+  - `concurrent_batches` (integer): Parallel Action Scheduler batches. Default: `3`, maximum: `50`.
+  - `batch_size` (integer): Actions claimed per scheduler batch. Default: `25`, maximum: `500`.
+  - `time_limit` (integer): Seconds per scheduler batch. Default: `60`, maximum: `300`.
+  - `chunk_size` (integer): Child jobs created per fan-out scheduling cycle. Default: `10`, maximum: `500`.
+  - `chunk_delay` (integer): Seconds between fan-out chunks. Default: `30`, maximum: `300`.
 
 **Example Request**:
 
@@ -103,6 +108,13 @@ curl -X POST https://example.com/wp-json/datamachine/v1/settings \
   -u username:application_password \
   -d '{
     "problem_flow_threshold": 5,
+    "queue_tuning": {
+      "concurrent_batches": 20,
+      "batch_size": 300,
+      "time_limit": 300,
+      "chunk_size": 300,
+      "chunk_delay": 0
+    },
     "pipeline_ai_concurrency_limit": 10,
     "pipeline_ai_provider_concurrency_limits": { "openai": 10 },
     "pipeline_ai_throttle_delay": 5

--- a/docs/architecture/pipeline-execution-axes.md
+++ b/docs/architecture/pipeline-execution-axes.md
@@ -185,7 +185,7 @@ Note: `chunk_size` is the **producer-side** knob (how DM creates child jobs). Th
 | Visible to | Site operator (Settings → General → Queue Performance) | Site operator (Settings → General → Pipeline AI Concurrency) |
 | Purpose | Keep local queue work moving | Protect provider/API budgets and avoid transport saturation |
 
-Both layers matter. Raising Action Scheduler concurrency without raising `pipeline_ai_concurrency_limit` can still serialize AI-heavy pipelines at the provider-call lane. Raising AI concurrency without enough queue throughput leaves provider capacity idle. The default pipeline AI concurrency is deliberately moderate for self-hosted installs; high-volume sites should tune it alongside queue throughput and provider-specific limits such as `pipeline_ai_provider_concurrency_limits.openai`.
+Both layers matter. Raising Action Scheduler concurrency without raising `pipeline_ai_concurrency_limit` can still serialize AI-heavy pipelines at the provider-call lane. Raising AI concurrency without enough queue throughput leaves provider capacity idle. Defaults are deliberately moderate for self-hosted installs, while the settings allow higher operator ceilings for managed workers and large queues. High-volume sites should tune queue throughput alongside provider-specific limits such as `pipeline_ai_provider_concurrency_limits.openai`.
 
 ### Queueable fetch vs. queueable AI — same primitive, two consumption shapes
 

--- a/docs/architecture/pipeline-execution-axes.md
+++ b/docs/architecture/pipeline-execution-axes.md
@@ -174,6 +174,19 @@ A flow with `max_items = 50` and 50 packets produces 50 child jobs. They are *al
 
 Note: `chunk_size` is the **producer-side** knob (how DM creates child jobs). The complementary **consumer-side** knobs (`concurrent_batches`, `batch_size`, `time_limit`) live in the same `queue_tuning` settings group and control how Action Scheduler drains the resulting queue. Tune them together — bumping consumer-side concurrency without bumping producer-side chunking leaves the queue runner idle waiting for work.
 
+### Queue throughput vs. AI provider concurrency — different layers
+
+`queue_tuning` controls how fast WordPress and Action Scheduler move jobs through the local queue. Pipeline AI steps also pass through a provider backpressure lane before making external model calls:
+
+| | `queue_tuning.concurrent_batches` / `batch_size` | `pipeline_ai_concurrency_limit` |
+|---|---|---|
+| Where | Action Scheduler queue runner and Data Machine worker drain | `PipelineAIConcurrencyLimiter` before each pipeline AI request |
+| Cap on | Local scheduled actions claimed and executed | Concurrent pipeline AI provider calls |
+| Visible to | Site operator (Settings → General → Queue Performance) | Site operator (Settings → General → Pipeline AI Concurrency) |
+| Purpose | Keep local queue work moving | Protect provider/API budgets and avoid transport saturation |
+
+Both layers matter. Raising Action Scheduler concurrency without raising `pipeline_ai_concurrency_limit` can still serialize AI-heavy pipelines at the provider-call lane. Raising AI concurrency without enough queue throughput leaves provider capacity idle. The default pipeline AI concurrency is deliberately moderate for self-hosted installs; high-volume sites should tune it alongside queue throughput and provider-specific limits such as `pipeline_ai_provider_concurrency_limits.openai`.
+
 ### Queueable fetch vs. queueable AI — same primitive, two consumption shapes
 
 Both share `QueueableTrait` and the same queue-mode mechanics. They differ in which storage slot they consume and how that slot's payload is interpreted.

--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -118,6 +118,18 @@ class SettingsAbilities {
 							'type'        => 'number',
 							'description' => 'Full request timeout in seconds for wp-ai-client provider requests.',
 						),
+						'pipeline_ai_concurrency_limit'  => array(
+							'type'        => 'integer',
+							'description' => 'Site-wide maximum number of concurrent pipeline AI provider calls.',
+						),
+						'pipeline_ai_provider_concurrency_limits' => array(
+							'type'        => 'object',
+							'description' => 'Optional per-provider pipeline AI concurrency limits keyed by provider slug. Values above 0 add a provider-specific cap in addition to the site-wide cap.',
+						),
+						'pipeline_ai_throttle_delay'     => array(
+							'type'        => 'integer',
+							'description' => 'Seconds before a pipeline AI job retries after the AI concurrency limit is saturated.',
+						),
 						'disabled_tools'                 => array( 'type' => 'object' ),
 						'ai_provider_keys'               => array( 'type' => 'object' ),
 						'queue_tuning'                   => array(
@@ -363,6 +375,9 @@ class SettingsAbilities {
 				'max_turns'                      => $settings['max_turns'] ?? $defaults['max_turns'],
 				'wp_ai_client_connect_timeout'   => $settings['wp_ai_client_connect_timeout'] ?? $defaults['wp_ai_client_connect_timeout'],
 				'wp_ai_client_request_timeout'   => $settings['wp_ai_client_request_timeout'] ?? $defaults['wp_ai_client_request_timeout'],
+				'pipeline_ai_concurrency_limit'  => $settings['pipeline_ai_concurrency_limit'] ?? $defaults['pipeline_ai_concurrency_limit'],
+				'pipeline_ai_provider_concurrency_limits' => $settings['pipeline_ai_provider_concurrency_limits'] ?? $defaults['pipeline_ai_provider_concurrency_limits'],
+				'pipeline_ai_throttle_delay'     => $settings['pipeline_ai_throttle_delay'] ?? $defaults['pipeline_ai_throttle_delay'],
 				'disabled_tools'                 => $settings['disabled_tools'] ?? array(),
 				'ai_provider_keys'               => $masked_keys,
 				'queue_tuning'                   => wp_parse_args( $settings['queue_tuning'] ?? array(), $defaults['queue_tuning'] ),
@@ -481,6 +496,38 @@ class SettingsAbilities {
 				min( PluginSettings::MAX_WP_AI_CLIENT_REQUEST_TIMEOUT, (float) $input['wp_ai_client_request_timeout'] )
 			);
 			$handled_keys[]                               = 'wp_ai_client_request_timeout';
+		}
+
+		if ( isset( $input['pipeline_ai_concurrency_limit'] ) ) {
+			$limit                                         = absint( $input['pipeline_ai_concurrency_limit'] );
+			$all_settings['pipeline_ai_concurrency_limit'] = max( 1, min( PluginSettings::MAX_PIPELINE_AI_CONCURRENCY_LIMIT, $limit ) );
+			$handled_keys[]                                = 'pipeline_ai_concurrency_limit';
+		}
+
+		if ( isset( $input['pipeline_ai_provider_concurrency_limits'] ) && is_array( $input['pipeline_ai_provider_concurrency_limits'] ) ) {
+			$provider_limits = array();
+			foreach ( $input['pipeline_ai_provider_concurrency_limits'] as $provider => $limit ) {
+				$provider = sanitize_key( (string) $provider );
+				if ( '' === $provider ) {
+					continue;
+				}
+
+				$limit = absint( $limit );
+				if ( $limit <= 0 ) {
+					continue;
+				}
+
+				$provider_limits[ $provider ] = min( PluginSettings::MAX_PIPELINE_AI_CONCURRENCY_LIMIT, $limit );
+			}
+
+			$all_settings['pipeline_ai_provider_concurrency_limits'] = $provider_limits;
+			$handled_keys[]                                          = 'pipeline_ai_provider_concurrency_limits';
+		}
+
+		if ( isset( $input['pipeline_ai_throttle_delay'] ) ) {
+			$delay                                      = absint( $input['pipeline_ai_throttle_delay'] );
+			$all_settings['pipeline_ai_throttle_delay'] = max( 1, min( PluginSettings::MAX_PIPELINE_AI_THROTTLE_DELAY, $delay ) );
+			$handled_keys[]                             = 'pipeline_ai_throttle_delay';
 		}
 
 		if ( isset( $input['disabled_tools'] ) ) {

--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -551,27 +551,27 @@ class SettingsAbilities {
 
 			if ( isset( $input['queue_tuning']['concurrent_batches'] ) ) {
 				$batches                      = absint( $input['queue_tuning']['concurrent_batches'] );
-				$tuning['concurrent_batches'] = max( 1, min( 10, $batches ) ); // 1-10 range
+				$tuning['concurrent_batches'] = max( 1, min( PluginSettings::MAX_QUEUE_CONCURRENT_BATCHES, $batches ) );
 			}
 
 			if ( isset( $input['queue_tuning']['batch_size'] ) ) {
 				$size                 = absint( $input['queue_tuning']['batch_size'] );
-				$tuning['batch_size'] = max( 10, min( 200, $size ) ); // 10-200 range
+				$tuning['batch_size'] = max( 10, min( PluginSettings::MAX_QUEUE_BATCH_SIZE, $size ) );
 			}
 
 			if ( isset( $input['queue_tuning']['time_limit'] ) ) {
 				$limit                = absint( $input['queue_tuning']['time_limit'] );
-				$tuning['time_limit'] = max( 15, min( 300, $limit ) ); // 15-300 seconds range
+				$tuning['time_limit'] = max( 15, min( PluginSettings::MAX_QUEUE_TIME_LIMIT, $limit ) );
 			}
 
 			if ( isset( $input['queue_tuning']['chunk_size'] ) ) {
 				$chunk                = absint( $input['queue_tuning']['chunk_size'] );
-				$tuning['chunk_size'] = max( 1, min( 100, $chunk ) ); // 1-100 range
+				$tuning['chunk_size'] = max( 1, min( PluginSettings::MAX_QUEUE_CHUNK_SIZE, $chunk ) );
 			}
 
 			if ( isset( $input['queue_tuning']['chunk_delay'] ) ) {
 				$delay                 = absint( $input['queue_tuning']['chunk_delay'] );
-				$tuning['chunk_delay'] = max( 0, min( 300, $delay ) ); // 0-300 seconds range
+				$tuning['chunk_delay'] = max( 0, min( PluginSettings::MAX_QUEUE_CHUNK_DELAY, $delay ) );
 			}
 
 			$all_settings['queue_tuning'] = $tuning;

--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -359,28 +359,28 @@ class SettingsAbilities {
 		return array(
 			'success'          => true,
 			'settings'         => array(
-				'cleanup_job_data_on_failure'    => $settings['cleanup_job_data_on_failure'] ?? true,
-				'file_retention_days'            => $settings['file_retention_days'] ?? 7,
-				'chat_retention_days'            => $settings['chat_retention_days'] ?? 90,
-				'chat_ai_titles_enabled'         => $settings['chat_ai_titles_enabled'] ?? true,
-				'alt_text_auto_generate_enabled' => $settings['alt_text_auto_generate_enabled'] ?? true,
-				'problem_flow_threshold'         => $settings['problem_flow_threshold'] ?? 3,
-				'flows_per_page'                 => $settings['flows_per_page'] ?? 20,
-				'jobs_per_page'                  => $settings['jobs_per_page'] ?? 50,
-				'site_context_enabled'           => $settings['site_context_enabled'] ?? false,
-				'daily_memory_enabled'           => $settings['daily_memory_enabled'] ?? false,
-				'default_provider'               => $settings['default_provider'] ?? '',
-				'default_model'                  => $settings['default_model'] ?? '',
-				'mode_models'                    => $settings['mode_models'] ?? array(),
-				'max_turns'                      => $settings['max_turns'] ?? $defaults['max_turns'],
-				'wp_ai_client_connect_timeout'   => $settings['wp_ai_client_connect_timeout'] ?? $defaults['wp_ai_client_connect_timeout'],
-				'wp_ai_client_request_timeout'   => $settings['wp_ai_client_request_timeout'] ?? $defaults['wp_ai_client_request_timeout'],
-				'pipeline_ai_concurrency_limit'  => $settings['pipeline_ai_concurrency_limit'] ?? $defaults['pipeline_ai_concurrency_limit'],
+				'cleanup_job_data_on_failure'             => $settings['cleanup_job_data_on_failure'] ?? true,
+				'file_retention_days'                     => $settings['file_retention_days'] ?? 7,
+				'chat_retention_days'                     => $settings['chat_retention_days'] ?? 90,
+				'chat_ai_titles_enabled'                  => $settings['chat_ai_titles_enabled'] ?? true,
+				'alt_text_auto_generate_enabled'          => $settings['alt_text_auto_generate_enabled'] ?? true,
+				'problem_flow_threshold'                  => $settings['problem_flow_threshold'] ?? 3,
+				'flows_per_page'                          => $settings['flows_per_page'] ?? 20,
+				'jobs_per_page'                           => $settings['jobs_per_page'] ?? 50,
+				'site_context_enabled'                    => $settings['site_context_enabled'] ?? false,
+				'daily_memory_enabled'                    => $settings['daily_memory_enabled'] ?? false,
+				'default_provider'                        => $settings['default_provider'] ?? '',
+				'default_model'                           => $settings['default_model'] ?? '',
+				'mode_models'                             => $settings['mode_models'] ?? array(),
+				'max_turns'                               => $settings['max_turns'] ?? $defaults['max_turns'],
+				'wp_ai_client_connect_timeout'            => $settings['wp_ai_client_connect_timeout'] ?? $defaults['wp_ai_client_connect_timeout'],
+				'wp_ai_client_request_timeout'            => $settings['wp_ai_client_request_timeout'] ?? $defaults['wp_ai_client_request_timeout'],
+				'pipeline_ai_concurrency_limit'           => $settings['pipeline_ai_concurrency_limit'] ?? $defaults['pipeline_ai_concurrency_limit'],
 				'pipeline_ai_provider_concurrency_limits' => $settings['pipeline_ai_provider_concurrency_limits'] ?? $defaults['pipeline_ai_provider_concurrency_limits'],
-				'pipeline_ai_throttle_delay'     => $settings['pipeline_ai_throttle_delay'] ?? $defaults['pipeline_ai_throttle_delay'],
-				'disabled_tools'                 => $settings['disabled_tools'] ?? array(),
-				'ai_provider_keys'               => $masked_keys,
-				'queue_tuning'                   => wp_parse_args( $settings['queue_tuning'] ?? array(), $defaults['queue_tuning'] ),
+				'pipeline_ai_throttle_delay'              => $settings['pipeline_ai_throttle_delay'] ?? $defaults['pipeline_ai_throttle_delay'],
+				'disabled_tools'                          => $settings['disabled_tools'] ?? array(),
+				'ai_provider_keys'                        => $masked_keys,
+				'queue_tuning'                            => wp_parse_args( $settings['queue_tuning'] ?? array(), $defaults['queue_tuning'] ),
 			),
 			'defaults'         => $defaults,
 			'network_settings' => array(
@@ -499,7 +499,7 @@ class SettingsAbilities {
 		}
 
 		if ( isset( $input['pipeline_ai_concurrency_limit'] ) ) {
-			$limit                                         = absint( $input['pipeline_ai_concurrency_limit'] );
+			$limit = absint( $input['pipeline_ai_concurrency_limit'] );
 			$all_settings['pipeline_ai_concurrency_limit'] = max( 1, min( PluginSettings::MAX_PIPELINE_AI_CONCURRENCY_LIMIT, $limit ) );
 			$handled_keys[]                                = 'pipeline_ai_concurrency_limit';
 		}
@@ -521,7 +521,7 @@ class SettingsAbilities {
 			}
 
 			$all_settings['pipeline_ai_provider_concurrency_limits'] = $provider_limits;
-			$handled_keys[]                                          = 'pipeline_ai_provider_concurrency_limits';
+			$handled_keys[] = 'pipeline_ai_provider_concurrency_limits';
 		}
 
 		if ( isset( $input['pipeline_ai_throttle_delay'] ) ) {

--- a/inc/Core/Admin/Settings/assets/react/components/tabs/GeneralTab.jsx
+++ b/inc/Core/Admin/Settings/assets/react/components/tabs/GeneralTab.jsx
@@ -26,6 +26,9 @@ const EMPTY_FORM = {
 	chat_ai_titles_enabled: true,
 	wp_ai_client_connect_timeout: 15,
 	wp_ai_client_request_timeout: 300,
+	pipeline_ai_concurrency_limit: 3,
+	pipeline_ai_provider_concurrency_limits: {},
+	pipeline_ai_throttle_delay: 10,
 	flows_per_page: 20,
 	jobs_per_page: 50,
 	queue_tuning: {
@@ -57,6 +60,11 @@ const QUEUE_LIMITS = {
 	chunk_delay: { min: 0, max: 300, default: 30 },
 };
 
+const AI_CONCURRENCY_LIMITS = {
+	pipeline_ai_concurrency_limit: { min: 1, max: 50, default: 3 },
+	pipeline_ai_throttle_delay: { min: 1, max: 300, default: 10 },
+};
+
 const GeneralTab = () => {
 	const { data, isLoading, error } = useSettings();
 	const updateMutation = useUpdateSettings();
@@ -70,6 +78,12 @@ const GeneralTab = () => {
 	const transportDefaults = {
 		connectTimeout: data?.defaults?.wp_ai_client_connect_timeout ?? 15,
 		requestTimeout: data?.defaults?.wp_ai_client_request_timeout ?? 300,
+	};
+	const aiConcurrencyDefaults = {
+		limit: data?.defaults?.pipeline_ai_concurrency_limit ?? 3,
+		providerLimits:
+			data?.defaults?.pipeline_ai_provider_concurrency_limits ?? {},
+		throttleDelay: data?.defaults?.pipeline_ai_throttle_delay ?? 10,
 	};
 
 	const form = useFormState( {
@@ -97,6 +111,12 @@ const GeneralTab = () => {
 					data.settings.wp_ai_client_connect_timeout ?? transportDefaults.connectTimeout,
 				wp_ai_client_request_timeout:
 					data.settings.wp_ai_client_request_timeout ?? transportDefaults.requestTimeout,
+				pipeline_ai_concurrency_limit:
+					data.settings.pipeline_ai_concurrency_limit ?? aiConcurrencyDefaults.limit,
+				pipeline_ai_provider_concurrency_limits:
+					data.settings.pipeline_ai_provider_concurrency_limits ?? aiConcurrencyDefaults.providerLimits,
+				pipeline_ai_throttle_delay:
+					data.settings.pipeline_ai_throttle_delay ?? aiConcurrencyDefaults.throttleDelay,
 				flows_per_page:
 					data.settings.flows_per_page ?? EMPTY_FORM.flows_per_page,
 				jobs_per_page:
@@ -128,6 +148,33 @@ const GeneralTab = () => {
 				[ key ]: value,
 			},
 		} );
+		save.markChanged();
+	};
+
+	const updateAIConcurrency = ( key, rawValue ) => {
+		const { min, max, default: defaultVal } = AI_CONCURRENCY_LIMITS[ key ];
+		const fallback =
+			key === 'pipeline_ai_concurrency_limit'
+				? aiConcurrencyDefaults.limit
+				: aiConcurrencyDefaults.throttleDelay;
+		const value = clamp( rawValue, min, max, fallback ?? defaultVal );
+		form.updateField( key, value );
+		save.markChanged();
+	};
+
+	const updateProviderLimit = ( provider, rawValue ) => {
+		const value = clamp( rawValue, 0, 50, 0 );
+		const providerLimits = {
+			...( form.data.pipeline_ai_provider_concurrency_limits ?? {} ),
+		};
+
+		if ( value > 0 ) {
+			providerLimits[ provider ] = value;
+		} else {
+			delete providerLimits[ provider ];
+		}
+
+		form.updateField( 'pipeline_ai_provider_concurrency_limits', providerLimits );
 		save.markChanged();
 	};
 
@@ -392,6 +439,97 @@ const GeneralTab = () => {
 								<p className="description">
 									Number of jobs to display per page in the
 									Jobs admin.
+								</p>
+							</fieldset>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+
+			<h3>Pipeline AI Concurrency</h3>
+			<p className="description datamachine-section-description">
+				Limit concurrent provider calls from pipeline AI steps. These
+				limits are separate from Action Scheduler queue throughput: queue
+				settings decide how many actions run, while these settings decide
+				how many pipeline AI calls may be in flight at once.
+			</p>
+			<table className="form-table">
+				<tbody>
+					<tr>
+						<th scope="row">Site-wide AI calls</th>
+						<td>
+							<fieldset>
+								<input
+									type="number"
+									id="pipeline_ai_concurrency_limit"
+									value={ form.data.pipeline_ai_concurrency_limit }
+									onChange={ ( e ) =>
+										updateAIConcurrency(
+											'pipeline_ai_concurrency_limit',
+											e.target.value
+										)
+									}
+									min="1"
+									max="50"
+									className="small-text"
+								/>
+								<p className="description">
+									Maximum concurrent pipeline AI provider calls across
+									the site. (1-50, default:{ ' ' }
+									{ aiConcurrencyDefaults.limit })
+								</p>
+							</fieldset>
+						</td>
+					</tr>
+
+					<tr>
+						<th scope="row">OpenAI AI calls</th>
+						<td>
+							<fieldset>
+								<input
+									type="number"
+									id="pipeline_ai_provider_openai_limit"
+									value={
+										form.data.pipeline_ai_provider_concurrency_limits
+											?.openai ?? 0
+									}
+									onChange={ ( e ) =>
+										updateProviderLimit( 'openai', e.target.value )
+									}
+									min="0"
+									max="50"
+									className="small-text"
+								/>
+								<p className="description">
+									Optional OpenAI-specific cap. Use 0 to rely only on
+									the site-wide AI call limit.
+								</p>
+							</fieldset>
+						</td>
+					</tr>
+
+					<tr>
+						<th scope="row">AI throttle retry delay</th>
+						<td>
+							<fieldset>
+								<input
+									type="number"
+									id="pipeline_ai_throttle_delay"
+									value={ form.data.pipeline_ai_throttle_delay }
+									onChange={ ( e ) =>
+										updateAIConcurrency(
+											'pipeline_ai_throttle_delay',
+											e.target.value
+										)
+									}
+									min="1"
+									max="300"
+									className="small-text"
+								/>
+								<p className="description">
+									Seconds before a pipeline AI job retries when the
+									AI concurrency lane is full. (1-300, default:{ ' ' }
+									{ aiConcurrencyDefaults.throttleDelay })
 								</p>
 							</fieldset>
 						</td>

--- a/inc/Core/Admin/Settings/assets/react/components/tabs/GeneralTab.jsx
+++ b/inc/Core/Admin/Settings/assets/react/components/tabs/GeneralTab.jsx
@@ -53,10 +53,10 @@ const clamp = ( raw, min, max, defaultValue ) =>
 	Math.max( min, Math.min( max, parseInt( raw, 10 ) || defaultValue ) );
 
 const QUEUE_LIMITS = {
-	concurrent_batches: { min: 1, max: 10, default: 3 },
-	batch_size: { min: 10, max: 200, default: 25 },
+	concurrent_batches: { min: 1, max: 50, default: 3 },
+	batch_size: { min: 10, max: 500, default: 25 },
 	time_limit: { min: 15, max: 300, default: 60 },
-	chunk_size: { min: 1, max: 100, default: 10 },
+	chunk_size: { min: 1, max: 500, default: 10 },
 	chunk_delay: { min: 0, max: 300, default: 30 },
 };
 
@@ -565,13 +565,13 @@ const GeneralTab = () => {
 										)
 									}
 									min="1"
-									max="10"
+									max="50"
 									className="small-text"
 								/>
 								<p className="description">
 									Number of action batches that can run
 									simultaneously. Higher = faster processing,
-									but more server load. (1-10, default: { queueDefaults.concurrent_batches })
+									but more server load. (1-50, default: { queueDefaults.concurrent_batches })
 								</p>
 							</fieldset>
 						</td>
@@ -594,13 +594,13 @@ const GeneralTab = () => {
 										)
 									}
 									min="10"
-									max="200"
+									max="500"
 									className="small-text"
 								/>
 								<p className="description">
 									Number of actions claimed per batch. For
 									AI-heavy workloads, smaller batches with
-									more concurrency often works better. (10-200,
+									more concurrency often works better. (10-500,
 									default: { queueDefaults.batch_size })
 								</p>
 							</fieldset>
@@ -653,14 +653,14 @@ const GeneralTab = () => {
 										)
 									}
 									min="1"
-									max="100"
+									max="500"
 									className="small-text"
 								/>
 								<p className="description">
 									Number of child jobs Data Machine creates
 									per scheduling cycle when fanning out a
 									batch. Lower = gentler on the queue;
-									higher = faster fan-out. (1-100,
+									higher = faster fan-out. (1-500,
 									default: { queueDefaults.chunk_size })
 								</p>
 							</fieldset>

--- a/inc/Core/PluginSettings.php
+++ b/inc/Core/PluginSettings.php
@@ -25,6 +25,11 @@ class PluginSettings {
 	public const DEFAULT_PIPELINE_AI_THROTTLE_DELAY    = 10;
 	public const MAX_PIPELINE_AI_CONCURRENCY_LIMIT     = 50;
 	public const MAX_PIPELINE_AI_THROTTLE_DELAY        = 300;
+	public const MAX_QUEUE_CONCURRENT_BATCHES          = 50;
+	public const MAX_QUEUE_BATCH_SIZE                  = 500;
+	public const MAX_QUEUE_TIME_LIMIT                  = 300;
+	public const MAX_QUEUE_CHUNK_SIZE                  = 500;
+	public const MAX_QUEUE_CHUNK_DELAY                 = 300;
 	public const DEFAULT_WP_AI_CLIENT_CONNECT_TIMEOUT  = 15.0;
 	public const DEFAULT_WP_AI_CLIENT_REQUEST_TIMEOUT  = 300.0;
 	public const MAX_WP_AI_CLIENT_CONNECT_TIMEOUT      = 300.0;

--- a/inc/Core/PluginSettings.php
+++ b/inc/Core/PluginSettings.php
@@ -21,8 +21,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 class PluginSettings {
 
 	public const DEFAULT_MAX_TURNS                     = 25;
-	public const DEFAULT_PIPELINE_AI_CONCURRENCY_LIMIT = 1;
+	public const DEFAULT_PIPELINE_AI_CONCURRENCY_LIMIT = 3;
 	public const DEFAULT_PIPELINE_AI_THROTTLE_DELAY    = 10;
+	public const MAX_PIPELINE_AI_CONCURRENCY_LIMIT     = 50;
+	public const MAX_PIPELINE_AI_THROTTLE_DELAY        = 300;
 	public const DEFAULT_WP_AI_CLIENT_CONNECT_TIMEOUT  = 15.0;
 	public const DEFAULT_WP_AI_CLIENT_REQUEST_TIMEOUT  = 300.0;
 	public const MAX_WP_AI_CLIENT_CONNECT_TIMEOUT      = 300.0;

--- a/tests/Unit/Abilities/SettingsAbilitiesTest.php
+++ b/tests/Unit/Abilities/SettingsAbilitiesTest.php
@@ -156,6 +156,62 @@ class SettingsAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 300, $updated_settings['pipeline_ai_throttle_delay'] );
 	}
 
+	public function test_update_settings_accepts_high_throughput_queue_tuning(): void {
+		$result = $this->settings_abilities->executeUpdateSettings(
+			array(
+				'queue_tuning' => array(
+					'concurrent_batches' => 50,
+					'batch_size'         => 500,
+					'time_limit'         => 300,
+					'chunk_size'         => 500,
+					'chunk_delay'        => 0,
+				),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+
+		$updated_settings = get_option( 'datamachine_settings', array() );
+		$this->assertSame(
+			array(
+				'concurrent_batches' => 50,
+				'batch_size'         => 500,
+				'time_limit'         => 300,
+				'chunk_size'         => 500,
+				'chunk_delay'        => 0,
+			),
+			$updated_settings['queue_tuning']
+		);
+	}
+
+	public function test_update_settings_clamps_queue_tuning_to_operator_ceiling(): void {
+		$result = $this->settings_abilities->executeUpdateSettings(
+			array(
+				'queue_tuning' => array(
+					'concurrent_batches' => 999,
+					'batch_size'         => 999,
+					'time_limit'         => 999,
+					'chunk_size'         => 999,
+					'chunk_delay'        => 999,
+				),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+
+		$updated_settings = get_option( 'datamachine_settings', array() );
+		$this->assertSame(
+			array(
+				'concurrent_batches' => 50,
+				'batch_size'         => 500,
+				'time_limit'         => 300,
+				'chunk_size'         => 500,
+				'chunk_delay'        => 300,
+			),
+			$updated_settings['queue_tuning']
+		);
+	}
+
 	public function test_update_settings_clamps_wp_ai_client_timeouts(): void {
 		$result = $this->settings_abilities->executeUpdateSettings(
 			array(

--- a/tests/Unit/Abilities/SettingsAbilitiesTest.php
+++ b/tests/Unit/Abilities/SettingsAbilitiesTest.php
@@ -101,8 +101,59 @@ class SettingsAbilitiesTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'max_turns', $settings );
 		$this->assertArrayHasKey( 'wp_ai_client_connect_timeout', $settings );
 		$this->assertArrayHasKey( 'wp_ai_client_request_timeout', $settings );
+		$this->assertArrayHasKey( 'pipeline_ai_concurrency_limit', $settings );
+		$this->assertArrayHasKey( 'pipeline_ai_provider_concurrency_limits', $settings );
+		$this->assertArrayHasKey( 'pipeline_ai_throttle_delay', $settings );
 		$this->assertArrayHasKey( 'disabled_tools', $settings );
 		$this->assertArrayHasKey( 'ai_provider_keys', $settings );
+	}
+
+	public function test_get_settings_exposes_pipeline_ai_concurrency_defaults(): void {
+		$result = $this->settings_abilities->executeGetSettings( array() );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 3, $result['settings']['pipeline_ai_concurrency_limit'] );
+		$this->assertSame( array(), $result['settings']['pipeline_ai_provider_concurrency_limits'] );
+		$this->assertSame( 10, $result['settings']['pipeline_ai_throttle_delay'] );
+	}
+
+	public function test_update_settings_updates_pipeline_ai_concurrency_settings(): void {
+		$result = $this->settings_abilities->executeUpdateSettings(
+			array(
+				'pipeline_ai_concurrency_limit'           => 12,
+				'pipeline_ai_provider_concurrency_limits' => array(
+					'openai' => 10,
+					''       => 20,
+					'bad'    => 0,
+				),
+				'pipeline_ai_throttle_delay'              => 5,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertArrayNotHasKey( 'unhandled_keys', $result );
+
+		$updated_settings = get_option( 'datamachine_settings', array() );
+		$this->assertSame( 12, $updated_settings['pipeline_ai_concurrency_limit'] );
+		$this->assertSame( array( 'openai' => 10 ), $updated_settings['pipeline_ai_provider_concurrency_limits'] );
+		$this->assertSame( 5, $updated_settings['pipeline_ai_throttle_delay'] );
+	}
+
+	public function test_update_settings_clamps_pipeline_ai_concurrency_settings(): void {
+		$result = $this->settings_abilities->executeUpdateSettings(
+			array(
+				'pipeline_ai_concurrency_limit'           => 999,
+				'pipeline_ai_provider_concurrency_limits' => array( 'openai' => 999 ),
+				'pipeline_ai_throttle_delay'              => 999,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+
+		$updated_settings = get_option( 'datamachine_settings', array() );
+		$this->assertSame( 50, $updated_settings['pipeline_ai_concurrency_limit'] );
+		$this->assertSame( array( 'openai' => 50 ), $updated_settings['pipeline_ai_provider_concurrency_limits'] );
+		$this->assertSame( 300, $updated_settings['pipeline_ai_throttle_delay'] );
 	}
 
 	public function test_update_settings_clamps_wp_ai_client_timeouts(): void {


### PR DESCRIPTION
## Summary
- Raise the default pipeline AI concurrency limit from 1 to 3 and add explicit max bounds for concurrency and retry delay.
- Expose pipeline AI concurrency, provider-specific caps, and throttle delay through settings abilities and the General settings UI.
- Raise queue tuning operator ceilings while keeping defaults conservative: concurrent batches up to 50, batch size up to 500, and fan-out chunk size up to 500.
- Document the distinction between queue throughput and AI provider concurrency, with focused settings tests for defaults, updates, sanitization, and clamping.

## Root cause
High-volume AI pipelines could look queue-scaled while still serializing at the hidden `pipeline_ai_concurrency_limit` lane, because the setting defaulted to 1 and was not visible in the admin/API settings contract.

Queue throughput had a separate operator-ceiling issue: `queue_tuning.concurrent_batches` was hard-capped at 10 and fan-out `chunk_size` at 100. Those caps are reasonable local guardrails but too low as hard ceilings for managed/high-throughput runtimes with supervised workers.

## Testing
- `homeboy test --path "/Users/chubes/Developer/data-machine@fix-pipeline-ai-concurrency-settings" --extension wordpress -- --filter=SettingsAbilitiesTest`
- `npm run build`
- `git diff --check`
- `php -l inc/Core/PluginSettings.php`
- `php -l inc/Abilities/SettingsAbilities.php`
- `php -l tests/Unit/Abilities/SettingsAbilitiesTest.php`
- `vendor/bin/phpcs inc/Core/PluginSettings.php inc/Abilities/SettingsAbilities.php tests/Unit/Abilities/SettingsAbilitiesTest.php`

## Notes
- Repo-wide `homeboy lint` is still blocked by pre-existing PHPStan debt, including `inc/Engine/AI/Tools/Global/GoogleAnalytics.php::phpstan.parameter.notFound`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the concurrency bottleneck, drafting the settings/admin/docs/test changes, and running local verification; Chris remains responsible for review and merge.