### PR TITLE
Complete agent chat after tool calls

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -204,6 +204,10 @@ class AgentsChatHandler {
 				continue;
 			}
 
+			if ( in_array( (string) ( $message['type'] ?? '' ), array( 'tool_call', 'tool_result' ), true ) ) {
+				continue;
+			}
+
 			if ( ! is_string( $message['content'] ) ) {
 				continue;
 			}

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -196,7 +196,7 @@ class ChatOrchestrator {
 			$provider,
 			$model,
 			array(
-				'single_turn'          => true,
+				'single_turn'          => false,
 				'max_turns'            => $max_turns,
 				'selected_pipeline_id' => $selected_pipeline_id ? $selected_pipeline_id : null,
 				'mode'                 => $mode,
@@ -372,7 +372,7 @@ class ChatOrchestrator {
 			$provider,
 			$model,
 			array(
-				'single_turn'          => true,
+				'single_turn'          => false,
 				'max_turns'            => $max_turns,
 				'selected_pipeline_id' => $selected_pipeline_id,
 				'mode'                 => (string) ( $session['mode'] ?? ToolPolicyResolver::MODE_CHAT ),

--- a/tests/agents-chat-tool-continuation-smoke.php
+++ b/tests/agents-chat-tool-continuation-smoke.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Smoke tests for Agents API chat tool continuation behavior.
+ *
+ * @package DataMachine\Tests
+ */
+
+function datamachine_agents_chat_tool_continuation_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( ...$args ) {
+		return true;
+	}
+}
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$assertions = 0;
+
+$chat_orchestrator_source = file_get_contents( __DIR__ . '/../inc/Api/Chat/ChatOrchestrator.php' );
+datamachine_agents_chat_tool_continuation_assert(
+	is_string( $chat_orchestrator_source ),
+	'ChatOrchestrator source should be readable.'
+);
+++ $assertions;
+
+datamachine_agents_chat_tool_continuation_assert(
+	! str_contains( $chat_orchestrator_source, "'single_turn'          => true" ),
+	'Interactive chat entrypoints should not force single-turn execution.'
+);
+++ $assertions;
+
+require_once __DIR__ . '/../inc/Abilities/Chat/AgentsChatHandler.php';
+
+$handler = new DataMachine\Abilities\Chat\AgentsChatHandler();
+$method  = new ReflectionMethod( $handler, 'toCanonicalMessages' );
+
+$messages = $method->invoke(
+	$handler,
+	array(
+		array(
+			'role'    => 'user',
+			'type'    => 'text',
+			'content' => 'What do you know?',
+		),
+		array(
+			'role'    => 'assistant',
+			'type'    => 'tool_call',
+			'content' => 'AI ACTION (Turn 1): Executing Wiki Brain List.',
+		),
+		array(
+			'role'    => 'user',
+			'type'    => 'tool_result',
+			'content' => 'TOOL RESPONSE (Turn 1): SUCCESS.',
+		),
+		array(
+			'role'    => 'assistant',
+			'type'    => 'text',
+			'content' => 'Here is the answer.',
+		),
+	)
+);
+
+datamachine_agents_chat_tool_continuation_assert(
+	array(
+		array(
+			'role'    => 'user',
+			'content' => 'What do you know?',
+		),
+		array(
+			'role'    => 'assistant',
+			'content' => 'Here is the answer.',
+		),
+	) === $messages,
+	'Canonical Agents API chat output should omit internal tool call/result messages.'
+);
+++ $assertions;
+
+echo 'Agents chat tool continuation smoke passed (' . $assertions . " assertions).\n";


### PR DESCRIPTION
## Summary
- Let Data Machine chat requests continue through tool execution until a final assistant response or turn budget instead of stopping after the first model turn.
- Filter typed tool call/result transcript messages out of canonical `agents/chat` message output so clients only receive visible chat messages.
- Add a focused smoke test for the chat continuation and transcript projection regression.

## Testing
- `php -l inc/Api/Chat/ChatOrchestrator.php && php -l inc/Abilities/Chat/AgentsChatHandler.php && php -l tests/agents-chat-tool-continuation-smoke.php`
- `php tests/agents-chat-tool-continuation-smoke.php`
- `homeboy test --path . --extension wordpress` (1256 tests, 1253 passed, 3 skipped)
- `homeboy lint --path . --extension wordpress` (fails on pre-existing unrelated JS lint/dependency findings outside this change)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the chat/tool continuation path, drafted the patch and smoke test, and ran local verification. Chris remains responsible for review and acceptance.