### PR TITLE
Expose AI runtime provenance

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -475,7 +475,11 @@ class AIStep extends Step {
 			// event_id, event_url, post_id written via datamachine_merge_engine_data).
 			$usage = $loop_result['usage'] ?? array();
 			if ( ! empty( $usage ) && $this->job_id > 0 && ( $usage['total_tokens'] ?? 0 ) > 0 ) {
-				datamachine_merge_engine_data( $this->job_id, array( 'token_usage' => $usage ) );
+				$usage_engine_data = array( 'token_usage' => $usage );
+				if ( isset( $loop_result['runtime_provenance'] ) && is_array( $loop_result['runtime_provenance'] ) ) {
+					$usage_engine_data['runtime_provenance'] = $loop_result['runtime_provenance'];
+				}
+				datamachine_merge_engine_data( $this->job_id, $usage_engine_data );
 			}
 
 			// Store the transcript session ID when the AI loop persisted one.
@@ -492,6 +496,9 @@ class AIStep extends Step {
 			if ( $this->job_id > 0 ) {
 				$artifact_engine_data                           = datamachine_get_engine_data( $this->job_id );
 				$artifact_engine_data['tool_execution_summary'] = self::summarizeToolExecutions( $loop_result );
+				if ( isset( $loop_result['runtime_provenance'] ) && is_array( $loop_result['runtime_provenance'] ) ) {
+					$artifact_engine_data['runtime_provenance'] = $loop_result['runtime_provenance'];
+				}
 
 				foreach ( array( 'completion_assertions_required', 'completion_assertions_missing', 'completion_assertions_satisfied' ) as $assertion_key ) {
 					if ( isset( $loop_result[ $assertion_key ] ) && array() !== $loop_result[ $assertion_key ] ) {

--- a/inc/Engine/AI/RequestMetadata.php
+++ b/inc/Engine/AI/RequestMetadata.php
@@ -121,7 +121,7 @@ class RequestMetadata {
 					'model'                => $metadata['model'] ?? null,
 					'mode'                 => $metadata['mode'] ?? null,
 					'request_json_bytes'   => $metadata['request_json_bytes'] ?? null,
-					'messages_json_bytes' => $metadata['messages_json_bytes'] ?? null,
+					'messages_json_bytes'  => $metadata['messages_json_bytes'] ?? null,
 					'tools_json_bytes'     => $metadata['tools_json_bytes'] ?? null,
 					'message_count'        => $metadata['message_count'] ?? null,
 					'tool_count'           => $metadata['tools']['count'] ?? null,

--- a/inc/Engine/AI/RequestMetadata.php
+++ b/inc/Engine/AI/RequestMetadata.php
@@ -33,11 +33,17 @@ class RequestMetadata {
 		$messages_json = wp_json_encode( $request['messages'] ?? array(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
 		$tools_json    = wp_json_encode( $structured_tools, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
 		$request_json  = wp_json_encode( $request, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+		$model_config  = self::model_config( $request );
 
 		return array(
 			'provider'            => $provider,
 			'model'               => $model,
 			'mode'                => $mode,
+			'prompt_sha256'       => hash( 'sha256', (string) $messages_json ),
+			'input_sha256'        => hash( 'sha256', (string) $request_json ),
+			'tool_policy_sha256'  => hash( 'sha256', (string) $tools_json ),
+			'model_config'        => $model_config,
+			'model_config_source' => ! empty( $model_config ) ? 'provider_request' : 'default',
 			'message_count'       => count( $request['messages'] ?? array() ),
 			'request_json_bytes'  => strlen( (string) $request_json ),
 			'messages_json_bytes' => strlen( (string) $messages_json ),
@@ -205,5 +211,23 @@ class RequestMetadata {
 
 		usort( $files, fn( $a, $b ) => ( $b['bytes'] ?? 0 ) <=> ( $a['bytes'] ?? 0 ) );
 		return $files;
+	}
+
+	/**
+	 * Extract the effective model config Data Machine supplied to wp-ai-client.
+	 *
+	 * @param array $request Provider request array.
+	 * @return array<string,mixed>
+	 */
+	private static function model_config( array $request ): array {
+		$config = array();
+		if ( isset( $request['temperature'] ) && is_numeric( $request['temperature'] ) ) {
+			$config['temperature'] = (float) $request['temperature'];
+		}
+		if ( isset( $request['max_tokens'] ) && is_numeric( $request['max_tokens'] ) ) {
+			$config['max_tokens'] = (int) $request['max_tokens'];
+		}
+
+		return $config;
 	}
 }

--- a/inc/Engine/AI/RuntimeProvenance.php
+++ b/inc/Engine/AI/RuntimeProvenance.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Stable runtime provenance for AI provider calls.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+class RuntimeProvenance {
+
+	/**
+	 * Build a redacted provenance object for benchmark/eval replay artifacts.
+	 *
+	 * @param array  $result  Normalized conversation result.
+	 * @param array  $payload Data Machine loop payload.
+	 * @param string $provider Provider identifier.
+	 * @param string $model Model identifier.
+	 * @param string $mode Execution mode.
+	 * @return array<string,mixed>
+	 */
+	public static function fromConversationResult( array $result, array $payload, string $provider, string $model, string $mode ): array {
+		$request_metadata = is_array( $result['request_metadata'] ?? null ) ? $result['request_metadata'] : array();
+		$usage            = is_array( $result['usage'] ?? null ) ? $result['usage'] : array();
+		$error_message    = isset( $result['error'] ) ? (string) $result['error'] : '';
+
+		$provenance = array(
+			'schema_version' => 1,
+			'provider'       => array_filter(
+				array(
+					'id'        => (string) ( $request_metadata['provider'] ?? $provider ),
+					'source'    => 'wp-ai-client',
+					'transport' => is_array( $request_metadata['transport'] ?? null ) ? 'wp-ai-client-http' : 'wp-ai-client',
+				),
+				static fn( $value ) => null !== $value && '' !== $value
+			),
+			'model'          => array_filter(
+				array(
+					'id'            => (string) ( $request_metadata['model'] ?? $model ),
+					'config'        => is_array( $request_metadata['model_config'] ?? null ) ? $request_metadata['model_config'] : array(),
+					'config_source' => (string) ( $request_metadata['model_config_source'] ?? 'default' ),
+				),
+				static fn( $value ) => array() !== $value && null !== $value && '' !== $value
+			),
+			'mode'           => $mode,
+			'identifiers'    => self::identifiers( $payload ),
+			'input'          => array_filter(
+				array(
+					'prompt_sha256' => $request_metadata['prompt_sha256'] ?? null,
+					'input_sha256'  => $request_metadata['input_sha256'] ?? null,
+					'message_count' => $request_metadata['message_count'] ?? null,
+				),
+				static fn( $value ) => null !== $value && '' !== $value
+			),
+			'tools'          => array_filter(
+				array(
+					'policy_sha256' => $request_metadata['tool_policy_sha256'] ?? null,
+					'count'         => $request_metadata['tools']['count'] ?? null,
+					'policy_inputs' => self::tool_policy_inputs( $payload ),
+					'names'         => self::tool_names( $result ),
+				),
+				static fn( $value ) => array() !== $value && null !== $value && '' !== $value
+			),
+			'usage'          => $usage,
+			'attempts'       => array(
+				'retry_count'    => 0,
+				'fallback_count' => 0,
+				'retries'        => array(),
+				'fallbacks'      => array(),
+			),
+			'status'         => array_filter(
+				array(
+					'status'        => (string) ( $result['status'] ?? ( isset( $result['error'] ) ? 'error' : 'completed' ) ),
+					'completed'     => (bool) ( $result['completed'] ?? false ),
+					'finish_reason' => self::finish_reason( $result ),
+					'cancelled'     => 'cancelled' === ( $result['status'] ?? '' ),
+					'timed_out'     => 'timeout' === ( $result['status'] ?? '' ),
+				),
+				static fn( $value ) => null !== $value && '' !== $value
+			),
+			'provider_errors' => '' !== $error_message ? array(
+				array_filter(
+					array(
+						'code'    => isset( $result['error_code'] ) ? (string) $result['error_code'] : null,
+						'message' => $error_message,
+					),
+					static fn( $value ) => null !== $value && '' !== $value
+				),
+			) : array(),
+			'request'        => self::request_shape( $request_metadata ),
+		);
+
+		if ( isset( $result['tool_audit_events'] ) && is_array( $result['tool_audit_events'] ) ) {
+			$provenance['tool_audit_events'] = $result['tool_audit_events'];
+		}
+
+		return $provenance;
+	}
+
+	/** @return array<string,mixed> */
+	private static function identifiers( array $payload ): array {
+		$keys        = array( 'agent_id', 'agent_slug', 'agent_mode', 'pipeline_id', 'flow_id', 'flow_step_id', 'step_id', 'job_id', 'session_id', 'transcript_session_id' );
+		$identifiers = array();
+		foreach ( $keys as $key ) {
+			if ( isset( $payload[ $key ] ) && '' !== $payload[ $key ] ) {
+				$identifiers[ $key ] = $payload[ $key ];
+			}
+		}
+
+		return $identifiers;
+	}
+
+	/** @return array<int,string> */
+	private static function tool_names( array $result ): array {
+		$names = array();
+		foreach ( $result['tool_execution_results'] ?? array() as $tool_result ) {
+			if ( is_array( $tool_result ) && isset( $tool_result['tool_name'] ) && is_string( $tool_result['tool_name'] ) ) {
+				$names[] = $tool_result['tool_name'];
+			}
+		}
+
+		return array_values( array_unique( $names ) );
+	}
+
+	/** @return array<string,mixed> */
+	private static function tool_policy_inputs( array $payload ): array {
+		$inputs = array(
+			'mode'                    => $payload['agent_mode'] ?? null,
+			'agent_id'                => $payload['agent_id'] ?? null,
+			'agent_slug'              => $payload['agent_slug'] ?? null,
+			'pipeline_step_id'        => $payload['step_id'] ?? null,
+			'configured_handler_slugs' => is_array( $payload['configured_handler_slugs'] ?? null ) ? array_values( $payload['configured_handler_slugs'] ) : null,
+			'tool_runtime_rules'      => is_array( $payload['tool_runtime_rules'] ?? null ) ? $payload['tool_runtime_rules'] : null,
+		);
+
+		return array_filter(
+			$inputs,
+			static fn( $value ) => null !== $value && '' !== $value && array() !== $value
+		);
+	}
+
+	private static function finish_reason( array $result ): ?string {
+		if ( isset( $result['finish_reason'] ) && is_string( $result['finish_reason'] ) ) {
+			return $result['finish_reason'];
+		}
+		$request_metadata = is_array( $result['request_metadata'] ?? null ) ? $result['request_metadata'] : array();
+		if ( isset( $request_metadata['response']['finish_reason'] ) && is_string( $request_metadata['response']['finish_reason'] ) ) {
+			return $request_metadata['response']['finish_reason'];
+		}
+		if ( ! empty( $result['max_turns_reached'] ) || 'budget_exceeded' === ( $result['status'] ?? '' ) ) {
+			return 'max_turns';
+		}
+		if ( isset( $result['error'] ) ) {
+			return 'provider_error';
+		}
+		return ! empty( $result['completed'] ) ? 'stop' : null;
+	}
+
+	/** @return array<string,mixed> */
+	private static function request_shape( array $request_metadata ): array {
+		return array_filter(
+			array(
+				'request_json_bytes'  => $request_metadata['request_json_bytes'] ?? null,
+				'messages_json_bytes' => $request_metadata['messages_json_bytes'] ?? null,
+				'tools_json_bytes'    => $request_metadata['tools_json_bytes'] ?? null,
+				'transport'           => is_array( $request_metadata['transport'] ?? null ) ? $request_metadata['transport'] : null,
+			),
+			static fn( $value ) => null !== $value && array() !== $value
+		);
+	}
+}

--- a/inc/Engine/AI/RuntimeProvenance.php
+++ b/inc/Engine/AI/RuntimeProvenance.php
@@ -27,8 +27,8 @@ class RuntimeProvenance {
 		$error_message    = isset( $result['error'] ) ? (string) $result['error'] : '';
 
 		$provenance = array(
-			'schema_version' => 1,
-			'provider'       => array_filter(
+			'schema_version'  => 1,
+			'provider'        => array_filter(
 				array(
 					'id'        => (string) ( $request_metadata['provider'] ?? $provider ),
 					'source'    => 'wp-ai-client',
@@ -36,7 +36,7 @@ class RuntimeProvenance {
 				),
 				static fn( $value ) => null !== $value && '' !== $value
 			),
-			'model'          => array_filter(
+			'model'           => array_filter(
 				array(
 					'id'            => (string) ( $request_metadata['model'] ?? $model ),
 					'config'        => is_array( $request_metadata['model_config'] ?? null ) ? $request_metadata['model_config'] : array(),
@@ -44,9 +44,9 @@ class RuntimeProvenance {
 				),
 				static fn( $value ) => array() !== $value && null !== $value && '' !== $value
 			),
-			'mode'           => $mode,
-			'identifiers'    => self::identifiers( $payload ),
-			'input'          => array_filter(
+			'mode'            => $mode,
+			'identifiers'     => self::identifiers( $payload ),
+			'input'           => array_filter(
 				array(
 					'prompt_sha256' => $request_metadata['prompt_sha256'] ?? null,
 					'input_sha256'  => $request_metadata['input_sha256'] ?? null,
@@ -54,7 +54,7 @@ class RuntimeProvenance {
 				),
 				static fn( $value ) => null !== $value && '' !== $value
 			),
-			'tools'          => array_filter(
+			'tools'           => array_filter(
 				array(
 					'policy_sha256' => $request_metadata['tool_policy_sha256'] ?? null,
 					'count'         => $request_metadata['tools']['count'] ?? null,
@@ -63,14 +63,14 @@ class RuntimeProvenance {
 				),
 				static fn( $value ) => array() !== $value && null !== $value && '' !== $value
 			),
-			'usage'          => $usage,
-			'attempts'       => array(
+			'usage'           => $usage,
+			'attempts'        => array(
 				'retry_count'    => 0,
 				'fallback_count' => 0,
 				'retries'        => array(),
 				'fallbacks'      => array(),
 			),
-			'status'         => array_filter(
+			'status'          => array_filter(
 				array(
 					'status'        => (string) ( $result['status'] ?? ( isset( $result['error'] ) ? 'error' : 'completed' ) ),
 					'completed'     => (bool) ( $result['completed'] ?? false ),
@@ -89,7 +89,7 @@ class RuntimeProvenance {
 					static fn( $value ) => null !== $value && '' !== $value
 				),
 			) : array(),
-			'request'        => self::request_shape( $request_metadata ),
+			'request'         => self::request_shape( $request_metadata ),
 		);
 
 		if ( isset( $result['tool_audit_events'] ) && is_array( $result['tool_audit_events'] ) ) {
@@ -127,12 +127,12 @@ class RuntimeProvenance {
 	/** @return array<string,mixed> */
 	private static function tool_policy_inputs( array $payload ): array {
 		$inputs = array(
-			'mode'                    => $payload['agent_mode'] ?? null,
-			'agent_id'                => $payload['agent_id'] ?? null,
-			'agent_slug'              => $payload['agent_slug'] ?? null,
-			'pipeline_step_id'        => $payload['step_id'] ?? null,
+			'mode'                     => $payload['agent_mode'] ?? null,
+			'agent_id'                 => $payload['agent_id'] ?? null,
+			'agent_slug'               => $payload['agent_slug'] ?? null,
+			'pipeline_step_id'         => $payload['step_id'] ?? null,
 			'configured_handler_slugs' => is_array( $payload['configured_handler_slugs'] ?? null ) ? array_values( $payload['configured_handler_slugs'] ) : null,
-			'tool_runtime_rules'      => is_array( $payload['tool_runtime_rules'] ?? null ) ? $payload['tool_runtime_rules'] : null,
+			'tool_runtime_rules'       => is_array( $payload['tool_runtime_rules'] ?? null ) ? $payload['tool_runtime_rules'] : null,
 		);
 
 		return array_filter(

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -142,13 +142,13 @@ function datamachine_run_conversation(
 			'status'                          => 'error',
 			'runtime_provenance'              => RuntimeProvenance::fromConversationResult(
 				array(
-					'messages'          => $messages,
-					'completed'         => false,
-					'error'             => $error_message,
-					'error_code'        => 'completion_required_tool_unavailable',
-					'usage'             => array(),
-					'request_metadata'  => array(),
-					'status'            => 'error',
+					'messages'         => $messages,
+					'completed'        => false,
+					'error'            => $error_message,
+					'error_code'       => 'completion_required_tool_unavailable',
+					'usage'            => array(),
+					'request_metadata' => array(),
+					'status'           => 'error',
 				),
 				$loop_payload,
 				$provider,
@@ -233,7 +233,7 @@ function datamachine_run_conversation(
 		// We can't read the substrate's accumulated turn_count/usage/etc here
 		// because the loop didn't return — surface what we know with empty
 		// defaults for the substrate-tracked fields.
-		$error_result = array(
+		$error_result                       = array(
 			'messages'               => $messages,
 			'final_content'          => '',
 			'turn_count'             => 0,
@@ -253,7 +253,7 @@ function datamachine_run_conversation(
 	try {
 		$result = WP_Agent_Conversation_Result::normalize( $result );
 	} catch ( \InvalidArgumentException $e ) {
-		$error_result = array(
+		$error_result                       = array(
 			'messages'               => $messages,
 			'final_content'          => '',
 			'turn_count'             => 0,
@@ -367,8 +367,8 @@ function datamachine_build_turn_runner(
 		// Per-turn request metadata is captured locally and returned in the
 		// turn result so the substrate can surface the latest one on the
 		// final loop result.
-		$request_metadata = array();
-		$ai_response      = RequestBuilder::build(
+		$request_metadata      = array();
+		$ai_response           = RequestBuilder::build(
 			$messages,
 			$provider,
 			$model,
@@ -422,8 +422,8 @@ function datamachine_build_turn_runner(
 
 		// Per-turn token usage. Substrate accumulates this across turns and
 		// exposes the running total on the final loop result.
-		$token_usage = $ai_result->getTokenUsage();
-		$turn_usage  = array(
+		$token_usage   = $ai_result->getTokenUsage();
+		$turn_usage    = array(
 			'prompt_tokens'     => $token_usage->getPromptTokens(),
 			'completion_tokens' => $token_usage->getCompletionTokens(),
 			'total_tokens'      => $token_usage->getTotalTokens(),

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -75,8 +75,9 @@ function datamachine_run_conversation(
 	// surfaces turn_count, final_content, usage, and request_metadata on the
 	// final result directly (see agents-api#136), so we only carry by-reference
 	// the things substrate doesn't track for us.
-	$last_tool_calls   = array();
-	$completion_nudges = array();
+	$last_tool_calls       = array();
+	$completion_nudges     = array();
+	$last_request_metadata = array();
 
 	// Base log context for consistent logging.
 	$base_log_context = array_filter(
@@ -139,6 +140,21 @@ function datamachine_run_conversation(
 			'usage'                           => array(),
 			'request_metadata'                => array(),
 			'status'                          => 'error',
+			'runtime_provenance'              => RuntimeProvenance::fromConversationResult(
+				array(
+					'messages'          => $messages,
+					'completed'         => false,
+					'error'             => $error_message,
+					'error_code'        => 'completion_required_tool_unavailable',
+					'usage'             => array(),
+					'request_metadata'  => array(),
+					'status'            => 'error',
+				),
+				$loop_payload,
+				$provider,
+				$model,
+				$mode
+			),
 		);
 	}
 
@@ -162,7 +178,8 @@ function datamachine_run_conversation(
 		$completion_policy,
 		$tool_runtime_rules,
 		$last_tool_calls,
-		$completion_nudges
+		$completion_nudges,
+		$last_request_metadata
 	);
 
 	// Build should_continue callback. Budget enforcement is handled by
@@ -216,7 +233,7 @@ function datamachine_run_conversation(
 		// We can't read the substrate's accumulated turn_count/usage/etc here
 		// because the loop didn't return — surface what we know with empty
 		// defaults for the substrate-tracked fields.
-		return array(
+		$error_result = array(
 			'messages'               => $messages,
 			'final_content'          => '',
 			'turn_count'             => 0,
@@ -225,16 +242,18 @@ function datamachine_run_conversation(
 			'tool_execution_results' => array(),
 			'error'                  => $e->getMessage(),
 			'usage'                  => array(),
-			'request_metadata'       => array(),
+			'request_metadata'       => $last_request_metadata,
 			'status'                 => 'error',
 		);
+		$error_result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $error_result, $loop_payload, $provider, $model, $mode );
+		return $error_result;
 	}
 
 	// Normalize the substrate result and augment with DM-specific fields.
 	try {
 		$result = WP_Agent_Conversation_Result::normalize( $result );
 	} catch ( \InvalidArgumentException $e ) {
-		return array(
+		$error_result = array(
 			'messages'               => $messages,
 			'final_content'          => '',
 			'turn_count'             => 0,
@@ -244,6 +263,8 @@ function datamachine_run_conversation(
 			'usage'                  => array(),
 			'error'                  => $e->getMessage(),
 		);
+		$error_result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $error_result, $loop_payload, $provider, $model, $mode );
+		return $error_result;
 	}
 
 	// Substrate now surfaces turn_count, final_content, usage, and
@@ -279,6 +300,8 @@ function datamachine_run_conversation(
 			$turn_budget->ceiling()
 		);
 	}
+
+	$result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $result, $loop_payload, $provider, $model, $mode );
 
 	return $result;
 }
@@ -320,7 +343,8 @@ function datamachine_build_turn_runner(
 	WP_Agent_Conversation_Completion_Policy $completion_policy,
 	DataMachineToolRuntimeRules $tool_runtime_rules,
 	array &$last_tool_calls,
-	array &$completion_nudges
+	array &$completion_nudges,
+	array &$last_request_metadata
 ): callable {
 	return static function ( array $messages, array $turn_context ) use (
 		$tools,
@@ -333,7 +357,8 @@ function datamachine_build_turn_runner(
 		$completion_policy,
 		$tool_runtime_rules,
 		&$last_tool_calls,
-		&$completion_nudges
+		&$completion_nudges,
+		&$last_request_metadata
 	): array {
 		// The upstream loop provides the turn number via turn_context.
 		$turn_count = (int) ( $turn_context['turn'] ?? 1 );
@@ -352,6 +377,7 @@ function datamachine_build_turn_runner(
 			$loop_payload,
 			$request_metadata
 		);
+		$last_request_metadata = $request_metadata;
 
 		datamachine_emit_loop_event(
 			$event_sink,
@@ -402,6 +428,11 @@ function datamachine_build_turn_runner(
 			'completion_tokens' => $token_usage->getCompletionTokens(),
 			'total_tokens'      => $token_usage->getTotalTokens(),
 		);
+		$finish_reason = datamachine_ai_result_finish_reason( $ai_result );
+		if ( null !== $finish_reason ) {
+			$request_metadata['response']['finish_reason'] = $finish_reason;
+			$last_request_metadata                         = $request_metadata;
+		}
 
 		// Add AI message to conversation if it has content.
 		if ( ! empty( $ai_content ) ) {
@@ -644,12 +675,34 @@ function datamachine_build_turn_runner(
 			'tool_execution_results'       => $tool_execution_results,
 			'request_metadata'             => $request_metadata,
 			'usage'                        => $turn_usage,
+			'finish_reason'                => $finish_reason,
 			'conversation_complete'        => $conversation_complete,
 			'completion_nudge'             => $completion_nudge ?? '',
 			'duplicate_tool_call_rejected' => $duplicate_rejected,
 			'tool_runtime_rule_rejected'   => $runtime_rule_rejected,
 		);
 	};
+}
+
+/**
+ * Best-effort finish reason extraction from wp-ai-client result DTOs.
+ *
+ * @param \WordPress\AiClient\Results\DTO\GenerativeAiResult $result AI result.
+ * @return string|null
+ */
+function datamachine_ai_result_finish_reason( $result ): ?string {
+	try {
+		$candidates = $result->getCandidates();
+		$candidate  = $candidates[0] ?? null;
+		if ( is_object( $candidate ) && method_exists( $candidate, 'getFinishReason' ) ) {
+			$reason = $candidate->getFinishReason();
+			return is_scalar( $reason ) ? (string) $reason : null;
+		}
+	} catch ( \Throwable $e ) {
+		return null;
+	}
+
+	return null;
 }
 
 /**

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -143,6 +143,15 @@ assert_runner_request( is_array( $result['tool_execution_results'] ?? null ), 'r
 assert_runner_request( 5 === ( $result['usage']['total_tokens'] ?? null ), 'result preserves accumulated usage totals' );
 assert_runner_request( is_array( $dispatched_request ), 'substrate dispatched a provider request' );
 assert_runner_request( ! empty( $sink->events ), 'DM event sink received events through the substrate bridge' );
+assert_runner_request( isset( $result['runtime_provenance'] ) && is_array( $result['runtime_provenance'] ), 'result includes runtime provenance' );
+assert_runner_request( 1 === ( $result['runtime_provenance']['schema_version'] ?? null ), 'runtime provenance exposes a stable schema version' );
+assert_runner_request( 'openai' === ( $result['runtime_provenance']['provider']['id'] ?? null ), 'runtime provenance records provider id' );
+assert_runner_request( 'gpt-smoke' === ( $result['runtime_provenance']['model']['id'] ?? null ), 'runtime provenance records model id' );
+assert_runner_request( 5 === ( $result['runtime_provenance']['usage']['total_tokens'] ?? null ), 'runtime provenance records token usage' );
+assert_runner_request( 'flow-step-smoke' === ( $result['runtime_provenance']['identifiers']['flow_step_id'] ?? null ), 'runtime provenance records flow step id' );
+assert_runner_request( 1569 === ( $result['runtime_provenance']['identifiers']['job_id'] ?? null ), 'runtime provenance records job id' );
+assert_runner_request( isset( $result['runtime_provenance']['input']['prompt_sha256'] ) && 64 === strlen( $result['runtime_provenance']['input']['prompt_sha256'] ), 'runtime provenance records prompt hash' );
+assert_runner_request( isset( $result['runtime_provenance']['tools']['policy_sha256'] ) && 64 === strlen( $result['runtime_provenance']['tools']['policy_sha256'] ), 'runtime provenance records tool policy hash' );
 
 // 2. Error path returns a structured error result without throwing.
 WpAiClientTestDouble::reset();
@@ -165,6 +174,8 @@ $error_result = datamachine_run_conversation(
 assert_runner_request( isset( $error_result['error'] ), 'error path returns a structured error field' );
 assert_runner_request( str_contains( (string) ( $error_result['error'] ?? '' ), 'provider offline' ), 'error path preserves the provider error message' );
 assert_runner_request( false === ( $error_result['completed'] ?? true ), 'error path marks conversation not completed' );
+assert_runner_request( 'provider_error' === ( $error_result['runtime_provenance']['status']['finish_reason'] ?? null ), 'error provenance records provider error finish reason' );
+assert_runner_request( str_contains( (string) ( $error_result['runtime_provenance']['provider_errors'][0]['message'] ?? '' ), 'provider offline' ), 'error provenance records provider error message' );
 
 if ( runner_request_failure_count() > 0 ) {
 	exit( 1 );

--- a/tests/ai-request-metadata-guardrails-smoke.php
+++ b/tests/ai-request-metadata-guardrails-smoke.php
@@ -93,8 +93,13 @@ function size_format( $bytes ): string {
 	return $bytes . ' B';
 }
 
+function datamachine_merge_engine_data( int $job_id, array $data ): void {
+	$GLOBALS['datamachine_test_engine_data'][ $job_id ] = array_merge( $GLOBALS['datamachine_test_engine_data'][ $job_id ] ?? array(), $data );
+}
+
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 require_once __DIR__ . '/agents-api-loader.php';
+require_once __DIR__ . '/Unit/Support/WpAiClientTestDoubles.php';
 datamachine_tests_require_agents_api();
 
 use DataMachine\Cli\Commands\JobsCommand;
@@ -214,6 +219,7 @@ function reset_smoke_state(): void {
 	$GLOBALS['datamachine_test_filters'] = array();
 	$GLOBALS['datamachine_test_logs']    = array();
 	$GLOBALS['datamachine_test_request_metadata'] = array();
+	$GLOBALS['datamachine_test_wp_ai_client_provider_ids'] = array();
 	WP_CLI::$logs                        = array();
 }
 
@@ -300,7 +306,7 @@ $transcript_request = new WP_Agent_Conversation_Request(
 	array( array( 'role' => 'user', 'content' => 'hello' ) ),
 	array(),
 	null,
-	array( 'persist_transcript' => true, 'job_id' => 279, 'flow_step_id' => 12, 'user_id' => 1, 'agent_id' => 2 ),
+	array( 'persist_transcript' => true, 'job_id' => 279, 'flow_step_id' => 12, 'user_id' => 1, 'agent_id' => 2, 'agent_slug' => 'smoke-agent' ),
 	array( 'provider' => 'openai', 'model' => 'gpt-smoke' ),
 	10,
 	false,


### PR DESCRIPTION
## Summary
- Adds a stable `runtime_provenance` object to Data Machine conversation results with provider/model IDs, model config source, token usage, provider errors, status, hashes, tool policy details, and agent/pipeline/flow/job identifiers.
- Adds redacted request/input/tool-policy hashes to `RequestMetadata` and persists runtime provenance into AI step engine data for Homeboy/eval artifact consumers.
- Extends smoke coverage for success and provider-error provenance paths, and keeps the pure-PHP metadata harness loading the wp-ai-client DTO doubles it exercises.

Fixes https://github.com/Extra-Chill/data-machine/issues/2012
Motivated by https://github.com/Automattic/wp-gym/pull/76

## Testing
- `php tests/agent-conversation-runner-request-smoke.php`
- `php tests/agent-conversation-result-smoke.php`
- `php tests/wp-ai-client-request-timeout-smoke.php`
- `php tests/ai-request-metadata-guardrails-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/RuntimeProvenance.php inc/Engine/AI/conversation-loop.php inc/Engine/AI/RequestMetadata.php inc/Core/Steps/AI/AIStep.php tests/agent-conversation-runner-request-smoke.php tests/ai-request-metadata-guardrails-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@wp-gym-provenance-foundation --extension wordpress --force-hot`

## Known lint baseline
- `homeboy lint --path /Users/chubes/Developer/data-machine@wp-gym-provenance-foundation --extension wordpress --force-hot` currently reports 462 existing admin React lint findings outside this PHP-only change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the provenance foundation, added smoke coverage, and ran verification commands for Chris to review.