### PR TITLE
Preserve original source attribution on posts

### DIFF
--- a/inc/Abilities/Content/UpsertPostAbility.php
+++ b/inc/Abilities/Content/UpsertPostAbility.php
@@ -26,16 +26,19 @@ namespace DataMachine\Abilities\Content;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Content\ContentFormat;
+use DataMachine\Core\SourceDate;
 use DataMachine\Core\WordPress\ResolvePostByPath;
+use DataMachine\Core\WordPress\PostTracking;
 
 defined( 'ABSPATH' ) || exit;
 
 class UpsertPostAbility {
 
-	public const ABILITY_NAME      = 'datamachine/upsert-post';
-	public const META_CONTENT_HASH = '_datamachine_content_hash';
-	public const META_RAW_SOURCE   = '_datamachine_raw_source';
-	public const META_STUB_MARKER  = '_datamachine_auto_stub';
+	public const ABILITY_NAME           = 'datamachine/upsert-post';
+	public const META_CONTENT_HASH      = '_datamachine_content_hash';
+	public const META_RAW_SOURCE        = '_datamachine_raw_source';
+	public const META_STUB_MARKER       = '_datamachine_auto_stub';
+	public const META_ORIGINAL_DATE_GMT = '_datamachine_original_date_gmt';
 
 	private static bool $registered = false;
 
@@ -64,40 +67,40 @@ class UpsertPostAbility {
 						'type'       => 'object',
 						'required'   => array( 'post_type', 'title', 'content' ),
 						'properties' => array(
-							'post_type'      => array(
+							'post_type'         => array(
 								'type'        => 'string',
 								'description' => 'Post type slug (e.g. post, page, wiki, ec_doc).',
 							),
-							'title'          => array(
+							'title'             => array(
 								'type'        => 'string',
 								'description' => 'Post title.',
 							),
-							'content'        => array(
+							'content'           => array(
 								'type'        => 'string',
 								'description' => 'Post content. Replaces existing content when updating. Raw ability callers that omit content_format are treated as providing block markup for backwards compatibility.',
 							),
-							'content_format' => array(
+							'content_format'    => array(
 								'type'        => 'string',
 								'enum'        => array( 'blocks', 'html', 'markdown' ),
 								'description' => 'Authoring/source format of content, not the stored post_content format. Raw ability/API calls default to blocks for compatibility. Pass markdown or html when supplying those source formats; the post type stored format is decided by datamachine_post_content_format.',
 							),
-							'post_id'        => array(
+							'post_id'           => array(
 								'type'        => 'integer',
 								'description' => 'Explicit post ID. Most deterministic identity. Overrides other identity fields.',
 							),
-							'slug'           => array(
+							'slug'              => array(
 								'type'        => 'string',
 								'description' => 'Post slug (post_name). Used with parent_id for scoped lookup.',
 							),
-							'parent_id'      => array(
+							'parent_id'         => array(
 								'type'        => 'integer',
 								'description' => 'Parent post ID for scoped slug lookup.',
 							),
-							'parent_path'    => array(
+							'parent_path'       => array(
 								'type'        => 'string',
 								'description' => 'Slash-delimited parent slug path (e.g. "artist/link-pages"). Resolved via ResolvePostByPath. Overrides parent_id.',
 							),
-							'identity_meta'  => array(
+							'identity_meta'     => array(
 								'type'        => 'object',
 								'description' => 'Custom meta-based identity. {key: "_source_file", value: "artist/getting-started.md"}',
 								'properties'  => array(
@@ -106,35 +109,43 @@ class UpsertPostAbility {
 								),
 								'required'    => array( 'key', 'value' ),
 							),
-							'content_hash'   => array(
+							'content_hash'      => array(
 								'type'        => 'string',
 								'description' => 'Hash of normalized content for no_change detection. If omitted, no idempotency check is performed (always writes).',
 							),
-							'raw_source'     => array(
+							'raw_source'        => array(
 								'type'        => 'string',
 								'description' => 'Optional raw source (e.g. markdown) stored in _datamachine_raw_source meta for round-trip sync.',
 							),
-							'post_status'    => array(
+							'source_url'        => array(
+								'type'        => 'string',
+								'description' => 'Original source URL for attribution and dedupe.',
+							),
+							'original_date_gmt' => array(
+								'type'        => 'string',
+								'description' => 'Original source publication date in GMT.',
+							),
+							'post_status'       => array(
 								'type'        => 'string',
 								'description' => 'Post status for create path. Defaults to publish.',
 							),
-							'post_author'    => array(
+							'post_author'       => array(
 								'type'        => 'integer',
 								'description' => 'Post author user ID. Only applied on create; ignored on update.',
 							),
-							'post_excerpt'   => array(
+							'post_excerpt'      => array(
 								'type'        => 'string',
 								'description' => 'Post excerpt.',
 							),
-							'taxonomies'     => array(
+							'taxonomies'        => array(
 								'type'        => 'object',
 								'description' => 'Taxonomy terms to assign. {taxonomy: [term1, term2]}',
 							),
-							'meta_input'     => array(
+							'meta_input'        => array(
 								'type'        => 'object',
 								'description' => 'Additional post meta to set.',
 							),
-							'create_stubs'   => array(
+							'create_stubs'      => array(
 								'type'        => 'boolean',
 								'description' => 'When parent_path is provided, auto-create missing intermediate nodes as stubs.',
 							),
@@ -202,42 +213,50 @@ class UpsertPostAbility {
 			'method'      => 'handleChatToolCall',
 			'description' => 'Idempotently create or update a WordPress post. For normal authored prose, write content as markdown and omit content_format; Data Machine converts that authoring format to the post type stored format. Only set content_format when you are intentionally providing html or serialized block markup.',
 			'parameters'  => array(
-				'post_type'      => array(
+				'post_type'         => array(
 					'type'        => 'string',
 					'description' => 'Post type slug.',
 				),
-				'title'          => array(
+				'title'             => array(
 					'type'        => 'string',
 					'description' => 'Post title.',
 				),
-				'content'        => array(
+				'content'           => array(
 					'type'        => 'string',
 					'description' => 'Post content to author. Use markdown for normal prose unless content_format explicitly says otherwise.',
 				),
-				'content_format' => array(
+				'content_format'    => array(
 					'type'        => 'string',
 					'enum'        => array( 'markdown', 'html', 'blocks' ),
 					'description' => 'Optional authoring/source format for content. Omit for normal prose; AI tool calls default to markdown. Set to html or blocks only when content is already in that format. This is distinct from the stored format chosen by the post type.',
 				),
-				'slug'           => array(
+				'slug'              => array(
 					'type'        => 'string',
 					'description' => 'Post slug for lookup.',
 				),
-				'parent_id'      => array(
+				'parent_id'         => array(
 					'type'        => 'integer',
 					'description' => 'Parent post ID.',
 				),
-				'parent_path'    => array(
+				'parent_path'       => array(
 					'type'        => 'string',
 					'description' => 'Slash-delimited parent path (e.g. "artist/link-pages").',
 				),
-				'post_author'    => array(
+				'post_author'       => array(
 					'type'        => 'integer',
 					'description' => 'Post author user ID (create only).',
 				),
-				'content_hash'   => array(
+				'content_hash'      => array(
 					'type'        => 'string',
 					'description' => 'Hash for idempotency check.',
+				),
+				'source_url'        => array(
+					'type'        => 'string',
+					'description' => 'Original source URL for attribution and dedupe.',
+				),
+				'original_date_gmt' => array(
+					'type'        => 'string',
+					'description' => 'Original source publication date in GMT.',
 				),
 			),
 			'required'    => array( 'post_type', 'title', 'content' ),
@@ -268,23 +287,25 @@ class UpsertPostAbility {
 	 * @return array Result with action: created|updated|no_change.
 	 */
 	public static function execute( array $input ): array {
-		$post_type      = sanitize_key( $input['post_type'] ?? '' );
-		$title          = trim( $input['title'] ?? '' );
-		$content        = $input['content'] ?? '';
-		$content_format = sanitize_key( $input['content_format'] ?? 'blocks' );
-		$post_id        = absint( $input['post_id'] ?? 0 );
-		$slug           = sanitize_title( $input['slug'] ?? '' );
-		$parent_id      = absint( $input['parent_id'] ?? 0 );
-		$parent_path    = trim( $input['parent_path'] ?? '' );
-		$identity_meta  = $input['identity_meta'] ?? array();
-		$content_hash   = $input['content_hash'] ?? '';
-		$raw_source     = $input['raw_source'] ?? '';
-		$post_status    = sanitize_key( $input['post_status'] ?? 'publish' );
-		$post_author    = absint( $input['post_author'] ?? 0 );
-		$post_excerpt   = $input['post_excerpt'] ?? '';
-		$taxonomies     = $input['taxonomies'] ?? array();
-		$meta_input     = $input['meta_input'] ?? array();
-		$create_stubs   = ! empty( $input['create_stubs'] );
+		$post_type         = sanitize_key( $input['post_type'] ?? '' );
+		$title             = trim( $input['title'] ?? '' );
+		$content           = $input['content'] ?? '';
+		$content_format    = sanitize_key( $input['content_format'] ?? 'blocks' );
+		$post_id           = absint( $input['post_id'] ?? 0 );
+		$slug              = sanitize_title( $input['slug'] ?? '' );
+		$parent_id         = absint( $input['parent_id'] ?? 0 );
+		$parent_path       = trim( $input['parent_path'] ?? '' );
+		$identity_meta     = $input['identity_meta'] ?? array();
+		$content_hash      = $input['content_hash'] ?? '';
+		$raw_source        = $input['raw_source'] ?? '';
+		$source_url        = esc_url_raw( (string) ( $input['source_url'] ?? '' ) );
+		$original_date_gmt = SourceDate::normalizeGmt( $input['original_date_gmt'] ?? '' );
+		$post_status       = sanitize_key( $input['post_status'] ?? 'publish' );
+		$post_author       = absint( $input['post_author'] ?? 0 );
+		$post_excerpt      = $input['post_excerpt'] ?? '';
+		$taxonomies        = $input['taxonomies'] ?? array();
+		$meta_input        = $input['meta_input'] ?? array();
+		$create_stubs      = ! empty( $input['create_stubs'] );
 
 		if ( '' === $post_type || '' === $title ) {
 			return array(
@@ -345,6 +366,7 @@ class UpsertPostAbility {
 		if ( $existing_id > 0 && '' !== $content_hash ) {
 			$stored_hash = get_post_meta( $existing_id, self::META_CONTENT_HASH, true );
 			if ( $stored_hash === $content_hash ) {
+				self::applySourceMetadata( $existing_id, $source_url, $original_date_gmt );
 				$post = get_post( $existing_id );
 				return array(
 					'success'  => true,
@@ -377,6 +399,11 @@ class UpsertPostAbility {
 			$post_data['post_parent'] = $parent_id;
 		}
 
+		if ( null !== $original_date_gmt ) {
+			$post_data['post_date_gmt'] = $original_date_gmt;
+			$post_data['post_date']     = get_date_from_gmt( $original_date_gmt );
+		}
+
 		if ( $existing_id > 0 ) {
 			$post_data['ID'] = $existing_id;
 			$action          = 'updated';
@@ -396,6 +423,14 @@ class UpsertPostAbility {
 
 		if ( '' !== $raw_source ) {
 			$all_meta[ self::META_RAW_SOURCE ] = $raw_source;
+		}
+
+		if ( '' !== $source_url ) {
+			$all_meta[ PostTracking::SOURCE_URL_META_KEY ] = $source_url;
+		}
+
+		if ( null !== $original_date_gmt ) {
+			$all_meta[ self::META_ORIGINAL_DATE_GMT ] = $original_date_gmt;
 		}
 
 		if ( ! empty( $all_meta ) ) {
@@ -456,6 +491,31 @@ class UpsertPostAbility {
 			'post_url' => get_permalink( (int) $id ),
 			'path'     => ResolvePostByPath::build_path( $post ),
 		);
+	}
+
+	/**
+	 * Apply source metadata to an existing post when content is unchanged.
+	 *
+	 * @param int         $post_id           Post ID.
+	 * @param string      $source_url        Source URL.
+	 * @param string|null $original_date_gmt Original source date.
+	 */
+	private static function applySourceMetadata( int $post_id, string $source_url, ?string $original_date_gmt ): void {
+		$update = array( 'ID' => $post_id );
+
+		if ( '' !== $source_url ) {
+			update_post_meta( $post_id, PostTracking::SOURCE_URL_META_KEY, $source_url );
+		}
+
+		if ( null !== $original_date_gmt ) {
+			update_post_meta( $post_id, self::META_ORIGINAL_DATE_GMT, $original_date_gmt );
+			$update['post_date_gmt'] = $original_date_gmt;
+			$update['post_date']     = get_date_from_gmt( $original_date_gmt );
+		}
+
+		if ( count( $update ) > 1 ) {
+			wp_update_post( $update );
+		}
 	}
 
 	/**

--- a/inc/Abilities/Publish/PublishWordPressAbility.php
+++ b/inc/Abilities/Publish/PublishWordPressAbility.php
@@ -12,6 +12,7 @@ namespace DataMachine\Abilities\Publish;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Content\ContentFormat;
+use DataMachine\Core\SourceDate;
 use DataMachine\Core\WordPress\PostTracking;
 use DataMachine\Core\WordPress\WordPressPublishHelper;
 use DataMachine\Core\WordPress\WordPressSettingsResolver;
@@ -86,6 +87,11 @@ class PublishWordPressAbility {
 								'default'     => '',
 								'description' => __( 'Source URL for attribution', 'data-machine' ),
 							),
+							'original_date_gmt'      => array(
+								'type'        => 'string',
+								'default'     => '',
+								'description' => __( 'Original source publication date in GMT', 'data-machine' ),
+							),
 							'add_source_attribution' => array(
 								'type'        => 'boolean',
 								'default'     => true,
@@ -159,6 +165,7 @@ class PublishWordPressAbility {
 		$taxonomies             = $config['taxonomies'];
 		$featured_image_path    = $config['featured_image_path'];
 		$source_url             = $config['source_url'];
+		$original_date_gmt      = $this->normalizeOriginalDateGmt( $config['original_date_gmt'] );
 		$add_source_attribution = $config['add_source_attribution'];
 		$job_id                 = $config['job_id'];
 
@@ -253,6 +260,11 @@ class PublishWordPressAbility {
 				array( 'post_author' => $post_author )
 			),
 		);
+
+		if ( null !== $original_date_gmt ) {
+			$post_data['post_date_gmt'] = $original_date_gmt;
+			$post_data['post_date']     = get_date_from_gmt( $original_date_gmt );
+		}
 
 		// Support hierarchical post types (pages, custom hierarchical CPTs).
 		$post_parent = (int) ( $config['post_parent'] ?? 0 );
@@ -375,6 +387,10 @@ class PublishWordPressAbility {
 			update_post_meta( $post_id, PostTracking::SOURCE_URL_META_KEY, esc_url_raw( $source_url ) );
 		}
 
+		if ( null !== $original_date_gmt ) {
+			update_post_meta( $post_id, '_datamachine_original_date_gmt', $original_date_gmt );
+		}
+
 		$logs[] = array(
 			'level'   => 'debug',
 			'message' => 'WordPress: Post published successfully',
@@ -408,6 +424,7 @@ class PublishWordPressAbility {
 			'taxonomies'             => array(),
 			'featured_image_path'    => '',
 			'source_url'             => '',
+			'original_date_gmt'      => '',
 			'content_format'         => 'html',
 			'add_source_attribution' => true,
 			'post_parent'            => 0,
@@ -415,6 +432,16 @@ class PublishWordPressAbility {
 		);
 
 		return array_merge( $defaults, $input );
+	}
+
+	/**
+	 * Normalize an arbitrary source date into a MySQL GMT datetime.
+	 *
+	 * @param mixed $date Source date value.
+	 * @return string|null MySQL GMT datetime or null when invalid.
+	 */
+	private function normalizeOriginalDateGmt( $date ): ?string {
+		return SourceDate::normalizeGmt( $date );
 	}
 
 	/**

--- a/inc/Core/EngineData.php
+++ b/inc/Core/EngineData.php
@@ -166,6 +166,15 @@ class EngineData {
 	}
 
 	/**
+	 * Get the original source publication date in GMT.
+	 *
+	 * @return string|null MySQL GMT datetime or null.
+	 */
+	public function getOriginalDateGmt(): ?string {
+		return SourceDate::normalizeGmt( $this->get( 'original_date_gmt' ) );
+	}
+
+	/**
 	 * Get the Image File Path (from Files Repository).
 	 *
 	 * @return string|null Absolute file path or null.

--- a/inc/Core/SourceDate.php
+++ b/inc/Core/SourceDate.php
@@ -26,6 +26,10 @@ class SourceDate {
 		}
 
 		$timestamp = strtotime( (string) $date );
-		return false !== $timestamp ? gmdate( 'Y-m-d H:i:s', $timestamp ) : null;
+		if ( false === $timestamp || $timestamp > time() ) {
+			return null;
+		}
+
+		return gmdate( 'Y-m-d H:i:s', $timestamp );
 	}
 }

--- a/inc/Core/SourceDate.php
+++ b/inc/Core/SourceDate.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Source date normalization helpers.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalizes source-provided datetimes for WordPress storage.
+ */
+class SourceDate {
+
+	/**
+	 * Normalize an arbitrary source date into a MySQL GMT datetime.
+	 *
+	 * @param mixed $date Source date value.
+	 * @return string|null MySQL GMT datetime or null when invalid.
+	 */
+	public static function normalizeGmt( $date ): ?string {
+		if ( empty( $date ) || ! is_scalar( $date ) ) {
+			return null;
+		}
+
+		$timestamp = strtotime( (string) $date );
+		return false !== $timestamp ? gmdate( 'Y-m-d H:i:s', $timestamp ) : null;
+	}
+}

--- a/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php
+++ b/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php
@@ -200,6 +200,7 @@ class WordPress extends PublishHandler {
 			'featured_image_path'    => $media['image_file_path'],
 			'featured_image_url'     => $media['image_url'],
 			'source_url'             => $engine->getSourceUrl(),
+			'original_date_gmt'      => $engine->getOriginalDateGmt(),
 			'add_source_attribution' => 'append' === ( $handler_config['link_handling'] ?? 'append' ),
 			'job_id'                 => $parameters['job_id'] ?? null,
 		);

--- a/tests/content-format-abilities-smoke.php
+++ b/tests/content-format-abilities-smoke.php
@@ -403,6 +403,23 @@ namespace {
 	assert_content_ability( 'upsert-original-date-meta-stored', '2020-09-24 06:12:53' === get_post_meta( $source_id, '_datamachine_original_date_gmt', true ) );
 	assert_content_ability( 'upsert-original-date-applies-post-date-gmt', '2020-09-24 06:12:53' === ( $source_post->post_date_gmt ?? '' ) );
 
+	$future_source_upsert = DataMachine\Abilities\Content\UpsertPostAbility::execute(
+		array(
+			'post_type'         => 'wiki',
+			'title'             => 'Future Source Date Ignored',
+			'content'           => "# Future\n\nRaw markdown.",
+			'content_format'    => 'markdown',
+			'source_url'        => 'https://example.com/future-source-post/',
+			'original_date_gmt' => '2999-01-01T00:00:00+00:00',
+		)
+	);
+	$future_source_id     = (int) ( $future_source_upsert['post_id'] ?? 0 );
+	$future_source_post   = get_post( $future_source_id );
+	assert_content_ability( 'upsert-future-source-date-succeeds', true === $future_source_upsert['success'] );
+	assert_content_ability( 'upsert-future-source-url-still-stored', 'https://example.com/future-source-post/' === get_post_meta( $future_source_id, '_datamachine_source_url', true ) );
+	assert_content_ability( 'upsert-future-original-date-ignored', '' === get_post_meta( $future_source_id, '_datamachine_original_date_gmt', true ) );
+	assert_content_ability( 'upsert-future-original-date-does-not-set-post-date-gmt', empty( $future_source_post->post_date_gmt ) );
+
 	$chat_upsert   = DataMachine\Abilities\Content\UpsertPostAbility::handleChatToolCall(
 		array(
 			'post_type' => 'post',

--- a/tests/content-format-abilities-smoke.php
+++ b/tests/content-format-abilities-smoke.php
@@ -73,6 +73,7 @@ namespace {
 	);
 	$GLOBALS['__content_ability_next_id']     = 20;
 	$GLOBALS['__content_ability_conversions'] = array();
+	$GLOBALS['__content_ability_meta']        = array();
 
 	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
 		$GLOBALS['__content_ability_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
@@ -103,6 +104,10 @@ namespace {
 
 	function sanitize_text_field( $value ): string {
 		return trim( (string) $value );
+	}
+
+	function esc_url_raw( $url ): string {
+		return trim( (string) $url );
 	}
 
 	function absint( $value ): int {
@@ -139,8 +144,16 @@ namespace {
 	}
 
 	function get_post_meta( int $post_id, string $key, bool $single = false ) {
-		unset( $post_id, $key, $single );
-		return '';
+		$value = $GLOBALS['__content_ability_meta'][ $post_id ][ $key ] ?? '';
+		return $single ? $value : array( $value );
+	}
+
+	function update_post_meta( int $post_id, string $key, $value ): void {
+		$GLOBALS['__content_ability_meta'][ $post_id ][ $key ] = $value;
+	}
+
+	function get_date_from_gmt( string $date ): string {
+		return $date;
 	}
 
 	function taxonomy_exists( string $taxonomy ): bool {
@@ -175,6 +188,9 @@ namespace {
 			if ( 'meta_input' !== $key ) {
 				$existing->{$key} = $value;
 			}
+		}
+		foreach ( $post_data['meta_input'] ?? array() as $key => $value ) {
+			$GLOBALS['__content_ability_meta'][ $id ][ $key ] = $value;
 		}
 		$existing->ID                              = $id;
 		$GLOBALS['__content_ability_posts'][ $id ] = $existing;
@@ -327,6 +343,8 @@ namespace {
 	);
 
 	include_once dirname( __DIR__ ) . '/inc/Core/Content/ContentFormat.php';
+	include_once dirname( __DIR__ ) . '/inc/Core/SourceDate.php';
+	include_once dirname( __DIR__ ) . '/inc/Core/WordPress/PostTracking.php';
 	include_once dirname( __DIR__ ) . '/inc/Abilities/Content/BlockSanitizer.php';
 	include_once dirname( __DIR__ ) . '/inc/Abilities/Content/GetPostBlocksAbility.php';
 	include_once dirname( __DIR__ ) . '/inc/Abilities/Content/EditPostBlocksAbility.php';
@@ -367,6 +385,23 @@ namespace {
 	$new_post = get_post( (int) $new_id );
 	assert_content_ability( 'upsert-markdown-source-succeeds', true === $upsert['success'] );
 	assert_content_ability( 'upsert-markdown-source-stays-markdown', "# Stored\n\nRaw markdown." === ( $new_post->post_content ?? '' ) );
+
+	$source_upsert = DataMachine\Abilities\Content\UpsertPostAbility::execute(
+		array(
+			'post_type'         => 'wiki',
+			'title'             => 'Source Dated Markdown',
+			'content'           => "# Source\n\nRaw markdown.",
+			'content_format'    => 'markdown',
+			'source_url'        => 'https://example.com/source-post/',
+			'original_date_gmt' => '2020-09-24T06:12:53+00:00',
+		)
+	);
+	$source_id     = (int) ( $source_upsert['post_id'] ?? 0 );
+	$source_post   = get_post( $source_id );
+	assert_content_ability( 'upsert-source-date-succeeds', true === $source_upsert['success'] );
+	assert_content_ability( 'upsert-source-url-meta-stored', 'https://example.com/source-post/' === get_post_meta( $source_id, '_datamachine_source_url', true ) );
+	assert_content_ability( 'upsert-original-date-meta-stored', '2020-09-24 06:12:53' === get_post_meta( $source_id, '_datamachine_original_date_gmt', true ) );
+	assert_content_ability( 'upsert-original-date-applies-post-date-gmt', '2020-09-24 06:12:53' === ( $source_post->post_date_gmt ?? '' ) );
 
 	$chat_upsert   = DataMachine\Abilities\Content\UpsertPostAbility::handleChatToolCall(
 		array(

--- a/tests/wordpress-publish-content-format-smoke.php
+++ b/tests/wordpress-publish-content-format-smoke.php
@@ -209,6 +209,7 @@ namespace {
     );
 
     require_once dirname( __DIR__ ) . '/inc/Core/Content/ContentFormat.php';
+    require_once dirname( __DIR__ ) . '/inc/Core/SourceDate.php';
     require_once dirname( __DIR__ ) . '/inc/Core/WordPress/PostTracking.php';
     require_once dirname( __DIR__ ) . '/inc/Core/WordPress/WordPressSettingsResolver.php';
     require_once dirname( __DIR__ ) . '/inc/Core/WordPress/WordPressPublishHelper.php';


### PR DESCRIPTION
## Summary
- Add shared source-date normalization and expose original source dates through engine data.
- Store source URL and original publication date on generic post upserts, including no-change updates.
- Apply original source dates to WordPress publish/upsert post dates instead of defaulting to generation time.
- Ignore future source publication dates so attribution cannot accidentally schedule existing posts as future content.

## Testing
- `homeboy lint --path \"/Users/chubes/Developer/data-machine@fix-wiki-source-date-attribution\" --extension wordpress --file \"inc/Core/SourceDate.php\"`
- `homeboy lint --path \"/Users/chubes/Developer/data-machine@fix-wiki-source-date-attribution\" --extension wordpress --file \"inc/Core/EngineData.php\"`
- `homeboy lint --path \"/Users/chubes/Developer/data-machine@fix-wiki-source-date-attribution\" --extension wordpress --file \"inc/Abilities/Content/UpsertPostAbility.php\"`
- `homeboy lint --path \"/Users/chubes/Developer/data-machine@fix-wiki-source-date-attribution\" --extension wordpress --file \"inc/Abilities/Publish/PublishWordPressAbility.php\"`
- `homeboy lint --path \"/Users/chubes/Developer/data-machine@fix-wiki-source-date-attribution\" --extension wordpress --file \"inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php\"`
- `homeboy lint --path \"/Users/chubes/Developer/data-machine@fix-wiki-source-date-attribution\" --extension wordpress --file \"tests/content-format-abilities-smoke.php\"`
- `php tests/content-format-abilities-smoke.php`
- `php tests/upsert-handler-result-handoff-smoke.php`
- `php tests/wordpress-publish-content-format-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the wiki source/date attribution path, drafting the implementation and smoke coverage, and running local/live verification. Chris reviewed and directed the changes.