### PR TITLE
Support custom mode tool inheritance via filter

### DIFF
--- a/inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php
+++ b/inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php
@@ -41,15 +41,27 @@ final class DataMachineToolRegistrySource {
 				continue;
 			}
 
+			// Handler-wrapper tools belong to the adjacent-handler source.
+			// Skip them here regardless of mode so they cannot leak into
+			// the static-registry surface — including via mode inheritance.
+			if ( isset( $tool_config['_handler_callable'] ) ) {
+				continue;
+			}
+
 			if ( ToolPolicyResolver::MODE_PIPELINE === $mode && ToolPolicyResolver::isPipelinePolicyToolAllowed( $tool_config, $tool_name, $args ) ) {
 				$tool_config['modes'] = array_values( array_unique( array_merge( $tool_config['modes'], array( ToolPolicyResolver::MODE_PIPELINE ) ) ) );
 			}
 
-			if ( ToolPolicyResolver::MODE_PIPELINE === $mode ) {
-				if ( isset( $tool_config['_handler_callable'] ) ) {
-					continue;
-				}
+			// Tools admitted via mode inheritance get the current mode
+			// stamped onto their `modes` array. Downstream policy filters
+			// (notably Agents API's `filter_by_mode`) re-check tool modes
+			// against the runtime mode; without the rewrite, inherited
+			// tools would be filtered back out one layer up.
+			$tool_config['modes'] = array_values(
+				array_unique( array_merge( $tool_config['modes'] ?? array(), array( $mode ) ) )
+			);
 
+			if ( ToolPolicyResolver::MODE_PIPELINE === $mode ) {
 				if ( $this->tool_manager->is_tool_available( $tool_name, null ) ) {
 					$available_tools[ $tool_name ] = $tool_config;
 				}
@@ -76,21 +88,59 @@ final class DataMachineToolRegistrySource {
 	/**
 	 * Filter resolved tools by agent mode.
 	 *
+	 * Tools declare which modes they belong to via the `modes` key on
+	 * registration (e.g. `['chat', 'pipeline']`). By default a tool is
+	 * available to a request only when the request's mode appears in
+	 * that list verbatim.
+	 *
+	 * Extension plugins that register custom modes via `AgentModeRegistry`
+	 * can opt their mode into another mode's tool surface by hooking the
+	 * `datamachine_tool_mode_matchable_modes` filter. Returning
+	 * `['world', 'pipeline']` for the `world` mode, for example, makes
+	 * every tool registered for `pipeline` available to `world` runs as
+	 * well — without re-registering each tool. The default value is
+	 * `[$mode]` so existing behavior is unchanged for any mode that does
+	 * not opt in.
+	 *
 	 * @param array  $tools Resolved tools array.
 	 * @param string $mode  Mode slug to filter by.
+	 * @param array  $args  Resolution context passed through from the source.
 	 * @return array Filtered tools.
 	 */
 	private function filterByMode( array $tools, string $mode, array $args = array() ): array {
+		/**
+		 * Filter the modes a tool's `modes` array is matched against.
+		 *
+		 * Custom modes registered via `AgentModeRegistry` can declare
+		 * inheritance from a built-in mode by appending its slug to the
+		 * matchable list. Tools whose `modes` array intersects with the
+		 * matchable list become available to the current mode.
+		 *
+		 * Defaults to `[$mode]`, which preserves the historical exact-
+		 * match behavior. The filter is the seam custom modes use to
+		 * inherit tool surfaces without DM having to know about them.
+		 *
+		 * @since 0.113.0
+		 *
+		 * @param string[] $matchable Mode slugs to match tool `modes` against.
+		 * @param string   $mode      Current execution mode.
+		 * @param array    $args      Tool resolution context.
+		 */
+		$matchable = apply_filters( 'datamachine_tool_mode_matchable_modes', array( $mode ), $mode, $args );
+		if ( ! is_array( $matchable ) || empty( $matchable ) ) {
+			$matchable = array( $mode );
+		}
+
 		return array_filter(
 			$tools,
-			static function ( $tool, string $tool_name ) use ( $mode, $args ) {
+			static function ( $tool, string $tool_name ) use ( $mode, $matchable, $args ) {
 				$modes = $tool['modes'] ?? array();
 				if ( ToolPolicyResolver::MODE_PIPELINE === $mode
 					&& ToolPolicyResolver::isPipelinePolicyToolAllowed( $tool, $tool_name, $args ) ) {
 					return true;
 				}
 
-				return in_array( $mode, $modes, true );
+				return ! empty( array_intersect( $matchable, $modes ) );
 			},
 			ARRAY_FILTER_USE_BOTH
 		);

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -257,7 +257,46 @@ add_filter(
 );
 assert_source_equals( array( 'chat_static_tool' ), array_keys( resolve_source_tools( ToolPolicyResolver::MODE_CHAT, new SourcePolicyToolManager() ) ), 'legacy Data Machine tool-source filters are no longer mirrored', $failures, $passes );
 
-echo "\n[4] Data Machine source adapters own product vocabulary:\n";
+echo "\n[4] custom mode can inherit another mode's tool surface via filter:\n";
+remove_all_filters_for_source_smoke();
+assert_source_equals(
+	array( 'custom_static_tool' ),
+	array_keys( resolve_source_tools( 'custom_mode', new SourcePolicyToolManager() ) ),
+	'custom mode without filter still gets only custom-mode tools',
+	$failures,
+	$passes
+);
+add_filter(
+	'datamachine_tool_mode_matchable_modes',
+	static function ( array $matchable, string $mode ): array {
+		if ( 'custom_mode' === $mode ) {
+			$matchable[] = ToolPolicyResolver::MODE_PIPELINE;
+		}
+		return $matchable;
+	},
+	10,
+	2
+);
+$inherited = resolve_source_tools( 'custom_mode', new SourcePolicyToolManager() );
+assert_source_equals( true, isset( $inherited['custom_static_tool'] ), 'inheritance keeps custom mode\'s own tools', $failures, $passes );
+assert_source_equals( true, isset( $inherited['static_pipeline_tool'] ), 'inheritance from pipeline exposes pipeline-only tools to the custom mode', $failures, $passes );
+assert_source_equals( true, isset( $inherited['collision_tool'] ), 'pipeline tools registered for the inherited mode become available', $failures, $passes );
+assert_source_equals( false, isset( $inherited['chat_static_tool'] ), 'inheritance does not leak unrelated mode tools', $failures, $passes );
+assert_source_equals( false, isset( $inherited['handler_wrapper'] ), 'inherited custom mode still skips handler wrappers (non-pipeline source)', $failures, $passes );
+remove_all_filters_for_source_smoke();
+add_filter(
+	'datamachine_tool_mode_matchable_modes',
+	static function (): array {
+		return array();
+	},
+	10,
+	2
+);
+$null_filter = resolve_source_tools( 'custom_mode', new SourcePolicyToolManager() );
+assert_source_equals( array( 'custom_static_tool' ), array_keys( $null_filter ), 'empty filter return falls back to current mode', $failures, $passes );
+remove_all_filters_for_source_smoke();
+
+echo "\n[5] Data Machine source adapters own product vocabulary:\n";
 $registry_source          = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php' );
 $adjacent_source          = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php' );
 $datamachine_tool_source  = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php' );


### PR DESCRIPTION
## Summary

Adds `datamachine_tool_mode_matchable_modes`, a small filter in `DataMachineToolRegistrySource::filterByMode` that lets a custom `AgentModeRegistry` mode opt into another mode's tool surface without re-registering every tool. Tools admitted via inheritance get the current mode stamped onto their `modes` array on the way out, so downstream policy filters (notably Agents API's `filter_by_mode`) see them as native to the runtime mode.

This unblocks extension plugins that register their own execution modes (e.g. an upcoming `world` mode in `world-of-wordpress`) from having to either re-register every workspace/github tool against their mode or paper over the gap with a wrapper layer. Default behavior is unchanged for any mode that does not opt in.

## Why

Today, `DataMachineToolRegistrySource::filterByMode` requires an exact `in_array($mode, $tool['modes'], true)` match for a tool to be available to a given mode. Tools register with hardcoded mode lists like `['chat', 'pipeline']`, so any new mode registered via `AgentModeRegistry::register()` is silently denied access to the entire workspace and GitHub tool surface. The downstream consequence: a custom mode wakes with memory and directives but no hands.

The filter introduced here is the seam custom modes use to declare inheritance from a built-in mode (typically `pipeline`):

```php
add_filter(
    'datamachine_tool_mode_matchable_modes',
    static function ( array $matchable, string $mode ): array {
        if ( 'world' === $mode ) {
            $matchable[] = 'pipeline';
        }
        return $matchable;
    },
    10,
    2
);
```

After that one-liner, the `world` mode sees every tool registered for `pipeline` as available, with the tool's `modes` array transparently rewritten to include `'world'` so subsequent gates (Agents API, ToolPolicyResolver) treat the tool as native to the mode.

## Implementation

**`inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php`**
- Adds `apply_filters( 'datamachine_tool_mode_matchable_modes', [ $mode ], $mode, $args )` to compute the matchable mode set.
- Replaces `in_array( $mode, $modes, true )` with `! empty( array_intersect( $matchable, $modes ) )`.
- Stamps the current mode onto each admitted tool's `modes` array so downstream filters (e.g. Agents API's `filter_by_mode`) recognise the tool as native to the runtime mode.
- Hoists the `_handler_callable` skip out of the `MODE_PIPELINE === $mode` branch so adjacent-handler wrappers cannot leak into the static-registry surface for any mode (including inherited custom modes).
- Documents the filter and the rewrite in inline comments and the method docblock.

**`tests/tool-source-registry-smoke.php`**
- Extends with a `[4] custom mode can inherit another mode's tool surface via filter` section covering:
  - Custom mode without the filter still gets only its own tools (default behavior unchanged).
  - Inheritance from `pipeline` exposes pipeline-only tools to the custom mode.
  - The custom mode's own tools are preserved alongside inherited ones.
  - Inheritance does not leak unrelated mode tools (`chat_static_tool` stays out of the inherited custom mode).
  - Inherited custom modes still skip handler wrappers (the new universal `_handler_callable` skip).
  - Returning an empty filter array falls back to the current mode.

## Validation

- `php tests/tool-source-registry-smoke.php` — all 21 assertions pass.
- `homeboy test data-machine` — 1264 passed, 0 failed, 3 skipped (pre-existing).
- Spot-checked related smokes: `adjacent-handler-tool-policy-smoke.php`, `pipeline-tool-policy-surfaces-smoke.php`, `pipeline-tool-policy-snapshot-smoke.php`, `global-tool-pipeline-modes-smoke.php`, `duplicate-tool-call-mode-aware-smoke.php`, `directive-policy-resolver-smoke.php` — all pass.

## Backwards compatibility

- Existing behavior for `chat`, `pipeline`, `system` modes is unchanged: `apply_filters` returns `[$mode]` by default and `array_intersect([$mode], $tool_modes)` is equivalent to the original `in_array` check.
- The `_handler_callable` skip moving out of the `MODE_PIPELINE === $mode` branch tightens (rather than loosens) the contract: handler wrappers were already skipped in pipeline mode, and they were never expected to surface in `chat`/`system` because no tool registers a handler-wrapper against those modes. The change closes a latent leak that would have been triggered by the new inheritance path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Traced the mode-gate sites in DM and Agents API, designed the filter + rewrite approach to handle both gates with a single change in DM, drafted the implementation and the smoke extension. Chris specified the parallel-PR approach (DM upstream + world-of-wordpress consumer in lockstep) and required the upstream fix rather than a workaround in the consumer.