### PR TITLE
Preserve scheduled jobs during stuck recovery

### DIFF
--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -210,6 +210,17 @@ class RecoverStuckJobsAbility {
 			$job_id      = (int) $job->job_id;
 			$job_flow_id = (int) $job->flow_id;
 
+			if ( $this->hasActiveStepAction( $job_id ) ) {
+				++$skipped;
+				$jobs[] = array(
+					'job_id'  => $job_id,
+					'flow_id' => $job_flow_id,
+					'status'  => 'skipped',
+					'reason'  => 'Pending or in-progress Action Scheduler step action exists',
+				);
+				continue;
+			}
+
 			if ( $dry_run ) {
 				++$timed_out;
 				$jobs[] = array(
@@ -422,6 +433,52 @@ class RecoverStuckJobsAbility {
 		}
 
 		return $terminal_actions;
+	}
+
+	/**
+	 * Check whether Action Scheduler still owns executable work for a job.
+	 *
+	 * Pipeline jobs can stay in the `processing` state across multiple scheduled
+	 * steps. If a later `datamachine_execute_step` action is still pending or
+	 * in-progress, timeout recovery must not mark the job failed just because the
+	 * original job row is old.
+	 *
+	 * @param int $job_id Job ID.
+	 * @return bool True when a pending/in-progress step action exists.
+	 */
+	private function hasActiveStepAction( int $job_id ): bool {
+		global $wpdb;
+
+		if ( $job_id <= 0 ) {
+			return false;
+		}
+
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$like_job_id   = '%"job_id":' . $wpdb->esc_like( (string) $job_id ) . '%';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
+		$actions = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT action_id, args
+				 FROM {$actions_table}
+				 WHERE hook = %s
+				 AND status IN ( %s, %s )
+				 AND args LIKE %s",
+				'datamachine_execute_step',
+				'pending',
+				'in-progress',
+				$like_job_id
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		foreach ( $actions as $action ) {
+			if ( $job_id === $this->extractActionJobId( (string) ( $action->args ?? '' ) ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/recover-stuck-active-action-guard-smoke.php
+++ b/tests/recover-stuck-active-action-guard-smoke.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Static smoke test for recover-stuck active Action Scheduler guard.
+ *
+ * Run with: php tests/recover-stuck-active-action-guard-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failed = 0;
+$total  = 0;
+
+function assert_recover_stuck_guard_smoke( string $name, bool $condition, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+
+	if ( $condition ) {
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+
+	echo "  [FAIL] {$name}" . ( $detail ? " - {$detail}" : '' ) . "\n";
+	++$failed;
+}
+
+$source = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RecoverStuckJobsAbility.php' ) ?: '';
+$timeout_loop = strstr( $source, 'foreach ( $timed_out_jobs as $job )' ) ?: '';
+
+echo "Case 1: timed-out recovery skips jobs with active step actions\n";
+assert_recover_stuck_guard_smoke( 'active step guard method exists', str_contains( $source, 'private function hasActiveStepAction' ) );
+assert_recover_stuck_guard_smoke( 'timeout loop invokes active step guard before dry-run timeout', strpos( $timeout_loop, '$this->hasActiveStepAction( $job_id )' ) < strpos( $timeout_loop, 'if ( $dry_run )' ) );
+assert_recover_stuck_guard_smoke( 'guard records skipped status', str_contains( $source, "'status'  => 'skipped'") && str_contains( $source, 'Pending or in-progress Action Scheduler step action exists' ) );
+
+echo "Case 2: guard is limited to executable Data Machine step actions\n";
+assert_recover_stuck_guard_smoke( 'guard queries datamachine_execute_step', str_contains( $source, 'datamachine_execute_step' ) );
+assert_recover_stuck_guard_smoke( 'guard checks pending and in-progress actions', str_contains( $source, "'pending'") && str_contains( $source, "'in-progress'") );
+assert_recover_stuck_guard_smoke( 'guard confirms exact job id from action args', str_contains( $source, '$this->extractActionJobId' ) );
+
+echo "\nRecover-stuck active action guard smoke complete: {$total} assertions, {$failed} failures.\n";
+if ( $failed > 0 ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Skips timeout recovery for old `processing` jobs when a matching pending or in-progress `datamachine_execute_step` Action Scheduler action still exists.
- Adds a smoke test covering the active Action Scheduler guard so recovery does not fail jobs that are still scheduled to continue.

## Evidence
- Live WP Cloud scale run showed `recover-stuck --dry-run` would timeout old `processing` jobs even though matching pending `datamachine_execute_step` actions still existed.
- Sample aggregate: 31 `processing` jobs older than 2 hours, 30 with pending Action Scheduler step actions.

## Verification
- `php -l inc/Abilities/Job/RecoverStuckJobsAbility.php`
- `php -l tests/recover-stuck-active-action-guard-smoke.php`
- `php tests/recover-stuck-active-action-guard-smoke.php`
- `vendor/bin/phpcs inc/Abilities/Job/RecoverStuckJobsAbility.php tests/recover-stuck-active-action-guard-smoke.php`
- `git diff --check`
- `homeboy test --path "/Users/chubes/Developer/data-machine@fix-recover-stuck-pending-actions" --extension wordpress -- tests/recover-stuck-active-action-guard-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the WP Cloud queue state, implemented the recovery guard, added the smoke test, and prepared this PR description. Chris remains responsible for review and merge.