### PR TITLE
Pipeline-policy tools follow pipeline mode inheritance

### DIFF
--- a/inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php
+++ b/inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php
@@ -32,9 +32,12 @@ final class DataMachineToolRegistrySource {
 	 * @return array Tools keyed by tool name.
 	 */
 	public function __invoke( string $mode, array $args = array() ): array {
-		$available_tools = array();
-		$all_tools       = $this->tool_manager->get_all_tools();
-		$mode_tools      = $this->filterByMode( $all_tools, $mode, $args );
+		$available_tools   = array();
+		$all_tools         = $this->tool_manager->get_all_tools();
+		$matchable         = self::resolveMatchableModes( $mode, $args );
+		$mode_tools        = $this->filterByMode( $all_tools, $matchable, $args );
+		$is_pipeline_mode  = ToolPolicyResolver::MODE_PIPELINE === $mode;
+		$inherits_pipeline = in_array( ToolPolicyResolver::MODE_PIPELINE, $matchable, true );
 
 		foreach ( $mode_tools as $tool_name => $tool_config ) {
 			if ( ! is_array( $tool_config ) || empty( $tool_config ) ) {
@@ -48,7 +51,12 @@ final class DataMachineToolRegistrySource {
 				continue;
 			}
 
-			if ( ToolPolicyResolver::MODE_PIPELINE === $mode && ToolPolicyResolver::isPipelinePolicyToolAllowed( $tool_config, $tool_name, $args ) ) {
+			// Pipeline-policy tools (durable memory writes, etc.) opt into
+			// pipeline runs by being explicitly listed in the flow's
+			// allow_only / enabled_tools. They should activate whenever the
+			// run is reachable from `pipeline` — either directly or through
+			// a custom mode that inherits from `pipeline`.
+			if ( $inherits_pipeline && ToolPolicyResolver::isPipelinePolicyToolAllowed( $tool_config, $tool_name, $args ) ) {
 				$tool_config['modes'] = array_values( array_unique( array_merge( $tool_config['modes'], array( ToolPolicyResolver::MODE_PIPELINE ) ) ) );
 			}
 
@@ -61,7 +69,11 @@ final class DataMachineToolRegistrySource {
 				array_unique( array_merge( $tool_config['modes'] ?? array(), array( $mode ) ) )
 			);
 
-			if ( ToolPolicyResolver::MODE_PIPELINE === $mode ) {
+			// Pipeline-shaped runs (direct or inherited) take the
+			// availability-only gate: pipeline-policy tools are admitted
+			// without per-tool config checks because their inclusion was
+			// already authorized by the flow's allow_only list.
+			if ( $is_pipeline_mode || $inherits_pipeline ) {
 				if ( $this->tool_manager->is_tool_available( $tool_name, null ) ) {
 					$available_tools[ $tool_name ] = $tool_config;
 				}
@@ -107,7 +119,21 @@ final class DataMachineToolRegistrySource {
 	 * @param array  $args  Resolution context passed through from the source.
 	 * @return array Filtered tools.
 	 */
-	private function filterByMode( array $tools, string $mode, array $args = array() ): array {
+	/**
+	 * Resolve the modes a tool's `modes` array is matched against.
+	 *
+	 * Custom modes registered via `AgentModeRegistry` can declare
+	 * inheritance from a built-in mode by appending its slug to the
+	 * matchable list via `datamachine_tool_mode_matchable_modes`. Tools
+	 * whose `modes` array intersects with the resolved matchable list
+	 * become available to the current mode. Defaults to `[$mode]`, which
+	 * preserves the historical exact-match behavior.
+	 *
+	 * @param string $mode Current execution mode.
+	 * @param array  $args Tool resolution context.
+	 * @return string[]    Mode slugs to match tool `modes` against.
+	 */
+	private static function resolveMatchableModes( string $mode, array $args ): array {
 		/**
 		 * Filter the modes a tool's `modes` array is matched against.
 		 *
@@ -127,16 +153,37 @@ final class DataMachineToolRegistrySource {
 		 * @param array    $args      Tool resolution context.
 		 */
 		$matchable = apply_filters( 'datamachine_tool_mode_matchable_modes', array( $mode ), $mode, $args );
+
 		if ( ! is_array( $matchable ) || empty( $matchable ) ) {
-			$matchable = array( $mode );
+			return array( $mode );
 		}
+
+		return $matchable;
+	}
+
+	/**
+	 * Filter resolved tools by agent mode using the resolved matchable set.
+	 *
+	 * Pipeline-policy tools (e.g. `agent_daily_memory`) register against
+	 * the synthetic `pipeline_policy` mode. They opt into a run only when
+	 * the run is reachable from `pipeline` AND the tool is named in
+	 * `allow_only`. This keeps powerful-but-automatable tools behind an
+	 * explicit allowlist instead of being unconditionally inherited.
+	 *
+	 * @param array $tools     Resolved tools array.
+	 * @param array $matchable Mode slugs to match tool `modes` against.
+	 * @param array $args      Resolution context (used for pipeline-policy allow_only).
+	 * @return array Filtered tools.
+	 */
+	private function filterByMode( array $tools, array $matchable, array $args ): array {
+		$inherits_pipeline = in_array( ToolPolicyResolver::MODE_PIPELINE, $matchable, true );
 
 		return array_filter(
 			$tools,
-			static function ( $tool, string $tool_name ) use ( $mode, $matchable, $args ) {
+			static function ( $tool, string $tool_name ) use ( $matchable, $args, $inherits_pipeline ) {
 				$modes = $tool['modes'] ?? array();
-				if ( ToolPolicyResolver::MODE_PIPELINE === $mode
-					&& ToolPolicyResolver::isPipelinePolicyToolAllowed( $tool, $tool_name, $args ) ) {
+
+				if ( $inherits_pipeline && ToolPolicyResolver::isPipelinePolicyToolAllowed( $tool, $tool_name, $args ) ) {
 					return true;
 				}
 

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -102,6 +102,7 @@ class SourcePolicyToolManager extends ToolManager {
 			'custom_static_tool'   => array( 'modes' => array( 'custom_mode' ), 'origin' => 'static' ),
 			'handler_wrapper'      => array( 'modes' => array( 'pipeline' ), '_handler_callable' => 'noop' ),
 			'disabled_static_tool' => array( 'modes' => array( 'chat' ), 'origin' => 'static', 'access_level' => 'public' ),
+			'durable_memory_tool'  => array( 'modes' => array( 'chat', 'pipeline_policy' ), 'origin' => 'static', 'access_level' => 'public' ),
 		);
 	}
 
@@ -197,7 +198,7 @@ assert_source_equals( array( 'ticketmaster_fetch:previous:fetch_step', 'publish_
 
 echo "\n[2] non-pipeline modes use static registry only:\n";
 $manager = new SourcePolicyToolManager();
-assert_source_equals( array( 'chat_static_tool' ), array_keys( resolve_source_tools( ToolPolicyResolver::MODE_CHAT, $manager ) ), 'chat mode gets static chat tools only', $failures, $passes );
+assert_source_equals( array( 'chat_static_tool', 'durable_memory_tool' ), array_keys( resolve_source_tools( ToolPolicyResolver::MODE_CHAT, $manager ) ), 'chat mode gets static chat tools only', $failures, $passes );
 assert_source_equals( array(), $manager->handler_calls, 'chat mode does not query adjacent handlers', $failures, $passes );
 assert_source_equals( array( 'system_static_tool' ), array_keys( resolve_source_tools( ToolPolicyResolver::MODE_SYSTEM, new SourcePolicyToolManager() ) ), 'system mode gets static system tools only', $failures, $passes );
 assert_source_equals( array( 'custom_static_tool' ), array_keys( resolve_source_tools( 'custom_mode', new SourcePolicyToolManager() ) ), 'custom mode gets static custom-mode tools only', $failures, $passes );
@@ -231,7 +232,7 @@ add_filter(
 	3
 );
 $tools = resolve_source_tools( ToolPolicyResolver::MODE_CHAT, new SourcePolicyToolManager() );
-assert_source_equals( array( 'chat_static_tool', 'extra_tool' ), array_keys( $tools ), 'filter appends extra source after static source', $failures, $passes );
+assert_source_equals( array( 'chat_static_tool', 'durable_memory_tool', 'extra_tool' ), array_keys( $tools ), 'filter appends extra source after static source', $failures, $passes );
 remove_all_filters_for_source_smoke();
 add_filter(
 	'datamachine_tool_sources',
@@ -255,7 +256,7 @@ add_filter(
 	10,
 	1
 );
-assert_source_equals( array( 'chat_static_tool' ), array_keys( resolve_source_tools( ToolPolicyResolver::MODE_CHAT, new SourcePolicyToolManager() ) ), 'legacy Data Machine tool-source filters are no longer mirrored', $failures, $passes );
+assert_source_equals( array( 'chat_static_tool', 'durable_memory_tool' ), array_keys( resolve_source_tools( ToolPolicyResolver::MODE_CHAT, new SourcePolicyToolManager() ) ), 'legacy Data Machine tool-source filters are no longer mirrored', $failures, $passes );
 
 echo "\n[4] custom mode can inherit another mode's tool surface via filter:\n";
 remove_all_filters_for_source_smoke();
@@ -296,7 +297,50 @@ $null_filter = resolve_source_tools( 'custom_mode', new SourcePolicyToolManager(
 assert_source_equals( array( 'custom_static_tool' ), array_keys( $null_filter ), 'empty filter return falls back to current mode', $failures, $passes );
 remove_all_filters_for_source_smoke();
 
-echo "\n[5] Data Machine source adapters own product vocabulary:\n";
+echo "\n[5] pipeline_policy tools follow pipeline inheritance:\n";
+remove_all_filters_for_source_smoke();
+$pipeline_policy_baseline = resolve_source_tools(
+	ToolPolicyResolver::MODE_PIPELINE,
+	new SourcePolicyToolManager(),
+	array( 'allow_only' => array( 'durable_memory_tool' ) )
+);
+assert_source_equals( true, isset( $pipeline_policy_baseline['durable_memory_tool'] ), 'pipeline mode picks up policy-gated tool when allowlisted', $failures, $passes );
+$pipeline_policy_no_allowlist = resolve_source_tools(
+	ToolPolicyResolver::MODE_PIPELINE,
+	new SourcePolicyToolManager()
+);
+assert_source_equals( false, isset( $pipeline_policy_no_allowlist['durable_memory_tool'] ), 'pipeline mode skips policy-gated tool without allowlist', $failures, $passes );
+add_filter(
+	'datamachine_tool_mode_matchable_modes',
+	static function ( array $matchable, string $mode ): array {
+		if ( 'custom_mode' === $mode ) {
+			$matchable[] = ToolPolicyResolver::MODE_PIPELINE;
+		}
+		return $matchable;
+	},
+	10,
+	2
+);
+$inherited_policy = resolve_source_tools(
+	'custom_mode',
+	new SourcePolicyToolManager(),
+	array( 'allow_only' => array( 'durable_memory_tool' ) )
+);
+assert_source_equals( true, isset( $inherited_policy['durable_memory_tool'] ), 'custom mode that inherits pipeline picks up policy-gated tool when allowlisted', $failures, $passes );
+$inherited_policy_no_allowlist = resolve_source_tools(
+	'custom_mode',
+	new SourcePolicyToolManager()
+);
+assert_source_equals( false, isset( $inherited_policy_no_allowlist['durable_memory_tool'] ), 'custom mode that inherits pipeline still skips policy-gated tool without allowlist', $failures, $passes );
+remove_all_filters_for_source_smoke();
+$chat_no_inheritance = resolve_source_tools(
+	ToolPolicyResolver::MODE_CHAT,
+	new SourcePolicyToolManager(),
+	array( 'allow_only' => array( 'durable_memory_tool' ) )
+);
+assert_source_equals( true, isset( $chat_no_inheritance['durable_memory_tool'] ), 'chat mode keeps direct access to its own pipeline_policy tool entry', $failures, $passes );
+
+echo "\n[6] Data Machine source adapters own product vocabulary:\n";
 $registry_source          = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php' );
 $adjacent_source          = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php' );
 $datamachine_tool_source  = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php' );


### PR DESCRIPTION
## Summary

Pipeline-policy tools (e.g. `agent_daily_memory`, registered against the synthetic `pipeline_policy` mode) were only admitted when the runtime mode was literally `MODE_PIPELINE`. Custom modes that opted into pipeline's tool surface via [#2016](https://github.com/Extra-Chill/data-machine/pull/2016)'s `datamachine_tool_mode_matchable_modes` filter still hit the literal short-circuit and lost access to those tools — including `agent_daily_memory`, which any flow's `completion_assertions` can require.

This PR makes the pipeline-policy gate honor inheritance: a custom mode that inherits from `pipeline` picks up policy-gated tools the same way pipeline runs do, with the `allow_only` opt-in still in place.

## Why this is a follow-up to #2016

Without this fix, a custom mode that inherits from `pipeline` can use workspace and GitHub tools (because their `modes` arrays are intersected against the matchable set) but cannot use any tool registered under `pipeline_policy`. Concretely, the new `world` mode in `world-of-wordpress` requires `agent_daily_memory` for completion and was failing every cycle with `completion_required_tool_unavailable`.

The first PR added the inheritance seam. This PR extends it through the pipeline-policy gate so the seam is actually whole.

## Implementation

**`inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php`**
- Pulled the matchable-mode resolution into a private static helper (`resolveMatchableModes`) so `__invoke` and `filterByMode` share one source of truth instead of recomputing.
- Refactored `__invoke` to compute the matchable set once, derive `$inherits_pipeline = in_array(MODE_PIPELINE, $matchable, true)`, and use that flag everywhere the old `MODE_PIPELINE === $mode` short-circuit was load-bearing:
  - The pipeline-policy mode rewrite (so policy-gated tools get `pipeline` stamped onto their modes when inherited).
  - The pipeline-shaped availability gate (no `requires_config` ceremony, just `is_tool_available`).
- Reframed `filterByMode` to take the precomputed matchable set and `$args`, and to consult `isPipelinePolicyToolAllowed` whenever `pipeline` is reachable — direct or inherited.

**`tests/tool-source-registry-smoke.php`**
- Adds `durable_memory_tool` (modes `['chat', 'pipeline_policy']`) to the manager fixture so the new behavior has something to test against.
- Adds section [5] covering:
  - pipeline mode picks up the policy-gated tool when allowlisted
  - pipeline mode skips the policy-gated tool without an allowlist (gate intact)
  - custom mode inheriting from pipeline picks up the policy-gated tool when allowlisted (the new behavior)
  - custom mode inheriting from pipeline still respects the allowlist gate
  - chat mode keeps direct access to its own `pipeline_policy`-mode tool entry
- Updates [2] and [3] expectations to include the new fixture entry, since `durable_memory_tool` registers under `chat` too.

## Validation

- `php tests/tool-source-registry-smoke.php` — all 26 assertions pass.
- `homeboy test data-machine` — 1264 passed, 0 failed, 3 skipped (pre-existing).

## Backwards compatibility

- Pipeline mode behavior is unchanged: the same tools that were admitted before are still admitted, with the same `allow_only` gate.
- Chat and system modes are unchanged.
- Custom modes without inheritance are unchanged.
- Custom modes that inherit from pipeline gain access to pipeline-policy tools when the flow allowlists them — the new and intended behavior.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Diagnosed the `completion_required_tool_unavailable` failure on the first world-mode run, traced it back to the pipeline-policy gate's literal mode comparison being stronger than the inheritance filter, refactored the matchable-mode resolution to a single source of truth, extended smoke coverage. Chris specified the urgency: world cycles are blocked on this until it merges and propagates.