### PR TITLE
Support multi-mode AI runs

### DIFF
--- a/docs/architecture/policy-resolvers.md
+++ b/docs/architecture/policy-resolvers.md
@@ -59,15 +59,16 @@ Resolution concepts:
 
 Adjacent handler tools are different from optional/static tools. They come from the previous and next pipeline steps and represent the workflow's required flow plumbing. They are gathered by `AdjacentHandlerToolSource` before generic policy filtering and are protected by Data Machine's mandatory-tool policy where appropriate. A required adjacent publish/upsert handler with no callable AI tool fails before the model call; request inspection reports the same missing-handler state.
 
-### Pipeline Policy-Gated Tools
+### Opt-In Tools
 
-Some tools are safe for chat but too powerful for default pipeline exposure. They declare `pipeline_policy` mode instead of `pipeline` mode.
+Some tools are too powerful for default exposure but are still valid in their real modes. They declare those real modes plus `requires_opt_in`.
 
 ```php
-'modes' => array( 'chat', ToolPolicyResolver::MODE_PIPELINE_POLICY )
+'modes' => array( 'chat', ToolPolicyResolver::MODE_PIPELINE ),
+'requires_opt_in' => true,
 ```
 
-`DataMachineToolRegistrySource` includes such a tool in a pipeline request only when `ToolPolicyResolver::isPipelinePolicyToolAllowed()` sees the tool name in `allow_only`. In practice, that means the flow-step snapshot's `enabled_tools` list opted in.
+`DataMachineToolRegistrySource` includes such a tool only when `ToolPolicyResolver::isOptInToolAllowed()` sees the tool name in `allow_only`. In practice, that means the flow-step snapshot's `enabled_tools` list opted in.
 
 ### Pipeline Disabled Tools
 

--- a/docs/core-filters.md
+++ b/docs/core-filters.md
@@ -180,6 +180,6 @@ Central registry for execution modes. Extensions register modes; the settings UI
 **Since:** 0.68.0  
 **Priority:** 22
 
-Injects execution-mode guidance as a runtime directive. Reads `$payload['agent_mode']` and emits one `system_text` output with composed content.
+Injects execution-mode guidance as a runtime directive. Reads `$payload['agent_modes']` and emits one `system_text` output with composed content for every active mode.
 
-Built-in defaults for `chat`, `pipeline`, and `system` are shipped as class constants. Custom modes (e.g. `editor`, `bridge`) provide their content exclusively via the `datamachine_agent_mode_{slug}` filter.
+Built-in defaults for `chat`, `pipeline`, and `system` are shipped as class constants. Custom modes (e.g. `editor`, `bridge`) provide their content via the `datamachine_agent_mode_{slug}` filter and can be additive with other active modes.

--- a/docs/core-system/ai-directives.md
+++ b/docs/core-system/ai-directives.md
@@ -95,7 +95,7 @@ Injects execution-mode guidance (chat, pipeline, system) as a runtime directive 
 
 **Extension hook**: `datamachine_agent_mode_{slug}` — extensions can append or modify mode-specific guidance for a given mode (e.g. the editor plugin appends diff workflow instructions when the `editor` mode is active).
 
-**Payload key**: Reads `agent_mode` from the request payload.
+**Payload key**: Reads `agent_modes` from the request payload and composes guidance once for each active mode.
 
 ### CallerContextDirective (Priority 25)
 

--- a/docs/core-system/prompt-builder.md
+++ b/docs/core-system/prompt-builder.md
@@ -104,7 +104,7 @@ $promptBuilder->setMessages($messages)
               ->setTools($structured_tools);
 
 // Apply directives via PromptBuilder
-$request = $promptBuilder->build($agent_mode, $provider, $context);
+$request = $promptBuilder->build($agent_modes, $provider, $context);
 ```
 
 ## Migration from Legacy System

--- a/docs/core-system/tool-manager.md
+++ b/docs/core-system/tool-manager.md
@@ -135,9 +135,8 @@ Tool definitions declare the request modes that may see them:
 | `pipeline` | `ToolPolicyResolver::MODE_PIPELINE` | Automated AI pipeline steps. Includes adjacent handler tools plus static registry tools explicitly marked for pipeline. |
 | `chat` | `ToolPolicyResolver::MODE_CHAT` | User-present chat sessions. Runs the chat access gate and ability permission checks. |
 | `system` | `ToolPolicyResolver::MODE_SYSTEM` | Background/system jobs with a small explicit tool set. |
-| `pipeline_policy` | `ToolPolicyResolver::MODE_PIPELINE_POLICY` | Opt-in marker for tools hidden from pipeline by default but grantable through pipeline tool policy. |
 
-`pipeline_policy` does not expose a tool by itself. A pipeline request must also include the tool in `allow_only`, usually from `enabled_tools` in the flow-step snapshot.
+Runtime requests may activate multiple modes at once, for example `['pipeline', 'world']`. A tool is eligible when its declared `modes` intersects with any active mode. Powerful tools can add `requires_opt_in => true`; those tools must also appear in `allow_only`, usually from `enabled_tools` in the flow-step snapshot.
 
 ## Availability Checks
 
@@ -172,7 +171,7 @@ Pipeline AI steps build resolver policy args from the workflow snapshot through 
 
 | Config key | Resolver arg | Effect |
 |---|---|---|
-| `enabled_tools` on the flow step | `allow_only` | Narrows optional/static tools to the listed names and grants matching `pipeline_policy` tools. |
+| `enabled_tools` on the flow step | `allow_only` | Narrows optional/static tools to the listed names and grants matching `requires_opt_in` tools. |
 | `disabled_tools` on the pipeline step | `deny` | Removes listed tools. |
 | `disabled_tools` on the flow step | `deny` | Removes listed tools. |
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -376,7 +376,7 @@ $ai_response = RequestBuilder::build(
     $provider,      // AI provider name
     $model,         // Model identifier
     $tools,         // Raw tools array from filters
-    $agent_mode,    // 'chat', 'pipeline', 'system', or extension mode
+    $agent_modes,   // ['chat'], ['pipeline', 'world'], etc.
     $context        // Agent-specific context
 );
 ```

--- a/docs/development/hooks/engine-filters.md
+++ b/docs/development/hooks/engine-filters.md
@@ -58,7 +58,7 @@ $content = apply_filters( "datamachine_agent_mode_{$mode}", $default_content, $p
 **Parameters**:
 
 - `$default_content` (string) — Built-in guidance for that mode (or empty for unregistered modes).
-- `$payload` (array) — Full request payload (`agent_id`, `user_id`, `agent_mode`, etc.).
+- `$payload` (array) — Full request payload (`agent_id`, `user_id`, `agent_modes`, etc.).
 
 **Return**: Modified guidance text. Returning an empty string suppresses the directive.
 
@@ -81,7 +81,7 @@ Tools are registered via a single unified filter. Per-mode tool partitioning is 
 
 ### datamachine_tools
 
-Single Data Machine registry for AI tools. `ToolManager` reads this registry, `ToolSourceRegistry` composes source pools, and `ToolPolicyResolver::resolve()` assembles the final request-visible tool set for a mode.
+Single Data Machine registry for AI tools. `ToolManager` reads this registry, `ToolSourceRegistry` composes source pools, and `ToolPolicyResolver::resolve()` assembles the final request-visible tool set for active modes.
 
 **Hook usage**:
 
@@ -134,7 +134,7 @@ add_filter( 'datamachine_tools', function ( $tools ) {
 } );
 ```
 
-Use `pipeline` mode only when a static registry tool is useful inside an automated pipeline AI step. Use `pipeline_policy` for powerful tools that should stay hidden from pipeline by default but can be explicitly granted through `enabled_tools`. Chat affordances and tools that duplicate engine-level validation should stay `chat`-only; pipeline AI steps already receive adjacent handler tools plus pipeline/flow memory directives.
+Use `pipeline` mode only when a static registry tool is useful inside an automated pipeline AI step. Add `requires_opt_in => true` for powerful tools that should stay hidden by default but can be explicitly granted through `enabled_tools`. Chat affordances and tools that duplicate engine-level validation should stay `chat`-only; pipeline AI steps already receive adjacent handler tools plus pipeline/flow memory directives.
 
 > Earlier per-mode tool filters were consolidated into `datamachine_tools` in v0.68.0 (PR #1130). Register current tools through the unified registry and declare `modes` on the tool definition.
 

--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -11,6 +11,7 @@ use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Api\Chat\ChatOrchestrator;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\PluginSettings;
+use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 use WP_Error;
 
 defined( 'ABSPATH' ) || exit;
@@ -89,12 +90,13 @@ class AgentsChatHandler {
 		}
 
 		$client_context = is_array( $input['client_context'] ?? null ) ? $input['client_context'] : array();
-		$mode           = $this->resolveMode( $input, $client_context );
-		$agent_config   = PluginSettings::resolveModelForAgentMode( 0 === $agent_id ? null : $agent_id, $mode );
+		$modes          = $this->resolveModes( $input, $client_context );
+		$mode           = implode( ',', $modes );
+		$agent_config   = $this->resolveModelForModes( 0 === $agent_id ? null : $agent_id, $modes );
 		$provider       = $agent_config['provider'];
 		$model          = $agent_config['model'];
 
-		if ( '' === $model && 'chat' !== $mode ) {
+		if ( '' === $model && ! in_array( 'chat', $modes, true ) ) {
 			$chat_config = PluginSettings::resolveModelForAgentMode( 0 === $agent_id ? null : $agent_id, 'chat' );
 			$provider    = '' === $provider ? $chat_config['provider'] : $provider;
 			$model       = $chat_config['model'];
@@ -115,7 +117,7 @@ class AgentsChatHandler {
 			$user_id,
 			array(
 				'session_id'     => $input['session_id'] ?? null,
-				'mode'           => $mode,
+				'modes'          => $modes,
 				'agent_id'       => $agent_id,
 				'attachments'    => $input['attachments'] ?? array(),
 				'client_context' => $client_context,
@@ -188,17 +190,41 @@ class AgentsChatHandler {
 	}
 
 	/**
-	 * Resolve the Data Machine execution mode from canonical Agents API input.
+	 * Resolve the Data Machine execution modes from canonical Agents API input.
 	 *
 	 * @param array $input Canonical agents/chat input.
 	 * @param array $client_context Transport-level client context.
-	 * @return string Sanitized mode slug.
+	 * @return array<int,string> Sanitized mode slugs.
 	 */
-	private function resolveMode( array $input, array $client_context ): string {
-		$mode = $input['mode'] ?? $client_context['agent_mode'] ?? $client_context['mode'] ?? 'chat';
-		$mode = sanitize_key( (string) $mode );
+	private function resolveModes( array $input, array $client_context ): array {
+		$modes = $input['modes'] ?? $client_context['agent_modes'] ?? null;
+		if ( ! is_array( $modes ) || empty( $modes ) ) {
+			$modes = array( $input['mode'] ?? $client_context['mode'] ?? 'chat' );
+		}
 
-		return '' !== $mode ? $mode : 'chat';
+		return ToolPolicyResolver::normalizeModes( $modes );
+	}
+
+	/**
+	 * Resolve a model for the first configured active mode.
+	 *
+	 * @param int|null $agent_id Agent ID.
+	 * @param array    $modes    Active modes.
+	 * @return array{provider:string,model:string}
+	 */
+	private function resolveModelForModes( ?int $agent_id, array $modes ): array {
+		$fallback = array( 'provider' => '', 'model' => '' );
+		foreach ( $modes as $mode ) {
+			$config = PluginSettings::resolveModelForAgentMode( $agent_id, $mode );
+			if ( '' !== $config['provider'] && '' !== $config['model'] ) {
+				return $config;
+			}
+			if ( '' === $fallback['provider'] && '' === $fallback['model'] ) {
+				$fallback = $config;
+			}
+		}
+
+		return $fallback;
 	}
 
 	/**

--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -213,7 +213,10 @@ class AgentsChatHandler {
 	 * @return array{provider:string,model:string}
 	 */
 	private function resolveModelForModes( ?int $agent_id, array $modes ): array {
-		$fallback = array( 'provider' => '', 'model' => '' );
+		$fallback = array(
+			'provider' => '',
+			'model'    => '',
+		);
 		foreach ( $modes as $mode ) {
 			$config = PluginSettings::resolveModelForAgentMode( $agent_id, $mode );
 			if ( '' !== $config['provider'] && '' !== $config['model'] ) {

--- a/inc/Abilities/Media/ImageGenerationAbilities.php
+++ b/inc/Abilities/Media/ImageGenerationAbilities.php
@@ -382,7 +382,7 @@ class ImageGenerationAbilities {
 			$provider,
 			$model,
 			array(), // No tools needed for prompt refinement.
-			'system',
+			array( 'system' ),
 			array( 'purpose' => 'image_prompt_refinement' )
 		);
 

--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -153,7 +153,7 @@ class PipelineStepAbilities {
 			'datamachine/update-pipeline-step',
 			array(
 				'label'               => __( 'Update Pipeline Step', 'data-machine' ),
-				'description'         => __( 'Update pipeline step configuration (system prompt, AI execution mode, and AI tool policy). Model/provider are configured via mode_models setting.', 'data-machine' ),
+				'description'         => __( 'Update pipeline step configuration (system prompt, AI execution modes, and AI tool policy). Model/provider are configured via mode_models setting.', 'data-machine' ),
 				'category'            => 'datamachine-pipeline',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -167,9 +167,10 @@ class PipelineStepAbilities {
 							'type'        => 'string',
 							'description' => __( 'System prompt for AI step', 'data-machine' ),
 						),
-						'agent_mode'       => array(
-							'type'        => 'string',
-							'description' => __( 'Agent execution mode for this AI step. Defaults to pipeline.', 'data-machine' ),
+						'agent_modes'      => array(
+							'type'        => 'array',
+							'description' => __( 'Agent execution modes for this AI step. Defaults to pipeline.', 'data-machine' ),
+							'items'       => array( 'type' => 'string' ),
 						),
 						'disabled_tools'   => array(
 							'type'        => 'array',
@@ -535,7 +536,7 @@ class PipelineStepAbilities {
 		}
 
 		$system_prompt = $input['system_prompt'] ?? null;
-		$agent_mode    = $input['agent_mode'] ?? null;
+		$agent_modes   = $input['agent_modes'] ?? null;
 		$policy_fields = array( 'disabled_tools', 'tool_categories' );
 
 		// provider/model are no longer configurable at the pipeline step level.
@@ -549,10 +550,10 @@ class PipelineStepAbilities {
 			}
 		}
 
-		if ( null === $system_prompt && null === $agent_mode && ! $has_policy_field ) {
+		if ( null === $system_prompt && null === $agent_modes && ! $has_policy_field ) {
 			return array(
 				'success' => false,
-				'error'   => 'At least one of system_prompt, agent_mode, disabled_tools, or tool_categories is required',
+				'error'   => 'At least one of system_prompt, agent_modes, disabled_tools, or tool_categories is required',
 			);
 		}
 
@@ -586,9 +587,16 @@ class PipelineStepAbilities {
 			$updated_fields[]                  = 'system_prompt';
 		}
 
-		if ( null !== $agent_mode ) {
-			$step_config_data['agent_mode'] = sanitize_key( (string) $agent_mode );
-			$updated_fields[]               = 'agent_mode';
+		if ( null !== $agent_modes ) {
+			$sanitized_modes = self::sanitizeStringListField( $agent_modes, 'agent_modes' );
+			if ( is_wp_error( $sanitized_modes ) ) {
+				return array(
+					'success' => false,
+					'error'   => $sanitized_modes->get_error_message(),
+				);
+			}
+			$step_config_data['agent_modes'] = $sanitized_modes;
+			$updated_fields[]                = 'agent_modes';
 		}
 
 		foreach ( $policy_fields as $field ) {

--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -865,7 +865,7 @@ class SystemAbilities {
 				$provider,
 				$model,
 				array(), // No tools for title generation
-				'system', // Agent type
+				array( 'system' ), // Agent modes
 				array() // No payload needed
 			);
 

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -67,7 +67,8 @@ class ChatOrchestrator {
 		$request_id           = $options['request_id'] ?? null;
 		$agent_id             = (int) ( $options['agent_id'] ?? 0 );
 		$agent_slug           = (string) ( $options['agent_slug'] ?? '' );
-		$mode                 = ! empty( $options['mode'] ) ? sanitize_key( (string) $options['mode'] ) : ToolPolicyResolver::MODE_CHAT;
+		$modes                = ToolPolicyResolver::normalizeModes( ! empty( $options['modes'] ) ? $options['modes'] : array( $options['mode'] ?? ToolPolicyResolver::MODE_CHAT ) );
+		$mode                 = implode( ',', $modes );
 
 		$chat_db                     = ConversationStoreFactory::get();
 		$session_metadata            = array();
@@ -515,7 +516,7 @@ class ChatOrchestrator {
 			$provider,
 			$model,
 			array(
-				'mode'    => ToolPolicyResolver::MODE_CHAT,
+				'modes'   => array( ToolPolicyResolver::MODE_CHAT ),
 				'user_id' => $user_id,
 			)
 		);
@@ -714,7 +715,7 @@ class ChatOrchestrator {
 			$resolver       = new ToolPolicyResolver();
 			$all_tools      = $resolver->resolve(
 				array(
-					'mode'        => $mode,
+					'modes'       => $modes,
 					'agent_id'    => $agent_id,
 					'agent_slug'  => $agent_slug,
 					'user_id'     => $user_id,
@@ -724,9 +725,10 @@ class ChatOrchestrator {
 			$client_context = $options['client_context'] ?? array();
 
 			$loop_context = array(
-				'session_id' => $session_id,
-				'user_id'    => $user_id,
-				'agent_id'   => $agent_id,
+				'session_id'   => $session_id,
+				'user_id'      => $user_id,
+				'agent_id'     => $agent_id,
+				'agent_modes'  => $modes,
 			);
 			if ( '' !== $agent_slug ) {
 				$loop_context['agent_slug'] = $agent_slug;
@@ -743,7 +745,7 @@ class ChatOrchestrator {
 				$all_tools,
 				$provider,
 				$model,
-				$mode,
+				$modes,
 				$loop_context,
 				$max_turns,
 				$single_turn

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -725,10 +725,10 @@ class ChatOrchestrator {
 			$client_context = $options['client_context'] ?? array();
 
 			$loop_context = array(
-				'session_id'   => $session_id,
-				'user_id'      => $user_id,
-				'agent_id'     => $agent_id,
-				'agent_modes'  => $modes,
+				'session_id'  => $session_id,
+				'user_id'     => $user_id,
+				'agent_id'    => $agent_id,
+				'agent_modes' => $modes,
 			);
 			if ( '' !== $agent_slug ) {
 				$loop_context['agent_slug'] = $agent_slug;

--- a/inc/Api/Chat/Tools/ConfigurePipelineStep.php
+++ b/inc/Api/Chat/Tools/ConfigurePipelineStep.php
@@ -33,7 +33,7 @@ class ConfigurePipelineStep extends BaseTool {
 		return array(
 			'class'       => self::class,
 			'method'      => 'handle_tool_call',
-			'description' => 'Configure pipeline-level AI step settings: system prompt, execution mode, and tool policy. Model/provider are managed via the mode_models site setting, not per-pipeline. For flow-level settings (handler, handler_config, user_message), use configure_flow_steps instead.',
+			'description' => 'Configure pipeline-level AI step settings: system prompt, execution modes, and tool policy. Model/provider are managed via the mode_models site setting, not per-pipeline. For flow-level settings (handler, handler_config, user_message), use configure_flow_steps instead.',
 			'parameters'  => array(
 				'type'       => 'object',
 				'properties' => array(
@@ -45,9 +45,10 @@ class ConfigurePipelineStep extends BaseTool {
 						'type'        => 'string',
 						'description' => 'System prompt for the AI step - defines the AI persona and instructions',
 					),
-					'agent_mode'       => array(
-						'type'        => 'string',
-						'description' => 'Agent execution mode for this AI step. Defaults to pipeline.',
+					'agent_modes'      => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'Agent execution modes for this AI step. Defaults to pipeline.',
 					),
 					'disabled_tools'   => array(
 						'type'        => 'array',

--- a/inc/Api/Chat/Tools/CreatePipeline.php
+++ b/inc/Api/Chat/Tools/CreatePipeline.php
@@ -346,8 +346,8 @@ class CreatePipeline extends BaseTool {
 			if ( isset( $step['system_prompt'] ) ) {
 				$normalized_step['system_prompt'] = $step['system_prompt'];
 			}
-			if ( isset( $step['agent_mode'] ) && is_scalar( $step['agent_mode'] ) ) {
-				$normalized_step['agent_mode'] = sanitize_key( (string) $step['agent_mode'] );
+			if ( isset( $step['agent_modes'] ) && is_array( $step['agent_modes'] ) ) {
+				$normalized_step['agent_modes'] = array_values( array_unique( array_filter( array_map( 'sanitize_key', $step['agent_modes'] ) ) ) );
 			}
 
 			$normalized[] = $normalized_step;

--- a/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
+++ b/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
@@ -44,7 +44,7 @@ class ExecuteWorkflowTool extends BaseTool {
 
 		$description = 'Execute an ephemeral workflow (not saved to database).
 
-STEP FORMAT: {type: "' . $types_list . '", handler_slug, handler_config, user_message?, system_prompt?, agent_mode?}
+STEP FORMAT: {type: "' . $types_list . '", handler_slug, handler_config, user_message?, system_prompt?, agent_modes?}
 
 Use api_query GET /datamachine/v1/handlers/{slug} for handler_config fields.
 

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -89,7 +89,7 @@ class AIStep extends Step {
 		// Pipeline-level model/provider fields are ignored — mode_models is the authority.
 		$execution_modes = self::resolveExecutionModes( $pipeline_step_config, $this->flow_step_config );
 		$mode_model      = self::resolveModelForExecutionModes( $agent_id, $execution_modes );
-		$provider_name  = $mode_model['provider'];
+		$provider_name   = $mode_model['provider'];
 		if ( empty( $provider_name ) ) {
 			do_action(
 				'datamachine_fail_job',
@@ -711,7 +711,10 @@ class AIStep extends Step {
 	 * @return array{provider:string,model:string}
 	 */
 	private static function resolveModelForExecutionModes( int $agent_id, array $modes ): array {
-		$fallback = array( 'provider' => '', 'model' => '' );
+		$fallback = array(
+			'provider' => '',
+			'model'    => '',
+		);
 		foreach ( $modes as $mode ) {
 			$model = PluginSettings::resolveModelForAgentMode( $agent_id, $mode );
 			if ( ! empty( $model['provider'] ) ) {

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -87,8 +87,8 @@ class AIStep extends Step {
 
 		// Model/provider resolved exclusively via mode system (agent → site → network).
 		// Pipeline-level model/provider fields are ignored — mode_models is the authority.
-		$execution_mode = self::resolveExecutionMode( $pipeline_step_config, $this->flow_step_config );
-		$mode_model     = PluginSettings::resolveModelForAgentMode( $agent_id, $execution_mode );
+		$execution_modes = self::resolveExecutionModes( $pipeline_step_config, $this->flow_step_config );
+		$mode_model      = self::resolveModelForExecutionModes( $agent_id, $execution_modes );
 		$provider_name  = $mode_model['provider'];
 		if ( empty( $provider_name ) ) {
 			do_action(
@@ -98,9 +98,9 @@ class AIStep extends Step {
 				array(
 					'flow_step_id'     => $this->flow_step_id,
 					'pipeline_step_id' => $pipeline_step_id,
-					'agent_mode'       => $execution_mode,
-					'error_message'    => sprintf( 'AI step requires provider configuration for agent mode "%s". Set a default provider in Data Machine settings or configure mode_models.', $execution_mode ),
-					'solution'         => sprintf( 'Set default_provider in Data Machine settings or configure mode_models for the %s mode', $execution_mode ),
+					'agent_modes'      => $execution_modes,
+					'error_message'    => sprintf( 'AI step requires provider configuration for agent modes "%s". Set a default provider in Data Machine settings or configure mode_models.', implode( ',', $execution_modes ) ),
+					'solution'         => sprintf( 'Set default_provider in Data Machine settings or configure mode_models for one of these modes: %s', implode( ', ', $execution_modes ) ),
 				)
 			);
 			return false;
@@ -158,12 +158,13 @@ class AIStep extends Step {
 		$user_id      = (int) ( $job_snapshot['user_id'] ?? 0 );
 
 		$pipeline_step_config = $this->engine->getPipelineStepConfig( $pipeline_step_id );
-		$execution_mode       = self::resolveExecutionMode( $pipeline_step_config, $this->flow_step_config );
+		$execution_modes      = self::resolveExecutionModes( $pipeline_step_config, $this->flow_step_config );
 
 		// Model/provider resolved exclusively via mode system — pipeline config is ignored.
-		$mode_model    = PluginSettings::resolveModelForAgentMode( $agent_id, $execution_mode );
+		$mode_model    = self::resolveModelForExecutionModes( $agent_id, $execution_modes );
 		$provider_name = $mode_model['provider'];
 		$model_name    = $mode_model['model'];
+		$mode_label    = implode( ',', $execution_modes );
 
 		$lease_result = PipelineAIConcurrencyLimiter::acquire(
 			$provider_name,
@@ -173,7 +174,7 @@ class AIStep extends Step {
 				'pipeline_step_id' => $pipeline_step_id,
 				'pipeline_id'      => $job_snapshot['pipeline_id'] ?? null,
 				'flow_id'          => $job_snapshot['flow_id'] ?? null,
-				'mode'             => $execution_mode,
+				'mode'             => $mode_label,
 			)
 		);
 
@@ -283,7 +284,7 @@ class AIStep extends Step {
 				'user_id'                     => $user_id,
 				'agent_id'                    => $agent_id,
 				'agent_slug'                  => $agent_slug,
-				'agent_mode'                  => $execution_mode,
+				'agent_modes'                 => $execution_modes,
 				'pipeline_id'                 => $job_snapshot['pipeline_id'] ?? null,
 				'flow_id'                     => $job_snapshot['flow_id'] ?? null,
 				'persist_transcript'          => $persist_transcript,
@@ -330,7 +331,7 @@ class AIStep extends Step {
 			$available_tools = $resolver->resolve(
 				array_merge(
 					array(
-						'mode'                 => $execution_mode,
+						'modes'                => $execution_modes,
 						'agent_id'             => $agent_id,
 						'agent_slug'           => $agent_slug,
 						'previous_step_config' => $previous_step_config,
@@ -419,7 +420,7 @@ class AIStep extends Step {
 					$available_tools,
 					$provider_name,
 					$model_name,
-					$execution_mode,
+					$execution_modes,
 					$payload,
 					$max_turns
 				);
@@ -686,24 +687,42 @@ class AIStep extends Step {
 	}
 
 	/**
-	 * Resolve the agent execution mode for this AI step.
+	 * Resolve the agent execution modes for this AI step.
 	 *
 	 * @param array $pipeline_step_config Pipeline step config.
 	 * @param array $flow_step_config Flow step config.
-	 * @return string Agent mode slug.
+	 * @return array<int,string> Agent mode slugs.
 	 */
-	private static function resolveExecutionMode( array $pipeline_step_config, array $flow_step_config ): string {
-		$raw_mode = ToolPolicyResolver::MODE_PIPELINE;
-		foreach ( array( $flow_step_config['agent_mode'] ?? null, $pipeline_step_config['agent_mode'] ?? null ) as $candidate ) {
-			if ( is_scalar( $candidate ) && '' !== trim( (string) $candidate ) ) {
-				$raw_mode = $candidate;
-				break;
+	private static function resolveExecutionModes( array $pipeline_step_config, array $flow_step_config ): array {
+		foreach ( array( $flow_step_config['agent_modes'] ?? null, $pipeline_step_config['agent_modes'] ?? null ) as $candidate ) {
+			if ( is_array( $candidate ) && ! empty( $candidate ) ) {
+				return ToolPolicyResolver::normalizeModes( $candidate );
 			}
 		}
 
-		$mode = function_exists( 'sanitize_key' ) ? sanitize_key( (string) $raw_mode ) : strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $raw_mode ) ?? '' );
+		return array( ToolPolicyResolver::MODE_PIPELINE );
+	}
 
-		return '' !== $mode ? $mode : ToolPolicyResolver::MODE_PIPELINE;
+	/**
+	 * Resolve the first configured model for an active mode set.
+	 *
+	 * @param int   $agent_id Agent ID.
+	 * @param array $modes    Active mode slugs.
+	 * @return array{provider:string,model:string}
+	 */
+	private static function resolveModelForExecutionModes( int $agent_id, array $modes ): array {
+		$fallback = array( 'provider' => '', 'model' => '' );
+		foreach ( $modes as $mode ) {
+			$model = PluginSettings::resolveModelForAgentMode( $agent_id, $mode );
+			if ( ! empty( $model['provider'] ) ) {
+				return $model;
+			}
+			if ( '' === $fallback['provider'] && '' === $fallback['model'] ) {
+				$fallback = $model;
+			}
+		}
+
+		return $fallback;
 	}
 
 	/**

--- a/inc/Core/Steps/FlowStepConfigFactory.php
+++ b/inc/Core/Steps/FlowStepConfigFactory.php
@@ -39,7 +39,7 @@ class FlowStepConfigFactory {
 				self::promptQueueFromWorkflowStep( $step ),
 				array(
 					'queue_mode'         => 'static',
-					'agent_mode'         => isset( $step['agent_mode'] ) && is_scalar( $step['agent_mode'] ) ? self::sanitizeAgentMode( (string) $step['agent_mode'] ) : '',
+					'agent_modes'        => self::sanitizeAgentModes( $step['agent_modes'] ?? array() ),
 					'disabled_tools'     => $step['disabled_tools'] ?? array(),
 					'pipeline_id'        => 'direct',
 					'flow_id'            => 'direct',
@@ -91,7 +91,7 @@ class FlowStepConfigFactory {
 					'pipeline_id'      => $pipeline_id,
 					'flow_id'          => $flow_id,
 					'execution_order'  => $step['execution_order'] ?? 0,
-					'agent_mode'       => isset( $pipeline_step_config['agent_mode'] ) && is_scalar( $pipeline_step_config['agent_mode'] ) ? self::sanitizeAgentMode( (string) $pipeline_step_config['agent_mode'] ) : '',
+					'agent_modes'      => self::sanitizeAgentModes( $pipeline_step_config['agent_modes'] ?? array() ),
 					'disabled_tools'   => $pipeline_step_config['disabled_tools'] ?? array(),
 				),
 				self::queueDefaultsForStepType( $step_type )
@@ -113,7 +113,7 @@ class FlowStepConfigFactory {
 			'step_type'                           => true,
 			'execution_order'                     => true,
 			'enabled_tools'                       => true,
-			'agent_mode'                          => true,
+			'agent_modes'                         => true,
 			'disabled_tools'                      => true,
 			'completion_assertions'               => true,
 			'tool_runtime_rules'                  => true,
@@ -318,12 +318,27 @@ class FlowStepConfigFactory {
 	}
 
 	/**
-	 * Sanitize an agent mode slug without requiring full WordPress bootstrap.
+	 * Sanitize agent mode slugs without requiring full WordPress bootstrap.
 	 *
-	 * @param string $mode Raw mode.
-	 * @return string Sanitized mode.
+	 * @param mixed $modes Raw modes.
+	 * @return array<int,string> Sanitized modes.
 	 */
-	private static function sanitizeAgentMode( string $mode ): string {
-		return function_exists( 'sanitize_key' ) ? sanitize_key( $mode ) : strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $mode ) ?? '' );
+	private static function sanitizeAgentModes( mixed $modes ): array {
+		if ( ! is_array( $modes ) ) {
+			return array();
+		}
+
+		$sanitized = array();
+		foreach ( $modes as $mode ) {
+			if ( ! is_scalar( $mode ) ) {
+				continue;
+			}
+			$mode = function_exists( 'sanitize_key' ) ? sanitize_key( (string) $mode ) : strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $mode ) ?? '' );
+			if ( '' !== $mode ) {
+				$sanitized[] = $mode;
+			}
+		}
+
+		return array_values( array_unique( $sanitized ) );
 	}
 }

--- a/inc/Core/Steps/WorkflowConfigFactory.php
+++ b/inc/Core/Steps/WorkflowConfigFactory.php
@@ -137,7 +137,7 @@ class WorkflowConfigFactory {
 		if ( 'ai' === $step_type ) {
 			$pipeline_step['system_prompt']  = $step['system_prompt'] ?? '';
 			$pipeline_step['disabled_tools'] = is_array( $step['disabled_tools'] ?? null ) ? array_values( $step['disabled_tools'] ) : array();
-			$agent_modes = self::sanitizeAgentModes( $step['agent_modes'] ?? array() );
+			$agent_modes                     = self::sanitizeAgentModes( $step['agent_modes'] ?? array() );
 			if ( ! empty( $agent_modes ) ) {
 				$pipeline_step['agent_modes'] = $agent_modes;
 			}

--- a/inc/Core/Steps/WorkflowConfigFactory.php
+++ b/inc/Core/Steps/WorkflowConfigFactory.php
@@ -137,8 +137,9 @@ class WorkflowConfigFactory {
 		if ( 'ai' === $step_type ) {
 			$pipeline_step['system_prompt']  = $step['system_prompt'] ?? '';
 			$pipeline_step['disabled_tools'] = is_array( $step['disabled_tools'] ?? null ) ? array_values( $step['disabled_tools'] ) : array();
-			if ( isset( $step['agent_mode'] ) && is_scalar( $step['agent_mode'] ) ) {
-				$pipeline_step['agent_mode'] = self::sanitizeAgentMode( (string) $step['agent_mode'] );
+			$agent_modes = self::sanitizeAgentModes( $step['agent_modes'] ?? array() );
+			if ( ! empty( $agent_modes ) ) {
+				$pipeline_step['agent_modes'] = $agent_modes;
 			}
 			foreach ( array( 'completion_assertions', 'tool_runtime_rules', 'tool_categories' ) as $field ) {
 				if ( is_array( $step[ $field ] ?? null ) ) {
@@ -153,12 +154,27 @@ class WorkflowConfigFactory {
 	}
 
 	/**
-	 * Sanitize an agent mode slug without requiring full WordPress bootstrap.
+	 * Sanitize agent mode slugs without requiring full WordPress bootstrap.
 	 *
-	 * @param string $mode Raw mode.
-	 * @return string Sanitized mode.
+	 * @param mixed $modes Raw modes.
+	 * @return array<int,string> Sanitized modes.
 	 */
-	private static function sanitizeAgentMode( string $mode ): string {
-		return function_exists( 'sanitize_key' ) ? sanitize_key( $mode ) : strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $mode ) ?? '' );
+	private static function sanitizeAgentModes( mixed $modes ): array {
+		if ( ! is_array( $modes ) ) {
+			return array();
+		}
+
+		$sanitized = array();
+		foreach ( $modes as $mode ) {
+			if ( ! is_scalar( $mode ) ) {
+				continue;
+			}
+			$mode = function_exists( 'sanitize_key' ) ? sanitize_key( (string) $mode ) : strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $mode ) ?? '' );
+			if ( '' !== $mode ) {
+				$sanitized[] = $mode;
+			}
+		}
+
+		return array_values( array_unique( $sanitized ) );
 	}
 }

--- a/inc/Engine/AI/AgentModeRegistry.php
+++ b/inc/Engine/AI/AgentModeRegistry.php
@@ -3,8 +3,8 @@
  * Agent Mode Registry
  *
  * Central registry for AI execution modes (chat, pipeline, system, editor, etc.).
- * Each mode has an ID, label, description, and priority for sort order.
- * Core modes register through the same API that extensions use.
+ * Each mode has an ID, label, description, and priority for sort order. Runtime
+ * requests can activate multiple registered modes additively.
  *
  * Extension point: the `datamachine_agent_modes` action fires once per request
  * when the registry is first consumed, allowing extensions to register

--- a/inc/Engine/AI/Directives/AgentModeDirective.php
+++ b/inc/Engine/AI/Directives/AgentModeDirective.php
@@ -123,9 +123,8 @@ MD;
 	/**
 	 * Get directive outputs for the current agent mode.
 	 *
-	 * Reads the mode slug from $payload['agent_mode'], applies the built-in
-	 * default, then filters through datamachine_agent_mode_{slug} for
-	 * extension composition.
+	 * Reads mode slugs from $payload['agent_modes'], applies built-in defaults,
+	 * then filters through datamachine_agent_mode_{slug} for extension composition.
 	 *
 	 * @param string      $provider_name AI provider name.
 	 * @param array       $tools         Available tools.
@@ -134,36 +133,44 @@ MD;
 	 * @return array Directive outputs.
 	 */
 	public static function get_outputs( string $provider_name, array $tools, ?string $step_id = null, array $payload = array() ): array {
-		$mode = $payload['agent_mode'] ?? '';
+		$modes = self::normalizeModes( $payload['agent_modes'] ?? array() );
 
-		if ( empty( $mode ) ) {
+		if ( empty( $modes ) ) {
 			return array();
 		}
 
-		$default = self::get_default_for_mode( $mode );
+		$contents = array();
+		foreach ( $modes as $mode ) {
+			$default = self::get_default_for_mode( $mode );
 
-		/**
-		 * Filter agent-mode guidance for a given mode slug.
-		 *
-		 * Lets extensions append or modify mode-specific guidance
-		 * (e.g. the editor plugin appends diff workflow instructions
-		 * when the 'editor' mode is active).
-		 *
-		 * Fires as datamachine_agent_mode_{mode}, e.g.
-		 * datamachine_agent_mode_chat.
-		 *
-		 * @since 0.68.0
-		 *
-		 * @param string $content Current guidance text.
-		 * @param array  $payload Full request payload (agent_id, user_id, etc.).
-		 */
-		$content = apply_filters(
-			"datamachine_agent_mode_{$mode}",
-			$default,
-			$payload
-		);
+			/**
+			 * Filter agent-mode guidance for a given mode slug.
+			 *
+			 * Lets extensions append or modify mode-specific guidance
+			 * (e.g. the editor plugin appends diff workflow instructions
+			 * when the 'editor' mode is active).
+			 *
+			 * Fires as datamachine_agent_mode_{mode}, e.g.
+			 * datamachine_agent_mode_chat.
+			 *
+			 * @since 0.68.0
+			 *
+			 * @param string $content Current guidance text.
+			 * @param array  $payload Full request payload (agent_id, user_id, etc.).
+			 */
+			$content = apply_filters(
+				"datamachine_agent_mode_{$mode}",
+				$default,
+				$payload
+			);
 
-		$content = trim( (string) $content );
+			$content = trim( (string) $content );
+			if ( '' !== $content ) {
+				$contents[] = $content;
+			}
+		}
+
+		$content = trim( implode( "\n\n", $contents ) );
 
 		if ( '' === $content ) {
 			return array();
@@ -192,6 +199,29 @@ MD;
 			'system'   => self::SYSTEM_MODE,
 			default     => '',
 		};
+	}
+
+	/** @return array<int,string> */
+	private static function normalizeModes( mixed $modes ): array {
+		if ( is_string( $modes ) ) {
+			$modes = array( $modes );
+		}
+		if ( ! is_array( $modes ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $modes as $mode ) {
+			if ( ! is_scalar( $mode ) ) {
+				continue;
+			}
+			$mode = function_exists( 'sanitize_key' ) ? sanitize_key( (string) $mode ) : strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $mode ) ?? '' );
+			if ( '' !== $mode ) {
+				$normalized[] = $mode;
+			}
+		}
+
+		return array_values( array_unique( $normalized ) );
 	}
 }
 

--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -68,13 +68,13 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 
 		$items = array();
 
-		// Load registered files applicable to the current agent mode,
+		// Load registered files applicable to the current agent modes,
 		// filtered through the per-agent MemoryPolicy.
-		$mode       = $payload['agent_mode'] ?? '';
+		$modes      = self::normalizeModes( $payload['agent_modes'] ?? array() );
 		$resolver   = new MemoryPolicyResolver();
 		$mode_files = $resolver->resolveRegistered(
 			array(
-				'mode'     => $mode,
+				'modes'    => $modes,
 				'agent_id' => $agent_id,
 			)
 		);
@@ -259,6 +259,29 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 		}
 
 		return trim( $content );
+	}
+
+	/** @return array<int,string> */
+	private static function normalizeModes( mixed $modes ): array {
+		if ( is_string( $modes ) ) {
+			$modes = array( $modes );
+		}
+		if ( ! is_array( $modes ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $modes as $mode ) {
+			if ( ! is_scalar( $mode ) ) {
+				continue;
+			}
+			$mode = function_exists( 'sanitize_key' ) ? sanitize_key( (string) $mode ) : strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $mode ) ?? '' );
+			if ( '' !== $mode ) {
+				$normalized[] = $mode;
+			}
+		}
+
+		return array_values( array_unique( $normalized ) );
 	}
 }
 

--- a/inc/Engine/AI/Directives/DirectivePolicyResolver.php
+++ b/inc/Engine/AI/Directives/DirectivePolicyResolver.php
@@ -21,15 +21,15 @@ class DirectivePolicyResolver {
 	 * Resolve directives after applying optional per-agent policy.
 	 *
 	 * @param array $directives Registered directive configs.
-	 * @param array $args       Resolution args: mode, agent_id.
+	 * @param array $args       Resolution args: modes, agent_id.
 	 * @return array{directives: array, suppressed: array}
 	 */
 	public function resolve( array $directives, array $args ): array {
-		$mode     = isset( $args['mode'] ) ? (string) $args['mode'] : '';
+		$modes    = self::normalizeModes( $args['modes'] ?? ( array_key_exists( 'mode', $args ) ? array( $args['mode'] ) : array() ) );
 		$agent_id = isset( $args['agent_id'] ) ? (int) $args['agent_id'] : 0;
 		$policy   = $agent_id > 0 ? $this->getAgentDirectivePolicy( $agent_id ) : null;
 
-		$result = $this->applyPolicy( $directives, $policy, $mode );
+		$result = $this->applyPolicy( $directives, $policy, $modes );
 
 		/**
 		 * Filter the directive stack after per-agent policy is applied.
@@ -86,11 +86,12 @@ class DirectivePolicyResolver {
 	 *
 	 * @param array      $directives Registered directive configs.
 	 * @param array|null $policy     Normalized policy.
-	 * @param string     $mode       Current agent mode.
+	 * @param array      $modes      Current agent modes.
 	 * @return array{directives: array, suppressed: array}
 	 */
-	public function applyPolicy( array $directives, ?array $policy, string $mode = '' ): array {
-		if ( null === $policy || ! $this->policyAppliesToMode( $policy, $mode ) ) {
+	public function applyPolicy( array $directives, ?array $policy, array $modes = array() ): array {
+		$modes = self::normalizeModes( $modes );
+		if ( null === $policy || ! $this->policyAppliesToModes( $policy, $modes ) ) {
 			return array(
 				'directives' => $directives,
 				'suppressed' => array(),
@@ -178,9 +179,32 @@ class DirectivePolicyResolver {
 	 * @param string $mode   Current mode.
 	 * @return bool
 	 */
-	private function policyAppliesToMode( array $policy, string $mode ): bool {
+	private function policyAppliesToModes( array $policy, array $active_modes ): bool {
 		$modes = $policy['modes'] ?? array();
-		return empty( $modes ) || in_array( $mode, $modes, true );
+		return empty( $modes ) || ! empty( array_intersect( $active_modes, $modes ) );
+	}
+
+	/** @return array<int,string> */
+	private static function normalizeModes( mixed $modes ): array {
+		if ( is_string( $modes ) ) {
+			$modes = array( $modes );
+		}
+		if ( ! is_array( $modes ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $modes as $mode ) {
+			if ( ! is_scalar( $mode ) ) {
+				continue;
+			}
+			$mode = function_exists( 'sanitize_key' ) ? sanitize_key( (string) $mode ) : strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $mode ) ?? '' );
+			if ( '' !== $mode ) {
+				$normalized[] = $mode;
+			}
+		}
+
+		return array_values( array_unique( $normalized ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Memory/MemoryPolicyResolver.php
+++ b/inc/Engine/AI/Memory/MemoryPolicyResolver.php
@@ -51,7 +51,7 @@ class MemoryPolicyResolver {
 	 * @param array $args {
 	 *     Resolution arguments describing the request.
 	 *
-	 *     @type string   $mode       Required. Agent mode slug (e.g. 'chat', 'pipeline').
+	 *     @type string[] $modes      Required. Agent mode slugs (e.g. 'chat', 'pipeline').
 	 *     @type int|null $agent_id   Optional agent ID for per-agent policy filtering.
 	 *     @type array    $deny       Filenames to explicitly deny (highest precedence).
 	 *     @type array    $allow_only Mode-level allowlist narrowing.
@@ -59,12 +59,12 @@ class MemoryPolicyResolver {
 	 * @return array<string, array> Filename => metadata map, sorted by priority ascending.
 	 */
 	public function resolveRegistered( array $args ): array {
-		$mode     = $args['mode'] ?? '';
+		$modes    = self::normalizeModes( $args['modes'] ?? ( array_key_exists( 'mode', $args ) ? array( $args['mode'] ) : array() ) );
 		$agent_id = isset( $args['agent_id'] ) ? (int) $args['agent_id'] : 0;
 
 		// 1. Start with registry output filtered by mode (already priority-sorted).
-		$files = ! empty( $mode )
-			? MemoryFileRegistry::get_for_mode( $mode )
+		$files = ! empty( $modes )
+			? MemoryFileRegistry::get_for_modes( $modes )
 			: MemoryFileRegistry::get_all();
 
 		// 2. Apply per-agent policy.
@@ -86,7 +86,8 @@ class MemoryPolicyResolver {
 		}
 
 		// 5. Allow external filtering of the resolved registered set.
-		$files = apply_filters( 'datamachine_resolved_memory_files', $files, $mode, $args );
+		$filter_mode = 1 === count( $modes ) ? $modes[0] : $modes;
+		$files       = apply_filters( 'datamachine_resolved_memory_files', $files, $filter_mode, $args );
 
 		return $files;
 	}
@@ -310,5 +311,28 @@ class MemoryPolicyResolver {
 			self::MODE_CHAT     => 'Admin chat session',
 			self::MODE_SYSTEM   => 'System task execution',
 		);
+	}
+
+	/** @return array<int,string> */
+	private static function normalizeModes( mixed $modes ): array {
+		if ( is_string( $modes ) ) {
+			$modes = array( $modes );
+		}
+		if ( ! is_array( $modes ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $modes as $mode ) {
+			if ( ! is_scalar( $mode ) ) {
+				continue;
+			}
+			$mode = function_exists( 'sanitize_key' ) ? sanitize_key( (string) $mode ) : strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $mode ) ?? '' );
+			if ( '' !== $mode ) {
+				$normalized[] = $mode;
+			}
+		}
+
+		return array_values( array_unique( $normalized ) );
 	}
 }

--- a/inc/Engine/AI/MemoryFileRegistry.php
+++ b/inc/Engine/AI/MemoryFileRegistry.php
@@ -438,7 +438,7 @@ class MemoryFileRegistry {
 	}
 
 	/**
-	 * Get always-injected files applicable to a specific agent mode.
+	 * Get always-injected files applicable to active agent modes.
 	 *
 	 * Returns files that either list the mode in their `modes` array
 	 * or are registered with `['all']`, excluding files
@@ -447,13 +447,13 @@ class MemoryFileRegistry {
 	 * @since 0.60.0
 	 * @since 0.68.0 Internal key renamed from contexts to modes.
 	 *
-	 * @param string $mode Agent mode slug (e.g. 'chat', 'pipeline', 'system', 'editor').
+	 * @param array $modes Agent mode slugs (e.g. 'chat', 'pipeline', 'system', 'editor').
 	 * @return array<string, array> Filtered and sorted file metadata.
 	 */
-	public static function get_for_mode( string $mode ): array {
-		$mode = sanitize_key( $mode );
+	public static function get_for_modes( array $modes ): array {
+		$modes = array_values( array_unique( array_filter( array_map( 'sanitize_key', $modes ) ) ) );
 
-		if ( empty( $mode ) ) {
+		if ( empty( $modes ) ) {
 			return self::get_resolved();
 		}
 
@@ -461,7 +461,7 @@ class MemoryFileRegistry {
 
 		return array_filter(
 			self::get_resolved(),
-			function ( $meta ) use ( $mode, $agents_api_loaded ) {
+			function ( $meta ) use ( $modes, $agents_api_loaded ) {
 				$default_policy   = $agents_api_loaded ? WP_Agent_Context_Injection_Policy::ALWAYS : 'always';
 				$retrieval_policy = $meta['retrieval_policy'] ?? $default_policy;
 				$is_always        = $agents_api_loaded
@@ -471,39 +471,39 @@ class MemoryFileRegistry {
 					return false;
 				}
 
-				$modes = $meta['modes'] ?? self::MODES_NONE;
-				if ( empty( $modes ) ) {
+				$file_modes = $meta['modes'] ?? self::MODES_NONE;
+				if ( empty( $file_modes ) ) {
 					return false;
 				}
 
-				return in_array( self::MODE_ALL, $modes, true )
-					|| in_array( $mode, $modes, true );
+				return in_array( self::MODE_ALL, $file_modes, true )
+					|| ! empty( array_intersect( $modes, $file_modes ) );
 			}
 		);
 	}
 
 	/**
-	 * Check if a file applies to a specific agent mode.
+	 * Check if a file applies to active agent modes.
 	 *
 	 * @since 0.60.0
 	 * @since 0.68.0 Internal key renamed from contexts to modes.
 	 *
 	 * @param string $filename Filename to check.
-	 * @param string $mode     Agent mode slug.
+	 * @param array  $modes    Agent mode slugs.
 	 * @return bool True if the file should be injected in this mode.
 	 */
-	public static function applies_to_mode( string $filename, string $mode ): bool {
+	public static function applies_to_modes( string $filename, array $modes ): bool {
 		$resolved = self::get_resolved();
 		$filename = sanitize_file_name( $filename );
-		$mode     = sanitize_key( $mode );
+		$modes    = array_values( array_unique( array_filter( array_map( 'sanitize_key', $modes ) ) ) );
 
 		if ( ! isset( $resolved[ $filename ] ) ) {
 			return true; // Unregistered files are included everywhere.
 		}
 
-		$modes = $resolved[ $filename ]['modes'] ?? array( self::MODE_ALL );
-		return in_array( self::MODE_ALL, $modes, true )
-			|| in_array( $mode, $modes, true );
+		$file_modes = $resolved[ $filename ]['modes'] ?? array( self::MODE_ALL );
+		return in_array( self::MODE_ALL, $file_modes, true )
+			|| ! empty( array_intersect( $modes, $file_modes ) );
 	}
 
 	/**

--- a/inc/Engine/AI/PromptBuilder.php
+++ b/inc/Engine/AI/PromptBuilder.php
@@ -138,9 +138,9 @@ class PromptBuilder {
 			: array();
 
 		foreach ( $this->directives as $directiveConfig ) {
-			$directive = $directiveConfig['directive'];
+			$directive       = $directiveConfig['directive'];
 			$directive_modes = $directiveConfig['modes'];
-			$priority  = (int) ( $directiveConfig['priority'] ?? 10 );
+			$priority        = (int) ( $directiveConfig['priority'] ?? 10 );
 
 			if ( ! in_array( 'all', $directive_modes, true ) && empty( array_intersect( $payload['agent_modes'], $directive_modes ) ) ) {
 				continue;

--- a/inc/Engine/AI/PromptBuilder.php
+++ b/inc/Engine/AI/PromptBuilder.php
@@ -92,13 +92,13 @@ class PromptBuilder {
 	/**
 	 * Build the final AI request with directives applied
 	 *
-	 * @param string $mode     Agent mode ('pipeline', 'chat', etc.)
+	 * @param array  $modes    Agent modes ('pipeline', 'chat', etc.)
 	 * @param string $provider AI provider name
 	 * @param array  $payload  Request payload
 	 * @return array Request array with messages, tools, and directive metadata
 	 */
-	public function build( string $mode, string $provider, array $payload = array() ): array {
-		$detailed = $this->buildDetailed( $mode, $provider, $payload );
+	public function build( array $modes, string $provider, array $payload = array() ): array {
+		$detailed = $this->buildDetailed( $modes, $provider, $payload );
 
 		return array(
 			'messages'           => $detailed['messages'],
@@ -111,12 +111,13 @@ class PromptBuilder {
 	/**
 	 * Build the final AI request and include directive-level inspection metadata.
 	 *
-	 * @param string $mode     Agent mode ('pipeline', 'chat', etc.).
+	 * @param array  $modes    Agent modes ('pipeline', 'chat', etc.).
 	 * @param string $provider AI provider name.
 	 * @param array  $payload  Request payload.
 	 * @return array Request array with messages, tools, applied_directives, directive_metadata, and directive_breakdown.
 	 */
-	public function buildDetailed( string $mode, string $provider, array $payload = array() ): array {
+	public function buildDetailed( array $modes, string $provider, array $payload = array() ): array {
+		$modes = self::normalizeModes( $modes );
 		usort(
 			$this->directives,
 			function ( $a, $b ) {
@@ -124,10 +125,8 @@ class PromptBuilder {
 			}
 		);
 
-		// Ensure directives can access the current agent mode.
-		if ( ! isset( $payload['agent_mode'] ) ) {
-			$payload['agent_mode'] = $mode;
-		}
+		// Ensure directives can access the current agent modes.
+		$payload['agent_modes'] = self::normalizeModes( $payload['agent_modes'] ?? $modes );
 
 		$conversation_messages = $this->messages;
 		$directive_outputs     = array();
@@ -140,10 +139,10 @@ class PromptBuilder {
 
 		foreach ( $this->directives as $directiveConfig ) {
 			$directive = $directiveConfig['directive'];
-			$modes     = $directiveConfig['modes'];
+			$directive_modes = $directiveConfig['modes'];
 			$priority  = (int) ( $directiveConfig['priority'] ?? 10 );
 
-			if ( ! in_array( 'all', $modes, true ) && ! in_array( $mode, $modes, true ) ) {
+			if ( ! in_array( 'all', $directive_modes, true ) && empty( array_intersect( $payload['agent_modes'], $directive_modes ) ) ) {
 				continue;
 			}
 
@@ -301,5 +300,28 @@ class PromptBuilder {
 			}
 		}
 		return $total;
+	}
+
+	/** @return array<int,string> */
+	private static function normalizeModes( mixed $modes ): array {
+		if ( is_string( $modes ) ) {
+			$modes = array( $modes );
+		}
+		if ( ! is_array( $modes ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $modes as $mode ) {
+			if ( ! is_scalar( $mode ) ) {
+				continue;
+			}
+			$mode = function_exists( 'sanitize_key' ) ? sanitize_key( (string) $mode ) : strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $mode ) ?? '' );
+			if ( '' !== $mode ) {
+				$normalized[] = $mode;
+			}
+		}
+
+		return array_values( array_unique( $normalized ) );
 	}
 }

--- a/inc/Engine/AI/ProviderRequestAssembler.php
+++ b/inc/Engine/AI/ProviderRequestAssembler.php
@@ -23,7 +23,7 @@ class ProviderRequestAssembler {
 	 * @param string $provider   AI provider name.
 	 * @param string $model      Model identifier.
 	 * @param array  $tools      Raw tools array from filters or runtime declarations.
-	 * @param string $mode       Execution mode.
+	 * @param array  $modes      Execution modes.
 	 * @param array  $payload    Request payload.
 	 * @param array  $directives Directive configs already selected by the caller.
 	 * @return array Assembled request and inspection metadata.
@@ -33,7 +33,7 @@ class ProviderRequestAssembler {
 		string $provider,
 		string $model,
 		array $tools,
-		string $mode,
+		array $modes,
 		array $payload = array(),
 		array $directives = array()
 	): array {
@@ -50,7 +50,7 @@ class ProviderRequestAssembler {
 			);
 		}
 
-		$request             = $prompt_builder->buildDetailed( $mode, $provider, $payload );
+		$request             = $prompt_builder->buildDetailed( $modes, $provider, $payload );
 		$request['messages'] = WP_Agent_Message::normalize_many( $request['messages'] ?? array() );
 		$applied_directives  = $request['applied_directives'] ?? array();
 		$directive_metadata  = $request['directive_metadata'] ?? array();

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -109,7 +109,7 @@ class RequestBuilder {
 				'AI request blocked: wp-ai-client unavailable',
 				array_filter(
 					array(
-					'mode'         => $mode_label,
+						'mode'         => $mode_label,
 						'job_id'       => $payload['job_id'] ?? null,
 						'flow_step_id' => $payload['flow_step_id'] ?? null,
 						'provider'     => $provider,

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -38,7 +38,7 @@ class RequestBuilder {
 	 * @param string $provider    AI provider name (openai, anthropic, google, grok, openrouter)
 	 * @param string $model       Model identifier
 	 * @param array  $tools       Raw tools array from filters
-	 * @param string $mode     Execution mode: 'chat' or 'pipeline'
+	 * @param array  $modes       Execution modes.
 	 * @param array  $payload     Step payload (session_id, job_id, flow_step_id, data, etc)
 	 * @param array|null $request_metadata Optional output parameter for request metadata.
 	 * @return \WordPress\AiClient\Results\DTO\GenerativeAiResult|\WP_Error AI response from wp-ai-client.
@@ -48,13 +48,15 @@ class RequestBuilder {
 		string $provider,
 		string $model,
 		array $tools,
-		string $mode,
+		array $modes,
 		array $payload = array(),
 		?array &$request_metadata = null
 	) {
 		WpAiClientCache::install();
 
-		$assembled        = self::assemble( $messages, $provider, $model, $tools, $mode, $payload );
+		$modes            = self::normalizeModes( $modes );
+		$mode_label       = implode( ',', $modes );
+		$assembled        = self::assemble( $messages, $provider, $model, $tools, $modes, $payload );
 		$request          = $assembled['request'];
 		$provider_request = ProviderRequestAssembler::toProviderRequest( $request );
 		$prompt_context   = self::wpAiClientPromptContext( $request['messages'] ?? array() );
@@ -71,7 +73,7 @@ class RequestBuilder {
 			$directive_metadata,
 			$provider,
 			$model,
-			$mode
+			$mode_label
 		);
 		RequestMetadata::warn_if_oversized( $request_metadata, $payload );
 
@@ -81,7 +83,7 @@ class RequestBuilder {
 			'AI request built',
 			array_filter(
 				array(
-					'mode'                  => $mode,
+					'mode'                  => $mode_label,
 					'job_id'                => $payload['job_id'] ?? null,
 					'flow_step_id'          => $payload['flow_step_id'] ?? null,
 					'provider'              => $provider,
@@ -107,7 +109,7 @@ class RequestBuilder {
 				'AI request blocked: wp-ai-client unavailable',
 				array_filter(
 					array(
-						'mode'         => $mode,
+					'mode'         => $mode_label,
 						'job_id'       => $payload['job_id'] ?? null,
 						'flow_step_id' => $payload['flow_step_id'] ?? null,
 						'provider'     => $provider,
@@ -141,7 +143,7 @@ class RequestBuilder {
 
 		$result                        = null;
 		$request_options               = null;
-		$transport_profile             = self::wpAiClientTransportProfile( $mode, $provider, $model, $payload );
+		$transport_profile             = self::wpAiClientTransportProfile( $mode_label, $provider, $model, $payload );
 		$request_timeout               = (float) $transport_profile['request_timeout'];
 		$connect_timeout               = (float) $transport_profile['connect_timeout'];
 		$request_metadata['transport'] = $transport_profile;
@@ -414,7 +416,7 @@ class RequestBuilder {
 	/**
 	 * Resolve the request timeout Data Machine applies to wp-ai-client calls.
 	 *
-	 * @param string $mode     Execution mode.
+	 * @param array  $modes    Execution modes.
 	 * @param string $provider Provider identifier.
 	 * @param string $model    Model identifier.
 	 * @param array  $payload  Step payload.
@@ -578,22 +580,23 @@ class RequestBuilder {
 		string $provider,
 		string $model,
 		array $tools,
-		string $mode,
+		array $modes,
 		array $payload = array()
 	): array {
-		$payload          = self::withDirectiveContext( $payload );
+		$modes            = self::normalizeModes( $modes );
+		$payload          = self::withDirectiveContext( array_merge( $payload, array( 'agent_modes' => $modes ) ) );
 		$directives       = apply_filters( 'datamachine_directives', array() );
 		$directive_policy = ( new DirectivePolicyResolver() )->resolve(
 			$directives,
 			array(
-				'mode'     => $mode,
+				'modes'    => $modes,
 				'agent_id' => $payload['agent_id'] ?? 0,
 			)
 		);
 		$directives       = $directive_policy['directives'];
 		$suppressed       = $directive_policy['suppressed'];
 
-		$assembled = ( new ProviderRequestAssembler() )->assemble( $messages, $provider, $model, $tools, $mode, $payload, $directives );
+		$assembled = ( new ProviderRequestAssembler() )->assemble( $messages, $provider, $model, $tools, $modes, $payload, $directives );
 
 		return array(
 			'request'               => $assembled['request'],
@@ -706,6 +709,29 @@ class RequestBuilder {
 				'supportedOptions'      => array(),
 			),
 		);
+	}
+
+	/** @return array<int,string> */
+	private static function normalizeModes( mixed $modes ): array {
+		if ( is_string( $modes ) ) {
+			$modes = array( $modes );
+		}
+		if ( ! is_array( $modes ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $modes as $mode ) {
+			if ( ! is_scalar( $mode ) ) {
+				continue;
+			}
+			$mode = function_exists( 'sanitize_key' ) ? sanitize_key( (string) $mode ) : strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $mode ) ?? '' );
+			if ( '' !== $mode ) {
+				$normalized[] = $mode;
+			}
+		}
+
+		return array_values( array_unique( $normalized ) );
 	}
 
 	/**

--- a/inc/Engine/AI/RequestInspector.php
+++ b/inc/Engine/AI/RequestInspector.php
@@ -106,7 +106,7 @@ class RequestInspector {
 		$tools    = $resolver->resolve(
 			array_merge(
 				array(
-					'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
+					'modes'                => array( ToolPolicyResolver::MODE_PIPELINE ),
 					'agent_id'             => $agent_id,
 					'agent_slug'           => $agent_slug,
 					'previous_step_config' => $previous_step_config,
@@ -150,7 +150,7 @@ class RequestInspector {
 			$provider,
 			$model,
 			$tools,
-			ToolPolicyResolver::MODE_PIPELINE,
+			array( ToolPolicyResolver::MODE_PIPELINE ),
 			$payload
 		);
 		$transport_profile = RequestBuilder::wpAiClientTransportProfile(

--- a/inc/Engine/AI/RuntimeProvenance.php
+++ b/inc/Engine/AI/RuntimeProvenance.php
@@ -18,10 +18,10 @@ class RuntimeProvenance {
 	 * @param array  $payload Data Machine loop payload.
 	 * @param string $provider Provider identifier.
 	 * @param string $model Model identifier.
-	 * @param string $mode Execution mode.
+	 * @param array  $modes Execution modes.
 	 * @return array<string,mixed>
 	 */
-	public static function fromConversationResult( array $result, array $payload, string $provider, string $model, string $mode ): array {
+	public static function fromConversationResult( array $result, array $payload, string $provider, string $model, array $modes ): array {
 		$request_metadata = is_array( $result['request_metadata'] ?? null ) ? $result['request_metadata'] : array();
 		$usage            = is_array( $result['usage'] ?? null ) ? $result['usage'] : array();
 		$error_message    = isset( $result['error'] ) ? (string) $result['error'] : '';
@@ -44,7 +44,8 @@ class RuntimeProvenance {
 				),
 				static fn( $value ) => array() !== $value && null !== $value && '' !== $value
 			),
-			'mode'            => $mode,
+			'mode'            => implode( ',', $modes ),
+			'modes'           => $modes,
 			'identifiers'     => self::identifiers( $payload ),
 			'input'           => array_filter(
 				array(
@@ -101,7 +102,7 @@ class RuntimeProvenance {
 
 	/** @return array<string,mixed> */
 	private static function identifiers( array $payload ): array {
-		$keys        = array( 'agent_id', 'agent_slug', 'agent_mode', 'pipeline_id', 'flow_id', 'flow_step_id', 'step_id', 'job_id', 'session_id', 'transcript_session_id' );
+		$keys        = array( 'agent_id', 'agent_slug', 'agent_modes', 'pipeline_id', 'flow_id', 'flow_step_id', 'step_id', 'job_id', 'session_id', 'transcript_session_id' );
 		$identifiers = array();
 		foreach ( $keys as $key ) {
 			if ( isset( $payload[ $key ] ) && '' !== $payload[ $key ] ) {
@@ -127,7 +128,8 @@ class RuntimeProvenance {
 	/** @return array<string,mixed> */
 	private static function tool_policy_inputs( array $payload ): array {
 		$inputs = array(
-			'mode'                     => $payload['agent_mode'] ?? null,
+			'mode'                     => isset( $payload['agent_modes'] ) && is_array( $payload['agent_modes'] ) ? implode( ',', $payload['agent_modes'] ) : null,
+			'modes'                    => is_array( $payload['agent_modes'] ?? null ) ? array_values( $payload['agent_modes'] ) : null,
 			'agent_id'                 => $payload['agent_id'] ?? null,
 			'agent_slug'               => $payload['agent_slug'] ?? null,
 			'pipeline_step_id'         => $payload['step_id'] ?? null,

--- a/inc/Engine/AI/System/Tasks/AltTextTask.php
+++ b/inc/Engine/AI/System/Tasks/AltTextTask.php
@@ -95,7 +95,7 @@ class AltTextTask extends SystemTask {
 			$provider,
 			$model,
 			array(),
-			'system',
+			array( 'system' ),
 			$ai_payload
 		);
 

--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -161,7 +161,7 @@ class DailyMemoryTask extends SystemTask {
 			$provider,
 			$model,
 			array(),
-			'system',
+			array( 'system' ),
 			$ai_payload
 		);
 

--- a/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
+++ b/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
@@ -139,7 +139,7 @@ class InternalLinkingTask extends SystemTask {
 				$provider,
 				$model,
 				array(),
-				'system',
+				array( 'system' ),
 				$ai_payload
 			);
 

--- a/inc/Engine/AI/System/Tasks/MetaDescriptionTask.php
+++ b/inc/Engine/AI/System/Tasks/MetaDescriptionTask.php
@@ -91,7 +91,7 @@ class MetaDescriptionTask extends SystemTask {
 			$provider,
 			$model,
 			array(),
-			'system',
+			array( 'system' ),
 			$ai_payload
 		);
 

--- a/inc/Engine/AI/Tools/BaseTool.php
+++ b/inc/Engine/AI/Tools/BaseTool.php
@@ -27,8 +27,8 @@ abstract class BaseTool {
 	 *
 	 * All tools register via the single `datamachine_tools` filter. Each tool
 	 * must declare its modes — the agent modes where it's available (e.g.
-	 * 'chat', 'pipeline'). Tools that should be available to pipeline runs only
-	 * when explicitly allowlisted may declare 'pipeline_policy'.
+	 * 'chat', 'pipeline'). Tools that should be available only when explicitly
+	 * allowlisted may declare `requires_opt_in` in metadata.
 	 *
 	 * Tools should also declare which ability they wrap via the `ability` key
 	 * (or `abilities` for composed tools). The ToolPolicyResolver uses this to
@@ -60,6 +60,7 @@ abstract class BaseTool {
 	 *     @type string[] $abilities    Multiple ability slugs for composed tools. ALL must pass permission check.
 	 *     @type string   $access_level Fallback for tools without a linked ability.
 	 *                                  One of: 'public', 'authenticated', 'author', 'editor', 'admin'. Default: 'admin'.
+	 *     @type bool     $requires_opt_in Only expose the tool when `allow_only` includes the tool name.
 	 * }
 	 */
 	protected function registerTool( string $toolName, array|callable $toolDefinition, array $modes = array(), array $meta = array() ): void {
@@ -69,13 +70,15 @@ abstract class BaseTool {
 				if ( is_callable( $toolDefinition ) ) {
 					// Wrap callable with modes for pre-resolution filtering.
 					$tools[ $toolName ] = array(
-						'_callable' => $toolDefinition,
-						'modes'     => $modes,
+						'_callable'       => $toolDefinition,
+						'modes'           => $modes,
+						'requires_opt_in' => ! empty( $meta['requires_opt_in'] ),
 					);
 				} else {
 					// Array definition — merge modes directly.
-					$toolDefinition['modes'] = $modes;
-					$tools[ $toolName ]      = $toolDefinition;
+					$toolDefinition['modes']           = $modes;
+					$toolDefinition['requires_opt_in'] = ! empty( $meta['requires_opt_in'] );
+					$tools[ $toolName ]                = $toolDefinition;
 				}
 
 				// Merge permission metadata into the tool entry.
@@ -87,6 +90,9 @@ abstract class BaseTool {
 				}
 				if ( ! empty( $meta['access_level'] ) ) {
 					$tools[ $toolName ]['access_level'] = $meta['access_level'];
+				}
+				if ( ! empty( $meta['requires_opt_in'] ) ) {
+					$tools[ $toolName ]['requires_opt_in'] = true;
 				}
 
 				return $tools;

--- a/inc/Engine/AI/Tools/Execution/ToolExecutionCore.php
+++ b/inc/Engine/AI/Tools/Execution/ToolExecutionCore.php
@@ -164,6 +164,15 @@ class ToolExecutionCore {
 		}
 
 		$registry = \WP_Abilities_Registry::get_instance();
+		if ( method_exists( $registry, 'is_registered' ) && ! $registry->is_registered( $ability_slug ) ) {
+			return array(
+				'success'   => false,
+				'error'     => sprintf( "Tool '%s' references missing ability '%s'.", $tool_name, $ability_slug ),
+				'tool_name' => $tool_name,
+				'ability'   => $ability_slug,
+			);
+		}
+
 		$ability  = $registry->get_registered( $ability_slug );
 
 		if ( ! $ability ) {

--- a/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
@@ -23,7 +23,7 @@ use DataMachine\Abilities\PermissionHelper;
 class AgentDailyMemory extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'agent_daily_memory', array( $this, 'getToolDefinition' ), array( 'chat', ToolPolicyResolver::MODE_PIPELINE_POLICY ), array( 'abilities' => array( 'datamachine/daily-memory-read', 'datamachine/daily-memory-write', 'datamachine/daily-memory-list', 'datamachine/search-daily-memory' ) ) );
+		$this->registerTool( 'agent_daily_memory', array( $this, 'getToolDefinition' ), array( 'chat', ToolPolicyResolver::MODE_PIPELINE ), array( 'abilities' => array( 'datamachine/daily-memory-read', 'datamachine/daily-memory-write', 'datamachine/daily-memory-list', 'datamachine/search-daily-memory' ), 'requires_opt_in' => true ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/AgentMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentMemory.php
@@ -23,7 +23,7 @@ use DataMachine\Abilities\PermissionHelper;
 class AgentMemory extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'agent_memory', array( $this, 'getToolDefinition' ), array( 'chat', ToolPolicyResolver::MODE_PIPELINE_POLICY ), array( 'abilities' => array( 'datamachine/get-agent-memory', 'datamachine/update-agent-memory', 'datamachine/list-agent-memory-sections' ) ) );
+		$this->registerTool( 'agent_memory', array( $this, 'getToolDefinition' ), array( 'chat', ToolPolicyResolver::MODE_PIPELINE ), array( 'abilities' => array( 'datamachine/get-agent-memory', 'datamachine/update-agent-memory', 'datamachine/list-agent-memory-sections' ), 'requires_opt_in' => true ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Policy/DataMachineToolAccessPolicy.php
+++ b/inc/Engine/AI/Tools/Policy/DataMachineToolAccessPolicy.php
@@ -65,6 +65,10 @@ final class DataMachineToolAccessPolicy {
 		if ( ! empty( $ability_slugs ) ) {
 			$registry = \WP_Abilities_Registry::get_instance();
 			foreach ( $ability_slugs as $slug ) {
+				if ( method_exists( $registry, 'is_registered' ) && ! $registry->is_registered( $slug ) ) {
+					return false;
+				}
+
 				$ability = $registry->get_registered( $slug );
 				if ( ! $ability || ! $ability->check_permissions() ) {
 					return false;

--- a/inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php
+++ b/inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php
@@ -20,13 +20,13 @@ final class AdjacentHandlerToolSource {
 	/**
 	 * Gather handler tools from adjacent pipeline steps.
 	 *
-	 * @param string      $mode         Agent mode slug.
+	 * @param array       $modes        Agent mode slugs.
 	 * @param array       $args         Full resolution arguments.
 	 * @param ToolManager $tool_manager Tool registry/handler resolver.
 	 * @return array Tools keyed by tool name.
 	 */
-	public function __invoke( string $mode, array $args, ToolManager $tool_manager ): array {
-		if ( ToolPolicyResolver::MODE_PIPELINE !== $mode ) {
+	public function __invoke( array $modes, array $args, ToolManager $tool_manager ): array {
+		if ( ! in_array( ToolPolicyResolver::MODE_PIPELINE, $modes, true ) ) {
 			return array();
 		}
 

--- a/inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php
+++ b/inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php
@@ -28,16 +28,13 @@ final class DataMachineToolRegistrySource {
 	/**
 	 * Gather mode-filtered tools from Data Machine's static registry.
 	 *
-	 * @param string $mode Agent mode slug.
+	 * @param array $modes Agent mode slugs.
 	 * @return array Tools keyed by tool name.
 	 */
-	public function __invoke( string $mode, array $args = array() ): array {
-		$available_tools   = array();
-		$all_tools         = $this->tool_manager->get_all_tools();
-		$matchable         = self::resolveMatchableModes( $mode, $args );
-		$mode_tools        = $this->filterByMode( $all_tools, $matchable, $args );
-		$is_pipeline_mode  = ToolPolicyResolver::MODE_PIPELINE === $mode;
-		$inherits_pipeline = in_array( ToolPolicyResolver::MODE_PIPELINE, $matchable, true );
+	public function __invoke( array $modes, array $args = array() ): array {
+		$available_tools = array();
+		$all_tools       = $this->tool_manager->get_all_tools();
+		$mode_tools      = $this->filterByModes( $all_tools, $modes );
 
 		foreach ( $mode_tools as $tool_name => $tool_config ) {
 			if ( ! is_array( $tool_config ) || empty( $tool_config ) ) {
@@ -51,33 +48,7 @@ final class DataMachineToolRegistrySource {
 				continue;
 			}
 
-			// Pipeline-policy tools (durable memory writes, etc.) opt into
-			// pipeline runs by being explicitly listed in the flow's
-			// allow_only / enabled_tools. They should activate whenever the
-			// run is reachable from `pipeline` — either directly or through
-			// a custom mode that inherits from `pipeline`.
-			if ( $inherits_pipeline && ToolPolicyResolver::isPipelinePolicyToolAllowed( $tool_config, $tool_name, $args ) ) {
-				$tool_config['modes'] = array_values( array_unique( array_merge( $tool_config['modes'], array( ToolPolicyResolver::MODE_PIPELINE ) ) ) );
-			}
-
-			// Tools admitted via mode inheritance get the current mode
-			// stamped onto their `modes` array. Downstream policy filters
-			// (notably Agents API's `filter_by_mode`) re-check tool modes
-			// against the runtime mode; without the rewrite, inherited
-			// tools would be filtered back out one layer up.
-			$tool_config['modes'] = array_values(
-				array_unique( array_merge( $tool_config['modes'] ?? array(), array( $mode ) ) )
-			);
-
-			// Pipeline-shaped runs (direct or inherited) take the
-			// availability-only gate: pipeline-policy tools are admitted
-			// without per-tool config checks because their inclusion was
-			// already authorized by the flow's allow_only list.
-			if ( $is_pipeline_mode || $inherits_pipeline ) {
-				if ( $this->tool_manager->is_tool_available( $tool_name, null ) ) {
-					$available_tools[ $tool_name ] = $tool_config;
-				}
-
+			if ( ! ToolPolicyResolver::isOptInToolAllowed( $tool_config, $tool_name, $args ) ) {
 				continue;
 			}
 
@@ -98,98 +69,20 @@ final class DataMachineToolRegistrySource {
 	}
 
 	/**
-	 * Filter resolved tools by agent mode.
+	 * Filter resolved tools by active agent modes.
 	 *
-	 * Tools declare which modes they belong to via the `modes` key on
-	 * registration (e.g. `['chat', 'pipeline']`). By default a tool is
-	 * available to a request only when the request's mode appears in
-	 * that list verbatim.
-	 *
-	 * Extension plugins that register custom modes via `AgentModeRegistry`
-	 * can opt their mode into another mode's tool surface by hooking the
-	 * `datamachine_tool_mode_matchable_modes` filter. Returning
-	 * `['world', 'pipeline']` for the `world` mode, for example, makes
-	 * every tool registered for `pipeline` available to `world` runs as
-	 * well — without re-registering each tool. The default value is
-	 * `[$mode]` so existing behavior is unchanged for any mode that does
-	 * not opt in.
-	 *
-	 * @param array  $tools Resolved tools array.
-	 * @param string $mode  Mode slug to filter by.
-	 * @param array  $args  Resolution context passed through from the source.
+	 * @param array $tools Resolved tools array.
+	 * @param array $modes Active mode slugs.
 	 * @return array Filtered tools.
 	 */
-	/**
-	 * Resolve the modes a tool's `modes` array is matched against.
-	 *
-	 * Custom modes registered via `AgentModeRegistry` can declare
-	 * inheritance from a built-in mode by appending its slug to the
-	 * matchable list via `datamachine_tool_mode_matchable_modes`. Tools
-	 * whose `modes` array intersects with the resolved matchable list
-	 * become available to the current mode. Defaults to `[$mode]`, which
-	 * preserves the historical exact-match behavior.
-	 *
-	 * @param string $mode Current execution mode.
-	 * @param array  $args Tool resolution context.
-	 * @return string[]    Mode slugs to match tool `modes` against.
-	 */
-	private static function resolveMatchableModes( string $mode, array $args ): array {
-		/**
-		 * Filter the modes a tool's `modes` array is matched against.
-		 *
-		 * Custom modes registered via `AgentModeRegistry` can declare
-		 * inheritance from a built-in mode by appending its slug to the
-		 * matchable list. Tools whose `modes` array intersects with the
-		 * matchable list become available to the current mode.
-		 *
-		 * Defaults to `[$mode]`, which preserves the historical exact-
-		 * match behavior. The filter is the seam custom modes use to
-		 * inherit tool surfaces without DM having to know about them.
-		 *
-		 * @since 0.113.0
-		 *
-		 * @param string[] $matchable Mode slugs to match tool `modes` against.
-		 * @param string   $mode      Current execution mode.
-		 * @param array    $args      Tool resolution context.
-		 */
-		$matchable = apply_filters( 'datamachine_tool_mode_matchable_modes', array( $mode ), $mode, $args );
-
-		if ( ! is_array( $matchable ) || empty( $matchable ) ) {
-			return array( $mode );
-		}
-
-		return $matchable;
-	}
-
-	/**
-	 * Filter resolved tools by agent mode using the resolved matchable set.
-	 *
-	 * Pipeline-policy tools (e.g. `agent_daily_memory`) register against
-	 * the synthetic `pipeline_policy` mode. They opt into a run only when
-	 * the run is reachable from `pipeline` AND the tool is named in
-	 * `allow_only`. This keeps powerful-but-automatable tools behind an
-	 * explicit allowlist instead of being unconditionally inherited.
-	 *
-	 * @param array $tools     Resolved tools array.
-	 * @param array $matchable Mode slugs to match tool `modes` against.
-	 * @param array $args      Resolution context (used for pipeline-policy allow_only).
-	 * @return array Filtered tools.
-	 */
-	private function filterByMode( array $tools, array $matchable, array $args ): array {
-		$inherits_pipeline = in_array( ToolPolicyResolver::MODE_PIPELINE, $matchable, true );
-
+	private function filterByModes( array $tools, array $active_modes ): array {
 		return array_filter(
 			$tools,
-			static function ( $tool, string $tool_name ) use ( $matchable, $args, $inherits_pipeline ) {
-				$modes = $tool['modes'] ?? array();
-
-				if ( $inherits_pipeline && ToolPolicyResolver::isPipelinePolicyToolAllowed( $tool, $tool_name, $args ) ) {
-					return true;
-				}
-
-				return ! empty( array_intersect( $matchable, $modes ) );
-			},
-			ARRAY_FILTER_USE_BOTH
+			static function ( $tool ) use ( $active_modes ) {
+				$tool_modes = $tool['modes'] ?? array();
+				$tool_modes = is_array( $tool_modes ) ? $tool_modes : array( $tool_modes );
+				return ! empty( array_intersect( $active_modes, $tool_modes ) );
+			}
 		);
 	}
 }

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -127,9 +127,12 @@ class ToolManager {
 
 		// Handle unified registry wrapper: ['_callable' becomes callable, 'modes' becomes [...]]
 		$modes = array();
+		$meta  = array();
 		if ( is_array( $definition ) && isset( $definition['_callable'] ) ) {
 			$modes      = $definition['modes'] ?? array();
+			$meta       = $definition;
 			$definition = $definition['_callable'];
+			unset( $meta['_callable'] );
 		}
 
 		// Resolve callable or use array directly
@@ -145,6 +148,11 @@ class ToolManager {
 		// Merge modes into resolved definition (registry modes take precedence)
 		if ( ! empty( $modes ) ) {
 			$resolved['modes'] = $modes;
+		}
+		foreach ( array( 'ability', 'abilities', 'access_level', 'requires_opt_in' ) as $key ) {
+			if ( isset( $meta[ $key ] ) ) {
+				$resolved[ $key ] = $meta[ $key ];
+			}
 		}
 
 		// Cache the resolved definition
@@ -611,7 +619,7 @@ class ToolManager {
 		// If mode specified, use ToolPolicyResolver to filter appropriately.
 		if ( null !== $mode ) {
 			$resolver = new ToolPolicyResolver( $this );
-			$tools    = $resolver->resolve( array( 'mode' => $mode ) );
+			$tools    = $resolver->resolve( array( 'modes' => array( $mode ) ) );
 		} else {
 			$tools = $this->get_all_tools();
 		}

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -36,12 +36,6 @@ class ToolPolicyResolver {
 	public const MODE_CHAT     = 'chat';
 	public const MODE_SYSTEM   = 'system';
 
-	/**
-	 * Opt-in pipeline mode for tools that should never be exposed to pipeline
-	 * agents by default, but may be explicitly enabled by a flow/tool policy.
-	 */
-	public const MODE_PIPELINE_POLICY = 'pipeline_policy';
-
 	private ToolManager $tool_manager;
 	private ToolSourceRegistry $tool_source_registry;
 	private DataMachineAgentToolPolicyProvider $agent_policy_provider;
@@ -73,14 +67,14 @@ class ToolPolicyResolver {
 	}
 
 	/**
-	 * Resolve available tools for a given agent mode.
+	 * Resolve available tools for given agent modes.
 	 *
 	 * This is the single entry point. All tool assembly should go through here.
 	 *
 	 * @param array $args {
 	 *     Resolution arguments describing the request.
 	 *
-	 *     @type string      $mode                  Required. One of the MODE_* constants (or a custom mode slug).
+	 *     @type string[]    $modes                 Active agent mode slugs.
 	 *     @type int|null    $agent_id              Agent ID for per-agent tool policy filtering.
 	 *     @type array|null  $previous_step_config  Pipeline only: previous step config.
 	 *     @type array|null  $next_step_config      Pipeline only: next step config.
@@ -95,23 +89,25 @@ class ToolPolicyResolver {
 	 * @return array Resolved tools array keyed by tool name.
 	 */
 	public function resolve( array $args ): array {
-		$mode     = $args['mode'] ?? self::MODE_PIPELINE;
+		$modes    = self::normalizeModes( $args['modes'] ?? ( array_key_exists( 'mode', $args ) ? array( $args['mode'] ) : array( self::MODE_PIPELINE ) ) );
 		$agent_id = isset( $args['agent_id'] ) ? (int) $args['agent_id'] : 0;
 
-		$is_interactive = self::MODE_CHAT === $mode || ! empty( $args['interactive'] );
+		$is_interactive = in_array( self::MODE_CHAT, $modes, true ) || ! empty( $args['interactive'] );
 
 		if ( $is_interactive && ! $this->tool_access_policy->passesChatGate( $args ) ) {
 			return array();
 		}
 
 		// 1. Gather tools from Data Machine-owned sources.
-		$tools = $this->gatherByMode( $mode, $args );
+		$args['modes'] = $modes;
+		$tools         = $this->gatherByModes( $modes, $args );
 
 		// 2. Delegate generic mode/allow/deny/category policy resolution to Agents API.
 		$policy_context = array_merge(
 			$args,
 			array(
-				'mode'              => $mode,
+				'mode'              => '',
+				'modes'             => $modes,
 				'datamachine_tools' => $tools,
 			)
 		);
@@ -132,7 +128,8 @@ class ToolPolicyResolver {
 
 		// 7. Allow external filtering of resolved tools.
 		// @phpstan-ignore-next-line WordPress apply_filters accepts additional hook arguments.
-		$tools = apply_filters( 'datamachine_resolved_tools', $tools, $mode, $args );
+		$filter_mode = 1 === count( $modes ) ? $modes[0] : $modes;
+		$tools       = apply_filters( 'datamachine_resolved_tools', $tools, $filter_mode, $args );
 
 		return $tools;
 	}
@@ -140,12 +137,12 @@ class ToolPolicyResolver {
 	/**
 	 * Gather tools by mode preset.
 	 *
-	 * @param string $mode Agent mode slug.
+	 * @param array $modes Agent mode slugs.
 	 * @param array  $args Full resolution arguments.
 	 * @return array Tools array.
 	 */
-	private function gatherByMode( string $mode, array $args ): array {
-		return $this->tool_source_registry->gather( $mode, $args );
+	private function gatherByModes( array $modes, array $args ): array {
+		return $this->tool_source_registry->gather( $modes, $args );
 	}
 
 	/**
@@ -218,20 +215,44 @@ class ToolPolicyResolver {
 	}
 
 	/**
-	 * Whether a tool is available to a pipeline only by explicit policy opt-in.
+	 * Normalize active mode input to sanitized slugs.
 	 *
-	 * Policy-gated pipeline tools stay out of the default pipeline tool pool, but
-	 * can be granted by a flow's `enabled_tools` allowlist or equivalent tool
-	 * policy. This is intended for powerful-but-automatable tools such as durable
-	 * agent memory writes.
+	 * @param mixed $modes Raw mode input.
+	 * @return array<int,string>
+	 */
+	public static function normalizeModes( mixed $modes ): array {
+		if ( is_string( $modes ) ) {
+			$modes = array( $modes );
+		}
+		if ( ! is_array( $modes ) ) {
+			$modes = array();
+		}
+
+		$normalized = array();
+		foreach ( $modes as $mode ) {
+			if ( ! is_scalar( $mode ) ) {
+				continue;
+			}
+			$mode = function_exists( 'sanitize_key' ) ? sanitize_key( (string) $mode ) : strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $mode ) ?? '' );
+			if ( '' !== $mode ) {
+				$normalized[] = $mode;
+			}
+		}
+
+		$normalized = array_values( array_unique( $normalized ) );
+		return ! empty( $normalized ) ? $normalized : array( self::MODE_PIPELINE );
+	}
+
+	/**
+	 * Whether an explicitly opt-in tool is available to this run.
 	 *
 	 * @param array  $tool_config Tool definition.
 	 * @param string $tool_name   Tool identifier.
 	 * @param array  $args        Resolver args, including optional allow_only.
-	 * @return bool True when the tool should be included for this pipeline pass.
+	 * @return bool True when the tool should be included.
 	 */
-	public static function isPipelinePolicyToolAllowed( array $tool_config, string $tool_name, array $args ): bool {
-		return in_array( self::MODE_PIPELINE_POLICY, $tool_config['modes'] ?? array(), true )
-			&& in_array( $tool_name, $args['allow_only'] ?? array(), true );
+	public static function isOptInToolAllowed( array $tool_config, string $tool_name, array $args ): bool {
+		return empty( $tool_config['requires_opt_in'] )
+			|| in_array( $tool_name, $args['allow_only'] ?? array(), true );
 	}
 }

--- a/inc/Engine/AI/Tools/ToolSourceRegistry.php
+++ b/inc/Engine/AI/Tools/ToolSourceRegistry.php
@@ -26,18 +26,18 @@ class ToolSourceRegistry {
 	}
 
 	/**
-	 * Gather tools from the sources configured for a mode.
+	 * Gather tools from the sources configured for active modes.
 	 *
-	 * @param string $mode Agent mode slug.
+	 * @param array $modes Agent mode slugs.
 	 * @param array  $args Full resolution arguments.
 	 * @return array Tools keyed by tool name.
 	 */
-	public function gather( string $mode, array $args ): array {
+	public function gather( array $modes, array $args ): array {
 		$tools   = array();
-		$sources = $this->getRegisteredSources( $mode, $args );
+		$sources = $this->getRegisteredSources( $modes, $args );
 
-		foreach ( $this->getSourcesForMode( $mode, $args ) as $source_slug ) {
-			$source_tools = $this->gatherFromSource( $source_slug, $mode, $args, $sources );
+		foreach ( $this->getSourcesForModes( $modes, $args ) as $source_slug ) {
+			$source_tools = $this->gatherFromSource( $source_slug, $modes, $args, $sources );
 
 			foreach ( $source_tools as $tool_name => $tool_config ) {
 				if ( isset( $tools[ $tool_name ] ) ) {
@@ -54,11 +54,11 @@ class ToolSourceRegistry {
 	/**
 	 * Return registered tool sources.
 	 *
-	 * @param string $mode Agent mode slug.
+	 * @param array $modes Agent mode slugs.
 	 * @param array  $args Full resolution arguments.
 	 * @return array<string, callable> Source callbacks keyed by source slug.
 	 */
-	private function getRegisteredSources( string $mode, array $args ): array {
+	private function getRegisteredSources( array $modes, array $args ): array {
 		// @phpstan-ignore-next-line WordPress apply_filters accepts additional hook arguments.
 		$sources = apply_filters(
 			'agents_api_tool_sources',
@@ -66,7 +66,7 @@ class ToolSourceRegistry {
 				self::SOURCE_STATIC_REGISTRY   => new DataMachineToolRegistrySource( $this->tool_manager ),
 				self::SOURCE_ADJACENT_HANDLERS => new AdjacentHandlerToolSource(),
 			),
-			$mode,
+			$modes,
 			$args,
 			$this->tool_manager
 		);
@@ -75,19 +75,19 @@ class ToolSourceRegistry {
 	}
 
 	/**
-	 * Return source slugs for a mode.
+	 * Return source slugs for active modes.
 	 *
-	 * @param string $mode Agent mode slug.
+	 * @param array $modes Agent mode slugs.
 	 * @param array  $args Full resolution arguments.
 	 * @return array<int, string> Source slugs in precedence order.
 	 */
-	private function getSourcesForMode( string $mode, array $args ): array {
-		$sources = ToolPolicyResolver::MODE_PIPELINE === $mode
+	private function getSourcesForModes( array $modes, array $args ): array {
+		$sources = in_array( ToolPolicyResolver::MODE_PIPELINE, $modes, true )
 			? array( self::SOURCE_ADJACENT_HANDLERS, self::SOURCE_STATIC_REGISTRY )
 			: array( self::SOURCE_STATIC_REGISTRY );
 
 		// @phpstan-ignore-next-line WordPress apply_filters accepts additional hook arguments.
-		$sources = apply_filters( 'agents_api_tool_sources_for_mode', $sources, $mode, $args );
+		$sources = apply_filters( 'agents_api_tool_sources_for_mode', $sources, $modes, $args );
 
 		if ( ! is_array( $sources ) ) {
 			return array();
@@ -105,18 +105,18 @@ class ToolSourceRegistry {
 	 * Gather tools from one source.
 	 *
 	 * @param string $source_slug Source slug.
-	 * @param string $mode        Agent mode slug.
+	 * @param array  $modes       Agent mode slugs.
 	 * @param array  $args        Full resolution arguments.
 	 * @param array  $sources     Registered source callbacks keyed by source slug.
 	 * @return array Tools keyed by tool name.
 	 */
-	private function gatherFromSource( string $source_slug, string $mode, array $args, array $sources ): array {
+	private function gatherFromSource( string $source_slug, array $modes, array $args, array $sources ): array {
 		$source = $sources[ $source_slug ] ?? null;
 		if ( ! is_callable( $source ) ) {
 			return array();
 		}
 
-		$tools = call_user_func( $source, $mode, $args, $this->tool_manager );
+		$tools = call_user_func( $source, $modes, $args, $this->tool_manager );
 
 		return is_array( $tools ) ? $tools : array();
 	}

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -37,7 +37,7 @@ defined( 'ABSPATH' ) || exit;
  * @param array  $tools       Available tools keyed by tool name.
  * @param string $provider    AI provider identifier.
  * @param string $model       AI model identifier.
- * @param string $mode        Execution mode ('pipeline', 'chat', ...).
+	 * @param array  $modes       Execution modes ('pipeline', 'chat', ...).
  * @param array  $payload     Step payload / loop context.
  * @param int    $max_turns   Maximum conversation turns.
  * @param bool   $single_turn Execute exactly one turn and return.
@@ -48,17 +48,19 @@ function datamachine_run_conversation(
 	array $tools,
 	string $provider,
 	string $model,
-	string $mode,
+	array $modes,
 	array $payload = array(),
 	int $max_turns = PluginSettings::DEFAULT_MAX_TURNS,
 	bool $single_turn = false
 ): array {
 	$messages = WP_Agent_Message::normalize_many( $messages );
+	$modes    = Tools\ToolPolicyResolver::normalizeModes( $modes );
+	$mode     = implode( ',', $modes );
 
 	// Resolve DM runtime collaborators from the payload.
 	$event_sink           = datamachine_resolve_event_sink( $payload );
 	$assertions           = datamachine_resolve_completion_assertions( $payload );
-	$completion_policy    = datamachine_resolve_completion_policy( $mode, $payload, $assertions );
+	$completion_policy    = datamachine_resolve_completion_policy( $modes, $payload, $assertions );
 	$tool_runtime_rules   = datamachine_resolve_tool_runtime_rules( $payload );
 	$transcript_persister = datamachine_resolve_transcript_persister( $payload );
 	$transcript_lock      = $payload['transcript_lock'] ?? $payload['transcript_lock_store'] ?? null;
@@ -83,6 +85,7 @@ function datamachine_run_conversation(
 	$base_log_context = array_filter(
 		array(
 			'mode'         => $mode,
+			'modes'        => $modes,
 			'job_id'       => $loop_payload['job_id'] ?? null,
 			'flow_step_id' => $loop_payload['flow_step_id'] ?? null,
 			'agent_slug'   => $loop_payload['agent_slug'] ?? null,
@@ -153,7 +156,7 @@ function datamachine_run_conversation(
 				$loop_payload,
 				$provider,
 				$model,
-				$mode
+				$modes
 			),
 		);
 	}
@@ -172,6 +175,7 @@ function datamachine_run_conversation(
 		$provider,
 		$model,
 		$mode,
+		$modes,
 		$loop_payload,
 		$event_sink,
 		$base_log_context,
@@ -205,12 +209,12 @@ function datamachine_run_conversation(
 			array(
 				'max_turns'             => $max_turns,
 				'budgets'               => array( $turn_budget ),
-				'context'               => array_merge( $loop_payload, array( 'mode' => $mode ) ),
+				'context'               => array_merge( $loop_payload, array( 'mode' => $mode, 'modes' => $modes ) ),
 				'request'               => new \AgentsAPI\AI\WP_Agent_Conversation_Request(
 					$messages,
 					array(),
 					null,
-					array_merge( $loop_payload, array( 'mode' => $mode ) ),
+					array_merge( $loop_payload, array( 'mode' => $mode, 'modes' => $modes ) ),
 					array(
 						'provider'  => $provider,
 						'model'     => $model,
@@ -245,7 +249,7 @@ function datamachine_run_conversation(
 			'request_metadata'       => $last_request_metadata,
 			'status'                 => 'error',
 		);
-		$error_result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $error_result, $loop_payload, $provider, $model, $mode );
+		$error_result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $error_result, $loop_payload, $provider, $model, $modes );
 		return $error_result;
 	}
 
@@ -263,7 +267,7 @@ function datamachine_run_conversation(
 			'usage'                  => array(),
 			'error'                  => $e->getMessage(),
 		);
-		$error_result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $error_result, $loop_payload, $provider, $model, $mode );
+		$error_result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $error_result, $loop_payload, $provider, $model, $modes );
 		return $error_result;
 	}
 
@@ -301,7 +305,7 @@ function datamachine_run_conversation(
 		);
 	}
 
-	$result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $result, $loop_payload, $provider, $model, $mode );
+	$result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $result, $loop_payload, $provider, $model, $modes );
 
 	return $result;
 }
@@ -322,7 +326,8 @@ function datamachine_run_conversation(
  * @param array                                     $tools              Available tools.
  * @param string                                    $provider           AI provider.
  * @param string                                    $model              AI model.
- * @param string                                    $mode               Execution mode.
+	 * @param string                                    $mode               Comma-separated execution mode label.
+	 * @param array                                     $modes              Execution mode slugs.
  * @param array                                     $loop_payload       Cleaned payload.
  * @param LoopEventSinkInterface                    $event_sink         DM event sink.
  * @param array                                     $base_log_context   Base log context.
@@ -337,6 +342,7 @@ function datamachine_build_turn_runner(
 	string $provider,
 	string $model,
 	string $mode,
+	array $modes,
 	array $loop_payload,
 	LoopEventSinkInterface $event_sink,
 	array $base_log_context,
@@ -351,6 +357,7 @@ function datamachine_build_turn_runner(
 		$provider,
 		$model,
 		$mode,
+		$modes,
 		$loop_payload,
 		$event_sink,
 		$base_log_context,
@@ -373,7 +380,7 @@ function datamachine_build_turn_runner(
 			$provider,
 			$model,
 			$tools,
-			$mode,
+			$modes,
 			$loop_payload,
 			$request_metadata
 		);
@@ -931,11 +938,11 @@ function datamachine_resolve_event_sink( array $payload ): LoopEventSinkInterfac
 /**
  * Resolve the runtime completion policy from mode and payload.
  *
- * @param string $mode    Execution mode.
+	 * @param array  $modes   Execution modes.
  * @param array  $payload Loop payload.
  * @return WP_Agent_Conversation_Completion_Policy
  */
-function datamachine_resolve_completion_policy( string $mode, array $payload, ?DataMachineCompletionAssertions $assertions = null ): WP_Agent_Conversation_Completion_Policy {
+function datamachine_resolve_completion_policy( array $modes, array $payload, ?DataMachineCompletionAssertions $assertions = null ): WP_Agent_Conversation_Completion_Policy {
 	$policy = $payload['completion_policy'] ?? null;
 	if ( $policy instanceof WP_Agent_Conversation_Completion_Policy ) {
 		return $policy;
@@ -946,7 +953,7 @@ function datamachine_resolve_completion_policy( string $mode, array $payload, ?D
 	$configured_handlers = $payload['configured_handler_slugs'] ?? array();
 	$configured_handlers = is_array( $configured_handlers ) ? array_values( $configured_handlers ) : array();
 
-	if ( ! empty( $configured_handlers ) || 'pipeline' === $mode ) {
+	if ( ! empty( $configured_handlers ) || in_array( 'pipeline', $modes, true ) ) {
 		return new DataMachineHandlerCompletionPolicy( $configured_handlers, $assertions );
 	}
 

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -209,12 +209,18 @@ function datamachine_run_conversation(
 			array(
 				'max_turns'             => $max_turns,
 				'budgets'               => array( $turn_budget ),
-				'context'               => array_merge( $loop_payload, array( 'mode' => $mode, 'modes' => $modes ) ),
+				'context'               => array_merge( $loop_payload, array(
+					'mode'  => $mode,
+					'modes' => $modes,
+				) ),
 				'request'               => new \AgentsAPI\AI\WP_Agent_Conversation_Request(
 					$messages,
 					array(),
 					null,
-					array_merge( $loop_payload, array( 'mode' => $mode, 'modes' => $modes ) ),
+					array_merge( $loop_payload, array(
+						'mode'  => $mode,
+						'modes' => $modes,
+					) ),
 					array(
 						'provider'  => $provider,
 						'model'     => $model,

--- a/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
+++ b/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
@@ -528,7 +528,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 		);
 
 		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'system_prompt, agent_mode, disabled_tools, or tool_categories', $result['error'] );
+		$this->assertStringContainsString( 'system_prompt, agent_modes, disabled_tools, or tool_categories', $result['error'] );
 	}
 
 	public function test_update_pipeline_step_no_fields(): void {

--- a/tests/Unit/Core/Steps/AI/AIStepTest.php
+++ b/tests/Unit/Core/Steps/AI/AIStepTest.php
@@ -116,20 +116,20 @@ class AIStepTest extends TestCase {
 		);
 	}
 
-	public function test_resolve_execution_mode_uses_flow_override_then_pipeline_config(): void {
-		$method = new ReflectionMethod( AIStep::class, 'resolveExecutionMode' );
+	public function test_resolve_execution_modes_uses_flow_override_then_pipeline_config(): void {
+		$method = new ReflectionMethod( AIStep::class, 'resolveExecutionModes' );
 		$method->setAccessible( true );
 
 		$this->assertSame(
-			'rl_task',
-			$method->invoke( null, array( 'agent_mode' => 'pipeline' ), array( 'agent_mode' => 'rl_task' ) )
+			array( 'rl_task' ),
+			$method->invoke( null, array( 'agent_modes' => array( 'pipeline' ) ), array( 'agent_modes' => array( 'rl_task' ) ) )
 		);
 		$this->assertSame(
-			'eval',
-			$method->invoke( null, array( 'agent_mode' => 'Eval' ), array( 'agent_mode' => '' ) )
+			array( 'eval' ),
+			$method->invoke( null, array( 'agent_modes' => array( 'Eval' ) ), array( 'agent_modes' => array() ) )
 		);
 		$this->assertSame(
-			ToolPolicyResolver::MODE_PIPELINE,
+			array( ToolPolicyResolver::MODE_PIPELINE ),
 			$method->invoke( null, array(), array() )
 		);
 	}

--- a/tests/Unit/Engine/AI/MemoryFileRegistryTest.php
+++ b/tests/Unit/Engine/AI/MemoryFileRegistryTest.php
@@ -112,10 +112,10 @@ class MemoryFileRegistryTest extends TestCase {
 	}
 
 	/**
-	 * get_for_mode() only returns files whose modes match the requested mode
+	 * get_for_modes() only returns files whose modes match the requested modes
 	 * AND whose retrieval_policy is `always`.
 	 */
-	public function test_get_for_mode_filters_by_mode_and_policy(): void {
+	public function test_get_for_modes_filters_by_mode_and_policy(): void {
 		MemoryFileRegistry::register( 'CHAT_ONLY.md', 10, array(
 			'layer' => MemoryFileRegistry::LAYER_AGENT,
 			'modes' => array( 'chat' ),
@@ -132,7 +132,7 @@ class MemoryFileRegistryTest extends TestCase {
 			'layer' => MemoryFileRegistry::LAYER_AGENT,
 		) );
 
-		$chat_files = MemoryFileRegistry::get_for_mode( 'chat' );
+		$chat_files = MemoryFileRegistry::get_for_modes( array( 'chat' ) );
 		$this->assertArrayHasKey( 'CHAT_ONLY.md', $chat_files );
 		$this->assertArrayHasKey( 'ALL_MODES.md', $chat_files );
 		$this->assertArrayNotHasKey( 'PIPELINE_ONLY.md', $chat_files );

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -126,7 +126,7 @@ $result = datamachine_run_conversation(
 	$tools,
 	'openai',
 	'gpt-smoke',
-	'pipeline',
+	array( 'pipeline' ),
 	array(
 		'job_id'       => 1569,
 		'flow_step_id' => 'flow-step-smoke',
@@ -166,7 +166,7 @@ $error_result = datamachine_run_conversation(
 	$tools,
 	'openai',
 	'gpt-smoke',
-	'pipeline',
+	array( 'pipeline' ),
 	array(),
 	1
 );

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -246,7 +246,7 @@ $natural_result = datamachine_run_conversation(
 	array(),
 	'openai',
 	'gpt-smoke',
-	'chat',
+	array( 'chat' ),
 	array(),
 	5
 );
@@ -276,7 +276,7 @@ $satisfied_result = datamachine_run_conversation(
 	array(),
 	'openai',
 	'gpt-smoke',
-	'chat',
+	array( 'chat' ),
 	array(
 		'completion_assertions' => array(
 			'required_engine_data_keys' => array( 'final_url' ),
@@ -353,7 +353,7 @@ $nudge_result = datamachine_run_conversation(
 	),
 	'openai',
 	'gpt-smoke',
-	'chat',
+	array( 'chat' ),
 	array(
 		'event_sink'            => $nudge_event_sink,
 		'transcript_persister'  => $nudge_transcript,
@@ -423,7 +423,7 @@ $minimum_count_result = datamachine_run_conversation(
 	),
 	'openai',
 	'gpt-smoke',
-	'chat',
+	array( 'chat' ),
 	array(
 		'completion_assertions' => array(
 			'minimum_successful_tool_counts' => array( 'runtime_policy_tool' => 2 ),
@@ -505,7 +505,7 @@ $duplicate_result = datamachine_run_conversation(
 	),
 	'openai',
 	'gpt-smoke',
-	'pipeline',
+	array( 'pipeline' ),
 	array(
 		'transcript_persister'  => $duplicate_transcript,
 		'completion_assertions' => array(
@@ -567,7 +567,7 @@ $repeatable_result = datamachine_run_conversation(
 	),
 	'openai',
 	'gpt-smoke',
-	'pipeline',
+	array( 'pipeline' ),
 	array(),
 	4
 );
@@ -635,7 +635,7 @@ $inspection_nudge_result = datamachine_run_conversation(
 	),
 	'openai',
 	'gpt-smoke',
-	'pipeline',
+	array( 'pipeline' ),
 	array(
 		'transcript_persister'  => $inspection_nudge_transcript,
 		'completion_assertions' => array(
@@ -704,7 +704,7 @@ $runtime_rule_result = datamachine_run_conversation(
 	),
 	'openai',
 	'gpt-smoke',
-	'pipeline',
+	array( 'pipeline' ),
 	array(
 		'transcript_persister'  => $runtime_rule_transcript,
 		'completion_assertions' => array(
@@ -796,7 +796,7 @@ $pr_prerequisite_result = datamachine_run_conversation(
 	),
 	'openai',
 	'gpt-smoke',
-	'pipeline',
+	array( 'pipeline' ),
 	array(
 		'completion_assertions' => array(
 			'required_tool_names' => array( 'create_github_pull_request', 'agent_daily_memory' ),
@@ -882,7 +882,7 @@ $satisfied_runtime_rule_result = datamachine_run_conversation(
 	),
 	'openai',
 	'gpt-smoke',
-	'pipeline',
+	array( 'pipeline' ),
 	array(
 		'completion_assertions' => array(
 			'required_tool_names' => array( 'workspace_git_status' ),
@@ -1214,7 +1214,7 @@ $daily_memory_unavailable_result = datamachine_run_conversation(
 	),
 	'openai',
 	'gpt-smoke',
-	'pipeline',
+	array( 'pipeline' ),
 	array(
 		'event_sink'            => $daily_memory_unavailable_sink,
 		'completion_assertions' => array(
@@ -1299,7 +1299,7 @@ $daily_memory_success_result = datamachine_run_conversation(
 	),
 	'openai',
 	'gpt-smoke',
-	'pipeline',
+	array( 'pipeline' ),
 	array(
 		'completion_assertions' => array(
 			'required_tool_names' => array( 'agent_daily_memory' ),
@@ -1354,7 +1354,7 @@ $result = datamachine_run_conversation(
 	),
 	'openai',
 	'gpt-smoke',
-	'chat',
+	array( 'chat' ),
 	array(
 		'completion_policy'    => $completion_policy,
 		'transcript_persister' => $transcript_policy,

--- a/tests/agent-daily-memory-directive-smoke.php
+++ b/tests/agent-daily-memory-directive-smoke.php
@@ -117,7 +117,7 @@ namespace {
         )
         ->addDirective( \DataMachine\Engine\AI\Directives\AgentDailyMemoryDirective::class, 35, array( 'chat' ) )
         ->buildDetailed(
-            'chat',
+			array( 'chat' ),
             'openai',
             array(
                 'agent_id' => 123,

--- a/tests/ai-loop-event-sink-smoke.php
+++ b/tests/ai-loop-event-sink-smoke.php
@@ -218,7 +218,7 @@ $result = datamachine_run_conversation(
 	loop_event_sink_tools(),
 	'openai',
 	'gpt-smoke',
-	'pipeline',
+	array( 'pipeline' ),
 	array(
 		'event_sink'   => $collector,
 		'job_id'       => 1479,
@@ -297,7 +297,7 @@ $action_result = datamachine_run_conversation(
 	loop_event_sink_tools(),
 	'openai',
 	'gpt-smoke',
-	'pipeline',
+	array( 'pipeline' ),
 	array( 'job_id' => 1774 ),
 	3
 );
@@ -323,7 +323,7 @@ $failure_result = datamachine_run_conversation(
 	array(),
 	'openai',
 	'gpt-smoke',
-	'pipeline',
+	array( 'pipeline' ),
 	array( 'event_sink' => $failure_sink ),
 	1
 );
@@ -361,7 +361,7 @@ $throwing_result = datamachine_run_conversation(
 	array(),
 	'openai',
 	'gpt-smoke',
-	'pipeline',
+	array( 'pipeline' ),
 	array( 'event_sink' => new LoopEventSinkSmokeThrowingSink() ),
 	1
 );

--- a/tests/ai-request-inspector-smoke.php
+++ b/tests/ai-request-inspector-smoke.php
@@ -121,7 +121,7 @@ $generic_assembled = ( new \DataMachine\Engine\AI\ProviderRequestAssembler() )->
 	'openai',
 	'gpt-test',
 	$tools,
-	'pipeline',
+	array( 'pipeline' ),
 	array(
 		'job_id'       => 1423,
 		'flow_step_id' => 'ai_step_1',
@@ -160,7 +160,7 @@ $assembled = \DataMachine\Engine\AI\RequestBuilder::assemble(
 	'openai',
 	'gpt-test',
 	$tools,
-	'pipeline',
+	array( 'pipeline' ),
 	array(
 		'job_id'       => 1423,
 		'flow_step_id' => 'ai_step_1',

--- a/tests/ai-request-metadata-guardrails-smoke.php
+++ b/tests/ai-request-metadata-guardrails-smoke.php
@@ -266,7 +266,7 @@ function build_smoke_request() {
 				'parameters'  => array( 'type' => 'object', 'properties' => array( 'title' => array( 'type' => 'string' ) ) ),
 			),
 		),
-		'pipeline',
+		array( 'pipeline' ),
 		array( 'job_id' => 279, 'flow_step_id' => 12, 'persist_transcript' => true ),
 		$request_metadata
 	);

--- a/tests/ai-step-agent-mode-plumbing-smoke.php
+++ b/tests/ai-step-agent-mode-plumbing-smoke.php
@@ -24,28 +24,28 @@ $assert = static function ( string $message, bool $condition ) use ( &$failures,
 };
 
 $assert(
-	'AI step resolves execution mode from step configuration',
-	false !== strpos( $source, 'resolveExecutionMode( $pipeline_step_config, $this->flow_step_config )' )
+	'AI step resolves execution modes from step configuration',
+	false !== strpos( $source, 'resolveExecutionModes( $pipeline_step_config, $this->flow_step_config )' )
 );
 
 $assert(
-	'model resolution uses resolved execution mode',
-	false !== strpos( $source, 'PluginSettings::resolveModelForAgentMode( $agent_id, $execution_mode )' )
+	'model resolution uses resolved execution modes',
+	false !== strpos( $source, 'resolveModelForExecutionModes( $agent_id, $execution_modes )' )
 );
 
 $assert(
-	'tool policy receives resolved execution mode',
-	false !== strpos( $source, "'mode'                 => $" . 'execution_mode' )
+	'tool policy receives resolved execution modes',
+	false !== strpos( $source, "'modes'                => $" . 'execution_modes' )
 );
 
 $assert(
-	'conversation loop receives resolved execution mode',
-	false !== strpos( $source, "\n\t\t\t\t\t$" . 'execution_mode,' )
+	'conversation loop receives resolved execution modes',
+	false !== strpos( $source, "\n\t\t\t\t\t$" . 'execution_modes,' )
 );
 
 $assert(
-	'payload carries agent_mode for directives and runtime context',
-	false !== strpos( $source, "'agent_mode'                  => $" . 'execution_mode' )
+	'payload carries agent_modes for directives and runtime context',
+	false !== strpos( $source, "'agent_modes'                 => $" . 'execution_modes' )
 );
 
 $assert(

--- a/tests/core-memory-composable-first-read-smoke.php
+++ b/tests/core-memory-composable-first-read-smoke.php
@@ -155,7 +155,7 @@ namespace {
 		array(),
 		null,
 		array(
-			'agent_mode' => 'pipeline',
+			'agent_modes' => array( 'pipeline' ),
 			'user_id'    => 123,
 			'agent_id'   => 456,
 		)

--- a/tests/directive-policy-resolver-smoke.php
+++ b/tests/directive-policy-resolver-smoke.php
@@ -81,7 +81,7 @@ namespace {
 	$result = $resolver->resolve(
 		$directives,
 		array(
-			'mode'     => 'pipeline',
+			'modes'    => array( 'pipeline' ),
 			'agent_id' => 0,
 		)
 	);
@@ -100,7 +100,7 @@ namespace {
 	$result = $resolver->resolve(
 		$directives,
 		array(
-			'mode'     => 'pipeline',
+			'modes'    => array( 'pipeline' ),
 			'agent_id' => 1,
 		)
 	);
@@ -119,7 +119,7 @@ namespace {
 	$result = $resolver->resolve(
 		$directives,
 		array(
-			'mode'     => 'pipeline',
+			'modes'    => array( 'pipeline' ),
 			'agent_id' => 2,
 		)
 	);
@@ -138,7 +138,7 @@ namespace {
 	$result = $resolver->resolve(
 		$directives,
 		array(
-			'mode'     => 'pipeline',
+			'modes'    => array( 'pipeline' ),
 			'agent_id' => 3,
 		)
 	);
@@ -158,7 +158,7 @@ namespace {
 	$result = $resolver->resolve(
 		$directives,
 		array(
-			'mode'     => 'chat',
+			'modes'    => array( 'chat' ),
 			'agent_id' => 4,
 		)
 	);
@@ -167,7 +167,7 @@ namespace {
 	$result = $resolver->resolve(
 		$directives,
 		array(
-			'mode'     => 'pipeline',
+			'modes'    => array( 'pipeline' ),
 			'agent_id' => 4,
 		)
 	);

--- a/tests/global-tool-pipeline-modes-smoke.php
+++ b/tests/global-tool-pipeline-modes-smoke.php
@@ -66,14 +66,18 @@ function load_global_tool_for_pipeline_modes( string $relative_path, string $cla
 	new $class_name();
 }
 
-function resolve_tools_for_pipeline_modes( string $mode ): array {
+function resolve_tools_for_pipeline_modes( string $mode, array $allow_only = array() ): array {
 	$tools = apply_filters( 'datamachine_tools', array() );
 
 	return array_filter(
 		$tools,
-		function ( $tool ) use ( $mode ) {
-			return is_array( $tool ) && in_array( $mode, $tool['modes'] ?? array(), true );
+		function ( $tool, string $tool_name ) use ( $mode, $allow_only ) {
+			return is_array( $tool )
+				&& in_array( $mode, $tool['modes'] ?? array(), true )
+				&& ( empty( $tool['requires_opt_in'] ) || in_array( $tool_name, $allow_only, true ) );
 		}
+		,
+		ARRAY_FILTER_USE_BOTH
 	);
 }
 
@@ -107,7 +111,7 @@ foreach ( $chat_only as $tool => [ $path, $class_name ] ) {
 load_global_tool_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentDailyMemory.php', 'DataMachine\Engine\AI\Tools\Global\AgentDailyMemory' );
 load_global_tool_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentMemory.php', 'DataMachine\Engine\AI\Tools\Global\AgentMemory' );
 
-$chat_tools     = resolve_tools_for_pipeline_modes( 'chat' );
+$chat_tools     = resolve_tools_for_pipeline_modes( 'chat', array( 'agent_daily_memory', 'agent_memory' ) );
 $pipeline_tools = resolve_tools_for_pipeline_modes( 'pipeline' );
 assert_true_for_pipeline_modes(
 	isset( $chat_tools['agent_daily_memory'] ),
@@ -122,8 +126,8 @@ assert_true_for_pipeline_modes(
 	$passes
 );
 assert_true_for_pipeline_modes(
-	file_contains_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentDailyMemory.php', 'ToolPolicyResolver::MODE_PIPELINE_POLICY' ),
-	'agent_daily_memory declares policy-controlled pipeline availability',
+	file_contains_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentDailyMemory.php', "'requires_opt_in' => true" ),
+	'agent_daily_memory declares opt-in availability',
 	$failures,
 	$passes
 );
@@ -140,8 +144,8 @@ assert_true_for_pipeline_modes(
 	$passes
 );
 assert_true_for_pipeline_modes(
-	file_contains_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentMemory.php', 'ToolPolicyResolver::MODE_PIPELINE_POLICY' ),
-	'agent_memory declares policy-controlled pipeline availability',
+	file_contains_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentMemory.php', "'requires_opt_in' => true" ),
+	'agent_memory declares opt-in availability',
 	$failures,
 	$passes
 );

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -87,8 +87,8 @@ class SnapshotPolicyToolManager extends ToolManager {
 			'alpha_tool'         => array( 'modes' => array( 'pipeline' ) ),
 			'beta_tool'          => array( 'modes' => array( 'pipeline' ) ),
 			'danger_tool'        => array( 'modes' => array( 'pipeline' ) ),
-			'agent_daily_memory' => array( 'modes' => array( 'chat', ToolPolicyResolver::MODE_PIPELINE_POLICY ) ),
-			'agent_memory'       => array( 'modes' => array( 'chat', ToolPolicyResolver::MODE_PIPELINE_POLICY ) ),
+			'agent_daily_memory' => array( 'modes' => array( 'chat', ToolPolicyResolver::MODE_PIPELINE ), 'requires_opt_in' => true ),
+			'agent_memory'       => array( 'modes' => array( 'chat', ToolPolicyResolver::MODE_PIPELINE ), 'requires_opt_in' => true ),
 			'chat_only'          => array( 'modes' => array( 'chat' ) ),
 		);
 	}
@@ -96,6 +96,10 @@ class SnapshotPolicyToolManager extends ToolManager {
 	public function is_tool_available( string $tool_id, ?string $context_id = null ): bool {
 		$this->availability_contexts[] = $context_id;
 		return null === $context_id;
+	}
+
+	public function is_globally_enabled( string $tool_id ): bool {
+		return true;
 	}
 
 	public function resolveHandlerTools( string $handler_slug, array $handler_config, array $engine_data, string $cache_scope = '' ): array {
@@ -152,7 +156,7 @@ $tools   = resolve_policy_tools_for_test(
 	$manager
 );
 assert_policy_equals( array( 'alpha_tool' ), array_keys( $tools ), 'allowlist keeps only enabled tool', $failures, $passes );
-assert_policy_equals( array( null, null, null ), $manager->availability_contexts, 'pipeline availability does not pass context IDs for default pipeline tools', $failures, $passes );
+assert_policy_equals( array(), $manager->availability_contexts, 'default pipeline tools avoid per-step availability context lookups', $failures, $passes );
 
 $manager = new SnapshotPolicyToolManager();
 $tools   = resolve_policy_tools_for_test(
@@ -165,7 +169,7 @@ $tools   = resolve_policy_tools_for_test(
 	$manager
 );
 assert_policy_equals( array( 'agent_daily_memory', 'agent_memory' ), array_keys( $tools ), 'allowlist can intentionally grant policy-controlled memory tools', $failures, $passes );
-assert_policy_equals( array( null, null, null, null, null ), $manager->availability_contexts, 'policy-controlled memory tools still use pipeline availability checks', $failures, $passes );
+assert_policy_equals( array(), $manager->availability_contexts, 'opt-in memory tools avoid per-step availability context lookups', $failures, $passes );
 
 echo "\n[2] ephemeral workflow disabled_tools deny from snapshot:\n";
 $ephemeral = WorkflowConfigFactory::buildEphemeralConfigs(
@@ -184,7 +188,7 @@ $pipeline_step_config = $ephemeral['pipeline_config']['ephemeral_pipeline_0'];
 $manager              = new SnapshotPolicyToolManager();
 $tools                = resolve_policy_tools_for_test( $flow_step_config, $pipeline_step_config, $manager );
 assert_policy_equals( array( 'alpha_tool', 'beta_tool' ), array_keys( $tools ), 'ephemeral disabled_tools removes denied tool without DB row and does not auto-grant daily memory', $failures, $passes );
-assert_policy_equals( array( null, null, null ), $manager->availability_contexts, 'ephemeral policy never re-reads by synthetic pipeline step ID', $failures, $passes );
+assert_policy_equals( array(), $manager->availability_contexts, 'ephemeral policy never re-reads by synthetic pipeline step ID', $failures, $passes );
 
 echo "\n[3] persistent workflow disabled_tools still apply from snapshot:\n";
 $workflow = array(
@@ -203,7 +207,7 @@ $flow_step_id         = array_key_first( $flow_config );
 $manager              = new SnapshotPolicyToolManager();
 $tools                = resolve_policy_tools_for_test( $flow_config[ $flow_step_id ], $pipeline_config[ $pipeline_step_id ], $manager );
 assert_policy_equals( array( 'alpha_tool', 'danger_tool' ), array_keys( $tools ), 'persistent disabled_tools removes denied tool', $failures, $passes );
-assert_policy_equals( array( null, null, null ), $manager->availability_contexts, 'persistent policy does not re-read persisted step config', $failures, $passes );
+assert_policy_equals( array(), $manager->availability_contexts, 'persistent policy does not re-read persisted step config', $failures, $passes );
 
 echo "\n[4] RequestInspector and AIStep share policy input helper:\n";
 $ai_step_source   = file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' ) ?: '';

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -102,7 +102,7 @@ class SourcePolicyToolManager extends ToolManager {
 			'custom_static_tool'   => array( 'modes' => array( 'custom_mode' ), 'origin' => 'static' ),
 			'handler_wrapper'      => array( 'modes' => array( 'pipeline' ), '_handler_callable' => 'noop' ),
 			'disabled_static_tool' => array( 'modes' => array( 'chat' ), 'origin' => 'static', 'access_level' => 'public' ),
-			'durable_memory_tool'  => array( 'modes' => array( 'chat', 'pipeline_policy' ), 'origin' => 'static', 'access_level' => 'public' ),
+			'durable_memory_tool'  => array( 'modes' => array( 'chat', 'pipeline' ), 'origin' => 'static', 'access_level' => 'public', 'requires_opt_in' => true ),
 		);
 	}
 
@@ -150,13 +150,13 @@ function assert_source_equals( $expected, $actual, string $name, array &$failure
 	echo '    actual:   ' . var_export( $actual, true ) . "\n";
 }
 
-function resolve_source_tools( string $mode, SourcePolicyToolManager $manager, array $extra = array() ): array {
+function resolve_source_tools( string|array $modes, SourcePolicyToolManager $manager, array $extra = array() ): array {
 	$resolver = new ToolPolicyResolver( $manager );
 
 	return $resolver->resolve(
 		array_merge(
 			array(
-				'mode'                 => $mode,
+				'modes'                => is_array( $modes ) ? $modes : array( $modes ),
 				'agent_id'             => 0,
 				'previous_step_config' => null,
 				'next_step_config'     => null,
@@ -198,7 +198,7 @@ assert_source_equals( array( 'ticketmaster_fetch:previous:fetch_step', 'publish_
 
 echo "\n[2] non-pipeline modes use static registry only:\n";
 $manager = new SourcePolicyToolManager();
-assert_source_equals( array( 'chat_static_tool', 'durable_memory_tool' ), array_keys( resolve_source_tools( ToolPolicyResolver::MODE_CHAT, $manager ) ), 'chat mode gets static chat tools only', $failures, $passes );
+assert_source_equals( array( 'chat_static_tool' ), array_keys( resolve_source_tools( ToolPolicyResolver::MODE_CHAT, $manager ) ), 'chat mode gets static chat tools only', $failures, $passes );
 assert_source_equals( array(), $manager->handler_calls, 'chat mode does not query adjacent handlers', $failures, $passes );
 assert_source_equals( array( 'system_static_tool' ), array_keys( resolve_source_tools( ToolPolicyResolver::MODE_SYSTEM, new SourcePolicyToolManager() ) ), 'system mode gets static system tools only', $failures, $passes );
 assert_source_equals( array( 'custom_static_tool' ), array_keys( resolve_source_tools( 'custom_mode', new SourcePolicyToolManager() ) ), 'custom mode gets static custom-mode tools only', $failures, $passes );
@@ -207,8 +207,8 @@ echo "\n[3] filters can add a source without disturbing default order:\n";
 remove_all_filters_for_source_smoke();
 add_filter(
 	'agents_api_tool_sources',
-	static function ( array $sources, string $mode, array $args, ToolManager $tool_manager ): array {
-		unset( $mode, $args, $tool_manager );
+	static function ( array $sources, array $modes, array $args, ToolManager $tool_manager ): array {
+		unset( $modes, $args, $tool_manager );
 		$sources['extra_source'] = static function (): array {
 			return array(
 				'extra_tool' => array( 'origin' => 'extra', 'access_level' => 'public' ),
@@ -221,9 +221,9 @@ add_filter(
 );
 add_filter(
 	'agents_api_tool_sources_for_mode',
-	static function ( array $sources, string $mode, array $args ): array {
+	static function ( array $sources, array $modes, array $args ): array {
 		unset( $args );
-		if ( ToolPolicyResolver::MODE_CHAT === $mode ) {
+		if ( in_array( ToolPolicyResolver::MODE_CHAT, $modes, true ) ) {
 			$sources[] = 'extra_source';
 		}
 		return $sources;
@@ -232,7 +232,7 @@ add_filter(
 	3
 );
 $tools = resolve_source_tools( ToolPolicyResolver::MODE_CHAT, new SourcePolicyToolManager() );
-assert_source_equals( array( 'chat_static_tool', 'durable_memory_tool', 'extra_tool' ), array_keys( $tools ), 'filter appends extra source after static source', $failures, $passes );
+assert_source_equals( array( 'chat_static_tool', 'extra_tool' ), array_keys( $tools ), 'filter appends extra source after static source', $failures, $passes );
 remove_all_filters_for_source_smoke();
 add_filter(
 	'datamachine_tool_sources',
@@ -256,89 +256,51 @@ add_filter(
 	10,
 	1
 );
-assert_source_equals( array( 'chat_static_tool', 'durable_memory_tool' ), array_keys( resolve_source_tools( ToolPolicyResolver::MODE_CHAT, new SourcePolicyToolManager() ) ), 'legacy Data Machine tool-source filters are no longer mirrored', $failures, $passes );
+assert_source_equals( array( 'chat_static_tool' ), array_keys( resolve_source_tools( ToolPolicyResolver::MODE_CHAT, new SourcePolicyToolManager() ) ), 'legacy Data Machine tool-source filters are no longer mirrored', $failures, $passes );
 
-echo "\n[4] custom mode can inherit another mode's tool surface via filter:\n";
+echo "\n[4] multi-mode runs expose every active mode surface:\n";
 remove_all_filters_for_source_smoke();
 assert_source_equals(
 	array( 'custom_static_tool' ),
 	array_keys( resolve_source_tools( 'custom_mode', new SourcePolicyToolManager() ) ),
-	'custom mode without filter still gets only custom-mode tools',
+	'custom mode alone gets only custom-mode tools',
 	$failures,
 	$passes
 );
-add_filter(
-	'datamachine_tool_mode_matchable_modes',
-	static function ( array $matchable, string $mode ): array {
-		if ( 'custom_mode' === $mode ) {
-			$matchable[] = ToolPolicyResolver::MODE_PIPELINE;
-		}
-		return $matchable;
-	},
-	10,
-	2
-);
-$inherited = resolve_source_tools( 'custom_mode', new SourcePolicyToolManager() );
-assert_source_equals( true, isset( $inherited['custom_static_tool'] ), 'inheritance keeps custom mode\'s own tools', $failures, $passes );
-assert_source_equals( true, isset( $inherited['static_pipeline_tool'] ), 'inheritance from pipeline exposes pipeline-only tools to the custom mode', $failures, $passes );
-assert_source_equals( true, isset( $inherited['collision_tool'] ), 'pipeline tools registered for the inherited mode become available', $failures, $passes );
-assert_source_equals( false, isset( $inherited['chat_static_tool'] ), 'inheritance does not leak unrelated mode tools', $failures, $passes );
-assert_source_equals( false, isset( $inherited['handler_wrapper'] ), 'inherited custom mode still skips handler wrappers (non-pipeline source)', $failures, $passes );
-remove_all_filters_for_source_smoke();
-add_filter(
-	'datamachine_tool_mode_matchable_modes',
-	static function (): array {
-		return array();
-	},
-	10,
-	2
-);
-$null_filter = resolve_source_tools( 'custom_mode', new SourcePolicyToolManager() );
-assert_source_equals( array( 'custom_static_tool' ), array_keys( $null_filter ), 'empty filter return falls back to current mode', $failures, $passes );
-remove_all_filters_for_source_smoke();
+$multimode = resolve_source_tools( array( 'pipeline', 'custom_mode' ), new SourcePolicyToolManager() );
+assert_source_equals( true, isset( $multimode['custom_static_tool'] ), 'multi-mode run keeps custom mode tools', $failures, $passes );
+assert_source_equals( true, isset( $multimode['static_pipeline_tool'] ), 'multi-mode run exposes pipeline tools', $failures, $passes );
+assert_source_equals( true, isset( $multimode['collision_tool'] ), 'multi-mode run exposes static pipeline tools', $failures, $passes );
+assert_source_equals( false, isset( $multimode['chat_static_tool'] ), 'multi-mode run does not leak unrelated mode tools', $failures, $passes );
+assert_source_equals( false, isset( $multimode['handler_wrapper'] ), 'multi-mode run still skips handler wrappers in static source', $failures, $passes );
 
-echo "\n[5] pipeline_policy tools follow pipeline inheritance:\n";
-remove_all_filters_for_source_smoke();
-$pipeline_policy_baseline = resolve_source_tools(
+echo "\n[5] requires_opt_in tools require allow_only:\n";
+$opt_in_baseline = resolve_source_tools(
 	ToolPolicyResolver::MODE_PIPELINE,
 	new SourcePolicyToolManager(),
 	array( 'allow_only' => array( 'durable_memory_tool' ) )
 );
-assert_source_equals( true, isset( $pipeline_policy_baseline['durable_memory_tool'] ), 'pipeline mode picks up policy-gated tool when allowlisted', $failures, $passes );
-$pipeline_policy_no_allowlist = resolve_source_tools(
+assert_source_equals( true, isset( $opt_in_baseline['durable_memory_tool'] ), 'pipeline mode picks up opt-in tool when allowlisted', $failures, $passes );
+$opt_in_no_allowlist = resolve_source_tools(
 	ToolPolicyResolver::MODE_PIPELINE,
 	new SourcePolicyToolManager()
 );
-assert_source_equals( false, isset( $pipeline_policy_no_allowlist['durable_memory_tool'] ), 'pipeline mode skips policy-gated tool without allowlist', $failures, $passes );
-add_filter(
-	'datamachine_tool_mode_matchable_modes',
-	static function ( array $matchable, string $mode ): array {
-		if ( 'custom_mode' === $mode ) {
-			$matchable[] = ToolPolicyResolver::MODE_PIPELINE;
-		}
-		return $matchable;
-	},
-	10,
-	2
-);
-$inherited_policy = resolve_source_tools(
-	'custom_mode',
+$multi_opt_in = resolve_source_tools(
+	array( 'custom_mode', ToolPolicyResolver::MODE_PIPELINE ),
 	new SourcePolicyToolManager(),
 	array( 'allow_only' => array( 'durable_memory_tool' ) )
 );
-assert_source_equals( true, isset( $inherited_policy['durable_memory_tool'] ), 'custom mode that inherits pipeline picks up policy-gated tool when allowlisted', $failures, $passes );
-$inherited_policy_no_allowlist = resolve_source_tools(
-	'custom_mode',
+assert_source_equals( true, isset( $multi_opt_in['durable_memory_tool'] ), 'multi-mode run picks up opt-in pipeline tool when allowlisted', $failures, $passes );
+$multi_opt_in_no_allowlist = resolve_source_tools(
+	array( 'custom_mode', ToolPolicyResolver::MODE_PIPELINE ),
 	new SourcePolicyToolManager()
 );
-assert_source_equals( false, isset( $inherited_policy_no_allowlist['durable_memory_tool'] ), 'custom mode that inherits pipeline still skips policy-gated tool without allowlist', $failures, $passes );
-remove_all_filters_for_source_smoke();
+assert_source_equals( false, isset( $multi_opt_in_no_allowlist['durable_memory_tool'] ), 'multi-mode run skips opt-in pipeline tool without allowlist', $failures, $passes );
 $chat_no_inheritance = resolve_source_tools(
 	ToolPolicyResolver::MODE_CHAT,
-	new SourcePolicyToolManager(),
-	array( 'allow_only' => array( 'durable_memory_tool' ) )
+	new SourcePolicyToolManager()
 );
-assert_source_equals( true, isset( $chat_no_inheritance['durable_memory_tool'] ), 'chat mode keeps direct access to its own pipeline_policy tool entry', $failures, $passes );
+assert_source_equals( false, isset( $chat_no_inheritance['durable_memory_tool'] ), 'chat mode also respects requires_opt_in', $failures, $passes );
 
 echo "\n[6] Data Machine source adapters own product vocabulary:\n";
 $registry_source          = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php' );

--- a/tests/workflow-spec-contract-smoke.php
+++ b/tests/workflow-spec-contract-smoke.php
@@ -160,7 +160,7 @@ $configs         = WorkflowConfigFactory::buildEphemeralConfigs(
 			array(
 				'type'           => 'ai',
 				'label'          => 'Summarize',
-				'agent_mode'     => 'rl_task',
+				'agent_modes'    => array( 'rl_task' ),
 				'system_prompt'  => 'Be concise.',
 				'disabled_tools' => array( 'danger_tool' ),
 				'completion_assertions' => array(
@@ -188,7 +188,7 @@ assert_workflow_spec_equals( array( 'ephemeral_pipeline_0', 'ephemeral_pipeline_
 assert_workflow_spec_equals( array( 'fetch', 'ai', 'system_task' ), array_column( $pipeline_steps, 'step_type' ), 'ephemeral pipeline_config preserves step types', $failures, $passes );
 assert_workflow_spec_equals( array( 0, 1, 2 ), array_column( $pipeline_steps, 'execution_order' ), 'ephemeral pipeline_config preserves execution order', $failures, $passes );
 assert_workflow_spec_equals( 'Fetch Source', $pipeline_steps[0]['label'] ?? null, 'ephemeral pipeline_config preserves fetch label', $failures, $passes );
-assert_workflow_spec_equals( 'rl_task', $pipeline_steps[1]['agent_mode'] ?? null, 'ephemeral pipeline_config preserves AI agent mode', $failures, $passes );
+assert_workflow_spec_equals( array( 'rl_task' ), $pipeline_steps[1]['agent_modes'] ?? null, 'ephemeral pipeline_config preserves AI agent modes', $failures, $passes );
 assert_workflow_spec_equals( 'Be concise.', $pipeline_steps[1]['system_prompt'] ?? null, 'ephemeral pipeline_config preserves AI system prompt', $failures, $passes );
 assert_workflow_spec_equals( array( 'danger_tool' ), $pipeline_steps[1]['disabled_tools'] ?? null, 'ephemeral pipeline_config preserves AI disabled tools', $failures, $passes );
 assert_workflow_spec_equals( array( 'required_tool_names' => array( 'publish_result' ) ), $pipeline_steps[1]['completion_assertions'] ?? null, 'ephemeral pipeline_config preserves AI completion assertions', $failures, $passes );

--- a/tests/wp-ai-client-request-timeout-smoke.php
+++ b/tests/wp-ai-client-request-timeout-smoke.php
@@ -253,7 +253,7 @@ $result           = RequestBuilder::build(
 	'openai',
 	'gpt-smoke',
 	array(),
-	'pipeline',
+	array( 'pipeline' ),
 	array( 'job_id' => 1695, 'flow_step_id' => 'ai-step-1' ),
 	$request_metadata
 );

--- a/tests/wp-ai-client-runtime-gate-smoke.php
+++ b/tests/wp-ai-client-runtime-gate-smoke.php
@@ -146,7 +146,7 @@ $response = RequestBuilder::build(
 	'openai',
 	'gpt-smoke',
 	array(),
-	'pipeline',
+	array( 'pipeline' ),
 	array( 'job_id' => 1633 )
 );
 

--- a/tests/wp-ai-client-tool-schema-smoke.php
+++ b/tests/wp-ai-client-tool-schema-smoke.php
@@ -153,7 +153,7 @@ $response = \DataMachine\Engine\AI\RequestBuilder::build(
 			),
 		),
 	),
-	'pipeline',
+	array( 'pipeline' ),
 	array( 'job_id' => 1684 )
 );
 
@@ -213,7 +213,7 @@ $captured_request = array();
 			),
 		),
 	),
-	'pipeline',
+	array( 'pipeline' ),
 	array( 'job_id' => 1686 )
 );
 
@@ -262,7 +262,7 @@ $response_no_user = \DataMachine\Engine\AI\RequestBuilder::build(
 	'openai',
 	'gpt-smoke',
 	array(),
-	'pipeline',
+	array( 'pipeline' ),
 	array( 'job_id' => 1685 )
 );
 
@@ -302,7 +302,7 @@ $captured_request = array();
 			'parameters'  => array(),
 		),
 	),
-	'pipeline',
+	array( 'pipeline' ),
 	array( 'job_id' => 1686 )
 );
 


### PR DESCRIPTION
## Summary
- Replace singular AI execution mode plumbing with additive `agent_modes` arrays across AI steps, chat orchestration, request building, prompt directives, memory files, tool sources, and runtime provenance.
- Remove pipeline-policy mode inheritance from tool resolution and make pipeline memory tools explicit opt-in via `requires_opt_in`/allow-only policy.
- Update workflow/pipeline config surfaces, docs, unit tests, and smoke coverage for multimode execution.

## Related
- Fixes Extra-Chill/data-machine#2020.
- Follow-up PRs planned for Data Machine Code and World of WordPress after this core contract lands.

## Validation
- `php tests/tool-source-registry-smoke.php && php tests/agent-daily-memory-directive-smoke.php && php tests/global-tool-pipeline-modes-smoke.php && php tests/pipeline-tool-policy-snapshot-smoke.php && php tests/pipeline-tool-policy-surfaces-smoke.php && php tests/ai-step-agent-mode-plumbing-smoke.php && php tests/directive-policy-resolver-smoke.php && php tests/core-memory-composable-first-read-smoke.php && php tests/workflow-spec-contract-smoke.php && php tests/ai-request-inspector-smoke.php && php tests/agent-conversation-runner-request-smoke.php && php tests/ai-loop-event-sink-smoke.php && php tests/wp-ai-client-tool-schema-smoke.php && php tests/agent-conversation-runtime-policy-smoke.php && php tests/ai-request-metadata-guardrails-smoke.php && php tests/wp-ai-client-request-timeout-smoke.php && php tests/wp-ai-client-runtime-gate-smoke.php`
- `homeboy test data-machine -- --filter='MemoryFileRegistryTest|ToolPolicyResolverTest|ChatToolsAvailabilityTest'`
- `homeboy test data-machine` — 1264 passed, 3 skipped

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the multimode plumbing changes, updated tests/docs, and ran validation; Chris remains responsible for review and merge.