### PR TITLE
Separate chat transcript ownership from runtime user

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -691,6 +691,7 @@ function datamachine_ensure_all_tables() {
 	\DataMachine\Core\Database\BundleArtifacts\InstalledBundleArtifacts::create_table();
 
 	\DataMachine\Core\Database\Chat\Chat::create_table();
+	\DataMachine\Core\Database\Chat\Chat::ensure_owner_columns();
 	\DataMachine\Core\Database\Chat\Chat::ensure_mode_column();
 	\DataMachine\Core\Database\Chat\Chat::ensure_workspace_columns();
 	\DataMachine\Core\Database\Chat\Chat::ensure_agent_id_column();

--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -121,7 +121,7 @@ class AgentsChatHandler {
 				'agent_id'          => $agent_id,
 				'attachments'       => $input['attachments'] ?? array(),
 				'client_context'    => $client_context,
-				'transcript_owner' => is_array( $input['transcript_owner'] ?? null ) ? $input['transcript_owner'] : null,
+				'transcript_owner'  => is_array( $input['transcript_owner'] ?? null ) ? $input['transcript_owner'] : null,
 			)
 		);
 

--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -116,12 +116,12 @@ class AgentsChatHandler {
 			sanitize_text_field( $model ),
 			$user_id,
 			array(
-				'session_id'        => $input['session_id'] ?? null,
-				'modes'             => $modes,
-				'agent_id'          => $agent_id,
-				'attachments'       => $input['attachments'] ?? array(),
-				'client_context'    => $client_context,
-				'transcript_owner'  => is_array( $input['transcript_owner'] ?? null ) ? $input['transcript_owner'] : null,
+				'session_id'       => $input['session_id'] ?? null,
+				'modes'            => $modes,
+				'agent_id'         => $agent_id,
+				'attachments'      => $input['attachments'] ?? array(),
+				'client_context'   => $client_context,
+				'transcript_owner' => is_array( $input['transcript_owner'] ?? null ) ? $input['transcript_owner'] : null,
 			)
 		);
 

--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -116,11 +116,12 @@ class AgentsChatHandler {
 			sanitize_text_field( $model ),
 			$user_id,
 			array(
-				'session_id'     => $input['session_id'] ?? null,
-				'modes'          => $modes,
-				'agent_id'       => $agent_id,
-				'attachments'    => $input['attachments'] ?? array(),
-				'client_context' => $client_context,
+				'session_id'        => $input['session_id'] ?? null,
+				'modes'             => $modes,
+				'agent_id'          => $agent_id,
+				'attachments'       => $input['attachments'] ?? array(),
+				'client_context'    => $client_context,
+				'transcript_owner' => is_array( $input['transcript_owner'] ?? null ) ? $input['transcript_owner'] : null,
 			)
 		);
 

--- a/inc/Abilities/Chat/ChatSessionHelpers.php
+++ b/inc/Abilities/Chat/ChatSessionHelpers.php
@@ -51,20 +51,35 @@ trait ChatSessionHelpers {
 	}
 
 	/**
+	 * Resolve the transcript owner used by session abilities.
+	 *
+	 * @param array $input           Ability input.
+	 * @param int   $fallback_user_id User ID compatibility fallback.
+	 * @return array|\WP_Error
+	 */
+	protected function resolve_transcript_owner( array $input, int $fallback_user_id ) {
+		return ChatTranscriptOwner::resolve_for_request( $input, $fallback_user_id );
+	}
+
+	/**
 	 * Verify that a session exists and belongs to the given user.
 	 *
 	 * @param string $session_id Session ID to verify.
 	 * @param int    $user_id    User ID to check ownership against.
 	 * @return array|array{error: string} Session data on success, or array with 'error' key on failure.
 	 */
-	protected function verifySessionOwnership( string $session_id, int $user_id ): array {
+	protected function verifySessionOwnership( string $session_id, int $user_id, ?array $transcript_owner = null ): array {
 		$session = $this->chat_db->get_session( $session_id );
 
 		if ( ! $session ) {
 			return array( 'error' => 'session_not_found' );
 		}
 
-		if ( (int) $session['user_id'] !== $user_id ) {
+		$owns_session = null !== $transcript_owner && method_exists( $this->chat_db, 'session_matches_owner' )
+			? $this->chat_db->session_matches_owner( $session, $transcript_owner )
+			: ( (int) $session['user_id'] === $user_id );
+
+		if ( ! $owns_session ) {
 			return array( 'error' => 'session_access_denied' );
 		}
 

--- a/inc/Abilities/Chat/ChatTranscriptOwner.php
+++ b/inc/Abilities/Chat/ChatTranscriptOwner.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Transcript owner adapter for chat sessions.
+ *
+ * @package DataMachine\Abilities\Chat
+ */
+
+namespace DataMachine\Abilities\Chat;
+
+use DataMachine\Abilities\PermissionHelper;
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolves the transcript owner separately from the runtime execution user.
+ *
+ * This is intentionally a Data Machine-local adapter while Agents API issue
+ * #174 is open. The only non-user prototype shape accepted here is an explicit
+ * browser/principal key supplied as `transcript_owner` or
+ * `client_context.transcript_owner`.
+ */
+class ChatTranscriptOwner {
+
+	/**
+	 * Resolve a transcript owner for the current request.
+	 *
+	 * @param array $input Canonical/chat input or options.
+	 * @param int   $fallback_user_id Runtime user fallback for logged-in compatibility.
+	 * @return array{owner_type:string,owner_key:string,owner_key_hash:string,owner_label:string,user_id:int}|WP_Error
+	 */
+	public static function resolve_for_request( array $input = array(), int $fallback_user_id = 0 ): array|WP_Error {
+		$explicit = self::extract_explicit_owner( $input );
+		if ( null !== $explicit ) {
+			return self::normalize_explicit_owner( $explicit, $fallback_user_id );
+		}
+
+		$current_user_id = get_current_user_id();
+		if ( $current_user_id > 0 ) {
+			return self::user_owner( $current_user_id );
+		}
+
+		$acting_user_id = PermissionHelper::acting_user_id();
+		if ( $acting_user_id > 0 && $acting_user_id === $fallback_user_id && is_user_logged_in() ) {
+			return self::user_owner( $acting_user_id );
+		}
+
+		return new WP_Error(
+			'transcript_owner_required',
+			__( 'A logged-in user or explicit browser transcript owner is required for persistent chat sessions.', 'data-machine' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	/**
+	 * Build owner columns from a stored user ID for migration/back-compat.
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return array{owner_type:string,owner_key:string,owner_key_hash:string,owner_label:string,user_id:int}
+	 */
+	public static function user_owner( int $user_id ): array {
+		$user_id = absint( $user_id );
+
+		return self::from_key( 'user', 'user:' . $user_id, 'User ' . $user_id, $user_id );
+	}
+
+	/**
+	 * Hash a stable owner key for storage.
+	 *
+	 * @param string $owner_key Stable owner key.
+	 * @return string
+	 */
+	public static function hash_owner_key( string $owner_key ): string {
+		return hash( 'sha256', $owner_key );
+	}
+
+	/**
+	 * Extract a prototype owner from supported local input positions.
+	 *
+	 * @param array $input Request input.
+	 * @return array|null
+	 */
+	private static function extract_explicit_owner( array $input ): ?array {
+		if ( isset( $input['transcript_owner'] ) && is_array( $input['transcript_owner'] ) ) {
+			return $input['transcript_owner'];
+		}
+
+		if ( isset( $input['session_owner'] ) && is_array( $input['session_owner'] ) ) {
+			return $input['session_owner'];
+		}
+
+		$client_context = is_array( $input['client_context'] ?? null ) ? $input['client_context'] : array();
+		if ( isset( $client_context['transcript_owner'] ) && is_array( $client_context['transcript_owner'] ) ) {
+			return $client_context['transcript_owner'];
+		}
+
+		if ( isset( $client_context['session_owner'] ) && is_array( $client_context['session_owner'] ) ) {
+			return $client_context['session_owner'];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Normalize a local prototype owner shape.
+	 *
+	 * @param array $owner            Explicit owner input.
+	 * @param int   $fallback_user_id Runtime user fallback.
+	 * @return array{owner_type:string,owner_key:string,owner_key_hash:string,owner_label:string,user_id:int}|WP_Error
+	 */
+	private static function normalize_explicit_owner( array $owner, int $fallback_user_id ): array|WP_Error {
+		$type  = sanitize_key( (string) ( $owner['owner_type'] ?? $owner['type'] ?? '' ) );
+		$key   = trim( (string) ( $owner['owner_key'] ?? $owner['key'] ?? $owner['principal_key'] ?? '' ) );
+		$label = sanitize_text_field( (string) ( $owner['owner_label'] ?? $owner['label'] ?? '' ) );
+
+		if ( 'user' === $type ) {
+			$user_id = absint( $owner['user_id'] ?? preg_replace( '/^user:/', '', $key ) );
+			return $user_id > 0 ? self::user_owner( $user_id ) : new WP_Error( 'invalid_transcript_owner', __( 'Invalid user transcript owner.', 'data-machine' ), array( 'status' => 400 ) );
+		}
+
+		if ( '' === $type || '' === $key ) {
+			return new WP_Error( 'invalid_transcript_owner', __( 'Transcript owner type and key are required.', 'data-machine' ), array( 'status' => 400 ) );
+		}
+
+		if ( 'audience' === $type && in_array( $key, array( 'public', 'audience:public' ), true ) ) {
+			return new WP_Error( 'non_isolating_transcript_owner', __( 'Public audience is not an isolating transcript owner.', 'data-machine' ), array( 'status' => 400 ) );
+		}
+
+		if ( '' === $label ) {
+			$label = $type;
+		}
+
+		return self::from_key( $type, $type . ':' . $key, $label, $fallback_user_id );
+	}
+
+	/**
+	 * Build a normalized owner array from a stable key.
+	 *
+	 * @param string $type    Owner type.
+	 * @param string $key     Stable owner key.
+	 * @param string $label   Human-readable label.
+	 * @param int    $user_id Compatibility/reporting user ID.
+	 * @return array{owner_type:string,owner_key:string,owner_key_hash:string,owner_label:string,user_id:int}
+	 */
+	private static function from_key( string $type, string $key, string $label, int $user_id ): array {
+		return array(
+			'owner_type'     => sanitize_key( $type ),
+			'owner_key'      => $key,
+			'owner_key_hash' => self::hash_owner_key( $key ),
+			'owner_label'    => mb_substr( sanitize_text_field( $label ), 0, 191 ),
+			'user_id'        => absint( $user_id ),
+		);
+	}
+}

--- a/inc/Abilities/Chat/CreateChatSessionAbility.php
+++ b/inc/Abilities/Chat/CreateChatSessionAbility.php
@@ -128,6 +128,10 @@ class CreateChatSessionAbility {
 			$session_metadata['source'] = $source;
 		}
 
+		if ( isset( $input['transcript_owner'] ) && is_array( $input['transcript_owner'] ) ) {
+			$session_metadata['transcript_owner'] = $input['transcript_owner'];
+		}
+
 		// Merge any additional metadata from input.
 		if ( ! empty( $input['metadata'] ) && is_array( $input['metadata'] ) ) {
 			$session_metadata = array_merge( $session_metadata, $input['metadata'] );

--- a/inc/Abilities/Chat/DeleteChatSessionAbility.php
+++ b/inc/Abilities/Chat/DeleteChatSessionAbility.php
@@ -98,6 +98,13 @@ class DeleteChatSessionAbility {
 
 		$session_id = sanitize_text_field( $input['session_id'] );
 		$user_id    = (int) $input['user_id'];
+		$owner      = $this->resolve_transcript_owner( $input, $user_id );
+		if ( is_wp_error( $owner ) ) {
+			return array(
+				'success' => false,
+				'error'   => $owner->get_error_code(),
+			);
+		}
 
 		if ( ! $this->can_access_user_sessions( $user_id ) ) {
 			return array(
@@ -106,7 +113,7 @@ class DeleteChatSessionAbility {
 			);
 		}
 
-		$session = $this->verifySessionOwnership( $session_id, $user_id );
+		$session = $this->verifySessionOwnership( $session_id, $user_id, $owner );
 
 		if ( isset( $session['error'] ) ) {
 			return array(

--- a/inc/Abilities/Chat/GetChatSessionAbility.php
+++ b/inc/Abilities/Chat/GetChatSessionAbility.php
@@ -101,6 +101,13 @@ class GetChatSessionAbility {
 
 		$session_id = sanitize_text_field( $input['session_id'] );
 		$user_id    = (int) $input['user_id'];
+		$owner      = $this->resolve_transcript_owner( $input, $user_id );
+		if ( is_wp_error( $owner ) ) {
+			return array(
+				'success' => false,
+				'error'   => $owner->get_error_code(),
+			);
+		}
 
 		if ( ! $this->can_access_user_sessions( $user_id ) ) {
 			return array(
@@ -109,7 +116,7 @@ class GetChatSessionAbility {
 			);
 		}
 
-		$session = $this->verifySessionOwnership( $session_id, $user_id );
+		$session = $this->verifySessionOwnership( $session_id, $user_id, $owner );
 
 		if ( isset( $session['error'] ) ) {
 			return array(

--- a/inc/Abilities/Chat/ListChatSessionsAbility.php
+++ b/inc/Abilities/Chat/ListChatSessionsAbility.php
@@ -112,6 +112,13 @@ class ListChatSessionsAbility {
 		}
 
 		$user_id = (int) $input['user_id'];
+		$owner   = $this->resolve_transcript_owner( $input, $user_id );
+		if ( is_wp_error( $owner ) ) {
+			return array(
+				'success' => false,
+				'error'   => $owner->get_error_code(),
+			);
+		}
 
 		if ( ! $this->can_access_user_sessions( $user_id ) ) {
 			return array(
@@ -125,8 +132,8 @@ class ListChatSessionsAbility {
 		$mode     = ! empty( $input['mode'] ) ? sanitize_text_field( $input['mode'] ) : null;
 		$agent_id = isset( $input['agent_id'] ) && is_numeric( $input['agent_id'] ) ? (int) $input['agent_id'] : null;
 
-		$sessions = $this->chat_db->get_user_sessions( $user_id, $limit, $offset, $mode, $agent_id );
-		$total    = $this->chat_db->get_user_session_count( $user_id, $mode, $agent_id );
+		$sessions = $this->chat_db->get_user_sessions( $user_id, $limit, $offset, $mode, $agent_id, $owner );
+		$total    = $this->chat_db->get_user_session_count( $user_id, $mode, $agent_id, $owner );
 
 		return array(
 			'success'  => true,

--- a/inc/Abilities/Chat/MarkSessionReadAbility.php
+++ b/inc/Abilities/Chat/MarkSessionReadAbility.php
@@ -104,7 +104,15 @@ class MarkSessionReadAbility {
 			);
 		}
 
-		$session = $this->verifySessionOwnership( $session_id, $user_id );
+		$owner = $this->resolve_transcript_owner( $input, $user_id );
+		if ( is_wp_error( $owner ) ) {
+			return array(
+				'success' => false,
+				'error'   => $owner->get_error_code(),
+			);
+		}
+
+		$session = $this->verifySessionOwnership( $session_id, $user_id, $owner );
 
 		if ( isset( $session['error'] ) ) {
 			return array(
@@ -113,7 +121,7 @@ class MarkSessionReadAbility {
 			);
 		}
 
-		$last_read_at = $this->chat_db->mark_session_read( $session_id, $user_id );
+		$last_read_at = $this->chat_db->mark_session_read( $session_id, $user_id, $owner );
 
 		if ( false === $last_read_at ) {
 			return array(

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -16,6 +16,7 @@
 
 namespace DataMachine\Api\Chat;
 
+use DataMachine\Abilities\Chat\ChatTranscriptOwner;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Core\Workspace\WordPressWorkspaceScope;
@@ -69,6 +70,10 @@ class ChatOrchestrator {
 		$agent_slug           = (string) ( $options['agent_slug'] ?? '' );
 		$modes                = ToolPolicyResolver::normalizeModes( ! empty( $options['modes'] ) ? $options['modes'] : array( $options['mode'] ?? ToolPolicyResolver::MODE_CHAT ) );
 		$mode                 = implode( ',', $modes );
+		$transcript_owner     = ChatTranscriptOwner::resolve_for_request( $options, $user_id );
+		if ( is_wp_error( $transcript_owner ) ) {
+			return $transcript_owner;
+		}
 
 		$chat_db                     = ConversationStoreFactory::get();
 		$session_metadata            = array();
@@ -94,7 +99,11 @@ class ChatOrchestrator {
 				);
 			}
 
-			if ( (int) $session['user_id'] !== $user_id ) {
+			$owns_session = method_exists( $chat_db, 'session_matches_owner' )
+				? $chat_db->session_matches_owner( $session, $transcript_owner )
+				: ( (int) $session['user_id'] === $user_id );
+
+			if ( ! $owns_session ) {
 				return new WP_Error(
 					'session_access_denied',
 					__( 'Access denied to this session', 'data-machine' ),
@@ -109,7 +118,7 @@ class ChatOrchestrator {
 			}
 		} else {
 			// Check for recent pending session to prevent duplicates from timeout retries.
-			$pending_session = $chat_db->get_recent_pending_session( WordPressWorkspaceScope::current(), $user_id, 600, $mode, $acting_token_id );
+			$pending_session = $chat_db->get_recent_pending_session( WordPressWorkspaceScope::current(), $user_id, 600, $mode, $acting_token_id, $transcript_owner );
 
 			if ( $pending_session ) {
 				$session_id       = $pending_session['session_id'];
@@ -128,7 +137,7 @@ class ChatOrchestrator {
 					)
 				);
 			} else {
-				$create_result = self::createSession( $user_id, '', $agent_id, $mode );
+				$create_result = self::createSession( $user_id, '', $agent_id, $mode, $transcript_owner );
 
 				if ( is_wp_error( $create_result ) ) {
 					return $create_result;
@@ -588,7 +597,7 @@ class ChatOrchestrator {
 	 * @param string $source  Optional source identifier.
 	 * @return string|WP_Error Session ID on success, WP_Error on failure.
 	 */
-	private static function createSession( int $user_id, string $source = '', int $agent_id = 0, string $mode = ToolPolicyResolver::MODE_CHAT ): string|WP_Error {
+	private static function createSession( int $user_id, string $source = '', int $agent_id = 0, string $mode = ToolPolicyResolver::MODE_CHAT, ?array $transcript_owner = null ): string|WP_Error {
 		$mode = '' !== $mode ? sanitize_key( $mode ) : ToolPolicyResolver::MODE_CHAT;
 
 		if ( $agent_id <= 0 ) {
@@ -606,6 +615,10 @@ class ChatOrchestrator {
 				'agent_slug' => $agent_slug,
 				'mode'       => $mode,
 			);
+
+			if ( null !== $transcript_owner ) {
+				$input['transcript_owner'] = $transcript_owner;
+			}
 
 			if ( $source ) {
 				$input['source'] = $source;
@@ -638,6 +651,10 @@ class ChatOrchestrator {
 			'started_at'    => current_time( 'mysql', true ),
 			'message_count' => 0,
 		);
+
+		if ( null !== $transcript_owner ) {
+			$metadata['transcript_owner'] = $transcript_owner;
+		}
 
 		$acting_token_id = \DataMachine\Abilities\PermissionHelper::get_acting_token_id();
 		if ( $acting_token_id ) {

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -518,13 +518,13 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		$session_owner_hash = (string) ( $session['owner_key_hash'] ?? '' );
 
 		if ( '' === $session_owner_type || '' === $session_owner_hash ) {
-			$legacy = ChatTranscriptOwner::user_owner( absint( $session['user_id'] ?? 0 ) );
+			$legacy             = ChatTranscriptOwner::user_owner( absint( $session['user_id'] ?? 0 ) );
 			$session_owner_type = $legacy['owner_type'];
 			$session_owner_hash = $legacy['owner_key_hash'];
 		}
 
-		return $session_owner_type === (string) ( $owner['owner_type'] ?? '' )
-			&& $session_owner_hash === (string) ( $owner['owner_key_hash'] ?? '' );
+		return (string) ( $owner['owner_type'] ?? '' ) === $session_owner_type
+			&& (string) ( $owner['owner_key_hash'] ?? '' ) === $session_owner_hash;
 	}
 
 	/**

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -12,6 +12,7 @@
 namespace DataMachine\Core\Database\Chat;
 
 use DataMachine\Core\Admin\DateFormatter;
+use DataMachine\Abilities\Chat\ChatTranscriptOwner;
 use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\Database\BaseRepository;
 use AgentsAPI\AI\WP_Agent_Message;
@@ -55,6 +56,9 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			workspace_type VARCHAR(50) NOT NULL,
 			workspace_id VARCHAR(191) NOT NULL,
 			user_id BIGINT(20) UNSIGNED NOT NULL,
+			owner_type VARCHAR(40) NOT NULL DEFAULT 'user',
+			owner_key_hash VARCHAR(64) NOT NULL,
+			owner_label VARCHAR(191) NULL,
 			agent_id BIGINT(20) UNSIGNED NULL,
 			title VARCHAR(100) NULL,
 			messages LONGTEXT NOT NULL,
@@ -72,6 +76,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			PRIMARY KEY  (session_id),
 			KEY workspace (workspace_type, workspace_id),
 			KEY user_id (user_id),
+			KEY owner (owner_type, owner_key_hash),
 			KEY agent_id (agent_id),
 			KEY mode (mode),
 			KEY user_mode (user_id, mode),
@@ -83,6 +88,63 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		dbDelta( $sql );
+	}
+
+	/**
+	 * Ensure transcript owner columns exist and migrate legacy rows to user ownership.
+	 *
+	 * @return void
+	 */
+	public static function ensure_owner_columns(): void {
+		global $wpdb;
+
+		$table_name = self::get_prefixed_table_name();
+
+		if ( ! self::column_exists( $table_name, 'owner_type', $wpdb ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN owner_type VARCHAR(40) NOT NULL DEFAULT %s', $table_name, 'user' ) );
+		}
+
+		if ( ! self::column_exists( $table_name, 'owner_key_hash', $wpdb ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN owner_key_hash VARCHAR(64) NULL', $table_name ) );
+		}
+
+		if ( ! self::column_exists( $table_name, 'owner_label', $wpdb ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN owner_label VARCHAR(191) NULL', $table_name ) );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i SET owner_type = %s WHERE owner_type IS NULL OR owner_type = %s',
+				$table_name,
+				'user',
+				''
+			)
+		);
+
+		// Backfill user-owned hashes row-by-row because the value is intentionally
+		// derived through PHP's hash() to stay engine-independent.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $wpdb->get_results( $wpdb->prepare( 'SELECT session_id, user_id FROM %i WHERE owner_key_hash IS NULL OR owner_key_hash = %s', $table_name, '' ), ARRAY_A );
+		foreach ( $rows as $row ) {
+			$user_id = absint( $row['user_id'] ?? 0 );
+			$owner   = ChatTranscriptOwner::user_owner( $user_id );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$wpdb->update(
+				$table_name,
+				array(
+					'owner_type'     => $owner['owner_type'],
+					'owner_key_hash' => $owner['owner_key_hash'],
+					'owner_label'    => $owner['owner_label'],
+				),
+				array( 'session_id' => (string) $row['session_id'] ),
+				array( '%s', '%s', '%s' ),
+				array( '%s' )
+			);
+		}
 	}
 
 	/**
@@ -280,6 +342,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		global $wpdb;
 
 		list( $workspace, $user_id, $agent, $metadata, $context ) = self::normalize_create_session_args( $args );
+		$owner = self::normalize_owner_from_metadata( $metadata, $user_id );
 
 		try {
 			$identity   = self::resolve_agent_identity_for_session( $agent );
@@ -321,6 +384,9 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				'workspace_type' => $workspace->workspace_type,
 				'workspace_id'   => $workspace->workspace_id,
 				'user_id'        => $user_id,
+				'owner_type'     => $owner['owner_type'],
+				'owner_key_hash' => $owner['owner_key_hash'],
+				'owner_label'    => $owner['owner_label'],
 				'agent_id'       => $agent_id > 0 ? $agent_id : null,
 				'messages'       => wp_json_encode( array() ),
 				'metadata'       => wp_json_encode( $metadata ),
@@ -329,7 +395,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				'mode'           => $context,
 				'expires_at'     => null,
 			),
-			array( '%s', '%s', '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s' )
+			array( '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%s' )
 		);
 
 		if ( false === $result ) {
@@ -388,6 +454,80 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	}
 
 	/**
+	 * Normalize transcript owner metadata for storage.
+	 *
+	 * @param array $metadata Session metadata.
+	 * @param int   $user_id  Compatibility user ID.
+	 * @return array{owner_type:string,owner_key_hash:string,owner_label:string}
+	 */
+	private static function normalize_owner_from_metadata( array &$metadata, int $user_id ): array {
+		$owner = is_array( $metadata['transcript_owner'] ?? null ) ? $metadata['transcript_owner'] : ChatTranscriptOwner::user_owner( $user_id );
+
+		if ( empty( $owner['owner_key_hash'] ) && ! empty( $owner['owner_key'] ) ) {
+			$owner['owner_key_hash'] = ChatTranscriptOwner::hash_owner_key( (string) $owner['owner_key'] );
+		}
+
+		$normalized = array(
+			'owner_type'     => sanitize_key( (string) ( $owner['owner_type'] ?? 'user' ) ),
+			'owner_key_hash' => preg_replace( '/[^a-f0-9]/', '', strtolower( (string) ( $owner['owner_key_hash'] ?? '' ) ) ),
+			'owner_label'    => mb_substr( sanitize_text_field( (string) ( $owner['owner_label'] ?? '' ) ), 0, 191 ),
+		);
+
+		if ( '' === $normalized['owner_type'] || '' === $normalized['owner_key_hash'] ) {
+			$fallback   = ChatTranscriptOwner::user_owner( $user_id );
+			$normalized = array(
+				'owner_type'     => $fallback['owner_type'],
+				'owner_key_hash' => $fallback['owner_key_hash'],
+				'owner_label'    => $fallback['owner_label'],
+			);
+		}
+
+		$metadata['transcript_owner'] = $normalized;
+
+		return $normalized;
+	}
+
+	/**
+	 * Add owner constraints to a WHERE fragment.
+	 *
+	 * @param array      $where      WHERE fragments.
+	 * @param array      $query_args Query args.
+	 * @param array|null $owner      Optional owner array.
+	 * @return void
+	 */
+	private static function append_owner_where( array &$where, array &$query_args, ?array $owner ): void {
+		if ( empty( $owner['owner_type'] ) || empty( $owner['owner_key_hash'] ) ) {
+			return;
+		}
+
+		$where[]      = 'owner_type = %s';
+		$query_args[] = sanitize_key( (string) $owner['owner_type'] );
+		$where[]      = 'owner_key_hash = %s';
+		$query_args[] = (string) $owner['owner_key_hash'];
+	}
+
+	/**
+	 * Check whether a loaded session row belongs to an owner.
+	 *
+	 * @param array $session Session row.
+	 * @param array $owner   Owner array.
+	 * @return bool
+	 */
+	public function session_matches_owner( array $session, array $owner ): bool {
+		$session_owner_type = (string) ( $session['owner_type'] ?? '' );
+		$session_owner_hash = (string) ( $session['owner_key_hash'] ?? '' );
+
+		if ( '' === $session_owner_type || '' === $session_owner_hash ) {
+			$legacy = ChatTranscriptOwner::user_owner( absint( $session['user_id'] ?? 0 ) );
+			$session_owner_type = $legacy['owner_type'];
+			$session_owner_hash = $legacy['owner_key_hash'];
+		}
+
+		return $session_owner_type === (string) ( $owner['owner_type'] ?? '' )
+			&& $session_owner_hash === (string) ( $owner['owner_key_hash'] ?? '' );
+	}
+
+	/**
 	 * Resolve the generic transcript agent slug to Data Machine's stored agent ID.
 	 *
 	 * Integer input is retained as a Data Machine-internal compatibility path for
@@ -432,7 +572,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 * Normalize pending-session arguments across current and workspace-aware contracts.
 	 *
 	 * @param array $args Raw method arguments.
-	 * @return array{0:WP_Agent_Workspace_Scope,1:int,2:int,3:string,4:int|null}
+	 * @return array{0:WP_Agent_Workspace_Scope,1:int,2:int,3:string,4:int|null,5:array|null}
 	 */
 	private static function normalize_recent_pending_session_args( array $args ): array {
 		if ( isset( $args[0] ) && $args[0] instanceof WP_Agent_Workspace_Scope ) {
@@ -442,6 +582,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				(int) ( $args[2] ?? 600 ),
 				(string) ( $args[3] ?? 'chat' ),
 				isset( $args[4] ) ? (int) $args[4] : null,
+				is_array( $args[5] ?? null ) ? $args[5] : null,
 			);
 		}
 
@@ -451,6 +592,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			(int) ( $args[1] ?? 600 ),
 			(string) ( $args[2] ?? 'chat' ),
 			isset( $args[3] ) ? (int) $args[3] : null,
+			is_array( $args[4] ?? null ) ? $args[4] : null,
 		);
 	}
 
@@ -518,6 +660,8 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			$query_args[] = $args['context'];
 		}
 
+		self::append_owner_where( $where, $query_args, is_array( $args['transcript_owner'] ?? null ) ? $args['transcript_owner'] : null );
+
 		if ( is_string( $args['agent_slug'] ?? null ) && '' !== $args['agent_slug'] ) {
 			try {
 				$identity = self::resolve_agent_identity_for_session( $args['agent_slug'] );
@@ -530,7 +674,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			$query_args[] = $identity['agent_id'];
 		}
 
-		$select = $include_messages ? '*' : 'session_id, workspace_type, workspace_id, user_id, agent_id, title, metadata, provider, model, provider_response_id, mode, created_at, updated_at, last_read_at, expires_at';
+		$select = $include_messages ? '*' : 'session_id, workspace_type, workspace_id, user_id, owner_type, owner_key_hash, owner_label, agent_id, title, metadata, provider, model, provider_response_id, mode, created_at, updated_at, last_read_at, expires_at';
 		$sql    = 'SELECT ' . $select . ' FROM %i WHERE ' . implode( ' AND ', $where ) . ' ORDER BY updated_at DESC LIMIT %d OFFSET %d';
 
 		$query_args[] = $limit;
@@ -840,65 +984,34 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		int $limit = 20,
 		int $offset = 0,
 		?string $mode = null,
-		?int $agent_id = null
+		?int $agent_id = null,
+		?array $transcript_owner = null
 	): array {
 		global $wpdb;
 
 		$table_name = self::get_prefixed_table_name();
+		$where      = array( 'user_id = %d' );
+		$params     = array( $table_name, $user_id );
 
-		if ( null !== $agent_id && null !== $mode && '' !== $mode ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$sessions = $wpdb->get_results(
-				$wpdb->prepare(
-					'SELECT * FROM %i WHERE user_id = %d AND mode = %s AND agent_id = %d ORDER BY updated_at DESC LIMIT %d OFFSET %d',
-					$table_name,
-					$user_id,
-					$mode,
-					$agent_id,
-					$limit,
-					$offset
-				),
-				ARRAY_A
-			);
-		} elseif ( null !== $agent_id ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$sessions = $wpdb->get_results(
-				$wpdb->prepare(
-					'SELECT * FROM %i WHERE user_id = %d AND agent_id = %d ORDER BY updated_at DESC LIMIT %d OFFSET %d',
-					$table_name,
-					$user_id,
-					$agent_id,
-					$limit,
-					$offset
-				),
-				ARRAY_A
-			);
-		} elseif ( null !== $mode && '' !== $mode ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$sessions = $wpdb->get_results(
-				$wpdb->prepare(
-					'SELECT * FROM %i WHERE user_id = %d AND mode = %s ORDER BY updated_at DESC LIMIT %d OFFSET %d',
-					$table_name,
-					$user_id,
-					$mode,
-					$limit,
-					$offset
-				),
-				ARRAY_A
-			);
-		} else {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$sessions = $wpdb->get_results(
-				$wpdb->prepare(
-					'SELECT * FROM %i WHERE user_id = %d ORDER BY updated_at DESC LIMIT %d OFFSET %d',
-					$table_name,
-					$user_id,
-					$limit,
-					$offset
-				),
-				ARRAY_A
-			);
+		if ( null !== $mode && '' !== $mode ) {
+			$where[]  = 'mode = %s';
+			$params[] = $mode;
 		}
+
+		if ( null !== $agent_id ) {
+			$where[]  = 'agent_id = %d';
+			$params[] = $agent_id;
+		}
+
+		self::append_owner_where( $where, $params, $transcript_owner );
+
+		$params[] = $limit;
+		$params[] = $offset;
+
+		$sql = 'SELECT * FROM %i WHERE ' . implode( ' AND ', $where ) . ' ORDER BY updated_at DESC LIMIT %d OFFSET %d';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$sessions = $wpdb->get_results( $wpdb->prepare( $sql, ...$params ), ARRAY_A );
 
 		if ( ! $sessions ) {
 			return array();
@@ -966,53 +1079,31 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	public function get_user_session_count(
 		int $user_id,
 		?string $mode = null,
-		?int $agent_id = null
+		?int $agent_id = null,
+		?array $transcript_owner = null
 	): int {
 		global $wpdb;
 
 		$table_name = self::get_prefixed_table_name();
+		$where      = array( 'user_id = %d' );
+		$params     = array( $table_name, $user_id );
 
-		if ( null !== $agent_id && null !== $mode && '' !== $mode ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$count = $wpdb->get_var(
-				$wpdb->prepare(
-					'SELECT COUNT(*) FROM %i WHERE user_id = %d AND mode = %s AND agent_id = %d',
-					$table_name,
-					$user_id,
-					$mode,
-					$agent_id
-				)
-			);
-		} elseif ( null !== $agent_id ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$count = $wpdb->get_var(
-				$wpdb->prepare(
-					'SELECT COUNT(*) FROM %i WHERE user_id = %d AND agent_id = %d',
-					$table_name,
-					$user_id,
-					$agent_id
-				)
-			);
-		} elseif ( null !== $mode && '' !== $mode ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$count = $wpdb->get_var(
-				$wpdb->prepare(
-					'SELECT COUNT(*) FROM %i WHERE user_id = %d AND mode = %s',
-					$table_name,
-					$user_id,
-					$mode
-				)
-			);
-		} else {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$count = $wpdb->get_var(
-				$wpdb->prepare(
-					'SELECT COUNT(*) FROM %i WHERE user_id = %d',
-					$table_name,
-					$user_id
-				)
-			);
+		if ( null !== $mode && '' !== $mode ) {
+			$where[]  = 'mode = %s';
+			$params[] = $mode;
 		}
+
+		if ( null !== $agent_id ) {
+			$where[]  = 'agent_id = %d';
+			$params[] = $agent_id;
+		}
+
+		self::append_owner_where( $where, $params, $transcript_owner );
+
+		$sql = 'SELECT COUNT(*) FROM %i WHERE ' . implode( ' AND ', $where );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$count = $wpdb->get_var( $wpdb->prepare( $sql, ...$params ) );
 
 		return (int) $count;
 	}
@@ -1041,7 +1132,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	public function get_recent_pending_session( ...$args ): ?array {
 		global $wpdb;
 
-		list( $workspace, $user_id, $seconds, $context, $token_id ) = self::normalize_recent_pending_session_args( $args );
+		list( $workspace, $user_id, $seconds, $context, $token_id, $transcript_owner ) = self::normalize_recent_pending_session_args( $args );
 
 		$table_name  = self::get_prefixed_table_name();
 		$cutoff_time = gmdate( 'Y-m-d H:i:s', time() - $seconds );
@@ -1073,6 +1164,12 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		if ( null !== $token_id ) {
 			$query   .= ' AND metadata LIKE %s';
 			$params[] = '%"token_id":' . (int) $token_id . '%';
+		}
+
+		if ( is_array( $transcript_owner ) && ! empty( $transcript_owner['owner_type'] ) && ! empty( $transcript_owner['owner_key_hash'] ) ) {
+			$query   .= ' AND owner_type = %s AND owner_key_hash = %s';
+			$params[] = sanitize_key( (string) $transcript_owner['owner_type'] );
+			$params[] = (string) $transcript_owner['owner_key_hash'];
 		}
 
 		$query .= ' ORDER BY created_at DESC LIMIT 1';
@@ -1220,22 +1317,31 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 * @param int    $user_id    User ID for ownership verification.
 	 * @return string|false The new last_read_at value on success, false on failure.
 	 */
-	public function mark_session_read( string $session_id, int $user_id ) {
+	public function mark_session_read( string $session_id, int $user_id, ?array $transcript_owner = null ) {
 		global $wpdb;
 
 		$table_name   = self::get_prefixed_table_name();
 		$last_read_at = (string) current_time( 'mysql', true );
+		$where        = array(
+			'session_id' => $session_id,
+			'user_id'    => $user_id,
+		);
+		$where_format = array( '%s', '%d' );
+
+		if ( is_array( $transcript_owner ) && ! empty( $transcript_owner['owner_type'] ) && ! empty( $transcript_owner['owner_key_hash'] ) ) {
+			$where['owner_type']     = sanitize_key( (string) $transcript_owner['owner_type'] );
+			$where['owner_key_hash'] = (string) $transcript_owner['owner_key_hash'];
+			$where_format[]          = '%s';
+			$where_format[]          = '%s';
+		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$result = $wpdb->update(
 			$table_name,
 			array( 'last_read_at' => $last_read_at ),
-			array(
-				'session_id' => $session_id,
-				'user_id'    => $user_id,
-			),
+			$where,
 			array( '%s' ),
-			array( '%s', '%d' )
+			$where_format
 		);
 
 		if ( false === $result ) {

--- a/tests/agents-api-transcript-store-smoke.php
+++ b/tests/agents-api-transcript-store-smoke.php
@@ -90,6 +90,22 @@ class AgentsApiFakeTranscriptStore implements WP_Agent_Conversation_Store {
 		return $this->sessions[ $session_id ] ?? null;
 	}
 
+	public function list_sessions( WP_Agent_Workspace_Scope $workspace, int $user_id, array $args = array() ): array {
+		$context = (string) ( $args['context'] ?? '' );
+
+		return array_values(
+			array_filter(
+				$this->sessions,
+				static function ( array $session ) use ( $workspace, $user_id, $context ): bool {
+					return $workspace->workspace_type === $session['workspace_type']
+						&& $workspace->workspace_id === $session['workspace_id']
+						&& $user_id === $session['user_id']
+						&& ( '' === $context || $context === $session['context'] );
+				}
+			)
+		);
+	}
+
 	public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '', ?string $provider_response_id = null ): bool {
 		unset( $provider_response_id );
 		if ( ! isset( $this->sessions[ $session_id ] ) ) {

--- a/tests/chat-transcript-owner-smoke.php
+++ b/tests/chat-transcript-owner-smoke.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Pure-PHP smoke test for transcript owner normalization.
+ *
+ * Run with: php tests/chat-transcript-owner-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+function sanitize_key( string $value ): string {
+	return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $value ) );
+}
+
+function sanitize_text_field( string $value ): string {
+	return trim( preg_replace( '/[\r\n\t]+/', ' ', $value ) );
+}
+
+function __( string $text, string $domain = 'default' ): string {
+	unset( $domain );
+	return $text;
+}
+
+function absint( $value ): int {
+	return abs( (int) $value );
+}
+
+function get_current_user_id(): int {
+	return 0;
+}
+
+function is_user_logged_in(): bool {
+	return false;
+}
+
+function is_wp_error( $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+class WP_Error {
+	private string $code;
+
+	public function __construct( string $code ) {
+		$this->code = $code;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+}
+
+require_once __DIR__ . '/../inc/Abilities/Chat/ChatTranscriptOwner.php';
+
+use DataMachine\Abilities\Chat\ChatTranscriptOwner;
+
+$failures = array();
+$passes   = 0;
+
+$assert_true = static function ( bool $condition, string $label ) use ( &$failures, &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	$failures[] = $label;
+	echo "FAIL: {$label}\n";
+};
+
+echo "chat-transcript-owner-smoke\n";
+
+$user_owner = ChatTranscriptOwner::user_owner( 7 );
+$assert_true( 'user' === $user_owner['owner_type'], 'user owner keeps user type' );
+$assert_true( hash( 'sha256', 'user:7' ) === $user_owner['owner_key_hash'], 'user owner hashes user key' );
+
+$browser_owner = ChatTranscriptOwner::resolve_for_request(
+	array(
+		'client_context' => array(
+			'transcript_owner' => array(
+				'type'  => 'browser',
+				'key'   => 'browser-session-abc',
+				'label' => 'Anonymous browser',
+			),
+		),
+	),
+	42
+);
+$assert_true( ! is_wp_error( $browser_owner ), 'explicit browser owner resolves' );
+$assert_true( 'browser' === $browser_owner['owner_type'], 'browser owner keeps browser type' );
+$assert_true( 42 === $browser_owner['user_id'], 'browser owner preserves runtime user for reporting' );
+$assert_true( hash( 'sha256', 'browser:browser-session-abc' ) === $browser_owner['owner_key_hash'], 'browser owner hashes scoped key' );
+
+$public_owner = ChatTranscriptOwner::resolve_for_request(
+	array(
+		'transcript_owner' => array(
+			'type' => 'audience',
+			'key'  => 'public',
+		),
+	),
+	42
+);
+$assert_true( is_wp_error( $public_owner ), 'public audience owner is rejected' );
+$assert_true( 'non_isolating_transcript_owner' === $public_owner->get_error_code(), 'public audience rejection is explicit' );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " transcript owner assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} transcript owner assertions passed.\n";


### PR DESCRIPTION
## Summary
- Add isolated transcript owner fields and migration/backfill behavior for existing chat sessions.
- Separate chat runtime user resolution from transcript owner resolution.
- Reject broad public-audience transcript ownership so public access cannot expose shared or agent-owner sessions.

## Dependency
- Depends on Agents API principal-owned conversation-session contract: https://github.com/Automattic/agents-api/pull/175
- Tracks https://github.com/Extra-Chill/data-machine/issues/2023.

## Testing
- `php tests/chat-transcript-owner-smoke.php`
- `php tests/agents-api-transcript-store-smoke.php`
- `composer lint -- --standard=phpcs.xml.dist <focused files>`
- `git diff --check`
- `php -l` on touched PHP files

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the implementation, migration/test coverage, and PR description; Chris remains responsible for review and validation.