### PR TITLE
Fix stuck job recovery CLI output

### DIFF
--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -64,6 +64,16 @@ class JobsCommand extends BaseCommand {
 	 * default: 2
 	 * ---
 	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Preview stuck jobs recovery
@@ -78,12 +88,16 @@ class JobsCommand extends BaseCommand {
 	 *     # Recover stuck jobs with custom timeout
 	 *     wp datamachine jobs recover-stuck --timeout=4
 	 *
+	 *     # Preview stuck jobs recovery as JSON
+	 *     wp datamachine jobs recover-stuck --dry-run --format=json
+	 *
 	 * @subcommand recover-stuck
 	 */
 	public function recover_stuck( array $args, array $assoc_args ): void {
 		$dry_run = isset( $assoc_args['dry-run'] );
 		$flow_id = isset( $assoc_args['flow'] ) ? (int) $assoc_args['flow'] : null;
 		$timeout = isset( $assoc_args['timeout'] ) ? max( 1, (int) $assoc_args['timeout'] ) : 2;
+		$format  = $assoc_args['format'] ?? 'table';
 
 		$result = ( new RecoverStuckJobsAbility() )->execute(
 			array(
@@ -100,12 +114,36 @@ class JobsCommand extends BaseCommand {
 
 		$jobs = $result['jobs'] ?? array();
 
+		$summary = $this->summarize_recover_stuck_result( $result );
+
+		if ( 'table' !== $format ) {
+			WP_CLI::print_value(
+				array(
+					'success' => true,
+					'dry_run' => $dry_run,
+					'summary' => $summary,
+					'jobs'    => $jobs,
+					'message' => $result['message'] ?? '',
+				),
+				array(
+					'format' => $format,
+				)
+			);
+			return;
+		}
+
 		if ( empty( $jobs ) ) {
 			WP_CLI::success( 'No stuck jobs found.' );
 			return;
 		}
 
-		WP_CLI::log( sprintf( 'Found %d stuck jobs or stale actions.', count( $jobs ) ) );
+		WP_CLI::log(
+			sprintf(
+				'Found %d recoverable jobs/actions and %d guarded jobs.',
+				$summary['actionable'],
+				$summary['skipped']
+			)
+		);
 
 		if ( $dry_run ) {
 			WP_CLI::log( 'Dry run - no changes will be made.' );
@@ -156,6 +194,29 @@ class JobsCommand extends BaseCommand {
 		}
 
 		WP_CLI::success( $result['message'] );
+	}
+
+	/**
+	 * Summarize recover-stuck ability output for operator-facing CLI reporting.
+	 *
+	 * @param array $result Recovery ability result.
+	 * @return array<string,int>
+	 */
+	private function summarize_recover_stuck_result( array $result ): array {
+		$recovered     = (int) ( $result['recovered'] ?? 0 );
+		$timed_out     = (int) ( $result['timed_out'] ?? 0 );
+		$stale_actions = (int) ( $result['stale_actions'] ?? 0 );
+		$skipped       = (int) ( $result['skipped'] ?? 0 );
+
+		return array(
+			'recovered'     => $recovered,
+			'timed_out'     => $timed_out,
+			'stale_actions' => $stale_actions,
+			'skipped'       => $skipped,
+			'actionable'    => $recovered + $timed_out + $stale_actions,
+			'total'         => $recovered + $timed_out + $stale_actions + $skipped,
+			'requeued'      => (int) ( $result['requeued'] ?? 0 ),
+		);
 	}
 
 	/**

--- a/tests/recover-stuck-cli-output-smoke.php
+++ b/tests/recover-stuck-cli-output-smoke.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Static smoke test for recover-stuck CLI output.
+ *
+ * Run with: php tests/recover-stuck-cli-output-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failed = 0;
+$total  = 0;
+
+function assert_recover_stuck_cli_output_smoke( string $name, bool $condition, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+
+	if ( $condition ) {
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+
+	echo "  [FAIL] {$name}" . ( $detail ? " - {$detail}" : '' ) . "\n";
+	++$failed;
+}
+
+$source = file_get_contents( __DIR__ . '/../inc/Cli/Commands/JobsCommand.php' ) ?: '';
+
+echo "Case 1: recover-stuck exposes structured output\n";
+assert_recover_stuck_cli_output_smoke( 'recover-stuck documents format option', str_contains( $source, '[--format=<format>]' ) );
+assert_recover_stuck_cli_output_smoke( 'recover-stuck supports json examples', str_contains( $source, 'recover-stuck --dry-run --format=json' ) );
+assert_recover_stuck_cli_output_smoke( 'non-table output uses WP_CLI print_value', str_contains( $source, "if ( 'table' !== \$format )" ) && str_contains( $source, 'WP_CLI::print_value' ) );
+assert_recover_stuck_cli_output_smoke( 'structured output includes summary and jobs', str_contains( $source, "'summary' => \$summary" ) && str_contains( $source, "'jobs'    => \$jobs" ) );
+
+echo "Case 2: recover-stuck separates actionable and guarded jobs\n";
+assert_recover_stuck_cli_output_smoke( 'summary helper exists', str_contains( $source, 'private function summarize_recover_stuck_result' ) );
+assert_recover_stuck_cli_output_smoke( 'summary computes actionable total', str_contains( $source, "'actionable'    => \$recovered + \$timed_out + \$stale_actions" ) );
+assert_recover_stuck_cli_output_smoke( 'table headline reports guarded jobs separately', str_contains( $source, 'Found %d recoverable jobs/actions and %d guarded jobs.' ) );
+
+echo "\nRecover-stuck CLI output smoke complete: {$total} assertions, {$failed} failures.\n";
+if ( $failed > 0 ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Adds `--format=json|yaml` support to `wp datamachine jobs recover-stuck` so operators can inspect the computed stuck/recovery set programmatically.
- Clarifies table output by separating recoverable jobs/actions from guarded jobs that still have pending or in-progress Action Scheduler work.
- Adds a focused smoke test covering the CLI contract.

## Testing
- `php tests/recover-stuck-cli-output-smoke.php`
- `php tests/recover-stuck-active-action-guard-smoke.php && php tests/recover-stuck-terminal-actions-smoke.php`
- `php -l inc/Cli/Commands/JobsCommand.php && php -l tests/recover-stuck-cli-output-smoke.php`
- `vendor/bin/phpcs inc/Cli/Commands/JobsCommand.php tests/recover-stuck-cli-output-smoke.php`

## Known validation blockers
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-stuck-job-cli-output` fails on existing unrelated PHP/JS lint findings outside this change.
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-stuck-job-cli-output` fails before tests run because the Playground runner cannot load `WP_Agent_Principal_Access_Store` while bootstrapping `AgentAccessStoreAdapter`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the CLI/ability gap, drafted the CLI output fix and smoke coverage, and ran validation commands; Chris remains responsible for review and merge.