### PR TITLE
fix: resolve CLI memory agent context

### DIFF
--- a/inc/Cli/AgentResolver.php
+++ b/inc/Cli/AgentResolver.php
@@ -115,6 +115,9 @@ class AgentResolver {
 
 		$agent_slug = self::resolvePrincipalAgentSlug();
 		if ( '' === $agent_slug ) {
+			$agent_slug = self::resolveEnvironmentAgentSlug();
+		}
+		if ( '' === $agent_slug ) {
 			$agent_slug = self::resolveActiveAgentSlugForUser( $effective_user_id );
 		}
 		if ( '' === $agent_slug ) {
@@ -230,6 +233,26 @@ class AgentResolver {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Resolve an agent slug from the current CLI process environment.
+	 *
+	 * This gives coding-agent shells and scheduled CLI jobs a stable explicit
+	 * context path without mutating the user's active-agent preference.
+	 *
+	 * @return string Effective agent slug, or empty string when unset/invalid.
+	 */
+	private static function resolveEnvironmentAgentSlug(): string {
+		$env_slug = getenv( 'DATAMACHINE_AGENT_SLUG' );
+		$slug     = is_string( $env_slug ) ? sanitize_title( $env_slug ) : '';
+		if ( '' === $slug ) {
+			return '';
+		}
+
+		$agents_repo = new Agents();
+		$agent       = $agents_repo->get_by_slug( $slug );
+		return $agent ? $slug : '';
 	}
 
 	/**

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -25,6 +25,95 @@ defined( 'ABSPATH' ) || exit;
 class AgentsCommand extends AgentBundleCommand {
 
 	/**
+	 * Get or set the active agent for CLI/default user context.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action>
+	 * : Action to perform.
+	 * ---
+	 * options:
+	 *   - get
+	 *   - set
+	 * ---
+	 *
+	 * [<agent>]
+	 * : Agent slug or ID. Required for `set`.
+	 *
+	 * [--user_id=<id>]
+	 * : User ID whose active agent should be read or changed.
+	 *
+	 * [--format=<format>]
+	 * : Output format for `get`.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine agent active get
+	 *     wp datamachine agent active set intelligence-chubes4
+	 *     wp datamachine agent active set wordpress-com-wiki --user_id=1
+	 *
+	 * @subcommand active
+	 */
+	public function active( array $args, array $assoc_args ): void {
+		$action = isset( $args[0] ) ? (string) $args[0] : '';
+		if ( ! in_array( $action, array( 'get', 'set' ), true ) ) {
+			WP_CLI::error( 'Usage: wp datamachine agent active <get|set> [agent] [--user_id=<id>]' );
+			return;
+		}
+
+		$input        = array();
+		$user_id_flag = \WP_CLI\Utils\get_flag_value( $assoc_args, 'user_id', null );
+		if ( null !== $user_id_flag ) {
+			$input['user_id'] = (int) $user_id_flag;
+		}
+
+		if ( 'get' === $action ) {
+			$result = AgentAbilities::getActiveAgent( $input );
+			if ( empty( $result['success'] ) ) {
+				WP_CLI::error( $result['error'] ?? 'Failed to get active agent.' );
+				return;
+			}
+
+			$item = array(
+				'agent_slug'   => $result['agent_slug'] ?? '',
+				'source'       => $result['source'] ?? '',
+				'needs_choice' => ! empty( $result['needs_choice'] ) ? 'Yes' : 'No',
+			);
+
+			if ( ! empty( $result['agent'] ) && is_array( $result['agent'] ) ) {
+				$item['agent_id']   = (int) ( $result['agent']['agent_id'] ?? 0 );
+				$item['agent_name'] = (string) ( $result['agent']['agent_name'] ?? '' );
+			}
+
+			$this->format_items( array( $item ), array_keys( $item ), $assoc_args );
+			return;
+		}
+
+		$agent = isset( $args[1] ) ? (string) $args[1] : '';
+		if ( '' === $agent ) {
+			WP_CLI::error( 'Agent is required. Usage: wp datamachine agent active set <agent>' );
+			return;
+		}
+
+		$input['agent'] = $agent;
+		$result         = AgentAbilities::setActiveAgent( $input );
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to set active agent.' );
+			return;
+		}
+
+		WP_CLI::success( sprintf( 'Active agent set to %s for user %d.', (string) $result['agent_slug'], (int) $result['user_id'] ) );
+	}
+
+	/**
 	 * List registered agent identities.
 	 *
 	 * ## OPTIONS

--- a/tests/cli-effective-agent-resolver-smoke.php
+++ b/tests/cli-effective-agent-resolver-smoke.php
@@ -124,6 +124,14 @@ namespace {
 	agents_api_smoke_assert_equals( 2, $context['agent_id'], 'active preference resolves before ambiguous owner fallback', $failures, $passes );
 	agents_api_smoke_assert_equals( 'intelligence-chubes4', $context['agent_slug'], 'active preference carries slug', $failures, $passes );
 
+	$GLOBALS['__datamachine_test_user_meta'][1]['datamachine_active_agent_slug'] = '';
+	putenv( 'DATAMACHINE_AGENT_SLUG=intelligence-chubes4' );
+	$context = DataMachine\Cli\AgentResolver::resolveEffectiveContext( array( 'user' => 1 ) );
+	agents_api_smoke_assert_equals( 2, $context['agent_id'], 'environment agent slug resolves before ambiguous owner fallback', $failures, $passes );
+	agents_api_smoke_assert_equals( 'intelligence-chubes4', $context['agent_slug'], 'environment agent slug carries slug', $failures, $passes );
+	putenv( 'DATAMACHINE_AGENT_SLUG' );
+	$GLOBALS['__datamachine_test_user_meta'][1]['datamachine_active_agent_slug'] = 'intelligence-chubes4';
+
 	add_filter(
 		'agents_api_execution_principal',
 		static function ( $principal, $request_context ) {


### PR DESCRIPTION
## Summary
- Resolve Data Machine CLI agent context from `DATAMACHINE_AGENT_SLUG` before falling back to ambiguous owner-owned agent lookup.
- Add `wp datamachine agent active get|set` so operators have a stable CLI path to inspect or persist the active agent.
- Extend the CLI effective agent resolver smoke test to cover environment-provided agent context.

## Verification
- `php -l inc/Cli/AgentResolver.php`
- `php -l inc/Cli/Commands/AgentsCommand.php`
- `php tests/cli-effective-agent-resolver-smoke.php`
- `vendor/bin/phpcs inc/Cli/AgentResolver.php inc/Cli/Commands/AgentsCommand.php tests/cli-effective-agent-resolver-smoke.php`

## Notes
- Full `homeboy lint --path /Users/chubes/Developer/data-machine@fix-cli-memory-agent-context --extension wordpress` still reports existing unrelated JS/admin lint findings in files not touched by this PR.

Fixes #2026

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the CLI context-resolution failure, drafting the PHP changes and smoke-test coverage, and running targeted verification. Chris remains responsible for review and merge.