### PR TITLE
Allow disabling AI directives

### DIFF
--- a/docs/core-system/ai-directives.md
+++ b/docs/core-system/ai-directives.md
@@ -272,6 +272,14 @@ add_filter('datamachine_directives', function($directives) {
 });
 ```
 
+**`datamachine_directives_enabled`** — Disable the entire directive stack before any directive class renders:
+
+```php
+add_filter( 'datamachine_directives_enabled', '__return_false' );
+```
+
+Use this for eval or training runners that need a provider request with no hidden Data Machine context. Returning `false` removes every registered directive after discovery and before per-agent policy resolution or directive rendering.
+
 **`datamachine_agent_mode_{slug}`** — Append or modify mode-specific guidance:
 
 ```php

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -1131,6 +1131,28 @@ add_filter('datamachine_directives', function($directives) {
 - **25-35**: Caller, daily memory, and client-reported context
 - **40-50**: Pipeline, flow, chat inventory, and workflow-specific directives
 
+### `datamachine_directives_enabled`
+
+**Since**: v0.112.1
+
+**Purpose**: Disable all Data Machine directives before directive classes render into a provider request.
+
+**Parameters**:
+
+- `$enabled` (bool) - Whether directive rendering is enabled. Defaults to `true`.
+- `$directives` (array) - Registered directive configurations.
+- `$args` (array) - Resolution args such as `modes` and `agent_id`.
+
+**Return**: Boolean enabled state.
+
+**Usage Example**:
+
+```php
+add_filter( 'datamachine_directives_enabled', '__return_false' );
+```
+
+Use this for eval or training runs that need to guarantee Data Machine contributes no hidden system-message context. Returning `false` suppresses every registered directive before per-agent policy resolution and before any directive class `get_outputs()` method is called.
+
 ### `datamachine_global_directives` (LEGACY — use `datamachine_directives`)
 
 **Deprecated**: v0.2.5

--- a/inc/Engine/AI/Directives/DirectivePolicyResolver.php
+++ b/inc/Engine/AI/Directives/DirectivePolicyResolver.php
@@ -47,7 +47,7 @@ class DirectivePolicyResolver {
 			);
 		}
 
-		$policy   = $agent_id > 0 ? $this->getAgentDirectivePolicy( $agent_id ) : null;
+		$policy = $agent_id > 0 ? $this->getAgentDirectivePolicy( $agent_id ) : null;
 
 		$result = $this->applyPolicy( $directives, $policy, $modes );
 

--- a/inc/Engine/AI/Directives/DirectivePolicyResolver.php
+++ b/inc/Engine/AI/Directives/DirectivePolicyResolver.php
@@ -27,6 +27,26 @@ class DirectivePolicyResolver {
 	public function resolve( array $directives, array $args ): array {
 		$modes    = self::normalizeModes( $args['modes'] ?? ( array_key_exists( 'mode', $args ) ? array( $args['mode'] ) : array() ) );
 		$agent_id = isset( $args['agent_id'] ) ? (int) $args['agent_id'] : 0;
+
+		/**
+		 * Filter whether Data Machine directives should be applied to the request.
+		 *
+		 * Returning false removes every registered directive before directive classes
+		 * are invoked, which lets eval/training runners guarantee that Data Machine
+		 * context does not leak into the model input.
+		 *
+		 * @param bool  $enabled    Whether directives are enabled.
+		 * @param array $directives  Registered directive configs.
+		 * @param array $args        Resolution args.
+		 */
+		$enabled = apply_filters( 'datamachine_directives_enabled', true, $directives, $args );
+		if ( false === $enabled ) {
+			return array(
+				'directives' => array(),
+				'suppressed' => $this->getDirectiveNames( $directives ),
+			);
+		}
+
 		$policy   = $agent_id > 0 ? $this->getAgentDirectivePolicy( $agent_id ) : null;
 
 		$result = $this->applyPolicy( $directives, $policy, $modes );
@@ -253,6 +273,26 @@ class DirectivePolicyResolver {
 		$short      = false === $pos ? $class_name : substr( $class_name, $pos + 1 );
 
 		return array_values( array_unique( array( $class_name, $short ) ) );
+	}
+
+	/**
+	 * Get stable short names for registered directives.
+	 *
+	 * @param array $directives Registered directive configs.
+	 * @return string[] Directive short names.
+	 */
+	private function getDirectiveNames( array $directives ): array {
+		$names = array();
+		foreach ( $directives as $directive ) {
+			$class = $directive['class'] ?? null;
+			if ( ! is_string( $class ) || '' === $class ) {
+				continue;
+			}
+			$identifiers = $this->getClassIdentifiers( $class );
+			$names[]     = $identifiers[ count( $identifiers ) - 1 ];
+		}
+
+		return array_values( array_unique( $names ) );
 	}
 
 	/**

--- a/tests/ai-request-inspector-smoke.php
+++ b/tests/ai-request-inspector-smoke.php
@@ -191,7 +191,39 @@ assert_test( 'request JSON byte count stable', 496 === $request_json_bytes, 'got
 assert_test( 'messages JSON byte count stable', 277 === $messages_json_bytes, 'got ' . $messages_json_bytes );
 assert_test( 'tools JSON byte count stable', 178 === $tools_json_bytes, 'got ' . $tools_json_bytes );
 
-echo "\nCase 4: CLI command surface is registered and documented\n";
+echo "\nCase 4: directives can be disabled before any directive class renders\n";
+
+add_filter(
+	'datamachine_directives_enabled',
+	static function ( bool $enabled, array $directives, array $args ): bool {
+		assert_test( 'directive enabled filter receives default true', true === $enabled );
+		assert_test( 'directive enabled filter sees registered directives', ! empty( $directives ) );
+		assert_test( 'directive enabled filter sees active mode', array( 'pipeline' ) === ( $args['modes'] ?? array() ) );
+		return false;
+	},
+	10,
+	3
+);
+
+$without_directives = \DataMachine\Engine\AI\RequestBuilder::assemble(
+	$messages,
+	'openai',
+	'gpt-test',
+	$tools,
+	array( 'pipeline' ),
+	array(
+		'job_id'       => 1423,
+		'flow_step_id' => 'ai_step_1',
+		'step_id'      => 'pipeline_ai_1',
+	)
+);
+
+assert_test( 'directive kill switch keeps original user message first', 'user' === ( $without_directives['request']['messages'][0]['role'] ?? '' ) );
+assert_test( 'directive kill switch removes rendered directive breakdown', array() === ( $without_directives['directive_breakdown'] ?? array() ) );
+assert_test( 'directive kill switch removes applied directives', array() === ( $without_directives['applied_directives'] ?? array() ) );
+assert_test( 'directive kill switch reports suppressed directive', array( 'Test_Request_Inspector_Directive' ) === ( $without_directives['suppressed_directives'] ?? array() ) );
+
+echo "\nCase 5: CLI command surface is registered and documented\n";
 
 $bootstrap = (string) file_get_contents( __DIR__ . '/../inc/Cli/Bootstrap.php' );
 $command   = (string) file_get_contents( __DIR__ . '/../inc/Cli/Commands/AICommand.php' );
@@ -214,7 +246,7 @@ assert_test( 'inspect request ability loaded by plugin bootstrap', false !== str
 assert_test( 'inspect request ability instantiated by plugin bootstrap', false !== strpos( $plugin, 'new \\DataMachine\\Abilities\\AI\\InspectRequestAbility()' ) );
 assert_test( 'ability registers datamachine/inspect-ai-request', false !== strpos( $ability, 'datamachine/inspect-ai-request' ) );
 
-echo "\nCase 4: prompt validation context is adapter-provided\n";
+echo "\nCase 6: prompt validation context is adapter-provided\n";
 
 $prompt_builder_source  = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/PromptBuilder.php' );
 $request_builder_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/RequestBuilder.php' );


### PR DESCRIPTION
## Summary
- Adds `datamachine_directives_enabled` as an explicit kill switch for the full directive stack.
- Suppresses every registered directive before per-agent policy lookup or directive rendering when the filter returns false.
- Documents the eval/training use case and adds request-assembly smoke coverage proving no directive system messages are rendered.

## Testing
- `php -l inc/Engine/AI/Directives/DirectivePolicyResolver.php`
- `php -l tests/ai-request-inspector-smoke.php`
- `php tests/ai-request-inspector-smoke.php`

## Known test status
- Broad `homeboy lint --path /Users/chubes/Developer/data-machine@filter-directive-context-nullifier --extension wordpress` is blocked by existing React/ESLint findings unrelated to this PHP/docs change.
- Broad `homeboy test --path /Users/chubes/Developer/data-machine@filter-directive-context-nullifier --extension wordpress` is blocked before tests load by missing `WP_Agent_Principal_Access_Store` in the Playground test bootstrap.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Tracing directive assembly, implementing the filter hook, updating docs, adding smoke coverage, and running focused verification. Chris remains responsible for review and merge.