### PR TITLE
ci: publish vendor-bundled release ZIP

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -25,3 +25,63 @@ jobs:
       expected-commands: audit,lint,test
       autofix: 'false'
     secrets: inherit
+
+  build-release-asset:
+    if: needs.homeboy.outputs.released == 'true'
+    needs: [homeboy]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.homeboy.outputs.release-tag }}
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer:v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - run: composer install --no-dev --optimize-autoloader --prefer-dist --no-interaction
+      - run: npm ci
+      - run: npm run build
+
+      - name: Build plugin ZIP
+        run: |
+          mkdir -p dist/data-machine
+          rsync -a ./ dist/data-machine/ \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='.claude' \
+            --exclude='.datamachine' \
+            --exclude='AGENTS.md' \
+            --exclude='dist' \
+            --exclude='docs' \
+            --exclude='node_modules' \
+            --exclude='tests' \
+            --exclude='.buildignore' \
+            --exclude='*.zip' \
+            --exclude='*.tar.gz' \
+            --exclude='*.log' \
+            --exclude='*.tmp' \
+            --exclude='*.temp' \
+            --exclude='*.cache' \
+            --exclude='*.bak' \
+            --exclude='*.backup' \
+            --exclude='package-lock.json' \
+            --exclude='package.json' \
+            --exclude='webpack.config.js' \
+            --exclude='jsconfig.json' \
+            --exclude='phpstan-baseline.neon' \
+            --exclude='phpunit.xml*'
+          cd dist
+          zip -r data-machine.zip data-machine
+
+      - run: gh release upload "${{ needs.homeboy.outputs.release-tag }}" dist/data-machine.zip --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a `build-release-asset` follow-up job to the Homeboy workflow when Homeboy creates a release.
- Builds the release tag with Composer production dependencies, the wp-scripts admin bundle, and uploads `data-machine.zip` to the GitHub Release.
- Stages a clean plugin directory with runtime files only, excluding tests, docs, GitHub metadata, Node modules, and dev configs.

## Issue
- Fixes https://github.com/Extra-Chill/data-machine/issues/2029

## Related PRs
- Data Machine Code companion PR: https://github.com/Extra-Chill/data-machine-code/pull/408

## Validation
- `composer install --no-dev --optimize-autoloader --prefer-dist --no-interaction`
- `npm ci`
- `npm run build`
- Locally staged and zipped `dist/data-machine.zip`, extracted it, and verified it contains `data-machine.php`, `inc/`, `vendor/autoload.php`, and built admin assets under `inc/Core/Admin/assets/build/`.
- Verified extracted ZIP excludes `tests/`, `docs/`, `.github/`, `node_modules/`, `package.json`, `package-lock.json`, and `phpstan-baseline.neon`.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/homeboy.yml")'`

## Notes
- `homeboy audit` reports existing repo-wide heuristic findings unrelated to this workflow-only change.
- `homeboy lint` reports existing repo-wide lint findings unrelated to this workflow-only change.
- `homeboy test` currently fails before tests run in the local environment because the local dependency load is missing `WP_Agent_Principal_Access_Store` from Agents API/Data Machine bootstrap.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the release-asset workflow job, validated the local ZIP contents, and drafted the PR description. Chris specified the issue, desired workflow shape, and release artifact requirements.
