### PR TITLE
fix: preserve bundle flow step settings

### DIFF
--- a/inc/Engine/Bundle/AgentBundleFlowFile.php
+++ b/inc/Engine/Bundle/AgentBundleFlowFile.php
@@ -28,6 +28,7 @@ final class AgentBundleFlowFile {
 		'handler_slug',
 		'handler_slugs',
 		'handler_config',
+		'flow_step_settings',
 		'enabled_tools',
 		'disabled_tools',
 		'prompt_queue',
@@ -136,9 +137,9 @@ final class AgentBundleFlowFile {
 			return (bool) $value;
 		}
 
-		if ( 'handler_config' === $field ) {
+		if ( in_array( $field, array( 'handler_config', 'flow_step_settings' ), true ) ) {
 			if ( ! is_array( $value ) ) {
-				throw new BundleValidationException( 'flow file handler_config must be an object.' );
+				throw new BundleValidationException( sprintf( 'flow file %s must be an object.', esc_html( $field ) ) );
 			}
 			return $value;
 		}

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -114,6 +114,12 @@ $array_bundle = array(
 					'system_prompt'    => 'Review carefully.',
 					'disabled_tools'   => array( 'datamachine/delete-flow' ),
 				),
+				'88_graph' => array(
+					'pipeline_step_id' => '88_graph',
+					'step_type'        => 'system_task',
+					'execution_order'  => 2,
+					'label'            => 'Extract graph',
+				),
 			),
 			'memory_file_contents' => array( 'pipeline.md' => "# Pipeline\n" ),
 		),
@@ -174,6 +180,22 @@ $array_bundle = array(
 					),
 					'queue_mode'       => 'loop',
 				),
+				'88_graph_144' => array(
+					'flow_step_id'       => '88_graph_144',
+					'pipeline_step_id'   => '88_graph',
+					'pipeline_id'        => 88,
+					'flow_id'            => 144,
+					'execution_order'    => 2,
+					'step_type'          => 'system_task',
+					'flow_step_settings' => array(
+						'task'   => 'wiki_graph_extract',
+						'params' => array(
+							'root'    => 'wordpress-com',
+							'limit'   => 5,
+							'dry_run' => true,
+						),
+					),
+				),
 			),
 			'scheduling_config'    => array(
 				'enabled'   => true,
@@ -214,6 +236,7 @@ assert_adapter_equals( 'flow document preserves completion assertions', array( '
 assert_adapter_equals( 'flow document preserves tool runtime rules', 4, $flow['steps'][1]['tool_runtime_rules'][0]['max_calls'] ?? null );
 assert_adapter_equals( 'flow document preserves prompt queue', 'Review PR #1', $flow['steps'][1]['prompt_queue'][0]['prompt'] );
 assert_adapter_equals( 'flow document preserves queue mode', 'loop', $flow['steps'][1]['queue_mode'] );
+assert_adapter_equals( 'flow document preserves system task settings', 'wiki_graph_extract', $flow['steps'][2]['flow_step_settings']['task'] ?? null );
 assert_adapter_equals( 'flow document preserves scheduling interval', 'hourly', $flow['schedule'] );
 assert_adapter_equals( 'memory path moves agent files under memory/agent', "# Soul\n", $directory->memory_files()['agent/SOUL.md'] ?? null );
 
@@ -256,6 +279,8 @@ assert_adapter_equals( 'round-trip preserves completion assertions', array( 'cre
 assert_adapter_equals( 'round-trip preserves tool runtime rules', array( 'workspace_edit', 'create_github_issue' ), $round_steps[1]['tool_runtime_rules'][0]['then_require_one_of'] ?? null );
 assert_adapter_equals( 'round-trip preserves prompt queue', 'Review PR #1', $round_steps[1]['prompt_queue'][0]['prompt'] );
 assert_adapter_equals( 'round-trip preserves queue mode', 'loop', $round_steps[1]['queue_mode'] );
+assert_adapter_equals( 'round-trip preserves system task settings', 'wiki_graph_extract', $round_steps[2]['flow_step_settings']['task'] ?? null );
+assert_adapter_equals( 'round-trip preserves system task params', 'wordpress-com', $round_steps[2]['flow_step_settings']['params']['root'] ?? null );
 assert_adapter_equals( 'round-trip preserves scheduling interval', 'hourly', $round_flow['scheduling_config']['interval'] );
 
 echo "\n[3] Directory read resolves prompt file references relative to bundle root\n";


### PR DESCRIPTION
## Summary
- Preserve `flow_step_settings` when directory bundle flow files are normalized.
- Cover system-task flow settings in the agent bundle directory adapter smoke test.

## Testing
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `php -l inc/Engine/Bundle/AgentBundleFlowFile.php && php -l tests/agent-bundler-directory-adapter-smoke.php`
- `vendor/bin/phpcs inc/Engine/Bundle/AgentBundleFlowFile.php tests/agent-bundler-directory-adapter-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-bundle-flow-step-settings --extension wordpress --changed-since main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the live graph extraction failure, drafted the importer fix and smoke coverage, and ran focused validation; Chris remains responsible for review and merge.