### PR TITLE
Fix chat turn mode normalization

### DIFF
--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -712,7 +712,8 @@ class ChatOrchestrator {
 		$single_turn          = $options['single_turn'] ?? false;
 		$max_turns            = $options['max_turns'] ?? PluginSettings::get( 'max_turns', PluginSettings::DEFAULT_MAX_TURNS );
 		$selected_pipeline_id = $options['selected_pipeline_id'] ?? null;
-		$mode                 = ! empty( $options['mode'] ) ? sanitize_key( (string) $options['mode'] ) : ToolPolicyResolver::MODE_CHAT;
+		$modes                = ToolPolicyResolver::normalizeModes( ! empty( $options['modes'] ) ? $options['modes'] : array( $options['mode'] ?? ToolPolicyResolver::MODE_CHAT ) );
+		$mode                 = implode( ',', $modes );
 		$agent_id             = (int) ( $options['agent_id'] ?? 0 );
 		$agent_slug           = (string) ( $options['agent_slug'] ?? '' );
 


### PR DESCRIPTION
## Summary
- Normalize `modes` inside `ChatOrchestrator::executeConversationTurn()` before resolving tools and running the AI loop.
- Preserve legacy single `mode` callers by converting them to the multi-mode array expected by `datamachine_run_conversation()`.

## Testing
- `php -l inc/Api/Chat/ChatOrchestrator.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-chat-orchestrator-modes --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the production fatal and drafting the one-line compatibility fix; Chris remains responsible for review and validation.