### PR TITLE
fix: emit packets for assertion-only AI completions

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -921,6 +921,24 @@ class AIStep extends Step {
 			$outputPackets = $packet->addTo( $outputPackets );
 		}
 
+		if ( count( $outputPackets ) === 0 && true === ( $loop_result['completion_assertions_complete'] ?? false ) ) {
+			$packet        = new DataPacket(
+				array(
+					'title' => 'AI Completion Assertions Satisfied',
+					'body'  => 'The AI step satisfied its configured completion assertions.',
+				),
+				array(
+					'source_type'                     => 'ai_completion_assertions',
+					'flow_step_id'                    => $flow_step_id,
+					'conversation_turn'               => $turn_count,
+					'completion_assertions_satisfied' => is_array( $loop_result['completion_assertions_satisfied'] ?? null ) ? $loop_result['completion_assertions_satisfied'] : array(),
+					'completion_assertions_missing'   => is_array( $loop_result['completion_assertions_missing'] ?? null ) ? $loop_result['completion_assertions_missing'] : array(),
+				),
+				'ai_completion_assertions'
+			);
+			$outputPackets = $packet->addTo( $outputPackets );
+		}
+
 		return $outputPackets;
 	}
 }

--- a/tests/Unit/Core/Steps/AI/AIStepTest.php
+++ b/tests/Unit/Core/Steps/AI/AIStepTest.php
@@ -443,4 +443,37 @@ class AIStepTest extends TestCase {
 		$this->assertCount( 1, $result );
 		$this->assertSame( 'ai_response', $result[0]['type'] );
 	}
+
+	public function test_process_loop_results_emits_completion_assertion_packet_when_final_turn_is_empty(): void {
+		$method = new ReflectionMethod( AIStep::class, 'processLoopResults' );
+		$method->setAccessible( true );
+
+		$loop_result = array(
+			'messages'                         => array(),
+			'tool_execution_results'           => array(),
+			'completion_assertions_complete'    => true,
+			'completion_assertions_satisfied'   => array(
+				'complete_when_any' => array( 'design_comment_and_labels' ),
+			),
+			'completion_assertions_missing'     => array(),
+		);
+
+		$result = $method->invoke(
+			null,
+			$loop_result,
+			array(
+				array(
+					'type'     => 'fetch',
+					'metadata' => array( 'source_type' => 'github_issue' ),
+				),
+			),
+			array( 'flow_step_id' => 'design_ai_step' ),
+			array()
+		);
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'ai_completion_assertions', $result[0]['type'] );
+		$this->assertSame( 'ai_completion_assertions', $result[0]['metadata']['source_type'] );
+		$this->assertSame( array( 'design_comment_and_labels' ), $result[0]['metadata']['completion_assertions_satisfied']['complete_when_any'] );
+	}
 }

--- a/tests/ai-completion-assertion-packet-smoke.php
+++ b/tests/ai-completion-assertion-packet-smoke.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Pure-PHP smoke test for side-effect-only AI completion assertions.
+ *
+ * Run with: php tests/ai-completion-assertion-packet-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$__filters = array();
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	$GLOBALS['__filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+}
+
+function apply_filters( string $hook, $value, ...$args ) {
+	if ( empty( $GLOBALS['__filters'][ $hook ] ) ) {
+		return $value;
+	}
+
+	ksort( $GLOBALS['__filters'][ $hook ] );
+	foreach ( $GLOBALS['__filters'][ $hook ] as $callbacks ) {
+		foreach ( $callbacks as $entry ) {
+			$callback      = $entry[0];
+			$accepted_args = $entry[1];
+			$call_args     = array_slice( array_merge( array( $value ), $args ), 0, $accepted_args );
+			$value         = $callback( ...$call_args );
+		}
+	}
+
+	return $value;
+}
+
+function do_action( string $hook, ...$args ): void {
+	$GLOBALS['__actions'][] = array( $hook, $args );
+}
+
+function did_action( string $hook ): int {
+	return 'init' === $hook ? 1 : 0;
+}
+
+function current_action(): string {
+	return '';
+}
+
+function get_option( string $key, $default_value = false ) {
+	return $default_value;
+}
+
+require_once __DIR__ . '/../inc/Core/DataPacket.php';
+require_once __DIR__ . '/../inc/Core/PluginSettings.php';
+require_once __DIR__ . '/../inc/Core/Steps/Step.php';
+require_once __DIR__ . '/../inc/Core/Steps/StepTypeRegistrationTrait.php';
+require_once __DIR__ . '/../inc/Core/Steps/QueueableTrait.php';
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-access-policy.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-policy-filter.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-policy.php';
+require_once __DIR__ . '/../inc/Engine/AI/ConversationManager.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineAgentToolPolicyProvider.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineMandatoryToolPolicy.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineToolAccessPolicy.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
+require_once __DIR__ . '/../inc/Core/Steps/AI/AIStep.php';
+
+use DataMachine\Core\Steps\AI\AIStep;
+
+$passes   = 0;
+$failures = array();
+
+function assert_completion_packet( bool $condition, string $name, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+}
+
+echo "AI completion assertion packet smoke\n";
+echo "-------------------------------------\n\n";
+
+$method = new ReflectionMethod( AIStep::class, 'processLoopResults' );
+
+$result = $method->invoke(
+	null,
+	array(
+		'messages'                       => array(),
+		'tool_execution_results'         => array(),
+		'completion_assertions_complete'  => true,
+		'completion_assertions_satisfied' => array(
+			'complete_when_any' => array( 'design_comment_and_labels' ),
+		),
+		'completion_assertions_missing'   => array(),
+	),
+	array(
+		array(
+			'type'     => 'fetch',
+			'metadata' => array( 'source_type' => 'github_issue' ),
+		),
+	),
+	array( 'flow_step_id' => 'design_ai_step' ),
+	array()
+);
+
+assert_completion_packet( 1 === count( $result ), 'AI step emits one summary packet', $failures, $passes );
+assert_completion_packet( 'ai_completion_assertions' === ( $result[0]['type'] ?? '' ), 'packet uses completion assertion type', $failures, $passes );
+assert_completion_packet( 'design_ai_step' === ( $result[0]['metadata']['flow_step_id'] ?? '' ), 'packet preserves flow step id', $failures, $passes );
+assert_completion_packet( array( 'design_comment_and_labels' ) === ( $result[0]['metadata']['completion_assertions_satisfied']['complete_when_any'] ?? array() ), 'packet carries satisfied outcome', $failures, $passes );
+
+echo "\n-------------------------------------\n";
+echo sprintf( "%d / %d passed\n", $passes, $passes + count( $failures ) );
+
+if ( ! empty( $failures ) ) {
+	echo "Failures:\n";
+	foreach ( $failures as $failure ) {
+		echo " - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "All checks passed.\n";


### PR DESCRIPTION
## Summary
- Emit a non-handler `ai_completion_assertions` packet when an AI step satisfies configured completion assertions but has no terminal tool result or assistant text to serialize.
- Preserve satisfied/missing completion assertion diagnostics on the emitted packet so CI runners can distinguish successful side-effect-only steps from empty-output failures.
- Add regression coverage for the empty-final-turn completion assertion case, including a pure PHP smoke test.

## Testing
- `php tests/ai-completion-assertion-packet-smoke.php`
- `php tests/upsert-handler-result-handoff-smoke.php`
- `php -l inc/Core/Steps/AI/AIStep.php && php -l tests/Unit/Core/Steps/AI/AIStepTest.php && php -l tests/ai-completion-assertion-packet-smoke.php`
- `git diff --check`

## Known test limitation
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-ai-completion-summary-packet --extension wordpress` currently fails before running tests with `Interface "WP_Agent_Principal_Access_Store" not found` while loading `AgentAccessStoreAdapter.php` in the Playground harness.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause analysis, patch drafting, and focused smoke-test coverage; Chris remains responsible for review and merge.