### PR TITLE
Align principal session workspace for Data Machine chat

### DIFF
--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -441,13 +441,15 @@ class Chat extends BaseRepository implements ConversationStoreInterface, WP_Agen
 	 * @return string Session ID (UUID), or empty string on failure.
 	 */
 	public function create_session_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, string $agent_slug = '', array $metadata = array(), string $context = 'chat' ): string {
+		unset( $workspace );
+
 		$transcript_owner = self::principal_owner_to_transcript_owner( $owner );
 		if ( null === $transcript_owner ) {
 			return '';
 		}
 
 		$metadata['transcript_owner'] = $transcript_owner;
-		return $this->create_session( $workspace, (int) $transcript_owner['user_id'], $agent_slug, $metadata, $context );
+		return $this->create_session( WordPressWorkspaceScope::current(), (int) $transcript_owner['user_id'], $agent_slug, $metadata, $context );
 	}
 
 	/**
@@ -737,6 +739,8 @@ class Chat extends BaseRepository implements ConversationStoreInterface, WP_Agen
 	 * @return array<int,array<string,mixed>> Session rows.
 	 */
 	public function list_sessions_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, array $args = array() ): array {
+		unset( $workspace );
+
 		$transcript_owner = self::principal_owner_to_transcript_owner( $owner );
 		if ( null === $transcript_owner ) {
 			return array();
@@ -744,7 +748,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface, WP_Agen
 
 		$args['transcript_owner'] = $transcript_owner;
 		$args['owner_only']       = true;
-		return $this->list_sessions( $workspace, (int) $transcript_owner['user_id'], $args );
+		return $this->list_sessions( WordPressWorkspaceScope::current(), (int) $transcript_owner['user_id'], $args );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Normalizes principal-owned Agents API session operations onto Data Machine's current WordPress workspace.
- Keeps create/list behavior aligned with ChatOrchestrator transcript storage so browser-principal session lists can find their sessions.

## Testing
- php -l inc/Core/Database/Chat/Chat.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the workspace mismatch, drafted the adapter fix, and ran syntax verification; Chris remains responsible for review and merge.