### PR TITLE
Fix direct workflow static prompt queues

### DIFF
--- a/inc/Core/Steps/QueueableTrait.php
+++ b/inc/Core/Steps/QueueableTrait.php
@@ -188,8 +188,23 @@ trait QueueableTrait {
 		$job_context = $this->engine->getJobContext();
 		$flow_id     = $job_context['flow_id'] ?? null;
 
-		if ( ! $flow_id ) {
-			return null;
+		if ( ! $flow_id || ! is_numeric( $flow_id ) ) {
+			if ( 'static' !== $queue_mode ) {
+				return null;
+			}
+
+			$prompt_queue = is_array( $this->flow_step_config[ QueueAbility::SLOT_PROMPT_QUEUE ] ?? null )
+				? $this->flow_step_config[ QueueAbility::SLOT_PROMPT_QUEUE ]
+				: array();
+			$entry        = $prompt_queue[0] ?? null;
+			if ( ! is_array( $entry ) || empty( $entry['prompt'] ) ) {
+				return null;
+			}
+
+			return array(
+				'prompt'   => (string) $entry['prompt'],
+				'added_at' => isset( $entry['added_at'] ) ? (string) $entry['added_at'] : null,
+			);
 		}
 
 		$entry = QueueAbility::consumeFromQueueSlot(

--- a/tests/queueable-direct-static-prompt-smoke.php
+++ b/tests/queueable-direct-static-prompt-smoke.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Pure-PHP smoke test for static prompt queues in direct workflows.
+ *
+ * Run with: php tests/queueable-direct-static-prompt-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Abilities\Flow {
+	class QueueAbility {
+		public const SLOT_PROMPT_QUEUE       = 'prompt_queue';
+		public const SLOT_CONFIG_PATCH_QUEUE = 'config_patch_queue';
+
+		public static function consumeFromQueueSlot( int $flow_id, string $flow_step_id, string $slot, string $queue_mode ): ?array {
+			throw new \RuntimeException( 'Persistent queue storage should not be read for direct static workflows.' );
+		}
+	}
+}
+
+namespace DataMachine\Core\Steps {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+	}
+
+	require_once dirname( __DIR__ ) . '/inc/Core/Steps/QueueableTrait.php';
+
+	class Queueable_Direct_Static_Prompt_Test_Engine {
+		public function getJobContext(): array {
+			return array( 'flow_id' => 'direct' );
+		}
+	}
+
+	class Queueable_Direct_Static_Prompt_Test_Step {
+		use QueueableTrait;
+
+		public object $engine;
+		public string $flow_step_id = 'ephemeral_step_1';
+		public array $flow_step_config = array(
+			'prompt_queue' => array(
+				array(
+					'prompt'   => 'Refresh this exact source URL.',
+					'added_at' => '2026-05-16T00:00:00Z',
+				),
+			),
+		);
+
+		public function __construct() {
+			$this->engine = new Queueable_Direct_Static_Prompt_Test_Engine();
+		}
+
+		public function consumeForTest( string $queue_mode ): array {
+			return $this->consumeFromPromptQueue( $queue_mode );
+		}
+	}
+}
+
+namespace {
+	$failures = 0;
+	$assert   = static function ( bool $condition, string $message ) use ( &$failures ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+		++$failures;
+		echo "  [FAIL] {$message}\n";
+	};
+
+	echo "Queueable direct static prompt smoke\n";
+
+	$step   = new \DataMachine\Core\Steps\Queueable_Direct_Static_Prompt_Test_Step();
+	$result = $step->consumeForTest( 'static' );
+
+	$assert( 'Refresh this exact source URL.' === ( $result['value'] ?? '' ), 'direct static workflows read prompt_queue from step config' );
+	$assert( true === ( $result['from_queue'] ?? false ), 'direct static prompt is marked as queue-sourced' );
+	$assert( false === ( $result['mutated'] ?? true ), 'direct static prompt consumption is non-mutating' );
+
+	$drain_result = $step->consumeForTest( 'drain' );
+	$assert( '' === ( $drain_result['value'] ?? null ), 'direct non-static workflows do not read embedded prompt_queue' );
+
+	if ( $failures > 0 ) {
+		exit( 1 );
+	}
+
+	echo "Queueable direct static prompt smoke passed.\n";
+}


### PR DESCRIPTION
## Summary
- Let direct/ephemeral workflow AI steps read their embedded static `prompt_queue` from step config when no numeric flow ID exists.
- Preserve existing persistent flow queue behavior for numeric flow IDs and non-static direct modes.
- Add pure-PHP smoke coverage for direct static prompt consumption.

## Testing
- `php tests/queueable-direct-static-prompt-smoke.php`
- `php -l inc/Core/Steps/QueueableTrait.php && php -l tests/queueable-direct-static-prompt-smoke.php`
- `php tests/upsert-handler-result-handoff-smoke.php`
- `php tests/queue-mode-callsites-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-direct-static-prompt-queue --changed-since origin/main`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause analysis, patch drafting, and smoke-test coverage for direct workflow prompt queue handling; Chris remains responsible for review and testing.