### PR TITLE
fix: complete assertion-only non-handler AI runs

### DIFF
--- a/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
+++ b/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
@@ -50,6 +50,11 @@ class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Comple
 		$mode            = (string) ( $runtime_context['mode'] ?? '' );
 
 		if ( 'pipeline' !== $mode || ! $is_handler_tool || ! ( $tool_result['success'] ?? false ) ) {
+			$completed_assertions = $this->completedAssertionsDecision( $runtime_context, $turn_count, $tool_name );
+			if ( null !== $completed_assertions ) {
+				return $completed_assertions;
+			}
+
 			$missing_assertions = $this->incompleteAssertionsDecision( $runtime_context, $turn_count );
 			if ( null !== $missing_assertions ) {
 				return $missing_assertions;
@@ -158,6 +163,34 @@ class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Comple
 				'satisfied'            => $evaluation['satisfied'],
 				'required'             => $this->assertions->required(),
 				'continuation_message' => DataMachineCompletionAssertions::buildNudge( $evaluation['missing'], array() ),
+			)
+		);
+	}
+
+	/**
+	 * Complete assertion-only pipeline runs as soon as a non-handler tool satisfies them.
+	 *
+	 * @param array  $runtime_context Caller-owned runtime context.
+	 * @param int    $turn_count      Current turn count.
+	 * @param string $tool_name       Tool that just ran.
+	 * @return WP_Agent_Conversation_Completion_Decision|null
+	 */
+	private function completedAssertionsDecision( array $runtime_context, int $turn_count, string $tool_name ): ?WP_Agent_Conversation_Completion_Decision {
+		if ( ! $this->assertions->hasAssertions() ) {
+			return null;
+		}
+
+		$evaluation = $this->assertions->evaluate( $runtime_context );
+		if ( ! $evaluation['complete'] || empty( $evaluation['satisfied']['complete_when_any'] ) ) {
+			return null;
+		}
+
+		return WP_Agent_Conversation_Completion_Decision::complete(
+			'AIConversationLoop: Completion assertions satisfied by non-handler tool, ending conversation',
+			array(
+				'tool_name'  => $tool_name,
+				'turn_count' => $turn_count,
+				'satisfied'  => $evaluation['satisfied'],
 			)
 		);
 	}

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -1149,6 +1149,58 @@ $parameter_outcome_decision = $parameter_outcome_policy->recordNaturalCompletion
 assert_runtime_policy( $parameter_outcome_decision->isComplete(), 'complete_when_any required_parameters accept matching tool arguments' );
 assert_runtime_policy( array( 'mailbox_return' ) === ( $parameter_outcome_decision->context()['satisfied']['complete_when_any'] ?? null ), 'parameter-matched outcome name is reported as satisfied' );
 
+$design_outcome_policy = new DataMachineHandlerCompletionPolicy(
+	array(),
+	new \DataMachine\Engine\AI\DataMachineCompletionAssertions(
+		array(
+			'complete_when_any' => array(
+				array(
+					'name'  => 'design_comment_and_labels',
+					'tools' => array(
+						array(
+							'name'                => 'manage_github_issue',
+							'required_parameters' => array( 'action' => 'comment' ),
+							'required_output'     => array( 'comment.html_url' ),
+						),
+						array(
+							'name' => 'remove_label_from_issue',
+						),
+						array(
+							'name' => 'add_label_to_issue',
+						),
+					),
+				),
+			),
+		)
+	)
+);
+$design_outcome_policy->recordToolResult(
+	'manage_github_issue',
+	array( 'name' => 'manage_github_issue' ),
+	array(
+		'success' => true,
+		'data'    => array( 'comment' => array( 'html_url' => 'https://github.com/Extra-Chill/data-machine/issues/1#issuecomment-3' ) ),
+	),
+	array( 'mode' => 'pipeline', 'tool_parameters' => array( 'action' => 'comment' ) ),
+	1
+);
+$design_outcome_policy->recordToolResult(
+	'remove_label_from_issue',
+	array( 'name' => 'remove_label_from_issue' ),
+	array( 'success' => true ),
+	array( 'mode' => 'pipeline' ),
+	2
+);
+$design_outcome_decision = $design_outcome_policy->recordToolResult(
+	'add_label_to_issue',
+	array( 'name' => 'add_label_to_issue' ),
+	array( 'success' => true ),
+	array( 'mode' => 'pipeline' ),
+	3
+);
+assert_runtime_policy( $design_outcome_decision->isComplete(), 'non-handler complete_when_any outcome completes immediately when satisfied' );
+assert_runtime_policy( array( 'design_comment_and_labels' ) === ( $design_outcome_decision->context()['satisfied']['complete_when_any'] ?? null ), 'non-handler completion reports satisfied outcome name' );
+
 $multi_call_outcome_policy = new DataMachineHandlerCompletionPolicy(
 	array(),
 	new \DataMachine\Engine\AI\DataMachineCompletionAssertions(


### PR DESCRIPTION
## Summary
- Complete assertion-only pipeline runs as soon as a non-handler `complete_when_any` outcome is satisfied.
- Preserve existing required-tool behavior that still needs a natural completion turn.
- Add smoke coverage for the wp-site-generator design flow shape: GitHub comment plus label updates.

## Tests
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `php tests/ai-completion-assertion-packet-smoke.php`
- `php -l inc/Engine/AI/DataMachineHandlerCompletionPolicy.php && php -l tests/agent-conversation-runtime-policy-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the completion-policy regression, drafted the code/test changes, and ran focused smoke checks; Chris remains responsible for review and merge.