### PR TITLE
Surface missing AI completion assertions

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -970,8 +970,8 @@ class AIStep extends Step {
 		}
 
 		return array(
-			'reason'                         => 'completion_assertions_missing',
-			'completion_assertions_missing'  => $missing,
+			'reason'                          => 'completion_assertions_missing',
+			'completion_assertions_missing'   => $missing,
 			'completion_assertions_satisfied' => is_array( $loop_result['completion_assertions_satisfied'] ?? null ) ? $loop_result['completion_assertions_satisfied'] : array(),
 			'completion_assertions_required'  => is_array( $loop_result['completion_assertions_required'] ?? null ) ? $loop_result['completion_assertions_required'] : array(),
 		);

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -510,6 +510,20 @@ class AIStep extends Step {
 				datamachine_set_engine_data( $this->job_id, $artifact_engine_data );
 			}
 
+			$missing_assertion_failure = self::missingCompletionAssertionsFailure( $loop_result );
+			if ( null !== $missing_assertion_failure ) {
+				do_action(
+					'datamachine_fail_job',
+					$this->job_id,
+					'completion_assertions_missing',
+					array_merge(
+						array( 'flow_step_id' => $this->flow_step_id ),
+						$missing_assertion_failure
+					)
+				);
+				return array();
+			}
+
 			// Process loop results into data packets
 			return self::processLoopResults( $loop_result, $this->dataPackets, $payload, $available_tools );
 		} finally {
@@ -940,5 +954,26 @@ class AIStep extends Step {
 		}
 
 		return $outputPackets;
+	}
+
+	/**
+	 * Build a structured failure payload when an AI loop exhausts without
+	 * satisfying configured completion assertions.
+	 *
+	 * @param array $loop_result Conversation loop result.
+	 * @return array<string,mixed>|null Failure payload, or null when assertions are complete/not configured.
+	 */
+	private static function missingCompletionAssertionsFailure( array $loop_result ): ?array {
+		$missing = is_array( $loop_result['completion_assertions_missing'] ?? null ) ? $loop_result['completion_assertions_missing'] : array();
+		if ( empty( $missing ) || true === ( $loop_result['completion_assertions_complete'] ?? false ) ) {
+			return null;
+		}
+
+		return array(
+			'reason'                         => 'completion_assertions_missing',
+			'completion_assertions_missing'  => $missing,
+			'completion_assertions_satisfied' => is_array( $loop_result['completion_assertions_satisfied'] ?? null ) ? $loop_result['completion_assertions_satisfied'] : array(),
+			'completion_assertions_required'  => is_array( $loop_result['completion_assertions_required'] ?? null ) ? $loop_result['completion_assertions_required'] : array(),
+		);
 	}
 }

--- a/tests/ai-completion-assertion-packet-smoke.php
+++ b/tests/ai-completion-assertion-packet-smoke.php
@@ -91,6 +91,7 @@ echo "AI completion assertion packet smoke\n";
 echo "-------------------------------------\n\n";
 
 $method = new ReflectionMethod( AIStep::class, 'processLoopResults' );
+$missing_method = new ReflectionMethod( AIStep::class, 'missingCompletionAssertionsFailure' );
 
 $result = $method->invoke(
 	null,
@@ -117,6 +118,31 @@ assert_completion_packet( 1 === count( $result ), 'AI step emits one summary pac
 assert_completion_packet( 'ai_completion_assertions' === ( $result[0]['type'] ?? '' ), 'packet uses completion assertion type', $failures, $passes );
 assert_completion_packet( 'design_ai_step' === ( $result[0]['metadata']['flow_step_id'] ?? '' ), 'packet preserves flow step id', $failures, $passes );
 assert_completion_packet( array( 'design_comment_and_labels' ) === ( $result[0]['metadata']['completion_assertions_satisfied']['complete_when_any'] ?? array() ), 'packet carries satisfied outcome', $failures, $passes );
+
+$missing_failure = $missing_method->invoke(
+	null,
+	array(
+		'completion_assertions_complete'  => false,
+		'completion_assertions_missing'   => array( 'tool_names' => array( 'comment_github_pull_request' ) ),
+		'completion_assertions_satisfied' => array( 'complete_when_any' => array( 'pull_request_path' ) ),
+		'completion_assertions_required'  => array( 'tool_names' => array( 'comment_github_pull_request' ) ),
+	)
+);
+
+assert_completion_packet( is_array( $missing_failure ), 'missing assertions build structured failure payload', $failures, $passes );
+assert_completion_packet( 'completion_assertions_missing' === ( $missing_failure['reason'] ?? '' ), 'missing assertion failure uses explicit reason', $failures, $passes );
+assert_completion_packet( array( 'comment_github_pull_request' ) === ( $missing_failure['completion_assertions_missing']['tool_names'] ?? array() ), 'missing assertion failure preserves missing tool names', $failures, $passes );
+
+$complete_failure = $missing_method->invoke(
+	null,
+	array(
+		'completion_assertions_complete'  => true,
+		'completion_assertions_missing'   => array(),
+		'completion_assertions_satisfied' => array( 'complete_when_any' => array( 'pull_request_path' ) ),
+	)
+);
+
+assert_completion_packet( null === $complete_failure, 'satisfied assertions do not build failure payload', $failures, $passes );
 
 echo "\n-------------------------------------\n";
 echo sprintf( "%d / %d passed\n", $passes, $passes + count( $failures ) );


### PR DESCRIPTION
## Summary
- Fail AI steps with `completion_assertions_missing` when the conversation loop exits with unmet assertions.
- Preserve structured missing/satisfied/required assertion details in the failure payload instead of falling through to `empty_data_packet_returned`.
- Extend the side-effect-only assertion smoke test to cover the missing-assertion failure payload.

## Verification
- `php tests/ai-completion-assertion-packet-smoke.php`
- `php tests/ai-error-status-propagation-smoke.php`
- `php -l inc/Core/Steps/AI/AIStep.php && php -l tests/ai-completion-assertion-packet-smoke.php`
- `git diff --check`

## Context
The wp-site-generator iterator can perform upstream GitHub side effects and then stop before a required callback. Data Machine currently reports that as `empty_data_packet_returned`, which hides the real contract failure from Homeboy and callers. This makes incomplete assertion state explicit so downstream workflows can react to the actual missing requirement.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the assertion/empty-packet contract gap, drafted the focused Data Machine fix and smoke coverage, and ran targeted checks. Chris remains responsible for review and merge.