### PR TITLE
Preserve local agent config on bundle upgrades

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -709,6 +709,14 @@ class AgentBundleCommand extends BaseCommand {
 		$agent_id                   = is_array( $agent ) ? (int) ( $agent['agent_id'] ?? 0 ) : 0;
 		$pipeline_id_map            = array();
 		$existing_pipelines_by_slug = array();
+		$incoming_config            = is_array( $bundle['agent']['agent_config'] ?? null ) ? $bundle['agent']['agent_config'] : array();
+
+		$artifacts[] = array(
+			'artifact_type' => 'agent_config',
+			'artifact_id'   => 'config',
+			'source_path'   => 'manifest.json#/agent/agent_config',
+			'payload'       => self::tracked_agent_config_payload( $incoming_config ),
+		);
 
 		if ( $agent_id > 0 ) {
 			foreach ( $this->pipelines()->get_all_pipelines( null, $agent_id ) as $pipeline ) {
@@ -780,6 +788,13 @@ class AgentBundleCommand extends BaseCommand {
 		$artifacts = array();
 		$pipelines = $this->pipelines()->get_all_pipelines( null, $agent_id );
 		$flows     = $this->flows()->get_all_flows( null, $agent_id );
+
+		$artifacts[] = array(
+			'artifact_type' => 'agent_config',
+			'artifact_id'   => 'config',
+			'source_path'   => 'manifest.json#/agent/agent_config',
+			'payload'       => self::tracked_agent_config_payload( is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array() ),
+		);
 
 		$pipeline_by_slug = array();
 		foreach ( $pipelines as $pipeline ) {
@@ -870,6 +885,22 @@ class AgentBundleCommand extends BaseCommand {
 		unset( $step );
 
 		return $flow_config;
+	}
+
+	/**
+	 * Return the bundle-owned agent config payload tracked by package upgrades.
+	 *
+	 * The installer maintains `datamachine_bundle` bookkeeping under agent_config;
+	 * that metadata is not authored by bundles and must not participate in local
+	 * config drift checks.
+	 *
+	 * @param array<string,mixed> $config Agent config.
+	 * @return array<string,mixed>
+	 */
+	private static function tracked_agent_config_payload( array $config ): array {
+		unset( $config['datamachine_bundle'] );
+		ksort( $config, SORT_STRING );
+		return $config;
 	}
 
 	private function resolve_bundle_agent( array $bundle, string $slug = '' ): ?array {

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -626,20 +626,42 @@ class AgentBundler {
 			// 1. Create or update the agent record.
 			$incoming_config = $agent_data['agent_config'] ?? array();
 
-			$incoming_config = is_array( $incoming_config ) ? $incoming_config : array();
+			$incoming_config                = is_array( $incoming_config ) ? $incoming_config : array();
+			$existing_bundle_state          = is_array( $existing['agent_config']['datamachine_bundle'] ?? null )
+				? $existing['agent_config']['datamachine_bundle']
+				: array();
+			$artifact_records               = is_array( $existing_bundle_state['artifacts'] ?? null ) ? $existing_bundle_state['artifacts'] : array();
+			$config_conflicts               = array();
+			$agent_config_key               = self::artifact_key( 'agent_config', 'config' );
+			$incoming_config_payload        = self::tracked_agent_config_payload( $incoming_config );
+			$current_config_payload         = self::tracked_agent_config_payload( is_array( $existing['agent_config'] ?? null ) ? $existing['agent_config'] : array() );
+			$agent_config_record            = $artifact_records[ $agent_config_key ] ?? null;
+			$agent_config_has_local_changes = $existing && (
+				$this->artifact_has_local_modifications( is_array( $agent_config_record ) ? $agent_config_record : null, $current_config_payload )
+				|| ( ! is_array( $agent_config_record ) && ! empty( $current_config_payload ) )
+			);
+			$agent_config_target_differs    = ! hash_equals(
+				AgentBundleArtifactHasher::hash( $incoming_config_payload ),
+				AgentBundleArtifactHasher::hash( $current_config_payload )
+			);
+
+			if ( $agent_config_has_local_changes && $agent_config_target_differs ) {
+				$config_conflicts[] = array(
+					'artifact_type' => 'agent_config',
+					'artifact_id'   => 'config',
+					'reason'        => 'local_modified',
+				);
+				$incoming_config    = array();
+			}
 
 			$config = is_array( $existing['agent_config'] ?? null )
-			? array_merge( $existing['agent_config'], $incoming_config )
-			: $incoming_config;
-
-			$existing_bundle_state = is_array( $existing['agent_config']['datamachine_bundle'] ?? null )
-			? $existing['agent_config']['datamachine_bundle']
-			: array();
+				? array_merge( $existing['agent_config'], $incoming_config )
+				: $incoming_config;
 
 			$config['datamachine_bundle'] = array_merge(
-			$existing_bundle_state,
-			$bundle_metadata,
-			array( 'artifacts' => $existing_bundle_state['artifacts'] ?? array() )
+				$existing_bundle_state,
+				$bundle_metadata,
+				array( 'artifacts' => $existing_bundle_state['artifacts'] ?? array() )
 			);
 			if ( ! empty( $bundle_run_artifacts ) ) {
 				$config['datamachine_bundle']['run_artifacts'] = $bundle_run_artifacts;
@@ -648,20 +670,20 @@ class AgentBundler {
 			if ( $existing ) {
 				$agent_id = (int) $existing['agent_id'];
 				if ( ! $this->agents_repo->update_agent(
-				$agent_id,
-				array(
-					'agent_name'   => $agent_data['agent_name'] ?? $slug,
-					'agent_config' => $config,
-				)
+					$agent_id,
+					array(
+						'agent_name'   => $agent_data['agent_name'] ?? $slug,
+						'agent_config' => $config,
+					)
 				) ) {
 					throw new \RuntimeException( 'Failed to update existing agent record.' );
 				}
 			} else {
 				$agent_id = $this->agents_repo->create_if_missing(
-				$slug,
-				$agent_data['agent_name'] ?? $slug,
-				$owner_id,
-				$config
+					$slug,
+					$agent_data['agent_name'] ?? $slug,
+					$owner_id,
+					$config
 				);
 				if ( ! $agent_id ) {
 					throw new \RuntimeException( 'Failed to create agent record.' );
@@ -678,8 +700,17 @@ class AgentBundler {
 			}
 
 			$artifact_records = $config['datamachine_bundle']['artifacts'];
-			$conflicts        = array();
+			$conflicts        = $config_conflicts;
 			$runtime_drift    = array();
+			if ( empty( $config_conflicts ) ) {
+				$artifact_records[ $agent_config_key ] = $this->bundle_artifact_record(
+					$bundle_metadata,
+					'agent_config',
+					'config',
+					'manifest.json#/agent/agent_config',
+					$incoming_config_payload
+				);
+			}
 
 			// 4. Import pipelines — build old→new ID map.
 			$pipeline_id_map = array(); // old_id => new_id.
@@ -1302,6 +1333,22 @@ class AgentBundler {
 
 	private static function artifact_key( string $type, string $id ): string {
 		return AgentBundleArtifactExtensions::artifact_key( $type, $id );
+	}
+
+	/**
+	 * Return the bundle-owned agent config payload tracked by package upgrades.
+	 *
+	 * Data Machine writes installation bookkeeping under `datamachine_bundle` at
+	 * runtime. That metadata is not authored by bundles, so excluding it keeps
+	 * agent config conflict detection focused on operator/bundle-owned settings.
+	 *
+	 * @param array<string,mixed> $config Agent config.
+	 * @return array<string,mixed>
+	 */
+	private static function tracked_agent_config_payload( array $config ): array {
+		unset( $config['datamachine_bundle'] );
+		ksort( $config, SORT_STRING );
+		return $config;
 	}
 
 	private function preserve_runtime_queue_fields( array $incoming_flow_config, array $existing_flow_config ): array {

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -595,6 +595,83 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_upgrade_preserves_locally_modified_agent_config_and_reports_conflict(): void {
+		$bundle = $this->fixture_bundle( 'context-agent' );
+		$bundle['agent']['agent_config'] = array(
+			'intelligence' => array(
+				'context_servers' => array(
+					'wporg' => array(
+						'transport' => 'stdio',
+						'command'   => 'node',
+					),
+				),
+			),
+		);
+
+		$first = $this->bundler->import( $bundle, null, $this->owner_id );
+		$this->assertTrue( (bool) $first['success'], 'Initial install succeeds.' );
+
+		$agent = $this->agents_repo->get_by_slug( 'context-agent' );
+		$this->agents_repo->update_agent(
+			(int) $agent['agent_id'],
+			array(
+				'agent_config' => array_merge(
+					$agent['agent_config'],
+					array(
+						'intelligence' => array(
+							'context_servers' => array(
+								'wporg' => array(
+									'transport' => 'streamable-http',
+									'url'       => 'https://example.test/mcp',
+									'headers'   => array( 'Authorization' => 'Bearer local-token' ),
+								),
+							),
+						),
+					)
+				),
+			)
+		);
+
+		$updated_bundle = $bundle;
+		$updated_bundle['agent']['agent_config']['intelligence']['context_servers']['wporg']['args'] = array( 'mcp-context-wporg/dist/index.js' );
+
+		$second = $this->bundler->import(
+			$updated_bundle,
+			null,
+			$this->owner_id,
+			false,
+			array( 'is_upgrade' => true )
+		);
+
+		$this->assertTrue( (bool) $second['success'], 'Upgrade succeeds so clean artifacts can apply.' );
+		$this->assertSame(
+			array(
+				'artifact_type' => 'agent_config',
+				'artifact_id'   => 'config',
+				'reason'        => 'local_modified',
+			),
+			$second['summary']['conflicts'][0] ?? null,
+			'Locally modified agent config is reported as a conflict.'
+		);
+
+		$after = $this->agents_repo->get_by_slug( 'context-agent' );
+		$this->assertSame(
+			'streamable-http',
+			$after['agent_config']['intelligence']['context_servers']['wporg']['transport'] ?? null,
+			'Upgrade preserves the live context server transport.'
+		);
+		$this->assertSame(
+			'Bearer local-token',
+			$after['agent_config']['intelligence']['context_servers']['wporg']['headers']['Authorization'] ?? null,
+			'Upgrade preserves the live context server authorization header.'
+		);
+		$this->assertArrayNotHasKey(
+			'args',
+			$after['agent_config']['intelligence']['context_servers']['wporg'],
+			'Bundle context server args do not overwrite local runtime config without approval.'
+		);
+	}
+
 	/**
 	 * Defensive registry cleanup: even though the importer does not currently write to
 	 * `datamachine_bundle_artifacts`, extensions can. If an agent is deleted, any tracked rows for

--- a/tests/agent-bundle-upgrade-planner-smoke.php
+++ b/tests/agent-bundle-upgrade-planner-smoke.php
@@ -131,6 +131,82 @@ if ( ! class_exists( 'WP_Error' ) ) {
 		}
 	}
 }
+if ( ! class_exists( 'AgentsAPI\\Core\\Workspace\\WP_Agent_Workspace_Scope' ) ) {
+	eval( '
+	namespace AgentsAPI\\Core\\Workspace;
+	class WP_Agent_Workspace_Scope {
+		private string $type;
+		private string $id;
+		private function __construct( string $type, string $id ) { $this->type = $type; $this->id = $id; }
+		public static function from_parts( string $type, string $id ): self { return new self( $type, $id ); }
+		public static function from_array( array $data ): self { return new self( (string) ( $data["type"] ?? "site" ), (string) ( $data["id"] ?? "test" ) ); }
+		public function to_array(): array { return array( "type" => $this->type, "id" => $this->id ); }
+	}
+	' );
+}
+if ( ! class_exists( 'AgentsAPI\\AI\\Approvals\\WP_Agent_Pending_Action_Status' ) ) {
+	eval( '
+	namespace AgentsAPI\\AI\\Approvals;
+	final class WP_Agent_Pending_Action_Status {
+		public const PENDING = "pending";
+		public const ACCEPTED = "accepted";
+		public const REJECTED = "rejected";
+		public const EXPIRED = "expired";
+		public const DELETED = "deleted";
+		public static function normalize( string $status ): string { return $status; }
+	}
+	' );
+}
+if ( ! class_exists( 'AgentsAPI\\AI\\WP_Agent_Message' ) ) {
+	eval( '
+	namespace AgentsAPI\\AI;
+	final class WP_Agent_Message {
+		public const SCHEMA = "wp-agent-message";
+		public const VERSION = "1.0.0";
+		public const TYPE_APPROVAL_REQUIRED = "approval_required";
+		public static function approvalRequired( string $summary, array $payload, array $metadata ): array {
+			$pending = $payload["pending_action"] ?? array();
+			return array(
+				"schema" => self::SCHEMA,
+				"version" => self::VERSION,
+				"type" => self::TYPE_APPROVAL_REQUIRED,
+				"role" => "tool",
+				"content" => $summary,
+				"payload" => $payload,
+				"metadata" => $metadata,
+				"kind" => $pending["kind"] ?? "",
+				"preview" => $pending["preview"] ?? array(),
+			);
+		}
+	}
+	' );
+}
+if ( ! class_exists( 'AgentsAPI\\AI\\Approvals\\WP_Agent_Approval_Decision' ) ) {
+	eval( '
+	namespace AgentsAPI\\AI\\Approvals;
+	final class WP_Agent_Approval_Decision {
+		private string $value;
+		private function __construct( string $value ) { $this->value = $value; }
+		public static function from_string( string $value ): self {
+			if ( ! in_array( $value, array( "accepted", "rejected" ), true ) ) { throw new \\InvalidArgumentException( "invalid decision" ); }
+			return new self( $value );
+		}
+		public function value(): string { return $this->value; }
+		public function is_rejected(): bool { return "rejected" === $this->value; }
+	}
+	' );
+}
+if ( ! class_exists( 'AgentsAPI\\AI\\Approvals\\WP_Agent_Pending_Action' ) ) {
+	eval( '
+	namespace AgentsAPI\\AI\\Approvals;
+	final class WP_Agent_Pending_Action {
+		private array $data;
+		private function __construct( array $data ) { $this->data = $data; }
+		public static function from_array( array $data ): self { return new self( $data ); }
+		public function to_array(): array { return $this->data; }
+	}
+	' );
+}
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php';
@@ -226,6 +302,58 @@ $approval = $plan_array['needs_approval'][0] ?? array();
 assert_upgrade_plan( 'approval entry includes before payload', isset( $approval['diff']['before']['note'] ) );
 assert_upgrade_plan_equals( 'secret-like target keys are redacted', '[redacted]', $approval['diff']['after']['api_token'] ?? null );
 assert_upgrade_plan( 'raw secret value is absent from preview', false === strpos( (string) json_encode( $plan_array ), 'secret-token-value' ) );
+
+echo "\n[2b] Agent config drift is surfaced like artifact conflicts\n";
+$old_agent_config = upgrade_artifact(
+	'agent_config',
+	'config',
+	array(
+		'intelligence' => array(
+			'context_servers' => array(
+				'wporg' => array( 'transport' => 'stdio' ),
+			),
+		),
+	),
+	'manifest.json#/agent/agent_config'
+);
+$local_agent_config = upgrade_artifact(
+	'agent_config',
+	'config',
+	array(
+		'intelligence' => array(
+			'context_servers' => array(
+				'wporg' => array(
+					'transport' => 'streamable-http',
+					'headers'   => array( 'Authorization' => 'Bearer local-token' ),
+				),
+			),
+		),
+	),
+	'manifest.json#/agent/agent_config'
+);
+$target_agent_config = upgrade_artifact(
+	'agent_config',
+	'config',
+	array(
+		'intelligence' => array(
+			'context_servers' => array(
+				'wporg' => array( 'transport' => 'stdio', 'command' => 'node' ),
+			),
+		),
+	),
+	'manifest.json#/agent/agent_config'
+);
+$config_plan       = AgentBundleUpgradePlanner::plan(
+	array( installed_row( $old_agent_config ) ),
+	array( $local_agent_config ),
+	array( $target_agent_config ),
+	array( 'bundle_slug' => 'wordpress-core-wiki' )
+)->to_array();
+$config_conflict   = $config_plan['needs_approval'][0] ?? array();
+assert_upgrade_plan_equals( 'locally changed context server needs approval', 'agent_config:config', $config_conflict['artifact_key'] ?? null );
+assert_upgrade_plan_equals( 'agent config reason is local modified', 'local_modified', $config_conflict['reason'] ?? null );
+assert_upgrade_plan_equals( 'authorization header is redacted', '[redacted]', $config_conflict['diff']['before']['intelligence']['context_servers']['wporg']['headers']['Authorization'] ?? null );
+assert_upgrade_plan( 'raw local bearer is absent from config preview', false === strpos( (string) json_encode( $config_plan ), 'local-token' ) );
 
 echo "\n[3] PendingAction stages bundle-upgrade previews\n";
 $staged = AgentBundleUpgradePendingAction::stage(


### PR DESCRIPTION
## Summary
- Track bundle-authored `agent_config` as a first-class upgrade artifact so local runtime changes appear in upgrade diffs.
- Preserve locally modified agent config during imports instead of overwriting environment-specific context server settings.
- Add smoke/unit coverage for context server drift, approval previews, and secret redaction.

## Testing
- `php -l inc/Core/Agents/AgentBundler.php && php -l inc/Cli/Commands/AgentBundleCommand.php && php -l tests/agent-bundle-upgrade-planner-smoke.php && php -l tests/Unit/Core/Agents/AgentBundlerImportTest.php`
- `php tests/agent-bundle-upgrade-planner-smoke.php`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-agent-config-upgrade-conflicts --extension wordpress` fails on existing repo-wide JS/dependency lint findings; no findings target the changed files after cleanup.
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-agent-config-upgrade-conflicts --extension wordpress --scenario host-smoke` fails during bootstrap before tests run: `Interface "WP_Agent_Principal_Access_Store" not found`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the code changes, smoke coverage, verification commands, and PR description for Chris to review and test.