### PR TITLE
Add external login primitives

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -149,6 +149,9 @@ function datamachine_run_datamachine_plugin() {
 	// Agent auth callback handler (receives tokens from external DM instances).
 	new \DataMachine\Core\Auth\AgentAuthCallback();
 
+	// External human-login callback routing (separate from credential auth).
+	\DataMachine\Core\Auth\ExternalLoginRouter::register();
+
 	// Register ability categories first — must happen before any ability registration.
 	require_once __DIR__ . '/inc/Abilities/AbilityCategories.php';
 	\DataMachine\Abilities\AbilityCategories::ensure_registered();

--- a/inc/Core/Auth/ExternalLoginProviderInterface.php
+++ b/inc/Core/Auth/ExternalLoginProviderInterface.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * External login provider contract.
+ *
+ * @package DataMachine\Core\Auth
+ */
+
+namespace DataMachine\Core\Auth;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Authenticates a human visitor with an external identity provider.
+ *
+ * Credential auth providers connect tools and store provider tokens. External
+ * login providers prove a visitor identity, create/link a WordPress user, set
+ * the site auth cookie, and return the visitor to the frontend.
+ */
+interface ExternalLoginProviderInterface {
+
+	/**
+	 * Stable provider slug, for example `wpcom`.
+	 */
+	public function get_slug(): string;
+
+	/**
+	 * Site-relative callback path handled by this provider.
+	 */
+	public function get_callback_path(): string;
+
+	/**
+	 * Handle a callback request.
+	 *
+	 * Return null when the request belongs to another provider or login intent
+	 * sharing the same callback path.
+	 *
+	 * @param array<string,mixed> $request_params Sanitized request parameters.
+	 * @return array{redirect_to:string,user_id?:int,migrated_sessions?:int}|WP_Error|null
+	 */
+	public function handle_external_login_callback( array $request_params );
+}

--- a/inc/Core/Auth/ExternalLoginRouter.php
+++ b/inc/Core/Auth/ExternalLoginRouter.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * External login callback router.
+ *
+ * @package DataMachine\Core\Auth
+ */
+
+namespace DataMachine\Core\Auth;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Routes external human-login callbacks independently from credential auth.
+ */
+final class ExternalLoginRouter {
+
+	/**
+	 * Register rewrite and direct path handling.
+	 */
+	public static function register(): void {
+		add_action( 'init', array( __CLASS__, 'register_rewrites' ) );
+		add_filter( 'query_vars', array( __CLASS__, 'register_query_vars' ) );
+		add_action( 'template_redirect', array( __CLASS__, 'maybe_handle_callback' ), 0 );
+	}
+
+	/**
+	 * Register callback rewrites for known providers.
+	 */
+	public static function register_rewrites(): void {
+		foreach ( self::providers() as $provider ) {
+			$path = trim( $provider->get_callback_path(), '/' );
+			if ( '' === $path ) {
+				continue;
+			}
+
+			add_rewrite_rule(
+				'^' . preg_quote( $path, '#' ) . '/?$',
+				'index.php?datamachine_external_login_provider=' . rawurlencode( $provider->get_slug() ),
+				'top'
+			);
+		}
+	}
+
+	/**
+	 * @param string[] $vars Query vars.
+	 * @return string[] Query vars.
+	 */
+	public static function register_query_vars( array $vars ): array {
+		$vars[] = 'datamachine_external_login_provider';
+		return $vars;
+	}
+
+	/**
+	 * Handle a callback request when a registered provider claims it.
+	 */
+	public static function maybe_handle_callback(): void {
+		$request_path = isset( $_SERVER['REQUEST_URI'] ) ? (string) wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH ) : '';
+		if ( '' === $request_path ) {
+			return;
+		}
+
+		$request_params = self::sanitize_request_params( $_GET ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- External login callbacks validate OAuth state in provider handlers.
+
+		foreach ( self::providers() as $provider ) {
+			if ( untrailingslashit( $request_path ) !== untrailingslashit( $provider->get_callback_path() ) ) {
+				continue;
+			}
+
+			$result = $provider->handle_external_login_callback( $request_params );
+			if ( null === $result ) {
+				continue;
+			}
+
+			if ( is_wp_error( $result ) ) {
+				wp_die( esc_html( $result->get_error_message() ), esc_html__( 'External sign-in failed', 'data-machine' ), array( 'response' => 400 ) );
+			}
+
+			$redirect_to = wp_validate_redirect( (string) ( $result['redirect_to'] ?? '' ), home_url( '/' ) );
+			wp_safe_redirect( $redirect_to );
+			exit;
+		}
+	}
+
+	/**
+	 * Return a provider callback URL.
+	 */
+	public static function callback_url( string $provider_slug ): string {
+		$provider = self::provider( $provider_slug );
+		return $provider ? site_url( $provider->get_callback_path() ) : '';
+	}
+
+	/**
+	 * @return array<string,ExternalLoginProviderInterface>
+	 */
+	public static function providers(): array {
+		/**
+		 * Filters registered external human-login providers.
+		 *
+		 * @param array<string,ExternalLoginProviderInterface> $providers Providers keyed by slug.
+		 */
+		$providers = apply_filters( 'datamachine_external_login_providers', array() );
+		if ( ! is_array( $providers ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $providers as $provider ) {
+			if ( ! $provider instanceof ExternalLoginProviderInterface ) {
+				continue;
+			}
+
+			$slug = sanitize_key( $provider->get_slug() );
+			if ( '' !== $slug ) {
+				$normalized[ $slug ] = $provider;
+			}
+		}
+
+		return $normalized;
+	}
+
+	public static function provider( string $provider_slug ): ?ExternalLoginProviderInterface {
+		$providers = self::providers();
+		$slug      = sanitize_key( $provider_slug );
+		return $providers[ $slug ] ?? null;
+	}
+
+	/**
+	 * @param array<string,mixed> $params Raw request params.
+	 * @return array<string,mixed> Sanitized request params.
+	 */
+	private static function sanitize_request_params( array $params ): array {
+		$sanitized = array();
+		foreach ( $params as $key => $value ) {
+			$key = sanitize_key( (string) $key );
+			if ( '' === $key ) {
+				continue;
+			}
+
+			$sanitized[ $key ] = is_scalar( $value ) ? sanitize_text_field( wp_unslash( (string) $value ) ) : '';
+		}
+
+		return $sanitized;
+	}
+}

--- a/inc/Core/Auth/PrincipalSessionPromoter.php
+++ b/inc/Core/Auth/PrincipalSessionPromoter.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Principal session promotion helpers.
+ *
+ * @package DataMachine\Core\Auth
+ */
+
+namespace DataMachine\Core\Auth;
+
+use DataMachine\Abilities\Chat\ChatTranscriptOwner;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Moves anonymous/browser-owned transcripts onto a logged-in user principal.
+ */
+final class PrincipalSessionPromoter {
+
+	/**
+	 * Promote browser-principal chat sessions to a WordPress user owner.
+	 */
+	public static function promote_browser_to_user( string $browser_principal_id, int $user_id ): int {
+		if ( '' === $browser_principal_id || $user_id <= 0 ) {
+			return 0;
+		}
+
+		$old = ChatTranscriptOwner::resolve_for_request(
+			array(
+				'transcript_owner' => array(
+					'type' => 'browser',
+					'key'  => $browser_principal_id,
+				),
+			),
+			0
+		);
+		if ( is_wp_error( $old ) ) {
+			return 0;
+		}
+
+		$user = ChatTranscriptOwner::user_owner( $user_id );
+
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_chat_sessions';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Intentional ownership migration for a completed login flow.
+		$result = $wpdb->update(
+			$table,
+			array(
+				'user_id'        => $user_id,
+				'owner_type'     => $user['owner_type'],
+				'owner_key_hash' => $user['owner_key_hash'],
+				'owner_label'    => $user['owner_label'],
+			),
+			array(
+				'owner_type'     => $old['owner_type'],
+				'owner_key_hash' => $old['owner_key_hash'],
+			),
+			array( '%d', '%s', '%s', '%s' ),
+			array( '%s', '%s' )
+		);
+
+		return false === $result ? 0 : (int) $result;
+	}
+}

--- a/tests/external-login-primitives-smoke.php
+++ b/tests/external-login-primitives-smoke.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Smoke tests for external login primitives.
+ *
+ *   php tests/external-login-primitives-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ );
+	}
+
+	class WP_Error {
+		public function __construct( private string $code, private string $message = '' ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+	}
+
+	class DataMachine_External_Login_WPDB_Smoke {
+		public string $prefix = 'wp_';
+		public array $rows = array();
+		public function update( string $table, array $data, array $where, array $formats = array(), array $where_formats = array() ) {
+			unset( $table, $formats, $where_formats );
+			$count = 0;
+			foreach ( $this->rows as &$row ) {
+				if ( $row['owner_type'] === $where['owner_type'] && $row['owner_key_hash'] === $where['owner_key_hash'] ) {
+					$row = array_merge( $row, $data );
+					++$count;
+				}
+			}
+			return $count;
+		}
+	}
+
+	$GLOBALS['wpdb'] = new DataMachine_External_Login_WPDB_Smoke();
+	$GLOBALS['datamachine_external_login_providers'] = array();
+
+	function __( $text, $domain = null ) { unset( $domain ); return $text; }
+	function esc_html__( $text, $domain = null ) { unset( $domain ); return $text; }
+	function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+	function sanitize_key( $value ): string { return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) ); }
+	function sanitize_text_field( $value ): string { return trim( (string) $value ); }
+	function wp_unslash( $value ) { return $value; }
+	function wp_parse_url( string $url, int $component = -1 ) { return parse_url( $url, $component ); }
+	function untrailingslashit( string $value ): string { return rtrim( $value, '/' ); }
+	function site_url( string $path = '' ): string { return 'https://example.test' . $path; }
+	function home_url( string $path = '' ): string { return 'https://example.test' . $path; }
+	function add_action() {}
+	function add_filter() {}
+	function add_rewrite_rule() {}
+	function apply_filters( string $hook, $value ) {
+		if ( 'datamachine_external_login_providers' === $hook ) {
+			return $GLOBALS['datamachine_external_login_providers'];
+		}
+		return $value;
+	}
+}
+
+namespace DataMachine\Abilities\Chat {
+	class ChatTranscriptOwner {
+		public static function user_owner( int $user_id ): array {
+			return array( 'owner_type' => 'user', 'owner_key' => 'user:' . $user_id, 'owner_key_hash' => hash( 'sha256', 'user:' . $user_id ), 'owner_label' => 'User ' . $user_id, 'user_id' => $user_id );
+		}
+		public static function resolve_for_request( array $input = array(), int $fallback_user_id = 0 ) {
+			unset( $fallback_user_id );
+			$owner = $input['transcript_owner'] ?? array();
+			$key = ( $owner['type'] ?? '' ) . ':' . ( $owner['key'] ?? '' );
+			return array( 'owner_type' => $owner['type'] ?? '', 'owner_key' => $key, 'owner_key_hash' => hash( 'sha256', $key ), 'owner_label' => $owner['type'] ?? '', 'user_id' => 0 );
+		}
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Core/Auth/ExternalLoginProviderInterface.php';
+	require_once dirname( __DIR__ ) . '/inc/Core/Auth/ExternalLoginRouter.php';
+	require_once dirname( __DIR__ ) . '/inc/Core/Auth/PrincipalSessionPromoter.php';
+
+	$pass = 0;
+	$fail = 0;
+	$assert = static function ( string $label, bool $condition ) use ( &$pass, &$fail ): void {
+		if ( $condition ) { ++$pass; echo "PASS: {$label}\n"; return; }
+		++$fail; echo "FAIL: {$label}\n";
+	};
+
+	$provider = new class() implements \DataMachine\Core\Auth\ExternalLoginProviderInterface {
+		public function get_slug(): string { return 'demo'; }
+		public function get_callback_path(): string { return '/login/demo/callback'; }
+		public function handle_external_login_callback( array $request_params ) { return array( 'redirect_to' => $request_params['redirect_to'] ?? 'https://example.test/' ); }
+	};
+	$GLOBALS['datamachine_external_login_providers'] = array( 'demo' => $provider, 'invalid' => new \stdClass() );
+
+	$assert( 'provider registry filters invalid entries', array( 'demo' ) === array_keys( \DataMachine\Core\Auth\ExternalLoginRouter::providers() ) );
+	$assert( 'callback URL resolves from provider', 'https://example.test/login/demo/callback' === \DataMachine\Core\Auth\ExternalLoginRouter::callback_url( 'demo' ) );
+
+	$browser_id = 'browser:abc';
+	$GLOBALS['wpdb']->rows[] = array( 'session_id' => 's1', 'user_id' => 1, 'owner_type' => 'browser', 'owner_key_hash' => hash( 'sha256', 'browser:' . $browser_id ), 'owner_label' => 'Browser' );
+	$count = \DataMachine\Core\Auth\PrincipalSessionPromoter::promote_browser_to_user( $browser_id, 12 );
+	$assert( 'browser sessions promote to user owner', 1 === $count && 'user' === $GLOBALS['wpdb']->rows[0]['owner_type'] && 12 === $GLOBALS['wpdb']->rows[0]['user_id'] );
+
+	echo "\n{$pass} passed, {$fail} failed\n";
+	exit( $fail > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary
- Adds a generic external-login provider contract and callback router separate from credential auth providers.
- Adds a browser-principal to WordPress user transcript promotion helper for login flows.
- Includes smoke coverage for provider registration, callback URL resolution, and browser session promotion.

## Testing
- php -l inc/Core/Auth/ExternalLoginProviderInterface.php
- php -l inc/Core/Auth/ExternalLoginRouter.php
- php -l inc/Core/Auth/PrincipalSessionPromoter.php
- php tests/external-login-primitives-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic external-login primitive and smoke coverage; Chris remains responsible for review and merge.