### PR TITLE
feat: add WordPress Playground marketing blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Agentic workflow automation for WordPress.
 
+[![Try Data Machine in WordPress Playground](https://img.shields.io/badge/Try_Data_Machine_in-WordPress_Playground-3858e9?style=for-the-badge&logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Extra-Chill/data-machine/main/blueprints/playground.json)
+
+Click the badge to open a fresh Data Machine in a browser-only WordPress instance. The Playground boots WordPress, installs Data Machine plus its substrate (Agents API and the WordPress AI Provider for OpenAI), and drops you into the Data Machine admin. Add your own OpenAI key in Settings to start chatting with an agent or running a pipeline. Nothing persists once the tab closes.
+
 ## What It Does
 
 Data Machine turns a WordPress site into an agent runtime — persistent identity, memory, pipelines, abilities, and tools that AI agents use to operate autonomously.

--- a/blueprints/playground.json
+++ b/blueprints/playground.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "preferredVersions": {
+    "php": "latest",
+    "wp": "beta"
+  },
+  "landingPage": "/wp-admin/admin.php?page=datamachine-agent",
+  "login": true,
+  "steps": [
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "git:directory",
+        "url": "https://github.com/Automattic/agents-api",
+        "ref": "main",
+        "refType": "branch"
+      },
+      "options": {
+        "activate": true,
+        "targetFolderName": "agents-api"
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "git:directory",
+        "url": "https://github.com/WordPress/ai-provider-for-openai",
+        "ref": "trunk",
+        "refType": "branch"
+      },
+      "options": {
+        "activate": true,
+        "targetFolderName": "ai-provider-for-openai"
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "url",
+        "url": "https://github.com/Extra-Chill/data-machine/releases/latest/download/data-machine.zip"
+      },
+      "options": {
+        "activate": true,
+        "targetFolderName": "data-machine"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add a public WordPress Playground blueprint at `blueprints/playground.json` that opens a fresh, configured Data Machine in the visitor's browser with one click. The badge at the top of the README links to it. This is purely a marketing/onboarding surface — visitors get to try Data Machine without installing WordPress, configuring a server, or setting up plugins.

## What the blueprint installs

| Plugin | Source | Why |
|---|---|---|
| Agents API | `git:directory` from `Automattic/agents-api@main` | DM's substrate dependency. Already validated in the world-of-wordpress Playground. |
| AI Provider for OpenAI | `git:directory` from `WordPress/ai-provider-for-openai@trunk` | DM's chat/pipeline AI path. Already validated. |
| Data Machine | `releases/latest/download/data-machine.zip` | The star. Uses the vendor-bundled release asset shipped by the homeboy release workflow on every release. |

After install the visitor is auto-logged-in as admin and dropped on `/wp-admin/admin.php?page=datamachine-agent` (the Agents page, which is DM's first-position admin menu entry) so the create-agent flow is the most direct path from \"what is this?\" to \"I made it do something.\"

## What's intentionally excluded

- **Markdown Database Integration.** DM's activation is `dbDelta`-based and works on Playground's native SQLite without MDI. MDI is a separate sell that deserves its own blueprint if/when we want to demo the markdown-as-DB story.
- **Data Machine Code.** DMC is a coding-agent extension. A DM-first marketing demo should be DM-first; a DMC-focused blueprint can be a follow-up PR once we know the DMC story we want to tell.
- **Embedded demo agent/bundle.** No pre-installed agent. Visitors land in DM with the create-agent wizard available. Honest framing — \"here is the tool, build something\" — and zero artifacts to maintain. A demo bundle can come in a follow-up PR once the blueprint shape is proven.

## Validation

- `python3 -c \"import json; json.load(open('blueprints/playground.json'))\"` passes.
- Plugin install pattern (Agents API + AI Provider via `git:directory`, DM via `releases/latest/download/*.zip`) is identical to the world-of-wordpress blueprint, which has been booting successfully for the entire run of that experiment.
- DM v0.43.0 ZIP attached to the latest release (verified manually); the homeboy `release-asset.yml` workflow re-publishes a fresh ZIP on every future release via `release.published`, so the badge URL automatically tracks new versions.
- DM activation (`datamachine_activate_plugin`) only depends on `dbDelta` table creation and memory file scaffolding. Confirmed no MDI hard dependency.

## Marketing value

- Repository visitors get a working trial in 10-20 seconds with zero local setup.
- The badge is a recognizable WordPress Playground pattern; visitors already know what it means.
- A Playground tab is a low-commitment way to evaluate DM. Lower bar than reading docs or watching a demo video.
- Once visitors are inside, the React admin UI, agent wizard, pipeline builder, and chat surface speak for themselves.

## Follow-up ideas (not in this PR)

- Pre-installed simple example agent so visitors can hit Run on something without writing it themselves.
- DMC-focused blueprint that adds workspace + GitHub tools to the demo.
- Full agent-stack blueprint matching `world-of-wordpress` for visitors who want to see the whole brain.
- An empty pipeline shape pre-seeded into the create-agent wizard so the first-click is even faster.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Identified the gap during a Discord conversation, surveyed DM's admin menu registration to pick the right `landingPage` slug, surveyed DM's activation hook to confirm no MDI dependency, and drafted the blueprint, README badge, and PR description. Chris confirmed the stack scope (DM + Agents API + AI Provider, no MDI, no DMC) and the choice to ship an empty DM rather than a pre-installed example bundle.