### PR TITLE
feat(system-task): DispatchMessageTask wrapping agents/dispatch-message

### DIFF
--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -19,6 +19,7 @@ use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Engine\AI\System\Tasks\AgentCallTask;
 use DataMachine\Engine\AI\System\Tasks\AltTextTask;
 use DataMachine\Engine\AI\System\Tasks\DailyMemoryTask;
+use DataMachine\Engine\AI\System\Tasks\DispatchMessageTask;
 use DataMachine\Engine\AI\System\Tasks\EmitDataPacketsTask;
 use DataMachine\Engine\AI\System\Tasks\ImageGenerationTask;
 use DataMachine\Engine\AI\System\Tasks\ImageOptimizationTask;
@@ -74,6 +75,7 @@ class SystemAgentServiceProvider {
 	 */
 	public function getBuiltInTasks( array $tasks ): array {
 		$tasks['agent_call']                             = AgentCallTask::class;
+		$tasks['dispatch_message']                       = DispatchMessageTask::class;
 		$tasks['emit_data_packets']                      = EmitDataPacketsTask::class;
 		$tasks['image_generation']                       = ImageGenerationTask::class;
 		$tasks['image_optimization']                     = ImageOptimizationTask::class;

--- a/inc/Engine/AI/System/Tasks/DispatchMessageTask.php
+++ b/inc/Engine/AI/System/Tasks/DispatchMessageTask.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Dispatch Message System Task.
+ *
+ * Thin wrapper around the canonical `agents/dispatch-message` ability
+ * (agents-api v0.107.0+). Lets Data Machine flows hand an outbound
+ * message off to whichever channel transport is registered via the
+ * `wp_agent_dispatch_message_handler` filter — without DM needing any
+ * knowledge of the underlying transport runtime.
+ *
+ * This task is to `agents/dispatch-message` what `AgentCallTask` is to
+ * `datamachine/agent-call`: it forwards `handler_config.params` straight
+ * to the ability and surfaces the canonical output (or WP_Error) in the
+ * job result envelope.
+ *
+ * Expected handler_config shape:
+ *
+ *     {
+ *       "task": "dispatch_message",
+ *       "params": {
+ *         "channel": "<channel-id>",
+ *         "recipient": "<transport-specific recipient id>",
+ *         "message": "<text body>",
+ *         "conversation_id": null,
+ *         "attachments": [],
+ *         "client_context": {},
+ *         "metadata": {}
+ *       }
+ *     }
+ *
+ * Required input: `channel`, `recipient`, `message`. Everything else is
+ * optional and passes through to the ability untouched.
+ *
+ * @package DataMachine\Engine\AI\System\Tasks
+ */
+
+namespace DataMachine\Engine\AI\System\Tasks;
+
+defined( 'ABSPATH' ) || exit;
+
+class DispatchMessageTask extends SystemTask {
+
+	/**
+	 * Canonical ability slug forwarded to by this task.
+	 */
+	private const ABILITY_SLUG = 'agents/dispatch-message';
+
+	/**
+	 * Get the task type identifier.
+	 *
+	 * @return string
+	 */
+	public function getTaskType(): string {
+		return 'dispatch_message';
+	}
+
+	/**
+	 * Get task metadata for admin UI and TaskRegistry.
+	 *
+	 * @return array
+	 */
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Dispatch Message',
+			'description'     => 'Send one outbound message through a registered channel transport via the agents/dispatch-message ability.',
+			'setting_key'     => null,
+			'default_enabled' => true,
+			'trigger'         => 'On-demand via CLI, REST, or pipeline step',
+			'trigger_type'    => 'manual',
+			'supports_run'    => true,
+		);
+	}
+
+	/**
+	 * Execute dispatch message task.
+	 *
+	 * Resolves the canonical `agents/dispatch-message` ability and forwards
+	 * the configured `params`. Fails the job cleanly when the substrate is
+	 * missing (agents-api not installed or too old) or when the ability
+	 * returns a WP_Error. On success, stores the canonical output
+	 * (`sent`, `channel`, `recipient`, `message_id`, `metadata`) in the
+	 * job result envelope alongside a `completed_at` timestamp — mirroring
+	 * AgentCallTask's success shape.
+	 *
+	 * @param int   $jobId  DM Job ID.
+	 * @param array $params Task params with `channel`, `recipient`, `message` and optional passthrough fields.
+	 */
+	public function executeTask( int $jobId, array $params ): void {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->failJob(
+				$jobId,
+				sprintf( 'Ability %s not registered — agents-api missing or too old.', self::ABILITY_SLUG )
+			);
+			return;
+		}
+
+		$ability = wp_get_ability( self::ABILITY_SLUG );
+		if ( ! $ability ) {
+			$this->failJob(
+				$jobId,
+				sprintf( 'Ability %s not registered — agents-api missing or too old.', self::ABILITY_SLUG )
+			);
+			return;
+		}
+
+		$input = $this->extractAbilityInput( $params );
+
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			$code    = $result->get_error_code();
+			$message = $result->get_error_message();
+			$detail  = is_string( $code ) && '' !== $code
+				? sprintf( '[%s] %s', $code, $message )
+				: $message;
+			$this->failJob( $jobId, $detail );
+			return;
+		}
+
+		if ( ! is_array( $result ) ) {
+			$this->failJob(
+				$jobId,
+				sprintf( 'Ability %s returned an unexpected non-array result.', self::ABILITY_SLUG )
+			);
+			return;
+		}
+
+		$this->completeJob(
+			$jobId,
+			array_merge(
+				$result,
+				array( 'completed_at' => current_time( 'mysql' ) )
+			)
+		);
+	}
+
+	/**
+	 * Pull the canonical ability input out of the task params.
+	 *
+	 * Accepts either the wrapped shape used by SystemTaskStep
+	 * (`{ task, params: { channel, recipient, message, ... } }`) or a
+	 * flat shape where the canonical fields are already on `$params`.
+	 *
+	 * Unknown keys on `$params['params']` pass through untouched so
+	 * future ability schema additions do not require a code change here.
+	 *
+	 * @param array $params Task params from engine_data.
+	 * @return array Canonical input map for the ability.
+	 */
+	private function extractAbilityInput( array $params ): array {
+		$inner = isset( $params['params'] ) && is_array( $params['params'] )
+			? $params['params']
+			: $params;
+
+		// Drop SystemTask scaffolding keys that may leak in when the
+		// flat shape is used. The ability's input_schema accepts only
+		// the canonical message fields plus optional passthrough.
+		unset( $inner['task'], $inner['task_type'] );
+
+		return $inner;
+	}
+}

--- a/tests/dispatch-message-task-smoke.php
+++ b/tests/dispatch-message-task-smoke.php
@@ -1,0 +1,399 @@
+<?php
+/**
+ * Pure-PHP smoke test for DispatchMessageTask (#2049).
+ *
+ * Run with: php tests/dispatch-message-task-smoke.php
+ *
+ * Pins four behaviours of the new system_task wrapping
+ * `agents/dispatch-message`:
+ *
+ *   1. The task is registered for task id `dispatch_message` and the
+ *      DispatchMessageTask class file/import shape lives in the provider.
+ *   2. When the ability is not registered (agents-api missing), the
+ *      task fails the job with a clear error message — no fatals.
+ *   3. When a handler returns canonical output, the task completes the
+ *      job and surfaces `sent / channel / recipient / message_id /
+ *      metadata` in the result envelope.
+ *   4. When a handler returns a WP_Error, the task fails the job and
+ *      propagates the error code + message.
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Engine\AI\System\Tasks {
+
+	// Lightweight SystemTask shim so we can exercise DispatchMessageTask
+	// without booting the real Jobs DB layer that the production
+	// SystemTask base depends on. Records completeJob/failJob calls so
+	// the test can assert on them.
+	abstract class SystemTask {
+		/** @var array<int, array{job_id:int, data:array}> */
+		public static array $completed = array();
+		/** @var array<int, array{job_id:int, message:string}> */
+		public static array $failed = array();
+
+		abstract public function executeTask( int $jobId, array $params ): void;
+		abstract public function getTaskType(): string;
+
+		public static function getTaskMeta(): array {
+			return array();
+		}
+
+		public function needsPipelineContext(): bool {
+			return false;
+		}
+
+		public function getFlowStepConfigPassthrough(): array {
+			return array();
+		}
+
+		protected function completeJob( int $jobId, array $data ): void {
+			self::$completed[] = array(
+				'job_id' => $jobId,
+				'data'   => $data,
+			);
+		}
+
+		protected function failJob( int $jobId, string $message ): void {
+			self::$failed[] = array(
+				'job_id'  => $jobId,
+				'message' => $message,
+			);
+		}
+
+		public static function resetCalls(): void {
+			self::$completed = array();
+			self::$failed    = array();
+		}
+	}
+}
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	// ─── Minimal WP function stubs ────────────────────────────────────
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, $value ) {
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( string $hook, ...$args ): void {
+			// no-op
+		}
+	}
+
+	if ( ! function_exists( 'current_time' ) ) {
+		function current_time( string $type ): string {
+			return 'mysql' === $type ? '2000-01-01 00:00:00' : (string) time();
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			private string $code;
+			private string $message;
+
+			public function __construct( string $code = '', string $message = '' ) {
+				$this->code    = $code;
+				$this->message = $message;
+			}
+
+			public function get_error_code(): string {
+				return $this->code;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+		}
+	}
+
+	$GLOBALS['dispatch_message_ability_resolver'] = static function ( string $slug ) {
+		return null;
+	};
+
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		function wp_get_ability( string $slug ) {
+			$resolver = $GLOBALS['dispatch_message_ability_resolver'] ?? null;
+			if ( ! is_callable( $resolver ) ) {
+				return null;
+			}
+			return $resolver( $slug );
+		}
+	}
+
+	// Load the production task class. It uses the namespaced SystemTask
+	// shim defined above instead of the real Jobs-coupled base.
+	require_once dirname( __DIR__ ) . '/inc/Engine/AI/System/Tasks/DispatchMessageTask.php';
+
+	/**
+	 * Tiny ability double matching the surface DispatchMessageTask uses
+	 * (`execute( array $input )`). The executor returns whatever the
+	 * registered callable returns — mimics the agents/dispatch-message
+	 * dispatcher contract.
+	 */
+	final class DispatchMessageTask_FakeAbility {
+		/** @var callable */
+		private $callback;
+		/** @var array<int, array> */
+		public array $invocations = array();
+
+		public function __construct( callable $callback ) {
+			$this->callback = $callback;
+		}
+
+		public function execute( array $input ) {
+			$this->invocations[] = $input;
+			return call_user_func( $this->callback, $input );
+		}
+	}
+
+	// ─── Test harness ─────────────────────────────────────────────────
+
+	$GLOBALS['__dispatch_failures'] = array();
+	$GLOBALS['__dispatch_passes']   = 0;
+
+	function dispatch_assert_equals( $expected, $actual, string $name ): void {
+		if ( $expected === $actual ) {
+			++$GLOBALS['__dispatch_passes'];
+			echo "  ✓ {$name}\n";
+			return;
+		}
+
+		$GLOBALS['__dispatch_failures'][] = $name;
+		echo "  ✗ {$name}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	}
+
+	function dispatch_assert_true( bool $condition, string $name, string $detail = '' ): void {
+		if ( $condition ) {
+			++$GLOBALS['__dispatch_passes'];
+			echo "  ✓ {$name}\n";
+			return;
+		}
+
+		$GLOBALS['__dispatch_failures'][] = $name;
+		echo "  ✗ {$name}" . ( '' !== $detail ? " — {$detail}" : '' ) . "\n";
+	}
+
+	function dispatch_assert_contains( string $needle, string $haystack, string $name ): void {
+		dispatch_assert_true(
+			'' !== $needle && false !== strpos( $haystack, $needle ),
+			$name,
+			"expected to find '{$needle}' in '{$haystack}'"
+		);
+	}
+
+	echo "dispatch-message task smoke (#2049)\n";
+	echo "------------------------------------\n";
+
+	$root = dirname( __DIR__ );
+
+	$task_path     = $root . '/inc/Engine/AI/System/Tasks/DispatchMessageTask.php';
+	$provider_path = $root . '/inc/Engine/AI/System/SystemAgentServiceProvider.php';
+
+	$task_source     = file_exists( $task_path ) ? (string) file_get_contents( $task_path ) : '';
+	$provider_source = file_exists( $provider_path ) ? (string) file_get_contents( $provider_path ) : '';
+
+	echo "\n[1] task file + provider registration:\n";
+	dispatch_assert_true( '' !== $task_source, 'DispatchMessageTask.php exists' );
+	dispatch_assert_contains( 'class DispatchMessageTask extends SystemTask', $task_source, 'class extends SystemTask' );
+	dispatch_assert_contains( "return 'dispatch_message';", $task_source, 'getTaskType returns dispatch_message' );
+	dispatch_assert_contains( 'agents/dispatch-message', $task_source, 'task references the canonical ability slug' );
+	dispatch_assert_contains( 'use DataMachine\\Engine\\AI\\System\\Tasks\\DispatchMessageTask;', $provider_source, 'provider imports DispatchMessageTask' );
+	dispatch_assert_contains( "\$tasks['dispatch_message']", $provider_source, 'provider maps dispatch_message task id' );
+	dispatch_assert_contains( 'DispatchMessageTask::class', $provider_source, 'provider maps to DispatchMessageTask::class' );
+
+	echo "\n[2] no transport-specific names in the new code:\n";
+	$banned = array( 'kimaki', 'discord', 'slack', 'telegram', 'whatsapp', 'cc-connect' );
+	foreach ( $banned as $name ) {
+		$task_clean = false === stripos( $task_source, $name );
+		dispatch_assert_true( $task_clean, "task source contains no '{$name}'" );
+	}
+
+	$task = new \DataMachine\Engine\AI\System\Tasks\DispatchMessageTask();
+	$base = \DataMachine\Engine\AI\System\Tasks\SystemTask::class;
+
+	echo "\n[3] ability-missing path fails the job cleanly:\n";
+
+	$base::resetCalls();
+	$GLOBALS['dispatch_message_ability_resolver'] = static function ( string $slug ) {
+		return null; // simulate wp_get_ability returning null
+	};
+
+	$task->executeTask(
+		101,
+		array(
+			'task'   => 'dispatch_message',
+			'params' => array(
+				'channel'   => 'example-channel',
+				'recipient' => 'example-recipient',
+				'message'   => 'hi',
+			),
+		)
+	);
+
+	dispatch_assert_equals( 0, count( $base::$completed ), 'ability missing: no job completed' );
+	dispatch_assert_equals( 1, count( $base::$failed ), 'ability missing: job failed once' );
+	dispatch_assert_equals( 101, $base::$failed[0]['job_id'], 'ability missing: failed job id propagated' );
+	dispatch_assert_contains( 'agents/dispatch-message', $base::$failed[0]['message'], 'ability missing: error mentions ability slug' );
+	dispatch_assert_contains( 'agents-api', $base::$failed[0]['message'], 'ability missing: error mentions agents-api substrate' );
+
+	echo "\n[4] handler success path completes the job with canonical output:\n";
+
+	$base::resetCalls();
+
+	$success_payload = array(
+		'sent'       => true,
+		'channel'    => 'example-channel',
+		'recipient'  => 'example-recipient',
+		'message_id' => 'msg_42',
+		'metadata'   => array( 'delivered_at' => 'now' ),
+	);
+
+	$success_ability = new DispatchMessageTask_FakeAbility(
+		static function ( array $input ) use ( $success_payload ) {
+			return $success_payload;
+		}
+	);
+
+	$GLOBALS['dispatch_message_ability_resolver'] = static function ( string $slug ) use ( $success_ability ) {
+		return 'agents/dispatch-message' === $slug ? $success_ability : null;
+	};
+
+	$task->executeTask(
+		202,
+		array(
+			'task'   => 'dispatch_message',
+			'params' => array(
+				'channel'         => 'example-channel',
+				'recipient'       => 'example-recipient',
+				'message'         => 'hello world',
+				'conversation_id' => null,
+				'attachments'     => array(),
+				'client_context'  => array( 'agent_id' => 7 ),
+				'metadata'        => array( 'job_id' => 202 ),
+			),
+		)
+	);
+
+	dispatch_assert_equals( 1, count( $base::$completed ), 'success: job completed once' );
+	dispatch_assert_equals( 0, count( $base::$failed ), 'success: no job failures' );
+	dispatch_assert_equals( 202, $base::$completed[0]['job_id'], 'success: completed job id propagated' );
+
+	$completed_data = $base::$completed[0]['data'];
+	dispatch_assert_equals( true, $completed_data['sent'] ?? null, 'success: sent flag in envelope' );
+	dispatch_assert_equals( 'example-channel', $completed_data['channel'] ?? null, 'success: channel in envelope' );
+	dispatch_assert_equals( 'example-recipient', $completed_data['recipient'] ?? null, 'success: recipient in envelope' );
+	dispatch_assert_equals( 'msg_42', $completed_data['message_id'] ?? null, 'success: message_id in envelope' );
+	dispatch_assert_equals( array( 'delivered_at' => 'now' ), $completed_data['metadata'] ?? null, 'success: metadata in envelope' );
+	dispatch_assert_true( isset( $completed_data['completed_at'] ), 'success: completed_at timestamp present' );
+
+	$forwarded = $success_ability->invocations[0] ?? array();
+	dispatch_assert_equals( 'example-channel', $forwarded['channel'] ?? null, 'success: channel forwarded' );
+	dispatch_assert_equals( 'example-recipient', $forwarded['recipient'] ?? null, 'success: recipient forwarded' );
+	dispatch_assert_equals( 'hello world', $forwarded['message'] ?? null, 'success: message forwarded' );
+	dispatch_assert_true( array_key_exists( 'conversation_id', $forwarded ) && null === $forwarded['conversation_id'], 'success: conversation_id forwarded as null' );
+	dispatch_assert_equals( array(), $forwarded['attachments'] ?? null, 'success: attachments forwarded' );
+	dispatch_assert_equals( array( 'agent_id' => 7 ), $forwarded['client_context'] ?? null, 'success: client_context forwarded' );
+	dispatch_assert_equals( array( 'job_id' => 202 ), $forwarded['metadata'] ?? null, 'success: metadata forwarded' );
+	dispatch_assert_true( ! array_key_exists( 'task', $forwarded ), 'success: SystemTask wrapper key task is stripped' );
+
+	echo "\n[5] handler WP_Error path fails the job with the error message:\n";
+
+	$base::resetCalls();
+
+	$error_ability = new DispatchMessageTask_FakeAbility(
+		static function ( array $input ) {
+			return new \WP_Error( 'transport_offline', 'Channel transport is offline.' );
+		}
+	);
+
+	$GLOBALS['dispatch_message_ability_resolver'] = static function ( string $slug ) use ( $error_ability ) {
+		return 'agents/dispatch-message' === $slug ? $error_ability : null;
+	};
+
+	$task->executeTask(
+		303,
+		array(
+			'task'   => 'dispatch_message',
+			'params' => array(
+				'channel'   => 'example-channel',
+				'recipient' => 'example-recipient',
+				'message'   => 'will fail',
+			),
+		)
+	);
+
+	dispatch_assert_equals( 0, count( $base::$completed ), 'wp_error: no job completed' );
+	dispatch_assert_equals( 1, count( $base::$failed ), 'wp_error: job failed once' );
+	dispatch_assert_equals( 303, $base::$failed[0]['job_id'], 'wp_error: failed job id propagated' );
+	dispatch_assert_contains( 'transport_offline', $base::$failed[0]['message'], 'wp_error: error code surfaced' );
+	dispatch_assert_contains( 'Channel transport is offline.', $base::$failed[0]['message'], 'wp_error: error message surfaced' );
+
+	echo "\n[6] flat-shape params (no nested params key) also work:\n";
+
+	$base::resetCalls();
+
+	$flat_ability = new DispatchMessageTask_FakeAbility(
+		static function ( array $input ) {
+			return array(
+				'sent'       => true,
+				'channel'    => $input['channel'] ?? '',
+				'recipient'  => $input['recipient'] ?? '',
+				'message_id' => 'flat_1',
+				'metadata'   => array(),
+			);
+		}
+	);
+
+	$GLOBALS['dispatch_message_ability_resolver'] = static function ( string $slug ) use ( $flat_ability ) {
+		return 'agents/dispatch-message' === $slug ? $flat_ability : null;
+	};
+
+	$task->executeTask(
+		404,
+		array(
+			'task'      => 'dispatch_message',
+			'task_type' => 'dispatch_message',
+			'channel'   => 'flat-channel',
+			'recipient' => 'flat-recipient',
+			'message'   => 'flat body',
+		)
+	);
+
+	dispatch_assert_equals( 1, count( $base::$completed ), 'flat shape: job completed' );
+	$flat_forwarded = $flat_ability->invocations[0] ?? array();
+	dispatch_assert_equals( 'flat-channel', $flat_forwarded['channel'] ?? null, 'flat shape: channel forwarded' );
+	dispatch_assert_equals( 'flat-recipient', $flat_forwarded['recipient'] ?? null, 'flat shape: recipient forwarded' );
+	dispatch_assert_equals( 'flat body', $flat_forwarded['message'] ?? null, 'flat shape: message forwarded' );
+	dispatch_assert_true( ! array_key_exists( 'task', $flat_forwarded ), 'flat shape: task scaffolding stripped' );
+	dispatch_assert_true( ! array_key_exists( 'task_type', $flat_forwarded ), 'flat shape: task_type scaffolding stripped' );
+
+	echo "\n------------------------------------\n";
+	$total = $GLOBALS['__dispatch_passes'] + count( $GLOBALS['__dispatch_failures'] );
+	echo "{$GLOBALS['__dispatch_passes']} / {$total} passed\n";
+
+	if ( ! empty( $GLOBALS['__dispatch_failures'] ) ) {
+		echo "\nFailures:\n";
+		foreach ( $GLOBALS['__dispatch_failures'] as $failure ) {
+			echo " - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\nAll assertions passed.\n";
+}


### PR DESCRIPTION
## Summary

Adds `DispatchMessageTask` — a thin system_task wrapper around the canonical `agents/dispatch-message` ability (agents-api v0.107.0+). This is the DM-side bridge that lets a scheduled flow tick hand an outbound message off to whichever channel runtime is registered via the `wp_agent_dispatch_message_handler` filter, without DM needing any knowledge of the underlying transport (CLI runtime in DMC, future Slack/WhatsApp/etc. runtimes, …).

The shape mirrors `AgentCallTask` exactly: resolve the ability, forward params, surface canonical output or `WP_Error` into the job result envelope.

Closes #2049

## Files

- `inc/Engine/AI/System/Tasks/DispatchMessageTask.php` *(new)* — new `SystemTask` subclass. `getTaskType()` returns `dispatch_message`. `executeTask()` resolves `wp_get_ability( 'agents/dispatch-message' )`, forwards the canonical input (`channel`, `recipient`, `message`, plus optional `conversation_id` / `attachments` / `client_context` / `metadata`), and routes the result into `completeJob()` or `failJob()` per the SystemTask base contract. Handles both wrapped (`{ task, params: { … } }`) and flat (`{ channel, recipient, message }`) handler_config shapes, stripping SystemTask scaffolding before forwarding to the ability.
- `inc/Engine/AI/System/SystemAgentServiceProvider.php` — registers `\$tasks['dispatch_message'] = DispatchMessageTask::class;` adjacent to the existing `agent_call` sibling.
- `tests/dispatch-message-task-smoke.php` *(new)* — pure-PHP smoke covering source-level registration, ability-missing failure, handler success envelope, `WP_Error` propagation, and flat-shape passthrough.

## Acceptance criteria (from #2049)

- [x] `task: dispatch_message` is a recognized system_task type (registered in `SystemAgentServiceProvider::getBuiltInTasks()`).
- [x] Pipeline runs with this task type call `agents/dispatch-message` once per execution (executeTask resolves the ability and calls `\$ability->execute( \$input )` exactly once per invocation).
- [x] Task fails gracefully (clear log message, job marked failed, no fatal) when agents-api or the ability is missing — error message explicitly names the ability slug and the agents-api substrate.
- [x] No knowledge of any specific transport in the task code — the task source contains zero references to ` kimaki / discord / slack / telegram / whatsapp / cc-connect`. Channel resolution stays inside the ability + its registered handler.
- [x] Smoke test covers all four paths (registered, ability-missing, handler success, handler WP_Error) plus a bonus flat-shape passthrough check.
- [x] Conventional commit messages (`feat(system-task): …` and `test(system-task): …`). No CHANGELOG edits. No version bumps.

## Smoke test output

\`\`\`
\$ php tests/dispatch-message-task-smoke.php
dispatch-message task smoke (#2049)
------------------------------------

[1] task file + provider registration:
  ✓ DispatchMessageTask.php exists
  ✓ class extends SystemTask
  ✓ getTaskType returns dispatch_message
  ✓ task references the canonical ability slug
  ✓ provider imports DispatchMessageTask
  ✓ provider maps dispatch_message task id
  ✓ provider maps to DispatchMessageTask::class

[2] no transport-specific names in the new code:
  ✓ task source contains no 'kimaki'
  ✓ task source contains no 'discord'
  ✓ task source contains no 'slack'
  ✓ task source contains no 'telegram'
  ✓ task source contains no 'whatsapp'
  ✓ task source contains no 'cc-connect'

[3] ability-missing path fails the job cleanly:
  ✓ ability missing: no job completed
  ✓ ability missing: job failed once
  ✓ ability missing: failed job id propagated
  ✓ ability missing: error mentions ability slug
  ✓ ability missing: error mentions agents-api substrate

[4] handler success path completes the job with canonical output:
  ✓ success: job completed once
  ✓ success: no job failures
  ✓ success: completed job id propagated
  ✓ success: sent flag in envelope
  ✓ success: channel in envelope
  ✓ success: recipient in envelope
  ✓ success: message_id in envelope
  ✓ success: metadata in envelope
  ✓ success: completed_at timestamp present
  ✓ success: channel forwarded
  ✓ success: recipient forwarded
  ✓ success: message forwarded
  ✓ success: conversation_id forwarded as null
  ✓ success: attachments forwarded
  ✓ success: client_context forwarded
  ✓ success: metadata forwarded
  ✓ success: SystemTask wrapper key task is stripped

[5] handler WP_Error path fails the job with the error message:
  ✓ wp_error: no job completed
  ✓ wp_error: job failed once
  ✓ wp_error: failed job id propagated
  ✓ wp_error: error code surfaced
  ✓ wp_error: error message surfaced

[6] flat-shape params (no nested params key) also work:
  ✓ flat shape: job completed
  ✓ flat shape: channel forwarded
  ✓ flat shape: recipient forwarded
  ✓ flat shape: message forwarded
  ✓ flat shape: task scaffolding stripped
  ✓ flat shape: task_type scaffolding stripped

------------------------------------
46 / 46 passed

All assertions passed.
\`\`\`

Reproduce with: \`php tests/dispatch-message-task-smoke.php\` from the repo root.

## Transport-neutrality confirmation

\`\`\`
\$ grep -iE 'kimaki|discord|slack|telegram|whatsapp|cc-connect' \\
    inc/Engine/AI/System/Tasks/DispatchMessageTask.php
(zero matches)
\`\`\`

The only matches in \`tests/dispatch-message-task-smoke.php\` are inside the **banned-list array** that powers the assertion itself — not transport coupling in production code.

## Lint

\`vendor/bin/phpcs inc/Engine/AI/System/Tasks/DispatchMessageTask.php inc/Engine/AI/System/SystemAgentServiceProvider.php tests/dispatch-message-task-smoke.php\` is clean (zero findings against the repo's default standard). Per AGENTS.md, no attempt was made to address unrelated pre-existing lint debt on \`main\`.

## Handler config example

An example flow handler_config is documented in #2049:

\`\`\`json
{
  \"task\": \"dispatch_message\",
  \"params\": {
    \"channel\": \"<channel-id>\",
    \"recipient\": \"<transport-specific recipient id>\",
    \"message\": \"<text body>\",
    \"conversation_id\": null,
    \"attachments\": [],
    \"client_context\": {},
    \"metadata\": {}
  }
}
\`\`\`

Required input: \`channel\`, \`recipient\`, \`message\`. Everything else passes through to the ability untouched.

## Out of scope (per #2049)

- Admin UI / form-builder for configuring the task — JSON / WP-CLI for now.
- Migration of existing \`agent_call\` flows to \`dispatch_message\` (operational, per-site).

cc <@532385681268408341> when ready for review.