### PR TITLE
Fix core bundle artifact apply handlers

### DIFF
--- a/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
@@ -7,6 +7,10 @@
 
 namespace DataMachine\Engine\Bundle;
 
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Pipelines\Pipelines;
+
 defined( 'ABSPATH' ) || exit;
 
 add_filter(
@@ -28,3 +32,184 @@ add_filter(
 		return $handlers;
 	}
 );
+
+add_filter(
+	'datamachine_agent_bundle_apply_artifact',
+	static function ( $result, array $artifact, array $agent, array $context ) {
+		if ( null !== $result ) {
+			return $result;
+		}
+
+		return AgentBundleCoreArtifactApply::apply( $artifact, $agent, $context );
+	},
+	10,
+	4
+);
+
+/**
+ * Applies Data Machine-owned bundle artifacts from approved PendingActions.
+ */
+final class AgentBundleCoreArtifactApply {
+
+	/**
+	 * Apply an approved core artifact.
+	 *
+	 * @param array<string,mixed> $artifact Artifact envelope.
+	 * @param array<string,mixed> $agent Agent row or agent context.
+	 * @param array<string,mixed> $context Apply context.
+	 * @return array<string,mixed>|\WP_Error|null
+	 */
+	public static function apply( array $artifact, array $agent, array $context ): mixed {
+		$type     = (string) ( $artifact['artifact_type'] ?? '' );
+		$agent_id = (int) ( $agent['agent_id'] ?? 0 );
+		$payload  = is_array( $artifact['payload'] ?? null ) ? $artifact['payload'] : array();
+
+		if ( $agent_id <= 0 || empty( $payload ) || ! in_array( $type, array( 'pipeline', 'flow' ), true ) ) {
+			return null;
+		}
+
+		$applied = 'pipeline' === $type
+			? self::apply_pipeline( $artifact, $agent_id, $payload )
+			: self::apply_flow( $artifact, $agent_id, $payload );
+		if ( is_wp_error( $applied ) ) {
+			return $applied;
+		}
+
+		$registry = self::record_applied_artifact( $artifact, $agent_id, $context );
+		if ( is_wp_error( $registry ) ) {
+			return $registry;
+		}
+
+		return array_merge( $applied, array( 'registry' => 'updated' ) );
+	}
+
+	/**
+	 * @param array<string,mixed> $artifact Artifact envelope.
+	 * @param array<string,mixed> $payload Artifact payload.
+	 */
+	private static function apply_pipeline( array $artifact, int $agent_id, array $payload ): array|\WP_Error {
+		$slug = self::artifact_slug( $artifact, $payload, 'pipeline' );
+		$repo = new Pipelines();
+		$row  = $repo->get_by_portable_slug( $agent_id, $slug );
+		if ( ! $row ) {
+			return new \WP_Error( 'datamachine_bundle_pipeline_missing', sprintf( 'Pipeline artifact "%s" is not installed for this agent.', $slug ) );
+		}
+
+		$updated = $repo->update_pipeline(
+			(int) $row['pipeline_id'],
+			array(
+				'pipeline_name'   => (string) ( $payload['pipeline_name'] ?? $row['pipeline_name'] ?? $slug ),
+				'pipeline_config' => is_array( $payload['pipeline_config'] ?? null ) ? $payload['pipeline_config'] : array(),
+				'portable_slug'   => $slug,
+			)
+		);
+
+		if ( ! $updated ) {
+			return new \WP_Error( 'datamachine_bundle_pipeline_update_failed', sprintf( 'Failed to update pipeline artifact "%s".', $slug ) );
+		}
+
+		return array(
+			'artifact_type' => 'pipeline',
+			'artifact_id'   => $slug,
+			'pipeline_id'   => (int) $row['pipeline_id'],
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $artifact Artifact envelope.
+	 * @param array<string,mixed> $payload Artifact payload.
+	 */
+	private static function apply_flow( array $artifact, int $agent_id, array $payload ): array|\WP_Error {
+		$slug = self::artifact_slug( $artifact, $payload, 'flow' );
+		$repo = new Flows();
+		$row  = null;
+		foreach ( $repo->get_all_flows( null, $agent_id ) as $flow ) {
+			if ( $slug === (string) ( $flow['portable_slug'] ?? '' ) ) {
+				$row = $flow;
+				break;
+			}
+		}
+
+		if ( ! $row ) {
+			return new \WP_Error( 'datamachine_bundle_flow_missing', sprintf( 'Flow artifact "%s" is not installed for this agent.', $slug ) );
+		}
+
+		$updated = $repo->update_flow(
+			(int) $row['flow_id'],
+			array(
+				'flow_name'     => (string) ( $payload['flow_name'] ?? $row['flow_name'] ?? $slug ),
+				'flow_config'   => is_array( $payload['flow_config'] ?? null ) ? $payload['flow_config'] : array(),
+				'portable_slug' => $slug,
+			)
+		);
+
+		if ( ! $updated ) {
+			return new \WP_Error( 'datamachine_bundle_flow_update_failed', sprintf( 'Failed to update flow artifact "%s".', $slug ) );
+		}
+
+		return array(
+			'artifact_type' => 'flow',
+			'artifact_id'   => $slug,
+			'flow_id'       => (int) $row['flow_id'],
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $artifact Artifact envelope.
+	 * @param array<string,mixed> $payload Artifact payload.
+	 */
+	private static function artifact_slug( array $artifact, array $payload, string $fallback ): string {
+		return PortableSlug::normalize(
+			(string) ( $payload['portable_slug'] ?? $artifact['artifact_id'] ?? $fallback ),
+			$fallback
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $artifact Artifact envelope.
+	 * @param array<string,mixed> $context Apply context.
+	 */
+	private static function record_applied_artifact( array $artifact, int $agent_id, array $context ): bool|\WP_Error {
+		$agents = new Agents();
+		$agent  = $agents->get_agent( $agent_id );
+		if ( ! $agent ) {
+			return new \WP_Error( 'datamachine_bundle_agent_missing', sprintf( 'Agent ID %d was not found.', $agent_id ) );
+		}
+
+		$config      = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
+		$bundle      = is_array( $context['bundle'] ?? null ) ? $context['bundle'] : array();
+		$bundle_slug = (string) ( $bundle['bundle_slug'] ?? $config['datamachine_bundle']['bundle_slug'] ?? '' );
+		$version     = (string) ( $bundle['bundle_version'] ?? $config['datamachine_bundle']['bundle_version'] ?? '' );
+		$type        = (string) ( $artifact['artifact_type'] ?? '' );
+		$id          = (string) ( $artifact['artifact_id'] ?? '' );
+		$payload     = $artifact['payload'] ?? null;
+		$hash        = AgentBundleArtifactHasher::hash( $payload );
+		$now         = gmdate( 'c' );
+
+		if ( '' === $bundle_slug || '' === $type || '' === $id ) {
+			return new \WP_Error( 'datamachine_bundle_registry_incomplete', 'Bundle artifact registry metadata is incomplete.' );
+		}
+
+		$config['datamachine_bundle']['bundle_slug']    = $bundle_slug;
+		$config['datamachine_bundle']['bundle_version'] = $version;
+		$config['datamachine_bundle']['artifacts'][ AgentBundleArtifactExtensions::artifact_key( $type, $id ) ] = array(
+			'bundle_slug'       => $bundle_slug,
+			'bundle_version'    => $version,
+			'artifact_type'     => $type,
+			'artifact_id'       => $id,
+			'source_path'       => (string) ( $artifact['source_path'] ?? '' ),
+			'installed_hash'    => $hash,
+			'current_hash'      => $hash,
+			'installed_payload' => $payload,
+			'status'            => AgentBundleArtifactStatus::CLEAN,
+			'installed_at'      => $now,
+			'updated_at'        => $now,
+		);
+
+		if ( ! $agents->update_agent( $agent_id, array( 'agent_config' => $config ) ) ) {
+			return new \WP_Error( 'datamachine_bundle_registry_update_failed', 'Failed to update bundle artifact registry.' );
+		}
+
+		return true;
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
@@ -124,7 +124,7 @@ final class AgentBundleCoreArtifactApply {
 		$repo = new Flows();
 		$row  = null;
 		foreach ( $repo->get_all_flows( null, $agent_id ) as $flow ) {
-			if ( $slug === (string) ( $flow['portable_slug'] ?? '' ) ) {
+			if ( (string) ( $flow['portable_slug'] ?? '' ) === $slug ) {
 				$row = $flow;
 				break;
 			}


### PR DESCRIPTION
## Summary
- Adds Data Machine-owned apply handling for approved `pipeline` and `flow` bundle artifacts.
- Updates the installed artifact registry after successful apply so rebased bundle upgrades can resolve cleanly.

## Testing
- `php -l inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php`
- `php tests/agent-bundle-pending-action-rebase-smoke.php`
- `php tests/agent-bundle-upgrade-planner-smoke.php`
- `vendor/bin/phpcs inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Ported and verified the core bundle artifact apply handler fix from a stale local worktree onto current main; Chris remains responsible for review and testing.