### PR TITLE
fix: support nested agent config paths

### DIFF
--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -1092,8 +1092,8 @@ class AgentsCommand extends AgentBundleCommand {
 				$decoded = json_decode( $raw_value, true );
 				$value   = ( null !== $decoded || 'null' === $raw_value ) ? $decoded : $raw_value;
 
-				$config[ $key ] = $value;
-				$display        = is_array( $value ) ? wp_json_encode( $value, JSON_UNESCAPED_SLASHES ) : (string) $value;
+				$this->setConfigValue( $config, $key, $value );
+				$display = is_array( $value ) ? wp_json_encode( $value, JSON_UNESCAPED_SLASHES ) : (string) $value;
 				WP_CLI::log( sprintf( '  %s → %s', $key, $display ) );
 			}
 		}
@@ -1103,8 +1103,7 @@ class AgentsCommand extends AgentBundleCommand {
 			$unsets = is_array( $assoc_args['unset'] ) ? $assoc_args['unset'] : array( $assoc_args['unset'] );
 
 			foreach ( $unsets as $key ) {
-				if ( array_key_exists( $key, $config ) ) {
-					unset( $config[ $key ] );
+				if ( $this->unsetConfigValue( $config, (string) $key ) ) {
 					WP_CLI::log( sprintf( '  Removed: %s', $key ) );
 				} else {
 					WP_CLI::warning( sprintf( '  Key not found: %s', $key ) );
@@ -1116,6 +1115,78 @@ class AgentsCommand extends AgentBundleCommand {
 		$agents_repo->update_agent( $agent_id, array( 'agent_config' => $config ) );
 
 		WP_CLI::success( sprintf( 'Config updated for agent "%s".', $agent['agent_slug'] ) );
+	}
+
+	/**
+	 * Set a config value, supporting dot notation for nested paths.
+	 *
+	 * @param array  $config Config array, passed by reference.
+	 * @param string $path   Dot-notated config path.
+	 * @param mixed  $value  Value to set.
+	 */
+	private function setConfigValue( array &$config, string $path, $value ): void {
+		$segments = $this->getConfigPathSegments( $path );
+		if ( empty( $segments ) ) {
+			return;
+		}
+
+		$target =& $config;
+		$last   = array_pop( $segments );
+		foreach ( $segments as $segment ) {
+			if ( ! isset( $target[ $segment ] ) || ! is_array( $target[ $segment ] ) ) {
+				$target[ $segment ] = array();
+			}
+			$target =& $target[ $segment ];
+		}
+
+		$target[ $last ] = $value;
+	}
+
+	/**
+	 * Remove a config value, supporting dot notation for nested paths.
+	 *
+	 * @param array  $config Config array, passed by reference.
+	 * @param string $path   Dot-notated config path.
+	 * @return bool Whether a value was removed.
+	 */
+	private function unsetConfigValue( array &$config, string $path ): bool {
+		$segments = $this->getConfigPathSegments( $path );
+		if ( empty( $segments ) ) {
+			return false;
+		}
+
+		$target =& $config;
+		$last   = array_pop( $segments );
+		foreach ( $segments as $segment ) {
+			if ( ! isset( $target[ $segment ] ) || ! is_array( $target[ $segment ] ) ) {
+				return false;
+			}
+			$target =& $target[ $segment ];
+		}
+
+		if ( ! array_key_exists( $last, $target ) ) {
+			return false;
+		}
+
+		unset( $target[ $last ] );
+		return true;
+	}
+
+	/**
+	 * Split a dot-notated config path into usable segments.
+	 *
+	 * @param string $path Config path.
+	 * @return string[]
+	 */
+	private function getConfigPathSegments( string $path ): array {
+		$segments = array_filter(
+			array_map( 'trim', explode( '.', $path ) ),
+			static function ( string $segment ): bool {
+				return '' !== $segment;
+			}
+		);
+
+		return array_values( $segments );
 	}
 
 	/**

--- a/tests/Unit/Cli/Commands/AgentsCommandTest.php
+++ b/tests/Unit/Cli/Commands/AgentsCommandTest.php
@@ -62,4 +62,89 @@ class AgentsCommandTest extends TestCase {
 		$this->assertNotNull( $returnType );
 		$this->assertSame( 'void', $returnType->getName() );
 	}
+
+	/**
+	 * Test config path setter supports dot notation.
+	 */
+	public function test_set_config_value_supports_dot_notation(): void {
+		$command = new AgentsCommand();
+		$method  = new ReflectionMethod( AgentsCommand::class, 'setConfigValue' );
+		$method->setAccessible( true );
+
+		$config = array(
+			'intelligence' => array(
+				'context_servers' => 'legacy',
+			),
+		);
+
+		$method->invokeArgs( $command, array( &$config, 'intelligence.context_servers.a8c.url', 'https://example.com/mcp' ) );
+
+		$this->assertSame(
+			array(
+				'intelligence' => array(
+					'context_servers' => array(
+						'a8c' => array(
+							'url' => 'https://example.com/mcp',
+						),
+					),
+				),
+			),
+			$config
+		);
+	}
+
+	/**
+	 * Test config path unsetter supports dot notation.
+	 */
+	public function test_unset_config_value_supports_dot_notation(): void {
+		$command = new AgentsCommand();
+		$method  = new ReflectionMethod( AgentsCommand::class, 'unsetConfigValue' );
+		$method->setAccessible( true );
+
+		$config = array(
+			'intelligence' => array(
+				'context_servers' => array(
+					'a8c' => array(
+						'url'     => 'https://example.com/mcp',
+						'timeout' => 30,
+					),
+				),
+			),
+		);
+
+		$removed = $method->invokeArgs( $command, array( &$config, 'intelligence.context_servers.a8c.url' ) );
+
+		$this->assertTrue( $removed );
+		$this->assertSame(
+			array(
+				'intelligence' => array(
+					'context_servers' => array(
+						'a8c' => array(
+							'timeout' => 30,
+						),
+					),
+				),
+			),
+			$config
+		);
+	}
+
+	/**
+	 * Test config path unsetter reports missing nested paths.
+	 */
+	public function test_unset_config_value_returns_false_for_missing_path(): void {
+		$command = new AgentsCommand();
+		$method  = new ReflectionMethod( AgentsCommand::class, 'unsetConfigValue' );
+		$method->setAccessible( true );
+
+		$config = array(
+			'intelligence' => array(
+				'context_servers' => array(),
+			),
+		);
+
+		$removed = $method->invokeArgs( $command, array( &$config, 'intelligence.context_servers.a8c.url' ) );
+
+		$this->assertFalse( $removed );
+	}
 }


### PR DESCRIPTION
## Summary
- Treat `wp datamachine agent config --set=foo.bar=value` as a nested config update instead of storing a literal dotted key.
- Apply the same path semantics to `--unset=foo.bar`, with unit coverage for set, unset, and missing nested paths.

## Testing
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main` was attempted before PR prep and remains blocked by the existing bootstrap error: `Interface \"WP_Agent_Principal_Access_Store\" not found` in `AgentAccessStoreAdapter.php`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the CLI path handling patch, unit coverage, and PR description; Chris remains responsible for review and merge.