### PR TITLE
fix: avoid hard principal transcript dependency

### DIFF
--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -17,7 +17,6 @@ use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\Database\BaseRepository;
 use AgentsAPI\AI\WP_Agent_Execution_Principal;
 use AgentsAPI\AI\WP_Agent_Message;
-use AgentsAPI\Core\Database\Chat\WP_Agent_Principal_Conversation_Store;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
 use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 use WP_Error;
@@ -34,7 +33,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * filter. Resolve via {@see ConversationStoreFactory::get()} rather than
  * instantiating this class directly.
  */
-class Chat extends BaseRepository implements ConversationStoreInterface, WP_Agent_Principal_Conversation_Store {
+class Chat extends BaseRepository implements ConversationStoreInterface {
 
 	/**
 	 * Table name (without prefix)

--- a/inc/Core/Database/Chat/ConversationStoreFactory.php
+++ b/inc/Core/Database/Chat/ConversationStoreFactory.php
@@ -51,7 +51,7 @@ class ConversationStoreFactory {
 			return self::$instance;
 		}
 
-		$default = new Chat();
+		$default = self::default_store();
 
 		/**
 		 * Filter: swap the Data Machine chat conversation persistence backend.
@@ -106,6 +106,23 @@ class ConversationStoreFactory {
 
 		self::$instance = $default;
 		return self::$instance;
+	}
+
+	/**
+	 * Create the default MySQL-backed store.
+	 *
+	 * The principal-owner transcript interface is an optional Agents API contract.
+	 * Use the principal-aware subclass only when that interface is loaded, so
+	 * activation remains safe with older dependency checkouts.
+	 *
+	 * @return ConversationStoreInterface
+	 */
+	private static function default_store(): ConversationStoreInterface {
+		if ( interface_exists( 'AgentsAPI\\Core\\Database\\Chat\\WP_Agent_Principal_Conversation_Store' ) ) {
+			return new PrincipalChat();
+		}
+
+		return new Chat();
 	}
 
 	/**

--- a/inc/Core/Database/Chat/PrincipalChat.php
+++ b/inc/Core/Database/Chat/PrincipalChat.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Principal-aware chat database store.
+ *
+ * @package DataMachine\Core\Database\Chat
+ * @since   next
+ */
+
+namespace DataMachine\Core\Database\Chat;
+
+use AgentsAPI\Core\Database\Chat\WP_Agent_Principal_Conversation_Store;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Adds the optional Agents API principal-owner marker to the default store.
+ *
+ * Keep the base {@see Chat} class free of this optional interface so Data
+ * Machine can activate cleanly when an older Agents API dependency has not yet
+ * shipped the principal-owned session contract.
+ */
+class PrincipalChat extends Chat implements WP_Agent_Principal_Conversation_Store {
+}

--- a/tests/conversation-store-contracts-smoke.php
+++ b/tests/conversation-store-contracts-smoke.php
@@ -37,6 +37,7 @@ use DataMachine\Core\Database\Chat\ConversationRetentionInterface;
 use DataMachine\Core\Database\Chat\ConversationSessionIndexInterface;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Chat\ConversationStoreInterface;
+use DataMachine\Core\Database\Chat\PrincipalChat;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Lock;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Store;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Principal_Conversation_Store;
@@ -112,7 +113,8 @@ foreach ( $narrow_contracts as $contract ) {
 }
 
 $assert_true( ( new ReflectionClass( Chat::class ) )->implementsInterface( ConversationStoreInterface::class ), 'Chat remains a ConversationStoreInterface aggregate' );
-$assert_true( ( new ReflectionClass( Chat::class ) )->implementsInterface( WP_Agent_Principal_Conversation_Store::class ), 'Chat supports principal-owned transcript sessions' );
+$assert_true( ! ( new ReflectionClass( Chat::class ) )->implementsInterface( WP_Agent_Principal_Conversation_Store::class ), 'Base Chat store does not hard-require optional principal session contract' );
+$assert_true( ( new ReflectionClass( PrincipalChat::class ) )->implementsInterface( WP_Agent_Principal_Conversation_Store::class ), 'PrincipalChat supports principal-owned transcript sessions when contract is available' );
 $assert_true( ( new ReflectionClass( InMemoryConversationStore::class ) )->implementsInterface( ConversationStoreInterface::class ), 'test adapter remains a ConversationStoreInterface aggregate' );
 
 $factory_get = new ReflectionMethod( ConversationStoreFactory::class, 'get' );


### PR DESCRIPTION
## Summary
- Keeps the base `Chat` store from hard-implementing the optional Agents API principal conversation interface during activation.
- Adds `PrincipalChat` as the principal-aware subclass used only when the optional Agents API contract is loaded.
- Updates the conversation store smoke test to verify the fallback and principal-aware paths.

## Testing
- `php -l inc/Core/Database/Chat/Chat.php && php -l inc/Core/Database/Chat/PrincipalChat.php && php -l inc/Core/Database/Chat/ConversationStoreFactory.php && php tests/conversation-store-contracts-smoke.php`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the activation bootstrap failure, drafted the optional-interface fallback, updated smoke coverage, and prepared the PR description; Chris remains responsible for review and merge.