### PR TITLE
Support principal-owned session reads

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -820,12 +820,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "f60d01133e0cbbf01c2dc01ec444534948ac7b5f"
+                "reference": "da4477579eb03963af202a39cfd6102bebdbd802"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/f60d01133e0cbbf01c2dc01ec444534948ac7b5f",
-                "reference": "f60d01133e0cbbf01c2dc01ec444534948ac7b5f",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/da4477579eb03963af202a39cfd6102bebdbd802",
+                "reference": "da4477579eb03963af202a39cfd6102bebdbd802",
                 "shasum": ""
             },
             "require": {
@@ -864,6 +864,7 @@
                     "php tests/conversation-runner-contracts-smoke.php",
                     "php tests/conversation-transcript-lock-smoke.php",
                     "php tests/conversation-compaction-smoke.php",
+                    "php tests/tool-pair-validator-smoke.php",
                     "php tests/markdown-section-compaction-smoke.php",
                     "php tests/context-registry-smoke.php",
                     "php tests/conversation-loop-smoke.php",
@@ -899,7 +900,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-16T13:34:28+00:00"
+            "time": "2026-05-17T21:38:05+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -751,6 +751,30 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	}
 
 	/**
+	 * Read one transcript session for a canonical Agents API principal owner.
+	 *
+	 * @param WP_Agent_Workspace_Scope      $workspace  Workspace owning the session.
+	 * @param array{type:string,key:string} $owner      Canonical principal owner.
+	 * @param string                        $session_id Session ID.
+	 * @return array<string,mixed>|null Session row, or null when missing/not owned.
+	 */
+	public function get_session_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, string $session_id ): ?array {
+		unset( $workspace );
+
+		$transcript_owner = self::principal_owner_to_transcript_owner( $owner );
+		if ( null === $transcript_owner ) {
+			return null;
+		}
+
+		$session = $this->get_session( $session_id );
+		if ( ! is_array( $session ) || ! self::session_matches_owner( $session, $transcript_owner ) ) {
+			return null;
+		}
+
+		return $session;
+	}
+
+	/**
 	 * Resolve the generic transcript agent slug from a stored session row.
 	 *
 	 * @param array<string,mixed> $session Stored session row.

--- a/inc/Core/Database/Chat/ConversationStoreFactory.php
+++ b/inc/Core/Database/Chat/ConversationStoreFactory.php
@@ -118,7 +118,7 @@ class ConversationStoreFactory {
 	 * @return ConversationStoreInterface
 	 */
 	private static function default_store(): ConversationStoreInterface {
-		if ( interface_exists( 'AgentsAPI\\Core\\Database\\Chat\\WP_Agent_Principal_Conversation_Store' ) ) {
+		if ( interface_exists( 'AgentsAPI\\Core\\Database\\Chat\\WP_Agent_Principal_Conversation_Session_Reader' ) ) {
 			return new PrincipalChat();
 		}
 

--- a/inc/Core/Database/Chat/PrincipalChat.php
+++ b/inc/Core/Database/Chat/PrincipalChat.php
@@ -9,6 +9,7 @@
 namespace DataMachine\Core\Database\Chat;
 
 use AgentsAPI\Core\Database\Chat\WP_Agent_Principal_Conversation_Store;
+use AgentsAPI\Core\Database\Chat\WP_Agent_Principal_Conversation_Session_Reader;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -19,5 +20,5 @@ defined( 'ABSPATH' ) || exit;
  * Machine can activate cleanly when an older Agents API dependency has not yet
  * shipped the principal-owned session contract.
  */
-class PrincipalChat extends Chat implements WP_Agent_Principal_Conversation_Store {
+class PrincipalChat extends Chat implements WP_Agent_Principal_Conversation_Store, WP_Agent_Principal_Conversation_Session_Reader {
 }

--- a/tests/conversation-store-contracts-smoke.php
+++ b/tests/conversation-store-contracts-smoke.php
@@ -40,6 +40,7 @@ use DataMachine\Core\Database\Chat\ConversationStoreInterface;
 use DataMachine\Core\Database\Chat\PrincipalChat;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Lock;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Store;
+use AgentsAPI\Core\Database\Chat\WP_Agent_Principal_Conversation_Session_Reader;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Principal_Conversation_Store;
 use DataMachine\Tests\Unit\Core\Database\Chat\InMemoryConversationStore;
 
@@ -115,6 +116,7 @@ foreach ( $narrow_contracts as $contract ) {
 $assert_true( ( new ReflectionClass( Chat::class ) )->implementsInterface( ConversationStoreInterface::class ), 'Chat remains a ConversationStoreInterface aggregate' );
 $assert_true( ! ( new ReflectionClass( Chat::class ) )->implementsInterface( WP_Agent_Principal_Conversation_Store::class ), 'Base Chat store does not hard-require optional principal session contract' );
 $assert_true( ( new ReflectionClass( PrincipalChat::class ) )->implementsInterface( WP_Agent_Principal_Conversation_Store::class ), 'PrincipalChat supports principal-owned transcript sessions when contract is available' );
+$assert_true( ( new ReflectionClass( PrincipalChat::class ) )->implementsInterface( WP_Agent_Principal_Conversation_Session_Reader::class ), 'PrincipalChat supports owner-aware single-session reads when contract is available' );
 $assert_true( ( new ReflectionClass( InMemoryConversationStore::class ) )->implementsInterface( ConversationStoreInterface::class ), 'test adapter remains a ConversationStoreInterface aggregate' );
 
 $factory_get = new ReflectionMethod( ConversationStoreFactory::class, 'get' );


### PR DESCRIPTION
## Summary
- Update Agents API to include the owner-aware session read contract from Automattic/agents-api#179.
- Implement get_session_for_owner in Data Machine principal-aware chat store so browser-owned sessions can be loaded by ID without exposing raw owner keys.
- Gate the principal-aware store on the new interface and extend contract smoke coverage.

## Testing
- php tests/conversation-store-contracts-smoke.php
- homeboy lint --changed-since origin/main
- homeboy test --changed-since origin/main

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the logged-out session load ownership path, drafted the Data Machine implementation and coverage, and ran scoped verification; Chris remains responsible for review and merge.