### PR TITLE
Clarify system task contracts

### DIFF
--- a/docs/api/endpoints/system.md
+++ b/docs/api/endpoints/system.md
@@ -471,8 +471,9 @@ add_filter('datamachine_tasks', function($tasks) {
 
 **Task class requirements**:
 - Must extend `DataMachine\Engine\AI\System\Tasks\SystemTask`
-- Must implement `execute(int $jobId, array $params): void`
+- Must implement `executeTask(int $jobId, array $params): void`
 - Must implement `getTaskType(): string`
+- May override `getWorkflow()` when the task needs a multi-step workflow
 - May override `getTaskMeta()` for UI metadata
 - May override `getPromptDefinitions()` for editable prompts
 - May override `supportsUndo()` for undo support

--- a/docs/core-system/recurring-scheduler.md
+++ b/docs/core-system/recurring-scheduler.md
@@ -132,8 +132,7 @@ definition.
 
 Hooks are schedule-scoped because a single task handler can have multiple
 schedule bindings. Legacy task-scoped hooks (`datamachine_recurring_<task_type>`)
-are still recognized during migration, then unscheduled once the canonical
-schedule-scoped hook is reconciled.
+are unscheduled once the canonical schedule-scoped hook is reconciled.
 
 ## Upgrade migration
 

--- a/docs/core-system/recurring-scheduler.md
+++ b/docs/core-system/recurring-scheduler.md
@@ -122,23 +122,25 @@ Two primitives, not one.
 
 - **`RecurringScheduler`** — *when* something runs. Handles the AS timer.
 - **`TaskScheduler::schedule()`** — *what* gets enqueued now. Creates a DM
-  Job and fires `datamachine_task_handle` to run a task handler.
+  workflow job through `datamachine/execute-workflow`.
 
 The bridge is the closure registered per-schedule in
 `SystemAgentServiceProvider::registerActionSchedulerHooks()`: it listens
-for `datamachine_recurring_<task_type>`, and its only job is to call
+for `datamachine_recurring_<schedule_id>`, and its only job is to call
 `TaskScheduler::schedule()` with the task params from the schedule
 definition.
 
+Hooks are schedule-scoped because a single task handler can have multiple
+schedule bindings. Legacy task-scoped hooks (`datamachine_recurring_<task_type>`)
+are still recognized during migration, then unscheduled once the canonical
+schedule-scoped hook is reconciled.
+
 ## Upgrade migration
 
-The only non-additive change for existing installs is the AS hook
-rename for daily memory generation
-(`datamachine_system_agent_daily_memory` → `datamachine_recurring_daily_memory_generation`).
-`SystemAgentServiceProvider::manageRecurringTaskSchedules()` runs on
-`action_scheduler_init` and unschedules any pending action queued under
-the old hook before the new schedule gets a chance to dispatch, so
-upgrading sites don't carry a zombie recurring action. No other contract
+Existing installs may have pending AS actions under older task-scoped hook
+names. `SystemAgentServiceProvider::manageRecurringTaskSchedules()` runs on
+`action_scheduler_init`, schedules the canonical schedule-scoped hook, and
+unschedules legacy task-scoped hooks when the names differ. No other contract
 changes; `FlowScheduling::handle_scheduling_update()` signature, REST
 endpoints, CLI commands, the `datamachine_scheduler_intervals` filter,
 and `TaskScheduler::schedule()` are all unchanged.

--- a/docs/core-system/system-tasks.md
+++ b/docs/core-system/system-tasks.md
@@ -239,7 +239,7 @@ Scheduler:
   pending → schedule via `RecurringScheduler::ensureSchedule()`.
 - If the setting resolves to false → unschedule.
 
-Recurring hooks are schedule-scoped because one task can have multiple schedules with different params or cadences. Task-scoped legacy hooks (`datamachine_recurring_<task_type>`) are registered only as a migration bridge and are unscheduled when the schedule-scoped hook is reconciled.
+Recurring hooks are schedule-scoped because one task can have multiple schedules with different params or cadences. Task-scoped legacy hooks (`datamachine_recurring_<task_type>`) are unscheduled when the schedule-scoped hook is reconciled.
 
 ## SystemTaskStep
 

--- a/docs/core-system/system-tasks.md
+++ b/docs/core-system/system-tasks.md
@@ -46,7 +46,7 @@ abstract class SystemTask {
 ]
 ```
 
-`executeTask()` is the imperative body called by `SystemTaskStep`. Legacy persisted step settings that use `task` instead of `task_type` are still readable, but new code should write `task_type`.
+`executeTask()` is the imperative body called by `SystemTaskStep`. System task step settings use `task_type`; configs that still use the older `task` key must be upgraded before they run.
 
 ### Job Lifecycle Methods
 
@@ -265,7 +265,7 @@ Configured via the pipeline step UI with two fields:
 - **Task Type** (select dropdown, stored as `task_type`) — chooses from registered task types via `TaskRegistry`
 - **Params** (JSON editor) — task-specific parameters, defaults to `{}`
 
-Legacy persisted configs may still contain `task`; the runtime reads both keys. New bundle, workflow, and agent-generated configs should use `task_type`.
+Bundle, workflow, and agent-generated configs must use `task_type`.
 
 ### Settings
 

--- a/docs/core-system/system-tasks.md
+++ b/docs/core-system/system-tasks.md
@@ -1,6 +1,6 @@
 # System Tasks
 
-System tasks are background operations that run outside the normal pipeline execution cycle. They handle AI-powered content operations (alt text, meta descriptions, internal linking), media processing (image generation, optimization), and agent housekeeping (daily memory synthesis, agent ping). All system tasks share a common base class with standardized job management, effect tracking, and undo support.
+System tasks are reusable task handlers that can run on demand, from recurring schedules, or inline as workflow/pipeline steps. They handle AI-powered content operations (alt text, meta descriptions, internal linking), media processing (image generation, optimization), and agent housekeeping (daily memory synthesis). All system tasks share a common base class with standardized job management, effect tracking, and undo support.
 
 ## Overview
 
@@ -9,9 +9,9 @@ The system tasks framework consists of:
 1. **SystemTask base class** — abstract base with job completion, failure handling, rescheduling, and undo
 2. **SystemAgentServiceProvider** — registers task handlers and Action Scheduler hooks
 3. **TaskRegistry** — central registry of available task types
-4. **TaskScheduler** — schedules and dispatches tasks via Action Scheduler
+4. **TaskScheduler** — enqueues a task run through `datamachine/execute-workflow`
 5. **SystemTaskStep** — pipeline step type that bridges system tasks into pipeline workflows
-6. **Seven built-in tasks** — each implementing a specific AI or system operation
+6. **RecurringScheduleRegistry** — optional schedule bindings that say when a task should run
 
 > Note: `GitHubIssueTask` was extracted to the `data-machine-code` extension plugin (see PR #926). It is no longer part of core data-machine.
 
@@ -24,10 +24,29 @@ All system tasks extend this abstract class:
 
 ```php
 abstract class SystemTask {
-    abstract public function execute(int $jobId, array $params): void;
+    public function getWorkflow(array $params): array;
+    abstract public function executeTask(int $jobId, array $params): void;
     abstract public function getTaskType(): string;
 }
 ```
+
+`getWorkflow()` is the scheduling contract. The default implementation returns a single `system_task` workflow step using the canonical `flow_step_settings.task_type` key:
+
+```php
+[
+    'steps' => [
+        [
+            'type' => 'system_task',
+            'flow_step_settings' => [
+                'task_type' => $this->getTaskType(),
+                'params'    => $params,
+            ],
+        ],
+    ],
+]
+```
+
+`executeTask()` is the imperative body called by `SystemTaskStep`. Legacy persisted step settings that use `task` instead of `task_type` are still readable, but new code should write `task_type`.
 
 ### Job Lifecycle Methods
 
@@ -185,26 +204,28 @@ Registers all task infrastructure on instantiation:
 
 ### Task Registration
 
-Hooks the `datamachine_tasks` filter to register the seven built-in task types:
+Hooks the `datamachine_tasks` filter to register built-in task types:
 
 | Task Key | Class |
 |----------|-------|
-| `agent_ping` | `AgentPingTask` |
+| `agent_call` | `AgentCallTask` |
+| `dispatch_message` | `DispatchMessageTask` |
+| `emit_data_packets` | `EmitDataPacketsTask` |
 | `image_generation` | `ImageGenerationTask` |
 | `image_optimization` | `ImageOptimizationTask` |
 | `alt_text_generation` | `AltTextTask` |
 | `internal_linking` | `InternalLinkingTask` |
 | `daily_memory_generation` | `DailyMemoryTask` |
 | `meta_description_generation` | `MetaDescriptionTask` |
+| `retention_*` | Retention cleanup task classes |
 
 ### Action Scheduler Hooks
 
 | Hook | Handler | Description |
 |------|---------|-------------|
-| `datamachine_task_handle` | `handleScheduledTask` | Dispatches a scheduled task job |
 | `datamachine_task_process_batch` | `handleBatchChunk` | Processes a batch chunk |
 | `datamachine_system_agent_set_featured_image` | `handleDeferredFeaturedImage` | Retries featured image assignment (up to 12 × 15s = 3 minutes) |
-| `datamachine_recurring_<task_type>` | closure → `TaskScheduler::schedule()` | One hook per registered recurring schedule. Fires on the cadence defined by the schedule and enqueues an ephemeral DM job for the bound task. |
+| `datamachine_recurring_<schedule_id>` | closure → `TaskScheduler::schedule()` | One hook per registered recurring schedule. Fires on the cadence defined by the schedule and enqueues a DM workflow job for the bound task. |
 
 ### Recurring Task Schedule Management
 
@@ -218,9 +239,7 @@ Scheduler:
   pending → schedule via `RecurringScheduler::ensureSchedule()`.
 - If the setting resolves to false → unschedule.
 
-On upgrade, any pending AS action queued under the pre-refactor hook
-`datamachine_system_agent_daily_memory` is unscheduled during the first
-reconciliation so no zombie recurring action remains in the queue.
+Recurring hooks are schedule-scoped because one task can have multiple schedules with different params or cadences. Task-scoped legacy hooks (`datamachine_recurring_<task_type>`) are registered only as a migration bridge and are unscheduled when the schedule-scoped hook is reconciled.
 
 ## SystemTaskStep
 
@@ -233,7 +252,7 @@ A pipeline step type that bridges system tasks into the pipeline engine. This al
 
 ### How It Works
 
-1. Reads `flow_step_settings.task` to determine the task type
+1. Reads `flow_step_settings.task_type` to determine the task type
 2. Creates a child DM job for independent tracking
 3. Injects pipeline context (e.g., `post_id` from a preceding Publish step) into task params
 4. Executes the task handler synchronously
@@ -243,8 +262,10 @@ A pipeline step type that bridges system tasks into the pipeline engine. This al
 
 Configured via the pipeline step UI with two fields:
 
-- **Task** (select dropdown) — chooses from registered task types via `TaskRegistry`
+- **Task Type** (select dropdown, stored as `task_type`) — chooses from registered task types via `TaskRegistry`
 - **Params** (JSON editor) — task-specific parameters, defaults to `{}`
+
+Legacy persisted configs may still contain `task`; the runtime reads both keys. New bundle, workflow, and agent-generated configs should use `task_type`.
 
 ### Settings
 
@@ -363,14 +384,13 @@ Compresses oversized images and generates WebP variants using WordPress's native
 | Manual run | No |
 | Prompts | None (not an AI task) |
 
-### AgentPingTask
+### AgentCallTask
 
-**Type:** `agent_ping`
-**Source:** `inc/Engine/AI/System/Tasks/AgentPingTask.php`
-**Since:** v0.60.0
+**Type:** `agent_call`
+**Source:** `inc/Engine/AI/System/Tasks/AgentCallTask.php`
 **Undo:** No
 
-Sends pipeline context to external webhook endpoints (Discord, Slack, custom HTTP collectors). Delegates HTTP transport to `SendPingAbility` (`inc/Abilities/AgentPing/SendPingAbility.php`). When dispatched as a pipeline step via `SystemTaskStep`, supports queue popping so a single ping configuration can be reused across queued runs.
+Dispatches a structured agent invocation through a target transport. Webhook fire-and-forget delivery preserves the historical agent ping behavior under the generic `agent_call` contract. When dispatched as a pipeline step via `SystemTaskStep`, it can forward pipeline context and use queue modes so one configuration can be reused across queued runs.
 
 | Property | Value |
 |----------|-------|
@@ -390,7 +410,7 @@ add_filter('datamachine_tasks', function(array $tasks): array {
 });
 ```
 
-The class must extend `SystemTask` and implement `execute()` and `getTaskType()`. Override `getTaskMeta()` for admin UI display, `supportsUndo()` for reversibility, and `getPromptDefinitions()` for editable prompts.
+The class must extend `SystemTask` and implement `executeTask()` and `getTaskType()`. Override `getWorkflow()` only when the task needs a richer multi-step workflow. Override `getTaskMeta()` for admin UI display, `supportsUndo()` for reversibility, and `getPromptDefinitions()` for editable prompts.
 
 ## Architecture Diagram
 
@@ -399,22 +419,24 @@ The class must extend `SystemTask` and implement `execute()` and `getTaskType()`
                      |                          |                         |
                      v                          v                         v
               TaskScheduler              SystemTaskStep              TaskScheduler
-                     |                          |                         |
-                     v                          v                         v
-              TaskRegistry -----> resolve task class <----- TaskRegistry
-                                        |
-                                        v
-                                   SystemTask
-                                   .execute()
-                                        |
-                    +-------------------+-------------------+
-                    |                   |                   |
-                    v                   v                   v
-             completeJob()        failJob()          reschedule()
-                    |                   |                   |
-                    v                   v                   v
-              Jobs table          Jobs table        Action Scheduler
-            (engine_data)       (failed status)     (retry in N sec)
+                      |                          |                         |
+                      v                          v                         v
+              getWorkflow() ----> system_task step <----- TaskRegistry
+                      |                          |
+                      v                          v
+              execute-workflow             executeTask()
+                                                 |
+                                                 v
+                                           SystemTask body
+                                                 |
+                    +----------------------------+-------------------+
+                    |                            |                   |
+                    v                            v                   v
+             completeJob()                 failJob()          reschedule()
+                    |                            |                   |
+                    v                            v                   v
+              Jobs table                   Jobs table        Action Scheduler
+            (engine_data)                (failed status)     (retry in N sec)
 ```
 
 ## Source Files
@@ -429,6 +451,6 @@ The class must extend `SystemTask` and implement `execute()` and `getTaskType()`
 | `inc/Engine/AI/System/Tasks/AltTextTask.php` | AI-powered image alt text generation |
 | `inc/Engine/AI/System/Tasks/ImageGenerationTask.php` | Async image generation via Replicate API |
 | `inc/Engine/AI/System/Tasks/ImageOptimizationTask.php` | Image compression and WebP generation |
-| `inc/Engine/AI/System/Tasks/AgentPingTask.php` | Send pipeline context to external webhook endpoints |
+| `inc/Engine/AI/System/Tasks/AgentCallTask.php` | Send structured agent invocation payloads |
 | `inc/Core/Steps/SystemTask/SystemTaskStep.php` | Pipeline step type bridging system tasks |
 | `inc/Core/Steps/SystemTask/SystemTaskSettings.php` | Admin UI settings for the SystemTask step |

--- a/inc/Core/Steps/SystemTask/SystemTaskSettings.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskSettings.php
@@ -26,20 +26,37 @@ class SystemTaskSettings extends SettingsHandler {
 	 */
 	public static function get_fields(): array {
 		return array(
-			'task'   => array(
+			'task_type' => array(
 				'type'        => 'select',
 				'label'       => __( 'Task Type', 'data-machine' ),
 				'description' => __( 'The system task to execute. Available tasks are registered by Data Machine and plugins.', 'data-machine' ),
 				'required'    => true,
 				'options'     => self::getTaskOptions(),
 			),
-			'params' => array(
+			'params'    => array(
 				'type'        => 'json',
 				'label'       => __( 'Task Parameters', 'data-machine' ),
 				'description' => __( 'JSON object of task-specific parameters. Pipeline context (post_id) is injected automatically.', 'data-machine' ),
 				'default'     => '{}',
 			),
 		);
+	}
+
+	/**
+	 * Sanitize System Task step settings.
+	 *
+	 * Accepts the legacy `task` key so existing saved steps can still be opened
+	 * and resaved through the settings UI without losing their task selection.
+	 *
+	 * @param array $raw_settings Raw settings input from user.
+	 * @return array Sanitized settings.
+	 */
+	public static function sanitize( array $raw_settings ): array {
+		if ( empty( $raw_settings['task_type'] ) && ! empty( $raw_settings['task'] ) ) {
+			$raw_settings['task_type'] = $raw_settings['task'];
+		}
+
+		return parent::sanitize( $raw_settings );
 	}
 
 	/**

--- a/inc/Core/Steps/SystemTask/SystemTaskSettings.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskSettings.php
@@ -43,23 +43,6 @@ class SystemTaskSettings extends SettingsHandler {
 	}
 
 	/**
-	 * Sanitize System Task step settings.
-	 *
-	 * Accepts the legacy `task` key so existing saved steps can still be opened
-	 * and resaved through the settings UI without losing their task selection.
-	 *
-	 * @param array $raw_settings Raw settings input from user.
-	 * @return array Sanitized settings.
-	 */
-	public static function sanitize( array $raw_settings ): array {
-		if ( empty( $raw_settings['task_type'] ) && ! empty( $raw_settings['task'] ) ) {
-			$raw_settings['task_type'] = $raw_settings['task'];
-		}
-
-		return parent::sanitize( $raw_settings );
-	}
-
-	/**
 	 * Get available task types as select options.
 	 *
 	 * Reads from the System Agent's registered task handlers.

--- a/inc/Core/Steps/SystemTask/SystemTaskStep.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskStep.php
@@ -10,8 +10,6 @@
  *   task_type - Task type identifier (e.g., 'internal_linking')
  *   params    - Task-specific parameters merged with pipeline context
  *
- * Legacy persisted steps may still use `task`; runtime reads both keys.
- *
  * Pipeline context (post_id from Publish step) is injected automatically
  * into the task params.
  *
@@ -474,14 +472,14 @@ class SystemTaskStep extends Step {
 	/**
 	 * Resolve the configured task type for this step.
 	 *
-	 * `task_type` is the canonical field used by public task APIs. The older
-	 * `task` field remains readable so persisted flows continue to execute.
+	 * `task_type` is the canonical field used by public task APIs and workflow
+	 * step configuration.
 	 *
 	 * @param array $settings Flow step settings.
 	 * @return string Configured task type, or empty string.
 	 */
 	private static function getConfiguredTaskType( array $settings ): string {
-		$task_type = $settings['task_type'] ?? ( $settings['task'] ?? '' );
+		$task_type = $settings['task_type'] ?? '';
 		return is_string( $task_type ) ? $task_type : '';
 	}
 }

--- a/inc/Core/Steps/SystemTask/SystemTaskStep.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskStep.php
@@ -6,9 +6,11 @@
  * mechanical/deterministic tasks (internal linking, alt text generation)
  * to run as pipeline steps without a full agent turn.
  *
- * Configuration is at the flow step level via handler_config:
- *   task   - Task type identifier (e.g., 'internal_linking')
- *   params - Task-specific parameters merged with pipeline context
+ * Configuration is at the flow step level via flow_step_settings:
+ *   task_type - Task type identifier (e.g., 'internal_linking')
+ *   params    - Task-specific parameters merged with pipeline context
+ *
+ * Legacy persisted steps may still use `task`; runtime reads both keys.
  *
  * Pipeline context (post_id from Publish step) is injected automatically
  * into the task params.
@@ -96,7 +98,7 @@ class SystemTaskStep extends Step {
 	 */
 	protected function validateStepConfiguration(): bool {
 		$step_settings = $this->getHandlerConfig();
-		$task_type     = $step_settings['task'] ?? '';
+		$task_type     = self::getConfiguredTaskType( $step_settings );
 
 		if ( empty( $task_type ) ) {
 			do_action(
@@ -141,7 +143,7 @@ class SystemTaskStep extends Step {
 	 */
 	protected function executeStep(): array {
 		$handler_config = $this->getHandlerConfig();
-		$task_type      = $handler_config['task'];
+		$task_type      = self::getConfiguredTaskType( $handler_config );
 		$task_params    = $handler_config['params'] ?? array();
 
 		// Inject pipeline context into task params.
@@ -467,5 +469,19 @@ class SystemTaskStep extends Step {
 		}
 
 		return $normalized;
+	}
+
+	/**
+	 * Resolve the configured task type for this step.
+	 *
+	 * `task_type` is the canonical field used by public task APIs. The older
+	 * `task` field remains readable so persisted flows continue to execute.
+	 *
+	 * @param array $settings Flow step settings.
+	 * @return string Configured task type, or empty string.
+	 */
+	private static function getConfiguredTaskType( array $settings ): string {
+		$task_type = $settings['task_type'] ?? ( $settings['task'] ?? '' );
+		return is_string( $task_type ) ? $task_type : '';
 	}
 }

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -316,9 +316,6 @@ class SystemAgentServiceProvider {
 			};
 
 			add_action( $hook, $dispatch_schedule );
-			if ( $legacy_hook !== $hook ) {
-				add_action( $legacy_hook, $dispatch_schedule );
-			}
 		}
 	}
 

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -233,7 +233,7 @@ class SystemAgentServiceProvider {
 	 *   - datamachine_task_process_batch  → process batch chunks
 	 *   - datamachine_task_retry          → retry polling tasks (e.g. image generation)
 	 *   - datamachine_system_agent_set_featured_image → deferred featured image
-	 *   - datamachine_recurring_<task>    → per-schedule ticks via TaskScheduler
+	 *   - datamachine_recurring_<schedule> → per-schedule ticks via TaskScheduler
 	 *
 	 * @since 0.72.0
 	 */
@@ -258,64 +258,67 @@ class SystemAgentServiceProvider {
 		// primary agent.
 		foreach ( RecurringScheduleRegistry::all() as $schedule ) {
 			$hook        = RecurringScheduleRegistry::hookFor( $schedule );
+			$legacy_hook = RecurringScheduleRegistry::legacyHookFor( $schedule );
 			$task_type   = $schedule['task_type'];
 			$schedule_id = $schedule['schedule_id'];
 			if ( '' === $hook ) {
 				continue;
 			}
 
-			add_action(
-				$hook,
-				static function () use ( $schedule_id, $task_type ): void {
-					$def = RecurringScheduleRegistry::get( $schedule_id );
-					if ( null === $def ) {
-						return;
-					}
-
-					$params = $def['task_params'] ?? array();
-					if ( ! empty( $def['task_params_callback'] ) && is_callable( $def['task_params_callback'] ) ) {
-						$params = (array) call_user_func( $def['task_params_callback'] );
-					}
-
-					if ( ! empty( $def['per_agent'] ) ) {
-						$agents_repo = new Agents();
-						$agents      = $agents_repo->get_all();
-
-						if ( empty( $agents ) ) {
-							// No agents on this install — fall back to a
-							// single site-scoped run so the task still
-							// fires (mirrors pre-multi-agent behaviour).
-							TaskScheduler::schedule( $task_type, $params );
-							return;
-						}
-
-						foreach ( $agents as $agent ) {
-							$agent_id = (int) ( $agent['agent_id'] ?? 0 );
-							$owner_id = (int) ( $agent['owner_id'] ?? 0 );
-
-							if ( $agent_id <= 0 ) {
-								continue;
-							}
-
-							$agent_params             = $params;
-							$agent_params['agent_id'] = $agent_id;
-							$agent_params['user_id']  = $owner_id;
-
-							TaskScheduler::schedule(
-								$task_type,
-								$agent_params,
-								array(
-									'agent_id' => $agent_id,
-									'user_id'  => $owner_id,
-								)
-							);
-						}
-						return;
-					}
-
-					TaskScheduler::schedule( $task_type, $params );
+			$dispatch_schedule = static function () use ( $schedule_id, $task_type ): void {
+				$def = RecurringScheduleRegistry::get( $schedule_id );
+				if ( null === $def ) {
+					return;
 				}
-			);
+
+				$params = $def['task_params'] ?? array();
+				if ( ! empty( $def['task_params_callback'] ) && is_callable( $def['task_params_callback'] ) ) {
+					$params = (array) call_user_func( $def['task_params_callback'] );
+				}
+
+				if ( ! empty( $def['per_agent'] ) ) {
+					$agents_repo = new Agents();
+					$agents      = $agents_repo->get_all();
+
+					if ( empty( $agents ) ) {
+						// No agents on this install — fall back to a
+						// single site-scoped run so the task still
+						// fires (mirrors pre-multi-agent behaviour).
+						TaskScheduler::schedule( $task_type, $params );
+						return;
+					}
+
+					foreach ( $agents as $agent ) {
+						$agent_id = (int) ( $agent['agent_id'] ?? 0 );
+						$owner_id = (int) ( $agent['owner_id'] ?? 0 );
+
+						if ( $agent_id <= 0 ) {
+							continue;
+						}
+
+						$agent_params             = $params;
+						$agent_params['agent_id'] = $agent_id;
+						$agent_params['user_id']  = $owner_id;
+
+						TaskScheduler::schedule(
+							$task_type,
+							$agent_params,
+							array(
+								'agent_id' => $agent_id,
+								'user_id'  => $owner_id,
+							)
+						);
+					}
+					return;
+				}
+
+				TaskScheduler::schedule( $task_type, $params );
+			};
+
+			add_action( $hook, $dispatch_schedule );
+			if ( $legacy_hook !== $hook ) {
+				add_action( $legacy_hook, $dispatch_schedule );
+			}
 		}
 	}
 
@@ -330,8 +333,9 @@ class SystemAgentServiceProvider {
 		}
 
 		foreach ( RecurringScheduleRegistry::all() as $schedule ) {
-			$hook    = RecurringScheduleRegistry::hookFor( $schedule );
-			$enabled = RecurringScheduleRegistry::isEnabled( $schedule );
+			$hook        = RecurringScheduleRegistry::hookFor( $schedule );
+			$legacy_hook = RecurringScheduleRegistry::legacyHookFor( $schedule );
+			$enabled     = RecurringScheduleRegistry::isEnabled( $schedule );
 
 			$options = array();
 			if ( ! empty( $schedule['cron_expression'] ) ) {
@@ -351,6 +355,10 @@ class SystemAgentServiceProvider {
 				$options,
 				$enabled
 			);
+
+			if ( $legacy_hook !== $hook ) {
+				RecurringScheduler::unschedule( $legacy_hook, array() );
+			}
 
 			if ( $result instanceof \WP_Error ) {
 				do_action(

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -69,8 +69,8 @@ abstract class SystemTask {
 				array(
 					'type'               => 'system_task',
 					'flow_step_settings' => array(
-						'task'   => $this->getTaskType(),
-						'params' => $params,
+						'task_type' => $this->getTaskType(),
+						'params'    => $params,
 					),
 				),
 			),

--- a/inc/Engine/Tasks/RecurringScheduleRegistry.php
+++ b/inc/Engine/Tasks/RecurringScheduleRegistry.php
@@ -127,14 +127,38 @@ class RecurringScheduleRegistry {
 	/**
 	 * The Action Scheduler hook that fires for this schedule.
 	 *
-	 * All scheduled hooks share a single naming convention so external
-	 * code can reliably target them.
+	 * Hooks are schedule-scoped, not task-scoped. A task can have multiple
+	 * recurring schedules with different params/cadences, so the hook must
+	 * identify the schedule binding that fired.
 	 *
 	 * @param array $schedule Normalized schedule definition.
 	 * @return string
 	 */
 	public static function hookFor( array $schedule ): string {
-		return 'datamachine_recurring_' . $schedule['task_type'];
+		$schedule_id = $schedule['schedule_id'] ?? '';
+		return 'datamachine_recurring_' . self::sanitizeHookSuffix( (string) $schedule_id );
+	}
+
+	/**
+	 * Legacy task-scoped Action Scheduler hook used before schedule ids were canonical.
+	 *
+	 * @param array $schedule Normalized schedule definition.
+	 * @return string Legacy hook name.
+	 */
+	public static function legacyHookFor( array $schedule ): string {
+		return 'datamachine_recurring_' . self::sanitizeHookSuffix( (string) $schedule['task_type'] );
+	}
+
+	/**
+	 * Normalize a schedule/task id for an Action Scheduler hook suffix.
+	 *
+	 * @param string $value Raw schedule or task identifier.
+	 * @return string Hook-safe suffix.
+	 */
+	private static function sanitizeHookSuffix( string $value ): string {
+		$value = strtolower( $value );
+		$value = preg_replace( '/[^a-z0-9_\-]/', '_', $value );
+		return trim( (string) $value, '_' );
 	}
 
 	/**

--- a/tests/Unit/Engine/AI/System/Tasks/ImageGenerationTaskTest.php
+++ b/tests/Unit/Engine/AI/System/Tasks/ImageGenerationTaskTest.php
@@ -58,7 +58,7 @@ class ImageGenerationTaskTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'steps', $workflow );
 		$this->assertCount( 1, $workflow['steps'] );
 		$this->assertSame( 'system_task', $workflow['steps'][0]['type'] );
-		$this->assertSame( 'image_generation', $workflow['steps'][0]['flow_step_settings']['task'] );
+		$this->assertSame( 'image_generation', $workflow['steps'][0]['flow_step_settings']['task_type'] );
 	}
 
 	public function test_execute_task_fails_when_image_file_missing(): void {

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -188,8 +188,8 @@ $array_bundle = array(
 					'execution_order'    => 2,
 					'step_type'          => 'system_task',
 					'flow_step_settings' => array(
-						'task'   => 'wiki_graph_extract',
-						'params' => array(
+						'task_type' => 'wiki_graph_extract',
+						'params'    => array(
 							'root'    => 'wordpress-com',
 							'limit'   => 5,
 							'dry_run' => true,
@@ -236,7 +236,7 @@ assert_adapter_equals( 'flow document preserves completion assertions', array( '
 assert_adapter_equals( 'flow document preserves tool runtime rules', 4, $flow['steps'][1]['tool_runtime_rules'][0]['max_calls'] ?? null );
 assert_adapter_equals( 'flow document preserves prompt queue', 'Review PR #1', $flow['steps'][1]['prompt_queue'][0]['prompt'] );
 assert_adapter_equals( 'flow document preserves queue mode', 'loop', $flow['steps'][1]['queue_mode'] );
-assert_adapter_equals( 'flow document preserves system task settings', 'wiki_graph_extract', $flow['steps'][2]['flow_step_settings']['task'] ?? null );
+assert_adapter_equals( 'flow document preserves system task settings', 'wiki_graph_extract', $flow['steps'][2]['flow_step_settings']['task_type'] ?? null );
 assert_adapter_equals( 'flow document preserves scheduling interval', 'hourly', $flow['schedule'] );
 assert_adapter_equals( 'memory path moves agent files under memory/agent', "# Soul\n", $directory->memory_files()['agent/SOUL.md'] ?? null );
 
@@ -279,7 +279,7 @@ assert_adapter_equals( 'round-trip preserves completion assertions', array( 'cre
 assert_adapter_equals( 'round-trip preserves tool runtime rules', array( 'workspace_edit', 'create_github_issue' ), $round_steps[1]['tool_runtime_rules'][0]['then_require_one_of'] ?? null );
 assert_adapter_equals( 'round-trip preserves prompt queue', 'Review PR #1', $round_steps[1]['prompt_queue'][0]['prompt'] );
 assert_adapter_equals( 'round-trip preserves queue mode', 'loop', $round_steps[1]['queue_mode'] );
-assert_adapter_equals( 'round-trip preserves system task settings', 'wiki_graph_extract', $round_steps[2]['flow_step_settings']['task'] ?? null );
+assert_adapter_equals( 'round-trip preserves system task settings', 'wiki_graph_extract', $round_steps[2]['flow_step_settings']['task_type'] ?? null );
 assert_adapter_equals( 'round-trip preserves system task params', 'wordpress-com', $round_steps[2]['flow_step_settings']['params']['root'] ?? null );
 assert_adapter_equals( 'round-trip preserves scheduling interval', 'hourly', $round_flow['scheduling_config']['interval'] );
 

--- a/tests/recurring-schedule-registry-contract-smoke.php
+++ b/tests/recurring-schedule-registry-contract-smoke.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Pure-PHP smoke for recurring schedule hook contracts.
+ *
+ * Run with: php tests/recurring-schedule-registry-contract-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value ) {
+		if ( 'datamachine_recurring_schedules' !== $hook ) {
+			return $value;
+		}
+
+		return array(
+			'cleanup_fast' => array(
+				'task_type' => 'cleanup',
+				'interval'  => 'hourly',
+			),
+			'cleanup_slow' => array(
+				'task_type' => 'cleanup',
+				'interval'  => 'daily',
+			),
+		);
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Engine/Tasks/RecurringScheduleRegistry.php';
+
+use DataMachine\Engine\Tasks\RecurringScheduleRegistry;
+
+function datamachine_recurring_contract_assert_same( $expected, $actual, string $message, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		echo "  [PASS] {$message}\n";
+		++$passes;
+		return;
+	}
+
+	echo "  [FAIL] {$message}\n";
+	echo '         expected: ' . var_export( $expected, true ) . "\n";
+	echo '         actual:   ' . var_export( $actual, true ) . "\n";
+	$failures[] = $message;
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "=== recurring-schedule-registry-contract-smoke ===\n";
+
+$schedules = RecurringScheduleRegistry::all();
+
+echo "\n[1] hooks are schedule-scoped\n";
+datamachine_recurring_contract_assert_same( 'datamachine_recurring_cleanup_fast', RecurringScheduleRegistry::hookFor( $schedules['cleanup_fast'] ), 'fast cleanup schedule gets unique hook', $failures, $passes );
+datamachine_recurring_contract_assert_same( 'datamachine_recurring_cleanup_slow', RecurringScheduleRegistry::hookFor( $schedules['cleanup_slow'] ), 'slow cleanup schedule gets unique hook', $failures, $passes );
+
+echo "\n[2] legacy task-scoped hook remains discoverable for migration\n";
+datamachine_recurring_contract_assert_same( 'datamachine_recurring_cleanup', RecurringScheduleRegistry::legacyHookFor( $schedules['cleanup_fast'] ), 'legacy hook is task-scoped', $failures, $passes );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAILED: " . count( $failures ) . " recurring schedule contract assertion(s) failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} recurring schedule contract assertions passed.\n";

--- a/tests/system-task-config-passthrough-smoke.php
+++ b/tests/system-task-config-passthrough-smoke.php
@@ -89,21 +89,21 @@ $built = build_configs_from_workflow_for_test(
 			array(
 				'type'           => 'system_task',
 				'flow_step_settings' => array(
-					'task'   => 'daily_memory_generation',
-					'params' => array(),
+					'task_type' => 'daily_memory_generation',
+					'params'    => array(),
 				),
 			),
 		),
 	)
 );
 $step0 = $built['flow_config']['ephemeral_step_0'];
-assert_equals( array( 'task' => 'daily_memory_generation', 'params' => array() ), FlowStepConfig::getPrimaryHandlerConfig( $step0 ), 'system_task config reachable', $failures, $passes );
+assert_equals( array( 'task_type' => 'daily_memory_generation', 'params' => array() ), FlowStepConfig::getPrimaryHandlerConfig( $step0 ), 'system_task config reachable', $failures, $passes );
 assert_equals( 'system_task', FlowStepConfig::getEffectiveSlug( $step0 ), 'system_task settings slug is step_type', $failures, $passes );
 assert_absent( 'handler_slug', $step0, 'system_task has no handler_slug', $failures, $passes );
 assert_absent( 'handler_slugs', $step0, 'system_task has no handler_slugs', $failures, $passes );
 assert_absent( 'handler_config', $step0, 'system_task has no handler_config', $failures, $passes );
 assert_absent( 'handler_configs', $step0, 'system_task has no handler_configs', $failures, $passes );
-assert_equals( array( 'task' => 'daily_memory_generation', 'params' => array() ), $step0['flow_step_settings'] ?? array(), 'system_task stores flow_step_settings', $failures, $passes );
+assert_equals( array( 'task_type' => 'daily_memory_generation', 'params' => array() ), $step0['flow_step_settings'] ?? array(), 'system_task stores flow_step_settings', $failures, $passes );
 
 echo "\n[2] fetch stores handler_slugs + handler_configs:\n";
 $built = build_configs_from_workflow_for_test(

--- a/tests/system-task-config-passthrough-smoke.php
+++ b/tests/system-task-config-passthrough-smoke.php
@@ -174,10 +174,10 @@ echo "\n[6] normalize canonical rows without cross-shape inference:\n";
 $system_task = FlowStepConfig::normalizeHandlerShape(
 	array(
 		'step_type'      => 'system_task',
-		'handler_config' => array( 'task' => 'agent_call' ),
+		'handler_config' => array( 'task_type' => 'agent_call' ),
 	)
 );
-assert_equals( array( 'task' => 'agent_call' ), $system_task['flow_step_settings'] ?? array(), 'legacy system_task config normalizes to flow_step_settings', $failures, $passes );
+assert_equals( array( 'task_type' => 'agent_call' ), $system_task['flow_step_settings'] ?? array(), 'system_task config normalizes to flow_step_settings', $failures, $passes );
 assert_absent( 'handler_config', $system_task, 'system_task scalar handler_config is removed', $failures, $passes );
 assert_absent( 'handler_slugs', $system_task, 'system_task slugs remain absent', $failures, $passes );
 

--- a/tests/system-task-contract-smoke.php
+++ b/tests/system-task-contract-smoke.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Pure-PHP smoke for the public SystemTask contract.
+ *
+ * Run with: php tests/system-task-contract-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$root = dirname( __DIR__ );
+
+function datamachine_contract_assert_contains( string $haystack, string $needle, string $message, array &$failures, int &$passes ): void {
+	if ( str_contains( $haystack, $needle ) ) {
+		echo "  [PASS] {$message}\n";
+		++$passes;
+		return;
+	}
+
+	echo "  [FAIL] {$message}\n";
+	$failures[] = $message;
+}
+
+$system_task = file_get_contents( $root . '/inc/Engine/AI/System/Tasks/SystemTask.php' ) ?: '';
+$step        = file_get_contents( $root . '/inc/Core/Steps/SystemTask/SystemTaskStep.php' ) ?: '';
+$settings    = file_get_contents( $root . '/inc/Core/Steps/SystemTask/SystemTaskSettings.php' ) ?: '';
+
+$failures = array();
+$passes   = 0;
+
+echo "=== system-task-contract-smoke ===\n";
+
+echo "\n[1] task_type is the canonical workflow/settings key\n";
+datamachine_contract_assert_contains( $system_task, "'task_type' => \$this->getTaskType()", 'SystemTask::getWorkflow writes task_type', $failures, $passes );
+datamachine_contract_assert_contains( $settings, "'task_type' => array", 'SystemTaskSettings exposes task_type field', $failures, $passes );
+datamachine_contract_assert_contains( $settings, "\$raw_settings['task_type'] = \$raw_settings['task'];", 'SystemTaskSettings maps legacy task to task_type on sanitize', $failures, $passes );
+
+echo "\n[2] legacy task key remains readable\n";
+datamachine_contract_assert_contains( $step, "\$settings['task_type'] ?? ( \$settings['task'] ?? '' )", 'SystemTaskStep reads task_type with task fallback', $failures, $passes );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAILED: " . count( $failures ) . " system task contract assertion(s) failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} system task contract assertions passed.\n";

--- a/tests/system-task-contract-smoke.php
+++ b/tests/system-task-contract-smoke.php
@@ -36,10 +36,9 @@ echo "=== system-task-contract-smoke ===\n";
 echo "\n[1] task_type is the canonical workflow/settings key\n";
 datamachine_contract_assert_contains( $system_task, "'task_type' => \$this->getTaskType()", 'SystemTask::getWorkflow writes task_type', $failures, $passes );
 datamachine_contract_assert_contains( $settings, "'task_type' => array", 'SystemTaskSettings exposes task_type field', $failures, $passes );
-datamachine_contract_assert_contains( $settings, "\$raw_settings['task_type'] = \$raw_settings['task'];", 'SystemTaskSettings maps legacy task to task_type on sanitize', $failures, $passes );
 
-echo "\n[2] legacy task key remains readable\n";
-datamachine_contract_assert_contains( $step, "\$settings['task_type'] ?? ( \$settings['task'] ?? '' )", 'SystemTaskStep reads task_type with task fallback', $failures, $passes );
+echo "\n[2] system task step reads only task_type\n";
+datamachine_contract_assert_contains( $step, "\$settings['task_type'] ?? ''", 'SystemTaskStep reads task_type directly', $failures, $passes );
 
 if ( ! empty( $failures ) ) {
 	echo "\nFAILED: " . count( $failures ) . " system task contract assertion(s) failed.\n";

--- a/tests/system-task-workflow-validation-smoke.php
+++ b/tests/system-task-workflow-validation-smoke.php
@@ -90,8 +90,8 @@ $wf = array(
 		array(
 			'type'               => 'system_task',
 			'flow_step_settings' => array(
-				'task'   => 'daily_memory_generation',
-				'params' => array(),
+				'task_type' => 'daily_memory_generation',
+				'params'     => array(),
 			),
 		),
 	),
@@ -145,7 +145,7 @@ $wf = array(
 	'steps' => array(
 		array( 'type' => 'fetch', 'handler_slug' => 'rss' ),
 		array( 'type' => 'ai' ),
-		array( 'type' => 'system_task', 'flow_step_settings' => array( 'task' => 'cleanup' ) ),
+		array( 'type' => 'system_task', 'flow_step_settings' => array( 'task_type' => 'cleanup' ) ),
 	),
 );
 $r = validate_workflow_for_test( $wf );
@@ -185,8 +185,8 @@ $wf = array(
 		array(
 			'type'               => 'system_task',
 			'flow_step_settings' => array(
-				'task'   => 'daily_memory_generation',
-				'params' => array( 'date' => '2026-04-24' ),
+				'task_type' => 'daily_memory_generation',
+				'params'     => array( 'date' => '2026-04-24' ),
 			),
 		),
 	),

--- a/tests/tool-policy-resolver-adjacency-smoke.php
+++ b/tests/tool-policy-resolver-adjacency-smoke.php
@@ -170,7 +170,7 @@ $args         = array(
 	'previous_step_config' => array(
 		'flow_step_id'    => 'flow_sys_1',
 		'step_type'       => 'system_task',
-		'flow_step_settings' => array( 'task' => 'daily_memory_generation', 'params' => array() ),
+		'flow_step_settings' => array( 'task_type' => 'daily_memory_generation', 'params' => array() ),
 	),
 	'next_step_config'     => null,
 );
@@ -195,7 +195,7 @@ $args         = array(
 	'next_step_config'     => array(
 		'flow_step_id'    => 'flow_sys_2',
 		'step_type'       => 'system_task',
-		'flow_step_settings' => array( 'task' => 'agent_call', 'params' => array() ),
+		'flow_step_settings' => array( 'task_type' => 'agent_call', 'params' => array() ),
 	),
 );
 $tools = gather_pipeline_handler_tools_for_test( $args, $tool_manager );

--- a/tests/workflow-spec-contract-smoke.php
+++ b/tests/workflow-spec-contract-smoke.php
@@ -140,7 +140,7 @@ $valid_workflow = array(
 	'steps' => array(
 		array( 'type' => 'fetch' ),
 		array( 'type' => 'ai' ),
-		array( 'type' => 'system_task', 'flow_step_settings' => array( 'task' => 'daily_memory_generation' ) ),
+		array( 'type' => 'system_task', 'flow_step_settings' => array( 'task_type' => 'daily_memory_generation' ) ),
 	),
 );
 
@@ -176,7 +176,7 @@ $configs         = WorkflowConfigFactory::buildEphemeralConfigs(
 			array(
 				'type'           => 'system_task',
 				'label'          => 'Cleanup',
-				'flow_step_settings' => array( 'task' => 'retention_logs' ),
+				'flow_step_settings' => array( 'task_type' => 'retention_logs' ),
 			),
 		),
 	)


### PR DESCRIPTION
## Summary
- Make `task_type` the only accepted system task step setting; older `task` configs must be upgraded instead of silently mapped.
- Scope recurring task hooks by schedule id and unschedule old task-scoped hooks during reconciliation without continuing to execute them.
- Refresh system task docs and add smoke coverage for the canonical contracts.

## Testing
- `php tests/system-task-contract-smoke.php`
- `php tests/recurring-schedule-registry-contract-smoke.php`
- `php tests/system-task-workflow-validation-smoke.php`
- `php tests/workflow-spec-contract-smoke.php`
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `php tests/system-task-config-passthrough-smoke.php`
- `php tests/tool-policy-resolver-adjacency-smoke.php`
- `php tests/system-task-output-packets-smoke.php`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main` — 864 tests, 2554 assertions

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Audited the system task architecture, drafted the refactor and tests, and ran verification. Chris remains responsible for review and merge.