### PR TITLE
Fix execute-workflow system task settings

### DIFF
--- a/inc/Core/Steps/SystemTask/SystemTaskStep.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskStep.php
@@ -479,7 +479,7 @@ class SystemTaskStep extends Step {
 	 * @return string Configured task type, or empty string.
 	 */
 	private static function getConfiguredTaskType( array $settings ): string {
-		$task_type = $settings['task_type'] ?? '';
+		$task_type = $settings['task_type'] ?? ( $settings['task'] ?? '' );
 		return is_string( $task_type ) ? $task_type : '';
 	}
 }

--- a/inc/Core/Steps/WorkflowConfigFactory.php
+++ b/inc/Core/Steps/WorkflowConfigFactory.php
@@ -150,6 +150,10 @@ class WorkflowConfigFactory {
 			}
 		}
 
+		if ( 'system_task' === $step_type && is_array( $step['flow_step_settings'] ?? null ) ) {
+			$pipeline_step['flow_step_settings'] = $step['flow_step_settings'];
+		}
+
 		return $pipeline_step;
 	}
 

--- a/tests/Unit/Engine/AI/System/Tasks/AltTextTaskTest.php
+++ b/tests/Unit/Engine/AI/System/Tasks/AltTextTaskTest.php
@@ -21,7 +21,6 @@ class AltTextTaskTest extends WP_UnitTestCase {
 	private string $test_image_path;
 
 	public function set_up(): void {
-		global $wp_filesystem;
 		parent::set_up();
 		$this->task = new AltTextTask();
 
@@ -33,7 +32,7 @@ class AltTextTaskTest extends WP_UnitTestCase {
 		
 		// Create a minimal JPEG file
 		$jpeg_data = base64_decode( '/9j/4AAQSkZJRgABAQEAAAAAAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwA/3/AD' );
-		$wp_filesystem->put_contents( $this->test_image_path, $jpeg_data );
+		file_put_contents( $this->test_image_path, $jpeg_data );
 
 		// Create attachment
 		$this->attachment_id = self::factory()->attachment->create_object( [

--- a/tests/workflow-spec-contract-smoke.php
+++ b/tests/workflow-spec-contract-smoke.php
@@ -194,7 +194,16 @@ assert_workflow_spec_equals( array( 'danger_tool' ), $pipeline_steps[1]['disable
 assert_workflow_spec_equals( array( 'required_tool_names' => array( 'publish_result' ) ), $pipeline_steps[1]['completion_assertions'] ?? null, 'ephemeral pipeline_config preserves AI completion assertions', $failures, $passes );
 assert_workflow_spec_equals( array( array( 'id' => 'after-worktree', 'max_calls' => 4 ) ), $pipeline_steps[1]['tool_runtime_rules'] ?? null, 'ephemeral pipeline_config preserves AI tool runtime rules', $failures, $passes );
 assert_workflow_spec_equals( 'Cleanup', $pipeline_steps[2]['label'] ?? null, 'ephemeral pipeline_config preserves system_task label', $failures, $passes );
+assert_workflow_spec_equals( array( 'task_type' => 'retention_logs' ), $pipeline_steps[2]['flow_step_settings'] ?? null, 'ephemeral pipeline_config preserves system_task settings', $failures, $passes );
 assert_workflow_spec_equals( false, array_key_exists( 'system_prompt', $pipeline_steps[2] ), 'non-AI ephemeral pipeline rows do not gain AI metadata', $failures, $passes );
+
+$legacy_task_workflow = array(
+	'steps' => array(
+		array( 'type' => 'system_task', 'flow_step_settings' => array( 'task' => 'retention_logs' ) ),
+	),
+);
+$legacy_configs       = WorkflowConfigFactory::buildEphemeralConfigs( $legacy_task_workflow );
+assert_workflow_spec_equals( array( 'task' => 'retention_logs' ), array_values( $legacy_configs['pipeline_config'] )[0]['flow_step_settings'] ?? null, 'ephemeral pipeline_config preserves legacy task settings', $failures, $passes );
 
 $execute_source  = file_get_contents( __DIR__ . '/../inc/Abilities/Job/ExecuteWorkflowAbility.php' ) ?: '';
 $pipeline_source = file_get_contents( __DIR__ . '/../inc/Abilities/Pipeline/PipelineHelpers.php' ) ?: '';


### PR DESCRIPTION
## Summary
- Preserve `flow_step_settings` on ephemeral `system_task` pipeline rows built from workflow specs.
- Keep legacy `task` settings readable while `task_type` remains canonical.
- Extend workflow spec smoke coverage so execute-workflow system tasks keep their task config.

## Verification
- `php tests/workflow-spec-contract-smoke.php`
- `php tests/system-task-config-passthrough-smoke.php`
- `php tests/system-task-workflow-validation-smoke.php`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the iterator failure, drafted the workflow config fix and regression coverage, and ran scoped verification; Chris remains responsible for review and merge decisions.