### PR TITLE
feat(engine): add datamachine_engine_snapshot filter at job init

### DIFF
--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -244,6 +244,30 @@ class RunFlowAbility {
 			$engine_snapshot = array_merge( $existing_data, $engine_snapshot );
 		}
 
+		/**
+		 * Filter the engine snapshot before it is persisted for a new job.
+		 *
+		 * Lets extensions enrich the engine_data snapshot with context that
+		 * lives outside DM core. For example, Data Machine Code projects the
+		 * active workspace identity (repo, handle, branch, path) into
+		 * `active_workspace` so directives, abilities, and tool calls can
+		 * read which repo the current job is operating against.
+		 *
+		 * Filters MUST return an array. Returning a non-array silently
+		 * preserves the prior snapshot.
+		 *
+		 * @since 0.10.3
+		 *
+		 * @param array $engine_snapshot The snapshot about to be persisted.
+		 * @param int   $job_id          Job being initialized.
+		 * @param array $flow            Flow row from the database.
+		 * @param array $pipeline        Pipeline row from the database.
+		 */
+		$filtered_snapshot = apply_filters( 'datamachine_engine_snapshot', $engine_snapshot, $job_id, $flow, $pipeline );
+		if ( is_array( $filtered_snapshot ) ) {
+			$engine_snapshot = $filtered_snapshot;
+		}
+
 		datamachine_set_engine_data( $job_id, $engine_snapshot );
 
 		try {


### PR DESCRIPTION
Adds a one-line extension point to \`RunFlowAbility::execute()\` so downstream plugins can enrich the engine snapshot at job initialization without forking DM or building parallel persistence machinery.

## Motivation

DM core has no way for an external plugin to inject runtime context into a job's \`engine_data\` at the moment the job is created. Today the only public path is the \`initial_data\` input on \`run-flow\` — which is fine when the *caller* knows the context, but useless for cases where the context lives in a *third* plugin that the caller doesn't know about.

Concrete driver: Data Machine Code already tracks every workspace and worktree's identity (\`WorktreeContextInjector\`), but that knowledge never reaches AI directives, abilities, or tool calls during a job because there's no point in the run-flow pipeline where DMC can stamp \"hey, this job is bound to \`extrachill-artist-platform@docs/agent-run-123\`\" into \`engine_data\`. See Extra-Chill/data-machine-code#423.

## What this adds

One \`apply_filters()\` call at the right spot:

\`\`\`php
\$filtered_snapshot = apply_filters( 'datamachine_engine_snapshot', \$engine_snapshot, \$job_id, \$flow, \$pipeline );
if ( is_array( \$filtered_snapshot ) ) {
    \$engine_snapshot = \$filtered_snapshot;
}
\`\`\`

Fires immediately before \`datamachine_set_engine_data()\`. Filters receive the assembled snapshot, the job ID, and the source flow + pipeline rows. Returning a modified array enriches the snapshot. Returning a non-array silently preserves the prior snapshot so a misbehaving filter cannot corrupt \`engine_data\`.

## Why this shape

| Alternative considered | Why rejected |
|------------------------|--------------|
| New schema / table for \"runtime context\" | Massive overkill for what's a one-time-per-job context attachment |
| New CLI surface | No reason — the filter is invisible to operators |
| New ability | Same job/snapshot context, abilities can't observe the in-flight assembly |
| Action hook only (no return value) | Filters compose better — multiple plugins can stack enrichments |
| Filter after persist | Too late — \`engine_data\` is already the source of truth by then |

The filter pattern matches existing DM conventions (\`datamachine_directives\`, \`datamachine_memory_files\`, \`datamachine_agent_modes\`, \`datamachine_agent_mode_{slug}\`). One line, fully backward-compatible — DM runs unchanged with no callbacks registered.

## Downstream consumers

- **Data Machine Code** — projects \`active_workspace\` (repo, handle, branch, path, origin metadata) into the snapshot when callers pass a workspace handle via \`initial_data.active_workspace.handle\`. See Extra-Chill/data-machine-code#423 + its companion PR.
- **Future**: any plugin that has per-run context it wants visible to AI directives — security scoping, audit attribution, environment tagging, etc.

## Smoke testing

\`php -l\` clean. Pattern is structurally identical to the existing \`datamachine_directives\` filter loop already in DM; no new code paths.

End-to-end smoke (a filter callback that mutates \`engine_data\` and an AI step reading it back) is exercised by the companion DMC PR's projector against the artist-platform docs-agent pilot.

## Scope

One file, one filter, 24 net lines (mostly the docblock). No tests added in this PR because the change is purely a passthrough; the actual behavior under test belongs to the downstream consumer.

Refs Extra-Chill/data-machine-code#423
Refs Extra-Chill/extrachill-docs#31