### PR TITLE
ci: restore release-asset.yml as Playground unblock

### DIFF
--- a/.github/workflows/release-asset.yml
+++ b/.github/workflows/release-asset.yml
@@ -1,0 +1,79 @@
+name: Release asset
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to (re)build and upload an asset for.'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-release-asset:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [ -n "${{ github.event.release.tag_name }}" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer:v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - run: composer install --no-dev --optimize-autoloader --prefer-dist --no-interaction
+      - run: npm ci
+      - run: npm run build
+
+      - name: Build plugin ZIP
+        run: |
+          mkdir -p dist/data-machine
+          rsync -a ./ dist/data-machine/ \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='.claude' \
+            --exclude='.datamachine' \
+            --exclude='AGENTS.md' \
+            --exclude='dist' \
+            --exclude='docs' \
+            --exclude='node_modules' \
+            --exclude='tests' \
+            --exclude='.buildignore' \
+            --exclude='*.zip' \
+            --exclude='*.tar.gz' \
+            --exclude='*.log' \
+            --exclude='*.tmp' \
+            --exclude='*.temp' \
+            --exclude='*.cache' \
+            --exclude='*.bak' \
+            --exclude='*.backup' \
+            --exclude='package-lock.json' \
+            --exclude='package.json' \
+            --exclude='webpack.config.js' \
+            --exclude='jsconfig.json' \
+            --exclude='phpstan-baseline.neon' \
+            --exclude='phpunit.xml*'
+          cd dist
+          zip -r data-machine.zip data-machine
+
+      - run: gh release upload "${{ steps.tag.outputs.tag }}" dist/data-machine.zip --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Bridge until [homeboy#2581](https://github.com/Extra-Chill/homeboy/issues/2581) (full dogfooding refactor) lands. Restores the standalone `release-asset.yml` workflow that was deleted in PR #2055.

## Why

The homeboy-native release workflow correctly bumps versions, generates changelogs, tags, and pushes — but **produces zero release assets** because homeboy-action's `run-release.sh` hardcodes `--skip-publish --no-github-release`. The wordpress extension's `release.publish` action never runs, so the release ZIP is never attached to the GitHub Release.

Result: Playground blueprint `installPlugin` from `releases/latest/download/data-machine.zip` returns 404, breaking every browser-based DM trial.

## What this restores

`.github/workflows/release-asset.yml` triggers on `release.published` (the event created by the homeboy pipeline when it creates the GitHub Release), then:

1. Re-checkouts at the tag
2. Runs `composer install --no-dev` + `npm run build`
3. Builds the vendor-bundled ZIP
4. Uploads via `gh release upload "$TAG" dist/data-machine.zip --clobber`

Parallel codepath alongside the homeboy-native `release.yml`. The homeboy pipeline tags + pushes + creates the GitHub Release entry. This workflow attaches the ZIP after.

## Temporary

Tracked in [homeboy#2581](https://github.com/Extra-Chill/homeboy/issues/2581). Once that issue's phases 2-4 land:
- Phase 2: `homeboy release --from-artifacts <dir>`
- Phase 3: refactor homeboy's release.yml
- Phase 4: switch homeboy-action's `--skip-publish` to opt-in

The homeboy-native pipeline ships ZIPs automatically via the wordpress extension's `release.publish`, and this restored `release-asset.yml` gets deleted again.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Restored the file from `git show b6edc981^:.github/workflows/release-asset.yml` (the commit before PR #2055 deleted it). Cross-referenced with the dogfooding issue homeboy#2581 to make the temporary nature explicit.