### PR TITLE
Require canonical system task type field

### DIFF
--- a/inc/Core/Steps/SystemTask/SystemTaskStep.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskStep.php
@@ -479,7 +479,7 @@ class SystemTaskStep extends Step {
 	 * @return string Configured task type, or empty string.
 	 */
 	private static function getConfiguredTaskType( array $settings ): string {
-		$task_type = $settings['task_type'] ?? ( $settings['task'] ?? '' );
+		$task_type = $settings['task_type'] ?? '';
 		return is_string( $task_type ) ? $task_type : '';
 	}
 }

--- a/tests/workflow-spec-contract-smoke.php
+++ b/tests/workflow-spec-contract-smoke.php
@@ -197,19 +197,13 @@ assert_workflow_spec_equals( 'Cleanup', $pipeline_steps[2]['label'] ?? null, 'ep
 assert_workflow_spec_equals( array( 'task_type' => 'retention_logs' ), $pipeline_steps[2]['flow_step_settings'] ?? null, 'ephemeral pipeline_config preserves system_task settings', $failures, $passes );
 assert_workflow_spec_equals( false, array_key_exists( 'system_prompt', $pipeline_steps[2] ), 'non-AI ephemeral pipeline rows do not gain AI metadata', $failures, $passes );
 
-$legacy_task_workflow = array(
-	'steps' => array(
-		array( 'type' => 'system_task', 'flow_step_settings' => array( 'task' => 'retention_logs' ) ),
-	),
-);
-$legacy_configs       = WorkflowConfigFactory::buildEphemeralConfigs( $legacy_task_workflow );
-assert_workflow_spec_equals( array( 'task' => 'retention_logs' ), array_values( $legacy_configs['pipeline_config'] )[0]['flow_step_settings'] ?? null, 'ephemeral pipeline_config preserves legacy task settings', $failures, $passes );
-
 $execute_source  = file_get_contents( __DIR__ . '/../inc/Abilities/Job/ExecuteWorkflowAbility.php' ) ?: '';
 $pipeline_source = file_get_contents( __DIR__ . '/../inc/Abilities/Pipeline/PipelineHelpers.php' ) ?: '';
+$system_task_source = file_get_contents( __DIR__ . '/../inc/Core/Steps/SystemTask/SystemTaskStep.php' ) ?: '';
 
 assert_workflow_spec_equals( 1, substr_count( $execute_source, 'WorkflowSpecValidator::validate' ), 'execute-workflow calls shared validator once', $failures, $passes );
 assert_workflow_spec_equals( 1, substr_count( $pipeline_source, 'WorkflowSpecValidator::validate' ), 'create-pipeline helper calls shared validator once', $failures, $passes );
+assert_workflow_spec_equals( 0, substr_count( $system_task_source, "['task']" ), 'system_task execution no longer accepts legacy task field', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " workflow spec assertions failed.\n";


### PR DESCRIPTION
## Summary
- Remove the legacy `flow_step_settings.task` fallback from `SystemTaskStep`.
- Keep system task workflow config on the canonical `flow_step_settings.task_type` field only.
- Update workflow contract smoke coverage to assert the legacy field is no longer accepted.

## Verification
- `php tests/workflow-spec-contract-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-execute-workflow-system-task-settings --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-execute-workflow-system-task-settings --extension wordpress --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small compatibility removal, updated smoke coverage, and ran local verification; Chris directed the change.