### PR TITLE
Refactor flow step config contract

### DIFF
--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -46,7 +46,7 @@ class ExecuteWorkflowAbility {
 								'properties'  => array(
 									'steps' => array(
 										'type'        => 'array',
-										'description' => __( 'Array of step objects with type, handler_slug, handler_config', 'data-machine' ),
+										'description' => __( 'Array of step objects with type, handler_slugs, handler_configs, and flow_step_settings', 'data-machine' ),
 									),
 								),
 							),

--- a/inc/Abilities/Pipeline/PipelineHelpers.php
+++ b/inc/Abilities/Pipeline/PipelineHelpers.php
@@ -237,17 +237,19 @@ trait PipelineHelpers {
 		$handler_abilities = new HandlerAbilities();
 
 		foreach ( $steps as $index => $step ) {
-			$handler_slug = $step['handler_slug'] ?? null;
-			if ( empty( $handler_slug ) ) {
+			$handler_slugs = FlowStepConfig::getConfiguredHandlerSlugs( $step );
+			if ( empty( $handler_slugs ) ) {
 				continue;
 			}
 
-			if ( ! $handler_abilities->handlerExists( $handler_slug ) ) {
-				return array(
-					'success'     => false,
-					'error'       => "Step at index {$index} has invalid handler_slug '{$handler_slug}'",
-					'remediation' => 'Use list_handlers tool to find valid handler slugs',
-				);
+			foreach ( $handler_slugs as $handler_slug ) {
+				if ( ! $handler_abilities->handlerExists( $handler_slug ) ) {
+					return array(
+						'success'     => false,
+						'error'       => "Step at index {$index} has invalid handler slug '{$handler_slug}'",
+						'remediation' => 'Use list_handlers tool to find valid handler slugs',
+					);
+				}
 			}
 		}
 

--- a/inc/Core/Steps/FlowStepConfig.php
+++ b/inc/Core/Steps/FlowStepConfig.php
@@ -2,7 +2,8 @@
 /**
  * Flow Step Config Utilities
  *
- * Static helpers for reading handler slugs and configs from step configuration arrays.
+ * Static helpers for reading canonical handler slugs and configs from step
+ * configuration arrays.
  *
  * @package DataMachine\Core\Steps
  * @since 0.39.0
@@ -150,8 +151,7 @@ class FlowStepConfig {
 			return $slugs;
 		}
 
-		$slug = $step_config['handler_slug'] ?? null;
-		return is_string( $slug ) && '' !== $slug ? array( $slug ) : array();
+		return array();
 	}
 
 	/**
@@ -287,7 +287,7 @@ class FlowStepConfig {
 			return self::getHandlerConfigForSlug( $step_config, $slug );
 		}
 
-		$config = $step_config['flow_step_settings'] ?? ( $step_config['handler_config'] ?? array() );
+		$config = $step_config['flow_step_settings'] ?? array();
 		return is_array( $config ) ? $config : array();
 	}
 
@@ -306,8 +306,7 @@ class FlowStepConfig {
 				return is_array( $config ) ? $config : array();
 			}
 
-			$config = ( $step_config['handler_slug'] ?? null ) === $slug ? ( $step_config['handler_config'] ?? array() ) : array();
-			return is_array( $config ) ? $config : array();
+			return array();
 		}
 
 		$effective_slug = self::getEffectiveSlug( $step_config );
@@ -353,8 +352,6 @@ class FlowStepConfig {
 	 */
 	public static function normalizeHandlerShape( array $step_config ): array {
 		$uses_handler    = self::usesHandler( $step_config );
-		$scalar_slug     = is_string( $step_config['handler_slug'] ?? null ) ? $step_config['handler_slug'] : '';
-		$scalar_config   = is_array( $step_config['handler_config'] ?? null ) ? $step_config['handler_config'] : array();
 		$step_settings   = is_array( $step_config['flow_step_settings'] ?? null ) ? $step_config['flow_step_settings'] : array();
 		$handler_slugs   = self::sanitizeSlugList( is_array( $step_config['handler_slugs'] ?? null ) ? $step_config['handler_slugs'] : array() );
 		$handler_configs = is_array( $step_config['handler_configs'] ?? null ) ? $step_config['handler_configs'] : array();
@@ -362,18 +359,10 @@ class FlowStepConfig {
 		unset( $step_config['handler'], $step_config['handler_slug'], $step_config['handler_slugs'], $step_config['handler_config'], $step_config['handler_configs'], $step_config['flow_step_settings'] );
 
 		if ( ! $uses_handler ) {
-			$settings = ! empty( $step_settings ) ? $step_settings : $scalar_config;
-			if ( ! empty( $settings ) ) {
-				$step_config['flow_step_settings'] = $settings;
+			if ( ! empty( $step_settings ) ) {
+				$step_config['flow_step_settings'] = $step_settings;
 			}
 			return $step_config;
-		}
-
-		if ( empty( $handler_slugs ) && '' !== $scalar_slug ) {
-			$handler_slugs = array( $scalar_slug );
-		}
-		if ( '' !== $scalar_slug && ! array_key_exists( $scalar_slug, $handler_configs ) ) {
-			$handler_configs[ $scalar_slug ] = $scalar_config;
 		}
 
 		if ( ! empty( $handler_slugs ) ) {

--- a/inc/Core/Steps/FlowStepConfigFactory.php
+++ b/inc/Core/Steps/FlowStepConfigFactory.php
@@ -43,8 +43,8 @@ class FlowStepConfigFactory {
 					'disabled_tools'     => $step['disabled_tools'] ?? array(),
 					'pipeline_id'        => 'direct',
 					'flow_id'            => 'direct',
-					'handler_slug'       => $step['handler_slug'] ?? '',
-					'handler_config'     => $step['handler_config'] ?? array(),
+					'handler_slugs'      => $step['handler_slugs'] ?? array(),
+					'handler_configs'    => $step['handler_configs'] ?? array(),
 					'flow_step_settings' => $step['flow_step_settings'] ?? array(),
 				)
 			)
@@ -131,20 +131,11 @@ class FlowStepConfigFactory {
 			}
 		}
 
-		$handler_slug       = $args['handler_slug'] ?? '';
-		$handler_config     = $args['handler_config'] ?? array();
 		$flow_step_settings = is_array( $args['flow_step_settings'] ?? null ) ? $args['flow_step_settings'] : array();
 		$handler_slugs      = is_array( $args['handler_slugs'] ?? null ) ? $args['handler_slugs'] : array();
 		$handler_configs    = is_array( $args['handler_configs'] ?? null ) ? $args['handler_configs'] : array();
 
 		if ( FlowStepConfig::usesHandler( $step_config ) ) {
-			if ( is_string( $handler_slug ) && '' !== $handler_slug ) {
-				$handler_slugs[] = $handler_slug;
-				if ( ! array_key_exists( $handler_slug, $handler_configs ) ) {
-					$handler_configs[ $handler_slug ] = $handler_config;
-				}
-			}
-
 			$step_config = FlowStepConfig::normalizeHandlerShape(
 				array_merge(
 					$step_config,
@@ -154,11 +145,8 @@ class FlowStepConfigFactory {
 					)
 				)
 			);
-		} else {
-			$settings = ! empty( $flow_step_settings ) ? $flow_step_settings : ( is_array( $handler_config ) ? $handler_config : array() );
-			if ( ! empty( $settings ) ) {
-				$step_config['flow_step_settings'] = $settings;
-			}
+		} elseif ( ! empty( $flow_step_settings ) ) {
+			$step_config['flow_step_settings'] = $flow_step_settings;
 		}
 
 		return $step_config;
@@ -216,7 +204,7 @@ class FlowStepConfigFactory {
 	 */
 	public static function withHandlerFields( array $step_config, array $handler_fields ): array {
 		$overlay = array();
-		foreach ( array( 'handler_slug', 'handler_slugs', 'handler_config', 'handler_configs', 'flow_step_settings' ) as $field ) {
+		foreach ( array( 'handler_slugs', 'handler_configs', 'flow_step_settings' ) as $field ) {
 			if ( array_key_exists( $field, $handler_fields ) ) {
 				$overlay[ $field ] = $handler_fields[ $field ];
 			}

--- a/inc/Engine/AI/Directives/AgentModeDirective.php
+++ b/inc/Engine/AI/Directives/AgentModeDirective.php
@@ -43,7 +43,7 @@ HANDLERS are the core intelligence. Fetch handlers extract and structure source 
 
 PIPELINES define workflow structure: step types in sequence (e.g., event_import → ai → upsert). The pipeline system_prompt defines AI behavior shared by all flows.
 
-FLOWS are configured pipeline instances. Handler-based single steps use handler_slug + handler_config; multi-handler steps use handler_slugs + handler_configs; handler-free steps only carry handler_config when they have settings. When creating flows, match handler configurations from existing flows on the same pipeline.
+FLOWS are configured pipeline instances. Handler-backed steps use handler_slugs + handler_configs; handler-free steps use flow_step_settings when they have settings. When creating flows, match handler configurations from existing flows on the same pipeline.
 
 AI STEPS process data that handlers cannot automatically handle. The pipeline system_prompt sets the agent's stable identity (shared across every flow). The flow's per-flow user message lives in the prompt_queue head — appended as the final user-role message after fetched data packets — use it for per-flow task framing on top of the pipeline system_prompt. The two are additive, not alternative. Set it via `flow update --set-user-message` (a 1-entry static queue) or `flow queue add` plus `flow queue mode <drain|loop|static>`.
 

--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -127,9 +127,6 @@ class ImportExport {
 			}
 
 			$settings = $row['settings'];
-			if ( '' !== $row['handler'] && empty( $settings['handler_slug'] ) && empty( $settings['handler_slugs'] ) ) {
-				$settings['handler_slug'] = $row['handler'];
-			}
 
 			try {
 				$this->restore_flow_step_config(

--- a/inc/Engine/Bundle/AgentBundleArrayAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleArrayAdapter.php
@@ -317,7 +317,7 @@ final class AgentBundleArrayAdapter {
 				$document_step['step_type'] = $pipeline_step_types_by_id[ $pipeline_step_id ];
 			}
 
-			foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'completion_assertions', 'tool_runtime_rules', 'enabled' ) as $field ) {
+			foreach ( array( 'step_type', 'handler_slugs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'completion_assertions', 'tool_runtime_rules', 'enabled' ) as $field ) {
 				if ( array_key_exists( $field, $step ) ) {
 					$document_step[ $field ] = $step[ $field ];
 				}
@@ -337,7 +337,7 @@ final class AgentBundleArrayAdapter {
 			'execution_order'  => (int) $step['step_position'],
 		);
 
-		foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'handler_config', 'handler_configs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'completion_assertions', 'tool_runtime_rules', 'enabled' ) as $field ) {
+		foreach ( array( 'step_type', 'handler_slugs', 'handler_configs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'completion_assertions', 'tool_runtime_rules', 'enabled' ) as $field ) {
 			if ( array_key_exists( $field, $step ) ) {
 				$config[ $field ] = $step[ $field ];
 			}
@@ -349,10 +349,6 @@ final class AgentBundleArrayAdapter {
 	private static function handler_configs_from_step( array $step ): array {
 		if ( is_array( $step['handler_configs'] ?? null ) ) {
 			return $step['handler_configs'];
-		}
-
-		if ( is_string( $step['handler_slug'] ?? null ) && is_array( $step['handler_config'] ?? null ) ) {
-			return array( $step['handler_slug'] => $step['handler_config'] );
 		}
 
 		return array();

--- a/inc/Engine/Bundle/AgentBundleFlowFile.php
+++ b/inc/Engine/Bundle/AgentBundleFlowFile.php
@@ -25,9 +25,7 @@ final class AgentBundleFlowFile {
 
 	private const OPTIONAL_STEP_FIELDS = array(
 		'step_type',
-		'handler_slug',
 		'handler_slugs',
-		'handler_config',
 		'flow_step_settings',
 		'enabled_tools',
 		'disabled_tools',
@@ -129,7 +127,7 @@ final class AgentBundleFlowFile {
 	}
 
 	private static function normalize_optional_step_field( string $field, $value ) {
-		if ( in_array( $field, array( 'step_type', 'handler_slug' ), true ) ) {
+		if ( 'step_type' === $field ) {
 			return (string) $value;
 		}
 
@@ -137,7 +135,7 @@ final class AgentBundleFlowFile {
 			return (bool) $value;
 		}
 
-		if ( in_array( $field, array( 'handler_config', 'flow_step_settings' ), true ) ) {
+		if ( 'flow_step_settings' === $field ) {
 			if ( ! is_array( $value ) ) {
 				throw new BundleValidationException( sprintf( 'flow file %s must be an object.', esc_html( $field ) ) );
 			}

--- a/tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php
@@ -361,8 +361,8 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
                     'execution_order'  => 0,
                     'pipeline_id'      => $pipeline_id,
                     'flow_id'          => $flow_id,
-                    'handler_slug'     => 'fake_fetch',
-                    'handler_config'   => array('source' => 'contract-test'),
+                    'handler_slugs'    => array('fake_fetch'),
+                    'handler_configs'  => array('fake_fetch' => array('source' => 'contract-test')),
                     'queue_mode'       => 'static',
                 )
             ),
@@ -391,8 +391,8 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
                     'execution_order'  => 2,
                     'pipeline_id'      => $pipeline_id,
                     'flow_id'          => $flow_id,
-                    'handler_slug'     => 'fake_publish',
-                    'handler_config'   => array('destination' => 'contract-test'),
+                    'handler_slugs'    => array('fake_publish'),
+                    'handler_configs'  => array('fake_publish' => array('destination' => 'contract-test')),
                 )
             ),
         );

--- a/tests/Unit/Cli/Commands/Flows/BulkConfigCommandTest.php
+++ b/tests/Unit/Cli/Commands/Flows/BulkConfigCommandTest.php
@@ -66,10 +66,12 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 					'pipeline_id'     => $this->pipeline_id,
 					'flow_id'         => $this->flow_id_1,
 					'execution_order' => 0,
-					'handler_slug'    => 'rss',
-					'handler_config'  => array(
-						'feed_url'  => 'https://example.com/feed',
-						'max_items' => 5,
+					'handler_slugs'   => array( 'rss' ),
+					'handler_configs' => array(
+						'rss' => array(
+							'feed_url'  => 'https://example.com/feed',
+							'max_items' => 5,
+						),
 					),
 				),
 			),
@@ -92,10 +94,12 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 					'pipeline_id'     => $this->pipeline_id,
 					'flow_id'         => $this->flow_id_2,
 					'execution_order' => 0,
-					'handler_slug'    => 'rss',
-					'handler_config'  => array(
-						'feed_url'  => 'https://example.com/other-feed',
-						'max_items' => 3,
+					'handler_slugs'   => array( 'rss' ),
+					'handler_configs' => array(
+						'rss' => array(
+							'feed_url'  => 'https://example.com/other-feed',
+							'max_items' => 3,
+						),
 					),
 				),
 			),

--- a/tests/Unit/Engine/ImportExportStepConfigTest.php
+++ b/tests/Unit/Engine/ImportExportStepConfigTest.php
@@ -173,10 +173,12 @@ class ImportExportStepConfigTest extends WP_UnitTestCase {
 		$source_flow      = $this->db_flows->get_flow( (int) $source_flow_id );
 		$flow_config      = $source_flow['flow_config'] ?? array();
 		$source_flow_step = apply_filters( 'datamachine_generate_flow_step_id', '', $source_step_id, (int) $source_flow_id );
-		$flow_config[ $source_flow_step ]['handler_slug']    = 'rss';
-		$flow_config[ $source_flow_step ]['handler_config']  = array(
-			'feed_url'  => 'https://example.com/feed',
-			'max_items' => 25,
+		$flow_config[ $source_flow_step ]['handler_slugs']   = array( 'rss' );
+		$flow_config[ $source_flow_step ]['handler_configs'] = array(
+			'rss' => array(
+				'feed_url'  => 'https://example.com/feed',
+				'max_items' => 25,
+			),
 		);
 		$flow_config[ $source_flow_step ]['enabled'] = true;
 		$this->db_flows->update_flow( (int) $source_flow_id, array( 'flow_config' => $flow_config ) );

--- a/tests/agent-bundle-format-smoke.php
+++ b/tests/agent-bundle-format-smoke.php
@@ -185,13 +185,13 @@ $flow = AgentBundleFlowFile::from_array(
 			),
 			array(
 				'step_position'   => 1,
-				'handler_slug'    => 'wordpress_publish',
+				'handler_slugs'   => array( 'wordpress_publish' ),
 				'handler_configs' => array( 'wordpress_publish' => array( 'post_type' => 'wiki' ) ),
 				'disabled_tools'  => array( 'datamachine/delete-flow' ),
 			),
 			array(
 				'step_position'   => 0,
-				'handler_slug'    => 'mcp',
+				'handler_slugs'   => array( 'mcp' ),
 				'handler_configs' => array( 'mcp' => array( 'auth_ref' => 'wpcom:default', 'provider' => 'mgs' ) ),
 				'config_patch_queue' => array(
 					array(
@@ -206,7 +206,7 @@ $flow = AgentBundleFlowFile::from_array(
 );
 $flow_array = $flow->to_array();
 assert_bundle_equals( 'flow references pipeline by slug, not source ID', 'wc-daily-ingest', $flow_array['pipeline_slug'] );
-assert_bundle_equals( 'flow step 0 first after normalization', 'mcp', $flow_array['steps'][0]['handler_slug'] );
+assert_bundle_equals( 'flow step 0 first after normalization', array( 'mcp' ), $flow_array['steps'][0]['handler_slugs'] );
 assert_bundle_equals( 'flow step preserves fetch config patch queue', array( 'after' => '2026-04-01' ), $flow_array['steps'][0]['config_patch_queue'][0]['patch'] );
 assert_bundle_equals( 'flow step preserves AI enabled tools', array( 'datamachine/get-github-pull-review-context' ), $flow_array['steps'][2]['enabled_tools'] );
 assert_bundle_equals( 'flow step preserves AI prompt queue', 'Review this PR.', $flow_array['steps'][2]['prompt_queue'][0]['prompt'] );

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -136,10 +136,12 @@ $array_bundle = array(
 					'pipeline_id'        => 88,
 					'flow_id'            => 144,
 					'execution_order'    => 0,
-					'handler_slug'       => 'mcp',
-					'handler_config'     => array(
-						'provider' => 'github',
-						'auth_ref' => 'github:default',
+					'handler_slugs'      => array( 'mcp' ),
+					'handler_configs'    => array(
+						'mcp' => array(
+							'provider' => 'github',
+							'auth_ref' => 'github:default',
+						),
 					),
 					'config_patch_queue' => array(
 						array(

--- a/tests/bulk-create-pipeline-workflow-smoke.php
+++ b/tests/bulk-create-pipeline-workflow-smoke.php
@@ -88,8 +88,8 @@ $workflow = array(
 		array(
 			'type'               => 'fetch',
 			'label'              => 'Fetch Context',
-			'handler_slug'       => 'mcp',
-			'handler_config'     => array( 'provider' => 'github', 'query' => 'repo:Extra-Chill/data-machine' ),
+			'handler_slugs'      => array( 'mcp' ),
+			'handler_configs'    => array( 'mcp' => array( 'provider' => 'github', 'query' => 'repo:Extra-Chill/data-machine' ) ),
 			'config_patch_queue' => array( array( 'patch' => array( 'query' => 'workflow spec' ), 'added_at' => '2026-04-27T00:00:00Z' ) ),
 			'queue_mode'         => 'drain',
 		),
@@ -127,8 +127,8 @@ $flow_steps      = array_values( $flow_config );
 
 assert_bulk_workflow_equals( 2, count( $pipeline_config ), 'bulk workflow creates persistent pipeline rows', $failures, $passes );
 assert_bulk_workflow_equals( 2, count( $flow_config ), 'bulk workflow creates persistent flow rows through shared factory', $failures, $passes );
-assert_bulk_workflow_equals( 'mcp', $flow_steps[0]['handler_slug'] ?? null, 'bulk workflow preserves handler slug', $failures, $passes );
-assert_bulk_workflow_equals( array( 'provider' => 'github', 'query' => 'repo:Extra-Chill/data-machine' ), $flow_steps[0]['handler_config'] ?? null, 'bulk workflow preserves handler config', $failures, $passes );
+assert_bulk_workflow_equals( array( 'mcp' ), $flow_steps[0]['handler_slugs'] ?? null, 'bulk workflow preserves handler slugs', $failures, $passes );
+assert_bulk_workflow_equals( array( 'mcp' => array( 'provider' => 'github', 'query' => 'repo:Extra-Chill/data-machine' ) ), $flow_steps[0]['handler_configs'] ?? null, 'bulk workflow preserves handler configs', $failures, $passes );
 assert_bulk_workflow_equals( array( 'query' => 'workflow spec' ), $flow_steps[0]['config_patch_queue'][0]['patch'] ?? null, 'bulk workflow preserves config patch queue', $failures, $passes );
 assert_bulk_workflow_equals( 'drain', $flow_steps[0]['queue_mode'] ?? null, 'bulk workflow preserves queue mode', $failures, $passes );
 assert_bulk_workflow_equals( array( 'datamachine/read-github-file' ), $flow_steps[1]['enabled_tools'] ?? null, 'bulk workflow preserves enabled tools', $failures, $passes );
@@ -138,10 +138,10 @@ assert_bulk_workflow_equals( 'Use the latest queue item.', $flow_steps[1]['promp
 $template_workflow = array(
 	'steps' => array(
 		array(
-			'type'          => 'publish',
-			'label'         => 'Template Publish',
-			'handler_slug'  => 'wordpress',
-			'handler_config' => array( 'post_type' => 'wiki' ),
+			'type'            => 'publish',
+			'label'           => 'Template Publish',
+			'handler_slugs'   => array( 'wordpress' ),
+			'handler_configs' => array( 'wordpress' => array( 'post_type' => 'wiki' ) ),
 		),
 	),
 );

--- a/tests/flow-step-config-factory-smoke.php
+++ b/tests/flow-step-config-factory-smoke.php
@@ -70,8 +70,6 @@ function assert_factory_equals( $expected, $actual, string $name, array &$failur
 function legacy_workflow_step_config_for_test( array $step, int $index ): array {
 	$step_id          = "ephemeral_step_{$index}";
 	$pipeline_step_id = "ephemeral_pipeline_{$index}";
-	$handler_slug     = $step['handler_slug'] ?? '';
-	$handler_config   = $step['handler_config'] ?? array();
 	$step_type        = $step['type'];
 	$prompt_queue     = array();
 
@@ -97,21 +95,21 @@ function legacy_workflow_step_config_for_test( array $step, int $index ): array 
 			: array(),
 		'prompt_queue'     => $prompt_queue,
 		'queue_mode'       => 'static',
+		'agent_modes'      => array(),
 		'disabled_tools'   => $step['disabled_tools'] ?? array(),
 		'pipeline_id'      => 'direct',
 		'flow_id'          => 'direct',
 	);
 
-	if ( ! empty( $handler_slug ) ) {
-		if ( FlowStepConfig::isMultiHandler( $flow_step_config ) ) {
-			$flow_step_config['handler_slugs']   = array( $handler_slug );
-			$flow_step_config['handler_configs'] = array( $handler_slug => $handler_config );
-		} else {
-			$flow_step_config['handler_slug']   = $handler_slug;
-			$flow_step_config['handler_config'] = $handler_config;
+	if ( FlowStepConfig::usesHandler( $flow_step_config ) ) {
+		if ( ! empty( $step['handler_slugs'] ) ) {
+			$flow_step_config['handler_slugs'] = $step['handler_slugs'];
 		}
-	} elseif ( ! FlowStepConfig::usesHandler( $flow_step_config ) && ! empty( $handler_config ) ) {
-		$flow_step_config['handler_config'] = $handler_config;
+		if ( ! empty( $step['handler_configs'] ) ) {
+			$flow_step_config['handler_configs'] = $step['handler_configs'];
+		}
+	} elseif ( ! empty( $step['flow_step_settings'] ) ) {
+		$flow_step_config['flow_step_settings'] = $step['flow_step_settings'];
 	}
 
 	return $flow_step_config;
@@ -137,6 +135,7 @@ function legacy_synced_step_config_for_test( array $step, int $flow_id, int $pip
 		'pipeline_id'      => $pipeline_id,
 		'flow_id'          => $flow_id,
 		'execution_order'  => $step['execution_order'] ?? 0,
+		'agent_modes'      => array(),
 		'disabled_tools'   => $disabled_tools,
 		'queue_mode'       => 'static',
 	);
@@ -166,20 +165,20 @@ echo "FlowStepConfigFactory smoke (#1345)\n";
 echo "-----------------------------------\n";
 
 $workflow_cases = array(
-	'fetch keeps scalar handler shape'        => array(
-		'type'           => 'fetch',
-		'handler_slug'   => 'mcp',
-		'handler_config' => array( 'server' => 'a8c' ),
-		'disabled_tools' => array( 'local_search' ),
+	'fetch keeps canonical handler shape'     => array(
+		'type'            => 'fetch',
+		'handler_slugs'   => array( 'mcp' ),
+		'handler_configs' => array( 'mcp' => array( 'server' => 'a8c' ) ),
+		'disabled_tools'  => array( 'local_search' ),
 	),
 	'publish keeps multi-handler shape'       => array(
-		'type'           => 'publish',
-		'handler_slug'   => 'wordpress_publish',
-		'handler_config' => array( 'post_type' => 'post' ),
+		'type'            => 'publish',
+		'handler_slugs'   => array( 'wordpress_publish' ),
+		'handler_configs' => array( 'wordpress_publish' => array( 'post_type' => 'post' ) ),
 	),
 	'system_task keeps handler-free settings' => array(
-		'type'           => 'system_task',
-		'handler_config' => array( 'task' => 'daily_memory_generation' ),
+		'type'               => 'system_task',
+		'flow_step_settings' => array( 'task_type' => 'daily_memory_generation' ),
 	),
 	'ai converts user message to prompt queue' => array(
 		'type'          => 'ai',

--- a/tests/flow-step-config-overlays-smoke.php
+++ b/tests/flow-step-config-overlays-smoke.php
@@ -111,10 +111,14 @@ $overridden = FlowStepConfigFactory::withHandlerConfig(
 	'wordpress_xmlrpc',
 	array( 'post_type' => 'page' )
 );
-assert_overlay_same( 'copy override replaces multi-handler list', array( 'wordpress_xmlrpc' ), $overridden['handler_slugs'] );
+assert_overlay_same( 'copy override appends multi-handler list', array( 'wordpress', 'pinterest', 'wordpress_xmlrpc' ), $overridden['handler_slugs'] );
 assert_overlay_same(
-	'copy override stores config under replacement handler',
-	array( 'wordpress_xmlrpc' => array( 'post_type' => 'page' ) ),
+	'copy override stores config under added handler',
+	array(
+		'wordpress'        => array( 'post_type' => 'post' ),
+		'pinterest'        => array( 'board' => 'events' ),
+		'wordpress_xmlrpc' => array( 'post_type' => 'page' ),
+	),
 	$overridden['handler_configs']
 );
 
@@ -137,20 +141,20 @@ $import_base = FlowStepConfigFactory::build(
 $import_restored = FlowStepConfigFactory::withHandlerFields(
 	$import_base,
 	array(
-		'handler_slug'   => 'mcp',
-		'handler_config' => array( 'server' => 'a8c', 'provider' => 'slack' ),
+		'handler_slugs'   => array( 'mcp' ),
+		'handler_configs' => array( 'mcp' => array( 'server' => 'a8c', 'provider' => 'slack' ) ),
 	)
 );
 
 assert_overlay_same(
-	'import restore path preserves field order and scalar handler shape',
+	'import restore path preserves field order and canonical handler shape',
 	array(
 		'flow_step_id'     => 'fetch_step_42',
 		'pipeline_step_id' => 'fetch_step',
 		'flow_id'          => 42,
 		'step_type'        => 'fetch',
-		'handler_slug'     => 'mcp',
-		'handler_config'   => array( 'server' => 'a8c', 'provider' => 'slack' ),
+		'handler_slugs'    => array( 'mcp' ),
+		'handler_configs'  => array( 'mcp' => array( 'server' => 'a8c', 'provider' => 'slack' ) ),
 	),
 	$import_restored
 );
@@ -164,12 +168,12 @@ $import_handler_free = FlowStepConfigFactory::withHandlerFields(
 			'step_type'        => 'system_task',
 		)
 	),
-	array( 'handler_config' => array( 'task' => 'daily_memory_generation' ) )
+	array( 'flow_step_settings' => array( 'task_type' => 'daily_memory_generation' ) )
 );
 assert_overlay_same(
 	'import restore path preserves handler-free settings config',
-	array( 'task' => 'daily_memory_generation' ),
-	$import_handler_free['handler_config']
+	array( 'task_type' => 'daily_memory_generation' ),
+	$import_handler_free['flow_step_settings']
 );
 
 $flow_helpers_source = file_get_contents( __DIR__ . '/../inc/Abilities/Flow/FlowHelpers.php' );

--- a/tests/flow-step-legacy-handler-field-smoke.php
+++ b/tests/flow-step-legacy-handler-field-smoke.php
@@ -84,9 +84,9 @@ $single = FlowStepConfig::normalizeHandlerShape(
 	array_merge(
 		$synced_step,
 		array(
-			'handler'        => 'rss',
-			'handler_slug'   => 'rss',
-			'handler_config' => array( 'url' => 'https://example.com/feed.xml' ),
+			'handler'         => 'rss',
+			'handler_slugs'   => array( 'rss' ),
+			'handler_configs' => array( 'rss' => array( 'url' => 'https://example.com/feed.xml' ) ),
 		)
 	)
 );
@@ -107,8 +107,8 @@ $multi = FlowStepConfig::normalizeHandlerShape(
 		'pipeline_id'      => 1,
 		'flow_id'          => 10,
 		'handler'          => 'wordpress_publish',
-		'handler_slug'     => 'wordpress_publish',
-		'handler_config'   => array( 'post_type' => 'post' ),
+		'handler_slugs'    => array( 'wordpress_publish' ),
+		'handler_configs'  => array( 'wordpress_publish' => array( 'post_type' => 'post' ) ),
 	)
 );
 assert_equals( array( 'wordpress_publish' ), $multi['handler_slugs'] ?? array(), 'multi-handler slug is canonical list', $failures, $passes );

--- a/tests/import-export-portable-flow-settings-smoke.php
+++ b/tests/import-export-portable-flow-settings-smoke.php
@@ -42,6 +42,12 @@ if ( ! function_exists( 'apply_filters' ) ) {
 	}
 }
 
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
 require_once __DIR__ . '/../inc/Engine/Actions/ImportExport.php';
@@ -106,8 +112,8 @@ $fetch_settings = call_import_export_private(
 	'export_flow_step_settings',
 	array(
 		'step_type'          => 'fetch',
-		'handler_slug'       => 'webhook_payload',
-		'handler_config'     => array( 'payload_path' => 'pull_request' ),
+		'handler_slugs'      => array( 'webhook_payload' ),
+		'handler_configs'    => array( 'webhook_payload' => array( 'payload_path' => 'pull_request' ) ),
 		'config_patch_queue' => array(
 			array(
 				'patch'    => array( 'after' => '2026-04-01' ),
@@ -130,7 +136,6 @@ $normalized = call_import_export_private(
 		'enabled_tools' => array( 'datamachine/read-github-file' ),
 		'queue_mode'    => 'static',
 		'prompt_queue'  => array( array( 'prompt' => 'Pinned prompt.' ) ),
-		'handler_slug'  => 'ignored_here',
 	)
 );
 

--- a/tests/system-task-config-passthrough-smoke.php
+++ b/tests/system-task-config-passthrough-smoke.php
@@ -110,9 +110,9 @@ $built = build_configs_from_workflow_for_test(
 	array(
 		'steps' => array(
 			array(
-				'type'           => 'fetch',
-				'handler_slug'   => 'mcp',
-				'handler_config' => array( 'server' => 'a8c' ),
+				'type'            => 'fetch',
+				'handler_slugs'   => array( 'mcp' ),
+				'handler_configs' => array( 'mcp' => array( 'server' => 'a8c' ) ),
 			),
 		),
 	)
@@ -131,9 +131,9 @@ $built = build_configs_from_workflow_for_test(
 	array(
 		'steps' => array(
 			array(
-				'type'           => 'publish',
-				'handler_slug'   => 'wordpress_publish',
-				'handler_config' => array( 'post_type' => 'post' ),
+				'type'            => 'publish',
+				'handler_slugs'   => array( 'wordpress_publish' ),
+				'handler_configs' => array( 'wordpress_publish' => array( 'post_type' => 'post' ) ),
 			),
 		),
 	)
@@ -173,23 +173,23 @@ assert_equals( 'be helpful', $built['pipeline_config']['ephemeral_pipeline_0']['
 echo "\n[6] normalize canonical rows without cross-shape inference:\n";
 $system_task = FlowStepConfig::normalizeHandlerShape(
 	array(
-		'step_type'      => 'system_task',
-		'handler_config' => array( 'task_type' => 'agent_call' ),
+		'step_type'          => 'system_task',
+		'flow_step_settings' => array( 'task_type' => 'agent_call' ),
 	)
 );
-assert_equals( array( 'task_type' => 'agent_call' ), $system_task['flow_step_settings'] ?? array(), 'system_task config normalizes to flow_step_settings', $failures, $passes );
+assert_equals( array( 'task_type' => 'agent_call' ), $system_task['flow_step_settings'] ?? array(), 'system_task settings are preserved', $failures, $passes );
 assert_absent( 'handler_config', $system_task, 'system_task scalar handler_config is removed', $failures, $passes );
 assert_absent( 'handler_slugs', $system_task, 'system_task slugs remain absent', $failures, $passes );
 
 $fetch = FlowStepConfig::normalizeHandlerShape(
 	array(
-		'step_type'      => 'fetch',
-		'handler_slug'   => 'rss',
-		'handler_config' => array( 'url' => 'https://example.com/feed.xml' ),
+		'step_type'       => 'fetch',
+		'handler_slugs'   => array( 'rss' ),
+		'handler_configs' => array( 'rss' => array( 'url' => 'https://example.com/feed.xml' ) ),
 	)
 );
-assert_equals( array( 'rss' ), $fetch['handler_slugs'] ?? array(), 'fetch singular slug normalizes to plural list', $failures, $passes );
-assert_equals( array( 'rss' => array( 'url' => 'https://example.com/feed.xml' ) ), $fetch['handler_configs'] ?? array(), 'fetch singular config normalizes to plural map', $failures, $passes );
+assert_equals( array( 'rss' ), $fetch['handler_slugs'] ?? array(), 'fetch slugs preserved', $failures, $passes );
+assert_equals( array( 'rss' => array( 'url' => 'https://example.com/feed.xml' ) ), $fetch['handler_configs'] ?? array(), 'fetch configs preserved', $failures, $passes );
 assert_absent( 'handler_slug', $fetch, 'fetch scalar slug is removed', $failures, $passes );
 assert_absent( 'handler_config', $fetch, 'fetch scalar config is removed', $failures, $passes );
 

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -177,10 +177,10 @@ $tools   = resolve_source_tools(
 	$manager,
 	array(
 		'previous_step_config' => array(
-			'flow_step_id'   => 'fetch_step',
-			'step_type'      => 'fetch',
-			'handler_slug'   => 'ticketmaster_fetch',
-			'handler_config' => array( 'marker' => 'previous' ),
+			'flow_step_id'    => 'fetch_step',
+			'step_type'       => 'fetch',
+			'handler_slugs'   => array( 'ticketmaster_fetch' ),
+			'handler_configs' => array( 'ticketmaster_fetch' => array( 'marker' => 'previous' ) ),
 		),
 		'next_step_config'     => array(
 			'flow_step_id'     => 'publish_step',

--- a/tests/workflow-persistent-install-smoke.php
+++ b/tests/workflow-persistent-install-smoke.php
@@ -85,8 +85,8 @@ $workflow = array(
 		array(
 			'type'               => 'fetch',
 			'label'              => 'Webhook Payload',
-			'handler_slug'       => 'webhook_payload',
-			'handler_config'     => array( 'payload_path' => 'pull_request' ),
+			'handler_slugs'      => array( 'webhook_payload' ),
+			'handler_configs'    => array( 'webhook_payload' => array( 'payload_path' => 'pull_request' ) ),
 			'config_patch_queue' => array( array( 'patch' => array( 'after' => '2026-04-01' ), 'added_at' => '2026-04-27T00:00:00Z' ) ),
 			'queue_mode'         => 'drain',
 		),
@@ -144,8 +144,8 @@ assert_workflow_equals( array( 'fetch', 'ai', 'ai' ), array_column( $flow_steps,
 assert_workflow_equals( '88_uuid-1_144', $flow_steps[0]['flow_step_id'] ?? null, 'flow step id maps pipeline step id to flow id', $failures, $passes );
 assert_workflow_equals( 88, $flow_steps[0]['pipeline_id'] ?? null, 'flow stores target pipeline id', $failures, $passes );
 assert_workflow_equals( 144, $flow_steps[0]['flow_id'] ?? null, 'flow stores target flow id', $failures, $passes );
-assert_workflow_equals( 'webhook_payload', $flow_steps[0]['handler_slug'] ?? null, 'flow preserves fetch handler slug', $failures, $passes );
-assert_workflow_equals( array( 'payload_path' => 'pull_request' ), $flow_steps[0]['handler_config'] ?? null, 'flow preserves fetch handler config', $failures, $passes );
+assert_workflow_equals( array( 'webhook_payload' ), $flow_steps[0]['handler_slugs'] ?? null, 'flow preserves fetch handler slugs', $failures, $passes );
+assert_workflow_equals( array( 'webhook_payload' => array( 'payload_path' => 'pull_request' ) ), $flow_steps[0]['handler_configs'] ?? null, 'flow preserves fetch handler configs', $failures, $passes );
 assert_workflow_equals( array( 'after' => '2026-04-01' ), $flow_steps[0]['config_patch_queue'][0]['patch'] ?? null, 'flow preserves fetch config patch queue', $failures, $passes );
 assert_workflow_equals( 'drain', $flow_steps[0]['queue_mode'] ?? null, 'flow preserves explicit fetch queue mode', $failures, $passes );
 assert_workflow_equals( array( 'datamachine/get-github-pull-review-context', 'datamachine/upsert-github-pull-review-comment' ), $flow_steps[1]['enabled_tools'] ?? null, 'flow preserves AI enabled tools', $failures, $passes );

--- a/tests/workflow-spec-contract-smoke.php
+++ b/tests/workflow-spec-contract-smoke.php
@@ -152,10 +152,10 @@ $configs         = WorkflowConfigFactory::buildEphemeralConfigs(
 	array(
 		'steps' => array(
 			array(
-				'type'           => 'fetch',
-				'label'          => 'Fetch Source',
-				'handler_slug'   => 'mcp',
-				'handler_config' => array( 'server' => 'a8c' ),
+				'type'            => 'fetch',
+				'label'           => 'Fetch Source',
+				'handler_slugs'   => array( 'mcp' ),
+				'handler_configs' => array( 'mcp' => array( 'server' => 'a8c' ) ),
 			),
 			array(
 				'type'           => 'ai',
@@ -196,14 +196,6 @@ assert_workflow_spec_equals( array( array( 'id' => 'after-worktree', 'max_calls'
 assert_workflow_spec_equals( 'Cleanup', $pipeline_steps[2]['label'] ?? null, 'ephemeral pipeline_config preserves system_task label', $failures, $passes );
 assert_workflow_spec_equals( array( 'task_type' => 'retention_logs' ), $pipeline_steps[2]['flow_step_settings'] ?? null, 'ephemeral pipeline_config preserves system_task settings', $failures, $passes );
 assert_workflow_spec_equals( false, array_key_exists( 'system_prompt', $pipeline_steps[2] ), 'non-AI ephemeral pipeline rows do not gain AI metadata', $failures, $passes );
-
-$legacy_task_workflow = array(
-	'steps' => array(
-		array( 'type' => 'system_task', 'flow_step_settings' => array( 'task' => 'retention_logs' ) ),
-	),
-);
-$legacy_configs       = WorkflowConfigFactory::buildEphemeralConfigs( $legacy_task_workflow );
-assert_workflow_spec_equals( array( 'task' => 'retention_logs' ), array_values( $legacy_configs['pipeline_config'] )[0]['flow_step_settings'] ?? null, 'ephemeral pipeline_config preserves legacy task settings', $failures, $passes );
 
 $execute_source  = file_get_contents( __DIR__ . '/../inc/Abilities/Job/ExecuteWorkflowAbility.php' ) ?: '';
 $pipeline_source = file_get_contents( __DIR__ . '/../inc/Abilities/Pipeline/PipelineHelpers.php' ) ?: '';


### PR DESCRIPTION
## Summary
- Require canonical flow-step config shapes: handler-backed steps use `handler_slugs`/`handler_configs`, handler-free steps use `flow_step_settings`.
- Remove singular `handler_slug`/`handler_config` fallback reads from flow-step helpers, bundle adapters, workflow builders, and CSV import restore.
- Update workflow/bundle smoke fixtures and agent-facing copy to the canonical contract.

## Verification
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the flow-step config contract refactor; Chris remains responsible for review and merge.