### PR TITLE
Unify multi-mode model resolution

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -92,15 +92,9 @@ class AgentsChatHandler {
 		$client_context = is_array( $input['client_context'] ?? null ) ? $input['client_context'] : array();
 		$modes          = $this->resolveModes( $input, $client_context );
 		$mode           = implode( ',', $modes );
-		$agent_config   = $this->resolveModelForModes( 0 === $agent_id ? null : $agent_id, $modes );
+		$agent_config   = PluginSettings::resolveModelForAgentModes( 0 === $agent_id ? null : $agent_id, $modes, 'chat' );
 		$provider       = $agent_config['provider'];
 		$model          = $agent_config['model'];
-
-		if ( '' === $model && ! in_array( 'chat', $modes, true ) ) {
-			$chat_config = PluginSettings::resolveModelForAgentMode( 0 === $agent_id ? null : $agent_id, 'chat' );
-			$provider    = '' === $provider ? $chat_config['provider'] : $provider;
-			$model       = $chat_config['model'];
-		}
 
 		if ( '' === $provider ) {
 			return new WP_Error( 'provider_required', __( 'AI provider is required. Set a default in Data Machine settings.', 'data-machine' ), array( 'status' => 400 ) );
@@ -204,31 +198,6 @@ class AgentsChatHandler {
 		}
 
 		return ToolPolicyResolver::normalizeModes( $modes );
-	}
-
-	/**
-	 * Resolve a model for the first configured active mode.
-	 *
-	 * @param int|null $agent_id Agent ID.
-	 * @param array    $modes    Active modes.
-	 * @return array{provider:string,model:string}
-	 */
-	private function resolveModelForModes( ?int $agent_id, array $modes ): array {
-		$fallback = array(
-			'provider' => '',
-			'model'    => '',
-		);
-		foreach ( $modes as $mode ) {
-			$config = PluginSettings::resolveModelForAgentMode( $agent_id, $mode );
-			if ( '' !== $config['provider'] && '' !== $config['model'] ) {
-				return $config;
-			}
-			if ( '' === $fallback['provider'] && '' === $fallback['model'] ) {
-				$fallback = $config;
-			}
-		}
-
-		return $fallback;
 	}
 
 	/**

--- a/inc/Abilities/Chat/SendMessageAbility.php
+++ b/inc/Abilities/Chat/SendMessageAbility.php
@@ -174,21 +174,13 @@ class SendMessageAbility {
 		$model    = $input['model'] ?? '';
 
 		if ( empty( $provider ) || empty( $model ) ) {
-			$agent_config = PluginSettings::resolveModelForAgentMode( $agent_id > 0 ? $agent_id : null, $mode );
+			$agent_config = PluginSettings::resolveModelForAgentModes( $agent_id > 0 ? $agent_id : null, array( $mode ), 'chat' );
 			if ( empty( $provider ) ) {
 				$provider = $agent_config['provider'];
 			}
 			if ( empty( $model ) ) {
 				$model = $agent_config['model'];
 			}
-		}
-
-		if ( empty( $model ) && 'chat' !== $mode ) {
-			$chat_config = PluginSettings::resolveModelForAgentMode( $agent_id > 0 ? $agent_id : null, 'chat' );
-			if ( empty( $provider ) ) {
-				$provider = $chat_config['provider'];
-			}
-			$model = $chat_config['model'];
 		}
 
 		if ( empty( $provider ) ) {

--- a/inc/Core/PluginSettings.php
+++ b/inc/Core/PluginSettings.php
@@ -97,7 +97,7 @@ class PluginSettings {
 	 * Get a specific per-site setting value (no cascade).
 	 *
 	 * @param string $key     Setting key
-	 * @param mixed  $default Default value if key not found
+	 * @param mixed  $default_value Default value if key not found
 	 * @return mixed
 	 */
 	public static function get( string $key, mixed $default_value = null ): mixed {
@@ -118,7 +118,7 @@ class PluginSettings {
 	 * @since 0.32.0
 	 *
 	 * @param string $key     Setting key.
-	 * @param mixed  $default Default value if neither site nor network has it.
+	 * @param mixed  $default_value Default value if neither site nor network has it.
 	 * @return mixed
 	 */
 	public static function resolve( string $key, mixed $default_value = null ): mixed {
@@ -242,6 +242,53 @@ class PluginSettings {
 		self::$agent_model_cache[ $cache_key ] = self::getModelForMode( $mode );
 
 		return self::$agent_model_cache[ $cache_key ];
+	}
+
+	/**
+	 * Resolve provider/model for the first complete mode in an ordered mode set.
+	 *
+	 * Behavioral modes can intentionally omit model configuration and compose with
+	 * an execution surface mode such as chat or pipeline. Treat provider/model as
+	 * an atomic pair so a provider from one mode is never combined with a model
+	 * from another mode.
+	 *
+	 * @param int|null       $agent_id      Agent ID or null/0 for no agent-specific override.
+	 * @param array<int,string> $modes      Ordered mode slugs.
+	 * @param string|null    $fallback_mode Optional execution-surface fallback mode.
+	 * @return array{ provider: string, model: string }
+	 */
+	public static function resolveModelForAgentModes( ?int $agent_id, array $modes, ?string $fallback_mode = null ): array {
+		$fallback = array(
+			'provider' => '',
+			'model'    => '',
+		);
+
+		foreach ( $modes as $mode ) {
+			$mode   = sanitize_key( (string) $mode );
+			$config = self::resolveModelForAgentMode( $agent_id, $mode );
+
+			if ( '' !== $config['provider'] && '' !== $config['model'] ) {
+				return $config;
+			}
+
+			if ( '' === $fallback['provider'] && '' === $fallback['model'] ) {
+				$fallback = $config;
+			}
+		}
+
+		$fallback_mode = null === $fallback_mode ? '' : sanitize_key( $fallback_mode );
+		if ( '' !== $fallback_mode && ! in_array( $fallback_mode, array_map( 'sanitize_key', $modes ), true ) ) {
+			$config = self::resolveModelForAgentMode( $agent_id, $fallback_mode );
+			if ( '' !== $config['provider'] && '' !== $config['model'] ) {
+				return $config;
+			}
+
+			if ( '' === $fallback['provider'] && '' === $fallback['model'] ) {
+				$fallback = $config;
+			}
+		}
+
+		return $fallback;
 	}
 
 	/**

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -623,7 +623,7 @@ class AIStep extends Step {
 	 *
 	 * @param array $pipeline_assertions Pipeline step assertions.
 	 * @param array $flow_assertions     Flow step assertions.
-	 * @return array<string, array<int, string>> Merged assertions.
+	 * @return array<string, mixed> Merged assertions.
 	 */
 	private static function mergeCompletionAssertions( array $pipeline_assertions, array $flow_assertions ): array {
 		$merged = array();
@@ -725,21 +725,7 @@ class AIStep extends Step {
 	 * @return array{provider:string,model:string}
 	 */
 	private static function resolveModelForExecutionModes( int $agent_id, array $modes ): array {
-		$fallback = array(
-			'provider' => '',
-			'model'    => '',
-		);
-		foreach ( $modes as $mode ) {
-			$model = PluginSettings::resolveModelForAgentMode( $agent_id, $mode );
-			if ( ! empty( $model['provider'] ) ) {
-				return $model;
-			}
-			if ( '' === $fallback['provider'] && '' === $fallback['model'] ) {
-				$fallback = $model;
-			}
-		}
-
-		return $fallback;
+		return PluginSettings::resolveModelForAgentModes( $agent_id, $modes, ToolPolicyResolver::MODE_PIPELINE );
 	}
 
 	/**

--- a/tests/mode-model-resolution-smoke.php
+++ b/tests/mode-model-resolution-smoke.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Smoke tests for ordered multi-mode model resolution.
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core\Database\Agents {
+	class Agents {
+		public static array $agents = array();
+
+		public function get_agent( int $agent_id ): ?array {
+			return self::$agents[ $agent_id ] ?? null;
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ );
+	}
+
+	function get_option( string $key, mixed $default_value = false ): mixed {
+		return $GLOBALS['datamachine_mode_model_options'][ $key ] ?? $default_value;
+	}
+
+	function get_site_option( string $key, mixed $default_value = false ): mixed {
+		return $GLOBALS['datamachine_mode_model_site_options'][ $key ] ?? $default_value;
+	}
+
+	function sanitize_text_field( mixed $value ): string {
+		return trim( (string) $value );
+	}
+
+	function sanitize_key( mixed $value ): string {
+		$value = strtolower( (string) $value );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $value ) ?? '';
+	}
+
+	require_once __DIR__ . '/../inc/Core/NetworkSettings.php';
+	require_once __DIR__ . '/../inc/Core/PluginSettings.php';
+
+	use DataMachine\Core\Database\Agents\Agents;
+	use DataMachine\Core\PluginSettings;
+
+	$passes = 0;
+	$fails  = 0;
+
+	$assert_same = static function ( mixed $expected, mixed $actual, string $label ) use ( &$passes, &$fails ): void {
+		if ( $expected === $actual ) {
+			$passes++;
+			echo "PASS: {$label}\n";
+			return;
+		}
+
+		$fails++;
+		echo "FAIL: {$label}\n";
+		echo '  expected: ' . json_encode( $expected ) . "\n";
+		echo '  actual:   ' . json_encode( $actual ) . "\n";
+	};
+
+	$GLOBALS['datamachine_mode_model_options']      = array(
+		'datamachine_settings' => array(
+			'mode_models' => array(
+				'chat'     => array(
+					'provider' => 'openai',
+					'model'    => 'gpt-5.5',
+				),
+				'pipeline' => array(
+					'provider' => 'openai',
+					'model'    => 'gpt-5.4-mini',
+				),
+			),
+		),
+	);
+	$GLOBALS['datamachine_mode_model_site_options'] = array();
+
+	Agents::$agents = array(
+		7 => array(
+			'agent_config' => array(
+				'mode_models' => array(
+					'intelligence' => array(
+						'provider' => 'openai',
+						'model'    => '',
+					),
+				),
+			),
+		),
+	);
+
+	PluginSettings::clearCache();
+
+	$assert_same(
+		array( 'provider' => 'openai', 'model' => 'gpt-5.4-mini' ),
+		PluginSettings::resolveModelForAgentModes( 7, array( 'intelligence', 'pipeline' ), 'pipeline' ),
+		'incomplete behavior mode falls through to pipeline model'
+	);
+
+	$assert_same(
+		array( 'provider' => 'openai', 'model' => 'gpt-5.5' ),
+		PluginSettings::resolveModelForAgentModes( 7, array( 'intelligence', 'chat' ), 'chat' ),
+		'incomplete behavior mode falls through to chat model'
+	);
+
+	$assert_same(
+		array( 'provider' => 'openai', 'model' => 'gpt-5.5' ),
+		PluginSettings::resolveModelForAgentModes( 7, array( 'intelligence' ), 'chat' ),
+		'chat execution surface fallback applies when behavior mode is alone'
+	);
+
+	$assert_same(
+		array( 'provider' => 'openai', 'model' => 'gpt-5.4-mini' ),
+		PluginSettings::resolveModelForAgentModes( 7, array( 'intelligence' ), 'pipeline' ),
+		'pipeline execution surface fallback applies when behavior mode is alone'
+	);
+
+	Agents::$agents[7]['agent_config']['mode_models']['intelligence']['model'] = 'gpt-5.5-intelligence';
+	PluginSettings::clearCache();
+
+	$assert_same(
+		array( 'provider' => 'openai', 'model' => 'gpt-5.5-intelligence' ),
+		PluginSettings::resolveModelForAgentModes( 7, array( 'intelligence', 'pipeline' ), 'pipeline' ),
+		'complete behavior mode still wins when intentionally configured'
+	);
+
+	$ai_step_source = file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' ) ?: '';
+	$chat_source    = file_get_contents( __DIR__ . '/../inc/Abilities/Chat/AgentsChatHandler.php' ) ?: '';
+	$send_source    = file_get_contents( __DIR__ . '/../inc/Abilities/Chat/SendMessageAbility.php' ) ?: '';
+
+	$assert_same( true, str_contains( $ai_step_source, "resolveModelForAgentModes( $" . "agent_id, $" . "modes, ToolPolicyResolver::MODE_PIPELINE )" ), 'AIStep uses shared mode-model resolver with pipeline fallback' );
+	$assert_same( true, str_contains( $chat_source, "resolveModelForAgentModes( 0 === $" . "agent_id ? null : $" . "agent_id, $" . "modes, 'chat' )" ), 'canonical agents/chat uses shared mode-model resolver with chat fallback' );
+	$assert_same( true, str_contains( $send_source, "resolveModelForAgentModes( $" . "agent_id > 0 ? $" . "agent_id : null, array( $" . "mode ), 'chat' )" ), 'send-message ability uses shared mode-model resolver with chat fallback' );
+
+	echo "\n{$passes} passed, {$fails} failed\n";
+	if ( $fails > 0 ) {
+		exit( 1 );
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared PluginSettings resolver for ordered multi-mode provider/model selection
- treat provider/model as an atomic pair so partial behavior-mode config cannot combine with another mode's model
- use chat fallback for chat entrypoints and pipeline fallback for AI pipeline steps
- cover intelligence+chat and intelligence+pipeline fallback behavior

## Testing
- php tests/mode-model-resolution-smoke.php
- homeboy lint --changed-since origin/main
- homeboy test --changed-since origin/main

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the shared resolver, updated call sites, and added smoke coverage; Chris identified the model-resolution contract gap and reviewed the intended behavior.