### PR TITLE
fix: allow pending job cancellation

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -100,6 +100,23 @@ class ExecuteStepAbility {
 	public function execute( array $input ): array {
 		$job_id       = (int) ( $input['job_id'] ?? 0 );
 		$flow_step_id = (string) ( $input['flow_step_id'] ?? '' );
+		$job          = $this->db_jobs->get_job( $job_id );
+
+		if ( ! $job ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Job %d not found.', $job_id ),
+			);
+		}
+
+		$current_status = (string) ( $job['status'] ?? '' );
+		if ( JobStatus::isStatusFinal( $current_status ) ) {
+			return array(
+				'success'        => false,
+				'error'          => sprintf( 'Job %d has terminal status "%s"; step execution skipped.', $job_id, $current_status ),
+				'terminal_state' => $current_status,
+			);
+		}
 
 		// Transition job to 'processing' now that Action Scheduler is actually
 		// executing it. For parent jobs this is a no-op (already processing via

--- a/inc/Abilities/Job/FailJobAbility.php
+++ b/inc/Abilities/Job/FailJobAbility.php
@@ -10,6 +10,8 @@
 
 namespace DataMachine\Abilities\Job;
 
+use DataMachine\Core\JobStatus;
+
 defined( 'ABSPATH' ) || exit;
 
 class FailJobAbility {
@@ -31,7 +33,7 @@ class FailJobAbility {
 				'datamachine/fail-job',
 				array(
 					'label'               => __( 'Fail Job', 'data-machine' ),
-					'description'         => __( 'Manually fail a processing job with an optional reason.', 'data-machine' ),
+					'description'         => __( 'Manually fail a pending or processing job with an optional reason.', 'data-machine' ),
 					'category'            => 'datamachine-jobs',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -76,7 +78,7 @@ class FailJobAbility {
 	/**
 	 * Execute fail-job ability.
 	 *
-	 * Marks a processing job as failed with the given reason.
+	 * Marks a pending or processing job as failed with the given reason.
 	 *
 	 * @param array $input Input parameters with job_id and optional reason.
 	 * @return array Result with job_id, previous_status, and new_status.
@@ -114,15 +116,15 @@ class FailJobAbility {
 			);
 		}
 
-		// Only allow failing processing jobs.
-		if ( 'processing' !== $previous_status ) {
+		// Pending jobs are queued but not yet running; cancellation is safest before they start.
+		if ( ! in_array( $previous_status, array( JobStatus::PENDING, JobStatus::PROCESSING ), true ) ) {
 			return array(
 				'success' => false,
-				'error'   => sprintf( 'Job %d has status "%s" — only processing jobs can be failed.', $job_id, $previous_status ),
+				'error'   => sprintf( 'Job %d has status "%s" — only pending or processing jobs can be failed.', $job_id, $previous_status ),
 			);
 		}
 
-		$new_status = "failed - {$reason}";
+		$new_status = JobStatus::failed( $reason )->toString();
 		$this->db_jobs->complete_job( $job_id, $new_status );
 
 		do_action( 'datamachine_job_complete', $job_id, 'failed' );

--- a/tests/Unit/Abilities/Job/FailJobAbilityTest.php
+++ b/tests/Unit/Abilities/Job/FailJobAbilityTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Fail-job ability coverage.
+ *
+ * @package DataMachine\Tests\Unit\Abilities\Job
+ */
+
+namespace DataMachine\Tests\Unit\Abilities\Job;
+
+use DataMachine\Abilities\Engine\ExecuteStepAbility;
+use DataMachine\Abilities\Job\FailJobAbility;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\JobStatus;
+use WP_UnitTestCase;
+
+class FailJobAbilityTest extends WP_UnitTestCase {
+
+	public function test_fail_job_allows_pending_jobs(): void {
+		$jobs_db = new Jobs();
+		$job_id  = $this->createDirectJob( $jobs_db );
+
+		$result = ( new FailJobAbility() )->execute(
+			array(
+				'job_id' => $job_id,
+				'reason' => 'manual cancellation',
+			)
+		);
+
+		$this->assertTrue( $result['success'] ?? false );
+		$this->assertSame( JobStatus::PENDING, $result['previous_status'] ?? '' );
+		$this->assertSame( 'failed - manual cancellation', $result['new_status'] ?? '' );
+		$this->assertSame( 'failed - manual cancellation', $jobs_db->get_job( $job_id )['status'] ?? '' );
+	}
+
+	public function test_execute_step_does_not_restart_terminal_jobs(): void {
+		$jobs_db = new Jobs();
+		$job_id  = $this->createDirectJob( $jobs_db );
+
+		$this->assertTrue( $jobs_db->complete_job( $job_id, JobStatus::failed( 'manual cancellation' )->toString() ) );
+
+		$result = ( new ExecuteStepAbility() )->execute(
+			array(
+				'job_id'       => $job_id,
+				'flow_step_id' => 'queued_step',
+			)
+		);
+
+		$this->assertFalse( $result['success'] ?? true );
+		$this->assertSame( 'failed - manual cancellation', $result['terminal_state'] ?? '' );
+		$this->assertStringContainsString( 'terminal status', $result['error'] ?? '' );
+		$this->assertSame( 'failed - manual cancellation', $jobs_db->get_job( $job_id )['status'] ?? '' );
+	}
+
+	private function createDirectJob( Jobs $jobs_db ): int {
+		$job_id = $jobs_db->create_job(
+			array(
+				'pipeline_id' => 'direct',
+				'flow_id'     => 'direct',
+				'source'      => 'system',
+				'label'       => 'Pending cancellation test',
+			)
+		);
+
+		$this->assertIsInt( $job_id );
+		$this->assertSame( JobStatus::PENDING, $jobs_db->get_job( $job_id )['status'] ?? '' );
+
+		return $job_id;
+	}
+}


### PR DESCRIPTION
## Summary
- Allows `datamachine/fail-job` to mark queued `pending` jobs as failed, not just already-running `processing` jobs.
- Prevents queued step callbacks from restarting jobs that were already moved to a terminal status before Action Scheduler runs them.
- Adds unit coverage for pending cancellation and terminal-job execution guards.

Fixes #2076.

## Testing
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the issue, drafted the core cancellation fix and regression tests, and ran targeted verification; Chris remains responsible for review and merge.