### PR TITLE
fix(email): download all attachments instead of only the first

### DIFF
--- a/inc/Abilities/Fetch/FetchEmailAbility.php
+++ b/inc/Abilities/Fetch/FetchEmailAbility.php
@@ -416,10 +416,10 @@ class FetchEmailAbility {
 		$body = $this->fetchBody( $connection, $uid );
 
 		// Check for attachments.
-		$structure         = imap_fetchstructure( $connection, $uid, FT_UID );
-		$attachment_count  = 0;
-		$downloaded_files  = array();
-		$skipped_count     = 0;
+		$structure        = imap_fetchstructure( $connection, $uid, FT_UID );
+		$attachment_count = 0;
+		$downloaded_files = array();
+		$skipped_count    = 0;
 
 		if ( $structure ) {
 			$attachments      = $this->findAttachments( $structure );

--- a/inc/Abilities/Fetch/FetchEmailAbility.php
+++ b/inc/Abilities/Fetch/FetchEmailAbility.php
@@ -416,42 +416,73 @@ class FetchEmailAbility {
 		$body = $this->fetchBody( $connection, $uid );
 
 		// Check for attachments.
-		$structure        = imap_fetchstructure( $connection, $uid, FT_UID );
-		$attachment_count = 0;
-		$file_info        = null;
+		$structure         = imap_fetchstructure( $connection, $uid, FT_UID );
+		$attachment_count  = 0;
+		$downloaded_files  = array();
+		$skipped_count     = 0;
 
 		if ( $structure ) {
 			$attachments      = $this->findAttachments( $structure );
 			$attachment_count = count( $attachments );
 
 			if ( $config['download_attachments'] && ! empty( $attachments ) ) {
-				$file_info = $this->downloadAttachment( $connection, $uid, $attachments[0] );
+				foreach ( $attachments as $attachment ) {
+					$file_info = $this->downloadAttachment( $connection, $uid, $attachment );
+					if ( null === $file_info ) {
+						++$skipped_count;
+						do_action(
+							'datamachine_log',
+							'warning',
+							'Email attachment download failed',
+							array(
+								'uid'         => $uid,
+								'filename'    => $attachment['filename'] ?? '(unknown)',
+								'part_number' => $attachment['part_number'] ?? '',
+							)
+						);
+						continue;
+					}
+					$downloaded_files[] = $file_info;
+				}
 			}
+		}
+
+		$metadata = array(
+			'uid'               => $uid,
+			'message_id'        => $message_id,
+			'item_identifier'   => $message_id,
+			'from'              => $from_email,
+			'from_name'         => $from_name,
+			'to'                => $to_address,
+			'date'              => $date,
+			'original_date_gmt' => $date,
+			'seen'              => $seen,
+			'flagged'           => $flagged,
+			'has_attachments'   => $attachment_count > 0,
+			'attachment_count'  => $attachment_count,
+			'in_reply_to'       => $in_reply,
+			'references'        => $references,
+		);
+
+		// Expose every downloaded attachment under metadata.files so callers
+		// that need access to attachments beyond the first can read them.
+		// file_info stays as the first attachment for backward compatibility
+		// with the FetchHandler pipeline contract (one file_info per item).
+		if ( ! empty( $downloaded_files ) ) {
+			$metadata['files'] = $downloaded_files;
+		}
+		if ( $skipped_count > 0 ) {
+			$metadata['attachments_skipped'] = $skipped_count;
 		}
 
 		$item = array(
 			'title'    => $subject,
 			'content'  => $body,
-			'metadata' => array(
-				'uid'               => $uid,
-				'message_id'        => $message_id,
-				'item_identifier'   => $message_id,
-				'from'              => $from_email,
-				'from_name'         => $from_name,
-				'to'                => $to_address,
-				'date'              => $date,
-				'original_date_gmt' => $date,
-				'seen'              => $seen,
-				'flagged'           => $flagged,
-				'has_attachments'   => $attachment_count > 0,
-				'attachment_count'  => $attachment_count,
-				'in_reply_to'       => $in_reply,
-				'references'        => $references,
-			),
+			'metadata' => $metadata,
 		);
 
-		if ( $file_info ) {
-			$item['file_info'] = $file_info;
+		if ( ! empty( $downloaded_files ) ) {
+			$item['file_info'] = $downloaded_files[0];
 		}
 
 		return $item;
@@ -626,6 +657,7 @@ class FetchEmailAbility {
 
 		return array(
 			'file_path' => $file_path,
+			'filename'  => basename( $file_path ),
 			'mime_type' => $attachment_info['mime_type'],
 			'file_size' => $written,
 		);


### PR DESCRIPTION
## Summary

Fixes #2078 — silent data loss when an IMAP message has more than one attachment.

## The bug

`FetchEmailAbility::fetchMessage()` hard-coded `\$attachments[0]` when calling `downloadAttachment()`, so only the first attachment was ever written to disk. Every additional attachment was silently dropped:

- No warning surfaced by the CLI
- No `ERROR` or `WARNING` row in the logs
- The returned `metadata.attachment_count` correctly reported the upstream count (2, 3, etc.) — making it look like everything worked

Reproducer (on extrachill.com production, against the email used to discover this):

```
wp datamachine email read 87801 --format=json
# metadata.attachment_count: 2

rm wp-content/uploads/datamachine-files/email-attachments/*
wp datamachine email fetch \
  --search='FROM "chrisgardner" SUBJECT "dani rucker"' \
  --max=5 --download-attachments
ls wp-content/uploads/datamachine-files/email-attachments/
# only 1 file written
```

## The fix

- Loop over all detected attachments instead of indexing `[0]`.
- Expose every successfully downloaded file under `metadata.files` so callers (CLI/JSON consumers, downstream abilities) can read past the first attachment.
- Keep `\$item['file_info']` pointing at the first attachment so the existing single-`file_info`-per-item contract enforced by `FetchHandler::toDataPackets()` continues to hold. Nothing in the generic pipeline contract changes.
- Log a `warning` for each attachment whose download fails (empty body, decode failure, disk write failure) and surface the count via `metadata.attachments_skipped` so silent loss can no longer happen.
- Include the resolved on-disk filename in each `file_info` struct so callers can distinguish multiple files inside `metadata.files`.

## What did NOT change

- The pipeline contract. `FetchHandler::toDataPackets()` still reads `\$item['file_info']` as a single struct and produces one packet per item. Email continues to emit one item per message; the extra attachments simply become accessible via `metadata.files` instead of being lost.
- Filename collision behavior. `wp_unique_filename()` already handled collisions correctly inside `downloadAttachment()`; the bug was never about collisions, it was about the call site only ever firing once.

## Why one-item-per-email, not one-item-per-attachment

Each email has one subject, one body, and one logical content payload. Splitting into N items would duplicate the body text N times and break dedupe via `item_identifier` (which is the message-id). The N-attachments-on-one-item shape is consistent with how an email is modeled everywhere else in the system.

## Test plan

On a live install with at least one multi-attachment email in the inbox:

```
# 1. Clear any prior downloads.
rm wp-content/uploads/datamachine-files/email-attachments/*

# 2. Fetch the multi-attachment email.
wp datamachine email fetch \\
  --search='FROM "<sender>" SUBJECT "<subject with multiple attachments>"' \\
  --max=1 --download-attachments --format=json

# 3. Verify metadata.files contains every attachment with distinct paths.
# 4. Verify the on-disk count matches metadata.attachment_count.
# 5. Verify metadata.attachments_skipped is 0 (or matches the count of any genuinely unreadable parts).
```

For a synthetic test, send yourself a 3-attachment email and walk through the same steps. All three files should land on disk; `metadata.files` should have length 3; `file_info` should equal `metadata.files[0]`.

## Logging changes

New WARNING entries get a context payload `{ uid, filename, part_number }` so the operator can correlate them to the source email. Existing INFO/DEBUG output is unchanged.

## Closes

Closes #2078