### PR TITLE
Fix duplicate path stub creation

### DIFF
--- a/inc/Abilities/Content/UpsertPostAbility.php
+++ b/inc/Abilities/Content/UpsertPostAbility.php
@@ -403,12 +403,15 @@ class UpsertPostAbility {
 			);
 		}
 
-		// Idempotency check.
+		// Idempotency check. Parent/slug changes still need a write even when
+		// the content hash is unchanged.
 		if ( $existing_id > 0 && '' !== $content_hash ) {
 			$stored_hash = get_post_meta( $existing_id, self::META_CONTENT_HASH, true );
-			if ( $stored_hash === $content_hash ) {
+			$post        = get_post( $existing_id );
+			$same_parent = ! $post instanceof \WP_Post || $parent_id <= 0 || (int) $post->post_parent === $parent_id;
+			$same_slug   = ! $post instanceof \WP_Post || '' === $slug || (string) $post->post_name === $slug;
+			if ( $stored_hash === $content_hash && $same_parent && $same_slug ) {
 				self::applySourceMetadata( $existing_id, $source_url, $original_date_gmt );
-				$post       = get_post( $existing_id );
 				$post_title = $post instanceof \WP_Post ? $post->post_title : $title;
 				return array(
 					'success'  => true,

--- a/inc/Core/WordPress/ResolvePostByPath.php
+++ b/inc/Core/WordPress/ResolvePostByPath.php
@@ -51,7 +51,7 @@ class ResolvePostByPath {
 		}
 
 		if ( str_contains( $identifier, '/' ) ) {
-			$parts     = array_values( array_filter( explode( '/', $identifier ) ) );
+			$parts          = array_values( array_filter( explode( '/', $identifier ) ) );
 			$current_parent = $parent_id;
 
 			foreach ( $parts as $slug_part ) {
@@ -174,6 +174,77 @@ class ResolvePostByPath {
 		string $stub_meta_key,
 		array $stub_defaults = array()
 	) {
+		$found = self::find_stub( $slug, $post_type, $parent_id );
+
+		if ( ! empty( $found ) ) {
+			return (int) $found;
+		}
+
+		$lock_key = self::stub_lock_key( $slug, $post_type, $parent_id );
+		$locked   = self::acquire_stub_lock( $lock_key );
+
+		if ( ! $locked ) {
+			$found = self::find_stub( $slug, $post_type, $parent_id );
+			if ( ! empty( $found ) ) {
+				return (int) $found;
+			}
+
+			return new \WP_Error(
+				'stub_lock_timeout',
+				sprintf( 'Timed out waiting to create %s stub: %s', $post_type, $slug )
+			);
+		}
+
+		try {
+			$found = self::find_stub( $slug, $post_type, $parent_id );
+			if ( ! empty( $found ) ) {
+				return (int) $found;
+			}
+
+			$title = ucwords( str_replace( array( '-', '_' ), ' ', $slug ) );
+
+			$defaults = array(
+				'post_type'      => $post_type,
+				'post_title'     => $title,
+				'post_name'      => $slug,
+				'post_parent'    => $parent_id,
+				'post_status'    => 'publish',
+				'post_content'   => '',
+				'comment_status' => 'closed',
+				'ping_status'    => 'closed',
+			);
+
+			$post_data = wp_parse_args( $stub_defaults, $defaults );
+
+			$new_id = wp_insert_post( $post_data, true );
+
+			if ( is_wp_error( $new_id ) ) {
+				return $new_id;
+			}
+
+			$created = get_post( (int) $new_id );
+			if ( $created && $created->post_name !== $slug ) {
+				$found = self::find_stub( $slug, $post_type, $parent_id );
+				if ( ! empty( $found ) ) {
+					wp_delete_post( (int) $new_id, true );
+					return (int) $found;
+				}
+			}
+
+			if ( '' !== $stub_meta_key ) {
+				update_post_meta( (int) $new_id, $stub_meta_key, '1' );
+			}
+
+			return (int) $new_id;
+		} finally {
+			delete_option( $lock_key );
+		}
+	}
+
+	/**
+	 * Find an existing slug under the requested parent.
+	 */
+	private static function find_stub( string $slug, string $post_type, int $parent_id ): int {
 		$found = get_posts(
 			array(
 				'post_type'      => $post_type,
@@ -186,36 +257,35 @@ class ResolvePostByPath {
 			)
 		);
 
-		if ( ! empty( $found ) ) {
-			return (int) $found[0];
+		return empty( $found ) ? 0 : (int) $found[0];
+	}
+
+	/**
+	 * Return the option key used as an atomic DB-backed stub creation lock.
+	 */
+	private static function stub_lock_key( string $slug, string $post_type, int $parent_id ): string {
+		return '_datamachine_stub_lock_' . md5( $post_type . '|' . $parent_id . '|' . $slug );
+	}
+
+	/**
+	 * Acquire a short-lived creation lock using add_option's unique key insert.
+	 */
+	private static function acquire_stub_lock( string $lock_key ): bool {
+		for ( $attempt = 0; $attempt < 40; $attempt++ ) {
+			if ( add_option( $lock_key, (string) time(), '', false ) ) {
+				return true;
+			}
+
+			$locked_at = (int) get_option( $lock_key, 0 );
+			if ( $locked_at > 0 && time() - $locked_at > 30 ) {
+				delete_option( $lock_key );
+				continue;
+			}
+
+			usleep( 50000 );
 		}
 
-		$title = ucwords( str_replace( array( '-', '_' ), ' ', $slug ) );
-
-		$defaults = array(
-			'post_type'      => $post_type,
-			'post_title'     => $title,
-			'post_name'      => $slug,
-			'post_parent'    => $parent_id,
-			'post_status'    => 'publish',
-			'post_content'   => '',
-			'comment_status' => 'closed',
-			'ping_status'    => 'closed',
-		);
-
-		$post_data = wp_parse_args( $stub_defaults, $defaults );
-
-		$new_id = wp_insert_post( $post_data, true );
-
-		if ( is_wp_error( $new_id ) ) {
-			return $new_id;
-		}
-
-		if ( '' !== $stub_meta_key ) {
-			update_post_meta( (int) $new_id, $stub_meta_key, '1' );
-		}
-
-		return (int) $new_id;
+		return false;
 	}
 
 	/**

--- a/tests/resolve-post-by-path-stub-concurrency-smoke.php
+++ b/tests/resolve-post-by-path-stub-concurrency-smoke.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Pure-PHP smoke test for concurrent path stub creation safeguards.
+ *
+ * Run with: php tests/resolve-post-by-path-stub-concurrency-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+$GLOBALS['__rpbp_posts']      = array();
+$GLOBALS['__rpbp_next_id']    = 100;
+$GLOBALS['__rpbp_options']    = array();
+$GLOBALS['__rpbp_meta']       = array();
+$GLOBALS['__rpbp_failures']   = 0;
+$GLOBALS['__rpbp_race_slug']  = '';
+$GLOBALS['__rpbp_race_fired'] = false;
+
+class WP_Error {
+	private string $code;
+	private string $message;
+
+	public function __construct( string $code = '', string $message = '' ) {
+		$this->code    = $code;
+		$this->message = $message;
+	}
+
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+}
+
+class WP_Post {
+	public int $ID = 0;
+	public string $post_type = 'wiki';
+	public string $post_title = '';
+	public string $post_name = '';
+	public int $post_parent = 0;
+}
+
+function rpbp_assert( bool $ok, string $message ): void {
+	if ( $ok ) {
+		echo "  PASS: {$message}\n";
+		return;
+	}
+
+	echo "  FAIL: {$message}\n";
+	$GLOBALS['__rpbp_failures']++;
+}
+
+function rpbp_insert_post( string $slug, int $parent_id, string $title = '' ): int {
+	$post              = new WP_Post();
+	$post->ID          = $GLOBALS['__rpbp_next_id']++;
+	$post->post_title  = '' !== $title ? $title : ucwords( str_replace( '-', ' ', $slug ) );
+	$post->post_name   = $slug;
+	$post->post_parent = $parent_id;
+
+	$GLOBALS['__rpbp_posts'][ $post->ID ] = $post;
+	return $post->ID;
+}
+
+function get_posts( array $args ): array {
+	$out = array();
+	foreach ( $GLOBALS['__rpbp_posts'] as $post ) {
+		if ( ( $args['post_type'] ?? '' ) !== $post->post_type ) {
+			continue;
+		}
+		if ( isset( $args['name'] ) && (string) $args['name'] !== $post->post_name ) {
+			continue;
+		}
+		if ( isset( $args['post_parent'] ) && (int) $args['post_parent'] !== $post->post_parent ) {
+			continue;
+		}
+		$out[] = 'ids' === ( $args['fields'] ?? '' ) ? $post->ID : $post;
+	}
+	return $out;
+}
+
+function wp_parse_args( array $args, array $defaults ): array { return array_merge( $defaults, $args ); }
+function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+
+function add_option( string $name, $value = '', $deprecated = '', $autoload = null ): bool {
+	unset( $deprecated, $autoload );
+	if ( array_key_exists( $name, $GLOBALS['__rpbp_options'] ) ) {
+		return false;
+	}
+	$GLOBALS['__rpbp_options'][ $name ] = $value;
+	return true;
+}
+
+function delete_option( string $name ): bool {
+	unset( $GLOBALS['__rpbp_options'][ $name ] );
+	return true;
+}
+
+function get_option( string $name, $default = false ) { return $GLOBALS['__rpbp_options'][ $name ] ?? $default; }
+
+function wp_insert_post( array $post_data, bool $wp_error = false ) {
+	unset( $wp_error );
+	$slug      = (string) ( $post_data['post_name'] ?? '' );
+	$parent_id = (int) ( $post_data['post_parent'] ?? 0 );
+
+	if ( $GLOBALS['__rpbp_race_slug'] === $slug && ! $GLOBALS['__rpbp_race_fired'] ) {
+		$GLOBALS['__rpbp_race_fired'] = true;
+		rpbp_insert_post( $slug, $parent_id, 'Canonical Race Winner' );
+	}
+
+	if ( ! empty( get_posts( array( 'post_type' => (string) $post_data['post_type'], 'name' => $slug, 'post_parent' => $parent_id, 'fields' => 'ids' ) ) ) ) {
+		$slug .= '-2';
+	}
+
+	return rpbp_insert_post( $slug, $parent_id, (string) ( $post_data['post_title'] ?? '' ) );
+}
+
+function get_post( int $post_id ) { return $GLOBALS['__rpbp_posts'][ $post_id ] ?? null; }
+
+function wp_delete_post( int $post_id, bool $force_delete = false ) {
+	unset( $force_delete );
+	unset( $GLOBALS['__rpbp_posts'][ $post_id ] );
+	return true;
+}
+
+function update_post_meta( int $post_id, string $key, $value ): void { $GLOBALS['__rpbp_meta'][ $post_id ][ $key ] = $value; }
+}
+
+namespace {
+require_once dirname( __DIR__ ) . '/inc/Core/WordPress/ResolvePostByPath.php';
+
+echo "=== resolve-post-by-path-stub-concurrency-smoke ===\n";
+
+$GLOBALS['__rpbp_race_slug'] = 'jetpack';
+$resolved = \DataMachine\Core\WordPress\ResolvePostByPath::resolve_or_create_stub( 'jetpack', 'wiki', 0, '_auto_stub' );
+
+rpbp_assert( 100 === $resolved, 'returns the concurrently-created canonical stub' );
+rpbp_assert( 1 === count( $GLOBALS['__rpbp_posts'] ), 'removes the duplicate suffixed stub created by the race' );
+rpbp_assert( 'jetpack' === get_post( (int) $resolved )->post_name, 'canonical stub keeps requested slug' );
+
+if ( $GLOBALS['__rpbp_failures'] > 0 ) {
+	exit( 1 );
+}
+
+echo "All resolve-post-by-path stub concurrency checks passed.\n";
+}


### PR DESCRIPTION
## Summary
- Add an atomic DB-backed lock around hierarchical path stub creation.
- Re-resolve and clean up suffixed duplicates if a concurrent insert wins the race.
- Keep upsert idempotency from skipping requested parent/slug repairs when content is unchanged.

## Testing
- php tests/resolve-post-by-path-stub-concurrency-smoke.php
- homeboy lint --changed-since origin/main
- homeboy test --changed-since origin/main

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the concurrency guard, idempotency fix, smoke coverage, and ran scoped verification; Chris reviewed and requested the fix path.