### PR TITLE
fix: scope handler tool cache by job config

### DIFF
--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -240,7 +240,7 @@ class ToolManager {
 		array $engine_data,
 		string $cache_scope = ''
 	): array {
-		$cache_key = $cache_scope . '|handler_tools|' . $handler_slug;
+		$cache_key = self::buildHandlerToolsCacheKey( $cache_scope, $handler_slug, $handler_config, $engine_data );
 
 		if ( '' !== $cache_scope && isset( self::$resolved_cache[ $cache_key ] ) ) {
 			return self::$resolved_cache[ $cache_key ];
@@ -348,6 +348,38 @@ class ToolManager {
 		}
 
 		return $resolved;
+	}
+
+	/**
+	 * Build a cache key for adjacent handler tool resolution.
+	 *
+	 * Direct workflows reuse synthetic flow_step_ids like `ephemeral_step_2`
+	 * across jobs. Handler tools carry the adjacent step's handler_config, so
+	 * the cache key must include the config and job identity to avoid reusing a
+	 * previous job's pinned write target.
+	 *
+	 * @param string $cache_scope    Scope key (usually flow_step_id).
+	 * @param string $handler_slug   Adjacent step handler slug.
+	 * @param array  $handler_config Handler configuration from flow step.
+	 * @param array  $engine_data    Engine data snapshot.
+	 * @return string Cache key.
+	 */
+	private static function buildHandlerToolsCacheKey( string $cache_scope, string $handler_slug, array $handler_config, array $engine_data ): string {
+		$job_snapshot = is_array( $engine_data['job'] ?? null ) ? $engine_data['job'] : array();
+		$job_id       = (int) ( $engine_data['job_id'] ?? $job_snapshot['job_id'] ?? 0 );
+		$config_json  = wp_json_encode( $handler_config );
+		$config_hash  = md5( false === $config_json ? '' : $config_json );
+
+		return implode(
+			'|',
+			array(
+				$cache_scope,
+				'handler_tools',
+				$handler_slug,
+				'job:' . $job_id,
+				'config:' . $config_hash,
+			)
+		);
 	}
 
 	/**

--- a/tests/Unit/AI/Tools/HandlerToolResolutionTest.php
+++ b/tests/Unit/AI/Tools/HandlerToolResolutionTest.php
@@ -298,6 +298,47 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 		$this->assertSame( 2, $invocations, 'Different scope must re-invoke callback.' );
 	}
 
+	public function test_resolution_cache_varies_by_handler_config_and_job(): void {
+		$invocations = 0;
+		add_filter(
+			'datamachine_tools',
+			function ( array $tools ) use ( &$invocations ): array {
+				$tools['__handler_tools_pinned'] = array(
+					'_handler_callable' => function ( string $slug, array $config ) use ( &$invocations ) {
+						unset( $slug );
+						$invocations++;
+						return array(
+							'pinned' => array(
+								'description'    => 'Pinned handler',
+								'handler_config' => $config,
+							),
+						);
+					},
+					'handler'           => 'pinned',
+					'modes'             => array( 'pipeline' ),
+				);
+				return $tools;
+			}
+		);
+
+		$first = $this->tool_manager->resolveHandlerTools(
+			'pinned',
+			array( 'fixed_slug' => '13751' ),
+			array( 'job' => array( 'job_id' => 55300 ) ),
+			'ephemeral_step_2'
+		);
+		$second = $this->tool_manager->resolveHandlerTools(
+			'pinned',
+			array( 'fixed_slug' => '13378' ),
+			array( 'job' => array( 'job_id' => 55301 ) ),
+			'ephemeral_step_2'
+		);
+
+		$this->assertSame( 2, $invocations, 'Same ephemeral step must not reuse handler tools across different jobs/configs.' );
+		$this->assertSame( '13751', $first['pinned']['handler_config']['fixed_slug'] ?? null );
+		$this->assertSame( '13378', $second['pinned']['handler_config']['fixed_slug'] ?? null );
+	}
+
 	public function test_no_caching_when_scope_is_empty(): void {
 		$invocations = 0;
 		add_filter(


### PR DESCRIPTION
## Summary
- include handler config and current job identity in adjacent handler tool cache keys
- prevent direct workflows from reusing stale pinned handler configs across jobs
- add coverage for same ephemeral step IDs with different job/config pairs

## Testing
- homeboy lint --changed-since origin/main
- homeboy test --changed-since origin/main

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause investigation, patch implementation, and scoped test updates; Chris remains responsible for review and validation.