### PR TITLE
Fix agent memory artifact scope export

### DIFF
--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -229,9 +229,9 @@ class JobArtifacts {
 			if ( $agent_id <= 0 && $default_agent_id > 0 ) {
 				$agent_id = $default_agent_id;
 			}
-			$user_id  = (int) ( $tool_call['user_id'] ?? ( $job['user_id'] ?? 0 ) );
-			$layer    = AgentMemoryFile::resolve_layer_for( $filename );
-			$key      = $layer . ':' . $agent_id . ':' . $user_id . ':' . $filename;
+			$user_id = (int) ( $tool_call['user_id'] ?? ( $job['user_id'] ?? 0 ) );
+			$layer   = AgentMemoryFile::resolve_layer_for( $filename );
+			$key     = $layer . ':' . $agent_id . ':' . $user_id . ':' . $filename;
 
 			$files[ $key ] = array(
 				'agent_id' => $agent_id,

--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -225,7 +225,10 @@ class JobArtifacts {
 				continue;
 			}
 
-			$agent_id = (int) ( $tool_call['agent_id'] ?? $default_agent_id );
+			$agent_id = (int) ( $tool_call['agent_id'] ?? 0 );
+			if ( $agent_id <= 0 && $default_agent_id > 0 ) {
+				$agent_id = $default_agent_id;
+			}
 			$user_id  = (int) ( $tool_call['user_id'] ?? ( $job['user_id'] ?? 0 ) );
 			$layer    = AgentMemoryFile::resolve_layer_for( $filename );
 			$key      = $layer . ':' . $agent_id . ':' . $user_id . ':' . $filename;

--- a/inc/Engine/AI/Tools/Global/AgentMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentMemory.php
@@ -90,6 +90,7 @@ class AgentMemory extends BaseTool {
 		return array(
 			'success'   => true,
 			'data'      => $result,
+			'scope'     => $scope,
 			'tool_name' => 'agent_memory',
 		);
 	}
@@ -157,6 +158,7 @@ class AgentMemory extends BaseTool {
 		return array(
 			'success'   => true,
 			'data'      => $result,
+			'scope'     => $scope,
 			'tool_name' => 'agent_memory',
 		);
 	}
@@ -202,6 +204,7 @@ class AgentMemory extends BaseTool {
 		return array(
 			'success'   => true,
 			'data'      => $result,
+			'scope'     => $scope,
 			'tool_name' => 'agent_memory',
 		);
 	}

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1086,8 +1086,9 @@ function datamachine_summarize_tool_execution_results( array $tool_execution_res
 		}
 
 		if ( 'agent_memory' === $tool_name ) {
-			$summary['user_id']  = isset( $parameters['user_id'] ) ? (int) $parameters['user_id'] : null;
-			$summary['agent_id'] = isset( $parameters['agent_id'] ) ? (int) $parameters['agent_id'] : null;
+			$scope               = is_array( $tool_result['scope'] ?? null ) ? $tool_result['scope'] : array();
+			$summary['user_id']  = isset( $scope['user_id'] ) ? (int) $scope['user_id'] : ( isset( $parameters['user_id'] ) ? (int) $parameters['user_id'] : null );
+			$summary['agent_id'] = isset( $scope['agent_id'] ) ? (int) $scope['agent_id'] : ( isset( $parameters['agent_id'] ) ? (int) $parameters['agent_id'] : null );
 			$summary['action']   = isset( $parameters['action'] ) ? sanitize_key( (string) $parameters['action'] ) : null;
 			$summary['file']     = isset( $parameters['file'] ) ? sanitize_file_name( (string) $parameters['file'] ) : 'MEMORY.md';
 			$summary['section']  = isset( $parameters['section'] ) ? sanitize_text_field( (string) $parameters['section'] ) : null;

--- a/tests/job-artifacts-daily-memory-smoke.php
+++ b/tests/job-artifacts-daily-memory-smoke.php
@@ -87,10 +87,11 @@ $assert(
 
 $assert(
 	false !== strpos( $loop, "'agent_memory' === \$tool_name" )
+		&& false !== strpos( $loop, "\$tool_result['scope']" )
 		&& false !== strpos( $loop, "\$summary['file']" )
 		&& false !== strpos( $loop, "\$summary['section']" )
 		&& false !== strpos( $loop, "'update' === \$summary['action']" ),
-	'agent memory update summaries preserve file, section, action, and content for artifact export'
+	'agent memory update summaries preserve resolved scope, file, section, action, and content for artifact export'
 );
 
 $assert(
@@ -110,8 +111,9 @@ $assert(
 $assert(
 	false !== strpos( $job_artifacts, 'new AgentMemoryFile' )
 		&& false !== strpos( $job_artifacts, 'get_all()' )
+		&& false !== strpos( $job_artifacts, '$agent_id <= 0 && $default_agent_id > 0' )
 		&& false !== strpos( $job_artifacts, 'agent_memory_fallback_content' ),
-	'agent memory artifacts export the full updated file content with a write-content fallback'
+	'agent memory artifacts export the full updated file content using the resolved job agent when needed'
 );
 
 $assert(


### PR DESCRIPTION
## Summary
- Preserve the resolved agent memory scope in `agent_memory` tool results.
- Use the resolved scope when building job artifact memory exports so agent-scoped memory does not fall back to `agent_id: 0`.
- Extend the job artifact smoke coverage for resolved memory scopes.

## Testing
- `php tests/job-artifacts-daily-memory-smoke.php`
- `php -l inc/Engine/AI/Tools/Global/AgentMemory.php`
- `php -l inc/Engine/AI/conversation-loop.php`
- `php -l inc/Core/JobArtifacts.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the artifact scope regression and drafted the code/test changes; Chris requested the fix and remains responsible for review and merge.