### PR TITLE
fix: preserve workflow handler config fields

### DIFF
--- a/inc/Core/Steps/FlowStepConfigFactory.php
+++ b/inc/Core/Steps/FlowStepConfigFactory.php
@@ -43,6 +43,8 @@ class FlowStepConfigFactory {
 					'disabled_tools'     => $step['disabled_tools'] ?? array(),
 					'pipeline_id'        => 'direct',
 					'flow_id'            => 'direct',
+					'handler_slug'       => $step['handler_slug'] ?? '',
+					'handler_config'     => $step['handler_config'] ?? array(),
 					'handler_slugs'      => $step['handler_slugs'] ?? array(),
 					'handler_configs'    => $step['handler_configs'] ?? array(),
 					'flow_step_settings' => $step['flow_step_settings'] ?? array(),
@@ -131,9 +133,18 @@ class FlowStepConfigFactory {
 			}
 		}
 
+		$handler_slug       = is_string( $args['handler_slug'] ?? null ) ? (string) $args['handler_slug'] : '';
+		$handler_config     = is_array( $args['handler_config'] ?? null ) ? $args['handler_config'] : array();
 		$flow_step_settings = is_array( $args['flow_step_settings'] ?? null ) ? $args['flow_step_settings'] : array();
 		$handler_slugs      = is_array( $args['handler_slugs'] ?? null ) ? $args['handler_slugs'] : array();
 		$handler_configs    = is_array( $args['handler_configs'] ?? null ) ? $args['handler_configs'] : array();
+
+		if ( '' !== $handler_slug ) {
+			$handler_slugs[] = $handler_slug;
+			if ( ! array_key_exists( $handler_slug, $handler_configs ) ) {
+				$handler_configs[ $handler_slug ] = $handler_config;
+			}
+		}
 
 		if ( FlowStepConfig::usesHandler( $step_config ) ) {
 			$step_config = FlowStepConfig::normalizeHandlerShape(

--- a/tests/workflow-persistent-install-smoke.php
+++ b/tests/workflow-persistent-install-smoke.php
@@ -155,6 +155,25 @@ assert_workflow_equals( array( 'datamachine/delete-flow' ), $flow_steps[1]['disa
 assert_workflow_equals( array( array( 'prompt' => 'Prompt A', 'added_at' => '2026-04-27T00:00:00Z' ) ), $flow_steps[2]['prompt_queue'] ?? null, 'flow preserves explicit prompt queue', $failures, $passes );
 assert_workflow_equals( 'loop', $flow_steps[2]['queue_mode'] ?? null, 'flow preserves explicit AI queue mode', $failures, $passes );
 
+$legacy_handler_workflow = array(
+	'steps' => array(
+		array(
+			'type'           => 'fetch',
+			'handler_slug'   => 'mcp',
+			'handler_config' => array( 'query' => 'https://example.com/source' ),
+		),
+		array(
+			'type'           => 'upsert',
+			'handler_slug'   => 'wiki_upsert',
+			'handler_config' => array( 'fixed_slug' => '13751' ),
+		),
+	),
+);
+$legacy_handler_config = WorkflowConfigFactory::buildEphemeralConfigs( $legacy_handler_workflow )['flow_config'];
+assert_workflow_equals( array( 'mcp' ), $legacy_handler_config['ephemeral_step_0']['handler_slugs'] ?? null, 'workflow handler_slug maps to handler_slugs', $failures, $passes );
+assert_workflow_equals( array( 'mcp' => array( 'query' => 'https://example.com/source' ) ), $legacy_handler_config['ephemeral_step_0']['handler_configs'] ?? null, 'workflow handler_config maps to handler_configs', $failures, $passes );
+assert_workflow_equals( array( 'wiki_upsert' => array( 'fixed_slug' => '13751' ) ), $legacy_handler_config['ephemeral_step_1']['handler_configs'] ?? null, 'workflow upsert handler_config is preserved', $failures, $passes );
+
 $execute_workflow_source = file_get_contents( __DIR__ . '/../inc/Abilities/Job/ExecuteWorkflowAbility.php' ) ?: '';
 $create_pipeline_source  = file_get_contents( __DIR__ . '/../inc/Abilities/Pipeline/CreatePipelineAbility.php' ) ?: '';
 


### PR DESCRIPTION
## Summary
- restore public workflow step support for handler_slug and handler_config
- map legacy workflow handler fields into canonical handler_slugs and handler_configs
- add smoke coverage for fetch/upsert workflow steps using the documented single-handler shape

## Testing
- homeboy lint --changed-since origin/main
- homeboy test --changed-since origin/main

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause investigation, patch implementation, and scoped smoke coverage; Chris remains responsible for review and validation.