### PR TITLE
fix: isolate action scheduler drain failures

### DIFF
--- a/inc/Cli/Commands/DrainCommand.php
+++ b/inc/Cli/Commands/DrainCommand.php
@@ -177,7 +177,7 @@ class DrainCommand extends BaseCommand {
 			'action-scheduler action run ' . implode( ' ', array_map( 'intval', $action_ids ) ),
 			array(
 				'exit_error' => false,
-				'launch'     => false,
+				'launch'     => true,
 				'return'     => 'all',
 			)
 		);

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -44,7 +44,7 @@ assert_drain_contains( "a.status = \\'pending\\'", $drain_src, 'drain queries pe
 assert_drain_contains( 'getDuePendingActionIds', $drain_src, 'drain queries concrete due Data Machine action IDs' );
 assert_drain_contains( 'action-scheduler action run ', $drain_src, 'drain runs concrete action IDs instead of generic queue runner' );
 assert_drain_contains( "'exit_error' => false", $drain_src, 'drain failure is surfaced as warning instead of fataling after job start' );
-assert_drain_contains( "'launch'     => false", $drain_src, 'drain runs nested WP-CLI command in-process for Studio compatibility' );
+assert_drain_contains( "'launch'     => true", $drain_src, 'drain isolates nested Action Scheduler CLI fatals from the parent drain command' );
 assert_drain_contains( "'return'     => 'all'", $drain_src, 'drain captures Action Scheduler command result' );
 assert_drain_contains( "'remaining_pending'", $drain_src, 'drain reports remaining pending actions' );
 assert_drain_contains( "'batch_chunks'", $drain_src, 'drain reports batch chunk counts' );


### PR DESCRIPTION
## Summary
- Runs nested `action-scheduler action run` calls in an isolated WP-CLI process so Action Scheduler fatals do not take down `wp datamachine drain`.
- Keeps existing drain behavior that captures nested command output and reports non-zero results as warnings.
- Updates the drain smoke test to lock in isolated execution.

Fixes #2085.

## Testing
- `php -l inc/Cli/Commands/DrainCommand.php`
- `php tests/flow-run-cli-drain-smoke.php`
- `homeboy test --changed-since origin/main`
- `homeboy lint --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the local drain fatal, drafted the targeted CLI isolation fix, updated smoke coverage, and ran verification for Chris to review.