### PR TITLE
fix: run drain actions without nested cli

### DIFF
--- a/inc/Cli/Commands/DrainCommand.php
+++ b/inc/Cli/Commands/DrainCommand.php
@@ -170,16 +170,29 @@ class DrainCommand extends BaseCommand {
 	 * Run specific due Action Scheduler actions.
 	 *
 	 * @param int[] $action_ids Action IDs.
-	 * @return object WP_CLI::runcommand result object.
+	 * @return object Result object with return_code and stderr fields.
 	 */
 	private static function runActionSchedulerActions( array $action_ids ): object {
-		return WP_CLI::runcommand(
-			'action-scheduler action run ' . implode( ' ', array_map( 'intval', $action_ids ) ),
-			array(
-				'exit_error' => false,
-				'launch'     => true,
-				'return'     => 'all',
-			)
+		$runner   = \ActionScheduler::runner();
+		$warnings = array();
+
+		foreach ( $action_ids as $action_id ) {
+			$action_id = absint( $action_id );
+			if ( $action_id <= 0 ) {
+				continue;
+			}
+
+			try {
+				$runner->process_action( $action_id, 'Data Machine CLI drain' );
+			} catch ( \Throwable $throwable ) {
+				$warnings[] = sprintf( 'Action %d failed during drain: %s', $action_id, $throwable->getMessage() );
+			}
+		}
+
+		return (object) array(
+			'return_code' => empty( $warnings ) ? 0 : 1,
+			'stdout'      => '',
+			'stderr'      => implode( "\n", $warnings ),
 		);
 	}
 

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -42,10 +42,10 @@ assert_drain_contains( "datamachine_execute_step'", $drain_src, 'drain includes 
 assert_drain_contains( 'hookWhereSql( $hooks )', $drain_src, 'drain supports an optional hook scope' );
 assert_drain_contains( "a.status = \\'pending\\'", $drain_src, 'drain queries pending actions in the Data Machine group' );
 assert_drain_contains( 'getDuePendingActionIds', $drain_src, 'drain queries concrete due Data Machine action IDs' );
-assert_drain_contains( 'action-scheduler action run ', $drain_src, 'drain runs concrete action IDs instead of generic queue runner' );
-assert_drain_contains( "'exit_error' => false", $drain_src, 'drain failure is surfaced as warning instead of fataling after job start' );
-assert_drain_contains( "'launch'     => true", $drain_src, 'drain isolates nested Action Scheduler CLI fatals from the parent drain command' );
-assert_drain_contains( "'return'     => 'all'", $drain_src, 'drain captures Action Scheduler command result' );
+assert_drain_contains( "\\ActionScheduler::runner()", $drain_src, 'drain runs concrete action IDs through Action Scheduler runner' );
+assert_drain_contains( "'Data Machine CLI drain'", $drain_src, 'drain records a Data Machine-specific execution context' );
+assert_drain_contains( 'catch ( \\Throwable $throwable )', $drain_src, 'drain catches per-action runner failures instead of fataling after job start' );
+assert_drain_contains( "'return_code' => empty( \$warnings ) ? 0 : 1", $drain_src, 'drain surfaces runner failures through a result object' );
 assert_drain_contains( "'remaining_pending'", $drain_src, 'drain reports remaining pending actions' );
 assert_drain_contains( "'batch_chunks'", $drain_src, 'drain reports batch chunk counts' );
 assert_drain_contains( "'step_executions'", $drain_src, 'drain reports step execution counts' );


### PR DESCRIPTION
## Summary
- Replaces the nested `action-scheduler action run` WP-CLI call with direct `ActionScheduler::runner()->process_action()` calls for each due action id.
- Catches `Throwable` per action so raced/deleted Action Scheduler actions are reported as drain warnings instead of taking down the whole drain.
- Keeps Studio-compatible drain execution without relying on an isolated PHP binary path.

Fixes #2087.

## Testing
- `php -l inc/Cli/Commands/DrainCommand.php`
- `php tests/flow-run-cli-drain-smoke.php`
- `homeboy test --changed-since origin/main`
- `homeboy lint --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Studio launch regression from the first drain fix, drafted the direct runner implementation and smoke-test updates, and ran verification for Chris to review.