### PR TITLE
Fix user principal agent access grants

### DIFF
--- a/inc/Core/Auth/AgentAccessStoreAdapter.php
+++ b/inc/Core/Auth/AgentAccessStoreAdapter.php
@@ -165,7 +165,7 @@ class AgentAccessStoreAdapter implements \WP_Agent_Access_Store, \WP_Agent_Princ
 	public function get_access_for_principal( string $agent_id, \AgentsAPI\AI\WP_Agent_Execution_Principal $principal, ?string $workspace_id = null ): ?\WP_Agent_Access_Grant {
 		$normalized = $this->normalize_principal( $principal );
 		if ( null === $normalized ) {
-			return null;
+			return $principal->acting_user_id > 0 ? $this->get_access( $agent_id, $principal->acting_user_id, $workspace_id ) : null;
 		}
 
 		$grant = $this->access_repository->get_principal_access( $this->storage_agent_id( $agent_id ), $normalized['principal_type'], $normalized['principal_id'], $workspace_id );
@@ -180,7 +180,7 @@ class AgentAccessStoreAdapter implements \WP_Agent_Access_Store, \WP_Agent_Princ
 	public function get_agent_ids_for_principal( \AgentsAPI\AI\WP_Agent_Execution_Principal $principal, ?string $minimum_role = null, ?string $workspace_id = null ): array {
 		$normalized = $this->normalize_principal( $principal );
 		if ( null === $normalized ) {
-			return array();
+			return $principal->acting_user_id > 0 ? $this->get_agent_ids_for_user( $principal->acting_user_id, $minimum_role, $workspace_id ) : array();
 		}
 
 		$agent_ids = $this->access_repository->get_agent_ids_for_principal( $normalized['principal_type'], $normalized['principal_id'], $minimum_role, $workspace_id );

--- a/tests/agents-api-access-store-adapter-smoke.php
+++ b/tests/agents-api-access-store-adapter-smoke.php
@@ -224,6 +224,11 @@ agents_api_smoke_assert_equals( $stored_grant->to_array(), $repository->get_acce
 agents_api_smoke_assert_equals( $grant->to_array(), $adapter->get_access( 'wiki-brain', 7 )->to_array(), 'get_access maps slug to storage ID and returns slug contract', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'wiki-brain' ), $adapter->get_agent_ids_for_user( 7, \WP_Agent_Access_Grant::ROLE_VIEWER ), 'agent ID list is Agents API slug shape', $failures, $passes );
 agents_api_smoke_assert_equals( array( $grant->to_array() ), array_map( static fn( \WP_Agent_Access_Grant $value ): array => $value->to_array(), $adapter->get_users_for_agent( 'wiki-brain' ) ), 'get_users_for_agent returns slug contract', $failures, $passes );
+
+$user_principal = \AgentsAPI\AI\WP_Agent_Execution_Principal::user_session( 7, '__wordpress_user__' );
+agents_api_smoke_assert_equals( $grant->to_array(), $adapter->get_access_for_principal( 'wiki-brain', $user_principal )->to_array(), 'principal grant falls back to user access for WordPress user sessions', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'wiki-brain' ), $adapter->get_agent_ids_for_principal( $user_principal, \WP_Agent_Access_Grant::ROLE_VIEWER ), 'principal agent IDs fall back to user access for WordPress user sessions', $failures, $passes );
+
 agents_api_smoke_assert_equals( true, $adapter->revoke_access( 'wiki-brain', 7 ), 'revoke maps slug to storage ID', $failures, $passes );
 agents_api_smoke_assert_equals( null, $adapter->get_access( 'wiki-brain', 7 ), 'revoke removes repository grant', $failures, $passes );
 


### PR DESCRIPTION
## Summary
- fall back to Data Machine user access grants when an Agents API principal represents a logged-in WordPress user
- keep non-user audience principal grants on the existing principal-access path
- add smoke coverage for user-principal access/list fallback

## Testing
- php tests/agents-api-access-store-adapter-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the logged-in frontend chat access regression, drafted the Data Machine adapter fix, and ran the targeted smoke test. Chris remains responsible for review and validation.
