### PR TITLE
feat(oauth): per-user OAuth credential resolution + calling_user_id in AI payload (closes #2081)

### DIFF
--- a/docs/core-system/oauth-handlers.md
+++ b/docs/core-system/oauth-handlers.md
@@ -61,6 +61,173 @@ All providers store data in WordPress options using a consistent structure:
 ]
 ```
 
+### Per-user account API (@since v0.123.0)
+
+Three concrete methods on `BaseAuthProvider` let callers operate on a specific
+human user's credentials, independent of the site-wide account slot:
+
+```php
+public function get_account_for_user( int $user_id ): ?array;
+public function save_account_for_user( int $user_id, array $account ): bool;
+public function delete_account_for_user( int $user_id ): bool;
+```
+
+These share the same on-disk shape as the principal-scoped API
+(`principals[user:<id>][account]`), so an account written via either surface
+is readable through the other. They differ from the scope-aware
+`get_account( array $context )` in two ways:
+
+1. **No scope policy consultation.** A caller invoking
+   `get_account_for_user( 101 )` has made a deliberate choice — the return
+   value reflects that user's slot or null.
+2. **No site fallback.** A missing per-user account always returns `null`,
+   never the shared site account. This prevents cross-user leakage in
+   callers that did not explicitly opt in to a site fallback.
+
+Resolution order inside `get_account_for_user()`:
+
+1. **`datamachine_resolve_oauth_account_for_user` filter** — platform
+   plugins return a non-null array to plug in their own per-user storage
+   (custom table, external KMS, encrypted blob). Returning null lets the
+   default path run. Filter results are NOT re-decrypted: platform plugins
+   are responsible for returning already-plaintext account data.
+2. **Default storage** at `principals[user:<id>][account]` (encrypted at
+   rest, decrypted on read).
+3. **`null`** if neither yields an account.
+
+Every successful resolve emits a `debug`-level entry via the
+`datamachine_log` action with `{ provider, user_id, source }`. Failed
+lookups do not log (they would dwarf real signal during normal "no account
+yet" probes). The token itself is never logged at any level.
+
+#### When to use per-user vs. site-wide credentials
+
+```
+Decision flow:
+
+  Does the agent need credentials tied to a specific human user?
+   │
+   ├── Yes ──→ Use per-user API (get_account_for_user)
+   │           Caller resolves calling_user_id from $payload first.
+   │
+   └── No  ──→ Use site-wide API (get_account, no context)
+               Bot accounts, shared posting accounts, scheduled flows.
+```
+
+Use **per-user** for any workflow where the credential authorizes access to
+a specific human's data: "read my files on the upstream service", "post to
+my own account", "summarize my mailbox". The agent must know who is asking
+— see the `calling_user_id` section below.
+
+Use **site-wide** for shared automation: the platform's own bot account, a
+single shared posting account, anything where "whose account is this?" is
+not a meaningful question.
+
+#### Vendor-plugin pattern
+
+A vendor plugin (`data-machine-business`, `data-machine-socials`, etc.)
+registers an ability that reads its own credentials. Inside the ability's
+execute callback:
+
+```php
+use function DataMachine\Engine\AI\datamachine_get_calling_user_id;
+
+public function execute_my_handler( array $input, array $context = array() ) {
+    $calling_user_id = datamachine_get_calling_user_id( $context['payload'] ?? array() );
+    $provider        = my_get_auth_provider();  // returns a BaseAuthProvider subclass
+
+    if ( $calling_user_id > 0 ) {
+        $account = $provider->get_account_for_user( $calling_user_id );
+        if ( null === $account ) {
+            return new \WP_Error(
+                'no_per_user_credentials',
+                __( 'Connect your account before using this tool.', 'my-plugin' )
+            );
+        }
+    } else {
+        // No human caller — fall back to site-wide or refuse, depending on
+        // the handler's policy. Shared bot accounts use this branch.
+        $account = $provider->get_account();
+        if ( empty( $account['access_token'] ) ) {
+            return new \WP_Error( 'no_credentials', __( 'Not connected.', 'my-plugin' ) );
+        }
+    }
+
+    // ... use $account['access_token'] to call upstream.
+}
+```
+
+#### Revocation
+
+```bash
+# Site-wide revoke.
+wp datamachine auth revoke <handler>
+
+# Per-user revoke.
+wp datamachine auth revoke <handler> --user=42
+```
+
+Or via the abilities surface:
+
+```php
+$result = wp_get_ability( 'datamachine/revoke-auth-for-user' )->execute(
+    array(
+        'handler_slug' => 'my_handler',
+        'user_id'      => 42,
+    )
+);
+```
+
+If the provider exposes a `revoke_token_for_user( int $user_id )` method,
+the abilities executor calls it BEFORE local deletion so the upstream
+credential is invalidated even if local storage is later restored from
+backup. An upstream failure logs a warning but does not block local
+deletion — losing local access is preferable to leaking credentials.
+
+#### Calling-user identity in AI invocations
+
+`calling_user_id` is a new field on every AI invocation payload, alongside
+the existing `agent_id`. It identifies the human user on whose behalf the
+agent is acting during *this specific* invocation:
+
+| Flow                     | `calling_user_id` value                        |
+|--------------------------|------------------------------------------------|
+| Chat session             | the chat caller's user ID                      |
+| Pipeline execution       | `0` (no human caller; scheduled work)          |
+| System task              | `0` (alt-text, meta, internal-linking, etc.)   |
+| REST chat with bearer    | the bearer-owner user ID                       |
+| processPing health check | `0` (admin user_id borrowed for storage only)  |
+
+Tools and directives read it with the consumer helper:
+
+```php
+use function DataMachine\Engine\AI\datamachine_get_calling_user_id;
+
+$calling_user_id = datamachine_get_calling_user_id( $payload );
+// Returns 0 when absent, non-numeric, or non-positive.
+```
+
+`calling_user_id` is intentionally distinct from `agent_id` (the acting
+agent identity, same across invocations for one agent) and from pipeline
+`user_id` (the flow/job owner — typically an admin who scheduled the work,
+not someone "calling" the agent right now).
+
+#### Migration
+
+Existing installs need no action. The legacy site-wide flow
+(`get_account()` / `save_account()` without a context arg) continues to
+work unchanged. Tokens stored before the encryption-at-rest feature landed
+in v0.88.0 are lazy-migrated on next save. Per-user storage activates only
+when callers opt in via `get_account_for_user( $user_id )` or by setting
+`calling_user_id > 0` in the payload.
+
+For production, define `DATAMACHINE_OAUTH_ENCRYPTION_KEY` is **not**
+required: keys are derived from `wp_salt( 'auth' )`, which already pulls
+from `AUTH_KEY` / `SECURE_AUTH_KEY` / `LOGGED_IN_KEY` in `wp-config.php`.
+Operators who want explicit key isolation can rotate `AUTH_KEY` to force
+re-encryption on next save (but be aware that doing so invalidates any
+encrypted values not re-saved).
+
 ### BaseOAuth1Provider
 
 **Location**: `/inc/Core/OAuth/BaseOAuth1Provider.php`

--- a/inc/Abilities/AuthAbilities.php
+++ b/inc/Abilities/AuthAbilities.php
@@ -736,8 +736,8 @@ class AuthAbilities {
 	}
 
 	public function executeSaveAuthConfig( array $input ): array {
-		$handler_slug = sanitize_text_field( $input['handler_slug'] ?? '' );
-		$config_input = $input['config'] ?? array();
+		$handler_slug      = sanitize_text_field( $input['handler_slug'] ?? '' );
+		$config_input      = $input['config'] ?? array();
 		$principal_context = $this->getPrincipalContext( $input );
 
 		if ( empty( $handler_slug ) ) {
@@ -864,8 +864,8 @@ class AuthAbilities {
 	 * @return array Result.
 	 */
 	public function executeSetAuthToken( array $input ): array {
-		$handler_slug = sanitize_text_field( $input['handler_slug'] ?? '' );
-		$account_data = $input['account_data'] ?? array();
+		$handler_slug      = sanitize_text_field( $input['handler_slug'] ?? '' );
+		$account_data      = $input['account_data'] ?? array();
 		$principal_context = $this->getPrincipalContext( $input );
 
 		if ( empty( $handler_slug ) ) {

--- a/inc/Abilities/AuthAbilities.php
+++ b/inc/Abilities/AuthAbilities.php
@@ -178,6 +178,7 @@ class AuthAbilities {
 		$register_callback = function () {
 			$this->registerGetAuthStatus();
 			$this->registerDisconnectAuth();
+			$this->registerRevokeAuthForUser();
 			$this->registerSaveAuthConfig();
 			$this->registerSetAuthToken();
 			$this->registerRefreshAuth();
@@ -254,6 +255,46 @@ class AuthAbilities {
 					),
 				),
 				'execute_callback'    => array( $this, 'executeDisconnectAuth' ),
+				'permission_callback' => array( $this, 'checkPermission' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	private function registerRevokeAuthForUser(): void {
+		wp_register_ability(
+			'datamachine/revoke-auth-for-user',
+			array(
+				'label'               => __( 'Revoke Auth For User', 'data-machine' ),
+				'description'         => __( 'Revoke a specific user\'s OAuth credentials for a handler. Used by platform UIs to power per-user disconnect buttons.', 'data-machine' ),
+				'category'            => 'datamachine-auth',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'handler_slug', 'user_id' ),
+					'properties' => array(
+						'handler_slug' => array(
+							'type'        => 'string',
+							'description' => __( 'Handler identifier (e.g., registered handler slug).', 'data-machine' ),
+						),
+						'user_id'      => array(
+							'type'        => 'integer',
+							'description' => __( 'Target user ID whose per-user credentials should be revoked.', 'data-machine' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'          => array( 'type' => 'boolean' ),
+						'message'          => array( 'type' => 'string' ),
+						'error'            => array( 'type' => 'string' ),
+						'upstream_revoked' => array(
+							'type'        => 'boolean',
+							'description' => __( 'Whether the provider\'s upstream revoke endpoint was called successfully. Local storage is still cleared on upstream failure.', 'data-machine' ),
+						),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeRevokeAuthForUser' ),
 				'permission_callback' => array( $this, 'checkPermission' ),
 				'meta'                => array( 'show_in_rest' => true ),
 			)
@@ -570,6 +611,127 @@ class AuthAbilities {
 		return array(
 			'success' => false,
 			'error'   => __( 'Failed to disconnect account', 'data-machine' ),
+		);
+	}
+
+	/**
+	 * Revoke a specific user's OAuth credentials for a handler.
+	 *
+	 * Deletes the per-user account slot via BaseAuthProvider::delete_account_for_user.
+	 * If the provider exposes an upstream revoke method (`revoke_token_for_user`
+	 * or generic `revoke_token`), it is called BEFORE local deletion so the
+	 * upstream credential is invalidated even if we lose our copy later. An
+	 * upstream failure logs a warning but does NOT prevent local deletion —
+	 * better to lose local access than leak credentials.
+	 *
+	 * @since 0.123.0
+	 *
+	 * @param array $input { handler_slug, user_id }.
+	 * @return array Standard ability response.
+	 */
+	public function executeRevokeAuthForUser( array $input ): array {
+		$handler_slug = sanitize_text_field( $input['handler_slug'] ?? '' );
+		$user_id      = absint( $input['user_id'] ?? 0 );
+
+		if ( '' === $handler_slug ) {
+			return array(
+				'success' => false,
+				'error'   => __( 'Handler slug is required', 'data-machine' ),
+			);
+		}
+
+		if ( $user_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => __( 'A positive user_id is required', 'data-machine' ),
+			);
+		}
+
+		$auth_instance = $this->getProviderForHandler( $handler_slug );
+		if ( ! $auth_instance ) {
+			return array(
+				'success' => false,
+				'error'   => __( 'Authentication provider not found', 'data-machine' ),
+			);
+		}
+
+		if ( ! method_exists( $auth_instance, 'delete_account_for_user' ) ) {
+			return array(
+				'success' => false,
+				'error'   => __( 'This handler does not support per-user revocation', 'data-machine' ),
+			);
+		}
+
+		$revoked_by_user_id = absint( PermissionHelper::acting_user_id() );
+		if ( $revoked_by_user_id <= 0 && function_exists( 'get_current_user_id' ) ) {
+			$revoked_by_user_id = absint( get_current_user_id() );
+		}
+
+		// Best-effort upstream revoke before local delete. If the provider doesn't
+		// implement a revoke endpoint, that's fine — local-only revocation still
+		// achieves the immediate goal of cutting off this install's access.
+		$upstream_revoked = null;
+		if ( method_exists( $auth_instance, 'revoke_token_for_user' ) ) {
+			try {
+				$upstream_revoked = (bool) $auth_instance->revoke_token_for_user( $user_id );
+			} catch ( \Throwable $e ) {
+				$upstream_revoked = false;
+				do_action(
+					'datamachine_log',
+					'warning',
+					'OAuth: Upstream per-user revoke threw',
+					array(
+						'provider' => $handler_slug,
+						'user_id'  => $user_id,
+						'error'    => $e->getMessage(),
+					)
+				);
+			}
+			if ( ! $upstream_revoked ) {
+				do_action(
+					'datamachine_log',
+					'warning',
+					'OAuth: Upstream per-user revoke failed; continuing with local delete',
+					array(
+						'provider' => $handler_slug,
+						'user_id'  => $user_id,
+					)
+				);
+			}
+		}
+
+		$deleted = $auth_instance->delete_account_for_user( $user_id );
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'OAuth: Per-user credentials revoked',
+			array(
+				'provider'         => $handler_slug,
+				'user_id'          => $user_id,
+				'revoked_by'       => $revoked_by_user_id,
+				'upstream_revoked' => $upstream_revoked,
+				'local_deleted'    => $deleted,
+			)
+		);
+
+		if ( ! $deleted ) {
+			return array(
+				'success'          => false,
+				'error'            => __( 'Failed to delete per-user credentials', 'data-machine' ),
+				'upstream_revoked' => (bool) $upstream_revoked,
+			);
+		}
+
+		return array(
+			'success'          => true,
+			'message'          => sprintf(
+				/* translators: 1: Service name, 2: user ID */
+				__( '%1$s credentials revoked for user %2$d', 'data-machine' ),
+				ucfirst( $handler_slug ),
+				$user_id
+			),
+			'upstream_revoked' => (bool) $upstream_revoked,
 		);
 	}
 

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -525,8 +525,11 @@ class ChatOrchestrator {
 			$provider,
 			$model,
 			array(
-				'modes'   => array( ToolPolicyResolver::MODE_CHAT ),
-				'user_id' => $user_id,
+				'modes'           => array( ToolPolicyResolver::MODE_CHAT ),
+				'user_id'         => $user_id,
+				// Ping is a system-level health check; there is no human caller
+				// even though the session is recorded under the admin user_id.
+				'calling_user_id' => 0,
 			)
 		);
 
@@ -742,11 +745,25 @@ class ChatOrchestrator {
 			);
 			$client_context = $options['client_context'] ?? array();
 
+			// `calling_user_id` is the human user on whose behalf this AI invocation
+			// is running. In a chat session that's the chat caller. Tools that resolve
+			// per-user OAuth credentials read this field — distinct from `agent_id`
+			// (the acting agent identity) and from pipeline `user_id` (job owner).
+			//
+			// Callers can override via `$options['calling_user_id']` to express
+			// "this is a system-level invocation borrowing an admin session_id for
+			// storage but has no real human caller" (e.g. processPing). When the
+			// override is absent, the chat user is the calling user.
+			$calling_user_id = isset( $options['calling_user_id'] )
+				? max( 0, (int) $options['calling_user_id'] )
+				: $user_id;
+
 			$loop_context = array(
-				'session_id'  => $session_id,
-				'user_id'     => $user_id,
-				'agent_id'    => $agent_id,
-				'agent_modes' => $modes,
+				'session_id'      => $session_id,
+				'user_id'         => $user_id,
+				'calling_user_id' => $calling_user_id,
+				'agent_id'        => $agent_id,
+				'agent_modes'     => $modes,
 			);
 			if ( '' !== $agent_slug ) {
 				$loop_context['agent_slug'] = $agent_slug;

--- a/inc/Cli/Commands/AuthCommand.php
+++ b/inc/Cli/Commands/AuthCommand.php
@@ -197,6 +197,109 @@ class AuthCommand extends BaseCommand {
 	}
 
 	/**
+	 * Revoke authentication for a handler at site or per-user scope.
+	 *
+	 * Without --user, behaves like `disconnect` — clears the shared
+	 * site-wide account slot. With --user=<id>, clears only that user's
+	 * per-user credential slot via the BaseAuthProvider per-user API.
+	 *
+	 * Providers that expose an upstream revoke endpoint are called first,
+	 * before local deletion, so upstream credentials are invalidated even
+	 * if local storage is later restored from a backup. An upstream
+	 * failure logs a warning but does not prevent local deletion.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <handler_slug>
+	 * : Handler to revoke (e.g., a registered handler slug).
+	 *
+	 * [--user=<id>]
+	 * : Target user ID. When provided, revokes only that user's per-user
+	 *   credentials. When omitted, revokes the site-wide account.
+	 *
+	 * [--yes]
+	 * : Skip confirmation prompt.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Revoke the site-wide account.
+	 *     wp datamachine auth revoke <handler>
+	 *
+	 *     # Revoke a specific user's per-user credentials.
+	 *     wp datamachine auth revoke <handler> --user=42
+	 *
+	 * @subcommand revoke
+	 */
+	public function revoke( array $args, array $assoc_args ): void {
+		if ( empty( $args[0] ) ) {
+			WP_CLI::error( 'Handler slug is required.' );
+			return;
+		}
+
+		$handler_slug = sanitize_text_field( $args[0] );
+
+		if ( ! $this->abilities->providerExists( $handler_slug ) ) {
+			WP_CLI::error( sprintf( 'Auth provider "%s" not found.', $handler_slug ) );
+			return;
+		}
+
+		$user_id = isset( $assoc_args['user'] ) ? absint( $assoc_args['user'] ) : 0;
+
+		// Per-user revoke path.
+		if ( $user_id > 0 ) {
+			if ( ! isset( $assoc_args['yes'] ) ) {
+				WP_CLI::confirm(
+					sprintf(
+						'Revoke %s credentials for user %d? This will delete that user\'s per-user account slot.',
+						ucfirst( $handler_slug ),
+						$user_id
+					)
+				);
+			}
+
+			$result = $this->abilities->executeRevokeAuthForUser(
+				array(
+					'handler_slug' => $handler_slug,
+					'user_id'      => $user_id,
+				)
+			);
+
+			if ( ! empty( $result['success'] ) ) {
+				$msg = $result['message'] ?? sprintf( '%s credentials revoked for user %d.', ucfirst( $handler_slug ), $user_id );
+				if ( array_key_exists( 'upstream_revoked', $result ) ) {
+					$msg .= $result['upstream_revoked']
+						? ' (upstream revoke succeeded)'
+						: ' (upstream revoke skipped or failed; local delete completed)';
+				}
+				WP_CLI::success( $msg );
+				return;
+			}
+
+			WP_CLI::error( $result['error'] ?? 'Failed to revoke per-user credentials.' );
+			return;
+		}
+
+		// Site-wide revoke path (delegates to the existing disconnect ability).
+		$auth_status = $this->abilities->getAuthStatus( $handler_slug );
+		if ( ! $auth_status['authenticated'] ) {
+			WP_CLI::warning( sprintf( '%s is not currently authenticated at site scope.', ucfirst( $handler_slug ) ) );
+			return;
+		}
+
+		if ( ! isset( $assoc_args['yes'] ) ) {
+			WP_CLI::confirm( sprintf( 'Revoke site-wide %s credentials? This will clear stored account data.', ucfirst( $handler_slug ) ) );
+		}
+
+		$result = $this->abilities->executeDisconnectAuth( array( 'handler_slug' => $handler_slug ) );
+
+		if ( ! empty( $result['success'] ) ) {
+			WP_CLI::success( $result['message'] ?? sprintf( '%s site-wide credentials revoked.', ucfirst( $handler_slug ) ) );
+		} else {
+			WP_CLI::error( $result['error'] ?? 'Failed to revoke.' );
+		}
+	}
+
+	/**
 	 * View or save API configuration for a handler.
 	 *
 	 * Without --<field>=<value> flags, shows the current config and required fields.

--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -345,6 +345,116 @@ abstract class BaseAuthProvider {
 		return true;
 	}
 
+	// -------------------------------------------------------------------------
+	// Per-user account API
+	//
+	// These methods provide a deliberate, no-fallback per-user storage surface
+	// for callers that operate on a specific human user's credentials. They
+	// share the same underlying storage layout as the principal-scoped API
+	// (`principals[user:<id>][account]`) so an account written via either
+	// surface is readable through the other.
+	//
+	// Unlike `get_account( array $context )`, these methods never consult the
+	// provider's scope policy and never fall back to site-wide storage when
+	// no per-user account exists. A missing per-user account always returns
+	// `null`.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Get the OAuth account for a specific user.
+	 *
+	 * Sensitive fields are decrypted on read. Returns `null` when no per-user
+	 * account exists for this provider+user — there is intentionally no
+	 * fallback to site-wide storage so callers cannot accidentally cross
+	 * user boundaries.
+	 *
+	 * @since 0.123.0
+	 *
+	 * @param int $user_id Target user ID. Must be a positive integer.
+	 * @return array|null Decrypted account data, or null if no account exists.
+	 */
+	public function get_account_for_user( int $user_id ): ?array {
+		$user_id = absint( $user_id );
+		if ( $user_id <= 0 ) {
+			return null;
+		}
+
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		$provider_data = $all_auth_data[ $this->provider_slug ] ?? array();
+		$scope_key     = 'user:' . $user_id;
+		$account       = $provider_data['principals'][ $scope_key ]['account'] ?? null;
+
+		if ( ! is_array( $account ) || empty( $account ) ) {
+			return null;
+		}
+
+		return $this->decrypt_fields( $account );
+	}
+
+	/**
+	 * Save the OAuth account for a specific user.
+	 *
+	 * Sensitive fields are encrypted before storage. Stores under the same
+	 * `principals[user:<id>][account]` slot used by the scope-aware
+	 * `save_account()` path so the two surfaces stay in sync.
+	 *
+	 * @since 0.123.0
+	 *
+	 * @param int   $user_id Target user ID. Must be a positive integer.
+	 * @param array $account Account data to store. Must include `access_token`
+	 *                       for the credential to be useful.
+	 * @return bool True on successful write, false on invalid input or storage failure.
+	 */
+	public function save_account_for_user( int $user_id, array $account ): bool {
+		$user_id = absint( $user_id );
+		if ( $user_id <= 0 ) {
+			return false;
+		}
+
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		if ( ! isset( $all_auth_data[ $this->provider_slug ] ) || ! is_array( $all_auth_data[ $this->provider_slug ] ) ) {
+			$all_auth_data[ $this->provider_slug ] = array();
+		}
+		if ( ! isset( $all_auth_data[ $this->provider_slug ]['principals'] ) || ! is_array( $all_auth_data[ $this->provider_slug ]['principals'] ) ) {
+			$all_auth_data[ $this->provider_slug ]['principals'] = array();
+		}
+
+		$scope_key = 'user:' . $user_id;
+		$all_auth_data[ $this->provider_slug ]['principals'][ $scope_key ]['account'] = $this->encrypt_fields( $account );
+
+		return update_site_option( 'datamachine_auth_data', $all_auth_data );
+	}
+
+	/**
+	 * Delete the OAuth account for a specific user.
+	 *
+	 * Returns true when the per-user slot existed and was removed, or when
+	 * there was nothing to remove (idempotent). Returns false only on
+	 * invalid input or a storage failure.
+	 *
+	 * @since 0.123.0
+	 *
+	 * @param int $user_id Target user ID. Must be a positive integer.
+	 * @return bool True on success (including no-op deletes), false on invalid input or storage failure.
+	 */
+	public function delete_account_for_user( int $user_id ): bool {
+		$user_id = absint( $user_id );
+		if ( $user_id <= 0 ) {
+			return false;
+		}
+
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		$scope_key     = 'user:' . $user_id;
+
+		if ( ! isset( $all_auth_data[ $this->provider_slug ]['principals'][ $scope_key ] ) ) {
+			return true; // Idempotent: nothing to delete.
+		}
+
+		unset( $all_auth_data[ $this->provider_slug ]['principals'][ $scope_key ] );
+
+		return update_site_option( 'datamachine_auth_data', $all_auth_data );
+	}
+
 	/**
 	 * Get the authenticated username for this provider.
 	 *

--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -368,6 +368,14 @@ abstract class BaseAuthProvider {
 	 * fallback to site-wide storage so callers cannot accidentally cross
 	 * user boundaries.
 	 *
+	 * Resolution order:
+	 *   1. `datamachine_resolve_oauth_account_for_user` filter — platform
+	 *      plugins return a non-null array to short-circuit with their own
+	 *      per-user storage layer (custom table, encrypted blob, etc.).
+	 *   2. Default user-meta-equivalent storage at
+	 *      `principals[user:<id>][account]`.
+	 *   3. Return null if neither yielded an account.
+	 *
 	 * @since 0.123.0
 	 *
 	 * @param int $user_id Target user ID. Must be a positive integer.
@@ -377,6 +385,37 @@ abstract class BaseAuthProvider {
 		$user_id = absint( $user_id );
 		if ( $user_id <= 0 ) {
 			return null;
+		}
+
+		/**
+		 * Filter the resolution of an OAuth account for a given user.
+		 *
+		 * Platform plugins can return a non-null array to plug in their own
+		 * per-user credential storage (custom table, external KMS, encrypted
+		 * blob, etc.) without touching core. Returning null lets the default
+		 * storage path run.
+		 *
+		 * The filter fires BEFORE the default lookup. The filter result is
+		 * NOT passed through decrypt_fields() — platform plugins are
+		 * responsible for returning already-decrypted account data in the
+		 * canonical shape (access_token, refresh_token, scope, expires_at,
+		 * etc. as plaintext).
+		 *
+		 * @since 0.123.0
+		 *
+		 * @param array|null $account     Resolved account, or null to fall through.
+		 * @param string     $provider    Provider slug (e.g. registered handler slug).
+		 * @param int        $user_id     Target user ID.
+		 */
+		$resolved = apply_filters(
+			'datamachine_resolve_oauth_account_for_user',
+			null,
+			$this->provider_slug,
+			$user_id
+		);
+
+		if ( is_array( $resolved ) && ! empty( $resolved ) ) {
+			return $resolved;
 		}
 
 		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );

--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -415,6 +415,7 @@ abstract class BaseAuthProvider {
 		);
 
 		if ( is_array( $resolved ) && ! empty( $resolved ) ) {
+			$this->log_per_user_account_read( $user_id, 'filter' );
 			return $resolved;
 		}
 
@@ -427,7 +428,37 @@ abstract class BaseAuthProvider {
 			return null;
 		}
 
+		$this->log_per_user_account_read( $user_id, 'default' );
 		return $this->decrypt_fields( $account );
+	}
+
+	/**
+	 * Emit an audit log entry for a successful per-user account resolution.
+	 *
+	 * Only successful resolves are logged — failed lookups would dwarf real
+	 * signal during normal "no account exists yet" probes. The token itself
+	 * is NEVER logged, at any level.
+	 *
+	 * @since 0.123.0
+	 *
+	 * @param int    $user_id Resolved user ID.
+	 * @param string $source  Resolution source — 'filter' or 'default'.
+	 */
+	private function log_per_user_account_read( int $user_id, string $source ): void {
+		if ( ! function_exists( 'do_action' ) ) {
+			return;
+		}
+
+		do_action(
+			'datamachine_log',
+			'debug',
+			'OAuth: Per-user account resolved',
+			array(
+				'provider' => $this->provider_slug,
+				'user_id'  => $user_id,
+				'source'   => $source,
+			)
+		);
 	}
 
 	/**

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -282,6 +282,11 @@ class AIStep extends Step {
 				'engine'                      => $this->engine,
 				'engine_data'                 => $this->engine->all(),
 				'user_id'                     => $user_id,
+				// Pipeline executions have no human caller — the agent is acting on a
+				// scheduled job, not on behalf of a person. Per-user OAuth resolution
+				// reads this field; setting it to 0 prevents accidentally picking up
+				// per-user credentials of the flow owner.
+				'calling_user_id'             => 0,
 				'agent_id'                    => $agent_id,
 				'agent_slug'                  => $agent_slug,
 				'agent_modes'                 => $execution_modes,

--- a/inc/Engine/AI/System/Tasks/AltTextTask.php
+++ b/inc/Engine/AI/System/Tasks/AltTextTask.php
@@ -82,7 +82,11 @@ class AltTextTask extends SystemTask {
 			ConversationManager::buildConversationMessage( 'user', $prompt ),
 		);
 
-		$ai_payload = array( 'attachment_id' => $attachment_id );
+		$ai_payload = array(
+			'attachment_id'   => $attachment_id,
+			// System task — no human caller. See MetaDescriptionTask for rationale.
+			'calling_user_id' => 0,
+		);
 		if ( ! empty( $params['agent_id'] ) ) {
 			$ai_payload['agent_id'] = (int) $params['agent_id'];
 		}

--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -148,7 +148,10 @@ class DailyMemoryTask extends SystemTask {
 			\DataMachine\Engine\AI\ConversationManager::buildConversationMessage( 'user', $prompt ),
 		);
 
-		$ai_payload = array();
+		$ai_payload = array(
+			// System task — no human caller. See MetaDescriptionTask for rationale.
+			'calling_user_id' => 0,
+		);
 		if ( $agent_id > 0 ) {
 			$ai_payload['agent_id'] = $agent_id;
 		}

--- a/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
+++ b/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
@@ -125,7 +125,12 @@ class InternalLinkingTask extends SystemTask {
 			}
 
 			$prompt     = $this->buildBlockPrompt( $candidate['inner_html'], $related_post );
-			$ai_payload = array( 'post_id' => $post_id );
+			$ai_payload = array(
+				'post_id'         => $post_id,
+				// System task — no human caller. See MetaDescriptionTask for the
+				// rationale on why per-user OAuth resolution must see 0 here.
+				'calling_user_id' => 0,
+			);
 			if ( ! empty( $params['agent_id'] ) ) {
 				$ai_payload['agent_id'] = (int) $params['agent_id'];
 			}

--- a/inc/Engine/AI/System/Tasks/MetaDescriptionTask.php
+++ b/inc/Engine/AI/System/Tasks/MetaDescriptionTask.php
@@ -78,7 +78,13 @@ class MetaDescriptionTask extends SystemTask {
 			ConversationManager::buildConversationMessage( 'user', $prompt ),
 		);
 
-		$ai_payload = array( 'post_id' => $post_id );
+		$ai_payload = array(
+			'post_id'         => $post_id,
+			// System tasks run without a human caller — calling_user_id is 0 so
+			// tools that resolve per-user OAuth credentials know not to look up
+			// any specific user's storage slot.
+			'calling_user_id' => 0,
+		);
 		if ( ! empty( $params['agent_id'] ) ) {
 			$ai_payload['agent_id'] = (int) $params['agent_id'];
 		}

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1119,6 +1119,52 @@ function datamachine_payload_without_runtime_objects( array $payload ): array {
 }
 
 /**
+ * Read the calling-user identity from an AI invocation payload.
+ *
+ * `calling_user_id` is the human user on whose behalf the agent is acting
+ * during this invocation. It is intentionally distinct from `agent_id`
+ * (the acting agent identity, which is the same across invocations for a
+ * given agent) and from the pipeline `user_id` (which is the flow/job
+ * owner — typically an admin who scheduled the work, not someone who is
+ * "calling" the agent right now).
+ *
+ * Producer semantics:
+ *   - Chat sessions set this to the chat caller's user ID.
+ *   - Pipeline executions set this to 0 (no human caller — the agent runs
+ *     against a scheduled job).
+ *   - System tasks (title gen, summaries, alt text) set this to 0.
+ *   - REST-initiated invocations set this to the authenticated bearer
+ *     token's owner when present, else `get_current_user_id()`, else 0.
+ *
+ * Consumer pattern (tools/directives that resolve per-user OAuth):
+ *
+ *   ```php
+ *   $calling_user_id = datamachine_get_calling_user_id( $payload );
+ *   if ( $calling_user_id > 0 ) {
+ *       $account = $provider->get_account_for_user( $calling_user_id );
+ *   } else {
+ *       // No human caller — fall back to site-wide or skip the call.
+ *   }
+ *   ```
+ *
+ * Returns 0 when the key is absent, non-numeric, or non-positive so
+ * callers can safely guard `> 0` without re-validating.
+ *
+ * @since 0.123.0
+ *
+ * @param array $payload AI invocation payload.
+ * @return int Non-negative user ID. 0 means "no human caller".
+ */
+function datamachine_get_calling_user_id( array $payload ): int {
+	$raw = $payload['calling_user_id'] ?? 0;
+	if ( ! is_numeric( $raw ) ) {
+		return 0;
+	}
+	$user_id = (int) $raw;
+	return $user_id > 0 ? $user_id : 0;
+}
+
+/**
  * Emit a loop event without letting observer failures change loop results.
  *
  * @param LoopEventSinkInterface $sink    Event sink.

--- a/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
+++ b/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
@@ -235,4 +235,136 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 
 		remove_all_filters( 'datamachine_oauth_callback_url' );
 	}
+
+	// -------------------------------------------------------------------------
+	// Per-user account API
+	// -------------------------------------------------------------------------
+
+	public function test_get_account_for_user_returns_null_when_no_account(): void {
+		$this->assertNull( $this->provider->get_account_for_user( 42 ) );
+	}
+
+	public function test_save_account_for_user_round_trip(): void {
+		$account = array(
+			'access_token' => 'tok_user_42',
+			'username'     => 'alice',
+			'scope'        => 'read write',
+		);
+
+		$saved = $this->provider->save_account_for_user( 42, $account );
+		$this->assertTrue( $saved );
+
+		$loaded = $this->provider->get_account_for_user( 42 );
+		$this->assertIsArray( $loaded );
+		$this->assertSame( 'tok_user_42', $loaded['access_token'] );
+		$this->assertSame( 'alice', $loaded['username'] );
+		$this->assertSame( 'read write', $loaded['scope'] );
+	}
+
+	public function test_delete_account_for_user_removes_account(): void {
+		$this->provider->save_account_for_user( 42, array( 'access_token' => 'tok_user_42' ) );
+		$this->assertNotNull( $this->provider->get_account_for_user( 42 ) );
+
+		$this->assertTrue( $this->provider->delete_account_for_user( 42 ) );
+		$this->assertNull( $this->provider->get_account_for_user( 42 ) );
+	}
+
+	public function test_delete_account_for_user_is_idempotent(): void {
+		$this->assertTrue( $this->provider->delete_account_for_user( 12345 ) );
+	}
+
+	public function test_per_user_accounts_are_isolated_between_users(): void {
+		$this->provider->save_account_for_user( 101, array( 'access_token' => 'tok_alice' ) );
+		$this->provider->save_account_for_user( 202, array( 'access_token' => 'tok_bob' ) );
+
+		$alice = $this->provider->get_account_for_user( 101 );
+		$bob   = $this->provider->get_account_for_user( 202 );
+
+		$this->assertSame( 'tok_alice', $alice['access_token'] );
+		$this->assertSame( 'tok_bob', $bob['access_token'] );
+	}
+
+	public function test_per_user_account_does_not_fall_back_to_site_account(): void {
+		// Site-wide account stored.
+		$this->provider->save_account( array( 'access_token' => 'site_token' ) );
+
+		// Per-user read for a user without per-user storage MUST be null.
+		$this->assertNull( $this->provider->get_account_for_user( 42 ) );
+
+		// Site account is still readable via the site-scoped API.
+		$this->assertSame( 'site_token', $this->provider->get_account()['access_token'] );
+	}
+
+	public function test_per_user_save_does_not_affect_site_account(): void {
+		$this->provider->save_account( array( 'access_token' => 'site_token' ) );
+		$this->provider->save_account_for_user( 42, array( 'access_token' => 'tok_user_42' ) );
+
+		$this->assertSame( 'site_token', $this->provider->get_account()['access_token'] );
+		$this->assertSame( 'tok_user_42', $this->provider->get_account_for_user( 42 )['access_token'] );
+	}
+
+	public function test_invalid_user_ids_are_rejected(): void {
+		$this->assertFalse( $this->provider->save_account_for_user( 0, array( 'access_token' => 'x' ) ) );
+		$this->assertNull( $this->provider->get_account_for_user( 0 ) );
+		$this->assertFalse( $this->provider->delete_account_for_user( 0 ) );
+	}
+
+	public function test_resolve_filter_short_circuits_default_lookup(): void {
+		$received = null;
+
+		add_filter(
+			'datamachine_resolve_oauth_account_for_user',
+			function ( $account, $provider, $user_id ) use ( &$received ) {
+				$received = array( $account, $provider, $user_id );
+				if ( 'test_provider' === $provider && 707 === $user_id ) {
+					return array(
+						'access_token' => 'platform_supplied',
+						'scope'        => 'platform:read',
+					);
+				}
+				return $account;
+			},
+			10,
+			3
+		);
+
+		$result = $this->provider->get_account_for_user( 707 );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'platform_supplied', $result['access_token'] );
+		$this->assertSame( array( null, 'test_provider', 707 ), $received );
+
+		remove_all_filters( 'datamachine_resolve_oauth_account_for_user' );
+	}
+
+	public function test_resolve_filter_returning_null_falls_through_to_default(): void {
+		add_filter(
+			'datamachine_resolve_oauth_account_for_user',
+			function ( $account ) {
+				return $account; // null in, null out.
+			}
+		);
+
+		$this->provider->save_account_for_user( 808, array( 'access_token' => 'tok_default' ) );
+
+		$this->assertSame( 'tok_default', $this->provider->get_account_for_user( 808 )['access_token'] );
+
+		remove_all_filters( 'datamachine_resolve_oauth_account_for_user' );
+	}
+
+	public function test_resolve_filter_returning_empty_array_falls_through(): void {
+		// Empty array should not short-circuit (it's indistinguishable from "no account").
+		add_filter(
+			'datamachine_resolve_oauth_account_for_user',
+			function () {
+				return array();
+			}
+		);
+
+		$this->provider->save_account_for_user( 909, array( 'access_token' => 'tok_default' ) );
+
+		$this->assertSame( 'tok_default', $this->provider->get_account_for_user( 909 )['access_token'] );
+
+		remove_all_filters( 'datamachine_resolve_oauth_account_for_user' );
+	}
 }

--- a/tests/auth-per-user-api-smoke.php
+++ b/tests/auth-per-user-api-smoke.php
@@ -172,7 +172,42 @@ smoke_assert(
 	isset( $raw['shared']['principals']['user:303']['account'] )
 );
 
-echo "\n[7] sensitive fields are encrypted at rest\n";
+echo "\n[7] platform override filter short-circuits default lookup\n";
+$filter_provider = new Per_User_Smoke_Provider( 'filtered' );
+
+$captured_args = null;
+add_filter(
+	'datamachine_resolve_oauth_account_for_user',
+	function ( $account, $provider, $user_id ) use ( &$captured_args ) {
+		$captured_args = array( $account, $provider, $user_id );
+		if ( 'filtered' === $provider && 707 === $user_id ) {
+			return array(
+				'access_token' => 'platform-supplied-token',
+				'scope'        => 'platform:read',
+			);
+		}
+		return $account;
+	},
+	10,
+	3
+);
+
+$override = $filter_provider->get_account_for_user( 707 );
+smoke_assert( 'filter return value short-circuits default lookup', is_array( $override ) && 'platform-supplied-token' === $override['access_token'] );
+smoke_assert(
+	'filter receives (null, provider, user_id) arguments',
+	is_array( $captured_args ) && null === $captured_args[0] && 'filtered' === $captured_args[1] && 707 === $captured_args[2]
+);
+
+// Filter returning null lets the default fall through.
+$filter_provider->save_account_for_user( 808, array( 'access_token' => 'default-token' ) );
+$default = $filter_provider->get_account_for_user( 808 );
+smoke_assert(
+	'filter returning null lets default lookup proceed',
+	is_array( $default ) && 'default-token' === $default['access_token']
+);
+
+echo "\n[8] sensitive fields are encrypted at rest\n";
 $raw          = get_site_option( 'datamachine_auth_data', array() );
 $stored_token = $raw['sample']['principals']['user:202']['account']['access_token'] ?? '';
 smoke_assert(

--- a/tests/auth-per-user-api-smoke.php
+++ b/tests/auth-per-user-api-smoke.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Smoke tests for the per-user OAuth account API.
+ *
+ *   php tests/auth-per-user-api-smoke.php
+ *
+ * Exercises `get_account_for_user`, `save_account_for_user`, and
+ * `delete_account_for_user` — the deliberate-no-fallback surface for
+ * vendor plugins that operate on a specific user's credentials.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+if ( ! defined( 'WPINC' ) ) {
+	define( 'WPINC', 'wp-includes' );
+}
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+
+$GLOBALS['datamachine_auth_per_user_options'] = array();
+$GLOBALS['datamachine_auth_per_user_filters'] = array();
+$GLOBALS['datamachine_auth_per_user_logs']    = array();
+
+function __( $text, $domain = null ) {
+	unset( $domain );
+	return $text;
+}
+
+function esc_html( $text ) {
+	return $text;
+}
+
+function absint( $value ) {
+	return abs( (int) $value );
+}
+
+function wp_salt( $scheme = 'auth' ) {
+	return 'auth-per-user-smoke-' . $scheme;
+}
+
+function maybe_serialize( $value ) {
+	return serialize( $value );
+}
+
+function get_site_option( $name, $default = false ) {
+	return $GLOBALS['datamachine_auth_per_user_options'][ $name ] ?? $default;
+}
+
+function update_site_option( $name, $value ) {
+	$GLOBALS['datamachine_auth_per_user_options'][ $name ] = $value;
+	return true;
+}
+
+function get_current_user_id() {
+	return 0;
+}
+
+function apply_filters( $hook, $value, ...$args ) {
+	foreach ( $GLOBALS['datamachine_auth_per_user_filters'][ $hook ] ?? array() as $callback ) {
+		$value = $callback( $value, ...$args );
+	}
+	return $value;
+}
+
+function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+	unset( $priority, $accepted_args );
+	$GLOBALS['datamachine_auth_per_user_filters'][ $hook ][] = $callback;
+}
+
+function do_action( $hook, ...$args ) {
+	$GLOBALS['datamachine_auth_per_user_logs'][] = array( $hook, $args );
+}
+
+function set_transient( $key, $value, $expiration = 0 ) {
+	unset( $key, $value, $expiration );
+	return true;
+}
+
+function get_transient( $key ) {
+	unset( $key );
+	return false;
+}
+
+function delete_transient( $key ) {
+	unset( $key );
+	return true;
+}
+
+require_once dirname( __DIR__ ) . '/inc/Core/OAuth/OAuthRedirects.php';
+require_once dirname( __DIR__ ) . '/inc/Core/OAuth/BaseAuthProvider.php';
+
+class Per_User_Smoke_Provider extends DataMachine\Core\OAuth\BaseAuthProvider {
+	public function __construct( string $slug = 'sample' ) {
+		parent::__construct( $slug );
+	}
+
+	public function get_config_fields(): array {
+		return array();
+	}
+
+	public function is_authenticated(): bool {
+		return false;
+	}
+}
+
+$pass     = 0;
+$fail     = 0;
+$failures = array();
+
+function smoke_assert( string $label, bool $condition, string $detail = '' ): void {
+	global $pass, $fail, $failures;
+	if ( $condition ) {
+		$pass++;
+		echo "  ✓ {$label}\n";
+		return;
+	}
+	$fail++;
+	$failures[] = array( $label, $detail );
+	echo "  ✗ {$label}" . ( $detail ? "\n      {$detail}" : '' ) . "\n";
+}
+
+echo "[1] round-trip per-user save and read\n";
+$provider = new Per_User_Smoke_Provider();
+$saved    = $provider->save_account_for_user( 101, array(
+	'access_token' => 'tok-alice',
+	'username'     => 'alice',
+) );
+smoke_assert( 'save returns true', $saved );
+
+$account = $provider->get_account_for_user( 101 );
+smoke_assert( 'read returns array', is_array( $account ) );
+smoke_assert( 'access_token round-trips through encryption', is_array( $account ) && 'tok-alice' === $account['access_token'] );
+smoke_assert( 'plaintext fields preserved', is_array( $account ) && 'alice' === $account['username'] );
+
+echo "\n[2] missing per-user account returns null (no site fallback)\n";
+$GLOBALS['datamachine_auth_per_user_options']['datamachine_auth_data']['sample']['account'] = array(
+	'access_token' => 'site-token',
+);
+$missing = $provider->get_account_for_user( 999 );
+smoke_assert( 'unknown user returns null', null === $missing );
+smoke_assert( 'site account still readable via legacy path', 'site-token' === $provider->get_account()['access_token'] );
+
+echo "\n[3] two users do not see each other's accounts\n";
+$provider->save_account_for_user( 202, array( 'access_token' => 'tok-bob' ) );
+$alice = $provider->get_account_for_user( 101 );
+$bob   = $provider->get_account_for_user( 202 );
+smoke_assert( 'alice reads alice', is_array( $alice ) && 'tok-alice' === $alice['access_token'] );
+smoke_assert( 'bob reads bob', is_array( $bob ) && 'tok-bob' === $bob['access_token'] );
+
+echo "\n[4] delete is targeted and idempotent\n";
+$deleted = $provider->delete_account_for_user( 101 );
+smoke_assert( 'delete returns true', $deleted );
+smoke_assert( 'deleted account returns null on read', null === $provider->get_account_for_user( 101 ) );
+smoke_assert( 'other users unaffected by delete', is_array( $provider->get_account_for_user( 202 ) ) );
+smoke_assert( 'second delete is idempotent', $provider->delete_account_for_user( 101 ) );
+
+echo "\n[5] invalid user ids are rejected\n";
+smoke_assert( 'save with zero user_id returns false', false === $provider->save_account_for_user( 0, array( 'access_token' => 'x' ) ) );
+smoke_assert( 'read with zero user_id returns null', null === $provider->get_account_for_user( 0 ) );
+smoke_assert( 'delete with zero user_id returns false', false === $provider->delete_account_for_user( 0 ) );
+
+echo "\n[6] per-user storage shares slot with principal-scoped writes\n";
+$shared = new Per_User_Smoke_Provider( 'shared' );
+$shared->save_account_for_user( 303, array( 'access_token' => 'tok-shared' ) );
+$raw = get_site_option( 'datamachine_auth_data', array() );
+smoke_assert(
+	'per-user account lives at principals[user:303][account]',
+	isset( $raw['shared']['principals']['user:303']['account'] )
+);
+
+echo "\n[7] sensitive fields are encrypted at rest\n";
+$raw          = get_site_option( 'datamachine_auth_data', array() );
+$stored_token = $raw['sample']['principals']['user:202']['account']['access_token'] ?? '';
+smoke_assert(
+	'access_token is encrypted in storage',
+	is_string( $stored_token ) && str_starts_with( $stored_token, DataMachine\Core\OAuth\BaseAuthProvider::ENCRYPTION_PREFIX )
+);
+smoke_assert(
+	'decrypted value matches original',
+	'tok-bob' === $provider->get_account_for_user( 202 )['access_token']
+);
+
+echo "\n{$pass} passed, {$fail} failed\n";
+if ( $fail > 0 ) {
+	echo "\nFailures:\n";
+	foreach ( $failures as $failure ) {
+		echo "  - {$failure[0]}" . ( $failure[1] ? ": {$failure[1]}" : '' ) . "\n";
+	}
+	exit( 1 );
+}

--- a/tests/auth-per-user-api-smoke.php
+++ b/tests/auth-per-user-api-smoke.php
@@ -207,7 +207,57 @@ smoke_assert(
 	is_array( $default ) && 'default-token' === $default['access_token']
 );
 
-echo "\n[8] sensitive fields are encrypted at rest\n";
+echo "\n[8] audit log fires on successful per-user reads only\n";
+$GLOBALS['datamachine_auth_per_user_logs'] = array();
+$logged_provider                           = new Per_User_Smoke_Provider( 'logged' );
+$logged_provider->save_account_for_user( 909, array( 'access_token' => 'tok-logged' ) );
+$GLOBALS['datamachine_auth_per_user_logs'] = array(); // reset after the save's encrypt path.
+
+$logged_provider->get_account_for_user( 909 );
+$resolved_logs = array_filter(
+	$GLOBALS['datamachine_auth_per_user_logs'],
+	function ( $entry ) {
+		return 'datamachine_log' === $entry[0]
+			&& isset( $entry[1][1] )
+			&& 'OAuth: Per-user account resolved' === $entry[1][1];
+	}
+);
+smoke_assert( 'successful read emits one audit log entry', 1 === count( $resolved_logs ) );
+
+$entry = array_values( $resolved_logs )[0] ?? null;
+smoke_assert( 'audit log level is debug', is_array( $entry ) && 'debug' === $entry[1][0] );
+$context = is_array( $entry ) ? ( $entry[1][2] ?? array() ) : array();
+smoke_assert( 'audit log context carries provider', is_array( $context ) && 'logged' === ( $context['provider'] ?? null ) );
+smoke_assert( 'audit log context carries user_id', is_array( $context ) && 909 === ( $context['user_id'] ?? null ) );
+smoke_assert( 'audit log context carries source', is_array( $context ) && 'default' === ( $context['source'] ?? null ) );
+
+// Failed read (no account) should NOT log.
+$GLOBALS['datamachine_auth_per_user_logs'] = array();
+$logged_provider->get_account_for_user( 12345 ); // not stored.
+$fail_logs = array_filter(
+	$GLOBALS['datamachine_auth_per_user_logs'],
+	function ( $entry ) {
+		return 'datamachine_log' === $entry[0]
+			&& isset( $entry[1][1] )
+			&& 'OAuth: Per-user account resolved' === $entry[1][1];
+	}
+);
+smoke_assert( 'failed read emits no audit log entry', 0 === count( $fail_logs ) );
+
+// Token MUST NOT appear in any log entry, ever.
+$GLOBALS['datamachine_auth_per_user_logs'] = array();
+$logged_provider->get_account_for_user( 909 ); // successful read again.
+$logged_provider->get_account_for_user( 99999 ); // failed read.
+$all_log_text = '';
+foreach ( $GLOBALS['datamachine_auth_per_user_logs'] as $entry ) {
+	$all_log_text .= json_encode( $entry );
+}
+smoke_assert(
+	'no token value appears in any audit log',
+	false === strpos( $all_log_text, 'tok-logged' )
+);
+
+echo "\n[9] sensitive fields are encrypted at rest\n";
 $raw          = get_site_option( 'datamachine_auth_data', array() );
 $stored_token = $raw['sample']['principals']['user:202']['account']['access_token'] ?? '';
 smoke_assert(

--- a/tests/calling-user-id-payload-smoke.php
+++ b/tests/calling-user-id-payload-smoke.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Smoke tests for the calling_user_id payload helper.
+ *
+ *   php tests/calling-user-id-payload-smoke.php
+ *
+ * Exercises datamachine_get_calling_user_id() — the consumer-side helper
+ * that tools and directives use to read the human caller identity from
+ * an AI invocation payload, distinct from the acting agent_id and from
+ * the pipeline user_id (job owner).
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+if ( ! defined( 'WPINC' ) ) {
+	define( 'WPINC', 'wp-includes' );
+}
+
+// Minimal WP stubs so the helper file can load.
+function __( $text, $domain = null ) {
+	unset( $domain );
+	return $text;
+}
+
+function do_action( $hook, ...$args ) {
+	unset( $hook, $args );
+}
+
+function apply_filters( $hook, $value, ...$args ) {
+	unset( $hook, $args );
+	return $value;
+}
+
+function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+	unset( $hook, $callback, $priority, $accepted_args );
+}
+
+// The helper file pulls in agents-api and substrate classes that we don't
+// need just to test a single payload-reader function. Define the function
+// directly here so the test is hermetic — it mirrors the implementation in
+// inc/Engine/AI/conversation-loop.php exactly.
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/conversation-loop.php';
+
+$pass     = 0;
+$fail     = 0;
+$failures = array();
+
+function smoke_assert( string $label, bool $condition, string $detail = '' ): void {
+	global $pass, $fail, $failures;
+	if ( $condition ) {
+		$pass++;
+		echo "  ✓ {$label}\n";
+		return;
+	}
+	$fail++;
+	$failures[] = array( $label, $detail );
+	echo "  ✗ {$label}" . ( $detail ? "\n      {$detail}" : '' ) . "\n";
+}
+
+use function DataMachine\Engine\AI\datamachine_get_calling_user_id;
+
+echo "[1] explicit positive calling_user_id is returned as-is\n";
+smoke_assert( 'integer 42 is returned', 42 === datamachine_get_calling_user_id( array( 'calling_user_id' => 42 ) ) );
+smoke_assert( 'integer 1 is returned', 1 === datamachine_get_calling_user_id( array( 'calling_user_id' => 1 ) ) );
+smoke_assert( 'numeric string "99" coerces to 99', 99 === datamachine_get_calling_user_id( array( 'calling_user_id' => '99' ) ) );
+
+echo "\n[2] missing key returns 0\n";
+smoke_assert( 'empty payload returns 0', 0 === datamachine_get_calling_user_id( array() ) );
+smoke_assert(
+	'payload with user_id but no calling_user_id returns 0',
+	0 === datamachine_get_calling_user_id( array( 'user_id' => 42, 'agent_id' => 7 ) )
+);
+
+echo "\n[3] zero and negative values normalize to 0\n";
+smoke_assert( 'explicit 0 returns 0', 0 === datamachine_get_calling_user_id( array( 'calling_user_id' => 0 ) ) );
+smoke_assert( 'negative -5 normalizes to 0', 0 === datamachine_get_calling_user_id( array( 'calling_user_id' => -5 ) ) );
+
+echo "\n[4] non-numeric values return 0\n";
+smoke_assert( 'null returns 0', 0 === datamachine_get_calling_user_id( array( 'calling_user_id' => null ) ) );
+smoke_assert( 'string "abc" returns 0', 0 === datamachine_get_calling_user_id( array( 'calling_user_id' => 'abc' ) ) );
+smoke_assert( 'array returns 0', 0 === datamachine_get_calling_user_id( array( 'calling_user_id' => array( 42 ) ) ) );
+
+echo "\n[5] calling_user_id is independent of user_id and agent_id\n";
+$payload = array(
+	'user_id'         => 99,  // pipeline job owner
+	'agent_id'        => 7,   // acting agent
+	'calling_user_id' => 42,  // human caller
+);
+smoke_assert( 'calling_user_id reads cleanly with sibling fields', 42 === datamachine_get_calling_user_id( $payload ) );
+
+echo "\n{$pass} passed, {$fail} failed\n";
+if ( $fail > 0 ) {
+	echo "\nFailures:\n";
+	foreach ( $failures as $failure ) {
+		echo "  - {$failure[0]}" . ( $failure[1] ? ": {$failure[1]}" : '' ) . "\n";
+	}
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary

Implements #2081. This is foundational substrate work that unlocks per-user agent workflows (per-user OAuth resolution + calling-user identity in AI invocations) without ripping out the existing principal-scoped storage that already powers site-wide auth.

Six commits, additive:

1. **`feat(oauth): add per-user account API to BaseAuthProvider`** — adds `get_account_for_user($user_id)`, `save_account_for_user($user_id, $account)`, `delete_account_for_user($user_id)` to `BaseAuthProvider`. These share the same on-disk shape as the existing principal-scoped API (`principals[user:<id>][account]`) so accounts written through either surface are readable through the other. Unlike `get_account([ 'user_id' => $n ])`, the new methods never consult the provider's scope policy and never fall back to site-wide on miss — preventing accidental cross-user leakage.
2. **`feat(oauth): add datamachine_resolve_oauth_account_for_user filter`** — platform plugins can return a non-null array to short-circuit the default lookup with their own per-user credential store (custom table, external KMS, encrypted blob). Filter results are not re-decrypted — platform plugins return already-plaintext data.
3. **`feat(oauth): audit log on successful per-user account reads`** — every successful resolve emits a `debug`-level entry via `datamachine_log` with `{provider, user_id, source}`. Failed lookups stay quiet. Tokens are never logged at any level.
4. **`feat(cli): wp datamachine auth revoke command with per-user support`** — adds `wp datamachine auth revoke <handler> [--user=<id>]` plus the `datamachine/revoke-auth-for-user` ability for UI integration. If the provider exposes a `revoke_token_for_user($user_id)` method, it's called BEFORE local deletion so the upstream credential is invalidated even if local storage is later restored from backup. Upstream failure logs a warning but does not block local deletion.
5. **`feat(ai): propagate calling_user_id through AI invocation payload`** — every AI payload now carries `calling_user_id`. Chat → caller's user_id; pipeline → 0; system tasks → 0; processPing → 0. Consumer helper `datamachine_get_calling_user_id($payload): int` returns 0 when absent/non-numeric/non-positive so tools can guard with `> 0` without re-validating.
6. **`docs(oauth): per-user OAuth API + calling_user_id architecture`** — documents the decision flow (per-user vs. site-wide), vendor-plugin code pattern, revocation paths, calling_user_id producer/consumer contract, and migration notes (none required for existing installs).

## What was reused vs. added

The existing `BaseAuthProvider` already had a principal-scoped storage model with four scopes (`site`, `user`, `agent`, `principal`), encryption at rest via AES-256-GCM keyed from `wp_salt('auth')`, OAuth state nonce + PKCE handling in `OAuth2Handler`, scope-policy filtering via `datamachine_auth_scope_policy`, and an `AuthAbilities` layer that already built principal contexts. This PR layers a deliberate, no-fallback per-user surface on top of that machinery rather than duplicating it:

- **Reused:** existing `principals[user:<id>][account]` storage shape, `encrypt_fields`/`decrypt_fields`, `wp_salt('auth')`-derived AES-256-GCM, `OAuth2Handler` state/PKCE, `AuthAbilities` registration pattern, `ChatOrchestrator::executeConversationTurn` loop_context plumbing.
- **Added:** per-user concrete methods on `BaseAuthProvider`, `datamachine_resolve_oauth_account_for_user` filter, per-user audit log, `wp datamachine auth revoke`, `datamachine/revoke-auth-for-user` ability, `calling_user_id` payload key + propagation at all producer sites, `datamachine_get_calling_user_id` consumer helper.

The PR does **not** swap encryption to libsodium as the issue text suggested. The existing AES-256-GCM with `dm:enc:v1:` envelope and `hash_hkdf`-equivalent key derivation from `wp_salt('auth')` is functionally equivalent (both authenticated; both pull from `SECURE_AUTH_KEY` / `AUTH_KEY`) and would require re-encrypting every stored token for no real security gain. Migration cost without benefit.

## Acceptance criteria

Copied from #2081:

- [x] `BaseAuthProvider::get_account_for_user($user_id)`, `save_account_for_user`, and `delete_account_for_user` exist with default user_meta-equivalent implementations. → `principals[user:<id>][account]` storage matching the existing principal-scoped API.
- [x] Storage encrypts `access_token` and `refresh_token` at rest. → Already done via `encrypt_fields`/`decrypt_fields` (AES-256-GCM, envelope `dm:enc:v1:`). The new methods inherit this transparently.
- [x] `datamachine_resolve_oauth_account_for_user` filter fires and short-circuits resolution when non-null is returned.
- [x] AI invocation payloads include `calling_user_id` in chat, pipeline, and system flows, with the values described above.
- [x] Directives can read `$payload['calling_user_id']` — payload survives `RequestBuilder::withDirectiveContext` and is consumed via `datamachine_get_calling_user_id($payload)`.
- [x] Tools can read calling user from the invocation context — same helper; `ToolExecutor` passes `$payload` to every tool's `execute()`.
- [x] `wp datamachine auth revoke <provider> --user=<id>` removes the per-user token and logs the action.
- [x] No vendor-specific names appear in any file touched by this PR (`grep -iE "google|drive|notion|dropbox|bluesky|twitter|instagram|roadie|extrachill"` on the full diff returns zero matches).
- [x] Existing site-wide auth flows behave identically — `tests/auth-principal-scoped-smoke.php` and `tests/Unit/Core/OAuth/BaseAuthProviderTest.php` still pass; per-user methods do not touch site storage.
- [x] Documentation snippet explaining when to use per-user vs. site-wide credentials, with a vendor-plugin code example → `docs/core-system/oauth-handlers.md` "Per-user account API" section.

## Security model summary

- **Encryption at rest.** `access_token`, `refresh_token`, and the other fields in `ENCRYPTED_FIELDS` are encrypted with AES-256-GCM before persisting. Key is `hash('sha256', wp_salt('auth') . 'datamachine-oauth')` — 32 bytes derived from `AUTH_KEY` / `SECURE_AUTH_KEY` in `wp-config.php`. Envelope `dm:enc:v1:{iv}:{tag}:{ciphertext}` allows future cipher rotation. Plaintext legacy values are detected by absence of the envelope prefix and lazy-migrated on next save.
- **Audit log.** Every successful per-user account resolve emits `datamachine_log` debug entry with `{provider, user_id, source}`. Successful revoke emits an info-level entry with `{provider, user_id, revoked_by, upstream_revoked, local_deleted}`. Tokens are never in any log entry.
- **Revocation.** Upstream revoke (if provider implements `revoke_token_for_user`) runs BEFORE local delete. Upstream failure logs warning but does not block local delete — losing local access beats leaking credentials.
- **No cross-user fallback.** `get_account_for_user( 101 )` returns `null` when user 101 has no account, even if site-wide credentials exist. The two scopes are strictly separate.
- **Layer purity.** Zero vendor names in this diff. Verified via grep on the full `origin/main...HEAD` diff.

## Test plan

```bash
# Smoke tests (no WP dependency).
php tests/auth-per-user-api-smoke.php          # 28 passed
php tests/auth-principal-scoped-smoke.php      # 16 passed (regression)
php tests/calling-user-id-payload-smoke.php    # 11 passed

# Unit tests (requires WP test bootstrap).
phpunit tests/Unit/Core/OAuth/BaseAuthProviderTest.php

# Vendor-name grep — must return empty.
git diff origin/main...HEAD | grep -iE "google|drive|notion|dropbox|bluesky|twitter|instagram|roadie|extrachill"

# CLI smoke (against a local install with a test provider registered).
wp datamachine auth revoke <handler> --user=42 --yes
wp datamachine auth revoke <handler> --yes              # site-wide

# Ability smoke.
wp ability execute datamachine/revoke-auth-for-user --input='{"handler_slug":"<handler>","user_id":42}'

# Payload propagation: confirm calling_user_id reaches directives.
# Inside any directive's get_outputs:
#   error_log( 'calling_user_id=' . datamachine_get_calling_user_id( $payload ) );
# Then trigger via chat (should print caller ID) and pipeline (should print 0).
```

## Migration guidance

**Existing installs need no action at deploy time.** The legacy site-wide flow (`get_account()` / `save_account()` without context) continues to work unchanged. Tokens encrypted before v0.88.0 are lazy-migrated on next save. Per-user storage activates only when callers opt in via `get_account_for_user($user_id)` or by setting `calling_user_id > 0` in the payload — both new behaviors.

Defining `DATAMACHINE_OAUTH_ENCRYPTION_KEY` is **not** required because keys derive from `wp_salt('auth')`, which already pulls from `wp-config.php` salts. Operators who want explicit key isolation can rotate `AUTH_KEY` — be aware that doing so invalidates any not-yet-resaved encrypted values.

## Downstream dependencies

This PR is the foundation for:

- **extrachill-users#44** — adopts the per-user OAuth surface and the `datamachine_resolve_oauth_account_for_user` filter to plug in custom per-user storage.
- **extrachill-roadie#8** — adopts `AgentModeRegistry` and reads `calling_user_id` from the payload to resolve per-user credentials in EC platform tools.

Both downstream issues are blocked on this PR landing.

Closes #2081