### PR TITLE
Preserve AI failure diagnostics

### DIFF
--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -251,7 +251,7 @@ function datamachine_run_conversation(
 		// the substrate can return its accumulated result. Preserve the latest
 		// known state from completed turns so failed job artifacts still explain
 		// where the conversation stopped.
-		$error_result                       = array(
+		$error_result          = array(
 			'messages'               => $latest_messages,
 			'final_content'          => '',
 			'turn_count'             => $latest_turn_count,
@@ -396,7 +396,7 @@ function datamachine_build_turn_runner(
 		&$latest_turn_count
 	): array {
 		// The upstream loop provides the turn number via turn_context.
-		$turn_count = (int) ( $turn_context['turn'] ?? 1 );
+		$turn_count        = (int) ( $turn_context['turn'] ?? 1 );
 		$latest_turn_count = $turn_count;
 		$latest_messages   = $messages;
 

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -81,6 +81,8 @@ function datamachine_run_conversation(
 	$tool_execution_results = array();
 	$completion_nudges      = array();
 	$last_request_metadata  = array();
+	$latest_messages        = $messages;
+	$latest_turn_count      = 0;
 
 	// Base log context for consistent logging.
 	$base_log_context = array_filter(
@@ -185,7 +187,9 @@ function datamachine_run_conversation(
 		$last_tool_calls,
 		$tool_execution_results,
 		$completion_nudges,
-		$last_request_metadata
+		$last_request_metadata,
+		$latest_messages,
+		$latest_turn_count
 	);
 
 	// Build should_continue callback. Budget enforcement is handled by
@@ -203,6 +207,24 @@ function datamachine_run_conversation(
 		return ! empty( $result['tool_execution_results'] ) || ! empty( $result['completion_nudge'] ) || ! empty( $result['duplicate_tool_call_rejected'] ) || ! empty( $result['tool_runtime_rule_rejected'] );
 	};
 
+	$conversation_request = new \AgentsAPI\AI\WP_Agent_Conversation_Request(
+		$messages,
+		array(),
+		null,
+		array_merge( $loop_payload, array(
+			'mode'  => $mode,
+			'modes' => $modes,
+		) ),
+		array(
+			'provider'  => $provider,
+			'model'     => $model,
+			'wordpress' => WordPressWorkspaceScope::metadata(),
+		),
+		$max_turns,
+		$single_turn,
+		WordPressWorkspaceScope::current()
+	);
+
 	// Run through the upstream substrate loop.
 	try {
 		$result = WP_Agent_Conversation_Loop::run(
@@ -215,23 +237,7 @@ function datamachine_run_conversation(
 					'mode'  => $mode,
 					'modes' => $modes,
 				) ),
-				'request'               => new \AgentsAPI\AI\WP_Agent_Conversation_Request(
-					$messages,
-					array(),
-					null,
-					array_merge( $loop_payload, array(
-						'mode'  => $mode,
-						'modes' => $modes,
-					) ),
-					array(
-						'provider'  => $provider,
-						'model'     => $model,
-						'wordpress' => WordPressWorkspaceScope::metadata(),
-					),
-					$max_turns,
-					$single_turn,
-					WordPressWorkspaceScope::current()
-				),
+				'request'               => $conversation_request,
 				'should_continue'       => $should_continue,
 				'transcript_persister'  => $transcript_persister,
 				'transcript_lock'       => $transcript_lock,
@@ -241,22 +247,26 @@ function datamachine_run_conversation(
 			)
 		);
 	} catch ( \RuntimeException $e ) {
-		// The turn runner throws RuntimeException for wp-ai-client failures.
-		// We can't read the substrate's accumulated turn_count/usage/etc here
-		// because the loop didn't return — surface what we know with empty
-		// defaults for the substrate-tracked fields.
+		// The turn runner throws RuntimeException for wp-ai-client failures before
+		// the substrate can return its accumulated result. Preserve the latest
+		// known state from completed turns so failed job artifacts still explain
+		// where the conversation stopped.
 		$error_result                       = array(
-			'messages'               => $messages,
+			'messages'               => $latest_messages,
 			'final_content'          => '',
-			'turn_count'             => 0,
+			'turn_count'             => $latest_turn_count,
 			'completed'              => false,
 			'last_tool_calls'        => $last_tool_calls,
-			'tool_execution_results' => array(),
+			'tool_execution_results' => $tool_execution_results,
 			'error'                  => $e->getMessage(),
 			'usage'                  => array(),
 			'request_metadata'       => $last_request_metadata,
 			'status'                 => 'error',
 		);
+		$transcript_session_id = $transcript_persister->persist( $latest_messages, $conversation_request, $error_result );
+		if ( '' !== $transcript_session_id ) {
+			$error_result['transcript_session_id'] = $transcript_session_id;
+		}
 		$error_result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $error_result, $loop_payload, $provider, $model, $modes );
 		return $error_result;
 	}
@@ -363,7 +373,9 @@ function datamachine_build_turn_runner(
 	array &$last_tool_calls,
 	array &$all_tool_results,
 	array &$completion_nudges,
-	array &$last_request_metadata
+	array &$last_request_metadata,
+	array &$latest_messages,
+	int &$latest_turn_count
 ): callable {
 	return static function ( array $messages, array $turn_context ) use (
 		$tools,
@@ -379,10 +391,14 @@ function datamachine_build_turn_runner(
 		&$last_tool_calls,
 		&$all_tool_results,
 		&$completion_nudges,
-		&$last_request_metadata
+		&$last_request_metadata,
+		&$latest_messages,
+		&$latest_turn_count
 	): array {
 		// The upstream loop provides the turn number via turn_context.
 		$turn_count = (int) ( $turn_context['turn'] ?? 1 );
+		$latest_turn_count = $turn_count;
+		$latest_messages   = $messages;
 
 		// Build and dispatch AI request using centralized RequestBuilder.
 		// Per-turn request metadata is captured locally and returned in the
@@ -691,6 +707,8 @@ function datamachine_build_turn_runner(
 				}
 			}
 		}
+
+		$latest_messages = $messages;
 
 		return array(
 			'messages'                     => $messages,

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -57,6 +57,8 @@ require_once __DIR__ . '/Unit/Support/WpAiClientTestDoubles.php';
 use DataMachine\Engine\AI\LoopEventSinkInterface;
 use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 use AgentsAPI\AI\WP_Agent_Message;
+use AgentsAPI\AI\WP_Agent_Conversation_Request;
+use AgentsAPI\AI\WP_Agent_Transcript_Persister;
 
 use function DataMachine\Engine\AI\datamachine_run_conversation;
 
@@ -68,6 +70,29 @@ class RunnerRequestSmokeSink implements LoopEventSinkInterface {
 			'event'   => $event,
 			'payload' => $payload,
 		);
+	}
+}
+
+class RunnerRequestSmokeTool {
+	public function execute( array $params ): array {
+		return array(
+			'success' => true,
+			'name'    => (string) ( $params['name'] ?? '' ),
+		);
+	}
+}
+
+class RunnerRequestSmokeTranscriptPersister implements WP_Agent_Transcript_Persister {
+	public array $calls = array();
+
+	public function persist( array $messages, WP_Agent_Conversation_Request $request, array $result ): string {
+		$this->calls[] = array(
+			'messages' => $messages,
+			'result'   => $result,
+			'context'  => $request->runtimeContext(),
+		);
+
+		return 'runner-request-smoke-failure-session';
 	}
 }
 
@@ -176,6 +201,70 @@ assert_runner_request( str_contains( (string) ( $error_result['error'] ?? '' ), 
 assert_runner_request( false === ( $error_result['completed'] ?? true ), 'error path marks conversation not completed' );
 assert_runner_request( 'provider_error' === ( $error_result['runtime_provenance']['status']['finish_reason'] ?? null ), 'error provenance records provider error finish reason' );
 assert_runner_request( str_contains( (string) ( $error_result['runtime_provenance']['provider_errors'][0]['message'] ?? '' ), 'provider offline' ), 'error provenance records provider error message' );
+
+// 3. Mid-conversation provider failures preserve the completed-turn context.
+$mid_failure_dispatch_count = 0;
+$mid_failure_transcript     = new RunnerRequestSmokeTranscriptPersister();
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$mid_failure_dispatch_count ) {
+		++$mid_failure_dispatch_count;
+
+		if ( 1 === $mid_failure_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => '',
+					'tool_calls' => array(
+						array(
+							'name'       => 'runner_request_smoke_tool',
+							'parameters' => array( 'name' => 'Ada' ),
+						),
+					),
+					'usage'      => array(
+						'prompt_tokens'     => 4,
+						'completion_tokens' => 5,
+						'total_tokens'      => 9,
+					),
+				),
+			);
+		}
+
+		throw new RuntimeException( 'provider offline after tool' );
+	}
+);
+
+$mid_failure_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'use a tool then continue' ) ),
+	array(
+		'runner_request_smoke_tool' => array(
+			'name'        => 'runner_request_smoke_tool',
+			'description' => 'Runner request smoke tool',
+			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+			'class'       => RunnerRequestSmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	array( 'pipeline' ),
+	array(
+		'transcript_persister' => $mid_failure_transcript,
+	),
+	3
+);
+
+assert_runner_request( 2 === $mid_failure_dispatch_count, 'mid-conversation failure reaches the second provider request' );
+assert_runner_request( str_contains( (string) ( $mid_failure_result['error'] ?? '' ), 'provider offline after tool' ), 'mid-conversation failure preserves provider error' );
+assert_runner_request( 2 === ( $mid_failure_result['turn_count'] ?? null ), 'mid-conversation failure preserves latest turn count' );
+assert_runner_request( 1 === count( $mid_failure_result['tool_execution_results'] ?? array() ), 'mid-conversation failure preserves completed tool results' );
+assert_runner_request( str_contains( wp_json_encode( $mid_failure_result['messages'] ?? array() ), 'runner_request_smoke_tool' ), 'mid-conversation failure preserves accumulated messages' );
+assert_runner_request( 'provider_error' === ( $mid_failure_result['runtime_provenance']['status']['finish_reason'] ?? null ), 'mid-conversation failure provenance records provider error' );
+assert_runner_request( 'runner-request-smoke-failure-session' === ( $mid_failure_result['transcript_session_id'] ?? null ), 'mid-conversation failure returns refreshed transcript session id' );
+$last_failure_transcript_call = end( $mid_failure_transcript->calls );
+assert_runner_request( ! empty( $mid_failure_transcript->calls ), 'mid-conversation failure persists refreshed failure transcript' );
+assert_runner_request( str_contains( (string) ( $last_failure_transcript_call['result']['error'] ?? '' ), 'provider offline after tool' ), 'failure transcript result includes provider error' );
+assert_runner_request( 2 === ( $last_failure_transcript_call['result']['turn_count'] ?? null ), 'failure transcript result includes latest turn count' );
 
 if ( runner_request_failure_count() > 0 ) {
 	exit( 1 );


### PR DESCRIPTION
## Summary
- Preserve the latest conversation messages, turn count, and completed tool results when provider requests fail mid-loop.
- Persist a refreshed failure transcript so CI artifacts include the provider error and the turn where the run stopped.
- Extend the conversation runner smoke test to cover mid-conversation provider failures.

## Testing
- `php tests/agent-conversation-runner-request-smoke.php`
- `php -l inc/Engine/AI/conversation-loop.php && php -l tests/agent-conversation-runner-request-smoke.php`
- `composer lint -- inc/Engine/AI/conversation-loop.php tests/agent-conversation-runner-request-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the World Creator CI failure path and drafted the failure-diagnostics code/test changes for Chris to review.