### PR TITLE
Fail empty bundle upgrade applies

### DIFF
--- a/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
@@ -163,6 +163,13 @@ final class AgentBundleUpgradePendingAction {
 			$applied[] = $applied_entry;
 		}
 
+		if ( empty( $applied ) && empty( $failed ) && ! empty( $targets ) ) {
+			$failed[] = array(
+				'artifact_key' => '',
+				'error'        => 'No bundle artifacts were approved for apply; nothing changed.',
+			);
+		}
+
 		return array(
 			'success' => empty( $failed ),
 			'applied' => $applied,

--- a/tests/agent-bundle-pending-action-rebase-smoke.php
+++ b/tests/agent-bundle-pending-action-rebase-smoke.php
@@ -226,6 +226,18 @@ pa_rebase_assert(
 	'remote' === ( $captured_payloads['flow:tricky']['flow_config']['1_a_1']['handler_config']['tool'] ?? null )
 );
 
+$captured_payloads = array();
+$empty_apply       = AgentBundleUpgradePendingAction::apply(
+	array(
+		'agent'              => array( 'agent_id' => 7 ),
+		'approved_artifacts' => array(),
+		'target_artifacts'   => $apply_input['target_artifacts'],
+	)
+);
+pa_rebase_assert( 'empty approval apply fails clearly', false === ( $empty_apply['success'] ?? true ) );
+pa_rebase_assert_equals( 'empty approval apply writes nothing', array(), $captured_payloads );
+pa_rebase_assert_equals( 'empty approval apply reports no-op failure', 'No bundle artifacts were approved for apply; nothing changed.', $empty_apply['failed'][0]['error'] ?? null );
+
 echo "\nTotal assertions: {$total}\n";
 if ( 0 !== $failures ) {
 	echo "Failures: {$failures}\n";


### PR DESCRIPTION
## Summary
- Treat accepted bundle upgrade applies with target artifacts but zero approved/applied artifacts as failures.
- Preserve the existing partial-apply behavior when at least one artifact is approved and written.
- Add smoke coverage for the no-op apply case so operators don't see a successful accepted action when nothing changed.

## Context
This came from the Matt wiki bundle upgrade on intelligence.horse: the agent config was locally modified, the staged bundle upgrade had no approved artifacts, and accepting the PendingAction reported success while every artifact was skipped as `not_approved`.

## Testing
- `php tests/agent-bundle-pending-action-rebase-smoke.php`
- `php tests/agent-bundle-upgrade-planner-smoke.php`
- `homeboy lint --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the bundle-upgrade no-op success path, implemented the result contract fix, and added/reran smoke coverage.