### PR TITLE
fix: preserve repeatable system run params

### DIFF
--- a/inc/Cli/Commands/SystemCommand.php
+++ b/inc/Cli/Commands/SystemCommand.php
@@ -212,7 +212,7 @@ class SystemCommand extends BaseCommand {
 	 * <task_type>
 	 * : The task type to run (e.g. alt_text_generation, daily_memory_generation).
 	 *
-	 * [--param=<param>]
+	 * [--param=<param>]...
 	 * : Structured task param as key=value. Repeatable.
 	 *
 	 * [--params=<json>]

--- a/tests/system-run-task-params-smoke.php
+++ b/tests/system-run-task-params-smoke.php
@@ -239,7 +239,7 @@ $registry       = file_get_contents( __DIR__ . '/../inc/Engine/Tasks/TaskRegistr
 $scheduler        = file_get_contents( __DIR__ . '/../inc/Engine/Tasks/TaskScheduler.php' );
 $workflow_ability = file_get_contents( __DIR__ . '/../inc/Abilities/Job/ExecuteWorkflowAbility.php' );
 $assert( 'CLI avoids invalid --param key=value synopsis placeholder', ! str_contains( $system_command, '[--param=<key=value>]' ) );
-$assert( 'CLI documents valid --param synopsis placeholder', str_contains( $system_command, '[--param=<param>]' ) );
+$assert( 'CLI documents repeatable --param synopsis placeholder', str_contains( $system_command, '[--param=<param>]...' ) );
 $assert( 'CLI documents --param key=value semantics', str_contains( $system_command, 'Structured task param as key=value. Repeatable.' ) );
 $assert( 'CLI forwards task_params to runTask', str_contains( $system_command, "'task_params' => $" . 'params' ) );
 $assert( 'run-task ability schema accepts task_params', str_contains( $abilities, "'task_params' => array" ) );


### PR DESCRIPTION
## Summary
- Mark `wp datamachine system run --param` as repeatable in the WP-CLI synopsis so repeated `--param=key=value` values are preserved.
- Tighten the system-run smoke tripwire to require the repeatable synopsis.

## Testing
- `php tests/system-run-task-params-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-system-run-repeatable-param --extension wordpress`
- `php -l inc/Cli/Commands/SystemCommand.php && php -l tests/system-run-task-params-smoke.php`
- `git diff --check`

Note: `homeboy lint --path /Users/chubes/Developer/data-machine@fix-system-run-repeatable-param --extension wordpress` still reports existing repository-wide JS lint findings unrelated to this PHP/docblock change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WP-CLI repeatable option synopsis issue, drafted the small fix and smoke-test tripwire, and ran verification commands. Chris remains responsible for review and acceptance.