### PR TITLE
fix: include batch parent jobs in scoped drain

### DIFF
--- a/inc/Cli/Commands/DrainCommand.php
+++ b/inc/Cli/Commands/DrainCommand.php
@@ -365,9 +365,11 @@ class DrainCommand extends BaseCommand {
 		if ( ! empty( $job_ids ) ) {
 			$clauses = array();
 			foreach ( $job_ids as $job_id ) {
-				$clauses[] = '(a.args LIKE %s OR a.args LIKE %s)';
+				$clauses[] = '(a.args LIKE %s OR a.args LIKE %s OR a.args LIKE %s OR a.args LIKE %s)';
 				$values[]  = '%"job_id":' . $job_id . ',%';
 				$values[]  = '%"job_id":' . $job_id . '}%';
+				$values[]  = '%"parent_job_id":' . $job_id . ',%';
+				$values[]  = '%"parent_job_id":' . $job_id . '}%';
 			}
 			$sql .= '(' . implode( ' OR ', $clauses ) . ') AND ';
 		}

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -43,6 +43,7 @@ assert_drain_contains( '[--job-id=<ids>]', $drain_src, 'drain documents optional
 assert_drain_contains( 'normalizeJobIds', $drain_src, 'drain normalizes optional job-id scope' );
 assert_drain_contains( 'hookWhereSql( $hooks, $job_ids )', $drain_src, 'drain supports optional hook and job-id scopes' );
 assert_drain_contains( 'a.args LIKE %s', $drain_src, 'drain can filter pending actions by serialized job_id args' );
+assert_drain_contains( '"parent_job_id":', $drain_src, 'drain can filter batch actions by serialized parent_job_id args' );
 assert_drain_contains( "a.status = \\'pending\\'", $drain_src, 'drain queries pending actions in the Data Machine group' );
 assert_drain_contains( 'getDuePendingActionIds', $drain_src, 'drain queries concrete due Data Machine action IDs' );
 assert_drain_contains( "\\ActionScheduler::runner()", $drain_src, 'drain runs concrete action IDs through Action Scheduler runner' );


### PR DESCRIPTION
## Summary
- Extends `wp datamachine drain --job-id=<id>` matching to include Action Scheduler args with `parent_job_id`.
- Allows task batch parent jobs, including cleanup chunk batches, to be drained through the same scoped drain operator surface.
- Adds smoke coverage for serialized `parent_job_id` matching.

Fixes #2096.

## Testing
- `php -l inc/Cli/Commands/DrainCommand.php`
- `php tests/flow-run-cli-drain-smoke.php`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed why scoped drain missed task batch actions, drafted the parent-job matching fix and smoke coverage, and ran verification for Chris to review.