### PR TITLE
Rebase agent config bundle paths

### DIFF
--- a/inc/Engine/Bundle/AgentBundleArtifactRebase.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactRebase.php
@@ -194,6 +194,10 @@ final class AgentBundleArtifactRebase {
 	 */
 	public static function policy_burn_in_safe( array $input ): array {
 		$type = (string) $input['artifact_type'];
+		if ( 'agent_config' === $type ) {
+			return self::policy_agent_config_burn_in_safe( $input );
+		}
+
 		if ( 'flow' !== $type ) {
 			return self::policy_conservative( $input );
 		}
@@ -377,6 +381,32 @@ final class AgentBundleArtifactRebase {
 	}
 
 	/**
+	 * Burn-in-safe policy for agent_config artifacts.
+	 *
+	 * Agent config mixes bundle-owned brain config with runtime-local connection
+	 * details. Preserve local runtime connection/auth subtrees, while allowing
+	 * clean remote changes elsewhere (for example graph ontology aliases) to merge.
+	 *
+	 * @param array<string,mixed> $input Rebase input.
+	 * @return array<string,mixed>
+	 */
+	private static function policy_agent_config_burn_in_safe( array $input ): array {
+		$base   = is_array( $input['base'] ?? null ) ? $input['base'] : array();
+		$local  = is_array( $input['local'] ?? null ) ? $input['local'] : array();
+		$remote = is_array( $input['remote'] ?? null ) ? $input['remote'] : array();
+
+		$decisions = array();
+		$ambiguous = array();
+		$merged    = self::merge_agent_config_value( $base, $local, $remote, '', $decisions, $ambiguous );
+
+		return array(
+			'merged'    => is_array( $merged ) ? $merged : array(),
+			'decisions' => $decisions,
+			'ambiguous' => $ambiguous,
+		);
+	}
+
+	/**
 	 * Keep local burn-in max_items consistent across legacy and canonical shapes.
 	 *
 	 * Flow payloads may carry both `handler_config` and `handler_configs` while
@@ -455,6 +485,111 @@ final class AgentBundleArtifactRebase {
 		}
 
 		return $local['max_items'];
+	}
+
+	/**
+	 * Merge one agent_config value using path-aware ownership rules.
+	 *
+	 * @param mixed                               $base Base value.
+	 * @param mixed                               $local Local value.
+	 * @param mixed                               $remote Remote value.
+	 * @param string                              $path Dot path.
+	 * @param array<string,array<string,string>>  $decisions In/out decisions map.
+	 * @param array<int,string>                   $ambiguous In/out ambiguous list.
+	 */
+	private static function merge_agent_config_value( mixed $base, mixed $local, mixed $remote, string $path, array &$decisions, array &$ambiguous ): mixed {
+		$local_exists  = null !== $local;
+		$remote_exists = null !== $remote;
+		$base_exists   = null !== $base;
+
+		if ( $local === $remote ) {
+			return $local;
+		}
+
+		if ( self::is_runtime_local_agent_config_path( $path ) ) {
+			$decisions[ $path ] = array(
+				'source' => 'local',
+				'reason' => 'burn_in_preserve_runtime_agent_config',
+			);
+			return $local_exists ? $local : $base;
+		}
+
+		if ( is_array( $local ) && is_array( $remote ) && ( is_array( $base ) || ! $base_exists ) ) {
+			$base_array = is_array( $base ) ? $base : array();
+			$merged     = array();
+			$keys       = array_unique( array_merge( array_keys( $base_array ), array_keys( $local ), array_keys( $remote ) ) );
+			foreach ( $keys as $key ) {
+				$key_path          = '' === $path ? (string) $key : $path . '.' . (string) $key;
+				$key_base_exists   = array_key_exists( $key, $base_array );
+				$key_local_exists  = array_key_exists( $key, $local );
+				$key_remote_exists = array_key_exists( $key, $remote );
+				$value             = self::merge_agent_config_value(
+					$key_base_exists ? $base_array[ $key ] : null,
+					$key_local_exists ? $local[ $key ] : null,
+					$key_remote_exists ? $remote[ $key ] : null,
+					$key_path,
+					$decisions,
+					$ambiguous
+				);
+				if ( $key_local_exists || $key_remote_exists || null !== $value ) {
+					$merged[ $key ] = $value;
+				}
+			}
+			return $merged;
+		}
+
+		$local_changed  = $local_exists && ( ! $base_exists || $local !== $base );
+		$remote_changed = $remote_exists && ( ! $base_exists || $remote !== $base );
+
+		if ( $local_changed && $remote_changed ) {
+			$decisions[ $path ] = array(
+				'source' => 'ambiguous',
+				'reason' => 'both_diverged_from_base',
+			);
+			$ambiguous[]        = $path;
+			return $local;
+		}
+
+		if ( $local_changed ) {
+			$decisions[ $path ] = array(
+				'source' => 'local',
+				'reason' => 'remote_unchanged_from_base',
+			);
+			return $local;
+		}
+
+		if ( $remote_changed ) {
+			$decisions[ $path ] = array(
+				'source' => 'remote',
+				'reason' => 'local_unchanged_from_base',
+			);
+			return $remote;
+		}
+
+		return $remote_exists ? $remote : $local;
+	}
+
+	/**
+	 * Whether an agent_config path is runtime-local and should preserve local state.
+	 *
+	 * @param string $path Dot path.
+	 */
+	private static function is_runtime_local_agent_config_path( string $path ): bool {
+		$prefixes = array(
+			'intelligence.context_servers',
+			'intelligence.auth_refs',
+			'allowed_redirect_uris',
+			'model',
+			'provider',
+		);
+
+		foreach ( $prefixes as $prefix ) {
+			if ( $path === $prefix || str_starts_with( $path, $prefix . '.' ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
@@ -64,13 +64,17 @@ final class AgentBundleCoreArtifactApply {
 		$agent_id = (int) ( $agent['agent_id'] ?? 0 );
 		$payload  = is_array( $artifact['payload'] ?? null ) ? $artifact['payload'] : array();
 
-		if ( $agent_id <= 0 || empty( $payload ) || ! in_array( $type, array( 'pipeline', 'flow' ), true ) ) {
+		if ( $agent_id <= 0 || empty( $payload ) || ! in_array( $type, array( 'agent_config', 'pipeline', 'flow' ), true ) ) {
 			return null;
 		}
 
-		$applied = 'pipeline' === $type
-			? self::apply_pipeline( $artifact, $agent_id, $payload )
-			: self::apply_flow( $artifact, $agent_id, $payload );
+		if ( 'agent_config' === $type ) {
+			$applied = self::apply_agent_config( $artifact, $agent_id, $payload );
+		} else {
+			$applied = 'pipeline' === $type
+				? self::apply_pipeline( $artifact, $agent_id, $payload )
+				: self::apply_flow( $artifact, $agent_id, $payload );
+		}
 		if ( is_wp_error( $applied ) ) {
 			return $applied;
 		}
@@ -81,6 +85,32 @@ final class AgentBundleCoreArtifactApply {
 		}
 
 		return array_merge( $applied, array( 'registry' => 'updated' ) );
+	}
+
+	/**
+	 * @param array<string,mixed> $artifact Artifact envelope.
+	 * @param array<string,mixed> $payload Artifact payload.
+	 */
+	private static function apply_agent_config( array $artifact, int $agent_id, array $payload ): array|\WP_Error {
+		$agents = new Agents();
+		$agent  = $agents->get_agent( $agent_id );
+		if ( ! $agent ) {
+			return new \WP_Error( 'datamachine_bundle_agent_missing', sprintf( 'Agent ID %d was not found.', $agent_id ) );
+		}
+		$current_config = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
+		if ( ! empty( $current_config['datamachine_bundle'] ) && ! isset( $payload['datamachine_bundle'] ) ) {
+			$payload['datamachine_bundle'] = $current_config['datamachine_bundle'];
+		}
+
+		if ( ! $agents->update_agent( $agent_id, array( 'agent_config' => $payload ) ) ) {
+			return new \WP_Error( 'datamachine_bundle_agent_config_update_failed', 'Failed to update agent_config bundle artifact.' );
+		}
+
+		return array(
+			'artifact_type' => 'agent_config',
+			'artifact_id'   => (string) ( $artifact['artifact_id'] ?? 'config' ),
+			'agent_id'      => $agent_id,
+		);
 	}
 
 	/**

--- a/tests/agent-bundle-artifact-rebase-smoke.php
+++ b/tests/agent-bundle-artifact-rebase-smoke.php
@@ -97,6 +97,53 @@ rebase_assert( 'pipeline rebase requires approval under burn-in-safe', true === 
 rebase_assert_equals( 'pipeline merged stays local under burn-in-safe', array( 'steps' => array( 'fetch', 'ai' ), 'note' => 'local' ), $pipeline_result['merged'] );
 
 // ---------------------------------------------------------------------------
+// [2b] agent_config burn-in-safe preserves runtime-local config but takes clean bundle changes.
+// ---------------------------------------------------------------------------
+echo "\n[2b] burn-in-safe rebases agent_config path-wise\n";
+$base_agent_config = array(
+	'intelligence'            => array(
+		'context_servers' => array(
+			'a8c' => array(
+				'transport' => 'streamable-http',
+				'url'       => 'https://public-api.wordpress.com/wpcom/v2/context-a8c-mcp/v1',
+			),
+		),
+	),
+	'intelligence_wiki_brain' => array(
+		'graph_config' => array(
+			'entity_types' => array(
+				'strategic-signal' => array(
+					'label'       => 'Strategic signal',
+					'description' => 'Source-backed signal.',
+				),
+			),
+		),
+	),
+);
+$local_agent_config = $base_agent_config;
+$local_agent_config['intelligence']['context_servers']['a8c']['url']                      = 'https://local-tunnel.example.test/mcp';
+$local_agent_config['intelligence']['context_servers']['a8c']['headers']['Authorization'] = 'Bearer local-token';
+$remote_agent_config = $base_agent_config;
+$remote_agent_config['intelligence_wiki_brain']['graph_config']['entity_types']['strategic-signal']['aliases'] = array( 'strategy-signal' );
+
+$agent_config_result = AgentBundleArtifactRebase::rebase(
+	array(
+		'artifact_type' => 'agent_config',
+		'artifact_id'   => 'config',
+		'base'          => $base_agent_config,
+		'local'         => $local_agent_config,
+		'remote'        => $remote_agent_config,
+	),
+	AgentBundleArtifactRebase::POLICY_BURN_IN_SAFE
+);
+rebase_assert( 'agent_config rebase is unambiguous for runtime-local plus bundle-owned paths', false === $agent_config_result['requires_approval'] );
+rebase_assert_equals( 'agent_config preserves local context server URL', 'https://local-tunnel.example.test/mcp', $agent_config_result['merged']['intelligence']['context_servers']['a8c']['url'] ?? null );
+rebase_assert_equals( 'agent_config preserves local auth header', 'Bearer local-token', $agent_config_result['merged']['intelligence']['context_servers']['a8c']['headers']['Authorization'] ?? null );
+rebase_assert_equals( 'agent_config takes remote graph alias', array( 'strategy-signal' ), $agent_config_result['merged']['intelligence_wiki_brain']['graph_config']['entity_types']['strategic-signal']['aliases'] ?? null );
+rebase_assert_equals( 'agent_config records runtime-local decision', 'burn_in_preserve_runtime_agent_config', $agent_config_result['decisions']['intelligence.context_servers']['reason'] ?? null );
+rebase_assert_equals( 'agent_config records bundle-owned remote decision', 'local_unchanged_from_base', $agent_config_result['decisions']['intelligence_wiki_brain.graph_config.entity_types.strategic-signal.aliases']['reason'] ?? null );
+
+// ---------------------------------------------------------------------------
 // [3] burn-in-safe takes remote source-shape, keeps local throttles.
 // Mirrors the wordpress-com-wiki Flow 41 case from the issue.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extend `burn-in-safe` bundle artifact rebase to `agent_config` artifacts.
- Preserve runtime-local agent config paths such as `intelligence.context_servers` and auth refs.
- Allow clean bundle-owned paths, such as wiki brain graph config aliases, to merge without manual `agent config --set` surgery.
- Add core apply support for approved `agent_config` artifacts while preserving the existing bundle registry.

## Context
This follows the Matt wiki graph alias upgrade on intelligence.horse: a safe bundle graph-config addition was blocked behind a coarse locally modified `agent_config:config` artifact because local ContextA8C runtime config had drifted.

## Testing
- `php tests/agent-bundle-artifact-rebase-smoke.php`
- `php tests/agent-bundle-pending-action-rebase-smoke.php`
- `php tests/agent-bundle-upgrade-planner-smoke.php`
- `homeboy lint --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the coarse agent_config rebase footgun, implemented path-aware rebase/apply handling, and added/reran smoke coverage.