### PR TITLE
Fix custom chat modes loading core memory

### DIFF
--- a/inc/Engine/AI/AgentModeRegistry.php
+++ b/inc/Engine/AI/AgentModeRegistry.php
@@ -3,8 +3,9 @@
  * Agent Mode Registry
  *
  * Central registry for AI execution modes (chat, pipeline, system, editor, etc.).
- * Each mode has an ID, label, description, and priority for sort order. Runtime
- * requests can activate multiple registered modes additively.
+	 * Each mode has an ID, label, description, priority for sort order, and
+	 * optional memory contexts activated by that mode. Runtime requests can
+	 * activate multiple registered modes additively.
  *
  * Extension point: the `datamachine_agent_modes` action fires once per request
  * when the registry is first consumed, allowing extensions to register
@@ -44,8 +45,9 @@ class AgentModeRegistry {
 	 * @param array  $args     {
 	 *     Registration arguments.
 	 *
-	 *     @type string $label       Human-readable display label.
-	 *     @type string $description Description of the mode's purpose.
+	 *     @type string   $label           Human-readable display label.
+	 *     @type string   $description     Description of the mode's purpose.
+	 *     @type string[] $memory_contexts Semantic memory contexts activated by the mode.
 	 * }
 	 * @return void
 	 */
@@ -57,10 +59,11 @@ class AgentModeRegistry {
 		}
 
 		self::$modes[ $id ] = array(
-			'id'          => $id,
-			'priority'    => $priority,
-			'label'       => $args['label'] ?? self::id_to_label( $id ),
-			'description' => $args['description'] ?? '',
+			'id'              => $id,
+			'priority'        => $priority,
+			'label'           => $args['label'] ?? self::id_to_label( $id ),
+			'description'     => $args['description'] ?? '',
+			'memory_contexts' => self::normalize_memory_contexts( $args['memory_contexts'] ?? array() ),
 		);
 	}
 
@@ -122,6 +125,30 @@ class AgentModeRegistry {
 	 */
 	public static function get_ids(): array {
 		return array_keys( self::get_resolved() );
+	}
+
+	/**
+	 * Get semantic memory contexts activated by execution modes.
+	 *
+	 * @since 0.124.3
+	 *
+	 * @param array<int,string> $modes Execution mode slugs.
+	 * @return array<int,string> Memory context slugs.
+	 */
+	public static function get_memory_contexts_for_modes( array $modes ): array {
+		$resolved = self::get_resolved();
+		$contexts = array();
+
+		foreach ( $modes as $mode ) {
+			$mode = sanitize_key( (string) $mode );
+			if ( '' === $mode || empty( $resolved[ $mode ]['memory_contexts'] ) ) {
+				continue;
+			}
+
+			$contexts = array_merge( $contexts, $resolved[ $mode ]['memory_contexts'] );
+		}
+
+		return array_values( array_unique( $contexts ) );
 	}
 
 	/**
@@ -206,5 +233,35 @@ class AgentModeRegistry {
 	 */
 	private static function id_to_label( string $id ): string {
 		return ucwords( str_replace( array( '-', '_' ), ' ', $id ) );
+	}
+
+	/**
+	 * Normalize memory context slugs.
+	 *
+	 * @param mixed $contexts Raw memory context list.
+	 * @return array<int,string>
+	 */
+	private static function normalize_memory_contexts( mixed $contexts ): array {
+		if ( is_string( $contexts ) ) {
+			$contexts = array( $contexts );
+		}
+
+		if ( ! is_array( $contexts ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $contexts as $context ) {
+			if ( ! is_scalar( $context ) ) {
+				continue;
+			}
+
+			$context = sanitize_key( (string) $context );
+			if ( '' !== $context ) {
+				$normalized[] = $context;
+			}
+		}
+
+		return array_values( array_unique( $normalized ) );
 	}
 }

--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -70,7 +70,7 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 
 		// Load registered files applicable to the current agent modes,
 		// filtered through the per-agent MemoryPolicy.
-		$modes      = self::memory_modes( self::normalizeModes( $payload['agent_modes'] ?? array() ), $payload );
+		$modes      = self::normalizeModes( $payload['agent_modes'] ?? array() );
 		$resolver   = new MemoryPolicyResolver();
 		$mode_files = $resolver->resolveRegistered(
 			array(
@@ -282,29 +282,6 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 		}
 
 		return array_values( array_unique( $normalized ) );
-	}
-
-	/**
-	 * Expand execution modes into memory scopes for core memory file selection.
-	 *
-	 * Agent identity memory applies to interactive conversations, including
-	 * pipeline turns and session-backed custom modes. System mode remains
-	 * explicit so background maintenance does not inherit agent identity.
-	 *
-	 * @param array<int,string> $modes   Normalized active modes.
-	 * @param array             $payload Runtime payload.
-	 * @return array<int,string>
-	 */
-	private static function memory_modes( array $modes, array $payload ): array {
-		if ( in_array( 'system', $modes, true ) || in_array( 'interactive', $modes, true ) ) {
-			return $modes;
-		}
-
-		if ( array_intersect( $modes, array( 'chat', 'pipeline' ) ) || ! empty( $payload['session_id'] ) ) {
-			$modes[] = 'interactive';
-		}
-
-		return array_values( array_unique( $modes ) );
 	}
 }
 

--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -70,7 +70,7 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 
 		// Load registered files applicable to the current agent modes,
 		// filtered through the per-agent MemoryPolicy.
-		$modes      = self::normalizeModes( $payload['agent_modes'] ?? array() );
+		$modes      = self::memory_modes( self::normalizeModes( $payload['agent_modes'] ?? array() ), $payload );
 		$resolver   = new MemoryPolicyResolver();
 		$mode_files = $resolver->resolveRegistered(
 			array(
@@ -282,6 +282,29 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 		}
 
 		return array_values( array_unique( $normalized ) );
+	}
+
+	/**
+	 * Expand custom interactive chat modes for core memory file selection.
+	 *
+	 * Custom modes such as a domain-specific frontend chat mode should still
+	 * receive agent identity and memory files registered for `chat`. System mode
+	 * remains explicit so background maintenance does not inherit agent identity.
+	 *
+	 * @param array<int,string> $modes   Normalized active modes.
+	 * @param array             $payload Runtime payload.
+	 * @return array<int,string>
+	 */
+	private static function memory_modes( array $modes, array $payload ): array {
+		if ( in_array( 'system', $modes, true ) || in_array( 'chat', $modes, true ) ) {
+			return $modes;
+		}
+
+		if ( ! empty( $payload['session_id'] ) ) {
+			$modes[] = 'chat';
+		}
+
+		return array_values( array_unique( $modes ) );
 	}
 }
 

--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -285,23 +285,23 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 	}
 
 	/**
-	 * Expand custom interactive chat modes for core memory file selection.
+	 * Expand execution modes into memory scopes for core memory file selection.
 	 *
-	 * Custom modes such as a domain-specific frontend chat mode should still
-	 * receive agent identity and memory files registered for `chat`. System mode
-	 * remains explicit so background maintenance does not inherit agent identity.
+	 * Agent identity memory applies to interactive conversations, including
+	 * pipeline turns and session-backed custom modes. System mode remains
+	 * explicit so background maintenance does not inherit agent identity.
 	 *
 	 * @param array<int,string> $modes   Normalized active modes.
 	 * @param array             $payload Runtime payload.
 	 * @return array<int,string>
 	 */
 	private static function memory_modes( array $modes, array $payload ): array {
-		if ( in_array( 'system', $modes, true ) || in_array( 'chat', $modes, true ) ) {
+		if ( in_array( 'system', $modes, true ) || in_array( 'interactive', $modes, true ) ) {
 			return $modes;
 		}
 
-		if ( ! empty( $payload['session_id'] ) ) {
-			$modes[] = 'chat';
+		if ( array_intersect( $modes, array( 'chat', 'pipeline' ) ) || ! empty( $payload['session_id'] ) ) {
+			$modes[] = 'interactive';
 		}
 
 		return array_values( array_unique( $modes ) );

--- a/inc/Engine/AI/Memory/MemoryPolicyResolver.php
+++ b/inc/Engine/AI/Memory/MemoryPolicyResolver.php
@@ -26,6 +26,7 @@
 namespace DataMachine\Engine\AI\Memory;
 
 use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Engine\AI\AgentModeRegistry;
 use DataMachine\Engine\AI\MemoryFileRegistry;
 
 defined( 'ABSPATH' ) || exit;
@@ -59,12 +60,13 @@ class MemoryPolicyResolver {
 	 * @return array<string, array> Filename => metadata map, sorted by priority ascending.
 	 */
 	public function resolveRegistered( array $args ): array {
-		$modes    = self::normalizeModes( $args['modes'] ?? ( array_key_exists( 'mode', $args ) ? array( $args['mode'] ) : array() ) );
-		$agent_id = isset( $args['agent_id'] ) ? (int) $args['agent_id'] : 0;
+		$modes              = self::normalizeModes( $args['modes'] ?? ( array_key_exists( 'mode', $args ) ? array( $args['mode'] ) : array() ) );
+		$injection_contexts = self::resolveInjectionContexts( $modes, $args );
+		$agent_id           = isset( $args['agent_id'] ) ? (int) $args['agent_id'] : 0;
 
 		// 1. Start with registry output filtered by mode (already priority-sorted).
-		$files = ! empty( $modes )
-			? MemoryFileRegistry::get_for_modes( $modes )
+		$files = ! empty( $modes ) || ! empty( $injection_contexts )
+			? MemoryFileRegistry::get_for_modes( $modes, $injection_contexts )
 			: MemoryFileRegistry::get_all();
 
 		// 2. Apply per-agent policy.
@@ -90,6 +92,25 @@ class MemoryPolicyResolver {
 		$files       = apply_filters( 'datamachine_resolved_memory_files', $files, $filter_mode, $args );
 
 		return $files;
+	}
+
+	/**
+	 * Resolve semantic memory contexts from explicit args and registered modes.
+	 *
+	 * @param array<int,string> $modes Normalized execution modes.
+	 * @param array             $args  Resolution arguments.
+	 * @return array<int,string>
+	 */
+	private static function resolveInjectionContexts( array $modes, array $args ): array {
+		$contexts = MemoryFileRegistry::normalize_injection_contexts(
+			$args['injection_contexts'] ?? ( $args['memory_contexts'] ?? array() )
+		);
+
+		if ( ! empty( $modes ) ) {
+			$contexts = array_merge( $contexts, AgentModeRegistry::get_memory_contexts_for_modes( $modes ) );
+		}
+
+		return array_values( array_unique( $contexts ) );
 	}
 
 	/**

--- a/inc/Engine/AI/MemoryFileRegistry.php
+++ b/inc/Engine/AI/MemoryFileRegistry.php
@@ -43,6 +43,13 @@ class MemoryFileRegistry {
 	const MODE_ALL = 'all';
 
 	/**
+	 * Semantic prompt-injection contexts independent of execution mode slugs.
+	 */
+	const INJECTION_AGENT_IDENTITY = 'agent_identity';
+	const INJECTION_AGENT_MEMORY   = 'agent_memory';
+	const INJECTION_USER_PROFILE   = 'user_profile';
+
+	/**
 	 * Default mode list for registered files.
 	 *
 	 * Files without explicit modes are registered and manageable, but are not
@@ -89,6 +96,8 @@ class MemoryFileRegistry {
 	 *                                        Array of mode slugs (e.g. 'chat', 'editor', 'pipeline',
 	 *                                        'system') or array( 'all' ) to make available everywhere.
 	 *                                        Default empty array: registered but never injected.
+	 *     @type string[]    $injection_contexts Semantic prompt-injection contexts where this file applies
+	 *                                        independent of execution mode (e.g. 'agent_identity').
 	 *     @type string      $retrieval_policy Context injection policy. Only `always` files are injected
 	 *                                        by CoreMemoryFilesDirective. Defaults to `never` when modes are
 	 *                                        omitted, otherwise `always`.
@@ -125,25 +134,27 @@ class MemoryFileRegistry {
 			$modes = self::MODES_NONE;
 		}
 		$modes                    = array_values( array_unique( array_map( 'sanitize_key', $modes ) ) );
-		$default_retrieval_policy = self::default_retrieval_policy( empty( $modes ) );
+		$injection_contexts       = self::normalize_injection_contexts( $args['injection_contexts'] ?? array() );
+		$default_retrieval_policy = self::default_retrieval_policy( empty( $modes ) && empty( $injection_contexts ) );
 
 		// Convention path: relative path from ABSPATH for an additional copy.
 		$convention_path = isset( $args['convention_path'] ) ? ltrim( $args['convention_path'], '/' ) : '';
 
 		$metadata = array(
-			'filename'         => $filename,
-			'priority'         => $priority,
-			'layer'            => $layer,
-			'protected'        => (bool) ( $args['protected'] ?? false ),
-			'editable'         => $editable,
-			'composable'       => $composable,
-			'convention_path'  => $convention_path,
-			'modes'            => $modes,
-			'label'            => $args['label'] ?? self::filename_to_label( $filename ),
-			'description'      => $args['description'] ?? '',
-			'retrieval_policy' => self::normalize_retrieval_policy( $args['retrieval_policy'] ?? $default_retrieval_policy ),
-			'authority_tier'   => $args['authority_tier'] ?? self::default_authority_tier( $layer, $filename ),
-			'provenance'       => is_array( $args['provenance'] ?? null ) ? $args['provenance'] : self::default_provenance( $filename ),
+			'filename'           => $filename,
+			'priority'           => $priority,
+			'layer'              => $layer,
+			'protected'          => (bool) ( $args['protected'] ?? false ),
+			'editable'           => $editable,
+			'composable'         => $composable,
+			'convention_path'    => $convention_path,
+			'modes'              => $modes,
+			'injection_contexts' => $injection_contexts,
+			'label'              => $args['label'] ?? self::filename_to_label( $filename ),
+			'description'        => $args['description'] ?? '',
+			'retrieval_policy'   => self::normalize_retrieval_policy( $args['retrieval_policy'] ?? $default_retrieval_policy ),
+			'authority_tier'     => $args['authority_tier'] ?? self::default_authority_tier( $layer, $filename ),
+			'provenance'         => is_array( $args['provenance'] ?? null ) ? $args['provenance'] : self::default_provenance( $filename ),
 		);
 
 		self::$files[ $filename ] = $metadata;
@@ -158,21 +169,23 @@ class MemoryFileRegistry {
 		WP_Agent_Memory_Registry::register(
 			self::source_id_for_filename( $filename ),
 			array(
-				'layer'            => $layer,
-				'priority'         => $priority,
-				'protected'        => $metadata['protected'],
-				'editable'         => $editable,
-				'modes'            => $modes,
-				'retrieval_policy' => $metadata['retrieval_policy'],
-				'composable'       => $composable,
-				'context_slug'     => self::context_slug_for_filename( $filename ),
-				'convention_path'  => $convention_path,
-				'label'            => $metadata['label'],
-				'description'      => $metadata['description'],
-				'meta'             => array(
-					'filename'       => $filename,
-					'authority_tier' => $metadata['authority_tier'],
-					'provenance'     => $metadata['provenance'],
+				'layer'              => $layer,
+				'priority'           => $priority,
+				'protected'          => $metadata['protected'],
+				'editable'           => $editable,
+				'modes'              => $modes,
+				'injection_contexts' => $injection_contexts,
+				'retrieval_policy'   => $metadata['retrieval_policy'],
+				'composable'         => $composable,
+				'context_slug'       => self::context_slug_for_filename( $filename ),
+				'convention_path'    => $convention_path,
+				'label'              => $metadata['label'],
+				'description'        => $metadata['description'],
+				'meta'               => array(
+					'filename'           => $filename,
+					'authority_tier'     => $metadata['authority_tier'],
+					'provenance'         => $metadata['provenance'],
+					'injection_contexts' => $injection_contexts,
 				),
 			)
 		);
@@ -211,6 +224,36 @@ class MemoryFileRegistry {
 			return in_array( $policy, $valid, true ) ? $policy : 'always';
 		}
 		return WP_Agent_Context_Injection_Policy::normalize( $policy );
+	}
+
+	/**
+	 * Normalize semantic memory context slugs.
+	 *
+	 * @param mixed $contexts Raw context value.
+	 * @return array<int,string>
+	 */
+	public static function normalize_injection_contexts( mixed $contexts ): array {
+		if ( is_string( $contexts ) ) {
+			$contexts = array( $contexts );
+		}
+
+		if ( ! is_array( $contexts ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $contexts as $context ) {
+			if ( ! is_scalar( $context ) ) {
+				continue;
+			}
+
+			$context = sanitize_key( (string) $context );
+			if ( '' !== $context ) {
+				$normalized[] = $context;
+			}
+		}
+
+		return array_values( array_unique( $normalized ) );
 	}
 
 	/**
@@ -450,10 +493,11 @@ class MemoryFileRegistry {
 	 * @param array $modes Agent mode slugs (e.g. 'chat', 'pipeline', 'system', 'editor').
 	 * @return array<string, array> Filtered and sorted file metadata.
 	 */
-	public static function get_for_modes( array $modes ): array {
-		$modes = array_values( array_unique( array_filter( array_map( 'sanitize_key', $modes ) ) ) );
+	public static function get_for_modes( array $modes, array $injection_contexts = array() ): array {
+		$modes              = array_values( array_unique( array_filter( array_map( 'sanitize_key', $modes ) ) ) );
+		$injection_contexts = self::normalize_injection_contexts( $injection_contexts );
 
-		if ( empty( $modes ) ) {
+		if ( empty( $modes ) && empty( $injection_contexts ) ) {
 			return self::get_resolved();
 		}
 
@@ -461,7 +505,7 @@ class MemoryFileRegistry {
 
 		return array_filter(
 			self::get_resolved(),
-			function ( $meta ) use ( $modes, $agents_api_loaded ) {
+			function ( $meta ) use ( $modes, $injection_contexts, $agents_api_loaded ) {
 				$default_policy   = $agents_api_loaded ? WP_Agent_Context_Injection_Policy::ALWAYS : 'always';
 				$retrieval_policy = $meta['retrieval_policy'] ?? $default_policy;
 				$is_always        = $agents_api_loaded
@@ -471,13 +515,15 @@ class MemoryFileRegistry {
 					return false;
 				}
 
-				$file_modes = $meta['modes'] ?? self::MODES_NONE;
-				if ( empty( $file_modes ) ) {
+				$file_modes    = $meta['modes'] ?? self::MODES_NONE;
+				$file_contexts = self::normalize_injection_contexts( $meta['injection_contexts'] ?? array() );
+				if ( empty( $file_modes ) && empty( $file_contexts ) ) {
 					return false;
 				}
 
 				return in_array( self::MODE_ALL, $file_modes, true )
-					|| ! empty( array_intersect( $modes, $file_modes ) );
+					|| ! empty( array_intersect( $modes, $file_modes ) )
+					|| ! empty( array_intersect( $injection_contexts, $file_contexts ) );
 			}
 		);
 	}
@@ -492,18 +538,21 @@ class MemoryFileRegistry {
 	 * @param array  $modes    Agent mode slugs.
 	 * @return bool True if the file should be injected in this mode.
 	 */
-	public static function applies_to_modes( string $filename, array $modes ): bool {
-		$resolved = self::get_resolved();
-		$filename = sanitize_file_name( $filename );
-		$modes    = array_values( array_unique( array_filter( array_map( 'sanitize_key', $modes ) ) ) );
+	public static function applies_to_modes( string $filename, array $modes, array $injection_contexts = array() ): bool {
+		$resolved           = self::get_resolved();
+		$filename           = sanitize_file_name( $filename );
+		$modes              = array_values( array_unique( array_filter( array_map( 'sanitize_key', $modes ) ) ) );
+		$injection_contexts = self::normalize_injection_contexts( $injection_contexts );
 
 		if ( ! isset( $resolved[ $filename ] ) ) {
 			return true; // Unregistered files are included everywhere.
 		}
 
-		$file_modes = $resolved[ $filename ]['modes'] ?? array( self::MODE_ALL );
+		$file_modes    = $resolved[ $filename ]['modes'] ?? array( self::MODE_ALL );
+		$file_contexts = self::normalize_injection_contexts( $resolved[ $filename ]['injection_contexts'] ?? array() );
 		return in_array( self::MODE_ALL, $file_modes, true )
-			|| ! empty( array_intersect( $modes, $file_modes ) );
+			|| ! empty( array_intersect( $modes, $file_modes ) )
+			|| ! empty( array_intersect( $injection_contexts, $file_contexts ) );
 	}
 
 	/**
@@ -616,19 +665,20 @@ class MemoryFileRegistry {
 			}
 
 			$files[ $filename ] = array(
-				'filename'         => $filename,
-				'priority'         => (int) ( $source['priority'] ?? 50 ),
-				'layer'            => self::normalize_layer( $source['layer'] ?? self::LAYER_AGENT ),
-				'protected'        => (bool) ( $source['protected'] ?? false ),
-				'editable'         => $source['editable'] ?? true,
-				'composable'       => (bool) ( $source['composable'] ?? false ),
-				'convention_path'  => is_string( $source['convention_path'] ?? null ) ? $source['convention_path'] : '',
-				'modes'            => is_array( $source['modes'] ?? null ) ? $source['modes'] : self::MODES_NONE,
-				'label'            => is_string( $source['label'] ?? null ) ? $source['label'] : self::filename_to_label( $filename ),
-				'description'      => is_string( $source['description'] ?? null ) ? $source['description'] : '',
-				'retrieval_policy' => is_string( $source['retrieval_policy'] ?? null ) ? $source['retrieval_policy'] : WP_Agent_Context_Injection_Policy::ALWAYS,
-				'authority_tier'   => is_string( $source['meta']['authority_tier'] ?? null ) ? $source['meta']['authority_tier'] : self::default_authority_tier( self::normalize_layer( $source['layer'] ?? self::LAYER_AGENT ), $filename ),
-				'provenance'       => is_array( $source['meta']['provenance'] ?? null ) ? $source['meta']['provenance'] : self::default_provenance( $filename ),
+				'filename'           => $filename,
+				'priority'           => (int) ( $source['priority'] ?? 50 ),
+				'layer'              => self::normalize_layer( $source['layer'] ?? self::LAYER_AGENT ),
+				'protected'          => (bool) ( $source['protected'] ?? false ),
+				'editable'           => $source['editable'] ?? true,
+				'composable'         => (bool) ( $source['composable'] ?? false ),
+				'convention_path'    => is_string( $source['convention_path'] ?? null ) ? $source['convention_path'] : '',
+				'modes'              => is_array( $source['modes'] ?? null ) ? $source['modes'] : self::MODES_NONE,
+				'injection_contexts' => self::normalize_injection_contexts( $source['injection_contexts'] ?? ( $source['meta']['injection_contexts'] ?? array() ) ),
+				'label'              => is_string( $source['label'] ?? null ) ? $source['label'] : self::filename_to_label( $filename ),
+				'description'        => is_string( $source['description'] ?? null ) ? $source['description'] : '',
+				'retrieval_policy'   => is_string( $source['retrieval_policy'] ?? null ) ? $source['retrieval_policy'] : WP_Agent_Context_Injection_Policy::ALWAYS,
+				'authority_tier'     => is_string( $source['meta']['authority_tier'] ?? null ) ? $source['meta']['authority_tier'] : self::default_authority_tier( self::normalize_layer( $source['layer'] ?? self::LAYER_AGENT ), $filename ),
+				'provenance'         => is_array( $source['meta']['provenance'] ?? null ) ? $source['meta']['provenance'] : self::default_provenance( $filename ),
 			);
 		}
 
@@ -707,32 +757,19 @@ class MemoryFileRegistry {
 	 * @return string Authority tier slug.
 	 */
 	private static function default_authority_tier( string $layer, string $filename ): string {
-		if ( ! self::agents_api_loaded() ) {
-			if ( self::LAYER_SHARED === $layer || self::LAYER_NETWORK === $layer ) {
-				return 'workspace_shared';
-			}
-			if ( self::LAYER_USER === $layer ) {
-				return 'user_global';
-			}
-			if ( 'SOUL.md' === $filename ) {
-				return 'agent_identity';
-			}
-			return 'agent_memory';
-		}
-
 		if ( self::LAYER_SHARED === $layer || self::LAYER_NETWORK === $layer ) {
-			return \AgentsAPI\AI\Context\WP_Agent_Context_Authority_Tier::WORKSPACE_SHARED;
+			return 'workspace_shared';
 		}
 
 		if ( self::LAYER_USER === $layer ) {
-			return \AgentsAPI\AI\Context\WP_Agent_Context_Authority_Tier::USER_GLOBAL;
+			return 'user_global';
 		}
 
 		if ( 'SOUL.md' === $filename ) {
-			return \AgentsAPI\AI\Context\WP_Agent_Context_Authority_Tier::AGENT_IDENTITY;
+			return 'agent_identity';
 		}
 
-		return \AgentsAPI\AI\Context\WP_Agent_Context_Authority_Tier::AGENT_MEMORY;
+		return 'agent_memory';
 	}
 
 	private static function default_provenance( string $filename ): array {

--- a/inc/Engine/AI/MemoryFileRegistry.php
+++ b/inc/Engine/AI/MemoryFileRegistry.php
@@ -638,7 +638,7 @@ class MemoryFileRegistry {
 		// When the Agents API substrate is missing, the local self::$files map
 		// is the single source of truth. See agents_api_loaded() docblock.
 		$files = self::agents_api_loaded()
-			? self::from_agents_api_sources( WP_Agent_Memory_Registry::get_all() )
+			? array_replace( self::from_agents_api_sources( WP_Agent_Memory_Registry::get_all() ), self::$files )
 			: self::$files;
 		uasort(
 			$files,

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -167,12 +167,14 @@ add_action(
 	'init',
 	function () {
 		AgentModeRegistry::register( 'chat', 10, array(
-			'label'       => __( 'Chat Agent', 'data-machine' ),
-			'description' => __( 'Interactive chat conversations. Benefits from capable models for complex reasoning.', 'data-machine' ),
+			'label'           => __( 'Chat Agent', 'data-machine' ),
+			'description'     => __( 'Interactive chat conversations. Benefits from capable models for complex reasoning.', 'data-machine' ),
+			'memory_contexts' => array( 'agent_identity', 'agent_memory', 'user_profile' ),
 		) );
 		AgentModeRegistry::register( 'pipeline', 20, array(
-			'label'       => __( 'Pipeline Agent', 'data-machine' ),
-			'description' => __( 'Structured workflow execution. Operates within defined steps — efficient models work well.', 'data-machine' ),
+			'label'           => __( 'Pipeline Agent', 'data-machine' ),
+			'description'     => __( 'Structured workflow execution. Operates within defined steps — efficient models work well.', 'data-machine' ),
+			'memory_contexts' => array( 'agent_identity', 'agent_memory' ),
 		) );
 		AgentModeRegistry::register( 'system', 30, array(
 			'label'       => __( 'System Agent', 'data-machine' ),
@@ -204,34 +206,35 @@ function datamachine_register_default_memory_files(): void {
 	) );
 
 	// Agent layer — identity and knowledge, scoped to a single agent.
-	// Injected in interactive modes only. Excluded from
+	// Injected only when an execution mode activates the matching semantic
+	// memory context. Excluded from
 	// system mode so autonomous maintenance tasks (e.g. daily memory
 	// compaction) are not primed with the agent's identity while operating
 	// on these files.
 	MemoryFileRegistry::register( 'SOUL.md', 20, array(
-		'layer'       => MemoryFileRegistry::LAYER_AGENT,
-		'protected'   => true,
-		'modes'       => array( 'chat', 'pipeline', 'interactive' ),
-		'label'       => 'Agent Identity',
-		'description' => 'Agent identity, voice, rules. Injected in interactive modes only.',
+		'layer'              => MemoryFileRegistry::LAYER_AGENT,
+		'protected'          => true,
+		'injection_contexts' => array( 'agent_identity' ),
+		'label'              => 'Agent Identity',
+		'description'        => 'Agent identity, voice, rules. Injected when the mode activates agent identity memory.',
 	) );
 	MemoryFileRegistry::register( 'MEMORY.md', 30, array(
-		'layer'       => MemoryFileRegistry::LAYER_AGENT,
-		'protected'   => true,
-		'modes'       => array( 'chat', 'pipeline', 'interactive' ),
-		'label'       => 'Agent Memory',
-		'description' => 'Accumulated knowledge. Injected in interactive modes only.',
+		'layer'              => MemoryFileRegistry::LAYER_AGENT,
+		'protected'          => true,
+		'injection_contexts' => array( 'agent_memory' ),
+		'label'              => 'Agent Memory',
+		'description'        => 'Accumulated knowledge. Injected when the mode activates agent memory.',
 	) );
 
 	// User layer — human preferences, network-scoped on multisite.
 	// Only injected in interactive modes where a human is present.
 	// Pipelines can still opt in via pipeline memory file selection.
 	MemoryFileRegistry::register( 'USER.md', 25, array(
-		'layer'       => MemoryFileRegistry::LAYER_USER,
-		'protected'   => true,
-		'modes'       => array( 'chat', 'editor' ),
-		'label'       => 'User Profile',
-		'description' => 'Information about the human the agent works with. Injected in chat and editor modes only.',
+		'layer'              => MemoryFileRegistry::LAYER_USER,
+		'protected'          => true,
+		'injection_contexts' => array( 'user_profile' ),
+		'label'              => 'User Profile',
+		'description'        => 'Information about the human the agent works with. Injected when the mode activates user profile memory.',
 	) );
 
 	// Network layer — multisite topology, only meaningful on multisite installs.

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -204,21 +204,21 @@ function datamachine_register_default_memory_files(): void {
 	) );
 
 	// Agent layer — identity and knowledge, scoped to a single agent.
-	// Injected in interactive modes only (chat, pipeline). Excluded from
+	// Injected in interactive modes only. Excluded from
 	// system mode so autonomous maintenance tasks (e.g. daily memory
 	// compaction) are not primed with the agent's identity while operating
 	// on these files.
 	MemoryFileRegistry::register( 'SOUL.md', 20, array(
 		'layer'       => MemoryFileRegistry::LAYER_AGENT,
 		'protected'   => true,
-		'modes'       => array( 'chat', 'pipeline' ),
+		'modes'       => array( 'chat', 'pipeline', 'interactive' ),
 		'label'       => 'Agent Identity',
 		'description' => 'Agent identity, voice, rules. Injected in interactive modes only.',
 	) );
 	MemoryFileRegistry::register( 'MEMORY.md', 30, array(
 		'layer'       => MemoryFileRegistry::LAYER_AGENT,
 		'protected'   => true,
-		'modes'       => array( 'chat', 'pipeline' ),
+		'modes'       => array( 'chat', 'pipeline', 'interactive' ),
 		'label'       => 'Agent Memory',
 		'description' => 'Accumulated knowledge. Injected in interactive modes only.',
 	) );

--- a/tests/Unit/AI/Memory/MemoryPolicyResolverTest.php
+++ b/tests/Unit/AI/Memory/MemoryPolicyResolverTest.php
@@ -8,6 +8,7 @@
 namespace DataMachine\Tests\Unit\AI\Memory;
 
 use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Engine\AI\AgentModeRegistry;
 use DataMachine\Engine\AI\Memory\MemoryPolicyResolver;
 use DataMachine\Engine\AI\MemoryFileRegistry;
 use WP_UnitTestCase;
@@ -28,6 +29,28 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 		// Reset the memory file registry before each test so we control
 		// exactly which files are registered.
 		MemoryFileRegistry::reset();
+		AgentModeRegistry::reset();
+		AgentModeRegistry::register(
+			MemoryPolicyResolver::MODE_CHAT,
+			10,
+			array(
+				'memory_contexts' => array( 'agent_identity', 'agent_memory', 'user_profile' ),
+			)
+		);
+		AgentModeRegistry::register(
+			MemoryPolicyResolver::MODE_PIPELINE,
+			20,
+			array(
+				'memory_contexts' => array( 'agent_identity', 'agent_memory' ),
+			)
+		);
+		AgentModeRegistry::register(
+			'intelligence',
+			30,
+			array(
+				'memory_contexts' => array( 'agent_identity', 'agent_memory' ),
+			)
+		);
 
 		// Seed a small, known set of registered files so assertions are
 		// stable across test runs. The real core registrations happen in
@@ -36,24 +59,24 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 			'SOUL.md',
 			10,
 			array(
-				'layer' => MemoryFileRegistry::LAYER_AGENT,
-				'modes' => array( 'all' ),
+				'layer'              => MemoryFileRegistry::LAYER_AGENT,
+				'injection_contexts' => array( 'agent_identity' ),
 			)
 		);
 		MemoryFileRegistry::register(
 			'MEMORY.md',
 			20,
 			array(
-				'layer' => MemoryFileRegistry::LAYER_AGENT,
-				'modes' => array( 'all' ),
+				'layer'              => MemoryFileRegistry::LAYER_AGENT,
+				'injection_contexts' => array( 'agent_memory' ),
 			)
 		);
 		MemoryFileRegistry::register(
 			'USER.md',
 			30,
 			array(
-				'layer' => MemoryFileRegistry::LAYER_USER,
-				'modes' => array( 'chat', 'pipeline' ),
+				'layer'              => MemoryFileRegistry::LAYER_USER,
+				'injection_contexts' => array( 'user_profile' ),
 			)
 		);
 		MemoryFileRegistry::register(
@@ -77,6 +100,7 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 
 	public function tear_down(): void {
 		MemoryFileRegistry::reset();
+		AgentModeRegistry::reset();
 		remove_all_filters( 'datamachine_resolved_memory_files' );
 		remove_all_filters( 'datamachine_resolved_scoped_memory_files' );
 		parent::tear_down();
@@ -109,9 +133,36 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'SOUL.md', $files );
 		$this->assertArrayHasKey( 'MEMORY.md', $files );
-		$this->assertArrayHasKey( 'USER.md', $files );
+		$this->assertArrayNotHasKey( 'USER.md', $files );
 		$this->assertArrayNotHasKey( 'CHAT_ONLY.md', $files );
 		$this->assertArrayNotHasKey( 'EXTERNAL_RUNTIME.md', $files );
+	}
+
+	public function test_registered_custom_mode_uses_declared_memory_contexts(): void {
+		$files = $this->resolver->resolveRegistered(
+			array(
+				'mode' => 'intelligence',
+			)
+		);
+
+		$this->assertArrayHasKey( 'SOUL.md', $files );
+		$this->assertArrayHasKey( 'MEMORY.md', $files );
+		$this->assertArrayNotHasKey( 'USER.md', $files );
+		$this->assertArrayNotHasKey( 'CHAT_ONLY.md', $files );
+	}
+
+	public function test_registered_custom_mode_without_memory_contexts_does_not_guess(): void {
+		AgentModeRegistry::register( 'retrieval_only', 40, array() );
+
+		$files = $this->resolver->resolveRegistered(
+			array(
+				'mode' => 'retrieval_only',
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'SOUL.md', $files );
+		$this->assertArrayNotHasKey( 'MEMORY.md', $files );
+		$this->assertArrayNotHasKey( 'USER.md', $files );
 	}
 
 	public function test_registered_file_without_modes_is_not_injected_in_any_mode(): void {

--- a/tests/Unit/Engine/AI/MemoryFileRegistryTest.php
+++ b/tests/Unit/Engine/AI/MemoryFileRegistryTest.php
@@ -140,4 +140,23 @@ class MemoryFileRegistryTest extends TestCase {
 		// never appear in mode-filtered injection lists.
 		$this->assertArrayNotHasKey( 'NO_MODES.md', $chat_files );
 	}
+
+	/**
+	 * Semantic injection contexts are independent of execution mode slugs.
+	 */
+	public function test_get_for_modes_filters_by_injection_contexts(): void {
+		MemoryFileRegistry::register( 'SOUL.md', 10, array(
+			'layer'              => MemoryFileRegistry::LAYER_AGENT,
+			'injection_contexts' => array( MemoryFileRegistry::INJECTION_AGENT_IDENTITY ),
+		) );
+		MemoryFileRegistry::register( 'CHAT_ONLY.md', 20, array(
+			'layer' => MemoryFileRegistry::LAYER_AGENT,
+			'modes' => array( 'chat' ),
+		) );
+
+		$files = MemoryFileRegistry::get_for_modes( array( 'intelligence' ), array( MemoryFileRegistry::INJECTION_AGENT_IDENTITY ) );
+
+		$this->assertArrayHasKey( 'SOUL.md', $files );
+		$this->assertArrayNotHasKey( 'CHAT_ONLY.md', $files );
+	}
 }

--- a/tests/core-memory-composable-first-read-smoke.php
+++ b/tests/core-memory-composable-first-read-smoke.php
@@ -185,7 +185,23 @@ namespace {
 
 	$custom_context = end( $GLOBALS['__core_memory_composable_resolver_contexts'] );
 	core_memory_composable_assert( in_array( 'intelligence', $custom_context['modes'] ?? array(), true ), 'custom mode is preserved for memory resolution' );
-	core_memory_composable_assert( in_array( 'chat', $custom_context['modes'] ?? array(), true ), 'session-backed custom mode also resolves chat memory files' );
+	core_memory_composable_assert( ! in_array( 'chat', $custom_context['modes'] ?? array(), true ), 'custom mode does not masquerade as chat' );
+	core_memory_composable_assert( in_array( 'interactive', $custom_context['modes'] ?? array(), true ), 'session-backed custom mode resolves interactive memory files' );
+
+	\DataMachine\Engine\AI\Directives\CoreMemoryFilesDirective::get_outputs(
+		'openai',
+		array(),
+		null,
+		array(
+			'agent_modes' => array( 'pipeline' ),
+			'user_id'     => 123,
+			'agent_id'    => 456,
+		)
+	);
+
+	$pipeline_context = end( $GLOBALS['__core_memory_composable_resolver_contexts'] );
+	core_memory_composable_assert( in_array( 'pipeline', $pipeline_context['modes'] ?? array(), true ), 'pipeline mode is preserved for memory resolution' );
+	core_memory_composable_assert( in_array( 'interactive', $pipeline_context['modes'] ?? array(), true ), 'pipeline mode resolves interactive memory files' );
 
 	\DataMachine\Engine\AI\Directives\CoreMemoryFilesDirective::get_outputs(
 		'openai',
@@ -200,7 +216,7 @@ namespace {
 	);
 
 	$system_context = end( $GLOBALS['__core_memory_composable_resolver_contexts'] );
-	core_memory_composable_assert( ! in_array( 'chat', $system_context['modes'] ?? array(), true ), 'system mode does not inherit chat memory files' );
+	core_memory_composable_assert( ! in_array( 'interactive', $system_context['modes'] ?? array(), true ), 'system mode does not inherit interactive memory files' );
 
 	echo "\n{$assertions} assertions, {$failures} failures\n";
 	if ( $failures > 0 ) {

--- a/tests/core-memory-composable-first-read-smoke.php
+++ b/tests/core-memory-composable-first-read-smoke.php
@@ -186,22 +186,6 @@ namespace {
 	$custom_context = end( $GLOBALS['__core_memory_composable_resolver_contexts'] );
 	core_memory_composable_assert( in_array( 'intelligence', $custom_context['modes'] ?? array(), true ), 'custom mode is preserved for memory resolution' );
 	core_memory_composable_assert( ! in_array( 'chat', $custom_context['modes'] ?? array(), true ), 'custom mode does not masquerade as chat' );
-	core_memory_composable_assert( in_array( 'interactive', $custom_context['modes'] ?? array(), true ), 'session-backed custom mode resolves interactive memory files' );
-
-	\DataMachine\Engine\AI\Directives\CoreMemoryFilesDirective::get_outputs(
-		'openai',
-		array(),
-		null,
-		array(
-			'agent_modes' => array( 'pipeline' ),
-			'user_id'     => 123,
-			'agent_id'    => 456,
-		)
-	);
-
-	$pipeline_context = end( $GLOBALS['__core_memory_composable_resolver_contexts'] );
-	core_memory_composable_assert( in_array( 'pipeline', $pipeline_context['modes'] ?? array(), true ), 'pipeline mode is preserved for memory resolution' );
-	core_memory_composable_assert( in_array( 'interactive', $pipeline_context['modes'] ?? array(), true ), 'pipeline mode resolves interactive memory files' );
 
 	\DataMachine\Engine\AI\Directives\CoreMemoryFilesDirective::get_outputs(
 		'openai',
@@ -216,7 +200,7 @@ namespace {
 	);
 
 	$system_context = end( $GLOBALS['__core_memory_composable_resolver_contexts'] );
-	core_memory_composable_assert( ! in_array( 'interactive', $system_context['modes'] ?? array(), true ), 'system mode does not inherit interactive memory files' );
+	core_memory_composable_assert( ! in_array( 'chat', $system_context['modes'] ?? array(), true ), 'system mode does not inherit chat memory files' );
 
 	echo "\n{$assertions} assertions, {$failures} failures\n";
 	if ( $failures > 0 ) {

--- a/tests/core-memory-composable-first-read-smoke.php
+++ b/tests/core-memory-composable-first-read-smoke.php
@@ -76,6 +76,7 @@ namespace DataMachine\Abilities\File {
 namespace DataMachine\Engine\AI\Memory {
 	class MemoryPolicyResolver {
 		public function resolveRegistered( array $context ): array {
+			$GLOBALS['__core_memory_composable_resolver_contexts'][] = $context;
 			return $GLOBALS['__core_memory_composable_registry'];
 		}
 	}
@@ -140,9 +141,10 @@ namespace {
 		++$failures;
 	}
 
-	$GLOBALS['__core_memory_composable_files']       = array();
-	$GLOBALS['__core_memory_composable_regenerated'] = array();
-	$GLOBALS['__core_memory_composable_registry']    = array(
+	$GLOBALS['__core_memory_composable_files']             = array();
+	$GLOBALS['__core_memory_composable_regenerated']       = array();
+	$GLOBALS['__core_memory_composable_resolver_contexts'] = array();
+	$GLOBALS['__core_memory_composable_registry']          = array(
 		'SITE.md' => array(
 			'layer'      => 'shared',
 			'priority'   => 10,
@@ -168,6 +170,37 @@ namespace {
 		array( 'user_id' => 123, 'agent_id' => 456 ) === $GLOBALS['__core_memory_composable_regenerated'][0]['context'],
 		'regeneration receives prompt scope'
 	);
+
+	\DataMachine\Engine\AI\Directives\CoreMemoryFilesDirective::get_outputs(
+		'openai',
+		array(),
+		null,
+		array(
+			'agent_modes' => array( 'intelligence' ),
+			'session_id'  => 'session-1',
+			'user_id'     => 123,
+			'agent_id'    => 456,
+		)
+	);
+
+	$custom_context = end( $GLOBALS['__core_memory_composable_resolver_contexts'] );
+	core_memory_composable_assert( in_array( 'intelligence', $custom_context['modes'] ?? array(), true ), 'custom mode is preserved for memory resolution' );
+	core_memory_composable_assert( in_array( 'chat', $custom_context['modes'] ?? array(), true ), 'session-backed custom mode also resolves chat memory files' );
+
+	\DataMachine\Engine\AI\Directives\CoreMemoryFilesDirective::get_outputs(
+		'openai',
+		array(),
+		null,
+		array(
+			'agent_modes' => array( 'system' ),
+			'session_id'  => 'session-2',
+			'user_id'     => 123,
+			'agent_id'    => 456,
+		)
+	);
+
+	$system_context = end( $GLOBALS['__core_memory_composable_resolver_contexts'] );
+	core_memory_composable_assert( ! in_array( 'chat', $system_context['modes'] ?? array(), true ), 'system mode does not inherit chat memory files' );
 
 	echo "\n{$assertions} assertions, {$failures} failures\n";
 	if ( $failures > 0 ) {


### PR DESCRIPTION
## Summary
- Decouple core memory injection from execution mode slugs.
- Let execution modes declare semantic `memory_contexts`, and let memory files declare matching `injection_contexts`.
- Register built-in `chat` and `pipeline` modes with the core contexts they activate.
- Move `SOUL.md`, `MEMORY.md`, and `USER.md` onto semantic injection contexts instead of hard-coded mode lists.
- Preserve `system` behavior by giving it no agent identity or memory contexts.
- Add regression coverage for custom modes with declared memory contexts and for custom modes that do not opt in.

Fixes #2100

## Testing
- `php -l inc/Engine/AI/AgentModeRegistry.php`
- `php -l inc/Engine/AI/MemoryFileRegistry.php`
- `php -l inc/Engine/AI/Memory/MemoryPolicyResolver.php`
- `php -l inc/Engine/AI/Directives/CoreMemoryFilesDirective.php`
- `php -l inc/bootstrap.php`
- `php -l tests/Unit/AI/Memory/MemoryPolicyResolverTest.php`
- `php -l tests/Unit/Engine/AI/MemoryFileRegistryTest.php`
- `php -l tests/core-memory-composable-first-read-smoke.php`
- `php tests/core-memory-composable-first-read-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-custom-mode-memory-injection --changed-since main`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-custom-mode-memory-injection --changed-since main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the memory-context refactor, regression coverage, and local verification commands for Chris to review.