### PR TITLE
Reject legacy handler flow fields

### DIFF
--- a/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
+++ b/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
@@ -44,15 +44,15 @@ class ExecuteWorkflowTool extends BaseTool {
 
 		$description = 'Execute an ephemeral workflow (not saved to database).
 
-STEP FORMAT: {type: "' . $types_list . '", handler_slug, handler_config, user_message?, system_prompt?, agent_modes?}
+STEP FORMAT: {type: "' . $types_list . '", handler_slugs?, handler_configs?, flow_step_settings?, user_message?, system_prompt?, agent_modes?}
 
-Use api_query GET /datamachine/v1/handlers/{slug} for handler_config fields.
+Use api_query GET /datamachine/v1/handlers/{slug} for handler_configs fields.
 
 EXAMPLE:
 [
-  {"type": "fetch", "handler_slug": "rss", "handler_config": {"feed_url": "..."}},
+  {"type": "fetch", "handler_slugs": ["rss"], "handler_configs": {"rss": {"feed_url": "..."}}},
   {"type": "ai", "user_message": "Summarize for social media"},
-  {"type": "publish", "handler_slug": "wordpress_publish", "handler_config": {"post_type": "post"}}
+  {"type": "publish", "handler_slugs": ["wordpress_publish"], "handler_configs": {"wordpress_publish": {"post_type": "post"}}}
 ]';
 
 		return array(
@@ -65,7 +65,7 @@ EXAMPLE:
 					'steps'   => array(
 						'type'        => 'array',
 						'items'       => array( 'type' => 'object' ),
-						'description' => 'Step objects: {type, handler_slug, handler_config}. AI steps: {type: "ai", user_message}.',
+						'description' => 'Step objects: {type, handler_slugs, handler_configs}. AI steps: {type: "ai", user_message}.',
 					),
 					'dry_run' => array(
 						'type'        => 'boolean',

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -372,7 +372,7 @@ class AgentBundler {
 				$document_step['step_type'] = $pipeline_step_types_by_id[ $pipeline_step_id ];
 			}
 
-			foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'completion_assertions', 'tool_runtime_rules', 'enabled' ) as $field ) {
+			foreach ( array( 'step_type', 'handler_slugs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'completion_assertions', 'tool_runtime_rules', 'enabled' ) as $field ) {
 				if ( array_key_exists( $field, $step ) ) {
 					$document_step[ $field ] = $step[ $field ];
 				}
@@ -394,13 +394,11 @@ class AgentBundler {
 			return array();
 		}
 
-		if ( is_array( $step['handler_configs'] ?? null ) ) {
-			$configs = $step['handler_configs'];
-		} elseif ( is_string( $step['handler_slug'] ?? null ) && is_array( $step['handler_config'] ?? null ) ) {
-			$configs = array( $step['handler_slug'] => $step['handler_config'] );
-		} else {
+		if ( ! is_array( $step['handler_configs'] ?? null ) ) {
 			return array();
 		}
+
+		$configs = $step['handler_configs'];
 
 		if ( 'refs' !== $handler_auth ) {
 			return $configs;

--- a/inc/Core/Steps/FlowStepConfigFactory.php
+++ b/inc/Core/Steps/FlowStepConfigFactory.php
@@ -43,8 +43,6 @@ class FlowStepConfigFactory {
 					'disabled_tools'     => $step['disabled_tools'] ?? array(),
 					'pipeline_id'        => 'direct',
 					'flow_id'            => 'direct',
-					'handler_slug'       => $step['handler_slug'] ?? '',
-					'handler_config'     => $step['handler_config'] ?? array(),
 					'handler_slugs'      => $step['handler_slugs'] ?? array(),
 					'handler_configs'    => $step['handler_configs'] ?? array(),
 					'flow_step_settings' => $step['flow_step_settings'] ?? array(),
@@ -124,7 +122,6 @@ class FlowStepConfigFactory {
 			'queue_mode'                          => true,
 			'pipeline_id'                         => true,
 			'flow_id'                             => true,
-			'handler'                             => true,
 		);
 
 		foreach ( $args as $field => $value ) {
@@ -133,18 +130,9 @@ class FlowStepConfigFactory {
 			}
 		}
 
-		$handler_slug       = is_string( $args['handler_slug'] ?? null ) ? (string) $args['handler_slug'] : '';
-		$handler_config     = is_array( $args['handler_config'] ?? null ) ? $args['handler_config'] : array();
 		$flow_step_settings = is_array( $args['flow_step_settings'] ?? null ) ? $args['flow_step_settings'] : array();
 		$handler_slugs      = is_array( $args['handler_slugs'] ?? null ) ? $args['handler_slugs'] : array();
 		$handler_configs    = is_array( $args['handler_configs'] ?? null ) ? $args['handler_configs'] : array();
-
-		if ( '' !== $handler_slug ) {
-			$handler_slugs[] = $handler_slug;
-			if ( ! array_key_exists( $handler_slug, $handler_configs ) ) {
-				$handler_configs[ $handler_slug ] = $handler_config;
-			}
-		}
 
 		if ( FlowStepConfig::usesHandler( $step_config ) ) {
 			$step_config = FlowStepConfig::normalizeHandlerShape(

--- a/inc/Core/Steps/Step.php
+++ b/inc/Core/Steps/Step.php
@@ -115,7 +115,7 @@ abstract class Step {
 
 	/**
 	 * Validate step-specific configuration requirements.
-	 * Default implementation checks for handler_slug. Override for custom validation.
+	 * Default implementation checks for a configured handler slug. Override for custom validation.
 	 *
 	 * @return bool True if configuration is valid, false otherwise
 	 */
@@ -215,8 +215,8 @@ abstract class Step {
 	/**
 	 * Get the primary handler slug from flow step configuration.
 	 *
-	 * Reads the canonical scalar `handler_slug` field. Multi-handler steps
-	 * should call getHandlerSlugs(); handler-free steps return null.
+	 * Reads the first canonical `handler_slugs` entry. Multi-handler steps should
+	 * call getHandlerSlugs(); handler-free steps return null.
 	 *
 	 * @return string|null Handler slug or null if not set
 	 */
@@ -227,9 +227,8 @@ abstract class Step {
 	/**
 	 * Get the primary handler configuration from flow step configuration.
 	 *
-	 * Reads the canonical config slot: `handler_config` for handler-free and
-	 * single-handler steps, or `handler_configs[primary_slug]` for true
-	 * multi-handler steps.
+	 * Reads the canonical config slot: `flow_step_settings` for handler-free
+	 * steps, or `handler_configs[primary_slug]` for handler-backed steps.
 	 *
 	 * @return array Handler configuration array
 	 */

--- a/inc/Core/Steps/WorkflowSpecValidator.php
+++ b/inc/Core/Steps/WorkflowSpecValidator.php
@@ -58,6 +58,15 @@ class WorkflowSpecValidator {
 				);
 			}
 
+			foreach ( array( 'handler', 'handler_slug', 'handler_config' ) as $legacy_field ) {
+				if ( array_key_exists( $legacy_field, $step ) ) {
+					return array(
+						'valid' => false,
+						'error' => "Step {$index} uses unsupported legacy field {$legacy_field}; use handler_slugs and handler_configs",
+					);
+				}
+			}
+
 			$step_type = $step['type'] ?? null;
 			if ( ! is_string( $step_type ) || '' === trim( $step_type ) ) {
 				return array(

--- a/inc/Engine/Bundle/AgentBundleArtifactRebase.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactRebase.php
@@ -288,13 +288,15 @@ final class AgentBundleArtifactRebase {
 				}
 
 				if ( 1 === count( $local_hcs ) && 1 === count( $remote_hcs ) ) {
-					$local_slug    = (string) array_key_first( $local_hcs );
-					$remote_slug   = (string) array_key_first( $remote_hcs );
-					$local_config  = is_array( $local_hcs[ $local_slug ] ?? null ) ? $local_hcs[ $local_slug ] : array();
-					$base_config   = is_array( $base_hcs[ $local_slug ] ?? null ) ? $base_hcs[ $local_slug ] : array();
+					$local_slug     = (string) array_key_first( $local_hcs );
+					$remote_slug    = (string) array_key_first( $remote_hcs );
+					$local_config   = is_array( $local_hcs[ $local_slug ] ?? null ) ? $local_hcs[ $local_slug ] : array();
+					$base_config    = is_array( $base_hcs[ $local_slug ] ?? null ) ? $base_hcs[ $local_slug ] : array();
 					$local_throttle = self::local_preserved_max_items( $base_config, $local_config );
+
 					if ( null !== $local_throttle && is_array( $merged_hcs[ $remote_slug ] ?? null ) ) {
 						$merged_hcs[ $remote_slug ]['max_items'] = $local_throttle;
+
 						$decisions[ "flow_config.{$step_id}.handler_configs.{$remote_slug}.max_items" ] = array(
 							'source' => 'local',
 							'reason' => 'burn_in_preserve_throttle_across_handler_slug_change',

--- a/inc/Engine/Bundle/AgentBundleArtifactRebase.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactRebase.php
@@ -177,14 +177,13 @@ final class AgentBundleArtifactRebase {
 	 *   - flow_config.*.config_patch_queue
 	 *   - flow_config.*.queue_mode
 	 *   - flow_config.*._queue_consume_revision
-	 *   - flow_config.*.handler_config.max_items (and handler_configs.*.max_items)
+	 *   - flow_config.*.handler_configs.*.max_items
 	 *     when local diverged from base only on the throttle.
 	 *   - scheduling_config (whole subtree, including max_items)
 	 *
 	 * Takes remote source-shape changes when remote diverged from base on
 	 * provider-routing fields:
-	 *   - flow_config.*.handler
-	 *   - flow_config.*.handler_config.* and handler_configs.*.* except local-preserved keys
+	 *   - flow_config.*.handler_configs.*.* except local-preserved keys
 	 *     (server, provider, tool, params, query, owner, repo, channel, perPage, source-shape)
 	 *
 	 * Non-flow artifacts are forwarded to conservative policy.
@@ -266,24 +265,7 @@ final class AgentBundleArtifactRebase {
 				}
 			}
 
-			// Merge handler_config keys (single-handler shape).
-			$base_hc   = is_array( $base_step['handler_config'] ?? null ) ? $base_step['handler_config'] : array();
-			$local_hc  = is_array( $local_step['handler_config'] ?? null ) ? $local_step['handler_config'] : array();
-			$remote_hc = is_array( $remote_step['handler_config'] ?? null ) ? $remote_step['handler_config'] : array();
-
-			if ( ! empty( $local_hc ) || ! empty( $remote_hc ) ) {
-				$merged_hc                     = self::merge_handler_config(
-					$base_hc,
-					$local_hc,
-					$remote_hc,
-					"flow_config.{$step_id}.handler_config",
-					$decisions,
-					$ambiguous
-				);
-				$merged_step['handler_config'] = $merged_hc;
-			}
-
-			// Merge handler_configs (multi-handler shape: keyed by handler slug).
+			// Merge handler_configs (keyed by handler slug).
 			$base_hcs   = is_array( $base_step['handler_configs'] ?? null ) ? $base_step['handler_configs'] : array();
 			$local_hcs  = is_array( $local_step['handler_configs'] ?? null ) ? $local_step['handler_configs'] : array();
 			$remote_hcs = is_array( $remote_step['handler_configs'] ?? null ) ? $remote_step['handler_configs'] : array();
@@ -304,18 +286,24 @@ final class AgentBundleArtifactRebase {
 						$ambiguous
 					);
 				}
+
+				if ( 1 === count( $local_hcs ) && 1 === count( $remote_hcs ) ) {
+					$local_slug    = (string) array_key_first( $local_hcs );
+					$remote_slug   = (string) array_key_first( $remote_hcs );
+					$local_config  = is_array( $local_hcs[ $local_slug ] ?? null ) ? $local_hcs[ $local_slug ] : array();
+					$base_config   = is_array( $base_hcs[ $local_slug ] ?? null ) ? $base_hcs[ $local_slug ] : array();
+					$local_throttle = self::local_preserved_max_items( $base_config, $local_config );
+					if ( null !== $local_throttle && is_array( $merged_hcs[ $remote_slug ] ?? null ) ) {
+						$merged_hcs[ $remote_slug ]['max_items'] = $local_throttle;
+						$decisions[ "flow_config.{$step_id}.handler_configs.{$remote_slug}.max_items" ] = array(
+							'source' => 'local',
+							'reason' => 'burn_in_preserve_throttle_across_handler_slug_change',
+						);
+					}
+				}
+
 				$merged_step['handler_configs'] = $merged_hcs;
 			}
-
-			self::mirror_preserved_handler_throttle(
-				$base_hc,
-				$local_hc,
-				$base_hcs,
-				$local_hcs,
-				$step_id,
-				$merged_step,
-				$decisions
-			);
 
 			$merged_steps[ $step_id ] = $merged_step;
 		}
@@ -404,68 +392,6 @@ final class AgentBundleArtifactRebase {
 			'decisions' => $decisions,
 			'ambiguous' => $ambiguous,
 		);
-	}
-
-	/**
-	 * Keep local burn-in max_items consistent across legacy and canonical shapes.
-	 *
-	 * Flow payloads may carry both `handler_config` and `handler_configs` while
-	 * installs migrate between old and new representations. The two shapes are
-	 * equivalent runtime inputs, so a locally lowered throttle must not be
-	 * preserved in only one of them.
-	 *
-	 * @param array<string,mixed>                $base_hc Single-handler base config.
-	 * @param array<string,mixed>                $local_hc Single-handler local config.
-	 * @param array<string,mixed>                $base_hcs Multi-handler base config.
-	 * @param array<string,mixed>                $local_hcs Multi-handler local config.
-	 * @param string|int                         $step_id Flow step ID.
-	 * @param array<string,mixed>                $merged_step In/out merged step.
-	 * @param array<string,array<string,string>> $decisions In/out decisions map.
-	 */
-	private static function mirror_preserved_handler_throttle(
-		array $base_hc,
-		array $local_hc,
-		array $base_hcs,
-		array $local_hcs,
-		string|int $step_id,
-		array &$merged_step,
-		array &$decisions
-	): void {
-		$single_throttle = self::local_preserved_max_items( $base_hc, $local_hc );
-		if ( null !== $single_throttle && is_array( $merged_step['handler_configs'] ?? null ) ) {
-			foreach ( $merged_step['handler_configs'] as $slug => &$handler_config ) {
-				if ( ! is_array( $handler_config ) ) {
-					continue;
-				}
-				$handler_config['max_items'] = $single_throttle;
-				$decisions[ "flow_config.{$step_id}.handler_configs.{$slug}.max_items" ] = array(
-					'source' => 'local',
-					'reason' => 'burn_in_preserve_throttle_shape_mirror',
-				);
-			}
-			unset( $handler_config );
-		}
-
-		if ( ! is_array( $merged_step['handler_config'] ?? null ) ) {
-			return;
-		}
-
-		foreach ( $local_hcs as $slug => $local_config ) {
-			if ( ! is_array( $local_config ) ) {
-				continue;
-			}
-			$base_config = is_array( $base_hcs[ $slug ] ?? null ) ? $base_hcs[ $slug ] : array();
-			$max_items   = self::local_preserved_max_items( $base_config, $local_config );
-			if ( null === $max_items ) {
-				continue;
-			}
-			$merged_step['handler_config']['max_items']                     = $max_items;
-			$decisions[ "flow_config.{$step_id}.handler_config.max_items" ] = array(
-				'source' => 'local',
-				'reason' => 'burn_in_preserve_throttle_shape_mirror',
-			);
-			return;
-		}
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentBundleFlowFile.php
+++ b/inc/Engine/Bundle/AgentBundleFlowFile.php
@@ -98,6 +98,11 @@ final class AgentBundleFlowFile {
 			if ( ! is_array( $step ) ) {
 				throw new BundleValidationException( 'flow file steps must contain objects.' );
 			}
+			foreach ( array( 'handler', 'handler_slug', 'handler_config' ) as $legacy_field ) {
+				if ( array_key_exists( $legacy_field, $step ) ) {
+					throw new BundleValidationException( sprintf( 'flow file step uses unsupported legacy field %s; use handler_slugs and handler_configs.', esc_html( $legacy_field ) ) );
+				}
+			}
 			foreach ( array( 'step_position', 'handler_configs' ) as $field ) {
 				if ( ! array_key_exists( $field, $step ) ) {
 					throw new BundleValidationException( sprintf( 'flow file step is missing required field %s.', esc_html( $field ) ) );

--- a/tests/agent-bundle-artifact-rebase-smoke.php
+++ b/tests/agent-bundle-artifact-rebase-smoke.php
@@ -151,13 +151,15 @@ echo "\n[3] burn-in-safe preserves throttles, takes remote provider/owner/repo\n
 $base_flow = array(
 	'flow_config' => array(
 		'10_fetch_1' => array(
-			'handler'        => 'github',
-			'handler_config' => array(
-				'server'    => 'github',
-				'owner'     => 'old-owner',
-				'repo'      => 'old-repo',
-				'perPage'   => 25,
-				'max_items' => 25,
+			'handler_slugs'   => array( 'github' ),
+			'handler_configs' => array(
+				'github' => array(
+					'server'    => 'github',
+					'owner'     => 'old-owner',
+					'repo'      => 'old-repo',
+					'perPage'   => 25,
+					'max_items' => 25,
+				),
 			),
 			'queue_mode'         => 'idle',
 			'config_patch_queue' => array(),
@@ -173,13 +175,15 @@ $base_flow = array(
 $local_flow = array(
 	'flow_config' => array(
 		'10_fetch_1' => array(
-			'handler'        => 'github',
-			'handler_config' => array(
-				'server'    => 'github',
-				'owner'     => 'old-owner',
-				'repo'      => 'old-repo',
-				'perPage'   => 25,
-				'max_items' => 1, // local burn-in throttle
+			'handler_slugs'   => array( 'github' ),
+			'handler_configs' => array(
+				'github' => array(
+					'server'    => 'github',
+					'owner'     => 'old-owner',
+					'repo'      => 'old-repo',
+					'perPage'   => 25,
+					'max_items' => 1, // local burn-in throttle
+				),
 			),
 			'queue_mode'         => 'drain', // runtime queue change
 			'config_patch_queue' => array( array( 'patch' => array( 'state' => 'live' ) ) ),
@@ -195,13 +199,15 @@ $local_flow = array(
 $remote_flow = array(
 	'flow_config' => array(
 		'10_fetch_1' => array(
-			'handler'        => 'github-a8c', // upstream provider switch
-			'handler_config' => array(
-				'server'    => 'github-a8c',
-				'owner'     => 'Automattic',
-				'repo'      => 'wpcom',
-				'perPage'   => 1,
-				'max_items' => 25, // bundle-default upper bound
+			'handler_slugs'   => array( 'github-a8c' ), // upstream provider switch
+			'handler_configs' => array(
+				'github-a8c' => array(
+					'server'    => 'github-a8c',
+					'owner'     => 'Automattic',
+					'repo'      => 'wpcom',
+					'perPage'   => 1,
+					'max_items' => 25, // bundle-default upper bound
+				),
 			),
 			'queue_mode'         => 'idle',
 			'config_patch_queue' => array(),
@@ -226,13 +232,14 @@ $result = AgentBundleArtifactRebase::rebase(
 );
 
 $step = $result['merged']['flow_config']['10_fetch_1'] ?? array();
+$github_config = $step['handler_configs']['github-a8c'] ?? array();
 
-rebase_assert_equals( 'remote source-shape: handler', 'github-a8c', $step['handler'] ?? null );
-rebase_assert_equals( 'remote source-shape: server', 'github-a8c', $step['handler_config']['server'] ?? null );
-rebase_assert_equals( 'remote source-shape: owner', 'Automattic', $step['handler_config']['owner'] ?? null );
-rebase_assert_equals( 'remote source-shape: repo', 'wpcom', $step['handler_config']['repo'] ?? null );
-rebase_assert_equals( 'remote source-shape: perPage', 1, $step['handler_config']['perPage'] ?? null );
-rebase_assert_equals( 'local throttle preserved: max_items', 1, $step['handler_config']['max_items'] ?? null );
+rebase_assert_equals( 'remote source-shape: handler slugs', array( 'github-a8c' ), $step['handler_slugs'] ?? null );
+rebase_assert_equals( 'remote source-shape: server', 'github-a8c', $github_config['server'] ?? null );
+rebase_assert_equals( 'remote source-shape: owner', 'Automattic', $github_config['owner'] ?? null );
+rebase_assert_equals( 'remote source-shape: repo', 'wpcom', $github_config['repo'] ?? null );
+rebase_assert_equals( 'remote source-shape: perPage', 1, $github_config['perPage'] ?? null );
+rebase_assert_equals( 'local throttle preserved: max_items', 1, $github_config['max_items'] ?? null );
 rebase_assert_equals( 'local runtime queue preserved: queue_mode', 'drain', $step['queue_mode'] ?? null );
 rebase_assert_equals( 'local runtime queue preserved: config_patch_queue length', 1, count( $step['config_patch_queue'] ?? array() ) );
 rebase_assert_equals(
@@ -248,12 +255,12 @@ rebase_assert( 'rebase does not require approval in canonical case', false === $
 rebase_assert_equals(
 	'decision recorded for max_items local preservation',
 	'local',
-	$result['decisions']['flow_config.10_fetch_1.handler_config.max_items']['source'] ?? null
+	$result['decisions']['flow_config.10_fetch_1.handler_configs.github-a8c.max_items']['source'] ?? null
 );
 rebase_assert_equals(
 	'decision recorded for owner remote source-shape',
 	'remote',
-	$result['decisions']['flow_config.10_fetch_1.handler_config.owner']['source'] ?? null
+	$result['decisions']['flow_config.10_fetch_1.handler_configs.github-a8c.owner']['source'] ?? null
 );
 
 // ---------------------------------------------------------------------------
@@ -267,9 +274,11 @@ $ambiguous_result = AgentBundleArtifactRebase::rebase(
 		'base'          => array(
 			'flow_config' => array(
 				'1_step_1' => array(
-					'handler_config' => array(
-						'tool'      => 'old-tool',
-						'max_items' => 10,
+					'handler_configs' => array(
+						'mcp' => array(
+							'tool'      => 'old-tool',
+							'max_items' => 10,
+						),
 					),
 				),
 			),
@@ -277,9 +286,11 @@ $ambiguous_result = AgentBundleArtifactRebase::rebase(
 		'local' => array(
 			'flow_config' => array(
 				'1_step_1' => array(
-					'handler_config' => array(
-						'tool'      => 'local-tool', // local changed source-shape
-						'max_items' => 1,            // local lowered throttle
+					'handler_configs' => array(
+						'mcp' => array(
+							'tool'      => 'local-tool', // local changed source-shape
+							'max_items' => 1,            // local lowered throttle
+						),
 					),
 				),
 			),
@@ -287,9 +298,11 @@ $ambiguous_result = AgentBundleArtifactRebase::rebase(
 		'remote' => array(
 			'flow_config' => array(
 				'1_step_1' => array(
-					'handler_config' => array(
-						'tool'      => 'remote-tool', // remote also changed source-shape
-						'max_items' => 25,            // remote raised throttle
+					'handler_configs' => array(
+						'mcp' => array(
+							'tool'      => 'remote-tool', // remote also changed source-shape
+							'max_items' => 25,            // remote raised throttle
+						),
 					),
 				),
 			),
@@ -301,13 +314,13 @@ $ambiguous_result = AgentBundleArtifactRebase::rebase(
 rebase_assert( 'ambiguous overlap requires approval', true === $ambiguous_result['requires_approval'] );
 rebase_assert(
 	'tool flagged ambiguous when both diverged from base',
-	in_array( 'flow_config.1_step_1.handler_config.tool', $ambiguous_result['ambiguous'], true )
+	in_array( 'flow_config.1_step_1.handler_configs.mcp.tool', $ambiguous_result['ambiguous'], true )
 );
 rebase_assert(
 	'max_items flagged ambiguous when both throttles diverged',
-	in_array( 'flow_config.1_step_1.handler_config.max_items', $ambiguous_result['ambiguous'], true )
+	in_array( 'flow_config.1_step_1.handler_configs.mcp.max_items', $ambiguous_result['ambiguous'], true )
 );
-$step_ambiguous = $ambiguous_result['merged']['flow_config']['1_step_1']['handler_config'] ?? array();
+$step_ambiguous = $ambiguous_result['merged']['flow_config']['1_step_1']['handler_configs']['mcp'] ?? array();
 rebase_assert_equals( 'ambiguous merge defaults to local tool (safer)', 'local-tool', $step_ambiguous['tool'] ?? null );
 rebase_assert_equals( 'ambiguous merge defaults to local throttle', 1, $step_ambiguous['max_items'] ?? null );
 
@@ -360,62 +373,9 @@ rebase_assert_equals( 'multi: rss feed from remote (local unchanged)', 'https://
 rebase_assert( 'multi: no ambiguous fields', empty( $multi_result['ambiguous'] ) );
 
 // ---------------------------------------------------------------------------
-// [6] Equivalent legacy/canonical handler config shapes keep throttle in sync.
+// [6] Hashes are recomputed for the merged payload.
 // ---------------------------------------------------------------------------
-echo "\n[6] handler_config max_items mirrors into handler_configs\n";
-$shape_result = AgentBundleArtifactRebase::rebase(
-	array(
-		'artifact_type' => 'flow',
-		'artifact_id'   => 'shape-transition',
-		'base'          => array(
-			'flow_config' => array(
-				'1_step_1' => array(
-					'handler_config' => array(
-						'owner'     => 'old',
-						'max_items' => 25,
-					),
-				),
-			),
-		),
-		'local' => array(
-			'flow_config' => array(
-				'1_step_1' => array(
-					'handler_config' => array(
-						'owner'     => 'old',
-						'max_items' => 1,
-					),
-				),
-			),
-		),
-		'remote' => array(
-			'flow_config' => array(
-				'1_step_1' => array(
-					'handler_config'  => array(
-						'owner'     => 'Automattic',
-						'max_items' => 25,
-					),
-					'handler_configs' => array(
-						'github-a8c' => array(
-							'owner'     => 'Automattic',
-							'max_items' => 25,
-						),
-					),
-				),
-			),
-		),
-	),
-	AgentBundleArtifactRebase::POLICY_BURN_IN_SAFE
-);
-
-$shape_step = $shape_result['merged']['flow_config']['1_step_1'] ?? array();
-rebase_assert_equals( 'shape: single handler throttle from local', 1, $shape_step['handler_config']['max_items'] ?? null );
-rebase_assert_equals( 'shape: multi handler throttle mirrors local', 1, $shape_step['handler_configs']['github-a8c']['max_items'] ?? null );
-rebase_assert_equals( 'shape: multi handler source-shape remains remote', 'Automattic', $shape_step['handler_configs']['github-a8c']['owner'] ?? null );
-
-// ---------------------------------------------------------------------------
-// [7] Hashes are recomputed for the merged payload.
-// ---------------------------------------------------------------------------
-echo "\n[7] Rebase output carries reproducible hashes\n";
+echo "\n[6] Rebase output carries reproducible hashes\n";
 $hashed_result = AgentBundleArtifactRebase::rebase(
 	array(
 		'artifact_type' => 'flow',

--- a/tests/agent-bundle-format-smoke.php
+++ b/tests/agent-bundle-format-smoke.php
@@ -308,6 +308,31 @@ try {
 }
 assert_bundle( 'malformed config_patch_queue fails clearly', $threw );
 
+$threw = false;
+try {
+	AgentBundleFlowFile::from_array(
+		array(
+			'schema_version' => 1,
+			'slug'           => 'Legacy Handler Slug',
+			'name'           => 'Legacy Handler Slug',
+			'pipeline_slug'  => 'WC Daily Ingest',
+			'schedule'       => 'daily',
+			'max_items'      => array(),
+			'steps'          => array(
+				array(
+					'step_position'   => 0,
+					'handler_slug'     => 'mcp',
+					'handler_config'   => array( 'provider' => 'mgs' ),
+					'handler_configs'  => array( 'mcp' => array( 'provider' => 'mgs' ) ),
+				),
+			),
+		)
+	);
+} catch ( BundleValidationException $e ) {
+	$threw = str_contains( $e->getMessage(), 'unsupported legacy field handler_slug' );
+}
+assert_bundle( 'legacy handler_slug in flow file fails clearly', $threw );
+
 echo "\n[4] Directory write/read round-trips without DB access\n";
 $bundle = new AgentBundleDirectory(
 	$manifest,

--- a/tests/system-task-workflow-validation-smoke.php
+++ b/tests/system-task-workflow-validation-smoke.php
@@ -59,6 +59,15 @@ function validate_workflow_for_test( array $workflow ): array {
 	$valid_types         = array_keys( $step_type_abilities->getAllStepTypes() );
 
 	foreach ( $workflow['steps'] as $index => $step ) {
+		foreach ( array( 'handler', 'handler_slug', 'handler_config' ) as $legacy_field ) {
+			if ( array_key_exists( $legacy_field, $step ) ) {
+				return array(
+					'valid' => false,
+					'error' => "Step {$index} uses unsupported legacy field {$legacy_field}; use handler_slugs and handler_configs",
+				);
+			}
+		}
+
 		if ( ! isset( $step['type'] ) ) {
 			return array( 'valid' => false, 'error' => "Step {$index} missing type" );
 		}
@@ -122,10 +131,11 @@ $r  = validate_workflow_for_test( $wf );
 dm_assert( true === $r['valid'], 'fetch without handler_slug accepted at workflow level' );
 
 // -----------------------------------------------------------------
-echo "\n[5] fetch step WITH handler_slug — VALID\n";
+echo "\n[5] fetch step WITH legacy handler_slug — INVALID\n";
 $wf = array( 'steps' => array( array( 'type' => 'fetch', 'handler_slug' => 'rss' ) ) );
 $r  = validate_workflow_for_test( $wf );
-dm_assert( true === $r['valid'], 'fetch with handler_slug=rss accepted' );
+dm_assert( false === $r['valid'], 'fetch with legacy handler_slug rejected' );
+dm_assert( str_contains( $r['error'] ?? '', 'unsupported legacy field handler_slug' ), 'legacy handler_slug error is explicit' );
 
 // -----------------------------------------------------------------
 echo "\n[6] publish step without handler_slug — VALID at workflow level\n";
@@ -143,7 +153,11 @@ dm_assert( true === $r['valid'], 'upsert without handler_slug accepted at workfl
 echo "\n[8] mixed workflow: fetch + ai + system_task — VALID\n";
 $wf = array(
 	'steps' => array(
-		array( 'type' => 'fetch', 'handler_slug' => 'rss' ),
+		array(
+			'type'            => 'fetch',
+			'handler_slugs'   => array( 'rss' ),
+			'handler_configs' => array( 'rss' => array( 'feed_url' => 'https://example.com/feed.xml' ) ),
+		),
 		array( 'type' => 'ai' ),
 		array( 'type' => 'system_task', 'flow_step_settings' => array( 'task_type' => 'cleanup' ) ),
 	),

--- a/tests/workflow-persistent-install-smoke.php
+++ b/tests/workflow-persistent-install-smoke.php
@@ -155,25 +155,6 @@ assert_workflow_equals( array( 'datamachine/delete-flow' ), $flow_steps[1]['disa
 assert_workflow_equals( array( array( 'prompt' => 'Prompt A', 'added_at' => '2026-04-27T00:00:00Z' ) ), $flow_steps[2]['prompt_queue'] ?? null, 'flow preserves explicit prompt queue', $failures, $passes );
 assert_workflow_equals( 'loop', $flow_steps[2]['queue_mode'] ?? null, 'flow preserves explicit AI queue mode', $failures, $passes );
 
-$legacy_handler_workflow = array(
-	'steps' => array(
-		array(
-			'type'           => 'fetch',
-			'handler_slug'   => 'mcp',
-			'handler_config' => array( 'query' => 'https://example.com/source' ),
-		),
-		array(
-			'type'           => 'upsert',
-			'handler_slug'   => 'wiki_upsert',
-			'handler_config' => array( 'fixed_slug' => '13751' ),
-		),
-	),
-);
-$legacy_handler_config = WorkflowConfigFactory::buildEphemeralConfigs( $legacy_handler_workflow )['flow_config'];
-assert_workflow_equals( array( 'mcp' ), $legacy_handler_config['ephemeral_step_0']['handler_slugs'] ?? null, 'workflow handler_slug maps to handler_slugs', $failures, $passes );
-assert_workflow_equals( array( 'mcp' => array( 'query' => 'https://example.com/source' ) ), $legacy_handler_config['ephemeral_step_0']['handler_configs'] ?? null, 'workflow handler_config maps to handler_configs', $failures, $passes );
-assert_workflow_equals( array( 'wiki_upsert' => array( 'fixed_slug' => '13751' ) ), $legacy_handler_config['ephemeral_step_1']['handler_configs'] ?? null, 'workflow upsert handler_config is preserved', $failures, $passes );
-
 $execute_workflow_source = file_get_contents( __DIR__ . '/../inc/Abilities/Job/ExecuteWorkflowAbility.php' ) ?: '';
 $create_pipeline_source  = file_get_contents( __DIR__ . '/../inc/Abilities/Pipeline/CreatePipelineAbility.php' ) ?: '';
 

--- a/tests/workflow-spec-contract-smoke.php
+++ b/tests/workflow-spec-contract-smoke.php
@@ -124,6 +124,8 @@ $invalid_cases    = array(
 	'associative steps' => array( 'steps' => array( 'first' => array( 'type' => 'fetch' ) ) ),
 	'scalar step'       => array( 'steps' => array( 'fetch' ) ),
 	'missing type'      => array( 'steps' => array( array( 'handler_slug' => 'rss' ) ) ),
+	'legacy handler field' => array( 'steps' => array( array( 'type' => 'fetch', 'handler_slug' => 'rss' ) ) ),
+	'legacy config field'  => array( 'steps' => array( array( 'type' => 'fetch', 'handler_config' => array( 'url' => 'https://example.com' ) ) ) ),
 	'non-string type'   => array( 'steps' => array( array( 'type' => 123 ) ) ),
 	'unknown type'      => array( 'steps' => array( array( 'type' => 'time_travel' ) ) ),
 );


### PR DESCRIPTION
## Summary
- Reject legacy scalar handler fields (`handler`, `handler_slug`, `handler_config`) in workflow specs and bundle flow files
- Stop exporting or translating scalar handler fields from flow configs
- Keep bundle rebase logic on canonical `handler_slugs` / `handler_configs`

## Testing
- `php tests/workflow-persistent-install-smoke.php`
- `php tests/system-task-workflow-validation-smoke.php`
- `php tests/agent-bundle-format-smoke.php`
- `php tests/workflow-spec-contract-smoke.php`
- `php tests/flow-step-legacy-handler-field-smoke.php`
- `php tests/agent-bundle-artifact-rebase-smoke.php`
- `php -l` on changed PHP files
- `./vendor/bin/phpcs` on changed files

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigating the Intelligence Horse flow failure, drafting the strict contract change, and running targeted verification. Chris reviewed and directed the change.