### PR TITLE
Register NETWORK.md only on multisite

### DIFF
--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -237,16 +237,18 @@ function datamachine_register_default_memory_files(): void {
 		'description'        => 'Information about the human the agent works with. Injected when the mode activates user profile memory.',
 	) );
 
-	// Network layer — multisite topology, only meaningful on multisite installs.
-	// Composable: content assembled from sections registered against SectionRegistry.
-	MemoryFileRegistry::register( 'NETWORK.md', 5, array(
-		'layer'       => MemoryFileRegistry::LAYER_NETWORK,
-		'protected'   => true,
-		'composable'  => true,
-		'modes'       => array( MemoryFileRegistry::MODE_ALL ),
-		'label'       => 'Network Context',
-		'description' => 'Auto-generated multisite network topology. Composable — extend via SectionRegistry.',
-	) );
+	// Network layer — multisite topology.
+	if ( is_multisite() ) {
+		// Composable: content assembled from sections registered against SectionRegistry.
+		MemoryFileRegistry::register( 'NETWORK.md', 5, array(
+			'layer'       => MemoryFileRegistry::LAYER_NETWORK,
+			'protected'   => true,
+			'composable'  => true,
+			'modes'       => array( MemoryFileRegistry::MODE_ALL ),
+			'label'       => 'Network Context',
+			'description' => 'Auto-generated multisite network topology. Composable — extend via SectionRegistry.',
+		) );
+	}
 }
 
 if ( did_action( 'plugins_loaded' ) ) {

--- a/tests/Unit/Engine/AI/MemoryFileRegistryTest.php
+++ b/tests/Unit/Engine/AI/MemoryFileRegistryTest.php
@@ -159,4 +159,22 @@ class MemoryFileRegistryTest extends TestCase {
 		$this->assertArrayHasKey( 'SOUL.md', $files );
 		$this->assertArrayNotHasKey( 'CHAT_ONLY.md', $files );
 	}
+
+	/**
+	 * NETWORK.md is a multisite topology file, so core should not register it on single-site installs.
+	 */
+	public function test_default_memory_files_do_not_register_network_on_single_site(): void {
+		$this->assertFalse( is_multisite() );
+		$this->assertTrue( function_exists( 'datamachine_register_default_memory_files' ) );
+
+		datamachine_register_default_memory_files();
+
+		$files = MemoryFileRegistry::get_all();
+		$this->assertArrayHasKey( 'SITE.md', $files );
+		$this->assertArrayHasKey( 'RULES.md', $files );
+		$this->assertArrayHasKey( 'SOUL.md', $files );
+		$this->assertArrayHasKey( 'MEMORY.md', $files );
+		$this->assertArrayHasKey( 'USER.md', $files );
+		$this->assertArrayNotHasKey( 'NETWORK.md', $files );
+	}
 }


### PR DESCRIPTION
## Summary
- Gate the default `NETWORK.md` memory file registration behind `is_multisite()`.
- Keep direct `MemoryFileRegistry::register()` behavior unchanged for extensions/tests.
- Add regression coverage proving single-site default memory registration does not include `NETWORK.md`.

## Testing
- `php -l inc/bootstrap.php`
- `php -l tests/Unit/Engine/AI/MemoryFileRegistryTest.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-network-memory-multisite-only --changed-since main`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-network-memory-multisite-only --changed-since main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the multisite registration guard, regression test, and verification commands for Chris to review.