### PR TITLE
fix: add operator-invoked legacy handler shape migrator

### DIFF
--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -22,6 +22,7 @@ use DataMachine\Cli\AgentResolver;
 use DataMachine\Cli\UserResolver;
 use DataMachine\Cli\Commands\DrainCommand;
 use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Core\Steps\LegacyHandlerShapeMigrator;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -154,8 +155,14 @@ class FlowsCommand extends BaseCommand {
  * [--to-agent=<slug_or_id>]
  * : Destination agent slug or ID for bulk reassign. Must be a valid agent.
  *
- * [--yes]
- * : Skip confirmation prompt (delete/reassign subcommands).
+	 * [--yes]
+	 * : Skip confirmation prompt (delete/reassign/migrate-legacy-handler-shape subcommands).
+	 *
+	 * [--all-sites]
+	 * : Apply migrate-legacy-handler-shape to every site on the multisite network.
+	 *
+	 * [--verbose]
+	 * : Log per-row detail during migrate-legacy-handler-shape.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -230,6 +237,12 @@ class FlowsCommand extends BaseCommand {
  *
  *     # Dry-run reassign
  *     wp datamachine flows reassign --where-null --to-agent=events-bot --dry-run
+ *
+ *     # Audit legacy scalar handler shapes on the current site
+ *     wp datamachine flows migrate-legacy-handler-shape --dry-run --verbose
+ *
+ *     # Rewrite legacy scalar handler shapes across the whole multisite network
+ *     wp datamachine flows migrate-legacy-handler-shape --all-sites --yes
  */
 	public function __invoke( array $args, array $assoc_args ): void {
 		$flow_id     = null;
@@ -297,6 +310,12 @@ class FlowsCommand extends BaseCommand {
 		// Handle 'reassign' subcommand.
 		if ( ! empty( $args ) && 'reassign' === $args[0] ) {
 			$this->reassignFlows( $assoc_args );
+			return;
+		}
+
+		// Handle 'migrate-legacy-handler-shape' subcommand.
+		if ( ! empty( $args ) && 'migrate-legacy-handler-shape' === $args[0] ) {
+			$this->migrateLegacyHandlerShape( $assoc_args );
 			return;
 		}
 
@@ -2023,5 +2042,168 @@ class FlowsCommand extends BaseCommand {
 			$source_label,
 			$to_agent_id
 		) );
+	}
+
+	/**
+	 * Rewrite legacy scalar handler shapes in stored flow_config rows.
+	 *
+	 * Pre-1.0 Data Machine stored single-handler steps with scalar
+	 * `handler_slug` + `handler_config` keys; #712 (Mar 2026) introduced the
+	 * canonical `handler_slugs` / `handler_configs` shape and migrated every
+	 * row in the same release. That persisted migration was retired in
+	 * `e113857` ("Drop pre-1.0 data-shape migrations") on the assumption that
+	 * every install booting current code had already been migrated. Sites
+	 * that still carry scalar-shape rows — e.g. imported flows, restored
+	 * backups, externally-authored flow_config — therefore have no automatic
+	 * recovery path.
+	 *
+	 * #2102 ("Reject legacy handler flow fields", May 2026) made the readers
+	 * canonical-only: handler-backed fetch steps in the scalar shape now
+	 * resolve to a `null` primary slug and run as silent no-ops, and
+	 * `WorkflowSpecValidator` rejects any spec containing the legacy keys.
+	 * This subcommand is the operator-invoked path back to the canonical
+	 * shape without re-introducing a long-tail persisted migration chain.
+	 *
+	 * Scope: current site only. Use `--all-sites` on multisite to iterate
+	 * every site on the network, or run the command with `--url=<host>`
+	 * once per site for finer control.
+	 *
+	 * @param array $assoc_args Associative arguments.
+	 */
+	private function migrateLegacyHandlerShape( array $assoc_args ): void {
+		$dry_run    = isset( $assoc_args['dry-run'] );
+		$skip       = isset( $assoc_args['yes'] );
+		$all_sites  = isset( $assoc_args['all-sites'] );
+		$verbose    = isset( $assoc_args['verbose'] );
+
+		if ( $all_sites && ! is_multisite() ) {
+			WP_CLI::warning( '--all-sites has no effect on a single-site install; continuing on current site.' );
+			$all_sites = false;
+		}
+
+		if ( ! $dry_run && ! $skip ) {
+			$scope = $all_sites ? 'every site on the network' : sprintf( 'site %d', (int) get_current_blog_id() );
+			WP_CLI::confirm( sprintf( 'Rewrite legacy scalar handler shapes in flow_config rows for %s?', $scope ) );
+		}
+
+		$totals = array(
+			'sites_scanned'           => 0,
+			'flows_scanned'           => 0,
+			'flows_with_legacy'       => 0,
+			'flows_rewritten'         => 0,
+			'steps_migrated'          => 0,
+			'orphan_legacy_dropped'   => 0,
+			'errors'                  => 0,
+		);
+
+		if ( $all_sites ) {
+			$site_ids = get_sites( array( 'fields' => 'ids' ) );
+			foreach ( $site_ids as $site_id ) {
+				switch_to_blog( (int) $site_id );
+				$totals = $this->migrateLegacyHandlerShapeForCurrentSite( $totals, $dry_run, $verbose );
+				restore_current_blog();
+			}
+		} else {
+			$totals = $this->migrateLegacyHandlerShapeForCurrentSite( $totals, $dry_run, $verbose );
+		}
+
+		WP_CLI::log( '' );
+		WP_CLI::log( sprintf( 'Sites scanned:           %d', $totals['sites_scanned'] ) );
+		WP_CLI::log( sprintf( 'Flows scanned:           %d', $totals['flows_scanned'] ) );
+		WP_CLI::log( sprintf( 'Flows with legacy shape: %d', $totals['flows_with_legacy'] ) );
+		WP_CLI::log( sprintf( 'Flows rewritten:         %d%s', $totals['flows_rewritten'], $dry_run ? ' (dry-run)' : '' ) );
+		WP_CLI::log( sprintf( 'Steps migrated:          %d', $totals['steps_migrated'] ) );
+		WP_CLI::log( sprintf( 'Orphan legacy dropped:   %d', $totals['orphan_legacy_dropped'] ) );
+
+		if ( $totals['errors'] > 0 ) {
+			WP_CLI::warning( sprintf( '%d row(s) could not be processed (see preceding log lines).', $totals['errors'] ) );
+		}
+
+		if ( $dry_run ) {
+			WP_CLI::success( 'Dry run complete. Re-run without --dry-run to persist the rewrites.' );
+			return;
+		}
+
+		WP_CLI::success( 'Legacy handler shape migration complete.' );
+	}
+
+	/**
+	 * Walk every flow on the current site, rewriting legacy handler shapes.
+	 *
+	 * @param array<string, int> $totals  Accumulator across sites.
+	 * @param bool               $dry_run Skip persistence when true.
+	 * @param bool               $verbose Log per-flow detail when true.
+	 * @return array<string, int> Updated accumulator.
+	 */
+	private function migrateLegacyHandlerShapeForCurrentSite( array $totals, bool $dry_run, bool $verbose ): array {
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_flows';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		if ( $table_exists !== $table ) {
+			if ( $verbose ) {
+				WP_CLI::log( sprintf( '[site:%d] no flows table — skipping.', (int) get_current_blog_id() ) );
+			}
+			return $totals;
+		}
+
+		++$totals['sites_scanned'];
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results( "SELECT flow_id, flow_config FROM {$table}", ARRAY_A );
+		if ( empty( $rows ) ) {
+			return $totals;
+		}
+
+		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
+
+		foreach ( $rows as $row ) {
+			++$totals['flows_scanned'];
+
+			$flow_id     = (int) $row['flow_id'];
+			$flow_config = json_decode( (string) $row['flow_config'], true );
+
+			if ( ! is_array( $flow_config ) ) {
+				++$totals['errors'];
+				WP_CLI::warning( sprintf( '[site:%d flow:%d] flow_config is not valid JSON; skipping.', (int) get_current_blog_id(), $flow_id ) );
+				continue;
+			}
+
+			$report = LegacyHandlerShapeMigrator::migrate_flow_config( $flow_config );
+
+			if ( ! $report['changed'] ) {
+				continue;
+			}
+
+			++$totals['flows_with_legacy'];
+			$totals['steps_migrated']        += $report['steps_migrated'];
+			$totals['orphan_legacy_dropped'] += $report['dropped_orphan_legacy_config'];
+
+			if ( $verbose ) {
+				WP_CLI::log( sprintf(
+					'[site:%d flow:%d] migrated %d step(s): %s',
+					(int) get_current_blog_id(),
+					$flow_id,
+					$report['steps_migrated'],
+					implode( ', ', $report['migrated_step_ids'] )
+				) );
+			}
+
+			if ( $dry_run ) {
+				++$totals['flows_rewritten'];
+				continue;
+			}
+
+			$ok = $db_flows->update_flow( $flow_id, array( 'flow_config' => $report['config'] ) );
+			if ( $ok ) {
+				++$totals['flows_rewritten'];
+			} else {
+				++$totals['errors'];
+				WP_CLI::warning( sprintf( '[site:%d flow:%d] update_flow returned false; row not rewritten.', (int) get_current_blog_id(), $flow_id ) );
+			}
+		}
+
+		return $totals;
 	}
 }

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -2071,10 +2071,10 @@ class FlowsCommand extends BaseCommand {
 	 * @param array $assoc_args Associative arguments.
 	 */
 	private function migrateLegacyHandlerShape( array $assoc_args ): void {
-		$dry_run    = isset( $assoc_args['dry-run'] );
-		$skip       = isset( $assoc_args['yes'] );
-		$all_sites  = isset( $assoc_args['all-sites'] );
-		$verbose    = isset( $assoc_args['verbose'] );
+		$dry_run   = isset( $assoc_args['dry-run'] );
+		$skip      = isset( $assoc_args['yes'] );
+		$all_sites = isset( $assoc_args['all-sites'] );
+		$verbose   = isset( $assoc_args['verbose'] );
 
 		if ( $all_sites && ! is_multisite() ) {
 			WP_CLI::warning( '--all-sites has no effect on a single-site install; continuing on current site.' );
@@ -2087,13 +2087,13 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		$totals = array(
-			'sites_scanned'           => 0,
-			'flows_scanned'           => 0,
-			'flows_with_legacy'       => 0,
-			'flows_rewritten'         => 0,
-			'steps_migrated'          => 0,
-			'orphan_legacy_dropped'   => 0,
-			'errors'                  => 0,
+			'sites_scanned'         => 0,
+			'flows_scanned'         => 0,
+			'flows_with_legacy'     => 0,
+			'flows_rewritten'       => 0,
+			'steps_migrated'        => 0,
+			'orphan_legacy_dropped' => 0,
+			'errors'                => 0,
 		);
 
 		if ( $all_sites ) {

--- a/inc/Core/Steps/LegacyHandlerShapeMigrator.php
+++ b/inc/Core/Steps/LegacyHandlerShapeMigrator.php
@@ -60,13 +60,13 @@ class LegacyHandlerShapeMigrator {
 	 */
 	public static function migrate_flow_config( array $flow_config ): array {
 		$report = array(
-			'changed'                       => false,
-			'steps_migrated'                => 0,
-			'steps_already_canonical'       => 0,
-			'steps_skipped_non_step'        => 0,
-			'dropped_orphan_legacy_config'  => 0,
-			'migrated_step_ids'             => array(),
-			'config'                        => $flow_config,
+			'changed'                      => false,
+			'steps_migrated'               => 0,
+			'steps_already_canonical'      => 0,
+			'steps_skipped_non_step'       => 0,
+			'dropped_orphan_legacy_config' => 0,
+			'migrated_step_ids'            => array(),
+			'config'                       => $flow_config,
 		);
 
 		foreach ( $flow_config as $step_id => $step ) {
@@ -86,7 +86,7 @@ class LegacyHandlerShapeMigrator {
 			}
 
 			$report['config'][ $step_id ] = self::migrate_step( $step, $report );
-			$report['changed']             = true;
+			$report['changed']            = true;
 			++$report['steps_migrated'];
 			$report['migrated_step_ids'][] = (string) $step_id;
 		}

--- a/inc/Core/Steps/LegacyHandlerShapeMigrator.php
+++ b/inc/Core/Steps/LegacyHandlerShapeMigrator.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Legacy Handler Shape Migrator
+ *
+ * Operator-invoked one-shot migrator that rewrites stored `flow_config` JSON
+ * from the pre-1.0 scalar handler shape (`handler`, `handler_slug`,
+ * `handler_config`) into the canonical shape (`handler_slugs`,
+ * `handler_configs`, `flow_step_settings`).
+ *
+ * After `b9db8d8` (#712) the canonical shape became authoritative and a
+ * persisted migration ran on every plugins_loaded. That migration was removed
+ * in `e113857` ("Drop pre-1.0 data-shape migrations") on the assumption that
+ * every install booting current code had already been migrated. That
+ * assumption did not hold for every install: production sites that re-issued
+ * legacy-shape writes — directly or via cloned/imported flow data — still
+ * carry rows in the scalar shape.
+ *
+ * The strict legacy-field rejection landed in #2102 (May 2026) which makes
+ * those leftover rows runtime-fatal: handler-backed fetch steps return a null
+ * primary slug and run as no-ops. This migrator is the explicit operator path
+ * back to the canonical shape without re-introducing an open-ended persisted
+ * migration chain.
+ *
+ * Pure in-memory transformation. The CLI wraps this with persistence and
+ * per-site iteration.
+ *
+ * @package DataMachine\Core\Steps
+ * @since 0.124.6
+ */
+
+namespace DataMachine\Core\Steps;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Rewrite legacy scalar handler shapes inside `flow_config` JSON into the
+ * canonical `handler_slugs` / `handler_configs` / `flow_step_settings` shape.
+ */
+class LegacyHandlerShapeMigrator {
+
+	/**
+	 * Migrate a single decoded `flow_config` array in place.
+	 *
+	 * Returns a report describing what changed. The migrator never invents
+	 * handler data: if a step is in handler-free territory (or has no
+	 * resolvable slug to lift), legacy keys are dropped without synthesising
+	 * a new slug list. Callers can opt into stricter behaviour by inspecting
+	 * the report's `dropped_orphan_legacy_config` counter.
+	 *
+	 * @param array<string, mixed> $flow_config Decoded `flow_config` JSON keyed by flow step ID.
+	 * @return array{
+	 *     changed: bool,
+	 *     steps_migrated: int,
+	 *     steps_already_canonical: int,
+	 *     steps_skipped_non_step: int,
+	 *     dropped_orphan_legacy_config: int,
+	 *     migrated_step_ids: array<int, string>,
+	 *     config: array<string, mixed>
+	 * }
+	 */
+	public static function migrate_flow_config( array $flow_config ): array {
+		$report = array(
+			'changed'                       => false,
+			'steps_migrated'                => 0,
+			'steps_already_canonical'       => 0,
+			'steps_skipped_non_step'        => 0,
+			'dropped_orphan_legacy_config'  => 0,
+			'migrated_step_ids'             => array(),
+			'config'                        => $flow_config,
+		);
+
+		foreach ( $flow_config as $step_id => $step ) {
+			// Flow-level metadata keys (e.g. memory_files) live alongside steps but are not steps themselves.
+			if ( ! is_array( $step ) || ! isset( $step['step_type'] ) ) {
+				++$report['steps_skipped_non_step'];
+				continue;
+			}
+
+			$has_legacy = array_key_exists( 'handler', $step )
+				|| array_key_exists( 'handler_slug', $step )
+				|| array_key_exists( 'handler_config', $step );
+
+			if ( ! $has_legacy ) {
+				++$report['steps_already_canonical'];
+				continue;
+			}
+
+			$report['config'][ $step_id ] = self::migrate_step( $step, $report );
+			$report['changed']             = true;
+			++$report['steps_migrated'];
+			$report['migrated_step_ids'][] = (string) $step_id;
+		}
+
+		return $report;
+	}
+
+	/**
+	 * Migrate a single step array.
+	 *
+	 * Lifts scalar `handler` / `handler_slug` into `handler_slugs[]` and scalar
+	 * `handler_config` into either `handler_configs[<slug>]` (handler-backed
+	 * steps) or `flow_step_settings` (handler-free steps), then strips the
+	 * legacy keys via {@see FlowStepConfig::normalizeHandlerShape()}.
+	 *
+	 * @param array<string, mixed>                                                                            $step   Step config row.
+	 * @param array{dropped_orphan_legacy_config: int, ...}                                                   $report In/out report counters.
+	 * @return array<string, mixed> Migrated step config row.
+	 */
+	private static function migrate_step( array $step, array &$report ): array {
+		$legacy_slug   = self::extract_legacy_slug( $step );
+		$legacy_config = is_array( $step['handler_config'] ?? null ) ? $step['handler_config'] : array();
+
+		$uses_handler = FlowStepConfig::usesHandler( $step );
+
+		if ( $uses_handler ) {
+			$handler_slugs   = is_array( $step['handler_slugs'] ?? null ) ? array_values( $step['handler_slugs'] ) : array();
+			$handler_configs = is_array( $step['handler_configs'] ?? null ) ? $step['handler_configs'] : array();
+
+			if ( '' !== $legacy_slug && ! in_array( $legacy_slug, $handler_slugs, true ) ) {
+				$handler_slugs[] = $legacy_slug;
+			}
+
+			if ( '' !== $legacy_slug && ! empty( $legacy_config ) && ! array_key_exists( $legacy_slug, $handler_configs ) ) {
+				$handler_configs[ $legacy_slug ] = $legacy_config;
+			}
+
+			// Orphan: legacy_config but no slug we can attribute it to. Track it; do not invent a slot.
+			if ( '' === $legacy_slug && ! empty( $legacy_config ) ) {
+				++$report['dropped_orphan_legacy_config'];
+			}
+
+			$step['handler_slugs']   = $handler_slugs;
+			$step['handler_configs'] = $handler_configs;
+		} else {
+			// Handler-free step: lift legacy_config into flow_step_settings only if the canonical slot is empty.
+			$existing_settings = is_array( $step['flow_step_settings'] ?? null ) ? $step['flow_step_settings'] : array();
+
+			if ( ! empty( $legacy_config ) && empty( $existing_settings ) ) {
+				$step['flow_step_settings'] = $legacy_config;
+			} elseif ( ! empty( $legacy_config ) && ! empty( $existing_settings ) ) {
+				// Both slots present: canonical wins; the redundant legacy copy is dropped.
+				++$report['dropped_orphan_legacy_config'];
+			}
+
+			// A handler-free step with a legacy `handler_slug` (e.g. an older synthetic
+			// `handler_slugs => [step_type]` rewrite from #712) carried no real handler.
+			// We do not preserve it; the canonical handler-free shape has no slug list.
+			if ( '' !== $legacy_slug ) {
+				++$report['dropped_orphan_legacy_config'];
+			}
+		}
+
+		// Strip every legacy key plus reapply canonical normalization.
+		return FlowStepConfig::normalizeHandlerShape( $step );
+	}
+
+	/**
+	 * Extract a legacy scalar handler slug, preferring `handler_slug` over `handler`.
+	 *
+	 * @param array<string, mixed> $step Step config row.
+	 * @return string Legacy slug, or empty string when none is present/string.
+	 */
+	private static function extract_legacy_slug( array $step ): string {
+		foreach ( array( 'handler_slug', 'handler' ) as $key ) {
+			if ( isset( $step[ $key ] ) && is_string( $step[ $key ] ) && '' !== $step[ $key ] ) {
+				return $step[ $key ];
+			}
+		}
+		return '';
+	}
+}

--- a/tests/legacy-handler-shape-migration-smoke.php
+++ b/tests/legacy-handler-shape-migration-smoke.php
@@ -1,0 +1,332 @@
+<?php
+/**
+ * Pure-PHP smoke test for `LegacyHandlerShapeMigrator`.
+ *
+ * Run with: php tests/legacy-handler-shape-migration-smoke.php
+ *
+ * Covers the production shapes observed before #2102 made the readers
+ * canonical-only:
+ *   - handler-backed fetch step with scalar handler_slug + handler_config
+ *   - handler-backed event_import step with scalar shape (third-party step type)
+ *   - handler-free system_task step with redundant scalar handler_config
+ *   - already-canonical mixed flow that the migrator must leave untouched
+ *   - flow-level metadata keys (e.g. memory_files) that must not be mutated
+ *   - publish step in plural canonical shape (must pass through unchanged)
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value ) {
+		if ( 'datamachine_step_types' !== $hook ) {
+			return $value;
+		}
+
+		return array(
+			'ai'           => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'system_task'  => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'webhook_gate' => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'fetch'        => array( 'uses_handler' => true, 'multi_handler' => false ),
+			'publish'      => array( 'uses_handler' => true, 'multi_handler' => true ),
+			'upsert'       => array( 'uses_handler' => true, 'multi_handler' => true ),
+			// Third-party step type registered by data-machine-events.
+			'event_import' => array( 'uses_handler' => true, 'multi_handler' => false ),
+		);
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['__legacy_handler_shape_migration_actions'][] = array( $hook, $args );
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/Core/Steps/LegacyHandlerShapeMigrator.php';
+
+use DataMachine\Core\Steps\LegacyHandlerShapeMigrator;
+
+$failures = array();
+$passes   = 0;
+
+function legacy_assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function legacy_assert_absent( string $key, array $array_value, string $name, array &$failures, int &$passes ): void {
+	legacy_assert_equals( false, array_key_exists( $key, $array_value ), $name, $failures, $passes );
+}
+
+echo "legacy handler shape migration smoke\n";
+echo "-------------------------------------\n";
+
+echo "\n[1] handler-backed fetch step: scalar reddit shape (wire.extrachill.com)\n";
+$flow_config = array(
+	'fetch_1' => array(
+		'flow_step_id'     => 'fetch_1',
+		'step_type'        => 'fetch',
+		'pipeline_step_id' => 'fetch_p',
+		'pipeline_id'      => 1,
+		'flow_id'          => 1,
+		'execution_order'  => 0,
+		'enabled_tools'    => array(),
+		'enabled'          => true,
+		'handler_slug'     => 'reddit',
+		'handler_config'   => array(
+			'subreddit'         => 'bonnaroo',
+			'sort_by'           => 'top',
+			'min_upvotes'       => 30,
+			'min_comment_count' => 10,
+			'timeframe_limit'   => '72_hours',
+		),
+	),
+);
+
+$report = LegacyHandlerShapeMigrator::migrate_flow_config( $flow_config );
+legacy_assert_equals( true, $report['changed'], 'fetch step: report flagged as changed', $failures, $passes );
+legacy_assert_equals( 1, $report['steps_migrated'], 'fetch step: one step migrated', $failures, $passes );
+legacy_assert_equals( array( 'fetch_1' ), $report['migrated_step_ids'], 'fetch step: step id surfaced in report', $failures, $passes );
+
+$migrated_step = $report['config']['fetch_1'];
+legacy_assert_equals( array( 'reddit' ), $migrated_step['handler_slugs'] ?? null, 'fetch step: scalar slug lifted into handler_slugs', $failures, $passes );
+legacy_assert_equals(
+	array(
+		'subreddit'         => 'bonnaroo',
+		'sort_by'           => 'top',
+		'min_upvotes'       => 30,
+		'min_comment_count' => 10,
+		'timeframe_limit'   => '72_hours',
+	),
+	$migrated_step['handler_configs']['reddit'] ?? null,
+	'fetch step: scalar config lifted into handler_configs[slug]',
+	$failures,
+	$passes
+);
+legacy_assert_absent( 'handler_slug', $migrated_step, 'fetch step: legacy handler_slug stripped', $failures, $passes );
+legacy_assert_absent( 'handler_config', $migrated_step, 'fetch step: legacy handler_config stripped', $failures, $passes );
+legacy_assert_absent( 'handler', $migrated_step, 'fetch step: legacy handler stripped', $failures, $passes );
+
+echo "\n[2] handler-backed event_import step (events.extrachill.com)\n";
+$flow_config = array(
+	'event_1' => array(
+		'flow_step_id'   => 'event_1',
+		'step_type'      => 'event_import',
+		'handler_slug'   => 'universal_web_scraper',
+		'handler_config' => array(
+			'source_url' => 'https://www.theroyalamerican.com/schedule',
+			'venue'      => '2',
+		),
+	),
+);
+
+$report = LegacyHandlerShapeMigrator::migrate_flow_config( $flow_config );
+$migrated_step = $report['config']['event_1'];
+legacy_assert_equals( array( 'universal_web_scraper' ), $migrated_step['handler_slugs'] ?? null, 'event_import: third-party step type recognised as handler-backed', $failures, $passes );
+legacy_assert_equals(
+	array(
+		'source_url' => 'https://www.theroyalamerican.com/schedule',
+		'venue'      => '2',
+	),
+	$migrated_step['handler_configs']['universal_web_scraper'] ?? null,
+	'event_import: scalar config lifted into handler_configs[slug]',
+	$failures,
+	$passes
+);
+
+echo "\n[3] handler-free system_task with redundant scalar handler_config + canonical flow_step_settings\n";
+$flow_config = array(
+	'task_1' => array(
+		'flow_step_id'       => 'task_1',
+		'step_type'          => 'system_task',
+		'flow_step_settings' => array(
+			'task'   => 'dispatch_message',
+			'params' => array( 'channel' => 'kimaki' ),
+		),
+		'handler_config'     => array(
+			'task'   => 'dispatch_message',
+			'params' => array( 'channel' => 'kimaki' ),
+		),
+	),
+);
+
+$report = LegacyHandlerShapeMigrator::migrate_flow_config( $flow_config );
+$migrated_step = $report['config']['task_1'];
+legacy_assert_equals( true, $report['changed'], 'system_task: report flagged as changed (legacy keys dropped)', $failures, $passes );
+legacy_assert_equals(
+	array(
+		'task'   => 'dispatch_message',
+		'params' => array( 'channel' => 'kimaki' ),
+	),
+	$migrated_step['flow_step_settings'] ?? null,
+	'system_task: canonical flow_step_settings preserved verbatim',
+	$failures,
+	$passes
+);
+legacy_assert_absent( 'handler_slug', $migrated_step, 'system_task: legacy handler_slug stripped', $failures, $passes );
+legacy_assert_absent( 'handler_config', $migrated_step, 'system_task: legacy handler_config stripped', $failures, $passes );
+legacy_assert_absent( 'handler_slugs', $migrated_step, 'system_task: no synthetic handler_slugs created for handler-free step', $failures, $passes );
+legacy_assert_absent( 'handler_configs', $migrated_step, 'system_task: no synthetic handler_configs created for handler-free step', $failures, $passes );
+legacy_assert_equals( 1, $report['dropped_orphan_legacy_config'], 'system_task: redundant legacy config recorded as dropped orphan', $failures, $passes );
+
+echo "\n[4] handler-free system_task with scalar handler_config and no canonical settings yet (legacy-only)\n";
+$flow_config = array(
+	'task_2' => array(
+		'flow_step_id'   => 'task_2',
+		'step_type'      => 'system_task',
+		'handler_config' => array(
+			'task'   => 'dispatch_message',
+			'params' => array( 'channel' => 'kimaki' ),
+		),
+	),
+);
+
+$report = LegacyHandlerShapeMigrator::migrate_flow_config( $flow_config );
+$migrated_step = $report['config']['task_2'];
+legacy_assert_equals(
+	array(
+		'task'   => 'dispatch_message',
+		'params' => array( 'channel' => 'kimaki' ),
+	),
+	$migrated_step['flow_step_settings'] ?? null,
+	'system_task (legacy-only): scalar handler_config lifted into flow_step_settings',
+	$failures,
+	$passes
+);
+legacy_assert_absent( 'handler_config', $migrated_step, 'system_task (legacy-only): scalar handler_config stripped after lift', $failures, $passes );
+
+echo "\n[5] already-canonical mixed flow: fetch + ai + publish; only legacy-shape steps mutate\n";
+$flow_config = array(
+	'fetch_1' => array(
+		'flow_step_id'    => 'fetch_1',
+		'step_type'       => 'fetch',
+		'handler_slug'    => 'reddit',
+		'handler_config'  => array( 'subreddit' => 'festivals' ),
+	),
+	'ai_1'    => array(
+		'flow_step_id' => 'ai_1',
+		'step_type'    => 'ai',
+		'enabled_tools' => array(),
+		'prompt_queue' => array( array( 'prompt' => 'summarise' ) ),
+	),
+	'publish_1' => array(
+		'flow_step_id'    => 'publish_1',
+		'step_type'       => 'publish',
+		'handler_slugs'   => array( 'wordpress_publish' ),
+		'handler_configs' => array(
+			'wordpress_publish' => array(
+				'post_type'   => 'festival_wire',
+				'post_status' => 'publish',
+			),
+		),
+	),
+);
+
+$report = LegacyHandlerShapeMigrator::migrate_flow_config( $flow_config );
+legacy_assert_equals( 1, $report['steps_migrated'], 'mixed flow: only the legacy fetch step migrates', $failures, $passes );
+legacy_assert_equals( array( 'fetch_1' ), $report['migrated_step_ids'], 'mixed flow: report names the migrated step id', $failures, $passes );
+
+$migrated_fetch = $report['config']['fetch_1'];
+legacy_assert_equals( array( 'reddit' ), $migrated_fetch['handler_slugs'] ?? null, 'mixed flow: fetch slug lifted', $failures, $passes );
+legacy_assert_equals( array( 'subreddit' => 'festivals' ), $migrated_fetch['handler_configs']['reddit'] ?? null, 'mixed flow: fetch config lifted', $failures, $passes );
+
+$untouched_publish = $report['config']['publish_1'];
+legacy_assert_equals( array( 'wordpress_publish' ), $untouched_publish['handler_slugs'] ?? null, 'mixed flow: canonical publish slugs untouched', $failures, $passes );
+legacy_assert_equals(
+	array(
+		'post_type'   => 'festival_wire',
+		'post_status' => 'publish',
+	),
+	$untouched_publish['handler_configs']['wordpress_publish'] ?? null,
+	'mixed flow: canonical publish config untouched',
+	$failures,
+	$passes
+);
+
+$untouched_ai = $report['config']['ai_1'];
+legacy_assert_equals( array( array( 'prompt' => 'summarise' ) ), $untouched_ai['prompt_queue'] ?? null, 'mixed flow: ai prompt_queue untouched', $failures, $passes );
+
+echo "\n[6] flow with no legacy fields and no changes: report is_changed=false\n";
+$flow_config = array(
+	'task_1' => array(
+		'flow_step_id'       => 'task_1',
+		'step_type'          => 'system_task',
+		'flow_step_settings' => array( 'task' => 'noop' ),
+	),
+);
+$report = LegacyHandlerShapeMigrator::migrate_flow_config( $flow_config );
+legacy_assert_equals( false, $report['changed'], 'clean flow: no changes reported', $failures, $passes );
+legacy_assert_equals( 0, $report['steps_migrated'], 'clean flow: zero migrations', $failures, $passes );
+legacy_assert_equals( 1, $report['steps_already_canonical'], 'clean flow: counted as already-canonical', $failures, $passes );
+
+echo "\n[7] flow-level metadata keys are not treated as steps\n";
+$flow_config = array(
+	'memory_files' => array( 'briefing.md' ),
+	'fetch_1'      => array(
+		'flow_step_id'   => 'fetch_1',
+		'step_type'      => 'fetch',
+		'handler_slug'   => 'rss',
+		'handler_config' => array( 'feed_url' => 'https://example.com/rss' ),
+	),
+);
+
+$report = LegacyHandlerShapeMigrator::migrate_flow_config( $flow_config );
+legacy_assert_equals( 1, $report['steps_migrated'], 'metadata keys: only the real step migrates', $failures, $passes );
+legacy_assert_equals( array( 'briefing.md' ), $report['config']['memory_files'] ?? null, 'metadata keys: memory_files preserved untouched', $failures, $passes );
+legacy_assert_equals( array( 'rss' ), $report['config']['fetch_1']['handler_slugs'] ?? null, 'metadata keys: fetch step still migrated', $failures, $passes );
+legacy_assert_equals( 1, $report['steps_skipped_non_step'], 'metadata keys: counter incremented for non-step entry', $failures, $passes );
+
+echo "\n[8] orphan legacy: handler-backed step with handler_config but no slug\n";
+$flow_config = array(
+	'fetch_x' => array(
+		'flow_step_id'   => 'fetch_x',
+		'step_type'      => 'fetch',
+		'handler_config' => array( 'feed_url' => 'https://orphan.example.com/rss' ),
+	),
+);
+$report = LegacyHandlerShapeMigrator::migrate_flow_config( $flow_config );
+legacy_assert_equals( 1, $report['dropped_orphan_legacy_config'], 'orphan: counted as dropped', $failures, $passes );
+$migrated_orphan = $report['config']['fetch_x'];
+legacy_assert_absent( 'handler_config', $migrated_orphan, 'orphan: legacy handler_config stripped', $failures, $passes );
+legacy_assert_absent( 'handler_slugs', $migrated_orphan, 'orphan: no synthetic slug list invented', $failures, $passes );
+
+echo "\n[9] re-running migrator on already-migrated output is a no-op\n";
+$flow_config = array(
+	'fetch_1' => array(
+		'flow_step_id'   => 'fetch_1',
+		'step_type'      => 'fetch',
+		'handler_slug'   => 'reddit',
+		'handler_config' => array( 'subreddit' => 'idempotent' ),
+	),
+);
+$first  = LegacyHandlerShapeMigrator::migrate_flow_config( $flow_config );
+$second = LegacyHandlerShapeMigrator::migrate_flow_config( $first['config'] );
+legacy_assert_equals( true, $first['changed'], 'idempotent: first pass changes', $failures, $passes );
+legacy_assert_equals( false, $second['changed'], 'idempotent: second pass is a no-op', $failures, $passes );
+legacy_assert_equals( $first['config'], $second['config'], 'idempotent: config stable across passes', $failures, $passes );
+
+echo "\n-------------------------------------\n";
+$total = $passes + count( $failures );
+echo "{$passes} / {$total} passed\n";
+
+if ( ! empty( $failures ) ) {
+	echo "\nFailures:\n";
+	foreach ( $failures as $failure ) {
+		echo " - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nAll assertions passed.\n";


### PR DESCRIPTION
## Summary

Closes #2103.

After #2102 made the canonical handler shape authoritative — `WorkflowSpecValidator` and `AgentBundleFlowFile` reject every legacy scalar field, and `FlowStepConfig::getPrimaryHandlerSlug` / `getPrimaryHandlerConfig` no longer fall back to scalar `handler_slug` / `handler_config` — stored `flow_config` JSON on installs that still carry the legacy scalar shape silently break: handler-backed fetch steps resolve to a `null` primary slug and execute as no-ops.

The persisted shape migration that originally lifted those scalars into canonical `handler_slugs` / `handler_configs` was removed in `e113857` ("Drop pre-1.0 data-shape migrations") on the assumption that every install booting current code had already been migrated. The extrachill.com production network shows that assumption does not hold for every install — 628 of 701 flows across 9 sites are sitting in the legacy shape today, including every active reddit scraper on wire.extrachill.com and every event import flow on events.extrachill.com.

Re-introducing an automatic `plugins_loaded` migration would violate the "drop pre-1.0 data-shape migrations" policy and re-bloat the schema runtime. Ship the rewrite as an operator-invoked WP-CLI subcommand instead.

## New command

\`\`\`
wp datamachine flows migrate-legacy-handler-shape [--dry-run] [--all-sites] [--yes] [--verbose]
\`\`\`

- Defaults to the current site. Use \`--url=<host>\` to target a specific subsite or \`--all-sites\` to iterate every site on the network.
- \`--dry-run\` reports counts (and per-row detail with \`--verbose\`) without writing.
- \`--yes\` skips the confirmation prompt.
- Persistence goes through \`Flows::update_flow()\` so writes follow the same path as every other \`flow_config\` update.

## Migrator

\`inc/Core/Steps/LegacyHandlerShapeMigrator.php\` is a pure in-memory transformation:

- Callers pass a decoded \`flow_config\` array and receive a report containing the rewritten config plus counters (\`steps_migrated\`, \`dropped_orphan_legacy_config\`, \`steps_already_canonical\`, \`steps_skipped_non_step\`).
- Handler-backed steps: lift scalar \`handler_slug\` / \`handler\` into \`handler_slugs[]\`, lift scalar \`handler_config\` into \`handler_configs[<slug>]\`, strip the legacy keys.
- Handler-free steps: lift scalar \`handler_config\` into \`flow_step_settings\` only when the canonical slot is empty; drop redundant legacy copies and count them under \`dropped_orphan_legacy_config\`. Never invents a synthetic \`handler_slugs\` for handler-free step types.
- Orphan legacy configs without a resolvable slug are stripped and counted, never attributed to an invented slug.
- Cardinality (\`uses_handler\`) is read via \`FlowStepConfig::usesHandler()\` which honours the live \`datamachine_step_types\` filter, so third-party step types (e.g. \`event_import\` from \`data-machine-events\`) migrate correctly.
- Normalization delegates to \`FlowStepConfig::normalizeHandlerShape()\` to keep the canonical contract single-sourced.

## Verification on extrachill.com network

Dry-run across 9 sites / 701 flows:

\`\`\`
sites_scanned         9
flows_scanned         701
flows_with_legacy     628
steps_migrated        633
orphan_legacy_dropped 1
\`\`\`

Spot-checked on real prod rows:

- **wire.extrachill.com flow 1** (\`r/bonnaroo\`, daily reddit scraper) — fetch step goes from \`handler_slug: "reddit"\` + scalar \`handler_config\` to canonical \`handler_slugs: ["reddit"]\` + \`handler_configs.reddit: {…}\` with every field preserved.
- **extrachill.com flow 4** (\`EC Agent Progress Ping\`, system_task) — keeps its canonical \`flow_step_settings\` verbatim, drops the redundant scalar \`handler_config\` copy, no synthetic slug lists invented.

## Tests

- **New**: \`tests/legacy-handler-shape-migration-smoke.php\` — 39 assertions covering the production shapes (reddit fetch, \`universal_web_scraper\` event_import, system_task with redundant handler_config, system_task with legacy-only handler_config, mixed canonical+legacy flow, no-change flow, flow-level metadata keys like \`memory_files\`, orphan legacy config without a slug, and idempotency across re-runs).
- \`tests/flow-step-legacy-handler-field-smoke.php\` still 19/19.
- \`tests/workflow-spec-contract-smoke.php\` still 36/36.
- \`tests/agent-bundle-format-smoke.php\` still 72/72.
- \`tests/migration-runtime-smoke.php\` still 16/16.
- \`php -l\` clean on the three changed files.
- \`./vendor/bin/phpcs --standard=phpcs.xml.dist\` clean on the three changed files.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (Claude)
- **Used for:** Investigated the prod blast radius after PR #2102 merged, traced the reader path to confirm legacy rows go to no-op, drafted the migrator + CLI wrapper + smoke test, and verified end-to-end against the live extrachill.com multisite DB. Chris reviewed and authorised the approach.