### PR TITLE
Migrate stored legacy handler flow fields

### DIFF
--- a/inc/migrations/flows.php
+++ b/inc/migrations/flows.php
@@ -11,6 +11,177 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
+ * Normalize legacy scalar handler fields in a persisted flow config array.
+ *
+ * Runtime readers intentionally consume only the canonical plural handler
+ * fields. This helper is for one deploy-time storage migration only: old flow
+ * rows that predate the strict workflow contract need their stored JSON moved
+ * to the canonical shape before runtime fallback disappears.
+ *
+ * @param array $flow_config Flow configuration decoded from storage.
+ * @return array Normalized flow configuration.
+ */
+function datamachine_normalize_stored_flow_legacy_handler_fields( array $flow_config ): array {
+	foreach ( $flow_config as $flow_step_id => $step_config ) {
+		if ( ! is_array( $step_config ) || ! isset( $step_config['step_type'] ) ) {
+			continue;
+		}
+
+		$uses_handler = \DataMachine\Core\Steps\FlowStepConfig::usesHandler( $step_config );
+		$legacy_slug  = '';
+		foreach ( array( 'handler_slug', 'handler' ) as $legacy_slug_key ) {
+			if ( isset( $step_config[ $legacy_slug_key ] ) && is_string( $step_config[ $legacy_slug_key ] ) && '' !== $step_config[ $legacy_slug_key ] ) {
+				$legacy_slug = $step_config[ $legacy_slug_key ];
+				break;
+			}
+		}
+
+		$legacy_config = is_array( $step_config['handler_config'] ?? null ) ? $step_config['handler_config'] : array();
+
+		unset( $step_config['handler'], $step_config['handler_slug'], $step_config['handler_config'] );
+
+		if ( ! $uses_handler ) {
+			unset( $step_config['handler_slugs'], $step_config['handler_configs'] );
+			$flow_config[ $flow_step_id ] = $step_config;
+			continue;
+		}
+
+		$handler_slugs = datamachine_sanitize_stored_flow_handler_slugs(
+			is_array( $step_config['handler_slugs'] ?? null ) ? $step_config['handler_slugs'] : array()
+		);
+
+		if ( empty( $handler_slugs ) && '' !== $legacy_slug ) {
+			$handler_slugs = array( $legacy_slug );
+		}
+
+		$handler_configs = is_array( $step_config['handler_configs'] ?? null ) ? $step_config['handler_configs'] : array();
+		if ( ! empty( $legacy_config ) ) {
+			$config_slug = $handler_slugs[0] ?? $legacy_slug;
+			if ( '' !== $config_slug && ! array_key_exists( $config_slug, $handler_configs ) ) {
+				$handler_configs[ $config_slug ] = $legacy_config;
+			}
+		}
+
+		unset( $step_config['handler_slugs'], $step_config['handler_configs'] );
+
+		if ( ! empty( $handler_slugs ) ) {
+			$step_config['handler_slugs'] = $handler_slugs;
+		}
+
+		$handler_configs = array_filter( $handler_configs, 'is_array' );
+		if ( ! empty( $handler_configs ) ) {
+			$step_config['handler_configs'] = $handler_configs;
+		}
+
+		$flow_config[ $flow_step_id ] = $step_config;
+	}
+
+	return $flow_config;
+}
+
+/**
+ * Normalize and de-duplicate handler slugs from stored JSON.
+ *
+ * @param array $slugs Raw slug values.
+ * @return array<int, string> Clean slug list.
+ */
+function datamachine_sanitize_stored_flow_handler_slugs( array $slugs ): array {
+	$clean = array();
+	foreach ( $slugs as $slug ) {
+		if ( ! is_string( $slug ) || '' === $slug ) {
+			continue;
+		}
+		if ( ! in_array( $slug, $clean, true ) ) {
+			$clean[] = $slug;
+		}
+	}
+	return $clean;
+}
+
+/**
+ * Migrate stored flow_config JSON away from legacy scalar handler fields.
+ *
+ * @return void
+ */
+function datamachine_migrate_stored_flow_legacy_handler_fields(): void {
+	global $wpdb;
+
+	$table_name = $wpdb->prefix . 'datamachine_flows';
+	if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) !== $table_name ) {
+		return;
+	}
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+	$flows = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT flow_id, flow_config FROM {$table_name}
+			WHERE flow_config LIKE %s
+			OR flow_config LIKE %s
+			OR flow_config LIKE %s",
+			'%' . $wpdb->esc_like( '"handler_slug"' ) . '%',
+			'%' . $wpdb->esc_like( '"handler_config"' ) . '%',
+			'%' . $wpdb->esc_like( '"handler"' ) . '%'
+		),
+		ARRAY_A
+	);
+	// phpcs:enable WordPress.DB.PreparedSQL
+
+	if ( empty( $flows ) ) {
+		return;
+	}
+
+	$updated = 0;
+	$failed  = 0;
+	$invalid = 0;
+
+	foreach ( $flows as $flow ) {
+		$flow_id     = (int) $flow['flow_id'];
+		$raw_config  = (string) $flow['flow_config'];
+		$flow_config = json_decode( $raw_config, true );
+
+		if ( ! is_array( $flow_config ) ) {
+			++$invalid;
+			continue;
+		}
+
+		$normalized = datamachine_normalize_stored_flow_legacy_handler_fields( $flow_config );
+		$encoded    = wp_json_encode( $normalized );
+
+		if ( false === $encoded || $encoded === $raw_config ) {
+			continue;
+		}
+
+		$result = $wpdb->update(
+			$table_name,
+			array( 'flow_config' => $encoded ),
+			array( 'flow_id' => $flow_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		if ( false === $result ) {
+			++$failed;
+			continue;
+		}
+
+		++$updated;
+	}
+
+	do_action(
+		'datamachine_log',
+		$failed > 0 || $invalid > 0 ? 'warning' : 'info',
+		'Migrated stored flow legacy handler fields',
+		array(
+			'scanned' => count( $flows ),
+			'updated' => $updated,
+			'failed'  => $failed,
+			'invalid' => $invalid,
+		)
+	);
+}
+
+/**
  * Re-schedule all flows with non-manual scheduling on plugin activation.
  *
  * Ensures scheduled flows resume after plugin reactivation.

--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -32,6 +32,7 @@ function datamachine_run_schema_migrations(): void {
 	datamachine_migrate_bundle_artifacts_table();
 	datamachine_migrate_processed_item_claims();
 	datamachine_migrate_pending_actions_table();
+	datamachine_migrate_stored_flow_legacy_handler_fields();
 }
 
 /**

--- a/tests/flow-step-legacy-handler-field-smoke.php
+++ b/tests/flow-step-legacy-handler-field-smoke.php
@@ -35,6 +35,7 @@ if ( ! function_exists( 'do_action' ) ) {
 }
 
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/migrations/flows.php';
 
 use DataMachine\Core\Steps\FlowStepConfig;
 
@@ -145,6 +146,30 @@ foreach ( $source_checks as $relative_path => $needles ) {
 		assert_not_contains( $needle, $source, "{$relative_path} does not contain {$needle}", $failures, $passes );
 	}
 }
+
+echo "\n[6] stored flow migration preserves legacy-only fetch handler config:\n";
+$stored_flow_config = array(
+	'fetch_10'       => array(
+		'flow_step_id'   => 'fetch_10',
+		'step_type'      => 'fetch',
+		'handler_slug'   => 'rss',
+		'handler_config' => array( 'url' => 'https://example.com/feed.xml' ),
+	),
+	'system_task_10' => array(
+		'flow_step_id'   => 'system_task_10',
+		'step_type'      => 'system_task',
+		'handler_config' => array( 'task' => 'ping' ),
+	),
+);
+$migrated_flow_config = datamachine_normalize_stored_flow_legacy_handler_fields( $stored_flow_config );
+$migrated_fetch       = $migrated_flow_config['fetch_10'];
+$migrated_task        = $migrated_flow_config['system_task_10'];
+assert_equals( array( 'rss' ), $migrated_fetch['handler_slugs'] ?? array(), 'legacy-only fetch slug migrates to canonical list', $failures, $passes );
+assert_equals( array( 'rss' => array( 'url' => 'https://example.com/feed.xml' ) ), $migrated_fetch['handler_configs'] ?? array(), 'legacy-only fetch config migrates to canonical map', $failures, $passes );
+assert_absent( 'handler_slug', $migrated_fetch, 'migrated fetch drops scalar slug', $failures, $passes );
+assert_absent( 'handler_config', $migrated_fetch, 'migrated fetch drops scalar config', $failures, $passes );
+assert_absent( 'handler_config', $migrated_task, 'handler-free stored step drops redundant scalar config', $failures, $passes );
+assert_absent( 'handler_slugs', $migrated_task, 'handler-free stored step has no canonical handler slugs', $failures, $passes );
 
 echo "\n-------------------------------------------\n";
 $total = $passes + count( $failures );

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -67,6 +67,7 @@ $schema_chain = array(
 	'datamachine_migrate_bundle_artifacts_table',
 	'datamachine_migrate_processed_item_claims',
 	'datamachine_migrate_pending_actions_table',
+	'datamachine_migrate_stored_flow_legacy_handler_fields',
 );
 
 foreach ( $schema_chain as $fn ) {


### PR DESCRIPTION
## Summary
- Add a deploy-time migration for stored `flow_config` JSON that still uses legacy scalar `handler`, `handler_slug`, or `handler_config` fields.
- Preserve handler-backed fetch settings by rewriting them into canonical `handler_slugs` / `handler_configs` before strict runtime readers drop fallback support.
- Strip redundant legacy handler fields from handler-free stored steps.

Closes #2103.

## Testing
- `php tests/flow-step-legacy-handler-field-smoke.php`
- `php tests/migration-runtime-smoke.php`
- `php -l inc/migrations/flows.php && php -l inc/migrations/runtime.php && php -l tests/flow-step-legacy-handler-field-smoke.php && php -l tests/migration-runtime-smoke.php`
- `./vendor/bin/phpcs inc/migrations/flows.php inc/migrations/runtime.php tests/migration-runtime-smoke.php tests/flow-step-legacy-handler-field-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Triage, drafting the stored-flow migration, adding targeted smoke coverage, and running validation. Chris remains responsible for review and validation.