### PR TITLE
Fix memory section writes with nested headings

### DIFF
--- a/inc/Abilities/AgentMemoryAbilities.php
+++ b/inc/Abilities/AgentMemoryAbilities.php
@@ -390,6 +390,42 @@ class AgentMemoryAbilities {
 	}
 
 	/**
+	 * Delete an agent file section.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result.
+	 */
+	public static function deleteMemorySection( array $input ): array {
+		$consent_decision = DataMachineAgentConsentPolicy::get()->can_store_memory(
+			array(
+				'mode'               => 'ability',
+				'interactive'        => true,
+				'permission_granted' => PermissionHelper::can_manage(),
+				'agent_id'           => (int) ( $input['agent_id'] ?? 0 ),
+				'user_id'            => (int) ( $input['user_id'] ?? 0 ),
+			)
+		);
+		if ( ! $consent_decision->is_allowed() ) {
+			return array(
+				'success'          => false,
+				'message'          => 'Memory delete consent denied.',
+				'consent_decision' => $consent_decision->to_array(),
+			);
+		}
+
+		$filename = $input['file'] ?? 'MEMORY.md';
+		if ( 'MEMORY.md' !== $filename && ! \DataMachine\Engine\AI\MemoryFileRegistry::is_editable( $filename ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'File %s is read-only and cannot be edited via section delete.', $filename ),
+			);
+		}
+
+		$memory = self::resolveMemory( $input );
+		return $memory->delete_section( (string) $input['section'] );
+	}
+
+	/**
 	 * Policy-constrained write to the current agent's own operational memory.
 	 *
 	 * @param array $input Input parameters.

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -363,6 +363,53 @@ class MemoryCommand extends BaseCommand {
 	}
 
 	/**
+	 * Delete a section from an agent file.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <file_or_section>
+	 * : Filename (e.g. SOUL.md) or section name (without ##).
+	 *   Arguments ending in .md are treated as filenames.
+	 *
+	 * [<section>]
+	 * : Section name when the first argument is a filename.
+	 *
+	 * [--agent=<slug>]
+	 * : Agent slug or numeric ID.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine memory delete "Old Notes"
+	 *     wp datamachine memory delete SOUL.md "Old Voice" --agent=studio
+	 *
+	 * @subcommand delete
+	 */
+	public function delete( array $args, array $assoc_args ): void {
+		$parsed = $this->parseFileAndSection( $args );
+		if ( null === $parsed['section'] ) {
+			WP_CLI::error( 'Usage: wp datamachine memory delete [<file.md>] <section>' );
+			return;
+		}
+
+		$input = array_merge(
+			$this->resolveMemoryScoping( $assoc_args ),
+			array( 'section' => $parsed['section'] )
+		);
+
+		if ( null !== $parsed['file'] ) {
+			$input['file'] = $parsed['file'];
+		}
+
+		$result = AgentMemoryAbilities::deleteMemorySection( $input );
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['message'] ?? 'Failed to delete section.' );
+			return;
+		}
+
+		WP_CLI::success( $result['message'] );
+	}
+
+	/**
 	 * Read content from stdin (php://stdin) and return as string.
 	 *
 	 * Returns an empty string if stdin yields nothing.

--- a/inc/Core/FilesRepository/AgentMemory.php
+++ b/inc/Core/FilesRepository/AgentMemory.php
@@ -32,6 +32,9 @@ defined( 'ABSPATH' ) || exit;
 
 class AgentMemory {
 
+	private const SECTION_BODY_START = '<!-- datamachine-section-body -->';
+	private const SECTION_BODY_END   = '<!-- /datamachine-section-body -->';
+
 	/**
 	 * Recommended maximum file size for agent memory files (8KB ≈ 2K tokens).
 	 *
@@ -377,11 +380,12 @@ class AgentMemory {
 		$current      = $this->store->read( $this->scope );
 		$file_content = $current->exists ? $current->content : '';
 		$section_pos  = $this->find_section_position( $file_content, $section_name );
+		$body         = $this->format_section_body( $content );
 
 		if ( null === $section_pos ) {
-			$file_content .= "\n## {$section_name}\n{$content}\n";
+			$file_content .= "\n## {$section_name}\n{$body}\n";
 		} else {
-			$file_content = $this->replace_section_content( $file_content, $section_pos, $content );
+			$file_content = $this->replace_section_content( $file_content, $section_pos, $body );
 		}
 
 		$write = $this->store->write( $this->scope, $file_content, $current->exists ? $current->hash : null );
@@ -426,11 +430,11 @@ class AgentMemory {
 		$section_pos  = $this->find_section_position( $file_content, $section_name );
 
 		if ( null === $section_pos ) {
-			$file_content .= "\n## {$section_name}\n{$content}\n";
+			$file_content .= "\n## {$section_name}\n" . $this->format_section_body( $content ) . "\n";
 		} else {
 			$existing     = $this->parse_section( $file_content, $section_name ) ?? '';
 			$merged       = rtrim( $existing ) . "\n" . $content . "\n";
-			$file_content = $this->replace_section_content( $file_content, $section_pos, $merged );
+			$file_content = $this->replace_section_content( $file_content, $section_pos, $this->format_section_body( $merged ) );
 		}
 
 		$write = $this->store->write( $this->scope, $file_content, $current->exists ? $current->hash : null );
@@ -456,6 +460,51 @@ class AgentMemory {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Delete a specific section and its body.
+	 *
+	 * @param string $section_name Section header text (without ##).
+	 * @return array{success: bool, message: string, file_size?: int}
+	 */
+	public function delete_section( string $section_name ): array {
+		$current = $this->store->read( $this->scope );
+
+		if ( ! $current->exists ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'File %s does not exist.', $this->scope->filename ),
+			);
+		}
+
+		$section_pos = $this->find_section_position( $current->content, $section_name );
+		if ( null === $section_pos ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Section "%s" not found.', $section_name ),
+			);
+		}
+
+		$file_content = substr( $current->content, 0, $section_pos['start'] ) . substr( $current->content, $section_pos['end'] );
+		$file_content = preg_replace( "/\n{3,}/", "\n\n", $file_content ) ?? $file_content;
+		$file_content = rtrim( $file_content ) . "\n";
+
+		$write = $this->store->write( $this->scope, $file_content, $current->hash );
+		if ( ! $write->success ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Failed to delete section "%s" (%s).', $section_name, $write->error ?? 'unknown' ),
+			);
+		}
+
+		$this->emit_updated_event( $file_content, $write );
+
+		return array(
+			'success'   => true,
+			'message'   => sprintf( 'Section "%s" deleted.', $section_name ),
+			'file_size' => $write->bytes,
+		);
 	}
 
 	/**
@@ -506,9 +555,21 @@ class AgentMemory {
 		$current_section = null;
 		$query_lower     = mb_strtolower( $query );
 		$line_count      = count( $lines );
+		$in_marked_body  = false;
 
 		foreach ( $lines as $index => $line ) {
-			if ( preg_match( '/^## (.+)$/', $line, $header_match ) ) {
+			$trimmed = trim( $line );
+			if ( self::SECTION_BODY_START === $trimmed ) {
+				$in_marked_body = true;
+				continue;
+			}
+
+			if ( self::SECTION_BODY_END === $trimmed ) {
+				$in_marked_body = false;
+				continue;
+			}
+
+			if ( ! $in_marked_body && preg_match( '/^## (.+)$/', $line, $header_match ) ) {
 				$current_section = trim( $header_match[1] );
 			}
 
@@ -550,10 +611,26 @@ class AgentMemory {
 	 * @return string[] List of section names.
 	 */
 	private function parse_section_headers( string $content ): array {
-		$sections = array();
-		if ( preg_match_all( '/^## (.+)$/m', $content, $matches ) ) {
-			$sections = array_map( 'trim', $matches[1] );
+		$sections       = array();
+		$in_marked_body = false;
+
+		foreach ( explode( "\n", $content ) as $line ) {
+			$trimmed = trim( $line );
+			if ( self::SECTION_BODY_START === $trimmed ) {
+				$in_marked_body = true;
+				continue;
+			}
+
+			if ( self::SECTION_BODY_END === $trimmed ) {
+				$in_marked_body = false;
+				continue;
+			}
+
+			if ( ! $in_marked_body && preg_match( '/^## (.+)$/', $line, $match ) ) {
+				$sections[] = trim( $match[1] );
+			}
 		}
+
 		return $sections;
 	}
 
@@ -565,14 +642,13 @@ class AgentMemory {
 	 * @return string|null Section body or null if not found.
 	 */
 	private function parse_section( string $content, string $section_name ): ?string {
-		$escaped = preg_quote( $section_name, '/' );
-		$pattern = '/^## ' . $escaped . '\s*\n(.*?)(?=\n## |\z)/ms';
-
-		if ( preg_match( $pattern, $content, $match ) ) {
-			return trim( $match[1] );
+		$section_pos = $this->find_section_position( $content, $section_name );
+		if ( null === $section_pos ) {
+			return null;
 		}
 
-		return null;
+		$body = substr( $content, $section_pos['header_end'], $section_pos['end'] - $section_pos['header_end'] );
+		return trim( $this->unwrap_section_body( $body ) );
 	}
 
 	/**
@@ -584,14 +660,27 @@ class AgentMemory {
 	 */
 	private function find_section_position( string $content, string $section_name ): ?array {
 		$escaped = preg_quote( $section_name, '/' );
-		$pattern = '/^(## ' . $escaped . '\s*\n)(.*?)(?=\n## |\z)/ms';
+		$pattern = '/(^|\n)(## ' . $escaped . '[ \t]*\n)/';
 
 		if ( preg_match( $pattern, $content, $match, PREG_OFFSET_CAPTURE ) ) {
-			$full_start  = $match[0][1];
-			$header      = $match[1][0];
+			$prefix      = $match[1][0];
+			$full_start  = $match[0][1] + strlen( $prefix );
+			$header      = $match[2][0];
 			$header_end  = $full_start + strlen( $header );
-			$body        = $match[2][0];
-			$section_end = $header_end + strlen( $body );
+			$body        = substr( $content, $header_end );
+			$section_end = strlen( $content );
+
+			if ( str_starts_with( $body, self::SECTION_BODY_START . "\n" ) ) {
+				$end_marker_pos = strpos( $body, "\n" . self::SECTION_BODY_END );
+				if ( false !== $end_marker_pos ) {
+					$section_end = $header_end + $end_marker_pos + 1 + strlen( self::SECTION_BODY_END );
+					if ( "\n" === substr( $content, $section_end, 1 ) ) {
+						++$section_end;
+					}
+				}
+			} elseif ( preg_match( '/\n## /', $body, $next_match, PREG_OFFSET_CAPTURE ) ) {
+				$section_end = $header_end + $next_match[0][1];
+			}
 
 			return array(
 				'start'      => $full_start,
@@ -616,6 +705,36 @@ class AgentMemory {
 		$after  = substr( $file_content, $position['end'] );
 
 		return $before . $new_content . "\n" . $after;
+	}
+
+	/**
+	 * Marker-wrap section bodies that contain top-level markdown headings.
+	 *
+	 * Plain markdown cannot otherwise distinguish a body `##` heading from the
+	 * next agent-memory section. The markers are stripped from section reads and
+	 * ignored by section listing.
+	 */
+	private function format_section_body( string $content ): string {
+		$content = rtrim( $content );
+		if ( ! preg_match( '/^## .+$/m', $content ) ) {
+			return $content;
+		}
+
+		return self::SECTION_BODY_START . "\n" . $content . "\n" . self::SECTION_BODY_END;
+	}
+
+	/**
+	 * Remove section body boundary markers from a parsed body.
+	 */
+	private function unwrap_section_body( string $body ): string {
+		$body = trim( $body );
+		if ( ! str_starts_with( $body, self::SECTION_BODY_START ) ) {
+			return $body;
+		}
+
+		$body = preg_replace( '/^' . preg_quote( self::SECTION_BODY_START, '/' ) . '\s*\n?/', '', $body ) ?? $body;
+		$body = preg_replace( '/\n?' . preg_quote( self::SECTION_BODY_END, '/' ) . '$/', '', $body ) ?? $body;
+		return $body;
 	}
 
 	/**

--- a/tests/agent-memory-events-smoke.php
+++ b/tests/agent-memory-events-smoke.php
@@ -70,6 +70,19 @@ if ( ! function_exists( 'size_format' ) ) {
 	}
 }
 
+if ( ! function_exists( 'untrailingslashit' ) ) {
+	function untrailingslashit( string $value ): string {
+		return rtrim( $value, '/' );
+	}
+}
+
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( string $_path = '/' ): string {
+		unset( $_path );
+		return '1';
+	}
+}
+
 if ( ! function_exists( 'post_type_exists' ) ) {
 	function post_type_exists( string $post_type ): bool {
 		return in_array( $post_type, $GLOBALS['datamachine_agent_memory_events_post_types'], true );
@@ -200,6 +213,7 @@ require_once __DIR__ . '/../inc/Engine/AI/MemoryFileRegistry.php';
 require_once __DIR__ . '/../inc/Core/FilesRepository/DirectoryManager.php';
 require_once __DIR__ . '/agents-api-loader.php';
 datamachine_tests_require_agents_api();
+require_once __DIR__ . '/../inc/Core/Workspace/WordPressWorkspaceScope.php';
 require_once __DIR__ . '/../inc/Core/FilesRepository/DiskAgentMemoryStore.php';
 require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemoryStoreFactory.php';
 require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemory.php';

--- a/tests/agent-memory-section-body-smoke.php
+++ b/tests/agent-memory-section-body-smoke.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Pure-PHP smoke test for opaque agent memory section bodies (#1978).
+ *
+ * Run with: php tests/agent-memory-section-body-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+
+$GLOBALS['datamachine_agent_memory_section_filters'] = array();
+
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ): int {
+		return abs( (int) $value );
+	}
+}
+
+if ( ! function_exists( 'sanitize_file_name' ) ) {
+	function sanitize_file_name( string $filename ): string {
+		return preg_replace( '/[^a-zA-Z0-9._\/\-]/', '', $filename );
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $value ): string {
+		$value = strtolower( $value );
+		$value = preg_replace( '/[^a-z0-9]+/', '-', $value );
+		return trim( (string) $value, '-' );
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( string $value ): string {
+		return rtrim( $value, '/' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'untrailingslashit' ) ) {
+	function untrailingslashit( string $value ): string {
+		return rtrim( $value, '/' );
+	}
+}
+
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( string $_path = '/' ): string {
+		unset( $_path );
+		return 'https://example.test';
+	}
+}
+
+if ( ! function_exists( 'wp_upload_dir' ) ) {
+	function wp_upload_dir(): array {
+		return array( 'basedir' => sys_get_temp_dir() );
+	}
+}
+
+if ( ! function_exists( 'is_multisite' ) ) {
+	function is_multisite(): bool {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'size_format' ) ) {
+	function size_format( int $bytes ): string {
+		return $bytes . ' B';
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['datamachine_agent_memory_section_filters'][ $hook ][ $priority ][] = array(
+			'callback'      => $callback,
+			'accepted_args' => $accepted_args,
+		);
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$filters = $GLOBALS['datamachine_agent_memory_section_filters'][ $hook ] ?? array();
+		ksort( $filters );
+
+		foreach ( $filters as $callbacks ) {
+			foreach ( $callbacks as $filter ) {
+				$value = $filter['callback']( ...array_slice( array_merge( array( $value ), $args ), 0, $filter['accepted_args'] ) );
+			}
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $_hook, ...$_args ): void {}
+}
+
+require_once __DIR__ . '/../inc/Engine/AI/MemoryFileRegistry.php';
+require_once __DIR__ . '/agents-api-loader.php';
+datamachine_tests_require_agents_api();
+require_once __DIR__ . '/../inc/Core/Workspace/WordPressWorkspaceScope.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/DirectoryManager.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/DiskAgentMemoryStore.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemoryStoreFactory.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemory.php';
+
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_List_Entry;
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Metadata;
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Query;
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Read_Result;
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Scope;
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Store;
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Store_Capabilities;
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Write_Result;
+use DataMachine\Core\FilesRepository\AgentMemory;
+
+class AgentMemorySectionBodyFakeStore implements WP_Agent_Memory_Store {
+
+	/** @var array<string, string> */
+	public array $files = array();
+
+	public function capabilities(): WP_Agent_Memory_Store_Capabilities {
+		return WP_Agent_Memory_Store_Capabilities::none();
+	}
+
+	public function read( WP_Agent_Memory_Scope $scope, array $metadata_fields = WP_Agent_Memory_Metadata::FIELDS ): WP_Agent_Memory_Read_Result {
+		if ( ! array_key_exists( $scope->key(), $this->files ) ) {
+			return WP_Agent_Memory_Read_Result::not_found();
+		}
+
+		$content = $this->files[ $scope->key() ];
+		return new WP_Agent_Memory_Read_Result( true, $content, sha1( $content ), strlen( $content ), 123, null, $metadata_fields );
+	}
+
+	public function write( WP_Agent_Memory_Scope $scope, string $content, ?string $if_match = null, ?WP_Agent_Memory_Metadata $metadata = null ): WP_Agent_Memory_Write_Result {
+		unset( $metadata );
+		$current = $this->read( $scope );
+		if ( null !== $if_match && $current->hash !== $if_match ) {
+			return WP_Agent_Memory_Write_Result::failure( 'conflict' );
+		}
+
+		$this->files[ $scope->key() ] = $content;
+		return WP_Agent_Memory_Write_Result::ok( sha1( $content ), strlen( $content ) );
+	}
+
+	public function exists( WP_Agent_Memory_Scope $scope ): bool {
+		return array_key_exists( $scope->key(), $this->files );
+	}
+
+	public function delete( WP_Agent_Memory_Scope $scope ): WP_Agent_Memory_Write_Result {
+		unset( $this->files[ $scope->key() ] );
+		return WP_Agent_Memory_Write_Result::ok( '', 0 );
+	}
+
+	public function list_layer( WP_Agent_Memory_Scope $_scope_query, ?WP_Agent_Memory_Query $query = null ): array {
+		unset( $_scope_query, $query );
+		return array();
+	}
+
+	public function list_subtree( WP_Agent_Memory_Scope $_scope_query, string $_prefix, ?WP_Agent_Memory_Query $query = null ): array {
+		unset( $_scope_query, $_prefix, $query );
+		return array();
+	}
+}
+
+function datamachine_agent_memory_section_assert( bool $condition, string $message ): void {
+	static $assertions = 0;
+	++$assertions;
+
+	if ( ! $condition ) {
+		fwrite( STDERR, "Assertion failed: {$message}\n" );
+		exit( 1 );
+	}
+
+	echo "ok {$assertions} - {$message}\n";
+}
+
+$store = new AgentMemorySectionBodyFakeStore();
+add_filter(
+	'agents_api_memory_store',
+	function ( $_default, WP_Agent_Memory_Scope $_scope ) use ( $store ) {
+		unset( $_default, $_scope );
+		return $store;
+	},
+	10,
+	2
+);
+
+$memory = new AgentMemory( 7, 42, 'MEMORY.md', 'agent' );
+$body   = "Overview line\n\n## Stack\n- WordPress\n\n## Network options\n- Multisite";
+
+$memory->replace_all( "# MEMORY.md\n" );
+
+$write = $memory->set_section( 'Transcribe Pipeline', $body );
+datamachine_agent_memory_section_assert( true === $write['success'], 'section write with nested headings succeeds' );
+
+$sections = $memory->get_sections();
+datamachine_agent_memory_section_assert( array( 'Transcribe Pipeline' ) === $sections['sections'], 'nested body headings are not listed as sections' );
+
+$read = $memory->get_section( 'Transcribe Pipeline' );
+datamachine_agent_memory_section_assert( true === $read['success'], 'section read succeeds' );
+datamachine_agent_memory_section_assert( $body === $read['content'], 'section read returns literal nested headings without markers' );
+
+$append = $memory->append_to_section( 'Transcribe Pipeline', "\n## Runtime\n- CLI" );
+datamachine_agent_memory_section_assert( true === $append['success'], 'append with nested heading succeeds' );
+
+$appended = $memory->get_section( 'Transcribe Pipeline' );
+datamachine_agent_memory_section_assert( str_contains( $appended['content'], '## Runtime' ), 'append preserves nested heading as body content' );
+
+$search = $memory->search( 'CLI' );
+datamachine_agent_memory_section_assert( true === $search['success'], 'search succeeds' );
+datamachine_agent_memory_section_assert( 'Transcribe Pipeline' === $search['matches'][0]['section'], 'search keeps matches in parent section' );
+
+$delete = $memory->delete_section( 'Transcribe Pipeline' );
+datamachine_agent_memory_section_assert( true === $delete['success'], 'section delete succeeds' );
+
+$after_delete = $memory->get_sections();
+datamachine_agent_memory_section_assert( array() === $after_delete['sections'], 'section delete removes the heading and body' );
+
+echo "agent-memory-section-body-smoke complete\n";


### PR DESCRIPTION
## Summary
- Preserve literal `##` headings in `wp datamachine memory write` section bodies by treating marker-wrapped section bodies as opaque content.
- Add `wp datamachine memory delete [<file.md>] <section>` for removing stale/zombie sections.
- Add a focused smoke test for nested section headings, append, search attribution, and section deletion.

Closes #1978.

## Testing
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-memory-write-section-delete --extension wordpress --changed-since origin/main`
- `php tests/agent-memory-section-body-smoke.php && php tests/agent-memory-events-smoke.php && php tests/agents-api-memory-store-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the memory section parser/write/delete changes and drafted focused smoke coverage; Chris remains responsible for review and testing.