### PR TITLE
Surface agentless flow ownership drift

### DIFF
--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -16,6 +16,8 @@ use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Engine\AI\RequestBuilder;
 use AgentsAPI\AI\WP_Agent_Message;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\Tasks\RecurringScheduler;
 use DataMachine\Engine\Tasks\TaskScheduler;
@@ -161,6 +163,11 @@ class SystemAbilities {
 				'callback' => array( $this, 'runSchedulerDiagnostics' ),
 				'default'  => true,
 			),
+			'ownership' => array(
+				'label'    => __( 'Agent Ownership', 'data-machine' ),
+				'callback' => array( $this, 'runOwnershipDiagnostics' ),
+				'default'  => true,
+			),
 		);
 
 		return apply_filters( 'datamachine_system_health_checks', $checks );
@@ -285,6 +292,32 @@ class SystemAbilities {
 			),
 			'recommendation'          => 'stale' === $status
 				? __( 'For local or low-traffic installs, schedule an external wake-up such as wp cron event run --due-now or wp datamachine drain.', 'data-machine' )
+				: null,
+		);
+	}
+
+	/**
+	 * Report rows that still execute through legacy agent-less ownership paths.
+	 *
+	 * @param array $options Optional check options.
+	 * @return array Ownership diagnostic results.
+	 */
+	private function runOwnershipDiagnostics( array $options = array() ): array {
+		unset( $options );
+
+		$pipeline_count = ( new Pipelines() )->count_by_agent_id( null );
+		$flow_count     = ( new Flows() )->count_by_agent_id( null );
+		$status         = ( $pipeline_count > 0 || $flow_count > 0 ) ? 'warning' : 'ok';
+
+		return array(
+			'status'            => $status,
+			'message'           => 'ok' === $status
+				? __( 'all pipelines and flows have agent ownership', 'data-machine' )
+				: __( 'unowned pipelines or flows can run outside the agent ownership envelope', 'data-machine' ),
+			'unowned_pipelines' => $pipeline_count,
+			'unowned_flows'     => $flow_count,
+			'recommendation'    => 'warning' === $status
+				? __( 'Inspect with wp datamachine pipelines orphans and wp datamachine flows orphans, then reassign with --where-null.', 'data-machine' )
 				: null,
 		);
 	}

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -313,6 +313,12 @@ class FlowsCommand extends BaseCommand {
 			return;
 		}
 
+		// Handle 'orphans' subcommand.
+		if ( ! empty( $args ) && 'orphans' === $args[0] ) {
+			$this->listOrphanedFlows( $assoc_args );
+			return;
+		}
+
 		// Handle 'migrate-legacy-handler-shape' subcommand.
 		if ( ! empty( $args ) && 'migrate-legacy-handler-shape' === $args[0] ) {
 			$this->migrateLegacyHandlerShape( $assoc_args );
@@ -2042,6 +2048,52 @@ class FlowsCommand extends BaseCommand {
 			$source_label,
 			$to_agent_id
 		) );
+	}
+
+	/**
+	 * List flows with NULL agent_id without mutating data.
+	 *
+	 * @param array $assoc_args Associative arguments.
+	 */
+	private function listOrphanedFlows( array $assoc_args ): void {
+		$limit  = max( 1, min( 100, (int) ( $assoc_args['limit'] ?? 20 ) ) );
+		$offset = max( 0, (int) ( $assoc_args['offset'] ?? 0 ) );
+		$format = $assoc_args['format'] ?? 'table';
+
+		$flows_repo = new \DataMachine\Core\Database\Flows\Flows();
+		$rows       = $flows_repo->get_orphaned_flows( $limit, $offset );
+		$total      = $flows_repo->count_by_agent_id( null );
+
+		$items = array_map(
+			static function ( array $flow ): array {
+				return array(
+					'id'            => (int) ( $flow['flow_id'] ?? 0 ),
+					'name'          => (string) ( $flow['flow_name'] ?? '' ),
+					'pipeline_id'   => (int) ( $flow['pipeline_id'] ?? 0 ),
+					'user_id'       => (int) ( $flow['user_id'] ?? 0 ),
+					'portable_slug' => (string) ( $flow['portable_slug'] ?? '' ),
+					'created'       => (string) ( $flow['created_at'] ?? '' ),
+				);
+			},
+			$rows
+		);
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( array(
+				'total' => $total,
+				'flows' => $items,
+			), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		if ( empty( $items ) ) {
+			WP_CLI::success( 'No orphaned flows found.' );
+			return;
+		}
+
+		WP_CLI::warning( sprintf( 'Found %d orphaned flow(s) with agent_id=NULL.', $total ) );
+		\WP_CLI\Utils\format_items( 'table', $items, array( 'id', 'name', 'pipeline_id', 'user_id', 'portable_slug', 'created' ) );
+		WP_CLI::log( 'Repair with: wp datamachine flows reassign --where-null --to-agent=<agent> --dry-run' );
 	}
 
 	/**

--- a/inc/Cli/Commands/PipelinesCommand.php
+++ b/inc/Cli/Commands/PipelinesCommand.php
@@ -235,6 +235,12 @@ class PipelinesCommand extends BaseCommand {
 			return;
 		}
 
+		// Handle 'orphans' subcommand.
+		if ( ! empty( $args ) && 'orphans' === $args[0] ) {
+			$this->listOrphanedPipelines( $assoc_args );
+			return;
+		}
+
 		// Handle 'memory-files' subcommand.
 		if ( ! empty( $args ) && 'memory-files' === $args[0] ) {
 			if ( ! isset( $args[1] ) ) {
@@ -1086,5 +1092,50 @@ class PipelinesCommand extends BaseCommand {
 			$source_label,
 			$to_agent_id
 		) );
+	}
+
+	/**
+	 * List pipelines with NULL agent_id without mutating data.
+	 *
+	 * @param array $assoc_args Associative arguments.
+	 */
+	private function listOrphanedPipelines( array $assoc_args ): void {
+		$limit  = max( 1, min( 100, (int) ( $assoc_args['limit'] ?? 20 ) ) );
+		$offset = max( 0, (int) ( $assoc_args['offset'] ?? 0 ) );
+		$format = $assoc_args['format'] ?? 'table';
+
+		$pipelines_repo = new \DataMachine\Core\Database\Pipelines\Pipelines();
+		$rows           = $pipelines_repo->get_orphaned_pipelines( $limit, $offset );
+		$total          = $pipelines_repo->count_by_agent_id( null );
+
+		$items = array_map(
+			static function ( array $pipeline ): array {
+				return array(
+					'id'            => (int) ( $pipeline['pipeline_id'] ?? 0 ),
+					'name'          => (string) ( $pipeline['pipeline_name'] ?? '' ),
+					'user_id'       => (int) ( $pipeline['user_id'] ?? 0 ),
+					'portable_slug' => (string) ( $pipeline['portable_slug'] ?? '' ),
+					'updated'       => (string) ( $pipeline['updated_at'] ?? '' ),
+				);
+			},
+			$rows
+		);
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( array(
+				'total'     => $total,
+				'pipelines' => $items,
+			), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		if ( empty( $items ) ) {
+			WP_CLI::success( 'No orphaned pipelines found.' );
+			return;
+		}
+
+		WP_CLI::warning( sprintf( 'Found %d orphaned pipeline(s) with agent_id=NULL.', $total ) );
+		\WP_CLI\Utils\format_items( 'table', $items, array( 'id', 'name', 'user_id', 'portable_slug', 'updated' ) );
+		WP_CLI::log( 'Repair with: wp datamachine pipelines reassign --where-null --to-agent=<agent> --dry-run' );
 	}
 }

--- a/inc/Cli/Commands/SystemCommand.php
+++ b/inc/Cli/Commands/SystemCommand.php
@@ -131,6 +131,10 @@ class SystemCommand extends BaseCommand {
 					WP_CLI::log( sprintf( '  Daily memory:   last attempted %s GMT', $daily_memory['last_attempt_gmt'] ) );
 				}
 			}
+			if ( isset( $check_result['unowned_pipelines'] ) || isset( $check_result['unowned_flows'] ) ) {
+				WP_CLI::log( sprintf( '  Unowned pipelines: %d', (int) ( $check_result['unowned_pipelines'] ?? 0 ) ) );
+				WP_CLI::log( sprintf( '  Unowned flows:     %d', (int) ( $check_result['unowned_flows'] ?? 0 ) ) );
+			}
 			if ( ! empty( $check_result['recommendation'] ) ) {
 				WP_CLI::log( sprintf( '  Recommendation: %s', $check_result['recommendation'] ) );
 			}

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -1295,6 +1295,32 @@ class Flows extends BaseRepository {
 	}
 
 	/**
+	 * List flows with no agent owner.
+	 *
+	 * @param int $limit  Maximum rows to return.
+	 * @param int $offset SQL offset.
+	 * @return array<int, array<string, mixed>> Orphaned flow rows.
+	 */
+	public function get_orphaned_flows( int $limit = 20, int $offset = 0 ): array {
+		$limit  = max( 1, min( 100, $limit ) );
+		$offset = max( 0, $offset );
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Table name uses %i and limit/offset are prepared integers.
+		$results = $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				'SELECT flow_id, flow_name, pipeline_id, user_id, portable_slug, created_at FROM %i WHERE agent_id IS NULL ORDER BY pipeline_id ASC, flow_id ASC LIMIT %d OFFSET %d',
+				$this->table_name,
+				$limit,
+				$offset
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+
+		return is_array( $results ) ? $results : array();
+	}
+
+	/**
 	 * Bulk-reassign agent_id on flows belonging to a specific pipeline.
 	 *
 	 * Used for cascade: when a pipeline's agent_id changes, its child flows follow.

--- a/inc/Core/Database/Pipelines/Pipelines.php
+++ b/inc/Core/Database/Pipelines/Pipelines.php
@@ -886,4 +886,30 @@ class Pipelines extends BaseRepository {
 
 		return (int) $count;
 	}
+
+	/**
+	 * List pipelines with no agent owner.
+	 *
+	 * @param int $limit  Maximum rows to return.
+	 * @param int $offset SQL offset.
+	 * @return array<int, array<string, mixed>> Orphaned pipeline rows.
+	 */
+	public function get_orphaned_pipelines( int $limit = 20, int $offset = 0 ): array {
+		$limit  = max( 1, min( 100, $limit ) );
+		$offset = max( 0, $offset );
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Table name uses %i and limit/offset are prepared integers.
+		$results = $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				'SELECT pipeline_id, pipeline_name, user_id, portable_slug, created_at, updated_at FROM %i WHERE agent_id IS NULL ORDER BY updated_at DESC LIMIT %d OFFSET %d',
+				$this->table_name,
+				$limit,
+				$offset
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+
+		return is_array( $results ) ? $results : array();
+	}
 }

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -405,6 +405,7 @@ class AIStep extends Step {
 			}
 			if ( $owner_id <= 0 && $user_id > 0 ) {
 				// Legacy / agent-less flows: fall back to the flow's user_id.
+				$this->logAgentlessFallback( $job_snapshot, $user_id, $pipeline_step_id );
 				$owner_id = $user_id;
 			}
 
@@ -746,6 +747,29 @@ class AIStep extends Step {
 		} catch ( \InvalidArgumentException $e ) {
 			return (int) ( $job_snapshot['agent_id'] ?? 0 );
 		}
+	}
+
+	/**
+	 * Log when execution falls back to a user without an agent context.
+	 *
+	 * @param array  $job_snapshot     Portable job snapshot from engine data.
+	 * @param int    $fallback_user_id User ID used for the legacy fallback.
+	 * @param string $pipeline_step_id Pipeline step currently executing.
+	 */
+	private function logAgentlessFallback( array $job_snapshot, int $fallback_user_id, string $pipeline_step_id ): void {
+		do_action(
+			'datamachine_log',
+			'warning',
+			'AIStep: Agent-less job snapshot fell back to flow user_id; execution is outside the agent ownership envelope.',
+			array(
+				'job_id'           => $this->job_id,
+				'flow_id'          => (int) ( $job_snapshot['flow_id'] ?? 0 ),
+				'pipeline_id'      => (int) ( $job_snapshot['pipeline_id'] ?? 0 ),
+				'flow_step_id'     => $this->flow_step_id,
+				'pipeline_step_id' => $pipeline_step_id,
+				'fallback_user_id' => $fallback_user_id,
+			)
+		);
 	}
 
 	/**

--- a/inc/Core/Steps/SystemTask/SystemTaskStep.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskStep.php
@@ -322,6 +322,7 @@ class SystemTaskStep extends Step {
 		}
 		if ( $owner_id <= 0 && $parent_user_id > 0 ) {
 			// Legacy / agent-less flows: fall back to the flow's user_id.
+			$this->logAgentlessFallback( $parent_job_snapshot, $parent_user_id, (int) $child_job_id );
 			$owner_id = $parent_user_id;
 		}
 
@@ -481,5 +482,28 @@ class SystemTaskStep extends Step {
 	private static function getConfiguredTaskType( array $settings ): string {
 		$task_type = $settings['task_type'] ?? '';
 		return is_string( $task_type ) ? $task_type : '';
+	}
+
+	/**
+	 * Log when a system task runs via the legacy user fallback without agent context.
+	 *
+	 * @param array $parent_job_snapshot Parent job snapshot from engine data.
+	 * @param int   $fallback_user_id    User ID used for the fallback.
+	 * @param int   $child_job_id        Child job created for the system task.
+	 */
+	private function logAgentlessFallback( array $parent_job_snapshot, int $fallback_user_id, int $child_job_id ): void {
+		do_action(
+			'datamachine_log',
+			'warning',
+			'SystemTaskStep: Agent-less parent job snapshot fell back to flow user_id; execution is outside the agent ownership envelope.',
+			array(
+				'parent_job_id'    => $this->job_id,
+				'child_job_id'     => $child_job_id,
+				'flow_id'          => (int) ( $parent_job_snapshot['flow_id'] ?? 0 ),
+				'pipeline_id'      => (int) ( $parent_job_snapshot['pipeline_id'] ?? 0 ),
+				'flow_step_id'     => $this->flow_step_id,
+				'fallback_user_id' => $fallback_user_id,
+			)
+		);
 	}
 }

--- a/tests/pipeline-flow-reassign-agent-smoke.php
+++ b/tests/pipeline-flow-reassign-agent-smoke.php
@@ -65,6 +65,13 @@ smoke_assert(
 	$passes
 );
 
+smoke_assert(
+	str_contains( $pipelines_src, 'public function get_orphaned_pipelines( int $limit = 20, int $offset = 0 ): array' ),
+	'Pipelines::get_orphaned_pipelines() read-only listing method exists',
+	$failures,
+	$passes
+);
+
 // reassign_agent_id handles NULL source
 smoke_assert(
 	str_contains( $pipelines_src, 'WHERE agent_id IS NULL' ),
@@ -104,6 +111,13 @@ smoke_assert(
 	$passes
 );
 
+smoke_assert(
+	str_contains( $flows_src, 'public function get_orphaned_flows( int $limit = 20, int $offset = 0 ): array' ),
+	'Flows::get_orphaned_flows() read-only listing method exists',
+	$failures,
+	$passes
+);
+
 // reassign_agent_id_for_pipeline method exists
 smoke_assert(
 	str_contains( $flows_src, 'public function reassign_agent_id_for_pipeline( int $pipeline_id, ?int $from_agent_id, int $to_agent_id ): int' ),
@@ -131,6 +145,15 @@ smoke_assert(
 smoke_assert(
 	str_contains( $pipelines_cmd_src, 'private function reassignPipelines(' ),
 	'PipelinesCommand::reassignPipelines() method exists',
+	$failures,
+	$passes
+);
+
+smoke_assert(
+	str_contains( $pipelines_cmd_src, "'orphans' === \$args[0]" )
+	&& str_contains( $pipelines_cmd_src, 'private function listOrphanedPipelines(' )
+	&& str_contains( $pipelines_cmd_src, 'get_orphaned_pipelines' ),
+	'PipelinesCommand exposes read-only orphans subcommand',
 	$failures,
 	$passes
 );
@@ -195,6 +218,15 @@ smoke_assert(
 smoke_assert(
 	str_contains( $flows_cmd_src, 'private function reassignFlows(' ),
 	'FlowsCommand::reassignFlows() method exists',
+	$failures,
+	$passes
+);
+
+smoke_assert(
+	str_contains( $flows_cmd_src, "'orphans' === \$args[0]" )
+	&& str_contains( $flows_cmd_src, 'private function listOrphanedFlows(' )
+	&& str_contains( $flows_cmd_src, 'get_orphaned_flows' ),
+	'FlowsCommand exposes read-only orphans subcommand',
 	$failures,
 	$passes
 );
@@ -264,6 +296,45 @@ smoke_assert(
 smoke_assert(
 	! str_contains( $post_tracking_src, 'is not mutated by update_flow' ),
 	'PostTracking no longer claims agent_id is immutable',
+	$failures,
+	$passes
+);
+
+// ── 8. Agent-less fallback observability ───────────────────────────────
+
+echo "\n--- Agent-less fallback observability ---\n";
+
+$ai_step_file = __DIR__ . '/../inc/Core/Steps/AI/AIStep.php';
+$ai_step_src  = file_get_contents( $ai_step_file );
+
+smoke_assert(
+	str_contains( $ai_step_src, 'function logAgentlessFallback' )
+	&& str_contains( $ai_step_src, 'Agent-less job snapshot fell back to flow user_id' ),
+	'AIStep logs legacy agent-less fallback',
+	$failures,
+	$passes
+);
+
+$system_task_step_file = __DIR__ . '/../inc/Core/Steps/SystemTask/SystemTaskStep.php';
+$system_task_step_src  = file_get_contents( $system_task_step_file );
+
+smoke_assert(
+	str_contains( $system_task_step_src, 'function logAgentlessFallback' )
+	&& str_contains( $system_task_step_src, 'Agent-less parent job snapshot fell back to flow user_id' ),
+	'SystemTaskStep logs legacy agent-less fallback',
+	$failures,
+	$passes
+);
+
+$system_abilities_file = __DIR__ . '/../inc/Abilities/SystemAbilities.php';
+$system_abilities_src  = file_get_contents( $system_abilities_file );
+
+smoke_assert(
+	str_contains( $system_abilities_src, "'ownership' => array(" )
+	&& str_contains( $system_abilities_src, 'runOwnershipDiagnostics' )
+	&& str_contains( $system_abilities_src, 'unowned_pipelines' )
+	&& str_contains( $system_abilities_src, 'unowned_flows' ),
+	'System health includes agent ownership diagnostics',
 	$failures,
 	$passes
 );


### PR DESCRIPTION
## Summary
- Log warnings when AI and system task execution fall back to `user_id` without an agent context.
- Add read-only orphan listing commands for pipelines and flows with `agent_id = NULL`.
- Include agent ownership coverage in `wp datamachine system health`.

Closes #2063.

## Testing
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-agentless-flow-observability --extension wordpress --changed-since origin/main`
- `./vendor/bin/phpcs --standard=phpcs.xml.dist inc/Core/Database/Pipelines/Pipelines.php inc/Core/Database/Flows/Flows.php inc/Core/Steps/AI/AIStep.php inc/Core/Steps/SystemTask/SystemTaskStep.php inc/Cli/Commands/PipelinesCommand.php inc/Cli/Commands/Flows/FlowsCommand.php inc/Abilities/SystemAbilities.php inc/Cli/Commands/SystemCommand.php tests/pipeline-flow-reassign-agent-smoke.php`
- `php tests/pipeline-flow-reassign-agent-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the observability/CLI diagnostics path and expanded smoke coverage; Chris remains responsible for review and testing.