### PR TITLE
Fix duplicate bundle and OAuth helper findings

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -14,6 +14,7 @@ use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
 use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
+use DataMachine\Engine\Bundle\AgentBundleAgentConfig;
 use DataMachine\Engine\Bundle\AgentBundleArtifactRebase;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
@@ -747,7 +748,7 @@ class AgentBundleCommand extends BaseCommand {
 			'artifact_type' => 'agent_config',
 			'artifact_id'   => 'config',
 			'source_path'   => 'manifest.json#/agent/agent_config',
-			'payload'       => self::tracked_agent_config_payload( $incoming_config ),
+			'payload'       => AgentBundleAgentConfig::tracked_payload( $incoming_config ),
 		);
 
 		if ( $agent_id > 0 ) {
@@ -825,7 +826,7 @@ class AgentBundleCommand extends BaseCommand {
 			'artifact_type' => 'agent_config',
 			'artifact_id'   => 'config',
 			'source_path'   => 'manifest.json#/agent/agent_config',
-			'payload'       => self::tracked_agent_config_payload( is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array() ),
+			'payload'       => AgentBundleAgentConfig::tracked_payload( is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array() ),
 		);
 
 		$pipeline_by_slug = array();
@@ -917,22 +918,6 @@ class AgentBundleCommand extends BaseCommand {
 		unset( $step );
 
 		return $flow_config;
-	}
-
-	/**
-	 * Return the bundle-owned agent config payload tracked by package upgrades.
-	 *
-	 * The installer maintains `datamachine_bundle` bookkeeping under agent_config;
-	 * that metadata is not authored by bundles and must not participate in local
-	 * config drift checks.
-	 *
-	 * @param array<string,mixed> $config Agent config.
-	 * @return array<string,mixed>
-	 */
-	private static function tracked_agent_config_payload( array $config ): array {
-		unset( $config['datamachine_bundle'] );
-		ksort( $config, SORT_STRING );
-		return $config;
 	}
 
 	private function resolve_bundle_agent( array $bundle, string $slug = '' ): ?array {

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -21,6 +21,7 @@ use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Api\Flows\FlowScheduling;
 use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
 use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
+use DataMachine\Engine\Bundle\AgentBundleAgentConfig;
 use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
 use DataMachine\Engine\Bundle\BundleStepIdRemapper;
 use DataMachine\Engine\Bundle\AgentBundleDirectory;
@@ -631,8 +632,8 @@ class AgentBundler {
 			$artifact_records               = is_array( $existing_bundle_state['artifacts'] ?? null ) ? $existing_bundle_state['artifacts'] : array();
 			$config_conflicts               = array();
 			$agent_config_key               = self::artifact_key( 'agent_config', 'config' );
-			$incoming_config_payload        = self::tracked_agent_config_payload( $incoming_config );
-			$current_config_payload         = self::tracked_agent_config_payload( is_array( $existing['agent_config'] ?? null ) ? $existing['agent_config'] : array() );
+			$incoming_config_payload        = AgentBundleAgentConfig::tracked_payload( $incoming_config );
+			$current_config_payload         = AgentBundleAgentConfig::tracked_payload( is_array( $existing['agent_config'] ?? null ) ? $existing['agent_config'] : array() );
 			$agent_config_record            = $artifact_records[ $agent_config_key ] ?? null;
 			$agent_config_has_local_changes = $existing && (
 				$this->artifact_has_local_modifications( is_array( $agent_config_record ) ? $agent_config_record : null, $current_config_payload )
@@ -1331,22 +1332,6 @@ class AgentBundler {
 
 	private static function artifact_key( string $type, string $id ): string {
 		return AgentBundleArtifactExtensions::artifact_key( $type, $id );
-	}
-
-	/**
-	 * Return the bundle-owned agent config payload tracked by package upgrades.
-	 *
-	 * Data Machine writes installation bookkeeping under `datamachine_bundle` at
-	 * runtime. That metadata is not authored by bundles, so excluding it keeps
-	 * agent config conflict detection focused on operator/bundle-owned settings.
-	 *
-	 * @param array<string,mixed> $config Agent config.
-	 * @return array<string,mixed>
-	 */
-	private static function tracked_agent_config_payload( array $config ): array {
-		unset( $config['datamachine_bundle'] );
-		ksort( $config, SORT_STRING );
-		return $config;
 	}
 
 	private function preserve_runtime_queue_fields( array $incoming_flow_config, array $existing_flow_config ): array {

--- a/inc/Engine/Bundle/AgentBundleAgentConfig.php
+++ b/inc/Engine/Bundle/AgentBundleAgentConfig.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Agent bundle agent-config helpers.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalizes agent config for bundle artifact comparisons.
+ */
+final class AgentBundleAgentConfig {
+
+	/**
+	 * Return the bundle-owned agent config payload tracked by package upgrades.
+	 *
+	 * Data Machine writes installation bookkeeping under `datamachine_bundle` at
+	 * runtime. That metadata is not authored by bundles, so excluding it keeps
+	 * agent config drift checks focused on operator/bundle-owned settings.
+	 *
+	 * @param array<string,mixed> $config Agent config.
+	 * @return array<string,mixed>
+	 */
+	public static function tracked_payload( array $config ): array {
+		unset( $config['datamachine_bundle'] );
+		ksort( $config, SORT_STRING );
+		return $config;
+	}
+}

--- a/tests/Unit/Core/OAuth/OAuth2HandlerStateTest.php
+++ b/tests/Unit/Core/OAuth/OAuth2HandlerStateTest.php
@@ -52,7 +52,7 @@ class OAuth2HandlerStateTest extends WP_UnitTestCase {
 	public function test_create_state_stores_structured_record_in_transient(): void {
 		$state = $this->handler->create_state( 'test_provider', array( 'key' => 'value' ) );
 
-		$record = get_transient( $this->state_transient_key( 'test_provider', $state ) );
+		$record = get_transient( $this->get_state_transient_key( 'test_provider', $state ) );
 
 		$this->assertIsArray( $record );
 		$this->assertArrayHasKey( 'nonce', $record );
@@ -64,7 +64,7 @@ class OAuth2HandlerStateTest extends WP_UnitTestCase {
 	public function test_create_state_without_payload_stores_empty_array(): void {
 		$state = $this->handler->create_state( 'test_provider' );
 
-		$record = get_transient( $this->state_transient_key( 'test_provider', $state ) );
+		$record = get_transient( $this->get_state_transient_key( 'test_provider', $state ) );
 
 		$this->assertIsArray( $record );
 		$this->assertSame( array(), $record['payload'] );
@@ -209,7 +209,7 @@ class OAuth2HandlerStateTest extends WP_UnitTestCase {
 		$state = $this->handler->create_state( 'test_expired' );
 
 		// Simulate expiration by deleting the transient.
-		delete_transient( $this->state_transient_key( 'test_expired', $state ) );
+		delete_transient( $this->get_state_transient_key( 'test_expired', $state ) );
 
 		$result = $this->handler->verify_state( 'test_expired', $state );
 
@@ -259,7 +259,8 @@ class OAuth2HandlerStateTest extends WP_UnitTestCase {
 		$this->assertSame( 4096, OAuth2Handler::MAX_PAYLOAD_SIZE );
 	}
 
-	private function state_transient_key( string $provider_key, string $state ): string {
-		return "datamachine_{$provider_key}_oauth_state_" . substr( hash( 'sha256', $state ), 0, 24 );
+	private function get_state_transient_key( string $provider_key, string $state ): string {
+		$method = new \ReflectionMethod( $this->handler, 'state_transient_key' );
+		return (string) $method->invoke( $this->handler, $provider_key, $state );
 	}
 }


### PR DESCRIPTION
## Summary
- Extract bundle agent-config artifact normalization into `AgentBundleAgentConfig::tracked_payload()` and reuse it from both bundle import/export paths.
- Update the OAuth state test to call the handler's private transient-key helper through reflection instead of copying the implementation into the test.
- Clears the duplicate-function audit finding in #1996 without treating it as a Homeboy false positive.

Closes #1996.

## Testing
- `homeboy audit --path /Users/chubes/Developer/data-machine@fix-audit-duplicate-functions --extension wordpress --changed-since origin/main`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-audit-duplicate-functions --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-audit-duplicate-functions --extension wordpress --changed-since origin/main`
- `php tests/datamachine-package-artifacts-smoke.php && php tests/export-agent-ability-smoke.php`
- `git diff --check`

## Notes
- Directly running `php tests/agent-bundle-portable-update-smoke.php` in the raw shell still hits a pre-existing legacy `handler_slug` fixture error; the Homeboy WordPress Playground test selection passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the audit finding, implemented the shared helper, adjusted the OAuth test, and ran validation; Chris remains responsible for review and testing.