### PR TITLE
feat: expose composable section provenance

### DIFF
--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -1164,11 +1164,15 @@ class MemoryCommand extends BaseCommand {
 
 			foreach ( $sections as $slug => $section ) {
 				$items[] = array(
-					'file'        => $filename,
-					'slug'        => $slug,
-					'priority'    => $section['priority'],
-					'label'       => $section['label'],
-					'description' => $section['description'],
+					'file'            => $filename,
+					'slug'            => $slug,
+					'priority'        => $section['priority'],
+					'label'           => $section['label'],
+					'description'     => $section['description'],
+					'source_plugin'   => $section['source_plugin'] ?? '-',
+					'source_file'     => $section['source_file'] ?? '-',
+					'source_callback' => $section['source_callback'] ?? '-',
+					'registered_at'   => $section['registered_at'] ?? '-',
 				);
 			}
 		} else {
@@ -1184,21 +1188,29 @@ class MemoryCommand extends BaseCommand {
 				$sections = SectionRegistry::get_sections( $fname );
 				foreach ( $sections as $slug => $section ) {
 					$items[] = array(
-						'file'        => $fname,
-						'slug'        => $slug,
-						'priority'    => $section['priority'],
-						'label'       => $section['label'],
-						'description' => $section['description'],
+						'file'            => $fname,
+						'slug'            => $slug,
+						'priority'        => $section['priority'],
+						'label'           => $section['label'],
+						'description'     => $section['description'],
+						'source_plugin'   => $section['source_plugin'] ?? '-',
+						'source_file'     => $section['source_file'] ?? '-',
+						'source_callback' => $section['source_callback'] ?? '-',
+						'registered_at'   => $section['registered_at'] ?? '-',
 					);
 				}
 
 				if ( empty( $sections ) ) {
 					$items[] = array(
-						'file'        => $fname,
-						'slug'        => '(none)',
-						'priority'    => '-',
-						'label'       => '-',
-						'description' => 'No sections registered.',
+						'file'            => $fname,
+						'slug'            => '(none)',
+						'priority'        => '-',
+						'label'           => '-',
+						'description'     => 'No sections registered.',
+						'source_plugin'   => '-',
+						'source_file'     => '-',
+						'source_callback' => '-',
+						'registered_at'   => '-',
 					);
 				}
 			}
@@ -1209,7 +1221,7 @@ class MemoryCommand extends BaseCommand {
 			return;
 		}
 
-		$this->format_items( $items, array( 'file', 'slug', 'priority', 'label' ), $assoc_args );
+		$this->format_items( $items, array( 'file', 'slug', 'priority', 'label', 'source_plugin', 'source_file', 'source_callback', 'registered_at' ), $assoc_args );
 	}
 
 	/**

--- a/inc/Engine/AI/SectionRegistry.php
+++ b/inc/Engine/AI/SectionRegistry.php
@@ -50,6 +50,10 @@ class SectionRegistry {
 	 *
 	 *     @type string $label       Human-readable label.
 	 *     @type string $description Description of what this section provides.
+	 *     @type string $source_plugin Plugin slug/path that owns the registration.
+	 *     @type string $source_file   File that registered the section.
+	 *     @type string $source_callback Callback that renders the section.
+	 *     @type string $registered_at WordPress hook active during registration.
 	 * }
 	 * @return void
 	 */
@@ -70,12 +74,18 @@ class SectionRegistry {
 			return call_user_func( $callback, $context );
 		};
 
+		$provenance = array_merge( self::registration_provenance( $callback ), array_intersect_key( $args, array_flip( array( 'source_plugin', 'source_file', 'source_callback', 'registered_at' ) ) ) );
+
 		self::$sections[ $filename ][ $slug ] = array(
-			'slug'        => $slug,
-			'priority'    => $priority,
-			'callback'    => $section_callback,
-			'label'       => $args['label'] ?? self::slug_to_label( $slug ),
-			'description' => $args['description'] ?? '',
+			'slug'            => $slug,
+			'priority'        => $priority,
+			'callback'        => $section_callback,
+			'label'           => $args['label'] ?? self::slug_to_label( $slug ),
+			'description'     => $args['description'] ?? '',
+			'source_plugin'   => $provenance['source_plugin'],
+			'source_file'     => $provenance['source_file'],
+			'source_callback' => $provenance['source_callback'],
+			'registered_at'   => $provenance['registered_at'],
 		);
 
 		WP_Agent_Context_Section_Registry::register(
@@ -89,7 +99,11 @@ class SectionRegistry {
 				'retrieval_policy' => $args['retrieval_policy'] ?? null,
 				'modes'            => $args['modes'] ?? array( MemoryFileRegistry::MODE_ALL ),
 				'meta'             => array(
-					'filename' => $filename,
+					'filename'        => $filename,
+					'source_plugin'   => self::$sections[ $filename ][ $slug ]['source_plugin'],
+					'source_file'     => self::$sections[ $filename ][ $slug ]['source_file'],
+					'source_callback' => self::$sections[ $filename ][ $slug ]['source_callback'],
+					'registered_at'   => self::$sections[ $filename ][ $slug ]['registered_at'],
 				),
 			)
 		);
@@ -249,5 +263,106 @@ class SectionRegistry {
 	 */
 	private static function slug_to_label( string $slug ): string {
 		return ucwords( str_replace( array( '-', '_' ), ' ', $slug ) );
+	}
+
+	/**
+	 * Infer registration provenance from the caller frame and callback.
+	 *
+	 * @param callable $callback Section render callback.
+	 * @return array<string, string>
+	 */
+	private static function registration_provenance( callable $callback ): array {
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- Intentional provenance capture for registered composable sections.
+		$trace         = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
+		$source_file   = '';
+		$registered_at = function_exists( 'current_filter' ) ? (string) current_filter() : '';
+
+		foreach ( $trace as $frame ) {
+			$file = (string) ( $frame['file'] ?? '' );
+			if ( '' === $file || __FILE__ === $file ) {
+				continue;
+			}
+
+			$source_file = $file;
+			break;
+		}
+
+		return array(
+			'source_plugin'   => self::source_plugin_from_file( $source_file ),
+			'source_file'     => self::normalize_source_file( $source_file ),
+			'source_callback' => self::describe_callback( $callback ),
+			'registered_at'   => '' !== $registered_at ? $registered_at : '-',
+		);
+	}
+
+	/**
+	 * Normalize a source file for operator-facing output.
+	 *
+	 * @param string $file Absolute file path.
+	 * @return string Relative plugin/site path when possible.
+	 */
+	private static function normalize_source_file( string $file ): string {
+		if ( '' === $file ) {
+			return '-';
+		}
+
+		if ( function_exists( 'plugin_basename' ) ) {
+			$plugin_basename = plugin_basename( $file );
+			if ( is_string( $plugin_basename ) && '' !== $plugin_basename && $plugin_basename !== $file ) {
+				return $plugin_basename;
+			}
+		}
+
+		if ( defined( 'ABSPATH' ) ) {
+			$root = rtrim( (string) ABSPATH, '/\\' ) . DIRECTORY_SEPARATOR;
+			if ( 0 === strpos( $file, $root ) ) {
+				return ltrim( substr( $file, strlen( $root ) ), '/\\' );
+			}
+		}
+
+		return basename( $file );
+	}
+
+	/**
+	 * Derive a plugin owner from a source file.
+	 *
+	 * @param string $file Absolute file path.
+	 * @return string Plugin slug/path, or '-' when unavailable.
+	 */
+	private static function source_plugin_from_file( string $file ): string {
+		$source_file = self::normalize_source_file( $file );
+		if ( '-' === $source_file ) {
+			return '-';
+		}
+
+		$parts = explode( '/', str_replace( '\\', '/', $source_file ) );
+		return $parts[0] ?? '-';
+	}
+
+	/**
+	 * Describe a PHP callback for CLI provenance output.
+	 *
+	 * @param callable $callback Callback to describe.
+	 * @return string Human-readable callback name.
+	 */
+	private static function describe_callback( callable $callback ): string {
+		if ( is_string( $callback ) ) {
+			return $callback;
+		}
+
+		if ( $callback instanceof \Closure ) {
+			return 'Closure';
+		}
+
+		if ( is_array( $callback ) && 2 === count( $callback ) ) {
+			$target = is_object( $callback[0] ) ? get_class( $callback[0] ) : (string) $callback[0];
+			return $target . '::' . (string) $callback[1];
+		}
+
+		if ( is_object( $callback ) ) {
+			return get_class( $callback ) . '::__invoke';
+		}
+
+		return '-';
 	}
 }

--- a/tests/agents-api-memory-contract-adoption-smoke.php
+++ b/tests/agents-api-memory-contract-adoption-smoke.php
@@ -115,6 +115,11 @@ SectionRegistry::register( 'SITE.md', 'one', 20, static fn(): string => "## One\
 SectionRegistry::register( 'SITE.md', 'zero', 10, static fn(): string => "## Zero\nBefore" );
 $content = SectionRegistry::generate( 'SITE.md' );
 datamachine_contract_adoption_assert( "## Zero\nBefore\n\n## One\nFirst" === $content, 'Data Machine section composition stays priority-stable through Agents API' );
+$sections = SectionRegistry::get_sections( 'SITE.md' );
+datamachine_contract_adoption_assert( 'tests' === $sections['one']['source_plugin'], 'section registry records source plugin provenance' );
+datamachine_contract_adoption_assert( 'tests/agents-api-memory-contract-adoption-smoke.php' === $sections['one']['source_file'], 'section registry records source file provenance' );
+datamachine_contract_adoption_assert( 'Closure' === $sections['one']['source_callback'], 'section registry records callback provenance' );
+datamachine_contract_adoption_assert( '-' === $sections['one']['registered_at'], 'section registry records registration hook provenance fallback' );
 
 $disk_store = ( new ReflectionClass( DiskAgentMemoryStore::class ) )->newInstanceWithoutConstructor();
 $disk_caps  = $disk_store->capabilities();


### PR DESCRIPTION
Closes #1327

## Summary
- Captures composable section registration provenance in `SectionRegistry`.
- Exposes `source_plugin`, `source_file`, `source_callback`, and `registered_at` in `wp datamachine memory compose --list`.
- Preserves provenance in the Agents API context-section adapter metadata.

## Verification
- `php tests/agents-api-memory-contract-adoption-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-memory-compose-provenance --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-memory-compose-provenance --extension wordpress --changed-since origin/main`
- `homeboy audit --path /Users/chubes/Developer/data-machine@fix-memory-compose-provenance --extension wordpress --changed-since origin/main`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the provenance capture/list output change and ran local verification; Chris remains responsible for review and merge.