### PR TITLE
Dispatch pending action lifecycle observers

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -820,12 +820,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "da4477579eb03963af202a39cfd6102bebdbd802"
+                "reference": "42f9702746d2ded1ef0af63d3f7b9ac3e83cb1cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/da4477579eb03963af202a39cfd6102bebdbd802",
-                "reference": "da4477579eb03963af202a39cfd6102bebdbd802",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/42f9702746d2ded1ef0af63d3f7b9ac3e83cb1cf",
+                "reference": "42f9702746d2ded1ef0af63d3f7b9ac3e83cb1cf",
                 "shasum": ""
             },
             "require": {
@@ -857,6 +857,7 @@
                     "php tests/pending-action-abilities-smoke.php",
                     "php tests/identity-smoke.php",
                     "php tests/memory-metadata-contract-smoke.php",
+                    "php tests/memory-store-resolver-smoke.php",
                     "php tests/approval-action-value-shape-smoke.php",
                     "php tests/workspace-scope-smoke.php",
                     "php tests/compaction-item-smoke.php",
@@ -900,7 +901,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-17T21:38:05+00:00"
+            "time": "2026-05-20T01:05:13+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/data-machine.php
+++ b/data-machine.php
@@ -313,6 +313,7 @@ function datamachine_run_datamachine_plugin() {
 	// ActionPolicy + unified pending-action resolver. Content abilities register
 	// themselves on `datamachine_pending_action_handlers` via
 	// inc/Abilities/Content/ContentActionHandlers.php (required above).
+	\DataMachine\Engine\AI\Actions\PendingActionObservers::register( new \DataMachine\Engine\AI\Actions\WordPressActionDispatchObserver() );
 	new \DataMachine\Engine\AI\Actions\PendingActionInspectionAbility();
 	new \DataMachine\Engine\AI\Actions\ResolvePendingActionAbility();
 	new \DataMachine\Engine\AI\Actions\ResolvePendingAction();

--- a/docs/core-system/pending-actions.md
+++ b/docs/core-system/pending-actions.md
@@ -15,11 +15,22 @@ Data Machine directly adapts to these merged contracts from `automattic/agents-a
 - `AgentsAPI\AI\Approvals\PendingAction_Store`
 - `AgentsAPI\AI\Approvals\PendingAction_Resolver`
 - `AgentsAPI\AI\Approvals\PendingAction_Handler`
+- `AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Observer`
 - `AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision`
 - `AgentsAPI\AI\Approvals\PendingAction`
 - `AgentsAPI\AI\Tools\ActionPolicy`
 
 The compatibility seam remains the existing `datamachine_pending_action_handlers` map. Handler objects that implement `AgentsAPI\AI\Approvals\PendingAction_Handler` can be placed under the same `apply` key and Data Machine will dispatch to the Agents API handler method. Legacy callable handlers continue to receive the stored `apply_input` and full Data Machine payload.
+
+## Lifecycle Observers
+
+`PendingActionStore` dispatches registered `WP_Agent_Pending_Action_Observer` instances after durable lifecycle transitions complete. Data Machine registers a default WordPress adapter with these hooks:
+
+- `datamachine_pending_action_stored( WP_Agent_Pending_Action $action )`
+- `datamachine_pending_action_resolved( string $decision, string $action_id, string $kind, array $payload, mixed $result )`
+- `datamachine_pending_action_expired( WP_Agent_Pending_Action $action )`
+
+The resolved hook keeps its legacy signature for compatibility. Object-oriented observers receive the upstream value-object signature from `WP_Agent_Pending_Action_Observer`.
 
 ## Surfaces
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -545,10 +545,20 @@ the final content in the post type's canonical format.
 user resolution. Use this to notify users, log audit trails, or mirror the
 payload into a visible queue.
 
+### `datamachine_pending_action_stored`
+
+**Purpose**: Fires after `PendingActionStore` successfully persists a pending
+action. Receives `WP_Agent_Pending_Action $action`.
+
 ### `datamachine_pending_action_resolved`
 
-**Purpose**: Fires after a staged action is accepted or rejected. Receives
-`$decision, $action_id, $kind, $payload, $result`.
+**Purpose**: Fires after a staged action is accepted or rejected. This hook keeps
+the legacy signature: `$decision, $action_id, $kind, $payload, $result`.
+
+### `datamachine_pending_action_expired`
+
+**Purpose**: Fires after `PendingActionStore` marks a pending action expired.
+Receives `WP_Agent_Pending_Action $action`.
 
 ### `datamachine_tool_action_policy`
 

--- a/inc/Engine/AI/Actions/PendingActionObservers.php
+++ b/inc/Engine/AI/Actions/PendingActionObservers.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Pending action observer registry.
+ *
+ * @package DataMachine\Engine\AI\Actions
+ */
+
+namespace DataMachine\Engine\AI\Actions;
+
+use AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision;
+use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action;
+use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Observer;
+
+defined( 'ABSPATH' ) || exit;
+
+final class PendingActionObservers {
+
+	/**
+	 * Registered observers.
+	 *
+	 * @var array<int,WP_Agent_Pending_Action_Observer>
+	 */
+	private static array $observers = array();
+
+	public static function register( WP_Agent_Pending_Action_Observer $observer ): void {
+		foreach ( self::$observers as $registered ) {
+			if ( $registered === $observer || get_class( $registered ) === get_class( $observer ) ) {
+				return;
+			}
+		}
+
+		self::$observers[] = $observer;
+	}
+
+	public static function unregister( WP_Agent_Pending_Action_Observer $observer ): void {
+		self::$observers = array_values(
+			array_filter(
+				self::$observers,
+				static fn( WP_Agent_Pending_Action_Observer $registered ): bool => $registered !== $observer && get_class( $registered ) !== get_class( $observer )
+			)
+		);
+	}
+
+	/**
+	 * @return array<int,WP_Agent_Pending_Action_Observer>
+	 */
+	public static function list(): array {
+		return self::$observers;
+	}
+
+	public static function dispatch_stored( WP_Agent_Pending_Action $action ): void {
+		foreach ( self::$observers as $observer ) {
+			self::call_observer(
+				$observer,
+				'on_stored',
+				static function () use ( $observer, $action ): void {
+					$observer->on_stored( $action );
+				}
+			);
+		}
+	}
+
+	public static function dispatch_resolved( WP_Agent_Pending_Action $action, WP_Agent_Approval_Decision $decision, string $resolver ): void {
+		foreach ( self::$observers as $observer ) {
+			self::call_observer(
+				$observer,
+				'on_resolved',
+				static function () use ( $observer, $action, $decision, $resolver ): void {
+					$observer->on_resolved( $action, $decision, $resolver );
+				}
+			);
+		}
+	}
+
+	public static function dispatch_expired( WP_Agent_Pending_Action $action ): void {
+		foreach ( self::$observers as $observer ) {
+			self::call_observer(
+				$observer,
+				'on_expired',
+				static function () use ( $observer, $action ): void {
+					$observer->on_expired( $action );
+				}
+			);
+		}
+	}
+
+	public static function reset(): void {
+		self::$observers = array();
+	}
+
+	private static function call_observer( WP_Agent_Pending_Action_Observer $observer, string $method, callable $callback ): void {
+		try {
+			$callback();
+		} catch ( \Throwable $error ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Pending action observer failed: ' . $error->getMessage(),
+				array(
+					'observer' => get_class( $observer ),
+					'method'   => $method,
+				)
+			);
+		}
+	}
+}

--- a/inc/Engine/AI/Actions/PendingActionStore.php
+++ b/inc/Engine/AI/Actions/PendingActionStore.php
@@ -206,7 +206,12 @@ class PendingActionStore {
 			$payload['action_id']  = $action_id;
 			$payload['status']     = WP_Agent_Pending_Action_Status::PENDING;
 
-			return set_transient( self::TRANSIENT_PREFIX . $action_id, $payload, self::resolve_ttl( $payload ) );
+			$stored = set_transient( self::TRANSIENT_PREFIX . $action_id, $payload, self::resolve_ttl( $payload ) );
+			if ( $stored ) {
+				self::dispatch_stored_payload( $payload );
+			}
+
+			return $stored;
 		}
 
 		$now        = time();
@@ -248,6 +253,9 @@ class PendingActionStore {
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$stored = $wpdb->replace( self::get_table_name(), $row, $formats );
+		if ( false !== $stored ) {
+			self::dispatch_stored_payload( $payload );
+		}
 
 		return false !== $stored;
 	}
@@ -321,13 +329,23 @@ class PendingActionStore {
 		global $wpdb;
 
 		if ( ! self::has_database() ) {
-			return delete_transient( self::TRANSIENT_PREFIX . $action_id );
+			$payload = get_transient( self::TRANSIENT_PREFIX . $action_id );
+			$action  = is_array( $payload ) ? self::action_from_payload( $payload ) : null;
+			$deleted = delete_transient( self::TRANSIENT_PREFIX . $action_id );
+			if ( $deleted && null !== $action ) {
+				self::dispatch_resolution( $action, $decision, $resolver ?? self::current_resolver() );
+			}
+
+			return $deleted;
 		}
 
 		$status = self::normalize_status( $decision );
 		if ( '' === $status ) {
 			return false;
 		}
+
+		$row    = self::get_row( $action_id );
+		$action = is_array( $row ) ? self::action_from_payload( self::row_to_payload( $row ) ) : null;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$updated = $wpdb->update(
@@ -345,6 +363,11 @@ class PendingActionStore {
 			array( '%s', '%s', '%d', '%s', '%s', '%s', '%s' ),
 			array( '%s' )
 		);
+
+		if ( false !== $updated && null !== $action ) {
+			$resolved_action = self::get_action( $action_id, true ) ?? $action;
+			self::dispatch_resolution( $resolved_action, $status, $resolver ?? self::current_resolver() );
+		}
 
 		return false !== $updated;
 	}
@@ -464,20 +487,25 @@ class PendingActionStore {
 
 		$boundary = null !== $before ? gmdate( 'Y-m-d H:i:s', self::normalize_timestamp( $before ) ) : current_time( 'mysql', true );
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-		$updated = $wpdb->query(
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
+		$action_ids = $wpdb->get_col(
 			$wpdb->prepare(
-				'UPDATE %i SET status = %s, resolved_at = %s, resolution_error = %s WHERE status = %s AND expires_at IS NOT NULL AND expires_at <= %s',
+				'SELECT action_id FROM %i WHERE status = %s AND expires_at IS NOT NULL AND expires_at <= %s',
 				self::get_table_name(),
-				WP_Agent_Pending_Action_Status::EXPIRED,
-				$boundary,
-				'Pending action expired.',
 				WP_Agent_Pending_Action_Status::PENDING,
 				$boundary
 			)
 		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
 
-		return false === $updated ? 0 : (int) $updated;
+		$expired = 0;
+		foreach ( (array) $action_ids as $action_id ) {
+			if ( self::record_resolution( (string) $action_id, WP_Agent_Pending_Action_Status::EXPIRED, null, 'Pending action expired.', 'system:expiration' ) ) {
+				++$expired;
+			}
+		}
+
+		return $expired;
 	}
 
 	/**
@@ -658,6 +686,48 @@ class PendingActionStore {
 			'resolution_metadata' => isset( $payload['resolution_metadata'] ) && is_array( $payload['resolution_metadata'] ) ? $payload['resolution_metadata'] : array(),
 			'metadata'            => $metadata,
 		);
+	}
+
+	/**
+	 * Dispatch a stored lifecycle event from a Data Machine payload.
+	 */
+	private static function dispatch_stored_payload( array $payload ): void {
+		$action = self::action_from_payload( $payload );
+		if ( null !== $action ) {
+			PendingActionObservers::dispatch_stored( $action );
+		}
+	}
+
+	/**
+	 * Dispatch terminal lifecycle events that have observer contracts.
+	 */
+	private static function dispatch_resolution( WP_Agent_Pending_Action $action, string $status, string $resolver ): void {
+		if ( WP_Agent_Pending_Action_Status::EXPIRED === $status ) {
+			PendingActionObservers::dispatch_expired( $action );
+			return;
+		}
+
+		if ( ! in_array( $status, array( WP_Agent_Approval_Decision::ACCEPTED, WP_Agent_Approval_Decision::REJECTED ), true ) ) {
+			return;
+		}
+
+		try {
+			PendingActionObservers::dispatch_resolved( $action, WP_Agent_Approval_Decision::from_string( $status ), $resolver );
+		} catch ( \InvalidArgumentException $error ) {
+			unset( $error );
+		}
+	}
+
+	/**
+	 * Convert a payload to an observer-safe Agents API value object.
+	 */
+	private static function action_from_payload( array $payload ): ?WP_Agent_Pending_Action {
+		try {
+			return WP_Agent_Pending_Action::from_array( self::payload_to_action_array( $payload ) );
+		} catch ( \InvalidArgumentException $error ) {
+			unset( $error );
+			return null;
+		}
 	}
 
 	/**

--- a/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
+++ b/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
@@ -244,7 +244,6 @@ class ResolvePendingActionAbility {
 			// No handler registered — can't apply, but reject is still safe.
 			if ( $decision->is_rejected() ) {
 				PendingActionStore::record_resolution( $action_id, WP_Agent_Pending_Action_Status::REJECTED, null, null, $resolver, array( 'reason' => 'no_handler_rejected' ) );
-				self::fireResolvedAction( $decision_value, $action_id, $kind, $payload, null );
 				return array(
 					'success'   => true,
 					'decision'  => 'rejected',
@@ -302,7 +301,6 @@ class ResolvePendingActionAbility {
 
 		if ( $decision->is_rejected() ) {
 			PendingActionStore::record_resolution( $action_id, WP_Agent_Pending_Action_Status::REJECTED, null, null, $resolver );
-			self::fireResolvedAction( $decision_value, $action_id, $kind, $payload, null );
 			return array(
 				'success'   => true,
 				'decision'  => 'rejected',
@@ -316,7 +314,6 @@ class ResolvePendingActionAbility {
 
 		if ( is_wp_error( $result ) ) {
 			PendingActionStore::record_resolution( $action_id, WP_Agent_Pending_Action_Status::ACCEPTED, null, $result->get_error_message(), $resolver );
-			self::fireResolvedAction( $decision_value, $action_id, $kind, $payload, $result );
 			return array(
 				'success'   => false,
 				'decision'  => 'accepted',
@@ -328,7 +325,6 @@ class ResolvePendingActionAbility {
 
 		if ( is_array( $result ) && array_key_exists( 'success', $result ) && false === $result['success'] ) {
 			PendingActionStore::record_resolution( $action_id, WP_Agent_Pending_Action_Status::ACCEPTED, $result, $result['error'] ?? 'Apply handler reported failure.', $resolver );
-			self::fireResolvedAction( $decision_value, $action_id, $kind, $payload, $result );
 			return array(
 				'success'   => false,
 				'decision'  => 'accepted',
@@ -340,7 +336,6 @@ class ResolvePendingActionAbility {
 		}
 
 		PendingActionStore::record_resolution( $action_id, WP_Agent_Pending_Action_Status::ACCEPTED, $result, null, $resolver );
-		self::fireResolvedAction( $decision_value, $action_id, $kind, $payload, $result );
 
 		return array(
 			'success'   => true,
@@ -456,30 +451,5 @@ class ResolvePendingActionAbility {
 	private static function resolverFromCurrentUser(): string {
 		$user_id = get_current_user_id();
 		return $user_id > 0 ? 'user:' . $user_id : 'system:anonymous';
-	}
-
-	/**
-	 * Fire the post-resolution action.
-	 *
-	 * @param string     $decision  accepted|rejected.
-	 * @param string     $action_id Action ID.
-	 * @param string     $kind      Kind.
-	 * @param array      $payload   Stored payload.
-	 * @param mixed|null $result    Apply result (for accepted) or null.
-	 * @return void
-	 */
-	private static function fireResolvedAction( string $decision, string $action_id, string $kind, array $payload, $result ): void {
-		/**
-		 * Fires after a pending action has been resolved.
-		 *
-		 * @since 0.72.0
-		 *
-		 * @param string     $decision  accepted|rejected.
-		 * @param string     $action_id Action ID.
-		 * @param string     $kind      Kind.
-		 * @param array      $payload   Stored payload (pre-deletion).
-		 * @param mixed|null $result    Apply result (for accepted) or null.
-		 */
-		do_action( 'datamachine_pending_action_resolved', $decision, $action_id, $kind, $payload, $result );
 	}
 }

--- a/inc/Engine/AI/Actions/WordPressActionDispatchObserver.php
+++ b/inc/Engine/AI/Actions/WordPressActionDispatchObserver.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * WordPress action adapter for pending-action lifecycle events.
+ *
+ * @package DataMachine\Engine\AI\Actions
+ */
+
+namespace DataMachine\Engine\AI\Actions;
+
+use AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision;
+use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action;
+use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Observer;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WordPressActionDispatchObserver implements WP_Agent_Pending_Action_Observer {
+
+	public function on_stored( WP_Agent_Pending_Action $action ): void {
+		do_action( 'datamachine_pending_action_stored', $action );
+	}
+
+	public function on_resolved( WP_Agent_Pending_Action $action, WP_Agent_Approval_Decision $decision, string $resolver ): void {
+		unset( $resolver );
+
+		$payload  = $this->legacy_payload( $action );
+		$resolved = $action->to_array();
+
+		do_action(
+			'datamachine_pending_action_resolved',
+			$decision->value(),
+			$action->get_action_id(),
+			$action->get_kind(),
+			$payload,
+			$resolved['resolution_result'] ?? null
+		);
+	}
+
+	public function on_expired( WP_Agent_Pending_Action $action ): void {
+		do_action( 'datamachine_pending_action_expired', $action );
+	}
+
+	/**
+	 * Build the legacy Data Machine hook payload shape from the Agents API value.
+	 */
+	private function legacy_payload( WP_Agent_Pending_Action $action ): array {
+		$data        = $action->to_array();
+		$metadata    = is_array( $data['metadata'] ?? null ) ? $data['metadata'] : array();
+		$datamachine = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
+
+		return array(
+			'action_id'           => $data['action_id'],
+			'kind'                => $data['kind'],
+			'summary'             => $data['summary'],
+			'preview_data'        => $data['preview'],
+			'apply_input'         => $data['apply_input'],
+			'workspace'           => $data['workspace'],
+			'agent'               => $data['agent'],
+			'creator'             => $data['creator'],
+			'agent_id'            => $datamachine['agent_id'] ?? 0,
+			'created_by'          => $datamachine['created_by'] ?? 0,
+			'context'             => $datamachine['context'] ?? array(),
+			'metadata'            => $metadata,
+			'status'              => $data['status'],
+			'created_at'          => $data['created_at'],
+			'expires_at'          => $data['expires_at'],
+			'resolved_at'         => $data['resolved_at'],
+			'resolver'            => $data['resolver'],
+			'resolution_result'   => $data['resolution_result'],
+			'resolution_error'    => $data['resolution_error'],
+			'resolution_metadata' => $data['resolution_metadata'],
+		);
+	}
+}

--- a/tests/pending-action-resolver-contract-smoke.php
+++ b/tests/pending-action-resolver-contract-smoke.php
@@ -122,6 +122,9 @@ if ( ! class_exists( 'WP_Error' ) ) {
 }
 
 require_once dirname( __DIR__ ) . '/vendor/automattic/agents-api/agents-api.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Workspace/WordPressWorkspaceScope.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionObservers.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/WordPressActionDispatchObserver.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionStore.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionResolverAdapter.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/ResolvePendingActionAbility.php';

--- a/tests/pending-actions-agents-api-contract-smoke.php
+++ b/tests/pending-actions-agents-api-contract-smoke.php
@@ -37,6 +37,8 @@ function datamachine_pending_actions_source( string $path ): string {
 }
 
 $store_source       = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/PendingActionStore.php' );
+$observers_source   = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/PendingActionObservers.php' );
+$wp_observer_source = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/WordPressActionDispatchObserver.php' );
 $adapter_source     = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/PendingActionStoreAdapter.php' );
 $resolver_adapter   = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/PendingActionResolverAdapter.php' );
 $resolver_source    = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/ResolvePendingActionAbility.php' );
@@ -59,6 +61,10 @@ $expected_agents_api_approval_primitives = array(
 	'AgentsAPI\\AI\\Approvals\\WP_Agent_Pending_Action_Handler'  => array(
 		'path' => 'vendor/automattic/agents-api/src/Approvals/class-wp-agent-pending-action-handler.php',
 		'type' => 'interface WP_Agent_Pending_Action_Handler',
+	),
+	'AgentsAPI\\AI\\Approvals\\WP_Agent_Pending_Action_Observer' => array(
+		'path' => 'vendor/automattic/agents-api/src/Approvals/class-wp-agent-pending-action-observer.php',
+		'type' => 'interface WP_Agent_Pending_Action_Observer',
 	),
 	'AgentsAPI\\AI\\Approvals\\WP_Agent_Pending_Action'                  => array(
 		'path' => 'vendor/automattic/agents-api/src/Approvals/class-wp-agent-pending-action.php',
@@ -91,6 +97,8 @@ datamachine_pending_actions_assert( str_contains( $adapter_source, 'record_resol
 datamachine_pending_actions_assert( str_contains( $resolver_adapter, 'implements WP_Agent_Pending_Action_Resolver' ), 'resolver adapter implements Agents API WP_Agent_Pending_Action_Resolver', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $action_policy, 'use AgentsAPI\\AI\\Tools\\WP_Agent_Action_Policy;' ) && str_contains( $action_policy, 'WP_Agent_Action_Policy::normalize' ), 'ActionPolicyResolver consumes Agents API WP_Agent_Action_Policy vocabulary', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $resolver_adapter, 'WP_Agent_Approval_Decision' ), 'resolver adapter consumes Agents API WP_Agent_Approval_Decision vocabulary', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $observers_source, 'WP_Agent_Pending_Action_Observer' ), 'observer registry consumes Agents API WP_Agent_Pending_Action_Observer contract', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $wp_observer_source, 'datamachine_pending_action_stored' ) && str_contains( $wp_observer_source, 'datamachine_pending_action_resolved' ) && str_contains( $wp_observer_source, 'datamachine_pending_action_expired' ), 'WordPress observer adapter exposes stored/resolved/expired actions', $failures, $passes );
 
 echo "\n[2] Durable storage preserves legacy lookup while retaining audit rows:\n";
 datamachine_pending_actions_assert( str_contains( $store_source, 'CREATE TABLE {$table_name}' ), 'PendingActionStore creates a durable table', $failures, $passes );
@@ -116,6 +124,7 @@ datamachine_pending_actions_assert( str_contains( $resolver_source, 'datamachine
 datamachine_pending_actions_assert( str_contains( $resolver_source, 'can_resolve_pending_action' ) && str_contains( $resolver_source, 'handle_pending_action( $pending_action, $decision' ), 'Agents API handler permission and apply contracts are used through the existing handler filter', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $plugin_source, 'new \\DataMachine\\Engine\\AI\\Actions\\ResolvePendingActionAbility();' ), 'existing resolve ability remains registered', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $plugin_source, 'new \\DataMachine\\Engine\\AI\\Actions\\ResolvePendingAction();' ), 'existing chat resolver tool remains registered', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $plugin_source, 'PendingActionObservers::register' ) && str_contains( $plugin_source, 'WordPressActionDispatchObserver' ), 'default WordPress pending-action observer is registered during bootstrap', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $runtime_source, 'datamachine_migrate_pending_actions_table' ), 'upgrade path creates pending-action table on deployed installs', $failures, $passes );
 
 echo "\n[5] Store contract adapter preserves transient fallback behavior:\n";
@@ -174,6 +183,15 @@ if ( ! function_exists( 'add_action' ) ) {
 	}
 }
 
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook_name, ...$args ): void {
+		$GLOBALS['datamachine_pending_action_observer_events'][] = array(
+			'hook' => $hook_name,
+			'args' => $args,
+		);
+	}
+}
+
 if ( ! function_exists( 'wp_generate_uuid4' ) ) {
 	function wp_generate_uuid4(): string {
 		return '11111111-2222-4333-8444-555555555555';
@@ -182,8 +200,13 @@ if ( ! function_exists( 'wp_generate_uuid4' ) ) {
 
 require_once dirname( __DIR__ ) . '/vendor/automattic/agents-api/agents-api.php';
 require_once dirname( __DIR__ ) . '/inc/Core/Workspace/WordPressWorkspaceScope.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionObservers.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/WordPressActionDispatchObserver.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionStoreAdapter.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionStore.php';
+
+\DataMachine\Engine\AI\Actions\PendingActionObservers::reset();
+\DataMachine\Engine\AI\Actions\PendingActionObservers::register( new \DataMachine\Engine\AI\Actions\WordPressActionDispatchObserver() );
 
 $store     = \DataMachine\Engine\AI\Actions\PendingActionStore::adapter();
 $action_id = \DataMachine\Engine\AI\Actions\PendingActionStore::generate_id();
@@ -210,13 +233,14 @@ $action    = \AgentsAPI\AI\Approvals\WP_Agent_Pending_Action::from_array(
 datamachine_pending_actions_assert( $store instanceof \AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Store, 'PendingActionStore adapter is an Agents API store', $failures, $passes );
 datamachine_pending_actions_assert( str_starts_with( $action_id, 'act_' ), 'legacy generate_id returns namespaced action IDs', $failures, $passes );
 datamachine_pending_actions_assert( $store->store( $action ), 'contract store writes WP_Agent_Pending_Action through transient fallback', $failures, $passes );
+datamachine_pending_actions_assert( 'datamachine_pending_action_stored' === ( $GLOBALS['datamachine_pending_action_observer_events'][0]['hook'] ?? null ), 'stored observer action fires after contract store write', $failures, $passes );
 
 $stored = $store->get( $action_id );
 datamachine_pending_actions_assert( $stored instanceof \AgentsAPI\AI\Approvals\WP_Agent_Pending_Action && 'contract_smoke' === $stored->get_kind(), 'contract get reads the stored WP_Agent_Pending_Action', $failures, $passes );
 datamachine_pending_actions_assert( $stored instanceof \AgentsAPI\AI\Approvals\WP_Agent_Pending_Action && $action_id === $stored->get_action_id(), 'contract store preserves action ID in payload', $failures, $passes );
 datamachine_pending_actions_assert( $stored instanceof \AgentsAPI\AI\Approvals\WP_Agent_Pending_Action && null !== $stored->get_expires_at(), 'transient fallback preserves expiration audit data', $failures, $passes );
 
-$legacy_action_id = \DataMachine\Engine\AI\Actions\PendingActionStore::generate_id();
+$legacy_action_id = 'act_legacy_smoke';
 $product_payload  = array(
 	'action_id'    => $legacy_action_id,
 	'kind'         => 'legacy_smoke',
@@ -236,8 +260,12 @@ datamachine_pending_actions_assert( $legacy_stored instanceof \AgentsAPI\AI\Appr
 datamachine_pending_actions_assert( $legacy_stored instanceof \AgentsAPI\AI\Approvals\WP_Agent_Pending_Action && array( 'legacy_value' => 2 ) === $legacy_stored->get_apply_input(), 'value-object conversion preserves apply input', $failures, $passes );
 datamachine_pending_actions_assert( $store->delete( $legacy_action_id ), 'contract delete removes legacy transient fallback payload', $failures, $passes );
 
-datamachine_pending_actions_assert( $store->delete( $action_id ), 'contract delete removes transient fallback payload', $failures, $passes );
-datamachine_pending_actions_assert( null === $store->get( $action_id ), 'contract get returns null after delete', $failures, $passes );
+$GLOBALS['datamachine_pending_action_observer_events'] = array();
+datamachine_pending_actions_assert( $store->get( $action_id ) instanceof \AgentsAPI\AI\Approvals\WP_Agent_Pending_Action, 'contract get still sees pending action before resolution', $failures, $passes );
+datamachine_pending_actions_assert( $store->record_resolution( $action_id, \AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision::accepted(), 'user:123' ), 'contract record_resolution resolves transient fallback payload', $failures, $passes );
+$resolved_hooks = array_map( static fn( array $event ): string => (string) ( $event['hook'] ?? '' ), $GLOBALS['datamachine_pending_action_observer_events'] ?? array() );
+datamachine_pending_actions_assert( in_array( 'datamachine_pending_action_resolved', $resolved_hooks, true ), 'resolved observer action fires after contract resolution', $failures, $passes );
+datamachine_pending_actions_assert( null === $store->get( $action_id ), 'contract get returns null after transient fallback resolution', $failures, $passes );
 
 if ( ! empty( $failures ) ) {
 	echo "\nFailures:\n";


### PR DESCRIPTION
## Summary
- Adds a Data Machine pending-action observer registry backed by the upstream Agents API `WP_Agent_Pending_Action_Observer` contract.
- Dispatches stored, resolved, and expired lifecycle events from `PendingActionStore` after durable transitions complete.
- Registers a WordPress hook adapter while preserving the legacy `datamachine_pending_action_resolved` signature.

Closes #1928.

## Testing
- `php tests/pending-actions-agents-api-contract-smoke.php`
- `php tests/pending-action-resolver-contract-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@feat-pending-action-observers --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@feat-pending-action-observers --extension wordpress --changed-since origin/main`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the pending-action observer dispatch path, smoke coverage, docs updates, and local validation; Chris remains responsible for review and merge decisions.