### PR TITLE
Add signed pending action resolution URLs

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -315,6 +315,7 @@ function datamachine_run_datamachine_plugin() {
 	// inc/Abilities/Content/ContentActionHandlers.php (required above).
 	\DataMachine\Engine\AI\Actions\PendingActionObservers::register( new \DataMachine\Engine\AI\Actions\WordPressActionDispatchObserver() );
 	new \DataMachine\Engine\AI\Actions\PendingActionInspectionAbility();
+	new \DataMachine\Engine\AI\Actions\SignPendingActionResolutionAbility();
 	new \DataMachine\Engine\AI\Actions\ResolvePendingActionAbility();
 	new \DataMachine\Engine\AI\Actions\ResolvePendingAction();
 

--- a/docs/core-system/pending-actions.md
+++ b/docs/core-system/pending-actions.md
@@ -37,12 +37,44 @@ The resolved hook keeps its legacy signature for compatibility. Object-oriented 
 - Ability: `datamachine/list-pending-actions`
 - Ability: `datamachine/get-pending-action`
 - Ability: `datamachine/summarize-pending-actions`
+- Ability: `datamachine/sign-pending-action-resolution`
 - Resolver ability: `datamachine/resolve-pending-action`
 - Chat tool: `resolve_pending_action`
 - REST: `GET /datamachine/v1/actions`
 - REST: `GET /datamachine/v1/actions/{action_id}`
 - REST: `GET /datamachine/v1/actions/summary`
+- REST: `GET /datamachine/v1/actions/resolve-by-token?t={token}`
 - REST resolver: `POST /datamachine/v1/actions/resolve`
 - CLI: `wp datamachine pending-actions list|get|summary`
 
 `PendingActionStore::get()` remains the live-pending lookup used by legacy callers. Resolved rows are retained for audit and are available through inspect/list/get surfaces.
+
+## Signed Resolution URLs
+
+`datamachine/sign-pending-action-resolution` creates short-lived approve and reject URLs for a pending action. The URLs are stateless: the `t` query parameter contains a JSON payload signed with an HMAC secret stored in the `datamachine_pending_action_resolution_secret` option.
+
+Input:
+
+```php
+array(
+	'action_id' => 'act_...',
+	'lifetime'  => 604800, // Optional, seconds; capped at 30 days.
+	'resolver'  => 'email_approval', // Optional audit identifier.
+)
+```
+
+Output:
+
+```php
+array(
+	'success'     => true,
+	'action_id'   => 'act_...',
+	'approve_url' => 'https://example.test/wp-json/datamachine/v1/actions/resolve-by-token?t=...',
+	'reject_url'  => 'https://example.test/wp-json/datamachine/v1/actions/resolve-by-token?t=...',
+	'expires_at'  => '2026-05-17T12:00:00+00:00',
+)
+```
+
+The public token route validates the signature and expiry before delegating to the same resolver path as `datamachine/resolve-pending-action`. Already-resolved accepted/rejected rows return their existing decision instead of being overwritten. Expired, deleted, missing, or otherwise non-resolvable rows return `410`.
+
+Use `SignPendingActionResolutionAbility::rotate_secret()` to invalidate existing signed URLs during a security incident.

--- a/inc/Engine/AI/Actions/SignPendingActionResolutionAbility.php
+++ b/inc/Engine/AI/Actions/SignPendingActionResolutionAbility.php
@@ -1,0 +1,407 @@
+<?php
+/**
+ * Signed pending-action approval URLs.
+ *
+ * @package DataMachine\Engine\AI\Actions
+ */
+
+namespace DataMachine\Engine\AI\Actions;
+
+use AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision;
+use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Status;
+use DataMachine\Abilities\PermissionHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+final class SignPendingActionResolutionAbility {
+
+	private const OPTION_SECRET        = 'datamachine_pending_action_resolution_secret';
+	private const DEFAULT_LIFETIME     = 604800;
+	private const MAX_TOKEN_LIFETIME   = 2592000;
+	private const DEFAULT_RESOLVER     = 'signed_pending_action_url';
+	private const TOKEN_VERSION        = 1;
+	private const RESOLVE_ROUTE        = '/actions/resolve-by-token';
+	private const TOKEN_QUERY_ARG      = 't';
+	private const HTML_RESPONSE_FILTER = 'datamachine_pending_action_resolution_token_html';
+
+	/** @var bool */
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->register_ability();
+		$this->register_rest_route();
+		$this->register_html_response_sender();
+		self::$registered = true;
+	}
+
+	/**
+	 * Register the signing ability.
+	 */
+	private function register_ability(): void {
+		$register = function () {
+			wp_register_ability(
+				'datamachine/sign-pending-action-resolution',
+				array(
+					'label'               => __( 'Sign Pending Action Resolution', 'data-machine' ),
+					'description'         => __( 'Create signed approve and reject URLs for a pending action.', 'data-machine' ),
+					'category'            => 'datamachine-actions',
+					'input_schema'        => self::input_schema(),
+					'output_schema'       => self::output_schema(),
+					'execute_callback'    => array( self::class, 'execute' ),
+					'permission_callback' => fn() => PermissionHelper::can( 'chat' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register );
+		}
+	}
+
+	/**
+	 * Register the public resolution endpoint.
+	 */
+	private function register_rest_route(): void {
+		add_action(
+			'rest_api_init',
+			function () {
+				register_rest_route(
+					'datamachine/v1',
+					self::RESOLVE_ROUTE,
+					array(
+						'methods'             => 'GET',
+						'callback'            => array( self::class, 'handle_rest' ),
+						'permission_callback' => '__return_true',
+						'args'                => array(
+							self::TOKEN_QUERY_ARG => array(
+								'required'          => true,
+								'type'              => 'string',
+								'sanitize_callback' => 'sanitize_text_field',
+							),
+						),
+					)
+				);
+			}
+		);
+	}
+
+	/**
+	 * Serve browser confirmation responses as raw HTML instead of JSON strings.
+	 */
+	private function register_html_response_sender(): void {
+		add_filter(
+			'rest_pre_serve_request',
+			static function ( bool $served, $result, \WP_REST_Request $request ): bool {
+				if ( '/datamachine/v1' . self::RESOLVE_ROUTE !== $request->get_route() || ! $result instanceof \WP_REST_Response ) {
+					return $served;
+				}
+
+				$data = $result->get_data();
+				if ( ! is_string( $data ) ) {
+					return $served;
+				}
+
+				$headers      = $result->get_headers();
+				$content_type = (string) ( $headers['Content-Type'] ?? $headers['content-type'] ?? '' );
+				if ( ! str_contains( strtolower( $content_type ), 'text/html' ) ) {
+					return $served;
+				}
+
+				status_header( $result->get_status() );
+				foreach ( $headers as $header => $value ) {
+					header( $header . ': ' . $value );
+				}
+
+				echo $data; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped HTML is assembled in html_response().
+				return true;
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Ability callback: create signed approve/reject URLs.
+	 */
+	public static function execute( array $input ): array {
+		$action_id = isset( $input['action_id'] ) ? sanitize_text_field( (string) $input['action_id'] ) : '';
+		if ( '' === $action_id ) {
+			return array(
+				'success' => false,
+				'error'   => 'action_id is required.',
+			);
+		}
+
+		$action = PendingActionStore::get( $action_id );
+		if ( null === $action ) {
+			return array(
+				'success'   => false,
+				'error'     => 'Pending action not found or already resolved.',
+				'action_id' => $action_id,
+			);
+		}
+
+		$lifetime   = self::normalize_lifetime( $input['lifetime'] ?? self::DEFAULT_LIFETIME );
+		$expires_at = time() + $lifetime;
+		$resolver   = isset( $input['resolver'] ) ? sanitize_text_field( (string) $input['resolver'] ) : self::DEFAULT_RESOLVER;
+		$resolver   = '' !== $resolver ? $resolver : self::DEFAULT_RESOLVER;
+
+		return array(
+			'success'     => true,
+			'action_id'   => $action_id,
+			'approve_url' => self::url_for_decision( $action_id, WP_Agent_Approval_Decision::ACCEPTED, $expires_at, $resolver ),
+			'reject_url'  => self::url_for_decision( $action_id, WP_Agent_Approval_Decision::REJECTED, $expires_at, $resolver ),
+			'expires_at'  => gmdate( 'c', $expires_at ),
+		);
+	}
+
+	/**
+	 * Public REST callback for signed URL resolution.
+	 */
+	public static function handle_rest( \WP_REST_Request $request ): \WP_REST_Response {
+		$result = self::resolve_token( (string) $request->get_param( self::TOKEN_QUERY_ARG ) );
+		$status = (int) ( $result['status_code'] ?? ( ! empty( $result['success'] ) ? 200 : 400 ) );
+
+		unset( $result['status_code'] );
+
+		if ( self::request_wants_json( $request ) ) {
+			return new \WP_REST_Response( $result, $status );
+		}
+
+		$response = new \WP_REST_Response( self::html_response( $result, $status ), $status );
+		$response->header( 'Content-Type', 'text/html; charset=' . get_option( 'blog_charset', 'UTF-8' ) );
+		return $response;
+	}
+
+	/**
+	 * Resolve a signed token and return a structured result.
+	 */
+	public static function resolve_token( string $token ): array {
+		$payload = self::verify_token( $token );
+		if ( is_wp_error( $payload ) ) {
+			return array(
+				'success'     => false,
+				'error'       => $payload->get_error_message(),
+				'status_code' => 'expired_token' === $payload->get_error_code() ? 410 : 400,
+			);
+		}
+
+		$action_id = sanitize_text_field( (string) ( $payload['action_id'] ?? '' ) );
+		$decision  = sanitize_text_field( (string) ( $payload['decision'] ?? '' ) );
+		$resolver  = sanitize_text_field( (string) ( $payload['resolver'] ?? self::DEFAULT_RESOLVER ) );
+
+		$existing = PendingActionStore::inspect( $action_id );
+		if ( null === $existing ) {
+			return array(
+				'success'     => false,
+				'error'       => 'Pending action not found or expired.',
+				'action_id'   => $action_id,
+				'status_code' => 410,
+			);
+		}
+
+		$status = (string) ( $existing['status'] ?? WP_Agent_Pending_Action_Status::PENDING );
+		if ( WP_Agent_Pending_Action_Status::PENDING !== $status ) {
+			if ( in_array( $status, array( WP_Agent_Approval_Decision::ACCEPTED, WP_Agent_Approval_Decision::REJECTED ), true ) ) {
+				return array(
+					'success'          => true,
+					'already_resolved' => true,
+					'decision'         => $status,
+					'action_id'        => $action_id,
+					'kind'             => (string) ( $existing['kind'] ?? '' ),
+					'status_code'      => 200,
+				);
+			}
+
+			return array(
+				'success'     => false,
+				'error'       => 'Pending action is no longer resolvable.',
+				'action_id'   => $action_id,
+				'decision'    => $status,
+				'status_code' => 410,
+			);
+		}
+
+		$result                = ResolvePendingActionAbility::execute(
+			array(
+				'action_id' => $action_id,
+				'decision'  => $decision,
+				'resolver'  => '' !== $resolver ? $resolver : self::DEFAULT_RESOLVER,
+				'context'   => array( 'resolution_transport' => 'signed_url' ),
+			)
+		);
+		$result['status_code'] = ! empty( $result['success'] ) ? 200 : 400;
+
+		return $result;
+	}
+
+	/**
+	 * Rotate the HMAC secret. Existing signed URLs become invalid.
+	 */
+	public static function rotate_secret(): string {
+		$secret = self::new_secret();
+		update_option( self::OPTION_SECRET, $secret, false );
+		return $secret;
+	}
+
+	private static function url_for_decision( string $action_id, string $decision, int $expires_at, string $resolver ): string {
+		return add_query_arg(
+			self::TOKEN_QUERY_ARG,
+			self::sign_payload(
+				array(
+					'v'          => self::TOKEN_VERSION,
+					'action_id'  => $action_id,
+					'decision'   => $decision,
+					'expires_at' => $expires_at,
+					'nonce'      => wp_generate_uuid4(),
+					'resolver'   => $resolver,
+				)
+			),
+			rest_url( 'datamachine/v1' . self::RESOLVE_ROUTE )
+		);
+	}
+
+	private static function sign_payload( array $payload ): string {
+		$encoded_payload = self::base64url_encode( wp_json_encode( $payload ) );
+		$signature       = hash_hmac( 'sha256', $encoded_payload, self::secret(), true );
+
+		return $encoded_payload . '.' . self::base64url_encode( $signature );
+	}
+
+	/**
+	 * @return array|\WP_Error
+	 */
+	private static function verify_token( string $token ) {
+		$token = trim( $token );
+		if ( '' === $token || ! str_contains( $token, '.' ) ) {
+			return new \WP_Error( 'invalid_token', 'Resolution token is invalid.' );
+		}
+
+		list( $encoded_payload, $encoded_signature ) = explode( '.', $token, 2 );
+		$expected_signature                          = self::base64url_encode( hash_hmac( 'sha256', $encoded_payload, self::secret(), true ) );
+		if ( ! hash_equals( $expected_signature, $encoded_signature ) ) {
+			return new \WP_Error( 'invalid_token', 'Resolution token signature is invalid.' );
+		}
+
+		$decoded = self::base64url_decode( $encoded_payload );
+		$payload = json_decode( $decoded, true );
+		if ( ! is_array( $payload ) ) {
+			return new \WP_Error( 'invalid_token', 'Resolution token payload is invalid.' );
+		}
+
+		if ( self::TOKEN_VERSION !== (int) ( $payload['v'] ?? 0 ) ) {
+			return new \WP_Error( 'invalid_token', 'Resolution token version is unsupported.' );
+		}
+
+		if ( time() > (int) ( $payload['expires_at'] ?? 0 ) ) {
+			return new \WP_Error( 'expired_token', 'Resolution token has expired.' );
+		}
+
+		$decision = (string) ( $payload['decision'] ?? '' );
+		if ( ! in_array( $decision, array( WP_Agent_Approval_Decision::ACCEPTED, WP_Agent_Approval_Decision::REJECTED ), true ) ) {
+			return new \WP_Error( 'invalid_token', 'Resolution token decision is invalid.' );
+		}
+
+		if ( '' === (string) ( $payload['action_id'] ?? '' ) ) {
+			return new \WP_Error( 'invalid_token', 'Resolution token action is invalid.' );
+		}
+
+		return $payload;
+	}
+
+	private static function secret(): string {
+		$secret = get_option( self::OPTION_SECRET, '' );
+		if ( is_string( $secret ) && '' !== $secret ) {
+			return $secret;
+		}
+
+		return self::rotate_secret();
+	}
+
+	private static function new_secret(): string {
+		return bin2hex( random_bytes( 32 ) );
+	}
+
+	private static function normalize_lifetime( $lifetime ): int {
+		$lifetime = (int) $lifetime;
+		if ( $lifetime <= 0 ) {
+			$lifetime = self::DEFAULT_LIFETIME;
+		}
+
+		return min( $lifetime, self::MAX_TOKEN_LIFETIME );
+	}
+
+	private static function request_wants_json( \WP_REST_Request $request ): bool {
+		$accept = (string) $request->get_header( 'accept' );
+		return str_contains( strtolower( $accept ), 'application/json' );
+	}
+
+	private static function html_response( array $result, int $status ): string {
+		$title   = ! empty( $result['success'] ) ? __( 'Pending action resolved', 'data-machine' ) : __( 'Pending action not resolved', 'data-machine' );
+		$message = ! empty( $result['success'] )
+			? sprintf( 'Action %s was %s.', (string) ( $result['action_id'] ?? '' ), (string) ( $result['decision'] ?? 'resolved' ) )
+			: (string) ( $result['error'] ?? 'The pending action could not be resolved.' );
+
+		$html = '<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>' . esc_html( $title ) . '</title></head><body><main><h1>' . esc_html( $title ) . '</h1><p>' . esc_html( $message ) . '</p></main></body></html>';
+
+		return (string) apply_filters( self::HTML_RESPONSE_FILTER, $html, $result, $status );
+	}
+
+	private static function base64url_encode( string $value ): string {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Token payloads use standard base64url encoding.
+		return rtrim( strtr( base64_encode( $value ), '+/', '-_' ), '=' );
+	}
+
+	private static function base64url_decode( string $value ): string {
+		$padding = strlen( $value ) % 4;
+		if ( $padding > 0 ) {
+			$value .= str_repeat( '=', 4 - $padding );
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Token payloads use standard base64url decoding.
+		$decoded = base64_decode( strtr( $value, '-_', '+/' ), true );
+		return false === $decoded ? '' : $decoded;
+	}
+
+	private static function input_schema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'action_id' ),
+			'properties' => array(
+				'action_id' => array(
+					'type'        => 'string',
+					'description' => __( 'The pending action identifier.', 'data-machine' ),
+				),
+				'lifetime'  => array(
+					'type'        => 'integer',
+					'description' => __( 'Signed URL lifetime in seconds. Defaults to 7 days and is capped at 30 days.', 'data-machine' ),
+				),
+				'resolver'  => array(
+					'type'        => 'string',
+					'description' => __( 'Resolver identifier recorded on successful resolution.', 'data-machine' ),
+				),
+			),
+		);
+	}
+
+	private static function output_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success'     => array( 'type' => 'boolean' ),
+				'action_id'   => array( 'type' => 'string' ),
+				'approve_url' => array( 'type' => 'string' ),
+				'reject_url'  => array( 'type' => 'string' ),
+				'expires_at'  => array( 'type' => 'string' ),
+				'error'       => array( 'type' => 'string' ),
+			),
+		);
+	}
+}

--- a/tests/pending-actions-agents-api-contract-smoke.php
+++ b/tests/pending-actions-agents-api-contract-smoke.php
@@ -39,6 +39,7 @@ function datamachine_pending_actions_source( string $path ): string {
 $store_source       = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/PendingActionStore.php' );
 $observers_source   = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/PendingActionObservers.php' );
 $wp_observer_source = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/WordPressActionDispatchObserver.php' );
+$signer_source      = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/SignPendingActionResolutionAbility.php' );
 $adapter_source     = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/PendingActionStoreAdapter.php' );
 $resolver_adapter   = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/PendingActionResolverAdapter.php' );
 $resolver_source    = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/ResolvePendingActionAbility.php' );
@@ -125,6 +126,9 @@ datamachine_pending_actions_assert( str_contains( $resolver_source, 'can_resolve
 datamachine_pending_actions_assert( str_contains( $plugin_source, 'new \\DataMachine\\Engine\\AI\\Actions\\ResolvePendingActionAbility();' ), 'existing resolve ability remains registered', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $plugin_source, 'new \\DataMachine\\Engine\\AI\\Actions\\ResolvePendingAction();' ), 'existing chat resolver tool remains registered', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $plugin_source, 'PendingActionObservers::register' ) && str_contains( $plugin_source, 'WordPressActionDispatchObserver' ), 'default WordPress pending-action observer is registered during bootstrap', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $plugin_source, 'new \\DataMachine\\Engine\\AI\\Actions\\SignPendingActionResolutionAbility();' ), 'signed pending-action resolution ability is registered', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $signer_source, 'datamachine/sign-pending-action-resolution' ) && str_contains( $signer_source, '/actions/resolve-by-token' ), 'signed pending-action resolution exposes ability and public token route', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $signer_source, 'hash_hmac' ) && str_contains( $signer_source, 'datamachine_pending_action_resolution_secret' ), 'signed pending-action resolution uses a stored HMAC secret', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $runtime_source, 'datamachine_migrate_pending_actions_table' ), 'upgrade path creates pending-action table on deployed installs', $failures, $passes );
 
 echo "\n[5] Store contract adapter preserves transient fallback behavior:\n";

--- a/tests/signed-pending-action-resolution-smoke.php
+++ b/tests/signed-pending-action-resolution-smoke.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Pure-PHP smoke coverage for signed pending-action resolution URLs.
+ *
+ * Run with: php tests/signed-pending-action-resolution-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$GLOBALS['__signed_filters']    = array();
+$GLOBALS['__signed_transients'] = array();
+$GLOBALS['__signed_options']    = array();
+
+function datamachine_signed_assert( bool $condition, string $message, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	$failures[] = $message;
+	echo "FAIL: {$message}\n";
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = 'default' ) {
+		unset( $domain );
+		return $text;
+	}
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $value ) {
+		return trim( wp_strip_all_tags( (string) $value ) );
+	}
+}
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( (string) $text );
+	}
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	function wp_generate_uuid4(): string {
+		return '11111111-2222-4333-8444-555555555555';
+	}
+}
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id() {
+		return 0;
+	}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $option, $default = false ) {
+		return $GLOBALS['__signed_options'][ $option ] ?? $default;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $option, $value, $autoload = null ) {
+		unset( $autoload );
+		$GLOBALS['__signed_options'][ $option ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'rest_url' ) ) {
+	function rest_url( string $path = '' ): string {
+		return 'https://example.test/wp-json/' . ltrim( $path, '/' );
+	}
+}
+if ( ! function_exists( 'add_query_arg' ) ) {
+	function add_query_arg( $key, $value, $url ) {
+		return $url . ( str_contains( $url, '?' ) ? '&' : '?' ) . rawurlencode( (string) $key ) . '=' . rawurlencode( (string) $value );
+	}
+}
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook = '' ) {
+		unset( $hook );
+		return 0;
+	}
+}
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook = '' ) {
+		unset( $hook );
+		return false;
+	}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['__signed_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+		ksort( $GLOBALS['__signed_filters'][ $hook ], SORT_NUMERIC );
+		return true;
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		return add_filter( $hook, $callback, $priority, $accepted_args );
+	}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value, ...$args ) {
+		if ( empty( $GLOBALS['__signed_filters'][ $hook ] ) ) {
+			return $value;
+		}
+
+		foreach ( $GLOBALS['__signed_filters'][ $hook ] as $callbacks ) {
+			foreach ( $callbacks as $registration ) {
+				$value = call_user_func_array( $registration[0], array_slice( array_merge( array( $value ), $args ), 0, $registration[1] ) );
+			}
+		}
+
+		return $value;
+	}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook, ...$args ) {
+		apply_filters( $hook, null, ...$args );
+	}
+}
+if ( ! function_exists( 'set_transient' ) ) {
+	function set_transient( $key, $value, $expiration = 0 ) {
+		unset( $expiration );
+		$GLOBALS['__signed_transients'][ $key ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'get_transient' ) ) {
+	function get_transient( $key ) {
+		return $GLOBALS['__signed_transients'][ $key ] ?? false;
+	}
+}
+if ( ! function_exists( 'delete_transient' ) ) {
+	function delete_transient( $key ) {
+		unset( $GLOBALS['__signed_transients'][ $key ] );
+		return true;
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) {
+		return $value instanceof WP_Error;
+	}
+}
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+
+		public function __construct( string $code = '', string $message = '' ) {
+			$this->code    = $code;
+			$this->message = $message;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+require_once dirname( __DIR__ ) . '/vendor/automattic/agents-api/agents-api.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Workspace/WordPressWorkspaceScope.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionObservers.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionStore.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/ResolvePendingActionAbility.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/SignPendingActionResolutionAbility.php';
+
+$failures = array();
+$passes   = 0;
+
+echo "signed-pending-action-resolution-smoke\n";
+
+$action_id = 'act_signed_smoke';
+\DataMachine\Engine\AI\Actions\PendingActionStore::store(
+	$action_id,
+	array(
+		'kind'         => 'signed_smoke',
+		'summary'      => 'Signed URL smoke action',
+		'preview_data' => array( 'title' => 'Preview' ),
+		'apply_input'  => array( 'value' => 42 ),
+		'created_by'   => 0,
+		'agent_id'     => 0,
+		'context'      => array(),
+	)
+);
+
+add_filter(
+	'datamachine_pending_action_handlers',
+	static function ( array $handlers ): array {
+		$handlers['signed_smoke'] = array(
+			'apply' => static function ( array $apply_input ): array {
+				return array(
+					'success' => true,
+					'value'   => $apply_input['value'] ?? null,
+				);
+			},
+		);
+		return $handlers;
+	}
+);
+
+$signed = \DataMachine\Engine\AI\Actions\SignPendingActionResolutionAbility::execute(
+	array(
+		'action_id' => $action_id,
+		'lifetime'  => 60,
+		'resolver'  => 'email_approval',
+	)
+);
+
+datamachine_signed_assert( true === ( $signed['success'] ?? false ), 'signing ability succeeds for pending action', $failures, $passes );
+datamachine_signed_assert( str_contains( (string) ( $signed['approve_url'] ?? '' ), '/actions/resolve-by-token?t=' ), 'approve URL targets token route', $failures, $passes );
+datamachine_signed_assert( str_contains( (string) ( $signed['reject_url'] ?? '' ), '/actions/resolve-by-token?t=' ), 'reject URL targets token route', $failures, $passes );
+datamachine_signed_assert( ! empty( $GLOBALS['__signed_options']['datamachine_pending_action_resolution_secret'] ), 'HMAC secret is generated in wp_options', $failures, $passes );
+
+$query = array();
+parse_str( (string) parse_url( (string) $signed['approve_url'], PHP_URL_QUERY ), $query );
+
+$resolved = \DataMachine\Engine\AI\Actions\SignPendingActionResolutionAbility::resolve_token( (string) ( $query['t'] ?? '' ) );
+
+datamachine_signed_assert( true === ( $resolved['success'] ?? false ), 'valid approve token resolves action', $failures, $passes );
+datamachine_signed_assert( 'accepted' === ( $resolved['decision'] ?? null ), 'approve token records accepted decision', $failures, $passes );
+datamachine_signed_assert( 'signed_smoke' === ( $resolved['kind'] ?? null ), 'resolution keeps pending action kind', $failures, $passes );
+datamachine_signed_assert( null === \DataMachine\Engine\AI\Actions\PendingActionStore::get( $action_id ), 'resolved transient action is no longer pending', $failures, $passes );
+
+\DataMachine\Engine\AI\Actions\SignPendingActionResolutionAbility::rotate_secret();
+$after_rotation = \DataMachine\Engine\AI\Actions\SignPendingActionResolutionAbility::resolve_token( (string) ( $query['t'] ?? '' ) );
+datamachine_signed_assert( false === ( $after_rotation['success'] ?? true ), 'rotating the HMAC secret invalidates existing tokens', $failures, $passes );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFailures:\n";
+	foreach ( $failures as $failure ) {
+		echo " - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nSigned pending-action resolution smoke passed ({$passes} assertions).\n";


### PR DESCRIPTION
## Summary
- Adds `datamachine/sign-pending-action-resolution` to generate signed approve/reject URLs for pending actions.
- Adds public `GET /datamachine/v1/actions/resolve-by-token?t=...` resolution via HMAC tokens, expiry checks, and existing pending-action resolver flow.
- Documents the signed URL surface and covers token generation, resolution, and secret rotation with smoke tests.

Closes #1929.

## Testing
- `php tests/signed-pending-action-resolution-smoke.php`
- `php tests/pending-actions-agents-api-contract-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@feat-signed-pending-action-urls --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@feat-signed-pending-action-urls --extension wordpress --changed-since origin/main`
- `homeboy audit --path /Users/chubes/Developer/data-machine@feat-signed-pending-action-urls --extension wordpress --changed-since origin/main`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the signed pending-action URL ability, REST adapter, documentation, smoke coverage, and local validation; Chris remains responsible for review and merge decisions.