### PR TITLE
Accept canonical chat session owners

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -115,6 +115,7 @@ class AgentsChatHandler {
 				'agent_id'         => $agent_id,
 				'attachments'      => $input['attachments'] ?? array(),
 				'client_context'   => $client_context,
+				'session_owner'    => is_array( $input['session_owner'] ?? null ) ? $input['session_owner'] : null,
 				'transcript_owner' => is_array( $input['transcript_owner'] ?? null ) ? $input['transcript_owner'] : null,
 			)
 		);

--- a/inc/Abilities/Chat/CreateChatSessionAbility.php
+++ b/inc/Abilities/Chat/CreateChatSessionAbility.php
@@ -128,7 +128,9 @@ class CreateChatSessionAbility {
 			$session_metadata['source'] = $source;
 		}
 
-		if ( isset( $input['transcript_owner'] ) && is_array( $input['transcript_owner'] ) ) {
+		if ( isset( $input['session_owner'] ) && is_array( $input['session_owner'] ) ) {
+			$session_metadata['transcript_owner'] = $input['session_owner'];
+		} elseif ( isset( $input['transcript_owner'] ) && is_array( $input['transcript_owner'] ) ) {
 			$session_metadata['transcript_owner'] = $input['transcript_owner'];
 		}
 

--- a/inc/Abilities/Chat/SendMessageAbility.php
+++ b/inc/Abilities/Chat/SendMessageAbility.php
@@ -58,6 +58,10 @@ class SendMessageAbility {
 								'type'        => 'string',
 								'description' => __( 'Existing session ID to continue. Omit to create a new session.', 'data-machine' ),
 							),
+							'session_owner'        => array(
+								'type'        => 'object',
+								'description' => __( 'Canonical opaque owner for persisted conversation sessions.', 'data-machine' ),
+							),
 							'provider'             => array(
 								'type'        => 'string',
 								'description' => __( 'AI provider identifier. Resolved from agent/defaults if omitted.', 'data-machine' ),
@@ -213,6 +217,7 @@ class SendMessageAbility {
 				'agent_id'             => $agent_id,
 				'attachments'          => $input['attachments'] ?? array(),
 				'client_context'       => $input['client_context'] ?? array(),
+				'session_owner'        => is_array( $input['session_owner'] ?? null ) ? $input['session_owner'] : null,
 			)
 		);
 	}

--- a/tests/chat-transcript-owner-smoke.php
+++ b/tests/chat-transcript-owner-smoke.php
@@ -93,6 +93,20 @@ $assert_true( 'browser' === $browser_owner['owner_type'], 'browser owner keeps b
 $assert_true( 42 === $browser_owner['user_id'], 'browser owner preserves runtime user for reporting' );
 $assert_true( hash( 'sha256', 'browser:browser-session-abc' ) === $browser_owner['owner_key_hash'], 'browser owner hashes scoped key' );
 
+$canonical_owner = ChatTranscriptOwner::resolve_for_request(
+	array(
+		'session_owner' => array(
+			'type'  => 'browser',
+			'key'   => 'browser-session-def',
+			'label' => 'Canonical browser',
+		),
+	),
+	42
+);
+$assert_true( ! is_wp_error( $canonical_owner ), 'canonical session_owner resolves' );
+$assert_true( 'browser' === $canonical_owner['owner_type'], 'canonical session_owner keeps browser type' );
+$assert_true( hash( 'sha256', 'browser:browser-session-def' ) === $canonical_owner['owner_key_hash'], 'canonical session_owner hashes scoped key' );
+
 $public_owner = ChatTranscriptOwner::resolve_for_request(
 	array(
 		'transcript_owner' => array(


### PR DESCRIPTION
## Summary
- pass canonical `session_owner` from `agents/chat` into Data Machine chat orchestration
- accept `session_owner` in send-message and create-session abilities while preserving the legacy `transcript_owner` storage path
- add smoke coverage for canonical owner resolution and hashing

## Testing
- `php tests/chat-transcript-owner-smoke.php`
- `php tests/agents-chat-tool-continuation-smoke.php`
- `php -l inc/Abilities/Chat/AgentsChatHandler.php && php -l inc/Abilities/Chat/CreateChatSessionAbility.php && php -l inc/Abilities/Chat/SendMessageAbility.php && php -l tests/chat-transcript-owner-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-canonical-session-owner-chat --extension wordpress --changed-only`

Note: full repo lint still reports pre-existing unrelated JavaScript lint findings outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the adapter changes and smoke coverage; Chris remains responsible for review and validation.