### PR TITLE
Fix fetch steps overwriting prior failures

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -642,6 +642,30 @@ class ExecuteStepAbility {
 		// This applies regardless of whether the flow has historical processed items —
 		// a new flow checking a source with no events is not broken, it just has nothing yet.
 		$is_fetch_step = in_array( $step_type, array( 'fetch', 'event_import' ), true );
+		$prior_status  = $this->getPriorTerminalStatus( $job_id );
+		if ( null !== $prior_status ) {
+			do_action(
+				'datamachine_log',
+				'debug',
+				'Step returned no data after job was already marked failed or rescheduled for retry',
+				array(
+					'job_id'       => $job_id,
+					'pipeline_id'  => $pipeline_id,
+					'flow_id'      => $flow_id,
+					'flow_step_id' => $flow_step_id,
+					'step_class'   => $step_class,
+					'step_type'    => $step_type,
+					'job_status'   => $prior_status,
+				)
+			);
+
+			return array(
+				'success'      => true,
+				'step_success' => false,
+				'outcome'      => 'failed',
+				'error'        => $prior_status,
+			);
+		}
 
 		if ( $is_fetch_step ) {
 			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED_NO_ITEMS );
@@ -676,31 +700,6 @@ class ExecuteStepAbility {
 		// and (when the second reason is non-retryable) trigger
 		// `cleanup_job_data_packets` even though a retry is still pending,
 		// orphaning the next attempt with no input data.
-		$prior_status = $this->getPriorTerminalStatus( $job_id );
-		if ( null !== $prior_status ) {
-			do_action(
-				'datamachine_log',
-				'debug',
-				'Step returned no data after job was already marked failed or rescheduled for retry',
-				array(
-					'job_id'       => $job_id,
-					'pipeline_id'  => $pipeline_id,
-					'flow_id'      => $flow_id,
-					'flow_step_id' => $flow_step_id,
-					'step_class'   => $step_class,
-					'step_type'    => $step_type,
-					'job_status'   => $prior_status,
-				)
-			);
-
-			return array(
-				'success'      => true,
-				'step_success' => false,
-				'outcome'      => 'failed',
-				'error'        => $prior_status,
-			);
-		}
-
 		do_action(
 			'datamachine_log',
 			'error',

--- a/tests/ai-error-status-propagation-smoke.php
+++ b/tests/ai-error-status-propagation-smoke.php
@@ -54,6 +54,7 @@ use DataMachine\Core\Database\Jobs\Jobs;
 
 class DataMachine_Test_Jobs_For_AI_Status extends Jobs {
 	private string $status;
+	public ?string $completed_status = null;
 
 	public function __construct( string $status ) {
 		$this->status = $status;
@@ -64,6 +65,12 @@ class DataMachine_Test_Jobs_For_AI_Status extends Jobs {
 			'job_id' => $job_id,
 			'status' => $this->status,
 		);
+	}
+
+	public function complete_job( int $job_id, string $status ): bool {
+		unset( $job_id );
+		$this->completed_status = $status;
+		return true;
 	}
 }
 
@@ -136,6 +143,52 @@ $invoke_empty_ai_route = function ( string $status ) use ( $build_ability ): arr
 	);
 };
 
+$invoke_empty_fetch_route = function ( string $status ) use ( $build_ability ): array {
+	list( $ability, $route ) = $build_ability( $status );
+
+	return $route->invoke(
+		$ability,
+		123,
+		'fetch_step',
+		9,
+		array(
+			'pipeline_id' => 3,
+			'step_type'   => 'fetch',
+		),
+		'fetch',
+		'DataMachine\Core\Steps\Fetch\FetchStep',
+		array(),
+		array( 'data' => array() ),
+		false,
+		null
+	);
+};
+
+$fetch_completed_status = function ( string $status ) use ( $build_ability ): ?string {
+	list( $ability, $route_method ) = $build_ability( $status );
+	$reflection = new ReflectionClass( $ability );
+	$db_jobs    = $reflection->getProperty( 'db_jobs' )->getValue( $ability );
+
+	$route_method->invoke(
+		$ability,
+		123,
+		'fetch_step',
+		9,
+		array(
+			'pipeline_id' => 3,
+			'step_type'   => 'fetch',
+		),
+		'fetch',
+		'DataMachine\Core\Steps\Fetch\FetchStep',
+		array(),
+		array( 'data' => array() ),
+		false,
+		null
+	);
+
+	return $db_jobs->completed_status;
+};
+
 echo "=== ai-error-status-propagation-smoke ===\n";
 
 $short_circuit_message = 'Step returned no data after job was already marked failed or rescheduled for retry';
@@ -194,6 +247,20 @@ $failure_reason               = is_array( $last_failure ) ? ( $last_failure['arg
 $assert( 'pending without retry still fails through generic path', 'failed' === ( $result['outcome'] ?? '' ) );
 $assert( 'pending without retry still emits fail-job action', 1 === count( $failed_jobs ) );
 $assert( 'pending without retry reason is empty_data_packet_returned', 'empty_data_packet_returned' === $failure_reason );
+
+echo "\n[5] explicit fetch failure is not reclassified as completed_no_items\n";
+$datamachine_action_log       = datamachine_empty_action_log();
+$datamachine_test_engine_data = array();
+$result                       = $invoke_empty_fetch_route( 'failed - mcp_provider_access_forbidden' );
+$failed_jobs                  = $actions_by_hook( 'datamachine_fail_job' );
+$debug_logs                   = $logs_with_message( $short_circuit_message );
+$completed_status             = $fetch_completed_status( 'failed - mcp_provider_access_forbidden' );
+
+$assert( 'fetch route preserves prior provider failure', 'failed' === ( $result['outcome'] ?? '' ) );
+$assert( 'fetch route surfaces provider failure status', 'failed - mcp_provider_access_forbidden' === ( $result['error'] ?? '' ) );
+$assert( 'fetch route does not emit a second fail-job action', empty( $failed_jobs ) );
+$assert( 'fetch route does not complete failed job as no-items', null === $completed_status );
+$assert( 'fetch route logs the short-circuit message', 1 <= count( $debug_logs ) );
 
 if ( $failures > 0 ) {
 	echo "\n=== ai-error-status-propagation-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";


### PR DESCRIPTION
## Summary
- Preserve prior failed/retry statuses before classifying empty fetch results as completed_no_items.
- Prevent provider/auth failures that already called datamachine_fail_job from being silently rewritten as no-item ticks.
- Add smoke coverage for fetch-step prior failures.

## Testing
- php tests/ai-error-status-propagation-smoke.php
- homeboy lint --changed-since origin/main
- homeboy test --changed-since origin/main

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Incident investigation on intelligence.horse ingestion, drafting the failure-preservation fix, and running scoped verification.