### PR TITLE
Fix stale OAuth state feedback in settings

### DIFF
--- a/inc/Core/Admin/Settings/assets/react/SettingsApp.jsx
+++ b/inc/Core/Admin/Settings/assets/react/SettingsApp.jsx
@@ -19,6 +19,7 @@ import GeneralTab from './components/tabs/GeneralTab';
 import ApiKeysTab from './components/tabs/ApiKeysTab';
 import HandlerDefaultsTab from './components/tabs/HandlerDefaultsTab';
 import AuthProvidersTab from './components/tabs/AuthProvidersTab';
+import { useAuthProviders } from './queries/authProviders';
 
 const STORAGE_KEY = 'datamachine_settings_active_tab';
 
@@ -53,6 +54,8 @@ const getOAuthFeedbackFromUrl = () => {
 
 	if ( authSuccess ) {
 		return {
+			code: 'success',
+			provider,
 			type: 'success',
 			message: provider
 				? /* translators: %s: provider name (e.g., Pinterest) */
@@ -73,6 +76,8 @@ const getOAuthFeedbackFromUrl = () => {
 	};
 
 	return {
+		code: authError,
+		provider,
 		type: 'error',
 		message: errorMessages[ authError ] ||
 			/* translators: %s: error code */
@@ -93,13 +98,19 @@ const cleanOAuthParamsFromUrl = () => {
 
 const SettingsApp = () => {
 	const [ activeTab, setActiveTab ] = useState( getInitialTab() );
+	const [ oauthFeedback, setOauthFeedback ] = useState( null );
 	const [ oauthNotice, setOauthNotice ] = useState( null );
+	const shouldReconcileStateError =
+		oauthFeedback?.code === 'invalid_state' && !! oauthFeedback.provider;
+	const { data: authProviders, error: authProvidersError } = useAuthProviders( {
+		enabled: shouldReconcileStateError,
+	} );
 
 	// Handle OAuth callback feedback on mount.
 	useEffect( () => {
 		const feedback = getOAuthFeedbackFromUrl();
 		if ( feedback ) {
-			setOauthNotice( feedback );
+			setOauthFeedback( feedback );
 			// Auto-switch to Auth Providers tab.
 			setActiveTab( 'auth-providers' );
 			localStorage.setItem( STORAGE_KEY, 'auth-providers' );
@@ -107,6 +118,42 @@ const SettingsApp = () => {
 			cleanOAuthParamsFromUrl();
 		}
 	}, [] );
+
+	useEffect( () => {
+		if ( ! oauthFeedback ) {
+			return;
+		}
+
+		if ( oauthFeedback.code !== 'invalid_state' || ! oauthFeedback.provider ) {
+			setOauthNotice( oauthFeedback );
+			return;
+		}
+
+		if ( ! authProviders && ! authProvidersError ) {
+			return;
+		}
+
+		const connectedProvider = authProviders?.find(
+			( provider ) =>
+				provider.provider_key === oauthFeedback.provider &&
+				provider.is_authenticated
+		);
+
+		setOauthNotice(
+			connectedProvider
+				? {
+						...oauthFeedback,
+						type: 'success',
+						message:
+							/* translators: %s: provider name (e.g., Pinterest) */
+							sprintf(
+								__( 'Successfully connected to %s.', 'data-machine' ),
+								connectedProvider.label || oauthFeedback.provider
+							),
+				  }
+				: oauthFeedback
+		);
+	}, [ oauthFeedback, authProviders, authProvidersError ] );
 
 	const handleSelect = useCallback( ( tabName ) => {
 		setActiveTab( tabName );

--- a/inc/Core/Admin/Settings/assets/react/SettingsApp.jsx
+++ b/inc/Core/Admin/Settings/assets/react/SettingsApp.jsx
@@ -40,17 +40,18 @@ const getInitialTab = () => {
 /**
  * Get OAuth callback feedback from URL query params.
  *
- * @returns {Object|null} Feedback object or null if no OAuth params present.
+ * @return {Object|null} Feedback object or null if no OAuth params present.
  */
 const getOAuthFeedbackFromUrl = () => {
 	const urlParams = new URLSearchParams( window.location.search );
 	const authSuccess = urlParams.get( 'auth_success' );
 	const authError = urlParams.get( 'auth_error' );
-	const provider = urlParams.get( 'provider' );
 
 	if ( ! authSuccess && ! authError ) {
 		return null;
 	}
+
+	const provider = urlParams.get( 'provider' );
 
 	if ( authSuccess ) {
 		return {
@@ -138,18 +139,20 @@ const SettingsApp = () => {
 				provider.provider_key === oauthFeedback.provider &&
 				provider.is_authenticated
 		);
+		const connectedProviderName =
+			connectedProvider?.label || oauthFeedback.provider;
+		const connectedMessage = sprintf(
+			/* translators: %s: provider name (e.g., Pinterest) */
+			__( 'Successfully connected to %s.', 'data-machine' ),
+			connectedProviderName
+		);
 
 		setOauthNotice(
 			connectedProvider
 				? {
 						...oauthFeedback,
 						type: 'success',
-						message:
-							/* translators: %s: provider name (e.g., Pinterest) */
-							sprintf(
-								__( 'Successfully connected to %s.', 'data-machine' ),
-								connectedProvider.label || oauthFeedback.provider
-							),
+						message: connectedMessage,
 				  }
 				: oauthFeedback
 		);

--- a/inc/Core/Admin/Settings/assets/react/queries/authProviders.js
+++ b/inc/Core/Admin/Settings/assets/react/queries/authProviders.js
@@ -20,7 +20,7 @@ export const AUTH_PROVIDERS_KEY = [ 'authProviders' ];
 /**
  * Fetch all registered auth providers with status
  */
-export const useAuthProviders = () => {
+export const useAuthProviders = ( options = {} ) => {
 	return useQuery( {
 		queryKey: AUTH_PROVIDERS_KEY,
 		queryFn: async () => {
@@ -33,6 +33,7 @@ export const useAuthProviders = () => {
 			return response.data;
 		},
 		staleTime: 30 * 1000,
+		...options,
 	} );
 };
 

--- a/inc/Core/Admin/Settings/assets/react/queries/authProviders.js
+++ b/inc/Core/Admin/Settings/assets/react/queries/authProviders.js
@@ -19,6 +19,8 @@ export const AUTH_PROVIDERS_KEY = [ 'authProviders' ];
 
 /**
  * Fetch all registered auth providers with status
+ *
+ * @param {Object} options TanStack Query options.
  */
 export const useAuthProviders = ( options = {} ) => {
 	return useQuery( {


### PR DESCRIPTION
## Summary
- Reconcile settings-page invalid OAuth state callbacks against the current provider connection state.
- Show the success notice when a duplicate or stale callback reports invalid_state after the account is already connected.
- Allow auth provider query options so the extra reconciliation fetch only runs for this callback case.

## Testing
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the OAuth callback/settings feedback path, drafted the React fix, and ran the frontend build. Chris requested the PR.