### PR TITLE
fix: run fetch handlers as flow owner

### DIFF
--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -130,6 +130,16 @@ class FetchStep extends Step {
 		$handler_settings['flow_step_id'] = $this->flow_step_config['flow_step_id'];
 		$handler_settings['pipeline_id']  = $this->flow_step_config['pipeline_id'];
 		$handler_settings['flow_id']      = $this->flow_step_config['flow_id'];
+		$job_context                      = $this->engine->getJobContext();
+		$owner_user_id                    = (int) ( $job_context['user_id'] ?? 0 );
+		$agent_id                         = (int) ( $job_context['agent_id'] ?? 0 );
+
+		if ( $owner_user_id > 0 ) {
+			$handler_settings['user_id'] = $owner_user_id;
+		}
+		if ( $agent_id > 0 ) {
+			$handler_settings['agent_id'] = $agent_id;
+		}
 
 		$resolved_handler_settings = AuthRefHandlerConfig::resolve_runtime_config(
 			$handler_settings,
@@ -139,6 +149,8 @@ class FetchStep extends Step {
 				'pipeline_id'  => $this->flow_step_config['pipeline_id'],
 				'flow_id'      => $this->flow_step_config['flow_id'],
 				'job_id'       => $this->job_id,
+				'user_id'      => $owner_user_id,
+				'agent_id'     => $agent_id,
 			)
 		);
 
@@ -149,7 +161,7 @@ class FetchStep extends Step {
 
 		$handler_settings = $resolved_handler_settings;
 
-		$packets = $this->execute_handler( $handler, $handler_settings, (string) $this->job_id );
+		$packets = $this->execute_handler_as_owner( $handler, $handler_settings, (string) $this->job_id, $owner_user_id );
 
 		if ( empty( $packets ) ) {
 			$this->log( 'error', 'Fetch handler returned no content' );
@@ -216,6 +228,39 @@ class FetchStep extends Step {
 				)
 			);
 			return array();
+		}
+	}
+
+	/**
+	 * Execute the fetch handler as the flow owner when one is known.
+	 *
+	 * Scheduled fetches often run without a logged-in WordPress user. Principal-
+	 * scoped auth providers still need the flow owner as current user so handler
+	 * code can resolve user-scoped OAuth credentials without falling back to an
+	 * anonymous/site context.
+	 *
+	 * @param string $handler_name Handler slug.
+	 * @param array  $handler_settings Handler settings.
+	 * @param string $job_id Job ID.
+	 * @param int    $owner_user_id Flow owner user ID.
+	 * @return DataPacket[] Array of DataPackets, or empty array on failure.
+	 */
+	private function execute_handler_as_owner( string $handler_name, array $handler_settings, string $job_id, int $owner_user_id ): array {
+		if ( $owner_user_id <= 0 || ! function_exists( 'wp_set_current_user' ) || ! function_exists( 'get_current_user_id' ) ) {
+			return $this->execute_handler( $handler_name, $handler_settings, $job_id );
+		}
+
+		$previous_user_id = (int) get_current_user_id();
+		if ( $previous_user_id !== $owner_user_id ) {
+			wp_set_current_user( $owner_user_id );
+		}
+
+		try {
+			return $this->execute_handler( $handler_name, $handler_settings, $job_id );
+		} finally {
+			if ( $previous_user_id !== $owner_user_id ) {
+				wp_set_current_user( $previous_user_id );
+			}
 		}
 	}
 

--- a/tests/fetch-owner-auth-context-smoke.php
+++ b/tests/fetch-owner-auth-context-smoke.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Pure-PHP smoke test for fetch owner auth context.
+ *
+ * Run with: php tests/fetch-owner-auth-context-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$root = dirname( __DIR__ );
+$file = file_get_contents( $root . '/inc/Core/Steps/Fetch/FetchStep.php' ) ?: '';
+
+$failed = 0;
+$total  = 0;
+
+function assert_fetch_owner_auth_context( string $name, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+
+	++$failed;
+	echo "  [FAIL] {$name}\n";
+}
+
+echo "=== fetch-owner-auth-context-smoke ===\n";
+
+assert_fetch_owner_auth_context(
+	'FetchStep reads owner user_id from engine job context',
+	str_contains( $file, "\$owner_user_id                    = (int) ( \$job_context['user_id'] ?? 0 );" )
+);
+
+assert_fetch_owner_auth_context(
+	'FetchStep passes user_id into handler settings',
+	str_contains( $file, "\$handler_settings['user_id'] = \$owner_user_id;" )
+);
+
+assert_fetch_owner_auth_context(
+	'FetchStep passes agent_id into handler settings',
+	str_contains( $file, "\$handler_settings['agent_id'] = \$agent_id;" )
+);
+
+assert_fetch_owner_auth_context(
+	'FetchStep passes principal context to auth_ref resolver',
+	str_contains( $file, "'user_id'      => \$owner_user_id," ) && str_contains( $file, "'agent_id'     => \$agent_id," )
+);
+
+assert_fetch_owner_auth_context(
+	'FetchStep executes handlers as owner user',
+	str_contains( $file, 'private function execute_handler_as_owner' ) && str_contains( $file, 'wp_set_current_user( $owner_user_id );' )
+);
+
+assert_fetch_owner_auth_context(
+	'FetchStep restores previous current user',
+	str_contains( $file, 'wp_set_current_user( $previous_user_id );' )
+);
+
+if ( $failed > 0 ) {
+	echo "\nfetch-owner-auth-context-smoke failed: {$failed}/{$total} assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nfetch-owner-auth-context-smoke passed: {$total} assertions.\n";


### PR DESCRIPTION
## Summary
- pass flow owner and agent context into fetch handler settings/auth_ref resolution
- run fetch handlers with the flow owner as the current WordPress user so principal-scoped OAuth credentials resolve during scheduled/background fetches
- add a smoke test covering the owner auth-context wiring

## Testing
- php tests/fetch-owner-auth-context-smoke.php
- php tests/ai-error-status-propagation-smoke.php
- homeboy lint --changed-since origin/main
- homeboy test --changed-since origin/main

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the scheduled fetch OAuth context failure, drafted the code/test changes, and ran verification; Chris remains responsible for review and merge.