### PR TITLE
Fix taxonomy CLI ability contract

### DIFF
--- a/inc/Abilities/Taxonomy/AbstractTaxonomyAbility.php
+++ b/inc/Abilities/Taxonomy/AbstractTaxonomyAbility.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Shared Taxonomy Ability scaffolding.
+ *
+ * @package DataMachine\Abilities\Taxonomy
+ */
+
+namespace DataMachine\Abilities\Taxonomy;
+
+use DataMachine\Abilities\PermissionHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+abstract class AbstractTaxonomyAbility {
+
+	public function __construct() {
+		$this->registerAbility();
+	}
+
+	/**
+	 * Ability name registered with the WordPress Abilities API.
+	 *
+	 * @return string
+	 */
+	abstract protected function getAbilityName(): string;
+
+	/**
+	 * Ability registration arguments.
+	 *
+	 * @return array
+	 */
+	abstract protected function getAbilityArgs(): array;
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability( $this->getAbilityName(), $this->getAbilityArgs() );
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Check permission for taxonomy abilities.
+	 *
+	 * @return bool True if user has permission.
+	 */
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+}

--- a/inc/Abilities/Taxonomy/CreateTaxonomyTermAbility.php
+++ b/inc/Abilities/Taxonomy/CreateTaxonomyTermAbility.php
@@ -10,27 +10,22 @@
 
 namespace DataMachine\Abilities\Taxonomy;
 
-use DataMachine\Abilities\PermissionHelper;
-
 use DataMachine\Core\WordPress\TaxonomyHandler;
 
 defined( 'ABSPATH' ) || exit;
 
-class CreateTaxonomyTermAbility {
+class CreateTaxonomyTermAbility extends AbstractTaxonomyAbility {
 
-	public function __construct() {
-		$this->registerAbility();
+	protected function getAbilityName(): string {
+		return 'datamachine/create-taxonomy-term';
 	}
 
-	private function registerAbility(): void {
-		$register_callback = function () {
-			wp_register_ability(
-				'datamachine/create-taxonomy-term',
-				array(
-					'label'               => __( 'Create Taxonomy Term', 'data-machine' ),
-					'description'         => __( 'Create a new taxonomy term. The term will be created if it does not already exist.', 'data-machine' ),
-					'category'            => 'datamachine-taxonomy',
-					'input_schema'        => array(
+	protected function getAbilityArgs(): array {
+		return array(
+			'label'               => __( 'Create Taxonomy Term', 'data-machine' ),
+			'description'         => __( 'Create a new taxonomy term. The term will be created if it does not already exist.', 'data-machine' ),
+			'category'            => 'datamachine-taxonomy',
+			'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
 							'taxonomy'    => array(
@@ -58,7 +53,7 @@ class CreateTaxonomyTermAbility {
 						),
 						'required'   => array( 'taxonomy', 'name' ),
 					),
-					'output_schema'       => array(
+			'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
 							'success'   => array( 'type' => 'boolean' ),
@@ -71,18 +66,10 @@ class CreateTaxonomyTermAbility {
 							'error'     => array( 'type' => 'string' ),
 						),
 					),
-					'execute_callback'    => array( $this, 'execute' ),
-					'permission_callback' => array( $this, 'checkPermission' ),
-					'meta'                => array( 'show_in_rest' => true ),
-				)
-			);
-		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+			'execute_callback'    => array( $this, 'execute' ),
+			'permission_callback' => array( $this, 'checkPermission' ),
+			'meta'                => array( 'show_in_rest' => true ),
+		);
 	}
 
 	/**
@@ -209,12 +196,4 @@ class CreateTaxonomyTermAbility {
 		);
 	}
 
-	/**
-	 * Check permission for this ability.
-	 *
-	 * @return bool True if user has permission.
-	 */
-	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
-	}
 }

--- a/inc/Abilities/Taxonomy/DeleteTaxonomyTermAbility.php
+++ b/inc/Abilities/Taxonomy/DeleteTaxonomyTermAbility.php
@@ -10,27 +10,22 @@
 
 namespace DataMachine\Abilities\Taxonomy;
 
-use DataMachine\Abilities\PermissionHelper;
-
 use DataMachine\Core\WordPress\TaxonomyHandler;
 
 defined( 'ABSPATH' ) || exit;
 
-class DeleteTaxonomyTermAbility {
+class DeleteTaxonomyTermAbility extends AbstractTaxonomyAbility {
 
-	public function __construct() {
-		$this->registerAbility();
+	protected function getAbilityName(): string {
+		return 'datamachine/delete-taxonomy-term';
 	}
 
-	private function registerAbility(): void {
-		$register_callback = function () {
-			wp_register_ability(
-				'datamachine/delete-taxonomy-term',
-				array(
-					'label'               => __( 'Delete Taxonomy Term', 'data-machine' ),
-					'description'         => __( 'Delete an existing taxonomy term. Optionally reassign posts to another term.', 'data-machine' ),
-					'category'            => 'datamachine-taxonomy',
-					'input_schema'        => array(
+	protected function getAbilityArgs(): array {
+		return array(
+			'label'               => __( 'Delete Taxonomy Term', 'data-machine' ),
+			'description'         => __( 'Delete an existing taxonomy term. Optionally reassign posts to another term.', 'data-machine' ),
+			'category'            => 'datamachine-taxonomy',
+			'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
 							'term'     => array(
@@ -50,7 +45,7 @@ class DeleteTaxonomyTermAbility {
 						),
 						'required'   => array( 'term', 'taxonomy' ),
 					),
-					'output_schema'       => array(
+			'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
 							'success'    => array( 'type' => 'boolean' ),
@@ -62,18 +57,10 @@ class DeleteTaxonomyTermAbility {
 							'error'      => array( 'type' => 'string' ),
 						),
 					),
-					'execute_callback'    => array( $this, 'execute' ),
-					'permission_callback' => array( $this, 'checkPermission' ),
-					'meta'                => array( 'show_in_rest' => true ),
-				)
-			);
-		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+			'execute_callback'    => array( $this, 'execute' ),
+			'permission_callback' => array( $this, 'checkPermission' ),
+			'meta'                => array( 'show_in_rest' => true ),
+		);
 	}
 
 	/**
@@ -190,12 +177,4 @@ class DeleteTaxonomyTermAbility {
 		);
 	}
 
-	/**
-	 * Check permission for this ability.
-	 *
-	 * @return bool True if user has permission.
-	 */
-	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
-	}
 }

--- a/inc/Abilities/Taxonomy/GetTaxonomyTermsAbility.php
+++ b/inc/Abilities/Taxonomy/GetTaxonomyTermsAbility.php
@@ -10,27 +10,22 @@
 
 namespace DataMachine\Abilities\Taxonomy;
 
-use DataMachine\Abilities\PermissionHelper;
-
 use DataMachine\Core\WordPress\TaxonomyHandler;
 
 defined( 'ABSPATH' ) || exit;
 
-class GetTaxonomyTermsAbility {
+class GetTaxonomyTermsAbility extends AbstractTaxonomyAbility {
 
-	public function __construct() {
-		$this->registerAbility();
+	protected function getAbilityName(): string {
+		return 'datamachine/get-taxonomy-terms';
 	}
 
-	private function registerAbility(): void {
-		$register_callback = function () {
-			wp_register_ability(
-				'datamachine/get-taxonomy-terms',
-				array(
-					'label'               => __( 'Get Taxonomy Terms', 'data-machine' ),
-					'description'         => __( 'Retrieve taxonomy terms with optional filtering by taxonomy, search, and pagination.', 'data-machine' ),
-					'category'            => 'datamachine-taxonomy',
-					'input_schema'        => array(
+	protected function getAbilityArgs(): array {
+		return array(
+			'label'               => __( 'Get Taxonomy Terms', 'data-machine' ),
+			'description'         => __( 'Retrieve taxonomy terms with optional filtering by taxonomy, search, and pagination.', 'data-machine' ),
+			'category'            => 'datamachine-taxonomy',
+			'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
 							'taxonomy'   => array(
@@ -69,7 +64,7 @@ class GetTaxonomyTermsAbility {
 							),
 						),
 					),
-					'output_schema'       => array(
+			'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
 							'success' => array( 'type' => 'boolean' ),
@@ -91,18 +86,10 @@ class GetTaxonomyTermsAbility {
 							'error'   => array( 'type' => 'string' ),
 						),
 					),
-					'execute_callback'    => array( $this, 'execute' ),
-					'permission_callback' => array( $this, 'checkPermission' ),
-					'meta'                => array( 'show_in_rest' => true ),
-				)
-			);
-		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+			'execute_callback'    => array( $this, 'execute' ),
+			'permission_callback' => array( $this, 'checkPermission' ),
+			'meta'                => array( 'show_in_rest' => true ),
+		);
 	}
 
 	/**
@@ -190,12 +177,4 @@ class GetTaxonomyTermsAbility {
 		);
 	}
 
-	/**
-	 * Check permission for this ability.
-	 *
-	 * @return bool True if user has permission.
-	 */
-	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
-	}
 }

--- a/inc/Abilities/Taxonomy/UpdateTaxonomyTermAbility.php
+++ b/inc/Abilities/Taxonomy/UpdateTaxonomyTermAbility.php
@@ -10,27 +10,22 @@
 
 namespace DataMachine\Abilities\Taxonomy;
 
-use DataMachine\Abilities\PermissionHelper;
-
 use DataMachine\Core\WordPress\TaxonomyHandler;
 
 defined( 'ABSPATH' ) || exit;
 
-class UpdateTaxonomyTermAbility {
+class UpdateTaxonomyTermAbility extends AbstractTaxonomyAbility {
 
-	public function __construct() {
-		$this->registerAbility();
+	protected function getAbilityName(): string {
+		return 'datamachine/update-taxonomy-term';
 	}
 
-	private function registerAbility(): void {
-		$register_callback = function () {
-			wp_register_ability(
-				'datamachine/update-taxonomy-term',
-				array(
-					'label'               => __( 'Update Taxonomy Term', 'data-machine' ),
-					'description'         => __( 'Update an existing taxonomy term. Supports updating name, slug, description, and parent.', 'data-machine' ),
-					'category'            => 'datamachine-taxonomy',
-					'input_schema'        => array(
+	protected function getAbilityArgs(): array {
+		return array(
+			'label'               => __( 'Update Taxonomy Term', 'data-machine' ),
+			'description'         => __( 'Update an existing taxonomy term. Supports updating name, slug, description, and parent.', 'data-machine' ),
+			'category'            => 'datamachine-taxonomy',
+			'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
 							'term'        => array(
@@ -62,7 +57,7 @@ class UpdateTaxonomyTermAbility {
 						),
 						'required'   => array( 'term', 'taxonomy' ),
 					),
-					'output_schema'       => array(
+			'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
 							'success'   => array( 'type' => 'boolean' ),
@@ -75,18 +70,10 @@ class UpdateTaxonomyTermAbility {
 							'error'     => array( 'type' => 'string' ),
 						),
 					),
-					'execute_callback'    => array( $this, 'execute' ),
-					'permission_callback' => array( $this, 'checkPermission' ),
-					'meta'                => array( 'show_in_rest' => true ),
-				)
-			);
-		};
-
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+			'execute_callback'    => array( $this, 'execute' ),
+			'permission_callback' => array( $this, 'checkPermission' ),
+			'meta'                => array( 'show_in_rest' => true ),
+		);
 	}
 
 	/**
@@ -259,12 +246,4 @@ class UpdateTaxonomyTermAbility {
 		);
 	}
 
-	/**
-	 * Check permission for this ability.
-	 *
-	 * @return bool True if user has permission.
-	 */
-	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
-	}
 }

--- a/inc/Cli/Commands/TaxonomyCommand.php
+++ b/inc/Cli/Commands/TaxonomyCommand.php
@@ -227,7 +227,7 @@ class TaxonomyCommand extends BaseCommand {
 			return;
 		}
 
-		WP_CLI::success( sprintf( 'Created term "%s" (ID: %d).', $result['name'] ?? $name, $result['term_id'] ?? 0 ) );
+		WP_CLI::success( sprintf( 'Created term "%s" (ID: %d).', $result['term_name'] ?? $name, $result['term_id'] ?? 0 ) );
 
 		if ( 'json' === $format ) {
 			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
@@ -241,6 +241,9 @@ class TaxonomyCommand extends BaseCommand {
 	 *
 	 * <term_id>
 	 * : Term ID to update.
+	 *
+	 * --taxonomy=<taxonomy>
+	 * : Taxonomy slug.
 	 *
 	 * [--name=<name>]
 	 * : New term name.
@@ -256,20 +259,29 @@ class TaxonomyCommand extends BaseCommand {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp datamachine taxonomy update 5 --name="Renamed Category"
-	 *     wp datamachine taxonomy update 5 --slug=renamed-cat
+	 *     wp datamachine taxonomy update 5 --taxonomy=category --name="Renamed Category"
+	 *     wp datamachine taxonomy update 5 --taxonomy=category --slug=renamed-cat
 	 *
 	 * @subcommand update
 	 */
 	public function update( array $args, array $assoc_args ): void {
-		$term_id = (int) ( $args[0] ?? 0 );
+		$term_id  = (int) ( $args[0] ?? 0 );
+		$taxonomy = $assoc_args['taxonomy'] ?? '';
 
 		if ( $term_id <= 0 ) {
 			WP_CLI::error( 'Valid term ID is required.' );
 			return;
 		}
 
-		$input = array( 'term_id' => $term_id );
+		if ( empty( $taxonomy ) ) {
+			WP_CLI::error( 'Taxonomy is required (--taxonomy=<slug>).' );
+			return;
+		}
+
+		$input = array(
+			'term'     => (string) $term_id,
+			'taxonomy' => $taxonomy,
+		);
 
 		if ( isset( $assoc_args['name'] ) ) {
 			$input['name'] = $assoc_args['name'];
@@ -302,18 +314,22 @@ class TaxonomyCommand extends BaseCommand {
 	 * <term_id>
 	 * : Term ID to delete.
 	 *
+	 * --taxonomy=<taxonomy>
+	 * : Taxonomy slug.
+	 *
 	 * [--yes]
 	 * : Skip confirmation prompt.
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp datamachine taxonomy delete 5
-	 *     wp datamachine taxonomy delete 5 --yes
+	 *     wp datamachine taxonomy delete 5 --taxonomy=category
+	 *     wp datamachine taxonomy delete 5 --taxonomy=category --yes
 	 *
 	 * @subcommand delete
 	 */
 	public function delete( array $args, array $assoc_args ): void {
 		$term_id      = (int) ( $args[0] ?? 0 );
+		$taxonomy     = $assoc_args['taxonomy'] ?? '';
 		$skip_confirm = isset( $assoc_args['yes'] );
 
 		if ( $term_id <= 0 ) {
@@ -321,11 +337,21 @@ class TaxonomyCommand extends BaseCommand {
 			return;
 		}
 
+		if ( empty( $taxonomy ) ) {
+			WP_CLI::error( 'Taxonomy is required (--taxonomy=<slug>).' );
+			return;
+		}
+
 		if ( ! $skip_confirm ) {
 			WP_CLI::confirm( sprintf( 'Delete term %d?', $term_id ) );
 		}
 
-		$result = ( new DeleteTaxonomyTermAbility() )->execute( array( 'term_id' => $term_id ) );
+		$result = ( new DeleteTaxonomyTermAbility() )->execute(
+			array(
+				'term'     => (string) $term_id,
+				'taxonomy' => $taxonomy,
+			)
+		);
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to delete term.' );

--- a/tests/taxonomy-ability-cleanup-smoke.php
+++ b/tests/taxonomy-ability-cleanup-smoke.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Pure-PHP smoke test for taxonomy ability cleanup and CLI contracts.
+ *
+ * Run with: php tests/taxonomy-ability-cleanup-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failed = 0;
+$total  = 0;
+
+/**
+ * Assert helper.
+ *
+ * @param string $name      Test case name.
+ * @param bool   $condition Pass/fail.
+ */
+function assert_taxonomy_ability_cleanup( string $name, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$name}\n";
+		return;
+	}
+	echo "  FAIL: {$name}\n";
+	++$failed;
+}
+
+$root_dir         = dirname( __DIR__ );
+$taxonomy_command = (string) file_get_contents( $root_dir . '/inc/Cli/Commands/TaxonomyCommand.php' );
+
+echo "=== Taxonomy Ability Cleanup Smoke ===\n";
+
+echo "\n[abilities:1] Concrete taxonomy abilities use shared scaffolding\n";
+foreach ( array(
+	'CreateTaxonomyTermAbility',
+	'DeleteTaxonomyTermAbility',
+	'GetTaxonomyTermsAbility',
+	'UpdateTaxonomyTermAbility',
+) as $class ) {
+	$contents = (string) file_get_contents( $root_dir . "/inc/Abilities/Taxonomy/{$class}.php" );
+	assert_taxonomy_ability_cleanup( "{$class} extends AbstractTaxonomyAbility", false !== strpos( $contents, "class {$class} extends AbstractTaxonomyAbility" ) );
+	assert_taxonomy_ability_cleanup( "{$class} has no duplicated registerAbility method", false === strpos( $contents, 'function registerAbility' ) );
+}
+
+echo "\n[cli:1] Taxonomy update/delete pass ability contract inputs\n";
+assert_taxonomy_ability_cleanup( 'update documents --taxonomy option', false !== strpos( $taxonomy_command, 'wp datamachine taxonomy update 5 --taxonomy=category' ) );
+assert_taxonomy_ability_cleanup( 'delete documents --taxonomy option', false !== strpos( $taxonomy_command, 'wp datamachine taxonomy delete 5 --taxonomy=category' ) );
+assert_taxonomy_ability_cleanup( 'update passes term input', false !== strpos( $taxonomy_command, "'term'     => (string) \$term_id" ) );
+assert_taxonomy_ability_cleanup( 'delete passes taxonomy input', false !== strpos( $taxonomy_command, "'taxonomy' => \$taxonomy" ) );
+
+echo "\n";
+if ( 0 === $failed ) {
+	echo "=== taxonomy-ability-cleanup-smoke: ALL PASS ({$total}) ===\n";
+	exit( 0 );
+}
+
+echo "=== taxonomy-ability-cleanup-smoke: {$failed} FAIL of {$total} ===\n";
+exit( 1 );


### PR DESCRIPTION
## Summary
- Extract shared taxonomy ability registration/permission scaffolding into `AbstractTaxonomyAbility`.
- Keep concrete taxonomy abilities focused on schemas and execution logic.
- Align taxonomy CLI update/delete calls with the ability contract by requiring `--taxonomy` and passing `term` plus `taxonomy`.
- Fix taxonomy create CLI output to read `term_name` from the ability response.

## Testing
- `php -l inc/Abilities/Taxonomy/AbstractTaxonomyAbility.php && php -l inc/Abilities/Taxonomy/CreateTaxonomyTermAbility.php && php -l inc/Abilities/Taxonomy/DeleteTaxonomyTermAbility.php && php -l inc/Abilities/Taxonomy/GetTaxonomyTermsAbility.php && php -l inc/Abilities/Taxonomy/UpdateTaxonomyTermAbility.php && php -l inc/Cli/Commands/TaxonomyCommand.php && php -l tests/taxonomy-ability-cleanup-smoke.php`
- `vendor/bin/phpcs --standard=WordPress inc/Abilities/Taxonomy/AbstractTaxonomyAbility.php inc/Abilities/Taxonomy/CreateTaxonomyTermAbility.php inc/Abilities/Taxonomy/DeleteTaxonomyTermAbility.php inc/Abilities/Taxonomy/GetTaxonomyTermsAbility.php inc/Abilities/Taxonomy/UpdateTaxonomyTermAbility.php inc/Cli/Commands/TaxonomyCommand.php tests/taxonomy-ability-cleanup-smoke.php`
- `php tests/taxonomy-ability-cleanup-smoke.php`
- `php tests/cleanup-cluster-smoke.php`

## Notes
- Full Homeboy Playground review is currently blocked by a validation dependency resolver issue that can mount a stale local `agents-api` checkout instead of the consumer's locked dependency: https://github.com/Extra-Chill/homeboy-extensions/issues/707
- `tests/cleanup-cluster-smoke.php` passes, but emits an existing warning when the injected local `AGENTS.md` symlink target is not present in this worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the taxonomy scaffold cleanup, CLI contract fix, smoke test, and local verification. Chris reviewed direction and requested the PR.