### PR TITLE
Canary WP Codebox test runtime

### DIFF
--- a/.github/workflows/wp-codebox-test-canary.yml
+++ b/.github/workflows/wp-codebox-test-canary.yml
@@ -1,0 +1,53 @@
+name: WP Codebox test canary
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  wp-codebox-test:
+    name: Data Machine PHPUnit via WP Codebox
+    runs-on: ubuntu-latest
+    env:
+      HOMEBOY_WORDPRESS_TEST_RUNTIME: wp-codebox
+      HOMEBOY_WORDPRESS_DEPENDENCY_PATHS: ${{ github.workspace }}/.ci/agents-api
+      HOMEBOY_WP_CODEBOX_BIN: ${{ github.workspace }}/.ci/wp-codebox/packages/cli/dist/index.js
+    steps:
+      - name: Checkout Data Machine
+        uses: actions/checkout@v6
+
+      - name: Checkout Agents API dependency
+        uses: actions/checkout@v6
+        with:
+          repository: Automattic/agents-api
+          path: .ci/agents-api
+
+      - name: Checkout WP Codebox
+        uses: actions/checkout@v6
+        with:
+          repository: chubes4/wp-codebox
+          path: .ci/wp-codebox
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: .ci/wp-codebox/package-lock.json
+
+      - name: Build WP Codebox CLI
+        working-directory: .ci/wp-codebox
+        run: |
+          npm ci
+          npm run build
+
+      - name: Run Homeboy test canary
+        uses: Extra-Chill/homeboy-action@v2
+        with:
+          commands: test
+          expected-commands: test
+          autofix: 'false'


### PR DESCRIPTION
## Summary
- Add a dedicated GitHub Actions canary for running Data Machine PHPUnit tests through the WP Codebox Homeboy backend.
- Build WP Codebox in CI and mount a fresh `Automattic/agents-api` checkout as the validation dependency.
- Leave the default Homeboy CI workflow unchanged while the runtime rollout continues.

## Verification
- Local equivalent passed without dependency override after resolving the local `agents-api` component path: `1295` tests, `4148` assertions, `3` skipped.
- Workflow syntax reviewed locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the canary workflow based on the verified local command shape and prepared the PR.