### PR TITLE
Remove redundant Action Scheduler guards

### DIFF
--- a/inc/Abilities/Engine/ScheduleFlowAbility.php
+++ b/inc/Abilities/Engine/ScheduleFlowAbility.php
@@ -94,9 +94,7 @@ class ScheduleFlowAbility {
 		$interval_or_timestamp = $input['interval_or_timestamp'] ?? null;
 
 		// Always unschedule existing to prevent duplicates.
-		if ( function_exists( 'as_unschedule_all_actions' ) ) {
-			as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
-		}
+		as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
 
 		if ( 'manual' === $interval_or_timestamp ) {
 			return $this->clearSchedule( $flow_id );
@@ -148,13 +146,6 @@ class ScheduleFlowAbility {
 	 * @return array Result.
 	 */
 	private function scheduleOneTime( int $flow_id, int $timestamp ): array {
-		if ( ! function_exists( 'as_schedule_single_action' ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Action Scheduler not available.',
-			);
-		}
-
 		$action_id = as_schedule_single_action(
 			$timestamp,
 			'datamachine_run_flow_now',

--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -98,13 +98,6 @@ class ScheduleNextStepAbility {
 		$flow_step_id = $input['flow_step_id'] ?? '';
 		$dataPackets  = $input['data_packets'] ?? array();
 
-		if ( ! function_exists( 'as_schedule_single_action' ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Action Scheduler not available.',
-			);
-		}
-
 		// Store data by job_id (if present).
 		if ( ! empty( $dataPackets ) ) {
 			$engine_snapshot  = datamachine_get_engine_data( $job_id );

--- a/inc/Abilities/Flow/DeleteFlowAbility.php
+++ b/inc/Abilities/Flow/DeleteFlowAbility.php
@@ -93,9 +93,7 @@ class DeleteFlowAbility {
 
 		$pipeline_id = (int) ( $flow['pipeline_id'] ?? 0 );
 
-		if ( function_exists( 'as_unschedule_all_actions' ) ) {
-			as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
-		}
+		as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
 
 		$success = $this->db_flows->delete_flow( $flow_id );
 

--- a/inc/Abilities/Flow/PauseFlowAbility.php
+++ b/inc/Abilities/Flow/PauseFlowAbility.php
@@ -130,9 +130,7 @@ class PauseFlowAbility {
 			$this->db_flows->update_flow_scheduling( $fid, $scheduling );
 
 			// Unschedule Action Scheduler hooks so paused flows don't fire.
-			if ( function_exists( 'as_unschedule_all_actions' ) ) {
-				as_unschedule_all_actions( 'datamachine_run_flow_now', array( $fid ), 'data-machine' );
-			}
+			as_unschedule_all_actions( 'datamachine_run_flow_now', array( $fid ), 'data-machine' );
 
 			++$paused;
 			$details[] = array(

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -267,13 +267,6 @@ class ExecuteWorkflowAbility {
 		// Delayed execution
 		$timestamp = (int) $timestamp;
 
-		if ( ! function_exists( 'as_schedule_single_action' ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Action Scheduler not available for delayed execution',
-			);
-		}
-
 		$action_id = as_schedule_single_action(
 			$timestamp,
 			'datamachine_schedule_next_step',

--- a/inc/Abilities/Pipeline/DeletePipelineAbility.php
+++ b/inc/Abilities/Pipeline/DeletePipelineAbility.php
@@ -104,9 +104,7 @@ class DeletePipelineAbility {
 				continue;
 			}
 
-			if ( function_exists( 'as_unschedule_all_actions' ) ) {
-				as_unschedule_all_actions( 'datamachine_run_flow_now', array( (int) $flow_id ), 'data-machine' );
-			}
+			as_unschedule_all_actions( 'datamachine_run_flow_now', array( (int) $flow_id ), 'data-machine' );
 
 			$this->db_flows->delete_flow( (int) $flow_id );
 		}

--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -212,14 +212,6 @@ class SendEmailQueuedAbility {
 	public function execute( array $input ): array {
 		$logs = array();
 
-		if ( ! function_exists( 'as_schedule_single_action' ) || ! function_exists( 'as_enqueue_async_action' ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Action Scheduler not available.',
-				'logs'    => $logs,
-			);
-		}
-
 		// Validate the bare minimum here. The underlying ability re-validates
 		// the full payload when the worker runs.
 		$to = isset( $input['to'] ) ? (string) $input['to'] : '';
@@ -370,19 +362,6 @@ class SendEmailQueuedAbility {
 		// Re-enqueue with backoff. Bump the attempt counter on the payload.
 		$payload['_attempt'] = $attempt + 1;
 		$retry_at            = time() + self::RETRY_BACKOFF_SECONDS;
-
-		if ( ! function_exists( 'as_schedule_single_action' ) ) {
-			do_action(
-				'datamachine_log',
-				'error',
-				'Email worker: Action Scheduler unavailable for retry',
-				array(
-					'attempt' => $attempt,
-					'error'   => $error_msg,
-				)
-			);
-			return;
-		}
 
 		$retry_action_id = as_schedule_single_action( $retry_at, self::WORKER_HOOK, array( $payload ), self::GROUP );
 

--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -185,14 +185,12 @@ class BatchScheduler {
 			)
 		);
 
-		if ( function_exists( 'as_schedule_single_action' ) ) {
-			as_schedule_single_action(
-				time(),
-				$hook,
-				array( 'parent_job_id' => $parent_job_id ),
-				'data-machine'
-			);
-		}
+		as_schedule_single_action(
+			time(),
+			$hook,
+			array( 'parent_job_id' => $parent_job_id ),
+			'data-machine'
+		);
 
 		return array(
 			'parent_job_id' => $parent_job_id,
@@ -291,14 +289,12 @@ class BatchScheduler {
 			$parent_engine['batch_state']['offset'] = $new_offset;
 			datamachine_set_engine_data( $parent_job_id, $parent_engine );
 
-			if ( function_exists( 'as_schedule_single_action' ) ) {
-				as_schedule_single_action(
-					time() + $delay,
-					$hook,
-					array( 'parent_job_id' => $parent_job_id ),
-					'data-machine'
-				);
-			}
+			as_schedule_single_action(
+				time() + $delay,
+				$hook,
+				array( 'parent_job_id' => $parent_job_id ),
+				'data-machine'
+			);
 		} else {
 			// Last chunk — drop batch_state to free row space. Top-level
 			// batch_total / batch_scheduled / batch_offset stay so the

--- a/inc/Core/Admin/FlowFormatter.php
+++ b/inc/Core/Admin/FlowFormatter.php
@@ -135,7 +135,7 @@ class FlowFormatter {
 	 * @return string|null MySQL datetime string or null
 	 */
 	private static function get_next_run_time( ?int $flow_id ): ?string {
-		if ( ! $flow_id || ! function_exists( 'as_next_scheduled_action' ) ) {
+		if ( ! $flow_id ) {
 			return null;
 		}
 

--- a/inc/Core/JobRetryPolicy.php
+++ b/inc/Core/JobRetryPolicy.php
@@ -78,16 +78,6 @@ class JobRetryPolicy {
 			);
 		}
 
-		if ( ! function_exists( 'as_schedule_single_action' ) ) {
-			return array(
-				'retried'      => false,
-				'exhausted'    => false,
-				'attempt'      => $attempt,
-				'max_attempts' => $max_attempts,
-				'reason'       => 'action_scheduler_unavailable',
-			);
-		}
-
 		$delay_seconds = self::resolveDelay( $attempt, $policy, $context_data );
 		$timestamp     = time() + $delay_seconds;
 		$flow_step_id  = (string) ( $context_data['flow_step_id'] ?? '' );

--- a/inc/Core/Steps/WebhookGate/WebhookGateStep.php
+++ b/inc/Core/Steps/WebhookGate/WebhookGateStep.php
@@ -220,7 +220,7 @@ class WebhookGateStep extends Step {
 		set_transient( 'datamachine_webhook_gate_' . $token, $this->job_id, $expiry );
 
 		// Schedule timeout action if configured.
-		if ( $timeout_hours > 0 && function_exists( 'as_schedule_single_action' ) ) {
+		if ( $timeout_hours > 0 ) {
 			as_schedule_single_action(
 				time() + ( $timeout_hours * HOUR_IN_SECONDS ),
 				'datamachine_webhook_gate_timeout',

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -494,18 +494,16 @@ class SystemAgentServiceProvider {
 				return;
 			}
 
-			if ( function_exists( 'as_schedule_single_action' ) ) {
-				as_schedule_single_action(
-					time() + 15,
-					'datamachine_system_agent_set_featured_image',
-					array(
-						'attachment_id'   => $attachmentId,
-						'pipeline_job_id' => $pipelineJobId,
-						'attempt'         => $attempt + 1,
-					),
-					'data-machine'
-				);
-			}
+			as_schedule_single_action(
+				time() + 15,
+				'datamachine_system_agent_set_featured_image',
+				array(
+					'attachment_id'   => $attachmentId,
+					'pipeline_job_id' => $pipelineJobId,
+					'attempt'         => $attempt + 1,
+				),
+				'data-machine'
+			);
 			return;
 		}
 

--- a/inc/Engine/AI/System/Tasks/ImageGenerationTask.php
+++ b/inc/Engine/AI/System/Tasks/ImageGenerationTask.php
@@ -206,10 +206,6 @@ class ImageGenerationTask extends SystemTask {
 	}
 
 	private function scheduleFeaturedImageRetry( int $attachmentId, int $pipelineJobId ): void {
-		if ( ! function_exists( 'as_schedule_single_action' ) ) {
-			return;
-		}
-
 		as_schedule_single_action(
 			time() + 15,
 			'datamachine_system_agent_set_featured_image',

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -240,14 +240,12 @@ abstract class SystemTask {
 		$engine_data['attempts'] = $attempts;
 		$jobs_db->store_engine_data( $jobId, $engine_data );
 
-		if ( function_exists( 'as_schedule_single_action' ) ) {
-			as_schedule_single_action(
-				time() + $delaySeconds,
-				'datamachine_task_retry',
-				array( $jobId ),
-				'data-machine'
-			);
-		}
+		as_schedule_single_action(
+			time() + $delaySeconds,
+			'datamachine_task_retry',
+			array( $jobId ),
+			'data-machine'
+		);
 	}
 
 	// ─── Prompt system ────────────────────────────────────────────────

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -80,9 +80,7 @@ function datamachine_register_execution_engine() {
 			// If flow was deleted without cleaning up scheduled actions,
 			// cancel the orphaned actions to prevent recurring errors.
 			if ( ! datamachine_flow_exists( $flow_id ) ) {
-				if ( function_exists( 'as_unschedule_all_actions' ) ) {
-					as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
-				}
+				as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
 				do_action(
 					'datamachine_log',
 					'warning',


### PR DESCRIPTION
## Summary
- Remove dead `function_exists()` checks around Action Scheduler procedural APIs in runtime paths where Action Scheduler is already a required dependency.
- Keep readiness/bootstrap/test guards outside this cleanup so runtime-state checks remain unchanged.
- Simplify flow/job/task retry scheduling paths by calling the scheduler APIs directly.

## Verification
- `vendor/bin/phpcbf --standard=WordPress <changed files>`
- `php -l <changed files>`
- `vendor/bin/phpcs --standard=WordPress <changed files>`
- `git diff --check`
- `php tests/job-retry-policy-smoke.php`
- `php tests/task-scheduler-batch-parent-link-smoke.php`
- `php tests/flow-formatter-loaded-settings-display-smoke.php`
- `php tests/system-health-scheduler-smoke.php`
- `homeboy review --path /Users/chubes/Developer/data-machine@cleanup-unused-params-batch-1 --extension wordpress --changed-since origin/main --report=pr-comment`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identifying redundant Action Scheduler availability guards, applying the mechanical cleanup, and running targeted verification. Chris remains responsible for review and merge.