### PR TITLE
Share rest_url smoke test stub

### DIFF
--- a/tests/fixtures/rest-url-stub.php
+++ b/tests/fixtures/rest-url-stub.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Shared rest_url() stub for pure-PHP smoke tests.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! function_exists( 'rest_url' ) ) {
+	function rest_url( string $path = '' ): string {
+		return 'https://example.test/wp-json/' . ltrim( $path, '/' );
+	}
+}

--- a/tests/signed-pending-action-resolution-smoke.php
+++ b/tests/signed-pending-action-resolution-smoke.php
@@ -15,6 +15,8 @@ $GLOBALS['__signed_filters']    = array();
 $GLOBALS['__signed_transients'] = array();
 $GLOBALS['__signed_options']    = array();
 
+require_once __DIR__ . '/fixtures/rest-url-stub.php';
+
 function datamachine_signed_assert( bool $condition, string $message, array &$failures, int &$passes ): void {
 	if ( $condition ) {
 		++$passes;
@@ -67,11 +69,6 @@ if ( ! function_exists( 'update_option' ) ) {
 		unset( $autoload );
 		$GLOBALS['__signed_options'][ $option ] = $value;
 		return true;
-	}
-}
-if ( ! function_exists( 'rest_url' ) ) {
-	function rest_url( string $path = '' ): string {
-		return 'https://example.test/wp-json/' . ltrim( $path, '/' );
 	}
 }
 if ( ! function_exists( 'add_query_arg' ) ) {

--- a/tests/webhook-custom-verifier-mode-smoke.php
+++ b/tests/webhook-custom-verifier-mode-smoke.php
@@ -40,6 +40,7 @@ namespace {
 		define( 'ABSPATH', __DIR__ . '/' );
 	}
 
+	require_once __DIR__ . '/fixtures/rest-url-stub.php';
 	require_once __DIR__ . '/smoke-wp-stubs.php';
 
 	$GLOBALS['__webhook_custom_mode_filters'] = array();
@@ -67,12 +68,6 @@ namespace {
 
 	if ( ! function_exists( 'do_action' ) ) {
 		function do_action( string $hook_name, ...$args ): void {}
-	}
-
-	if ( ! function_exists( 'rest_url' ) ) {
-		function rest_url( string $path = '' ): string {
-			return 'https://example.test/wp-json/' . ltrim( $path, '/' );
-		}
 	}
 
 	class TestRegisteredWebhookVerifier {


### PR DESCRIPTION
## Summary
- Move the duplicated `rest_url()` pure-PHP smoke test stub into `tests/fixtures/rest-url-stub.php`.
- Require the shared fixture from the signed pending-action and webhook verifier smoke tests.
- Closes #2114.

## Verification
- `php -l tests/fixtures/rest-url-stub.php && php -l tests/signed-pending-action-resolution-smoke.php && php -l tests/webhook-custom-verifier-mode-smoke.php`
- `php tests/signed-pending-action-resolution-smoke.php`
- `php tests/webhook-custom-verifier-mode-smoke.php`
- `vendor/bin/phpcs --standard=WordPress tests/fixtures/rest-url-stub.php tests/signed-pending-action-resolution-smoke.php tests/webhook-custom-verifier-mode-smoke.php`
- `homeboy audit --path /Users/chubes/Developer/data-machine@cleanup-shared-rest-url-test-stub --extension wordpress --changed-since origin/main`

## Notes
- `homeboy test --changed-since origin/main` did not complete locally: the changed files are pure smoke scripts, Homeboy selected no PHPUnit files, then the runner loop timed out on a hot local machine. The two affected smoke scripts were run directly and passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Verifying the audit finding, extracting the shared test stub, and running targeted checks. Chris remains responsible for review and merge.