### PR TITLE
Refactor auth disconnect into deprecated revoke alias

### DIFF
--- a/docs/core-system/oauth-handlers.md
+++ b/docs/core-system/oauth-handlers.md
@@ -167,6 +167,10 @@ wp datamachine auth revoke <handler>
 wp datamachine auth revoke <handler> --user=42
 ```
 
+`wp datamachine auth disconnect <handler>` is kept as a deprecated site-wide
+alias for `revoke` so existing scripts continue to run during the CLI verb
+transition. New callsites should use `revoke`.
+
 Or via the abilities surface:
 
 ```php

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -506,7 +506,10 @@ wp datamachine auth status wordpress-api
 # Connect (OAuth shows URL; direct accepts credentials)
 wp datamachine auth connect google --client_id=xxx --client_secret=xxx
 
-# Disconnect
+# Revoke site-wide credentials
+wp datamachine auth revoke google --yes
+
+# Deprecated alias for site-wide revoke
 wp datamachine auth disconnect google --yes
 
 # View or save API config

--- a/inc/Cli/Commands/AuthCommand.php
+++ b/inc/Cli/Commands/AuthCommand.php
@@ -3,7 +3,7 @@
  * WP-CLI Auth Command
  *
  * CLI surface for authentication management operations.
- * Wraps the AuthAbilities layer for status, connect, disconnect, and config.
+ * Wraps the AuthAbilities layer for status, connect, revoke, and config.
  *
  * @package DataMachine\Cli\Commands
  * @since 0.36.0
@@ -141,6 +141,9 @@ class AuthCommand extends BaseCommand {
 	/**
 	 * Disconnect authentication for a handler.
 	 *
+	 * Deprecated alias for `revoke` at site scope. Kept so existing scripts do
+	 * not break during the CLI verb transition.
+	 *
 	 * Clears stored account data (tokens, credentials). Does not remove
 	 * API configuration (client ID, client secret).
 	 *
@@ -154,7 +157,7 @@ class AuthCommand extends BaseCommand {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Disconnect Twitter
+	 *     # Deprecated: use `wp datamachine auth revoke twitter` instead.
 	 *     wp datamachine auth disconnect twitter
 	 *
 	 *     # Disconnect without confirmation
@@ -163,37 +166,9 @@ class AuthCommand extends BaseCommand {
 	 * @subcommand disconnect
 	 */
 	public function disconnect( array $args, array $assoc_args ): void {
-		if ( empty( $args[0] ) ) {
-			WP_CLI::error( 'Handler slug is required.' );
-			return;
-		}
-
-		$handler_slug = sanitize_text_field( $args[0] );
-
-		if ( ! $this->abilities->providerExists( $handler_slug ) ) {
-			WP_CLI::error( sprintf( 'Auth provider "%s" not found.', $handler_slug ) );
-			return;
-		}
-
-		// Check current status.
-		$auth_status = $this->abilities->getAuthStatus( $handler_slug );
-
-		if ( ! $auth_status['authenticated'] ) {
-			WP_CLI::warning( sprintf( '%s is not currently authenticated.', ucfirst( $handler_slug ) ) );
-			return;
-		}
-
-		if ( ! isset( $assoc_args['yes'] ) ) {
-			WP_CLI::confirm( sprintf( 'Disconnect %s? This will clear stored account data.', ucfirst( $handler_slug ) ) );
-		}
-
-		$result = $this->abilities->executeDisconnectAuth( array( 'handler_slug' => $handler_slug ) );
-
-		if ( ! empty( $result['success'] ) ) {
-			WP_CLI::success( $result['message'] ?? sprintf( '%s disconnected.', ucfirst( $handler_slug ) ) );
-		} else {
-			WP_CLI::error( $result['error'] ?? 'Failed to disconnect.' );
-		}
+		WP_CLI::warning( '`disconnect` is deprecated; use `revoke` instead.' );
+		unset( $assoc_args['user'] );
+		$this->revoke( $args, $assoc_args );
 	}
 
 	/**

--- a/tests/auth-cli-disconnect-alias-smoke.php
+++ b/tests/auth-cli-disconnect-alias-smoke.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Pure-PHP smoke coverage for the deprecated auth disconnect CLI alias.
+ *
+ * Run with: php tests/auth-cli-disconnect-alias-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Cli {
+	class BaseCommand {}
+}
+
+namespace DataMachine\Abilities {
+	class AuthAbilities {
+		public array $calls = array();
+
+		public function providerExists( string $handler_slug ): bool {
+			$this->calls[] = array( 'providerExists', $handler_slug );
+			return true;
+		}
+
+		public function getAuthStatus( string $handler_slug ): array {
+			$this->calls[] = array( 'getAuthStatus', $handler_slug );
+			return array( 'authenticated' => true );
+		}
+
+		public function executeDisconnectAuth( array $input ): array {
+			$this->calls[] = array( 'executeDisconnectAuth', $input );
+			return array(
+				'success' => true,
+				'message' => 'site-wide revoked',
+			);
+		}
+
+		public function executeRevokeAuthForUser( array $input ): array {
+			$this->calls[] = array( 'executeRevokeAuthForUser', $input );
+			return array( 'success' => false );
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+	}
+
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $value ) {
+			return trim( (string) $value );
+		}
+	}
+
+	if ( ! function_exists( 'absint' ) ) {
+		function absint( $value ): int {
+			return abs( (int) $value );
+		}
+	}
+
+	class WP_CLI {
+		public static array $warnings = array();
+		public static array $successes = array();
+
+		public static function warning( string $message ): void {
+			self::$warnings[] = $message;
+		}
+
+		public static function success( string $message ): void {
+			self::$successes[] = $message;
+		}
+
+		public static function error( string $message ): void {
+			throw new RuntimeException( $message );
+		}
+
+		public static function confirm( string $message ): void {
+			throw new RuntimeException( 'Unexpected confirmation prompt: ' . $message );
+		}
+	}
+
+	require_once dirname( __DIR__ ) . '/inc/Cli/Commands/AuthCommand.php';
+
+	$command = new \DataMachine\Cli\Commands\AuthCommand();
+	$command->disconnect( array( 'twitter' ), array( 'yes' => true, 'user' => 42 ) );
+
+	$reflection = new ReflectionClass( $command );
+	$property   = $reflection->getProperty( 'abilities' );
+	$abilities = $property->getValue( $command );
+
+	$failures = array();
+
+	if ( array( '`disconnect` is deprecated; use `revoke` instead.' ) !== WP_CLI::$warnings ) {
+		$failures[] = 'disconnect emits the expected deprecation warning';
+	}
+
+	if ( array( 'site-wide revoked' ) !== WP_CLI::$successes ) {
+		$failures[] = 'disconnect delegates to revoke site-wide success handling';
+	}
+
+	$called_per_user = false;
+	$called_site     = false;
+	foreach ( $abilities->calls as $call ) {
+		if ( 'executeRevokeAuthForUser' === $call[0] ) {
+			$called_per_user = true;
+		}
+		if ( 'executeDisconnectAuth' === $call[0] && array( 'handler_slug' => 'twitter' ) === $call[1] ) {
+			$called_site = true;
+		}
+	}
+
+	if ( $called_per_user ) {
+		$failures[] = 'disconnect must not forward command-scoped --user into revoke';
+	}
+
+	if ( ! $called_site ) {
+		$failures[] = 'disconnect reaches the site-wide revoke implementation';
+	}
+
+	if ( $failures ) {
+		echo "auth-cli-disconnect-alias-smoke failed\n";
+		foreach ( $failures as $failure ) {
+			echo " - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "auth-cli-disconnect-alias-smoke passed\n";
+}


### PR DESCRIPTION
## Summary
- Keeps `wp datamachine auth disconnect <handler>` as a deprecated site-wide alias for `revoke` instead of duplicating revoke logic.
- Strips `--user` before delegation so the legacy `disconnect` command cannot accidentally use the per-user revoke path.
- Updates auth CLI docs and adds a pure-PHP smoke test for the alias behavior.

Closes #2116

## Verification
- `php -l inc/Cli/Commands/AuthCommand.php && php -l tests/auth-cli-disconnect-alias-smoke.php`
- `php tests/auth-cli-disconnect-alias-smoke.php`
- `vendor/bin/phpcs --standard=WordPress inc/Cli/Commands/AuthCommand.php tests/auth-cli-disconnect-alias-smoke.php`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/data-machine@cleanup-auth-disconnect-alias --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@cleanup-auth-disconnect-alias --extension wordpress --changed-since origin/main`
- `homeboy audit --path /Users/chubes/Developer/data-machine@cleanup-auth-disconnect-alias --extension wordpress --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the small CLI refactor, docs update, smoke coverage, and local verification under Chris's direction.