### PR TITLE
Expose generic job outcome metrics

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -235,6 +235,8 @@ class ExecuteStepAbility {
 				$status_override
 			);
 
+			$recorded_status = $status_override ? $status_override : ( $result['outcome'] ?? null );
+
 			RunMetrics::recordStepResult(
 				$job_id,
 				$flow_step_id,
@@ -243,7 +245,7 @@ class ExecuteStepAbility {
 					'result'       => $result['outcome'] ?? ( $step_success ? 'completed' : 'failed' ),
 					'step_success' => $step_success,
 					'packet_count' => count( $dataPackets ),
-					'status'       => $status_override ?: ( $result['outcome'] ?? null ),
+					'status'       => $recorded_status,
 					'error'        => $result['error'] ?? null,
 				)
 			);

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -20,6 +20,7 @@ use DataMachine\Core\EngineData;
 use DataMachine\Core\FilesRepository\FileCleanup;
 use DataMachine\Core\FilesRepository\FileRetrieval;
 use DataMachine\Core\JobStatus;
+use DataMachine\Core\RunMetrics;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\Step;
 use DataMachine\Engine\StepNavigator;
@@ -221,7 +222,7 @@ class ExecuteStepAbility {
 				)
 			);
 
-			return $this->routeAfterExecution(
+			$result = $this->routeAfterExecution(
 				$job_id,
 				$flow_step_id,
 				$flow_id,
@@ -233,7 +234,33 @@ class ExecuteStepAbility {
 				$step_success,
 				$status_override
 			);
+
+			RunMetrics::recordStepResult(
+				$job_id,
+				$flow_step_id,
+				array(
+					'step_type'    => $step_type,
+					'result'       => $result['outcome'] ?? ( $step_success ? 'completed' : 'failed' ),
+					'step_success' => $step_success,
+					'packet_count' => count( $dataPackets ),
+					'status'       => $status_override ?: ( $result['outcome'] ?? null ),
+					'error'        => $result['error'] ?? null,
+				)
+			);
+
+			return $result;
 		} catch ( \Throwable $e ) {
+			RunMetrics::recordStepResult(
+				$job_id,
+				$flow_step_id,
+				array(
+					'result'       => 'failed',
+					'step_success' => false,
+					'packet_count' => 0,
+					'reason'       => 'throwable_exception_in_step_execution',
+					'error'        => $e->getMessage(),
+				)
+			);
 			do_action(
 				'datamachine_fail_job',
 				$job_id,

--- a/inc/Abilities/Job/GetJobsAbility.php
+++ b/inc/Abilities/Job/GetJobsAbility.php
@@ -63,6 +63,10 @@ class GetJobsAbility {
 								'type'        => array( 'string', 'null' ),
 								'description' => __( 'Filter jobs by source (pipeline, chat, system, api, direct)', 'data-machine' ),
 							),
+							'handler'     => array(
+								'type'        => array( 'string', 'null' ),
+								'description' => __( 'Filter jobs by generic handler slug recorded in job outcome metadata.', 'data-machine' ),
+							),
 							'per_page'    => array(
 								'type'        => 'integer',
 								'default'     => self::DEFAULT_PER_PAGE,
@@ -133,6 +137,7 @@ class GetJobsAbility {
 		$agent_id    = $input['agent_id'] ?? null;
 		$status      = $input['status'] ?? null;
 		$source      = $input['source'] ?? null;
+		$handler     = $input['handler'] ?? null;
 		$since       = $input['since'] ?? null;
 		$per_page    = (int) ( $input['per_page'] ?? self::DEFAULT_PER_PAGE );
 		$offset      = (int) ( $input['offset'] ?? 0 );
@@ -201,6 +206,11 @@ class GetJobsAbility {
 		if ( null !== $source && '' !== $source ) {
 			$args['source']            = sanitize_text_field( $source );
 			$filters_applied['source'] = $args['source'];
+		}
+
+		if ( null !== $handler && '' !== $handler ) {
+			$args['handler']            = sanitize_key( (string) $handler );
+			$filters_applied['handler'] = $args['handler'];
 		}
 
 		if ( null !== $agent_id ) {

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -963,11 +963,11 @@ class JobsCommand extends BaseCommand {
 	 * @subcommand list
 	 */
 	public function list_jobs( array $args, array $assoc_args ): void {
-		$status  = $assoc_args['status'] ?? null;
-		$flow_id = isset( $assoc_args['flow'] ) ? (int) $assoc_args['flow'] : null;
+		$status      = $assoc_args['status'] ?? null;
+		$flow_id     = isset( $assoc_args['flow'] ) ? (int) $assoc_args['flow'] : null;
 		$pipeline_id = isset( $assoc_args['pipeline'] ) ? (int) $assoc_args['pipeline'] : null;
-		$limit   = (int) ( $assoc_args['limit'] ?? 20 );
-		$format  = $assoc_args['format'] ?? 'table';
+		$limit       = (int) ( $assoc_args['limit'] ?? 20 );
+		$format      = $assoc_args['format'] ?? 'table';
 
 		if ( $limit < 1 ) {
 			$limit = 20;

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -23,6 +23,7 @@ use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Abilities\Job\RetryJobAbility;
 use DataMachine\Abilities\Job\RunMetricsAbility;
 use DataMachine\Core\JobArtifacts;
+use DataMachine\Core\RunMetrics;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Jobs\Jobs;
 use AgentsAPI\AI\WP_Agent_Message;
@@ -899,6 +900,12 @@ class JobsCommand extends BaseCommand {
 	 * [--source=<source>]
 	 * : Filter by source (pipeline, system).
 	 *
+	 * [--pipeline=<pipeline_id>]
+	 * : Filter by pipeline ID.
+	 *
+	 * [--handler=<handler_slug>]
+	 * : Filter by handler slug recorded in generic job outcome metadata.
+	 *
 	 * [--since=<datetime>]
 	 * : Show jobs created after this time. Accepts ISO datetime or relative strings (e.g., "1 hour ago", "today", "yesterday").
 	 *
@@ -958,6 +965,7 @@ class JobsCommand extends BaseCommand {
 	public function list_jobs( array $args, array $assoc_args ): void {
 		$status  = $assoc_args['status'] ?? null;
 		$flow_id = isset( $assoc_args['flow'] ) ? (int) $assoc_args['flow'] : null;
+		$pipeline_id = isset( $assoc_args['pipeline'] ) ? (int) $assoc_args['pipeline'] : null;
 		$limit   = (int) ( $assoc_args['limit'] ?? 20 );
 		$format  = $assoc_args['format'] ?? 'table';
 
@@ -986,6 +994,18 @@ class JobsCommand extends BaseCommand {
 
 		if ( $flow_id ) {
 			$input['flow_id'] = $flow_id;
+		}
+
+		if ( $pipeline_id ) {
+			$input['pipeline_id'] = $pipeline_id;
+		}
+
+		if ( ! empty( $assoc_args['source'] ) ) {
+			$input['source'] = (string) $assoc_args['source'];
+		}
+
+		if ( ! empty( $assoc_args['handler'] ) ) {
+			$input['handler'] = (string) $assoc_args['handler'];
 		}
 
 		$since = $assoc_args['since'] ?? null;
@@ -1031,7 +1051,7 @@ class JobsCommand extends BaseCommand {
 
 		// Transform jobs to flat row format.
 		$items = array_map(
-			function ( $j ) {
+			function ( $j ) use ( $format ) {
 				$source         = $j['source'] ?? 'pipeline';
 				$status_display = strlen( $j['status'] ?? '' ) > 40 ? substr( $j['status'], 0, 40 ) . '...' : ( $j['status'] ?? '' );
 
@@ -1041,7 +1061,7 @@ class JobsCommand extends BaseCommand {
 					$flow_display = $j['flow_name'] ?? ( isset( $j['flow_id'] ) ? "Flow {$j['flow_id']}" : '' );
 				}
 
-				return array(
+				$item = array(
 					'id'        => $j['job_id'] ?? '',
 					'source'    => $source,
 					'flow'      => $flow_display,
@@ -1049,9 +1069,26 @@ class JobsCommand extends BaseCommand {
 					'created'   => $j['created_at'] ?? '',
 					'completed' => $j['completed_at'] ?? '-',
 				);
+
+				if ( 'json' === $format ) {
+					$metrics              = RunMetrics::fromJob( $j );
+					$item['pipeline_id']  = $j['pipeline_id'] ?? null;
+					$item['flow_id']      = $j['flow_id'] ?? null;
+					$item['handler_slug'] = $metrics['outcome']['handler_slug'] ?? null;
+					$item['outcome']      = $metrics['outcome'];
+					$item['step_results'] = $metrics['step_results'];
+					$item['counts']       = $metrics['counts'];
+				}
+
+				return $item;
 			},
 			$jobs
 		);
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $items, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
 
 		$this->format_items( $items, $this->default_fields, $assoc_args, 'id' );
 

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -391,7 +391,7 @@ class Jobs extends BaseRepository {
 		if ( $results ) {
 			foreach ( $results as &$result ) {
 				if ( isset( $result['engine_data'] ) && is_string( $result['engine_data'] ) && '' !== $result['engine_data'] ) {
-					$decoded = json_decode( $result['engine_data'], true );
+					$decoded               = json_decode( $result['engine_data'], true );
 					$result['engine_data'] = JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ? $decoded : array();
 				} else {
 					$result['engine_data'] = array();

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -206,6 +206,16 @@ class Jobs extends BaseRepository {
 			$where_values[]  = sanitize_text_field( $args['source'] );
 		}
 
+		if ( ! empty( $args['handler'] ) ) {
+			$handler = sanitize_key( (string) $args['handler'] );
+			if ( '' !== $handler ) {
+				$where_clauses[] = '(engine_data LIKE %s OR engine_data LIKE %s OR engine_data LIKE %s)';
+				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler_slug":"' . $handler . '"' ) . '%';
+				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler":"' . $handler . '"' ) . '%';
+				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler_slugs":["' . $handler . '"' ) . '%';
+			}
+		}
+
 		if ( isset( $args['user_id'] ) ) {
 			$where_clauses[] = 'user_id = %d';
 			$where_values[]  = absint( $args['user_id'] );
@@ -315,6 +325,16 @@ class Jobs extends BaseRepository {
 			$where_values[]  = sanitize_text_field( $args['source'] );
 		}
 
+		if ( ! empty( $args['handler'] ) ) {
+			$handler = sanitize_key( (string) $args['handler'] );
+			if ( '' !== $handler ) {
+				$where_clauses[] = '(j.engine_data LIKE %s OR j.engine_data LIKE %s OR j.engine_data LIKE %s)';
+				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler_slug":"' . $handler . '"' ) . '%';
+				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler":"' . $handler . '"' ) . '%';
+				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler_slugs":["' . $handler . '"' ) . '%';
+			}
+		}
+
 		if ( isset( $args['user_id'] ) ) {
 			$where_clauses[] = 'j.user_id = %d';
 			$where_values[]  = absint( $args['user_id'] );
@@ -368,6 +388,17 @@ class Jobs extends BaseRepository {
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above
 		$results = $this->wpdb->get_results( $query, ARRAY_A );
+		if ( $results ) {
+			foreach ( $results as &$result ) {
+				if ( isset( $result['engine_data'] ) && is_string( $result['engine_data'] ) && '' !== $result['engine_data'] ) {
+					$decoded = json_decode( $result['engine_data'], true );
+					$result['engine_data'] = JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ? $decoded : array();
+				} else {
+					$result['engine_data'] = array();
+				}
+			}
+			unset( $result );
+		}
 
 		return $results ? $results : array();
 	}

--- a/inc/Core/JobStatus.php
+++ b/inc/Core/JobStatus.php
@@ -268,7 +268,10 @@ class JobStatus {
 	 * Parse base status from a potentially compound status string.
 	 */
 	private static function parseBaseStatus( string $status ): string {
-		foreach ( self::FINAL_STATUSES as $base ) {
+		$base_statuses = self::FINAL_STATUSES;
+		usort( $base_statuses, static fn( string $a, string $b ): int => strlen( $b ) <=> strlen( $a ) );
+
+		foreach ( $base_statuses as $base ) {
 			if ( str_starts_with( $status, $base ) ) {
 				return $base;
 			}

--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -21,12 +21,56 @@ class RunMetrics {
 		'processed',
 		'skipped',
 		'failed',
+		'fetch_packets',
+		'no_content',
+		'source_rejected',
 		'retried',
 		'scheduled',
 		'staged_actions',
 		'accepted_actions',
 		'rejected_actions',
 	);
+
+	private const STEP_RESULTS_KEY = 'step_results';
+
+	public static function recordStepResult( int $job_id, string $flow_step_id, array $result ): bool {
+		if ( $job_id <= 0 || '' === $flow_step_id ) {
+			return false;
+		}
+
+		$engine       = EngineData::retrieve( $job_id );
+		$step_results = is_array( $engine[ self::STEP_RESULTS_KEY ] ?? null ) ? $engine[ self::STEP_RESULTS_KEY ] : array();
+		$existing     = is_array( $step_results[ $flow_step_id ] ?? null ) ? $step_results[ $flow_step_id ] : array();
+		$clean_result = self::sanitizeResult( $result );
+
+		$step_results[ $flow_step_id ] = array_replace_recursive(
+			$existing,
+			array_merge(
+				array(
+					'flow_step_id' => $flow_step_id,
+					'recorded_at'  => self::now(),
+				),
+				$clean_result
+			)
+		);
+
+		$engine[ self::STEP_RESULTS_KEY ] = $step_results;
+
+		$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
+		if ( isset( $clean_result['packet_count'] ) && 'fetch' === ( $clean_result['step_type'] ?? '' ) ) {
+			$metrics['counts']['fetch_packets'] = max( (int) $metrics['counts']['fetch_packets'], (int) $clean_result['packet_count'] );
+		}
+		if ( in_array( $clean_result['result'] ?? '', array( 'no_content', 'completed_no_items' ), true ) ) {
+			$metrics['counts']['no_content'] = max( 1, (int) $metrics['counts']['no_content'] );
+		}
+		if ( 'source_rejected' === ( $clean_result['result'] ?? '' ) || ! empty( $clean_result['source_rejection_reason'] ) ) {
+			$metrics['counts']['source_rejected'] = max( 1, (int) $metrics['counts']['source_rejected'] );
+		}
+		$metrics['last_activity_at'] = self::now();
+		$engine[ self::KEY ]        = $metrics;
+
+		return EngineData::persist( $job_id, $engine );
+	}
 
 	public static function start( int $job_id, array $context = array() ): bool {
 		if ( $job_id <= 0 ) {
@@ -134,6 +178,8 @@ class RunMetrics {
 				'completed_at'     => $ended_at,
 			),
 			'duration_seconds' => self::durationSeconds( $started_at, $duration_end ),
+			'outcome'          => self::outcomeDetails( $job, $engine, $counts ),
+			'step_results'     => self::stepResults( $engine ),
 			'context'          => $metrics['context'],
 			'token_usage'      => self::tokenUsage( $engine ),
 			'cost'             => self::cost( $engine ),
@@ -214,7 +260,95 @@ class RunMetrics {
 			$counts['failed'] = max( 1, (int) ( $counts['failed'] ?? 0 ) );
 		}
 
+		foreach ( self::stepResults( $engine ) as $step_result ) {
+			if ( 'fetch' === ( $step_result['step_type'] ?? '' ) && isset( $step_result['packet_count'] ) ) {
+				$counts['fetch_packets'] = max( (int) ( $counts['fetch_packets'] ?? 0 ), (int) $step_result['packet_count'] );
+			}
+			if ( in_array( $step_result['result'] ?? '', array( 'no_content', 'completed_no_items' ), true ) ) {
+				$counts['no_content'] = max( 1, (int) ( $counts['no_content'] ?? 0 ) );
+			}
+			if ( 'source_rejected' === ( $step_result['result'] ?? '' ) || ! empty( $step_result['source_rejection_reason'] ) ) {
+				$counts['source_rejected'] = max( 1, (int) ( $counts['source_rejected'] ?? 0 ) );
+			}
+		}
+
 		return $counts;
+	}
+
+	private static function outcomeDetails( array $job, array $engine, array $counts ): array {
+		$status             = (string) ( $job['status'] ?? '' );
+		$job_status         = JobStatus::fromString( $status );
+		$source_rejection   = is_array( $engine['source_rejection'] ?? null ) ? $engine['source_rejection'] : array();
+		$is_source_rejected = ! empty( $counts['source_rejected'] ) || ! empty( $source_rejection ) || 'source-rejected' === $job_status->getReason();
+
+		return array_filter(
+			array(
+				'status'                  => $status,
+				'base_status'             => $job_status->getBaseStatus(),
+				'status_reason'           => $job_status->getReason(),
+				'fetch_packet_count'      => (int) ( $counts['fetch_packets'] ?? 0 ),
+				'no_content'              => ! empty( $counts['no_content'] ) || JobStatus::COMPLETED_NO_ITEMS === $job_status->getBaseStatus(),
+				'source_rejected'         => $is_source_rejected,
+				'source_rejection_reason' => $source_rejection['reason'] ?? ( $is_source_rejected ? $job_status->getReason() : null ),
+				'handler_slug'            => self::firstStepField( $engine, 'handler_slug' ),
+				'provider_id'             => self::firstStepField( $engine, 'provider_id' ),
+				'tool_ids'                => self::mergedStepListField( $engine, 'tool_ids' ),
+			),
+			static fn( $value ) => null !== $value
+		);
+	}
+
+	private static function stepResults( array $engine ): array {
+		$step_results = is_array( $engine[ self::STEP_RESULTS_KEY ] ?? null ) ? $engine[ self::STEP_RESULTS_KEY ] : array();
+		return array_values( array_filter( $step_results, 'is_array' ) );
+	}
+
+	private static function firstStepField( array $engine, string $field ) {
+		foreach ( self::stepResults( $engine ) as $result ) {
+			if ( isset( $result[ $field ] ) && '' !== $result[ $field ] ) {
+				return $result[ $field ];
+			}
+		}
+		return null;
+	}
+
+	private static function mergedStepListField( array $engine, string $field ): array {
+		$values = array();
+		foreach ( self::stepResults( $engine ) as $result ) {
+			$list = is_array( $result[ $field ] ?? null ) ? $result[ $field ] : array();
+			foreach ( $list as $value ) {
+				if ( is_scalar( $value ) && '' !== (string) $value ) {
+					$values[] = (string) $value;
+				}
+			}
+		}
+		return array_values( array_unique( $values ) );
+	}
+
+	private static function sanitizeResult( array $result ): array {
+		$clean = array();
+		foreach ( $result as $key => $value ) {
+			$key = function_exists( 'sanitize_key' ) ? sanitize_key( (string) $key ) : preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+			if ( '' === $key ) {
+				continue;
+			}
+			if ( is_scalar( $value ) || null === $value ) {
+				$clean[ $key ] = $value;
+			} elseif ( is_array( $value ) ) {
+				$clean[ $key ] = self::sanitizeList( $value );
+			}
+		}
+		return $clean;
+	}
+
+	private static function sanitizeList( array $values ): array {
+		$clean = array();
+		foreach ( $values as $key => $value ) {
+			if ( is_scalar( $value ) || null === $value ) {
+				$clean[ is_int( $key ) ? $key : (string) $key ] = $value;
+			}
+		}
+		return $clean;
 	}
 
 	private static function childTotals( int $job_id ): array {

--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -67,7 +67,7 @@ class RunMetrics {
 			$metrics['counts']['source_rejected'] = max( 1, (int) $metrics['counts']['source_rejected'] );
 		}
 		$metrics['last_activity_at'] = self::now();
-		$engine[ self::KEY ]        = $metrics;
+		$engine[ self::KEY ]         = $metrics;
 
 		return EngineData::persist( $job_id, $engine );
 	}

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -8,6 +8,7 @@ use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\DataPacket;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\PluginSettings;
+use DataMachine\Core\RunMetrics;
 use DataMachine\Core\Steps\Step;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\AI\ToolPolicy\PipelineToolPolicyArgs;
@@ -132,6 +133,17 @@ class AIStep extends Step {
 			$reason = $pre_check['reason'] ?? 'pre-AI check determined processing is unnecessary';
 
 			$this->engine->set( 'job_status', $status );
+			RunMetrics::recordStepResult(
+				$this->job_id,
+				$this->flow_step_id,
+				array(
+					'step_type'    => 'ai',
+					'result'       => 'skipped',
+					'packet_count' => 0,
+					'reason'       => $reason,
+					'status'       => $status,
+				)
+			);
 
 			do_action(
 				'datamachine_log',
@@ -211,6 +223,17 @@ class AIStep extends Step {
 					);
 
 					$this->engine->set( 'job_status', \DataMachine\Core\JobStatus::COMPLETED_NO_ITEMS );
+					RunMetrics::recordStepResult(
+						$this->job_id,
+						$this->flow_step_id,
+						array(
+							'step_type'    => 'ai',
+							'result'       => 'completed_no_items',
+							'packet_count' => 0,
+							'reason'       => 'empty_queue',
+							'queue_mode'   => $queue_mode,
+						)
+					);
 
 					return $this->dataPackets;
 				}
@@ -457,6 +480,21 @@ class AIStep extends Step {
 					);
 				}
 
+				RunMetrics::recordStepResult(
+					$this->job_id,
+					$this->flow_step_id,
+					array(
+						'step_type'    => 'ai',
+						'result'       => 'failed',
+						'provider_id'  => $provider_name,
+						'model_id'     => $model_name,
+						'tool_ids'     => array_keys( $available_tools ),
+						'packet_count' => 0,
+						'reason'       => $failure_reason,
+						'error_code'   => $loop_result['error_code'] ?? null,
+					)
+				);
+
 				do_action(
 					'datamachine_fail_job',
 					$this->job_id,
@@ -531,7 +569,22 @@ class AIStep extends Step {
 			}
 
 			// Process loop results into data packets
-			return self::processLoopResults( $loop_result, $this->dataPackets, $payload, $available_tools );
+			$processed_packets = self::processLoopResults( $loop_result, $this->dataPackets, $payload, $available_tools );
+			RunMetrics::recordStepResult(
+				$this->job_id,
+				$this->flow_step_id,
+				array(
+					'step_type'     => 'ai',
+					'result'        => empty( $processed_packets ) ? 'no_content' : 'completed',
+					'provider_id'   => $provider_name,
+					'model_id'      => $model_name,
+					'tool_ids'      => array_keys( $available_tools ),
+					'handler_slugs' => $required_handler_slugs,
+					'packet_count'  => count( $processed_packets ),
+				)
+			);
+
+			return $processed_packets;
 		} finally {
 			if ( $ai_concurrency_lease instanceof PipelineAIConcurrencyLease ) {
 				$ai_concurrency_lease->release();

--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -3,6 +3,7 @@
 namespace DataMachine\Core\Steps\Fetch;
 
 use DataMachine\Core\DataPacket;
+use DataMachine\Core\RunMetrics;
 use DataMachine\Core\Steps\QueueableTrait;
 use DataMachine\Core\Steps\Step;
 use DataMachine\Core\Steps\StepTypeRegistrationTrait;
@@ -108,6 +109,18 @@ class FetchStep extends Step {
 				);
 
 				$this->engine->set( 'job_status', \DataMachine\Core\JobStatus::COMPLETED_NO_ITEMS );
+				RunMetrics::recordStepResult(
+					$this->job_id,
+					$this->flow_step_id,
+					array(
+						'step_type'    => 'fetch',
+						'result'       => 'completed_no_items',
+						'handler_slug' => (string) $handler,
+						'packet_count' => 0,
+						'reason'       => 'empty_queue',
+						'queue_mode'   => $queue_mode,
+					)
+				);
 
 				return $this->dataPackets;
 			}
@@ -156,6 +169,18 @@ class FetchStep extends Step {
 
 		if ( is_wp_error( $resolved_handler_settings ) ) {
 			$this->log( 'error', 'Fetch auth_ref resolution failed: ' . $resolved_handler_settings->get_error_message() );
+			RunMetrics::recordStepResult(
+				$this->job_id,
+				$this->flow_step_id,
+				array(
+					'step_type'    => 'fetch',
+					'result'       => 'failed',
+					'handler_slug' => (string) $handler,
+					'packet_count' => 0,
+					'reason'       => 'auth_ref_resolution_failed',
+					'error'        => $resolved_handler_settings->get_error_message(),
+				)
+			);
 			return $this->dataPackets;
 		}
 
@@ -165,8 +190,35 @@ class FetchStep extends Step {
 
 		if ( empty( $packets ) ) {
 			$this->log( 'error', 'Fetch handler returned no content' );
+			RunMetrics::recordStepResult(
+				$this->job_id,
+				$this->flow_step_id,
+				array_merge(
+					$this->extractHandlerOutcomeIds( $handler_settings ),
+					array(
+						'step_type'    => 'fetch',
+						'result'       => 'no_content',
+						'handler_slug' => (string) $handler,
+						'packet_count' => 0,
+					)
+				)
+			);
 			return $this->dataPackets;
 		}
+
+		RunMetrics::recordStepResult(
+			$this->job_id,
+			$this->flow_step_id,
+			array_merge(
+				$this->extractHandlerOutcomeIds( $handler_settings ),
+				array(
+					'step_type'    => 'fetch',
+					'result'       => 'completed',
+					'handler_slug' => (string) $handler,
+					'packet_count' => count( $packets ),
+				)
+			)
+		);
 
 		$this->log(
 			'info',
@@ -280,5 +332,33 @@ class FetchStep extends Step {
 
 		$class_name = $handler_info['class'];
 		return class_exists( $class_name ) ? new $class_name() : null;
+	}
+
+	/**
+	 * Extract generic provider/tool identifiers from handler settings.
+	 *
+	 * @param array $handler_settings Handler settings after runtime auth resolution.
+	 * @return array<string,mixed>
+	 */
+	private function extractHandlerOutcomeIds( array $handler_settings ): array {
+		$out = array();
+		foreach ( array( 'provider_id', 'provider_slug', 'provider', 'auth_provider', 'server_key', 'context_server_key' ) as $key ) {
+			if ( ! empty( $handler_settings[ $key ] ) && is_scalar( $handler_settings[ $key ] ) ) {
+				$out['provider_id'] = (string) $handler_settings[ $key ];
+				break;
+			}
+		}
+
+		$tool_ids = array();
+		foreach ( array( 'tool_id', 'tool_slug', 'tool_name', 'handler_tool', 'mcp_tool' ) as $key ) {
+			if ( ! empty( $handler_settings[ $key ] ) && is_scalar( $handler_settings[ $key ] ) ) {
+				$tool_ids[] = (string) $handler_settings[ $key ];
+			}
+		}
+		if ( ! empty( $tool_ids ) ) {
+			$out['tool_ids'] = array_values( array_unique( $tool_ids ) );
+		}
+
+		return $out;
 	}
 }

--- a/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
+++ b/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
@@ -17,6 +17,7 @@
 namespace DataMachine\Core\Steps\Fetch\Tools;
 
 use DataMachine\Core\JobStatus;
+use DataMachine\Core\RunMetrics;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -125,7 +126,33 @@ class FetchItemDispositionTool {
 
 		// Set job status override for engine to use at completion
 		$status = JobStatus::agentSkipped( 'source-rejected' );
-		datamachine_merge_engine_data( $job_id, array( 'job_status' => $status->toString() ) );
+		datamachine_merge_engine_data(
+			$job_id,
+			array(
+				'job_status'       => $status->toString(),
+				'source_rejection' => array(
+					'reason'          => $reason,
+					'flow_step_id'    => $flow_step_id,
+					'item_identifier' => $item_identifier,
+					'source_type'     => $source_type,
+				),
+			)
+		);
+
+		if ( $flow_step_id ) {
+			RunMetrics::recordStepResult(
+				$job_id,
+				(string) $flow_step_id,
+				array(
+					'step_type'               => 'fetch',
+					'result'                  => 'source_rejected',
+					'packet_count'            => 0,
+					'source_rejection_reason' => $reason,
+					'source_type'             => $source_type,
+					'item_identifier'         => $item_identifier,
+				)
+			);
+		}
 
 		do_action(
 			'datamachine_log',

--- a/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
+++ b/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
@@ -139,7 +139,7 @@ class FetchItemDispositionTool {
 			)
 		);
 
-		if ( $flow_step_id ) {
+		if ( $flow_step_id && class_exists( RunMetrics::class ) ) {
 			RunMetrics::recordStepResult(
 				$job_id,
 				(string) $flow_step_id,

--- a/tests/job-outcome-metrics-smoke.php
+++ b/tests/job-outcome-metrics-smoke.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Pure-PHP smoke test for generic job outcome metrics (#2130).
+ *
+ * Run with: php tests/job-outcome-metrics-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/RunMetrics.php';
+
+use DataMachine\Core\RunMetrics;
+
+$failures = 0;
+$total    = 0;
+
+$assert = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$label}\n";
+		return;
+	}
+
+	++$failures;
+	echo "  [FAIL] {$label}\n";
+};
+
+$job = function ( string $status, array $engine_data ): array {
+	return array(
+		'job_id'      => 123,
+		'source'      => 'pipeline',
+		'label'       => 'Outcome smoke',
+		'flow_id'     => '10',
+		'pipeline_id' => '20',
+		'status'      => $status,
+		'created_at'  => '2026-05-20 00:00:00',
+		'engine_data' => $engine_data,
+	);
+};
+
+echo "=== job-outcome-metrics-smoke ===\n";
+
+echo "\n[1] completed fetch exposes packet count and handler IDs\n";
+$metrics = RunMetrics::fromJob(
+	$job(
+		'completed',
+		array(
+			'step_results' => array(
+				'fetch_1' => array(
+					'flow_step_id' => 'fetch_1',
+					'step_type'    => 'fetch',
+					'result'       => 'completed',
+					'handler_slug' => 'mcp',
+					'provider_id'  => 'a8c',
+					'tool_ids'     => array( 'search' ),
+					'packet_count' => 7,
+				),
+			),
+		)
+	)
+);
+$assert( 'fetch packet count is machine readable', 7 === $metrics['outcome']['fetch_packet_count'] );
+$assert( 'handler slug is exposed', 'mcp' === $metrics['outcome']['handler_slug'] );
+$assert( 'provider id is exposed', 'a8c' === $metrics['outcome']['provider_id'] );
+$assert( 'tool ids are exposed', array( 'search' ) === $metrics['outcome']['tool_ids'] );
+
+echo "\n[2] completed_no_items exposes no-content outcome\n";
+$metrics = RunMetrics::fromJob(
+	$job(
+		'completed_no_items',
+		array(
+			'step_results' => array(
+				'fetch_1' => array(
+					'flow_step_id' => 'fetch_1',
+					'step_type'    => 'fetch',
+					'result'       => 'no_content',
+					'handler_slug' => 'rss',
+					'packet_count' => 0,
+				),
+			),
+		)
+	)
+);
+$assert( 'base status is completed_no_items', 'completed_no_items' === $metrics['outcome']['base_status'] );
+$assert( 'no_content boolean is true', true === $metrics['outcome']['no_content'] );
+
+echo "\n[3] failed status exposes failure base status\n";
+$metrics = RunMetrics::fromJob( $job( 'failed - api-timeout', array() ) );
+$assert( 'failed base status is exposed', 'failed' === $metrics['outcome']['base_status'] );
+$assert( 'failed status reason is exposed', 'api-timeout' === $metrics['outcome']['status_reason'] );
+
+echo "\n[4] source rejected exposes rejection reason without log scraping\n";
+$metrics = RunMetrics::fromJob(
+	$job(
+		'agent_skipped - source-rejected',
+		array(
+			'source_rejection' => array( 'reason' => 'not relevant' ),
+			'step_results'     => array(
+				'fetch_1' => array(
+					'flow_step_id'             => 'fetch_1',
+					'step_type'                => 'fetch',
+					'result'                   => 'source_rejected',
+					'source_rejection_reason'  => 'not relevant',
+				),
+			),
+		)
+	)
+);
+$assert( 'source_rejected boolean is true', true === $metrics['outcome']['source_rejected'] );
+$assert( 'source rejection reason is exposed', 'not relevant' === $metrics['outcome']['source_rejection_reason'] );
+
+echo "\n[5] CLI/source integration markers exist\n";
+$jobs_command = file_get_contents( __DIR__ . '/../inc/Cli/Commands/JobsCommand.php' ) ?: '';
+$fetch_step   = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/FetchStep.php' ) ?: '';
+$disposition  = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php' ) ?: '';
+$assert( 'jobs list supports pipeline filter', str_contains( $jobs_command, "assoc_args['pipeline']" ) );
+$assert( 'jobs list supports handler filter', str_contains( $jobs_command, "assoc_args['handler']" ) );
+$assert( 'jobs list JSON includes outcome', str_contains( $jobs_command, "item['outcome']" ) );
+$assert( 'fetch step records packet count', str_contains( $fetch_step, "'packet_count' => count( \$packets )" ) );
+$assert( 'source rejection persists structured reason', str_contains( $disposition, "'source_rejection'" ) );
+
+if ( $failures > 0 ) {
+	echo "\n=== job-outcome-metrics-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";
+	exit( 1 );
+}
+
+echo "\n=== job-outcome-metrics-smoke: ALL PASS ({$total} assertions) ===\n";


### PR DESCRIPTION
## Summary
- Persist generic per-step outcome metadata in job `engine_data`, including fetch packet counts, no-content outcomes, handler/provider/tool IDs, step results, and source rejection details.
- Surface machine-readable outcome data through `RunMetrics`, `jobs metrics`, and `jobs list --format=json` with practical flow, pipeline, source, handler, and since filtering.
- Fix `completed_no_items` base-status parsing so no-content jobs report the correct machine-readable status.

## Verification
- `php tests/job-outcome-metrics-smoke.php`
- `php tests/job-status-accounting-smoke.php`
- `./vendor/bin/phpcs inc/Abilities/Engine/ExecuteStepAbility.php inc/Abilities/Job/GetJobsAbility.php inc/Cli/Commands/JobsCommand.php inc/Core/Database/Jobs/Jobs.php inc/Core/JobStatus.php inc/Core/RunMetrics.php inc/Core/Steps/AI/AIStep.php inc/Core/Steps/Fetch/FetchStep.php inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php tests/job-outcome-metrics-smoke.php`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-issue-2130-fetch-job-metrics --extension wordpress`

## Notes
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-issue-2130-fetch-job-metrics --extension wordpress` still reports pre-existing React/admin lint findings outside the changed PHP files.

Closes #2130

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted and verified the generic Data Machine outcome metrics implementation and PR description; Chris remains responsible for review and merge.