### PR TITLE
Add explicit OAuth site account API

### DIFF
--- a/docs/architecture/oauth-account-scope-api.md
+++ b/docs/architecture/oauth-account-scope-api.md
@@ -186,7 +186,8 @@ scope is genuinely delegated to provider policy.
 ## Rollout Slices
 
 1. Add this RFC and link it from OAuth handler docs.
-2. Add site-wide named methods and tests in `BaseAuthProvider`.
+2. Add site-wide named methods and tests in `BaseAuthProvider`. Shipped in
+   v0.128.0.
 3. Add agent named methods and tests in `BaseAuthProvider`.
 4. Add `get_account_for_context()` and reduce context-array `get_account()` to
    a deprecated shim for non-empty contexts.

--- a/docs/core-system/oauth-handlers.md
+++ b/docs/core-system/oauth-handlers.md
@@ -32,6 +32,9 @@ abstract public function is_authenticated(): bool;
 public function __construct(string $provider_slug);
 public function is_configured(): bool;
 public function get_callback_url(): string;
+public function get_site_account(): ?array;
+public function save_site_account(array $account): bool;
+public function delete_site_account(): bool;
 public function get_account(): array;
 public function get_config(): array;
 public function save_account(array $data): bool;
@@ -60,6 +63,23 @@ All providers store data in WordPress options using a consistent structure:
     ]
 ]
 ```
+
+### Site-wide account API (@since v0.128.0)
+
+Three concrete methods on `BaseAuthProvider` let callers operate on the shared
+site-wide account slot without consulting auth scope policy:
+
+```php
+public function get_site_account(): ?array;
+public function save_site_account( array $account ): bool;
+public function delete_site_account(): bool;
+```
+
+Use these methods for shared bot accounts, scheduled flows, and other cases
+where the credential is intentionally not owned by a specific user or agent.
+`get_site_account()` returns `null` when no site-wide account exists. The
+legacy `get_account()` method continues to return an empty array for missing
+accounts and remains unchanged during the migration window.
 
 ### Per-user account API (@since v0.123.0)
 

--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -212,6 +212,81 @@ abstract class BaseAuthProvider {
 		return apply_filters( 'datamachine_oauth_callback_url', $url, $this->provider_slug );
 	}
 
+	// -------------------------------------------------------------------------
+	// Site-wide account API
+	//
+	// These methods provide explicit top-level account storage access for shared
+	// bot credentials, scheduled flows, and other cases where the credential is
+	// intentionally not owned by a specific user or agent.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Get the site-wide OAuth account for this provider.
+	 *
+	 * Unlike `get_account( array $context )`, this method never consults auth
+	 * scope policy and never resolves to a user or agent principal. It only reads
+	 * the provider's top-level account slot.
+	 *
+	 * @since 0.128.0
+	 *
+	 * @return array|null Decrypted site-wide account data, or null if no account exists.
+	 */
+	public function get_site_account(): ?array {
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		$provider_data = $all_auth_data[ $this->provider_slug ] ?? array();
+		$account       = $provider_data['account'] ?? null;
+
+		if ( ! is_array( $account ) || empty( $account ) ) {
+			return null;
+		}
+
+		return $this->decrypt_fields( $account );
+	}
+
+	/**
+	 * Save the site-wide OAuth account for this provider.
+	 *
+	 * Sensitive fields are encrypted before storage. The account is stored in the
+	 * top-level provider account slot and does not affect principal-scoped user or
+	 * agent accounts.
+	 *
+	 * @since 0.128.0
+	 *
+	 * @param array $account Account data to store.
+	 * @return bool True on successful write, false on storage failure.
+	 */
+	public function save_site_account( array $account ): bool {
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		if ( ! isset( $all_auth_data[ $this->provider_slug ] ) || ! is_array( $all_auth_data[ $this->provider_slug ] ) ) {
+			$all_auth_data[ $this->provider_slug ] = array();
+		}
+
+		$all_auth_data[ $this->provider_slug ]['account'] = $this->encrypt_fields( $account );
+
+		return update_site_option( 'datamachine_auth_data', $all_auth_data );
+	}
+
+	/**
+	 * Delete the site-wide OAuth account for this provider.
+	 *
+	 * Principal-scoped user and agent accounts are preserved. The delete is
+	 * idempotent: removing a missing site account is successful.
+	 *
+	 * @since 0.128.0
+	 *
+	 * @return bool True on success, false on storage failure.
+	 */
+	public function delete_site_account(): bool {
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+
+		if ( isset( $all_auth_data[ $this->provider_slug ]['account'] ) ) {
+			unset( $all_auth_data[ $this->provider_slug ]['account'] );
+			return update_site_option( 'datamachine_auth_data', $all_auth_data );
+		}
+
+		return true;
+	}
+
 	/**
 	 * Get OAuth account data directly from options.
 	 *

--- a/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
+++ b/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
@@ -237,6 +237,69 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 	}
 
 	// -------------------------------------------------------------------------
+	// Site-wide account API
+	// -------------------------------------------------------------------------
+
+	public function test_get_site_account_returns_null_when_no_account(): void {
+		$this->assertNull( $this->provider->get_site_account() );
+	}
+
+	public function test_save_site_account_round_trip(): void {
+		$account = array(
+			'access_token' => 'tok_site',
+			'username'     => 'bot-account',
+			'scope'        => 'read write',
+		);
+
+		$this->assertTrue( $this->provider->save_site_account( $account ) );
+		$this->assertSame( $account, $this->provider->get_site_account() );
+	}
+
+	public function test_site_account_shares_legacy_site_slot(): void {
+		$this->provider->save_site_account( array( 'access_token' => 'tok_site' ) );
+
+		$this->assertSame( 'tok_site', $this->provider->get_account()['access_token'] );
+
+		$this->provider->save_account( array( 'access_token' => 'tok_legacy' ) );
+
+		$this->assertSame( 'tok_legacy', $this->provider->get_site_account()['access_token'] );
+	}
+
+	public function test_delete_site_account_removes_only_site_account(): void {
+		$this->provider->save_site_account( array( 'access_token' => 'tok_site' ) );
+		$this->provider->save_account_for_user( 42, array( 'access_token' => 'tok_user' ) );
+
+		$this->assertTrue( $this->provider->delete_site_account() );
+
+		$this->assertNull( $this->provider->get_site_account() );
+		$this->assertSame( 'tok_user', $this->provider->get_account_for_user( 42 )['access_token'] );
+	}
+
+	public function test_delete_site_account_is_idempotent(): void {
+		$this->assertTrue( $this->provider->delete_site_account() );
+	}
+
+	public function test_site_account_methods_do_not_consult_scope_policy(): void {
+		add_filter(
+			'datamachine_auth_scope_policy',
+			function () {
+				return BaseAuthProvider::AUTH_SCOPE_USER;
+			}
+		);
+
+		wp_set_current_user( self::factory()->user->create() );
+
+		$this->provider->save_site_account( array( 'access_token' => 'tok_site' ) );
+		$this->provider->save_account_for_user( get_current_user_id(), array( 'access_token' => 'tok_user' ) );
+
+		$this->assertSame( 'tok_site', $this->provider->get_site_account()['access_token'] );
+		$this->assertSame( 'tok_user', $this->provider->get_account()['access_token'] );
+
+		remove_all_filters( 'datamachine_auth_scope_policy' );
+		wp_set_current_user( 0 );
+	}
+
+	// -------------------------------------------------------------------------
 	// Per-user account API
 	// -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds explicit `get_site_account()`, `save_site_account()`, and `delete_site_account()` methods to `BaseAuthProvider`.
- Keeps legacy `get_account()` behavior unchanged while creating the site-wide API needed for the OAuth scope migration.
- Covers site account round-trips, legacy slot compatibility, idempotent delete, principal preservation, and policy bypass behavior.
- Updates OAuth handler docs and marks the site-account rollout slice in the RFC.

Refs #2117

## Verification
- `php -l inc/Core/OAuth/BaseAuthProvider.php && php -l tests/Unit/Core/OAuth/BaseAuthProviderTest.php`
- `vendor/bin/phpcs --standard=WordPress inc/Core/OAuth/BaseAuthProvider.php tests/Unit/Core/OAuth/BaseAuthProviderTest.php`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/data-machine@feature-oauth-site-account-api --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@feature-oauth-site-account-api --extension wordpress --changed-since origin/main`
- `homeboy audit --path /Users/chubes/Developer/data-machine@feature-oauth-site-account-api --extension wordpress --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the OAuth site account API slice, tests, docs, and local verification under Chris's direction.