### PR TITLE
Fix direct workflow AI packet inspection

### DIFF
--- a/inc/Engine/AI/RequestInspector.php
+++ b/inc/Engine/AI/RequestInspector.php
@@ -89,7 +89,7 @@ class RequestInspector {
 			);
 		}
 
-		$data_packets              = $this->retrieveDataPackets( $job_id, $engine );
+		$data_packets              = $this->retrieveDataPackets( $job_id, $engine, $flow_step_id );
 		$packet_projection_context = $this->buildProjectionContext( $job_id, $flow_step_id, $pipeline_step_id, $engine, $job );
 		$messages                  = $this->buildInitialMessages( $data_packets, $engine, $flow_step_config, $packet_projection_context );
 		$payload                   = $this->buildPayload( $job_id, $flow_step_id, $pipeline_step_id, $data_packets, $engine, $job );
@@ -186,10 +186,15 @@ class RequestInspector {
 		return 1 === count( $ai_steps ) ? $ai_steps[0] : '';
 	}
 
-	private function retrieveDataPackets( int $job_id, EngineData $engine ): array {
+	private function retrieveDataPackets( int $job_id, EngineData $engine, string $flow_step_id ): array {
 		$job_context = $engine->getJobContext();
 		$flow_id     = $job_context['flow_id'] ?? null;
-		if ( null === $flow_id || 'direct' === $flow_id || (int) $flow_id <= 0 ) {
+		if ( 'direct' === $flow_id ) {
+			$direct_step_data_packets = $engine->get( 'direct_step_data_packets', array() );
+			return is_array( $direct_step_data_packets[ $flow_step_id ] ?? null ) ? $direct_step_data_packets[ $flow_step_id ] : array();
+		}
+
+		if ( null === $flow_id || (int) $flow_id <= 0 ) {
 			return array();
 		}
 

--- a/tests/ai-request-inspector-smoke.php
+++ b/tests/ai-request-inspector-smoke.php
@@ -255,6 +255,13 @@ assert_test( 'PromptBuilder no longer reads job_id directly', false === strpos( 
 assert_test( 'PromptBuilder no longer reads flow_step_id directly', false === strpos( $prompt_builder_source, "\$payload['flow_step_id']" ) );
 assert_test( 'RequestBuilder maps legacy identifiers into directive_context', false !== strpos( $request_builder_source, "'directive_context'" ) );
 
+echo "\nCase 7: direct workflow packets are inspectable\n";
+
+$request_inspector_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/RequestInspector.php' );
+assert_test( 'RequestInspector passes flow step id into packet retrieval', false !== strpos( $request_inspector_source, '$this->retrieveDataPackets( $job_id, $engine, $flow_step_id )' ) );
+assert_test( 'RequestInspector recognizes direct workflows', false !== strpos( $request_inspector_source, "'direct' === \$flow_id" ) );
+assert_test( 'RequestInspector reads direct step packet slots', false !== strpos( $request_inspector_source, "\$direct_step_data_packets[ \$flow_step_id ]" ) );
+
 echo "\n$total assertions, $failed failures\n";
 $failed_count = (int) ( $GLOBALS['failed'] ?? $failed );
 if ( $failed_count > 0 ) {

--- a/tests/direct-request-inspector-packets-smoke.php
+++ b/tests/direct-request-inspector-packets-smoke.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Pure-PHP smoke test for direct workflow AI packet inspection.
+ *
+ * Run with: php tests/direct-request-inspector-packets-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../inc/Core/EngineData.php';
+require_once __DIR__ . '/../inc/Engine/AI/RequestInspector.php';
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function ( $expected, $actual, string $message ) use ( &$failures, &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  [PASS] {$message}\n";
+		return;
+	}
+
+	++$failures;
+	echo "  [FAIL] {$message}\n";
+	echo '    expected: ' . json_encode( $expected ) . "\n";
+	echo '    actual:   ' . json_encode( $actual ) . "\n";
+};
+
+echo "Direct request inspector packet smoke\n";
+
+$packet = array(
+	'type'     => 'wiki_graph_exception_review',
+	'data'     => array(
+		'title' => 'Wiki graph exceptions needing AI review',
+		'body'  => '{"items":[{"action_id":"pa-review","root_owner_agent":"matt-wiki"}]}',
+	),
+	'metadata' => array( 'source_type' => 'wiki_graph_maintain' ),
+);
+
+$engine = new \DataMachine\Core\EngineData(
+	array(
+		'job'                      => array(
+			'flow_id'     => 'direct',
+			'pipeline_id' => 'direct',
+		),
+		'direct_step_data_packets' => array(
+			'ephemeral_step_1' => array( $packet ),
+		),
+	),
+	87291
+);
+
+$method = new ReflectionMethod( \DataMachine\Engine\AI\RequestInspector::class, 'retrieveDataPackets' );
+$result = $method->invoke( new \DataMachine\Engine\AI\RequestInspector(), 87291, $engine, 'ephemeral_step_1' );
+
+$assert( array( $packet ), $result, 'direct workflow AI step receives its engine-backed packet slot' );
+$assert( array(), $method->invoke( new \DataMachine\Engine\AI\RequestInspector(), 87291, $engine, 'ephemeral_step_2' ), 'other direct workflow steps do not receive adjacent packet slots' );
+
+if ( $failures > 0 ) {
+	echo "\nFAILED: {$failures} failures, {$passes} passes.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} direct request inspector packet assertions passed.\n";


### PR DESCRIPTION
## Summary
- include direct workflow step packets when inspecting AI request context
- preserve existing file-backed flow packet inspection behavior
- add smoke coverage for direct workflow packet visibility

## Testing
- php tests/direct-request-inspector-packets-smoke.php
- php tests/ai-request-inspector-smoke.php
- homeboy lint --path /Users/chubes/Developer/data-machine@fix-direct-ai-inspector-packets --extension wordpress --changed-since origin/main
- homeboy test --path /Users/chubes/Developer/data-machine@fix-direct-ai-inspector-packets --extension wordpress --changed-since origin/main

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the missing direct workflow packet inspection path, drafted the code/test changes, and ran verification; Chris remains responsible for review and merge.