### PR TITLE
Add explicit OAuth agent account API

### DIFF
--- a/docs/architecture/oauth-account-scope-api.md
+++ b/docs/architecture/oauth-account-scope-api.md
@@ -188,7 +188,8 @@ scope is genuinely delegated to provider policy.
 1. Add this RFC and link it from OAuth handler docs.
 2. Add site-wide named methods and tests in `BaseAuthProvider`. Shipped in
    v0.128.0.
-3. Add agent named methods and tests in `BaseAuthProvider`.
+3. Add agent named methods and tests in `BaseAuthProvider`. Shipped in
+   v0.129.0.
 4. Add `get_account_for_context()` and reduce context-array `get_account()` to
    a deprecated shim for non-empty contexts.
 5. Update internal site-wide callsites to `get_site_account()` /

--- a/docs/core-system/oauth-handlers.md
+++ b/docs/core-system/oauth-handlers.md
@@ -35,6 +35,12 @@ public function get_callback_url(): string;
 public function get_site_account(): ?array;
 public function save_site_account(array $account): bool;
 public function delete_site_account(): bool;
+public function get_account_for_user(int $user_id): ?array;
+public function save_account_for_user(int $user_id, array $account): bool;
+public function delete_account_for_user(int $user_id): bool;
+public function get_account_for_agent(int $agent_id): ?array;
+public function save_account_for_agent(int $agent_id, array $account): bool;
+public function delete_account_for_agent(int $agent_id): bool;
 public function get_account(): array;
 public function get_config(): array;
 public function save_account(array $data): bool;
@@ -119,6 +125,23 @@ Every successful resolve emits a `debug`-level entry via the
 `datamachine_log` action with `{ provider, user_id, source }`. Failed
 lookups do not log (they would dwarf real signal during normal "no account
 yet" probes). The token itself is never logged at any level.
+
+### Per-agent account API (@since v0.129.0)
+
+Three concrete methods on `BaseAuthProvider` let callers operate on credentials
+delegated to a specific agent, independent of the site-wide and per-user account
+slots:
+
+```php
+public function get_account_for_agent( int $agent_id ): ?array;
+public function save_account_for_agent( int $agent_id, array $account ): bool;
+public function delete_account_for_agent( int $agent_id ): bool;
+```
+
+These share the same on-disk shape as the principal-scoped API
+(`principals[agent:<id>][account]`), so an account written via either surface is
+readable through the other. Like the per-user API, these methods never consult
+auth scope policy and never fall back to site-wide storage.
 
 #### When to use per-user vs. site-wide credentials
 

--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -600,6 +600,109 @@ abstract class BaseAuthProvider {
 		return update_site_option( 'datamachine_auth_data', $all_auth_data );
 	}
 
+	// -------------------------------------------------------------------------
+	// Per-agent account API
+	//
+	// These methods provide a deliberate, no-fallback per-agent storage surface
+	// for callers that operate on credentials delegated to a specific agent.
+	// They share the same underlying storage layout as the principal-scoped API
+	// (`principals[agent:<id>][account]`) so an account written via either
+	// surface is readable through the other.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Get the OAuth account for a specific agent.
+	 *
+	 * Sensitive fields are decrypted on read. Returns `null` when no per-agent
+	 * account exists for this provider+agent — there is intentionally no fallback
+	 * to site-wide storage.
+	 *
+	 * @since 0.129.0
+	 *
+	 * @param int $agent_id Target agent ID. Must be a positive integer.
+	 * @return array|null Decrypted account data, or null if no account exists.
+	 */
+	public function get_account_for_agent( int $agent_id ): ?array {
+		$agent_id = absint( $agent_id );
+		if ( $agent_id <= 0 ) {
+			return null;
+		}
+
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		$provider_data = $all_auth_data[ $this->provider_slug ] ?? array();
+		$scope_key     = 'agent:' . $agent_id;
+		$account       = $provider_data['principals'][ $scope_key ]['account'] ?? null;
+
+		if ( ! is_array( $account ) || empty( $account ) ) {
+			return null;
+		}
+
+		return $this->decrypt_fields( $account );
+	}
+
+	/**
+	 * Save the OAuth account for a specific agent.
+	 *
+	 * Sensitive fields are encrypted before storage. Stores under the same
+	 * `principals[agent:<id>][account]` slot used by the scope-aware
+	 * `save_account()` path so the two surfaces stay in sync.
+	 *
+	 * @since 0.129.0
+	 *
+	 * @param int   $agent_id Target agent ID. Must be a positive integer.
+	 * @param array $account Account data to store.
+	 * @return bool True on successful write, false on invalid input or storage failure.
+	 */
+	public function save_account_for_agent( int $agent_id, array $account ): bool {
+		$agent_id = absint( $agent_id );
+		if ( $agent_id <= 0 ) {
+			return false;
+		}
+
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		if ( ! isset( $all_auth_data[ $this->provider_slug ] ) || ! is_array( $all_auth_data[ $this->provider_slug ] ) ) {
+			$all_auth_data[ $this->provider_slug ] = array();
+		}
+		if ( ! isset( $all_auth_data[ $this->provider_slug ]['principals'] ) || ! is_array( $all_auth_data[ $this->provider_slug ]['principals'] ) ) {
+			$all_auth_data[ $this->provider_slug ]['principals'] = array();
+		}
+
+		$scope_key = 'agent:' . $agent_id;
+		$all_auth_data[ $this->provider_slug ]['principals'][ $scope_key ]['account'] = $this->encrypt_fields( $account );
+
+		return update_site_option( 'datamachine_auth_data', $all_auth_data );
+	}
+
+	/**
+	 * Delete the OAuth account for a specific agent.
+	 *
+	 * Returns true when the per-agent slot existed and was removed, or when there
+	 * was nothing to remove (idempotent). Returns false only on invalid input or a
+	 * storage failure.
+	 *
+	 * @since 0.129.0
+	 *
+	 * @param int $agent_id Target agent ID. Must be a positive integer.
+	 * @return bool True on success (including no-op deletes), false on invalid input or storage failure.
+	 */
+	public function delete_account_for_agent( int $agent_id ): bool {
+		$agent_id = absint( $agent_id );
+		if ( $agent_id <= 0 ) {
+			return false;
+		}
+
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		$scope_key     = 'agent:' . $agent_id;
+
+		if ( ! isset( $all_auth_data[ $this->provider_slug ]['principals'][ $scope_key ] ) ) {
+			return true; // Idempotent: nothing to delete.
+		}
+
+		unset( $all_auth_data[ $this->provider_slug ]['principals'][ $scope_key ] );
+
+		return update_site_option( 'datamachine_auth_data', $all_auth_data );
+	}
+
 	/**
 	 * Get the authenticated username for this provider.
 	 *

--- a/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
+++ b/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
@@ -430,4 +430,97 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 
 		remove_all_filters( 'datamachine_resolve_oauth_account_for_user' );
 	}
+
+	// -------------------------------------------------------------------------
+	// Per-agent account API
+	// -------------------------------------------------------------------------
+
+	public function test_get_account_for_agent_returns_null_when_no_account(): void {
+		$this->assertNull( $this->provider->get_account_for_agent( 303 ) );
+	}
+
+	public function test_save_account_for_agent_round_trip(): void {
+		$account = array(
+			'access_token' => 'tok_agent_303',
+			'username'     => 'agent-account',
+			'scope'        => 'read write',
+		);
+
+		$saved = $this->provider->save_account_for_agent( 303, $account );
+		$this->assertTrue( $saved );
+
+		$loaded = $this->provider->get_account_for_agent( 303 );
+		$this->assertIsArray( $loaded );
+		$this->assertSame( 'tok_agent_303', $loaded['access_token'] );
+		$this->assertSame( 'agent-account', $loaded['username'] );
+		$this->assertSame( 'read write', $loaded['scope'] );
+	}
+
+	public function test_delete_account_for_agent_removes_account(): void {
+		$this->provider->save_account_for_agent( 303, array( 'access_token' => 'tok_agent_303' ) );
+		$this->assertNotNull( $this->provider->get_account_for_agent( 303 ) );
+
+		$this->assertTrue( $this->provider->delete_account_for_agent( 303 ) );
+		$this->assertNull( $this->provider->get_account_for_agent( 303 ) );
+	}
+
+	public function test_delete_account_for_agent_is_idempotent(): void {
+		$this->assertTrue( $this->provider->delete_account_for_agent( 12345 ) );
+	}
+
+	public function test_per_agent_accounts_are_isolated_between_agents(): void {
+		$this->provider->save_account_for_agent( 303, array( 'access_token' => 'tok_agent_a' ) );
+		$this->provider->save_account_for_agent( 404, array( 'access_token' => 'tok_agent_b' ) );
+
+		$agent_a = $this->provider->get_account_for_agent( 303 );
+		$agent_b = $this->provider->get_account_for_agent( 404 );
+
+		$this->assertSame( 'tok_agent_a', $agent_a['access_token'] );
+		$this->assertSame( 'tok_agent_b', $agent_b['access_token'] );
+	}
+
+	public function test_per_agent_account_does_not_fall_back_to_site_account(): void {
+		$this->provider->save_site_account( array( 'access_token' => 'site_token' ) );
+
+		$this->assertNull( $this->provider->get_account_for_agent( 303 ) );
+		$this->assertSame( 'site_token', $this->provider->get_site_account()['access_token'] );
+	}
+
+	public function test_per_agent_save_does_not_affect_site_or_user_account(): void {
+		$this->provider->save_site_account( array( 'access_token' => 'site_token' ) );
+		$this->provider->save_account_for_user( 42, array( 'access_token' => 'tok_user_42' ) );
+		$this->provider->save_account_for_agent( 303, array( 'access_token' => 'tok_agent_303' ) );
+
+		$this->assertSame( 'site_token', $this->provider->get_site_account()['access_token'] );
+		$this->assertSame( 'tok_user_42', $this->provider->get_account_for_user( 42 )['access_token'] );
+		$this->assertSame( 'tok_agent_303', $this->provider->get_account_for_agent( 303 )['access_token'] );
+	}
+
+	public function test_invalid_agent_ids_are_rejected(): void {
+		$this->assertFalse( $this->provider->save_account_for_agent( 0, array( 'access_token' => 'x' ) ) );
+		$this->assertNull( $this->provider->get_account_for_agent( 0 ) );
+		$this->assertFalse( $this->provider->delete_account_for_agent( 0 ) );
+	}
+
+	public function test_per_agent_account_shares_principal_scoped_agent_slot(): void {
+		add_filter(
+			'datamachine_auth_scope_policy',
+			function () {
+				return BaseAuthProvider::AUTH_SCOPE_AGENT;
+			}
+		);
+
+		$this->provider->save_account_for_agent( 303, array( 'access_token' => 'tok_agent_303' ) );
+
+		$this->assertSame(
+			'tok_agent_303',
+			$this->provider->get_account( array( 'agent_id' => 303 ) )['access_token']
+		);
+
+		$this->provider->save_account( array( 'access_token' => 'tok_agent_scoped' ), array( 'agent_id' => 404 ) );
+
+		$this->assertSame( 'tok_agent_scoped', $this->provider->get_account_for_agent( 404 )['access_token'] );
+
+		remove_all_filters( 'datamachine_auth_scope_policy' );
+	}
 }


### PR DESCRIPTION
## Summary
- Adds explicit `get_account_for_agent()`, `save_account_for_agent()`, and `delete_account_for_agent()` methods to `BaseAuthProvider`.
- Keeps legacy `get_account( array( 'agent_id' => ... ) )` behavior unchanged while adding the no-fallback per-agent API from the OAuth scope RFC.
- Covers round-trips, idempotent deletes, agent isolation, no site fallback, site/user preservation, invalid IDs, and compatibility with the existing principal-scoped agent slot.
- Updates OAuth handler docs and marks the agent-account rollout slice in the RFC.

Refs #2117

## Verification
- `php -l inc/Core/OAuth/BaseAuthProvider.php && php -l tests/Unit/Core/OAuth/BaseAuthProviderTest.php`
- `vendor/bin/phpcs --standard=WordPress inc/Core/OAuth/BaseAuthProvider.php tests/Unit/Core/OAuth/BaseAuthProviderTest.php`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/data-machine@feature-oauth-agent-account-api --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@feature-oauth-agent-account-api --extension wordpress --changed-since origin/main`
- `homeboy audit --path /Users/chubes/Developer/data-machine@feature-oauth-agent-account-api --extension wordpress --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the OAuth agent account API slice, tests, docs, and local verification under Chris's direction.