### PR TITLE
Add explicit OAuth account context resolver

### DIFF
--- a/docs/architecture/oauth-account-scope-api.md
+++ b/docs/architecture/oauth-account-scope-api.md
@@ -190,14 +190,15 @@ scope is genuinely delegated to provider policy.
    v0.128.0.
 3. Add agent named methods and tests in `BaseAuthProvider`. Shipped in
    v0.129.0.
-4. Add `get_account_for_context()` and reduce context-array `get_account()` to
-   a deprecated shim for non-empty contexts.
-5. Update internal site-wide callsites to `get_site_account()` /
+4. Add `get_account_for_context()`. Shipped in v0.130.0.
+5. Reduce context-array `get_account()` to a deprecated shim for non-empty
+   contexts.
+6. Update internal site-wide callsites to `get_site_account()` /
    `save_site_account()` / `delete_site_account()`.
-6. Update internal scoped callsites to `get_account_for_user()` or
+7. Update internal scoped callsites to `get_account_for_user()` or
    `get_account_for_agent()` when the scope is explicit.
-7. Publish vendor migration notes and coordinate downstream plugin updates.
-8. After at least one release cycle, decide whether context-free `get_account()`
+8. Publish vendor migration notes and coordinate downstream plugin updates.
+9. After at least one release cycle, decide whether context-free `get_account()`
    should also become a deprecated alias for `get_site_account()`.
 
 ## Open Questions

--- a/docs/core-system/oauth-handlers.md
+++ b/docs/core-system/oauth-handlers.md
@@ -41,6 +41,7 @@ public function delete_account_for_user(int $user_id): bool;
 public function get_account_for_agent(int $agent_id): ?array;
 public function save_account_for_agent(int $agent_id, array $account): bool;
 public function delete_account_for_agent(int $agent_id): bool;
+public function get_account_for_context(array $context = array()): ?array;
 public function get_account(): array;
 public function get_config(): array;
 public function save_account(array $data): bool;
@@ -142,6 +143,23 @@ These share the same on-disk shape as the principal-scoped API
 (`principals[agent:<id>][account]`), so an account written via either surface is
 readable through the other. Like the per-user API, these methods never consult
 auth scope policy and never fall back to site-wide storage.
+
+### Policy-resolved account context API (@since v0.130.0)
+
+`get_account_for_context()` is the explicit account lookup for callers that want
+provider policy to decide which credential scope applies to an execution
+context:
+
+```php
+public function get_account_for_context( array $context = array() ): ?array;
+```
+
+The method consults `datamachine_auth_scope_policy` and the same context inputs
+as legacy `get_account( array $context )`: explicit `agent_id`, explicit
+`user_id`, acting agent/user IDs from `PermissionHelper`, and the current WP
+user. It preserves the current site fallback behavior during the migration
+window, but returns `null` when neither a scoped account nor a site-wide account
+exists.
 
 #### When to use per-user vs. site-wide credentials
 

--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -314,6 +314,38 @@ abstract class BaseAuthProvider {
 	}
 
 	/**
+	 * Get the OAuth account that applies to an execution context.
+	 *
+	 * This is the explicit policy-resolved account lookup. It preserves the
+	 * existing `get_account( array $context )` scope resolution and site fallback
+	 * semantics while returning `null` when no account is available.
+	 *
+	 * @since 0.130.0
+	 *
+	 * @param array $context Optional principal context, e.g. user_id or agent_id.
+	 * @return array|null Decrypted account data, or null if no account resolves.
+	 */
+	public function get_account_for_context( array $context = array() ): ?array {
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		$provider_data = $all_auth_data[ $this->provider_slug ] ?? array();
+		$scope         = $this->get_principal_scope( $context, 'account' );
+
+		if ( null !== $scope ) {
+			$scoped_account = $provider_data['principals'][ $scope ]['account'] ?? array();
+			if ( ! empty( $scoped_account ) && is_array( $scoped_account ) ) {
+				return $this->decrypt_fields( $scoped_account );
+			}
+		}
+
+		$account = $provider_data['account'] ?? array();
+		if ( ! is_array( $account ) || empty( $account ) ) {
+			return null;
+		}
+
+		return $this->decrypt_fields( $account );
+	}
+
+	/**
 	 * Get OAuth configuration keys directly from options.
 	 *
 	 * Automatically decrypts any encrypted fields. Plaintext legacy values

--- a/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
+++ b/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
@@ -300,6 +300,95 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 	}
 
 	// -------------------------------------------------------------------------
+	// Policy-resolved account context API
+	// -------------------------------------------------------------------------
+
+	public function test_get_account_for_context_returns_null_when_no_account(): void {
+		$this->assertNull( $this->provider->get_account_for_context() );
+	}
+
+	public function test_get_account_for_context_reads_site_account_by_default(): void {
+		$this->provider->save_site_account( array( 'access_token' => 'tok_site' ) );
+
+		$this->assertSame( 'tok_site', $this->provider->get_account_for_context()['access_token'] );
+	}
+
+	public function test_get_account_for_context_preserves_site_policy_for_user_context(): void {
+		$this->provider->save_site_account( array( 'access_token' => 'tok_site' ) );
+		$this->provider->save_account_for_user( 42, array( 'access_token' => 'tok_user_42' ) );
+
+		$this->assertSame( 'tok_site', $this->provider->get_account_for_context( array( 'user_id' => 42 ) )['access_token'] );
+	}
+
+	public function test_get_account_for_context_resolves_user_policy(): void {
+		add_filter(
+			'datamachine_auth_scope_policy',
+			function () {
+				return BaseAuthProvider::AUTH_SCOPE_USER;
+			}
+		);
+
+		$this->provider->save_site_account( array( 'access_token' => 'tok_site' ) );
+		$this->provider->save_account_for_user( 42, array( 'access_token' => 'tok_user_42' ) );
+
+		$this->assertSame( 'tok_user_42', $this->provider->get_account_for_context( array( 'user_id' => 42 ) )['access_token'] );
+
+		remove_all_filters( 'datamachine_auth_scope_policy' );
+	}
+
+	public function test_get_account_for_context_resolves_agent_before_user_for_principal_policy(): void {
+		add_filter(
+			'datamachine_auth_scope_policy',
+			function () {
+				return BaseAuthProvider::AUTH_SCOPE_PRINCIPAL;
+			}
+		);
+
+		$this->provider->save_site_account( array( 'access_token' => 'tok_site' ) );
+		$this->provider->save_account_for_user( 42, array( 'access_token' => 'tok_user_42' ) );
+		$this->provider->save_account_for_agent( 303, array( 'access_token' => 'tok_agent_303' ) );
+
+		$account = $this->provider->get_account_for_context(
+			array(
+				'user_id'  => 42,
+				'agent_id' => 303,
+			)
+		);
+
+		$this->assertSame( 'tok_agent_303', $account['access_token'] );
+
+		remove_all_filters( 'datamachine_auth_scope_policy' );
+	}
+
+	public function test_get_account_for_context_falls_back_to_site_account_when_scoped_account_missing(): void {
+		add_filter(
+			'datamachine_auth_scope_policy',
+			function () {
+				return BaseAuthProvider::AUTH_SCOPE_USER;
+			}
+		);
+
+		$this->provider->save_site_account( array( 'access_token' => 'tok_site' ) );
+
+		$this->assertSame( 'tok_site', $this->provider->get_account_for_context( array( 'user_id' => 42 ) )['access_token'] );
+
+		remove_all_filters( 'datamachine_auth_scope_policy' );
+	}
+
+	public function test_get_account_for_context_returns_null_when_policy_scoped_and_no_fallback_exists(): void {
+		add_filter(
+			'datamachine_auth_scope_policy',
+			function () {
+				return BaseAuthProvider::AUTH_SCOPE_USER;
+			}
+		);
+
+		$this->assertNull( $this->provider->get_account_for_context( array( 'user_id' => 42 ) ) );
+
+		remove_all_filters( 'datamachine_auth_scope_policy' );
+	}
+
+	// -------------------------------------------------------------------------
 	// Per-user account API
 	// -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `BaseAuthProvider::get_account_for_context()` as the explicit policy-resolved account lookup from the OAuth scope RFC.
- Preserves current `get_account( array $context )` scope policy and site fallback semantics while returning `null` when no account resolves.
- Covers default site lookup, site-policy behavior, user-policy behavior, principal agent precedence, site fallback, and null-on-missing behavior.
- Updates OAuth handler docs and marks the context-resolver rollout slice in the RFC.

Refs #2117

## Verification
- `php -l inc/Core/OAuth/BaseAuthProvider.php && php -l tests/Unit/Core/OAuth/BaseAuthProviderTest.php`
- `vendor/bin/phpcs --standard=WordPress inc/Core/OAuth/BaseAuthProvider.php tests/Unit/Core/OAuth/BaseAuthProviderTest.php`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/data-machine@feature-oauth-account-context-resolver --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@feature-oauth-account-context-resolver --extension wordpress --changed-since origin/main`
- `homeboy audit --path /Users/chubes/Developer/data-machine@feature-oauth-account-context-resolver --extension wordpress --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the OAuth account context resolver slice, tests, docs, and local verification under Chris's direction.