### PR TITLE
Deprecate OAuth get_account context argument

### DIFF
--- a/docs/architecture/oauth-account-scope-api.md
+++ b/docs/architecture/oauth-account-scope-api.md
@@ -192,13 +192,15 @@ scope is genuinely delegated to provider policy.
    v0.129.0.
 4. Add `get_account_for_context()`. Shipped in v0.130.0.
 5. Reduce context-array `get_account()` to a deprecated shim for non-empty
-   contexts.
-6. Update internal site-wide callsites to `get_site_account()` /
+   contexts. Shipped in v0.131.0.
+6. Reduce context-array `save_account()` and `clear_account()` to deprecated
+   shims for non-empty contexts.
+7. Update internal site-wide callsites to `get_site_account()` /
    `save_site_account()` / `delete_site_account()`.
-7. Update internal scoped callsites to `get_account_for_user()` or
+8. Update internal scoped callsites to `get_account_for_user()` or
    `get_account_for_agent()` when the scope is explicit.
-8. Publish vendor migration notes and coordinate downstream plugin updates.
-9. After at least one release cycle, decide whether context-free `get_account()`
+9. Publish vendor migration notes and coordinate downstream plugin updates.
+10. After at least one release cycle, decide whether context-free `get_account()`
    should also become a deprecated alias for `get_site_account()`.
 
 ## Open Questions

--- a/docs/core-system/oauth-handlers.md
+++ b/docs/core-system/oauth-handlers.md
@@ -85,8 +85,8 @@ public function delete_site_account(): bool;
 Use these methods for shared bot accounts, scheduled flows, and other cases
 where the credential is intentionally not owned by a specific user or agent.
 `get_site_account()` returns `null` when no site-wide account exists. The
-legacy `get_account()` method continues to return an empty array for missing
-accounts and remains unchanged during the migration window.
+legacy context-free `get_account()` method continues to return an empty array
+for missing accounts during the migration window.
 
 ### Per-user account API (@since v0.123.0)
 
@@ -160,6 +160,11 @@ as legacy `get_account( array $context )`: explicit `agent_id`, explicit
 user. It preserves the current site fallback behavior during the migration
 window, but returns `null` when neither a scoped account nor a site-wide account
 exists.
+
+Passing a non-empty context array to `get_account()` is deprecated as of
+v0.131.0. The legacy method still returns an array for backward compatibility,
+but callers should use `get_account_for_context()` when they want
+policy-resolved lookup.
 
 #### When to use per-user vs. site-wide credentials
 

--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -298,6 +298,18 @@ abstract class BaseAuthProvider {
 	 * @return array Account data or empty array
 	 */
 	public function get_account( array $context = array() ): array {
+		if ( ! empty( $context ) ) {
+			if ( function_exists( '_deprecated_function' ) ) {
+				_deprecated_function(
+					__METHOD__ . ' with a context argument',
+					'0.131.0',
+					'BaseAuthProvider::get_account_for_context()'
+				);
+			}
+
+			return $this->get_account_for_context( $context ) ?? array();
+		}
+
 		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
 		$provider_data = $all_auth_data[ $this->provider_slug ] ?? array();
 		$scope         = $this->get_principal_scope( $context, 'account' );

--- a/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
+++ b/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
@@ -388,6 +388,95 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 		remove_all_filters( 'datamachine_auth_scope_policy' );
 	}
 
+	public function test_get_account_without_context_does_not_emit_deprecation(): void {
+		$deprecated_calls = array();
+
+		add_action(
+			'deprecated_function_run',
+			function ( $function_name, $replacement, $version ) use ( &$deprecated_calls ) {
+				$deprecated_calls[] = array( $function_name, $replacement, $version );
+			},
+			10,
+			3
+		);
+
+		$this->provider->get_account();
+
+		$this->assertSame( array(), $deprecated_calls );
+
+		remove_all_filters( 'deprecated_function_run' );
+	}
+
+	public function test_get_account_with_context_emits_deprecation_and_preserves_return_shape(): void {
+		$deprecated_calls = array();
+		$this->setExpectedDeprecated( 'DataMachine\Core\OAuth\BaseAuthProvider::get_account with a context argument' );
+
+		add_filter(
+			'deprecated_function_trigger_error',
+			function () {
+				return false;
+			}
+		);
+		add_action(
+			'deprecated_function_run',
+			function ( $function_name, $replacement, $version ) use ( &$deprecated_calls ) {
+				$deprecated_calls[] = array( $function_name, $replacement, $version );
+			},
+			10,
+			3
+		);
+
+		$result = $this->provider->get_account( array( 'user_id' => 42 ) );
+
+		$this->assertSame( array(), $result );
+		$this->assertSame(
+			array(
+				array(
+					'DataMachine\Core\OAuth\BaseAuthProvider::get_account with a context argument',
+					'BaseAuthProvider::get_account_for_context()',
+					'0.131.0',
+				),
+			),
+			$deprecated_calls
+		);
+
+		remove_all_filters( 'deprecated_function_trigger_error' );
+		remove_all_filters( 'deprecated_function_run' );
+	}
+
+	public function test_deprecated_get_account_context_uses_context_resolver_behavior(): void {
+		$this->setExpectedDeprecated( 'DataMachine\Core\OAuth\BaseAuthProvider::get_account with a context argument' );
+
+		add_filter(
+			'deprecated_function_trigger_error',
+			function () {
+				return false;
+			}
+		);
+		add_filter(
+			'datamachine_auth_scope_policy',
+			function () {
+				return BaseAuthProvider::AUTH_SCOPE_PRINCIPAL;
+			}
+		);
+
+		$this->provider->save_site_account( array( 'access_token' => 'tok_site' ) );
+		$this->provider->save_account_for_user( 42, array( 'access_token' => 'tok_user_42' ) );
+		$this->provider->save_account_for_agent( 303, array( 'access_token' => 'tok_agent_303' ) );
+
+		$result = $this->provider->get_account(
+			array(
+				'user_id'  => 42,
+				'agent_id' => 303,
+			)
+		);
+
+		$this->assertSame( 'tok_agent_303', $result['access_token'] );
+
+		remove_all_filters( 'deprecated_function_trigger_error' );
+		remove_all_filters( 'datamachine_auth_scope_policy' );
+	}
+
 	// -------------------------------------------------------------------------
 	// Per-user account API
 	// -------------------------------------------------------------------------
@@ -603,7 +692,7 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 
 		$this->assertSame(
 			'tok_agent_303',
-			$this->provider->get_account( array( 'agent_id' => 303 ) )['access_token']
+			$this->provider->get_account_for_context( array( 'agent_id' => 303 ) )['access_token']
 		);
 
 		$this->provider->save_account( array( 'access_token' => 'tok_agent_scoped' ), array( 'agent_id' => 404 ) );


### PR DESCRIPTION
## Summary
- Deprecates non-empty context-array calls to `BaseAuthProvider::get_account()` and routes them through `get_account_for_context()`.
- Preserves the legacy array return shape while documenting the explicit policy-resolved replacement.
- Adds unit coverage for context-free calls, deprecated context calls, and resolver behavior parity.

Refs #2117

## Testing
- `vendor/bin/phpcs --standard=WordPress inc/Core/OAuth/BaseAuthProvider.php tests/Unit/Core/OAuth/BaseAuthProviderTest.php`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/data-machine@cleanup-oauth-get-account-context-deprecation --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@cleanup-oauth-get-account-context-deprecation --extension wordpress --changed-since origin/main`
- `homeboy audit --path /Users/chubes/Developer/data-machine@cleanup-oauth-get-account-context-deprecation --extension wordpress --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the scoped deprecation bridge, tests, docs updates, and local verification; Chris remains responsible for review and merge.