### PR TITLE
Deprecate OAuth account write context arguments

### DIFF
--- a/docs/architecture/oauth-account-scope-api.md
+++ b/docs/architecture/oauth-account-scope-api.md
@@ -194,7 +194,7 @@ scope is genuinely delegated to provider policy.
 5. Reduce context-array `get_account()` to a deprecated shim for non-empty
    contexts. Shipped in v0.131.0.
 6. Reduce context-array `save_account()` and `clear_account()` to deprecated
-   shims for non-empty contexts.
+   shims for non-empty contexts. Shipped in v0.132.0.
 7. Update internal site-wide callsites to `get_site_account()` /
    `save_site_account()` / `delete_site_account()`.
 8. Update internal scoped callsites to `get_account_for_user()` or

--- a/docs/core-system/oauth-handlers.md
+++ b/docs/core-system/oauth-handlers.md
@@ -166,6 +166,10 @@ v0.131.0. The legacy method still returns an array for backward compatibility,
 but callers should use `get_account_for_context()` when they want
 policy-resolved lookup.
 
+Passing a non-empty context array to `save_account()` or `clear_account()` is
+deprecated as of v0.132.0. Callers should use the explicit site, user, or agent
+methods when they know the target scope.
+
 #### When to use per-user vs. site-wide credentials
 
 ```

--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -393,6 +393,14 @@ abstract class BaseAuthProvider {
 	 * @return bool True on success
 	 */
 	public function save_account( array $data, array $context = array() ): bool {
+		if ( ! empty( $context ) && function_exists( '_deprecated_function' ) ) {
+			_deprecated_function(
+				__METHOD__ . ' with a context argument',
+				'0.132.0',
+				'BaseAuthProvider::save_site_account(), BaseAuthProvider::save_account_for_user(), or BaseAuthProvider::save_account_for_agent()'
+			);
+		}
+
 		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
 		if ( ! isset( $all_auth_data[ $this->provider_slug ] ) ) {
 			$all_auth_data[ $this->provider_slug ] = array();
@@ -446,6 +454,14 @@ abstract class BaseAuthProvider {
 	 * @return bool True on success
 	 */
 	public function clear_account( array $context = array() ): bool {
+		if ( ! empty( $context ) && function_exists( '_deprecated_function' ) ) {
+			_deprecated_function(
+				__METHOD__ . ' with a context argument',
+				'0.132.0',
+				'BaseAuthProvider::delete_site_account(), BaseAuthProvider::delete_account_for_user(), or BaseAuthProvider::delete_account_for_agent()'
+			);
+		}
+
 		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
 		$scope         = $this->get_principal_scope( $context, 'account' );
 

--- a/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
+++ b/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
@@ -477,6 +477,144 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 		remove_all_filters( 'datamachine_auth_scope_policy' );
 	}
 
+	public function test_save_account_without_context_does_not_emit_deprecation(): void {
+		$deprecated_calls = array();
+
+		add_action(
+			'deprecated_function_run',
+			function ( $function_name, $replacement, $version ) use ( &$deprecated_calls ) {
+				$deprecated_calls[] = array( $function_name, $replacement, $version );
+			},
+			10,
+			3
+		);
+
+		$this->provider->save_account( array( 'access_token' => 'tok_site' ) );
+
+		$this->assertSame( array(), $deprecated_calls );
+
+		remove_all_filters( 'deprecated_function_run' );
+	}
+
+	public function test_save_account_with_context_emits_deprecation_and_preserves_policy_write(): void {
+		$deprecated_calls = array();
+		$this->setExpectedDeprecated( 'DataMachine\Core\OAuth\BaseAuthProvider::save_account with a context argument' );
+
+		add_filter(
+			'deprecated_function_trigger_error',
+			function () {
+				return false;
+			}
+		);
+		add_filter(
+			'datamachine_auth_scope_policy',
+			function () {
+				return BaseAuthProvider::AUTH_SCOPE_PRINCIPAL;
+			}
+		);
+		add_action(
+			'deprecated_function_run',
+			function ( $function_name, $replacement, $version ) use ( &$deprecated_calls ) {
+				$deprecated_calls[] = array( $function_name, $replacement, $version );
+			},
+			10,
+			3
+		);
+
+		$result = $this->provider->save_account(
+			array( 'access_token' => 'tok_agent_scoped' ),
+			array(
+				'user_id'  => 42,
+				'agent_id' => 303,
+			)
+		);
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'tok_agent_scoped', $this->provider->get_account_for_agent( 303 )['access_token'] );
+		$this->assertSame(
+			array(
+				array(
+					'DataMachine\Core\OAuth\BaseAuthProvider::save_account with a context argument',
+					'BaseAuthProvider::save_site_account(), BaseAuthProvider::save_account_for_user(), or BaseAuthProvider::save_account_for_agent()',
+					'0.132.0',
+				),
+			),
+			$deprecated_calls
+		);
+
+		remove_all_filters( 'deprecated_function_trigger_error' );
+		remove_all_filters( 'datamachine_auth_scope_policy' );
+		remove_all_filters( 'deprecated_function_run' );
+	}
+
+	public function test_clear_account_without_context_does_not_emit_deprecation(): void {
+		$deprecated_calls = array();
+
+		add_action(
+			'deprecated_function_run',
+			function ( $function_name, $replacement, $version ) use ( &$deprecated_calls ) {
+				$deprecated_calls[] = array( $function_name, $replacement, $version );
+			},
+			10,
+			3
+		);
+
+		$this->provider->clear_account();
+
+		$this->assertSame( array(), $deprecated_calls );
+
+		remove_all_filters( 'deprecated_function_run' );
+	}
+
+	public function test_clear_account_with_context_emits_deprecation_and_preserves_policy_delete(): void {
+		$deprecated_calls = array();
+		$this->setExpectedDeprecated( 'DataMachine\Core\OAuth\BaseAuthProvider::clear_account with a context argument' );
+
+		add_filter(
+			'deprecated_function_trigger_error',
+			function () {
+				return false;
+			}
+		);
+		add_filter(
+			'datamachine_auth_scope_policy',
+			function () {
+				return BaseAuthProvider::AUTH_SCOPE_PRINCIPAL;
+			}
+		);
+		add_action(
+			'deprecated_function_run',
+			function ( $function_name, $replacement, $version ) use ( &$deprecated_calls ) {
+				$deprecated_calls[] = array( $function_name, $replacement, $version );
+			},
+			10,
+			3
+		);
+
+		$this->provider->save_site_account( array( 'access_token' => 'tok_site' ) );
+		$this->provider->save_account_for_agent( 303, array( 'access_token' => 'tok_agent_303' ) );
+
+		$result = $this->provider->clear_account( array( 'agent_id' => 303 ) );
+
+		$this->assertTrue( $result );
+		$this->assertNull( $this->provider->get_account_for_agent( 303 ) );
+		$this->assertSame( 'tok_site', $this->provider->get_site_account()['access_token'] );
+		$this->assertSame(
+			array(
+				array(
+					'DataMachine\Core\OAuth\BaseAuthProvider::clear_account with a context argument',
+					'BaseAuthProvider::delete_site_account(), BaseAuthProvider::delete_account_for_user(), or BaseAuthProvider::delete_account_for_agent()',
+					'0.132.0',
+				),
+			),
+			$deprecated_calls
+		);
+
+		remove_all_filters( 'deprecated_function_trigger_error' );
+		remove_all_filters( 'datamachine_auth_scope_policy' );
+		remove_all_filters( 'deprecated_function_run' );
+	}
+
 	// -------------------------------------------------------------------------
 	// Per-user account API
 	// -------------------------------------------------------------------------
@@ -695,7 +833,7 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 			$this->provider->get_account_for_context( array( 'agent_id' => 303 ) )['access_token']
 		);
 
-		$this->provider->save_account( array( 'access_token' => 'tok_agent_scoped' ), array( 'agent_id' => 404 ) );
+		$this->provider->save_account_for_agent( 404, array( 'access_token' => 'tok_agent_scoped' ) );
 
 		$this->assertSame( 'tok_agent_scoped', $this->provider->get_account_for_agent( 404 )['access_token'] );
 


### PR DESCRIPTION
## Summary
- Deprecates non-empty context-array calls to `BaseAuthProvider::save_account()` and `BaseAuthProvider::clear_account()`.
- Preserves the existing policy-resolved write/delete behavior during the migration window.
- Documents the explicit site, user, and agent account methods as the replacement paths.

Refs #2117

## Testing
- `php -l inc/Core/OAuth/BaseAuthProvider.php && php -l tests/Unit/Core/OAuth/BaseAuthProviderTest.php`
- `vendor/bin/phpcs --standard=WordPress inc/Core/OAuth/BaseAuthProvider.php tests/Unit/Core/OAuth/BaseAuthProviderTest.php`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/data-machine@cleanup-oauth-save-clear-context-deprecation --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@cleanup-oauth-save-clear-context-deprecation --extension wordpress --changed-since origin/main`
- `homeboy audit --path /Users/chubes/Developer/data-machine@cleanup-oauth-save-clear-context-deprecation --extension wordpress --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the scoped deprecation bridge, tests, docs updates, and local verification; Chris remains responsible for review and merge.