### PR TITLE
docs: refresh Data Machine documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Full REST API under `datamachine/v1`:
 - `GET|POST|PATCH|DELETE /agents...` — Agent CRUD, current agent, access, tokens
 - `POST /agent-ping/confirm`, `POST /agent-ping/callback/{callback_id}` — Agent Ping confirmation/callbacks
 - `GET /handlers`, `/step-types`, `/providers`, `/tools`, `/settings`, `/system/*` — Discovery and settings
-- `GET|POST /auth/*`, `/email/*`, `/processed-items`, `/users/*`, `/analytics/*`, `/links/*` — Supporting product surfaces
+- `GET|POST /auth/*`, `/email/*`, `/users/*`, `/analytics/*`, `/links/*`; `DELETE /processed-items` — Supporting product surfaces
 - `GET /actions/pending`, `GET /actions/pending/{id}`, `POST /actions/resolve` — Approval-gated pending actions
 
 Detailed endpoint docs live under [`docs/api/`](docs/api/). Routes under `wp-json/datamachine/v1` are the Data Machine product API, not the generic Agents API substrate.
@@ -291,7 +291,7 @@ Detailed endpoint docs live under [`docs/api/`](docs/api/). Routes under `wp-jso
 
 ## AI Providers
 
-OpenAI, Anthropic, Google, Grok, OpenRouter — configure a global default per-site, with per-mode overrides for pipeline, chat, and system. Runtime provider dispatch goes through WordPress core's `wp-ai-client` via Data Machine's `RequestBuilder`; there is no runtime fallback to `chubes_ai_request` or `ai-http-client`.
+Configure any provider registered with `wp-ai-client`, then choose a global default per site with optional per-mode overrides for pipeline, chat, and system. Data Machine reads provider/model metadata from the wp-ai-client provider registry and Connectors-shaped settings via `WpAiClientProviderAdmin`; runtime dispatch goes through `RequestBuilder` and has no fallback to `chubes_ai_request` or `ai-http-client`.
 
 ## Runtime Architecture
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ Core should expose behavior through abilities, hooks, REST, CLI, handlers, and b
 - **Engine Execution**: Bounded execution cycle, Single Item Execution Model, job status logic, and retry behavior ([core-system/engine-execution.md](core-system/engine-execution.md)).
 - **Pipeline Execution Axes**: Queue, fan-out, per-step iteration, and scheduled runs as separate dimensions ([architecture/pipeline-execution-axes.md](architecture/pipeline-execution-axes.md)).
 - **Troubleshooting Problem Flows**: Automated monitoring of consecutive failures/no-items and how to resolve them ([core-system/troubleshooting-problem-flows.md](core-system/troubleshooting-problem-flows.md)).
-- **Abilities API**: WordPress capability discovery and execution for Data Machine operations ([core-system/abilities-api.md](core-system/abilities-api.md)).
+- **Abilities API**: Current `datamachine/*` domain inventory, permission model, and registration contract ([core-system/abilities-api.md](core-system/abilities-api.md)).
 - **WP-CLI**: Current command surface including cycle, drain, worker, pending actions, retention, bundles, and aliases ([core-system/wp-cli.md](core-system/wp-cli.md)).
 
 ### Architecture Deep Dives
@@ -47,22 +47,20 @@ Core should expose behavior through abilities, hooks, REST, CLI, handlers, and b
 - **Daily Memory System**: DailyMemoryTask lifecycle, deterministic overflow, opt-in daily injection, and daily memory artifacts ([core-system/daily-memory-system.md](core-system/daily-memory-system.md)).
 - **Memory Policy**: Per-agent memory injection policy and safe self-memory write gates ([core-system/memory-policy.md](core-system/memory-policy.md)).
 - **Agent Bundles**: Portable agent package schema, artifact tracking, extras, extension artifacts, run artifacts, and authenticated sources ([core-system/agent-bundles.md](core-system/agent-bundles.md)).
-- **Universal Engine**: Shared AI infrastructure for pipeline and chat agents.
+- **Universal Engine**: Shared AI infrastructure for pipeline, chat, and system agents ([core-system/universal-engine.md](core-system/universal-engine.md)).
 - **AI Conversation Loop**: Data Machine turn runner over `AgentsAPI\AI\WP_Agent_Conversation_Loop` ([core-system/ai-conversation-loop.md](core-system/ai-conversation-loop.md)).
-- **AI Directives System**: Hierarchical directive injection for contextual AI behavior.
-- **Tool Execution**: Resolved tool dispatch, action policy, ability-only execution, and approval staging.
-- **Tool Manager**: Data Machine tool registry, source-level availability checks, policy resolution, and handler tool expansion.
-- **Request Builder**: Directive-aware construction of provider requests.
-- **Conversation Manager**: Message normalization, logging, and tool call tracking.
-- **Prompt Builder**: Priority-based directive registration via filters.
-- **Parameter Systems**: Unified parameter handling across tools and handlers.
-- **Tool Result Finder**: Utility for interpreting tool responses inside data packets.
-- **OAuth Handlers**: Base classes for OAuth1/OAuth2 providers and app-password flows.
-- **Handler Registration Trait**: Centralized registration pattern for fetch, publish, and upsert handlers.
-- **HTTP Client**: Standardized outbound request flow for handlers with structured logging and browser-mode header support.
-- **Import/Export System**: Pipeline configuration backup, migration, and sharing functionality.
-- **Agent Bundles**: Portable agent recipes with memory, pipelines, flows, reserved schema trees, and extension-owned extras ([core-system/agent-bundles.md](core-system/agent-bundles.md)).
-- **Daily Memory System**: Append-only daily artifacts, daily-memory directive, chat tool, REST/CLI, and summarization task ([core-system/daily-memory-system.md](core-system/daily-memory-system.md)).
+- **AI Directives System**: Hierarchical directive injection for contextual AI behavior ([core-system/ai-directives.md](core-system/ai-directives.md)).
+- **Tool Execution**: Resolved tool dispatch, action policy, ability execution, and approval staging ([core-system/tool-execution.md](core-system/tool-execution.md)).
+- **Tool Manager**: Data Machine tool registry, source-level availability checks, policy resolution, and handler tool expansion ([core-system/tool-manager.md](core-system/tool-manager.md)).
+- **Request Builder**: Directive-aware construction of wp-ai-client provider requests ([core-system/request-builder.md](core-system/request-builder.md)).
+- **Conversation Manager**: Message normalization, logging, and tool call tracking ([core-system/conversation-manager.md](core-system/conversation-manager.md)).
+- **Prompt Builder**: Priority-based directive registration via filters ([core-system/prompt-builder.md](core-system/prompt-builder.md)).
+- **Parameter Systems**: Unified parameter handling across tools and handlers ([api/endpoints/parameter-systems.md](api/endpoints/parameter-systems.md)).
+- **Tool Result Finder**: Utility for interpreting tool responses inside data packets ([core-system/tool-result-finder.md](core-system/tool-result-finder.md)).
+- **OAuth Handlers**: Base classes for OAuth1/OAuth2 providers and app-password flows ([core-system/oauth-handlers.md](core-system/oauth-handlers.md)).
+- **Handler Registration Trait**: Centralized registration pattern for fetch, publish, and upsert handlers ([core-system/handler-registration-trait.md](core-system/handler-registration-trait.md)).
+- **HTTP Client**: Standardized outbound request flow for handlers with structured logging and browser-mode header support ([core-system/http-client.md](core-system/http-client.md)).
+- **Import/Export System**: Pipeline configuration backup, migration, and sharing functionality ([core-system/import-export.md](core-system/import-export.md)).
 - **Ephemeral Workflows**: Execute workflow definitions without first saving a persistent pipeline ([core-system/ephemeral-workflows.md](core-system/ephemeral-workflows.md)).
 - **Memory Policy**: Read/write/editability policy for self-memory and file sections ([core-system/memory-policy.md](core-system/memory-policy.md)).
 
@@ -105,7 +103,7 @@ docs/
 ├── architecture/                      # Architecture deep dives (axes, policies, primitives)
 ├── CHANGELOG.md                       # Semantic changelog for releases
 ├── core-system/                       # Engine, services, and core infrastructure pieces
-│   ├── abilities-api.md               # WordPress 6.9 Abilities API for flow queries, logging, and post filtering
+│   ├── abilities-api.md               # Current datamachine/* ability domains, permissions, and registration contract
 │   ├── ai-directives.md               # AI directive system and priority hierarchy
 │   ├── ai-conversation-loop.md        # Data Machine turn runner over Agents API conversation loop
 │   ├── agent-bundles.md               # Portable agent bundle schema and extras contract

--- a/docs/ai-tools/bing-webmaster.md
+++ b/docs/ai-tools/bing-webmaster.md
@@ -127,7 +127,7 @@ wp datamachine analytics bing page_stats --allow-root
 POST /wp-json/datamachine/v1/analytics/bing
 ```
 
-**Authentication**: Requires `manage_options` capability.
+**Authentication**: Requires the relevant Data Machine management capability plus configured Bing Webmaster access.
 
 **Request Body**:
 ```json

--- a/docs/ai-tools/google-analytics.md
+++ b/docs/ai-tools/google-analytics.md
@@ -190,7 +190,7 @@ wp datamachine analytics ga user_demographics --allow-root
 POST /wp-json/datamachine/v1/analytics/ga
 ```
 
-**Authentication**: Requires `manage_options` capability.
+**Authentication**: Requires the relevant Data Machine management capability plus configured Google Analytics access.
 
 **Request Body**:
 ```json

--- a/docs/ai-tools/google-search-console.md
+++ b/docs/ai-tools/google-search-console.md
@@ -209,7 +209,7 @@ wp datamachine analytics gsc submit_sitemap --sitemap-url=https://chubes.net/sit
 POST /wp-json/datamachine/v1/analytics/gsc
 ```
 
-**Authentication**: Requires `manage_options` capability.
+**Authentication**: Requires the relevant Data Machine management capability plus configured Google Search Console access.
 
 **Request Body**:
 ```json

--- a/docs/ai-tools/google-search.md
+++ b/docs/ai-tools/google-search.md
@@ -192,7 +192,7 @@ $result = $google_search_tool->handle_tool_call([
 
 ### WordPress Integration
 
-**Permissions**: Requires `manage_options` capability for configuration
+**Permissions**: Requires the relevant Data Machine management capability for configuration
 **Storage**: Configuration stored in WordPress options table
 **Logging**: All operations logged via `datamachine_log` action
 **REST API**: Configuration handled through Data Machine REST API endpoints

--- a/docs/ai-tools/pagespeed-insights.md
+++ b/docs/ai-tools/pagespeed-insights.md
@@ -188,7 +188,7 @@ wp datamachine analytics pagespeed analyze --format=json --allow-root
 POST /wp-json/datamachine/v1/analytics/pagespeed
 ```
 
-**Authentication**: Requires `manage_options` capability.
+**Authentication**: Requires the relevant Data Machine management capability for tool configuration and execution context.
 
 **Request Body**:
 ```json

--- a/docs/api/endpoints/handlers.md
+++ b/docs/api/endpoints/handlers.md
@@ -10,7 +10,7 @@ The Handlers endpoint provides information about registered fetch, publish, and 
 
 ## Authentication
 
-Requires `manage_options` capability. See Authentication Guide.
+Public metadata endpoints. The routes use `__return_true` because handler labels, schema metadata, and auth requirements are used for UI discovery and do not expose stored credentials.
 
 ## Endpoints
 
@@ -18,7 +18,7 @@ Requires `manage_options` capability. See Authentication Guide.
 
 Retrieve list of available handlers with metadata.
 
-**Permission**: `manage_options` capability required
+**Permission**: Public metadata endpoint
 
 **Purpose**: Discover available handlers for pipeline configuration
 

--- a/docs/api/endpoints/processed-items.md
+++ b/docs/api/endpoints/processed-items.md
@@ -1,4 +1,4 @@
-# Deduplication Tracking Endpoints
+# Processed Items Endpoint
 
 **Implementation**: `inc/Api/ProcessedItems.php`
 
@@ -6,480 +6,65 @@
 
 ## Overview
 
-Deduplication tracking endpoints manage item tracking records to prevent duplicate processing of content items across flow executions. When a fetch handler processes an item (like an RSS post or Reddit comment), a record is stored to mark it as processed so future flow runs skip it.
+Processed items are the deduplication records Data Machine uses to avoid re-processing the same source item across flow executions. Fetch handlers and engine code write these records during execution; the REST surface currently exposes an operator cleanup endpoint for resetting deduplication by pipeline or flow.
+
+For richer read/check/stale-history operations, use the `datamachine/*` abilities in `ProcessedItemsAbilities` or the WP-CLI `wp datamachine processed-items` command.
 
 ## Authentication
 
-Requires `manage_options` capability. See Authentication Guide documentation.
+The REST endpoint requires `PermissionHelper::can( 'manage_flows' )`. Administrators pass through the mapped Data Machine capability fallback.
 
-## Endpoints
+## Endpoint
 
-### GET /processed-items
+### DELETE `/processed-items`
 
-Retrieve deduplication tracking records with pagination and filtering.
+Clear processed-item records for a flow or pipeline.
 
-**Permission**: `manage_options` capability required
-
-**Purpose**: Monitor what items have been processed to prevent duplicates, useful for debugging and workflow optimization
+**Permission**: `manage_flows`
 
 **Parameters**:
-- `page` (integer, optional): Page number for pagination (default: 1)
-- `per_page` (integer, optional): Items per page (default: 20, max: 100)
-- `flow_id` (integer, optional): Filter by specific flow ID
 
-**Example Requests**:
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `clear_type` | string | Yes | Either `pipeline` or `flow`. |
+| `target_id` | integer | Yes | Pipeline ID or flow ID matching `clear_type`. |
+
+**Example request**:
 
 ```bash
-# Get all processed items (paginated)
-curl https://example.com/wp-json/datamachine/v1/processed-items \
-  -u username:application_password
-
-# Get processed items for specific flow
-curl https://example.com/wp-json/datamachine/v1/processed-items?flow_id=42 \
-  -u username:application_password
-
-# Get specific page
-curl https://example.com/wp-json/datamachine/v1/processed-items?page=2&per_page=50 \
-  -u username:application_password
+curl -X DELETE https://example.com/wp-json/datamachine/v1/processed-items \
+  -u username:application_password \
+  -H 'Content-Type: application/json' \
+  -d '{"clear_type":"flow","target_id":42}'
 ```
 
-**Success Response (200 OK)**:
+**Success response**:
 
 ```json
 {
   "success": true,
-  "items": [
-    {
-      "id": 1523,
-      "flow_step_id": "step_uuid_42",
-      "source_type": "rss",
-      "item_identifier": "https://example.com/post-123",
-      "job_id": 789,
-      "processed_at": "2024-01-02 14:30:00"
-    },
-    {
-      "id": 1522,
-      "flow_step_id": "step_uuid_42",
-      "source_type": "rss",
-      "item_identifier": "https://example.com/post-122",
-      "job_id": 788,
-      "processed_at": "2024-01-02 14:00:00"
-    }
-  ],
-  "total": 1523,
-  "page": 1,
-  "per_page": 20
+  "message": "Cleared processed items for flow 42",
+  "cleared_count": 17,
+  "clear_type": "flow",
+  "target_id": 42
 }
 ```
 
-**Response Fields**:
-- `success` (boolean): Request success status
-- `items` (array): Array of deduplication tracking records
-- `total` (integer): Total number of tracked items matching filters
-- `page` (integer): Current page number
-- `per_page` (integer): Number of items per page
-
-**Tracked Item Fields**:
-- `id` (integer): Unique processed item ID
-- `flow_step_id` (string): Flow step identifier (format: `{pipeline_step_id}_{flow_id}`)
-- `source_type` (string): Handler type (e.g., `rss`, `reddit`, `wordpress-local`)
-- `item_identifier` (string): Unique identifier for the processed item (URL, post ID, etc.)
-- `job_id` (integer): Associated job ID
-- `processed_at` (string): Timestamp when item was processed
-
-### DELETE /processed-items/{id}
-
-Delete a specific deduplication tracking record to allow reprocessing that item.
-
-**Permission**: `manage_options` capability required
-
-**Purpose**: Remove tracking for a specific item to force it to be processed again on next flow execution
-
-**Parameters**:
-- `id` (integer, required): Processed item ID (in URL path)
-
-**Example Request**:
-
-```bash
-curl -X DELETE https://example.com/wp-json/datamachine/v1/processed-items/1523 \
-  -u username:application_password
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "message": "Deduplication tracking record deleted successfully.",
-  "id": 1523
-}
-```
-
-**Response Fields**:
-- `success` (boolean): Request success status
-- `message` (string): Confirmation message
-- `id` (integer): Deleted tracking record ID
-
-**Error Response (404 Not Found)**:
-
-```json
-{
-  "code": "processed_item_not_found",
-  "message": "Processed item not found.",
-  "data": {"status": 404}
-}
-```
-
-### DELETE /processed-items
-
-Clear deduplication tracking records in bulk by pipeline or flow.
-
-**Permission**: `manage_options` capability required
-
-**Purpose**: Reset deduplication tracking to allow items to be processed again on next execution
-
-**Parameters**:
-- `clear_type` (string, required): Clear scope - `pipeline` or `flow`
-- `target_id` (integer, required): Pipeline ID or Flow ID depending on clear_type
-
-**Example Requests**:
-
-```bash
-# Clear processed items for entire pipeline
-curl -X DELETE https://example.com/wp-json/datamachine/v1/processed-items \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"clear_type": "pipeline", "target_id": 5}'
-
-# Clear processed items for specific flow
-curl -X DELETE https://example.com/wp-json/datamachine/v1/processed-items \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"clear_type": "flow", "target_id": 42}'
-```
-
-**Success Response (200 OK)**:
-
-```json
-{
-  "success": true,
-  "data": null,
-  "message": "Deleted 42 deduplication tracking records.",
-  "items_deleted": 42
-}
-```
-
-**Error Response (400 Bad Request)**:
-
-```json
-{
-  "code": "invalid_clear_type",
-  "message": "Invalid clear type. Must be 'pipeline' or 'flow'.",
-  "data": {"status": 400}
-}
-```
-
-## Deduplication Tracking System
-
-### How It Works
-
-1. **Fetch Handler**: Records item identifier when fetching content from a source
-2. **Database Storage**: Stores `flow_step_id`, `source_type`, `item_identifier`, and `job_id`
-3. **Future Executions**: Checks if an item was previously processed before fetching
-4. **Skip Duplicates**: Prevents reprocessing of the same item across flow runs
-
-### Item Identifiers by Handler
-
-**RSS Handler**:
-- Identifier: RSS item link URL
-- Example: `https://example.com/post-123`
-
-**Reddit Handler**:
-- Identifier: Reddit post ID
-- Example: `t3_abc123`
-
-**WordPress Local Handler**:
-- Identifier: WordPress post ID
-- Example: `456`
-
-**WordPress API Handler**:
-- Identifier: Post link URL
-- Example: `https://external-site.com/post-789`
-
-**WordPress Media Handler**:
-- Identifier: Attachment ID
-- Example: `789`
-
-**Google Sheets Handler**:
-- Identifier: Row index
-- Example: `5`
-
-### Flow Step ID Format
-
-Processed items are tracked per flow step using composite ID:
-
-```
-{pipeline_step_id}_{flow_id}
-```
-
-**Example**: `abc-123-def-456_42`
-
-This allows:
-- Same pipeline step in different flows to maintain independent tracking
-- Pipeline-wide clearing when pipeline is deleted
-- Flow-specific clearing when flow is deleted
-
-## Common Workflows
-
-### Force Reprocessing of RSS Feed
-
-```bash
-# 1. Clear deduplication tracking for flow
-curl -X DELETE https://example.com/wp-json/datamachine/v1/processed-items \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"clear_type": "flow", "target_id": 42}'
-
-# 2. Execute flow again - items will be processed since tracking was cleared
-curl -X POST https://example.com/wp-json/datamachine/v1/execute \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"flow_id": 42}'
-```
-
-### Debug Deduplication Behavior
-
-```bash
-# Check what items have been tracked as processed
-curl https://example.com/wp-json/datamachine/v1/processed-items?flow_id=42&per_page=100 \
-  -u username:application_password
-```
-
-### Reset Pipeline Tracking
-
-```bash
-# Clear all deduplication tracking for pipeline
-curl -X DELETE https://example.com/wp-json/datamachine/v1/processed-items \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"clear_type": "pipeline", "target_id": 5}'
-```
-
-## Integration Examples
-
-### Python Deduplication Management
-
-```python
-import requests
-from requests.auth import HTTPBasicAuth
-
-url = "https://example.com/wp-json/datamachine/v1/processed-items"
-auth = HTTPBasicAuth("username", "application_password")
-
-# Get deduplication tracking records for flow
-params = {"flow_id": 42, "per_page": 100}
-response = requests.get(url, params=params, auth=auth)
-
-if response.status_code == 200:
-    data = response.json()
-    print(f"Found {len(data['items'])} tracked items")
-
-    for item in data['items']:
-        print(f"Processed: {item['item_identifier']} at {item['processed_at']}")
-
-# Clear deduplication tracking
-clear_response = requests.delete(url, json={
-    "clear_type": "flow",
-    "target_id": 42
-}, auth=auth)
-
-if clear_response.status_code == 200:
-    print("Deduplication tracking cleared")
-```
-
-### JavaScript Item Tracking Management
-
-```javascript
-const axios = require('axios');
-
-const deduplicationAPI = {
-  baseURL: 'https://example.com/wp-json/datamachine/v1/processed-items',
-  auth: {
-    username: 'admin',
-    password: 'application_password'
-  }
-};
-
-// Get tracked items count
-async function getTrackedCount(flowId) {
-  const response = await axios.get(deduplicationAPI.baseURL, {
-    params: { flow_id: flowId, per_page: 1 },
-    auth: deduplicationAPI.auth
-  });
-
-  return response.data.total;
-}
-
-// Clear deduplication tracking by flow
-async function clearFlowTracking(flowId) {
-  const response = await axios.delete(deduplicationAPI.baseURL, {
-    data: {
-      clear_type: 'flow',
-      target_id: flowId
-    },
-    auth: deduplicationAPI.auth
-  });
-
-  return response.data.success;
-}
-
-// Delete specific tracking record
-async function deleteTrackingRecord(itemId) {
-  const response = await axios.delete(
-    `${deduplicationAPI.baseURL}/${itemId}`,
-    { auth: deduplicationAPI.auth }
-  );
-
-  return response.data.success;
-}
-
-// Usage
-const count = await getTrackedCount(42);
-console.log(`Flow 42 has ${count} tracked items`);
-
-await clearFlowTracking(42);
-console.log('Flow deduplication tracking cleared');
-```
-
-## Use Cases
-
-### Reprocess RSS Feed Items
-
-Clear deduplication tracking to force re-import of previously skipped content:
-
-```bash
-curl -X DELETE https://example.com/wp-json/datamachine/v1/processed-items \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"clear_type": "flow", "target_id": 42}'
-```
-
-### Debug Handler Configuration
-
-After fixing handler configuration, reset deduplication tracking to reprocess items with new settings:
-
-```bash
-curl -X DELETE https://example.com/wp-json/datamachine/v1/processed-items \
-  -H "Content-Type: application/json" \
-  -u username:application_password \
-  -d '{"clear_type": "pipeline", "target_id": 5}'
-```
-
-### Monitor Workflow Progress
-
-Track how many items have been processed over time by checking deduplication records:
-
-```bash
-curl https://example.com/wp-json/datamachine/v1/processed-items?flow_id=42 \
-  -u username:application_password
-```
-
-### Remove Specific Deduplication Record
-
-Delete tracking for a specific item to allow it to be processed again:
-
-```bash
-curl -X DELETE https://example.com/wp-json/datamachine/v1/processed-items/1523 \
-  -u username:application_password
-```
-
-## Abilities API Integration
-
-Six registered abilities provide programmatic access to processed items operations. These are used by REST API endpoints, CLI commands, and Chat tools.
-
-| Ability | Description |
-|---------|-------------|
-| `datamachine/clear-processed-items` | Clear processed items by pipeline or flow scope |
-| `datamachine/check-processed-item` | Check if a specific item has been processed for a flow step |
-| `datamachine/has-processed-history` | Check if a flow step has any processing history |
-| `datamachine/processed-items-get-processed-at` | Get the last-processed Unix timestamp for a specific item (or null) |
-| `datamachine/processed-items-find-stale` | Given candidate identifiers, return those older than N days |
-| `datamachine/processed-items-find-never-processed` | Given candidate identifiers, return those with no row for this flow step + source type |
-
-### Revisit API (since 0.71.0)
-
-The three `processed-items-*` abilities expose the time-windowed read surface on the `processed_timestamp` column that has been populated on every row since the table existed. Together with the `datamachine_should_reprocess_item` filter (see [core-filters.md](../../development/hooks/core-filters.md)), they let consumers build maintenance-style pipelines ("review wiki post X if last reviewed > 7 days ago", "venue refresh on cadence", "rotating SEO audit") as thin wrappers on one DM primitive — no parallel tables, no post_meta, no new registration surface.
-
-See `ProcessedItems::get_processed_at()`, `has_been_processed_within()`, `find_stale()`, and `find_never_processed()` for the underlying methods.
-
-### has-processed-history
-
-Distinguishes "no new items found" from "first run with an empty source." The `has_processed_items()` method on `ProcessedItems` checks whether any record exists for a given `flow_step_id`. The engine uses this to select between two completion statuses:
-
-- **`completed_no_items`** — The flow step has processed items before but the current run found nothing new. This is normal steady-state behavior.
-- **`completed` (empty)** — The flow step has never processed anything. This indicates a first run that returned no data, which may signal a configuration issue.
-
-## SkipItemTool
-
-**Implementation**: `inc/Core/Steps/Fetch/Tools/SkipItemTool.php`
-**Since**: 0.9.7
-
-The `SkipItemTool` is a handler tool available during the Fetch step that allows the AI agent to explicitly skip an item that does not meet processing criteria. It acts as a safety net when keyword exclusions or other filters miss items that should not be processed.
-
-**Behavior**:
-1. Marks the item as processed via `datamachine_mark_item_processed` action so it is not refetched on subsequent runs
-2. Sets `job_status` in engine_data to `agent_skipped - {reason}` via `datamachine_merge_engine_data()`
-3. The engine reads the `job_status` override at completion and applies it as the final job status
-
-**Parameters**:
-- `reason` (string, required): Explanation of why the item is being skipped
-- `job_id` (integer, required): Current job ID
-- `engine` (object, injected): ExecutionContext engine providing `item_id`, `source_type`, and `flow_step_id`
-
-**Tool Result**:
-```php
-[
-    'success'   => true,
-    'message'   => 'Item skipped: {reason}',
-    'status'    => 'agent_skipped - {reason}',
-    'item_id'   => '{item_identifier}',
-    'tool_name' => 'skip_item',
-]
-```
-
-## ExecutionContext
-
-**Implementation**: `inc/Core/ExecutionContext.php`
-**Since**: 0.9.16
-
-`ExecutionContext` bridges fetch handlers to the database layer by encapsulating execution mode, deduplication, engine data access, file storage, and logging into a single object.
-
-**Execution Modes**:
-- **`flow`** — Standard flow-based execution with full pipeline/flow context and deduplication tracking
-- **`direct`** — Direct execution without database persistence (CLI tools, ephemeral workflows); deduplication is disabled and IDs are set to the sentinel value `'direct'`
-
-**Factory Methods**:
-- `ExecutionContext::fromFlow($pipeline_id, $flow_id, $flow_step_id, $job_id, $handler_type)` — Standard flow execution
-- `ExecutionContext::direct($handler_type)` — Direct execution mode
-- `ExecutionContext::fromConfig($config, $job_id, $handler_type)` — Backward-compatible creation from handler config array
-
-**Key Methods for Processed Items**:
-- `isItemProcessed(string $item_id): bool` — Checks deduplication via `ProcessedItems::has_item_been_processed()` and applies the `datamachine_should_reprocess_item` filter so consumers can opt into revisit semantics (since 0.71.0). Returns `false` in direct and standalone modes.
-- `markItemProcessed(string $item_id): void` — Fires `datamachine_mark_item_processed` action. No-op in direct mode.
-- `storeEngineData(array $data): void` — Merges data into engine snapshot for the current job
-- `getEngine(): EngineData` — Lazily loads engine data for the current job
+## Ability Surface
+
+`ProcessedItemsAbilities` registers the current ability surface for programmatic callers:
+
+| Ability | Purpose |
+|---------|---------|
+| `datamachine/clear-processed-items` | Clear dedupe records by flow or pipeline. |
+| `datamachine/check-processed-item` | Check whether an item has been processed. |
+| `datamachine/has-processed-history` | Check whether a flow has any processed history. |
+| `datamachine/processed-items-get-processed-at` | Return the last processed timestamp for an item. |
+| `datamachine/processed-items-find-stale` | Filter candidate items to those processed before a threshold. |
+| `datamachine/processed-items-find-never-processed` | Filter candidate items to those with no processed record. |
 
 ## Related Documentation
 
-- Execute Endpoint - Workflow execution
-- Jobs Endpoints - Job monitoring
-- Handlers Endpoint - Available handlers
-- Authentication - Auth methods
-
----
-
-**Base URL**: `/wp-json/datamachine/v1/processed-items`
-**Permission**: `manage_options` capability required
-**Implementation**: `inc/Api/ProcessedItems.php`
-**Database Table**: `wp_datamachine_processed_items`
-**Abilities**: `DataMachine\Abilities\ProcessedItemsAbilities`
+- [API Overview](../index.md)
+- [Abilities API](../../core-system/abilities-api.md)
+- [WP-CLI Commands](../../core-system/wp-cli.md)

--- a/docs/api/endpoints/providers.md
+++ b/docs/api/endpoints/providers.md
@@ -10,7 +10,7 @@ The Providers endpoint retrieves information about available AI providers and th
 
 ## Authentication
 
-Requires `manage_options` capability. See Authentication Guide.
+Public metadata endpoint. The route uses `__return_true` because provider labels and model metadata are needed by setup/admin clients and do not expose raw API keys.
 
 ## Endpoints
 
@@ -18,7 +18,7 @@ Requires `manage_options` capability. See Authentication Guide.
 
 Retrieve available AI providers with configuration status.
 
-**Permission**: `manage_options` capability required
+**Permission**: Public metadata endpoint
 
 **Purpose**: Discover available AI providers and check their configuration status
 

--- a/docs/api/endpoints/settings.md
+++ b/docs/api/endpoints/settings.md
@@ -18,7 +18,7 @@ Settings endpoints manage tool configuration for Data Machine.
 
 ## Authentication
 
-Requires `manage_options` capability. See Authentication Guide.
+Settings endpoints require `PermissionHelper::can( 'manage_settings' )`. Administrators pass through the mapped Data Machine capability fallback.
 
 ## Endpoints
 
@@ -26,7 +26,7 @@ Requires `manage_options` capability. See Authentication Guide.
 
 Save configuration for a specific tool.
 
-**Permission**: `manage_options` capability required
+**Permission**: `manage_settings`
 
 **Parameters**:
 - `tool_id` (string, required): Tool identifier (in URL path) - e.g., `google_search`

--- a/docs/api/endpoints/step-types.md
+++ b/docs/api/endpoints/step-types.md
@@ -10,7 +10,7 @@ The StepTypes endpoint provides information about available step types for pipel
 
 ## Authentication
 
-Requires `manage_options` capability. See Authentication Guide.
+Public metadata endpoints. The routes use `__return_true` because step-type labels, handler requirements, and UI metadata are not sensitive.
 
 ## Endpoints
 
@@ -18,7 +18,7 @@ Requires `manage_options` capability. See Authentication Guide.
 
 Retrieve available step types for pipeline configuration.
 
-**Permission**: `manage_options` capability required
+**Permission**: Public metadata endpoint
 
 **Purpose**: Discover available step types for pipeline builder UI
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -436,7 +436,7 @@ See [HTTP Client](core-system/http-client.md) for implementation details and usa
 **Complete REST API Integration**:
 All admin pages now use REST API architecture with zero jQuery/AJAX dependencies.
 
-**Security Model**: All admin operations require `manage_options` capability with WordPress nonce validation.
+**Security Model**: Admin operations use scoped Data Machine capabilities through `PermissionHelper` plus WordPress nonce validation for browser requests. Administrators continue to pass through the `manage_options` capability mapping.
 
 ### Extension Framework
 Complete extension system for custom handlers and tools:
@@ -482,7 +482,7 @@ Complete extension system for custom handlers and tools:
 - Job failure handling with retry support (max 24 attempts)
 
 ### Security
-- Admin-only access (`manage_options` capability)
+- Scoped Data Machine capabilities for admin and agent operations
 - Multi-agent access control (viewer, operator, admin roles)
 - CSRF protection via WordPress nonces
 - Input sanitization and validation

--- a/docs/core-system/abilities-api.md
+++ b/docs/core-system/abilities-api.md
@@ -6,374 +6,59 @@ WordPress 6.9 Abilities API provides standardized capability discovery and execu
 
 The Abilities API in `inc/Abilities/` provides a unified interface for Data Machine operations. Each ability implements `execute_callback` with `permission_callback` for consistent access control across REST API, CLI commands, and Chat tools.
 
-**Total registered abilities**: 193
+**Total registered abilities**: 205
 
-The tables below document the core ability groups most commonly used by REST, CLI, and chat integrations. For a generated live inventory, run `wp abilities list --category=datamachine-*` or inspect the current `wp_register_ability()` callsites under `inc/Abilities/`.
+This page documents the shape of the current ability surface and the source files that own each domain. For an exact live inventory, run `wp abilities list --category=datamachine-*` in a loaded WordPress install or inspect `wp_register_ability()` callsites under `inc/Abilities/`.
 
 ## Multi-Agent Scoping
 
 Data Machine follows a WordPress-shaped identifier model: `agent_id` is the stable numeric row ID, and `agent_slug` is the human-readable, portable identifier. Programmatic ability inputs should use explicit fields (`agent_id` when selecting by row ID, `agent_slug` when selecting by slug). The generic `agent` selector is reserved for CLI and resolver-style boundaries that intentionally accept either ID or slug. The `PermissionHelper` class resolves selectors to scoped agent and user IDs, enforces ownership checks via `owns_resource()` and `owns_agent_resource()`, and controls access grants via `can_access_agent()`.
 
-## Registered Abilities
-
-### Pipeline Management (7 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/get-pipelines` | List pipelines with pagination, or get single by ID | `inc/Abilities/Pipeline/GetPipelinesAbility.php` |
-| `datamachine/create-pipeline` | Create new pipeline | `inc/Abilities/Pipeline/CreatePipelineAbility.php` |
-| `datamachine/update-pipeline` | Update pipeline properties | `inc/Abilities/Pipeline/UpdatePipelineAbility.php` |
-| `datamachine/delete-pipeline` | Delete pipeline and associated flows | `inc/Abilities/Pipeline/DeletePipelineAbility.php` |
-| `datamachine/duplicate-pipeline` | Duplicate pipeline with flows | `inc/Abilities/Pipeline/DuplicatePipelineAbility.php` |
-| `datamachine/import-pipelines` | Import pipelines from CSV | `inc/Abilities/Pipeline/ImportExportAbility.php` |
-| `datamachine/export-pipelines` | Export pipelines to CSV | `inc/Abilities/Pipeline/ImportExportAbility.php` |
-
-### Pipeline Steps (5 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/get-pipeline-steps` | List steps for a pipeline, or get single by ID | `inc/Abilities/PipelineStepAbilities.php` |
-| `datamachine/add-pipeline-step` | Add step to pipeline (auto-syncs to all flows) | `inc/Abilities/PipelineStepAbilities.php` |
-| `datamachine/update-pipeline-step` | Update pipeline step config (system prompt, provider, model, tools) | `inc/Abilities/PipelineStepAbilities.php` |
-| `datamachine/delete-pipeline-step` | Remove step from pipeline (removes from all flows) | `inc/Abilities/PipelineStepAbilities.php` |
-| `datamachine/reorder-pipeline-steps` | Reorder pipeline steps | `inc/Abilities/PipelineStepAbilities.php` |
-
-### Flow Management (5 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/get-flows` | List flows with filtering, or get single by ID | `inc/Abilities/Flow/GetFlowsAbility.php` |
-| `datamachine/create-flow` | Create new flow from pipeline | `inc/Abilities/Flow/CreateFlowAbility.php` |
-| `datamachine/update-flow` | Update flow properties | `inc/Abilities/Flow/UpdateFlowAbility.php` |
-| `datamachine/delete-flow` | Delete flow and associated jobs | `inc/Abilities/Flow/DeleteFlowAbility.php` |
-| `datamachine/duplicate-flow` | Duplicate flow within pipeline | `inc/Abilities/Flow/DuplicateFlowAbility.php` |
-
-### Flow Steps (4 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/get-flow-steps` | List steps for a flow, or get single by ID | `inc/Abilities/FlowStep/GetFlowStepsAbility.php` |
-| `datamachine/update-flow-step` | Update flow step config | `inc/Abilities/FlowStep/UpdateFlowStepAbility.php` |
-| `datamachine/configure-flow-steps` | Bulk configure flow steps | `inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php` |
-| `datamachine/validate-flow-steps-config` | Validate flow steps configuration | `inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php` |
-
-### Queue Management (13 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/queue-add` | Add item to flow queue | `inc/Abilities/Flow/QueueAbility.php` |
-| `datamachine/queue-list` | List queue entries | `inc/Abilities/Flow/QueueAbility.php` |
-| `datamachine/queue-clear` | Clear queue | `inc/Abilities/Flow/QueueAbility.php` |
-| `datamachine/queue-remove` | Remove item from queue | `inc/Abilities/Flow/QueueAbility.php` |
-| `datamachine/queue-update` | Update queue item | `inc/Abilities/Flow/QueueAbility.php` |
-| `datamachine/queue-move` | Reorder queue item | `inc/Abilities/Flow/QueueAbility.php` |
-| `datamachine/queue-mode` | Set queue access mode (`drain`, `loop`, or `static`) | `inc/Abilities/Flow/QueueAbility.php` |
-| `datamachine/config-patch-add` | Add a fetch config patch to a flow step queue | `inc/Abilities/Flow/QueueAbility.php` |
-| `datamachine/config-patch-list` | List fetch config patches | `inc/Abilities/Flow/QueueAbility.php` |
-| `datamachine/config-patch-clear` | Clear fetch config patches | `inc/Abilities/Flow/QueueAbility.php` |
-| `datamachine/config-patch-remove` | Remove a fetch config patch by index | `inc/Abilities/Flow/QueueAbility.php` |
-| `datamachine/config-patch-update` | Update a fetch config patch by index | `inc/Abilities/Flow/QueueAbility.php` |
-| `datamachine/config-patch-move` | Reorder a fetch config patch | `inc/Abilities/Flow/QueueAbility.php` |
-
-### Webhook Triggers (8 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/webhook-trigger-enable` | Enable webhook trigger for a flow. Supports `bearer` (default) or `hmac` (template-based). | `inc/Abilities/Flow/WebhookTriggerAbility.php` |
-| `datamachine/webhook-trigger-disable` | Disable webhook trigger, revoke all auth material (token, template, secrets). | `inc/Abilities/Flow/WebhookTriggerAbility.php` |
-| `datamachine/webhook-trigger-regenerate` | Regenerate Bearer token (bearer mode only; old token immediately invalidated). | `inc/Abilities/Flow/WebhookTriggerAbility.php` |
-| `datamachine/webhook-trigger-set-secret` | Set or replace a specific secret id on an existing HMAC flow (no grace window). | `inc/Abilities/Flow/WebhookTriggerAbility.php` |
-| `datamachine/webhook-trigger-rotate-secret` | **Zero-downtime rotation** — demote current → previous with a TTL, install a fresh current. | `inc/Abilities/Flow/WebhookTriggerAbility.php` |
-| `datamachine/webhook-trigger-forget-secret` | Remove a specific secret by id from the rotation list. | `inc/Abilities/Flow/WebhookTriggerAbility.php` |
-| `datamachine/webhook-trigger-rate-limit` | Set rate limiting for flow webhook trigger. | `inc/Abilities/Flow/WebhookTriggerAbility.php` |
-| `datamachine/webhook-trigger-status` | Get webhook trigger status — auth mode, template, secret ids. Never the secret values. | `inc/Abilities/Flow/WebhookTriggerAbility.php` |
-
-### Job Execution (9 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/get-jobs` | List jobs with filtering, or get single by ID | `inc/Abilities/Job/GetJobsAbility.php` |
-| `datamachine/get-jobs-summary` | Get job status summary counts | `inc/Abilities/Job/JobsSummaryAbility.php` |
-| `datamachine/delete-jobs` | Delete jobs by criteria | `inc/Abilities/Job/DeleteJobsAbility.php` |
-| `datamachine/execute-workflow` | Execute workflow | `inc/Abilities/Job/ExecuteWorkflowAbility.php` |
-| `datamachine/get-flow-health` | Get flow health metrics | `inc/Abilities/Job/FlowHealthAbility.php` |
-| `datamachine/get-problem-flows` | List flows exceeding failure threshold | `inc/Abilities/Job/ProblemFlowsAbility.php` |
-| `datamachine/recover-stuck-jobs` | Recover jobs stuck in processing state | `inc/Abilities/Job/RecoverStuckJobsAbility.php` |
-| `datamachine/retry-job` | Retry a failed job | `inc/Abilities/Job/RetryJobAbility.php` |
-| `datamachine/fail-job` | Manually fail a processing job | `inc/Abilities/Job/FailJobAbility.php` |
-
-### Engine (4 abilities)
-
-Internal abilities for the pipeline execution engine.
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/run-flow` | Run a flow | `inc/Abilities/Engine/RunFlowAbility.php` |
-| `datamachine/execute-step` | Execute a pipeline step | `inc/Abilities/Engine/ExecuteStepAbility.php` |
-| `datamachine/schedule-next-step` | Schedule the next step in pipeline execution | `inc/Abilities/Engine/ScheduleNextStepAbility.php` |
-| `datamachine/schedule-flow` | Schedule a flow for execution | `inc/Abilities/Engine/ScheduleFlowAbility.php` |
-
-### Agent Management (6 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/list-agents` | List all registered agent identities | `inc/Abilities/AgentAbilities.php` |
-| `datamachine/create-agent` | Create a new agent identity with filesystem directory and owner access | `inc/Abilities/AgentAbilities.php` |
-| `datamachine/get-agent` | Retrieve a single agent by slug or ID with access grants | `inc/Abilities/AgentAbilities.php` |
-| `datamachine/update-agent` | Update an agent's mutable fields (name, config, status) | `inc/Abilities/AgentAbilities.php` |
-| `datamachine/delete-agent` | Delete an agent record and access grants, optionally remove filesystem | `inc/Abilities/AgentAbilities.php` |
-| `datamachine/rename-agent` | Rename an agent slug — updates database and moves filesystem directory | `inc/Abilities/AgentAbilities.php` |
-
-### Agent Memory (4 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/get-agent-memory` | Read agent memory content — full file or a specific section | `inc/Abilities/AgentMemoryAbilities.php` |
-| `datamachine/update-agent-memory` | Write to a specific section of agent memory — set (replace) or append | `inc/Abilities/AgentMemoryAbilities.php` |
-| `datamachine/search-agent-memory` | Search across agent memory content, returns matching lines with context | `inc/Abilities/AgentMemoryAbilities.php` |
-| `datamachine/list-agent-memory-sections` | List all section headers in agent memory | `inc/Abilities/AgentMemoryAbilities.php` |
-
-### Daily Memory (5 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/daily-memory-read` | Read a daily memory file by date (defaults to today) | `inc/Abilities/DailyMemoryAbilities.php` |
-| `datamachine/daily-memory-write` | Write or append to a daily memory file | `inc/Abilities/DailyMemoryAbilities.php` |
-| `datamachine/daily-memory-list` | List all daily memory files grouped by month | `inc/Abilities/DailyMemoryAbilities.php` |
-| `datamachine/search-daily-memory` | Search across daily memory files with optional date range | `inc/Abilities/DailyMemoryAbilities.php` |
-| `datamachine/daily-memory-delete` | Delete a daily memory file by date | `inc/Abilities/DailyMemoryAbilities.php` |
-
-### Agent Files (5 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/list-agent-files` | List memory files from agent identity and user layers | `inc/Abilities/File/AgentFileAbilities.php` |
-| `datamachine/get-agent-file` | Get a single agent memory file with content | `inc/Abilities/File/AgentFileAbilities.php` |
-| `datamachine/write-agent-file` | Write or update content for an agent memory file | `inc/Abilities/File/AgentFileAbilities.php` |
-| `datamachine/delete-agent-file` | Delete an agent memory file (protected files cannot be deleted) | `inc/Abilities/File/AgentFileAbilities.php` |
-| `datamachine/upload-agent-file` | Upload a file to the agent memory directory | `inc/Abilities/File/AgentFileAbilities.php` |
-
-### Flow Files (5 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/list-flow-files` | List uploaded files for a flow step | `inc/Abilities/File/FlowFileAbilities.php` |
-| `datamachine/get-flow-file` | Get metadata for a single flow file | `inc/Abilities/File/FlowFileAbilities.php` |
-| `datamachine/delete-flow-file` | Delete an uploaded file from a flow step | `inc/Abilities/File/FlowFileAbilities.php` |
-| `datamachine/upload-flow-file` | Upload a file to a flow step | `inc/Abilities/File/FlowFileAbilities.php` |
-| `datamachine/cleanup-flow-files` | Cleanup data packets and temporary files for a job or flow | `inc/Abilities/File/FlowFileAbilities.php` |
-
-### Chat Sessions (4 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/create-chat-session` | Create a new chat session for a user | `inc/Abilities/Chat/CreateChatSessionAbility.php` |
-| `datamachine/list-chat-sessions` | List chat sessions with pagination and context filtering | `inc/Abilities/Chat/ListChatSessionsAbility.php` |
-| `datamachine/get-chat-session` | Retrieve a chat session with conversation and metadata | `inc/Abilities/Chat/GetChatSessionAbility.php` |
-| `datamachine/delete-chat-session` | Delete a chat session after verifying ownership | `inc/Abilities/Chat/DeleteChatSessionAbility.php` |
-
-### Coding / GitHub Extension Abilities
-
-Workspace and GitHub coding abilities live in the `data-machine-code` extension plugin. Data Machine core no longer registers the old workspace, GitHub issue, or GitHub repository ability names.
-
-### Handler Execution (8 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/fetch-rss` | Fetch items from RSS/Atom feeds | `inc/Abilities/Fetch/FetchRssAbility.php` |
-| `datamachine/fetch-files` | Process uploaded files | `inc/Abilities/Fetch/FetchFilesAbility.php` |
-| `datamachine/fetch-wordpress-api` | Fetch posts from WordPress REST API | `inc/Abilities/Fetch/FetchWordPressApiAbility.php` |
-| `datamachine/fetch-wordpress-media` | Query WordPress media library | `inc/Abilities/Fetch/FetchWordPressMediaAbility.php` |
-| `datamachine/get-wordpress-post` | Retrieve single WordPress post by ID/URL | `inc/Abilities/Fetch/GetWordPressPostAbility.php` |
-| `datamachine/query-wordpress-posts` | Query WordPress posts with filters | `inc/Abilities/Fetch/QueryWordPressPostsAbility.php` |
-| `datamachine/publish-wordpress` | Create WordPress posts | `inc/Abilities/Publish/PublishWordPressAbility.php` |
-| `datamachine/update-wordpress` | Update existing WordPress posts | `inc/Abilities/Update/UpdateWordPressAbility.php` |
-
-### Duplicate Check (2 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/check-duplicate` | Check if similar content exists as published post or in queue | `inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php` |
-| `datamachine/titles-match` | Compare two titles for semantic equivalence using similarity engine | `inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php` |
-
-> **Extensions:** `datamachine/check-duplicate` runs extension strategies before core's generic matching via the `datamachine_duplicate_strategies` filter. See [Duplicate Detection Filters](../development/hooks/core-filters.md#duplicate-detection-filters) for the strategy contract and registration example.
-
-### Post Query (2 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/query-posts` | Find posts created by Data Machine, filtered by handler/flow/pipeline | `inc/Abilities/PostQueryAbilities.php` |
-| `datamachine/list-posts` | List Data Machine posts with combinable filters | `inc/Abilities/PostQueryAbilities.php` |
-
-### Content / Block Editing (4 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/upsert-post` | Create or update a post. AI/chat tool calls default to markdown authoring; raw ability/API callers that omit `content_format` keep the legacy block-markup default. | `inc/Abilities/Content/UpsertPostAbility.php` |
-| `datamachine/get-post-blocks` | Get Gutenberg blocks from a post | `inc/Abilities/Content/GetPostBlocksAbility.php` |
-| `datamachine/edit-post-blocks` | Update Gutenberg blocks in a post | `inc/Abilities/Content/EditPostBlocksAbility.php` |
-| `datamachine/replace-post-blocks` | Replace specific blocks in a post | `inc/Abilities/Content/ReplacePostBlocksAbility.php` |
-
-`content_format` is the caller's authoring/source format (`markdown`, `html`, or
-`blocks`). It is distinct from the stored `post_content` format, which is chosen
-per post type by `datamachine_post_content_format`. Normal AI-authored prose
-should be markdown; only set `content_format` when the caller intentionally
-supplies HTML or serialized block markup.
-
-The block editing abilities are storage-format aware. They read the post type's
-canonical stored format through `DataMachine\Core\Content\ContentFormat`, convert
-to block markup for the edit operation, then convert the result back before
-writing.
-
-### Media (7 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/generate-alt-text` | Queue system agent generation of alt text for images | `inc/Abilities/Media/AltTextAbilities.php` |
-| `datamachine/diagnose-alt-text` | Report alt text coverage for image attachments | `inc/Abilities/Media/AltTextAbilities.php` |
-| `datamachine/generate-image` | Generate images using AI models via Replicate API | `inc/Abilities/Media/ImageGenerationAbilities.php` |
-| `datamachine/upload-media` | Upload or fetch a media file (image/video), store in repository | `inc/Abilities/Media/MediaAbilities.php` |
-| `datamachine/validate-media` | Validate a media file against platform-specific constraints | `inc/Abilities/Media/MediaAbilities.php` |
-| `datamachine/video-metadata` | Extract video metadata (duration, resolution, codec) via ffprobe | `inc/Abilities/Media/MediaAbilities.php` |
-| `datamachine/render-image-template` | Generate branded graphics from registered GD templates | `inc/Abilities/Media/ImageTemplateAbilities.php` |
-
-### Image Templates (1 ability)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/list-image-templates` | List all registered image generation templates | `inc/Abilities/Media/ImageTemplateAbilities.php` |
-
-### Image Optimization (2 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/diagnose-images` | Scan media library for oversized images, missing WebP, missing thumbnails | `inc/Abilities/Media/ImageOptimizationAbilities.php` |
-| `datamachine/optimize-images` | Compress oversized images and generate WebP variants | `inc/Abilities/Media/ImageOptimizationAbilities.php` |
-
-### Internal Linking (7 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/internal-linking` | Queue system agent insertion of semantic internal links | `inc/Abilities/InternalLinkingAbilities.php` |
-| `datamachine/diagnose-internal-links` | Report internal link coverage across published posts | `inc/Abilities/InternalLinkingAbilities.php` |
-| `datamachine/audit-internal-links` | Scan post content for internal links, build link graph | `inc/Abilities/InternalLinkingAbilities.php` |
-| `datamachine/get-orphaned-posts` | Return posts with zero inbound internal links | `inc/Abilities/InternalLinkingAbilities.php` |
-| `datamachine/get-backlinks` | Return posts that link to a given post | `inc/Abilities/InternalLinkingAbilities.php` |
-| `datamachine/check-broken-links` | HTTP HEAD check links to find broken URLs | `inc/Abilities/InternalLinkingAbilities.php` |
-| `datamachine/link-opportunities` | Rank candidate internal links from search analytics and the cached link graph | `inc/Abilities/InternalLinkingAbilities.php` |
-
-### SEO — Meta Descriptions (2 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/generate-meta-description` | Queue system agent generation of meta descriptions | `inc/Abilities/SEO/MetaDescriptionAbilities.php` |
-| `datamachine/diagnose-meta-descriptions` | Report post excerpt (meta description) coverage | `inc/Abilities/SEO/MetaDescriptionAbilities.php` |
-
-### SEO — IndexNow (4 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/indexnow-submit` | Submit URLs to IndexNow for instant search engine indexing | `inc/Abilities/SEO/IndexNowAbilities.php` |
-| `datamachine/indexnow-status` | Get IndexNow integration status (enabled, API key, endpoint) | `inc/Abilities/SEO/IndexNowAbilities.php` |
-| `datamachine/indexnow-generate-key` | Generate a new IndexNow API key | `inc/Abilities/SEO/IndexNowAbilities.php` |
-| `datamachine/indexnow-verify-key` | Verify that the IndexNow key file is accessible | `inc/Abilities/SEO/IndexNowAbilities.php` |
-
-### Analytics (4 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/bing-webmaster` | Fetch search analytics from Bing Webmaster Tools API | `inc/Abilities/Analytics/BingWebmasterAbilities.php` |
-| `datamachine/google-search-console` | Fetch search analytics from Google Search Console API | `inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php` |
-| `datamachine/google-analytics` | Fetch visitor analytics from Google Analytics (GA4) Data API | `inc/Abilities/Analytics/GoogleAnalyticsAbilities.php` |
-| `datamachine/pagespeed` | Run Lighthouse audits via PageSpeed Insights API | `inc/Abilities/Analytics/PageSpeedAbilities.php` |
-
-### Taxonomy (5 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/get-taxonomy-terms` | List taxonomy terms | `inc/Abilities/Taxonomy/GetTaxonomyTermsAbility.php` |
-| `datamachine/create-taxonomy-term` | Create a taxonomy term | `inc/Abilities/Taxonomy/CreateTaxonomyTermAbility.php` |
-| `datamachine/update-taxonomy-term` | Update a taxonomy term | `inc/Abilities/Taxonomy/UpdateTaxonomyTermAbility.php` |
-| `datamachine/delete-taxonomy-term` | Delete a taxonomy term | `inc/Abilities/Taxonomy/DeleteTaxonomyTermAbility.php` |
-| `datamachine/resolve-term` | Resolve a term by name or slug | `inc/Abilities/Taxonomy/ResolveTermAbility.php` |
-
-### Settings (7 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/get-settings` | Get plugin settings including AI settings and masked API keys | `inc/Abilities/SettingsAbilities.php` |
-| `datamachine/update-settings` | Partial update of plugin settings | `inc/Abilities/SettingsAbilities.php` |
-| `datamachine/get-scheduling-intervals` | Get available scheduling intervals | `inc/Abilities/SettingsAbilities.php` |
-| `datamachine/get-tool-config` | Get AI tool configuration with fields and current values | `inc/Abilities/SettingsAbilities.php` |
-| `datamachine/save-tool-config` | Save AI tool configuration | `inc/Abilities/SettingsAbilities.php` |
-| `datamachine/get-handler-defaults` | Get handler default settings grouped by step type | `inc/Abilities/SettingsAbilities.php` |
-| `datamachine/update-handler-defaults` | Update defaults for a specific handler | `inc/Abilities/SettingsAbilities.php` |
-
-### Authentication (3 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/get-auth-status` | Get OAuth connection status | `inc/Abilities/AuthAbilities.php` |
-| `datamachine/disconnect-auth` | Disconnect OAuth provider | `inc/Abilities/AuthAbilities.php` |
-| `datamachine/save-auth-config` | Save OAuth API configuration | `inc/Abilities/AuthAbilities.php` |
-
-### Logging (5 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/write-to-log` | Write log entry with level routing | `inc/Abilities/LogAbilities.php` |
-| `datamachine/clear-logs` | Clear logs by agent type | `inc/Abilities/LogAbilities.php` |
-| `datamachine/read-logs` | Read logs with filtering and pagination | `inc/Abilities/LogAbilities.php` |
-| `datamachine/get-log-metadata` | Get log entry counts and time range | `inc/Abilities/LogAbilities.php` |
-| `datamachine/read-debug-log` | Read PHP debug.log entries | `inc/Abilities/LogAbilities.php` |
-
-### Local Search (1 ability)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/local-search` | Search WordPress site for posts by title or content | `inc/Abilities/LocalSearchAbilities.php` |
-
-### Handler Discovery (5 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/get-handlers` | List available handlers, or get single by slug | `inc/Abilities/HandlerAbilities.php` |
-| `datamachine/validate-handler` | Validate handler configuration | `inc/Abilities/HandlerAbilities.php` |
-| `datamachine/get-handler-config-fields` | Get handler configuration fields | `inc/Abilities/HandlerAbilities.php` |
-| `datamachine/apply-handler-defaults` | Apply default settings to handler | `inc/Abilities/HandlerAbilities.php` |
-| `datamachine/get-handler-site-defaults` | Get site-wide handler defaults | `inc/Abilities/HandlerAbilities.php` |
-
-### Step Types (2 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/get-step-types` | List available step types, or get single by slug | `inc/Abilities/StepTypeAbilities.php` |
-| `datamachine/validate-step-type` | Validate step type configuration | `inc/Abilities/StepTypeAbilities.php` |
-
-### Processed Items (6 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/clear-processed-items` | Clear processed items for flow (resets deduplication) | `inc/Abilities/ProcessedItemsAbilities.php` |
-| `datamachine/check-processed-item` | Check if item was processed | `inc/Abilities/ProcessedItemsAbilities.php` |
-| `datamachine/has-processed-history` | Check if flow has processed history | `inc/Abilities/ProcessedItemsAbilities.php` |
-| `datamachine/processed-items-get-processed-at` | Get last-processed Unix timestamp for an item (or null) | `inc/Abilities/ProcessedItemsAbilities.php` |
-| `datamachine/processed-items-find-stale` | Given candidates, return those older than N days | `inc/Abilities/ProcessedItemsAbilities.php` |
-| `datamachine/processed-items-find-never-processed` | Given candidates, return those never processed | `inc/Abilities/ProcessedItemsAbilities.php` |
-
-### Agent Ping (1 ability)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/send-ping` | Send agent ping notification | `inc/Abilities/AgentPing/SendPingAbility.php` |
-
-### System Infrastructure (3 abilities)
-
-| Ability | Description | Location |
-|---------|-------------|----------|
-| `datamachine/generate-session-title` | Generate AI-powered title for chat session | `inc/Abilities/SystemAbilities.php` |
-| `datamachine/system-health-check` | Unified health diagnostics for Data Machine and extensions | `inc/Abilities/SystemAbilities.php` |
-| `datamachine/run-task` | Manually trigger a registered system task for immediate execution | `inc/Abilities/SystemAbilities.php` |
+## Registered Ability Domains
+
+The current core registry has 205 `datamachine/*` abilities across these domains:
+
+| Domain | Count | Source anchor | Examples |
+|--------|-------|---------------|----------|
+| AI diagnostics | 1 | `inc/Abilities/AI/` | `datamachine/inspect-ai-request` |
+| Agent identity | 11 | `inc/Abilities/AgentAbilities.php` | list/get/create/update/delete/rename/import/export agents, active-agent selection, audience access |
+| Agent calls | 2 | `inc/Abilities/AgentCall/`, `inc/Abilities/AgentRemoteCall/` | `datamachine/agent-call`, `datamachine/agent-remote-call` |
+| Agent memory | 5 | `inc/Abilities/AgentMemoryAbilities.php` | read/update/search sections, self-memory writes |
+| Agent tokens | 3 | `inc/Abilities/AgentTokenAbilities.php` | create/list/revoke agent bearer tokens |
+| Analytics | 4 | `inc/Abilities/Analytics/` | Bing Webmaster, Google Analytics, Google Search Console, PageSpeed |
+| Auth | 7 | `inc/Abilities/AuthAbilities.php` | provider listing, status, connect/disconnect, token set/refresh/revoke |
+| Chat | 6 | `inc/Abilities/Chat/` | sessions, read state, message sending |
+| Content/block editing | 5 | `inc/Abilities/Content/` | upsert posts, get/edit/replace blocks, insert content |
+| Daily memory | 5 | `inc/Abilities/DailyMemoryAbilities.php` | read/write/list/search/delete daily memory artifacts |
+| Duplicate checks | 2 | `inc/Abilities/DuplicateCheck/` | duplicate detection, title matching |
+| Email | 10 | `inc/Abilities/Email/` | reply/delete/move/flag/batch/unsubscribe/test connection |
+| Engine | 5 | `inc/Abilities/Engine/` | run flow, drain job, execute/schedule steps |
+| Fetch handlers | 7 | `inc/Abilities/Fetch/` | RSS, files, email, WordPress API/media/post queries |
+| Files | 11 | `inc/Abilities/File/` | agent files, flow files, memory scaffolds, cleanup |
+| Flow | 28 | `inc/Abilities/Flow/` | CRUD, pause/resume, queues, config patches, webhooks |
+| Flow steps | 4 | `inc/Abilities/FlowStep/` | get/update/configure/validate flow steps |
+| Handlers | 6 | `inc/Abilities/HandlerAbilities.php`, `inc/Abilities/Handler/` | discovery, validation, defaults, test harness |
+| Internal linking | 7 | `inc/Abilities/InternalLinkingAbilities.php` | diagnostics, audit, backlinks, broken links, opportunities |
+| Jobs | 10 | `inc/Abilities/Job/` | list/summary/delete/execute/retry/fail/recover/metrics/problem flows |
+| Local search | 1 | `inc/Abilities/LocalSearchAbilities.php` | site-local post/content search |
+| Logs | 5 | `inc/Abilities/LogAbilities.php` | write/read/clear/metadata/debug log |
+| Media | 10 | `inc/Abilities/Media/` | alt text, image generation/optimization/templates, upload/validate/video metadata |
+| Pipeline | 7 | `inc/Abilities/Pipeline/` | CRUD, duplicate, import/export |
+| Pipeline steps | 5 | `inc/Abilities/PipelineStepAbilities.php` | get/add/update/delete/reorder steps |
+| Post queries | 2 | `inc/Abilities/PostQueryAbilities.php` | query/list Data Machine-created posts |
+| Processed items | 6 | `inc/Abilities/ProcessedItemsAbilities.php` | clear/check/history/stale/never-processed helpers |
+| Publish | 3 | `inc/Abilities/Publish/` | WordPress publish, immediate and queued email sends |
+| SEO | 6 | `inc/Abilities/SEO/` | IndexNow, meta descriptions |
+| Settings | 7 | `inc/Abilities/SettingsAbilities.php` | settings, intervals, tool config, handler defaults |
+| Source inventory | 2 | `inc/Abilities/SourceInventoryAbility.php`, `inc/Abilities/SourceAggregateAbility.php` | source inventory and aggregate reporting |
+| Step types | 2 | `inc/Abilities/StepTypeAbilities.php` | list/validate step types |
+| System | 3 | `inc/Abilities/SystemAbilities.php` | session titles, health checks, system task runs |
+| Taxonomy | 6 | `inc/Abilities/Taxonomy/` | get/create/update/delete/resolve terms, merge term meta |
+| Update handlers | 1 | `inc/Abilities/Update/` | WordPress update handler |
+
+Workspace, GitHub, and code-review abilities are intentionally not registered by Data Machine core. They live in the `data-machine-code` extension plugin.
+
+`content_format` remains the caller's authoring/source format (`markdown`, `html`, or `blocks`) and is distinct from the stored `post_content` format selected by `datamachine_post_content_format`. Content/block abilities read the post type's canonical stored format through `DataMachine\Core\Content\ContentFormat`, convert to block markup for block edits, then convert back before writing.
 
 ## Category Registration
 
@@ -397,7 +82,7 @@ All abilities support both WordPress admin and WP-CLI contexts via the shared `P
 
 ```php
 // Standard permission check
-PermissionHelper::can_manage(); // WP-CLI always returns true; web requires manage_options
+PermissionHelper::can_manage(); // WP-CLI/background/pre-auth contexts pass; web users need a mapped Data Machine capability.
 
 // Multi-agent scoped permission check. Requests may provide explicit
 // `agent_id` or `agent_slug`; resolver boundaries may also accept `agent`.
@@ -439,19 +124,11 @@ public function register(): void {
 
 ## Testing
 
-Unit tests in `tests/Unit/Abilities/` verify ability registration, schema validation, permission checks, and execution logic:
+Ability coverage lives in focused smoke tests under `tests/` rather than a separate `tests/Unit/Abilities/` tree. The ability-related smoke tests cover registration, schema contracts, permission contexts, chat/tool integration, source inventory, queue behavior, taxonomy cleanup, auth scoping, and wp-ai-client runtime boundaries. Run them through Homeboy or directly through the repository's PHP smoke harness:
 
-- `AuthAbilitiesTest.php` - Authentication abilities
-- `FileAbilitiesTest.php` - File management abilities
-- `FlowAbilitiesTest.php` - Flow CRUD abilities
-- `FlowStepAbilitiesTest.php` - Flow step abilities
-- `JobAbilitiesTest.php` - Job execution abilities
-- `LogAbilitiesTest.php` - Logging abilities
-- `PipelineAbilitiesTest.php` - Pipeline CRUD abilities
-- `PipelineStepAbilitiesTest.php` - Pipeline step abilities
-- `PostQueryAbilitiesTest.php` - Post query abilities
-- `ProcessedItemsAbilitiesTest.php` - Processed items abilities
-- `SettingsAbilitiesTest.php` - Settings abilities
+```bash
+homeboy test data-machine
+```
 
 ## WP-CLI Integration
 

--- a/docs/core-system/daily-memory-system.md
+++ b/docs/core-system/daily-memory-system.md
@@ -357,7 +357,7 @@ Daily memory endpoints are registered alongside other agent file endpoints:
 | `PUT` | `/datamachine/v1/files/agent/daily/{year}/{month}/{day}` | Write/replace a daily file |
 | `DELETE` | `/datamachine/v1/files/agent/daily/{year}/{month}/{day}` | Delete a daily file |
 
-All endpoints require `manage_options` capability. The `PUT` endpoint accepts content as a JSON body parameter or raw body and always uses `mode: 'write'` (replace). An optional `user_id` query parameter enables multi-agent scoping.
+Daily memory endpoints require a logged-in user. Users can access their own files; accessing another user's files requires `PermissionHelper::can( 'manage_agents' )`. The `PUT` endpoint accepts content as a JSON body parameter or raw body and always uses `mode: 'write'` (replace). An optional `user_id` query parameter enables multi-agent scoping.
 
 **Note:** There is no REST search endpoint for daily memory. Search is only available via the AI tool and CLI.
 

--- a/docs/core-system/services-layer.md
+++ b/docs/core-system/services-layer.md
@@ -1,12 +1,12 @@
-# Services Layer Architecture
+# Abilities-First Service Layer
 
-**Abilities-First Architecture** (@since v0.11.7)
+Data Machine's public service layer is the WordPress Abilities API. REST controllers, WP-CLI commands, chat tools, system tasks, and extension integrations call `datamachine/*` abilities instead of reaching into manager classes or controller internals.
 
-The Services Layer has been fully migrated to the WordPress 6.9 Abilities API. The legacy Services directory has been deleted. All business logic now resides in ability classes under `inc/Abilities/`.
+The legacy Services directory has been removed. Current business operations live in focused ability classes under `inc/Abilities/`, with lower-level repositories and core classes kept as implementation details behind those abilities.
 
 ## Migration Status
 
-The migration from OOP service managers to WordPress Abilities API is **complete**:
+The migration from OOP service managers to WordPress Abilities API is complete:
 
 | Former Service | Replacement | Location |
 |----------------|-------------|----------|
@@ -19,27 +19,27 @@ The migration from OOP service managers to WordPress Abilities API is **complete
 | `HandlerService` | `HandlerAbilities` | `inc/Abilities/HandlerAbilities.php` |
 | `StepTypeService` | `StepTypeAbilities` | `inc/Abilities/StepTypeAbilities.php` |
 | `LogsManager` | `LogAbilities` | `inc/Abilities/LogAbilities.php` |
-| `CacheManager` | Ability-level `clearCache()` methods (legacy name) | Per-ability class |
+| `CacheManager` | Ability-level/cache-owner invalidation methods | Per-ability class or owning core class |
 | `AuthProviderService` | `AuthAbilities` | `inc/Abilities/AuthAbilities.php` |
 
 ## Abilities Overview
 
-Ability classes under `inc/Abilities/` register the operations Data Machine exposes to REST, WP-CLI, and chat tools. The current registry includes 193 `wp_register_ability()` callsites across domains including:
+Ability classes under `inc/Abilities/` register the operations Data Machine exposes to REST, WP-CLI, chat tools, background jobs, and external integrations. The current registry includes 205 `datamachine/*` abilities across domains including:
 
 - Pipeline and pipeline-step CRUD, duplication, import, and export
 - Flow CRUD, scheduling, duplication, pause/resume, webhook triggers, and per-step configuration
 - Prompt queues, fetch config-patch queues, and queue mode management
 - Job execution, retry/fail/delete/recovery, flow health, and summaries
-- Agent identity, access, tokens, remote calls, memory, and ping notifications
-- File, scaffold, chat, email, media, SEO, taxonomy, settings, auth, logs, and analytics operations
+- Agent identity, access grants, tokens, active-agent selection, remote calls, memory, and self-memory writes
+- File, scaffold, chat, email, media, SEO, taxonomy CRUD/resolution/merge, settings, auth, logs, source inventory, and analytics operations
 
 ## Architecture Principles
 
-- **Standardized Capability Discovery**: All operations exposed via `wp_register_ability()`
+- **Standardized Capability Discovery**: Public operations are exposed via `wp_register_ability()`
 - **Single Responsibility**: Each ability class handles one domain
 - **Centralized Business Logic**: Consistent validation and error handling
-- **Permission Integration**: All abilities check `manage_options` or WP_CLI context
-- **Cache Management**: Each ability class provides its own `clearCache()` method
+- **Permission Integration**: Abilities use `PermissionHelper` for Data Machine capabilities, agent token ceilings, pre-authenticated contexts, Action Scheduler, and WP-CLI
+- **Cache Management**: Cache invalidation stays with the ability or core class that owns the cached domain
 
 ## Cache Management
 

--- a/docs/development/hooks/core-actions.md
+++ b/docs/development/hooks/core-actions.md
@@ -345,10 +345,10 @@ do_action('datamachine_log', 'info', 'Flow execution started successfully', [
 
 ### Capability Requirements
 
-All actions require `manage_options` capability:
+Callbacks that expose admin-only behavior should use the scoped Data Machine capability for the operation:
 
 ```php
-if (!current_user_can('manage_options')) {
+if ( ! \DataMachine\Abilities\PermissionHelper::can( 'manage_flows' ) ) {
     wp_die(__('You do not have sufficient permissions to access this page.'));
 }
 ```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -93,9 +93,11 @@ The ability classes under `inc/Abilities/` provide direct method calls for core 
 - Flow, pipeline, and flow-step operations live in focused classes under `inc/Abilities/Flow/`, `inc/Abilities/Pipeline/`, and `inc/Abilities/FlowStep/`; `PipelineStepAbilities` handles pipeline-step ordering and synchronization.
 - Job abilities monitor execution outcomes, retries, manual failure, recovery, summaries, and deletion.
 - `ProcessedItemsAbilities` deduplicates content across executions by tracking previously processed identifiers.
-- `AgentAbilities` manages agent CRUD, renaming (with filesystem migration), and deletion.
-- `AgentMemoryAbilities` provides section-based read, write, append, and search operations on memory files.
+- `AgentAbilities` manages agent CRUD, active-agent selection, bundle import/export, audience access grants, renaming, and deletion.
+- `AgentTokenAbilities` manages per-agent bearer tokens for external clients.
+- `AgentMemoryAbilities` provides section-based read, write, append, search, and self-memory operations on memory files.
 - `DailyMemoryAbilities` manages daily memory files — read, write, list, search, and delete by date.
+- `EmailAbilities`, `SourceInventoryAbility`, and `SourceAggregateAbility` expose email operations plus source-level inventory and aggregate reporting.
 - `LogAbilities` and the `LogRepository` aggregate log entries in the `wp_datamachine_logs` table for filtering in the admin UI.
 - Cache invalidation is handled by ability-level `clearCache()` methods to ensure dynamic handler and step type registrations are immediately reflected across the system.
 
@@ -152,7 +154,7 @@ wp datamachine jobs undo <job_id> --dry-run --allow-root
 
 - **Authentication providers** extend BaseAuthProvider, BaseOAuth1Provider, or BaseOAuth2Provider under `/inc/Core/OAuth/`; concrete providers live next to their handlers in core or extension plugins.
 - **OAuth handlers** (`OAuth1Handler`, `OAuth2Handler`) standardize callback handling, nonce validation, and credential storage.
-- **Capability checks** (`manage_options`) and WordPress nonces guard REST endpoints; inputs run through `sanitize_*` helpers before hitting services.
+- **Capability checks** use Data Machine capabilities through `PermissionHelper`, with support for WP-CLI, Action Scheduler, pre-authenticated contexts, and agent bearer-token ceilings. WordPress nonces guard browser REST requests; inputs run through `sanitize_*` helpers before hitting abilities.
 - **Multi-agent permissions**: `PermissionHelper` handles agent-level access checks via `resolve_scoped_agent_id()`, `can_access_agent()`, and `owns_agent_resource()`.
 - **HttpClient** centralizes outbound HTTP requests with consistent headers, browser-mode simulation, timeout control, and logging via `datamachine_log`.
 


### PR DESCRIPTION
## Summary
- Refresh the docs navigation, overview, service-layer, and abilities docs to match the current Data Machine plugin surface.
- Replace stale processed-items REST documentation with the current cleanup endpoint plus ability/WP-CLI guidance.
- Correct stale permission language for public metadata endpoints, settings, daily memory, hooks, and admin/security docs.

## Verification
- `homeboy test data-machine` (1321 passed, 3 skipped)
- Local markdown link check: no broken local links
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Audited documentation against the current source, drafted the documentation cleanup, and ran verification commands for Chris to review.