### PR TITLE
feat: add filter hooks so taxonomy-owning plugins can enrich AI tool descriptions and refuse AI-supplied values

### DIFF
--- a/inc/Core/WordPress/TaxonomyHandler.php
+++ b/inc/Core/WordPress/TaxonomyHandler.php
@@ -108,6 +108,31 @@ class TaxonomyHandler {
 	 * Iterates through public taxonomies (or specific post type taxonomies) and
 	 * generates tool parameters for any taxonomy configured as "AI Decides".
 	 *
+	 * The auto-generated description uses only the taxonomy label, which is
+	 * intentionally generic — DM core has no business knowing what any
+	 * particular taxonomy means. Plugins that own a taxonomy should hook the
+	 * {@see 'datamachine_taxonomy_tool_parameter'} filter to enrich the
+	 * description with domain context, add an `enum` constraint, mark the
+	 * field required, etc.
+	 *
+	 * Example: a plugin that owns a "region" taxonomy might want the AI to
+	 * only pick from a fixed list of cities and never invent new ones:
+	 *
+	 *     add_filter(
+	 *         'datamachine_taxonomy_tool_parameter',
+	 *         function ( $param_def, $taxonomy, $handler_config, $post_type ) {
+	 *             if ( 'region' !== $taxonomy->name ) {
+	 *                 return $param_def;
+	 *             }
+	 *             $terms = get_terms( array( 'taxonomy' => 'region', 'hide_empty' => false ) );
+	 *             $param_def['enum']        = wp_list_pluck( $terms, 'name' );
+	 *             $param_def['description'] = 'Pick the discovery region this post belongs to. Must be one of the existing terms — do not invent new regions.';
+	 *             return $param_def;
+	 *         },
+	 *         10,
+	 *         4
+	 *     );
+	 *
 	 * @param array       $handler_config Handler configuration with taxonomy selections
 	 * @param string|null $post_type Optional post type to filter taxonomies
 	 * @return array Parameter definitions for AI-decided taxonomies
@@ -138,7 +163,7 @@ class TaxonomyHandler {
 
 			$is_hierarchical = $taxonomy->hierarchical;
 
-			$parameters[ $param_name ] = array(
+			$param_def = array(
 				'type'        => $is_hierarchical ? 'string' : 'array',
 				'description' => sprintf(
 					'Assign %s for this post. %s',
@@ -151,10 +176,46 @@ class TaxonomyHandler {
 
 			// For non-hierarchical (tags), we need to specify items type
 			if ( ! $is_hierarchical ) {
-				$parameters[ $param_name ]['items'] = array(
+				$param_def['items'] = array(
 					'type' => 'string',
 				);
 			}
+
+			/**
+			 * Filters the AI tool parameter definition for a taxonomy.
+			 *
+			 * Allows the plugin that owns a taxonomy to enrich the description
+			 * with semantic context the AI can use to pick correct term values,
+			 * add an `enum` constraint, mark the field `required`, change the
+			 * `type`, etc. Default behavior (when no filter is hooked) is
+			 * identical to pre-filter output.
+			 *
+			 * Taxonomy ownership lives in the plugin that registered the
+			 * taxonomy, not in Data Machine core. This filter is the recommended
+			 * extension point for any taxonomy whose business rules live in
+			 * another plugin.
+			 *
+			 * @since 0.131.0
+			 *
+			 * @param array       $param_def      JSON Schema fragment for this parameter.
+			 *                                    Includes `type`, `description`, and
+			 *                                    (for non-hierarchical taxonomies) `items`.
+			 * @param \WP_Taxonomy $taxonomy       The taxonomy object being exposed to the AI.
+			 * @param array       $handler_config The handler config (so the filter can
+			 *                                    inspect whether this is AI-decided vs
+			 *                                    pre-selected, and behave accordingly).
+			 * @param string|null $post_type      Post type being targeted, or null if all
+			 *                                    public taxonomies are in scope.
+			 */
+			$param_def = apply_filters(
+				'datamachine_taxonomy_tool_parameter',
+				$param_def,
+				$taxonomy,
+				$handler_config,
+				$post_type
+			);
+
+			$parameters[ $param_name ] = $param_def;
 		}
 
 		return $parameters;
@@ -300,7 +361,34 @@ class TaxonomyHandler {
 
 	/**
 	 * Assign taxonomy terms with dynamic term creation using wp_insert_term().
-	 * Creates non-existing terms automatically before assignment.
+	 *
+	 * Creates non-existing terms automatically before assignment. Fires the
+	 * {@see 'datamachine_taxonomy_assign_value'} filter before processing so
+	 * the plugin that owns the taxonomy can sanitize, coerce, or refuse the
+	 * AI-supplied value at runtime — preventing junk terms from being created
+	 * when the AI invents values outside the taxonomy's intended domain.
+	 *
+	 * Example: a plugin that owns a "region" taxonomy can refuse any value
+	 * the AI invented and force the value to be derived from another field:
+	 *
+	 *     add_filter(
+	 *         'datamachine_taxonomy_assign_value',
+	 *         function ( $taxonomy_value, $taxonomy_name, $post_id ) {
+	 *             if ( 'region' !== $taxonomy_name ) {
+	 *                 return $taxonomy_value;
+	 *             }
+	 *             // Region is derived from another field, not AI-decided.
+	 *             // Returning empty skips assignment for this taxonomy.
+	 *             return '';
+	 *         },
+	 *         10,
+	 *         3
+	 *     );
+	 *
+	 * When the filter returns an empty string, null, or empty array, the
+	 * assignment is skipped silently (no terms created, no error raised).
+	 * Default behavior (when no filter is hooked) is identical to the
+	 * pre-filter behavior.
 	 *
 	 * @param int    $post_id WordPress post ID
 	 * @param string $taxonomy_name Taxonomy name
@@ -310,6 +398,36 @@ class TaxonomyHandler {
 	public function assignTaxonomy( int $post_id, string $taxonomy_name, $taxonomy_value ): array {
 		if ( ! $this->validateTaxonomyExists( $taxonomy_name ) ) {
 			return $this->createErrorResult( "Taxonomy '{$taxonomy_name}' does not exist" );
+		}
+
+		/**
+		 * Filters the AI-supplied taxonomy value before term resolution.
+		 *
+		 * Lets the plugin that owns a taxonomy mutate, sanitize, or refuse the
+		 * value the AI picked, before {@see processTerms()} creates new terms.
+		 * Returning an empty value (`''`, `null`, or `array()`) skips
+		 * assignment for this taxonomy without raising an error — useful when
+		 * a taxonomy is derived from another data source and the AI must
+		 * never pick it.
+		 *
+		 * @since 0.131.0
+		 *
+		 * @param mixed  $taxonomy_value The AI-supplied value. Either a string
+		 *                               (hierarchical taxonomy) or an array
+		 *                               of strings (flat taxonomy).
+		 * @param string $taxonomy_name  The taxonomy slug being assigned.
+		 * @param int    $post_id        The post ID receiving the assignment.
+		 */
+		$taxonomy_value = apply_filters(
+			'datamachine_taxonomy_assign_value',
+			$taxonomy_value,
+			$taxonomy_name,
+			$post_id
+		);
+
+		// Empty filter return: skip assignment silently.
+		if ( null === $taxonomy_value || '' === $taxonomy_value || ( is_array( $taxonomy_value ) && empty( $taxonomy_value ) ) ) {
+			return $this->createSuccessResult( $taxonomy_name, array(), array() );
 		}
 
 		$terms    = is_array( $taxonomy_value ) ? $taxonomy_value : array( $taxonomy_value );

--- a/tests/Unit/Core/WordPress/TaxonomyHandlerFiltersTest.php
+++ b/tests/Unit/Core/WordPress/TaxonomyHandlerFiltersTest.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * TaxonomyHandler filter hook tests.
+ *
+ * Covers the two extension points added in #2152:
+ * - `datamachine_taxonomy_tool_parameter` — enrich the AI tool parameter
+ *   definition for a taxonomy (description, enum, required, etc.).
+ * - `datamachine_taxonomy_assign_value` — mutate / refuse the AI-supplied
+ *   value before terms are created.
+ *
+ * These tests must stay generic. A taxonomy named `region` is registered
+ * inside each test so DM core gains no knowledge of any specific
+ * domain taxonomy name.
+ *
+ * @package DataMachine\Tests\Unit\Core\WordPress
+ */
+
+namespace DataMachine\Tests\Unit\Core\WordPress;
+
+use DataMachine\Core\WordPress\TaxonomyHandler;
+use WP_UnitTestCase;
+
+class TaxonomyHandlerFiltersTest extends WP_UnitTestCase {
+
+	/**
+	 * Generic taxonomy slug used by every test in this file.
+	 *
+	 * Intentionally NOT named after any real Extra Chill taxonomy so the
+	 * tests document the generic contract, not a vendor-specific shape.
+	 */
+	private const TEST_TAXONOMY = 'dm_test_region';
+
+	public function set_up(): void {
+		parent::set_up();
+
+		register_taxonomy(
+			self::TEST_TAXONOMY,
+			array( 'post' ),
+			array(
+				'public'       => true,
+				'hierarchical' => true,
+				'label'        => 'Regions',
+				'labels'       => (object) array(
+					'name' => 'Regions',
+				),
+			)
+		);
+	}
+
+	public function tear_down(): void {
+		unregister_taxonomy( self::TEST_TAXONOMY );
+
+		remove_all_filters( 'datamachine_taxonomy_tool_parameter' );
+		remove_all_filters( 'datamachine_taxonomy_assign_value' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Default behavior (no filter hooked) must match pre-#2152 output:
+	 * auto-generated description, no enum, no required flag.
+	 */
+	public function test_default_tool_parameter_is_unchanged_when_no_filter_hooked(): void {
+		$handler_config = array(
+			'taxonomy_' . self::TEST_TAXONOMY . '_selection' => 'ai_decides',
+		);
+
+		$params = TaxonomyHandler::getTaxonomyToolParameters( $handler_config, 'post' );
+
+		$this->assertArrayHasKey( self::TEST_TAXONOMY, $params );
+		$param_def = $params[ self::TEST_TAXONOMY ];
+
+		$this->assertSame( 'string', $param_def['type'] );
+		$this->assertStringContainsString( 'regions', $param_def['description'] );
+		$this->assertArrayNotHasKey( 'enum', $param_def );
+		$this->assertArrayNotHasKey( 'required', $param_def );
+	}
+
+	/**
+	 * Hooking the filter must let a plugin replace the description and
+	 * inject an `enum` constraint that downstream tool schema consumes.
+	 */
+	public function test_tool_parameter_filter_can_enrich_description_and_add_enum(): void {
+		$captured = array();
+
+		add_filter(
+			'datamachine_taxonomy_tool_parameter',
+			function ( $param_def, $taxonomy, $handler_config, $post_type ) use ( &$captured ) {
+				$captured = array(
+					'taxonomy_name'  => $taxonomy->name,
+					'handler_config' => $handler_config,
+					'post_type'      => $post_type,
+				);
+
+				if ( self::TEST_TAXONOMY !== $taxonomy->name ) {
+					return $param_def;
+				}
+
+				$param_def['description'] = 'Pick from the curated list of regions. Do not invent new values.';
+				$param_def['enum']        = array( 'North', 'South', 'East', 'West' );
+				return $param_def;
+			},
+			10,
+			4
+		);
+
+		$handler_config = array(
+			'taxonomy_' . self::TEST_TAXONOMY . '_selection' => 'ai_decides',
+		);
+
+		$params = TaxonomyHandler::getTaxonomyToolParameters( $handler_config, 'post' );
+
+		$this->assertArrayHasKey( self::TEST_TAXONOMY, $params );
+		$param_def = $params[ self::TEST_TAXONOMY ];
+
+		$this->assertSame(
+			'Pick from the curated list of regions. Do not invent new values.',
+			$param_def['description']
+		);
+		$this->assertSame(
+			array( 'North', 'South', 'East', 'West' ),
+			$param_def['enum']
+		);
+
+		// Filter receives full context.
+		$this->assertSame( self::TEST_TAXONOMY, $captured['taxonomy_name'] );
+		$this->assertSame( $handler_config, $captured['handler_config'] );
+		$this->assertSame( 'post', $captured['post_type'] );
+	}
+
+	/**
+	 * Default behavior (no filter hooked) must still create terms exactly
+	 * as before #2152.
+	 */
+	public function test_default_assignment_creates_term_when_no_filter_hooked(): void {
+		$post_id = self::factory()->post->create();
+		$handler = new TaxonomyHandler();
+
+		$result = $handler->assignTaxonomy( $post_id, self::TEST_TAXONOMY, 'Charleston' );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 1, $result['term_count'] );
+
+		$term = get_term_by( 'name', 'Charleston', self::TEST_TAXONOMY );
+		$this->assertNotFalse( $term );
+
+		$assigned = wp_get_object_terms( $post_id, self::TEST_TAXONOMY, array( 'fields' => 'names' ) );
+		$this->assertContains( 'Charleston', $assigned );
+	}
+
+	/**
+	 * Returning an empty string from the filter must refuse the assignment:
+	 * no term is created, no error is raised.
+	 */
+	public function test_assign_value_filter_can_refuse_ai_supplied_value(): void {
+		add_filter(
+			'datamachine_taxonomy_assign_value',
+			function ( $taxonomy_value, $taxonomy_name, $post_id ) {
+				if ( self::TEST_TAXONOMY === $taxonomy_name ) {
+					// Owner refuses anything the AI picks for this taxonomy.
+					return '';
+				}
+				return $taxonomy_value;
+			},
+			10,
+			3
+		);
+
+		$post_id = self::factory()->post->create();
+		$handler = new TaxonomyHandler();
+
+		$refused_value = 'Some Junk Venue Name';
+
+		$result = $handler->assignTaxonomy( $post_id, self::TEST_TAXONOMY, $refused_value );
+
+		// No error: silent skip is the contract.
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 0, $result['term_count'] );
+
+		// No term was created.
+		$term = get_term_by( 'name', $refused_value, self::TEST_TAXONOMY );
+		$this->assertFalse( $term );
+
+		// No terms are assigned to the post.
+		$assigned = wp_get_object_terms( $post_id, self::TEST_TAXONOMY, array( 'fields' => 'names' ) );
+		$this->assertSame( array(), $assigned );
+	}
+
+	/**
+	 * Returning a mutated value from the filter must reroute term creation
+	 * to that value (not the original AI-supplied value).
+	 */
+	public function test_assign_value_filter_can_coerce_value(): void {
+		add_filter(
+			'datamachine_taxonomy_assign_value',
+			function ( $taxonomy_value, $taxonomy_name ) {
+				if ( self::TEST_TAXONOMY === $taxonomy_name ) {
+					return 'Coerced Value';
+				}
+				return $taxonomy_value;
+			},
+			10,
+			2
+		);
+
+		$post_id = self::factory()->post->create();
+		$handler = new TaxonomyHandler();
+
+		$result = $handler->assignTaxonomy( $post_id, self::TEST_TAXONOMY, 'Original AI Pick' );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 1, $result['term_count'] );
+
+		// Coerced value was created.
+		$coerced = get_term_by( 'name', 'Coerced Value', self::TEST_TAXONOMY );
+		$this->assertNotFalse( $coerced );
+
+		// Original AI pick was NOT created.
+		$original = get_term_by( 'name', 'Original AI Pick', self::TEST_TAXONOMY );
+		$this->assertFalse( $original );
+	}
+}


### PR DESCRIPTION
## Summary

Adds two filter hooks to `TaxonomyHandler` so plugins that **own** a taxonomy can attach domain semantics — enrich the AI tool description, add `enum` constraints, refuse AI-supplied values — **without polluting Data Machine core** with any vendor-specific taxonomy knowledge.

Closes #2152.

## What changed

### `inc/Core/WordPress/TaxonomyHandler.php`

**New filter: `datamachine_taxonomy_tool_parameter`**

Fires inside `getTaxonomyToolParameters()` after the auto-generated description is built, before the param def is added to the returned array. Lets a taxonomy-owning plugin:

- Replace the generic auto-description with domain context.
- Add an `enum` constraint to lock the AI to a fixed term list.
- Mark the field `required`.
- Mutate `type` / `items` if needed.

Signature: `apply_filters( 'datamachine_taxonomy_tool_parameter', array $param_def, WP_Taxonomy $taxonomy, array $handler_config, ?string $post_type )`

**New filter: `datamachine_taxonomy_assign_value`**

Fires inside `assignTaxonomy()` before `processTerms()` runs. Lets a taxonomy-owning plugin:

- Sanity-check the AI's pick against domain rules.
- Coerce the value (e.g. AI said "Tucson, AZ" → owner returns "Tucson" to hit the existing canonical term).
- **Refuse** assignment entirely by returning `''` / `null` / `array()` — `assignTaxonomy()` then returns a clean success result with `term_count: 0` and no terms are created. No error raised, no junk terms.

Signature: `apply_filters( 'datamachine_taxonomy_assign_value', mixed $taxonomy_value, string $taxonomy_name, int $post_id )`

Both filters are documented in the method docblocks with inline usage examples that reference a generic `region` taxonomy — not any specific Extra Chill taxonomy.

### `tests/Unit/Core/WordPress/TaxonomyHandlerFiltersTest.php`

New test file with 5 cases covering the contract:

1. Default tool parameter output is unchanged when no filter is hooked.
2. `datamachine_taxonomy_tool_parameter` can replace description and add `enum`, and receives full context (`taxonomy`, `handler_config`, `post_type`).
3. Default `assignTaxonomy()` creates terms when no filter is hooked.
4. `datamachine_taxonomy_assign_value` returning `''` refuses creation silently (no term, no error).
5. `datamachine_taxonomy_assign_value` can coerce the value to a different term.

The test registers a generic `dm_test_region` taxonomy in `set_up()` and tears it down in `tear_down()` — no specific Extra Chill taxonomy name appears.

## Layer purity check

\`\`\`
$ grep -E 'location|venue|artist|festival' inc/Core/WordPress/TaxonomyHandler.php
$ echo exit=$?
exit=1
\`\`\`

Zero matches. `TaxonomyHandler` remains generic.

## Default behavior unchanged

When no filter is hooked:
- `getTaxonomyToolParameters()` returns the exact same shape as before (verified by `test_default_tool_parameter_is_unchanged_when_no_filter_hooked`).
- `assignTaxonomy()` creates terms exactly as before (verified by `test_default_assignment_creates_term_when_no_filter_hooked`).

## Test output

`homeboy test data-machine` — **1325 passed, 3 skipped, 1 failed**.

The single failure (`ContentActionHandlersTest::test_resolved_pending_action_fires_hook_once`) is **pre-existing on `main`** and unrelated to this PR — confirmed by running the suite against the base branch.

All 5 new `TaxonomyHandlerFiltersTest` cases pass. Verified the tests are meaningful by running them against the unfiltered baseline (where the implementation hooks don't exist yet) — 3 of the 5 tests fail there as expected, proving the filters are doing real work.

## Out of scope

This PR adds the hooks but **does not** add any consumers for them. The downstream extrachill-events work (using these hooks so `location` is derived from venue, never AI-decided) is Extra-Chill/extrachill-events#98 and ships in a separate PR.