### PR TITLE
fix: back off empty drain queue ticks

### DIFF
--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -138,6 +138,8 @@ class RunFlowAbility {
 
 		$empty_drain_skip = $this->getEmptyDrainQueueSkip( $flow_config );
 		if ( null !== $empty_drain_skip ) {
+			$this->recordSuppressedRun( $flow_id, $scheduling_config, $empty_drain_skip );
+
 			do_action(
 				'datamachine_log',
 				'info',
@@ -146,6 +148,7 @@ class RunFlowAbility {
 					'flow_id'      => $flow_id,
 					'pipeline_id'  => $pipeline_id,
 					'flow_step_id' => $empty_drain_skip['flow_step_id'],
+					'reason'       => 'empty_drain_queue',
 				)
 			);
 
@@ -157,6 +160,10 @@ class RunFlowAbility {
 				'skipped'    => true,
 				'reason'     => 'empty_drain_queue',
 			);
+		}
+
+		if ( isset( $scheduling_config['datamachine_last_suppressed_run'] ) ) {
+			$this->clearSuppressedRun( $flow_id, $scheduling_config );
 		}
 
 		$agent_identity = null;
@@ -357,7 +364,7 @@ class RunFlowAbility {
 	 * Return first-step drain queue details when a scheduled flow has no work.
 	 *
 	 * @param array $flow_config Normalized flow config.
-	 * @return array{flow_step_id:string}|null
+	 * @return array{flow_step_id:string,queue_mode:string,reason:string}|null
 	 */
 	private function getEmptyDrainQueueSkip( array $flow_config ): ?array {
 		try {
@@ -384,6 +391,81 @@ class RunFlowAbility {
 			return null;
 		}
 
-		return array( 'flow_step_id' => (string) $first_flow_step_id );
+		return array(
+			'flow_step_id' => (string) $first_flow_step_id,
+			'queue_mode'   => 'drain',
+			'reason'       => 'empty_drain_queue',
+		);
+	}
+
+	/**
+	 * Persist a virtual run marker for scheduled empty drain ticks.
+	 *
+	 * The cycle scheduler uses latest job timestamps to decide when a flow is
+	 * due. Empty drain skips intentionally do not create jobs, so this marker
+	 * lets the scheduler back off until the next normal window while keeping the
+	 * operator-visible reason separate from provider exhaustion.
+	 *
+	 * @param int   $flow_id           Flow ID.
+	 * @param array $scheduling_config Current scheduling config.
+	 * @param array $skip              Skip details from getEmptyDrainQueueSkip().
+	 */
+	private function recordSuppressedRun( int $flow_id, array $scheduling_config, array $skip ): void {
+		$suppressed_at = current_time( 'mysql', true );
+
+		$scheduling_config['datamachine_last_suppressed_run'] = array(
+			'reason'        => (string) ( $skip['reason'] ?? 'empty_drain_queue' ),
+			'flow_step_id'  => (string) ( $skip['flow_step_id'] ?? '' ),
+			'queue_mode'    => (string) ( $skip['queue_mode'] ?? 'drain' ),
+			'suppressed_at' => $suppressed_at,
+			'backoff_until' => $this->getSuppressedRunBackoffUntil( $scheduling_config, $suppressed_at ),
+		);
+
+		$this->db_flows->update_flow_scheduling( $flow_id, $scheduling_config );
+	}
+
+	/**
+	 * Clear stale suppression metadata once the flow can start normally.
+	 *
+	 * @param int   $flow_id           Flow ID.
+	 * @param array $scheduling_config Current scheduling config.
+	 */
+	private function clearSuppressedRun( int $flow_id, array $scheduling_config ): void {
+		unset( $scheduling_config['datamachine_last_suppressed_run'] );
+		$this->db_flows->update_flow_scheduling( $flow_id, $scheduling_config );
+	}
+
+	/**
+	 * Resolve the human-readable backoff boundary for suppression metadata.
+	 *
+	 * @param array  $scheduling_config Current scheduling config.
+	 * @param string $suppressed_at     UTC MySQL datetime.
+	 * @return string|null UTC MySQL datetime when known.
+	 */
+	private function getSuppressedRunBackoffUntil( array $scheduling_config, string $suppressed_at ): ?string {
+		$interval = (string) ( $scheduling_config['interval'] ?? '' );
+		if ( '' === $interval || 'manual' === $interval ) {
+			return null;
+		}
+
+		try {
+			$suppressed_time = new \DateTime( $suppressed_at, new \DateTimeZone( 'UTC' ) );
+
+			if ( 'cron' === $interval && ! empty( $scheduling_config['cron_expression'] ) && class_exists( 'CronExpression' ) ) {
+				$cron = \CronExpression::factory( (string) $scheduling_config['cron_expression'] );
+				return $cron->getNextRunDate( $suppressed_time )->format( 'Y-m-d H:i:s' );
+			}
+
+			$intervals     = apply_filters( 'datamachine_scheduler_intervals', array() );
+			$interval_data = $intervals[ $interval ] ?? null;
+			if ( is_array( $interval_data ) && isset( $interval_data['seconds'] ) ) {
+				$suppressed_time->modify( '+' . max( 0, (int) $interval_data['seconds'] ) . ' seconds' );
+				return $suppressed_time->format( 'Y-m-d H:i:s' );
+			}
+		} catch ( \Exception $e ) {
+			return null;
+		}
+
+		return null;
 	}
 }

--- a/inc/Cli/Commands/CycleCommand.php
+++ b/inc/Cli/Commands/CycleCommand.php
@@ -105,6 +105,12 @@ class CycleCommand extends BaseCommand {
 					continue;
 				}
 
+				if ( ! empty( $result['skipped'] ) ) {
+					$row['status'] = 'suppressed';
+					$row['reason'] = (string) ( $result['reason'] ?? $row['reason'] );
+					continue;
+				}
+
 				$row['status'] = 'started';
 				$row['job_id'] = isset( $result['job_id'] ) ? (int) $result['job_id'] : null;
 			}

--- a/inc/Core/Admin/FlowFormatter.php
+++ b/inc/Core/Admin/FlowFormatter.php
@@ -110,21 +110,25 @@ class FlowFormatter {
 			$next_run = self::get_next_run_time( $flow_id );
 		}
 
-		$is_enabled = \DataMachine\Core\Database\Flows\Flows::is_flow_enabled( $scheduling_config );
+		$is_enabled     = \DataMachine\Core\Database\Flows\Flows::is_flow_enabled( $scheduling_config );
+		$suppressed_run = is_array( $scheduling_config['datamachine_last_suppressed_run'] ?? null )
+			? $scheduling_config['datamachine_last_suppressed_run']
+			: null;
 
 		return array(
-			'flow_id'           => $flow_id,
-			'flow_name'         => $flow['flow_name'] ?? '',
-			'pipeline_id'       => isset( $flow['pipeline_id'] ) ? (int) $flow['pipeline_id'] : null,
-			'flow_config'       => $flow_config,
-			'scheduling_config' => $scheduling_config,
-			'enabled'           => $is_enabled,
-			'last_run'          => $last_run_at,
-			'last_run_status'   => $last_run_status,
-			'last_run_display'  => DateFormatter::format_for_display( $last_run_at ),
-			'is_running'        => $is_running,
-			'next_run'          => $next_run,
-			'next_run_display'  => DateFormatter::format_for_display( $next_run ),
+			'flow_id'             => $flow_id,
+			'flow_name'           => $flow['flow_name'] ?? '',
+			'pipeline_id'         => isset( $flow['pipeline_id'] ) ? (int) $flow['pipeline_id'] : null,
+			'flow_config'         => $flow_config,
+			'scheduling_config'   => $scheduling_config,
+			'enabled'             => $is_enabled,
+			'last_run'            => $last_run_at,
+			'last_run_status'     => $last_run_status,
+			'last_suppressed_run' => $suppressed_run,
+			'last_run_display'    => DateFormatter::format_for_display( $last_run_at ),
+			'is_running'          => $is_running,
+			'next_run'            => $next_run,
+			'next_run_display'    => DateFormatter::format_for_display( $next_run ),
 		);
 	}
 

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -2,7 +2,9 @@
 
 namespace DataMachine\Core\Database\Flows;
 
+use DataMachine\Abilities\Flow\QueueAbility;
 use DataMachine\Core\Database\BaseRepository;
+use DataMachine\Engine\ExecutionPlan;
 
 /**
  * Flows Database Class
@@ -1022,9 +1024,15 @@ class Flows extends BaseRepository {
 
 		foreach ( $flows as $flow ) {
 			$scheduling_config = json_decode( $flow['scheduling_config'], true );
+			$scheduling_config = is_array( $scheduling_config ) ? $scheduling_config : array();
 			$flow_id           = (int) $flow['flow_id'];
 			$latest_job        = $latest_jobs[ $flow_id ] ?? null;
 			$last_run_at       = $latest_job['created_at'] ?? null;
+			$suppressed_run    = self::get_last_suppressed_run( $scheduling_config );
+
+			if ( null !== $suppressed_run && ! self::first_drain_queue_has_work( $flow['flow_config'] ?? '' ) ) {
+				$last_run_at = self::latest_mysql_datetime( $last_run_at, $suppressed_run['suppressed_at'] );
+			}
 
 			if ( $this->is_flow_ready_for_execution( $scheduling_config, $current_time, $last_run_at ) ) {
 				$flow['flow_config']       = json_decode( $flow['flow_config'], true ) ?? array();
@@ -1095,6 +1103,85 @@ class Flows extends BaseRepository {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Read a valid suppressed-run marker from scheduling config.
+	 *
+	 * @param array $scheduling_config Scheduling configuration.
+	 * @return array{suppressed_at:string,reason:string,flow_step_id:string,queue_mode:string,backoff_until:?string}|null
+	 */
+	private static function get_last_suppressed_run( array $scheduling_config ): ?array {
+		$marker = $scheduling_config['datamachine_last_suppressed_run'] ?? null;
+		if ( ! is_array( $marker ) ) {
+			return null;
+		}
+
+		$suppressed_at = (string) ( $marker['suppressed_at'] ?? '' );
+		if ( '' === $suppressed_at ) {
+			return null;
+		}
+
+		return array(
+			'suppressed_at' => $suppressed_at,
+			'reason'        => (string) ( $marker['reason'] ?? 'empty_drain_queue' ),
+			'flow_step_id'  => (string) ( $marker['flow_step_id'] ?? '' ),
+			'queue_mode'    => (string) ( $marker['queue_mode'] ?? '' ),
+			'backoff_until' => isset( $marker['backoff_until'] ) ? (string) $marker['backoff_until'] : null,
+		);
+	}
+
+	/**
+	 * Determine whether the first drain-mode fetch step has queued work now.
+	 *
+	 * @param mixed $flow_config_json Raw flow config JSON or decoded array.
+	 * @return bool True when new queued work should bypass suppression.
+	 */
+	private static function first_drain_queue_has_work( mixed $flow_config_json ): bool {
+		$flow_config = is_array( $flow_config_json ) ? $flow_config_json : json_decode( (string) $flow_config_json, true );
+		if ( ! is_array( $flow_config ) ) {
+			return false;
+		}
+
+		try {
+			$first_flow_step_id = ExecutionPlan::from_flow_config( $flow_config )->first_step_id();
+		} catch ( \InvalidArgumentException $e ) {
+			return false;
+		}
+
+		if ( ! $first_flow_step_id || ! isset( $flow_config[ $first_flow_step_id ] ) || ! is_array( $flow_config[ $first_flow_step_id ] ) ) {
+			return false;
+		}
+
+		$first_step = $flow_config[ $first_flow_step_id ];
+		if ( 'fetch' !== (string) ( $first_step['step_type'] ?? '' ) ) {
+			return false;
+		}
+
+		if ( 'drain' !== (string) ( $first_step['queue_mode'] ?? 'static' ) ) {
+			return false;
+		}
+
+		$queue = $first_step[ QueueAbility::SLOT_CONFIG_PATCH_QUEUE ] ?? array();
+		return is_array( $queue ) && ! empty( $queue );
+	}
+
+	/**
+	 * Return the later of two UTC MySQL datetime strings.
+	 *
+	 * @param string|null $left  First datetime.
+	 * @param string|null $right Second datetime.
+	 * @return string|null Latest datetime or null.
+	 */
+	private static function latest_mysql_datetime( ?string $left, ?string $right ): ?string {
+		if ( null === $left || '' === $left ) {
+			return $right;
+		}
+		if ( null === $right || '' === $right ) {
+			return $left;
+		}
+
+		return strtotime( $right ) > strtotime( $left ) ? $right : $left;
 	}
 
 	/**

--- a/tests/empty-drain-suppression-smoke.php
+++ b/tests/empty-drain-suppression-smoke.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Pure-PHP smoke test for empty drain queue suppression/backoff wiring.
+ *
+ * Run with: php tests/empty-drain-suppression-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$files = array(
+	'flows'     => __DIR__ . '/../inc/Core/Database/Flows/Flows.php',
+	'formatter' => __DIR__ . '/../inc/Core/Admin/FlowFormatter.php',
+	'cycle'     => __DIR__ . '/../inc/Cli/Commands/CycleCommand.php',
+);
+
+$sources = array();
+foreach ( $files as $key => $path ) {
+	$sources[ $key ] = file_get_contents( $path ) ?: '';
+}
+
+$assertions = 0;
+
+function assert_empty_drain_suppression_true( bool $condition, string $message ): void {
+	global $assertions;
+	++$assertions;
+
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+function assert_empty_drain_suppression_contains( string $needle, string $haystack, string $message ): void {
+	assert_empty_drain_suppression_true( false !== strpos( $haystack, $needle ), $message );
+}
+
+assert_empty_drain_suppression_contains( 'datamachine_last_suppressed_run', $sources['flows'], 'flow readiness reads suppression marker' );
+assert_empty_drain_suppression_contains( 'first_drain_queue_has_work', $sources['flows'], 'flow readiness bypasses suppression when new queue work exists' );
+assert_empty_drain_suppression_contains( 'latest_mysql_datetime( $last_run_at, $suppressed_run[\'suppressed_at\'] )', $sources['flows'], 'suppressed tick participates in due-time calculation' );
+assert_empty_drain_suppression_contains( 'QueueAbility::SLOT_CONFIG_PATCH_QUEUE', $sources['flows'], 'flow readiness checks the generic queue slot' );
+assert_empty_drain_suppression_contains( 'last_suppressed_run', $sources['formatter'], 'formatted flow status exposes suppression details' );
+assert_empty_drain_suppression_contains( "\$row['status'] = 'suppressed';", $sources['cycle'], 'cycle command reports suppressed empty-drain flows clearly' );
+
+echo "OK ({$assertions} assertions)\n";

--- a/tests/run-flow-empty-drain-queue-smoke.php
+++ b/tests/run-flow-empty-drain-queue-smoke.php
@@ -31,6 +31,9 @@ assert_run_flow_empty_drain_contains( '$empty_drain_skip = $this->getEmptyDrainQ
 assert_run_flow_empty_drain_contains( "'reason'     => 'empty_drain_queue'", $run_flow_src, 'empty drain skip returns explicit reason' );
 assert_run_flow_empty_drain_contains( '\'drain\' !== (string) ( $first_step[\'queue_mode\'] ?? \'static\' )', $run_flow_src, 'skip is scoped to drain mode' );
 assert_run_flow_empty_drain_contains( 'QueueAbility::SLOT_CONFIG_PATCH_QUEUE', $run_flow_src, 'skip checks the config patch queue slot' );
+assert_run_flow_empty_drain_contains( '$this->recordSuppressedRun( $flow_id, $scheduling_config, $empty_drain_skip );', $run_flow_src, 'empty drain skip records scheduler suppression metadata' );
+assert_run_flow_empty_drain_contains( "'datamachine_last_suppressed_run'", $run_flow_src, 'suppression marker uses explicit Data Machine scheduling key' );
+assert_run_flow_empty_drain_contains( "'backoff_until'", $run_flow_src, 'suppression marker records backoff boundary for status' );
 
 $skip_pos       = strpos( $run_flow_src, '$empty_drain_skip = $this->getEmptyDrainQueueSkip( $flow_config );' );
 $create_job_pos = strpos( $run_flow_src, '$job_id = $this->db_jobs->create_job( $job_data );' );


### PR DESCRIPTION
## Summary
- Records empty first-step drain queue skips as generic scheduler suppression metadata on the flow.
- Treats suppression timestamps as virtual run timestamps until new drain queue work appears, stopping cycle runners from selecting the same empty flow every tick.
- Exposes suppression details in formatted flow status and reports cycle skips as `suppressed`.

Fixes #2158.

## Tests
- `php -l inc/Abilities/Engine/RunFlowAbility.php && php -l inc/Core/Database/Flows/Flows.php && php -l inc/Core/Admin/FlowFormatter.php && php -l inc/Cli/Commands/CycleCommand.php && php -l tests/empty-drain-suppression-smoke.php && php -l tests/run-flow-empty-drain-queue-smoke.php`
- `php tests/run-flow-empty-drain-queue-smoke.php && php tests/empty-drain-suppression-smoke.php`
- `git diff --check`
- `vendor/bin/phpcs inc/Abilities/Engine/RunFlowAbility.php inc/Core/Database/Flows/Flows.php inc/Core/Admin/FlowFormatter.php inc/Cli/Commands/CycleCommand.php tests/run-flow-empty-drain-queue-smoke.php tests/empty-drain-suppression-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the generic empty-drain suppression/backoff change, added smoke coverage, and ran targeted verification; Chris remains responsible for review and merge.