### PR TITLE
Persist source disposition diagnostics

### DIFF
--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -52,6 +52,7 @@ class JobArtifacts {
 			'status'                 => (string) ( $job['status'] ?? '' ),
 			'agent_id'               => $agent['agent_id'],
 			'agent_slug'             => $agent['agent_slug'],
+			'disposition_diagnostic' => $this->disposition_diagnostic( $engine_data ),
 			'required_tool_names'    => $this->tool_names_from_assertions( $engine_data['completion_assertions_required'] ?? array() ),
 			'satisfied_tool_names'   => $this->tool_names_from_assertions( $engine_data['completion_assertions_satisfied'] ?? array() ),
 			'successful_tool_calls'  => $tool_calls,
@@ -150,6 +151,56 @@ class JobArtifacts {
 				)
 			)
 		);
+	}
+
+	/**
+	 * Return bounded source/disposition evidence persisted by pipeline tools.
+	 *
+	 * @param array<string,mixed> $engine_data Job engine data.
+	 * @return array<string,mixed>|null
+	 */
+	private function disposition_diagnostic( array $engine_data ): ?array {
+		$diagnostic = $engine_data['disposition_diagnostic'] ?? null;
+		if ( ! is_array( $diagnostic ) ) {
+			$source_rejection = $engine_data['source_rejection'] ?? array();
+			$item_deferral    = $engine_data['item_deferral'] ?? array();
+			if ( is_array( $source_rejection ) && is_array( $source_rejection['diagnostic'] ?? null ) ) {
+				$diagnostic = $source_rejection['diagnostic'];
+			} elseif ( is_array( $item_deferral ) && is_array( $item_deferral['diagnostic'] ?? null ) ) {
+				$diagnostic = $item_deferral['diagnostic'];
+			}
+		}
+
+		if ( ! is_array( $diagnostic ) ) {
+			return null;
+		}
+
+		$fields = array(
+			'type',
+			'disposition',
+			'reason',
+			'tool_name',
+			'item_identifier',
+			'source_url',
+			'provider',
+			'source_type',
+			'flow_step_id',
+			'packet_count',
+			'excerpt',
+			'excerpt_chars',
+			'excerpt_limit',
+			'truncated',
+			'diagnostic',
+		);
+
+		$out = array();
+		foreach ( $fields as $field ) {
+			if ( array_key_exists( $field, $diagnostic ) ) {
+				$out[ $field ] = $diagnostic[ $field ];
+			}
+		}
+
+		return empty( $out ) ? null : $out;
 	}
 
 	/**

--- a/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
+++ b/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
@@ -25,6 +25,7 @@ class FetchItemDispositionTool {
 
 	private const DISPOSITION_REJECT_SOURCE = 'reject_source';
 	private const DISPOSITION_DEFER_ITEM    = 'defer_item';
+	private const MAX_DIAGNOSTIC_CHARS      = 1200;
 
 	/**
 	 * Handle the reject_source/defer_item tool call.
@@ -86,6 +87,7 @@ class FetchItemDispositionTool {
 		$item_identifier = $engine->get( 'item_identifier' );
 		$source_type     = $engine->get( 'source_type' );
 		$flow_step_id    = $this->resolveFetchFlowStepId( $engine ) ?? ( $parameters['flow_step_id'] ?? $engine->get( 'flow_step_id' ) );
+		$diagnostic      = $this->buildDispositionDiagnostic( self::DISPOSITION_REJECT_SOURCE, $tool_name, $reason, $flow_step_id, $item_identifier, $source_type, $parameters );
 
 		// Mark item as processed so it won't be refetched
 		if ( $flow_step_id && $item_identifier && $source_type ) {
@@ -129,12 +131,14 @@ class FetchItemDispositionTool {
 		datamachine_merge_engine_data(
 			$job_id,
 			array(
-				'job_status'       => $status->toString(),
-				'source_rejection' => array(
+				'job_status'             => $status->toString(),
+				'disposition_diagnostic' => $diagnostic,
+				'source_rejection'       => array(
 					'reason'          => $reason,
 					'flow_step_id'    => $flow_step_id,
 					'item_identifier' => $item_identifier,
 					'source_type'     => $source_type,
+					'diagnostic'      => $diagnostic,
 				),
 			)
 		);
@@ -219,13 +223,27 @@ class FetchItemDispositionTool {
 		$source_type     = $engine->get( 'source_type' );
 		$flow_step_id    = $this->resolveFetchFlowStepId( $engine ) ?? ( $parameters['flow_step_id'] ?? $engine->get( 'flow_step_id' ) );
 		$released        = null;
+		$diagnostic      = $this->buildDispositionDiagnostic( self::DISPOSITION_DEFER_ITEM, $tool_name, $reason, $flow_step_id, $item_identifier, $source_type, $parameters );
 
 		if ( $flow_step_id && $item_identifier && $source_type ) {
 			$released = ( new \DataMachine\Core\Database\ProcessedItems\ProcessedItems() )->release_claim( $flow_step_id, (string) $source_type, (string) $item_identifier );
 		}
 
 		$status = JobStatus::failed( 'item-deferred' );
-		datamachine_merge_engine_data( $job_id, array( 'job_status' => $status->toString() ) );
+		datamachine_merge_engine_data(
+			$job_id,
+			array(
+				'job_status'             => $status->toString(),
+				'disposition_diagnostic' => $diagnostic,
+				'item_deferral'          => array(
+					'reason'          => $reason,
+					'flow_step_id'    => $flow_step_id,
+					'item_identifier' => $item_identifier,
+					'source_type'     => $source_type,
+					'diagnostic'      => $diagnostic,
+				),
+			)
+		);
 
 		do_action(
 			'datamachine_log',
@@ -289,5 +307,167 @@ class FetchItemDispositionTool {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Build bounded, generic evidence for skipped/deferred source decisions.
+	 *
+	 * @param string     $disposition     Disposition slug.
+	 * @param string     $tool_name       Tool name.
+	 * @param string     $reason          Operator-visible disposition reason.
+	 * @param mixed      $flow_step_id    Flow step ID.
+	 * @param mixed      $item_identifier Source item identifier.
+	 * @param mixed      $source_type     Source type.
+	 * @param array      $parameters      Tool parameters including current data packets.
+	 * @return array<string,mixed>
+	 */
+	private function buildDispositionDiagnostic( string $disposition, string $tool_name, string $reason, mixed $flow_step_id, mixed $item_identifier, mixed $source_type, array $parameters ): array {
+		$packets       = is_array( $parameters['data'] ?? null ) ? $parameters['data'] : array();
+		$packet        = $this->selectDiagnosticPacket( $packets, $item_identifier );
+		$packet_data   = is_array( $packet['data'] ?? null ) ? $packet['data'] : array();
+		$metadata      = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+		$excerpt       = $this->packetExcerpt( $packet_data );
+		$bounded       = $this->boundAndRedact( $excerpt );
+		$diagnostic    = array(
+			'type'            => 'pipeline_disposition_diagnostic',
+			'disposition'     => $disposition,
+			'reason'          => $this->cleanScalar( $reason ),
+			'tool_name'       => $this->cleanScalar( $tool_name ),
+			'item_identifier' => $this->cleanScalar( $item_identifier ),
+			'source_url'      => $this->sourceUrlFromMetadata( $metadata ),
+			'provider'        => $this->providerFromMetadata( $metadata ),
+			'source_type'     => $this->cleanScalar( $source_type ?: ( $metadata['source_type'] ?? '' ) ),
+			'flow_step_id'    => $this->cleanScalar( $flow_step_id ),
+			'packet_count'    => count( $packets ),
+			'excerpt'         => $bounded['text'],
+			'excerpt_chars'   => strlen( $bounded['text'] ),
+			'excerpt_limit'   => self::MAX_DIAGNOSTIC_CHARS,
+			'truncated'       => $bounded['truncated'],
+		);
+
+		if ( '' === $diagnostic['excerpt'] ) {
+			$diagnostic['diagnostic'] = $this->packetShapeDiagnostic( $packet );
+			unset( $diagnostic['excerpt'], $diagnostic['excerpt_chars'], $diagnostic['truncated'] );
+		}
+
+		return array_filter(
+			$diagnostic,
+			static fn( $value ) => null !== $value && '' !== $value && array() !== $value
+		);
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $packets Data packets.
+	 * @param mixed                          $item_identifier Current item identifier.
+	 * @return array<string,mixed>
+	 */
+	private function selectDiagnosticPacket( array $packets, mixed $item_identifier ): array {
+		$item_identifier = (string) $item_identifier;
+		foreach ( $packets as $packet ) {
+			if ( ! is_array( $packet ) ) {
+				continue;
+			}
+
+			$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+			if ( '' !== $item_identifier && $item_identifier === (string) ( $metadata['item_identifier'] ?? '' ) ) {
+				return $packet;
+			}
+		}
+
+		$first = reset( $packets );
+		return is_array( $first ) ? $first : array();
+	}
+
+	/**
+	 * @param array<string,mixed> $data Packet data.
+	 */
+	private function packetExcerpt( array $data ): string {
+		$parts = array();
+		foreach ( array( 'title', 'body', 'content', 'text', 'description', 'summary' ) as $key ) {
+			if ( ! isset( $data[ $key ] ) || is_array( $data[ $key ] ) || is_object( $data[ $key ] ) ) {
+				continue;
+			}
+
+			$value = trim( (string) $data[ $key ] );
+			if ( '' !== $value ) {
+				$parts[] = $value;
+			}
+		}
+
+		return trim( implode( "\n\n", $parts ) );
+	}
+
+	/**
+	 * @return array{text:string,truncated:bool}
+	 */
+	private function boundAndRedact( string $text ): array {
+		$text = function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( $text ) : strip_tags( $text );
+		$text = trim( preg_replace( '/\s+/u', ' ', $text ) ?? '' );
+		$text = preg_replace( '/\b(Bearer|Basic)\s+[A-Za-z0-9._~+\/-]+=*/i', '$1 [redacted]', $text ) ?? $text;
+		$text = preg_replace( '/\b(api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret|password|secret)\b\s*[:=]\s*[^\s,;]+/i', '$1=[redacted]', $text ) ?? $text;
+		$text = preg_replace( '/([?&](?:token|access_token|key|api_key|secret|password)=)[^&\s]+/i', '$1[redacted]', $text ) ?? $text;
+
+		$truncated = strlen( $text ) > self::MAX_DIAGNOSTIC_CHARS;
+		if ( $truncated ) {
+			$text = substr( $text, 0, self::MAX_DIAGNOSTIC_CHARS );
+		}
+
+		return array(
+			'text'      => $text,
+			'truncated' => $truncated,
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $metadata Packet metadata.
+	 */
+	private function sourceUrlFromMetadata( array $metadata ): string {
+		foreach ( array( 'source_url', 'url', 'permalink', 'link', 'guid' ) as $key ) {
+			if ( ! empty( $metadata[ $key ] ) && is_scalar( $metadata[ $key ] ) ) {
+				return $this->redactScalar( (string) $metadata[ $key ] );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * @param array<string,mixed> $metadata Packet metadata.
+	 */
+	private function providerFromMetadata( array $metadata ): string {
+		foreach ( array( 'provider_id', 'provider_slug', 'provider', 'auth_provider', 'server_key', 'context_server_key', 'handler' ) as $key ) {
+			if ( ! empty( $metadata[ $key ] ) && is_scalar( $metadata[ $key ] ) ) {
+				return $this->cleanScalar( (string) $metadata[ $key ] );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * @param array<string,mixed> $packet Packet data.
+	 */
+	private function packetShapeDiagnostic( array $packet ): string {
+		$data     = is_array( $packet['data'] ?? null ) ? $packet['data'] : array();
+		$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+
+		return sprintf(
+			'No textual packet excerpt available; packet keys: %s; metadata keys: %s',
+			implode( ',', array_slice( array_map( 'strval', array_keys( $data ) ), 0, 12 ) ),
+			implode( ',', array_slice( array_map( 'strval', array_keys( $metadata ) ), 0, 12 ) )
+		);
+	}
+
+	private function cleanScalar( mixed $value ): string {
+		if ( ! is_scalar( $value ) ) {
+			return '';
+		}
+
+		return trim( preg_replace( '/\s+/u', ' ', (string) $value ) ?? '' );
+	}
+
+	private function redactScalar( string $value ): string {
+		$bounded = $this->boundAndRedact( $value );
+		return $bounded['text'];
 	}
 }

--- a/tests/fetch-item-dispositions-smoke.php
+++ b/tests/fetch-item-dispositions-smoke.php
@@ -84,6 +84,21 @@ namespace {
 	);
 
 	$tool = new DataMachine\Core\Steps\Fetch\Tools\FetchItemDispositionTool();
+	$data_packets = array(
+		array(
+			'type'     => 'fetch',
+			'data'     => array(
+				'title' => 'Fixture source title',
+				'body'  => str_repeat( 'Source body with access_token=secret-value. ', 40 ),
+			),
+			'metadata' => array(
+				'item_identifier' => 'source-123',
+				'source_type'     => 'rss',
+				'source_url'      => 'https://example.test/post?access_token=secret-value',
+				'provider_id'     => 'fixture-provider',
+			),
+		),
+	);
 
 	echo "Case 1: reject_source marks processed\n";
 	$reject = $tool->handle_tool_call(
@@ -91,6 +106,7 @@ namespace {
 			'job_id'       => 1814,
 			'flow_step_id' => 'ai-step_7',
 			'engine'       => $engine,
+			'data'         => $data_packets,
 			'reason'       => 'duplicate-source',
 		),
 		array( 'disposition' => 'reject_source' )
@@ -99,6 +115,11 @@ namespace {
 	assert_fetch_disposition_smoke( 'reject_source reports explicit tool name', 'reject_source' === ( $reject['tool_name'] ?? '' ) );
 	assert_fetch_disposition_smoke( 'reject_source marks fetch step processed', array( 'fetch-step_7', 'rss', 'source-123', 1814 ) === ( $GLOBALS['fetch_disposition_smoke_processed'][0] ?? null ) );
 	assert_fetch_disposition_smoke( 'reject_source sets source-rejected status', 'agent_skipped - source-rejected' === ( $GLOBALS['fetch_disposition_smoke_engine'][1814]['job_status'] ?? '' ) );
+	$reject_diagnostic = $GLOBALS['fetch_disposition_smoke_engine'][1814]['disposition_diagnostic'] ?? array();
+	assert_fetch_disposition_smoke( 'reject_source persists disposition diagnostic', 'reject_source' === ( $reject_diagnostic['disposition'] ?? '' ) && 'duplicate-source' === ( $reject_diagnostic['reason'] ?? '' ) );
+	assert_fetch_disposition_smoke( 'reject_source diagnostic includes source identity', 'source-123' === ( $reject_diagnostic['item_identifier'] ?? '' ) && 'fixture-provider' === ( $reject_diagnostic['provider'] ?? '' ) && 'fetch-step_7' === ( $reject_diagnostic['flow_step_id'] ?? '' ) );
+	assert_fetch_disposition_smoke( 'reject_source diagnostic includes packet count and bounded excerpt', 1 === ( $reject_diagnostic['packet_count'] ?? 0 ) && 1200 === ( $reject_diagnostic['excerpt_limit'] ?? 0 ) && 1200 >= strlen( $reject_diagnostic['excerpt'] ?? '' ) );
+	assert_fetch_disposition_smoke( 'reject_source diagnostic redacts obvious secrets', ! str_contains( $reject_diagnostic['excerpt'] ?? '', 'secret-value' ) && ! str_contains( $reject_diagnostic['source_url'] ?? '', 'secret-value' ) );
 
 	echo "Case 2: defer_item releases claim without marking processed\n";
 	$GLOBALS['fetch_disposition_smoke_processed'] = array();
@@ -107,6 +128,7 @@ namespace {
 			'job_id'       => 1815,
 			'flow_step_id' => 'ai-step_7',
 			'engine'       => $engine,
+			'data'         => $data_packets,
 			'reason'       => 'tool-error',
 		),
 		array( 'disposition' => 'defer_item' )
@@ -116,6 +138,8 @@ namespace {
 	assert_fetch_disposition_smoke( 'defer_item releases fetch step claim', array( 'fetch-step_7', 'rss', 'source-123' ) === ( $GLOBALS['fetch_disposition_smoke_released'][0] ?? null ) );
 	assert_fetch_disposition_smoke( 'defer_item does not mark processed', array() === $GLOBALS['fetch_disposition_smoke_processed'] );
 	assert_fetch_disposition_smoke( 'tool-error deferral remains retry eligible', 'failed - item-deferred' === ( $GLOBALS['fetch_disposition_smoke_engine'][1815]['job_status'] ?? '' ) );
+	$defer_diagnostic = $GLOBALS['fetch_disposition_smoke_engine'][1815]['disposition_diagnostic'] ?? array();
+	assert_fetch_disposition_smoke( 'defer_item persists disposition diagnostic', 'defer_item' === ( $defer_diagnostic['disposition'] ?? '' ) && 'tool-error' === ( $defer_diagnostic['reason'] ?? '' ) );
 
 	echo "Case 3: production tool surface exposes positive affordances\n";
 	$fetch_handler = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/FetchHandler.php' );

--- a/tests/job-artifacts-daily-memory-smoke.php
+++ b/tests/job-artifacts-daily-memory-smoke.php
@@ -129,6 +129,14 @@ $assert(
 	'artifact payload includes transcript session metadata without raw messages'
 );
 
+$assert(
+	false !== strpos( $job_artifacts, "'disposition_diagnostic'" )
+		&& false !== strpos( $job_artifacts, 'private function disposition_diagnostic' )
+		&& false !== strpos( $job_artifacts, "'packet_count'" )
+		&& false !== strpos( $job_artifacts, "'excerpt_limit'" ),
+	'job artifacts expose bounded source disposition diagnostics for skipped/deferred jobs'
+);
+
 echo "\n";
 if ( empty( $failures ) ) {
 	echo "OK: job artifacts daily memory smoke assertions passed.\n";


### PR DESCRIPTION
## Summary
- Persists a bounded, redacted disposition diagnostic when `reject_source` or `defer_item` is used by fetch pipelines.
- Exposes the diagnostic through `wp datamachine jobs artifacts` via `disposition_diagnostic`, including reason, tool, source identity, source URL/provider/source type when available, flow step, packet count, and a bounded excerpt or packet-shape diagnostic.
- Keeps transcript persistence unchanged and stores only bounded packet evidence by default.

Fixes #2157.

## Tests
- `php -l inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php`
- `php -l inc/Core/JobArtifacts.php`
- `php tests/fetch-item-dispositions-smoke.php`
- `php tests/job-artifacts-daily-memory-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (`openai/gpt-5.5`)
- **Used for:** Drafted the bounded disposition diagnostic implementation and targeted smoke coverage; Chris remains responsible for review and validation.