### PR TITLE
fix: clean lint blocker formatting

### DIFF
--- a/inc/Abilities/Taxonomy/CreateTaxonomyTermAbility.php
+++ b/inc/Abilities/Taxonomy/CreateTaxonomyTermAbility.php
@@ -26,46 +26,46 @@ class CreateTaxonomyTermAbility extends AbstractTaxonomyAbility {
 			'description'         => __( 'Create a new taxonomy term. The term will be created if it does not already exist.', 'data-machine' ),
 			'category'            => 'datamachine-taxonomy',
 			'input_schema'        => array(
-						'type'       => 'object',
-						'properties' => array(
-							'taxonomy'    => array(
-								'type'        => 'string',
-								'required'    => true,
-								'description' => __( 'Taxonomy slug (category, post_tag, custom taxonomy)', 'data-machine' ),
-							),
-							'name'        => array(
-								'type'        => 'string',
-								'required'    => true,
-								'description' => __( 'Term name', 'data-machine' ),
-							),
-							'slug'        => array(
-								'type'        => 'string',
-								'description' => __( 'Term slug (auto-generated if not provided)', 'data-machine' ),
-							),
-							'description' => array(
-								'type'        => 'string',
-								'description' => __( 'Term description', 'data-machine' ),
-							),
-							'parent'      => array(
-								'type'        => 'integer',
-								'description' => __( 'Parent term ID for hierarchical taxonomies', 'data-machine' ),
-							),
-						),
-						'required'   => array( 'taxonomy', 'name' ),
+				'type'       => 'object',
+				'properties' => array(
+					'taxonomy'    => array(
+						'type'        => 'string',
+						'required'    => true,
+						'description' => __( 'Taxonomy slug (category, post_tag, custom taxonomy)', 'data-machine' ),
 					),
+					'name'        => array(
+						'type'        => 'string',
+						'required'    => true,
+						'description' => __( 'Term name', 'data-machine' ),
+					),
+					'slug'        => array(
+						'type'        => 'string',
+						'description' => __( 'Term slug (auto-generated if not provided)', 'data-machine' ),
+					),
+					'description' => array(
+						'type'        => 'string',
+						'description' => __( 'Term description', 'data-machine' ),
+					),
+					'parent'      => array(
+						'type'        => 'integer',
+						'description' => __( 'Parent term ID for hierarchical taxonomies', 'data-machine' ),
+					),
+				),
+				'required'   => array( 'taxonomy', 'name' ),
+			),
 			'output_schema'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'success'   => array( 'type' => 'boolean' ),
-							'term_id'   => array( 'type' => 'integer' ),
-							'term_name' => array( 'type' => 'string' ),
-							'term_slug' => array( 'type' => 'string' ),
-							'taxonomy'  => array( 'type' => 'string' ),
-							'created'   => array( 'type' => 'boolean' ),
-							'existed'   => array( 'type' => 'boolean' ),
-							'error'     => array( 'type' => 'string' ),
-						),
-					),
+				'type'       => 'object',
+				'properties' => array(
+					'success'   => array( 'type' => 'boolean' ),
+					'term_id'   => array( 'type' => 'integer' ),
+					'term_name' => array( 'type' => 'string' ),
+					'term_slug' => array( 'type' => 'string' ),
+					'taxonomy'  => array( 'type' => 'string' ),
+					'created'   => array( 'type' => 'boolean' ),
+					'existed'   => array( 'type' => 'boolean' ),
+					'error'     => array( 'type' => 'string' ),
+				),
+			),
 			'execute_callback'    => array( $this, 'execute' ),
 			'permission_callback' => array( $this, 'checkPermission' ),
 			'meta'                => array( 'show_in_rest' => true ),
@@ -195,5 +195,4 @@ class CreateTaxonomyTermAbility extends AbstractTaxonomyAbility {
 			'existed'   => false,
 		);
 	}
-
 }

--- a/inc/Abilities/Taxonomy/DeleteTaxonomyTermAbility.php
+++ b/inc/Abilities/Taxonomy/DeleteTaxonomyTermAbility.php
@@ -26,37 +26,37 @@ class DeleteTaxonomyTermAbility extends AbstractTaxonomyAbility {
 			'description'         => __( 'Delete an existing taxonomy term. Optionally reassign posts to another term.', 'data-machine' ),
 			'category'            => 'datamachine-taxonomy',
 			'input_schema'        => array(
-						'type'       => 'object',
-						'properties' => array(
-							'term'     => array(
-								'type'        => 'string',
-								'required'    => true,
-								'description' => __( 'Term identifier (ID, name, or slug)', 'data-machine' ),
-							),
-							'taxonomy' => array(
-								'type'        => 'string',
-								'required'    => true,
-								'description' => __( 'Taxonomy slug (category, post_tag, custom taxonomy)', 'data-machine' ),
-							),
-							'reassign' => array(
-								'type'        => 'integer',
-								'description' => __( 'Term ID to reassign posts to (optional)', 'data-machine' ),
-							),
-						),
-						'required'   => array( 'term', 'taxonomy' ),
+				'type'       => 'object',
+				'properties' => array(
+					'term'     => array(
+						'type'        => 'string',
+						'required'    => true,
+						'description' => __( 'Term identifier (ID, name, or slug)', 'data-machine' ),
 					),
+					'taxonomy' => array(
+						'type'        => 'string',
+						'required'    => true,
+						'description' => __( 'Taxonomy slug (category, post_tag, custom taxonomy)', 'data-machine' ),
+					),
+					'reassign' => array(
+						'type'        => 'integer',
+						'description' => __( 'Term ID to reassign posts to (optional)', 'data-machine' ),
+					),
+				),
+				'required'   => array( 'term', 'taxonomy' ),
+			),
 			'output_schema'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'success'    => array( 'type' => 'boolean' ),
-							'term_id'    => array( 'type' => 'integer' ),
-							'term_name'  => array( 'type' => 'string' ),
-							'taxonomy'   => array( 'type' => 'string' ),
-							'deleted'    => array( 'type' => 'boolean' ),
-							'reassigned' => array( 'type' => 'integer' ),
-							'error'      => array( 'type' => 'string' ),
-						),
-					),
+				'type'       => 'object',
+				'properties' => array(
+					'success'    => array( 'type' => 'boolean' ),
+					'term_id'    => array( 'type' => 'integer' ),
+					'term_name'  => array( 'type' => 'string' ),
+					'taxonomy'   => array( 'type' => 'string' ),
+					'deleted'    => array( 'type' => 'boolean' ),
+					'reassigned' => array( 'type' => 'integer' ),
+					'error'      => array( 'type' => 'string' ),
+				),
+			),
 			'execute_callback'    => array( $this, 'execute' ),
 			'permission_callback' => array( $this, 'checkPermission' ),
 			'meta'                => array( 'show_in_rest' => true ),
@@ -176,5 +176,4 @@ class DeleteTaxonomyTermAbility extends AbstractTaxonomyAbility {
 			'reassigned' => null !== $reassign ? absint( $reassign ) : null,
 		);
 	}
-
 }

--- a/inc/Abilities/Taxonomy/GetTaxonomyTermsAbility.php
+++ b/inc/Abilities/Taxonomy/GetTaxonomyTermsAbility.php
@@ -26,66 +26,66 @@ class GetTaxonomyTermsAbility extends AbstractTaxonomyAbility {
 			'description'         => __( 'Retrieve taxonomy terms with optional filtering by taxonomy, search, and pagination.', 'data-machine' ),
 			'category'            => 'datamachine-taxonomy',
 			'input_schema'        => array(
-						'type'       => 'object',
-						'properties' => array(
-							'taxonomy'   => array(
-								'type'        => 'string',
-								'description' => __( 'Taxonomy slug (category, post_tag, custom taxonomy)', 'data-machine' ),
-							),
-							'search'     => array(
-								'type'        => 'string',
-								'description' => __( 'Search term to filter terms by name', 'data-machine' ),
-							),
-							'parent'     => array(
-								'type'        => 'integer',
-								'description' => __( 'Parent term ID to get child terms', 'data-machine' ),
-							),
-							'hide_empty' => array(
-								'type'        => 'boolean',
-								'description' => __( 'Hide terms with no posts (default: false)', 'data-machine' ),
-							),
-							'number'     => array(
-								'type'        => 'integer',
-								'description' => __( 'Maximum number of terms to return', 'data-machine' ),
-							),
-							'offset'     => array(
-								'type'        => 'integer',
-								'description' => __( 'Number of terms to skip', 'data-machine' ),
-							),
-							'orderby'    => array(
-								'type'        => 'string',
-								'enum'        => array( 'name', 'slug', 'term_id', 'count' ),
-								'description' => __( 'Sort field (default: name)', 'data-machine' ),
-							),
-							'order'      => array(
-								'type'        => 'string',
-								'enum'        => array( 'ASC', 'DESC' ),
-								'description' => __( 'Sort order (default: ASC)', 'data-machine' ),
-							),
-						),
+				'type'       => 'object',
+				'properties' => array(
+					'taxonomy'   => array(
+						'type'        => 'string',
+						'description' => __( 'Taxonomy slug (category, post_tag, custom taxonomy)', 'data-machine' ),
 					),
+					'search'     => array(
+						'type'        => 'string',
+						'description' => __( 'Search term to filter terms by name', 'data-machine' ),
+					),
+					'parent'     => array(
+						'type'        => 'integer',
+						'description' => __( 'Parent term ID to get child terms', 'data-machine' ),
+					),
+					'hide_empty' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Hide terms with no posts (default: false)', 'data-machine' ),
+					),
+					'number'     => array(
+						'type'        => 'integer',
+						'description' => __( 'Maximum number of terms to return', 'data-machine' ),
+					),
+					'offset'     => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of terms to skip', 'data-machine' ),
+					),
+					'orderby'    => array(
+						'type'        => 'string',
+						'enum'        => array( 'name', 'slug', 'term_id', 'count' ),
+						'description' => __( 'Sort field (default: name)', 'data-machine' ),
+					),
+					'order'      => array(
+						'type'        => 'string',
+						'enum'        => array( 'ASC', 'DESC' ),
+						'description' => __( 'Sort order (default: ASC)', 'data-machine' ),
+					),
+				),
+			),
 			'output_schema'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'success' => array( 'type' => 'boolean' ),
-							'terms'   => array(
-								'type'  => 'array',
-								'items' => array(
-									'type'       => 'object',
-									'properties' => array(
-										'term_id'    => array( 'type' => 'integer' ),
-										'name'       => array( 'type' => 'string' ),
-										'slug'       => array( 'type' => 'string' ),
-										'count'      => array( 'type' => 'integer' ),
-										'parent'     => array( 'type' => 'integer' ),
-										'term_group' => array( 'type' => 'integer' ),
-									),
-								),
+				'type'       => 'object',
+				'properties' => array(
+					'success' => array( 'type' => 'boolean' ),
+					'terms'   => array(
+						'type'  => 'array',
+						'items' => array(
+							'type'       => 'object',
+							'properties' => array(
+								'term_id'    => array( 'type' => 'integer' ),
+								'name'       => array( 'type' => 'string' ),
+								'slug'       => array( 'type' => 'string' ),
+								'count'      => array( 'type' => 'integer' ),
+								'parent'     => array( 'type' => 'integer' ),
+								'term_group' => array( 'type' => 'integer' ),
 							),
-							'total'   => array( 'type' => 'integer' ),
-							'error'   => array( 'type' => 'string' ),
 						),
 					),
+					'total'   => array( 'type' => 'integer' ),
+					'error'   => array( 'type' => 'string' ),
+				),
+			),
 			'execute_callback'    => array( $this, 'execute' ),
 			'permission_callback' => array( $this, 'checkPermission' ),
 			'meta'                => array( 'show_in_rest' => true ),
@@ -176,5 +176,4 @@ class GetTaxonomyTermsAbility extends AbstractTaxonomyAbility {
 			'total'   => count( $formatted_terms ),
 		);
 	}
-
 }

--- a/inc/Abilities/Taxonomy/UpdateTaxonomyTermAbility.php
+++ b/inc/Abilities/Taxonomy/UpdateTaxonomyTermAbility.php
@@ -26,50 +26,50 @@ class UpdateTaxonomyTermAbility extends AbstractTaxonomyAbility {
 			'description'         => __( 'Update an existing taxonomy term. Supports updating name, slug, description, and parent.', 'data-machine' ),
 			'category'            => 'datamachine-taxonomy',
 			'input_schema'        => array(
-						'type'       => 'object',
-						'properties' => array(
-							'term'        => array(
-								'type'        => 'string',
-								'required'    => true,
-								'description' => __( 'Term identifier (ID, name, or slug)', 'data-machine' ),
-							),
-							'taxonomy'    => array(
-								'type'        => 'string',
-								'required'    => true,
-								'description' => __( 'Taxonomy slug (category, post_tag, custom taxonomy)', 'data-machine' ),
-							),
-							'name'        => array(
-								'type'        => 'string',
-								'description' => __( 'New term name', 'data-machine' ),
-							),
-							'slug'        => array(
-								'type'        => 'string',
-								'description' => __( 'New term slug', 'data-machine' ),
-							),
-							'description' => array(
-								'type'        => 'string',
-								'description' => __( 'New term description', 'data-machine' ),
-							),
-							'parent'      => array(
-								'type'        => 'integer',
-								'description' => __( 'New parent term ID for hierarchical taxonomies', 'data-machine' ),
-							),
-						),
-						'required'   => array( 'term', 'taxonomy' ),
+				'type'       => 'object',
+				'properties' => array(
+					'term'        => array(
+						'type'        => 'string',
+						'required'    => true,
+						'description' => __( 'Term identifier (ID, name, or slug)', 'data-machine' ),
 					),
+					'taxonomy'    => array(
+						'type'        => 'string',
+						'required'    => true,
+						'description' => __( 'Taxonomy slug (category, post_tag, custom taxonomy)', 'data-machine' ),
+					),
+					'name'        => array(
+						'type'        => 'string',
+						'description' => __( 'New term name', 'data-machine' ),
+					),
+					'slug'        => array(
+						'type'        => 'string',
+						'description' => __( 'New term slug', 'data-machine' ),
+					),
+					'description' => array(
+						'type'        => 'string',
+						'description' => __( 'New term description', 'data-machine' ),
+					),
+					'parent'      => array(
+						'type'        => 'integer',
+						'description' => __( 'New parent term ID for hierarchical taxonomies', 'data-machine' ),
+					),
+				),
+				'required'   => array( 'term', 'taxonomy' ),
+			),
 			'output_schema'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'success'   => array( 'type' => 'boolean' ),
-							'term_id'   => array( 'type' => 'integer' ),
-							'term_name' => array( 'type' => 'string' ),
-							'term_slug' => array( 'type' => 'string' ),
-							'taxonomy'  => array( 'type' => 'string' ),
-							'updated'   => array( 'type' => 'boolean' ),
-							'changes'   => array( 'type' => 'object' ),
-							'error'     => array( 'type' => 'string' ),
-						),
-					),
+				'type'       => 'object',
+				'properties' => array(
+					'success'   => array( 'type' => 'boolean' ),
+					'term_id'   => array( 'type' => 'integer' ),
+					'term_name' => array( 'type' => 'string' ),
+					'term_slug' => array( 'type' => 'string' ),
+					'taxonomy'  => array( 'type' => 'string' ),
+					'updated'   => array( 'type' => 'boolean' ),
+					'changes'   => array( 'type' => 'object' ),
+					'error'     => array( 'type' => 'string' ),
+				),
+			),
 			'execute_callback'    => array( $this, 'execute' ),
 			'permission_callback' => array( $this, 'checkPermission' ),
 			'meta'                => array( 'show_in_rest' => true ),
@@ -245,5 +245,4 @@ class UpdateTaxonomyTermAbility extends AbstractTaxonomyAbility {
 			'changes'   => $changes,
 		);
 	}
-
 }

--- a/inc/Core/Database/Logs/LogRepository.php
+++ b/inc/Core/Database/Logs/LogRepository.php
@@ -285,32 +285,26 @@ class LogRepository extends BaseRepository {
 	 * }
 	 */
 	public function get_metadata( ?int $agent_id = null ): array {
-		$where  = '1=1';
-		$params = array();
-
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 		if ( null !== $agent_id ) {
-			$where    = 'agent_id = %d';
-			$params[] = $agent_id;
-		}
-
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		if ( ! empty( $params ) ) {
-			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders -- Dynamic query construction with safe values.
 			$row = $this->wpdb->get_row(
 				$this->wpdb->prepare(
-					"SELECT COUNT(*) AS total_entries, MIN(created_at) AS oldest, MAX(created_at) AS newest FROM {$this->table_name} WHERE {$where}",
-					...$params
+					'SELECT COUNT(*) AS total_entries, MIN(created_at) AS oldest, MAX(created_at) AS newest FROM %i WHERE agent_id = %d',
+					$this->table_name,
+					$agent_id
 				),
 				ARRAY_A
 			);
-			// phpcs:enable WordPress.DB.PreparedSQLPlaceholders
 		} else {
 			$row = $this->wpdb->get_row(
-				"SELECT COUNT(*) AS total_entries, MIN(created_at) AS oldest, MAX(created_at) AS newest FROM {$this->table_name} WHERE {$where}",
+				$this->wpdb->prepare(
+					'SELECT COUNT(*) AS total_entries, MIN(created_at) AS oldest, MAX(created_at) AS newest FROM %i',
+					$this->table_name
+				),
 				ARRAY_A
 			);
 		}
-		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL
 
 		return array(
 			'total_entries' => (int) ( $row['total_entries'] ?? 0 ),
@@ -326,32 +320,26 @@ class LogRepository extends BaseRepository {
 	 * @return array<string, int> Level => count mapping.
 	 */
 	public function get_level_counts( ?int $agent_id = null ): array {
-		$where  = '1=1';
-		$params = array();
-
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 		if ( null !== $agent_id ) {
-			$where    = 'agent_id = %d';
-			$params[] = $agent_id;
-		}
-
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		if ( ! empty( $params ) ) {
-			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders -- Dynamic query construction with safe values.
 			$rows = $this->wpdb->get_results(
 				$this->wpdb->prepare(
-					"SELECT level, COUNT(*) AS cnt FROM {$this->table_name} WHERE {$where} GROUP BY level",
-					...$params
+					'SELECT level, COUNT(*) AS cnt FROM %i WHERE agent_id = %d GROUP BY level',
+					$this->table_name,
+					$agent_id
 				),
 				ARRAY_A
 			);
-			// phpcs:enable WordPress.DB.PreparedSQLPlaceholders
 		} else {
 			$rows = $this->wpdb->get_results(
-				"SELECT level, COUNT(*) AS cnt FROM {$this->table_name} WHERE {$where} GROUP BY level",
+				$this->wpdb->prepare(
+					'SELECT level, COUNT(*) AS cnt FROM %i GROUP BY level',
+					$this->table_name
+				),
 				ARRAY_A
 			);
 		}
-		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL
 
 		$counts = array();
 		if ( $rows ) {

--- a/inc/Core/Database/PostIdentityIndex/PostIdentityIndex.php
+++ b/inc/Core/Database/PostIdentityIndex/PostIdentityIndex.php
@@ -123,6 +123,7 @@ class PostIdentityIndex extends BaseRepository {
 		$placeholders = implode( ', ', $formats );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL, WordPress.DB.PreparedSQLPlaceholders -- Table name from $wpdb->prefix, not user input.
 		$result = $this->wpdb->query(
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$this->wpdb->prepare(
@@ -130,6 +131,7 @@ class PostIdentityIndex extends BaseRepository {
 				...array_values( $data )
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL, WordPress.DB.PreparedSQLPlaceholders
 
 		if ( false === $result ) {
 			$this->log_db_error( 'PostIdentityIndex::upsert', array( 'post_id' => $post_id ) );
@@ -181,7 +183,8 @@ class PostIdentityIndex extends BaseRepository {
 
 		if ( null !== $venue_term_id && $venue_term_id > 0 ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			return $this->wpdb->get_results(
+			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+			$rows = $this->wpdb->get_results(
 				$this->wpdb->prepare(
 					"SELECT * FROM {$this->table_name} WHERE event_date = %s AND venue_term_id = %d LIMIT %d",
 					$event_date,
@@ -189,18 +192,25 @@ class PostIdentityIndex extends BaseRepository {
 					$limit
 				),
 				ARRAY_A
-			) ?: array();
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL
+
+			return $rows ? $rows : array();
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return $this->wpdb->get_results(
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+		$rows = $this->wpdb->get_results(
 			$this->wpdb->prepare(
 				"SELECT * FROM {$this->table_name} WHERE event_date = %s LIMIT %d",
 				$event_date,
 				$limit
 			),
 			ARRAY_A
-		) ?: array();
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL
+
+		return $rows ? $rows : array();
 	}
 
 	/**
@@ -218,6 +228,7 @@ class PostIdentityIndex extends BaseRepository {
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 		$row = $this->wpdb->get_row(
 			$this->wpdb->prepare(
 				"SELECT * FROM {$this->table_name} WHERE event_date = %s AND title_hash = %s LIMIT 1",
@@ -226,8 +237,9 @@ class PostIdentityIndex extends BaseRepository {
 			),
 			ARRAY_A
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL
 
-		return $row ?: null;
+		return $row ? $row : null;
 	}
 
 	/**
@@ -246,6 +258,7 @@ class PostIdentityIndex extends BaseRepository {
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 		$row = $this->wpdb->get_row(
 			$this->wpdb->prepare(
 				"SELECT * FROM {$this->table_name} WHERE ticket_url = %s AND event_date = %s LIMIT 1",
@@ -254,8 +267,9 @@ class PostIdentityIndex extends BaseRepository {
 			),
 			ARRAY_A
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL
 
-		return $row ?: null;
+		return $row ? $row : null;
 	}
 
 	/**
@@ -272,6 +286,7 @@ class PostIdentityIndex extends BaseRepository {
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 		$row = $this->wpdb->get_row(
 			$this->wpdb->prepare(
 				"SELECT * FROM {$this->table_name} WHERE source_url = %s LIMIT 1",
@@ -279,8 +294,9 @@ class PostIdentityIndex extends BaseRepository {
 			),
 			ARRAY_A
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL
 
-		return $row ?: null;
+		return $row ? $row : null;
 	}
 
 	/**
@@ -298,14 +314,18 @@ class PostIdentityIndex extends BaseRepository {
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return $this->wpdb->get_results(
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+		$rows = $this->wpdb->get_results(
 			$this->wpdb->prepare(
 				"SELECT * FROM {$this->table_name} WHERE event_date = %s AND ticket_url IS NOT NULL AND ticket_url != '' LIMIT %d",
 				$event_date,
 				$limit
 			),
 			ARRAY_A
-		) ?: array();
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL
+
+		return $rows ? $rows : array();
 	}
 
 	/**
@@ -323,14 +343,18 @@ class PostIdentityIndex extends BaseRepository {
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return $this->wpdb->get_results(
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+		$rows = $this->wpdb->get_results(
 			$this->wpdb->prepare(
 				"SELECT * FROM {$this->table_name} WHERE event_date = %s LIMIT %d",
 				$event_date,
 				$limit
 			),
 			ARRAY_A
-		) ?: array();
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL
+
+		return $rows ? $rows : array();
 	}
 
 	// -----------------------------------------------------------------------
@@ -366,6 +390,7 @@ class PostIdentityIndex extends BaseRepository {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$results = $wpdb->get_col(
 			$wpdb->prepare(
+				// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 				"SELECT p.ID FROM {$wpdb->posts} p
 				LEFT JOIN {$this->table_name} idx ON p.ID = idx.post_id
 				WHERE p.post_type = %s
@@ -378,8 +403,9 @@ class PostIdentityIndex extends BaseRepository {
 				$offset
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL
 
-		return array_map( 'intval', $results ?: array() );
+		return array_map( 'intval', $results ? $results : array() );
 	}
 
 	/**
@@ -390,12 +416,14 @@ class PostIdentityIndex extends BaseRepository {
 	 */
 	public function delete_by_post_type( string $post_type ): int {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 		$result = $this->wpdb->query(
 			$this->wpdb->prepare(
 				"DELETE FROM {$this->table_name} WHERE post_type = %s",
 				$post_type
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		return false === $result ? 0 : $result;
 	}


### PR DESCRIPTION
## Summary
- Fixes WPCS formatting in the taxonomy term ability schemas.
- Removes short ternaries and scopes database-query lint suppressions in post identity/log repository code.
- Keeps the first lint blocker batch limited to low-risk PHP cleanup.

## Verification
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-quality-lint-blockers --extension wordpress --changed-only --errors-only`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-quality-lint-blockers --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the lint cleanup patch and ran local verification; Chris remains responsible for review and merge.