### PR TITLE
fix: clean remaining lint blockers

### DIFF
--- a/inc/Abilities/AgentCall/AgentCallAbility.php
+++ b/inc/Abilities/AgentCall/AgentCallAbility.php
@@ -221,18 +221,56 @@ class AgentCallAbility {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			do_action( 'datamachine_log', 'error', 'Agent call webhook request failed', array( 'url' => $this->sanitizeUrlForLog( $url ), 'error' => $response->get_error_message() ) );
-			return array( 'success' => false, 'url' => $this->sanitizeUrlForLog( $url ), 'error' => $response->get_error_message() );
+			do_action(
+				'datamachine_log',
+				'error',
+				'Agent call webhook request failed',
+				array(
+					'url'   => $this->sanitizeUrlForLog( $url ),
+					'error' => $response->get_error_message(),
+				)
+			);
+			return array(
+				'success' => false,
+				'url'     => $this->sanitizeUrlForLog( $url ),
+				'error'   => $response->get_error_message(),
+			);
 		}
 
 		$status_code = wp_remote_retrieve_response_code( $response );
 		if ( $status_code >= 200 && $status_code < 300 ) {
-			do_action( 'datamachine_log', 'info', 'Agent call webhook sent successfully', array( 'url' => $this->sanitizeUrlForLog( $url ), 'status_code' => $status_code ) );
-			return array( 'success' => true, 'url' => $this->sanitizeUrlForLog( $url ), 'status_code' => $status_code );
+			do_action(
+				'datamachine_log',
+				'info',
+				'Agent call webhook sent successfully',
+				array(
+					'url'         => $this->sanitizeUrlForLog( $url ),
+					'status_code' => $status_code,
+				)
+			);
+			return array(
+				'success'     => true,
+				'url'         => $this->sanitizeUrlForLog( $url ),
+				'status_code' => $status_code,
+			);
 		}
 
-		do_action( 'datamachine_log', 'warning', 'Agent call webhook received non-success response', array( 'url' => $this->sanitizeUrlForLog( $url ), 'status_code' => $status_code, 'response_body' => wp_remote_retrieve_body( $response ) ) );
-		return array( 'success' => false, 'url' => $this->sanitizeUrlForLog( $url ), 'status_code' => $status_code, 'error' => 'Webhook returned non-success status code: ' . $status_code );
+		do_action(
+			'datamachine_log',
+			'warning',
+			'Agent call webhook received non-success response',
+			array(
+				'url'           => $this->sanitizeUrlForLog( $url ),
+				'status_code'   => $status_code,
+				'response_body' => wp_remote_retrieve_body( $response ),
+			)
+		);
+		return array(
+			'success'     => false,
+			'url'         => $this->sanitizeUrlForLog( $url ),
+			'status_code' => $status_code,
+			'error'       => 'Webhook returned non-success status code: ' . $status_code,
+		);
 	}
 
 	/**

--- a/inc/Abilities/Email/EmailAbilities.php
+++ b/inc/Abilities/Email/EmailAbilities.php
@@ -520,7 +520,7 @@ class EmailAbilities {
 		global $phpmailer;
 		$error = 'wp_mail() returned false';
 		if ( isset( $phpmailer ) && $phpmailer instanceof \PHPMailer\PHPMailer\PHPMailer ) {
-			$error = $phpmailer->ErrorInfo ?: $error;
+			$error = $phpmailer->ErrorInfo ? $phpmailer->ErrorInfo : $error;
 		}
 
 		return array(
@@ -619,7 +619,7 @@ class EmailAbilities {
 
 		return array(
 			'success' => true,
-			'message' => sprintf( 'Flag %s %s on UID %d', $flag, $action === 'clear' ? 'cleared' : 'set', $uid ),
+			'message' => sprintf( 'Flag %s %s on UID %d', $flag, 'clear' === $action ? 'cleared' : 'set', $uid ),
 		);
 	}
 

--- a/inc/Abilities/Email/EmailAbilities.php
+++ b/inc/Abilities/Email/EmailAbilities.php
@@ -627,6 +627,8 @@ class EmailAbilities {
 	 * Test the IMAP connection with stored credentials.
 	 */
 	public function executeTestConnection( array $input ): array {
+		unset( $input );
+
 		if ( ! function_exists( 'imap_open' ) ) {
 			return array(
 				'success' => false,

--- a/inc/Abilities/Fetch/FetchEmailAbility.php
+++ b/inc/Abilities/Fetch/FetchEmailAbility.php
@@ -563,7 +563,8 @@ class FetchEmailAbility {
 	private function decodeBody( string $body, int $encoding ): string {
 		switch ( $encoding ) {
 			case 3: // BASE64.
-				return base64_decode( $body, true ) ?: $body;
+				$decoded_body = base64_decode( $body, true );
+				return false !== $decoded_body ? $decoded_body : $body;
 			case 4: // QUOTED-PRINTABLE.
 				return quoted_printable_decode( $body );
 			case 1: // 8BIT.

--- a/inc/Abilities/Fetch/FetchEmailAbility.php
+++ b/inc/Abilities/Fetch/FetchEmailAbility.php
@@ -563,6 +563,7 @@ class FetchEmailAbility {
 	private function decodeBody( string $body, int $encoding ): string {
 		switch ( $encoding ) {
 			case 3: // BASE64.
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes MIME transfer encoding, not executable payloads.
 				$decoded_body = base64_decode( $body, true );
 				return false !== $decoded_body ? $decoded_body : $body;
 			case 4: // QUOTED-PRINTABLE.

--- a/inc/Engine/AI/System/Tasks/AgentCallTask.php
+++ b/inc/Engine/AI/System/Tasks/AgentCallTask.php
@@ -178,12 +178,12 @@ class AgentCallTask extends SystemTask {
 		$context = array_merge(
 			$context,
 			array(
-				'data_packets'  => $params['data_packets'] ?? array(),
-				'engine_data'   => $params['engine_data'] ?? array(),
-				'flow_id'       => $params['flow_id'] ?? null,
-				'pipeline_id'   => $params['pipeline_id'] ?? null,
-				'job_id'        => $params['job_id'] ?? $jobId,
-				'from_queue'    => $from_queue,
+				'data_packets' => $params['data_packets'] ?? array(),
+				'engine_data'  => $params['engine_data'] ?? array(),
+				'flow_id'      => $params['flow_id'] ?? null,
+				'pipeline_id'  => $params['pipeline_id'] ?? null,
+				'job_id'       => $params['job_id'] ?? $jobId,
+				'from_queue'   => $from_queue,
 			)
 		);
 		$input['context'] = $context;

--- a/inc/Engine/AI/System/Tasks/AgentCallTask.php
+++ b/inc/Engine/AI/System/Tasks/AgentCallTask.php
@@ -174,8 +174,8 @@ class AgentCallTask extends SystemTask {
 			}
 		}
 
-		$context = is_array( $input['context'] ?? null ) ? $input['context'] : array();
-		$context = array_merge(
+		$context          = is_array( $input['context'] ?? null ) ? $input['context'] : array();
+		$context          = array_merge(
 			$context,
 			array(
 				'data_packets' => $params['data_packets'] ?? array(),

--- a/inc/Engine/AI/System/Tasks/ImageOptimizationTask.php
+++ b/inc/Engine/AI/System/Tasks/ImageOptimizationTask.php
@@ -63,7 +63,7 @@ class ImageOptimizationTask extends SystemTask {
 
 		$file_path = get_attached_file( $attachment_id );
 		if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
-			$this->failJob( $jobId, 'Attachment file not found: ' . ( $file_path ?: 'empty path' ) );
+			$this->failJob( $jobId, 'Attachment file not found: ' . ( $file_path ? $file_path : 'empty path' ) );
 			return;
 		}
 
@@ -138,18 +138,27 @@ class ImageOptimizationTask extends SystemTask {
 		$editor = wp_get_image_editor( $file_path );
 
 		if ( is_wp_error( $editor ) ) {
-			return array( 'success' => false, 'error' => 'Image editor not available: ' . $editor->get_error_message() );
+			return array(
+				'success' => false,
+				'error'   => 'Image editor not available: ' . $editor->get_error_message(),
+			);
 		}
 
 		$editor->set_quality( $quality );
 		$saved = $editor->save( $file_path, $mime_type );
 
 		if ( is_wp_error( $saved ) ) {
-			return array( 'success' => false, 'error' => 'Compression failed: ' . $saved->get_error_message() );
+			return array(
+				'success' => false,
+				'error'   => 'Compression failed: ' . $saved->get_error_message(),
+			);
 		}
 
 		clearstatcache( true, $file_path );
-		return array( 'success' => true, 'new_size' => filesize( $file_path ) );
+		return array(
+			'success'  => true,
+			'new_size' => filesize( $file_path ),
+		);
 	}
 
 	/**
@@ -162,21 +171,35 @@ class ImageOptimizationTask extends SystemTask {
 		$webp_path = preg_replace( '/\.(jpe?g|png)$/i', '.webp', $file_path );
 
 		if ( file_exists( $webp_path ) ) {
-			return array( 'success' => true, 'webp_path' => $webp_path, 'webp_size' => filesize( $webp_path ) );
+			return array(
+				'success'   => true,
+				'webp_path' => $webp_path,
+				'webp_size' => filesize( $webp_path ),
+			);
 		}
 
 		$editor = wp_get_image_editor( $file_path );
 		if ( is_wp_error( $editor ) ) {
-			return array( 'success' => false, 'error' => 'Image editor not available: ' . $editor->get_error_message() );
+			return array(
+				'success' => false,
+				'error'   => 'Image editor not available: ' . $editor->get_error_message(),
+			);
 		}
 
 		$editor->set_quality( $quality );
 		$saved = $editor->save( $webp_path, 'image/webp' );
 
 		if ( is_wp_error( $saved ) ) {
-			return array( 'success' => false, 'error' => 'WebP generation failed: ' . $saved->get_error_message() );
+			return array(
+				'success' => false,
+				'error'   => 'WebP generation failed: ' . $saved->get_error_message(),
+			);
 		}
 
-		return array( 'success' => true, 'webp_path' => $saved['path'], 'webp_size' => filesize( $saved['path'] ) );
+		return array(
+			'success'   => true,
+			'webp_path' => $saved['path'],
+			'webp_size' => filesize( $saved['path'] ),
+		);
 	}
 }

--- a/inc/migrations/scaffolding.php
+++ b/inc/migrations/scaffolding.php
@@ -426,6 +426,8 @@ function datamachine_scaffold_soul_content( string $content, string $filename, a
  * @return string
  */
 function datamachine_scaffold_memory_content( string $content, string $filename, array $context ): string {
+	unset( $context );
+
 	if ( 'MEMORY.md' !== $filename || '' !== $content ) {
 		return $content;
 	}
@@ -448,6 +450,8 @@ function datamachine_scaffold_memory_content( string $content, string $filename,
  * @return string
  */
 function datamachine_scaffold_rules_content( string $content, string $filename, array $context ): string {
+	unset( $context );
+
 	if ( 'RULES.md' !== $filename || '' !== $content ) {
 		return $content;
 	}

--- a/inc/migrations/scaffolding.php
+++ b/inc/migrations/scaffolding.php
@@ -452,7 +452,8 @@ function datamachine_scaffold_rules_content( string $content, string $filename, 
 		return $content;
 	}
 
-	$site_name = get_bloginfo( 'name' ) ?: 'this site';
+	$site_name = get_bloginfo( 'name' );
+	$site_name = $site_name ? $site_name : 'this site';
 
 	return <<<MD
 # Site Rules


### PR DESCRIPTION
## Summary
- Expand inline associative arrays in agent call and image optimization paths to satisfy PHPCS spacing rules.
- Replace remaining short ternaries in the touched PHP paths with explicit conditionals.
- Fix the touched email Yoda-condition finding exposed by file-scoped lint.

## Testing
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-quality-lint-followup --extension wordpress --changed-only --errors-only`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-quality-lint-followup --extension wordpress`

## Notes
- While preparing this lint cleanup, `homeboy lint --fix` exposed a Homeboy Extensions fixer bug that could rewrite JavaScript `else if` patterns into PHP `elseif`. Fixed upstream in Extra-Chill/homeboy-extensions#750 before continuing this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed lint findings, drafted the mechanical PHP cleanup, identified/fixed the upstream fixer bug, and ran local verification. Chris remains responsible for review and merge.