### PR TITLE
fix: align fetch ability schemas

### DIFF
--- a/inc/Abilities/Fetch/FetchRssAbility.php
+++ b/inc/Abilities/Fetch/FetchRssAbility.php
@@ -41,16 +41,16 @@ class FetchRssAbility {
 						'type'       => 'object',
 						'required'   => array( 'feed_url' ),
 						'properties' => array(
-							'feed_url'        => array(
+							'feed_url'         => array(
 								'type'        => 'string',
 								'description' => __( 'URL of the RSS/Atom feed', 'data-machine' ),
 							),
-							'timeframe_limit' => array(
+							'timeframe_limit'  => array(
 								'type'        => 'string',
 								'default'     => 'all_time',
 								'description' => __( 'Timeframe filter (all_time, 24_hours, 7_days, 30_days, 90_days, 6_months, 1_year)', 'data-machine' ),
 							),
-							'search'          => array(
+							'search'           => array(
 								'type'        => 'string',
 								'default'     => '',
 								'description' => __( 'Search term to filter items', 'data-machine' ),
@@ -60,12 +60,12 @@ class FetchRssAbility {
 								'default'     => '',
 								'description' => __( 'Comma-separated keywords; items whose title or description contains any of these are skipped', 'data-machine' ),
 							),
-							'processed_items' => array(
+							'processed_items'  => array(
 								'type'        => 'array',
 								'default'     => array(),
 								'description' => __( 'Array of already processed item GUIDs to skip', 'data-machine' ),
 							),
-							'download_images' => array(
+							'download_images'  => array(
 								'type'        => 'boolean',
 								'default'     => true,
 								'description' => __( 'Whether to download enclosure images', 'data-machine' ),

--- a/inc/Abilities/Fetch/FetchWordPressApiAbility.php
+++ b/inc/Abilities/Fetch/FetchWordPressApiAbility.php
@@ -42,16 +42,16 @@ class FetchWordPressApiAbility {
 						'type'       => 'object',
 						'required'   => array( 'endpoint_url' ),
 						'properties' => array(
-							'endpoint_url'    => array(
+							'endpoint_url'     => array(
 								'type'        => 'string',
 								'description' => __( 'Complete REST API endpoint URL (e.g., https://example.com/wp-json/wp/v2/posts)', 'data-machine' ),
 							),
-							'timeframe_limit' => array(
+							'timeframe_limit'  => array(
 								'type'        => 'string',
 								'default'     => 'all_time',
 								'description' => __( 'Timeframe filter (all_time, 24_hours, 7_days, 30_days, 90_days, 6_months, 1_year)', 'data-machine' ),
 							),
-							'search'          => array(
+							'search'           => array(
 								'type'        => 'string',
 								'default'     => '',
 								'description' => __( 'Search term to filter items', 'data-machine' ),
@@ -61,12 +61,12 @@ class FetchWordPressApiAbility {
 								'default'     => '',
 								'description' => __( 'Comma-separated keywords; items whose title, content, or excerpt contains any of these are skipped', 'data-machine' ),
 							),
-							'processed_items' => array(
+							'processed_items'  => array(
 								'type'        => 'array',
 								'default'     => array(),
 								'description' => __( 'Array of already processed item IDs to skip', 'data-machine' ),
 							),
-							'download_images' => array(
+							'download_images'  => array(
 								'type'        => 'boolean',
 								'default'     => true,
 								'description' => __( 'Whether to download featured images', 'data-machine' ),

--- a/inc/Abilities/Media/BrandTokens.php
+++ b/inc/Abilities/Media/BrandTokens.php
@@ -30,7 +30,7 @@ class BrandTokens {
 	 * @var array
 	 */
 	private const DEFAULTS = array(
-		'colors' => array(
+		'colors'     => array(
 			'background'      => '#ffffff',
 			'background_dark' => '#0f0f0f',
 			'surface'         => '#f1f5f9',
@@ -44,7 +44,7 @@ class BrandTokens {
 			'header_bg'       => '#000000',
 			'border'          => '#dddddd',
 		),
-		'fonts'  => array(
+		'fonts'      => array(
 			// Absolute paths to .ttf files. GD cannot use .woff2 — themes
 			// must ship TTF/OTF for any font they want in rendered images.
 			'heading' => null,


### PR DESCRIPTION
## Summary
- Align fetch ability input schema keys with the longer `exclude_keywords` key.
- Align brand token default sections with the rest of the defaults array.

## Testing
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-fetch-lint-cleanup --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-fetch-lint-cleanup --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified remaining PHPCS alignment findings, drafted the mechanical formatting cleanup, and ran local verification. Chris remains responsible for review and merge.