### PR TITLE
fix: clean formatting lint blockers

### DIFF
--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -305,7 +305,7 @@ class PipelineBatchScheduler {
 		$item_engine_data = $single_packet['metadata']['_engine_data'] ?? array();
 		if ( ! empty( $item_engine_data ) && is_array( $item_engine_data ) ) {
 			$item_engine_data = $this->removeReservedEngineDataKeys( $item_engine_data, $parent_job_id );
-			$child_engine = array_merge( $child_engine, $item_engine_data );
+			$child_engine     = array_merge( $child_engine, $item_engine_data );
 		}
 
 		// Seed dedup context (item_identifier + source_type) from DataPacket metadata.

--- a/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
+++ b/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
@@ -225,7 +225,7 @@ class QueryWordPressPostsAbility {
 			// Build search text once for both include and exclude filters.
 			// $search is server-side handled by WP_Query when single-term;
 			// only the comma-separated case falls through to client-side filtering.
-			$search_text = '';
+			$search_text       = '';
 			$needs_search_text = ( $use_client_side_search && ! empty( $search ) ) || '' !== trim( $exclude_keywords );
 			if ( $needs_search_text ) {
 				$search_text = $post->post_title . ' ' . wp_strip_all_tags( $post->post_content . ' ' . $post->post_excerpt );

--- a/inc/Abilities/File/FileConstants.php
+++ b/inc/Abilities/File/FileConstants.php
@@ -93,5 +93,4 @@ class FileConstants {
 	public static function get_edit_capability( string $filename ) {
 		return MemoryFileRegistry::get_edit_capability( $filename );
 	}
-
 }

--- a/inc/Abilities/Flow/QueueAbility.php
+++ b/inc/Abilities/Flow/QueueAbility.php
@@ -1611,7 +1611,7 @@ class QueueAbility {
 				$queue[] = $entry;
 			}
 
-			$flow_config[ $flow_step_id ][ $slot ] = $queue;
+			$flow_config[ $flow_step_id ][ $slot ]                   = $queue;
 			$flow_config[ $flow_step_id ]['_queue_consume_revision'] =
 				(int) ( $flow_config[ $flow_step_id ]['_queue_consume_revision'] ?? 0 ) + 1;
 

--- a/inc/Abilities/LogAbilities.php
+++ b/inc/Abilities/LogAbilities.php
@@ -499,6 +499,7 @@ class LogAbilities {
 	 * @return array Lines from the file.
 	 */
 	private static function tailDebugLog( string $file, int $lines ): array {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- Efficient reverse tailing needs a seekable stream.
 		$handle = fopen( $file, 'r' );
 		if ( ! $handle ) {
 			return array();
@@ -511,8 +512,9 @@ class LogAbilities {
 		// Read backwards to find line breaks.
 		$found_lines = array();
 		$line_buffer = '';
+		$line_count  = count( $found_lines );
 
-		while ( $pos > 0 && count( $found_lines ) < $lines ) {
+		while ( $pos > 0 && $line_count < $lines ) {
 			--$pos;
 			fseek( $handle, $pos, SEEK_SET );
 			$char = fgetc( $handle );
@@ -520,6 +522,7 @@ class LogAbilities {
 			if ( "\n" === $char ) {
 				if ( '' !== trim( $line_buffer ) ) {
 					array_unshift( $found_lines, strrev( $line_buffer ) );
+					$line_count = count( $found_lines );
 				}
 				$line_buffer = '';
 			} else {
@@ -528,10 +531,11 @@ class LogAbilities {
 		}
 
 		// Don't forget the last line if we hit the beginning.
-		if ( '' !== trim( $line_buffer ) && count( $found_lines ) < $lines ) {
+		if ( '' !== trim( $line_buffer ) && $line_count < $lines ) {
 			array_unshift( $found_lines, strrev( $line_buffer ) );
 		}
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Handle opened above for seekable reverse tailing.
 		fclose( $handle );
 
 		return $found_lines;

--- a/inc/Api/AgentFiles.php
+++ b/inc/Api/AgentFiles.php
@@ -118,8 +118,6 @@ class AgentFiles {
 			)
 		);
 
-
-
 		// Daily memory file routes.
 		$daily_date_args = array(
 			'user_id' => $user_id_arg,

--- a/inc/Api/Flows/FlowSteps.php
+++ b/inc/Api/Flows/FlowSteps.php
@@ -181,7 +181,7 @@ class FlowSteps {
 		$handler_config = $request->get_param( 'handler_config' ) ?? array();
 		$user_message   = $request->get_param( 'user_message' );
 
-		$input     = array( 'flow_step_id' => $flow_step_id );
+		$input = array( 'flow_step_id' => $flow_step_id );
 
 		if ( null !== $handler_slug ) {
 			$input['handler_slug'] = $handler_slug;

--- a/inc/Cli/Commands/ExternalCommand.php
+++ b/inc/Cli/Commands/ExternalCommand.php
@@ -422,7 +422,8 @@ class ExternalCommand extends BaseCommand {
 			}
 
 			if ( '' !== $opener && function_exists( 'shell_exec' ) ) {
-				@shell_exec( sprintf( '%s %s > /dev/null 2>&1 &', $opener, escapeshellarg( $url ) ) );
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec -- CLI-only helper to open an authorization URL.
+				shell_exec( sprintf( '%s %s > /dev/null 2>&1 &', $opener, escapeshellarg( $url ) ) );
 				WP_CLI::log( '(Attempted to open URL in your default browser.)' );
 			}
 		}
@@ -525,7 +526,7 @@ class ExternalCommand extends BaseCommand {
 			if ( '' === $line || false === strpos( $line, ':' ) ) {
 				continue;
 			}
-			list( $name, $value ) = explode( ':', $line, 2 );
+			list( $name, $value )     = explode( ':', $line, 2 );
 			$headers[ trim( $name ) ] = trim( $value );
 		}
 		if ( ! empty( $headers ) ) {

--- a/inc/Cli/Commands/Flows/QueueCommand.php
+++ b/inc/Cli/Commands/Flows/QueueCommand.php
@@ -392,8 +392,8 @@ class QueueCommand extends BaseCommand {
 			$flow_step_id = $resolved['step_id'];
 		}
 
-		$step_type   = $this->getStepType( $flow_id, $flow_step_id );
-		$ability_id  = ( 'fetch' === $step_type )
+		$step_type  = $this->getStepType( $flow_id, $flow_step_id );
+		$ability_id = ( 'fetch' === $step_type )
 			? 'datamachine/config-patch-clear'
 			: 'datamachine/queue-clear';
 

--- a/inc/Cli/Commands/HandlersCommand.php
+++ b/inc/Cli/Commands/HandlersCommand.php
@@ -95,8 +95,8 @@ class HandlersCommand extends BaseCommand {
 		$items = array();
 		foreach ( $result['handlers'] as $slug => $handler ) {
 			$items[] = array(
-				'slug'      => $slug,
-				'label'     => $handler['label'] ?? '',
+				'slug'           => $slug,
+				'label'          => $handler['label'] ?? '',
 				'step_type'      => $handler['step_type'] ?? '',
 				'settings_class' => $handler['settings_class'] ?? '',
 			);

--- a/inc/Cli/Commands/RetentionCommand.php
+++ b/inc/Cli/Commands/RetentionCommand.php
@@ -311,7 +311,7 @@ class RetentionCommand extends BaseCommand {
 
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$results = $wpdb->get_results(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholder list is generated from table count and values are still prepared.
 				$wpdb->prepare(
 					"SELECT table_name, table_rows,
 						ROUND((data_length + index_length) / 1024 / 1024, 1) AS size_mb
@@ -320,6 +320,7 @@ class RetentionCommand extends BaseCommand {
 					AND table_name IN ({$placeholders})",
 					...$unique_tables
 				)
+				// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 			);
 
 			if ( $results ) {
@@ -349,5 +350,4 @@ class RetentionCommand extends BaseCommand {
 
 		return $sizes;
 	}
-
 }

--- a/inc/Cli/Commands/TaxonomyCommand.php
+++ b/inc/Cli/Commands/TaxonomyCommand.php
@@ -101,7 +101,7 @@ class TaxonomyCommand extends BaseCommand {
 			return;
 		}
 
-		$input   = array(
+		$input = array(
 			'taxonomy'   => $taxonomy,
 			'hide_empty' => false,
 			'number'     => (int) ( $assoc_args['number'] ?? 50 ),

--- a/inc/Core/OAuth/BaseOAuth2Provider.php
+++ b/inc/Core/OAuth/BaseOAuth2Provider.php
@@ -590,7 +590,7 @@ abstract class BaseOAuth2Provider extends BaseAuthProvider {
 	 * @return array Query parameters for the authorization URL.
 	 */
 	protected function build_auth_url_params( array $state_payload = array() ): array {
-		$state = $this->oauth2->create_state( $this->provider_slug, $state_payload );
+		$state  = $this->oauth2->create_state( $this->provider_slug, $state_payload );
 		$params = array(
 			'response_type' => $this->get_oauth_response_type(),
 			'redirect_uri'  => $this->get_callback_url(),
@@ -655,5 +655,4 @@ abstract class BaseOAuth2Provider extends BaseAuthProvider {
 			$this->get_callback_url()
 		);
 	}
-
 }

--- a/inc/Core/OAuth/OAuth1Handler.php
+++ b/inc/Core/OAuth/OAuth1Handler.php
@@ -359,5 +359,4 @@ class OAuth1Handler {
 		$transient_key = self::TEMP_TOKEN_SECRET_PREFIX . $provider_key . '_' . $oauth_token;
 		delete_transient( $transient_key );
 	}
-
 }

--- a/inc/Core/Steps/FlowStepTargetResolver.php
+++ b/inc/Core/Steps/FlowStepTargetResolver.php
@@ -88,8 +88,8 @@ class FlowStepTargetResolver {
 		return array(
 			'success' => false,
 			'error'   => array(
-				$field   => $value,
-				'error'  => "No step found for {$field} '{$value}'",
+				$field  => $value,
+				'error' => "No step found for {$field} '{$value}'",
 			),
 		);
 	}

--- a/inc/Engine/AI/Memory/MemorySectionArtifact.php
+++ b/inc/Engine/AI/Memory/MemorySectionArtifact.php
@@ -147,6 +147,7 @@ final class MemorySectionArtifact {
 	private static function owner( string $owner ): string {
 		$owner = sanitize_key( self::non_empty_string( $owner, 'owner' ) );
 		if ( ! in_array( $owner, self::OWNERS, true ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 			throw new BundleValidationException( sprintf( 'memory section owner must be one of: %s.', implode( ', ', self::OWNERS ) ) );
 		}
 
@@ -168,7 +169,7 @@ final class MemorySectionArtifact {
 	}
 
 	private static function source_path( string $path ): string {
-		$path = str_replace( "\\", '/', trim( $path ) );
+		$path = str_replace( '\\', '/', trim( $path ) );
 		$path = ltrim( $path, '/' );
 		if ( str_contains( $path, '..' ) ) {
 			throw new BundleValidationException( 'memory section source_path must be bundle-local.' );

--- a/inc/Engine/AI/Memory/MemorySectionPendingAction.php
+++ b/inc/Engine/AI/Memory/MemorySectionPendingAction.php
@@ -40,8 +40,8 @@ final class MemorySectionPendingAction {
 		$mode     = self::mode( (string) ( $args['mode'] ?? 'append' ) );
 		$reason   = (string) ( $args['reason'] ?? '' );
 
-		$memory  = new AgentMemory( $user_id, $agent_id, $file );
-		$current = $memory->get_section( $section );
+		$memory          = new AgentMemory( $user_id, $agent_id, $file );
+		$current         = $memory->get_section( $section );
 		$current_content = ! empty( $current['success'] ) ? (string) $current['content'] : '';
 		$proposed        = 'append' === $mode && '' !== $current_content
 			? rtrim( $current_content ) . "\n" . $content

--- a/inc/Engine/Actions/Handlers/FailJobHandler.php
+++ b/inc/Engine/Actions/Handlers/FailJobHandler.php
@@ -131,9 +131,9 @@ class FailJobHandler {
 		$db_processed_items->delete_processed_items( array( 'job_id' => $job_id ) );
 		self::releaseInFlightSourceClaims( $db_processed_items, $job_id, $engine_data );
 
-		$cleanup_files          = \DataMachine\Core\PluginSettings::get( 'cleanup_job_data_on_failure', true );
-		$files_cleaned          = false;
-		$retry_pending          = self::hasPendingRetry( $engine_data );
+		$cleanup_files = \DataMachine\Core\PluginSettings::get( 'cleanup_job_data_on_failure', true );
+		$files_cleaned = false;
+		$retry_pending = self::hasPendingRetry( $engine_data );
 
 		// Skip cleanup whenever a retry is already scheduled for this job.
 		// JobRetryPolicy::recordRetry writes the next_retry_at timestamp before


### PR DESCRIPTION
## Summary
- Cleans remaining low-risk PHPCS formatting blockers across CLI, API, OAuth, memory, and queue files.
- Removes the silenced CLI browser opener call and documents targeted PHPCS suppressions where existing behavior intentionally uses dynamic placeholders or seekable file handles.
- Keeps changes behavior-neutral while reducing main-branch lint noise.

## Testing
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-lint-formatting-other-batch --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-lint-formatting-other-batch --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted lint cleanup edits and ran local verification; Chris remains responsible for review and merge.