### PR TITLE
fix: clear remaining lint warnings

### DIFF
--- a/inc/Abilities/SEO/MetaDescriptionAbilities.php
+++ b/inc/Abilities/SEO/MetaDescriptionAbilities.php
@@ -346,6 +346,7 @@ class MetaDescriptionAbilities {
 			$args = array_merge( $post_types, array( $limit ) );
 		}
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query shape is selected from fixed strings above; values are prepared.
 		$results = $wpdb->get_col( $wpdb->prepare( $sql, $args ) );
 
 		return array_map( 'absint', $results ? $results : array() );

--- a/inc/Api/Email.php
+++ b/inc/Api/Email.php
@@ -399,6 +399,7 @@ class Email {
 		);
 	}
 
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- REST permission callbacks receive the request by contract.
 	public static function check_permission( \WP_REST_Request $request ): bool {
 		return PermissionHelper::can_manage();
 	}
@@ -633,6 +634,7 @@ class Email {
 		return self::to_response( $result );
 	}
 
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- REST callback signature receives the request by contract.
 	public static function handle_test_connection( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
 		$ability = wp_get_ability( 'datamachine/email-test-connection' );
 		if ( ! $ability ) {

--- a/inc/Core/Auth/AgentAuthCallback.php
+++ b/inc/Core/Auth/AgentAuthCallback.php
@@ -168,6 +168,7 @@ class AgentAuthCallback {
 	 * @param \WP_REST_Request $request Request object.
 	 * @return \WP_REST_Response
 	 */
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- REST callback signature receives the request by contract.
 	public function list_external_tokens( \WP_REST_Request $request ): \WP_REST_Response {
 		$tokens = get_option( self::OPTION_KEY, array() );
 		$result = array();
@@ -327,8 +328,8 @@ class AgentAuthCallback {
 			width: 48px;
 			height: 48px;
 			border-radius: 50%;
-			background: ' . $bg_color . ';
-			color: ' . $color . ';
+			background: ' . esc_attr( $bg_color ) . ';
+			color: ' . esc_attr( $color ) . ';
 			font-size: 1.5rem;
 			line-height: 48px;
 			margin: 0 auto 1rem;
@@ -358,9 +359,9 @@ class AgentAuthCallback {
 </head>
 <body>
 	<div class="result-container">
-		<div class="result-icon">' . $icon . '</div>
+		<div class="result-icon">' . esc_html( $icon ) . '</div>
 		<h1>' . esc_html( $title ) . '</h1>
-		<p class="message">' . $message . '</p>
+		<p class="message">' . wp_kses_post( $message ) . '</p>
 		<p class="close-hint">You can close this window.</p>
 	</div>
 </body>

--- a/inc/Core/Database/Agents/Agents.php
+++ b/inc/Core/Database/Agents/Agents.php
@@ -74,12 +74,12 @@ class Agents extends BaseRepository {
 		$table_name = $wpdb->base_prefix . self::TABLE_NAME;
 
 		if ( ! BaseRepository::column_exists( $table_name, 'site_scope', $wpdb ) ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			// `AFTER <col>` is MySQL-only; SQLite (Studio) rejects it. Column position
 			// is cosmetic — both engines accept the bare ADD COLUMN form.
-			$wpdb->query( "ALTER TABLE `{$table_name}` ADD COLUMN site_scope BIGINT(20) UNSIGNED NULL DEFAULT NULL" );
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$wpdb->query( "ALTER TABLE `{$table_name}` ADD KEY site_scope (site_scope)" );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN site_scope BIGINT(20) UNSIGNED NULL DEFAULT NULL', $table_name ) );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD KEY site_scope (site_scope)', $table_name ) );
 		}
 	}
 

--- a/inc/Core/FilesRepository/VideoMetadata.php
+++ b/inc/Core/FilesRepository/VideoMetadata.php
@@ -104,8 +104,8 @@ class VideoMetadata {
 		$output     = array();
 		$return_var = -1;
 
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
-		@exec( 'which ffprobe 2>/dev/null', $output, $return_var );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec -- ffprobe availability requires probing the system binary.
+		exec( 'which ffprobe 2>/dev/null', $output, $return_var );
 
 		self::$ffprobe_available = ( 0 === $return_var && ! empty( $output ) );
 
@@ -130,8 +130,8 @@ class VideoMetadata {
 		$output     = array();
 		$return_var = -1;
 
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
-		@exec( $command, $output, $return_var );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec -- Video metadata extraction delegates to ffprobe.
+		exec( $command, $output, $return_var );
 
 		if ( 0 !== $return_var || empty( $output ) ) {
 			return null;
@@ -207,7 +207,6 @@ class VideoMetadata {
 			$finfo = finfo_open( FILEINFO_MIME_TYPE );
 			if ( $finfo ) {
 				$mime = finfo_file( $finfo, $file_path );
-				finfo_close( $finfo );
 				if ( $mime && strpos( $mime, '/' ) !== false ) {
 					return $mime;
 				}

--- a/inc/Core/Steps/Fetch/Handlers/WebhookPayload/WebhookPayload.php
+++ b/inc/Core/Steps/Fetch/Handlers/WebhookPayload/WebhookPayload.php
@@ -145,6 +145,7 @@ class WebhookPayload extends FetchHandler {
 	private static function getRequiredPath( array $payload, string $path ) {
 		$value = self::getPath( $payload, $path );
 		if ( null === $value ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 			throw new \UnexpectedValueException( sprintf( 'Missing webhook payload path "%s".', $path ) );
 		}
 

--- a/inc/Engine/ExecutionPlan.php
+++ b/inc/Engine/ExecutionPlan.php
@@ -42,11 +42,13 @@ class ExecutionPlan {
 
 		foreach ( $flow_config as $step_id => $step_config ) {
 			if ( ! is_array( $step_config ) || ! array_key_exists( 'execution_order', $step_config ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 				throw new \InvalidArgumentException( sprintf( 'Flow step "%s" is missing execution_order.', (string) $step_id ) );
 			}
 
 			$order = self::normalize_order( $step_config['execution_order'], (string) $step_id );
 			if ( array_key_exists( $order, $steps_by_order ) ) {
+				// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 				throw new \InvalidArgumentException(
 					sprintf(
 						'Duplicate execution_order %d for flow steps "%s" and "%s".',
@@ -55,6 +57,7 @@ class ExecutionPlan {
 						(string) $step_id
 					)
 				);
+				// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			}
 
 			$steps_by_order[ $order ] = (string) $step_id;
@@ -115,6 +118,7 @@ class ExecutionPlan {
 			return (int) $raw_order;
 		}
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 		throw new \InvalidArgumentException( sprintf( 'Flow step "%s" has invalid execution_order.', $step_id ) );
 	}
 }


### PR DESCRIPTION
## Summary
- Clears remaining explicit PHPCS security, database, code-analysis, and system-call warnings outside the WP AI client cache class layout.
- Escapes callback result-page output and removes silenced ffprobe execution.
- Keeps REST callback signatures intact while documenting contract-required unused request parameters.

## Testing
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-lint-security-other-batch --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-lint-security-other-batch --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted lint cleanup edits and ran local verification; Chris remains responsible for review and merge.