### PR TITLE
feat: add flow config pre-save filter

### DIFF
--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -183,7 +183,12 @@ class Flows extends BaseRepository {
 			}
 		}
 
-		$flow_config       = wp_json_encode( $flow_data['flow_config'] );
+		$flow_config = $this->prepare_flow_config_for_save( $flow_data['flow_config'], 0, $flow_data );
+		if ( false === $flow_config ) {
+			return false;
+		}
+
+		$flow_config       = wp_json_encode( $flow_config );
 		$scheduling_config = wp_json_encode( $flow_data['scheduling_config'] );
 
 		$user_id  = isset( $flow_data['user_id'] ) ? absint( $flow_data['user_id'] ) : 0;
@@ -791,7 +796,12 @@ class Flows extends BaseRepository {
 		}
 
 		if ( isset( $flow_data['flow_config'] ) ) {
-			$update_data['flow_config'] = wp_json_encode( $flow_data['flow_config'] );
+			$flow_config = $this->prepare_flow_config_for_save( $flow_data['flow_config'], $flow_id, $flow_data );
+			if ( false === $flow_config ) {
+				return false;
+			}
+
+			$update_data['flow_config'] = wp_json_encode( $flow_config );
 			$update_formats[]           = '%s';
 		}
 
@@ -854,6 +864,32 @@ class Flows extends BaseRepository {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Apply the flow-config write-boundary filter before persisting JSON.
+	 *
+	 * @param array<string,mixed> $flow_config Flow config payload.
+	 * @param int                 $flow_id     Flow ID, or 0 while creating a new flow.
+	 * @param array<string,mixed> $flow_data   Full create/update payload.
+	 * @return array<string,mixed>|false Filtered flow config, or false when rejected.
+	 */
+	private function prepare_flow_config_for_save( array $flow_config, int $flow_id, array $flow_data ) {
+		$filtered_config = apply_filters( 'datamachine_flow_config_pre_save', $flow_config, $flow_id, $flow_data );
+		if ( is_wp_error( $filtered_config ) ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'flow_config rejected by datamachine_flow_config_pre_save filter',
+				array(
+					'flow_id' => $flow_id,
+					'reason'  => $filtered_config->get_error_message(),
+				)
+			);
+			return false;
+		}
+
+		return is_array( $filtered_config ) ? $filtered_config : $flow_config;
 	}
 
 	/**

--- a/tests/flow-config-pre-save-filter-smoke.php
+++ b/tests/flow-config-pre-save-filter-smoke.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Pure-PHP smoke test for the flow_config pre-save filter.
+ *
+ * Run with: php tests/flow-config-pre-save-filter-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+define( 'ABSPATH', __DIR__ . '/' );
+define( 'ARRAY_A', 'ARRAY_A' );
+
+$GLOBALS['datamachine_flow_config_pre_save_filters'] = array();
+$GLOBALS['datamachine_flow_config_pre_save_logs']    = array();
+
+class WP_Error {
+	private string $message;
+
+	public function __construct( string $code, string $message ) {
+		unset( $code );
+		$this->message = $message;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+}
+
+function add_filter( string $hook_name, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $priority, $accepted_args );
+	$GLOBALS['datamachine_flow_config_pre_save_filters'][ $hook_name ][] = $callback;
+}
+
+function apply_filters( string $hook_name, $value, ...$args ) {
+	foreach ( $GLOBALS['datamachine_flow_config_pre_save_filters'][ $hook_name ] ?? array() as $callback ) {
+		$value = $callback( $value, ...$args );
+	}
+
+	return $value;
+}
+
+function do_action( string $hook_name, ...$args ): void {
+	$GLOBALS['datamachine_flow_config_pre_save_logs'][] = array( $hook_name, $args );
+}
+
+function is_wp_error( $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function wp_json_encode( $value ): string {
+	return json_encode( $value );
+}
+
+function sanitize_text_field( $value ): string {
+	return trim( (string) $value );
+}
+
+function sanitize_title( $value ): string {
+	return strtolower( preg_replace( '/[^a-z0-9-]+/i', '-', trim( (string) $value ) ) );
+}
+
+function absint( $value ): int {
+	return max( 0, (int) $value );
+}
+
+final class DataMachineFlowConfigPreSaveFakeWpdb {
+	public string $prefix     = 'wp_';
+	public int $insert_id     = 123;
+	public string $last_error = '';
+	public array $inserted    = array();
+	public array $updated     = array();
+
+	public function insert( string $table, array $data, array $formats ) {
+		$this->inserted[] = compact( 'table', 'data', 'formats' );
+		return 1;
+	}
+
+	public function update( string $table, array $data, array $where, array $formats, array $where_formats ) {
+		$this->updated[] = compact( 'table', 'data', 'where', 'formats', 'where_formats' );
+		return 1;
+	}
+}
+
+$GLOBALS['wpdb'] = new DataMachineFlowConfigPreSaveFakeWpdb();
+
+require_once dirname( __DIR__ ) . '/inc/Core/Database/BaseRepository.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Database/Flows/Flows.php';
+
+use DataMachine\Core\Database\Flows\Flows;
+
+function datamachine_flow_config_pre_save_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL {$message}\n" );
+		exit( 1 );
+	}
+
+	echo "PASS {$message}\n";
+}
+
+echo "flow-config-pre-save-filter-smoke\n";
+
+$flows = new Flows();
+
+add_filter(
+	'datamachine_flow_config_pre_save',
+	static function ( array $flow_config, int $flow_id, array $flow_data ) {
+		$flow_config['step_one']['handler_configs']['upsert_event']['taxonomy_location_selection'] = 'derived';
+		$flow_config['step_one']['seen_flow_id'] = $flow_id;
+		$flow_config['step_one']['seen_flow_name'] = $flow_data['flow_name'] ?? '';
+		return $flow_config;
+	},
+	10,
+	3
+);
+
+$created = $flows->create_flow(
+	array(
+		'pipeline_id'       => 10,
+		'flow_name'         => ' Event Flow ',
+		'flow_config'       => array(
+			'step_one' => array(
+				'handler_configs' => array(
+					'upsert_event' => array( 'taxonomy_location_selection' => 'ai_decides' ),
+				),
+			),
+		),
+		'scheduling_config' => array(),
+	)
+);
+
+datamachine_flow_config_pre_save_assert( 123 === $created, 'create_flow returns the inserted flow ID' );
+$created_config = json_decode( $GLOBALS['wpdb']->inserted[0]['data']['flow_config'], true );
+datamachine_flow_config_pre_save_assert( 'derived' === $created_config['step_one']['handler_configs']['upsert_event']['taxonomy_location_selection'], 'create_flow persists filtered flow_config' );
+datamachine_flow_config_pre_save_assert( 0 === $created_config['step_one']['seen_flow_id'], 'create_flow passes flow_id 0 to the pre-save filter' );
+
+$updated = $flows->update_flow(
+	456,
+	array(
+		'flow_name'   => 'Updated Flow',
+		'flow_config' => array( 'step_one' => array() ),
+	)
+);
+
+datamachine_flow_config_pre_save_assert( true === $updated, 'update_flow succeeds when the filter returns an array' );
+$updated_config = json_decode( $GLOBALS['wpdb']->updated[0]['data']['flow_config'], true );
+datamachine_flow_config_pre_save_assert( 456 === $updated_config['step_one']['seen_flow_id'], 'update_flow passes the persisted flow ID to the pre-save filter' );
+datamachine_flow_config_pre_save_assert( 'Updated Flow' === $updated_config['step_one']['seen_flow_name'], 'update_flow passes the full update payload to the pre-save filter' );
+
+$GLOBALS['datamachine_flow_config_pre_save_filters']['datamachine_flow_config_pre_save'] = array(
+	static fn() => new WP_Error( 'invalid_flow_config', 'location must be derived' ),
+);
+
+$before_update_count = count( $GLOBALS['wpdb']->updated );
+$rejected            = $flows->update_flow( 789, array( 'flow_config' => array( 'step_one' => array() ) ) );
+
+datamachine_flow_config_pre_save_assert( false === $rejected, 'update_flow rejects WP_Error filter results' );
+datamachine_flow_config_pre_save_assert( $before_update_count === count( $GLOBALS['wpdb']->updated ), 'rejected flow_config is not written' );
+$last_log = end( $GLOBALS['datamachine_flow_config_pre_save_logs'] );
+datamachine_flow_config_pre_save_assert( 'location must be derived' === ( $last_log[1][2]['reason'] ?? '' ), 'rejection reason is logged' );
+
+echo "All flow config pre-save filter assertions passed.\n";


### PR DESCRIPTION
## Summary
- Add `datamachine_flow_config_pre_save` at the flow write boundary for `create_flow()` and `update_flow()`.
- Allow platform filters to coerce the decoded `flow_config` array or reject the save with `WP_Error` before JSON persistence.
- Add a pure-PHP smoke test covering create/update coercion, flow ID/payload arguments, and rejection logging/no-write behavior.

Fixes https://github.com/Extra-Chill/data-machine/issues/2153

## Verification
- `php tests/flow-config-pre-save-filter-smoke.php`
- `git diff --check`
- `homeboy lint --force-hot --changed-since origin/main --path /Users/chubes/Developer/data-machine@fix-flow-config-pre-save-filter --extension wordpress --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/data-machine-2153-lint.json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the filter implementation, smoke coverage, verification commands, and PR description for Chris to review.