### PR TITLE
fix: recover stale in-progress step actions

### DIFF
--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -210,7 +210,7 @@ class RecoverStuckJobsAbility {
 			$job_id      = (int) $job->job_id;
 			$job_flow_id = (int) $job->flow_id;
 
-			if ( $this->hasActiveStepAction( $job_id ) ) {
+			if ( $this->hasActiveStepAction( $job_id, $timeout_hours ) ) {
 				++$skipped;
 				$jobs[] = array(
 					'job_id'  => $job_id,
@@ -444,9 +444,10 @@ class RecoverStuckJobsAbility {
 	 * original job row is old.
 	 *
 	 * @param int $job_id Job ID.
-	 * @return bool True when a pending/in-progress step action exists.
+	 * @param int $timeout_hours Hours before in-progress actions are considered stale.
+	 * @return bool True when a pending or fresh in-progress step action exists.
 	 */
-	private function hasActiveStepAction( int $job_id ): bool {
+	private function hasActiveStepAction( int $job_id, int $timeout_hours ): bool {
 		global $wpdb;
 
 		if ( $job_id <= 0 ) {
@@ -459,7 +460,7 @@ class RecoverStuckJobsAbility {
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
 		$actions = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT action_id, args
+				"SELECT action_id, args, status, scheduled_date_gmt, last_attempt_gmt
 				 FROM {$actions_table}
 				 WHERE hook = %s
 				 AND status IN ( %s, %s )
@@ -472,9 +473,27 @@ class RecoverStuckJobsAbility {
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
+		$timeout_seconds = max( 1, $timeout_hours ) * HOUR_IN_SECONDS;
+		$now_gmt         = strtotime( current_time( 'mysql', true ) );
+
 		foreach ( $actions as $action ) {
 			if ( $job_id === $this->extractActionJobId( (string) ( $action->args ?? '' ) ) ) {
-				return true;
+				if ( 'pending' === (string) $action->status ) {
+					return true;
+				}
+
+				$last_attempt = (string) ( $action->last_attempt_gmt ?? '' );
+				$scheduled    = (string) ( $action->scheduled_date_gmt ?? '' );
+				$reference    = $last_attempt && '0000-00-00 00:00:00' !== $last_attempt ? $last_attempt : $scheduled;
+				$started_at   = $reference ? strtotime( $reference ) : false;
+
+				if ( false === $started_at || false === $now_gmt ) {
+					return true;
+				}
+
+				if ( ( $now_gmt - $started_at ) < $timeout_seconds ) {
+					return true;
+				}
 			}
 		}
 

--- a/tests/recover-stuck-active-action-guard-smoke.php
+++ b/tests/recover-stuck-active-action-guard-smoke.php
@@ -28,13 +28,19 @@ $timeout_loop = strstr( $source, 'foreach ( $timed_out_jobs as $job )' ) ?: '';
 
 echo "Case 1: timed-out recovery skips jobs with active step actions\n";
 assert_recover_stuck_guard_smoke( 'active step guard method exists', str_contains( $source, 'private function hasActiveStepAction' ) );
-assert_recover_stuck_guard_smoke( 'timeout loop invokes active step guard before dry-run timeout', strpos( $timeout_loop, '$this->hasActiveStepAction( $job_id )' ) < strpos( $timeout_loop, 'if ( $dry_run )' ) );
+assert_recover_stuck_guard_smoke( 'timeout loop invokes active step guard before dry-run timeout', strpos( $timeout_loop, '$this->hasActiveStepAction( $job_id, $timeout_hours )' ) < strpos( $timeout_loop, 'if ( $dry_run )' ) );
 assert_recover_stuck_guard_smoke( 'guard records skipped status', str_contains( $source, "'status'  => 'skipped'") && str_contains( $source, 'Pending or in-progress Action Scheduler step action exists' ) );
 
 echo "Case 2: guard is limited to executable Data Machine step actions\n";
 assert_recover_stuck_guard_smoke( 'guard queries datamachine_execute_step', str_contains( $source, 'datamachine_execute_step' ) );
 assert_recover_stuck_guard_smoke( 'guard checks pending and in-progress actions', str_contains( $source, "'pending'") && str_contains( $source, "'in-progress'") );
 assert_recover_stuck_guard_smoke( 'guard confirms exact job id from action args', str_contains( $source, '$this->extractActionJobId' ) );
+
+echo "Case 3: stale in-progress step actions do not block timeout recovery forever\n";
+assert_recover_stuck_guard_smoke( 'guard receives timeout window', str_contains( $source, 'private function hasActiveStepAction( int $job_id, int $timeout_hours )' ) );
+assert_recover_stuck_guard_smoke( 'guard reads action attempt timestamps', str_contains( $source, 'last_attempt_gmt' ) && str_contains( $source, 'scheduled_date_gmt' ) );
+assert_recover_stuck_guard_smoke( 'pending actions remain guarded unconditionally', str_contains( $source, 'if ( \'pending\' === (string) $action->status )' ) );
+assert_recover_stuck_guard_smoke( 'old in-progress actions can fall through', str_contains( $source, '( $now_gmt - $started_at ) < $timeout_seconds' ) );
 
 echo "\nRecover-stuck active action guard smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary
- Let `recover-stuck` distinguish fresh in-progress Action Scheduler step actions from stale ones.
- Keep pending step actions guarded, while allowing old in-progress actions past the same timeout window so dead worker claims do not block recovery forever.
- Extend the recovery guard smoke test to cover stale in-progress actions.

## Verification
- `php -l inc/Abilities/Job/RecoverStuckJobsAbility.php`
- `php tests/recover-stuck-active-action-guard-smoke.php`
- `php tests/recover-stuck-cli-output-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-stale-action-recovery --extension wordpress --changed-only`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-stale-action-recovery --extension wordpress`

## Notes
- Full `homeboy lint` still reports existing deprecated-function findings in unrelated media files: `MediaValidator.php` and `GDRenderer.php`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosing the stale job recovery path, drafting the code/test change, and running verification. Chris remains responsible for review and merge.