### PR TITLE
fix: add OAuth account update helpers

### DIFF
--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -267,6 +267,23 @@ abstract class BaseAuthProvider {
 	}
 
 	/**
+	 * Merge partial account data into the site-wide OAuth account.
+	 *
+	 * Use this for incremental token/profile refreshes where omitted fields should
+	 * be preserved. Use `save_site_account()` for initial authorization or
+	 * re-consent flows that intentionally replace the complete account payload.
+	 *
+	 * @since 0.132.0
+	 *
+	 * @param array $patch Partial account data to merge into the existing account.
+	 * @return bool True on successful write, false on storage failure.
+	 */
+	public function update_site_account( array $patch ): bool {
+		$existing = $this->get_stored_account_for_scope( null );
+		return $this->store_account_for_scope( array_merge( $existing, $patch ), null );
+	}
+
+	/**
 	 * Delete the site-wide OAuth account for this provider.
 	 *
 	 * Principal-scoped user and agent accounts are preserved. The delete is
@@ -401,22 +418,32 @@ abstract class BaseAuthProvider {
 			);
 		}
 
-		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
-		if ( ! isset( $all_auth_data[ $this->provider_slug ] ) ) {
-			$all_auth_data[ $this->provider_slug ] = array();
-		}
+		return $this->store_account_for_scope( $data, $this->get_principal_scope( $context, 'account' ) );
+	}
 
-		$scope = $this->get_principal_scope( $context, 'account' );
-		if ( null !== $scope ) {
-			if ( ! isset( $all_auth_data[ $this->provider_slug ]['principals'] ) || ! is_array( $all_auth_data[ $this->provider_slug ]['principals'] ) ) {
-				$all_auth_data[ $this->provider_slug ]['principals'] = array();
-			}
-			$all_auth_data[ $this->provider_slug ]['principals'][ $scope ]['account'] = $this->encrypt_fields( $data );
-		} else {
-			$all_auth_data[ $this->provider_slug ]['account'] = $this->encrypt_fields( $data );
-		}
+	/**
+	 * Merge partial account data into the policy-resolved OAuth account slot.
+	 *
+	 * This method preserves omitted fields. It writes to the same site/user/agent
+	 * slot that `save_account()` would target for the supplied context, but reads
+	 * only that exact slot before merging so a missing scoped account does not pull
+	 * values from the legacy site fallback.
+	 *
+	 * Use `save_account()` for full replacement, especially initial authorization
+	 * or re-consent flows. Use this method for token refreshes and other partial
+	 * account updates.
+	 *
+	 * @since 0.132.0
+	 *
+	 * @param array $patch Partial account data to merge.
+	 * @param array $context Optional principal context, e.g. user_id or agent_id.
+	 * @return bool True on successful write, false on storage failure.
+	 */
+	public function update_account( array $patch, array $context = array() ): bool {
+		$scope    = $this->get_principal_scope( $context, 'account' );
+		$existing = $this->get_stored_account_for_scope( $scope );
 
-		return update_site_option( 'datamachine_auth_data', $all_auth_data );
+		return $this->store_account_for_scope( array_merge( $existing, $patch ), $scope );
 	}
 
 	/**
@@ -478,6 +505,55 @@ abstract class BaseAuthProvider {
 			return update_site_option( 'datamachine_auth_data', $all_auth_data );
 		}
 		return true;
+	}
+
+	/**
+	 * Read the exact stored account slot for merge updates.
+	 *
+	 * Unlike `get_account_for_context()`, this does not fall back from a scoped
+	 * principal slot to the legacy site account. Partial updates must not copy site
+	 * credentials into a user or agent slot just because the scoped slot is empty.
+	 *
+	 * @since 0.132.0
+	 *
+	 * @param string|null $scope Principal scope key (`user:<id>` or `agent:<id>`), or null for site account.
+	 * @return array<string,mixed> Decrypted account data, or an empty array when none exists.
+	 */
+	private function get_stored_account_for_scope( ?string $scope ): array {
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		$provider_data = $all_auth_data[ $this->provider_slug ] ?? array();
+		$account       = null === $scope
+			? ( $provider_data['account'] ?? array() )
+			: ( $provider_data['principals'][ $scope ]['account'] ?? array() );
+
+		return is_array( $account ) ? $this->decrypt_fields( $account ) : array();
+	}
+
+	/**
+	 * Store account data in the exact site or principal scope slot.
+	 *
+	 * @since 0.132.0
+	 *
+	 * @param array<string,mixed> $account Account data to store.
+	 * @param string|null         $scope   Principal scope key, or null for the site account.
+	 * @return bool True on successful write, false on storage failure.
+	 */
+	private function store_account_for_scope( array $account, ?string $scope ): bool {
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		if ( ! isset( $all_auth_data[ $this->provider_slug ] ) || ! is_array( $all_auth_data[ $this->provider_slug ] ) ) {
+			$all_auth_data[ $this->provider_slug ] = array();
+		}
+
+		if ( null !== $scope ) {
+			if ( ! isset( $all_auth_data[ $this->provider_slug ]['principals'] ) || ! is_array( $all_auth_data[ $this->provider_slug ]['principals'] ) ) {
+				$all_auth_data[ $this->provider_slug ]['principals'] = array();
+			}
+			$all_auth_data[ $this->provider_slug ]['principals'][ $scope ]['account'] = $this->encrypt_fields( $account );
+		} else {
+			$all_auth_data[ $this->provider_slug ]['account'] = $this->encrypt_fields( $account );
+		}
+
+		return update_site_option( 'datamachine_auth_data', $all_auth_data );
 	}
 
 	// -------------------------------------------------------------------------
@@ -631,6 +707,26 @@ abstract class BaseAuthProvider {
 	}
 
 	/**
+	 * Merge partial account data into a specific user's OAuth account.
+	 *
+	 * @since 0.132.0
+	 *
+	 * @param int   $user_id Target user ID. Must be a positive integer.
+	 * @param array $patch   Partial account data to merge.
+	 * @return bool True on successful write, false on invalid input or storage failure.
+	 */
+	public function update_account_for_user( int $user_id, array $patch ): bool {
+		$user_id = absint( $user_id );
+		if ( $user_id <= 0 ) {
+			return false;
+		}
+
+		$scope_key = 'user:' . $user_id;
+		$existing  = $this->get_stored_account_for_scope( $scope_key );
+		return $this->store_account_for_scope( array_merge( $existing, $patch ), $scope_key );
+	}
+
+	/**
 	 * Delete the OAuth account for a specific user.
 	 *
 	 * Returns true when the per-user slot existed and was removed, or when
@@ -731,6 +827,26 @@ abstract class BaseAuthProvider {
 		$all_auth_data[ $this->provider_slug ]['principals'][ $scope_key ]['account'] = $this->encrypt_fields( $account );
 
 		return update_site_option( 'datamachine_auth_data', $all_auth_data );
+	}
+
+	/**
+	 * Merge partial account data into a specific agent's OAuth account.
+	 *
+	 * @since 0.132.0
+	 *
+	 * @param int   $agent_id Target agent ID. Must be a positive integer.
+	 * @param array $patch    Partial account data to merge.
+	 * @return bool True on successful write, false on invalid input or storage failure.
+	 */
+	public function update_account_for_agent( int $agent_id, array $patch ): bool {
+		$agent_id = absint( $agent_id );
+		if ( $agent_id <= 0 ) {
+			return false;
+		}
+
+		$scope_key = 'agent:' . $agent_id;
+		$existing  = $this->get_stored_account_for_scope( $scope_key );
+		return $this->store_account_for_scope( array_merge( $existing, $patch ), $scope_key );
 	}
 
 	/**

--- a/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
+++ b/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
@@ -75,6 +75,41 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 		$this->assertSame( $account_data, $this->provider->get_account() );
 	}
 
+	public function test_save_account_replaces_existing_account_data(): void {
+		$this->provider->save_account(
+			array(
+				'access_token'  => 'tok_original',
+				'refresh_token' => 'refresh_original',
+				'scope'         => 'read write',
+			)
+		);
+
+		$this->assertTrue( $this->provider->save_account( array( 'access_token' => 'tok_reauth' ) ) );
+
+		$this->assertSame( array( 'access_token' => 'tok_reauth' ), $this->provider->get_account() );
+	}
+
+	public function test_update_account_merges_existing_account_data(): void {
+		$this->provider->save_account(
+			array(
+				'access_token'  => 'tok_original',
+				'refresh_token' => 'refresh_original',
+				'scope'         => 'read write',
+			)
+		);
+
+		$this->assertTrue( $this->provider->update_account( array( 'access_token' => 'tok_refreshed' ) ) );
+
+		$this->assertSame(
+			array(
+				'access_token'  => 'tok_refreshed',
+				'refresh_token' => 'refresh_original',
+				'scope'         => 'read write',
+			),
+			$this->provider->get_account()
+		);
+	}
+
 	public function test_save_config_stores_data(): void {
 		$config_data = array(
 			'api_key'    => 'key_abc',
@@ -253,6 +288,27 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 
 		$this->assertTrue( $this->provider->save_site_account( $account ) );
 		$this->assertSame( $account, $this->provider->get_site_account() );
+	}
+
+	public function test_update_site_account_merges_existing_account_data(): void {
+		$this->provider->save_site_account(
+			array(
+				'access_token'  => 'tok_site',
+				'refresh_token' => 'refresh_site',
+				'scope'         => 'read write',
+			)
+		);
+
+		$this->assertTrue( $this->provider->update_site_account( array( 'access_token' => 'tok_site_refreshed' ) ) );
+
+		$this->assertSame(
+			array(
+				'access_token'  => 'tok_site_refreshed',
+				'refresh_token' => 'refresh_site',
+				'scope'         => 'read write',
+			),
+			$this->provider->get_site_account()
+		);
 	}
 
 	public function test_site_account_shares_legacy_site_slot(): void {
@@ -547,6 +603,74 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 		remove_all_filters( 'deprecated_function_run' );
 	}
 
+	public function test_update_account_with_context_merges_policy_scoped_slot(): void {
+		add_filter(
+			'datamachine_auth_scope_policy',
+			function () {
+				return BaseAuthProvider::AUTH_SCOPE_PRINCIPAL;
+			}
+		);
+
+		$this->provider->save_account_for_agent(
+			303,
+			array(
+				'access_token'  => 'tok_agent_original',
+				'refresh_token' => 'refresh_agent',
+				'scope'         => 'read write',
+			)
+		);
+
+		$this->assertTrue(
+			$this->provider->update_account(
+				array( 'access_token' => 'tok_agent_refreshed' ),
+				array(
+					'user_id'  => 42,
+					'agent_id' => 303,
+				)
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'access_token'  => 'tok_agent_refreshed',
+				'refresh_token' => 'refresh_agent',
+				'scope'         => 'read write',
+			),
+			$this->provider->get_account_for_agent( 303 )
+		);
+
+		remove_all_filters( 'datamachine_auth_scope_policy' );
+	}
+
+	public function test_update_account_with_scoped_context_does_not_merge_site_fallback(): void {
+		add_filter(
+			'datamachine_auth_scope_policy',
+			function () {
+				return BaseAuthProvider::AUTH_SCOPE_USER;
+			}
+		);
+
+		$this->provider->save_site_account(
+			array(
+				'access_token'  => 'tok_site',
+				'refresh_token' => 'refresh_site',
+				'scope'         => 'site_scope',
+			)
+		);
+
+		$this->assertTrue(
+			$this->provider->update_account(
+				array( 'access_token' => 'tok_user_new' ),
+				array( 'user_id' => 42 )
+			)
+		);
+
+		$this->assertSame( array( 'access_token' => 'tok_user_new' ), $this->provider->get_account_for_user( 42 ) );
+		$this->assertSame( 'refresh_site', $this->provider->get_site_account()['refresh_token'] );
+
+		remove_all_filters( 'datamachine_auth_scope_policy' );
+	}
+
 	public function test_clear_account_without_context_does_not_emit_deprecation(): void {
 		$deprecated_calls = array();
 
@@ -640,6 +764,53 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 		$this->assertSame( 'read write', $loaded['scope'] );
 	}
 
+	public function test_update_account_for_user_merges_existing_account_data(): void {
+		$this->provider->save_account_for_user(
+			42,
+			array(
+				'access_token'  => 'tok_user_original',
+				'refresh_token' => 'refresh_user',
+				'scope'         => 'read write',
+			)
+		);
+
+		$this->assertTrue( $this->provider->update_account_for_user( 42, array( 'access_token' => 'tok_user_refreshed' ) ) );
+
+		$this->assertSame(
+			array(
+				'access_token'  => 'tok_user_refreshed',
+				'refresh_token' => 'refresh_user',
+				'scope'         => 'read write',
+			),
+			$this->provider->get_account_for_user( 42 )
+		);
+	}
+
+	public function test_update_account_for_user_does_not_copy_filter_resolved_account_into_default_storage(): void {
+		add_filter(
+			'datamachine_resolve_oauth_account_for_user',
+			function ( $account, $provider, $user_id ) {
+				if ( 'test_provider' === $provider && 707 === $user_id ) {
+					return array(
+						'access_token'  => 'platform_supplied',
+						'refresh_token' => 'platform_refresh',
+						'scope'         => 'platform:read',
+					);
+				}
+
+				return $account;
+			},
+			10,
+			3
+		);
+
+		$this->assertTrue( $this->provider->update_account_for_user( 707, array( 'access_token' => 'default_storage_token' ) ) );
+
+		remove_all_filters( 'datamachine_resolve_oauth_account_for_user' );
+
+		$this->assertSame( array( 'access_token' => 'default_storage_token' ), $this->provider->get_account_for_user( 707 ) );
+	}
+
 	public function test_delete_account_for_user_removes_account(): void {
 		$this->provider->save_account_for_user( 42, array( 'access_token' => 'tok_user_42' ) );
 		$this->assertNotNull( $this->provider->get_account_for_user( 42 ) );
@@ -684,6 +855,7 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 
 	public function test_invalid_user_ids_are_rejected(): void {
 		$this->assertFalse( $this->provider->save_account_for_user( 0, array( 'access_token' => 'x' ) ) );
+		$this->assertFalse( $this->provider->update_account_for_user( 0, array( 'access_token' => 'x' ) ) );
 		$this->assertNull( $this->provider->get_account_for_user( 0 ) );
 		$this->assertFalse( $this->provider->delete_account_for_user( 0 ) );
 	}
@@ -772,6 +944,28 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 		$this->assertSame( 'read write', $loaded['scope'] );
 	}
 
+	public function test_update_account_for_agent_merges_existing_account_data(): void {
+		$this->provider->save_account_for_agent(
+			303,
+			array(
+				'access_token'  => 'tok_agent_original',
+				'refresh_token' => 'refresh_agent',
+				'scope'         => 'read write',
+			)
+		);
+
+		$this->assertTrue( $this->provider->update_account_for_agent( 303, array( 'access_token' => 'tok_agent_refreshed' ) ) );
+
+		$this->assertSame(
+			array(
+				'access_token'  => 'tok_agent_refreshed',
+				'refresh_token' => 'refresh_agent',
+				'scope'         => 'read write',
+			),
+			$this->provider->get_account_for_agent( 303 )
+		);
+	}
+
 	public function test_delete_account_for_agent_removes_account(): void {
 		$this->provider->save_account_for_agent( 303, array( 'access_token' => 'tok_agent_303' ) );
 		$this->assertNotNull( $this->provider->get_account_for_agent( 303 ) );
@@ -814,6 +1008,7 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 
 	public function test_invalid_agent_ids_are_rejected(): void {
 		$this->assertFalse( $this->provider->save_account_for_agent( 0, array( 'access_token' => 'x' ) ) );
+		$this->assertFalse( $this->provider->update_account_for_agent( 0, array( 'access_token' => 'x' ) ) );
 		$this->assertNull( $this->provider->get_account_for_agent( 0 ) );
 		$this->assertFalse( $this->provider->delete_account_for_agent( 0 ) );
 	}


### PR DESCRIPTION
## Summary
- Adds explicit OAuth account update helpers for site, policy-resolved, user, and agent account slots so token refreshes can merge partial data without losing stored fields like `scope`.
- Keeps existing `save_*account*()` APIs as full replacement paths for initial auth and re-consent flows.
- Reads exact scoped storage slots during merge updates so user/agent updates do not accidentally inherit site fallback or filter-resolved external credentials.

Fixes #2168.

## Testing
- `homeboy test --force-hot --path \"/Users/chubes/Developer/data-machine@fix-oauth-account-update-api\" --extension wordpress --output \"/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/data-machine-2168-test.json\"`
- `git diff --check`
- `homeboy lint --force-hot --changed-since origin/main --path \"/Users/chubes/Developer/data-machine@fix-oauth-account-update-api\" --extension wordpress --output \"/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/data-machine-2168-lint.json\"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the code changes and tests under Chris's direction; Chris remains responsible for review and merge.