### PR TITLE
Fix pipeline batch parent finalization

### DIFF
--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -193,6 +193,8 @@ class PipelineBatchScheduler {
 				sprintf( 'Pipeline batch: all %d items scheduled', $result['total'] ),
 				array( 'parent_job_id' => $parent_job_id )
 			);
+
+			self::maybeCompleteParent( $parent_job_id );
 		}
 	}
 
@@ -423,6 +425,27 @@ class PipelineBatchScheduler {
 			return; // Not a child job.
 		}
 
+		self::maybeCompleteParent( (int) $parent_job_id );
+	}
+
+	/**
+	 * Complete a batch parent once all scheduled children have reached terminal states.
+	 *
+	 * Child-complete hooks are the common path, but the final chunk is also a
+	 * scheduler ownership boundary. Rechecking there preserves the invariant that
+	 * a fully scheduled, fully terminal batch parent cannot remain processing with
+	 * no future scheduler action.
+	 *
+	 * @param int $parent_job_id Parent job ID.
+	 */
+	private static function maybeCompleteParent( int $parent_job_id ): void {
+		$jobs_db = new Jobs();
+		$parent  = $jobs_db->get_job( $parent_job_id );
+
+		if ( ! $parent || JobStatus::PROCESSING !== ( $parent['status'] ?? '' ) ) {
+			return;
+		}
+
 		// Check parent is a pipeline batch.
 		$parent_engine = datamachine_get_engine_data( (int) $parent_job_id );
 		if ( empty( $parent_engine['batch'] ) ) {
@@ -448,7 +471,7 @@ class PipelineBatchScheduler {
 					COUNT(*) as total,
 					SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
 					SUM(CASE WHEN status LIKE 'failed%%' THEN 1 ELSE 0 END) as failed,
-					SUM(CASE WHEN status LIKE 'agent_skipped%%' THEN 1 ELSE 0 END) as skipped,
+					SUM(CASE WHEN status LIKE 'agent_skipped%%' OR status = 'completed_no_items' THEN 1 ELSE 0 END) as skipped,
 					SUM(CASE WHEN status = 'processing' OR status = 'pending' THEN 1 ELSE 0 END) as active
 				FROM {$table}
 				WHERE parent_job_id = %d",

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -21,6 +21,7 @@ use DataMachine\Abilities\Job\GetJobsAbility;
 use DataMachine\Abilities\Job\JobsSummaryAbility;
 use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Abilities\Job\RetryJobAbility;
+use DataMachine\Abilities\Engine\PipelineBatchScheduler;
 use DataMachine\Abilities\Job\RunMetricsAbility;
 use DataMachine\Core\JobArtifacts;
 use DataMachine\Core\RunMetrics;
@@ -306,6 +307,7 @@ class JobsCommand extends BaseCommand {
 			'total'             => 0,
 			'active_processing' => 0,
 			'queued_next_step'  => 0,
+			'waiting_children'  => 0,
 			'scheduler_starved' => 0,
 			'stale_in_progress' => 0,
 			'no_scheduler_path' => 0,
@@ -343,10 +345,11 @@ class JobsCommand extends BaseCommand {
 		if ( 'table' === $format ) {
 			WP_CLI::log(
 				sprintf(
-					'Inspected %d processing jobs: %d active, %d queued, %d scheduler-starved, %d stale in-progress, %d without scheduler path.',
+					'Inspected %d processing jobs: %d active, %d queued, %d waiting on children, %d scheduler-starved, %d stale in-progress, %d without scheduler path.',
 					$summary['total'],
 					$summary['active_processing'],
 					$summary['queued_next_step'],
+					$summary['waiting_children'],
 					$summary['scheduler_starved'],
 					$summary['stale_in_progress'],
 					$summary['no_scheduler_path']
@@ -704,7 +707,7 @@ class JobsCommand extends BaseCommand {
 	 */
 	private function diagnose_job_liveness( array $job, int $overdue_minutes ): array {
 		$job_id  = (int) ( $job['job_id'] ?? 0 );
-		$actions = $this->get_job_step_actions( $job_id );
+		$actions = $this->get_job_scheduler_actions( $job_id );
 
 		$pending     = array_values( array_filter( $actions, fn( $action ) => 'pending' === ( $action['status'] ?? '' ) ) );
 		$in_progress = array_values( array_filter( $actions, fn( $action ) => 'in-progress' === ( $action['status'] ?? '' ) ) );
@@ -717,6 +720,16 @@ class JobsCommand extends BaseCommand {
 		$oldest_pending_age  = $this->minutes_since( $oldest_pending );
 		$oldest_progress_age = $this->minutes_since( $oldest_in_progress );
 
+		$engine_data = json_decode( (string) ( $job['engine_data'] ?? '' ), true );
+		if ( ! is_array( $engine_data ) ) {
+			$engine_data = array();
+		}
+
+		$child_counts = ! empty( $engine_data['batch'] ) ? $this->get_child_status_counts( $job_id ) : array();
+		$active_children = (int) ( $child_counts['active'] ?? 0 );
+		$total_children  = (int) ( $child_counts['total'] ?? 0 );
+		$batch_total     = (int) ( $engine_data['batch_total'] ?? 0 );
+
 		if ( ! empty( $in_progress ) && $oldest_progress_age > $overdue_minutes ) {
 			$classification = 'stale_in_progress';
 		} elseif ( ! empty( $in_progress ) ) {
@@ -725,14 +738,12 @@ class JobsCommand extends BaseCommand {
 			$classification = 'scheduler_starved';
 		} elseif ( ! empty( $pending ) ) {
 			$classification = 'queued_next_step';
+		} elseif ( $active_children > 0 || ( $batch_total > 0 && $total_children < $batch_total ) ) {
+			$classification = 'waiting_children';
 		} else {
 			$classification = 'no_scheduler_path';
 		}
 
-		$engine_data = json_decode( (string) ( $job['engine_data'] ?? '' ), true );
-		if ( ! is_array( $engine_data ) ) {
-			$engine_data = array();
-		}
 		$last_activity = $engine_data['run_metrics']['last_activity_at'] ?? null;
 
 		return array(
@@ -748,6 +759,9 @@ class JobsCommand extends BaseCommand {
 			'in_progress_actions' => count( $in_progress ),
 			'complete_actions'    => count( $complete ),
 			'failed_actions'      => count( $failed ),
+			'child_jobs'          => $total_children,
+			'active_children'     => $active_children,
+			'batch_total'         => $batch_total,
 			'oldest_pending'      => $oldest_pending,
 			'oldest_in_progress'  => $oldest_in_progress,
 			'latest_attempt'      => $latest_attempt,
@@ -755,12 +769,12 @@ class JobsCommand extends BaseCommand {
 	}
 
 	/**
-	 * Get Action Scheduler execute-step actions for a job.
+	 * Get Action Scheduler actions that can advance a job.
 	 *
 	 * @param int $job_id Job ID.
 	 * @return array<int,array<string,mixed>>
 	 */
-	private function get_job_step_actions( int $job_id ): array {
+	private function get_job_scheduler_actions( int $job_id ): array {
 		global $wpdb;
 
 		if ( $job_id <= 0 ) {
@@ -768,18 +782,21 @@ class JobsCommand extends BaseCommand {
 		}
 
 		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
-		$like_job_id   = '%"job_id":' . $wpdb->esc_like( (string) $job_id ) . '%';
+		$like_job_id        = '%"job_id":' . $wpdb->esc_like( (string) $job_id ) . '%';
+		$like_parent_job_id = '%"parent_job_id":' . $wpdb->esc_like( (string) $job_id ) . '%';
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT action_id, hook, status, scheduled_date_gmt, last_attempt_gmt, attempts, args
 				 FROM {$actions_table}
-				 WHERE hook = %s
-				 AND args LIKE %s
+				 WHERE hook IN (%s, %s)
+				 AND (args LIKE %s OR args LIKE %s)
 				 ORDER BY action_id ASC",
 				'datamachine_execute_step',
-				$like_job_id
+				PipelineBatchScheduler::BATCH_HOOK,
+				$like_job_id,
+				$like_parent_job_id
 			),
 			ARRAY_A
 		);
@@ -796,6 +813,41 @@ class JobsCommand extends BaseCommand {
 	}
 
 	/**
+	 * Count child jobs for a batch parent.
+	 *
+	 * @param int $parent_job_id Parent job ID.
+	 * @return array<string,int>
+	 */
+	private function get_child_status_counts( int $parent_job_id ): array {
+		global $wpdb;
+
+		if ( $parent_job_id <= 0 ) {
+			return array();
+		}
+
+		$jobs_table = $wpdb->prefix . 'datamachine_jobs';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT
+					COUNT(*) as total,
+					SUM(CASE WHEN status = 'processing' OR status = 'pending' THEN 1 ELSE 0 END) as active
+				 FROM {$jobs_table}
+				 WHERE parent_job_id = %d",
+				$parent_job_id
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return array(
+			'total'  => (int) ( $row['total'] ?? 0 ),
+			'active' => (int) ( $row['active'] ?? 0 ),
+		);
+	}
+
+	/**
 	 * Extract job ID from an Action Scheduler args payload.
 	 *
 	 * @param string $args Action args.
@@ -808,9 +860,17 @@ class JobsCommand extends BaseCommand {
 				return (int) $decoded['job_id'];
 			}
 
+			if ( isset( $decoded['parent_job_id'] ) && is_numeric( $decoded['parent_job_id'] ) ) {
+				return (int) $decoded['parent_job_id'];
+			}
+
 			foreach ( $decoded as $value ) {
 				if ( is_array( $value ) && isset( $value['job_id'] ) && is_numeric( $value['job_id'] ) ) {
 					return (int) $value['job_id'];
+				}
+
+				if ( is_array( $value ) && isset( $value['parent_job_id'] ) && is_numeric( $value['parent_job_id'] ) ) {
+					return (int) $value['parent_job_id'];
 				}
 			}
 		}
@@ -821,9 +881,17 @@ class JobsCommand extends BaseCommand {
 				return (int) $unserialized['job_id'];
 			}
 
+			if ( isset( $unserialized['parent_job_id'] ) && is_numeric( $unserialized['parent_job_id'] ) ) {
+				return (int) $unserialized['parent_job_id'];
+			}
+
 			foreach ( $unserialized as $value ) {
 				if ( is_array( $value ) && isset( $value['job_id'] ) && is_numeric( $value['job_id'] ) ) {
 					return (int) $value['job_id'];
+				}
+
+				if ( is_array( $value ) && isset( $value['parent_job_id'] ) && is_numeric( $value['parent_job_id'] ) ) {
+					return (int) $value['parent_job_id'];
 				}
 			}
 		}

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -725,7 +725,7 @@ class JobsCommand extends BaseCommand {
 			$engine_data = array();
 		}
 
-		$child_counts = ! empty( $engine_data['batch'] ) ? $this->get_child_status_counts( $job_id ) : array();
+		$child_counts    = ! empty( $engine_data['batch'] ) ? $this->get_child_status_counts( $job_id ) : array();
 		$active_children = (int) ( $child_counts['active'] ?? 0 );
 		$total_children  = (int) ( $child_counts['total'] ?? 0 );
 		$batch_total     = (int) ( $engine_data['batch_total'] ?? 0 );
@@ -781,7 +781,7 @@ class JobsCommand extends BaseCommand {
 			return array();
 		}
 
-		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$actions_table      = $wpdb->prefix . 'actionscheduler_actions';
 		$like_job_id        = '%"job_id":' . $wpdb->esc_like( (string) $job_id ) . '%';
 		$like_parent_job_id = '%"parent_job_id":' . $wpdb->esc_like( (string) $job_id ) . '%';
 

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -388,6 +388,50 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'failed', $parent_job['status'] );
 	}
 
+	public function test_final_chunk_completes_parent_when_children_already_terminal(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+
+		datamachine_merge_engine_data( $parent_id, array(
+			'batch'             => true,
+			'batch_total'       => 1,
+			'batch_scheduled'   => 1,
+			'batch_chunk_size'  => \DataMachine\Core\ActionScheduler\BatchScheduler::DEFAULT_CHUNK_SIZE,
+			'batch_context'     => PipelineBatchScheduler::BATCH_CONTEXT,
+			'next_flow_step_id' => 'step_done',
+			'started_at'        => current_time( 'mysql' ),
+			'batch_state'       => array(
+				'offset' => 1,
+				'total'  => 1,
+				'items'  => array(),
+				'extra'  => array(
+					'next_flow_step_id' => 'step_done',
+					'engine_snapshot'   => $engine,
+				),
+				'hook'   => PipelineBatchScheduler::BATCH_HOOK,
+			),
+		) );
+
+		$child = $this->jobs_db->create_job( array(
+			'pipeline_id'   => $this->test_pipeline_id,
+			'flow_id'       => $this->test_flow_id,
+			'source'        => 'pipeline',
+			'label'         => 'Already terminal child',
+			'parent_job_id' => $parent_id,
+		) );
+		$this->jobs_db->start_job( (int) $child );
+		$this->jobs_db->complete_job( (int) $child, JobStatus::COMPLETED_NO_ITEMS );
+
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->processChunk( $parent_id );
+
+		$parent_job = $this->jobs_db->get_job( $parent_id );
+		$this->assertEquals( JobStatus::COMPLETED_NO_ITEMS, $parent_job['status'] );
+
+		$parent_engine = datamachine_get_engine_data( $parent_id );
+		$this->assertEquals( 1, $parent_engine['batch_results']['skipped'] );
+	}
+
 	public function test_child_jobs_receive_per_item_engine_data(): void {
 		$parent_id = $this->create_parent_job();
 		$engine    = $this->make_engine_snapshot( $parent_id );

--- a/tests/job-liveness-cli-smoke.php
+++ b/tests/job-liveness-cli-smoke.php
@@ -29,11 +29,13 @@ echo "Case 1: liveness command is registered and read-only\n";
 assert_job_liveness_cli_smoke( 'liveness subcommand exists', str_contains( $source, '@subcommand liveness' ) );
 assert_job_liveness_cli_smoke( 'diagnostic queries processing jobs', str_contains( $source, "WHERE status = 'processing'" ) );
 assert_job_liveness_cli_smoke( 'diagnostic reads execute-step actions', str_contains( $source, 'datamachine_execute_step' ) );
+assert_job_liveness_cli_smoke( 'diagnostic reads pipeline batch actions', str_contains( $source, 'PipelineBatchScheduler::BATCH_HOOK' ) );
 assert_job_liveness_cli_smoke( 'diagnostic does not update database rows', ! str_contains( strstr( $source, 'public function liveness' ) ?: '', '$wpdb->update(' ) );
 
 echo "Case 2: liveness classification exposes scheduler starvation\n";
 assert_job_liveness_cli_smoke( 'scheduler-starved classification exists', str_contains( $source, "'scheduler_starved'") );
 assert_job_liveness_cli_smoke( 'queued-next-step classification exists', str_contains( $source, "'queued_next_step'") );
+assert_job_liveness_cli_smoke( 'waiting-children classification exists', str_contains( $source, "'waiting_children'") );
 assert_job_liveness_cli_smoke( 'stale-in-progress classification exists', str_contains( $source, "'stale_in_progress'") );
 assert_job_liveness_cli_smoke( 'no-scheduler-path classification exists', str_contains( $source, "'no_scheduler_path'") );
 assert_job_liveness_cli_smoke( 'overdue threshold is configurable', str_contains( $source, '[--overdue-minutes=<minutes>]' ) );


### PR DESCRIPTION
## Summary
- Rechecks pipeline batch parent completion after the final batch chunk so fully terminal children cannot leave the parent stuck in `processing` with no future scheduler owner.
- Makes `jobs liveness` batch-aware by counting pipeline batch chunk actions and active child jobs as scheduler paths instead of reporting them as `no_scheduler_path`.
- Covers the missed-finalization gap with a focused batch scheduler unit test and updates the liveness smoke test for batch ownership.

Fixes #2180.

## Verification
- `php -l inc/Abilities/Engine/PipelineBatchScheduler.php`
- `php -l inc/Cli/Commands/JobsCommand.php`
- `php -l tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php && php -l tests/job-liveness-cli-smoke.php`
- `php tests/job-liveness-cli-smoke.php`
- `vendor/bin/phpcs inc/Abilities/Engine/PipelineBatchScheduler.php inc/Cli/Commands/JobsCommand.php tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php tests/job-liveness-cli-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-issue-2180-child-finalization --extension wordpress --filter PipelineBatchSchedulerTest` passed: 1288 tests, 1285 passed, 3 skipped.

## Notes
- `vendor/bin/phpunit tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php` could not run because `vendor/bin/phpunit` is not present in this checkout; Homeboy WP Codebox was used for PHPUnit verification.
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-issue-2180-child-finalization --extension wordpress --force-hot` still reports pre-existing admin React lint findings outside the touched files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigating issue #2180, drafting the generic Data Machine fix, adding targeted coverage, and running local verification. Chris remains responsible for review and merge.