### PR TITLE
Classify empty AI packet diagnostics

### DIFF
--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -28,6 +28,10 @@ class RunMetrics {
 		'hydration_failed',
 		'hydration_partial',
 		'ai_empty_packet',
+		'ai_required_handler_not_called',
+		'ai_handler_tool_failed',
+		'ai_empty_response',
+		'ai_completion_assertions_missing',
 		'missing_handler_packet',
 		'source_rejected',
 		'item_deferred',
@@ -323,6 +327,7 @@ class RunMetrics {
 				'handler_slug'            => self::firstStepField( $engine, 'handler_slug' ),
 				'provider_id'             => self::firstStepField( $engine, 'provider_id' ),
 				'tool_ids'                => self::mergedStepListField( $engine, 'tool_ids' ),
+				'ai_diagnostic_reason'    => self::firstStepField( $engine, 'diagnostic_reason' ),
 			),
 			static fn( $value ) => null !== $value
 		);
@@ -336,7 +341,7 @@ class RunMetrics {
 			$classes = array_merge( $classes, self::classesFromStepResult( $step_result, $status ) );
 		}
 
-		foreach ( array( 'true_empty_query', 'provider_error', 'hydration_failed', 'hydration_partial', 'ai_empty_packet', 'missing_handler_packet', 'source_rejected', 'item_deferred' ) as $class ) {
+		foreach ( array( 'true_empty_query', 'provider_error', 'hydration_failed', 'hydration_partial', 'ai_empty_packet', 'ai_required_handler_not_called', 'ai_handler_tool_failed', 'ai_empty_response', 'ai_completion_assertions_missing', 'missing_handler_packet', 'source_rejected', 'item_deferred' ) as $class ) {
 			if ( ! empty( $counts[ $class ] ) ) {
 				$classes[] = $class;
 			}
@@ -349,6 +354,9 @@ class RunMetrics {
 		$result  = (string) ( $step_result['result'] ?? '' );
 		$reason  = self::outcomeReasonFrom( $step_result, $status );
 		$classes = self::classesFromReason( $reason );
+		if ( isset( $step_result['diagnostic_reason'] ) && is_scalar( $step_result['diagnostic_reason'] ) ) {
+			$classes = array_merge( $classes, self::classesFromReason( (string) $step_result['diagnostic_reason'] ) );
+		}
 
 		if ( in_array( $result, array( 'no_content', 'completed_no_items' ), true ) ) {
 			$classes[] = 'true_empty_query';
@@ -392,6 +400,18 @@ class RunMetrics {
 		}
 		if ( 'empty_data_packet_returned' === $reason ) {
 			$classes[] = 'ai_empty_packet';
+		}
+		if ( in_array( $reason, array( 'ai_required_handler_not_called', 'required_handler_tool_not_called' ), true ) ) {
+			$classes[] = 'ai_required_handler_not_called';
+		}
+		if ( 'ai_handler_tool_failed' === $reason ) {
+			$classes[] = 'ai_handler_tool_failed';
+		}
+		if ( 'ai_empty_response' === $reason ) {
+			$classes[] = 'ai_empty_response';
+		}
+		if ( in_array( $reason, array( 'ai_completion_assertions_missing', 'completion_assertions_missing' ), true ) ) {
+			$classes[] = 'ai_completion_assertions_missing';
 		}
 		if ( 'handler_requiring_step_missing_handler_packets' === $reason ) {
 			$classes[] = 'missing_handler_packet';

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -556,6 +556,20 @@ class AIStep extends Step {
 
 			$missing_assertion_failure = self::missingCompletionAssertionsFailure( $loop_result );
 			if ( null !== $missing_assertion_failure ) {
+				RunMetrics::recordStepResult(
+					$this->job_id,
+					$this->flow_step_id,
+					array(
+						'step_type'         => 'ai',
+						'result'            => 'failed',
+						'provider_id'       => $provider_name,
+						'model_id'          => $model_name,
+						'tool_ids'          => array_keys( $available_tools ),
+						'handler_slugs'     => $required_handler_slugs,
+						'packet_count'      => 0,
+						'diagnostic_reason' => 'ai_completion_assertions_missing',
+					)
+				);
 				do_action(
 					'datamachine_fail_job',
 					$this->job_id,
@@ -570,17 +584,19 @@ class AIStep extends Step {
 
 			// Process loop results into data packets
 			$processed_packets = self::processLoopResults( $loop_result, $this->dataPackets, $payload, $available_tools );
+			$diagnostic_reason = empty( $processed_packets ) ? self::emptyOutputDiagnosticReason( $loop_result, $required_handler_slugs ) : '';
 			RunMetrics::recordStepResult(
 				$this->job_id,
 				$this->flow_step_id,
 				array(
-					'step_type'     => 'ai',
-					'result'        => empty( $processed_packets ) ? 'no_content' : 'completed',
-					'provider_id'   => $provider_name,
-					'model_id'      => $model_name,
-					'tool_ids'      => array_keys( $available_tools ),
-					'handler_slugs' => $required_handler_slugs,
-					'packet_count'  => count( $processed_packets ),
+					'step_type'         => 'ai',
+					'result'            => empty( $processed_packets ) ? 'no_content' : 'completed',
+					'provider_id'       => $provider_name,
+					'model_id'          => $model_name,
+					'tool_ids'          => array_keys( $available_tools ),
+					'handler_slugs'     => $required_handler_slugs,
+					'packet_count'      => count( $processed_packets ),
+					'diagnostic_reason' => $diagnostic_reason,
 				)
 			);
 
@@ -1022,6 +1038,58 @@ class AIStep extends Step {
 		}
 
 		return $outputPackets;
+	}
+
+	/**
+	 * Explain why an AI step emitted no packets without changing terminal status semantics.
+	 *
+	 * @param array             $loop_result             Conversation loop result.
+	 * @param array<int,string> $required_handler_slugs  Handler slugs required by downstream steps.
+	 * @return string
+	 */
+	private static function emptyOutputDiagnosticReason( array $loop_result, array $required_handler_slugs ): string {
+		$tool_results      = is_array( $loop_result['tool_execution_results'] ?? null ) ? $loop_result['tool_execution_results'] : array();
+		$messages          = is_array( $loop_result['messages'] ?? null ) ? $loop_result['messages'] : array();
+		$handler_attempted = false;
+		$handler_succeeded = false;
+		$assistant_content = '';
+
+		foreach ( $tool_results as $tool_result_data ) {
+			if ( empty( $tool_result_data['is_handler_tool'] ) ) {
+				continue;
+			}
+
+			$handler_attempted = true;
+			$tool_result       = is_array( $tool_result_data['result'] ?? null ) ? $tool_result_data['result'] : array();
+			if ( ! empty( $tool_result['success'] ) ) {
+				$handler_succeeded = true;
+			}
+		}
+
+		foreach ( $messages as $message ) {
+			if ( 'assistant' !== ( $message['role'] ?? '' ) ) {
+				continue;
+			}
+
+			$content = trim( (string) ( $message['content'] ?? '' ) );
+			if ( '' !== $content ) {
+				$assistant_content = $content;
+			}
+		}
+
+		if ( ! empty( $required_handler_slugs ) && ! $handler_attempted ) {
+			return 'ai_required_handler_not_called';
+		}
+
+		if ( $handler_attempted && ! $handler_succeeded ) {
+			return 'ai_handler_tool_failed';
+		}
+
+		if ( empty( $tool_results ) && '' === $assistant_content ) {
+			return 'ai_empty_response';
+		}
+
+		return 'ai_empty_packet';
 	}
 
 	/**

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -584,7 +584,7 @@ class AIStep extends Step {
 
 			// Process loop results into data packets
 			$processed_packets = self::processLoopResults( $loop_result, $this->dataPackets, $payload, $available_tools );
-			$diagnostic_reason = empty( $processed_packets ) ? self::emptyOutputDiagnosticReason( $loop_result, $required_handler_slugs ) : '';
+			$diagnostic_reason = self::outputDiagnosticReason( $loop_result, $required_handler_slugs, $processed_packets );
 			RunMetrics::recordStepResult(
 				$this->job_id,
 				$this->flow_step_id,
@@ -1041,7 +1041,43 @@ class AIStep extends Step {
 	}
 
 	/**
-	 * Explain why an AI step emitted no packets without changing terminal status semantics.
+	 * Explain why AI step output cannot satisfy downstream packet requirements.
+	 *
+	 * @param array             $loop_result             Conversation loop result.
+	 * @param array<int,string> $required_handler_slugs  Handler slugs required by downstream steps.
+	 * @param array             $processed_packets       Data packets emitted by the AI step.
+	 * @return string
+	 */
+	private static function outputDiagnosticReason( array $loop_result, array $required_handler_slugs, array $processed_packets ): string {
+		if ( ! empty( $required_handler_slugs ) && ! self::hasHandlerCompletePacket( $processed_packets ) ) {
+			return self::emptyOutputDiagnosticReason( $loop_result, $required_handler_slugs );
+		}
+
+		if ( empty( $processed_packets ) ) {
+			return self::emptyOutputDiagnosticReason( $loop_result, $required_handler_slugs );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Check whether processed output includes a handler completion packet.
+	 *
+	 * @param array $processed_packets Data packets emitted by the AI step.
+	 * @return bool
+	 */
+	private static function hasHandlerCompletePacket( array $processed_packets ): bool {
+		foreach ( $processed_packets as $packet ) {
+			if ( 'ai_handler_complete' === ( $packet['type'] ?? '' ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Explain why an AI step output cannot satisfy downstream handler requirements.
 	 *
 	 * @param array             $loop_result             Conversation loop result.
 	 * @param array<int,string> $required_handler_slugs  Handler slugs required by downstream steps.

--- a/tests/job-outcome-metrics-smoke.php
+++ b/tests/job-outcome-metrics-smoke.php
@@ -131,17 +131,38 @@ $metrics = RunMetrics::fromJob(
 		array(
 			'step_results' => array(
 				'ai_1' => array(
-					'flow_step_id' => 'ai_1',
-					'step_type'    => 'ai',
-					'result'       => 'failed',
-					'reason'       => 'empty_data_packet_returned',
-					'packet_count' => 0,
+					'flow_step_id'      => 'ai_1',
+					'step_type'         => 'ai',
+					'result'            => 'failed',
+					'reason'            => 'empty_data_packet_returned',
+					'diagnostic_reason' => 'ai_required_handler_not_called',
+					'packet_count'      => 0,
 				),
 			),
 		)
 	)
 );
-$assert( 'AI empty packet class is exposed from step result', array( 'ai_empty_packet' ) === $metrics['outcome_classes'] );
+$assert( 'AI empty packet class is exposed from step result', in_array( 'ai_empty_packet', $metrics['outcome_classes'], true ) );
+$assert( 'AI handler-not-called diagnostic class is exposed from step result', in_array( 'ai_required_handler_not_called', $metrics['outcome_classes'], true ) );
+$assert( 'AI diagnostic reason is exposed in outcome details', 'ai_required_handler_not_called' === ( $metrics['outcome']['ai_diagnostic_reason'] ?? '' ) );
+
+$metrics = RunMetrics::fromJob(
+	$job(
+		'failed - completion_assertions_missing',
+		array(
+			'step_results' => array(
+				'ai_1' => array(
+					'flow_step_id'      => 'ai_1',
+					'step_type'         => 'ai',
+					'result'            => 'failed',
+					'diagnostic_reason' => 'ai_completion_assertions_missing',
+					'packet_count'      => 0,
+				),
+			),
+		)
+	)
+);
+$assert( 'AI assertion diagnostic class is exposed', in_array( 'ai_completion_assertions_missing', $metrics['outcome_classes'], true ) );
 
 $metrics = RunMetrics::fromJob(
 	$job(

--- a/tests/upsert-handler-result-handoff-smoke.php
+++ b/tests/upsert-handler-result-handoff-smoke.php
@@ -150,6 +150,7 @@ assert_handoff_equals( array( 'fixed_parent_path' => 'woocommerce' ), $available
 assert_handoff_equals( array( 'fixed_parent_path' => 'woocommerce' ), $available_tools['wiki_upsert']['config_seen'] ?? null, 'handler callback still receives the same config', $failures, $passes );
 
 $method = new ReflectionMethod( AIStep::class, 'processLoopResults' );
+$output_diagnostic_method = new ReflectionMethod( AIStep::class, 'outputDiagnosticReason' );
 $diagnostic_method = new ReflectionMethod( AIStep::class, 'emptyOutputDiagnosticReason' );
 
 $packets = $method->invoke(
@@ -188,6 +189,32 @@ assert_handoff_equals( 'wiki_upsert', $packets[0]['metadata']['handler_tool'] ??
 
 $found = ToolResultFinder::findHandlerResult( $packets, 'wiki_upsert', 'upsert_step', false );
 assert_handoff_equals( $packets[0], $found, 'ToolResultFinder finds packet by required handler slug', $failures, $passes );
+
+$diagnostic = $output_diagnostic_method->invoke(
+	null,
+	array(
+		'messages'               => array(
+			array( 'role' => 'assistant', 'content' => 'I summarized the source but did not write the article.' ),
+		),
+		'tool_execution_results' => array(),
+	),
+	array( 'wiki_upsert' ),
+	array(
+		array(
+			'type' => 'ai_response',
+			'data' => array( 'content' => 'I summarized the source but did not write the article.' ),
+		),
+	)
+);
+assert_handoff_equals( 'ai_required_handler_not_called', $diagnostic, 'AI non-handler output records missing handler diagnostic', $failures, $passes );
+
+$diagnostic = $output_diagnostic_method->invoke(
+	null,
+	array( 'tool_execution_results' => array() ),
+	array( 'wiki_upsert' ),
+	$packets
+);
+assert_handoff_equals( '', $diagnostic, 'AI handler-complete output records no diagnostic', $failures, $passes );
 
 $diagnostic = $diagnostic_method->invoke(
 	null,

--- a/tests/upsert-handler-result-handoff-smoke.php
+++ b/tests/upsert-handler-result-handoff-smoke.php
@@ -51,6 +51,10 @@ function get_option( string $key, $default_value = false ) {
 	return $default_value;
 }
 
+function wp_json_encode( $value, int $flags = 0, int $depth = 512 ) {
+	return json_encode( $value, $flags, $depth );
+}
+
 require_once __DIR__ . '/../inc/Core/DataPacket.php';
 require_once __DIR__ . '/../inc/Core/PluginSettings.php';
 require_once __DIR__ . '/../inc/Core/Steps/Step.php';
@@ -146,6 +150,7 @@ assert_handoff_equals( array( 'fixed_parent_path' => 'woocommerce' ), $available
 assert_handoff_equals( array( 'fixed_parent_path' => 'woocommerce' ), $available_tools['wiki_upsert']['config_seen'] ?? null, 'handler callback still receives the same config', $failures, $passes );
 
 $method = new ReflectionMethod( AIStep::class, 'processLoopResults' );
+$diagnostic_method = new ReflectionMethod( AIStep::class, 'emptyOutputDiagnosticReason' );
 
 $packets = $method->invoke(
 	null,
@@ -183,6 +188,43 @@ assert_handoff_equals( 'wiki_upsert', $packets[0]['metadata']['handler_tool'] ??
 
 $found = ToolResultFinder::findHandlerResult( $packets, 'wiki_upsert', 'upsert_step', false );
 assert_handoff_equals( $packets[0], $found, 'ToolResultFinder finds packet by required handler slug', $failures, $passes );
+
+$diagnostic = $diagnostic_method->invoke(
+	null,
+	array(
+		'messages'               => array(
+			array( 'role' => 'assistant', 'content' => 'I could not find enough useful material.' ),
+		),
+		'tool_execution_results' => array(),
+	),
+	array( 'wiki_upsert' )
+);
+assert_handoff_equals( 'ai_required_handler_not_called', $diagnostic, 'AI empty output records missing handler diagnostic', $failures, $passes );
+
+$diagnostic = $diagnostic_method->invoke(
+	null,
+	array(
+		'tool_execution_results' => array(
+			array(
+				'tool_name'       => 'wiki_upsert',
+				'result'          => array( 'success' => false, 'message' => 'quality gate rejected' ),
+				'is_handler_tool' => true,
+			),
+		),
+	),
+	array( 'wiki_upsert' )
+);
+assert_handoff_equals( 'ai_handler_tool_failed', $diagnostic, 'AI empty output records failed handler diagnostic', $failures, $passes );
+
+$diagnostic = $diagnostic_method->invoke(
+	null,
+	array(
+		'messages'               => array(),
+		'tool_execution_results' => array(),
+	),
+	array()
+);
+assert_handoff_equals( 'ai_empty_response', $diagnostic, 'AI empty output records empty response diagnostic', $failures, $passes );
 
 echo "\n------------------------------------------\n";
 echo "{$passes} / " . ( $passes + count( $failures ) ) . " passed\n";


### PR DESCRIPTION
## Summary
- Record an `AIStep` diagnostic reason when the AI loop emits no downstream packets, without changing the existing terminal status semantics.
- Surface diagnostic outcome classes such as `ai_required_handler_not_called`, `ai_handler_tool_failed`, `ai_empty_response`, and `ai_completion_assertions_missing` through run metrics.
- Extend smoke coverage for metrics and handler handoff diagnostics.

## Verification
- `php tests/job-outcome-metrics-smoke.php`
- `php tests/upsert-handler-result-handoff-smoke.php`
- `php -l inc/Core/Steps/AI/AIStep.php && php -l inc/Core/RunMetrics.php && php -l tests/job-outcome-metrics-smoke.php && php -l tests/upsert-handler-result-handoff-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-ai-empty-packet-diagnostics --extension wordpress`

## Notes
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-ai-empty-packet-diagnostics --extension wordpress` still reports existing frontend/admin lint debt outside the modified PHP files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed live empty-packet metrics, drafted the diagnostic classification change and smoke coverage, and ran verification for Chris to review.