### PR TITLE
Require handler completion before natural finish

### DIFF
--- a/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
+++ b/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
@@ -114,6 +114,19 @@ class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Comple
 	 * @inheritDoc
 	 */
 	public function recordNaturalCompletion( array $messages, string $assistant_text, array $runtime_context, int $turn_count ): WP_Agent_Conversation_Completion_Decision {
+		$remaining_handlers = $this->remainingConfiguredHandlers();
+		if ( ! empty( $remaining_handlers ) ) {
+			return WP_Agent_Conversation_Completion_Decision::incomplete(
+				'AIConversationLoop: Configured handler completion missing, nudging continuation',
+				array(
+					'turn_count'           => $turn_count,
+					'remaining_handlers'   => $remaining_handlers,
+					'configured_handlers'  => $this->configured_handlers,
+					'continuation_message' => DataMachineCompletionAssertions::buildNudge( array( 'handler_slugs' => $remaining_handlers ), $messages ),
+				)
+			);
+		}
+
 		$evaluation = $this->assertions->evaluate( $runtime_context, $assistant_text );
 		if ( $evaluation['complete'] ) {
 			return WP_Agent_Conversation_Completion_Decision::complete(
@@ -135,6 +148,19 @@ class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Comple
 				'continuation_message' => DataMachineCompletionAssertions::buildNudge( $evaluation['missing'], $messages ),
 			)
 		);
+	}
+
+	/**
+	 * Return configured handler slugs that have not completed yet.
+	 *
+	 * @return array<int,string>
+	 */
+	private function remainingConfiguredHandlers(): array {
+		if ( empty( $this->configured_handlers ) ) {
+			return array();
+		}
+
+		return array_values( array_diff( $this->configured_handlers, array_unique( $this->executed_handler_slugs ) ) );
 	}
 
 	/**

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -224,6 +224,16 @@ assert_runtime_policy( array( 'pinterest_publish' ) === ( $first_decision->conte
 assert_runtime_policy( $second_decision->isComplete(), 'handler policy completes after all configured handlers fire' );
 assert_runtime_policy( array( 'wordpress_publish', 'pinterest_publish' ) === array_values( $second_decision->context()['executed_handlers'] ?? array() ), 'handler policy reports executed handlers' );
 
+$natural_before_handler_policy   = new DataMachineHandlerCompletionPolicy( array( 'wiki_upsert' ) );
+$natural_before_handler_decision = $natural_before_handler_policy->recordNaturalCompletion(
+	array( array( 'role' => 'user', 'content' => 'write the wiki article' ) ),
+	'I summarized the source.',
+	array( 'mode' => 'pipeline' ),
+	1
+);
+assert_runtime_policy( ! $natural_before_handler_decision->isComplete(), 'handler policy rejects natural completion before configured handlers fire' );
+assert_runtime_policy( array( 'wiki_upsert' ) === ( $natural_before_handler_decision->context()['remaining_handlers'] ?? null ), 'handler policy reports remaining handlers on natural completion' );
+
 // 2. Injected completion/transcript collaborators steer the loop without leaking into provider payloads.
 $natural_dispatch_count = 0;
 WpAiClientTestDouble::reset();


### PR DESCRIPTION
## Summary
- Keep pipeline conversations incomplete when configured adjacent handlers have not completed yet, even if the assistant naturally finishes.
- Report remaining handler slugs in the completion decision context so missing handler handoffs stay diagnosable.
- Add smoke coverage for natural completion before `wiki_upsert` runs.

## Verification
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `php -l inc/Engine/AI/DataMachineHandlerCompletionPolicy.php && php -l tests/agent-conversation-runtime-policy-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-handler-natural-completion --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the handler completion policy gap, drafted the targeted fix and smoke coverage, and ran verification for Chris to review.