### PR TITLE
fix: report chat list message counts

### DIFF
--- a/inc/Cli/Commands/ChatCommand.php
+++ b/inc/Cli/Commands/ChatCommand.php
@@ -132,12 +132,12 @@ class ChatCommand extends BaseCommand {
 		// Flatten for display.
 		$display_items = array();
 		foreach ( $sessions as $session ) {
-			$metadata        = $session['metadata'] ?? array();
+			$metadata        = is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array();
 			$display_items[] = array(
 				'session_id'    => $session['session_id'],
 				'title'         => $session['title'] ?? '(untitled)',
 				'mode'          => $session['mode'] ?? 'chat',
-				'message_count' => $metadata['message_count'] ?? 0,
+				'message_count' => self::get_session_message_count( $session ),
 				'created_at'    => $metadata['started_at'] ?? $session['created_at'] ?? '-',
 			);
 		}
@@ -147,6 +147,26 @@ class ChatCommand extends BaseCommand {
 
 		$format = $assoc_args['format'] ?? 'table';
 		$this->output_pagination( $offset, count( $sessions ), $total, $format, 'sessions' );
+	}
+
+	/**
+	 * Resolve the message count for a session summary row.
+	 *
+	 * @param array $session Session summary or full session payload.
+	 * @return int
+	 */
+	private static function get_session_message_count( array $session ): int {
+		if ( isset( $session['message_count'] ) && is_numeric( $session['message_count'] ) ) {
+			return max( 0, (int) $session['message_count'] );
+		}
+
+		$metadata = is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array();
+		if ( isset( $metadata['message_count'] ) && is_numeric( $metadata['message_count'] ) ) {
+			return max( 0, (int) $metadata['message_count'] );
+		}
+
+		$messages = $session['messages'] ?? null;
+		return is_array( $messages ) ? count( $messages ) : 0;
 	}
 
 	/**

--- a/tests/chat-list-message-count-smoke.php
+++ b/tests/chat-list-message-count-smoke.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Pure-PHP smoke test for chat list message count resolution.
+ *
+ * Run with: php tests/chat-list-message-count-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! class_exists( 'WP_CLI_Command' ) ) {
+	class WP_CLI_Command {}
+}
+
+require_once __DIR__ . '/../inc/Cli/BaseCommand.php';
+require_once __DIR__ . '/../inc/Cli/Commands/ChatCommand.php';
+
+$failures = array();
+$passes   = 0;
+
+$assert_same = static function ( int $expected, int $actual, string $label ) use ( &$failures, &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	$failures[] = sprintf( '%s (expected %d, got %d)', $label, $expected, $actual );
+	echo "FAIL: {$label}\n";
+};
+
+echo "chat-list-message-count-smoke\n";
+
+$method = new ReflectionMethod( DataMachine\Cli\Commands\ChatCommand::class, 'get_session_message_count' );
+
+$count_messages = static function ( array $session ) use ( $method ): int {
+	return (int) $method->invoke( null, $session );
+};
+
+$assert_same( 8, $count_messages( array( 'message_count' => 8 ) ), 'uses top-level session index count' );
+$assert_same( 4, $count_messages( array( 'metadata' => array( 'message_count' => 4 ) ) ), 'falls back to metadata count' );
+$assert_same(
+	2,
+	$count_messages(
+		array(
+			'messages' => array(
+				array( 'role' => 'user', 'content' => 'hello' ),
+				array( 'role' => 'assistant', 'content' => 'hi' ),
+			),
+		)
+	),
+	'falls back to full message array count'
+);
+$assert_same(
+	8,
+	$count_messages(
+		array(
+			'message_count' => 8,
+			'metadata'      => array( 'message_count' => 0 ),
+		)
+	),
+	'prefers top-level session index count over stale metadata'
+);
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " chat list message count assertions failed.\n";
+	foreach ( $failures as $failure ) {
+		echo "- {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nAll {$passes} chat list message count assertions passed.\n";


### PR DESCRIPTION
## Summary
- Fixes `wp datamachine chat list` to read `message_count` from the session index summary rows returned by the chat store.
- Keeps fallbacks for legacy metadata/full-session payloads so list output stays accurate across supported shapes.
- Adds a pure-PHP smoke test covering persisted sessions with top-level message counts.

Fixes #2183.

## Testing
- `php -l inc/Cli/Commands/ChatCommand.php`
- `php -l tests/chat-list-message-count-smoke.php`
- `php tests/chat-list-message-count-smoke.php`
- `vendor/bin/phpcs inc/Cli/Commands/ChatCommand.php tests/chat-list-message-count-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-chat-list-message-count --extension wordpress` — 1287 tests, 0 failed, 3 skipped

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the CLI message-count fix, added the smoke test, and ran local verification; Chris remains responsible for review and merge.