### PR TITLE
fix: protect active batch parents during recovery

### DIFF
--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -121,6 +121,20 @@ class PipelineBatchScheduler {
 	 * @param int $parent_job_id The parent job ID.
 	 */
 	public function processChunk( int $parent_job_id ): void {
+		$parent_job = $this->db_jobs->get_job( $parent_job_id );
+		if ( ! $parent_job || JobStatus::PROCESSING !== ( $parent_job['status'] ?? '' ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Pipeline batch: skipped chunk because parent is no longer processing',
+				array(
+					'parent_job_id' => $parent_job_id,
+					'parent_status' => $parent_job['status'] ?? 'missing',
+				)
+			);
+			return;
+		}
+
 		$result = BatchScheduler::processChunk(
 			$parent_job_id,
 			array( $this, 'createChildJobFromBatch' )

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -210,13 +210,13 @@ class RecoverStuckJobsAbility {
 			$job_id      = (int) $job->job_id;
 			$job_flow_id = (int) $job->flow_id;
 
-			if ( $this->hasActiveStepAction( $job_id, $timeout_hours ) ) {
+			if ( $this->hasActiveSchedulerWork( $job_id, $engine_data, $timeout_hours ) ) {
 				++$skipped;
 				$jobs[] = array(
 					'job_id'  => $job_id,
 					'flow_id' => $job_flow_id,
 					'status'  => 'skipped',
-					'reason'  => 'Pending or in-progress Action Scheduler step action exists',
+					'reason'  => 'Pending or in-progress scheduler work exists',
 				);
 				continue;
 			}
@@ -436,7 +436,27 @@ class RecoverStuckJobsAbility {
 	}
 
 	/**
-	 * Check whether Action Scheduler still owns executable work for a job.
+	 * Check whether scheduler or child work still owns executable work for a job.
+	 *
+	 * @param int                  $job_id Job ID.
+	 * @param array<string, mixed> $engine_data Job engine data.
+	 * @param int                  $timeout_hours Hours before in-progress actions are considered stale.
+	 * @return bool True when pending or fresh in-progress work exists.
+	 */
+	private function hasActiveSchedulerWork( int $job_id, array $engine_data, int $timeout_hours ): bool {
+		if ( $this->hasActiveStepAction( $job_id, $timeout_hours ) ) {
+			return true;
+		}
+
+		if ( $this->hasActiveBatchWork( $job_id, $engine_data, $timeout_hours ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check whether Action Scheduler still owns executable step work for a job.
 	 *
 	 * Pipeline jobs can stay in the `processing` state across multiple scheduled
 	 * steps. If a later `datamachine_execute_step` action is still pending or
@@ -501,34 +521,150 @@ class RecoverStuckJobsAbility {
 	}
 
 	/**
+	 * Check whether a pipeline batch parent still has scheduled chunk or child work.
+	 *
+	 * Batch parents wait on `datamachine_pipeline_batch_chunk` actions and child jobs,
+	 * not `datamachine_execute_step` actions. Treat both as live work so recovery
+	 * does not fail a parent while fan-out is still queued or children are active.
+	 *
+	 * @param int                  $parent_job_id Parent job ID.
+	 * @param array<string, mixed> $engine_data Parent engine data.
+	 * @param int                  $timeout_hours Hours before in-progress actions are considered stale.
+	 * @return bool True when batch chunk or child work is still active.
+	 */
+	private function hasActiveBatchWork( int $parent_job_id, array $engine_data, int $timeout_hours ): bool {
+		if ( $parent_job_id <= 0 || empty( $engine_data['batch'] ) ) {
+			return false;
+		}
+
+		if ( $this->hasActiveActionForArg( 'datamachine_pipeline_batch_chunk', 'parent_job_id', $parent_job_id, $timeout_hours ) ) {
+			return true;
+		}
+
+		global $wpdb;
+		$jobs_table = $wpdb->prefix . 'datamachine_jobs';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
+		$active_children = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*)
+				 FROM {$jobs_table}
+				 WHERE parent_job_id = %d
+				 AND status IN ( %s, %s )",
+				$parent_job_id,
+				'pending',
+				'processing'
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return $active_children > 0;
+	}
+
+	/**
+	 * Check for a pending or fresh in-progress Action Scheduler action by arg ID.
+	 *
+	 * @param string $hook Action hook.
+	 * @param string $arg_name Numeric argument name to match.
+	 * @param int    $arg_id Expected numeric argument value.
+	 * @param int    $timeout_hours Hours before in-progress actions are considered stale.
+	 * @return bool True when matching action is pending or freshly in-progress.
+	 */
+	private function hasActiveActionForArg( string $hook, string $arg_name, int $arg_id, int $timeout_hours ): bool {
+		global $wpdb;
+
+		if ( $arg_id <= 0 ) {
+			return false;
+		}
+
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$like_arg_id   = '%"' . $wpdb->esc_like( $arg_name ) . '":' . $wpdb->esc_like( (string) $arg_id ) . '%';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
+		$actions = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT action_id, args, status, scheduled_date_gmt, last_attempt_gmt
+				 FROM {$actions_table}
+				 WHERE hook = %s
+				 AND status IN ( %s, %s )
+				 AND args LIKE %s",
+				$hook,
+				'pending',
+				'in-progress',
+				$like_arg_id
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$timeout_seconds = max( 1, $timeout_hours ) * HOUR_IN_SECONDS;
+		$now_gmt         = strtotime( current_time( 'mysql', true ) );
+
+		foreach ( $actions as $action ) {
+			if ( $arg_id !== $this->extractActionArgInt( (string) ( $action->args ?? '' ), $arg_name ) ) {
+				continue;
+			}
+
+			if ( 'pending' === (string) $action->status ) {
+				return true;
+			}
+
+			$last_attempt = (string) ( $action->last_attempt_gmt ?? '' );
+			$scheduled    = (string) ( $action->scheduled_date_gmt ?? '' );
+			$reference    = $last_attempt && '0000-00-00 00:00:00' !== $last_attempt ? $last_attempt : $scheduled;
+			$started_at   = $reference ? strtotime( $reference ) : false;
+
+			if ( false === $started_at || false === $now_gmt ) {
+				return true;
+			}
+
+			if ( ( $now_gmt - $started_at ) < $timeout_seconds ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Extract the Data Machine job ID from Action Scheduler args.
 	 *
 	 * @param string $args Action Scheduler args payload.
 	 * @return int Job ID, or 0 when unavailable.
 	 */
 	private function extractActionJobId( string $args ): int {
+		return $this->extractActionArgInt( $args, 'job_id' );
+	}
+
+	/**
+	 * Extract a numeric argument from an Action Scheduler args payload.
+	 *
+	 * @param string $args Action Scheduler args payload.
+	 * @param string $arg_name Argument name to extract.
+	 * @return int Argument value, or 0 when unavailable.
+	 */
+	private function extractActionArgInt( string $args, string $arg_name ): int {
 		$decoded = json_decode( $args, true );
 		if ( is_array( $decoded ) ) {
-			if ( isset( $decoded['job_id'] ) && is_numeric( $decoded['job_id'] ) ) {
-				return (int) $decoded['job_id'];
+			if ( isset( $decoded[ $arg_name ] ) && is_numeric( $decoded[ $arg_name ] ) ) {
+				return (int) $decoded[ $arg_name ];
 			}
 
 			foreach ( $decoded as $value ) {
-				if ( is_array( $value ) && isset( $value['job_id'] ) && is_numeric( $value['job_id'] ) ) {
-					return (int) $value['job_id'];
+				if ( is_array( $value ) && isset( $value[ $arg_name ] ) && is_numeric( $value[ $arg_name ] ) ) {
+					return (int) $value[ $arg_name ];
 				}
 			}
 		}
 
 		$unserialized = maybe_unserialize( $args );
 		if ( is_array( $unserialized ) ) {
-			if ( isset( $unserialized['job_id'] ) && is_numeric( $unserialized['job_id'] ) ) {
-				return (int) $unserialized['job_id'];
+			if ( isset( $unserialized[ $arg_name ] ) && is_numeric( $unserialized[ $arg_name ] ) ) {
+				return (int) $unserialized[ $arg_name ];
 			}
 
 			foreach ( $unserialized as $value ) {
-				if ( is_array( $value ) && isset( $value['job_id'] ) && is_numeric( $value['job_id'] ) ) {
-					return (int) $value['job_id'];
+				if ( is_array( $value ) && isset( $value[ $arg_name ] ) && is_numeric( $value[ $arg_name ] ) ) {
+					return (int) $value[ $arg_name ];
 				}
 			}
 		}

--- a/tests/pipeline-batch-terminal-parent-guard-smoke.php
+++ b/tests/pipeline-batch-terminal-parent-guard-smoke.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Static smoke test for terminal parent guard in pipeline batch chunks.
+ *
+ * Run with: php tests/pipeline-batch-terminal-parent-guard-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failed = 0;
+$total  = 0;
+
+function assert_pipeline_batch_terminal_guard_smoke( string $name, bool $condition, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+
+	if ( $condition ) {
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+
+	echo "  [FAIL] {$name}" . ( $detail ? " - {$detail}" : '' ) . "\n";
+	++$failed;
+}
+
+$source        = file_get_contents( __DIR__ . '/../inc/Abilities/Engine/PipelineBatchScheduler.php' ) ?: '';
+$process_chunk = strstr( $source, 'public function processChunk' ) ?: '';
+
+echo "Case 1: batch chunks refuse terminal parents\n";
+assert_pipeline_batch_terminal_guard_smoke( 'processChunk reads parent job before processing batch state', strpos( $process_chunk, '$parent_job = $this->db_jobs->get_job( $parent_job_id );' ) < strpos( $process_chunk, 'BatchScheduler::processChunk' ) );
+assert_pipeline_batch_terminal_guard_smoke( 'processChunk requires processing status', str_contains( $process_chunk, 'JobStatus::PROCESSING !== ( $parent_job[\'status\'] ?? \'\' )' ) );
+assert_pipeline_batch_terminal_guard_smoke( 'terminal parent guard returns before child creation', strpos( $process_chunk, 'return;' ) < strpos( $process_chunk, 'BatchScheduler::processChunk' ) );
+assert_pipeline_batch_terminal_guard_smoke( 'terminal parent guard logs skipped chunk', str_contains( $process_chunk, 'Pipeline batch: skipped chunk because parent is no longer processing' ) );
+
+echo "\nPipeline batch terminal parent guard smoke complete: {$total} assertions, {$failed} failures.\n";
+if ( $failed > 0 ) {
+	exit( 1 );
+}

--- a/tests/recover-stuck-active-action-guard-smoke.php
+++ b/tests/recover-stuck-active-action-guard-smoke.php
@@ -26,10 +26,11 @@ function assert_recover_stuck_guard_smoke( string $name, bool $condition, string
 $source = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RecoverStuckJobsAbility.php' ) ?: '';
 $timeout_loop = strstr( $source, 'foreach ( $timed_out_jobs as $job )' ) ?: '';
 
-echo "Case 1: timed-out recovery skips jobs with active step actions\n";
+echo "Case 1: timed-out recovery skips jobs with active scheduler work\n";
+assert_recover_stuck_guard_smoke( 'active scheduler work method exists', str_contains( $source, 'private function hasActiveSchedulerWork' ) );
 assert_recover_stuck_guard_smoke( 'active step guard method exists', str_contains( $source, 'private function hasActiveStepAction' ) );
-assert_recover_stuck_guard_smoke( 'timeout loop invokes active step guard before dry-run timeout', strpos( $timeout_loop, '$this->hasActiveStepAction( $job_id, $timeout_hours )' ) < strpos( $timeout_loop, 'if ( $dry_run )' ) );
-assert_recover_stuck_guard_smoke( 'guard records skipped status', str_contains( $source, "'status'  => 'skipped'") && str_contains( $source, 'Pending or in-progress Action Scheduler step action exists' ) );
+assert_recover_stuck_guard_smoke( 'timeout loop invokes scheduler guard before dry-run timeout', strpos( $timeout_loop, '$this->hasActiveSchedulerWork( $job_id, $engine_data, $timeout_hours )' ) < strpos( $timeout_loop, 'if ( $dry_run )' ) );
+assert_recover_stuck_guard_smoke( 'guard records skipped status', str_contains( $source, "'status'  => 'skipped'") && str_contains( $source, 'Pending or in-progress scheduler work exists' ) );
 
 echo "Case 2: guard is limited to executable Data Machine step actions\n";
 assert_recover_stuck_guard_smoke( 'guard queries datamachine_execute_step', str_contains( $source, 'datamachine_execute_step' ) );
@@ -41,6 +42,12 @@ assert_recover_stuck_guard_smoke( 'guard receives timeout window', str_contains(
 assert_recover_stuck_guard_smoke( 'guard reads action attempt timestamps', str_contains( $source, 'last_attempt_gmt' ) && str_contains( $source, 'scheduled_date_gmt' ) );
 assert_recover_stuck_guard_smoke( 'pending actions remain guarded unconditionally', str_contains( $source, 'if ( \'pending\' === (string) $action->status )' ) );
 assert_recover_stuck_guard_smoke( 'old in-progress actions can fall through', str_contains( $source, '( $now_gmt - $started_at ) < $timeout_seconds' ) );
+
+echo "Case 4: batch parents guard chunk actions and active children\n";
+assert_recover_stuck_guard_smoke( 'active batch guard method exists', str_contains( $source, 'private function hasActiveBatchWork' ) );
+assert_recover_stuck_guard_smoke( 'batch guard checks pipeline chunk actions', str_contains( $source, 'datamachine_pipeline_batch_chunk' ) && str_contains( $source, 'parent_job_id' ) );
+assert_recover_stuck_guard_smoke( 'batch guard checks active children', str_contains( $source, 'WHERE parent_job_id = %d' ) && str_contains( $source, "status IN ( %s, %s )" ) );
+assert_recover_stuck_guard_smoke( 'generic action arg extractor supports parent ids', str_contains( $source, 'private function extractActionArgInt' ) && str_contains( $source, '$this->extractActionArgInt( (string) ( $action->args ?? \'\' ), $arg_name )' ) );
 
 echo "\nRecover-stuck active action guard smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary
- Keep `recover-stuck` from timing out batch parent jobs while pending/fresh batch chunk actions or active children still own the work.
- Skip late pipeline batch chunk actions when their parent job is already terminal, so they cannot create children under a failed/completed parent.
- Add smoke coverage for the batch recovery guard and terminal-parent chunk guard.

## Live evidence
- On `intelligence.horse`, Matt batch parents `107579` and `107598` were marked failed by recover-stuck at `2026-05-22 20:05:09` while their delayed `datamachine_pipeline_batch_chunk` actions (`281336`, `281342`) later created pending child jobs at `20:16:44` / `20:16:46`.
- No processed-item rows existed for those failed parents or their pending children, so the issue was scheduler lifecycle classification rather than dedupe poisoning.

## Testing
- `php tests/recover-stuck-active-action-guard-smoke.php && php tests/pipeline-batch-terminal-parent-guard-smoke.php && php tests/recover-stuck-cli-output-smoke.php && php tests/recover-stuck-terminal-actions-smoke.php && php tests/batch-completion-strategy-smoke.php && php tests/batch-child-agent-id-smoke.php`
- `./vendor/bin/phpcs inc/Abilities/Job/RecoverStuckJobsAbility.php inc/Abilities/Engine/PipelineBatchScheduler.php tests/recover-stuck-active-action-guard-smoke.php tests/pipeline-batch-terminal-parent-guard-smoke.php`
- `homeboy test --path "/Users/chubes/Developer/data-machine@fix-batch-parent-recovery-guard" --extension wordpress` (`1287` tests, `0` failures, `3` skipped)

## Notes
- Full `homeboy lint` remains blocked by pre-existing unrelated frontend ESLint findings in React admin files, including `eslint.no-alert` and `@wordpress/dependency-group` issues.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated live batch recovery failures, drafted the scoped PHP fix and smoke tests, and ran verification; Chris remains responsible for review and merge.