### PR TITLE
Fix jobs stuck after next-step scheduling failures

### DIFF
--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -128,6 +128,12 @@ class ScheduleNextStepAbility {
 							'flow_step_id' => $flow_step_id,
 						)
 					);
+					$this->failScheduling(
+						$job_id,
+						$flow_step_id,
+						'missing_flow_id_during_data_storage',
+						array( 'packet_count' => count( $dataPackets ) )
+					);
 					return array(
 						'success' => false,
 						'error'   => 'Flow ID missing during data storage.',
@@ -180,9 +186,53 @@ class ScheduleNextStepAbility {
 			);
 		}
 
+		if ( false === $action_id ) {
+			$this->failScheduling(
+				$job_id,
+				$flow_step_id,
+				'next_step_schedule_failed',
+				array( 'packet_count' => count( $dataPackets ) )
+			);
+		}
+
 		return array(
 			'success'   => false !== $action_id,
 			'action_id' => $action_id,
+		);
+	}
+
+	/**
+	 * Route next-step scheduling failures through the normal job failure policy.
+	 *
+	 * The caller reaches this ability through do_action(), so a false return value
+	 * is not observable by ExecuteStepAbility. Failing here preserves the liveness
+	 * invariant: a job that cannot schedule its required next step is either
+	 * requeued by JobRetryPolicy or completed as failed, never left processing
+	 * without scheduler ownership.
+	 *
+	 * @param int    $job_id       Job ID.
+	 * @param string $flow_step_id Next flow step that could not be scheduled.
+	 * @param string $reason       Failure reason.
+	 * @param array  $context      Additional failure context.
+	 */
+	private function failScheduling( int $job_id, string $flow_step_id, string $reason, array $context = array() ): void {
+		if ( $job_id <= 0 || '' === $flow_step_id ) {
+			return;
+		}
+
+		do_action(
+			'datamachine_fail_job',
+			$job_id,
+			'step_execution_failure',
+			array_merge(
+				array(
+					'flow_step_id'      => $flow_step_id,
+					'next_flow_step_id' => $flow_step_id,
+					'reason'            => $reason,
+					'retryable'         => true,
+				),
+				$context
+			)
 		);
 	}
 }

--- a/tests/schedule-next-step-failure-smoke.php
+++ b/tests/schedule-next-step-failure-smoke.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Static smoke test for next-step scheduling failure ownership.
+ *
+ * Run with: php tests/schedule-next-step-failure-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failed = 0;
+$total  = 0;
+
+function assert_schedule_next_step_failure_smoke( string $name, bool $condition, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+
+	if ( $condition ) {
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+
+	echo "  [FAIL] {$name}" . ( $detail ? " - {$detail}" : '' ) . "\n";
+	++$failed;
+}
+
+$source  = file_get_contents( __DIR__ . '/../inc/Abilities/Engine/ScheduleNextStepAbility.php' ) ?: '';
+$execute = strstr( $source, 'public function execute' ) ?: '';
+$helper  = strstr( $source, 'private function failScheduling' ) ?: '';
+
+echo "Case 1: schedule-next-step owns Action Scheduler failures\n";
+assert_schedule_next_step_failure_smoke( 'helper exists', str_contains( $source, 'private function failScheduling' ) );
+assert_schedule_next_step_failure_smoke( 'action scheduler failure is checked', str_contains( $execute, 'if ( false === $action_id )' ) );
+assert_schedule_next_step_failure_smoke( 'failed scheduling routes through helper', str_contains( $execute, "'next_step_schedule_failed'") );
+assert_schedule_next_step_failure_smoke( 'helper failure happens before returning action result', strpos( $execute, 'if ( false === $action_id )' ) < strpos( $execute, "'success'   => false !== $" . 'action_id' ) );
+
+echo "Case 2: unscheduled jobs are requeued or finalized through fail-job\n";
+assert_schedule_next_step_failure_smoke( 'helper calls fail-job action', str_contains( $helper, "'datamachine_fail_job'") );
+assert_schedule_next_step_failure_smoke( 'failure carries current next step id for retry', str_contains( $helper, "'flow_step_id'      => $" . 'flow_step_id') );
+assert_schedule_next_step_failure_smoke( 'failure is retryable for scheduler handoff recovery', str_contains( $helper, "'retryable'         => true") );
+assert_schedule_next_step_failure_smoke( 'failure records next step context', str_contains( $helper, "'next_flow_step_id' => $" . 'flow_step_id') );
+
+echo "Case 3: early returns before scheduling are not silent\n";
+assert_schedule_next_step_failure_smoke( 'missing flow id calls helper', str_contains( $execute, "'missing_flow_id_during_data_storage'") );
+assert_schedule_next_step_failure_smoke( 'missing flow id failure precedes false return', strpos( $execute, "'missing_flow_id_during_data_storage'") < strpos( $execute, "'Flow ID missing during data storage.'" ) );
+
+echo "\nSchedule-next-step failure smoke complete: {$total} assertions, {$failed} failures.\n";
+if ( $failed > 0 ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Route failed next-step scheduling through the normal `datamachine_fail_job` path so jobs are retried or finalized instead of remaining `processing` without scheduler ownership.
- Cover both Action Scheduler handoff failures and pre-schedule missing flow-id failures with a focused smoke test.

## Validation
- `php -l inc/Abilities/Engine/ScheduleNextStepAbility.php`
- `php -l tests/schedule-next-step-failure-smoke.php`
- `php tests/schedule-next-step-failure-smoke.php`
- `php tests/job-liveness-cli-smoke.php`
- `php tests/recover-stuck-active-action-guard-smoke.php`
- `vendor/bin/phpcs inc/Abilities/Engine/ScheduleNextStepAbility.php tests/schedule-next-step-failure-smoke.php`
- `git diff --check`
- `homeboy test --changed-since origin/main --skip-lint`

Fixes #2180.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the job liveness/scheduler handoff path, drafted the fix and focused smoke coverage, and ran validation. Chris remains responsible for review and merge.