### PR TITLE
Fix jobs list field hydration at operator scale

### DIFF
--- a/inc/Abilities/Job/GetJobsAbility.php
+++ b/inc/Abilities/Job/GetJobsAbility.php
@@ -95,6 +95,11 @@ class GetJobsAbility {
 								'type'        => array( 'string', 'null' ),
 								'description' => __( 'Filter jobs created at or after this datetime (Y-m-d H:i:s)', 'data-machine' ),
 							),
+							'fields'      => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'description' => __( 'Optional database field projection for low-memory list output.', 'data-machine' ),
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -143,6 +148,7 @@ class GetJobsAbility {
 		$offset      = (int) ( $input['offset'] ?? 0 );
 		$orderby     = $input['orderby'] ?? 'j.job_id';
 		$order       = $input['order'] ?? 'DESC';
+		$fields      = $input['fields'] ?? null;
 
 		// Direct job lookup by ID - bypasses pagination and filters.
 		if ( $job_id ) {
@@ -185,6 +191,10 @@ class GetJobsAbility {
 			'per_page' => $per_page,
 			'offset'   => $offset,
 		);
+
+		if ( is_array( $fields ) && ! empty( $fields ) ) {
+			$args['fields'] = $fields;
+		}
 
 		$filters_applied = array();
 
@@ -239,7 +249,9 @@ class GetJobsAbility {
 		$jobs  = $this->db_jobs->get_jobs_for_list_table( $args );
 		$total = $this->db_jobs->get_jobs_count( $args );
 
-		$jobs = $this->enrichJobNames( $jobs );
+		if ( empty( $args['fields'] ) ) {
+			$jobs = $this->enrichJobNames( $jobs );
+		}
 		$jobs = array_map( array( $this, 'addDisplayFields' ), $jobs );
 
 		return array(

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -1036,6 +1036,7 @@ class JobsCommand extends BaseCommand {
 		$pipeline_id = isset( $assoc_args['pipeline'] ) ? (int) $assoc_args['pipeline'] : null;
 		$limit       = (int) ( $assoc_args['limit'] ?? 20 );
 		$format      = $assoc_args['format'] ?? 'table';
+		$fields      = $this->parse_job_list_fields( $assoc_args['fields'] ?? '' );
 
 		if ( $limit < 1 ) {
 			$limit = 20;
@@ -1086,6 +1087,15 @@ class JobsCommand extends BaseCommand {
 			$input['since'] = gmdate( 'Y-m-d H:i:s', $timestamp );
 		}
 
+		if ( 'count' === $format ) {
+			WP_CLI::line( (string) ( new Jobs() )->get_jobs_count( $input ) );
+			return;
+		}
+
+		if ( ! empty( $fields ) ) {
+			$input['fields'] = $this->get_database_fields_for_job_list_fields( $fields );
+		}
+
 		$result = ( new GetJobsAbility() )->execute( $input );
 
 		if ( ! $result['success'] ) {
@@ -1119,7 +1129,11 @@ class JobsCommand extends BaseCommand {
 
 		// Transform jobs to flat row format.
 		$items = array_map(
-			function ( $j ) use ( $format ) {
+			function ( $j ) use ( $format, $fields ) {
+				if ( ! empty( $fields ) ) {
+					return $this->format_requested_job_list_fields( $j, $fields );
+				}
+
 				$source         = $j['source'] ?? 'pipeline';
 				$status_display = strlen( $j['status'] ?? '' ) > 40 ? substr( $j['status'], 0, 40 ) . '...' : ( $j['status'] ?? '' );
 
@@ -1153,6 +1167,11 @@ class JobsCommand extends BaseCommand {
 			$jobs
 		);
 
+		if ( ! empty( $fields ) ) {
+			$this->format_items( $items, $fields, $assoc_args, 'id' );
+			return;
+		}
+
 		if ( 'json' === $format ) {
 			WP_CLI::log( wp_json_encode( $items, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 			return;
@@ -1163,6 +1182,100 @@ class JobsCommand extends BaseCommand {
 		if ( 'table' === $format ) {
 			WP_CLI::log( sprintf( 'Showing %d jobs.', count( $jobs ) ) );
 		}
+	}
+
+	/**
+	 * Parse comma-separated list fields.
+	 */
+	private function parse_job_list_fields( string $fields ): array {
+		if ( '' === trim( $fields ) ) {
+			return array();
+		}
+
+		$parsed = array();
+		foreach ( explode( ',', $fields ) as $field ) {
+			$field = sanitize_key( trim( $field ) );
+			if ( '' !== $field ) {
+				$parsed[] = $field;
+			}
+		}
+
+		return array_values( array_unique( $parsed ) );
+	}
+
+	/**
+	 * Translate CLI output fields to the minimum job table fields needed.
+	 */
+	private function get_database_fields_for_job_list_fields( array $fields ): array {
+		$field_map = array(
+			'id'            => array( 'job_id' ),
+			'job_id'        => array( 'job_id' ),
+			'user_id'       => array( 'user_id' ),
+			'pipeline_id'   => array( 'pipeline_id' ),
+			'flow_id'       => array( 'flow_id' ),
+			'source'        => array( 'source' ),
+			'label'         => array( 'label' ),
+			'parent_job_id' => array( 'parent_job_id' ),
+			'status'        => array( 'status' ),
+			'created'       => array( 'created_at' ),
+			'created_at'    => array( 'created_at' ),
+			'completed'     => array( 'completed_at' ),
+			'completed_at'  => array( 'completed_at' ),
+			'flow'          => array( 'source', 'label', 'flow_id', 'flow_name' ),
+			'pipeline_name' => array( 'pipeline_name' ),
+			'flow_name'     => array( 'flow_name' ),
+			'handler_slug'  => array( 'status', 'engine_data' ),
+			'outcome'       => array( 'status', 'engine_data' ),
+			'step_results'  => array( 'status', 'engine_data' ),
+			'counts'        => array( 'status', 'engine_data' ),
+		);
+
+		$database_fields = array( 'job_id' );
+		foreach ( $fields as $field ) {
+			foreach ( $field_map[ $field ] ?? array( $field ) as $database_field ) {
+				$database_fields[] = $database_field;
+			}
+		}
+
+		return array_values( array_unique( $database_fields ) );
+	}
+
+	/**
+	 * Build one low-memory CLI output row for an explicit --fields list.
+	 */
+	private function format_requested_job_list_fields( array $job, array $fields ): array {
+		$item    = array();
+		$metrics = null;
+
+		foreach ( $fields as $field ) {
+			switch ( $field ) {
+				case 'id':
+					$item[ $field ] = $job['job_id'] ?? '';
+					break;
+				case 'created':
+					$item[ $field ] = $job['created_at'] ?? '';
+					break;
+				case 'completed':
+					$item[ $field ] = $job['completed_at'] ?? '-';
+					break;
+				case 'flow':
+					$item[ $field ] = 'system' === ( $job['source'] ?? 'pipeline' )
+						? ( $job['label'] ?? $job['display_label'] ?? 'System Task' )
+						: ( $job['flow_name'] ?? ( isset( $job['flow_id'] ) ? "Flow {$job['flow_id']}" : '' ) );
+					break;
+				case 'handler_slug':
+				case 'outcome':
+				case 'step_results':
+				case 'counts':
+					$metrics        = $metrics ?? RunMetrics::fromJob( $job );
+					$item[ $field ] = 'handler_slug' === $field ? ( $metrics['outcome']['handler_slug'] ?? null ) : $metrics[ $field ];
+					break;
+				default:
+					$item[ $field ] = $job[ $field ] ?? null;
+			}
+		}
+
+		return $item;
 	}
 
 	/**

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -371,19 +371,19 @@ class Jobs extends BaseRepository {
 
 		if ( is_array( $fields ) && ! empty( $fields ) ) {
 			$allowed_fields = array(
-				'job_id'         => 'j.job_id',
-				'user_id'        => 'j.user_id',
-				'pipeline_id'    => 'j.pipeline_id',
-				'flow_id'        => 'j.flow_id',
-				'source'         => 'j.source',
-				'label'          => 'j.label',
-				'parent_job_id'  => 'j.parent_job_id',
-				'status'         => 'j.status',
-				'engine_data'    => 'j.engine_data',
-				'created_at'     => 'j.created_at',
-				'completed_at'   => 'j.completed_at',
-				'pipeline_name'  => 'p.pipeline_name',
-				'flow_name'      => 'f.flow_name',
+				'job_id'        => 'j.job_id',
+				'user_id'       => 'j.user_id',
+				'pipeline_id'   => 'j.pipeline_id',
+				'flow_id'       => 'j.flow_id',
+				'source'        => 'j.source',
+				'label'         => 'j.label',
+				'parent_job_id' => 'j.parent_job_id',
+				'status'        => 'j.status',
+				'engine_data'   => 'j.engine_data',
+				'created_at'    => 'j.created_at',
+				'completed_at'  => 'j.completed_at',
+				'pipeline_name' => 'p.pipeline_name',
+				'flow_name'     => 'f.flow_name',
 			);
 
 			$requested_fields = array_values( array_unique( array_filter( array_map( 'strval', $fields ) ) ) );

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -278,6 +278,7 @@ class Jobs extends BaseRepository {
 		$order    = strtoupper( $args['order'] ?? 'DESC' );
 		$per_page = (int) ( $args['per_page'] ?? 20 );
 		$offset   = (int) ( $args['offset'] ?? 0 );
+		$fields   = $args['fields'] ?? null;
 
 		$pipelines_table = $this->wpdb->prefix . 'datamachine_pipelines';
 		$flows_table     = $this->wpdb->prefix . 'datamachine_flows';
@@ -364,22 +365,68 @@ class Jobs extends BaseRepository {
 			$where_sql = 'WHERE ' . implode( ' AND ', $where_clauses );
 		}
 
+		$select_fields       = 'j.*, p.pipeline_name, f.flow_name';
+		$include_child_count = true;
+		$decode_engine_data  = true;
+
+		if ( is_array( $fields ) && ! empty( $fields ) ) {
+			$allowed_fields = array(
+				'job_id'         => 'j.job_id',
+				'user_id'        => 'j.user_id',
+				'pipeline_id'    => 'j.pipeline_id',
+				'flow_id'        => 'j.flow_id',
+				'source'         => 'j.source',
+				'label'          => 'j.label',
+				'parent_job_id'  => 'j.parent_job_id',
+				'status'         => 'j.status',
+				'engine_data'    => 'j.engine_data',
+				'created_at'     => 'j.created_at',
+				'completed_at'   => 'j.completed_at',
+				'pipeline_name'  => 'p.pipeline_name',
+				'flow_name'      => 'f.flow_name',
+			);
+
+			$requested_fields = array_values( array_unique( array_filter( array_map( 'strval', $fields ) ) ) );
+			if ( ! in_array( 'job_id', $requested_fields, true ) ) {
+				$requested_fields[] = 'job_id';
+			}
+
+			$select_parts = array();
+			foreach ( $requested_fields as $field ) {
+				if ( isset( $allowed_fields[ $field ] ) ) {
+					$select_parts[] = $allowed_fields[ $field ] . ' AS ' . $field;
+				}
+			}
+
+			if ( ! empty( $select_parts ) ) {
+				$select_fields       = implode( ', ', $select_parts );
+				$include_child_count = in_array( 'child_count', $requested_fields, true );
+				$decode_engine_data  = in_array( 'engine_data', $requested_fields, true );
+			}
+		}
+
+		$child_count_select = $include_child_count
+			? ', (SELECT COUNT(*) FROM %i c WHERE c.parent_job_id = j.job_id) AS child_count'
+			: '';
+		$query_tables       = $include_child_count
+			? array( $this->table_name, $this->table_name, $pipelines_table, $flows_table )
+			: array( $this->table_name, $pipelines_table, $flows_table );
+
 		// Note: orderby is validated above, so safe to interpolate.
 		// For direct execution jobs, LEFT JOINs will return NULL for pipeline_name/flow_name.
 		// JOIN uses j.pipeline_id (varchar) directly against CAST of p.pipeline_id (int) to varchar
 		// for index-friendly matching on the jobs table side.
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		$query = $this->wpdb->prepare(
-			"SELECT j.*, p.pipeline_name, f.flow_name,
-                 (SELECT COUNT(*) FROM %i c WHERE c.parent_job_id = j.job_id) AS child_count
-             FROM %i j
-             LEFT JOIN %i p ON j.pipeline_id = p.pipeline_id
-             LEFT JOIN %i f ON j.flow_id = f.flow_id
-             {$where_sql}
-             ORDER BY {$orderby} {$order}
-             LIMIT %d OFFSET %d",
+			"SELECT {$select_fields}{$child_count_select}
+			 FROM %i j
+			 LEFT JOIN %i p ON j.pipeline_id = p.pipeline_id
+			 LEFT JOIN %i f ON j.flow_id = f.flow_id
+			 {$where_sql}
+			 ORDER BY {$orderby} {$order}
+			 LIMIT %d OFFSET %d",
 			array_merge(
-				array( $this->table_name, $this->table_name, $pipelines_table, $flows_table ),
+				$query_tables,
 				$where_values,
 				array( $per_page, $offset )
 			)
@@ -388,7 +435,7 @@ class Jobs extends BaseRepository {
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above
 		$results = $this->wpdb->get_results( $query, ARRAY_A );
-		if ( $results ) {
+		if ( $results && $decode_engine_data ) {
 			foreach ( $results as &$result ) {
 				if ( isset( $result['engine_data'] ) && is_string( $result['engine_data'] ) && '' !== $result['engine_data'] ) {
 					$decoded               = json_decode( $result['engine_data'], true );

--- a/tests/jobs-list-efficiency-smoke.php
+++ b/tests/jobs-list-efficiency-smoke.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Smoke coverage for low-memory jobs list behavior.
+ *
+ * @package DataMachine\Tests
+ */
+
+$root        = dirname( __DIR__ );
+$jobs_cli    = file_get_contents( $root . '/inc/Cli/Commands/JobsCommand.php' ) ?: '';
+$jobs_db     = file_get_contents( $root . '/inc/Core/Database/Jobs/Jobs.php' ) ?: '';
+$jobs_ability = file_get_contents( $root . '/inc/Abilities/Job/GetJobsAbility.php' ) ?: '';
+
+$failures = 0;
+$total    = 0;
+
+$assert = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	++$failures;
+	echo "FAIL: {$label}\n";
+};
+
+$assert( 'jobs list count uses count query before get-jobs ability', strpos( $jobs_cli, '\'count\' === $format' ) < strpos( $jobs_cli, 'new GetJobsAbility()' ) );
+$assert( 'jobs list maps requested fields to database projection', str_contains( $jobs_cli, 'get_database_fields_for_job_list_fields' ) );
+$assert( 'jobs list formats explicit fields without default JSON metrics', str_contains( $jobs_cli, 'format_requested_job_list_fields' ) );
+$assert( 'get-jobs ability accepts projected fields', str_contains( $jobs_ability, "args['fields']" ) );
+$assert( 'jobs repository has projected SELECT path', str_contains( $jobs_db, '$select_fields       = implode' ) );
+$assert( 'jobs repository decodes engine_data only when selected', str_contains( $jobs_db, '$decode_engine_data  = in_array' ) );
+$assert( 'jobs repository keeps full SELECT as default behavior', str_contains( $jobs_db, '$select_fields       = \'j.*, p.pipeline_name, f.flow_name\'' ) );
+
+if ( $failures > 0 ) {
+	echo "\n=== jobs-list-efficiency-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";
+	exit( 1 );
+}
+
+echo "\n=== jobs-list-efficiency-smoke: ALL PASS ({$total} assertions) ===\n";


### PR DESCRIPTION
## Summary
- Project `datamachine jobs list --fields=...` down to the requested job columns so operator-scale JSON reports do not hydrate heavy `engine_data` payloads unless requested.
- Short-circuit `datamachine jobs list --format=count` to the existing count query before loading rows.
- Add smoke coverage for the low-memory field projection and count-query paths.

Closes #2179

## Validation
- `php -l inc/Core/Database/Jobs/Jobs.php`
- `php -l inc/Cli/Commands/JobsCommand.php`
- `php -l inc/Abilities/Job/GetJobsAbility.php`
- `php -l tests/jobs-list-efficiency-smoke.php`
- `php tests/jobs-list-efficiency-smoke.php`
- `php tests/job-outcome-metrics-smoke.php`
- `composer lint -- inc/Core/Database/Jobs/Jobs.php inc/Abilities/Job/GetJobsAbility.php inc/Cli/Commands/JobsCommand.php tests/jobs-list-efficiency-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@issue-2179-jobs-list-efficiency --extension wordpress` (1285 passed, 3 skipped)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the jobs list memory path, drafted the code change and smoke coverage, and ran local validation. Chris remains responsible for review and merge.