### PR TITLE
fix: bundle Agents API for release

### DIFF
--- a/blueprints/playground.json
+++ b/blueprints/playground.json
@@ -11,19 +11,6 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "git:directory",
-        "url": "https://github.com/Automattic/agents-api",
-        "ref": "main",
-        "refType": "branch"
-      },
-      "options": {
-        "activate": true,
-        "targetFolderName": "agents-api"
-      }
-    },
-    {
-      "step": "installPlugin",
-      "pluginData": {
-        "resource": "git:directory",
         "url": "https://github.com/WordPress/ai-provider-for-openai",
         "ref": "trunk",
         "refType": "branch"

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=8.2",
+		"automattic/agents-api": "dev-main",
 		"woocommerce/action-scheduler": "^3.9",
 		"chubes4/block-format-bridge": "^0.6"
 	},
 	"require-dev": {
-		"automattic/agents-api": "dev-main",
 		"php-stubs/wordpress-stubs": "^6.9",
 		"wp-coding-standards/wpcs": "^3.1",
 		"phpcsstandards/phpcsutils": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,102 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b4f18f541cdb5ef9fd8ecf4674d82f6",
+    "content-hash": "48086caf56f4689948901abdd2a991e1",
     "packages": [
+        {
+            "name": "automattic/agents-api",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/agents-api.git",
+                "reference": "fd4040fad23679c98daddeff8e2b0f600784385c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/fd4040fad23679c98daddeff8e2b0f600784385c",
+                "reference": "fd4040fad23679c98daddeff8e2b0f600784385c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "suggest": {
+                "woocommerce/action-scheduler": "Required to actually run cron-triggered workflows. The substrate detects Action Scheduler at runtime and no-ops cleanly when absent; install this package (or any plugin that ships it, like WooCommerce) to enable scheduled workflow runs."
+            },
+            "default-branch": true,
+            "type": "wordpress-plugin",
+            "autoload": {
+                "files": [
+                    "agents-api.php"
+                ]
+            },
+            "scripts": {
+                "test": [
+                    "php tests/bootstrap-smoke.php",
+                    "php tests/message-envelope-smoke.php",
+                    "php tests/registry-smoke.php",
+                    "php tests/execution-principal-smoke.php",
+                    "php tests/effective-agent-resolver-smoke.php",
+                    "php tests/caller-context-smoke.php",
+                    "php tests/authorization-smoke.php",
+                    "php tests/agents-access-ability-smoke.php",
+                    "php tests/agents-conversation-session-abilities-smoke.php",
+                    "php tests/action-policy-values-smoke.php",
+                    "php tests/consent-policy-smoke.php",
+                    "php tests/tool-policy-contracts-smoke.php",
+                    "php tests/action-policy-resolver-smoke.php",
+                    "php tests/tool-runtime-smoke.php",
+                    "php tests/pending-action-store-contract-smoke.php",
+                    "php tests/approval-resolver-contract-smoke.php",
+                    "php tests/pending-action-abilities-smoke.php",
+                    "php tests/identity-smoke.php",
+                    "php tests/memory-metadata-contract-smoke.php",
+                    "php tests/memory-store-resolver-smoke.php",
+                    "php tests/approval-action-value-shape-smoke.php",
+                    "php tests/workspace-scope-smoke.php",
+                    "php tests/compaction-item-smoke.php",
+                    "php tests/compaction-conservation-smoke.php",
+                    "php tests/conversation-runner-contracts-smoke.php",
+                    "php tests/conversation-transcript-lock-smoke.php",
+                    "php tests/conversation-compaction-smoke.php",
+                    "php tests/tool-pair-validator-smoke.php",
+                    "php tests/markdown-section-compaction-smoke.php",
+                    "php tests/context-registry-smoke.php",
+                    "php tests/conversation-loop-smoke.php",
+                    "php tests/conversation-loop-tool-execution-smoke.php",
+                    "php tests/conversation-loop-completion-policy-smoke.php",
+                    "php tests/conversation-loop-transcript-persister-smoke.php",
+                    "php tests/conversation-loop-events-smoke.php",
+                    "php tests/iteration-budget-smoke.php",
+                    "php tests/conversation-loop-budgets-smoke.php",
+                    "php tests/channels-smoke.php",
+                    "php tests/frontend-chat-rest-smoke.php",
+                    "php tests/agents-dispatch-message-ability-smoke.php",
+                    "php tests/webhook-safety-smoke.php",
+                    "php tests/remote-bridge-smoke.php",
+                    "php tests/context-authority-smoke.php",
+                    "php tests/guidelines-substrate-smoke.php",
+                    "php tests/workflow-bindings-smoke.php",
+                    "php tests/workflow-spec-validator-smoke.php",
+                    "php tests/workflow-runner-smoke.php",
+                    "php tests/workflow-lifecycle-smoke.php",
+                    "php tests/agents-workflow-ability-smoke.php",
+                    "php tests/routine-smoke.php",
+                    "php tests/subagents-smoke.php",
+                    "php tests/no-product-imports-smoke.php"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "WordPress-shaped agent runtime substrate.",
+            "homepage": "https://github.com/Automattic/agents-api",
+            "support": {
+                "issues": "https://github.com/Automattic/agents-api/issues",
+                "source": "https://github.com/Automattic/agents-api"
+            },
+            "time": "2026-05-20T13:16:34+00:00"
+        },
         {
             "name": "chubes4/block-format-bridge",
             "version": "v0.6.6",
@@ -814,95 +908,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "automattic/agents-api",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "42f9702746d2ded1ef0af63d3f7b9ac3e83cb1cf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/42f9702746d2ded1ef0af63d3f7b9ac3e83cb1cf",
-                "reference": "42f9702746d2ded1ef0af63d3f7b9ac3e83cb1cf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "suggest": {
-                "woocommerce/action-scheduler": "Required to actually run cron-triggered workflows. The substrate detects Action Scheduler at runtime and no-ops cleanly when absent; install this package (or any plugin that ships it, like WooCommerce) to enable scheduled workflow runs."
-            },
-            "default-branch": true,
-            "type": "wordpress-plugin",
-            "scripts": {
-                "test": [
-                    "php tests/bootstrap-smoke.php",
-                    "php tests/message-envelope-smoke.php",
-                    "php tests/registry-smoke.php",
-                    "php tests/execution-principal-smoke.php",
-                    "php tests/effective-agent-resolver-smoke.php",
-                    "php tests/caller-context-smoke.php",
-                    "php tests/authorization-smoke.php",
-                    "php tests/agents-access-ability-smoke.php",
-                    "php tests/agents-conversation-session-abilities-smoke.php",
-                    "php tests/action-policy-values-smoke.php",
-                    "php tests/consent-policy-smoke.php",
-                    "php tests/tool-policy-contracts-smoke.php",
-                    "php tests/action-policy-resolver-smoke.php",
-                    "php tests/tool-runtime-smoke.php",
-                    "php tests/pending-action-store-contract-smoke.php",
-                    "php tests/approval-resolver-contract-smoke.php",
-                    "php tests/pending-action-abilities-smoke.php",
-                    "php tests/identity-smoke.php",
-                    "php tests/memory-metadata-contract-smoke.php",
-                    "php tests/memory-store-resolver-smoke.php",
-                    "php tests/approval-action-value-shape-smoke.php",
-                    "php tests/workspace-scope-smoke.php",
-                    "php tests/compaction-item-smoke.php",
-                    "php tests/compaction-conservation-smoke.php",
-                    "php tests/conversation-runner-contracts-smoke.php",
-                    "php tests/conversation-transcript-lock-smoke.php",
-                    "php tests/conversation-compaction-smoke.php",
-                    "php tests/tool-pair-validator-smoke.php",
-                    "php tests/markdown-section-compaction-smoke.php",
-                    "php tests/context-registry-smoke.php",
-                    "php tests/conversation-loop-smoke.php",
-                    "php tests/conversation-loop-tool-execution-smoke.php",
-                    "php tests/conversation-loop-completion-policy-smoke.php",
-                    "php tests/conversation-loop-transcript-persister-smoke.php",
-                    "php tests/conversation-loop-events-smoke.php",
-                    "php tests/iteration-budget-smoke.php",
-                    "php tests/conversation-loop-budgets-smoke.php",
-                    "php tests/channels-smoke.php",
-                    "php tests/frontend-chat-rest-smoke.php",
-                    "php tests/agents-dispatch-message-ability-smoke.php",
-                    "php tests/webhook-safety-smoke.php",
-                    "php tests/remote-bridge-smoke.php",
-                    "php tests/context-authority-smoke.php",
-                    "php tests/guidelines-substrate-smoke.php",
-                    "php tests/workflow-bindings-smoke.php",
-                    "php tests/workflow-spec-validator-smoke.php",
-                    "php tests/workflow-runner-smoke.php",
-                    "php tests/workflow-lifecycle-smoke.php",
-                    "php tests/agents-workflow-ability-smoke.php",
-                    "php tests/routine-smoke.php",
-                    "php tests/subagents-smoke.php",
-                    "php tests/no-product-imports-smoke.php"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "WordPress-shaped agent runtime substrate.",
-            "homepage": "https://github.com/Automattic/agents-api",
-            "support": {
-                "issues": "https://github.com/Automattic/agents-api/issues",
-                "source": "https://github.com/Automattic/agents-api"
-            },
-            "time": "2026-05-20T01:05:13+00:00"
-        },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v1.2.0",

--- a/data-machine.php
+++ b/data-machine.php
@@ -6,7 +6,6 @@
  * Version:           0.132.3
  * Requires at least: 7.0
  * Requires PHP:     8.2
- * Requires Plugins: agents-api
  * Author:          Chris Huber, extrachill
  * Author URI:      https://chubes.net
  * License:         GPL v2 or later
@@ -24,6 +23,10 @@ define( 'DATAMACHINE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DATAMACHINE_URL', plugin_dir_url( __FILE__ ) );
 
 require_once __DIR__ . '/vendor/autoload.php';
+
+if ( ! defined( 'AGENTS_API_LOADED' ) ) {
+	require_once __DIR__ . '/vendor/automattic/agents-api/agents-api.php';
+}
 
 // WP-CLI integration
 if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/homeboy.json
+++ b/homeboy.json
@@ -24,8 +24,7 @@
       "mysql_password": "",
       "release_latest_branch": "release-latest",
       "settings": {
-        "playground_wordpress_version": "7.0",
-        "validation_dependencies": "agents-api"
+        "playground_wordpress_version": "7.0"
       }
     }
   },

--- a/tests/release-bundled-agents-api-smoke.php
+++ b/tests/release-bundled-agents-api-smoke.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Pure-PHP smoke test for bundling Agents API into Data Machine releases (#2178).
+ *
+ * Run with: php tests/release-bundled-agents-api-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failures = array();
+$passes   = 0;
+$root     = dirname( __DIR__ );
+
+echo "release-bundled-agents-api-smoke\n";
+
+function datamachine_release_bundle_assert( bool $condition, string $name, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+}
+
+function datamachine_release_bundle_json_file( string $path ): array {
+	$decoded = json_decode( (string) file_get_contents( $path ), true );
+	if ( ! is_array( $decoded ) ) {
+		throw new RuntimeException( "Unable to decode JSON file: {$path}" );
+	}
+
+	return $decoded;
+}
+
+$composer = datamachine_release_bundle_json_file( $root . '/composer.json' );
+$lock     = datamachine_release_bundle_json_file( $root . '/composer.lock' );
+$homeboy  = datamachine_release_bundle_json_file( $root . '/homeboy.json' );
+$blueprint = datamachine_release_bundle_json_file( $root . '/blueprints/playground.json' );
+
+$plugin_source = (string) file_get_contents( $root . '/data-machine.php' );
+
+echo "\n[1] Release metadata bundles Agents API instead of requiring a separate plugin:\n";
+datamachine_release_bundle_assert( isset( $composer['require']['automattic/agents-api'] ), 'composer production dependencies include automattic/agents-api', $failures, $passes );
+datamachine_release_bundle_assert( ! isset( $composer['require-dev']['automattic/agents-api'] ), 'composer dev dependencies do not own automattic/agents-api', $failures, $passes );
+datamachine_release_bundle_assert( false === strpos( $plugin_source, 'Requires Plugins: agents-api' ), 'plugin header does not require standalone Agents API activation', $failures, $passes );
+
+$runtime_packages = array_column( $lock['packages'] ?? array(), 'name' );
+$dev_packages     = array_column( $lock['packages-dev'] ?? array(), 'name' );
+datamachine_release_bundle_assert( in_array( 'automattic/agents-api', $runtime_packages, true ), 'composer.lock keeps automattic/agents-api in runtime packages', $failures, $passes );
+datamachine_release_bundle_assert( ! in_array( 'automattic/agents-api', $dev_packages, true ), 'composer.lock keeps automattic/agents-api out of dev packages', $failures, $passes );
+
+echo "\n[2] Runtime bootstrap is idempotent with standalone Agents API:\n";
+datamachine_release_bundle_assert( false !== strpos( $plugin_source, "defined( 'AGENTS_API_LOADED' )" ), 'Data Machine checks the Agents API loaded sentinel before bundling', $failures, $passes );
+datamachine_release_bundle_assert( false !== strpos( $plugin_source, "vendor/automattic/agents-api/agents-api.php" ), 'Data Machine loads the bundled Agents API bootstrap', $failures, $passes );
+datamachine_release_bundle_assert( is_file( $root . '/vendor/automattic/agents-api/agents-api.php' ), 'local bundled Agents API bootstrap exists for package validation', $failures, $passes );
+
+echo "\n[3] Validation paths no longer install a separate GitHub-only Agents API plugin:\n";
+$validation_dependencies = $homeboy['extensions']['wordpress']['settings']['validation_dependencies'] ?? '';
+datamachine_release_bundle_assert( false === strpos( (string) $validation_dependencies, 'agents-api' ), 'Homeboy validation dependency list does not request standalone agents-api', $failures, $passes );
+
+$blueprint_payload = json_encode( $blueprint );
+datamachine_release_bundle_assert( is_string( $blueprint_payload ) && false === strpos( $blueprint_payload, 'github.com/Automattic/agents-api' ), 'Playground blueprint does not install the GitHub-only Agents API plugin', $failures, $passes );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " release bundle assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nRelease bundle smoke passed ({$passes} assertions).\n";


### PR DESCRIPTION
## Summary
- Moves `automattic/agents-api` into production Composer dependencies so release packages include the runtime substrate.
- Loads the bundled Agents API bootstrap idempotently and removes the WordPress `Requires Plugins: agents-api` activation dependency.
- Updates Playground/Homeboy validation paths and adds a smoke test proving packaged installs do not depend on the separate GitHub-only plugin.

Fixes #2178.

## Verification
- `php tests/release-bundled-agents-api-smoke.php`
- `php tests/agents-api-bootstrap-smoke.php`
- `./vendor/bin/phpcs data-machine.php tests/release-bundled-agents-api-smoke.php`
- `composer validate --strict` (valid with existing warning about the `version` field)
- `composer install --no-dev --dry-run --no-interaction`
- `homeboy test --path /Users/chubes/Developer/data-machine@issue-2178-bundle-agents-api --extension wordpress` (1285 passed, 3 skipped)
- `homeboy release --path /Users/chubes/Developer/data-machine@issue-2178-bundle-agents-api --dry-run`

## Notes
- `homeboy lint --path /Users/chubes/Developer/data-machine@issue-2178-bundle-agents-api --extension wordpress` still reports pre-existing admin React lint findings outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the bundled runtime implementation, release metadata updates, smoke coverage, and local verification commands for Chris to review.