### PR TITLE
Fix WP Ability error handling for legacy callers

### DIFF
--- a/inc/Cli/Commands/Flows/QueueCommand.php
+++ b/inc/Cli/Commands/Flows/QueueCommand.php
@@ -31,6 +31,7 @@ namespace DataMachine\Cli\Commands\Flows;
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Abilities\Flow\QueueAbility;
+use DataMachine\Core\AbilityResult;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -171,13 +172,13 @@ class QueueCommand extends BaseCommand {
 				return;
 			}
 
-			$result = wp_get_ability( 'datamachine/config-patch-add' )->execute(
+			$result = AbilityResult::normalize( wp_get_ability( 'datamachine/config-patch-add' )->execute(
 				array(
 					'flow_id'      => $flow_id,
 					'flow_step_id' => $flow_step_id,
 					'patch'        => $patch,
 				)
-			);
+			) );
 		} else {
 			if ( 'fetch' === $step_type ) {
 				WP_CLI::error( 'Fetch steps consume config patches, not string prompts. Use --patch=\'{...}\' instead.' );
@@ -189,13 +190,13 @@ class QueueCommand extends BaseCommand {
 				return;
 			}
 
-			$result = wp_get_ability( 'datamachine/queue-add' )->execute(
+			$result = AbilityResult::normalize( wp_get_ability( 'datamachine/queue-add' )->execute(
 				array(
 					'flow_id'      => $flow_id,
 					'flow_step_id' => $flow_step_id,
 					'prompt'       => $prompt,
 				)
-			);
+			) );
 		}
 
 		if ( ! $result['success'] ) {
@@ -268,19 +269,19 @@ class QueueCommand extends BaseCommand {
 			$flow_step_id = $resolved['step_id'];
 		}
 
-		$prompt_result = wp_get_ability( 'datamachine/queue-list' )->execute(
+		$prompt_result = AbilityResult::normalize( wp_get_ability( 'datamachine/queue-list' )->execute(
 			array(
 				'flow_id'      => $flow_id,
 				'flow_step_id' => $flow_step_id,
 			)
-		);
+		) );
 
-		$patch_result = wp_get_ability( 'datamachine/config-patch-list' )->execute(
+		$patch_result = AbilityResult::normalize( wp_get_ability( 'datamachine/config-patch-list' )->execute(
 			array(
 				'flow_id'      => $flow_id,
 				'flow_step_id' => $flow_step_id,
 			)
-		);
+		) );
 
 		if ( ! $prompt_result['success'] && ! $patch_result['success'] ) {
 			WP_CLI::error( $prompt_result['error'] ?? $patch_result['error'] ?? 'Failed to list queue' );
@@ -397,12 +398,12 @@ class QueueCommand extends BaseCommand {
 			? 'datamachine/config-patch-clear'
 			: 'datamachine/queue-clear';
 
-		$result = wp_get_ability( $ability_id )->execute(
+		$result = AbilityResult::normalize( wp_get_ability( $ability_id )->execute(
 			array(
 				'flow_id'      => $flow_id,
 				'flow_step_id' => $flow_step_id,
 			)
-		);
+		) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to clear queue' );
@@ -469,13 +470,13 @@ class QueueCommand extends BaseCommand {
 			? 'datamachine/config-patch-remove'
 			: 'datamachine/queue-remove';
 
-		$result = wp_get_ability( $ability_id )->execute(
+		$result = AbilityResult::normalize( wp_get_ability( $ability_id )->execute(
 			array(
 				'flow_id'      => $flow_id,
 				'flow_step_id' => $flow_step_id,
 				'index'        => $index,
 			)
-		);
+		) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to remove item from queue' );
@@ -579,27 +580,27 @@ class QueueCommand extends BaseCommand {
 				WP_CLI::error( 'Invalid --patch: not a JSON object.' );
 				return;
 			}
-			$result = wp_get_ability( 'datamachine/config-patch-update' )->execute(
+			$result = AbilityResult::normalize( wp_get_ability( 'datamachine/config-patch-update' )->execute(
 				array(
 					'flow_id'      => $flow_id,
 					'flow_step_id' => $flow_step_id,
 					'index'        => $index,
 					'patch'        => $patch,
 				)
-			);
+			) );
 		} else {
 			if ( 'fetch' === $step_type ) {
 				WP_CLI::error( 'Fetch steps consume config patches, not string prompts. Use --patch=\'{...}\' instead.' );
 				return;
 			}
-			$result = wp_get_ability( 'datamachine/queue-update' )->execute(
+			$result = AbilityResult::normalize( wp_get_ability( 'datamachine/queue-update' )->execute(
 				array(
 					'flow_id'      => $flow_id,
 					'flow_step_id' => $flow_step_id,
 					'index'        => $index,
 					'prompt'       => $prompt,
 				)
-			);
+			) );
 		}
 
 		if ( ! $result['success'] ) {
@@ -671,14 +672,14 @@ class QueueCommand extends BaseCommand {
 			? 'datamachine/config-patch-move'
 			: 'datamachine/queue-move';
 
-		$result = wp_get_ability( $ability_id )->execute(
+		$result = AbilityResult::normalize( wp_get_ability( $ability_id )->execute(
 			array(
 				'flow_id'      => $flow_id,
 				'flow_step_id' => $flow_step_id,
 				'from_index'   => $from_index,
 				'to_index'     => $to_index,
 			)
-		);
+		) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to move item in queue' );
@@ -754,13 +755,13 @@ class QueueCommand extends BaseCommand {
 			$flow_step_id = $resolved['step_id'];
 		}
 
-		$result = wp_get_ability( 'datamachine/queue-mode' )->execute(
+		$result = AbilityResult::normalize( wp_get_ability( 'datamachine/queue-mode' )->execute(
 			array(
 				'flow_id'      => $flow_id,
 				'flow_step_id' => $flow_step_id,
 				'mode'         => $mode,
 			)
-		);
+		) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to set queue mode' );

--- a/inc/Core/AbilityResult.php
+++ b/inc/Core/AbilityResult.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Helpers for consuming WordPress Ability execution results.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalizes core WP_Ability results at legacy caller boundaries.
+ */
+class AbilityResult {
+
+	/**
+	 * Convert a WP_Ability::execute() result into Data Machine's legacy array shape.
+	 *
+	 * Core returns WP_Error for validation, permission, and callback failures. Many
+	 * Data Machine callers still expect arrays with a success flag; this keeps
+	 * those callers safe while callbacks migrate to returning WP_Error directly.
+	 *
+	 * @param mixed $result Ability execution result.
+	 * @return array Normalized result array.
+	 */
+	public static function normalize( $result ): array {
+		if ( is_wp_error( $result ) ) {
+			$data = $result->get_error_data();
+
+			return array(
+				'success'       => false,
+				'error'         => $result->get_error_message(),
+				'wp_error_code' => $result->get_error_code(),
+				'wp_error_data' => is_array( $data ) ? $data : array(),
+			);
+		}
+
+		if ( is_array( $result ) ) {
+			return $result;
+		}
+
+		return array(
+			'success' => true,
+			'data'    => $result,
+		);
+	}
+}

--- a/inc/Engine/Tasks/TaskScheduler.php
+++ b/inc/Engine/Tasks/TaskScheduler.php
@@ -23,6 +23,7 @@ defined( 'ABSPATH' ) || exit;
 
 use DataMachine\Core\ActionScheduler\BatchScheduler;
 use DataMachine\Core\Agents\AgentIdentityResolver;
+use DataMachine\Core\AbilityResult;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\JobStatus;
 
@@ -149,7 +150,7 @@ class TaskScheduler {
 			? $task_meta['label']
 			: ucfirst( str_replace( '_', ' ', $taskType ) );
 
-		$result = $ability->execute( array(
+		$result = AbilityResult::normalize( $ability->execute( array(
 			'workflow'     => $workflow,
 			'timestamp'    => $params['scheduled_at'] ?? null,
 			'initial_data' => array(
@@ -164,7 +165,7 @@ class TaskScheduler {
 				'agent_slug'    => $context_agent_slug,
 				'job'           => $job_snapshot,
 			),
-		) );
+		) ) );
 
 		if ( empty( $result['success'] ) ) {
 			do_action(

--- a/tests/ability-result-wp-error-smoke.php
+++ b/tests/ability-result-wp-error-smoke.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Smoke test for WP_Error-safe ability result consumption.
+ *
+ * Run with: php tests/ability-result-wp-error-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private $data;
+
+		public function __construct( string $code = '', string $message = '', $data = null ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data() {
+			return $this->data;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/AbilityResult.php';
+
+use DataMachine\Core\AbilityResult;
+
+$failed = 0;
+$total  = 0;
+
+$assert = static function ( string $label, bool $condition ) use ( &$failed, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	++$failed;
+	echo "FAIL: {$label}\n";
+};
+
+$wp_error_result = AbilityResult::normalize(
+	new WP_Error(
+		'rest_forbidden',
+		'Permission denied.',
+		array( 'status' => 403 )
+	)
+);
+
+$assert( 'WP_Error normalizes to failed legacy result', false === $wp_error_result['success'] );
+$assert( 'WP_Error message is preserved', 'Permission denied.' === $wp_error_result['error'] );
+$assert( 'WP_Error code is preserved', 'rest_forbidden' === $wp_error_result['wp_error_code'] );
+$assert( 'WP_Error data is preserved', 403 === ( $wp_error_result['wp_error_data']['status'] ?? null ) );
+
+$array_result = array(
+	'success' => false,
+	'error'   => 'Legacy failure.',
+);
+$assert( 'legacy arrays pass through unchanged', $array_result === AbilityResult::normalize( $array_result ) );
+
+$scalar_result = AbilityResult::normalize( 'ok' );
+$assert( 'non-array successful callback values become success arrays', true === $scalar_result['success'] );
+$assert( 'non-array callback data is retained', 'ok' === $scalar_result['data'] );
+
+if ( $failed > 0 ) {
+	echo "=== ability-result-wp-error-smoke: {$failed} FAIL of {$total} ===\n";
+	exit( 1 );
+}
+
+echo "=== ability-result-wp-error-smoke: ALL PASS ({$total}) ===\n";


### PR DESCRIPTION
## Summary
- Add `DataMachine\Core\AbilityResult` to normalize `WP_Error` results from `WP_Ability::execute()` into Data Machine's legacy `success/error` array shape.
- Apply the normalizer to queue CLI ability calls and system task scheduling so core WP_Ability validation, permission, or callback errors do not fatal when callers inspect `$result['success']`.
- Add a targeted smoke test covering `WP_Error`, legacy array, and scalar callback result normalization.

Refs #999.

## Validation
- `php -l inc/Core/AbilityResult.php && php -l inc/Engine/Tasks/TaskScheduler.php && php -l inc/Cli/Commands/Flows/QueueCommand.php && php -l tests/ability-result-wp-error-smoke.php && php tests/ability-result-wp-error-smoke.php`
- `vendor/bin/phpcs inc/Core/AbilityResult.php inc/Engine/Tasks/TaskScheduler.php inc/Cli/Commands/Flows/QueueCommand.php tests/ability-result-wp-error-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@issue-999-wp-ability-contract --extension wordpress --force-hot` passed: 1285 passed, 3 skipped

## Notes
- `homeboy lint --path /Users/chubes/Developer/data-machine@issue-999-wp-ability-contract --extension wordpress --force-hot` still reports existing frontend ESLint findings outside this PHP slice.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the WP_Error normalization helper, targeted caller updates, smoke test, and validation/PR workflow for Chris to review.