### PR TITLE
fix: lighten pipeline admin list reads

### DIFF
--- a/inc/Abilities/Pipeline/GetPipelinesAbility.php
+++ b/inc/Abilities/Pipeline/GetPipelinesAbility.php
@@ -169,15 +169,11 @@ class GetPipelinesAbility {
 				);
 			}
 
-			// List mode: paginate at the SQL layer instead of loading all rows
-			// into memory and slicing. Count runs as a separate COUNT(*) query.
-			$pipelines = $this->db_pipelines->get_all_pipelines(
-				$user_id,
-				$agent_id,
-				$search,
-				$per_page,
-				$offset
-			);
+			// List-like modes do not render pipeline steps, so avoid selecting and
+			// decoding large pipeline_config blobs for every pipeline on the page.
+			$pipelines = in_array( $output_mode, array( 'list', 'summary', 'ids' ), true )
+				? $this->db_pipelines->get_all_pipelines_summary( $user_id, $agent_id, $search, $per_page, $offset )
+				: $this->db_pipelines->get_all_pipelines( $user_id, $agent_id, $search, $per_page, $offset );
 			$total     = $this->db_pipelines->get_pipelines_count( $user_id, $agent_id, $search );
 
 			$formatted_pipelines = $this->formatPipelinesByMode(

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx
@@ -144,12 +144,10 @@ export default function PipelinesApp() {
 		data: fetchedSelectedPipeline,
 		isLoading: fetchedSelectedLoading,
 		error: fetchedSelectedError,
-	} = usePipeline(
-		selectedPipelineId && ! selectedFromList ? selectedPipelineId : null
-	);
-	const selectedPipeline = selectedFromList || fetchedSelectedPipeline;
+	} = usePipeline( selectedPipelineId || null );
+	const selectedPipeline = fetchedSelectedPipeline || selectedFromList;
 	const selectedPipelineLoading =
-		selectedPipelineId && ! selectedFromList && fetchedSelectedLoading;
+		selectedPipelineId && fetchedSelectedLoading;
 	const selectedPipelineError = fetchedSelectedError;
 
 	const [ isCreatingPipeline, setIsCreatingPipeline ] = useState( false );

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
@@ -73,7 +73,11 @@ export const usePipelineSearch = ( {
 	const normalizedSearch = search ? search.trim() : '';
 
 	return useQuery( {
-		queryKey: [ 'pipelines', 'search', { search: normalizedSearch, perPage } ],
+		queryKey: [
+			'pipelines',
+			'search',
+			{ search: normalizedSearch, perPage },
+		],
 		queryFn: async () => {
 			const response = await fetchPipelines( null, {
 				perPage,
@@ -96,14 +100,12 @@ export const usePipelineSearch = ( {
 };
 
 /**
- * Fetch a single pipeline by ID. Falls back to the `[ 'pipelines' ]` list
- * cache so reads are free when the pipeline is already in memory.
+ * Fetch a single pipeline by ID with full config. The pipeline list cache is
+ * intentionally lightweight and omits pipeline_config for scalable list loads.
  *
  * @param {number|string|null} pipelineId
  */
 export const usePipeline = ( pipelineId ) => {
-	const queryClient = useQueryClient();
-
 	return useQuery( {
 		queryKey: [
 			'pipelines',
@@ -111,19 +113,9 @@ export const usePipeline = ( pipelineId ) => {
 			pipelineId ? String( pipelineId ) : null,
 		],
 		queryFn: async () => {
-			// Prefer the list cache when the pipeline is already there.
-			const cachedList = queryClient.getQueryData( [ 'pipelines' ] );
-			if ( Array.isArray( cachedList ) ) {
-				const hit = cachedList.find( ( p ) =>
-					isSameId( p.pipeline_id, pipelineId )
-				);
-				if ( hit ) {
-					return hit;
-				}
-			}
-
 			const response = await fetchPipelines( pipelineId, {
 				includeFlows: false,
+				outputMode: 'full',
 			} );
 			if ( ! response.success ) {
 				throw getFetchError( response, 'Failed to fetch pipeline' );
@@ -289,8 +281,6 @@ export const useDeletePipelineStep = () => {
 		},
 	} );
 };
-
-
 
 export const useUploadContextFile = () => {
 	const queryClient = useQueryClient();

--- a/inc/Core/Database/Pipelines/Pipelines.php
+++ b/inc/Core/Database/Pipelines/Pipelines.php
@@ -215,6 +215,67 @@ class Pipelines extends BaseRepository {
 	}
 
 	/**
+	 * Get pipeline rows for list views without loading pipeline_config longtext.
+	 *
+	 * @param int|null    $user_id  Optional user ID to filter by.
+	 * @param int|null    $agent_id Optional agent ID to filter by.
+	 * @param string|null $search   Optional search term to filter by pipeline name (LIKE).
+	 * @param int|null    $per_page Optional SQL LIMIT. Null returns all rows.
+	 * @param int         $offset   SQL OFFSET (only honored when $per_page is set).
+	 * @return array Array of pipeline records without decoded pipeline_config.
+	 */
+	public function get_all_pipelines_summary(
+		?int $user_id = null,
+		?int $agent_id = null,
+		?string $search = null,
+		?int $per_page = null,
+		int $offset = 0
+	): array {
+		$where_clauses = array();
+		$where_values  = array();
+
+		if ( null !== $agent_id ) {
+			$where_clauses[] = 'agent_id = %d';
+			$where_values[]  = $agent_id;
+		} elseif ( null !== $user_id ) {
+			$where_clauses[] = 'user_id = %d';
+			$where_values[]  = $user_id;
+		}
+
+		if ( null !== $search && '' !== $search ) {
+			$where_clauses[] = 'pipeline_name LIKE %s';
+			$where_values[]  = '%' . $this->wpdb->esc_like( $search ) . '%';
+		}
+
+		$where = '';
+		if ( ! empty( $where_clauses ) ) {
+			$where = ' WHERE ' . implode( ' AND ', $where_clauses );
+		}
+
+		$limit_clause = '';
+		$limit_values = array();
+		if ( null !== $per_page && $per_page > 0 ) {
+			$limit_clause   = ' LIMIT %d OFFSET %d';
+			$limit_values[] = (int) $per_page;
+			$limit_values[] = max( 0, (int) $offset );
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQL.NotPrepared
+		$results = $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				"SELECT pipeline_id, pipeline_name, user_id, agent_id, portable_slug, created_at, updated_at
+				FROM %i{$where}
+				ORDER BY updated_at DESC{$limit_clause}",
+				array_merge( array( $this->table_name ), $where_values, $limit_values )
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQL.NotPrepared
+
+		return $results ? $results : array();
+	}
+
+	/**
 	 * Get lightweight pipelines list for UI dropdowns.
 	 *
 	 * @param int|null $user_id  Optional user ID to filter by.

--- a/tests/pipeline-list-output-mode-smoke.php
+++ b/tests/pipeline-list-output-mode-smoke.php
@@ -7,7 +7,10 @@ $root = dirname( __DIR__ );
 
 $get_pipelines    = file_get_contents( $root . '/inc/Abilities/Pipeline/GetPipelinesAbility.php' );
 $pipeline_helpers = file_get_contents( $root . '/inc/Abilities/Pipeline/PipelineHelpers.php' );
+$pipeline_db      = file_get_contents( $root . '/inc/Core/Database/Pipelines/Pipelines.php' );
 $rest_api         = file_get_contents( $root . '/inc/Api/Pipelines/Pipelines.php' );
+$pipelines_app    = file_get_contents( $root . '/inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx' );
+$pipeline_queries = file_get_contents( $root . '/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js' );
 $pipelines_client = file_get_contents( $root . '/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js' );
 $jobs_client      = file_get_contents( $root . '/inc/Core/Admin/Pages/Jobs/assets/react/api/jobs.js' );
 
@@ -35,6 +38,19 @@ $assert(
 );
 
 $assert(
+	'pipeline database exposes summary query without pipeline_config',
+	false !== strpos( $pipeline_db, 'function get_all_pipelines_summary' )
+		&& false !== strpos( $pipeline_db, 'SELECT pipeline_id, pipeline_name, user_id, agent_id, portable_slug, created_at, updated_at' )
+		&& false === strpos( $pipeline_db, 'SELECT pipeline_id, pipeline_name, pipeline_config' )
+);
+
+$assert(
+	'pipeline ability uses summary query for list-like modes',
+	false !== strpos( $get_pipelines, "array( 'list', 'summary', 'ids' )" )
+		&& false !== strpos( $get_pipelines, 'get_all_pipelines_summary' )
+);
+
+$assert(
 	'pipeline list branch unsets embedded flows',
 	false !== strpos( $pipeline_helpers, "unset( \$pipeline['flows'] );" )
 );
@@ -57,6 +73,17 @@ $assert(
 $assert(
 	'pipelines admin client requests list output mode',
 	false !== strpos( $pipelines_client, "outputMode = 'list'" ) && false !== strpos( $pipelines_client, 'output_mode: outputMode' )
+);
+
+$assert(
+	'selected pipeline query requests full output mode',
+	false !== strpos( $pipeline_queries, "outputMode: 'full'" )
+);
+
+$assert(
+	'pipelines app hydrates selected pipeline separately from list cache',
+	false !== strpos( $pipelines_app, 'usePipeline( selectedPipelineId || null )' )
+		&& false !== strpos( $pipelines_app, 'fetchedSelectedPipeline || selectedFromList' )
 );
 
 $assert(


### PR DESCRIPTION
## Summary
- Adds a lightweight pipeline summary query for `list`, `summary`, and `ids` output modes so admin collection reads skip `pipeline_config` longtext selection and JSON decoding.
- Keeps full single-pipeline hydration for the selected pipeline so step editing still receives complete `pipeline_config`.
- Extends the existing pipeline list smoke test to lock in the lighter read path and selected-pipeline hydration behavior.

Closes #1958.

## Validation
- `php -l inc/Core/Database/Pipelines/Pipelines.php && php -l inc/Abilities/Pipeline/GetPipelinesAbility.php && php tests/pipeline-list-output-mode-smoke.php`
- `npx wp-scripts lint-js inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js`
- `vendor/bin/phpcs inc/Core/Database/Pipelines/Pipelines.php inc/Abilities/Pipeline/GetPipelinesAbility.php`
- `npm run build`
- `homeboy test --path /Users/chubes/Developer/data-machine@issue-1958-admin-summary-fields --extension wordpress --force-hot`

## Notes
- `homeboy lint --path /Users/chubes/Developer/data-machine@issue-1958-admin-summary-fields --extension wordpress --force-hot` still reports existing repo-wide lint findings in unrelated frontend files. Focused lint for changed JS files passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the admin list read paths, drafted the lightweight summary-query patch, updated validation coverage, and ran local checks for Chris to review.