### PR TITLE
Add bounded sync runner for exploration

### DIFF
--- a/inc/Cli/BaseCommand.php
+++ b/inc/Cli/BaseCommand.php
@@ -96,7 +96,7 @@ class BaseCommand extends WP_CLI_Command {
 	 * @return array<int, array> Packet list.
 	 */
 	private function read_sync_input_packets( string $input_file ): array {
-		$contents = file_get_contents( $input_file );
+		$contents = file_get_contents( $input_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- CLI reads a local JSON path supplied by --input-file.
 		if ( false === $contents ) {
 			WP_CLI::error( sprintf( 'Unable to read input file: %s', $input_file ) );
 		}

--- a/inc/Cli/BaseCommand.php
+++ b/inc/Cli/BaseCommand.php
@@ -27,6 +27,99 @@ defined( 'ABSPATH' ) || exit;
 class BaseCommand extends WP_CLI_Command {
 
 	/**
+	 * Build bounded sync-runner options shared by flow and pipeline commands.
+	 *
+	 * @param array $assoc_args WP-CLI associative arguments.
+	 * @return array Runner options.
+	 */
+	protected function build_sync_runner_options( array $assoc_args ): array {
+		$options = array(
+			'max_steps'       => (int) ( $assoc_args['max-steps'] ?? $assoc_args['max_steps'] ?? 20 ),
+			'max_items'       => (int) ( $assoc_args['max-items'] ?? $assoc_args['max_items'] ?? 50 ),
+			'timeout_seconds' => (int) ( $assoc_args['timeout'] ?? $assoc_args['timeout-seconds'] ?? 60 ),
+			'show_packets'    => isset( $assoc_args['show-packets'] ) || isset( $assoc_args['show_packets'] ),
+		);
+
+		$input_file = $assoc_args['input-file'] ?? $assoc_args['input_file'] ?? null;
+		if ( is_string( $input_file ) && '' !== $input_file ) {
+			$options['input_packets'] = $this->read_sync_input_packets( $input_file );
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Output sync-runner diagnostics.
+	 *
+	 * @param array  $packet Diagnostics packet.
+	 * @param string $format Output format.
+	 */
+	protected function output_sync_runner_packet( array $packet, string $format ): void {
+		if ( 'json' === $format ) {
+			WP_CLI::line( (string) wp_json_encode( $packet, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		if ( 'yaml' === $format ) {
+			\WP_CLI\Utils\format_items( 'yaml', array( $packet ), array_keys( $packet ) );
+			return;
+		}
+
+		WP_CLI::log( sprintf( 'Success: %s', ! empty( $packet['success'] ) ? 'yes' : 'no' ) );
+		WP_CLI::log( sprintf( 'Stopped: %s', $packet['stopped_reason'] ?? 'unknown' ) );
+		WP_CLI::log( sprintf( 'Job ID:  %s', $packet['job_id'] ?? 'none' ) );
+		WP_CLI::log( sprintf( 'Steps:   %d', (int) ( $packet['counts']['steps_executed'] ?? 0 ) ) );
+		WP_CLI::log( sprintf( 'Packets: %d', (int) ( $packet['counts']['packets_seen'] ?? 0 ) ) );
+
+		$steps = is_array( $packet['steps'] ?? null ) ? $packet['steps'] : array();
+		if ( ! empty( $steps ) ) {
+			$rows = array_map(
+				static function ( array $step ): array {
+					return array(
+						'flow_step_id' => $step['flow_step_id'] ?? '',
+						'step_type'    => $step['step_type'] ?? '',
+						'input'        => $step['input_count'] ?? 0,
+						'output'       => $step['output_count'] ?? 0,
+						'next_step_id' => $step['next_step_id'] ?? '',
+					);
+				},
+				$steps
+			);
+			$this->format_items( $rows, array( 'flow_step_id', 'step_type', 'input', 'output', 'next_step_id' ), array( 'format' => 'table' ) );
+		}
+	}
+
+	/**
+	 * Read JSON input packets for run-sync.
+	 *
+	 * @param string $input_file JSON file path.
+	 * @return array<int, array> Packet list.
+	 */
+	private function read_sync_input_packets( string $input_file ): array {
+		$contents = file_get_contents( $input_file );
+		if ( false === $contents ) {
+			WP_CLI::error( sprintf( 'Unable to read input file: %s', $input_file ) );
+		}
+
+		$decoded = json_decode( $contents, true );
+		if ( ! is_array( $decoded ) ) {
+			WP_CLI::error( sprintf( 'Input file must contain JSON object or array: %s', $input_file ) );
+		}
+
+		if ( isset( $decoded['data_packets'] ) && is_array( $decoded['data_packets'] ) ) {
+			$decoded = $decoded['data_packets'];
+		} elseif ( isset( $decoded['packets'] ) && is_array( $decoded['packets'] ) ) {
+			$decoded = $decoded['packets'];
+		}
+
+		if ( array_is_list( $decoded ) ) {
+			return array_values( array_filter( $decoded, 'is_array' ) );
+		}
+
+		return array( $decoded );
+	}
+
+	/**
 	 * Format and display items using WP-CLI's native Formatter.
 	 *
 	 * @param array  $items      Items to display (array of associative arrays).

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -23,6 +23,7 @@ use DataMachine\Cli\UserResolver;
 use DataMachine\Cli\Commands\DrainCommand;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\LegacyHandlerShapeMigrator;
+use DataMachine\Engine\Debug\SyncRunner;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -88,6 +89,21 @@ class FlowsCommand extends BaseCommand {
 	 *
 	 * [--[no-]drain]
 	 * : Drain due Data Machine batch chunk and step actions after an immediate run.
+	 *
+	 * [--max-steps=<number>]
+	 * : Maximum inline steps for run-sync. Default: 20.
+	 *
+	 * [--max-items=<number>]
+	 * : Maximum packets retained from any sync step. Default: 50.
+	 *
+	 * [--timeout=<seconds>]
+	 * : Maximum wall time for run-sync. Default: 60.
+	 *
+	 * [--show-packets]
+	 * : Include full packets in run-sync output instead of summaries.
+	 *
+	 * [--input-file=<path>]
+	 * : JSON packet input for run-sync, useful when exploring downstream steps.
 	 *
 	 * [--pipeline_id=<id>]
 	 * : Pipeline ID for flow creation (create subcommand).
@@ -180,6 +196,9 @@ class FlowsCommand extends BaseCommand {
 	 *
 	 *     # Run a flow immediately
 	 *     wp datamachine flows run 42
+	 *
+	 *     # Run a flow inline for bounded local exploration
+	 *     wp datamachine flows run-sync 42 --max-steps=20 --show-packets --format=json
 	 *
 	 *     # Create a new flow
 	 *     wp datamachine flows create --pipeline_id=3 --name="My Flow"
@@ -370,6 +389,14 @@ class FlowsCommand extends BaseCommand {
 			if ( isset( $args[1] ) ) {
 				$flow_id = (int) $args[1];
 			}
+		} elseif ( ! empty( $args ) && 'run-sync' === $args[0] ) {
+			// Handle 'run-sync' subcommand: `flows run-sync 42`.
+			if ( ! isset( $args[1] ) ) {
+				WP_CLI::error( 'Usage: wp datamachine flows run-sync <flow_id> [--max-steps=N] [--max-items=N] [--timeout=N] [--show-packets] [--input-file=<path>] [--format=json]' );
+				return;
+			}
+			$this->runFlowSync( (int) $args[1], $assoc_args );
+			return;
 		} elseif ( ! empty( $args ) && 'run' === $args[0] ) {
 			// Handle 'run' subcommand: `flows run 42`.
 			if ( ! isset( $args[1] ) ) {
@@ -461,6 +488,18 @@ class FlowsCommand extends BaseCommand {
 		$this->format_items( $items, $this->default_fields, $assoc_args, 'id' );
 		$this->output_pagination( $offset, count( $flows ), $total, $format, 'flows' );
 		$this->outputFilters( $result['filters_applied'] ?? array(), $format );
+	}
+
+	/**
+	 * Run a flow synchronously for bounded local exploration.
+	 *
+	 * @param int   $flow_id    Flow ID.
+	 * @param array $assoc_args WP-CLI args.
+	 */
+	private function runFlowSync( int $flow_id, array $assoc_args ): void {
+		$format = (string) ( $assoc_args['format'] ?? 'json' );
+		$packet = ( new SyncRunner() )->runFlow( $flow_id, $this->build_sync_runner_options( $assoc_args ) );
+		$this->output_sync_runner_packet( $packet, $format );
 	}
 
 	/**

--- a/inc/Cli/Commands/PipelinesCommand.php
+++ b/inc/Cli/Commands/PipelinesCommand.php
@@ -392,9 +392,9 @@ class PipelinesCommand extends BaseCommand {
 	private function runPipelineSync( int $pipeline_id, array $assoc_args ): void {
 		$result = ( new GetPipelinesAbility() )->execute(
 			array(
-				'pipeline_id'    => $pipeline_id,
-				'output_mode'    => 'full',
-				'include_flows'  => true,
+				'pipeline_id'   => $pipeline_id,
+				'output_mode'   => 'full',
+				'include_flows' => true,
 			)
 		);
 
@@ -409,8 +409,8 @@ class PipelinesCommand extends BaseCommand {
 			return;
 		}
 
-		$format = (string) ( $assoc_args['format'] ?? 'json' );
-		$packet = ( new SyncRunner() )->runFlow( (int) $flows[0]['flow_id'], $this->build_sync_runner_options( $assoc_args ) );
+		$format                = (string) ( $assoc_args['format'] ?? 'json' );
+		$packet                = ( new SyncRunner() )->runFlow( (int) $flows[0]['flow_id'], $this->build_sync_runner_options( $assoc_args ) );
 		$packet['pipeline_id'] = $pipeline_id;
 		$this->output_sync_runner_packet( $packet, $format );
 	}

--- a/inc/Cli/Commands/PipelinesCommand.php
+++ b/inc/Cli/Commands/PipelinesCommand.php
@@ -20,6 +20,7 @@ use DataMachine\Abilities\Pipeline\DeletePipelineAbility;
 use DataMachine\Abilities\Pipeline\GetPipelinesAbility;
 use DataMachine\Abilities\Pipeline\UpdatePipelineAbility;
 use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Engine\Debug\SyncRunner;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -121,6 +122,21 @@ class PipelinesCommand extends BaseCommand {
 	 * [--remove=<filename>]
 	 * : Detach a memory file from a pipeline (memory-files subcommand).
 	 *
+	 * [--max-steps=<number>]
+	 * : Maximum inline steps for run-sync. Default: 20.
+	 *
+	 * [--max-items=<number>]
+	 * : Maximum packets retained from any sync step. Default: 50.
+	 *
+	 * [--timeout=<seconds>]
+	 * : Maximum wall time for run-sync. Default: 60.
+	 *
+	 * [--show-packets]
+	 * : Include full packets in run-sync output instead of summaries.
+	 *
+	 * [--input-file=<path>]
+	 * : JSON packet input for run-sync, useful when exploring downstream steps.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # List all pipelines
@@ -181,27 +197,40 @@ class PipelinesCommand extends BaseCommand {
 	 *     # Attach a memory file
 	 *     wp datamachine pipelines memory-files 5 --add=content-briefing.md
 	 *
- *     # Detach a memory file
- *     wp datamachine pipelines memory-files 5 --remove=content-briefing.md
- *
- *     # Update pipeline agent
- *     wp datamachine pipelines update 13 --agent=events-bot
- *
- *     # Update pipeline agent and cascade to child flows
- *     wp datamachine pipelines update 13 --agent=events-bot --cascade-flows
- *
- *     # Bulk reassign: move orphan pipelines → events-bot
- *     wp datamachine pipelines reassign --where-null --to-agent=events-bot
- *
- *     # Bulk reassign: move pipelines from agent_id=1 → events-bot
- *     wp datamachine pipelines reassign --from-agent=1 --to-agent=events-bot
- *
- *     # Dry-run reassign
- *     wp datamachine pipelines reassign --where-null --to-agent=events-bot --dry-run
- *
+	 *     # Detach a memory file
+	 *     wp datamachine pipelines memory-files 5 --remove=content-briefing.md
+	 *
+	 *     # Run the first flow in a pipeline inline for bounded local exploration
+	 *     wp datamachine pipelines run-sync 5 --input-file=packets.json --show-packets --format=json
+	 *
+	 *     # Update pipeline agent
+	 *     wp datamachine pipelines update 13 --agent=events-bot
+	 *
+	 *     # Update pipeline agent and cascade to child flows
+	 *     wp datamachine pipelines update 13 --agent=events-bot --cascade-flows
+	 *
+	 *     # Bulk reassign: move orphan pipelines → events-bot
+	 *     wp datamachine pipelines reassign --where-null --to-agent=events-bot
+	 *
+	 *     # Bulk reassign: move pipelines from agent_id=1 → events-bot
+	 *     wp datamachine pipelines reassign --from-agent=1 --to-agent=events-bot
+	 *
+	 *     # Dry-run reassign
+	 *     wp datamachine pipelines reassign --where-null --to-agent=events-bot --dry-run
+	 *
 	 */
 	public function __invoke( array $args, array $assoc_args ): void {
 		$pipeline_id = null;
+
+		// Handle 'run-sync' subcommand.
+		if ( ! empty( $args ) && 'run-sync' === $args[0] ) {
+			if ( ! isset( $args[1] ) ) {
+				WP_CLI::error( 'Usage: wp datamachine pipelines run-sync <pipeline_id> [--max-steps=N] [--max-items=N] [--timeout=N] [--show-packets] [--input-file=<path>] [--format=json]' );
+				return;
+			}
+			$this->runPipelineSync( (int) $args[1], $assoc_args );
+			return;
+		}
 
 		// Handle 'create' subcommand.
 		if ( ! empty( $args ) && 'create' === $args[0] ) {
@@ -352,6 +381,38 @@ class PipelinesCommand extends BaseCommand {
 			$this->format_items( $items, $this->default_fields, $assoc_args, 'id' );
 			$this->output_pagination( $offset, count( $pipelines ), $total, $format, 'pipelines' );
 		}
+	}
+
+	/**
+	 * Run the first flow attached to a pipeline synchronously.
+	 *
+	 * @param int   $pipeline_id Pipeline ID.
+	 * @param array $assoc_args  WP-CLI args.
+	 */
+	private function runPipelineSync( int $pipeline_id, array $assoc_args ): void {
+		$result = ( new GetPipelinesAbility() )->execute(
+			array(
+				'pipeline_id'    => $pipeline_id,
+				'output_mode'    => 'full',
+				'include_flows'  => true,
+			)
+		);
+
+		if ( empty( $result['success'] ) || empty( $result['pipelines'][0] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Pipeline not found' );
+			return;
+		}
+
+		$flows = is_array( $result['pipelines'][0]['flows'] ?? null ) ? $result['pipelines'][0]['flows'] : array();
+		if ( empty( $flows[0]['flow_id'] ) ) {
+			WP_CLI::error( sprintf( 'Pipeline %d has no flows to run synchronously.', $pipeline_id ) );
+			return;
+		}
+
+		$format = (string) ( $assoc_args['format'] ?? 'json' );
+		$packet = ( new SyncRunner() )->runFlow( (int) $flows[0]['flow_id'], $this->build_sync_runner_options( $assoc_args ) );
+		$packet['pipeline_id'] = $pipeline_id;
+		$this->output_sync_runner_packet( $packet, $format );
 	}
 
 	/**

--- a/inc/Engine/Debug/SyncRunner.php
+++ b/inc/Engine/Debug/SyncRunner.php
@@ -1,0 +1,351 @@
+<?php
+/**
+ * Bounded synchronous flow runner for CLI exploration.
+ *
+ * @package DataMachine\Engine\Debug
+ */
+
+namespace DataMachine\Engine\Debug;
+
+use DataMachine\Abilities\Engine\EngineHelpers;
+use DataMachine\Abilities\Engine\RunFlowAbility;
+use DataMachine\Abilities\StepTypeAbilities;
+use DataMachine\Core\EngineData;
+use DataMachine\Core\JobStatus;
+use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Core\Steps\Step;
+use DataMachine\Engine\StepNavigator;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Executes a flow inline with hard bounds for local debugging.
+ */
+class SyncRunner {
+
+	use EngineHelpers;
+
+	/**
+	 * Captured step schedules from the run-flow bootstrap.
+	 *
+	 * @var array<int, array{job_id:int,flow_step_id:string,data_packets:array}>
+	 */
+	private array $captured_schedules = array();
+
+	public function __construct() {
+		$this->initDatabases();
+	}
+
+	/**
+	 * Run a flow synchronously with bounded execution.
+	 *
+	 * @param int   $flow_id Flow ID.
+	 * @param array $options Runner options.
+	 * @return array Diagnostics packet.
+	 */
+	public function runFlow( int $flow_id, array $options = array() ): array {
+		$options      = $this->normalizeOptions( $options );
+		$started_at   = microtime( true );
+		$started_time = gmdate( 'c' );
+
+		$packet = array(
+			'success'         => false,
+			'mode'            => 'sync_debug',
+			'flow_id'         => $flow_id,
+			'job_id'          => null,
+			'stopped_reason'  => null,
+			'bounds'          => array(
+				'max_steps'       => $options['max_steps'],
+				'max_items'       => $options['max_items'],
+				'timeout_seconds' => $options['timeout_seconds'],
+			),
+			'counts'          => array(
+				'steps_executed' => 0,
+				'packets_seen'   => 0,
+			),
+			'steps'           => array(),
+			'errors'          => array(),
+			'started_at'      => $started_time,
+			'completed_at'    => null,
+			'duration_ms'     => null,
+		);
+
+		$initial_packets = $options['input_packets'];
+		$initial_data    = empty( $initial_packets ) ? array() : array( 'sync_runner_input_packets' => $initial_packets );
+		$run_result      = $this->runFlowBootstrap( $flow_id, $initial_data );
+		$job_id          = (int) ( $run_result['job_id'] ?? 0 );
+		$packet['job_id'] = $job_id > 0 ? $job_id : null;
+
+		if ( empty( $run_result['success'] ) ) {
+			$packet['errors'][]       = $run_result['error'] ?? 'Flow bootstrap failed.';
+			$packet['stopped_reason'] = $run_result['reason'] ?? 'bootstrap_failed';
+			return $this->finishPacket( $packet, $started_at );
+		}
+
+		if ( ! empty( $run_result['skipped'] ) ) {
+			$packet['success']        = true;
+			$packet['stopped_reason'] = $run_result['reason'] ?? 'skipped';
+			return $this->finishPacket( $packet, $started_at );
+		}
+
+		$current_step_id = (string) ( $this->captured_schedules[0]['flow_step_id'] ?? ( $run_result['first_step'] ?? '' ) );
+		$data_packets    = ! empty( $initial_packets ) ? $initial_packets : array();
+
+		while ( '' !== $current_step_id ) {
+			if ( $this->timedOut( $started_at, $options['timeout_seconds'] ) ) {
+				$packet['stopped_reason'] = 'timeout';
+				$this->markBoundedStop( $job_id, 'sync_runner_timeout' );
+				break;
+			}
+
+			if ( $packet['counts']['steps_executed'] >= $options['max_steps'] ) {
+				$packet['stopped_reason'] = 'max_steps';
+				$this->markBoundedStop( $job_id, 'sync_runner_max_steps' );
+				break;
+			}
+
+			$step_result = $this->executeStepInline( $job_id, $current_step_id, $data_packets, $options );
+			$packet['steps'][] = $step_result['diagnostics'];
+			$packet['counts']['steps_executed']++;
+			$packet['counts']['packets_seen'] += $step_result['output_count'];
+
+			if ( ! empty( $step_result['error'] ) ) {
+				$packet['errors'][]       = $step_result['error'];
+				$packet['stopped_reason'] = 'error';
+				$this->db_jobs->complete_job( $job_id, JobStatus::FAILED . ' - sync_runner_error' );
+				break;
+			}
+
+			if ( null !== $step_result['stopped_reason'] ) {
+				$packet['success']        = true;
+				$packet['stopped_reason'] = $step_result['stopped_reason'];
+				break;
+			}
+
+			$current_step_id = (string) ( $step_result['next_step_id'] ?? '' );
+			$data_packets    = $step_result['data_packets'];
+		}
+
+		if ( null === $packet['stopped_reason'] ) {
+			$packet['success']        = true;
+			$packet['stopped_reason'] = 'completed';
+		}
+
+		return $this->finishPacket( $packet, $started_at );
+	}
+
+	/**
+	 * Normalize runner bounds.
+	 */
+	private function normalizeOptions( array $options ): array {
+		return array(
+			'max_steps'       => max( 1, min( 100, (int) ( $options['max_steps'] ?? 20 ) ) ),
+			'max_items'       => max( 1, min( 1000, (int) ( $options['max_items'] ?? 50 ) ) ),
+			'timeout_seconds' => max( 1, min( 900, (int) ( $options['timeout_seconds'] ?? 60 ) ) ),
+			'show_packets'    => true === ( $options['show_packets'] ?? false ),
+			'input_packets'   => is_array( $options['input_packets'] ?? null ) ? array_values( $options['input_packets'] ) : array(),
+		);
+	}
+
+	/**
+	 * Run normal flow bootstrap while capturing the initial scheduled step.
+	 */
+	private function runFlowBootstrap( int $flow_id, array $initial_data ): array {
+		$this->captured_schedules = array();
+		$previous_hook            = $GLOBALS['wp_filter']['datamachine_schedule_next_step'] ?? null;
+
+		\remove_all_actions( 'datamachine_schedule_next_step' );
+		\add_action(
+			'datamachine_schedule_next_step',
+			function ( $job_id, $flow_step_id, $data_packets = array() ): void {
+				$this->captured_schedules[] = array(
+					'job_id'       => (int) $job_id,
+					'flow_step_id' => (string) $flow_step_id,
+					'data_packets' => is_array( $data_packets ) ? $data_packets : array(),
+				);
+			},
+			10,
+			3
+		);
+
+		try {
+			$result = ( new RunFlowAbility() )->execute(
+				array(
+					'flow_id'      => $flow_id,
+					'initial_data' => $initial_data,
+				)
+			);
+		} finally {
+			\remove_all_actions( 'datamachine_schedule_next_step' );
+			if ( null === $previous_hook ) {
+				unset( $GLOBALS['wp_filter']['datamachine_schedule_next_step'] );
+			} else {
+				$GLOBALS['wp_filter']['datamachine_schedule_next_step'] = $previous_hook;
+			}
+		}
+
+		return is_array( $result ?? null ) ? $result : array( 'success' => false, 'error' => 'Flow bootstrap returned no result.' );
+	}
+
+	/**
+	 * Execute one flow step inline.
+	 */
+	private function executeStepInline( int $job_id, string $flow_step_id, array $data_packets, array $options ): array {
+		$engine_snapshot  = \datamachine_get_engine_data( $job_id );
+		$engine           = new EngineData( $engine_snapshot, $job_id );
+		$flow_step_config = $engine->getFlowStepConfig( $flow_step_id );
+
+		if ( ! is_array( $flow_step_config ) || empty( $flow_step_config['step_type'] ) ) {
+			return $this->stepFailure( $flow_step_id, 'missing_step_type_in_flow_step_config' );
+		}
+
+		$step_type       = (string) $flow_step_config['step_type'];
+		$step_definition = ( new StepTypeAbilities() )->getStepType( $step_type );
+		if ( ! is_array( $step_definition ) || empty( $step_definition['class'] ) ) {
+			return $this->stepFailure( $flow_step_id, sprintf( 'Step type "%s" not found in registry.', $step_type ) );
+		}
+
+		$step_class = (string) $step_definition['class'];
+		$flow_step  = new $step_class();
+		if ( ! $flow_step instanceof Step ) {
+			return $this->stepFailure( $flow_step_id, sprintf( 'Step class "%s" must extend DataMachine\\Core\\Steps\\Step.', $step_class ) );
+		}
+
+		$input_count = count( $data_packets );
+		$started_at  = microtime( true );
+
+		try {
+			$output_packets = $flow_step->execute(
+				array(
+					'job_id'       => $job_id,
+					'flow_step_id' => $flow_step_id,
+					'data'         => $data_packets,
+					'engine'       => $engine,
+				)
+			);
+		} catch ( \Throwable $e ) {
+			return $this->stepFailure( $flow_step_id, $e->getMessage(), $step_type, $step_class, $input_count );
+		}
+
+		if ( ! is_array( $output_packets ) ) {
+			$output_packets = array();
+		}
+
+		$output_packets = array_values( $output_packets );
+		$truncated      = false;
+		if ( count( $output_packets ) > $options['max_items'] ) {
+			$output_packets = array_slice( $output_packets, 0, $options['max_items'] );
+			$truncated      = true;
+		}
+
+		$output_count = count( $output_packets );
+		$next_step_id = ( new StepNavigator() )->get_next_flow_step_id( $flow_step_id, array( 'job_id' => $job_id ) );
+		$reason       = null;
+
+		if ( $truncated ) {
+			$reason = 'max_items';
+			$this->markBoundedStop( $job_id, 'sync_runner_max_items' );
+		} elseif ( 0 === $output_count && in_array( $step_type, array( 'fetch', 'event_import' ), true ) ) {
+			$reason = 'completed_no_items';
+			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED_NO_ITEMS );
+		} elseif ( 0 === $output_count ) {
+			return $this->stepFailure( $flow_step_id, 'empty_data_packet_returned', $step_type, $step_class, $input_count );
+		} elseif ( null === $next_step_id ) {
+			$reason = 'completed';
+			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED );
+		}
+
+		$diagnostics = array(
+			'flow_step_id'    => $flow_step_id,
+			'step_type'       => $step_type,
+			'step_class'      => $step_class,
+			'handler_slugs'   => FlowStepConfig::getConfiguredHandlerSlugs( $flow_step_config ),
+			'handler_configs' => FlowStepConfig::getHandlerConfigs( $flow_step_config ),
+			'input_count'     => $input_count,
+			'output_count'    => $output_count,
+			'duration_ms'     => (int) round( ( microtime( true ) - $started_at ) * 1000 ),
+			'next_step_id'    => $next_step_id,
+		);
+
+		if ( $options['show_packets'] ) {
+			$diagnostics['packets'] = $output_packets;
+		} else {
+			$diagnostics['packet_summaries'] = $this->summarizePackets( $output_packets );
+		}
+
+		return array(
+			'diagnostics'    => $diagnostics,
+			'data_packets'   => $output_packets,
+			'output_count'    => $output_count,
+			'next_step_id'    => $next_step_id,
+			'stopped_reason' => $reason,
+			'error'          => null,
+		);
+	}
+
+	/**
+	 * Build a consistent failed step result.
+	 */
+	private function stepFailure( string $flow_step_id, string $error, string $step_type = '', string $step_class = '', int $input_count = 0 ): array {
+		return array(
+			'diagnostics'    => array(
+				'flow_step_id' => $flow_step_id,
+				'step_type'    => $step_type,
+				'step_class'   => $step_class,
+				'input_count'  => $input_count,
+				'output_count' => 0,
+				'error'        => $error,
+			),
+			'data_packets'   => array(),
+			'output_count'    => 0,
+			'next_step_id'    => null,
+			'stopped_reason' => 'error',
+			'error'          => $error,
+		);
+	}
+
+	/**
+	 * Summarize packets without dumping full payloads.
+	 */
+	private function summarizePackets( array $packets ): array {
+		$summaries = array();
+		foreach ( $packets as $index => $packet ) {
+			$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+			$summaries[] = array(
+				'index'           => $index,
+				'type'            => (string) ( $packet['type'] ?? ( $metadata['type'] ?? 'unknown' ) ),
+				'source_type'     => $metadata['source_type'] ?? null,
+				'item_identifier' => $metadata['item_identifier'] ?? null,
+				'success'         => $metadata['success'] ?? null,
+				'keys'            => is_array( $packet ) ? array_keys( $packet ) : array(),
+			);
+		}
+
+		return $summaries;
+	}
+
+	/**
+	 * Mark a non-terminal bounded stop on the debug job.
+	 */
+	private function markBoundedStop( int $job_id, string $status ): void {
+		if ( $job_id > 0 ) {
+			$this->db_jobs->update_job_status( $job_id, $status );
+		}
+	}
+
+	/**
+	 * Check timeout against a monotonic-ish wall clock for CLI bounds.
+	 */
+	private function timedOut( float $started_at, int $timeout_seconds ): bool {
+		return ( microtime( true ) - $started_at ) >= $timeout_seconds;
+	}
+
+	/**
+	 * Complete packet timing metadata.
+	 */
+	private function finishPacket( array $packet, float $started_at ): array {
+		$packet['completed_at'] = gmdate( 'c' );
+		$packet['duration_ms']  = (int) round( ( microtime( true ) - $started_at ) * 1000 );
+		return $packet;
+	}
+}

--- a/inc/Engine/Debug/SyncRunner.php
+++ b/inc/Engine/Debug/SyncRunner.php
@@ -9,6 +9,7 @@ namespace DataMachine\Engine\Debug;
 
 use DataMachine\Abilities\Engine\EngineHelpers;
 use DataMachine\Abilities\Engine\RunFlowAbility;
+use DataMachine\Abilities\Engine\ScheduleNextStepAbility;
 use DataMachine\Abilities\StepTypeAbilities;
 use DataMachine\Core\EngineData;
 use DataMachine\Core\JobStatus;
@@ -49,31 +50,31 @@ class SyncRunner {
 		$started_time = gmdate( 'c' );
 
 		$packet = array(
-			'success'         => false,
-			'mode'            => 'sync_debug',
-			'flow_id'         => $flow_id,
-			'job_id'          => null,
-			'stopped_reason'  => null,
-			'bounds'          => array(
+			'success'        => false,
+			'mode'           => 'sync_debug',
+			'flow_id'        => $flow_id,
+			'job_id'         => null,
+			'stopped_reason' => null,
+			'bounds'         => array(
 				'max_steps'       => $options['max_steps'],
 				'max_items'       => $options['max_items'],
 				'timeout_seconds' => $options['timeout_seconds'],
 			),
-			'counts'          => array(
+			'counts'         => array(
 				'steps_executed' => 0,
 				'packets_seen'   => 0,
 			),
-			'steps'           => array(),
-			'errors'          => array(),
-			'started_at'      => $started_time,
-			'completed_at'    => null,
-			'duration_ms'     => null,
+			'steps'          => array(),
+			'errors'         => array(),
+			'started_at'     => $started_time,
+			'completed_at'   => null,
+			'duration_ms'    => null,
 		);
 
-		$initial_packets = $options['input_packets'];
-		$initial_data    = empty( $initial_packets ) ? array() : array( 'sync_runner_input_packets' => $initial_packets );
-		$run_result      = $this->runFlowBootstrap( $flow_id, $initial_data );
-		$job_id          = (int) ( $run_result['job_id'] ?? 0 );
+		$initial_packets  = $options['input_packets'];
+		$initial_data     = empty( $initial_packets ) ? array() : array( 'sync_runner_input_packets' => $initial_packets );
+		$run_result       = $this->runFlowBootstrap( $flow_id, $initial_data );
+		$job_id           = (int) ( $run_result['job_id'] ?? 0 );
 		$packet['job_id'] = $job_id > 0 ? $job_id : null;
 
 		if ( empty( $run_result['success'] ) ) {
@@ -104,9 +105,9 @@ class SyncRunner {
 				break;
 			}
 
-			$step_result = $this->executeStepInline( $job_id, $current_step_id, $data_packets, $options );
+			$step_result       = $this->executeStepInline( $job_id, $current_step_id, $data_packets, $options );
 			$packet['steps'][] = $step_result['diagnostics'];
-			$packet['counts']['steps_executed']++;
+			++$packet['counts']['steps_executed'];
 			$packet['counts']['packets_seen'] += $step_result['output_count'];
 
 			if ( ! empty( $step_result['error'] ) ) {
@@ -152,7 +153,6 @@ class SyncRunner {
 	 */
 	private function runFlowBootstrap( int $flow_id, array $initial_data ): array {
 		$this->captured_schedules = array();
-		$previous_hook            = $GLOBALS['wp_filter']['datamachine_schedule_next_step'] ?? null;
 
 		\remove_all_actions( 'datamachine_schedule_next_step' );
 		\add_action(
@@ -177,14 +177,33 @@ class SyncRunner {
 			);
 		} finally {
 			\remove_all_actions( 'datamachine_schedule_next_step' );
-			if ( null === $previous_hook ) {
-				unset( $GLOBALS['wp_filter']['datamachine_schedule_next_step'] );
-			} else {
-				$GLOBALS['wp_filter']['datamachine_schedule_next_step'] = $previous_hook;
-			}
+			$this->restoreProductionScheduleNextStepHook();
 		}
 
-		return is_array( $result ?? null ) ? $result : array( 'success' => false, 'error' => 'Flow bootstrap returned no result.' );
+		return is_array( $result ?? null ) ? $result : array(
+			'success' => false,
+			'error'   => 'Flow bootstrap returned no result.',
+		);
+	}
+
+	/**
+	 * Restore the production schedule bridge after temporary CLI capture.
+	 */
+	private function restoreProductionScheduleNextStepHook(): void {
+		\add_action(
+			'datamachine_schedule_next_step',
+			static function ( $job_id, $flow_step_id, $data_packets = array() ): void {
+				( new ScheduleNextStepAbility() )->execute(
+					array(
+						'job_id'       => (int) $job_id,
+						'flow_step_id' => (string) $flow_step_id,
+						'data_packets' => is_array( $data_packets ) ? $data_packets : array(),
+					)
+				);
+			},
+			10,
+			3
+		);
 	}
 
 	/**
@@ -276,8 +295,8 @@ class SyncRunner {
 		return array(
 			'diagnostics'    => $diagnostics,
 			'data_packets'   => $output_packets,
-			'output_count'    => $output_count,
-			'next_step_id'    => $next_step_id,
+			'output_count'   => $output_count,
+			'next_step_id'   => $next_step_id,
 			'stopped_reason' => $reason,
 			'error'          => null,
 		);
@@ -297,8 +316,8 @@ class SyncRunner {
 				'error'        => $error,
 			),
 			'data_packets'   => array(),
-			'output_count'    => 0,
-			'next_step_id'    => null,
+			'output_count'   => 0,
+			'next_step_id'   => null,
 			'stopped_reason' => 'error',
 			'error'          => $error,
 		);
@@ -310,7 +329,7 @@ class SyncRunner {
 	private function summarizePackets( array $packets ): array {
 		$summaries = array();
 		foreach ( $packets as $index => $packet ) {
-			$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+			$metadata    = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
 			$summaries[] = array(
 				'index'           => $index,
 				'type'            => (string) ( $packet['type'] ?? ( $metadata['type'] ?? 'unknown' ) ),

--- a/tests/sync-runner-bounds-smoke.php
+++ b/tests/sync-runner-bounds-smoke.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Smoke test for the bounded synchronous debug runner source contract.
+ *
+ * Run with: php tests/sync-runner-bounds-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$root   = dirname( __DIR__ );
+$source = (string) file_get_contents( $root . '/inc/Engine/Debug/SyncRunner.php' );
+$base   = (string) file_get_contents( $root . '/inc/Cli/BaseCommand.php' );
+$flows  = (string) file_get_contents( $root . '/inc/Cli/Commands/Flows/FlowsCommand.php' );
+$pipes  = (string) file_get_contents( $root . '/inc/Cli/Commands/PipelinesCommand.php' );
+
+$assertions = 0;
+
+$assert = static function ( bool $condition, string $message ) use ( &$assertions ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		fwrite( STDERR, "sync-runner smoke failed: {$message}\n" );
+		exit( 1 );
+	}
+};
+
+$assert( str_contains( $source, "'mode'            => 'sync_debug'" ), 'diagnostics packet identifies sync debug mode' );
+$assert( str_contains( $source, "'max_steps'       => max( 1, min( 100" ), 'max_steps is bounded' );
+$assert( str_contains( $source, "'max_items'       => max( 1, min( 1000" ), 'max_items is bounded' );
+$assert( str_contains( $source, "'timeout_seconds' => max( 1, min( 900" ), 'timeout is bounded' );
+$assert( str_contains( $source, "'stopped_reason'] = 'timeout'" ), 'timeout stop is reported' );
+$assert( str_contains( $source, "'stopped_reason'] = 'max_steps'" ), 'max step stop is reported' );
+$assert( str_contains( $source, "'sync_runner_max_items'" ), 'max item stop is recorded' );
+$assert( str_contains( $source, "'stopped_reason' => 'error'" ), 'step errors produce error stop diagnostics' );
+$assert( str_contains( $source, '\\remove_all_actions( \'datamachine_schedule_next_step\'' ), 'sync runner captures schedule-next-step hook' );
+$assert( str_contains( $source, '$GLOBALS[\'wp_filter\'][\'datamachine_schedule_next_step\'] = $previous_hook' ), 'sync runner restores production schedule hook' );
+$assert( ! str_contains( $source, 'as_schedule_single_action' ), 'sync runner does not call Action Scheduler directly' );
+$assert( str_contains( $base, 'read_sync_input_packets' ), 'CLI can load input packet JSON' );
+$assert( str_contains( $flows, "'run-sync' === \$args[0]" ), 'flow CLI exposes run-sync' );
+$assert( str_contains( $pipes, "'run-sync' === \$args[0]" ), 'pipeline CLI exposes run-sync' );
+
+echo "sync-runner bounds smoke passed ({$assertions} assertions)\n";

--- a/tests/sync-runner-bounds-smoke.php
+++ b/tests/sync-runner-bounds-smoke.php
@@ -23,7 +23,7 @@ $assert = static function ( bool $condition, string $message ) use ( &$assertion
 	}
 };
 
-$assert( str_contains( $source, "'mode'            => 'sync_debug'" ), 'diagnostics packet identifies sync debug mode' );
+$assert( str_contains( $source, "'mode'" ) && str_contains( $source, "'sync_debug'" ), 'diagnostics packet identifies sync debug mode' );
 $assert( str_contains( $source, "'max_steps'       => max( 1, min( 100" ), 'max_steps is bounded' );
 $assert( str_contains( $source, "'max_items'       => max( 1, min( 1000" ), 'max_items is bounded' );
 $assert( str_contains( $source, "'timeout_seconds' => max( 1, min( 900" ), 'timeout is bounded' );
@@ -32,7 +32,7 @@ $assert( str_contains( $source, "'stopped_reason'] = 'max_steps'" ), 'max step s
 $assert( str_contains( $source, "'sync_runner_max_items'" ), 'max item stop is recorded' );
 $assert( str_contains( $source, "'stopped_reason' => 'error'" ), 'step errors produce error stop diagnostics' );
 $assert( str_contains( $source, '\\remove_all_actions( \'datamachine_schedule_next_step\'' ), 'sync runner captures schedule-next-step hook' );
-$assert( str_contains( $source, '$GLOBALS[\'wp_filter\'][\'datamachine_schedule_next_step\'] = $previous_hook' ), 'sync runner restores production schedule hook' );
+$assert( str_contains( $source, 'restoreProductionScheduleNextStepHook' ), 'sync runner restores production schedule hook' );
 $assert( ! str_contains( $source, 'as_schedule_single_action' ), 'sync runner does not call Action Scheduler directly' );
 $assert( str_contains( $base, 'read_sync_input_packets' ), 'CLI can load input packet JSON' );
 $assert( str_contains( $flows, "'run-sync' === \$args[0]" ), 'flow CLI exposes run-sync' );


### PR DESCRIPTION
## Summary
- Adds explicit `flow(s) run-sync` and `pipeline(s) run-sync` CLI exploration commands with bounded `--max-steps`, `--max-items`, and `--timeout` controls.
- Runs flow steps inline in a debug-only runner that captures/restores the scheduling hook instead of changing production Action Scheduler execution semantics.
- Emits diagnostics packets with counts, handler configs, packet summaries, errors, and optional full packets via `--show-packets`.

Fixes #1612

## Validation
- `vendor/bin/phpcs inc/Engine/Debug/SyncRunner.php inc/Cli/BaseCommand.php inc/Cli/Commands/Flows/FlowsCommand.php inc/Cli/Commands/PipelinesCommand.php tests/sync-runner-bounds-smoke.php`
- `php tests/sync-runner-bounds-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@issue-1612-run-sync --extension wordpress --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the bounded sync runner implementation, CLI wiring, smoke coverage, and validation loop for Chris to review and land.