### PR TITLE
fix: scope agent authorize consent

### DIFF
--- a/inc/Abilities/AgentTokenAbilities.php
+++ b/inc/Abilities/AgentTokenAbilities.php
@@ -320,7 +320,15 @@ class AgentTokenAbilities {
 
 		$tokens_repo = new AgentTokens();
 		$tokens      = array_map(
-			static fn( \WP_Agent_Token $token ): array => $token->to_metadata_array(),
+			static function ( \WP_Agent_Token $token ): array {
+				$metadata = $token->to_metadata_array();
+				$scope    = isset( $token->metadata['datamachine_scope'] ) && is_array( $token->metadata['datamachine_scope'] )
+					? $token->metadata['datamachine_scope']
+					: $token->allowed_capabilities;
+
+				$metadata['scope_label'] = AgentTokens::scope_label( $scope );
+				return $metadata;
+			},
 			$tokens_repo->list_tokens( (string) $agent_id )
 		);
 

--- a/inc/Abilities/PermissionHelper.php
+++ b/inc/Abilities/PermissionHelper.php
@@ -9,6 +9,7 @@
 namespace DataMachine\Abilities;
 
 use AgentsAPI\AI\WP_Agent_Execution_Principal;
+use DataMachine\Core\Database\Agents\AgentTokens;
 
 /**
  * Helper class for ability permission checks.
@@ -99,6 +100,14 @@ class PermissionHelper {
 	 * @var array|null
 	 */
 	private static ?\WP_Agent_Capability_Ceiling $capability_ceiling = null;
+
+	/**
+	 * Structured token scope for Data Machine ability-category enforcement.
+	 *
+	 * @since 1.0.0
+	 * @var array|null
+	 */
+	private static ?array $agent_token_scope = null;
 
 	/**
 	 * Agents API execution principal for the current request.
@@ -264,15 +273,19 @@ class PermissionHelper {
 	 * @param int|null   $token_id     Token ID for login-level runtime scoping.
 	 */
 	public static function set_agent_context( int $agent_id, int $owner_id, ?array $capabilities = null, ?int $token_id = null ): void {
+		$scope = AgentTokens::normalize_capability_payload( $capabilities );
+
 		self::$acting_agent_id     = $agent_id;
 		self::$acting_token_id     = $token_id;
 		self::$agent_owner_id      = $owner_id;
+		self::$agent_token_scope   = $scope['stored_payload'];
 		self::$capability_ceiling  = new \WP_Agent_Capability_Ceiling(
 			$owner_id,
-			$capabilities,
+			$scope['allowed_capabilities'],
 			array(
 				'agent_id' => $agent_id,
 				'token_id' => $token_id,
+				'scope'    => $scope['stored_payload'],
 			)
 		);
 		self::$execution_principal = null !== $token_id
@@ -307,6 +320,7 @@ class PermissionHelper {
 		self::$acting_token_id     = null;
 		self::$agent_owner_id      = 0;
 		self::$capability_ceiling  = null;
+		self::$agent_token_scope   = null;
 		self::$execution_principal = null;
 		self::$caller_context      = null;
 	}
@@ -409,6 +423,61 @@ class PermissionHelper {
 	 */
 	public static function in_agent_context(): bool {
 		return null !== self::$acting_agent_id;
+	}
+
+	/**
+	 * Check whether the current token scope allows a Data Machine ability.
+	 *
+	 * Raw WordPress capabilities remain enforced separately through the Agents API
+	 * capability ceiling. This method applies Data Machine's structured scope
+	 * metadata: category allow-list, explicit ability allow-list, and deny-list.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $ability_slug Ability slug, e.g. datamachine/get-posts.
+	 * @param string $category     Optional already-resolved ability category.
+	 * @return bool
+	 */
+	public static function can_use_ability( string $ability_slug, string $category = '' ): bool {
+		if ( '' === trim( $ability_slug ) ) {
+			return false;
+		}
+
+		if ( null === self::$acting_agent_id || null === self::$agent_token_scope ) {
+			return true;
+		}
+
+		$scope = AgentTokens::normalize_capability_payload( self::$agent_token_scope )['stored_payload'];
+		if ( null === $scope ) {
+			return true;
+		}
+
+		$deny = (array) ( $scope['ability_deny'] ?? array() );
+		if ( in_array( $ability_slug, $deny, true ) ) {
+			return false;
+		}
+
+		$allow = (array) ( $scope['ability_allow'] ?? array() );
+		if ( in_array( $ability_slug, $allow, true ) ) {
+			return true;
+		}
+
+		$categories = (array) ( $scope['ability_categories'] ?? array() );
+		if ( array() === $categories ) {
+			return true;
+		}
+
+		if ( '' === $category && class_exists( '\\WP_Abilities_Registry' ) ) {
+			$registry = \WP_Abilities_Registry::get_instance();
+			if ( method_exists( $registry, 'is_registered' ) && $registry->is_registered( $ability_slug ) ) {
+				$ability = $registry->get_registered( $ability_slug );
+				if ( is_object( $ability ) && method_exists( $ability, 'get_category' ) ) {
+					$category = (string) $ability->get_category();
+				}
+			}
+		}
+
+		return '' !== $category && in_array( $category, $categories, true );
 	}
 
 	/**

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -880,7 +880,9 @@ class AgentsCommand extends AgentBundleCommand {
 			WP_CLI::log( sprintf( 'Expires in:  %d days', $days ) );
 		}
 		if ( null !== $capabilities ) {
-			WP_CLI::log( sprintf( 'Capabilities: %s', implode( ', ', $capabilities ) ) );
+			$scope = \DataMachine\Core\Database\Agents\AgentTokens::normalize_capability_payload( $capabilities );
+			WP_CLI::log( sprintf( 'Scope:       %s', \DataMachine\Core\Database\Agents\AgentTokens::scope_label( $capabilities ) ) );
+			WP_CLI::log( sprintf( 'Capabilities: %s', implode( ', ', $scope['allowed_capabilities'] ?? array() ) ) );
 		}
 	}
 
@@ -924,13 +926,14 @@ class AgentsCommand extends AgentBundleCommand {
 				'token_id'  => $token['token_id'],
 				'prefix'    => $token['token_prefix'] . '...',
 				'label'     => ! empty( $token['label'] ) ? $token['label'] : '(none)',
+				'scope'     => $token['scope_label'] ?? 'Full owner ceiling',
 				'last_used' => $token['last_used_at'] ?? 'never',
 				'expires'   => $token['expires_at'] ?? 'never',
 				'status'    => $expired ? 'expired' : 'active',
 			);
 		}
 
-		$this->format_items( $items, array( 'token_id', 'prefix', 'label', 'last_used', 'expires', 'status' ), $assoc_args, 'token_id' );
+		$this->format_items( $items, array( 'token_id', 'prefix', 'label', 'scope', 'last_used', 'expires', 'status' ), $assoc_args, 'token_id' );
 	}
 
 	/**

--- a/inc/Core/Auth/AgentAuthMiddleware.php
+++ b/inc/Core/Auth/AgentAuthMiddleware.php
@@ -180,7 +180,10 @@ class AgentAuthMiddleware {
 		// Set agent execution context in PermissionHelper.
 		// This adds the agent_id scoping layer and the Agents API capability ceiling.
 		$token_capabilities = $token instanceof \WP_Agent_Token ? $token->allowed_capabilities : null;
-		PermissionHelper::set_agent_context( $agent_id, $owner_id, $token_capabilities, $token_id );
+		$token_scope        = $token instanceof \WP_Agent_Token && isset( $token->metadata['datamachine_scope'] ) && is_array( $token->metadata['datamachine_scope'] )
+			? $token->metadata['datamachine_scope']
+			: $token_capabilities;
+		PermissionHelper::set_agent_context( $agent_id, $owner_id, $token_scope, $token_id );
 		PermissionHelper::set_execution_principal( $principal );
 
 		// Expose the caller context for downstream code (ChatOrchestrator,

--- a/inc/Core/Auth/AgentAuthorize.php
+++ b/inc/Core/Auth/AgentAuthorize.php
@@ -116,6 +116,10 @@ class AgentAuthorize {
 						'type'     => 'string',
 						'enum'     => array( 'authorize', 'deny' ),
 					),
+					'scope_preset'          => array(
+						'required' => false,
+						'type'     => 'string',
+					),
 					'_authorize_nonce'      => array(
 						'required' => true,
 						'type'     => 'string',
@@ -238,6 +242,7 @@ class AgentAuthorize {
 		$redirect_uri = esc_url_raw( $request->get_param( 'redirect_uri' ) );
 		$label        = sanitize_text_field( $request->get_param( 'label' ) );
 		$action       = sanitize_text_field( $request->get_param( 'action' ) );
+		$scope_key    = sanitize_key( (string) $request->get_param( 'scope_preset' ) );
 		$nonce        = $request->get_param( '_authorize_nonce' );
 
 		// Look up agent for redirect URI validation.
@@ -285,6 +290,18 @@ class AgentAuthorize {
 			exit;
 		}
 
+		$scope_presets = $this->get_scope_presets( $agent, $redirect_uri );
+		if ( '' === $scope_key ) {
+			$scope_key = $this->get_default_scope_key( $agent, $redirect_uri, $scope_presets );
+		}
+
+		if ( ! isset( $scope_presets[ $scope_key ] ) ) {
+			header( 'Location: ' . add_query_arg( 'error', 'invalid_scope', $redirect_uri ) );
+			exit;
+		}
+
+		$scope_payload = $this->scope_payload_from_preset( $scope_key, $scope_presets[ $scope_key ] );
+
 		/**
 		 * Filter: Allow extensions to intercept the authorize flow before token minting.
 		 *
@@ -327,7 +344,7 @@ class AgentAuthorize {
 			(int) $agent['agent_id'],
 			$agent['agent_slug'],
 			$token_label,
-			null, // All capabilities.
+			$scope_payload,
 			null  // No expiry.
 		);
 
@@ -346,6 +363,7 @@ class AgentAuthorize {
 				'user_id'    => $user_id,
 				'token_id'   => $result['token_id'],
 				'label'      => $token_label,
+				'scope'      => $scope_key,
 			)
 		);
 
@@ -475,6 +493,143 @@ class AgentAuthorize {
 	}
 
 	/**
+	 * Return filterable approve-time scope presets.
+	 *
+	 * Null capabilities on the full preset intentionally preserve the existing
+	 * owner-ceiling behavior for users who do not change the selection.
+	 *
+	 * @param array  $agent        Agent row.
+	 * @param string $redirect_uri Redirect URI being authorized.
+	 * @return array<string,array<string,mixed>>
+	 */
+	private function get_scope_presets( array $agent, string $redirect_uri ): array {
+		$presets = array(
+			'read_only'            => array(
+				'label'              => __( 'Read-only', 'data-machine' ),
+				'description'        => __( 'Can read content and use read-oriented agent tools. Cannot create, edit, publish, delete, or change settings.', 'data-machine' ),
+				'ability_categories' => array( 'datamachine-agent', 'datamachine-content', 'datamachine-memory' ),
+				'ability_allow'      => array(),
+				'ability_deny'       => array(),
+				'capabilities'       => array( 'read', 'datamachine_chat', 'datamachine_use_tools' ),
+			),
+			'content_collaborator' => array(
+				'label'              => __( 'Content collaborator', 'data-machine' ),
+				'description'        => __( 'Can draft, edit, and publish owned content through content and memory tools. Cannot manage agents, flows, settings, or logs.', 'data-machine' ),
+				'ability_categories' => array( 'datamachine-agent', 'datamachine-content', 'datamachine-memory', 'datamachine-publishing', 'datamachine-media', 'datamachine-seo' ),
+				'ability_allow'      => array(),
+				'ability_deny'       => array( 'datamachine/delete-flow', 'datamachine/delete-pipeline' ),
+				'capabilities'       => array( 'read', 'edit_posts', 'publish_posts', 'upload_files', 'datamachine_chat', 'datamachine_use_tools' ),
+			),
+			'publisher'            => array(
+				'label'              => __( 'Publisher', 'data-machine' ),
+				'description'        => __( 'Can perform editor-level publishing work. Cannot manage Data Machine settings, flows, or agent credentials.', 'data-machine' ),
+				'ability_categories' => array( 'datamachine-agent', 'datamachine-content', 'datamachine-memory', 'datamachine-publishing', 'datamachine-media', 'datamachine-seo', 'datamachine-taxonomy' ),
+				'ability_allow'      => array(),
+				'ability_deny'       => array( 'datamachine/delete-flow', 'datamachine/delete-pipeline' ),
+				'capabilities'       => array( 'read', 'edit_posts', 'publish_posts', 'edit_others_posts', 'edit_published_posts', 'upload_files', 'datamachine_chat', 'datamachine_use_tools' ),
+			),
+			'full_owner_ceiling'   => array(
+				'label'              => __( 'Full owner ceiling', 'data-machine' ),
+				'description'        => __( 'Current behavior: this token can use anything the authorizing user can use. Choose only for trusted runtimes.', 'data-machine' ),
+				'ability_categories' => array(),
+				'ability_allow'      => array(),
+				'ability_deny'       => array(),
+				'capabilities'       => null,
+			),
+		);
+
+		/**
+		 * Filter approve-time agent token scope presets.
+		 *
+		 * Each preset may define label, description, ability_categories,
+		 * ability_allow, ability_deny, and capabilities. A null capabilities value
+		 * means unrestricted owner ceiling for backwards compatibility.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array<string,array<string,mixed>> $presets      Scope presets keyed by slug.
+		 * @param array                            $agent        Agent row.
+		 * @param string                           $redirect_uri Redirect URI being authorized.
+		 */
+		$presets = apply_filters( 'datamachine_agent_scope_presets', $presets, $agent, $redirect_uri );
+
+		$normalized = array();
+		foreach ( (array) $presets as $key => $preset ) {
+			$key = sanitize_key( (string) $key );
+			if ( '' === $key || ! is_array( $preset ) ) {
+				continue;
+			}
+
+			$normalized[ $key ] = array(
+				'label'              => sanitize_text_field( (string) ( $preset['label'] ?? $key ) ),
+				'description'        => sanitize_text_field( (string) ( $preset['description'] ?? '' ) ),
+				'ability_categories' => $this->normalize_string_list( $preset['ability_categories'] ?? array() ),
+				'ability_allow'      => $this->normalize_string_list( $preset['ability_allow'] ?? array() ),
+				'ability_deny'       => $this->normalize_string_list( $preset['ability_deny'] ?? array() ),
+				'capabilities'       => array_key_exists( 'capabilities', $preset ) && null === $preset['capabilities'] ? null : $this->normalize_string_list( $preset['capabilities'] ?? array() ),
+			);
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * @param array<string,array<string,mixed>> $presets Scope presets.
+	 */
+	private function get_default_scope_key( array $agent, string $redirect_uri, array $presets ): string {
+		$config  = $agent['agent_config'] ?? array();
+		$default = is_array( $config ) ? sanitize_key( (string) ( $config['default_scope'] ?? '' ) ) : '';
+
+		if ( '' !== $default && isset( $presets[ $default ] ) ) {
+			return $default;
+		}
+
+		return isset( $presets['full_owner_ceiling'] ) ? 'full_owner_ceiling' : (string) array_key_first( $presets );
+	}
+
+	/**
+	 * @param array<string,mixed> $preset Scope preset.
+	 */
+	private function scope_payload_from_preset( string $scope_key, array $preset ): ?array {
+		if ( array_key_exists( 'capabilities', $preset ) && null === $preset['capabilities'] ) {
+			return null;
+		}
+
+		return array(
+			'scope'              => $scope_key,
+			'label'              => (string) ( $preset['label'] ?? $scope_key ),
+			'ability_categories' => $this->normalize_string_list( $preset['ability_categories'] ?? array() ),
+			'ability_allow'      => $this->normalize_string_list( $preset['ability_allow'] ?? array() ),
+			'ability_deny'       => $this->normalize_string_list( $preset['ability_deny'] ?? array() ),
+			'capabilities'       => $this->normalize_string_list( $preset['capabilities'] ?? array() ),
+		);
+	}
+
+	/**
+	 * @param mixed $value Raw list-like value.
+	 * @return array<int,string>
+	 */
+	private function normalize_string_list( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( $value as $item ) {
+			if ( ! is_scalar( $item ) ) {
+				continue;
+			}
+
+			$item = trim( (string) $item );
+			if ( '' !== $item ) {
+				$items[] = $item;
+			}
+		}
+
+		return array_values( array_unique( $items ) );
+	}
+
+	/**
 	 * Render the consent screen HTML.
 	 *
 	 * Minimal, self-contained page — no admin chrome needed.
@@ -501,6 +656,19 @@ class AgentAuthorize {
 
 		$parsed_uri  = wp_parse_url( $redirect_uri );
 		$uri_display = esc_html( ( $parsed_uri['host'] ?? '' ) . ( isset( $parsed_uri['port'] ) ? ':' . $parsed_uri['port'] : '' ) );
+		$presets     = $this->get_scope_presets( $agent, $redirect_uri );
+		$default_key = $this->get_default_scope_key( $agent, $redirect_uri, $presets );
+
+		$scope_options = '';
+		foreach ( $presets as $key => $preset ) {
+			$scope_options .= sprintf(
+				'<label class="scope-option"><input type="radio" name="scope_preset" value="%1$s" %2$s><span><strong>%3$s</strong><small>%4$s</small></span></label>',
+				esc_attr( $key ),
+				checked( $default_key, $key, false ),
+				esc_html( (string) ( $preset['label'] ?? $key ) ),
+				esc_html( (string) ( $preset['description'] ?? '' ) )
+			);
+		}
 
 		header( 'Content-Type: text/html; charset=utf-8' );
 
@@ -573,6 +741,33 @@ class AgentAuthorize {
 			border-left: 4px solid #dba617;
 			border-radius: 0 4px 4px 0;
 		}
+		.scope-options {
+			border: 1px solid #dcdcde;
+			border-radius: 6px;
+			margin-bottom: 1.5rem;
+			overflow: hidden;
+		}
+		.scope-options legend {
+			font-size: 0.75rem;
+			font-weight: 700;
+			color: #50575e;
+			padding: 0 0.5rem;
+			margin-left: 0.75rem;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+		}
+		.scope-option {
+			display: flex;
+			gap: 0.75rem;
+			padding: 0.875rem 1rem;
+			border-top: 1px solid #dcdcde;
+			cursor: pointer;
+		}
+		.scope-option:first-of-type { border-top: 0; }
+		.scope-option:hover { background: #f6f7f7; }
+		.scope-option input { margin-top: 0.2rem; }
+		.scope-option strong { display: block; font-size: 0.9375rem; margin-bottom: 0.25rem; }
+		.scope-option small { display: block; color: #646970; line-height: 1.4; }
 		.auth-actions {
 			display: flex;
 			gap: 0.75rem;
@@ -624,7 +819,7 @@ class AgentAuthorize {
 		</dl>
 
 		<div class="auth-notice">
-			This will create a bearer token granting <strong>' . esc_html( $agent_name ) . '</strong> API access to this site with your permissions. The token does not expire.
+			This will create a bearer token for <strong>' . esc_html( $agent_name ) . '</strong>. Choose the least privilege this runtime needs. The token does not expire.
 		</div>
 
 		<form method="POST" action="' . esc_url( $action_url ) . '">
@@ -638,6 +833,25 @@ class AgentAuthorize {
 			<input type="hidden" name="code_challenge_method" value="' . esc_attr( $code_challenge_method ) . '">' : '' ) .
 			( ! empty( $state ) ? '
 			<input type="hidden" name="state" value="' . esc_attr( $state ) . '">' : '' ) . '
+
+			<fieldset class="scope-options">
+				<legend>Access scope</legend>
+				' . wp_kses(
+					$scope_options,
+					array(
+						'label'  => array( 'class' => true ),
+						'input'  => array(
+							'type'    => true,
+							'name'    => true,
+							'value'   => true,
+							'checked' => true,
+						),
+						'span'   => array(),
+						'strong' => array(),
+						'small'  => array(),
+					)
+				) . '
+			</fieldset>
 
 			<div class="auth-actions">
 				<button type="submit" name="action" value="authorize" class="btn-authorize">Authorize</button>

--- a/inc/Core/Database/Agents/AgentTokens.php
+++ b/inc/Core/Database/Agents/AgentTokens.php
@@ -100,6 +100,8 @@ class AgentTokens extends BaseRepository implements \WP_Agent_Token_Store {
 			return null;
 		}
 
+		$scope = self::normalize_capability_payload( $capabilities );
+
 		try {
 			$token = $this->create_token(
 				new \WP_Agent_Token(
@@ -109,13 +111,18 @@ class AgentTokens extends BaseRepository implements \WP_Agent_Token_Store {
 					$token_hash,
 					$prefix,
 					sanitize_text_field( $label ),
-					$capabilities,
+					$scope['allowed_capabilities'],
 					$expires_at,
 					null,
 					current_time( 'mysql', true ),
 					null,
 					null,
-					array( 'agent_slug' => $agent_slug )
+					array_filter(
+						array(
+							'agent_slug'        => $agent_slug,
+							'datamachine_scope' => $scope['stored_payload'],
+						)
+					)
 				)
 			);
 		} catch ( \Throwable $e ) {
@@ -136,12 +143,16 @@ class AgentTokens extends BaseRepository implements \WP_Agent_Token_Store {
 	public function create_token( \WP_Agent_Token $token ): \WP_Agent_Token {
 		$agent_id = (int) $token->agent_id;
 
+		$scope_payload = isset( $token->metadata['datamachine_scope'] ) && is_array( $token->metadata['datamachine_scope'] )
+			? $token->metadata['datamachine_scope']
+			: $token->allowed_capabilities;
+
 		$insert_data = array(
 			'agent_id'     => $agent_id,
 			'token_hash'   => $token->token_hash,
 			'token_prefix' => $token->token_prefix,
 			'label'        => sanitize_text_field( $token->label ),
-			'capabilities' => null !== $token->allowed_capabilities ? wp_json_encode( $token->allowed_capabilities ) : null,
+			'capabilities' => null !== $scope_payload ? wp_json_encode( $scope_payload ) : null,
 			'expires_at'   => $token->expires_at,
 			'created_at'   => $token->created_at ?? current_time( 'mysql', true ),
 		);
@@ -322,9 +333,15 @@ class AgentTokens extends BaseRepository implements \WP_Agent_Token_Store {
 		}
 
 		$capabilities = null;
+		$metadata     = array( 'agent_slug' => (string) $agent['agent_slug'] );
 		if ( ! empty( $row['capabilities'] ) ) {
-			$decoded      = json_decode( (string) $row['capabilities'], true );
-			$capabilities = is_array( $decoded ) ? array_values( array_map( 'strval', $decoded ) ) : null;
+			$decoded = json_decode( (string) $row['capabilities'], true );
+			$scope   = is_array( $decoded ) ? self::normalize_capability_payload( $decoded ) : self::normalize_capability_payload( null );
+
+			$capabilities = $scope['allowed_capabilities'];
+			if ( null !== $scope['stored_payload'] ) {
+				$metadata['datamachine_scope'] = $scope['stored_payload'];
+			}
 		}
 
 		return new \WP_Agent_Token(
@@ -340,7 +357,97 @@ class AgentTokens extends BaseRepository implements \WP_Agent_Token_Store {
 			isset( $row['created_at'] ) ? (string) $row['created_at'] : null,
 			null,
 			null,
-			array( 'agent_slug' => (string) $agent['agent_slug'] )
+			$metadata
 		);
+	}
+
+	/**
+	 * Normalize legacy flat capability arrays and structured Data Machine scopes.
+	 *
+	 * The database column remains the source of truth. Structured payloads are
+	 * preserved for audit/UI while Agents API receives only raw WP capability
+	 * strings for its generic capability ceiling object.
+	 *
+	 * @param array|null $payload Stored or requested capability payload.
+	 * @return array{allowed_capabilities: ?array<int,string>, stored_payload: ?array}
+	 */
+	public static function normalize_capability_payload( ?array $payload ): array {
+		if ( null === $payload ) {
+			return array(
+				'allowed_capabilities' => null,
+				'stored_payload'       => null,
+			);
+		}
+
+		$is_structured = array_keys( $payload ) !== range( 0, count( $payload ) - 1 );
+		if ( ! $is_structured ) {
+			$capabilities = self::normalize_string_list( $payload );
+			return array(
+				'allowed_capabilities' => $capabilities,
+				'stored_payload'       => $capabilities,
+			);
+		}
+
+		$capabilities = self::normalize_string_list( $payload['capabilities'] ?? array() );
+		$stored       = array(
+			'scope'              => sanitize_key( (string) ( $payload['scope'] ?? '' ) ),
+			'label'              => sanitize_text_field( (string) ( $payload['label'] ?? '' ) ),
+			'ability_categories' => self::normalize_string_list( $payload['ability_categories'] ?? array() ),
+			'ability_allow'      => self::normalize_string_list( $payload['ability_allow'] ?? array() ),
+			'ability_deny'       => self::normalize_string_list( $payload['ability_deny'] ?? array() ),
+			'capabilities'       => $capabilities,
+		);
+
+		return array(
+			'allowed_capabilities' => $capabilities,
+			'stored_payload'       => $stored,
+		);
+	}
+
+	/**
+	 * Return a human-readable scope label for token audit surfaces.
+	 *
+	 * @param array|null $payload Token capability payload.
+	 */
+	public static function scope_label( ?array $payload ): string {
+		$scope = self::normalize_capability_payload( $payload );
+		if ( null === $scope['stored_payload'] ) {
+			return __( 'Full owner ceiling', 'data-machine' );
+		}
+
+		$stored = $scope['stored_payload'];
+		if ( isset( $stored['label'] ) && '' !== $stored['label'] ) {
+			return (string) $stored['label'];
+		}
+
+		if ( isset( $stored['scope'] ) && '' !== $stored['scope'] ) {
+			return ucwords( str_replace( '_', ' ', (string) $stored['scope'] ) );
+		}
+
+		return __( 'Custom scope', 'data-machine' );
+	}
+
+	/**
+	 * @param mixed $value Raw list-like value.
+	 * @return array<int,string>
+	 */
+	private static function normalize_string_list( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( $value as $item ) {
+			if ( ! is_scalar( $item ) ) {
+				continue;
+			}
+
+			$item = trim( (string) $item );
+			if ( '' !== $item ) {
+				$items[] = $item;
+			}
+		}
+
+		return array_values( array_unique( $items ) );
 	}
 }

--- a/inc/Engine/AI/Tools/Policy/DataMachineToolAccessPolicy.php
+++ b/inc/Engine/AI/Tools/Policy/DataMachineToolAccessPolicy.php
@@ -70,6 +70,11 @@ final class DataMachineToolAccessPolicy {
 				}
 
 				$ability = $registry->get_registered( $slug );
+				$category = is_object( $ability ) && method_exists( $ability, 'get_category' ) ? (string) $ability->get_category() : '';
+				if ( ! PermissionHelper::can_use_ability( $slug, $category ) ) {
+					return false;
+				}
+
 				if ( ! $ability || ! $ability->check_permissions() ) {
 					return false;
 				}

--- a/tests/Unit/Abilities/PermissionHelperTest.php
+++ b/tests/Unit/Abilities/PermissionHelperTest.php
@@ -203,6 +203,53 @@ class PermissionHelperTest extends WP_UnitTestCase {
 		$this->assertFalse( PermissionHelper::can( 'manage_agents' ) );
 	}
 
+	public function test_agent_token_context_accepts_structured_scope_payload(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		PermissionHelper::set_agent_context(
+			123,
+			$user_id,
+			array(
+				'scope'              => 'read_only',
+				'label'              => 'Read-only',
+				'ability_categories' => array( 'datamachine-content' ),
+				'ability_allow'      => array( 'datamachine/wiki' ),
+				'ability_deny'       => array( 'datamachine/delete-post' ),
+				'capabilities'       => array( 'datamachine_chat' ),
+			),
+			456
+		);
+
+		$principal = PermissionHelper::get_execution_principal();
+
+		$this->assertSame( array( 'datamachine_chat' ), $principal->capability_ceiling->allowed_capabilities );
+		$this->assertTrue( PermissionHelper::can( 'chat' ) );
+		$this->assertFalse( PermissionHelper::can( 'use_tools' ) );
+	}
+
+	public function test_structured_scope_enforces_ability_allow_deny_and_categories(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		PermissionHelper::set_agent_context(
+			123,
+			$user_id,
+			array(
+				'scope'              => 'content_collaborator',
+				'label'              => 'Content collaborator',
+				'ability_categories' => array( 'datamachine-content' ),
+				'ability_allow'      => array( 'datamachine/wiki' ),
+				'ability_deny'       => array( 'datamachine/delete-post' ),
+				'capabilities'       => array( 'datamachine_chat' ),
+			),
+			456
+		);
+
+		$this->assertTrue( PermissionHelper::can_use_ability( 'datamachine/get-posts', 'datamachine-content' ) );
+		$this->assertTrue( PermissionHelper::can_use_ability( 'datamachine/wiki', 'datamachine-system' ) );
+		$this->assertFalse( PermissionHelper::can_use_ability( 'datamachine/delete-post', 'datamachine-content' ) );
+		$this->assertFalse( PermissionHelper::can_use_ability( 'datamachine/update-settings', 'datamachine-settings' ) );
+	}
+
 	public function test_user_session_agent_context_uses_owner_ceiling_without_token_id(): void {
 		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 

--- a/tests/agent-token-scope-payload-smoke.php
+++ b/tests/agent-token-scope-payload-smoke.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Pure-PHP smoke for structured agent token scope payloads.
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! interface_exists( 'WP_Agent_Token_Store' ) ) {
+		interface WP_Agent_Token_Store {}
+	}
+
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( $key ) {
+			return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $key ) );
+		}
+	}
+
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $value ) {
+			return trim( wp_strip_all_tags( (string) $value ) );
+		}
+	}
+
+	if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+		function wp_strip_all_tags( $value ) {
+			return strip_tags( (string) $value );
+		}
+	}
+
+	if ( ! function_exists( '__' ) ) {
+		function __( $text, $domain = 'default' ) {
+			unset( $domain );
+			return $text;
+		}
+	}
+}
+
+namespace DataMachine\Core\Database {
+	if ( ! class_exists( BaseRepository::class ) ) {
+		abstract class BaseRepository {}
+	}
+}
+
+namespace {
+	require_once __DIR__ . '/../inc/Core/Database/Agents/AgentTokens.php';
+
+	use DataMachine\Core\Database\Agents\AgentTokens;
+
+	$failures = 0;
+
+	$assert = static function ( bool $condition, string $message ) use ( &$failures ): void {
+		if ( $condition ) {
+			echo "PASS: {$message}\n";
+			return;
+		}
+
+		++$failures;
+		echo "FAIL: {$message}\n";
+	};
+
+	$scope = array(
+		'scope'              => 'read_only',
+		'label'              => 'Read-only',
+		'ability_categories' => array( 'datamachine-content', '' ),
+		'ability_allow'      => array( 'datamachine/wiki' ),
+		'ability_deny'       => array( 'datamachine/delete-post' ),
+		'capabilities'       => array( 'read', 'datamachine_chat', 'read' ),
+	);
+
+	$normalized = AgentTokens::normalize_capability_payload( $scope );
+
+	$assert( array( 'read', 'datamachine_chat' ) === $normalized['allowed_capabilities'], 'structured scope extracts raw capability ceiling' );
+	$assert( 'read_only' === $normalized['stored_payload']['scope'], 'structured scope keeps scope key for storage' );
+	$assert( array( 'datamachine-content' ) === $normalized['stored_payload']['ability_categories'], 'structured scope normalizes categories' );
+	$assert( 'Read-only' === AgentTokens::scope_label( $normalized['stored_payload'] ), 'structured scope reports audit label' );
+	$assert( 'Full owner ceiling' === AgentTokens::scope_label( null ), 'null capabilities remain full owner ceiling' );
+
+	exit( $failures > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary
- Adds filterable approve-time AgentAuthorize scope presets: read-only, content collaborator, publisher, and full owner ceiling.
- Stores structured scope payloads in the existing agent token capabilities column while hydrating raw capability ceilings for Agents API enforcement.
- Enforces structured ability allow/deny/category scopes through PermissionHelper and the tool access policy, and surfaces scope labels in token list output.

Fixes #1124.

## Validation
- `php -l inc/Core/Auth/AgentAuthorize.php && php -l inc/Core/Database/Agents/AgentTokens.php && php tests/agent-token-scope-payload-smoke.php`
- `homeboy lint --path . --extension wordpress --changed-since origin/main`

## Known validation caveat
- `homeboy test --path . --extension wordpress` and `homeboy test --path . --extension wordpress -- --filter=PermissionHelperTest` both failed before structured test results with an unclassified WP Codebox exit 1. `homeboy test --analyze` reported 0 tests observed and no failure clusters.
- Full `homeboy lint --path . --extension wordpress` still reports existing unrelated frontend ESLint findings in untouched React assets. Changed-file lint passed with no findings.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the scoped consent implementation, targeted smoke coverage, validation commands, and this PR summary for Chris to review.