### PR TITLE
Fix agent template upgrade tracking

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -991,8 +991,8 @@ class AgentBundleCommand extends BaseCommand {
 			if ( ! is_array( $record ) ) {
 				continue;
 			}
-			$key          = AgentBundleArtifactExtensions::artifact_key( (string) ( $record['artifact_type'] ?? '' ), (string) ( $record['artifact_id'] ?? '' ) );
-			$current_hash = isset( $current[ $key ] ) ? AgentBundleArtifactHasher::hash( $current[ $key ]['payload'] ?? null ) : null;
+			$key                    = AgentBundleArtifactExtensions::artifact_key( (string) ( $record['artifact_type'] ?? '' ), (string) ( $record['artifact_id'] ?? '' ) );
+			$current_hash           = isset( $current[ $key ] ) ? AgentBundleArtifactHasher::hash( $current[ $key ]['payload'] ?? null ) : null;
 			$record['current_hash'] = $current_hash;
 			$record['status']       = AgentBundleArtifactStatus::classify( (string) ( $record['installed_hash'] ?? '' ), $current_hash );
 			$classified[]           = $record;

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -15,7 +15,9 @@ use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
 use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
 use DataMachine\Engine\Bundle\AgentBundleAgentConfig;
+use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
 use DataMachine\Engine\Bundle\AgentBundleArtifactRebase;
+use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
 use DataMachine\Engine\Bundle\AgentBundleRuntimeDrift;
@@ -107,11 +109,14 @@ class AgentBundleCommand extends BaseCommand {
 			}
 
 			$items[] = array(
-				'agent_id'       => (int) $agent['agent_id'],
-				'agent_slug'     => (string) $agent['agent_slug'],
-				'bundle_slug'    => (string) $bundle['bundle_slug'],
-				'bundle_version' => (string) ( $bundle['bundle_version'] ?? '' ),
-				'artifacts'      => count( is_array( $bundle['artifacts'] ?? null ) ? $bundle['artifacts'] : array() ),
+				'agent_id'         => (int) $agent['agent_id'],
+				'agent_slug'       => (string) $agent['agent_slug'],
+				'template_slug'    => (string) ( $bundle['template_slug'] ?? $bundle['bundle_slug'] ),
+				'template_version' => (string) ( $bundle['template_version'] ?? $bundle['bundle_version'] ?? '' ),
+				'bundle_slug'      => (string) $bundle['bundle_slug'],
+				'bundle_version'   => (string) ( $bundle['bundle_version'] ?? '' ),
+				'source_ref'       => (string) ( $bundle['source_ref'] ?? '' ),
+				'artifacts'        => count( is_array( $bundle['artifacts'] ?? null ) ? $bundle['artifacts'] : array() ),
 			);
 		}
 
@@ -120,7 +125,7 @@ class AgentBundleCommand extends BaseCommand {
 			return;
 		}
 
-		$this->format_items( $items, array( 'agent_id', 'agent_slug', 'bundle_slug', 'bundle_version', 'artifacts' ), $assoc_args, 'agent_id' );
+		$this->format_items( $items, array( 'agent_id', 'agent_slug', 'template_slug', 'template_version', 'bundle_slug', 'bundle_version', 'artifacts' ), $assoc_args, 'agent_id' );
 	}
 
 	/**
@@ -148,7 +153,7 @@ class AgentBundleCommand extends BaseCommand {
 		}
 
 		$status = $this->installed_status( $agent );
-		$this->output( $status, $assoc_args, array( 'agent_id', 'agent_slug', 'bundle_slug', 'bundle_version', 'artifact_count' ) );
+		$this->output( $status, $assoc_args, array( 'agent_id', 'agent_slug', 'template_slug', 'template_version', 'bundle_slug', 'bundle_version', 'artifact_count' ) );
 	}
 
 	/**
@@ -816,7 +821,7 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	/** @param array<int,array<string,mixed>> $installed */
-	private function current_artifacts( array $agent, array $installed ): array {
+	protected function current_artifacts( array $agent, array $installed ): array {
 		$agent_id  = (int) $agent['agent_id'];
 		$artifacts = array();
 		$pipelines = $this->pipelines()->get_all_pipelines( null, $agent_id );
@@ -950,20 +955,50 @@ class AgentBundleCommand extends BaseCommand {
 		return null;
 	}
 
-	private function installed_status( array $agent ): array {
+	protected function installed_status( array $agent ): array {
 		$bundle    = $agent['agent_config']['datamachine_bundle'] ?? array();
 		$artifacts = is_array( $bundle['artifacts'] ?? null ) ? $bundle['artifacts'] : array();
+		$artifacts = $this->classified_installed_artifacts( $agent, array_values( $artifacts ) );
 
 		return array(
-			'agent_id'        => (int) $agent['agent_id'],
-			'agent_slug'      => (string) $agent['agent_slug'],
-			'bundle_slug'     => (string) ( $bundle['bundle_slug'] ?? '' ),
-			'bundle_version'  => (string) ( $bundle['bundle_version'] ?? '' ),
-			'source_ref'      => (string) ( $bundle['source_ref'] ?? '' ),
-			'source_revision' => (string) ( $bundle['source_revision'] ?? '' ),
-			'artifact_count'  => count( $artifacts ),
-			'artifacts'       => array_values( $artifacts ),
+			'agent_id'         => (int) $agent['agent_id'],
+			'agent_slug'       => (string) $agent['agent_slug'],
+			'template_slug'    => (string) ( $bundle['template_slug'] ?? $bundle['bundle_slug'] ?? '' ),
+			'template_version' => (string) ( $bundle['template_version'] ?? $bundle['bundle_version'] ?? '' ),
+			'bundle_slug'      => (string) ( $bundle['bundle_slug'] ?? '' ),
+			'bundle_version'   => (string) ( $bundle['bundle_version'] ?? '' ),
+			'source_ref'       => (string) ( $bundle['source_ref'] ?? '' ),
+			'source_revision'  => (string) ( $bundle['source_revision'] ?? '' ),
+			'artifact_count'   => count( $artifacts ),
+			'artifacts'        => $artifacts,
 		);
+	}
+
+	/**
+	 * @param array<string,mixed>          $agent Agent row.
+	 * @param array<int,array<string,mixed>> $installed Installed registry rows.
+	 * @return array<int,array<string,mixed>>
+	 */
+	protected function classified_installed_artifacts( array $agent, array $installed ): array {
+		$current = array();
+		foreach ( $this->current_artifacts( $agent, $installed ) as $artifact ) {
+			$key             = AgentBundleArtifactExtensions::artifact_key( (string) ( $artifact['artifact_type'] ?? '' ), (string) ( $artifact['artifact_id'] ?? '' ) );
+			$current[ $key ] = $artifact;
+		}
+
+		$classified = array();
+		foreach ( $installed as $record ) {
+			if ( ! is_array( $record ) ) {
+				continue;
+			}
+			$key          = AgentBundleArtifactExtensions::artifact_key( (string) ( $record['artifact_type'] ?? '' ), (string) ( $record['artifact_id'] ?? '' ) );
+			$current_hash = isset( $current[ $key ] ) ? AgentBundleArtifactHasher::hash( $current[ $key ]['payload'] ?? null ) : null;
+			$record['current_hash'] = $current_hash;
+			$record['status']       = AgentBundleArtifactStatus::classify( (string) ( $record['installed_hash'] ?? '' ), $current_hash );
+			$classified[]           = $record;
+		}
+
+		return $classified;
 	}
 
 	private function bundle_summary( array $bundle, string $slug = '' ): array {

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -30,6 +30,7 @@ use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\AgentBundleRuntimeDrift;
 use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
+use DataMachine\Engine\Bundle\AgentTemplateMetadata;
 use DataMachine\Engine\Bundle\AgentPackageProjection;
 use DataMachine\Engine\Bundle\BundleValidationException;
 use DataMachine\Engine\Bundle\PortableSlug;
@@ -533,6 +534,9 @@ class AgentBundler {
 			'source_ref'      => $bundle_source_ref,
 			'source_revision' => $bundle_source_revision,
 		);
+		$template_metadata      = AgentTemplateMetadata::from_bundle_array( $bundle )->to_array();
+		unset( $template_metadata['installed_hashes'] );
+		$bundle_metadata        = array_merge( $template_metadata, $bundle_metadata );
 		$is_portable_bundle     = ! empty( $bundle['bundle_slug'] ) || $this->bundle_has_portable_artifacts( $bundle );
 		$reconcile_runtime      = ! empty( $options['reconcile_runtime'] );
 		$is_upgrade             = ! empty( $options['is_upgrade'] );

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -536,10 +536,10 @@ class AgentBundler {
 		);
 		$template_metadata      = AgentTemplateMetadata::from_bundle_array( $bundle )->to_array();
 		unset( $template_metadata['installed_hashes'] );
-		$bundle_metadata        = array_merge( $template_metadata, $bundle_metadata );
-		$is_portable_bundle     = ! empty( $bundle['bundle_slug'] ) || $this->bundle_has_portable_artifacts( $bundle );
-		$reconcile_runtime      = ! empty( $options['reconcile_runtime'] );
-		$is_upgrade             = ! empty( $options['is_upgrade'] );
+		$bundle_metadata    = array_merge( $template_metadata, $bundle_metadata );
+		$is_portable_bundle = ! empty( $bundle['bundle_slug'] ) || $this->bundle_has_portable_artifacts( $bundle );
+		$reconcile_runtime  = ! empty( $options['reconcile_runtime'] );
+		$is_upgrade         = ! empty( $options['is_upgrade'] );
 
 		// Check for slug collision.
 		// On install: existing slug + (renamed-to-collision OR non-portable bundle) is a hard error.

--- a/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
@@ -210,6 +210,10 @@ final class AgentBundleCoreArtifactApply {
 		$bundle      = is_array( $context['bundle'] ?? null ) ? $context['bundle'] : array();
 		$bundle_slug = (string) ( $bundle['bundle_slug'] ?? $config['datamachine_bundle']['bundle_slug'] ?? '' );
 		$version     = (string) ( $bundle['bundle_version'] ?? $config['datamachine_bundle']['bundle_version'] ?? '' );
+		$template_slug    = (string) ( $bundle['template_slug'] ?? $config['datamachine_bundle']['template_slug'] ?? $bundle_slug );
+		$template_version = (string) ( $bundle['template_version'] ?? $config['datamachine_bundle']['template_version'] ?? $version );
+		$source_ref       = (string) ( $bundle['source_ref'] ?? $config['datamachine_bundle']['source_ref'] ?? '' );
+		$source_revision  = (string) ( $bundle['source_revision'] ?? $config['datamachine_bundle']['source_revision'] ?? '' );
 		$type        = (string) ( $artifact['artifact_type'] ?? '' );
 		$id          = (string) ( $artifact['artifact_id'] ?? '' );
 		$payload     = $artifact['payload'] ?? null;
@@ -222,6 +226,10 @@ final class AgentBundleCoreArtifactApply {
 
 		$config['datamachine_bundle']['bundle_slug']    = $bundle_slug;
 		$config['datamachine_bundle']['bundle_version'] = $version;
+		$config['datamachine_bundle']['template_slug']    = $template_slug;
+		$config['datamachine_bundle']['template_version'] = $template_version;
+		$config['datamachine_bundle']['source_ref']        = $source_ref;
+		$config['datamachine_bundle']['source_revision']   = $source_revision;
 		$config['datamachine_bundle']['artifacts'][ AgentBundleArtifactExtensions::artifact_key( $type, $id ) ] = array(
 			'bundle_slug'       => $bundle_slug,
 			'bundle_version'    => $version,

--- a/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
@@ -206,30 +206,30 @@ final class AgentBundleCoreArtifactApply {
 			return new \WP_Error( 'datamachine_bundle_agent_missing', sprintf( 'Agent ID %d was not found.', $agent_id ) );
 		}
 
-		$config      = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
-		$bundle      = is_array( $context['bundle'] ?? null ) ? $context['bundle'] : array();
-		$bundle_slug = (string) ( $bundle['bundle_slug'] ?? $config['datamachine_bundle']['bundle_slug'] ?? '' );
-		$version     = (string) ( $bundle['bundle_version'] ?? $config['datamachine_bundle']['bundle_version'] ?? '' );
+		$config           = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
+		$bundle           = is_array( $context['bundle'] ?? null ) ? $context['bundle'] : array();
+		$bundle_slug      = (string) ( $bundle['bundle_slug'] ?? $config['datamachine_bundle']['bundle_slug'] ?? '' );
+		$version          = (string) ( $bundle['bundle_version'] ?? $config['datamachine_bundle']['bundle_version'] ?? '' );
 		$template_slug    = (string) ( $bundle['template_slug'] ?? $config['datamachine_bundle']['template_slug'] ?? $bundle_slug );
 		$template_version = (string) ( $bundle['template_version'] ?? $config['datamachine_bundle']['template_version'] ?? $version );
 		$source_ref       = (string) ( $bundle['source_ref'] ?? $config['datamachine_bundle']['source_ref'] ?? '' );
 		$source_revision  = (string) ( $bundle['source_revision'] ?? $config['datamachine_bundle']['source_revision'] ?? '' );
-		$type        = (string) ( $artifact['artifact_type'] ?? '' );
-		$id          = (string) ( $artifact['artifact_id'] ?? '' );
-		$payload     = $artifact['payload'] ?? null;
-		$hash        = AgentBundleArtifactHasher::hash( $payload );
-		$now         = gmdate( 'c' );
+		$type             = (string) ( $artifact['artifact_type'] ?? '' );
+		$id               = (string) ( $artifact['artifact_id'] ?? '' );
+		$payload          = $artifact['payload'] ?? null;
+		$hash             = AgentBundleArtifactHasher::hash( $payload );
+		$now              = gmdate( 'c' );
 
 		if ( '' === $bundle_slug || '' === $type || '' === $id ) {
 			return new \WP_Error( 'datamachine_bundle_registry_incomplete', 'Bundle artifact registry metadata is incomplete.' );
 		}
 
-		$config['datamachine_bundle']['bundle_slug']    = $bundle_slug;
-		$config['datamachine_bundle']['bundle_version'] = $version;
+		$config['datamachine_bundle']['bundle_slug']      = $bundle_slug;
+		$config['datamachine_bundle']['bundle_version']   = $version;
 		$config['datamachine_bundle']['template_slug']    = $template_slug;
 		$config['datamachine_bundle']['template_version'] = $template_version;
-		$config['datamachine_bundle']['source_ref']        = $source_ref;
-		$config['datamachine_bundle']['source_revision']   = $source_revision;
+		$config['datamachine_bundle']['source_ref']       = $source_ref;
+		$config['datamachine_bundle']['source_revision']  = $source_revision;
 		$config['datamachine_bundle']['artifacts'][ AgentBundleArtifactExtensions::artifact_key( $type, $id ) ] = array(
 			'bundle_slug'       => $bundle_slug,
 			'bundle_version'    => $version,

--- a/inc/Engine/Bundle/AgentTemplateMetadata.php
+++ b/inc/Engine/Bundle/AgentTemplateMetadata.php
@@ -73,6 +73,25 @@ final class AgentTemplateMetadata {
 		);
 	}
 
+	public static function from_bundle_array( array $bundle, array $installed_hashes = array() ): self {
+		$bundle_slug     = (string) ( $bundle['bundle_slug'] ?? ( $bundle['agent']['agent_slug'] ?? 'bundle' ) );
+		$bundle_version  = (string) ( $bundle['bundle_version'] ?? '1' );
+		$template        = is_array( $bundle['template'] ?? null ) ? $bundle['template'] : array();
+		$template_meta   = is_array( $bundle['template_metadata'] ?? null ) ? $bundle['template_metadata'] : array();
+		$template_slug   = (string) ( $bundle['template_slug'] ?? $template['slug'] ?? $template_meta['template_slug'] ?? $bundle_slug );
+		$template_version = (string) ( $bundle['template_version'] ?? $template['version'] ?? $template_meta['template_version'] ?? $bundle_version );
+
+		return new self(
+			$template_slug,
+			$template_version,
+			$bundle_slug,
+			$bundle_version,
+			(string) ( $bundle['source_ref'] ?? $template_meta['source_ref'] ?? '' ),
+			(string) ( $bundle['source_revision'] ?? $template_meta['source_revision'] ?? '' ),
+			$installed_hashes
+		);
+	}
+
 	public function to_array(): array {
 		return array(
 			'template_slug'    => $this->template_slug,

--- a/inc/Engine/Bundle/AgentTemplateMetadata.php
+++ b/inc/Engine/Bundle/AgentTemplateMetadata.php
@@ -74,11 +74,11 @@ final class AgentTemplateMetadata {
 	}
 
 	public static function from_bundle_array( array $bundle, array $installed_hashes = array() ): self {
-		$bundle_slug     = (string) ( $bundle['bundle_slug'] ?? ( $bundle['agent']['agent_slug'] ?? 'bundle' ) );
-		$bundle_version  = (string) ( $bundle['bundle_version'] ?? '1' );
-		$template        = is_array( $bundle['template'] ?? null ) ? $bundle['template'] : array();
-		$template_meta   = is_array( $bundle['template_metadata'] ?? null ) ? $bundle['template_metadata'] : array();
-		$template_slug   = (string) ( $bundle['template_slug'] ?? $template['slug'] ?? $template_meta['template_slug'] ?? $bundle_slug );
+		$bundle_slug      = (string) ( $bundle['bundle_slug'] ?? ( $bundle['agent']['agent_slug'] ?? 'bundle' ) );
+		$bundle_version   = (string) ( $bundle['bundle_version'] ?? '1' );
+		$template         = is_array( $bundle['template'] ?? null ) ? $bundle['template'] : array();
+		$template_meta    = is_array( $bundle['template_metadata'] ?? null ) ? $bundle['template_metadata'] : array();
+		$template_slug    = (string) ( $bundle['template_slug'] ?? $template['slug'] ?? $template_meta['template_slug'] ?? $bundle_slug );
 		$template_version = (string) ( $bundle['template_version'] ?? $template['version'] ?? $template_meta['template_version'] ?? $bundle_version );
 
 		return new self(

--- a/tests/agent-bundle-template-upgrade-tracking-smoke.php
+++ b/tests/agent-bundle-template-upgrade-tracking-smoke.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Pure-PHP smoke test for template source/version reporting and local artifact classification (#1537).
+ *
+ * Run with: php tests/agent-bundle-template-upgrade-tracking-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $title ) {
+		$title = strtolower( trim( (string) $title ) );
+		$title = preg_replace( '/[^a-z0-9]+/', '-', $title );
+		return trim( (string) $title, '-' );
+	}
+}
+if ( ! class_exists( 'WP_CLI_Command' ) ) {
+	class WP_CLI_Command {}
+}
+if ( ! class_exists( 'WP_CLI' ) ) {
+	class WP_CLI {
+		public static function line( $message = '' ): void {
+			echo $message . "\n";
+		}
+		public static function log( $message = '' ): void {
+			echo $message . "\n";
+		}
+		public static function error( $message = '' ): void {
+			throw new RuntimeException( (string) $message );
+		}
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleValidationException.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSchema.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/PortableSlug.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactExtensions.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleAgentConfig.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactHasher.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactStatus.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentTemplateMetadata.php';
+require_once dirname( __DIR__ ) . '/inc/Cli/BaseCommand.php';
+require_once dirname( __DIR__ ) . '/inc/Cli/Commands/AgentBundleCommand.php';
+
+use DataMachine\Cli\Commands\AgentBundleCommand;
+use DataMachine\Engine\Bundle\AgentBundleAgentConfig;
+use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
+use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
+use DataMachine\Engine\Bundle\AgentTemplateMetadata;
+
+$failures = 0;
+$total    = 0;
+
+function template_tracking_assert( string $label, bool $condition ): void {
+	global $failures, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$label}\n";
+		return;
+	}
+	echo "  FAIL: {$label}\n";
+	++$failures;
+}
+
+function template_tracking_assert_equals( string $label, $expected, $actual ): void {
+	template_tracking_assert( $label, $expected === $actual );
+}
+
+final class TemplateTrackingCommand extends AgentBundleCommand {
+	private array $current;
+
+	public function __construct( array $current ) {
+		$this->current = $current;
+	}
+
+	public function expose_status( array $agent ): array {
+		return $this->installed_status( $agent );
+	}
+
+	protected function current_artifacts( array $agent, array $installed ): array {
+		unset( $agent, $installed );
+		return $this->current;
+	}
+}
+
+echo "=== Agent Bundle Template Upgrade Tracking Smoke (#1537) ===\n";
+
+$bundle = array(
+	'bundle_slug'     => 'wordpress-com-brain',
+	'bundle_version'  => '1.2.3',
+	'template_slug'   => 'domain-wiki-template',
+	'template_version' => '4.5.6',
+	'source_ref'      => 'https://github.com/Automattic/intelligence/releases/download/v1.2.3/wpcom.zip',
+	'source_revision' => 'etag-abc123',
+	'agent'           => array( 'agent_slug' => 'wordpress-com-brain' ),
+);
+
+echo "\n[1] Bundle arrays produce template source/version metadata\n";
+$metadata = AgentTemplateMetadata::from_bundle_array( $bundle )->to_array();
+template_tracking_assert_equals( 'template slug comes from bundle metadata', 'domain-wiki-template', $metadata['template_slug'] );
+template_tracking_assert_equals( 'template version comes from bundle metadata', '4.5.6', $metadata['template_version'] );
+template_tracking_assert_equals( 'bundle version remains distinct', '1.2.3', $metadata['bundle_version'] );
+template_tracking_assert_equals( 'source revision is preserved', 'etag-abc123', $metadata['source_revision'] );
+
+echo "\n[2] Installed status reports source/version and live local modification state\n";
+$installed_agent_config = array( 'model' => 'openai/gpt-5.5' );
+$installed_pipeline     = array(
+	'portable_slug'   => 'daily-sync',
+	'pipeline_name'   => 'Daily Sync',
+	'pipeline_config' => array( 'step' => array( 'max_items' => 25 ) ),
+);
+$current_pipeline       = array(
+	'portable_slug'   => 'daily-sync',
+	'pipeline_name'   => 'Daily Sync',
+	'pipeline_config' => array( 'step' => array( 'max_items' => 1 ) ),
+);
+
+$agent = array(
+	'agent_id'     => 123,
+	'agent_slug'   => 'wordpress-com-brain',
+	'agent_config' => array(
+		'model'              => 'openai/gpt-5.5',
+		'datamachine_bundle' => array(
+			'template_slug'    => 'domain-wiki-template',
+			'template_version' => '4.5.6',
+			'bundle_slug'      => 'wordpress-com-brain',
+			'bundle_version'   => '1.2.3',
+			'source_ref'       => 'https://github.com/Automattic/intelligence/releases/download/v1.2.3/wpcom.zip',
+			'source_revision'  => 'etag-abc123',
+			'artifacts'        => array(
+				'agent_config:config' => array(
+					'artifact_type'  => 'agent_config',
+					'artifact_id'    => 'config',
+					'source_path'    => 'manifest.json#/agent/agent_config',
+					'installed_hash' => AgentBundleArtifactHasher::hash( $installed_agent_config ),
+				),
+				'pipeline:daily-sync' => array(
+					'artifact_type'  => 'pipeline',
+					'artifact_id'    => 'daily-sync',
+					'source_path'    => 'pipelines/daily-sync.json',
+					'installed_hash' => AgentBundleArtifactHasher::hash( $installed_pipeline ),
+				),
+			),
+		),
+	),
+);
+
+$command = new TemplateTrackingCommand(
+	array(
+		array(
+			'artifact_type' => 'agent_config',
+			'artifact_id'   => 'config',
+			'payload'       => AgentBundleAgentConfig::tracked_payload( $agent['agent_config'] ),
+		),
+		array(
+			'artifact_type' => 'pipeline',
+			'artifact_id'   => 'daily-sync',
+			'payload'       => $current_pipeline,
+		),
+	)
+);
+$status  = $command->expose_status( $agent );
+$records = array_column( $status['artifacts'], null, 'artifact_id' );
+
+template_tracking_assert_equals( 'status reports template slug', 'domain-wiki-template', $status['template_slug'] );
+template_tracking_assert_equals( 'status reports template version', '4.5.6', $status['template_version'] );
+template_tracking_assert_equals( 'status reports bundle source', $bundle['source_ref'], $status['source_ref'] );
+template_tracking_assert_equals( 'unchanged agent config is clean', AgentBundleArtifactStatus::CLEAN, $records['config']['status'] ?? null );
+template_tracking_assert_equals( 'changed pipeline is modified', AgentBundleArtifactStatus::MODIFIED, $records['daily-sync']['status'] ?? null );
+
+echo "\nTotal assertions: {$total}\n";
+if ( 0 !== $failures ) {
+	echo "Failures: {$failures}\n";
+	exit( 1 );
+}
+
+echo "All assertions passed.\n";


### PR DESCRIPTION
## Summary
- Persist `template_slug` and `template_version` with installed bundle metadata, defaulting to bundle identity when no distinct template metadata is present.
- Expose template/source metadata in `wp datamachine agent installed` and `agent status`.
- Recompute installed artifact statuses from live local artifacts in status output so modified template-owned artifacts are classified consistently.

## Tests
- `vendor/bin/phpcs inc/Engine/Bundle/AgentTemplateMetadata.php inc/Core/Agents/AgentBundler.php inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php inc/Cli/Commands/AgentBundleCommand.php tests/agent-bundle-template-upgrade-tracking-smoke.php`
- `php tests/agent-bundle-template-upgrade-tracking-smoke.php`
- `php tests/prompt-auth-template-artifacts-smoke.php`
- `php tests/agent-bundle-installed-artifact-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing and testing the focused #1537 template upgrade tracking slice; Chris remains responsible for review.