### PR TITLE
Route bundle imports through value objects

### DIFF
--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -1163,11 +1163,16 @@ class AgentBundler {
 	 * @return array Importable bundle array.
 	 */
 	private function canonical_import_bundle( array $bundle ): array {
-		if ( (string) ( $bundle['bundle_schema_version'] ?? '' ) !== BundleSchema::VERSION ) {
+		if ( (string) ( $bundle['bundle_schema_version'] ?? '' ) !== (string) BundleSchema::VERSION ) {
 			return $bundle;
 		}
 
-		return AgentBundleArrayAdapter::to_array_bundle( AgentBundleArrayAdapter::from_array_bundle( $bundle ) );
+		$canonical = AgentBundleArrayAdapter::to_array_bundle( AgentBundleArrayAdapter::from_array_bundle( $bundle ) );
+		if ( is_array( $bundle['abilities_manifest'] ?? null ) ) {
+			$canonical['abilities_manifest'] = $bundle['abilities_manifest'];
+		}
+
+		return $canonical;
 	}
 
 	/**

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -31,6 +31,7 @@ use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\AgentBundleRuntimeDrift;
 use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
 use DataMachine\Engine\Bundle\AgentPackageProjection;
+use DataMachine\Engine\Bundle\BundleSchema;
 use DataMachine\Engine\Bundle\BundleValidationException;
 use DataMachine\Engine\Bundle\PortableSlug;
 use DataMachine\Core\Steps\FlowStepConfig;
@@ -515,6 +516,16 @@ class AgentBundler {
 				'success'    => false,
 				'error_code' => 'install_invalid_bundle',
 				'error'      => 'Invalid bundle: missing bundle_version or agent data.',
+			);
+		}
+
+		try {
+			$bundle = $this->canonical_import_bundle( $bundle );
+		} catch ( BundleValidationException $e ) {
+			return array(
+				'success'    => false,
+				'error_code' => 'install_invalid_bundle',
+				'error'      => $e->getMessage(),
 			);
 		}
 
@@ -1127,6 +1138,36 @@ class AgentBundler {
 				'error'      => sprintf( 'Agent install rolled back: %s', $e->getMessage() ),
 			);
 		}
+	}
+
+	/**
+	 * Import an agent from a directory bundle value object.
+	 *
+	 * @param AgentBundleDirectory $directory Bundle directory value object.
+	 * @param string|null          $new_slug Optional override slug.
+	 * @param int                  $owner_id WordPress user ID to own the imported agent.
+	 * @param bool                 $dry_run If true, validate without writing.
+	 * @param array                $options Import options.
+	 * @return array{success: bool, message?: string, error?: string, error_code?: string, summary?: array}
+	 */
+	public function import_directory_object( AgentBundleDirectory $directory, ?string $new_slug = null, int $owner_id = 0, bool $dry_run = false, array $options = array() ): array {
+		return $this->import( AgentBundleArrayAdapter::to_array_bundle( $directory ), $new_slug, $owner_id, $dry_run, $options );
+	}
+
+	/**
+	 * Normalize schema-versioned bundle arrays through directory value objects before import.
+	 *
+	 * Legacy backup arrays intentionally keep the raw runtime-config path for compatibility.
+	 *
+	 * @param array $bundle Bundle array.
+	 * @return array Importable bundle array.
+	 */
+	private function canonical_import_bundle( array $bundle ): array {
+		if ( (string) ( $bundle['bundle_schema_version'] ?? '' ) !== BundleSchema::VERSION ) {
+			return $bundle;
+		}
+
+		return AgentBundleArrayAdapter::to_array_bundle( AgentBundleArrayAdapter::from_array_bundle( $bundle ) );
 	}
 
 	/**

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -277,6 +277,33 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$this->assertSame( array( 'mcp' => 7 ), $flow['scheduling_config']['max_items'] ?? null, 'Schedule limits import from directory document.' );
 	}
 
+	public function test_schema_versioned_array_import_does_not_require_source_install_ids(): void {
+		$bundle = AgentBundleArrayAdapter::to_array_bundle( AgentBundleArrayAdapter::from_array_bundle( $this->fixture_bundle( 'schema-array-agent' ) ) );
+		$this->assertSame( BundleSchema::VERSION, $bundle['bundle_schema_version'] ?? null, 'Test fixture uses integer schema version.' );
+		unset( $bundle['pipelines'][0]['original_id'], $bundle['flows'][0]['original_id'], $bundle['flows'][0]['original_pipeline_id'] );
+
+		$result = $this->bundler->import( $bundle, null, $this->owner_id );
+
+		$this->assertTrue( (bool) $result['success'], 'Schema-versioned array import succeeds.' );
+		$this->assertSame( 1, $result['summary']['flows_imported'] ?? null, 'Schema-versioned arrays rebuild portable flow references without source install IDs.' );
+
+		$agent    = $this->agents_repo->get_by_slug( 'schema-array-agent' );
+		$pipeline = $this->pipelines_repo->get_by_portable_slug( (int) $agent['agent_id'], 'static-site-pipeline' );
+		$flow     = $this->flows_repo->get_by_portable_slug( (int) $pipeline['pipeline_id'], 'static-site-flow' );
+
+		$this->assertNotEmpty( $flow, 'Flow imports from a schema-versioned array that omits source install IDs.' );
+	}
+
+	public function test_schema_versioned_array_import_preserves_abilities_manifest_for_dry_run_checks(): void {
+		$bundle                       = AgentBundleArrayAdapter::to_array_bundle( AgentBundleArrayAdapter::from_array_bundle( $this->fixture_bundle( 'schema-abilities-agent' ) ) );
+		$bundle['abilities_manifest'] = array( 'datamachine/test-missing-ability' );
+
+		$result = $this->bundler->import( $bundle, null, $this->owner_id, true );
+
+		$this->assertTrue( (bool) $result['success'], 'Schema-versioned dry run succeeds.' );
+		$this->assertSame( array( 'datamachine/test-missing-ability' ), $result['summary']['missing_abilities'] ?? null, 'Abilities manifest survives schema array canonicalization.' );
+	}
+
 	public function test_import_exposes_run_artifact_egress_policy_in_agent_and_flow_metadata(): void {
 		$bundle                  = $this->fixture_bundle( 'artifact-policy-agent' );
 		$bundle['run_artifacts'] = array(

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -36,6 +36,7 @@ use DataMachine\Core\Database\Jobs\Jobs as JobsRepository;
 use DataMachine\Core\Database\Pipelines\Pipelines as PipelinesRepository;
 use DataMachine\Abilities\Engine\RunFlowAbility;
 use DataMachine\Engine\AI\Tools\Global\AgentDailyMemory;
+use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
 use DataMachine\Engine\Bundle\AgentBundleInstalledArtifact;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\BundleSchema;
@@ -225,6 +226,55 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$this->assertSame( 'daily', $flow['scheduling_config']['interval'] ?? null, 'Importer preserves the bundle interval.' );
 		$this->assertTrue( $flow['scheduling_config']['enabled'] ?? false, 'Importer keeps scheduled bundle flows enabled.' );
 		$this->assertSame( array( 'mcp' => 5 ), $flow['scheduling_config']['max_items'] ?? null, 'Importer preserves bundle max item caps.' );
+	}
+
+	public function test_directory_value_object_import_preserves_workflow_runtime_seed_fields(): void {
+		$bundle = $this->fixture_bundle( 'directory-import-agent' );
+		$bundle['flows'][0]['flow_config']['1_step-uuid_1'] = array_merge(
+			$bundle['flows'][0]['flow_config']['1_step-uuid_1'],
+			array(
+				'step_type'          => 'fetch',
+				'handler_configs'    => array(
+					'mcp' => array(
+						'provider' => 'mgs',
+						'auth_ref' => 'mgs:default',
+					),
+				),
+				'enabled_tools'      => array( 'datamachine/search' ),
+				'disabled_tools'     => array( 'datamachine/delete-flow' ),
+				'config_patch_queue' => array(
+					array( 'patch' => array( 'query' => 'bundle-seed' ) ),
+				),
+				'queue_mode'         => 'loop',
+				'enabled'            => false,
+			)
+		);
+		$bundle['flows'][0]['scheduling_config'] = array(
+			'enabled'  => true,
+			'interval' => 'daily',
+			'max_items' => array(
+				'mcp' => 7,
+			),
+		);
+
+		$directory = AgentBundleArrayAdapter::from_array_bundle( $bundle );
+		$result    = $this->bundler->import_directory_object( $directory, null, $this->owner_id );
+
+		$this->assertTrue( (bool) $result['success'], 'Directory value-object import succeeds.' );
+
+		$agent    = $this->agents_repo->get_by_slug( 'directory-import-agent' );
+		$pipeline = $this->pipelines_repo->get_by_portable_slug( (int) $agent['agent_id'], 'static-site-pipeline' );
+		$flow     = $this->flows_repo->get_by_portable_slug( (int) $pipeline['pipeline_id'], 'static-site-flow' );
+		$step     = reset( $flow['flow_config'] );
+
+		$this->assertSame( 'mgs:default', $step['handler_configs']['mcp']['auth_ref'] ?? null, 'Handler config imports from directory document.' );
+		$this->assertSame( array( 'datamachine/search' ), $step['enabled_tools'] ?? null, 'Enabled tools import from directory document.' );
+		$this->assertSame( array( 'datamachine/delete-flow' ), $step['disabled_tools'] ?? null, 'Disabled tools import from directory document.' );
+		$this->assertSame( 'bundle-seed', $step['config_patch_queue'][0]['patch']['query'] ?? null, 'Queue seed imports from directory document.' );
+		$this->assertSame( 'loop', $step['queue_mode'] ?? null, 'Queue state imports from directory document.' );
+		$this->assertFalse( $step['enabled'] ?? true, 'Disabled step state imports from directory document.' );
+		$this->assertSame( 'daily', $flow['scheduling_config']['interval'] ?? null, 'Schedule imports from directory document.' );
+		$this->assertSame( array( 'mcp' => 7 ), $flow['scheduling_config']['max_items'] ?? null, 'Schedule limits import from directory document.' );
 	}
 
 	public function test_import_exposes_run_artifact_egress_policy_in_agent_and_flow_metadata(): void {

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -298,6 +298,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$bundle                       = AgentBundleArrayAdapter::to_array_bundle( AgentBundleArrayAdapter::from_array_bundle( $this->fixture_bundle( 'schema-abilities-agent' ) ) );
 		$bundle['abilities_manifest'] = array( 'datamachine/test-missing-ability' );
 
+		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 		$result = $this->bundler->import( $bundle, null, $this->owner_id, true );
 
 		$this->assertTrue( (bool) $result['success'], 'Schema-versioned dry run succeeds.' );


### PR DESCRIPTION
## Summary
- Route schema-versioned bundle arrays through `AgentBundleDirectory` value objects before import while keeping legacy raw arrays on the compatibility path.
- Add `AgentBundler::import_directory_object()` for direct value-object imports.
- Cover directory value-object import of handler config, enabled/disabled tools, queue state, disabled steps, and scheduling without source install IDs.

Refs #1501.

## Tests
- `php -l inc/Core/Agents/AgentBundler.php`
- `php -l tests/Unit/Core/Agents/AgentBundlerImportTest.php`
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `composer lint`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@issue-1501-bundler-import --extension wordpress --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing and testing the focused #1501 bundler import slice; Chris remains responsible for review.