### PR TITLE
fix: expose system task prompts as bundle artifacts

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -808,6 +808,10 @@ class AgentBundleCommand extends BaseCommand {
 			);
 		}
 
+		foreach ( self::bundle_file_artifacts( $bundle ) as $artifact ) {
+			$artifacts[] = $artifact;
+		}
+
 		foreach ( AgentBundleArtifactExtensions::normalize_artifacts( is_array( $bundle['extension_artifacts'] ?? null ) ? $bundle['extension_artifacts'] : array() ) as $artifact ) {
 			$artifacts[] = $artifact;
 		}
@@ -868,6 +872,7 @@ class AgentBundleCommand extends BaseCommand {
 
 		$artifacts = array_merge(
 			$artifacts,
+			\DataMachine\Engine\AI\System\SystemTaskPromptRegistry::current_artifacts(),
 			AgentBundleArtifactExtensions::current_artifacts(
 				$agent,
 				$installed,
@@ -876,6 +881,45 @@ class AgentBundleCommand extends BaseCommand {
 		);
 
 		return $artifacts;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private static function bundle_file_artifacts( array $bundle ): array {
+		$artifacts = array();
+		$files     = is_array( $bundle['artifact_files'] ?? null ) ? $bundle['artifact_files'] : array();
+
+		foreach ( self::bundle_file_artifact_directories() as $directory => $type ) {
+			foreach ( is_array( $files[ $directory ] ?? null ) ? $files[ $directory ] : array() as $relative_path => $payload ) {
+				$artifact_id = is_array( $payload ) && is_string( $payload['artifact_id'] ?? null )
+					? (string) $payload['artifact_id']
+					: self::artifact_id_from_relative_path( (string) $relative_path );
+
+				$artifacts[] = array(
+					'artifact_type' => $type,
+					'artifact_id'   => $artifact_id,
+					'source_path'   => $directory . '/' . ltrim( (string) $relative_path, '/' ),
+					'payload'       => $payload,
+				);
+			}
+		}
+
+		return $artifacts;
+	}
+
+	/** @return array<string,string> */
+	private static function bundle_file_artifact_directories(): array {
+		return array(
+			\DataMachine\Engine\Bundle\BundleSchema::PROMPTS_DIR       => 'prompt',
+			\DataMachine\Engine\Bundle\BundleSchema::RUBRICS_DIR       => 'rubric',
+			\DataMachine\Engine\Bundle\BundleSchema::TOOL_POLICIES_DIR => 'tool_policy',
+			\DataMachine\Engine\Bundle\BundleSchema::AUTH_REFS_DIR     => 'auth_ref',
+			\DataMachine\Engine\Bundle\BundleSchema::SEED_QUEUES_DIR   => 'seed_queue',
+		);
+	}
+
+	private static function artifact_id_from_relative_path( string $relative_path ): string {
+		$relative_path = preg_replace( '/\.(json|md|txt)$/i', '', $relative_path );
+		return null === $relative_path ? '' : $relative_path;
 	}
 
 	private function pipeline_payload( array $pipeline, string $portable_slug ): array {

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -33,7 +33,9 @@ use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
 use DataMachine\Engine\Bundle\AgentPackageProjection;
 use DataMachine\Engine\Bundle\BundleValidationException;
 use DataMachine\Engine\Bundle\PortableSlug;
+use DataMachine\Engine\Bundle\PromptArtifact;
 use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Engine\AI\System\SystemTaskPromptRegistry;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -221,6 +223,9 @@ class AgentBundler {
 
 		$pipeline_slugs  = array_map( fn( AgentBundlePipelineFile $pipeline ) => $pipeline->slug(), $pipeline_documents );
 		$flow_slugs      = array_map( fn( AgentBundleFlowFile $flow ) => $flow->slug(), $flow_documents );
+		$artifact_files  = array(
+			\DataMachine\Engine\Bundle\BundleSchema::PROMPTS_DIR => SystemTaskPromptRegistry::bundle_prompt_files(),
+		);
 		$extension_paths = array_map( static fn( array $artifact ) => (string) ( $artifact['source_path'] ?? '' ), $extension_artifacts );
 		$manifest        = new AgentBundleManifest(
 			gmdate( 'c' ),
@@ -239,13 +244,14 @@ class AgentBundler {
 				'memory'       => array_keys( $memory_files ),
 				'pipelines'    => $pipeline_slugs,
 				'flows'        => $flow_slugs,
+				'prompts'      => array_keys( $artifact_files[ \DataMachine\Engine\Bundle\BundleSchema::PROMPTS_DIR ] ),
 				'extensions'   => array_values( array_filter( $extension_paths ) ),
 				'handler_auth' => $handler_auth,
 			)
 		);
 
 		$extras    = self::collect_export_extras( $agent_id, $agent );
-		$directory = new AgentBundleDirectory( $manifest, $memory_files, $pipeline_documents, $flow_documents, array(), $extension_artifacts, $extras );
+		$directory = new AgentBundleDirectory( $manifest, $memory_files, $pipeline_documents, $flow_documents, $artifact_files, $extension_artifacts, $extras );
 
 		return array(
 			'success'   => true,
@@ -933,7 +939,41 @@ class AgentBundler {
 				);
 			}
 
-			// 6. Apply plugin-owned artifacts through their owning plugin.
+			// 6. Apply bundle-owned prompt artifacts without touching local overrides.
+			foreach ( self::bundle_file_artifacts( $bundle ) as $artifact ) {
+				if ( PromptArtifact::TYPE_PROMPT !== (string) $artifact['artifact_type'] ) {
+					continue;
+				}
+
+				$artifact_key = self::artifact_key( (string) $artifact['artifact_type'], (string) $artifact['artifact_id'] );
+				if ( SystemTaskPromptRegistry::has_local_override_for_artifact( $artifact ) ) {
+					$conflicts[] = array(
+						'artifact_type' => $artifact['artifact_type'],
+						'artifact_id'   => $artifact['artifact_id'],
+						'reason'        => 'local_modified',
+					);
+					continue;
+				}
+
+				if ( ! SystemTaskPromptRegistry::apply_bundle_artifact( $artifact ) ) {
+					$conflicts[] = array(
+						'artifact_type' => $artifact['artifact_type'],
+						'artifact_id'   => $artifact['artifact_id'],
+						'reason'        => 'missing_apply_handler',
+					);
+					continue;
+				}
+
+				$artifact_records[ $artifact_key ] = $this->bundle_artifact_record(
+					$bundle_metadata,
+					(string) $artifact['artifact_type'],
+					(string) $artifact['artifact_id'],
+					(string) $artifact['source_path'],
+					$artifact['payload'] ?? null
+				);
+			}
+
+			// 7. Apply plugin-owned artifacts through their owning plugin.
 			$agent_context               = array_merge(
 			$agent_data,
 			array(
@@ -1318,6 +1358,45 @@ class AgentBundler {
 			'installed_at'      => $now,
 			'updated_at'        => $now,
 		);
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private static function bundle_file_artifacts( array $bundle ): array {
+		$artifacts = array();
+		$files     = is_array( $bundle['artifact_files'] ?? null ) ? $bundle['artifact_files'] : array();
+
+		foreach ( self::bundle_file_artifact_directories() as $directory => $type ) {
+			foreach ( is_array( $files[ $directory ] ?? null ) ? $files[ $directory ] : array() as $relative_path => $payload ) {
+				$artifact_id = is_array( $payload ) && is_string( $payload['artifact_id'] ?? null )
+					? (string) $payload['artifact_id']
+					: self::artifact_id_from_relative_path( (string) $relative_path );
+
+				$artifacts[] = array(
+					'artifact_type' => $type,
+					'artifact_id'   => $artifact_id,
+					'source_path'   => $directory . '/' . ltrim( (string) $relative_path, '/' ),
+					'payload'       => $payload,
+				);
+			}
+		}
+
+		return $artifacts;
+	}
+
+	/** @return array<string,string> */
+	private static function bundle_file_artifact_directories(): array {
+		return array(
+			\DataMachine\Engine\Bundle\BundleSchema::PROMPTS_DIR       => 'prompt',
+			\DataMachine\Engine\Bundle\BundleSchema::RUBRICS_DIR       => 'rubric',
+			\DataMachine\Engine\Bundle\BundleSchema::TOOL_POLICIES_DIR => 'tool_policy',
+			\DataMachine\Engine\Bundle\BundleSchema::AUTH_REFS_DIR     => 'auth_ref',
+			\DataMachine\Engine\Bundle\BundleSchema::SEED_QUEUES_DIR   => 'seed_queue',
+		);
+	}
+
+	private static function artifact_id_from_relative_path( string $relative_path ): string {
+		$relative_path = preg_replace( '/\.(json|md|txt)$/i', '', $relative_path );
+		return null === $relative_path ? '' : $relative_path;
 	}
 
 	/** @param array<int,array<string,mixed>> $artifacts */

--- a/inc/Engine/AI/System/SystemTaskPromptRegistry.php
+++ b/inc/Engine/AI/System/SystemTaskPromptRegistry.php
@@ -10,11 +10,19 @@ namespace DataMachine\Engine\AI\System;
 defined( 'ABSPATH' ) || exit;
 
 use DataMachine\Engine\Bundle\PromptArtifact;
+use DataMachine\Engine\Bundle\BundleSchema;
+use DataMachine\Engine\Tasks\TaskRegistry;
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
 
 /**
  * Resolves versioned prompt artifacts for AI-backed system tasks.
  */
 final class SystemTaskPromptRegistry {
+
+	/**
+	 * Option key for bundle-installed system task prompt artifacts.
+	 */
+	private const INSTALLED_ARTIFACTS_OPTION = 'datamachine_system_task_prompt_artifacts';
 
 	/**
 	 * Build the stable artifact ID for a system task prompt.
@@ -50,6 +58,131 @@ final class SystemTaskPromptRegistry {
 	}
 
 	/**
+	 * Collect default system task prompt artifacts from registered tasks.
+	 *
+	 * @return array<string,PromptArtifact> Artifact ID => artifact.
+	 */
+	public static function default_artifacts(): array {
+		$artifacts = array();
+
+		foreach ( TaskRegistry::getHandlers() as $task_type => $handler_class ) {
+			if ( ! class_exists( $handler_class ) ) {
+				continue;
+			}
+
+			$task = new $handler_class();
+			if ( ! $task instanceof SystemTask ) {
+				continue;
+			}
+
+			foreach ( $task->getPromptDefinitions() as $prompt_key => $definition ) {
+				if ( ! is_array( $definition ) ) {
+					continue;
+				}
+
+				$artifact = self::artifact_from_definition( (string) $task_type, (string) $prompt_key, $definition );
+				if ( $artifact ) {
+					$artifacts[ $artifact->artifact_id() ] = self::installed_artifact_for( $artifact ) ?? $artifact;
+				}
+			}
+		}
+
+		ksort( $artifacts, SORT_STRING );
+		return $artifacts;
+	}
+
+	/**
+	 * Build bundle prompt files for system task prompt artifacts.
+	 *
+	 * @return array<string,array<string,mixed>> Relative path under prompts/ => artifact payload.
+	 */
+	public static function bundle_prompt_files(): array {
+		$files = array();
+		foreach ( self::default_artifacts() as $artifact ) {
+			$files[ self::bundle_relative_path( $artifact ) ] = $artifact->to_array();
+		}
+
+		ksort( $files, SORT_STRING );
+		return $files;
+	}
+
+	/**
+	 * Report current runtime artifact state for upgrade planning.
+	 *
+	 * Local overrides deliberately change the reported payload hash so upgrade
+	 * planning treats them as locally modified instead of overwriting them.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	public static function current_artifacts(): array {
+		$artifacts = array();
+		$overrides = SystemTask::getAllPromptOverrides();
+
+		foreach ( self::default_artifacts() as $artifact ) {
+			$metadata   = $artifact->version_metadata()['metadata'] ?? array();
+			$task_type  = is_array( $metadata ) ? (string) ( $metadata['task_type'] ?? '' ) : '';
+			$prompt_key = is_array( $metadata ) ? (string) ( $metadata['prompt_key'] ?? '' ) : '';
+			$override   = $overrides[ $task_type ][ $prompt_key ] ?? null;
+
+			$artifacts[] = array(
+				'artifact_type' => PromptArtifact::TYPE_PROMPT,
+				'artifact_id'   => $artifact->artifact_id(),
+				'source_path'   => BundleSchema::PROMPTS_DIR . '/' . self::bundle_relative_path( $artifact ),
+				'payload'       => self::payload_with_override( $artifact, is_string( $override ) ? $override : null ),
+			);
+		}
+
+		return $artifacts;
+	}
+
+	/**
+	 * Apply a bundle-carried system task prompt artifact without touching overrides.
+	 *
+	 * @param array<string,mixed> $artifact Artifact envelope.
+	 * @return bool True when the artifact was accepted and stored.
+	 */
+	public static function apply_bundle_artifact( array $artifact ): bool {
+		if ( PromptArtifact::TYPE_PROMPT !== (string) ( $artifact['artifact_type'] ?? '' ) ) {
+			return false;
+		}
+
+		$payload = is_array( $artifact['payload'] ?? null ) ? $artifact['payload'] : array();
+		if ( empty( $payload ) ) {
+			return false;
+		}
+
+		$prompt_artifact = PromptArtifact::from_array( $payload );
+		if ( ! str_starts_with( $prompt_artifact->artifact_id(), 'system-task:' ) ) {
+			return false;
+		}
+
+		$installed                          = self::installed_artifacts();
+		$installed[ $prompt_artifact->artifact_id() ] = $prompt_artifact->to_array();
+
+		return update_option( self::INSTALLED_ARTIFACTS_OPTION, $installed, false );
+	}
+
+	/**
+	 * Whether applying the target would collide with a local prompt override.
+	 */
+	public static function has_local_override_for_artifact( array $artifact ): bool {
+		$payload = is_array( $artifact['payload'] ?? null ) ? $artifact['payload'] : array();
+		if ( empty( $payload ) ) {
+			return false;
+		}
+
+		$metadata   = is_array( $payload['metadata'] ?? null ) ? $payload['metadata'] : array();
+		$task_type  = (string) ( $metadata['task_type'] ?? '' );
+		$prompt_key = (string) ( $metadata['prompt_key'] ?? '' );
+		if ( '' === $task_type || '' === $prompt_key ) {
+			return false;
+		}
+
+		$overrides = SystemTask::getAllPromptOverrides();
+		return isset( $overrides[ $task_type ][ $prompt_key ] ) && '' !== (string) $overrides[ $task_type ][ $prompt_key ];
+	}
+
+	/**
 	 * Resolve an effective task prompt through the artifact seam.
 	 *
 	 * @param  string              $task_type  Task slug.
@@ -59,6 +192,7 @@ final class SystemTaskPromptRegistry {
 	 * @return array{content:string, artifact_id:string, content_hash:string, source:string, version:string, artifact:?PromptArtifact}
 	 */
 	public static function resolve_effective_prompt( string $task_type, string $prompt_key, ?PromptArtifact $artifact, ?string $override = null ): array {
+		$artifact = $artifact ? ( self::installed_artifact_for( $artifact ) ?? $artifact ) : null;
 		$override = null === $override ? null : (string) $override;
 		$content  = null !== $override && '' !== $override ? $override : ( $artifact ? $artifact->content() : '' );
 		$source   = null !== $override && '' !== $override ? 'override' : 'artifact';
@@ -101,5 +235,53 @@ final class SystemTaskPromptRegistry {
 			'version'      => isset( $resolved['version'] ) ? (string) $resolved['version'] : ( $artifact ? $artifact->version() : '' ),
 			'artifact'     => $resolved['artifact'] ?? $artifact,
 		);
+	}
+
+	private static function installed_artifact_for( PromptArtifact $default_artifact ): ?PromptArtifact {
+		$installed = self::installed_artifacts();
+		$payload   = $installed[ $default_artifact->artifact_id() ] ?? null;
+		if ( ! is_array( $payload ) ) {
+			return null;
+		}
+
+		try {
+			$artifact = PromptArtifact::from_array( $payload );
+		} catch ( \Throwable $e ) {
+			return null;
+		}
+
+		return $artifact->artifact_id() === $default_artifact->artifact_id() ? $artifact : null;
+	}
+
+	/** @return array<string,array<string,mixed>> */
+	private static function installed_artifacts(): array {
+		$stored = get_option( self::INSTALLED_ARTIFACTS_OPTION, array() );
+		return is_array( $stored ) ? $stored : array();
+	}
+
+	private static function bundle_relative_path( PromptArtifact $artifact ): string {
+		$metadata   = $artifact->version_metadata()['metadata'] ?? array();
+		$task_type  = is_array( $metadata ) ? sanitize_key( (string) ( $metadata['task_type'] ?? '' ) ) : '';
+		$prompt_key = is_array( $metadata ) ? sanitize_key( (string) ( $metadata['prompt_key'] ?? '' ) ) : '';
+		if ( '' !== $task_type && '' !== $prompt_key ) {
+			return 'system-tasks/' . $task_type . '/' . $prompt_key . '.json';
+		}
+
+		return 'system-tasks/' . sanitize_key( str_replace( ':', '-', $artifact->artifact_id() ) ) . '.json';
+	}
+
+	/** @return array<string,mixed> */
+	private static function payload_with_override( PromptArtifact $artifact, ?string $override ): array {
+		$payload = $artifact->to_array();
+		if ( null === $override || '' === $override ) {
+			return $payload;
+		}
+
+		$payload['content']      = $override;
+		$payload['content_hash'] = hash( 'sha256', $override );
+		$payload['metadata']     = is_array( $payload['metadata'] ?? null ) ? $payload['metadata'] : array();
+		$payload['metadata']['local_override'] = true;
+
+		return $payload;
 	}
 }

--- a/inc/Engine/AI/System/SystemTaskPromptRegistry.php
+++ b/inc/Engine/AI/System/SystemTaskPromptRegistry.php
@@ -156,7 +156,7 @@ final class SystemTaskPromptRegistry {
 			return false;
 		}
 
-		$installed                          = self::installed_artifacts();
+		$installed                                    = self::installed_artifacts();
 		$installed[ $prompt_artifact->artifact_id() ] = $prompt_artifact->to_array();
 
 		return update_option( self::INSTALLED_ARTIFACTS_OPTION, $installed, false );
@@ -277,9 +277,9 @@ final class SystemTaskPromptRegistry {
 			return $payload;
 		}
 
-		$payload['content']      = $override;
-		$payload['content_hash'] = hash( 'sha256', $override );
-		$payload['metadata']     = is_array( $payload['metadata'] ?? null ) ? $payload['metadata'] : array();
+		$payload['content']                    = $override;
+		$payload['content_hash']               = hash( 'sha256', $override );
+		$payload['metadata']                   = is_array( $payload['metadata'] ?? null ) ? $payload['metadata'] : array();
 		$payload['metadata']['local_override'] = true;
 
 		return $payload;

--- a/inc/Engine/Bundle/AgentBundleArrayAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleArrayAdapter.php
@@ -54,7 +54,7 @@ final class AgentBundleArrayAdapter {
 			self::memory_files_from_array_bundle( $bundle, $pipeline_slugs, $flow_slugs ),
 			self::pipeline_files_from_array_bundle( $bundle['pipelines'] ?? array(), $pipeline_slugs ),
 			self::flow_files_from_array_bundle( $bundle['flows'] ?? array(), $bundle['pipelines'] ?? array(), $pipeline_slugs, $flow_slugs ),
-			array(),
+			self::artifact_files_from_array_bundle( $bundle ),
 			is_array( $bundle['extension_artifacts'] ?? null ) ? $bundle['extension_artifacts'] : array(),
 			is_array( $bundle['extras'] ?? null ) ? $bundle['extras'] : array()
 		);
@@ -154,6 +154,7 @@ final class AgentBundleArrayAdapter {
 			'user_template'         => $memory_files['USER.md'] ?? '',
 			'pipelines'             => $pipelines,
 			'flows'                 => $flows,
+			'artifact_files'        => self::artifact_files_from_directory( $directory ),
 			'extension_artifacts'   => $directory->extension_artifacts(),
 			'extras'                => $directory->extras(),
 			'abilities_manifest'    => array(),
@@ -164,6 +165,42 @@ final class AgentBundleArrayAdapter {
 		}
 
 		return $bundle;
+	}
+
+	/** @return array<string,array<string,array|string>> */
+	private static function artifact_files_from_array_bundle( array $bundle ): array {
+		$artifact_files = is_array( $bundle['artifact_files'] ?? null ) ? $bundle['artifact_files'] : array();
+		$normalized     = array();
+
+		foreach ( self::artifact_file_directories() as $directory ) {
+			if ( is_array( $artifact_files[ $directory ] ?? null ) ) {
+				$normalized[ $directory ] = $artifact_files[ $directory ];
+			}
+		}
+
+		return $normalized;
+	}
+
+	/** @return array<string,array<string,array|string>> */
+	private static function artifact_files_from_directory( AgentBundleDirectory $directory ): array {
+		return array(
+			BundleSchema::PROMPTS_DIR       => $directory->prompts(),
+			BundleSchema::RUBRICS_DIR       => $directory->rubrics(),
+			BundleSchema::TOOL_POLICIES_DIR => $directory->tool_policies(),
+			BundleSchema::AUTH_REFS_DIR     => $directory->auth_refs(),
+			BundleSchema::SEED_QUEUES_DIR   => $directory->seed_queues(),
+		);
+	}
+
+	/** @return string[] */
+	private static function artifact_file_directories(): array {
+		return array(
+			BundleSchema::PROMPTS_DIR,
+			BundleSchema::RUBRICS_DIR,
+			BundleSchema::TOOL_POLICIES_DIR,
+			BundleSchema::AUTH_REFS_DIR,
+			BundleSchema::SEED_QUEUES_DIR,
+		);
 	}
 
 	/** @param array<int,array<string,mixed>> $pipelines */

--- a/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
@@ -128,7 +128,7 @@ final class AgentBundleUpgradePlanner {
 			foreach ( $bundle->{$method}() as $relative_path => $payload ) {
 				$artifacts[] = array(
 					'artifact_type' => $type,
-					'artifact_id'   => self::artifact_id_from_relative_path( (string) $relative_path ),
+					'artifact_id'   => self::artifact_id_from_payload( $payload, (string) $relative_path ),
 					'source_path'   => $directory . '/' . $relative_path,
 					'payload'       => $payload,
 				);
@@ -156,6 +156,14 @@ final class AgentBundleUpgradePlanner {
 	private static function artifact_id_from_relative_path( string $relative_path ): string {
 		$relative_path = preg_replace( '/\.(json|md|txt)$/i', '', $relative_path );
 		return null === $relative_path ? '' : $relative_path;
+	}
+
+	private static function artifact_id_from_payload( mixed $payload, string $relative_path ): string {
+		if ( is_array( $payload ) && is_string( $payload['artifact_id'] ?? null ) && '' !== trim( $payload['artifact_id'] ) ) {
+			return (string) $payload['artifact_id'];
+		}
+
+		return self::artifact_id_from_relative_path( $relative_path );
 	}
 
 	/** @param array<int,array<string,mixed>|AgentBundleInstalledArtifact> $artifacts */

--- a/tests/prompt-auth-template-artifacts-smoke.php
+++ b/tests/prompt-auth-template-artifacts-smoke.php
@@ -117,7 +117,8 @@ if ( ! function_exists( 'get_option' ) ) {
 }
 
 if ( ! function_exists( 'update_option' ) ) {
-	function update_option( $key, $value ) {
+	function update_option( $key, $value, $autoload = null ) {
+		unset( $autoload );
 		$GLOBALS['__prompt_smoke_options'][ $key ] = $value;
 		return true;
 	}
@@ -129,6 +130,9 @@ use DataMachine\Engine\AI\System\SystemTaskPromptRegistry;
 use DataMachine\Engine\AI\System\Tasks\SystemTask;
 use DataMachine\Api\System\System;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
+use DataMachine\Engine\Bundle\AgentBundleDirectory;
+use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
+use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
 use DataMachine\Engine\Bundle\AgentTemplateMetadata;
 use DataMachine\Engine\Bundle\AuthRef;
 use DataMachine\Engine\Bundle\AuthRefResolver;
@@ -312,6 +316,56 @@ $prompt_detail_response = System::get_prompt( new WP_REST_Request( array( 'task_
 $prompt_detail          = $prompt_detail_response['data'];
 prompt_artifact_assert_equals( 'REST prompt detail exposes artifact source path', 'system-tasks/fixture_generation/generate.md', $prompt_detail['artifact_source_path'] ?? null );
 prompt_artifact_assert_equals( 'REST prompt detail exposes default artifact hash', hash( 'sha256', 'Write about {{topic}}.' ), $prompt_detail['artifact_hash'] ?? null );
+
+$bundle_prompt_files = SystemTaskPromptRegistry::bundle_prompt_files();
+$prompt_payload      = $bundle_prompt_files['system-tasks/fixture_generation/generate.json'] ?? array();
+prompt_artifact_assert( 'system task prompt exports as bundle prompt artifact', is_array( $prompt_payload ) && 'system-task:fixture_generation:generate' === ( $prompt_payload['artifact_id'] ?? '' ) );
+
+$directory = new AgentBundleDirectory(
+	AgentBundleManifest::from_array(
+		array(
+			'schema_version' => 1,
+			'bundle_slug'    => 'system-prompt-fixture',
+			'bundle_version' => '1.0.0',
+			'exported_at'    => '2026-04-28T00:00:00Z',
+			'exported_by'    => 'data-machine/test',
+			'agent'          => array(
+				'slug'         => 'fixture-agent',
+				'label'        => 'Fixture Agent',
+				'description'  => 'Exercises system prompt bundle artifacts.',
+				'agent_config' => array(),
+			),
+			'included'       => array(
+				'memory'       => array(),
+				'pipelines'    => array(),
+				'flows'        => array(),
+				'prompts'      => array_keys( $bundle_prompt_files ),
+				'handler_auth' => 'refs',
+			),
+		)
+	),
+	array(),
+	array(),
+	array(),
+	array( BundleSchema::PROMPTS_DIR => $bundle_prompt_files )
+);
+$array_bundle = AgentBundleArrayAdapter::to_array_bundle( $directory );
+$round_trip   = AgentBundleArrayAdapter::from_array_bundle( $array_bundle );
+prompt_artifact_assert_equals( 'array bundle preserves prompt artifact files', $prompt_payload, $round_trip->prompts()['system-tasks/fixture_generation/generate.json'] ?? null );
+
+$target_artifacts = AgentBundleUpgradePlanner::artifacts_from_bundle( $directory );
+$target_prompt    = array_values( array_filter( $target_artifacts, static fn( array $artifact ): bool => 'system-task:fixture_generation:generate' === ( $artifact['artifact_id'] ?? '' ) ) )[0] ?? array();
+prompt_artifact_assert_equals( 'upgrade planner uses payload artifact ID for system prompt', 'prompt', $target_prompt['artifact_type'] ?? null );
+
+SystemTaskPromptRegistry::apply_bundle_artifact( $target_prompt );
+$current_without_override = SystemTaskPromptRegistry::current_artifacts()[0] ?? array();
+prompt_artifact_assert_equals( 'installed prompt artifact is current when no override exists', $prompt_payload['content_hash'], $current_without_override['payload']['content_hash'] ?? null );
+
+SystemTask::setPromptOverride( 'fixture_generation', 'generate', 'Local {{topic}} override.' );
+$current_with_override = SystemTaskPromptRegistry::current_artifacts()[0] ?? array();
+prompt_artifact_assert_equals( 'local override changes current artifact hash deterministically', hash( 'sha256', 'Local {{topic}} override.' ), $current_with_override['payload']['content_hash'] ?? null );
+prompt_artifact_assert( 'local override is detectable before bundle apply', SystemTaskPromptRegistry::has_local_override_for_artifact( $target_prompt ) );
+SystemTask::setPromptOverride( 'fixture_generation', 'generate', '' );
 
 echo "\n[3] Agent template source/version metadata round-trips\n";
 $manifest       = AgentBundleManifest::from_array(


### PR DESCRIPTION
## Summary
- Exposes registered system task prompt definitions as versioned `prompts/system-tasks/...json` bundle artifacts during export.
- Preserves prompt artifact files through array bundle import/export and includes them in upgrade planning with stable artifact IDs.
- Adds a shared installed system-task prompt artifact store so runtime resolution can use installed artifact defaults while local overrides remain untouched and are reported as locally modified.

## Tests
- `php tests/prompt-auth-template-artifacts-smoke.php`
- `php tests/agent-bundle-format-smoke.php`
- `php tests/datamachine-package-artifacts-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/System/SystemTaskPromptRegistry.php inc/Core/Agents/AgentBundler.php inc/Engine/Bundle/AgentBundleArrayAdapter.php inc/Engine/Bundle/AgentBundleUpgradePlanner.php inc/Cli/Commands/AgentBundleCommand.php tests/prompt-auth-template-artifacts-smoke.php`

## Notes
- `php tests/agent-bundle-upgrade-planner-smoke.php` currently fatals before exercising this change because the smoke stubs `AgentsAPI\\Core\\Workspace\\WP_Agent_Workspace_Scope` and then Composer autoload loads the same class from `vendor/automattic/agents-api`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing and testing the focused #1536 system prompt artifact slice; Chris remains responsible for review.

Fixes #1536