### PR TITLE
Add async runtime tool broker

### DIFF
--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -232,6 +232,16 @@ class ChatOrchestrator {
 			'current_turn'      => $result['turn_count'],
 			'has_pending_tools' => ! $is_completed,
 		);
+		if ( ! empty( $result['runtime_tool_pending_requests'] ) ) {
+			$metadata['runtime_tool_requests'] = array();
+			foreach ( (array) $result['runtime_tool_pending_requests'] as $request ) {
+				if ( is_array( $request ) && ! empty( $request['request_id'] ) ) {
+					$metadata['runtime_tool_requests'][ (string) $request['request_id'] ] = $request;
+				}
+			}
+			$metadata['runtime_tool_pending'] = true;
+			$metadata['has_pending_tools']    = true;
+		}
 
 		// Accumulate token usage across turns in session metadata.
 		$turn_usage = $result['usage'] ?? array();
@@ -288,6 +298,9 @@ class ChatOrchestrator {
 			'max_turns'    => $max_turns,
 			'turn_number'  => $result['turn_count'],
 		);
+		if ( ! empty( $result['runtime_tool_pending_requests'] ) ) {
+			$response_data['runtime_tool_pending_requests'] = $result['runtime_tool_pending_requests'];
+		}
 
 		if ( isset( $result['warning'] ) ) {
 			$response_data['warning'] = $result['warning'];
@@ -411,6 +424,19 @@ class ChatOrchestrator {
 			'current_turn'      => $current_turn,
 			'has_pending_tools' => ! $is_completed,
 		);
+		if ( ! empty( $metadata['runtime_tool_requests'] ) ) {
+			$updated_metadata['runtime_tool_requests'] = $metadata['runtime_tool_requests'];
+		}
+		if ( ! empty( $result['runtime_tool_pending_requests'] ) ) {
+			$updated_metadata['runtime_tool_requests'] = is_array( $updated_metadata['runtime_tool_requests'] ?? null ) ? $updated_metadata['runtime_tool_requests'] : array();
+			foreach ( (array) $result['runtime_tool_pending_requests'] as $request ) {
+				if ( is_array( $request ) && ! empty( $request['request_id'] ) ) {
+					$updated_metadata['runtime_tool_requests'][ (string) $request['request_id'] ] = $request;
+				}
+			}
+			$updated_metadata['runtime_tool_pending'] = true;
+			$updated_metadata['has_pending_tools']    = true;
+		}
 
 		// Accumulate token usage across continuation turns.
 		$turn_usage     = $result['usage'] ?? array();
@@ -450,6 +476,9 @@ class ChatOrchestrator {
 			'max_turns'         => $max_turns,
 			'max_turns_reached' => $max_turns_reached,
 		);
+		if ( ! empty( $result['runtime_tool_pending_requests'] ) ) {
+			$continue_response['runtime_tool_pending_requests'] = $result['runtime_tool_pending_requests'];
+		}
 
 		/** This action is documented in inc/Api/Chat/ChatOrchestrator.php */
 		do_action( 'datamachine_chat_response_complete', $session_id, $continue_response, (int) ( $session['agent_id'] ?? 0 ), $user_id );
@@ -820,14 +849,15 @@ class ChatOrchestrator {
 			}
 
 			return array(
-				'messages'          => $loop_result['messages'],
-				'final_content'     => $loop_result['final_content'],
-				'completed'         => $loop_result['completed'] ?? false,
-				'turn_count'        => $loop_result['turn_count'] ?? 1,
-				'last_tool_calls'   => $loop_result['last_tool_calls'] ?? array(),
-				'warning'           => $loop_result['warning'] ?? null,
-				'max_turns_reached' => $loop_result['max_turns_reached'] ?? false,
-				'usage'             => $loop_result['usage'] ?? array(),
+				'messages'                       => $loop_result['messages'],
+				'final_content'                  => $loop_result['final_content'],
+				'completed'                      => $loop_result['completed'] ?? false,
+				'turn_count'                     => $loop_result['turn_count'] ?? 1,
+				'last_tool_calls'                => $loop_result['last_tool_calls'] ?? array(),
+				'warning'                        => $loop_result['warning'] ?? null,
+				'max_turns_reached'              => $loop_result['max_turns_reached'] ?? false,
+				'usage'                          => $loop_result['usage'] ?? array(),
+				'runtime_tool_pending_requests' => $loop_result['runtime_tool_pending_requests'] ?? array(),
 			);
 		} catch ( \Throwable $e ) {
 			do_action(

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -849,14 +849,14 @@ class ChatOrchestrator {
 			}
 
 			return array(
-				'messages'                       => $loop_result['messages'],
-				'final_content'                  => $loop_result['final_content'],
-				'completed'                      => $loop_result['completed'] ?? false,
-				'turn_count'                     => $loop_result['turn_count'] ?? 1,
-				'last_tool_calls'                => $loop_result['last_tool_calls'] ?? array(),
-				'warning'                        => $loop_result['warning'] ?? null,
-				'max_turns_reached'              => $loop_result['max_turns_reached'] ?? false,
-				'usage'                          => $loop_result['usage'] ?? array(),
+				'messages'                      => $loop_result['messages'],
+				'final_content'                 => $loop_result['final_content'],
+				'completed'                     => $loop_result['completed'] ?? false,
+				'turn_count'                    => $loop_result['turn_count'] ?? 1,
+				'last_tool_calls'               => $loop_result['last_tool_calls'] ?? array(),
+				'warning'                       => $loop_result['warning'] ?? null,
+				'max_turns_reached'             => $loop_result['max_turns_reached'] ?? false,
+				'usage'                         => $loop_result['usage'] ?? array(),
 				'runtime_tool_pending_requests' => $loop_result['runtime_tool_pending_requests'] ?? array(),
 			);
 		} catch ( \Throwable $e ) {

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -618,7 +618,7 @@ function datamachine_build_turn_runner(
 				}
 
 				if ( ! empty( $tool_result['pending'] ) && is_array( $tool_result['runtime_tool_request'] ?? null ) ) {
-					$runtime_tool_pending    = true;
+					$runtime_tool_pending     = true;
 					$runtime_pending_turn     = true;
 					$conversation_complete    = true;
 					$runtime_tool_requests[]  = $tool_result['runtime_tool_request'];
@@ -1073,9 +1073,9 @@ function datamachine_store_runtime_tool_request_on_session( array $pending_reque
 		? $metadata['runtime_tool_requests']
 		: array();
 	$metadata['runtime_tool_requests'][ $pending_request['request_id'] ] = $pending_request;
-	$metadata['has_pending_tools'] = true;
-	$metadata['status']            = 'processing';
-	$metadata['last_activity']     = function_exists( 'current_time' ) ? current_time( 'mysql', true ) : gmdate( 'Y-m-d H:i:s' );
+	$metadata['has_pending_tools']                                       = true;
+	$metadata['status']        = 'processing';
+	$metadata['last_activity'] = function_exists( 'current_time' ) ? current_time( 'mysql', true ) : gmdate( 'Y-m-d H:i:s' );
 
 	$chat_db->update_session(
 		$session_id,
@@ -1151,9 +1151,9 @@ function datamachine_submit_runtime_tool_result( string $request_id, $result ): 
 		(string) ( $session['model'] ?? '' )
 	);
 
-	$request['status']       = ! empty( $tool_result['success'] ) ? 'fulfilled' : 'failed';
-	$request['fulfilled_at'] = gmdate( 'c' );
-	$request['result']       = $tool_result;
+	$request['status']                   = ! empty( $tool_result['success'] ) ? 'fulfilled' : 'failed';
+	$request['fulfilled_at']             = gmdate( 'c' );
+	$request['result']                   = $tool_result;
 	$engine_data['runtime_tool_request'] = $request;
 	$jobs_db->store_engine_data( $job_id, $engine_data );
 	$jobs_db->complete_job( $job_id, ! empty( $tool_result['success'] ) ? 'completed' : 'failed' );

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -83,6 +83,8 @@ function datamachine_run_conversation(
 	$last_request_metadata  = array();
 	$latest_messages        = $messages;
 	$latest_turn_count      = 0;
+	$runtime_tool_pending   = false;
+	$runtime_tool_requests  = array();
 
 	// Base log context for consistent logging.
 	$base_log_context = array_filter(
@@ -189,13 +191,18 @@ function datamachine_run_conversation(
 		$completion_nudges,
 		$last_request_metadata,
 		$latest_messages,
-		$latest_turn_count
+		$latest_turn_count,
+		$runtime_tool_pending,
+		$runtime_tool_requests
 	);
 
 	// Build should_continue callback. Budget enforcement is handled by
 	// upstream via the budgets option — we only check DM-specific conditions.
 	$should_continue = static function ( array $result, array $turn_context ) use ( $single_turn ): bool {
 		unset( $turn_context ); // Required by upstream callable signature.
+		if ( ! empty( $result['runtime_tool_pending'] ) ) {
+			return false;
+		}
 		if ( $single_turn ) {
 			return false;
 		}
@@ -297,6 +304,12 @@ function datamachine_run_conversation(
 	// DM-only fields that the substrate doesn't know about.
 	$result['completed']       = 'budget_exceeded' !== ( $result['status'] ?? '' );
 	$result['last_tool_calls'] = $last_tool_calls;
+	if ( $runtime_tool_pending ) {
+		$result['completed']                     = false;
+		$result['runtime_tool_pending']          = true;
+		$result['runtime_tool_pending_requests'] = $runtime_tool_requests;
+		$result['status']                        = 'runtime_tool_pending';
+	}
 	if ( ! empty( $completion_nudges ) ) {
 		$latest_nudge                              = $completion_nudges[ count( $completion_nudges ) - 1 ];
 		$result['completion_nudge_count']          = count( $completion_nudges );
@@ -375,7 +388,9 @@ function datamachine_build_turn_runner(
 	array &$completion_nudges,
 	array &$last_request_metadata,
 	array &$latest_messages,
-	int &$latest_turn_count
+	int &$latest_turn_count,
+	bool &$runtime_tool_pending,
+	array &$runtime_tool_requests
 ): callable {
 	return static function ( array $messages, array $turn_context ) use (
 		$tools,
@@ -393,7 +408,9 @@ function datamachine_build_turn_runner(
 		&$completion_nudges,
 		&$last_request_metadata,
 		&$latest_messages,
-		&$latest_turn_count
+		&$latest_turn_count,
+		&$runtime_tool_pending,
+		&$runtime_tool_requests
 	): array {
 		// The upstream loop provides the turn number via turn_context.
 		$turn_count        = (int) ( $turn_context['turn'] ?? 1 );
@@ -487,6 +504,7 @@ function datamachine_build_turn_runner(
 		$completion_nudge       = '';
 		$duplicate_rejected     = false;
 		$runtime_rule_rejected  = false;
+		$runtime_pending_turn   = false;
 		if ( ! empty( $tool_calls ) ) {
 			foreach ( $tool_calls as $tool_call ) {
 				$tool_name       = $tool_call['name'];
@@ -599,6 +617,24 @@ function datamachine_build_turn_runner(
 					);
 				}
 
+				if ( ! empty( $tool_result['pending'] ) && is_array( $tool_result['runtime_tool_request'] ?? null ) ) {
+					$runtime_tool_pending    = true;
+					$runtime_pending_turn     = true;
+					$conversation_complete    = true;
+					$runtime_tool_requests[]  = $tool_result['runtime_tool_request'];
+					$tool_execution_results[] = array(
+						'tool_name'       => $tool_name,
+						'result'          => $tool_result,
+						'parameters'      => $tool_parameters,
+						'is_handler_tool' => false,
+						'runtime'         => datamachine_tool_runtime_metadata( is_array( $tool_def ) ? $tool_def : null, $tool_result ),
+						'turn_count'      => $turn_count,
+					);
+					$all_tool_results[]       = $tool_execution_results[ count( $tool_execution_results ) - 1 ];
+					datamachine_persist_inflight_tool_summary( $loop_payload, $tool_execution_results );
+					break;
+				}
+
 				do_action(
 					'datamachine_log',
 					'debug',
@@ -670,7 +706,7 @@ function datamachine_build_turn_runner(
 				}
 			}
 
-			if ( '' !== $completion_nudge && datamachine_should_append_tool_completion_nudge( $tool_execution_results, $completion_decision->context() ) ) {
+			if ( ! $runtime_pending_turn && '' !== $completion_nudge && datamachine_should_append_tool_completion_nudge( $tool_execution_results, $completion_decision->context() ) ) {
 				$messages[] = ConversationManager::buildConversationMessage( 'user', $completion_nudge );
 				datamachine_record_completion_nudge(
 					$completion_nudges,
@@ -735,6 +771,7 @@ function datamachine_build_turn_runner(
 			'completion_nudge'             => $completion_nudge ?? '',
 			'duplicate_tool_call_rejected' => $duplicate_rejected,
 			'tool_runtime_rule_rejected'   => $runtime_rule_rejected,
+			'runtime_tool_pending'         => $runtime_pending_turn,
 		);
 	};
 }
@@ -899,6 +936,15 @@ function datamachine_fulfill_runtime_tool_call(
 		$result = new \WP_Error( 'runtime_tool_callback_failed', $e->getMessage() );
 	}
 
+	if ( null === $result && datamachine_should_defer_runtime_tool_call( $request, $payload ) ) {
+		$deferred = datamachine_defer_runtime_tool_call( $request, $payload );
+		if ( ! ( $deferred instanceof \WP_Error ) ) {
+			return $deferred;
+		}
+
+		$result = $deferred;
+	}
+
 	$tool_result = datamachine_normalize_runtime_tool_result( $tool_name, $result );
 
 	datamachine_emit_loop_event(
@@ -916,6 +962,276 @@ function datamachine_fulfill_runtime_tool_call(
 	);
 
 	return $tool_result;
+}
+
+/**
+ * Whether a runtime tool call should pause the run for async fulfillment.
+ *
+ * @param array<string,mixed> $request Runtime tool request.
+ * @param array<string,mixed> $payload Loop/tool payload.
+ */
+function datamachine_should_defer_runtime_tool_call( array $request, array $payload ): bool {
+	$client_context = is_array( $payload['client_context'] ?? null ) ? $payload['client_context'] : array();
+	if ( empty( $client_context['runtime_tool_async'] ) ) {
+		return false;
+	}
+
+	return '' !== (string) ( $request['session_id'] ?? '' );
+}
+
+/**
+ * Persist a pending runtime tool request and schedule its timeout.
+ *
+ * @param array<string,mixed> $request Runtime tool request.
+ * @param array<string,mixed> $payload Loop/tool payload.
+ * @return array<string,mixed>|\WP_Error Pending tool result or persistence error.
+ */
+function datamachine_defer_runtime_tool_call( array $request, array $payload ): array|\WP_Error {
+	$jobs_db = new \DataMachine\Core\Database\Jobs\Jobs();
+	$job_id  = $jobs_db->create_job(
+		array(
+			'pipeline_id' => null,
+			'flow_id'     => null,
+			'source'      => 'runtime_tool',
+			'label'       => 'Runtime tool: ' . (string) ( $request['tool_name'] ?? '' ),
+			'user_id'     => (int) ( $payload['user_id'] ?? 0 ),
+			'agent_id'    => (int) ( $payload['agent_id'] ?? 0 ),
+		)
+	);
+
+	if ( ! $job_id ) {
+		return new \WP_Error( 'runtime_tool_request_not_persisted', 'Runtime tool request could not be persisted.' );
+	}
+
+	$request_id      = 'runtime_tool_' . (int) $job_id;
+	$client_context  = is_array( $payload['client_context'] ?? null ) ? $payload['client_context'] : array();
+	$timeout_seconds = max( 5, (int) ( $client_context['runtime_tool_timeout'] ?? 300 ) );
+	$pending_request = array(
+		'request_id'      => $request_id,
+		'job_id'          => (int) $job_id,
+		'status'          => 'pending',
+		'tool_name'       => (string) ( $request['tool_name'] ?? '' ),
+		'call_id'         => (string) ( $request['call_id'] ?? '' ),
+		'parameters'      => is_array( $request['parameters'] ?? null ) ? $request['parameters'] : array(),
+		'turn_count'      => (int) ( $request['turn_count'] ?? 0 ),
+		'session_id'      => (string) ( $request['session_id'] ?? '' ),
+		'user_id'         => (int) ( $payload['user_id'] ?? 0 ),
+		'agent_id'        => (int) ( $payload['agent_id'] ?? 0 ),
+		'mode'            => (string) ( $request['mode'] ?? '' ),
+		'modes'           => is_array( $request['modes'] ?? null ) ? $request['modes'] : array(),
+		'created_at'      => gmdate( 'c' ),
+		'expires_at'      => gmdate( 'c', time() + $timeout_seconds ),
+		'timeout_seconds' => $timeout_seconds,
+	);
+
+	$jobs_db->start_job( (int) $job_id, 'pending_runtime_tool' );
+	$jobs_db->store_engine_data(
+		(int) $job_id,
+		array(
+			'task_type'            => 'runtime_tool_request',
+			'runtime_tool_request' => $pending_request,
+		)
+	);
+	datamachine_store_runtime_tool_request_on_session( $pending_request );
+
+	if ( function_exists( 'as_schedule_single_action' ) ) {
+		as_schedule_single_action( time() + $timeout_seconds, 'datamachine_runtime_tool_timeout', array( $request_id ), 'datamachine-runtime-tools' );
+	}
+
+	do_action( 'datamachine_runtime_tool_request_deferred', $pending_request, $payload );
+
+	return array(
+		'success'              => false,
+		'pending'              => true,
+		'tool_name'            => $pending_request['tool_name'],
+		'executor'             => 'client',
+		'code'                 => 'runtime_tool_pending',
+		'error'                => 'Runtime tool request is pending client fulfillment.',
+		'runtime_tool_request' => $pending_request,
+	);
+}
+
+/**
+ * Store pending runtime tool request metadata on the owning chat session.
+ *
+ * @param array<string,mixed> $pending_request Pending request metadata.
+ */
+function datamachine_store_runtime_tool_request_on_session( array $pending_request ): void {
+	$session_id = (string) ( $pending_request['session_id'] ?? '' );
+	if ( '' === $session_id || ! class_exists( \DataMachine\Core\Database\Chat\ConversationStoreFactory::class ) ) {
+		return;
+	}
+
+	$chat_db = \DataMachine\Core\Database\Chat\ConversationStoreFactory::get();
+	$session = $chat_db->get_session( $session_id );
+	if ( ! is_array( $session ) ) {
+		return;
+	}
+
+	$metadata                          = is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array();
+	$metadata['runtime_tool_requests'] = is_array( $metadata['runtime_tool_requests'] ?? null )
+		? $metadata['runtime_tool_requests']
+		: array();
+	$metadata['runtime_tool_requests'][ $pending_request['request_id'] ] = $pending_request;
+	$metadata['has_pending_tools'] = true;
+	$metadata['status']            = 'processing';
+	$metadata['last_activity']     = function_exists( 'current_time' ) ? current_time( 'mysql', true ) : gmdate( 'Y-m-d H:i:s' );
+
+	$chat_db->update_session(
+		$session_id,
+		is_array( $session['messages'] ?? null ) ? $session['messages'] : array(),
+		$metadata,
+		(string) ( $session['provider'] ?? '' ),
+		(string) ( $session['model'] ?? '' )
+	);
+}
+
+/**
+ * Submit a client result for a deferred runtime tool request.
+ *
+ * @param string $request_id Runtime tool request id (`runtime_tool_<job_id>`).
+ * @param mixed  $result     Client tool result.
+ * @return array<string,mixed>|\WP_Error Submission result.
+ */
+function datamachine_submit_runtime_tool_result( string $request_id, $result ): array|\WP_Error {
+	$job_id = datamachine_runtime_tool_job_id_from_request_id( $request_id );
+	if ( $job_id <= 0 ) {
+		return new \WP_Error( 'runtime_tool_request_invalid', 'Runtime tool request id is invalid.' );
+	}
+
+	$jobs_db     = new \DataMachine\Core\Database\Jobs\Jobs();
+	$engine_data = $jobs_db->retrieve_engine_data( $job_id );
+	$request     = is_array( $engine_data['runtime_tool_request'] ?? null ) ? $engine_data['runtime_tool_request'] : array();
+	if ( empty( $request ) || 'pending' !== (string) ( $request['status'] ?? '' ) ) {
+		return new \WP_Error( 'runtime_tool_request_not_pending', 'Runtime tool request is not pending.' );
+	}
+
+	$tool_result = datamachine_normalize_runtime_tool_result( (string) ( $request['tool_name'] ?? '' ), $result );
+	$session_id  = (string) ( $request['session_id'] ?? '' );
+	if ( '' === $session_id || ! class_exists( \DataMachine\Core\Database\Chat\ConversationStoreFactory::class ) ) {
+		return new \WP_Error( 'runtime_tool_session_missing', 'Runtime tool request has no resumable chat session.' );
+	}
+
+	$chat_db = \DataMachine\Core\Database\Chat\ConversationStoreFactory::get();
+	$session = $chat_db->get_session( $session_id );
+	if ( ! is_array( $session ) ) {
+		return new \WP_Error( 'runtime_tool_session_not_found', 'Runtime tool session was not found.' );
+	}
+
+	$messages   = is_array( $session['messages'] ?? null ) ? $session['messages'] : array();
+	$messages[] = ConversationManager::formatToolResultMessage(
+		(string) ( $request['tool_name'] ?? '' ),
+		$tool_result,
+		is_array( $request['parameters'] ?? null ) ? $request['parameters'] : array(),
+		false,
+		(int) ( $request['turn_count'] ?? 0 )
+	);
+
+	$metadata = is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array();
+	if ( is_array( $metadata['runtime_tool_requests'] ?? null ) && isset( $metadata['runtime_tool_requests'][ $request_id ] ) ) {
+		$metadata['runtime_tool_requests'][ $request_id ]['status']       = ! empty( $tool_result['success'] ) ? 'fulfilled' : 'failed';
+		$metadata['runtime_tool_requests'][ $request_id ]['fulfilled_at'] = gmdate( 'c' );
+		$metadata['runtime_tool_requests'][ $request_id ]['result']       = $tool_result;
+	}
+	$metadata['runtime_tool_last_result'] = array(
+		'request_id' => $request_id,
+		'tool_name'  => (string) ( $request['tool_name'] ?? '' ),
+		'success'    => ! empty( $tool_result['success'] ),
+		'created_at' => gmdate( 'c' ),
+	);
+	$metadata['has_pending_tools']        = datamachine_session_has_pending_runtime_tools( $metadata );
+	$metadata['status']                   = $metadata['has_pending_tools'] ? 'processing' : 'processing';
+	$metadata['last_activity']            = function_exists( 'current_time' ) ? current_time( 'mysql', true ) : gmdate( 'Y-m-d H:i:s' );
+
+	$chat_db->update_session(
+		$session_id,
+		$messages,
+		$metadata,
+		(string) ( $session['provider'] ?? '' ),
+		(string) ( $session['model'] ?? '' )
+	);
+
+	$request['status']       = ! empty( $tool_result['success'] ) ? 'fulfilled' : 'failed';
+	$request['fulfilled_at'] = gmdate( 'c' );
+	$request['result']       = $tool_result;
+	$engine_data['runtime_tool_request'] = $request;
+	$jobs_db->store_engine_data( $job_id, $engine_data );
+	$jobs_db->complete_job( $job_id, ! empty( $tool_result['success'] ) ? 'completed' : 'failed' );
+
+	if ( function_exists( 'as_enqueue_async_action' ) ) {
+		as_enqueue_async_action( 'datamachine_runtime_tool_resume', array( $request_id ), 'datamachine-runtime-tools' );
+	}
+
+	do_action( 'datamachine_runtime_tool_result_submitted', $request, $tool_result );
+
+	return array(
+		'success'    => true,
+		'request_id' => $request_id,
+		'job_id'     => $job_id,
+		'scheduled'  => function_exists( 'as_enqueue_async_action' ),
+	);
+}
+
+/** Resume a deferred runtime tool conversation. */
+function datamachine_resume_runtime_tool_request( string $request_id ): void {
+	$job_id = datamachine_runtime_tool_job_id_from_request_id( $request_id );
+	if ( $job_id <= 0 || ! class_exists( \DataMachine\Api\Chat\ChatOrchestrator::class ) ) {
+		return;
+	}
+
+	$engine_data = ( new \DataMachine\Core\Database\Jobs\Jobs() )->retrieve_engine_data( $job_id );
+	$request     = is_array( $engine_data['runtime_tool_request'] ?? null ) ? $engine_data['runtime_tool_request'] : array();
+	if ( empty( $request ) || 'pending' === (string) ( $request['status'] ?? '' ) ) {
+		return;
+	}
+
+	\DataMachine\Api\Chat\ChatOrchestrator::processContinue(
+		(string) ( $request['session_id'] ?? '' ),
+		(int) ( $request['user_id'] ?? 0 )
+	);
+}
+
+/** Fail and resume an expired runtime tool request. */
+function datamachine_timeout_runtime_tool_request( string $request_id ): void {
+	$job_id = datamachine_runtime_tool_job_id_from_request_id( $request_id );
+	if ( $job_id <= 0 ) {
+		return;
+	}
+
+	$engine_data = ( new \DataMachine\Core\Database\Jobs\Jobs() )->retrieve_engine_data( $job_id );
+	$request     = is_array( $engine_data['runtime_tool_request'] ?? null ) ? $engine_data['runtime_tool_request'] : array();
+	if ( empty( $request ) || 'pending' !== (string) ( $request['status'] ?? '' ) ) {
+		return;
+	}
+
+	datamachine_submit_runtime_tool_result(
+		$request_id,
+		new \WP_Error( 'runtime_tool_timeout', 'Client runtime tool request timed out.' )
+	);
+}
+
+/** @param array<string,mixed> $metadata Session metadata. */
+function datamachine_session_has_pending_runtime_tools( array $metadata ): bool {
+	foreach ( (array) ( $metadata['runtime_tool_requests'] ?? array() ) as $request ) {
+		if ( is_array( $request ) && 'pending' === (string) ( $request['status'] ?? '' ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function datamachine_runtime_tool_job_id_from_request_id( string $request_id ): int {
+	if ( ! str_starts_with( $request_id, 'runtime_tool_' ) ) {
+		return 0;
+	}
+
+	return max( 0, (int) substr( $request_id, strlen( 'runtime_tool_' ) ) );
+}
+
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'datamachine_runtime_tool_resume', __NAMESPACE__ . '\\datamachine_resume_runtime_tool_request' );
+	add_action( 'datamachine_runtime_tool_timeout', __NAMESPACE__ . '\\datamachine_timeout_runtime_tool_request' );
 }
 
 /**

--- a/tests/runtime-tool-async-broker-smoke.php
+++ b/tests/runtime-tool-async-broker-smoke.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Smoke assertions for async client runtime tool broker wiring.
+ *
+ * Run with: php tests/runtime-tool-async-broker-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+$failures = array();
+$passes   = 0;
+
+function datamachine_runtime_async_assert( bool $condition, string $message, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "  ✓ {$message}\n";
+		return;
+	}
+
+	$failures[] = $message;
+	echo "  ✗ {$message}\n";
+}
+
+$loop_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/conversation-loop.php' );
+$chat_source = (string) file_get_contents( __DIR__ . '/../inc/Api/Chat/ChatOrchestrator.php' );
+
+echo "runtime-tool-async-broker-smoke\n\n";
+
+datamachine_runtime_async_assert(
+	str_contains( $loop_source, 'function datamachine_defer_runtime_tool_call' ),
+	'conversation loop exposes a durable runtime tool defer path',
+	$failures,
+	$passes
+);
+datamachine_runtime_async_assert(
+	str_contains( $loop_source, "'source'      => 'runtime_tool'" ) && str_contains( $loop_source, "'pending_runtime_tool'" ),
+	'deferred runtime tool requests are represented as Data Machine jobs',
+	$failures,
+	$passes
+);
+datamachine_runtime_async_assert(
+	str_contains( $loop_source, 'as_schedule_single_action' ) && str_contains( $loop_source, 'datamachine_runtime_tool_timeout' ),
+	'deferred runtime tool requests schedule Action Scheduler timeouts',
+	$failures,
+	$passes
+);
+datamachine_runtime_async_assert(
+	str_contains( $loop_source, 'function datamachine_submit_runtime_tool_result' ),
+	'client runtime tool results have a submission entry point',
+	$failures,
+	$passes
+);
+datamachine_runtime_async_assert(
+	str_contains( $loop_source, 'as_enqueue_async_action' ) && str_contains( $loop_source, 'datamachine_runtime_tool_resume' ),
+	'submitted runtime tool results enqueue async conversation resume',
+	$failures,
+	$passes
+);
+datamachine_runtime_async_assert(
+	str_contains( $loop_source, 'ChatOrchestrator::processContinue' ),
+	'async resume reuses the existing chat continuation path',
+	$failures,
+	$passes
+);
+datamachine_runtime_async_assert(
+	str_contains( $loop_source, 'runtime_tool_pending_requests' ) && str_contains( $loop_source, "'runtime_tool_pending'" ),
+	'conversation results surface pending runtime tool requests without fabricating tool output',
+	$failures,
+	$passes
+);
+datamachine_runtime_async_assert(
+	str_contains( $chat_source, 'runtime_tool_pending_requests' ) && str_contains( $chat_source, 'runtime_tool_requests' ),
+	'chat sessions persist pending runtime tool request metadata',
+	$failures,
+	$passes
+);
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " runtime tool async broker assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} runtime tool async broker assertions passed.\n";


### PR DESCRIPTION
## Summary
- Adds an async runtime-tool broker path for client tools that cannot return inline: the run pauses, a pending runtime-tool job is persisted, and chat metadata exposes the pending request.
- Adds Action Scheduler hooks for timeout and resume: submitted client results append a normal tool-result message, enqueue chat continuation, and complete the runtime-tool job.
- Keeps inline callback fulfillment as the fast path while using Data Machine jobs for durable pending state.

## Scope
This PR builds on #2206. The broker is intentionally chat-resume focused because chat sessions already own pending-tool continuation semantics; pipeline-specific pause/resume can be layered later if a pipeline transport needs client runtime tools.

Closes #2205.
Refs #1485.

## Tests
- `php -l inc/Engine/AI/conversation-loop.php`
- `php -l inc/Api/Chat/ChatOrchestrator.php`
- `php -l tests/runtime-tool-async-broker-smoke.php`
- `php tests/runtime-tool-async-broker-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`
- `php tests/tool-source-registry-smoke.php`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the async runtime tool broker path and smoke coverage; Chris remains responsible for review and merge.