### PR TITLE
fix: use release branch for playground blueprint

### DIFF
--- a/blueprints/playground.json
+++ b/blueprints/playground.json
@@ -23,8 +23,10 @@
     {
       "step": "installPlugin",
       "pluginData": {
-        "resource": "url",
-        "url": "https://github.com/Extra-Chill/data-machine/releases/latest/download/data-machine.zip"
+        "resource": "git:directory",
+        "url": "https://github.com/Extra-Chill/data-machine",
+        "ref": "release-latest",
+        "refType": "branch"
       },
       "options": {
         "activate": true,


### PR DESCRIPTION
## Summary
- Switch the Playground blueprint to install Data Machine from the dynamic `release-latest` branch mirror instead of the mutable latest release ZIP asset.
- Keeps the README Playground button dynamic while avoiding failures when a GitHub release exists before its ZIP asset is published.

## Testing
- `jq empty blueprints/playground.json`
- Verified `release-latest` exposes `data-machine.php` at the plugin root.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the broken Playground release asset path and drafted the minimal Blueprint update; Chris requested PR and merge.