### PR TITLE
Route bundle upgrades through abilities

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -18,6 +18,8 @@ use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Agents\AgentAccess;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Engine\Bundle\AgentBundleDirectory;
+use DataMachine\Engine\Bundle\AgentBundleAbilityService;
+use DataMachine\Engine\Bundle\AgentBundleArtifactRebase;
 use DataMachine\Engine\Bundle\BundleSource;
 use DataMachine\Engine\Bundle\BundleSourceAuth;
 use DataMachine\Engine\Bundle\BundleValidationException;
@@ -361,6 +363,129 @@ class AgentAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'importAgent' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/list-agent-bundles',
+				array(
+					'label'               => 'List Agent Bundles',
+					'description'         => 'List installed bundle-backed agents with template/source metadata.',
+					'category'            => 'datamachine-agent',
+					'input_schema'        => array( 'type' => 'object' ),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'listAgentBundles' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'readonly'   => true,
+							'idempotent' => true,
+						),
+					),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/get-agent-bundle-status',
+				array(
+					'label'               => 'Get Agent Bundle Status',
+					'description'         => 'Return installed bundle source/version metadata and tracked artifact state for an agent or bundle slug.',
+					'category'            => 'datamachine-agent',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'slug' ),
+						'properties' => array(
+							'slug' => array(
+								'type'        => 'string',
+								'description' => 'Agent slug or installed bundle slug.',
+							),
+						),
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'getAgentBundleStatus' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'readonly'   => true,
+							'idempotent' => true,
+						),
+					),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/plan-agent-bundle-upgrade',
+				array(
+					'label'               => 'Plan Agent Bundle Upgrade',
+					'description'         => 'Build the canonical bundle upgrade plan, including clean updates, local overrides, warnings, and runtime drift.',
+					'category'            => 'datamachine-agent',
+					'input_schema'        => self::bundleLifecycleInputSchema(),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'planAgentBundleUpgrade' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'readonly'   => true,
+							'idempotent' => true,
+						),
+					),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/rebase-agent-bundle-artifacts',
+				array(
+					'label'               => 'Rebase Agent Bundle Artifacts',
+					'description'         => 'Preview 3-way rebases for locally modified bundle artifacts using a named policy.',
+					'category'            => 'datamachine-agent',
+					'input_schema'        => self::bundleLifecycleInputSchema( true ),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'rebaseAgentBundleArtifacts' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'readonly'   => true,
+							'idempotent' => true,
+						),
+					),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/apply-agent-bundle-upgrade',
+				array(
+					'label'               => 'Apply Agent Bundle Upgrade',
+					'description'         => 'Apply clean bundle artifact updates and stage local overrides as PendingActions.',
+					'category'            => 'datamachine-agent',
+					'input_schema'        => self::bundleLifecycleInputSchema( true ),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'applyAgentBundleUpgrade' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/resolve-agent-bundle-upgrade-action',
+				array(
+					'label'               => 'Resolve Agent Bundle Upgrade Action',
+					'description'         => 'Accept a staged bundle upgrade PendingAction through the canonical bundle ability surface.',
+					'category'            => 'datamachine-agent',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'pending_action_id' ),
+						'properties' => array(
+							'pending_action_id' => array( 'type' => 'string' ),
+						),
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'resolveAgentBundleUpgradeAction' ),
 					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
@@ -1159,6 +1284,126 @@ class AgentAbilities {
 		$result['auth_warnings'] = $auth_warnings;
 
 		return $result;
+	}
+
+	/**
+	 * List installed bundle-backed agents through the canonical bundle ability contract.
+	 *
+	 * @param array $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public static function listAgentBundles( array $input = array() ): array {
+		unset( $input );
+		return self::bundleLifecycleService()->list_installed();
+	}
+
+	/**
+	 * Return installed bundle status for an agent or bundle slug.
+	 *
+	 * @param array $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public static function getAgentBundleStatus( array $input ): array {
+		return self::bundleLifecycleService()->status( (string) ( $input['slug'] ?? '' ) );
+	}
+
+	/**
+	 * Build a canonical bundle upgrade plan.
+	 *
+	 * @param array $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public static function planAgentBundleUpgrade( array $input ): array {
+		return self::bundleLifecycleService()->plan( $input );
+	}
+
+	/**
+	 * Preview 3-way rebases for locally modified bundle artifacts.
+	 *
+	 * @param array $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public static function rebaseAgentBundleArtifacts( array $input ): array {
+		return self::bundleLifecycleService()->rebase( $input );
+	}
+
+	/**
+	 * Apply clean bundle upgrades and stage approval-required changes.
+	 *
+	 * @param array $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public static function applyAgentBundleUpgrade( array $input ): array {
+		return self::bundleLifecycleService()->upgrade( $input );
+	}
+
+	/**
+	 * Resolve a bundle upgrade PendingAction through the bundle ability surface.
+	 *
+	 * @param array $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public static function resolveAgentBundleUpgradeAction( array $input ): array {
+		return self::bundleLifecycleService()->apply_pending_action( (string) ( $input['pending_action_id'] ?? $input['action_id'] ?? '' ) );
+	}
+
+	private static function bundleLifecycleService(): AgentBundleAbilityService {
+		return new AgentBundleAbilityService();
+	}
+
+	private static function bundleLifecycleInputSchema( bool $include_rebase = false ): array {
+		$properties = array(
+			'source'            => array(
+				'type'        => 'string',
+				'description' => 'Bundle source: local path (directory, .zip, .json) or remote URL.',
+			),
+			'slug'              => array(
+				'type'        => 'string',
+				'description' => 'Optional target agent slug override.',
+			),
+			'owner_id'          => array(
+				'type'        => 'integer',
+				'description' => 'WordPress user ID that owns imported or upgraded artifacts.',
+			),
+			'dry_run'           => array(
+				'type'        => 'boolean',
+				'description' => 'Preview without writing.',
+			),
+			'reconcile_runtime' => array(
+				'type'        => 'boolean',
+				'description' => 'Replace preserved flow runtime queues and scheduling with the bundle seed.',
+			),
+			'token'             => array(
+				'type'        => 'string',
+				'description' => 'One-shot auth token for private archive downloads; never persisted.',
+			),
+			'token_env'         => array(
+				'type'        => 'string',
+				'description' => 'Environment variable or PHP constant name that contains a one-shot auth token.',
+			),
+		);
+
+		if ( $include_rebase ) {
+			$properties['rebase_local'] = array(
+				'type'        => 'boolean',
+				'description' => 'Attach a policy-driven 3-way rebase preview for locally modified artifacts.',
+			);
+			$properties['policy']       = array(
+				'type'        => 'string',
+				'enum'        => array( AgentBundleArtifactRebase::POLICY_CONSERVATIVE, AgentBundleArtifactRebase::POLICY_BURN_IN_SAFE ),
+				'description' => 'Rebase policy name.',
+			);
+			$properties['artifact']     = array(
+				'type'        => 'string',
+				'description' => 'Optional artifact_key filter for rebase previews.',
+			);
+		}
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'source' ),
+			'properties' => $properties,
+		);
 	}
 
 	/**

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -7,6 +7,7 @@
 
 namespace DataMachine\Cli\Commands;
 
+use DataMachine\Abilities\AgentAbilities;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Core\Agents\AgentBundler;
 use DataMachine\Core\Database\Agents\Agents;
@@ -101,24 +102,8 @@ class AgentBundleCommand extends BaseCommand {
 	public function installed( array $args, array $assoc_args ): void {
 		unset( $args );
 
-		$items = array();
-		foreach ( $this->agents()->get_all() as $agent ) {
-			$bundle = $agent['agent_config']['datamachine_bundle'] ?? array();
-			if ( empty( $bundle['bundle_slug'] ) ) {
-				continue;
-			}
-
-			$items[] = array(
-				'agent_id'         => (int) $agent['agent_id'],
-				'agent_slug'       => (string) $agent['agent_slug'],
-				'template_slug'    => (string) ( $bundle['template_slug'] ?? $bundle['bundle_slug'] ),
-				'template_version' => (string) ( $bundle['template_version'] ?? $bundle['bundle_version'] ?? '' ),
-				'bundle_slug'      => (string) $bundle['bundle_slug'],
-				'bundle_version'   => (string) ( $bundle['bundle_version'] ?? '' ),
-				'source_ref'       => (string) ( $bundle['source_ref'] ?? '' ),
-				'artifacts'        => count( is_array( $bundle['artifacts'] ?? null ) ? $bundle['artifacts'] : array() ),
-			);
-		}
+		$response = AgentAbilities::listAgentBundles();
+		$items    = is_array( $response['bundles'] ?? null ) ? $response['bundles'] : array();
 
 		if ( 'json' === ( $assoc_args['format'] ?? 'table' ) && empty( $items ) ) {
 			WP_CLI::line( '[]' );
@@ -146,13 +131,12 @@ class AgentBundleCommand extends BaseCommand {
 	 * ---
 	 */
 	public function status( array $args, array $assoc_args ): void {
-		$agent = $this->resolve_installed_agent( (string) ( $args[0] ?? '' ) );
-		if ( ! $agent ) {
-			WP_CLI::error( 'Installed bundle not found.' );
+		$status = AgentAbilities::getAgentBundleStatus( array( 'slug' => (string) ( $args[0] ?? '' ) ) );
+		if ( empty( $status['success'] ) ) {
+			WP_CLI::error( (string) ( $status['error'] ?? 'Installed bundle not found.' ) );
 			return;
 		}
 
-		$status = $this->installed_status( $agent );
 		$this->output( $status, $assoc_args, array( 'agent_id', 'agent_slug', 'template_slug', 'template_version', 'bundle_slug', 'bundle_version', 'artifact_count' ) );
 	}
 
@@ -183,13 +167,13 @@ class AgentBundleCommand extends BaseCommand {
 	 * ---
 	 */
 	public function diff( array $args, array $assoc_args ): void {
-		$bundle = $this->load_bundle_arg( $args, $assoc_args );
-		$plan   = $this->add_runtime_drift_to_plan(
-			$this->plan_for_bundle( $bundle, (string) ( $assoc_args['slug'] ?? '' ) )->to_array(),
-			$bundle,
-			(string) ( $assoc_args['slug'] ?? '' )
-		);
-		$this->output_plan( $plan, $assoc_args );
+		$response = AgentAbilities::planAgentBundleUpgrade( $this->bundle_ability_input( $args, $assoc_args ) );
+		if ( empty( $response['success'] ) ) {
+			WP_CLI::error( (string) ( $response['error'] ?? 'Bundle diff failed.' ) );
+			return;
+		}
+
+		$this->output_plan( is_array( $response['plan'] ?? null ) ? $response['plan'] : array(), $assoc_args );
 	}
 
 	/**
@@ -246,25 +230,20 @@ class AgentBundleCommand extends BaseCommand {
 	 * ---
 	 */
 	public function upgrade( array $args, array $assoc_args ): void {
-		$bundle            = $this->load_bundle_arg( $args, $assoc_args );
-		$slug              = (string) ( $assoc_args['slug'] ?? '' );
-		$plan              = $this->plan_for_bundle( $bundle, $slug );
 		$dry_run           = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
-		$reconcile_runtime = \WP_CLI\Utils\get_flag_value( $assoc_args, 'reconcile-runtime', false );
-		$rebase_local      = \WP_CLI\Utils\get_flag_value( $assoc_args, 'rebase-local', false );
-		$policy_name       = (string) ( $assoc_args['policy'] ?? AgentBundleArtifactRebase::POLICY_CONSERVATIVE );
+		$input             = $this->bundle_ability_input( $args, $assoc_args );
+		$input['dry_run']  = $dry_run;
+		if ( isset( $assoc_args['owner'] ) ) {
+			$input['owner_id'] = $this->resolve_user_id( $assoc_args['owner'] );
+		}
 
 		if ( $dry_run ) {
-			$plan_array = $this->add_runtime_drift_to_plan(
-				$plan->to_array(),
-				$bundle,
-				$slug,
-				$reconcile_runtime ? 'replace_bundle_seed' : 'preserve_existing'
-			);
-			if ( $rebase_local ) {
-				$plan_array['rebase'] = $this->rebase_locally_modified( $plan, $bundle, $slug, $policy_name );
+			$response = AgentAbilities::applyAgentBundleUpgrade( $input );
+			if ( empty( $response['success'] ) ) {
+				WP_CLI::error( (string) ( $response['error'] ?? 'Bundle upgrade preview failed.' ) );
+				return;
 			}
-			$this->output_plan( $plan_array, $assoc_args );
+			$this->output_plan( is_array( $response['plan'] ?? null ) ? $response['plan'] : array(), $assoc_args );
 			return;
 		}
 
@@ -272,55 +251,10 @@ class AgentBundleCommand extends BaseCommand {
 			WP_CLI::confirm( 'Apply clean bundle artifact updates now?' );
 		}
 
-		$owner_id = isset( $assoc_args['owner'] ) ? $this->resolve_user_id( $assoc_args['owner'] ) : 0;
-		$result   = $this->bundler()->import(
-			$bundle,
-			'' !== $slug ? $slug : null,
-			$owner_id,
-			false,
-			array(
-				'reconcile_runtime' => $reconcile_runtime,
-				// Mark this as an upgrade so the importer treats an existing agent row as the upgrade
-				// target instead of returning "Agent slug already exists" when local pipelines/flows
-				// have been edited (#1801). Local-modified artifacts come back in `result.conflicts`
-				// and get staged as PendingActions below.
-				'is_upgrade'        => true,
-			)
-		);
-		if ( empty( $result['success'] ) ) {
-			WP_CLI::error( (string) ( $result['error'] ?? 'Bundle upgrade failed.' ) );
+		$response = AgentAbilities::applyAgentBundleUpgrade( $input );
+		if ( empty( $response['success'] ) ) {
+			WP_CLI::error( (string) ( $response['error'] ?? 'Bundle upgrade failed.' ) );
 			return;
-		}
-
-		$response = array(
-			'success' => true,
-			'import'  => $result,
-			'plan'    => $plan->to_array(),
-		);
-
-		if ( $plan->has_pending_approval() ) {
-			$agent                      = $this->resolve_bundle_agent( $bundle, $slug );
-			$rebased_artifacts          = $rebase_local
-				? $this->rebase_locally_modified( $plan, $bundle, $slug, $policy_name )
-				: array();
-			$approved_artifacts         = $this->approved_rebased_artifact_keys( $rebased_artifacts );
-			$pending                    = AgentBundleUpgradePendingAction::stage(
-				$plan,
-				array(
-					'bundle'             => $this->bundle_summary( $bundle, $slug ),
-					'agent'              => $agent ? $agent : array(),
-					'target_artifacts'   => $this->bundle_artifacts( $bundle ),
-					'approved_artifacts' => $approved_artifacts,
-					'rebased_artifacts'  => $rebased_artifacts,
-					'summary'            => 'Review locally modified bundle artifacts before applying.',
-					'agent_id'           => $agent ? (int) $agent['agent_id'] : 0,
-					'user_id'            => get_current_user_id(),
-				)
-			);
-			$response['pending_action'] = $pending;
-			if ( ! empty( $rebased_artifacts ) ) {
-				$response['rebase'] = $rebased_artifacts;
-			}
 		}
 
 		$this->output( $response, $assoc_args, array( 'success' ) );
@@ -344,19 +278,12 @@ class AgentBundleCommand extends BaseCommand {
 	 * ---
 	 */
 	public function apply( array $args, array $assoc_args ): void {
-		$action_id = sanitize_text_field( (string) ( $args[0] ?? '' ) );
-		if ( '' === $action_id ) {
-			WP_CLI::error( 'Pending action ID is required.' );
+		$result               = AgentAbilities::resolveAgentBundleUpgradeAction( array( 'pending_action_id' => (string) ( $args[0] ?? '' ) ) );
+		$assoc_args['format'] = $assoc_args['format'] ?? 'json';
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( (string) ( $result['error'] ?? 'Pending action apply failed.' ) );
 			return;
 		}
-
-		$result               = ResolvePendingActionAbility::execute(
-			array(
-				'action_id' => $action_id,
-				'decision'  => 'accepted',
-			)
-		);
-		$assoc_args['format'] = $assoc_args['format'] ?? 'json';
 		$this->output( $result, $assoc_args, array( 'success', 'action_id', 'kind' ) );
 	}
 
@@ -396,30 +323,32 @@ class AgentBundleCommand extends BaseCommand {
 	 * ---
 	 */
 	public function rebase( array $args, array $assoc_args ): void {
-		$bundle      = $this->load_bundle_arg( $args );
-		$slug        = (string) ( $assoc_args['slug'] ?? '' );
-		$plan        = $this->plan_for_bundle( $bundle, $slug );
-		$policy_name = (string) ( $assoc_args['policy'] ?? AgentBundleArtifactRebase::POLICY_CONSERVATIVE );
-		$only        = isset( $assoc_args['artifact'] ) ? (string) $assoc_args['artifact'] : '';
-
-		$rebased = $this->rebase_locally_modified( $plan, $bundle, $slug, $policy_name );
-		if ( '' !== $only ) {
-			$rebased = array_values(
-				array_filter(
-					$rebased,
-					static fn( array $entry ) => ( $entry['artifact_key'] ?? '' ) === $only
-				)
-			);
+		$response = AgentAbilities::rebaseAgentBundleArtifacts( $this->bundle_ability_input( $args, $assoc_args ) );
+		if ( empty( $response['success'] ) ) {
+			WP_CLI::error( (string) ( $response['error'] ?? 'Bundle artifact rebase failed.' ) );
+			return;
 		}
-
-		$response = array(
-			'policy'  => $policy_name,
-			'count'   => count( $rebased ),
-			'rebased' => $rebased,
-		);
 
 		$assoc_args['format'] = $assoc_args['format'] ?? 'json';
 		$this->output( $response, $assoc_args, array( 'policy', 'count' ) );
+	}
+
+	private function bundle_ability_input( array $args, array $assoc_args ): array {
+		$input = array(
+			'source'            => (string) ( $args[0] ?? '' ),
+			'slug'              => (string) ( $assoc_args['slug'] ?? '' ),
+			'reconcile_runtime' => \WP_CLI\Utils\get_flag_value( $assoc_args, 'reconcile-runtime', false ),
+			'rebase_local'      => \WP_CLI\Utils\get_flag_value( $assoc_args, 'rebase-local', false ),
+			'policy'            => (string) ( $assoc_args['policy'] ?? AgentBundleArtifactRebase::POLICY_CONSERVATIVE ),
+		);
+
+		foreach ( array( 'token' => 'token', 'token-env' => 'token_env', 'artifact' => 'artifact' ) as $cli_key => $ability_key ) {
+			if ( isset( $assoc_args[ $cli_key ] ) ) {
+				$input[ $ability_key ] = (string) $assoc_args[ $cli_key ];
+			}
+		}
+
+		return $input;
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentBundleAbilityService.php
+++ b/inc/Engine/Bundle/AgentBundleAbilityService.php
@@ -1,0 +1,684 @@
+<?php
+/**
+ * Ability-backed agent bundle lifecycle service.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+use DataMachine\Core\Agents\AgentBundler;
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Canonical implementation for bundle lifecycle abilities.
+ */
+final class AgentBundleAbilityService {
+
+	private Agents $agents;
+	private Pipelines $pipelines;
+	private Flows $flows;
+	private AgentBundler $bundler;
+
+	public function __construct( ?Agents $agents = null, ?Pipelines $pipelines = null, ?Flows $flows = null, ?AgentBundler $bundler = null ) {
+		$this->agents    = $agents ?? new Agents();
+		$this->pipelines = $pipelines ?? new Pipelines();
+		$this->flows     = $flows ?? new Flows();
+		$this->bundler   = $bundler ?? new AgentBundler();
+	}
+
+	/** @return array<string,mixed> */
+	public function list_installed(): array {
+		$items = array();
+		foreach ( $this->agents->get_all() as $agent ) {
+			$bundle = $agent['agent_config']['datamachine_bundle'] ?? array();
+			if ( empty( $bundle['bundle_slug'] ) ) {
+				continue;
+			}
+
+			$items[] = array(
+				'agent_id'         => (int) $agent['agent_id'],
+				'agent_slug'       => (string) $agent['agent_slug'],
+				'template_slug'    => (string) ( $bundle['template_slug'] ?? $bundle['bundle_slug'] ),
+				'template_version' => (string) ( $bundle['template_version'] ?? $bundle['bundle_version'] ?? '' ),
+				'bundle_slug'      => (string) $bundle['bundle_slug'],
+				'bundle_version'   => (string) ( $bundle['bundle_version'] ?? '' ),
+				'source_ref'       => (string) ( $bundle['source_ref'] ?? '' ),
+				'source_revision'  => (string) ( $bundle['source_revision'] ?? '' ),
+				'artifacts'        => count( is_array( $bundle['artifacts'] ?? null ) ? $bundle['artifacts'] : array() ),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'bundles' => $items,
+		);
+	}
+
+	/** @return array<string,mixed> */
+	public function status( string $slug ): array {
+		$agent = $this->resolve_installed_agent( $slug );
+		if ( ! $agent ) {
+			return array(
+				'success' => false,
+				'error'   => 'Installed bundle not found.',
+			);
+		}
+
+		return array_merge( array( 'success' => true ), $this->installed_status( $agent ) );
+	}
+
+	/** @return array<string,mixed> */
+	public function plan( array $input ): array {
+		$loaded = $this->load_bundle_from_input( $input );
+		if ( empty( $loaded['success'] ) ) {
+			return $loaded;
+		}
+
+		$bundle            = $loaded['bundle'];
+		$slug              = (string) ( $input['slug'] ?? '' );
+		$reconcile_runtime = ! empty( $input['reconcile_runtime'] );
+		$plan              = $this->add_runtime_drift_to_plan(
+			$this->plan_for_bundle( $bundle, $slug )->to_array(),
+			$bundle,
+			$slug,
+			$reconcile_runtime ? 'replace_bundle_seed' : 'preserve_existing'
+		);
+
+		return array(
+			'success' => true,
+			'plan'    => $plan,
+			'bundle'  => $this->bundle_summary( $bundle, $slug ),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	public function rebase( array $input ): array {
+		$loaded = $this->load_bundle_from_input( $input );
+		if ( empty( $loaded['success'] ) ) {
+			return $loaded;
+		}
+
+		$bundle      = $loaded['bundle'];
+		$slug        = (string) ( $input['slug'] ?? '' );
+		$policy_name = (string) ( $input['policy'] ?? AgentBundleArtifactRebase::POLICY_CONSERVATIVE );
+		$only        = isset( $input['artifact'] ) ? (string) $input['artifact'] : '';
+		$plan        = $this->plan_for_bundle( $bundle, $slug );
+		$rebased     = $this->rebase_locally_modified( $plan, $bundle, $slug, $policy_name );
+
+		if ( '' !== $only ) {
+			$rebased = array_values(
+				array_filter(
+					$rebased,
+					static fn( array $entry ) => ( $entry['artifact_key'] ?? '' ) === $only
+				)
+			);
+		}
+
+		return array(
+			'success' => true,
+			'policy'  => $policy_name,
+			'count'   => count( $rebased ),
+			'rebased' => $rebased,
+		);
+	}
+
+	/** @return array<string,mixed> */
+	public function upgrade( array $input ): array {
+		$loaded = $this->load_bundle_from_input( $input );
+		if ( empty( $loaded['success'] ) ) {
+			return $loaded;
+		}
+
+		$bundle            = $loaded['bundle'];
+		$slug              = (string) ( $input['slug'] ?? '' );
+		$dry_run           = ! empty( $input['dry_run'] );
+		$reconcile_runtime = ! empty( $input['reconcile_runtime'] );
+		$rebase_local      = ! empty( $input['rebase_local'] );
+		$policy_name       = (string) ( $input['policy'] ?? AgentBundleArtifactRebase::POLICY_CONSERVATIVE );
+		$plan              = $this->plan_for_bundle( $bundle, $slug );
+
+		if ( $dry_run ) {
+			$plan_array = $this->add_runtime_drift_to_plan(
+				$plan->to_array(),
+				$bundle,
+				$slug,
+				$reconcile_runtime ? 'replace_bundle_seed' : 'preserve_existing'
+			);
+			if ( $rebase_local ) {
+				$plan_array['rebase'] = $this->rebase_locally_modified( $plan, $bundle, $slug, $policy_name );
+			}
+
+			return array(
+				'success' => true,
+				'plan'    => $plan_array,
+				'bundle'  => $this->bundle_summary( $bundle, $slug ),
+			);
+		}
+
+		$result = $this->bundler->import(
+			$bundle,
+			'' !== $slug ? $slug : null,
+			isset( $input['owner_id'] ) ? (int) $input['owner_id'] : 0,
+			false,
+			array(
+				'reconcile_runtime' => $reconcile_runtime,
+				'is_upgrade'        => true,
+			)
+		);
+		if ( empty( $result['success'] ) ) {
+			return $result;
+		}
+
+		$response = array(
+			'success' => true,
+			'import'  => $result,
+			'plan'    => $plan->to_array(),
+		);
+
+		if ( $plan->has_pending_approval() ) {
+			$agent             = $this->resolve_bundle_agent( $bundle, $slug );
+			$rebased_artifacts = $rebase_local
+				? $this->rebase_locally_modified( $plan, $bundle, $slug, $policy_name )
+				: array();
+			$pending           = AgentBundleUpgradePendingAction::stage(
+				$plan,
+				array(
+					'bundle'             => $this->bundle_summary( $bundle, $slug ),
+					'agent'              => $agent ? $agent : array(),
+					'target_artifacts'   => $this->bundle_artifacts( $bundle ),
+					'approved_artifacts' => $this->approved_rebased_artifact_keys( $rebased_artifacts ),
+					'rebased_artifacts'  => $rebased_artifacts,
+					'summary'            => 'Review locally modified bundle artifacts before applying.',
+					'agent_id'           => $agent ? (int) $agent['agent_id'] : 0,
+					'user_id'            => function_exists( 'get_current_user_id' ) ? get_current_user_id() : 0,
+				)
+			);
+			$response['pending_action'] = $pending;
+			if ( ! empty( $rebased_artifacts ) ) {
+				$response['rebase'] = $rebased_artifacts;
+			}
+		}
+
+		return $response;
+	}
+
+	/** @return array<string,mixed> */
+	public function apply_pending_action( string $action_id ): array {
+		$action_id = function_exists( 'sanitize_text_field' ) ? sanitize_text_field( $action_id ) : trim( $action_id );
+		if ( '' === $action_id ) {
+			return array(
+				'success' => false,
+				'error'   => 'Pending action ID is required.',
+			);
+		}
+
+		return ResolvePendingActionAbility::execute(
+			array(
+				'action_id' => $action_id,
+				'decision'  => 'accepted',
+			)
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private function load_bundle_from_input( array $input ): array {
+		$source = trim( (string) ( $input['source'] ?? '' ) );
+		if ( '' === $source ) {
+			return array(
+				'success' => false,
+				'error'   => 'Bundle source is required.',
+			);
+		}
+
+		$context  = BundleSourceAuth::build_resolve_context(
+			isset( $input['token'] ) ? (string) $input['token'] : null,
+			isset( $input['token_env'] ) ? (string) $input['token_env'] : null
+		);
+		$resolved = BundleSource::resolve( $source, $context );
+		if ( is_wp_error( $resolved ) ) {
+			return array(
+				'success' => false,
+				'error'   => $resolved->get_error_message(),
+			);
+		}
+
+		$revision = BundleSource::is_remote( $source ) ? BundleSource::last_resolved_revision() : null;
+		$bundle   = null;
+		try {
+			if ( is_dir( $resolved ) ) {
+				$bundle = $this->bundler->from_directory( $resolved );
+			} elseif ( preg_match( '/\.zip$/i', $resolved ) ) {
+				$bundle = $this->bundler->from_zip( $resolved );
+			} elseif ( preg_match( '/\.json$/i', $resolved ) ) {
+				$bundle = $this->bundler->from_json( (string) file_get_contents( $resolved ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			}
+		} catch ( BundleValidationException $e ) {
+			BundleSource::cleanup( $resolved, $source );
+			return array(
+				'success' => false,
+				'error'   => $e->getMessage(),
+			);
+		}
+
+		BundleSource::cleanup( $resolved, $source );
+		if ( ! is_array( $bundle ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to parse bundle. Use .zip, .json, or a bundle directory.',
+			);
+		}
+
+		if ( BundleSource::is_remote( $source ) && empty( $bundle['source_ref'] ) ) {
+			$bundle['source_ref'] = $source;
+		}
+		if ( null !== $revision && empty( $bundle['source_revision'] ) ) {
+			$bundle['source_revision'] = $revision;
+		}
+
+		return array(
+			'success' => true,
+			'bundle'  => $bundle,
+		);
+	}
+
+	private function plan_for_bundle( array $bundle, string $slug = '' ): AgentBundleUpgradePlan {
+		$agent = $this->resolve_bundle_agent( $bundle, $slug );
+		if ( ! $agent ) {
+			return AgentBundleUpgradePlanner::plan( array(), array(), $this->bundle_artifacts( $bundle ), $this->bundle_summary( $bundle, $slug ) );
+		}
+
+		$bundle_state = is_array( $agent['agent_config']['datamachine_bundle'] ?? null ) ? $agent['agent_config']['datamachine_bundle'] : array();
+		$installed    = array_values( is_array( $bundle_state['artifacts'] ?? null ) ? $bundle_state['artifacts'] : array() );
+
+		return AgentBundleUpgradePlanner::plan(
+			$installed,
+			$this->current_artifacts( $agent, $installed ),
+			$this->bundle_artifacts_for_agent( $bundle, $agent ),
+			$this->bundle_summary( $bundle, $slug )
+		);
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private function bundle_artifacts( array $bundle ): array {
+		return $this->bundle_artifacts_for_agent( $bundle, null );
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private function bundle_artifacts_for_agent( array $bundle, ?array $agent ): array {
+		$artifacts                  = array();
+		$agent_id                   = is_array( $agent ) ? (int) ( $agent['agent_id'] ?? 0 ) : 0;
+		$pipeline_id_map            = array();
+		$existing_pipelines_by_slug = array();
+		$incoming_config            = is_array( $bundle['agent']['agent_config'] ?? null ) ? $bundle['agent']['agent_config'] : array();
+
+		$artifacts[] = array(
+			'artifact_type' => 'agent_config',
+			'artifact_id'   => 'config',
+			'source_path'   => 'manifest.json#/agent/agent_config',
+			'payload'       => AgentBundleAgentConfig::tracked_payload( $incoming_config ),
+		);
+
+		if ( $agent_id > 0 ) {
+			foreach ( $this->pipelines->get_all_pipelines( null, $agent_id ) as $pipeline ) {
+				$existing_pipelines_by_slug[ (string) ( $pipeline['portable_slug'] ?? '' ) ] = $pipeline;
+			}
+		}
+
+		foreach ( $bundle['pipelines'] ?? array() as $pipeline ) {
+			if ( ! is_array( $pipeline ) ) {
+				continue;
+			}
+			$slug = PortableSlug::normalize( (string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ), 'pipeline' );
+			if ( isset( $existing_pipelines_by_slug[ $slug ] ) ) {
+				$old_id                      = (int) ( $pipeline['original_id'] ?? 0 );
+				$new_id                      = (int) ( $existing_pipelines_by_slug[ $slug ]['pipeline_id'] ?? 0 );
+				$pipeline_id_map[ $old_id ]  = $new_id;
+				$pipeline['pipeline_config'] = BundleStepIdRemapper::remap_pipeline_step_ids( is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(), $old_id, $new_id );
+			}
+
+			$artifacts[] = array(
+				'artifact_type' => 'pipeline',
+				'artifact_id'   => $slug,
+				'source_path'   => 'pipelines/' . $slug . '.json',
+				'payload'       => $this->pipeline_payload( $pipeline, $slug ),
+			);
+		}
+
+		foreach ( $bundle['flows'] ?? array() as $flow ) {
+			if ( ! is_array( $flow ) ) {
+				continue;
+			}
+			$slug            = PortableSlug::normalize( (string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? 'flow' ) ), 'flow' );
+			$old_pipeline_id = (int) ( $flow['original_pipeline_id'] ?? 0 );
+			$new_pipeline_id = (int) ( $pipeline_id_map[ $old_pipeline_id ] ?? 0 );
+			$existing_flow   = $new_pipeline_id > 0 ? $this->flows->get_by_portable_slug( $new_pipeline_id, $slug ) : null;
+
+			if ( $existing_flow ) {
+				$flow['flow_config'] = BundleStepIdRemapper::remap_flow_step_ids( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array(), $old_pipeline_id, $new_pipeline_id, (int) $existing_flow['flow_id'] );
+			}
+
+			$artifacts[] = array(
+				'artifact_type' => 'flow',
+				'artifact_id'   => $slug,
+				'source_path'   => 'flows/' . $slug . '.json',
+				'payload'       => $this->flow_payload( $flow, $slug ),
+			);
+		}
+
+		foreach ( AgentBundleArtifactExtensions::normalize_artifacts( is_array( $bundle['extension_artifacts'] ?? null ) ? $bundle['extension_artifacts'] : array() ) as $artifact ) {
+			$artifacts[] = $artifact;
+		}
+
+		return $artifacts;
+	}
+
+	/** @param array<int,array<string,mixed>> $installed */
+	private function current_artifacts( array $agent, array $installed ): array {
+		$agent_id  = (int) $agent['agent_id'];
+		$artifacts = array();
+		$pipelines = $this->pipelines->get_all_pipelines( null, $agent_id );
+		$flows     = $this->flows->get_all_flows( null, $agent_id );
+
+		$artifacts[] = array(
+			'artifact_type' => 'agent_config',
+			'artifact_id'   => 'config',
+			'source_path'   => 'manifest.json#/agent/agent_config',
+			'payload'       => AgentBundleAgentConfig::tracked_payload( is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array() ),
+		);
+
+		$pipeline_by_slug = array();
+		foreach ( $pipelines as $pipeline ) {
+			$slug = (string) ( $pipeline['portable_slug'] ?? '' );
+			if ( '' !== $slug ) {
+				$pipeline_by_slug[ $slug ] = $pipeline;
+			}
+		}
+
+		$flow_by_slug = array();
+		foreach ( $flows as $flow ) {
+			$slug = (string) ( $flow['portable_slug'] ?? '' );
+			if ( '' !== $slug ) {
+				$flow_by_slug[ $slug ] = $flow;
+			}
+		}
+
+		foreach ( $installed as $record ) {
+			$type = (string) ( $record['artifact_type'] ?? '' );
+			$id   = (string) ( $record['artifact_id'] ?? '' );
+			if ( 'pipeline' === $type && isset( $pipeline_by_slug[ $id ] ) ) {
+				$artifacts[] = array(
+					'artifact_type' => 'pipeline',
+					'artifact_id'   => $id,
+					'source_path'   => (string) ( $record['source_path'] ?? '' ),
+					'payload'       => $this->pipeline_payload( $pipeline_by_slug[ $id ], $id ),
+				);
+			}
+			if ( 'flow' === $type && isset( $flow_by_slug[ $id ] ) ) {
+				$artifacts[] = array(
+					'artifact_type' => 'flow',
+					'artifact_id'   => $id,
+					'source_path'   => (string) ( $record['source_path'] ?? '' ),
+					'payload'       => $this->flow_payload( $flow_by_slug[ $id ], $id ),
+				);
+			}
+		}
+
+		return array_merge( $artifacts, AgentBundleArtifactExtensions::current_artifacts( $agent, $installed, array( 'agent_id' => $agent_id ) ) );
+	}
+
+	private function add_runtime_drift_to_plan( array $plan, array $bundle, string $slug = '', string $decision = 'preserve_existing' ): array {
+		$agent = $this->resolve_bundle_agent( $bundle, $slug );
+		if ( ! $agent ) {
+			return $plan;
+		}
+
+		$drifts = $this->runtime_drifts_for_bundle( $bundle, $agent, $decision );
+		if ( empty( $drifts ) ) {
+			return $plan;
+		}
+
+		$plan['runtime_drift'] = $drifts;
+		foreach ( $drifts as $drift ) {
+			$plan['warnings'][] = $drift;
+		}
+		$plan['counts']['warnings'] = count( $plan['warnings'] ?? array() );
+
+		return $plan;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private function runtime_drifts_for_bundle( array $bundle, array $agent, string $decision ): array {
+		$agent_id                   = (int) ( $agent['agent_id'] ?? 0 );
+		$pipeline_id_map            = array();
+		$existing_pipelines_by_slug = array();
+		$drifts                     = array();
+
+		foreach ( $this->pipelines->get_all_pipelines( null, $agent_id ) as $pipeline ) {
+			$existing_pipelines_by_slug[ (string) ( $pipeline['portable_slug'] ?? '' ) ] = $pipeline;
+		}
+
+		foreach ( $bundle['pipelines'] ?? array() as $pipeline ) {
+			if ( ! is_array( $pipeline ) ) {
+				continue;
+			}
+			$slug = PortableSlug::normalize( (string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ), 'pipeline' );
+			if ( isset( $existing_pipelines_by_slug[ $slug ] ) ) {
+				$pipeline_id_map[ (int) ( $pipeline['original_id'] ?? 0 ) ] = (int) ( $existing_pipelines_by_slug[ $slug ]['pipeline_id'] ?? 0 );
+			}
+		}
+
+		foreach ( $bundle['flows'] ?? array() as $flow ) {
+			if ( ! is_array( $flow ) ) {
+				continue;
+			}
+			$old_pipeline_id = (int) ( $flow['original_pipeline_id'] ?? 0 );
+			$new_pipeline_id = (int) ( $pipeline_id_map[ $old_pipeline_id ] ?? 0 );
+			if ( $new_pipeline_id <= 0 ) {
+				continue;
+			}
+			$flow_slug     = PortableSlug::normalize( (string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? 'flow' ) ), 'flow' );
+			$existing_flow = $this->flows->get_by_portable_slug( $new_pipeline_id, $flow_slug );
+			if ( ! $existing_flow ) {
+				continue;
+			}
+			$target_flow = array_merge(
+				$flow,
+				array(
+					'flow_config' => BundleStepIdRemapper::remap_flow_step_ids( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array(), $old_pipeline_id, $new_pipeline_id, (int) $existing_flow['flow_id'] ),
+				)
+			);
+			$preview     = AgentBundleRuntimeDrift::preview( $flow_slug, $existing_flow, $target_flow, $decision );
+			if ( null !== $preview ) {
+				$drifts[] = $preview;
+			}
+		}
+
+		return $drifts;
+	}
+
+	private function rebase_locally_modified( AgentBundleUpgradePlan $plan, array $bundle, string $slug, string $policy_name ): array {
+		$needs_approval = $plan->bucket( 'needs_approval' );
+		if ( empty( $needs_approval ) ) {
+			return array();
+		}
+
+		$agent = $this->resolve_bundle_agent( $bundle, $slug );
+		if ( ! $agent ) {
+			return array();
+		}
+
+		$bundle_state    = is_array( $agent['agent_config']['datamachine_bundle'] ?? null ) ? $agent['agent_config']['datamachine_bundle'] : array();
+		$installed       = is_array( $bundle_state['artifacts'] ?? null ) ? $bundle_state['artifacts'] : array();
+		$installed_index = array();
+		foreach ( $installed as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$key                     = AgentBundleArtifactExtensions::artifact_key( (string) ( $row['artifact_type'] ?? '' ), (string) ( $row['artifact_id'] ?? '' ) );
+			$installed_index[ $key ] = $row;
+		}
+
+		$current_index = array();
+		foreach ( $this->current_artifacts( $agent, $installed ) as $artifact ) {
+			$key                   = AgentBundleArtifactExtensions::artifact_key( (string) $artifact['artifact_type'], (string) $artifact['artifact_id'] );
+			$current_index[ $key ] = $artifact;
+		}
+
+		$target_index = array();
+		foreach ( $this->bundle_artifacts_for_agent( $bundle, $agent ) as $artifact ) {
+			$key                  = AgentBundleArtifactExtensions::artifact_key( (string) $artifact['artifact_type'], (string) $artifact['artifact_id'] );
+			$target_index[ $key ] = $artifact;
+		}
+
+		$results = array();
+		foreach ( $needs_approval as $entry ) {
+			$key    = (string) ( $entry['artifact_key'] ?? '' );
+			$target = $target_index[ $key ] ?? null;
+			$local  = $current_index[ $key ] ?? null;
+			if ( ! is_array( $target ) || ! is_array( $local ) ) {
+				continue;
+			}
+
+			$base_payload  = null;
+			$installed_row = $installed_index[ $key ] ?? null;
+			if ( is_array( $installed_row ) ) {
+				if ( array_key_exists( 'installed_payload', $installed_row ) ) {
+					$base_payload = $installed_row['installed_payload'];
+				} elseif ( array_key_exists( 'payload', $installed_row ) ) {
+					$base_payload = $installed_row['payload'];
+				}
+			}
+
+			$results[] = AgentBundleArtifactRebase::rebase(
+				array(
+					'artifact_type' => (string) $target['artifact_type'],
+					'artifact_id'   => (string) $target['artifact_id'],
+					'source_path'   => (string) ( $target['source_path'] ?? '' ),
+					'base'          => $base_payload,
+					'local'         => $local['payload'] ?? null,
+					'remote'        => $target['payload'] ?? null,
+				),
+				$policy_name
+			);
+		}
+
+		return $results;
+	}
+
+	private function approved_rebased_artifact_keys( array $rebased_artifacts ): array {
+		$approved = array();
+		foreach ( $rebased_artifacts as $artifact ) {
+			if ( ! is_array( $artifact ) || ! empty( $artifact['requires_approval'] ) ) {
+				continue;
+			}
+			$key = (string) ( $artifact['artifact_key'] ?? '' );
+			if ( '' === $key ) {
+				$key = AgentBundleArtifactExtensions::artifact_key( (string) ( $artifact['artifact_type'] ?? '' ), (string) ( $artifact['artifact_id'] ?? '' ) );
+			}
+			if ( '' !== $key ) {
+				$approved[] = $key;
+			}
+		}
+
+		return array_values( array_unique( $approved ) );
+	}
+
+	private function pipeline_payload( array $pipeline, string $portable_slug ): array {
+		return array(
+			'portable_slug'   => $portable_slug,
+			'pipeline_name'   => (string) ( $pipeline['pipeline_name'] ?? '' ),
+			'pipeline_config' => is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(),
+		);
+	}
+
+	private function flow_payload( array $flow, string $portable_slug ): array {
+		return array(
+			'portable_slug'     => $portable_slug,
+			'flow_name'         => (string) ( $flow['flow_name'] ?? '' ),
+			'flow_config'       => $this->flow_config_without_runtime_queues( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() ),
+			'scheduling_policy' => $this->flow_scheduling_policy( is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array() ),
+			'queue_policy'      => 'create_seed_upgrade_preserve_existing',
+		);
+	}
+
+	private function flow_scheduling_policy( array $config ): string {
+		$interval = (string) ( $config['interval'] ?? 'manual' );
+		$enabled  = array_key_exists( 'enabled', $config ) ? false !== $config['enabled'] : 'manual' !== $interval;
+
+		return ( 'manual' === $interval || ! $enabled ) ? 'create_paused_upgrade_preserve_existing' : 'create_bundle_schedule_upgrade_preserve_existing';
+	}
+
+	private function flow_config_without_runtime_queues( array $flow_config ): array {
+		foreach ( $flow_config as &$step ) {
+			if ( is_array( $step ) ) {
+				unset( $step['prompt_queue'], $step['config_patch_queue'], $step['queue_mode'], $step['_queue_consume_revision'] );
+			}
+		}
+		unset( $step );
+
+		return $flow_config;
+	}
+
+	private function resolve_bundle_agent( array $bundle, string $slug = '' ): ?array {
+		$target = '' !== $slug ? sanitize_title( $slug ) : sanitize_title( (string) ( $bundle['agent']['agent_slug'] ?? '' ) );
+		return '' === $target ? null : $this->agents->get_by_slug( $target );
+	}
+
+	private function resolve_installed_agent( string $slug ): ?array {
+		$slug = sanitize_title( $slug );
+		if ( '' === $slug ) {
+			return null;
+		}
+
+		$agent = $this->agents->get_by_slug( $slug );
+		if ( $agent && ! empty( $agent['agent_config']['datamachine_bundle']['bundle_slug'] ) ) {
+			return $agent;
+		}
+
+		foreach ( $this->agents->get_all() as $candidate ) {
+			$bundle = $candidate['agent_config']['datamachine_bundle'] ?? array();
+			if ( sanitize_title( (string) ( $bundle['bundle_slug'] ?? '' ) ) === $slug ) {
+				return $candidate;
+			}
+		}
+
+		return null;
+	}
+
+	private function installed_status( array $agent ): array {
+		$bundle    = $agent['agent_config']['datamachine_bundle'] ?? array();
+		$artifacts = is_array( $bundle['artifacts'] ?? null ) ? $bundle['artifacts'] : array();
+
+		return array(
+			'agent_id'         => (int) $agent['agent_id'],
+			'agent_slug'       => (string) $agent['agent_slug'],
+			'template_slug'    => (string) ( $bundle['template_slug'] ?? $bundle['bundle_slug'] ?? '' ),
+			'template_version' => (string) ( $bundle['template_version'] ?? $bundle['bundle_version'] ?? '' ),
+			'bundle_slug'      => (string) ( $bundle['bundle_slug'] ?? '' ),
+			'bundle_version'   => (string) ( $bundle['bundle_version'] ?? '' ),
+			'source_ref'       => (string) ( $bundle['source_ref'] ?? '' ),
+			'source_revision'  => (string) ( $bundle['source_revision'] ?? '' ),
+			'artifact_count'   => count( $artifacts ),
+			'artifacts'        => array_values( $artifacts ),
+		);
+	}
+
+	private function bundle_summary( array $bundle, string $slug = '' ): array {
+		$package = AgentBundler::package_from_bundle( $bundle );
+
+		return array(
+			'bundle_slug'    => $package->get_slug(),
+			'bundle_version' => $package->get_version(),
+			'target_slug'    => '' !== $slug ? sanitize_title( $slug ) : $package->get_agent()->get_slug(),
+			'pipelines'      => count( $bundle['pipelines'] ?? array() ),
+			'flows'          => count( $bundle['flows'] ?? array() ),
+			'artifacts'      => count( $package->get_artifacts() ),
+		);
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleArtifactRebase.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactRebase.php
@@ -270,6 +270,21 @@ final class AgentBundleArtifactRebase {
 			$local_hcs  = is_array( $local_step['handler_configs'] ?? null ) ? $local_step['handler_configs'] : array();
 			$remote_hcs = is_array( $remote_step['handler_configs'] ?? null ) ? $remote_step['handler_configs'] : array();
 
+			// Legacy/single-handler flow shapes still carry `handler_config` directly on
+			// the step. Apply the same burn-in-safe ownership rules there so template
+			// upgrades cannot silently reset local throttles before the config is
+			// normalized into keyed `handler_configs`.
+			if ( empty( $local_hcs ) && empty( $remote_hcs ) && ( is_array( $local_step['handler_config'] ?? null ) || is_array( $remote_step['handler_config'] ?? null ) ) ) {
+				$merged_step['handler_config'] = self::merge_handler_config(
+					is_array( $base_step['handler_config'] ?? null ) ? $base_step['handler_config'] : array(),
+					is_array( $local_step['handler_config'] ?? null ) ? $local_step['handler_config'] : array(),
+					is_array( $remote_step['handler_config'] ?? null ) ? $remote_step['handler_config'] : array(),
+					"flow_config.{$step_id}.handler_config",
+					$decisions,
+					$ambiguous
+				);
+			}
+
 			if ( ! empty( $local_hcs ) || ! empty( $remote_hcs ) ) {
 				$merged_hcs = array();
 				$slugs      = array_unique( array_merge( array_keys( $local_hcs ), array_keys( $remote_hcs ) ) );

--- a/tests/agent-bundle-ability-contract-smoke.php
+++ b/tests/agent-bundle-ability-contract-smoke.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Smoke test for ability-first agent bundle lifecycle contract (#1537).
+ *
+ * Run with: php tests/agent-bundle-ability-contract-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$root     = dirname( __DIR__ );
+$failures = array();
+$passes   = 0;
+
+function datamachine_bundle_ability_assert( bool $condition, string $label, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "  PASS {$label}\n";
+		return;
+	}
+
+	$failures[] = $label;
+	echo "  FAIL {$label}\n";
+}
+
+function datamachine_bundle_ability_contains( string $source, string $needle, string $label, array &$failures, int &$passes ): void {
+	datamachine_bundle_ability_assert( false !== strpos( $source, $needle ), $label, $failures, $passes );
+}
+
+$abilities = (string) file_get_contents( $root . '/inc/Abilities/AgentAbilities.php' );
+$cli       = (string) file_get_contents( $root . '/inc/Cli/Commands/AgentBundleCommand.php' );
+$service   = (string) file_get_contents( $root . '/inc/Engine/Bundle/AgentBundleAbilityService.php' );
+
+echo "agent-bundle-ability-contract-smoke\n";
+
+echo "\n[1] Abilities expose the lifecycle contract\n";
+foreach ( array(
+	'datamachine/list-agent-bundles'                  => 'installed bundle listing ability registered',
+	'datamachine/get-agent-bundle-status'             => 'bundle status ability registered',
+	'datamachine/plan-agent-bundle-upgrade'           => 'upgrade planning ability registered',
+	'datamachine/rebase-agent-bundle-artifacts'       => 'artifact rebase ability registered',
+	'datamachine/apply-agent-bundle-upgrade'          => 'upgrade apply ability registered',
+	'datamachine/resolve-agent-bundle-upgrade-action' => 'PendingAction resolution ability registered',
+) as $needle => $label ) {
+	datamachine_bundle_ability_contains( $abilities, $needle, $label, $failures, $passes );
+}
+
+echo "\n[2] Abilities are backed by one lifecycle service\n";
+foreach ( array(
+	'AgentBundleAbilityService'                  => 'ability callbacks use lifecycle service',
+	'AgentBundleUpgradePlanner::plan'            => 'service owns upgrade planning',
+	'AgentBundleUpgradePendingAction::stage'     => 'service owns approval staging',
+	'ResolvePendingActionAbility::execute'       => 'service owns PendingAction apply bridge',
+	'AgentBundleArtifactExtensions::current_artifacts' => 'service owns extension current-state collection',
+) as $needle => $label ) {
+	datamachine_bundle_ability_contains( $service . $abilities, $needle, $label, $failures, $passes );
+}
+
+echo "\n[3] WP-CLI wraps ability callbacks instead of duplicating public lifecycle logic\n";
+foreach ( array(
+	'AgentAbilities::listAgentBundles'              => 'installed command calls list ability callback',
+	'AgentAbilities::getAgentBundleStatus'          => 'status command calls status ability callback',
+	'AgentAbilities::planAgentBundleUpgrade'        => 'diff command calls plan ability callback',
+	'AgentAbilities::applyAgentBundleUpgrade'       => 'upgrade command calls apply ability callback',
+	'AgentAbilities::rebaseAgentBundleArtifacts'    => 'rebase command calls rebase ability callback',
+	'AgentAbilities::resolveAgentBundleUpgradeAction' => 'apply command calls PendingAction ability callback',
+) as $needle => $label ) {
+	datamachine_bundle_ability_contains( $cli, $needle, $label, $failures, $passes );
+}
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " ability contract assertion(s) failed.\n";
+	exit( 1 );
+}
+
+echo "\nAgent bundle ability contract smoke passed ({$passes} assertions).\n";


### PR DESCRIPTION
## Summary
- Adds canonical agent bundle lifecycle abilities for installed status, upgrade planning, rebasing, applying, and PendingAction resolution.
- Moves bundle upgrade/status/rebase orchestration into `AgentBundleAbilityService` so CLI wraps the ability contract instead of owning separate lifecycle logic.
- Preserves local burn-in throttles for legacy single-handler `handler_config` rebase shapes.

Closes #1537.

## Tests
- `php -l inc/Engine/Bundle/AgentBundleAbilityService.php`
- `php -l inc/Abilities/AgentAbilities.php`
- `php -l inc/Cli/Commands/AgentBundleCommand.php`
- `php -l inc/Engine/Bundle/AgentBundleArtifactRebase.php`
- `php -l tests/agent-bundle-ability-contract-smoke.php`
- `php tests/agent-bundle-ability-contract-smoke.php`
- `php tests/agent-bundle-upgrade-planner-smoke.php`
- `php tests/agent-bundle-runtime-drift-smoke.php`
- `php tests/agent-bundle-installed-payload-snapshot-smoke.php`
- `composer lint -- --standard=phpcs.xml.dist inc/Engine/Bundle/AgentBundleAbilityService.php inc/Abilities/AgentAbilities.php inc/Cli/Commands/AgentBundleCommand.php inc/Engine/Bundle/AgentBundleArtifactRebase.php tests/agent-bundle-ability-contract-smoke.php`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@issue-1537-ability-bundle-upgrades --extension wordpress --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the ability-first bundle upgrade contract, CLI wrapper refactor, focused smoke coverage, and targeted validation; Chris remains responsible for review and merge.