### PR TITLE
fix: emit canonical pending action resolution hooks

### DIFF
--- a/docs/core-system/pending-actions.md
+++ b/docs/core-system/pending-actions.md
@@ -27,10 +27,10 @@ The compatibility seam remains the existing `datamachine_pending_action_handlers
 `PendingActionStore` dispatches registered `WP_Agent_Pending_Action_Observer` instances after durable lifecycle transitions complete. Data Machine registers a default WordPress adapter with these hooks:
 
 - `datamachine_pending_action_stored( WP_Agent_Pending_Action $action )`
-- `datamachine_pending_action_resolved( string $decision, string $action_id, string $kind, array $payload, mixed $result )`
+- `datamachine_pending_action_resolved( WP_Agent_Pending_Action $action, WP_Agent_Approval_Decision $decision, string $resolver )`
 - `datamachine_pending_action_expired( WP_Agent_Pending_Action $action )`
 
-The resolved hook keeps its legacy signature for compatibility. Object-oriented observers receive the upstream value-object signature from `WP_Agent_Pending_Action_Observer`.
+The resolved hook receives the same canonical value-object signature as `WP_Agent_Pending_Action_Observer::on_resolved()`.
 
 ## Surfaces
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -552,8 +552,9 @@ action. Receives `WP_Agent_Pending_Action $action`.
 
 ### `datamachine_pending_action_resolved`
 
-**Purpose**: Fires after a staged action is accepted or rejected. This hook keeps
-the legacy signature: `$decision, $action_id, $kind, $payload, $result`.
+**Purpose**: Fires after a staged action is accepted or rejected. Receives the
+canonical Agents API contract: `WP_Agent_Pending_Action $action`,
+`WP_Agent_Approval_Decision $decision`, and `string $resolver`.
 
 ### `datamachine_pending_action_expired`
 

--- a/inc/Engine/AI/Actions/WordPressActionDispatchObserver.php
+++ b/inc/Engine/AI/Actions/WordPressActionDispatchObserver.php
@@ -31,5 +31,4 @@ final class WordPressActionDispatchObserver implements WP_Agent_Pending_Action_O
 	public function on_expired( WP_Agent_Pending_Action $action ): void {
 		do_action( 'datamachine_pending_action_expired', $action );
 	}
-
 }

--- a/inc/Engine/AI/Actions/WordPressActionDispatchObserver.php
+++ b/inc/Engine/AI/Actions/WordPressActionDispatchObserver.php
@@ -20,18 +20,11 @@ final class WordPressActionDispatchObserver implements WP_Agent_Pending_Action_O
 	}
 
 	public function on_resolved( WP_Agent_Pending_Action $action, WP_Agent_Approval_Decision $decision, string $resolver ): void {
-		unset( $resolver );
-
-		$payload  = $this->legacy_payload( $action );
-		$resolved = $action->to_array();
-
 		do_action(
 			'datamachine_pending_action_resolved',
-			$decision->value(),
-			$action->get_action_id(),
-			$action->get_kind(),
-			$payload,
-			$resolved['resolution_result'] ?? null
+			$action,
+			$decision,
+			$resolver
 		);
 	}
 
@@ -39,35 +32,4 @@ final class WordPressActionDispatchObserver implements WP_Agent_Pending_Action_O
 		do_action( 'datamachine_pending_action_expired', $action );
 	}
 
-	/**
-	 * Build the legacy Data Machine hook payload shape from the Agents API value.
-	 */
-	private function legacy_payload( WP_Agent_Pending_Action $action ): array {
-		$data        = $action->to_array();
-		$metadata    = is_array( $data['metadata'] ?? null ) ? $data['metadata'] : array();
-		$datamachine = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
-
-		return array(
-			'action_id'           => $data['action_id'],
-			'kind'                => $data['kind'],
-			'summary'             => $data['summary'],
-			'preview_data'        => $data['preview'],
-			'apply_input'         => $data['apply_input'],
-			'workspace'           => $data['workspace'],
-			'agent'               => $data['agent'],
-			'creator'             => $data['creator'],
-			'agent_id'            => $datamachine['agent_id'] ?? 0,
-			'created_by'          => $datamachine['created_by'] ?? 0,
-			'context'             => $datamachine['context'] ?? array(),
-			'metadata'            => $metadata,
-			'status'              => $data['status'],
-			'created_at'          => $data['created_at'],
-			'expires_at'          => $data['expires_at'],
-			'resolved_at'         => $data['resolved_at'],
-			'resolver'            => $data['resolver'],
-			'resolution_result'   => $data['resolution_result'],
-			'resolution_error'    => $data['resolution_error'],
-			'resolution_metadata' => $data['resolution_metadata'],
-		);
-	}
 }

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -86,7 +86,7 @@ function datamachine_register_core_actions() {
 			$metadata    = $action->get_metadata();
 			$datamachine = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
 			$context     = is_array( $datamachine['context'] ?? null ) ? $datamachine['context'] : array();
-			$job_id  = (int) ( $context['job_id'] ?? 0 );
+			$job_id      = (int) ( $context['job_id'] ?? 0 );
 			if ( $job_id <= 0 ) {
 				return;
 			}

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -52,6 +52,8 @@ use DataMachine\Engine\Actions\Handlers\MarkItemProcessedHandler;
 use DataMachine\Engine\Actions\Handlers\FailJobHandler;
 use DataMachine\Engine\Actions\Handlers\JobCompleteHandler;
 use DataMachine\Engine\Actions\Handlers\LogHandler;
+use AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision;
+use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action;
 
 /**
  * Register core Data Machine action hooks.
@@ -78,19 +80,21 @@ function datamachine_register_core_actions() {
 	);
 	add_action(
 		'datamachine_pending_action_resolved',
-		function ( string $decision, string $action_id, string $kind, array $payload ): void {
-			$action_id;
-			$kind;
-			$context = is_array( $payload['context'] ?? null ) ? $payload['context'] : array();
+		function ( WP_Agent_Pending_Action $action, WP_Agent_Approval_Decision $decision, string $resolver ): void {
+			unset( $resolver );
+
+			$metadata    = $action->get_metadata();
+			$datamachine = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
+			$context     = is_array( $datamachine['context'] ?? null ) ? $datamachine['context'] : array();
 			$job_id  = (int) ( $context['job_id'] ?? 0 );
 			if ( $job_id <= 0 ) {
 				return;
 			}
-			$key = 'accepted' === $decision ? 'accepted_actions' : 'rejected_actions';
+			$key = $decision->is_accepted() ? 'accepted_actions' : 'rejected_actions';
 			\DataMachine\Core\RunMetrics::increment( $job_id, $key );
 		},
 		10,
-		5
+		3
 	);
 
 	// AI library error logging — universal handler for all AI interactions (pipeline agents, chat agents).

--- a/tests/pending-actions-agents-api-contract-smoke.php
+++ b/tests/pending-actions-agents-api-contract-smoke.php
@@ -100,6 +100,8 @@ datamachine_pending_actions_assert( str_contains( $action_policy, 'use AgentsAPI
 datamachine_pending_actions_assert( str_contains( $resolver_adapter, 'WP_Agent_Approval_Decision' ), 'resolver adapter consumes Agents API WP_Agent_Approval_Decision vocabulary', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $observers_source, 'WP_Agent_Pending_Action_Observer' ), 'observer registry consumes Agents API WP_Agent_Pending_Action_Observer contract', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $wp_observer_source, 'datamachine_pending_action_stored' ) && str_contains( $wp_observer_source, 'datamachine_pending_action_resolved' ) && str_contains( $wp_observer_source, 'datamachine_pending_action_expired' ), 'WordPress observer adapter exposes stored/resolved/expired actions', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $wp_observer_source, 'do_action(' . PHP_EOL . "\t\t\t'datamachine_pending_action_resolved'," . PHP_EOL . "\t\t\t\$action," . PHP_EOL . "\t\t\t\$decision," . PHP_EOL . "\t\t\t\$resolver" ), 'resolved WordPress hook emits canonical Agents API action, decision, and resolver arguments', $failures, $passes );
+datamachine_pending_actions_assert( ! str_contains( $wp_observer_source, 'legacy_payload' ) && ! str_contains( $wp_observer_source, 'preview_data' ), 'resolved WordPress hook no longer builds legacy Data Machine payloads', $failures, $passes );
 
 echo "\n[2] Durable storage preserves legacy lookup while retaining audit rows:\n";
 datamachine_pending_actions_assert( str_contains( $store_source, 'CREATE TABLE {$table_name}' ), 'PendingActionStore creates a durable table', $failures, $passes );
@@ -341,6 +343,17 @@ datamachine_pending_actions_assert( $store->get( $action_id ) instanceof \Agents
 datamachine_pending_actions_assert( $store->record_resolution( $action_id, \AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision::accepted(), 'user:123' ), 'contract record_resolution resolves transient fallback payload', $failures, $passes );
 $resolved_hooks = array_map( static fn( array $event ): string => (string) ( $event['hook'] ?? '' ), $GLOBALS['datamachine_pending_action_observer_events'] ?? array() );
 datamachine_pending_actions_assert( in_array( 'datamachine_pending_action_resolved', $resolved_hooks, true ), 'resolved observer action fires after contract resolution', $failures, $passes );
+$resolved_event = null;
+foreach ( $GLOBALS['datamachine_pending_action_observer_events'] ?? array() as $event ) {
+	if ( 'datamachine_pending_action_resolved' === ( $event['hook'] ?? null ) ) {
+		$resolved_event = $event;
+		break;
+	}
+}
+$resolved_args = is_array( $resolved_event ) ? ( $resolved_event['args'] ?? array() ) : array();
+datamachine_pending_actions_assert( ( $resolved_args[0] ?? null ) instanceof \AgentsAPI\AI\Approvals\WP_Agent_Pending_Action, 'resolved hook receives canonical pending action value object', $failures, $passes );
+datamachine_pending_actions_assert( ( $resolved_args[1] ?? null ) instanceof \AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision, 'resolved hook receives canonical approval decision value object', $failures, $passes );
+datamachine_pending_actions_assert( 'user:123' === ( $resolved_args[2] ?? null ), 'resolved hook receives resolver identifier as third argument', $failures, $passes );
 datamachine_pending_actions_assert( null === $store->get( $action_id ), 'contract get returns null after transient fallback resolution', $failures, $passes );
 
 if ( ! empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- Replaces the legacy `datamachine_pending_action_resolved` hook payload with the canonical Agents API action, decision, and resolver contract.
- Updates the only in-repo runtime consumer to read Data Machine job context from `metadata.datamachine.context`.
- Updates pending-action docs and smoke coverage to pin the resolved hook signature and removal of `legacy_payload()`.

## Verification
- `php tests/pending-actions-agents-api-contract-smoke.php`
- `php -l inc/Engine/AI/Actions/WordPressActionDispatchObserver.php && php -l inc/Engine/Actions/DataMachineActions.php && php -l tests/pending-actions-agents-api-contract-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/Actions/WordPressActionDispatchObserver.php inc/Engine/Actions/DataMachineActions.php tests/pending-actions-agents-api-contract-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-pending-action-resolved-contract --extension wordpress`

## Verification gaps
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-pending-action-resolved-contract --extension wordpress` reports existing repository-wide frontend lint findings outside this change.

Fixes #2222.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing pending-action resolved hook consumers, implementing the canonical hook contract, updating smoke coverage and docs, and running verification.