### PR TITLE
Remove OAuth pre-nonce fallback transients

### DIFF
--- a/inc/Core/OAuth/OAuth2Handler.php
+++ b/inc/Core/OAuth/OAuth2Handler.php
@@ -127,11 +127,6 @@ class OAuth2Handler {
 		$record = get_transient( $this->state_transient_key( $provider_key, $state ) );
 
 		if ( false === $record ) {
-			// Backward compatibility for states created before nonce-keyed storage.
-			$record = get_transient( "datamachine_{$provider_key}_oauth_state" );
-		}
-
-		if ( false === $record ) {
 			$this->log_state_verification( $provider_key, false );
 			return false;
 		}
@@ -147,7 +142,6 @@ class OAuth2Handler {
 		}
 
 		delete_transient( $this->state_transient_key( $provider_key, $state ) );
-		delete_transient( "datamachine_{$provider_key}_oauth_state" );
 		$this->log_state_verification( $provider_key, true );
 
 		return $record['payload'] ?? array();
@@ -250,17 +244,11 @@ class OAuth2Handler {
 	public function get_pkce_verifier( string $provider_key, string $state = '' ): ?string {
 		$verifier = get_transient( $this->pkce_transient_key( $provider_key, $state ) );
 
-		if ( false === $verifier && '' !== $state ) {
-			// Backward compatibility for verifiers created before nonce-keyed storage.
-			$verifier = get_transient( "datamachine_{$provider_key}_pkce_verifier" );
-		}
-
 		if ( false === $verifier ) {
 			return null;
 		}
 
 		delete_transient( $this->pkce_transient_key( $provider_key, $state ) );
-		delete_transient( "datamachine_{$provider_key}_pkce_verifier" );
 		return $verifier;
 	}
 

--- a/tests/Unit/Core/OAuth/BaseOAuth2ProviderTest.php
+++ b/tests/Unit/Core/OAuth/BaseOAuth2ProviderTest.php
@@ -649,6 +649,39 @@ class BaseOAuth2ProviderTest extends WP_UnitTestCase {
 		$this->assertNull( $handler->get_pkce_verifier( 'nonexistent_provider' ) );
 	}
 
+	public function test_state_keyed_pkce_verifiers_do_not_cross_match(): void {
+		$handler      = new \DataMachine\Core\OAuth\OAuth2Handler();
+		$first_state  = str_repeat( '1', 64 );
+		$second_state = str_repeat( '2', 64 );
+		$first_pkce   = $handler->create_pkce( 'test_pkce_concurrent', $first_state );
+		$second_pkce  = $handler->create_pkce( 'test_pkce_concurrent', $second_state );
+
+		$this->assertNull(
+			$handler->get_pkce_verifier( 'test_pkce_concurrent', str_repeat( 'x', 64 ) )
+		);
+		$this->assertSame(
+			$first_pkce['verifier'],
+			$handler->get_pkce_verifier( 'test_pkce_concurrent', $first_state )
+		);
+		$this->assertSame(
+			$second_pkce['verifier'],
+			$handler->get_pkce_verifier( 'test_pkce_concurrent', $second_state )
+		);
+	}
+
+	public function test_state_keyed_pkce_verifier_does_not_fallback_to_provider_wide_transient(): void {
+		$handler = new \DataMachine\Core\OAuth\OAuth2Handler();
+		$state   = str_repeat( '3', 64 );
+
+		set_transient( 'datamachine_test_pkce_legacy_pkce_verifier', 'legacy-verifier', 900 );
+
+		$this->assertNull( $handler->get_pkce_verifier( 'test_pkce_legacy', $state ) );
+		$this->assertSame(
+			'legacy-verifier',
+			$handler->get_pkce_verifier( 'test_pkce_legacy' )
+		);
+	}
+
 	public function test_pkce_challenge_is_valid_s256(): void {
 		$handler = new \DataMachine\Core\OAuth\OAuth2Handler();
 		$pkce    = $handler->create_pkce( 'test_pkce_s256' );

--- a/tests/Unit/Core/OAuth/OAuth2HandlerStateTest.php
+++ b/tests/Unit/Core/OAuth/OAuth2HandlerStateTest.php
@@ -34,6 +34,7 @@ class OAuth2HandlerStateTest extends WP_UnitTestCase {
 		delete_transient( 'datamachine_test_malformed_oauth_state' );
 		delete_transient( 'datamachine_test_oversize_oauth_state' );
 		delete_transient( 'datamachine_test_expired_oauth_state' );
+		delete_transient( 'datamachine_test_legacy_oauth_state' );
 		parent::tear_down();
 	}
 
@@ -230,6 +231,35 @@ class OAuth2HandlerStateTest extends WP_UnitTestCase {
 		// Second verification fails (consumed).
 		$result2 = $this->handler->verify_state( 'test_provider', $state );
 		$this->assertFalse( $result2 );
+	}
+
+	public function test_concurrent_provider_states_are_verified_by_nonce(): void {
+		$first_state  = $this->handler->create_state( 'test_concurrent', array( 'request_id' => 'first' ) );
+		$second_state = $this->handler->create_state( 'test_concurrent', array( 'request_id' => 'second' ) );
+
+		$this->assertSame(
+			array( 'request_id' => 'first' ),
+			$this->handler->verify_state( 'test_concurrent', $first_state )
+		);
+		$this->assertSame(
+			array( 'request_id' => 'second' ),
+			$this->handler->verify_state( 'test_concurrent', $second_state )
+		);
+	}
+
+	public function test_provider_wide_state_transient_is_not_used_as_fallback(): void {
+		$requested_state = str_repeat( 'a', 64 );
+
+		set_transient(
+			'datamachine_test_legacy_oauth_state',
+			array(
+				'nonce'   => $requested_state,
+				'payload' => array( 'legacy' => true ),
+			),
+			900
+		);
+
+		$this->assertFalse( $this->handler->verify_state( 'test_legacy', $requested_state ) );
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removes provider-wide OAuth state fallback reads now that state storage is nonce-keyed.
- Removes provider-wide PKCE fallback reads for state-keyed verifier lookups while preserving the explicit no-state PKCE path.
- Adds tests for concurrent provider state/PKCE flows and fail-closed legacy fallback behavior.

Closes #2216.

## Verification
- `homeboy lint --changed-only`
- `homeboy test --changed-since origin/main`
- `homeboy audit --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the OAuth fallback removal, added focused unit coverage, ran local validation, and drafted this PR description for Chris to review.