### PR TITLE
fix: contain legacy handler migrator lifecycle

### DIFF
--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -73,9 +73,15 @@ wp datamachine flows list-handlers 10
 
 # Memory file management
 wp datamachine flows memory-files 10 --add=context.md
+
+# Operator repair: audit and rewrite pre-1.0 scalar handler rows
+wp datamachine flows migrate-legacy-handler-shape --dry-run --verbose
+wp datamachine flows migrate-legacy-handler-shape --all-sites --yes
 ```
 
-**Options**: `--per_page`, `--offset`, `--handler`, `--format`, `--fields`
+`migrate-legacy-handler-shape` is a contained operator repair command for older stored `flow_config` rows that still use scalar `handler`, `handler_slug`, or `handler_config` keys. Normal workflow specs, import/update paths, readers, and writers remain canonical-only and use `handler_slugs`, `handler_configs`, and `flow_step_settings`.
+
+**Options**: `--per_page`, `--offset`, `--handler`, `--format`, `--fields`, `--dry-run`, `--all-sites`, `--yes`, `--verbose`
 
 ### datamachine flows queue
 

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -23,7 +23,6 @@ use DataMachine\Cli\AgentResolver;
 use DataMachine\Cli\UserResolver;
 use DataMachine\Cli\Commands\DrainCommand;
 use DataMachine\Core\Steps\FlowStepConfig;
-use DataMachine\Core\Steps\LegacyHandlerShapeMigrator;
 use DataMachine\Engine\Debug\SyncRunner;
 
 defined( 'ABSPATH' ) || exit;

--- a/inc/Cli/Commands/Flows/LegacyHandlerShapeMigrator.php
+++ b/inc/Cli/Commands/Flows/LegacyHandlerShapeMigrator.php
@@ -7,34 +7,25 @@
  * `handler_config`) into the canonical shape (`handler_slugs`,
  * `handler_configs`, `flow_step_settings`).
  *
- * After `b9db8d8` (#712) the canonical shape became authoritative and a
- * persisted migration ran on every plugins_loaded. That migration was removed
- * in `e113857` ("Drop pre-1.0 data-shape migrations") on the assumption that
- * every install booting current code had already been migrated. That
- * assumption did not hold for every install: production sites that re-issued
- * legacy-shape writes — directly or via cloned/imported flow data — still
- * carry rows in the scalar shape.
+ * This class intentionally lives beside the `flows migrate-legacy-handler-shape`
+ * WP-CLI command. Runtime readers, writers, validators, importers, and step
+ * config factories must stay canonical-only; this is not a compatibility layer.
  *
- * The strict legacy-field rejection landed in #2102 (May 2026) which makes
- * those leftover rows runtime-fatal: handler-backed fetch steps return a null
- * primary slug and run as no-ops. This migrator is the explicit operator path
- * back to the canonical shape without re-introducing an open-ended persisted
- * migration chain.
- *
- * Pure in-memory transformation. The CLI wraps this with persistence and
- * per-site iteration.
- *
- * @package DataMachine\Core\Steps
+ * @package DataMachine\Cli\Commands\Flows
  * @since 0.124.6
  */
 
-namespace DataMachine\Core\Steps;
+namespace DataMachine\Cli\Commands\Flows;
+
+use DataMachine\Core\Steps\FlowStepConfig;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Rewrite legacy scalar handler shapes inside `flow_config` JSON into the
  * canonical `handler_slugs` / `handler_configs` / `flow_step_settings` shape.
+ *
+ * @internal Operator repair helper for `wp datamachine flows migrate-legacy-handler-shape` only.
  */
 class LegacyHandlerShapeMigrator {
 
@@ -102,8 +93,8 @@ class LegacyHandlerShapeMigrator {
 	 * steps) or `flow_step_settings` (handler-free steps), then strips the
 	 * legacy keys via {@see FlowStepConfig::normalizeHandlerShape()}.
 	 *
-	 * @param array<string, mixed>                                                                            $step   Step config row.
-	 * @param array{dropped_orphan_legacy_config: int, ...}                                                   $report In/out report counters.
+	 * @param array<string, mixed>                  $step   Step config row.
+	 * @param array{dropped_orphan_legacy_config:int,...} $report In/out report counters.
 	 * @return array<string, mixed> Migrated step config row.
 	 */
 	private static function migrate_step( array $step, array &$report ): array {

--- a/tests/legacy-handler-shape-migration-smoke.php
+++ b/tests/legacy-handler-shape-migration-smoke.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Pure-PHP smoke test for `LegacyHandlerShapeMigrator`.
+ * Pure-PHP smoke test for the operator-only legacy handler shape migrator.
  *
  * Run with: php tests/legacy-handler-shape-migration-smoke.php
  *
@@ -46,9 +46,9 @@ if ( ! function_exists( 'do_action' ) ) {
 }
 
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
-require_once __DIR__ . '/../inc/Core/Steps/LegacyHandlerShapeMigrator.php';
+require_once __DIR__ . '/../inc/Cli/Commands/Flows/LegacyHandlerShapeMigrator.php';
 
-use DataMachine\Core\Steps\LegacyHandlerShapeMigrator;
+use DataMachine\Cli\Commands\Flows\LegacyHandlerShapeMigrator;
 
 $failures = array();
 $passes   = 0;

--- a/tests/workflow-persistent-install-smoke.php
+++ b/tests/workflow-persistent-install-smoke.php
@@ -134,7 +134,9 @@ assert_workflow_equals( 'Webhook Payload', $pipeline_steps[0]['label'] ?? null, 
 assert_workflow_equals( 'Review Pull Request', $pipeline_steps[1]['label'] ?? null, 'pipeline preserves AI label', $failures, $passes );
 assert_workflow_equals( 'Review the PR.', $pipeline_steps[1]['system_prompt'] ?? null, 'pipeline preserves AI system prompt', $failures, $passes );
 assert_workflow_equals( array( 'datamachine/delete-flow' ), $pipeline_steps[1]['disabled_tools'] ?? null, 'pipeline preserves AI disabled tools', $failures, $passes );
+assert_workflow_equals( false, array_key_exists( 'handler', $pipeline_steps[0] ), 'pipeline rows stay handler-alias-free', $failures, $passes );
 assert_workflow_equals( false, array_key_exists( 'handler_slug', $pipeline_steps[0] ), 'pipeline rows stay handler-free', $failures, $passes );
+assert_workflow_equals( false, array_key_exists( 'handler_config', $pipeline_steps[0] ), 'pipeline rows stay scalar-config-free', $failures, $passes );
 
 $flow_config = WorkflowConfigFactory::buildPersistentFlowConfig( $workflow, 88, 144, $pipeline_config );
 $flow_steps  = array_values( $flow_config );
@@ -146,6 +148,9 @@ assert_workflow_equals( 88, $flow_steps[0]['pipeline_id'] ?? null, 'flow stores 
 assert_workflow_equals( 144, $flow_steps[0]['flow_id'] ?? null, 'flow stores target flow id', $failures, $passes );
 assert_workflow_equals( array( 'webhook_payload' ), $flow_steps[0]['handler_slugs'] ?? null, 'flow preserves fetch handler slugs', $failures, $passes );
 assert_workflow_equals( array( 'webhook_payload' => array( 'payload_path' => 'pull_request' ) ), $flow_steps[0]['handler_configs'] ?? null, 'flow preserves fetch handler configs', $failures, $passes );
+assert_workflow_equals( false, array_key_exists( 'handler', $flow_steps[0] ), 'flow rows do not recreate scalar handler alias', $failures, $passes );
+assert_workflow_equals( false, array_key_exists( 'handler_slug', $flow_steps[0] ), 'flow rows do not recreate scalar handler_slug', $failures, $passes );
+assert_workflow_equals( false, array_key_exists( 'handler_config', $flow_steps[0] ), 'flow rows do not recreate scalar handler_config', $failures, $passes );
 assert_workflow_equals( array( 'after' => '2026-04-01' ), $flow_steps[0]['config_patch_queue'][0]['patch'] ?? null, 'flow preserves fetch config patch queue', $failures, $passes );
 assert_workflow_equals( 'drain', $flow_steps[0]['queue_mode'] ?? null, 'flow preserves explicit fetch queue mode', $failures, $passes );
 assert_workflow_equals( array( 'datamachine/get-github-pull-review-context', 'datamachine/upsert-github-pull-review-comment' ), $flow_steps[1]['enabled_tools'] ?? null, 'flow preserves AI enabled tools', $failures, $passes );

--- a/tests/workflow-spec-contract-smoke.php
+++ b/tests/workflow-spec-contract-smoke.php
@@ -124,6 +124,7 @@ $invalid_cases    = array(
 	'associative steps' => array( 'steps' => array( 'first' => array( 'type' => 'fetch' ) ) ),
 	'scalar step'       => array( 'steps' => array( 'fetch' ) ),
 	'missing type'      => array( 'steps' => array( array( 'handler_slug' => 'rss' ) ) ),
+	'legacy handler alias field' => array( 'steps' => array( array( 'type' => 'fetch', 'handler' => 'rss' ) ) ),
 	'legacy handler field' => array( 'steps' => array( array( 'type' => 'fetch', 'handler_slug' => 'rss' ) ) ),
 	'legacy config field'  => array( 'steps' => array( array( 'type' => 'fetch', 'handler_config' => array( 'url' => 'https://example.com' ) ) ) ),
 	'non-string type'   => array( 'steps' => array( array( 'type' => 123 ) ) ),
@@ -204,6 +205,9 @@ assert_workflow_spec_equals( array( array( 'id' => 'after-worktree', 'max_calls'
 assert_workflow_spec_equals( 'Cleanup', $pipeline_steps[2]['label'] ?? null, 'ephemeral pipeline_config preserves system_task label', $failures, $passes );
 assert_workflow_spec_equals( array( 'task_type' => 'retention_logs' ), $pipeline_steps[2]['flow_step_settings'] ?? null, 'ephemeral pipeline_config preserves system_task settings', $failures, $passes );
 assert_workflow_spec_equals( false, array_key_exists( 'system_prompt', $pipeline_steps[2] ), 'non-AI ephemeral pipeline rows do not gain AI metadata', $failures, $passes );
+assert_workflow_spec_equals( false, array_key_exists( 'handler', $pipeline_steps[0] ), 'ephemeral pipeline rows do not emit scalar handler alias', $failures, $passes );
+assert_workflow_spec_equals( false, array_key_exists( 'handler_slug', $pipeline_steps[0] ), 'ephemeral pipeline rows do not emit scalar handler_slug', $failures, $passes );
+assert_workflow_spec_equals( false, array_key_exists( 'handler_config', $pipeline_steps[0] ), 'ephemeral pipeline rows do not emit scalar handler_config', $failures, $passes );
 
 $execute_source  = file_get_contents( __DIR__ . '/../inc/Abilities/Job/ExecuteWorkflowAbility.php' ) ?: '';
 $pipeline_source = file_get_contents( __DIR__ . '/../inc/Abilities/Pipeline/PipelineHelpers.php' ) ?: '';


### PR DESCRIPTION
## Summary
- Keeps the legacy handler shape migrator as a contained WP-CLI operator repair command instead of a core step utility.
- Documents `wp datamachine flows migrate-legacy-handler-shape` as the explicit repair path for pre-1.0 scalar handler rows.
- Tightens smoke coverage so canonical workflow validation rejects all scalar legacy handler fields and workflow config builders do not recreate them.

Fixes #2224.

## Verification
- `php tests/legacy-handler-shape-migration-smoke.php`
- `php tests/workflow-spec-contract-smoke.php`
- `php tests/workflow-persistent-install-smoke.php`
- `vendor/bin/phpcs inc/Cli/Commands/Flows/LegacyHandlerShapeMigrator.php inc/Cli/Commands/Flows/FlowsCommand.php tests/legacy-handler-shape-migration-smoke.php tests/workflow-spec-contract-smoke.php tests/workflow-persistent-install-smoke.php`
- `php -l inc/Cli/Commands/Flows/LegacyHandlerShapeMigrator.php && php -l inc/Cli/Commands/Flows/FlowsCommand.php`
- `git diff --check`
- `homeboy test --path /Users/chubes/Developer/data-machine@issue-2224-legacy-handler-migrator --extension wordpress --force-hot`

## Verification gaps
- `homeboy lint --path /Users/chubes/Developer/data-machine@issue-2224-legacy-handler-migrator --extension wordpress --force-hot` still reports existing repo-wide lint debt outside this change; targeted `phpcs` for changed PHP files passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the CLI lifecycle containment, updating smoke tests/docs, and running verification. Chris remains responsible for review and merge.