### PR TITLE
fix: require canonical chat session creation path

### DIFF
--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -620,8 +620,7 @@ class ChatOrchestrator {
 	/**
 	 * Create a new chat session.
 	 *
-	 * Delegates to the create-chat-session ability when available,
-	 * falls back to direct ChatDatabase access.
+	 * Delegates to the canonical create-chat-session ability.
 	 *
 	 * @since 0.31.0
 	 *
@@ -638,77 +637,58 @@ class ChatOrchestrator {
 				: 0;
 		}
 
-		$ability = wp_get_ability( 'datamachine/create-chat-session' );
-
-		if ( $ability ) {
-			$agent_slug = ConversationStoreFactory::resolve_agent_slug_for_transcript( $agent_id );
-			$input      = array(
-				'user_id'    => $user_id,
-				'agent_slug' => $agent_slug,
-				'mode'       => $mode,
-			);
-
-			if ( null !== $transcript_owner ) {
-				$input['transcript_owner'] = $transcript_owner;
-			}
-
-			if ( $source ) {
-				$input['source'] = $source;
-			}
-
-			$result = \DataMachine\Abilities\PermissionHelper::run_as_authenticated(
-				function () use ( $ability, $input ) {
-					return $ability->execute( $input );
-				}
-			);
-
-			if ( is_wp_error( $result ) ) {
-				return $result;
-			}
-
-			if ( empty( $result['success'] ) ) {
-				return new WP_Error(
-					'session_creation_failed',
-					$result['error'] ?? __( 'Failed to create chat session', 'data-machine' ),
-					array( 'status' => 500 )
-				);
-			}
-
-			return $result['session_id'];
-		}
-
-		// Fallback: direct store access.
-		$chat_db  = ConversationStoreFactory::get();
-		$metadata = array(
-			'started_at'    => current_time( 'mysql', true ),
-			'message_count' => 0,
-		);
-
-		if ( null !== $transcript_owner ) {
-			$metadata['transcript_owner'] = $transcript_owner;
-		}
-
-		$acting_token_id = \DataMachine\Abilities\PermissionHelper::get_acting_token_id();
-		if ( $acting_token_id ) {
-			$metadata['token_id'] = $acting_token_id;
-		}
-
-		if ( $source ) {
-			$metadata['source'] = $source;
-		}
-
-		$agent_slug = ConversationStoreFactory::resolve_agent_slug_for_transcript( $agent_id );
-		$session_id = $chat_db->create_session( WordPressWorkspaceScope::current(), $user_id, $agent_slug, $metadata, $mode );
-
-		if ( empty( $session_id ) ) {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
 			return new WP_Error(
-				'session_creation_failed',
-				__( 'Failed to create chat session', 'data-machine' ),
+				'session_creation_ability_unavailable',
+				__( 'Chat session creation ability API is unavailable.', 'data-machine' ),
 				array( 'status' => 500 )
 			);
 		}
 
-		return $session_id;
+		$ability = wp_get_ability( 'datamachine/create-chat-session' );
+
+		if ( ! $ability ) {
+			return new WP_Error(
+				'session_creation_ability_unavailable',
+				__( 'Chat session creation ability is unavailable.', 'data-machine' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$agent_slug = ConversationStoreFactory::resolve_agent_slug_for_transcript( $agent_id );
+		$input      = array(
+			'user_id'    => $user_id,
+			'agent_slug' => $agent_slug,
+			'mode'       => $mode,
+		);
+
+		if ( null !== $transcript_owner ) {
+			$input['transcript_owner'] = $transcript_owner;
+		}
+
+		if ( $source ) {
+			$input['source'] = $source;
+		}
+
+		$result = \DataMachine\Abilities\PermissionHelper::run_as_authenticated(
+			function () use ( $ability, $input ) {
+				return $ability->execute( $input );
+			}
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		if ( empty( $result['success'] ) || empty( $result['session_id'] ) ) {
+			return new WP_Error(
+				'session_creation_failed',
+				$result['error'] ?? __( 'Failed to create chat session', 'data-machine' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return $result['session_id'];
 	}
 
 	/**

--- a/tests/chat-session-canonical-path-smoke.php
+++ b/tests/chat-session-canonical-path-smoke.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Source smoke coverage for canonical chat session creation.
+ *
+ * Run with: php tests/chat-session-canonical-path-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+$root              = dirname( __DIR__ );
+$chat_orchestrator = file_get_contents( $root . '/inc/Api/Chat/ChatOrchestrator.php' );
+
+$failures = array();
+
+$assert = static function ( bool $condition, string $message ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	echo "FAIL: {$message}\n";
+	$failures[] = $message;
+};
+
+$assert(
+	false !== strpos( $chat_orchestrator, "wp_get_ability( 'datamachine/create-chat-session' )" ),
+	'ChatOrchestrator resolves the create-chat-session ability'
+);
+
+$assert(
+	false !== strpos( $chat_orchestrator, "'session_creation_ability_unavailable'" ),
+	'ChatOrchestrator reports missing ability dependencies as an explicit error'
+);
+
+$assert(
+	false === strpos( $chat_orchestrator, 'Fallback: direct store access' ),
+	'ChatOrchestrator does not keep a direct-store fallback path'
+);
+
+$assert(
+	false === strpos( $chat_orchestrator, '$chat_db->create_session' ),
+	'ChatOrchestrator does not create chat sessions through the store directly'
+);
+
+echo "\n";
+if ( empty( $failures ) ) {
+	echo "OK: canonical chat session creation smoke assertions passed.\n";
+	exit( 0 );
+}
+
+echo sprintf( "FAILED: %d assertion(s) failed.\n", count( $failures ) );
+exit( 1 );


### PR DESCRIPTION
## Summary
- Makes `datamachine/create-chat-session` the single canonical session-creation path for `ChatOrchestrator`.
- Removes the direct conversation-store fallback so missing ability registration fails loudly.
- Adds source smoke coverage that verifies the canonical ability path and missing-dependency error remain in place.

Fixes #2219.

## Verification
- `php tests/chat-session-canonical-path-smoke.php`
- `php -l inc/Api/Chat/ChatOrchestrator.php`
- `php -l tests/chat-session-canonical-path-smoke.php`
- `composer exec phpcs -- inc/Api/Chat/ChatOrchestrator.php tests/chat-session-canonical-path-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-chat-session-canonical-create --extension wordpress`

## Verification gaps
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-chat-session-canonical-create --extension wordpress` reports existing unrelated JS/admin lint findings outside the touched files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the canonical chat session creation path change, added focused smoke coverage, and ran verification; Chris remains responsible for review and merge.