### PR TITLE
Centralize ability result normalization

### DIFF
--- a/inc/Api/Chat/Chat.php
+++ b/inc/Api/Chat/Chat.php
@@ -15,6 +15,7 @@
 namespace DataMachine\Api\Chat;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\AbilityResult;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\AI\WpAiClientProviderAdmin;
 use WP_REST_Response;
@@ -701,22 +702,19 @@ class Chat {
 			return $result;
 		}
 
-		// Legacy convention: ability callbacks return { success: false, error: ... }.
-		// Map to WP_Error until all abilities are migrated to return WP_Error directly.
-		// See: https://github.com/Extra-Chill/data-machine/issues/999
-		if ( is_array( $result ) && isset( $result['success'] ) && ! $result['success'] ) {
-			$error_code = $result['error'] ?? 'ability_failed';
-
-			$status_map = array(
+		$legacy_error = AbilityResult::legacy_failure_to_wp_error(
+			$result,
+			'ability_failed',
+			'Ability execution failed.',
+			array(
 				'session_not_found'     => 404,
 				'session_access_denied' => 403,
-			);
-
-			return new WP_Error(
-				$error_code,
-				$result['error'] ?? 'Ability execution failed.',
-				array( 'status' => $status_map[ $error_code ] ?? 500 )
-			);
+			),
+			500,
+			true
+		);
+		if ( $legacy_error ) {
+			return $legacy_error;
 		}
 
 		return rest_ensure_response(

--- a/inc/Api/Email.php
+++ b/inc/Api/Email.php
@@ -11,6 +11,7 @@
 namespace DataMachine\Api;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\AbilityResult;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -659,12 +660,13 @@ class Email {
 			return $result;
 		}
 
+		$legacy_error = AbilityResult::legacy_failure_to_wp_error( $result, 'email_error', 'Operation failed', array(), 400 );
+		if ( $legacy_error ) {
+			return $legacy_error;
+		}
+
 		if ( ! ( $result['success'] ?? false ) ) {
-			return new \WP_Error(
-				'email_error',
-				$result['error'] ?? 'Operation failed',
-				array( 'status' => 400 )
-			);
+			return new \WP_Error( 'email_error', 'Operation failed', array( 'status' => 400 ) );
 		}
 
 		return rest_ensure_response( $result );

--- a/inc/Core/AbilityResult.php
+++ b/inc/Core/AbilityResult.php
@@ -26,13 +26,11 @@ class AbilityResult {
 	 */
 	public static function normalize( $result ): array {
 		if ( is_wp_error( $result ) ) {
-			$data = $result->get_error_data();
-
 			return array(
 				'success'       => false,
 				'error'         => $result->get_error_message(),
 				'wp_error_code' => $result->get_error_code(),
-				'wp_error_data' => is_array( $data ) ? $data : array(),
+				'wp_error_data' => self::wp_error_data( $result ),
 			);
 		}
 
@@ -44,5 +42,82 @@ class AbilityResult {
 			'success' => true,
 			'data'    => $result,
 		);
+	}
+
+	/**
+	 * Convert a WP_Ability::execute() result into Data Machine's tool result shape.
+	 *
+	 * @param mixed  $result       Ability execution result.
+	 * @param string $tool_name    Tool name.
+	 * @param string $ability_slug Ability slug.
+	 * @return array Normalized tool execution result.
+	 */
+	public static function normalize_tool_result( $result, string $tool_name, string $ability_slug ): array {
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'       => false,
+				'error'         => $result->get_error_message(),
+				'tool_name'     => $tool_name,
+				'ability'       => $ability_slug,
+				'wp_error_code' => $result->get_error_code(),
+				'wp_error_data' => self::wp_error_data( $result ),
+			);
+		}
+
+		if ( is_array( $result ) ) {
+			return $result;
+		}
+
+		return array(
+			'success'   => true,
+			'tool_name' => $tool_name,
+			'ability'   => $ability_slug,
+			'result'    => $result,
+		);
+	}
+
+	/**
+	 * Convert a legacy failed ability result array into WP_Error.
+	 *
+	 * @param mixed  $result          Ability execution result.
+	 * @param string $default_code    Error code to use when the result has no error code.
+	 * @param string $default_message Error message to use when the result has no message.
+	 * @param array  $status_map      Optional map of error code to HTTP status.
+	 * @param int    $default_status  Default HTTP status.
+	 * @param bool   $use_error_as_code Use the legacy error string as the WP_Error code when error_code is absent.
+	 * @return \WP_Error|null WP_Error for failed legacy arrays, null otherwise.
+	 */
+	public static function legacy_failure_to_wp_error( $result, string $default_code = 'ability_failed', string $default_message = 'Ability execution failed.', array $status_map = array(), int $default_status = 500, bool $use_error_as_code = false ): ?\WP_Error {
+		if ( ! is_array( $result ) || ! isset( $result['success'] ) || $result['success'] ) {
+			return null;
+		}
+
+		$error_code = (string) ( $result['error_code'] ?? ( $use_error_as_code ? ( $result['error'] ?? $default_code ) : $default_code ) );
+		if ( '' === $error_code ) {
+			$error_code = $default_code;
+		}
+
+		$message = (string) ( $result['message'] ?? $result['error'] ?? $default_message );
+		if ( '' === $message ) {
+			$message = $default_message;
+		}
+
+		return new \WP_Error(
+			$error_code,
+			$message,
+			array( 'status' => $status_map[ $error_code ] ?? $default_status )
+		);
+	}
+
+	/**
+	 * Return WP_Error data as an array for legacy result payloads.
+	 *
+	 * @param \WP_Error $error Error object.
+	 * @return array
+	 */
+	private static function wp_error_data( \WP_Error $error ): array {
+		$data = $error->get_error_data();
+
+		return is_array( $data ) ? $data : array();
 	}
 }

--- a/inc/Engine/AI/Tools/Execution/ToolExecutionCore.php
+++ b/inc/Engine/AI/Tools/Execution/ToolExecutionCore.php
@@ -12,6 +12,7 @@
 
 namespace DataMachine\Engine\AI\Tools\Execution;
 
+use DataMachine\Core\AbilityResult;
 use DataMachine\Engine\AI\Tools\ToolParameters;
 
 defined( 'ABSPATH' ) || exit;
@@ -203,26 +204,7 @@ class ToolExecutionCore {
 			);
 		}
 
-		$result = $ability->execute( $parameters );
-		if ( is_wp_error( $result ) ) {
-			return array(
-				'success'   => false,
-				'error'     => $result->get_error_message(),
-				'tool_name' => $tool_name,
-				'ability'   => $ability_slug,
-			);
-		}
-
-		if ( is_array( $result ) ) {
-			return $result;
-		}
-
-		return array(
-			'success'   => true,
-			'tool_name' => $tool_name,
-			'ability'   => $ability_slug,
-			'result'    => $result,
-		);
+		return AbilityResult::normalize_tool_result( $ability->execute( $parameters ), $tool_name, $ability_slug );
 	}
 
 	/**

--- a/tests/ability-result-wp-error-smoke.php
+++ b/tests/ability-result-wp-error-smoke.php
@@ -86,6 +86,52 @@ $scalar_result = AbilityResult::normalize( 'ok' );
 $assert( 'non-array successful callback values become success arrays', true === $scalar_result['success'] );
 $assert( 'non-array callback data is retained', 'ok' === $scalar_result['data'] );
 
+$tool_error_result = AbilityResult::normalize_tool_result(
+	new WP_Error( 'tool_forbidden', 'Tool denied.', array( 'status' => 403 ) ),
+	'demo_tool',
+	'datamachine/demo'
+);
+$assert( 'tool WP_Error normalizes to failed tool result', false === $tool_error_result['success'] );
+$assert( 'tool WP_Error keeps tool name', 'demo_tool' === $tool_error_result['tool_name'] );
+$assert( 'tool WP_Error keeps ability slug', 'datamachine/demo' === $tool_error_result['ability'] );
+$assert( 'tool WP_Error code is preserved', 'tool_forbidden' === $tool_error_result['wp_error_code'] );
+
+$tool_array_result = array( 'success' => true, 'custom' => 'value' );
+$assert( 'tool array results pass through unchanged', $tool_array_result === AbilityResult::normalize_tool_result( $tool_array_result, 'demo_tool', 'datamachine/demo' ) );
+
+$tool_scalar_result = AbilityResult::normalize_tool_result( 'ok', 'demo_tool', 'datamachine/demo' );
+$assert( 'tool scalar result is wrapped as success', true === $tool_scalar_result['success'] );
+$assert( 'tool scalar result payload uses tool result key', 'ok' === $tool_scalar_result['result'] );
+
+$legacy_error = AbilityResult::legacy_failure_to_wp_error(
+	array(
+		'success' => false,
+		'error'   => 'session_not_found',
+	),
+	'ability_failed',
+	'Ability execution failed.',
+	array( 'session_not_found' => 404 ),
+	500,
+	true
+);
+$assert( 'legacy failure arrays convert to WP_Error', $legacy_error instanceof WP_Error );
+$assert( 'legacy failure error code is preserved', 'session_not_found' === $legacy_error->get_error_code() );
+$assert( 'legacy failure status map is applied', 404 === ( $legacy_error->get_error_data()['status'] ?? null ) );
+$assert( 'successful arrays do not convert to WP_Error', null === AbilityResult::legacy_failure_to_wp_error( array( 'success' => true ) ) );
+
+$default_code_error = AbilityResult::legacy_failure_to_wp_error(
+	array(
+		'success' => false,
+		'error'   => 'Human readable failure.',
+	),
+	'email_error',
+	'Operation failed.',
+	array(),
+	400
+);
+$assert( 'legacy failures default to provided error code', 'email_error' === $default_code_error->get_error_code() );
+$assert( 'legacy failures keep error message', 'Human readable failure.' === $default_code_error->get_error_message() );
+
 if ( $failed > 0 ) {
 	echo "=== ability-result-wp-error-smoke: {$failed} FAIL of {$total} ===\n";
 	exit( 1 );


### PR DESCRIPTION
## Summary
- Defines the central 1.0 boundary helpers in `AbilityResult` for legacy arrays, `WP_Error`, tool execution results, and REST error conversion.
- Routes tool execution, chat REST, and email REST legacy normalization through those helpers without broad API churn.
- Extends the existing ability result smoke test to cover `WP_Error`, array passthrough, scalar tool results, and legacy failure conversion.

Fixes #2225.

## Verification
- `php tests/ability-result-wp-error-smoke.php`
- `php -l inc/Core/AbilityResult.php`
- `php -l inc/Engine/AI/Tools/Execution/ToolExecutionCore.php`
- `php -l inc/Api/Chat/Chat.php`
- `php -l inc/Api/Email.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-collapse-legacy-result-contracts --extension wordpress --force-hot`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-collapse-legacy-result-contracts --extension wordpress --changed-only --errors-only --force-hot`

## Verification notes
- Full repo `homeboy lint --path /Users/chubes/Developer/data-machine@fix-collapse-legacy-result-contracts --extension wordpress --force-hot` still reports pre-existing JavaScript/admin lint findings outside these PHP changes, so the passing lint command is scoped to changed files.
- The first DMC worktree bootstrap path crashed after creating the worktree with Studio PHP runtime `ErrnoError { errno: 33 }`; the worktree existed and subsequent work completed in the DMC-managed checkout.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused result-normalization cleanup, expanded smoke coverage, ran verification, and drafted this PR description for Chris to review.