### PR TITLE
fix: add drain timeout margin

### DIFF
--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -399,10 +399,11 @@ wp datamachine drain
 
 # Bound work for cron/supervisors
 wp datamachine drain --limit=500 --batch-size=25 --time-limit=300
+wp datamachine drain --time-limit=600 --stop-before-timeout=30 --format=json
 wp datamachine drain --limit=500 --time-limit=300 --format=json
 ```
 
-**Options**: `--limit`, `--batch-size`, `--time-limit`, `--format=table|json`
+**Options**: `--limit`, `--batch-size`, `--time-limit`, `--stop-before-timeout`, `--job-id`, `--format=table|json`
 
 ### datamachine cycle / cycles
 

--- a/inc/Cli/Commands/DrainCommand.php
+++ b/inc/Cli/Commands/DrainCommand.php
@@ -46,6 +46,14 @@ class DrainCommand extends BaseCommand {
 	 * default: 0
 	 * ---
 	 *
+	 * [--stop-before-timeout=<seconds>]
+	 * : Stop this many seconds before the wall-clock limit so the drain exits
+	 * cleanly before an external supervisor timeout. Only applies when
+	 * --time-limit is greater than 0.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
 	 * [--job-id=<ids>]
 	 * : Optional comma-separated Data Machine job IDs to drain. Useful when
 	 * unrelated due work is blocked ahead of a known cleanup or retry run.
@@ -72,10 +80,11 @@ class DrainCommand extends BaseCommand {
 
 		$stats = self::drain(
 			array(
-				'limit'      => isset( $assoc_args['limit'] ) ? (int) $assoc_args['limit'] : 0,
-				'batch_size' => isset( $assoc_args['batch-size'] ) ? (int) $assoc_args['batch-size'] : 25,
-				'time_limit' => isset( $assoc_args['time-limit'] ) ? (int) $assoc_args['time-limit'] : 0,
-				'job_ids'    => isset( $assoc_args['job-id'] ) ? (string) $assoc_args['job-id'] : '',
+				'limit'               => isset( $assoc_args['limit'] ) ? (int) $assoc_args['limit'] : 0,
+				'batch_size'          => isset( $assoc_args['batch-size'] ) ? (int) $assoc_args['batch-size'] : 25,
+				'time_limit'          => isset( $assoc_args['time-limit'] ) ? (int) $assoc_args['time-limit'] : 0,
+				'stop_before_timeout' => isset( $assoc_args['stop-before-timeout'] ) ? (int) $assoc_args['stop-before-timeout'] : 0,
+				'job_ids'             => isset( $assoc_args['job-id'] ) ? (string) $assoc_args['job-id'] : '',
 			)
 		);
 
@@ -94,28 +103,37 @@ class DrainCommand extends BaseCommand {
 	 * so this drain runs concrete due action IDs from that same group instead of
 	 * a hand-maintained hook allow-list.
 	 *
-	 * @param array{limit?:int,batch_size?:int,time_limit?:int,hooks?:string[],job_ids?:string|int[]} $options Drain options.
+	 * @param array{limit?:int,batch_size?:int,time_limit?:int,stop_before_timeout?:int,hooks?:string[],job_ids?:string|int[]} $options Drain options.
 	 * @return array<string,int|string> Drain stats.
 	 */
 	public static function drain( array $options = array() ): array {
-		$limit      = max( 0, (int) ( $options['limit'] ?? 0 ) );
-		$batch_size = max( 1, (int) ( $options['batch_size'] ?? 25 ) );
-		$time_limit = max( 0, (int) ( $options['time_limit'] ?? 0 ) );
-		$hooks      = self::normalizeHooks( $options['hooks'] ?? null );
-		$job_ids    = self::normalizeJobIds( $options['job_ids'] ?? null );
+		$limit               = max( 0, (int) ( $options['limit'] ?? 0 ) );
+		$batch_size          = max( 1, (int) ( $options['batch_size'] ?? 25 ) );
+		$time_limit          = max( 0, (int) ( $options['time_limit'] ?? 0 ) );
+		$stop_before_timeout = max( 0, (int) ( $options['stop_before_timeout'] ?? 0 ) );
+		$hooks               = self::normalizeHooks( $options['hooks'] ?? null );
+		$job_ids             = self::normalizeJobIds( $options['job_ids'] ?? null );
 
 		$started_at    = time();
 		$before_counts = self::getStatusCounts( $hooks, $job_ids );
 		$batches       = 0;
 		$warnings      = 0;
+		$stop_reason   = 'empty';
 
 		while ( self::getDuePendingCount( $hooks, $job_ids ) > 0 ) {
-			$stats = self::buildStats( $before_counts, self::getStatusCounts( $hooks, $job_ids ), $batches, $warnings, $hooks, $job_ids );
+			$stats = self::buildStats( $before_counts, self::getStatusCounts( $hooks, $job_ids ), $batches, $warnings, $hooks, $job_ids, $stop_reason );
 			if ( $limit > 0 && (int) $stats['actions_processed'] >= $limit ) {
+				$stop_reason = 'limit';
 				break;
 			}
 
 			if ( $time_limit > 0 && ( time() - $started_at ) >= $time_limit ) {
+				$stop_reason = 'time_limit';
+				break;
+			}
+
+			if ( $time_limit > 0 && ( $time_limit - ( time() - $started_at ) ) <= $stop_before_timeout ) {
+				$stop_reason = 'timeout_margin';
 				break;
 			}
 
@@ -124,11 +142,13 @@ class DrainCommand extends BaseCommand {
 				$current_batch_size = min( $batch_size, $limit - (int) $stats['actions_processed'] );
 			}
 			if ( $current_batch_size <= 0 ) {
+				$stop_reason = 'limit';
 				break;
 			}
 
 			$action_ids = self::getDuePendingActionIds( $current_batch_size, $hooks, $job_ids );
 			if ( empty( $action_ids ) ) {
+				$stop_reason = 'empty';
 				break;
 			}
 
@@ -141,6 +161,7 @@ class DrainCommand extends BaseCommand {
 				++$warnings;
 				$message = trim( (string) ( $result->stderr ?? '' ) );
 				WP_CLI::warning( '' === $message ? 'Action Scheduler CLI drain failed.' : $message );
+				$stop_reason = 'warning';
 				break;
 			}
 
@@ -149,11 +170,12 @@ class DrainCommand extends BaseCommand {
 			if ( 0 === $progress && self::getDuePendingCount( $hooks, $job_ids ) >= $due_before ) {
 				++$warnings;
 				WP_CLI::warning( 'Drain stopped because Action Scheduler made no observable progress.' );
+				$stop_reason = 'no_progress';
 				break;
 			}
 		}
 
-		return self::buildStats( $before_counts, self::getStatusCounts( $hooks, $job_ids ), $batches, $warnings, $hooks, $job_ids );
+		return self::buildStats( $before_counts, self::getStatusCounts( $hooks, $job_ids ), $batches, $warnings, $hooks, $job_ids, $stop_reason );
 	}
 
 	/**
@@ -213,7 +235,7 @@ class DrainCommand extends BaseCommand {
 	 * @param int                             $warnings      Warning count.
 	 * @return array<string,int|string> Stats.
 	 */
-	private static function buildStats( array $before_counts, array $after_counts, int $batches, int $warnings, ?array $hooks = null, array $job_ids = array() ): array {
+	private static function buildStats( array $before_counts, array $after_counts, int $batches, int $warnings, ?array $hooks = null, array $job_ids = array(), string $stop_reason = 'empty' ): array {
 		$batch_completed   = self::delta( $before_counts, $after_counts, self::HOOK_BATCH_CHUNK, 'complete' );
 		$batch_failed      = self::delta( $before_counts, $after_counts, self::HOOK_BATCH_CHUNK, 'failed' );
 		$step_completed    = self::delta( $before_counts, $after_counts, self::HOOK_EXECUTE_STEP, 'complete' );
@@ -238,6 +260,7 @@ class DrainCommand extends BaseCommand {
 			'remaining_pending'          => self::getDuePendingCount( $hooks, $job_ids ),
 			'total_pending'              => self::getPendingCount( $hooks, $job_ids ),
 			'warnings'                   => $warnings,
+			'stop_reason'                => $stop_reason,
 			'hooks'                      => implode( ',', self::processedHooks( $before_counts, $after_counts ) ),
 			'job_ids'                    => implode( ',', $job_ids ),
 		);

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -40,6 +40,8 @@ assert_drain_contains( "WP_CLI::add_command( 'datamachine drain'", $boot_src, 'f
 assert_drain_contains( "datamachine_pipeline_batch_chunk'", $drain_src, 'drain includes pipeline batch chunk hook' );
 assert_drain_contains( "datamachine_execute_step'", $drain_src, 'drain includes execute step hook' );
 assert_drain_contains( '[--job-id=<ids>]', $drain_src, 'drain documents optional job-id scope' );
+assert_drain_contains( '[--stop-before-timeout=<seconds>]', $drain_src, 'drain documents optional timeout safety margin' );
+assert_drain_contains( "'stop_before_timeout'", $drain_src, 'drain accepts worker-style timeout safety margin option' );
 assert_drain_contains( 'normalizeJobIds', $drain_src, 'drain normalizes optional job-id scope' );
 assert_drain_contains( 'hookWhereSql( $hooks, $job_ids )', $drain_src, 'drain supports optional hook and job-id scopes' );
 assert_drain_contains( 'a.args LIKE %s', $drain_src, 'drain can filter pending actions by serialized job_id args' );
@@ -56,6 +58,8 @@ assert_drain_contains( "'step_executions'", $drain_src, 'drain reports step exec
 assert_drain_contains( "'other_actions'", $drain_src, 'drain reports non-pipeline action counts' );
 assert_drain_contains( "'completions'", $drain_src, 'drain reports completions' );
 assert_drain_contains( "'failures'", $drain_src, 'drain reports failures' );
+assert_drain_contains( "'stop_reason'", $drain_src, 'drain reports why it stopped' );
+assert_drain_contains( "'timeout_margin'", $drain_src, 'drain reports timeout margin stops' );
 
 $run_flow_start = strpos( $src, 'private function runFlow' );
 assert_true( false !== $run_flow_start, 'runFlow method found' );


### PR DESCRIPTION
## Summary
- Adds `--stop-before-timeout` to `wp datamachine drain` so local drains can exit before an external timeout kills the process.
- Reports `stop_reason` from drain runs, including `timeout_margin`, so JSON/table output explains why the drain stopped.
- Updates WP-CLI docs and smoke coverage for the new option.

## Verification
- `php -l inc/Cli/Commands/DrainCommand.php`
- `php tests/flow-run-cli-drain-smoke.php`

## Linked issues
- Fixes Extra-Chill/data-machine-code#445

## Notes
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-drain-stop-before-timeout --extension wordpress` could not run because the local Homeboy extension registry does not have the `wordpress` extension linked, even though this component declares it.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the CLI gap, drafting the implementation, updating smoke coverage/docs, and running local verification. Chris remains responsible for review and merge.