### PR TITLE
Adopt Agents API package lifecycle primitives

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=8.2",
-		"automattic/agents-api": "dev-package-lifecycle-foundation",
+		"automattic/agents-api": "dev-main",
 		"woocommerce/action-scheduler": "^3.9",
 		"chubes4/block-format-bridge": "^0.6"
 	},

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=8.2",
-		"automattic/agents-api": "dev-main",
+		"automattic/agents-api": "dev-package-lifecycle-foundation",
 		"woocommerce/action-scheduler": "^3.9",
 		"chubes4/block-format-bridge": "^0.6"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48086caf56f4689948901abdd2a991e1",
+    "content-hash": "e80f9cf6aeff4f17da2aedf7eba19ac2",
     "packages": [
         {
             "name": "automattic/agents-api",
-            "version": "dev-main",
+            "version": "dev-package-lifecycle-foundation",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "fd4040fad23679c98daddeff8e2b0f600784385c"
+                "reference": "af7aa842071456ca701841360a838ba81df45edc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/fd4040fad23679c98daddeff8e2b0f600784385c",
-                "reference": "fd4040fad23679c98daddeff8e2b0f600784385c",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/af7aa842071456ca701841360a838ba81df45edc",
+                "reference": "af7aa842071456ca701841360a838ba81df45edc",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,6 @@
             "suggest": {
                 "woocommerce/action-scheduler": "Required to actually run cron-triggered workflows. The substrate detects Action Scheduler at runtime and no-ops cleanly when absent; install this package (or any plugin that ships it, like WooCommerce) to enable scheduled workflow runs."
             },
-            "default-branch": true,
             "type": "wordpress-plugin",
             "autoload": {
                 "files": [
@@ -38,6 +37,7 @@
                     "php tests/bootstrap-smoke.php",
                     "php tests/message-envelope-smoke.php",
                     "php tests/registry-smoke.php",
+                    "php tests/package-lifecycle-smoke.php",
                     "php tests/execution-principal-smoke.php",
                     "php tests/effective-agent-resolver-smoke.php",
                     "php tests/caller-context-smoke.php",
@@ -98,7 +98,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-20T13:16:34+00:00"
+            "time": "2026-05-25T15:23:54+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "fd4040fad23679c98daddeff8e2b0f600784385c"
+                "reference": "53843c7467d344d78f3a1a3c89714f399e3e0674"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/fd4040fad23679c98daddeff8e2b0f600784385c",
-                "reference": "fd4040fad23679c98daddeff8e2b0f600784385c",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/53843c7467d344d78f3a1a3c89714f399e3e0674",
+                "reference": "53843c7467d344d78f3a1a3c89714f399e3e0674",
                 "shasum": ""
             },
             "require": {
@@ -38,6 +38,7 @@
                     "php tests/bootstrap-smoke.php",
                     "php tests/message-envelope-smoke.php",
                     "php tests/registry-smoke.php",
+                    "php tests/package-lifecycle-smoke.php",
                     "php tests/execution-principal-smoke.php",
                     "php tests/effective-agent-resolver-smoke.php",
                     "php tests/caller-context-smoke.php",
@@ -98,7 +99,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-20T13:16:34+00:00"
+            "time": "2026-05-25T15:51:14+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e80f9cf6aeff4f17da2aedf7eba19ac2",
+    "content-hash": "48086caf56f4689948901abdd2a991e1",
     "packages": [
         {
             "name": "automattic/agents-api",
-            "version": "dev-package-lifecycle-foundation",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "af7aa842071456ca701841360a838ba81df45edc"
+                "reference": "fd4040fad23679c98daddeff8e2b0f600784385c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/af7aa842071456ca701841360a838ba81df45edc",
-                "reference": "af7aa842071456ca701841360a838ba81df45edc",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/fd4040fad23679c98daddeff8e2b0f600784385c",
+                "reference": "fd4040fad23679c98daddeff8e2b0f600784385c",
                 "shasum": ""
             },
             "require": {
@@ -26,6 +26,7 @@
             "suggest": {
                 "woocommerce/action-scheduler": "Required to actually run cron-triggered workflows. The substrate detects Action Scheduler at runtime and no-ops cleanly when absent; install this package (or any plugin that ships it, like WooCommerce) to enable scheduled workflow runs."
             },
+            "default-branch": true,
             "type": "wordpress-plugin",
             "autoload": {
                 "files": [
@@ -37,7 +38,6 @@
                     "php tests/bootstrap-smoke.php",
                     "php tests/message-envelope-smoke.php",
                     "php tests/registry-smoke.php",
-                    "php tests/package-lifecycle-smoke.php",
                     "php tests/execution-principal-smoke.php",
                     "php tests/effective-agent-resolver-smoke.php",
                     "php tests/caller-context-smoke.php",
@@ -98,7 +98,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-25T15:23:54+00:00"
+            "time": "2026-05-20T13:16:34+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",

--- a/inc/Engine/Bundle/AgentBundleArtifactHasher.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactHasher.php
@@ -21,22 +21,6 @@ final class AgentBundleArtifactHasher {
 	 * @return string SHA-256 hash.
 	 */
 	public static function hash( mixed $artifact ): string {
-		if ( class_exists( '\WP_Agent_Package_Artifact_Hasher' ) ) {
-			return \WP_Agent_Package_Artifact_Hasher::hash( $artifact );
-		}
-
-		if ( is_string( $artifact ) ) {
-			$normalized = $artifact;
-		} elseif ( is_array( $artifact ) ) {
-			$normalized = BundleSchema::encode_json( $artifact );
-		} else {
-			$encoded = wp_json_encode( $artifact, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-			if ( ! is_string( $encoded ) ) {
-				throw new BundleValidationException( 'Unable to encode bundle artifact for hashing.' );
-			}
-			$normalized = $encoded;
-		}
-
-		return hash( 'sha256', $normalized );
+		return \WP_Agent_Package_Artifact_Hasher::hash( $artifact );
 	}
 }

--- a/inc/Engine/Bundle/AgentBundleArtifactHasher.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactHasher.php
@@ -21,6 +21,10 @@ final class AgentBundleArtifactHasher {
 	 * @return string SHA-256 hash.
 	 */
 	public static function hash( mixed $artifact ): string {
+		if ( class_exists( '\WP_Agent_Package_Artifact_Hasher' ) ) {
+			return \WP_Agent_Package_Artifact_Hasher::hash( $artifact );
+		}
+
 		if ( is_string( $artifact ) ) {
 			$normalized = $artifact;
 		} elseif ( is_array( $artifact ) ) {

--- a/inc/Engine/Bundle/AgentBundleArtifactStatus.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactStatus.php
@@ -14,10 +14,10 @@ defined( 'ABSPATH' ) || exit;
  */
 final class AgentBundleArtifactStatus {
 
-	public const CLEAN    = 'clean';
-	public const MODIFIED = 'modified';
-	public const MISSING  = 'missing';
-	public const ORPHANED = 'orphaned';
+	public const CLEAN    = \WP_Agent_Package_Artifact_Status::CLEAN;
+	public const MODIFIED = \WP_Agent_Package_Artifact_Status::MODIFIED;
+	public const MISSING  = \WP_Agent_Package_Artifact_Status::MISSING;
+	public const ORPHANED = \WP_Agent_Package_Artifact_Status::ORPHANED;
 
 	/**
 	 * Classify an artifact by installed and current hash presence.
@@ -27,26 +27,6 @@ final class AgentBundleArtifactStatus {
 	 * @return string One of clean, modified, missing, orphaned.
 	 */
 	public static function classify( ?string $installed_hash, ?string $current_hash ): string {
-		if ( class_exists( '\WP_Agent_Package_Artifact_Status' ) ) {
-			return \WP_Agent_Package_Artifact_Status::classify( $installed_hash, $current_hash );
-		}
-
-		$installed_hash = self::normalize_hash( $installed_hash );
-		$current_hash   = self::normalize_hash( $current_hash );
-
-		if ( null === $installed_hash && null !== $current_hash ) {
-			return self::ORPHANED;
-		}
-
-		if ( null === $installed_hash || null === $current_hash ) {
-			return self::MISSING;
-		}
-
-		return hash_equals( $installed_hash, $current_hash ) ? self::CLEAN : self::MODIFIED;
-	}
-
-	private static function normalize_hash( ?string $hash ): ?string {
-		$hash = null === $hash ? '' : trim( $hash );
-		return '' === $hash ? null : $hash;
+		return \WP_Agent_Package_Artifact_Status::classify( $installed_hash, $current_hash );
 	}
 }

--- a/inc/Engine/Bundle/AgentBundleArtifactStatus.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactStatus.php
@@ -27,6 +27,10 @@ final class AgentBundleArtifactStatus {
 	 * @return string One of clean, modified, missing, orphaned.
 	 */
 	public static function classify( ?string $installed_hash, ?string $current_hash ): string {
+		if ( class_exists( '\WP_Agent_Package_Artifact_Status' ) ) {
+			return \WP_Agent_Package_Artifact_Status::classify( $installed_hash, $current_hash );
+		}
+
 		$installed_hash = self::normalize_hash( $installed_hash );
 		$current_hash   = self::normalize_hash( $current_hash );
 

--- a/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
+++ b/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
@@ -25,7 +25,7 @@ final class AgentBundleInstalledArtifact {
 	private string $status;
 	private string $installed_at;
 	private string $updated_at;
-	private ?\WP_Agent_Package_Installed_Artifact $package_artifact = null;
+	private \WP_Agent_Package_Installed_Artifact $package_artifact;
 
 	public function __construct(
 		string $bundle_slug,
@@ -155,18 +155,7 @@ final class AgentBundleInstalledArtifact {
 	}
 
 	public function to_array(): array {
-		$row = null !== $this->package_artifact ? self::from_package_artifact_array( $this->package_artifact->to_array() ) : array(
-			'bundle_slug'    => $this->bundle_slug,
-			'bundle_version' => $this->bundle_version,
-			'artifact_type'  => $this->artifact_type,
-			'artifact_id'    => $this->artifact_id,
-			'source_path'    => $this->source_path,
-			'installed_hash' => $this->installed_hash,
-			'current_hash'   => $this->current_hash,
-			'status'         => $this->status,
-			'installed_at'   => $this->installed_at,
-			'updated_at'     => $this->updated_at,
-		);
+		$row = self::from_package_artifact_array( $this->package_artifact->to_array() );
 		if ( null !== $this->installed_payload ) {
 			$row['installed_payload'] = $this->installed_payload;
 		}
@@ -174,9 +163,9 @@ final class AgentBundleInstalledArtifact {
 	}
 
 	/**
-	 * Returns the underlying Agents API package artifact snapshot when available.
+	 * Returns the underlying Agents API package artifact snapshot.
 	 */
-	public function package_artifact(): ?\WP_Agent_Package_Installed_Artifact {
+	public function package_artifact(): \WP_Agent_Package_Installed_Artifact {
 		return $this->package_artifact;
 	}
 
@@ -215,11 +204,7 @@ final class AgentBundleInstalledArtifact {
 		return $path;
 	}
 
-	private static function build_package_artifact( string $bundle_slug, string $bundle_version, string $artifact_type, string $artifact_id, string $source_path, ?string $installed_hash, ?string $current_hash, string $installed_at, string $updated_at, mixed $installed_payload ): ?\WP_Agent_Package_Installed_Artifact {
-		if ( ! class_exists( '\WP_Agent_Package_Installed_Artifact' ) ) {
-			return null;
-		}
-
+	private static function build_package_artifact( string $bundle_slug, string $bundle_version, string $artifact_type, string $artifact_id, string $source_path, ?string $installed_hash, ?string $current_hash, string $installed_at, string $updated_at, mixed $installed_payload ): \WP_Agent_Package_Installed_Artifact {
 		return new \WP_Agent_Package_Installed_Artifact(
 			array(
 				'package_slug'      => $bundle_slug,

--- a/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
+++ b/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
@@ -25,6 +25,7 @@ final class AgentBundleInstalledArtifact {
 	private string $status;
 	private string $installed_at;
 	private string $updated_at;
+	private ?\WP_Agent_Package_Installed_Artifact $package_artifact = null;
 
 	public function __construct(
 		string $bundle_slug,
@@ -49,6 +50,18 @@ final class AgentBundleInstalledArtifact {
 		$this->status            = AgentBundleArtifactStatus::classify( $this->installed_hash, $this->current_hash );
 		$this->installed_at      = self::non_empty_string( $installed_at, 'installed_at' );
 		$this->updated_at        = self::non_empty_string( $updated_at, 'updated_at' );
+		$this->package_artifact  = self::build_package_artifact(
+			$this->bundle_slug,
+			$this->bundle_version,
+			$this->artifact_type,
+			$this->artifact_id,
+			$this->source_path,
+			$this->installed_hash,
+			$this->current_hash,
+			$this->installed_at,
+			$this->updated_at,
+			$this->installed_payload
+		);
 	}
 
 	/**
@@ -142,7 +155,7 @@ final class AgentBundleInstalledArtifact {
 	}
 
 	public function to_array(): array {
-		$row = array(
+		$row = null !== $this->package_artifact ? self::from_package_artifact_array( $this->package_artifact->to_array() ) : array(
 			'bundle_slug'    => $this->bundle_slug,
 			'bundle_version' => $this->bundle_version,
 			'artifact_type'  => $this->artifact_type,
@@ -158,6 +171,13 @@ final class AgentBundleInstalledArtifact {
 			$row['installed_payload'] = $this->installed_payload;
 		}
 		return $row;
+	}
+
+	/**
+	 * Returns the underlying Agents API package artifact snapshot when available.
+	 */
+	public function package_artifact(): ?\WP_Agent_Package_Installed_Artifact {
+		return $this->package_artifact;
 	}
 
 	private static function validate_artifact_type( string $type ): string {
@@ -193,5 +213,61 @@ final class AgentBundleInstalledArtifact {
 		}
 
 		return $path;
+	}
+
+	private static function build_package_artifact( string $bundle_slug, string $bundle_version, string $artifact_type, string $artifact_id, string $source_path, ?string $installed_hash, ?string $current_hash, string $installed_at, string $updated_at, mixed $installed_payload ): ?\WP_Agent_Package_Installed_Artifact {
+		if ( ! class_exists( '\WP_Agent_Package_Installed_Artifact' ) ) {
+			return null;
+		}
+
+		return new \WP_Agent_Package_Installed_Artifact(
+			array(
+				'package_slug'      => $bundle_slug,
+				'package_version'   => $bundle_version,
+				'artifact_type'     => self::package_artifact_type( $artifact_type ),
+				'artifact_id'       => $artifact_id,
+				'source'            => $source_path,
+				'installed_hash'    => $installed_hash,
+				'current_hash'      => $current_hash,
+				'installed_payload' => $installed_payload,
+				'installed_at'      => $installed_at,
+				'updated_at'        => $updated_at,
+			)
+		);
+	}
+
+	/** @param array<string,mixed> $package_row */
+	private static function from_package_artifact_array( array $package_row ): array {
+		$row = array(
+			'bundle_slug'    => (string) $package_row['package_slug'],
+			'bundle_version' => (string) $package_row['package_version'],
+			'artifact_type'  => self::bundle_artifact_type( (string) $package_row['artifact_type'] ),
+			'artifact_id'    => (string) $package_row['artifact_id'],
+			'source_path'    => (string) $package_row['source'],
+			'installed_hash' => $package_row['installed_hash'] ?? null,
+			'current_hash'   => $package_row['current_hash'] ?? null,
+			'status'         => (string) $package_row['status'],
+			'installed_at'   => (string) $package_row['installed_at'],
+			'updated_at'     => (string) $package_row['updated_at'],
+		);
+
+		if ( array_key_exists( 'installed_payload', $package_row ) ) {
+			$row['installed_payload'] = $package_row['installed_payload'];
+		}
+
+		return $row;
+	}
+
+	private static function package_artifact_type( string $type ): string {
+		if ( str_contains( $type, '/' ) ) {
+			return $type;
+		}
+
+		return 'datamachine/' . str_replace( '_', '-', $type );
+	}
+
+	private static function bundle_artifact_type( string $type ): string {
+		$type = str_starts_with( $type, 'datamachine/' ) ? substr( $type, strlen( 'datamachine/' ) ) : $type;
+		return str_replace( '-', '_', $type );
 	}
 }

--- a/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
@@ -26,6 +26,17 @@ final class AgentBundleUpgradePlanner {
 	 * @param array<string,mixed>                                         $metadata Optional plan metadata.
 	 */
 	public static function plan( array $installed_artifacts, array $current_artifacts, array $target_artifacts, array $metadata = array() ): AgentBundleUpgradePlan {
+		if ( class_exists( '\WP_Agent_Package_Update_Planner' ) ) {
+			$plan = \WP_Agent_Package_Update_Planner::plan(
+				self::package_artifacts( $installed_artifacts ),
+				self::package_artifacts( $current_artifacts ),
+				self::package_artifacts( $target_artifacts ),
+				$metadata
+			);
+
+			return new AgentBundleUpgradePlan( self::bundle_buckets_from_package_plan( $plan ), $metadata );
+		}
+
 		$installed = self::index_installed_artifacts( $installed_artifacts );
 		$current   = self::index_artifacts( $current_artifacts );
 		$target    = self::index_artifacts( $target_artifacts );
@@ -164,6 +175,84 @@ final class AgentBundleUpgradePlanner {
 		}
 
 		return self::artifact_id_from_relative_path( $relative_path );
+	}
+
+	/**
+	 * Convert Data Machine artifact rows to Agents API package artifact rows.
+	 *
+	 * @param array<int,array<string,mixed>|AgentBundleInstalledArtifact> $artifacts Bundle artifacts.
+	 * @return array<int,array<string,mixed>> Package artifacts.
+	 */
+	private static function package_artifacts( array $artifacts ): array {
+		$converted = array();
+		foreach ( $artifacts as $artifact ) {
+			$row = $artifact instanceof AgentBundleInstalledArtifact ? $artifact->to_array() : $artifact;
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$artifact_type = (string) ( $row['artifact_type'] ?? '' );
+			$artifact_id   = (string) ( $row['artifact_id'] ?? '' );
+			if ( '' === $artifact_type || '' === $artifact_id ) {
+				continue;
+			}
+
+			$converted[] = array_merge(
+				$row,
+				array(
+					'artifact_type' => self::package_artifact_type( $artifact_type ),
+					'artifact_id'   => $artifact_id,
+					'source'        => (string) ( $row['source_path'] ?? ( $row['source'] ?? '' ) ),
+				)
+			);
+		}
+
+		return $converted;
+	}
+
+	private static function package_artifact_type( string $type ): string {
+		if ( str_contains( $type, '/' ) ) {
+			return $type;
+		}
+
+		return 'datamachine/' . str_replace( '_', '-', $type );
+	}
+
+	private static function bundle_artifact_type( string $type ): string {
+		$type = str_starts_with( $type, 'datamachine/' ) ? substr( $type, strlen( 'datamachine/' ) ) : $type;
+
+		return str_replace( '-', '_', $type );
+	}
+
+	private static function bundle_buckets_from_package_plan( \WP_Agent_Package_Update_Plan $plan ): array {
+		$buckets = array();
+		foreach ( $plan->get_buckets() as $bucket => $entries ) {
+			$buckets[ $bucket ] = array_map( array( self::class, 'bundle_entry_from_package_entry' ), $entries );
+		}
+
+		return $buckets;
+	}
+
+	/** @param array<string,mixed> $entry */
+	private static function bundle_entry_from_package_entry( array $entry ): array {
+		$artifact_type = self::bundle_artifact_type( (string) ( $entry['artifact_type'] ?? '' ) );
+		$artifact_id   = (string) ( $entry['artifact_id'] ?? '' );
+		$reason        = (string) ( $entry['reason'] ?? '' );
+
+		$converted = array_merge(
+			$entry,
+			array(
+				'artifact_key'  => AgentBundleArtifactExtensions::artifact_key( $artifact_type, $artifact_id ),
+				'artifact_type' => $artifact_type,
+				'artifact_id'   => $artifact_id,
+				'source_path'   => (string) ( $entry['source'] ?? ( $entry['source_path'] ?? '' ) ),
+				'summary'       => sprintf( '%s %s: %s', $artifact_type, $artifact_id, str_replace( '_', ' ', $reason ) ),
+			)
+		);
+
+		unset( $converted['source'] );
+
+		return $converted;
 	}
 
 	/** @param array<int,array<string,mixed>|AgentBundleInstalledArtifact> $artifacts */

--- a/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
@@ -26,74 +26,14 @@ final class AgentBundleUpgradePlanner {
 	 * @param array<string,mixed>                                         $metadata Optional plan metadata.
 	 */
 	public static function plan( array $installed_artifacts, array $current_artifacts, array $target_artifacts, array $metadata = array() ): AgentBundleUpgradePlan {
-		if ( class_exists( '\WP_Agent_Package_Update_Planner' ) ) {
-			$plan = \WP_Agent_Package_Update_Planner::plan(
-				self::package_artifacts( $installed_artifacts ),
-				self::package_artifacts( $current_artifacts ),
-				self::package_artifacts( $target_artifacts ),
-				$metadata
-			);
-
-			return new AgentBundleUpgradePlan( self::bundle_buckets_from_package_plan( $plan ), $metadata );
-		}
-
-		$installed = self::index_installed_artifacts( $installed_artifacts );
-		$current   = self::index_artifacts( $current_artifacts );
-		$target    = self::index_artifacts( $target_artifacts );
-		$buckets   = array(
-			'auto_apply'     => array(),
-			'needs_approval' => array(),
-			'warnings'       => array(),
-			'no_op'          => array(),
+		$plan = \WP_Agent_Package_Update_Planner::plan(
+			self::package_artifacts( $installed_artifacts ),
+			self::package_artifacts( $current_artifacts ),
+			self::package_artifacts( $target_artifacts ),
+			$metadata
 		);
 
-		foreach ( $target as $key => $target_artifact ) {
-			$current_artifact   = $current[ $key ] ?? null;
-			$installed_artifact = $installed[ $key ] ?? null;
-			$current_hash       = self::artifact_hash( $current_artifact );
-			$target_hash        = self::artifact_hash( $target_artifact );
-			$installed_hash     = isset( $installed_artifact['installed_hash'] ) ? (string) $installed_artifact['installed_hash'] : null;
-
-			if ( null !== $current_hash && hash_equals( $target_hash, $current_hash ) ) {
-				$buckets['no_op'][] = self::entry( $key, $target_artifact, $installed_hash, $current_hash, $target_hash, 'already_matches_target', $current_artifact );
-				continue;
-			}
-
-			if ( null === $current_hash && null !== $installed_hash ) {
-				$buckets['warnings'][] = self::entry( $key, $target_artifact, $installed_hash, null, $target_hash, 'missing_local_artifact', $current_artifact );
-				continue;
-			}
-
-			if ( null === $installed_hash ) {
-				$bucket               = null === $current_hash ? 'auto_apply' : 'needs_approval';
-				$reason               = null === $current_hash ? 'new_artifact' : 'untracked_local_artifact';
-				$buckets[ $bucket ][] = self::entry( $key, $target_artifact, null, $current_hash, $target_hash, $reason, $current_artifact );
-				continue;
-			}
-
-			if ( null !== $current_hash && hash_equals( $installed_hash, $current_hash ) ) {
-				$buckets['auto_apply'][] = self::entry( $key, $target_artifact, $installed_hash, $current_hash, $target_hash, 'local_unchanged_from_installed', $current_artifact );
-				continue;
-			}
-
-			$buckets['needs_approval'][] = self::entry( $key, $target_artifact, $installed_hash, $current_hash, $target_hash, 'local_modified', $current_artifact );
-		}
-
-		foreach ( $installed as $key => $installed_artifact ) {
-			if ( isset( $target[ $key ] ) ) {
-				continue;
-			}
-			$buckets['warnings'][] = array(
-				'artifact_key'  => $key,
-				'artifact_type' => $installed_artifact['artifact_type'],
-				'artifact_id'   => $installed_artifact['artifact_id'],
-				'source_path'   => $installed_artifact['source_path'],
-				'reason'        => 'orphaned_installed_artifact',
-				'summary'       => sprintf( '%s %s is not present in the target bundle.', $installed_artifact['artifact_type'], $installed_artifact['artifact_id'] ),
-			);
-		}
-
-		return new AgentBundleUpgradePlan( $buckets, $metadata );
+		return new AgentBundleUpgradePlan( self::bundle_buckets_from_package_plan( $plan ), $metadata );
 	}
 
 	/** @return array<int,array<string,mixed>> */
@@ -255,85 +195,4 @@ final class AgentBundleUpgradePlanner {
 		return $converted;
 	}
 
-	/** @param array<int,array<string,mixed>|AgentBundleInstalledArtifact> $artifacts */
-	private static function index_installed_artifacts( array $artifacts ): array {
-		$indexed = array();
-		foreach ( $artifacts as $artifact ) {
-			$row             = $artifact instanceof AgentBundleInstalledArtifact ? $artifact->to_array() : $artifact;
-			$key             = self::artifact_key( (string) ( $row['artifact_type'] ?? '' ), (string) ( $row['artifact_id'] ?? '' ) );
-			$indexed[ $key ] = $row;
-		}
-
-		ksort( $indexed, SORT_STRING );
-		return $indexed;
-	}
-
-	/** @param array<int,array<string,mixed>> $artifacts */
-	private static function index_artifacts( array $artifacts ): array {
-		$indexed = array();
-		foreach ( $artifacts as $artifact ) {
-			$key             = self::artifact_key( (string) ( $artifact['artifact_type'] ?? '' ), (string) ( $artifact['artifact_id'] ?? '' ) );
-			$indexed[ $key ] = $artifact;
-		}
-
-		ksort( $indexed, SORT_STRING );
-		return $indexed;
-	}
-
-	private static function entry( string $key, array $target, ?string $installed_hash, ?string $current_hash, string $target_hash, string $reason, ?array $current ): array {
-		return array(
-			'artifact_key'   => $key,
-			'artifact_type'  => (string) $target['artifact_type'],
-			'artifact_id'    => (string) $target['artifact_id'],
-			'source_path'    => (string) ( $target['source_path'] ?? '' ),
-			'reason'         => $reason,
-			'installed_hash' => $installed_hash,
-			'current_hash'   => $current_hash,
-			'target_hash'    => $target_hash,
-			'summary'        => self::summary( $target, $reason ),
-			'diff'           => array(
-				'before' => self::redact( $current['payload'] ?? null ),
-				'after'  => self::redact( $target['payload'] ?? null ),
-			),
-		);
-	}
-
-	private static function artifact_key( string $type, string $id ): string {
-		return AgentBundleArtifactExtensions::artifact_key( $type, $id );
-	}
-
-	private static function artifact_hash( ?array $artifact ): ?string {
-		if ( null === $artifact ) {
-			return null;
-		}
-		if ( isset( $artifact['hash'] ) && '' !== trim( (string) $artifact['hash'] ) ) {
-			return (string) $artifact['hash'];
-		}
-		if ( ! array_key_exists( 'payload', $artifact ) || null === $artifact['payload'] ) {
-			return null;
-		}
-		return AgentBundleArtifactHasher::hash( $artifact['payload'] );
-	}
-
-	private static function summary( array $artifact, string $reason ): string {
-		return sprintf( '%s %s: %s', (string) $artifact['artifact_type'], (string) $artifact['artifact_id'], str_replace( '_', ' ', $reason ) );
-	}
-
-	private static function redact( mixed $value ): mixed {
-		if ( ! is_array( $value ) ) {
-			return $value;
-		}
-
-		$redacted = array();
-		foreach ( $value as $key => $child ) {
-			$key_string = (string) $key;
-			if ( preg_match( '/(secret|token|password|api[_-]?key|authorization|credential)/i', $key_string ) ) {
-				$redacted[ $key ] = '[redacted]';
-				continue;
-			}
-			$redacted[ $key ] = self::redact( $child );
-		}
-
-		return $redacted;
-	}
 }

--- a/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
@@ -194,5 +194,4 @@ final class AgentBundleUpgradePlanner {
 
 		return $converted;
 	}
-
 }

--- a/tests/agent-bundle-installed-payload-snapshot-smoke.php
+++ b/tests/agent-bundle-installed-payload-snapshot-smoke.php
@@ -38,10 +38,21 @@ if ( ! function_exists( 'esc_html' ) ) {
 		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
 	}
 }
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $title ) {
+		$title = strtolower( trim( (string) $title ) );
+		$title = preg_replace( '/[^a-z0-9_-]+/', '-', $title );
+		return trim( null === $title ? '' : $title, '-' );
+	}
+}
 
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSchema.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleValidationException.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/PortableSlug.php';
+require_once dirname( __DIR__ ) . '/vendor/automattic/agents-api/src/Packages/class-wp-agent-package-artifact.php';
+require_once dirname( __DIR__ ) . '/vendor/automattic/agents-api/src/Packages/class-wp-agent-package-artifact-hasher.php';
+require_once dirname( __DIR__ ) . '/vendor/automattic/agents-api/src/Packages/class-wp-agent-package-artifact-status.php';
+require_once dirname( __DIR__ ) . '/vendor/automattic/agents-api/src/Packages/class-wp-agent-package-installed-artifact.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactExtensions.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactHasher.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactStatus.php';

--- a/tests/agent-bundle-upgrade-planner-smoke.php
+++ b/tests/agent-bundle-upgrade-planner-smoke.php
@@ -13,6 +13,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
 	define( 'HOUR_IN_SECONDS', 3600 );
 }
+if ( ! defined( 'DATAMACHINE_PENDING_ACTION_TRANSIENT_FALLBACK' ) ) {
+	define( 'DATAMACHINE_PENDING_ACTION_TRANSIENT_FALLBACK', true );
+}
 
 $GLOBALS['__bundle_upgrade_filters']    = array();
 $GLOBALS['__bundle_upgrade_transients'] = array();


### PR DESCRIPTION
## Summary
- Wires bundle artifact hashing, status classification, installed snapshots, and update planning directly to the generic Agents API package lifecycle primitives.
- Keeps Data Machine bundle-specific artifact types and upgrade plan presentation in Data Machine while using Agents API as the required lifecycle foundation.
- Updates the normal `dev-main` Agents API lock to include the merged lifecycle primitives from Automattic/agents-api#201.

## Related
- Built on merged Automattic/agents-api#201
- Refs #2235

## Tests
- `php tests/agent-bundle-upgrade-planner-smoke.php`
- `php tests/agent-bundle-extension-artifacts-smoke.php`
- `php tests/agent-bundle-installed-payload-snapshot-smoke.php`
- `php tests/datamachine-package-artifacts-smoke.php`
- `composer test`
- `composer lint`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, smoke coverage adjustment, verification commands, and PR description. Chris remains responsible for review and acceptance.