### PR TITLE
fix(chat): preserve multi-mode arrays through ChatOrchestrator

### DIFF
--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -200,6 +200,14 @@ class ChatOrchestrator {
 		}
 
 		// --- Execute AI conversation turn ---
+		// Pass both 'modes' (array of sanitized slugs) and 'mode' (comma-joined
+		// string for logging/analytics). executeConversationTurn prefers the
+		// array form when present — required so multi-mode contexts like
+		// ['cluckin-chuck', 'chat'] survive. Passing only the comma-joined
+		// string would route through sanitize_key() in ToolPolicyResolver::
+		// normalizeModes which strips the comma and produces a single junk
+		// mode like 'cluckin-chuckchat', causing mode-restricted tool
+		// allowlists (frontend chat surface guards) to silently no-op.
 		$result = self::executeConversationTurn(
 			$session_id,
 			$messages,
@@ -209,6 +217,7 @@ class ChatOrchestrator {
 				'single_turn'          => false,
 				'max_turns'            => $max_turns,
 				'selected_pipeline_id' => $selected_pipeline_id ? $selected_pipeline_id : null,
+				'modes'                => $modes,
 				'mode'                 => $mode,
 				'user_id'              => $user_id,
 				'agent_id'             => $agent_id,
@@ -389,6 +398,19 @@ class ChatOrchestrator {
 			return self::sessionLockContentionError();
 		}
 
+		// Recover the original modes array from the stored session.mode column.
+		// Sessions created from a multi-mode request (e.g. ['cluckin-chuck',
+		// 'chat']) persist as the comma-joined string 'cluckin-chuck,chat'.
+		// Pass both forms — the array survives mode-specific tool allowlist
+		// filters (see ToolPolicyResolver::normalizeModes which would otherwise
+		// sanitize_key the comma away into a junk single mode).
+		$stored_mode = (string) ( $session['mode'] ?? ToolPolicyResolver::MODE_CHAT );
+		$modes       = ToolPolicyResolver::normalizeModes(
+			false !== strpos( $stored_mode, ',' )
+				? array_map( 'trim', explode( ',', $stored_mode ) )
+				: $stored_mode
+		);
+
 		$result = self::executeConversationTurn(
 			$session_id,
 			$messages,
@@ -398,7 +420,8 @@ class ChatOrchestrator {
 				'single_turn'          => false,
 				'max_turns'            => $max_turns,
 				'selected_pipeline_id' => $selected_pipeline_id,
-				'mode'                 => (string) ( $session['mode'] ?? ToolPolicyResolver::MODE_CHAT ),
+				'modes'                => $modes,
+				'mode'                 => $stored_mode,
 				'user_id'              => (int) ( $session['user_id'] ?? 0 ),
 				'agent_id'             => (int) ( $session['agent_id'] ?? 0 ),
 				'agent_slug'           => (string) ( $session['agent_slug'] ?? '' ),
@@ -629,7 +652,23 @@ class ChatOrchestrator {
 	 * @return string|WP_Error Session ID on success, WP_Error on failure.
 	 */
 	private static function createSession( int $user_id, string $source = '', int $agent_id = 0, string $mode = ToolPolicyResolver::MODE_CHAT, ?array $transcript_owner = null ): string|WP_Error {
-		$mode = '' !== $mode ? sanitize_key( $mode ) : ToolPolicyResolver::MODE_CHAT;
+		// Comma-joined multi-mode strings ('cluckin-chuck,chat') survive intact
+		// here so processContinue can later parse them back into a modes array.
+		// Single-mode strings still get sanitize_key'd for the usual safety.
+		if ( '' === $mode ) {
+			$mode = ToolPolicyResolver::MODE_CHAT;
+		} elseif ( false !== strpos( $mode, ',' ) ) {
+			$parts = array_filter( array_map(
+				static fn( $part ) => sanitize_key( trim( (string) $part ) ),
+				explode( ',', $mode )
+			) );
+			$mode  = implode( ',', $parts );
+			if ( '' === $mode ) {
+				$mode = ToolPolicyResolver::MODE_CHAT;
+			}
+		} else {
+			$mode = sanitize_key( $mode );
+		}
 
 		if ( $agent_id <= 0 ) {
 			$agent_id = function_exists( 'datamachine_resolve_or_create_agent_id' )


### PR DESCRIPTION
Closes the upstream half of chubes4/cluckin-chuck#12.

## Problem

Multi-mode chat requests get silently collapsed to a single junk mode whenever they flow through `ChatOrchestrator`. For a request like `agent_modes = ['cluckin-chuck', 'chat']`:

1. `processChat` line 71 normalizes the array correctly: `$modes = ['cluckin-chuck', 'chat']`
2. Line 72 joins to comma-string for logging: `$mode = 'cluckin-chuck,chat'`
3. **Line 212 passes only the joined string** (`'mode' => $mode`) to `executeConversationTurn`
4. `executeConversationTurn` line 715: `normalizeModes($options['mode'])` runs `sanitize_key('cluckin-chuck,chat')`
5. `sanitize_key` strips the comma → `'cluckin-chuckchat'` (single junk mode)
6. The original `cluckin-chuck` mode no longer exists in the resolved list

`processContinue` line 388 has the same shape, and `createSession` line 641 `sanitize_key`s the multi-mode string when writing to `session.mode` — so the broken state persists across session resumption.

## Why this matters

Mode-restricted tool allowlist filters (host plugins that hook `datamachine_resolved_tools` to lock down a public chat surface to a specific tool subset) silently no-op when their mode slug doesn't appear in the active mode list. That defeats the entire point of the multi-mode resolution pattern: a downstream that intentionally composes a custom mode + `chat` as the execution surface ends up with the unrestricted `chat` surface.

### Concrete downstream example

[Cluckin' Chuck](https://github.com/chubes4/cluckin-chuck) uses this exact pattern for a public chat agent. The `cluckin-chuck` mode carries the wing-business directive + a tool allowlist filter that strips everything except 13 wing tools. `chat` is required as the execution surface or DM treats the call as pipeline mode and the filter never runs.

With this bug present:
- frontend chat injects `client_context.agent_modes = ['cluckin-chuck', 'chat']`
- DM resolves it to `['cluckin-chuckchat']`
- the allowlist filter exits early because `in_array('cluckin-chuck', $modes, true)` is false
- the agent has visibility into the full ~128 admin chat tools (data-machine-socials publishers, GitHub, Reddit, pipeline management, etc.)
- production transcript shows the agent successfully dispatching `read_instagram` from a public chat session

## Fix

Three small changes inside `ChatOrchestrator`:

1. **`processChat` (line 212):** also pass `'modes' => $modes` (array) alongside the joined `'mode'` string. `executeConversationTurn` line 715 already prefers the array form when present (`!empty($options['modes'])`), so the multi-mode resolution survives without further refactor.
2. **`processContinue` (line 388):** recover the modes array from `session.mode` by splitting on comma instead of trusting `sanitize_key`. Same dual-key pattern (`'modes' + 'mode'`).
3. **`createSession` (line 641):** preserve comma-joined multi-mode strings when writing to `session.mode`. Sanitize each comma-separated part individually so the multi-mode shape survives subsequent `processContinue` calls.

## Verification

End-to-end simulation against the live filter chain in a downstream that depends on this for surface restriction:

```
stored='chat'                → modes=[chat]                   (admin surface — correct)
stored='cluckin-chuck'       → modes=[cluckin-chuck]          (custom — correct)
stored='cluckin-chuck,chat'  → modes=[cluckin-chuck,chat]     (multi — FIXED)
stored='cluckin-chuckchat'   → modes=[cluckin-chuckchat]      (legacy junk, unchanged)
```

The legacy-junk row is unchanged on purpose — sessions created before this fix carry the broken `session.mode` value, and the DB is the source of truth. Operators can patch those out-of-band if needed; downstream Cluckin' Chuck just ran `UPDATE wp_datamachine_chat_sessions SET mode='cluckin-chuck,chat' WHERE session_id=...` for the one affected session.

## Out of scope

A proper fix would persist `agent_modes` as a JSON array column in the session table, so the modes are first-class state instead of being recovered from a comma-string heuristic. That's a schema migration and a bigger PR. This change is the minimum required to close the surface-escape security issue without touching the schema.

## Versioning

Patch bump (no breaking changes to public APIs — `'mode'` is still passed for backward compat, `'modes'` is additive). Handled by your release tooling.