### PR TITLE
fix: bound stuck job recovery memory

### DIFF
--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -118,7 +118,7 @@ class RecoverStuckJobsAbility {
 				$where_clause .= $wpdb->prepare( ' AND flow_id = %d', $flow_id );
 			}
 
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic WHERE clause is prepared above.
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Dynamic WHERE clause is prepared above; limit is an internal constant.
 			$stuck_jobs = $wpdb->get_results(
 				"SELECT job_id, flow_id
 					 FROM {$table}
@@ -126,7 +126,7 @@ class RecoverStuckJobsAbility {
 					 ORDER BY job_id ASC
 					 LIMIT " . self::CANDIDATE_BATCH_SIZE
 			);
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
 
 			if ( empty( $stuck_jobs ) ) {
 				break;
@@ -214,7 +214,7 @@ class RecoverStuckJobsAbility {
 				$timeout_where .= $wpdb->prepare( ' AND flow_id = %d', $flow_id );
 			}
 
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic WHERE clause is prepared above.
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Dynamic WHERE clause is prepared above; limit is an internal constant.
 			$timed_out_jobs = $wpdb->get_results(
 				"SELECT job_id, flow_id
 					 FROM {$table}
@@ -222,7 +222,7 @@ class RecoverStuckJobsAbility {
 					 ORDER BY job_id ASC
 					 LIMIT " . self::CANDIDATE_BATCH_SIZE
 			);
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
 
 			if ( empty( $timed_out_jobs ) ) {
 				break;
@@ -356,13 +356,13 @@ class RecoverStuckJobsAbility {
 		}
 
 		return array(
-			'success'       => true,
-			'recovered'     => $recovered,
-			'skipped'       => $skipped,
-			'timed_out'     => $timed_out,
-			'stale_actions' => $stale_actions,
-			'requeued'      => $requeued,
-			'dry_run'       => $dry_run,
+			'success'        => true,
+			'recovered'      => $recovered,
+			'skipped'        => $skipped,
+			'timed_out'      => $timed_out,
+			'stale_actions'  => $stale_actions,
+			'requeued'       => $requeued,
+			'dry_run'        => $dry_run,
 			'jobs'           => $jobs,
 			'jobs_omitted'   => $jobs_omitted,
 			'jobs_truncated' => $jobs_truncated,
@@ -493,16 +493,16 @@ class RecoverStuckJobsAbility {
 			$query_args[] = $flow_id;
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic placeholder list is prepared below.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Dynamic placeholder list is prepared below.
 		$terminal_jobs = $wpdb->get_results(
 			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- The dynamic SQL contains only generated placeholders; values are supplied in matching order.
+				// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- The dynamic SQL contains only generated placeholders; values are supplied in matching order.
 				$sql,
 				$query_args
 			),
 			ARRAY_A
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( empty( $terminal_jobs ) ) {
 			return array();

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -19,6 +19,9 @@ class RecoverStuckJobsAbility {
 
 	use JobHelpers;
 
+	private const CANDIDATE_BATCH_SIZE = 50;
+	private const JOB_DETAIL_LIMIT     = 100;
+
 	public function __construct() {
 		$this->initDatabases();
 
@@ -98,173 +101,195 @@ class RecoverStuckJobsAbility {
 		$flow_id       = isset( $input['flow_id'] ) && is_numeric( $input['flow_id'] ) ? (int) $input['flow_id'] : null;
 		$timeout_hours = isset( $input['timeout_hours'] ) && is_numeric( $input['timeout_hours'] ) ? max( 1, (int) $input['timeout_hours'] ) : 2;
 
-		$where_clause = "WHERE status = 'processing' AND engine_data LIKE '%\"job_status\"%'";
-		if ( $flow_id ) {
-			$where_clause .= $wpdb->prepare( ' AND flow_id = %d', $flow_id );
-		}
+		$recovered      = 0;
+		$skipped        = 0;
+		$jobs           = array();
+		$jobs_omitted   = 0;
+		$jobs_truncated = false;
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic WHERE clause
-		$stuck_jobs = $wpdb->get_results(
-			"SELECT job_id, flow_id, engine_data
-			 FROM {$table}
-			 {$where_clause}"
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-
-		if ( empty( $stuck_jobs ) ) {
-			$stuck_jobs = array();
-		}
-
-		$recovered = 0;
-		$skipped   = 0;
-		$jobs      = array();
-
-		foreach ( $stuck_jobs as $job ) {
-			$engine_data = json_decode( $job->engine_data, true );
-			$status      = $engine_data['job_status'] ?? null;
-
-			// Truncate to fit varchar(255) column. Full reason is in engine_data.
-			if ( $status && strlen( $status ) > 255 ) {
-				$status = substr( $status, 0, 252 ) . '...';
+		$last_job_id = 0;
+		while ( true ) {
+			$where_clause = $wpdb->prepare(
+				"WHERE status = 'processing' AND job_id > %d AND engine_data LIKE %s",
+				$last_job_id,
+				'%"job_status"%'
+			);
+			if ( $flow_id ) {
+				$where_clause .= $wpdb->prepare( ' AND flow_id = %d', $flow_id );
 			}
 
-			if ( ! $status || ! JobStatus::isStatusFinal( $status ) ) {
-				++$skipped;
-				$jobs[] = array(
-					'job_id'  => (int) $job->job_id,
-					'flow_id' => (int) $job->flow_id,
-					'status'  => 'skipped',
-					'reason'  => sprintf( 'Invalid or non-final status: %s', $status ?? 'null' ),
-				);
-				continue;
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic WHERE clause is prepared above.
+			$stuck_jobs = $wpdb->get_results(
+				"SELECT job_id, flow_id
+					 FROM {$table}
+					 {$where_clause}
+					 ORDER BY job_id ASC
+					 LIMIT " . self::CANDIDATE_BATCH_SIZE
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+			if ( empty( $stuck_jobs ) ) {
+				break;
 			}
 
-			if ( $dry_run ) {
-				++$recovered;
-				$jobs[] = array(
-					'job_id'        => (int) $job->job_id,
-					'flow_id'       => (int) $job->flow_id,
-					'status'        => 'would_recover',
-					'target_status' => $status,
-				);
-			} else {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-				$result = $wpdb->update(
-					$table,
-					array(
-						'status'       => $status,
-						'completed_at' => current_time( 'mysql', true ),
-					),
-					array( 'job_id' => $job->job_id ),
-					array( '%s', '%s' ),
-					array( '%d' )
-				);
+			foreach ( $stuck_jobs as $job ) {
+				$last_job_id = max( $last_job_id, (int) $job->job_id );
+				$engine_data = $this->getJobEngineData( (int) $job->job_id );
+				$status      = $engine_data['job_status'] ?? null;
 
-				if ( false !== $result ) {
-					++$recovered;
-					$jobs[] = array(
-						'job_id'        => (int) $job->job_id,
-						'flow_id'       => (int) $job->flow_id,
-						'status'        => 'recovered',
-						'target_status' => $status,
-					);
+				// Truncate to fit varchar(255) column. Full reason is in engine_data.
+				if ( $status && strlen( $status ) > 255 ) {
+					$status = substr( $status, 0, 252 ) . '...';
+				}
 
-					do_action( 'datamachine_job_complete', $job->job_id, $status );
-				} else {
+				if ( ! $status || ! JobStatus::isStatusFinal( $status ) ) {
 					++$skipped;
-					$jobs[] = array(
+					$this->appendJobDetail( $jobs, $jobs_omitted, array(
 						'job_id'  => (int) $job->job_id,
 						'flow_id' => (int) $job->flow_id,
 						'status'  => 'skipped',
-						'reason'  => 'Database update failed',
+						'reason'  => sprintf( 'Invalid or non-final status: %s', $status ?? 'null' ),
+					) );
+					continue;
+				}
+
+				if ( $dry_run ) {
+					++$recovered;
+					$this->appendJobDetail( $jobs, $jobs_omitted, array(
+						'job_id'        => (int) $job->job_id,
+						'flow_id'       => (int) $job->flow_id,
+						'status'        => 'would_recover',
+						'target_status' => $status,
+					) );
+				} else {
+					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+					$result = $wpdb->update(
+						$table,
+						array(
+							'status'       => $status,
+							'completed_at' => current_time( 'mysql', true ),
+						),
+						array( 'job_id' => $job->job_id ),
+						array( '%s', '%s' ),
+						array( '%d' )
 					);
+
+					if ( false !== $result ) {
+						++$recovered;
+						$this->appendJobDetail( $jobs, $jobs_omitted, array(
+							'job_id'        => (int) $job->job_id,
+							'flow_id'       => (int) $job->flow_id,
+							'status'        => 'recovered',
+							'target_status' => $status,
+						) );
+
+						do_action( 'datamachine_job_complete', $job->job_id, $status );
+					} else {
+						++$skipped;
+						$this->appendJobDetail( $jobs, $jobs_omitted, array(
+							'job_id'  => (int) $job->job_id,
+							'flow_id' => (int) $job->flow_id,
+							'status'  => 'skipped',
+							'reason'  => 'Database update failed',
+						) );
+					}
 				}
 			}
 		}
 
 		// Second recovery pass: timed-out jobs (processing without job_status override, older than timeout).
-		$timeout_where = $wpdb->prepare(
-			"WHERE status = 'processing' AND engine_data NOT LIKE %s AND created_at < DATE_SUB(NOW(), INTERVAL %d HOUR)",
-			'%"job_status"%',
-			$timeout_hours
-		);
-		if ( $flow_id ) {
-			$timeout_where .= $wpdb->prepare( ' AND flow_id = %d', $flow_id );
-		}
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic WHERE clause
-		$timed_out_jobs = $wpdb->get_results(
-			"SELECT job_id, flow_id, engine_data FROM {$table} {$timeout_where}"
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-
 		$timed_out     = 0;
 		$stale_actions = 0;
 		$requeued      = 0;
 
-		foreach ( $timed_out_jobs as $job ) {
-			$engine_data = json_decode( $job->engine_data, true );
-			if ( ! is_array( $engine_data ) ) {
-				$engine_data = array();
+		$last_job_id = 0;
+		while ( true ) {
+			$timeout_where = $wpdb->prepare(
+				"WHERE status = 'processing' AND job_id > %d AND engine_data NOT LIKE %s AND created_at < DATE_SUB(NOW(), INTERVAL %d HOUR)",
+				$last_job_id,
+				'%"job_status"%',
+				$timeout_hours
+			);
+			if ( $flow_id ) {
+				$timeout_where .= $wpdb->prepare( ' AND flow_id = %d', $flow_id );
 			}
 
-			$job_id      = (int) $job->job_id;
-			$job_flow_id = (int) $job->flow_id;
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic WHERE clause is prepared above.
+			$timed_out_jobs = $wpdb->get_results(
+				"SELECT job_id, flow_id
+					 FROM {$table}
+					 {$timeout_where}
+					 ORDER BY job_id ASC
+					 LIMIT " . self::CANDIDATE_BATCH_SIZE
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
-			if ( $this->hasActiveSchedulerWork( $job_id, $engine_data, $timeout_hours ) ) {
-				++$skipped;
-				$jobs[] = array(
-					'job_id'  => $job_id,
-					'flow_id' => $job_flow_id,
-					'status'  => 'skipped',
-					'reason'  => 'Pending or in-progress scheduler work exists',
-				);
-				continue;
+			if ( empty( $timed_out_jobs ) ) {
+				break;
 			}
 
-			if ( $dry_run ) {
-				++$timed_out;
-				$jobs[] = array(
-					'job_id'  => $job_id,
-					'flow_id' => $job_flow_id,
-					'status'  => 'would_timeout',
-				);
-			} else {
-				// Mark as failed
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-				$result = $wpdb->update(
-					$table,
-					array(
-						'status'       => 'failed',
-						'completed_at' => current_time( 'mysql', true ),
-					),
-					array( 'job_id' => $job_id ),
-					array( '%s', '%s' ),
-					array( '%d' )
-				);
+			foreach ( $timed_out_jobs as $job ) {
+				$last_job_id = max( $last_job_id, (int) $job->job_id );
+				$engine_data = $this->getJobEngineData( (int) $job->job_id );
 
-				if ( false !== $result ) {
-					++$timed_out;
-					$jobs[] = array(
-						'job_id'  => $job_id,
-						'flow_id' => $job_flow_id,
-						'status'  => 'timed_out',
-					);
+				$job_id      = (int) $job->job_id;
+				$job_flow_id = (int) $job->flow_id;
 
-					do_action( 'datamachine_job_complete', $job_id, 'failed' );
-
-					// Restore drain-mode queued_prompt_backup if the prior run removed an entry.
-					$backup = $engine_data['queued_prompt_backup'] ?? array();
-					if ( ! empty( $backup ) && $this->restoreQueuedPromptBackup( $job_flow_id, $backup ) ) {
-						++$requeued;
-					}
-				} else {
-					$jobs[] = array(
+				if ( $this->hasActiveSchedulerWork( $job_id, $engine_data, $timeout_hours ) ) {
+					++$skipped;
+					$this->appendJobDetail( $jobs, $jobs_omitted, array(
 						'job_id'  => $job_id,
 						'flow_id' => $job_flow_id,
 						'status'  => 'skipped',
-						'reason'  => 'Database update failed for timeout',
+						'reason'  => 'Pending or in-progress scheduler work exists',
+					) );
+					continue;
+				}
+
+				if ( $dry_run ) {
+					++$timed_out;
+					$this->appendJobDetail( $jobs, $jobs_omitted, array(
+						'job_id'  => $job_id,
+						'flow_id' => $job_flow_id,
+						'status'  => 'would_timeout',
+					) );
+				} else {
+					// Mark as failed
+					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+					$result = $wpdb->update(
+						$table,
+						array(
+							'status'       => 'failed',
+							'completed_at' => current_time( 'mysql', true ),
+						),
+						array( 'job_id' => $job_id ),
+						array( '%s', '%s' ),
+						array( '%d' )
 					);
+
+					if ( false !== $result ) {
+						++$timed_out;
+						$this->appendJobDetail( $jobs, $jobs_omitted, array(
+							'job_id'  => $job_id,
+							'flow_id' => $job_flow_id,
+							'status'  => 'timed_out',
+						) );
+
+						do_action( 'datamachine_job_complete', $job_id, 'failed' );
+
+						// Restore drain-mode queued_prompt_backup if the prior run removed an entry.
+						$backup = $engine_data['queued_prompt_backup'] ?? array();
+						if ( ! empty( $backup ) && $this->restoreQueuedPromptBackup( $job_flow_id, $backup ) ) {
+							++$requeued;
+						}
+					} else {
+						$this->appendJobDetail( $jobs, $jobs_omitted, array(
+							'job_id'  => $job_id,
+							'flow_id' => $job_flow_id,
+							'status'  => 'skipped',
+							'reason'  => 'Database update failed for timeout',
+						) );
+					}
 				}
 			}
 		}
@@ -278,36 +303,38 @@ class RecoverStuckJobsAbility {
 
 			if ( $dry_run ) {
 				++$stale_actions;
-				$jobs[] = array(
+				$this->appendJobDetail( $jobs, $jobs_omitted, array(
 					'job_id'        => $job_id,
 					'flow_id'       => $job_flow_id,
 					'action_id'     => $action_id,
 					'status'        => 'would_reconcile_action',
 					'target_status' => $terminal_state,
-				);
+				) );
 				continue;
 			}
 
 			if ( $this->completeTerminalBackedAction( $action_id, $job_id, $terminal_state ) ) {
 				++$stale_actions;
-				$jobs[] = array(
+				$this->appendJobDetail( $jobs, $jobs_omitted, array(
 					'job_id'        => $job_id,
 					'flow_id'       => $job_flow_id,
 					'action_id'     => $action_id,
 					'status'        => 'reconciled_action',
 					'target_status' => $terminal_state,
-				);
+				) );
 			} else {
 				++$skipped;
-				$jobs[] = array(
+				$this->appendJobDetail( $jobs, $jobs_omitted, array(
 					'job_id'    => $job_id,
 					'flow_id'   => $job_flow_id,
 					'action_id' => $action_id,
 					'status'    => 'skipped',
 					'reason'    => 'Action Scheduler reconciliation failed',
-				);
+				) );
 			}
 		}
+
+		$jobs_truncated = $jobs_omitted > 0;
 
 		$message = $dry_run
 			? sprintf( 'Dry run complete. Would recover %d jobs, timeout %d jobs, reconcile %d terminal-backed actions.', $recovered, $timed_out, $stale_actions )
@@ -336,9 +363,77 @@ class RecoverStuckJobsAbility {
 			'stale_actions' => $stale_actions,
 			'requeued'      => $requeued,
 			'dry_run'       => $dry_run,
-			'jobs'          => $jobs,
-			'message'       => $message,
+			'jobs'           => $jobs,
+			'jobs_omitted'   => $jobs_omitted,
+			'jobs_truncated' => $jobs_truncated,
+			'message'        => $message,
 		);
+	}
+
+	/**
+	 * Count stale processing work without loading job payloads.
+	 *
+	 * @param int|null $flow_id Optional flow filter.
+	 * @param int      $timeout_hours Timeout window.
+	 * @return int Stale processing candidate count.
+	 */
+	public static function countStuckCandidates( ?int $flow_id = null, int $timeout_hours = 2 ): int {
+		global $wpdb;
+		$table         = $wpdb->prefix . 'datamachine_jobs';
+		$timeout_hours = max( 1, $timeout_hours );
+
+		$where = $wpdb->prepare(
+			"WHERE status = 'processing' AND ( engine_data LIKE %s OR ( engine_data NOT LIKE %s AND created_at < DATE_SUB(NOW(), INTERVAL %d HOUR) ) )",
+			'%"job_status"%',
+			'%"job_status"%',
+			$timeout_hours
+		);
+		if ( $flow_id ) {
+			$where .= $wpdb->prepare( ' AND flow_id = %d', $flow_id );
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic WHERE clause is prepared above.
+		return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table} {$where}" );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	/**
+	 * Fetch and decode one job's engine data.
+	 *
+	 * @param int $job_id Job ID.
+	 * @return array<string,mixed> Decoded engine data.
+	 */
+	private function getJobEngineData( int $job_id ): array {
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_jobs';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
+		$raw = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT engine_data FROM {$table} WHERE job_id = %d",
+				$job_id
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$decoded = is_string( $raw ) ? json_decode( $raw, true ) : array();
+		return is_array( $decoded ) ? $decoded : array();
+	}
+
+	/**
+	 * Append a bounded job detail row to keep dry-run output memory-safe.
+	 *
+	 * @param array<int,array<string,mixed>> $jobs Job details.
+	 * @param int                           $jobs_omitted Omitted detail count.
+	 * @param array<string,mixed>           $detail Detail row.
+	 */
+	private function appendJobDetail( array &$jobs, int &$jobs_omitted, array $detail ): void {
+		if ( count( $jobs ) < self::JOB_DETAIL_LIMIT ) {
+			$jobs[] = $detail;
+			return;
+		}
+
+		++$jobs_omitted;
 	}
 
 	/**

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -129,11 +129,13 @@ class JobsCommand extends BaseCommand {
 		if ( 'table' !== $format ) {
 			WP_CLI::print_value(
 				array(
-					'success' => true,
-					'dry_run' => $dry_run,
-					'summary' => $summary,
-					'jobs'    => $jobs,
-					'message' => $result['message'] ?? '',
+					'success'        => true,
+					'dry_run'        => $dry_run,
+					'summary'        => $summary,
+					'jobs'           => $jobs,
+					'jobs_omitted'   => (int) ( $result['jobs_omitted'] ?? 0 ),
+					'jobs_truncated' => ! empty( $result['jobs_truncated'] ),
+					'message'        => $result['message'] ?? '',
 				),
 				array(
 					'format' => $format,
@@ -203,6 +205,10 @@ class JobsCommand extends BaseCommand {
 			}
 		}
 
+		if ( ! empty( $result['jobs_truncated'] ) ) {
+			WP_CLI::log( sprintf( 'Output truncated; %d additional job/action details omitted.', (int) ( $result['jobs_omitted'] ?? 0 ) ) );
+		}
+
 		WP_CLI::success( $result['message'] );
 	}
 
@@ -226,6 +232,7 @@ class JobsCommand extends BaseCommand {
 			'actionable'    => $recovered + $timed_out + $stale_actions,
 			'total'         => $recovered + $timed_out + $stale_actions + $skipped,
 			'requeued'      => (int) ( $result['requeued'] ?? 0 ),
+			'jobs_omitted'  => (int) ( $result['jobs_omitted'] ?? 0 ),
 		);
 	}
 

--- a/inc/Cli/Commands/WorkerCommand.php
+++ b/inc/Cli/Commands/WorkerCommand.php
@@ -292,11 +292,7 @@ class WorkerCommand extends BaseCommand {
 		$drain_status    = DrainCommand::status();
 		$jobs_summary    = ( new JobsSummaryAbility() )->execute( array() );
 		$jobs            = ! empty( $jobs_summary['success'] ) && is_array( $jobs_summary['summary'] ?? null ) ? $jobs_summary['summary'] : array();
-		$stuck           = ( new RecoverStuckJobsAbility() )->execute(
-			array(
-				'dry_run' => true,
-			)
-		);
+		$stuck_jobs      = RecoverStuckJobsAbility::countStuckCandidates();
 
 		return array(
 			'pending_actions'       => (int) ( $pending_summary['total'] ?? 0 ),
@@ -307,7 +303,7 @@ class WorkerCommand extends BaseCommand {
 			'processing_jobs'       => (int) ( $jobs['processing'] ?? 0 ),
 			'pending_jobs'          => (int) ( $jobs['pending'] ?? 0 ),
 			'failed_jobs'           => (int) ( $jobs['failed'] ?? 0 ),
-			'stuck_jobs'            => (int) ( $stuck['recovered'] ?? 0 ) + (int) ( $stuck['timed_out'] ?? 0 ) + (int) ( $stuck['stale_actions'] ?? 0 ),
+			'stuck_jobs'            => $stuck_jobs,
 		);
 	}
 

--- a/tests/recover-stuck-bounded-memory-smoke.php
+++ b/tests/recover-stuck-bounded-memory-smoke.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Static smoke test for memory-bounded stuck job recovery.
+ *
+ * Run with: php tests/recover-stuck-bounded-memory-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failed = 0;
+$total  = 0;
+
+function assert_recover_stuck_bounded_memory_smoke( string $name, bool $condition, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+
+	if ( $condition ) {
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+
+	echo "  [FAIL] {$name}" . ( $detail ? " - {$detail}" : '' ) . "\n";
+	++$failed;
+}
+
+$ability_source = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RecoverStuckJobsAbility.php' ) ?: '';
+$worker_source  = file_get_contents( __DIR__ . '/../inc/Cli/Commands/WorkerCommand.php' ) ?: '';
+
+echo "Case 1: recovery queries candidate IDs in bounded batches\n";
+assert_recover_stuck_bounded_memory_smoke( 'batch size constant exists', str_contains( $ability_source, 'private const CANDIDATE_BATCH_SIZE = 50' ) );
+assert_recover_stuck_bounded_memory_smoke( 'candidate queries order by job id', str_contains( $ability_source, 'ORDER BY job_id ASC' ) );
+assert_recover_stuck_bounded_memory_smoke( 'candidate queries are limited', str_contains( $ability_source, 'LIMIT " . self::CANDIDATE_BATCH_SIZE' ) );
+assert_recover_stuck_bounded_memory_smoke( 'bulk timeout query does not select engine_data', ! str_contains( $ability_source, 'SELECT job_id, flow_id, engine_data FROM' ) );
+
+echo "Case 2: recovery fetches large payloads one job at a time\n";
+assert_recover_stuck_bounded_memory_smoke( 'single-job engine data helper exists', str_contains( $ability_source, 'private function getJobEngineData' ) );
+assert_recover_stuck_bounded_memory_smoke( 'single-job engine data query is keyed by job_id', str_contains( $ability_source, 'SELECT engine_data FROM {$table} WHERE job_id = %d' ) );
+assert_recover_stuck_bounded_memory_smoke( 'timeout loop uses single-job engine data fetch', str_contains( $ability_source, '$engine_data = $this->getJobEngineData( (int) $job->job_id );' ) );
+
+echo "Case 3: dry-run details are bounded\n";
+assert_recover_stuck_bounded_memory_smoke( 'job detail limit constant exists', str_contains( $ability_source, 'private const JOB_DETAIL_LIMIT     = 100' ) );
+assert_recover_stuck_bounded_memory_smoke( 'bounded append helper exists', str_contains( $ability_source, 'private function appendJobDetail' ) );
+assert_recover_stuck_bounded_memory_smoke( 'result reports omitted details', str_contains( $ability_source, "'jobs_omitted'" ) && str_contains( $ability_source, "'jobs_truncated'" ) );
+
+echo "Case 4: worker status avoids full recovery dry-run\n";
+assert_recover_stuck_bounded_memory_smoke( 'cheap stuck candidate counter exists', str_contains( $ability_source, 'public static function countStuckCandidates' ) );
+assert_recover_stuck_bounded_memory_smoke( 'worker status uses cheap counter', str_contains( $worker_source, 'RecoverStuckJobsAbility::countStuckCandidates()' ) );
+assert_recover_stuck_bounded_memory_smoke( 'worker status no longer executes dry-run recovery', ! str_contains( $worker_source, "'dry_run' => true" ) );
+
+echo "\nRecover-stuck bounded memory smoke complete: {$total} assertions, {$failed} failures.\n";
+if ( $failed > 0 ) {
+	exit( 1 );
+}

--- a/tests/recover-stuck-cli-output-smoke.php
+++ b/tests/recover-stuck-cli-output-smoke.php
@@ -29,12 +29,14 @@ echo "Case 1: recover-stuck exposes structured output\n";
 assert_recover_stuck_cli_output_smoke( 'recover-stuck documents format option', str_contains( $source, '[--format=<format>]' ) );
 assert_recover_stuck_cli_output_smoke( 'recover-stuck supports json examples', str_contains( $source, 'recover-stuck --dry-run --format=json' ) );
 assert_recover_stuck_cli_output_smoke( 'non-table output uses WP_CLI print_value', str_contains( $source, "if ( 'table' !== \$format )" ) && str_contains( $source, 'WP_CLI::print_value' ) );
-assert_recover_stuck_cli_output_smoke( 'structured output includes summary and jobs', str_contains( $source, "'summary' => \$summary" ) && str_contains( $source, "'jobs'    => \$jobs" ) );
+assert_recover_stuck_cli_output_smoke( 'structured output includes summary and jobs', str_contains( $source, "'summary'        => \$summary" ) && str_contains( $source, "'jobs'           => \$jobs" ) );
+assert_recover_stuck_cli_output_smoke( 'structured output includes truncation metadata', str_contains( $source, "'jobs_omitted'" ) && str_contains( $source, "'jobs_truncated'" ) );
 
 echo "Case 2: recover-stuck separates actionable and guarded jobs\n";
 assert_recover_stuck_cli_output_smoke( 'summary helper exists', str_contains( $source, 'private function summarize_recover_stuck_result' ) );
 assert_recover_stuck_cli_output_smoke( 'summary computes actionable total', str_contains( $source, "'actionable'    => \$recovered + \$timed_out + \$stale_actions" ) );
 assert_recover_stuck_cli_output_smoke( 'table headline reports guarded jobs separately', str_contains( $source, 'Found %d recoverable jobs/actions and %d guarded jobs.' ) );
+assert_recover_stuck_cli_output_smoke( 'table output reports truncated details', str_contains( $source, 'Output truncated; %d additional job/action details omitted.' ) );
 
 echo "\nRecover-stuck CLI output smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary
- Bounds stuck-job recovery queries so `engine_data` longtext payloads are not bulk-loaded for all stale processing jobs.
- Caps recover-stuck detail output and reports truncation metadata for large dry-runs.
- Makes `datamachine worker status` use a cheap stuck-candidate count instead of executing full recovery dry-run.

## Context
On `intelligence.horse`, `datamachine worker run --batch-size=1` and `datamachine jobs recover-stuck --dry-run` exhausted the 512 MB PHP memory limit before drain could start. The live site had 532 stale `processing` jobs with about 174 MB of raw `engine_data`; `wpdb->get_results()` plus object/JSON overhead blew past memory.

## Testing
- `vendor/bin/phpcs inc/Abilities/Job/RecoverStuckJobsAbility.php inc/Cli/Commands/WorkerCommand.php inc/Cli/Commands/JobsCommand.php tests/recover-stuck-bounded-memory-smoke.php tests/recover-stuck-cli-output-smoke.php`
- `php tests/recover-stuck-bounded-memory-smoke.php`
- `php tests/recover-stuck-active-action-guard-smoke.php`
- `php tests/recover-stuck-cli-output-smoke.php`
- `php tests/recover-stuck-terminal-actions-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-recover-stuck-bounded --extension wordpress` (`1300` tests, `1297` passed, `3` skipped, `0` failed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the live worker OOM, drafted the bounded recovery/status fix, added smoke coverage, and ran verification. Chris reviewed and directed the work.