### PR TITLE
refactor: use Agents API package adoption orchestration

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "53843c7467d344d78f3a1a3c89714f399e3e0674"
+                "reference": "672cbc46442928602f2a2e94256177b08ca93aae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/53843c7467d344d78f3a1a3c89714f399e3e0674",
-                "reference": "53843c7467d344d78f3a1a3c89714f399e3e0674",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/672cbc46442928602f2a2e94256177b08ca93aae",
+                "reference": "672cbc46442928602f2a2e94256177b08ca93aae",
                 "shasum": ""
             },
             "require": {
@@ -39,6 +39,7 @@
                     "php tests/message-envelope-smoke.php",
                     "php tests/registry-smoke.php",
                     "php tests/package-lifecycle-smoke.php",
+                    "php tests/package-adoption-orchestration-smoke.php",
                     "php tests/execution-principal-smoke.php",
                     "php tests/effective-agent-resolver-smoke.php",
                     "php tests/caller-context-smoke.php",
@@ -99,7 +100,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-25T15:51:14+00:00"
+            "time": "2026-05-25T19:51:55+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",

--- a/inc/Engine/Bundle/AgentBundleAdoptionStateStore.php
+++ b/inc/Engine/Bundle/AgentBundleAdoptionStateStore.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Agents API package adoption state store for Data Machine bundles.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+use DataMachine\Core\Database\Agents\Agents;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Adapts Data Machine bundle artifact state to the storage-neutral Agents API contract.
+ */
+final class AgentBundleAdoptionStateStore implements \WP_Agent_Package_Artifact_State_Store {
+
+	/** @var array<string,mixed> */
+	private array $agent;
+
+	/** @var array<int,array<string,mixed>> */
+	private array $installed;
+
+	/** @var array<int,array<string,mixed>> */
+	private array $current;
+
+	/** @var array<int,array<string,mixed>> */
+	private array $target;
+
+	/** @var array<string,mixed> */
+	private array $bundle;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array<string,mixed>              $agent Agent row or context.
+	 * @param array<int,array<string,mixed>>   $installed Installed bundle artifact rows.
+	 * @param array<int,array<string,mixed>>   $current Current artifact rows.
+	 * @param array<int,array<string,mixed>>   $target Target artifact rows.
+	 * @param array<string,mixed>              $bundle Bundle metadata.
+	 */
+	public function __construct( array $agent, array $installed, array $current, array $target, array $bundle ) {
+		$this->agent     = $agent;
+		$this->installed = $installed;
+		$this->current   = $current;
+		$this->target    = $target;
+		$this->bundle    = $bundle;
+	}
+
+	public function get_installed_artifacts( \WP_Agent_Package $package, array $context = array() ): array {
+		unset( $package, $context );
+		return self::package_artifact_rows( $this->installed );
+	}
+
+	public function get_current_artifacts( \WP_Agent_Package $package, array $context = array() ): array {
+		unset( $package, $context );
+		return self::package_artifact_rows( $this->current );
+	}
+
+	public function get_target_artifacts( \WP_Agent_Package $package, array $context = array() ): array {
+		unset( $package, $context );
+		return self::package_artifact_rows( $this->target );
+	}
+
+	public function record_installed_artifacts( \WP_Agent_Package $package, array $artifacts, array $context = array() ): bool {
+		unset( $package, $context );
+		global $wpdb;
+
+		$agent_id = (int) ( $this->agent['agent_id'] ?? 0 );
+		if ( $agent_id <= 0 || ! is_object( $wpdb ) ) {
+			return false;
+		}
+
+		$agents = new Agents();
+		$agent  = $agents->get_agent( $agent_id );
+		if ( ! $agent ) {
+			return false;
+		}
+
+		$config = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
+		if ( ! isset( $config['datamachine_bundle'] ) || ! is_array( $config['datamachine_bundle'] ) ) {
+			$config['datamachine_bundle'] = array();
+		}
+
+		$config['datamachine_bundle']['bundle_slug']      = (string) ( $this->bundle['bundle_slug'] ?? $config['datamachine_bundle']['bundle_slug'] ?? '' );
+		$config['datamachine_bundle']['bundle_version']   = (string) ( $this->bundle['bundle_version'] ?? $config['datamachine_bundle']['bundle_version'] ?? '' );
+		$config['datamachine_bundle']['template_slug']    = (string) ( $this->bundle['template_slug'] ?? $config['datamachine_bundle']['template_slug'] ?? $config['datamachine_bundle']['bundle_slug'] ?? '' );
+		$config['datamachine_bundle']['template_version'] = (string) ( $this->bundle['template_version'] ?? $config['datamachine_bundle']['template_version'] ?? $config['datamachine_bundle']['bundle_version'] ?? '' );
+		$config['datamachine_bundle']['source_ref']       = (string) ( $this->bundle['source_ref'] ?? $config['datamachine_bundle']['source_ref'] ?? '' );
+		$config['datamachine_bundle']['source_revision']  = (string) ( $this->bundle['source_revision'] ?? $config['datamachine_bundle']['source_revision'] ?? '' );
+
+		if ( ! isset( $config['datamachine_bundle']['artifacts'] ) || ! is_array( $config['datamachine_bundle']['artifacts'] ) ) {
+			$config['datamachine_bundle']['artifacts'] = array();
+		}
+
+		foreach ( $artifacts as $artifact ) {
+			if ( ! $artifact instanceof \WP_Agent_Package_Installed_Artifact ) {
+				continue;
+			}
+
+			$row  = $artifact->to_array();
+			$type = AgentBundleUpgradePlanner::bundle_artifact_type( (string) $row['artifact_type'] );
+			$id   = (string) $row['artifact_id'];
+			$key  = AgentBundleArtifactExtensions::artifact_key( $type, $id );
+
+			$config['datamachine_bundle']['artifacts'][ $key ] = array(
+				'bundle_slug'       => (string) $config['datamachine_bundle']['bundle_slug'],
+				'bundle_version'    => (string) $config['datamachine_bundle']['bundle_version'],
+				'artifact_type'     => $type,
+				'artifact_id'       => $id,
+				'source_path'       => (string) ( $row['source'] ?? '' ),
+				'installed_hash'    => $row['installed_hash'] ?? null,
+				'current_hash'      => $row['current_hash'] ?? null,
+				'installed_payload' => $row['installed_payload'] ?? null,
+				'status'            => AgentBundleArtifactStatus::classify( $row['installed_hash'] ?? null, $row['current_hash'] ?? null ),
+				'installed_at'      => (string) ( $row['installed_at'] ?? '' ),
+				'updated_at'        => (string) ( $row['updated_at'] ?? '' ),
+			);
+		}
+
+		return (bool) $agents->update_agent( $agent_id, array( 'agent_config' => $config ) );
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $artifacts Bundle artifact rows.
+	 * @return array<int,array<string,mixed>> Package artifact rows.
+	 */
+	public static function package_artifact_rows( array $artifacts ): array {
+		$rows = array();
+		foreach ( $artifacts as $artifact ) {
+			if ( ! is_array( $artifact ) ) {
+				continue;
+			}
+
+			$type = (string) ( $artifact['artifact_type'] ?? '' );
+			$id   = (string) ( $artifact['artifact_id'] ?? '' );
+			if ( '' === $type || '' === $id ) {
+				continue;
+			}
+
+			$rows[] = array_merge(
+				$artifact,
+				array(
+					'artifact_type' => AgentBundleUpgradePlanner::package_artifact_type( $type ),
+					'artifact_id'   => $id,
+					'source'        => (string) ( $artifact['source_path'] ?? ( $artifact['source'] ?? '' ) ),
+				)
+			);
+		}
+
+		return $rows;
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
@@ -71,97 +71,40 @@ final class AgentBundleUpgradePendingAction {
 		$approved = isset( $apply_input['approved_artifacts'] ) && is_array( $apply_input['approved_artifacts'] )
 			? array_values( array_map( 'strval', $apply_input['approved_artifacts'] ) )
 			: array();
-		$approved = array_fill_keys( $approved, true );
 		$targets  = isset( $apply_input['target_artifacts'] ) && is_array( $apply_input['target_artifacts'] ) ? $apply_input['target_artifacts'] : array();
 		$rebased  = isset( $apply_input['rebased_artifacts'] ) && is_array( $apply_input['rebased_artifacts'] ) ? $apply_input['rebased_artifacts'] : array();
 		$agent    = isset( $apply_input['agent'] ) && is_array( $apply_input['agent'] ) ? $apply_input['agent'] : array();
-		$applied  = array();
-		$skipped  = array();
-		$failed   = array();
 
-		// Index rebased artifacts by key for O(1) lookup. A rebased entry
-		// substitutes its merged payload for the wholesale target during apply.
-		$rebased_by_key = array();
-		foreach ( $rebased as $entry ) {
-			if ( ! is_array( $entry ) ) {
-				continue;
-			}
-			$key = (string) ( $entry['artifact_key'] ?? AgentBundleArtifactExtensions::artifact_key(
-				(string) ( $entry['artifact_type'] ?? '' ),
-				(string) ( $entry['artifact_id'] ?? '' )
-			) );
-			if ( '' === $key ) {
-				continue;
-			}
-			if ( ! empty( $entry['requires_approval'] ) ) {
-				// Rebased entries with unresolved ambiguous fields stay
-				// approval-required and never auto-apply.
-				continue;
-			}
-			$rebased_by_key[ $key ] = $entry;
-		}
+		$adoption_targets = self::rebased_targets( $targets, $rebased );
+		self::ensure_package_artifact_types( $adoption_targets );
 
-		foreach ( $targets as $artifact ) {
-			if ( ! is_array( $artifact ) ) {
-				continue;
-			}
-			$key = AgentBundleArtifactExtensions::artifact_key( (string) ( $artifact['artifact_type'] ?? '' ), (string) ( $artifact['artifact_id'] ?? '' ) );
-			if ( ! isset( $approved[ $key ] ) ) {
-				$skipped[] = array(
-					'artifact_key' => $key,
-					'reason'       => 'not_approved',
-				);
-				continue;
-			}
+		$store  = new AgentBundleAdoptionStateStore(
+			$agent,
+			array(),
+			array(),
+			$adoption_targets,
+			isset( $apply_input['bundle'] ) && is_array( $apply_input['bundle'] ) ? $apply_input['bundle'] : array()
+		);
+		$result = ( new \WP_Agent_Package_Adoption_Orchestrator( $store ) )->adopt(
+			new \WP_Agent_Package_Adoption_Request(
+				self::package_from_apply_input( $apply_input, $adoption_targets ),
+				array(
+					'operation'              => 'upgrade',
+					'auto_apply'             => false,
+					'approved_artifact_keys' => self::approved_package_artifact_keys( $approved ),
+					'context'                => array_merge(
+						$apply_input,
+						array(
+							'agent' => $agent,
+						)
+					),
+				)
+			)
+		);
 
-			$apply_artifact = $artifact;
-			$rebase_meta    = null;
-			if ( isset( $rebased_by_key[ $key ] ) ) {
-				$rebase_entry              = $rebased_by_key[ $key ];
-				$apply_artifact['payload'] = $rebase_entry['merged'] ?? $artifact['payload'] ?? null;
-				if ( isset( $rebase_entry['merged_hash'] ) ) {
-					$apply_artifact['hash'] = (string) $rebase_entry['merged_hash'];
-				}
-				$rebase_meta = array(
-					'policy'      => (string) ( $rebase_entry['policy'] ?? '' ),
-					'merged_hash' => isset( $rebase_entry['merged_hash'] ) ? (string) $rebase_entry['merged_hash'] : null,
-					'decisions'   => is_array( $rebase_entry['decisions'] ?? null ) ? $rebase_entry['decisions'] : array(),
-				);
-			}
-
-			/**
-			 * Apply one approved bundle upgrade artifact.
-			 *
-			 * @param mixed $result Null until a consumer applies the artifact.
-			 * @param array $artifact Target artifact payload (may be rebased).
-			 * @param array $apply_input Full PendingAction input.
-			 */
-			$result = AgentBundleArtifactExtensions::apply_artifact( $apply_artifact, $agent, $apply_input );
-			$result = apply_filters( 'datamachine_bundle_upgrade_apply_artifact', $result, $apply_artifact, $apply_input );
-			if ( is_wp_error( $result ) ) {
-				$failed[] = array(
-					'artifact_key' => $key,
-					'error'        => $result->get_error_message(),
-				);
-				continue;
-			}
-			if ( null === $result ) {
-				$failed[] = array(
-					'artifact_key' => $key,
-					'error'        => 'No bundle artifact apply handler registered.',
-				);
-				continue;
-			}
-
-			$applied_entry = array(
-				'artifact_key' => $key,
-				'result'       => $result,
-			);
-			if ( null !== $rebase_meta ) {
-				$applied_entry['rebase'] = $rebase_meta;
-			}
-			$applied[] = $applied_entry;
-		}
+		$applied = self::applied_from_adoption_result( $result, self::rebase_by_package_key( $adoption_targets ) );
+		$skipped = self::skipped_from_adoption_result( $result );
+		$failed  = self::failed_from_adoption_result( $result );
 
 		if ( empty( $applied ) && empty( $failed ) && ! empty( $targets ) ) {
 			$failed[] = array(
@@ -175,6 +118,194 @@ final class AgentBundleUpgradePendingAction {
 			'applied' => $applied,
 			'skipped' => $skipped,
 			'failed'  => $failed,
+		);
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $targets Target artifacts.
+	 * @param array<int,array<string,mixed>> $rebased Rebasing results.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function rebased_targets( array $targets, array $rebased ): array {
+		$rebased_by_key = array();
+		foreach ( $rebased as $entry ) {
+			if ( ! is_array( $entry ) || ! empty( $entry['requires_approval'] ) ) {
+				continue;
+			}
+
+			$key = (string) ( $entry['artifact_key'] ?? AgentBundleArtifactExtensions::artifact_key(
+				(string) ( $entry['artifact_type'] ?? '' ),
+				(string) ( $entry['artifact_id'] ?? '' )
+			) );
+			if ( '' !== $key ) {
+				$rebased_by_key[ $key ] = $entry;
+			}
+		}
+
+		$prepared = array();
+		foreach ( $targets as $artifact ) {
+			if ( ! is_array( $artifact ) ) {
+				continue;
+			}
+
+			$key            = AgentBundleArtifactExtensions::artifact_key( (string) ( $artifact['artifact_type'] ?? '' ), (string) ( $artifact['artifact_id'] ?? '' ) );
+			$apply_artifact = $artifact;
+			if ( isset( $rebased_by_key[ $key ] ) ) {
+				$rebase_entry              = $rebased_by_key[ $key ];
+				$apply_artifact['payload'] = $rebase_entry['merged'] ?? $artifact['payload'] ?? null;
+				if ( isset( $rebase_entry['merged_hash'] ) ) {
+					$apply_artifact['hash'] = (string) $rebase_entry['merged_hash'];
+				}
+				$apply_artifact['rebase'] = array(
+					'policy'      => (string) ( $rebase_entry['policy'] ?? '' ),
+					'merged_hash' => isset( $rebase_entry['merged_hash'] ) ? (string) $rebase_entry['merged_hash'] : null,
+					'decisions'   => is_array( $rebase_entry['decisions'] ?? null ) ? $rebase_entry['decisions'] : array(),
+				);
+			}
+
+			$prepared[] = $apply_artifact;
+		}
+
+		return $prepared;
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $targets Bundle target artifacts.
+	 */
+	private static function package_from_apply_input( array $apply_input, array $targets ): \WP_Agent_Package {
+		$bundle    = isset( $apply_input['bundle'] ) && is_array( $apply_input['bundle'] ) ? $apply_input['bundle'] : array();
+		$agent     = isset( $apply_input['agent'] ) && is_array( $apply_input['agent'] ) ? $apply_input['agent'] : array();
+		$artifacts = array();
+
+		foreach ( AgentBundleAdoptionStateStore::package_artifact_rows( $targets ) as $target ) {
+			$artifacts[] = array(
+				'type'   => (string) $target['artifact_type'],
+				'slug'   => (string) $target['artifact_id'],
+				'source' => (string) ( $target['source'] ?? '' ),
+			);
+		}
+
+		$agent_slug = (string) ( $agent['agent_slug'] ?? $bundle['target_slug'] ?? 'bundle-agent' );
+
+		return \WP_Agent_Package::from_array(
+			array(
+				'slug'      => (string) ( $bundle['bundle_slug'] ?? $agent_slug ),
+				'version'   => (string) ( $bundle['bundle_version'] ?? '0.0.0' ),
+				'agent'     => array(
+					'slug'  => $agent_slug,
+					'label' => (string) ( $agent['agent_name'] ?? $agent_slug ),
+				),
+				'artifacts' => $artifacts,
+			)
+		);
+	}
+
+	/**
+	 * @param array<int,string> $approved Bundle artifact keys.
+	 * @return array<int,string>
+	 */
+	private static function approved_package_artifact_keys( array $approved ): array {
+		$keys = array();
+		foreach ( $approved as $key ) {
+			$parts = explode( ':', (string) $key, 2 );
+			if ( 2 !== count( $parts ) ) {
+				continue;
+			}
+
+			$keys[] = AgentBundleUpgradePlanner::package_artifact_type( $parts[0] ) . ':' . $parts[1];
+		}
+
+		return array_values( array_unique( $keys ) );
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $targets Bundle target artifacts.
+	 */
+	private static function ensure_package_artifact_types( array $targets ): void {
+		if ( ! function_exists( 'wp_has_agent_package_artifact_type' ) || ! function_exists( 'wp_register_agent_package_artifact_type' ) ) {
+			return;
+		}
+
+		foreach ( AgentBundleAdoptionStateStore::package_artifact_rows( $targets ) as $target ) {
+			wp_has_agent_package_artifact_type( (string) $target['artifact_type'] );
+		}
+	}
+
+	/**
+	 * @param array<string,array<string,mixed>> $rebase_by_key Rebase metadata by package artifact key.
+	 */
+	private static function applied_from_adoption_result( \WP_Agent_Package_Adoption_Result $result, array $rebase_by_key ): array {
+		$applied = array();
+		foreach ( $result->get_applied_artifacts() as $entry ) {
+			$artifact      = self::bundle_entry_from_package_entry( $entry );
+			$package_key   = (string) ( $entry['artifact_key'] ?? '' );
+			$applied_entry = array(
+				'artifact_key' => (string) $artifact['artifact_key'],
+				'result'       => $entry['callback_result'] ?? array(),
+			);
+			if ( isset( $rebase_by_key[ $package_key ] ) ) {
+				$applied_entry['rebase'] = $rebase_by_key[ $package_key ];
+			}
+
+			$applied[] = $applied_entry;
+		}
+
+		return $applied;
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $targets Prepared bundle targets.
+	 * @return array<string,array<string,mixed>>
+	 */
+	private static function rebase_by_package_key( array $targets ): array {
+		$indexed = array();
+		foreach ( AgentBundleAdoptionStateStore::package_artifact_rows( $targets ) as $target ) {
+			if ( is_array( $target['rebase'] ?? null ) ) {
+				$indexed[ (string) $target['artifact_type'] . ':' . (string) $target['artifact_id'] ] = $target['rebase'];
+			}
+		}
+
+		return $indexed;
+	}
+
+	private static function skipped_from_adoption_result( \WP_Agent_Package_Adoption_Result $result ): array {
+		$skipped = array();
+		foreach ( $result->get_skipped_artifacts() as $entry ) {
+			$artifact  = self::bundle_entry_from_package_entry( $entry );
+			$skipped[] = array(
+				'artifact_key' => (string) $artifact['artifact_key'],
+				'reason'       => (string) ( $entry['apply_reason'] ?? 'skipped' ),
+			);
+		}
+
+		return $skipped;
+	}
+
+	private static function failed_from_adoption_result( \WP_Agent_Package_Adoption_Result $result ): array {
+		$failed = array();
+		foreach ( $result->get_failed_artifacts() as $entry ) {
+			$artifact = self::bundle_entry_from_package_entry( $entry );
+			$failed[] = array(
+				'artifact_key' => (string) $artifact['artifact_key'],
+				'error'        => (string) ( $entry['apply_error'] ?? $entry['apply_reason'] ?? 'Artifact apply failed.' ),
+			);
+		}
+
+		return $failed;
+	}
+
+	/** @param array<string,mixed> $entry Package entry. */
+	private static function bundle_entry_from_package_entry( array $entry ): array {
+		$type = AgentBundleUpgradePlanner::bundle_artifact_type( (string) ( $entry['artifact_type'] ?? '' ) );
+		$id   = (string) ( $entry['artifact_id'] ?? '' );
+
+		return array_merge(
+			$entry,
+			array(
+				'artifact_key'  => AgentBundleArtifactExtensions::artifact_key( $type, $id ),
+				'artifact_type' => $type,
+				'artifact_id'   => $id,
+			)
 		);
 	}
 }

--- a/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
@@ -150,7 +150,7 @@ final class AgentBundleUpgradePlanner {
 		return $converted;
 	}
 
-	private static function package_artifact_type( string $type ): string {
+	public static function package_artifact_type( string $type ): string {
 		if ( str_contains( $type, '/' ) ) {
 			return $type;
 		}
@@ -158,7 +158,11 @@ final class AgentBundleUpgradePlanner {
 		return 'datamachine/' . str_replace( '_', '-', $type );
 	}
 
-	private static function bundle_artifact_type( string $type ): string {
+	public static function bundle_artifact_type( string $type ): string {
+		if ( str_starts_with( $type, 'datamachine-extension/' ) ) {
+			return substr( $type, strlen( 'datamachine-extension/' ) );
+		}
+
 		$type = str_starts_with( $type, 'datamachine/' ) ? substr( $type, strlen( 'datamachine/' ) ) : $type;
 
 		return str_replace( '-', '_', $type );

--- a/inc/Engine/Bundle/register-agent-package-artifacts.php
+++ b/inc/Engine/Bundle/register-agent-package-artifacts.php
@@ -96,8 +96,8 @@ function datamachine_agent_package_artifact_type_definitions(): array {
  * @return mixed
  */
 function import_datamachine_agent_package_artifact( \WP_Agent_Package_Artifact $artifact, array $context ) {
-	$target         = is_array( $context['target'] ?? null ) ? $context['target'] : array();
-	$bundle_type    = AgentBundleUpgradePlanner::bundle_artifact_type( $artifact->get_type() );
+	$target          = is_array( $context['target'] ?? null ) ? $context['target'] : array();
+	$bundle_type     = AgentBundleUpgradePlanner::bundle_artifact_type( $artifact->get_type() );
 	$bundle_artifact = array(
 		'artifact_type' => $bundle_type,
 		'artifact_id'   => (string) ( $target['artifact_id'] ?? $artifact->get_slug() ),

--- a/inc/Engine/Bundle/register-agent-package-artifacts.php
+++ b/inc/Engine/Bundle/register-agent-package-artifacts.php
@@ -29,37 +29,97 @@ function register_datamachine_agent_package_artifact_types(): void {
 /**
  * Data Machine package artifact type metadata.
  *
- * @return array<string,array<string,string>>
+ * @return array<string,array<string,mixed>>
  */
 function datamachine_agent_package_artifact_type_definitions(): array {
-	return array(
+	$import_callback = __NAMESPACE__ . '\\import_datamachine_agent_package_artifact';
+
+	$definitions = array(
 		'datamachine/pipeline'    => array(
-			'label'       => 'Data Machine pipeline',
-			'description' => 'A portable Data Machine pipeline document.',
+			'label'           => 'Data Machine pipeline',
+			'description'     => 'A portable Data Machine pipeline document.',
+			'import_callback' => $import_callback,
 		),
 		'datamachine/flow'        => array(
-			'label'       => 'Data Machine flow',
-			'description' => 'A portable Data Machine flow document.',
+			'label'           => 'Data Machine flow',
+			'description'     => 'A portable Data Machine flow document.',
+			'import_callback' => $import_callback,
 		),
 		'datamachine/prompt'      => array(
-			'label'       => 'Data Machine prompt',
-			'description' => 'A reusable prompt artifact owned by Data Machine materialization.',
+			'label'           => 'Data Machine prompt',
+			'description'     => 'A reusable prompt artifact owned by Data Machine materialization.',
+			'import_callback' => $import_callback,
 		),
 		'datamachine/rubric'      => array(
-			'label'       => 'Data Machine rubric',
-			'description' => 'A reusable rubric artifact owned by Data Machine materialization.',
+			'label'           => 'Data Machine rubric',
+			'description'     => 'A reusable rubric artifact owned by Data Machine materialization.',
+			'import_callback' => $import_callback,
 		),
 		'datamachine/tool-policy' => array(
-			'label'       => 'Data Machine tool policy',
-			'description' => 'A portable tool policy artifact for Data Machine package installs.',
+			'label'           => 'Data Machine tool policy',
+			'description'     => 'A portable tool policy artifact for Data Machine package installs.',
+			'import_callback' => $import_callback,
 		),
 		'datamachine/auth-ref'    => array(
-			'label'       => 'Data Machine auth reference',
-			'description' => 'A portable auth reference artifact resolved by Data Machine during install.',
+			'label'           => 'Data Machine auth reference',
+			'description'     => 'A portable auth reference artifact resolved by Data Machine during install.',
+			'import_callback' => $import_callback,
 		),
 		'datamachine/queue-seed'  => array(
-			'label'       => 'Data Machine queue seed',
-			'description' => 'A portable queue seed artifact for Data Machine flow setup.',
+			'label'           => 'Data Machine queue seed',
+			'description'     => 'A portable queue seed artifact for Data Machine flow setup.',
+			'import_callback' => $import_callback,
 		),
 	);
+
+	foreach ( BundleSchema::artifact_types() as $bundle_artifact_type ) {
+		$package_type = AgentBundleUpgradePlanner::package_artifact_type( $bundle_artifact_type );
+		if ( isset( $definitions[ $package_type ] ) ) {
+			continue;
+		}
+
+		$definitions[ $package_type ] = array(
+			'label'           => $package_type,
+			'description'     => 'Plugin-owned Data Machine bundle artifact.',
+			'import_callback' => $import_callback,
+		);
+	}
+
+	return $definitions;
+}
+
+/**
+ * Apply a package artifact through Data Machine bundle materializers.
+ *
+ * @param \WP_Agent_Package_Artifact $artifact Package artifact declaration.
+ * @param array<string,mixed>        $context Adoption context.
+ * @return mixed
+ */
+function import_datamachine_agent_package_artifact( \WP_Agent_Package_Artifact $artifact, array $context ) {
+	$target         = is_array( $context['target'] ?? null ) ? $context['target'] : array();
+	$bundle_type    = AgentBundleUpgradePlanner::bundle_artifact_type( $artifact->get_type() );
+	$bundle_artifact = array(
+		'artifact_type' => $bundle_type,
+		'artifact_id'   => (string) ( $target['artifact_id'] ?? $artifact->get_slug() ),
+		'source_path'   => (string) ( $target['source'] ?? $artifact->get_source() ),
+		'payload'       => $target['payload'] ?? null,
+	);
+
+	if ( isset( $target['hash'] ) ) {
+		$bundle_artifact['hash'] = (string) $target['hash'];
+	}
+
+	$agent  = is_array( $context['agent'] ?? null ) ? $context['agent'] : array();
+	$result = AgentBundleArtifactExtensions::apply_artifact( $bundle_artifact, $agent, $context );
+
+	/**
+	 * Back-compat apply seam for existing bundle artifact materializers.
+	 *
+	 * @param mixed               $result Current result.
+	 * @param array<string,mixed> $bundle_artifact Bundle artifact envelope.
+	 * @param array<string,mixed> $context Full adoption context.
+	 */
+	$result = apply_filters( 'datamachine_bundle_upgrade_apply_artifact', $result, $bundle_artifact, $context );
+
+	return ( null === $result || is_wp_error( $result ) ) ? false : $result;
 }

--- a/tests/agent-bundle-extension-artifacts-smoke.php
+++ b/tests/agent-bundle-extension-artifacts-smoke.php
@@ -16,6 +16,7 @@ if ( class_exists( 'PHPUnit\\Framework\\TestCase', false ) ) {
 }
 
 $GLOBALS['__bundle_extension_filters'] = array();
+$GLOBALS['__bundle_extension_actions'] = array();
 
 if ( ! function_exists( 'wp_json_encode' ) ) {
 	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
@@ -25,6 +26,11 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 if ( ! function_exists( 'esc_html' ) ) {
 	function esc_html( $text ) {
 		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+if ( ! function_exists( '_doing_it_wrong' ) ) {
+	function _doing_it_wrong( $function_name, $message, $version ) {
+		unset( $function_name, $message, $version );
 	}
 }
 if ( ! function_exists( 'sanitize_key' ) ) {
@@ -64,8 +70,12 @@ if ( ! function_exists( 'add_filter' ) ) {
 }
 if ( ! function_exists( 'did_action' ) ) {
 	function did_action( $hook = '' ) {
-		unset( $hook );
-		return 0;
+		return 'init' === $hook ? 1 : 0;
+	}
+}
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook = '' ) {
+		return in_array( $hook, $GLOBALS['__bundle_extension_actions'], true );
 	}
 }
 if ( ! function_exists( 'add_action' ) ) {
@@ -86,8 +96,16 @@ if ( ! function_exists( 'apply_filters' ) ) {
 		return $value;
 	}
 }
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook, ...$args ) {
+		$GLOBALS['__bundle_extension_actions'][] = $hook;
+		apply_filters( $hook, null, ...$args );
+		array_pop( $GLOBALS['__bundle_extension_actions'] );
+	}
+}
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/register-agent-package-artifacts.php';
 
 use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
 use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;

--- a/tests/agent-bundle-pending-action-rebase-smoke.php
+++ b/tests/agent-bundle-pending-action-rebase-smoke.php
@@ -13,44 +13,46 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
 }
 
-$GLOBALS['__rebase_pa_filters'] = array();
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+agents_api_smoke_require_module();
 
 if ( ! function_exists( 'wp_json_encode' ) ) {
 	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
 		return json_encode( $data, $options, $depth );
 	}
 }
-if ( ! function_exists( 'add_filter' ) ) {
-	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
-		$GLOBALS['__rebase_pa_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
-		ksort( $GLOBALS['__rebase_pa_filters'][ $hook ], SORT_NUMERIC );
-		return true;
-	}
-}
-if ( ! function_exists( 'apply_filters' ) ) {
-	function apply_filters( $hook, $value, ...$args ) {
-		if ( empty( $GLOBALS['__rebase_pa_filters'][ $hook ] ) ) {
-			return $value;
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $message;
+
+		public function __construct( string $code = '', string $message = '' ) {
+			unset( $code );
+			$this->message = $message;
 		}
-		foreach ( $GLOBALS['__rebase_pa_filters'][ $hook ] as $callbacks ) {
-			foreach ( $callbacks as $registration ) {
-				$value = call_user_func_array( $registration[0], array_slice( array_merge( array( $value ), $args ), 0, $registration[1] ) );
-			}
+
+		public function get_error_message(): string {
+			return $this->message;
 		}
-		return $value;
 	}
 }
 if ( ! function_exists( 'is_wp_error' ) ) {
 	function is_wp_error( $value ) {
-		return false;
+		return $value instanceof WP_Error;
 	}
 }
 
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSchema.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactExtensions.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactHasher.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactStatus.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactRebase.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleUpgradePlanner.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleAdoptionStateStore.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/register-agent-package-artifacts.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php';
+
+do_action( 'init' );
 
 use DataMachine\Engine\Bundle\AgentBundleArtifactRebase;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;

--- a/tests/agent-bundle-upgrade-planner-smoke.php
+++ b/tests/agent-bundle-upgrade-planner-smoke.php
@@ -19,6 +19,7 @@ if ( ! defined( 'DATAMACHINE_PENDING_ACTION_TRANSIENT_FALLBACK' ) ) {
 
 $GLOBALS['__bundle_upgrade_filters']    = array();
 $GLOBALS['__bundle_upgrade_transients'] = array();
+$GLOBALS['__bundle_upgrade_actions']    = array();
 
 if ( ! function_exists( 'wp_json_encode' ) ) {
 	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
@@ -30,9 +31,21 @@ if ( ! function_exists( 'esc_html' ) ) {
 		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
 	}
 }
+if ( ! function_exists( '_doing_it_wrong' ) ) {
+	function _doing_it_wrong( $function_name, $message, $version ) {
+		unset( $function_name, $message, $version );
+	}
+}
 if ( ! function_exists( 'sanitize_key' ) ) {
 	function sanitize_key( $key ) {
 		return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $key ) );
+	}
+}
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $title ) {
+		$slug = strtolower( (string) $title );
+		$slug = preg_replace( '/[^a-z0-9]+/', '-', $slug );
+		return trim( (string) $slug, '-' );
 	}
 }
 if ( ! function_exists( 'sanitize_text_field' ) ) {
@@ -57,12 +70,12 @@ if ( ! function_exists( 'current_user_can' ) ) {
 }
 if ( ! function_exists( 'did_action' ) ) {
 	function did_action( $hook = '' ) {
-		return 0;
+		return 'init' === $hook ? 1 : 0;
 	}
 }
 if ( ! function_exists( 'doing_action' ) ) {
 	function doing_action( $hook = '' ) {
-		return false;
+		return in_array( $hook, $GLOBALS['__bundle_upgrade_actions'], true );
 	}
 }
 if ( ! function_exists( 'wp_generate_uuid4' ) ) {
@@ -114,7 +127,9 @@ if ( ! function_exists( 'apply_filters' ) ) {
 }
 if ( ! function_exists( 'do_action' ) ) {
 	function do_action( $hook, ...$args ) {
+		$GLOBALS['__bundle_upgrade_actions'][] = $hook;
 		apply_filters( $hook, null, ...$args );
+		array_pop( $GLOBALS['__bundle_upgrade_actions'] );
 	}
 }
 if ( ! function_exists( 'is_wp_error' ) ) {
@@ -211,6 +226,7 @@ if ( ! class_exists( 'AgentsAPI\\AI\\Approvals\\WP_Agent_Pending_Action' ) ) {
 	}
 	' );
 }
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/register-agent-package-artifacts.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php';
 
 use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
@@ -236,7 +252,12 @@ function assert_upgrade_plan( string $label, bool $condition ): void {
 }
 
 function assert_upgrade_plan_equals( string $label, $expected, $actual ): void {
-	assert_upgrade_plan( $label, $expected === $actual );
+	$ok = $expected === $actual;
+	assert_upgrade_plan( $label, $ok );
+	if ( ! $ok ) {
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	}
 }
 
 function upgrade_artifact( string $type, string $id, $payload, string $source_path = '' ): array {


### PR DESCRIPTION
## Summary
- Refactors bundle-upgrade PendingAction apply onto the merged Agents API package adoption orchestrator.
- Adds a Data Machine state-store adapter that maps bundle artifact rows to package artifact rows and records applied package snapshots back into `datamachine_bundle` metadata.
- Registers Data Machine package artifact import callbacks so core and plugin-owned bundle artifacts keep routing through existing Data Machine materializers.
- Updates `automattic/agents-api` to `dev-main` at Automattic/agents-api#203's merge commit.

## Related
- Follows https://github.com/Automattic/agents-api/pull/203
- Builds on https://github.com/Extra-Chill/data-machine/pull/2236
- Tracks https://github.com/Extra-Chill/data-machine/issues/2235

## Testing
- `php tests/agent-bundle-pending-action-rebase-smoke.php && php tests/agent-bundle-upgrade-planner-smoke.php && php tests/agent-bundle-extension-artifacts-smoke.php && php tests/agent-bundle-installed-payload-snapshot-smoke.php && php tests/datamachine-package-artifacts-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@refactor-agents-api-adoption-orchestrator --extension wordpress --changed-only --errors-only`
- `homeboy test --path /Users/chubes/Developer/data-machine@refactor-agents-api-adoption-orchestrator --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refactored the Data Machine bundle upgrade apply path onto the Agents API orchestration contracts, updated smoke coverage, and ran local verification for Chris to review.