### PR TITLE
Add memory-safe jobs summary aggregates

### DIFF
--- a/inc/Abilities/Job/JobsSummaryAbility.php
+++ b/inc/Abilities/Job/JobsSummaryAbility.php
@@ -32,7 +32,32 @@ class JobsSummaryAbility {
 					'category'            => 'datamachine-jobs',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'properties' => array(),
+						'properties' => array(
+							'flow_id'     => array(
+								'type'        => array( 'integer', 'string', 'null' ),
+								'description' => __( 'Filter jobs by flow ID.', 'data-machine' ),
+							),
+							'pipeline_id' => array(
+								'type'        => array( 'integer', 'string', 'null' ),
+								'description' => __( 'Filter jobs by pipeline ID.', 'data-machine' ),
+							),
+							'handler'     => array(
+								'type'        => array( 'string', 'null' ),
+								'description' => __( 'Filter jobs by handler slug recorded in job outcome metadata.', 'data-machine' ),
+							),
+							'status'      => array(
+								'type'        => array( 'string', 'null' ),
+								'description' => __( 'Filter jobs by status prefix.', 'data-machine' ),
+							),
+							'source'      => array(
+								'type'        => array( 'string', 'null' ),
+								'description' => __( 'Filter jobs by source.', 'data-machine' ),
+							),
+							'since'       => array(
+								'type'        => array( 'string', 'null' ),
+								'description' => __( 'Filter jobs created at or after this datetime (Y-m-d H:i:s).', 'data-machine' ),
+							),
+						),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -63,42 +88,23 @@ class JobsSummaryAbility {
 	 * Returns job counts grouped by base status. Compound statuses (e.g., "agent_skipped - reason")
 	 * are normalized to their base status.
 	 *
-	 * @param array $input Input parameters (none required).
+	 * @param array $input Filter parameters.
 	 * @return array Result with summary counts.
 	 */
-	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Ability interface requires $input
 	public function execute( array $input ): array {
-		global $wpdb;
-		$table = $wpdb->prefix . 'datamachine_jobs';
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$results = $wpdb->get_results(
-			"SELECT
-				CASE
-					WHEN status LIKE 'agent_skipped%' THEN 'agent_skipped'
-					WHEN status LIKE 'completed_no_items%' THEN 'completed_no_items'
-					WHEN status LIKE 'failed%' THEN 'failed'
-					ELSE status
-				END as base_status,
-				COUNT(*) as count
-			 FROM {$table}
-			 GROUP BY base_status
-			 ORDER BY count DESC"
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-
-		$summary = array();
-		$total   = 0;
-
-		foreach ( $results as $row ) {
-			$summary[ $row->base_status ] = (int) $row->count;
-			$total                       += (int) $row->count;
+		$filters = array();
+		foreach ( array( 'flow_id', 'pipeline_id', 'handler', 'status', 'source', 'since', 'user_id', 'agent_id' ) as $key ) {
+			if ( isset( $input[ $key ] ) && '' !== $input[ $key ] && null !== $input[ $key ] ) {
+				$filters[ $key ] = $input[ $key ];
+			}
 		}
+
+		$summary = $this->db_jobs->get_jobs_summary( $filters );
 
 		return array(
 			'success' => true,
 			'summary' => $summary,
-			'total'   => $total,
+			'total'   => (int) ( $summary['total'] ?? 0 ),
 		);
 	}
 }

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -1855,6 +1855,24 @@ class JobsCommand extends BaseCommand {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--status=<status>]
+	 * : Filter by status prefix.
+	 *
+	 * [--source=<source>]
+	 * : Filter by job source.
+	 *
+	 * [--flow=<flow_id>]
+	 * : Filter by flow ID.
+	 *
+	 * [--pipeline=<pipeline_id>]
+	 * : Filter by pipeline ID.
+	 *
+	 * [--handler=<handler_slug>]
+	 * : Filter by handler slug recorded in generic job outcome metadata.
+	 *
+	 * [--since=<datetime>]
+	 * : Summarize jobs created after this time. Accepts ISO datetime or relative strings (e.g., "1 hour ago", "today", "yesterday").
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -1880,10 +1898,45 @@ class JobsCommand extends BaseCommand {
 	 *     # JSON output
 	 *     wp datamachine jobs summary --format=json
 	 *
+	 *     # Dashboard-safe summary for today's jobs in one pipeline
+	 *     wp datamachine jobs summary --pipeline=42 --since=today --format=json
+	 *
 	 * @subcommand summary
 	 */
 	public function summary( array $args, array $assoc_args ): void {
-		$result = ( new JobsSummaryAbility() )->execute( array() );
+		$input = AgentResolver::buildScopingInput( $assoc_args );
+
+		if ( ! empty( $assoc_args['status'] ) ) {
+			$input['status'] = (string) $assoc_args['status'];
+		}
+
+		if ( isset( $assoc_args['flow'] ) ) {
+			$input['flow_id'] = (string) $assoc_args['flow'];
+		}
+
+		if ( isset( $assoc_args['pipeline'] ) ) {
+			$input['pipeline_id'] = (string) $assoc_args['pipeline'];
+		}
+
+		if ( ! empty( $assoc_args['source'] ) ) {
+			$input['source'] = (string) $assoc_args['source'];
+		}
+
+		if ( ! empty( $assoc_args['handler'] ) ) {
+			$input['handler'] = (string) $assoc_args['handler'];
+		}
+
+		$since = $assoc_args['since'] ?? null;
+		if ( $since ) {
+			$timestamp = strtotime( $since );
+			if ( false === $timestamp ) {
+				WP_CLI::error( sprintf( 'Invalid --since value: "%s". Use ISO datetime or relative string (e.g., "1 hour ago", "today").', $since ) );
+				return;
+			}
+			$input['since'] = gmdate( 'Y-m-d H:i:s', $timestamp );
+		}
+
+		$result = ( new JobsSummaryAbility() )->execute( $input );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Unknown error occurred' );
@@ -1897,16 +1950,61 @@ class JobsCommand extends BaseCommand {
 			return;
 		}
 
-		// Transform summary to row format.
-		$items = array();
-		foreach ( $summary as $status => $count ) {
-			$items[] = array(
-				'status' => $status,
-				'count'  => $count,
-			);
+		$format = $assoc_args['format'] ?? 'table';
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
 		}
 
-		$this->format_items( $items, array( 'status', 'count' ), $assoc_args );
+		if ( 'yaml' === $format ) {
+			/** @phpstan-ignore-next-line Spyc is provided by WP-CLI at runtime. */
+			WP_CLI::log( (string) call_user_func( array( 'Spyc', 'YAMLDump' ), $summary, false, false, true ) );
+			return;
+		}
+
+		$items = array();
+		foreach ( array( 'status', 'pipeline', 'flow', 'handler' ) as $group ) {
+			foreach ( $summary[ $group ] ?? array() as $row ) {
+				$items[] = array(
+					'group' => $group,
+					'key'   => $this->get_summary_row_key( $group, $row ),
+					'name'  => $this->get_summary_row_name( $group, $row ),
+					'count' => (int) ( $row['count'] ?? 0 ),
+				);
+			}
+		}
+
+		$this->format_items( $items, array( 'group', 'key', 'name', 'count' ), $assoc_args );
+
+		if ( 'table' === $format ) {
+			WP_CLI::log( sprintf( 'Total: %d', (int) ( $summary['total'] ?? 0 ) ) );
+			WP_CLI::log( sprintf( 'Failed: %d', (int) ( $summary['failed_count'] ?? 0 ) ) );
+			WP_CLI::log( sprintf( 'Stuck processing: %d', (int) ( $summary['stuck_processing_count'] ?? 0 ) ) );
+		}
+	}
+
+	/**
+	 * Get a stable key for a summary table row.
+	 */
+	private function get_summary_row_key( string $group, array $row ): string {
+		return match ( $group ) {
+			'status' => (string) ( $row['status'] ?? '' ),
+			'pipeline' => (string) ( $row['pipeline_id'] ?? '' ),
+			'flow' => (string) ( $row['flow_id'] ?? '' ),
+			'handler' => (string) ( $row['handler_slug'] ?? '' ),
+			default => '',
+		};
+	}
+
+	/**
+	 * Get a display name for a summary table row.
+	 */
+	private function get_summary_row_name( string $group, array $row ): string {
+		return match ( $group ) {
+			'pipeline' => (string) ( $row['pipeline_name'] ?? '' ),
+			'flow' => (string) ( $row['flow_name'] ?? '' ),
+			default => '',
+		};
 	}
 
 	/**

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -268,19 +268,19 @@ class Jobs extends BaseRepository {
 	 * @return array Summary buckets and totals.
 	 */
 	public function get_jobs_summary( array $args = array() ): array {
-		$where_parts = $this->build_jobs_summary_where( $args, 'j' );
-		$where_sql = $where_parts['sql'];
+		$where_parts  = $this->build_jobs_summary_where( $args, 'j' );
+		$where_sql    = $where_parts['sql'];
 		$where_values = $where_parts['values'];
 
 		return array(
-			'total' => $this->get_jobs_count( $args ),
-			'failed_count' => $this->get_jobs_count( array_merge( $args, array( 'status' => 'failed' ) ) ),
+			'total'                  => $this->get_jobs_count( $args ),
+			'failed_count'           => $this->get_jobs_count( array_merge( $args, array( 'status' => 'failed' ) ) ),
 			'stuck_processing_count' => $this->get_stuck_processing_count( $args ),
-			'status' => $this->get_status_summary_rows( $where_sql, $where_values ),
-			'pipeline' => $this->get_pipeline_summary_rows( $where_sql, $where_values ),
-			'flow' => $this->get_flow_summary_rows( $where_sql, $where_values ),
-			'handler' => $this->get_handler_summary_rows( $args, $where_sql, $where_values ),
-			'filters' => $this->summarize_job_filters( $args ),
+			'status'                 => $this->get_status_summary_rows( $where_sql, $where_values ),
+			'pipeline'               => $this->get_pipeline_summary_rows( $where_sql, $where_values ),
+			'flow'                   => $this->get_flow_summary_rows( $where_sql, $where_values ),
+			'handler'                => $this->get_handler_summary_rows( $args, $where_sql, $where_values ),
+			'filters'                => $this->summarize_job_filters( $args ),
 		);
 	}
 
@@ -380,7 +380,9 @@ class Jobs extends BaseRepository {
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above from fixed SQL fragments and placeholders.
-		return $this->normalize_summary_rows( $this->wpdb->get_results( $query, ARRAY_A ) ?: array(), array( 'status' ) );
+		$rows = $this->wpdb->get_results( $query, ARRAY_A );
+
+		return $this->normalize_summary_rows( $rows ? $rows : array(), array( 'status' ) );
 	}
 
 	/**
@@ -402,7 +404,9 @@ class Jobs extends BaseRepository {
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above from fixed SQL fragments and placeholders.
-		return $this->normalize_summary_rows( $this->wpdb->get_results( $query, ARRAY_A ) ?: array(), array( 'pipeline_id', 'pipeline_name' ) );
+		$rows = $this->wpdb->get_results( $query, ARRAY_A );
+
+		return $this->normalize_summary_rows( $rows ? $rows : array(), array( 'pipeline_id', 'pipeline_name' ) );
 	}
 
 	/**
@@ -424,7 +428,9 @@ class Jobs extends BaseRepository {
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above from fixed SQL fragments and placeholders.
-		return $this->normalize_summary_rows( $this->wpdb->get_results( $query, ARRAY_A ) ?: array(), array( 'flow_id', 'flow_name', 'pipeline_id' ) );
+		$rows = $this->wpdb->get_results( $query, ARRAY_A );
+
+		return $this->normalize_summary_rows( $rows ? $rows : array(), array( 'flow_id', 'flow_name', 'pipeline_id' ) );
 	}
 
 	/**
@@ -461,7 +467,9 @@ class Jobs extends BaseRepository {
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above from fixed SQL fragments and placeholders.
-		return $this->normalize_summary_rows( $this->wpdb->get_results( $query, ARRAY_A ) ?: array(), array( 'handler_slug' ) );
+		$rows = $this->wpdb->get_results( $query, ARRAY_A );
+
+		return $this->normalize_summary_rows( $rows ? $rows : array(), array( 'handler_slug' ) );
 	}
 
 	/**

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -259,6 +259,261 @@ class Jobs extends BaseRepository {
 	}
 
 	/**
+	 * Get memory-safe aggregate job summary counts.
+	 *
+	 * Uses grouped SQL queries so operator dashboards can inspect large job
+	 * backlogs without hydrating or decoding long engine_data blobs.
+	 *
+	 * @param array $args Filter arguments matching get_jobs_count().
+	 * @return array Summary buckets and totals.
+	 */
+	public function get_jobs_summary( array $args = array() ): array {
+		$where_parts = $this->build_jobs_summary_where( $args, 'j' );
+		$where_sql   = $where_parts['sql'];
+		$where_values = $where_parts['values'];
+
+		return array(
+			'total'                   => $this->get_jobs_count( $args ),
+			'failed_count'            => $this->get_jobs_count( array_merge( $args, array( 'status' => 'failed' ) ) ),
+			'stuck_processing_count'  => $this->get_stuck_processing_count( $args ),
+			'status'                  => $this->get_status_summary_rows( $where_sql, $where_values ),
+			'pipeline'                => $this->get_pipeline_summary_rows( $where_sql, $where_values ),
+			'flow'                    => $this->get_flow_summary_rows( $where_sql, $where_values ),
+			'handler'                 => $this->get_handler_summary_rows( $args, $where_sql, $where_values ),
+			'filters'                 => $this->summarize_job_filters( $args ),
+		);
+	}
+
+	/**
+	 * Build WHERE SQL for aggregate summary queries.
+	 *
+	 * @param array  $args  Filter arguments.
+	 * @param string $alias Table alias.
+	 * @return array{sql:string,values:array}
+	 */
+	private function build_jobs_summary_where( array $args, string $alias = 'j' ): array {
+		$prefix        = '' !== $alias ? $alias . '.' : '';
+		$where_clauses = array();
+		$where_values  = array();
+
+		if ( ! empty( $args['flow_id'] ) ) {
+			$where_clauses[] = $prefix . 'flow_id = %s';
+			$where_values[]  = (string) $args['flow_id'];
+		}
+
+		if ( ! empty( $args['pipeline_id'] ) ) {
+			$where_clauses[] = $prefix . 'pipeline_id = %s';
+			$where_values[]  = (string) $args['pipeline_id'];
+		}
+
+		if ( ! empty( $args['status'] ) ) {
+			$status_value    = sanitize_text_field( $args['status'] );
+			$where_clauses[] = $prefix . 'status LIKE %s';
+			$where_values[]  = $this->wpdb->esc_like( $status_value ) . '%';
+		}
+
+		if ( ! empty( $args['source'] ) ) {
+			$where_clauses[] = $prefix . 'source = %s';
+			$where_values[]  = sanitize_text_field( $args['source'] );
+		}
+
+		if ( ! empty( $args['handler'] ) ) {
+			$handler = sanitize_key( (string) $args['handler'] );
+			if ( '' !== $handler ) {
+				$where_clauses[] = '(' . $prefix . 'engine_data LIKE %s OR ' . $prefix . 'engine_data LIKE %s OR ' . $prefix . 'engine_data LIKE %s)';
+				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler_slug":"' . $handler . '"' ) . '%';
+				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler":"' . $handler . '"' ) . '%';
+				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler_slugs":["' . $handler . '"' ) . '%';
+			}
+		}
+
+		if ( isset( $args['user_id'] ) ) {
+			$where_clauses[] = $prefix . 'user_id = %d';
+			$where_values[]  = absint( $args['user_id'] );
+		}
+
+		if ( isset( $args['agent_id'] ) ) {
+			$where_clauses[] = $prefix . 'agent_id = %d';
+			$where_values[]  = absint( $args['agent_id'] );
+		}
+
+		if ( ! empty( $args['since'] ) ) {
+			$where_clauses[] = $prefix . 'created_at >= %s';
+			$where_values[]  = sanitize_text_field( $args['since'] );
+		}
+
+		if ( isset( $args['parent_job_id'] ) ) {
+			$where_clauses[] = $prefix . 'parent_job_id = %d';
+			$where_values[]  = absint( $args['parent_job_id'] );
+		}
+
+		if ( ! empty( $args['hide_children'] ) ) {
+			$where_clauses[] = '(' . $prefix . 'parent_job_id IS NULL OR ' . $prefix . 'parent_job_id = 0)';
+		}
+
+		return array(
+			'sql'    => empty( $where_clauses ) ? '' : 'WHERE ' . implode( ' AND ', $where_clauses ),
+			'values' => $where_values,
+		);
+	}
+
+	/**
+	 * Get aggregate status summary rows.
+	 */
+	private function get_status_summary_rows( string $where_sql, array $where_values ): array {
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$query = $this->wpdb->prepare(
+			"SELECT
+				CASE
+					WHEN j.status LIKE 'agent_skipped%' THEN 'agent_skipped'
+					WHEN j.status LIKE 'completed_no_items%' THEN 'completed_no_items'
+					WHEN j.status LIKE 'failed%' THEN 'failed'
+					ELSE j.status
+				END AS status,
+				COUNT(*) AS count
+			 FROM %i j
+			 {$where_sql}
+			 GROUP BY status
+			 ORDER BY count DESC",
+			array_merge( array( $this->table_name ), $where_values )
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return $this->normalize_summary_rows( $this->wpdb->get_results( $query, ARRAY_A ) ?: array(), array( 'status' ) );
+	}
+
+	/**
+	 * Get aggregate pipeline summary rows.
+	 */
+	private function get_pipeline_summary_rows( string $where_sql, array $where_values ): array {
+		$pipelines_table = $this->wpdb->prefix . 'datamachine_pipelines';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$query = $this->wpdb->prepare(
+			"SELECT j.pipeline_id, p.pipeline_name, COUNT(*) AS count
+			 FROM %i j
+			 LEFT JOIN %i p ON j.pipeline_id = p.pipeline_id
+			 {$where_sql}
+			 GROUP BY j.pipeline_id, p.pipeline_name
+			 ORDER BY count DESC",
+			array_merge( array( $this->table_name, $pipelines_table ), $where_values )
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return $this->normalize_summary_rows( $this->wpdb->get_results( $query, ARRAY_A ) ?: array(), array( 'pipeline_id', 'pipeline_name' ) );
+	}
+
+	/**
+	 * Get aggregate flow summary rows.
+	 */
+	private function get_flow_summary_rows( string $where_sql, array $where_values ): array {
+		$flows_table = $this->wpdb->prefix . 'datamachine_flows';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$query = $this->wpdb->prepare(
+			"SELECT j.flow_id, f.flow_name, j.pipeline_id, COUNT(*) AS count
+			 FROM %i j
+			 LEFT JOIN %i f ON j.flow_id = f.flow_id
+			 {$where_sql}
+			 GROUP BY j.flow_id, f.flow_name, j.pipeline_id
+			 ORDER BY count DESC",
+			array_merge( array( $this->table_name, $flows_table ), $where_values )
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return $this->normalize_summary_rows( $this->wpdb->get_results( $query, ARRAY_A ) ?: array(), array( 'flow_id', 'flow_name', 'pipeline_id' ) );
+	}
+
+	/**
+	 * Get aggregate handler summary rows without selecting engine_data blobs.
+	 */
+	private function get_handler_summary_rows( array $args, string $where_sql, array $where_values ): array {
+		if ( ! empty( $args['handler'] ) ) {
+			$handler = sanitize_key( (string) $args['handler'] );
+			return '' === $handler ? array() : array(
+				array(
+					'handler_slug' => $handler,
+					'count'        => $this->get_jobs_count( $args ),
+				),
+			);
+		}
+
+		$handler_where = '' === $where_sql
+			? 'WHERE j.engine_data LIKE %s'
+			: $where_sql . ' AND j.engine_data LIKE %s';
+		$values        = array_merge( $where_values, array( '%"handler_slug":"%' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$query = $this->wpdb->prepare(
+			"SELECT
+				SUBSTRING_INDEX(SUBSTRING_INDEX(REGEXP_SUBSTR(j.engine_data, '\"handler_slug\":\"[^\"]+\"'), ':\"', -1), '\"', 1) AS handler_slug,
+				COUNT(*) AS count
+			 FROM %i j
+			 {$handler_where}
+			 GROUP BY handler_slug
+			 HAVING handler_slug IS NOT NULL AND handler_slug != ''
+			 ORDER BY count DESC",
+			array_merge( array( $this->table_name ), $values )
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return $this->normalize_summary_rows( $this->wpdb->get_results( $query, ARRAY_A ) ?: array(), array( 'handler_slug' ) );
+	}
+
+	/**
+	 * Count processing jobs older than the dashboard stuck threshold.
+	 */
+	private function get_stuck_processing_count( array $args ): int {
+		$stuck_args           = $args;
+		$stuck_args['status'] = 'processing';
+		$where_parts          = $this->build_jobs_summary_where( $stuck_args, 'j' );
+		$where_sql            = '' === $where_parts['sql'] ? 'WHERE j.created_at < %s' : $where_parts['sql'] . ' AND j.created_at < %s';
+		$stuck_seconds        = defined( 'HOUR_IN_SECONDS' ) ? 2 * HOUR_IN_SECONDS : 7200;
+		$where_values         = array_merge( $where_parts['values'], array( gmdate( 'Y-m-d H:i:s', time() - $stuck_seconds ) ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$query = $this->wpdb->prepare(
+			"SELECT COUNT(j.job_id) FROM %i j {$where_sql}",
+			array_merge( array( $this->table_name ), $where_values )
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return (int) $this->wpdb->get_var( $query );
+	}
+
+	/**
+	 * Normalize aggregate rows to stable scalar arrays.
+	 */
+	private function normalize_summary_rows( array $rows, array $fields ): array {
+		$normalized = array();
+
+		foreach ( $rows as $row ) {
+			$item = array();
+			foreach ( $fields as $field ) {
+				$item[ $field ] = isset( $row[ $field ] ) ? (string) $row[ $field ] : '';
+			}
+			$item['count'] = (int) ( $row['count'] ?? 0 );
+			$normalized[]  = $item;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Return the filters applied to a job summary query.
+	 */
+	private function summarize_job_filters( array $args ): array {
+		$filters = array();
+		foreach ( array( 'pipeline_id', 'flow_id', 'handler', 'status', 'source', 'since', 'user_id', 'agent_id', 'parent_job_id', 'hide_children' ) as $key ) {
+			if ( isset( $args[ $key ] ) && '' !== $args[ $key ] && null !== $args[ $key ] ) {
+				$filters[ $key ] = $args[ $key ];
+			}
+		}
+
+		return $filters;
+	}
+
+	/**
 	 * Get paginated jobs with pipeline and flow names.
 	 *
 	 * Supports filtering by flow_id, pipeline_id, and status.

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -269,18 +269,18 @@ class Jobs extends BaseRepository {
 	 */
 	public function get_jobs_summary( array $args = array() ): array {
 		$where_parts = $this->build_jobs_summary_where( $args, 'j' );
-		$where_sql   = $where_parts['sql'];
+		$where_sql = $where_parts['sql'];
 		$where_values = $where_parts['values'];
 
 		return array(
-			'total'                   => $this->get_jobs_count( $args ),
-			'failed_count'            => $this->get_jobs_count( array_merge( $args, array( 'status' => 'failed' ) ) ),
-			'stuck_processing_count'  => $this->get_stuck_processing_count( $args ),
-			'status'                  => $this->get_status_summary_rows( $where_sql, $where_values ),
-			'pipeline'                => $this->get_pipeline_summary_rows( $where_sql, $where_values ),
-			'flow'                    => $this->get_flow_summary_rows( $where_sql, $where_values ),
-			'handler'                 => $this->get_handler_summary_rows( $args, $where_sql, $where_values ),
-			'filters'                 => $this->summarize_job_filters( $args ),
+			'total' => $this->get_jobs_count( $args ),
+			'failed_count' => $this->get_jobs_count( array_merge( $args, array( 'status' => 'failed' ) ) ),
+			'stuck_processing_count' => $this->get_stuck_processing_count( $args ),
+			'status' => $this->get_status_summary_rows( $where_sql, $where_values ),
+			'pipeline' => $this->get_pipeline_summary_rows( $where_sql, $where_values ),
+			'flow' => $this->get_flow_summary_rows( $where_sql, $where_values ),
+			'handler' => $this->get_handler_summary_rows( $args, $where_sql, $where_values ),
+			'filters' => $this->summarize_job_filters( $args ),
 		);
 	}
 
@@ -365,9 +365,9 @@ class Jobs extends BaseRepository {
 		$query = $this->wpdb->prepare(
 			"SELECT
 				CASE
-					WHEN j.status LIKE 'agent_skipped%' THEN 'agent_skipped'
-					WHEN j.status LIKE 'completed_no_items%' THEN 'completed_no_items'
-					WHEN j.status LIKE 'failed%' THEN 'failed'
+					WHEN LEFT(j.status, 13) = 'agent_skipped' THEN 'agent_skipped'
+					WHEN LEFT(j.status, 18) = 'completed_no_items' THEN 'completed_no_items'
+					WHEN LEFT(j.status, 6) = 'failed' THEN 'failed'
 					ELSE j.status
 				END AS status,
 				COUNT(*) AS count
@@ -379,6 +379,7 @@ class Jobs extends BaseRepository {
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above from fixed SQL fragments and placeholders.
 		return $this->normalize_summary_rows( $this->wpdb->get_results( $query, ARRAY_A ) ?: array(), array( 'status' ) );
 	}
 
@@ -400,6 +401,7 @@ class Jobs extends BaseRepository {
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above from fixed SQL fragments and placeholders.
 		return $this->normalize_summary_rows( $this->wpdb->get_results( $query, ARRAY_A ) ?: array(), array( 'pipeline_id', 'pipeline_name' ) );
 	}
 
@@ -421,6 +423,7 @@ class Jobs extends BaseRepository {
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above from fixed SQL fragments and placeholders.
 		return $this->normalize_summary_rows( $this->wpdb->get_results( $query, ARRAY_A ) ?: array(), array( 'flow_id', 'flow_name', 'pipeline_id' ) );
 	}
 
@@ -457,6 +460,7 @@ class Jobs extends BaseRepository {
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above from fixed SQL fragments and placeholders.
 		return $this->normalize_summary_rows( $this->wpdb->get_results( $query, ARRAY_A ) ?: array(), array( 'handler_slug' ) );
 	}
 
@@ -478,6 +482,7 @@ class Jobs extends BaseRepository {
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above from fixed SQL fragments and placeholders.
 		return (int) $this->wpdb->get_var( $query );
 	}
 

--- a/tests/jobs-list-efficiency-smoke.php
+++ b/tests/jobs-list-efficiency-smoke.php
@@ -9,6 +9,7 @@ $root        = dirname( __DIR__ );
 $jobs_cli    = file_get_contents( $root . '/inc/Cli/Commands/JobsCommand.php' ) ?: '';
 $jobs_db     = file_get_contents( $root . '/inc/Core/Database/Jobs/Jobs.php' ) ?: '';
 $jobs_ability = file_get_contents( $root . '/inc/Abilities/Job/GetJobsAbility.php' ) ?: '';
+$jobs_summary_ability = file_get_contents( $root . '/inc/Abilities/Job/JobsSummaryAbility.php' ) ?: '';
 
 $failures = 0;
 $total    = 0;
@@ -31,6 +32,12 @@ $assert( 'get-jobs ability accepts projected fields', str_contains( $jobs_abilit
 $assert( 'jobs repository has projected SELECT path', str_contains( $jobs_db, '$select_fields       = implode' ) );
 $assert( 'jobs repository decodes engine_data only when selected', str_contains( $jobs_db, '$decode_engine_data  = in_array' ) );
 $assert( 'jobs repository keeps full SELECT as default behavior', str_contains( $jobs_db, '$select_fields       = \'j.*, p.pipeline_name, f.flow_name\'' ) );
+$assert( 'jobs summary command accepts dashboard filters', str_contains( $jobs_cli, 'wp datamachine jobs summary --pipeline=42 --since=today --format=json' ) );
+$assert( 'jobs summary ability delegates to aggregate repository query', str_contains( $jobs_summary_ability, 'get_jobs_summary( $filters )' ) );
+$assert( 'jobs repository exposes memory-safe aggregate summary query', str_contains( $jobs_db, 'function get_jobs_summary' ) );
+$assert( 'jobs summary groups status with SQL count', str_contains( $jobs_db, 'GROUP BY status' ) && str_contains( $jobs_db, 'COUNT(*) AS count' ) );
+$assert( 'jobs summary groups pipelines without selecting engine_data blobs', str_contains( $jobs_db, 'function get_pipeline_summary_rows' ) && false === strpos( substr( $jobs_db, strpos( $jobs_db, 'function get_pipeline_summary_rows' ), 1200 ), 'SELECT j.engine_data' ) );
+$assert( 'jobs summary handler aggregation avoids decoding engine_data', str_contains( $jobs_db, 'function get_handler_summary_rows' ) && false === strpos( substr( $jobs_db, strpos( $jobs_db, 'function get_handler_summary_rows' ), 1700 ), 'json_decode' ) );
 
 if ( $failures > 0 ) {
 	echo "\n=== jobs-list-efficiency-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";


### PR DESCRIPTION
## Summary
- Extends `wp datamachine jobs summary` with status, pipeline, flow, handler, and since/source filters for operator dashboards.
- Moves summary generation through aggregate SQL/count queries so dashboard use cases avoid hydrating or serializing full job rows and `engine_data` blobs.
- Adds smoke coverage for the low-memory summary path alongside the existing jobs list efficiency coverage.

## Dashboard example
`wp datamachine jobs summary --since=today --limit=500 --format=json` is no longer needed for grouped counts. Use:

`wp datamachine jobs summary --since=today --format=json`

Optional scoped examples:

`wp datamachine jobs summary --pipeline=42 --since=today --format=json`

`wp datamachine jobs summary --handler=mcp --since=today --format=json`

## Tests
- `php -l inc/Core/Database/Jobs/Jobs.php`
- `php -l inc/Cli/Commands/JobsCommand.php`
- `php -l inc/Abilities/Job/JobsSummaryAbility.php`
- `php tests/jobs-list-efficiency-smoke.php`
- `php tests/job-outcome-metrics-smoke.php`
- `vendor/bin/phpcs inc/Core/Database/Jobs/Jobs.php inc/Cli/Commands/JobsCommand.php inc/Abilities/Job/JobsSummaryAbility.php tests/jobs-list-efficiency-smoke.php`
- `homeboy test data-machine` (1300 tests, 1297 passed, 3 skipped, 0 failed)

Fixes #2242.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation and tests; Chris remains responsible for review and merge decisions.