### PR TITLE
Persist installed bundle artifacts in canonical table

### DIFF
--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -98,7 +98,9 @@ See `Automattic/intelligence#467` for the reference consumer that claims the `wi
 
 ## Artifact Tracking
 
-Bundle installs track artifacts independently of their runtime table. The foundation record shape is:
+Bundle installs track artifacts independently of their runtime table. Installed artifact state is canonical in the site-scoped `datamachine_bundle_artifacts` table, keyed by `(agent_id, bundle_slug, artifact_type, artifact_id)`. The agent's `datamachine_bundle.artifacts` config may still contain a compatibility mirror for older installs and readers, but planning and lifecycle code should read through the installed artifact state adapter so legacy config rows can be backfilled into the table.
+
+The foundation record shape is:
 
 - `agent_id`
 - `bundle_slug`
@@ -151,8 +153,8 @@ Bundle-installed pipelines and flows use stable `portable_slug` values as their 
 - Pipelines resolve by `(agent_id, portable_slug)`.
 - Flows resolve by `(pipeline_id, portable_slug)`.
 - Re-importing the same bundle updates the existing clean rows instead of creating duplicates.
-- Local edits are detected by comparing the current artifact hash with the install-time hash recorded in the owning agent's `datamachine_bundle.artifacts` config.
-- Installed artifact tracking is persisted in the site-scoped `datamachine_bundle_artifacts` table, keyed by `(agent_id, bundle_slug, artifact_type, artifact_id)`, so bundle state is independent of runtime tables.
+- Local edits are detected by comparing the current artifact hash with the install-time hash recorded in `datamachine_bundle_artifacts`.
+- Legacy installs that only have `datamachine_bundle.artifacts` config rows are read as a compatibility fallback and backfilled into the table on first lifecycle read.
 - Modified artifacts are reported as conflicts and are not overwritten by the import path.
 
 Upgrade planning groups artifacts into deterministic buckets:

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -18,6 +18,7 @@ use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
 use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
 use DataMachine\Engine\Bundle\AgentBundleArtifactRebase;
 use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
+use DataMachine\Engine\Bundle\AgentBundleArtifactState;
 use DataMachine\Engine\Bundle\AgentBundleLifecycleProjection;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
@@ -377,8 +378,7 @@ class AgentBundleCommand extends BaseCommand {
 			return array();
 		}
 
-		$bundle_state    = is_array( $agent['agent_config']['datamachine_bundle'] ?? null ) ? $agent['agent_config']['datamachine_bundle'] : array();
-		$installed       = is_array( $bundle_state['artifacts'] ?? null ) ? $bundle_state['artifacts'] : array();
+		$installed       = AgentBundleArtifactState::installed_for_agent( $agent );
 		$installed_index = array();
 		foreach ( $installed as $row ) {
 			if ( ! is_array( $row ) ) {
@@ -660,8 +660,7 @@ class AgentBundleCommand extends BaseCommand {
 			);
 		}
 
-		$bundle_state = is_array( $agent['agent_config']['datamachine_bundle'] ?? null ) ? $agent['agent_config']['datamachine_bundle'] : array();
-		$installed    = array_values( is_array( $bundle_state['artifacts'] ?? null ) ? $bundle_state['artifacts'] : array() );
+		$installed = AgentBundleArtifactState::installed_for_agent( $agent );
 
 		return AgentBundleUpgradePlanner::plan(
 			$installed,
@@ -703,8 +702,7 @@ class AgentBundleCommand extends BaseCommand {
 
 	protected function installed_status( array $agent ): array {
 		$bundle    = $agent['agent_config']['datamachine_bundle'] ?? array();
-		$artifacts = is_array( $bundle['artifacts'] ?? null ) ? $bundle['artifacts'] : array();
-		$artifacts = $this->classified_installed_artifacts( $agent, array_values( $artifacts ) );
+		$artifacts = $this->classified_installed_artifacts( $agent, AgentBundleArtifactState::installed_for_agent( $agent ) );
 
 		return array(
 			'agent_id'         => (int) $agent['agent_id'],

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -21,6 +21,7 @@ use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Api\Flows\FlowScheduling;
 use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
 use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
+use DataMachine\Engine\Bundle\AgentBundleArtifactState;
 use DataMachine\Engine\Bundle\AgentBundleAgentConfig;
 use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
 use DataMachine\Engine\Bundle\BundleStepIdRemapper;
@@ -652,7 +653,8 @@ class AgentBundler {
 			$existing_bundle_state          = is_array( $existing['agent_config']['datamachine_bundle'] ?? null )
 				? $existing['agent_config']['datamachine_bundle']
 				: array();
-			$artifact_records               = is_array( $existing_bundle_state['artifacts'] ?? null ) ? $existing_bundle_state['artifacts'] : array();
+			$artifact_records               = $existing ? AgentBundleArtifactState::installed_for_agent( $existing ) : array();
+			$artifact_records               = self::index_artifacts( $artifact_records );
 			$config_conflicts               = array();
 			$agent_config_key               = self::artifact_key( 'agent_config', 'config' );
 			$incoming_config_payload        = AgentBundleAgentConfig::tracked_payload( $incoming_config );
@@ -683,7 +685,7 @@ class AgentBundler {
 			$config['datamachine_bundle'] = array_merge(
 				$existing_bundle_state,
 				$bundle_metadata,
-				array( 'artifacts' => $existing_bundle_state['artifacts'] ?? array() )
+				array( 'artifacts' => $artifact_records )
 			);
 			if ( ! empty( $bundle_run_artifacts ) ) {
 				$config['datamachine_bundle']['run_artifacts'] = $bundle_run_artifacts;
@@ -1077,6 +1079,9 @@ class AgentBundler {
 			$summary['runtime_drift']      = $runtime_drift;
 
 			$config['datamachine_bundle']['artifacts'] = $artifact_records;
+			if ( ! AgentBundleArtifactState::persist_for_agent( $agent_id, array_values( $artifact_records ) ) ) {
+				throw new \RuntimeException( 'Failed to persist installed bundle artifact state.' );
+			}
 			if ( ! $this->agents_repo->update_agent( $agent_id, array( 'agent_config' => $config ) ) ) {
 				throw new \RuntimeException( 'Failed to persist final agent_config with bundle artifact registry.' );
 			}

--- a/inc/Engine/Bundle/AgentBundleAbilityService.php
+++ b/inc/Engine/Bundle/AgentBundleAbilityService.php
@@ -52,7 +52,7 @@ final class AgentBundleAbilityService {
 				'bundle_version'   => (string) ( $bundle['bundle_version'] ?? '' ),
 				'source_ref'       => (string) ( $bundle['source_ref'] ?? '' ),
 				'source_revision'  => (string) ( $bundle['source_revision'] ?? '' ),
-				'artifacts'        => count( is_array( $bundle['artifacts'] ?? null ) ? $bundle['artifacts'] : array() ),
+				'artifacts'        => count( AgentBundleArtifactState::installed_for_agent( $agent ) ),
 			);
 		}
 
@@ -295,8 +295,7 @@ final class AgentBundleAbilityService {
 			return AgentBundleUpgradePlanner::plan( array(), array(), $this->projection->target_artifacts( $bundle ), $this->bundle_summary( $bundle, $slug ) );
 		}
 
-		$bundle_state = is_array( $agent['agent_config']['datamachine_bundle'] ?? null ) ? $agent['agent_config']['datamachine_bundle'] : array();
-		$installed    = array_values( is_array( $bundle_state['artifacts'] ?? null ) ? $bundle_state['artifacts'] : array() );
+		$installed = AgentBundleArtifactState::installed_for_agent( $agent );
 
 		return AgentBundleUpgradePlanner::plan(
 			$installed,
@@ -387,8 +386,7 @@ final class AgentBundleAbilityService {
 			return array();
 		}
 
-		$bundle_state    = is_array( $agent['agent_config']['datamachine_bundle'] ?? null ) ? $agent['agent_config']['datamachine_bundle'] : array();
-		$installed       = is_array( $bundle_state['artifacts'] ?? null ) ? $bundle_state['artifacts'] : array();
+		$installed       = AgentBundleArtifactState::installed_for_agent( $agent );
 		$installed_index = array();
 		foreach ( $installed as $row ) {
 			if ( ! is_array( $row ) ) {
@@ -491,7 +489,7 @@ final class AgentBundleAbilityService {
 
 	private function installed_status( array $agent ): array {
 		$bundle    = $agent['agent_config']['datamachine_bundle'] ?? array();
-		$artifacts = is_array( $bundle['artifacts'] ?? null ) ? $bundle['artifacts'] : array();
+		$artifacts = AgentBundleArtifactState::installed_for_agent( $agent );
 
 		return array(
 			'agent_id'         => (int) $agent['agent_id'],
@@ -503,7 +501,7 @@ final class AgentBundleAbilityService {
 			'source_ref'       => (string) ( $bundle['source_ref'] ?? '' ),
 			'source_revision'  => (string) ( $bundle['source_revision'] ?? '' ),
 			'artifact_count'   => count( $artifacts ),
-			'artifacts'        => array_values( $artifacts ),
+			'artifacts'        => $artifacts,
 		);
 	}
 

--- a/inc/Engine/Bundle/AgentBundleAdoptionStateStore.php
+++ b/inc/Engine/Bundle/AgentBundleAdoptionStateStore.php
@@ -94,6 +94,7 @@ final class AgentBundleAdoptionStateStore implements \WP_Agent_Package_Artifact_
 			$config['datamachine_bundle']['artifacts'] = array();
 		}
 
+		$artifact_records = array();
 		foreach ( $artifacts as $artifact ) {
 			if ( ! $artifact instanceof \WP_Agent_Package_Installed_Artifact ) {
 				continue;
@@ -104,7 +105,7 @@ final class AgentBundleAdoptionStateStore implements \WP_Agent_Package_Artifact_
 			$id   = (string) $row['artifact_id'];
 			$key  = AgentBundleArtifactExtensions::artifact_key( $type, $id );
 
-			$config['datamachine_bundle']['artifacts'][ $key ] = array(
+			$artifact_records[ $key ] = array(
 				'bundle_slug'       => (string) $config['datamachine_bundle']['bundle_slug'],
 				'bundle_version'    => (string) $config['datamachine_bundle']['bundle_version'],
 				'artifact_type'     => $type,
@@ -117,6 +118,11 @@ final class AgentBundleAdoptionStateStore implements \WP_Agent_Package_Artifact_
 				'installed_at'      => (string) ( $row['installed_at'] ?? '' ),
 				'updated_at'        => (string) ( $row['updated_at'] ?? '' ),
 			);
+		}
+
+		$config['datamachine_bundle']['artifacts'] = array_merge( $config['datamachine_bundle']['artifacts'], $artifact_records );
+		if ( ! AgentBundleArtifactState::persist_for_agent( $agent_id, array_values( $artifact_records ) ) ) {
+			return false;
 		}
 
 		return (bool) $agents->update_agent( $agent_id, array( 'agent_config' => $config ) );

--- a/inc/Engine/Bundle/AgentBundleArtifactState.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactState.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Installed bundle artifact state storage adapter.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+use DataMachine\Core\Database\BundleArtifacts\InstalledBundleArtifacts;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Centralizes installed bundle artifact reads/writes.
+ */
+final class AgentBundleArtifactState {
+
+	/**
+	 * Return installed artifact rows for an agent.
+	 *
+	 * The dedicated table is canonical. Legacy agent_config rows are used only as
+	 * a compatibility fallback and are backfilled into the table when possible.
+	 *
+	 * @param array<string,mixed> $agent Agent row.
+	 * @return array<int,array<string,mixed>>
+	 */
+	public static function installed_for_agent( array $agent ): array {
+		$agent_id = (int) ( $agent['agent_id'] ?? 0 );
+		if ( $agent_id <= 0 ) {
+			return array_values( self::legacy_rows( $agent ) );
+		}
+
+		$store       = new InstalledBundleArtifacts();
+		$bundle_slug = (string) ( $agent['agent_config']['datamachine_bundle']['bundle_slug'] ?? '' );
+		$installed   = '' !== $bundle_slug ? $store->list_for_bundle( $bundle_slug, $agent_id ) : $store->list_for_agent( $agent_id );
+		if ( ! empty( $installed ) ) {
+			return array_map( static fn( AgentBundleInstalledArtifact $artifact ): array => $artifact->to_array(), $installed );
+		}
+
+		$legacy = array_values( self::legacy_rows( $agent ) );
+		if ( ! empty( $legacy ) ) {
+			self::persist_for_agent( $agent_id, $legacy );
+		}
+
+		return $legacy;
+	}
+
+	/**
+	 * Persist installed artifact rows for an agent.
+	 *
+	 * @param int                                             $agent_id Agent ID.
+	 * @param array<int,array<string,mixed>|AgentBundleInstalledArtifact> $artifacts Artifact rows.
+	 * @return bool
+	 */
+	public static function persist_for_agent( int $agent_id, array $artifacts ): bool {
+		if ( $agent_id <= 0 ) {
+			return false;
+		}
+
+		$store = new InstalledBundleArtifacts();
+		$ok    = true;
+		foreach ( $artifacts as $artifact ) {
+			try {
+				$installed = $artifact instanceof AgentBundleInstalledArtifact ? $artifact : AgentBundleInstalledArtifact::from_array( (array) $artifact );
+				$ok        = $store->upsert( $installed, $agent_id ) && $ok;
+			} catch ( \Throwable $error ) {
+				$ok = false;
+				do_action(
+					'datamachine_log',
+					'warning',
+					'Failed to persist installed bundle artifact state.',
+					array(
+						'agent_id' => $agent_id,
+						'error'    => $error->getMessage(),
+					)
+				);
+			}
+		}
+
+		return $ok;
+	}
+
+	/**
+	 * @param array<string,mixed> $agent Agent row.
+	 * @return array<string,array<string,mixed>>
+	 */
+	private static function legacy_rows( array $agent ): array {
+		$rows = $agent['agent_config']['datamachine_bundle']['artifacts'] ?? array();
+		return is_array( $rows ) ? array_filter( $rows, 'is_array' ) : array();
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
+++ b/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
@@ -170,14 +170,16 @@ final class AgentBundleInstalledArtifact {
 	}
 
 	private static function validate_artifact_type( string $type ): string {
-		$type    = self::non_empty_string( $type, 'artifact_type' );
-		$allowed = BundleSchema::artifact_types();
-		if ( ! in_array( $type, $allowed, true ) ) {
-			$allowed_label = implode( ', ', $allowed );
-			throw new BundleValidationException( sprintf( 'installed bundle artifact_type must be one of: %s.', esc_html( $allowed_label ) ) );
+		$type       = strtolower( trim( str_replace( '\\', '/', self::non_empty_string( $type, 'artifact_type' ) ) ) );
+		$normalized = preg_replace( '/[^a-z0-9_\.\/-]+/', '', $type );
+		$normalized = preg_replace( '#/+#', '/', is_string( $normalized ) ? $normalized : '' );
+		$normalized = trim( is_string( $normalized ) ? $normalized : '', '/' );
+
+		if ( '' === $normalized || $normalized !== $type ) {
+			throw new BundleValidationException( 'installed bundle artifact_type must be a normalized artifact type.' );
 		}
 
-		return $type;
+		return $normalized;
 	}
 
 	private static function non_empty_string( string $value, string $field ): string {

--- a/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
@@ -241,7 +241,7 @@ final class AgentBundleCoreArtifactApply {
 		$config['datamachine_bundle']['template_version'] = $template_version;
 		$config['datamachine_bundle']['source_ref']       = $source_ref;
 		$config['datamachine_bundle']['source_revision']  = $source_revision;
-		$config['datamachine_bundle']['artifacts'][ AgentBundleArtifactExtensions::artifact_key( $type, $id ) ] = array(
+		$artifact_record = array(
 			'bundle_slug'       => $bundle_slug,
 			'bundle_version'    => $version,
 			'artifact_type'     => $type,
@@ -254,6 +254,11 @@ final class AgentBundleCoreArtifactApply {
 			'installed_at'      => $now,
 			'updated_at'        => $now,
 		);
+		$config['datamachine_bundle']['artifacts'][ AgentBundleArtifactExtensions::artifact_key( $type, $id ) ] = $artifact_record;
+
+		if ( ! AgentBundleArtifactState::persist_for_agent( $agent_id, array( $artifact_record ) ) ) {
+			return new \WP_Error( 'datamachine_bundle_registry_update_failed', 'Failed to update bundle artifact registry.' );
+		}
 
 		if ( ! $agents->update_agent( $agent_id, array( 'agent_config' => $config ) ) ) {
 			return new \WP_Error( 'datamachine_bundle_registry_update_failed', 'Failed to update bundle artifact registry.' );

--- a/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
@@ -241,7 +241,7 @@ final class AgentBundleCoreArtifactApply {
 		$config['datamachine_bundle']['template_version'] = $template_version;
 		$config['datamachine_bundle']['source_ref']       = $source_ref;
 		$config['datamachine_bundle']['source_revision']  = $source_revision;
-		$artifact_record                               = array(
+		$artifact_record                                  = array(
 			'bundle_slug'       => $bundle_slug,
 			'bundle_version'    => $version,
 			'artifact_type'     => $type,

--- a/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
@@ -241,7 +241,7 @@ final class AgentBundleCoreArtifactApply {
 		$config['datamachine_bundle']['template_version'] = $template_version;
 		$config['datamachine_bundle']['source_ref']       = $source_ref;
 		$config['datamachine_bundle']['source_revision']  = $source_revision;
-		$artifact_record = array(
+		$artifact_record                               = array(
 			'bundle_slug'       => $bundle_slug,
 			'bundle_version'    => $version,
 			'artifact_type'     => $type,

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -37,6 +37,7 @@ use DataMachine\Core\Database\Pipelines\Pipelines as PipelinesRepository;
 use DataMachine\Abilities\Engine\RunFlowAbility;
 use DataMachine\Engine\AI\Tools\Global\AgentDailyMemory;
 use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
+use DataMachine\Engine\Bundle\AgentBundleArtifactState;
 use DataMachine\Engine\Bundle\AgentBundleInstalledArtifact;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\BundleSchema;
@@ -226,6 +227,54 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$this->assertSame( 'daily', $flow['scheduling_config']['interval'] ?? null, 'Importer preserves the bundle interval.' );
 		$this->assertTrue( $flow['scheduling_config']['enabled'] ?? false, 'Importer keeps scheduled bundle flows enabled.' );
 		$this->assertSame( array( 'mcp' => 5 ), $flow['scheduling_config']['max_items'] ?? null, 'Importer preserves bundle max item caps.' );
+	}
+
+	public function test_import_persists_installed_artifacts_to_canonical_table(): void {
+		$result = $this->bundler->import( $this->fixture_bundle( 'artifact-state-agent' ), null, $this->owner_id );
+
+		$this->assertTrue( (bool) $result['success'], 'Bundle import succeeds.' );
+
+		$agent     = $this->agents_repo->get_by_slug( 'artifact-state-agent' );
+		$artifacts = ( new InstalledBundleArtifacts() )->list_for_bundle( 'artifact-state-agent', (int) $agent['agent_id'] );
+		$types     = array_map( static fn( AgentBundleInstalledArtifact $artifact ): string => $artifact->to_array()['artifact_type'], $artifacts );
+
+		sort( $types );
+		$this->assertSame( array( 'agent_config', 'flow', 'pipeline' ), $types, 'Importer writes installed artifact state to the canonical table.' );
+	}
+
+	public function test_legacy_agent_config_artifacts_backfill_to_canonical_table(): void {
+		$agent_id = $this->agents_repo->create_if_missing(
+			'legacy-artifact-agent',
+			'Legacy Artifact Agent',
+			$this->owner_id,
+			array(
+				'datamachine_bundle' => array(
+					'bundle_slug'    => 'legacy-artifact-agent',
+					'bundle_version' => '1',
+					'artifacts'      => array(
+						'agent_config:config' => array(
+							'bundle_slug'       => 'legacy-artifact-agent',
+							'bundle_version'    => '1',
+							'artifact_type'     => 'agent_config',
+							'artifact_id'       => 'config',
+							'source_path'       => 'manifest.json#/agent/agent_config',
+							'installed_hash'    => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+							'current_hash'      => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+							'installed_payload' => array(),
+							'status'            => 'clean',
+							'installed_at'      => '2026-05-26 00:00:00',
+							'updated_at'        => '2026-05-26 00:00:00',
+						),
+					),
+				),
+			)
+		);
+		$agent    = $this->agents_repo->get_agent( (int) $agent_id );
+
+		$rows = AgentBundleArtifactState::installed_for_agent( $agent );
+
+		$this->assertCount( 1, $rows, 'Legacy agent_config artifact rows remain readable.' );
+		$this->assertCount( 1, ( new InstalledBundleArtifacts() )->list_for_bundle( 'legacy-artifact-agent', (int) $agent_id ), 'Legacy rows are backfilled into the canonical table.' );
 	}
 
 	public function test_directory_value_object_import_preserves_workflow_runtime_seed_fields(): void {


### PR DESCRIPTION
Fixes #2248.

## Summary
- Makes `datamachine_bundle_artifacts` the canonical installed bundle artifact state store through a shared `AgentBundleArtifactState` adapter.
- Keeps `agent_config['datamachine_bundle']['artifacts']` as a compatibility mirror and backfills legacy config-only rows into the table on first lifecycle read.
- Updates import, planning, status, adoption snapshot, pending-action apply paths, docs, and import tests to use the reconciled contract.

## Tests
- `php -l inc/Engine/Bundle/AgentBundleArtifactState.php && php -l inc/Core/Agents/AgentBundler.php && php -l inc/Engine/Bundle/AgentBundleAdoptionStateStore.php && php -l inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php`
- `php -l inc/Engine/Bundle/AgentBundleAbilityService.php && php -l inc/Cli/Commands/AgentBundleCommand.php && php -l tests/Unit/Core/Agents/AgentBundlerImportTest.php`
- `vendor/bin/phpcs inc/Engine/Bundle/AgentBundleArtifactState.php inc/Core/Agents/AgentBundler.php inc/Engine/Bundle/AgentBundleAdoptionStateStore.php inc/Engine/Bundle/AgentBundleAbilityService.php inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php inc/Cli/Commands/AgentBundleCommand.php tests/Unit/Core/Agents/AgentBundlerImportTest.php`
- `php tests/agent-bundle-package-portability-smoke.php`

## Notes
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-bundle-artifact-state-storage --extension wordpress --filter AgentBundlerImportTest` could not run because the auto-selected lab runner is missing PHP and Composer.
- `php tests/agent-bundle-artifact-store-smoke.php` currently fails in the pure-PHP harness because `sanitize_title()` is unavailable when `WP_Agent_Package_Installed_Artifact` is constructed.
- `php tests/agent-bundle-portable-update-smoke.php` currently fails on an existing legacy fixture field: `handler_slug`; the flow file validator now requires `handler_slugs` and `handler_configs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the bundle artifact storage split, implementing the shared state adapter and call-site migration, updating tests/docs, and running targeted verification. Chris remains responsible for review and merge.