### PR TITLE
Add bundle validate and inspect surfaces

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "672cbc46442928602f2a2e94256177b08ca93aae"
+                "reference": "f75cf68b3aa316953ed9da594a51f01b19fd6e04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/672cbc46442928602f2a2e94256177b08ca93aae",
-                "reference": "672cbc46442928602f2a2e94256177b08ca93aae",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/f75cf68b3aa316953ed9da594a51f01b19fd6e04",
+                "reference": "f75cf68b3aa316953ed9da594a51f01b19fd6e04",
                 "shasum": ""
             },
             "require": {
@@ -39,6 +39,7 @@
                     "php tests/message-envelope-smoke.php",
                     "php tests/registry-smoke.php",
                     "php tests/package-lifecycle-smoke.php",
+                    "php tests/package-capability-contract-smoke.php",
                     "php tests/package-adoption-orchestration-smoke.php",
                     "php tests/execution-principal-smoke.php",
                     "php tests/effective-agent-resolver-smoke.php",
@@ -100,7 +101,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-25T19:51:55+00:00"
+            "time": "2026-05-25T22:17:42+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",

--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -87,6 +87,7 @@ See `Automattic/intelligence#467` for the reference consumer that claims the `wi
 - `exported_at` and `exported_by`: export metadata.
 - `agent`: `slug`, `label`, `description`, and `agent_config` defaults.
 - `included`: lists of `memory`, `pipelines`, `flows`, `prompts`, `rubrics`, `tool_policies`, `auth_refs`, and `seed_queues`, plus `handler_auth` mode.
+- `capabilities`: optional package-level capability strings required by the bundle.
 
 `handler_auth` is one of:
 
@@ -222,6 +223,26 @@ Bundles have two plugin-extension surfaces with different contracts:
 
 Use extras for bulk opaque content where Data Machine should not inspect individual files. Use extension artifacts when each item needs stable identity, hashes, status, and upgrade behavior.
 
+## Validation And Inspection
+
+`inspect` and `validate` are read-only lifecycle surfaces. They resolve and parse a bundle, project it to an Agents API `WP_Agent_Package`, and run `WP_Agent_Package_Capability_Checker` against Data Machine's host capability list.
+
+The compatibility report shape is stable for automation:
+
+```json
+{
+  "compatible": true,
+  "status": "compatible",
+  "required_capabilities": [],
+  "host_capabilities": ["datamachine", "datamachine/agent-bundle"],
+  "unsupported_capabilities": [],
+  "unknown_artifact_types": [],
+  "unsupported_artifacts": []
+}
+```
+
+Plugins can extend the host capability list with the `datamachine_agent_bundle_host_capabilities` filter. Unsupported package-level requirements appear in `unsupported_capabilities`; unknown artifact types and unsupported artifact-level `requires` entries appear in `unsupported_artifacts`.
+
 ## CLI
 
 Agent package operations live under `wp datamachine agent`:
@@ -231,6 +252,8 @@ Agent package operations live under `wp datamachine agent`:
 - `export <agent>` writes an agent identity, memory, pipelines, and flows to a portable bundle.
 - `installed` reports installed package-backed agents without clobbering `agent list`.
 - `status <slug>` reports installed version and tracked artifact state by agent slug or bundle slug.
+- `inspect <path|url>` loads a bundle without writing and returns package metadata plus compatibility details.
+- `validate <path|url>` loads a bundle without writing and returns whether Data Machine can support its declared package and artifact requirements.
 - `diff <path|url>` builds a read-only upgrade plan.
 - `upgrade <path|url>` applies clean updates and stages locally modified artifacts as PendingActions.
 - `rebase <path|url>` previews 3-way merges for locally modified bundle artifacts.

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -389,6 +389,46 @@ class AgentAbilities {
 			);
 
 			wp_register_ability(
+				'datamachine/inspect-agent-bundle',
+				array(
+					'label'               => 'Inspect Agent Bundle',
+					'description'         => 'Load an agent bundle without writing and return projected package metadata plus host compatibility.',
+					'category'            => 'datamachine-agent',
+					'input_schema'        => self::bundleLifecycleInputSchema(),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'inspectAgentBundle' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'readonly'   => true,
+							'idempotent' => true,
+						),
+					),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/validate-agent-bundle',
+				array(
+					'label'               => 'Validate Agent Bundle',
+					'description'         => 'Validate an agent bundle without writing and report unsupported host capabilities or artifact requirements.',
+					'category'            => 'datamachine-agent',
+					'input_schema'        => self::bundleLifecycleInputSchema(),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'validateAgentBundle' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'readonly'   => true,
+							'idempotent' => true,
+						),
+					),
+				)
+			);
+
+			wp_register_ability(
 				'datamachine/get-agent-bundle-status',
 				array(
 					'label'               => 'Get Agent Bundle Status',
@@ -1305,6 +1345,26 @@ class AgentAbilities {
 	 */
 	public static function getAgentBundleStatus( array $input ): array {
 		return self::bundleLifecycleService()->status( (string) ( $input['slug'] ?? '' ) );
+	}
+
+	/**
+	 * Inspect a bundle without writing runtime state.
+	 *
+	 * @param array $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public static function inspectAgentBundle( array $input ): array {
+		return self::bundleLifecycleService()->inspect( $input );
+	}
+
+	/**
+	 * Validate a bundle without writing runtime state.
+	 *
+	 * @param array $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public static function validateAgentBundle( array $input ): array {
+		return self::bundleLifecycleService()->validate( $input );
 	}
 
 	/**

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -141,6 +141,80 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	/**
+	 * Inspect an agent package from a local file, directory, or URL without writing.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <path>
+	 * : Package path (.zip, .json, or directory) or remote URL.
+	 *
+	 * [--slug=<slug>]
+	 * : Override target agent slug for summary output.
+	 *
+	 * [--token=<token>]
+	 * : Auth token for private archive downloads. Used for this single resolve(); never persisted, never logged.
+	 *
+	 * [--token-env=<varname>]
+	 * : Environment variable (or PHP constant) name to read the auth token from. Preferred over --token for shell-history hygiene.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: json
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function inspect( array $args, array $assoc_args ): void {
+		$response = AgentAbilities::inspectAgentBundle( $this->bundle_ability_input( $args, $assoc_args ) );
+		if ( empty( $response['success'] ) ) {
+			WP_CLI::error( (string) ( $response['error'] ?? 'Bundle inspect failed.' ) );
+			return;
+		}
+
+		$assoc_args['format'] = $assoc_args['format'] ?? 'json';
+		$this->output( $response, $assoc_args, array( 'success' ) );
+	}
+
+	/**
+	 * Validate an agent package from a local file, directory, or URL without writing.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <path>
+	 * : Package path (.zip, .json, or directory) or remote URL.
+	 *
+	 * [--slug=<slug>]
+	 * : Override target agent slug for summary output.
+	 *
+	 * [--token=<token>]
+	 * : Auth token for private archive downloads. Used for this single resolve(); never persisted, never logged.
+	 *
+	 * [--token-env=<varname>]
+	 * : Environment variable (or PHP constant) name to read the auth token from. Preferred over --token for shell-history hygiene.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: json
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function validate( array $args, array $assoc_args ): void {
+		$response = AgentAbilities::validateAgentBundle( $this->bundle_ability_input( $args, $assoc_args ) );
+		if ( empty( $response['success'] ) ) {
+			WP_CLI::error( (string) ( $response['error'] ?? 'Bundle validation failed.' ) );
+			return;
+		}
+
+		$assoc_args['format'] = $assoc_args['format'] ?? 'json';
+		$this->output( $response, $assoc_args, array( 'valid', 'status' ) );
+	}
+
+	/**
 	 * Show an upgrade diff for a package path.
 	 *
 	 * ## OPTIONS

--- a/inc/Engine/Bundle/AgentBundleAbilityService.php
+++ b/inc/Engine/Bundle/AgentBundleAbilityService.php
@@ -100,6 +100,50 @@ final class AgentBundleAbilityService {
 	}
 
 	/** @return array<string,mixed> */
+	public function inspect( array $input ): array {
+		$loaded = $this->load_bundle_from_input( $input );
+		if ( empty( $loaded['success'] ) ) {
+			return $loaded;
+		}
+
+		$bundle        = $loaded['bundle'];
+		$package       = AgentPackageProjection::from_array_bundle( $bundle );
+		$compatibility = self::capability_report( $package )->to_array();
+
+		return array(
+			'success'       => true,
+			'bundle'        => $this->bundle_summary( $bundle, (string) ( $input['slug'] ?? '' ) ),
+			'package'       => $package->to_array(),
+			'compatibility' => $compatibility,
+		);
+	}
+
+	/** @return array<string,mixed> */
+	public function validate( array $input ): array {
+		$inspect = $this->inspect( $input );
+		if ( empty( $inspect['success'] ) ) {
+			return array_merge(
+				$inspect,
+				array(
+					'valid'  => false,
+					'status' => 'invalid',
+				)
+			);
+		}
+
+		$compatibility = is_array( $inspect['compatibility'] ?? null ) ? $inspect['compatibility'] : array();
+		$compatible    = ! empty( $compatibility['compatible'] );
+
+		return array(
+			'success'       => true,
+			'valid'         => $compatible,
+			'status'        => $compatible ? 'valid' : 'unsupported',
+			'bundle'        => $inspect['bundle'],
+			'compatibility' => $compatibility,
+		);
+	}
+
+	/** @return array<string,mixed> */
 	public function rebase( array $input ): array {
 		$loaded = $this->load_bundle_from_input( $input );
 		if ( empty( $loaded['success'] ) ) {
@@ -304,6 +348,54 @@ final class AgentBundleAbilityService {
 			$this->projection->target_artifacts( $bundle, $agent ),
 			$this->bundle_summary( $bundle, $slug )
 		);
+	}
+
+	public static function capability_report( \WP_Agent_Package $package ): \WP_Agent_Package_Capability_Report {
+		if ( function_exists( 'wp_get_agent_package_artifact_types' ) && function_exists( 'do_action' ) && ( ! function_exists( 'did_action' ) || 0 === did_action( 'wp_agent_package_artifacts_init' ) ) ) {
+			do_action( 'wp_agent_package_artifacts_init' );
+		}
+
+		return \WP_Agent_Package_Capability_Checker::check( $package, self::host_capabilities() );
+	}
+
+	/** @return array<int,string> */
+	public static function host_capabilities(): array {
+		$capabilities = array(
+			'datamachine',
+			'datamachine/agent',
+			'datamachine/agent-bundle',
+			'datamachine/bundle-schema-v1',
+			'datamachine/pipeline',
+			'datamachine/flow',
+			'datamachine/prompt',
+			'datamachine/rubric',
+			'datamachine/tool-policy',
+			'datamachine/auth-ref',
+			'datamachine/queue-seed',
+		);
+
+		/**
+		 * Extend host capability strings used for read-only bundle compatibility checks.
+		 *
+		 * @param array<int,string> $capabilities Data Machine host capabilities.
+		 */
+		$capabilities = function_exists( 'apply_filters' ) ? apply_filters( 'datamachine_agent_bundle_host_capabilities', $capabilities ) : $capabilities;
+		if ( ! is_array( $capabilities ) ) {
+			$capabilities = array();
+		}
+
+		$normalized = array();
+		foreach ( $capabilities as $capability ) {
+			$capability = trim( strtolower( (string) $capability ) );
+			if ( '' !== $capability ) {
+				$normalized[] = $capability;
+			}
+		}
+
+		$normalized = array_values( array_unique( $normalized ) );
+		sort( $normalized, SORT_STRING );
+
+		return $normalized;
 	}
 
 	private function add_runtime_drift_to_plan( array $plan, array $bundle, string $slug = '', string $decision = 'preserve_existing' ): array {

--- a/inc/Engine/Bundle/AgentBundleArrayAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleArrayAdapter.php
@@ -46,7 +46,8 @@ final class AgentBundleArrayAdapter {
 				'flows'        => array_values( $flow_slugs ),
 				'handler_auth' => 'refs',
 			),
-			BundleSchema::normalize_run_artifact_egress_policy( $bundle['run_artifacts'] ?? array() )
+			BundleSchema::normalize_run_artifact_egress_policy( $bundle['run_artifacts'] ?? array() ),
+			is_array( $bundle['capabilities'] ?? null ) ? $bundle['capabilities'] : array()
 		);
 
 		return new AgentBundleDirectory(
@@ -162,6 +163,9 @@ final class AgentBundleArrayAdapter {
 		$run_artifacts = BundleSchema::normalize_run_artifact_egress_policy( $manifest['run_artifacts'] ?? array() );
 		if ( ! empty( $run_artifacts ) ) {
 			$bundle['run_artifacts'] = $run_artifacts;
+		}
+		if ( ! empty( $manifest['capabilities'] ) && is_array( $manifest['capabilities'] ) ) {
+			$bundle['capabilities'] = $manifest['capabilities'];
 		}
 
 		return $bundle;

--- a/inc/Engine/Bundle/AgentBundleArtifactExtensions.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactExtensions.php
@@ -100,12 +100,17 @@ final class AgentBundleArtifactExtensions {
 				continue;
 			}
 
-			$normalized[] = array(
+			$normalized_artifact = array(
 				'artifact_type' => $type,
 				'artifact_id'   => $id,
 				'source_path'   => $source_path,
 				'payload'       => $artifact['payload'] ?? null,
 			);
+			if ( is_array( $artifact['requires'] ?? null ) ) {
+				$normalized_artifact['requires'] = self::string_list( $artifact['requires'] );
+			}
+
+			$normalized[] = $normalized_artifact;
 		}
 
 		usort(
@@ -161,6 +166,21 @@ final class AgentBundleArtifactExtensions {
 		$type = trim( is_string( $type ) ? $type : '', '/' );
 
 		return $type;
+	}
+
+	private static function string_list( array $values ): array {
+		$normalized = array();
+		foreach ( $values as $value ) {
+			$value = trim( strtolower( (string) $value ) );
+			if ( '' !== $value ) {
+				$normalized[] = $value;
+			}
+		}
+
+		$normalized = array_values( array_unique( $normalized ) );
+		sort( $normalized, SORT_STRING );
+
+		return $normalized;
 	}
 
 	private static function sanitize_key( string $key ): string {

--- a/inc/Engine/Bundle/AgentBundleManifest.php
+++ b/inc/Engine/Bundle/AgentBundleManifest.php
@@ -23,8 +23,9 @@ final class AgentBundleManifest {
 	private array $agent;
 	private array $included;
 	private array $run_artifacts;
+	private array $capabilities;
 
-	public function __construct( string $exported_at, string $exported_by, string $bundle_slug, string $bundle_version, string $source_ref, string $source_revision, array $agent, array $included, array $run_artifacts = array() ) {
+	public function __construct( string $exported_at, string $exported_by, string $bundle_slug, string $bundle_version, string $source_ref, string $source_revision, array $agent, array $included, array $run_artifacts = array(), array $capabilities = array() ) {
 		$this->exported_at     = $exported_at;
 		$this->exported_by     = $exported_by;
 		$this->bundle_slug     = PortableSlug::normalize( $bundle_slug, 'bundle' );
@@ -34,6 +35,7 @@ final class AgentBundleManifest {
 		$this->agent           = self::validate_agent( $agent );
 		$this->included        = self::validate_included( $included );
 		$this->run_artifacts   = BundleSchema::normalize_run_artifact_egress_policy( $run_artifacts );
+		$this->capabilities    = self::validate_string_list( $capabilities, 'capabilities' );
 	}
 
 	/**
@@ -64,7 +66,8 @@ final class AgentBundleManifest {
 			(string) ( $data['source_revision'] ?? '' ),
 			$data['agent'],
 			$data['included'],
-			is_array( $data['run_artifacts'] ?? null ) ? $data['run_artifacts'] : array()
+			is_array( $data['run_artifacts'] ?? null ) ? $data['run_artifacts'] : array(),
+			is_array( $data['capabilities'] ?? null ) ? $data['capabilities'] : array()
 		);
 	}
 
@@ -88,6 +91,9 @@ final class AgentBundleManifest {
 
 		if ( ! empty( $this->run_artifacts ) ) {
 			$data['run_artifacts'] = $this->run_artifacts;
+		}
+		if ( ! empty( $this->capabilities ) ) {
+			$data['capabilities'] = $this->capabilities;
 		}
 
 		return $data;
@@ -124,6 +130,10 @@ final class AgentBundleManifest {
 
 	public function run_artifacts(): array {
 		return $this->run_artifacts;
+	}
+
+	public function capabilities(): array {
+		return $this->capabilities;
 	}
 
 	private static function validate_agent( array $agent ): array {
@@ -185,6 +195,25 @@ final class AgentBundleManifest {
 			'extensions'    => $included['extensions'],
 			'handler_auth'  => $included['handler_auth'],
 		);
+	}
+
+	private static function validate_string_list( array $values, string $field ): array {
+		if ( ! array_is_list( $values ) ) {
+			throw new BundleValidationException( sprintf( 'manifest.json %s must be a list.', esc_html( $field ) ) );
+		}
+
+		$normalized = array();
+		foreach ( $values as $value ) {
+			$value = trim( strtolower( (string) $value ) );
+			if ( '' !== $value ) {
+				$normalized[] = $value;
+			}
+		}
+
+		$normalized = array_values( array_unique( $normalized ) );
+		sort( $normalized, SORT_STRING );
+
+		return $normalized;
 	}
 
 	private static function validate_version_string( string $value, string $field ): string {

--- a/inc/Engine/Bundle/AgentPackageProjection.php
+++ b/inc/Engine/Bundle/AgentPackageProjection.php
@@ -25,11 +25,12 @@ final class AgentPackageProjection {
 
 		return \WP_Agent_Package::from_array(
 			array(
-				'slug'      => (string) $manifest['bundle_slug'],
-				'version'   => (string) $manifest['bundle_version'],
-				'agent'     => self::agent_from_manifest( $manifest ),
-				'artifacts' => self::artifacts_from_directory( $directory ),
-				'meta'      => self::meta_from_manifest( $manifest ),
+				'slug'         => (string) $manifest['bundle_slug'],
+				'version'      => (string) $manifest['bundle_version'],
+				'agent'        => self::agent_from_manifest( $manifest ),
+				'capabilities' => self::string_list( is_array( $manifest['capabilities'] ?? null ) ? $manifest['capabilities'] : array() ),
+				'artifacts'    => self::artifacts_from_directory( $directory ),
+				'meta'         => self::meta_from_manifest( $manifest ),
 			)
 		);
 	}
@@ -145,7 +146,8 @@ final class AgentPackageProjection {
 				array(
 					'extension_artifact_type' => $artifact_type,
 					'payload_kind'            => 'json',
-				)
+				),
+				self::string_list( is_array( $artifact['requires'] ?? null ) ? $artifact['requires'] : array() )
 			);
 		}
 
@@ -193,8 +195,8 @@ final class AgentPackageProjection {
 	 * @param array<string,mixed> $meta   Artifact metadata.
 	 * @return array<string,mixed>
 	 */
-	private static function artifact( string $type, string $slug, string $label, string $source, array $meta = array() ): array {
-		return array(
+	private static function artifact( string $type, string $slug, string $label, string $source, array $meta = array(), array $requires = array() ): array {
+		$artifact = array(
 			'type'   => $type,
 			'slug'   => $slug,
 			'label'  => $label,
@@ -206,6 +208,33 @@ final class AgentPackageProjection {
 				$meta
 			),
 		);
+
+		if ( ! empty( $requires ) ) {
+			$artifact['requires'] = self::string_list( $requires );
+		}
+
+		return $artifact;
+	}
+
+	/**
+	 * Normalize capability strings for package declarations.
+	 *
+	 * @param array<int,mixed> $values Raw capability values.
+	 * @return array<int,string>
+	 */
+	private static function string_list( array $values ): array {
+		$normalized = array();
+		foreach ( $values as $value ) {
+			$value = trim( strtolower( (string) $value ) );
+			if ( '' !== $value ) {
+				$normalized[] = $value;
+			}
+		}
+
+		$normalized = array_values( array_unique( $normalized ) );
+		sort( $normalized, SORT_STRING );
+
+		return $normalized;
 	}
 
 	/**

--- a/tests/bundle-validate-inspect-smoke.php
+++ b/tests/bundle-validate-inspect-smoke.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Pure-PHP smoke test for read-only bundle validate/inspect compatibility.
+ *
+ * Run with: php tests/bundle-validate-inspect-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failures = array();
+$passes   = 0;
+
+echo "bundle-validate-inspect-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+agents_api_smoke_require_module();
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/register-agent-package-artifacts.php';
+
+use DataMachine\Engine\Bundle\AgentBundleAbilityService;
+use DataMachine\Engine\Bundle\AgentBundleDirectory;
+use DataMachine\Engine\Bundle\AgentBundleFlowFile;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
+use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
+use DataMachine\Engine\Bundle\AgentPackageProjection;
+use DataMachine\Engine\Bundle\BundleSchema;
+
+function datamachine_bundle_validate_smoke_reset_registry(): void {
+	do_action( 'init' );
+	WP_Agent_Package_Artifacts_Registry::reset_for_tests();
+	do_action( 'wp_agent_package_artifacts_init' );
+}
+
+echo "\n[1] Valid Data Machine bundle projects and passes host capability checks:\n";
+datamachine_bundle_validate_smoke_reset_registry();
+
+$directory = new AgentBundleDirectory(
+	new AgentBundleManifest(
+		'2026-05-25T12:00:00Z',
+		'data-machine/test',
+		'Valid Package',
+		'1.0.0',
+		'',
+		'',
+		array(
+			'slug'         => 'valid-agent',
+			'label'        => 'Valid Agent',
+			'description'  => 'Validates package compatibility.',
+			'agent_config' => array(),
+		),
+		array(
+			'memory'        => array(),
+			'pipelines'     => array( 'daily-ingest' ),
+			'flows'         => array( 'daily-ingest-flow' ),
+			'prompts'       => array( 'daily-prompt' ),
+			'rubrics'       => array(),
+			'tool_policies' => array(),
+			'auth_refs'     => array(),
+			'seed_queues'   => array(),
+			'extensions'    => array(),
+			'handler_auth'  => 'refs',
+		),
+		array(),
+		array( 'datamachine/agent-bundle' )
+	),
+	array(),
+	array(
+		new AgentBundlePipelineFile(
+			'daily-ingest',
+			'Daily ingest',
+			array(
+				array(
+					'step_position' => 0,
+					'step_type'     => 'fetch',
+					'step_config'   => array(),
+				),
+			)
+		),
+	),
+	array(
+		new AgentBundleFlowFile(
+			'daily-ingest-flow',
+			'Daily ingest flow',
+			'daily-ingest',
+			'manual',
+			array(),
+			array(
+				array(
+					'step_position'   => 0,
+					'step_type'       => 'fetch',
+					'handler_configs' => array(),
+				),
+			)
+		),
+	),
+	array(
+		BundleSchema::PROMPTS_DIR => array( 'daily-prompt.md' => "Run the daily ingest.\n" ),
+	)
+);
+
+$package = AgentPackageProjection::from_directory( $directory );
+$report  = AgentBundleAbilityService::capability_report( $package )->to_array();
+agents_api_smoke_assert_equals( true, $report['compatible'] ?? false, 'valid bundle is compatible with Data Machine host capabilities', $failures, $passes );
+agents_api_smoke_assert_equals( array(), $report['unsupported_capabilities'] ?? null, 'valid bundle has no unsupported package capabilities', $failures, $passes );
+agents_api_smoke_assert_equals( array(), $report['unsupported_artifacts'] ?? null, 'valid bundle has no unsupported artifacts', $failures, $passes );
+
+echo "\n[2] Projected extension artifact requirements are reported as unsupported:\n";
+add_filter(
+	'datamachine_agent_bundle_artifact_types',
+	static function ( array $types ): array {
+		$types[] = 'intelligence/wiki-brain';
+		return $types;
+	},
+	10,
+	1
+);
+datamachine_bundle_validate_smoke_reset_registry();
+$extension_directory = new AgentBundleDirectory(
+	new AgentBundleManifest(
+		'2026-05-25T12:00:00Z',
+		'data-machine/test',
+		'Extension Package',
+		'1.0.0',
+		'',
+		'',
+		array(
+			'slug'         => 'extension-agent',
+			'label'        => 'Extension Agent',
+			'description'  => '',
+			'agent_config' => array(),
+		),
+		array(
+			'memory'        => array(),
+			'pipelines'     => array(),
+			'flows'         => array(),
+			'prompts'       => array(),
+			'rubrics'       => array(),
+			'tool_policies' => array(),
+			'auth_refs'     => array(),
+			'seed_queues'   => array(),
+			'extensions'    => array( 'extensions/intelligence/wiki-brain/woocommerce.json' ),
+			'handler_auth'  => 'refs',
+		)
+	),
+	array(),
+	array(),
+	array(),
+	array(),
+	array(
+		array(
+			'artifact_type' => 'intelligence/wiki-brain',
+			'artifact_id'   => 'woocommerce',
+			'source_path'   => 'extensions/intelligence/wiki-brain/woocommerce.json',
+			'payload'       => array( 'root' => 'woocommerce' ),
+			'requires'      => array( 'intelligence/wiki-brain' ),
+		),
+	)
+);
+$extension_report = AgentBundleAbilityService::capability_report( AgentPackageProjection::from_directory( $extension_directory ) )->to_array();
+agents_api_smoke_assert_equals( false, $extension_report['compatible'] ?? true, 'bundle with unsupported extension requirement is incompatible', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'intelligence/wiki-brain' ), $extension_report['unsupported_capabilities'] ?? null, 'unsupported artifact requirement is promoted to required capabilities', $failures, $passes );
+agents_api_smoke_assert_equals( 'intelligence/wiki-brain:woocommerce', $extension_report['unsupported_artifacts'][0]['artifact_key'] ?? '', 'unsupported extension artifact carries stable key', $failures, $passes );
+
+echo "\n[3] Unsupported capability and unknown artifact reports stay machine-readable:\n";
+$unsupported_package = WP_Agent_Package::from_array(
+	array(
+		'slug'         => 'unsupported-package',
+		'version'      => '1.0.0',
+		'agent'        => array(
+			'slug'           => 'unsupported-agent',
+			'label'          => 'Unsupported Agent',
+			'description'    => '',
+			'default_config' => array(),
+		),
+		'capabilities' => array( 'datamachine/agent-bundle', 'intelligence/wiki-brain' ),
+		'artifacts'    => array(
+			array(
+				'type'     => 'unknown/vendor-artifact',
+				'slug'     => 'opaque-seed',
+				'label'    => 'Opaque seed',
+				'source'   => 'extensions/unknown/vendor-artifact/opaque-seed.json',
+				'requires' => array( 'unknown/runtime' ),
+			),
+		),
+	)
+);
+$unsupported_report = WP_Agent_Package_Capability_Checker::check( $unsupported_package, AgentBundleAbilityService::host_capabilities() )->to_array();
+agents_api_smoke_assert_equals( false, $unsupported_report['compatible'] ?? true, 'unsupported package is incompatible', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'intelligence/wiki-brain', 'unknown/runtime' ), $unsupported_report['unsupported_capabilities'] ?? null, 'unsupported capabilities include package and artifact requirements', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'unknown/vendor-artifact' ), $unsupported_report['unknown_artifact_types'] ?? null, 'unknown artifact type is reported', $failures, $passes );
+agents_api_smoke_assert_equals( 'unknown/vendor-artifact:opaque-seed', $unsupported_report['unsupported_artifacts'][0]['artifact_key'] ?? '', 'unsupported artifact carries stable key', $failures, $passes );
+
+echo "\n[4] Ability and CLI surfaces are registered in source:\n";
+$ability_source = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/AgentAbilities.php' );
+$cli_source     = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Cli/Commands/AgentBundleCommand.php' );
+agents_api_smoke_assert_equals( true, str_contains( $ability_source, 'datamachine/validate-agent-bundle' ), 'validate ability is registered', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $ability_source, 'datamachine/inspect-agent-bundle' ), 'inspect ability is registered', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $cli_source, 'function validate(' ), 'validate CLI method exists', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $cli_source, 'function inspect(' ), 'inspect CLI method exists', $failures, $passes );
+
+agents_api_smoke_finish( 'bundle validate/inspect', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds read-only `datamachine/inspect-agent-bundle` and `datamachine/validate-agent-bundle` ability surfaces plus `wp datamachine agent inspect|validate` CLI commands.
- Projects bundles into Agents API `WP_Agent_Package` objects and reports host compatibility through `WP_Agent_Package_Capability_Checker` / `WP_Agent_Package_Capability_Report`.
- Preserves package-level `capabilities` and extension artifact-level `requires` declarations so unsupported requirements are visible in stable JSON output.

Closes #2246.
Closes #2247.

## Tests
- `php tests/bundle-validate-inspect-smoke.php`
- `php tests/datamachine-package-artifacts-smoke.php`
- `vendor/bin/phpcs docs/core-system/agent-bundles.md inc/Abilities/AgentAbilities.php inc/Cli/Commands/AgentBundleCommand.php inc/Engine/Bundle/AgentBundleAbilityService.php inc/Engine/Bundle/AgentBundleArrayAdapter.php inc/Engine/Bundle/AgentBundleArtifactExtensions.php inc/Engine/Bundle/AgentBundleManifest.php inc/Engine/Bundle/AgentPackageProjection.php tests/bundle-validate-inspect-smoke.php`
- `git diff --check`
- `composer validate --strict` (passes with existing package version-field warning)

## Notes
- `homeboy test --path /Users/chubes/Developer/data-machine@feature-bundle-validate-inspect --extension wordpress` could not run because the auto-selected `lab` runner is missing PHP and Composer; `--runner local` is not configured as a Homeboy runner.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the validate/inspect surfaces, Agents API compatibility integration, tests, and documentation updates for Chris to review.