### PR TITLE
Fix bundle file artifact lifecycle projection

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -230,9 +230,9 @@ class AgentBundleCommand extends BaseCommand {
 	 * ---
 	 */
 	public function upgrade( array $args, array $assoc_args ): void {
-		$dry_run           = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
-		$input             = $this->bundle_ability_input( $args, $assoc_args );
-		$input['dry_run']  = $dry_run;
+		$dry_run          = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+		$input            = $this->bundle_ability_input( $args, $assoc_args );
+		$input['dry_run'] = $dry_run;
 		if ( isset( $assoc_args['owner'] ) ) {
 			$input['owner_id'] = $this->resolve_user_id( $assoc_args['owner'] );
 		}
@@ -342,7 +342,13 @@ class AgentBundleCommand extends BaseCommand {
 			'policy'            => (string) ( $assoc_args['policy'] ?? AgentBundleArtifactRebase::POLICY_CONSERVATIVE ),
 		);
 
-		foreach ( array( 'token' => 'token', 'token-env' => 'token_env', 'artifact' => 'artifact' ) as $cli_key => $ability_key ) {
+		foreach (
+			array(
+				'token'     => 'token',
+				'token-env' => 'token_env',
+				'artifact'  => 'artifact',
+			) as $cli_key => $ability_key
+		) {
 			if ( isset( $assoc_args[ $cli_key ] ) ) {
 				$input[ $ability_key ] = (string) $assoc_args[ $cli_key ];
 			}

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -15,10 +15,10 @@ use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
 use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
-use DataMachine\Engine\Bundle\AgentBundleAgentConfig;
 use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
 use DataMachine\Engine\Bundle\AgentBundleArtifactRebase;
 use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
+use DataMachine\Engine\Bundle\AgentBundleLifecycleProjection;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
 use DataMachine\Engine\Bundle\AgentBundleRuntimeDrift;
@@ -383,13 +383,13 @@ class AgentBundleCommand extends BaseCommand {
 		}
 
 		$current_index = array();
-		foreach ( $this->current_artifacts( $agent, $installed ) as $artifact ) {
+		foreach ( $this->projection()->current_artifacts( $agent, $installed ) as $artifact ) {
 			$key                   = AgentBundleArtifactExtensions::artifact_key( (string) $artifact['artifact_type'], (string) $artifact['artifact_id'] );
 			$current_index[ $key ] = $artifact;
 		}
 
 		$target_index = array();
-		foreach ( $this->bundle_artifacts_for_agent( $bundle, $agent ) as $artifact ) {
+		foreach ( $this->projection()->target_artifacts( $bundle, $agent ) as $artifact ) {
 			$key                  = AgentBundleArtifactExtensions::artifact_key( (string) $artifact['artifact_type'], (string) $artifact['artifact_id'] );
 			$target_index[ $key ] = $artifact;
 		}
@@ -649,7 +649,7 @@ class AgentBundleCommand extends BaseCommand {
 			return AgentBundleUpgradePlanner::plan(
 				array(),
 				array(),
-				$this->bundle_artifacts( $bundle ),
+				$this->projection()->target_artifacts( $bundle ),
 				$this->bundle_summary( $bundle, $slug )
 			);
 		}
@@ -659,344 +659,10 @@ class AgentBundleCommand extends BaseCommand {
 
 		return AgentBundleUpgradePlanner::plan(
 			$installed,
-			$this->current_artifacts( $agent, $installed ),
-			$this->bundle_artifacts_for_agent( $bundle, $agent ),
+			$this->projection()->current_artifacts( $agent, $installed ),
+			$this->projection()->target_artifacts( $bundle, $agent ),
 			$this->bundle_summary( $bundle, $slug )
 		);
-	}
-
-	/** @return array<int,array<string,mixed>> */
-	private function bundle_artifacts( array $bundle ): array {
-		return $this->bundle_artifacts_for_agent( $bundle, null );
-	}
-
-	/** @return array<int,array<string,mixed>> */
-	private function bundle_artifacts_for_agent( array $bundle, ?array $agent ): array {
-		$artifacts                  = array();
-		$agent_id                   = is_array( $agent ) ? (int) ( $agent['agent_id'] ?? 0 ) : 0;
-		$pipeline_id_map            = array();
-		$existing_pipelines_by_slug = array();
-		$incoming_config            = is_array( $bundle['agent']['agent_config'] ?? null ) ? $bundle['agent']['agent_config'] : array();
-
-		$artifacts[] = array(
-			'artifact_type' => 'agent_config',
-			'artifact_id'   => 'config',
-			'source_path'   => 'manifest.json#/agent/agent_config',
-			'payload'       => AgentBundleAgentConfig::tracked_payload( $incoming_config ),
-		);
-
-		if ( $agent_id > 0 ) {
-			foreach ( $this->pipelines()->get_all_pipelines( null, $agent_id ) as $pipeline ) {
-				$existing_pipelines_by_slug[ (string) ( $pipeline['portable_slug'] ?? '' ) ] = $pipeline;
-			}
-		}
-
-		foreach ( $bundle['pipelines'] ?? array() as $pipeline ) {
-			if ( ! is_array( $pipeline ) ) {
-				continue;
-			}
-			$slug = PortableSlug::normalize( (string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ), 'pipeline' );
-			if ( isset( $existing_pipelines_by_slug[ $slug ] ) ) {
-				$old_id = (int) ( $pipeline['original_id'] ?? 0 );
-				$new_id = (int) ( $existing_pipelines_by_slug[ $slug ]['pipeline_id'] ?? 0 );
-
-				$pipeline_id_map[ $old_id ]  = $new_id;
-				$pipeline['pipeline_config'] = BundleStepIdRemapper::remap_pipeline_step_ids(
-					is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(),
-					$old_id,
-					$new_id
-				);
-			}
-
-			$artifacts[] = array(
-				'artifact_type' => 'pipeline',
-				'artifact_id'   => $slug,
-				'source_path'   => 'pipelines/' . $slug . '.json',
-				'payload'       => $this->pipeline_payload( $pipeline, $slug ),
-			);
-		}
-
-		foreach ( $bundle['flows'] ?? array() as $flow ) {
-			if ( ! is_array( $flow ) ) {
-				continue;
-			}
-			$slug            = PortableSlug::normalize( (string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? 'flow' ) ), 'flow' );
-			$old_pipeline_id = (int) ( $flow['original_pipeline_id'] ?? 0 );
-			$new_pipeline_id = (int) ( $pipeline_id_map[ $old_pipeline_id ] ?? 0 );
-			$existing_flow   = $new_pipeline_id > 0 ? $this->flows()->get_by_portable_slug( $new_pipeline_id, $slug ) : null;
-
-			if ( $existing_flow ) {
-				$flow['flow_config'] = BundleStepIdRemapper::remap_flow_step_ids(
-					is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array(),
-					$old_pipeline_id,
-					$new_pipeline_id,
-					(int) $existing_flow['flow_id']
-				);
-			}
-
-			$artifacts[] = array(
-				'artifact_type' => 'flow',
-				'artifact_id'   => $slug,
-				'source_path'   => 'flows/' . $slug . '.json',
-				'payload'       => $this->flow_payload( $flow, $slug ),
-			);
-		}
-
-		foreach ( self::bundle_file_artifacts( $bundle ) as $artifact ) {
-			$artifacts[] = $artifact;
-		}
-
-		foreach ( AgentBundleArtifactExtensions::normalize_artifacts( is_array( $bundle['extension_artifacts'] ?? null ) ? $bundle['extension_artifacts'] : array() ) as $artifact ) {
-			$artifacts[] = $artifact;
-		}
-
-		return $artifacts;
-	}
-
-	/** @param array<int,array<string,mixed>> $installed */
-	protected function current_artifacts( array $agent, array $installed ): array {
-		$agent_id  = (int) $agent['agent_id'];
-		$artifacts = array();
-		$pipelines = $this->pipelines()->get_all_pipelines( null, $agent_id );
-		$flows     = $this->flows()->get_all_flows( null, $agent_id );
-
-		$artifacts[] = array(
-			'artifact_type' => 'agent_config',
-			'artifact_id'   => 'config',
-			'source_path'   => 'manifest.json#/agent/agent_config',
-			'payload'       => AgentBundleAgentConfig::tracked_payload( is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array() ),
-		);
-
-		$pipeline_by_slug = array();
-		foreach ( $pipelines as $pipeline ) {
-			$slug = (string) ( $pipeline['portable_slug'] ?? '' );
-			if ( '' !== $slug ) {
-				$pipeline_by_slug[ $slug ] = $pipeline;
-			}
-		}
-
-		$flow_by_slug = array();
-		foreach ( $flows as $flow ) {
-			$slug = (string) ( $flow['portable_slug'] ?? '' );
-			if ( '' !== $slug ) {
-				$flow_by_slug[ $slug ] = $flow;
-			}
-		}
-
-		foreach ( $installed as $record ) {
-			$type = (string) ( $record['artifact_type'] ?? '' );
-			$id   = (string) ( $record['artifact_id'] ?? '' );
-			if ( 'pipeline' === $type && isset( $pipeline_by_slug[ $id ] ) ) {
-				$artifacts[] = array(
-					'artifact_type' => 'pipeline',
-					'artifact_id'   => $id,
-					'source_path'   => (string) ( $record['source_path'] ?? '' ),
-					'payload'       => $this->pipeline_payload( $pipeline_by_slug[ $id ], $id ),
-				);
-			}
-			if ( 'flow' === $type && isset( $flow_by_slug[ $id ] ) ) {
-				$installed_payload = is_array( $record['installed_payload'] ?? null ) ? $record['installed_payload'] : null;
-				$artifacts[]       = array(
-					'artifact_type' => 'flow',
-					'artifact_id'   => $id,
-					'source_path'   => (string) ( $record['source_path'] ?? '' ),
-					'payload'       => $this->flow_payload( $flow_by_slug[ $id ], $id, $installed_payload ),
-				);
-			}
-			if ( 'rubric' === $type ) {
-				$payload = self::current_payload_from_record( is_array( $record ) ? $record : null );
-				if ( null !== $payload ) {
-					$artifacts[] = array(
-						'artifact_type' => $type,
-						'artifact_id'   => $id,
-						'source_path'   => (string) ( $record['source_path'] ?? '' ),
-						'payload'       => $payload,
-					);
-				}
-			}
-		}
-
-		$artifacts = array_merge(
-			$artifacts,
-			\DataMachine\Engine\AI\System\SystemTaskPromptRegistry::current_artifacts(),
-			AgentBundleArtifactExtensions::current_artifacts(
-				$agent,
-				$installed,
-				array( 'agent_id' => $agent_id )
-			)
-		);
-
-		return $artifacts;
-	}
-
-	/** @return array<int,array<string,mixed>> */
-	private static function bundle_file_artifacts( array $bundle ): array {
-		$artifacts = array();
-		$files     = is_array( $bundle['artifact_files'] ?? null ) ? $bundle['artifact_files'] : array();
-
-		foreach ( self::bundle_file_artifact_directories() as $directory => $type ) {
-			foreach ( is_array( $files[ $directory ] ?? null ) ? $files[ $directory ] : array() as $relative_path => $payload ) {
-				$artifact_id = is_array( $payload ) && is_string( $payload['artifact_id'] ?? null )
-					? (string) $payload['artifact_id']
-					: self::artifact_id_from_relative_path( (string) $relative_path );
-
-				$artifacts[] = array(
-					'artifact_type' => $type,
-					'artifact_id'   => $artifact_id,
-					'source_path'   => $directory . '/' . ltrim( (string) $relative_path, '/' ),
-					'payload'       => $payload,
-				);
-			}
-		}
-
-		return $artifacts;
-	}
-
-	/** @return array<string,string> */
-	private static function bundle_file_artifact_directories(): array {
-		return array(
-			\DataMachine\Engine\Bundle\BundleSchema::PROMPTS_DIR       => 'prompt',
-			\DataMachine\Engine\Bundle\BundleSchema::RUBRICS_DIR       => 'rubric',
-			\DataMachine\Engine\Bundle\BundleSchema::TOOL_POLICIES_DIR => 'tool_policy',
-			\DataMachine\Engine\Bundle\BundleSchema::AUTH_REFS_DIR     => 'auth_ref',
-			\DataMachine\Engine\Bundle\BundleSchema::SEED_QUEUES_DIR   => 'seed_queue',
-		);
-	}
-
-	private static function artifact_id_from_relative_path( string $relative_path ): string {
-		$relative_path = preg_replace( '/\.(json|md|txt)$/i', '', $relative_path );
-		return null === $relative_path ? '' : $relative_path;
-	}
-
-	private static function current_payload_from_record( ?array $record ): mixed {
-		if ( ! is_array( $record ) ) {
-			return null;
-		}
-		if ( array_key_exists( 'current_payload', $record ) ) {
-			return $record['current_payload'];
-		}
-		if ( array_key_exists( 'installed_payload', $record ) ) {
-			return $record['installed_payload'];
-		}
-		if ( array_key_exists( 'payload', $record ) ) {
-			return $record['payload'];
-		}
-
-		return null;
-	}
-
-	private function pipeline_payload( array $pipeline, string $portable_slug ): array {
-		return array(
-			'portable_slug'   => $portable_slug,
-			'pipeline_name'   => (string) ( $pipeline['pipeline_name'] ?? '' ),
-			'pipeline_config' => is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(),
-		);
-	}
-
-	private function flow_payload( array $flow, string $portable_slug, ?array $installed_payload = null ): array {
-		$scheduling_policy = $this->flow_scheduling_policy( is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array() );
-
-		return array(
-			'portable_slug'     => $portable_slug,
-			'flow_name'         => (string) ( $flow['flow_name'] ?? '' ),
-			'flow_config'       => $this->flow_config_without_runtime_queues( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() ),
-			'scheduling_policy' => $scheduling_policy,
-			'queue_policy'      => 'create_seed_upgrade_preserve_existing',
-			'runtime_overlays'  => $this->flow_runtime_overlays( $flow, $installed_payload ),
-		);
-	}
-
-	private function flow_scheduling_policy( array $config ): string {
-		$interval = (string) ( $config['interval'] ?? 'manual' );
-		$enabled  = array_key_exists( 'enabled', $config ) ? false !== $config['enabled'] : 'manual' !== $interval;
-
-		if ( 'manual' === $interval || ! $enabled ) {
-			return 'create_paused_upgrade_preserve_existing';
-		}
-
-		return 'create_bundle_schedule_upgrade_preserve_existing';
-	}
-
-	private function flow_config_without_runtime_queues( array $flow_config ): array {
-		foreach ( $flow_config as &$step ) {
-			if ( is_array( $step ) ) {
-				unset( $step['prompt_queue'], $step['config_patch_queue'], $step['queue_mode'], $step['_queue_consume_revision'] );
-				unset( $step['handler_config']['max_items'] );
-				if ( empty( $step['handler_config'] ) ) {
-					unset( $step['handler_config'] );
-				}
-				if ( is_array( $step['handler_configs'] ?? null ) ) {
-					foreach ( $step['handler_configs'] as $handler_slug => &$handler_config ) {
-						if ( is_array( $handler_config ) ) {
-							unset( $handler_config['max_items'] );
-							if ( empty( $handler_config ) ) {
-								unset( $step['handler_configs'][ $handler_slug ] );
-							}
-						}
-					}
-					unset( $handler_config );
-					if ( empty( $step['handler_configs'] ) ) {
-						unset( $step['handler_configs'] );
-					}
-				}
-			}
-		}
-		unset( $step );
-
-		return $flow_config;
-	}
-
-	private function flow_runtime_overlays( array $flow, ?array $installed_payload = null ): array {
-		if ( is_array( $installed_payload['runtime_overlays'] ?? null ) ) {
-			return $installed_payload['runtime_overlays'];
-		}
-
-		$overlays    = array();
-		$flow_config = is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array();
-		$steps       = array();
-
-		foreach ( $flow_config as $flow_step_id => $step ) {
-			if ( ! is_array( $step ) ) {
-				continue;
-			}
-
-			$step_overlay = array();
-			foreach ( array( 'prompt_queue', 'config_patch_queue', 'queue_mode', '_queue_consume_revision' ) as $field ) {
-				if ( array_key_exists( $field, $step ) ) {
-					$step_overlay[ $field ] = $step[ $field ];
-				}
-			}
-			if ( array_key_exists( 'max_items', $step['handler_config'] ?? array() ) ) {
-				$step_overlay['handler_config'] = array( 'max_items' => $step['handler_config']['max_items'] );
-			}
-			if ( is_array( $step['handler_configs'] ?? null ) ) {
-				foreach ( $step['handler_configs'] as $handler_slug => $handler_config ) {
-					if ( is_array( $handler_config ) && array_key_exists( 'max_items', $handler_config ) ) {
-						$step_overlay['handler_configs'][ (string) $handler_slug ] = array( 'max_items' => $handler_config['max_items'] );
-					}
-				}
-			}
-
-			if ( ! empty( $step_overlay ) ) {
-				ksort( $step_overlay, SORT_STRING );
-				$steps[ (string) $flow_step_id ] = $step_overlay;
-			}
-		}
-
-		if ( ! empty( $steps ) ) {
-			ksort( $steps, SORT_STRING );
-			$overlays['steps'] = $steps;
-		}
-
-		$scheduling = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
-		unset( $scheduling['last_run'], $scheduling['next_run'], $scheduling['run_count'], $scheduling['run_artifacts'] );
-		if ( ! empty( $scheduling ) ) {
-			ksort( $scheduling, SORT_STRING );
-			$overlays['scheduling_config'] = $scheduling;
-		}
-
-		ksort( $overlays, SORT_STRING );
-		return $overlays;
 	}
 
 	private function resolve_bundle_agent( array $bundle, string $slug = '' ): ?array {
@@ -1055,7 +721,7 @@ class AgentBundleCommand extends BaseCommand {
 	 */
 	protected function classified_installed_artifacts( array $agent, array $installed ): array {
 		$current = array();
-		foreach ( $this->current_artifacts( $agent, $installed ) as $artifact ) {
+		foreach ( $this->projection()->current_artifacts( $agent, $installed ) as $artifact ) {
 			$key             = AgentBundleArtifactExtensions::artifact_key( (string) ( $artifact['artifact_type'] ?? '' ), (string) ( $artifact['artifact_id'] ?? '' ) );
 			$current[ $key ] = $artifact;
 		}
@@ -1153,5 +819,9 @@ class AgentBundleCommand extends BaseCommand {
 
 	private function flows(): Flows {
 		return new Flows();
+	}
+
+	private function projection(): AgentBundleLifecycleProjection {
+		return new AgentBundleLifecycleProjection( $this->pipelines(), $this->flows() );
 	}
 }

--- a/inc/Engine/Bundle/AgentBundleAbilityService.php
+++ b/inc/Engine/Bundle/AgentBundleAbilityService.php
@@ -27,10 +27,10 @@ final class AgentBundleAbilityService {
 	private AgentBundleLifecycleProjection $projection;
 
 	public function __construct( ?Agents $agents = null, ?Pipelines $pipelines = null, ?Flows $flows = null, ?AgentBundler $bundler = null, ?AgentBundleLifecycleProjection $projection = null ) {
-		$this->agents    = $agents ?? new Agents();
-		$this->pipelines = $pipelines ?? new Pipelines();
-		$this->flows     = $flows ?? new Flows();
-		$this->bundler   = $bundler ?? new AgentBundler();
+		$this->agents     = $agents ?? new Agents();
+		$this->pipelines  = $pipelines ?? new Pipelines();
+		$this->flows      = $flows ?? new Flows();
+		$this->bundler    = $bundler ?? new AgentBundler();
 		$this->projection = $projection ?? new AgentBundleLifecycleProjection( $this->pipelines, $this->flows );
 	}
 
@@ -184,16 +184,16 @@ final class AgentBundleAbilityService {
 		);
 
 		if ( $plan->has_pending_approval() ) {
-			$agent             = $this->resolve_bundle_agent( $bundle, $slug );
-			$rebased_artifacts = $rebase_local
+			$agent                      = $this->resolve_bundle_agent( $bundle, $slug );
+			$rebased_artifacts          = $rebase_local
 				? $this->rebase_locally_modified( $plan, $bundle, $slug, $policy_name )
 				: array();
-			$pending           = AgentBundleUpgradePendingAction::stage(
+			$pending                    = AgentBundleUpgradePendingAction::stage(
 				$plan,
 				array(
 					'bundle'             => $this->bundle_summary( $bundle, $slug ),
 					'agent'              => $agent ? $agent : array(),
-					'target_artifacts'   => $this->projection->target_artifacts( $bundle, $agent ?: null ),
+					'target_artifacts'   => $this->projection->target_artifacts( $bundle, $agent ? $agent : null ),
 					'approved_artifacts' => $this->approved_rebased_artifact_keys( $rebased_artifacts ),
 					'rebased_artifacts'  => $rebased_artifacts,
 					'summary'            => 'Review locally modified bundle artifacts before applying.',

--- a/inc/Engine/Bundle/AgentBundleAbilityService.php
+++ b/inc/Engine/Bundle/AgentBundleAbilityService.php
@@ -24,12 +24,14 @@ final class AgentBundleAbilityService {
 	private Pipelines $pipelines;
 	private Flows $flows;
 	private AgentBundler $bundler;
+	private AgentBundleLifecycleProjection $projection;
 
-	public function __construct( ?Agents $agents = null, ?Pipelines $pipelines = null, ?Flows $flows = null, ?AgentBundler $bundler = null ) {
+	public function __construct( ?Agents $agents = null, ?Pipelines $pipelines = null, ?Flows $flows = null, ?AgentBundler $bundler = null, ?AgentBundleLifecycleProjection $projection = null ) {
 		$this->agents    = $agents ?? new Agents();
 		$this->pipelines = $pipelines ?? new Pipelines();
 		$this->flows     = $flows ?? new Flows();
 		$this->bundler   = $bundler ?? new AgentBundler();
+		$this->projection = $projection ?? new AgentBundleLifecycleProjection( $this->pipelines, $this->flows );
 	}
 
 	/** @return array<string,mixed> */
@@ -191,7 +193,7 @@ final class AgentBundleAbilityService {
 				array(
 					'bundle'             => $this->bundle_summary( $bundle, $slug ),
 					'agent'              => $agent ? $agent : array(),
-					'target_artifacts'   => $this->bundle_artifacts( $bundle ),
+					'target_artifacts'   => $this->projection->target_artifacts( $bundle, $agent ?: null ),
 					'approved_artifacts' => $this->approved_rebased_artifact_keys( $rebased_artifacts ),
 					'rebased_artifacts'  => $rebased_artifacts,
 					'summary'            => 'Review locally modified bundle artifacts before applying.',
@@ -290,7 +292,7 @@ final class AgentBundleAbilityService {
 	private function plan_for_bundle( array $bundle, string $slug = '' ): AgentBundleUpgradePlan {
 		$agent = $this->resolve_bundle_agent( $bundle, $slug );
 		if ( ! $agent ) {
-			return AgentBundleUpgradePlanner::plan( array(), array(), $this->bundle_artifacts( $bundle ), $this->bundle_summary( $bundle, $slug ) );
+			return AgentBundleUpgradePlanner::plan( array(), array(), $this->projection->target_artifacts( $bundle ), $this->bundle_summary( $bundle, $slug ) );
 		}
 
 		$bundle_state = is_array( $agent['agent_config']['datamachine_bundle'] ?? null ) ? $agent['agent_config']['datamachine_bundle'] : array();
@@ -298,138 +300,10 @@ final class AgentBundleAbilityService {
 
 		return AgentBundleUpgradePlanner::plan(
 			$installed,
-			$this->current_artifacts( $agent, $installed ),
-			$this->bundle_artifacts_for_agent( $bundle, $agent ),
+			$this->projection->current_artifacts( $agent, $installed ),
+			$this->projection->target_artifacts( $bundle, $agent ),
 			$this->bundle_summary( $bundle, $slug )
 		);
-	}
-
-	/** @return array<int,array<string,mixed>> */
-	private function bundle_artifacts( array $bundle ): array {
-		return $this->bundle_artifacts_for_agent( $bundle, null );
-	}
-
-	/** @return array<int,array<string,mixed>> */
-	private function bundle_artifacts_for_agent( array $bundle, ?array $agent ): array {
-		$artifacts                  = array();
-		$agent_id                   = is_array( $agent ) ? (int) ( $agent['agent_id'] ?? 0 ) : 0;
-		$pipeline_id_map            = array();
-		$existing_pipelines_by_slug = array();
-		$incoming_config            = is_array( $bundle['agent']['agent_config'] ?? null ) ? $bundle['agent']['agent_config'] : array();
-
-		$artifacts[] = array(
-			'artifact_type' => 'agent_config',
-			'artifact_id'   => 'config',
-			'source_path'   => 'manifest.json#/agent/agent_config',
-			'payload'       => AgentBundleAgentConfig::tracked_payload( $incoming_config ),
-		);
-
-		if ( $agent_id > 0 ) {
-			foreach ( $this->pipelines->get_all_pipelines( null, $agent_id ) as $pipeline ) {
-				$existing_pipelines_by_slug[ (string) ( $pipeline['portable_slug'] ?? '' ) ] = $pipeline;
-			}
-		}
-
-		foreach ( $bundle['pipelines'] ?? array() as $pipeline ) {
-			if ( ! is_array( $pipeline ) ) {
-				continue;
-			}
-			$slug = PortableSlug::normalize( (string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ), 'pipeline' );
-			if ( isset( $existing_pipelines_by_slug[ $slug ] ) ) {
-				$old_id                      = (int) ( $pipeline['original_id'] ?? 0 );
-				$new_id                      = (int) ( $existing_pipelines_by_slug[ $slug ]['pipeline_id'] ?? 0 );
-				$pipeline_id_map[ $old_id ]  = $new_id;
-				$pipeline['pipeline_config'] = BundleStepIdRemapper::remap_pipeline_step_ids( is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(), $old_id, $new_id );
-			}
-
-			$artifacts[] = array(
-				'artifact_type' => 'pipeline',
-				'artifact_id'   => $slug,
-				'source_path'   => 'pipelines/' . $slug . '.json',
-				'payload'       => $this->pipeline_payload( $pipeline, $slug ),
-			);
-		}
-
-		foreach ( $bundle['flows'] ?? array() as $flow ) {
-			if ( ! is_array( $flow ) ) {
-				continue;
-			}
-			$slug            = PortableSlug::normalize( (string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? 'flow' ) ), 'flow' );
-			$old_pipeline_id = (int) ( $flow['original_pipeline_id'] ?? 0 );
-			$new_pipeline_id = (int) ( $pipeline_id_map[ $old_pipeline_id ] ?? 0 );
-			$existing_flow   = $new_pipeline_id > 0 ? $this->flows->get_by_portable_slug( $new_pipeline_id, $slug ) : null;
-
-			if ( $existing_flow ) {
-				$flow['flow_config'] = BundleStepIdRemapper::remap_flow_step_ids( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array(), $old_pipeline_id, $new_pipeline_id, (int) $existing_flow['flow_id'] );
-			}
-
-			$artifacts[] = array(
-				'artifact_type' => 'flow',
-				'artifact_id'   => $slug,
-				'source_path'   => 'flows/' . $slug . '.json',
-				'payload'       => $this->flow_payload( $flow, $slug ),
-			);
-		}
-
-		foreach ( AgentBundleArtifactExtensions::normalize_artifacts( is_array( $bundle['extension_artifacts'] ?? null ) ? $bundle['extension_artifacts'] : array() ) as $artifact ) {
-			$artifacts[] = $artifact;
-		}
-
-		return $artifacts;
-	}
-
-	/** @param array<int,array<string,mixed>> $installed */
-	private function current_artifacts( array $agent, array $installed ): array {
-		$agent_id  = (int) $agent['agent_id'];
-		$artifacts = array();
-		$pipelines = $this->pipelines->get_all_pipelines( null, $agent_id );
-		$flows     = $this->flows->get_all_flows( null, $agent_id );
-
-		$artifacts[] = array(
-			'artifact_type' => 'agent_config',
-			'artifact_id'   => 'config',
-			'source_path'   => 'manifest.json#/agent/agent_config',
-			'payload'       => AgentBundleAgentConfig::tracked_payload( is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array() ),
-		);
-
-		$pipeline_by_slug = array();
-		foreach ( $pipelines as $pipeline ) {
-			$slug = (string) ( $pipeline['portable_slug'] ?? '' );
-			if ( '' !== $slug ) {
-				$pipeline_by_slug[ $slug ] = $pipeline;
-			}
-		}
-
-		$flow_by_slug = array();
-		foreach ( $flows as $flow ) {
-			$slug = (string) ( $flow['portable_slug'] ?? '' );
-			if ( '' !== $slug ) {
-				$flow_by_slug[ $slug ] = $flow;
-			}
-		}
-
-		foreach ( $installed as $record ) {
-			$type = (string) ( $record['artifact_type'] ?? '' );
-			$id   = (string) ( $record['artifact_id'] ?? '' );
-			if ( 'pipeline' === $type && isset( $pipeline_by_slug[ $id ] ) ) {
-				$artifacts[] = array(
-					'artifact_type' => 'pipeline',
-					'artifact_id'   => $id,
-					'source_path'   => (string) ( $record['source_path'] ?? '' ),
-					'payload'       => $this->pipeline_payload( $pipeline_by_slug[ $id ], $id ),
-				);
-			}
-			if ( 'flow' === $type && isset( $flow_by_slug[ $id ] ) ) {
-				$artifacts[] = array(
-					'artifact_type' => 'flow',
-					'artifact_id'   => $id,
-					'source_path'   => (string) ( $record['source_path'] ?? '' ),
-					'payload'       => $this->flow_payload( $flow_by_slug[ $id ], $id ),
-				);
-			}
-		}
-
-		return array_merge( $artifacts, AgentBundleArtifactExtensions::current_artifacts( $agent, $installed, array( 'agent_id' => $agent_id ) ) );
 	}
 
 	private function add_runtime_drift_to_plan( array $plan, array $bundle, string $slug = '', string $decision = 'preserve_existing' ): array {
@@ -525,13 +399,13 @@ final class AgentBundleAbilityService {
 		}
 
 		$current_index = array();
-		foreach ( $this->current_artifacts( $agent, $installed ) as $artifact ) {
+		foreach ( $this->projection->current_artifacts( $agent, $installed ) as $artifact ) {
 			$key                   = AgentBundleArtifactExtensions::artifact_key( (string) $artifact['artifact_type'], (string) $artifact['artifact_id'] );
 			$current_index[ $key ] = $artifact;
 		}
 
 		$target_index = array();
-		foreach ( $this->bundle_artifacts_for_agent( $bundle, $agent ) as $artifact ) {
+		foreach ( $this->projection->target_artifacts( $bundle, $agent ) as $artifact ) {
 			$key                  = AgentBundleArtifactExtensions::artifact_key( (string) $artifact['artifact_type'], (string) $artifact['artifact_id'] );
 			$target_index[ $key ] = $artifact;
 		}
@@ -587,42 +461,6 @@ final class AgentBundleAbilityService {
 		}
 
 		return array_values( array_unique( $approved ) );
-	}
-
-	private function pipeline_payload( array $pipeline, string $portable_slug ): array {
-		return array(
-			'portable_slug'   => $portable_slug,
-			'pipeline_name'   => (string) ( $pipeline['pipeline_name'] ?? '' ),
-			'pipeline_config' => is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(),
-		);
-	}
-
-	private function flow_payload( array $flow, string $portable_slug ): array {
-		return array(
-			'portable_slug'     => $portable_slug,
-			'flow_name'         => (string) ( $flow['flow_name'] ?? '' ),
-			'flow_config'       => $this->flow_config_without_runtime_queues( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() ),
-			'scheduling_policy' => $this->flow_scheduling_policy( is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array() ),
-			'queue_policy'      => 'create_seed_upgrade_preserve_existing',
-		);
-	}
-
-	private function flow_scheduling_policy( array $config ): string {
-		$interval = (string) ( $config['interval'] ?? 'manual' );
-		$enabled  = array_key_exists( 'enabled', $config ) ? false !== $config['enabled'] : 'manual' !== $interval;
-
-		return ( 'manual' === $interval || ! $enabled ) ? 'create_paused_upgrade_preserve_existing' : 'create_bundle_schedule_upgrade_preserve_existing';
-	}
-
-	private function flow_config_without_runtime_queues( array $flow_config ): array {
-		foreach ( $flow_config as &$step ) {
-			if ( is_array( $step ) ) {
-				unset( $step['prompt_queue'], $step['config_patch_queue'], $step['queue_mode'], $step['_queue_consume_revision'] );
-			}
-		}
-		unset( $step );
-
-		return $flow_config;
 	}
 
 	private function resolve_bundle_agent( array $bundle, string $slug = '' ): ?array {

--- a/inc/Engine/Bundle/AgentBundleLifecycleProjection.php
+++ b/inc/Engine/Bundle/AgentBundleLifecycleProjection.php
@@ -1,0 +1,374 @@
+<?php
+/**
+ * Shared agent bundle lifecycle artifact projection.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Engine\AI\System\SystemTaskPromptRegistry;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Builds target and current artifact rows for bundle lifecycle planning.
+ */
+final class AgentBundleLifecycleProjection {
+
+	private ?Pipelines $pipelines;
+	private ?Flows $flows;
+
+	public function __construct( ?Pipelines $pipelines = null, ?Flows $flows = null ) {
+		$this->pipelines = $pipelines;
+		$this->flows     = $flows;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public function target_artifacts( array $bundle, ?array $agent = null ): array {
+		$artifacts                  = array();
+		$agent_id                   = is_array( $agent ) ? (int) ( $agent['agent_id'] ?? 0 ) : 0;
+		$pipeline_id_map            = array();
+		$existing_pipelines_by_slug = array();
+		$incoming_config            = is_array( $bundle['agent']['agent_config'] ?? null ) ? $bundle['agent']['agent_config'] : array();
+
+		$artifacts[] = array(
+			'artifact_type' => 'agent_config',
+			'artifact_id'   => 'config',
+			'source_path'   => 'manifest.json#/agent/agent_config',
+			'payload'       => AgentBundleAgentConfig::tracked_payload( $incoming_config ),
+		);
+
+		if ( $agent_id > 0 ) {
+			foreach ( $this->pipelines()->get_all_pipelines( null, $agent_id ) as $pipeline ) {
+				$existing_pipelines_by_slug[ (string) ( $pipeline['portable_slug'] ?? '' ) ] = $pipeline;
+			}
+		}
+
+		foreach ( $bundle['pipelines'] ?? array() as $pipeline ) {
+			if ( ! is_array( $pipeline ) ) {
+				continue;
+			}
+
+			$slug = PortableSlug::normalize( (string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ), 'pipeline' );
+			if ( isset( $existing_pipelines_by_slug[ $slug ] ) ) {
+				$old_id = (int) ( $pipeline['original_id'] ?? 0 );
+				$new_id = (int) ( $existing_pipelines_by_slug[ $slug ]['pipeline_id'] ?? 0 );
+
+				$pipeline_id_map[ $old_id ]  = $new_id;
+				$pipeline['pipeline_config'] = BundleStepIdRemapper::remap_pipeline_step_ids(
+					is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(),
+					$old_id,
+					$new_id
+				);
+			}
+
+			$artifacts[] = array(
+				'artifact_type' => 'pipeline',
+				'artifact_id'   => $slug,
+				'source_path'   => 'pipelines/' . $slug . '.json',
+				'payload'       => self::pipeline_payload( $pipeline, $slug ),
+			);
+		}
+
+		foreach ( $bundle['flows'] ?? array() as $flow ) {
+			if ( ! is_array( $flow ) ) {
+				continue;
+			}
+
+			$slug            = PortableSlug::normalize( (string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? 'flow' ) ), 'flow' );
+			$old_pipeline_id = (int) ( $flow['original_pipeline_id'] ?? 0 );
+			$new_pipeline_id = (int) ( $pipeline_id_map[ $old_pipeline_id ] ?? 0 );
+			$existing_flow   = $new_pipeline_id > 0 ? $this->flows()->get_by_portable_slug( $new_pipeline_id, $slug ) : null;
+
+			if ( $existing_flow ) {
+				$flow['flow_config'] = BundleStepIdRemapper::remap_flow_step_ids(
+					is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array(),
+					$old_pipeline_id,
+					$new_pipeline_id,
+					(int) $existing_flow['flow_id']
+				);
+			}
+
+			$artifacts[] = array(
+				'artifact_type' => 'flow',
+				'artifact_id'   => $slug,
+				'source_path'   => 'flows/' . $slug . '.json',
+				'payload'       => self::flow_payload( $flow, $slug ),
+			);
+		}
+
+		foreach ( self::bundle_file_artifacts( $bundle ) as $artifact ) {
+			$artifacts[] = $artifact;
+		}
+
+		foreach ( AgentBundleArtifactExtensions::normalize_artifacts( is_array( $bundle['extension_artifacts'] ?? null ) ? $bundle['extension_artifacts'] : array() ) as $artifact ) {
+			$artifacts[] = $artifact;
+		}
+
+		return $artifacts;
+	}
+
+	/** @param array<int,array<string,mixed>> $installed */
+	public function current_artifacts( array $agent, array $installed ): array {
+		$agent_id  = (int) $agent['agent_id'];
+		$artifacts = array();
+		$pipelines = $this->pipelines()->get_all_pipelines( null, $agent_id );
+		$flows     = $this->flows()->get_all_flows( null, $agent_id );
+
+		$artifacts[] = array(
+			'artifact_type' => 'agent_config',
+			'artifact_id'   => 'config',
+			'source_path'   => 'manifest.json#/agent/agent_config',
+			'payload'       => AgentBundleAgentConfig::tracked_payload( is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array() ),
+		);
+
+		$pipeline_by_slug = array();
+		foreach ( $pipelines as $pipeline ) {
+			$slug = (string) ( $pipeline['portable_slug'] ?? '' );
+			if ( '' !== $slug ) {
+				$pipeline_by_slug[ $slug ] = $pipeline;
+			}
+		}
+
+		$flow_by_slug = array();
+		foreach ( $flows as $flow ) {
+			$slug = (string) ( $flow['portable_slug'] ?? '' );
+			if ( '' !== $slug ) {
+				$flow_by_slug[ $slug ] = $flow;
+			}
+		}
+
+		foreach ( $installed as $record ) {
+			$type = (string) ( $record['artifact_type'] ?? '' );
+			$id   = (string) ( $record['artifact_id'] ?? '' );
+			if ( 'pipeline' === $type && isset( $pipeline_by_slug[ $id ] ) ) {
+				$artifacts[] = array(
+					'artifact_type' => 'pipeline',
+					'artifact_id'   => $id,
+					'source_path'   => (string) ( $record['source_path'] ?? '' ),
+					'payload'       => self::pipeline_payload( $pipeline_by_slug[ $id ], $id ),
+				);
+			}
+			if ( 'flow' === $type && isset( $flow_by_slug[ $id ] ) ) {
+				$installed_payload = is_array( $record['installed_payload'] ?? null ) ? $record['installed_payload'] : null;
+				$artifacts[]       = array(
+					'artifact_type' => 'flow',
+					'artifact_id'   => $id,
+					'source_path'   => (string) ( $record['source_path'] ?? '' ),
+					'payload'       => self::flow_payload( $flow_by_slug[ $id ], $id, $installed_payload ),
+				);
+			}
+			if ( in_array( $type, self::bundle_file_artifact_types(), true ) ) {
+				$payload = self::current_payload_from_record( is_array( $record ) ? $record : null );
+				if ( null !== $payload ) {
+					$artifacts[] = array(
+						'artifact_type' => $type,
+						'artifact_id'   => $id,
+						'source_path'   => (string) ( $record['source_path'] ?? '' ),
+						'payload'       => $payload,
+					);
+				}
+			}
+		}
+
+		return array_merge(
+			$artifacts,
+			SystemTaskPromptRegistry::current_artifacts(),
+			AgentBundleArtifactExtensions::current_artifacts( $agent, $installed, array( 'agent_id' => $agent_id ) )
+		);
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public static function bundle_file_artifacts( array $bundle ): array {
+		$artifacts = array();
+		$files     = is_array( $bundle['artifact_files'] ?? null ) ? $bundle['artifact_files'] : array();
+
+		foreach ( self::bundle_file_artifact_directories() as $directory => $type ) {
+			foreach ( is_array( $files[ $directory ] ?? null ) ? $files[ $directory ] : array() as $relative_path => $payload ) {
+				$artifact_id = is_array( $payload ) && is_string( $payload['artifact_id'] ?? null )
+					? (string) $payload['artifact_id']
+					: self::artifact_id_from_relative_path( (string) $relative_path );
+
+				$artifacts[] = array(
+					'artifact_type' => $type,
+					'artifact_id'   => $artifact_id,
+					'source_path'   => $directory . '/' . ltrim( (string) $relative_path, '/' ),
+					'payload'       => $payload,
+				);
+			}
+		}
+
+		return $artifacts;
+	}
+
+	/** @return array<string,string> */
+	private static function bundle_file_artifact_directories(): array {
+		return array(
+			BundleSchema::PROMPTS_DIR       => 'prompt',
+			BundleSchema::RUBRICS_DIR       => 'rubric',
+			BundleSchema::TOOL_POLICIES_DIR => 'tool_policy',
+			BundleSchema::AUTH_REFS_DIR     => 'auth_ref',
+			BundleSchema::SEED_QUEUES_DIR   => 'seed_queue',
+		);
+	}
+
+	/** @return string[] */
+	private static function bundle_file_artifact_types(): array {
+		return array_values( self::bundle_file_artifact_directories() );
+	}
+
+	private static function artifact_id_from_relative_path( string $relative_path ): string {
+		$relative_path = preg_replace( '/\.(json|md|txt)$/i', '', $relative_path );
+		return null === $relative_path ? '' : $relative_path;
+	}
+
+	private static function current_payload_from_record( ?array $record ): mixed {
+		if ( ! is_array( $record ) ) {
+			return null;
+		}
+		if ( array_key_exists( 'current_payload', $record ) ) {
+			return $record['current_payload'];
+		}
+		if ( array_key_exists( 'installed_payload', $record ) ) {
+			return $record['installed_payload'];
+		}
+		if ( array_key_exists( 'payload', $record ) ) {
+			return $record['payload'];
+		}
+
+		return null;
+	}
+
+	private static function pipeline_payload( array $pipeline, string $portable_slug ): array {
+		return array(
+			'portable_slug'   => $portable_slug,
+			'pipeline_name'   => (string) ( $pipeline['pipeline_name'] ?? '' ),
+			'pipeline_config' => is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(),
+		);
+	}
+
+	private static function flow_payload( array $flow, string $portable_slug, ?array $installed_payload = null ): array {
+		$scheduling_policy = self::flow_scheduling_policy( is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array() );
+
+		return array(
+			'portable_slug'     => $portable_slug,
+			'flow_name'         => (string) ( $flow['flow_name'] ?? '' ),
+			'flow_config'       => self::flow_config_without_runtime_queues( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() ),
+			'scheduling_policy' => $scheduling_policy,
+			'queue_policy'      => 'create_seed_upgrade_preserve_existing',
+			'runtime_overlays'  => self::flow_runtime_overlays( $flow, $installed_payload ),
+		);
+	}
+
+	private static function flow_scheduling_policy( array $config ): string {
+		$interval = (string) ( $config['interval'] ?? 'manual' );
+		$enabled  = array_key_exists( 'enabled', $config ) ? false !== $config['enabled'] : 'manual' !== $interval;
+
+		if ( 'manual' === $interval || ! $enabled ) {
+			return 'create_paused_upgrade_preserve_existing';
+		}
+
+		return 'create_bundle_schedule_upgrade_preserve_existing';
+	}
+
+	private static function flow_config_without_runtime_queues( array $flow_config ): array {
+		foreach ( $flow_config as &$step ) {
+			if ( is_array( $step ) ) {
+				unset( $step['prompt_queue'], $step['config_patch_queue'], $step['queue_mode'], $step['_queue_consume_revision'] );
+				unset( $step['handler_config']['max_items'] );
+				if ( empty( $step['handler_config'] ) ) {
+					unset( $step['handler_config'] );
+				}
+				if ( is_array( $step['handler_configs'] ?? null ) ) {
+					foreach ( $step['handler_configs'] as $handler_slug => &$handler_config ) {
+						if ( is_array( $handler_config ) ) {
+							unset( $handler_config['max_items'] );
+							if ( empty( $handler_config ) ) {
+								unset( $step['handler_configs'][ $handler_slug ] );
+							}
+						}
+					}
+					unset( $handler_config );
+					if ( empty( $step['handler_configs'] ) ) {
+						unset( $step['handler_configs'] );
+					}
+				}
+			}
+		}
+		unset( $step );
+
+		return $flow_config;
+	}
+
+	private static function flow_runtime_overlays( array $flow, ?array $installed_payload = null ): array {
+		if ( is_array( $installed_payload['runtime_overlays'] ?? null ) ) {
+			return $installed_payload['runtime_overlays'];
+		}
+
+		$overlays    = array();
+		$flow_config = is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array();
+		$steps       = array();
+
+		foreach ( $flow_config as $flow_step_id => $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+
+			$step_overlay = array();
+			foreach ( array( 'prompt_queue', 'config_patch_queue', 'queue_mode', '_queue_consume_revision' ) as $field ) {
+				if ( array_key_exists( $field, $step ) ) {
+					$step_overlay[ $field ] = $step[ $field ];
+				}
+			}
+			if ( array_key_exists( 'max_items', $step['handler_config'] ?? array() ) ) {
+				$step_overlay['handler_config'] = array( 'max_items' => $step['handler_config']['max_items'] );
+			}
+			if ( is_array( $step['handler_configs'] ?? null ) ) {
+				foreach ( $step['handler_configs'] as $handler_slug => $handler_config ) {
+					if ( is_array( $handler_config ) && array_key_exists( 'max_items', $handler_config ) ) {
+						$step_overlay['handler_configs'][ (string) $handler_slug ] = array( 'max_items' => $handler_config['max_items'] );
+					}
+				}
+			}
+
+			if ( ! empty( $step_overlay ) ) {
+				ksort( $step_overlay, SORT_STRING );
+				$steps[ (string) $flow_step_id ] = $step_overlay;
+			}
+		}
+
+		if ( ! empty( $steps ) ) {
+			ksort( $steps, SORT_STRING );
+			$overlays['steps'] = $steps;
+		}
+
+		$scheduling = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
+		unset( $scheduling['last_run'], $scheduling['next_run'], $scheduling['run_count'], $scheduling['run_artifacts'] );
+		if ( ! empty( $scheduling ) ) {
+			ksort( $scheduling, SORT_STRING );
+			$overlays['scheduling_config'] = $scheduling;
+		}
+
+		ksort( $overlays, SORT_STRING );
+		return $overlays;
+	}
+
+	private function pipelines(): Pipelines {
+		if ( null === $this->pipelines ) {
+			$this->pipelines = new Pipelines();
+		}
+
+		return $this->pipelines;
+	}
+
+	private function flows(): Flows {
+		if ( null === $this->flows ) {
+			$this->flows = new Flows();
+		}
+
+		return $this->flows;
+	}
+}

--- a/tests/agent-bundle-ability-contract-smoke.php
+++ b/tests/agent-bundle-ability-contract-smoke.php
@@ -29,6 +29,7 @@ function datamachine_bundle_ability_contains( string $source, string $needle, st
 $abilities = (string) file_get_contents( $root . '/inc/Abilities/AgentAbilities.php' );
 $cli       = (string) file_get_contents( $root . '/inc/Cli/Commands/AgentBundleCommand.php' );
 $service   = (string) file_get_contents( $root . '/inc/Engine/Bundle/AgentBundleAbilityService.php' );
+$projection = (string) file_get_contents( $root . '/inc/Engine/Bundle/AgentBundleLifecycleProjection.php' );
 
 echo "agent-bundle-ability-contract-smoke\n";
 
@@ -50,9 +51,10 @@ foreach ( array(
 	'AgentBundleUpgradePlanner::plan'            => 'service owns upgrade planning',
 	'AgentBundleUpgradePendingAction::stage'     => 'service owns approval staging',
 	'ResolvePendingActionAbility::execute'       => 'service owns PendingAction apply bridge',
-	'AgentBundleArtifactExtensions::current_artifacts' => 'service owns extension current-state collection',
+	'AgentBundleLifecycleProjection'              => 'service uses shared lifecycle projection',
+	'AgentBundleArtifactExtensions::current_artifacts' => 'shared lifecycle projection owns extension current-state collection',
 ) as $needle => $label ) {
-	datamachine_bundle_ability_contains( $service . $abilities, $needle, $label, $failures, $passes );
+	datamachine_bundle_ability_contains( $service . $projection . $abilities, $needle, $label, $failures, $passes );
 }
 
 echo "\n[3] WP-CLI wraps ability callbacks instead of duplicating public lifecycle logic\n";

--- a/tests/datamachine-package-artifacts-smoke.php
+++ b/tests/datamachine-package-artifacts-smoke.php
@@ -21,6 +21,7 @@ use DataMachine\Core\Agents\AgentBundler;
 use DataMachine\Engine\Bundle\AgentBundleDirectory;
 use DataMachine\Engine\Bundle\AgentBundleFlowFile;
 use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
+use DataMachine\Engine\Bundle\AgentBundleLifecycleProjection;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
 use DataMachine\Engine\Bundle\AgentPackageProjection;
@@ -162,10 +163,25 @@ $array_bundle    = AgentBundleArrayAdapter::to_array_bundle( $directory );
 $array_package   = AgentBundler::package_from_bundle( $array_bundle );
 $array_artifacts = datamachine_package_smoke_artifacts_by_type( $array_package );
 $command_source  = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Cli/Commands/AgentBundleCommand.php' );
+$service_source  = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleAbilityService.php' );
 $bundler_source  = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Core/Agents/AgentBundler.php' );
 agents_api_smoke_assert_equals( 'woocommerce-wiki-package', $array_package->get_slug(), 'array bundle projection preserves package identity', $failures, $passes );
 agents_api_smoke_assert_equals( 'flows/daily-ingest-flow.json', $array_artifacts['datamachine/flow:daily-ingest-flow']['source'] ?? '', 'array bundle projection preserves typed artifact payloads', $failures, $passes );
 agents_api_smoke_assert_equals( true, str_contains( $command_source, 'AgentBundler::package_from_bundle( $bundle )' ), 'package install/diff summary reads identity through WP_Agent_Package', $failures, $passes );
 agents_api_smoke_assert_equals( true, str_contains( $bundler_source, '\'package\'   => AgentPackageProjection::from_directory( $directory )' ), 'export directory path exposes package projection alongside Data Machine directory', $failures, $passes );
+
+echo "\n[4] Ability lifecycle planning uses shared first-class artifact projection:\n";
+$lifecycle_artifacts = array();
+foreach ( ( new AgentBundleLifecycleProjection() )->target_artifacts( $array_bundle ) as $artifact ) {
+	$lifecycle_artifacts[ (string) $artifact['artifact_type'] . ':' . (string) $artifact['artifact_id'] ] = $artifact;
+}
+ksort( $lifecycle_artifacts, SORT_STRING );
+agents_api_smoke_assert_equals( 'prompts/extract-facts.md', $lifecycle_artifacts['prompt:extract-facts']['source_path'] ?? '', 'lifecycle projection includes prompt file artifacts', $failures, $passes );
+agents_api_smoke_assert_equals( 'rubrics/wiki-quality.json', $lifecycle_artifacts['rubric:wiki-quality']['source_path'] ?? '', 'lifecycle projection includes rubric file artifacts', $failures, $passes );
+agents_api_smoke_assert_equals( 'tool-policies/read-only-context.json', $lifecycle_artifacts['tool_policy:read-only-context']['source_path'] ?? '', 'lifecycle projection includes tool policy file artifacts', $failures, $passes );
+agents_api_smoke_assert_equals( 'auth-refs/github-default.json', $lifecycle_artifacts['auth_ref:github-default']['source_path'] ?? '', 'lifecycle projection includes auth ref file artifacts', $failures, $passes );
+agents_api_smoke_assert_equals( 'seed-queues/mgs-topic-loop.json', $lifecycle_artifacts['seed_queue:mgs-topic-loop']['source_path'] ?? '', 'lifecycle projection includes seed queue file artifacts', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $service_source, '$this->projection->target_artifacts( $bundle' ), 'ability service plans through shared lifecycle projection', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $command_source, '$this->projection()->target_artifacts( $bundle' ), 'CLI planning uses the same lifecycle projection', $failures, $passes );
 
 agents_api_smoke_finish( 'Data Machine package artifact projection', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds a shared bundle lifecycle projection helper used by both the ability service and WP-CLI lifecycle code.
- Includes first-class bundle file artifacts in lifecycle target/current planning: prompts, rubrics, tool policies, auth refs, and seed queues.
- Extends smoke coverage so the ability-backed lifecycle path fails if file artifacts drop out of projection again.

Fixes #2244.
Fixes #2245.

## Tests
- `php -l inc/Engine/Bundle/AgentBundleLifecycleProjection.php`
- `php -l inc/Engine/Bundle/AgentBundleAbilityService.php`
- `php -l inc/Cli/Commands/AgentBundleCommand.php`
- `php -l tests/datamachine-package-artifacts-smoke.php`
- `php tests/datamachine-package-artifacts-smoke.php`
- `php tests/agent-bundle-package-portability-smoke.php`
- `php tests/agent-bundle-ability-contract-smoke.php`
- `./vendor/bin/phpcs inc/Engine/Bundle/AgentBundleLifecycleProjection.php inc/Engine/Bundle/AgentBundleAbilityService.php inc/Cli/Commands/AgentBundleCommand.php tests/agent-bundle-ability-contract-smoke.php tests/datamachine-package-artifacts-smoke.php`

## Not run
- `homeboy test --path ... --extension wordpress` and `homeboy lint --path ... --extension wordpress` could not start because Homeboy auto-selected runner `lab`, which is missing required PHP/Composer tools.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the shared lifecycle projection refactor, regression smoke coverage, and verification commands for Chris to review.