### PR TITLE
fix: guard worker and drain concurrency

### DIFF
--- a/inc/Cli/Commands/DrainCommand.php
+++ b/inc/Cli/Commands/DrainCommand.php
@@ -8,6 +8,7 @@
 namespace DataMachine\Cli\Commands;
 
 use DataMachine\Cli\BaseCommand;
+use DataMachine\Cli\WorkerLock;
 use WP_CLI;
 
 defined( 'ABSPATH' ) || exit;
@@ -103,7 +104,7 @@ class DrainCommand extends BaseCommand {
 	 * so this drain runs concrete due action IDs from that same group instead of
 	 * a hand-maintained hook allow-list.
 	 *
-	 * @param array{limit?:int,batch_size?:int,time_limit?:int,stop_before_timeout?:int,hooks?:string[],job_ids?:string|int[]} $options Drain options.
+	 * @param array{limit?:int,batch_size?:int,time_limit?:int,stop_before_timeout?:int,hooks?:string[],job_ids?:string|int[],acquire_lock?:bool,lock_owner?:string} $options Drain options.
 	 * @return array<string,int|string> Drain stats.
 	 */
 	public static function drain( array $options = array() ): array {
@@ -113,6 +114,16 @@ class DrainCommand extends BaseCommand {
 		$stop_before_timeout = max( 0, (int) ( $options['stop_before_timeout'] ?? 0 ) );
 		$hooks               = self::normalizeHooks( $options['hooks'] ?? null );
 		$job_ids             = self::normalizeJobIds( $options['job_ids'] ?? null );
+		$acquire_lock        = (bool) ( $options['acquire_lock'] ?? true );
+		$lock                = array();
+
+		if ( $acquire_lock ) {
+			$lock_ttl = $time_limit > 0 ? $time_limit + max( 60, $stop_before_timeout ) : 600;
+			$lock     = WorkerLock::acquire( (string) ( $options['lock_owner'] ?? self::defaultLockOwner( 'drain' ) ), $lock_ttl );
+			if ( empty( $lock['acquired'] ) ) {
+				return self::lockedStats( $hooks, $job_ids, $lock );
+			}
+		}
 
 		$started_at    = time();
 		$before_counts = self::getStatusCounts( $hooks, $job_ids );
@@ -120,62 +131,69 @@ class DrainCommand extends BaseCommand {
 		$warnings      = 0;
 		$stop_reason   = 'empty';
 
-		while ( self::getDuePendingCount( $hooks, $job_ids ) > 0 ) {
+		try {
+			while ( self::getDuePendingCount( $hooks, $job_ids ) > 0 ) {
+				$stats = self::buildStats( $before_counts, self::getStatusCounts( $hooks, $job_ids ), $batches, $warnings, $hooks, $job_ids, $stop_reason );
+				if ( $limit > 0 && (int) $stats['actions_processed'] >= $limit ) {
+					$stop_reason = 'limit';
+					break;
+				}
+
+				if ( $time_limit > 0 && ( time() - $started_at ) >= $time_limit ) {
+					$stop_reason = 'time_limit';
+					break;
+				}
+
+				if ( $time_limit > 0 && ( $time_limit - ( time() - $started_at ) ) <= $stop_before_timeout ) {
+					$stop_reason = 'timeout_margin';
+					break;
+				}
+
+				$current_batch_size = $batch_size;
+				if ( $limit > 0 ) {
+					$current_batch_size = min( $batch_size, $limit - (int) $stats['actions_processed'] );
+				}
+				if ( $current_batch_size <= 0 ) {
+					$stop_reason = 'limit';
+					break;
+				}
+
+				$action_ids = self::getDuePendingActionIds( $current_batch_size, $hooks, $job_ids );
+				if ( empty( $action_ids ) ) {
+					$stop_reason = 'empty';
+					break;
+				}
+
+				$due_before    = self::getDuePendingCount( $hooks, $job_ids );
+				$status_before = self::getStatusCounts( $hooks, $job_ids );
+				$result        = self::runActionSchedulerActions( $action_ids );
+				++$batches;
+
+				if ( 0 !== (int) ( $result->return_code ?? 1 ) ) {
+					++$warnings;
+					$message = trim( (string) ( $result->stderr ?? '' ) );
+					WP_CLI::warning( '' === $message ? 'Action Scheduler CLI drain failed.' : $message );
+					$stop_reason = 'warning';
+					break;
+				}
+
+				$status_after = self::getStatusCounts( $hooks, $job_ids );
+				$progress     = self::processedDelta( $status_before, $status_after );
+				if ( 0 === $progress && self::getDuePendingCount( $hooks, $job_ids ) >= $due_before ) {
+					++$warnings;
+					WP_CLI::warning( 'Drain stopped because Action Scheduler made no observable progress.' );
+					$stop_reason = 'no_progress';
+					break;
+				}
+			}
+
 			$stats = self::buildStats( $before_counts, self::getStatusCounts( $hooks, $job_ids ), $batches, $warnings, $hooks, $job_ids, $stop_reason );
-			if ( $limit > 0 && (int) $stats['actions_processed'] >= $limit ) {
-				$stop_reason = 'limit';
-				break;
-			}
-
-			if ( $time_limit > 0 && ( time() - $started_at ) >= $time_limit ) {
-				$stop_reason = 'time_limit';
-				break;
-			}
-
-			if ( $time_limit > 0 && ( $time_limit - ( time() - $started_at ) ) <= $stop_before_timeout ) {
-				$stop_reason = 'timeout_margin';
-				break;
-			}
-
-			$current_batch_size = $batch_size;
-			if ( $limit > 0 ) {
-				$current_batch_size = min( $batch_size, $limit - (int) $stats['actions_processed'] );
-			}
-			if ( $current_batch_size <= 0 ) {
-				$stop_reason = 'limit';
-				break;
-			}
-
-			$action_ids = self::getDuePendingActionIds( $current_batch_size, $hooks, $job_ids );
-			if ( empty( $action_ids ) ) {
-				$stop_reason = 'empty';
-				break;
-			}
-
-			$due_before    = self::getDuePendingCount( $hooks, $job_ids );
-			$status_before = self::getStatusCounts( $hooks, $job_ids );
-			$result        = self::runActionSchedulerActions( $action_ids );
-			++$batches;
-
-			if ( 0 !== (int) ( $result->return_code ?? 1 ) ) {
-				++$warnings;
-				$message = trim( (string) ( $result->stderr ?? '' ) );
-				WP_CLI::warning( '' === $message ? 'Action Scheduler CLI drain failed.' : $message );
-				$stop_reason = 'warning';
-				break;
-			}
-
-			$status_after = self::getStatusCounts( $hooks, $job_ids );
-			$progress     = self::processedDelta( $status_before, $status_after );
-			if ( 0 === $progress && self::getDuePendingCount( $hooks, $job_ids ) >= $due_before ) {
-				++$warnings;
-				WP_CLI::warning( 'Drain stopped because Action Scheduler made no observable progress.' );
-				$stop_reason = 'no_progress';
-				break;
+			return self::withLockStatus( $stats, $lock );
+		} finally {
+			if ( $acquire_lock ) {
+				WorkerLock::release( (string) ( $lock['lock_token'] ?? '' ) );
 			}
 		}
-
-		return self::buildStats( $before_counts, self::getStatusCounts( $hooks, $job_ids ), $batches, $warnings, $hooks, $job_ids, $stop_reason );
 	}
 
 	/**
@@ -187,13 +205,82 @@ class DrainCommand extends BaseCommand {
 	public static function status( array $options = array() ): array {
 		$hooks   = self::normalizeHooks( $options['hooks'] ?? null );
 		$job_ids = self::normalizeJobIds( $options['job_ids'] ?? null );
+		$lock    = WorkerLock::snapshot();
 
 		return array(
 			'due_pending'   => self::getDuePendingCount( $hooks, $job_ids ),
 			'total_pending' => self::getPendingCount( $hooks, $job_ids ),
 			'hooks'         => implode( ',', array_keys( self::getStatusCounts( $hooks, $job_ids ) ) ),
 			'job_ids'       => implode( ',', $job_ids ),
+		) + self::publicLockStatus( $lock );
+	}
+
+	/**
+	 * Build a lock-skipped drain result.
+	 *
+	 * @param string[]|null                 $hooks   Hook scope.
+	 * @param int[]                         $job_ids Job ID scope.
+	 * @param array<string,int|string|bool> $lock    Lock state.
+	 * @return array<string,int|string> Drain stats.
+	 */
+	private static function lockedStats( ?array $hooks, array $job_ids, array $lock ): array {
+		return self::withLockStatus(
+			array(
+				'batches'                    => 0,
+				'batch_chunks'               => 0,
+				'step_executions'            => 0,
+				'completions'                => 0,
+				'failures'                   => 0,
+				'batch_chunk_completions'    => 0,
+				'batch_chunk_failures'       => 0,
+				'step_execution_completions' => 0,
+				'step_execution_failures'    => 0,
+				'actions_processed'          => 0,
+				'other_actions'              => 0,
+				'remaining_pending'          => self::getDuePendingCount( $hooks, $job_ids ),
+				'total_pending'              => self::getPendingCount( $hooks, $job_ids ),
+				'warnings'                   => 0,
+				'stop_reason'                => 'locked',
+				'hooks'                      => implode( ',', array_keys( self::getStatusCounts( $hooks, $job_ids ) ) ),
+				'job_ids'                    => implode( ',', $job_ids ),
+			),
+			$lock
 		);
+	}
+
+	/**
+	 * Add operator-facing lock fields to stats.
+	 *
+	 * @param array<string,int|string>      $stats Stats.
+	 * @param array<string,int|string|bool> $lock  Lock state.
+	 * @return array<string,int|string> Stats with lock fields.
+	 */
+	private static function withLockStatus( array $stats, array $lock ): array {
+		return $stats + self::publicLockStatus( $lock );
+	}
+
+	/**
+	 * Strip private lock fields before CLI output.
+	 *
+	 * @param array<string,int|string|bool> $lock Lock state.
+	 * @return array<string,int|string> Public lock state.
+	 */
+	private static function publicLockStatus( array $lock ): array {
+		return array(
+			'lock_status'      => (string) ( $lock['lock_status'] ?? 'unlocked' ),
+			'lock_owner'       => (string) ( $lock['lock_owner'] ?? '' ),
+			'lock_age_seconds' => (int) ( $lock['lock_age_seconds'] ?? 0 ),
+			'lock_expires_at'  => (int) ( $lock['lock_expires_at'] ?? 0 ),
+		);
+	}
+
+	/**
+	 * Build a compact default owner string for lock diagnostics.
+	 */
+	private static function defaultLockOwner( string $command ): string {
+		$pid = getmypid();
+
+		return sprintf( '%s pid:%d host:%s', $command, false === $pid ? 0 : $pid, php_uname( 'n' ) );
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkerCommand.php
+++ b/inc/Cli/Commands/WorkerCommand.php
@@ -10,6 +10,7 @@ namespace DataMachine\Cli\Commands;
 use DataMachine\Abilities\Job\JobsSummaryAbility;
 use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Cli\BaseCommand;
+use DataMachine\Cli\WorkerLock;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 use WP_CLI;
 
@@ -184,6 +185,11 @@ class WorkerCommand extends BaseCommand {
 		$max_passes              = max( 0, (int) ( $options['max_passes'] ?? 0 ) );
 		$stop_before_timeout     = max( 0, (int) ( $options['stop_before_timeout'] ?? 30 ) );
 		$once                    = (bool) ( $options['once'] ?? false );
+		$lock                    = WorkerLock::acquire( self::defaultLockOwner(), $time_limit > 0 ? $time_limit + max( 60, $stop_before_timeout ) : 600 );
+
+		if ( empty( $lock['acquired'] ) ) {
+			return self::lockedStats( $lock );
+		}
 
 		$passes      = 0;
 		$recoveries  = 0;
@@ -194,92 +200,97 @@ class WorkerCommand extends BaseCommand {
 		$warnings    = 0;
 		$stop_reason = 'time_limit';
 
-		while ( true ) {
-			$elapsed = time() - $started_at;
-			if ( $time_limit > 0 && $elapsed >= $time_limit ) {
-				break;
-			}
-			if ( $time_limit > 0 && ( $time_limit - $elapsed ) <= $stop_before_timeout ) {
-				$stop_reason = 'timeout_margin';
-				break;
-			}
-			if ( $max_passes > 0 && $passes >= $max_passes ) {
-				$stop_reason = 'max_passes';
-				break;
-			}
-
-			$pending_actions = self::pendingActionCount();
-			if ( $stop_on_pending_actions && $pending_actions > 0 ) {
-				$stop_reason = 'pending_actions';
-				break;
-			}
-
-			++$passes;
-
-			if ( $recover_stuck ) {
-				$recovery = ( new RecoverStuckJobsAbility() )->execute(
-					array(
-						'dry_run'       => false,
-						'timeout_hours' => $stuck_timeout,
-					)
-				);
-
-				if ( empty( $recovery['success'] ) ) {
-					++$warnings;
-				} else {
-					$recoveries += (int) ( $recovery['recovered'] ?? 0 );
-					$timed_out  += (int) ( $recovery['timed_out'] ?? 0 );
-					$reconciled += (int) ( $recovery['stale_actions'] ?? 0 );
+		try {
+			while ( true ) {
+				$elapsed = time() - $started_at;
+				if ( $time_limit > 0 && $elapsed >= $time_limit ) {
+					break;
 				}
-			}
-
-			$remaining_time = $time_limit > 0 ? max( 1, $time_limit - $stop_before_timeout - ( time() - $started_at ) ) : $drain_time_limit;
-			$drain          = DrainCommand::drain(
-				array(
-					'limit'      => $drain_limit,
-					'batch_size' => $batch_size,
-					'time_limit' => min( $drain_time_limit, $remaining_time ),
-				)
-			);
-
-			$completions += (int) ( $drain['completions'] ?? 0 );
-			$failures    += (int) ( $drain['failures'] ?? 0 );
-			$warnings    += (int) ( $drain['warnings'] ?? 0 );
-
-			if ( $once ) {
-				$stop_reason = 'once';
-				break;
-			}
-
-			if ( (int) ( $drain['remaining_pending'] ?? 0 ) <= 0 ) {
-				$stop_reason = 'idle';
-				if ( $sleep <= 0 ) {
+				if ( $time_limit > 0 && ( $time_limit - $elapsed ) <= $stop_before_timeout ) {
+					$stop_reason = 'timeout_margin';
+					break;
+				}
+				if ( $max_passes > 0 && $passes >= $max_passes ) {
+					$stop_reason = 'max_passes';
 					break;
 				}
 
-				sleep( min( $sleep, $time_limit > 0 ? max( 0, $time_limit - $stop_before_timeout - ( time() - $started_at ) ) : $sleep ) );
+				$pending_actions = self::pendingActionCount();
+				if ( $stop_on_pending_actions && $pending_actions > 0 ) {
+					$stop_reason = 'pending_actions';
+					break;
+				}
+
+				++$passes;
+
+				if ( $recover_stuck ) {
+					$recovery = ( new RecoverStuckJobsAbility() )->execute(
+						array(
+							'dry_run'       => false,
+							'timeout_hours' => $stuck_timeout,
+						)
+					);
+
+					if ( empty( $recovery['success'] ) ) {
+						++$warnings;
+					} else {
+						$recoveries += (int) ( $recovery['recovered'] ?? 0 );
+						$timed_out  += (int) ( $recovery['timed_out'] ?? 0 );
+						$reconciled += (int) ( $recovery['stale_actions'] ?? 0 );
+					}
+				}
+
+				$remaining_time = $time_limit > 0 ? max( 1, $time_limit - $stop_before_timeout - ( time() - $started_at ) ) : $drain_time_limit;
+				$drain          = DrainCommand::drain(
+					array(
+						'limit'        => $drain_limit,
+						'batch_size'   => $batch_size,
+						'time_limit'   => min( $drain_time_limit, $remaining_time ),
+						'acquire_lock' => false,
+					)
+				);
+
+				$completions += (int) ( $drain['completions'] ?? 0 );
+				$failures    += (int) ( $drain['failures'] ?? 0 );
+				$warnings    += (int) ( $drain['warnings'] ?? 0 );
+
+				if ( $once ) {
+					$stop_reason = 'once';
+					break;
+				}
+
+				if ( (int) ( $drain['remaining_pending'] ?? 0 ) <= 0 ) {
+					$stop_reason = 'idle';
+					if ( $sleep <= 0 ) {
+						break;
+					}
+
+					sleep( min( $sleep, $time_limit > 0 ? max( 0, $time_limit - $stop_before_timeout - ( time() - $started_at ) ) : $sleep ) );
+				}
 			}
+
+			$status = self::statusSnapshot();
+
+			return array(
+				'passes'                   => $passes,
+				'job_recoveries'           => $recoveries,
+				'job_timeouts'             => $timed_out,
+				'stale_actions_reconciled' => $reconciled,
+				'action_completions'       => $completions,
+				'action_failures'          => $failures,
+				'pending_actions'          => (int) $status['pending_actions'],
+				'due_actions'              => (int) $status['due_actions'],
+				'total_pending_actions'    => (int) $status['total_pending_actions'],
+				'processing_jobs'          => (int) $status['processing_jobs'],
+				'pending_jobs'             => (int) $status['pending_jobs'],
+				'stuck_jobs'               => (int) $status['stuck_jobs'],
+				'warnings'                 => $warnings,
+				'duration_seconds'         => time() - $started_at,
+				'stop_reason'              => $stop_reason,
+			) + self::publicLockStatus( $lock );
+		} finally {
+			WorkerLock::release( (string) ( $lock['lock_token'] ?? '' ) );
 		}
-
-		$status = self::statusSnapshot();
-
-		return array(
-			'passes'                   => $passes,
-			'job_recoveries'           => $recoveries,
-			'job_timeouts'             => $timed_out,
-			'stale_actions_reconciled' => $reconciled,
-			'action_completions'       => $completions,
-			'action_failures'          => $failures,
-			'pending_actions'          => (int) $status['pending_actions'],
-			'due_actions'              => (int) $status['due_actions'],
-			'total_pending_actions'    => (int) $status['total_pending_actions'],
-			'processing_jobs'          => (int) $status['processing_jobs'],
-			'pending_jobs'             => (int) $status['pending_jobs'],
-			'stuck_jobs'               => (int) $status['stuck_jobs'],
-			'warnings'                 => $warnings,
-			'duration_seconds'         => time() - $started_at,
-			'stop_reason'              => $stop_reason,
-		);
 	}
 
 	/**
@@ -293,6 +304,7 @@ class WorkerCommand extends BaseCommand {
 		$jobs_summary    = ( new JobsSummaryAbility() )->execute( array() );
 		$jobs            = ! empty( $jobs_summary['success'] ) && is_array( $jobs_summary['summary'] ?? null ) ? $jobs_summary['summary'] : array();
 		$stuck_jobs      = RecoverStuckJobsAbility::countStuckCandidates();
+		$lock            = WorkerLock::snapshot();
 
 		return array(
 			'pending_actions'       => (int) ( $pending_summary['total'] ?? 0 ),
@@ -304,7 +316,59 @@ class WorkerCommand extends BaseCommand {
 			'pending_jobs'          => (int) ( $jobs['pending'] ?? 0 ),
 			'failed_jobs'           => (int) ( $jobs['failed'] ?? 0 ),
 			'stuck_jobs'            => $stuck_jobs,
+		) + self::publicLockStatus( $lock );
+	}
+
+	/**
+	 * Build a lock-skipped worker result.
+	 *
+	 * @param array<string,int|string|bool> $lock Lock state.
+	 * @return array<string,int|string> Worker stats.
+	 */
+	private static function lockedStats( array $lock ): array {
+		$status = self::statusSnapshot();
+
+		return array(
+			'passes'                   => 0,
+			'job_recoveries'           => 0,
+			'job_timeouts'             => 0,
+			'stale_actions_reconciled' => 0,
+			'action_completions'       => 0,
+			'action_failures'          => 0,
+			'pending_actions'          => (int) $status['pending_actions'],
+			'due_actions'              => (int) $status['due_actions'],
+			'total_pending_actions'    => (int) $status['total_pending_actions'],
+			'processing_jobs'          => (int) $status['processing_jobs'],
+			'pending_jobs'             => (int) $status['pending_jobs'],
+			'stuck_jobs'               => (int) $status['stuck_jobs'],
+			'warnings'                 => 0,
+			'duration_seconds'         => 0,
+			'stop_reason'              => 'locked',
+		) + self::publicLockStatus( $lock );
+	}
+
+	/**
+	 * Strip private lock fields before CLI output.
+	 *
+	 * @param array<string,int|string|bool> $lock Lock state.
+	 * @return array<string,int|string> Public lock state.
+	 */
+	private static function publicLockStatus( array $lock ): array {
+		return array(
+			'lock_status'      => (string) ( $lock['lock_status'] ?? 'unlocked' ),
+			'lock_owner'       => (string) ( $lock['lock_owner'] ?? '' ),
+			'lock_age_seconds' => (int) ( $lock['lock_age_seconds'] ?? 0 ),
+			'lock_expires_at'  => (int) ( $lock['lock_expires_at'] ?? 0 ),
 		);
+	}
+
+	/**
+	 * Build a compact default owner string for lock diagnostics.
+	 */
+	private static function defaultLockOwner(): string {
+		$pid = getmypid();
+
+		return sprintf( 'worker pid:%d host:%s', false === $pid ? 0 : $pid, php_uname( 'n' ) );
 	}
 
 	/**

--- a/inc/Cli/WorkerLock.php
+++ b/inc/Cli/WorkerLock.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Shared WP-CLI worker/drain runtime lock.
+ *
+ * @package DataMachine\Cli
+ */
+
+namespace DataMachine\Cli;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Prevent overlapping external worker/drain invocations.
+ */
+class WorkerLock {
+
+	private const OPTION_NAME = 'datamachine_worker_runtime_lock';
+
+	private const DEFAULT_TTL = 600;
+
+	/**
+	 * Acquire the runtime lock.
+	 *
+	 * @param string $owner Operator-facing lock owner.
+	 * @param int    $ttl   Stale-lock timeout in seconds.
+	 * @return array<string,int|string|bool> Lock state.
+	 */
+	public static function acquire( string $owner, int $ttl = self::DEFAULT_TTL ): array {
+		$ttl = max( 60, $ttl );
+		$now = time();
+
+		$existing = self::snapshot( $now, $ttl );
+		if ( 'stale' === $existing['lock_status'] ) {
+			delete_option( self::OPTION_NAME );
+		} elseif ( 'held' === $existing['lock_status'] ) {
+			$existing['acquired'] = false;
+			return $existing;
+		}
+
+		$token   = wp_generate_uuid4();
+		$payload = array(
+			'token'      => $token,
+			'owner'      => sanitize_text_field( $owner ),
+			'started_at' => $now,
+			'expires_at' => $now + $ttl,
+			'ttl'        => $ttl,
+		);
+
+		if ( add_option( self::OPTION_NAME, $payload, '', 'no' ) ) {
+			return self::formatSnapshot( $payload, $now, 'held', true );
+		}
+
+		$existing             = self::snapshot( $now, $ttl );
+		$existing['acquired'] = false;
+		return $existing;
+	}
+
+	/**
+	 * Release the lock only when the caller still owns it.
+	 *
+	 * @param string $token Lock token returned by acquire().
+	 */
+	public static function release( string $token ): void {
+		if ( '' === $token ) {
+			return;
+		}
+
+		$payload = get_option( self::OPTION_NAME, array() );
+		if ( is_array( $payload ) && hash_equals( (string) ( $payload['token'] ?? '' ), $token ) ) {
+			delete_option( self::OPTION_NAME );
+		}
+	}
+
+	/**
+	 * Return a read-only lock snapshot for operator status surfaces.
+	 *
+	 * @param int|null $now Current timestamp for tests/callers that need stability.
+	 * @param int      $ttl Stale-lock timeout in seconds.
+	 * @return array<string,int|string|bool> Lock state.
+	 */
+	public static function snapshot( ?int $now = null, int $ttl = self::DEFAULT_TTL ): array {
+		$now     = $now ?? time();
+		$ttl     = max( 60, $ttl );
+		$payload = get_option( self::OPTION_NAME, array() );
+
+		if ( ! is_array( $payload ) || empty( $payload['started_at'] ) ) {
+			return array(
+				'lock_status'      => 'unlocked',
+				'lock_owner'       => '',
+				'lock_age_seconds' => 0,
+				'lock_expires_at'  => 0,
+				'lock_token'       => '',
+				'acquired'         => false,
+			);
+		}
+
+		$started_at = (int) ( $payload['started_at'] ?? 0 );
+		$expires_at = (int) ( $payload['expires_at'] ?? ( $started_at + $ttl ) );
+		$status     = $expires_at <= $now ? 'stale' : 'held';
+
+		return self::formatSnapshot( $payload, $now, $status, false );
+	}
+
+	/**
+	 * Normalize lock payload for CLI output.
+	 *
+	 * @param array<string,mixed> $payload  Stored payload.
+	 * @param int                 $now      Current timestamp.
+	 * @param string              $status   Lock status.
+	 * @param bool                $acquired Whether this process acquired it.
+	 * @return array<string,int|string|bool> Lock state.
+	 */
+	private static function formatSnapshot( array $payload, int $now, string $status, bool $acquired ): array {
+		$started_at = (int) ( $payload['started_at'] ?? 0 );
+
+		return array(
+			'lock_status'      => $status,
+			'lock_owner'       => (string) ( $payload['owner'] ?? '' ),
+			'lock_age_seconds' => max( 0, $now - $started_at ),
+			'lock_expires_at'  => (int) ( $payload['expires_at'] ?? 0 ),
+			'lock_token'       => (string) ( $payload['token'] ?? '' ),
+			'acquired'         => $acquired,
+		);
+	}
+}

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -42,6 +42,11 @@ assert_drain_contains( "datamachine_execute_step'", $drain_src, 'drain includes 
 assert_drain_contains( '[--job-id=<ids>]', $drain_src, 'drain documents optional job-id scope' );
 assert_drain_contains( '[--stop-before-timeout=<seconds>]', $drain_src, 'drain documents optional timeout safety margin' );
 assert_drain_contains( "'stop_before_timeout'", $drain_src, 'drain accepts worker-style timeout safety margin option' );
+assert_drain_contains( 'WorkerLock::acquire', $drain_src, 'drain acquires shared worker/drain lock' );
+assert_drain_contains( 'WorkerLock::release', $drain_src, 'drain releases shared worker/drain lock' );
+assert_drain_contains( "'stop_reason'                => 'locked'", $drain_src, 'drain exits cleanly when lock is held' );
+assert_drain_contains( 'lock_age_seconds', $drain_src, 'drain reports lock age' );
+assert_drain_contains( 'lock_owner', $drain_src, 'drain reports lock owner' );
 assert_drain_contains( 'normalizeJobIds', $drain_src, 'drain normalizes optional job-id scope' );
 assert_drain_contains( 'hookWhereSql( $hooks, $job_ids )', $drain_src, 'drain supports optional hook and job-id scopes' );
 assert_drain_contains( 'a.args LIKE %s', $drain_src, 'drain can filter pending actions by serialized job_id args' );

--- a/tests/worker-cli-smoke.php
+++ b/tests/worker-cli-smoke.php
@@ -35,8 +35,11 @@ assert_worker_contains( "WP_CLI::add_command( 'datamachine worker'", $boot_src, 
 assert_worker_contains( 'class WorkerCommand extends BaseCommand', $worker_src, 'worker follows CLI command pattern' );
 assert_worker_contains( '@subcommand run', $worker_src, 'worker exposes run subcommand' );
 assert_worker_contains( '@subcommand status', $worker_src, 'worker exposes status subcommand' );
+assert_worker_contains( 'WorkerLock::acquire', $worker_src, 'worker acquires shared worker/drain lock' );
+assert_worker_contains( 'WorkerLock::release', $worker_src, 'worker releases shared worker/drain lock' );
 assert_worker_contains( 'RecoverStuckJobsAbility', $worker_src, 'worker composes stuck job recovery ability' );
 assert_worker_contains( 'DrainCommand::drain(', $worker_src, 'worker composes the existing drain loop' );
+assert_worker_contains( "'acquire_lock' => false", $worker_src, 'worker internal drain does not fight outer lock' );
 assert_worker_contains( 'PendingActionStore::summary', $worker_src, 'worker reads pending-action gate through the store' );
 assert_worker_contains( 'JobsSummaryAbility', $worker_src, 'worker reads job status through the existing summary ability' );
 assert_worker_contains( 'stop_on_pending_actions', $worker_src, 'worker can stop at approval gates' );
@@ -44,6 +47,9 @@ assert_worker_contains( 'max_passes', $worker_src, 'worker supports bounded pass
 assert_worker_contains( 'stop_before_timeout', $worker_src, 'worker exits before external supervisor timeouts' );
 assert_worker_contains( 'drain_time_limit', $worker_src, 'worker bounds each drain pass' );
 assert_worker_contains( 'DrainCommand::status()', $worker_src, 'worker reads Action Scheduler state through drain status' );
+assert_worker_contains( 'lock_age_seconds', $worker_src, 'worker status reports lock age' );
+assert_worker_contains( 'lock_owner', $worker_src, 'worker status reports lock owner' );
+assert_worker_contains( "'stop_reason'              => 'locked'", $worker_src, 'worker exits cleanly when lock is held' );
 assert_worker_not_contains( 'action-scheduler action run ', $worker_src, 'worker does not shell directly to Action Scheduler' );
 assert_worker_not_contains( 'actionscheduler_actions', $worker_src, 'worker does not query Action Scheduler tables directly' );
 assert_worker_not_contains( 'datamachine_jobs', $worker_src, 'worker does not query jobs tables directly' );

--- a/tests/worker-lock-smoke.php
+++ b/tests/worker-lock-smoke.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Pure-PHP smoke test for the Data Machine worker/drain runtime lock.
+ *
+ * Run with: php tests/worker-lock-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+$GLOBALS['datamachine_worker_lock_options'] = array();
+
+function get_option( string $name, mixed $default = false ): mixed {
+	return $GLOBALS['datamachine_worker_lock_options'][ $name ] ?? $default;
+}
+
+function add_option( string $name, mixed $value, string $deprecated = '', string $autoload = 'yes' ): bool {
+	unset( $deprecated, $autoload );
+	if ( array_key_exists( $name, $GLOBALS['datamachine_worker_lock_options'] ) ) {
+		return false;
+	}
+
+	$GLOBALS['datamachine_worker_lock_options'][ $name ] = $value;
+	return true;
+}
+
+function delete_option( string $name ): bool {
+	unset( $GLOBALS['datamachine_worker_lock_options'][ $name ] );
+	return true;
+}
+
+function wp_generate_uuid4(): string {
+	static $i = 0;
+	++$i;
+	return 'worker-lock-token-' . $i;
+}
+
+function sanitize_text_field( string $text ): string {
+	return trim( $text );
+}
+
+require_once __DIR__ . '/../inc/Cli/WorkerLock.php';
+
+use DataMachine\Cli\WorkerLock;
+
+$assertions = 0;
+
+function assert_worker_lock_true( bool $condition, string $message ): void {
+	global $assertions;
+	++$assertions;
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+$first = WorkerLock::acquire( 'worker one', 120 );
+assert_worker_lock_true( true === $first['acquired'], 'first worker acquires the lock' );
+assert_worker_lock_true( 'held' === $first['lock_status'], 'acquired lock reports held status' );
+assert_worker_lock_true( 'worker one' === $first['lock_owner'], 'lock reports owner' );
+
+$second = WorkerLock::acquire( 'worker two', 120 );
+assert_worker_lock_true( false === $second['acquired'], 'overlapping worker skips cleanly' );
+assert_worker_lock_true( 'held' === $second['lock_status'], 'overlapping worker sees held lock' );
+assert_worker_lock_true( 'worker one' === $second['lock_owner'], 'overlap reports existing owner' );
+
+WorkerLock::release( (string) $first['lock_token'] );
+$released = WorkerLock::snapshot();
+assert_worker_lock_true( 'unlocked' === $released['lock_status'], 'release clears owned lock' );
+
+$stale_started = time() - 300;
+add_option(
+	'datamachine_worker_runtime_lock',
+	array(
+		'token'      => 'stale-token',
+		'owner'      => 'old worker',
+		'started_at' => $stale_started,
+		'expires_at' => $stale_started + 60,
+		'ttl'        => 60,
+	),
+	'',
+	'no'
+);
+
+$stale = WorkerLock::snapshot();
+assert_worker_lock_true( 'stale' === $stale['lock_status'], 'expired lock reports stale status' );
+
+$replacement = WorkerLock::acquire( 'new worker', 120 );
+assert_worker_lock_true( true === $replacement['acquired'], 'stale lock is replaced by new owner' );
+assert_worker_lock_true( 'new worker' === $replacement['lock_owner'], 'replacement lock reports new owner' );
+
+WorkerLock::release( 'wrong-token' );
+$still_held = WorkerLock::snapshot();
+assert_worker_lock_true( 'held' === $still_held['lock_status'], 'wrong token does not release lock' );
+
+WorkerLock::release( (string) $replacement['lock_token'] );
+assert_worker_lock_true( 'unlocked' === WorkerLock::snapshot()['lock_status'], 'replacement lock releases cleanly' );
+
+echo "OK ({$assertions} assertions)\n";


### PR DESCRIPTION
## Summary
- Add a shared short-lived WP-CLI runtime lock for external `datamachine worker run` and direct `datamachine drain` calls.
- Return clean `stop_reason=locked` / lock status fields instead of overlapping work when another invocation is already active.
- Surface lock status, owner, age, and expiry in worker/drain status output and smoke coverage.

## Notes
- The worker holds the coarse external invocation lock and calls its internal drain pass with `acquire_lock=false`, so worker ownership does not fight itself.
- This stays separate from per-job/action claim ownership work in #2252: the lock gates cron/process overlap, while claim ownership should continue to arbitrate individual work items.

## Tests
- `php tests/worker-lock-smoke.php`
- `php tests/worker-cli-smoke.php`
- `php tests/flow-run-cli-drain-smoke.php`
- `vendor/bin/phpcs inc/Cli/WorkerLock.php inc/Cli/Commands/DrainCommand.php inc/Cli/Commands/WorkerCommand.php tests/worker-lock-smoke.php tests/worker-cli-smoke.php tests/flow-run-cli-drain-smoke.php`
- `homeboy test --force-hot --path /Users/chubes/Developer/data-machine@fix-issue-2255-worker-lock --extension wordpress`
- `homeboy lint --force-hot --path /Users/chubes/Developer/data-machine@fix-issue-2255-worker-lock --extension wordpress --changed-since origin/main`

## Lint caveat
- Full unscoped `homeboy lint --force-hot --path /Users/chubes/Developer/data-machine@fix-issue-2255-worker-lock --extension wordpress` still reports existing unrelated JS lint findings outside this PHP/CLI change scope.

Fixes #2255.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the worker/drain lock, smoke coverage, verification runs, and PR drafting; Chris remains responsible for review and merge.