### PR TITLE
fix: polish pending action operator output

### DIFF
--- a/inc/Cli/ActionSchedulerWPCLICompat.php
+++ b/inc/Cli/ActionSchedulerWPCLICompat.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Action Scheduler WP-CLI compatibility shims.
+ *
+ * @package DataMachine\Cli
+ */
+
+namespace Action_Scheduler\WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( __NAMESPACE__ . '\\WP_CLI', false ) && class_exists( '\\WP_CLI', false ) ) {
+	/**
+	 * Proxies unqualified WP_CLI calls from bundled Action Scheduler namespaced commands.
+	 */
+	class WP_CLI {
+		/**
+		 * Forward static calls to the global WP_CLI class.
+		 *
+		 * @param string $method    Method name.
+		 * @param array  $arguments Method arguments.
+		 * @return mixed
+		 */
+		public static function __callStatic( string $method, array $arguments ) {
+			return call_user_func_array( array( '\\WP_CLI', $method ), $arguments );
+		}
+	}
+}

--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -16,6 +16,8 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 	return;
 }
 
+require_once __DIR__ . '/ActionSchedulerWPCLICompat.php';
+
 // Primary commands.
 WP_CLI::add_command( 'datamachine settings', Commands\SettingsCommand::class );
 WP_CLI::add_command( 'datamachine flows', Commands\Flows\FlowsCommand::class );

--- a/inc/Cli/Commands/PendingActionsCommand.php
+++ b/inc/Cli/Commands/PendingActionsCommand.php
@@ -108,6 +108,12 @@ class PendingActionsCommand extends BaseCommand {
 	 * [--kind=<kind>]
 	 * : Filter by action kind before summarizing.
 	 *
+	 * [--context-limit=<limit>]
+	 * : Maximum context buckets to include. Default 25, max 200. Use 0 for all buckets.
+	 *
+	 * [--include-context-details]
+	 * : Include all context buckets in the summary.
+	 *
 	 * [--format=<format>]
 	 * : Output format. Default json.
 	 *

--- a/inc/Engine/AI/Actions/PendingActionInspectionAbility.php
+++ b/inc/Engine/AI/Actions/PendingActionInspectionAbility.php
@@ -243,6 +243,20 @@ final class PendingActionInspectionAbility {
 			}
 		}
 
+		foreach ( array( 'context_limit', 'context-limit' ) as $key ) {
+			if ( isset( $input[ $key ] ) && '' !== $input[ $key ] ) {
+				$filters['context_limit'] = (int) $input[ $key ];
+				break;
+			}
+		}
+
+		foreach ( array( 'include_context_details', 'include-context-details' ) as $key ) {
+			if ( ! empty( $input[ $key ] ) ) {
+				$filters['include_context_details'] = true;
+				break;
+			}
+		}
+
 		if ( isset( $input['context'] ) && is_array( $input['context'] ) ) {
 			$filters['context'] = array_map( 'sanitize_text_field', $input['context'] );
 		}
@@ -257,20 +271,30 @@ final class PendingActionInspectionAbility {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
-				'status'         => array( 'type' => 'string' ),
-				'kind'           => array( 'type' => 'string' ),
-				'agent_id'       => array( 'type' => 'integer' ),
-				'created_by'     => array( 'type' => 'integer' ),
-				'context'        => array( 'type' => 'object' ),
-				'created_after'  => array( 'type' => 'string' ),
-				'created_before' => array( 'type' => 'string' ),
-				'limit'          => array(
+				'status'                  => array( 'type' => 'string' ),
+				'kind'                    => array( 'type' => 'string' ),
+				'agent_id'                => array( 'type' => 'integer' ),
+				'created_by'              => array( 'type' => 'integer' ),
+				'context'                 => array( 'type' => 'object' ),
+				'created_after'           => array( 'type' => 'string' ),
+				'created_before'          => array( 'type' => 'string' ),
+				'limit'                   => array(
 					'type'    => 'integer',
 					'default' => 50,
 				),
-				'offset'         => array(
+				'offset'                  => array(
 					'type'    => 'integer',
 					'default' => 0,
+				),
+				'context_limit'           => array(
+					'type'        => 'integer',
+					'default'     => 25,
+					'description' => __( 'Maximum context buckets to include in summaries. Use 0 for all buckets.', 'data-machine' ),
+				),
+				'include_context_details' => array(
+					'type'        => 'boolean',
+					'default'     => false,
+					'description' => __( 'Include all context buckets in summaries.', 'data-machine' ),
 				),
 			),
 		);

--- a/inc/Engine/AI/Actions/PendingActionStore.php
+++ b/inc/Engine/AI/Actions/PendingActionStore.php
@@ -472,11 +472,16 @@ class PendingActionStore {
 	public static function summary( array $filters = array() ): array {
 		if ( ! self::has_database() ) {
 			return array(
-				'total'       => 0,
-				'by_status'   => array(),
-				'by_kind'     => array(),
-				'by_agent_id' => array(),
-				'by_context'  => array(),
+				'total'                    => 0,
+				'by_status'                => array(),
+				'by_kind'                  => array(),
+				'by_agent_id'              => array(),
+				'by_context'               => array(),
+				'by_context_total'         => 0,
+				'by_context_shown'         => 0,
+				'by_context_omitted'       => 0,
+				'context_limit'            => self::normalize_context_summary_limit( $filters ),
+				'context_detail_truncated' => false,
 			);
 		}
 
@@ -525,12 +530,19 @@ class PendingActionStore {
 		$rows = $wpdb->get_results( $wpdb->prepare( $sql, ...$prepare_args ), ARRAY_A );
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
+		$context_limit = self::normalize_context_summary_limit( $filters );
+
 		$summary = array(
-			'total'       => count( (array) $rows ),
-			'by_status'   => array(),
-			'by_kind'     => array(),
-			'by_agent_id' => array(),
-			'by_context'  => array(),
+			'total'                    => count( (array) $rows ),
+			'by_status'                => array(),
+			'by_kind'                  => array(),
+			'by_agent_id'              => array(),
+			'by_context'               => array(),
+			'by_context_total'         => 0,
+			'by_context_shown'         => 0,
+			'by_context_omitted'       => 0,
+			'context_limit'            => $context_limit,
+			'context_detail_truncated' => false,
 		);
 
 		foreach ( (array) $rows as $row ) {
@@ -546,7 +558,68 @@ class PendingActionStore {
 			}
 		}
 
+		self::sort_summary_bucket( $summary['by_status'] );
+		self::sort_summary_bucket( $summary['by_kind'] );
+		self::sort_summary_bucket( $summary['by_agent_id'] );
+		self::sort_summary_bucket( $summary['by_context'] );
+
+		$context_total                       = count( $summary['by_context'] );
+		$summary['by_context_total']         = $context_total;
+		$summary['by_context']               = self::limit_summary_bucket( $summary['by_context'], $context_limit );
+		$summary['by_context_shown']         = count( $summary['by_context'] );
+		$summary['by_context_omitted']       = max( 0, $context_total - $summary['by_context_shown'] );
+		$summary['context_detail_truncated'] = $summary['by_context_omitted'] > 0;
+
 		return $summary;
+	}
+
+	/**
+	 * Normalize context bucket output limit for summaries.
+	 *
+	 * @param array $filters Query filters.
+	 * @return int Zero means unbounded.
+	 */
+	private static function normalize_context_summary_limit( array $filters ): int {
+		if ( ! empty( $filters['include_context_details'] ) ) {
+			return 0;
+		}
+
+		if ( array_key_exists( 'context_limit', $filters ) ) {
+			$limit = (int) $filters['context_limit'];
+			return 0 === $limit ? 0 : max( 1, min( 200, $limit ) );
+		}
+
+		return 25;
+	}
+
+	/**
+	 * Sort a summary bucket by count descending, then key ascending.
+	 *
+	 * @param array<string,int> $bucket Bucket to sort.
+	 */
+	private static function sort_summary_bucket( array &$bucket ): void {
+		uksort(
+			$bucket,
+			static function ( string $left, string $right ) use ( $bucket ): int {
+				$count_compare = ( $bucket[ $right ] ?? 0 ) <=> ( $bucket[ $left ] ?? 0 );
+				return 0 !== $count_compare ? $count_compare : strcmp( $left, $right );
+			}
+		);
+	}
+
+	/**
+	 * Return the top summary bucket rows according to the requested limit.
+	 *
+	 * @param array<string,int> $bucket Bucket to limit.
+	 * @param int               $limit  Zero means unbounded.
+	 * @return array<string,int>
+	 */
+	private static function limit_summary_bucket( array $bucket, int $limit ): array {
+		if ( 0 === $limit ) {
+			return $bucket;
+		}
+
+		return array_slice( $bucket, 0, $limit, true );
 	}
 
 	/**

--- a/tests/action-scheduler-wpcli-compat-smoke.php
+++ b/tests/action-scheduler-wpcli-compat-smoke.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Smoke coverage for the bundled Action Scheduler WP-CLI namespace shim.
+ *
+ * Run with: php tests/action-scheduler-wpcli-compat-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+echo "action-scheduler-wpcli-compat-smoke\n";
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! defined( 'WP_CLI' ) ) {
+	define( 'WP_CLI', true );
+}
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+	class WP_CLI {
+		/** @var array<int,string> */
+		public static array $commands = array();
+
+		public static function runcommand( string $command ): string {
+			self::$commands[] = $command;
+			return 'ok';
+		}
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Cli/ActionSchedulerWPCLICompat.php';
+
+$result = \Action_Scheduler\WP_CLI\WP_CLI::runcommand( 'action-scheduler action get 243850 --field=log_entries' );
+
+if ( 'ok' !== $result ) {
+	echo "FAIL: shim proxies return values from global WP_CLI\n";
+	exit( 1 );
+}
+
+if ( array( 'action-scheduler action get 243850 --field=log_entries' ) !== WP_CLI::$commands ) {
+	echo "FAIL: shim forwards namespaced WP_CLI::runcommand calls\n";
+	exit( 1 );
+}
+
+$source = file_get_contents( dirname( __DIR__ ) . '/vendor/woocommerce/action-scheduler/classes/WP_CLI/Action_Command.php' );
+if ( false === $source || ! str_contains( $source, 'WP_CLI::runcommand( $command );' ) ) {
+	echo "FAIL: bundled Action Scheduler logs command still needs the namespace shim\n";
+	exit( 1 );
+}
+
+echo "PASS: namespaced Action Scheduler WP_CLI calls proxy to global WP_CLI\n";

--- a/tests/pending-actions-summary-bounds-smoke.php
+++ b/tests/pending-actions-summary-bounds-smoke.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Static smoke coverage for bounded pending-action summary context output.
+ *
+ * Run with: php tests/pending-actions-summary-bounds-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+echo "pending-actions-summary-bounds-smoke\n";
+
+$root              = dirname( __DIR__ );
+$store_source      = file_get_contents( $root . '/inc/Engine/AI/Actions/PendingActionStore.php' );
+$inspection_source = file_get_contents( $root . '/inc/Engine/AI/Actions/PendingActionInspectionAbility.php' );
+$cli_source        = file_get_contents( $root . '/inc/Cli/Commands/PendingActionsCommand.php' );
+
+$failures = array();
+
+$assert = static function ( bool $condition, string $message ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	$failures[] = $message;
+	echo "FAIL: {$message}\n";
+};
+
+$assert( is_string( $store_source ) && str_contains( $store_source, 'return 25;' ), 'summary context output defaults to 25 buckets' );
+$assert( is_string( $store_source ) && str_contains( $store_source, 'include_context_details' ) && str_contains( $store_source, 'return 0;' ), 'summary supports explicit unbounded context details' );
+$assert( is_string( $store_source ) && str_contains( $store_source, 'limit_summary_bucket' ) && str_contains( $store_source, 'array_slice( $bucket, 0, $limit, true )' ), 'summary slices context buckets after aggregation' );
+$assert( is_string( $store_source ) && str_contains( $store_source, 'by_context_omitted' ) && str_contains( $store_source, 'context_detail_truncated' ), 'summary reports omitted context bucket metadata' );
+$assert( is_string( $inspection_source ) && str_contains( $inspection_source, 'context_limit' ) && str_contains( $inspection_source, 'include_context_details' ), 'ability schema exposes bounded and opt-in context summary controls' );
+$assert( is_string( $cli_source ) && str_contains( $cli_source, '--context-limit=<limit>' ) && str_contains( $cli_source, '--include-context-details' ), 'WP-CLI summary documents bounded and opt-in context controls' );
+
+if ( ! empty( $failures ) ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Add a Data Machine WP-CLI compatibility shim for the bundled Action Scheduler namespaced `WP_CLI::runcommand()` call so `wp action-scheduler action logs <id>` can proxy to the global WP-CLI class instead of fataling.
- Bound pending-action summary `by_context` output by default to the top 25 buckets and report `by_context_total`, `by_context_shown`, `by_context_omitted`, `context_limit`, and `context_detail_truncated`.
- Add opt-in full context details through `context_limit=0` / `--context-limit=0` or `include_context_details` / `--include-context-details`.

Fixes #2254.
Fixes #2256.

## Tests
- `php tests/action-scheduler-wpcli-compat-smoke.php`
- `php tests/pending-actions-summary-bounds-smoke.php`
- `php -l inc/Cli/ActionSchedulerWPCLICompat.php && php -l inc/Cli/Bootstrap.php && php -l inc/Cli/Commands/PendingActionsCommand.php && php -l inc/Engine/AI/Actions/PendingActionStore.php && php -l inc/Engine/AI/Actions/PendingActionInspectionAbility.php && php -l tests/action-scheduler-wpcli-compat-smoke.php && php -l tests/pending-actions-summary-bounds-smoke.php`
- `homeboy --force-hot lint --path /Users/chubes/Developer/data-machine@fix-operator-polish-actions --extension wordpress --changed-only`
- `homeboy --force-hot test --path /Users/chubes/Developer/data-machine@fix-operator-polish-actions --extension wordpress`

## Notes
- Full unscoped `homeboy --force-hot lint` was attempted and still fails on pre-existing frontend lint findings outside the files changed here; changed-file lint for this PR passes.
- Homeboy initially auto-selected the `lab` runner, but that runner is missing `php` and `composer`, so the final lint/test runs used the supported `--force-hot` local path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the minimal compatibility shim, bounded summary output changes, smoke coverage, and verification commands; Chris remains responsible for review and merge.