### PR TITLE
fix: claim drain actions before processing

### DIFF
--- a/inc/Cli/Commands/DrainCommand.php
+++ b/inc/Cli/Commands/DrainCommand.php
@@ -146,15 +146,9 @@ class DrainCommand extends BaseCommand {
 				break;
 			}
 
-			$action_ids = self::getDuePendingActionIds( $current_batch_size, $hooks, $job_ids );
-			if ( empty( $action_ids ) ) {
-				$stop_reason = 'empty';
-				break;
-			}
-
 			$due_before    = self::getDuePendingCount( $hooks, $job_ids );
 			$status_before = self::getStatusCounts( $hooks, $job_ids );
-			$result        = self::runActionSchedulerActions( $action_ids );
+			$result        = self::runActionSchedulerBatch( $current_batch_size, $hooks, $job_ids );
 			++$batches;
 
 			if ( 0 !== (int) ( $result->return_code ?? 1 ) ) {
@@ -197,26 +191,50 @@ class DrainCommand extends BaseCommand {
 	}
 
 	/**
-	 * Run specific due Action Scheduler actions.
+	 * Claim and run a batch of due Action Scheduler actions.
 	 *
-	 * @param int[] $action_ids Action IDs.
+	 * @param int           $batch_size Maximum actions to claim.
+	 * @param string[]|null $hooks      Hook scope, or null for all hooks in the group.
+	 * @param int[]         $job_ids    Optional job ID scope.
 	 * @return object Result object with return_code and stderr fields.
 	 */
-	private static function runActionSchedulerActions( array $action_ids ): object {
+	private static function runActionSchedulerBatch( int $batch_size, ?array $hooks = null, array $job_ids = array() ): object {
+		$store    = \ActionScheduler_Store::instance();
 		$runner   = \ActionScheduler::runner();
 		$warnings = array();
+		$claim    = null;
 
-		foreach ( $action_ids as $action_id ) {
-			$action_id = absint( $action_id );
-			if ( $action_id <= 0 ) {
-				continue;
-			}
+		try {
+			$claim = $store->stake_claim( $batch_size, null, $hooks ?? array(), self::GROUP );
+		} catch ( \Throwable $throwable ) {
+			return (object) array(
+				'return_code' => 1,
+				'stdout'      => '',
+				'stderr'      => sprintf( 'Action Scheduler claim failed during drain: %s', $throwable->getMessage() ),
+			);
+		}
 
-			try {
-				$runner->process_action( $action_id, 'Data Machine CLI drain' );
-			} catch ( \Throwable $throwable ) {
-				$warnings[] = sprintf( 'Action %d failed during drain: %s', $action_id, $throwable->getMessage() );
+		try {
+			foreach ( $claim->get_actions() as $action_id ) {
+				$action_id = absint( $action_id );
+				if ( $action_id <= 0 || ! self::actionMatchesJobIds( $action_id, $job_ids ) ) {
+					continue;
+				}
+
+				$claimed_action_ids = array_map( 'intval', $store->find_actions_by_claim_id( $claim->get_id() ) );
+				if ( ! in_array( $action_id, $claimed_action_ids, true ) ) {
+					$warnings[] = sprintf( 'Action Scheduler claim %d was lost during drain.', $claim->get_id() );
+					break;
+				}
+
+				try {
+					$runner->process_action( $action_id, 'Data Machine CLI drain' );
+				} catch ( \Throwable $throwable ) {
+					$warnings[] = sprintf( 'Action %d failed during drain: %s', $action_id, $throwable->getMessage() );
+				}
 			}
+		} finally {
+			$store->release_claim( $claim );
 		}
 
 		return (object) array(
@@ -224,6 +242,46 @@ class DrainCommand extends BaseCommand {
 			'stdout'      => '',
 			'stderr'      => implode( "\n", $warnings ),
 		);
+	}
+
+	/**
+	 * Check whether a claimed action belongs to the requested job scope.
+	 *
+	 * @param int   $action_id Action ID.
+	 * @param int[] $job_ids   Optional job ID scope.
+	 * @return bool True when the action is in scope.
+	 */
+	private static function actionMatchesJobIds( int $action_id, array $job_ids ): bool {
+		if ( empty( $job_ids ) ) {
+			return true;
+		}
+
+		global $wpdb;
+
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- This checks the args for an already-claimed Action Scheduler row.
+		$args = (string) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT args FROM %i WHERE action_id = %d',
+				$actions_table,
+				$action_id
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		foreach ( $job_ids as $job_id ) {
+			if (
+				false !== strpos( $args, '"job_id":' . $job_id . ',' )
+				|| false !== strpos( $args, '"job_id":' . $job_id . '}' )
+				|| false !== strpos( $args, '"parent_job_id":' . $job_id . ',' )
+				|| false !== strpos( $args, '"parent_job_id":' . $job_id . '}' )
+			) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -432,43 +490,6 @@ class DrainCommand extends BaseCommand {
 	 */
 	private static function getPendingCount( ?array $hooks = null, array $job_ids = array() ): int {
 		return self::countActions( false, $hooks, $job_ids );
-	}
-
-	/**
-	 * Get due pending Data Machine action IDs in execution order.
-	 *
-	 * @param int $limit Maximum IDs to return.
-	 * @return int[] Action IDs.
-	 */
-	private static function getDuePendingActionIds( int $limit, ?array $hooks = null, array $job_ids = array() ): array {
-		global $wpdb;
-
-		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
-		$groups_table  = $wpdb->prefix . 'actionscheduler_groups';
-		$hook_sql      = self::hookWhereSql( $hooks, $job_ids );
-		$values        = array_merge(
-			array( $actions_table, $groups_table ),
-			$hook_sql['values'],
-			array( self::GROUP, gmdate( 'Y-m-d H:i:s' ), $limit )
-		);
-
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic hook scope is constructed from normalized placeholders and values.
-		$ids = $wpdb->get_col(
-			$wpdb->prepare(
-				'SELECT a.action_id
-				FROM %i a
-				INNER JOIN %i g ON g.group_id = a.group_id
-				WHERE ' . $hook_sql['sql'] . 'a.status = \'pending\'
-				AND g.slug = %s
-				AND a.scheduled_date_gmt <= %s
-				ORDER BY a.scheduled_date_gmt ASC, a.action_id ASC
-				LIMIT %d',
-				$values
-			)
-		);
-		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
-
-		return array_map( 'intval', $ids );
 	}
 
 	/**

--- a/tests/drain-claim-ownership-smoke.php
+++ b/tests/drain-claim-ownership-smoke.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Pure-PHP smoke test for claim-owned Data Machine CLI drains (#2252).
+ *
+ * Run with: php tests/drain-claim-ownership-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$drain_file = __DIR__ . '/../inc/Cli/Commands/DrainCommand.php';
+$drain_src  = file_get_contents( $drain_file ) ?: '';
+
+$assertions = 0;
+
+function assert_true( bool $condition, string $message ): void {
+	global $assertions;
+	++$assertions;
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+function assert_contains( string $needle, string $haystack, string $message ): void {
+	assert_true( false !== strpos( $haystack, $needle ), $message );
+}
+
+function assert_not_contains( string $needle, string $haystack, string $message ): void {
+	assert_true( false === strpos( $haystack, $needle ), $message );
+}
+
+assert_contains( 'runActionSchedulerBatch', $drain_src, 'drain processes Action Scheduler batches' );
+assert_contains( '\ActionScheduler_Store::instance()', $drain_src, 'drain uses the Action Scheduler store' );
+assert_contains( 'stake_claim( $batch_size, null, $hooks ?? array(), self::GROUP )', $drain_src, 'drain stakes a group-scoped Action Scheduler claim' );
+assert_contains( '$claim->get_actions()', $drain_src, 'drain processes actions from the claim' );
+assert_contains( 'find_actions_by_claim_id( $claim->get_id() )', $drain_src, 'drain rechecks claim ownership before processing each action' );
+assert_contains( '$runner->process_action( $action_id, \'Data Machine CLI drain\' )', $drain_src, 'drain executes only claim-owned action IDs' );
+assert_contains( 'finally {', $drain_src, 'drain releases claims in a finally block' );
+assert_contains( '$store->release_claim( $claim )', $drain_src, 'drain releases the Action Scheduler claim' );
+assert_not_contains( 'getDuePendingActionIds', $drain_src, 'drain no longer preselects due action IDs outside Action Scheduler claims' );
+assert_not_contains( 'SELECT a.action_id', $drain_src, 'drain no longer directly selects action IDs to process' );
+
+$stake_pos   = strpos( $drain_src, 'stake_claim( $batch_size, null, $hooks ?? array(), self::GROUP )' );
+$verify_pos  = strpos( $drain_src, 'find_actions_by_claim_id( $claim->get_id() )' );
+$process_pos = strpos( $drain_src, '$runner->process_action( $action_id, \'Data Machine CLI drain\' )' );
+$release_pos = strpos( $drain_src, '$store->release_claim( $claim )' );
+
+assert_true( false !== $stake_pos, 'claim staking position found' );
+assert_true( false !== $verify_pos, 'claim verification position found' );
+assert_true( false !== $process_pos, 'claimed action processing position found' );
+assert_true( false !== $release_pos, 'claim release position found' );
+assert_true( $stake_pos < $verify_pos, 'drain stakes a claim before verifying ownership' );
+assert_true( $verify_pos < $process_pos, 'drain verifies ownership before processing' );
+assert_true( $process_pos < $release_pos, 'drain releases the claim after processing' );
+
+echo "OK ({$assertions} assertions)\n";

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -47,8 +47,10 @@ assert_drain_contains( 'hookWhereSql( $hooks, $job_ids )', $drain_src, 'drain su
 assert_drain_contains( 'a.args LIKE %s', $drain_src, 'drain can filter pending actions by serialized job_id args' );
 assert_drain_contains( '"parent_job_id":', $drain_src, 'drain can filter batch actions by serialized parent_job_id args' );
 assert_drain_contains( "a.status = \\'pending\\'", $drain_src, 'drain queries pending actions in the Data Machine group' );
-assert_drain_contains( 'getDuePendingActionIds', $drain_src, 'drain queries concrete due Data Machine action IDs' );
-assert_drain_contains( "\\ActionScheduler::runner()", $drain_src, 'drain runs concrete action IDs through Action Scheduler runner' );
+assert_drain_contains( 'stake_claim( $batch_size, null, $hooks ?? array(), self::GROUP )', $drain_src, 'drain claims due Data Machine actions through Action Scheduler' );
+assert_drain_contains( 'find_actions_by_claim_id( $claim->get_id() )', $drain_src, 'drain verifies Action Scheduler claim ownership before processing' );
+assert_drain_contains( 'release_claim( $claim )', $drain_src, 'drain releases Action Scheduler claims after processing' );
+assert_drain_contains( "\\ActionScheduler::runner()", $drain_src, 'drain uses Action Scheduler runner for claimed actions' );
 assert_drain_contains( "'Data Machine CLI drain'", $drain_src, 'drain records a Data Machine-specific execution context' );
 assert_drain_contains( 'catch ( \\Throwable $throwable )', $drain_src, 'drain catches per-action runner failures instead of fataling after job start' );
 assert_drain_contains( "'return_code' => empty( \$warnings ) ? 0 : 1", $drain_src, 'drain surfaces runner failures through a result object' );


### PR DESCRIPTION
## Summary
- Routes `wp datamachine drain` batches through Action Scheduler claims before processing actions.
- Verifies each action still belongs to the active claim before execution and always releases the claim afterward.
- Adds smoke coverage that prevents returning to unclaimed preselected action IDs.

Fixes #2252.

## Tests
- `php tests/drain-claim-ownership-smoke.php`
- `php tests/flow-run-cli-drain-smoke.php`
- `php -l inc/Cli/Commands/DrainCommand.php`
- `php -l tests/drain-claim-ownership-smoke.php`
- `composer run lint -- --standard=phpcs.xml.dist inc/Cli/Commands/DrainCommand.php tests/flow-run-cli-drain-smoke.php tests/drain-claim-ownership-smoke.php`

## Notes
- `composer run test` is currently blocked locally because Homeboy auto-selects runner `lab`, and that runner reports missing `php` and `composer` for the `test` command.
- PR #2257 also edits `DrainCommand.php` for a worker/drain runtime lock. It overlaps textually, but the approaches are complementary: this PR fixes Action Scheduler claim ownership inside a drain batch, while #2257 guards outer worker/drain concurrency.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the claim-safe drain path, drafted smoke coverage, and ran focused verification under Chris's direction.