### PR TITLE
Centralize bundle artifact projections

### DIFF
--- a/inc/Engine/Bundle/AgentBundleArrayAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleArrayAdapter.php
@@ -176,7 +176,7 @@ final class AgentBundleArrayAdapter {
 		$artifact_files = is_array( $bundle['artifact_files'] ?? null ) ? $bundle['artifact_files'] : array();
 		$normalized     = array();
 
-		foreach ( self::artifact_file_directories() as $directory ) {
+		foreach ( AgentBundleArtifactDefinitions::file_artifact_directories() as $directory ) {
 			if ( is_array( $artifact_files[ $directory ] ?? null ) ) {
 				$normalized[ $directory ] = $artifact_files[ $directory ];
 			}
@@ -187,24 +187,12 @@ final class AgentBundleArrayAdapter {
 
 	/** @return array<string,array<string,array|string>> */
 	private static function artifact_files_from_directory( AgentBundleDirectory $directory ): array {
-		return array(
-			BundleSchema::PROMPTS_DIR       => $directory->prompts(),
-			BundleSchema::RUBRICS_DIR       => $directory->rubrics(),
-			BundleSchema::TOOL_POLICIES_DIR => $directory->tool_policies(),
-			BundleSchema::AUTH_REFS_DIR     => $directory->auth_refs(),
-			BundleSchema::SEED_QUEUES_DIR   => $directory->seed_queues(),
-		);
-	}
+		$artifact_files = array();
+		foreach ( AgentBundleArtifactDefinitions::file_artifact_directories() as $artifact_directory ) {
+			$artifact_files[ $artifact_directory ] = AgentBundleArtifactDefinitions::files_from_directory( $directory, $artifact_directory );
+		}
 
-	/** @return string[] */
-	private static function artifact_file_directories(): array {
-		return array(
-			BundleSchema::PROMPTS_DIR,
-			BundleSchema::RUBRICS_DIR,
-			BundleSchema::TOOL_POLICIES_DIR,
-			BundleSchema::AUTH_REFS_DIR,
-			BundleSchema::SEED_QUEUES_DIR,
-		);
+		return $artifact_files;
 	}
 
 	/** @param array<int,array<string,mixed>> $pipelines */

--- a/inc/Engine/Bundle/AgentBundleArtifactDefinitions.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactDefinitions.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Shared bundle artifact definitions.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Central definition map for first-class bundle artifact files.
+ */
+final class AgentBundleArtifactDefinitions {
+
+	/**
+	 * Bundle file artifact definitions keyed by bundle directory.
+	 *
+	 * @return array<string,array{artifact_type:string,package_type:string}>
+	 */
+	public static function file_artifacts(): array {
+		return array(
+			BundleSchema::PROMPTS_DIR       => array(
+				'artifact_type' => 'prompt',
+				'package_type'  => 'datamachine/prompt',
+			),
+			BundleSchema::RUBRICS_DIR       => array(
+				'artifact_type' => 'rubric',
+				'package_type'  => 'datamachine/rubric',
+			),
+			BundleSchema::TOOL_POLICIES_DIR => array(
+				'artifact_type' => 'tool_policy',
+				'package_type'  => 'datamachine/tool-policy',
+			),
+			BundleSchema::AUTH_REFS_DIR     => array(
+				'artifact_type' => 'auth_ref',
+				'package_type'  => 'datamachine/auth-ref',
+			),
+			BundleSchema::SEED_QUEUES_DIR   => array(
+				'artifact_type' => 'seed_queue',
+				'package_type'  => 'datamachine/queue-seed',
+			),
+		);
+	}
+
+	/** @return string[] */
+	public static function file_artifact_directories(): array {
+		return array_keys( self::file_artifacts() );
+	}
+
+	/** @return string[] */
+	public static function file_artifact_types(): array {
+		return array_values( array_map( static fn( array $definition ): string => $definition['artifact_type'], self::file_artifacts() ) );
+	}
+
+	/**
+	 * Return the decoded file map for a first-class artifact directory.
+	 *
+	 * @return array<string,array|string>
+	 */
+	public static function files_from_directory( AgentBundleDirectory $directory, string $artifact_directory ): array {
+		return match ( $artifact_directory ) {
+			BundleSchema::PROMPTS_DIR       => $directory->prompts(),
+			BundleSchema::RUBRICS_DIR       => $directory->rubrics(),
+			BundleSchema::TOOL_POLICIES_DIR => $directory->tool_policies(),
+			BundleSchema::AUTH_REFS_DIR     => $directory->auth_refs(),
+			BundleSchema::SEED_QUEUES_DIR   => $directory->seed_queues(),
+			default                         => array(),
+		};
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleArtifactPayloads.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactPayloads.php
@@ -23,8 +23,8 @@ final class AgentBundleArtifactPayloads {
 	}
 
 	public static function flow_payload( array $flow, string $portable_slug, ?array $installed_payload = null ): array {
-		$scheduling       = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
-		$run_artifacts    = self::flow_run_artifacts( $flow, $scheduling );
+		$scheduling        = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
+		$run_artifacts     = self::flow_run_artifacts( $flow, $scheduling );
 		$scheduling_policy = self::flow_scheduling_policy( $scheduling );
 
 		$payload = array(

--- a/inc/Engine/Bundle/AgentBundleArtifactPayloads.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactPayloads.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Shared bundle artifact payload builders.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Builds comparable pipeline and flow payloads for bundle lifecycle checks.
+ */
+final class AgentBundleArtifactPayloads {
+
+	public static function pipeline_payload( array $pipeline, string $portable_slug ): array {
+		return array(
+			'portable_slug'   => $portable_slug,
+			'pipeline_name'   => (string) ( $pipeline['pipeline_name'] ?? '' ),
+			'pipeline_config' => is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(),
+		);
+	}
+
+	public static function flow_payload( array $flow, string $portable_slug, ?array $installed_payload = null ): array {
+		$scheduling       = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
+		$run_artifacts    = self::flow_run_artifacts( $flow, $scheduling );
+		$scheduling_policy = self::flow_scheduling_policy( $scheduling );
+
+		$payload = array(
+			'portable_slug'     => $portable_slug,
+			'flow_name'         => (string) ( $flow['flow_name'] ?? '' ),
+			'flow_config'       => self::flow_config_without_runtime_queues( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() ),
+			'scheduling_policy' => $scheduling_policy,
+			'queue_policy'      => 'create_seed_upgrade_preserve_existing',
+			'runtime_overlays'  => self::flow_runtime_overlays( $flow, $installed_payload ),
+		);
+
+		if ( ! empty( $run_artifacts ) ) {
+			$payload['run_artifacts'] = $run_artifacts;
+		}
+
+		return $payload;
+	}
+
+	private static function flow_run_artifacts( array $flow, array $scheduling ): array {
+		return BundleSchema::normalize_run_artifact_egress_policy( $flow['run_artifacts'] ?? $scheduling['run_artifacts'] ?? array() );
+	}
+
+	private static function flow_scheduling_policy( array $config ): string {
+		$interval = (string) ( $config['interval'] ?? 'manual' );
+		$enabled  = array_key_exists( 'enabled', $config ) ? false !== $config['enabled'] : 'manual' !== $interval;
+
+		if ( 'manual' === $interval || ! $enabled ) {
+			return 'create_paused_upgrade_preserve_existing';
+		}
+
+		return 'create_bundle_schedule_upgrade_preserve_existing';
+	}
+
+	private static function flow_config_without_runtime_queues( array $flow_config ): array {
+		foreach ( $flow_config as &$step ) {
+			if ( is_array( $step ) ) {
+				unset( $step['prompt_queue'], $step['config_patch_queue'], $step['queue_mode'], $step['_queue_consume_revision'] );
+				unset( $step['handler_config']['max_items'] );
+				if ( empty( $step['handler_config'] ) ) {
+					unset( $step['handler_config'] );
+				}
+				if ( is_array( $step['handler_configs'] ?? null ) ) {
+					foreach ( $step['handler_configs'] as $handler_slug => &$handler_config ) {
+						if ( is_array( $handler_config ) ) {
+							unset( $handler_config['max_items'] );
+							if ( empty( $handler_config ) ) {
+								unset( $step['handler_configs'][ $handler_slug ] );
+							}
+						}
+					}
+					unset( $handler_config );
+					if ( empty( $step['handler_configs'] ) ) {
+						unset( $step['handler_configs'] );
+					}
+				}
+			}
+		}
+		unset( $step );
+
+		return $flow_config;
+	}
+
+	private static function flow_runtime_overlays( array $flow, ?array $installed_payload = null ): array {
+		if ( is_array( $installed_payload['runtime_overlays'] ?? null ) ) {
+			return $installed_payload['runtime_overlays'];
+		}
+
+		$overlays    = array();
+		$flow_config = is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array();
+		$steps       = array();
+
+		foreach ( $flow_config as $flow_step_id => $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+
+			$step_overlay = array();
+			foreach ( array( 'prompt_queue', 'config_patch_queue', 'queue_mode', '_queue_consume_revision' ) as $field ) {
+				if ( array_key_exists( $field, $step ) ) {
+					$step_overlay[ $field ] = $step[ $field ];
+				}
+			}
+			if ( array_key_exists( 'max_items', $step['handler_config'] ?? array() ) ) {
+				$step_overlay['handler_config'] = array( 'max_items' => $step['handler_config']['max_items'] );
+			}
+			if ( is_array( $step['handler_configs'] ?? null ) ) {
+				foreach ( $step['handler_configs'] as $handler_slug => $handler_config ) {
+					if ( is_array( $handler_config ) && array_key_exists( 'max_items', $handler_config ) ) {
+						$step_overlay['handler_configs'][ (string) $handler_slug ] = array( 'max_items' => $handler_config['max_items'] );
+					}
+				}
+			}
+
+			if ( ! empty( $step_overlay ) ) {
+				ksort( $step_overlay, SORT_STRING );
+				$steps[ (string) $flow_step_id ] = $step_overlay;
+			}
+		}
+
+		if ( ! empty( $steps ) ) {
+			ksort( $steps, SORT_STRING );
+			$overlays['steps'] = $steps;
+		}
+
+		$scheduling = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
+		unset( $scheduling['last_run'], $scheduling['next_run'], $scheduling['run_count'], $scheduling['run_artifacts'] );
+		if ( ! empty( $scheduling ) ) {
+			ksort( $scheduling, SORT_STRING );
+			$overlays['scheduling_config'] = $scheduling;
+		}
+
+		ksort( $overlays, SORT_STRING );
+		return $overlays;
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleDirectory.php
+++ b/inc/Engine/Bundle/AgentBundleDirectory.php
@@ -81,7 +81,7 @@ final class AgentBundleDirectory {
 		self::ensure_directory( $directory . '/' . BundleSchema::MEMORY_DIR );
 		self::ensure_directory( $directory . '/' . BundleSchema::PIPELINES_DIR );
 		self::ensure_directory( $directory . '/' . BundleSchema::FLOWS_DIR );
-		foreach ( self::artifact_directories() as $artifact_directory ) {
+		foreach ( AgentBundleArtifactDefinitions::file_artifact_directories() as $artifact_directory ) {
 			self::ensure_directory( $directory . '/' . $artifact_directory );
 		}
 		self::ensure_directory( $directory . '/' . BundleSchema::EXTENSIONS_DIR );
@@ -210,10 +210,10 @@ final class AgentBundleDirectory {
 
 	/** @return array<string,array<string,array|string>> */
 	private static function normalize_artifact_files( array $artifact_files ): array {
-		$normalized = array_fill_keys( self::artifact_directories(), array() );
+		$normalized = array_fill_keys( AgentBundleArtifactDefinitions::file_artifact_directories(), array() );
 		foreach ( $artifact_files as $artifact_directory => $files ) {
 			$artifact_directory = (string) $artifact_directory;
-			if ( ! in_array( $artifact_directory, self::artifact_directories(), true ) ) {
+			if ( ! in_array( $artifact_directory, AgentBundleArtifactDefinitions::file_artifact_directories(), true ) ) {
 				throw new BundleValidationException( sprintf( 'Invalid artifact directory: %s', esc_html( $artifact_directory ) ) );
 			}
 			if ( ! is_array( $files ) ) {
@@ -255,7 +255,7 @@ final class AgentBundleDirectory {
 	/** @return array<string,array<string,array|string>> */
 	private static function read_artifact_directories( string $directory ): array {
 		$artifact_files = array();
-		foreach ( self::artifact_directories() as $artifact_directory ) {
+		foreach ( AgentBundleArtifactDefinitions::file_artifact_directories() as $artifact_directory ) {
 			$artifact_files[ $artifact_directory ] = self::read_artifact_files( $directory . '/' . $artifact_directory );
 		}
 
@@ -522,17 +522,6 @@ final class AgentBundleDirectory {
 		}
 		usort( $documents, fn( $a, $b ) => strcmp( $a->slug(), $b->slug() ) );
 		return $documents;
-	}
-
-	/** @return string[] */
-	private static function artifact_directories(): array {
-		return array(
-			BundleSchema::PROMPTS_DIR,
-			BundleSchema::RUBRICS_DIR,
-			BundleSchema::TOOL_POLICIES_DIR,
-			BundleSchema::AUTH_REFS_DIR,
-			BundleSchema::SEED_QUEUES_DIR,
-		);
 	}
 
 	private static function normalize_relative_path( string $relative_path, string $label ): string {

--- a/inc/Engine/Bundle/AgentBundleLifecycleProjection.php
+++ b/inc/Engine/Bundle/AgentBundleLifecycleProjection.php
@@ -69,7 +69,7 @@ final class AgentBundleLifecycleProjection {
 				'artifact_type' => 'pipeline',
 				'artifact_id'   => $slug,
 				'source_path'   => 'pipelines/' . $slug . '.json',
-				'payload'       => self::pipeline_payload( $pipeline, $slug ),
+				'payload'       => AgentBundleArtifactPayloads::pipeline_payload( $pipeline, $slug ),
 			);
 		}
 
@@ -96,7 +96,7 @@ final class AgentBundleLifecycleProjection {
 				'artifact_type' => 'flow',
 				'artifact_id'   => $slug,
 				'source_path'   => 'flows/' . $slug . '.json',
-				'payload'       => self::flow_payload( $flow, $slug ),
+				'payload'       => AgentBundleArtifactPayloads::flow_payload( $flow, $slug ),
 			);
 		}
 
@@ -149,7 +149,7 @@ final class AgentBundleLifecycleProjection {
 					'artifact_type' => 'pipeline',
 					'artifact_id'   => $id,
 					'source_path'   => (string) ( $record['source_path'] ?? '' ),
-					'payload'       => self::pipeline_payload( $pipeline_by_slug[ $id ], $id ),
+					'payload'       => AgentBundleArtifactPayloads::pipeline_payload( $pipeline_by_slug[ $id ], $id ),
 				);
 			}
 			if ( 'flow' === $type && isset( $flow_by_slug[ $id ] ) ) {
@@ -158,7 +158,7 @@ final class AgentBundleLifecycleProjection {
 					'artifact_type' => 'flow',
 					'artifact_id'   => $id,
 					'source_path'   => (string) ( $record['source_path'] ?? '' ),
-					'payload'       => self::flow_payload( $flow_by_slug[ $id ], $id, $installed_payload ),
+					'payload'       => AgentBundleArtifactPayloads::flow_payload( $flow_by_slug[ $id ], $id, $installed_payload ),
 				);
 			}
 			if ( in_array( $type, self::bundle_file_artifact_types(), true ) ) {
@@ -186,14 +186,14 @@ final class AgentBundleLifecycleProjection {
 		$artifacts = array();
 		$files     = is_array( $bundle['artifact_files'] ?? null ) ? $bundle['artifact_files'] : array();
 
-		foreach ( self::bundle_file_artifact_directories() as $directory => $type ) {
+		foreach ( AgentBundleArtifactDefinitions::file_artifacts() as $directory => $definition ) {
 			foreach ( is_array( $files[ $directory ] ?? null ) ? $files[ $directory ] : array() as $relative_path => $payload ) {
 				$artifact_id = is_array( $payload ) && is_string( $payload['artifact_id'] ?? null )
 					? (string) $payload['artifact_id']
 					: self::artifact_id_from_relative_path( (string) $relative_path );
 
 				$artifacts[] = array(
-					'artifact_type' => $type,
+					'artifact_type' => $definition['artifact_type'],
 					'artifact_id'   => $artifact_id,
 					'source_path'   => $directory . '/' . ltrim( (string) $relative_path, '/' ),
 					'payload'       => $payload,
@@ -204,20 +204,9 @@ final class AgentBundleLifecycleProjection {
 		return $artifacts;
 	}
 
-	/** @return array<string,string> */
-	private static function bundle_file_artifact_directories(): array {
-		return array(
-			BundleSchema::PROMPTS_DIR       => 'prompt',
-			BundleSchema::RUBRICS_DIR       => 'rubric',
-			BundleSchema::TOOL_POLICIES_DIR => 'tool_policy',
-			BundleSchema::AUTH_REFS_DIR     => 'auth_ref',
-			BundleSchema::SEED_QUEUES_DIR   => 'seed_queue',
-		);
-	}
-
 	/** @return string[] */
 	private static function bundle_file_artifact_types(): array {
-		return array_values( self::bundle_file_artifact_directories() );
+		return AgentBundleArtifactDefinitions::file_artifact_types();
 	}
 
 	private static function artifact_id_from_relative_path( string $relative_path ): string {
@@ -240,120 +229,6 @@ final class AgentBundleLifecycleProjection {
 		}
 
 		return null;
-	}
-
-	private static function pipeline_payload( array $pipeline, string $portable_slug ): array {
-		return array(
-			'portable_slug'   => $portable_slug,
-			'pipeline_name'   => (string) ( $pipeline['pipeline_name'] ?? '' ),
-			'pipeline_config' => is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(),
-		);
-	}
-
-	private static function flow_payload( array $flow, string $portable_slug, ?array $installed_payload = null ): array {
-		$scheduling_policy = self::flow_scheduling_policy( is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array() );
-
-		return array(
-			'portable_slug'     => $portable_slug,
-			'flow_name'         => (string) ( $flow['flow_name'] ?? '' ),
-			'flow_config'       => self::flow_config_without_runtime_queues( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() ),
-			'scheduling_policy' => $scheduling_policy,
-			'queue_policy'      => 'create_seed_upgrade_preserve_existing',
-			'runtime_overlays'  => self::flow_runtime_overlays( $flow, $installed_payload ),
-		);
-	}
-
-	private static function flow_scheduling_policy( array $config ): string {
-		$interval = (string) ( $config['interval'] ?? 'manual' );
-		$enabled  = array_key_exists( 'enabled', $config ) ? false !== $config['enabled'] : 'manual' !== $interval;
-
-		if ( 'manual' === $interval || ! $enabled ) {
-			return 'create_paused_upgrade_preserve_existing';
-		}
-
-		return 'create_bundle_schedule_upgrade_preserve_existing';
-	}
-
-	private static function flow_config_without_runtime_queues( array $flow_config ): array {
-		foreach ( $flow_config as &$step ) {
-			if ( is_array( $step ) ) {
-				unset( $step['prompt_queue'], $step['config_patch_queue'], $step['queue_mode'], $step['_queue_consume_revision'] );
-				unset( $step['handler_config']['max_items'] );
-				if ( empty( $step['handler_config'] ) ) {
-					unset( $step['handler_config'] );
-				}
-				if ( is_array( $step['handler_configs'] ?? null ) ) {
-					foreach ( $step['handler_configs'] as $handler_slug => &$handler_config ) {
-						if ( is_array( $handler_config ) ) {
-							unset( $handler_config['max_items'] );
-							if ( empty( $handler_config ) ) {
-								unset( $step['handler_configs'][ $handler_slug ] );
-							}
-						}
-					}
-					unset( $handler_config );
-					if ( empty( $step['handler_configs'] ) ) {
-						unset( $step['handler_configs'] );
-					}
-				}
-			}
-		}
-		unset( $step );
-
-		return $flow_config;
-	}
-
-	private static function flow_runtime_overlays( array $flow, ?array $installed_payload = null ): array {
-		if ( is_array( $installed_payload['runtime_overlays'] ?? null ) ) {
-			return $installed_payload['runtime_overlays'];
-		}
-
-		$overlays    = array();
-		$flow_config = is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array();
-		$steps       = array();
-
-		foreach ( $flow_config as $flow_step_id => $step ) {
-			if ( ! is_array( $step ) ) {
-				continue;
-			}
-
-			$step_overlay = array();
-			foreach ( array( 'prompt_queue', 'config_patch_queue', 'queue_mode', '_queue_consume_revision' ) as $field ) {
-				if ( array_key_exists( $field, $step ) ) {
-					$step_overlay[ $field ] = $step[ $field ];
-				}
-			}
-			if ( array_key_exists( 'max_items', $step['handler_config'] ?? array() ) ) {
-				$step_overlay['handler_config'] = array( 'max_items' => $step['handler_config']['max_items'] );
-			}
-			if ( is_array( $step['handler_configs'] ?? null ) ) {
-				foreach ( $step['handler_configs'] as $handler_slug => $handler_config ) {
-					if ( is_array( $handler_config ) && array_key_exists( 'max_items', $handler_config ) ) {
-						$step_overlay['handler_configs'][ (string) $handler_slug ] = array( 'max_items' => $handler_config['max_items'] );
-					}
-				}
-			}
-
-			if ( ! empty( $step_overlay ) ) {
-				ksort( $step_overlay, SORT_STRING );
-				$steps[ (string) $flow_step_id ] = $step_overlay;
-			}
-		}
-
-		if ( ! empty( $steps ) ) {
-			ksort( $steps, SORT_STRING );
-			$overlays['steps'] = $steps;
-		}
-
-		$scheduling = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
-		unset( $scheduling['last_run'], $scheduling['next_run'], $scheduling['run_count'], $scheduling['run_artifacts'] );
-		if ( ! empty( $scheduling ) ) {
-			ksort( $scheduling, SORT_STRING );
-			$overlays['scheduling_config'] = $scheduling;
-		}
-
-		ksort( $overlays, SORT_STRING );
-		return $overlays;
 	}
 
 	private function pipelines(): Pipelines {

--- a/inc/Engine/Bundle/AgentPackageProjection.php
+++ b/inc/Engine/Bundle/AgentPackageProjection.php
@@ -117,11 +117,12 @@ final class AgentPackageProjection {
 			);
 		}
 
-		foreach ( self::artifact_file_maps( $directory ) as $directory_name => $definition ) {
-			foreach ( $definition['files'] as $relative_path => $payload ) {
+		foreach ( AgentBundleArtifactDefinitions::file_artifacts() as $directory_name => $definition ) {
+			$files = AgentBundleArtifactDefinitions::files_from_directory( $directory, $directory_name );
+			foreach ( $files as $relative_path => $payload ) {
 				$slug        = self::slug_from_path( (string) $relative_path );
 				$artifacts[] = self::artifact(
-					$definition['type'],
+					$definition['package_type'],
 					$slug,
 					$slug,
 					$directory_name . '/' . ltrim( (string) $relative_path, '/' ),
@@ -152,37 +153,6 @@ final class AgentPackageProjection {
 		}
 
 		return $artifacts;
-	}
-
-	/**
-	 * Build artifact file directory definitions.
-	 *
-	 * @param AgentBundleDirectory $directory Bundle directory.
-	 * @return array<string,array{type:string,files:array<string,array|string>}>
-	 */
-	private static function artifact_file_maps( AgentBundleDirectory $directory ): array {
-		return array(
-			BundleSchema::PROMPTS_DIR       => array(
-				'type'  => 'datamachine/prompt',
-				'files' => $directory->prompts(),
-			),
-			BundleSchema::RUBRICS_DIR       => array(
-				'type'  => 'datamachine/rubric',
-				'files' => $directory->rubrics(),
-			),
-			BundleSchema::TOOL_POLICIES_DIR => array(
-				'type'  => 'datamachine/tool-policy',
-				'files' => $directory->tool_policies(),
-			),
-			BundleSchema::AUTH_REFS_DIR     => array(
-				'type'  => 'datamachine/auth-ref',
-				'files' => $directory->auth_refs(),
-			),
-			BundleSchema::SEED_QUEUES_DIR   => array(
-				'type'  => 'datamachine/queue-seed',
-				'files' => $directory->seed_queues(),
-			),
-		);
 	}
 
 	/**

--- a/tests/datamachine-package-artifacts-smoke.php
+++ b/tests/datamachine-package-artifacts-smoke.php
@@ -118,6 +118,11 @@ $directory = new AgentBundleDirectory(
 					'handler_configs' => array(),
 					'step_type'       => 'fetch',
 				),
+			),
+			array(
+				'completion_assertions' => array(
+					'egress' => array( 'artifact', 'bundle-file' ),
+				),
 			)
 		),
 	),
@@ -181,6 +186,8 @@ agents_api_smoke_assert_equals( 'rubrics/wiki-quality.json', $lifecycle_artifact
 agents_api_smoke_assert_equals( 'tool-policies/read-only-context.json', $lifecycle_artifacts['tool_policy:read-only-context']['source_path'] ?? '', 'lifecycle projection includes tool policy file artifacts', $failures, $passes );
 agents_api_smoke_assert_equals( 'auth-refs/github-default.json', $lifecycle_artifacts['auth_ref:github-default']['source_path'] ?? '', 'lifecycle projection includes auth ref file artifacts', $failures, $passes );
 agents_api_smoke_assert_equals( 'seed-queues/mgs-topic-loop.json', $lifecycle_artifacts['seed_queue:mgs-topic-loop']['source_path'] ?? '', 'lifecycle projection includes seed queue file artifacts', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'artifact', 'bundle-file' ), $lifecycle_artifacts['flow:daily-ingest-flow']['payload']['run_artifacts']['completion_assertions']['egress'] ?? array(), 'flow lifecycle payload preserves normalized run artifact policy', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $service_source, 'AgentBundleLifecycleProjection' ), 'ability service uses shared lifecycle projection service', $failures, $passes );
 agents_api_smoke_assert_equals( true, str_contains( $service_source, '$this->projection->target_artifacts( $bundle' ), 'ability service plans through shared lifecycle projection', $failures, $passes );
 agents_api_smoke_assert_equals( true, str_contains( $command_source, '$this->projection()->target_artifacts( $bundle' ), 'CLI planning uses the same lifecycle projection', $failures, $passes );
 

--- a/tests/export-agent-ability-smoke.php
+++ b/tests/export-agent-ability-smoke.php
@@ -67,6 +67,7 @@ require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleManifest.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundlePipelineFile.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleFlowFile.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleArtifactExtensions.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleArtifactDefinitions.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleDirectory.php';
 require_once __DIR__ . '/../inc/Core/Agents/AgentBundler.php';
 


### PR DESCRIPTION
## Summary
- Adds a shared bundle artifact definition map for first-class artifact directories/types used by directory, adapter, lifecycle, and package projection paths.
- Moves pipeline/flow lifecycle payload construction into a shared builder and preserves normalized flow `run_artifacts` in tracked flow artifact payloads.
- Extends package artifact smoke coverage for flow `run_artifacts` consistency.

## Tests
- `php tests/datamachine-package-artifacts-smoke.php`
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `php tests/run-artifact-egress-policy-smoke.php`
- `vendor/bin/phpcs inc/Engine/Bundle/AgentBundleArtifactDefinitions.php inc/Engine/Bundle/AgentBundleArtifactPayloads.php inc/Engine/Bundle/AgentBundleDirectory.php inc/Engine/Bundle/AgentBundleArrayAdapter.php inc/Engine/Bundle/AgentBundleLifecycleProjection.php inc/Engine/Bundle/AgentPackageProjection.php tests/datamachine-package-artifacts-smoke.php`
- `git diff --check`

## Notes
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-bundle-artifact-definition-map --extension wordpress` and `homeboy test --path /Users/chubes/Developer/data-machine@fix-bundle-artifact-definition-map --extension wordpress` did not run because Homeboy auto-selected runner `lab`, which reported missing `php` and `composer` before executing the gates.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the shared bundle artifact definition/payload refactor and targeted smoke/PHPCS verification; Chris remains responsible for review and merge.

Refs #2264