### PR TITLE
Consolidate ability result envelopes

### DIFF
--- a/inc/Abilities/Flow/CreateFlowAbility.php
+++ b/inc/Abilities/Flow/CreateFlowAbility.php
@@ -152,8 +152,10 @@ class CreateFlowAbility {
 		if ( ! $pipeline ) {
 			do_action( 'datamachine_log', 'error', 'Pipeline not found for flow creation', array( 'pipeline_id' => $pipeline_id ) );
 			return array(
-				'success' => false,
-				'error'   => 'Pipeline not found',
+				'success'    => false,
+				'error'      => 'Pipeline not found',
+				'error_code' => 'pipeline_not_found',
+				'status'     => 404,
 			);
 		}
 

--- a/inc/Abilities/Flow/DeleteFlowAbility.php
+++ b/inc/Abilities/Flow/DeleteFlowAbility.php
@@ -86,8 +86,10 @@ class DeleteFlowAbility {
 		if ( ! $flow ) {
 			do_action( 'datamachine_log', 'error', 'Flow not found for deletion', array( 'flow_id' => $flow_id ) );
 			return array(
-				'success' => false,
-				'error'   => 'Flow not found',
+				'success'    => false,
+				'error'      => 'Flow not found',
+				'error_code' => 'flow_not_found',
+				'status'     => 404,
 			);
 		}
 

--- a/inc/Abilities/Flow/DuplicateFlowAbility.php
+++ b/inc/Abilities/Flow/DuplicateFlowAbility.php
@@ -108,8 +108,10 @@ class DuplicateFlowAbility {
 		if ( ! $source_flow ) {
 			do_action( 'datamachine_log', 'error', 'Source flow not found for copy', array( 'source_flow_id' => $source_flow_id ) );
 			return array(
-				'success' => false,
-				'error'   => 'Source flow not found',
+				'success'    => false,
+				'error'      => 'Source flow not found',
+				'error_code' => 'flow_not_found',
+				'status'     => 404,
 			);
 		}
 
@@ -120,16 +122,20 @@ class DuplicateFlowAbility {
 		$source_pipeline = $this->db_pipelines->get_pipeline( $source_pipeline_id );
 		if ( ! $source_pipeline ) {
 			return array(
-				'success' => false,
-				'error'   => 'Source pipeline not found',
+				'success'    => false,
+				'error'      => 'Source pipeline not found',
+				'error_code' => 'pipeline_not_found',
+				'status'     => 404,
 			);
 		}
 
 		$target_pipeline = $this->db_pipelines->get_pipeline( $target_pipeline_id );
 		if ( ! $target_pipeline ) {
 			return array(
-				'success' => false,
-				'error'   => 'Target pipeline not found',
+				'success'    => false,
+				'error'      => 'Target pipeline not found',
+				'error_code' => 'pipeline_not_found',
+				'status'     => 404,
 			);
 		}
 

--- a/inc/Abilities/Flow/UpdateFlowAbility.php
+++ b/inc/Abilities/Flow/UpdateFlowAbility.php
@@ -113,8 +113,10 @@ class UpdateFlowAbility {
 		$flow = $this->db_flows->get_flow( $flow_id );
 		if ( ! $flow ) {
 			return array(
-				'success' => false,
-				'error'   => 'Flow not found',
+				'success'    => false,
+				'error'      => 'Flow not found',
+				'error_code' => 'flow_not_found',
+				'status'     => 404,
 			);
 		}
 

--- a/inc/Abilities/Pipeline/DeletePipelineAbility.php
+++ b/inc/Abilities/Pipeline/DeletePipelineAbility.php
@@ -89,8 +89,10 @@ class DeletePipelineAbility {
 		if ( ! $pipeline ) {
 			do_action( 'datamachine_log', 'error', 'Pipeline not found for deletion', array( 'pipeline_id' => $pipeline_id ) );
 			return array(
-				'success' => false,
-				'error'   => 'Pipeline not found',
+				'success'    => false,
+				'error'      => 'Pipeline not found',
+				'error_code' => 'pipeline_not_found',
+				'status'     => 404,
 			);
 		}
 

--- a/inc/Abilities/Pipeline/UpdatePipelineAbility.php
+++ b/inc/Abilities/Pipeline/UpdatePipelineAbility.php
@@ -102,8 +102,10 @@ class UpdatePipelineAbility {
 		$pipeline = $this->db_pipelines->get_pipeline( $pipeline_id );
 		if ( ! $pipeline ) {
 			return array(
-				'success' => false,
-				'error'   => 'Pipeline not found',
+				'success'    => false,
+				'error'      => 'Pipeline not found',
+				'error_code' => 'pipeline_not_found',
+				'status'     => 404,
 			);
 		}
 

--- a/inc/Api/Flows/Flows.php
+++ b/inc/Api/Flows/Flows.php
@@ -523,7 +523,7 @@ class Flows {
 				$status = 404;
 			}
 
-			return $error ?: new \WP_Error( 'flow_not_found', __( 'Flow not found.', 'data-machine' ), array( 'status' => $status ) );
+			return $error ? $error : new \WP_Error( 'flow_not_found', __( 'Flow not found.', 'data-machine' ), array( 'status' => $status ) );
 		}
 
 		return AbilityResult::rest_item_response( $result, $result['flows'][0] );

--- a/inc/Api/Flows/Flows.php
+++ b/inc/Api/Flows/Flows.php
@@ -11,6 +11,7 @@
 namespace DataMachine\Api\Flows;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\AbilityResult;
 use WP_REST_Server;
 
 if ( ! defined( 'WPINC' ) ) {
@@ -386,24 +387,7 @@ class Flows {
 
 		$result = $ability->execute( $input );
 
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] ) {
-			return new \WP_Error(
-				'flow_creation_failed',
-				$result['error'] ?? __( 'Failed to create flow.', 'data-machine' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'data'    => $result,
-			)
-		);
+		return AbilityResult::rest_item_response( $result, null, array(), 'flow_creation_failed', __( 'Failed to create flow.', 'data-machine' ), 400 );
 	}
 
 	/**
@@ -436,19 +420,7 @@ class Flows {
 			)
 		);
 
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] ) {
-			return new \WP_Error(
-				'flow_deletion_failed',
-				$result['error'] ?? __( 'Failed to delete flow.', 'data-machine' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		return rest_ensure_response( $result );
+		return AbilityResult::rest_item_response( $result, null, array(), 'flow_deletion_failed', __( 'Failed to delete flow.', 'data-machine' ), 400 );
 	}
 
 	/**
@@ -482,19 +454,7 @@ class Flows {
 			)
 		);
 
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] ) {
-			return new \WP_Error(
-				'flow_duplication_failed',
-				$result['error'] ?? __( 'Failed to duplicate flow.', 'data-machine' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		return rest_ensure_response( $result );
+		return AbilityResult::rest_item_response( $result, null, array(), 'flow_duplication_failed', __( 'Failed to duplicate flow.', 'data-machine' ), 400 );
 	}
 
 	/**
@@ -526,38 +486,19 @@ class Flows {
 		}
 		$result = $ability->execute( $input );
 
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] ) {
-			return new \WP_Error( 'ability_error', $result['error'], array( 'status' => 500 ) );
-		}
-
 		if ( $pipeline_id ) {
-			return rest_ensure_response(
+			return AbilityResult::rest_collection_response(
+				$result,
+				'flows',
 				array(
-					'success'  => true,
-					'data'     => array(
-						'pipeline_id' => $pipeline_id,
-						'flows'       => $result['flows'],
-					),
-					'total'    => $result['total'],
-					'per_page' => $result['per_page'],
-					'offset'   => $result['offset'],
-				)
+					'data_key'   => 'flows',
+					'data_extra' => array( 'pipeline_id' => $pipeline_id ),
+				),
+				'ability_error'
 			);
 		}
 
-		return rest_ensure_response(
-			array(
-				'success'  => true,
-				'data'     => $result['flows'],
-				'total'    => $result['total'] ?? count( $result['flows'] ),
-				'per_page' => $result['per_page'] ?? 20,
-				'offset'   => $result['offset'] ?? 0,
-			)
-		);
+		return AbilityResult::rest_collection_response( $result, 'flows', array(), 'ability_error' );
 	}
 
 	/**
@@ -573,29 +514,19 @@ class Flows {
 
 		$result = $ability->execute( array( 'flow_id' => $flow_id ) );
 
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] || empty( $result['flows'] ) ) {
+		$error = AbilityResult::failure_to_wp_error( $result, 'flow_not_found', __( 'Flow not found.', 'data-machine' ), 400 );
+		if ( $error || empty( $result['flows'] ) ) {
 			$status = 400;
-			if ( false !== strpos( $result['error'] ?? '', 'not found' ) || empty( $result['flows'] ) ) {
+			if ( $error && isset( $error->get_error_data()['status'] ) ) {
+				$status = (int) $error->get_error_data()['status'];
+			} elseif ( empty( $result['flows'] ) ) {
 				$status = 404;
 			}
 
-			return new \WP_Error(
-				'flow_not_found',
-				$result['error'] ?? __( 'Flow not found.', 'data-machine' ),
-				array( 'status' => $status )
-			);
+			return $error ?: new \WP_Error( 'flow_not_found', __( 'Flow not found.', 'data-machine' ), array( 'status' => $status ) );
 		}
 
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'data'    => $result['flows'][0],
-			)
-		);
+		return AbilityResult::rest_item_response( $result, $result['flows'][0] );
 	}
 
 	/**
@@ -640,16 +571,9 @@ class Flows {
 
 		$result = $ability->execute( $input );
 
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] ) {
-			return new \WP_Error(
-				'update_failed',
-				$result['error'] ?? __( 'Failed to update flow', 'data-machine' ),
-				array( 'status' => 400 )
-			);
+		$error = AbilityResult::failure_to_wp_error( $result, 'update_failed', __( 'Failed to update flow', 'data-machine' ), 400 );
+		if ( $error ) {
+			return $error;
 		}
 
 		$flow_id = $result['flow_id'];
@@ -668,13 +592,7 @@ class Flows {
 			}
 		}
 
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'data'    => $result['flow_data'] ?? array( 'flow_id' => $flow_id ),
-				'message' => __( 'Flow updated successfully', 'data-machine' ),
-			)
-		);
+		return AbilityResult::rest_item_response( $result, $result['flow_data'] ?? array( 'flow_id' => $flow_id ), array( 'message' => __( 'Flow updated successfully', 'data-machine' ) ) );
 	}
 
 	/**
@@ -694,19 +612,7 @@ class Flows {
 
 		$result = $ability->execute( array( 'flow_id' => $flow_id ) );
 
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] ) {
-			return new \WP_Error(
-				'pause_failed',
-				$result['error'] ?? __( 'Failed to pause flow.', 'data-machine' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		return rest_ensure_response( $result );
+		return AbilityResult::rest_item_response( $result, null, array(), 'pause_failed', __( 'Failed to pause flow.', 'data-machine' ), 400 );
 	}
 
 	/**
@@ -726,19 +632,7 @@ class Flows {
 
 		$result = $ability->execute( array( 'flow_id' => $flow_id ) );
 
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] ) {
-			return new \WP_Error(
-				'resume_failed',
-				$result['error'] ?? __( 'Failed to resume flow.', 'data-machine' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		return rest_ensure_response( $result );
+		return AbilityResult::rest_item_response( $result, null, array(), 'resume_failed', __( 'Failed to resume flow.', 'data-machine' ), 400 );
 	}
 
 	/**
@@ -775,19 +669,7 @@ class Flows {
 
 		$result = $ability->execute( $input );
 
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] ) {
-			return new \WP_Error(
-				'bulk_pause_failed',
-				$result['error'] ?? __( 'Failed to pause flows.', 'data-machine' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		return rest_ensure_response( $result );
+		return AbilityResult::rest_item_response( $result, null, array(), 'bulk_pause_failed', __( 'Failed to pause flows.', 'data-machine' ), 400 );
 	}
 
 	/**
@@ -824,19 +706,7 @@ class Flows {
 
 		$result = $ability->execute( $input );
 
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] ) {
-			return new \WP_Error(
-				'bulk_resume_failed',
-				$result['error'] ?? __( 'Failed to resume flows.', 'data-machine' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		return rest_ensure_response( $result );
+		return AbilityResult::rest_item_response( $result, null, array(), 'bulk_resume_failed', __( 'Failed to resume flows.', 'data-machine' ), 400 );
 	}
 
 	/**
@@ -861,16 +731,9 @@ class Flows {
 
 		$result = $ability->execute( $input );
 
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] ) {
-			return new \WP_Error(
-				'get_problem_flows_error',
-				$result['error'] ?? __( 'Failed to get problem flows', 'data-machine' ),
-				array( 'status' => 500 )
-			);
+		$error = AbilityResult::failure_to_wp_error( $result, 'get_problem_flows_error', __( 'Failed to get problem flows', 'data-machine' ) );
+		if ( $error ) {
+			return $error;
 		}
 
 		$problem_flows = array_merge( $result['failing'] ?? array(), $result['idle'] ?? array() );

--- a/inc/Api/Flows/Flows.php
+++ b/inc/Api/Flows/Flows.php
@@ -420,7 +420,7 @@ class Flows {
 			)
 		);
 
-		return AbilityResult::rest_item_response( $result, null, array(), 'flow_deletion_failed', __( 'Failed to delete flow.', 'data-machine' ), 400 );
+		return AbilityResult::rest_legacy_response( $result, 'flow_deletion_failed', __( 'Failed to delete flow.', 'data-machine' ), 400 );
 	}
 
 	/**
@@ -454,7 +454,7 @@ class Flows {
 			)
 		);
 
-		return AbilityResult::rest_item_response( $result, null, array(), 'flow_duplication_failed', __( 'Failed to duplicate flow.', 'data-machine' ), 400 );
+		return AbilityResult::rest_legacy_response( $result, 'flow_duplication_failed', __( 'Failed to duplicate flow.', 'data-machine' ), 400 );
 	}
 
 	/**
@@ -612,7 +612,7 @@ class Flows {
 
 		$result = $ability->execute( array( 'flow_id' => $flow_id ) );
 
-		return AbilityResult::rest_item_response( $result, null, array(), 'pause_failed', __( 'Failed to pause flow.', 'data-machine' ), 400 );
+		return AbilityResult::rest_legacy_response( $result, 'pause_failed', __( 'Failed to pause flow.', 'data-machine' ), 400 );
 	}
 
 	/**
@@ -632,7 +632,7 @@ class Flows {
 
 		$result = $ability->execute( array( 'flow_id' => $flow_id ) );
 
-		return AbilityResult::rest_item_response( $result, null, array(), 'resume_failed', __( 'Failed to resume flow.', 'data-machine' ), 400 );
+		return AbilityResult::rest_legacy_response( $result, 'resume_failed', __( 'Failed to resume flow.', 'data-machine' ), 400 );
 	}
 
 	/**
@@ -669,7 +669,7 @@ class Flows {
 
 		$result = $ability->execute( $input );
 
-		return AbilityResult::rest_item_response( $result, null, array(), 'bulk_pause_failed', __( 'Failed to pause flows.', 'data-machine' ), 400 );
+		return AbilityResult::rest_legacy_response( $result, 'bulk_pause_failed', __( 'Failed to pause flows.', 'data-machine' ), 400 );
 	}
 
 	/**
@@ -706,7 +706,7 @@ class Flows {
 
 		$result = $ability->execute( $input );
 
-		return AbilityResult::rest_item_response( $result, null, array(), 'bulk_resume_failed', __( 'Failed to resume flows.', 'data-machine' ), 400 );
+		return AbilityResult::rest_legacy_response( $result, 'bulk_resume_failed', __( 'Failed to resume flows.', 'data-machine' ), 400 );
 	}
 
 	/**

--- a/inc/Api/Jobs.php
+++ b/inc/Api/Jobs.php
@@ -19,6 +19,7 @@ namespace DataMachine\Api;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Abilities\Job\DeleteJobsAbility;
 use DataMachine\Abilities\Job\GetJobsAbility;
+use DataMachine\Core\AbilityResult;
 
 if ( ! defined( 'WPINC' ) ) {
 	die;
@@ -210,15 +211,7 @@ class Jobs {
 
 		$result = ( new GetJobsAbility() )->execute( $input );
 
-		return rest_ensure_response(
-			array(
-				'success'  => $result['success'],
-				'data'     => $result['jobs'],
-				'total'    => $result['total'],
-				'per_page' => $result['per_page'],
-				'offset'   => $result['offset'],
-			)
-		);
+		return AbilityResult::rest_collection_response( $result, 'jobs', array( 'top_extra' => array( 'filters_applied' ) ), 'get_jobs_failed', __( 'Failed to get jobs.', 'data-machine' ) );
 	}
 
 	/**
@@ -231,20 +224,12 @@ class Jobs {
 
 		$result = ( new GetJobsAbility() )->execute( array( 'job_id' => $job_id ) );
 
-		if ( ! $result['success'] || empty( $result['jobs'] ) ) {
-			return new \WP_Error(
-				'job_not_found',
-				$result['error'] ?? __( 'Job not found.', 'data-machine' ),
-				array( 'status' => 404 )
-			);
+		$error = AbilityResult::failure_to_wp_error( $result, 'job_not_found', __( 'Job not found.', 'data-machine' ), 404 );
+		if ( $error || empty( $result['jobs'] ) ) {
+			return $error ?: new \WP_Error( 'job_not_found', __( 'Job not found.', 'data-machine' ), array( 'status' => 404 ) );
 		}
 
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'data'    => $result['jobs'][0],
-			)
-		);
+		return AbilityResult::rest_item_response( $result, $result['jobs'][0] );
 	}
 
 	/**
@@ -263,12 +248,9 @@ class Jobs {
 			)
 		);
 
-		if ( ! $result['success'] ) {
-			return new \WP_Error(
-				'delete_failed',
-				$result['error'] ?? __( 'Failed to delete jobs.', 'data-machine' ),
-				array( 'status' => 500 )
-			);
+		$error = AbilityResult::failure_to_wp_error( $result, 'delete_failed', __( 'Failed to delete jobs.', 'data-machine' ) );
+		if ( $error ) {
+			return $error;
 		}
 
 		return rest_ensure_response(

--- a/inc/Api/Jobs.php
+++ b/inc/Api/Jobs.php
@@ -226,7 +226,7 @@ class Jobs {
 
 		$error = AbilityResult::failure_to_wp_error( $result, 'job_not_found', __( 'Job not found.', 'data-machine' ), 404 );
 		if ( $error || empty( $result['jobs'] ) ) {
-			return $error ?: new \WP_Error( 'job_not_found', __( 'Job not found.', 'data-machine' ), array( 'status' => 404 ) );
+			return $error ? $error : new \WP_Error( 'job_not_found', __( 'Job not found.', 'data-machine' ), array( 'status' => 404 ) );
 		}
 
 		return AbilityResult::rest_item_response( $result, $result['jobs'][0] );

--- a/inc/Api/Pipelines/Pipelines.php
+++ b/inc/Api/Pipelines/Pipelines.php
@@ -18,6 +18,7 @@ use DataMachine\Abilities\Pipeline\GetPipelinesAbility;
 use DataMachine\Abilities\Pipeline\ImportExportAbility;
 use DataMachine\Abilities\Pipeline\UpdatePipelineAbility;
 use DataMachine\Core\Admin\DateFormatter;
+use DataMachine\Core\AbilityResult;
 use WP_REST_Server;
 
 if ( ! defined( 'WPINC' ) ) {
@@ -324,12 +325,9 @@ class Pipelines {
 				array( 'pipeline_ids' => $export_ids )
 			);
 
-			if ( ! $result['success'] ) {
-				return new \WP_Error(
-					'export_failed',
-					$result['error'] ?? __( 'Failed to generate CSV export.', 'data-machine' ),
-					array( 'status' => 500 )
-				);
+			$error = AbilityResult::failure_to_wp_error( $result, 'export_failed', __( 'Failed to generate CSV export.', 'data-machine' ) );
+			if ( $error ) {
+				return $error;
 			}
 
 			$response = new \WP_REST_Response( $result['data'] );
@@ -428,12 +426,9 @@ class Pipelines {
 			}
 			$result = ( new GetPipelinesAbility() )->execute( $input );
 
-			if ( ! $result['success'] ) {
-				return new \WP_Error(
-					'get_pipelines_failed',
-					$result['error'] ?? __( 'Failed to get pipelines.', 'data-machine' ),
-					array( 'status' => 500 )
-				);
+			$error = AbilityResult::failure_to_wp_error( $result, 'get_pipelines_failed', __( 'Failed to get pipelines.', 'data-machine' ) );
+			if ( $error ) {
+				return $error;
 			}
 
 			$pipelines = $result['pipelines'];
@@ -447,18 +442,18 @@ class Pipelines {
 				);
 			}
 
-			return rest_ensure_response(
+			$result['pipelines'] = $pipelines;
+
+			return AbilityResult::rest_collection_response(
+				$result,
+				'pipelines',
 				array(
-					'success'     => true,
-					'per_page'    => $result['per_page'] ?? $per_page,
-					'offset'      => $result['offset'] ?? $offset,
-					'total'       => $result['total'],
-					'output_mode' => $result['output_mode'] ?? $output_mode,
-					'data'        => array(
-						'pipelines' => $pipelines,
-						'total'     => $result['total'],
-					),
-				)
+					'data_key'     => 'pipelines',
+					'compat_alias' => array( 'total' => 'total' ),
+					'top_extra'    => array( 'output_mode' ),
+				),
+				'get_pipelines_failed',
+				__( 'Failed to get pipelines.', 'data-machine' )
 			);
 		}
 	}
@@ -491,20 +486,7 @@ class Pipelines {
 
 		$result = ( new CreatePipelineAbility() )->execute( $input );
 
-		if ( ! $result['success'] ) {
-			return new \WP_Error(
-				'rest_internal_server_error',
-				$result['error'] ?? __( 'Failed to create pipeline.', 'data-machine' ),
-				array( 'status' => 500 )
-			);
-		}
-
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'data'    => $result,
-			)
-		);
+		return AbilityResult::rest_item_response( $result, null, array(), 'rest_internal_server_error', __( 'Failed to create pipeline.', 'data-machine' ) );
 	}
 
 	/**
@@ -528,19 +510,7 @@ class Pipelines {
 
 		$result = ( new DeletePipelineAbility() )->execute( array( 'pipeline_id' => $pipeline_id ) );
 
-		if ( ! $result['success'] ) {
-			$status = 500;
-			if ( strpos( $result['error'] ?? '', 'not found' ) !== false ) {
-				$status = 404;
-			}
-			return new \WP_Error(
-				'pipeline_deletion_failed',
-				$result['error'] ?? __( 'Failed to delete pipeline.', 'data-machine' ),
-				array( 'status' => $status )
-			);
-		}
-
-		return rest_ensure_response( $result );
+		return AbilityResult::rest_item_response( $result, null, array(), 'pipeline_deletion_failed', __( 'Failed to delete pipeline.', 'data-machine' ) );
 	}
 
 	/**
@@ -580,16 +550,9 @@ class Pipelines {
 			)
 		);
 
-		if ( ! $result['success'] ) {
-			$status = 500;
-			if ( strpos( $result['error'] ?? '', 'not found' ) !== false ) {
-				$status = 404;
-			}
-			return new \WP_Error(
-				'update_failed',
-				$result['error'] ?? __( 'Failed to save pipeline title', 'data-machine' ),
-				array( 'status' => $status )
-			);
+		$error = AbilityResult::failure_to_wp_error( $result, 'update_failed', __( 'Failed to save pipeline title', 'data-machine' ) );
+		if ( $error ) {
+			return $error;
 		}
 
 		return rest_ensure_response(

--- a/inc/Api/Pipelines/Pipelines.php
+++ b/inc/Api/Pipelines/Pipelines.php
@@ -510,7 +510,7 @@ class Pipelines {
 
 		$result = ( new DeletePipelineAbility() )->execute( array( 'pipeline_id' => $pipeline_id ) );
 
-		return AbilityResult::rest_item_response( $result, null, array(), 'pipeline_deletion_failed', __( 'Failed to delete pipeline.', 'data-machine' ) );
+		return AbilityResult::rest_legacy_response( $result, 'pipeline_deletion_failed', __( 'Failed to delete pipeline.', 'data-machine' ) );
 	}
 
 	/**

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -24,6 +24,7 @@ use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Abilities\Job\RetryJobAbility;
 use DataMachine\Abilities\Engine\PipelineBatchScheduler;
 use DataMachine\Abilities\Job\RunMetricsAbility;
+use DataMachine\Core\AbilityResult;
 use DataMachine\Core\JobArtifacts;
 use DataMachine\Core\RunMetrics;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
@@ -117,8 +118,9 @@ class JobsCommand extends BaseCommand {
 			)
 		);
 
-		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['error'] ?? 'Unknown error occurred' );
+		$error = AbilityResult::failure_to_wp_error( $result, 'get_jobs_failed', 'Unknown error occurred' );
+		if ( $error ) {
+			WP_CLI::error( $error->get_error_message() );
 			return;
 		}
 
@@ -1115,7 +1117,7 @@ class JobsCommand extends BaseCommand {
 
 		$jobs = $result['jobs'] ?? array();
 
-		if ( empty( $jobs ) ) {
+		if ( empty( $jobs ) && 'json' !== $format ) {
 			WP_CLI::warning( 'No jobs found.' );
 			return;
 		}
@@ -1183,7 +1185,9 @@ class JobsCommand extends BaseCommand {
 		}
 
 		if ( 'json' === $format ) {
-			WP_CLI::log( wp_json_encode( $items, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			$json_result         = $result;
+			$json_result['jobs'] = $items;
+			WP_CLI::log( wp_json_encode( AbilityResult::collection_envelope( $json_result, 'jobs', array( 'top_extra' => array( 'filters_applied' ) ) ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 			return;
 		}
 

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -1185,9 +1185,7 @@ class JobsCommand extends BaseCommand {
 		}
 
 		if ( 'json' === $format ) {
-			$json_result         = $result;
-			$json_result['jobs'] = $items;
-			WP_CLI::log( wp_json_encode( AbilityResult::collection_envelope( $json_result, 'jobs', array( 'top_extra' => array( 'filters_applied' ) ) ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			WP_CLI::log( wp_json_encode( AbilityResult::cli_collection_payload( $items, $result, 'jobs' ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 			return;
 		}
 

--- a/inc/Core/AbilityResult.php
+++ b/inc/Core/AbilityResult.php
@@ -102,10 +102,132 @@ class AbilityResult {
 			$message = $default_message;
 		}
 
+		$status = isset( $result['status'] ) ? (int) $result['status'] : ( $status_map[ $error_code ] ?? $default_status );
+
 		return new \WP_Error(
 			$error_code,
 			$message,
-			array( 'status' => $status_map[ $error_code ] ?? $default_status )
+			array( 'status' => $status )
+		);
+	}
+
+	/**
+	 * Convert ability output into a REST-ready WP_Error when execution failed.
+	 *
+	 * @param mixed  $result          Ability execution result.
+	 * @param string $default_code    Error code to use when the result has no error code.
+	 * @param string $default_message Error message to use when the result has no message.
+	 * @param int    $default_status  Default HTTP status.
+	 * @return \WP_Error|null WP_Error for failures, null for successful results.
+	 */
+	public static function failure_to_wp_error( $result, string $default_code = 'ability_failed', string $default_message = 'Ability execution failed.', int $default_status = 500 ): ?\WP_Error {
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return self::legacy_failure_to_wp_error( $result, $default_code, $default_message, array(), $default_status );
+	}
+
+	/**
+	 * Present a successful ability collection with Data Machine's canonical page envelope.
+	 *
+	 * @param array  $result     Successful ability result.
+	 * @param string $items_key  Key containing collection items in the ability result.
+	 * @param array  $options    Presentation options.
+	 * @return array REST/CLI-safe collection envelope.
+	 */
+	public static function collection_envelope( array $result, string $items_key, array $options = array() ): array {
+		$items        = $result[ $items_key ] ?? array();
+		$data_key     = $options['data_key'] ?? null;
+		$data         = $data_key ? array( $data_key => $items ) : $items;
+		$data_extra   = $options['data_extra'] ?? array();
+		$meta_keys    = $options['meta_keys'] ?? array( 'total', 'per_page', 'offset' );
+		$top_extra    = $options['top_extra'] ?? array();
+		$compat_alias = $options['compat_alias'] ?? array();
+
+		if ( $data_key && is_array( $data ) ) {
+			$data = array_merge( $data_extra, $data );
+			foreach ( $compat_alias as $alias => $source_key ) {
+				if ( array_key_exists( $source_key, $result ) ) {
+					$data[ $alias ] = $result[ $source_key ];
+				}
+			}
+		}
+
+		$envelope = array(
+			'success' => true,
+			'data'    => $data,
+		);
+
+		foreach ( $meta_keys as $key ) {
+			if ( array_key_exists( $key, $result ) ) {
+				$envelope[ $key ] = $result[ $key ];
+			}
+		}
+
+		foreach ( $top_extra as $key ) {
+			if ( array_key_exists( $key, $result ) ) {
+				$envelope[ $key ] = $result[ $key ];
+			}
+		}
+
+		if ( ! array_key_exists( 'total', $envelope ) ) {
+			$envelope['total'] = is_countable( $items ) ? count( $items ) : 0;
+		}
+
+		return $envelope;
+	}
+
+	/**
+	 * Present an ability collection as a REST response, normalizing failures first.
+	 *
+	 * @param mixed  $result          Ability execution result.
+	 * @param string $items_key       Key containing collection items in the ability result.
+	 * @param array  $options         Collection presentation options.
+	 * @param string $default_code    Default error code.
+	 * @param string $default_message Default error message.
+	 * @param int    $default_status  Default HTTP status.
+	 * @return \WP_REST_Response|\WP_Error REST response or error.
+	 */
+	public static function rest_collection_response( $result, string $items_key, array $options = array(), string $default_code = 'ability_failed', string $default_message = 'Ability execution failed.', int $default_status = 500 ) {
+		$error = self::failure_to_wp_error( $result, $default_code, $default_message, $default_status );
+		if ( $error ) {
+			return $error;
+		}
+
+		return rest_ensure_response( self::collection_envelope( self::normalize( $result ), $items_key, $options ) );
+	}
+
+	/**
+	 * Present an ability result as a single-resource REST response.
+	 *
+	 * @param mixed  $result          Ability execution result.
+	 * @param mixed  $data            Data payload for the response.
+	 * @param array  $extra           Extra top-level envelope fields.
+	 * @param string $default_code    Default error code.
+	 * @param string $default_message Default error message.
+	 * @param int    $default_status  Default HTTP status.
+	 * @return \WP_REST_Response|\WP_Error REST response or error.
+	 */
+	public static function rest_item_response( $result, $data = null, array $extra = array(), string $default_code = 'ability_failed', string $default_message = 'Ability execution failed.', int $default_status = 500 ) {
+		$error = self::failure_to_wp_error( $result, $default_code, $default_message, $default_status );
+		if ( $error ) {
+			return $error;
+		}
+
+		$normalized = self::normalize( $result );
+		if ( null === $data ) {
+			$data = $normalized;
+		}
+
+		return rest_ensure_response(
+			array_merge(
+				array(
+					'success' => true,
+					'data'    => $data,
+				),
+				$extra
+			)
 		);
 	}
 

--- a/inc/Core/AbilityResult.php
+++ b/inc/Core/AbilityResult.php
@@ -199,6 +199,46 @@ class AbilityResult {
 	}
 
 	/**
+	 * Present an ability result as a raw legacy REST response.
+	 *
+	 * Use this at explicit compatibility edges that already exposed ability fields
+	 * at the top level, such as mutation endpoints returning message/count data.
+	 *
+	 * @param mixed  $result          Ability execution result.
+	 * @param string $default_code    Default error code.
+	 * @param string $default_message Default error message.
+	 * @param int    $default_status  Default HTTP status.
+	 * @return \WP_REST_Response|\WP_Error REST response or error.
+	 */
+	public static function rest_legacy_response( $result, string $default_code = 'ability_failed', string $default_message = 'Ability execution failed.', int $default_status = 500 ) {
+		$error = self::failure_to_wp_error( $result, $default_code, $default_message, $default_status );
+		if ( $error ) {
+			return $error;
+		}
+
+		return rest_ensure_response( self::normalize( $result ) );
+	}
+
+	/**
+	 * Present collection rows for CLI JSON while allowing explicit envelope opt-in.
+	 *
+	 * @param array  $items        Rows formatted for CLI output.
+	 * @param array  $result       Ability result containing pagination metadata.
+	 * @param string $items_key    Collection key to use when envelope output is requested.
+	 * @param bool   $use_envelope Whether to return the shared collection envelope.
+	 * @return array CLI JSON payload.
+	 */
+	public static function cli_collection_payload( array $items, array $result, string $items_key, bool $use_envelope = false ): array {
+		if ( ! $use_envelope ) {
+			return $items;
+		}
+
+		$result[ $items_key ] = $items;
+
+		return self::collection_envelope( $result, $items_key, array( 'top_extra' => array( 'filters_applied' ) ) );
+	}
+
+	/**
 	 * Present an ability result as a single-resource REST response.
 	 *
 	 * @param mixed  $result          Ability execution result.

--- a/tests/ability-result-wp-error-smoke.php
+++ b/tests/ability-result-wp-error-smoke.php
@@ -45,6 +45,12 @@ if ( ! function_exists( 'is_wp_error' ) ) {
 	}
 }
 
+if ( ! function_exists( 'rest_ensure_response' ) ) {
+	function rest_ensure_response( $response ) {
+		return $response;
+	}
+}
+
 require_once __DIR__ . '/../inc/Core/AbilityResult.php';
 
 use DataMachine\Core\AbilityResult;
@@ -131,6 +137,64 @@ $default_code_error = AbilityResult::legacy_failure_to_wp_error(
 );
 $assert( 'legacy failures default to provided error code', 'email_error' === $default_code_error->get_error_code() );
 $assert( 'legacy failures keep error message', 'Human readable failure.' === $default_code_error->get_error_message() );
+
+$status_error = AbilityResult::failure_to_wp_error(
+	array(
+		'success'    => false,
+		'error'      => 'Pipeline not found.',
+		'error_code' => 'pipeline_not_found',
+		'status'     => 404,
+	),
+	'pipeline_failed',
+	'Pipeline failed.',
+	500
+);
+$assert( 'machine-readable legacy error_code is preserved', 'pipeline_not_found' === $status_error->get_error_code() );
+$assert( 'machine-readable status controls HTTP status', 404 === ( $status_error->get_error_data()['status'] ?? null ) );
+
+$collection = AbilityResult::collection_envelope(
+	array(
+		'success'     => true,
+		'pipelines'   => array( array( 'pipeline_id' => 7 ) ),
+		'total'       => 1,
+		'per_page'    => 20,
+		'offset'      => 0,
+		'output_mode' => 'list',
+	),
+	'pipelines',
+	array(
+		'data_key'     => 'pipelines',
+		'compat_alias' => array( 'total' => 'total' ),
+		'top_extra'    => array( 'output_mode' ),
+	)
+);
+$assert( 'collection envelope keeps success flag', true === $collection['success'] );
+$assert( 'collection envelope puts items under data key', 7 === ( $collection['data']['pipelines'][0]['pipeline_id'] ?? null ) );
+$assert( 'collection envelope keeps pagination metadata at top level', 20 === ( $collection['per_page'] ?? null ) );
+$assert( 'collection envelope supports explicit compatibility aliases', 1 === ( $collection['data']['total'] ?? null ) );
+$assert( 'collection envelope carries requested top-level extras', 'list' === ( $collection['output_mode'] ?? null ) );
+
+$rest_collection_error = AbilityResult::rest_collection_response(
+	array(
+		'success'    => false,
+		'error'      => 'No jobs.',
+		'error_code' => 'jobs_unavailable',
+		'status'     => 503,
+	),
+	'jobs',
+	array(),
+	'get_jobs_failed'
+);
+$assert( 'REST collection presenter returns WP_Error for failed ability results', $rest_collection_error instanceof WP_Error );
+$assert( 'REST collection presenter preserves failure status', 503 === ( $rest_collection_error->get_error_data()['status'] ?? null ) );
+
+$rest_item = AbilityResult::rest_item_response(
+	array( 'success' => true ),
+	array( 'job_id' => 9 ),
+	array( 'message' => 'ok' )
+);
+$assert( 'REST item presenter wraps single resource data', 9 === ( $rest_item['data']['job_id'] ?? null ) );
+$assert( 'REST item presenter includes explicit top-level extras', 'ok' === ( $rest_item['message'] ?? null ) );
 
 if ( $failed > 0 ) {
 	echo "=== ability-result-wp-error-smoke: {$failed} FAIL of {$total} ===\n";

--- a/tests/ability-result-wp-error-smoke.php
+++ b/tests/ability-result-wp-error-smoke.php
@@ -196,6 +196,35 @@ $rest_item = AbilityResult::rest_item_response(
 $assert( 'REST item presenter wraps single resource data', 9 === ( $rest_item['data']['job_id'] ?? null ) );
 $assert( 'REST item presenter includes explicit top-level extras', 'ok' === ( $rest_item['message'] ?? null ) );
 
+$legacy_rest = AbilityResult::rest_legacy_response(
+	array(
+		'success' => true,
+		'message' => 'Paused flows.',
+		'paused'  => 3,
+	)
+);
+$assert( 'legacy REST presenter preserves top-level success flag', true === ( $legacy_rest['success'] ?? null ) );
+$assert( 'legacy REST presenter preserves top-level mutation fields', 3 === ( $legacy_rest['paused'] ?? null ) );
+$assert( 'legacy REST presenter does not double-wrap under data', ! array_key_exists( 'data', $legacy_rest ) );
+
+$cli_rows = array(
+	array(
+		'id'     => 12,
+		'source' => 'pipeline',
+	),
+);
+$cli_result = array(
+	'success'  => true,
+	'jobs'     => array(),
+	'total'    => 1,
+	'per_page' => 20,
+	'offset'   => 0,
+);
+$assert( 'CLI collection payload defaults to legacy row array', $cli_rows === AbilityResult::cli_collection_payload( $cli_rows, $cli_result, 'jobs' ) );
+$cli_envelope = AbilityResult::cli_collection_payload( $cli_rows, $cli_result, 'jobs', true );
+$assert( 'CLI collection payload can opt into shared envelope', 12 === ( $cli_envelope['data'][0]['id'] ?? null ) );
+$assert( 'CLI envelope opt-in includes pagination metadata', 20 === ( $cli_envelope['per_page'] ?? null ) );
+
 if ( $failed > 0 ) {
 	echo "=== ability-result-wp-error-smoke: {$failed} FAIL of {$total} ===\n";
 	exit( 1 );


### PR DESCRIPTION
## Summary
- Adds shared `AbilityResult` presenters for REST single-resource responses, paginated collection envelopes, and transport-agnostic collection JSON.
- Migrates high-value flow, pipeline, job REST handlers and `wp datamachine jobs list --format=json` onto the shared envelope seam.
- Adds machine-readable `error_code` / `status` metadata for flow and pipeline not-found ability failures so REST status mapping no longer depends on message text.

## Verification
- `php -l inc/Core/AbilityResult.php && php -l inc/Api/Flows/Flows.php && php -l inc/Api/Pipelines/Pipelines.php && php -l inc/Api/Jobs.php && php -l inc/Cli/Commands/JobsCommand.php`
- `vendor/bin/phpcs inc/Core/AbilityResult.php inc/Api/Flows/Flows.php inc/Api/Pipelines/Pipelines.php inc/Api/Jobs.php inc/Cli/Commands/JobsCommand.php inc/Abilities/Pipeline/DeletePipelineAbility.php inc/Abilities/Pipeline/UpdatePipelineAbility.php inc/Abilities/Flow/DeleteFlowAbility.php inc/Abilities/Flow/UpdateFlowAbility.php inc/Abilities/Flow/CreateFlowAbility.php inc/Abilities/Flow/DuplicateFlowAbility.php tests/ability-result-wp-error-smoke.php`
- `php tests/ability-result-wp-error-smoke.php`
- `git diff --check`

## Notes
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-ability-rest-cli-result-envelopes --extension wordpress` could not run because Homeboy auto-selected lab runner `lab`, which is missing required `php` and `composer` tools for `test`.

Closes #2261.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the shared result presenter seam, migrated representative REST/CLI handlers, added smoke coverage, and ran targeted verification for Chris to review.