### PR TITLE
Fix step execution status classification

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -21,6 +21,7 @@ use DataMachine\Core\FilesRepository\FileCleanup;
 use DataMachine\Core\FilesRepository\FileRetrieval;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\RunMetrics;
+use DataMachine\Core\StepExecutionResult;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\Step;
 use DataMachine\Engine\StepNavigator;
@@ -203,7 +204,7 @@ class ExecuteStepAbility {
 			$dataPackets = $flow_step->execute( $payload );
 
 			$payload['data'] = $dataPackets;
-			$step_success    = $this->evaluateStepSuccess( $dataPackets, $job_id, $flow_step_id );
+			$step_success    = $this->evaluateStepSuccess( $dataPackets, $job_id, $flow_step_id, $step_type );
 
 			// Refresh engine data to capture changes made during step execution.
 			$refreshed_engine_data = datamachine_get_engine_data( $job_id );
@@ -349,83 +350,25 @@ class ExecuteStepAbility {
 	 * @param string $flow_step_id Flow step ID (for logging).
 	 * @return bool True if step succeeded.
 	 */
-	private function evaluateStepSuccess( array $dataPackets, int $job_id, string $flow_step_id ): bool {
-		$step_success = ! empty( $dataPackets );
+	private function evaluateStepSuccess( array $dataPackets, int $job_id, string $flow_step_id, string $step_type = '' ): bool {
+		$classification = StepExecutionResult::classify( $dataPackets, $step_type );
 
-		if ( $step_success ) {
-			$successful_handlers = $this->collectSuccessfulHandlerTools( $dataPackets );
-
-			foreach ( $dataPackets as $packet ) {
-				$metadata = $packet['metadata'] ?? array();
-				if ( isset( $metadata['success'] ) && false === $metadata['success'] ) {
-					$step_success = false;
-					do_action(
-						'datamachine_log',
-						'warning',
-						'Step returned failure packet',
-						array(
-							'job_id'        => $job_id,
-							'flow_step_id'  => $flow_step_id,
-							'packet_type'   => $packet['type'] ?? 'unknown',
-							'error_message' => $packet['data']['body'] ?? 'No error message',
-						)
-					);
-					break;
-				}
-
-				if ( isset( $metadata['tool_success'] ) && false === $metadata['tool_success'] ) {
-					$handler_tool = isset( $metadata['handler_tool'] ) ? (string) $metadata['handler_tool'] : '';
-					if ( '' !== $handler_tool && isset( $successful_handlers[ $handler_tool ] ) ) {
-						continue;
-					}
-
-					$step_success = false;
-					do_action(
-						'datamachine_log',
-						'warning',
-						'Step returned failed tool result',
-						array(
-							'job_id'        => $job_id,
-							'flow_step_id'  => $flow_step_id,
-							'packet_type'   => $packet['type'] ?? 'unknown',
-							'handler_tool'  => $handler_tool,
-							'error_message' => $packet['data']['body'] ?? 'No error message',
-						)
-					);
-					break;
-				}
-			}
+		if ( ! $classification['success'] ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Step execution did not produce a successful result',
+				array(
+					'job_id'       => $job_id,
+					'flow_step_id' => $flow_step_id,
+					'step_type'    => $step_type,
+					'reason'       => $classification['reason'],
+					'packet_count' => $classification['packet_count'],
+				)
+			);
 		}
 
-		return $step_success;
-	}
-
-	/**
-	 * Collect handler tools that have at least one successful result packet.
-	 *
-	 * AI tools may fail once and then succeed on a later turn. A later successful
-	 * required handler result should allow downstream upsert/publish steps to run.
-	 *
-	 * @param array $dataPackets Returned data packets.
-	 * @return array<string,bool>
-	 */
-	private function collectSuccessfulHandlerTools( array $dataPackets ): array {
-		$handlers = array();
-
-		foreach ( $dataPackets as $packet ) {
-			$metadata     = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
-			$handler_tool = isset( $metadata['handler_tool'] ) ? (string) $metadata['handler_tool'] : '';
-
-			if ( '' === $handler_tool ) {
-				continue;
-			}
-
-			if ( 'ai_handler_complete' === ( $packet['type'] ?? '' ) || true === ( $metadata['tool_success'] ?? false ) ) {
-				$handlers[ $handler_tool ] = true;
-			}
-		}
-
-		return $handlers;
+		return (bool) $classification['success'];
 	}
 
 	/**

--- a/inc/Core/AbilityResult.php
+++ b/inc/Core/AbilityResult.php
@@ -65,6 +65,12 @@ class AbilityResult {
 		}
 
 		if ( is_array( $result ) ) {
+			if ( array_key_exists( 'data', $result ) && ! array_key_exists( 'result', $result ) ) {
+				$result['result'] = $result['data'];
+			} elseif ( array_key_exists( 'result', $result ) && ! array_key_exists( 'data', $result ) ) {
+				$result['data'] = $result['result'];
+			}
+
 			return $result;
 		}
 
@@ -72,6 +78,7 @@ class AbilityResult {
 			'success'   => true,
 			'tool_name' => $tool_name,
 			'ability'   => $ability_slug,
+			'data'      => $result,
 			'result'    => $result,
 		);
 	}

--- a/inc/Core/StepExecutionResult.php
+++ b/inc/Core/StepExecutionResult.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Step execution result classifier.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Classifies execution success separately from DataPacket transport.
+ */
+class StepExecutionResult {
+
+	/** @var array<string,bool> */
+	private const NON_SUCCESS_PACKET_TYPES = array(
+		'ai_response' => true,
+	);
+
+	/**
+	 * Classify step output packets into an execution result.
+	 *
+	 * @param array  $data_packets Returned data packets.
+	 * @param string $step_type    Step type identifier.
+	 * @return array{success: bool, reason: string, packet_count: int}
+	 */
+	public static function classify( array $data_packets, string $step_type = '' ): array {
+		$packet_count = count( $data_packets );
+
+		if ( 0 === $packet_count ) {
+			return array(
+				'success'      => false,
+				'reason'       => 'empty_data_packet_returned',
+				'packet_count' => 0,
+			);
+		}
+
+		$successful_handlers = self::collectSuccessfulHandlerTools( $data_packets );
+		$has_success_packet  = false;
+
+		foreach ( $data_packets as $packet ) {
+			$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+			$type     = (string) ( $packet['type'] ?? '' );
+
+			if ( array_key_exists( 'step_execution_success', $metadata ) ) {
+				if ( false === (bool) $metadata['step_execution_success'] ) {
+					return array(
+						'success'      => false,
+						'reason'       => self::sanitizeReason( $metadata['failure_reason'] ?? 'step_execution_failed' ),
+						'packet_count' => $packet_count,
+					);
+				}
+
+				$has_success_packet = true;
+				continue;
+			}
+
+			if ( isset( $metadata['success'] ) && false === $metadata['success'] ) {
+				return array(
+					'success'      => false,
+					'reason'       => self::sanitizeReason( $metadata['failure_reason'] ?? 'packet_failure' ),
+					'packet_count' => $packet_count,
+				);
+			}
+
+			if ( isset( $metadata['tool_success'] ) && false === $metadata['tool_success'] ) {
+				$handler_tool = isset( $metadata['handler_tool'] ) ? (string) $metadata['handler_tool'] : '';
+				if ( '' !== $handler_tool && isset( $successful_handlers[ $handler_tool ] ) ) {
+					continue;
+				}
+
+				return array(
+					'success'      => false,
+					'reason'       => self::sanitizeReason( $metadata['failure_reason'] ?? 'tool_result_failed' ),
+					'packet_count' => $packet_count,
+				);
+			}
+
+			if ( ! isset( self::NON_SUCCESS_PACKET_TYPES[ $type ] ) ) {
+				$has_success_packet = true;
+			}
+		}
+
+		return array(
+			'success'      => $has_success_packet,
+			'reason'       => $has_success_packet ? 'completed' : self::fallbackReason( $step_type ),
+			'packet_count' => $packet_count,
+		);
+	}
+
+	/**
+	 * Collect handler tools with at least one successful result packet.
+	 *
+	 * @param array $data_packets Returned data packets.
+	 * @return array<string,bool>
+	 */
+	private static function collectSuccessfulHandlerTools( array $data_packets ): array {
+		$handlers = array();
+
+		foreach ( $data_packets as $packet ) {
+			$metadata     = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+			$handler_tool = isset( $metadata['handler_tool'] ) ? (string) $metadata['handler_tool'] : '';
+
+			if ( '' === $handler_tool ) {
+				continue;
+			}
+
+			if ( 'ai_handler_complete' === ( $packet['type'] ?? '' ) || true === ( $metadata['tool_success'] ?? false ) ) {
+				$handlers[ $handler_tool ] = true;
+			}
+		}
+
+		return $handlers;
+	}
+
+	private static function fallbackReason( string $step_type ): string {
+		return 'ai' === $step_type ? 'ai_response_without_tool_result' : 'step_output_not_successful';
+	}
+
+	private static function sanitizeReason( $reason ): string {
+		$reason = is_scalar( $reason ) ? trim( (string) $reason ) : '';
+		if ( '' === $reason ) {
+			return 'step_execution_failed';
+		}
+
+		return function_exists( 'sanitize_key' ) ? sanitize_key( str_replace( ' ', '_', $reason ) ) : preg_replace( '/[^a-z0-9_\-]/', '', strtolower( str_replace( ' ', '_', $reason ) ) );
+	}
+}

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -20,6 +20,7 @@ use DataMachine\Engine\AI\PipelineAIConcurrencyLease;
 use DataMachine\Engine\AI\PipelineAIConcurrencyLimiter;
 use DataMachine\Engine\AI\PipelineTranscriptPolicy;
 use DataMachine\Engine\AI\Tools\ToolExecutor;
+use DataMachine\Engine\AI\Tools\ToolResultFinder;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 
 use function DataMachine\Engine\AI\datamachine_run_conversation;
@@ -945,7 +946,7 @@ class AIStep extends Step {
 
 			$tool_def = $available_tools[ $tool_name ] ?? null;
 
-			$projected_tool_result_data = $tool_result['data'] ?? ( $tool_result['result'] ?? array() );
+			$projected_tool_result_data = ToolResultFinder::projectEnvelopeData( $tool_result );
 
 			if ( $is_handler_tool && ( $tool_result['success'] ?? false ) ) {
 				// Handler tool succeeded - mark completion

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -932,18 +932,20 @@ class AIStep extends Step {
 		// Input DataPackets are NOT included — they cause ghost child jobs.
 		$input_source_type = $inputDataPackets[0]['metadata']['source_type'] ?? 'unknown';
 
-		foreach ( $tool_execution_results as $tool_result_data ) {
-			$tool_name         = $tool_result_data['tool_name'] ?? '';
-			$tool_result       = $tool_result_data['result'] ?? array();
-			$tool_parameters   = $tool_result_data['parameters'] ?? array();
-			$is_handler_tool   = $tool_result_data['is_handler_tool'] ?? false;
-			$result_turn_count = $tool_result_data['turn_count'] ?? $turn_count;
+		foreach ( $tool_execution_results as $tool_execution_result ) {
+			$tool_name         = $tool_execution_result['tool_name'] ?? '';
+			$tool_result       = $tool_execution_result['result'] ?? array();
+			$tool_parameters   = $tool_execution_result['parameters'] ?? array();
+			$is_handler_tool   = $tool_execution_result['is_handler_tool'] ?? false;
+			$result_turn_count = $tool_execution_result['turn_count'] ?? $turn_count;
 
 			if ( empty( $tool_name ) ) {
 				continue;
 			}
 
 			$tool_def = $available_tools[ $tool_name ] ?? null;
+
+			$projected_tool_result_data = $tool_result['data'] ?? ( $tool_result['result'] ?? array() );
 
 			if ( $is_handler_tool && ( $tool_result['success'] ?? false ) ) {
 				// Handler tool succeeded - mark completion
@@ -961,14 +963,16 @@ class AIStep extends Step {
 						'body'  => 'Tool executed successfully by AI agent in ' . $result_turn_count . ' conversation turns',
 					),
 					array(
-						'tool_name'         => $tool_name,
-						'handler_tool'      => $tool_def['handler'] ?? null,
-						'tool_parameters'   => $clean_tool_parameters,
-						'handler_config'    => $handler_config,
-						'source_type'       => $input_source_type,
-						'flow_step_id'      => $flow_step_id,
-						'conversation_turn' => $result_turn_count,
-						'tool_result'       => $tool_result,
+						'tool_name'              => $tool_name,
+						'handler_tool'           => $tool_def['handler'] ?? null,
+						'tool_parameters'        => $clean_tool_parameters,
+						'handler_config'         => $handler_config,
+						'source_type'            => $input_source_type,
+						'flow_step_id'           => $flow_step_id,
+						'conversation_turn'      => $result_turn_count,
+						'tool_result_envelope'   => $tool_result,
+						'tool_result_data'       => $projected_tool_result_data,
+						'step_execution_success' => true,
 					),
 					'ai_handler_complete'
 				);
@@ -985,12 +989,13 @@ class AIStep extends Step {
 						'body'  => $success_message,
 					),
 					array(
-						'tool_name'       => $tool_name,
-						'handler_tool'    => $tool_def['handler'] ?? null,
-						'tool_parameters' => $tool_parameters,
-						'tool_success'    => $tool_result['success'] ?? false,
-						'tool_result'     => $tool_result['data'] ?? array(),
-						'source_type'     => $input_source_type,
+						'tool_name'            => $tool_name,
+						'handler_tool'         => $tool_def['handler'] ?? null,
+						'tool_parameters'      => $tool_parameters,
+						'tool_success'         => $tool_result['success'] ?? false,
+						'tool_result_envelope' => $tool_result,
+						'tool_result_data'     => $projected_tool_result_data,
+						'source_type'          => $input_source_type,
 					),
 					'tool_result'
 				);
@@ -1010,9 +1015,11 @@ class AIStep extends Step {
 					'body'  => $final_ai_content,
 				),
 				array(
-					'source_type'       => 'ai_response',
-					'flow_step_id'      => $flow_step_id,
-					'conversation_turn' => $turn_count,
+					'source_type'            => 'ai_response',
+					'flow_step_id'           => $flow_step_id,
+					'conversation_turn'      => $turn_count,
+					'step_execution_success' => false,
+					'failure_reason'         => 'ai_response_without_tool_result',
 				),
 				'ai_response'
 			);
@@ -1031,6 +1038,7 @@ class AIStep extends Step {
 					'conversation_turn'               => $turn_count,
 					'completion_assertions_satisfied' => is_array( $loop_result['completion_assertions_satisfied'] ?? null ) ? $loop_result['completion_assertions_satisfied'] : array(),
 					'completion_assertions_missing'   => is_array( $loop_result['completion_assertions_missing'] ?? null ) ? $loop_result['completion_assertions_missing'] : array(),
+					'step_execution_success'          => true,
 				),
 				'ai_completion_assertions'
 			);

--- a/inc/Core/Steps/Publish/PublishStep.php
+++ b/inc/Core/Steps/Publish/PublishStep.php
@@ -132,8 +132,10 @@ class PublishStep extends Step {
 	 * @return array Publish data packet
 	 */
 	private function create_publish_entry_from_tool_result( array $tool_result_entry, array $dataPackets, string $handler, string $flow_step_id ): array {
-		$tool_result_data = ToolResultFinder::projectResultData( $tool_result_entry );
-		$entry_type       = $tool_result_entry['type'] ?? '';
+		$tool_result_data     = ToolResultFinder::projectResultData( $tool_result_entry );
+		$tool_result_envelope = ToolResultFinder::projectResultEnvelope( $tool_result_entry );
+		$tool_result_success  = ToolResultFinder::projectResultSuccess( $tool_result_entry );
+		$entry_type           = $tool_result_entry['type'] ?? '';
 
 		if ( empty($tool_result_data) ) {
 			$this->log(
@@ -157,11 +159,12 @@ class PublishStep extends Step {
 			),
 			array(
 				'handler_used'        => $handler,
-				'publish_success'     => true,
+				'publish_success'     => $tool_result_success,
 				'executed_via'        => $executed_via,
 				'flow_step_id'        => $flow_step_id,
 				'source_type'         => $tool_result_entry['metadata']['source_type'] ?? 'unknown',
-				'tool_execution_data' => $tool_result_data,
+				'tool_execution_data' => $tool_result_envelope,
+				'tool_result_data'    => $tool_result_data,
 				'original_entry_type' => $entry_type,
 				'result'              => $tool_result_data,
 			),

--- a/inc/Core/Steps/Publish/PublishStep.php
+++ b/inc/Core/Steps/Publish/PublishStep.php
@@ -132,7 +132,7 @@ class PublishStep extends Step {
 	 * @return array Publish data packet
 	 */
 	private function create_publish_entry_from_tool_result( array $tool_result_entry, array $dataPackets, string $handler, string $flow_step_id ): array {
-		$tool_result_data = $tool_result_entry['metadata']['tool_result'] ?? array();
+		$tool_result_data = ToolResultFinder::projectResultData( $tool_result_entry );
 		$entry_type       = $tool_result_entry['type'] ?? '';
 
 		if ( empty($tool_result_data) ) {

--- a/inc/Core/Steps/Upsert/UpsertStep.php
+++ b/inc/Core/Steps/Upsert/UpsertStep.php
@@ -183,7 +183,9 @@ class UpsertStep extends Step {
 	 * @return array Updated data packet array
 	 */
 	private function create_update_entry_from_tool_result( array $tool_result_entry, array $dataPackets, string $handler, string $flow_step_id ): array {
-		$tool_result_data = ToolResultFinder::projectResultData( $tool_result_entry );
+		$tool_result_data     = ToolResultFinder::projectResultData( $tool_result_entry );
+		$tool_result_envelope = ToolResultFinder::projectResultEnvelope( $tool_result_entry );
+		$tool_result_success  = ToolResultFinder::projectResultSuccess( $tool_result_entry );
 
 		$packet = new DataPacket(
 			array(
@@ -194,9 +196,10 @@ class UpsertStep extends Step {
 				'step_type'           => 'upsert',
 				'handler'             => $handler,
 				'flow_step_id'        => $flow_step_id,
-				'success'             => $tool_result_data['success'] ?? false,
+				'success'             => $tool_result_success,
 				'executed_via'        => 'ai_tool_call',
-				'tool_execution_data' => $tool_result_data,
+				'tool_execution_data' => $tool_result_envelope,
+				'tool_result_data'    => $tool_result_data,
 			),
 			'upsert'
 		);

--- a/inc/Core/Steps/Upsert/UpsertStep.php
+++ b/inc/Core/Steps/Upsert/UpsertStep.php
@@ -183,7 +183,7 @@ class UpsertStep extends Step {
 	 * @return array Updated data packet array
 	 */
 	private function create_update_entry_from_tool_result( array $tool_result_entry, array $dataPackets, string $handler, string $flow_step_id ): array {
-		$tool_result_data = $tool_result_entry['metadata']['tool_result'] ?? array();
+		$tool_result_data = ToolResultFinder::projectResultData( $tool_result_entry );
 
 		$packet = new DataPacket(
 			array(

--- a/inc/Engine/AI/Tools/ToolResultFinder.php
+++ b/inc/Engine/AI/Tools/ToolResultFinder.php
@@ -17,6 +17,65 @@ if ( ! defined('ABSPATH') ) {
  */
 class ToolResultFinder {
 
+	/**
+	 * Project the stable tool-result data payload from a result packet.
+	 *
+	 * New packets carry both the full execution envelope and projected data.
+	 * Legacy packets overloaded metadata.tool_result, so compatibility remains
+	 * isolated here instead of leaking into every consumer.
+	 *
+	 * @param array $entry Tool result packet.
+	 * @return array
+	 */
+	public static function projectResultData( array $entry ): array {
+		$metadata = is_array( $entry['metadata'] ?? null ) ? $entry['metadata'] : array();
+
+		if ( is_array( $metadata['tool_result_data'] ?? null ) ) {
+			return $metadata['tool_result_data'];
+		}
+
+		if ( is_array( $metadata['tool_result_envelope'] ?? null ) ) {
+			$envelope = $metadata['tool_result_envelope'];
+			if ( is_array( $envelope['data'] ?? null ) ) {
+				return $envelope['data'];
+			}
+			if ( is_array( $envelope['result'] ?? null ) ) {
+				return $envelope['result'];
+			}
+			return $envelope;
+		}
+
+		if ( is_array( $metadata['tool_result'] ?? null ) ) {
+			$legacy = $metadata['tool_result'];
+			if ( is_array( $legacy['data'] ?? null ) ) {
+				return $legacy['data'];
+			}
+			return $legacy;
+		}
+
+		return array();
+	}
+
+	/**
+	 * Project the full tool-result envelope from a result packet.
+	 *
+	 * @param array $entry Tool result packet.
+	 * @return array
+	 */
+	public static function projectResultEnvelope( array $entry ): array {
+		$metadata = is_array( $entry['metadata'] ?? null ) ? $entry['metadata'] : array();
+
+		if ( is_array( $metadata['tool_result_envelope'] ?? null ) ) {
+			return $metadata['tool_result_envelope'];
+		}
+
+		if ( is_array( $metadata['tool_result'] ?? null ) ) {
+			return $metadata['tool_result'];
+		}
+
+		return array();
+	}
+
 
 	/**
 	 * Find AI tool execution result by exact handler match.

--- a/inc/Engine/AI/Tools/ToolResultFinder.php
+++ b/inc/Engine/AI/Tools/ToolResultFinder.php
@@ -29,31 +29,44 @@ class ToolResultFinder {
 	 */
 	public static function projectResultData( array $entry ): array {
 		$metadata = is_array( $entry['metadata'] ?? null ) ? $entry['metadata'] : array();
+		$envelope = self::projectResultEnvelope( $entry );
+
+		if ( ! empty( $metadata['tool_result_data'] ) && is_array( $metadata['tool_result_data'] ) ) {
+			return $metadata['tool_result_data'];
+		}
+
+		if ( ! empty( $envelope ) ) {
+			return self::projectEnvelopeData( $envelope );
+		}
 
 		if ( is_array( $metadata['tool_result_data'] ?? null ) ) {
 			return $metadata['tool_result_data'];
 		}
 
-		if ( is_array( $metadata['tool_result_envelope'] ?? null ) ) {
-			$envelope = $metadata['tool_result_envelope'];
-			if ( is_array( $envelope['data'] ?? null ) ) {
-				return $envelope['data'];
-			}
-			if ( is_array( $envelope['result'] ?? null ) ) {
-				return $envelope['result'];
-			}
-			return $envelope;
-		}
-
-		if ( is_array( $metadata['tool_result'] ?? null ) ) {
-			$legacy = $metadata['tool_result'];
-			if ( is_array( $legacy['data'] ?? null ) ) {
-				return $legacy['data'];
-			}
-			return $legacy;
-		}
-
 		return array();
+	}
+
+	/**
+	 * Project payload data from a full tool-result envelope.
+	 *
+	 * @param array $envelope Full tool execution result envelope.
+	 * @return array
+	 */
+	public static function projectEnvelopeData( array $envelope ): array {
+		if ( is_array( $envelope['data'] ?? null ) ) {
+			return $envelope['data'];
+		}
+
+		if ( is_array( $envelope['result'] ?? null ) ) {
+			return $envelope['result'];
+		}
+
+		$payload = $envelope;
+		foreach ( array( 'success', 'error', 'message', 'code', 'tool_name', 'ability', 'executor', 'wp_error_code', 'wp_error_data' ) as $semantic_key ) {
+			unset( $payload[ $semantic_key ] );
+		}
+
+		return $payload;
 	}
 
 	/**
@@ -73,7 +86,35 @@ class ToolResultFinder {
 			return $metadata['tool_result'];
 		}
 
+		if ( is_array( $metadata['tool_result_data'] ?? null ) ) {
+			return array(
+				'success' => (bool) ( $metadata['tool_success'] ?? false ),
+				'data'    => $metadata['tool_result_data'],
+			);
+		}
+
 		return array();
+	}
+
+	/**
+	 * Return semantic success from a result packet.
+	 *
+	 * @param array $entry Tool result packet.
+	 * @return bool
+	 */
+	public static function projectResultSuccess( array $entry ): bool {
+		$metadata = is_array( $entry['metadata'] ?? null ) ? $entry['metadata'] : array();
+		$envelope = self::projectResultEnvelope( $entry );
+
+		if ( array_key_exists( 'success', $envelope ) ) {
+			return (bool) $envelope['success'];
+		}
+
+		if ( array_key_exists( 'tool_success', $metadata ) ) {
+			return (bool) $metadata['tool_success'];
+		}
+
+		return 'ai_handler_complete' === ( $entry['type'] ?? '' );
 	}
 
 

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1266,6 +1266,11 @@ function datamachine_normalize_runtime_tool_result( string $tool_name, $result )
 		$result['success']   = array_key_exists( 'success', $result ) ? (bool) $result['success'] : true;
 		$result['tool_name'] = $result['tool_name'] ?? $tool_name;
 		$result['executor']  = $result['executor'] ?? 'client';
+		if ( array_key_exists( 'data', $result ) && ! array_key_exists( 'result', $result ) ) {
+			$result['result'] = $result['data'];
+		} elseif ( array_key_exists( 'result', $result ) && ! array_key_exists( 'data', $result ) ) {
+			$result['data'] = $result['result'];
+		}
 		return $result;
 	}
 
@@ -1274,6 +1279,7 @@ function datamachine_normalize_runtime_tool_result( string $tool_name, $result )
 		'tool_name' => $tool_name,
 		'executor'  => 'client',
 		'data'      => $result,
+		'result'    => $result,
 	);
 }
 

--- a/inc/Engine/Debug/SyncRunner.php
+++ b/inc/Engine/Debug/SyncRunner.php
@@ -13,6 +13,7 @@ use DataMachine\Abilities\Engine\ScheduleNextStepAbility;
 use DataMachine\Abilities\StepTypeAbilities;
 use DataMachine\Core\EngineData;
 use DataMachine\Core\JobStatus;
+use DataMachine\Core\StepExecutionResult;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\Step;
 use DataMachine\Engine\StepNavigator;
@@ -258,6 +259,7 @@ class SyncRunner {
 		}
 
 		$output_count = count( $output_packets );
+		$classification = StepExecutionResult::classify( $output_packets, $step_type );
 		$next_step_id = ( new StepNavigator() )->get_next_flow_step_id( $flow_step_id, array( 'job_id' => $job_id ) );
 		$reason       = null;
 
@@ -267,8 +269,8 @@ class SyncRunner {
 		} elseif ( 0 === $output_count && in_array( $step_type, array( 'fetch', 'event_import' ), true ) ) {
 			$reason = 'completed_no_items';
 			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED_NO_ITEMS );
-		} elseif ( 0 === $output_count ) {
-			return $this->stepFailure( $flow_step_id, 'empty_data_packet_returned', $step_type, $step_class, $input_count );
+		} elseif ( ! $classification['success'] ) {
+			return $this->stepFailure( $flow_step_id, $classification['reason'], $step_type, $step_class, $input_count, $output_count );
 		} elseif ( null === $next_step_id ) {
 			$reason = 'completed';
 			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED );
@@ -305,14 +307,14 @@ class SyncRunner {
 	/**
 	 * Build a consistent failed step result.
 	 */
-	private function stepFailure( string $flow_step_id, string $error, string $step_type = '', string $step_class = '', int $input_count = 0 ): array {
+	private function stepFailure( string $flow_step_id, string $error, string $step_type = '', string $step_class = '', int $input_count = 0, int $output_count = 0 ): array {
 		return array(
 			'diagnostics'    => array(
 				'flow_step_id' => $flow_step_id,
 				'step_type'    => $step_type,
 				'step_class'   => $step_class,
 				'input_count'  => $input_count,
-				'output_count' => 0,
+				'output_count' => $output_count,
 				'error'        => $error,
 			),
 			'data_packets'   => array(),

--- a/inc/Engine/Debug/SyncRunner.php
+++ b/inc/Engine/Debug/SyncRunner.php
@@ -258,10 +258,10 @@ class SyncRunner {
 			$truncated      = true;
 		}
 
-		$output_count = count( $output_packets );
+		$output_count   = count( $output_packets );
 		$classification = StepExecutionResult::classify( $output_packets, $step_type );
-		$next_step_id = ( new StepNavigator() )->get_next_flow_step_id( $flow_step_id, array( 'job_id' => $job_id ) );
-		$reason       = null;
+		$next_step_id   = ( new StepNavigator() )->get_next_flow_step_id( $flow_step_id, array( 'job_id' => $job_id ) );
+		$reason         = null;
 
 		if ( $truncated ) {
 			$reason = 'max_items';

--- a/tests/Unit/Core/Steps/AI/AIStepTest.php
+++ b/tests/Unit/Core/Steps/AI/AIStepTest.php
@@ -314,6 +314,9 @@ class AIStepTest extends TestCase {
 		$this->assertCount( 1, $result, 'processLoopResults should return only tool result packets, not input packets' );
 		$this->assertSame( 'ai_handler_complete', $result[0]['type'] );
 		$this->assertSame( 'upsert_event', $result[0]['metadata']['tool_name'] );
+		$this->assertArrayHasKey( 'tool_result_envelope', $result[0]['metadata'] );
+		$this->assertArrayHasKey( 'tool_result_data', $result[0]['metadata'] );
+		$this->assertArrayNotHasKey( 'tool_result', $result[0]['metadata'] );
 
 		// Verify the input packet is NOT in the output.
 		foreach ( $result as $packet ) {
@@ -442,6 +445,8 @@ class AIStepTest extends TestCase {
 		// Should emit a single AI response packet, not the input + response.
 		$this->assertCount( 1, $result );
 		$this->assertSame( 'ai_response', $result[0]['type'] );
+		$this->assertFalse( $result[0]['metadata']['step_execution_success'] );
+		$this->assertSame( 'ai_response_without_tool_result', $result[0]['metadata']['failure_reason'] );
 	}
 
 	public function test_process_loop_results_emits_completion_assertion_packet_when_final_turn_is_empty(): void {

--- a/tests/Unit/Core/Steps/AI/AIStepTest.php
+++ b/tests/Unit/Core/Steps/AI/AIStepTest.php
@@ -317,6 +317,7 @@ class AIStepTest extends TestCase {
 		$this->assertArrayHasKey( 'tool_result_envelope', $result[0]['metadata'] );
 		$this->assertArrayHasKey( 'tool_result_data', $result[0]['metadata'] );
 		$this->assertArrayNotHasKey( 'tool_result', $result[0]['metadata'] );
+		$this->assertSame( array( 'post_id' => 123 ), $result[0]['metadata']['tool_result_data'] );
 
 		// Verify the input packet is NOT in the output.
 		foreach ( $result as $packet ) {

--- a/tests/Unit/Engine/AI/Tools/ToolResultFinderTest.php
+++ b/tests/Unit/Engine/AI/Tools/ToolResultFinderTest.php
@@ -58,4 +58,31 @@ class ToolResultFinderTest extends TestCase {
 		$this->assertNull( $result );
 		$this->assertSame( array(), $logged );
 	}
+
+	public function test_project_result_data_prefers_stable_projected_contract(): void {
+		$entry = array(
+			'metadata' => array(
+				'tool_result_envelope' => array(
+					'success' => true,
+					'data'    => array( 'id' => 123 ),
+				),
+				'tool_result_data'     => array( 'id' => 456 ),
+			),
+		);
+
+		$this->assertSame( array( 'id' => 456 ), ToolResultFinder::projectResultData( $entry ) );
+	}
+
+	public function test_project_result_data_reads_legacy_envelope_shape(): void {
+		$entry = array(
+			'metadata' => array(
+				'tool_result' => array(
+					'success' => true,
+					'data'    => array( 'id' => 123 ),
+				),
+			),
+		);
+
+		$this->assertSame( array( 'id' => 123 ), ToolResultFinder::projectResultData( $entry ) );
+	}
 }

--- a/tests/Unit/Engine/AI/Tools/ToolResultFinderTest.php
+++ b/tests/Unit/Engine/AI/Tools/ToolResultFinderTest.php
@@ -85,4 +85,19 @@ class ToolResultFinderTest extends TestCase {
 
 		$this->assertSame( array( 'id' => 123 ), ToolResultFinder::projectResultData( $entry ) );
 	}
+
+	public function test_project_result_data_reads_legacy_top_level_payload_shape(): void {
+		$entry = array(
+			'metadata' => array(
+				'tool_result_envelope' => array(
+					'success' => true,
+					'post_id' => 123,
+				),
+				'tool_result_data'     => array(),
+			),
+		);
+
+		$this->assertTrue( ToolResultFinder::projectResultSuccess( $entry ) );
+		$this->assertSame( array( 'post_id' => 123 ), ToolResultFinder::projectResultData( $entry ) );
+	}
 }

--- a/tests/ability-result-wp-error-smoke.php
+++ b/tests/ability-result-wp-error-smoke.php
@@ -102,6 +102,7 @@ $assert( 'tool array results pass through unchanged', $tool_array_result === Abi
 $tool_scalar_result = AbilityResult::normalize_tool_result( 'ok', 'demo_tool', 'datamachine/demo' );
 $assert( 'tool scalar result is wrapped as success', true === $tool_scalar_result['success'] );
 $assert( 'tool scalar result payload uses tool result key', 'ok' === $tool_scalar_result['result'] );
+$assert( 'tool scalar result payload also uses data key', 'ok' === $tool_scalar_result['data'] );
 
 $legacy_error = AbilityResult::legacy_failure_to_wp_error(
 	array(

--- a/tests/ai-error-status-propagation-smoke.php
+++ b/tests/ai-error-status-propagation-smoke.php
@@ -44,6 +44,7 @@ if ( ! function_exists( 'datamachine_get_engine_data' ) ) {
 }
 
 require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/StepExecutionResult.php';
 require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
 require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
 require_once __DIR__ . '/../inc/Abilities/Engine/EngineHelpers.php';

--- a/tests/job-status-accounting-smoke.php
+++ b/tests/job-status-accounting-smoke.php
@@ -30,6 +30,7 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 }
 
 require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/StepExecutionResult.php';
 require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
 require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
 require_once __DIR__ . '/../inc/Abilities/Engine/EngineHelpers.php';
@@ -96,7 +97,21 @@ $packets = array(
 
 $assert( 'step fails when no successful handler result exists', false === $evaluate( $packets ) );
 
-echo "\n[3] reconcile-status command exists with repair markers\n";
+echo "\n[3] fallback AI response packet is not execution success\n";
+$packets = array(
+	array(
+		'type'     => 'ai_response',
+		'data'     => array( 'body' => 'summarized but did not execute a handler' ),
+		'metadata' => array(
+			'step_execution_success' => false,
+			'failure_reason'          => 'ai_response_without_tool_result',
+		),
+	),
+);
+
+$assert( 'step fails when only an AI fallback packet exists', false === $evaluate( $packets ) );
+
+echo "\n[4] reconcile-status command exists with repair markers\n";
 $jobs_command = file_get_contents( __DIR__ . '/../inc/Cli/Commands/JobsCommand.php' );
 $assert( 'CLI exposes reconcile-status subcommand', str_contains( $jobs_command, '@subcommand reconcile-status' ) );
 $assert( 'CLI detects successful wiki update artifacts', str_contains( $jobs_command, 'Updated wiki article:' ) );

--- a/tests/step-exception-failure-contract-smoke.php
+++ b/tests/step-exception-failure-contract-smoke.php
@@ -10,6 +10,9 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
+if ( ! defined( 'WPINC' ) ) {
+	define( 'WPINC', 'wp-includes' );
+}
 
 $datamachine_action_log = array();
 
@@ -66,8 +69,11 @@ if ( ! function_exists( 'datamachine_get_file_context' ) ) {
 
 require_once __DIR__ . '/../inc/Core/DataPacket.php';
 require_once __DIR__ . '/../inc/Core/EngineData.php';
+require_once __DIR__ . '/../inc/Core/StepExecutionResult.php';
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
 require_once __DIR__ . '/../inc/Core/Steps/Step.php';
+require_once __DIR__ . '/../inc/Engine/ExecutionPlan.php';
+require_once __DIR__ . '/../inc/Engine/StepNavigator.php';
 require_once __DIR__ . '/../inc/Abilities/Engine/EngineHelpers.php';
 require_once __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php';
 
@@ -78,6 +84,10 @@ use DataMachine\Core\Steps\Step;
 class DataMachine_Throwing_Test_Step extends Step {
 	public function __construct() {
 		parent::__construct( 'throwing' );
+	}
+
+	protected function validateStepConfiguration(): bool {
+		return true;
 	}
 
 	protected function executeStep(): array {

--- a/tests/tool-result-consumer-contract-smoke.php
+++ b/tests/tool-result-consumer-contract-smoke.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Pure-PHP smoke test for handler result projection into Upsert/Publish.
+ *
+ * Run with: php tests/tool-result-consumer-contract-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, $flags = 0, $depth = 512 ) {
+		return json_encode( $value, $flags, $depth );
+	}
+}
+
+if ( ! function_exists( 'current_time' ) ) {
+	function current_time( string $type, bool $gmt = false ): string {
+		unset( $type, $gmt );
+		return '2026-05-26 00:00:00';
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		unset( $hook, $args );
+	}
+}
+
+if ( ! function_exists( 'datamachine_get_engine_data' ) ) {
+	function datamachine_get_engine_data( int $job_id ): array {
+		unset( $job_id );
+		return array();
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/DataPacket.php';
+require_once __DIR__ . '/../inc/Core/EngineData.php';
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/Core/Steps/Step.php';
+require_once __DIR__ . '/../inc/Core/Steps/StepTypeRegistrationTrait.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolResultFinder.php';
+require_once __DIR__ . '/../inc/Core/Steps/Publish/PublishStep.php';
+require_once __DIR__ . '/../inc/Core/Steps/Upsert/UpsertStep.php';
+
+use DataMachine\Core\Steps\Publish\PublishStep;
+use DataMachine\Core\Steps\Upsert\UpsertStep;
+
+$failures = array();
+$passes   = 0;
+
+function assert_tool_consumer_contract( bool $condition, string $message, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "  [PASS] {$message}\n";
+		return;
+	}
+
+	$failures[] = $message;
+	echo "  [FAIL] {$message}\n";
+}
+
+function invoke_tool_consumer_contract_private_method( string $class_name, string $method_name, array $entry ): array {
+	$reflection = new ReflectionClass( $class_name );
+	$instance   = $reflection->newInstanceWithoutConstructor();
+	$method     = $reflection->getMethod( $method_name );
+
+	return $method->invoke( $instance, $entry, array(), 'demo_handler', 'flow_step_1' );
+}
+
+function handler_tool_result_entry( array $envelope ): array {
+	return array(
+		'type'     => 'ai_handler_complete',
+		'data'     => array( 'body' => 'handler completed' ),
+		'metadata' => array(
+			'tool_name'            => 'demo_tool',
+			'handler_tool'         => 'demo_handler',
+			'source_type'          => 'demo_source',
+			'tool_result_envelope' => $envelope,
+			'tool_result_data'     => DataMachine\Engine\AI\Tools\ToolResultFinder::projectEnvelopeData( $envelope ),
+		),
+	);
+}
+
+echo "=== tool-result-consumer-contract-smoke ===\n";
+
+$cases = array(
+	'success + data'             => array(
+		'envelope' => array(
+			'success' => true,
+			'data'    => array( 'post_id' => 123 ),
+		),
+		'payload'  => array( 'post_id' => 123 ),
+	),
+	'legacy success + top-level' => array(
+		'envelope' => array(
+			'success' => true,
+			'post_id' => 456,
+		),
+		'payload'  => array( 'post_id' => 456 ),
+	),
+);
+
+foreach ( $cases as $label => $case ) {
+	$entry          = handler_tool_result_entry( $case['envelope'] );
+	$upsert_packets = invoke_tool_consumer_contract_private_method( UpsertStep::class, 'create_update_entry_from_tool_result', $entry );
+	$publish_packets = invoke_tool_consumer_contract_private_method( PublishStep::class, 'create_publish_entry_from_tool_result', $entry );
+	$upsert_packet  = $upsert_packets[0] ?? array();
+	$publish_packet = $publish_packets[0] ?? array();
+
+	assert_tool_consumer_contract( true === ( $upsert_packet['metadata']['success'] ?? false ), "{$label}: Upsert preserves semantic success", $failures, $passes );
+	assert_tool_consumer_contract( $case['payload'] === ( $upsert_packet['data']['update_result'] ?? array() ), "{$label}: Upsert exposes payload data", $failures, $passes );
+	assert_tool_consumer_contract( $case['envelope'] === ( $upsert_packet['metadata']['tool_execution_data'] ?? array() ), "{$label}: Upsert preserves execution envelope", $failures, $passes );
+	assert_tool_consumer_contract( $case['payload'] === ( $upsert_packet['metadata']['tool_result_data'] ?? array() ), "{$label}: Upsert stores projected payload", $failures, $passes );
+
+	assert_tool_consumer_contract( true === ( $publish_packet['metadata']['publish_success'] ?? false ), "{$label}: Publish preserves semantic success", $failures, $passes );
+	assert_tool_consumer_contract( $case['payload'] === ( $publish_packet['metadata']['result'] ?? array() ), "{$label}: Publish exposes payload result", $failures, $passes );
+	assert_tool_consumer_contract( $case['envelope'] === ( $publish_packet['metadata']['tool_execution_data'] ?? array() ), "{$label}: Publish preserves execution envelope", $failures, $passes );
+	assert_tool_consumer_contract( $case['payload'] === ( $publish_packet['metadata']['tool_result_data'] ?? array() ), "{$label}: Publish stores projected payload", $failures, $passes );
+}
+
+if ( ! empty( $failures ) ) {
+	echo "\n=== tool-result-consumer-contract-smoke: " . count( $failures ) . " FAILURE(S) ===\n";
+	exit( 1 );
+}
+
+echo "\n=== tool-result-consumer-contract-smoke: ALL PASS ({$passes} assertions) ===\n";

--- a/tests/transition-fanout-policy-smoke.php
+++ b/tests/transition-fanout-policy-smoke.php
@@ -18,6 +18,7 @@ function apply_filters( string $hook, $value ) {
 function do_action( string $hook, ...$args ): void {}
 
 require_once __DIR__ . '/../inc/Core/DataPacket.php';
+require_once __DIR__ . '/../inc/Core/StepExecutionResult.php';
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
 require_once __DIR__ . '/../inc/Abilities/Engine/EngineHelpers.php';
 require_once __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php';


### PR DESCRIPTION
## Summary
- Add a shared `StepExecutionResult` classifier so live execution and debug sync classify step success from explicit execution metadata instead of packet presence alone.
- Split AI handler packet metadata into `tool_result_envelope` and `tool_result_data`, with `ToolResultFinder` owning legacy `metadata.tool_result` compatibility.
- Normalize ability/runtime scalar tool results onto both `data` and `result`, and keep Publish/Upsert consuming the projected handler-result contract.

Fixes #2263.

## Tests
- `php -l inc/Core/StepExecutionResult.php && php -l inc/Abilities/Engine/ExecuteStepAbility.php && php -l inc/Engine/Debug/SyncRunner.php && php -l inc/Core/Steps/AI/AIStep.php && php -l inc/Engine/AI/Tools/ToolResultFinder.php && php -l inc/Core/AbilityResult.php && php -l inc/Engine/AI/conversation-loop.php`
- `./vendor/bin/phpcs inc/Core/StepExecutionResult.php inc/Core/AbilityResult.php inc/Engine/AI/conversation-loop.php inc/Core/Steps/AI/AIStep.php inc/Engine/AI/Tools/ToolResultFinder.php inc/Core/Steps/Publish/PublishStep.php inc/Core/Steps/Upsert/UpsertStep.php inc/Abilities/Engine/ExecuteStepAbility.php inc/Engine/Debug/SyncRunner.php tests/job-status-accounting-smoke.php tests/ai-error-status-propagation-smoke.php tests/transition-fanout-policy-smoke.php tests/step-exception-failure-contract-smoke.php tests/ability-result-wp-error-smoke.php tests/Unit/Engine/AI/Tools/ToolResultFinderTest.php tests/Unit/Core/Steps/AI/AIStepTest.php`
- `php tests/ability-result-wp-error-smoke.php && php tests/job-status-accounting-smoke.php && php tests/ai-error-status-propagation-smoke.php && php tests/transition-fanout-policy-smoke.php && php tests/upsert-handler-result-handoff-smoke.php && php tests/ai-completion-assertion-packet-smoke.php && php tests/step-exception-failure-contract-smoke.php`
- `php -r 'define("ABSPATH", __DIR__ . "/"); require "inc/Engine/AI/Tools/ToolResultFinder.php"; $entry = array("metadata" => array("tool_result_envelope" => array("success" => true, "data" => array("id" => 123)), "tool_result_data" => array("id" => 456))); if (array("id" => 456) !== DataMachine\\Engine\\AI\\Tools\\ToolResultFinder::projectResultData($entry)) { exit(1); }'`

## Notes
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-step-execution-status-contract --extension wordpress` could not run because Homeboy auto-selected lab runner `lab`, which is missing required `php` and `composer` tools.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and implemented the classifier/packet contract changes, added targeted coverage, and ran local verification; Chris remains responsible for review and merge.