### PR TITLE
Normalize AI tool result packet contracts

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -20,6 +20,7 @@ use DataMachine\Engine\AI\PipelineAIConcurrencyLease;
 use DataMachine\Engine\AI\PipelineAIConcurrencyLimiter;
 use DataMachine\Engine\AI\PipelineTranscriptPolicy;
 use DataMachine\Engine\AI\Tools\ToolExecutor;
+use DataMachine\Engine\AI\Tools\ToolExecutionResult;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 
 use function DataMachine\Engine\AI\datamachine_run_conversation;
@@ -933,6 +934,7 @@ class AIStep extends Step {
 		$input_source_type = $inputDataPackets[0]['metadata']['source_type'] ?? 'unknown';
 
 		foreach ( $tool_execution_results as $tool_result_data ) {
+			$tool_result_data  = ToolExecutionResult::normalizeEntry( $tool_result_data );
 			$tool_name         = $tool_result_data['tool_name'] ?? '';
 			$tool_result       = $tool_result_data['result'] ?? array();
 			$tool_parameters   = $tool_result_data['parameters'] ?? array();
@@ -955,11 +957,7 @@ class AIStep extends Step {
 					unset( $clean_tool_parameters[ $handler_key ] );
 				}
 
-				$packet        = new DataPacket(
-					array(
-						'title' => 'Handler Tool Executed: ' . $tool_name,
-						'body'  => 'Tool executed successfully by AI agent in ' . $result_turn_count . ' conversation turns',
-					),
+				$metadata      = array_merge(
 					array(
 						'tool_name'         => $tool_name,
 						'handler_tool'      => $tool_def['handler'] ?? null,
@@ -968,8 +966,16 @@ class AIStep extends Step {
 						'source_type'       => $input_source_type,
 						'flow_step_id'      => $flow_step_id,
 						'conversation_turn' => $result_turn_count,
-						'tool_result'       => $tool_result,
 					),
+					ToolExecutionResult::packetResultMetadata( $tool_result, 'envelope' )
+				);
+
+				$packet        = new DataPacket(
+					array(
+						'title' => 'Handler Tool Executed: ' . $tool_name,
+						'body'  => 'Tool executed successfully by AI agent in ' . $result_turn_count . ' conversation turns',
+					),
+					$metadata,
 					'ai_handler_complete'
 				);
 				$outputPackets = $packet->addTo( $outputPackets );
@@ -979,19 +985,22 @@ class AIStep extends Step {
 				// Non-handler tool or failed tool - add tool result data packet
 				$success_message = ConversationManager::generateSuccessMessage( $tool_name, $tool_result, $tool_parameters );
 
+				$metadata      = array_merge(
+					array(
+						'tool_name'       => $tool_name,
+						'handler_tool'    => $tool_def['handler'] ?? null,
+						'tool_parameters' => $tool_parameters,
+						'source_type'     => $input_source_type,
+					),
+					ToolExecutionResult::packetResultMetadata( $tool_result, 'data' )
+				);
+
 				$packet        = new DataPacket(
 					array(
 						'title' => ucwords( str_replace( '_', ' ', $tool_name ) ) . ' Result',
 						'body'  => $success_message,
 					),
-					array(
-						'tool_name'       => $tool_name,
-						'handler_tool'    => $tool_def['handler'] ?? null,
-						'tool_parameters' => $tool_parameters,
-						'tool_success'    => $tool_result['success'] ?? false,
-						'tool_result'     => $tool_result['data'] ?? array(),
-						'source_type'     => $input_source_type,
-					),
+					$metadata,
 					'tool_result'
 				);
 				$outputPackets = $packet->addTo( $outputPackets );

--- a/inc/Engine/AI/Tools/ToolExecutionResult.php
+++ b/inc/Engine/AI/Tools/ToolExecutionResult.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Tool execution result contract helpers.
+ *
+ * @package DataMachine\Engine\AI\Tools
+ */
+
+namespace DataMachine\Engine\AI\Tools;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Normalizes AI tool execution results at Data Machine boundaries.
+ */
+class ToolExecutionResult {
+
+	/**
+	 * Normalize a tool execution result payload.
+	 *
+	 * @param mixed  $result    Raw tool result.
+	 * @param string $tool_name Tool name for scalar fallback payloads.
+	 * @return array<string,mixed>
+	 */
+	public static function normalizeResult( $result, string $tool_name = '' ): array {
+		if ( ! is_array( $result ) ) {
+			$normalized = array(
+				'success' => true,
+				'result'  => $result,
+			);
+
+			if ( '' !== $tool_name ) {
+				$normalized['tool_name'] = $tool_name;
+			}
+
+			return $normalized;
+		}
+
+		$normalized = $result;
+		if ( ! array_key_exists( 'success', $normalized ) ) {
+			$normalized['success'] = ! isset( $normalized['error'] );
+		}
+
+		if ( '' !== $tool_name && ! isset( $normalized['tool_name'] ) ) {
+			$normalized['tool_name'] = $tool_name;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize a tool_execution_results entry.
+	 *
+	 * @param mixed $entry Raw tool execution result entry.
+	 * @return array<string,mixed>
+	 */
+	public static function normalizeEntry( $entry ): array {
+		$entry = is_array( $entry ) ? $entry : array();
+
+		$tool_name  = isset( $entry['tool_name'] ) ? (string) $entry['tool_name'] : '';
+		$normalized = array(
+			'tool_name'  => $tool_name,
+			'result'     => self::normalizeResult( $entry['result'] ?? array(), $tool_name ),
+			'parameters' => is_array( $entry['parameters'] ?? null ) ? $entry['parameters'] : array(),
+			'turn_count' => isset( $entry['turn_count'] ) ? (int) $entry['turn_count'] : 0,
+		);
+
+		if ( array_key_exists( 'is_handler_tool', $entry ) ) {
+			$normalized['is_handler_tool'] = true === $entry['is_handler_tool'];
+		}
+
+		foreach ( array( 'runtime', 'tool_call_id' ) as $optional_key ) {
+			if ( array_key_exists( $optional_key, $entry ) ) {
+				$normalized[ $optional_key ] = $entry[ $optional_key ];
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Return the data payload from a normalized tool result envelope.
+	 *
+	 * @param array<string,mixed> $tool_result Normalized tool result envelope.
+	 * @return mixed
+	 */
+	public static function dataPayload( array $tool_result ) {
+		if ( array_key_exists( 'data', $tool_result ) ) {
+			return $tool_result['data'];
+		}
+
+		if ( array_key_exists( 'result', $tool_result ) ) {
+			return $tool_result['result'];
+		}
+
+		return $tool_result;
+	}
+
+	/**
+	 * Build explicit packet metadata for both envelope and data payload consumers.
+	 *
+	 * @param array<string,mixed> $tool_result        Normalized tool result envelope.
+	 * @param string             $compatibility_shape Shape exposed through legacy metadata.tool_result.
+	 * @return array<string,mixed>
+	 */
+	public static function packetResultMetadata( array $tool_result, string $compatibility_shape ): array {
+		$data_payload = self::dataPayload( $tool_result );
+
+		return array(
+			'tool_success'          => true === ( $tool_result['success'] ?? false ),
+			'tool_result'           => 'data' === $compatibility_shape ? $data_payload : $tool_result,
+			'tool_result_shape'     => 'data' === $compatibility_shape ? 'data' : 'envelope',
+			'tool_result_envelope'  => $tool_result,
+			'tool_result_data'      => $data_payload,
+			'tool_result_contract'  => 'datamachine_tool_result_v1',
+			'tool_result_data_path' => 'data',
+		);
+	}
+}

--- a/inc/Engine/AI/Tools/ToolResultFinder.php
+++ b/inc/Engine/AI/Tools/ToolResultFinder.php
@@ -39,16 +39,13 @@ class ToolResultFinder {
 			// 'tool_result' entries must be checked for tool_success to avoid treating
 			// failed tool calls as successful publish completions.
 			if ( 'ai_handler_complete' === $entry_type ) {
-				$handler_tool = $entry['metadata']['handler_tool'] ?? '';
-				if ( $handler_tool === $handler ) {
+				if ( self::handlerMatches( $entry, $handler ) && self::toolSucceeded( $entry ) ) {
 					return $entry;
 				}
 			}
 
 			if ( 'tool_result' === $entry_type ) {
-				$handler_tool = $entry['metadata']['handler_tool'] ?? '';
-				$tool_success = $entry['metadata']['tool_success'] ?? false;
-				if ( $handler_tool === $handler && $tool_success ) {
+				if ( self::handlerMatches( $entry, $handler ) && self::toolSucceeded( $entry ) ) {
 					return $entry;
 				}
 			}
@@ -82,12 +79,11 @@ class ToolResultFinder {
 
 		foreach ( $handler_slugs as $slug ) {
 			foreach ( $dataPackets as $entry ) {
-				$entry_type   = $entry['type'] ?? '';
-				$handler_tool = $entry['metadata']['handler_tool'] ?? '';
+				$entry_type = $entry['type'] ?? '';
 
-				if ( 'ai_handler_complete' === $entry_type && $handler_tool === $slug ) {
+				if ( 'ai_handler_complete' === $entry_type && self::handlerMatches( $entry, $slug ) && self::toolSucceeded( $entry ) ) {
 					$results[] = $entry;
-				} elseif ( 'tool_result' === $entry_type && $handler_tool === $slug && ( $entry['metadata']['tool_success'] ?? false ) ) {
+				} elseif ( 'tool_result' === $entry_type && self::handlerMatches( $entry, $slug ) && self::toolSucceeded( $entry ) ) {
 					$results[] = $entry;
 				}
 			}
@@ -106,5 +102,71 @@ class ToolResultFinder {
 		}
 
 		return $results;
+	}
+
+	/**
+	 * Check whether a packet belongs to the requested handler slug.
+	 *
+	 * @param array  $entry   Data packet.
+	 * @param string $handler Handler slug.
+	 * @return bool
+	 */
+	private static function handlerMatches( array $entry, string $handler ): bool {
+		$metadata = is_array( $entry['metadata'] ?? null ) ? $entry['metadata'] : array();
+
+		foreach ( array( 'handler_tool', 'tool_name' ) as $key ) {
+			if ( $handler === (string) ( $metadata[ $key ] ?? '' ) ) {
+				return true;
+			}
+		}
+
+		$envelope = self::toolResultEnvelope( $entry );
+		foreach ( array( 'handler_tool', 'tool_name' ) as $key ) {
+			if ( $handler === (string) ( $envelope[ $key ] ?? '' ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determine whether the packet represents a successful tool execution.
+	 *
+	 * @param array $entry Data packet.
+	 * @return bool
+	 */
+	private static function toolSucceeded( array $entry ): bool {
+		$metadata = is_array( $entry['metadata'] ?? null ) ? $entry['metadata'] : array();
+		if ( array_key_exists( 'tool_success', $metadata ) ) {
+			return true === $metadata['tool_success'];
+		}
+
+		$envelope = self::toolResultEnvelope( $entry );
+		if ( array_key_exists( 'success', $envelope ) ) {
+			return true === $envelope['success'];
+		}
+
+		return 'ai_handler_complete' === ( $entry['type'] ?? '' );
+	}
+
+	/**
+	 * Read the normalized tool result envelope from canonical or legacy metadata.
+	 *
+	 * @param array $entry Data packet.
+	 * @return array<string,mixed>
+	 */
+	private static function toolResultEnvelope( array $entry ): array {
+		$metadata = is_array( $entry['metadata'] ?? null ) ? $entry['metadata'] : array();
+
+		if ( is_array( $metadata['tool_result_envelope'] ?? null ) ) {
+			return $metadata['tool_result_envelope'];
+		}
+
+		if ( 'envelope' === ( $metadata['tool_result_shape'] ?? '' ) && is_array( $metadata['tool_result'] ?? null ) ) {
+			return $metadata['tool_result'];
+		}
+
+		return array();
 	}
 }

--- a/tests/Unit/Core/Steps/AI/AIStepTest.php
+++ b/tests/Unit/Core/Steps/AI/AIStepTest.php
@@ -404,9 +404,48 @@ class AIStepTest extends TestCase {
 		$this->assertCount( 1, $result );
 		$this->assertSame( 'ai_handler_complete', $result[0]['type'] );
 		$this->assertSame( 'wiki_upsert', $result[0]['metadata']['handler_tool'] );
+		$this->assertSame( 'envelope', $result[0]['metadata']['tool_result_shape'] );
+		$this->assertSame( 'datamachine_tool_result_v1', $result[0]['metadata']['tool_result_contract'] );
+		$this->assertSame( $loop_result['tool_execution_results'][0]['result'], $result[0]['metadata']['tool_result_envelope'] );
+		$this->assertSame( $loop_result['tool_execution_results'][0]['result'], $result[0]['metadata']['tool_result'] );
 
 		$found = ToolResultFinder::findHandlerResult( $result, 'wiki_upsert', 'upsert_step', false );
 		$this->assertSame( $result[0], $found );
+	}
+
+	public function test_process_loop_results_marks_generic_tool_result_payload_shape(): void {
+		$method = new ReflectionMethod( AIStep::class, 'processLoopResults' );
+		$method->setAccessible( true );
+
+		$tool_result = array(
+			'success' => true,
+			'data'    => array( 'items' => array( 'one' ) ),
+		);
+
+		$result = $method->invoke(
+			null,
+			array(
+				'messages'               => array(),
+				'tool_execution_results' => array(
+					array(
+						'tool_name'  => 'search_docs',
+						'result'     => $tool_result,
+						'parameters' => array( 'query' => 'contracts' ),
+						'turn_count' => 1,
+					),
+				),
+			),
+			array(),
+			array( 'flow_step_id' => 'ai_step' ),
+			array( 'search_docs' => array() )
+		);
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'tool_result', $result[0]['type'] );
+		$this->assertSame( 'data', $result[0]['metadata']['tool_result_shape'] );
+		$this->assertSame( array( 'items' => array( 'one' ) ), $result[0]['metadata']['tool_result'] );
+		$this->assertSame( $tool_result, $result[0]['metadata']['tool_result_envelope'] );
+		$this->assertTrue( $result[0]['metadata']['tool_success'] );
 	}
 
 	/**

--- a/tests/Unit/Engine/AI/Tools/ToolResultFinderTest.php
+++ b/tests/Unit/Engine/AI/Tools/ToolResultFinderTest.php
@@ -58,4 +58,54 @@ class ToolResultFinderTest extends TestCase {
 		$this->assertNull( $result );
 		$this->assertSame( array(), $logged );
 	}
+
+	public function test_find_handler_result_accepts_canonical_tool_result_envelope(): void {
+		$packet = array(
+			'type'     => 'tool_result',
+			'metadata' => array(
+				'handler_tool'         => 'upsert_event',
+				'tool_result_envelope' => array(
+					'success'   => true,
+					'tool_name' => 'upsert_event',
+					'data'      => array( 'post_id' => 123 ),
+				),
+				'tool_result_data'     => array( 'post_id' => 123 ),
+			),
+		);
+
+		$result = ToolResultFinder::findHandlerResult( array( $packet ), 'upsert_event', 'flow_step_1', false );
+
+		$this->assertSame( $packet, $result );
+	}
+
+	public function test_find_handler_result_rejects_failed_canonical_envelope(): void {
+		$packet = array(
+			'type'     => 'tool_result',
+			'metadata' => array(
+				'handler_tool'         => 'upsert_event',
+				'tool_result_envelope' => array(
+					'success' => false,
+					'error'   => 'rejected',
+				),
+			),
+		);
+
+		$result = ToolResultFinder::findHandlerResult( array( $packet ), 'upsert_event', 'flow_step_1', false );
+
+		$this->assertNull( $result );
+	}
+
+	public function test_find_handler_result_falls_back_to_tool_name_for_legacy_handler_packets(): void {
+		$packet = array(
+			'type'     => 'ai_handler_complete',
+			'metadata' => array(
+				'tool_name'            => 'wiki_upsert',
+				'tool_result_envelope' => array( 'success' => true ),
+			),
+		);
+
+		$result = ToolResultFinder::findHandlerResult( array( $packet ), 'wiki_upsert', 'flow_step_1', false );
+
+		$this->assertSame( $packet, $result );
+	}
 }

--- a/tests/ai-completion-assertion-packet-smoke.php
+++ b/tests/ai-completion-assertion-packet-smoke.php
@@ -71,6 +71,7 @@ require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/DataMachineToolRegistryS
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolExecutionResult.php';
 require_once __DIR__ . '/../inc/Core/Steps/AI/AIStep.php';
 
 use DataMachine\Core\Steps\AI\AIStep;

--- a/tests/upsert-handler-result-handoff-smoke.php
+++ b/tests/upsert-handler-result-handoff-smoke.php
@@ -75,6 +75,7 @@ require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/DataMachineToolRegistryS
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolExecutionResult.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolResultFinder.php';
 require_once __DIR__ . '/../inc/Core/Steps/AI/AIStep.php';
 


### PR DESCRIPTION
## Summary
- Adds a `ToolExecutionResult` helper to normalize tool execution result entries and payload envelopes before AI step packet emission.
- Emits explicit packet metadata for `tool_result_envelope`, `tool_result_data`, `tool_result_shape`, and `tool_result_contract` while preserving legacy `tool_result` compatibility.
- Updates `ToolResultFinder` to read canonical envelopes and legacy packets consistently when matching successful handler results.

Refs #2262.

## Tests
- `php tests/upsert-handler-result-handoff-smoke.php`
- `php tests/ai-completion-assertion-packet-smoke.php`
- `php tests/agent-conversation-result-smoke.php`
- `php tests/ability-result-wp-error-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/Tools/ToolExecutionResult.php inc/Engine/AI/Tools/ToolResultFinder.php inc/Core/Steps/AI/AIStep.php tests/Unit/Engine/AI/Tools/ToolResultFinderTest.php tests/Unit/Core/Steps/AI/AIStepTest.php tests/upsert-handler-result-handoff-smoke.php tests/ai-completion-assertion-packet-smoke.php`
- `php -l inc/Engine/AI/Tools/ToolExecutionResult.php`
- `php -l inc/Engine/AI/Tools/ToolResultFinder.php`
- `php -l inc/Core/Steps/AI/AIStep.php`

Not run:
- `vendor/bin/phpunit ...` because this checkout does not install `phpunit`.
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-tool-execution-result-contract --extension wordpress --filter ToolResultFinder` because Homeboy auto-selected lab runner `lab`, which is missing PHP and Composer.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, verification commands, and PR description for Chris to review.