### PR TITLE
ci: enable Homeboy lint autofix

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -23,5 +23,6 @@ jobs:
     with:
       commands: audit,lint,test
       expected-commands: audit,lint,test
-      autofix: 'false'
+      autofix: 'true'
+      autofix-commands: 'lint --fix'
     secrets: inherit


### PR DESCRIPTION
## Summary
- Enables Homeboy autofix in CI for lint failures.
- Scopes the autofix command to `lint --fix`, which routes through Homeboy's lint refactor path instead of broader audit/test fixes.

## Testing
- Parsed `.github/workflows/homeboy.yml` with Ruby YAML loader.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the workflow change and PR text; Chris remains responsible for review and merge.