### PR TITLE
fix: clean stale scheduler claims before draining

### DIFF
--- a/inc/Cli/Commands/DrainCommand.php
+++ b/inc/Cli/Commands/DrainCommand.php
@@ -292,6 +292,7 @@ class DrainCommand extends BaseCommand {
 		$claim    = null;
 
 		try {
+			self::runActionSchedulerTimeoutCleanup( $store );
 			$claim = $store->stake_claim( $batch_size, null, $hooks ?? array(), self::GROUP );
 		} catch ( \Throwable $throwable ) {
 			return (object) array(
@@ -318,6 +319,8 @@ class DrainCommand extends BaseCommand {
 					$runner->process_action( $action_id, 'Data Machine CLI drain' );
 				} catch ( \Throwable $throwable ) {
 					$warnings[] = sprintf( 'Action %d failed during drain: %s', $action_id, $throwable->getMessage() );
+				} finally {
+					self::flushRuntimeCache();
 				}
 			}
 		} finally {
@@ -329,6 +332,43 @@ class DrainCommand extends BaseCommand {
 			'stdout'      => '',
 			'stderr'      => implode( "\n", $warnings ),
 		);
+	}
+
+	/**
+	 * Reset stale claims/running actions before staking a CLI drain claim.
+	 *
+	 * Action Scheduler's own runners call their protected run_cleanup() before
+	 * claiming work. Data Machine claims a group-scoped batch directly, so it must
+	 * perform the same timeout cleanup or old claims can leave due actions counted
+	 * as pending but not claimable.
+	 *
+	 * @param \ActionScheduler_Store $store Action Scheduler store.
+	 */
+	private static function runActionSchedulerTimeoutCleanup( \ActionScheduler_Store $store ): void {
+		if ( ! class_exists( '\ActionScheduler_QueueCleaner' ) ) {
+			return;
+		}
+
+		$time_limit = absint( apply_filters( 'action_scheduler_queue_runner_time_limit', 30 ) );
+		$timeout    = max( 1, $time_limit ) * 10;
+		$cleaner    = new \ActionScheduler_QueueCleaner( $store );
+
+		$cleaner->reset_timeouts( $timeout );
+		$cleaner->mark_failures( $timeout );
+	}
+
+	/**
+	 * Flush in-request object cache state after each CLI-drained action.
+	 */
+	private static function flushRuntimeCache(): void {
+		if ( function_exists( 'wp_cache_supports' ) && wp_cache_supports( 'flush_runtime' ) && function_exists( 'wp_cache_flush_runtime' ) ) {
+			wp_cache_flush_runtime();
+			return;
+		}
+
+		if ( ! function_exists( 'wp_cache_supports' ) && function_exists( 'wp_cache_flush_runtime' ) ) {
+			wp_cache_flush_runtime();
+		}
 	}
 
 	/**

--- a/inc/Cli/WorkerLock.php
+++ b/inc/Cli/WorkerLock.php
@@ -30,9 +30,7 @@ class WorkerLock {
 		$now = time();
 
 		$existing = self::snapshot( $now, $ttl );
-		if ( 'stale' === $existing['lock_status'] ) {
-			delete_option( self::OPTION_NAME );
-		} elseif ( 'held' === $existing['lock_status'] ) {
+		if ( 'held' === $existing['lock_status'] ) {
 			$existing['acquired'] = false;
 			return $existing;
 		}
@@ -45,6 +43,18 @@ class WorkerLock {
 			'expires_at' => $now + $ttl,
 			'ttl'        => $ttl,
 		);
+
+		if ( 'stale' === $existing['lock_status'] ) {
+			update_option( self::OPTION_NAME, $payload, false );
+			$replaced = get_option( self::OPTION_NAME, array() );
+			if ( is_array( $replaced ) && hash_equals( $token, (string) ( $replaced['token'] ?? '' ) ) ) {
+				return self::formatSnapshot( $payload, $now, 'held', true );
+			}
+
+			$existing             = self::snapshot( $now, $ttl );
+			$existing['acquired'] = false;
+			return $existing;
+		}
 
 		if ( add_option( self::OPTION_NAME, $payload, '', 'no' ) ) {
 			return self::formatSnapshot( $payload, $now, 'held', true );

--- a/tests/drain-claim-ownership-smoke.php
+++ b/tests/drain-claim-ownership-smoke.php
@@ -31,26 +31,34 @@ function assert_not_contains( string $needle, string $haystack, string $message 
 
 assert_contains( 'runActionSchedulerBatch', $drain_src, 'drain processes Action Scheduler batches' );
 assert_contains( '\ActionScheduler_Store::instance()', $drain_src, 'drain uses the Action Scheduler store' );
+assert_contains( 'runActionSchedulerTimeoutCleanup( $store )', $drain_src, 'drain runs Action Scheduler timeout cleanup before claiming work' );
 assert_contains( 'stake_claim( $batch_size, null, $hooks ?? array(), self::GROUP )', $drain_src, 'drain stakes a group-scoped Action Scheduler claim' );
 assert_contains( '$claim->get_actions()', $drain_src, 'drain processes actions from the claim' );
 assert_contains( 'find_actions_by_claim_id( $claim->get_id() )', $drain_src, 'drain rechecks claim ownership before processing each action' );
 assert_contains( '$runner->process_action( $action_id, \'Data Machine CLI drain\' )', $drain_src, 'drain executes only claim-owned action IDs' );
+assert_contains( 'flushRuntimeCache()', $drain_src, 'drain flushes runtime cache between actions' );
 assert_contains( 'finally {', $drain_src, 'drain releases claims in a finally block' );
 assert_contains( '$store->release_claim( $claim )', $drain_src, 'drain releases the Action Scheduler claim' );
 assert_not_contains( 'getDuePendingActionIds', $drain_src, 'drain no longer preselects due action IDs outside Action Scheduler claims' );
 assert_not_contains( 'SELECT a.action_id', $drain_src, 'drain no longer directly selects action IDs to process' );
 
+$cleanup_pos = strpos( $drain_src, 'runActionSchedulerTimeoutCleanup( $store )' );
 $stake_pos   = strpos( $drain_src, 'stake_claim( $batch_size, null, $hooks ?? array(), self::GROUP )' );
 $verify_pos  = strpos( $drain_src, 'find_actions_by_claim_id( $claim->get_id() )' );
 $process_pos = strpos( $drain_src, '$runner->process_action( $action_id, \'Data Machine CLI drain\' )' );
+$flush_pos   = strpos( $drain_src, 'flushRuntimeCache()' );
 $release_pos = strpos( $drain_src, '$store->release_claim( $claim )' );
 
+assert_true( false !== $cleanup_pos, 'timeout cleanup position found' );
 assert_true( false !== $stake_pos, 'claim staking position found' );
 assert_true( false !== $verify_pos, 'claim verification position found' );
 assert_true( false !== $process_pos, 'claimed action processing position found' );
+assert_true( false !== $flush_pos, 'runtime cache flush position found' );
 assert_true( false !== $release_pos, 'claim release position found' );
+assert_true( $cleanup_pos < $stake_pos, 'drain cleans stale claims before staking a claim' );
 assert_true( $stake_pos < $verify_pos, 'drain stakes a claim before verifying ownership' );
 assert_true( $verify_pos < $process_pos, 'drain verifies ownership before processing' );
+assert_true( $process_pos < $flush_pos, 'drain flushes runtime cache after processing' );
 assert_true( $process_pos < $release_pos, 'drain releases the claim after processing' );
 
 echo "OK ({$assertions} assertions)\n";

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -52,12 +52,14 @@ assert_drain_contains( 'hookWhereSql( $hooks, $job_ids )', $drain_src, 'drain su
 assert_drain_contains( 'a.args LIKE %s', $drain_src, 'drain can filter pending actions by serialized job_id args' );
 assert_drain_contains( '"parent_job_id":', $drain_src, 'drain can filter batch actions by serialized parent_job_id args' );
 assert_drain_contains( "a.status = \\'pending\\'", $drain_src, 'drain queries pending actions in the Data Machine group' );
+assert_drain_contains( 'runActionSchedulerTimeoutCleanup( $store )', $drain_src, 'drain resets stale Action Scheduler claims before claiming work' );
 assert_drain_contains( 'stake_claim( $batch_size, null, $hooks ?? array(), self::GROUP )', $drain_src, 'drain claims due Data Machine actions through Action Scheduler' );
 assert_drain_contains( 'find_actions_by_claim_id( $claim->get_id() )', $drain_src, 'drain verifies Action Scheduler claim ownership before processing' );
 assert_drain_contains( 'release_claim( $claim )', $drain_src, 'drain releases Action Scheduler claims after processing' );
 assert_drain_contains( "\\ActionScheduler::runner()", $drain_src, 'drain uses Action Scheduler runner for claimed actions' );
 assert_drain_contains( "'Data Machine CLI drain'", $drain_src, 'drain records a Data Machine-specific execution context' );
 assert_drain_contains( 'catch ( \\Throwable $throwable )', $drain_src, 'drain catches per-action runner failures instead of fataling after job start' );
+assert_drain_contains( 'flushRuntimeCache()', $drain_src, 'drain flushes runtime cache after processing actions' );
 assert_drain_contains( "'return_code' => empty( \$warnings ) ? 0 : 1", $drain_src, 'drain surfaces runner failures through a result object' );
 assert_drain_contains( "'remaining_pending'", $drain_src, 'drain reports remaining pending actions' );
 assert_drain_contains( "'batch_chunks'", $drain_src, 'drain reports batch chunk counts' );

--- a/tests/worker-lock-smoke.php
+++ b/tests/worker-lock-smoke.php
@@ -25,6 +25,12 @@ function add_option( string $name, mixed $value, string $deprecated = '', string
 	return true;
 }
 
+function update_option( string $name, mixed $value, string|bool|null $autoload = null ): bool {
+	unset( $autoload );
+	$GLOBALS['datamachine_worker_lock_options'][ $name ] = $value;
+	return true;
+}
+
 function delete_option( string $name ): bool {
 	unset( $GLOBALS['datamachine_worker_lock_options'][ $name ] );
 	return true;


### PR DESCRIPTION
## Summary
- Cleans stale Action Scheduler pending/running timeouts before Data Machine stakes its CLI drain claim.
- Replaces stale worker/drain locks reliably by overwriting and verifying the replacement token instead of delete-plus-add.
- Flushes runtime object-cache state after each CLI-drained action to reduce memory pressure in long corpus drains.
- Updates focused smoke tests for the drain and worker-lock behavior.

## Verification
- `php -l inc/Cli/Commands/DrainCommand.php`
- `php -l inc/Cli/WorkerLock.php`
- `php tests/drain-claim-ownership-smoke.php`
- `php tests/flow-run-cli-drain-smoke.php`
- `php tests/worker-lock-smoke.php`
- Deployed to `intelligence.horse` via `homeboy deploy intelligence-horse data-machine --head --force`

## Runtime evidence
- Before fix, `wp datamachine worker run --once ...` stopped with `Drain stopped because Action Scheduler made no observable progress` while `1115` due actions remained.
- Direct `wp action-scheduler run --group=data-machine --force` reset/processed stale work, proving Action Scheduler timeout cleanup was missing from Data Machine's direct claim path.
- After the first deploy, live verification exposed a stale worker lock that reported `lock_status: stale` but still returned `stop_reason: locked`; the WorkerLock fix now replaces stale locks reliably.
- After redeploy, `wp datamachine drain --limit=3 --batch-size=3 --time-limit=120 --format=json` processed 3 actions, 0 failures, `stop_reason: limit`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the live `intelligence.horse` scheduler drain failure, drafted the Data Machine drain/lock fixes, deployed the branch for runtime verification, and ran focused verification commands. Chris remains responsible for review and merge.