### PR TITLE
Fix handler config validation failure surfaces

### DIFF
--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -7,6 +7,7 @@ use DataMachine\Core\RunMetrics;
 use DataMachine\Core\Steps\QueueableTrait;
 use DataMachine\Core\Steps\Step;
 use DataMachine\Core\Steps\StepTypeRegistrationTrait;
+use DataMachine\Core\Steps\Handlers\HandlerConfigValidator;
 use DataMachine\Engine\Bundle\AuthRefHandlerConfig;
 use DataMachine\Abilities\HandlerAbilities;
 
@@ -185,6 +186,43 @@ class FetchStep extends Step {
 		}
 
 		$handler_settings = $resolved_handler_settings;
+		$validation       = HandlerConfigValidator::validate(
+			(string) $handler,
+			'fetch',
+			$handler_settings,
+			array(
+				'flow_step_id' => $this->flow_step_config['flow_step_id'],
+				'pipeline_id'  => $this->flow_step_config['pipeline_id'],
+				'flow_id'      => $this->flow_step_config['flow_id'],
+				'job_id'       => $this->job_id,
+				'user_id'      => $owner_user_id,
+				'agent_id'     => $agent_id,
+			)
+		);
+
+		if ( is_wp_error( $validation ) ) {
+			$diagnostics = array_merge(
+				$this->extractHandlerOutcomeIds( $handler_settings ),
+				HandlerConfigValidator::diagnostics( $validation )
+			);
+
+			$this->log( 'error', 'Fetch handler config validation failed: ' . $validation->get_error_message(), $diagnostics );
+			RunMetrics::recordStepResult(
+				$this->job_id,
+				$this->flow_step_id,
+				array_merge(
+					$diagnostics,
+					array(
+						'step_type'    => 'fetch',
+						'result'       => 'failed',
+						'handler_slug' => (string) $handler,
+						'packet_count' => 0,
+					)
+				)
+			);
+
+			return $this->buildHandlerConfigValidationFailurePackets( $validation, (string) $handler );
+		}
 
 		$packets = $this->execute_handler_as_owner( $handler, $handler_settings, (string) $this->job_id, $owner_user_id );
 
@@ -332,6 +370,34 @@ class FetchStep extends Step {
 
 		$class_name = $handler_info['class'];
 		return class_exists( $class_name ) ? new $class_name() : null;
+	}
+
+	/**
+	 * Build an explicit failure packet for handler config validation errors.
+	 *
+	 * @param \WP_Error $error Validation error.
+	 * @param string    $handler_slug Handler slug.
+	 * @return array Updated data packet array.
+	 */
+	private function buildHandlerConfigValidationFailurePackets( \WP_Error $error, string $handler_slug ): array {
+		$packet = new DataPacket(
+			array(
+				'body' => $error->get_error_message(),
+			),
+			array_merge(
+				HandlerConfigValidator::diagnostics( $error ),
+				array(
+					'step_type'      => 'fetch',
+					'flow_step_id'   => $this->flow_step_id,
+					'handler_slug'   => $handler_slug,
+					'success'        => false,
+					'failure_reason' => HandlerConfigValidator::ERROR_CODE,
+				)
+			),
+			'step_error'
+		);
+
+		return $packet->addTo( $this->dataPackets );
 	}
 
 	/**

--- a/inc/Core/Steps/HandlerRegistrationTrait.php
+++ b/inc/Core/Steps/HandlerRegistrationTrait.php
@@ -37,6 +37,9 @@ trait HandlerRegistrationTrait {
 	 *                                      `datamachine_tools` registry at pipeline execution time.
 	 * @param string|null $authProviderKey Optional custom auth provider key for shared authentication
 	 * @param array $meta Optional arbitrary metadata (e.g. charLimit, maxImages). Passed through to /handlers API.
+	 * @param callable|null $validationCallback Optional runtime config validator. Receives
+	 *                                          `(array $handler_config, array $context)` and returns
+	 *                                          true/null, false, WP_Error, or a validation array.
 	 */
 	protected static function registerHandler(
 		string $slug,
@@ -49,7 +52,8 @@ trait HandlerRegistrationTrait {
 		?string $settingsClass = null,
 		?callable $aiToolCallback = null,
 		?string $authProviderKey = null,
-		array $meta = array()
+		array $meta = array(),
+		?callable $validationCallback = null
 	): void {
 		// Compute auth provider key for both handler metadata and auth registration
 		$provider_key = $authProviderKey ?? $slug;
@@ -117,6 +121,25 @@ trait HandlerRegistrationTrait {
 					);
 					return $tools;
 				}
+			);
+		}
+
+		if ( $validationCallback ) {
+			add_filter(
+				'datamachine_validate_handler_config',
+				function ( $result, string $handler_slug, string $step_type, array $handler_config, array $context ) use ( $slug, $type, $validationCallback ) {
+					if ( false === $result || ( is_array( $result ) && false === ( $result['valid'] ?? true ) ) || ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) ) {
+						return $result;
+					}
+
+					if ( $slug !== $handler_slug || $type !== $step_type ) {
+						return $result;
+					}
+
+					return $validationCallback( $handler_config, $context );
+				},
+				10,
+				5
 			);
 		}
 

--- a/inc/Core/Steps/Handlers/HandlerConfigValidator.php
+++ b/inc/Core/Steps/Handlers/HandlerConfigValidator.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Generic handler configuration validation lifecycle.
+ *
+ * @package DataMachine\Core\Steps\Handlers
+ */
+
+namespace DataMachine\Core\Steps\Handlers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Validates handler runtime configuration through a generic filter surface.
+ */
+class HandlerConfigValidator {
+
+	public const ERROR_CODE = 'handler_config_validation_failed';
+
+	/**
+	 * Validate handler configuration before handler execution.
+	 *
+	 * Validators hook `datamachine_validate_handler_config` and may return:
+	 * true/null for valid, false for generic invalid, WP_Error for invalid, or
+	 * an array with `valid`, `message`, `code`, and optional `data` keys.
+	 *
+	 * @param string $handler_slug Handler slug.
+	 * @param string $step_type Step type.
+	 * @param array  $handler_config Runtime handler config.
+	 * @param array  $context Execution context.
+	 * @return true|\WP_Error True when valid, normalized WP_Error when invalid.
+	 */
+	public static function validate( string $handler_slug, string $step_type, array $handler_config, array $context = array() ): true|\WP_Error {
+		$context = array_merge(
+			array(
+				'handler_slug' => $handler_slug,
+				'step_type'    => $step_type,
+			),
+			$context
+		);
+
+		$result = function_exists( 'apply_filters' )
+			? apply_filters( 'datamachine_validate_handler_config', true, $handler_slug, $step_type, $handler_config, $context )
+			: true;
+
+		return self::normalize_result( $result, $handler_slug, $step_type );
+	}
+
+	/**
+	 * Build stable diagnostics from a validation failure.
+	 *
+	 * @param \WP_Error $error Validation error.
+	 * @return array<string,mixed>
+	 */
+	public static function diagnostics( \WP_Error $error ): array {
+		$data = $error->get_error_data();
+		if ( ! is_array( $data ) ) {
+			$data = array();
+		}
+
+		return array_merge(
+			$data,
+			array(
+				'reason' => self::ERROR_CODE,
+				'error'  => $error->get_error_message(),
+			)
+		);
+	}
+
+	/**
+	 * Normalize validator output into the stable failure code.
+	 *
+	 * @param mixed  $result Validator result.
+	 * @param string $handler_slug Handler slug.
+	 * @param string $step_type Step type.
+	 * @return true|\WP_Error True when valid, normalized WP_Error when invalid.
+	 */
+	private static function normalize_result( mixed $result, string $handler_slug, string $step_type ): true|\WP_Error {
+		if ( true === $result || null === $result ) {
+			return true;
+		}
+
+		if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
+			$data = $result->get_error_data();
+			if ( ! is_array( $data ) ) {
+				$data = array();
+			}
+
+			$data = array_merge(
+				$data,
+				array(
+					'handler_slug'    => $handler_slug,
+					'step_type'       => $step_type,
+					'validation_code' => $result->get_error_code(),
+				)
+			);
+
+			return new \WP_Error( self::ERROR_CODE, $result->get_error_message(), $data );
+		}
+
+		if ( is_array( $result ) ) {
+			$valid = $result['valid'] ?? true;
+			if ( false !== $valid ) {
+				return true;
+			}
+
+			$data = is_array( $result['data'] ?? null ) ? $result['data'] : array();
+			$data = array_merge(
+				$data,
+				array(
+					'handler_slug'    => $handler_slug,
+					'step_type'       => $step_type,
+					'validation_code' => (string) ( $result['code'] ?? self::ERROR_CODE ),
+				)
+			);
+
+			return new \WP_Error(
+				self::ERROR_CODE,
+				(string) ( $result['message'] ?? 'Handler configuration failed validation.' ),
+				$data
+			);
+		}
+
+		return new \WP_Error(
+			self::ERROR_CODE,
+			'Handler configuration failed validation.',
+			array(
+				'handler_slug'    => $handler_slug,
+				'step_type'       => $step_type,
+				'validation_code' => self::ERROR_CODE,
+			)
+		);
+	}
+}

--- a/inc/Core/Steps/Publish/Handlers/PublishHandler.php
+++ b/inc/Core/Steps/Publish/Handlers/PublishHandler.php
@@ -16,6 +16,7 @@ namespace DataMachine\Core\Steps\Publish\Handlers;
 
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Core\EngineData;
+use DataMachine\Core\Steps\Handlers\HandlerConfigValidator;
 use DataMachine\Core\Steps\Handlers\HttpRequestHelpers;
 use DataMachine\Engine\Bundle\AuthRefHandlerConfig;
 
@@ -68,14 +69,23 @@ abstract class PublishHandler {
 		$parameters['job_id'] = $job_id;
 		$parameters['engine'] = $engine;
 
-		$handler_config = $tool_def['handler_config'] ?? array();
+		$handler_slug    = (string) ( $tool_def['handler'] ?? $this->handler_type );
+		$handler_config  = $tool_def['handler_config'] ?? array();
 		$handler_config = AuthRefHandlerConfig::resolve_runtime_config(
 			$handler_config,
-			(string) ( $tool_def['handler'] ?? $this->handler_type ),
+			$handler_slug,
 			array( 'job_id' => $job_id )
 		);
 		if ( is_wp_error( $handler_config ) ) {
 			return $this->errorResponse( 'Auth ref resolution failed: ' . $handler_config->get_error_message() );
+		}
+
+		$validation = HandlerConfigValidator::validate( $handler_slug, 'publish', $handler_config, array( 'job_id' => $job_id ) );
+		if ( is_wp_error( $validation ) ) {
+			return $this->errorResponse(
+				$validation->get_error_message(),
+				HandlerConfigValidator::diagnostics( $validation )
+			);
 		}
 
 		$result = $this->executePublish( $parameters, $handler_config );

--- a/inc/Core/Steps/Publish/Handlers/PublishHandler.php
+++ b/inc/Core/Steps/Publish/Handlers/PublishHandler.php
@@ -69,8 +69,8 @@ abstract class PublishHandler {
 		$parameters['job_id'] = $job_id;
 		$parameters['engine'] = $engine;
 
-		$handler_slug    = (string) ( $tool_def['handler'] ?? $this->handler_type );
-		$handler_config  = $tool_def['handler_config'] ?? array();
+		$handler_slug   = (string) ( $tool_def['handler'] ?? $this->handler_type );
+		$handler_config = $tool_def['handler_config'] ?? array();
 		$handler_config = AuthRefHandlerConfig::resolve_runtime_config(
 			$handler_config,
 			$handler_slug,

--- a/inc/Core/Steps/Upsert/Handlers/UpsertHandler.php
+++ b/inc/Core/Steps/Upsert/Handlers/UpsertHandler.php
@@ -12,6 +12,7 @@
 namespace DataMachine\Core\Steps\Upsert\Handlers;
 
 use DataMachine\Core\EngineData;
+use DataMachine\Core\Steps\Handlers\HandlerConfigValidator;
 use DataMachine\Engine\Bundle\AuthRefHandlerConfig;
 
 defined( 'ABSPATH' ) || exit;
@@ -80,14 +81,23 @@ abstract class UpsertHandler {
 		$parameters['job_id'] = $job_id;
 		$parameters['engine'] = $engine;
 
-		$handler_config = $tool_def['handler_config'] ?? array();
+		$handler_slug    = (string) ( $tool_def['handler'] ?? static::class );
+		$handler_config  = $tool_def['handler_config'] ?? array();
 		$handler_config = AuthRefHandlerConfig::resolve_runtime_config(
 			$handler_config,
-			(string) ( $tool_def['handler'] ?? static::class ),
+			$handler_slug,
 			array( 'job_id' => $job_id )
 		);
 		if ( is_wp_error( $handler_config ) ) {
 			return $this->errorResponse( 'Auth ref resolution failed: ' . $handler_config->get_error_message() );
+		}
+
+		$validation = HandlerConfigValidator::validate( $handler_slug, 'upsert', $handler_config, array( 'job_id' => $job_id ) );
+		if ( is_wp_error( $validation ) ) {
+			return $this->errorResponse(
+				$validation->get_error_message(),
+				HandlerConfigValidator::diagnostics( $validation )
+			);
 		}
 
 		$result = $this->executeUpsert( $parameters, $handler_config );

--- a/inc/Core/Steps/Upsert/Handlers/UpsertHandler.php
+++ b/inc/Core/Steps/Upsert/Handlers/UpsertHandler.php
@@ -81,8 +81,8 @@ abstract class UpsertHandler {
 		$parameters['job_id'] = $job_id;
 		$parameters['engine'] = $engine;
 
-		$handler_slug    = (string) ( $tool_def['handler'] ?? static::class );
-		$handler_config  = $tool_def['handler_config'] ?? array();
+		$handler_slug   = (string) ( $tool_def['handler'] ?? static::class );
+		$handler_config = $tool_def['handler_config'] ?? array();
 		$handler_config = AuthRefHandlerConfig::resolve_runtime_config(
 			$handler_config,
 			$handler_slug,

--- a/tests/handler-config-validation-smoke.php
+++ b/tests/handler-config-validation-smoke.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Smoke test for generic handler config validation lifecycle.
+ *
+ * Run with: php tests/handler-config-validation-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+require_once __DIR__ . '/smoke-wp-stubs.php';
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private mixed $data;
+
+		public function __construct( string $code = '', string $message = '', mixed $data = null ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data(): mixed {
+			return $this->data;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+$GLOBALS['handler_config_validation_filters'] = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['handler_config_validation_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		if ( empty( $GLOBALS['handler_config_validation_filters'][ $hook ] ) ) {
+			return $value;
+		}
+
+		ksort( $GLOBALS['handler_config_validation_filters'][ $hook ], SORT_NUMERIC );
+		foreach ( $GLOBALS['handler_config_validation_filters'][ $hook ] as $callbacks ) {
+			foreach ( $callbacks as [ $callback, $accepted_args ] ) {
+				$value = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+			}
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		unset( $hook, $args );
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/Handlers/HandlerConfigValidator.php';
+require_once __DIR__ . '/../inc/Core/Steps/HandlerRegistrationTrait.php';
+
+use DataMachine\Core\Steps\HandlerRegistrationTrait;
+use DataMachine\Core\Steps\Handlers\HandlerConfigValidator;
+
+class HandlerConfigValidationSmokeRegistration {
+	use HandlerRegistrationTrait;
+
+	public static function register(): void {
+		self::registerHandler(
+			'smoke_source',
+			'fetch',
+			self::class,
+			'Smoke Source',
+			'Smoke source handler',
+			false,
+			null,
+			null,
+			null,
+			null,
+			array(),
+			static function ( array $handler_config, array $context ): array {
+				if ( (int) ( $handler_config['days'] ?? 0 ) > 365 ) {
+					return array(
+						'valid'   => false,
+						'code'    => 'source_param_out_of_range',
+						'message' => 'days must be <= 365',
+						'data'    => array(
+							'param'        => 'days',
+							'context_seen' => $context['flow_step_id'] ?? null,
+						),
+					);
+				}
+
+				return array( 'valid' => true );
+			}
+		);
+	}
+}
+
+$passes = 0;
+$fails  = 0;
+
+$assert = static function ( string $label, bool $condition ) use ( &$passes, &$fails ): void {
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		++$passes;
+		return;
+	}
+
+	echo "FAIL: {$label}\n";
+	++$fails;
+};
+
+echo "\n[1] Handler registration installs config validator callback\n";
+HandlerConfigValidationSmokeRegistration::register();
+
+$valid = HandlerConfigValidator::validate(
+	'smoke_source',
+	'fetch',
+	array( 'days' => 30 ),
+	array( 'flow_step_id' => 'fetch-1' )
+);
+
+$assert( 'valid config returns true', true === $valid );
+
+$invalid = HandlerConfigValidator::validate(
+	'smoke_source',
+	'fetch',
+	array( 'days' => 366 ),
+	array( 'flow_step_id' => 'fetch-1' )
+);
+
+$assert( 'invalid config returns WP_Error', is_wp_error( $invalid ) );
+$assert( 'invalid config uses stable Data Machine error code', HandlerConfigValidator::ERROR_CODE === $invalid->get_error_code() );
+
+$diagnostics = HandlerConfigValidator::diagnostics( $invalid );
+$assert( 'diagnostics carry stable reason', HandlerConfigValidator::ERROR_CODE === ( $diagnostics['reason'] ?? null ) );
+$assert( 'diagnostics preserve validator-specific code', 'source_param_out_of_range' === ( $diagnostics['validation_code'] ?? null ) );
+$assert( 'diagnostics preserve actionable field metadata', 'days' === ( $diagnostics['param'] ?? null ) );
+$assert( 'validator receives execution context', 'fetch-1' === ( $diagnostics['context_seen'] ?? null ) );
+
+echo "\n[2] Non-matching handler is ignored\n";
+$other = HandlerConfigValidator::validate( 'other_source', 'fetch', array( 'days' => 999 ), array() );
+$assert( 'non-matching validator returns true', true === $other );
+
+echo "\n[3] Runtime execution paths invoke validation before handlers\n";
+$root            = dirname( __DIR__ );
+$fetch_step      = (string) file_get_contents( $root . '/inc/Core/Steps/Fetch/FetchStep.php' );
+$publish_handler = (string) file_get_contents( $root . '/inc/Core/Steps/Publish/Handlers/PublishHandler.php' );
+$upsert_handler  = (string) file_get_contents( $root . '/inc/Core/Steps/Upsert/Handlers/UpsertHandler.php' );
+
+$assert( 'fetch step validates handler config before execution', str_contains( $fetch_step, 'HandlerConfigValidator::validate' ) && str_contains( $fetch_step, 'HandlerConfigValidator::ERROR_CODE' ) );
+$assert( 'publish handler validates handler config before execution', str_contains( $publish_handler, 'HandlerConfigValidator::validate' ) );
+$assert( 'upsert handler validates handler config before execution', str_contains( $upsert_handler, 'HandlerConfigValidator::validate' ) );
+
+echo "\n=== Results ===\n";
+echo "Passed: {$passes}\n";
+echo "Failed: {$fails}\n";
+
+if ( $fails > 0 ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Adds a generic `datamachine_validate_handler_config` lifecycle with stable `handler_config_validation_failed` diagnostics.
- Wires validation before fetch/publish/upsert handler execution so invalid runtime config can fail explicitly instead of collapsing into generic no-content behavior.
- Adds a focused smoke test covering validator callback registration, stable diagnostics, and runtime path wiring.

Fixes #2275.

## Testing
- `php tests/handler-config-validation-smoke.php`
- `php tests/auth-ref-handler-config-smoke.php`
- `php -l inc/Core/Steps/Handlers/HandlerConfigValidator.php && php -l inc/Core/Steps/HandlerRegistrationTrait.php && php -l inc/Core/Steps/Fetch/FetchStep.php && php -l inc/Core/Steps/Publish/Handlers/PublishHandler.php && php -l inc/Core/Steps/Upsert/Handlers/UpsertHandler.php && php -l tests/handler-config-validation-smoke.php`
- `./vendor/bin/phpcs inc/Core/Steps/Handlers/HandlerConfigValidator.php inc/Core/Steps/HandlerRegistrationTrait.php inc/Core/Steps/Fetch/FetchStep.php inc/Core/Steps/Publish/Handlers/PublishHandler.php inc/Core/Steps/Upsert/Handlers/UpsertHandler.php tests/handler-config-validation-smoke.php`

## Follow-up
- Intelligence/a8c-intelligence can register source-specific validators, e.g. ContextA8C Slack `days <= 365`, without adding source semantics to Data Machine core.
- A later slice can run the same validator at flow save/queue-patch enqueue time for earlier UI/API rejection.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the generic validation primitive, runtime wiring, smoke coverage, and PR description. Chris remains responsible for review and merge.