### PR TITLE
Fix sandbox tool call metadata

### DIFF
--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -300,7 +300,7 @@ class ChatOrchestrator {
 		$response_data = array(
 			'session_id'   => $session_id,
 			'response'     => $result['final_content'],
-			'tool_calls'   => $result['last_tool_calls'],
+			'tool_calls'   => $result['tool_calls'] ?? $result['last_tool_calls'],
 			'conversation' => $result['messages'],
 			'metadata'     => $metadata,
 			'completed'    => $is_completed,
@@ -872,6 +872,7 @@ class ChatOrchestrator {
 				'final_content'                 => $loop_result['final_content'],
 				'completed'                     => $loop_result['completed'] ?? false,
 				'turn_count'                    => $loop_result['turn_count'] ?? 1,
+				'tool_calls'                    => $loop_result['tool_calls'] ?? array(),
 				'last_tool_calls'               => $loop_result['last_tool_calls'] ?? array(),
 				'warning'                       => $loop_result['warning'] ?? null,
 				'max_turns_reached'             => $loop_result['max_turns_reached'] ?? false,

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -78,6 +78,7 @@ function datamachine_run_conversation(
 	// final result directly (see agents-api#136), so we only carry by-reference
 	// the things substrate doesn't track for us.
 	$last_tool_calls        = array();
+	$all_tool_calls         = array();
 	$tool_execution_results = array();
 	$completion_nudges      = array();
 	$last_request_metadata  = array();
@@ -139,6 +140,7 @@ function datamachine_run_conversation(
 			'turn_count'                      => 0,
 			'completed'                       => false,
 			'last_tool_calls'                 => array(),
+			'tool_calls'                      => array(),
 			'tool_execution_results'          => array(),
 			'error'                           => $error_message,
 			'error_code'                      => 'completion_required_tool_unavailable',
@@ -187,6 +189,7 @@ function datamachine_run_conversation(
 		$completion_policy,
 		$tool_runtime_rules,
 		$last_tool_calls,
+		$all_tool_calls,
 		$tool_execution_results,
 		$completion_nudges,
 		$last_request_metadata,
@@ -264,6 +267,7 @@ function datamachine_run_conversation(
 			'turn_count'             => $latest_turn_count,
 			'completed'              => false,
 			'last_tool_calls'        => $last_tool_calls,
+			'tool_calls'             => $all_tool_calls,
 			'tool_execution_results' => $tool_execution_results,
 			'error'                  => $e->getMessage(),
 			'usage'                  => array(),
@@ -291,6 +295,7 @@ function datamachine_run_conversation(
 			'turn_count'             => 0,
 			'completed'              => false,
 			'last_tool_calls'        => array(),
+			'tool_calls'             => array(),
 			'tool_execution_results' => array(),
 			'usage'                  => array(),
 			'error'                  => $e->getMessage(),
@@ -304,6 +309,7 @@ function datamachine_run_conversation(
 	// DM-only fields that the substrate doesn't know about.
 	$result['completed']       = 'budget_exceeded' !== ( $result['status'] ?? '' );
 	$result['last_tool_calls'] = $last_tool_calls;
+	$result['tool_calls']      = $all_tool_calls;
 	if ( $runtime_tool_pending ) {
 		$result['completed']                     = false;
 		$result['runtime_tool_pending']          = true;
@@ -367,7 +373,8 @@ function datamachine_run_conversation(
  * @param array                                     $base_log_context   Base log context.
  * @param WP_Agent_Conversation_Completion_Policy   $completion_policy  Completion policy.
  * @param DataMachineToolRuntimeRules               $tool_runtime_rules Tool runtime rules.
- * @param array                                     &$last_tool_calls    Mutable last tool calls (DM-flavored shape).
+ * @param array                                     &$last_tool_calls    Mutable last turn's tool calls (DM-flavored shape).
+ * @param array                                     &$all_tool_calls     Mutable all tool calls made during the run.
  * @param array                                     &$all_tool_results   Mutable all executed tool results (DM-flavored shape).
  * @param array                                     &$completion_nudges  Mutable nudge diagnostics (DM-only).
  * @return callable Turn runner closure.
@@ -384,6 +391,7 @@ function datamachine_build_turn_runner(
 	WP_Agent_Conversation_Completion_Policy $completion_policy,
 	DataMachineToolRuntimeRules $tool_runtime_rules,
 	array &$last_tool_calls,
+	array &$all_tool_calls,
 	array &$all_tool_results,
 	array &$completion_nudges,
 	array &$last_request_metadata,
@@ -404,6 +412,7 @@ function datamachine_build_turn_runner(
 		$completion_policy,
 		$tool_runtime_rules,
 		&$last_tool_calls,
+		&$all_tool_calls,
 		&$all_tool_results,
 		&$completion_nudges,
 		&$last_request_metadata,
@@ -473,6 +482,9 @@ function datamachine_build_turn_runner(
 		$tool_calls      = datamachine_extract_tool_calls( $ai_result );
 		$ai_content      = RequestBuilder::resultText( $ai_result );
 		$last_tool_calls = $tool_calls;
+		foreach ( $tool_calls as $tool_call ) {
+			$all_tool_calls[] = $tool_call;
+		}
 
 		// Per-turn token usage. Substrate accumulates this across turns and
 		// exposes the running total on the final loop result.

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -94,6 +94,16 @@ class RunnerRequestSmokeTool {
 	}
 }
 
+class SandboxPipelineSmokeTool {
+	public function execute( array $params ): array {
+		return array(
+			'success' => true,
+			'path'    => (string) ( $params['path'] ?? '' ),
+			'content' => 'sandbox file content',
+		);
+	}
+}
+
 class RunnerRequestSmokeTranscriptPersister implements WP_Agent_Transcript_Persister {
 	public array $calls = array();
 
@@ -278,7 +288,86 @@ assert_runner_request( ! empty( $mid_failure_transcript->calls ), 'mid-conversat
 assert_runner_request( str_contains( (string) ( $last_failure_transcript_call['result']['error'] ?? '' ), 'provider offline after tool' ), 'failure transcript result includes provider error' );
 assert_runner_request( 2 === ( $last_failure_transcript_call['result']['turn_count'] ?? null ), 'failure transcript result includes latest turn count' );
 
-// 4. Client runtime tools are fulfilled by the transport callback, not PHP ToolExecutor.
+// 4. Sandbox/pipeline runs expose parsed function calls even after the final no-tool turn.
+$sandbox_dispatch_count = 0;
+$sandbox_requests       = array();
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function ( array $request_body ) use ( &$sandbox_dispatch_count, &$sandbox_requests ) {
+		++$sandbox_dispatch_count;
+		$sandbox_requests[] = $request_body;
+
+		if ( 1 === $sandbox_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => '',
+					'tool_calls' => array(
+						array(
+							'id'         => 'sandbox-call-1',
+							'name'       => 'workspace_read',
+							'parameters' => array( 'path' => 'README.md' ),
+						),
+					),
+					'usage'      => array(
+						'prompt_tokens'     => 7,
+						'completion_tokens' => 8,
+						'total_tokens'      => 15,
+					),
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => 'sandbox tool complete',
+				'tool_calls' => array(),
+				'usage'      => array(
+					'prompt_tokens'     => 2,
+					'completion_tokens' => 3,
+					'total_tokens'      => 5,
+				),
+			),
+		);
+	}
+);
+
+$sandbox_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'read the sandbox README' ) ),
+	array(
+		'workspace_read' => array(
+			'name'        => 'workspace_read',
+			'description' => 'Read a file from the sandbox workspace.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(
+					'path' => array( 'type' => 'string' ),
+				),
+				'required'   => array( 'path' ),
+			),
+			'class'       => SandboxPipelineSmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	array( 'sandbox', 'pipeline' ),
+	array(),
+	3
+);
+
+assert_runner_request( 2 === $sandbox_dispatch_count, 'sandbox/pipeline function call returns to provider for final answer' );
+assert_runner_request( isset( $sandbox_requests[0]['tools']['workspace_read'] ), 'sandbox/pipeline request sends workspace tool declaration' );
+assert_runner_request( 'sandbox tool complete' === ( $sandbox_result['final_content'] ?? null ), 'sandbox/pipeline run preserves final no-tool answer' );
+assert_runner_request( array() === ( $sandbox_result['last_tool_calls'] ?? null ), 'last_tool_calls reflects the final no-tool turn' );
+assert_runner_request( 1 === count( $sandbox_result['tool_calls'] ?? array() ), 'tool_calls preserves parsed calls from earlier turns' );
+assert_runner_request( 'workspace_read' === ( $sandbox_result['tool_calls'][0]['name'] ?? null ), 'tool_calls records the parsed workspace tool name' );
+assert_runner_request( array( 'path' => 'README.md' ) === ( $sandbox_result['tool_calls'][0]['parameters'] ?? null ), 'tool_calls records parsed workspace tool parameters' );
+assert_runner_request( 1 === count( $sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline function call executes a workspace tool' );
+assert_runner_request( 'README.md' === ( $sandbox_result['tool_execution_results'][0]['result']['path'] ?? null ), 'sandbox/pipeline tool execution receives parsed parameters' );
+
+// 5. Client runtime tools are fulfilled by the transport callback, not PHP ToolExecutor.
 $runtime_dispatch_count = 0;
 $runtime_requests       = array();
 $runtime_sink           = new RunnerRequestSmokeSink();


### PR DESCRIPTION
## Summary
- Preserve every parsed provider function call across a Data Machine conversation run, instead of exposing only the final turn's tool calls.
- Return accumulated tool calls through chat response metadata so sandbox agents can report executed workspace calls after the final no-tool answer.
- Add focused sandbox/pipeline smoke coverage for a stubbed wp-ai-client function call that is parsed, executed, and exposed in the result.

Fixes https://github.com/Extra-Chill/data-machine/issues/2278

## Tests
- `php tests/agent-conversation-runner-request-smoke.php`
- `php tests/wp-ai-client-tool-schema-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the Data Machine sandbox/chat/pipeline tool-call path, implemented the metadata preservation fix, and drafted focused smoke coverage. Chris remains responsible for review and merge.