### PR TITLE
Fix tracked items CLI base command import

### DIFF
--- a/inc/Cli/Commands/TrackedItemsCommand.php
+++ b/inc/Cli/Commands/TrackedItemsCommand.php
@@ -8,6 +8,7 @@
 namespace DataMachine\Cli\Commands;
 
 use DataMachine\Abilities\TrackedItemsAbilities;
+use DataMachine\Cli\BaseCommand;
 use WP_CLI;
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
## Summary
- Imports `DataMachine\Cli\BaseCommand` in the tracked-items WP-CLI command so the command can load in runtime WP-CLI contexts.

## Testing
- `php -l inc/Cli/Commands/TrackedItemsCommand.php`
- `php tests/tracked-items-smoke.php`
- `homeboy --force-hot lint --path /Users/chubes/Developer/data-machine@feature-tracked-items-ledger --extension wordpress --file inc/Cli/Commands/TrackedItemsCommand.php`

## Runtime verification
- Found while verifying the `wp-docs-runtime` deploy after #2276: WP-CLI fatals with `Class "DataMachine\\Cli\\Commands\\BaseCommand" not found` when loading `TrackedItemsCommand`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the runtime WP-CLI fatal, applying the minimal import fix, and running targeted verification.