### PR TITLE
fix: stop drains before memory exhaustion

### DIFF
--- a/inc/Cli/Commands/DrainCommand.php
+++ b/inc/Cli/Commands/DrainCommand.php
@@ -134,6 +134,11 @@ class DrainCommand extends BaseCommand {
 		try {
 			while ( self::getDuePendingCount( $hooks, $job_ids ) > 0 ) {
 				$stats = self::buildStats( $before_counts, self::getStatusCounts( $hooks, $job_ids ), $batches, $warnings, $hooks, $job_ids, $stop_reason );
+				if ( self::isMemorySoftLimitReached() ) {
+					$stop_reason = 'memory_limit';
+					break;
+				}
+
 				if ( $limit > 0 && (int) $stats['actions_processed'] >= $limit ) {
 					$stop_reason = 'limit';
 					break;
@@ -167,7 +172,7 @@ class DrainCommand extends BaseCommand {
 					++$warnings;
 					$message = trim( (string) ( $result->stderr ?? '' ) );
 					WP_CLI::warning( '' === $message ? 'Action Scheduler CLI drain failed.' : $message );
-					$stop_reason = 'warning';
+					$stop_reason = 'memory_limit' === (string) ( $result->stop_reason ?? '' ) ? 'memory_limit' : 'warning';
 					break;
 				}
 
@@ -304,6 +309,11 @@ class DrainCommand extends BaseCommand {
 
 		try {
 			foreach ( $claim->get_actions() as $action_id ) {
+				if ( self::isMemorySoftLimitReached() ) {
+					$warnings[] = 'Drain stopped before processing the next action because PHP memory usage reached the soft limit.';
+					break;
+				}
+
 				$action_id = absint( $action_id );
 				if ( $action_id <= 0 || ! self::actionMatchesJobIds( $action_id, $job_ids ) ) {
 					continue;
@@ -322,15 +332,23 @@ class DrainCommand extends BaseCommand {
 				} finally {
 					self::flushRuntimeCache();
 				}
+
+				if ( self::isMemorySoftLimitReached() ) {
+					$warnings[] = 'Drain stopped after processing an action because PHP memory usage reached the soft limit.';
+					break;
+				}
 			}
 		} finally {
 			$store->release_claim( $claim );
 		}
 
+		$stop_reason = self::warningsContainMemoryLimit( $warnings ) ? 'memory_limit' : '';
+
 		return (object) array(
 			'return_code' => empty( $warnings ) ? 0 : 1,
 			'stdout'      => '',
 			'stderr'      => implode( "\n", $warnings ),
+			'stop_reason' => $stop_reason,
 		);
 	}
 
@@ -369,6 +387,61 @@ class DrainCommand extends BaseCommand {
 		if ( ! function_exists( 'wp_cache_supports' ) && function_exists( 'wp_cache_flush_runtime' ) ) {
 			wp_cache_flush_runtime();
 		}
+	}
+
+	/**
+	 * Whether PHP memory usage is near the hard limit.
+	 */
+	private static function isMemorySoftLimitReached(): bool {
+		$limit = self::memoryLimitBytes();
+		if ( $limit <= 0 ) {
+			return false;
+		}
+
+		$ratio = (float) apply_filters( 'datamachine_cli_drain_memory_soft_limit_ratio', 0.80 );
+		$ratio = max( 0.50, min( 0.95, $ratio ) );
+
+		return memory_get_usage( true ) >= (int) floor( $limit * $ratio );
+	}
+
+	/**
+	 * Return PHP memory_limit in bytes, or 0 for unlimited/unknown.
+	 */
+	private static function memoryLimitBytes(): int {
+		$raw = trim( (string) ini_get( 'memory_limit' ) );
+		if ( '' === $raw || '-1' === $raw ) {
+			return 0;
+		}
+
+		$unit  = strtolower( substr( $raw, -1 ) );
+		$value = (float) $raw;
+		switch ( $unit ) {
+			case 'g':
+				$value *= 1024;
+				// Fall through.
+			case 'm':
+				$value *= 1024;
+				// Fall through.
+			case 'k':
+				$value *= 1024;
+		}
+
+		return max( 0, (int) $value );
+	}
+
+	/**
+	 * Whether a batch warning was caused by the memory soft limit.
+	 *
+	 * @param string[] $warnings Warning messages.
+	 */
+	private static function warningsContainMemoryLimit( array $warnings ): bool {
+		foreach ( $warnings as $warning ) {
+			if ( false !== strpos( $warning, 'memory usage reached the soft limit' ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/drain-claim-ownership-smoke.php
+++ b/tests/drain-claim-ownership-smoke.php
@@ -37,6 +37,8 @@ assert_contains( '$claim->get_actions()', $drain_src, 'drain processes actions f
 assert_contains( 'find_actions_by_claim_id( $claim->get_id() )', $drain_src, 'drain rechecks claim ownership before processing each action' );
 assert_contains( '$runner->process_action( $action_id, \'Data Machine CLI drain\' )', $drain_src, 'drain executes only claim-owned action IDs' );
 assert_contains( 'flushRuntimeCache()', $drain_src, 'drain flushes runtime cache between actions' );
+assert_contains( 'isMemorySoftLimitReached()', $drain_src, 'drain checks memory soft limit while processing actions' );
+assert_contains( "'memory_limit'", $drain_src, 'drain reports memory-limit stop reason from batch processing' );
 assert_contains( 'finally {', $drain_src, 'drain releases claims in a finally block' );
 assert_contains( '$store->release_claim( $claim )', $drain_src, 'drain releases the Action Scheduler claim' );
 assert_not_contains( 'getDuePendingActionIds', $drain_src, 'drain no longer preselects due action IDs outside Action Scheduler claims' );
@@ -47,6 +49,7 @@ $stake_pos   = strpos( $drain_src, 'stake_claim( $batch_size, null, $hooks ?? ar
 $verify_pos  = strpos( $drain_src, 'find_actions_by_claim_id( $claim->get_id() )' );
 $process_pos = strpos( $drain_src, '$runner->process_action( $action_id, \'Data Machine CLI drain\' )' );
 $flush_pos   = strpos( $drain_src, 'flushRuntimeCache()' );
+$memory_pos  = strpos( $drain_src, 'isMemorySoftLimitReached()' );
 $release_pos = strpos( $drain_src, '$store->release_claim( $claim )' );
 
 assert_true( false !== $cleanup_pos, 'timeout cleanup position found' );
@@ -54,6 +57,7 @@ assert_true( false !== $stake_pos, 'claim staking position found' );
 assert_true( false !== $verify_pos, 'claim verification position found' );
 assert_true( false !== $process_pos, 'claimed action processing position found' );
 assert_true( false !== $flush_pos, 'runtime cache flush position found' );
+assert_true( false !== $memory_pos, 'memory soft-limit check position found' );
 assert_true( false !== $release_pos, 'claim release position found' );
 assert_true( $cleanup_pos < $stake_pos, 'drain cleans stale claims before staking a claim' );
 assert_true( $stake_pos < $verify_pos, 'drain stakes a claim before verifying ownership' );

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -60,6 +60,8 @@ assert_drain_contains( "\\ActionScheduler::runner()", $drain_src, 'drain uses Ac
 assert_drain_contains( "'Data Machine CLI drain'", $drain_src, 'drain records a Data Machine-specific execution context' );
 assert_drain_contains( 'catch ( \\Throwable $throwable )', $drain_src, 'drain catches per-action runner failures instead of fataling after job start' );
 assert_drain_contains( 'flushRuntimeCache()', $drain_src, 'drain flushes runtime cache after processing actions' );
+assert_drain_contains( 'isMemorySoftLimitReached()', $drain_src, 'drain stops before hard PHP memory exhaustion' );
+assert_drain_contains( "'memory_limit'", $drain_src, 'drain reports memory-limit stop reason' );
 assert_drain_contains( "'return_code' => empty( \$warnings ) ? 0 : 1", $drain_src, 'drain surfaces runner failures through a result object' );
 assert_drain_contains( "'remaining_pending'", $drain_src, 'drain reports remaining pending actions' );
 assert_drain_contains( "'batch_chunks'", $drain_src, 'drain reports batch chunk counts' );


### PR DESCRIPTION
## Summary
- Adds a soft PHP memory guard to the Data Machine CLI drain loop so long WP-CLI drains stop cleanly before WP Cloud object-cache memory exhaustion.
- Reports `stop_reason: memory_limit` when a claimed Action Scheduler batch stops due to memory pressure.
- Extends focused drain smoke tests for the memory-limit stop path.

Follow-up to #2273 after live `intelligence.horse` drains still hit a memcached hard memory fatal with larger bounded batches.

## Verification
- `php -l inc/Cli/Commands/DrainCommand.php`
- `php tests/drain-claim-ownership-smoke.php && php tests/flow-run-cli-drain-smoke.php && php tests/worker-lock-smoke.php`

## Runtime evidence
- `wp datamachine drain --limit=10 --batch-size=5 --time-limit=180 --format=json` on `intelligence.horse` fataled with `Allowed memory size of 536870912 bytes exhausted` in `/scripts/object-cache.memcached.php` after #2273 and the Matt queue reconciliation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the live memory fatal, drafted the conservative drain memory guard, and ran focused verification commands.