### PR TITLE
Feed source inventory scans into tracked items

### DIFF
--- a/docs/core-system/abilities-api.md
+++ b/docs/core-system/abilities-api.md
@@ -6,7 +6,7 @@ WordPress 6.9 Abilities API provides standardized capability discovery and execu
 
 The Abilities API in `inc/Abilities/` provides a unified interface for Data Machine operations. Each ability implements `execute_callback` with `permission_callback` for consistent access control across REST API, CLI commands, and Chat tools.
 
-**Total registered abilities**: 201
+**Total registered abilities**: 205
 
 This page documents the shape of the current ability surface and the source files that own each domain. For an exact live inventory, run `wp abilities list --category=datamachine-*` in a loaded WordPress install or inspect `wp_register_ability()` callsites under `inc/Abilities/`.
 
@@ -16,7 +16,7 @@ Data Machine follows a WordPress-shaped identifier model: `agent_id` is the stab
 
 ## Registered Ability Domains
 
-The current core registry has 201 `datamachine/*` abilities across these domains:
+The current core registry has 205 `datamachine/*` abilities across these domains:
 
 | Domain | Count | Source anchor | Examples |
 |--------|-------|---------------|----------|
@@ -53,6 +53,7 @@ The current core registry has 201 `datamachine/*` abilities across these domains
 | Step types | 2 | `inc/Abilities/StepTypeAbilities.php` | list/validate step types |
 | System | 3 | `inc/Abilities/SystemAbilities.php` | session titles, health checks, system task runs |
 | Taxonomy | 6 | `inc/Abilities/Taxonomy/` | get/create/update/delete/resolve terms, merge term meta |
+| Tracked items | 4 | `inc/Abilities/TrackedItemsAbilities.php` | upsert/get/list/summarize durable source coverage state |
 | Update handlers | 1 | `inc/Abilities/Update/` | WordPress update handler |
 
 Workspace, GitHub, and code-review abilities are intentionally not registered by Data Machine core. They live in the `data-machine-code` extension plugin.

--- a/docs/core-system/database-schema.md
+++ b/docs/core-system/database-schema.md
@@ -1,6 +1,6 @@
 # Database Schema
 
-Data Machine uses eight core tables for managing pipelines, flows, jobs, agents, access control, deduplication tracking, chat sessions, and centralized logging.
+Data Machine uses core tables for managing pipelines, flows, jobs, agents, access control, deduplication tracking, durable source coverage, chat sessions, and centralized logging.
 
 ## Core Tables
 
@@ -142,6 +142,58 @@ CREATE TABLE wp_datamachine_processed_items (
 - `flow_source_item` (UNIQUE) — point lookups + dedupe constraint.
 - `flow_step_id`, `source_type`, `job_id` — bulk deletes and filtered audits.
 - `flow_source_ts` (since 0.71.0) — covers time-windowed range scans used by `find_stale()` / `has_been_processed_within()`. `ProcessedItems::ensure_flow_source_ts_index()` backfills the index on existing installs since `dbDelta` does not reliably add indexes to populated tables.
+
+### `wp_datamachine_tracked_items`
+
+**Purpose**: Durable source/entity coverage ledger
+
+Tracked items are separate from `wp_datamachine_processed_items`. Processed items remain the short-lived dedupe and claim table for flow execution. Tracked items store long-lived coverage state for source entities that need a durable answer such as discovered, queued, generated, reviewed, intentionally excluded, stale, or failed.
+
+```sql
+CREATE TABLE wp_datamachine_tracked_items (
+    id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+    namespace VARCHAR(191) NOT NULL,
+    item_id VARCHAR(191) NOT NULL,
+    item_type VARCHAR(100) NOT NULL DEFAULT '',
+    state VARCHAR(40) NOT NULL DEFAULT 'discovered',
+    source_ref VARCHAR(255) NOT NULL DEFAULT '',
+    source_revision VARCHAR(100) NOT NULL DEFAULT '',
+    source_path VARCHAR(255) NOT NULL DEFAULT '',
+    source_line BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+    output_ref VARCHAR(255) NOT NULL DEFAULT '',
+    metadata_json LONGTEXT NULL,
+    first_seen_at DATETIME NOT NULL,
+    last_seen_at DATETIME NOT NULL,
+    last_job_id BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+    updated_at DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY namespace_item (namespace, item_id),
+    KEY namespace_type_state (namespace, item_type, state),
+    KEY namespace_state (namespace, state),
+    KEY source_ref (source_ref(191)),
+    KEY updated_at (updated_at)
+);
+```
+
+**Fields**:
+- `id` - Auto-increment primary key
+- `namespace` - Consumer/project scope for separating ledgers
+- `item_id` - Stable source/entity identifier within the namespace
+- `item_type` - Generic type such as `function`, `class`, `hook`, `block`, `endpoint`, `article`, `ticket`, or another consumer-defined type
+- `state` - Generic coverage state: `discovered`, `queued`, `generated`, `reviewed`, `excluded`, `stale`, or `failed`
+- `source_ref` - Source system or repository reference
+- `source_revision` - Source revision, commit, cursor, or equivalent freshness marker
+- `source_path` and `source_line` - Optional file/source location
+- `output_ref` - Generated artifact, page, document, or other downstream output reference
+- `metadata_json` - Consumer-defined metadata for domain-specific facts and relationships
+- `first_seen_at`, `last_seen_at`, `updated_at` - Coverage ledger timestamps
+- `last_job_id` - Last Data Machine job associated with the tracked state
+
+**Indexes**:
+- `namespace_item` (UNIQUE) — stable upsert key.
+- `namespace_type_state` and `namespace_state` — coverage summaries by namespace/type/state.
+- `source_ref` — source-scoped audits.
+- `updated_at` — recent changes and stale-state scans.
 
 ### `wp_datamachine_chat_sessions`
 

--- a/inc/Abilities/SourceInventoryAbility.php
+++ b/inc/Abilities/SourceInventoryAbility.php
@@ -82,9 +82,9 @@ class SourceInventoryAbility {
 				return $result;
 			}
 
-			$aggregator       = new PageableSourceAggregator();
-			$config           = $input;
-			$config['params'] = is_array( $source['params'] ?? null ) ? $source['params'] : array();
+			$aggregator        = new PageableSourceAggregator();
+			$config            = $input;
+			$config['params']  = is_array( $source['params'] ?? null ) ? $source['params'] : array();
 			$tracking_callback = $this->buildTrackingCallback( $input, $aggregator );
 			if ( null !== $tracking_callback ) {
 				$config['item_callback'] = $tracking_callback;
@@ -128,13 +128,13 @@ class SourceInventoryAbility {
 	}
 
 	private function buildTrackingCallback( array $input, PageableSourceAggregator $aggregator ): ?callable {
-		$tracking = is_array( $input['track_items'] ?? null ) ? $input['track_items'] : array();
+		$tracking  = is_array( $input['track_items'] ?? null ) ? $input['track_items'] : array();
 		$namespace = trim( (string) ( $tracking['namespace'] ?? '' ) );
 		if ( '' === $namespace ) {
 			return null;
 		}
 
-		$repository = $this->tracked_items ?? new TrackedItems();
+		$repository   = $this->tracked_items ?? new TrackedItems();
 		$item_id_path = (string) ( $tracking['item_id_path'] ?? 'id' );
 
 		return static function ( array $item ) use ( $tracking, $namespace, $item_id_path, $repository, $aggregator ): bool {

--- a/inc/Abilities/SourceInventoryAbility.php
+++ b/inc/Abilities/SourceInventoryAbility.php
@@ -7,6 +7,7 @@
 
 namespace DataMachine\Abilities;
 
+use DataMachine\Core\Database\TrackedItems\TrackedItems;
 use DataMachine\Core\SourceAggregation\PageableSourceAggregator;
 use DataMachine\Core\SourceAggregation\SourceInventoryProfiler;
 
@@ -16,7 +17,11 @@ class SourceInventoryAbility {
 
 	private static bool $registered = false;
 
-	public function __construct() {
+	private ?TrackedItems $tracked_items;
+
+	public function __construct( ?TrackedItems $tracked_items = null ) {
+		$this->tracked_items = $tracked_items;
+
 		if ( self::$registered ) {
 			return;
 		}
@@ -77,10 +82,19 @@ class SourceInventoryAbility {
 				return $result;
 			}
 
+			$aggregator       = new PageableSourceAggregator();
 			$config           = $input;
 			$config['params'] = is_array( $source['params'] ?? null ) ? $source['params'] : array();
+			$tracking_callback = $this->buildTrackingCallback( $input, $aggregator );
+			if ( null !== $tracking_callback ) {
+				$config['item_callback'] = $tracking_callback;
+			}
 
-			$scan           = ( new PageableSourceAggregator() )->aggregate( $page_callback, $config );
+			$scan = $aggregator->aggregate( $page_callback, $config );
+			if ( isset( $scan['item_callback'] ) ) {
+				$scan['tracked_items'] = $scan['item_callback'];
+				unset( $scan['item_callback'] );
+			}
 			$result['scan'] = array_merge( array( 'success' => true ), $scan );
 		}
 
@@ -111,6 +125,64 @@ class SourceInventoryAbility {
 		}
 
 		return null;
+	}
+
+	private function buildTrackingCallback( array $input, PageableSourceAggregator $aggregator ): ?callable {
+		$tracking = is_array( $input['track_items'] ?? null ) ? $input['track_items'] : array();
+		$namespace = trim( (string) ( $tracking['namespace'] ?? '' ) );
+		if ( '' === $namespace ) {
+			return null;
+		}
+
+		$repository = $this->tracked_items ?? new TrackedItems();
+		$item_id_path = (string) ( $tracking['item_id_path'] ?? 'id' );
+
+		return static function ( array $item ) use ( $tracking, $namespace, $item_id_path, $repository, $aggregator ): bool {
+			$item_id = $aggregator->getPath( $item, $item_id_path );
+			if ( null === $item_id || '' === (string) $item_id ) {
+				return false;
+			}
+
+			$tracked_item = array(
+				'namespace'       => $namespace,
+				'item_id'         => (string) $item_id,
+				'item_type'       => (string) ( $tracking['item_type'] ?? '' ),
+				'state'           => (string) ( $tracking['state'] ?? TrackedItems::STATE_DISCOVERED ),
+				'source_ref'      => (string) ( $tracking['source_ref'] ?? '' ),
+				'source_revision' => (string) ( $tracking['source_revision'] ?? '' ),
+				'source_path'     => (string) ( $tracking['source_path'] ?? '' ),
+				'source_line'     => max( 0, (int) ( $tracking['source_line'] ?? 0 ) ),
+				'output_ref'      => (string) ( $tracking['output_ref'] ?? '' ),
+				'last_job_id'     => max( 0, (int) ( $tracking['last_job_id'] ?? 0 ) ),
+			);
+
+			foreach ( array( 'item_type', 'source_ref', 'source_revision', 'source_path', 'source_line', 'output_ref' ) as $field ) {
+				$path = (string) ( $tracking[ $field . '_path' ] ?? '' );
+				if ( '' === $path ) {
+					continue;
+				}
+
+				$value = $aggregator->getPath( $item, $path );
+				if ( null !== $value ) {
+					$tracked_item[ $field ] = $value;
+				}
+			}
+
+			$metadata_paths = is_array( $tracking['metadata_paths'] ?? null ) ? $tracking['metadata_paths'] : array();
+			foreach ( $metadata_paths as $metadata_key => $path ) {
+				$metadata_key = trim( (string) $metadata_key );
+				if ( '' === $metadata_key ) {
+					continue;
+				}
+
+				$value = $aggregator->getPath( $item, (string) $path );
+				if ( null !== $value ) {
+					$tracked_item['metadata'][ $metadata_key ] = $value;
+				}
+			}
+
+			return null !== $repository->upsert( $tracked_item );
+		};
 	}
 
 	private function getInputSchema(): array {
@@ -146,6 +218,25 @@ class SourceInventoryAbility {
 				'sample_limit_per_bucket' => array( 'type' => 'integer' ),
 				'max_items'               => array( 'type' => 'integer' ),
 				'max_pages'               => array( 'type' => 'integer' ),
+				'track_items'             => array(
+					'type'        => 'object',
+					'description' => 'When provided with scan=true, upsert each scanned item into the generic tracked-items ledger using path-based field mapping.',
+					'properties'  => array(
+						'namespace'            => array( 'type' => 'string' ),
+						'item_id_path'         => array( 'type' => 'string' ),
+						'item_type'            => array( 'type' => 'string' ),
+						'item_type_path'       => array( 'type' => 'string' ),
+						'state'                => array( 'type' => 'string' ),
+						'source_ref'           => array( 'type' => 'string' ),
+						'source_ref_path'      => array( 'type' => 'string' ),
+						'source_revision_path' => array( 'type' => 'string' ),
+						'source_path_path'     => array( 'type' => 'string' ),
+						'source_line_path'     => array( 'type' => 'string' ),
+						'output_ref_path'      => array( 'type' => 'string' ),
+						'metadata_paths'       => array( 'type' => 'object' ),
+						'last_job_id'          => array( 'type' => 'integer' ),
+					),
+				),
 			),
 		);
 	}

--- a/inc/Core/SourceAggregation/PageableSourceAggregator.php
+++ b/inc/Core/SourceAggregation/PageableSourceAggregator.php
@@ -33,6 +33,12 @@ class PageableSourceAggregator {
 		$max_pages               = max( 1, (int) ( $config['max_pages'] ?? 100 ) );
 		$group_by                = $this->normalizeStringList( $config['group_by'] ?? array() );
 		$sample_limit_per_bucket = max( 0, (int) ( $config['sample_limit_per_bucket'] ?? 3 ) );
+		$item_callback           = is_callable( $config['item_callback'] ?? null ) ? $config['item_callback'] : null;
+		$item_callback_result    = array(
+			'attempted' => 0,
+			'succeeded' => 0,
+			'failed'    => 0,
+		);
 
 		$total       = null;
 		$processed   = 0;
@@ -87,6 +93,14 @@ class PageableSourceAggregator {
 				}
 
 				$this->aggregateItem( $item, $group_by, $groups, $samples, $sample_limit_per_bucket );
+				if ( null !== $item_callback ) {
+					++$item_callback_result['attempted'];
+					if ( false !== $item_callback( $item ) ) {
+						++$item_callback_result['succeeded'];
+					} else {
+						++$item_callback_result['failed'];
+					}
+				}
 				++$processed;
 
 				if ( $max_items > 0 && $processed >= $max_items ) {
@@ -110,7 +124,7 @@ class PageableSourceAggregator {
 			$diagnostics['stop_reason'] = 'max_pages';
 		}
 
-		return array(
+		$result = array(
 			'total'       => $total ?? $processed,
 			'processed'   => $processed,
 			'pages'       => $page_count,
@@ -118,6 +132,12 @@ class PageableSourceAggregator {
 			'samples'     => $samples,
 			'diagnostics' => $diagnostics,
 		);
+
+		if ( null !== $item_callback ) {
+			$result['item_callback'] = $item_callback_result;
+		}
+
+		return $result;
 	}
 
 	/**

--- a/tests/source-inventory-smoke.php
+++ b/tests/source-inventory-smoke.php
@@ -21,6 +21,18 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+		function wp_strip_all_tags( $text ) {
+			return strip_tags( (string) $text );
+		}
+	}
+
+	if ( ! function_exists( 'current_time' ) ) {
+		function current_time( $type, $gmt = false ) {
+			return gmdate( 'Y-m-d H:i:s' );
+		}
+	}
+
 	if ( ! function_exists( '__' ) ) {
 		function __( $text, $domain = 'default' ) {
 			return $text;
@@ -87,10 +99,33 @@ namespace DataMachine\Abilities {
 namespace {
 	require_once __DIR__ . '/../inc/Core/SourceAggregation/PageableSourceAggregator.php';
 	require_once __DIR__ . '/../inc/Core/SourceAggregation/SourceInventoryProfiler.php';
+	require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+	require_once __DIR__ . '/../inc/Core/Database/TrackedItems/TrackedItems.php';
 	require_once __DIR__ . '/../inc/Abilities/SourceInventoryAbility.php';
 
 	use DataMachine\Abilities\SourceInventoryAbility;
+	use DataMachine\Core\Database\TrackedItems\TrackedItems;
 	use DataMachine\Core\SourceAggregation\SourceInventoryProfiler;
+
+	class SourceInventoryTrackedItemsSmokeRepository extends TrackedItems {
+		public array $items = array();
+
+		public function __construct() {}
+
+		public function upsert( array $item ): ?array {
+			$key = (string) $item['namespace'] . ':' . (string) $item['item_id'];
+			$this->items[ $key ] = array_merge(
+				array(
+					'id'       => count( $this->items ) + 1,
+					'metadata' => array(),
+				),
+				$this->items[ $key ] ?? array(),
+				$item
+			);
+
+			return $this->items[ $key ];
+		}
+	}
 
 	$failed = 0;
 	$total  = 0;
@@ -194,7 +229,8 @@ namespace {
 		),
 	);
 
-	$ability = new SourceInventoryAbility();
+	$tracked_items = new SourceInventoryTrackedItemsSmokeRepository();
+	$ability       = new SourceInventoryAbility( $tracked_items );
 	assert_source_inventory( 'ability registers datamachine/source-inventory', isset( $GLOBALS['source_inventory_registered_abilities']['datamachine/source-inventory'] ) );
 
 	$result = $ability->execute(
@@ -219,6 +255,37 @@ namespace {
 	assert_source_inventory( 'ability scan processes static pages', 3 === ( $result['scan']['processed'] ?? 0 ) );
 	assert_source_inventory( 'ability scan reports total denominator', 3 === ( $result['scan']['total'] ?? 0 ) );
 	assert_source_inventory( 'ability scan groups item fields', 2 === ( $result['scan']['groups']['venue']['A'] ?? 0 ) );
+
+	$tracked = $ability->execute(
+		array(
+			'source'      => array(
+				'kind'  => 'static_pages',
+				'pages' => array(
+					array(
+						'items' => array(
+							array( 'id' => 'wp_register_script_module', 'kind' => 'function', 'path' => 'src/wp-includes/script-modules.php', 'line' => 42 ),
+							array( 'id' => 'WP_Script_Modules', 'kind' => 'class', 'path' => 'src/wp-includes/class-wp-script-modules.php', 'line' => 14 ),
+						),
+					),
+				),
+			),
+			'scan'        => true,
+			'pagination'  => array( 'limit' => 10, 'item_path' => 'items' ),
+			'track_items' => array(
+				'namespace'        => 'wp-docs:core-script-modules',
+				'item_id_path'     => 'id',
+				'item_type_path'   => 'kind',
+				'state'            => TrackedItems::STATE_DISCOVERED,
+				'source_ref'       => 'wordpress-develop',
+				'source_path_path' => 'path',
+				'source_line_path' => 'line',
+			),
+		)
+	);
+	assert_source_inventory( 'tracked scan succeeds', true === ( $tracked['success'] ?? false ) );
+	assert_source_inventory( 'tracked scan reports upserts', 2 === ( $tracked['scan']['tracked_items']['succeeded'] ?? 0 ) );
+	assert_source_inventory( 'tracked scan writes first item', isset( $tracked_items->items['wp-docs:core-script-modules:wp_register_script_module'] ) );
+	assert_source_inventory( 'tracked scan maps source path', 'src/wp-includes/script-modules.php' === ( $tracked_items->items['wp-docs:core-script-modules:wp_register_script_module']['source_path'] ?? '' ) );
 
 	$unsupported = $ability->execute(
 		array(

--- a/tests/tracked-items-smoke.php
+++ b/tests/tracked-items-smoke.php
@@ -81,19 +81,22 @@ namespace {
 
 	class TrackedItemsSmokeRepository extends TrackedItems {
 		private array $items = array();
+		private int $next_id = 1;
 
 		public function __construct() {}
 
 		public function upsert( array $item ): ?array {
 			$key = (string) $item['namespace'] . ':' . (string) $item['item_id'];
+			$existing = $this->items[ $key ] ?? array();
 			$this->items[ $key ] = array_merge(
 				array(
-					'id'         => count( $this->items ) + 1,
+					'id'         => $existing['id'] ?? $this->next_id++,
 					'item_type'  => '',
 					'state'      => TrackedItems::STATE_DISCOVERED,
 					'metadata'   => array(),
 					'updated_at' => '2026-05-26 00:00:00',
 				),
+				$existing,
 				$item
 			);
 			return $this->items[ $key ];
@@ -104,14 +107,39 @@ namespace {
 		}
 
 		public function list( array $filters = array() ): array {
-			return array_values( $this->items );
+			$items = array_values( $this->items );
+			foreach ( array( 'namespace', 'item_type', 'state', 'source_ref', 'output_ref' ) as $filter_key ) {
+				$filter_value = (string) ( $filters[ $filter_key ] ?? '' );
+				if ( '' === $filter_value ) {
+					continue;
+				}
+
+				$items = array_values(
+					array_filter(
+						$items,
+						static fn ( array $item ): bool => $filter_value === (string) ( $item[ $filter_key ] ?? '' )
+					)
+				);
+			}
+
+			return $items;
 		}
 
 		public function summary( array $filters = array() ): array {
+			$items    = $this->list( $filters );
+			$by_type  = array();
+			$by_state = array();
+			foreach ( $items as $item ) {
+				$item_type = (string) ( $item['item_type'] ?? '' );
+				$state     = (string) ( $item['state'] ?? '' );
+				$by_type[ $item_type ][ $state ] = ( $by_type[ $item_type ][ $state ] ?? 0 ) + 1;
+				$by_state[ $state ]              = ( $by_state[ $state ] ?? 0 ) + 1;
+			}
+
 			return array(
-				'total'    => count( $this->items ),
-				'by_type'  => array( 'function' => array( 'generated' => count( $this->items ) ) ),
-				'by_state' => array( 'generated' => count( $this->items ) ),
+				'total'    => count( $items ),
+				'by_type'  => $by_type,
+				'by_state' => $by_state,
 			);
 		}
 	}
@@ -145,17 +173,39 @@ namespace {
 			'namespace' => 'wp-docs:core',
 			'item_id'   => 'function:wp_register_script_module',
 			'item_type' => 'function',
-			'state'     => TrackedItems::STATE_GENERATED,
+			'state'     => TrackedItems::STATE_DISCOVERED,
+			'source_ref' => 'wordpress-develop',
 		)
 	);
 
 	tracked_items_assert( 'upsert succeeds', true === ( $upsert['success'] ?? false ) );
 	$get = $abilities->executeGetTrackedItem( array( 'namespace' => 'wp-docs:core', 'item_id' => 'function:wp_register_script_module' ) );
 	tracked_items_assert( 'get returns tracked item', 'function:wp_register_script_module' === ( $get['item']['item_id'] ?? '' ) );
+	tracked_items_assert( 'initial state is discovered', TrackedItems::STATE_DISCOVERED === ( $get['item']['state'] ?? '' ) );
+
+	$transition = $abilities->executeUpsertTrackedItem(
+		array(
+			'namespace'  => 'wp-docs:core',
+			'item_id'    => 'function:wp_register_script_module',
+			'item_type'  => 'function',
+			'source_ref' => 'wordpress-develop',
+			'output_ref' => 'docs/reference/functions/wp-register-script-module.md',
+			'state'      => TrackedItems::STATE_GENERATED,
+			'metadata'   => array( 'signature' => 'wp_register_script_module()' ),
+		)
+	);
+
+	tracked_items_assert( 'state transition succeeds', true === ( $transition['success'] ?? false ) );
+	tracked_items_assert( 'state transition preserves row identity', ( $upsert['item']['id'] ?? null ) === ( $transition['item']['id'] ?? null ) );
+	tracked_items_assert( 'state transition stores generated state', TrackedItems::STATE_GENERATED === ( $transition['item']['state'] ?? '' ) );
+	tracked_items_assert( 'state transition stores output ref', 'docs/reference/functions/wp-register-script-module.md' === ( $transition['item']['output_ref'] ?? '' ) );
 	$list = $abilities->executeListTrackedItems( array( 'namespace' => 'wp-docs:core' ) );
 	tracked_items_assert( 'list returns tracked item', 1 === count( (array) ( $list['items'] ?? array() ) ) );
+	$filtered_list = $abilities->executeListTrackedItems( array( 'namespace' => 'wp-docs:core', 'state' => TrackedItems::STATE_EXCLUDED ) );
+	tracked_items_assert( 'list filters by state', 0 === count( (array) ( $filtered_list['items'] ?? array() ) ) );
 	$summary = $abilities->executeTrackedItemsSummary( array( 'namespace' => 'wp-docs:core' ) );
 	tracked_items_assert( 'summary counts tracked item', 1 === (int) ( $summary['total'] ?? 0 ) );
+	tracked_items_assert( 'summary groups generated state', 1 === (int) ( $summary['by_state'][ TrackedItems::STATE_GENERATED ] ?? 0 ) );
 
 	if ( $failed > 0 ) {
 		echo "\ntracked-items-smoke failed: {$failed}/{$total} assertions failed.\n";


### PR DESCRIPTION
## Summary
- adds optional `track_items` mapping to source-inventory scans so generic pageable sources can upsert scanned entities into `datamachine_tracked_items`
- extends the pageable source aggregator with an item callback hook and write counters
- documents the tracked-items table/ability surface and expands smoke coverage for state transitions plus source-inventory ledger writes

## Tests
- `php tests/tracked-items-smoke.php`
- `php tests/source-inventory-smoke.php`
- `php tests/migration-runtime-smoke.php`
- `php -l inc/Abilities/SourceInventoryAbility.php`
- `php -l inc/Core/SourceAggregation/PageableSourceAggregator.php`
- `php -l tests/source-inventory-smoke.php`
- `vendor/bin/phpcs inc/Abilities/SourceInventoryAbility.php inc/Core/SourceAggregation/PageableSourceAggregator.php tests/source-inventory-smoke.php tests/tracked-items-smoke.php`

## Full-suite note
- `composer test` did not run tests because the Homeboy lab WP Codebox workspace is missing `/home/chubes/Developer/_lab_workspaces/wordpress-aec3338e4f68/vendor`. This failed during recipe validation before PHPUnit execution.

Refs #2274.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigated the existing tracked-items implementation, drafted the source-inventory ledger feed, tests, docs, and verification notes for Chris to review.