### PR TITLE
fix(abilities): guarantee category registration before ability registration on multisite subsites

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -158,6 +158,10 @@ function datamachine_run_datamachine_plugin() {
 	\DataMachine\Core\Auth\ExternalLoginRouter::register();
 
 	// Register ability categories first — must happen before any ability registration.
+	// Categories are also registered unconditionally at file include time (see bottom
+	// of this file); this call is the defensive in-runtime path for late `plugins_loaded`
+	// inclusion (`plugin_sandbox_scrape()` during activation, etc.). The static guard in
+	// `AbilityCategories::register()` makes it idempotent.
 	require_once __DIR__ . '/inc/Abilities/AbilityCategories.php';
 	\DataMachine\Abilities\AbilityCategories::ensure_registered();
 
@@ -443,6 +447,34 @@ if ( did_action( 'plugins_loaded' ) ) {
 	// @phpstan-ignore-next-line WordPress stubs in CI omit the optional priority argument.
 	add_action( 'plugins_loaded', 'datamachine_run_datamachine_plugin', 20 );
 }
+
+/**
+ * Register ability categories unconditionally on every request.
+ *
+ * Categories are a cheap registration (~20 string entries) but they are a
+ * *contract* depended on by every Data Machine extension plugin
+ * (`data-machine-business`, `data-machine-socials`, etc.) and any consumer
+ * that calls `wp_register_ability( ..., [ 'category' => 'datamachine-*' ] )`.
+ *
+ * They MUST NOT be gated by `datamachine_should_load_full_runtime()` because
+ * extension plugins do not honour that gate — they instantiate their own
+ * ability classes at `plugins_loaded:20` regardless of request shape, and
+ * those abilities register against Data Machine categories. If the categories
+ * are missing when the lazy `wp_abilities_api_init` fire happens (e.g. when
+ * a frontend page calls `wp_get_ability()` via Frontend Agent Chat or an
+ * OG-card task), every extension ability registration triggers a
+ * `_doing_it_wrong` notice and the ability is silently dropped from the
+ * registry. See: Extra-Chill/data-machine#2287.
+ *
+ * Loading the file is cheap enough to do at file include time; calling
+ * `ensure_registered()` here attaches the `wp_abilities_api_categories_init`
+ * hook before `init` fires (the action cannot fire before `init`, so any
+ * later `plugins_loaded` priority works too — but earlier is safer for any
+ * site that includes our plugin file via `plugin_sandbox_scrape()` or
+ * similar late-load paths).
+ */
+require_once __DIR__ . '/inc/Abilities/AbilityCategories.php';
+\DataMachine\Abilities\AbilityCategories::ensure_registered();
 
 
 

--- a/inc/Abilities/AbilityCategories.php
+++ b/inc/Abilities/AbilityCategories.php
@@ -51,13 +51,88 @@ class AbilityCategories {
 	 * Safe to call multiple times — uses a static guard.
 	 * Must be called during `wp_abilities_api_categories_init` action —
 	 * WordPress core enforces this via `doing_action()` check.
+	 *
+	 * @return void
 	 */
 	public static function register(): void {
 		if ( self::$registered ) {
 			return;
 		}
 
-		$categories = array(
+		foreach ( self::get_category_definitions() as $slug => $args ) {
+			wp_register_ability_category( $slug, $args );
+		}
+
+		self::$registered = true;
+	}
+
+	/**
+	 * Ensure categories are registered.
+	 *
+	 * Handles three timing states so registration is robust regardless of
+	 * which plugin instantiates the abilities registry first:
+	 *
+	 *   1. `doing_action( wp_abilities_api_categories_init )` — the action
+	 *      is currently firing. Register immediately so the categories
+	 *      land in this same dispatch pass.
+	 *   2. `! did_action( wp_abilities_api_categories_init )` — the action
+	 *      has not fired yet. Attach a hook for the lazy fire.
+	 *   3. otherwise — the action has already fired and completed. The
+	 *      categories registry singleton exists; call its instance method
+	 *      directly so the categories still land in the registry. The
+	 *      public `wp_register_ability_category()` helper enforces
+	 *      `doing_action()`, but the underlying registry method does not.
+	 *
+	 * This mirrors the defensive pattern used by `block-format-bridge`
+	 * (see `vendor/chubes4/block-format-bridge/includes/abilities.php`)
+	 * and by sibling extension plugins.
+	 *
+	 * @return void
+	 */
+	public static function ensure_registered(): void {
+		if ( self::$registered ) {
+			return;
+		}
+
+		if ( doing_action( 'wp_abilities_api_categories_init' ) ) {
+			self::register();
+			return;
+		}
+
+		if ( ! did_action( 'wp_abilities_api_categories_init' ) ) {
+			add_action( 'wp_abilities_api_categories_init', array( self::class, 'register' ) );
+			return;
+		}
+
+		// Action already fired and completed. The categories registry
+		// singleton exists; register directly via the instance method so
+		// late-loaded contexts (e.g. lazy abilities-registry instantiation
+		// triggered before our `plugins_loaded` hook attached) still get
+		// the Data Machine categories. The instance-method path bypasses
+		// the public helper's `doing_action()` guard.
+		$registry = \WP_Ability_Categories_Registry::get_instance();
+		if ( null === $registry ) {
+			return;
+		}
+
+		foreach ( self::get_category_definitions() as $slug => $args ) {
+			if ( $registry->is_registered( $slug ) ) {
+				continue;
+			}
+			$registry->register( $slug, $args );
+		}
+
+		self::$registered = true;
+	}
+
+	/**
+	 * Category definitions used by both `register()` and the late-fire
+	 * recovery path in `ensure_registered()`.
+	 *
+	 * @return array<string, array<string, string>>
+	 */
+	private static function get_category_definitions(): array {
+		return array(
 			self::CONTENT    => array(
 				'label'       => __( 'Content', 'data-machine' ),
 				'description' => __( 'Content querying, editing, searching, and block operations.', 'data-machine' ),
@@ -135,28 +210,5 @@ class AbilityCategories {
 				'description' => __( 'Pending action staging and resolution (user approval of tool invocations).', 'data-machine' ),
 			),
 		);
-
-		foreach ( $categories as $slug => $args ) {
-			wp_register_ability_category( $slug, $args );
-		}
-
-		self::$registered = true;
-	}
-
-	/**
-	 * Ensure categories are registered.
-	 *
-	 * Always hooks into `wp_abilities_api_categories_init` — WordPress core
-	 * enforces that `wp_register_ability_category()` is only called during
-	 * that action (`doing_action()` check). The hook fires lazily when the
-	 * categories registry singleton is first accessed, so hooking in at
-	 * `plugins_loaded` time is safe.
-	 */
-	public static function ensure_registered(): void {
-		if ( self::$registered ) {
-			return;
-		}
-
-		add_action( 'wp_abilities_api_categories_init', array( self::class, 'register' ) );
 	}
 }

--- a/tests/abilities-categories-load-order-smoke.php
+++ b/tests/abilities-categories-load-order-smoke.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Regression smoke for #2287: ability categories must register before any
+ * ability registration, regardless of which plugin instantiates the
+ * abilities registry first.
+ *
+ * Two kinds of assertions:
+ *
+ * 1. Source-string assertions — `data-machine.php` must call
+ *    `AbilityCategories::ensure_registered()` UNCONDITIONALLY at file
+ *    include time, NOT only inside the gated runtime function. Categories
+ *    are a contract depended on by every extension plugin and must be
+ *    available on every request that touches the abilities API.
+ *
+ * 2. Behavioral assertions — `AbilityCategories::ensure_registered()` must
+ *    handle all three timing states defensively:
+ *      - `doing_action()` → register immediately
+ *      - `! did_action()` → hook for later
+ *      - already-fired → register directly via the registry instance
+ *
+ * Run with: php tests/abilities-categories-load-order-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare( strict_types = 1 );
+
+$failed = 0;
+$total  = 0;
+
+$assert = static function ( string $name, bool $condition ) use ( &$failed, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$name}\n";
+		return;
+	}
+
+	echo "  FAIL: {$name}\n";
+	++$failed;
+};
+
+// ============================================================
+// Source-string assertions
+// ============================================================
+
+$plugin_root = dirname( __DIR__ );
+$bootstrap   = file_get_contents( $plugin_root . '/data-machine.php' );
+$categories  = file_get_contents( $plugin_root . '/inc/Abilities/AbilityCategories.php' );
+
+if ( false === $bootstrap || false === $categories ) {
+	fwrite( STDERR, "FAIL: unable to read plugin source\n" );
+	exit( 1 );
+}
+
+$assert(
+	'data-machine.php calls ensure_registered() unconditionally at file load',
+	str_contains( $bootstrap, 'Register ability categories unconditionally on every request' )
+		&& str_contains( $bootstrap, "require_once __DIR__ . '/inc/Abilities/AbilityCategories.php';\n\\DataMachine\\Abilities\\AbilityCategories::ensure_registered();" )
+);
+
+$assert(
+	'unconditional call site is OUTSIDE datamachine_run_datamachine_plugin()',
+	(bool) preg_match(
+		'/^}\s*\/\*\*\s*\*\s*Register ability categories unconditionally on every request\./m',
+		$bootstrap
+	)
+);
+
+$assert(
+	'in-runtime call is still present (defensive idempotent path)',
+	substr_count(
+		$bootstrap,
+		'DataMachine\\Abilities\\AbilityCategories::ensure_registered()'
+	) >= 2
+);
+
+// ============================================================
+// Behavioral assertions: defensive three-state pattern
+// ============================================================
+
+$assert(
+	'ensure_registered() handles doing_action state',
+	str_contains( $categories, "doing_action( 'wp_abilities_api_categories_init' )" )
+);
+
+$assert(
+	'ensure_registered() handles pre-action state',
+	str_contains( $categories, "! did_action( 'wp_abilities_api_categories_init' )" )
+		&& str_contains( $categories, "add_action( 'wp_abilities_api_categories_init'" )
+);
+
+$assert(
+	'ensure_registered() handles post-action state via registry instance',
+	str_contains( $categories, 'WP_Ability_Categories_Registry::get_instance()' )
+		&& str_contains( $categories, '$registry->register(' )
+);
+
+$assert(
+	'post-action recovery path is idempotent (skips already-registered slugs)',
+	str_contains( $categories, '$registry->is_registered( $slug )' )
+);
+
+$assert(
+	'category definitions extracted into shared helper to avoid drift',
+	str_contains( $categories, 'private static function get_category_definitions(): array' )
+);
+
+// ============================================================
+// Behavioral simulation: load class under three stubbed states
+// ============================================================
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', '/tmp/' );
+}
+
+// State container so closure stubs can mutate them.
+$state = (object) array(
+	'doing'      => false,
+	'did'        => 0,
+	'hooked'     => array(),
+);
+
+// Translation/hook stubs.
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = null ) {
+		return $text;
+	}
+}
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook ) {
+		global $dm_2287_state;
+		return $dm_2287_state->doing && $hook === 'wp_abilities_api_categories_init';
+	}
+}
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook ) {
+		global $dm_2287_state;
+		return $hook === 'wp_abilities_api_categories_init' ? $dm_2287_state->did : 0;
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		global $dm_2287_state;
+		$dm_2287_state->hooked[ $hook ][] = $callback;
+		return true;
+	}
+}
+if ( ! function_exists( 'wp_register_ability_category' ) ) {
+	function wp_register_ability_category( $slug, $args ) {
+		global $dm_2287_state;
+		// Only succeed when the action is firing (mirror core's guard).
+		if ( ! doing_action( 'wp_abilities_api_categories_init' ) ) {
+			$dm_2287_state->doing_it_wrong = ( $dm_2287_state->doing_it_wrong ?? 0 ) + 1;
+			return null;
+		}
+		$dm_2287_state->registered[ $slug ] = $args;
+		return true;
+	}
+}
+
+// Stub the categories registry singleton for the post-action recovery test.
+if ( ! class_exists( 'WP_Ability_Categories_Registry' ) ) {
+	class WP_Ability_Categories_Registry {
+		/** @var array<string, array<string, mixed>> */
+		public array $registered = array();
+		private static ?self $instance = null;
+
+		public static function get_instance(): ?self {
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+			}
+			return self::$instance;
+		}
+
+		public static function reset(): void {
+			self::$instance = null;
+		}
+
+		public function is_registered( string $slug ): bool {
+			return isset( $this->registered[ $slug ] );
+		}
+
+		public function register( string $slug, array $args ): bool {
+			$this->registered[ $slug ] = $args;
+			return true;
+		}
+	}
+}
+
+$GLOBALS['dm_2287_state'] = $state;
+
+require_once $plugin_root . '/inc/Abilities/AbilityCategories.php';
+
+$reset = static function (): void {
+	global $dm_2287_state;
+	$dm_2287_state->doing  = false;
+	$dm_2287_state->did    = 0;
+	$dm_2287_state->hooked = array();
+	$dm_2287_state->registered = array();
+	$dm_2287_state->doing_it_wrong = 0;
+
+	$reflection = new ReflectionClass( \DataMachine\Abilities\AbilityCategories::class );
+	$prop       = $reflection->getProperty( 'registered' );
+	$prop->setAccessible( true );
+	$prop->setValue( null, false );
+
+	WP_Ability_Categories_Registry::reset();
+};
+
+// --- State 1: doing_action — register immediately via helper.
+$reset();
+$state->doing = true;
+$state->did   = 0;
+\DataMachine\Abilities\AbilityCategories::ensure_registered();
+$assert(
+	'state 1: when doing_action fires, categories register immediately via wp_register_ability_category()',
+	isset( $state->registered['datamachine-publishing'] )
+		&& isset( $state->registered['datamachine-fetch'] )
+		&& isset( $state->registered['datamachine-analytics'] )
+		&& empty( $state->hooked )
+);
+
+// --- State 2: pre-action — hook for later.
+$reset();
+$state->doing = false;
+$state->did   = 0;
+\DataMachine\Abilities\AbilityCategories::ensure_registered();
+$assert(
+	'state 2: when action has not fired, register() is hooked on wp_abilities_api_categories_init',
+	isset( $state->hooked['wp_abilities_api_categories_init'] )
+		&& count( $state->hooked['wp_abilities_api_categories_init'] ) === 1
+		&& empty( $state->registered )
+);
+
+// --- State 3: post-action — register directly via registry instance.
+//
+// This is the #2287 scenario: the abilities registry was instantiated by a
+// frontend `wp_get_ability()` call (e.g. Frontend Agent Chat enqueue) before
+// Data Machine's hook was attached. Without the recovery path, every
+// `wp_register_ability( ..., [ 'category' => 'datamachine-publishing' ] )`
+// in extension plugins triggers a `_doing_it_wrong` notice and the ability
+// is dropped from the registry.
+$reset();
+$state->doing = false;
+$state->did   = 1; // action has fired and completed
+\DataMachine\Abilities\AbilityCategories::ensure_registered();
+$registry = WP_Ability_Categories_Registry::get_instance();
+$assert(
+	'state 3 (regression for #2287): when action already fired, categories register directly via registry instance',
+	$registry instanceof WP_Ability_Categories_Registry
+		&& $registry->is_registered( 'datamachine-publishing' )
+		&& $registry->is_registered( 'datamachine-fetch' )
+		&& $registry->is_registered( 'datamachine-analytics' )
+		&& $registry->is_registered( 'datamachine-media' )
+);
+
+$assert(
+	'state 3: recovery path does not call wp_register_ability_category() (which would fire _doing_it_wrong)',
+	0 === ( $state->doing_it_wrong ?? 0 )
+);
+
+$assert(
+	'state 3: recovery path does not double-hook the action',
+	empty( $state->hooked )
+);
+
+// --- Idempotency: a second call after success is a no-op.
+$prior = $state->registered;
+\DataMachine\Abilities\AbilityCategories::ensure_registered();
+$assert(
+	'idempotent: second ensure_registered() call is a no-op (static guard)',
+	$state->registered === $prior
+);
+
+if ( $failed > 0 ) {
+	fwrite( STDERR, "\nabilities-categories-load-order-smoke: {$failed}/{$total} assertions failed\n" );
+	exit( 1 );
+}
+
+echo "\nAll {$total} abilities-categories-load-order assertions passed.\n";


### PR DESCRIPTION
Closes #2287.

## Summary

Data Machine ability categories (`datamachine-publishing`, `datamachine-fetch`, `datamachine-analytics`, …) are a contract that every extension plugin (`data-machine-business`, `data-machine-socials`, …) and downstream consumer registers abilities against. They were only registered from inside `datamachine_run_datamachine_plugin()`, which is gated by `datamachine_should_load_full_runtime()`. On lite frontend page views (non-admin, non-REST, non-AJAX, non-cron requests on multisite subsites) the gate returned false and the categories never registered. Extension plugins do **not** honour that gate — they instantiate their ability classes at `plugins_loaded:20` unconditionally — and the abilities API registry can still be lazily instantiated on the request (e.g. Frontend Agent Chat calling `wp_get_ability()` during `wp_enqueue_scripts`). With categories missing, every extension call to `wp_register_ability( ..., [ 'category' => 'datamachine-*' ] )` triggered a `_doing_it_wrong` notice and the ability was silently dropped.

This commit lifts category registration **out of the runtime gate** and adopts the three-state defensive pattern that block-format-bridge and `data-machine-events` already use.

## Root cause walkthrough

Confirmed via a temporary mu-plugin trace on `artist.extrachill.com` (multisite subsite, lite frontend `/` request):

```
wp_abilities_api_categories_init FIRING. bt=… wp_enqueue_scripts,
  frontend_agent_chat_enqueue, frontend_agent_chat_list_accessible_agents,
  frontend_agent_chat_execute_ability, frontend_agent_chat_get_required_ability,
  wp_get_ability, WP_Abilities_Registry::get_instance,
  WP_Ability_Categories_Registry::get_instance,
  do_action('wp_abilities_api_categories_init')

cat registry contents post-fire: site,user,agents-api,extrachill-…,
  block-format-bridge, extrachill-multisite, …, datamachine-events-*
```

Notice what's **missing** from the registry contents: every `datamachine-*` category. The hook for them was never attached because `datamachine_should_load_full_runtime()` returned false on the lite frontend request, so `datamachine_run_datamachine_plugin()` (and therefore `AbilityCategories::ensure_registered()`) never ran.

The downstream effect is the notice flood reported in #2287 plus silent registry drops for abilities like `datamachine/send-email`, `datamachine/post-message-slack`, `datamachine/fetch-googlesheets`, etc.

## Fix

`data-machine.php`
- Add an unconditional `AbilityCategories::ensure_registered()` call at file include time, *outside* `datamachine_run_datamachine_plugin()`. Categories are ~20 cheap string registrations — no reason to gate them. A doc block explains why this MUST NOT live inside the runtime gate.
- Keep the in-runtime call as a defensive idempotent path for `plugin_sandbox_scrape()`-style late inclusion (activation). The static guard makes it a no-op.

`inc/Abilities/AbilityCategories.php`
- Extract category definitions to a private `get_category_definitions()` helper so both the standard hook path (`register()`) and the late-fire recovery path read from a single source of truth.
- Reimplement `ensure_registered()` with the three-state defensive pattern:
  1. `doing_action( wp_abilities_api_categories_init )` → register immediately via `wp_register_ability_category()`.
  2. `! did_action( wp_abilities_api_categories_init )` → attach `register()` to the hook for the lazy fire.
  3. otherwise (action already fired and completed) → register directly via `WP_Ability_Categories_Registry::get_instance()->register()`. The public helper enforces `doing_action()` but the underlying registry method does not, so this path is safe and correct.

This mirrors `vendor/chubes4/block-format-bridge/includes/abilities.php` lines 216-219 (referenced in the issue) and the matching pattern in `extrachill-events`/`data-machine-events`.

## Tests

`tests/abilities-categories-load-order-smoke.php` (new) — 14 assertions covering source-string contracts and behavioural simulation of all three timing states, including a stub for the `WP_Ability_Categories_Registry` singleton so the action-already-fired recovery path can be exercised without a full WP bootstrap.

```
$ php tests/abilities-categories-load-order-smoke.php
  PASS: data-machine.php calls ensure_registered() unconditionally at file load
  PASS: unconditional call site is OUTSIDE datamachine_run_datamachine_plugin()
  PASS: in-runtime call is still present (defensive idempotent path)
  PASS: ensure_registered() handles doing_action state
  PASS: ensure_registered() handles pre-action state
  PASS: ensure_registered() handles post-action state via registry instance
  PASS: post-action recovery path is idempotent (skips already-registered slugs)
  PASS: category definitions extracted into shared helper to avoid drift
  PASS: state 1: when doing_action fires, categories register immediately via wp_register_ability_category()
  PASS: state 2: when action has not fired, register() is hooked on wp_abilities_api_categories_init
  PASS: state 3 (regression for #2287): when action already fired, categories register directly via registry instance
  PASS: state 3: recovery path does not call wp_register_ability_category() (which would fire _doing_it_wrong)
  PASS: state 3: recovery path does not double-hook the action
  PASS: idempotent: second ensure_registered() call is a no-op (static guard)

All 14 abilities-categories-load-order assertions passed.
```

Existing neighbouring smokes still pass:
- `tests/frontend-runtime-gate-smoke.php` — 10/10
- `tests/late-plugins-loaded-runtime-smoke.php` — 4/4

`homeboy lint --path . --extension wordpress` reports no new findings introduced by this change (existing baseline warnings in `inc/Abilities/Job/RecoverStuckJobsAbility.php` are untouched).

## Verification steps for the operator

After this PR lands and a release is cut + deployed via `homeboy release` / `homeboy deploy`:

1. Clear the debug log: `: > /var/www/extrachill.com/wp-content/debug.log`
2. Hit a multisite subsite frontend a few times: `for i in 1 2 3; do curl -sS -o /dev/null https://artist.extrachill.com/; curl -sS -o /dev/null https://artist.extrachill.com/wp-json/; done`
3. Tail the log: `grep -c 'is not registered' /var/www/extrachill.com/wp-content/debug.log` — expected **0**.
4. Confirm previously-broken abilities resolve at request time. From WP-CLI on the subsite: `wp --url=artist.extrachill.com eval 'var_dump( wp_has_ability( "datamachine/send-email" ), wp_has_ability( "datamachine/post-message-slack" ) );'` — both `bool(true)`.

(I locally swapped the patched files onto the running site briefly to confirm the notice flood stops at 0; production has been restored to the deployed `v0.132.4` artifact and is healthy.)

## Out of scope (follow-ups)

- The `datamachine/render-image-template` "not found" notices in the same log slice are a different symptom: the ability **class** itself lives behind the runtime gate (instantiated inside `datamachine_run_datamachine_plugin()`), so on lite frontend requests it isn't registered. The root cause is the same gate, but the fix shape (hoisting many ability class instantiations) is meaningfully broader than this PR's scope. Tracked separately — recommend a follow-up issue if it persists in production after this lands.
- Sibling incident issues: `Extra-Chill/extrachill-events#124`, `Extra-Chill/extrachill-users#56`.

## Constraints honoured

- Conventional commit prefix: `fix(abilities):`
- `CHANGELOG.md` untouched (homeboy generates from conventional commits)
- Version strings untouched
- Layer-pure: data-machine core only; no extension plugin references; no vendor-specific code
- Branch only; **no release, no deploy** — that's your call, @chubes

mention <@532385681268408341> when ready for review.