### PR TITLE
Expose generic content format conversion filter

### DIFF
--- a/inc/Core/Content/ContentFormat.php
+++ b/inc/Core/Content/ContentFormat.php
@@ -11,6 +11,34 @@ defined( 'ABSPATH' ) || exit;
 
 class ContentFormat {
 
+	/**
+	 * Register generic content-format conversion filters.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		add_filter( 'datamachine_content_format_convert', array( self::class, 'convertFilter' ), 10, 5 );
+	}
+
+	/**
+	 * Filter callback for generic content-format conversion requests.
+	 *
+	 * @param  mixed  $converted Existing conversion result from earlier filters.
+	 * @param  string $content   Source content.
+	 * @param  string $from      Source format slug.
+	 * @param  string $to        Target format slug.
+	 * @param  array  $context   Optional conversion context.
+	 * @return string|\WP_Error|null Converted content, error, or null.
+	 */
+	public static function convertFilter( $converted, string $content, string $from, string $to, array $context = array() ) {
+		unset( $context );
+
+		if ( is_string( $converted ) || is_wp_error( $converted ) ) {
+			return $converted;
+		}
+
+		return self::convertWithBfb( $content, $from, $to );
+	}
 
 	/**
 	 * Return the canonical storage format for a post type.
@@ -32,7 +60,24 @@ class ContentFormat {
 	 * @param  string $to      Target format slug.
 	 * @return string|\WP_Error Converted content or error.
 	 */
-	public static function convert( string $content, string $from, string $to ) {
+	public static function convert( string $content, string $from, string $to, array $context = array() ) {
+		$filtered = apply_filters( 'datamachine_content_format_convert', null, $content, $from, $to, $context );
+		if ( is_string( $filtered ) || is_wp_error( $filtered ) ) {
+			return $filtered;
+		}
+
+		return self::convertWithBfb( $content, $from, $to );
+	}
+
+	/**
+	 * Convert content through Block Format Bridge.
+	 *
+	 * @param  string $content Source content.
+	 * @param  string $from    Source format slug.
+	 * @param  string $to      Target format slug.
+	 * @return string|\WP_Error Converted content or error.
+	 */
+	private static function convertWithBfb( string $content, string $from, string $to ) {
 		$from = sanitize_key( $from );
 		$to   = sanitize_key( $to );
 

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -71,12 +71,14 @@ use DataMachine\Engine\AI\IterationBudgetRegistry;
 use DataMachine\Engine\AI\WpAiClientCache;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
+use DataMachine\Core\Content\ContentFormat;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Auth\AgentAccessStoreAdapter;
 use DataMachine\Core\OAuth\HttpBasicAuthProvider;
 use DataMachine\Core\PluginSettings;
 
 add_action( 'plugins_loaded', array( WpAiClientCache::class, 'install' ), 20 );
+ContentFormat::register();
 
 add_filter(
 	'datamachine_auth_providers',

--- a/tests/content-format-convert-filter-smoke.php
+++ b/tests/content-format-convert-filter-smoke.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Pure-PHP smoke test for the generic content-format conversion filter.
+ *
+ * Run with: php tests/content-format-convert-filter-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failed = 0;
+$total  = 0;
+
+function assert_content_format_filter( string $name, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$name}\n";
+		return;
+	}
+
+	echo "  FAIL: {$name}\n";
+	++$failed;
+}
+
+$GLOBALS['__content_format_filter_hooks'] = array();
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	$GLOBALS['__content_format_filter_hooks'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+}
+
+function apply_filters( string $hook, $value, ...$args ) {
+	if ( empty( $GLOBALS['__content_format_filter_hooks'][ $hook ] ) ) {
+		return $value;
+	}
+
+	ksort( $GLOBALS['__content_format_filter_hooks'][ $hook ] );
+	foreach ( $GLOBALS['__content_format_filter_hooks'][ $hook ] as $callbacks ) {
+		foreach ( $callbacks as $registered_callback ) {
+			list( $callback, $accepted_args ) = $registered_callback;
+			$value                            = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+		}
+	}
+
+	return $value;
+}
+
+function sanitize_key( $key ): string {
+	return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $key ) );
+}
+
+function is_wp_error( $thing ): bool {
+	return $thing instanceof WP_Error;
+}
+
+function bfb_convert( string $content, string $from, string $to ) {
+	return "[{$from}:{$to}]{$content}";
+}
+
+class WP_Error {
+}
+
+require_once dirname( __DIR__ ) . '/inc/Core/Content/ContentFormat.php';
+
+use DataMachine\Core\Content\ContentFormat;
+
+ContentFormat::register();
+
+$filtered = apply_filters(
+	'datamachine_content_format_convert',
+	null,
+	'# Hello',
+	'markdown',
+	'blocks',
+	array( 'post_type' => 'page' )
+);
+
+assert_content_format_filter( 'generic-filter-converts-with-bfb', '[markdown:blocks]# Hello' === $filtered );
+
+add_filter(
+	'datamachine_content_format_convert',
+	static function ( $converted, string $content, string $from, string $to ): string {
+		unset( $converted, $content, $from, $to );
+		return 'custom-conversion';
+	},
+	5,
+	4
+);
+
+$custom = ContentFormat::convert( '# Custom', 'markdown', 'blocks' );
+assert_content_format_filter( 'earlier-filter-can-override-default-conversion', 'custom-conversion' === $custom );
+
+echo "\nContent format conversion filter smoke: {$total} assertions, {$failed} failures.\n";
+
+exit( min( 1, $failed ) );


### PR DESCRIPTION
## Summary
- adds a generic `datamachine_content_format_convert` filter backed by Data Machine's bundled Block Format Bridge
- routes `ContentFormat::convert()` through the same filter while preserving existing fallback behavior
- adds a pure PHP smoke test for default conversion and override behavior

## Testing
- `php tests/content-format-convert-filter-smoke.php`
- `php tests/content-format-helper-smoke.php`
- `php tests/wordpress-publish-content-format-smoke.php`
- `php tests/content-format-abilities-smoke.php`
- `vendor/bin/phpcs inc/Core/Content/ContentFormat.php tests/content-format-convert-filter-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic content-format filter implementation and smoke test; Chris reviewed the architecture boundary and corrected the integration direction.
