### PR TITLE
Fix worker memory floor and fatal lock cleanup

### DIFF
--- a/inc/Cli/Commands/DrainCommand.php
+++ b/inc/Cli/Commands/DrainCommand.php
@@ -108,6 +108,8 @@ class DrainCommand extends BaseCommand {
 	 * @return array<string,int|string> Drain stats.
 	 */
 	public static function drain( array $options = array() ): array {
+		self::ensureCliMemoryLimit();
+
 		$limit               = max( 0, (int) ( $options['limit'] ?? 0 ) );
 		$batch_size          = max( 1, (int) ( $options['batch_size'] ?? 25 ) );
 		$time_limit          = max( 0, (int) ( $options['time_limit'] ?? 0 ) );
@@ -123,6 +125,13 @@ class DrainCommand extends BaseCommand {
 			if ( empty( $lock['acquired'] ) ) {
 				return self::lockedStats( $hooks, $job_ids, $lock );
 			}
+
+			$lock_token = (string) ( $lock['lock_token'] ?? '' );
+			register_shutdown_function(
+				static function () use ( $lock_token ): void {
+					WorkerLock::release( $lock_token );
+				}
+			);
 		}
 
 		$started_at    = time();
@@ -254,6 +263,28 @@ class DrainCommand extends BaseCommand {
 			),
 			$lock
 		);
+	}
+
+	/**
+	 * Raise the CLI memory floor for large Action Scheduler drains.
+	 */
+	public static function ensureCliMemoryLimit( int $minimum_bytes = 1073741824 ): void {
+		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+			return;
+		}
+
+		$current = self::memoryLimitBytes();
+		if ( 0 === $current || $current >= $minimum_bytes ) {
+			return;
+		}
+
+		add_filter(
+			'admin_memory_limit',
+			static function () use ( $minimum_bytes ): string {
+				return (string) $minimum_bytes;
+			}
+		);
+		wp_raise_memory_limit( 'admin' );
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkerCommand.php
+++ b/inc/Cli/Commands/WorkerCommand.php
@@ -173,6 +173,8 @@ class WorkerCommand extends BaseCommand {
 	 * @return array<string,int|string> Worker stats.
 	 */
 	public static function runLoop( array $options ): array {
+		DrainCommand::ensureCliMemoryLimit();
+
 		$started_at              = time();
 		$time_limit              = max( 0, (int) ( $options['time_limit'] ?? 300 ) );
 		$batch_size              = max( 1, (int) ( $options['batch_size'] ?? 10 ) );
@@ -190,6 +192,13 @@ class WorkerCommand extends BaseCommand {
 		if ( empty( $lock['acquired'] ) ) {
 			return self::lockedStats( $lock );
 		}
+
+		$lock_token = (string) ( $lock['lock_token'] ?? '' );
+		register_shutdown_function(
+			static function () use ( $lock_token ): void {
+				WorkerLock::release( $lock_token );
+			}
+		);
 
 		$passes      = 0;
 		$recoveries  = 0;

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -44,6 +44,7 @@ assert_drain_contains( '[--stop-before-timeout=<seconds>]', $drain_src, 'drain d
 assert_drain_contains( "'stop_before_timeout'", $drain_src, 'drain accepts worker-style timeout safety margin option' );
 assert_drain_contains( 'WorkerLock::acquire', $drain_src, 'drain acquires shared worker/drain lock' );
 assert_drain_contains( 'WorkerLock::release', $drain_src, 'drain releases shared worker/drain lock' );
+assert_drain_contains( 'register_shutdown_function', $drain_src, 'drain releases locks during PHP shutdown after fatals' );
 assert_drain_contains( "'stop_reason'                => 'locked'", $drain_src, 'drain exits cleanly when lock is held' );
 assert_drain_contains( 'lock_age_seconds', $drain_src, 'drain reports lock age' );
 assert_drain_contains( 'lock_owner', $drain_src, 'drain reports lock owner' );
@@ -63,6 +64,7 @@ assert_drain_contains( "'Data Machine CLI drain'", $drain_src, 'drain records a 
 assert_drain_contains( 'catch ( \\Throwable $throwable )', $drain_src, 'drain catches per-action runner failures instead of fataling after job start' );
 assert_drain_contains( 'flushRuntimeCache()', $drain_src, 'drain flushes runtime cache after processing actions' );
 assert_drain_contains( 'isMemorySoftLimitReached()', $drain_src, 'drain stops before hard PHP memory exhaustion' );
+assert_drain_contains( 'ensureCliMemoryLimit()', $drain_src, 'drain raises the CLI memory floor before processing large batches' );
 assert_drain_contains( "'memory_limit'", $drain_src, 'drain reports memory-limit stop reason' );
 assert_drain_contains( "'return_code' => empty( \$warnings ) ? 0 : 1", $drain_src, 'drain surfaces runner failures through a result object' );
 assert_drain_contains( "'remaining_pending'", $drain_src, 'drain reports remaining pending actions' );

--- a/tests/worker-cli-smoke.php
+++ b/tests/worker-cli-smoke.php
@@ -37,8 +37,10 @@ assert_worker_contains( '@subcommand run', $worker_src, 'worker exposes run subc
 assert_worker_contains( '@subcommand status', $worker_src, 'worker exposes status subcommand' );
 assert_worker_contains( 'WorkerLock::acquire', $worker_src, 'worker acquires shared worker/drain lock' );
 assert_worker_contains( 'WorkerLock::release', $worker_src, 'worker releases shared worker/drain lock' );
+assert_worker_contains( 'register_shutdown_function', $worker_src, 'worker releases locks during PHP shutdown after fatals' );
 assert_worker_contains( 'RecoverStuckJobsAbility', $worker_src, 'worker composes stuck job recovery ability' );
 assert_worker_contains( 'DrainCommand::drain(', $worker_src, 'worker composes the existing drain loop' );
+assert_worker_contains( 'DrainCommand::ensureCliMemoryLimit()', $worker_src, 'worker raises the CLI memory floor before draining' );
 assert_worker_contains( "'acquire_lock' => false", $worker_src, 'worker internal drain does not fight outer lock' );
 assert_worker_contains( 'PendingActionStore::summary', $worker_src, 'worker reads pending-action gate through the store' );
 assert_worker_contains( 'JobsSummaryAbility', $worker_src, 'worker reads job status through the existing summary ability' );


### PR DESCRIPTION
## Summary
- raise the WP-CLI memory floor before large worker/drain batches using WordPress' memory-limit API
- release worker/drain locks from shutdown handlers so fatal exits do not leave stale locks behind
- extend worker/drain smoke coverage for memory and shutdown cleanup paths

## Testing
- `php tests/flow-run-cli-drain-smoke.php`
- `php tests/worker-cli-smoke.php`
- `php -l inc/Cli/Commands/DrainCommand.php`
- `php -l inc/Cli/Commands/WorkerCommand.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-drain-batch-deadline --extension wordpress --changed-since origin/main --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the small worker/drain hardening patch and ran local validation; Chris remains responsible for review and merge.