### PR TITLE
Parse XML tool calls from text responses

### DIFF
--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1480,7 +1480,10 @@ function datamachine_extract_xml_tool_calls( string $text ): array {
 					continue;
 				}
 
-				$parameters[ $parameter_name ] = html_entity_decode( trim( strip_tags( (string) $parameter_match[2] ) ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+				$parameter_value = function_exists( '\wp_strip_all_tags' )
+					? \wp_strip_all_tags( (string) $parameter_match[2] )
+					: (string) preg_replace( '/<[^>]*>/', '', (string) $parameter_match[2] );
+				$parameters[ $parameter_name ] = html_entity_decode( trim( $parameter_value ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
 			}
 		}
 

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1480,7 +1480,7 @@ function datamachine_extract_xml_tool_calls( string $text ): array {
 					continue;
 				}
 
-				$parameter_value = function_exists( '\wp_strip_all_tags' )
+				$parameter_value          = function_exists( '\wp_strip_all_tags' )
 					? \wp_strip_all_tags( (string) $parameter_match[2] )
 					: (string) preg_replace( '/<[^>]*>/', '', (string) $parameter_match[2] );
 				$parameters[ $parameter_name ] = html_entity_decode( trim( $parameter_value ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1436,6 +1436,61 @@ function datamachine_extract_tool_calls( $result ): array {
 		);
 	}
 
+	if ( empty( $tool_calls ) ) {
+		foreach ( $candidates[0]->getMessage()->getParts() as $part ) {
+			if ( ! method_exists( $part, 'getText' ) ) {
+				continue;
+			}
+
+			$text = $part->getText();
+			if ( ! is_string( $text ) || '' === trim( $text ) ) {
+				continue;
+			}
+
+			$tool_calls = array_merge( $tool_calls, datamachine_extract_xml_tool_calls( $text ) );
+		}
+	}
+
+	return $tool_calls;
+}
+
+/**
+ * Extract XML-style tool calls emitted as plain text by some providers/models.
+ *
+ * @param string $text Text candidate content.
+ * @return array<int, array{name:string,parameters:array,id:mixed}>
+ */
+function datamachine_extract_xml_tool_calls( string $text ): array {
+	if ( ! str_contains( $text, '<function_calls>' ) || ! preg_match_all( '/<invoke\s+name=["\']([^"\']+)["\']\s*>(.*?)<\/invoke>/is', $text, $matches, PREG_SET_ORDER ) ) {
+		return array();
+	}
+
+	$tool_calls = array();
+	foreach ( $matches as $index => $match ) {
+		$name = sanitize_key( (string) $match[1] );
+		if ( '' === $name ) {
+			continue;
+		}
+
+		$parameters = array();
+		if ( preg_match_all( '/<parameter\s+name=["\']([^"\']+)["\']\s*>(.*?)<\/parameter>/is', (string) $match[2], $parameter_matches, PREG_SET_ORDER ) ) {
+			foreach ( $parameter_matches as $parameter_match ) {
+				$parameter_name = sanitize_key( (string) $parameter_match[1] );
+				if ( '' === $parameter_name ) {
+					continue;
+				}
+
+				$parameters[ $parameter_name ] = html_entity_decode( trim( strip_tags( (string) $parameter_match[2] ) ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+			}
+		}
+
+		$tool_calls[] = array(
+			'name'       => $name,
+			'parameters' => $parameters,
+			'id'         => 'xml-tool-call-' . ( $index + 1 ),
+		);
+	}
+
 	return $tool_calls;
 }
 

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -367,6 +367,62 @@ assert_runner_request( array( 'path' => 'README.md' ) === ( $sandbox_result['too
 assert_runner_request( 1 === count( $sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline function call executes a workspace tool' );
 assert_runner_request( 'README.md' === ( $sandbox_result['tool_execution_results'][0]['result']['path'] ?? null ), 'sandbox/pipeline tool execution receives parsed parameters' );
 
+// 4b. Sandbox/pipeline runs also execute XML tool calls emitted as text.
+$xml_dispatch_count = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$xml_dispatch_count ) {
+		++$xml_dispatch_count;
+
+		if ( 1 === $xml_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content' => 'I will inspect first.' . "\n\n" . '<function_calls><invoke name="workspace_read"><parameter name="path">README.md</parameter></invoke></function_calls>',
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content' => 'xml sandbox tool complete',
+			),
+		);
+	}
+);
+
+$xml_sandbox_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'read the sandbox README using XML tool syntax' ) ),
+	array(
+		'workspace_read' => array(
+			'name'        => 'workspace_read',
+			'description' => 'Read a file from the sandbox workspace.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(
+					'path' => array( 'type' => 'string' ),
+				),
+				'required'   => array( 'path' ),
+			),
+			'class'       => SandboxPipelineSmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	array( 'sandbox', 'pipeline' ),
+	array(),
+	3
+);
+
+assert_runner_request( 2 === $xml_dispatch_count, 'sandbox/pipeline XML tool call returns to provider for final answer' );
+assert_runner_request( 'xml sandbox tool complete' === ( $xml_sandbox_result['final_content'] ?? null ), 'sandbox/pipeline XML tool call preserves final answer' );
+assert_runner_request( 1 === count( $xml_sandbox_result['tool_calls'] ?? array() ), 'sandbox/pipeline XML tool call is parsed' );
+assert_runner_request( 'workspace_read' === ( $xml_sandbox_result['tool_calls'][0]['name'] ?? null ), 'sandbox/pipeline XML tool name is parsed' );
+assert_runner_request( array( 'path' => 'README.md' ) === ( $xml_sandbox_result['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline XML tool parameters are parsed' );
+assert_runner_request( 1 === count( $xml_sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline XML tool call executes a workspace tool' );
+
 // 5. Client runtime tools are fulfilled by the transport callback, not PHP ToolExecutor.
 $runtime_dispatch_count = 0;
 $runtime_requests       = array();


### PR DESCRIPTION
## Summary
- Parse XML-style <function_calls>/<invoke> tool calls when a provider returns them as text instead of native FunctionCall DTOs.
- Preserve native tool-call extraction priority and use the XML fallback only when no native calls are present.
- Add sandbox/pipeline smoke coverage proving XML tool calls execute and return to the provider for a final answer.

## Tests
- php tests/agent-conversation-runner-request-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated WP Codebox sandbox transcripts showing text-form tool calls, drafted the fallback parser and smoke coverage, and ran local verification.

Fixes https://github.com/Extra-Chill/data-machine/issues/2309