### PR TITLE
Preserve generic tool trace metadata

### DIFF
--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -57,6 +57,7 @@ class JobArtifacts {
 			'required_tool_names'    => $this->tool_names_from_assertions( $engine_data['completion_assertions_required'] ?? array() ),
 			'satisfied_tool_names'   => $this->tool_names_from_assertions( $engine_data['completion_assertions_satisfied'] ?? array() ),
 			'successful_tool_calls'  => $tool_calls,
+			'tool_trace'            => $this->tool_trace( $engine_data, $additional_tool_summaries ),
 			'transcript'             => $this->transcript_metadata( $job_id, $engine_data ),
 			'agent_memory_artifacts' => $this->agent_memory_artifacts( $job, $agent, $tool_calls ),
 			'daily_memory_artifacts' => $this->daily_memory_artifacts( $job, $agent, $tool_calls ),
@@ -127,6 +128,25 @@ class JobArtifacts {
 		}
 
 		return $successes;
+	}
+
+	/**
+	 * Return generic redacted tool trace entries for all tool executions.
+	 *
+	 * @param array $engine_data               Job engine data.
+	 * @param array $additional_tool_summaries In-flight summaries supplied by a running loop.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function tool_trace( array $engine_data, array $additional_tool_summaries ): array {
+		$trace     = array();
+		$summaries = is_array( $engine_data['tool_execution_summary'] ?? null ) ? $engine_data['tool_execution_summary'] : array();
+		foreach ( array_merge( $summaries, $additional_tool_summaries ) as $summary ) {
+			if ( is_array( $summary ) && is_array( $summary['trace'] ?? null ) ) {
+				$trace[] = $summary['trace'];
+			}
+		}
+
+		return $trace;
 	}
 
 	/**

--- a/inc/Engine/AI/RuntimeProvenance.php
+++ b/inc/Engine/AI/RuntimeProvenance.php
@@ -97,6 +97,11 @@ class RuntimeProvenance {
 			$provenance['tool_audit_events'] = $result['tool_audit_events'];
 		}
 
+		$tool_trace = self::tool_trace( $result );
+		if ( ! empty( $tool_trace ) ) {
+			$provenance['tool_trace'] = $tool_trace;
+		}
+
 		return $provenance;
 	}
 
@@ -171,5 +176,17 @@ class RuntimeProvenance {
 			),
 			static fn( $value ) => null !== $value && array() !== $value
 		);
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private static function tool_trace( array $result ): array {
+		$trace = array();
+		foreach ( $result['tool_execution_results'] ?? array() as $tool_result ) {
+			if ( is_array( $tool_result ) && is_array( $tool_result['trace'] ?? null ) ) {
+				$trace[] = $tool_result['trace'];
+			}
+		}
+
+		return $trace;
 	}
 }

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -521,6 +521,7 @@ function datamachine_build_turn_runner(
 			foreach ( $tool_calls as $tool_call ) {
 				$tool_name       = $tool_call['name'];
 				$tool_parameters = $tool_call['parameters'];
+				$tool_started_at  = microtime( true );
 
 				if ( empty( $tool_name ) ) {
 					do_action(
@@ -630,6 +631,7 @@ function datamachine_build_turn_runner(
 				}
 
 				if ( ! empty( $tool_result['pending'] ) && is_array( $tool_result['runtime_tool_request'] ?? null ) ) {
+					$tool_trace            = datamachine_build_tool_trace( $tool_name, $tool_call, $tool_parameters, $tool_result, is_array( $tool_def ) ? $tool_def : null, $turn_count, $tool_started_at, microtime( true ) );
 					$runtime_tool_pending     = true;
 					$runtime_pending_turn     = true;
 					$conversation_complete    = true;
@@ -640,6 +642,7 @@ function datamachine_build_turn_runner(
 						'parameters'      => $tool_parameters,
 						'is_handler_tool' => false,
 						'runtime'         => datamachine_tool_runtime_metadata( is_array( $tool_def ) ? $tool_def : null, $tool_result ),
+						'trace'           => $tool_trace,
 						'turn_count'      => $turn_count,
 					);
 					$all_tool_results[]       = $tool_execution_results[ count( $tool_execution_results ) - 1 ];
@@ -688,12 +691,14 @@ function datamachine_build_turn_runner(
 					);
 				}
 
+				$tool_trace               = datamachine_build_tool_trace( $tool_name, $tool_call, $tool_parameters, $tool_result, is_array( $tool_def ) ? $tool_def : null, $turn_count, $tool_started_at, microtime( true ) );
 				$tool_execution_results[] = array(
 					'tool_name'       => $tool_name,
 					'result'          => $tool_result,
 					'parameters'      => $tool_parameters,
 					'is_handler_tool' => $is_handler_tool,
 					'runtime'         => datamachine_tool_runtime_metadata( is_array( $tool_def ) ? $tool_def : null, $tool_result ),
+					'trace'           => $tool_trace,
 					'turn_count'      => $turn_count,
 				);
 				$all_tool_results[]       = $tool_execution_results[ count( $tool_execution_results ) - 1 ];
@@ -1568,6 +1573,130 @@ function datamachine_payload_with_inflight_run_artifacts( array $payload, array 
 }
 
 /**
+ * Build a generic, redacted trace entry for an executed tool call.
+ *
+ * The trace intentionally describes Data Machine execution mechanics only:
+ * tool identity, bounded/redacted arguments, result status, output summary,
+ * optional artifact references, timing, actor/source, and caller-supplied
+ * execution metadata. Eval consumers can project this into their own schemas
+ * without Data Machine adopting benchmark- or grader-specific semantics.
+ *
+ * @param string     $tool_name       Tool name.
+ * @param array      $tool_call       Normalized model tool call.
+ * @param array      $tool_parameters Tool arguments.
+ * @param array      $tool_result     Tool result envelope.
+ * @param array|null $tool_def        Tool definition.
+ * @param int        $turn_count      Conversation turn count.
+ * @param float      $started_at      Unix timestamp with microseconds.
+ * @param float      $ended_at        Unix timestamp with microseconds.
+ * @return array<string,mixed>
+ */
+function datamachine_build_tool_trace( string $tool_name, array $tool_call, array $tool_parameters, array $tool_result, ?array $tool_def, int $turn_count, float $started_at, float $ended_at ): array {
+	$metadata           = datamachine_tool_trace_metadata( $tool_result );
+	$redacted_arguments = datamachine_redact_tool_trace_value( $tool_parameters );
+	$arguments_json     = wp_json_encode( $tool_parameters, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+	$result_json        = wp_json_encode( $tool_result, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+	$duration_ms        = max( 0, (int) round( ( $ended_at - $started_at ) * 1000 ) );
+
+	$trace = array(
+		'schema_version'   => 1,
+		'tool_name'        => sanitize_key( $tool_name ),
+		'tool_call_id'     => isset( $tool_call['id'] ) ? sanitize_text_field( (string) $tool_call['id'] ) : null,
+		'turn_count'       => $turn_count,
+		'actor'            => datamachine_normalize_tool_trace_actor( $metadata['actor'] ?? ( $tool_def['trace_actor'] ?? 'agent' ) ),
+		'source'           => sanitize_key( (string) ( $metadata['source'] ?? ( $tool_def['trace_source'] ?? 'data_machine' ) ) ),
+		'status'           => datamachine_tool_trace_status( $tool_result ),
+		'started_at'       => gmdate( 'c', (int) floor( $started_at ) ),
+		'ended_at'         => gmdate( 'c', (int) floor( $ended_at ) ),
+		'duration_ms'      => $duration_ms,
+		'arguments_sha256' => hash( 'sha256', (string) $arguments_json ),
+		'result_sha256'    => hash( 'sha256', (string) $result_json ),
+		'output_summary'   => datamachine_tool_trace_output_summary( $tool_result ),
+		'artifact_refs'    => datamachine_tool_trace_artifact_refs( $tool_result, $metadata ),
+		'metadata'         => datamachine_redact_tool_trace_value( $metadata ),
+	);
+
+	$redacted_arguments_json = wp_json_encode( $redacted_arguments, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+	if ( strlen( (string) $redacted_arguments_json ) <= 2000 ) {
+		$trace['arguments_redacted'] = $redacted_arguments;
+	} else {
+		$trace['arguments_omitted'] = 'redacted_arguments_too_large';
+	}
+
+	return array_filter(
+		$trace,
+		static fn( $value ) => null !== $value && '' !== $value && array() !== $value
+	);
+}
+
+/** @return array<string,mixed> */
+function datamachine_tool_trace_metadata( array $tool_result ): array {
+	$execution_metadata = is_array( $tool_result['execution_metadata'] ?? null ) ? $tool_result['execution_metadata'] : array();
+	$trace_metadata     = is_array( $tool_result['trace_metadata'] ?? null ) ? $tool_result['trace_metadata'] : array();
+
+	return array_merge( $execution_metadata, $trace_metadata );
+}
+
+function datamachine_normalize_tool_trace_actor( mixed $actor ): string {
+	$actor = sanitize_key( (string) $actor );
+	return in_array( $actor, array( 'agent', 'system', 'grader', 'user' ), true ) ? $actor : 'agent';
+}
+
+function datamachine_tool_trace_status( array $tool_result ): string {
+	if ( ! empty( $tool_result['pending'] ) ) {
+		return 'pending';
+	}
+
+	return true === ( $tool_result['success'] ?? false ) ? 'success' : 'failed';
+}
+
+function datamachine_tool_trace_output_summary( array $tool_result ): ?string {
+	foreach ( array( 'message', 'summary', 'error' ) as $key ) {
+		if ( isset( $tool_result[ $key ] ) && is_scalar( $tool_result[ $key ] ) ) {
+			$summary = sanitize_text_field( (string) $tool_result[ $key ] );
+			return strlen( $summary ) > 500 ? substr( $summary, 0, 497 ) . '...' : $summary;
+		}
+	}
+
+	return null;
+}
+
+/** @return array<int|string,mixed> */
+function datamachine_tool_trace_artifact_refs( array $tool_result, array $metadata ): array {
+	foreach ( array( $metadata['artifact_refs'] ?? null, $tool_result['artifact_refs'] ?? null, $tool_result['artifacts'] ?? null ) as $refs ) {
+		if ( is_array( $refs ) ) {
+			return datamachine_redact_tool_trace_value( $refs );
+		}
+	}
+
+	return array();
+}
+
+function datamachine_redact_tool_trace_value( mixed $value ): mixed {
+	if ( is_array( $value ) ) {
+		$redacted = array();
+		foreach ( $value as $key => $child ) {
+			$key_string = (string) $key;
+			if ( preg_match( '/(api[_-]?key|auth|bearer|cookie|credential|nonce|password|secret|signature|token)/i', $key_string ) ) {
+				$redacted[ $key ] = '[redacted]';
+				continue;
+			}
+			$redacted[ $key ] = datamachine_redact_tool_trace_value( $child );
+		}
+
+		return $redacted;
+	}
+
+	if ( is_string( $value ) ) {
+		$redacted = preg_replace( '/Bearer\s+[A-Za-z0-9._~+\/\-]+=*/i', 'Bearer [redacted]', $value );
+		$redacted = preg_replace( '/\b(api[_-]?key|token|secret|password)\b\s*[:=]\s*\S+/i', '$1: [redacted]', $redacted ?? $value );
+		return $redacted ?? $value;
+	}
+
+	return $value;
+}
+
+/**
  * Build a bounded, non-secret summary of in-flight tool calls.
  *
  * @param array $tool_execution_results Tool execution results accumulated by the loop.
@@ -1595,6 +1724,9 @@ function datamachine_summarize_tool_execution_results( array $tool_execution_res
 			'turn_count' => isset( $result['turn_count'] ) ? (int) $result['turn_count'] : null,
 			'summary'    => isset( $tool_result['message'] ) ? sanitize_text_field( (string) $tool_result['message'] ) : null,
 		);
+		if ( is_array( $result['trace'] ?? null ) ) {
+			$summary['trace'] = $result['trace'];
+		}
 
 		if ( 'agent_daily_memory' === $tool_name ) {
 			$summary['user_id']  = isset( $parameters['user_id'] ) ? (int) $parameters['user_id'] : null;

--- a/tests/tool-trace-metadata-smoke.php
+++ b/tests/tool-trace-metadata-smoke.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Smoke tests for generic tool trace metadata preservation.
+ *
+ * @package DataMachine\Tests
+ */
+
+require_once __DIR__ . '/bootstrap-unit.php';
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $flags = 0, int $depth = 512 ) {
+		return json_encode( $data, $flags, $depth );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ): string {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $value ): string {
+		return trim( wp_strip_all_tags( (string) $value ) );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $value ): string {
+		return strip_tags( (string) $value );
+	}
+}
+
+require_once __DIR__ . '/../inc/Engine/AI/RuntimeProvenance.php';
+require_once __DIR__ . '/../inc/Engine/AI/conversation-loop.php';
+
+use DataMachine\Engine\AI\RuntimeProvenance;
+
+function assert_tool_trace_metadata( bool $condition, string $message, array &$failures, int &$passes ): void {
+	if ( ! $condition ) {
+		$failures[] = $message;
+		return;
+	}
+	++$passes;
+}
+
+$failures = array();
+$passes   = 0;
+
+$trace = DataMachine\Engine\AI\datamachine_build_tool_trace(
+	'terminal_grader',
+	array( 'id' => 'call_123' ),
+	array(
+		'command' => 'php grader.php',
+		'token'   => 'secret-token',
+	),
+	array(
+		'success'            => true,
+		'message'            => 'Grader completed.',
+		'trace_metadata'     => array(
+			'actor'             => 'system',
+			'source'            => 'terminal',
+			'structured_output' => array( 'passed' => true, 'score' => 1 ),
+			'artifact_refs'     => array( 'stdout' => 'artifacts/stdout.txt' ),
+		),
+		'execution_metadata' => array( 'runner' => 'terminal' ),
+	),
+	array(),
+	2,
+	1000.0,
+	1000.250
+);
+
+assert_tool_trace_metadata( 'terminal_grader' === $trace['tool_name'], 'trace keeps tool name', $failures, $passes );
+assert_tool_trace_metadata( 'call_123' === $trace['tool_call_id'], 'trace keeps provider tool call id', $failures, $passes );
+assert_tool_trace_metadata( 'system' === $trace['actor'], 'trace preserves system actor distinction', $failures, $passes );
+assert_tool_trace_metadata( 'terminal' === $trace['source'], 'trace preserves generic terminal source', $failures, $passes );
+assert_tool_trace_metadata( 'success' === $trace['status'], 'trace records result status', $failures, $passes );
+assert_tool_trace_metadata( 250 === $trace['duration_ms'], 'trace records duration in milliseconds', $failures, $passes );
+assert_tool_trace_metadata( '[redacted]' === $trace['arguments_redacted']['token'], 'trace redacts secret-looking argument keys', $failures, $passes );
+assert_tool_trace_metadata( true === $trace['metadata']['structured_output']['passed'], 'trace preserves structured execution output generically', $failures, $passes );
+assert_tool_trace_metadata( 'terminal' === $trace['metadata']['runner'], 'trace preserves generic execution metadata', $failures, $passes );
+assert_tool_trace_metadata( 'artifacts/stdout.txt' === $trace['artifact_refs']['stdout'], 'trace preserves artifact refs', $failures, $passes );
+
+$summary = DataMachine\Engine\AI\datamachine_summarize_tool_execution_results(
+	array(
+		array(
+			'tool_name'  => 'terminal_grader',
+			'result'     => array( 'success' => true, 'message' => 'Grader completed.' ),
+			'parameters' => array(),
+			'trace'      => $trace,
+			'turn_count' => 2,
+		),
+	)
+);
+
+assert_tool_trace_metadata( $trace === $summary[0]['trace'], 'tool execution summary preserves trace metadata', $failures, $passes );
+
+$provenance = RuntimeProvenance::fromConversationResult(
+	array(
+		'messages'               => array(),
+		'completed'              => true,
+		'tool_execution_results' => array(
+			array(
+				'tool_name'  => 'terminal_grader',
+				'result'     => array( 'success' => true ),
+				'parameters' => array(),
+				'trace'      => $trace,
+				'turn_count' => 2,
+			),
+		),
+		'request_metadata'       => array( 'tool_policy_sha256' => 'abc123' ),
+	),
+	array(),
+	'openai',
+	'gpt-5.5',
+	array( 'pipeline' )
+);
+
+assert_tool_trace_metadata( $trace === $provenance['tool_trace'][0], 'runtime provenance exports tool trace', $failures, $passes );
+assert_tool_trace_metadata( 'abc123' === $provenance['tools']['policy_sha256'], 'runtime provenance still exposes tool policy fingerprint', $failures, $passes );
+
+if ( ! empty( $failures ) ) {
+	echo "FAILED: " . count( $failures ) . " tool trace metadata assertions failed.\n";
+	foreach ( $failures as $failure ) {
+		echo " - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "Tool trace metadata smoke passed ({$passes} assertions).\n";


### PR DESCRIPTION
## Summary
- Add a generic redacted tool trace entry to Data Machine tool execution results.
- Export tool traces through runtime provenance and job artifact payloads for eval consumers.
- Preserve caller-provided generic execution/trace metadata, artifact refs, actor/source distinction, timings, hashes, and bounded redacted arguments without adding wp-gym-specific semantics.

Fixes #2310.

## Testing
- php tests/tool-trace-metadata-smoke.php
- php tests/agent-conversation-result-smoke.php
- php tests/run-artifact-egress-policy-smoke.php
- vendor/bin/phpcs inc/Engine/AI/conversation-loop.php inc/Engine/AI/RuntimeProvenance.php inc/Core/JobArtifacts.php tests/tool-trace-metadata-smoke.php
- git diff --check

## Known blocker
- homeboy test --path /Users/chubes/Developer/data-machine@fix-generic-eval-trace-metadata --extension wordpress failed in the lab offload before tests ran because the synced lab workspace was missing vendor/autoload.php at plugin bootstrap.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and tested the generic trace preservation code and smoke coverage; Chris remains responsible for review and merge.