### PR TITLE
fix: import flow step config in pipeline helpers

### DIFF
--- a/inc/Abilities/Pipeline/PipelineHelpers.php
+++ b/inc/Abilities/Pipeline/PipelineHelpers.php
@@ -18,6 +18,7 @@ use DataMachine\Abilities\StepTypeAbilities;
 use DataMachine\Core\Admin\DateFormatter;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\WorkflowSpecValidator;
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
## Summary
- Imports `DataMachine\Core\Steps\FlowStepConfig` in `PipelineHelpers`.
- Fixes a fatal when creating pipelines that validate handler slugs.

## Verification
- `php -l inc/Abilities/Pipeline/PipelineHelpers.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified the missing namespace import and prepared the one-line fix.