### PR TITLE
Parse JSON tool calls from text envelopes

### DIFF
--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1447,7 +1447,7 @@ function datamachine_extract_tool_calls( $result ): array {
 				continue;
 			}
 
-			$tool_calls = array_merge( $tool_calls, datamachine_extract_xml_tool_calls( $text ) );
+			$tool_calls = array_merge( $tool_calls, datamachine_extract_xml_tool_calls( $text ), datamachine_extract_json_tool_calls( $text ) );
 		}
 	}
 
@@ -1491,6 +1491,40 @@ function datamachine_extract_xml_tool_calls( string $text ): array {
 			'name'       => $name,
 			'parameters' => $parameters,
 			'id'         => 'xml-tool-call-' . ( $index + 1 ),
+		);
+	}
+
+	return $tool_calls;
+}
+
+/**
+ * Extract JSON tool calls emitted inside <tool_call> text envelopes.
+ *
+ * @param string $text Text candidate content.
+ * @return array<int, array{name:string,parameters:array,id:mixed}>
+ */
+function datamachine_extract_json_tool_calls( string $text ): array {
+	if ( ! str_contains( $text, '<tool_call>' ) || ! preg_match_all( '/<tool_call>\s*(.*?)\s*<\/tool_call>/is', $text, $matches, PREG_SET_ORDER ) ) {
+		return array();
+	}
+
+	$tool_calls = array();
+	foreach ( $matches as $index => $match ) {
+		$payload = json_decode( html_entity_decode( trim( (string) $match[1] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ), true );
+		if ( ! is_array( $payload ) ) {
+			continue;
+		}
+
+		$name = sanitize_key( (string) ( $payload['name'] ?? '' ) );
+		if ( '' === $name ) {
+			continue;
+		}
+
+		$parameters = $payload['arguments'] ?? ( $payload['parameters'] ?? array() );
+		$tool_calls[] = array(
+			'name'       => $name,
+			'parameters' => is_array( $parameters ) ? $parameters : datamachine_normalize_function_args( $parameters ),
+			'id'         => 'json-tool-call-' . ( $index + 1 ),
 		);
 	}
 

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -423,6 +423,62 @@ assert_runner_request( 'workspace_read' === ( $xml_sandbox_result['tool_calls'][
 assert_runner_request( array( 'path' => 'README.md' ) === ( $xml_sandbox_result['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline XML tool parameters are parsed' );
 assert_runner_request( 1 === count( $xml_sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline XML tool call executes a workspace tool' );
 
+// 4c. Sandbox/pipeline runs also execute JSON tool calls emitted in <tool_call> text envelopes.
+$json_tool_dispatch_count = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$json_tool_dispatch_count ) {
+		++$json_tool_dispatch_count;
+
+		if ( 1 === $json_tool_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content' => '<tool_call>{"name":"workspace_read","arguments":{"path":"README.md"}}</tool_call>',
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content' => 'json tool sandbox complete',
+			),
+		);
+	}
+);
+
+$json_tool_sandbox_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'read the sandbox README using JSON tool syntax' ) ),
+	array(
+		'workspace_read' => array(
+			'name'        => 'workspace_read',
+			'description' => 'Read a file from the sandbox workspace.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(
+					'path' => array( 'type' => 'string' ),
+				),
+				'required'   => array( 'path' ),
+			),
+			'class'       => SandboxPipelineSmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	array( 'sandbox', 'pipeline' ),
+	array(),
+	3
+);
+
+assert_runner_request( 2 === $json_tool_dispatch_count, 'sandbox/pipeline JSON text tool call returns to provider for final answer' );
+assert_runner_request( 'json tool sandbox complete' === ( $json_tool_sandbox_result['final_content'] ?? null ), 'sandbox/pipeline JSON text tool call preserves final answer' );
+assert_runner_request( 1 === count( $json_tool_sandbox_result['tool_calls'] ?? array() ), 'sandbox/pipeline JSON text tool call is parsed' );
+assert_runner_request( 'workspace_read' === ( $json_tool_sandbox_result['tool_calls'][0]['name'] ?? null ), 'sandbox/pipeline JSON text tool name is parsed' );
+assert_runner_request( array( 'path' => 'README.md' ) === ( $json_tool_sandbox_result['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline JSON text tool parameters are parsed' );
+assert_runner_request( 1 === count( $json_tool_sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline JSON text tool call executes a workspace tool' );
+
 // 5. Client runtime tools are fulfilled by the transport callback, not PHP ToolExecutor.
 $runtime_dispatch_count = 0;
 $runtime_requests       = array();


### PR DESCRIPTION
## Summary
- Parse `<tool_call>{...}</tool_call>` JSON text envelopes when providers return tool calls as assistant text instead of native function-call DTOs.
- Keep native function-call DTOs as the preferred path and retain the existing XML `<function_calls>` fallback.
- Add smoke coverage proving JSON text-envelope tool calls execute and return to the provider for a final answer.

## Tests
- `php tests/agent-conversation-runner-request-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-tool-call-json-text --changed-since af13676545ea4ff967c3cd2002aba0d899bd0ead --errors-only`
- PHPCS passed.
- PHPStan reported existing dependency-resolution/class-not-found findings for Agents API classes in the lab offload snapshot; no PHPCS findings remain from this change.

Fixes https://github.com/Extra-Chill/data-machine/issues/2309

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated WP Codebox sandbox probe output showing `<tool_call>` JSON text envelopes, drafted the parser and smoke coverage, and ran focused verification.