### PR TITLE
Add ability pipeline step

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -516,6 +516,7 @@ function datamachine_load_step_types() {
 	new \DataMachine\Core\Steps\Upsert\UpsertStep();
 	new \DataMachine\Core\Steps\AI\AIStep();
 	new \DataMachine\Core\Steps\WebhookGate\WebhookGateStep();
+	new \DataMachine\Core\Steps\Ability\AbilityStep();
 	new \DataMachine\Core\Steps\SystemTask\SystemTaskStep();
 }
 

--- a/inc/Core/Steps/Ability/AbilityStep.php
+++ b/inc/Core/Steps/Ability/AbilityStep.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Ability step.
+ *
+ * @package DataMachine\Core\Steps\Ability
+ */
+
+namespace DataMachine\Core\Steps\Ability;
+
+use DataMachine\Core\AbilityResult;
+use DataMachine\Core\DataPacket;
+use DataMachine\Core\Steps\Step;
+use DataMachine\Core\Steps\StepTypeRegistrationTrait;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Runs a registered WordPress Ability as a deterministic pipeline step.
+ */
+class AbilityStep extends Step {
+
+	use StepTypeRegistrationTrait;
+
+	public function __construct() {
+		parent::__construct( 'ability' );
+
+		self::registerStepType(
+			slug: 'ability',
+			label: 'Ability',
+			description: 'Run a registered WordPress Ability as a pipeline step',
+			class_name: self::class,
+			position: 65,
+			usesHandler: false,
+			hasPipelineConfig: false,
+			consumeAllPackets: false,
+			stepSettings: array(
+				'config_type' => 'handler',
+				'modal_type'  => 'configure-step',
+				'button_text' => 'Configure',
+				'label'       => 'Ability Configuration',
+			),
+			showSettingsDisplay: false
+		);
+	}
+
+	protected function validateStepConfiguration(): bool {
+		$settings = $this->getHandlerConfig();
+		$ability  = trim( (string) ( $settings['ability'] ?? '' ) );
+
+		if ( '' === $ability ) {
+			$this->logConfigurationError( 'Ability step requires an ability slug in flow_step_settings.' );
+			return false;
+		}
+
+		if ( ! class_exists( '\WP_Abilities_Registry' ) ) {
+			$this->logConfigurationError( 'Ability step requires the WordPress Abilities API.' );
+			return false;
+		}
+
+		$registry = \WP_Abilities_Registry::get_instance();
+		if ( method_exists( $registry, 'is_registered' ) && ! $registry->is_registered( $ability ) ) {
+			$this->logConfigurationError( 'Configured ability is not registered.', array( 'ability' => $ability ) );
+			return false;
+		}
+
+		return true;
+	}
+
+	protected function executeStep(): array {
+		$settings     = $this->getHandlerConfig();
+		$ability_slug = trim( (string) ( $settings['ability'] ?? '' ) );
+		$input        = is_array( $settings['input'] ?? null ) ? $settings['input'] : array();
+
+		$registry = \WP_Abilities_Registry::get_instance();
+		$ability  = $registry->get_registered( $ability_slug );
+
+		if ( ! $ability ) {
+			return $this->addResultPacket(
+				$ability_slug,
+				array(
+					'success' => false,
+					'error'   => 'Configured ability is not registered.',
+				),
+				'ability_not_registered'
+			);
+		}
+
+		$permission = $ability->check_permissions( $input );
+		if ( is_wp_error( $permission ) ) {
+			return $this->addResultPacket(
+				$ability_slug,
+				array(
+					'success'       => false,
+					'error'         => $permission->get_error_message(),
+					'wp_error_code' => $permission->get_error_code(),
+				),
+				'ability_permission_denied'
+			);
+		}
+
+		if ( true !== $permission ) {
+			return $this->addResultPacket(
+				$ability_slug,
+				array(
+					'success' => false,
+					'error'   => 'Configured ability is not permitted.',
+				),
+				'ability_permission_denied'
+			);
+		}
+
+		$result = AbilityResult::normalize( $ability->execute( $input ) );
+		return $this->addResultPacket(
+			$ability_slug,
+			$result,
+			empty( $result['success'] ) ? 'ability_execution_failed' : ''
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $result Normalized ability result.
+	 */
+	private function addResultPacket( string $ability_slug, array $result, string $failure_reason = '' ): array {
+		$success = ! array_key_exists( 'success', $result ) || true === (bool) $result['success'];
+
+		$packet = new DataPacket(
+			array(
+				'title'  => $success ? 'Ability Step Completed' : 'Ability Step Failed',
+				'body'   => wp_json_encode( $result ),
+				'result' => $result,
+			),
+			array_filter(
+				array(
+					'source_type'            => 'ability',
+					'flow_step_id'           => $this->flow_step_id,
+					'ability'                => $ability_slug,
+					'success'                => $success,
+					'step_execution_success' => $success,
+					'failure_reason'         => $failure_reason,
+				),
+				static fn( $value ) => '' !== $value && null !== $value
+			),
+			'ability_result'
+		);
+
+		return $packet->addTo( $this->dataPackets );
+	}
+}


### PR DESCRIPTION
## Summary
- Add a generic Data Machine `ability` step type for deterministic pipeline execution of registered WordPress Abilities.
- Check Ability API registration and permissions before execution.
- Emit normal `ability_result` packets with step success metadata so pipeline failures remain visible.

## Verification
- `php -l inc/Core/Steps/Ability/AbilityStep.php`
- `vendor/bin/phpcs inc/Core/Steps/Ability/AbilityStep.php data-machine.php`
- Deployed to `wp-docs-runtime` and verified `wp datamachine step-types list --format=json` includes `ability`.
- Ran runtime smoke flow ID 2; `datamachine/tracked-items-summary` returned 64 tracked Script Modules items via an `ability_result` packet.
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-ability-pipeline-step --extension wordpress` currently fails before tests because lab offload workspace lacks `vendor/autoload.php` in the mounted copy.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic ability step and ran local/runtime verification; Chris remains responsible for review and testing.
