### PR TITLE
Parse fenced JSON tool call arrays

### DIFF
--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -37,7 +37,7 @@ defined( 'ABSPATH' ) || exit;
  * @param array  $tools       Available tools keyed by tool name.
  * @param string $provider    AI provider identifier.
  * @param string $model       AI model identifier.
-	 * @param array  $modes       Execution modes ('pipeline', 'chat', ...).
+ * @param array  $modes       Execution modes ('pipeline', 'chat', ...).
  * @param array  $payload     Step payload / loop context.
  * @param int    $max_turns   Maximum conversation turns.
  * @param bool   $single_turn Execute exactly one turn and return.
@@ -366,8 +366,8 @@ function datamachine_run_conversation(
  * @param array                                     $tools              Available tools.
  * @param string                                    $provider           AI provider.
  * @param string                                    $model              AI model.
-	 * @param string                                    $mode               Comma-separated execution mode label.
-	 * @param array                                     $modes              Execution mode slugs.
+ * @param string                                    $mode               Comma-separated execution mode label.
+ * @param array                                     $modes              Execution mode slugs.
  * @param array                                     $loop_payload       Cleaned payload.
  * @param LoopEventSinkInterface                    $event_sink         DM event sink.
  * @param array                                     $base_log_context   Base log context.
@@ -1485,7 +1485,7 @@ function datamachine_extract_xml_tool_calls( string $text ): array {
 					continue;
 				}
 
-				$parameter_value          = function_exists( '\wp_strip_all_tags' )
+				$parameter_value               = function_exists( '\wp_strip_all_tags' )
 					? \wp_strip_all_tags( (string) $parameter_match[2] )
 					: (string) preg_replace( '/<[^>]*>/', '', (string) $parameter_match[2] );
 				$parameters[ $parameter_name ] = html_entity_decode( trim( $parameter_value ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
@@ -1593,7 +1593,7 @@ function datamachine_resolve_event_sink( array $payload ): LoopEventSinkInterfac
 /**
  * Resolve the runtime completion policy from mode and payload.
  *
-	 * @param array  $modes   Execution modes.
+ * @param array  $modes   Execution modes.
  * @param array  $payload Loop payload.
  * @return WP_Agent_Conversation_Completion_Policy
  */

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1498,34 +1498,55 @@ function datamachine_extract_xml_tool_calls( string $text ): array {
 }
 
 /**
- * Extract JSON tool calls emitted inside <tool_call> text envelopes.
+ * Extract JSON tool calls emitted as text by some providers/models.
  *
  * @param string $text Text candidate content.
  * @return array<int, array{name:string,parameters:array,id:mixed}>
  */
 function datamachine_extract_json_tool_calls( string $text ): array {
-	if ( ! str_contains( $text, '<tool_call>' ) || ! preg_match_all( '/<tool_call>\s*(.*?)\s*<\/tool_call>/is', $text, $matches, PREG_SET_ORDER ) ) {
+	$payloads = array();
+	if ( str_contains( $text, '<tool_call>' ) && preg_match_all( '/<tool_call>\s*(.*?)\s*<\/tool_call>/is', $text, $matches, PREG_SET_ORDER ) ) {
+		foreach ( $matches as $match ) {
+			$payloads[] = (string) $match[1];
+		}
+	}
+
+	if ( str_contains( $text, '```' ) && preg_match_all( '/```(?:json)?\s*(\{.*?\})\s*```/is', $text, $matches, PREG_SET_ORDER ) ) {
+		foreach ( $matches as $match ) {
+			$payloads[] = (string) $match[1];
+		}
+	}
+
+	if ( empty( $payloads ) ) {
 		return array();
 	}
 
 	$tool_calls = array();
-	foreach ( $matches as $index => $match ) {
-		$payload = json_decode( html_entity_decode( trim( (string) $match[1] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ), true );
+	foreach ( $payloads as $index => $raw_payload ) {
+		$payload = json_decode( html_entity_decode( trim( $raw_payload ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ), true );
 		if ( ! is_array( $payload ) ) {
 			continue;
 		}
 
-		$name = sanitize_key( (string) ( $payload['name'] ?? '' ) );
-		if ( '' === $name ) {
-			continue;
-		}
+		$calls = isset( $payload['tool_calls'] ) && is_array( $payload['tool_calls'] ) ? $payload['tool_calls'] : array( $payload );
+		foreach ( $calls as $call_index => $call ) {
+			if ( ! is_array( $call ) ) {
+				continue;
+			}
 
-		$parameters = $payload['arguments'] ?? ( $payload['parameters'] ?? array() );
-		$tool_calls[] = array(
-			'name'       => $name,
-			'parameters' => is_array( $parameters ) ? $parameters : datamachine_normalize_function_args( $parameters ),
-			'id'         => 'json-tool-call-' . ( $index + 1 ),
-		);
+			$function   = isset( $call['function'] ) && is_array( $call['function'] ) ? $call['function'] : array();
+			$name       = sanitize_key( (string) ( $function['name'] ?? ( $call['name'] ?? '' ) ) );
+			$parameters = $function['arguments'] ?? ( $call['arguments'] ?? ( $call['parameters'] ?? array() ) );
+			if ( '' === $name ) {
+				continue;
+			}
+
+			$tool_calls[] = array(
+				'name'       => $name,
+				'parameters' => is_array( $parameters ) ? $parameters : datamachine_normalize_function_args( $parameters ),
+				'id'         => $call['id'] ?? ( 'json-tool-call-' . ( $index + 1 ) . '-' . ( $call_index + 1 ) ),
+			);
+		}
 	}
 
 	return $tool_calls;

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -56,6 +56,12 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 	}
 }
 
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( string $text ): string {
+		return trim( preg_replace( '/[\r\n\t ]+/', ' ', strip_tags( $text ) ) ?? '' );
+	}
+}
+
 if ( ! function_exists( 'get_option' ) ) {
 	function get_option( string $name, $default_value = false ) {
 		unset( $name );

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -479,6 +479,62 @@ assert_runner_request( 'workspace_read' === ( $json_tool_sandbox_result['tool_ca
 assert_runner_request( array( 'path' => 'README.md' ) === ( $json_tool_sandbox_result['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline JSON text tool parameters are parsed' );
 assert_runner_request( 1 === count( $json_tool_sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline JSON text tool call executes a workspace tool' );
 
+// 4d. Sandbox/pipeline runs also execute fenced JSON tool_calls arrays emitted as text.
+$json_array_dispatch_count = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$json_array_dispatch_count ) {
+		++$json_array_dispatch_count;
+
+		if ( 1 === $json_array_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content' => "I will inspect first.\n```json\n{\"tool_calls\":[{\"id\":\"read-call\",\"type\":\"function\",\"function\":{\"name\":\"workspace_read\",\"arguments\":{\"path\":\"README.md\"}}}]}\n```",
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content' => 'json array sandbox complete',
+			),
+		);
+	}
+);
+
+$json_array_sandbox_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'read the sandbox README using fenced JSON tool_calls syntax' ) ),
+	array(
+		'workspace_read' => array(
+			'name'        => 'workspace_read',
+			'description' => 'Read a file from the sandbox workspace.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(
+					'path' => array( 'type' => 'string' ),
+				),
+				'required'   => array( 'path' ),
+			),
+			'class'       => SandboxPipelineSmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	array( 'sandbox', 'pipeline' ),
+	array(),
+	3
+);
+
+assert_runner_request( 2 === $json_array_dispatch_count, 'sandbox/pipeline fenced JSON tool_calls returns to provider for final answer' );
+assert_runner_request( 'json array sandbox complete' === ( $json_array_sandbox_result['final_content'] ?? null ), 'sandbox/pipeline fenced JSON tool_calls preserves final answer' );
+assert_runner_request( 1 === count( $json_array_sandbox_result['tool_calls'] ?? array() ), 'sandbox/pipeline fenced JSON tool_calls is parsed' );
+assert_runner_request( 'workspace_read' === ( $json_array_sandbox_result['tool_calls'][0]['name'] ?? null ), 'sandbox/pipeline fenced JSON tool_calls name is parsed' );
+assert_runner_request( array( 'path' => 'README.md' ) === ( $json_array_sandbox_result['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline fenced JSON tool_calls parameters are parsed' );
+assert_runner_request( 1 === count( $json_array_sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline fenced JSON tool_calls executes a workspace tool' );
+
 // 5. Client runtime tools are fulfilled by the transport callback, not PHP ToolExecutor.
 $runtime_dispatch_count = 0;
 $runtime_requests       = array();


### PR DESCRIPTION
## Summary
- Parse fenced JSON blocks that contain OpenAI-style `tool_calls` arrays when providers return tool calls as assistant text.
- Preserve the existing native function-call path, XML text fallback, and `<tool_call>` JSON-envelope fallback.
- Add smoke coverage for fenced JSON `tool_calls` executing workspace tools and returning to the provider for the final answer.

## Tests
- `php tests/agent-conversation-runner-request-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/conversation-loop.php tests/agent-conversation-runner-request-smoke.php`

Follow-up for https://github.com/Extra-Chill/data-machine/issues/2309

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated WP Codebox probe output showing fenced JSON `tool_calls`, drafted the parser and smoke coverage, and ran focused verification.