### PR TITLE
Harden system task workflow contracts

### DIFF
--- a/docs/ai-tools/execute-workflow.md
+++ b/docs/ai-tools/execute-workflow.md
@@ -22,14 +22,18 @@ The ExecuteWorkflow tool enables AI agents to execute complete multi-step workfl
 
 ## Step Configuration
 
+Workflow specs use the canonical fields `type`, `handler_slugs`, `handler_configs`, and `flow_step_settings`. The old aliases `step_type`, `handler_slug`, and `handler_config` are rejected by the shared workflow validator.
+
 ### Fetch Steps
 ```json
 {
-  "step_type": "fetch",
-  "handler_slug": "handler_name",
-  "handler_config": {
-    "required_field": "value",
-    "optional_field": "value"
+  "type": "fetch",
+  "handler_slugs": ["handler_name"],
+  "handler_configs": {
+    "handler_name": {
+      "required_field": "value",
+      "optional_field": "value"
+    }
   }
 }
 ```
@@ -37,7 +41,7 @@ The ExecuteWorkflow tool enables AI agents to execute complete multi-step workfl
 ### AI Steps
 ```json
 {
-  "step_type": "ai",
+  "type": "ai",
   "provider": "anthropic",
   "model": "claude-sonnet-4-20250514",
   "user_message": "Instruction for AI processing",
@@ -50,11 +54,13 @@ The ExecuteWorkflow tool enables AI agents to execute complete multi-step workfl
 ### Publish Steps
 ```json
 {
-  "step_type": "publish",
-  "handler_slug": "handler_name",
-  "handler_config": {
-    "required_field": "value",
-    "optional_field": "value"
+  "type": "publish",
+  "handler_slugs": ["handler_name"],
+  "handler_configs": {
+    "handler_name": {
+      "required_field": "value",
+      "optional_field": "value"
+    }
   }
 }
 ```
@@ -62,11 +68,27 @@ The ExecuteWorkflow tool enables AI agents to execute complete multi-step workfl
 ### Upsert Steps
 ```json
 {
-  "step_type": "update",
-  "handler_slug": "handler_name",
-  "handler_config": {
-    "required_field": "value",
-    "optional_field": "value"
+  "type": "upsert",
+  "handler_slugs": ["handler_name"],
+  "handler_configs": {
+    "handler_name": {
+      "required_field": "value",
+      "optional_field": "value"
+    }
+  }
+}
+```
+
+### System Task Steps
+```json
+{
+  "type": "system_task",
+  "flow_step_settings": {
+    "task_type": "alt_text_generation",
+    "params": {
+      "post_id": 123,
+      "dry_run": true
+    }
   }
 }
 ```
@@ -78,20 +100,24 @@ The ExecuteWorkflow tool enables AI agents to execute complete multi-step workfl
 {
   "steps": [
     {
-      "step_type": "fetch",
-      "handler_slug": "rss",
-      "handler_config": {
-        "feed_url": "https://example.com/feed.xml"
+      "type": "fetch",
+      "handler_slugs": ["rss"],
+      "handler_configs": {
+        "rss": {
+          "feed_url": "https://example.com/feed.xml"
+        }
       }
     },
     {
-      "step_type": "ai",
+      "type": "ai",
       "user_message": "Summarize this content and make it engaging for social media"
     },
     {
-      "step_type": "publish",
-      "handler_slug": "twitter",
-      "handler_config": {}
+      "type": "publish",
+      "handler_slugs": ["twitter"],
+      "handler_configs": {
+        "twitter": {}
+      }
     }
   ]
 }
@@ -102,21 +128,25 @@ The ExecuteWorkflow tool enables AI agents to execute complete multi-step workfl
 {
   "steps": [
     {
-      "step_type": "fetch",
-      "handler_slug": "wordpress_local",
-      "handler_config": {
-        "post_type": "post",
-        "posts_per_page": 5
+      "type": "fetch",
+      "handler_slugs": ["wordpress_local"],
+      "handler_configs": {
+        "wordpress_local": {
+          "post_type": "post",
+          "posts_per_page": 5
+        }
       }
     },
     {
-      "step_type": "ai",
+      "type": "ai",
       "user_message": "Update these posts with better SEO titles and meta descriptions"
     },
     {
-      "step_type": "update",
-      "handler_slug": "wordpress_update",
-      "handler_config": {}
+      "type": "upsert",
+      "handler_slugs": ["wordpress_update"],
+      "handler_configs": {
+        "wordpress_update": {}
+      }
     }
   ]
 }
@@ -127,29 +157,35 @@ The ExecuteWorkflow tool enables AI agents to execute complete multi-step workfl
 {
   "steps": [
     {
-      "step_type": "fetch",
-      "handler_slug": "files",
-      "handler_config": {
-        "file_path": "/content/article.txt"
+      "type": "fetch",
+      "handler_slugs": ["files"],
+      "handler_configs": {
+        "files": {
+          "file_path": "/content/article.txt"
+        }
       }
     },
     {
-      "step_type": "ai",
+      "type": "ai",
       "user_message": "Adapt this content for different social media platforms"
     },
     {
-      "step_type": "publish",
-      "handler_slug": "twitter",
-      "handler_config": {}
+      "type": "publish",
+      "handler_slugs": ["twitter"],
+      "handler_configs": {
+        "twitter": {}
+      }
     },
     {
-      "step_type": "ai",
+      "type": "ai",
       "user_message": "Create a longer version for Facebook"
     },
     {
-      "step_type": "publish",
-      "handler_slug": "facebook",
-      "handler_config": {}
+      "type": "publish",
+      "handler_slugs": ["facebook"],
+      "handler_configs": {
+        "facebook": {}
+      }
     }
   ]
 }
@@ -160,14 +196,16 @@ The ExecuteWorkflow tool enables AI agents to execute complete multi-step workfl
 ### WordPress Publish Handler
 ```json
 {
-  "step_type": "publish",
-  "handler_slug": "wordpress",
-  "handler_config": {
-    "post_type": "post",
-    "post_status": "publish",
-    "post_author": 1,
-    "taxonomy_category_selection": "ai_decides",
-    "taxonomy_tags_selection": "Technology, AI"
+  "type": "publish",
+  "handler_slugs": ["wordpress"],
+  "handler_configs": {
+    "wordpress": {
+      "post_type": "post",
+      "post_status": "publish",
+      "post_author": 1,
+      "taxonomy_category_selection": "ai_decides",
+      "taxonomy_tags_selection": "Technology, AI"
+    }
   }
 }
 ```
@@ -175,9 +213,11 @@ The ExecuteWorkflow tool enables AI agents to execute complete multi-step workfl
 ### Social Media Handlers
 ```json
 {
-  "step_type": "publish",
-  "handler_slug": "twitter",
-  "handler_config": {}
+  "type": "publish",
+  "handler_slugs": ["twitter"],
+  "handler_configs": {
+    "twitter": {}
+  }
 }
 ```
 

--- a/docs/ai-tools/execute-workflow.md
+++ b/docs/ai-tools/execute-workflow.md
@@ -22,7 +22,7 @@ The ExecuteWorkflow tool enables AI agents to execute complete multi-step workfl
 
 ## Step Configuration
 
-Workflow specs use the canonical fields `type`, `handler_slugs`, `handler_configs`, and `flow_step_settings`. The old aliases `step_type`, `handler_slug`, and `handler_config` are rejected by the shared workflow validator.
+Ephemeral workflow specs use the canonical fields `type`, `handler_slugs`, `handler_configs`, and `flow_step_settings`. Stored pipeline and flow config rows use `step_type` internally, but workflow input uses `type`. The old handler aliases `handler_slug` and `handler_config` are rejected by the shared workflow validator.
 
 ### Fetch Steps
 ```json

--- a/docs/core-system/system-tasks.md
+++ b/docs/core-system/system-tasks.md
@@ -1,6 +1,8 @@
 # System Tasks
 
-System tasks are reusable task handlers that can run on demand, from recurring schedules, or inline as workflow/pipeline steps. They handle AI-powered content operations (alt text, meta descriptions, internal linking), media processing (image generation, optimization), and agent housekeeping (daily memory synthesis). All system tasks share a common base class with standardized job management, effect tracking, and undo support.
+System tasks are reusable task handlers that can run on demand, from recurring schedules, or inline as workflow/pipeline steps. They handle AI-powered content operations (alt text, meta descriptions, internal linking), media processing (image generation, optimization), retention, and agent housekeeping (daily memory synthesis). All system tasks share a common base class with standardized job management, effect tracking, and undo support.
+
+Use system tasks for named operational jobs. Use pipelines and flows for reusable multi-step product workflows. A system task may call AI or mutate content when its metadata declares the safety envelope, but it should not become a hidden workflow composer that replaces explicit pipeline/flow steps.
 
 ## Overview
 
@@ -46,7 +48,9 @@ abstract class SystemTask {
 ]
 ```
 
-`executeTask()` is the imperative body called by `SystemTaskStep`. System task step settings use `task_type`; configs that still use the older `task` key must be upgraded before they run.
+`executeTask()` is the imperative body called by `SystemTaskStep`. System task step settings use `task_type`; configs that still use the older `task` key fail with an explicit legacy-field error and must be upgraded before they run.
+
+Keep `getWorkflow()` on the default one-step shape unless the task owns a bounded internal handoff that should still be scheduled as one named operation. If the work needs source inventory, generation, publishing, GitSync submission, coverage, or other independently observable stages, model those stages as pipeline/flow steps instead.
 
 ### Job Lifecycle Methods
 
@@ -70,9 +74,19 @@ public static function getTaskMeta(): array {
         'trigger'         => 'How it gets triggered',
         'trigger_type'    => 'cron|event|tool|manual',
         'supports_run'    => false,                       // Can be manually triggered?
+        'mutates'          => false,                       // Can modify content/files/state?
+        'supports_dry_run' => false,                       // Can preview instead of apply?
+        'requires_scope'   => false,                       // Manual runs require an explicit scope param?
+        'params_schema'    => [
+            'accepted' => [ 'post_id', 'limit', 'dry_run' ],
+            'required' => [ 'post_id' ],
+            'scope'    => [ 'post_id' ],
+        ],
     ];
 }
 ```
+
+Manual execution through `wp datamachine system run` or the `datamachine/run-task` ability is opt-in. Tasks must set `supports_run` to `true`; mutating tasks should also declare `mutates`, `supports_dry_run`, `requires_scope`, and `params_schema.scope` so broad runs require an explicit target.
 
 ### AI Model Resolution
 

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -4,6 +4,16 @@ Data Machine provides a broad WP-CLI surface for managing pipelines, flows, jobs
 
 > **Note:** The `wp datamachine workspace` and `wp datamachine github` commands have been moved to the `data-machine-code` extension plugin.
 
+## Contract Boundaries
+
+- **Pipelines** are reusable step templates. They define step order and durable structure.
+- **Flows** are runnable pipeline instances. They own schedules, queues, handler config, prompts, and per-flow step settings.
+- **Step types** are execution primitives such as `fetch`, `ai`, `publish`, `upsert`, and `system_task`.
+- **Handlers** are integrations selected by handler-backed step types. Only step types with `uses_handler=yes` accept handlers.
+- **System tasks** are named operational jobs. Use them for bounded tasks such as alt text, retention, internal links, and memory maintenance. Use pipelines/flows for reusable multi-step workflows instead of hiding workflow composition inside one system task.
+
+Workflow JSON uses canonical fields: `type`, `handler_slugs`, `handler_configs`, and `flow_step_settings`. Legacy aliases such as `step_type`, `handler`, `handler_slug`, and `handler_config` are rejected on normal workflow paths.
+
 ## Available Commands
 
 ### datamachine pipelines
@@ -17,7 +27,7 @@ wp datamachine pipelines list
 # Get a specific pipeline (shows steps and flows)
 wp datamachine pipelines get 5
 
-# Create a pipeline with steps
+# Create a pipeline with minimal step structure
 wp datamachine pipelines create --name="My Pipeline" --steps='[{"step_type":"fetch","label":"RSS Fetch"}]'
 
 # Update pipeline name or config
@@ -37,6 +47,8 @@ wp datamachine pipelines memory-files 5 --remove=strategy.md
 ```
 
 **Options**: `--per_page`, `--offset`, `--format`, `--fields`, `--dry-run`
+
+`--steps` creates pipeline step structure. Use workflow/bundle specs when preserving full step settings such as `handler_slugs`, `handler_configs`, `flow_step_settings`, AI prompts, queues, or tool policy. Use `flow_config` only when intentionally creating the first runnable flow with the pipeline.
 
 ### datamachine flows
 
@@ -82,6 +94,8 @@ wp datamachine flows migrate-legacy-handler-shape --all-sites --yes
 `migrate-legacy-handler-shape` is a contained operator repair command for older stored `flow_config` rows that still use scalar `handler`, `handler_slug`, or `handler_config` keys. Normal workflow specs, import/update paths, readers, and writers remain canonical-only and use `handler_slugs`, `handler_configs`, and `flow_step_settings`.
 
 **Options**: `--per_page`, `--offset`, `--handler`, `--format`, `--fields`, `--dry-run`, `--all-sites`, `--yes`, `--verbose`
+
+Flows own runnable configuration. Put handler config, prompt queues, per-flow task settings, schedules, and run-time overrides on flows, not on the pipeline template.
 
 ### datamachine flows queue
 
@@ -338,7 +352,7 @@ System tasks and health checks. **Since**: 0.41.0
 wp datamachine system health
 wp datamachine system health --types=php,wp,plugin
 
-# Run a system task immediately
+# Schedule a system task to run now
 wp datamachine system run alt_text_generation
 wp datamachine system run daily_memory_generation
 
@@ -351,6 +365,8 @@ wp datamachine system prompt-get alt_text_generation system_prompt
 wp datamachine system prompt-set alt_text_generation system_prompt "New prompt"
 wp datamachine system prompt-reset alt_text_generation system_prompt
 ```
+
+`system run` schedules a job through the system task contract; it does not execute the task inline in the CLI process. Process queued work with `wp datamachine worker run` or `wp datamachine drain`.
 
 ### datamachine batch
 

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -12,7 +12,7 @@ Data Machine provides a broad WP-CLI surface for managing pipelines, flows, jobs
 - **Handlers** are integrations selected by handler-backed step types. Only step types with `uses_handler=yes` accept handlers.
 - **System tasks** are named operational jobs. Use them for bounded tasks such as alt text, retention, internal links, and memory maintenance. Use pipelines/flows for reusable multi-step workflows instead of hiding workflow composition inside one system task.
 
-Workflow JSON uses canonical fields: `type`, `handler_slugs`, `handler_configs`, and `flow_step_settings`. Legacy aliases such as `step_type`, `handler`, `handler_slug`, and `handler_config` are rejected on normal workflow paths.
+Ephemeral workflow JSON uses canonical fields: `type`, `handler_slugs`, `handler_configs`, and `flow_step_settings`. Stored pipeline and flow config rows continue to use `step_type` internally; `step_type` is rejected only when submitted in an ephemeral workflow spec, where `type` is the public workflow key. Legacy handler aliases such as `handler`, `handler_slug`, and `handler_config` are rejected on normal workflow paths.
 
 ## Available Commands
 

--- a/inc/Cli/Commands/SystemCommand.php
+++ b/inc/Cli/Commands/SystemCommand.php
@@ -205,11 +205,11 @@ class SystemCommand extends BaseCommand {
 	}
 
 	/**
-	 * Run a system task immediately.
+	 * Schedule a system task to run now.
 	 *
-	 * Triggers a registered system task for immediate execution via the
-	 * datamachine/run-task ability. Only tasks with supports_run: true
-	 * can be triggered.
+	 * Enqueues a registered system task via the datamachine/run-task ability.
+	 * Only tasks with supports_run: true can be scheduled manually; process the
+	 * resulting job with `wp datamachine worker run` or `wp datamachine drain`.
 	 *
 	 * ## OPTIONS
 	 *

--- a/inc/Core/Steps/SystemTask/SystemTaskStep.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskStep.php
@@ -99,13 +99,22 @@ class SystemTaskStep extends Step {
 		$task_type     = self::getConfiguredTaskType( $step_settings );
 
 		if ( empty( $task_type ) ) {
+			$legacy_task_type = $step_settings['task'] ?? null;
+			$failure_code     = 'system_task_missing_task_type';
+			$error_message    = 'System Task step requires a task type in flow_step_settings.task_type.';
+
+			if ( is_string( $legacy_task_type ) && '' !== $legacy_task_type ) {
+				$failure_code  = 'system_task_legacy_task_field';
+				$error_message = 'System Task step uses unsupported legacy field flow_step_settings.task; use flow_step_settings.task_type.';
+			}
+
 			do_action(
 				'datamachine_fail_job',
 				$this->job_id,
-				'system_task_missing_task_type',
+				$failure_code,
 				array(
 					'flow_step_id'  => $this->flow_step_id,
-					'error_message' => 'System Task step requires a task type in flow_step_settings.',
+					'error_message' => $error_message,
 				)
 			);
 			return false;

--- a/inc/Core/Steps/WorkflowSpecValidator.php
+++ b/inc/Core/Steps/WorkflowSpecValidator.php
@@ -61,7 +61,7 @@ class WorkflowSpecValidator {
 			if ( array_key_exists( 'step_type', $step ) ) {
 				return array(
 					'valid' => false,
-					'error' => "Step {$index} uses unsupported legacy field step_type; use type",
+					'error' => "Step {$index} uses stored-config field step_type; ephemeral workflow specs use type",
 				);
 			}
 

--- a/inc/Core/Steps/WorkflowSpecValidator.php
+++ b/inc/Core/Steps/WorkflowSpecValidator.php
@@ -58,6 +58,13 @@ class WorkflowSpecValidator {
 				);
 			}
 
+			if ( array_key_exists( 'step_type', $step ) ) {
+				return array(
+					'valid' => false,
+					'error' => "Step {$index} uses unsupported legacy field step_type; use type",
+				);
+			}
+
 			foreach ( array( 'handler', 'handler_slug', 'handler_config' ) as $legacy_field ) {
 				if ( array_key_exists( $legacy_field, $step ) ) {
 					return array(

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -2,11 +2,11 @@
 /**
  * Abstract base class for all System Agent tasks.
  *
- * Tasks declare their execution shape via getWorkflow() — returning a
- * step-list JSON that the engine executes through datamachine/execute-workflow.
- * This is the same engine contract used by persistent flows, chat-built
- * workflows, and system tasks. The only difference between them is where
- * the JSON lives: database row, chat context, or hardcoded PHP.
+ * Tasks are named operational jobs. They can be scheduled directly or embedded
+ * in a pipeline through the `system_task` step type. Multi-step product
+ * workflows belong in pipelines/flows; keep getWorkflow() to the default
+ * single `system_task` step unless the task owns a bounded internal handoff
+ * that should still be scheduled as one named operation.
  *
  * ## Dual Contract
  *
@@ -57,8 +57,8 @@ abstract class SystemTask {
 	 *
 	 * Default implementation returns a single system_task step that
 	 * references this task's own type — the engine routes through
-	 * SystemTaskStep which calls executeTask(). Override to return
-	 * richer multi-step workflows.
+	 * SystemTaskStep which calls executeTask(). Prefer pipelines/flows for
+	 * reusable multi-step workflows instead of overriding this method.
 	 *
 	 * @param array $params Task parameters from the scheduler.
 	 * @return array Workflow definition with "steps" key.
@@ -102,12 +102,22 @@ abstract class SystemTask {
 	abstract public function getTaskType(): string;
 
 	/**
-	 * Get task metadata for UI display.
+	 * Get task metadata for registry, UI display, and manual-run safety.
 	 *
-	 * Override in concrete tasks to provide label, description, and
-	 * optional setting key for the System Tasks admin tab.
+	 * Override in concrete tasks to provide labels plus explicit execution
+	 * safety metadata. `supports_run` controls whether `wp datamachine system
+	 * run` and the run-task ability may schedule the task manually. Mutating
+	 * manual tasks should declare `mutates`, `supports_dry_run`, and a scoped
+	 * `params_schema` so callers cannot accidentally run broad operations.
 	 *
-	 * @return array{label: string, description: string, setting_key: ?string, default_enabled: bool}
+	 * Example params_schema:
+	 * array(
+	 *     'accepted' => array( 'post_id', 'limit', 'dry_run' ),
+	 *     'required' => array( 'post_id' ),
+	 *     'scope'    => array( 'post_id' ),
+	 * )
+	 *
+	 * @return array{label: string, description: string, setting_key: ?string, default_enabled: bool, trigger?: string, trigger_type?: string, supports_run?: bool, mutates?: bool, supports_dry_run?: bool, requires_scope?: bool, params_schema?: array{accepted?: array<int, string>, accepted_params?: array<int, string>, required?: array<int, string>, required_params?: array<int, string>, scope?: array<int, string>, scope_params?: array<int, string>}}
 	 * @since 0.32.0
 	 */
 	public static function getTaskMeta(): array {

--- a/tests/system-run-task-params-smoke.php
+++ b/tests/system-run-task-params-smoke.php
@@ -190,8 +190,8 @@ function smoke_default_system_task_workflow( string $task_type, array $params ):
 			array(
 				'type'               => 'system_task',
 				'flow_step_settings' => array(
-					'task'   => $task_type,
-					'params' => $params,
+					'task_type' => $task_type,
+					'params'    => $params,
 				),
 			),
 		),
@@ -277,6 +277,8 @@ $assert( 'TaskScheduler marks run-now jobs as system jobs', 'system' === $initia
 $assert( 'TaskScheduler labels system task jobs from task type', 'Wiki maintain' === $initial['job_label'] );
 $workflow = smoke_default_system_task_workflow( 'wiki_maintain', $initial['task_params'] );
 $assert( 'SystemTask workflow stores params in flow_step_settings', $scheduled_params === $workflow['steps'][0]['flow_step_settings']['params'] );
+$assert( 'SystemTask workflow stores canonical task_type', 'wiki_maintain' === $workflow['steps'][0]['flow_step_settings']['task_type'] );
+$assert( 'SystemTask workflow does not store legacy task alias', ! array_key_exists( 'task', $workflow['steps'][0]['flow_step_settings'] ) );
 
 echo "\n[4] Source tripwires\n";
 $system_command = file_get_contents( __DIR__ . '/../inc/Cli/Commands/SystemCommand.php' );

--- a/tests/system-task-contract-smoke.php
+++ b/tests/system-task-contract-smoke.php
@@ -40,6 +40,14 @@ datamachine_contract_assert_contains( $settings, "'task_type' => array", 'System
 echo "\n[2] system task step reads only task_type\n";
 datamachine_contract_assert_contains( $step, "\$settings['task_type'] ?? ''", 'SystemTaskStep reads task_type directly', $failures, $passes );
 
+echo "\n[3] legacy task alias fails explicitly\n";
+datamachine_contract_assert_contains( $step, 'system_task_legacy_task_field', 'SystemTaskStep has explicit legacy task failure code', $failures, $passes );
+datamachine_contract_assert_contains( $step, 'flow_step_settings.task_type', 'SystemTaskStep missing-task error names canonical task_type field', $failures, $passes );
+
+echo "\n[4] task metadata documents manual-run guardrails\n";
+datamachine_contract_assert_contains( $system_task, 'supports_run?: bool', 'SystemTask metadata documents supports_run', $failures, $passes );
+datamachine_contract_assert_contains( $system_task, 'params_schema?: array', 'SystemTask metadata documents params_schema', $failures, $passes );
+
 if ( ! empty( $failures ) ) {
 	echo "\nFAILED: " . count( $failures ) . " system task contract assertion(s) failed.\n";
 	exit( 1 );

--- a/tests/system-task-workflow-validation-smoke.php
+++ b/tests/system-task-workflow-validation-smoke.php
@@ -59,6 +59,13 @@ function validate_workflow_for_test( array $workflow ): array {
 	$valid_types         = array_keys( $step_type_abilities->getAllStepTypes() );
 
 	foreach ( $workflow['steps'] as $index => $step ) {
+		if ( array_key_exists( 'step_type', $step ) ) {
+			return array(
+				'valid' => false,
+				'error' => "Step {$index} uses unsupported legacy field step_type; use type",
+			);
+		}
+
 		foreach ( array( 'handler', 'handler_slug', 'handler_config' ) as $legacy_field ) {
 			if ( array_key_exists( $legacy_field, $step ) ) {
 				return array(
@@ -136,6 +143,13 @@ $wf = array( 'steps' => array( array( 'type' => 'fetch', 'handler_slug' => 'rss'
 $r  = validate_workflow_for_test( $wf );
 dm_assert( false === $r['valid'], 'fetch with legacy handler_slug rejected' );
 dm_assert( str_contains( $r['error'] ?? '', 'unsupported legacy field handler_slug' ), 'legacy handler_slug error is explicit' );
+
+// -----------------------------------------------------------------
+echo "\n[5b] step with legacy step_type — INVALID\n";
+$wf = array( 'steps' => array( array( 'step_type' => 'fetch' ) ) );
+$r  = validate_workflow_for_test( $wf );
+dm_assert( false === $r['valid'], 'legacy step_type rejected' );
+dm_assert( str_contains( $r['error'] ?? '', 'unsupported legacy field step_type' ), 'legacy step_type error is explicit' );
 
 // -----------------------------------------------------------------
 echo "\n[6] publish step without handler_slug — VALID at workflow level\n";

--- a/tests/system-task-workflow-validation-smoke.php
+++ b/tests/system-task-workflow-validation-smoke.php
@@ -62,7 +62,7 @@ function validate_workflow_for_test( array $workflow ): array {
 		if ( array_key_exists( 'step_type', $step ) ) {
 			return array(
 				'valid' => false,
-				'error' => "Step {$index} uses unsupported legacy field step_type; use type",
+				'error' => "Step {$index} uses stored-config field step_type; ephemeral workflow specs use type",
 			);
 		}
 
@@ -145,11 +145,11 @@ dm_assert( false === $r['valid'], 'fetch with legacy handler_slug rejected' );
 dm_assert( str_contains( $r['error'] ?? '', 'unsupported legacy field handler_slug' ), 'legacy handler_slug error is explicit' );
 
 // -----------------------------------------------------------------
-echo "\n[5b] step with legacy step_type — INVALID\n";
+echo "\n[5b] workflow spec with stored-config step_type — INVALID\n";
 $wf = array( 'steps' => array( array( 'step_type' => 'fetch' ) ) );
 $r  = validate_workflow_for_test( $wf );
-dm_assert( false === $r['valid'], 'legacy step_type rejected' );
-dm_assert( str_contains( $r['error'] ?? '', 'unsupported legacy field step_type' ), 'legacy step_type error is explicit' );
+dm_assert( false === $r['valid'], 'workflow spec step_type rejected' );
+dm_assert( str_contains( $r['error'] ?? '', 'stored-config field step_type' ), 'workflow spec step_type error is explicit' );
 
 // -----------------------------------------------------------------
 echo "\n[6] publish step without handler_slug — VALID at workflow level\n";

--- a/tests/workflow-spec-contract-smoke.php
+++ b/tests/workflow-spec-contract-smoke.php
@@ -124,6 +124,7 @@ $invalid_cases    = array(
 	'associative steps' => array( 'steps' => array( 'first' => array( 'type' => 'fetch' ) ) ),
 	'scalar step'       => array( 'steps' => array( 'fetch' ) ),
 	'missing type'      => array( 'steps' => array( array( 'handler_slug' => 'rss' ) ) ),
+	'legacy step_type field' => array( 'steps' => array( array( 'step_type' => 'fetch' ) ) ),
 	'legacy handler alias field' => array( 'steps' => array( array( 'type' => 'fetch', 'handler' => 'rss' ) ) ),
 	'legacy handler field' => array( 'steps' => array( array( 'type' => 'fetch', 'handler_slug' => 'rss' ) ) ),
 	'legacy config field'  => array( 'steps' => array( array( 'type' => 'fetch', 'handler_config' => array( 'url' => 'https://example.com' ) ) ) ),
@@ -215,7 +216,8 @@ $system_task_source = file_get_contents( __DIR__ . '/../inc/Core/Steps/SystemTas
 
 assert_workflow_spec_equals( 1, substr_count( $execute_source, 'WorkflowSpecValidator::validate' ), 'execute-workflow calls shared validator once', $failures, $passes );
 assert_workflow_spec_equals( 1, substr_count( $pipeline_source, 'WorkflowSpecValidator::validate' ), 'create-pipeline helper calls shared validator once', $failures, $passes );
-assert_workflow_spec_equals( 0, substr_count( $system_task_source, "['task']" ), 'system_task execution no longer accepts legacy task field', $failures, $passes );
+assert_workflow_spec_equals( false, str_contains( $system_task_source, "\$task_type = \$settings['task']" ), 'system_task execution does not resolve task type from legacy task field', $failures, $passes );
+assert_workflow_spec_equals( true, str_contains( $system_task_source, 'system_task_legacy_task_field' ), 'system_task execution rejects legacy task field explicitly', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " workflow spec assertions failed.\n";

--- a/tests/workflow-spec-contract-smoke.php
+++ b/tests/workflow-spec-contract-smoke.php
@@ -124,7 +124,7 @@ $invalid_cases    = array(
 	'associative steps' => array( 'steps' => array( 'first' => array( 'type' => 'fetch' ) ) ),
 	'scalar step'       => array( 'steps' => array( 'fetch' ) ),
 	'missing type'      => array( 'steps' => array( array( 'handler_slug' => 'rss' ) ) ),
-	'legacy step_type field' => array( 'steps' => array( array( 'step_type' => 'fetch' ) ) ),
+	'stored-config step_type field' => array( 'steps' => array( array( 'step_type' => 'fetch' ) ) ),
 	'legacy handler alias field' => array( 'steps' => array( array( 'type' => 'fetch', 'handler' => 'rss' ) ) ),
 	'legacy handler field' => array( 'steps' => array( array( 'type' => 'fetch', 'handler_slug' => 'rss' ) ) ),
 	'legacy config field'  => array( 'steps' => array( array( 'type' => 'fetch', 'handler_config' => array( 'url' => 'https://example.com' ) ) ) ),


### PR DESCRIPTION
## Summary
- Reject legacy workflow `step_type` fields through the shared workflow validator, matching the existing canonical `type` contract.
- Make embedded system task steps fail explicitly when old `flow_step_settings.task` is used instead of `task_type`.
- Clarify system task boundaries, manual-run metadata, scheduling semantics, and canonical execute-workflow JSON in docs.
- Extend smoke tests for canonical `task_type`, legacy alias rejection, and shared validator behavior.

## Testing
- `php tests/system-task-contract-smoke.php && php tests/system-run-task-params-smoke.php && php tests/system-task-workflow-validation-smoke.php && php tests/workflow-spec-contract-smoke.php`
- `composer run lint -- --standard=phpcs.xml.dist inc/Cli/Commands/SystemCommand.php inc/Core/Steps/SystemTask/SystemTaskStep.php inc/Core/Steps/WorkflowSpecValidator.php inc/Engine/AI/System/Tasks/SystemTask.php`
- `composer run test` failed before plugin load in the lab WP Codebox runner because the mounted plugin was missing `vendor/autoload.php`: `Failed opening required '/wordpress/wp-content/plugins/data-machine/vendor/autoload.php'`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Audited the system task/workflow contract boundaries, drafted the hardening patch, updated tests/docs, and ran verification commands for Chris to review.