### PR TITLE
Fix tool trace metadata lint formatting

### DIFF
--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -57,7 +57,7 @@ class JobArtifacts {
 			'required_tool_names'    => $this->tool_names_from_assertions( $engine_data['completion_assertions_required'] ?? array() ),
 			'satisfied_tool_names'   => $this->tool_names_from_assertions( $engine_data['completion_assertions_satisfied'] ?? array() ),
 			'successful_tool_calls'  => $tool_calls,
-			'tool_trace'            => $this->tool_trace( $engine_data, $additional_tool_summaries ),
+			'tool_trace'             => $this->tool_trace( $engine_data, $additional_tool_summaries ),
 			'transcript'             => $this->transcript_metadata( $job_id, $engine_data ),
 			'agent_memory_artifacts' => $this->agent_memory_artifacts( $job, $agent, $tool_calls ),
 			'daily_memory_artifacts' => $this->daily_memory_artifacts( $job, $agent, $tool_calls ),

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -521,7 +521,7 @@ function datamachine_build_turn_runner(
 			foreach ( $tool_calls as $tool_call ) {
 				$tool_name       = $tool_call['name'];
 				$tool_parameters = $tool_call['parameters'];
-				$tool_started_at  = microtime( true );
+				$tool_started_at = microtime( true );
 
 				if ( empty( $tool_name ) ) {
 					do_action(
@@ -631,7 +631,7 @@ function datamachine_build_turn_runner(
 				}
 
 				if ( ! empty( $tool_result['pending'] ) && is_array( $tool_result['runtime_tool_request'] ?? null ) ) {
-					$tool_trace            = datamachine_build_tool_trace( $tool_name, $tool_call, $tool_parameters, $tool_result, is_array( $tool_def ) ? $tool_def : null, $turn_count, $tool_started_at, microtime( true ) );
+					$tool_trace               = datamachine_build_tool_trace( $tool_name, $tool_call, $tool_parameters, $tool_result, is_array( $tool_def ) ? $tool_def : null, $turn_count, $tool_started_at, microtime( true ) );
 					$runtime_tool_pending     = true;
 					$runtime_pending_turn     = true;
 					$conversation_complete    = true;


### PR DESCRIPTION
## Summary
- align tool trace metadata array and assignment spacing after PR #2311

## Testing
- `php tests/tool-trace-metadata-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/conversation-loop.php inc/Engine/AI/RuntimeProvenance.php inc/Core/JobArtifacts.php tests/tool-trace-metadata-smoke.php`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Applied the lint-only formatting follow-up after the original PR merged; Chris remains responsible for review and merge.