### PR TITLE
Add source inventory system task

### DIFF
--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -34,6 +34,7 @@ use DataMachine\Engine\AI\System\Tasks\Retention\RetentionFilesTask;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionLogsTask;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionProcessedItemsTask;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionStaleClaimsTask;
+use DataMachine\Engine\AI\System\Tasks\SourceInventoryTask;
 use DataMachine\Engine\AI\System\Tasks\SystemTask;
 use DataMachine\Engine\Tasks\RecurringScheduleRegistry;
 use DataMachine\Engine\Tasks\RecurringScheduler;
@@ -77,6 +78,7 @@ class SystemAgentServiceProvider {
 		$tasks['agent_call']                             = AgentCallTask::class;
 		$tasks['dispatch_message']                       = DispatchMessageTask::class;
 		$tasks['emit_data_packets']                      = EmitDataPacketsTask::class;
+		$tasks['source_inventory']                       = SourceInventoryTask::class;
 		$tasks['image_generation']                       = ImageGenerationTask::class;
 		$tasks['image_optimization']                     = ImageOptimizationTask::class;
 		$tasks['alt_text_generation']                    = AltTextTask::class;

--- a/inc/Engine/AI/System/Tasks/SourceInventoryTask.php
+++ b/inc/Engine/AI/System/Tasks/SourceInventoryTask.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Source inventory system task.
+ *
+ * @package DataMachine\Engine\AI\System\Tasks
+ */
+
+namespace DataMachine\Engine\AI\System\Tasks;
+
+use DataMachine\Abilities\SourceInventoryAbility;
+
+defined( 'ABSPATH' ) || exit;
+
+class SourceInventoryTask extends SystemTask {
+
+	public function getTaskType(): string {
+		return 'source_inventory';
+	}
+
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Source Inventory',
+			'description'     => 'Inventory a configured source descriptor and optionally upsert tracked-items coverage state.',
+			'setting_key'     => null,
+			'default_enabled' => true,
+			'trigger'         => 'On-demand via workflow system_task step',
+			'trigger_type'    => 'manual',
+			'supports_run'    => true,
+			'mutates'         => true,
+			'params_schema'   => array(
+				'type'       => 'object',
+				'required'   => array( 'source' ),
+				'properties' => array(
+					'source'      => array(
+						'type'        => 'object',
+						'description' => 'Source descriptor. The source.kind field selects the registered inventory provider.',
+					),
+					'scan'        => array(
+						'type'        => 'boolean',
+						'description' => 'Whether to page through the source and collect items.',
+					),
+					'pagination'  => array( 'type' => 'object' ),
+					'group_by'    => array( 'type' => 'array' ),
+					'track_items' => array(
+						'type'        => 'object',
+						'description' => 'Optional tracked-items mapping used when scan=true.',
+					),
+				),
+			),
+		);
+	}
+
+	public function executeTask( int $jobId, array $params ): void {
+		$input = $this->normalizeInput( $params );
+		if ( empty( $input['source'] ) || ! is_array( $input['source'] ) ) {
+			$this->failJob( $jobId, 'source_inventory requires a source descriptor.' );
+			return;
+		}
+
+		$result = ( new SourceInventoryAbility() )->execute( $input );
+		if ( empty( $result['success'] ) ) {
+			$this->failJob( $jobId, (string) ( $result['error'] ?? 'Source inventory failed.' ) );
+			return;
+		}
+
+		$source = $input['source'];
+		$this->completeJob(
+			$jobId,
+			array(
+				'output_data_packets'  => array(
+					array(
+						'type'     => 'source_inventory_result',
+						'data'     => array(
+							'title'  => 'Source Inventory Completed',
+							'body'   => wp_json_encode( $result ),
+							'result' => $result,
+						),
+						'metadata' => array(
+							'source_type' => 'source_inventory',
+							'source_kind' => (string) ( $source['kind'] ?? '' ),
+							'source_ref'  => (string) ( $source['ref'] ?? $source['handle'] ?? $source['repo'] ?? '' ),
+							'source_path' => (string) ( $source['path'] ?? '' ),
+							'success'     => true,
+						),
+					),
+				),
+				'replace_data_packets' => false,
+				'source_inventory'     => $result,
+				'completed_at'         => current_time( 'mysql' ),
+			)
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $params Task params.
+	 * @return array<string,mixed>
+	 */
+	private function normalizeInput( array $params ): array {
+		if ( isset( $params['input'] ) && is_array( $params['input'] ) ) {
+			return $params['input'];
+		}
+
+		$input = array();
+		foreach ( array( 'source', 'scan', 'pagination', 'group_by', 'sample_limit_per_bucket', 'max_items', 'max_pages', 'track_items' ) as $key ) {
+			if ( array_key_exists( $key, $params ) ) {
+				$input[ $key ] = $params[ $key ];
+			}
+		}
+
+		return $input;
+	}
+}


### PR DESCRIPTION
## Summary
- Add a narrow `source_inventory` system task for deterministic source inventory inside pipelines.
- Source selection is explicit through `params.source.kind`; providers still plug into the existing source inventory callback seams.
- Emit a `source_inventory_result` packet while keeping docs generation as downstream pipeline/flow work rather than hiding it inside the task.

## Verification
- `php -l inc/Engine/AI/System/Tasks/SourceInventoryTask.php`
- `vendor/bin/phpcs inc/Engine/AI/System/Tasks/SourceInventoryTask.php inc/Engine/AI/System/SystemAgentServiceProvider.php`
- Deployed to `wp-docs-runtime`; verified `source_inventory` is registered in `TaskRegistry`.
- Runtime proof flow ID `4` / pipeline ID `4` ran a `system_task` step with `task_type=source_inventory`, `source.kind=workspace_files`, `handle=wordpress-develop`, and `path=src/wp-includes/abilities-api`.
- Runtime proof upserted 4 `source-file` tracked items into namespace `wp-docs:wordpress-core:abilities-api-system-task-pilot`; summary reported `total: 4`, `source-file/discovered: 4`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the bounded source inventory system task and ran runtime verification; Chris remains responsible for review and testing.
