### PR TITLE
Align workflow specs on step_type contract

### DIFF
--- a/docs/ai-tools/execute-workflow.md
+++ b/docs/ai-tools/execute-workflow.md
@@ -22,12 +22,12 @@ The ExecuteWorkflow tool enables AI agents to execute complete multi-step workfl
 
 ## Step Configuration
 
-Ephemeral workflow specs use the canonical fields `type`, `handler_slugs`, `handler_configs`, and `flow_step_settings`. Stored pipeline and flow config rows use `step_type` internally, but workflow input uses `type`. The old handler aliases `handler_slug` and `handler_config` are rejected by the shared workflow validator.
+Workflow specs use the same canonical fields as stored pipeline and flow config: `step_type`, `handler_slugs`, `handler_configs`, and `flow_step_settings`. The `type` field is accepted only as a compatibility alias for older ephemeral workflow specs. The old handler aliases `handler_slug` and `handler_config` are rejected by the shared workflow validator.
 
 ### Fetch Steps
 ```json
 {
-  "type": "fetch",
+  "step_type": "fetch",
   "handler_slugs": ["handler_name"],
   "handler_configs": {
     "handler_name": {
@@ -41,7 +41,7 @@ Ephemeral workflow specs use the canonical fields `type`, `handler_slugs`, `hand
 ### AI Steps
 ```json
 {
-  "type": "ai",
+  "step_type": "ai",
   "provider": "anthropic",
   "model": "claude-sonnet-4-20250514",
   "user_message": "Instruction for AI processing",
@@ -54,7 +54,7 @@ Ephemeral workflow specs use the canonical fields `type`, `handler_slugs`, `hand
 ### Publish Steps
 ```json
 {
-  "type": "publish",
+  "step_type": "publish",
   "handler_slugs": ["handler_name"],
   "handler_configs": {
     "handler_name": {
@@ -68,7 +68,7 @@ Ephemeral workflow specs use the canonical fields `type`, `handler_slugs`, `hand
 ### Upsert Steps
 ```json
 {
-  "type": "upsert",
+  "step_type": "upsert",
   "handler_slugs": ["handler_name"],
   "handler_configs": {
     "handler_name": {
@@ -82,7 +82,7 @@ Ephemeral workflow specs use the canonical fields `type`, `handler_slugs`, `hand
 ### System Task Steps
 ```json
 {
-  "type": "system_task",
+  "step_type": "system_task",
   "flow_step_settings": {
     "task_type": "alt_text_generation",
     "params": {
@@ -100,7 +100,7 @@ Ephemeral workflow specs use the canonical fields `type`, `handler_slugs`, `hand
 {
   "steps": [
     {
-      "type": "fetch",
+      "step_type": "fetch",
       "handler_slugs": ["rss"],
       "handler_configs": {
         "rss": {
@@ -109,11 +109,11 @@ Ephemeral workflow specs use the canonical fields `type`, `handler_slugs`, `hand
       }
     },
     {
-      "type": "ai",
+      "step_type": "ai",
       "user_message": "Summarize this content and make it engaging for social media"
     },
     {
-      "type": "publish",
+      "step_type": "publish",
       "handler_slugs": ["twitter"],
       "handler_configs": {
         "twitter": {}
@@ -128,7 +128,7 @@ Ephemeral workflow specs use the canonical fields `type`, `handler_slugs`, `hand
 {
   "steps": [
     {
-      "type": "fetch",
+      "step_type": "fetch",
       "handler_slugs": ["wordpress_local"],
       "handler_configs": {
         "wordpress_local": {
@@ -138,11 +138,11 @@ Ephemeral workflow specs use the canonical fields `type`, `handler_slugs`, `hand
       }
     },
     {
-      "type": "ai",
+      "step_type": "ai",
       "user_message": "Update these posts with better SEO titles and meta descriptions"
     },
     {
-      "type": "upsert",
+      "step_type": "upsert",
       "handler_slugs": ["wordpress_update"],
       "handler_configs": {
         "wordpress_update": {}
@@ -157,7 +157,7 @@ Ephemeral workflow specs use the canonical fields `type`, `handler_slugs`, `hand
 {
   "steps": [
     {
-      "type": "fetch",
+      "step_type": "fetch",
       "handler_slugs": ["files"],
       "handler_configs": {
         "files": {
@@ -166,22 +166,22 @@ Ephemeral workflow specs use the canonical fields `type`, `handler_slugs`, `hand
       }
     },
     {
-      "type": "ai",
+      "step_type": "ai",
       "user_message": "Adapt this content for different social media platforms"
     },
     {
-      "type": "publish",
+      "step_type": "publish",
       "handler_slugs": ["twitter"],
       "handler_configs": {
         "twitter": {}
       }
     },
     {
-      "type": "ai",
+      "step_type": "ai",
       "user_message": "Create a longer version for Facebook"
     },
     {
-      "type": "publish",
+      "step_type": "publish",
       "handler_slugs": ["facebook"],
       "handler_configs": {
         "facebook": {}
@@ -196,7 +196,7 @@ Ephemeral workflow specs use the canonical fields `type`, `handler_slugs`, `hand
 ### WordPress Publish Handler
 ```json
 {
-  "type": "publish",
+  "step_type": "publish",
   "handler_slugs": ["wordpress"],
   "handler_configs": {
     "wordpress": {
@@ -213,7 +213,7 @@ Ephemeral workflow specs use the canonical fields `type`, `handler_slugs`, `hand
 ### Social Media Handlers
 ```json
 {
-  "type": "publish",
+  "step_type": "publish",
   "handler_slugs": ["twitter"],
   "handler_configs": {
     "twitter": {}

--- a/docs/api/endpoints/execute.md
+++ b/docs/api/endpoints/execute.md
@@ -43,20 +43,24 @@ An ephemeral workflow must contain a `steps` array:
   "workflow": {
     "steps": [
       {
-        "type": "fetch",
-        "handler_slug": "rss",
-        "handler_config": { "feed_url": "https://example.com/feed" }
+        "step_type": "fetch",
+        "handler_slugs": ["rss"],
+        "handler_configs": {
+          "rss": { "feed_url": "https://example.com/feed" }
+        }
       },
       {
-        "type": "ai",
+        "step_type": "ai",
         "provider": "anthropic",
         "model": "claude-3-5-sonnet-20240620",
         "system_prompt": "Summarize this content"
       },
       {
-        "type": "publish",
-        "handler_slug": "wordpress-post",
-        "handler_config": { "post_status": "draft" }
+        "step_type": "publish",
+        "handler_slugs": ["wordpress-post"],
+        "handler_configs": {
+          "wordpress-post": { "post_status": "draft" }
+        }
       }
     ]
   }

--- a/docs/core-system/system-tasks.md
+++ b/docs/core-system/system-tasks.md
@@ -38,7 +38,7 @@ abstract class SystemTask {
 [
     'steps' => [
         [
-            'type' => 'system_task',
+            'step_type' => 'system_task',
             'flow_step_settings' => [
                 'task_type' => $this->getTaskType(),
                 'params'    => $params,

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -12,7 +12,7 @@ Data Machine provides a broad WP-CLI surface for managing pipelines, flows, jobs
 - **Handlers** are integrations selected by handler-backed step types. Only step types with `uses_handler=yes` accept handlers.
 - **System tasks** are named operational jobs. Use them for bounded tasks such as alt text, retention, internal links, and memory maintenance. Use pipelines/flows for reusable multi-step workflows instead of hiding workflow composition inside one system task.
 
-Ephemeral workflow JSON uses canonical fields: `type`, `handler_slugs`, `handler_configs`, and `flow_step_settings`. Stored pipeline and flow config rows continue to use `step_type` internally; `step_type` is rejected only when submitted in an ephemeral workflow spec, where `type` is the public workflow key. Legacy handler aliases such as `handler`, `handler_slug`, and `handler_config` are rejected on normal workflow paths.
+Workflow JSON uses the same canonical fields across entry points: `step_type`, `handler_slugs`, `handler_configs`, and `flow_step_settings`. The `type` field is accepted only as a compatibility alias for older ephemeral workflow specs; new workflows, pipelines, flows, and system tasks should use `step_type`. Legacy handler aliases such as `handler`, `handler_slug`, and `handler_config` are rejected on normal workflow paths.
 
 ## Available Commands
 

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -46,7 +46,7 @@ class ExecuteWorkflowAbility {
 								'properties'  => array(
 									'steps' => array(
 										'type'        => 'array',
-										'description' => __( 'Array of step objects with type, handler_slugs, handler_configs, and flow_step_settings', 'data-machine' ),
+										'description' => __( 'Array of step objects with step_type, handler_slugs, handler_configs, and flow_step_settings', 'data-machine' ),
 									),
 								),
 							),

--- a/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
+++ b/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
@@ -44,15 +44,15 @@ class ExecuteWorkflowTool extends BaseTool {
 
 		$description = 'Execute an ephemeral workflow (not saved to database).
 
-STEP FORMAT: {type: "' . $types_list . '", handler_slugs?, handler_configs?, flow_step_settings?, user_message?, system_prompt?, agent_modes?}
+STEP FORMAT: {step_type: "' . $types_list . '", handler_slugs?, handler_configs?, flow_step_settings?, user_message?, system_prompt?, agent_modes?}
 
 Use api_query GET /datamachine/v1/handlers/{slug} for handler_configs fields.
 
 EXAMPLE:
 [
-  {"type": "fetch", "handler_slugs": ["rss"], "handler_configs": {"rss": {"feed_url": "..."}}},
-  {"type": "ai", "user_message": "Summarize for social media"},
-  {"type": "publish", "handler_slugs": ["wordpress_publish"], "handler_configs": {"wordpress_publish": {"post_type": "post"}}}
+  {"step_type": "fetch", "handler_slugs": ["rss"], "handler_configs": {"rss": {"feed_url": "..."}}},
+  {"step_type": "ai", "user_message": "Summarize for social media"},
+  {"step_type": "publish", "handler_slugs": ["wordpress_publish"], "handler_configs": {"wordpress_publish": {"post_type": "post"}}}
 ]';
 
 		return array(
@@ -65,7 +65,7 @@ EXAMPLE:
 					'steps'   => array(
 						'type'        => 'array',
 						'items'       => array( 'type' => 'object' ),
-						'description' => 'Step objects: {type, handler_slugs, handler_configs}. AI steps: {type: "ai", user_message}.',
+						'description' => 'Step objects: {step_type, handler_slugs, handler_configs}. AI steps: {step_type: "ai", user_message}.',
 					),
 					'dry_run' => array(
 						'type'        => 'boolean',

--- a/inc/Core/Steps/FlowStepConfigFactory.php
+++ b/inc/Core/Steps/FlowStepConfigFactory.php
@@ -24,7 +24,7 @@ class FlowStepConfigFactory {
 	 * @return array Flow step config row.
 	 */
 	public static function buildFromWorkflowStep( array $step, int $index ): array {
-		$step_type = $step['type'];
+		$step_type = self::getWorkflowStepType( $step );
 		$config    = self::build(
 			array_merge(
 				array(
@@ -180,7 +180,7 @@ class FlowStepConfigFactory {
 			? trim( $step['user_message'] )
 			: '';
 
-		if ( 'ai' !== ( $step['type'] ?? '' ) || '' === $workflow_user_message ) {
+		if ( 'ai' !== self::getWorkflowStepType( $step ) || '' === $workflow_user_message ) {
 			return array( QueueAbility::SLOT_PROMPT_QUEUE => array() );
 		}
 
@@ -327,5 +327,19 @@ class FlowStepConfigFactory {
 		}
 
 		return array_values( array_unique( $sanitized ) );
+	}
+
+	/**
+	 * Resolve the workflow step type from canonical or compatibility fields.
+	 *
+	 * `step_type` is the canonical shared field. `type` is accepted only for
+	 * compatibility with older ephemeral workflow specs.
+	 *
+	 * @param array $step Workflow step input.
+	 * @return string Step type slug.
+	 */
+	private static function getWorkflowStepType( array $step ): string {
+		$step_type = $step['step_type'] ?? ( $step['type'] ?? '' );
+		return is_string( $step_type ) ? $step_type : '';
 	}
 }

--- a/inc/Core/Steps/WorkflowConfigFactory.php
+++ b/inc/Core/Steps/WorkflowConfigFactory.php
@@ -122,7 +122,7 @@ class WorkflowConfigFactory {
 	 * @return array<string,mixed> Pipeline step config.
 	 */
 	private static function pipelineStepFromWorkflowStep( array $step, string $pipeline_step_id, int $index ): array {
-		$step_type = (string) ( $step['type'] ?? '' );
+		$step_type = self::getWorkflowStepType( $step );
 		$label     = isset( $step['label'] ) && is_string( $step['label'] ) && '' !== trim( $step['label'] )
 			? $step['label']
 			: ucfirst( str_replace( '_', ' ', $step_type ) );
@@ -186,5 +186,16 @@ class WorkflowConfigFactory {
 		}
 
 		return array_values( array_unique( $sanitized ) );
+	}
+
+	/**
+	 * Resolve the workflow step type from canonical or compatibility fields.
+	 *
+	 * @param array $step Workflow step input.
+	 * @return string Step type slug.
+	 */
+	private static function getWorkflowStepType( array $step ): string {
+		$step_type = $step['step_type'] ?? ( $step['type'] ?? '' );
+		return is_string( $step_type ) ? $step_type : '';
 	}
 }

--- a/inc/Core/Steps/WorkflowSpecValidator.php
+++ b/inc/Core/Steps/WorkflowSpecValidator.php
@@ -58,13 +58,6 @@ class WorkflowSpecValidator {
 				);
 			}
 
-			if ( array_key_exists( 'step_type', $step ) ) {
-				return array(
-					'valid' => false,
-					'error' => "Step {$index} uses stored-config field step_type; ephemeral workflow specs use type",
-				);
-			}
-
 			foreach ( array( 'handler', 'handler_slug', 'handler_config' ) as $legacy_field ) {
 				if ( array_key_exists( $legacy_field, $step ) ) {
 					return array(
@@ -74,18 +67,18 @@ class WorkflowSpecValidator {
 				}
 			}
 
-			$step_type = $step['type'] ?? null;
+			$step_type = $step['step_type'] ?? ( $step['type'] ?? null );
 			if ( ! is_string( $step_type ) || '' === trim( $step_type ) ) {
 				return array(
 					'valid' => false,
-					'error' => "Step {$index} missing type",
+					'error' => "Step {$index} missing step_type",
 				);
 			}
 
 			if ( ! in_array( $step_type, $valid_types, true ) ) {
 				return array(
 					'valid' => false,
-					'error' => "Step {$index} has invalid type: {$step_type}. Valid types: " . implode( ', ', $valid_types ),
+					'error' => "Step {$index} has invalid step_type: {$step_type}. Valid types: " . implode( ', ', $valid_types ),
 				);
 			}
 		}

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -68,7 +68,7 @@ abstract class SystemTask {
 		return array(
 			'steps' => array(
 				array(
-					'type'               => 'system_task',
+					'step_type'          => 'system_task',
 					'flow_step_settings' => array(
 						'task_type' => $this->getTaskType(),
 						'params'    => $params,

--- a/tests/Unit/Engine/AI/System/Tasks/ImageGenerationTaskTest.php
+++ b/tests/Unit/Engine/AI/System/Tasks/ImageGenerationTaskTest.php
@@ -57,7 +57,7 @@ class ImageGenerationTaskTest extends WP_UnitTestCase {
 		$workflow = $this->task->getWorkflow( [ 'image_url' => 'https://example.com/generated.png' ] );
 		$this->assertArrayHasKey( 'steps', $workflow );
 		$this->assertCount( 1, $workflow['steps'] );
-		$this->assertSame( 'system_task', $workflow['steps'][0]['type'] );
+		$this->assertSame( 'system_task', $workflow['steps'][0]['step_type'] );
 		$this->assertSame( 'image_generation', $workflow['steps'][0]['flow_step_settings']['task_type'] );
 	}
 

--- a/tests/flow-step-config-factory-smoke.php
+++ b/tests/flow-step-config-factory-smoke.php
@@ -70,7 +70,7 @@ function assert_factory_equals( $expected, $actual, string $name, array &$failur
 function legacy_workflow_step_config_for_test( array $step, int $index ): array {
 	$step_id          = "ephemeral_step_{$index}";
 	$pipeline_step_id = "ephemeral_pipeline_{$index}";
-	$step_type        = $step['type'];
+	$step_type        = $step['step_type'] ?? ( $step['type'] ?? '' );
 	$prompt_queue     = array();
 
 	$workflow_user_message = is_string( $step['user_message'] ?? null )
@@ -166,22 +166,22 @@ echo "-----------------------------------\n";
 
 $workflow_cases = array(
 	'fetch keeps canonical handler shape'     => array(
-		'type'            => 'fetch',
+		'step_type'       => 'fetch',
 		'handler_slugs'   => array( 'mcp' ),
 		'handler_configs' => array( 'mcp' => array( 'server' => 'a8c' ) ),
 		'disabled_tools'  => array( 'local_search' ),
 	),
 	'publish keeps multi-handler shape'       => array(
-		'type'            => 'publish',
+		'step_type'       => 'publish',
 		'handler_slugs'   => array( 'wordpress_publish' ),
 		'handler_configs' => array( 'wordpress_publish' => array( 'post_type' => 'post' ) ),
 	),
 	'system_task keeps handler-free settings' => array(
-		'type'               => 'system_task',
+		'step_type'          => 'system_task',
 		'flow_step_settings' => array( 'task_type' => 'daily_memory_generation' ),
 	),
 	'ai converts user message to prompt queue' => array(
-		'type'          => 'ai',
+		'step_type'     => 'ai',
 		'enabled_tools' => array( 'local_search' ),
 		'user_message'  => ' Summarize ',
 	),

--- a/tests/queue-mode-callsites-smoke.php
+++ b/tests/queue-mode-callsites-smoke.php
@@ -97,7 +97,7 @@ function assert_callsite( string $name, bool $cond, string $detail = '' ): void 
 function build_ephemeral_flow_step_for_test( array $step, int $index ): array {
 	$step_id          = "ephemeral_step_{$index}";
 	$pipeline_step_id = "ephemeral_pipeline_{$index}";
-	$step_type        = $step['type'];
+	$step_type        = $step['step_type'] ?? ( $step['type'] ?? '' );
 
 	$workflow_user_message = is_string( $step['user_message'] ?? null )
 		? trim( $step['user_message'] )
@@ -126,7 +126,7 @@ echo "=== queue-mode-callsites-smoke ===\n";
 
 echo "\n[ephemeral:1] AI workflow step with user_message → 1-entry static prompt_queue\n";
 $step = array(
-	'type'         => 'ai',
+	'step_type'    => 'ai',
 	'user_message' => 'Summarize for social media',
 );
 $cfg = build_ephemeral_flow_step_for_test( $step, 0 );
@@ -146,7 +146,7 @@ assert_callsite(
 
 echo "\n[ephemeral:2] AI workflow step with empty user_message → empty prompt_queue\n";
 $step = array(
-	'type'         => 'ai',
+	'step_type'    => 'ai',
 	'user_message' => '',
 );
 $cfg = build_ephemeral_flow_step_for_test( $step, 0 );
@@ -155,7 +155,7 @@ assert_callsite( 'queue_mode still static', 'static' === $cfg['queue_mode'] );
 
 echo "\n[ephemeral:3] AI workflow step with no user_message field → empty prompt_queue\n";
 $step = array(
-	'type' => 'ai',
+	'step_type' => 'ai',
 );
 $cfg = build_ephemeral_flow_step_for_test( $step, 0 );
 assert_callsite( 'missing input → empty queue', array() === $cfg['prompt_queue'] );
@@ -165,7 +165,7 @@ echo "\n[ephemeral:4] non-AI workflow step ignores user_message field even when 
 // be defensive: a fetch step with a stray user_message in its spec
 // should NOT seed a prompt_queue (only AI steps consume prompt_queue).
 $step = array(
-	'type'         => 'fetch',
+	'step_type'    => 'fetch',
 	'user_message' => 'should be ignored',
 );
 $cfg = build_ephemeral_flow_step_for_test( $step, 0 );
@@ -176,7 +176,7 @@ assert_callsite(
 
 echo "\n[ephemeral:5] whitespace-only user_message → empty prompt_queue\n";
 $step = array(
-	'type'         => 'ai',
+	'step_type'    => 'ai',
 	'user_message' => '   ',
 );
 $cfg = build_ephemeral_flow_step_for_test( $step, 0 );

--- a/tests/system-run-task-params-smoke.php
+++ b/tests/system-run-task-params-smoke.php
@@ -188,7 +188,7 @@ function smoke_default_system_task_workflow( string $task_type, array $params ):
 	return array(
 		'steps' => array(
 			array(
-				'type'               => 'system_task',
+				'step_type'          => 'system_task',
 				'flow_step_settings' => array(
 					'task_type' => $task_type,
 					'params'    => $params,

--- a/tests/system-task-config-passthrough-smoke.php
+++ b/tests/system-task-config-passthrough-smoke.php
@@ -87,7 +87,7 @@ $built = build_configs_from_workflow_for_test(
 	array(
 		'steps' => array(
 			array(
-				'type'           => 'system_task',
+				'step_type'      => 'system_task',
 				'flow_step_settings' => array(
 					'task_type' => 'daily_memory_generation',
 					'params'    => array(),
@@ -110,7 +110,7 @@ $built = build_configs_from_workflow_for_test(
 	array(
 		'steps' => array(
 			array(
-				'type'            => 'fetch',
+				'step_type'       => 'fetch',
 				'handler_slugs'   => array( 'mcp' ),
 				'handler_configs' => array( 'mcp' => array( 'server' => 'a8c' ) ),
 			),
@@ -131,7 +131,7 @@ $built = build_configs_from_workflow_for_test(
 	array(
 		'steps' => array(
 			array(
-				'type'            => 'publish',
+				'step_type'       => 'publish',
 				'handler_slugs'   => array( 'wordpress_publish' ),
 				'handler_configs' => array( 'wordpress_publish' => array( 'post_type' => 'post' ) ),
 			),
@@ -145,7 +145,7 @@ assert_absent( 'handler_slug', $step0, 'publish has no scalar handler_slug', $fa
 assert_absent( 'handler_config', $step0, 'publish has no scalar handler_config', $failures, $passes );
 
 echo "\n[4] webhook_gate with no config has no handler fields:\n";
-$built = build_configs_from_workflow_for_test( array( 'steps' => array( array( 'type' => 'webhook_gate' ) ) ) );
+$built = build_configs_from_workflow_for_test( array( 'steps' => array( array( 'step_type' => 'webhook_gate' ) ) ) );
 $step0 = $built['flow_config']['ephemeral_step_0'];
 assert_equals( array(), FlowStepConfig::getPrimaryHandlerConfig( $step0 ), 'webhook_gate config empty', $failures, $passes );
 assert_absent( 'handler_slug', $step0, 'webhook_gate has no handler_slug', $failures, $passes );
@@ -157,7 +157,7 @@ $built = build_configs_from_workflow_for_test(
 	array(
 		'steps' => array(
 			array(
-				'type'          => 'ai',
+				'step_type'     => 'ai',
 				'system_prompt' => 'be helpful',
 				'enabled_tools' => array( 'intelligence/search' ),
 			),

--- a/tests/system-task-contract-smoke.php
+++ b/tests/system-task-contract-smoke.php
@@ -34,6 +34,7 @@ $passes   = 0;
 echo "=== system-task-contract-smoke ===\n";
 
 echo "\n[1] task_type is the canonical workflow/settings key\n";
+datamachine_contract_assert_contains( $system_task, "'step_type'          => 'system_task'", 'SystemTask::getWorkflow writes canonical step_type', $failures, $passes );
 datamachine_contract_assert_contains( $system_task, "'task_type' => \$this->getTaskType()", 'SystemTask::getWorkflow writes task_type', $failures, $passes );
 datamachine_contract_assert_contains( $settings, "'task_type' => array", 'SystemTaskSettings exposes task_type field', $failures, $passes );
 

--- a/tests/system-task-workflow-validation-smoke.php
+++ b/tests/system-task-workflow-validation-smoke.php
@@ -9,7 +9,7 @@
  *
  * Run with: php tests/system-task-workflow-validation-smoke.php
  *
- * Background — this fix removes a hardcoded `'ai' !== $step['type']`
+ * Background — this fix removes a hardcoded `'ai' !== $step['step_type']`
  * exception that was rejecting all valid handler-free step types other
  * than ai (system_task, webhook_gate). The check itself was redundant
  * because step types validate their own config at execution; the
@@ -59,13 +59,6 @@ function validate_workflow_for_test( array $workflow ): array {
 	$valid_types         = array_keys( $step_type_abilities->getAllStepTypes() );
 
 	foreach ( $workflow['steps'] as $index => $step ) {
-		if ( array_key_exists( 'step_type', $step ) ) {
-			return array(
-				'valid' => false,
-				'error' => "Step {$index} uses stored-config field step_type; ephemeral workflow specs use type",
-			);
-		}
-
 		foreach ( array( 'handler', 'handler_slug', 'handler_config' ) as $legacy_field ) {
 			if ( array_key_exists( $legacy_field, $step ) ) {
 				return array(
@@ -75,14 +68,15 @@ function validate_workflow_for_test( array $workflow ): array {
 			}
 		}
 
-		if ( ! isset( $step['type'] ) ) {
-			return array( 'valid' => false, 'error' => "Step {$index} missing type" );
+		$step_type = $step['step_type'] ?? ( $step['type'] ?? null );
+		if ( ! is_string( $step_type ) || '' === trim( $step_type ) ) {
+			return array( 'valid' => false, 'error' => "Step {$index} missing step_type" );
 		}
 
-		if ( ! in_array( $step['type'], $valid_types, true ) ) {
+		if ( ! in_array( $step_type, $valid_types, true ) ) {
 			return array(
 				'valid' => false,
-				'error' => "Step {$index} has invalid type: {$step['type']}. Valid types: " . implode( ', ', $valid_types ),
+				'error' => "Step {$index} has invalid step_type: {$step_type}. Valid types: " . implode( ', ', $valid_types ),
 			);
 		}
 	}
@@ -104,7 +98,7 @@ echo "\n[1] system_task workflow with no handler_slug — VALID (regression fix)
 $wf = array(
 	'steps' => array(
 		array(
-			'type'               => 'system_task',
+			'step_type'          => 'system_task',
 			'flow_step_settings' => array(
 				'task_type' => 'daily_memory_generation',
 				'params'     => array(),
@@ -117,13 +111,13 @@ dm_assert( true === $r['valid'], 'system_task step accepted without handler_slug
 
 // -----------------------------------------------------------------
 echo "\n[2] webhook_gate step with no handler_slug — VALID\n";
-$wf = array( 'steps' => array( array( 'type' => 'webhook_gate' ) ) );
+$wf = array( 'steps' => array( array( 'step_type' => 'webhook_gate' ) ) );
 $r  = validate_workflow_for_test( $wf );
 dm_assert( true === $r['valid'], 'webhook_gate step accepted without handler_slug' );
 
 // -----------------------------------------------------------------
 echo "\n[3] ai step with no handler_slug — VALID (existing behavior)\n";
-$wf = array( 'steps' => array( array( 'type' => 'ai' ) ) );
+$wf = array( 'steps' => array( array( 'step_type' => 'ai' ) ) );
 $r  = validate_workflow_for_test( $wf );
 dm_assert( true === $r['valid'], 'ai step accepted without handler_slug' );
 
@@ -133,33 +127,26 @@ echo "\n[4] fetch step without handler_slug — VALID at workflow level\n";
 // will fail at runtime when it tries to dispatch to a missing handler.
 // This is the correct boundary: workflow validates structure, step types
 // validate their own config.
-$wf = array( 'steps' => array( array( 'type' => 'fetch' ) ) );
+$wf = array( 'steps' => array( array( 'step_type' => 'fetch' ) ) );
 $r  = validate_workflow_for_test( $wf );
 dm_assert( true === $r['valid'], 'fetch without handler_slug accepted at workflow level' );
 
 // -----------------------------------------------------------------
 echo "\n[5] fetch step WITH legacy handler_slug — INVALID\n";
-$wf = array( 'steps' => array( array( 'type' => 'fetch', 'handler_slug' => 'rss' ) ) );
+$wf = array( 'steps' => array( array( 'step_type' => 'fetch', 'handler_slug' => 'rss' ) ) );
 $r  = validate_workflow_for_test( $wf );
 dm_assert( false === $r['valid'], 'fetch with legacy handler_slug rejected' );
 dm_assert( str_contains( $r['error'] ?? '', 'unsupported legacy field handler_slug' ), 'legacy handler_slug error is explicit' );
 
 // -----------------------------------------------------------------
-echo "\n[5b] workflow spec with stored-config step_type — INVALID\n";
-$wf = array( 'steps' => array( array( 'step_type' => 'fetch' ) ) );
-$r  = validate_workflow_for_test( $wf );
-dm_assert( false === $r['valid'], 'workflow spec step_type rejected' );
-dm_assert( str_contains( $r['error'] ?? '', 'stored-config field step_type' ), 'workflow spec step_type error is explicit' );
-
-// -----------------------------------------------------------------
 echo "\n[6] publish step without handler_slug — VALID at workflow level\n";
-$wf = array( 'steps' => array( array( 'type' => 'publish' ) ) );
+$wf = array( 'steps' => array( array( 'step_type' => 'publish' ) ) );
 $r  = validate_workflow_for_test( $wf );
 dm_assert( true === $r['valid'], 'publish without handler_slug accepted at workflow level' );
 
 // -----------------------------------------------------------------
 echo "\n[7] upsert step without handler_slug — VALID at workflow level\n";
-$wf = array( 'steps' => array( array( 'type' => 'upsert' ) ) );
+$wf = array( 'steps' => array( array( 'step_type' => 'upsert' ) ) );
 $r  = validate_workflow_for_test( $wf );
 dm_assert( true === $r['valid'], 'upsert without handler_slug accepted at workflow level' );
 
@@ -168,12 +155,12 @@ echo "\n[8] mixed workflow: fetch + ai + system_task — VALID\n";
 $wf = array(
 	'steps' => array(
 		array(
-			'type'            => 'fetch',
+			'step_type'       => 'fetch',
 			'handler_slugs'   => array( 'rss' ),
 			'handler_configs' => array( 'rss' => array( 'feed_url' => 'https://example.com/feed.xml' ) ),
 		),
-		array( 'type' => 'ai' ),
-		array( 'type' => 'system_task', 'flow_step_settings' => array( 'task_type' => 'cleanup' ) ),
+		array( 'step_type' => 'ai' ),
+		array( 'step_type' => 'system_task', 'flow_step_settings' => array( 'task_type' => 'cleanup' ) ),
 	),
 );
 $r = validate_workflow_for_test( $wf );
@@ -181,10 +168,10 @@ dm_assert( true === $r['valid'], 'realistic mixed workflow valid' );
 
 // -----------------------------------------------------------------
 echo "\n[9] step with unregistered type — INVALID\n";
-$wf = array( 'steps' => array( array( 'type' => 'time_travel' ) ) );
+$wf = array( 'steps' => array( array( 'step_type' => 'time_travel' ) ) );
 $r  = validate_workflow_for_test( $wf );
 dm_assert( false === $r['valid'], 'unregistered type rejected' );
-dm_assert( str_contains( $r['error'], 'invalid type' ), 'error names the issue' );
+dm_assert( str_contains( $r['error'], 'invalid step_type' ), 'error names the issue' );
 dm_assert( str_contains( $r['error'], 'time_travel' ), 'error names the bad type' );
 dm_assert( str_contains( $r['error'], 'Valid types' ), 'error lists valid alternatives' );
 
@@ -199,10 +186,10 @@ $r = validate_workflow_for_test( array() );
 dm_assert( false === $r['valid'], 'workflow lacking steps array rejected' );
 
 // -----------------------------------------------------------------
-echo "\n[12] step missing type — INVALID\n";
+echo "\n[12] step missing step_type — INVALID\n";
 $r = validate_workflow_for_test( array( 'steps' => array( array() ) ) );
-dm_assert( false === $r['valid'], 'step without type rejected' );
-dm_assert( str_contains( $r['error'], 'missing type' ), 'error names the issue' );
+dm_assert( false === $r['valid'], 'step without step_type rejected' );
+dm_assert( str_contains( $r['error'], 'missing step_type' ), 'error names the issue' );
 dm_assert( str_contains( $r['error'], 'Step 0' ), 'error identifies the step index' );
 
 // -----------------------------------------------------------------
@@ -211,7 +198,7 @@ echo "\n[13] real-world DailyMemoryTask workflow — VALID (the bug case)\n";
 $wf = array(
 	'steps' => array(
 		array(
-			'type'               => 'system_task',
+			'step_type'          => 'system_task',
 			'flow_step_settings' => array(
 				'task_type' => 'daily_memory_generation',
 				'params'     => array( 'date' => '2026-04-24' ),

--- a/tests/workflow-spec-contract-smoke.php
+++ b/tests/workflow-spec-contract-smoke.php
@@ -121,15 +121,14 @@ $pipeline_harness = new WorkflowSpecPipelineHarness();
 $invalid_cases    = array(
 	'missing steps'     => array(),
 	'empty steps'       => array( 'steps' => array() ),
-	'associative steps' => array( 'steps' => array( 'first' => array( 'type' => 'fetch' ) ) ),
+	'associative steps' => array( 'steps' => array( 'first' => array( 'step_type' => 'fetch' ) ) ),
 	'scalar step'       => array( 'steps' => array( 'fetch' ) ),
-	'missing type'      => array( 'steps' => array( array( 'handler_slug' => 'rss' ) ) ),
-	'stored-config step_type field' => array( 'steps' => array( array( 'step_type' => 'fetch' ) ) ),
-	'legacy handler alias field' => array( 'steps' => array( array( 'type' => 'fetch', 'handler' => 'rss' ) ) ),
-	'legacy handler field' => array( 'steps' => array( array( 'type' => 'fetch', 'handler_slug' => 'rss' ) ) ),
-	'legacy config field'  => array( 'steps' => array( array( 'type' => 'fetch', 'handler_config' => array( 'url' => 'https://example.com' ) ) ) ),
-	'non-string type'   => array( 'steps' => array( array( 'type' => 123 ) ) ),
-	'unknown type'      => array( 'steps' => array( array( 'type' => 'time_travel' ) ) ),
+	'missing step_type' => array( 'steps' => array( array( 'handler_slug' => 'rss' ) ) ),
+	'legacy handler alias field' => array( 'steps' => array( array( 'step_type' => 'fetch', 'handler' => 'rss' ) ) ),
+	'legacy handler field' => array( 'steps' => array( array( 'step_type' => 'fetch', 'handler_slug' => 'rss' ) ) ),
+	'legacy config field'  => array( 'steps' => array( array( 'step_type' => 'fetch', 'handler_config' => array( 'url' => 'https://example.com' ) ) ) ),
+	'non-string step_type' => array( 'steps' => array( array( 'step_type' => 123 ) ) ),
+	'unknown step_type' => array( 'steps' => array( array( 'step_type' => 'time_travel' ) ) ),
 );
 
 foreach ( $invalid_cases as $case => $workflow ) {
@@ -142,9 +141,9 @@ foreach ( $invalid_cases as $case => $workflow ) {
 
 $valid_workflow = array(
 	'steps' => array(
-		array( 'type' => 'fetch' ),
-		array( 'type' => 'ai' ),
-		array( 'type' => 'system_task', 'flow_step_settings' => array( 'task_type' => 'daily_memory_generation' ) ),
+		array( 'step_type' => 'fetch' ),
+		array( 'step_type' => 'ai' ),
+		array( 'step_type' => 'system_task', 'flow_step_settings' => array( 'task_type' => 'daily_memory_generation' ) ),
 	),
 );
 
@@ -152,17 +151,28 @@ assert_workflow_spec_equals( array( 'valid' => true ), WorkflowSpecValidator::va
 assert_workflow_spec_equals( true, $pipeline_harness->validateForTest( $valid_workflow ), 'create-pipeline adapter accepts valid workflow', $failures, $passes );
 assert_workflow_spec_equals( array( 'success' => true ), workflow_execute_edge_for_test( $valid_workflow ), 'execute-workflow adapter accepts valid workflow', $failures, $passes );
 
+$compat_workflow = array(
+	'steps' => array(
+		array( 'type' => 'fetch' ),
+		array( 'type' => 'ai' ),
+	),
+);
+
+assert_workflow_spec_equals( array( 'valid' => true ), WorkflowSpecValidator::validate( $compat_workflow ), 'shared validator accepts type compatibility alias', $failures, $passes );
+$compat_configs = WorkflowConfigFactory::buildEphemeralConfigs( $compat_workflow );
+assert_workflow_spec_equals( array( 'fetch', 'ai' ), array_column( array_values( $compat_configs['pipeline_config'] ), 'step_type' ), 'type alias normalizes to canonical step_type rows', $failures, $passes );
+
 $configs         = WorkflowConfigFactory::buildEphemeralConfigs(
 	array(
 		'steps' => array(
 			array(
-				'type'            => 'fetch',
+				'step_type'       => 'fetch',
 				'label'           => 'Fetch Source',
 				'handler_slugs'   => array( 'mcp' ),
 				'handler_configs' => array( 'mcp' => array( 'server' => 'a8c' ) ),
 			),
 			array(
-				'type'           => 'ai',
+				'step_type'      => 'ai',
 				'label'          => 'Summarize',
 				'agent_modes'    => array( 'rl_task' ),
 				'system_prompt'  => 'Be concise.',
@@ -182,7 +192,7 @@ $configs         = WorkflowConfigFactory::buildEphemeralConfigs(
 				),
 			),
 			array(
-				'type'           => 'system_task',
+				'step_type'      => 'system_task',
 				'label'          => 'Cleanup',
 				'flow_step_settings' => array( 'task_type' => 'retention_logs' ),
 			),


### PR DESCRIPTION
## Summary
- Make `step_type` the canonical workflow spec field across execute-workflow, system tasks, pipelines, and flows.
- Keep `type` as a compatibility alias only at the workflow input boundary, normalizing it into canonical `step_type` rows.
- Update generated system task workflows to emit `step_type`.
- Update execute-workflow tool/API docs and smoke tests to use the shared canonical JSON shape.

## Testing
- `php tests/system-task-contract-smoke.php && php tests/system-run-task-params-smoke.php && php tests/system-task-workflow-validation-smoke.php && php tests/workflow-spec-contract-smoke.php && php tests/flow-step-config-factory-smoke.php && php tests/system-task-config-passthrough-smoke.php && php tests/queue-mode-callsites-smoke.php`
- `php tests/workflow-spec-contract-smoke.php && composer run lint -- --standard=phpcs.xml.dist inc/Abilities/Job/ExecuteWorkflowAbility.php inc/Api/Chat/Tools/ExecuteWorkflowTool.php inc/Core/Steps/FlowStepConfigFactory.php inc/Core/Steps/WorkflowConfigFactory.php inc/Core/Steps/WorkflowSpecValidator.php inc/Engine/AI/System/Tasks/SystemTask.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Corrected the workflow contract direction after review, updated implementation/docs/tests, and ran targeted verification for Chris to review.