### PR TITLE
Refresh Agents API runtime lock

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "f75cf68b3aa316953ed9da594a51f01b19fd6e04"
+                "reference": "88f99231187413c0c05b315dc1010727eb8c6e46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/f75cf68b3aa316953ed9da594a51f01b19fd6e04",
-                "reference": "f75cf68b3aa316953ed9da594a51f01b19fd6e04",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/88f99231187413c0c05b315dc1010727eb8c6e46",
+                "reference": "88f99231187413c0c05b315dc1010727eb8c6e46",
                 "shasum": ""
             },
             "require": {
@@ -50,7 +50,9 @@
                     "php tests/action-policy-values-smoke.php",
                     "php tests/consent-policy-smoke.php",
                     "php tests/tool-policy-contracts-smoke.php",
+                    "php tests/tool-tier-resolver-smoke.php",
                     "php tests/action-policy-resolver-smoke.php",
+                    "php tests/ability-meta-abilities-smoke.php",
                     "php tests/tool-runtime-smoke.php",
                     "php tests/pending-action-store-contract-smoke.php",
                     "php tests/approval-resolver-contract-smoke.php",
@@ -58,6 +60,7 @@
                     "php tests/identity-smoke.php",
                     "php tests/memory-metadata-contract-smoke.php",
                     "php tests/memory-store-resolver-smoke.php",
+                    "php tests/ability-lifecycle-bridge-smoke.php",
                     "php tests/approval-action-value-shape-smoke.php",
                     "php tests/workspace-scope-smoke.php",
                     "php tests/compaction-item-smoke.php",
@@ -67,12 +70,16 @@
                     "php tests/conversation-compaction-smoke.php",
                     "php tests/tool-pair-validator-smoke.php",
                     "php tests/markdown-section-compaction-smoke.php",
+                    "php tests/spin-detector-smoke.php",
+                    "php tests/identical-failure-tracker-smoke.php",
+                    "php tests/tool-result-truncator-smoke.php",
                     "php tests/context-registry-smoke.php",
                     "php tests/conversation-loop-smoke.php",
                     "php tests/conversation-loop-tool-execution-smoke.php",
                     "php tests/conversation-loop-completion-policy-smoke.php",
                     "php tests/conversation-loop-transcript-persister-smoke.php",
                     "php tests/conversation-loop-events-smoke.php",
+                    "php tests/conversation-loop-interrupt-source-smoke.php",
                     "php tests/iteration-budget-smoke.php",
                     "php tests/conversation-loop-budgets-smoke.php",
                     "php tests/channels-smoke.php",
@@ -88,6 +95,7 @@
                     "php tests/workflow-lifecycle-smoke.php",
                     "php tests/agents-workflow-ability-smoke.php",
                     "php tests/routine-smoke.php",
+                    "php tests/event-trigger-smoke.php",
                     "php tests/subagents-smoke.php",
                     "php tests/no-product-imports-smoke.php"
                 ]
@@ -101,7 +109,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-25T22:17:42+00:00"
+            "time": "2026-05-27T12:29:52+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",


### PR DESCRIPTION
## Summary
- refresh `automattic/agents-api` in `composer.lock` from `f75cf68` to `88f9923`
- brings in the Agents API conversation runtime classes used by Data Machine's merged conversation-loop code
- fixes PHPStan class-resolution failures on `inc/Engine/AI/conversation-loop.php`

## Testing
- `php tests/tool-trace-metadata-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`
- `homeboy --force-hot lint data-machine --path . --extension wordpress --changed-since origin/main`
- `homeboy --force-hot test data-machine --path . --extension wordpress --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the PHPStan class-resolution failure, refreshed the lockfile with Composer, and ran targeted verification; Chris remains responsible for review and merge.