### PR TITLE
Export hashable job trace artifacts

### DIFF
--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -19,6 +19,13 @@ defined( 'ABSPATH' ) || exit;
 
 class JobArtifacts {
 
+	private const TRANSCRIPT_ARTIFACT_SCHEMA_VERSION = 1;
+	private const TOOL_TRACE_ARTIFACT_SCHEMA_VERSION = 1;
+	private const MAX_TRANSCRIPT_MESSAGES           = 200;
+	private const MAX_TRANSCRIPT_CONTENT_CHARS      = 4000;
+	private const MAX_TOOL_TRACE_ENTRIES            = 200;
+	private const MAX_TOOL_TRACE_FIELD_CHARS        = 4000;
+
 	/**
 	 * Build a deterministic artifact payload for a job.
 	 *
@@ -48,7 +55,9 @@ class JobArtifacts {
 			$this->successful_tool_summaries( $engine_data ),
 			$this->successful_tool_summaries_from_list( $additional_tool_summaries )
 		);
-		$payload     = array(
+		$transcript_artifact = $this->transcript_artifact( $job_id, $job, $agent, $engine_data );
+		$tool_trace_artifact = $this->tool_trace_artifact( $job_id, $job, $agent, $engine_data, $additional_tool_summaries );
+		$payload             = array(
 			'job_id'                 => $job_id,
 			'status'                 => (string) ( $job['status'] ?? '' ),
 			'agent_id'               => $agent['agent_id'],
@@ -59,6 +68,9 @@ class JobArtifacts {
 			'successful_tool_calls'  => $tool_calls,
 			'tool_trace'             => $this->tool_trace( $engine_data, $additional_tool_summaries ),
 			'transcript'             => $this->transcript_metadata( $job_id, $engine_data ),
+			'artifact_refs'          => $this->hashable_artifact_refs( $transcript_artifact, $tool_trace_artifact ),
+			'transcript_artifact'    => $transcript_artifact,
+			'tool_trace_artifact'    => $tool_trace_artifact,
 			'agent_memory_artifacts' => $this->agent_memory_artifacts( $job, $agent, $tool_calls ),
 			'daily_memory_artifacts' => $this->daily_memory_artifacts( $job, $agent, $tool_calls ),
 		);
@@ -147,6 +159,312 @@ class JobArtifacts {
 		}
 
 		return $trace;
+	}
+
+	/**
+	 * @return array<string,array<string,mixed>>
+	 */
+	private function hashable_artifact_refs( ?array $transcript_artifact, ?array $tool_trace_artifact ): array {
+		$refs = array();
+		foreach ( array( 'transcript' => $transcript_artifact, 'tool_trace' => $tool_trace_artifact ) as $key => $artifact ) {
+			if ( ! is_array( $artifact ) ) {
+				continue;
+			}
+
+			$refs[ $key ] = array(
+				'artifact_ref'   => $artifact['artifact_ref'],
+				'artifact_type'  => $artifact['artifact_type'],
+				'schema_version' => $artifact['schema_version'],
+				'sha256'         => $artifact['sha256'],
+				'bounded'        => $artifact['bounded'],
+				'redacted'       => $artifact['redacted'],
+			);
+		}
+
+		return $refs;
+	}
+
+	/**
+	 * @return array<string,mixed>|null
+	 */
+	private function transcript_artifact( int $job_id, array $job, array $agent, array $engine_data ): ?array {
+		$session_id = (string) ( $engine_data['transcript_session_id'] ?? '' );
+		if ( '' === $session_id ) {
+			$session_id = $this->find_transcript_session_id_for_job( $job_id );
+		}
+
+		if ( '' === $session_id ) {
+			return null;
+		}
+
+		$session = ConversationStoreFactory::get()->get_session( $session_id );
+		if ( ! $session ) {
+			$payload = array(
+				'schema_version' => self::TRANSCRIPT_ARTIFACT_SCHEMA_VERSION,
+				'artifact_type'  => 'transcript',
+				'artifact_ref'   => $this->artifact_ref( $job_id, 'transcript', $session_id ),
+				'source'         => $this->artifact_source( $job_id, $job, $agent, array( 'session_id' => $session_id ) ),
+				'missing'        => true,
+				'bounded'        => true,
+				'redacted'       => true,
+			);
+
+			return $this->with_payload_hash( $payload );
+		}
+
+		$messages = is_array( $session['messages'] ?? null ) ? array_values( $session['messages'] ) : array();
+		$metadata = is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array();
+		$entries  = array();
+		foreach ( array_slice( $messages, 0, self::MAX_TRANSCRIPT_MESSAGES ) as $index => $message ) {
+			if ( is_array( $message ) ) {
+				$entries[] = $this->normalize_transcript_message( $message, $index );
+			}
+		}
+
+		$payload = array(
+			'schema_version'   => self::TRANSCRIPT_ARTIFACT_SCHEMA_VERSION,
+			'artifact_type'    => 'transcript',
+			'artifact_ref'     => $this->artifact_ref( $job_id, 'transcript', $session_id ),
+			'source'           => $this->artifact_source(
+				$job_id,
+				$job,
+				$agent,
+				array(
+					'session_id' => $session_id,
+					'provider'   => $session['provider'] ?? ( $metadata['provider'] ?? null ),
+					'model'      => $session['model'] ?? ( $metadata['model'] ?? null ),
+					'mode'       => $session['mode'] ?? null,
+				)
+			),
+			'message_count'    => count( $messages ),
+			'messages_emitted' => count( $entries ),
+			'messages_omitted' => max( 0, count( $messages ) - count( $entries ) ),
+			'entries'          => $entries,
+			'usage'            => is_array( $metadata['usage'] ?? null ) ? $this->redact_and_bound_value( $metadata['usage'] ) : null,
+			'completed'        => isset( $metadata['completed'] ) ? (bool) $metadata['completed'] : null,
+			'bounded'          => true,
+			'redacted'         => true,
+		);
+
+		return $this->with_payload_hash( $this->filter_empty( $payload ) );
+	}
+
+	/**
+	 * @return array<string,mixed>|null
+	 */
+	private function tool_trace_artifact( int $job_id, array $job, array $agent, array $engine_data, array $additional_tool_summaries ): ?array {
+		$trace = $this->tool_trace( $engine_data, $additional_tool_summaries );
+		if ( empty( $trace ) ) {
+			return null;
+		}
+
+		$entries = array();
+		foreach ( array_slice( $trace, 0, self::MAX_TOOL_TRACE_ENTRIES ) as $index => $entry ) {
+			if ( is_array( $entry ) ) {
+				$entries[] = $this->normalize_tool_trace_entry( $entry, $index );
+			}
+		}
+
+		$payload = array(
+			'schema_version'  => self::TOOL_TRACE_ARTIFACT_SCHEMA_VERSION,
+			'artifact_type'   => 'tool_trace',
+			'artifact_ref'    => $this->artifact_ref( $job_id, 'tool-trace' ),
+			'source'          => $this->artifact_source( $job_id, $job, $agent ),
+			'trace_count'     => count( $trace ),
+			'entries_emitted' => count( $entries ),
+			'entries_omitted' => max( 0, count( $trace ) - count( $entries ) ),
+			'entries'         => $entries,
+			'bounded'         => true,
+			'redacted'        => true,
+		);
+
+		return $this->with_payload_hash( $payload );
+	}
+
+	/** @return array<string,mixed> */
+	private function normalize_transcript_message( array $message, int $index ): array {
+		$content        = $message['content'] ?? '';
+		$content_hash   = $this->hash_payload( $content );
+		$content_output = $this->redact_and_bound_value( $content, self::MAX_TRANSCRIPT_CONTENT_CHARS );
+		$entry          = array(
+			'index'          => $index,
+			'role'           => isset( $message['role'] ) ? sanitize_key( (string) $message['role'] ) : null,
+			'actor'          => isset( $message['actor'] ) ? sanitize_key( (string) $message['actor'] ) : null,
+			'source'         => isset( $message['source'] ) ? sanitize_key( (string) $message['source'] ) : null,
+			'tool_call_id'   => isset( $message['tool_call_id'] ) ? sanitize_text_field( (string) $message['tool_call_id'] ) : null,
+			'name'           => isset( $message['name'] ) ? sanitize_text_field( (string) $message['name'] ) : null,
+			'created_at'     => isset( $message['created_at'] ) ? sanitize_text_field( (string) $message['created_at'] ) : null,
+			'content_sha256' => $content_hash,
+			'content'        => $content_output,
+			'tool_calls'     => $this->normalize_transcript_tool_calls( $message['tool_calls'] ?? array() ),
+			'metadata'       => is_array( $message['metadata'] ?? null ) ? $this->redact_and_bound_value( $message['metadata'], self::MAX_TOOL_TRACE_FIELD_CHARS ) : null,
+		);
+
+		return $this->filter_empty( $entry );
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private function normalize_transcript_tool_calls( mixed $tool_calls ): array {
+		if ( ! is_array( $tool_calls ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $tool_calls as $index => $tool_call ) {
+			if ( ! is_array( $tool_call ) ) {
+				continue;
+			}
+
+			$function  = is_array( $tool_call['function'] ?? null ) ? $tool_call['function'] : array();
+			$arguments = $function['arguments'] ?? ( $tool_call['arguments'] ?? null );
+			if ( is_string( $arguments ) ) {
+				$decoded = json_decode( $arguments, true );
+				if ( is_array( $decoded ) ) {
+					$arguments = $decoded;
+				}
+			}
+
+			$normalized[] = $this->filter_empty(
+				array(
+					'index'              => is_int( $index ) ? $index : count( $normalized ),
+					'id'                 => isset( $tool_call['id'] ) ? sanitize_text_field( (string) $tool_call['id'] ) : null,
+					'type'               => isset( $tool_call['type'] ) ? sanitize_key( (string) $tool_call['type'] ) : null,
+					'name'               => isset( $function['name'] ) ? sanitize_text_field( (string) $function['name'] ) : ( isset( $tool_call['name'] ) ? sanitize_text_field( (string) $tool_call['name'] ) : null ),
+					'arguments_sha256'   => null !== $arguments ? $this->hash_payload( $arguments ) : null,
+					'arguments_redacted' => null !== $arguments ? $this->redact_and_bound_value( $arguments, self::MAX_TOOL_TRACE_FIELD_CHARS ) : null,
+				)
+			);
+		}
+
+		return $normalized;
+	}
+
+	/** @return array<string,mixed> */
+	private function normalize_tool_trace_entry( array $entry, int $index ): array {
+		$normalized = $this->filter_empty(
+			array(
+				'index'              => $index,
+				'schema_version'     => isset( $entry['schema_version'] ) ? (int) $entry['schema_version'] : null,
+				'tool_name'          => isset( $entry['tool_name'] ) ? sanitize_key( (string) $entry['tool_name'] ) : null,
+				'tool_call_id'       => isset( $entry['tool_call_id'] ) ? sanitize_text_field( (string) $entry['tool_call_id'] ) : null,
+				'turn_count'         => isset( $entry['turn_count'] ) ? (int) $entry['turn_count'] : null,
+				'actor'              => isset( $entry['actor'] ) ? sanitize_key( (string) $entry['actor'] ) : null,
+				'source'             => isset( $entry['source'] ) ? sanitize_key( (string) $entry['source'] ) : null,
+				'status'             => isset( $entry['status'] ) ? sanitize_key( (string) $entry['status'] ) : null,
+				'started_at'         => isset( $entry['started_at'] ) ? sanitize_text_field( (string) $entry['started_at'] ) : null,
+				'ended_at'           => isset( $entry['ended_at'] ) ? sanitize_text_field( (string) $entry['ended_at'] ) : null,
+				'duration_ms'        => isset( $entry['duration_ms'] ) ? (int) $entry['duration_ms'] : null,
+				'arguments_sha256'   => isset( $entry['arguments_sha256'] ) ? sanitize_text_field( (string) $entry['arguments_sha256'] ) : null,
+				'result_sha256'      => isset( $entry['result_sha256'] ) ? sanitize_text_field( (string) $entry['result_sha256'] ) : null,
+				'output_summary'     => isset( $entry['output_summary'] ) ? $this->bound_string( sanitize_text_field( (string) $entry['output_summary'] ), 500 ) : null,
+				'artifact_refs'      => is_array( $entry['artifact_refs'] ?? null ) ? $this->redact_and_bound_value( $entry['artifact_refs'], self::MAX_TOOL_TRACE_FIELD_CHARS ) : null,
+				'arguments_redacted' => isset( $entry['arguments_redacted'] ) ? $this->redact_and_bound_value( $entry['arguments_redacted'], self::MAX_TOOL_TRACE_FIELD_CHARS ) : null,
+				'arguments_omitted'  => isset( $entry['arguments_omitted'] ) ? sanitize_key( (string) $entry['arguments_omitted'] ) : null,
+				'metadata'           => is_array( $entry['metadata'] ?? null ) ? $this->redact_and_bound_value( $entry['metadata'], self::MAX_TOOL_TRACE_FIELD_CHARS ) : null,
+			)
+		);
+
+		$normalized['entry_sha256'] = $this->hash_payload( $normalized );
+		return $normalized;
+	}
+
+	/** @return array<string,mixed> */
+	private function artifact_source( int $job_id, array $job, array $agent, array $extra = array() ): array {
+		return $this->filter_empty(
+			array_merge(
+				array(
+					'job_id'       => $job_id,
+					'job_status'   => isset( $job['status'] ) ? (string) $job['status'] : null,
+					'agent_id'     => $agent['agent_id'],
+					'agent_slug'   => $agent['agent_slug'],
+					'user_id'      => isset( $job['user_id'] ) ? (int) $job['user_id'] : null,
+					'pipeline_id'  => isset( $job['pipeline_id'] ) ? (int) $job['pipeline_id'] : null,
+					'flow_id'      => isset( $job['flow_id'] ) ? (int) $job['flow_id'] : null,
+					'flow_step_id' => isset( $job['flow_step_id'] ) ? (int) $job['flow_step_id'] : null,
+					'created_at'   => isset( $job['created_at'] ) ? sanitize_text_field( (string) $job['created_at'] ) : null,
+					'completed_at' => isset( $job['completed_at'] ) ? sanitize_text_field( (string) $job['completed_at'] ) : null,
+				),
+				$extra
+			)
+		);
+	}
+
+	private function artifact_ref( int $job_id, string $artifact_type, string $qualifier = '' ): string {
+		$ref = 'datamachine://jobs/' . $job_id . '/artifacts/' . sanitize_key( $artifact_type );
+		if ( '' !== $qualifier ) {
+			$ref .= '/' . rawurlencode( $qualifier );
+		}
+
+		return $ref;
+	}
+
+	/** @return array<string,mixed> */
+	private function with_payload_hash( array $payload ): array {
+		$payload['sha256'] = $this->hash_payload( $payload );
+		return $payload;
+	}
+
+	private function hash_payload( mixed $payload ): string {
+		$json = wp_json_encode( $this->canonicalize( $payload ), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+		return hash( 'sha256', (string) $json );
+	}
+
+	private function canonicalize( mixed $value ): mixed {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$is_list = array_keys( $value ) === range( 0, count( $value ) - 1 );
+		if ( ! $is_list ) {
+			ksort( $value, SORT_STRING );
+		}
+
+		foreach ( $value as $key => $child ) {
+			$value[ $key ] = $this->canonicalize( $child );
+		}
+
+		return $value;
+	}
+
+	private function redact_and_bound_value( mixed $value, int $max_string_chars = self::MAX_TOOL_TRACE_FIELD_CHARS ): mixed {
+		if ( is_array( $value ) ) {
+			$redacted = array();
+			foreach ( $value as $key => $child ) {
+				$key_string = (string) $key;
+				if ( preg_match( '/(api[_-]?key|auth|bearer|cookie|credential|nonce|password|secret|signature|token)/i', $key_string ) ) {
+					$redacted[ $key ] = '[redacted]';
+					continue;
+				}
+
+				$redacted[ $key ] = $this->redact_and_bound_value( $child, $max_string_chars );
+			}
+
+			return $redacted;
+		}
+
+		if ( is_string( $value ) ) {
+			$redacted = preg_replace( '/Bearer\s+[A-Za-z0-9._~+\/\-]+=*/i', 'Bearer [redacted]', $value );
+			$redacted = preg_replace( '/\b(api[_-]?key|token|secret|password)\b\s*[:=]\s*\S+/i', '$1: [redacted]', $redacted ?? $value );
+			return $this->bound_string( $redacted ?? $value, $max_string_chars );
+		}
+
+		return $value;
+	}
+
+	private function bound_string( string $value, int $max_chars ): string {
+		if ( strlen( $value ) <= $max_chars ) {
+			return $value;
+		}
+
+		return substr( $value, 0, max( 0, $max_chars - 3 ) ) . '...';
+	}
+
+	/** @return array<string,mixed> */
+	private function filter_empty( array $value ): array {
+		return array_filter(
+			$value,
+			static fn( $child ) => null !== $child && '' !== $child && array() !== $child
+		);
 	}
 
 	/**

--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -21,10 +21,10 @@ class JobArtifacts {
 
 	private const TRANSCRIPT_ARTIFACT_SCHEMA_VERSION = 1;
 	private const TOOL_TRACE_ARTIFACT_SCHEMA_VERSION = 1;
-	private const MAX_TRANSCRIPT_MESSAGES           = 200;
-	private const MAX_TRANSCRIPT_CONTENT_CHARS      = 4000;
-	private const MAX_TOOL_TRACE_ENTRIES            = 200;
-	private const MAX_TOOL_TRACE_FIELD_CHARS        = 4000;
+	private const MAX_TRANSCRIPT_MESSAGES            = 200;
+	private const MAX_TRANSCRIPT_CONTENT_CHARS       = 4000;
+	private const MAX_TOOL_TRACE_ENTRIES             = 200;
+	private const MAX_TOOL_TRACE_FIELD_CHARS         = 4000;
 
 	/**
 	 * Build a deterministic artifact payload for a job.
@@ -49,9 +49,9 @@ class JobArtifacts {
 			);
 		}
 
-		$engine_data = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
-		$agent       = $this->resolve_agent( $job, $engine_data );
-		$tool_calls  = array_merge(
+		$engine_data         = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$agent               = $this->resolve_agent( $job, $engine_data );
+		$tool_calls          = array_merge(
 			$this->successful_tool_summaries( $engine_data ),
 			$this->successful_tool_summaries_from_list( $additional_tool_summaries )
 		);
@@ -166,7 +166,12 @@ class JobArtifacts {
 	 */
 	private function hashable_artifact_refs( ?array $transcript_artifact, ?array $tool_trace_artifact ): array {
 		$refs = array();
-		foreach ( array( 'transcript' => $transcript_artifact, 'tool_trace' => $tool_trace_artifact ) as $key => $artifact ) {
+		foreach (
+			array(
+				'transcript' => $transcript_artifact,
+				'tool_trace' => $tool_trace_artifact,
+			) as $key => $artifact
+		) {
 			if ( ! is_array( $artifact ) ) {
 				continue;
 			}

--- a/tests/job-artifact-hashable-smoke.php
+++ b/tests/job-artifact-hashable-smoke.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Smoke tests for hashable job transcript and tool trace artifacts.
+ *
+ * Run with: php tests/job-artifact-hashable-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+require_once __DIR__ . '/bootstrap-unit.php';
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $flags = 0, int $depth = 512 ) {
+		return json_encode( $data, $flags, $depth );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ): string {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $value ): string {
+		return trim( wp_strip_all_tags( (string) $value ) );
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $value ): string {
+		$value = strtolower( (string) $value );
+		$value = preg_replace( '/[^a-z0-9]+/', '-', $value );
+		return trim( (string) $value, '-' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $value ): string {
+		return strip_tags( (string) $value );
+	}
+}
+
+use DataMachine\Core\JobArtifacts;
+
+$failures = array();
+$passes   = 0;
+
+$assert_true = static function ( bool $condition, string $label ) use ( &$failures, &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		return;
+	}
+
+	$failures[] = $label;
+};
+
+$invoke = static function ( JobArtifacts $artifacts, string $method, array $args ) {
+	$reflection = new ReflectionMethod( $artifacts, $method );
+	return $reflection->invokeArgs( $artifacts, $args );
+};
+
+$artifacts = new JobArtifacts();
+
+$message = $invoke(
+	$artifacts,
+	'normalize_transcript_message',
+	array(
+		array(
+			'role'       => 'assistant',
+			'content'    => 'Use Bearer sk-secret and token=plain-secret while calling the tool.',
+			'tool_calls' => array(
+				array(
+					'id'       => 'call_normal_1',
+					'type'     => 'function',
+					'function' => array(
+						'name'      => 'normal_tool',
+						'arguments' => '{"query":"status","password":"super-secret"}',
+					),
+				),
+			),
+			'metadata'   => array(
+				'source' => 'provider-response',
+				'token'  => 'metadata-secret',
+			),
+		),
+		0,
+	)
+);
+
+$message_json = wp_json_encode( $message );
+$assert_true( 'assistant' === $message['role'], 'transcript artifact preserves role' );
+$assert_true( 'call_normal_1' === $message['tool_calls'][0]['id'], 'transcript artifact preserves tool-call id' );
+$assert_true( 'normal_tool' === $message['tool_calls'][0]['name'], 'transcript artifact preserves tool-call name' );
+$assert_true( isset( $message['content_sha256'] ) && 64 === strlen( $message['content_sha256'] ), 'transcript artifact hashes raw content' );
+$assert_true( '[redacted]' === $message['tool_calls'][0]['arguments_redacted']['password'], 'transcript tool-call arguments redact secret keys' );
+$assert_true( false === str_contains( $message_json, 'sk-secret' ), 'transcript content redacts bearer secrets' );
+$assert_true( false === str_contains( $message_json, 'plain-secret' ), 'transcript content redacts token assignments' );
+$assert_true( false === str_contains( $message_json, 'metadata-secret' ), 'transcript metadata redacts secret keys' );
+
+$normal_trace = array(
+	'schema_version'     => 1,
+	'tool_name'          => 'normal_tool',
+	'tool_call_id'       => 'call_normal_1',
+	'turn_count'         => 1,
+	'actor'              => 'agent',
+	'source'             => 'data_machine',
+	'status'             => 'success',
+	'started_at'         => '2026-05-27T00:00:00+00:00',
+	'ended_at'           => '2026-05-27T00:00:01+00:00',
+	'duration_ms'        => 1000,
+	'arguments_sha256'   => str_repeat( 'a', 64 ),
+	'result_sha256'      => str_repeat( 'b', 64 ),
+	'arguments_redacted' => array( 'query' => 'status' ),
+	'metadata'           => array( 'request_id' => 'req-normal' ),
+);
+$runtime_trace = array(
+	'schema_version'     => 1,
+	'tool_name'          => 'runtime_tool',
+	'tool_call_id'       => 'call_runtime_1',
+	'turn_count'         => 2,
+	'actor'              => 'system',
+	'source'             => 'runtime_tool',
+	'status'             => 'success',
+	'started_at'         => '2026-05-27T00:00:02+00:00',
+	'ended_at'           => '2026-05-27T00:00:03+00:00',
+	'duration_ms'        => 1000,
+	'arguments_sha256'   => str_repeat( 'c', 64 ),
+	'result_sha256'      => str_repeat( 'd', 64 ),
+	'arguments_redacted' => array( 'api_key' => '[redacted]' ),
+	'artifact_refs'      => array( 'stdout' => 'artifacts/stdout.txt' ),
+	'metadata'           => array(
+		'runtime_request' => array( 'id' => 'runtime-req-1' ),
+		'runtime_result'  => array( 'status' => 'ok' ),
+		'token'           => 'runtime-secret',
+	),
+);
+
+$tool_trace_artifact = $invoke(
+	$artifacts,
+	'tool_trace_artifact',
+	array(
+		123,
+		array(
+			'status'       => 'completed',
+			'user_id'      => 7,
+			'pipeline_id'  => 8,
+			'flow_id'      => 9,
+			'flow_step_id' => 10,
+		),
+		array(
+			'agent_id'   => 11,
+			'agent_slug' => 'hash-agent',
+		),
+		array(
+			'tool_execution_summary' => array(
+				array(
+					'success' => true,
+					'trace'   => $normal_trace,
+				),
+			),
+		),
+		array(
+			array(
+				'success' => true,
+				'trace'   => $runtime_trace,
+			),
+		),
+	)
+);
+
+$artifact_json = wp_json_encode( $tool_trace_artifact );
+$assert_true( 'tool_trace' === $tool_trace_artifact['artifact_type'], 'tool trace artifact is typed' );
+$assert_true( str_starts_with( $tool_trace_artifact['artifact_ref'], 'datamachine://jobs/123/artifacts/tool-trace' ), 'tool trace artifact has stable ref' );
+$assert_true( 2 === $tool_trace_artifact['trace_count'], 'tool trace artifact covers normal and runtime traces' );
+$assert_true( 'call_normal_1' === $tool_trace_artifact['entries'][0]['tool_call_id'], 'normal tool-call id is preserved' );
+$assert_true( 'call_runtime_1' === $tool_trace_artifact['entries'][1]['tool_call_id'], 'runtime tool-call id is preserved' );
+$assert_true( 'runtime_tool' === $tool_trace_artifact['entries'][1]['source'], 'runtime tool source is preserved' );
+$assert_true( 'runtime-req-1' === $tool_trace_artifact['entries'][1]['metadata']['runtime_request']['id'], 'runtime request metadata is preserved' );
+$assert_true( 'ok' === $tool_trace_artifact['entries'][1]['metadata']['runtime_result']['status'], 'runtime result metadata is preserved' );
+$assert_true( isset( $tool_trace_artifact['sha256'] ) && 64 === strlen( $tool_trace_artifact['sha256'] ), 'tool trace artifact has stable payload hash' );
+$assert_true( isset( $tool_trace_artifact['entries'][1]['entry_sha256'] ) && 64 === strlen( $tool_trace_artifact['entries'][1]['entry_sha256'] ), 'tool trace entries have stable hashes' );
+$assert_true( false === str_contains( $artifact_json, 'runtime-secret' ), 'tool trace artifact redacts metadata secrets' );
+
+$refs = $invoke( $artifacts, 'hashable_artifact_refs', array( null, $tool_trace_artifact ) );
+$assert_true( $tool_trace_artifact['sha256'] === $refs['tool_trace']['sha256'], 'artifact refs expose tool trace hash' );
+$assert_true( $tool_trace_artifact['artifact_ref'] === $refs['tool_trace']['artifact_ref'], 'artifact refs expose stable tool trace ref' );
+
+if ( $failures ) {
+	echo "FAILED: " . count( $failures ) . " hashable artifact assertions failed.\n";
+	foreach ( $failures as $failure ) {
+		echo " - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "Hashable job artifact smoke passed ({$passes} assertions).\n";


### PR DESCRIPTION
## Summary
- Add versioned, bounded, redacted transcript and tool trace artifacts to job artifact exports.
- Include stable artifact refs and SHA-256 hashes so consumers can reference replay/audit payloads without reading raw database internals.
- Preserve tool-call IDs, runtime request/result metadata, actor/source context, timing, artifact refs, and per-entry hashes while keeping eval/reward/scenario semantics out of core.
- Add smoke coverage for transcript redaction plus normal and runtime tool trace artifacts.

Fixes #2324.

## Verification
- php tests/job-artifact-hashable-smoke.php
- php tests/tool-trace-metadata-smoke.php
- php tests/agents-api-transcript-store-smoke.php
- php tests/run-artifact-egress-policy-smoke.php
- php tests/pipeline-transcript-session-link-smoke.php
- php -l inc/Core/JobArtifacts.php
- php -l tests/job-artifact-hashable-smoke.php
- vendor/bin/phpcs inc/Core/JobArtifacts.php tests/job-artifact-hashable-smoke.php
- git diff --check -- inc/Core/JobArtifacts.php tests/job-artifact-hashable-smoke.php

## Notes
- PHPStan is not installed in this checkout (composer package phpstan/phpstan is absent).
- Homeboy lab offload was attempted but blocked before code execution: lint snapshot materialization failed on the lab runner, and test bootstrap failed because the mounted lab checkout lacked vendor/autoload.php.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the implementation, smoke coverage, verification commands, and PR description; Chris remains responsible for review and merge.