### PR TITLE
Fix image optimization ability registration

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -191,6 +191,7 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/SystemAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Media/AltTextAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Media/ImageGenerationAbilities.php';
+	require_once __DIR__ . '/inc/Abilities/Media/ImageOptimizationAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Media/MediaAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/SEO/MetaDescriptionAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/SEO/IndexNowAbilities.php';
@@ -287,6 +288,7 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\SystemAbilities();
 	new \DataMachine\Abilities\Media\AltTextAbilities();
 	new \DataMachine\Abilities\Media\ImageGenerationAbilities();
+	new \DataMachine\Abilities\Media\ImageOptimizationAbilities();
 	new \DataMachine\Abilities\Media\MediaAbilities();
 	new \DataMachine\Abilities\SEO\MetaDescriptionAbilities();
 	new \DataMachine\Abilities\SEO\IndexNowAbilities();

--- a/tests/Unit/Abilities/AllAbilitiesRegisteredTest.php
+++ b/tests/Unit/Abilities/AllAbilitiesRegisteredTest.php
@@ -103,6 +103,9 @@ class AllAbilitiesRegisteredTest extends WP_UnitTestCase {
 			// DuplicateCheckAbility (2)
 			'datamachine/check-duplicate',
 			'datamachine/titles-match',
+			// ImageOptimizationAbilities (2)
+			'datamachine/diagnose-images',
+			'datamachine/optimize-images',
 		);
 
 		$missing = array();

--- a/tests/image-optimization-ability-registration-smoke.php
+++ b/tests/image-optimization-ability-registration-smoke.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Regression smoke for ImageOptimizationAbilities bootstrap registration.
+ *
+ * Run with: php tests/image-optimization-ability-registration-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $message ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( $condition ) {
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	$failures[] = $message;
+	echo "FAIL: {$message}\n";
+};
+
+$root      = dirname( __DIR__ );
+$bootstrap = (string) file_get_contents( $root . '/data-machine.php' );
+$test      = (string) file_get_contents( $root . '/tests/Unit/Abilities/AllAbilitiesRegisteredTest.php' );
+
+$assert(
+	str_contains( $bootstrap, "require_once __DIR__ . '/inc/Abilities/Media/ImageOptimizationAbilities.php';" ),
+	'data-machine.php loads ImageOptimizationAbilities'
+);
+
+$assert(
+	str_contains( $bootstrap, 'new \\DataMachine\\Abilities\\Media\\ImageOptimizationAbilities();' ),
+	'data-machine.php instantiates ImageOptimizationAbilities during ability bootstrap'
+);
+
+$assert(
+	str_contains( $test, "'datamachine/diagnose-images'" ),
+	'AllAbilitiesRegisteredTest expects datamachine/diagnose-images'
+);
+
+$assert(
+	str_contains( $test, "'datamachine/optimize-images'" ),
+	'AllAbilitiesRegisteredTest expects datamachine/optimize-images'
+);
+
+echo "\n{$assertions} assertions, " . count( $failures ) . " failures\n";
+
+if ( ! empty( $failures ) ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Register ImageOptimizationAbilities during Data Machine ability bootstrap.
- Add the image optimization ability slugs to AllAbilitiesRegisteredTest.
- Add a pure-PHP smoke regression for the bootstrap registration path.

## Verification
- php -l data-machine.php
- php -l tests/Unit/Abilities/AllAbilitiesRegisteredTest.php
- php -l tests/image-optimization-ability-registration-smoke.php
- php tests/image-optimization-ability-registration-smoke.php
- vendor/bin/phpcs data-machine.php tests/Unit/Abilities/AllAbilitiesRegisteredTest.php tests/image-optimization-ability-registration-smoke.php
- homeboy runner exec lab --cwd /home/chubes/Developer/_lab_workspaces/data-machine-fix-image-optimization-ability-registration-30dda1c32a36 --ssh homeboy test --path /home/chubes/Developer/_lab_workspaces/data-machine-fix-image-optimization-ability-registration-30dda1c32a36 -- --filter=AllAbilitiesRegisteredTest (1305 tests, 1302 passed, 3 skipped)
- homeboy audit --force-hot --path /Users/chubes/Developer/data-machine@fix-image-optimization-ability-registration --changed-since origin/HEAD (passed; informational raw-slug convention notes only)

## Notes
- A direct lab-offloaded Homeboy test from the local worktree failed before executing tests because the lab mirror excluded untracked vendor/ and could not load vendor/autoload.php. I synced a snapshot to the lab, installed Composer dependencies in that remote snapshot, and reran the Homeboy test there successfully.
- homeboy lint currently reports the repository's existing broad PHPStan backlog; PHPCS on the changed files is clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Verified the audit finding, drafted the registration fix and regression coverage, ran checks, and prepared this PR for Chris to review/test.