### PR TITLE
Fix OAuth account-scope fallback cleanup

### DIFF
--- a/docs/architecture/oauth-account-scope-api.md
+++ b/docs/architecture/oauth-account-scope-api.md
@@ -122,11 +122,11 @@ That behavior should be expressed as a named resolver instead of hiding inside
 all account reads:
 
 ```php
-public function get_account_for_context( array $context = array() ): ?array;
+public function get_account_for_policy_context( array $context = array() ): ?array;
 ```
 
-`get_account_for_context()` consults the same policy inputs as the current
-`get_account( array $context )` implementation:
+`get_account_for_policy_context()` consults the same policy inputs as the current
+`get_account( array $context )` compatibility implementation:
 
 - Explicit `agent_id` in context.
 - Explicit `user_id` in context.
@@ -135,8 +135,8 @@ public function get_account_for_context( array $context = array() ): ?array;
 - `get_current_user_id()`.
 - The provider's `datamachine_auth_scope_policy` result.
 
-The resolver may preserve the current site fallback behavior for one release
-cycle so existing policy-scoped providers keep working while callsites migrate.
+The method name makes the site fallback explicit. Named scope methods remain the
+safe default when missing user or agent credentials must stay missing.
 
 ## Deprecation Plan
 
@@ -177,7 +177,7 @@ context-free aliases after `get_site_account()` is widely adopted.
 | `save_account( $account, array( 'user_id' => $id ) )` | `save_account_for_user( $id, $account )` | User account only. |
 | `clear_account( array( 'user_id' => $id ) )` | `delete_account_for_user( $id )` | User account only. |
 | `get_account( array( 'agent_id' => $id ) )` | `get_account_for_agent( $id )` | Agent account only, no fallback. |
-| Ambient policy lookup | `get_account_for_context( $context )` | Provider policy decides scope. |
+| Ambient policy lookup with site fallback | `get_account_for_policy_context( $context )` | Provider policy decides scope, then falls back to site account. |
 
 Vendor plugins should prefer explicit named methods when the caller already
 knows the desired principal. Use policy-resolved lookup only when the desired
@@ -199,16 +199,16 @@ scope is genuinely delegated to provider policy.
    `save_site_account()` / `delete_site_account()`.
 8. Update internal scoped callsites to `get_account_for_user()` or
    `get_account_for_agent()` when the scope is explicit.
-9. Publish vendor migration notes and coordinate downstream plugin updates.
-10. After at least one release cycle, decide whether context-free `get_account()`
+9. Rename policy fallback lookup to `get_account_for_policy_context()` and keep
+   `get_account_for_context()` as a deprecated shim. Shipped in v0.136.0.
+10. Publish vendor migration notes and coordinate downstream plugin updates.
+11. After at least one release cycle, decide whether context-free `get_account()`
    should also become a deprecated alias for `get_site_account()`.
 
 ## Open Questions
 
 - Should config storage get the same named-scope treatment, or should this
   migration stay account-only until vendor account reads are cleaned up?
-- Should `get_account_for_context()` preserve site fallback permanently, or only
-  during the deprecation window?
 - Should per-agent account resolution expose a filter equivalent to
   `datamachine_resolve_oauth_account_for_user`?
 - Should missing site-wide accounts return `null` only in new methods while old

--- a/docs/core-system/oauth-handlers.md
+++ b/docs/core-system/oauth-handlers.md
@@ -41,7 +41,7 @@ public function delete_account_for_user(int $user_id): bool;
 public function get_account_for_agent(int $agent_id): ?array;
 public function save_account_for_agent(int $agent_id, array $account): bool;
 public function delete_account_for_agent(int $agent_id): bool;
-public function get_account_for_context(array $context = array()): ?array;
+public function get_account_for_policy_context(array $context = array()): ?array;
 public function get_account(): array;
 public function get_config(): array;
 public function save_account(array $data): bool;
@@ -144,14 +144,15 @@ These share the same on-disk shape as the principal-scoped API
 readable through the other. Like the per-user API, these methods never consult
 auth scope policy and never fall back to site-wide storage.
 
-### Policy-resolved account context API (@since v0.130.0)
+### Policy-resolved account context API (@since v0.136.0)
 
-`get_account_for_context()` is the explicit account lookup for callers that want
-provider policy to decide which credential scope applies to an execution
-context:
+`get_account_for_policy_context()` is the explicit account lookup for callers
+that intentionally want provider policy to decide which credential scope applies
+to an execution context and then fall back to the site account when the scoped
+slot is missing:
 
 ```php
-public function get_account_for_context( array $context = array() ): ?array;
+public function get_account_for_policy_context( array $context = array() ): ?array;
 ```
 
 The method consults `datamachine_auth_scope_policy` and the same context inputs
@@ -162,9 +163,9 @@ window, but returns `null` when neither a scoped account nor a site-wide account
 exists.
 
 Passing a non-empty context array to `get_account()` is deprecated as of
-v0.131.0. The legacy method still returns an array for backward compatibility,
-but callers should use `get_account_for_context()` when they want
-policy-resolved lookup.
+v0.131.0. The older `get_account_for_context()` name is deprecated as of
+v0.136.0 because it hid the fallback behavior. Both compatibility methods still
+route through `get_account_for_policy_context()` during the migration window.
 
 Passing a non-empty context array to `save_account()` or `clear_account()` is
 deprecated as of v0.132.0. Callers should use the explicit site, user, or agent

--- a/inc/Abilities/AuthAbilities.php
+++ b/inc/Abilities/AuthAbilities.php
@@ -829,13 +829,14 @@ class AuthAbilities {
 			}
 		} elseif ( method_exists( $auth_instance, 'save_config' ) ) {
 			$saved = $auth_instance->save_config( $config_data, $principal_context );
-		} elseif ( method_exists( $auth_instance, 'save_account' ) ) {
-			$saved = $auth_instance->save_account( $config_data, $principal_context );
 		} else {
-			return array(
-				'success' => false,
-				'error'   => __( 'Handler does not support saving account', 'data-machine' ),
-			);
+			$saved = $this->saveAuthAccountForContext( $auth_instance, $config_data, $principal_context );
+			if ( null === $saved ) {
+				return array(
+					'success' => false,
+					'error'   => __( 'Handler does not support saving account', 'data-machine' ),
+				);
+			}
 		}
 
 		if ( $saved ) {
@@ -849,6 +850,57 @@ class AuthAbilities {
 			'success' => false,
 			'error'   => __( 'Failed to save configuration', 'data-machine' ),
 		);
+	}
+
+	/**
+	 * Save account data through the explicit site/user/agent account APIs.
+	 *
+	 * @param object $auth_instance Auth provider instance.
+	 * @param array  $account_data Account data to save.
+	 * @param array  $principal_context Principal context with optional agent_id/user_id.
+	 * @return bool|null Save result, or null when no supported account save API exists.
+	 */
+	private function saveAuthAccountForContext( object $auth_instance, array $account_data, array $principal_context ): ?bool {
+		if ( ! empty( $principal_context['agent_id'] ) ) {
+			return method_exists( $auth_instance, 'save_account_for_agent' )
+				? (bool) $auth_instance->save_account_for_agent( absint( $principal_context['agent_id'] ), $account_data )
+				: null;
+		}
+
+		if ( ! empty( $principal_context['user_id'] ) ) {
+			return method_exists( $auth_instance, 'save_account_for_user' )
+				? (bool) $auth_instance->save_account_for_user( absint( $principal_context['user_id'] ), $account_data )
+				: null;
+		}
+
+		if ( method_exists( $auth_instance, 'save_site_account' ) ) {
+			return (bool) $auth_instance->save_site_account( $account_data );
+		}
+
+		if ( method_exists( $auth_instance, 'save_account' ) ) {
+			return (bool) $auth_instance->save_account( $account_data );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check whether the provider can save account data for the requested context.
+	 *
+	 * @param object $auth_instance Auth provider instance.
+	 * @param array  $principal_context Principal context with optional agent_id/user_id.
+	 * @return bool True when a matching account save API exists.
+	 */
+	private function supportsAuthAccountSaveForContext( object $auth_instance, array $principal_context ): bool {
+		if ( ! empty( $principal_context['agent_id'] ) ) {
+			return method_exists( $auth_instance, 'save_account_for_agent' );
+		}
+
+		if ( ! empty( $principal_context['user_id'] ) ) {
+			return method_exists( $auth_instance, 'save_account_for_user' );
+		}
+
+		return method_exists( $auth_instance, 'save_site_account' ) || method_exists( $auth_instance, 'save_account' );
 	}
 
 	/**
@@ -898,7 +950,7 @@ class AuthAbilities {
 			);
 		}
 
-		if ( ! method_exists( $auth_instance, 'save_account' ) ) {
+		if ( ! $this->supportsAuthAccountSaveForContext( $auth_instance, $principal_context ) ) {
 			return array(
 				'success' => false,
 				'error'   => __( 'This handler does not support saving account data', 'data-machine' ),
@@ -917,7 +969,7 @@ class AuthAbilities {
 			}
 		}
 
-		$saved = $auth_instance->save_account( $sanitized, $principal_context );
+		$saved = $this->saveAuthAccountForContext( $auth_instance, $sanitized, $principal_context );
 
 		if ( $saved ) {
 			// Schedule proactive refresh if the provider supports it.

--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -320,11 +320,11 @@ abstract class BaseAuthProvider {
 				_deprecated_function(
 					__METHOD__ . ' with a context argument',
 					'0.131.0',
-					'BaseAuthProvider::get_account_for_context()'
+					'BaseAuthProvider::get_account_for_policy_context()'
 				);
 			}
 
-			return $this->get_account_for_context( $context ) ?? array();
+			return $this->get_account_for_policy_context( $context ) ?? array();
 		}
 
 		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
@@ -345,16 +345,43 @@ abstract class BaseAuthProvider {
 	/**
 	 * Get the OAuth account that applies to an execution context.
 	 *
-	 * This is the explicit policy-resolved account lookup. It preserves the
-	 * existing `get_account( array $context )` scope resolution and site fallback
-	 * semantics while returning `null` when no account is available.
+	 * Deprecated compatibility wrapper for the explicit policy-fallback lookup.
+	 * New callers must choose a named scope API (`get_site_account()`,
+	 * `get_account_for_user()`, `get_account_for_agent()`) or intentionally opt
+	 * into policy resolution plus site fallback via
+	 * `get_account_for_policy_context()`.
 	 *
 	 * @since 0.130.0
+	 * @deprecated 0.136.0 Use get_account_for_policy_context() when fallback is intended.
 	 *
 	 * @param array $context Optional principal context, e.g. user_id or agent_id.
 	 * @return array|null Decrypted account data, or null if no account resolves.
 	 */
 	public function get_account_for_context( array $context = array() ): ?array {
+		if ( function_exists( '_deprecated_function' ) ) {
+			_deprecated_function(
+				__METHOD__,
+				'0.136.0',
+				'BaseAuthProvider::get_account_for_policy_context()'
+			);
+		}
+
+		return $this->get_account_for_policy_context( $context );
+	}
+
+	/**
+	 * Get the policy-resolved OAuth account for an execution context.
+	 *
+	 * This method is the explicit opt-in surface for scope-policy resolution with
+	 * legacy site-account fallback. Use named scope methods when a missing scoped
+	 * account must remain missing instead of falling back to site credentials.
+	 *
+	 * @since 0.136.0
+	 *
+	 * @param array $context Optional principal context, e.g. user_id or agent_id.
+	 * @return array|null Decrypted account data, or null if no account resolves.
+	 */
+	public function get_account_for_policy_context( array $context = array() ): ?array {
 		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
 		$provider_data = $all_auth_data[ $this->provider_slug ] ?? array();
 		$scope         = $this->get_principal_scope( $context, 'account' );

--- a/tests/Unit/Abilities/AuthAbilitiesTest.php
+++ b/tests/Unit/Abilities/AuthAbilitiesTest.php
@@ -10,7 +10,20 @@
 namespace DataMachine\Tests\Unit\Abilities;
 
 use DataMachine\Abilities\AuthAbilities;
+use DataMachine\Abilities\HandlerAbilities;
+use DataMachine\Core\OAuth\BaseAuthProvider;
 use WP_UnitTestCase;
+
+class AuthAbilitiesAccountScopeProvider extends BaseAuthProvider {
+
+	public function get_config_fields(): array {
+		return array();
+	}
+
+	public function is_authenticated(): bool {
+		return false;
+	}
+}
 
 class AuthAbilitiesTest extends WP_UnitTestCase {
 
@@ -18,6 +31,9 @@ class AuthAbilitiesTest extends WP_UnitTestCase {
 
 	public function set_up(): void {
 		parent::set_up();
+		delete_site_option( 'datamachine_auth_data' );
+		AuthAbilities::clearCache();
+		HandlerAbilities::clearCache();
 
 		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
@@ -26,6 +42,12 @@ class AuthAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function tear_down(): void {
+		delete_site_option( 'datamachine_auth_data' );
+		remove_all_filters( 'datamachine_auth_providers' );
+		remove_all_filters( 'datamachine_handlers' );
+		AuthAbilities::clearCache();
+		HandlerAbilities::clearCache();
+		wp_set_current_user( 0 );
 		parent::tear_down();
 	}
 
@@ -111,6 +133,67 @@ class AuthAbilitiesTest extends WP_UnitTestCase {
 
 		$this->assertFalse( $result['success'] );
 		$this->assertArrayHasKey( 'error', $result );
+	}
+
+	public function test_set_auth_token_saves_user_account_without_site_fallback(): void {
+		$provider = new AuthAbilitiesAccountScopeProvider( 'scope_provider' );
+		$this->registerAccountScopeProvider( $provider );
+
+		$result = $this->auth_abilities->executeSetAuthToken(
+			array(
+				'handler_slug' => 'scope_handler',
+				'user_id'      => 42,
+				'account_data' => array( 'access_token' => 'tok_user_42' ),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'tok_user_42', $provider->get_account_for_user( 42 )['access_token'] );
+		$this->assertNull( $provider->get_site_account() );
+		$this->assertNull( $provider->get_account_for_user( 99 ) );
+	}
+
+	public function test_set_auth_token_prefers_agent_account_when_user_and_agent_are_present(): void {
+		$provider = new AuthAbilitiesAccountScopeProvider( 'scope_provider' );
+		$this->registerAccountScopeProvider( $provider );
+
+		$result = $this->auth_abilities->executeSetAuthToken(
+			array(
+				'handler_slug' => 'scope_handler',
+				'user_id'      => 42,
+				'agent_id'     => 303,
+				'account_data' => array( 'access_token' => 'tok_agent_303' ),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'tok_agent_303', $provider->get_account_for_agent( 303 )['access_token'] );
+		$this->assertNull( $provider->get_account_for_user( 42 ) );
+		$this->assertNull( $provider->get_site_account() );
+	}
+
+	private function registerAccountScopeProvider( AuthAbilitiesAccountScopeProvider $provider ): void {
+		add_filter(
+			'datamachine_auth_providers',
+			function ( array $providers ) use ( $provider ): array {
+				$providers['scope_provider'] = $provider;
+				return $providers;
+			}
+		);
+		add_filter(
+			'datamachine_handlers',
+			function ( array $handlers ): array {
+				$handlers['scope_handler'] = array(
+					'slug'              => 'scope_handler',
+					'requires_auth'     => true,
+					'auth_provider_key' => 'scope_provider',
+				);
+				return $handlers;
+			}
+		);
+
+		AuthAbilities::clearCache();
+		HandlerAbilities::clearCache();
 	}
 
 	public function test_permission_callback(): void {

--- a/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
+++ b/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
@@ -359,24 +359,24 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 	// Policy-resolved account context API
 	// -------------------------------------------------------------------------
 
-	public function test_get_account_for_context_returns_null_when_no_account(): void {
-		$this->assertNull( $this->provider->get_account_for_context() );
+	public function test_get_account_for_policy_context_returns_null_when_no_account(): void {
+		$this->assertNull( $this->provider->get_account_for_policy_context() );
 	}
 
-	public function test_get_account_for_context_reads_site_account_by_default(): void {
+	public function test_get_account_for_policy_context_reads_site_account_by_default(): void {
 		$this->provider->save_site_account( array( 'access_token' => 'tok_site' ) );
 
-		$this->assertSame( 'tok_site', $this->provider->get_account_for_context()['access_token'] );
+		$this->assertSame( 'tok_site', $this->provider->get_account_for_policy_context()['access_token'] );
 	}
 
-	public function test_get_account_for_context_preserves_site_policy_for_user_context(): void {
+	public function test_get_account_for_policy_context_preserves_site_policy_for_user_context(): void {
 		$this->provider->save_site_account( array( 'access_token' => 'tok_site' ) );
 		$this->provider->save_account_for_user( 42, array( 'access_token' => 'tok_user_42' ) );
 
-		$this->assertSame( 'tok_site', $this->provider->get_account_for_context( array( 'user_id' => 42 ) )['access_token'] );
+		$this->assertSame( 'tok_site', $this->provider->get_account_for_policy_context( array( 'user_id' => 42 ) )['access_token'] );
 	}
 
-	public function test_get_account_for_context_resolves_user_policy(): void {
+	public function test_get_account_for_policy_context_resolves_user_policy(): void {
 		add_filter(
 			'datamachine_auth_scope_policy',
 			function () {
@@ -387,12 +387,12 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 		$this->provider->save_site_account( array( 'access_token' => 'tok_site' ) );
 		$this->provider->save_account_for_user( 42, array( 'access_token' => 'tok_user_42' ) );
 
-		$this->assertSame( 'tok_user_42', $this->provider->get_account_for_context( array( 'user_id' => 42 ) )['access_token'] );
+		$this->assertSame( 'tok_user_42', $this->provider->get_account_for_policy_context( array( 'user_id' => 42 ) )['access_token'] );
 
 		remove_all_filters( 'datamachine_auth_scope_policy' );
 	}
 
-	public function test_get_account_for_context_resolves_agent_before_user_for_principal_policy(): void {
+	public function test_get_account_for_policy_context_resolves_agent_before_user_for_principal_policy(): void {
 		add_filter(
 			'datamachine_auth_scope_policy',
 			function () {
@@ -404,7 +404,7 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 		$this->provider->save_account_for_user( 42, array( 'access_token' => 'tok_user_42' ) );
 		$this->provider->save_account_for_agent( 303, array( 'access_token' => 'tok_agent_303' ) );
 
-		$account = $this->provider->get_account_for_context(
+		$account = $this->provider->get_account_for_policy_context(
 			array(
 				'user_id'  => 42,
 				'agent_id' => 303,
@@ -416,7 +416,7 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 		remove_all_filters( 'datamachine_auth_scope_policy' );
 	}
 
-	public function test_get_account_for_context_falls_back_to_site_account_when_scoped_account_missing(): void {
+	public function test_get_account_for_policy_context_falls_back_to_site_account_when_scoped_account_missing(): void {
 		add_filter(
 			'datamachine_auth_scope_policy',
 			function () {
@@ -426,12 +426,12 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 
 		$this->provider->save_site_account( array( 'access_token' => 'tok_site' ) );
 
-		$this->assertSame( 'tok_site', $this->provider->get_account_for_context( array( 'user_id' => 42 ) )['access_token'] );
+		$this->assertSame( 'tok_site', $this->provider->get_account_for_policy_context( array( 'user_id' => 42 ) )['access_token'] );
 
 		remove_all_filters( 'datamachine_auth_scope_policy' );
 	}
 
-	public function test_get_account_for_context_returns_null_when_policy_scoped_and_no_fallback_exists(): void {
+	public function test_get_account_for_policy_context_returns_null_when_policy_scoped_and_no_fallback_exists(): void {
 		add_filter(
 			'datamachine_auth_scope_policy',
 			function () {
@@ -439,9 +439,55 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 			}
 		);
 
-		$this->assertNull( $this->provider->get_account_for_context( array( 'user_id' => 42 ) ) );
+		$this->assertNull( $this->provider->get_account_for_policy_context( array( 'user_id' => 42 ) ) );
 
 		remove_all_filters( 'datamachine_auth_scope_policy' );
+	}
+
+	public function test_get_account_for_context_emits_deprecation_and_routes_to_policy_context(): void {
+		$deprecated_calls = array();
+		$this->setExpectedDeprecated( 'DataMachine\Core\OAuth\BaseAuthProvider::get_account_for_context' );
+
+		add_filter(
+			'deprecated_function_trigger_error',
+			function () {
+				return false;
+			}
+		);
+		add_filter(
+			'datamachine_auth_scope_policy',
+			function () {
+				return BaseAuthProvider::AUTH_SCOPE_USER;
+			}
+		);
+		add_action(
+			'deprecated_function_run',
+			function ( $function_name, $replacement, $version ) use ( &$deprecated_calls ) {
+				$deprecated_calls[] = array( $function_name, $replacement, $version );
+			},
+			10,
+			3
+		);
+
+		$this->provider->save_site_account( array( 'access_token' => 'tok_site' ) );
+
+		$result = $this->provider->get_account_for_context( array( 'user_id' => 42 ) );
+
+		$this->assertSame( 'tok_site', $result['access_token'] );
+		$this->assertSame(
+			array(
+				array(
+					'DataMachine\Core\OAuth\BaseAuthProvider::get_account_for_context',
+					'BaseAuthProvider::get_account_for_policy_context()',
+					'0.136.0',
+				),
+			),
+			$deprecated_calls
+		);
+
+		remove_all_filters( 'deprecated_function_trigger_error' );
+		remove_all_filters( 'datamachine_auth_scope_policy' );
+		remove_all_filters( 'deprecated_function_run' );
 	}
 
 	public function test_get_account_without_context_does_not_emit_deprecation(): void {
@@ -489,7 +535,7 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 			array(
 				array(
 					'DataMachine\Core\OAuth\BaseAuthProvider::get_account with a context argument',
-					'BaseAuthProvider::get_account_for_context()',
+					'BaseAuthProvider::get_account_for_policy_context()',
 					'0.131.0',
 				),
 			),
@@ -1025,7 +1071,7 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 
 		$this->assertSame(
 			'tok_agent_303',
-			$this->provider->get_account_for_context( array( 'agent_id' => 303 ) )['access_token']
+			$this->provider->get_account_for_policy_context( array( 'agent_id' => 303 ) )['access_token']
 		);
 
 		$this->provider->save_account_for_agent( 404, array( 'access_token' => 'tok_agent_scoped' ) );

--- a/tests/auth-principal-scoped-smoke.php
+++ b/tests/auth-principal-scoped-smoke.php
@@ -135,11 +135,11 @@ function smoke_assert( string $label, bool $condition, string $detail = '' ): vo
 
 echo "[1] two users store provider accounts without overwriting\n";
 $provider = new Principal_Scoped_Provider();
-$provider->save_account( array( 'access_token' => 'alice-token' ), array( 'user_id' => 101 ) );
-$provider->save_account( array( 'access_token' => 'bob-token' ), array( 'user_id' => 202 ) );
+$provider->save_account_for_user( 101, array( 'access_token' => 'alice-token' ) );
+$provider->save_account_for_user( 202, array( 'access_token' => 'bob-token' ) );
 
-smoke_assert( 'alice reads alice token', 'alice-token' === $provider->get_account( array( 'user_id' => 101 ) )['access_token'] );
-smoke_assert( 'bob reads bob token', 'bob-token' === $provider->get_account( array( 'user_id' => 202 ) )['access_token'] );
+smoke_assert( 'alice reads alice token', 'alice-token' === $provider->get_account_for_user( 101 )['access_token'] );
+smoke_assert( 'bob reads bob token', 'bob-token' === $provider->get_account_for_user( 202 )['access_token'] );
 
 $raw = get_site_option( 'datamachine_auth_data', array() );
 smoke_assert( 'alice account stored under user principal', isset( $raw['example']['principals']['user:101']['account'] ) );
@@ -147,19 +147,20 @@ smoke_assert( 'bob account stored under user principal', isset( $raw['example'][
 smoke_assert( 'legacy site account was not written', ! isset( $raw['example']['account'] ) );
 
 echo "\n[2] agent scope wins when explicitly provided\n";
-$provider->save_account( array( 'access_token' => 'agent-token' ), array( 'agent_id' => 303, 'user_id' => 101 ) );
-smoke_assert( 'agent reads agent token', 'agent-token' === $provider->get_account( array( 'agent_id' => 303, 'user_id' => 101 ) )['access_token'] );
+$provider->save_account_for_agent( 303, array( 'access_token' => 'agent-token' ) );
+smoke_assert( 'agent reads agent token', 'agent-token' === $provider->get_account_for_agent( 303 )['access_token'] );
 $raw = get_site_option( 'datamachine_auth_data', array() );
 smoke_assert( 'agent account stored under agent principal', isset( $raw['example']['principals']['agent:303']['account'] ) );
 
-echo "\n[3] legacy account remains readable as fallback\n";
+echo "\n[3] policy context explicitly opts into site fallback\n";
 $GLOBALS['datamachine_auth_scope_options']['datamachine_auth_data']['legacy']['account'] = array( 'access_token' => 'legacy-token' );
 $legacy = new class() extends DataMachine\Core\OAuth\BaseAuthProvider {
 	public function __construct() { parent::__construct( 'legacy' ); }
 	public function get_config_fields(): array { return array(); }
 	public function is_authenticated(): bool { return ! empty( $this->get_account()['access_token'] ); }
 };
-smoke_assert( 'scoped lookup falls back to legacy account', 'legacy-token' === $legacy->get_account( array( 'user_id' => 404 ) )['access_token'] );
+smoke_assert( 'named user lookup does not fall back to legacy account', null === $legacy->get_account_for_user( 404 ) );
+smoke_assert( 'policy context lookup falls back to legacy account', 'legacy-token' === $legacy->get_account_for_policy_context( array( 'user_id' => 404 ) )['access_token'] );
 
 echo "\n[4] site-wide policy remains the default\n";
 $site_provider = new class() extends DataMachine\Core\OAuth\BaseAuthProvider {
@@ -167,9 +168,9 @@ $site_provider = new class() extends DataMachine\Core\OAuth\BaseAuthProvider {
 	public function get_config_fields(): array { return array(); }
 	public function is_authenticated(): bool { return ! empty( $this->get_account()['access_token'] ); }
 };
-$site_provider->save_account( array( 'access_token' => 'site-token-a' ), array( 'user_id' => 101 ) );
-$site_provider->save_account( array( 'access_token' => 'site-token-b' ), array( 'user_id' => 202 ) );
-smoke_assert( 'default policy writes site account', 'site-token-b' === $site_provider->get_account( array( 'user_id' => 101 ) )['access_token'] );
+$site_provider->save_site_account( array( 'access_token' => 'site-token-a' ) );
+$site_provider->save_site_account( array( 'access_token' => 'site-token-b' ) );
+smoke_assert( 'site account writes site account', 'site-token-b' === $site_provider->get_site_account()['access_token'] );
 $raw = get_site_option( 'datamachine_auth_data', array() );
 smoke_assert( 'default policy does not create principal accounts', ! isset( $raw['site_default']['principals'] ) );
 


### PR DESCRIPTION
## Summary
- Add `BaseAuthProvider::get_account_for_policy_context()` as the explicit policy-resolution plus site-fallback account lookup.
- Keep `get_account_for_context()` as a deprecated shim that routes to the explicit fallback method.
- Update Data Machine auth ability token/config account saves to use named site/user/agent account methods instead of context-array `save_account()` calls.
- Add focused tests proving user/agent saves do not create/read site credentials unless policy fallback is explicitly requested.
- Refresh OAuth account-scope docs for the 1.0 contract.

Closes #2218.

## Testing
- `php -l inc/Core/OAuth/BaseAuthProvider.php`
- `php -l inc/Abilities/AuthAbilities.php`
- `php -l tests/Unit/Core/OAuth/BaseAuthProviderTest.php`
- `php -l tests/Unit/Abilities/AuthAbilitiesTest.php`
- `php -l tests/auth-principal-scoped-smoke.php`
- `php tests/auth-principal-scoped-smoke.php`
- `homeboy test --force-hot --path /Users/chubes/Developer/data-machine@issue-2218-oauth-account-scope-cleanup --extension wordpress`
- `homeboy lint --force-hot --path /Users/chubes/Developer/data-machine@issue-2218-oauth-account-scope-cleanup --extension wordpress --changed-since origin/main`

## Notes
- Initial automatic Homeboy lab offload failed before tests because the lab snapshot did not include `vendor/autoload.php`; reran with `--force-hot` locally per Homeboy runner docs so the intended WP Codebox test path used the local Composer install.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigating issue #2218, implementing the OAuth account-scope cleanup, updating focused tests/docs, and running verification. Chris remains responsible for review and merge.
