### PR TITLE
Separate step execution status from packet transport

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -201,10 +201,13 @@ class ExecuteStepAbility {
 				'engine'       => $engine,
 			);
 
-			$dataPackets = $flow_step->execute( $payload );
+			$step_output           = $flow_step->execute( $payload );
+			$execution_result      = StepExecutionResult::fromStepOutput( $step_output, $step_type );
+			$dataPackets           = $execution_result['packets'];
+			$step_success          = (bool) $execution_result['success'];
 
 			$payload['data'] = $dataPackets;
-			$step_success    = $this->evaluateStepSuccess( $dataPackets, $job_id, $flow_step_id, $step_type );
+			$this->logStepExecutionResult( $execution_result, $job_id, $flow_step_id, $step_type );
 
 			// Refresh engine data to capture changes made during step execution.
 			$refreshed_engine_data = datamachine_get_engine_data( $job_id );
@@ -233,7 +236,8 @@ class ExecuteStepAbility {
 				$dataPackets,
 				$payload,
 				$step_success,
-				$status_override
+				$status_override,
+				$execution_result
 			);
 
 			$recorded_status = $status_override ? $status_override : ( $result['outcome'] ?? null );
@@ -245,9 +249,9 @@ class ExecuteStepAbility {
 					'step_type'    => $step_type,
 					'result'       => $result['outcome'] ?? ( $step_success ? 'completed' : 'failed' ),
 					'step_success' => $step_success,
-					'packet_count' => count( $dataPackets ),
+					'packet_count' => $execution_result['packet_count'],
 					'status'       => $recorded_status,
-					'reason'       => $result['reason'] ?? ( $result['error'] ?? null ),
+					'reason'       => $result['reason'] ?? ( $execution_result['reason'] ?? ( $result['error'] ?? null ) ),
 					'error'        => $result['error'] ?? null,
 				)
 			);
@@ -352,8 +356,23 @@ class ExecuteStepAbility {
 	 */
 	private function evaluateStepSuccess( array $dataPackets, int $job_id, string $flow_step_id, string $step_type = '' ): bool {
 		$classification = StepExecutionResult::classify( $dataPackets, $step_type );
+		$this->logStepExecutionResult( $classification, $job_id, $flow_step_id, $step_type );
 
-		if ( ! $classification['success'] ) {
+		return (bool) $classification['success'];
+	}
+
+	/**
+	 * Log non-successful step execution classification.
+	 *
+	 * @param array  $execution_result Normalized StepExecutionResult contract.
+	 * @param int    $job_id           Job ID (for logging).
+	 * @param string $flow_step_id     Flow step ID (for logging).
+	 * @param string $step_type        Step type identifier.
+	 */
+	private function logStepExecutionResult( array $execution_result, int $job_id, string $flow_step_id, string $step_type = '' ): void {
+		$success = (bool) ( $execution_result['success'] ?? false );
+
+		if ( ! $success ) {
 			do_action(
 				'datamachine_log',
 				'warning',
@@ -362,13 +381,12 @@ class ExecuteStepAbility {
 					'job_id'       => $job_id,
 					'flow_step_id' => $flow_step_id,
 					'step_type'    => $step_type,
-					'reason'       => $classification['reason'],
-					'packet_count' => $classification['packet_count'],
+					'status'       => $execution_result['status'] ?? 'failed',
+					'reason'       => $execution_result['reason'] ?? 'step_execution_failed',
+					'packet_count' => $execution_result['packet_count'] ?? 0,
 				)
 			);
 		}
-
-		return (bool) $classification['success'];
 	}
 
 	/**
@@ -396,7 +414,8 @@ class ExecuteStepAbility {
 		array $dataPackets,
 		array $payload,
 		bool $step_success,
-		$status_override
+		$status_override,
+		array $execution_result = array()
 	): array {
 		$pipeline_id = $flow_step_config['pipeline_id'] ?? null;
 
@@ -595,11 +614,7 @@ class ExecuteStepAbility {
 			);
 		}
 
-		// Fetch/event_import steps: empty data means "nothing to process", not failure.
-		// This applies regardless of whether the flow has historical processed items —
-		// a new flow checking a source with no events is not broken, it just has nothing yet.
-		$is_fetch_step = in_array( $step_type, array( 'fetch', 'event_import' ), true );
-		$prior_status  = $this->getPriorTerminalStatus( $job_id );
+		$prior_status = $this->getPriorTerminalStatus( $job_id );
 		if ( null !== $prior_status ) {
 			do_action(
 				'datamachine_log',
@@ -624,12 +639,15 @@ class ExecuteStepAbility {
 			);
 		}
 
-		if ( $is_fetch_step ) {
+		// completed_no_items is an execution status, not a packet-count guess.
+		// Fetch/event_import legacy empty outputs classify this way, and explicit
+		// result-shaped step returns can also choose it without emitting packets.
+		if ( 'completed_no_items' === ( $execution_result['status'] ?? '' ) ) {
 			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED_NO_ITEMS );
 			do_action(
 				'datamachine_log',
 				'info',
-				'Flow completed with no new items to process',
+				'Step completed with no new items to process',
 				array(
 					'job_id'       => $job_id,
 					'pipeline_id'  => $pipeline_id,
@@ -670,7 +688,7 @@ class ExecuteStepAbility {
 				'step_type'    => $step_type,
 			)
 		);
-		$empty_packet_reason = $this->getFailureReasonFromPackets( $dataPackets, 'empty_data_packet_returned' );
+		$empty_packet_reason = $this->getFailureReasonFromPackets( $dataPackets, $execution_result['reason'] ?? 'empty_data_packet_returned' );
 
 		do_action(
 			'datamachine_fail_job',

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -201,10 +201,10 @@ class ExecuteStepAbility {
 				'engine'       => $engine,
 			);
 
-			$step_output           = $flow_step->execute( $payload );
-			$execution_result      = StepExecutionResult::fromStepOutput( $step_output, $step_type );
-			$dataPackets           = $execution_result['packets'];
-			$step_success          = (bool) $execution_result['success'];
+			$step_output      = $flow_step->execute( $payload );
+			$execution_result = StepExecutionResult::fromStepOutput( $step_output, $step_type );
+			$dataPackets      = $execution_result['packets'];
+			$step_success     = (bool) $execution_result['success'];
 
 			$payload['data'] = $dataPackets;
 			$this->logStepExecutionResult( $execution_result, $job_id, $flow_step_id, $step_type );

--- a/inc/Core/StepExecutionResult.php
+++ b/inc/Core/StepExecutionResult.php
@@ -50,7 +50,7 @@ class StepExecutionResult {
 			if ( '' === $status ) {
 				$classified = self::classify( $packets, $step_type );
 				$status     = $classified['status'];
-				$reason     = $reason ?: $classified['reason'];
+				$reason     = '' !== $reason ? $reason : $classified['reason'];
 			}
 
 			if ( '' === $reason ) {
@@ -128,7 +128,10 @@ class StepExecutionResult {
 	}
 
 	private static function buildResult( string $status, array $packets, string $reason, ?string $terminal_status ): array {
-		$status = self::normalizeStatus( $status ) ?: self::STATUS_FAILED;
+		$status = self::normalizeStatus( $status );
+		if ( '' === $status ) {
+			$status = self::STATUS_FAILED;
+		}
 
 		return array(
 			'status'          => $status,

--- a/inc/Core/StepExecutionResult.php
+++ b/inc/Core/StepExecutionResult.php
@@ -10,9 +10,14 @@ namespace DataMachine\Core;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Classifies execution success separately from DataPacket transport.
+ * Normalizes step execution status separately from DataPacket transport.
  */
 class StepExecutionResult {
+
+	private const STATUS_SUCCEEDED          = 'succeeded';
+	private const STATUS_FAILED             = 'failed';
+	private const STATUS_COMPLETED_NO_ITEMS = 'completed_no_items';
+	private const STATUS_BLOCKED            = 'blocked';
 
 	/** @var array<string,bool> */
 	private const NON_SUCCESS_PACKET_TYPES = array(
@@ -20,21 +25,64 @@ class StepExecutionResult {
 	);
 
 	/**
-	 * Classify step output packets into an execution result.
+	 * Normalize a step return value into the explicit execution result contract.
+	 *
+	 * Packet lists remain the legacy transport shape. Result-shaped arrays may
+	 * carry status independently from packets:
+	 *
+	 * array(
+	 *     'status'          => 'succeeded|failed|completed_no_items|blocked',
+	 *     'packets'         => array(),
+	 *     'reason'          => '...',
+	 *     'terminal_status' => null,
+	 * )
+	 *
+	 * @param mixed  $step_output Step return value.
+	 * @param string $step_type   Step type identifier.
+	 * @return array{status: string, packets: array, reason: string, terminal_status: ?string, success: bool, packet_count: int}
+	 */
+	public static function fromStepOutput( $step_output, string $step_type = '' ): array {
+		if ( self::isExplicitResult( $step_output ) ) {
+			$packets = self::normalizePackets( $step_output['packets'] ?? ( $step_output['data_packets'] ?? array() ) );
+			$status  = self::normalizeStatus( $step_output['status'] ?? '' );
+			$reason  = is_scalar( $step_output['reason'] ?? null ) ? self::sanitizeReason( $step_output['reason'] ) : '';
+
+			if ( '' === $status ) {
+				$classified = self::classify( $packets, $step_type );
+				$status     = $classified['status'];
+				$reason     = $reason ?: $classified['reason'];
+			}
+
+			if ( '' === $reason ) {
+				$reason = self::defaultReasonForStatus( $status, $step_type );
+			}
+
+			$terminal_status = $step_output['terminal_status'] ?? null;
+			$terminal_status = is_scalar( $terminal_status ) && '' !== trim( (string) $terminal_status ) ? trim( (string) $terminal_status ) : null;
+
+			return self::buildResult( $status, $packets, $reason, $terminal_status );
+		}
+
+		return self::classify( self::normalizePackets( $step_output ), $step_type );
+	}
+
+	/**
+	 * Classify legacy step output packets into an execution result.
 	 *
 	 * @param array  $data_packets Returned data packets.
 	 * @param string $step_type    Step type identifier.
-	 * @return array{success: bool, reason: string, packet_count: int}
+	 * @return array{status: string, packets: array, reason: string, terminal_status: ?string, success: bool, packet_count: int}
 	 */
 	public static function classify( array $data_packets, string $step_type = '' ): array {
+		$data_packets = self::normalizePackets( $data_packets );
 		$packet_count = count( $data_packets );
 
 		if ( 0 === $packet_count ) {
-			return array(
-				'success'      => false,
-				'reason'       => 'empty_data_packet_returned',
-				'packet_count' => 0,
-			);
+			if ( in_array( $step_type, array( 'fetch', 'event_import' ), true ) ) {
+				return self::buildResult( self::STATUS_COMPLETED_NO_ITEMS, array(), 'completed_no_items', JobStatus::COMPLETED_NO_ITEMS );
+			}
+
+			return self::buildResult( self::STATUS_FAILED, array(), 'empty_data_packet_returned', null );
 		}
 
 		$successful_handlers = self::collectSuccessfulHandlerTools( $data_packets );
@@ -46,11 +94,7 @@ class StepExecutionResult {
 
 			if ( array_key_exists( 'step_execution_success', $metadata ) ) {
 				if ( false === (bool) $metadata['step_execution_success'] ) {
-					return array(
-						'success'      => false,
-						'reason'       => self::sanitizeReason( $metadata['failure_reason'] ?? 'step_execution_failed' ),
-						'packet_count' => $packet_count,
-					);
+					return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'step_execution_failed' ), null );
 				}
 
 				$has_success_packet = true;
@@ -58,11 +102,7 @@ class StepExecutionResult {
 			}
 
 			if ( isset( $metadata['success'] ) && false === $metadata['success'] ) {
-				return array(
-					'success'      => false,
-					'reason'       => self::sanitizeReason( $metadata['failure_reason'] ?? 'packet_failure' ),
-					'packet_count' => $packet_count,
-				);
+				return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'packet_failure' ), null );
 			}
 
 			if ( isset( $metadata['tool_success'] ) && false === $metadata['tool_success'] ) {
@@ -71,11 +111,7 @@ class StepExecutionResult {
 					continue;
 				}
 
-				return array(
-					'success'      => false,
-					'reason'       => self::sanitizeReason( $metadata['failure_reason'] ?? 'tool_result_failed' ),
-					'packet_count' => $packet_count,
-				);
+				return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'tool_result_failed' ), null );
 			}
 
 			if ( ! isset( self::NON_SUCCESS_PACKET_TYPES[ $type ] ) ) {
@@ -83,11 +119,57 @@ class StepExecutionResult {
 			}
 		}
 
-		return array(
-			'success'      => $has_success_packet,
-			'reason'       => $has_success_packet ? 'completed' : self::fallbackReason( $step_type ),
-			'packet_count' => $packet_count,
+		return self::buildResult(
+			$has_success_packet ? self::STATUS_SUCCEEDED : self::STATUS_FAILED,
+			$data_packets,
+			$has_success_packet ? 'completed' : self::fallbackReason( $step_type ),
+			null
 		);
+	}
+
+	private static function buildResult( string $status, array $packets, string $reason, ?string $terminal_status ): array {
+		$status = self::normalizeStatus( $status ) ?: self::STATUS_FAILED;
+
+		return array(
+			'status'          => $status,
+			'packets'         => $packets,
+			'reason'          => self::sanitizeReason( $reason ),
+			'terminal_status' => $terminal_status,
+			'success'         => self::STATUS_SUCCEEDED === $status,
+			'packet_count'    => count( $packets ),
+		);
+	}
+
+	private static function isExplicitResult( $step_output ): bool {
+		return is_array( $step_output ) && ( array_key_exists( 'status', $step_output ) || array_key_exists( 'packets', $step_output ) || array_key_exists( 'terminal_status', $step_output ) );
+	}
+
+	private static function normalizePackets( $packets ): array {
+		if ( ! is_array( $packets ) ) {
+			return array();
+		}
+
+		return array_values( $packets );
+	}
+
+	private static function normalizeStatus( $status ): string {
+		$status = self::sanitizeReason( $status );
+
+		return in_array( $status, array( self::STATUS_SUCCEEDED, self::STATUS_FAILED, self::STATUS_COMPLETED_NO_ITEMS, self::STATUS_BLOCKED ), true ) ? $status : '';
+	}
+
+	private static function defaultReasonForStatus( string $status, string $step_type ): string {
+		switch ( $status ) {
+			case self::STATUS_SUCCEEDED:
+				return 'completed';
+			case self::STATUS_COMPLETED_NO_ITEMS:
+				return 'completed_no_items';
+			case self::STATUS_BLOCKED:
+				return 'blocked';
+			case self::STATUS_FAILED:
+			default:
+				return self::fallbackReason( $step_type );
+		}
 	}
 
 	/**

--- a/inc/Engine/Debug/SyncRunner.php
+++ b/inc/Engine/Debug/SyncRunner.php
@@ -249,15 +249,15 @@ class SyncRunner {
 
 		$execution_result = StepExecutionResult::fromStepOutput( $output_packets, $step_type );
 		$output_packets   = $execution_result['packets'];
-		$truncated      = false;
+		$truncated        = false;
 		if ( count( $output_packets ) > $options['max_items'] ) {
 			$output_packets = array_slice( $output_packets, 0, $options['max_items'] );
-			$truncated      = true;
+			$truncated     = true;
 		}
 
-		$output_count   = count( $output_packets );
-		$next_step_id   = ( new StepNavigator() )->get_next_flow_step_id( $flow_step_id, array( 'job_id' => $job_id ) );
-		$reason         = null;
+		$output_count = count( $output_packets );
+		$next_step_id = ( new StepNavigator() )->get_next_flow_step_id( $flow_step_id, array( 'job_id' => $job_id ) );
+		$reason       = null;
 
 		if ( $truncated ) {
 			$reason = 'max_items';

--- a/inc/Engine/Debug/SyncRunner.php
+++ b/inc/Engine/Debug/SyncRunner.php
@@ -252,7 +252,7 @@ class SyncRunner {
 		$truncated        = false;
 		if ( count( $output_packets ) > $options['max_items'] ) {
 			$output_packets = array_slice( $output_packets, 0, $options['max_items'] );
-			$truncated     = true;
+			$truncated      = true;
 		}
 
 		$output_count = count( $output_packets );

--- a/inc/Engine/Debug/SyncRunner.php
+++ b/inc/Engine/Debug/SyncRunner.php
@@ -247,11 +247,8 @@ class SyncRunner {
 			return $this->stepFailure( $flow_step_id, $e->getMessage(), $step_type, $step_class, $input_count );
 		}
 
-		if ( ! is_array( $output_packets ) ) {
-			$output_packets = array();
-		}
-
-		$output_packets = array_values( $output_packets );
+		$execution_result = StepExecutionResult::fromStepOutput( $output_packets, $step_type );
+		$output_packets   = $execution_result['packets'];
 		$truncated      = false;
 		if ( count( $output_packets ) > $options['max_items'] ) {
 			$output_packets = array_slice( $output_packets, 0, $options['max_items'] );
@@ -259,18 +256,17 @@ class SyncRunner {
 		}
 
 		$output_count   = count( $output_packets );
-		$classification = StepExecutionResult::classify( $output_packets, $step_type );
 		$next_step_id   = ( new StepNavigator() )->get_next_flow_step_id( $flow_step_id, array( 'job_id' => $job_id ) );
 		$reason         = null;
 
 		if ( $truncated ) {
 			$reason = 'max_items';
 			$this->markBoundedStop( $job_id, 'sync_runner_max_items' );
-		} elseif ( 0 === $output_count && in_array( $step_type, array( 'fetch', 'event_import' ), true ) ) {
+		} elseif ( 'completed_no_items' === $execution_result['status'] ) {
 			$reason = 'completed_no_items';
 			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED_NO_ITEMS );
-		} elseif ( ! $classification['success'] ) {
-			return $this->stepFailure( $flow_step_id, $classification['reason'], $step_type, $step_class, $input_count, $output_count );
+		} elseif ( ! $execution_result['success'] ) {
+			return $this->stepFailure( $flow_step_id, $execution_result['reason'], $step_type, $step_class, $input_count, $output_count );
 		} elseif ( null === $next_step_id ) {
 			$reason = 'completed';
 			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED );

--- a/tests/step-execution-result-contract-smoke.php
+++ b/tests/step-execution-result-contract-smoke.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Pure-PHP smoke test for StepExecutionResult status/packet separation.
+ *
+ * Run with: php tests/step-execution-result-contract-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		$key = strtolower( $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/StepExecutionResult.php';
+
+use DataMachine\Core\JobStatus;
+use DataMachine\Core\StepExecutionResult;
+
+$failures = 0;
+$total    = 0;
+
+$assert = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$label}\n";
+		return;
+	}
+
+	++$failures;
+	echo "  [FAIL] {$label}\n";
+};
+
+echo "=== step-execution-result-contract-smoke ===\n";
+
+echo "\n[1] explicit status succeeds independently from packet count\n";
+$result = StepExecutionResult::fromStepOutput(
+	array(
+		'status'  => 'succeeded',
+		'packets' => array(),
+	),
+	'system_task'
+);
+
+$assert( 'explicit status is preserved', 'succeeded' === $result['status'] );
+$assert( 'empty explicit packet list can still be a successful execution', true === $result['success'] );
+$assert( 'packet count remains transport-only', 0 === $result['packet_count'] );
+
+echo "\n[2] explicit failure wins over successful-looking packets\n";
+$result = StepExecutionResult::fromStepOutput(
+	array(
+		'status'  => 'failed',
+		'reason'  => 'handler refused item',
+		'packets' => array(
+			array(
+				'type'     => 'source_item',
+				'metadata' => array(),
+			),
+		),
+	),
+	'fetch'
+);
+
+$assert( 'explicit failed status is authoritative', 'failed' === $result['status'] );
+$assert( 'explicit failed result is not successful', false === $result['success'] );
+$assert( 'explicit failure reason is sanitized', 'handler_refused_item' === $result['reason'] );
+
+echo "\n[3] legacy fetch empty output maps to completed_no_items\n";
+$result = StepExecutionResult::classify( array(), 'fetch' );
+
+$assert( 'fetch empty output has completed_no_items status', 'completed_no_items' === $result['status'] );
+$assert( 'fetch empty output exposes terminal status', JobStatus::COMPLETED_NO_ITEMS === $result['terminal_status'] );
+$assert( 'fetch empty output is not downstream success', false === $result['success'] );
+
+echo "\n[4] legacy AI fallback packets do not prove execution success\n";
+$result = StepExecutionResult::classify(
+	array(
+		array(
+			'type'     => 'ai_response',
+			'data'     => array( 'body' => 'I summarized instead of calling a handler.' ),
+			'metadata' => array(),
+		),
+	),
+	'ai'
+);
+
+$assert( 'AI response fallback fails without explicit success', 'failed' === $result['status'] );
+$assert( 'AI response fallback uses actionable failure reason', 'ai_response_without_tool_result' === $result['reason'] );
+
+if ( $failures > 0 ) {
+	echo "\n=== step-execution-result-contract-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";
+	exit( 1 );
+}
+
+echo "\n=== step-execution-result-contract-smoke: ALL PASS ({$total} assertions) ===\n";


### PR DESCRIPTION
## Summary
- normalize step returns through an explicit StepExecutionResult contract with status, packets, reason, terminal_status, success, and packet_count
- route ExecuteStepAbility and SyncRunner through the same normalized result instead of using packet count as execution success
- add a focused smoke test proving explicit status is authoritative and legacy fetch/AI fallback behavior stays stable

Fixes #2264

## Testing
- php -l inc/Core/StepExecutionResult.php inc/Abilities/Engine/ExecuteStepAbility.php inc/Engine/Debug/SyncRunner.php tests/step-execution-result-contract-smoke.php
- php tests/step-execution-result-contract-smoke.php
- php tests/job-status-accounting-smoke.php
- php tests/ai-error-status-propagation-smoke.php
- php tests/system-task-output-packets-smoke.php
- php tests/transition-fanout-policy-smoke.php
- php tests/step-exception-failure-contract-smoke.php
- vendor/bin/phpcs inc/Core/StepExecutionResult.php inc/Abilities/Engine/ExecuteStepAbility.php inc/Engine/Debug/SyncRunner.php tests/step-execution-result-contract-smoke.php
- homeboy --force-hot lint --path /Users/chubes/Developer/data-machine@issue-2264-step-execution-result-contract --extension wordpress --changed-since HEAD~3
- homeboy --force-hot test --path /Users/chubes/Developer/data-machine@issue-2264-step-execution-result-contract --extension wordpress --changed-since HEAD~3

## Notes
- Homeboy lab offload failed before checks because the runner workspace could not bootstrap/sync dependencies; the supported local --force-hot path succeeded.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated issue #2264, drafted the StepExecutionResult contract normalization change, added focused smoke coverage, and ran validation. Chris remains responsible for review and merge.