### PR TITLE
Fix packaged Plugin Check errors

### DIFF
--- a/.buildignore
+++ b/.buildignore
@@ -1,7 +1,10 @@
 # Development files
+.git
 .git/
 .gitignore
 .github/
+.datamachine/
+AGENTS.md
 .DS_Store
 **/.DS_Store
 *.log
@@ -14,6 +17,7 @@ build.sh
 /.homeboy-build/
 
 # Testing
+bin/install-wp-tests.sh
 tests/
 phpunit.xml
 coverage/

--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -12,6 +12,8 @@ namespace DataMachine\Cli;
 
 use WP_CLI;
 
+defined( 'ABSPATH' ) || exit;
+
 if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 	return;
 }

--- a/inc/Core/Admin/AdminRootFilters.php
+++ b/inc/Core/Admin/AdminRootFilters.php
@@ -9,6 +9,8 @@
 
 namespace DataMachine\Core\Admin;
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Register root CSS variables
  *

--- a/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
@@ -340,13 +340,13 @@ class GuidelineAgentMemoryStore implements WP_Agent_Memory_Store {
 
 		$posts = get_posts(
 			array(
-				'post_type'        => self::POST_TYPE,
-				'post_status'      => 'any',
-				'name'             => self::post_name_for_scope( $scope ),
-				'posts_per_page'   => 1,
-				'no_found_rows'    => true,
-				'orderby'          => 'ID',
-				'order'            => 'ASC',
+				'post_type'      => self::POST_TYPE,
+				'post_status'    => 'any',
+				'name'           => self::post_name_for_scope( $scope ),
+				'posts_per_page' => 1,
+				'no_found_rows'  => true,
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
 			)
 		);
 

--- a/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
@@ -345,7 +345,6 @@ class GuidelineAgentMemoryStore implements WP_Agent_Memory_Store {
 				'name'             => self::post_name_for_scope( $scope ),
 				'posts_per_page'   => 1,
 				'no_found_rows'    => true,
-				'suppress_filters' => true,
 				'orderby'          => 'ID',
 				'order'            => 'ASC',
 			)

--- a/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
+++ b/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
@@ -351,7 +351,7 @@ class FetchItemDispositionTool {
 			'item_identifier' => $this->cleanScalar( $item_identifier ),
 			'source_url'      => $this->sourceUrlFromMetadata( $metadata ),
 			'provider'        => $this->providerFromMetadata( $metadata ),
-			'source_type'     => $this->cleanScalar( $source_type ?: ( $metadata['source_type'] ?? '' ) ),
+			'source_type'     => $this->cleanScalar( $source_type ? $source_type : ( $metadata['source_type'] ?? '' ) ),
 			'flow_step_id'    => $this->cleanScalar( $flow_step_id ),
 			'packet_count'    => count( $packets ),
 			'excerpt'         => $bounded['text'],

--- a/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
+++ b/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
@@ -416,7 +416,7 @@ class FetchItemDispositionTool {
 	 * @return array{text:string,truncated:bool}
 	 */
 	private function boundAndRedact( string $text ): array {
-		$text = function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( $text ) : strip_tags( $text );
+		$text = wp_strip_all_tags( $text );
 		$text = trim( preg_replace( '/\s+/u', ' ', $text ) ?? '' );
 		$text = preg_replace( '/\b(Bearer|Basic)\s+[A-Za-z0-9._~+\/-]+=*/i', '$1 [redacted]', $text ) ?? $text;
 		$text = preg_replace( '/\b(api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret|password|secret)\b\s*[:=]\s*[^\s,;]+/i', '$1=[redacted]', $text ) ?? $text;

--- a/inc/Engine/AI/Directives/ClientContextDirective.php
+++ b/inc/Engine/AI/Directives/ClientContextDirective.php
@@ -20,6 +20,8 @@
 
 namespace DataMachine\Engine\AI\Directives;
 
+defined( 'ABSPATH' ) || exit;
+
 class ClientContextDirective {
 
 	/**

--- a/inc/migrations/scaffolding.php
+++ b/inc/migrations/scaffolding.php
@@ -130,18 +130,21 @@ function datamachine_get_scaffold_defaults( string $agent_name = '' ): array {
 		$identity_meta = "\n- **Name:** {$agent_name}";
 	}
 
-	$soul = <<<MD
-# Agent Soul — {$site_name}
-
-This file defines your personality. Customize it to shape how you communicate.
-
-## Identity
-{$identity_line}
-{$identity_meta}
-
-## Voice & Tone
-Write in a clear, helpful tone. Match the communication style your human prefers — observe how they talk to you and adapt.
-MD;
+	$soul = implode(
+		"\n",
+		array(
+			"# Agent Soul — {$site_name}",
+			'',
+			'This file defines your personality. Customize it to shape how you communicate.',
+			'',
+			'## Identity',
+			$identity_line,
+			$identity_meta,
+			'',
+			'## Voice & Tone',
+			'Write in a clear, helpful tone. Match the communication style your human prefers — observe how they talk to you and adapt.',
+		)
+	) . "\n";
 
 	// --- USER.md ---
 	$user_lines = array();
@@ -154,37 +157,43 @@ MD;
 	$user_lines[] = '- **Role:** Site Administrator';
 	$user_about   = implode( "\n", $user_lines );
 
-	$user = <<<MD
-# User Profile
-
-This file profiles your human. Update it when you learn new things about them.
-
-## About
-{$user_about}
-
-## Preferences
-<!-- Communication style, formatting preferences, things to remember -->
-
-## Goals
-<!-- What you're working toward with this site or project -->
-MD;
+	$user = implode(
+		"\n",
+		array(
+			'# User Profile',
+			'',
+			'This file profiles your human. Update it when you learn new things about them.',
+			'',
+			'## About',
+			$user_about,
+			'',
+			'## Preferences',
+			'<!-- Communication style, formatting preferences, things to remember -->',
+			'',
+			'## Goals',
+			"<!-- What you're working toward with this site or project -->",
+		)
+	) . "\n";
 
 	// --- MEMORY.md ---
-	$memory = <<<MD
-# Agent Memory
-
-This file tracks persistent knowledge. Keep it lean — persistent facts only, not session logs.
-
-## State
-- Data Machine v{$dm_version} activated on {$created}
-- WordPress {$wp_version}, PHP {$php_version}
-
-## Lessons Learned
-<!-- What worked, what didn't, patterns to remember -->
-
-## Context
-<!-- Accumulated knowledge about the site, audience, domain -->
-MD;
+	$memory = implode(
+		"\n",
+		array(
+			'# Agent Memory',
+			'',
+			'This file tracks persistent knowledge. Keep it lean — persistent facts only, not session logs.',
+			'',
+			'## State',
+			"- Data Machine v{$dm_version} activated on {$created}",
+			"- WordPress {$wp_version}, PHP {$php_version}",
+			'',
+			'## Lessons Learned',
+			"<!-- What worked, what didn't, patterns to remember -->",
+			'',
+			'## Context',
+			'<!-- Accumulated knowledge about the site, audience, domain -->',
+		)
+	) . "\n";
 
 	return array(
 		'SOUL.md'   => $soul,
@@ -374,18 +383,21 @@ function datamachine_scaffold_user_content( string $content, string $filename, a
 
 	$about = implode( "\n", $about_lines );
 
-	return <<<MD
-# User Profile
-
-## About
-{$about}
-
-## Preferences
-<!-- Communication style, topics of interest, working hours, things to remember -->
-
-## Goals
-<!-- What are you working toward? Projects, content themes, skills to develop -->
-MD;
+	return implode(
+		"\n",
+		array(
+			'# User Profile',
+			'',
+			'## About',
+			$about,
+			'',
+			'## Preferences',
+			'<!-- Communication style, topics of interest, working hours, things to remember -->',
+			'',
+			'## Goals',
+			'<!-- What are you working toward? Projects, content themes, skills to develop -->',
+		)
+	) . "\n";
 }
 
 /**
@@ -459,24 +471,27 @@ function datamachine_scaffold_rules_content( string $content, string $filename, 
 	$site_name = get_bloginfo( 'name' );
 	$site_name = $site_name ? $site_name : 'this site';
 
-	return <<<MD
-# Site Rules
-
-Behavioral constraints that apply to every agent on {$site_name}.
-
-## General
-- Be helpful, accurate, and concise.
-- Follow the site's voice and tone.
-- Do not make up facts or hallucinate information.
-
-## Safety
-- Never expose private user data.
-- Never run destructive operations without confirmation.
-- When in doubt, ask before acting.
-
-## Content
-- Do not publish or modify content without authorization.
-MD;
+	return implode(
+		"\n",
+		array(
+			'# Site Rules',
+			'',
+			"Behavioral constraints that apply to every agent on {$site_name}.",
+			'',
+			'## General',
+			'- Be helpful, accurate, and concise.',
+			"- Follow the site's voice and tone.",
+			'- Do not make up facts or hallucinate information.',
+			'',
+			'## Safety',
+			'- Never expose private user data.',
+			'- Never run destructive operations without confirmation.',
+			'- When in doubt, ask before acting.',
+			'',
+			'## Content',
+			'- Do not publish or modify content without authorization.',
+		)
+	) . "\n";
 }
 
 /**

--- a/tests/plugin-check-error-cleanup-smoke.php
+++ b/tests/plugin-check-error-cleanup-smoke.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Pure-PHP smoke test for Plugin Check error cleanup fixtures.
+ *
+ * Run with: php tests/plugin-check-error-cleanup-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failures = array();
+$passes   = 0;
+
+echo "plugin-check-error-cleanup-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+function datamachine_plugin_check_source( string $relative_path ): string {
+	$path = dirname( __DIR__ ) . '/' . $relative_path;
+	return (string) file_get_contents( $path );
+}
+
+function datamachine_plugin_check_has_heredoc( string $source ): bool {
+	foreach ( token_get_all( $source ) as $token ) {
+		if ( is_array( $token ) && T_START_HEREDOC === $token[0] ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+$buildignore = datamachine_plugin_check_source( '.buildignore' );
+agents_api_smoke_assert_equals( true, str_contains( $buildignore, ".git\n" ), 'gitfile metadata is excluded from distribution package', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $buildignore, ".datamachine/\n" ), 'DMC metadata is excluded from distribution package', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $buildignore, "AGENTS.md\n" ), 'agent context is excluded from distribution package', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $buildignore, "bin/install-wp-tests.sh\n" ), 'test install script is excluded from distribution package', $failures, $passes );
+
+foreach ( array( 'inc/Cli/Bootstrap.php', 'inc/Core/Admin/AdminRootFilters.php', 'inc/Engine/AI/Directives/ClientContextDirective.php' ) as $guarded_file ) {
+	agents_api_smoke_assert_equals( true, str_contains( datamachine_plugin_check_source( $guarded_file ), "defined( 'ABSPATH' ) || exit;" ), "{$guarded_file} has a direct access guard", $failures, $passes );
+}
+
+$fetch_disposition_source = datamachine_plugin_check_source( 'inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php' );
+agents_api_smoke_assert_equals( true, str_contains( $fetch_disposition_source, 'wp_strip_all_tags( $text )' ), 'fetch disposition redaction uses wp_strip_all_tags', $failures, $passes );
+agents_api_smoke_assert_equals( false, str_contains( $fetch_disposition_source, 'strip_tags(' ), 'fetch disposition redaction avoids strip_tags', $failures, $passes );
+
+$memory_store_source = datamachine_plugin_check_source( 'inc/Core/FilesRepository/GuidelineAgentMemoryStore.php' );
+agents_api_smoke_assert_equals( false, str_contains( $memory_store_source, "'suppress_filters'" ), 'memory store relies on get_posts default suppress_filters behavior', $failures, $passes );
+
+$scaffolding_source = datamachine_plugin_check_source( 'inc/migrations/scaffolding.php' );
+agents_api_smoke_assert_equals( false, datamachine_plugin_check_has_heredoc( $scaffolding_source ), 'scaffolding source avoids heredoc syntax', $failures, $passes );
+
+agents_api_smoke_finish( 'Plugin Check error cleanup', $failures, $passes );


### PR DESCRIPTION
## Summary
- exclude non-distribution metadata and `bin/install-wp-tests.sh` from package filtering
- add direct access guards to the three flagged PHP files
- replace the remaining `strip_tags()` path with `wp_strip_all_tags()`
- replace migration scaffolding heredocs with equivalent string assembly
- remove the redundant explicit `suppress_filters` argument from the memory lookup

Fixes #2294.
Fixes #2301.
Fixes #2295.
Fixes #2296.
Part of #2299.

## Testing
- `php tests/plugin-check-error-cleanup-smoke.php`
- `composer exec phpcs -- .buildignore inc/Cli/Bootstrap.php inc/Core/Admin/AdminRootFilters.php inc/Engine/AI/Directives/ClientContextDirective.php inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php inc/Core/FilesRepository/GuidelineAgentMemoryStore.php inc/migrations/scaffolding.php tests/plugin-check-error-cleanup-smoke.php`
- packaged `wp-codebox run --command wordpress.plugin-check --arg plugin-slug=data-machine` result: `errors: 0`; scoped findings from #2294, #2301, #2295, #2296, and the `suppress_filters` finding from #2299 absent

## Notes
- `homeboy test --path ...` failed before running tests because the lab offload copy did not include `vendor/autoload.php`.
- `homeboy lint --path ...` still reports existing repo-wide static-analysis findings unrelated to this scoped Plugin Check cleanup.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the mechanical Plugin Check cleanup, focused smoke test, and verification notes; Chris remains responsible for review and merge.