### PR TITLE
Normalize conversation loop diagnostics shape

### DIFF
--- a/docs/core-system/ai-conversation-loop.md
+++ b/docs/core-system/ai-conversation-loop.md
@@ -55,8 +55,8 @@ Current callers, including `AIStep` and `ChatOrchestrator`, call this function d
 - Base log context for `mode`, `job_id`, `flow_step_id`, and `agent_slug`.
 - Completion assertion preflight for required tools that are unavailable to the model.
 - Data Machine turn runner creation through `datamachine_build_turn_runner()`.
-- Mapping the Agents API `budget_exceeded` status back to Data Machine's `max_turns_reached` compatibility flag.
-- Augmenting the normalized Agents API result with Data Machine-only fields such as `last_tool_calls`, completion nudge diagnostics, and completion assertion diagnostics.
+- Mapping the Agents API `budget_exceeded` status to Data Machine's `metadata.datamachine.max_turns_reached` UI diagnostic.
+- Adding Data Machine-only fields such as `completed`, `last_tool_calls`, completion nudge diagnostics, and completion assertion diagnostics under `metadata.datamachine`.
 
 ## What Agents API Owns
 
@@ -148,16 +148,20 @@ If a required tool is not available in the current tool set, `datamachine_run_co
 
 ```php
 [
-    'completed'                       => false,
     'error_code'                      => 'completion_required_tool_unavailable',
-    'completion_assertions_required'  => $assertions->required(),
-    'unavailable_required_tool_names' => $unavailable_required_tools,
-    'available_tool_names'            => array_keys( $tools ),
     'status'                          => 'error',
+    'metadata'                        => [
+        'datamachine' => [
+            'completed'                       => false,
+            'completion_assertions_required'  => $assertions->required(),
+            'unavailable_required_tool_names' => $unavailable_required_tools,
+            'available_tool_names'            => array_keys( $tools ),
+        ],
+    ],
 ]
 ```
 
-When assertions are missing after a natural completion or partial progress, Data Machine appends a nudge as a user message and keeps the loop running when useful. Final results may include:
+When assertions are missing after a natural completion or partial progress, Data Machine appends a nudge as a user message and keeps the loop running when useful. Final results may include these fields under `metadata.datamachine`:
 
 - `completion_nudge_count`
 - `completion_nudge`
@@ -170,25 +174,30 @@ Job engine data and loop events receive the same diagnostics for evidence and ar
 
 ## Result Shape
 
-The returned array is normalized by `AgentsAPI\AI\WP_Agent_Conversation_Result::normalize()` and then augmented by Data Machine.
+The returned array keeps the Agents API conversation result at the top level. Data Machine runtime diagnostics live under `metadata.datamachine` so callers can distinguish substrate fields from Data Machine UI/provenance hints.
 
-Common fields:
+Common top-level fields:
 
 ```php
 [
     'messages'               => [], // canonical Agents API envelopes
     'final_content'          => '',
     'turn_count'             => 1,
-    'completed'              => true,
     'status'                 => 'completed',
-    'last_tool_calls'        => [],
     'tool_execution_results' => [],
     'usage'                  => [],
     'request_metadata'       => [],
+    'metadata'               => [
+        'datamachine' => [
+            'completed'       => true,
+            'last_tool_calls' => [],
+            'tool_calls'      => [],
+        ],
+    ],
 ]
 ```
 
-Error results use the same array style and include `error`; budget exhaustion also includes `max_turns_reached` and a warning.
+Error results use the same array style and include top-level `error`; budget exhaustion keeps top-level `status => budget_exceeded` and places `max_turns_reached` plus the UI warning under `metadata.datamachine`.
 
 ## Runtime Gates And Transport
 

--- a/docs/core-system/ai-message-envelope.md
+++ b/docs/core-system/ai-message-envelope.md
@@ -93,9 +93,9 @@ For new adapters, prefer putting type-specific fields in `payload` and adapter-s
 
 ## Result Normalization
 
-`AgentsAPI\AI\WP_Agent_Conversation_Result::normalize()` accepts result arrays from the Agents API loop or compatible adapters and normalizes every returned message to an envelope. Data Machine calls this normalizer immediately after `WP_Agent_Conversation_Loop::run()` and only then adds Data Machine-specific diagnostics such as completion assertions and `last_tool_calls`.
+`AgentsAPI\AI\WP_Agent_Conversation_Result::normalize()` accepts result arrays from the Agents API loop or compatible adapters and normalizes every returned message to an envelope. Data Machine calls this normalizer immediately after `WP_Agent_Conversation_Loop::run()` and then places Data Machine-specific diagnostics such as completion assertions and `last_tool_calls` under `metadata.datamachine`.
 
-Required result fields include `messages`, `final_content`, `turn_count`, `completed`, `tool_execution_results`, and `usage`; optional fields such as `status`, `request_metadata`, `error`, and `warning` are preserved.
+Canonical top-level result fields include `messages`, `final_content`, `turn_count`, `tool_execution_results`, and `usage`; optional fields such as `status`, `request_metadata`, and `error` are preserved. Data Machine UI/runtime hints such as `completed`, `warning`, `max_turns_reached`, `tool_calls`, and completion assertion diagnostics live under `metadata.datamachine`.
 
 ## Adapter Guidance
 

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -27,6 +27,7 @@ use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 use WP_Error;
 
 use function DataMachine\Engine\AI\datamachine_run_conversation;
+use function DataMachine\Engine\AI\datamachine_conversation_metadata;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -232,7 +233,8 @@ class ChatOrchestrator {
 		}
 
 		// --- Update session state ---
-		$is_completed = $result['completed'];
+		$loop_metadata = datamachine_conversation_metadata( $result );
+		$is_completed  = (bool) ( $loop_metadata['completed'] ?? false );
 
 		$metadata = array(
 			'status'            => $is_completed ? 'completed' : 'processing',
@@ -241,9 +243,9 @@ class ChatOrchestrator {
 			'current_turn'      => $result['turn_count'],
 			'has_pending_tools' => ! $is_completed,
 		);
-		if ( ! empty( $result['runtime_tool_pending_requests'] ) ) {
+		if ( ! empty( $loop_metadata['runtime_tool_pending_requests'] ) ) {
 			$metadata['runtime_tool_requests'] = array();
-			foreach ( (array) $result['runtime_tool_pending_requests'] as $request ) {
+			foreach ( (array) $loop_metadata['runtime_tool_pending_requests'] as $request ) {
 				if ( is_array( $request ) && ! empty( $request['request_id'] ) ) {
 					$metadata['runtime_tool_requests'][ (string) $request['request_id'] ] = $request;
 				}
@@ -300,22 +302,22 @@ class ChatOrchestrator {
 		$response_data = array(
 			'session_id'   => $session_id,
 			'response'     => $result['final_content'],
-			'tool_calls'   => $result['tool_calls'] ?? $result['last_tool_calls'],
+			'tool_calls'   => $loop_metadata['tool_calls'] ?? $loop_metadata['last_tool_calls'] ?? array(),
 			'conversation' => $result['messages'],
 			'metadata'     => $metadata,
 			'completed'    => $is_completed,
 			'max_turns'    => $max_turns,
 			'turn_number'  => $result['turn_count'],
 		);
-		if ( ! empty( $result['runtime_tool_pending_requests'] ) ) {
-			$response_data['runtime_tool_pending_requests'] = $result['runtime_tool_pending_requests'];
+		if ( ! empty( $loop_metadata['runtime_tool_pending_requests'] ) ) {
+			$response_data['runtime_tool_pending_requests'] = $loop_metadata['runtime_tool_pending_requests'];
 		}
 
-		if ( isset( $result['warning'] ) ) {
-			$response_data['warning'] = $result['warning'];
+		if ( isset( $loop_metadata['warning'] ) ) {
+			$response_data['warning'] = $loop_metadata['warning'];
 		}
 
-		if ( isset( $result['max_turns_reached'] ) && $result['max_turns_reached'] ) {
+		if ( ! empty( $loop_metadata['max_turns_reached'] ) ) {
 			$response_data['max_turns_reached'] = true;
 		}
 
@@ -435,9 +437,10 @@ class ChatOrchestrator {
 
 		// Extract new messages (added during this turn).
 		$new_messages      = array_slice( $result['messages'], $message_count_before );
-		$is_completed      = $result['completed'];
+		$loop_metadata     = datamachine_conversation_metadata( $result );
+		$is_completed      = (bool) ( $loop_metadata['completed'] ?? false );
 		$current_turn      = ( $metadata['current_turn'] ?? 0 ) + $result['turn_count'];
-		$max_turns_reached = $result['max_turns_reached'] ?? ( $current_turn >= $max_turns );
+		$max_turns_reached = $loop_metadata['max_turns_reached'] ?? ( $current_turn >= $max_turns );
 
 		// Update session with new state.
 		$updated_metadata = array(
@@ -450,9 +453,9 @@ class ChatOrchestrator {
 		if ( ! empty( $metadata['runtime_tool_requests'] ) ) {
 			$updated_metadata['runtime_tool_requests'] = $metadata['runtime_tool_requests'];
 		}
-		if ( ! empty( $result['runtime_tool_pending_requests'] ) ) {
+		if ( ! empty( $loop_metadata['runtime_tool_pending_requests'] ) ) {
 			$updated_metadata['runtime_tool_requests'] = is_array( $updated_metadata['runtime_tool_requests'] ?? null ) ? $updated_metadata['runtime_tool_requests'] : array();
-			foreach ( (array) $result['runtime_tool_pending_requests'] as $request ) {
+			foreach ( (array) $loop_metadata['runtime_tool_pending_requests'] as $request ) {
 				if ( is_array( $request ) && ! empty( $request['request_id'] ) ) {
 					$updated_metadata['runtime_tool_requests'][ (string) $request['request_id'] ] = $request;
 				}
@@ -493,14 +496,14 @@ class ChatOrchestrator {
 			'session_id'        => $session_id,
 			'new_messages'      => $new_messages,
 			'final_content'     => $result['final_content'],
-			'tool_calls'        => $result['last_tool_calls'],
+			'tool_calls'        => $loop_metadata['last_tool_calls'] ?? array(),
 			'completed'         => $is_completed,
 			'turn_number'       => $current_turn,
 			'max_turns'         => $max_turns,
 			'max_turns_reached' => $max_turns_reached,
 		);
-		if ( ! empty( $result['runtime_tool_pending_requests'] ) ) {
-			$continue_response['runtime_tool_pending_requests'] = $result['runtime_tool_pending_requests'];
+		if ( ! empty( $loop_metadata['runtime_tool_pending_requests'] ) ) {
+			$continue_response['runtime_tool_pending_requests'] = $loop_metadata['runtime_tool_pending_requests'];
 		}
 
 		/** This action is documented in inc/Api/Chat/ChatOrchestrator.php */
@@ -867,17 +870,16 @@ class ChatOrchestrator {
 				);
 			}
 
+			$loop_metadata = datamachine_conversation_metadata( $loop_result );
+
 			return array(
 				'messages'                      => $loop_result['messages'],
 				'final_content'                 => $loop_result['final_content'],
-				'completed'                     => $loop_result['completed'] ?? false,
 				'turn_count'                    => $loop_result['turn_count'] ?? 1,
-				'tool_calls'                    => $loop_result['tool_calls'] ?? array(),
-				'last_tool_calls'               => $loop_result['last_tool_calls'] ?? array(),
-				'warning'                       => $loop_result['warning'] ?? null,
-				'max_turns_reached'             => $loop_result['max_turns_reached'] ?? false,
 				'usage'                         => $loop_result['usage'] ?? array(),
-				'runtime_tool_pending_requests' => $loop_result['runtime_tool_pending_requests'] ?? array(),
+				'metadata'                      => array(
+					'datamachine' => $loop_metadata,
+				),
 			);
 		} catch ( \Throwable $e ) {
 			do_action(

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -873,11 +873,11 @@ class ChatOrchestrator {
 			$loop_metadata = datamachine_conversation_metadata( $loop_result );
 
 			return array(
-				'messages'                      => $loop_result['messages'],
-				'final_content'                 => $loop_result['final_content'],
-				'turn_count'                    => $loop_result['turn_count'] ?? 1,
-				'usage'                         => $loop_result['usage'] ?? array(),
-				'metadata'                      => array(
+				'messages'      => $loop_result['messages'],
+				'final_content' => $loop_result['final_content'],
+				'turn_count'    => $loop_result['turn_count'] ?? 1,
+				'usage'         => $loop_result['usage'] ?? array(),
+				'metadata'      => array(
 					'datamachine' => $loop_metadata,
 				),
 			);

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -24,6 +24,7 @@ use DataMachine\Engine\AI\Tools\ToolResultFinder;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 
 use function DataMachine\Engine\AI\datamachine_run_conversation;
+use function DataMachine\Engine\AI\datamachine_conversation_metadata;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -539,6 +540,8 @@ class AIStep extends Step {
 				);
 			}
 
+			$loop_metadata = datamachine_conversation_metadata( $loop_result );
+
 			if ( $this->job_id > 0 ) {
 				$artifact_engine_data                           = datamachine_get_engine_data( $this->job_id );
 				$artifact_engine_data['tool_execution_summary'] = self::summarizeToolExecutions( $loop_result );
@@ -547,15 +550,15 @@ class AIStep extends Step {
 				}
 
 				foreach ( array( 'completion_assertions_required', 'completion_assertions_missing', 'completion_assertions_satisfied' ) as $assertion_key ) {
-					if ( isset( $loop_result[ $assertion_key ] ) && array() !== $loop_result[ $assertion_key ] ) {
-						$artifact_engine_data[ $assertion_key ] = $loop_result[ $assertion_key ];
+					if ( isset( $loop_metadata[ $assertion_key ] ) && array() !== $loop_metadata[ $assertion_key ] ) {
+						$artifact_engine_data[ $assertion_key ] = $loop_metadata[ $assertion_key ];
 					}
 				}
 
 				datamachine_set_engine_data( $this->job_id, $artifact_engine_data );
 			}
 
-			$missing_assertion_failure = self::missingCompletionAssertionsFailure( $loop_result );
+			$missing_assertion_failure = self::missingCompletionAssertionsFailure( $loop_result, $loop_metadata );
 			if ( null !== $missing_assertion_failure ) {
 				RunMetrics::recordStepResult(
 					$this->job_id,
@@ -1027,7 +1030,8 @@ class AIStep extends Step {
 			$outputPackets = $packet->addTo( $outputPackets );
 		}
 
-		if ( count( $outputPackets ) === 0 && true === ( $loop_result['completion_assertions_complete'] ?? false ) ) {
+		$loop_metadata = datamachine_conversation_metadata( $loop_result );
+		if ( count( $outputPackets ) === 0 && true === ( $loop_metadata['completion_assertions_complete'] ?? false ) ) {
 			$packet        = new DataPacket(
 				array(
 					'title' => 'AI Completion Assertions Satisfied',
@@ -1037,8 +1041,8 @@ class AIStep extends Step {
 					'source_type'                     => 'ai_completion_assertions',
 					'flow_step_id'                    => $flow_step_id,
 					'conversation_turn'               => $turn_count,
-					'completion_assertions_satisfied' => is_array( $loop_result['completion_assertions_satisfied'] ?? null ) ? $loop_result['completion_assertions_satisfied'] : array(),
-					'completion_assertions_missing'   => is_array( $loop_result['completion_assertions_missing'] ?? null ) ? $loop_result['completion_assertions_missing'] : array(),
+					'completion_assertions_satisfied' => is_array( $loop_metadata['completion_assertions_satisfied'] ?? null ) ? $loop_metadata['completion_assertions_satisfied'] : array(),
+					'completion_assertions_missing'   => is_array( $loop_metadata['completion_assertions_missing'] ?? null ) ? $loop_metadata['completion_assertions_missing'] : array(),
 					'step_execution_success'          => true,
 				),
 				'ai_completion_assertions'
@@ -1144,17 +1148,18 @@ class AIStep extends Step {
 	 * @param array $loop_result Conversation loop result.
 	 * @return array<string,mixed>|null Failure payload, or null when assertions are complete/not configured.
 	 */
-	private static function missingCompletionAssertionsFailure( array $loop_result ): ?array {
-		$missing = is_array( $loop_result['completion_assertions_missing'] ?? null ) ? $loop_result['completion_assertions_missing'] : array();
-		if ( empty( $missing ) || true === ( $loop_result['completion_assertions_complete'] ?? false ) ) {
+	private static function missingCompletionAssertionsFailure( array $loop_result, array $loop_metadata ): ?array {
+		unset( $loop_result );
+		$missing = is_array( $loop_metadata['completion_assertions_missing'] ?? null ) ? $loop_metadata['completion_assertions_missing'] : array();
+		if ( empty( $missing ) || true === ( $loop_metadata['completion_assertions_complete'] ?? false ) ) {
 			return null;
 		}
 
 		return array(
 			'reason'                          => 'completion_assertions_missing',
 			'completion_assertions_missing'   => $missing,
-			'completion_assertions_satisfied' => is_array( $loop_result['completion_assertions_satisfied'] ?? null ) ? $loop_result['completion_assertions_satisfied'] : array(),
-			'completion_assertions_required'  => is_array( $loop_result['completion_assertions_required'] ?? null ) ? $loop_result['completion_assertions_required'] : array(),
+			'completion_assertions_satisfied' => is_array( $loop_metadata['completion_assertions_satisfied'] ?? null ) ? $loop_metadata['completion_assertions_satisfied'] : array(),
+			'completion_assertions_required'  => is_array( $loop_metadata['completion_assertions_required'] ?? null ) ? $loop_metadata['completion_assertions_required'] : array(),
 		);
 	}
 }

--- a/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
+++ b/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
@@ -27,6 +27,10 @@ class DataMachinePipelineTranscriptPersister implements WP_Agent_Transcript_Pers
 		$metadata        = $request->metadata();
 		$provider        = (string) ( $metadata['provider'] ?? '' );
 		$model           = (string) ( $metadata['model'] ?? '' );
+		$result_metadata = datamachine_conversation_metadata( $result );
+		$completed       = array_key_exists( 'completed', $result_metadata )
+			? (bool) $result_metadata['completed']
+			: (bool) ( $result['completed'] ?? false );
 
 		if ( empty( $runtime_context['persist_transcript'] ) ) {
 			return '';
@@ -62,7 +66,7 @@ class DataMachinePipelineTranscriptPersister implements WP_Agent_Transcript_Pers
 			'provider'     => $provider,
 			'model'        => $model,
 			'turn_count'   => $result['turn_count'] ?? 0,
-			'completed'    => (bool) ( $result['completed'] ?? false ),
+			'completed'    => $completed,
 			'error'        => $result['error'] ?? null,
 			'usage'        => $result['usage'] ?? array(),
 		);

--- a/inc/Engine/AI/RuntimeProvenance.php
+++ b/inc/Engine/AI/RuntimeProvenance.php
@@ -25,6 +25,8 @@ class RuntimeProvenance {
 		$request_metadata = is_array( $result['request_metadata'] ?? null ) ? $result['request_metadata'] : array();
 		$usage            = is_array( $result['usage'] ?? null ) ? $result['usage'] : array();
 		$error_message    = isset( $result['error'] ) ? (string) $result['error'] : '';
+		$metadata         = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
+		$datamachine      = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
 
 		$provenance = array(
 			'schema_version'  => 1,
@@ -74,7 +76,7 @@ class RuntimeProvenance {
 			'status'          => array_filter(
 				array(
 					'status'        => (string) ( $result['status'] ?? ( isset( $result['error'] ) ? 'error' : 'completed' ) ),
-					'completed'     => (bool) ( $result['completed'] ?? false ),
+					'completed'     => (bool) ( $datamachine['completed'] ?? false ),
 					'finish_reason' => self::finish_reason( $result ),
 					'cancelled'     => 'cancelled' === ( $result['status'] ?? '' ),
 					'timed_out'     => 'timeout' === ( $result['status'] ?? '' ),
@@ -156,13 +158,15 @@ class RuntimeProvenance {
 		if ( isset( $request_metadata['response']['finish_reason'] ) && is_string( $request_metadata['response']['finish_reason'] ) ) {
 			return $request_metadata['response']['finish_reason'];
 		}
-		if ( ! empty( $result['max_turns_reached'] ) || 'budget_exceeded' === ( $result['status'] ?? '' ) ) {
+		$metadata    = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
+		$datamachine = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
+		if ( ! empty( $datamachine['max_turns_reached'] ) || 'budget_exceeded' === ( $result['status'] ?? '' ) ) {
 			return 'max_turns';
 		}
 		if ( isset( $result['error'] ) ) {
 			return 'provider_error';
 		}
-		return ! empty( $result['completed'] ) ? 'stop' : null;
+		return ! empty( $datamachine['completed'] ) ? 'stop' : null;
 	}
 
 	/** @return array<string,mixed> */

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -134,38 +134,30 @@ function datamachine_run_conversation(
 			)
 		);
 
-		return array(
+		$error_result = array(
 			'messages'                        => $messages,
 			'final_content'                   => '',
 			'turn_count'                      => 0,
-			'completed'                       => false,
-			'last_tool_calls'                 => array(),
-			'tool_calls'                      => array(),
 			'tool_execution_results'          => array(),
 			'error'                           => $error_message,
 			'error_code'                      => 'completion_required_tool_unavailable',
-			'completion_assertions_required'  => $assertions->required(),
-			'unavailable_required_tool_names' => $unavailable_required_tools,
-			'available_tool_names'            => array_keys( $tools ),
 			'usage'                           => array(),
 			'request_metadata'                => array(),
 			'status'                          => 'error',
-			'runtime_provenance'              => RuntimeProvenance::fromConversationResult(
-				array(
-					'messages'         => $messages,
-					'completed'        => false,
-					'error'            => $error_message,
-					'error_code'       => 'completion_required_tool_unavailable',
-					'usage'            => array(),
-					'request_metadata' => array(),
-					'status'           => 'error',
-				),
-				$loop_payload,
-				$provider,
-				$model,
-				$modes
-			),
 		);
+		$error_result = datamachine_with_conversation_metadata(
+			$error_result,
+			array(
+				'completed'                       => false,
+				'last_tool_calls'                 => array(),
+				'tool_calls'                      => array(),
+				'completion_assertions_required'  => $assertions->required(),
+				'unavailable_required_tool_names' => $unavailable_required_tools,
+				'available_tool_names'            => array_keys( $tools ),
+			)
+		);
+		$error_result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $error_result, $loop_payload, $provider, $model, $modes );
+		return $error_result;
 	}
 
 	// Bridge DM's LoopEventSinkInterface to upstream's on_event callable.
@@ -265,14 +257,19 @@ function datamachine_run_conversation(
 			'messages'               => $latest_messages,
 			'final_content'          => '',
 			'turn_count'             => $latest_turn_count,
-			'completed'              => false,
-			'last_tool_calls'        => $last_tool_calls,
-			'tool_calls'             => $all_tool_calls,
 			'tool_execution_results' => $tool_execution_results,
 			'error'                  => $e->getMessage(),
 			'usage'                  => array(),
 			'request_metadata'       => $last_request_metadata,
 			'status'                 => 'error',
+		);
+		$error_result          = datamachine_with_conversation_metadata(
+			$error_result,
+			array(
+				'completed'       => false,
+				'last_tool_calls' => $last_tool_calls,
+				'tool_calls'      => $all_tool_calls,
+			)
 		);
 		$transcript_session_id = $transcript_persister->persist( $latest_messages, $conversation_request, $error_result );
 		if ( '' !== $transcript_session_id ) {
@@ -289,65 +286,131 @@ function datamachine_run_conversation(
 			$result['tool_execution_results'] = $tool_execution_results;
 		}
 	} catch ( \InvalidArgumentException $e ) {
-		$error_result                       = array(
+		$error_result = array(
 			'messages'               => $messages,
 			'final_content'          => '',
 			'turn_count'             => 0,
-			'completed'              => false,
-			'last_tool_calls'        => array(),
-			'tool_calls'             => array(),
 			'tool_execution_results' => array(),
 			'usage'                  => array(),
 			'error'                  => $e->getMessage(),
+		);
+		$error_result = datamachine_with_conversation_metadata(
+			$error_result,
+			array(
+				'completed'       => false,
+				'last_tool_calls' => array(),
+				'tool_calls'      => array(),
+			)
 		);
 		$error_result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $error_result, $loop_payload, $provider, $model, $modes );
 		return $error_result;
 	}
 
 	// Substrate now surfaces turn_count, final_content, usage, and
-	// request_metadata directly on the result (agents-api#136). Augment with
-	// DM-only fields that the substrate doesn't know about.
-	$result['completed']       = 'budget_exceeded' !== ( $result['status'] ?? '' );
-	$result['last_tool_calls'] = $last_tool_calls;
-	$result['tool_calls']      = $all_tool_calls;
+	// request_metadata directly on the result (agents-api#136). Keep DM-only
+	// diagnostics namespaced so the top level remains the Agents API result.
+	$datamachine_metadata = array(
+		'completed'       => 'budget_exceeded' !== ( $result['status'] ?? '' ),
+		'last_tool_calls' => $last_tool_calls,
+		'tool_calls'      => $all_tool_calls,
+	);
 	if ( $runtime_tool_pending ) {
-		$result['completed']                     = false;
-		$result['runtime_tool_pending']          = true;
-		$result['runtime_tool_pending_requests'] = $runtime_tool_requests;
-		$result['status']                        = 'runtime_tool_pending';
+		$datamachine_metadata['completed']                     = false;
+		$datamachine_metadata['runtime_tool_pending']          = true;
+		$datamachine_metadata['runtime_tool_pending_requests'] = $runtime_tool_requests;
+		$result['status']                                      = 'runtime_tool_pending';
 	}
 	if ( ! empty( $completion_nudges ) ) {
-		$latest_nudge                              = $completion_nudges[ count( $completion_nudges ) - 1 ];
-		$result['completion_nudge_count']          = count( $completion_nudges );
-		$result['completion_nudge']                = $latest_nudge['completion_nudge'] ?? '';
-		$result['completion_assertions_required']  = $latest_nudge['completion_assertions_required'] ?? array();
-		$result['completion_assertions_missing']   = $latest_nudge['completion_assertions_missing'] ?? array();
-		$result['completion_assertions_satisfied'] = $latest_nudge['completion_assertions_satisfied'] ?? array();
+		$latest_nudge                                           = $completion_nudges[ count( $completion_nudges ) - 1 ];
+		$datamachine_metadata['completion_nudge_count']          = count( $completion_nudges );
+		$datamachine_metadata['completion_nudge']                = $latest_nudge['completion_nudge'] ?? '';
+		$datamachine_metadata['completion_assertions_required']  = $latest_nudge['completion_assertions_required'] ?? array();
+		$datamachine_metadata['completion_assertions_missing']   = $latest_nudge['completion_assertions_missing'] ?? array();
+		$datamachine_metadata['completion_assertions_satisfied'] = $latest_nudge['completion_assertions_satisfied'] ?? array();
 	}
 	if ( $assertions->hasAssertions() ) {
-		$evaluation                                = $assertions->evaluate( $loop_payload, $result['final_content'] ?? '' );
-		$result['completion_assertions_required']  = $assertions->required();
-		$result['completion_assertions_missing']   = $evaluation['missing'];
-		$result['completion_assertions_satisfied'] = $evaluation['satisfied'];
-		$result['completion_assertions_complete']  = ! empty( $evaluation['complete'] );
+		$evaluation                                             = $assertions->evaluate( $loop_payload, $result['final_content'] ?? '' );
+		$datamachine_metadata['completion_assertions_required']  = $assertions->required();
+		$datamachine_metadata['completion_assertions_missing']   = $evaluation['missing'];
+		$datamachine_metadata['completion_assertions_satisfied'] = $evaluation['satisfied'];
+		$datamachine_metadata['completion_assertions_complete']  = ! empty( $evaluation['complete'] );
 		if ( ! empty( $evaluation['complete'] ) && 'budget_exceeded' !== ( $result['status'] ?? '' ) ) {
-			$result['completed'] = true;
+			$datamachine_metadata['completed'] = true;
 		}
 	}
-	// Map upstream budget_exceeded status to DM's max_turns_reached flag
-	// for backward compatibility with ChatOrchestrator response shaping.
+	// Map upstream budget_exceeded status to DM's max-turn diagnostics for chat
+	// response shaping without adding legacy aliases to the canonical result.
 	if ( 'budget_exceeded' === ( $result['status'] ?? '' ) && in_array( $result['budget'] ?? '', array( 'conversation_turns', 'turns' ), true ) ) {
-		$result['max_turns_reached'] = true;
-		$result['completed']         = false;
-		$result['warning']           = sprintf(
+		$datamachine_metadata['max_turns_reached'] = true;
+		$datamachine_metadata['completed']         = false;
+		$datamachine_metadata['warning']           = sprintf(
 			'Maximum conversation turns (%d) reached. Response may be incomplete.',
 			$turn_budget->ceiling()
 		);
 	}
 
+	$result = datamachine_with_conversation_metadata( $result, $datamachine_metadata );
 	$result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $result, $loop_payload, $provider, $model, $modes );
 
 	return $result;
+}
+
+/**
+ * Attach Data Machine-only conversation diagnostics under metadata.datamachine.
+ *
+ * @param array $result               Canonical Agents API conversation result.
+ * @param array $datamachine_metadata Data Machine diagnostics and UI hints.
+ * @return array Result with namespaced Data Machine metadata.
+ */
+function datamachine_with_conversation_metadata( array $result, array $datamachine_metadata ): array {
+	foreach ( datamachine_conversation_metadata_top_level_keys() as $key ) {
+		unset( $result[ $key ] );
+	}
+
+	$metadata = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
+	$metadata['datamachine'] = array_filter(
+		$datamachine_metadata,
+		static fn( $value ) => null !== $value
+	);
+	$result['metadata'] = $metadata;
+
+	return $result;
+}
+
+/**
+ * Top-level keys owned by Data Machine metadata, not the Agents API result.
+ *
+ * @return string[]
+ */
+function datamachine_conversation_metadata_top_level_keys(): array {
+	return array(
+		'completed',
+		'last_tool_calls',
+		'tool_calls',
+		'runtime_tool_pending',
+		'runtime_tool_pending_requests',
+		'completion_nudge_count',
+		'completion_nudge',
+		'completion_assertions_required',
+		'completion_assertions_missing',
+		'completion_assertions_satisfied',
+		'completion_assertions_complete',
+		'max_turns_reached',
+		'warning',
+		'unavailable_required_tool_names',
+		'available_tool_names',
+	);
+}
+
+/**
+ * Read Data Machine conversation diagnostics from a loop result.
+ *
+ * @param array $result Conversation result.
+ * @return array<string,mixed>
+ */
+function datamachine_conversation_metadata( array $result ): array {
+	$metadata = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
+	return is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
 }
 
 /**

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -134,18 +134,18 @@ function datamachine_run_conversation(
 			)
 		);
 
-		$error_result = array(
-			'messages'                        => $messages,
-			'final_content'                   => '',
-			'turn_count'                      => 0,
-			'tool_execution_results'          => array(),
-			'error'                           => $error_message,
-			'error_code'                      => 'completion_required_tool_unavailable',
-			'usage'                           => array(),
-			'request_metadata'                => array(),
-			'status'                          => 'error',
+		$error_result                       = array(
+			'messages'               => $messages,
+			'final_content'          => '',
+			'turn_count'             => 0,
+			'tool_execution_results' => array(),
+			'error'                  => $error_message,
+			'error_code'             => 'completion_required_tool_unavailable',
+			'usage'                  => array(),
+			'request_metadata'       => array(),
+			'status'                 => 'error',
 		);
-		$error_result = datamachine_with_conversation_metadata(
+		$error_result                       = datamachine_with_conversation_metadata(
 			$error_result,
 			array(
 				'completed'                       => false,
@@ -286,7 +286,7 @@ function datamachine_run_conversation(
 			$result['tool_execution_results'] = $tool_execution_results;
 		}
 	} catch ( \InvalidArgumentException $e ) {
-		$error_result = array(
+		$error_result                       = array(
 			'messages'               => $messages,
 			'final_content'          => '',
 			'turn_count'             => 0,
@@ -294,7 +294,7 @@ function datamachine_run_conversation(
 			'usage'                  => array(),
 			'error'                  => $e->getMessage(),
 		);
-		$error_result = datamachine_with_conversation_metadata(
+		$error_result                       = datamachine_with_conversation_metadata(
 			$error_result,
 			array(
 				'completed'       => false,
@@ -321,15 +321,15 @@ function datamachine_run_conversation(
 		$result['status']                                      = 'runtime_tool_pending';
 	}
 	if ( ! empty( $completion_nudges ) ) {
-		$latest_nudge                                           = $completion_nudges[ count( $completion_nudges ) - 1 ];
-		$datamachine_metadata['completion_nudge_count']          = count( $completion_nudges );
-		$datamachine_metadata['completion_nudge']                = $latest_nudge['completion_nudge'] ?? '';
+		$latest_nudge                                   = $completion_nudges[ count( $completion_nudges ) - 1 ];
+		$datamachine_metadata['completion_nudge_count'] = count( $completion_nudges );
+		$datamachine_metadata['completion_nudge']       = $latest_nudge['completion_nudge'] ?? '';
 		$datamachine_metadata['completion_assertions_required']  = $latest_nudge['completion_assertions_required'] ?? array();
 		$datamachine_metadata['completion_assertions_missing']   = $latest_nudge['completion_assertions_missing'] ?? array();
 		$datamachine_metadata['completion_assertions_satisfied'] = $latest_nudge['completion_assertions_satisfied'] ?? array();
 	}
 	if ( $assertions->hasAssertions() ) {
-		$evaluation                                             = $assertions->evaluate( $loop_payload, $result['final_content'] ?? '' );
+		$evaluation = $assertions->evaluate( $loop_payload, $result['final_content'] ?? '' );
 		$datamachine_metadata['completion_assertions_required']  = $assertions->required();
 		$datamachine_metadata['completion_assertions_missing']   = $evaluation['missing'];
 		$datamachine_metadata['completion_assertions_satisfied'] = $evaluation['satisfied'];
@@ -349,7 +349,7 @@ function datamachine_run_conversation(
 		);
 	}
 
-	$result = datamachine_with_conversation_metadata( $result, $datamachine_metadata );
+	$result                       = datamachine_with_conversation_metadata( $result, $datamachine_metadata );
 	$result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $result, $loop_payload, $provider, $model, $modes );
 
 	return $result;
@@ -367,12 +367,12 @@ function datamachine_with_conversation_metadata( array $result, array $datamachi
 		unset( $result[ $key ] );
 	}
 
-	$metadata = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
+	$metadata                = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
 	$metadata['datamachine'] = array_filter(
 		$datamachine_metadata,
 		static fn( $value ) => null !== $value
 	);
-	$result['metadata'] = $metadata;
+	$result['metadata']      = $metadata;
 
 	return $result;
 }

--- a/tests/Unit/Core/Steps/AI/AIStepTest.php
+++ b/tests/Unit/Core/Steps/AI/AIStepTest.php
@@ -13,6 +13,7 @@ use DataMachine\Engine\AI\Tools\ToolResultFinder;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
+use function DataMachine\Engine\AI\datamachine_with_conversation_metadata;
 
 class AIStepTest extends TestCase {
 
@@ -454,14 +455,18 @@ class AIStepTest extends TestCase {
 		$method = new ReflectionMethod( AIStep::class, 'processLoopResults' );
 		$method->setAccessible( true );
 
-		$loop_result = array(
-			'messages'                         => array(),
-			'tool_execution_results'           => array(),
-			'completion_assertions_complete'    => true,
-			'completion_assertions_satisfied'   => array(
-				'complete_when_any' => array( 'design_comment_and_labels' ),
+		$loop_result = datamachine_with_conversation_metadata(
+			array(
+				'messages'               => array(),
+				'tool_execution_results' => array(),
 			),
-			'completion_assertions_missing'     => array(),
+			array(
+				'completion_assertions_complete'  => true,
+				'completion_assertions_satisfied' => array(
+					'complete_when_any' => array( 'design_comment_and_labels' ),
+				),
+				'completion_assertions_missing'   => array(),
+			)
 		);
 
 		$result = $method->invoke(

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -79,6 +79,8 @@ use AgentsAPI\AI\WP_Agent_Conversation_Request;
 use AgentsAPI\AI\WP_Agent_Transcript_Persister;
 
 use function DataMachine\Engine\AI\datamachine_run_conversation;
+use function DataMachine\Engine\AI\datamachine_conversation_metadata;
+use function DataMachine\Engine\AI\datamachine_with_conversation_metadata;
 
 class RunnerRequestSmokeSink implements LoopEventSinkInterface {
 	public array $events = array();
@@ -188,9 +190,12 @@ $result = datamachine_run_conversation(
 	7,
 	true
 );
+$result_metadata = datamachine_conversation_metadata( $result );
 
 assert_runner_request( 'substrate ok' === ( $result['final_content'] ?? null ), 'result preserves final content from provider' );
-assert_runner_request( true === ( $result['completed'] ?? null ), 'result marks conversation complete when no tools called' );
+assert_runner_request( true === ( $result_metadata['completed'] ?? null ), 'result marks conversation complete when no tools called' );
+assert_runner_request( ! array_key_exists( 'completed', $result ), 'DM completion flag is namespaced outside the Agents API result top level' );
+assert_runner_request( is_array( $result['metadata']['datamachine'] ?? null ), 'result carries Data Machine diagnostics under metadata.datamachine' );
 assert_runner_request( 1 === ( $result['turn_count'] ?? null ), 'result preserves turn count' );
 assert_runner_request( is_array( $result['tool_execution_results'] ?? null ), 'result includes tool execution results' );
 assert_runner_request( 5 === ( $result['usage']['total_tokens'] ?? null ), 'result preserves accumulated usage totals' );
@@ -223,12 +228,39 @@ $error_result = datamachine_run_conversation(
 	array(),
 	1
 );
+$error_metadata = datamachine_conversation_metadata( $error_result );
 
 assert_runner_request( isset( $error_result['error'] ), 'error path returns a structured error field' );
 assert_runner_request( str_contains( (string) ( $error_result['error'] ?? '' ), 'provider offline' ), 'error path preserves the provider error message' );
-assert_runner_request( false === ( $error_result['completed'] ?? true ), 'error path marks conversation not completed' );
+assert_runner_request( false === ( $error_metadata['completed'] ?? true ), 'error path marks conversation not completed' );
 assert_runner_request( 'provider_error' === ( $error_result['runtime_provenance']['status']['finish_reason'] ?? null ), 'error provenance records provider error finish reason' );
 assert_runner_request( str_contains( (string) ( $error_result['runtime_provenance']['provider_errors'][0]['message'] ?? '' ), 'provider offline' ), 'error provenance records provider error message' );
+
+// 2b. Budget-exceeded results keep canonical status top-level and DM diagnostics namespaced.
+$budget_result = datamachine_with_conversation_metadata(
+	array(
+		'messages'               => $messages,
+		'final_content'          => '',
+		'turn_count'             => 3,
+		'tool_execution_results' => array(),
+		'usage'                  => array(),
+		'status'                 => 'budget_exceeded',
+		'budget'                 => 'turns',
+		'completed'              => false,
+		'max_turns_reached'      => true,
+	),
+	array(
+		'completed'         => false,
+		'max_turns_reached' => true,
+		'warning'           => 'Maximum conversation turns reached.',
+	)
+);
+$budget_metadata = datamachine_conversation_metadata( $budget_result );
+
+assert_runner_request( 'budget_exceeded' === ( $budget_result['status'] ?? null ), 'budget exceeded remains the canonical Agents API status' );
+assert_runner_request( true === ( $budget_metadata['max_turns_reached'] ?? null ), 'budget exceeded sets namespaced max-turn diagnostic' );
+assert_runner_request( false === ( $budget_metadata['completed'] ?? true ), 'budget exceeded marks namespaced completion false' );
+assert_runner_request( ! array_key_exists( 'max_turns_reached', $budget_result ), 'budget exceeded omits legacy max_turns_reached from top level' );
 
 // 3. Mid-conversation provider failures preserve the completed-turn context.
 $mid_failure_dispatch_count = 0;
@@ -362,14 +394,16 @@ $sandbox_result = datamachine_run_conversation(
 	array(),
 	3
 );
+$sandbox_metadata = datamachine_conversation_metadata( $sandbox_result );
 
 assert_runner_request( 2 === $sandbox_dispatch_count, 'sandbox/pipeline function call returns to provider for final answer' );
 assert_runner_request( isset( $sandbox_requests[0]['tools']['workspace_read'] ), 'sandbox/pipeline request sends workspace tool declaration' );
 assert_runner_request( 'sandbox tool complete' === ( $sandbox_result['final_content'] ?? null ), 'sandbox/pipeline run preserves final no-tool answer' );
-assert_runner_request( array() === ( $sandbox_result['last_tool_calls'] ?? null ), 'last_tool_calls reflects the final no-tool turn' );
-assert_runner_request( 1 === count( $sandbox_result['tool_calls'] ?? array() ), 'tool_calls preserves parsed calls from earlier turns' );
-assert_runner_request( 'workspace_read' === ( $sandbox_result['tool_calls'][0]['name'] ?? null ), 'tool_calls records the parsed workspace tool name' );
-assert_runner_request( array( 'path' => 'README.md' ) === ( $sandbox_result['tool_calls'][0]['parameters'] ?? null ), 'tool_calls records parsed workspace tool parameters' );
+assert_runner_request( array() === ( $sandbox_metadata['last_tool_calls'] ?? null ), 'last_tool_calls reflects the final no-tool turn' );
+assert_runner_request( 1 === count( $sandbox_metadata['tool_calls'] ?? array() ), 'tool_calls preserves parsed calls from earlier turns' );
+assert_runner_request( 'workspace_read' === ( $sandbox_metadata['tool_calls'][0]['name'] ?? null ), 'tool_calls records the parsed workspace tool name' );
+assert_runner_request( array( 'path' => 'README.md' ) === ( $sandbox_metadata['tool_calls'][0]['parameters'] ?? null ), 'tool_calls records parsed workspace tool parameters' );
+assert_runner_request( ! array_key_exists( 'tool_calls', $sandbox_result ), 'tool_calls are namespaced outside the Agents API result top level' );
 assert_runner_request( 1 === count( $sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline function call executes a workspace tool' );
 assert_runner_request( 'README.md' === ( $sandbox_result['tool_execution_results'][0]['result']['path'] ?? null ), 'sandbox/pipeline tool execution receives parsed parameters' );
 
@@ -421,12 +455,13 @@ $xml_sandbox_result = datamachine_run_conversation(
 	array(),
 	3
 );
+$xml_sandbox_metadata = datamachine_conversation_metadata( $xml_sandbox_result );
 
 assert_runner_request( 2 === $xml_dispatch_count, 'sandbox/pipeline XML tool call returns to provider for final answer' );
 assert_runner_request( 'xml sandbox tool complete' === ( $xml_sandbox_result['final_content'] ?? null ), 'sandbox/pipeline XML tool call preserves final answer' );
-assert_runner_request( 1 === count( $xml_sandbox_result['tool_calls'] ?? array() ), 'sandbox/pipeline XML tool call is parsed' );
-assert_runner_request( 'workspace_read' === ( $xml_sandbox_result['tool_calls'][0]['name'] ?? null ), 'sandbox/pipeline XML tool name is parsed' );
-assert_runner_request( array( 'path' => 'README.md' ) === ( $xml_sandbox_result['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline XML tool parameters are parsed' );
+assert_runner_request( 1 === count( $xml_sandbox_metadata['tool_calls'] ?? array() ), 'sandbox/pipeline XML tool call is parsed' );
+assert_runner_request( 'workspace_read' === ( $xml_sandbox_metadata['tool_calls'][0]['name'] ?? null ), 'sandbox/pipeline XML tool name is parsed' );
+assert_runner_request( array( 'path' => 'README.md' ) === ( $xml_sandbox_metadata['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline XML tool parameters are parsed' );
 assert_runner_request( 1 === count( $xml_sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline XML tool call executes a workspace tool' );
 
 // 4c. Sandbox/pipeline runs also execute JSON tool calls emitted in <tool_call> text envelopes.
@@ -477,12 +512,13 @@ $json_tool_sandbox_result = datamachine_run_conversation(
 	array(),
 	3
 );
+$json_tool_sandbox_metadata = datamachine_conversation_metadata( $json_tool_sandbox_result );
 
 assert_runner_request( 2 === $json_tool_dispatch_count, 'sandbox/pipeline JSON text tool call returns to provider for final answer' );
 assert_runner_request( 'json tool sandbox complete' === ( $json_tool_sandbox_result['final_content'] ?? null ), 'sandbox/pipeline JSON text tool call preserves final answer' );
-assert_runner_request( 1 === count( $json_tool_sandbox_result['tool_calls'] ?? array() ), 'sandbox/pipeline JSON text tool call is parsed' );
-assert_runner_request( 'workspace_read' === ( $json_tool_sandbox_result['tool_calls'][0]['name'] ?? null ), 'sandbox/pipeline JSON text tool name is parsed' );
-assert_runner_request( array( 'path' => 'README.md' ) === ( $json_tool_sandbox_result['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline JSON text tool parameters are parsed' );
+assert_runner_request( 1 === count( $json_tool_sandbox_metadata['tool_calls'] ?? array() ), 'sandbox/pipeline JSON text tool call is parsed' );
+assert_runner_request( 'workspace_read' === ( $json_tool_sandbox_metadata['tool_calls'][0]['name'] ?? null ), 'sandbox/pipeline JSON text tool name is parsed' );
+assert_runner_request( array( 'path' => 'README.md' ) === ( $json_tool_sandbox_metadata['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline JSON text tool parameters are parsed' );
 assert_runner_request( 1 === count( $json_tool_sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline JSON text tool call executes a workspace tool' );
 
 // 4d. Sandbox/pipeline runs also execute fenced JSON tool_calls arrays emitted as text.
@@ -533,12 +569,13 @@ $json_array_sandbox_result = datamachine_run_conversation(
 	array(),
 	3
 );
+$json_array_sandbox_metadata = datamachine_conversation_metadata( $json_array_sandbox_result );
 
 assert_runner_request( 2 === $json_array_dispatch_count, 'sandbox/pipeline fenced JSON tool_calls returns to provider for final answer' );
 assert_runner_request( 'json array sandbox complete' === ( $json_array_sandbox_result['final_content'] ?? null ), 'sandbox/pipeline fenced JSON tool_calls preserves final answer' );
-assert_runner_request( 1 === count( $json_array_sandbox_result['tool_calls'] ?? array() ), 'sandbox/pipeline fenced JSON tool_calls is parsed' );
-assert_runner_request( 'workspace_read' === ( $json_array_sandbox_result['tool_calls'][0]['name'] ?? null ), 'sandbox/pipeline fenced JSON tool_calls name is parsed' );
-assert_runner_request( array( 'path' => 'README.md' ) === ( $json_array_sandbox_result['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline fenced JSON tool_calls parameters are parsed' );
+assert_runner_request( 1 === count( $json_array_sandbox_metadata['tool_calls'] ?? array() ), 'sandbox/pipeline fenced JSON tool_calls is parsed' );
+assert_runner_request( 'workspace_read' === ( $json_array_sandbox_metadata['tool_calls'][0]['name'] ?? null ), 'sandbox/pipeline fenced JSON tool_calls name is parsed' );
+assert_runner_request( array( 'path' => 'README.md' ) === ( $json_array_sandbox_metadata['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline fenced JSON tool_calls parameters are parsed' );
 assert_runner_request( 1 === count( $json_array_sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline fenced JSON tool_calls executes a workspace tool' );
 
 // 5. Client runtime tools are fulfilled by the transport callback, not PHP ToolExecutor.

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -61,6 +61,12 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 	}
 }
 
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( string $text ): string {
+		return trim( preg_replace( '/[\r\n\t ]+/', ' ', strip_tags( $text ) ) ?? '' );
+	}
+}
+
 if ( ! function_exists( 'get_option' ) ) {
 	function get_option( string $_option, $default_value = false ) {
 		return $default_value;
@@ -79,6 +85,7 @@ use DataMachine\Engine\AI\LoopEventSinkInterface;
 use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 
 use function DataMachine\Engine\AI\datamachine_run_conversation;
+use function DataMachine\Engine\AI\datamachine_conversation_metadata;
 
 class RuntimePolicySmokeCompletionPolicy implements WP_Agent_Conversation_Completion_Policy {
 	public array $calls = array();
@@ -260,9 +267,10 @@ $natural_result = datamachine_run_conversation(
 	array(),
 	5
 );
+$natural_metadata = datamachine_conversation_metadata( $natural_result );
 
 assert_runtime_policy( 1 === $natural_dispatch_count, 'default no-tool response completes naturally' );
-assert_runtime_policy( ! empty( $natural_result['completed'] ), 'default natural completion result is completed' );
+assert_runtime_policy( ! empty( $natural_metadata['completed'] ), 'default natural completion result is completed' );
 
 $satisfied_dispatch_count = 0;
 $satisfied_nudge_actions  = runtime_policy_action_count( 'datamachine_ai_completion_nudge_added' );
@@ -297,10 +305,11 @@ $satisfied_result = datamachine_run_conversation(
 	),
 	5
 );
+$satisfied_metadata = datamachine_conversation_metadata( $satisfied_result );
 
 assert_runtime_policy( 1 === $satisfied_dispatch_count, 'satisfied natural assertion completes without nudge' );
-assert_runtime_policy( ! empty( $satisfied_result['completed'] ), 'satisfied natural assertion result is completed' );
-assert_runtime_policy( ! isset( $satisfied_result['completion_nudge_count'] ), 'satisfied natural assertion has no nudge diagnostics' );
+assert_runtime_policy( ! empty( $satisfied_metadata['completed'] ), 'satisfied natural assertion result is completed' );
+assert_runtime_policy( ! isset( $satisfied_metadata['completion_nudge_count'] ), 'satisfied natural assertion has no nudge diagnostics' );
 assert_runtime_policy( $satisfied_nudge_actions === runtime_policy_action_count( 'datamachine_ai_completion_nudge_added' ), 'satisfied natural assertion emits no nudge action' );
 
 $nudge_dispatch_count = 0;
@@ -374,14 +383,16 @@ $nudge_result = datamachine_run_conversation(
 	),
 	5
 );
+$nudge_metadata = datamachine_conversation_metadata( $nudge_result );
 
 assert_runtime_policy( 3 === $nudge_dispatch_count, 'missing natural assertion nudges and keeps loop running' );
 assert_runtime_policy( str_contains( wp_json_encode( $nudge_second_request ), 'The task is not complete yet' ), 'natural nudge is appended before retry request' );
 assert_runtime_policy( ! str_contains( wp_json_encode( $nudge_second_request ), 'completion signals are still missing' ), 'model-facing nudge omits assertion diagnostics phrasing' );
 assert_runtime_policy( 1 === count( $nudge_result['tool_execution_results'] ?? array() ), 'nudged loop captures required tool result' );
-assert_runtime_policy( 1 === ( $nudge_result['completion_nudge_count'] ?? 0 ), 'nudged loop returns nudge count diagnostic' );
-assert_runtime_policy( array( 'runtime_policy_tool' ) === ( $nudge_result['completion_assertions_satisfied']['tool_names'] ?? null ), 'nudged loop returns final satisfied assertion diagnostic' );
-assert_runtime_policy( str_contains( $nudge_result['completion_nudge'] ?? '', 'The task is not complete yet' ), 'nudged loop returns latest natural nudge message' );
+assert_runtime_policy( 1 === ( $nudge_metadata['completion_nudge_count'] ?? 0 ), 'nudged loop returns nudge count diagnostic' );
+assert_runtime_policy( array( 'runtime_policy_tool' ) === ( $nudge_metadata['completion_assertions_satisfied']['tool_names'] ?? null ), 'nudged loop returns final satisfied assertion diagnostic' );
+assert_runtime_policy( str_contains( $nudge_metadata['completion_nudge'] ?? '', 'The task is not complete yet' ), 'nudged loop returns latest natural nudge message' );
+assert_runtime_policy( ! array_key_exists( 'completion_nudge_count', $nudge_result ), 'nudged loop keeps Data Machine diagnostics out of the Agents API result top level' );
 assert_runtime_policy( 1 === count( array_filter( $nudge_event_sink->events, fn( $entry ) => 'completion_nudge_added' === ( $entry['event'] ?? '' ) ) ), 'nudged loop emits completion_nudge_added event' );
 $nudge_event_payload = runtime_policy_first_event_payload( $nudge_event_sink, 'completion_nudge_added' );
 assert_runtime_policy( array( 'runtime_policy_tool' ) === ( $nudge_event_payload['completion_assertions_missing']['tool_names'] ?? null ), 'nudge event includes missing assertion context' );
@@ -441,12 +452,13 @@ $minimum_count_result = datamachine_run_conversation(
 	),
 	6
 );
+$minimum_count_metadata = datamachine_conversation_metadata( $minimum_count_result );
 
 assert_runtime_policy( 5 === $minimum_count_dispatch_count, 'minimum successful tool count nudges until enough calls run' );
 assert_runtime_policy( 2 === count( $minimum_count_result['tool_execution_results'] ?? array() ), 'minimum successful tool count captures both tool results' );
-assert_runtime_policy( array( 'runtime_policy_tool>=2' ) === ( $minimum_count_result['completion_assertions_satisfied']['tool_counts'] ?? null ), 'minimum successful tool count reports satisfied count assertion' );
-assert_runtime_policy( str_contains( $minimum_count_result['completion_nudge'] ?? '', 'The task is not complete yet' ), 'minimum successful tool count returns natural nudge' );
-assert_runtime_policy( ! str_contains( $minimum_count_result['completion_nudge'] ?? '', 'runtime_policy_tool' ), 'minimum successful tool count nudge omits assertion tool name' );
+assert_runtime_policy( array( 'runtime_policy_tool>=2' ) === ( $minimum_count_metadata['completion_assertions_satisfied']['tool_counts'] ?? null ), 'minimum successful tool count reports satisfied count assertion' );
+assert_runtime_policy( str_contains( $minimum_count_metadata['completion_nudge'] ?? '', 'The task is not complete yet' ), 'minimum successful tool count returns natural nudge' );
+assert_runtime_policy( ! str_contains( $minimum_count_metadata['completion_nudge'] ?? '', 'runtime_policy_tool' ), 'minimum successful tool count nudge omits assertion tool name' );
 
 $duplicate_dispatch_count = 0;
 $duplicate_transcript     = new RuntimePolicySmokeTranscriptPersister();
@@ -1285,10 +1297,11 @@ $daily_memory_unavailable_result = datamachine_run_conversation(
 	),
 	5
 );
+$daily_memory_unavailable_metadata = datamachine_conversation_metadata( $daily_memory_unavailable_result );
 
 assert_runtime_policy( 0 === $daily_memory_unavailable_dispatch_count, 'unavailable required tool fails before provider dispatch' );
 assert_runtime_policy( 'completion_required_tool_unavailable' === ( $daily_memory_unavailable_result['error_code'] ?? '' ), 'unavailable required tool returns clear error code' );
-assert_runtime_policy( array( 'agent_daily_memory' ) === ( $daily_memory_unavailable_result['unavailable_required_tool_names'] ?? null ), 'unavailable required tool diagnostic names missing tool' );
+assert_runtime_policy( array( 'agent_daily_memory' ) === ( $daily_memory_unavailable_metadata['unavailable_required_tool_names'] ?? null ), 'unavailable required tool diagnostic names missing tool' );
 assert_runtime_policy( str_contains( $daily_memory_unavailable_result['error'] ?? '', 'agent_daily_memory' ), 'unavailable required tool error message names daily memory' );
 assert_runtime_policy( array( 'agent_daily_memory' ) === ( runtime_policy_first_event_payload( $daily_memory_unavailable_sink, 'completion_assertions_unavailable' )['unavailable_required_tool_names'] ?? null ), 'unavailable required tool emits preflight event' );
 
@@ -1371,10 +1384,11 @@ $daily_memory_success_result = datamachine_run_conversation(
 );
 
 $daily_memory_tool_results = $daily_memory_success_result['tool_execution_results'] ?? array();
+$daily_memory_success_metadata = datamachine_conversation_metadata( $daily_memory_success_result );
 assert_runtime_policy( 4 === $daily_memory_success_dispatch_count, 'required daily memory nudges until successful tool result and then natural completion' );
 assert_runtime_policy( false === ( $daily_memory_tool_results[0]['result']['success'] ?? null ), 'failed daily memory call is captured but not sufficient' );
 assert_runtime_policy( true === ( $daily_memory_tool_results[1]['result']['success'] ?? null ), 'successful daily memory call satisfies required tool assertion' );
-assert_runtime_policy( ! empty( $daily_memory_success_result['completed'] ), 'daily memory assertion result completes after successful tool call' );
+assert_runtime_policy( ! empty( $daily_memory_success_metadata['completed'] ), 'daily memory assertion result completes after successful tool call' );
 
 $dispatch_count     = 0;
 $provider_context   = null;

--- a/tests/ai-loop-event-sink-smoke.php
+++ b/tests/ai-loop-event-sink-smoke.php
@@ -85,6 +85,7 @@ use DataMachine\Engine\AI\NullLoopEventSink;
 use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 
 use function DataMachine\Engine\AI\datamachine_run_conversation;
+use function DataMachine\Engine\AI\datamachine_conversation_metadata;
 
 class LoopEventSinkSmokeCollector implements LoopEventSinkInterface {
 	public array $events = array();
@@ -226,8 +227,9 @@ $result = datamachine_run_conversation(
 	),
 	3
 );
+$result_metadata = datamachine_conversation_metadata( $result );
 
-assert_loop_event_sink( true === $result['completed'], 'evented loop preserves completed result shape' );
+assert_loop_event_sink( true === $result_metadata['completed'], 'evented loop preserves completed result shape' );
 assert_loop_event_sink( 'done' === $result['final_content'], 'evented loop preserves final content' );
 
 // With the upstream substrate, events come from both the substrate loop
@@ -301,9 +303,10 @@ $action_result = datamachine_run_conversation(
 	array( 'job_id' => 1774 ),
 	3
 );
+$action_metadata = datamachine_conversation_metadata( $action_result );
 
 $action_event_names = array_map( fn( array $entry ): string => $entry['event'], $action_events );
-assert_loop_event_sink( true === $action_result['completed'], 'canonical action observer does not require a per-run sink' );
+assert_loop_event_sink( true === $action_metadata['completed'], 'canonical action observer does not require a per-run sink' );
 assert_loop_event_sink( in_array( 'turn_started', $action_event_names, true ), 'canonical action observer receives turn_started' );
 assert_loop_event_sink( in_array( 'completed', $action_event_names, true ), 'canonical action observer receives completed' );
 assert_loop_event_sink( ! in_array( 'request_built', $action_event_names, true ), 'Data Machine request_built event stays product-specific' );
@@ -327,8 +330,9 @@ $failure_result = datamachine_run_conversation(
 	array( 'event_sink' => $failure_sink ),
 	1
 );
+$failure_metadata = datamachine_conversation_metadata( $failure_result );
 
-assert_loop_event_sink( false === $failure_result['completed'], 'failure path preserves completed=false result shape' );
+assert_loop_event_sink( false === $failure_metadata['completed'], 'failure path preserves completed=false result shape' );
 assert_loop_event_sink( str_contains( (string) ( $failure_result['error'] ?? '' ), 'provider offline' ), 'failure path preserves error message' );
 $failure_event_names = loop_event_sink_event_names( $failure_sink );
 assert_loop_event_sink( in_array( 'turn_started', $failure_event_names, true ), 'failure path emits turn_started' );
@@ -365,8 +369,9 @@ $throwing_result = datamachine_run_conversation(
 	array( 'event_sink' => new LoopEventSinkSmokeThrowingSink() ),
 	1
 );
+$throwing_metadata = datamachine_conversation_metadata( $throwing_result );
 
-assert_loop_event_sink( true === $throwing_result['completed'], 'throwing sink does not change loop completion' );
+assert_loop_event_sink( true === $throwing_metadata['completed'], 'throwing sink does not change loop completion' );
 assert_loop_event_sink( loop_event_sink_log_contains( 'datamachine_run_conversation: Event sink failed' ), 'throwing sink is logged as a warning' );
 
 echo "\n";

--- a/tests/job-artifacts-daily-memory-smoke.php
+++ b/tests/job-artifacts-daily-memory-smoke.php
@@ -40,9 +40,9 @@ $assert(
 );
 
 $assert(
-	false !== strpos( $loop, "'completion_assertions_required'  =" )
-		&& false !== strpos( $loop, "'completion_assertions_satisfied' =" ),
-	'conversation loop returns final completion assertion diagnostics even without a nudge'
+	false !== strpos( $loop, "\$datamachine_metadata['completion_assertions_required']" )
+		&& false !== strpos( $loop, "\$datamachine_metadata['completion_assertions_satisfied']" ),
+	'conversation loop returns final completion assertion diagnostics under Data Machine metadata even without a nudge'
 );
 
 $assert(

--- a/tests/runtime-tool-async-broker-smoke.php
+++ b/tests/runtime-tool-async-broker-smoke.php
@@ -65,8 +65,8 @@ datamachine_runtime_async_assert(
 	$passes
 );
 datamachine_runtime_async_assert(
-	str_contains( $loop_source, 'runtime_tool_pending_requests' ) && str_contains( $loop_source, "'runtime_tool_pending'" ),
-	'conversation results surface pending runtime tool requests without fabricating tool output',
+	str_contains( $loop_source, "\$metadata['datamachine']" ) && str_contains( $loop_source, 'runtime_tool_pending_requests' ) && str_contains( $loop_source, "'runtime_tool_pending'" ),
+	'conversation results surface pending runtime tool requests in Data Machine metadata without fabricating tool output',
 	$failures,
 	$passes
 );


### PR DESCRIPTION
## Summary
- keep the Agents API conversation result canonical at the top level
- move Data Machine-only conversation diagnostics into `metadata.datamachine`
- update chat response shaping, AI step artifact handling, runtime provenance, docs, and smoke coverage for the namespaced shape

Closes #2220.

## Verification
- `php tests/agent-conversation-runner-request-smoke.php`
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `php tests/ai-loop-event-sink-smoke.php`
- `php tests/runtime-tool-async-broker-smoke.php`
- `php tests/job-artifacts-daily-memory-smoke.php`
- `php tests/ai-message-envelope-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/conversation-loop.php inc/Api/Chat/ChatOrchestrator.php inc/Core/Steps/AI/AIStep.php inc/Engine/AI/DataMachinePipelineTranscriptPersister.php inc/Engine/AI/RuntimeProvenance.php`

## Homeboy notes
- `homeboy test --path /Users/chubes/Developer/data-machine@issue-2220-conversation-result-shape --extension wordpress` did not run tests: lab offload failed during bootstrap because `/wordpress/wp-content/plugins/data-machine/vendor/autoload.php` was missing in the lab workspace.
- `homeboy lint --path /Users/chubes/Developer/data-machine@issue-2220-conversation-result-shape --extension wordpress` reported the existing repo-wide PHPStan backlog.
- `homeboy lint --path /Users/chubes/Developer/data-machine@issue-2220-conversation-result-shape --extension wordpress --changed-only --summary` failed in lab offload because the materialized lab workspace was not a git repository.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated issue #2220, updated the conversation result boundary implementation/tests/docs, and ran local verification. Chris remains responsible for review and merge.