### PR TITLE
Require agent context for queued execution

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -3,8 +3,8 @@
 namespace DataMachine\Core\Steps\AI;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Agents\AgentIdentity;
 use DataMachine\Core\Agents\AgentIdentityResolver;
-use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\DataPacket;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\PluginSettings;
@@ -163,12 +163,18 @@ class AIStep extends Step {
 
 		$pipeline_step_id = $this->flow_step_config['pipeline_step_id'];
 
-		// Resolve user_id and agent_id from engine snapshot (set by RunFlowAbility).
+		// Resolve agent identity from engine snapshot (set by RunFlowAbility).
 		$job_snapshot = $this->engine->get( 'job' );
 		$job_snapshot = is_array( $job_snapshot ) ? $job_snapshot : array();
-		$agent_id     = $this->resolveAgentIdFromJobSnapshot( $job_snapshot );
-		$agent_slug   = $this->resolveAgentSlugFromJobSnapshot( $job_snapshot, $agent_id );
-		$user_id      = (int) ( $job_snapshot['user_id'] ?? 0 );
+		$identity     = $this->resolveAgentIdentityForExecution( $job_snapshot );
+		if ( null === $identity ) {
+			$this->failMissingAgentContext( $job_snapshot, (string) $pipeline_step_id );
+			return array();
+		}
+
+		$agent_id   = $identity->agent_id;
+		$agent_slug = $identity->agent_slug;
+		$owner_id   = $identity->owner_id;
 
 		$pipeline_step_config = $this->engine->getPipelineStepConfig( $pipeline_step_id );
 		$execution_modes      = self::resolveExecutionModes( $pipeline_step_config, $this->flow_step_config );
@@ -244,7 +250,6 @@ class AIStep extends Step {
 				// drive the conversation. Fall through with $user_message=''.
 			}
 
-			// Vision image from engine data (single source of truth)
 			$file_path    = null;
 			$mime_type    = null;
 			$engine_image = $this->engine->get( 'image_file_path' );
@@ -289,14 +294,10 @@ class AIStep extends Step {
 				$messages[] = ConversationManager::buildConversationMessage( 'user', $user_message );
 			}
 
-			$max_turns = PluginSettings::get( 'max_turns', PluginSettings::DEFAULT_MAX_TURNS );
-
-			// Resolve transcript persistence policy once per AI step invocation.
-			// Resolution order: flow > pipeline > site option (default false).
-			// The boolean is threaded through $payload so the loop doesn't need
-			// to repeat the lookup every turn.
+			$max_turns                   = PluginSettings::get( 'max_turns', PluginSettings::DEFAULT_MAX_TURNS );
 			$transcript_consent_decision = PipelineTranscriptPolicy::decision( $this->engine );
-			$persist_transcript          = $transcript_consent_decision->is_allowed();
+			$persist_transcript          = method_exists( $transcript_consent_decision, 'is_allowed' ) && (bool) call_user_func( array( $transcript_consent_decision, 'is_allowed' ) );
+			$transcript_consent_payload  = method_exists( $transcript_consent_decision, 'to_array' ) ? (array) call_user_func( array( $transcript_consent_decision, 'to_array' ) ) : array();
 
 			$payload = array(
 				'job_id'                      => $this->job_id,
@@ -305,7 +306,7 @@ class AIStep extends Step {
 				'data'                        => $this->dataPackets,
 				'engine'                      => $this->engine,
 				'engine_data'                 => $this->engine->all(),
-				'user_id'                     => $user_id,
+				'user_id'                     => $owner_id,
 				// Pipeline executions have no human caller — the agent is acting on a
 				// scheduled job, not on behalf of a person. Per-user OAuth resolution
 				// reads this field; setting it to 0 prevents accidentally picking up
@@ -317,7 +318,7 @@ class AIStep extends Step {
 				'pipeline_id'                 => $job_snapshot['pipeline_id'] ?? null,
 				'flow_id'                     => $job_snapshot['flow_id'] ?? null,
 				'persist_transcript'          => $persist_transcript,
-				'transcript_consent_decision' => $transcript_consent_decision->to_array(),
+				'transcript_consent_decision' => $transcript_consent_payload,
 			);
 
 			$navigator             = new \DataMachine\Engine\StepNavigator();
@@ -419,29 +420,9 @@ class AIStep extends Step {
 			// correct identity, post_author resolves to the agent owner, and
 			// per-agent capability ceilings are enforced in pipelines the same way
 			// they are in REST.
-			$owner_id = 0;
-			if ( $agent_id > 0 ) {
-				$agents_repo  = new Agents();
-				$agent_record = $agents_repo->get_agent( $agent_id );
-				if ( $agent_record ) {
-					$owner_id = (int) ( $agent_record['owner_id'] ?? 0 );
-				}
-			}
-			if ( $owner_id <= 0 && $user_id > 0 ) {
-				// Legacy / agent-less flows: fall back to the flow's user_id.
-				$this->logAgentlessFallback( $job_snapshot, $user_id, $pipeline_step_id );
-				$owner_id = $user_id;
-			}
-
 			$previous_user_id = get_current_user_id();
-			$context_set      = false;
-			if ( $owner_id > 0 ) {
-				wp_set_current_user( $owner_id );
-				if ( $agent_id > 0 ) {
-					PermissionHelper::set_agent_context( $agent_id, $owner_id );
-					$context_set = true;
-				}
-			}
+			wp_set_current_user( $owner_id );
+			PermissionHelper::set_agent_context( $agent_id, $owner_id );
 
 			try {
 				// Execute conversation loop via agents-api substrate.
@@ -455,10 +436,8 @@ class AIStep extends Step {
 					$max_turns
 				);
 			} finally {
-				if ( $context_set ) {
-					PermissionHelper::clear_agent_context();
-				}
-				if ( $owner_id > 0 && $previous_user_id !== $owner_id ) {
+				PermissionHelper::clear_agent_context();
+				if ( $previous_user_id !== $owner_id ) {
 					wp_set_current_user( $previous_user_id );
 				}
 			}
@@ -820,45 +799,55 @@ class AIStep extends Step {
 	}
 
 	/**
-	 * Log when execution falls back to a user without an agent context.
+	 * Resolve the agent identity required for queued AI execution.
+	 *
+	 * @param array $job_snapshot Portable job snapshot from engine data.
+	 * @return AgentIdentity|null Resolved identity, or null when the job is agent-less/invalid.
+	 */
+	private function resolveAgentIdentityForExecution( array $job_snapshot ): ?AgentIdentity {
+		if ( empty( $job_snapshot['agent_slug'] ) && empty( $job_snapshot['agent_id'] ) ) {
+			return null;
+		}
+
+		try {
+			return ( new AgentIdentityResolver() )->resolve_agent_identity( $job_snapshot );
+		} catch ( \InvalidArgumentException $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Fail queued AI execution when no real agent owner can be resolved.
 	 *
 	 * @param array  $job_snapshot     Portable job snapshot from engine data.
-	 * @param int    $fallback_user_id User ID used for the legacy fallback.
 	 * @param string $pipeline_step_id Pipeline step currently executing.
 	 */
-	private function logAgentlessFallback( array $job_snapshot, int $fallback_user_id, string $pipeline_step_id ): void {
+	private function failMissingAgentContext( array $job_snapshot, string $pipeline_step_id ): void {
+		RunMetrics::recordStepResult(
+			$this->job_id,
+			$this->flow_step_id,
+			array(
+				'step_type'    => 'ai',
+				'result'       => 'failed',
+				'packet_count' => 0,
+				'reason'       => 'ai_agent_context_required',
+			)
+		);
+
 		do_action(
-			'datamachine_log',
-			'warning',
-			'AIStep: Agent-less job snapshot fell back to flow user_id; execution is outside the agent ownership envelope.',
+			'datamachine_fail_job',
+			$this->job_id,
+			'ai_agent_context_required',
 			array(
 				'job_id'           => $this->job_id,
 				'flow_id'          => (int) ( $job_snapshot['flow_id'] ?? 0 ),
 				'pipeline_id'      => (int) ( $job_snapshot['pipeline_id'] ?? 0 ),
 				'flow_step_id'     => $this->flow_step_id,
 				'pipeline_step_id' => $pipeline_step_id,
-				'fallback_user_id' => $fallback_user_id,
+				'error_message'    => 'Queued AI execution requires a valid agent_id or agent_slug with an owner user. Reassign unowned flows/pipelines before running this step.',
+				'solution'         => 'Inspect with wp datamachine pipelines orphans and wp datamachine flows orphans, then reassign with --where-null.',
 			)
 		);
-	}
-
-	/**
-	 * Resolve agent slug from a portable job snapshot.
-	 */
-	private function resolveAgentSlugFromJobSnapshot( array $job_snapshot, int $agent_id ): string {
-		if ( ! empty( $job_snapshot['agent_slug'] ) ) {
-			return sanitize_title( (string) $job_snapshot['agent_slug'] );
-		}
-
-		if ( $agent_id <= 0 ) {
-			return '';
-		}
-
-		try {
-			return ( new AgentIdentityResolver() )->resolve_agent_slug( $agent_id );
-		} catch ( \InvalidArgumentException $e ) {
-			return '';
-		}
 	}
 
 	/**

--- a/inc/Core/Steps/SystemTask/SystemTaskStep.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskStep.php
@@ -21,9 +21,9 @@
 namespace DataMachine\Core\Steps\SystemTask;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Agents\AgentIdentity;
 use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\DataPacket;
-use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Steps\Step;
 use DataMachine\Core\Steps\StepTypeRegistrationTrait;
 use DataMachine\Core\Database\Jobs\Jobs;
@@ -160,13 +160,45 @@ class SystemTaskStep extends Step {
 		}
 
 		// Resolve the task handler class.
-		$handlers      = TaskRegistry::getHandlers();
-		$handler_class = $handlers[ $task_type ];
+		$handlers             = TaskRegistry::getHandlers();
+		$handler_class        = $handlers[ $task_type ];
+		$task_for_passthrough = new $handler_class();
+		if ( ! $task_for_passthrough instanceof SystemTask ) {
+			do_action(
+				'datamachine_fail_job',
+				$this->job_id,
+				'system_task_invalid_handler',
+				array(
+					'flow_step_id'  => $this->flow_step_id,
+					'task_type'     => $task_type,
+					'error_message' => 'System task handler must extend SystemTask.',
+				)
+			);
+			return array();
+		}
+
+		// Carry parent's agent identity into the child engine_data so
+		// task bodies (and any AI request they fire) can resolve the
+		// correct agent's MEMORY.md / SOUL.md / per-agent model. This
+		// mirrors the AIStep + PipelineBatchScheduler pattern (see
+		// #1083, #1198, #1207). Tasks default to requiring an agent ownership
+		// envelope; pure system maintenance tasks must opt out explicitly via
+		// SystemTask::requiresAgentContext().
+		$parent_job_snapshot = $this->engine->getJobContext();
+		$identity            = $this->resolveAgentIdentityForExecution( $parent_job_snapshot );
+		if ( null === $identity && $task_for_passthrough->requiresAgentContext() ) {
+			$this->failMissingAgentContext( $parent_job_snapshot, $task_type );
+			return array();
+		}
+
+		$parent_agent_id   = null !== $identity ? $identity->agent_id : 0;
+		$parent_agent_slug = null !== $identity ? $identity->agent_slug : '';
+		$parent_user_id    = null !== $identity ? $identity->owner_id : 0;
 
 		// Create a child job for independent tracking.
 		$jobs_db      = new Jobs();
-		$job_context  = $this->engine->getJobContext();
-		$child_job_id = $jobs_db->create_job(
+		$job_context  = $parent_job_snapshot;
+		$child_job_id = (int) $jobs_db->create_job(
 			array(
 				'pipeline_id'   => $job_context['pipeline_id'] ?? 'direct',
 				'flow_id'       => $job_context['flow_id'] ?? 'direct',
@@ -176,7 +208,7 @@ class SystemTaskStep extends Step {
 			)
 		);
 
-		if ( ! $child_job_id ) {
+		if ( $child_job_id <= 0 ) {
 			$this->log( 'error', 'Failed to create child job for system task', array( 'task_type' => $task_type ) );
 
 			$result_packet = new DataPacket(
@@ -194,26 +226,6 @@ class SystemTaskStep extends Step {
 			);
 
 			return $result_packet->addTo( $this->dataPackets );
-		}
-
-		// Carry parent's agent identity into the child engine_data so
-		// task bodies (and any AI request they fire) can resolve the
-		// correct agent's MEMORY.md / SOUL.md / per-agent model. This
-		// mirrors the AIStep + PipelineBatchScheduler pattern (see
-		// #1083, #1198, #1207). On agent-less flows the values are 0
-		// and behaviour matches single-agent installs.
-		$parent_job_snapshot = $this->engine->getJobContext();
-		$parent_agent_id     = (int) ( $parent_job_snapshot['agent_id'] ?? 0 );
-		$parent_agent_slug   = '';
-		$parent_user_id      = (int) ( $parent_job_snapshot['user_id'] ?? 0 );
-		if ( ! empty( $parent_job_snapshot['agent_slug'] ) || $parent_agent_id > 0 ) {
-			try {
-				$identity          = ( new AgentIdentityResolver() )->resolve_agent_identity( $parent_job_snapshot );
-				$parent_agent_id   = $identity->agent_id;
-				$parent_agent_slug = $identity->agent_slug;
-			} catch ( \InvalidArgumentException $e ) {
-				$parent_agent_slug = ! empty( $parent_job_snapshot['agent_slug'] ) ? sanitize_title( (string) $parent_job_snapshot['agent_slug'] ) : '';
-			}
 		}
 
 		// Store task params in child job engine_data.
@@ -239,7 +251,7 @@ class SystemTaskStep extends Step {
 			$child_engine_data['user_id'] = $parent_user_id;
 		}
 		$child_job_snapshot = array(
-			'job_id'        => (int) $child_job_id,
+			'job_id'        => $child_job_id,
 			'user_id'       => $parent_user_id,
 			'parent_job_id' => $this->job_id,
 		);
@@ -250,25 +262,6 @@ class SystemTaskStep extends Step {
 			$child_job_snapshot['agent_slug'] = $parent_agent_slug;
 		}
 		$child_engine_data['job'] = $child_job_snapshot;
-
-		// Instantiate the task once. Used here to read its declarative
-		// passthrough contract (#1297) and again inside the try/catch
-		// envelope below to call executeTask(). Passthrough methods are
-		// pure declarations with no side effects.
-		$task_for_passthrough = new $handler_class();
-		if ( ! $task_for_passthrough instanceof SystemTask ) {
-			do_action(
-				'datamachine_fail_job',
-				$this->job_id,
-				'system_task_invalid_handler',
-				array(
-					'flow_step_id'  => $this->flow_step_id,
-					'task_type'     => $task_type,
-					'error_message' => 'System task handler must extend SystemTask.',
-				)
-			);
-			return array();
-		}
 
 		// Inject the standard pipeline-execution context bundle when the
 		// task declares it needs it. Replaces the per-task `if` block
@@ -298,8 +291,8 @@ class SystemTaskStep extends Step {
 				$child_engine_data[ $key ] = $fsc[ $key ];
 			}
 		}
-		$jobs_db->store_engine_data( (int) $child_job_id, $child_engine_data );
-		$jobs_db->start_job( (int) $child_job_id, JobStatus::PROCESSING );
+		$jobs_db->store_engine_data( $child_job_id, $child_engine_data );
+		$jobs_db->start_job( $child_job_id, JobStatus::PROCESSING );
 
 		$this->log(
 			'info',
@@ -312,28 +305,10 @@ class SystemTaskStep extends Step {
 		);
 
 		// Establish agent execution context before firing the task body.
-		//
-		// SystemTaskStep runs inside the Action Scheduler queue under
-		// whatever user the parent step set up (typically nothing in
-		// pre-#1083 paths). System tasks frequently call abilities that
-		// mutate WordPress content (wp_update_post, update_post_meta,
-		// wp_save_post_revision) — those need a real user for proper
-		// post_author resolution and capability checks. This mirrors
-		// the AIStep envelope from #1083 so abilities fired inside
-		// executeTask() see the right identity.
-		$owner_id = 0;
-		if ( $parent_agent_id > 0 ) {
-			$agents_repo  = new Agents();
-			$agent_record = $agents_repo->get_agent( $parent_agent_id );
-			if ( $agent_record ) {
-				$owner_id = (int) ( $agent_record['owner_id'] ?? 0 );
-			}
-		}
-		if ( $owner_id <= 0 && $parent_user_id > 0 ) {
-			// Legacy / agent-less flows: fall back to the flow's user_id.
-			$this->logAgentlessFallback( $parent_job_snapshot, $parent_user_id, (int) $child_job_id );
-			$owner_id = $parent_user_id;
-		}
+		// System tasks frequently call abilities that mutate WordPress content;
+		// those abilities must see the agent owner plus per-agent capability
+		// context, never a broad user-only fallback.
+		$owner_id = $parent_user_id;
 
 		$previous_user_id = get_current_user_id();
 		$context_set      = false;
@@ -343,16 +318,14 @@ class SystemTaskStep extends Step {
 		$error_msg = '';
 
 		try {
-			if ( $owner_id > 0 ) {
+			if ( $owner_id > 0 && $parent_agent_id > 0 ) {
 				wp_set_current_user( $owner_id );
-				if ( $parent_agent_id > 0 ) {
-					PermissionHelper::set_agent_context( $parent_agent_id, $owner_id );
-					$context_set = true;
-				}
+				PermissionHelper::set_agent_context( $parent_agent_id, $owner_id );
+				$context_set = true;
 			}
 
 			// Reuse the instance built earlier for passthrough resolution.
-			$task_for_passthrough->executeTask( (int) $child_job_id, $child_engine_data );
+			$task_for_passthrough->executeTask( $child_job_id, $child_engine_data );
 		} catch ( \Throwable $e ) {
 			$success   = false;
 			$error_msg = $e->getMessage();
@@ -401,7 +374,7 @@ class SystemTaskStep extends Step {
 		}
 
 		$result = ! empty( $child_data['replace_data_packets'] ) ? array() : $this->dataPackets;
-		foreach ( $this->normalizeOutputDataPackets( $child_data['output_data_packets'] ?? array(), $task_type, (int) $child_job_id ) as $packet ) {
+		foreach ( $this->normalizeOutputDataPackets( $child_data['output_data_packets'] ?? array(), $task_type, $child_job_id ) as $packet ) {
 			$result = $packet->addTo( $result );
 		}
 
@@ -494,24 +467,42 @@ class SystemTaskStep extends Step {
 	}
 
 	/**
-	 * Log when a system task runs via the legacy user fallback without agent context.
+	 * Resolve the agent identity required for queued system-task execution.
 	 *
 	 * @param array $parent_job_snapshot Parent job snapshot from engine data.
-	 * @param int   $fallback_user_id    User ID used for the fallback.
-	 * @param int   $child_job_id        Child job created for the system task.
+	 * @return AgentIdentity|null Resolved identity, or null when the job is agent-less/invalid.
 	 */
-	private function logAgentlessFallback( array $parent_job_snapshot, int $fallback_user_id, int $child_job_id ): void {
+	private function resolveAgentIdentityForExecution( array $parent_job_snapshot ): ?AgentIdentity {
+		if ( empty( $parent_job_snapshot['agent_slug'] ) && empty( $parent_job_snapshot['agent_id'] ) ) {
+			return null;
+		}
+
+		try {
+			return ( new AgentIdentityResolver() )->resolve_agent_identity( $parent_job_snapshot );
+		} catch ( \InvalidArgumentException $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Fail queued system-task execution when no real agent owner can be resolved.
+	 *
+	 * @param array  $parent_job_snapshot Parent job snapshot from engine data.
+	 * @param string $task_type           System task type currently executing.
+	 */
+	private function failMissingAgentContext( array $parent_job_snapshot, string $task_type ): void {
 		do_action(
-			'datamachine_log',
-			'warning',
-			'SystemTaskStep: Agent-less parent job snapshot fell back to flow user_id; execution is outside the agent ownership envelope.',
+			'datamachine_fail_job',
+			$this->job_id,
+			'system_task_agent_context_required',
 			array(
-				'parent_job_id'    => $this->job_id,
-				'child_job_id'     => $child_job_id,
-				'flow_id'          => (int) ( $parent_job_snapshot['flow_id'] ?? 0 ),
-				'pipeline_id'      => (int) ( $parent_job_snapshot['pipeline_id'] ?? 0 ),
-				'flow_step_id'     => $this->flow_step_id,
-				'fallback_user_id' => $fallback_user_id,
+				'parent_job_id' => $this->job_id,
+				'flow_id'       => (int) ( $parent_job_snapshot['flow_id'] ?? 0 ),
+				'pipeline_id'   => (int) ( $parent_job_snapshot['pipeline_id'] ?? 0 ),
+				'flow_step_id'  => $this->flow_step_id,
+				'task_type'     => $task_type,
+				'error_message' => 'Queued system-task execution requires a valid agent_id or agent_slug with an owner user. Reassign unowned flows/pipelines before running this step.',
+				'solution'      => 'Inspect with wp datamachine pipelines orphans and wp datamachine flows orphans, then reassign with --where-null.',
 			)
 		);
 	}

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -283,10 +283,16 @@ class SystemAgentServiceProvider {
 					$agents      = $agents_repo->get_all();
 
 					if ( empty( $agents ) ) {
-						// No agents on this install — fall back to a
-						// single site-scoped run so the task still
-						// fires (mirrors pre-multi-agent behaviour).
-						TaskScheduler::schedule( $task_type, $params );
+						do_action(
+							'datamachine_log',
+							'warning',
+							'SystemAgentServiceProvider: per-agent recurring task skipped because no active agents exist',
+							array(
+								'schedule_id' => $schedule_id,
+								'task_type'   => $task_type,
+								'error_code'  => 'recurring_task_agent_context_required',
+							)
+						);
 						return;
 					}
 

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionTask.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionTask.php
@@ -14,6 +14,10 @@ use DataMachine\Engine\AI\System\Tasks\SystemTask;
 
 abstract class RetentionTask extends SystemTask {
 
+	public function requiresAgentContext(): bool {
+		return false;
+	}
+
 	final public function executeTask( int $jobId, array $params ): void {
 		try {
 			$result = $this->runRetentionCleanup();

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -79,6 +79,19 @@ abstract class SystemTask {
 	}
 
 	/**
+	 * Whether this task must run inside a resolved agent ownership envelope.
+	 *
+	 * Most system tasks can invoke abilities or mutate WordPress content, so the
+	 * safe default is agent-scoped execution. Pure internal maintenance tasks may
+	 * opt out explicitly and then run without user/agent fallback context.
+	 *
+	 * @return bool True when agent context is required.
+	 */
+	public function requiresAgentContext(): bool {
+		return true;
+	}
+
+	/**
 	 * Execute the task's imperative business logic.
 	 *
 	 * Called by SystemTaskStep when running as a pipeline/workflow step.

--- a/inc/Engine/Tasks/RecurringScheduleRegistry.php
+++ b/inc/Engine/Tasks/RecurringScheduleRegistry.php
@@ -27,9 +27,9 @@
  *
  * `per_agent` (default false): When true, the recurring hook iterates
  * every registered agent and fires one TaskScheduler::schedule() call per
- * agent with that agent's identity in $context. Site-scoped schedules
- * (e.g. image_optimization) leave it false and continue to fire once
- * per tick.
+ * agent with that agent's identity in $context. Site-scoped schedules leave
+ * it false and fire once per tick only when the task explicitly allows
+ * system-scoped execution.
  *
  * @package DataMachine\Engine\Tasks
  * @since   0.71.0

--- a/inc/Engine/Tasks/TaskScheduler.php
+++ b/inc/Engine/Tasks/TaskScheduler.php
@@ -27,6 +27,7 @@ use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\AbilityResult;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\JobStatus;
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
 
 class TaskScheduler {
 
@@ -86,7 +87,20 @@ class TaskScheduler {
 			return false;
 		}
 
-		$handler  = new $handler_class();
+		$handler = new $handler_class();
+		if ( ! $handler instanceof SystemTask ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				"TaskScheduler: Handler class for '{$taskType}' must extend SystemTask",
+				array(
+					'task_type'     => $taskType,
+					'handler_class' => $handler_class,
+				)
+			);
+			return false;
+		}
+
 		$workflow = $handler->getWorkflow( $params );
 
 		if ( empty( $workflow['steps'] ) ) {
@@ -115,20 +129,49 @@ class TaskScheduler {
 			return false;
 		}
 
-		// Resolve agent identity from the context. Callers without
-		// agent_id/user_id continue to work — the resulting job runs
-		// without an agent (matching pre-multi-agent behaviour).
-		$context_user_id    = (int) ( $context['user_id'] ?? 0 );
-		$context_agent_id   = (int) ( $context['agent_id'] ?? 0 );
-		$context_agent_slug = '';
-		if ( ! empty( $context['agent_slug'] ) || $context_agent_id > 0 ) {
+		// Resolve agent identity from the context when present. Tasks that can
+		// safely run as explicit system maintenance may opt out via
+		// SystemTask::requiresAgentContext(); all other queued task work must have
+		// a real agent owner before the workflow is enqueued.
+		$context_user_id        = 0;
+		$context_agent_id       = 0;
+		$context_agent_slug     = '';
+		$requires_agent_context = $handler->requiresAgentContext();
+		if ( ! empty( $context['agent_slug'] ) || ! empty( $context['agent_id'] ) ) {
 			try {
 				$identity           = ( new AgentIdentityResolver() )->resolve_agent_identity( $context );
+				$context_user_id    = $identity->owner_id;
 				$context_agent_id   = $identity->agent_id;
 				$context_agent_slug = $identity->agent_slug;
 			} catch ( \InvalidArgumentException $e ) {
-				$context_agent_slug = ! empty( $context['agent_slug'] ) ? sanitize_title( (string) $context['agent_slug'] ) : '';
+				do_action(
+					'datamachine_log',
+					'error',
+					'TaskScheduler: queued task received invalid agent context',
+					array(
+						'task_type'  => $taskType,
+						'context'    => 'system',
+						'route'      => $context,
+						'error'      => $e->getMessage(),
+						'error_code' => 'task_scheduler_invalid_agent_context',
+					)
+				);
+				return false;
 			}
+		} elseif ( $requires_agent_context ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'TaskScheduler: queued task requires agent context',
+				array(
+					'task_type'      => $taskType,
+					'context'        => 'system',
+					'route'          => $context,
+					'error_code'     => 'task_scheduler_agent_context_required',
+					'recommendation' => 'Provide agent_id or agent_slug, or reassign unowned flows/pipelines with --where-null before scheduling queued work.',
+				)
+			);
+			return false;
 		}
 
 		// Mirror RunFlowAbility's engine_data['job'] shape so downstream

--- a/tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php
@@ -11,6 +11,7 @@ use DataMachine\Abilities\Engine\ExecuteStepAbility;
 use DataMachine\Abilities\Engine\RunFlowAbility;
 use DataMachine\Abilities\HandlerAbilities;
 use DataMachine\Core\DataPacket;
+use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\Pipelines\Pipelines;
@@ -34,6 +35,7 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
     private array $captured_ai_tools = array();
     private array $captured_logs = array();
     private array $original_settings = array();
+    private int $agent_id = 0;
 
     public function set_up(): void
     {
@@ -43,6 +45,12 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
 
         $user_id = self::factory()->user->create(array('role' => 'administrator'));
         wp_set_current_user($user_id);
+
+        $this->agent_id = (new Agents())->create_if_missing(
+            'pipeline-contract-agent',
+            'Pipeline Contract Agent',
+            $user_id
+        );
 
         $this->original_settings = get_option('datamachine_settings', array());
         update_option(
@@ -317,6 +325,7 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
                 'pipeline_name'   => 'Fake AI Pipeline Contract',
                 'pipeline_config' => $pipeline_config,
                 'user_id'         => get_current_user_id(),
+                'agent_id'        => $this->agent_id,
             )
         );
 
@@ -338,6 +347,7 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
                 'flow_config'       => $flow_config,
                 'scheduling_config' => array('enabled' => true),
                 'user_id'           => get_current_user_id(),
+                'agent_id'          => $this->agent_id,
             )
         );
 

--- a/tests/system-task-agent-context-smoke.php
+++ b/tests/system-task-agent-context-smoke.php
@@ -43,6 +43,27 @@ if ( ! function_exists( 'sanitize_title' ) ) {
 
 // ─── Harness functions mirroring production paths ───────────────────
 
+function resolve_agent_identity_for_test( array $context ): ?array {
+	$agents = array(
+		2 => array( 'agent_id' => 2, 'agent_slug' => 'wayward-son', 'owner_id' => 1 ),
+		5 => array( 'agent_id' => 5, 'agent_slug' => 'valid-agent', 'owner_id' => 1 ),
+	);
+
+	$agent_id   = (int) ( $context['agent_id'] ?? 0 );
+	$agent_slug = ! empty( $context['agent_slug'] ) ? sanitize_title( (string) $context['agent_slug'] ) : '';
+
+	foreach ( $agents as $agent ) {
+		if ( $agent_id > 0 && $agent['agent_id'] === $agent_id ) {
+			return $agent;
+		}
+		if ( '' !== $agent_slug && $agent['agent_slug'] === $agent_slug ) {
+			return $agent;
+		}
+	}
+
+	return null;
+}
+
 /**
  * Mirror of TaskScheduler::schedule() initial_data construction.
  */
@@ -50,11 +71,17 @@ function build_task_scheduler_initial_data(
 	string $task_type,
 	array $params,
 	array $context,
-	int $parent_job_id
+	int $parent_job_id,
+	bool $requires_agent_context = true
 ): array {
-	$context_user_id    = (int) ( $context['user_id'] ?? 0 );
-	$context_agent_id   = (int) ( $context['agent_id'] ?? 0 );
-	$context_agent_slug = ! empty( $context['agent_slug'] ) ? sanitize_title( (string) $context['agent_slug'] ) : '';
+	$identity = resolve_agent_identity_for_test( $context );
+	if ( null === $identity && $requires_agent_context ) {
+		return array( 'error_code' => 'task_scheduler_agent_context_required' );
+	}
+
+	$context_user_id    = null !== $identity ? (int) $identity['owner_id'] : 0;
+	$context_agent_id   = null !== $identity ? (int) $identity['agent_id'] : 0;
+	$context_agent_slug = null !== $identity ? (string) $identity['agent_slug'] : '';
 
 	$job_snapshot = array(
 		'user_id' => $context_user_id,
@@ -114,12 +141,18 @@ function build_system_task_child_engine_data(
 	array $parent_engine_data,
 	int $child_job_id,
 	string $task_type,
-	array $task_params
+	array $task_params,
+	bool $requires_agent_context = true
 ): array {
 	$parent_job_snapshot = $parent_engine_data['job'] ?? array();
-	$parent_agent_id     = (int) ( $parent_job_snapshot['agent_id'] ?? 0 );
-	$parent_agent_slug   = ! empty( $parent_job_snapshot['agent_slug'] ) ? sanitize_title( (string) $parent_job_snapshot['agent_slug'] ) : '';
-	$parent_user_id      = (int) ( $parent_job_snapshot['user_id'] ?? 0 );
+	$identity = resolve_agent_identity_for_test( $parent_job_snapshot );
+	if ( null === $identity && $requires_agent_context ) {
+		return array( 'error_code' => 'system_task_agent_context_required' );
+	}
+
+	$parent_agent_id   = null !== $identity ? (int) $identity['agent_id'] : 0;
+	$parent_agent_slug = null !== $identity ? (string) $identity['agent_slug'] : '';
+	$parent_user_id    = null !== $identity ? (int) $identity['owner_id'] : 0;
 
 	$child_engine_data = array_merge( $task_params, array(
 		'task_type'        => $task_type,
@@ -159,10 +192,6 @@ function build_system_task_child_engine_data(
 function fan_out_per_agent_schedule( array $params, array $agents ): array {
 	$calls = array();
 	if ( empty( $agents ) ) {
-		$calls[] = array(
-			'params'  => $params,
-			'context' => array(),
-		);
 		return $calls;
 	}
 
@@ -231,13 +260,9 @@ $initial = build_task_scheduler_initial_data(
 $assert( 'flat agent_slug present', 'wayward-son' === $initial['agent_slug'] );
 $assert( 'job.agent_slug present', 'wayward-son' === $initial['job']['agent_slug'] );
 
-echo "\n[2] TaskScheduler initial_data without agent context (back-compat)\n";
+echo "\n[2] TaskScheduler rejects initial_data without agent context\n";
 $initial = build_task_scheduler_initial_data( 'image_optimization', array(), array(), 0 );
-$assert( 'flat agent_id is 0', 0 === $initial['agent_id'] );
-$assert( 'flat user_id is 0', 0 === $initial['user_id'] );
-$assert( 'job snapshot still present', is_array( $initial['job'] ) );
-$assert( 'job.agent_id absent (no agent set)', ! isset( $initial['job']['agent_id'] ) );
-$assert( 'job.user_id is 0', 0 === $initial['job']['user_id'] );
+$assert( 'agent-less task schedule is rejected', 'task_scheduler_agent_context_required' === $initial['error_code'] );
 
 echo "\n[3] ExecuteWorkflowAbility engine_data['job'] populated from initial_data\n";
 $initial   = build_task_scheduler_initial_data(
@@ -252,13 +277,9 @@ $assert( 'engine_data.job.job_id set', 100 === $engine['job']['job_id'] );
 $assert( 'engine_data.job.agent_id carried through', 2 === $engine['job']['agent_id'] );
 $assert( 'engine_data.job.user_id carried through', 1 === $engine['job']['user_id'] );
 
-echo "\n[4] ExecuteWorkflowAbility engine_data['job'] without agent context\n";
+echo "\n[4] ExecuteWorkflowAbility receives no agent-less TaskScheduler job\n";
 $initial = build_task_scheduler_initial_data( 'image_optimization', array(), array(), 0 );
-$engine  = build_engine_data_job_snapshot( 200, $initial );
-$assert( 'engine_data.job exists', is_array( $engine['job'] ) );
-$assert( 'engine_data.job.job_id set', 200 === $engine['job']['job_id'] );
-$assert( 'engine_data.job.agent_id absent', ! isset( $engine['job']['agent_id'] ) );
-$assert( 'engine_data.job.user_id is 0', 0 === $engine['job']['user_id'] );
+$assert( 'agent-less task does not build workflow initial_data', 'task_scheduler_agent_context_required' === $initial['error_code'] );
 
 echo "\n[5] SystemTaskStep child engine_data carries parent agent_id\n";
 $parent_engine = array(
@@ -281,13 +302,18 @@ $assert( 'child.job.agent_id from parent', 2 === $child['job']['agent_id'] );
 $assert( 'child.job.agent_slug from parent', 'wayward-son' === $child['job']['agent_slug'] );
 $assert( 'task params preserved', 42 === $child['attachment_id'] );
 
-echo "\n[6] SystemTaskStep child without agent context (legacy flow)\n";
+echo "\n[6] SystemTaskStep rejects child execution without agent context\n";
 $parent_engine = array( 'job' => array( 'job_id' => 600, 'user_id' => 0 ) );
 $child         = build_system_task_child_engine_data( 600, $parent_engine, 601, 'image_optimization', array() );
-$assert( 'child has no flat agent_id', ! isset( $child['agent_id'] ) );
-$assert( 'child has no flat user_id', ! isset( $child['user_id'] ) );
-$assert( 'child.job.agent_id absent', ! isset( $child['job']['agent_id'] ) );
-$assert( 'child.job.user_id is 0', 0 === $child['job']['user_id'] );
+$assert( 'agent-less child execution is rejected', 'system_task_agent_context_required' === $child['error_code'] );
+
+echo "\n[6b] Explicit system maintenance tasks may run without agent context\n";
+$initial = build_task_scheduler_initial_data( 'retention_completed_jobs', array(), array(), 0, false );
+$assert( 'system maintenance schedule can be agent-less by explicit task contract', ! isset( $initial['error_code'] ) );
+$assert( 'system maintenance job.user_id remains 0', 0 === $initial['job']['user_id'] );
+$child = build_system_task_child_engine_data( 600, $parent_engine, 601, 'retention_completed_jobs', array(), false );
+$assert( 'system maintenance child can be agent-less by explicit task contract', ! isset( $child['error_code'] ) );
+$assert( 'system maintenance child has no agent_id', ! isset( $child['job']['agent_id'] ) );
 
 echo "\n[7] Recurring schedule per_agent fan-out\n";
 $agents = array(
@@ -303,10 +329,9 @@ $assert( 'third call carries agent 3 with owner 2', 2 === $calls[2]['context']['
 $assert( 'agent_id surfaces in params', 2 === $calls[1]['params']['agent_id'] );
 $assert( 'date param preserved', '2026-04-25' === $calls[1]['params']['date'] );
 
-echo "\n[8] Recurring schedule per_agent fan-out with no agents (back-compat)\n";
+echo "\n[8] Recurring schedule per_agent fan-out with no agents skips scheduling\n";
 $calls = fan_out_per_agent_schedule( array( 'date' => '2026-04-25' ), array() );
-$assert( 'falls back to single call', 1 === count( $calls ) );
-$assert( 'fallback call has no agent context', empty( $calls[0]['context'] ) );
+$assert( 'no site-scoped fallback call is scheduled', 0 === count( $calls ) );
 
 echo "\n[9] Recurring schedule per_agent fan-out skips invalid agents\n";
 $agents = array(
@@ -316,6 +341,20 @@ $agents = array(
 $calls = fan_out_per_agent_schedule( array(), $agents );
 $assert( 'invalid agent_id skipped', 1 === count( $calls ) );
 $assert( 'valid agent fired', 5 === $calls[0]['context']['agent_id'] );
+
+echo "\n[10] Production sources fail instead of falling back to user-only context\n";
+$ai_step_source          = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Steps/AI/AIStep.php' );
+$system_task_step_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Steps/SystemTask/SystemTaskStep.php' );
+$scheduler_source        = file_get_contents( dirname( __DIR__ ) . '/inc/Engine/Tasks/TaskScheduler.php' );
+$provider_source         = file_get_contents( dirname( __DIR__ ) . '/inc/Engine/AI/System/SystemAgentServiceProvider.php' );
+$assert( 'AIStep has explicit missing-agent failure', str_contains( $ai_step_source, 'ai_agent_context_required' ) );
+$assert( 'SystemTaskStep has explicit missing-agent failure', str_contains( $system_task_step_source, 'system_task_agent_context_required' ) );
+$assert( 'TaskScheduler refuses agent-less queued task scheduling', str_contains( $scheduler_source, 'task_scheduler_agent_context_required' ) );
+$assert( 'SystemTask exposes explicit agent-context contract', str_contains( file_get_contents( dirname( __DIR__ ) . '/inc/Engine/AI/System/Tasks/SystemTask.php' ), 'function requiresAgentContext(): bool' ) );
+$assert( 'Retention tasks explicitly opt out of agent context', str_contains( file_get_contents( dirname( __DIR__ ) . '/inc/Engine/AI/System/Tasks/Retention/RetentionTask.php' ), 'function requiresAgentContext(): bool' ) );
+$assert( 'Recurring per-agent schedules do not fall back to a site-scoped task', str_contains( $provider_source, 'recurring_task_agent_context_required' ) && ! str_contains( $provider_source, 'pre-multi-agent behaviour' ) );
+$assert( 'AI fallback warning was removed', ! str_contains( $ai_step_source, 'fell back to flow user_id' ) );
+$assert( 'System task fallback warning was removed', ! str_contains( $system_task_step_source, 'fell back to flow user_id' ) );
 
 echo "\n";
 if ( $failures > 0 ) {


### PR DESCRIPTION
## Summary
- require queued AI steps to resolve a real agent owner instead of falling back to `flow.user_id`
- require system-task steps to run with an agent by default, with an explicit `SystemTask::requiresAgentContext()` opt-out for internal maintenance tasks
- skip per-agent recurring tasks when no agents exist instead of scheduling a site-scoped fallback
- update focused smoke coverage for agent context propagation, missing-agent failures, and explicit maintenance opt-out

Closes #2217.

## Testing
- `php tests/system-task-agent-context-smoke.php`
- `vendor/bin/phpcs inc/Core/Steps/AI/AIStep.php inc/Core/Steps/SystemTask/SystemTaskStep.php inc/Engine/Tasks/TaskScheduler.php inc/Engine/AI/System/SystemAgentServiceProvider.php inc/Engine/AI/System/Tasks/SystemTask.php inc/Engine/AI/System/Tasks/Retention/RetentionTask.php inc/Engine/Tasks/RecurringScheduleRegistry.php tests/system-task-agent-context-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@issue-2217-agentless-queued-execution --extension wordpress --file inc/Core/Steps/AI/AIStep.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@issue-2217-agentless-queued-execution --extension wordpress --file inc/Core/Steps/SystemTask/SystemTaskStep.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@issue-2217-agentless-queued-execution --extension wordpress --file inc/Engine/Tasks/TaskScheduler.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@issue-2217-agentless-queued-execution --extension wordpress --file inc/Engine/AI/System/Tasks/SystemTask.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@issue-2217-agentless-queued-execution --extension wordpress --file inc/Engine/AI/System/Tasks/Retention/RetentionTask.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@issue-2217-agentless-queued-execution --extension wordpress --file inc/Engine/AI/System/SystemAgentServiceProvider.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@issue-2217-agentless-queued-execution --extension wordpress --file inc/Engine/Tasks/RecurringScheduleRegistry.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@issue-2217-agentless-queued-execution --extension wordpress --file tests/system-task-agent-context-smoke.php`

## Known verification limitation
- `homeboy test --path /Users/chubes/Developer/data-machine@issue-2217-agentless-queued-execution --extension wordpress` failed before tests ran because the lab WP Codebox mount did not include `/wordpress/wp-content/plugins/data-machine/vendor/autoload.php`.
- `homeboy lint --changed-only` failed in the lab snapshot because the snapshot was not a git repository, so changed-file coverage was run with explicit `--file` invocations instead.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated issue #2217, implemented the agent-context enforcement and explicit system-task opt-out, updated smoke coverage, and ran verification; Chris remains responsible for review and merge.