### PR TITLE
fix: hoist frontend email abilities

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -29,7 +29,8 @@ if ( ! defined( 'AGENTS_API_LOADED' ) ) {
 }
 
 // WP-CLI integration
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
+// @phpstan-ignore-next-line Runtime constant may be defined false outside PHPStan's configured CLI context.
+if ( defined( 'WP_CLI' ) && (bool) constant( 'WP_CLI' ) ) {
 	require_once __DIR__ . '/inc/Cli/Bootstrap.php';
 }
 
@@ -110,9 +111,7 @@ function datamachine_run_datamachine_plugin() {
 	\DataMachine\Core\Database\BundleArtifacts\InstalledBundleArtifacts::register();
 
 	// Initialize FetchHandler to register skip_item tool for all fetch-type handlers.
-	if ( method_exists( \DataMachine\Core\Steps\Fetch\Handlers\FetchHandler::class, 'init' ) ) {
-		\DataMachine\Core\Steps\Fetch\Handlers\FetchHandler::init();
-	}
+	\DataMachine\Core\Steps\Fetch\Handlers\FetchHandler::init();
 
 	// Register all tools - must happen AFTER step types and handlers are registered.
 	\DataMachine\Engine\AI\Tools\ToolServiceProvider::register();
@@ -319,6 +318,7 @@ function datamachine_run_datamachine_plugin() {
 	// themselves on `datamachine_pending_action_handlers` via
 	// inc/Abilities/Content/ContentActionHandlers.php (required above).
 	if ( interface_exists( '\AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Observer' ) ) {
+		// @phpstan-ignore-next-line Scoped analysis sees the observer implementation before the conditional interface load.
 		\DataMachine\Engine\AI\Actions\PendingActionObservers::register( new \DataMachine\Engine\AI\Actions\WordPressActionDispatchObserver() );
 	}
 	new \DataMachine\Engine\AI\Actions\PendingActionInspectionAbility();
@@ -336,6 +336,10 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\Fetch\GetWordPressPostAbility();
 	new \DataMachine\Abilities\Fetch\QueryWordPressPostsAbility();
 	new \DataMachine\Abilities\Publish\PublishWordPressAbility();
+	// Send-email abilities are also registered unconditionally at file
+	// include time (see bottom of this file). This call is the defensive
+	// in-runtime path for late `plugins_loaded` inclusion. The static guards
+	// make it idempotent.
 	new \DataMachine\Abilities\Publish\SendEmailAbility();
 	new \DataMachine\Abilities\Publish\SendEmailQueuedAbility();
 	new \DataMachine\Abilities\Update\UpdateWordPressAbility();
@@ -393,7 +397,8 @@ function datamachine_should_load_full_runtime(): bool {
 		return true;
 	}
 
-	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	// @phpstan-ignore-next-line Runtime constant may be defined false outside PHPStan's configured CLI context.
+	if ( defined( 'WP_CLI' ) && (bool) constant( 'WP_CLI' ) ) {
 		return true;
 	}
 
@@ -504,6 +509,29 @@ require_once __DIR__ . '/inc/Abilities/AbilityCategories.php';
  */
 require_once __DIR__ . '/inc/Abilities/Media/ImageTemplateAbilities.php';
 \DataMachine\Abilities\Media\ImageTemplateAbilities::ensure_registered();
+
+/**
+ * Register `datamachine/send-email` and `datamachine/send-email-queued`
+ * unconditionally on every request.
+ *
+ * These abilities have proven consumers that can fire on lite frontend page
+ * views. `extrachill-multisite` exposes `ec_send_email()` and
+ * `ec_send_email_queued()` as generic mail helpers, so form handlers or other
+ * frontend hooks can resolve these abilities without a REST, Ajax, admin, cron,
+ * or CLI request shape. If the classes stay behind
+ * `datamachine_should_load_full_runtime()`, those helpers can trigger the lazy
+ * Abilities API registry before Data Machine attaches its ability hooks,
+ * causing `wp_get_ability()` to return `null` on normal frontend requests.
+ * See: Extra-Chill/data-machine#2303.
+ *
+ * Registration remains cheap: the immediate ability definitions are schema and
+ * callback wiring only, and the queued worker hook is a single no-op listener
+ * until Action Scheduler dispatches its specific hook.
+ */
+require_once __DIR__ . '/inc/Abilities/Publish/SendEmailAbility.php';
+require_once __DIR__ . '/inc/Abilities/Publish/SendEmailQueuedAbility.php';
+\DataMachine\Abilities\Publish\SendEmailAbility::ensure_registered();
+\DataMachine\Abilities\Publish\SendEmailQueuedAbility::ensure_registered();
 
 
 /**

--- a/docs/core-system/abilities-api.md
+++ b/docs/core-system/abilities-api.md
@@ -10,6 +10,8 @@ The Abilities API in `inc/Abilities/` provides a unified interface for Data Mach
 
 This page documents the shape of the current ability surface and the source files that own each domain. For an exact live inventory, run `wp abilities list --category=datamachine-*` in a loaded WordPress install or inspect `wp_register_ability()` callsites under `inc/Abilities/`.
 
+Normal frontend page views intentionally skip the full Data Machine runtime. Abilities that have proven frontend-lite consumers are documented in [Runtime-Gated Abilities Audit](runtime-gated-abilities-audit.md); only those proven reachable abilities should be hoisted out of the runtime gate.
+
 ## Multi-Agent Scoping
 
 Data Machine follows a WordPress-shaped identifier model: `agent_id` is the stable numeric row ID, and `agent_slug` is the human-readable, portable identifier. Programmatic ability inputs should use explicit fields (`agent_id` when selecting by row ID, `agent_slug` when selecting by slug). The generic `agent` selector is reserved for CLI and resolver-style boundaries that intentionally accept either ID or slug. The `PermissionHelper` class resolves selectors to scoped agent and user IDs, enforces ownership checks via `owns_resource()` and `owns_agent_resource()`, and controls access grants via `can_access_agent()`.

--- a/docs/core-system/runtime-gated-abilities-audit.md
+++ b/docs/core-system/runtime-gated-abilities-audit.md
@@ -1,0 +1,51 @@
+# Runtime-Gated Abilities Audit
+
+Issue: https://github.com/Extra-Chill/data-machine/issues/2303
+
+Data Machine skips the full runtime on normal frontend page views via `datamachine_should_load_full_runtime()`. Ability constructors inside `datamachine_run_datamachine_plugin()` therefore do not run on those lite requests unless the ability is explicitly hoisted to file-load registration.
+
+This audit records which gated abilities have proven frontend-lite consumers. Only proven reachable abilities should be hoisted; the rest stay gated until a concrete frontend-lite call site exists.
+
+## Disposition Table
+
+| Area | Abilities | Frontend-lite consumer evidence | Disposition |
+|---|---|---|---|
+| Auth | `datamachine/list-auth-providers`, `datamachine/get-auth-status`, `datamachine/connect-auth`, `datamachine/disconnect-auth`, `datamachine/set-auth-token`, `datamachine/revoke-auth-token`, `datamachine/refresh-auth-token` | Admin/API auth management only. No frontend-lite `wp_get_ability()` consumer found in the Data Machine repo or local Extra Chill extension checkouts during #2303. | Keep gated. |
+| AI diagnostics | `datamachine/inspect-ai-request` | Diagnostic/admin surface. No frontend-lite consumer found. | Keep gated. |
+| Files | Agent, flow, and scaffold file abilities | Agent/runtime file management. No frontend-lite consumer found. | Keep gated. |
+| Flow | `datamachine/get-flows`, `datamachine/create-flow`, `datamachine/update-flow`, `datamachine/delete-flow`, `datamachine/duplicate-flow`, `datamachine/pause-flow`, `datamachine/resume-flow`, queue/config/webhook flow abilities | Local Data Machine consumers are REST/CLI/tests. Issue #2303 noted Extra Chill Events references to `create-flow`, but those are REST-shaped ability classes rather than page-render helpers. | Keep gated. |
+| Flow steps | `datamachine/get-flow-steps`, `datamachine/update-flow-step`, `datamachine/configure-flow-steps`, `datamachine/validate-flow-steps-config` | Flow-builder/API surface. No frontend-lite consumer found. | Keep gated. |
+| Jobs | `datamachine/get-jobs`, `datamachine/delete-jobs`, `datamachine/execute-workflow`, `datamachine/flow-health`, `datamachine/problem-flows`, `datamachine/recover-stuck-jobs`, `datamachine/jobs-summary`, `datamachine/run-metrics`, `datamachine/fail-job`, `datamachine/retry-job` | Local Data Machine consumers are CLI, REST, cron, admin, or tests. Issue #2303 noted Extra Chill Events references to `execute-workflow`, but those are REST-shaped ability classes rather than page-render helpers. | Keep gated. |
+| Logs | `datamachine/write-to-log`, `datamachine/clear-logs`, `datamachine/read-logs`, `datamachine/get-log-metadata`, `datamachine/read-debug-log` | Runtime diagnostics/admin surface. No frontend-lite consumer found. | Keep gated. |
+| Post queries | `datamachine/query-posts`, `datamachine/list-posts` | Admin/chat/runtime query surface. No frontend-lite consumer found. | Keep gated. |
+| Pipeline | `datamachine/get-pipelines`, `datamachine/create-pipeline`, `datamachine/update-pipeline`, `datamachine/delete-pipeline`, `datamachine/duplicate-pipeline`, import/export pipeline abilities | Local Data Machine consumers are REST/CLI/tests. Issue #2303 noted Extra Chill Events references to `create-pipeline`, but those are REST-shaped ability classes rather than page-render helpers. | Keep gated. |
+| Pipeline steps | `datamachine/get-pipeline-steps`, `datamachine/add-pipeline-step`, `datamachine/update-pipeline-step`, `datamachine/delete-pipeline-step`, `datamachine/reorder-pipeline-steps` | Flow-builder/API surface. No frontend-lite consumer found. | Keep gated. |
+| Duplicate checks | `datamachine/check-duplicate`, duplicate title matching | Local Extra Chill Events use is inside a Data Machine upsert step handler, which runs under the full runtime. | Keep gated. |
+| Processed items | Processed-item clear/check/history/stale/never-processed helpers | Pipeline/runtime state surface. No frontend-lite consumer found. | Keep gated. |
+| Tracked items | `datamachine/upsert-tracked-item`, `datamachine/get-tracked-item`, `datamachine/list-tracked-items`, `datamachine/tracked-items-summary` | Pipeline/system-task coverage surface. No frontend-lite consumer found. | Keep gated. |
+| Settings | Settings and handler-default abilities | Admin/CLI/settings surface. No frontend-lite consumer found. | Keep gated. |
+| Handlers and step types | Handler discovery/test/defaults and step-type listing/validation | Admin/runtime discovery surface. No frontend-lite consumer found. | Keep gated. |
+| Local search | `datamachine/local-search` | Chat/runtime search surface. No frontend-lite consumer found. | Keep gated. |
+| Source inventory | `datamachine/source-inventory`, `datamachine/source-aggregate` | System-task/source coverage surface. No frontend-lite consumer found. | Keep gated. |
+| System | Session title, health, and system-task abilities | Admin/chat/system-task surface. No frontend-lite consumer found. | Keep gated. |
+| Media | `datamachine/generate-alt-text`, `datamachine/diagnose-alt-text`, image generation, media upload/validation/video metadata | Admin/pipeline media surface. No frontend-lite consumer found. | Keep gated. |
+| Image templates | `datamachine/render-image-template`, `datamachine/list-image-templates` | Proven frontend-lite consumers: Extra Chill OG-card and event-roundup generation. | Already hoisted by #2291. |
+| SEO | IndexNow and meta-description abilities | Pipeline/admin SEO surface. No frontend-lite consumer found. | Keep gated. |
+| Agent calls | `datamachine/agent-call`, `datamachine/agent-remote-call` | Agent/runtime surface. No frontend-lite consumer found. | Keep gated. |
+| Taxonomy | Resolve, merge meta, get/create/update/delete term abilities | Admin/pipeline taxonomy surface. No frontend-lite consumer found. | Keep gated. |
+| Agent identity and tokens | Agent CRUD/import/export/access/token abilities | Admin/agent management surface. No frontend-lite consumer found. | Keep gated. |
+| Agent memory and daily memory | Agent memory and daily memory read/write/list/search/delete abilities | Chat/agent runtime surface. No frontend-lite consumer found. | Keep gated. |
+| Chat | Chat session and message abilities | REST/frontend-chat requests hit `/wp-json/` and load the full runtime. No lite page-render consumer found. | Keep gated. |
+| Internal linking | Diagnostics, audit, backlinks, broken links, opportunities | Admin/runtime content analysis surface. No frontend-lite consumer found. | Keep gated. |
+| Content/block editing | `datamachine/get-post-blocks`, `datamachine/edit-post-blocks`, `datamachine/replace-post-blocks`, `datamachine/insert-content`, `datamachine/upsert-post` | Local Extra Chill Events use of `upsert-post` is inside a Data Machine upsert step handler, which runs under the full runtime. | Keep gated. |
+| Pending actions | Pending-action inspection/sign/resolve abilities | Agent approval/runtime surface. No frontend-lite consumer found. | Keep gated. |
+| Fetch | File, email, RSS, WordPress API/media/post query fetch abilities | Pipeline/runtime fetch surface. No frontend-lite consumer found. | Keep gated. |
+| Email mailbox | Email reply/delete/move/flag/batch/unsubscribe/test abilities | Admin/CLI/mailbox surface. No frontend-lite consumer found. | Keep gated. |
+| Publish | `datamachine/publish-wordpress` | Pipeline/runtime publish surface. No frontend-lite consumer found. | Keep gated. |
+| Publish email | `datamachine/send-email`, `datamachine/send-email-queued` | Proven frontend-lite consumers: issue #2303 documents `extrachill-multisite` generic `ec_send_email()` and `ec_send_email_queued()` helpers as callable from normal frontend hooks/form handlers. Data Machine core also uses these from REST/CLI/worker contexts. | Hoisted in #2303. |
+| Update | `datamachine/update-wordpress` | Pipeline/runtime update surface. No frontend-lite consumer found. | Keep gated. |
+| Handler test | `datamachine/test-handler` | Admin/test surface. No frontend-lite consumer found. | Keep gated. |
+
+## Rule For Future Hoists
+
+Hoist an ability only when there is a concrete consumer that can call `wp_get_ability()` during a lite frontend page view or another request shape that does not satisfy `datamachine_should_load_full_runtime()`. REST, Ajax, admin, cron, CLI, pipeline, and Action Scheduler consumers are already covered by the full runtime gate.

--- a/inc/Abilities/Publish/SendEmailAbility.php
+++ b/inc/Abilities/Publish/SendEmailAbility.php
@@ -28,9 +28,9 @@ defined( 'ABSPATH' ) || exit;
 
 class SendEmailAbility {
 
-	private static bool $registered = false;
+	private static bool $registered           = false;
 	private static bool $registration_pending = false;
-	private static ?self $instance = null;
+	private static ?self $instance            = null;
 
 	public function __construct() {
 		if ( null === self::$instance ) {
@@ -78,7 +78,7 @@ class SendEmailAbility {
 						return;
 					}
 					$register_via_helper();
-					self::$registered            = true;
+					self::$registered           = true;
 					self::$registration_pending = false;
 				}
 			);

--- a/inc/Abilities/Publish/SendEmailAbility.php
+++ b/inc/Abilities/Publish/SendEmailAbility.php
@@ -29,120 +29,179 @@ defined( 'ABSPATH' ) || exit;
 class SendEmailAbility {
 
 	private static bool $registered = false;
+	private static bool $registration_pending = false;
+	private static ?self $instance = null;
 
 	public function __construct() {
-		if ( self::$registered ) {
+		if ( null === self::$instance ) {
+			self::$instance = $this;
+		}
+
+		self::ensure_registered();
+	}
+
+	/**
+	 * Ensure the send-email ability is registered across all registry timing states.
+	 *
+	 * @return void
+	 */
+	public static function ensure_registered(): void {
+		if ( self::$registered || self::$registration_pending ) {
 			return;
 		}
 
-		$this->registerAbilities();
-		self::$registered = true;
-	}
+		if ( null === self::$instance ) {
+			new self();
+			return;
+		}
 
-	private function registerAbilities(): void {
-		$register_callback = function () {
-			wp_register_ability(
-				'datamachine/send-email',
-				array(
-					'label'               => __( 'Send Email', 'data-machine' ),
-					'description'         => __( 'Send an email with optional attachments via wp_mail(). Body may be supplied directly or rendered from a template registered via the datamachine_email_templates filter. Optionally routes the wp_mail() call through a specific site via switch_to_blog() on multisite.', 'data-machine' ),
-					'category'            => 'datamachine-publishing',
-					'input_schema'        => array(
-						'type'       => 'object',
-						// `body` is no longer hard-required: callers may supply `template` instead.
-						// Validation is enforced in execute() so existing callers passing `body`
-						// continue to work unchanged.
-						'required'   => array( 'to', 'subject' ),
-						'properties' => array(
-							'to'           => array(
-								'type'        => 'string',
-								'description' => __( 'Comma-separated recipient email addresses', 'data-machine' ),
-							),
-							'cc'           => array(
-								'type'        => 'string',
-								'default'     => '',
-								'description' => __( 'Comma-separated CC addresses', 'data-machine' ),
-							),
-							'bcc'          => array(
-								'type'        => 'string',
-								'default'     => '',
-								'description' => __( 'Comma-separated BCC addresses', 'data-machine' ),
-							),
-							'subject'      => array(
-								'type'        => 'string',
-								'description' => __( 'Email subject line. Supports {month}, {year}, {site_name}, {date}, {admin_email} placeholders. Placeholders are resolved after template render.', 'data-machine' ),
-							),
-							'body'         => array(
-								'type'        => 'string',
-								'default'     => '',
-								'description' => __( 'Email body content (HTML or plain text). Ignored when `template` is supplied. Supports {month}, {year}, {site_name}, {date}, {admin_email} placeholders.', 'data-machine' ),
-							),
-							'template'     => array(
-								'type'        => 'string',
-								'default'     => '',
-								'description' => __( 'Optional template id resolved via the datamachine_email_templates filter. When set, the registered callable receives `context` and its return value is used as the body before placeholder replacement. When empty, `body` is used verbatim.', 'data-machine' ),
-							),
-							'context'      => array(
-								'type'        => 'object',
-								'default'     => array(),
-								'description' => __( 'Opaque context array passed to the template callable. Each template owns its own context contract.', 'data-machine' ),
-							),
-							'mail_site_id' => array(
-								'type'        => 'integer',
-								'default'     => 0,
-								'description' => __( 'Optional multisite blog id. When > 0 and multisite is active, the wp_mail() call is wrapped in switch_to_blog()/restore_current_blog() so site-scoped SMTP config applies. Validation, header building, and template rendering run in the original site context.', 'data-machine' ),
-							),
-							'content_type' => array(
-								'type'        => 'string',
-								'default'     => 'text/html',
-								'description' => __( 'Content type: text/html or text/plain', 'data-machine' ),
-							),
-							'from_name'    => array(
-								'type'        => 'string',
-								'default'     => '',
-								'description' => __( 'Sender name. Falls back to site name.', 'data-machine' ),
-							),
-							'from_email'   => array(
-								'type'        => 'string',
-								'default'     => '',
-								'description' => __( 'Sender email. Falls back to admin email.', 'data-machine' ),
-							),
-							'reply_to'     => array(
-								'type'        => 'string',
-								'default'     => '',
-								'description' => __( 'Reply-to email address', 'data-machine' ),
-							),
-							'attachments'  => array(
-								'type'        => 'array',
-								'items'       => array( 'type' => 'string' ),
-								'default'     => array(),
-								'description' => __( 'Array of server file paths to attach', 'data-machine' ),
-							),
-						),
-					),
-					'output_schema'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'success'    => array( 'type' => 'boolean' ),
-							'message'    => array( 'type' => 'string' ),
-							'recipients' => array( 'type' => 'array' ),
-							'subject'    => array( 'type' => 'string' ),
-							'error'      => array( 'type' => 'string' ),
-							'logs'       => array( 'type' => 'array' ),
-						),
-					),
-					'execute_callback'    => array( $this, 'execute' ),
-					'permission_callback' => array( $this, 'checkPermission' ),
-					'meta'                => array( 'show_in_rest' => true ),
-				)
-			);
+		$definitions = self::get_ability_definitions( self::$instance );
+
+		$register_via_helper = static function () use ( $definitions ): void {
+			foreach ( $definitions as $name => $args ) {
+				wp_register_ability( $name, $args );
+			}
 		};
 
 		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
+			$register_via_helper();
+			self::$registered = true;
+			return;
 		}
+
+		if ( ! did_action( 'wp_abilities_api_init' ) ) {
+			self::$registration_pending = true;
+			add_action(
+				'wp_abilities_api_init',
+				static function () use ( $register_via_helper ): void {
+					if ( self::$registered ) {
+						return;
+					}
+					$register_via_helper();
+					self::$registered            = true;
+					self::$registration_pending = false;
+				}
+			);
+			return;
+		}
+
+		if ( ! class_exists( '\WP_Abilities_Registry' ) ) {
+			return;
+		}
+		$registry = \WP_Abilities_Registry::get_instance();
+		if ( null === $registry ) {
+			return;
+		}
+		foreach ( $definitions as $name => $args ) {
+			if ( $registry->is_registered( $name ) ) {
+				continue;
+			}
+			$registry->register( $name, $args );
+		}
+		self::$registered = true;
+	}
+
+	/**
+	 * Ability definitions used by every registration path in ensure_registered().
+	 *
+	 * @param self $instance Instance used for execute and permission callbacks.
+	 * @return array<string, array<string, mixed>>
+	 */
+	private static function get_ability_definitions( self $instance ): array {
+		return array(
+			'datamachine/send-email' => array(
+				'label'               => __( 'Send Email', 'data-machine' ),
+				'description'         => __( 'Send an email with optional attachments via wp_mail(). Body may be supplied directly or rendered from a template registered via the datamachine_email_templates filter. Optionally routes the wp_mail() call through a specific site via switch_to_blog() on multisite.', 'data-machine' ),
+				'category'            => 'datamachine-publishing',
+				'input_schema'        => array(
+					'type'       => 'object',
+					// `body` is no longer hard-required: callers may supply `template` instead.
+					// Validation is enforced in execute() so existing callers passing `body`
+					// continue to work unchanged.
+					'required'   => array( 'to', 'subject' ),
+					'properties' => array(
+						'to'           => array(
+							'type'        => 'string',
+							'description' => __( 'Comma-separated recipient email addresses', 'data-machine' ),
+						),
+						'cc'           => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'Comma-separated CC addresses', 'data-machine' ),
+						),
+						'bcc'          => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'Comma-separated BCC addresses', 'data-machine' ),
+						),
+						'subject'      => array(
+							'type'        => 'string',
+							'description' => __( 'Email subject line. Supports {month}, {year}, {site_name}, {date}, {admin_email} placeholders. Placeholders are resolved after template render.', 'data-machine' ),
+						),
+						'body'         => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'Email body content (HTML or plain text). Ignored when `template` is supplied. Supports {month}, {year}, {site_name}, {date}, {admin_email} placeholders.', 'data-machine' ),
+						),
+						'template'     => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'Optional template id resolved via the datamachine_email_templates filter. When set, the registered callable receives `context` and its return value is used as the body before placeholder replacement. When empty, `body` is used verbatim.', 'data-machine' ),
+						),
+						'context'      => array(
+							'type'        => 'object',
+							'default'     => array(),
+							'description' => __( 'Opaque context array passed to the template callable. Each template owns its own context contract.', 'data-machine' ),
+						),
+						'mail_site_id' => array(
+							'type'        => 'integer',
+							'default'     => 0,
+							'description' => __( 'Optional multisite blog id. When > 0 and multisite is active, the wp_mail() call is wrapped in switch_to_blog()/restore_current_blog() so site-scoped SMTP config applies. Validation, header building, and template rendering run in the original site context.', 'data-machine' ),
+						),
+						'content_type' => array(
+							'type'        => 'string',
+							'default'     => 'text/html',
+							'description' => __( 'Content type: text/html or text/plain', 'data-machine' ),
+						),
+						'from_name'    => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'Sender name. Falls back to site name.', 'data-machine' ),
+						),
+						'from_email'   => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'Sender email. Falls back to admin email.', 'data-machine' ),
+						),
+						'reply_to'     => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'Reply-to email address', 'data-machine' ),
+						),
+						'attachments'  => array(
+							'type'        => 'array',
+							'items'       => array( 'type' => 'string' ),
+							'default'     => array(),
+							'description' => __( 'Array of server file paths to attach', 'data-machine' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'message'    => array( 'type' => 'string' ),
+						'recipients' => array( 'type' => 'array' ),
+						'subject'    => array( 'type' => 'string' ),
+						'error'      => array( 'type' => 'string' ),
+						'logs'       => array( 'type' => 'array' ),
+					),
+				),
+				'execute_callback'    => array( $instance, 'execute' ),
+				'permission_callback' => array( $instance, 'checkPermission' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			),
+		);
 	}
 
 	/**

--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -27,10 +27,10 @@ defined( 'ABSPATH' ) || exit;
 
 class SendEmailQueuedAbility {
 
-	private static bool $registered = false;
+	private static bool $registered           = false;
 	private static bool $registration_pending = false;
-	private static bool $worker_registered = false;
-	private static ?self $instance = null;
+	private static bool $worker_registered    = false;
+	private static ?self $instance            = null;
 
 	/**
 	 * Action Scheduler hook for the worker that performs the actual send.
@@ -99,7 +99,7 @@ class SendEmailQueuedAbility {
 						return;
 					}
 					$register_via_helper();
-					self::$registered            = true;
+					self::$registered           = true;
 					self::$registration_pending = false;
 				}
 			);

--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -28,6 +28,9 @@ defined( 'ABSPATH' ) || exit;
 class SendEmailQueuedAbility {
 
 	private static bool $registered = false;
+	private static bool $registration_pending = false;
+	private static bool $worker_registered = false;
+	private static ?self $instance = null;
 
 	/**
 	 * Action Scheduler hook for the worker that performs the actual send.
@@ -50,138 +53,192 @@ class SendEmailQueuedAbility {
 	private const RETRY_BACKOFF_SECONDS = 300;
 
 	public function __construct() {
-		if ( self::$registered ) {
-			return;
+		if ( null === self::$instance ) {
+			self::$instance = $this;
 		}
 
-		$this->registerAbility();
-		$this->registerWorker();
-		self::$registered = true;
+		self::ensure_registered();
+		self::ensure_worker_registered( self::$instance );
 	}
 
 	/**
 	 * Register the `datamachine/send-email-queued` ability.
+	 *
+	 * @return void
 	 */
-	private function registerAbility(): void {
-		$register_callback = function () {
-			wp_register_ability(
-				'datamachine/send-email-queued',
-				array(
-					'label'               => __( 'Send Email (Queued)', 'data-machine' ),
-					'description'         => __( 'Queue an email for delivery via Action Scheduler. Accepts the same payload as datamachine/send-email plus optional send_at and priority. Returns the scheduled action id.', 'data-machine' ),
-					'category'            => 'datamachine-publishing',
-					'input_schema'        => array(
-						'type'       => 'object',
-						// Mirror datamachine/send-email: `to` + `subject` are required at the
-						// schema level; `body`/`template` are validated by the worker when the
-						// underlying ability runs.
-						'required'   => array( 'to', 'subject' ),
-						'properties' => array(
-							'to'           => array(
-								'type'        => 'string',
-								'description' => __( 'Comma-separated recipient email addresses', 'data-machine' ),
-							),
-							'cc'           => array(
-								'type'        => 'string',
-								'default'     => '',
-								'description' => __( 'Comma-separated CC addresses', 'data-machine' ),
-							),
-							'bcc'          => array(
-								'type'        => 'string',
-								'default'     => '',
-								'description' => __( 'Comma-separated BCC addresses', 'data-machine' ),
-							),
-							'subject'      => array(
-								'type'        => 'string',
-								'description' => __( 'Email subject line. Supports placeholders.', 'data-machine' ),
-							),
-							'body'         => array(
-								'type'        => 'string',
-								'default'     => '',
-								'description' => __( 'Email body. Ignored when `template` is supplied.', 'data-machine' ),
-							),
-							'template'     => array(
-								'type'        => 'string',
-								'default'     => '',
-								'description' => __( 'Template id resolved via datamachine_email_templates at worker run time.', 'data-machine' ),
-							),
-							'context'      => array(
-								'type'        => 'object',
-								'default'     => array(),
-								'description' => __( 'Opaque context passed to the template callable.', 'data-machine' ),
-							),
-							'mail_site_id' => array(
-								'type'        => 'integer',
-								'default'     => 0,
-								'description' => __( 'Optional multisite blog id used to wrap wp_mail() in switch_to_blog().', 'data-machine' ),
-							),
-							'content_type' => array(
-								'type'        => 'string',
-								'default'     => 'text/html',
-								'description' => __( 'Content type: text/html or text/plain', 'data-machine' ),
-							),
-							'from_name'    => array(
-								'type'        => 'string',
-								'default'     => '',
-								'description' => __( 'Sender name. Falls back to site name.', 'data-machine' ),
-							),
-							'from_email'   => array(
-								'type'        => 'string',
-								'default'     => '',
-								'description' => __( 'Sender email. Falls back to admin email.', 'data-machine' ),
-							),
-							'reply_to'     => array(
-								'type'        => 'string',
-								'default'     => '',
-								'description' => __( 'Reply-to email address.', 'data-machine' ),
-							),
-							'attachments'  => array(
-								'type'        => 'array',
-								'items'       => array( 'type' => 'string' ),
-								'default'     => array(),
-								'description' => __( 'Array of server file paths to attach.', 'data-machine' ),
-							),
-							'send_at'      => array(
-								'type'        => 'string',
-								'default'     => '',
-								'description' => __( 'When to send. Accepts ISO 8601 string or unix timestamp (as string or int). Empty enqueues asynchronously.', 'data-machine' ),
-							),
-							'priority'     => array(
-								'type'        => 'integer',
-								'default'     => 10,
-								'description' => __( 'Reserved for future Action Scheduler priority/group hints; currently informational.', 'data-machine' ),
-							),
-						),
-					),
-					'output_schema'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'success'       => array( 'type' => 'boolean' ),
-							'action_id'     => array( 'type' => 'integer' ),
-							'scheduled_for' => array( 'type' => 'integer' ),
-							'error'         => array( 'type' => 'string' ),
-							'logs'          => array( 'type' => 'array' ),
-						),
-					),
-					'execute_callback'    => array( $this, 'execute' ),
-					'permission_callback' => array( $this, 'checkPermission' ),
-					'meta'                => array(
-						'show_in_rest' => true,
-						'annotations'  => array(
-							'readonly'    => false,
-							'destructive' => false,
-							'idempotent'  => false,
-						),
-					),
-				)
-			);
+	public static function ensure_registered(): void {
+		if ( self::$registered || self::$registration_pending ) {
+			return;
+		}
+
+		if ( null === self::$instance ) {
+			new self();
+			return;
+		}
+
+		$definitions = self::get_ability_definitions( self::$instance );
+
+		$register_via_helper = static function () use ( $definitions ): void {
+			foreach ( $definitions as $name => $args ) {
+				wp_register_ability( $name, $args );
+			}
 		};
 
 		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
+			$register_via_helper();
+			self::$registered = true;
+			return;
 		}
+
+		if ( ! did_action( 'wp_abilities_api_init' ) ) {
+			self::$registration_pending = true;
+			add_action(
+				'wp_abilities_api_init',
+				static function () use ( $register_via_helper ): void {
+					if ( self::$registered ) {
+						return;
+					}
+					$register_via_helper();
+					self::$registered            = true;
+					self::$registration_pending = false;
+				}
+			);
+			return;
+		}
+
+		if ( ! class_exists( '\WP_Abilities_Registry' ) ) {
+			return;
+		}
+		$registry = \WP_Abilities_Registry::get_instance();
+		if ( null === $registry ) {
+			return;
+		}
+		foreach ( $definitions as $name => $args ) {
+			if ( $registry->is_registered( $name ) ) {
+				continue;
+			}
+			$registry->register( $name, $args );
+		}
+		self::$registered = true;
+	}
+
+	/**
+	 * Ability definitions used by every registration path in ensure_registered().
+	 *
+	 * @param self $instance Instance used for execute and permission callbacks.
+	 * @return array<string, array<string, mixed>>
+	 */
+	private static function get_ability_definitions( self $instance ): array {
+		return array(
+			'datamachine/send-email-queued' => array(
+				'label'               => __( 'Send Email (Queued)', 'data-machine' ),
+				'description'         => __( 'Queue an email for delivery via Action Scheduler. Accepts the same payload as datamachine/send-email plus optional send_at and priority. Returns the scheduled action id.', 'data-machine' ),
+				'category'            => 'datamachine-publishing',
+				'input_schema'        => array(
+					'type'       => 'object',
+					// Mirror datamachine/send-email: `to` + `subject` are required at the
+					// schema level; `body`/`template` are validated by the worker when the
+					// underlying ability runs.
+					'required'   => array( 'to', 'subject' ),
+					'properties' => array(
+						'to'           => array(
+							'type'        => 'string',
+							'description' => __( 'Comma-separated recipient email addresses', 'data-machine' ),
+						),
+						'cc'           => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'Comma-separated CC addresses', 'data-machine' ),
+						),
+						'bcc'          => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'Comma-separated BCC addresses', 'data-machine' ),
+						),
+						'subject'      => array(
+							'type'        => 'string',
+							'description' => __( 'Email subject line. Supports placeholders.', 'data-machine' ),
+						),
+						'body'         => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'Email body. Ignored when `template` is supplied.', 'data-machine' ),
+						),
+						'template'     => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'Template id resolved via datamachine_email_templates at worker run time.', 'data-machine' ),
+						),
+						'context'      => array(
+							'type'        => 'object',
+							'default'     => array(),
+							'description' => __( 'Opaque context passed to the template callable.', 'data-machine' ),
+						),
+						'mail_site_id' => array(
+							'type'        => 'integer',
+							'default'     => 0,
+							'description' => __( 'Optional multisite blog id used to wrap wp_mail() in switch_to_blog().', 'data-machine' ),
+						),
+						'content_type' => array(
+							'type'        => 'string',
+							'default'     => 'text/html',
+							'description' => __( 'Content type: text/html or text/plain', 'data-machine' ),
+						),
+						'from_name'    => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'Sender name. Falls back to site name.', 'data-machine' ),
+						),
+						'from_email'   => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'Sender email. Falls back to admin email.', 'data-machine' ),
+						),
+						'reply_to'     => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'Reply-to email address.', 'data-machine' ),
+						),
+						'attachments'  => array(
+							'type'        => 'array',
+							'items'       => array( 'type' => 'string' ),
+							'default'     => array(),
+							'description' => __( 'Array of server file paths to attach.', 'data-machine' ),
+						),
+						'send_at'      => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'When to send. Accepts ISO 8601 string or unix timestamp (as string or int). Empty enqueues asynchronously.', 'data-machine' ),
+						),
+						'priority'     => array(
+							'type'        => 'integer',
+							'default'     => 10,
+							'description' => __( 'Reserved for future Action Scheduler priority/group hints; currently informational.', 'data-machine' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'       => array( 'type' => 'boolean' ),
+						'action_id'     => array( 'type' => 'integer' ),
+						'scheduled_for' => array( 'type' => 'integer' ),
+						'error'         => array( 'type' => 'string' ),
+						'logs'          => array( 'type' => 'array' ),
+					),
+				),
+				'execute_callback'    => array( $instance, 'execute' ),
+				'permission_callback' => array( $instance, 'checkPermission' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
 	}
 
 	/**
@@ -190,8 +247,13 @@ class SendEmailQueuedAbility {
 	 * Hooked on plugins_loaded so Action Scheduler can dispatch it even when
 	 * the originating HTTP request that scheduled the job is no longer alive.
 	 */
-	private function registerWorker(): void {
-		add_action( self::WORKER_HOOK, array( $this, 'runWorker' ), 10, 1 );
+	private static function ensure_worker_registered( self $instance ): void {
+		if ( self::$worker_registered ) {
+			return;
+		}
+
+		add_action( self::WORKER_HOOK, array( $instance, 'runWorker' ), 10, 1 );
+		self::$worker_registered = true;
 	}
 
 	/**
@@ -258,7 +320,7 @@ class SendEmailQueuedAbility {
 			$scheduled_for = $timestamp;
 		}
 
-		if ( empty( $action_id ) || ! is_numeric( $action_id ) ) {
+		if ( empty( $action_id ) ) {
 			$logs[] = array(
 				'level'   => 'error',
 				'message' => 'Email queue: Action Scheduler did not return an action id',
@@ -294,7 +356,7 @@ class SendEmailQueuedAbility {
 	 * Calls `datamachine/send-email` with the payload. On failure, re-enqueues
 	 * a retry with a 5-minute delay, up to MAX_ATTEMPTS total attempts.
 	 *
-	 * @param array $payload Send-email payload (includes `_attempt`).
+	 * @param mixed $payload Send-email payload (includes `_attempt`).
 	 * @return void
 	 */
 	public function runWorker( $payload ): void {

--- a/tests/abilities-send-email-load-order-smoke.php
+++ b/tests/abilities-send-email-load-order-smoke.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Regression smoke for #2303: email abilities must register on lite frontend
+ * requests where `datamachine_should_load_full_runtime()` returns false.
+ *
+ * Run with: php tests/abilities-send-email-load-order-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare( strict_types = 1 );
+
+$failed = 0;
+$total  = 0;
+
+$assert = static function ( string $name, bool $condition ) use ( &$failed, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$name}\n";
+		return;
+	}
+
+	echo "  FAIL: {$name}\n";
+	++$failed;
+};
+
+$plugin_root = dirname( __DIR__ );
+$bootstrap   = file_get_contents( $plugin_root . '/data-machine.php' );
+$send_source = file_get_contents( $plugin_root . '/inc/Abilities/Publish/SendEmailAbility.php' );
+$queue_source = file_get_contents( $plugin_root . '/inc/Abilities/Publish/SendEmailQueuedAbility.php' );
+
+if ( false === $bootstrap || false === $send_source || false === $queue_source ) {
+	fwrite( STDERR, "FAIL: unable to read plugin source\n" );
+	exit( 1 );
+}
+
+$assert(
+	'data-machine.php registers send-email abilities unconditionally at file load',
+	str_contains( $bootstrap, 'Register `datamachine/send-email` and `datamachine/send-email-queued`' )
+		&& str_contains( $bootstrap, "require_once __DIR__ . '/inc/Abilities/Publish/SendEmailAbility.php';\nrequire_once __DIR__ . '/inc/Abilities/Publish/SendEmailQueuedAbility.php';\n\\DataMachine\\Abilities\\Publish\\SendEmailAbility::ensure_registered();\n\\DataMachine\\Abilities\\Publish\\SendEmailQueuedAbility::ensure_registered();" )
+);
+
+$assert(
+	'unconditional call site is outside datamachine_run_datamachine_plugin()',
+	(bool) preg_match(
+		'/^\\\\DataMachine\\\\Abilities\\\\Media\\\\ImageTemplateAbilities::ensure_registered\(\);\s*\n\s*\n\/\*\*\s*\*\s*Register `datamachine\/send-email`/m',
+		$bootstrap
+	)
+);
+
+$assert(
+	'in-runtime send-email instantiation remains as defensive idempotent path',
+	str_contains( $bootstrap, "new \\DataMachine\\Abilities\\Publish\\SendEmailAbility();" )
+);
+
+$assert(
+	'in-runtime send-email-queued instantiation remains as defensive idempotent path',
+	str_contains( $bootstrap, "new \\DataMachine\\Abilities\\Publish\\SendEmailQueuedAbility();" )
+);
+
+foreach ( array( 'send-email' => $send_source, 'send-email-queued' => $queue_source ) as $label => $source ) {
+	$assert(
+		"{$label}: ensure_registered() handles doing_action state",
+		str_contains( $source, "doing_action( 'wp_abilities_api_init' )" )
+	);
+	$assert(
+		"{$label}: ensure_registered() handles pre-action state",
+		str_contains( $source, "! did_action( 'wp_abilities_api_init' )" )
+			&& str_contains( $source, "add_action(\n\t\t\t\t'wp_abilities_api_init'" )
+	);
+	$assert(
+		"{$label}: ensure_registered() handles post-action state via registry instance",
+		str_contains( $source, '\\WP_Abilities_Registry::get_instance()' )
+			&& str_contains( $source, '$registry->register( $name, $args )' )
+	);
+	$assert(
+		"{$label}: recovery path skips already-registered abilities",
+		str_contains( $source, '$registry->is_registered( $name )' )
+	);
+	$assert(
+		"{$label}: definitions are shared across timing branches",
+		str_contains( $source, 'private static function get_ability_definitions' )
+	);
+}
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', '/tmp/' );
+}
+
+$GLOBALS['datamachine_2303_state'] = (object) array(
+	'doing'          => false,
+	'did'            => 0,
+	'hooked'         => array(),
+	'registered'     => array(),
+	'doing_it_wrong' => 0,
+);
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = null ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook ) {
+		global $datamachine_2303_state;
+		return $datamachine_2303_state->doing && 'wp_abilities_api_init' === $hook;
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook ) {
+		global $datamachine_2303_state;
+		return 'wp_abilities_api_init' === $hook ? $datamachine_2303_state->did : 0;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		global $datamachine_2303_state;
+		$datamachine_2303_state->hooked[ $hook ][] = $callback;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( $name, $args ) {
+		global $datamachine_2303_state;
+		if ( ! doing_action( 'wp_abilities_api_init' ) ) {
+			++$datamachine_2303_state->doing_it_wrong;
+			return null;
+		}
+		$datamachine_2303_state->registered[ $name ] = $args;
+		return true;
+	}
+}
+
+if ( ! class_exists( 'WP_Abilities_Registry' ) ) {
+	class WP_Abilities_Registry {
+		/** @var array<string, array<string, mixed>> */
+		public array $registered = array();
+		private static ?self $instance = null;
+
+		public static function get_instance(): ?self {
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+			}
+			return self::$instance;
+		}
+
+		public static function reset(): void {
+			self::$instance = null;
+		}
+
+		public function is_registered( string $name ): bool {
+			return isset( $this->registered[ $name ] );
+		}
+
+		public function register( string $name, array $args ): bool {
+			$this->registered[ $name ] = $args;
+			return true;
+		}
+	}
+}
+
+if ( ! class_exists( 'DataMachine\\Abilities\\PermissionHelper' ) ) {
+	eval(
+		'namespace DataMachine\\Abilities;
+		class PermissionHelper {
+			public static function can_manage(): bool { return true; }
+		}'
+	);
+}
+
+require_once $plugin_root . '/inc/Abilities/Publish/SendEmailAbility.php';
+require_once $plugin_root . '/inc/Abilities/Publish/SendEmailQueuedAbility.php';
+
+$reset_class = static function ( string $class ): void {
+	$reflection = new ReflectionClass( $class );
+	foreach ( array( 'registered', 'registration_pending', 'worker_registered' ) as $property ) {
+		if ( ! $reflection->hasProperty( $property ) ) {
+			continue;
+		}
+		$prop = $reflection->getProperty( $property );
+		$prop->setValue( null, false );
+	}
+	if ( $reflection->hasProperty( 'instance' ) ) {
+		$prop = $reflection->getProperty( 'instance' );
+		$prop->setValue( null, null );
+	}
+};
+
+$reset = static function () use ( $reset_class ): void {
+	global $datamachine_2303_state;
+	$datamachine_2303_state->doing          = false;
+	$datamachine_2303_state->did            = 0;
+	$datamachine_2303_state->hooked         = array();
+	$datamachine_2303_state->registered     = array();
+	$datamachine_2303_state->doing_it_wrong = 0;
+
+	$reset_class( \DataMachine\Abilities\Publish\SendEmailAbility::class );
+	$reset_class( \DataMachine\Abilities\Publish\SendEmailQueuedAbility::class );
+	WP_Abilities_Registry::reset();
+};
+
+$reset();
+$GLOBALS['datamachine_2303_state']->doing = true;
+\DataMachine\Abilities\Publish\SendEmailAbility::ensure_registered();
+\DataMachine\Abilities\Publish\SendEmailQueuedAbility::ensure_registered();
+$assert(
+	'state 1: doing_action registers both email abilities immediately',
+	isset( $GLOBALS['datamachine_2303_state']->registered['datamachine/send-email'] )
+		&& isset( $GLOBALS['datamachine_2303_state']->registered['datamachine/send-email-queued'] )
+);
+
+$reset();
+\DataMachine\Abilities\Publish\SendEmailAbility::ensure_registered();
+\DataMachine\Abilities\Publish\SendEmailQueuedAbility::ensure_registered();
+$assert(
+	'state 2: pre-action hooks both ability registration callbacks',
+	isset( $GLOBALS['datamachine_2303_state']->hooked['wp_abilities_api_init'] )
+		&& 2 === count( $GLOBALS['datamachine_2303_state']->hooked['wp_abilities_api_init'] )
+		&& empty( $GLOBALS['datamachine_2303_state']->registered )
+);
+
+$reset();
+$GLOBALS['datamachine_2303_state']->did = 1;
+\DataMachine\Abilities\Publish\SendEmailAbility::ensure_registered();
+\DataMachine\Abilities\Publish\SendEmailQueuedAbility::ensure_registered();
+$registry = WP_Abilities_Registry::get_instance();
+$assert(
+	'state 3: post-action registers both email abilities directly via registry instance',
+	$registry instanceof WP_Abilities_Registry
+		&& $registry->is_registered( 'datamachine/send-email' )
+		&& $registry->is_registered( 'datamachine/send-email-queued' )
+);
+
+$assert(
+	'state 3: recovery path avoids wp_register_ability() doing-it-wrong notices',
+	0 === $GLOBALS['datamachine_2303_state']->doing_it_wrong
+);
+
+$prior_registered = $registry->registered;
+\DataMachine\Abilities\Publish\SendEmailAbility::ensure_registered();
+\DataMachine\Abilities\Publish\SendEmailQueuedAbility::ensure_registered();
+$assert(
+	'idempotent: repeated ensure_registered() calls are no-ops after success',
+	$registry->registered === $prior_registered
+		&& 0 === $GLOBALS['datamachine_2303_state']->doing_it_wrong
+);
+
+$reset();
+$GLOBALS['datamachine_2303_state']->doing = true;
+new \DataMachine\Abilities\Publish\SendEmailAbility();
+new \DataMachine\Abilities\Publish\SendEmailQueuedAbility();
+$assert(
+	'constructor path: instantiating both classes triggers registration',
+	isset( $GLOBALS['datamachine_2303_state']->registered['datamachine/send-email'] )
+		&& isset( $GLOBALS['datamachine_2303_state']->registered['datamachine/send-email-queued'] )
+);
+
+if ( $failed > 0 ) {
+	fwrite( STDERR, "\nabilities-send-email-load-order-smoke: {$failed}/{$total} assertions failed\n" );
+	exit( 1 );
+}
+
+echo "\nAll {$total} abilities-send-email-load-order assertions passed.\n";


### PR DESCRIPTION
## Summary
- Hoists `datamachine/send-email` and `datamachine/send-email-queued` registration out of the full-runtime gate using the same defensive timing pattern as prior hoists.
- Adds a #2303 runtime-gated abilities disposition table documenting which gated abilities stay gated and why.
- Adds a 20-assertion regression smoke for the email ability load-order states.

## Testing
- `php tests/abilities-send-email-load-order-smoke.php`
- `php tests/send-email-template-smoke.php`
- `php -l inc/Abilities/Publish/SendEmailAbility.php && php -l inc/Abilities/Publish/SendEmailQueuedAbility.php && php -l tests/abilities-send-email-load-order-smoke.php && php -l data-machine.php`
- `homeboy lint data-machine --file data-machine.php --errors-only`
- `homeboy lint data-machine --file inc/Abilities/Publish/SendEmailAbility.php --errors-only`
- `homeboy lint data-machine --file inc/Abilities/Publish/SendEmailQueuedAbility.php --errors-only`
- `homeboy lint data-machine --file tests/abilities-send-email-load-order-smoke.php --errors-only`

## Caveat
- `homeboy test data-machine` failed before running tests in the lab offload workspace because `/wordpress/wp-content/plugins/data-machine/vendor/autoload.php` was missing from the mounted lab checkout. Targeted local smokes and per-file Homeboy lint passed.

Closes #2303.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Auditing the gated ability registration surface, drafting the runtime-gated disposition table, implementing the email ability hoist and regression smoke, and running verification. Chris remains responsible for review and merge.