### PR TITLE
Emit transcript and tool trace artifact files

### DIFF
--- a/inc/Core/Database/Chat/ConversationSessionIndexInterface.php
+++ b/inc/Core/Database/Chat/ConversationSessionIndexInterface.php
@@ -17,6 +17,14 @@ defined( 'ABSPATH' ) || exit;
 interface ConversationSessionIndexInterface {
 
 	/**
+	 * Fetch a full conversation session by ID.
+	 *
+	 * @param string $session_id Conversation session ID.
+	 * @return array<string, mixed>|null Session payload, or null when missing.
+	 */
+	public function get_session( string $session_id ): ?array;
+
+	/**
 	 * List sessions for a user with pagination and optional filtering.
 	 *
 	 * Returned entries are summary rows intended for the session switcher

--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -69,6 +69,7 @@ class JobArtifacts {
 			'tool_trace'             => $this->tool_trace( $engine_data, $additional_tool_summaries ),
 			'transcript'             => $this->transcript_metadata( $job_id, $engine_data ),
 			'artifact_refs'          => $this->hashable_artifact_refs( $transcript_artifact, $tool_trace_artifact ),
+			'artifact_files'         => $this->artifact_files_metadata( $engine_data ),
 			'transcript_artifact'    => $transcript_artifact,
 			'tool_trace_artifact'    => $tool_trace_artifact,
 			'agent_memory_artifacts' => $this->agent_memory_artifacts( $job, $agent, $tool_calls ),
@@ -78,6 +79,51 @@ class JobArtifacts {
 		return array(
 			'success'   => true,
 			'artifacts' => $payload,
+		);
+	}
+
+	/**
+	 * Write first-class transcript and tool trace artifact files for a job.
+	 *
+	 * @param int   $job_id                    Job ID.
+	 * @param array $additional_tool_summaries Tool summaries accumulated before engine_data persistence.
+	 * @return array{success: bool, artifact_files?: array<string,array<string,mixed>>, error?: string}
+	 */
+	public function write_artifact_files( int $job_id, array $additional_tool_summaries = array() ): array {
+		$result = $this->get( $job_id, $additional_tool_summaries );
+		if ( empty( $result['success'] ) || ! is_array( $result['artifacts'] ?? null ) ) {
+			return array(
+				'success' => false,
+				'error'   => (string) ( $result['error'] ?? 'Failed to build job artifacts.' ),
+			);
+		}
+
+		$payload        = $result['artifacts'];
+		$artifact_files = array();
+		foreach (
+			array(
+				'transcript' => $payload['transcript_artifact'] ?? null,
+				'tool_trace' => $payload['tool_trace_artifact'] ?? null,
+			) as $artifact_key => $artifact_payload
+		) {
+			if ( ! is_array( $artifact_payload ) ) {
+				continue;
+			}
+
+			$write_result = $this->write_artifact_file( $job_id, $artifact_key, $artifact_payload );
+			if ( empty( $write_result['success'] ) || ! is_array( $write_result['file'] ?? null ) ) {
+				return array(
+					'success' => false,
+					'error'   => (string) ( $write_result['error'] ?? 'Failed to write artifact file.' ),
+				);
+			}
+
+			$artifact_files[ $artifact_key ] = $write_result['file'];
+		}
+
+		return array(
+			'success'        => true,
+			'artifact_files' => $artifact_files,
 		);
 	}
 
@@ -190,6 +236,36 @@ class JobArtifacts {
 	}
 
 	/**
+	 * @return array<string,array<string,mixed>>
+	 */
+	private function artifact_files_metadata( array $engine_data ): array {
+		$artifact_files = is_array( $engine_data['artifact_files'] ?? null ) ? $engine_data['artifact_files'] : array();
+		$out            = array();
+
+		foreach ( array( 'transcript', 'tool_trace' ) as $key ) {
+			if ( ! is_array( $artifact_files[ $key ] ?? null ) ) {
+				continue;
+			}
+
+			$out[ $key ] = $this->filter_empty(
+				array(
+					'artifact_type'  => isset( $artifact_files[ $key ]['artifact_type'] ) ? sanitize_key( (string) $artifact_files[ $key ]['artifact_type'] ) : null,
+					'artifact_ref'   => isset( $artifact_files[ $key ]['artifact_ref'] ) ? sanitize_text_field( (string) $artifact_files[ $key ]['artifact_ref'] ) : null,
+					'relative_path'  => isset( $artifact_files[ $key ]['relative_path'] ) ? sanitize_text_field( (string) $artifact_files[ $key ]['relative_path'] ) : null,
+					'path'           => isset( $artifact_files[ $key ]['path'] ) ? (string) $artifact_files[ $key ]['path'] : null,
+					'url'            => isset( $artifact_files[ $key ]['url'] ) ? esc_url_raw( (string) $artifact_files[ $key ]['url'] ) : null,
+					'sha256'         => isset( $artifact_files[ $key ]['sha256'] ) ? sanitize_text_field( (string) $artifact_files[ $key ]['sha256'] ) : null,
+					'payload_sha256' => isset( $artifact_files[ $key ]['payload_sha256'] ) ? sanitize_text_field( (string) $artifact_files[ $key ]['payload_sha256'] ) : null,
+					'bytes'          => isset( $artifact_files[ $key ]['bytes'] ) ? (int) $artifact_files[ $key ]['bytes'] : null,
+					'written_at'     => isset( $artifact_files[ $key ]['written_at'] ) ? sanitize_text_field( (string) $artifact_files[ $key ]['written_at'] ) : null,
+				)
+			);
+		}
+
+		return $out;
+	}
+
+	/**
 	 * @return array<string,mixed>|null
 	 */
 	private function transcript_artifact( int $job_id, array $job, array $agent, array $engine_data ): ?array {
@@ -265,9 +341,7 @@ class JobArtifacts {
 
 		$entries = array();
 		foreach ( array_slice( $trace, 0, self::MAX_TOOL_TRACE_ENTRIES ) as $index => $entry ) {
-			if ( is_array( $entry ) ) {
-				$entries[] = $this->normalize_tool_trace_entry( $entry, $index );
-			}
+			$entries[] = $this->normalize_tool_trace_entry( $entry, $index );
 		}
 
 		$payload = array(
@@ -401,6 +475,66 @@ class JobArtifacts {
 		}
 
 		return $ref;
+	}
+
+	/**
+	 * @return array{success: bool, file?: array<string,mixed>, error?: string}
+	 */
+	private function write_artifact_file( int $job_id, string $artifact_key, array $artifact_payload ): array {
+		$upload_dir = wp_upload_dir();
+		$base_root  = (string) $upload_dir['basedir'];
+		$base_url   = (string) $upload_dir['baseurl'];
+		if ( '' === trim( $base_root ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Upload directory is unavailable.',
+			);
+		}
+		$base_dir = trailingslashit( $base_root ) . 'datamachine-artifacts/jobs/' . $job_id;
+		$base_url = '' !== $base_url ? trailingslashit( $base_url ) . 'datamachine-artifacts/jobs/' . $job_id : '';
+
+		if ( ! wp_mkdir_p( $base_dir ) ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Failed to create artifact directory for job %d.', $job_id ),
+			);
+		}
+
+		$file_name = sanitize_file_name( str_replace( '_', '-', $artifact_key ) . '.json' );
+		$file_path = trailingslashit( $base_dir ) . $file_name;
+		$json      = wp_json_encode( $this->canonicalize( $artifact_payload ), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+		if ( ! is_string( $json ) ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Failed to encode %s artifact for job %d.', $artifact_key, $job_id ),
+			);
+		}
+
+		$json .= "\n";
+		if ( false === file_put_contents( $file_path, $json ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Failed to write %s artifact for job %d.', $artifact_key, $job_id ),
+			);
+		}
+
+		$relative_path = 'datamachine-artifacts/jobs/' . $job_id . '/' . $file_name;
+		return array(
+			'success' => true,
+			'file'    => $this->filter_empty(
+				array(
+					'artifact_type'  => (string) ( $artifact_payload['artifact_type'] ?? $artifact_key ),
+					'artifact_ref'   => (string) ( $artifact_payload['artifact_ref'] ?? $this->artifact_ref( $job_id, $artifact_key ) ),
+					'relative_path'  => $relative_path,
+					'path'           => $file_path,
+					'url'            => '' !== $base_url ? trailingslashit( $base_url ) . $file_name : null,
+					'sha256'         => hash( 'sha256', $json ),
+					'payload_sha256' => (string) ( $artifact_payload['sha256'] ?? '' ),
+					'bytes'          => strlen( $json ),
+					'written_at'     => gmdate( 'c' ),
+				)
+			),
+		);
 	}
 
 	/** @return array<string,mixed> */
@@ -719,7 +853,8 @@ class JobArtifacts {
 
 			$date = (string) ( $tool_call['date'] ?? '' );
 			if ( '' === $date ) {
-				$date = gmdate( 'Y-m-d', strtotime( (string) ( $job['completed_at'] ?? $job['created_at'] ?? 'now' ) ) );
+				$timestamp = strtotime( (string) ( $job['completed_at'] ?? $job['created_at'] ?? 'now' ) );
+				$date      = gmdate( 'Y-m-d', false === $timestamp ? null : $timestamp );
 			}
 
 			if ( preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ) {
@@ -738,7 +873,7 @@ class JobArtifacts {
 			list( $year, $month, $day ) = explode( '-', $date );
 			$daily_memory               = new DailyMemory( (int) $memory_scope['user_id'], (int) $memory_scope['agent_id'] );
 			$read                       = $daily_memory->read( $year, $month, $day );
-			$content                    = empty( $read['success'] ) ? $this->daily_memory_fallback_content( $date, (string) ( $memory_scope['content'] ?? '' ) ) : (string) ( $read['content'] ?? '' );
+			$content                    = empty( $read['success'] ) ? $this->daily_memory_fallback_content( $date, (string) $memory_scope['content'] ) : (string) ( $read['content'] ?? '' );
 			if ( '' === $content ) {
 				continue;
 			}

--- a/inc/Engine/Filters/EngineData.php
+++ b/inc/Engine/Filters/EngineData.php
@@ -30,7 +30,12 @@ function datamachine_get_engine_data( int $job_id ): array {
  * @return bool True on success.
  */
 function datamachine_set_engine_data( int $job_id, array $snapshot ): bool {
-	return \DataMachine\Core\EngineData::persist( $job_id, $snapshot );
+	$persisted = \DataMachine\Core\EngineData::persist( $job_id, $snapshot );
+	if ( $persisted && datamachine_engine_data_should_write_artifact_files( $snapshot ) ) {
+		datamachine_write_engine_data_artifact_files( $job_id );
+	}
+
+	return $persisted;
 }
 
 /**
@@ -42,4 +47,44 @@ function datamachine_set_engine_data( int $job_id, array $snapshot ): bool {
  */
 function datamachine_merge_engine_data( int $job_id, array $data ): bool {
 	return \DataMachine\Core\EngineData::merge( $job_id, $data );
+}
+
+/**
+ * Determine whether an engine data snapshot has enough runtime artifact data to
+ * emit first-class transcript/tool-trace files.
+ *
+ * @param array $snapshot Engine data snapshot.
+ * @return bool Whether artifact files should be written.
+ */
+function datamachine_engine_data_should_write_artifact_files( array $snapshot ): bool {
+	return ! empty( $snapshot['transcript_session_id'] ) || ! empty( $snapshot['tool_execution_summary'] );
+}
+
+/**
+ * Write first-class runtime artifact files and store their refs in engine data.
+ *
+ * @param int $job_id Job ID.
+ * @return void
+ */
+function datamachine_write_engine_data_artifact_files( int $job_id ): void {
+	$artifact_file_result = ( new \DataMachine\Core\JobArtifacts() )->write_artifact_files( $job_id );
+	if ( ! empty( $artifact_file_result['success'] ) && is_array( $artifact_file_result['artifact_files'] ?? null ) && ! empty( $artifact_file_result['artifact_files'] ) ) {
+		\DataMachine\Core\EngineData::merge(
+			$job_id,
+			array( 'artifact_files' => $artifact_file_result['artifact_files'] )
+		);
+		return;
+	}
+
+	if ( empty( $artifact_file_result['success'] ) ) {
+		do_action(
+			'datamachine_log',
+			'warning',
+			'EngineData: Failed to write first-class job artifact files.',
+			array(
+				'job_id' => $job_id,
+				'error'  => (string) ( $artifact_file_result['error'] ?? 'unknown_error' ),
+			)
+		);
+	}
 }

--- a/tests/job-artifact-hashable-smoke.php
+++ b/tests/job-artifact-hashable-smoke.php
@@ -35,6 +35,40 @@ if ( ! function_exists( 'sanitize_title' ) ) {
 	}
 }
 
+if ( ! function_exists( 'sanitize_file_name' ) ) {
+	function sanitize_file_name( $value ): string {
+		return trim( preg_replace( '/[^A-Za-z0-9_.-]+/', '-', (string) $value ), '-' );
+	}
+}
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $value ): string {
+		return (string) $value;
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( $value ): string {
+		return rtrim( (string) $value, '/\\' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'wp_mkdir_p' ) ) {
+	function wp_mkdir_p( $target ): bool {
+		return is_dir( $target ) || mkdir( $target, 0775, true );
+	}
+}
+
+if ( ! function_exists( 'wp_upload_dir' ) ) {
+	function wp_upload_dir(): array {
+		$base = sys_get_temp_dir() . '/datamachine-job-artifact-smoke';
+		return array(
+			'basedir' => $base,
+			'baseurl' => 'https://example.test/uploads',
+		);
+	}
+}
+
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 	function wp_strip_all_tags( $value ): string {
 		return strip_tags( (string) $value );
@@ -97,6 +131,23 @@ $assert_true( '[redacted]' === $message['tool_calls'][0]['arguments_redacted']['
 $assert_true( false === str_contains( $message_json, 'sk-secret' ), 'transcript content redacts bearer secrets' );
 $assert_true( false === str_contains( $message_json, 'plain-secret' ), 'transcript content redacts token assignments' );
 $assert_true( false === str_contains( $message_json, 'metadata-secret' ), 'transcript metadata redacts secret keys' );
+
+$transcript_artifact = $invoke(
+	$artifacts,
+	'with_payload_hash',
+	array(
+		array(
+			'schema_version'   => 1,
+			'artifact_type'    => 'transcript',
+			'artifact_ref'     => 'datamachine://jobs/123/artifacts/transcript/session-abc',
+			'message_count'    => 1,
+			'messages_emitted' => 1,
+			'entries'          => array( $message ),
+			'bounded'          => true,
+			'redacted'         => true,
+		)
+	)
+);
 
 $normal_trace = array(
 	'schema_version'     => 1,
@@ -185,6 +236,35 @@ $assert_true( false === str_contains( $artifact_json, 'runtime-secret' ), 'tool 
 $refs = $invoke( $artifacts, 'hashable_artifact_refs', array( null, $tool_trace_artifact ) );
 $assert_true( $tool_trace_artifact['sha256'] === $refs['tool_trace']['sha256'], 'artifact refs expose tool trace hash' );
 $assert_true( $tool_trace_artifact['artifact_ref'] === $refs['tool_trace']['artifact_ref'], 'artifact refs expose stable tool trace ref' );
+
+$file_result = $invoke( $artifacts, 'write_artifact_file', array( 123, 'tool_trace', $tool_trace_artifact ) );
+$assert_true( true === ( $file_result['success'] ?? false ), 'tool trace artifact file write succeeds' );
+$assert_true( is_file( $file_result['file']['path'] ?? '' ), 'tool trace artifact file exists on disk' );
+$assert_true( 'datamachine-artifacts/jobs/123/tool-trace.json' === ( $file_result['file']['relative_path'] ?? '' ), 'artifact file has stable relative path' );
+$assert_true( $tool_trace_artifact['sha256'] === ( $file_result['file']['payload_sha256'] ?? '' ), 'artifact file references payload hash' );
+$assert_true( hash_file( 'sha256', $file_result['file']['path'] ) === ( $file_result['file']['sha256'] ?? '' ), 'artifact file hash matches written bytes' );
+
+$transcript_file_result = $invoke( $artifacts, 'write_artifact_file', array( 123, 'transcript', $transcript_artifact ) );
+$assert_true( true === ( $transcript_file_result['success'] ?? false ), 'transcript artifact file write succeeds' );
+$assert_true( is_file( $transcript_file_result['file']['path'] ?? '' ), 'transcript artifact file exists on disk' );
+$assert_true( 'datamachine-artifacts/jobs/123/transcript.json' === ( $transcript_file_result['file']['relative_path'] ?? '' ), 'transcript artifact file has stable relative path' );
+$assert_true( $transcript_artifact['sha256'] === ( $transcript_file_result['file']['payload_sha256'] ?? '' ), 'transcript artifact file references payload hash' );
+
+$artifact_files = $invoke(
+	$artifacts,
+	'artifact_files_metadata',
+	array(
+		array(
+			'artifact_files' => array(
+				'transcript' => $transcript_file_result['file'],
+				'tool_trace' => $file_result['file'],
+			),
+		)
+	)
+);
+$assert_true( $transcript_file_result['file']['relative_path'] === ( $artifact_files['transcript']['relative_path'] ?? '' ), 'engine artifact file metadata round-trips transcript relative path' );
+$assert_true( $file_result['file']['relative_path'] === ( $artifact_files['tool_trace']['relative_path'] ?? '' ), 'engine artifact file metadata round-trips relative path' );
+$assert_true( $file_result['file']['sha256'] === ( $artifact_files['tool_trace']['sha256'] ?? '' ), 'engine artifact file metadata round-trips file hash' );
 
 if ( $failures ) {
 	echo "FAILED: " . count( $failures ) . " hashable artifact assertions failed.\n";

--- a/tests/job-artifacts-daily-memory-smoke.php
+++ b/tests/job-artifacts-daily-memory-smoke.php
@@ -13,6 +13,7 @@ $root          = dirname( __DIR__ );
 $job_artifacts = file_get_contents( $root . '/inc/Core/JobArtifacts.php' );
 $jobs_cli      = file_get_contents( $root . '/inc/Cli/Commands/JobsCommand.php' );
 $ai_step       = file_get_contents( $root . '/inc/Core/Steps/AI/AIStep.php' );
+$engine_data   = file_get_contents( $root . '/inc/Engine/Filters/EngineData.php' );
 $loop          = file_get_contents( $root . '/inc/Engine/AI/conversation-loop.php' );
 
 $failures = array();
@@ -37,6 +38,13 @@ $assert(
 	false !== strpos( $ai_step, "'tool_execution_summary'" )
 		&& false !== strpos( $ai_step, 'summarizeToolExecutions' ),
 	'AI step persists sanitized tool execution summaries into engine_data'
+);
+
+$assert(
+	false !== strpos( $engine_data, 'write_artifact_files' )
+		&& false !== strpos( $engine_data, "'artifact_files' =>" )
+		&& false !== strpos( $job_artifacts, 'datamachine-artifacts/jobs/' ),
+	'engine data persistence writes first-class transcript/tool-trace artifact files and stores refs in engine_data'
 );
 
 $assert(


### PR DESCRIPTION
## Summary
- Writes first-class transcript and tool-trace JSON files under the uploads-based Data Machine artifact directory when engine data has transcript or tool execution evidence.
- Stores artifact file refs, paths, byte hashes, payload hashes, sizes, and timestamps in job engine data.
- Keeps the artifact schema generic and redacted, with smoke coverage proving transcript/tool-trace file writes and hash round-trips.

Fixes #2331.

## Checks
- `php tests/job-artifact-hashable-smoke.php`
- `php tests/job-artifacts-daily-memory-smoke.php`
- `php tests/tool-trace-metadata-smoke.php`
- `php tests/transcript-policy-smoke.php`
- `./vendor/bin/phpcs inc/Core/JobArtifacts.php inc/Engine/Filters/EngineData.php inc/Core/Database/Chat/ConversationSessionIndexInterface.php tests/job-artifact-hashable-smoke.php tests/job-artifacts-daily-memory-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-transcript-tool-trace-artifacts --extension wordpress --file inc/Core/JobArtifacts.php --summary`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-transcript-tool-trace-artifacts --extension wordpress --file inc/Engine/Filters/EngineData.php --summary`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-transcript-tool-trace-artifacts --extension wordpress --file inc/Core/Database/Chat/ConversationSessionIndexInterface.php --summary`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-transcript-tool-trace-artifacts --extension wordpress --file tests/job-artifact-hashable-smoke.php --summary`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-transcript-tool-trace-artifacts --extension wordpress --file tests/job-artifacts-daily-memory-smoke.php --summary`

## Blockers / caveats
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-transcript-tool-trace-artifacts --extension wordpress --skip-lint` did not execute tests: the lab WP Codebox bootstrap failed before PHPUnit because `/wordpress/wp-content/plugins/data-machine/vendor/autoload.php` was missing in the mounted lab workspace.
- Full unscoped `homeboy lint` still reports existing repository-wide PHPStan findings unrelated to this change; file-scoped Homeboy lint for changed production/test files passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and smoke-test updates; Chris remains responsible for review and validation.