### PR TITLE
Fix array values in flow settings summaries

### DIFF
--- a/inc/Core/Admin/FlowFormatter.php
+++ b/inc/Core/Admin/FlowFormatter.php
@@ -86,7 +86,7 @@ class FlowFormatter {
 			if ( ! empty( $step_data['settings_display'] ) && is_array( $step_data['settings_display'] ) ) {
 				$display_parts                 = array_map(
 					function ( $setting ) {
-						return sprintf( '%s: %s', $setting['label'], $setting['display_value'] );
+						return sprintf( '%s: %s', $setting['label'], self::format_display_summary_value( $setting['display_value'] ?? '' ) );
 					},
 					$step_data['settings_display']
 				);
@@ -131,6 +131,20 @@ class FlowFormatter {
 			'next_run'            => $next_run,
 			'next_run_display'    => DateFormatter::format_for_display( $next_run ),
 		);
+	}
+
+	/**
+	 * Format a settings display value for a compact text summary.
+	 *
+	 * @param mixed $value Display value.
+	 */
+	private static function format_display_summary_value( $value ): string {
+		if ( is_scalar( $value ) || null === $value ) {
+			return (string) $value;
+		}
+
+		$encoded = wp_json_encode( $value );
+		return is_string( $encoded ) ? $encoded : '';
 	}
 
 	/**

--- a/tests/flow-formatter-loaded-settings-display-smoke.php
+++ b/tests/flow-formatter-loaded-settings-display-smoke.php
@@ -69,6 +69,12 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $value ) {
+			return json_encode( $value );
+		}
+	}
+
 	if ( ! function_exists( 'wp_date' ) ) {
 		function wp_date( string $format, int $timestamp, ?\DateTimeZone $timezone = null ): string {
 			$date = new \DateTimeImmutable( '@' . $timestamp );
@@ -97,6 +103,10 @@ namespace {
 					'label' => 'Flag',
 					'type'  => 'checkbox',
 				),
+				'params' => array(
+					'label' => 'Parameters',
+					'type'  => 'json',
+				),
 			);
 		}
 	}
@@ -120,6 +130,7 @@ namespace {
 					'alpha' => array(
 						'choice' => 'b',
 						'flag'   => true,
+						'params' => array( 'query' => 'WooCommerce Fieldguide P2' ),
 					),
 				),
 			),
@@ -137,8 +148,9 @@ namespace {
 	$formatted = \DataMachine\Core\Admin\FlowFormatter::format_flow_for_response( $flow, null, array( 123 => null ) );
 	$config    = $formatted['flow_config'];
 
-	flow_formatter_loaded_config_expect( 'Choice: Bee | Flag: True' === $config['fetch_123']['settings_summary'], 'Single-handler settings summary should match loaded config.' );
+	flow_formatter_loaded_config_expect( 'Choice: Bee | Flag: True | Parameters: {"query":"WooCommerce Fieldguide P2"}' === $config['fetch_123']['settings_summary'], 'Single-handler settings summary should match loaded config.' );
 	flow_formatter_loaded_config_expect( 'Bee' === $config['fetch_123']['settings_display'][0]['display_value'], 'Single-handler settings display should use option labels.' );
+	flow_formatter_loaded_config_expect( is_array( $config['fetch_123']['settings_display'][2]['display_value'] ), 'Single-handler settings display should preserve array values.' );
 	flow_formatter_loaded_config_expect( 'Aye' === $config['publish_123']['handler_settings_displays']['alpha'][0]['display_value'], 'Multi-handler alpha display should match loaded config.' );
 	flow_formatter_loaded_config_expect( 'Bee' === $config['publish_123']['handler_settings_displays']['beta'][0]['display_value'], 'Multi-handler beta display should match loaded config.' );
 


### PR DESCRIPTION
## Summary
- format array/object settings display values as JSON when building compact flow settings summaries
- preserve the structured display value payload for API consumers
- cover array-valued handler settings in the flow formatter smoke test

## Testing
- `php tests/flow-formatter-loaded-settings-display-smoke.php`
- `php -l inc/Core/Admin/FlowFormatter.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-drain-batch-deadline --extension wordpress --changed-since origin/main --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the flow formatter warning encountered during live flow triage, drafted the fix, and ran local validation; Chris remains responsible for review and merge.