### PR TITLE
Collapse tool source registry onto Agents API

### DIFF
--- a/inc/Engine/AI/Tools/ToolSourceRegistry.php
+++ b/inc/Engine/AI/Tools/ToolSourceRegistry.php
@@ -9,6 +9,7 @@
 
 namespace DataMachine\Engine\AI\Tools;
 
+use AgentsAPI\AI\Tools\WP_Agent_Tool_Source_Registry;
 use DataMachine\Engine\AI\Tools\Sources\AdjacentHandlerToolSource;
 use DataMachine\Engine\AI\Tools\Sources\DataMachineToolRegistrySource;
 use DataMachine\Engine\AI\Tools\Sources\RuntimeToolSource;
@@ -22,9 +23,16 @@ class ToolSourceRegistry {
 	public const SOURCE_RUNTIME_TOOLS     = 'runtime_tools';
 
 	private ToolManager $tool_manager;
+	private WP_Agent_Tool_Source_Registry $registry;
 
 	public function __construct( ToolManager $tool_manager ) {
 		$this->tool_manager = $tool_manager;
+		$this->registry     = new WP_Agent_Tool_Source_Registry();
+
+		$this->registerDataMachineSources();
+		if ( function_exists( 'add_filter' ) ) {
+			add_filter( 'agents_api_tool_source_order', array( $this, 'orderSourcesForContext' ), 5, 3 );
+		}
 	}
 
 	/**
@@ -35,93 +43,77 @@ class ToolSourceRegistry {
 	 * @return array Tools keyed by tool name.
 	 */
 	public function gather( array $modes, array $args ): array {
-		$tools   = array();
-		$sources = $this->getRegisteredSources( $modes, $args );
-
-		foreach ( $this->getSourcesForModes( $modes, $args ) as $source_slug ) {
-			$source_tools = $this->gatherFromSource( $source_slug, $modes, $args, $sources );
-
-			foreach ( $source_tools as $tool_name => $tool_config ) {
-				if ( isset( $tools[ $tool_name ] ) ) {
-					continue;
-				}
-
-				$tools[ $tool_name ] = $tool_config;
-			}
-		}
-
-		return $tools;
-	}
-
-	/**
-	 * Return registered tool sources.
-	 *
-	 * @param array $modes Agent mode slugs.
-	 * @param array  $args Full resolution arguments.
-	 * @return array<string, callable> Source callbacks keyed by source slug.
-	 */
-	private function getRegisteredSources( array $modes, array $args ): array {
-		// @phpstan-ignore-next-line WordPress apply_filters accepts additional hook arguments.
-		$sources = apply_filters(
-			'agents_api_tool_sources',
-			array(
-				self::SOURCE_RUNTIME_TOOLS     => new RuntimeToolSource(),
-				self::SOURCE_STATIC_REGISTRY   => new DataMachineToolRegistrySource( $this->tool_manager ),
-				self::SOURCE_ADJACENT_HANDLERS => new AdjacentHandlerToolSource(),
-			),
-			$modes,
-			$args,
-			$this->tool_manager
-		);
-
-		return is_array( $sources ) ? $sources : array();
-	}
-
-	/**
-	 * Return source slugs for active modes.
-	 *
-	 * @param array $modes Agent mode slugs.
-	 * @param array  $args Full resolution arguments.
-	 * @return array<int, string> Source slugs in precedence order.
-	 */
-	private function getSourcesForModes( array $modes, array $args ): array {
-		$sources = in_array( ToolPolicyResolver::MODE_PIPELINE, $modes, true )
-			? array( self::SOURCE_RUNTIME_TOOLS, self::SOURCE_ADJACENT_HANDLERS, self::SOURCE_STATIC_REGISTRY )
-			: array( self::SOURCE_RUNTIME_TOOLS, self::SOURCE_STATIC_REGISTRY );
-
-		// @phpstan-ignore-next-line WordPress apply_filters accepts additional hook arguments.
-		$sources = apply_filters( 'agents_api_tool_sources_for_mode', $sources, $modes, $args );
-
-		if ( ! is_array( $sources ) ) {
-			return array();
-		}
-
-		return array_values(
-			array_filter(
-				$sources,
-				static fn( $source ) => is_string( $source ) && '' !== $source
+		return $this->registry->gather(
+			array_merge(
+				$args,
+				array(
+					'modes'        => $modes,
+					'tool_manager' => $this->tool_manager,
+				)
 			)
 		);
 	}
 
 	/**
-	 * Gather tools from one source.
+	 * Register Data Machine-owned sources with the Agents API source registry.
 	 *
-	 * @param string $source_slug Source slug.
-	 * @param array  $modes       Agent mode slugs.
-	 * @param array  $args        Full resolution arguments.
-	 * @param array  $sources     Registered source callbacks keyed by source slug.
-	 * @return array Tools keyed by tool name.
+	 * @return void
 	 */
-	private function gatherFromSource( string $source_slug, array $modes, array $args, array $sources ): array {
-		$source = $sources[ $source_slug ] ?? null;
-		if ( ! is_callable( $source ) ) {
-			return array();
+	private function registerDataMachineSources(): void {
+		$runtime_source = new RuntimeToolSource();
+		$static_source  = new DataMachineToolRegistrySource( $this->tool_manager );
+		$handler_source = new AdjacentHandlerToolSource();
+
+		$this->registry->registerSource(
+			self::SOURCE_RUNTIME_TOOLS,
+			static function ( array $context ) use ( $runtime_source ): array {
+				$modes = ToolPolicyResolver::normalizeModes( $context['modes'] ?? array() );
+				return $runtime_source( $modes, $context );
+			}
+		);
+
+		$this->registry->registerSource(
+			self::SOURCE_ADJACENT_HANDLERS,
+			function ( array $context ) use ( $handler_source ): array {
+				$modes = ToolPolicyResolver::normalizeModes( $context['modes'] ?? array() );
+				return $handler_source( $modes, $context, $this->tool_manager );
+			}
+		);
+
+		$this->registry->registerSource(
+			self::SOURCE_STATIC_REGISTRY,
+			static function ( array $context ) use ( $static_source ): array {
+				$modes = ToolPolicyResolver::normalizeModes( $context['modes'] ?? array() );
+				return $static_source( $modes, $context );
+			}
+		);
+	}
+
+	/**
+	 * Return source slugs for active modes through the Agents API order filter.
+	 *
+	 * @param array                         $order    Source slugs in upstream registry order.
+	 * @param array                         $context  Runtime context.
+	 * @param WP_Agent_Tool_Source_Registry $registry Source registry instance.
+	 * @return array<int, string> Source slugs in precedence order.
+	 */
+	public function orderSourcesForContext( array $order, array $context, WP_Agent_Tool_Source_Registry $registry ): array {
+		if ( $registry !== $this->registry ) {
+			return $order;
 		}
 
-		$tools = call_user_func( $source, $modes, $args, $this->tool_manager );
+		$modes = ToolPolicyResolver::normalizeModes( $context['modes'] ?? array() );
 
-		return is_array( $tools ) ? $tools : array();
+		$sources = in_array( ToolPolicyResolver::MODE_PIPELINE, $modes, true )
+			? array( self::SOURCE_RUNTIME_TOOLS, self::SOURCE_ADJACENT_HANDLERS, self::SOURCE_STATIC_REGISTRY )
+			: array( self::SOURCE_RUNTIME_TOOLS, self::SOURCE_STATIC_REGISTRY );
+
+		return array_values(
+			array_filter(
+				$sources,
+				static fn( $source ) => is_string( $source ) && '' !== $source && in_array( $source, $order, true )
+			)
+		);
 	}
 
 }

--- a/tests/adjacent-handler-tool-policy-smoke.php
+++ b/tests/adjacent-handler-tool-policy-smoke.php
@@ -40,6 +40,7 @@ namespace {
 	require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-declaration.php';
 	require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-policy-filter.php';
 	require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-policy.php';
+	require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-source-registry.php';
 	require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineAgentToolPolicyProvider.php';
 	require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineMandatoryToolPolicy.php';
 	require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineToolAccessPolicy.php';

--- a/tests/ai-completion-assertion-packet-smoke.php
+++ b/tests/ai-completion-assertion-packet-smoke.php
@@ -61,6 +61,7 @@ require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agen
 require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-declaration.php';
 require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-policy-filter.php';
 require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-policy.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-source-registry.php';
 require_once __DIR__ . '/../inc/Engine/AI/ConversationManager.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineAgentToolPolicyProvider.php';

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -65,6 +65,7 @@ require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agen
 require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-declaration.php';
 require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-policy-filter.php';
 require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-policy.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-source-registry.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineAgentToolPolicyProvider.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineMandatoryToolPolicy.php';

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -78,6 +78,7 @@ require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agen
 require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-declaration.php';
 require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-policy-filter.php';
 require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-policy.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-source-registry.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolParameters.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Execution/ToolExecutionCore.php';
@@ -213,9 +214,10 @@ echo "\n[3] filters can add a source without disturbing default order:\n";
 remove_all_filters_for_source_smoke();
 add_filter(
 	'agents_api_tool_sources',
-	static function ( array $sources, array $modes, array $args, ToolManager $tool_manager ): array {
-		unset( $modes, $args, $tool_manager );
-		$sources['extra_source'] = static function (): array {
+	static function ( array $sources, array $context ): array {
+		unset( $context );
+		$sources['extra_source'] = static function ( array $source_context ): array {
+			unset( $source_context );
 			return array(
 				'extra_tool' => array( 'origin' => 'extra', 'access_level' => 'public' ),
 			);
@@ -223,19 +225,19 @@ add_filter(
 		return $sources;
 	},
 	10,
-	4
+	2
 );
 add_filter(
-	'agents_api_tool_sources_for_mode',
-	static function ( array $sources, array $modes, array $args ): array {
-		unset( $args );
+	'agents_api_tool_source_order',
+	static function ( array $sources, array $context ): array {
+		$modes = is_array( $context['modes'] ?? null ) ? $context['modes'] : array();
 		if ( in_array( ToolPolicyResolver::MODE_CHAT, $modes, true ) ) {
 			$sources[] = 'extra_source';
 		}
 		return $sources;
 	},
 	10,
-	3
+	2
 );
 $tools = resolve_source_tools( ToolPolicyResolver::MODE_CHAT, new SourcePolicyToolManager() );
 assert_source_equals( array( 'chat_static_tool', 'extra_tool' ), array_keys( $tools ), 'filter appends extra source after static source', $failures, $passes );
@@ -442,6 +444,8 @@ assert_source_equals( false, false !== strpos( $registry_source, 'FlowStepConfig
 assert_source_equals( true, false !== strpos( $adjacent_source, 'FlowStepConfig' ), 'adjacent-handler source owns FlowStepConfig lookup', $failures, $passes );
 assert_source_equals( false, false !== strpos( $registry_source, 'get_all_tools' ), 'generic registry no longer reads Data Machine tool registry', $failures, $passes );
 assert_source_equals( true, false !== strpos( $datamachine_tool_source, 'get_all_tools' ), 'Data Machine registry source owns legacy registry lookup', $failures, $passes );
+assert_source_equals( true, false !== strpos( $registry_source, 'WP_Agent_Tool_Source_Registry' ), 'ToolSourceRegistry delegates source composition to Agents API registry', $failures, $passes );
+assert_source_equals( true, false !== strpos( $registry_source, 'agents_api_tool_source_order' ), 'Data Machine mode ordering uses Agents API source-order hook', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " tool source assertions failed.\n";

--- a/tests/upsert-handler-result-handoff-smoke.php
+++ b/tests/upsert-handler-result-handoff-smoke.php
@@ -65,6 +65,7 @@ require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agen
 require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-declaration.php';
 require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-policy-filter.php';
 require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-policy.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-source-registry.php';
 require_once __DIR__ . '/../inc/Engine/AI/ConversationManager.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineAgentToolPolicyProvider.php';


### PR DESCRIPTION
## Summary
- Reduce Data Machine's ToolSourceRegistry to a thin adapter over Agents API's WP_Agent_Tool_Source_Registry.
- Register Data Machine-owned runtime, adjacent-handler, and static datamachine_tools sources into the upstream registry.
- Express Data Machine source precedence through the upstream agents_api_tool_source_order extension point while preserving pipeline adjacent-handler precedence and non-pipeline isolation.
- Update source-registry smoke coverage for upstream source/context/order hooks and duplicate-name precedence.

Fixes #2338.

## Upstream dependency
- Depends on Automattic/agents-api#232.
- Current Agents API contract is sufficient: named source callbacks, runtime context, filterable source registration, filterable source ordering, first-source-wins duplicate precedence, and gathered declaration normalization are available in WP_Agent_Tool_Source_Registry.
- No Data Machine shim or upstream workaround was added.

## Verification
- php tests/tool-source-registry-smoke.php
- php tests/adjacent-handler-tool-policy-smoke.php
- php tests/pipeline-tool-policy-snapshot-smoke.php
- php tests/ai-completion-assertion-packet-smoke.php
- php tests/upsert-handler-result-handoff-smoke.php
- vendor/bin/phpcs inc/Engine/AI/Tools/ToolSourceRegistry.php tests/tool-source-registry-smoke.php tests/adjacent-handler-tool-policy-smoke.php tests/pipeline-tool-policy-snapshot-smoke.php tests/ai-completion-assertion-packet-smoke.php tests/upsert-handler-result-handoff-smoke.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the registry adapter change, updated smoke coverage, ran verification, and prepared this PR; Chris remains responsible for review and merge.