### PR TITLE
Make agents/chat the canonical chat entry point

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -227,10 +227,10 @@ class AgentsChatHandler {
 		$metadata                = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
 		$metadata['datamachine'] = array_filter(
 			array(
-				'tool_calls'    => $result['tool_calls'] ?? null,
+				'tool_calls'   => $result['tool_calls'] ?? null,
 				'conversation' => $result['conversation'] ?? null,
-				'max_turns'     => $result['max_turns'] ?? null,
-				'turn_number'   => $result['turn_number'] ?? null,
+				'max_turns'    => $result['max_turns'] ?? null,
+				'turn_number'  => $result['turn_number'] ?? null,
 			),
 			static fn( $value ): bool => null !== $value
 		);

--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -84,7 +84,7 @@ class AgentsChatHandler {
 			return $agent_id;
 		}
 
-		$user_id = $this->resolveRuntimeUserId( $agent_id, (string) ( $input['agent'] ?? '' ) );
+		$user_id = $this->resolveRuntimeUserId( $agent_id, (string) ( $input['agent'] ?? '' ), $input );
 		if ( $user_id <= 0 ) {
 			return new WP_Error( 'no_user', __( 'No user context available.', 'data-machine' ), array( 'status' => 400 ) );
 		}
@@ -93,8 +93,14 @@ class AgentsChatHandler {
 		$modes          = $this->resolveModes( $input, $client_context );
 		$mode           = implode( ',', $modes );
 		$agent_config   = PluginSettings::resolveModelForAgentModes( 0 === $agent_id ? null : $agent_id, $modes, 'chat' );
-		$provider       = $agent_config['provider'];
-		$model          = $agent_config['model'];
+		$provider       = (string) ( $input['provider'] ?? '' );
+		$model          = (string) ( $input['model'] ?? '' );
+		if ( '' === $provider ) {
+			$provider = $agent_config['provider'];
+		}
+		if ( '' === $model ) {
+			$model = $agent_config['model'];
+		}
 
 		if ( '' === $provider ) {
 			return new WP_Error( 'provider_required', __( 'AI provider is required. Set a default in Data Machine settings.', 'data-machine' ), array( 'status' => 400 ) );
@@ -110,13 +116,17 @@ class AgentsChatHandler {
 			sanitize_text_field( $model ),
 			$user_id,
 			array(
-				'session_id'       => $input['session_id'] ?? null,
-				'modes'            => $modes,
-				'agent_id'         => $agent_id,
-				'attachments'      => $input['attachments'] ?? array(),
-				'client_context'   => $client_context,
-				'session_owner'    => is_array( $input['session_owner'] ?? null ) ? $input['session_owner'] : null,
-				'transcript_owner' => is_array( $input['transcript_owner'] ?? null ) ? $input['transcript_owner'] : null,
+				'session_id'           => $input['session_id'] ?? null,
+				'selected_pipeline_id' => (int) ( $input['selected_pipeline_id'] ?? 0 ),
+				'max_turns'            => $input['max_turns'] ?? null,
+				'request_id'           => $input['request_id'] ?? null,
+				'modes'                => $modes,
+				'agent_id'             => $agent_id,
+				'agent_slug'           => sanitize_title( (string) ( $input['agent'] ?? '' ) ),
+				'attachments'          => $input['attachments'] ?? array(),
+				'client_context'       => $client_context,
+				'session_owner'        => is_array( $input['session_owner'] ?? null ) ? $input['session_owner'] : null,
+				'transcript_owner'     => is_array( $input['transcript_owner'] ?? null ) ? $input['transcript_owner'] : null,
 			)
 		);
 
@@ -160,9 +170,15 @@ class AgentsChatHandler {
 	 *
 	 * @param int    $agent_id Internal Data Machine agent ID.
 	 * @param string $agent    Requested Agents API agent slug/id.
+	 * @param array  $input    Canonical input plus Data Machine facade fields.
 	 * @return int Runtime WordPress user ID, or 0 when no safe context exists.
 	 */
-	private function resolveRuntimeUserId( int $agent_id, string $agent ): int {
+	private function resolveRuntimeUserId( int $agent_id, string $agent, array $input ): int {
+		$user_id = (int) ( $input['user_id'] ?? 0 );
+		if ( $user_id > 0 && PermissionHelper::can( 'chat' ) ) {
+			return $user_id;
+		}
+
 		$user_id = PermissionHelper::acting_user_id();
 		if ( $user_id <= 0 ) {
 			$user_id = get_current_user_id();
@@ -211,9 +227,10 @@ class AgentsChatHandler {
 		$metadata                = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
 		$metadata['datamachine'] = array_filter(
 			array(
-				'tool_calls'  => $result['tool_calls'] ?? null,
-				'max_turns'   => $result['max_turns'] ?? null,
-				'turn_number' => $result['turn_number'] ?? null,
+				'tool_calls'    => $result['tool_calls'] ?? null,
+				'conversation' => $result['conversation'] ?? null,
+				'max_turns'     => $result['max_turns'] ?? null,
+				'turn_number'   => $result['turn_number'] ?? null,
 			),
 			static fn( $value ): bool => null !== $value
 		);

--- a/inc/Abilities/Chat/SendMessageAbility.php
+++ b/inc/Abilities/Chat/SendMessageAbility.php
@@ -3,8 +3,8 @@
  * Send Message Ability
  *
  * Sends a user message to an AI agent within a chat session. Creates a new
- * session if none is provided. Wraps ChatOrchestrator::processChat() as the
- * canonical entry point for all interfaces (REST, CLI, bridge, tools).
+ * session if none is provided. This is a Data Machine product facade over the
+ * canonical Agents API `agents/chat` entry point.
  *
  * This is the ability that was missing — prior to this, the "send a message
  * and get an AI response" flow lived only in the Chat REST controller,
@@ -17,9 +17,6 @@
 namespace DataMachine\Abilities\Chat;
 
 use DataMachine\Abilities\PermissionHelper;
-use DataMachine\Api\Chat\ChatOrchestrator;
-use DataMachine\Core\PluginSettings;
-
 defined( 'ABSPATH' ) || exit;
 
 class SendMessageAbility {
@@ -136,9 +133,9 @@ class SendMessageAbility {
 	/**
 	 * Execute send-message ability.
 	 *
-	 * Resolves provider/model from agent context if not provided, then
-	 * delegates to ChatOrchestrator::processChat() for the full AI
-	 * conversation turn.
+	 * Delegates to the canonical Agents API `agents/chat` dispatcher. Data
+	 * Machine-specific inputs are passed through for Data Machine's registered
+	 * `wp_agent_chat_handler`; no chat runtime logic lives in this facade.
 	 *
 	 * @since 0.63.0
 	 *
@@ -146,9 +143,9 @@ class SendMessageAbility {
 	 * @return array|\WP_Error Response data from the orchestrator.
 	 */
 	public function execute( array $input ): array|\WP_Error {
-		$message = $input['message'] ?? '';
+		$message = trim( (string) ( $input['message'] ?? '' ) );
 
-		if ( empty( $message ) ) {
+		if ( '' === $message ) {
 			return new \WP_Error(
 				'empty_message',
 				__( 'Message cannot be empty.', 'data-machine' ),
@@ -156,69 +153,84 @@ class SendMessageAbility {
 			);
 		}
 
-		// Resolve user ID: explicit > acting user.
-		$user_id = (int) ( $input['user_id'] ?? 0 );
-		if ( $user_id <= 0 ) {
-			$user_id = PermissionHelper::acting_user_id();
-		}
-
-		if ( $user_id <= 0 ) {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
 			return new \WP_Error(
-				'no_user',
-				__( 'No user context available.', 'data-machine' ),
-				array( 'status' => 400 )
+				'agents_chat_unavailable',
+				__( 'Agents chat ability is unavailable.', 'data-machine' ),
+				array( 'status' => 500 )
 			);
 		}
 
-		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		$mode     = ! empty( $input['mode'] ) ? sanitize_key( (string) $input['mode'] ) : 'chat';
+		$ability = wp_get_ability( 'agents/chat' );
+		if ( ! $ability ) {
+			return new \WP_Error(
+				'agents_chat_unavailable',
+				__( 'Agents chat ability is not registered.', 'data-machine' ),
+				array( 'status' => 500 )
+			);
+		}
 
-		// Resolve provider/model from input or agent context.
-		$provider = $input['provider'] ?? '';
-		$model    = $input['model'] ?? '';
+		$canonical_input = $this->toCanonicalInput( array_merge( $input, array( 'message' => $message ) ) );
+		$result          = $ability->execute( $canonical_input );
 
-		if ( empty( $provider ) || empty( $model ) ) {
-			$agent_config = PluginSettings::resolveModelForAgentModes( $agent_id > 0 ? $agent_id : null, array( $mode ), 'chat' );
-			if ( empty( $provider ) ) {
-				$provider = $agent_config['provider'];
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return $this->toDataMachineOutput( is_array( $result ) ? $result : array() );
+	}
+
+	/**
+	 * Convert Data Machine facade input to canonical Agents API chat input.
+	 *
+	 * @param array $input Facade input.
+	 * @return array Canonical agents/chat input plus Data Machine adapter fields.
+	 */
+	private function toCanonicalInput( array $input ): array {
+		$agent_id       = (int) ( $input['agent_id'] ?? 0 );
+		$client_context = is_array( $input['client_context'] ?? null ) ? $input['client_context'] : array();
+
+		$canonical = array(
+			'agent'          => (string) ( $input['agent'] ?? ( $agent_id > 0 ? (string) $agent_id : '' ) ),
+			'message'        => (string) $input['message'],
+			'attachments'    => $input['attachments'] ?? array(),
+			'client_context' => $client_context,
+		);
+
+		foreach ( array( 'session_id', 'session_owner', 'transcript_owner' ) as $key ) {
+			if ( array_key_exists( $key, $input ) ) {
+				$canonical[ $key ] = $input[ $key ];
 			}
-			if ( empty( $model ) ) {
-				$model = $agent_config['model'];
+		}
+
+		foreach ( array( 'user_id', 'provider', 'model', 'mode', 'modes', 'selected_pipeline_id', 'max_turns', 'request_id' ) as $key ) {
+			if ( array_key_exists( $key, $input ) && null !== $input[ $key ] && '' !== $input[ $key ] ) {
+				$canonical[ $key ] = $input[ $key ];
 			}
 		}
 
-		if ( empty( $provider ) ) {
-			return new \WP_Error(
-				'provider_required',
-				__( 'AI provider is required. Set a default in Data Machine settings or provide one in the request.', 'data-machine' ),
-				array( 'status' => 400 )
-			);
-		}
+		return $canonical;
+	}
 
-		if ( empty( $model ) ) {
-			return new \WP_Error(
-				'model_required',
-				__( 'AI model is required. Set a default in Data Machine settings or provide one in the request.', 'data-machine' ),
-				array( 'status' => 400 )
-			);
-		}
+	/**
+	 * Convert canonical Agents API chat output to Data Machine's facade shape.
+	 *
+	 * @param array $result Canonical agents/chat output.
+	 * @return array Data Machine send-message output.
+	 */
+	private function toDataMachineOutput( array $result ): array {
+		$metadata    = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
+		$datamachine = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
 
-		return ChatOrchestrator::processChat(
-			$message,
-			sanitize_text_field( $provider ),
-			sanitize_text_field( $model ),
-			$user_id,
-			array(
-				'session_id'           => $input['session_id'] ?? null,
-				'selected_pipeline_id' => (int) ( $input['selected_pipeline_id'] ?? 0 ),
-				'max_turns'            => $input['max_turns'] ?? null,
-				'request_id'           => $input['request_id'] ?? null,
-				'mode'                 => $mode,
-				'agent_id'             => $agent_id,
-				'attachments'          => $input['attachments'] ?? array(),
-				'client_context'       => $input['client_context'] ?? array(),
-				'session_owner'        => is_array( $input['session_owner'] ?? null ) ? $input['session_owner'] : null,
-			)
+		return array(
+			'session_id'   => (string) ( $result['session_id'] ?? '' ),
+			'response'     => (string) ( $result['reply'] ?? '' ),
+			'completed'    => (bool) ( $result['completed'] ?? true ),
+			'tool_calls'   => $datamachine['tool_calls'] ?? array(),
+			'conversation' => $datamachine['conversation'] ?? $result['messages'] ?? array(),
+			'metadata'     => $metadata,
+			'max_turns'    => (int) ( $datamachine['max_turns'] ?? 0 ),
+			'turn_number'  => (int) ( $datamachine['turn_number'] ?? 0 ),
 		);
 	}
 }

--- a/tests/agents-chat-handler-smoke.php
+++ b/tests/agents-chat-handler-smoke.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Smoke tests for Data Machine's canonical Agents API chat adapter.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $value ): bool {
+		return $value instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( string $text, string $domain = 'default' ): string {
+		unset( $domain );
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( string $hook ): bool {
+		unset( $hook );
+		return false;
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( string $hook ): int {
+		unset( $hook );
+		return 1;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ): bool {
+		unset( $args );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $slug ): ?object {
+		$GLOBALS['datamachine_agents_chat_handler_last_slug'] = $slug;
+		return 'agents/chat' === $slug ? $GLOBALS['datamachine_agents_chat_handler_fake_ability'] : null;
+	}
+}
+
+$passes = 0;
+$fails  = 0;
+
+$assert = static function ( bool $condition, string $label ) use ( &$passes, &$fails ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	++$fails;
+	echo "FAIL: {$label}\n";
+};
+
+$root                = dirname( __DIR__ );
+$send_message_source = (string) file_get_contents( $root . '/inc/Abilities/Chat/SendMessageAbility.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Source smoke fixture.
+$handler_source      = (string) file_get_contents( $root . '/inc/Abilities/Chat/AgentsChatHandler.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Source smoke fixture.
+$chat_abilities      = (string) file_get_contents( $root . '/inc/Abilities/ChatAbilities.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Source smoke fixture.
+
+$assert( str_contains( $chat_abilities, 'new AgentsChatHandler();' ), 'ChatAbilities registers Data Machine as the Agents API chat handler' );
+$assert( str_contains( $handler_source, "register_chat_handler( array( $" . "this, 'execute' ) )" ) || str_contains( $handler_source, "add_filter( 'wp_agent_chat_handler'" ), 'AgentsChatHandler attaches to wp_agent_chat_handler seam' );
+$assert( str_contains( $handler_source, 'ChatOrchestrator::processChat(' ), 'AgentsChatHandler owns the single ChatOrchestrator runtime call' );
+$assert( str_contains( $handler_source, "'selected_pipeline_id' => (int) ( $" . "input['selected_pipeline_id'] ?? 0 )" ), 'AgentsChatHandler forwards selected pipeline context' );
+$assert( str_contains( $handler_source, "'request_id'           => $" . "input['request_id'] ?? null" ), 'AgentsChatHandler forwards request id for session dedupe' );
+$assert( str_contains( $handler_source, "'agent_slug'           => sanitize_title( (string) ( $" . "input['agent'] ?? '' ) )" ), 'AgentsChatHandler forwards agent targeting to the chat runtime' );
+$assert( ! str_contains( $send_message_source, 'ChatOrchestrator::processChat(' ), 'send-message facade does not duplicate ChatOrchestrator runtime logic' );
+$assert( str_contains( $send_message_source, "wp_get_ability( 'agents/chat' )" ), 'send-message facade dispatches through canonical agents/chat ability' );
+
+require_once $root . '/inc/Abilities/Chat/SendMessageAbility.php';
+
+$GLOBALS['datamachine_agents_chat_handler_fake_ability'] = new class() {
+	public array $last_input = array();
+
+	public function execute( array $input ): array {
+		$this->last_input = $input;
+		return array(
+			'session_id' => 'session-123',
+			'reply'      => 'Hello from agents/chat.',
+			'messages'   => array(
+				array(
+					'role'    => 'assistant',
+					'content' => 'Hello from agents/chat.',
+				),
+			),
+			'completed'  => true,
+			'metadata'   => array(
+				'datamachine' => array(
+					'tool_calls'   => array( array( 'name' => 'lookup' ) ),
+					'conversation' => array( array( 'role' => 'assistant', 'content' => 'Hello from agents/chat.' ) ),
+					'max_turns'    => 5,
+					'turn_number'  => 2,
+				),
+			),
+		);
+	}
+};
+
+$ability = new DataMachine\Abilities\Chat\SendMessageAbility();
+$result  = $ability->execute(
+	array(
+		'message'              => 'Continue this chat.',
+		'agent_id'             => 42,
+		'session_id'           => 'session-123',
+		'provider'             => 'openai',
+		'model'                => 'gpt-5.5',
+		'mode'                 => 'intelligence',
+		'selected_pipeline_id' => 7,
+		'request_id'           => 'request-abc',
+	)
+);
+
+$captured = $GLOBALS['datamachine_agents_chat_handler_fake_ability']->last_input;
+$assert( 'agents/chat' === $GLOBALS['datamachine_agents_chat_handler_last_slug'], 'send-message resolves canonical agents/chat ability' );
+$assert( '42' === ( $captured['agent'] ?? null ), 'send-message maps agent_id to canonical agent target' );
+$assert( 'session-123' === ( $captured['session_id'] ?? null ), 'send-message preserves session continuation id' );
+$assert( 7 === ( $captured['selected_pipeline_id'] ?? null ), 'send-message preserves Data Machine pipeline context' );
+$assert( 'Hello from agents/chat.' === ( $result['response'] ?? null ), 'send-message maps canonical reply to Data Machine response' );
+$assert( array( array( 'name' => 'lookup' ) ) === ( $result['tool_calls'] ?? null ), 'send-message restores Data Machine tool call metadata' );
+
+echo "\n{$passes} passed, {$fails} failed\n";
+if ( $fails > 0 ) {
+	exit( 1 );
+}

--- a/tests/mode-model-resolution-smoke.php
+++ b/tests/mode-model-resolution-smoke.php
@@ -129,7 +129,7 @@ namespace {
 
 	$assert_same( true, str_contains( $ai_step_source, "resolveModelForAgentModes( $" . "agent_id, $" . "modes, ToolPolicyResolver::MODE_PIPELINE )" ), 'AIStep uses shared mode-model resolver with pipeline fallback' );
 	$assert_same( true, str_contains( $chat_source, "resolveModelForAgentModes( 0 === $" . "agent_id ? null : $" . "agent_id, $" . "modes, 'chat' )" ), 'canonical agents/chat uses shared mode-model resolver with chat fallback' );
-	$assert_same( true, str_contains( $send_source, "resolveModelForAgentModes( $" . "agent_id > 0 ? $" . "agent_id : null, array( $" . "mode ), 'chat' )" ), 'send-message ability uses shared mode-model resolver with chat fallback' );
+	$assert_same( true, str_contains( $send_source, "wp_get_ability( 'agents/chat' )" ), 'send-message ability delegates model resolution to canonical agents/chat' );
 
 	echo "\n{$passes} passed, {$fails} failed\n";
 	if ( $fails > 0 ) {


### PR DESCRIPTION
## Summary
- route the Data Machine send-message product ability through the canonical Agents API agents/chat dispatcher
- extend Data Machine's wp_agent_chat_handler adapter to carry Data Machine-specific chat options into ChatOrchestrator
- add a focused smoke test for handler registration, session continuation, agent targeting, and facade output mapping

Fixes #2336

## Verification
- php -l inc/Abilities/Chat/AgentsChatHandler.php
- php -l inc/Abilities/Chat/SendMessageAbility.php
- php -l tests/agents-chat-handler-smoke.php
- php tests/agents-chat-handler-smoke.php
- php tests/agents-chat-tool-continuation-smoke.php
- php tests/mode-model-resolution-smoke.php
- php tests/consult-agent-tool-smoke.php
- vendor/bin/phpcs inc/Abilities/Chat/AgentsChatHandler.php inc/Abilities/Chat/SendMessageAbility.php tests/agents-chat-handler-smoke.php tests/mode-model-resolution-smoke.php

## Notes
- homeboy test --path /Users/chubes/Developer/data-machine@fix-agents-chat-handler-2336 --extension wordpress did not reach tests because the lab-mounted checkout lacked vendor/autoload.php.
- homeboy lint --path /Users/chubes/Developer/data-machine@fix-agents-chat-handler-2336 --extension wordpress reported existing repo-wide analyzer failures, mostly missing Agents API classes in the lint context.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Agents API chat handler routing changes, facade refactor, and targeted smoke coverage; Chris remains responsible for review and merge.