### PR TITLE
Converge bundle artifacts on agent packages

### DIFF
--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -841,18 +841,20 @@ class AgentBundler {
 					$scheduling['run_artifacts'] = $flow_run_artifacts;
 				}
 
-				$flow_config         = is_array( $flow_data['flow_config'] ?? null ) ? $flow_data['flow_config'] : array();
-				$existing_flow       = $this->flows_repo->get_by_portable_slug( (int) $new_pipeline_id, $portable_slug );
-				$target_flow_config  = $existing_flow
+				$flow_config          = is_array( $flow_data['flow_config'] ?? null ) ? $flow_data['flow_config'] : array();
+				$existing_flow        = $this->flows_repo->get_by_portable_slug( (int) $new_pipeline_id, $portable_slug );
+				$target_flow_config   = $existing_flow
 				? BundleStepIdRemapper::remap_flow_step_ids( $flow_config, $old_pipeline_id, (int) $new_pipeline_id, (int) $existing_flow['flow_id'] )
 				: $flow_config;
-				$flow_payload_source = array_merge(
+				$flow_artifact_record = is_array( $artifact_records[ $artifact_key ] ?? null ) ? $artifact_records[ $artifact_key ] : null;
+				$installed_payload    = is_array( $flow_artifact_record['installed_payload'] ?? null ) ? $flow_artifact_record['installed_payload'] : null;
+				$flow_payload_source  = array_merge(
 				$flow_data,
 				array(
 					'flow_config' => $target_flow_config,
 				)
 				);
-				$payload             = $this->flow_artifact_payload( $flow_payload_source, $portable_slug );
+				$payload              = $this->flow_artifact_payload( $flow_payload_source, $portable_slug, $installed_payload );
 
 				if ( $existing_flow ) {
 					$preview = AgentBundleRuntimeDrift::preview(
@@ -870,7 +872,7 @@ class AgentBundler {
 				$existing_flow
 				&& ! $reconcile_runtime
 				&& $this->artifact_has_local_modifications(
-					$artifact_records[ $artifact_key ] ?? null,
+					$flow_artifact_record,
 					$this->normalized_existing_flow_payload( $existing_flow, $portable_slug, (int) $new_pipeline_id, is_array( $artifact_records[ $artifact_key ] ?? null ) ? $artifact_records[ $artifact_key ] : null )
 				)
 				&& ! hash_equals(

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -317,9 +317,9 @@ class AgentBundler {
 	 * Project a legacy bundle array to the Core-shaped package contract.
 	 *
 	 * @param array<string,mixed> $bundle Legacy bundle array.
-	 * @return \WP_Agent_Package
+	 * @return object
 	 */
-	public static function package_from_bundle( array $bundle ): \WP_Agent_Package {
+	public static function package_from_bundle( array $bundle ): object {
 		return AgentPackageProjection::from_array_bundle( $bundle );
 	}
 
@@ -327,9 +327,9 @@ class AgentBundler {
 	 * Project a bundle directory to the Core-shaped package contract.
 	 *
 	 * @param AgentBundleDirectory $directory Bundle directory.
-	 * @return \WP_Agent_Package
+	 * @return object
 	 */
-	public static function package_from_directory( AgentBundleDirectory $directory ): \WP_Agent_Package {
+	public static function package_from_directory( AgentBundleDirectory $directory ): object {
 		return AgentPackageProjection::from_directory( $directory );
 	}
 
@@ -1392,7 +1392,7 @@ class AgentBundler {
 
 	private function bundle_artifact_record( array $bundle_metadata, string $type, string $id, string $source_path, mixed $payload ): array {
 		$hash = AgentBundleArtifactHasher::hash( $payload );
-		$now  = gmdate( 'c' );
+		$now  = gmdate( 'Y-m-d H:i:s' );
 
 		// installed_payload is the install-time snapshot. AgentBundleArtifactRebase
 		// uses it as the `base` side of the 3-way merge so burn-in-safe can tell

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -20,6 +20,8 @@ use DataMachine\Core\FilesRepository\DailyMemory;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Api\Flows\FlowScheduling;
 use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
+use DataMachine\Engine\Bundle\AgentBundleArtifactPayloads;
+use DataMachine\Engine\Bundle\AgentBundleArtifactDefinitions;
 use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
 use DataMachine\Engine\Bundle\AgentBundleArtifactState;
 use DataMachine\Engine\Bundle\AgentBundleAgentConfig;
@@ -1326,32 +1328,11 @@ class AgentBundler {
 	}
 
 	private function pipeline_artifact_payload( array $pipeline, string $portable_slug ): array {
-		return array(
-			'portable_slug'   => $portable_slug,
-			'pipeline_name'   => (string) ( $pipeline['pipeline_name'] ?? '' ),
-			'pipeline_config' => is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(),
-		);
+		return AgentBundleArtifactPayloads::pipeline_payload( $pipeline, $portable_slug );
 	}
 
 	private function flow_artifact_payload( array $flow, string $portable_slug, ?array $installed_payload = null ): array {
-		$scheduling_policy = is_string( $installed_payload['scheduling_policy'] ?? null )
-			? $installed_payload['scheduling_policy']
-			: $this->bundle_scheduling_policy( is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array() );
-		$run_artifacts     = \DataMachine\Engine\Bundle\BundleSchema::normalize_run_artifact_egress_policy( $flow['run_artifacts'] ?? $flow['scheduling_config']['run_artifacts'] ?? array() );
-
-		$payload = array(
-			'portable_slug'     => $portable_slug,
-			'flow_name'         => (string) ( $flow['flow_name'] ?? '' ),
-			'flow_config'       => $this->flow_config_without_runtime_queues( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() ),
-			'scheduling_policy' => $scheduling_policy,
-			'queue_policy'      => 'create_seed_upgrade_preserve_existing',
-			'runtime_overlays'  => $this->flow_runtime_overlays( $flow, $installed_payload ),
-		);
-		if ( ! empty( $run_artifacts ) ) {
-			$payload['run_artifacts'] = $run_artifacts;
-		}
-
-		return $payload;
+		return AgentBundleArtifactPayloads::flow_payload( $flow, $portable_slug, $installed_payload );
 	}
 
 	private function bundle_create_scheduling_config( array $config ): array {
@@ -1398,16 +1379,6 @@ class AgentBundler {
 		}
 	}
 
-	private function bundle_scheduling_policy( array $config ): string {
-		$create_config = $this->bundle_create_scheduling_config( $config );
-
-		if ( 'manual' === (string) ( $create_config['interval'] ?? 'manual' ) || false === ( $create_config['enabled'] ?? true ) ) {
-			return 'create_paused_upgrade_preserve_existing';
-		}
-
-		return 'create_bundle_schedule_upgrade_preserve_existing';
-	}
-
 	private function artifact_has_local_modifications( ?array $record, mixed $current_payload ): bool {
 		if ( empty( $record['installed_hash'] ) ) {
 			return false;
@@ -1446,41 +1417,7 @@ class AgentBundler {
 
 	/** @return array<int,array<string,mixed>> */
 	private static function bundle_file_artifacts( array $bundle ): array {
-		$artifacts = array();
-		$files     = is_array( $bundle['artifact_files'] ?? null ) ? $bundle['artifact_files'] : array();
-
-		foreach ( self::bundle_file_artifact_directories() as $directory => $type ) {
-			foreach ( is_array( $files[ $directory ] ?? null ) ? $files[ $directory ] : array() as $relative_path => $payload ) {
-				$artifact_id = is_array( $payload ) && is_string( $payload['artifact_id'] ?? null )
-					? (string) $payload['artifact_id']
-					: self::artifact_id_from_relative_path( (string) $relative_path );
-
-				$artifacts[] = array(
-					'artifact_type' => $type,
-					'artifact_id'   => $artifact_id,
-					'source_path'   => $directory . '/' . ltrim( (string) $relative_path, '/' ),
-					'payload'       => $payload,
-				);
-			}
-		}
-
-		return $artifacts;
-	}
-
-	/** @return array<string,string> */
-	private static function bundle_file_artifact_directories(): array {
-		return array(
-			\DataMachine\Engine\Bundle\BundleSchema::PROMPTS_DIR       => 'prompt',
-			\DataMachine\Engine\Bundle\BundleSchema::RUBRICS_DIR       => 'rubric',
-			\DataMachine\Engine\Bundle\BundleSchema::TOOL_POLICIES_DIR => 'tool_policy',
-			\DataMachine\Engine\Bundle\BundleSchema::AUTH_REFS_DIR     => 'auth_ref',
-			\DataMachine\Engine\Bundle\BundleSchema::SEED_QUEUES_DIR   => 'seed_queue',
-		);
-	}
-
-	private static function artifact_id_from_relative_path( string $relative_path ): string {
-		$relative_path = preg_replace( '/\.(json|md|txt)$/i', '', $relative_path );
-		return null === $relative_path ? '' : $relative_path;
+		return AgentBundleArtifactDefinitions::file_artifact_rows_from_bundle( $bundle );
 	}
 
 	private static function current_payload_from_record( ?array $record ): mixed {
@@ -1561,105 +1498,6 @@ class AgentBundler {
 			}
 			$step['handler_configs'][ $handler_slug ]['max_items'] = $handler_config['max_items'];
 		}
-	}
-
-	private function flow_config_without_runtime_queues( array $flow_config ): array {
-		$normalized = array();
-		foreach ( $flow_config as $flow_step_id => $step ) {
-			if ( ! is_array( $step ) ) {
-				$normalized[ (string) $flow_step_id ] = $step;
-				continue;
-			}
-			unset( $step['prompt_queue'], $step['config_patch_queue'], $step['queue_mode'], $step['_queue_consume_revision'] );
-			unset( $step['pipeline_id'], $step['flow_id'], $step['flow_step_id'] );
-			unset( $step['handler_config']['max_items'] );
-			if ( empty( $step['handler_config'] ) ) {
-				unset( $step['handler_config'] );
-			}
-			if ( isset( $step['pipeline_step_id'] ) ) {
-				$step['pipeline_step_id'] = $this->normalize_artifact_step_id( (string) $step['pipeline_step_id'] );
-			}
-			if ( is_array( $step['handler_configs'] ?? null ) ) {
-				foreach ( $step['handler_configs'] as $handler_slug => &$handler_config ) {
-					if ( is_array( $handler_config ) ) {
-						unset( $handler_config['max_items'] );
-						if ( empty( $handler_config ) ) {
-							unset( $step['handler_configs'][ $handler_slug ] );
-						}
-					}
-				}
-				unset( $handler_config );
-				if ( empty( $step['handler_configs'] ) ) {
-					unset( $step['handler_configs'] );
-				}
-			}
-
-			$normalized[ $this->normalize_artifact_step_id( (string) $flow_step_id ) ] = $step;
-		}
-		ksort( $normalized, SORT_STRING );
-
-		return $normalized;
-	}
-
-	private function normalize_artifact_step_id( string $step_id ): string {
-		$normalized = preg_replace( '/^\d+_/', '', $step_id );
-		$normalized = is_string( $normalized ) ? $normalized : $step_id;
-		$normalized = preg_replace( '/_\d+$/', '', $normalized );
-
-		return is_string( $normalized ) && '' !== $normalized ? $normalized : $step_id;
-	}
-
-	private function flow_runtime_overlays( array $flow, ?array $installed_payload = null ): array {
-		if ( is_array( $installed_payload['runtime_overlays'] ?? null ) ) {
-			return $installed_payload['runtime_overlays'];
-		}
-
-		$overlays    = array();
-		$flow_config = is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array();
-		$steps       = array();
-
-		foreach ( $flow_config as $flow_step_id => $step ) {
-			if ( ! is_array( $step ) ) {
-				continue;
-			}
-
-			$step_overlay = array();
-			foreach ( array( 'prompt_queue', 'config_patch_queue', 'queue_mode', '_queue_consume_revision' ) as $field ) {
-				if ( array_key_exists( $field, $step ) ) {
-					$step_overlay[ $field ] = $step[ $field ];
-				}
-			}
-			if ( array_key_exists( 'max_items', $step['handler_config'] ?? array() ) ) {
-				$step_overlay['handler_config'] = array( 'max_items' => $step['handler_config']['max_items'] );
-			}
-			if ( is_array( $step['handler_configs'] ?? null ) ) {
-				foreach ( $step['handler_configs'] as $handler_slug => $handler_config ) {
-					if ( is_array( $handler_config ) && array_key_exists( 'max_items', $handler_config ) ) {
-						$step_overlay['handler_configs'][ (string) $handler_slug ] = array( 'max_items' => $handler_config['max_items'] );
-					}
-				}
-			}
-
-			if ( ! empty( $step_overlay ) ) {
-				ksort( $step_overlay, SORT_STRING );
-				$steps[ (string) $flow_step_id ] = $step_overlay;
-			}
-		}
-
-		if ( ! empty( $steps ) ) {
-			ksort( $steps, SORT_STRING );
-			$overlays['steps'] = $steps;
-		}
-
-		$scheduling = $this->sanitize_scheduling_config( is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array() );
-		unset( $scheduling['run_artifacts'] );
-		if ( ! empty( $scheduling ) ) {
-			ksort( $scheduling, SORT_STRING );
-			$overlays['scheduling_config'] = $scheduling;
-		}
-
-		ksort( $overlays, SORT_STRING );
-		return $overlays;
 	}
 
 	private function normalized_existing_flow_payload( array $flow, string $portable_slug, int $new_pipeline_id, ?array $artifact_record = null ): array {

--- a/inc/Engine/Bundle/AgentBundleArtifactDefinitions.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactDefinitions.php
@@ -54,6 +54,69 @@ final class AgentBundleArtifactDefinitions {
 		return array_values( array_map( static fn( array $definition ): string => $definition['artifact_type'], self::file_artifacts() ) );
 	}
 
+	public static function package_artifact_type( string $type ): string {
+		$type = self::normalize_artifact_type( $type );
+		if ( str_contains( $type, '/' ) ) {
+			return $type;
+		}
+
+		foreach ( self::file_artifacts() as $definition ) {
+			if ( $type === $definition['artifact_type'] ) {
+				return $definition['package_type'];
+			}
+		}
+
+		return 'datamachine/' . str_replace( '_', '-', $type );
+	}
+
+	public static function bundle_artifact_type( string $type ): string {
+		if ( str_starts_with( $type, 'datamachine-extension/' ) ) {
+			return substr( $type, strlen( 'datamachine-extension/' ) );
+		}
+
+		foreach ( self::file_artifacts() as $definition ) {
+			if ( $type === $definition['package_type'] ) {
+				return $definition['artifact_type'];
+			}
+		}
+
+		$type = str_starts_with( $type, 'datamachine/' ) ? substr( $type, strlen( 'datamachine/' ) ) : $type;
+
+		return str_replace( '-', '_', self::normalize_artifact_type( $type ) );
+	}
+
+	public static function artifact_id_from_payload( mixed $payload, string $relative_path ): string {
+		if ( is_array( $payload ) && is_string( $payload['artifact_id'] ?? null ) && '' !== trim( $payload['artifact_id'] ) ) {
+			return (string) $payload['artifact_id'];
+		}
+
+		return self::artifact_id_from_relative_path( $relative_path );
+	}
+
+	public static function artifact_id_from_relative_path( string $relative_path ): string {
+		$relative_path = preg_replace( '/\.(json|md|txt)$/i', '', $relative_path );
+		return null === $relative_path ? '' : $relative_path;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public static function file_artifact_rows_from_bundle( array $bundle ): array {
+		$artifacts = array();
+		$files     = is_array( $bundle['artifact_files'] ?? null ) ? $bundle['artifact_files'] : array();
+
+		foreach ( self::file_artifacts() as $directory => $definition ) {
+			foreach ( is_array( $files[ $directory ] ?? null ) ? $files[ $directory ] : array() as $relative_path => $payload ) {
+				$artifacts[] = array(
+					'artifact_type' => $definition['artifact_type'],
+					'artifact_id'   => self::artifact_id_from_payload( $payload, (string) $relative_path ),
+					'source_path'   => $directory . '/' . ltrim( (string) $relative_path, '/' ),
+					'payload'       => $payload,
+				);
+			}
+		}
+
+		return $artifacts;
+	}
+
 	/**
 	 * Return the decoded file map for a first-class artifact directory.
 	 *
@@ -68,5 +131,13 @@ final class AgentBundleArtifactDefinitions {
 			BundleSchema::SEED_QUEUES_DIR   => $directory->seed_queues(),
 			default                         => array(),
 		};
+	}
+
+	private static function normalize_artifact_type( string $type ): string {
+		$type       = strtolower( trim( str_replace( '\\', '/', $type ) ) );
+		$normalized = preg_replace( '/[^a-z0-9_\.\/-]+/', '', $type );
+		$normalized = preg_replace( '#/+#', '/', is_string( $normalized ) ? $normalized : '' );
+
+		return trim( is_string( $normalized ) ? $normalized : '', '/' );
 	}
 }

--- a/inc/Engine/Bundle/AgentBundleArtifactPayloads.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactPayloads.php
@@ -33,7 +33,9 @@ final class AgentBundleArtifactPayloads {
 	public static function flow_payload( array $flow, string $portable_slug, ?array $installed_payload = null ): array {
 		$scheduling        = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
 		$run_artifacts     = self::flow_run_artifacts( $flow, $scheduling );
-		$scheduling_policy = self::flow_scheduling_policy( $scheduling );
+		$scheduling_policy = is_string( $installed_payload['scheduling_policy'] ?? null )
+			? $installed_payload['scheduling_policy']
+			: self::flow_scheduling_policy( $scheduling );
 
 		$payload = array(
 			'portable_slug'     => $portable_slug,

--- a/inc/Engine/Bundle/AgentBundleArtifactPayloads.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactPayloads.php
@@ -22,6 +22,14 @@ final class AgentBundleArtifactPayloads {
 		);
 	}
 
+	public static function pipeline_document_payload( array $pipeline, string $portable_slug ): array {
+		return array(
+			'portable_slug'   => $portable_slug,
+			'pipeline_name'   => (string) ( $pipeline['name'] ?? '' ),
+			'pipeline_config' => is_array( $pipeline['steps'] ?? null ) ? $pipeline['steps'] : array(),
+		);
+	}
+
 	public static function flow_payload( array $flow, string $portable_slug, ?array $installed_payload = null ): array {
 		$scheduling        = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
 		$run_artifacts     = self::flow_run_artifacts( $flow, $scheduling );
@@ -43,6 +51,22 @@ final class AgentBundleArtifactPayloads {
 		return $payload;
 	}
 
+	public static function flow_document_payload( array $flow, string $portable_slug ): array {
+		return self::flow_payload(
+			array(
+				'flow_name'         => (string) ( $flow['name'] ?? '' ),
+				'flow_config'       => is_array( $flow['steps'] ?? null ) ? $flow['steps'] : array(),
+				'scheduling_config' => array(
+					'enabled'   => 'manual' !== (string) ( $flow['schedule'] ?? 'manual' ),
+					'interval'  => (string) ( $flow['schedule'] ?? 'manual' ),
+					'max_items' => is_array( $flow['max_items'] ?? null ) ? $flow['max_items'] : array(),
+				),
+				'run_artifacts'     => BundleSchema::normalize_run_artifact_egress_policy( $flow['run_artifacts'] ?? array() ),
+			),
+			$portable_slug
+		);
+	}
+
 	private static function flow_run_artifacts( array $flow, array $scheduling ): array {
 		return BundleSchema::normalize_run_artifact_egress_policy( $flow['run_artifacts'] ?? $scheduling['run_artifacts'] ?? array() );
 	}
@@ -59,12 +83,17 @@ final class AgentBundleArtifactPayloads {
 	}
 
 	private static function flow_config_without_runtime_queues( array $flow_config ): array {
-		foreach ( $flow_config as &$step ) {
+		$normalized = array();
+		foreach ( $flow_config as $flow_step_id => $step ) {
 			if ( is_array( $step ) ) {
 				unset( $step['prompt_queue'], $step['config_patch_queue'], $step['queue_mode'], $step['_queue_consume_revision'] );
+				unset( $step['pipeline_id'], $step['flow_id'], $step['flow_step_id'] );
 				unset( $step['handler_config']['max_items'] );
 				if ( empty( $step['handler_config'] ) ) {
 					unset( $step['handler_config'] );
+				}
+				if ( isset( $step['pipeline_step_id'] ) ) {
+					$step['pipeline_step_id'] = self::normalize_artifact_step_id( (string) $step['pipeline_step_id'] );
 				}
 				if ( is_array( $step['handler_configs'] ?? null ) ) {
 					foreach ( $step['handler_configs'] as $handler_slug => &$handler_config ) {
@@ -81,10 +110,20 @@ final class AgentBundleArtifactPayloads {
 					}
 				}
 			}
-		}
-		unset( $step );
 
-		return $flow_config;
+			$normalized[ self::normalize_artifact_step_id( (string) $flow_step_id ) ] = $step;
+		}
+		ksort( $normalized, SORT_STRING );
+
+		return $normalized;
+	}
+
+	private static function normalize_artifact_step_id( string $step_id ): string {
+		$normalized = preg_replace( '/^\d+_/', '', $step_id );
+		$normalized = is_string( $normalized ) ? $normalized : $step_id;
+		$normalized = preg_replace( '/_\d+$/', '', $normalized );
+
+		return is_string( $normalized ) && '' !== $normalized ? $normalized : $step_id;
 	}
 
 	private static function flow_runtime_overlays( array $flow, ?array $installed_payload = null ): array {

--- a/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
+++ b/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
@@ -22,10 +22,9 @@ final class AgentBundleInstalledArtifact {
 	private ?string $installed_hash;
 	private ?string $current_hash;
 	private mixed $installed_payload;
-	private string $status;
 	private string $installed_at;
 	private string $updated_at;
-	private \WP_Agent_Package_Installed_Artifact $package_artifact;
+	private object $package_artifact;
 
 	public function __construct(
 		string $bundle_slug,
@@ -47,7 +46,6 @@ final class AgentBundleInstalledArtifact {
 		$this->installed_hash    = self::optional_string( $installed_hash );
 		$this->current_hash      = self::optional_string( $current_hash );
 		$this->installed_payload = $installed_payload;
-		$this->status            = AgentBundleArtifactStatus::classify( $this->installed_hash, $this->current_hash );
 		$this->installed_at      = self::non_empty_string( $installed_at, 'installed_at' );
 		$this->updated_at        = self::non_empty_string( $updated_at, 'updated_at' );
 		$this->package_artifact  = self::build_package_artifact(
@@ -155,7 +153,7 @@ final class AgentBundleInstalledArtifact {
 	}
 
 	public function to_array(): array {
-		$row = self::from_package_artifact_array( $this->package_artifact->to_array() );
+		$row = self::from_package_artifact_array( call_user_func( array( $this->package_artifact, 'to_array' ) ) );
 		if ( null !== $this->installed_payload ) {
 			$row['installed_payload'] = $this->installed_payload;
 		}
@@ -165,7 +163,7 @@ final class AgentBundleInstalledArtifact {
 	/**
 	 * Returns the underlying Agents API package artifact snapshot.
 	 */
-	public function package_artifact(): \WP_Agent_Package_Installed_Artifact {
+	public function package_artifact(): object {
 		return $this->package_artifact;
 	}
 
@@ -209,8 +207,10 @@ final class AgentBundleInstalledArtifact {
 		return $path;
 	}
 
-	private static function build_package_artifact( string $bundle_slug, string $bundle_version, string $artifact_type, string $artifact_id, string $source_path, ?string $installed_hash, ?string $current_hash, string $installed_at, string $updated_at, mixed $installed_payload ): \WP_Agent_Package_Installed_Artifact {
-		return new \WP_Agent_Package_Installed_Artifact(
+	private static function build_package_artifact( string $bundle_slug, string $bundle_version, string $artifact_type, string $artifact_id, string $source_path, ?string $installed_hash, ?string $current_hash, string $installed_at, string $updated_at, mixed $installed_payload ): object {
+		$artifact_class = 'WP_Agent_Package_Installed_Artifact';
+
+		return new $artifact_class(
 			array(
 				'package_slug'      => $bundle_slug,
 				'package_version'   => $bundle_version,

--- a/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
+++ b/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
@@ -170,13 +170,16 @@ final class AgentBundleInstalledArtifact {
 	}
 
 	private static function validate_artifact_type( string $type ): string {
-		$type       = strtolower( trim( str_replace( '\\', '/', self::non_empty_string( $type, 'artifact_type' ) ) ) );
+		$type       = AgentBundleArtifactDefinitions::bundle_artifact_type( self::non_empty_string( $type, 'artifact_type' ) );
 		$normalized = preg_replace( '/[^a-z0-9_\.\/-]+/', '', $type );
 		$normalized = preg_replace( '#/+#', '/', is_string( $normalized ) ? $normalized : '' );
 		$normalized = trim( is_string( $normalized ) ? $normalized : '', '/' );
 
 		if ( '' === $normalized || $normalized !== $type ) {
 			throw new BundleValidationException( 'installed bundle artifact_type must be a normalized artifact type.' );
+		}
+		if ( ! in_array( $normalized, BundleSchema::artifact_types(), true ) ) {
+			throw new BundleValidationException( 'installed bundle artifact_type must be one of the registered bundle artifact types.' );
 		}
 
 		return $normalized;
@@ -246,15 +249,10 @@ final class AgentBundleInstalledArtifact {
 	}
 
 	private static function package_artifact_type( string $type ): string {
-		if ( str_contains( $type, '/' ) ) {
-			return $type;
-		}
-
-		return 'datamachine/' . str_replace( '_', '-', $type );
+		return AgentBundleArtifactDefinitions::package_artifact_type( $type );
 	}
 
 	private static function bundle_artifact_type( string $type ): string {
-		$type = str_starts_with( $type, 'datamachine/' ) ? substr( $type, strlen( 'datamachine/' ) ) : $type;
-		return str_replace( '-', '_', $type );
+		return AgentBundleArtifactDefinitions::bundle_artifact_type( $type );
 	}
 }

--- a/inc/Engine/Bundle/AgentBundleLifecycleProjection.php
+++ b/inc/Engine/Bundle/AgentBundleLifecycleProjection.php
@@ -183,35 +183,12 @@ final class AgentBundleLifecycleProjection {
 
 	/** @return array<int,array<string,mixed>> */
 	public static function bundle_file_artifacts( array $bundle ): array {
-		$artifacts = array();
-		$files     = is_array( $bundle['artifact_files'] ?? null ) ? $bundle['artifact_files'] : array();
-
-		foreach ( AgentBundleArtifactDefinitions::file_artifacts() as $directory => $definition ) {
-			foreach ( is_array( $files[ $directory ] ?? null ) ? $files[ $directory ] : array() as $relative_path => $payload ) {
-				$artifact_id = is_array( $payload ) && is_string( $payload['artifact_id'] ?? null )
-					? (string) $payload['artifact_id']
-					: self::artifact_id_from_relative_path( (string) $relative_path );
-
-				$artifacts[] = array(
-					'artifact_type' => $definition['artifact_type'],
-					'artifact_id'   => $artifact_id,
-					'source_path'   => $directory . '/' . ltrim( (string) $relative_path, '/' ),
-					'payload'       => $payload,
-				);
-			}
-		}
-
-		return $artifacts;
+		return AgentBundleArtifactDefinitions::file_artifact_rows_from_bundle( $bundle );
 	}
 
 	/** @return string[] */
 	private static function bundle_file_artifact_types(): array {
 		return AgentBundleArtifactDefinitions::file_artifact_types();
-	}
-
-	private static function artifact_id_from_relative_path( string $relative_path ): string {
-		$relative_path = preg_replace( '/\.(json|md|txt)$/i', '', $relative_path );
-		return null === $relative_path ? '' : $relative_path;
 	}
 
 	private static function current_payload_from_record( ?array $record ): mixed {

--- a/inc/Engine/Bundle/AgentBundleLifecycleProjection.php
+++ b/inc/Engine/Bundle/AgentBundleLifecycleProjection.php
@@ -162,7 +162,7 @@ final class AgentBundleLifecycleProjection {
 				);
 			}
 			if ( in_array( $type, self::bundle_file_artifact_types(), true ) ) {
-				$payload = self::current_payload_from_record( is_array( $record ) ? $record : null );
+				$payload = self::current_payload_from_record( $record );
 				if ( null !== $payload ) {
 					$artifacts[] = array(
 						'artifact_type' => $type,

--- a/inc/Engine/Bundle/AgentBundleRuntimeDrift.php
+++ b/inc/Engine/Bundle/AgentBundleRuntimeDrift.php
@@ -191,7 +191,7 @@ final class AgentBundleRuntimeDrift {
 	}
 
 	private static function scheduling_preview( array $scheduling ): array {
-		$preview = array(
+		$preview       = array(
 			'enabled'   => (bool) ( $scheduling['enabled'] ?? false ),
 			'interval'  => (string) ( $scheduling['interval'] ?? 'manual' ),
 			'max_items' => is_array( $scheduling['max_items'] ?? null ) ? $scheduling['max_items'] : array(),

--- a/inc/Engine/Bundle/AgentBundleRuntimeDrift.php
+++ b/inc/Engine/Bundle/AgentBundleRuntimeDrift.php
@@ -191,11 +191,17 @@ final class AgentBundleRuntimeDrift {
 	}
 
 	private static function scheduling_preview( array $scheduling ): array {
-		return array(
+		$preview = array(
 			'enabled'   => (bool) ( $scheduling['enabled'] ?? false ),
 			'interval'  => (string) ( $scheduling['interval'] ?? 'manual' ),
 			'max_items' => is_array( $scheduling['max_items'] ?? null ) ? $scheduling['max_items'] : array(),
 		);
+		$run_artifacts = BundleSchema::normalize_run_artifact_egress_policy( $scheduling['run_artifacts'] ?? array() );
+		if ( ! empty( $run_artifacts ) ) {
+			$preview['run_artifacts'] = $run_artifacts;
+		}
+
+		return $preview;
 	}
 
 	private static function list_depth( mixed $value ): int {

--- a/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
@@ -57,29 +57,31 @@ final class AgentBundleUpgradePlanner {
 		}
 
 		foreach ( $bundle->pipelines() as $pipeline ) {
+			$document    = $pipeline->to_array();
 			$artifacts[] = array(
 				'artifact_type' => 'pipeline',
 				'artifact_id'   => $pipeline->slug(),
 				'source_path'   => BundleSchema::PIPELINES_DIR . '/' . $pipeline->slug() . '.json',
-				'payload'       => $pipeline->to_array(),
+				'payload'       => AgentBundleArtifactPayloads::pipeline_document_payload( $document, $pipeline->slug() ),
 			);
 		}
 
 		foreach ( $bundle->flows() as $flow ) {
+			$document    = $flow->to_array();
 			$artifacts[] = array(
 				'artifact_type' => 'flow',
 				'artifact_id'   => $flow->slug(),
 				'source_path'   => BundleSchema::FLOWS_DIR . '/' . $flow->slug() . '.json',
-				'payload'       => $flow->to_array(),
+				'payload'       => AgentBundleArtifactPayloads::flow_document_payload( $document, $flow->slug() ),
 			);
 		}
 
-		foreach ( self::materialized_artifact_directories() as $directory => $type ) {
+		foreach ( AgentBundleArtifactDefinitions::file_artifacts() as $directory => $definition ) {
 			$method = str_replace( '-', '_', $directory );
 			foreach ( $bundle->{$method}() as $relative_path => $payload ) {
 				$artifacts[] = array(
-					'artifact_type' => $type,
-					'artifact_id'   => self::artifact_id_from_payload( $payload, (string) $relative_path ),
+					'artifact_type' => $definition['artifact_type'],
+					'artifact_id'   => AgentBundleArtifactDefinitions::artifact_id_from_payload( $payload, (string) $relative_path ),
 					'source_path'   => $directory . '/' . $relative_path,
 					'payload'       => $payload,
 				);
@@ -91,30 +93,6 @@ final class AgentBundleUpgradePlanner {
 		}
 
 		return $artifacts;
-	}
-
-	/** @return array<string,string> */
-	private static function materialized_artifact_directories(): array {
-		return array(
-			BundleSchema::PROMPTS_DIR       => 'prompt',
-			BundleSchema::RUBRICS_DIR       => 'rubric',
-			BundleSchema::TOOL_POLICIES_DIR => 'tool_policy',
-			BundleSchema::AUTH_REFS_DIR     => 'auth_ref',
-			BundleSchema::SEED_QUEUES_DIR   => 'seed_queue',
-		);
-	}
-
-	private static function artifact_id_from_relative_path( string $relative_path ): string {
-		$relative_path = preg_replace( '/\.(json|md|txt)$/i', '', $relative_path );
-		return null === $relative_path ? '' : $relative_path;
-	}
-
-	private static function artifact_id_from_payload( mixed $payload, string $relative_path ): string {
-		if ( is_array( $payload ) && is_string( $payload['artifact_id'] ?? null ) && '' !== trim( $payload['artifact_id'] ) ) {
-			return (string) $payload['artifact_id'];
-		}
-
-		return self::artifact_id_from_relative_path( $relative_path );
 	}
 
 	/**
@@ -140,7 +118,7 @@ final class AgentBundleUpgradePlanner {
 			$converted[] = array_merge(
 				$row,
 				array(
-					'artifact_type' => self::package_artifact_type( $artifact_type ),
+					'artifact_type' => AgentBundleArtifactDefinitions::package_artifact_type( $artifact_type ),
 					'artifact_id'   => $artifact_id,
 					'source'        => (string) ( $row['source_path'] ?? ( $row['source'] ?? '' ) ),
 				)
@@ -151,21 +129,11 @@ final class AgentBundleUpgradePlanner {
 	}
 
 	public static function package_artifact_type( string $type ): string {
-		if ( str_contains( $type, '/' ) ) {
-			return $type;
-		}
-
-		return 'datamachine/' . str_replace( '_', '-', $type );
+		return AgentBundleArtifactDefinitions::package_artifact_type( $type );
 	}
 
 	public static function bundle_artifact_type( string $type ): string {
-		if ( str_starts_with( $type, 'datamachine-extension/' ) ) {
-			return substr( $type, strlen( 'datamachine-extension/' ) );
-		}
-
-		$type = str_starts_with( $type, 'datamachine/' ) ? substr( $type, strlen( 'datamachine/' ) ) : $type;
-
-		return str_replace( '-', '_', $type );
+		return AgentBundleArtifactDefinitions::bundle_artifact_type( $type );
 	}
 
 	private static function bundle_buckets_from_package_plan( \WP_Agent_Package_Update_Plan $plan ): array {

--- a/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
@@ -26,7 +26,8 @@ final class AgentBundleUpgradePlanner {
 	 * @param array<string,mixed>                                         $metadata Optional plan metadata.
 	 */
 	public static function plan( array $installed_artifacts, array $current_artifacts, array $target_artifacts, array $metadata = array() ): AgentBundleUpgradePlan {
-		$plan = \WP_Agent_Package_Update_Planner::plan(
+		$planner_class = 'WP_Agent_Package_Update_Planner';
+		$plan          = $planner_class::plan(
 			self::package_artifacts( $installed_artifacts ),
 			self::package_artifacts( $current_artifacts ),
 			self::package_artifacts( $target_artifacts ),
@@ -105,9 +106,6 @@ final class AgentBundleUpgradePlanner {
 		$converted = array();
 		foreach ( $artifacts as $artifact ) {
 			$row = $artifact instanceof AgentBundleInstalledArtifact ? $artifact->to_array() : $artifact;
-			if ( ! is_array( $row ) ) {
-				continue;
-			}
 
 			$artifact_type = (string) ( $row['artifact_type'] ?? '' );
 			$artifact_id   = (string) ( $row['artifact_id'] ?? '' );
@@ -136,9 +134,9 @@ final class AgentBundleUpgradePlanner {
 		return AgentBundleArtifactDefinitions::bundle_artifact_type( $type );
 	}
 
-	private static function bundle_buckets_from_package_plan( \WP_Agent_Package_Update_Plan $plan ): array {
+	private static function bundle_buckets_from_package_plan( object $plan ): array {
 		$buckets = array();
-		foreach ( $plan->get_buckets() as $bucket => $entries ) {
+		foreach ( call_user_func( array( $plan, 'get_buckets' ) ) as $bucket => $entries ) {
 			$buckets[ $bucket ] = array_map( array( self::class, 'bundle_entry_from_package_entry' ), $entries );
 		}
 

--- a/inc/Engine/Bundle/AgentPackageProjection.php
+++ b/inc/Engine/Bundle/AgentPackageProjection.php
@@ -94,39 +94,52 @@ final class AgentPackageProjection {
 
 		foreach ( $directory->pipelines() as $pipeline ) {
 			$document    = $pipeline->to_array();
+			$payload     = AgentBundleArtifactPayloads::pipeline_document_payload( $document, (string) $document['slug'] );
 			$artifacts[] = self::artifact(
 				'datamachine/pipeline',
 				(string) $document['slug'],
 				(string) $document['name'],
 				BundleSchema::PIPELINES_DIR . '/' . $document['slug'] . '.json',
-				array( 'step_count' => count( is_array( $document['steps'] ?? null ) ? $document['steps'] : array() ) )
+				array( 'step_count' => count( is_array( $document['steps'] ?? null ) ? $document['steps'] : array() ) ),
+				array(),
+				$payload
 			);
 		}
 
 		foreach ( $directory->flows() as $flow ) {
-			$document    = $flow->to_array();
+			$document      = $flow->to_array();
+			$payload       = AgentBundleArtifactPayloads::flow_document_payload( $document, (string) $document['slug'] );
+			$run_artifacts = BundleSchema::normalize_run_artifact_egress_policy( $document['run_artifacts'] ?? array() );
+			$meta          = array(
+				'pipeline_slug' => (string) ( $document['pipeline_slug'] ?? '' ),
+				'step_count'    => count( is_array( $document['steps'] ?? null ) ? $document['steps'] : array() ),
+			);
+			if ( ! empty( $run_artifacts ) ) {
+				$meta['run_artifacts'] = $run_artifacts;
+			}
 			$artifacts[] = self::artifact(
 				'datamachine/flow',
 				(string) $document['slug'],
 				(string) $document['name'],
 				BundleSchema::FLOWS_DIR . '/' . $document['slug'] . '.json',
-				array(
-					'pipeline_slug' => (string) ( $document['pipeline_slug'] ?? '' ),
-					'step_count'    => count( is_array( $document['steps'] ?? null ) ? $document['steps'] : array() ),
-				)
+				$meta,
+				array(),
+				$payload
 			);
 		}
 
 		foreach ( AgentBundleArtifactDefinitions::file_artifacts() as $directory_name => $definition ) {
 			$files = AgentBundleArtifactDefinitions::files_from_directory( $directory, $directory_name );
 			foreach ( $files as $relative_path => $payload ) {
-				$slug        = self::slug_from_path( (string) $relative_path );
+				$slug        = AgentBundleArtifactDefinitions::artifact_id_from_payload( $payload, (string) $relative_path );
 				$artifacts[] = self::artifact(
 					$definition['package_type'],
 					$slug,
 					$slug,
 					$directory_name . '/' . ltrim( (string) $relative_path, '/' ),
-					array( 'payload_kind' => is_array( $payload ) ? 'json' : 'text' )
+					array( 'payload_kind' => is_array( $payload ) ? 'json' : 'text' ),
+					array(),
+					$payload
 				);
 			}
 		}
@@ -148,7 +161,8 @@ final class AgentPackageProjection {
 					'extension_artifact_type' => $artifact_type,
 					'payload_kind'            => 'json',
 				),
-				self::string_list( is_array( $artifact['requires'] ?? null ) ? $artifact['requires'] : array() )
+				self::string_list( is_array( $artifact['requires'] ?? null ) ? $artifact['requires'] : array() ),
+				$artifact['payload'] ?? null
 			);
 		}
 
@@ -165,7 +179,7 @@ final class AgentPackageProjection {
 	 * @param array<string,mixed> $meta   Artifact metadata.
 	 * @return array<string,mixed>
 	 */
-	private static function artifact( string $type, string $slug, string $label, string $source, array $meta = array(), array $requires = array() ): array {
+	private static function artifact( string $type, string $slug, string $label, string $source, array $meta = array(), array $requires = array(), mixed $payload = null ): array {
 		$artifact = array(
 			'type'   => $type,
 			'slug'   => $slug,
@@ -181,6 +195,10 @@ final class AgentPackageProjection {
 
 		if ( ! empty( $requires ) ) {
 			$artifact['requires'] = self::string_list( $requires );
+		}
+
+		if ( null !== $payload ) {
+			$artifact['checksum'] = AgentBundleArtifactHasher::hash( $payload );
 		}
 
 		return $artifact;
@@ -207,16 +225,4 @@ final class AgentPackageProjection {
 		return $normalized;
 	}
 
-	/**
-	 * Build an artifact slug from a package-relative path.
-	 *
-	 * @param string $path Relative path.
-	 * @return string
-	 */
-	private static function slug_from_path( string $path ): string {
-		$basename = basename( str_replace( '\\', '/', $path ) );
-		$slug     = preg_replace( '/\.[^.]+$/', '', $basename );
-
-		return is_string( $slug ) && '' !== $slug ? $slug : $basename;
-	}
 }

--- a/inc/Engine/Bundle/AgentPackageProjection.php
+++ b/inc/Engine/Bundle/AgentPackageProjection.php
@@ -18,12 +18,13 @@ final class AgentPackageProjection {
 	 * Build a package from a bundle directory value object.
 	 *
 	 * @param AgentBundleDirectory $directory Bundle directory.
-	 * @return \WP_Agent_Package
+	 * @return object
 	 */
-	public static function from_directory( AgentBundleDirectory $directory ): \WP_Agent_Package {
-		$manifest = $directory->manifest()->to_array();
+	public static function from_directory( AgentBundleDirectory $directory ): object {
+		$manifest      = $directory->manifest()->to_array();
+		$package_class = 'WP_Agent_Package';
 
-		return \WP_Agent_Package::from_array(
+		return $package_class::from_array(
 			array(
 				'slug'         => (string) $manifest['bundle_slug'],
 				'version'      => (string) $manifest['bundle_version'],
@@ -39,9 +40,9 @@ final class AgentPackageProjection {
 	 * Build a package from a bundle array.
 	 *
 	 * @param array<string,mixed> $bundle Legacy bundle array.
-	 * @return \WP_Agent_Package
+	 * @return object
 	 */
-	public static function from_array_bundle( array $bundle ): \WP_Agent_Package {
+	public static function from_array_bundle( array $bundle ): object {
 		return self::from_directory( AgentBundleArrayAdapter::from_array_bundle( $bundle ) );
 	}
 
@@ -179,7 +180,15 @@ final class AgentPackageProjection {
 	 * @param array<string,mixed> $meta   Artifact metadata.
 	 * @return array<string,mixed>
 	 */
-	private static function artifact( string $type, string $slug, string $label, string $source, array $meta = array(), array $requires = array(), mixed $payload = null ): array {
+	private static function artifact(
+		string $type,
+		string $slug,
+		string $label,
+		string $source,
+		array $meta = array(),
+		array $requires = array(),
+		mixed $payload = null
+	): array {
 		$artifact = array(
 			'type'   => $type,
 			'slug'   => $slug,

--- a/inc/Engine/Bundle/AgentPackageProjection.php
+++ b/inc/Engine/Bundle/AgentPackageProjection.php
@@ -233,5 +233,4 @@ final class AgentPackageProjection {
 
 		return $normalized;
 	}
-
 }

--- a/inc/Engine/Bundle/BundleSchema.php
+++ b/inc/Engine/Bundle/BundleSchema.php
@@ -87,6 +87,7 @@ final class BundleSchema {
 
 	public const CORE_ARTIFACT_TYPES = array(
 		'agent',
+		'agent_config',
 		'memory',
 		'pipeline',
 		'flow',

--- a/tests/agent-bundle-installed-artifact-smoke.php
+++ b/tests/agent-bundle-installed-artifact-smoke.php
@@ -23,6 +23,13 @@ if ( ! function_exists( 'esc_html' ) ) {
 	}
 }
 
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $text ) {
+		$sanitized = preg_replace( '/[^a-z0-9]+/', '-', strtolower( (string) $text ) );
+		return trim( is_string( $sanitized ) ? $sanitized : '', '-' );
+	}
+}
+
 if ( ! function_exists( 'did_action' ) ) {
 	function did_action( $hook = '' ) {
 		return 0;

--- a/tests/agent-bundle-package-portability-smoke.php
+++ b/tests/agent-bundle-package-portability-smoke.php
@@ -269,7 +269,7 @@ datamachine_portability_assert( 'prompt artifact round-trips', isset( $imported_
 datamachine_portability_assert( 'rubric artifact round-trips', isset( $imported_by_key['datamachine/rubric:quality-rubric'] ) );
 datamachine_portability_assert( 'tool policy artifact round-trips', isset( $imported_by_key['datamachine/tool-policy:safe-tools'] ) );
 datamachine_portability_assert( 'auth ref artifact round-trips', isset( $imported_by_key['datamachine/auth-ref:github-default'] ) );
-datamachine_portability_assert( 'queue seed artifact round-trips', isset( $imported_by_key['datamachine/seed-queue:topic-loop'] ) );
+datamachine_portability_assert( 'queue seed artifact round-trips', isset( $imported_by_key['datamachine/queue-seed:topic-loop'] ) );
 datamachine_portability_assert( 'extension artifact round-trips with namespaced type', isset( $imported_by_key['intelligence/wiki-brain:portable'] ) );
 
 echo "\n[2] Agents API adoption plan preserves local edits while auto-applying clean artifacts:\n";

--- a/tests/agent-bundle-runtime-drift-smoke.php
+++ b/tests/agent-bundle-runtime-drift-smoke.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+require_once __DIR__ . '/../inc/Engine/Bundle/BundleSchema.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleRuntimeDrift.php';
 
 use DataMachine\Engine\Bundle\AgentBundleRuntimeDrift;
@@ -70,6 +71,9 @@ $target_flow = array(
 		'enabled'   => false,
 		'interval'  => 'manual',
 		'max_items' => array( 'fetch' => 5 ),
+		'run_artifacts' => array(
+			'completion_assertions' => array( 'egress' => array( 'artifact', 'bundle-file' ) ),
+		),
 	),
 );
 
@@ -86,6 +90,7 @@ agent_bundle_runtime_drift_assert( array( 'mcp' => 5 ) === ( $preview['steps'][0
 agent_bundle_runtime_drift_assert( true === ( $preview['scheduling']['changed'] ?? null ), 'scheduling drift is reported', $failures, $passes );
 agent_bundle_runtime_drift_assert( array( 'fetch' => 50 ) === ( $preview['scheduling']['current']['max_items'] ?? null ), 'current scheduling max_items is reported', $failures, $passes );
 agent_bundle_runtime_drift_assert( array( 'fetch' => 5 ) === ( $preview['scheduling']['target']['max_items'] ?? null ), 'target scheduling max_items is reported', $failures, $passes );
+agent_bundle_runtime_drift_assert( array( 'artifact', 'bundle-file' ) === ( $preview['scheduling']['target']['run_artifacts']['completion_assertions']['egress'] ?? null ), 'target run artifact policy is reported with scheduling drift', $failures, $passes );
 
 $preserved_config = $current_flow['flow_config'];
 agent_bundle_runtime_drift_assert( 2 === count( $preserved_config['88_fetch_2']['config_patch_queue'] ), 'default install leaves existing queue untouched', $failures, $passes );

--- a/tests/agents-api-smoke-helpers.php
+++ b/tests/agents-api-smoke-helpers.php
@@ -76,6 +76,10 @@ function esc_html( string $value ): string {
 	return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
 }
 
+function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+	return json_encode( $data, $options, $depth );
+}
+
 function __( string $text, string $domain = 'default' ): string {
 	unset( $domain );
 	return $text;

--- a/tests/datamachine-package-artifacts-smoke.php
+++ b/tests/datamachine-package-artifacts-smoke.php
@@ -17,7 +17,15 @@ require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 agents_api_smoke_require_module();
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/register-agent-package-artifacts.php';
 
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
 use DataMachine\Core\Agents\AgentBundler;
+use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
+use DataMachine\Engine\Bundle\AgentBundleArtifactPayloads;
 use DataMachine\Engine\Bundle\AgentBundleDirectory;
 use DataMachine\Engine\Bundle\AgentBundleFlowFile;
 use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
@@ -162,6 +170,10 @@ agents_api_smoke_assert_equals( 'seed-queues/mgs-topic-loop.json', $artifacts['d
 agents_api_smoke_assert_equals( 'extensions/intelligence/wiki-brain/woocommerce.json', $artifacts['intelligence/wiki-brain:woocommerce']['source'] ?? '', 'namespaced plugin artifact projects with package-relative extension source', $failures, $passes );
 agents_api_smoke_assert_equals( 'extensions/legacy-plugin/seed.json', $artifacts['datamachine-extension/legacy_plugin_artifact:seed']['source'] ?? '', 'legacy plugin artifact maps to generic package namespace', $failures, $passes );
 agents_api_smoke_assert_equals( 'legacy_plugin_artifact', $artifacts['datamachine-extension/legacy_plugin_artifact:seed']['meta']['extension_artifact_type'] ?? '', 'legacy plugin artifact preserves bundle artifact type in metadata', $failures, $passes );
+$flow_document = $directory->flows()[0]->to_array();
+$flow_payload  = AgentBundleArtifactPayloads::flow_document_payload( $flow_document, 'daily-ingest-flow' );
+agents_api_smoke_assert_equals( AgentBundleArtifactHasher::hash( $flow_payload ), $artifacts['datamachine/flow:daily-ingest-flow']['checksum'] ?? '', 'flow package artifact checksum uses shared run-artifact-aware payload', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'artifact', 'bundle-file' ), $artifacts['datamachine/flow:daily-ingest-flow']['meta']['run_artifacts']['completion_assertions']['egress'] ?? array(), 'flow package artifact exposes normalized run artifact policy in metadata', $failures, $passes );
 
 echo "\n[3] Existing bundle paths can read package identity from WP_Agent_Package:\n";
 $array_bundle    = AgentBundleArrayAdapter::to_array_bundle( $directory );
@@ -190,5 +202,48 @@ agents_api_smoke_assert_equals( array( 'artifact', 'bundle-file' ), $lifecycle_a
 agents_api_smoke_assert_equals( true, str_contains( $service_source, 'AgentBundleLifecycleProjection' ), 'ability service uses shared lifecycle projection service', $failures, $passes );
 agents_api_smoke_assert_equals( true, str_contains( $service_source, '$this->projection->target_artifacts( $bundle' ), 'ability service plans through shared lifecycle projection', $failures, $passes );
 agents_api_smoke_assert_equals( true, str_contains( $command_source, '$this->projection()->target_artifacts( $bundle' ), 'CLI planning uses the same lifecycle projection', $failures, $passes );
+
+echo "\n[5] Direct WP_Agent_Package artifacts carry run-artifact-aware checksums into generic planning:\n";
+$base_payload   = array( 'run_artifacts' => array( 'completion_assertions' => array( 'egress' => array( 'artifact' ) ) ) );
+$target_payload = array( 'run_artifacts' => array( 'completion_assertions' => array( 'egress' => array( 'artifact', 'bundle-file' ) ) ) );
+$direct_package = WP_Agent_Package::from_array(
+	array(
+		'slug'      => 'direct-package-fixture',
+		'version'   => '2.0.0',
+		'agent'     => array( 'slug' => 'direct-agent', 'label' => 'Direct Agent' ),
+		'artifacts' => array(
+			array(
+				'type'     => 'datamachine/flow',
+				'slug'     => 'direct-flow',
+				'label'    => 'Direct flow',
+				'source'   => 'flows/direct-flow.json',
+				'checksum' => AgentBundleArtifactHasher::hash( $target_payload ),
+				'meta'     => array( 'run_artifacts' => $target_payload['run_artifacts'] ),
+			),
+		),
+	)
+);
+$direct_plan    = WP_Agent_Package_Update_Planner::plan(
+	array(
+		array(
+			'artifact_type'  => 'datamachine/flow',
+			'artifact_id'    => 'direct-flow',
+			'source'         => 'flows/direct-flow.json',
+			'installed_hash' => AgentBundleArtifactHasher::hash( $base_payload ),
+		),
+	),
+	array(
+		array(
+			'artifact_type' => 'datamachine/flow',
+			'artifact_id'   => 'direct-flow',
+			'source'        => 'flows/direct-flow.json',
+			'payload'       => $base_payload,
+		),
+	),
+	$direct_package->get_artifacts()
+);
+$direct_auto_apply = $direct_plan->get_bucket( 'auto_apply' )[0] ?? array();
+agents_api_smoke_assert_equals( 'datamachine/flow:direct-flow', $direct_auto_apply['artifact_key'] ?? '', 'direct WP_Agent_Package artifact participates in generic update planning', $failures, $passes );
+agents_api_smoke_assert_equals( AgentBundleArtifactHasher::hash( $target_payload ), $direct_auto_apply['target_hash'] ?? '', 'direct package checksum supplies target hash without legacy bundle payload', $failures, $passes );
 
 agents_api_smoke_finish( 'Data Machine package artifact projection', $failures, $passes );


### PR DESCRIPTION
## Summary
- centralize Data Machine bundle artifact type/source/id helpers and reuse them across package projection, lifecycle planning, upgrade planning, and installed artifact state
- make package projection emit `WP_Agent_Package_Artifact` checksums from the same run-artifact-aware payload builders used by bundle planning/import paths
- include flow `run_artifacts` in package metadata and runtime drift previews
- add direct `WP_Agent_Package` update-planner fixture coverage alongside bundle array/directory smokes

## Issues
- Fixes https://github.com/Extra-Chill/data-machine/issues/2340
- Fixes https://github.com/Extra-Chill/data-machine/issues/2262

## Testing
- `php tests/datamachine-package-artifacts-smoke.php`
- `php tests/agent-bundle-package-portability-smoke.php`
- `php tests/agent-bundle-upgrade-planner-smoke.php`
- `php tests/agent-bundle-runtime-drift-smoke.php`
- `php tests/run-artifact-egress-policy-smoke.php`
- `php tests/bundle-validate-inspect-smoke.php`
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `php tests/agent-bundle-installed-artifact-smoke.php`
- `vendor/bin/phpcs <changed files>`
- `git diff --check`

## Notes
- `homeboy test --path <worktree> --extension wordpress` did not reach PHPUnit because the lab offload checkout mounted without `vendor/autoload.php`, causing WordPress bootstrap to fail before tests ran.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the bundle/package convergence changes, added smoke coverage, and ran targeted verification; Chris remains responsible for review and merge.