### PR TITLE
Add Agents API workflow job bridge

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -259,6 +259,7 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\Job\GetJobsAbility();
 	new \DataMachine\Abilities\Job\DeleteJobsAbility();
 	new \DataMachine\Abilities\Job\ExecuteWorkflowAbility();
+	new \DataMachine\Abilities\Job\ExecuteAgentWorkflowAbility();
 	new \DataMachine\Abilities\Job\FlowHealthAbility();
 	new \DataMachine\Abilities\Job\ProblemFlowsAbility();
 	new \DataMachine\Abilities\Job\RecoverStuckJobsAbility();

--- a/docs/agents-api-workflow-bridge.md
+++ b/docs/agents-api-workflow-bridge.md
@@ -1,0 +1,41 @@
+# Agents API Workflow Bridge
+
+Data Machine exposes `datamachine/execute-agent-workflow` as the supported bridge for simple Agents API workflow specs.
+
+The bridge accepts a `WP_Agent_Workflow_Spec` array, passes execution to `WP_Agent_Workflow_Runner`, and records the run as a Data Machine direct job. It does not convert the spec into a Data Machine pipeline or implement a second workflow runner.
+
+## Supported Scope
+
+Supported workflow shape:
+
+- top-level `ability` steps;
+- top-level `agent` steps, via the Agents API `agents/chat` ability;
+- empty triggers or `on_demand` triggers;
+- runner inputs, metadata, run IDs, and `continue_on_error`.
+
+Unsupported workflow features fail before execution with a typed error. Data Machine does not bridge `foreach`, cron triggers, action triggers, branching, parallel execution, nested workflows, or consumer-defined step types through this ability.
+
+## Job Mapping
+
+Each run creates one Data Machine job with:
+
+- `pipeline_id`: `direct`;
+- `flow_id`: `direct`;
+- `source`: `agents_api_workflow`;
+- `label`: caller-provided `label` or `Agents API Workflow: <workflow_id>`.
+
+The job `engine_data` stores:
+
+- `agents_api_workflow.workflow_id` and `agents_api_workflow.run_id`;
+- the source `spec`, runner `inputs`, and runner `metadata`;
+- `workflow_run_result`, mirroring `WP_Agent_Workflow_Run_Result::to_array()`;
+- `step_outcomes`, `output`, and `error` for job reporting;
+- `artifacts` and `logs`, copied from `metadata.artifacts` and `metadata.logs` when the caller supplies them because `WP_Agent_Workflow_Run_Result` has no separate first-class artifact/log fields;
+- `provenance` identifying Agents API as the source, `WP_Agent_Workflow_Runner` as the executor, and Data Machine jobs as the recording surface.
+
+Runner status maps to Data Machine job status as follows:
+
+- `running` remains `processing`;
+- `succeeded` becomes `completed`;
+- `failed` becomes `failed - <error_code>`;
+- `skipped` becomes `failed - agents_api_workflow_skipped`.

--- a/inc/Abilities/Job/ExecuteAgentWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteAgentWorkflowAbility.php
@@ -168,7 +168,10 @@ class ExecuteAgentWorkflowAbility {
 					return new WP_Error(
 						'agents_api_workflow_trigger_unsupported',
 						sprintf( 'Data Machine can execute Agents API workflows on demand only; trigger at index %d uses `%s`.', $index, '' !== $type ? $type : 'unknown' ),
-						array( 'trigger_index' => $index, 'trigger_type' => $type )
+						array(
+							'trigger_index' => $index,
+							'trigger_type'  => $type,
+						)
 					);
 				}
 			}
@@ -180,7 +183,11 @@ class ExecuteAgentWorkflowAbility {
 				return new WP_Error(
 					'agents_api_workflow_step_unsupported',
 					sprintf( 'Data Machine can record Agents API workflow steps of type ability or agent only; step at index %d uses `%s`.', $index, '' !== $type ? $type : 'unknown' ),
-					array( 'step_index' => $index, 'step_type' => $type, 'supported_step_types' => self::SUPPORTED_STEP_TYPES )
+					array(
+						'step_index'           => $index,
+						'step_type'            => $type,
+						'supported_step_types' => self::SUPPORTED_STEP_TYPES,
+					)
 				);
 			}
 		}

--- a/inc/Abilities/Job/ExecuteAgentWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteAgentWorkflowAbility.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Execute Agents API Workflow ability.
+ *
+ * @package DataMachine\Abilities\Job
+ */
+
+namespace DataMachine\Abilities\Job;
+
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Runner;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec;
+use DataMachine\Core\AgentsApiWorkflowJobRecorder;
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+class ExecuteAgentWorkflowAbility {
+
+	use JobHelpers;
+
+	private const SUPPORTED_STEP_TYPES = array( 'ability', 'agent' );
+
+	public function __construct() {
+		$this->initDatabases();
+		$this->registerAbility();
+	}
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/execute-agent-workflow',
+				array(
+					'label'               => __( 'Execute Agents API Workflow', 'data-machine' ),
+					'description'         => __( 'Execute a simple Agents API workflow spec through the Agents API runner and record it as a Data Machine job.', 'data-machine' ),
+					'category'            => 'datamachine-jobs',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'spec' ),
+						'properties' => array(
+							'spec'              => array(
+								'type'        => 'object',
+								'description' => __( 'Agents API WP_Agent_Workflow_Spec array. Data Machine supports only top-level ability and agent steps here.', 'data-machine' ),
+							),
+							'inputs'            => array(
+								'type'        => 'object',
+								'description' => __( 'Inputs passed to WP_Agent_Workflow_Runner.', 'data-machine' ),
+							),
+							'run_id'            => array(
+								'type'        => array( 'string', 'null' ),
+								'description' => __( 'Optional caller-stable Agents API run ID.', 'data-machine' ),
+							),
+							'continue_on_error' => array(
+								'type'        => 'boolean',
+								'default'     => false,
+								'description' => __( 'Forwarded to WP_Agent_Workflow_Runner.', 'data-machine' ),
+							),
+							'metadata'          => array(
+								'type'        => 'object',
+								'description' => __( 'Optional metadata forwarded to the Agents API workflow result.', 'data-machine' ),
+							),
+							'label'             => array(
+								'type'        => array( 'string', 'null' ),
+								'description' => __( 'Optional Data Machine job label.', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'     => array( 'type' => 'boolean' ),
+							'job_id'      => array( 'type' => array( 'integer', 'null' ) ),
+							'run_id'      => array( 'type' => 'string' ),
+							'workflow_id' => array( 'type' => 'string' ),
+							'status'      => array( 'type' => 'string' ),
+							'steps'       => array( 'type' => 'array' ),
+							'output'      => array( 'type' => 'object' ),
+							'error'       => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Execute a simple Agents API workflow spec and record it as a Data Machine job.
+	 *
+	 * @param array $input Ability input.
+	 * @return array
+	 */
+	public function execute( array $input ): array {
+		$spec_array = $input['spec'] ?? null;
+		if ( ! is_array( $spec_array ) ) {
+			return $this->error_response( 'invalid_spec', 'spec must be an object.' );
+		}
+
+		$unsupported = $this->validateBridgeableSpec( $spec_array );
+		if ( is_wp_error( $unsupported ) ) {
+			return $this->error_response( $unsupported->get_error_code(), $unsupported->get_error_message(), $unsupported->get_error_data() );
+		}
+
+		if ( ! class_exists( WP_Agent_Workflow_Spec::class ) || ! class_exists( WP_Agent_Workflow_Runner::class ) ) {
+			return $this->error_response( 'agents_api_workflows_unavailable', 'Agents API workflow classes are unavailable.' );
+		}
+
+		$spec = WP_Agent_Workflow_Spec::from_array( $spec_array );
+		if ( is_wp_error( $spec ) ) {
+			return $this->error_response( $spec->get_error_code(), $spec->get_error_message(), $spec->get_error_data() );
+		}
+
+		$recorder = new AgentsApiWorkflowJobRecorder(
+			$this->db_jobs,
+			$spec->to_array(),
+			array(
+				'label'    => is_string( $input['label'] ?? null ) ? $input['label'] : null,
+				'user_id'  => get_current_user_id(),
+				'agent_id' => isset( $input['agent_id'] ) ? (int) $input['agent_id'] : null,
+			)
+		);
+
+		$options = array(
+			'continue_on_error' => ! empty( $input['continue_on_error'] ),
+			'metadata'          => is_array( $input['metadata'] ?? null ) ? $input['metadata'] : array(),
+		);
+		if ( is_string( $input['run_id'] ?? null ) && '' !== $input['run_id'] ) {
+			$options['run_id'] = $input['run_id'];
+		}
+
+		$result = ( new WP_Agent_Workflow_Runner( $recorder ) )->run(
+			$spec,
+			is_array( $input['inputs'] ?? null ) ? $input['inputs'] : array(),
+			$options
+		);
+
+		return array(
+			'success'     => $result->is_succeeded(),
+			'job_id'      => $recorder->get_job_id(),
+			'run_id'      => $result->get_run_id(),
+			'workflow_id' => $result->get_workflow_id(),
+			'status'      => $result->get_status(),
+			'steps'       => $result->get_steps(),
+			'output'      => $result->get_output(),
+			'error'       => $result->get_error(),
+		);
+	}
+
+	/**
+	 * Validate Data Machine's bridge subset without replacing the Agents API validator/runner.
+	 *
+	 * @param array $spec Workflow spec array.
+	 * @return true|WP_Error
+	 */
+	public function validateBridgeableSpec( array $spec ) {
+		$triggers = $spec['triggers'] ?? array();
+		if ( ! empty( $triggers ) ) {
+			foreach ( $triggers as $index => $trigger ) {
+				$type = is_array( $trigger ) ? (string) ( $trigger['type'] ?? '' ) : '';
+				if ( 'on_demand' !== $type ) {
+					return new WP_Error(
+						'agents_api_workflow_trigger_unsupported',
+						sprintf( 'Data Machine can execute Agents API workflows on demand only; trigger at index %d uses `%s`.', $index, '' !== $type ? $type : 'unknown' ),
+						array( 'trigger_index' => $index, 'trigger_type' => $type )
+					);
+				}
+			}
+		}
+
+		foreach ( (array) ( $spec['steps'] ?? array() ) as $index => $step ) {
+			$type = is_array( $step ) ? (string) ( $step['type'] ?? '' ) : '';
+			if ( ! in_array( $type, self::SUPPORTED_STEP_TYPES, true ) ) {
+				return new WP_Error(
+					'agents_api_workflow_step_unsupported',
+					sprintf( 'Data Machine can record Agents API workflow steps of type ability or agent only; step at index %d uses `%s`.', $index, '' !== $type ? $type : 'unknown' ),
+					array( 'step_index' => $index, 'step_type' => $type, 'supported_step_types' => self::SUPPORTED_STEP_TYPES )
+				);
+			}
+		}
+
+		return true;
+	}
+
+	private function error_response( string $code, string $message, $data = null ): array {
+		$response = array(
+			'success' => false,
+			'error'   => array(
+				'code'    => $code,
+				'message' => $message,
+			),
+		);
+
+		if ( null !== $data ) {
+			$response['error']['data'] = $data;
+		}
+
+		return $response;
+	}
+}

--- a/inc/Core/AgentsApiWorkflowJobRecorder.php
+++ b/inc/Core/AgentsApiWorkflowJobRecorder.php
@@ -117,31 +117,31 @@ class AgentsApiWorkflowJobRecorder implements WP_Agent_Workflow_Run_Recorder {
 		$this->jobs->store_engine_data(
 			$this->job_id,
 			array(
-				'job'                  => array(
+				'job'                 => array(
 					'job_id'     => $this->job_id,
 					'user_id'    => (int) ( $this->options['user_id'] ?? 0 ),
 					'created_at' => function_exists( 'current_time' ) ? current_time( 'mysql', true ) : gmdate( 'Y-m-d H:i:s' ),
 				),
-				'agents_api_workflow'  => array(
+				'agents_api_workflow' => array(
 					'workflow_id' => $result->get_workflow_id(),
 					'run_id'      => $result->get_run_id(),
 					'spec'        => $this->spec,
 					'inputs'      => $result->get_inputs(),
 					'metadata'    => $result->get_metadata(),
 				),
-				'workflow_run_result'  => $result->to_array(),
-				'step_outcomes'        => $result->get_steps(),
-				'output'               => $result->get_output(),
-				'artifacts'            => is_array( $result->get_metadata()['artifacts'] ?? null ) ? $result->get_metadata()['artifacts'] : array(),
-				'logs'                 => is_array( $result->get_metadata()['logs'] ?? null ) ? $result->get_metadata()['logs'] : array(),
-				'error'                => $result->get_error(),
-				'provenance'           => array(
-					'source'       => 'agents-api',
-					'bridge'       => 'datamachine/execute-agent-workflow',
-					'execution'    => 'WP_Agent_Workflow_Runner',
-					'recorded_as'  => 'datamachine_job',
-					'pipeline_id'  => 'direct',
-					'flow_id'      => 'direct',
+				'workflow_run_result' => $result->to_array(),
+				'step_outcomes'       => $result->get_steps(),
+				'output'              => $result->get_output(),
+				'artifacts'           => is_array( $result->get_metadata()['artifacts'] ?? null ) ? $result->get_metadata()['artifacts'] : array(),
+				'logs'                => is_array( $result->get_metadata()['logs'] ?? null ) ? $result->get_metadata()['logs'] : array(),
+				'error'               => $result->get_error(),
+				'provenance'          => array(
+					'source'      => 'agents-api',
+					'bridge'      => 'datamachine/execute-agent-workflow',
+					'execution'   => 'WP_Agent_Workflow_Runner',
+					'recorded_as' => 'datamachine_job',
+					'pipeline_id' => 'direct',
+					'flow_id'     => 'direct',
 				),
 			)
 		);

--- a/inc/Core/AgentsApiWorkflowJobRecorder.php
+++ b/inc/Core/AgentsApiWorkflowJobRecorder.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Data Machine job recorder for Agents API workflow runs.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Recorder;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Result;
+use DataMachine\Core\Database\Jobs\Jobs;
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Records an Agents API workflow run into the Data Machine jobs table.
+ */
+class AgentsApiWorkflowJobRecorder implements WP_Agent_Workflow_Run_Recorder {
+
+	private ?int $job_id = null;
+
+	public function __construct(
+		private Jobs $jobs,
+		private array $spec,
+		private array $options = array()
+	) {}
+
+	/**
+	 * Return the Data Machine job ID created for this run.
+	 */
+	public function get_job_id(): ?int {
+		return $this->job_id;
+	}
+
+	/**
+	 * Persist the start of the Agents API workflow run.
+	 *
+	 * @param WP_Agent_Workflow_Run_Result $result Initial run result.
+	 * @return string|WP_Error
+	 */
+	public function start( WP_Agent_Workflow_Run_Result $result ) {
+		$job_id = $this->jobs->create_job(
+			array_filter(
+				array(
+					'pipeline_id' => 'direct',
+					'flow_id'     => 'direct',
+					'source'      => 'agents_api_workflow',
+					'label'       => $this->options['label'] ?? sprintf( 'Agents API Workflow: %s', $result->get_workflow_id() ),
+					'user_id'     => (int) ( $this->options['user_id'] ?? 0 ),
+					'agent_id'    => isset( $this->options['agent_id'] ) ? (int) $this->options['agent_id'] : null,
+				),
+				static fn( $value ) => null !== $value
+			)
+		);
+
+		if ( ! $job_id ) {
+			return new WP_Error( 'datamachine_job_create_failed', 'Failed to create Data Machine job for Agents API workflow run.' );
+		}
+
+		$this->job_id = (int) $job_id;
+		$this->jobs->start_job( $this->job_id, JobStatus::PROCESSING );
+		$this->persist_result( $result );
+
+		return $result->get_run_id();
+	}
+
+	/**
+	 * Update the Data Machine job with the latest workflow result.
+	 *
+	 * @param WP_Agent_Workflow_Run_Result $result Latest run result.
+	 * @return true|WP_Error
+	 */
+	public function update( WP_Agent_Workflow_Run_Result $result ) {
+		if ( null === $this->job_id ) {
+			return new WP_Error( 'datamachine_job_missing', 'Data Machine job was not created for this Agents API workflow run.' );
+		}
+
+		$this->persist_result( $result );
+
+		$status = $this->map_status( $result );
+		if ( null !== $status ) {
+			$this->jobs->complete_job( $this->job_id, $status );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Look up a previously recorded run.
+	 *
+	 * @param string $run_id Agents API run ID.
+	 * @return WP_Agent_Workflow_Run_Result|null
+	 */
+	public function find( string $run_id ): ?WP_Agent_Workflow_Run_Result {
+		unset( $run_id );
+		return null;
+	}
+
+	/**
+	 * Return recent workflow runs.
+	 *
+	 * @param array $args Query arguments.
+	 * @return WP_Agent_Workflow_Run_Result[]
+	 */
+	public function recent( array $args = array() ): array {
+		unset( $args );
+		return array();
+	}
+
+	private function persist_result( WP_Agent_Workflow_Run_Result $result ): void {
+		if ( null === $this->job_id ) {
+			return;
+		}
+
+		$this->jobs->store_engine_data(
+			$this->job_id,
+			array(
+				'job'                  => array(
+					'job_id'     => $this->job_id,
+					'user_id'    => (int) ( $this->options['user_id'] ?? 0 ),
+					'created_at' => function_exists( 'current_time' ) ? current_time( 'mysql', true ) : gmdate( 'Y-m-d H:i:s' ),
+				),
+				'agents_api_workflow'  => array(
+					'workflow_id' => $result->get_workflow_id(),
+					'run_id'      => $result->get_run_id(),
+					'spec'        => $this->spec,
+					'inputs'      => $result->get_inputs(),
+					'metadata'    => $result->get_metadata(),
+				),
+				'workflow_run_result'  => $result->to_array(),
+				'step_outcomes'        => $result->get_steps(),
+				'output'               => $result->get_output(),
+				'artifacts'            => is_array( $result->get_metadata()['artifacts'] ?? null ) ? $result->get_metadata()['artifacts'] : array(),
+				'logs'                 => is_array( $result->get_metadata()['logs'] ?? null ) ? $result->get_metadata()['logs'] : array(),
+				'error'                => $result->get_error(),
+				'provenance'           => array(
+					'source'       => 'agents-api',
+					'bridge'       => 'datamachine/execute-agent-workflow',
+					'execution'    => 'WP_Agent_Workflow_Runner',
+					'recorded_as'  => 'datamachine_job',
+					'pipeline_id'  => 'direct',
+					'flow_id'      => 'direct',
+				),
+			)
+		);
+	}
+
+	private function map_status( WP_Agent_Workflow_Run_Result $result ): ?string {
+		if ( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED === $result->get_status() ) {
+			return JobStatus::COMPLETED;
+		}
+
+		if ( WP_Agent_Workflow_Run_Result::STATUS_FAILED === $result->get_status() ) {
+			$error  = $result->get_error();
+			$reason = (string) ( $error['code'] ?? 'agents_api_workflow_failed' );
+			return JobStatus::failed( $reason )->toString();
+		}
+
+		if ( WP_Agent_Workflow_Run_Result::STATUS_SKIPPED === $result->get_status() ) {
+			return JobStatus::failed( 'agents_api_workflow_skipped' )->toString();
+		}
+
+		return null;
+	}
+}

--- a/tests/agents-api-workflow-bridge-smoke.php
+++ b/tests/agents-api-workflow-bridge-smoke.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Pure-PHP smoke test for bridging Agents API workflows into Data Machine jobs.
+ *
+ * Run with: php tests/agents-api-workflow-bridge-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core\Database\Jobs {
+	class Jobs {
+		public array $jobs = array();
+		public array $engine_data = array();
+		public int $next_id = 100;
+
+		public function create_job( array $job_data ): int|false {
+			$job_id = $this->next_id++;
+			$this->jobs[ $job_id ] = array_merge( $job_data, array( 'status' => 'pending' ) );
+			return $job_id;
+		}
+
+		public function start_job( int $job_id, string $status = 'processing' ): bool {
+			$this->jobs[ $job_id ]['status'] = $status;
+			return true;
+		}
+
+		public function complete_job( int $job_id, string $status ): bool {
+			$this->jobs[ $job_id ]['status'] = $status;
+			return true;
+		}
+
+		public function store_engine_data( int $job_id, array $data ): bool {
+			$this->engine_data[ $job_id ] = $data;
+			return true;
+		}
+	}
+}
+
+namespace {
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data() { return $this->data; }
+	}
+
+	function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+	function __( string $text, string $domain = 'default' ): string { unset( $domain ); return $text; }
+	function doing_action( string $hook ): bool { unset( $hook ); return false; }
+	function did_action( string $hook ): int { unset( $hook ); return 1; }
+	function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void { unset( $hook, $callback, $priority, $accepted_args ); }
+	function apply_filters( string $hook, $value ) { unset( $hook ); return $value; }
+	function get_current_user_id(): int { return 7; }
+	function current_time( string $type, bool $gmt = false ): string { unset( $type, $gmt ); return '2026-05-28 00:00:00'; }
+
+	$GLOBALS['__abilities'] = array();
+	function wp_get_ability( string $name ) { return $GLOBALS['__abilities'][ $name ] ?? null; }
+
+	class Stub_Agent_Workflow_Ability {
+		public function __construct( private \Closure $handler ) {}
+		public function execute( array $input ) { return ( $this->handler )( $input ); }
+	}
+
+	require_once __DIR__ . '/../vendor/automattic/agents-api/src/Workflows/class-wp-agent-workflow-bindings.php';
+	require_once __DIR__ . '/../vendor/automattic/agents-api/src/Workflows/class-wp-agent-workflow-spec-validator.php';
+	require_once __DIR__ . '/../vendor/automattic/agents-api/src/Workflows/class-wp-agent-workflow-spec.php';
+	require_once __DIR__ . '/../vendor/automattic/agents-api/src/Workflows/class-wp-agent-workflow-run-result.php';
+	require_once __DIR__ . '/../vendor/automattic/agents-api/src/Workflows/class-wp-agent-workflow-run-recorder.php';
+	require_once __DIR__ . '/../vendor/automattic/agents-api/src/Workflows/class-wp-agent-workflow-runner.php';
+	require_once __DIR__ . '/../inc/Core/JobStatus.php';
+	require_once __DIR__ . '/../inc/Abilities/PermissionHelper.php';
+	require_once __DIR__ . '/../inc/Abilities/Job/JobHelpers.php';
+	require_once __DIR__ . '/../inc/Core/AgentsApiWorkflowJobRecorder.php';
+	require_once __DIR__ . '/../inc/Abilities/Job/ExecuteAgentWorkflowAbility.php';
+
+	$failures = array();
+	$passes   = 0;
+
+	function assert_agent_workflow_bridge_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+		if ( $expected === $actual ) {
+			++$passes;
+			echo "  PASS {$name}\n";
+			return;
+		}
+
+		$failures[] = $name;
+		echo "  FAIL {$name}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	}
+
+	class Agent_Workflow_Bridge_Harness extends \DataMachine\Abilities\Job\ExecuteAgentWorkflowAbility {
+		public function __construct() {}
+		public function set_jobs( \DataMachine\Core\Database\Jobs\Jobs $jobs ): void { $this->db_jobs = $jobs; }
+	}
+
+	echo "agents-api-workflow-bridge-smoke\n";
+
+	$GLOBALS['__abilities']['demo/uppercase'] = new Stub_Agent_Workflow_Ability(
+		static fn( array $input ): array => array( 'value' => strtoupper( (string) ( $input['text'] ?? '' ) ) )
+	);
+	$GLOBALS['__abilities']['agents/chat'] = new Stub_Agent_Workflow_Ability(
+		static fn( array $input ): array => array( 'reply' => sprintf( '%s: %s', $input['agent'] ?? '', $input['message'] ?? '' ) )
+	);
+
+	$jobs   = new \DataMachine\Core\Database\Jobs\Jobs();
+	$bridge = new Agent_Workflow_Bridge_Harness();
+	$bridge->set_jobs( $jobs );
+
+	$ability_result = $bridge->execute(
+		array(
+			'run_id' => 'run-ability-1',
+			'metadata' => array(
+				'artifacts' => array( array( 'name' => 'summary.json', 'type' => 'application/json' ) ),
+				'logs'      => array( array( 'level' => 'info', 'message' => 'started' ) ),
+			),
+			'spec'   => array(
+				'id'       => 'demo/ability-workflow',
+				'triggers' => array( array( 'type' => 'on_demand' ) ),
+				'inputs'   => array( 'text' => array( 'type' => 'string', 'required' => true ) ),
+				'steps'    => array(
+					array( 'id' => 'upper', 'type' => 'ability', 'ability' => 'demo/uppercase', 'args' => array( 'text' => '${inputs.text}' ) ),
+				),
+			),
+			'inputs' => array( 'text' => 'cook' ),
+		)
+	);
+
+	assert_agent_workflow_bridge_equals( true, $ability_result['success'], 'ability workflow succeeds', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 100, $ability_result['job_id'], 'ability workflow returns job id', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'run-ability-1', $ability_result['run_id'], 'ability workflow preserves Agents API run id', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'completed', $jobs->jobs[100]['status'], 'ability workflow maps success to completed job', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'agents_api_workflow', $jobs->jobs[100]['source'], 'ability workflow records source', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'demo/ability-workflow', $jobs->engine_data[100]['agents_api_workflow']['workflow_id'], 'ability workflow records workflow id', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'COOK', $jobs->engine_data[100]['step_outcomes'][0]['output']['value'], 'ability workflow records step output', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'summary.json', $jobs->engine_data[100]['artifacts'][0]['name'], 'ability workflow records metadata artifacts explicitly', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'started', $jobs->engine_data[100]['logs'][0]['message'], 'ability workflow records metadata logs explicitly', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'WP_Agent_Workflow_Runner', $jobs->engine_data[100]['provenance']['execution'], 'ability workflow records runner provenance', $failures, $passes );
+
+	$agent_result = $bridge->execute(
+		array(
+			'run_id' => 'run-agent-1',
+			'spec'   => array(
+				'id'    => 'demo/agent-workflow',
+				'steps' => array(
+					array( 'id' => 'ask', 'type' => 'agent', 'agent' => 'demo-agent', 'message' => 'hello' ),
+				),
+			),
+		)
+	);
+
+	assert_agent_workflow_bridge_equals( true, $agent_result['success'], 'agent workflow succeeds when agents/chat is registered', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 101, $agent_result['job_id'], 'agent workflow returns job id', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'demo-agent: hello', $jobs->engine_data[101]['step_outcomes'][0]['output']['reply'], 'agent workflow records agent step output', $failures, $passes );
+
+	$unsupported = $bridge->execute(
+		array(
+			'spec' => array(
+				'id'    => 'demo/foreach-workflow',
+				'steps' => array(
+					array( 'id' => 'each', 'type' => 'foreach', 'items' => array(), 'steps' => array( array( 'id' => 'inner', 'type' => 'ability', 'ability' => 'demo/uppercase' ) ) ),
+				),
+			),
+		)
+	);
+
+	assert_agent_workflow_bridge_equals( false, $unsupported['success'], 'unsupported foreach workflow fails clearly', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'agents_api_workflow_step_unsupported', $unsupported['error']['code'], 'unsupported step error is typed', $failures, $passes );
+
+	$trigger_unsupported = $bridge->execute(
+		array(
+			'spec' => array(
+				'id'       => 'demo/cron-workflow',
+				'triggers' => array( array( 'type' => 'cron', 'schedule' => 'hourly' ) ),
+				'steps'    => array( array( 'id' => 'upper', 'type' => 'ability', 'ability' => 'demo/uppercase' ) ),
+			),
+		)
+	);
+
+	assert_agent_workflow_bridge_equals( false, $trigger_unsupported['success'], 'unsupported trigger workflow fails clearly', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'agents_api_workflow_trigger_unsupported', $trigger_unsupported['error']['code'], 'unsupported trigger error is typed', $failures, $passes );
+
+	if ( $failures ) {
+		echo "\nFAILED: " . count( $failures ) . " agents-api workflow bridge assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$passes} agents-api workflow bridge assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- add `datamachine/execute-agent-workflow` for simple Agents API workflow specs
- delegate execution to `WP_Agent_Workflow_Runner` while recording runs as Data Machine direct jobs
- document supported step/trigger scope plus job provenance, output, artifact, log, and error mapping
- add a pure-PHP smoke test for ability and agent steps plus unsupported feature failures

Closes https://github.com/Extra-Chill/data-machine/issues/2339

## Verification
- `php tests/agents-api-workflow-bridge-smoke.php`
- `php tests/workflow-spec-contract-smoke.php`
- `php vendor/automattic/agents-api/tests/workflow-runner-smoke.php`
- `vendor/bin/phpcs data-machine.php inc/Abilities/Job/ExecuteAgentWorkflowAbility.php inc/Core/AgentsApiWorkflowJobRecorder.php tests/agents-api-workflow-bridge-smoke.php`

## Notes
- `homeboy test data-machine` was attempted twice, but the lab WP Codebox bootstrap failed before running tests because `/wordpress/wp-content/plugins/data-machine/vendor/autoload.php` was missing in the lab-mounted checkout.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the bridge, tests, docs, verification, and PR drafting; Chris remains responsible for review and merge.