### PR TITLE
fix: mark silent max-turn tool runs incomplete

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -224,22 +224,28 @@ class AgentsChatHandler {
 	 * @return array
 	 */
 	private function toCanonicalOutput( array $result ): array {
-		$metadata                = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
-		$metadata['datamachine'] = array_filter(
-			array(
-				'tool_calls'   => $result['tool_calls'] ?? null,
-				'conversation' => $result['conversation'] ?? null,
-				'max_turns'    => $result['max_turns'] ?? null,
-				'turn_number'  => $result['turn_number'] ?? null,
+		$metadata             = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
+		$datamachine_metadata = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
+		$datamachine_metadata = array_filter(
+			array_merge(
+				$datamachine_metadata,
+				array(
+					'tool_calls'   => $result['tool_calls'] ?? null,
+					'conversation' => $result['conversation'] ?? null,
+					'max_turns'    => $result['max_turns'] ?? null,
+					'turn_number'  => $result['turn_number'] ?? null,
+				)
 			),
 			static fn( $value ): bool => null !== $value
 		);
+		$metadata['datamachine'] = $datamachine_metadata;
+		$completed               = (bool) ( $datamachine_metadata['completed'] ?? $result['completed'] ?? true );
 
 		return array(
 			'session_id' => (string) ( $result['session_id'] ?? '' ),
 			'reply'      => (string) ( $result['response'] ?? '' ),
 			'messages'   => $this->toCanonicalMessages( $result['conversation'] ?? array() ),
-			'completed'  => (bool) ( $result['completed'] ?? true ),
+			'completed'  => $completed,
 			'metadata'   => $metadata,
 		);
 	}

--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -224,9 +224,9 @@ class AgentsChatHandler {
 	 * @return array
 	 */
 	private function toCanonicalOutput( array $result ): array {
-		$metadata             = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
-		$datamachine_metadata = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
-		$datamachine_metadata = array_filter(
+		$metadata                = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
+		$datamachine_metadata    = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
+		$datamachine_metadata    = array_filter(
 			array_merge(
 				$datamachine_metadata,
 				array(

--- a/inc/Engine/AI/DefaultAgentConversationCompletionPolicy.php
+++ b/inc/Engine/AI/DefaultAgentConversationCompletionPolicy.php
@@ -42,6 +42,16 @@ class DefaultAgentConversationCompletionPolicy implements WP_Agent_Conversation_
 	 * @inheritDoc
 	 */
 	public function recordNaturalCompletion( array $messages, string $assistant_text, array $runtime_context, int $turn_count ): WP_Agent_Conversation_Completion_Decision {
+		if ( $this->looksLikeToolActionText( $assistant_text ) ) {
+			return WP_Agent_Conversation_Completion_Decision::incomplete(
+				'AIConversationLoop: Assistant emitted tool action prose without a tool call, nudging continuation',
+				array(
+					'turn_count'           => $turn_count,
+					'continuation_message' => 'Your previous response described a tool action but did not make a valid tool call. Use the available tool call format for the action, or provide a final answer if no tool is needed.',
+				)
+			);
+		}
+
 		$evaluation = $this->assertions->evaluate( $runtime_context, $assistant_text );
 		if ( $evaluation['complete'] ) {
 			return WP_Agent_Conversation_Completion_Decision::complete(
@@ -63,5 +73,12 @@ class DefaultAgentConversationCompletionPolicy implements WP_Agent_Conversation_
 				'continuation_message' => DataMachineCompletionAssertions::buildNudge( $evaluation['missing'], $messages ),
 			)
 		);
+	}
+
+	/**
+	 * Detect internal tool-action prose that should not be treated as a final answer.
+	 */
+	private function looksLikeToolActionText( string $assistant_text ): bool {
+		return 1 === preg_match( '/^\s*AI ACTION\s*\(Turn\s+\d+\):\s*Executing\s+/i', $assistant_text );
 	}
 }

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -311,7 +311,7 @@ function datamachine_run_conversation(
 	// Substrate now surfaces turn_count, final_content, usage, and
 	// request_metadata directly on the result (agents-api#136). Keep DM-only
 	// diagnostics namespaced so the top level remains the Agents API result.
-	$datamachine_metadata = array(
+	$datamachine_metadata     = array(
 		'completed'       => 'budget_exceeded' !== ( $result['status'] ?? '' ),
 		'last_tool_calls' => $last_tool_calls,
 		'tool_calls'      => $all_tool_calls,
@@ -854,7 +854,7 @@ function datamachine_build_turn_runner(
 			}
 		}
 
-		$latest_messages = $messages;
+		$latest_messages              = $messages;
 		$latest_conversation_complete = $conversation_complete;
 
 		return array(

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -77,15 +77,16 @@ function datamachine_run_conversation(
 	// surfaces turn_count, final_content, usage, and request_metadata on the
 	// final result directly (see agents-api#136), so we only carry by-reference
 	// the things substrate doesn't track for us.
-	$last_tool_calls        = array();
-	$all_tool_calls         = array();
-	$tool_execution_results = array();
-	$completion_nudges      = array();
-	$last_request_metadata  = array();
-	$latest_messages        = $messages;
-	$latest_turn_count      = 0;
-	$runtime_tool_pending   = false;
-	$runtime_tool_requests  = array();
+	$last_tool_calls              = array();
+	$all_tool_calls               = array();
+	$tool_execution_results       = array();
+	$completion_nudges            = array();
+	$last_request_metadata        = array();
+	$latest_messages              = $messages;
+	$latest_turn_count            = 0;
+	$latest_conversation_complete = false;
+	$runtime_tool_pending         = false;
+	$runtime_tool_requests        = array();
 
 	// Base log context for consistent logging.
 	$base_log_context = array_filter(
@@ -187,6 +188,7 @@ function datamachine_run_conversation(
 		$last_request_metadata,
 		$latest_messages,
 		$latest_turn_count,
+		$latest_conversation_complete,
 		$runtime_tool_pending,
 		$runtime_tool_requests
 	);
@@ -314,6 +316,17 @@ function datamachine_run_conversation(
 		'last_tool_calls' => $last_tool_calls,
 		'tool_calls'      => $all_tool_calls,
 	);
+	$silent_max_turns_reached = ! $latest_conversation_complete
+		&& (int) ( $result['turn_count'] ?? 0 ) >= $turn_budget->ceiling()
+		&& 'budget_exceeded' !== ( $result['status'] ?? '' );
+	if ( $silent_max_turns_reached ) {
+		$datamachine_metadata['completed']         = false;
+		$datamachine_metadata['max_turns_reached'] = true;
+		$datamachine_metadata['warning']           = sprintf(
+			'Maximum conversation turns (%d) reached. Response may be incomplete.',
+			$turn_budget->ceiling()
+		);
+	}
 	if ( $runtime_tool_pending ) {
 		$datamachine_metadata['completed']                     = false;
 		$datamachine_metadata['runtime_tool_pending']          = true;
@@ -460,6 +473,7 @@ function datamachine_build_turn_runner(
 	array &$last_request_metadata,
 	array &$latest_messages,
 	int &$latest_turn_count,
+	bool &$latest_conversation_complete,
 	bool &$runtime_tool_pending,
 	array &$runtime_tool_requests
 ): callable {
@@ -481,6 +495,7 @@ function datamachine_build_turn_runner(
 		&$last_request_metadata,
 		&$latest_messages,
 		&$latest_turn_count,
+		&$latest_conversation_complete,
 		&$runtime_tool_pending,
 		&$runtime_tool_requests
 	): array {
@@ -840,6 +855,7 @@ function datamachine_build_turn_runner(
 		}
 
 		$latest_messages = $messages;
+		$latest_conversation_complete = $conversation_complete;
 
 		return array(
 			'messages'                     => $messages,

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -407,6 +407,59 @@ assert_runner_request( ! array_key_exists( 'tool_calls', $sandbox_result ), 'too
 assert_runner_request( 1 === count( $sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline function call executes a workspace tool' );
 assert_runner_request( 'README.md' === ( $sandbox_result['tool_execution_results'][0]['result']['result']['path'] ?? null ), 'sandbox/pipeline tool execution receives parsed parameters' );
 
+// 4a. Silent max-turn exhaustion after a tool turn is incomplete, not a final answer.
+$max_turn_tool_dispatch_count = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$max_turn_tool_dispatch_count ) {
+		++$max_turn_tool_dispatch_count;
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => '',
+				'tool_calls' => array(
+					array(
+						'id'         => 'max-turn-call-1',
+						'name'       => 'workspace_read',
+						'parameters' => array( 'path' => 'README.md' ),
+					),
+				),
+			),
+		);
+	}
+);
+
+$max_turn_tool_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'read the sandbox README and continue' ) ),
+	array(
+		'workspace_read' => array(
+			'name'        => 'workspace_read',
+			'description' => 'Read a file from the sandbox workspace.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(
+					'path' => array( 'type' => 'string' ),
+				),
+				'required'   => array( 'path' ),
+			),
+			'class'       => SandboxPipelineSmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	array( 'sandbox', 'chat' ),
+	array(),
+	1
+);
+$max_turn_tool_metadata = datamachine_conversation_metadata( $max_turn_tool_result );
+
+assert_runner_request( 1 === $max_turn_tool_dispatch_count, 'max-turn tool run stops after the allowed provider turn' );
+assert_runner_request( false === ( $max_turn_tool_metadata['completed'] ?? true ), 'max-turn tool run is not marked completed' );
+assert_runner_request( true === ( $max_turn_tool_metadata['max_turns_reached'] ?? null ), 'max-turn tool run sets max-turn diagnostic' );
+assert_runner_request( 1 === count( $max_turn_tool_result['tool_execution_results'] ?? array() ), 'max-turn tool run preserves executed tool result' );
+
 // 4b. Sandbox/pipeline runs also execute XML tool calls emitted as text.
 $xml_dispatch_count = 0;
 WpAiClientTestDouble::reset();

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -407,7 +407,46 @@ assert_runner_request( ! array_key_exists( 'tool_calls', $sandbox_result ), 'too
 assert_runner_request( 1 === count( $sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline function call executes a workspace tool' );
 assert_runner_request( 'README.md' === ( $sandbox_result['tool_execution_results'][0]['result']['result']['path'] ?? null ), 'sandbox/pipeline tool execution receives parsed parameters' );
 
-// 4a. Silent max-turn exhaustion after a tool turn is incomplete, not a final answer.
+// 4a. Textual AI ACTION prose is not accepted as a final answer.
+$text_action_dispatch_count = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$text_action_dispatch_count ) {
+		++$text_action_dispatch_count;
+
+		if ( 1 === $text_action_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content' => 'AI ACTION (Turn 4): Executing Workspace Read with parameters: repo: agents-api, path: README.md',
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content' => 'text action recovered',
+			),
+		);
+	}
+);
+
+$text_action_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'inspect the README' ) ),
+	array(),
+	'openai',
+	'gpt-smoke',
+	array( 'sandbox', 'chat' ),
+	array(),
+	3
+);
+
+assert_runner_request( 2 === $text_action_dispatch_count, 'textual AI ACTION response receives a continuation turn' );
+assert_runner_request( 'text action recovered' === ( $text_action_result['final_content'] ?? null ), 'textual AI ACTION run preserves recovered final answer' );
+assert_runner_request( str_contains( wp_json_encode( $text_action_result['messages'] ?? array() ), 'did not make a valid tool call' ), 'textual AI ACTION run adds a corrective nudge' );
+
+// 4b. Silent max-turn exhaustion after a tool turn is incomplete, not a final answer.
 $max_turn_tool_dispatch_count = 0;
 WpAiClientTestDouble::reset();
 WpAiClientTestDouble::set_response_callback(
@@ -460,7 +499,7 @@ assert_runner_request( false === ( $max_turn_tool_metadata['completed'] ?? true 
 assert_runner_request( true === ( $max_turn_tool_metadata['max_turns_reached'] ?? null ), 'max-turn tool run sets max-turn diagnostic' );
 assert_runner_request( 1 === count( $max_turn_tool_result['tool_execution_results'] ?? array() ), 'max-turn tool run preserves executed tool result' );
 
-// 4b. Sandbox/pipeline runs also execute XML tool calls emitted as text.
+// 4c. Sandbox/pipeline runs also execute XML tool calls emitted as text.
 $xml_dispatch_count = 0;
 WpAiClientTestDouble::reset();
 WpAiClientTestDouble::set_response_callback(

--- a/tests/agents-chat-tool-continuation-smoke.php
+++ b/tests/agents-chat-tool-continuation-smoke.php
@@ -82,4 +82,31 @@ datamachine_agents_chat_tool_continuation_assert(
 );
 ++ $assertions;
 
+$output_method = new ReflectionMethod( $handler, 'toCanonicalOutput' );
+$output        = $output_method->invoke(
+	$handler,
+	array(
+		'session_id' => 'session-1',
+		'response'   => 'AI ACTION (Turn 4): Executing Workspace Read.',
+		'metadata'   => array(
+			'datamachine' => array(
+				'completed'         => false,
+				'max_turns_reached' => true,
+			),
+		),
+	)
+);
+
+datamachine_agents_chat_tool_continuation_assert(
+	false === $output['completed'],
+	'Canonical Agents API chat output should preserve Data Machine incomplete max-turn state.'
+);
+++ $assertions;
+
+datamachine_agents_chat_tool_continuation_assert(
+	true === ( $output['metadata']['datamachine']['max_turns_reached'] ?? null ),
+	'Canonical Agents API chat output should preserve Data Machine max-turn diagnostics.'
+);
+++ $assertions;
+
 echo 'Agents chat tool continuation smoke passed (' . $assertions . " assertions).\n";


### PR DESCRIPTION
## Summary
- track whether the final Data Machine conversation turn actually completed
- mark silent max-turn exhaustion after a tool call as incomplete with max-turn diagnostics
- add smoke coverage for a sandbox/chat tool run that exhausts its turn budget before a final answer

## Tests
- php tests/agent-conversation-runner-request-smoke.php
- php -l inc/Engine/AI/conversation-loop.php
- php -l tests/agent-conversation-runner-request-smoke.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated lab fanout artifacts, drafted the Data Machine completion fix and smoke coverage, and ran focused verification.