### PR TITLE
Harden settings output and SITE.md freshness

### DIFF
--- a/inc/Cli/Commands/SettingsCommand.php
+++ b/inc/Cli/Commands/SettingsCommand.php
@@ -276,6 +276,10 @@ class SettingsCommand extends BaseCommand {
 			'token',
 		);
 
+		if ( 'key' === $normalized || str_ends_with( $normalized, '_key' ) ) {
+			return true;
+		}
+
 		foreach ( $needles as $needle ) {
 			if ( str_contains( $normalized, $needle ) ) {
 				return true;

--- a/inc/migrations/site-md.php
+++ b/inc/migrations/site-md.php
@@ -67,6 +67,7 @@ add_action( 'datamachine_sections', 'datamachine_register_core_sections' );
  */
 function datamachine_register_core_invalidation_hooks( array $hooks ): array {
 	// SITE.md invalidation — site identity, structure, menus.
+	$hooks[] = 'upgrader_process_complete';
 	$hooks[] = 'switch_theme';
 	$hooks[] = 'update_option_blogname';
 	$hooks[] = 'update_option_blogdescription';
@@ -100,7 +101,15 @@ add_filter( 'datamachine_composable_invalidation_hooks', 'datamachine_register_c
  * @return string
  */
 function datamachine_site_section_header(): string {
-	return '# SITE';
+	$lines   = array();
+	$lines[] = '# SITE';
+	$lines[] = '';
+	$lines[] = sprintf(
+		'Generated: %s. Active plugin data comes from WordPress runtime state; refresh with `wp datamachine memory compose SITE.md` and compare with `wp plugin list --status=active` when auditing freshness.',
+		gmdate( 'Y-m-d H:i:s \U\T\C' )
+	);
+
+	return implode( "\n", $lines );
 }
 
 /**

--- a/tests/settings-command-redaction-smoke.php
+++ b/tests/settings-command-redaction-smoke.php
@@ -49,21 +49,41 @@ namespace {
 	};
 
 	$redacted = SettingsCommand::redactSecretsForDisplay(
-		'github_credential_profiles',
+		'github_credentials',
 		array(
-			array(
-				'id'              => 'default',
-				'app_private_key' => '-----BEGIN PRIVATE KEY-----secret',
-				'default_repo'    => 'chubes4/wp-docs',
+			'profiles' => array(
+				array(
+					'id'              => 'default',
+					'app_private_key' => '-----BEGIN PRIVATE KEY-----secret',
+					'token'           => 'ghs_nested_secret',
+					'password'        => 'nested-password',
+					'default_repo'    => 'chubes4/wp-docs',
+					'provider'        => array(
+						'api_key'       => 'sk-provider-secret',
+						'client_secret' => 'client-secret-value',
+						'profile_name'  => 'wp-docs',
+					),
+				),
 			),
 		)
 	);
 
-	$assert('[redacted]' === ( $redacted[0]['app_private_key'] ?? null ), 'nested app_private_key is redacted');
-	$assert('chubes4/wp-docs' === ( $redacted[0]['default_repo'] ?? null ), 'non-secret nested values remain visible');
+	$encoded_default = json_encode( $redacted );
+	$assert('[redacted]' === ( $redacted['profiles'][0]['app_private_key'] ?? null ), 'nested app_private_key is redacted');
+	$assert('[redacted]' === ( $redacted['profiles'][0]['token'] ?? null ), 'nested token is redacted');
+	$assert('[redacted]' === ( $redacted['profiles'][0]['password'] ?? null ), 'nested password is redacted');
+	$assert('[redacted]' === ( $redacted['profiles'][0]['provider']['api_key'] ?? null ), 'nested api_key is redacted');
+	$assert('[redacted]' === ( $redacted['profiles'][0]['provider']['client_secret'] ?? null ), 'nested client_secret is redacted');
+	$assert('chubes4/wp-docs' === ( $redacted['profiles'][0]['default_repo'] ?? null ), 'non-secret nested values remain visible');
+	$assert(false === strpos( $encoded_default, '-----BEGIN PRIVATE KEY-----secret' ), 'default output omits private key value');
+	$assert(false === strpos( $encoded_default, 'ghs_nested_secret' ), 'default output omits token value');
+	$assert(false === strpos( $encoded_default, 'nested-password' ), 'default output omits password value');
+	$assert(false === strpos( $encoded_default, 'sk-provider-secret' ), 'default output omits api key value');
+	$assert(false === strpos( $encoded_default, 'client-secret-value' ), 'default output omits client secret value');
 
 	$assert('[redacted]' === SettingsCommand::redactSecretsForDisplay('github_app_private_key', 'secret-key'), 'top-level private key is redacted');
 	$assert('[redacted]' === SettingsCommand::redactSecretsForDisplay('github_pat', 'ghp_secret'), 'GitHub PAT is redacted');
+	$assert('[redacted]' === SettingsCommand::redactSecretsForDisplay('openai_key', 'sk-obvious'), 'top-level *_key is redacted');
 	$assert('ghp_secret' === SettingsCommand::redactSecretsForDisplay('github_pat', 'ghp_secret', true), 'reveal flag returns raw value');
 	$assert('openai/gpt-5.5' === SettingsCommand::redactSecretsForDisplay('default_model', 'openai/gpt-5.5'), 'non-secret top-level value remains visible');
 

--- a/tests/site-md-plugin-freshness-smoke.php
+++ b/tests/site-md-plugin-freshness-smoke.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Smoke test for SITE.md active-plugin freshness signals.
+ *
+ * Run: php tests/site-md-plugin-freshness-smoke.php
+ */
+
+declare(strict_types=1);
+
+$root                = dirname( __DIR__ );
+$site_md_source      = file_get_contents( $root . '/inc/migrations/site-md.php' );
+$invalidation_source = file_get_contents( $root . '/inc/Engine/AI/ComposableFileInvalidation.php' );
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function ( bool $condition, string $message ) use ( &$failures, &$passes ): void {
+	if ( $condition ) {
+		$passes++;
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	$failures++;
+	echo "FAIL: {$message}\n";
+};
+
+$assert( false !== strpos( $invalidation_source, "add_action( 'activated_plugin'" ), 'plugin activation regenerates composable files' );
+$assert( false !== strpos( $invalidation_source, "add_action( 'deactivated_plugin'" ), 'plugin deactivation regenerates composable files' );
+$assert( false !== strpos( $site_md_source, "'upgrader_process_complete'" ), 'plugin updates invalidate SITE.md composition' );
+$assert( false !== strpos( $site_md_source, 'Generated:' ), 'SITE.md includes a visible generation timestamp' );
+$assert( false !== strpos( $site_md_source, 'wp datamachine memory compose SITE.md' ), 'SITE.md includes refresh guidance' );
+$assert( false !== strpos( $site_md_source, 'wp plugin list --status=active' ), 'SITE.md points to the active-plugin source of truth' );
+$assert( false !== strpos( $site_md_source, "get_option( 'active_plugins'" ), 'active plugin section reads live site plugin state' );
+
+printf( "Result: %d passed, %d failed\n", $passes, $failures );
+exit( $failures > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary
- Redact additional secret-like `*_key` settings in CLI output by default, while preserving the existing `--reveal` escape hatch.
- Expand settings redaction smoke coverage for private keys, tokens, passwords, API keys, client secrets, nested credentials/profiles, and `github_app_private_key`.
- Add SITE.md generation freshness guidance and invalidate composable context on plugin update events.
- Add smoke coverage for plugin activation/deactivation/update freshness signals and active-plugin source-of-truth guidance.

Closes #2351.
Closes #2352.

## Tests
- `php -l inc/Cli/Commands/SettingsCommand.php`
- `php -l inc/migrations/site-md.php`
- `php -l tests/settings-command-redaction-smoke.php`
- `php -l tests/site-md-plugin-freshness-smoke.php`
- `php tests/settings-command-redaction-smoke.php`
- `php tests/site-md-plugin-freshness-smoke.php`
- `vendor/bin/phpcs inc/Cli/Commands/SettingsCommand.php inc/migrations/site-md.php tests/settings-command-redaction-smoke.php tests/site-md-plugin-freshness-smoke.php`
- `git diff --check`

## Known test blocker
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-settings-redaction-site-refresh --extension wordpress` failed before running tests because the lab offload checkout did not include `vendor/autoload.php` for the plugin bootstrap. Targeted local checks above passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the affected Data Machine CLI and SITE.md composition paths, drafted the code/test changes, ran focused validation, and prepared this PR. Chris remains responsible for review and merge.
