### PR TITLE
Fix stale worker lock reclaim

### DIFF
--- a/inc/Cli/WorkerLock.php
+++ b/inc/Cli/WorkerLock.php
@@ -46,8 +46,16 @@ class WorkerLock {
 
 		if ( 'stale' === $existing['lock_status'] ) {
 			delete_option( self::OPTION_NAME );
-			if ( add_option( self::OPTION_NAME, $payload, '', 'no' ) ) {
+			if ( add_option( self::OPTION_NAME, $payload, '', false ) ) {
 				return self::formatSnapshot( $payload, $now, 'held', true );
+			}
+
+			$after_delete = self::snapshot( $now, $ttl );
+			if ( 'stale' === $after_delete['lock_status'] && update_option( self::OPTION_NAME, $payload, false ) ) {
+				$current = get_option( self::OPTION_NAME, array() );
+				if ( is_array( $current ) && hash_equals( $token, (string) ( $current['token'] ?? '' ) ) ) {
+					return self::formatSnapshot( $payload, $now, 'held', true );
+				}
 			}
 
 			$existing             = self::snapshot( $now, $ttl );
@@ -55,7 +63,7 @@ class WorkerLock {
 			return $existing;
 		}
 
-		if ( add_option( self::OPTION_NAME, $payload, '', 'no' ) ) {
+		if ( add_option( self::OPTION_NAME, $payload, '', false ) ) {
 			return self::formatSnapshot( $payload, $now, 'held', true );
 		}
 
@@ -103,7 +111,7 @@ class WorkerLock {
 			);
 		}
 
-		$started_at = (int) ( $payload['started_at'] ?? 0 );
+		$started_at = (int) $payload['started_at'];
 		$expires_at = (int) ( $payload['expires_at'] ?? ( $started_at + $ttl ) );
 		$status     = $expires_at <= $now ? 'stale' : 'held';
 

--- a/tests/worker-lock-smoke.php
+++ b/tests/worker-lock-smoke.php
@@ -10,6 +10,7 @@
 define( 'ABSPATH', __DIR__ );
 
 $GLOBALS['datamachine_worker_lock_options'] = array();
+$GLOBALS['datamachine_worker_lock_delete_noop'] = false;
 
 function get_option( string $name, mixed $default = false ): mixed {
 	return $GLOBALS['datamachine_worker_lock_options'][ $name ] ?? $default;
@@ -32,6 +33,10 @@ function update_option( string $name, mixed $value, string|bool|null $autoload =
 }
 
 function delete_option( string $name ): bool {
+	if ( ! empty( $GLOBALS['datamachine_worker_lock_delete_noop'] ) ) {
+		return false;
+	}
+
 	unset( $GLOBALS['datamachine_worker_lock_options'][ $name ] );
 	return true;
 }
@@ -102,5 +107,29 @@ assert_worker_lock_true( 'held' === $still_held['lock_status'], 'wrong token doe
 
 WorkerLock::release( (string) $replacement['lock_token'] );
 assert_worker_lock_true( 'unlocked' === WorkerLock::snapshot()['lock_status'], 'replacement lock releases cleanly' );
+
+$GLOBALS['datamachine_worker_lock_options'] = array();
+$stale_started = time() - 300;
+add_option(
+	'datamachine_worker_runtime_lock',
+	array(
+		'token'      => 'stale-token-with-sticky-cache',
+		'owner'      => 'old sticky worker',
+		'started_at' => $stale_started,
+		'expires_at' => $stale_started + 60,
+		'ttl'        => 60,
+	),
+	'',
+	'no'
+);
+
+$GLOBALS['datamachine_worker_lock_delete_noop'] = true;
+$sticky_replacement = WorkerLock::acquire( 'new sticky worker', 120 );
+$GLOBALS['datamachine_worker_lock_delete_noop'] = false;
+assert_worker_lock_true( true === $sticky_replacement['acquired'], 'stale lock is replaced when delete/add does not clear persistent option' );
+assert_worker_lock_true( 'new sticky worker' === $sticky_replacement['lock_owner'], 'sticky replacement lock reports new owner' );
+
+WorkerLock::release( (string) $sticky_replacement['lock_token'] );
+assert_worker_lock_true( 'unlocked' === WorkerLock::snapshot()['lock_status'], 'sticky replacement lock releases cleanly' );
 
 echo "OK ({$assertions} assertions)\n";


### PR DESCRIPTION
## Summary
- harden worker lock acquisition when stale lock deletion does not clear the persistent option before add_option()
- fall back to replacing the still-stale option with update_option() and verify ownership by token
- update the worker lock smoke test for sticky stale option behavior

## Verification
- `php tests/worker-lock-smoke.php`
- `php -l inc/Cli/WorkerLock.php`
- `php -l tests/worker-lock-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-stale-worker-lock-reclaim-runtime --extension wordpress --file inc/Cli/WorkerLock.php --errors-only`

## Runtime context
This unblocks `intelligence.horse`, where `datamachine worker run` observed a stale `datamachine_worker_runtime_lock` but still exited with `stop_reason=locked`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the live stale lock reclaim failure, drafted the lock acquisition hardening and smoke coverage, and ran targeted verification for Chris to review.