### PR TITLE
Fix early send-email ability translations

### DIFF
--- a/inc/Abilities/Publish/SendEmailAbility.php
+++ b/inc/Abilities/Publish/SendEmailAbility.php
@@ -55,9 +55,12 @@ class SendEmailAbility {
 			return;
 		}
 
-		$definitions = self::get_ability_definitions( self::$instance );
+		$register_via_helper = static function (): void {
+			if ( null === self::$instance ) {
+				return;
+			}
 
-		$register_via_helper = static function () use ( $definitions ): void {
+			$definitions = self::get_ability_definitions( self::$instance );
 			foreach ( $definitions as $name => $args ) {
 				wp_register_ability( $name, $args );
 			}
@@ -92,7 +95,7 @@ class SendEmailAbility {
 		if ( null === $registry ) {
 			return;
 		}
-		foreach ( $definitions as $name => $args ) {
+		foreach ( self::get_ability_definitions( self::$instance ) as $name => $args ) {
 			if ( $registry->is_registered( $name ) ) {
 				continue;
 			}

--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -76,9 +76,12 @@ class SendEmailQueuedAbility {
 			return;
 		}
 
-		$definitions = self::get_ability_definitions( self::$instance );
+		$register_via_helper = static function (): void {
+			if ( null === self::$instance ) {
+				return;
+			}
 
-		$register_via_helper = static function () use ( $definitions ): void {
+			$definitions = self::get_ability_definitions( self::$instance );
 			foreach ( $definitions as $name => $args ) {
 				wp_register_ability( $name, $args );
 			}
@@ -113,7 +116,7 @@ class SendEmailQueuedAbility {
 		if ( null === $registry ) {
 			return;
 		}
-		foreach ( $definitions as $name => $args ) {
+		foreach ( self::get_ability_definitions( self::$instance ) as $name => $args ) {
 			if ( $registry->is_registered( $name ) ) {
 				continue;
 			}

--- a/tests/send-email-ability-lazy-definitions-smoke.php
+++ b/tests/send-email-ability-lazy-definitions-smoke.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Regression: always-on send-email ability registration must not translate
+ * labels/descriptions while the plugin file is loading before init.
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+$datamachine_test_actions       = array();
+$datamachine_test_doing_actions = array();
+$datamachine_test_did_actions   = array();
+$datamachine_test_translations  = 0;
+$datamachine_test_registered    = array();
+
+function __( $text, $domain = 'default' ) {
+	global $datamachine_test_translations;
+	if ( 'data-machine' === $domain ) {
+		$datamachine_test_translations++;
+	}
+	return $text;
+}
+
+function add_action( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
+	global $datamachine_test_actions;
+	$datamachine_test_actions[ $hook_name ][] = $callback;
+	return true;
+}
+
+function doing_action( $hook_name = null ) {
+	global $datamachine_test_doing_actions;
+	return isset( $datamachine_test_doing_actions[ $hook_name ] );
+}
+
+function did_action( $hook_name ) {
+	global $datamachine_test_did_actions;
+	return $datamachine_test_did_actions[ $hook_name ] ?? 0;
+}
+
+function wp_register_ability( $name, $args ) {
+	global $datamachine_test_registered;
+	$datamachine_test_registered[ $name ] = $args;
+}
+
+require_once __DIR__ . '/../inc/Abilities/Publish/SendEmailAbility.php';
+require_once __DIR__ . '/../inc/Abilities/Publish/SendEmailQueuedAbility.php';
+
+\DataMachine\Abilities\Publish\SendEmailAbility::ensure_registered();
+\DataMachine\Abilities\Publish\SendEmailQueuedAbility::ensure_registered();
+
+if ( 0 !== $datamachine_test_translations ) {
+	fwrite( STDERR, "FAIL: send-email abilities translated definitions before wp_abilities_api_init.\n" );
+	exit( 1 );
+}
+
+foreach ( $datamachine_test_actions['wp_abilities_api_init'] ?? array() as $callback ) {
+	$datamachine_test_doing_actions['wp_abilities_api_init'] = true;
+	$datamachine_test_did_actions['wp_abilities_api_init']   = 1;
+	$callback();
+	unset( $datamachine_test_doing_actions['wp_abilities_api_init'] );
+}
+
+if ( ! isset( $datamachine_test_registered['datamachine/send-email'], $datamachine_test_registered['datamachine/send-email-queued'] ) ) {
+	fwrite( STDERR, "FAIL: send-email abilities were not registered when wp_abilities_api_init fired.\n" );
+	exit( 1 );
+}
+
+if ( 0 === $datamachine_test_translations ) {
+	fwrite( STDERR, "FAIL: send-email definitions were not built during wp_abilities_api_init.\n" );
+	exit( 1 );
+}
+
+echo "send-email-ability-lazy-definitions-smoke: ok\n";


### PR DESCRIPTION
## Summary
- Defer send-email ability schema construction until the ability registry initialization callback runs.
- Apply the same lazy definition behavior to queued send-email ability registration.
- Add a smoke test proving always-on registration does not translate strings before `wp_abilities_api_init`, while still registering both abilities when the hook fires.

## Verification
- `php -l inc/Abilities/Publish/SendEmailAbility.php && php -l inc/Abilities/Publish/SendEmailQueuedAbility.php`
- `php tests/send-email-ability-lazy-definitions-smoke.php`
- `studio wp datamachine settings get github_app_private_key --format=json` on `intelligence-chubes4` after deploying the branch locally; output returned redacted JSON without the `_load_textdomain_just_in_time` notice.

## Known pre-existing checks
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-textdomain-load-timing --extension wordpress` still reports existing repo-wide PHPStan findings unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause tracing, patch drafting, targeted smoke test, local verification, and PR preparation; Chris remains responsible for review and merge.
