### PR TITLE
Fix split-cache stale worker lock reclaim

### DIFF
--- a/inc/Cli/WorkerLock.php
+++ b/inc/Cli/WorkerLock.php
@@ -51,7 +51,7 @@ class WorkerLock {
 			}
 
 			$after_delete = self::snapshot( $now, $ttl );
-			if ( 'stale' === $after_delete['lock_status'] && update_option( self::OPTION_NAME, $payload, false ) ) {
+			if ( 'held' !== $after_delete['lock_status'] && update_option( self::OPTION_NAME, $payload, false ) ) {
 				$current = get_option( self::OPTION_NAME, array() );
 				if ( is_array( $current ) && hash_equals( $token, (string) ( $current['token'] ?? '' ) ) ) {
 					return self::formatSnapshot( $payload, $now, 'held', true );

--- a/tests/worker-lock-smoke.php
+++ b/tests/worker-lock-smoke.php
@@ -11,8 +11,14 @@ define( 'ABSPATH', __DIR__ );
 
 $GLOBALS['datamachine_worker_lock_options'] = array();
 $GLOBALS['datamachine_worker_lock_delete_noop'] = false;
+$GLOBALS['datamachine_worker_lock_get_after_delete_default'] = false;
 
 function get_option( string $name, mixed $default = false ): mixed {
+	if ( ! empty( $GLOBALS['datamachine_worker_lock_get_after_delete_default'] ) ) {
+		$GLOBALS['datamachine_worker_lock_get_after_delete_default'] = false;
+		return $default;
+	}
+
 	return $GLOBALS['datamachine_worker_lock_options'][ $name ] ?? $default;
 }
 
@@ -34,6 +40,7 @@ function update_option( string $name, mixed $value, string|bool|null $autoload =
 
 function delete_option( string $name ): bool {
 	if ( ! empty( $GLOBALS['datamachine_worker_lock_delete_noop'] ) ) {
+		$GLOBALS['datamachine_worker_lock_get_after_delete_default'] = true;
 		return false;
 	}
 
@@ -131,5 +138,29 @@ assert_worker_lock_true( 'new sticky worker' === $sticky_replacement['lock_owner
 
 WorkerLock::release( (string) $sticky_replacement['lock_token'] );
 assert_worker_lock_true( 'unlocked' === WorkerLock::snapshot()['lock_status'], 'sticky replacement lock releases cleanly' );
+
+$GLOBALS['datamachine_worker_lock_options'] = array();
+$stale_started = time() - 300;
+add_option(
+	'datamachine_worker_runtime_lock',
+	array(
+		'token'      => 'stale-token-with-split-cache',
+		'owner'      => 'old split-cache worker',
+		'started_at' => $stale_started,
+		'expires_at' => $stale_started + 60,
+		'ttl'        => 60,
+	),
+	'',
+	'no'
+);
+
+$GLOBALS['datamachine_worker_lock_delete_noop'] = true;
+$split_cache_replacement = WorkerLock::acquire( 'new split-cache worker', 120 );
+$GLOBALS['datamachine_worker_lock_delete_noop'] = false;
+assert_worker_lock_true( true === $split_cache_replacement['acquired'], 'stale lock is replaced when post-delete snapshot looks unlocked but add_option still fails' );
+assert_worker_lock_true( 'new split-cache worker' === $split_cache_replacement['lock_owner'], 'split-cache replacement lock reports new owner' );
+
+WorkerLock::release( (string) $split_cache_replacement['lock_token'] );
+assert_worker_lock_true( 'unlocked' === WorkerLock::snapshot()['lock_status'], 'split-cache replacement lock releases cleanly' );
 
 echo "OK ({$assertions} assertions)\n";


### PR DESCRIPTION
## Summary
- complete stale worker lock reclaim for cases where delete/add leaves the local snapshot unlocked while the persistent option still blocks add_option()
- replace the option whenever the post-delete snapshot is not actively held by another worker
- add smoke coverage for the split-cache stale option path observed on intelligence.horse

## Verification
- `php tests/worker-lock-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-stale-worker-lock-cache-split --extension wordpress --file inc/Cli/WorkerLock.php --errors-only`

## Runtime context
Follow-up to #2355. The live `intelligence.horse` worker still saw a stale lock but exited locked because add_option failed while the post-delete snapshot no longer reported stale.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the remaining live stale lock reclaim edge case, drafted the lock acquisition fix and smoke coverage, and ran targeted verification for Chris to review.