### PR TITLE
Thread chat interrupt sources through runtime

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -103,6 +103,7 @@ class AgentsChatHandler {
 				'selected_pipeline_id' => (int) ( $input['selected_pipeline_id'] ?? 0 ),
 				'max_turns'            => $input['max_turns'] ?? null,
 				'request_id'           => $input['request_id'] ?? null,
+				'interrupt_source'     => is_callable( $input['interrupt_source'] ?? null ) ? $input['interrupt_source'] : null,
 				'modes'                => $modes,
 				'agent_id'             => $agent_id,
 				'agent_slug'           => sanitize_title( (string) ( $input['agent'] ?? '' ) ),
@@ -217,6 +218,7 @@ class AgentsChatHandler {
 					'conversation' => $result['conversation'] ?? null,
 					'max_turns'    => $result['max_turns'] ?? null,
 					'turn_number'  => $result['turn_number'] ?? null,
+					'interrupted'  => $result['interrupted'] ?? null,
 				)
 			),
 			static fn( $value ): bool => null !== $value

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -53,6 +53,7 @@ class ChatOrchestrator {
 	 *     @type int    $selected_pipeline_id Currently selected pipeline ID.
 	 *     @type int    $max_turns            Maximum turns allowed.
 	 *     @type string $request_id           Idempotency request ID.
+	 *     @type callable|null $interrupt_source Optional cooperative interrupt source.
 	 * }
 	 * @return array|WP_Error Response data array or WP_Error on failure.
 	 */
@@ -67,6 +68,7 @@ class ChatOrchestrator {
 		$selected_pipeline_id = (int) ( $options['selected_pipeline_id'] ?? 0 );
 		$max_turns            = $options['max_turns'] ?? PluginSettings::get( 'max_turns', PluginSettings::DEFAULT_MAX_TURNS );
 		$request_id           = $options['request_id'] ?? null;
+		$interrupt_source     = is_callable( $options['interrupt_source'] ?? null ) ? $options['interrupt_source'] : null;
 		$agent_id             = (int) ( $options['agent_id'] ?? 0 );
 		$agent_slug           = (string) ( $options['agent_slug'] ?? '' );
 		$modes                = ToolPolicyResolver::normalizeModes( ! empty( $options['modes'] ) ? $options['modes'] : array( $options['mode'] ?? ToolPolicyResolver::MODE_CHAT ) );
@@ -223,6 +225,7 @@ class ChatOrchestrator {
 				'user_id'              => $user_id,
 				'agent_id'             => $agent_id,
 				'agent_slug'           => $agent_slug,
+				'interrupt_source'     => $interrupt_source,
 				'client_context'       => $options['client_context'] ?? array(),
 			)
 		);
@@ -319,6 +322,10 @@ class ChatOrchestrator {
 
 		if ( ! empty( $loop_metadata['max_turns_reached'] ) ) {
 			$response_data['max_turns_reached'] = true;
+		}
+
+		if ( isset( $loop_metadata['interrupted'] ) ) {
+			$response_data['interrupted'] = $loop_metadata['interrupted'];
 		}
 
 		/**
@@ -751,6 +758,7 @@ class ChatOrchestrator {
 	 *     @type int    $max_turns             Maximum turns allowed (default 25).
 	 *     @type int    $selected_pipeline_id  Currently selected pipeline ID.
 	 *     @type string $mode                  Agent mode (default 'chat').
+	 *     @type callable|null $interrupt_source Optional cooperative interrupt source.
 	 * }
 	 * @return array|WP_Error Result array with messages, final_content, completed, turn_count,
 	 *                        last_tool_calls, and optional warning/max_turns_reached keys.
@@ -770,6 +778,7 @@ class ChatOrchestrator {
 		$mode                 = implode( ',', $modes );
 		$agent_id             = (int) ( $options['agent_id'] ?? 0 );
 		$agent_slug           = (string) ( $options['agent_slug'] ?? '' );
+		$interrupt_source     = is_callable( $options['interrupt_source'] ?? null ) ? $options['interrupt_source'] : null;
 
 		$chat_db = ConversationStoreFactory::get();
 
@@ -825,6 +834,9 @@ class ChatOrchestrator {
 			}
 			if ( ! empty( $client_context ) ) {
 				$loop_context['client_context'] = $client_context;
+			}
+			if ( null !== $interrupt_source ) {
+				$loop_context['interrupt_source'] = $interrupt_source;
 			}
 
 			$loop_result = datamachine_run_conversation(

--- a/inc/Engine/AI/RuntimeProvenance.php
+++ b/inc/Engine/AI/RuntimeProvenance.php
@@ -163,6 +163,9 @@ class RuntimeProvenance {
 		if ( ! empty( $datamachine['max_turns_reached'] ) || 'budget_exceeded' === ( $result['status'] ?? '' ) ) {
 			return 'max_turns';
 		}
+		if ( 'interrupted' === ( $result['status'] ?? '' ) ) {
+			return 'interrupted';
+		}
 		if ( isset( $result['error'] ) ) {
 			return 'provider_error';
 		}

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -64,6 +64,7 @@ function datamachine_run_conversation(
 	$tool_runtime_rules   = datamachine_resolve_tool_runtime_rules( $payload );
 	$transcript_persister = datamachine_resolve_transcript_persister( $payload );
 	$transcript_lock      = $payload['transcript_lock'] ?? $payload['transcript_lock_store'] ?? null;
+	$interrupt_source     = is_callable( $payload['interrupt_source'] ?? null ) ? $payload['interrupt_source'] : null;
 
 	// Strip runtime objects from the loop payload before passing to tools/requests.
 	$loop_payload = datamachine_payload_without_runtime_objects( $payload );
@@ -247,6 +248,7 @@ function datamachine_run_conversation(
 				'transcript_lock'       => $transcript_lock,
 				'transcript_session_id' => (string) ( $loop_payload['transcript_session_id'] ?? $loop_payload['session_id'] ?? '' ),
 				'transcript_lock_ttl'   => (int) ( $payload['transcript_lock_ttl'] ?? 300 ),
+				'interrupt_source'      => $interrupt_source,
 				'on_event'              => $on_event,
 			)
 		);
@@ -312,10 +314,13 @@ function datamachine_run_conversation(
 	// request_metadata directly on the result (agents-api#136). Keep DM-only
 	// diagnostics namespaced so the top level remains the Agents API result.
 	$datamachine_metadata     = array(
-		'completed'       => 'budget_exceeded' !== ( $result['status'] ?? '' ),
+		'completed'       => ! in_array( (string) ( $result['status'] ?? '' ), array( 'budget_exceeded', 'interrupted' ), true ),
 		'last_tool_calls' => $last_tool_calls,
 		'tool_calls'      => $all_tool_calls,
 	);
+	if ( 'interrupted' === ( $result['status'] ?? '' ) && isset( $result['interrupted'] ) ) {
+		$datamachine_metadata['interrupted'] = $result['interrupted'];
+	}
 	$silent_max_turns_reached = ! $latest_conversation_complete
 		&& (int) ( $result['turn_count'] ?? 0 ) >= $turn_budget->ceiling()
 		&& 'budget_exceeded' !== ( $result['status'] ?? '' );
@@ -1960,7 +1965,7 @@ function datamachine_summarize_tool_execution_results( array $tool_execution_res
  * @return array Clean payload.
  */
 function datamachine_payload_without_runtime_objects( array $payload ): array {
-	unset( $payload['event_sink'], $payload['completion_policy'], $payload['transcript_persister'], $payload['transcript_lock'], $payload['transcript_lock_store'] );
+	unset( $payload['event_sink'], $payload['completion_policy'], $payload['transcript_persister'], $payload['transcript_lock'], $payload['transcript_lock_store'], $payload['interrupt_source'] );
 	return $payload;
 }
 

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -262,7 +262,77 @@ assert_runner_request( true === ( $budget_metadata['max_turns_reached'] ?? null 
 assert_runner_request( false === ( $budget_metadata['completed'] ?? true ), 'budget exceeded marks namespaced completion false' );
 assert_runner_request( ! array_key_exists( 'max_turns_reached', $budget_result ), 'budget exceeded omits legacy max_turns_reached from top level' );
 
-// 3. Mid-conversation provider failures preserve the completed-turn context.
+// 3. Interrupt sources are forwarded to the Agents API loop and cancel cooperatively.
+$interrupt_dispatch_count = 0;
+$interrupt_source_calls   = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$interrupt_dispatch_count ) {
+		++$interrupt_dispatch_count;
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => '',
+				'tool_calls' => array(
+					array(
+						'name'       => 'runner_request_smoke_tool',
+						'parameters' => array( 'name' => 'Grace' ),
+					),
+				),
+				'usage'      => array(
+					'prompt_tokens'     => 4,
+					'completion_tokens' => 5,
+					'total_tokens'      => 9,
+				),
+			),
+		);
+	}
+);
+
+$interrupt_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'use a tool before interruption' ) ),
+	array(
+		'runner_request_smoke_tool' => array(
+			'name'        => 'runner_request_smoke_tool',
+			'description' => 'Runner request smoke tool',
+			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+			'class'       => RunnerRequestSmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	array( 'pipeline' ),
+	array(
+		'interrupt_source' => static function ( WP_Agent_Conversation_Request $request, array $context ) use ( &$interrupt_source_calls ): array {
+			++$interrupt_source_calls;
+
+			assert_runner_request( 3 === count( $request->messages() ), 'interrupt source receives current transcript after tool execution' );
+			assert_runner_request( 1 === ( $context['turn'] ?? null ), 'interrupt source receives current turn context' );
+
+			return array(
+				'role'     => 'user',
+				'content'  => 'Cancel this Data Machine run.',
+				'metadata' => array(
+					'interrupt_action' => 'cancel',
+					'source'           => 'smoke-test',
+				),
+			);
+		},
+	),
+	3
+);
+$interrupt_metadata = datamachine_conversation_metadata( $interrupt_result );
+
+assert_runner_request( 1 === $interrupt_dispatch_count, 'interrupt cancellation prevents a second provider request' );
+assert_runner_request( 1 === $interrupt_source_calls, 'interrupt source is checked once between turns' );
+assert_runner_request( 'interrupted' === ( $interrupt_result['status'] ?? null ), 'interrupt cancellation preserves canonical interrupted status' );
+assert_runner_request( false === ( $interrupt_metadata['completed'] ?? true ), 'interrupt cancellation marks namespaced completion false' );
+assert_runner_request( 'cancel' === ( $interrupt_metadata['interrupted']['action'] ?? null ), 'interrupt diagnostics record cancel action' );
+assert_runner_request( 'interrupted' === ( $interrupt_result['runtime_provenance']['status']['finish_reason'] ?? null ), 'interrupt provenance records interrupted finish reason' );
+
+// 4. Mid-conversation provider failures preserve the completed-turn context.
 $mid_failure_dispatch_count = 0;
 $mid_failure_transcript     = new RunnerRequestSmokeTranscriptPersister();
 WpAiClientTestDouble::reset();

--- a/tests/agents-chat-handler-smoke.php
+++ b/tests/agents-chat-handler-smoke.php
@@ -81,7 +81,9 @@ $assert( ! str_contains( $handler_source, "wp_agent_chat_handler" ), 'AgentsChat
 $assert( str_contains( $handler_source, 'ChatOrchestrator::processChat(' ), 'AgentsChatHandler owns the single ChatOrchestrator runtime call' );
 $assert( str_contains( $handler_source, "'selected_pipeline_id' => (int) ( $" . "input['selected_pipeline_id'] ?? 0 )" ), 'AgentsChatHandler forwards selected pipeline context' );
 $assert( str_contains( $handler_source, "'request_id'           => $" . "input['request_id'] ?? null" ), 'AgentsChatHandler forwards request id for session dedupe' );
+$assert( str_contains( $handler_source, "'interrupt_source'     => is_callable( $" . "input['interrupt_source'] ?? null ) ? $" . "input['interrupt_source'] : null" ), 'AgentsChatHandler explicitly forwards callable interrupt sources' );
 $assert( str_contains( $handler_source, "'agent_slug'           => sanitize_title( (string) ( $" . "input['agent'] ?? '' ) )" ), 'AgentsChatHandler forwards agent targeting to the chat runtime' );
+$assert( str_contains( $handler_source, "'interrupted'  => $" . "result['interrupted'] ?? null" ), 'AgentsChatHandler returns interrupted diagnostics in canonical metadata' );
 $assert( ! file_exists( $root . '/inc/Abilities/Chat/SendMessageAbility.php' ), 'datamachine/send-message facade class is removed' );
 $assert( ! str_contains( $chat_abilities, 'SendMessageAbility' ), 'ChatAbilities no longer registers datamachine/send-message' );
 $assert( str_contains( $chat_api, "wp_get_ability( 'agents/chat' )" ), 'REST chat endpoint dispatches directly through canonical agents/chat' );


### PR DESCRIPTION
## Summary
- Thread explicit `interrupt_source` callables from `agents/chat` into the Data Machine conversation runtime.
- Preserve interrupted diagnostics in Data Machine metadata and runtime provenance.
- Add smoke coverage for cooperative cancellation between turns.

## Tests
- `php tests/agents-chat-handler-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and smoke coverage; Chris directed the change and validation flow.