### PR TITLE
Derive chat session titles from first user message

### DIFF
--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -705,7 +705,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			$query_args[] = $identity['agent_id'];
 		}
 
-		$select = $include_messages ? '*' : 'session_id, workspace_type, workspace_id, user_id, owner_type, owner_key_hash, owner_label, agent_id, title, metadata, provider, model, provider_response_id, mode, created_at, updated_at, last_read_at, expires_at';
+		$select = $include_messages ? '*' : 'session_id, workspace_type, workspace_id, user_id, owner_type, owner_key_hash, owner_label, agent_id, title, messages, metadata, provider, model, provider_response_id, mode, created_at, updated_at, last_read_at, expires_at';
 		$sql    = 'SELECT ' . $select . ' FROM %i WHERE ' . implode( ' AND ', $where ) . ' ORDER BY updated_at DESC LIMIT %d OFFSET %d';
 
 		$query_args[] = $limit;
@@ -719,8 +719,17 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		}
 
 		foreach ( $sessions as &$session ) {
-			if ( $include_messages ) {
+			if ( $include_messages || empty( $session['title'] ) ) {
 				$session['messages'] = self::normalize_messages( json_decode( $session['messages'] ?? '[]', true ) ?? array() );
+			}
+			if ( empty( $session['title'] ) && ! empty( $session['messages'] ) ) {
+				$session['title'] = self::title_from_messages( $session['messages'] );
+				if ( '' !== $session['title'] ) {
+					self::set_missing_session_title( $table_name, (string) $session['session_id'], (string) $session['title'] );
+				}
+			}
+			if ( ! $include_messages ) {
+				unset( $session['messages'] );
 			}
 			$session['metadata']   = json_decode( $session['metadata'] ?? '[]', true ) ?? array();
 			$session['agent_slug'] = self::resolve_agent_slug_from_session_row( $session );
@@ -879,7 +888,69 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			return false;
 		}
 
+		$title = self::title_from_messages( $normalized_messages );
+		if ( '' !== $title ) {
+			self::set_missing_session_title( $table_name, $session_id, $title );
+		}
+
 		return true;
+	}
+
+	/**
+	 * Derive a display title from the first user message in a transcript.
+	 *
+	 * @param array<int,array<string,mixed>> $messages Normalized transcript messages.
+	 * @return string Short title, or empty string when no user text exists.
+	 */
+	private static function title_from_messages( array $messages ): string {
+		foreach ( $messages as $message ) {
+			if ( ! is_array( $message ) || 'user' !== (string) ( $message['role'] ?? '' ) ) {
+				continue;
+			}
+
+			$text = self::message_content_text( $message );
+			$text = trim( preg_replace( '/\s+/', ' ', wp_strip_all_tags( $text ) ) ?? '' );
+			if ( '' !== $text ) {
+				return mb_substr( $text, 0, 100 );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Fill the session title only when it has not been set yet.
+	 *
+	 * @param string $table_name Session table name.
+	 * @param string $session_id Session UUID.
+	 * @param string $title      Derived display title.
+	 */
+	private static function set_missing_session_title( string $table_name, string $session_id, string $title ): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i SET title = %s WHERE session_id = %s AND (title IS NULL OR title = %s)',
+				$table_name,
+				$title,
+				$session_id,
+				''
+			)
+		);
+
+		if ( false === $result ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Failed to set derived chat session title',
+				array(
+					'session_id' => $session_id,
+					'error'      => $wpdb->last_error,
+					'mode'       => 'chat',
+				)
+			);
+		}
 	}
 
 	/**
@@ -1421,6 +1492,19 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		$content = $message['content'] ?? '';
 		if ( is_string( $content ) ) {
 			return $content;
+		}
+
+		if ( is_array( $content ) ) {
+			$text = array();
+			foreach ( $content as $part ) {
+				if ( is_array( $part ) && 'text' === (string) ( $part['type'] ?? '' ) && is_string( $part['text'] ?? null ) ) {
+					$text[] = $part['text'];
+				}
+			}
+
+			if ( ! empty( $text ) ) {
+				return implode( "\n\n", $text );
+			}
 		}
 
 		return (string) wp_json_encode( $content, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );

--- a/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
+++ b/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
@@ -136,6 +136,86 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		$this->assertSame( 'transcript-id-agent', $session['agent_slug'] );
 	}
 
+	public function test_builtin_chat_store_derives_missing_title_from_first_user_message(): void {
+		$store      = ConversationStoreFactory::get();
+		$session_id = $store->create_session( $this->workspace(), 12, $this->create_agent( 'title-agent' ), array(), 'chat' );
+
+		$this->assertTrue(
+			$store->update_session(
+				$session_id,
+				array(
+					array(
+						'role'    => 'assistant',
+						'content' => 'Before the user speaks',
+					),
+					array(
+						'role'    => 'user',
+						'content' => 'Build a candy shop website inspired by Gumroad.',
+					),
+				),
+				array( 'status' => 'completed' ),
+				'openai',
+				'gpt-test'
+			)
+		);
+
+		$session = $store->get_session( $session_id );
+		$this->assertSame( 'Build a candy shop website inspired by Gumroad.', $session['title'] );
+	}
+
+	public function test_builtin_chat_store_does_not_overwrite_existing_title(): void {
+		$store      = ConversationStoreFactory::get();
+		$session_id = $store->create_session( $this->workspace(), 12, $this->create_agent( 'manual-title-agent' ), array(), 'chat' );
+
+		$this->assertTrue( $store->update_title( $session_id, 'Manual title' ) );
+		$this->assertTrue(
+			$store->update_session(
+				$session_id,
+				array(
+					array(
+						'role'    => 'user',
+						'content' => 'This should not replace the title.',
+					),
+				),
+				array( 'status' => 'completed' ),
+				'openai',
+				'gpt-test'
+			)
+		);
+
+		$session = $store->get_session( $session_id );
+		$this->assertSame( 'Manual title', $session['title'] );
+	}
+
+	public function test_builtin_chat_store_backfills_missing_title_when_listing_summaries(): void {
+		global $wpdb;
+
+		$store      = ConversationStoreFactory::get();
+		$workspace  = $this->workspace();
+		$session_id = $store->create_session( $workspace, 12, $this->create_agent( 'summary-title-agent' ), array(), 'chat' );
+
+		$this->assertTrue(
+			$store->update_session(
+				$session_id,
+				array(
+					array(
+						'role'    => 'user',
+						'content' => 'Existing transcript should receive a summary title.',
+					),
+				),
+				array( 'status' => 'completed' ),
+				'openai',
+				'gpt-test'
+			)
+		);
+		$wpdb->update( $store->get_table_name(), array( 'title' => null ), array( 'session_id' => $session_id ), array( '%s' ), array( '%s' ) );
+
+		$sessions = $store->list_sessions( $workspace, 12, array( 'include_messages' => false ) );
+
+		$this->assertSame( 'Existing transcript should receive a summary title.', $sessions[0]['title'] );
+		$this->assertArrayNotHasKey( 'messages', $sessions[0] );
+	}
+
 	public function test_in_memory_store_accepts_agent_slug_and_exposes_it_on_get_session(): void {
 		$store      = new InMemoryConversationStore();
 		$session_id = $store->create_session( $this->workspace(), 5, 'memory-agent', array(), 'pipeline' );


### PR DESCRIPTION
## Summary
- Derives missing chat session titles from the first user message when transcripts are updated.
- Lazily backfills missing titles while listing session summaries so existing rows stop surfacing as `New chat` without returning message bodies.
- Preserves existing/manual titles and adds unit coverage for derivation, non-overwrite behavior, and summary backfill.

## Verification
- `php -l inc/Core/Database/Chat/Chat.php && php -l tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php`
- `git diff --check`

## Notes
- `homeboy test --path . --extension wordpress -- tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php` and `--force-hot` both failed before running tests because the WP Codebox PHPUnit workflow crashed during `Installing...` without structured test output.
- `homeboy lint --path . --extension wordpress` is blocked by existing unrelated JS/admin lint findings, including unresolved `@wordpress/*` and `@tanstack/react-query` imports plus pre-existing JSDoc/react-hooks issues.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the WP Cloud transcript rows, drafted the Data Machine store fix and tests, and ran verification commands; Chris remains responsible for review and merge.