### PR TITLE
fix: migrate admin entry points to createRoot for React 19

### DIFF
--- a/inc/Core/Admin/Pages/Agent/assets/react/index.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/index.jsx
@@ -7,7 +7,7 @@
 /**
  * WordPress dependencies
  */
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 import domReady from '@wordpress/dom-ready';
 /**
  * External dependencies
@@ -39,10 +39,9 @@ domReady( () => {
 		return;
 	}
 
-	render(
+	createRoot( rootElement ).render(
 		<QueryClientProvider client={ queryClient }>
 			<AgentApp />
-		</QueryClientProvider>,
-		rootElement
+		</QueryClientProvider>
 	);
 } );

--- a/inc/Core/Admin/Pages/Jobs/assets/react/index.jsx
+++ b/inc/Core/Admin/Pages/Jobs/assets/react/index.jsx
@@ -7,7 +7,7 @@
 /**
  * WordPress dependencies
  */
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 import domReady from '@wordpress/dom-ready';
 /**
  * External dependencies
@@ -34,10 +34,9 @@ domReady( () => {
 		return;
 	}
 
-	render(
+	createRoot( rootElement ).render(
 		<QueryClientProvider client={ queryClient }>
 			<JobsApp />
-		</QueryClientProvider>,
-		rootElement
+		</QueryClientProvider>
 	);
 } );

--- a/inc/Core/Admin/Pages/Logs/assets/react/index.jsx
+++ b/inc/Core/Admin/Pages/Logs/assets/react/index.jsx
@@ -7,7 +7,7 @@
 /**
  * WordPress dependencies
  */
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 import domReady from '@wordpress/dom-ready';
 /**
  * External dependencies
@@ -41,10 +41,9 @@ domReady( () => {
 	}
 
 	// Render React app
-	render(
+	createRoot( rootElement ).render(
 		<QueryClientProvider client={ queryClient }>
 			<LogsApp />
-		</QueryClientProvider>,
-		rootElement
+		</QueryClientProvider>
 	);
 } );

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/index.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/index.jsx
@@ -7,7 +7,7 @@
 /**
  * WordPress dependencies
  */
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 import domReady from '@wordpress/dom-ready';
 /**
  * External dependencies
@@ -42,12 +42,11 @@ domReady( () => {
 	}
 
 	// Render React app
-	render(
+	createRoot( rootElement ).render(
 		<QueryClientProvider client={ queryClient }>
 			<HandlerProvider>
 				<PipelinesApp />
 			</HandlerProvider>
-		</QueryClientProvider>,
-		rootElement
+		</QueryClientProvider>
 	);
 } );

--- a/inc/Core/Admin/Settings/assets/react/index.jsx
+++ b/inc/Core/Admin/Settings/assets/react/index.jsx
@@ -7,7 +7,7 @@
 /**
  * WordPress dependencies
  */
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 import domReady from '@wordpress/dom-ready';
 /**
  * External dependencies
@@ -41,10 +41,9 @@ domReady( () => {
 	}
 
 	// Render React app
-	render(
+	createRoot( rootElement ).render(
 		<QueryClientProvider client={ queryClient }>
 			<SettingsApp />
-		</QueryClientProvider>,
-		rootElement
+		</QueryClientProvider>
 	);
 } );


### PR DESCRIPTION
## Summary

Migrates the 5 admin React entry points from the deprecated `@wordpress/element` `render()` API to `createRoot().render()`, required for React 19 compatibility.

## Changes

In each entry point:
- `import { render }` → `import { createRoot }` from `@wordpress/element`
- `render( <JSX/>, rootElement )` → `createRoot( rootElement ).render( <JSX/> )`
- Existing provider wrapping (`QueryClientProvider`, `HandlerProvider`) preserved exactly.

## Files

- `inc/Core/Admin/Settings/assets/react/index.jsx`
- `inc/Core/Admin/Pages/Pipelines/assets/react/index.jsx`
- `inc/Core/Admin/Pages/Logs/assets/react/index.jsx`
- `inc/Core/Admin/Pages/Agent/assets/react/index.jsx`
- `inc/Core/Admin/Pages/Jobs/assets/react/index.jsx`

## Verification

- `npm run build` succeeds (webpack compiled all 5 entrypoints cleanly).
- Grep confirms no remaining `import { render }` from `@wordpress/element` in admin entry points.

Closes #2364