### PR TITLE
feat: make SITE.md current-site-honest; add Blog ID + Last Updated to NETWORK.md sites table

### DIFF
--- a/inc/migrations/site-md.php
+++ b/inc/migrations/site-md.php
@@ -209,6 +209,10 @@ function datamachine_site_section_post_types(): string {
 
 	$lines   = array();
 	$lines[] = '## Post Types';
+	if ( is_multisite() ) {
+		$lines[] = sprintf( '*Reflects this site (blog %d) only. For the network map, see NETWORK.md.*', get_current_blog_id() );
+		$lines[] = '';
+	}
 	$lines[] = '| Label | Slug | Published | Type |';
 	$lines[] = '|-------|------|-----------|------|';
 
@@ -234,6 +238,10 @@ function datamachine_site_section_taxonomies(): string {
 
 	$lines   = array();
 	$lines[] = '## Taxonomies';
+	if ( is_multisite() ) {
+		$lines[] = sprintf( '*Reflects this site (blog %d) only. For the network map, see NETWORK.md.*', get_current_blog_id() );
+		$lines[] = '';
+	}
 	$lines[] = '| Label | Slug | Terms | Type | Post Types |';
 	$lines[] = '|-------|------|-------|------|------------|';
 
@@ -518,8 +526,8 @@ function datamachine_network_section_sites(): string {
 
 	$lines   = array();
 	$lines[] = '## Sites';
-	$lines[] = '| Site | URL | Theme |';
-	$lines[] = '|------|-----|-------|';
+	$lines[] = '| Site | Blog ID | URL | Theme | Last Updated |';
+	$lines[] = '|------|---------|-----|-------|--------------|';
 
 	foreach ( $sites as $site ) {
 		$blog_id = (int) $site->blog_id;
@@ -530,8 +538,10 @@ function datamachine_network_section_sites(): string {
 		$theme = wp_get_theme()->get( 'Name' ) ? wp_get_theme()->get( 'Name' ) : 'Unknown';
 		restore_current_blog();
 
+		$last_updated = $site->last_updated ? mysql2date( 'Y-m-d H:i', $site->last_updated ) : '';
+
 		$is_main = ( $blog_id === $main_site_id ) ? ' (main)' : '';
-		$lines[] = sprintf( '| %s%s | %s | %s |', $name, $is_main, $url, $theme );
+		$lines[] = sprintf( '| %s%s | %d | %s | %s | %s |', $name, $is_main, $blog_id, $url, $theme, $last_updated );
 	}
 
 	return implode( "\n", $lines );


### PR DESCRIPTION
## Summary

Implements #2366. All edits in `inc/migrations/site-md.php`.

### NETWORK.md Sites table — 5 columns
Adds **Blog ID** and **Last Updated** columns, mirroring wp core's `WP_Site` data:

```
| Site | Blog ID | URL | Theme | Last Updated |
```

- **Blog ID**: `(int) $site->blog_id`
- **Last Updated**: `mysql2date( 'Y-m-d H:i', $site->last_updated )` — reads `WP_Site::$last_updated`. No extra query, no content counting. This is the **liveness signal**.

### SITE.md current-site honesty
Adds a one-line note under `## Post Types` and `## Taxonomies` (multisite only):

> *Reflects this site (blog N) only. For the network map, see NETWORK.md.*

Uses `get_current_blog_id()`. Single-site installs are unaffected.

### Explicitly NOT done
- No per-subsite content footprint / CPT counts anywhere
- No per-subsite data added to SITE.md — `last_updated` is the liveness signal by design

## Verification (against live extrachill.com multisite)

- `php -l` clean
- Sites table renders 5 columns with correct blog IDs (**events=7**, **wire=11**) and formatted timestamps
- Events (`2026-05-30`) and wire (`2026-05-30`) show fresh `last_updated` — the two daily DM-fed engines, exactly as expected
- SITE.md note renders with the current blog id

Closes #2366