### PR TITLE
fix: derive fallback email From from site, not hardcoded domain

### DIFF
--- a/inc/Abilities/Email/EmailAbilities.php
+++ b/inc/Abilities/Email/EmailAbilities.php
@@ -1323,8 +1323,22 @@ class EmailAbilities {
 			}
 		}
 
-		$auth   = $this->getAuthProvider();
-		$from   = $auth ? $auth->getUser() : 'noreply@extrachill.com';
+		$auth = $this->getAuthProvider();
+		if ( $auth ) {
+			$from = $auth->getUser();
+		} else {
+			// Derive a sane fallback From address from the WordPress site itself
+			// rather than hardcoding any specific domain.
+			$host = wp_parse_url( home_url(), PHP_URL_HOST );
+			$from = $host ? 'wordpress@' . $host : get_bloginfo( 'admin_email' );
+		}
+
+		/**
+		 * Filters the From address used when appending a copy to the Sent folder.
+		 *
+		 * @param string $from The derived From address.
+		 */
+		$from   = apply_filters( 'dm_email_sent_folder_from', $from );
 		$to_str = implode( ', ', $to );
 		$date   = gmdate( 'r' );
 


### PR DESCRIPTION
Closes #2374.

## The leak

`inc/Abilities/Email/EmailAbilities.php:1327` hardcoded `noreply@extrachill.com` as the fallback `From:` address when no auth provider is configured, inside `saveToSentFolder()`. This was the **only live-code Extra Chill business-string leak** in the entire DM core tree — EC business identity stamped onto Sent-folder copies for any site running Data Machine.

```php
$from = $auth ? $auth->getUser() : 'noreply@extrachill.com';
```

## The fix

Derive the fallback from the WordPress site itself, never a hardcoded domain:

```php
$auth = $this->getAuthProvider();
if ( $auth ) {
    $from = $auth->getUser();
} else {
    $host = wp_parse_url( home_url(), PHP_URL_HOST );
    $from = $host ? 'wordpress@' . $host : get_bloginfo( 'admin_email' );
}

$from = apply_filters( 'dm_email_sent_folder_from', $from );
```

- Fallback is now site-derived (`wordpress@<site-host>`, with `admin_email` as a secondary fallback if the host can't be parsed).
- Added a `dm_email_sent_folder_from` filter so sites/config can override without code edits.

## Verification

- `grep -riE 'extrachill' inc/Abilities/Email/` → **no matches** (live code or docblocks).
- `php -l` → no syntax errors.

## Acceptance criteria

- [x] No hardcoded extrachill.com address in DM core live code
- [x] Fallback sender derived from the site or config