### PR TITLE
refactor: de-vendor AgentCall transport (layer purity)

### DIFF
--- a/inc/Abilities/AgentCall/AgentCallAbility.php
+++ b/inc/Abilities/AgentCall/AgentCallAbility.php
@@ -274,25 +274,22 @@ class AgentCallAbility {
 	}
 
 	/**
-	 * Build webhook payload.
+	 * Build the webhook payload.
+	 *
+	 * Core always builds the canonical {task, messages, context, timestamp}
+	 * envelope. Vendor-specific payload shaping does not live in core: the
+	 * `datamachine_agent_call_payload` filter lets an extension reshape the
+	 * envelope for a given target URL (e.g. a chat-platform webhook). The
+	 * filter receives the canonical payload plus the target URL and the raw
+	 * task/context, and must return an array to send as the JSON body.
+	 *
+	 * @param string $url      Target webhook URL.
+	 * @param string $task     Task string.
+	 * @param array  $context  Call context.
+	 * @param string $reply_to Optional reply-to identifier.
+	 * @return array Payload to encode as the webhook JSON body.
 	 */
 	private function buildWebhookPayload( string $url, string $task, array $context, string $reply_to ): array {
-		if ( $this->isDiscordWebhook( $url ) ) {
-			$first_packet = $context['data_packets'][0] ?? array();
-			$title        = $first_packet['content']['title'] ?? 'New content';
-			$packet_url   = $first_packet['metadata']['url'] ?? $first_packet['metadata']['permalink'] ?? '';
-			$source       = ! empty( $context['from_queue'] ) ? '📋' : '🤖';
-			$content      = "{$source} **{$title}**";
-			if ( ! empty( $packet_url ) ) {
-				$content .= "\n{$packet_url}";
-			}
-			if ( '' !== $task ) {
-				$content .= "\n\n{$task}";
-			}
-
-			return array( 'content' => $content );
-		}
-
 		$engine_data = is_array( $context['engine_data'] ?? null ) ? $context['engine_data'] : array();
 		$payload     = array(
 			'task'      => $task,
@@ -314,16 +311,63 @@ class AgentCallAbility {
 			$payload['reply_to'] = $reply_to;
 		}
 
-		return $payload;
+		/**
+		 * Filter the agent-call webhook payload before delivery.
+		 *
+		 * Extensions can register vendor-specific payload formatters keyed off
+		 * the target URL. Core does not know the shape of any specific vendor's
+		 * API; it only emits the canonical envelope.
+		 *
+		 * @param array  $payload  Canonical {task, messages, context, timestamp} envelope.
+		 * @param string $url      Target webhook URL.
+		 * @param string $task     Task string.
+		 * @param array  $context  Call context.
+		 * @param string $reply_to Optional reply-to identifier.
+		 */
+		$shaped = apply_filters( 'datamachine_agent_call_payload', $payload, $url, $task, $context, $reply_to );
+
+		return is_array( $shaped ) ? $shaped : $payload;
 	}
 
-	private function isDiscordWebhook( string $url ): bool {
-		return str_contains( $url, 'discord.com/api/webhooks/' )
-			|| str_contains( $url, 'discordapp.com/api/webhooks/' );
-	}
-
+	/**
+	 * Mask credentials in a webhook URL before logging.
+	 *
+	 * Generic credential-stripping: webhook providers commonly embed a secret
+	 * as the final path segment (e.g. /api/webhooks/<id>/<token>). Core does not
+	 * know any vendor's URL shape, so it redacts the last path segment of every
+	 * webhook URL while preserving scheme, host, and the leading path for
+	 * debuggability. The query string and fragment are dropped entirely since
+	 * they frequently carry tokens.
+	 *
+	 * @param string $url Webhook URL.
+	 * @return string URL with the trailing path segment masked.
+	 */
 	private function sanitizeUrlForLog( string $url ): string {
-		return preg_replace( '#(discord(?:app)?\.com/api/webhooks/\d+/)[^/\s]+#', '$1[MASKED]', $url );
+		$parts = wp_parse_url( $url );
+		if ( ! is_array( $parts ) || empty( $parts['host'] ) ) {
+			return '[MASKED]';
+		}
+
+		$scheme = isset( $parts['scheme'] ) ? $parts['scheme'] . '://' : '';
+		$host   = $parts['host'];
+		$port   = isset( $parts['port'] ) ? ':' . $parts['port'] : '';
+		$path   = isset( $parts['path'] ) ? $parts['path'] : '';
+
+		$base = $scheme . $host . $port;
+
+		if ( '' === $path || '/' === $path ) {
+			return $base . $path;
+		}
+
+		$trimmed  = rtrim( $path, '/' );
+		$segments = explode( '/', $trimmed );
+		if ( count( $segments ) > 1 ) {
+			$segments[ count( $segments ) - 1 ] = '[MASKED]';
+		} else {
+			$segments = array( '', '[MASKED]' );
+		}
+
+		return $base . implode( '/', $segments );
 	}
 
 	private function failure( string $error, array $output = array() ): array {

--- a/inc/Engine/AI/LoopEventSinkInterface.php
+++ b/inc/Engine/AI/LoopEventSinkInterface.php
@@ -18,7 +18,7 @@ interface LoopEventSinkInterface {
 	 * Emit a loop event.
 	 *
 	 * Event names are transport-neutral. Renderers can map them to logs, SSE,
-	 * WebSockets, CLI output, Discord updates, transcripts, or other consumers.
+	 * WebSockets, CLI output, chat updates, transcripts, or other consumers.
 	 *
 	 * @param string $event   Event name.
 	 * @param array  $payload Structured event payload.


### PR DESCRIPTION
## Summary

Fixes the LAYER-PURITY violation in `inc/Abilities/AgentCall/AgentCallAbility.php` (closes #2373). The generic agent-call webhook transport hardcoded Discord-specific payload shaping and Discord-only log masking. Per RULES.md, vendor names must not appear in generic-layer code — `grep -riE 'discord' inc/` now returns **zero matches**.

## What changed

### 1. Payload formatting — vendor shaping removed, filter hook added
- **Removed** the `isDiscordWebhook()`-gated branch in `buildWebhookPayload()` that built a Discord-shaped payload (`📋`/`🤖` emoji, `**bold**` Markdown, `content` string).
- **Removed** the `isDiscordWebhook()` helper entirely.
- Core now **always** builds the canonical `{task, messages, context, timestamp}` envelope.
- Added a `datamachine_agent_call_payload` filter that receives `($payload, $url, $task, $context, $reply_to)` and returns the array to send. Vendor-specific shaping is now an **extension concern** — core knows no vendor's API shape.

### 2. Log masking — generic credential stripping
- **Replaced** the Discord-only masking regex in `sanitizeUrlForLog()` with a generic pass that:
  - redacts the **last path segment** of every webhook URL (where providers commonly embed a secret token),
  - **drops the query string and fragment** entirely (they frequently carry tokens),
  - preserves scheme/host/port + leading path for debuggability,
  - fails safe to `[MASKED]` on unparseable input.
- Applies at all 7 logging/error sites (no call-site changes needed — same method).

Verified output:
```
discord.com/api/webhooks/123456/SECRET   => discord.com/api/webhooks/123456/[MASKED]
hooks.slack.com/services/T0/B0/XXXSECRET => hooks.slack.com/services/T0/B0/[MASKED]
example.com/webhook/mytoken?auth=zzz     => example.com/webhook/[MASKED]
notaurl                                  => [MASKED]
```

### 3. Docblock de-vendoring
- `inc/Engine/AI/LoopEventSinkInterface.php` L21: "Discord updates" → "chat updates" (vendor name in a docblock example is also a RULES.md violation).

## Verification
- `grep -riE 'discord' inc/` → **zero live-code matches** (confirmed, exit 1).
- `php -l` clean on both files.
- No dangling references to the removed `isDiscordWebhook()` method anywhere in the codebase.
- Non-Discord webhooks (and now ALL webhooks) receive the canonical envelope unless a registered formatter reshapes it.

## Follow-ups (out of scope for this PR / worktree)
- **Re-register the Discord payload formatter from an extension** (e.g. `data-machine-socials` or the integration layer) via `datamachine_agent_call_payload`. This worktree is `data-machine` only, so the vendor formatter cannot be added here. Until then, Discord webhooks receive the canonical envelope rather than the chat-styled `content` string.
- **Dispatch registration**: `execute()` still dispatches via generic literal checks (`'webhook'` target type, `'fire_and_forget'` mode). These are **transport/mode identifiers, not vendor names**, so they are not a layer-purity violation. Converting them to a registered target map is a reasonable enhancement but adds surface area beyond this fix — left as a follow-up to keep this PR scoped to the actual vendor-coupling violation.