### PR TITLE
feat: scaffold Working Style section in default USER.md

### DIFF
--- a/inc/migrations/scaffolding.php
+++ b/inc/migrations/scaffolding.php
@@ -170,6 +170,9 @@ function datamachine_get_scaffold_defaults( string $agent_name = '' ): array {
 			'## Preferences',
 			'<!-- Communication style, formatting preferences, things to remember -->',
 			'',
+			'## Working Style',
+			'<!-- Autonomy level, how to handle decisions/forks, detail depth, when to ask before acting -->',
+			'',
 			'## Goals',
 			"<!-- What you're working toward with this site or project -->",
 		)


### PR DESCRIPTION
## Summary
- Adds an empty **Working Style** section (with hint comment) to the scaffolded default `USER.md` in `inc/migrations/scaffolding.php`.
- Placed after `## Preferences` and before `## Goals`, mirroring the existing empty-section + hint-comment convention used by Preferences and Goals.

## Why
Every human-agent pairing has a working style — autonomy level, how to handle decisions/forks, detail depth, and when to ask before acting. Seeding the section prompts users to capture it, matching the universally useful nature of About / Preferences / Goals.

## Change
```
## Working Style
<!-- Autonomy level, how to handle decisions/forks, detail depth, when to ask before acting -->
```

## Verify
- `php -l inc/migrations/scaffolding.php` — no syntax errors.
- Heredoc/array now contains `## Working Style` with its hint comment, formatted identically to surrounding sections.
- No re-scaffold of the live site (existing files are never overwritten); code read of the array confirms the change.

Closes #2378