### PR TITLE
docs: de-vendor core examples (layer purity)

### DIFF
--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -993,7 +993,7 @@ class AgentsCommand extends AgentBundleCommand {
 	 *     wp datamachine agents config sarai
 	 *
 	 *     # Set allowed redirect URIs
-	 *     wp datamachine agents config sarai --set='allowed_redirect_uris=["saraichinwag.com","https://saraichinwag.com/*"]'
+	 *     wp datamachine agents config sarai --set='allowed_redirect_uris=["example.com","https://example.com/*"]'
 	 *
 	 *     # Set a single key
 	 *     wp datamachine agents config sarai --set='model=gpt-4o'

--- a/inc/Core/Auth/AgentAuthorize.php
+++ b/inc/Core/Auth/AgentAuthorize.php
@@ -409,7 +409,7 @@ class AgentAuthorize {
 	 *
 	 * Always allows: localhost (any port), 127.0.0.1, same-site URLs.
 	 * External domains must be registered in the agent's config:
-	 * agent_config.allowed_redirect_uris = ["https://saraichinwag.com/*"]
+	 * agent_config.allowed_redirect_uris = ["https://example.com/*"]
 	 *
 	 * This scopes the blast radius per-agent — a compromised agent can only
 	 * redirect to its own registered domains, not arbitrary URLs.
@@ -468,9 +468,9 @@ class AgentAuthorize {
 	 * Check if a URI matches an allowed pattern.
 	 *
 	 * Supports:
-	 * - Exact match: "https://saraichinwag.com/callback"
-	 * - Wildcard path: "https://saraichinwag.com/*"
-	 * - Domain-only: "saraichinwag.com" (matches any path on that domain)
+	 * - Exact match: "https://example.com/callback"
+	 * - Wildcard path: "https://example.com/*"
+	 * - Domain-only: "example.com" (matches any path on that domain)
 	 *
 	 * @param string $uri     The redirect URI to check.
 	 * @param string $pattern The allowed pattern.


### PR DESCRIPTION
## Summary
Fixes #2375 — Data Machine core (generic layer) hardcoded `saraichinwag.com` as the worked example in docblocks and CLI help. RULES.md layer purity counts examples as violations: generic core must not name specific sites.

Replaced all `saraichinwag.com` occurrences with `example.com` in:
- `inc/Core/Auth/AgentAuthorize.php` — redirect-URI validation docblocks (~L412, L471-473)
- `inc/Cli/Commands/AgentsCommand.php:996` — CLI `## EXAMPLES` help text

## Scope
- **Docs/comments/help-text ONLY.** No runtime logic changed — the redirect validation derives allowed hosts from `network_home_url()` and was already correct.

## Verification
```
$ grep -ri saraichinwag inc/
(zero matches)
```

mention @chubes — ready for review.