### PR TITLE
style: clear phpcs lint debt (release preflight)

### DIFF
--- a/inc/Cli/Commands/Flows/QueueCommand.php
+++ b/inc/Cli/Commands/Flows/QueueCommand.php
@@ -397,7 +397,7 @@ class QueueCommand extends BaseCommand {
 			$flow_step_id = $resolved['step_id'];
 		}
 
-		$step_type  = $this->getStepType( $flow_id, $flow_step_id );
+		$step_type = $this->getStepType( $flow_id, $flow_step_id );
 
 		if ( ! empty( $assoc_args['dry-run'] ) ) {
 			$list_ability_id = ( 'fetch' === $step_type )

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -313,7 +313,7 @@ function datamachine_run_conversation(
 	// Substrate now surfaces turn_count, final_content, usage, and
 	// request_metadata directly on the result (agents-api#136). Keep DM-only
 	// diagnostics namespaced so the top level remains the Agents API result.
-	$datamachine_metadata     = array(
+	$datamachine_metadata = array(
 		'completed'       => ! in_array( (string) ( $result['status'] ?? '' ), array( 'budget_exceeded', 'interrupted' ), true ),
 		'last_tool_calls' => $last_tool_calls,
 		'tool_calls'      => $all_tool_calls,


### PR DESCRIPTION
## Summary

Clears the auto-fixable PHPCS lint debt tracked in #2369 so the release preflight (`homeboy lint`) stops inheriting red checks on otherwise-clean PRs. **Formatting only — zero logic changes.**

## Before / after

`homeboy lint` on `main` reported **3 findings**:

| # | File:Line | Code | Severity | Auto-fixable |
|---|-----------|------|----------|--------------|
| 1 | `inc/Engine/AI/ConversationManager.php:365` | `WordPress.PHP.YodaConditions.NotYoda` | error | ❌ no |
| 2 | `inc/Cli/Commands/Flows/QueueCommand.php:400` | `Generic.Formatting.MultipleStatementAlignment.IncorrectWarning` | warning | ✅ yes |
| 3 | `inc/Engine/AI/conversation-loop.php:316` | `Generic.Formatting.MultipleStatementAlignment.IncorrectWarning` | warning | ✅ yes |

After `phpcbf` (WordPress-Extra ruleset, the same standard homeboy runs):

- **#2 and #3 fixed** — both files now pass `phpcs` cleanly with **0 findings**.
- **#1 left untouched** (see below).

## The diff (formatting-only confirmation)

Both changes remove a single extra space before `=` in a statement-alignment block. No operators, operands, or comparison order changed:

```diff
- $step_type  = $this->getStepType( $flow_id, $flow_step_id );
+ $step_type = $this->getStepType( $flow_id, $flow_step_id );
```
```diff
- $datamachine_metadata     = array(
+ $datamachine_metadata = array(
```

Verified via `git diff`: 2 files changed, 2 insertions(+), 2 deletions(-) — pure whitespace.

## Remaining finding — needs manual review (not in this PR)

**`inc/Engine/AI/ConversationManager.php:365`** — `WordPress.PHP.YodaConditions.NotYoda` (error, not phpcbf-fixable):

```php
if ( $tool_name !== ( $message['payload']['tool_name'] ?? null ) ) {
```

This requires a manual Yoda-condition rewrite (reorder operands so the variable is on the right). It is semantically safe but is an operand-order change rather than a pure-whitespace auto-fix, so per the formatting-only scope of this PR it is **left for a follow-up / reviewer decision**. Until it's addressed, `homeboy lint` will still flag this one `error`.

Refs #2369