### PR TITLE
Use WP Codebox WordPress setting

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -24,7 +24,7 @@
       "mysql_password": "",
       "release_latest_branch": "release-latest",
       "settings": {
-        "playground_wordpress_version": "7.0"
+        "wp_codebox_wordpress_version": "7.0"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Rename the Homeboy WordPress runtime setting from `playground_wordpress_version` to `wp_codebox_wordpress_version`.
- Keeps Data Machine's Homeboy config aligned with the Homeboy Extensions WP Codebox cleanup.

## Testing
- `jq empty homeboy.json`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Applied the config migration and ran JSON/diff verification; Chris remains responsible for review and merge.