### PR TITLE
feat(indexnow): add datamachine_indexnow_skip_auto_submit filter for bulk ops

### DIFF
--- a/inc/Abilities/SEO/IndexNowAbilities.php
+++ b/inc/Abilities/SEO/IndexNowAbilities.php
@@ -109,6 +109,23 @@ class IndexNowAbilities {
 			return;
 		}
 
+		/**
+		 * Filters whether to skip the automatic per-post IndexNow ping.
+		 *
+		 * Lets bulk/background operations (e.g. large historical imports)
+		 * suppress the per-item outbound IndexNow POST, which would otherwise
+		 * fire one synchronous HTTP request per published post and ask search
+		 * engines to crawl thousands of pages at once. Callers should restore
+		 * the filter after the bulk operation completes.
+		 *
+		 * @param bool     $skip    Whether to skip the auto-submit. Default false.
+		 * @param int      $post_id Post ID being published/updated.
+		 * @param \WP_Post $post    Post object.
+		 */
+		if ( apply_filters( 'datamachine_indexnow_skip_auto_submit', false, $post_id, $post ) ) {
+			return;
+		}
+
 		$url = get_permalink( $post_id );
 		if ( empty( $url ) ) {
 			return;


### PR DESCRIPTION
## Summary

Adds a generic `datamachine_indexnow_skip_auto_submit` filter to the IndexNow auto-ping, so bulk/background operations can suppress the per-post outbound ping.

## Why

`IndexNowAbilities::on_post_saved()` fires one synchronous `wp_remote_post` to IndexNow per published post. A bulk operation that publishes thousands of posts (e.g. a large historical event import) would emit thousands of synchronous outbound pings — stalling the import runtime and pointlessly asking search engines to crawl everything at once.

## What changed

- `on_post_saved()` now checks `apply_filters('datamachine_indexnow_skip_auto_submit', false, $post_id, $post)` before submitting. Defaults to false (unchanged behavior).
- Callers wrap their bulk loop: `add_filter('datamachine_indexnow_skip_auto_submit', '__return_true')` ... loop ... `remove_filter(...)`.

The filter name is shared with extrachill-seo's IndexNow integration (separate PR) so a single filter suppresses both pingers during one bulk operation.

## First consumer
Extra-Chill/extrachill-users concert-import (PR #82) wraps its historical-event import batch in this filter.

Conventional commit; no version/changelog hand-edits.