### PR TITLE
Decouple pipeline-editing surface into core pipeline_editor mode

### DIFF
--- a/inc/Api/Chat/Chat.php
+++ b/inc/Api/Chat/Chat.php
@@ -492,6 +492,19 @@ class Chat {
 		$pipeline_id = (int) $request->get_param( 'selected_pipeline_id' );
 		if ( $pipeline_id > 0 ) {
 			$input['selected_pipeline_id'] = $pipeline_id;
+
+			// A selected pipeline means this request originates from the DM admin
+			// pipeline editor surface. Opt that surface into pipeline_editor mode
+			// (composed on top of chat) so it receives the pipeline/handler/flow
+			// guidance, the pipelines inventory, and the pipeline-editing tools.
+			// Portable surfaces (frontend widgets, bridges) send no pipeline and
+			// stay on generic chat. See data-machine#2425.
+			$requested_mode  = sanitize_key( (string) ( $request->get_param( 'mode' ) ?? '' ) );
+			$composed_modes  = array( 'chat', 'pipeline_editor' );
+			if ( '' !== $requested_mode && ! in_array( $requested_mode, $composed_modes, true ) ) {
+				$composed_modes[] = $requested_mode;
+			}
+			$input['modes'] = $composed_modes;
 		}
 
 		if ( $request_id ) {

--- a/inc/Api/Chat/Chat.php
+++ b/inc/Api/Chat/Chat.php
@@ -499,8 +499,8 @@ class Chat {
 			// guidance, the pipelines inventory, and the pipeline-editing tools.
 			// Portable surfaces (frontend widgets, bridges) send no pipeline and
 			// stay on generic chat. See data-machine#2425.
-			$requested_mode  = sanitize_key( (string) ( $request->get_param( 'mode' ) ?? '' ) );
-			$composed_modes  = array( 'chat', 'pipeline_editor' );
+			$requested_mode = sanitize_key( (string) ( $request->get_param( 'mode' ) ?? '' ) );
+			$composed_modes = array( 'chat', 'pipeline_editor' );
 			if ( '' !== $requested_mode && ! in_array( $requested_mode, $composed_modes, true ) ) {
 				$composed_modes[] = $requested_mode;
 			}

--- a/inc/Api/Chat/ChatPipelinesDirective.php
+++ b/inc/Api/Chat/ChatPipelinesDirective.php
@@ -129,7 +129,7 @@ add_filter(
 		$directives[] = array(
 			'class'    => ChatPipelinesDirective::class,
 			'priority' => 45,
-			'modes'    => array( 'chat' ),
+			'modes'    => array( 'pipeline_editor' ),
 		);
 
 		return $directives;

--- a/inc/Api/Chat/Tools/AddPipelineStep.php
+++ b/inc/Api/Chat/Tools/AddPipelineStep.php
@@ -21,7 +21,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class AddPipelineStep extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'add_pipeline_step', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/add-pipeline-step' ) );
+		$this->registerTool( 'add_pipeline_step', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/add-pipeline-step' ) );
 	}
 
 	private static function getValidStepTypes(): array {

--- a/inc/Api/Chat/Tools/ApiQuery.php
+++ b/inc/Api/Chat/Tools/ApiQuery.php
@@ -24,7 +24,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ApiQuery extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'api_query', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'access_level' => 'editor' ) );
+		$this->registerTool( 'api_query', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'access_level' => 'editor' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/AuthenticateHandler.php
+++ b/inc/Api/Chat/Tools/AuthenticateHandler.php
@@ -23,7 +23,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class AuthenticateHandler extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'authenticate_handler', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'abilities' => array( 'datamachine/get-handlers', 'datamachine/get-auth-status', 'datamachine/save-auth-config', 'datamachine/disconnect-auth' ) ) );
+		$this->registerTool( 'authenticate_handler', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'abilities' => array( 'datamachine/get-handlers', 'datamachine/get-auth-status', 'datamachine/save-auth-config', 'datamachine/disconnect-auth' ) ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/ConfigureFlowSteps.php
+++ b/inc/Api/Chat/Tools/ConfigureFlowSteps.php
@@ -21,7 +21,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ConfigureFlowSteps extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'configure_flow_steps', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'abilities' => array( 'datamachine/update-flow-step', 'datamachine/validate-handler', 'datamachine/configure-flow-steps', 'datamachine/validate-flow-steps-config' ) ) );
+		$this->registerTool( 'configure_flow_steps', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'abilities' => array( 'datamachine/update-flow-step', 'datamachine/validate-handler', 'datamachine/configure-flow-steps', 'datamachine/validate-flow-steps-config' ) ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/ConfigurePipelineStep.php
+++ b/inc/Api/Chat/Tools/ConfigurePipelineStep.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ConfigurePipelineStep extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'configure_pipeline_step', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/update-pipeline-step' ) );
+		$this->registerTool( 'configure_pipeline_step', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/update-pipeline-step' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/CopyFlow.php
+++ b/inc/Api/Chat/Tools/CopyFlow.php
@@ -21,7 +21,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class CopyFlow extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'copy_flow', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/duplicate-flow' ) );
+		$this->registerTool( 'copy_flow', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/duplicate-flow' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/CreateFlow.php
+++ b/inc/Api/Chat/Tools/CreateFlow.php
@@ -21,7 +21,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class CreateFlow extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'create_flow', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'abilities' => array( 'datamachine/create-flow', 'datamachine/update-flow-step' ) ) );
+		$this->registerTool( 'create_flow', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'abilities' => array( 'datamachine/create-flow', 'datamachine/update-flow-step' ) ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/CreatePipeline.php
+++ b/inc/Api/Chat/Tools/CreatePipeline.php
@@ -21,7 +21,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class CreatePipeline extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'create_pipeline', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/create-pipeline' ) );
+		$this->registerTool( 'create_pipeline', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/create-pipeline' ) );
 	}
 
 	private static function getValidStepTypes(): array {

--- a/inc/Api/Chat/Tools/DeleteFile.php
+++ b/inc/Api/Chat/Tools/DeleteFile.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class DeleteFile extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'delete_file', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/delete-flow-file' ) );
+		$this->registerTool( 'delete_file', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/delete-flow-file' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/DeleteFlow.php
+++ b/inc/Api/Chat/Tools/DeleteFlow.php
@@ -18,7 +18,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class DeleteFlow extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'delete_flow', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/delete-flow' ) );
+		$this->registerTool( 'delete_flow', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/delete-flow' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/DeletePipeline.php
+++ b/inc/Api/Chat/Tools/DeletePipeline.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class DeletePipeline extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'delete_pipeline', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/delete-pipeline' ) );
+		$this->registerTool( 'delete_pipeline', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/delete-pipeline' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/DeletePipelineStep.php
+++ b/inc/Api/Chat/Tools/DeletePipelineStep.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class DeletePipelineStep extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'delete_pipeline_step', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/delete-pipeline-step' ) );
+		$this->registerTool( 'delete_pipeline_step', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/delete-pipeline-step' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
+++ b/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ExecuteWorkflowTool extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'execute_workflow', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/execute-workflow' ) );
+		$this->registerTool( 'execute_workflow', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/execute-workflow' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/GetHandlerDefaults.php
+++ b/inc/Api/Chat/Tools/GetHandlerDefaults.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class GetHandlerDefaults extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'get_handler_defaults', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'abilities' => array( 'datamachine/get-handler-site-defaults', 'datamachine/get-handlers', 'datamachine/get-handler-config-fields' ) ) );
+		$this->registerTool( 'get_handler_defaults', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'abilities' => array( 'datamachine/get-handler-site-defaults', 'datamachine/get-handlers', 'datamachine/get-handler-config-fields' ) ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/GetProblemFlows.php
+++ b/inc/Api/Chat/Tools/GetProblemFlows.php
@@ -24,7 +24,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class GetProblemFlows extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'get_problem_flows', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/get-problem-flows' ) );
+		$this->registerTool( 'get_problem_flows', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/get-problem-flows' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/ListFlows.php
+++ b/inc/Api/Chat/Tools/ListFlows.php
@@ -17,7 +17,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ListFlows extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'list_flows', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/get-flows' ) );
+		$this->registerTool( 'list_flows', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/get-flows' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/ManageJobs.php
+++ b/inc/Api/Chat/Tools/ManageJobs.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ManageJobs extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'manage_jobs', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'abilities' => array( 'datamachine/get-jobs', 'datamachine/get-jobs-summary', 'datamachine/delete-jobs', 'datamachine/fail-job', 'datamachine/retry-job', 'datamachine/recover-stuck-jobs' ) ) );
+		$this->registerTool( 'manage_jobs', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'abilities' => array( 'datamachine/get-jobs', 'datamachine/get-jobs-summary', 'datamachine/delete-jobs', 'datamachine/fail-job', 'datamachine/retry-job', 'datamachine/recover-stuck-jobs' ) ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/ManageLogs.php
+++ b/inc/Api/Chat/Tools/ManageLogs.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ManageLogs extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'manage_logs', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'abilities' => array( 'datamachine/clear-logs', 'datamachine/get-log-metadata' ) ) );
+		$this->registerTool( 'manage_logs', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'abilities' => array( 'datamachine/clear-logs', 'datamachine/get-log-metadata' ) ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/ManageQueue.php
+++ b/inc/Api/Chat/Tools/ManageQueue.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ManageQueue extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'manage_queue', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'abilities' => array( 'datamachine/queue-add', 'datamachine/queue-list', 'datamachine/queue-clear', 'datamachine/queue-remove', 'datamachine/queue-update', 'datamachine/queue-move', 'datamachine/queue-mode' ) ) );
+		$this->registerTool( 'manage_queue', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'abilities' => array( 'datamachine/queue-add', 'datamachine/queue-list', 'datamachine/queue-clear', 'datamachine/queue-remove', 'datamachine/queue-update', 'datamachine/queue-move', 'datamachine/queue-mode' ) ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/ReadLogs.php
+++ b/inc/Api/Chat/Tools/ReadLogs.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ReadLogs extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'read_logs', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/read-logs' ) );
+		$this->registerTool( 'read_logs', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/read-logs' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/ReorderPipelineSteps.php
+++ b/inc/Api/Chat/Tools/ReorderPipelineSteps.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ReorderPipelineSteps extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'reorder_pipeline_steps', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/reorder-pipeline-steps' ) );
+		$this->registerTool( 'reorder_pipeline_steps', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/reorder-pipeline-steps' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/RunFlow.php
+++ b/inc/Api/Chat/Tools/RunFlow.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class RunFlow extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'run_flow', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'abilities' => array( 'datamachine/run-flow', 'datamachine/schedule-flow' ) ) );
+		$this->registerTool( 'run_flow', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'abilities' => array( 'datamachine/run-flow', 'datamachine/schedule-flow' ) ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/SetHandlerDefaults.php
+++ b/inc/Api/Chat/Tools/SetHandlerDefaults.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class SetHandlerDefaults extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'set_handler_defaults', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/update-handler-defaults' ) );
+		$this->registerTool( 'set_handler_defaults', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/update-handler-defaults' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/SystemHealthCheck.php
+++ b/inc/Api/Chat/Tools/SystemHealthCheck.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class SystemHealthCheck extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'system_health_check', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/system-health-check' ) );
+		$this->registerTool( 'system_health_check', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/system-health-check' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/UpdateFlow.php
+++ b/inc/Api/Chat/Tools/UpdateFlow.php
@@ -18,7 +18,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class UpdateFlow extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'update_flow', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'datamachine/update-flow' ) );
+		$this->registerTool( 'update_flow', array( $this, 'getToolDefinition' ), array( 'pipeline_editor' ), array( 'ability' => 'datamachine/update-flow' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Directives/AgentModeDirective.php
+++ b/inc/Engine/AI/Directives/AgentModeDirective.php
@@ -35,7 +35,23 @@ class AgentModeDirective implements DirectiveInterface {
 	private const CHAT_MODE = <<<'MD'
 # Chat Session Context
 
-This is a live chat session with a user in the Data Machine admin UI. You have tools to configure and manage workflows. Your identity, voice, and knowledge come from your memory files above.
+This is a live interactive chat session with a user. Your identity, voice, and knowledge come from your memory files above.
+MD;
+
+	/**
+	 * Default pipeline editor mode guidance.
+	 *
+	 * The DM admin pipeline-editing surface (the pipeline chat with a selected
+	 * pipeline) opts into this mode in addition to `chat`. It carries the
+	 * pipeline/handler/flow operating manual that used to live in CHAT_MODE.
+	 * Generic chat surfaces (frontend widgets, bridges) never receive it.
+	 *
+	 * @since 0.139.0
+	 */
+	private const PIPELINE_EDITOR_MODE = <<<'MD'
+# Pipeline Editor Context
+
+You are in the Data Machine admin pipeline editor. You have tools to configure and manage workflows.
 
 ## Data Machine Architecture
 
@@ -194,10 +210,11 @@ MD;
 	 */
 	private static function get_default_for_mode( string $mode ): string {
 		return match ( $mode ) {
-			'chat'     => self::CHAT_MODE,
-			'pipeline' => self::PIPELINE_MODE,
-			'system'   => self::SYSTEM_MODE,
-			default     => '',
+			'chat'            => self::CHAT_MODE,
+			'pipeline_editor' => self::PIPELINE_EDITOR_MODE,
+			'pipeline'        => self::PIPELINE_MODE,
+			'system'          => self::SYSTEM_MODE,
+			default           => '',
 		};
 	}
 

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -179,6 +179,11 @@ add_action(
 			'description'     => __( 'Structured workflow execution. Operates within defined steps — efficient models work well.', 'data-machine' ),
 			'memory_contexts' => array( 'agent_identity', 'agent_memory' ),
 		) );
+		AgentModeRegistry::register( 'pipeline_editor', 25, array(
+			'label'           => __( 'Pipeline Editor Agent', 'data-machine' ),
+			'description'     => __( 'Admin pipeline-editing surface. Composes on top of chat to add pipeline/handler/flow guidance, the pipelines inventory, and pipeline-editing tools.', 'data-machine' ),
+			'memory_contexts' => array( 'agent_identity', 'agent_memory', 'user_profile' ),
+		) );
 		AgentModeRegistry::register( 'system', 30, array(
 			'label'       => __( 'System Agent', 'data-machine' ),
 			'description' => __( 'Background tasks like alt text generation and issue creation.', 'data-machine' ),

--- a/tests/Unit/AI/Tools/ChatToolsAvailabilityTest.php
+++ b/tests/Unit/AI/Tools/ChatToolsAvailabilityTest.php
@@ -26,9 +26,27 @@ class ChatToolsAvailabilityTest extends WP_UnitTestCase {
 		$this->resolver = new ToolPolicyResolver();
 	}
 
-	public function test_chat_tools_include_update_flow(): void {
+	public function test_chat_tools_exclude_pipeline_editing_tools(): void {
+		// Pipeline-editing tools (update_flow et al.) moved from the generic
+		// chat mode to the dedicated pipeline_editor mode so portable chat
+		// surfaces (frontend widget, bridge) no longer inherit them.
+		// See data-machine#2425.
 		$tools = $this->resolver->resolve( [
 			'mode'     => ToolPolicyResolver::MODE_CHAT,
+		] );
+
+		$this->assertIsArray( $tools );
+		$this->assertArrayNotHasKey( 'update_flow', $tools );
+		$this->assertArrayNotHasKey( 'create_pipeline', $tools );
+		$this->assertArrayNotHasKey( 'run_flow', $tools );
+		$this->assertArrayNotHasKey( 'execute_workflow', $tools );
+	}
+
+	public function test_pipeline_editor_tools_include_update_flow(): void {
+		// The pipeline-editing tools live on the pipeline_editor mode now; the
+		// DM admin pipeline chat opts into [chat, pipeline_editor].
+		$tools = $this->resolver->resolve( [
+			'mode'     => 'pipeline_editor',
 		] );
 
 		$this->assertIsArray( $tools );

--- a/tests/Unit/Engine/AI/Tools/ToolPolicyResolverTest.php
+++ b/tests/Unit/Engine/AI/Tools/ToolPolicyResolverTest.php
@@ -52,7 +52,9 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'web_fetch', $tools );
 	}
 
-	public function test_chat_includes_chat_tools(): void {
+	public function test_chat_excludes_pipeline_editing_tools(): void {
+		// Pipeline-editing tools moved to the pipeline_editor mode (data-machine#2425),
+		// so generic chat no longer surfaces them. Portable chat surfaces stay clean.
 		$tools = $this->resolver->resolve(
 			array(
 				'mode' => ToolPolicyResolver::MODE_CHAT,
@@ -60,7 +62,36 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		);
 
 		$this->assertIsArray( $tools );
+		$this->assertArrayNotHasKey( 'update_flow', $tools );
+		$this->assertArrayNotHasKey( 'create_pipeline', $tools );
+		$this->assertArrayNotHasKey( 'run_flow', $tools );
+	}
+
+	public function test_pipeline_editor_includes_pipeline_editing_tools(): void {
+		// The DM admin pipeline chat opts into [chat, pipeline_editor]; the
+		// pipeline-editing tools resolve under the pipeline_editor mode.
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => 'pipeline_editor',
+			)
+		);
+
+		$this->assertIsArray( $tools );
 		$this->assertArrayHasKey( 'update_flow', $tools );
+	}
+
+	public function test_composed_chat_pipeline_editor_unions_tools(): void {
+		// Mode composition is additive: the admin surface sends both modes and
+		// gets the union — generic chat tools plus pipeline-editing tools.
+		$tools = $this->resolver->resolve(
+			array(
+				'modes' => array( ToolPolicyResolver::MODE_CHAT, 'pipeline_editor' ),
+			)
+		);
+
+		$this->assertIsArray( $tools );
+		$this->assertArrayHasKey( 'update_flow', $tools );
+		$this->assertArrayHasKey( 'web_fetch', $tools );
 	}
 
 	public function test_chat_tools_pass_availability_check(): void {
@@ -721,10 +752,14 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_agent_policy_applies_to_chat_context(): void {
+		// Deny a tool that genuinely resolves under chat mode (send_ping is a
+		// portable chat tool) and confirm other chat tools survive. update_flow
+		// is no longer a chat tool post data-machine#2425, so it can't prove the
+		// deny policy here.
 		$agent_id = $this->createAgentWithPolicy(
 			array(
 				'mode'  => 'deny',
-				'tools' => array( 'update_flow' ),
+				'tools' => array( 'send_ping' ),
 			)
 		);
 
@@ -735,7 +770,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertArrayNotHasKey( 'update_flow', $tools );
+		$this->assertArrayNotHasKey( 'send_ping', $tools );
 		// Other chat tools should still be present.
 		$this->assertArrayHasKey( 'web_fetch', $tools );
 	}


### PR DESCRIPTION
## Summary

Closes #2425.

Generic core mode `chat` carried the **entire** DM admin pipeline-editor surface — a hardcoded "you are in the Data Machine admin UI" prompt, the pipelines inventory, and ~25 pipeline-editing tools. Any portable chat surface (the `frontend-agent-chat` widget, `data-machine-chat-bridge`) that sends no mode defaults to `chat` and therefore inherited the false location claim and the admin tool surface (proven live on the extrachill.com homepage).

This PR decouples the pipeline-editing **surface** from generic chat into a new core mode `pipeline_editor`, using the existing additive mode composition (guidance concatenates, tools union). `chat` becomes truly portable; the admin/pipeline context only appears when a surface that actually *is* the admin editor asks for it.

## New `pipeline_editor` mode

- Registered in **core** (`inc/bootstrap.php`) at priority **25** (between `pipeline`=20 and `system`=30; `editor`=40 unchanged), mirroring how `data-machine-editor` registers `editor`.
- Owns the pipeline/handler/flow guidance (moved out of `CHAT_MODE` into a new `PIPELINE_EDITOR_MODE` constant), the pipelines inventory directive, and the 25 pipeline-editing tools.
- The DM admin pipeline chat opts into `[chat, pipeline_editor]` **server-side**: in `Chat::handle_chat`, a request carrying `selected_pipeline_id` (the admin pipeline editor surface) sends `modes => ['chat','pipeline_editor']`. Any explicitly-requested mode is preserved/appended. No JS rebuild required.
- `AgentsChatHandler::resolveModes()` is **unchanged** — still defaults to `['chat']` for callers that send nothing, which is correct for portable surfaces.

## Files changed

**Core mode / directive plumbing**
- `inc/Engine/AI/Directives/AgentModeDirective.php` — slimmed `CHAT_MODE` to a location-agnostic generic chat default; added `PIPELINE_EDITOR_MODE` with the moved pipeline/handler/flow/scheduling/execution guidance; added `pipeline_editor` case to `get_default_for_mode()`.
- `inc/bootstrap.php` — registered the `pipeline_editor` mode (priority 25).
- `inc/Api/Chat/ChatPipelinesDirective.php` — re-gated the pipelines inventory directive `modes` from `['chat']` to `['pipeline_editor']`.
- `inc/Api/Chat/Chat.php` — admin pipeline chat (`selected_pipeline_id` present) now sends `modes => ['chat','pipeline_editor']`.

**Tools re-gated `chat` → `pipeline_editor` (25)**
`create_pipeline`, `delete_pipeline`, `add_pipeline_step`, `configure_pipeline_step`, `delete_pipeline_step`, `reorder_pipeline_steps`, `create_flow`, `copy_flow`, `delete_flow`, `update_flow`, `configure_flow_steps`, `list_flows`, `get_problem_flows`, `run_flow`, `execute_workflow`, `api_query`, `authenticate_handler`, `get_handler_defaults`, `set_handler_defaults`, `manage_jobs`, `manage_queue`, `manage_logs`, `read_logs`, `system_health_check`, `delete_file`.

**Kept on generic `chat` (portable, unchanged)**
`consult_agent`, `send_ping`, and the taxonomy tools `assign_taxonomy_term` / `create_taxonomy_term` / `merge_taxonomy_terms` / `search_taxonomy_terms` / `update_taxonomy_term`. `insert_content` was left untouched (it is multi-mode `['chat','pipeline','system','editor']`, not a pipeline-admin tool).

## Verification

- **`php -l`** clean on all 29 changed files.
- **`phpcs`** (repo lint) clean — exit 0 on all changed files.
- **Smoke tests pass**: `agents-chat-handler-smoke` (13), `directive-policy-resolver-smoke` (10), `ai-step-agent-mode-plumbing-smoke` (6), `global-tool-pipeline-modes-smoke` (16), `pipeline-tool-policy-surfaces-smoke` (10), `mode-model-resolution-smoke` (8).
- **Leak check (grep)**: no pipeline-admin tool remains gated on bare `chat`; `CHAT_MODE` no longer contains the admin-UI location claim or pipeline manual.
- **Session-mode storage**: the admin pipeline chat persists `mode = "chat,pipeline_editor"` (exactly 20 chars, fits the `mode VARCHAR(20)` column; `processContinue` already parses comma-joined modes back into an array). The session-list endpoint applies no mode filter in practice (the JS client sends `context`, which the route arg `mode` does not bind), so admin sessions still list correctly.

### Could not verify
- No runtime browser test of the live admin pipeline chat (PR-only, no deploy). Logic verified via code trace + smoke tests.

## Out of scope (separate follow-up)
- Activating `roadie` mode for the EC frontend widget (making the widget request `[chat, roadie]` + populate page `client_context`) lives in **extrachill-roadie / frontend-agent-chat**, not this PR. This core PR only removes the wrong location from generic chat and decouples the surface.