### PR TITLE
Fix bundle artifact table ensure during import

### DIFF
--- a/inc/Core/Database/BundleArtifacts/InstalledBundleArtifacts.php
+++ b/inc/Core/Database/BundleArtifacts/InstalledBundleArtifacts.php
@@ -23,6 +23,13 @@ final class InstalledBundleArtifacts extends BaseRepository {
 	public const TABLE_NAME = 'datamachine_bundle_artifacts';
 
 	/**
+	 * Whether this request has already ensured the artifact table exists.
+	 *
+	 * @var bool
+	 */
+	private static bool $table_ensured = false;
+
+	/**
 	 * Wire cleanup hooks once per request.
 	 *
 	 * Currently registers a `datamachine_agent_deleted` listener that wipes any tracked artifact rows
@@ -97,6 +104,8 @@ final class InstalledBundleArtifacts extends BaseRepository {
 	 * @return bool
 	 */
 	public function upsert( AgentBundleInstalledArtifact $artifact, int $agent_id = 0 ): bool {
+		self::ensure_table();
+
 		$artifact_row      = $artifact->to_array();
 		$installed_payload = $artifact->installed_payload();
 		$encoded_payload   = null === $installed_payload
@@ -126,6 +135,12 @@ final class InstalledBundleArtifacts extends BaseRepository {
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$result = $this->wpdb->replace( $this->table_name, $row, $format );
+		if ( false === $result ) {
+			self::$table_ensured = false;
+			self::ensure_table();
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result = $this->wpdb->replace( $this->table_name, $row, $format );
+		}
 		if ( false === $result ) {
 			$this->log_db_error( 'upsert installed bundle artifact', $this->safe_log_context( $row ) );
 			return false;
@@ -158,6 +173,8 @@ final class InstalledBundleArtifacts extends BaseRepository {
 	 * Find one tracked artifact.
 	 */
 	public function get( string $bundle_slug, string $artifact_type, string $artifact_id, int $agent_id = 0 ): ?AgentBundleInstalledArtifact {
+		self::ensure_table();
+
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$row = $this->wpdb->get_row(
 			$this->wpdb->prepare(
@@ -181,6 +198,8 @@ final class InstalledBundleArtifacts extends BaseRepository {
 	 * @return AgentBundleInstalledArtifact[]
 	 */
 	public function list_for_bundle( string $bundle_slug, int $agent_id = 0 ): array {
+		self::ensure_table();
+
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$rows = $this->wpdb->get_results(
 			$this->wpdb->prepare(
@@ -202,6 +221,8 @@ final class InstalledBundleArtifacts extends BaseRepository {
 	 * @return AgentBundleInstalledArtifact[]
 	 */
 	public function list_for_agent( int $agent_id ): array {
+		self::ensure_table();
+
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$rows = $this->wpdb->get_results(
 			$this->wpdb->prepare(
@@ -254,6 +275,8 @@ final class InstalledBundleArtifacts extends BaseRepository {
 	 * Delete a tracked artifact row.
 	 */
 	public function delete( string $bundle_slug, string $artifact_type, string $artifact_id, int $agent_id = 0 ): bool {
+		self::ensure_table();
+
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$result = $this->wpdb->delete(
 			$this->table_name,
@@ -293,6 +316,8 @@ final class InstalledBundleArtifacts extends BaseRepository {
 	}
 
 	private function existing_record_id( array $row ): ?int {
+		self::ensure_table();
+
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$value = $this->wpdb->get_var(
 			$this->wpdb->prepare(
@@ -317,5 +342,20 @@ final class InstalledBundleArtifacts extends BaseRepository {
 			'artifact_id'   => (string) $row['artifact_id'],
 			'local_status'  => AgentBundleArtifactStatus::classify( (string) $row['installed_hash'], isset( $row['current_hash'] ) ? (string) $row['current_hash'] : null ),
 		);
+	}
+
+	/**
+	 * Ensure the table exists before runtime artifact reads/writes.
+	 *
+	 * Deploy-time migrations normally create this table, but isolated runtimes can
+	 * import bundles before the version-gated schema ensure has run.
+	 */
+	private static function ensure_table(): void {
+		if ( self::$table_ensured ) {
+			return;
+		}
+
+		self::create_table();
+		self::$table_ensured = true;
 	}
 }

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -242,6 +242,26 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$this->assertSame( array( 'agent_config', 'flow', 'pipeline' ), $types, 'Importer writes installed artifact state to the canonical table.' );
 	}
 
+	public function test_import_ensures_installed_artifact_table_at_runtime(): void {
+		global $wpdb;
+
+		// Some isolated runtimes can reach bundle import before deploy-time schema
+		// ensures run. The repository should self-heal instead of failing import.
+		$suppress_errors = $wpdb->suppress_errors( true );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}datamachine_bundle_artifacts" );
+		$wpdb->suppress_errors( $suppress_errors );
+
+		$result = $this->bundler->import( $this->fixture_bundle( 'artifact-table-ensure-agent' ), null, $this->owner_id );
+
+		$this->assertTrue( (bool) $result['success'], 'Bundle import succeeds after recreating the artifact table.' );
+
+		$agent     = $this->agents_repo->get_by_slug( 'artifact-table-ensure-agent' );
+		$artifacts = ( new InstalledBundleArtifacts() )->list_for_bundle( 'artifact-table-ensure-agent', (int) $agent['agent_id'] );
+
+		$this->assertCount( 3, $artifacts, 'Installed artifact rows are written after runtime table ensure.' );
+	}
+
 	public function test_directory_value_object_import_preserves_workflow_runtime_seed_fields(): void {
 		$bundle = $this->fixture_bundle( 'directory-import-agent' );
 		$bundle['flows'][0]['flow_config']['1_step-uuid_1'] = array_merge(


### PR DESCRIPTION
## Summary
- Ensures the installed bundle artifact table exists before runtime artifact reads and writes.
- Retries artifact upsert after re-running the schema ensure when the first write fails.
- Adds coverage for bundle import recreating `datamachine_bundle_artifacts` in isolated runtimes.

## Evidence
- `wp-site-generator` iterator run reached `datamachine/import-agent` after bundle schema migration and failed with `install_post_claim_failure`: https://github.com/chubes4/wp-site-generator/actions/runs/26715895064
- Result artifact error: `Agent install rolled back: Failed to persist installed bundle artifact state.`

## Verification
- `php -l inc/Core/Database/BundleArtifacts/InstalledBundleArtifacts.php`
- `php -l tests/Unit/Core/Agents/AgentBundlerImportTest.php`
- `git diff --check`
- `composer test` (`1306 passed, 3 skipped`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed CI artifact import failures, implemented the runtime table ensure, and added regression coverage.