### PR TITLE
Block repeated tools until required follow-up

### DIFF
--- a/inc/Engine/AI/DataMachineToolRuntimeRules.php
+++ b/inc/Engine/AI/DataMachineToolRuntimeRules.php
@@ -64,6 +64,10 @@ class DataMachineToolRuntimeRules {
 			return $this->evaluateRequirePriorToolRule( $rule, $tool_name, $messages );
 		}
 
+		if ( 'block_until_tool' === ( $rule['type'] ?? '' ) ) {
+			return $this->evaluateBlockUntilToolRule( $rule, $tool_name, $messages );
+		}
+
 		$after_tool  = (string) $rule['after_tool'];
 		$after_index = $this->lastToolCallIndex( $messages, $after_tool );
 		if ( $after_index < 0 ) {
@@ -172,6 +176,60 @@ class DataMachineToolRuntimeRules {
 	}
 
 	/**
+	 * @param array<string,mixed> $rule Runtime rule.
+	 * @return array{allowed:bool,error:string,context:array<string,mixed>}
+	 */
+	private function evaluateBlockUntilToolRule( array $rule, string $tool_name, array $messages ): array {
+		$after_tool  = (string) $rule['after_tool'];
+		$after_index = $this->lastToolCallIndex( $messages, $after_tool );
+		if ( $after_index < 0 ) {
+			return array(
+				'allowed' => true,
+				'error'   => '',
+				'context' => array(),
+			);
+		}
+
+		$until_one_of = (array) $rule['until_one_of'];
+		if ( in_array( $tool_name, $until_one_of, true ) || $this->hasToolCallAfter( $messages, $after_index, $until_one_of ) ) {
+			return array(
+				'allowed' => true,
+				'error'   => '',
+				'context' => array(),
+			);
+		}
+
+		$blocked_tools = (array) $rule['blocked_tools'];
+		if ( ! in_array( $tool_name, $blocked_tools, true ) ) {
+			return array(
+				'allowed' => true,
+				'error'   => '',
+				'context' => array(),
+			);
+		}
+
+		$required = implode( ', ', $until_one_of );
+		$error    = sprintf(
+			'TOOL POLICY REJECTED: After %1$s, do not use %2$s again until one of these follow-up tools succeeds: %3$s.',
+			$after_tool,
+			$tool_name,
+			$required
+		);
+
+		return array(
+			'allowed' => false,
+			'error'   => $error,
+			'context' => array(
+				'rule_id'       => (string) $rule['id'],
+				'after_tool'    => $after_tool,
+				'blocked_tools' => $blocked_tools,
+				'until_one_of'  => $until_one_of,
+				'rejected_tool' => $tool_name,
+			),
+		);
+	}
+
+	/**
 	 * @return array<int,array<string,mixed>>
 	 */
 	private function normalizeRules( array $rules ): array {
@@ -196,6 +254,24 @@ class DataMachineToolRuntimeRules {
 					'before_tool'                   => $before_tool,
 					'require_prior_tool'            => $require_prior_tool,
 					'require_prior_tool_parameters' => $require_prior_tool_parameters,
+				);
+				continue;
+			}
+
+			if ( 'block_until_tool' === $type ) {
+				$after_tool    = $this->sanitizeToolName( $rule['after_tool'] ?? '' );
+				$blocked_tools = $this->sanitizeToolList( $rule['blocked_tools'] ?? $rule['blocked_tool_names'] ?? array() );
+				$until_one_of  = $this->sanitizeToolList( $rule['until_one_of'] ?? $rule['then_require_one_of'] ?? array() );
+				if ( '' === $after_tool || empty( $blocked_tools ) || empty( $until_one_of ) ) {
+					continue;
+				}
+
+				$normalized[] = array(
+					'id'            => $this->sanitizeRuleId( $rule['id'] ?? 'tool-runtime-rule-' . $index ),
+					'type'          => 'block_until_tool',
+					'after_tool'    => $after_tool,
+					'blocked_tools' => $blocked_tools,
+					'until_one_of'  => $until_one_of,
 				);
 				continue;
 			}
@@ -317,7 +393,7 @@ class DataMachineToolRuntimeRules {
 
 	private function sanitizeRuleType( $value ): string {
 		$value = sanitize_key( (string) $value );
-		return in_array( $value, array( 'require_prior_tool' ), true ) ? $value : '';
+		return in_array( $value, array( 'require_prior_tool', 'block_until_tool' ), true ) ? $value : '';
 	}
 
 	/**

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -866,6 +866,94 @@ assert_runtime_policy( 6 === $pr_prerequisite_dispatch_count, 'prior-tool runtim
 assert_runtime_policy( array( 'agent_daily_memory', 'agent_daily_memory', 'create_github_pull_request' ) === $pr_prerequisite_tool_names, 'prior-tool runtime rule excludes rejected PR attempts from tool results' );
 assert_runtime_policy( str_contains( wp_json_encode( $pr_prerequisite_result['messages'] ?? array() ), 'Before using create_github_pull_request' ), 'prior-tool runtime rule explains required tool order' );
 
+$block_until_dispatch_count = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$block_until_dispatch_count ) {
+		++$block_until_dispatch_count;
+		$tool_name = match ( $block_until_dispatch_count ) {
+			1, 2 => 'create_github_issue',
+			3    => 'comment_github_pull_request',
+			default => '',
+		};
+
+		if ( '' === $tool_name ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => 'Done after source PR callback.',
+					'tool_calls' => array(),
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => '',
+				'tool_calls' => array(
+					array(
+						'name'       => $tool_name,
+						'parameters' => array( 'name' => 'block-until-smoke-' . $block_until_dispatch_count ),
+					),
+				),
+			),
+		);
+	}
+);
+
+$block_until_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'open one fallback issue, then comment on the source PR' ) ),
+	array(
+		'create_github_issue'          => array(
+			'name'        => 'create_github_issue',
+			'description' => 'Open a fallback issue',
+			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+		'comment_github_pull_request' => array(
+			'name'        => 'comment_github_pull_request',
+			'description' => 'Comment back on the source PR',
+			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	array( 'pipeline' ),
+	array(
+		'completion_assertions' => array(
+			'complete_when_any'    => array(
+				array(
+					'name'  => 'issue_fallback_path',
+					'tools' => array(
+						array( 'name' => 'create_github_issue' ),
+						array( 'name' => 'comment_github_pull_request' ),
+					),
+				),
+			),
+			'required_tool_names' => array( 'comment_github_pull_request' ),
+		),
+		'tool_runtime_rules'    => array(
+			array(
+				'id'            => 'issue-before-source-callback-smoke',
+				'type'          => 'block_until_tool',
+				'after_tool'    => 'create_github_issue',
+				'blocked_tools' => array( 'create_github_issue' ),
+				'until_one_of'  => array( 'comment_github_pull_request' ),
+			),
+		),
+	),
+	6
+);
+
+$block_until_tool_names = array_map( static fn( $entry ) => (string) ( $entry['tool_name'] ?? '' ), $block_until_result['tool_execution_results'] ?? array() );
+assert_runtime_policy( 3 === $block_until_dispatch_count, 'block-until runtime rule lets the model recover after rejected repeat publish tool' );
+assert_runtime_policy( array( 'create_github_issue', 'comment_github_pull_request' ) === $block_until_tool_names, 'block-until runtime rule excludes repeated publish tool before callback' );
+assert_runtime_policy( str_contains( wp_json_encode( $block_until_result['messages'] ?? array() ), 'After create_github_issue' ), 'block-until runtime rule explains required follow-up tool' );
+
 $satisfied_runtime_rule_dispatch_count = 0;
 WpAiClientTestDouble::reset();
 WpAiClientTestDouble::set_response_callback(


### PR DESCRIPTION
## Summary
- Add a generic `block_until_tool` runtime rule for AI conversation tool policies.
- Use it to reject repeated publish/action tools until a required follow-up tool is called.
- Cover the recovery path where a model retries `create_github_issue` before the required source callback.

## Testing
- `php -l inc/Engine/AI/DataMachineToolRuntimeRules.php`
- `php tests/agent-conversation-runtime-policy-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the iterator duplicate-issue failure, implemented the runtime rule and smoke coverage, and ran the targeted verification commands.