### PR TITLE
Expose top-level tool result fields to models

### DIFF
--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -160,12 +160,13 @@ class ConversationManager {
 			'turn'    => $turn_count,
 		);
 
-		if ( ! empty( $tool_result['data'] ) ) {
-			$payload['tool_data'] = $tool_result['data'];
+		$tool_data = self::modelFacingToolData( $tool_result );
+		if ( ! empty( $tool_data ) ) {
+			$payload['tool_data'] = $tool_data;
 
 			// Still append to content for AI context, but frontend can use metadata to hide it
 			if ( ! $is_handler_tool ) {
-				$content .= "\n\n" . wp_json_encode( $tool_result['data'] );
+				$content .= "\n\n" . wp_json_encode( $tool_data );
 			}
 		}
 
@@ -194,7 +195,7 @@ class ConversationManager {
 	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Kept for callers that pass original tool params alongside result data.
 	public static function generateSuccessMessage( string $tool_name, array $tool_result, array $tool_parameters ): string {
 		$success = $tool_result['success'] ?? false;
-		$data    = $tool_result['data'] ?? array();
+		$data    = self::modelFacingToolData( $tool_result );
 
 		if ( ! $success ) {
 			$error = $tool_result['error'] ?? 'Unknown error occurred';
@@ -215,6 +216,43 @@ class ConversationManager {
 
 		// Default fallback for tools without custom message
 		return 'SUCCESS: ' . ucwords( str_replace( '_', ' ', $tool_name ) ) . ' completed successfully.';
+	}
+
+	/**
+	 * Return bounded, model-facing tool data from common result shapes.
+	 *
+	 * Some extension tools return canonical outputs (for example `url`) at the
+	 * top level instead of inside `data`; expose safe scalars so follow-up tools
+	 * can reference exact created resources without re-querying.
+	 *
+	 * @param array $tool_result Tool result envelope.
+	 * @return array<string,mixed>
+	 */
+	private static function modelFacingToolData( array $tool_result ): array {
+		if ( ! empty( $tool_result['data'] ) && is_array( $tool_result['data'] ) ) {
+			return $tool_result['data'];
+		}
+
+		$public_keys = array(
+			'kind',
+			'repo',
+			'number',
+			'issue_number',
+			'pull_number',
+			'url',
+			'html_url',
+			'issue_url',
+			'pull_request_url',
+			'message',
+		);
+		$data        = array();
+		foreach ( $public_keys as $key ) {
+			if ( isset( $tool_result[ $key ] ) && ( is_scalar( $tool_result[ $key ] ) || null === $tool_result[ $key ] ) ) {
+				$data[ $key ] = $tool_result[ $key ];
+			}
+		}
+
+		return $data;
 	}
 
 	/**

--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -400,7 +400,7 @@ class ConversationManager {
 				continue;
 			}
 
-			if ( $tool_name !== ( $message['payload']['tool_name'] ?? null ) ) {
+			if ( ( $message['payload']['tool_name'] ?? null ) !== $tool_name ) {
 				continue;
 			}
 

--- a/tests/ai-message-envelope-smoke.php
+++ b/tests/ai-message-envelope-smoke.php
@@ -13,6 +13,12 @@ use AgentsAPI\AI\WP_Agent_Conversation_Result;
 use DataMachine\Engine\AI\ConversationManager;
 use AgentsAPI\AI\WP_Agent_Message;
 
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $flags = 0 ) {
+		return json_encode( $data, $flags );
+	}
+}
+
 function datamachine_message_envelope_assert( bool $condition, string $message ): void {
 	if ( ! $condition ) {
 		throw new RuntimeException( $message );
@@ -89,6 +95,27 @@ datamachine_message_envelope_count();
 datamachine_message_envelope_assert( array( 'post_id' => 123 ) === $tool_result_envelope['payload']['tool_data'], 'Tool result data is promoted to envelope payload.' );
 datamachine_message_envelope_count();
 datamachine_message_envelope_assert( $legacy_tool_result === WP_Agent_Message::to_provider_message( $tool_result_envelope ), 'Tool result envelope projects back to provider message shape.' );
+datamachine_message_envelope_count();
+
+$top_level_tool_result = ConversationManager::formatToolResultMessage(
+	'create_github_issue',
+	array(
+		'success'      => true,
+		'kind'         => 'issue',
+		'repo'         => 'Extra-Chill/data-machine',
+		'issue_number' => 2433,
+		'url'          => 'https://github.com/Extra-Chill/data-machine/issues/2433',
+		'html_url'     => 'https://github.com/Extra-Chill/data-machine/issues/2433',
+		'message'      => 'Issue #2433 created in Extra-Chill/data-machine.',
+	),
+	array(),
+	false,
+	4
+);
+$top_level_tool_result_envelope = WP_Agent_Message::normalize( $top_level_tool_result );
+datamachine_message_envelope_assert( 'https://github.com/Extra-Chill/data-machine/issues/2433' === ( $top_level_tool_result_envelope['payload']['tool_data']['url'] ?? null ), 'Top-level tool result URL is promoted to tool_data.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( str_contains( $top_level_tool_result['content'], 'github.com\\/Extra-Chill\\/data-machine\\/issues\\/2433' ), 'Top-level tool result URL is included in model-facing content.' );
 datamachine_message_envelope_count();
 
 $typed_final_result = array(


### PR DESCRIPTION
## Summary
- Promote safe top-level tool result fields such as `url`, `html_url`, `issue_url`, and `message` into model-facing `tool_data` when a tool does not return a nested `data` payload.
- Preserve existing nested `data` behavior for tools that already use it.
- Cover the issue-creation shape so follow-up tools can include exact upstream URLs without re-querying.

## Testing
- `php -l inc/Engine/AI/ConversationManager.php`
- `php tests/ai-message-envelope-smoke.php`
- `php tests/agent-conversation-runtime-policy-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the missing issue URL in iterator callbacks, implemented the model-facing result exposure fix, and ran targeted smoke tests.