### PR TITLE
Merge safe top-level tool result fields

### DIFF
--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -229,8 +229,9 @@ class ConversationManager {
 	 * @return array<string,mixed>
 	 */
 	private static function modelFacingToolData( array $tool_result ): array {
+		$data = array();
 		if ( ! empty( $tool_result['data'] ) && is_array( $tool_result['data'] ) ) {
-			return $tool_result['data'];
+			$data = $tool_result['data'];
 		}
 
 		$public_keys = array(
@@ -245,9 +246,8 @@ class ConversationManager {
 			'pull_request_url',
 			'message',
 		);
-		$data        = array();
 		foreach ( $public_keys as $key ) {
-			if ( isset( $tool_result[ $key ] ) && ( is_scalar( $tool_result[ $key ] ) || null === $tool_result[ $key ] ) ) {
+			if ( ! array_key_exists( $key, $data ) && isset( $tool_result[ $key ] ) && ( is_scalar( $tool_result[ $key ] ) || null === $tool_result[ $key ] ) ) {
 				$data[ $key ] = $tool_result[ $key ];
 			}
 		}

--- a/tests/ai-message-envelope-smoke.php
+++ b/tests/ai-message-envelope-smoke.php
@@ -118,6 +118,25 @@ datamachine_message_envelope_count();
 datamachine_message_envelope_assert( str_contains( $top_level_tool_result['content'], 'github.com\\/Extra-Chill\\/data-machine\\/issues\\/2433' ), 'Top-level tool result URL is included in model-facing content.' );
 datamachine_message_envelope_count();
 
+$merged_tool_result = ConversationManager::formatToolResultMessage(
+	'create_github_issue',
+	array(
+		'success'  => true,
+		'data'     => array(
+			'message' => 'Issue created.',
+		),
+		'html_url' => 'https://github.com/Extra-Chill/data-machine/issues/2434',
+	),
+	array(),
+	false,
+	4
+);
+$merged_tool_result_envelope = WP_Agent_Message::normalize( $merged_tool_result );
+datamachine_message_envelope_assert( 'https://github.com/Extra-Chill/data-machine/issues/2434' === ( $merged_tool_result_envelope['payload']['tool_data']['html_url'] ?? null ), 'Safe top-level tool result URL is merged into existing tool_data.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( 'Issue created.' === ( $merged_tool_result_envelope['payload']['tool_data']['message'] ?? null ), 'Existing nested tool data is preserved when top-level fields are merged.' );
+datamachine_message_envelope_count();
+
 $typed_final_result = array(
 	'schema'   => WP_Agent_Message::SCHEMA,
 	'version'  => WP_Agent_Message::VERSION,


### PR DESCRIPTION
## Summary
- Merge safe top-level tool result fields into existing nested `tool_data` instead of using them only when `data` is absent.
- Add smoke coverage for tool results that return both nested `data` and top-level issue URLs.

## Verification
- `php -l inc/Engine/AI/ConversationManager.php`
- `php tests/ai-message-envelope-smoke.php`
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `homeboy lint data-machine --path \"/Users/chubes/Developer/data-machine-release-main@fix-merge-tool-result-data\" --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the iterator callback result exposure gap, drafted the small PHP fix and regression smoke test, and ran local verification. Chris remains responsible for review and merge.