### PR TITLE
Fix Codex connect timeout for wp-ai-client requests

### DIFF
--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -21,6 +21,7 @@ require_once __DIR__ . '/WpAiClientCache.php';
 require_once __DIR__ . '/DefaultOptionsHttpTransporter.php';
 
 class RequestBuilder {
+	private const CODEX_CONNECT_TIMEOUT_FLOOR = 120.0;
 
 	/**
 	 * Build standardized AI request for any execution mode.
@@ -646,6 +647,13 @@ class RequestBuilder {
 			),
 			$request_timeout
 		);
+		if ( self::isCodexProvider( $provider ) ) {
+			$default_timeout = min(
+				max( $default_timeout, self::CODEX_CONNECT_TIMEOUT_FLOOR ),
+				$request_timeout,
+				PluginSettings::MAX_WP_AI_CLIENT_CONNECT_TIMEOUT
+			);
+		}
 		$timeout         = apply_filters(
 			'datamachine_wp_ai_client_connect_timeout',
 			$default_timeout,
@@ -661,6 +669,10 @@ class RequestBuilder {
 		}
 
 		return max( 0.0, (float) $timeout );
+	}
+
+	private static function isCodexProvider( string $provider ): bool {
+		return 'codex' === strtolower( $provider );
 	}
 
 	/**

--- a/tests/wp-ai-client-codex-timeout-smoke.php
+++ b/tests/wp-ai-client-codex-timeout-smoke.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Smoke test for Codex-specific wp-ai-client transport defaults.
+ *
+ * Run with: php tests/wp-ai-client-codex-timeout-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+$GLOBALS['datamachine_codex_timeout_test_settings'] = array(
+	'wp_ai_client_connect_timeout' => 25.0,
+	'wp_ai_client_request_timeout' => 180.0,
+);
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $option, $default_value = false ) {
+		if ( 'datamachine_settings' === $option ) {
+			return $GLOBALS['datamachine_codex_timeout_test_settings'];
+		}
+		return $default_value;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		unset( $hook, $args );
+		return $value;
+	}
+}
+
+require_once __DIR__ . '/bootstrap-unit.php';
+
+use DataMachine\Engine\AI\RequestBuilder;
+
+$failures = 0;
+
+function assert_codex_timeout_smoke( bool $condition, string $label ): void {
+	global $failures;
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	echo "FAIL: {$label}\n";
+	++$failures;
+}
+
+$openai_transport = RequestBuilder::wpAiClientTransportProfile( 'sandbox', 'openai', 'gpt-smoke', array() );
+$codex_transport  = RequestBuilder::wpAiClientTransportProfile( 'sandbox', 'codex', 'gpt-5.5', array() );
+
+assert_codex_timeout_smoke( 25.0 === ( $openai_transport['connect_timeout'] ?? null ), 'regular providers keep configured connect timeout default' );
+assert_codex_timeout_smoke( 120.0 === ( $codex_transport['connect_timeout'] ?? null ), 'Codex provider receives longer connect timeout default' );
+assert_codex_timeout_smoke( 180.0 === ( $codex_transport['request_timeout'] ?? null ), 'Codex provider keeps configured request timeout default' );
+
+$GLOBALS['datamachine_codex_timeout_test_settings']['wp_ai_client_request_timeout'] = 60.0;
+$settings_reflection = new ReflectionClass( \DataMachine\Core\PluginSettings::class );
+$settings_cache      = $settings_reflection->getProperty( 'cache' );
+$settings_cache->setValue( null, null );
+$short_codex = RequestBuilder::wpAiClientTransportProfile( 'sandbox', 'codex', 'gpt-5.5', array() );
+assert_codex_timeout_smoke( 60.0 === ( $short_codex['connect_timeout'] ?? null ), 'Codex connect timeout floor does not exceed request timeout' );
+
+if ( $failures > 0 ) {
+	exit( 1 );
+}
+
+echo "\nwp-ai-client Codex timeout smoke passed.\n";


### PR DESCRIPTION
## Summary
- Raise the default wp-ai-client connect timeout floor to 120s for the `codex` provider only.
- Keep regular providers on the configured/default connect timeout and cap Codex by the resolved request timeout.
- Add a focused smoke test for Codex transport defaults.

## Verification
- `php -l inc/Engine/AI/RequestBuilder.php`
- `php -l tests/wp-ai-client-codex-timeout-smoke.php`
- `php tests/wp-ai-client-codex-timeout-smoke.php`

## Live fan-out evidence
- Before this change, a real Homeboy -> WP Codebox -> Codex fan-out failed both cells at `cURL error 28: Operation timed out after 15002 milliseconds`.
- With this branch mounted into WP Codebox, the same fan-out got past the 15s transport failure; one cell completed a Codex response and the other reached the 300s scheduler timeout.
- Follow-up blocker exposed by that run: Codex emitted raw textual tool tags like `<workspace_read ... />` and `<tool name="workspace_read">...`, which Data Machine did not extract as executable tool calls. That is separate from the transport timeout fixed here.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the Codex transport timeout, drafting the provider-aware timeout policy and smoke coverage, and running local/live verification. Chris remains responsible for review and merge.