### PR TITLE
Parse tag-style text tool calls

### DIFF
--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1536,7 +1536,7 @@ function datamachine_extract_tool_calls( $result ): array {
 				continue;
 			}
 
-			$tool_calls = array_merge( $tool_calls, datamachine_extract_xml_tool_calls( $text ), datamachine_extract_json_tool_calls( $text ) );
+			$tool_calls = array_merge( $tool_calls, datamachine_extract_xml_tool_calls( $text ), datamachine_extract_json_tool_calls( $text ), datamachine_extract_tag_tool_calls( $text ) );
 		}
 	}
 
@@ -1634,6 +1634,66 @@ function datamachine_extract_json_tool_calls( string $text ): array {
 				'name'       => $name,
 				'parameters' => is_array( $parameters ) ? $parameters : datamachine_normalize_function_args( $parameters ),
 				'id'         => $call['id'] ?? ( 'json-tool-call-' . ( $index + 1 ) . '-' . ( $call_index + 1 ) ),
+			);
+		}
+	}
+
+	return $tool_calls;
+}
+
+/**
+ * Extract tag-style tool calls emitted as plain text by some providers/models.
+ *
+ * Supports compact forms such as `<workspace_read path="README.md" />` and
+ * `<tool name="workspace_read">{"path":"README.md"}</tool>`.
+ *
+ * @param string $text Text candidate content.
+ * @return array<int, array{name:string,parameters:array,id:mixed}>
+ */
+function datamachine_extract_tag_tool_calls( string $text ): array {
+	$tool_calls = array();
+	$index      = 0;
+
+	if ( preg_match_all( '/<tool\s+name=["\']([^"\']+)["\']\s*>(.*?)<\/tool>/is', $text, $matches, PREG_SET_ORDER ) ) {
+		foreach ( $matches as $match ) {
+			$name = sanitize_key( (string) $match[1] );
+			if ( '' === $name ) {
+				continue;
+			}
+
+			$parameters = datamachine_normalize_function_args( html_entity_decode( trim( (string) $match[2] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ) );
+			++$index;
+			$tool_calls[] = array(
+				'name'       => $name,
+				'parameters' => $parameters,
+				'id'         => 'tag-tool-call-' . $index,
+			);
+		}
+	}
+
+	if ( preg_match_all( '/<([a-zA-Z][a-zA-Z0-9_-]*)\s+([^<>]*?)\/>/s', $text, $matches, PREG_SET_ORDER ) ) {
+		foreach ( $matches as $match ) {
+			$name = sanitize_key( (string) $match[1] );
+			if ( '' === $name || ! str_contains( $name, '_' ) ) {
+				continue;
+			}
+
+			$parameters = array();
+			if ( preg_match_all( '/([a-zA-Z][a-zA-Z0-9_-]*)\s*=\s*(["\'])(.*?)\2/s', (string) $match[2], $attribute_matches, PREG_SET_ORDER ) ) {
+				foreach ( $attribute_matches as $attribute_match ) {
+					$parameter_name = sanitize_key( (string) $attribute_match[1] );
+					if ( '' === $parameter_name ) {
+						continue;
+					}
+					$parameters[ $parameter_name ] = html_entity_decode( (string) $attribute_match[3], ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+				}
+			}
+
+			++$index;
+			$tool_calls[] = array(
+				'name'       => $name,
+				'parameters' => $parameters,
+				'id'         => 'tag-tool-call-' . $index,
 			);
 		}
 	}

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -740,6 +740,120 @@ assert_runner_request( 'workspace_read' === ( $json_array_sandbox_metadata['tool
 assert_runner_request( array( 'path' => 'README.md' ) === ( $json_array_sandbox_metadata['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline fenced JSON tool_calls parameters are parsed' );
 assert_runner_request( 1 === count( $json_array_sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline fenced JSON tool_calls executes a workspace tool' );
 
+// 4e. Sandbox/pipeline runs also execute self-closing tag tool calls emitted as text.
+$tag_tool_dispatch_count = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$tag_tool_dispatch_count ) {
+		++$tag_tool_dispatch_count;
+
+		if ( 1 === $tag_tool_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content' => '<workspace_read path="README.md" />',
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content' => 'tag tool sandbox complete',
+			),
+		);
+	}
+);
+
+$tag_tool_sandbox_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'read the sandbox README using tag tool syntax' ) ),
+	array(
+		'workspace_read' => array(
+			'name'        => 'workspace_read',
+			'description' => 'Read a file from the sandbox workspace.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(
+					'path' => array( 'type' => 'string' ),
+				),
+				'required'   => array( 'path' ),
+			),
+			'class'       => SandboxPipelineSmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	array( 'sandbox', 'pipeline' ),
+	array(),
+	3
+);
+$tag_tool_sandbox_metadata = datamachine_conversation_metadata( $tag_tool_sandbox_result );
+
+assert_runner_request( 2 === $tag_tool_dispatch_count, 'sandbox/pipeline self-closing tag tool call returns to provider for final answer' );
+assert_runner_request( 'tag tool sandbox complete' === ( $tag_tool_sandbox_result['final_content'] ?? null ), 'sandbox/pipeline self-closing tag tool call preserves final answer' );
+assert_runner_request( 1 === count( $tag_tool_sandbox_metadata['tool_calls'] ?? array() ), 'sandbox/pipeline self-closing tag tool call is parsed' );
+assert_runner_request( 'workspace_read' === ( $tag_tool_sandbox_metadata['tool_calls'][0]['name'] ?? null ), 'sandbox/pipeline self-closing tag tool name is parsed' );
+assert_runner_request( array( 'path' => 'README.md' ) === ( $tag_tool_sandbox_metadata['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline self-closing tag tool parameters are parsed' );
+assert_runner_request( 1 === count( $tag_tool_sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline self-closing tag tool call executes a workspace tool' );
+
+// 4f. Sandbox/pipeline runs also execute named <tool> tag calls emitted as text.
+$named_tag_tool_dispatch_count = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$named_tag_tool_dispatch_count ) {
+		++$named_tag_tool_dispatch_count;
+
+		if ( 1 === $named_tag_tool_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content' => '<tool name="workspace_read">{"path":"README.md"}</tool>',
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content' => 'named tag tool sandbox complete',
+			),
+		);
+	}
+);
+
+$named_tag_tool_sandbox_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'read the sandbox README using named tag tool syntax' ) ),
+	array(
+		'workspace_read' => array(
+			'name'        => 'workspace_read',
+			'description' => 'Read a file from the sandbox workspace.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(
+					'path' => array( 'type' => 'string' ),
+				),
+				'required'   => array( 'path' ),
+			),
+			'class'       => SandboxPipelineSmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	array( 'sandbox', 'pipeline' ),
+	array(),
+	3
+);
+$named_tag_tool_sandbox_metadata = datamachine_conversation_metadata( $named_tag_tool_sandbox_result );
+
+assert_runner_request( 2 === $named_tag_tool_dispatch_count, 'sandbox/pipeline named tag tool call returns to provider for final answer' );
+assert_runner_request( 'named tag tool sandbox complete' === ( $named_tag_tool_sandbox_result['final_content'] ?? null ), 'sandbox/pipeline named tag tool call preserves final answer' );
+assert_runner_request( 1 === count( $named_tag_tool_sandbox_metadata['tool_calls'] ?? array() ), 'sandbox/pipeline named tag tool call is parsed' );
+assert_runner_request( 'workspace_read' === ( $named_tag_tool_sandbox_metadata['tool_calls'][0]['name'] ?? null ), 'sandbox/pipeline named tag tool name is parsed' );
+assert_runner_request( array( 'path' => 'README.md' ) === ( $named_tag_tool_sandbox_metadata['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline named tag tool parameters are parsed' );
+assert_runner_request( 1 === count( $named_tag_tool_sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline named tag tool call executes a workspace tool' );
+
 // 5. Client runtime tools are fulfilled by the transport callback, not PHP ToolExecutor.
 $runtime_dispatch_count = 0;
 $runtime_requests       = array();


### PR DESCRIPTION
## Summary
- Extend the generic text tool-call fallback parser to recognize self-closing tool tags like `<workspace_read path=\"README.md\" />`.
- Add support for named `<tool name=\"workspace_read\">{...}</tool>` text envelopes.
- Cover both formats through the full conversation runner smoke so parsed calls are executed, not just extracted.

## Verification
- `php -l inc/Engine/AI/conversation-loop.php`
- `php -l tests/agent-conversation-runner-request-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause investigation, implementation, and smoke coverage; Chris reviews and owns the final change.