### PR TITLE
Enforce agent access for canonical chat

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -9,7 +9,8 @@ namespace DataMachine\Abilities\Chat;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Api\Chat\ChatOrchestrator;
-use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\Agents\AgentIdentity;
+use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 use WP_Error;
@@ -38,16 +39,17 @@ class AgentsChatHandler {
 	 * @return bool
 	 */
 	public function checkPermission( bool $allowed, array $input ): bool {
-		if ( $allowed || PermissionHelper::can( 'chat' ) ) {
-			return true;
+		$agent = trim( (string) ( $input['agent'] ?? '' ) );
+		if ( '' === $agent ) {
+			return $allowed || PermissionHelper::can( 'chat' );
 		}
 
-		$agent = sanitize_title( (string) ( $input['agent'] ?? '' ) );
-		if ( '' === $agent || ! class_exists( '\WP_Agent_Access' ) || ! class_exists( '\WP_Agent_Access_Grant' ) ) {
+		$identity = $this->resolveAgentIdentity( $agent );
+		if ( $identity instanceof WP_Error || ! class_exists( '\WP_Agent_Access' ) || ! class_exists( '\WP_Agent_Access_Grant' ) ) {
 			return false;
 		}
 
-		return \WP_Agent_Access::can_current_principal_access_agent( $agent, \WP_Agent_Access_Grant::ROLE_VIEWER );
+		return $allowed || \WP_Agent_Access::can_current_principal_access_agent( $identity->agent_slug, \WP_Agent_Access_Grant::ROLE_VIEWER );
 	}
 
 	/**
@@ -62,12 +64,13 @@ class AgentsChatHandler {
 			return new WP_Error( 'empty_message', __( 'Message cannot be empty.', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
-		$agent_id = $this->resolveAgentId( (string) ( $input['agent'] ?? '' ) );
-		if ( $agent_id instanceof WP_Error ) {
-			return $agent_id;
+		$identity = $this->resolveAgentIdentity( (string) ( $input['agent'] ?? '' ) );
+		if ( $identity instanceof WP_Error ) {
+			return $identity;
 		}
+		$agent_id = $identity ? $identity->agent_id : 0;
 
-		$user_id = $this->resolveRuntimeUserId( $agent_id, (string) ( $input['agent'] ?? '' ), $input );
+		$user_id = $this->resolveRuntimeUserId( $identity, (string) ( $input['agent'] ?? '' ), $input );
 		if ( $user_id <= 0 ) {
 			return new WP_Error( 'no_user', __( 'No user context available.', 'data-machine' ), array( 'status' => 400 ) );
 		}
@@ -106,7 +109,7 @@ class AgentsChatHandler {
 				'interrupt_source'     => is_callable( $input['interrupt_source'] ?? null ) ? $input['interrupt_source'] : null,
 				'modes'                => $modes,
 				'agent_id'             => $agent_id,
-				'agent_slug'           => sanitize_title( (string) ( $input['agent'] ?? '' ) ),
+				'agent_slug'           => $identity ? $identity->agent_slug : '',
 				'attachments'          => $input['attachments'] ?? array(),
 				'client_context'       => $client_context,
 				'session_owner'        => is_array( $input['session_owner'] ?? null ) ? $input['session_owner'] : null,
@@ -122,27 +125,22 @@ class AgentsChatHandler {
 	}
 
 	/**
-	 * Resolve canonical agent input into Data Machine's integer agent ID.
+	 * Resolve canonical agent input into Data Machine's canonical identity.
 	 *
 	 * @param string $agent Agent slug or numeric ID.
-	 * @return int|WP_Error
+	 * @return AgentIdentity|WP_Error|null
 	 */
-	private function resolveAgentId( string $agent ) {
+	private function resolveAgentIdentity( string $agent ): AgentIdentity|WP_Error|null {
 		$agent = trim( $agent );
 		if ( '' === $agent ) {
-			return 0;
+			return null;
 		}
 
-		if ( ctype_digit( $agent ) ) {
-			return (int) $agent;
-		}
-
-		$row = ( new Agents() )->get_by_slug( sanitize_title( $agent ) );
-		if ( ! $row ) {
+		try {
+			return ( new AgentIdentityResolver() )->resolve_agent_identity( $agent );
+		} catch ( \InvalidArgumentException $e ) {
 			return new WP_Error( 'agent_not_found', __( 'Agent not found.', 'data-machine' ), array( 'status' => 404 ) );
 		}
-
-		return (int) ( $row['agent_id'] ?? 0 );
 	}
 
 	/**
@@ -152,12 +150,12 @@ class AgentsChatHandler {
 	 * Agents API access check succeeds, keeping model credentials and tool policy
 	 * scoped to the site-owned brain agent instead of an anonymous WP user.
 	 *
-	 * @param int    $agent_id Internal Data Machine agent ID.
+	 * @param AgentIdentity|null $identity Resolved agent identity, or null for unscoped legacy chats.
 	 * @param string $agent    Requested Agents API agent slug/id.
 	 * @param array  $input    Canonical input plus Data Machine facade fields.
 	 * @return int Runtime WordPress user ID, or 0 when no safe context exists.
 	 */
-	private function resolveRuntimeUserId( int $agent_id, string $agent, array $input ): int {
+	private function resolveRuntimeUserId( ?AgentIdentity $identity, string $agent, array $input ): int {
 		$user_id = (int) ( $input['user_id'] ?? 0 );
 		if ( $user_id > 0 && PermissionHelper::can( 'chat' ) ) {
 			return $user_id;
@@ -172,17 +170,15 @@ class AgentsChatHandler {
 			return $user_id;
 		}
 
-		$agent_slug = sanitize_title( $agent );
-		if ( '' === $agent_slug || ! class_exists( '\WP_Agent_Access' ) || ! class_exists( '\WP_Agent_Access_Grant' ) ) {
+		if ( ! $identity || ! class_exists( '\WP_Agent_Access' ) || ! class_exists( '\WP_Agent_Access_Grant' ) ) {
 			return 0;
 		}
 
-		if ( ! \WP_Agent_Access::can_current_principal_access_agent( $agent_slug, \WP_Agent_Access_Grant::ROLE_VIEWER ) ) {
+		if ( ! \WP_Agent_Access::can_current_principal_access_agent( $identity->agent_slug, \WP_Agent_Access_Grant::ROLE_VIEWER ) ) {
 			return 0;
 		}
 
-		$row = ( new Agents() )->get_agent( $agent_id );
-		return $row ? (int) ( $row['owner_id'] ?? 0 ) : 0;
+		return $identity->owner_id;
 	}
 
 	/**

--- a/tests/agents-chat-access-permission-smoke.php
+++ b/tests/agents-chat-access-permission-smoke.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Pure-PHP smoke tests for canonical agents/chat agent access enforcement.
+ *
+ * Run with: php tests/agents-chat-access-permission-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace AgentsAPI\AI\Channels {
+	function register_chat_handler( callable $handler ): void {
+		$GLOBALS['datamachine_agents_chat_access_handler'] = $handler;
+	}
+}
+
+namespace DataMachine\Core\Agents {
+	class AgentIdentity {
+		public function __construct(
+			public int $agent_id,
+			public string $agent_slug,
+			public int $owner_id,
+			public string $agent_name
+		) {}
+	}
+
+	class AgentIdentityResolver {
+		public function resolve_agent_identity( int|string|array $agent ): AgentIdentity {
+			$key = is_array( $agent ) ? (string) ( $agent['agent_slug'] ?? $agent['agent_id'] ?? '' ) : (string) $agent;
+			$key = \sanitize_title( $key );
+			if ( ! isset( $GLOBALS['datamachine_agents_chat_access_identities'][ $key ] ) ) {
+				throw new \InvalidArgumentException( 'agent_not_found' );
+			}
+
+			return $GLOBALS['datamachine_agents_chat_access_identities'][ $key ];
+		}
+	}
+}
+
+namespace DataMachine\Abilities {
+	class PermissionHelper {
+		public static function can( string $action ): bool {
+			return 'chat' === $action && (bool) ( $GLOBALS['datamachine_agents_chat_access_broad_chat'] ?? false );
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! function_exists( 'add_filter' ) ) {
+		function add_filter( ...$args ): bool {
+			unset( $args );
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'sanitize_title' ) ) {
+		function sanitize_title( string $value ): string {
+			$value = strtolower( trim( $value ) );
+			$value = preg_replace( '/[^a-z0-9]+/', '-', $value );
+			return trim( (string) $value, '-' );
+		}
+	}
+
+	if ( ! function_exists( '__' ) ) {
+		function __( string $text, string $domain = 'default' ): string {
+			unset( $domain );
+			return $text;
+		}
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
+		}
+	}
+
+	class WP_Agent_Access_Grant {
+		public const ROLE_ADMIN    = 'admin';
+		public const ROLE_OPERATOR = 'operator';
+		public const ROLE_VIEWER   = 'viewer';
+	}
+
+	class WP_Agent_Access {
+		public static function can_current_principal_access_agent( string $agent_id, string $minimum_role, array $context = array() ): bool {
+			unset( $context );
+			$GLOBALS['datamachine_agents_chat_access_last_check'] = array( $agent_id, $minimum_role );
+			return (bool) ( $GLOBALS['datamachine_agents_chat_access_grants'][ $agent_id ] ?? false );
+		}
+	}
+
+	require_once dirname( __DIR__ ) . '/inc/Abilities/Chat/AgentsChatHandler.php';
+
+	use DataMachine\Abilities\Chat\AgentsChatHandler;
+	use DataMachine\Core\Agents\AgentIdentity;
+
+	$passes   = 0;
+	$failures = array();
+
+	$assert_same = static function ( mixed $expected, mixed $actual, string $label ) use ( &$passes, &$failures ): void {
+		if ( $expected === $actual ) {
+			++$passes;
+			echo "PASS: {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "FAIL: {$label}\n";
+		echo '  expected: ' . var_export( $expected, true ) . "\n";
+		echo '  actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	$GLOBALS['datamachine_agents_chat_access_identities'] = array(
+		'wiki-brain' => new AgentIdentity( 42, 'wiki-brain', 7, 'Wiki Brain' ),
+		'42'         => new AgentIdentity( 42, 'wiki-brain', 7, 'Wiki Brain' ),
+	);
+
+	$handler = new AgentsChatHandler();
+
+	$GLOBALS['datamachine_agents_chat_access_broad_chat'] = true;
+	$GLOBALS['datamachine_agents_chat_access_grants']     = array( 'wiki-brain' => false );
+	$assert_same( false, $handler->checkPermission( false, array( 'agent' => 'wiki-brain' ) ), 'chat-capable caller without agent access is denied' );
+	$assert_same( array( 'wiki-brain', WP_Agent_Access_Grant::ROLE_VIEWER ), $GLOBALS['datamachine_agents_chat_access_last_check'], 'unauthorized caller is checked against canonical slug' );
+
+	$GLOBALS['datamachine_agents_chat_access_broad_chat'] = false;
+	$GLOBALS['datamachine_agents_chat_access_grants']     = array( 'wiki-brain' => true );
+	$assert_same( true, $handler->checkPermission( false, array( 'agent' => 'wiki-brain' ) ), 'explicitly authorized caller can chat with the agent' );
+
+	$GLOBALS['datamachine_agents_chat_access_grants'] = array( 'wiki-brain' => false );
+	$assert_same( true, $handler->checkPermission( true, array( 'agent' => 'wiki-brain' ) ), 'explicit upstream admin/operator override can chat with the agent' );
+
+	$GLOBALS['datamachine_agents_chat_access_broad_chat'] = true;
+	$GLOBALS['datamachine_agents_chat_access_grants']     = array( 'wiki-brain' => false );
+	$assert_same( false, $handler->checkPermission( false, array( 'agent' => '42' ) ), 'numeric agent ID cannot bypass access checks' );
+	$assert_same( array( 'wiki-brain', WP_Agent_Access_Grant::ROLE_VIEWER ), $GLOBALS['datamachine_agents_chat_access_last_check'], 'numeric agent ID is normalized to canonical slug before access check' );
+
+	$assert_same( false, $handler->checkPermission( false, array( 'agent' => '999' ) ), 'unknown numeric agent ID is denied' );
+
+	if ( $failures ) {
+		echo "\n" . count( $failures ) . " failed, {$passes} passed\n";
+		exit( 1 );
+	}
+
+	echo "\n{$passes} passed, 0 failed\n";
+}

--- a/tests/agents-chat-handler-smoke.php
+++ b/tests/agents-chat-handler-smoke.php
@@ -82,7 +82,7 @@ $assert( str_contains( $handler_source, 'ChatOrchestrator::processChat(' ), 'Age
 $assert( str_contains( $handler_source, "'selected_pipeline_id' => (int) ( $" . "input['selected_pipeline_id'] ?? 0 )" ), 'AgentsChatHandler forwards selected pipeline context' );
 $assert( str_contains( $handler_source, "'request_id'           => $" . "input['request_id'] ?? null" ), 'AgentsChatHandler forwards request id for session dedupe' );
 $assert( str_contains( $handler_source, "'interrupt_source'     => is_callable( $" . "input['interrupt_source'] ?? null ) ? $" . "input['interrupt_source'] : null" ), 'AgentsChatHandler explicitly forwards callable interrupt sources' );
-$assert( str_contains( $handler_source, "'agent_slug'           => sanitize_title( (string) ( $" . "input['agent'] ?? '' ) )" ), 'AgentsChatHandler forwards agent targeting to the chat runtime' );
+$assert( str_contains( $handler_source, "'agent_slug'           => $" . "identity ? $" . "identity->agent_slug : ''" ), 'AgentsChatHandler forwards resolved agent targeting to the chat runtime' );
 $assert( str_contains( $handler_source, "'interrupted'  => $" . "result['interrupted'] ?? null" ), 'AgentsChatHandler returns interrupted diagnostics in canonical metadata' );
 $assert( ! file_exists( $root . '/inc/Abilities/Chat/SendMessageAbility.php' ), 'datamachine/send-message facade class is removed' );
 $assert( ! str_contains( $chat_abilities, 'SendMessageAbility' ), 'ChatAbilities no longer registers datamachine/send-message' );


### PR DESCRIPTION
## Summary
- Resolves canonical `agents/chat` agent input through `AgentIdentityResolver` before permission/runtime use.
- Requires agent-specific Agents API access for requested agents so broad Data Machine `chat` permission no longer grants every agent.
- Adds focused smoke coverage for unauthorized chat-capable callers, authorized access, explicit override, and numeric ID normalization.

Fixes #2439

## Tests
- `php -l inc/Abilities/Chat/AgentsChatHandler.php && php -l tests/agents-chat-access-permission-smoke.php && php tests/agents-chat-access-permission-smoke.php && php tests/agents-chat-handler-smoke.php && php tests/agents-api-access-store-adapter-smoke.php`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-agents-chat-access --extension wordpress` (1310 passed, 3 skipped)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the access enforcement change, added focused smoke coverage, and ran verification under Chris's review.