### PR TITLE
Pass canonical identity to action policy resolution

### DIFF
--- a/inc/Engine/AI/Actions/ActionPolicyResolver.php
+++ b/inc/Engine/AI/Actions/ActionPolicyResolver.php
@@ -135,7 +135,8 @@ class ActionPolicyResolver {
 		if ( ! empty( $config ) ) {
 			$context['agent_config'] = $config;
 		} else {
-			unset( $context['agent_id'] );
+			// Preserve canonical agent identity while preventing fallback registry lookups.
+			$context['agent_config'] = array();
 		}
 
 		return $context;

--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -13,6 +13,8 @@ namespace DataMachine\Engine\AI\Tools;
 
 use AgentsAPI\AI\Tools\WP_Agent_Action_Policy;
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Execution_Core;
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 use DataMachine\Core\WordPress\PostTracking;
 use DataMachine\Engine\AI\Actions\ActionPolicyResolver;
 use DataMachine\Engine\AI\Actions\PendingActionHelper;
@@ -85,12 +87,13 @@ class ToolExecutor {
 		// as before this feature landed.
 		$resolver = new ActionPolicyResolver();
 		$policy   = $resolver->resolveForTool(
-			array(
-				'tool_name'      => $tool_name,
-				'tool_def'       => $tool_def,
-				'mode'           => $mode,
-				'agent_id'       => $agent_id,
-				'client_context' => $client_context,
+			array_merge(
+				self::buildActionPolicyContext( $payload, $agent_id, $client_context ),
+				array(
+					'tool_name' => $tool_name,
+					'tool_def'  => $tool_def,
+					'mode'      => $mode,
+				)
 			)
 		);
 
@@ -200,6 +203,130 @@ class ToolExecutor {
 		}
 
 		return $available_tools;
+	}
+
+	/**
+	 * Build canonical identity context for action-policy resolution.
+	 *
+	 * @param array $payload        Step payload / invocation context.
+	 * @param int   $agent_id       Acting Data Machine agent ID.
+	 * @param array $client_context Client-supplied context.
+	 * @return array<string,mixed> First-class Agents API context plus namespaced Data Machine metadata.
+	 */
+	private static function buildActionPolicyContext( array $payload, int $agent_id, array $client_context ): array {
+		$context = array(
+			'client_context' => $client_context,
+			'datamachine'    => array_filter(
+				array(
+					'job_id'               => $payload['job_id'] ?? null,
+					'flow_step_id'         => $payload['flow_step_id'] ?? null,
+					'selected_pipeline_id' => $payload['selected_pipeline_id'] ?? null,
+				),
+				static fn( $value ): bool => null !== $value && '' !== $value
+			),
+		);
+
+		$workspace = self::resolveActionPolicyWorkspace( $payload );
+		if ( null !== $workspace ) {
+			$context['workspace'] = $workspace;
+		}
+
+		$user_id = self::firstPositiveInt( $payload, $client_context, 'user_id' );
+		if ( $user_id > 0 ) {
+			$context['user_id'] = $user_id;
+		}
+
+		$acting_user_id = self::firstPositiveInt( $payload, $client_context, 'acting_user_id', 'calling_user_id' );
+		if ( $acting_user_id > 0 ) {
+			$context['acting_user_id'] = $acting_user_id;
+		}
+
+		if ( $agent_id > 0 ) {
+			$context['agent_id'] = $agent_id;
+		}
+
+		$agent_slug = self::firstNonEmptyString( $payload, $client_context, 'agent_slug' );
+		if ( '' !== $agent_slug ) {
+			$context['agent_slug'] = sanitize_title( $agent_slug );
+		}
+
+		foreach ( array( 'session_id', 'transcript_session_id', 'request_id' ) as $identifier ) {
+			$value = self::firstNonEmptyString( $payload, $client_context, $identifier );
+			if ( '' !== $value ) {
+				$context[ $identifier ] = $value;
+			}
+		}
+
+		if ( empty( $context['datamachine'] ) ) {
+			unset( $context['datamachine'] );
+		}
+
+		return $context;
+	}
+
+	/**
+	 * Resolve the canonical workspace for action-policy resolution.
+	 *
+	 * @param array $payload Step payload / invocation context.
+	 * @return WP_Agent_Workspace_Scope|null Workspace scope.
+	 */
+	private static function resolveActionPolicyWorkspace( array $payload ): ?WP_Agent_Workspace_Scope {
+		$workspace = $payload['workspace'] ?? null;
+		if ( $workspace instanceof WP_Agent_Workspace_Scope ) {
+			return $workspace;
+		}
+
+		if ( is_array( $workspace ) ) {
+			try {
+				return WP_Agent_Workspace_Scope::from_array( $workspace );
+			} catch ( \InvalidArgumentException $e ) {
+				return null;
+			}
+		}
+
+		return WordPressWorkspaceScope::current();
+	}
+
+	/**
+	 * Return the first positive integer from payload or client context.
+	 *
+	 * @param array  $payload        Step payload / invocation context.
+	 * @param array  $client_context Client-supplied context.
+	 * @param string ...$keys        Candidate keys in priority order.
+	 * @return int Positive integer or 0.
+	 */
+	private static function firstPositiveInt( array $payload, array $client_context, string ...$keys ): int {
+		foreach ( $keys as $key ) {
+			foreach ( array( $payload, $client_context ) as $source ) {
+				$value = isset( $source[ $key ] ) ? (int) $source[ $key ] : 0;
+				if ( $value > 0 ) {
+					return $value;
+				}
+			}
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Return the first non-empty string from payload or client context.
+	 *
+	 * @param array  $payload        Step payload / invocation context.
+	 * @param array  $client_context Client-supplied context.
+	 * @param string ...$keys        Candidate keys in priority order.
+	 * @return string Non-empty string or empty string.
+	 */
+	private static function firstNonEmptyString( array $payload, array $client_context, string ...$keys ): string {
+		foreach ( $keys as $key ) {
+			foreach ( array( $payload, $client_context ) as $source ) {
+				$value = $source[ $key ] ?? null;
+				if ( is_scalar( $value ) && '' !== trim( (string) $value ) ) {
+					return trim( (string) $value );
+				}
+			}
+		}
+
+		return '';
 	}
 
 	/**

--- a/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
+++ b/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
@@ -8,11 +8,17 @@
 namespace DataMachine\Tests\Unit\AI\Tools;
 
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters;
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
 use DataMachine\Engine\AI\Tools\ToolExecutor;
 use DataMachine\Engine\AI\Tools\ToolManager;
 use WP_UnitTestCase;
 
 class ToolExecutorValidationTest extends WP_UnitTestCase {
+
+	public function tear_down(): void {
+		remove_all_filters( 'agents_api_action_policy_providers' );
+		parent::tear_down();
+	}
 
 	public function test_validate_required_parameters_returns_valid_when_all_present(): void {
 		$tool_parameters = array(
@@ -235,6 +241,133 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'class', $result['error'] );
 	}
 
+	public function test_execute_tool_passes_canonical_identity_to_action_policy_providers(): void {
+		$workspace     = WP_Agent_Workspace_Scope::from_parts( 'site', 'workspace-a' );
+		$seen_contexts = array();
+
+		add_filter(
+			'agents_api_action_policy_providers',
+			function ( $providers ) use ( &$seen_contexts ) {
+				$providers[] = new class( $seen_contexts ) implements \WP_Agent_Action_Policy_Provider {
+					/** @var array<int,array<string,mixed>> */
+					private array $seen_contexts;
+
+					public function __construct( array &$seen_contexts ) {
+						$this->seen_contexts =& $seen_contexts;
+					}
+
+					public function get_action_policy( array $context ): ?string {
+						$this->seen_contexts[] = $context;
+						$workspace            = $context['workspace'] ?? null;
+
+						if (
+							$workspace instanceof WP_Agent_Workspace_Scope
+							&& 'workspace-a' === $workspace->workspace_id
+							&& 7 === (int) ( $context['user_id'] ?? 0 )
+							&& 9 === (int) ( $context['acting_user_id'] ?? 0 )
+							&& 11 === (int) ( $context['agent_id'] ?? 0 )
+							&& 'policy-agent' === (string) ( $context['agent_slug'] ?? '' )
+						) {
+							return 'forbidden';
+						}
+
+						return null;
+					}
+				};
+
+				return $providers;
+			},
+			10,
+			1
+		);
+
+		$result = ToolExecutor::executeTool(
+			'test_tool',
+			array( 'query' => 'test search' ),
+			$this->availableTestTools(),
+			array(
+				'workspace'       => $workspace->to_array(),
+				'user_id'         => 7,
+				'calling_user_id' => 9,
+				'agent_slug'      => 'Policy Agent',
+				'session_id'      => 'session-123',
+				'request_id'      => 'request-456',
+				'job_id'          => 21,
+				'flow_step_id'    => 34,
+			),
+			'chat',
+			11,
+			array( 'bridge_app' => 'unit-test' )
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'forbidden', $result['action_policy'] );
+		$this->assertNotEmpty( $seen_contexts );
+
+		$context = $seen_contexts[0];
+		$this->assertInstanceOf( WP_Agent_Workspace_Scope::class, $context['workspace'] ?? null );
+		$this->assertSame( 'workspace-a', $context['workspace']->workspace_id );
+		$this->assertSame( 7, $context['user_id'] );
+		$this->assertSame( 9, $context['acting_user_id'] );
+		$this->assertSame( 11, $context['agent_id'] );
+		$this->assertSame( 'policy-agent', $context['agent_slug'] );
+		$this->assertSame( 'session-123', $context['session_id'] );
+		$this->assertSame( 'request-456', $context['request_id'] );
+		$this->assertSame( 21, $context['datamachine']['job_id'] ?? null );
+		$this->assertSame( 34, $context['datamachine']['flow_step_id'] ?? null );
+		$this->assertSame( 'unit-test', $context['client_context']['bridge_app'] ?? null );
+	}
+
+	public function test_execute_tool_policy_provider_can_distinguish_identity_scopes(): void {
+		add_filter(
+			'agents_api_action_policy_providers',
+			function ( $providers ) {
+				$providers[] = new class() implements \WP_Agent_Action_Policy_Provider {
+					public function get_action_policy( array $context ): ?string {
+						$workspace = $context['workspace'] ?? null;
+
+						return $workspace instanceof WP_Agent_Workspace_Scope
+							&& 'workspace-b' === $workspace->workspace_id
+							&& 22 === (int) ( $context['acting_user_id'] ?? 0 )
+							&& 'scoped-agent' === (string) ( $context['agent_slug'] ?? '' )
+							? 'forbidden'
+							: null;
+					}
+				};
+
+				return $providers;
+			},
+			10,
+			1
+		);
+
+		$allowed = ToolExecutor::executeTool(
+			'test_tool',
+			array( 'query' => 'test search' ),
+			$this->availableTestTools(),
+			array(
+				'workspace'       => WP_Agent_Workspace_Scope::from_parts( 'site', 'workspace-a' )->to_array(),
+				'calling_user_id' => 22,
+				'agent_slug'      => 'scoped-agent',
+			)
+		);
+
+		$forbidden = ToolExecutor::executeTool(
+			'test_tool',
+			array( 'query' => 'test search' ),
+			$this->availableTestTools(),
+			array(
+				'workspace'       => WP_Agent_Workspace_Scope::from_parts( 'site', 'workspace-b' )->to_array(),
+				'calling_user_id' => 22,
+				'agent_slug'      => 'scoped-agent',
+			)
+		);
+
+		$this->assertTrue( $allowed['success'] );
+		$this->assertFalse( $forbidden['success'] );
+		$this->assertSame( 'forbidden', $forbidden['action_policy'] );
+	}
+
 	public function test_resolve_tools_invokes_callables(): void {
 		$callable_invoked = false;
 		$tools            = array(
@@ -273,6 +406,21 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 
 		$this->assertIsArray( $resolved['invalid_tool'] );
 		$this->assertEmpty( $resolved['invalid_tool'] );
+	}
+
+	private function availableTestTools(): array {
+		return array(
+			'test_tool' => array(
+				'class'      => TestToolHandler::class,
+				'method'     => 'handle_tool_call',
+				'parameters' => array(
+					'query' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+				),
+			),
+		);
 	}
 
 	private function invokeValidateMethod( array $tool_parameters, array $tool_def ): array {


### PR DESCRIPTION
## Summary
- Pass canonical `workspace`, `user_id`, `acting_user_id`, `agent_id`, `agent_slug`, and session/request identifiers into action-policy resolution from `ToolExecutor`.
- Keep Data Machine job/flow metadata namespaced under `datamachine` while preserving `client_context` for client-specific details.
- Preserve canonical agent identity even when no persisted Data Machine agent config exists, without triggering fallback registered-agent lookups.

Closes #2438.

## Tests
- `php -l inc/Engine/AI/Actions/ActionPolicyResolver.php && php -l inc/Engine/AI/Tools/ToolExecutor.php && php -l tests/Unit/AI/Tools/ToolExecutorValidationTest.php`
- `vendor/bin/phpcs inc/Engine/AI/Actions/ActionPolicyResolver.php inc/Engine/AI/Tools/ToolExecutor.php tests/Unit/AI/Tools/ToolExecutorValidationTest.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-action-policy-context --extension wordpress --changed-only`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-action-policy-context --extension wordpress`

Note: full `homeboy lint --path /Users/chubes/Developer/data-machine@fix-action-policy-context --extension wordpress` reports an unrelated existing PHPCS finding in `inc/Core/FilesRepository/MediaValidator.php` for deprecated `finfo_close()`; changed-file lint passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting the Data Machine/Agents API action-policy boundary, drafting the implementation, adding focused tests, and running verification. Chris remains responsible for review and merge.