### PR TITLE
Scope pending action access

### DIFF
--- a/inc/Cli/Commands/PendingActionsCommand.php
+++ b/inc/Cli/Commands/PendingActionsCommand.php
@@ -9,6 +9,7 @@ namespace DataMachine\Cli\Commands;
 
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Engine\AI\Actions\PendingActionInspectionAbility;
+use DataMachine\Engine\AI\Actions\PendingActionScope;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 use WP_CLI;
 
@@ -42,6 +43,9 @@ class PendingActionsCommand extends BaseCommand {
 	 * [--offset=<offset>]
 	 * : Offset for pagination.
 	 *
+	 * [--operator-wide]
+	 * : Explicitly inspect actions across all owners/agents/workspaces.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -61,7 +65,16 @@ class PendingActionsCommand extends BaseCommand {
 	 */
 	public function list( array $args, array $assoc_args ): void {
 		$filters = PendingActionInspectionAbility::normalize_filters( $assoc_args );
-		$rows    = PendingActionStore::list( $filters );
+		if ( ! empty( $assoc_args['operator-wide'] ) ) {
+			$filters['operator_wide'] = true;
+		}
+
+		$filters = PendingActionScope::filters( $filters );
+		if ( is_wp_error( $filters ) ) {
+			WP_CLI::error( $filters->get_error_message() );
+		}
+
+		$rows = PendingActionStore::list( $filters );
 
 		$fields = array( 'action_id', 'kind', 'summary', 'status', 'agent_id', 'created_by', 'created_at_iso', 'expires_at_iso' );
 		$this->format_items( $rows, $fields, $assoc_args, 'action_id' );
@@ -78,6 +91,9 @@ class PendingActionsCommand extends BaseCommand {
 	 * [--format=<format>]
 	 * : Output format. Default json.
 	 *
+	 * [--operator-wide]
+	 * : Explicitly inspect an action outside the current caller scope.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp datamachine pending-actions get act_123
@@ -88,8 +104,9 @@ class PendingActionsCommand extends BaseCommand {
 			WP_CLI::error( 'action_id is required.' );
 		}
 
-		$action = PendingActionStore::inspect( $action_id );
-		if ( null === $action ) {
+		$scope_input = ! empty( $assoc_args['operator-wide'] ) ? array( 'operator_wide' => true ) : array();
+		$action      = PendingActionStore::inspect( $action_id );
+		if ( null === $action || ! PendingActionScope::can_access_payload( $action, $scope_input ) ) {
 			WP_CLI::error( 'Pending action not found.' );
 		}
 
@@ -114,6 +131,9 @@ class PendingActionsCommand extends BaseCommand {
 	 * [--include-context-details]
 	 * : Include all context buckets in the summary.
 	 *
+	 * [--operator-wide]
+	 * : Explicitly summarize actions across all owners/agents/workspaces.
+	 *
 	 * [--format=<format>]
 	 * : Output format. Default json.
 	 *
@@ -122,7 +142,17 @@ class PendingActionsCommand extends BaseCommand {
 	 *     wp datamachine pending-actions summary
 	 */
 	public function summary( array $args, array $assoc_args ): void {
-		$summary = PendingActionStore::summary( PendingActionInspectionAbility::normalize_filters( $assoc_args ) );
+		$filters = PendingActionInspectionAbility::normalize_filters( $assoc_args );
+		if ( ! empty( $assoc_args['operator-wide'] ) ) {
+			$filters['operator_wide'] = true;
+		}
+
+		$filters = PendingActionScope::filters( $filters );
+		if ( is_wp_error( $filters ) ) {
+			WP_CLI::error( $filters->get_error_message() );
+		}
+
+		$summary = PendingActionStore::summary( $filters );
 		$format  = $assoc_args['format'] ?? 'json';
 
 		WP_CLI\Utils\format_items( $format, array( $summary ), array_keys( $summary ) );

--- a/inc/Engine/AI/Actions/PendingActionInspectionAbility.php
+++ b/inc/Engine/AI/Actions/PendingActionInspectionAbility.php
@@ -134,8 +134,16 @@ final class PendingActionInspectionAbility {
 	 * Ability callback: list actions.
 	 */
 	public static function list_actions( array $input ): array {
+		$filters = PendingActionScope::filters( self::normalize_filters( $input ) );
+		if ( is_wp_error( $filters ) ) {
+			return array(
+				'success' => false,
+				'error'   => $filters->get_error_message(),
+			);
+		}
+
 		$result = \AgentsAPI\AI\Approvals\agents_list_pending_actions(
-			array( 'filters' => self::normalize_filters( $input ) )
+			array( 'filters' => $filters )
 		);
 		if ( is_wp_error( $result ) ) {
 			return array(
@@ -177,7 +185,7 @@ final class PendingActionInspectionAbility {
 		}
 
 		$action = is_array( $result['action'] ?? null ) ? $result['action'] : null;
-		if ( null === $action ) {
+		if ( null === $action || ! PendingActionScope::can_access_payload( PendingActionScope::action_array_to_payload( $action ), $input ) ) {
 			return array(
 				'success'   => false,
 				'error'     => 'Pending action not found.',
@@ -195,8 +203,16 @@ final class PendingActionInspectionAbility {
 	 * Ability callback: summarize actions.
 	 */
 	public static function summary( array $input ): array {
+		$filters = PendingActionScope::filters( self::normalize_filters( $input ) );
+		if ( is_wp_error( $filters ) ) {
+			return array(
+				'success' => false,
+				'error'   => $filters->get_error_message(),
+			);
+		}
+
 		$result = \AgentsAPI\AI\Approvals\agents_summary_pending_actions(
-			array( 'filters' => self::normalize_filters( $input ) )
+			array( 'filters' => $filters )
 		);
 		if ( is_wp_error( $result ) ) {
 			return array(
@@ -231,7 +247,7 @@ final class PendingActionInspectionAbility {
 	 */
 	public static function normalize_filters( array $input ): array {
 		$filters = array();
-		foreach ( array( 'status', 'kind', 'created_after', 'created_before' ) as $key ) {
+		foreach ( array( 'status', 'kind', 'created_after', 'created_before', 'workspace_type', 'workspace_id', 'agent', 'creator', 'operator_wide', 'operator-wide', 'all' ) as $key ) {
 			if ( isset( $input[ $key ] ) && '' !== $input[ $key ] ) {
 				$filters[ $key ] = sanitize_text_field( (string) $input[ $key ] );
 			}
@@ -261,6 +277,12 @@ final class PendingActionInspectionAbility {
 			$filters['context'] = array_map( 'sanitize_text_field', $input['context'] );
 		}
 
+		foreach ( array( 'session_id', 'transcript_session_id' ) as $key ) {
+			if ( isset( $input[ $key ] ) && '' !== $input[ $key ] ) {
+				$filters['context'][ $key ] = sanitize_text_field( (string) $input[ $key ] );
+			}
+		}
+
 		return $filters;
 	}
 
@@ -276,6 +298,17 @@ final class PendingActionInspectionAbility {
 				'agent_id'                => array( 'type' => 'integer' ),
 				'created_by'              => array( 'type' => 'integer' ),
 				'context'                 => array( 'type' => 'object' ),
+				'workspace_type'          => array( 'type' => 'string' ),
+				'workspace_id'            => array( 'type' => 'string' ),
+				'agent'                   => array( 'type' => 'string' ),
+				'creator'                 => array( 'type' => 'string' ),
+				'session_id'              => array( 'type' => 'string' ),
+				'transcript_session_id'   => array( 'type' => 'string' ),
+				'operator_wide'           => array(
+					'type'        => 'boolean',
+					'default'     => false,
+					'description' => __( 'Explicitly request an operator-wide view. Requires manage-level Data Machine permissions.', 'data-machine' ),
+				),
 				'created_after'           => array( 'type' => 'string' ),
 				'created_before'          => array( 'type' => 'string' ),
 				'limit'                   => array(

--- a/inc/Engine/AI/Actions/PendingActionScope.php
+++ b/inc/Engine/AI/Actions/PendingActionScope.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * Pending-action caller scoping helpers.
+ *
+ * @package DataMachine\Engine\AI\Actions
+ */
+
+namespace DataMachine\Engine\AI\Actions;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Workspace\WordPressWorkspaceScope;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Applies the default pending-action visibility boundary for non-operator callers.
+ */
+final class PendingActionScope {
+
+	/**
+	 * Return scoped filters for list/summary inspection.
+	 *
+	 * @param array<string,mixed> $filters Normalized query filters.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function filters( array $filters ) {
+		if ( self::operator_wide_requested( $filters ) ) {
+			return self::operator_wide_allowed() ? self::without_operator_flags( $filters ) : self::operator_wide_error();
+		}
+
+		return self::apply_scope_to_filters( self::without_operator_flags( $filters ), self::current_scope( $filters ) );
+	}
+
+	/**
+	 * Check whether the current caller may inspect or resolve a payload.
+	 *
+	 * @param array<string,mixed> $payload Stored pending-action payload.
+	 * @param array<string,mixed> $input   Caller input/context.
+	 */
+	public static function can_access_payload( array $payload, array $input = array() ): bool {
+		if ( self::operator_wide_requested( $input ) ) {
+			return self::operator_wide_allowed();
+		}
+
+		$scope = self::current_scope( $input );
+		if ( ! self::workspace_matches( $payload, $scope ) ) {
+			return false;
+		}
+
+		if ( isset( $scope['created_by'] ) && ! self::owner_matches( $payload, $scope ) ) {
+			return false;
+		}
+
+		if ( ( isset( $scope['agent_id'] ) || isset( $scope['agent'] ) ) && ! self::agent_matches( $payload, $scope ) ) {
+			return false;
+		}
+
+		foreach ( $scope['context'] ?? array() as $key => $value ) {
+			$context = isset( $payload['context'] ) && is_array( $payload['context'] ) ? $payload['context'] : array();
+			if ( ! array_key_exists( $key, $context ) || (string) $context[ $key ] !== (string) $value ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Convert a canonical Agents API action array into Data Machine's payload shape.
+	 *
+	 * @param array<string,mixed> $action Canonical pending-action array.
+	 * @return array<string,mixed>
+	 */
+	public static function action_array_to_payload( array $action ): array {
+		$metadata    = isset( $action['metadata'] ) && is_array( $action['metadata'] ) ? $action['metadata'] : array();
+		$datamachine = isset( $metadata['datamachine'] ) && is_array( $metadata['datamachine'] ) ? $metadata['datamachine'] : array();
+
+		return array(
+			'action_id'   => $action['action_id'] ?? '',
+			'kind'        => $action['kind'] ?? '',
+			'summary'     => $action['summary'] ?? '',
+			'preview'     => $action['preview'] ?? array(),
+			'apply_input' => $action['apply_input'] ?? array(),
+			'workspace'   => $action['workspace'] ?? null,
+			'agent'       => $action['agent'] ?? null,
+			'creator'     => $action['creator'] ?? null,
+			'agent_id'    => $datamachine['agent_id'] ?? null,
+			'created_by'  => $datamachine['created_by'] ?? null,
+			'context'     => isset( $datamachine['context'] ) && is_array( $datamachine['context'] ) ? $datamachine['context'] : array(),
+			'metadata'    => $metadata,
+		);
+	}
+
+	/**
+	 * Return an explicit operator-wide denial error.
+	 */
+	public static function operator_wide_error(): \WP_Error {
+		return new \WP_Error(
+			'datamachine_pending_action_operator_wide_forbidden',
+			'operator_wide pending-action access requires manage-level Data Machine permissions.'
+		);
+	}
+
+	/**
+	 * Build the current default visibility scope.
+	 *
+	 * @param array<string,mixed> $input Caller input/context.
+	 * @return array<string,mixed>
+	 */
+	private static function current_scope( array $input ): array {
+		$workspace = WordPressWorkspaceScope::current();
+		$scope     = array(
+			'workspace_type' => $workspace->workspace_type,
+			'workspace_id'   => $workspace->workspace_id,
+			'context'        => self::session_context_from_input( $input ),
+		);
+
+		$acting_user_id = PermissionHelper::acting_user_id();
+		if ( $acting_user_id > 0 ) {
+			$scope['created_by'] = $acting_user_id;
+			$scope['creator']    = 'user:' . $acting_user_id;
+		}
+
+		$acting_agent_id = PermissionHelper::get_acting_agent_id();
+		if ( null !== $acting_agent_id && $acting_agent_id > 0 ) {
+			$scope['agent_id'] = $acting_agent_id;
+			$scope['agent']    = 'agent:' . $acting_agent_id;
+		} else {
+			$principal = PermissionHelper::get_execution_principal();
+			if ( null !== $principal && '' !== trim( (string) $principal->effective_agent_id ) ) {
+				$scope['agent'] = (string) $principal->effective_agent_id;
+			}
+		}
+
+		/**
+		 * Filter the default pending-action caller scope.
+		 *
+		 * @param array<string,mixed> $scope Current scope.
+		 * @param array<string,mixed> $input Caller input/context.
+		 */
+		$scope = apply_filters( 'datamachine_pending_action_current_scope', $scope, $input );
+
+		return is_array( $scope ) ? $scope : array();
+	}
+
+	/**
+	 * Apply caller scope as mandatory filters.
+	 *
+	 * @param array<string,mixed> $filters Query filters.
+	 * @param array<string,mixed> $scope   Caller scope.
+	 * @return array<string,mixed>
+	 */
+	private static function apply_scope_to_filters( array $filters, array $scope ): array {
+		foreach ( array( 'workspace_type', 'workspace_id' ) as $key ) {
+			if ( isset( $scope[ $key ] ) && '' !== $scope[ $key ] && null !== $scope[ $key ] ) {
+				$filters[ $key ] = $scope[ $key ];
+			}
+		}
+
+		if ( ! empty( $scope['created_by'] ) ) {
+			unset( $filters['created_by'], $filters['creator'] );
+			$filters['owner_user_id'] = (int) $scope['created_by'];
+		}
+
+		if ( ! empty( $scope['agent_id'] ) || ! empty( $scope['agent'] ) ) {
+			unset( $filters['agent_id'], $filters['agent'] );
+			$filters['agent_scope'] = array(
+				'agent_id' => $scope['agent_id'] ?? null,
+				'agent'    => $scope['agent'] ?? null,
+			);
+		}
+
+		if ( ! empty( $scope['context'] ) && is_array( $scope['context'] ) ) {
+			$filters['context'] = array_merge(
+				isset( $filters['context'] ) && is_array( $filters['context'] ) ? $filters['context'] : array(),
+				$scope['context']
+			);
+		}
+
+		return $filters;
+	}
+
+	/**
+	 * Extract supported session context from caller input.
+	 *
+	 * @param array<string,mixed> $input Caller input/context.
+	 * @return array<string,string>
+	 */
+	private static function session_context_from_input( array $input ): array {
+		$context = isset( $input['context'] ) && is_array( $input['context'] ) ? $input['context'] : array();
+		foreach ( array( 'session_id', 'transcript_session_id' ) as $key ) {
+			if ( ! empty( $context[ $key ] ) ) {
+				return array( $key => (string) $context[ $key ] );
+			}
+			if ( ! empty( $input[ $key ] ) ) {
+				return array( $key => (string) $input[ $key ] );
+			}
+		}
+
+		$principal = PermissionHelper::get_execution_principal();
+		if ( null !== $principal ) {
+			foreach ( array( 'session_id', 'transcript_session_id' ) as $key ) {
+				if ( ! empty( $principal->request_metadata[ $key ] ) ) {
+					return array( $key => (string) $principal->request_metadata[ $key ] );
+				}
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Check whether explicit operator-wide access was requested.
+	 *
+	 * @param array<string,mixed> $input Caller input/context.
+	 */
+	private static function operator_wide_requested( array $input ): bool {
+		foreach ( array( 'operator_wide', 'operator-wide', 'all' ) as $key ) {
+			if ( ! empty( $input[ $key ] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Remove internal operator flags before passing filters to the store.
+	 *
+	 * @param array<string,mixed> $filters Query filters.
+	 * @return array<string,mixed>
+	 */
+	private static function without_operator_flags( array $filters ): array {
+		unset( $filters['operator_wide'], $filters['operator-wide'], $filters['all'] );
+		return $filters;
+	}
+
+	/**
+	 * Whether the current caller may use the operator-wide view.
+	 */
+	private static function operator_wide_allowed(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	/**
+	 * Compare payload workspace with scope workspace.
+	 *
+	 * @param array<string,mixed> $payload Stored pending-action payload.
+	 * @param array<string,mixed> $scope   Caller scope.
+	 */
+	private static function workspace_matches( array $payload, array $scope ): bool {
+		if ( empty( $scope['workspace_type'] ) || empty( $scope['workspace_id'] ) ) {
+			return true;
+		}
+
+		$workspace = isset( $payload['workspace'] ) && is_array( $payload['workspace'] ) ? $payload['workspace'] : array();
+		return (string) ( $workspace['workspace_type'] ?? '' ) === (string) $scope['workspace_type']
+			&& (string) ( $workspace['workspace_id'] ?? '' ) === (string) $scope['workspace_id'];
+	}
+
+	/**
+	 * Return payload creator identifier.
+	 *
+	 * @param array<string,mixed> $payload Stored pending-action payload.
+	 */
+	private static function payload_creator( array $payload ): string {
+		if ( ! empty( $payload['creator'] ) ) {
+			return (string) $payload['creator'];
+		}
+
+		return ! empty( $payload['created_by'] ) ? 'user:' . (int) $payload['created_by'] : '';
+	}
+
+	/**
+	 * Check owner scope against numeric and canonical owner fields.
+	 *
+	 * @param array<string,mixed> $payload Stored pending-action payload.
+	 * @param array<string,mixed> $scope   Caller scope.
+	 */
+	private static function owner_matches( array $payload, array $scope ): bool {
+		$created_by = isset( $scope['created_by'] ) ? (int) $scope['created_by'] : 0;
+		$creator    = isset( $scope['creator'] ) ? (string) $scope['creator'] : ( $created_by > 0 ? 'user:' . $created_by : '' );
+
+		return ( $created_by > 0 && (int) ( $payload['created_by'] ?? 0 ) === $created_by )
+			|| ( '' !== $creator && self::payload_creator( $payload ) === $creator );
+	}
+
+	/**
+	 * Return payload agent identifier.
+	 *
+	 * @param array<string,mixed> $payload Stored pending-action payload.
+	 */
+	private static function payload_agent( array $payload ): string {
+		if ( ! empty( $payload['agent'] ) ) {
+			return (string) $payload['agent'];
+		}
+
+		return ! empty( $payload['agent_id'] ) ? 'agent:' . (int) $payload['agent_id'] : '';
+	}
+
+	/**
+	 * Check agent scope against numeric and canonical agent fields.
+	 *
+	 * @param array<string,mixed> $payload Stored pending-action payload.
+	 * @param array<string,mixed> $scope   Caller scope.
+	 */
+	private static function agent_matches( array $payload, array $scope ): bool {
+		$agent_id = isset( $scope['agent_id'] ) ? (int) $scope['agent_id'] : 0;
+		$agent    = isset( $scope['agent'] ) ? (string) $scope['agent'] : ( $agent_id > 0 ? 'agent:' . $agent_id : '' );
+
+		return ( $agent_id > 0 && (int) ( $payload['agent_id'] ?? 0 ) === $agent_id )
+			|| ( '' !== $agent && self::payload_agent( $payload ) === $agent );
+	}
+}

--- a/inc/Engine/AI/Actions/PendingActionStore.php
+++ b/inc/Engine/AI/Actions/PendingActionStore.php
@@ -421,6 +421,8 @@ class PendingActionStore {
 		self::add_filter_clause( $where, $args, $filters, 'created_by', 'created_by', '%d' );
 		self::add_filter_clause( $where, $args, $filters, 'creator', 'creator', '%s' );
 		self::add_filter_clause( $where, $args, $filters, 'resolver', 'resolver', '%s' );
+		self::add_owner_scope_clause( $where, $args, $filters );
+		self::add_agent_scope_clause( $where, $args, $filters );
 
 		if ( ! empty( $filters['context'] ) && is_array( $filters['context'] ) ) {
 			foreach ( $filters['context'] as $key => $value ) {
@@ -501,6 +503,8 @@ class PendingActionStore {
 		self::add_filter_clause( $where, $args, $filters, 'created_by', 'created_by', '%d' );
 		self::add_filter_clause( $where, $args, $filters, 'creator', 'creator', '%s' );
 		self::add_filter_clause( $where, $args, $filters, 'resolver', 'resolver', '%s' );
+		self::add_owner_scope_clause( $where, $args, $filters );
+		self::add_agent_scope_clause( $where, $args, $filters );
 
 		if ( ! empty( $filters['context'] ) && is_array( $filters['context'] ) ) {
 			foreach ( $filters['context'] as $key => $value ) {
@@ -889,6 +893,62 @@ class PendingActionStore {
 
 		$where[] = $column . ' = ' . $format;
 		$args[]  = '%d' === $format ? (int) $filters[ $filter_key ] : (string) $filters[ $filter_key ];
+	}
+
+	/**
+	 * Add an owner scope that matches either legacy numeric or canonical principal columns.
+	 *
+	 * @param array<int,string> $where   SQL where clauses.
+	 * @param array<int,mixed>  $args    SQL prepare args.
+	 * @param array<string,mixed> $filters Query filters.
+	 */
+	private static function add_owner_scope_clause( array &$where, array &$args, array $filters ): void {
+		if ( empty( $filters['owner_user_id'] ) ) {
+			return;
+		}
+
+		$owner_user_id = (int) $filters['owner_user_id'];
+		if ( $owner_user_id <= 0 ) {
+			return;
+		}
+
+		$where[] = '(created_by = %d OR creator = %s)';
+		$args[]  = $owner_user_id;
+		$args[]  = 'user:' . $owner_user_id;
+	}
+
+	/**
+	 * Add an agent scope that matches either legacy numeric or canonical principal columns.
+	 *
+	 * @param array<int,string> $where   SQL where clauses.
+	 * @param array<int,mixed>  $args    SQL prepare args.
+	 * @param array<string,mixed> $filters Query filters.
+	 */
+	private static function add_agent_scope_clause( array &$where, array &$args, array $filters ): void {
+		if ( empty( $filters['agent_scope'] ) || ! is_array( $filters['agent_scope'] ) ) {
+			return;
+		}
+
+		$agent_id = isset( $filters['agent_scope']['agent_id'] ) ? (int) $filters['agent_scope']['agent_id'] : 0;
+		$agent    = isset( $filters['agent_scope']['agent'] ) ? trim( (string) $filters['agent_scope']['agent'] ) : '';
+
+		if ( $agent_id > 0 && '' !== $agent ) {
+			$where[] = '(agent_id = %d OR agent = %s)';
+			$args[]  = $agent_id;
+			$args[]  = $agent;
+			return;
+		}
+
+		if ( $agent_id > 0 ) {
+			$where[] = 'agent_id = %d';
+			$args[]  = $agent_id;
+			return;
+		}
+
+		if ( '' !== $agent ) {
+			$where[] = 'agent = %s';
+			$args[]  = $agent;
+		}
 	}
 
 	/**

--- a/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
+++ b/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
@@ -220,6 +220,14 @@ class ResolvePendingActionAbility {
 			);
 		}
 
+		if ( ! PendingActionScope::can_access_payload( $payload, $input ) ) {
+			return array(
+				'success'   => false,
+				'error'     => 'You do not have permission to resolve this pending action.',
+				'action_id' => $action_id,
+			);
+		}
+
 		$kind             = (string) ( $payload['kind'] ?? '' );
 		$user_id          = get_current_user_id();
 		$apply_input      = isset( $payload['apply_input'] ) && is_array( $payload['apply_input'] ) ? $payload['apply_input'] : array();

--- a/tests/pending-action-resolver-contract-smoke.php
+++ b/tests/pending-action-resolver-contract-smoke.php
@@ -126,10 +126,12 @@ if ( ! class_exists( 'WP_Error' ) ) {
 }
 
 require_once dirname( __DIR__ ) . '/vendor/automattic/agents-api/agents-api.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/PermissionHelper.php';
 require_once dirname( __DIR__ ) . '/inc/Core/Workspace/WordPressWorkspaceScope.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionObservers.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/WordPressActionDispatchObserver.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionStore.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionScope.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionResolverAdapter.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/ResolvePendingActionAbility.php';
 
@@ -221,6 +223,8 @@ PendingActionStore::store(
 		'kind'        => 'contract_kind',
 		'summary'     => 'Apply contract handler.',
 		'apply_input' => array( 'target' => 'diff-123' ),
+		'created_by'  => 123,
+		'creator'     => 'user:123',
 	)
 );
 
@@ -270,6 +274,8 @@ PendingActionStore::store(
 		'kind'        => 'legacy_kind',
 		'summary'     => 'Reject legacy handler.',
 		'apply_input' => array( 'target' => 'diff-456' ),
+		'created_by'  => 123,
+		'creator'     => 'user:123',
 	)
 );
 
@@ -320,6 +326,8 @@ PendingActionStore::store(
 		'kind'        => 'denied_kind',
 		'summary'     => 'Denied contract handler.',
 		'apply_input' => array( 'target' => 'diff-789' ),
+		'created_by'  => 123,
+		'creator'     => 'user:123',
 	)
 );
 
@@ -340,6 +348,43 @@ $invalid = ResolvePendingActionAbility::execute(
 	)
 );
 resolver_smoke_assert( false === ( $invalid['success'] ?? true ), 'unknown Agents API approval decision is rejected', $failures, $passes );
+
+$scoped_out_apply_calls = 0;
+add_filter(
+	'datamachine_pending_action_handlers',
+	static function ( array $handlers ) use ( &$scoped_out_apply_calls ) {
+		$handlers['scoped_out_kind'] = array(
+			'apply' => static function () use ( &$scoped_out_apply_calls ) {
+				++$scoped_out_apply_calls;
+				return array( 'success' => true );
+			},
+		);
+
+		return $handlers;
+	},
+	40,
+	1
+);
+
+PendingActionStore::store(
+	'act_scoped_out',
+	array(
+		'kind'        => 'scoped_out_kind',
+		'summary'     => 'Scoped-out handler.',
+		'apply_input' => array( 'target' => 'diff-000' ),
+		'created_by'  => 999,
+		'creator'     => 'user:999',
+	)
+);
+
+$scoped_out = ResolvePendingActionAbility::execute(
+	array(
+		'action_id' => 'act_scoped_out',
+		'decision'  => 'accepted',
+	)
+);
+resolver_smoke_assert( false === ( $scoped_out['success'] ?? true ), 'resolver rejects actions outside caller owner scope', $failures, $passes );
+resolver_smoke_assert( 0 === $scoped_out_apply_calls, 'scope denial happens before handler execution', $failures, $passes );
 
 if ( ! empty( $failures ) ) {
 	echo "\nFailures:\n";

--- a/tests/pending-action-scope-smoke.php
+++ b/tests/pending-action-scope-smoke.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Pure-PHP smoke coverage for pending-action caller scoping.
+ *
+ * Run with: php tests/pending-action-scope-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$GLOBALS['__pending_action_scope_filters'] = array();
+$GLOBALS['__pending_action_scope_user_id'] = 123;
+$GLOBALS['__pending_action_scope_manage']  = false;
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['__pending_action_scope_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+		ksort( $GLOBALS['__pending_action_scope_filters'][ $hook ], SORT_NUMERIC );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		return add_filter( $hook, $callback, $priority, $accepted_args );
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value, ...$args ) {
+		if ( empty( $GLOBALS['__pending_action_scope_filters'][ $hook ] ) ) {
+			return $value;
+		}
+
+		foreach ( $GLOBALS['__pending_action_scope_filters'][ $hook ] as $callbacks ) {
+			foreach ( $callbacks as $registration ) {
+				$value = call_user_func_array( $registration[0], array_slice( array_merge( array( $value ), $args ), 0, $registration[1] ) );
+			}
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook = '' ) {
+		unset( $hook );
+		return false;
+	}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return (int) $GLOBALS['__pending_action_scope_user_id'];
+	}
+}
+
+if ( ! function_exists( 'is_user_logged_in' ) ) {
+	function is_user_logged_in(): bool {
+		return get_current_user_id() > 0;
+	}
+}
+
+if ( ! function_exists( 'user_can' ) ) {
+	function user_can( int $_user_id, string $capability ): bool {
+		return ! empty( $GLOBALS['__pending_action_scope_manage'] ) && 'manage_options' === $capability;
+	}
+}
+
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( string $path = '/' ): string {
+		unset( $path );
+		return 'https://scope.example';
+	}
+}
+
+if ( ! function_exists( 'site_url' ) ) {
+	function site_url( string $path = '/' ): string {
+		unset( $path );
+		return 'https://scope.example';
+	}
+}
+
+if ( ! function_exists( 'untrailingslashit' ) ) {
+	function untrailingslashit( string $value ): string {
+		return rtrim( $value, '/' );
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '' ) {}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+	}
+}
+
+require_once dirname( __DIR__ ) . '/vendor/automattic/agents-api/agents-api.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/PermissionHelper.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Workspace/WordPressWorkspaceScope.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionScope.php';
+
+use DataMachine\Engine\AI\Actions\PendingActionScope;
+
+$failures = array();
+$passes   = 0;
+
+function pending_action_scope_assert( bool $condition, string $message, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	$failures[] = $message;
+	echo "FAIL: {$message}\n";
+}
+
+echo "pending-action-scope-smoke\n";
+
+$scoped = PendingActionScope::filters( array( 'status' => 'pending' ) );
+pending_action_scope_assert( is_array( $scoped ), 'default scope returns filters', $failures, $passes );
+pending_action_scope_assert( 'site' === ( $scoped['workspace_type'] ?? null ), 'default scope includes workspace type', $failures, $passes );
+pending_action_scope_assert( 'https://scope.example' === ( $scoped['workspace_id'] ?? null ), 'default scope includes workspace ID', $failures, $passes );
+pending_action_scope_assert( 123 === ( $scoped['owner_user_id'] ?? null ), 'default scope includes owner user ID', $failures, $passes );
+
+$conflicting = PendingActionScope::filters( array( 'created_by' => 999, 'creator' => 'user:999' ) );
+pending_action_scope_assert( 123 === ( $conflicting['owner_user_id'] ?? null ), 'normal callers cannot widen owner filters', $failures, $passes );
+pending_action_scope_assert( ! isset( $conflicting['created_by'], $conflicting['creator'] ), 'normal caller owner filters use scoped OR matching', $failures, $passes );
+
+$session_scoped = PendingActionScope::filters( array( 'context' => array( 'session_id' => 'sess_123' ) ) );
+pending_action_scope_assert( 'sess_123' === ( $session_scoped['context']['session_id'] ?? null ), 'session context narrows scoped filters', $failures, $passes );
+
+add_filter(
+	'datamachine_pending_action_current_scope',
+	static function ( array $scope ): array {
+		$scope['agent_id'] = 456;
+		$scope['agent']    = 'agent:456';
+		return $scope;
+	},
+	10,
+	1
+);
+
+$agent_scoped = PendingActionScope::filters( array() );
+pending_action_scope_assert( 456 === ( $agent_scoped['agent_scope']['agent_id'] ?? null ), 'agent scope includes agent ID', $failures, $passes );
+pending_action_scope_assert( 'agent:456' === ( $agent_scoped['agent_scope']['agent'] ?? null ), 'agent scope includes agent principal', $failures, $passes );
+
+$matching_payload = array(
+	'workspace'  => array(
+		'workspace_type' => 'site',
+		'workspace_id'   => 'https://scope.example',
+	),
+	'created_by' => 123,
+	'creator'    => 'user:123',
+	'agent_id'   => 456,
+	'agent'      => 'agent:456',
+	'context'    => array( 'session_id' => 'sess_123' ),
+);
+pending_action_scope_assert( PendingActionScope::can_access_payload( $matching_payload, array( 'context' => array( 'session_id' => 'sess_123' ) ) ), 'matching owner/agent/workspace/session payload is visible', $failures, $passes );
+
+$other_owner_payload               = $matching_payload;
+$other_owner_payload['created_by'] = 999;
+$other_owner_payload['creator']    = 'user:999';
+pending_action_scope_assert( ! PendingActionScope::can_access_payload( $other_owner_payload, array( 'context' => array( 'session_id' => 'sess_123' ) ) ), 'other owner payload is hidden', $failures, $passes );
+
+$other_workspace_payload                                  = $matching_payload;
+$other_workspace_payload['workspace']['workspace_id']     = 'https://other.example';
+pending_action_scope_assert( ! PendingActionScope::can_access_payload( $other_workspace_payload, array( 'context' => array( 'session_id' => 'sess_123' ) ) ), 'other workspace payload is hidden', $failures, $passes );
+
+$operator_denied = PendingActionScope::filters( array( 'operator_wide' => true, 'created_by' => 999 ) );
+pending_action_scope_assert( $operator_denied instanceof WP_Error, 'operator-wide filters require explicit permission', $failures, $passes );
+
+$GLOBALS['__pending_action_scope_manage'] = true;
+$operator_allowed                         = PendingActionScope::filters( array( 'operator_wide' => true, 'created_by' => 999 ) );
+pending_action_scope_assert( is_array( $operator_allowed ) && 999 === ( $operator_allowed['created_by'] ?? null ), 'operator-wide filters preserve explicit operator query', $failures, $passes );
+pending_action_scope_assert( PendingActionScope::can_access_payload( $other_workspace_payload, array( 'operator_wide' => true ) ), 'operator-wide payload access is explicit', $failures, $passes );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFailures:\n";
+	foreach ( $failures as $failure ) {
+		echo '- ' . $failure . "\n";
+	}
+	exit( 1 );
+}
+
+echo "\nPending-action scope smoke passed ({$passes} assertions).\n";

--- a/tests/pending-actions-agents-api-contract-smoke.php
+++ b/tests/pending-actions-agents-api-contract-smoke.php
@@ -195,6 +195,24 @@ if ( ! function_exists( 'sanitize_text_field' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return 123;
+	}
+}
+
+if ( ! function_exists( 'is_user_logged_in' ) ) {
+	function is_user_logged_in(): bool {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'user_can' ) ) {
+	function user_can( int $_user_id, string $_capability ): bool {
+		return false;
+	}
+}
+
 if ( ! function_exists( 'is_wp_error' ) ) {
 	function is_wp_error( $value ): bool {
 		return $value instanceof WP_Error;
@@ -252,11 +270,13 @@ if ( ! function_exists( 'wp_generate_uuid4' ) ) {
 }
 
 require_once dirname( __DIR__ ) . '/vendor/automattic/agents-api/agents-api.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/PermissionHelper.php';
 require_once dirname( __DIR__ ) . '/inc/Core/Workspace/WordPressWorkspaceScope.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionObservers.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/WordPressActionDispatchObserver.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionStoreAdapter.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionStore.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionScope.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionInspectionAbility.php';
 
 \DataMachine\Engine\AI\Actions\PendingActionObservers::reset();
@@ -271,6 +291,7 @@ $action    = \AgentsAPI\AI\Approvals\WP_Agent_Pending_Action::from_array(
 		'summary'     => 'Contract smoke',
 		'preview'     => array( 'ok' => true ),
 		'apply_input' => array( 'value' => 1 ),
+		'workspace'   => \DataMachine\Core\Workspace\WordPressWorkspaceScope::current()->to_array(),
 		'creator'     => 'user:123',
 		'agent'       => 'agent:456',
 		'created_at'  => gmdate( 'c' ),


### PR DESCRIPTION
## Summary
- Scope pending-action list, summary, get, and resolve paths to the current workspace plus available owner, agent, and session context by default.
- Add explicit `operator_wide` / `--operator-wide` override paths gated by manage-level Data Machine permissions.
- Add focused smoke coverage for user, agent, workspace, session, resolver denial-before-handler, and operator-wide inspection behavior.

Closes #2440.

## Tests
- `php tests/pending-action-scope-smoke.php`
- `php tests/pending-action-resolver-contract-smoke.php`
- `php tests/pending-actions-agents-api-contract-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-pending-action-scope --extension wordpress`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-pending-action-scope --extension wordpress --changed-only`

## Notes
- Full `homeboy lint --path /Users/chubes/Developer/data-machine@fix-pending-action-scope --extension wordpress` still reports an unrelated existing PHP 8.2 deprecation in `inc/Core/FilesRepository/MediaValidator.php`.
- This does not depend on #2437; the helper exposes `datamachine_pending_action_current_scope` so explicit downstream grants can narrow/extend the default scope without relying on global table reads.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the pending-action scoping helper, wired inspection/resolution/CLI enforcement, and drafted focused smoke coverage for Chris to review and test.