### PR TITLE
Require pending action resolver grants

### DIFF
--- a/inc/Engine/AI/Actions/PendingActionHelper.php
+++ b/inc/Engine/AI/Actions/PendingActionHelper.php
@@ -50,6 +50,7 @@ class PendingActionHelper {
 	 *     @type int|null $agent_id     Optional. Acting agent ID (recorded for audit + can_resolve checks).
 	 *     @type int|null $user_id      Optional. Acting user ID (defaults to current user).
 	 *     @type array    $context      Optional. Free-form context (session_id, bridge_app, etc.).
+	 *     @type array    $resolver_grants Optional. Explicit non-human resolver grants.
 	 * }
 	 * @return array Agents API approval_required envelope, or a `staged=>false`
 	 *               error array when staging fails.
@@ -63,6 +64,7 @@ class PendingActionHelper {
 		$user_id      = isset( $args['user_id'] ) ? (int) $args['user_id'] : get_current_user_id();
 		$context      = isset( $args['context'] ) && is_array( $args['context'] ) ? $args['context'] : array();
 		$action_id    = isset( $args['action_id'] ) ? (string) $args['action_id'] : '';
+		$grants       = isset( $args['resolver_grants'] ) && is_array( $args['resolver_grants'] ) ? $args['resolver_grants'] : array();
 
 		if ( '' === $kind ) {
 			return array(
@@ -86,22 +88,27 @@ class PendingActionHelper {
 			$action_id = PendingActionStore::generate_id();
 		}
 
+		$grants = apply_filters( 'datamachine_pending_action_resolver_grants', $grants, $args );
+		$grants = is_array( $grants ) ? array_values( array_filter( $grants, 'is_array' ) ) : array();
+
 		$payload = array(
-			'kind'         => $kind,
-			'summary'      => wp_strip_all_tags( $summary ),
-			'apply_input'  => $apply_input,
-			'preview_data' => $preview_data,
-			'agent_id'     => $agent_id,
-			'agent'        => $agent_id > 0 ? 'agent:' . $agent_id : null,
-			'created_by'   => $user_id,
-			'creator'      => $user_id > 0 ? 'user:' . $user_id : null,
-			'context'      => $context,
-			'metadata'     => array(
+			'kind'            => $kind,
+			'summary'         => wp_strip_all_tags( $summary ),
+			'apply_input'     => $apply_input,
+			'preview_data'    => $preview_data,
+			'resolver_grants' => $grants,
+			'agent_id'        => $agent_id,
+			'agent'           => $agent_id > 0 ? 'agent:' . $agent_id : null,
+			'created_by'      => $user_id,
+			'creator'         => $user_id > 0 ? 'user:' . $user_id : null,
+			'context'         => $context,
+			'metadata'        => array(
 				'datamachine' => array(
-					'agent_id'     => $agent_id,
-					'created_by'   => $user_id,
-					'context'      => $context,
-					'resolve_with' => 'resolve_pending_action',
+					'agent_id'        => $agent_id,
+					'created_by'      => $user_id,
+					'context'         => $context,
+					'resolver_grants' => $grants,
+					'resolve_with'    => 'resolve_pending_action',
 				),
 			),
 		);
@@ -140,16 +147,17 @@ class PendingActionHelper {
 		$created_at = isset( $stored_payload['created_at'] ) ? (int) $stored_payload['created_at'] : time();
 
 		$pending_action = array(
-			'action_id'   => $action_id,
-			'kind'        => $kind,
-			'summary'     => $payload['summary'],
-			'preview'     => $preview_data,
-			'apply_input' => $apply_input,
-			'creator'     => $payload['creator'],
-			'agent'       => $payload['agent'],
-			'metadata'    => $payload['metadata'],
-			'created_at'  => gmdate( 'c', $created_at ),
-			'expires_at'  => null !== $expires_at ? gmdate( 'c', $expires_at ) : null,
+			'action_id'       => $action_id,
+			'kind'            => $kind,
+			'summary'         => $payload['summary'],
+			'preview'         => $preview_data,
+			'apply_input'     => $apply_input,
+			'resolver_grants' => $grants,
+			'creator'         => $payload['creator'],
+			'agent'           => $payload['agent'],
+			'metadata'        => $payload['metadata'],
+			'created_at'      => gmdate( 'c', $created_at ),
+			'expires_at'      => null !== $expires_at ? gmdate( 'c', $expires_at ) : null,
 		);
 
 		if ( class_exists( WP_Agent_Pending_Action::class ) ) {

--- a/inc/Engine/AI/Actions/PendingActionStore.php
+++ b/inc/Engine/AI/Actions/PendingActionStore.php
@@ -736,6 +736,9 @@ class PendingActionStore {
 	private static function row_to_payload( array $row ): array {
 		$created_at = self::mysql_to_timestamp( (string) ( $row['created_at'] ?? '' ) );
 		$expires_at = self::mysql_to_timestamp( (string) ( $row['expires_at'] ?? '' ) );
+		$metadata   = self::decode_json( $row['metadata'] ?? null );
+		$metadata   = is_array( $metadata ) ? $metadata : array();
+		$grants     = isset( $metadata['datamachine']['resolver_grants'] ) && is_array( $metadata['datamachine']['resolver_grants'] ) ? $metadata['datamachine']['resolver_grants'] : array();
 
 		return array(
 			'action_id'           => (string) ( $row['action_id'] ?? '' ),
@@ -743,6 +746,7 @@ class PendingActionStore {
 			'summary'             => (string) ( $row['summary'] ?? '' ),
 			'preview_data'        => self::decode_json( $row['preview_data'] ?? null ),
 			'apply_input'         => self::decode_json( $row['apply_input'] ?? null ),
+			'resolver_grants'     => $grants,
 			'agent_id'            => isset( $row['agent_id'] ) ? (int) $row['agent_id'] : 0,
 			'agent'               => isset( $row['agent'] ) ? (string) $row['agent'] : null,
 			'workspace'           => ! empty( $row['workspace_type'] ) && ! empty( $row['workspace_id'] ) ? array(
@@ -752,7 +756,7 @@ class PendingActionStore {
 			'created_by'          => isset( $row['created_by'] ) ? (int) $row['created_by'] : 0,
 			'creator'             => isset( $row['creator'] ) ? (string) $row['creator'] : null,
 			'context'             => self::decode_json( $row['context'] ?? null ),
-			'metadata'            => self::decode_json( $row['metadata'] ?? null ),
+			'metadata'            => $metadata,
 			'status'              => (string) ( $row['status'] ?? WP_Agent_Pending_Action_Status::PENDING ),
 			'created_at'          => $created_at,
 			'created_at_iso'      => $created_at > 0 ? gmdate( 'c', $created_at ) : null,
@@ -787,6 +791,7 @@ class PendingActionStore {
 			'agent_id'            => $metadata['datamachine']['agent_id'] ?? null,
 			'created_by'          => $metadata['datamachine']['created_by'] ?? null,
 			'context'             => $metadata['datamachine']['context'] ?? array(),
+			'resolver_grants'     => $metadata['datamachine']['resolver_grants'] ?? array(),
 			'metadata'            => $metadata,
 			'status'              => $data['status'],
 			'created_at'          => $data['created_at'],
@@ -810,9 +815,10 @@ class PendingActionStore {
 		$metadata['datamachine'] = array_merge(
 			isset( $metadata['datamachine'] ) && is_array( $metadata['datamachine'] ) ? $metadata['datamachine'] : array(),
 			array(
-				'agent_id'   => $payload['agent_id'] ?? 0,
-				'created_by' => $payload['created_by'] ?? 0,
-				'context'    => $payload['context'] ?? array(),
+				'agent_id'        => $payload['agent_id'] ?? 0,
+				'created_by'      => $payload['created_by'] ?? 0,
+				'context'         => $payload['context'] ?? array(),
+				'resolver_grants' => $payload['resolver_grants'] ?? array(),
 			)
 		);
 

--- a/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
+++ b/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
@@ -240,6 +240,24 @@ class ResolvePendingActionAbility {
 
 		$handlers = self::getKindHandlers();
 		$handler  = $handlers[ $kind ] ?? null;
+		$grant    = self::canResolveWithGrant( $payload, $decision, $resolver, $resolver_payload, $resolver_context );
+		if ( is_wp_error( $grant ) ) {
+			return array(
+				'success'   => false,
+				'error'     => $grant->get_error_message(),
+				'action_id' => $action_id,
+				'kind'      => $kind,
+			);
+		}
+
+		if ( false === $grant ) {
+			return array(
+				'success'   => false,
+				'error'     => 'This resolver is not granted permission to resolve this pending action.',
+				'action_id' => $action_id,
+				'kind'      => $kind,
+			);
+		}
 
 		if ( ! is_array( $handler ) || empty( $handler['apply'] ) || ! self::isApplyHandler( $handler['apply'] ) ) {
 			// No handler registered — can't apply, but reject is still safe.
@@ -430,6 +448,207 @@ class ResolvePendingActionAbility {
 		}
 
 		return $apply->can_resolve_pending_action( $pending_action, $decision, $resolver_payload, $resolver_context );
+	}
+
+	/**
+	 * Enforce explicit resolver grants for agent/system-led resolutions.
+	 *
+	 * Human user and signed-token approvals remain valid by default. Machine
+	 * resolvers must be represented by a stored grant so the policy is auditable.
+	 *
+	 * @return bool|\WP_Error True when allowed, false when denied.
+	 */
+	private static function canResolveWithGrant( array $payload, WP_Agent_Approval_Decision $decision, string $resolver, array $resolver_payload, array $resolver_context ) {
+		$resolver_type = self::resolverType( $resolver, $resolver_context );
+		if ( in_array( $resolver_type, array( 'user', 'signed_url' ), true ) ) {
+			return true;
+		}
+
+		$grants = self::resolverGrants( $payload );
+		foreach ( $grants as $grant ) {
+			if ( ! self::grantMatchesResolverType( $grant, $resolver_type ) ) {
+				continue;
+			}
+
+			if ( ! self::grantMatchesDecision( $grant, $decision->value() ) ) {
+				continue;
+			}
+
+			if ( ! self::grantMatchesResolver( $grant, $resolver ) ) {
+				continue;
+			}
+
+			if ( ! self::grantMatchesKind( $grant, (string) ( $payload['kind'] ?? '' ) ) ) {
+				continue;
+			}
+
+			if ( ! self::grantMatchesAgent( $grant, (int) ( $payload['agent_id'] ?? 0 ) ) ) {
+				continue;
+			}
+
+			if ( ! self::grantMatchesSession( $grant, $payload, $resolver_context ) ) {
+				continue;
+			}
+
+			$missing = self::missingRequiredGrantFields( $grant, $resolver_payload, $resolver_context );
+			if ( ! empty( $missing ) ) {
+				return new \WP_Error( 'missing_resolver_evidence', sprintf( 'Resolver grant requires %s.', implode( ', ', $missing ) ) );
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Normalize stored resolver grants from the pending action payload.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function resolverGrants( array $payload ): array {
+		$metadata            = isset( $payload['metadata'] ) && is_array( $payload['metadata'] ) ? $payload['metadata'] : array();
+		$datamachine_metadata = isset( $metadata['datamachine'] ) && is_array( $metadata['datamachine'] ) ? $metadata['datamachine'] : array();
+		$grants              = isset( $payload['resolver_grants'] ) && is_array( $payload['resolver_grants'] ) ? $payload['resolver_grants'] : array();
+		$metadata_grants     = isset( $datamachine_metadata['resolver_grants'] ) && is_array( $datamachine_metadata['resolver_grants'] ) ? $datamachine_metadata['resolver_grants'] : array();
+		$legacy              = isset( $payload['allowed_resolvers'] ) && is_array( $payload['allowed_resolvers'] ) ? $payload['allowed_resolvers'] : array();
+
+		$grants = array_merge( $grants, $metadata_grants );
+
+		foreach ( $legacy as $resolver ) {
+			$grants[] = array( 'resolver' => $resolver );
+		}
+
+		if ( ! empty( $payload['agent_resolvable'] ) ) {
+			$grants[] = array( 'type' => 'agent' );
+		}
+
+		if ( ! empty( $payload['system_resolvable'] ) ) {
+			$grants[] = array( 'type' => 'system_task' );
+		}
+
+		return array_values( array_filter( $grants, 'is_array' ) );
+	}
+
+	private static function grantMatchesResolverType( array $grant, string $resolver_type ): bool {
+		$types = self::stringList( $grant['types'] ?? ( $grant['type'] ?? ( $grant['resolver_type'] ?? null ) ) );
+		if ( empty( $types ) ) {
+			return true;
+		}
+
+		return in_array( $resolver_type, $types, true );
+	}
+
+	private static function grantMatchesDecision( array $grant, string $decision ): bool {
+		$decisions = self::stringList( $grant['decisions'] ?? ( $grant['decision'] ?? null ) );
+		if ( empty( $decisions ) ) {
+			return true;
+		}
+
+		return in_array( $decision, $decisions, true );
+	}
+
+	private static function grantMatchesResolver( array $grant, string $resolver ): bool {
+		$resolvers = self::stringList( $grant['resolvers'] ?? ( $grant['resolver'] ?? null ) );
+		if ( empty( $resolvers ) ) {
+			return true;
+		}
+
+		return in_array( $resolver, $resolvers, true );
+	}
+
+	private static function grantMatchesKind( array $grant, string $kind ): bool {
+		$kinds = self::stringList( $grant['kinds'] ?? ( $grant['kind'] ?? null ) );
+		if ( empty( $kinds ) ) {
+			return true;
+		}
+
+		return in_array( $kind, $kinds, true );
+	}
+
+	private static function grantMatchesAgent( array $grant, int $agent_id ): bool {
+		if ( ! isset( $grant['agent_id'] ) ) {
+			return true;
+		}
+
+		return (int) $grant['agent_id'] === $agent_id;
+	}
+
+	private static function grantMatchesSession( array $grant, array $payload, array $resolver_context ): bool {
+		if ( ! isset( $grant['session_id'] ) ) {
+			return true;
+		}
+
+		$payload_context = isset( $payload['context'] ) && is_array( $payload['context'] ) ? $payload['context'] : array();
+		$session_id      = (string) ( $resolver_context['session_id'] ?? ( $payload_context['session_id'] ?? '' ) );
+
+		return (string) $grant['session_id'] === $session_id;
+	}
+
+	/**
+	 * Check required evidence fields declared by a machine resolver grant.
+	 *
+	 * @return string[] Missing field labels.
+	 */
+	private static function missingRequiredGrantFields( array $grant, array $resolver_payload, array $resolver_context ): array {
+		$missing = array();
+		foreach ( self::stringList( $grant['required_payload_fields'] ?? null ) as $field ) {
+			if ( ! array_key_exists( $field, $resolver_payload ) || null === $resolver_payload[ $field ] || '' === $resolver_payload[ $field ] ) {
+				$missing[] = 'payload.' . $field;
+			}
+		}
+
+		foreach ( self::stringList( $grant['required_context_fields'] ?? null ) as $field ) {
+			if ( ! array_key_exists( $field, $resolver_context ) || null === $resolver_context[ $field ] || '' === $resolver_context[ $field ] ) {
+				$missing[] = 'context.' . $field;
+			}
+		}
+
+		return $missing;
+	}
+
+	/**
+	 * Identify the broad resolver class from the audit identifier/context.
+	 */
+	private static function resolverType( string $resolver, array $resolver_context ): string {
+		if ( 'signed_url' === (string) ( $resolver_context['resolution_transport'] ?? '' ) ) {
+			return 'signed_url';
+		}
+
+		if ( str_starts_with( $resolver, 'user:' ) ) {
+			return 'user';
+		}
+
+		if ( str_starts_with( $resolver, 'agent:' ) ) {
+			return 'agent';
+		}
+
+		if ( str_starts_with( $resolver, 'system_task:' ) || str_starts_with( $resolver, 'system:' ) ) {
+			return 'system_task';
+		}
+
+		if ( str_starts_with( $resolver, 'cli:' ) || str_starts_with( $resolver, 'operator:' ) ) {
+			return 'operator';
+		}
+
+		return 'unknown';
+	}
+
+	/**
+	 * Normalize grant scalar/list fields to strings.
+	 *
+	 * @return string[]
+	 */
+	private static function stringList( $value ): array {
+		if ( null === $value ) {
+			return array();
+		}
+
+		$values = is_array( $value ) ? $value : array( $value );
+		$values = array_map( 'strval', $values );
+		$values = array_map( 'sanitize_text_field', $values );
+
+		return array_values( array_filter( $values, static fn ( string $item ): bool => '' !== $item ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
+++ b/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
@@ -507,11 +507,11 @@ class ResolvePendingActionAbility {
 	 * @return array<int,array<string,mixed>>
 	 */
 	private static function resolverGrants( array $payload ): array {
-		$metadata            = isset( $payload['metadata'] ) && is_array( $payload['metadata'] ) ? $payload['metadata'] : array();
+		$metadata             = isset( $payload['metadata'] ) && is_array( $payload['metadata'] ) ? $payload['metadata'] : array();
 		$datamachine_metadata = isset( $metadata['datamachine'] ) && is_array( $metadata['datamachine'] ) ? $metadata['datamachine'] : array();
-		$grants              = isset( $payload['resolver_grants'] ) && is_array( $payload['resolver_grants'] ) ? $payload['resolver_grants'] : array();
-		$metadata_grants     = isset( $datamachine_metadata['resolver_grants'] ) && is_array( $datamachine_metadata['resolver_grants'] ) ? $datamachine_metadata['resolver_grants'] : array();
-		$legacy              = isset( $payload['allowed_resolvers'] ) && is_array( $payload['allowed_resolvers'] ) ? $payload['allowed_resolvers'] : array();
+		$grants               = isset( $payload['resolver_grants'] ) && is_array( $payload['resolver_grants'] ) ? $payload['resolver_grants'] : array();
+		$metadata_grants      = isset( $datamachine_metadata['resolver_grants'] ) && is_array( $datamachine_metadata['resolver_grants'] ) ? $datamachine_metadata['resolver_grants'] : array();
+		$legacy               = isset( $payload['allowed_resolvers'] ) && is_array( $payload['allowed_resolvers'] ) ? $payload['allowed_resolvers'] : array();
 
 		$grants = array_merge( $grants, $metadata_grants );
 

--- a/tests/pending-action-resolver-contract-smoke.php
+++ b/tests/pending-action-resolver-contract-smoke.php
@@ -265,11 +265,95 @@ add_filter(
 );
 
 PendingActionStore::store(
-	'act_legacy_reject',
+	'act_ungranted_agent_accept',
 	array(
 		'kind'        => 'legacy_kind',
-		'summary'     => 'Reject legacy handler.',
-		'apply_input' => array( 'target' => 'diff-456' ),
+		'summary'     => 'Ungrant agent acceptance.',
+		'apply_input' => array( 'target' => 'diff-ungranted' ),
+	)
+);
+
+$ungranted_agent_accept = ResolvePendingActionAbility::execute(
+	array(
+		'action_id' => 'act_ungranted_agent_accept',
+		'decision'  => 'accepted',
+		'resolver'  => 'agent:7',
+	)
+);
+
+resolver_smoke_assert( false === ( $ungranted_agent_accept['success'] ?? true ), 'ungranted agent acceptance fails closed', $failures, $passes );
+resolver_smoke_assert( 0 === $legacy_apply_calls, 'ungranted agent acceptance does not invoke apply handler', $failures, $passes );
+
+PendingActionStore::store(
+	'act_granted_agent_accept',
+	array(
+		'kind'            => 'legacy_kind',
+		'summary'         => 'Grant agent acceptance.',
+		'apply_input'     => array( 'target' => 'diff-agent-granted' ),
+		'resolver_grants' => array(
+			array(
+				'type'                    => 'agent',
+				'decisions'               => array( 'accepted' ),
+				'resolvers'               => array( 'agent:7' ),
+				'kind'                    => 'legacy_kind',
+				'required_payload_fields' => array( 'evidence' ),
+			),
+		),
+	)
+);
+
+$granted_agent_accept = ResolvePendingActionAbility::execute(
+	array(
+		'action_id' => 'act_granted_agent_accept',
+		'decision'  => 'accepted',
+		'resolver'  => 'agent:7',
+		'payload'   => array( 'evidence' => 'deterministic-policy' ),
+	)
+);
+
+resolver_smoke_assert( true === ( $granted_agent_accept['success'] ?? false ), 'granted agent acceptance succeeds', $failures, $passes );
+resolver_smoke_assert( 1 === $legacy_apply_calls, 'granted agent acceptance invokes apply handler once', $failures, $passes );
+
+PendingActionStore::store(
+	'act_rejection_only_system',
+	array(
+		'kind'            => 'legacy_kind',
+		'summary'         => 'Grant system rejection only.',
+		'apply_input'     => array( 'target' => 'diff-rejection-only' ),
+		'resolver_grants' => array(
+			array(
+				'type'      => 'system_task',
+				'decision'  => 'rejected',
+				'resolvers' => array( 'system_task:wiki_graph_maintain' ),
+			),
+		),
+	)
+);
+
+$rejection_only_accept = ResolvePendingActionAbility::execute(
+	array(
+		'action_id' => 'act_rejection_only_system',
+		'decision'  => 'accepted',
+		'resolver'  => 'system_task:wiki_graph_maintain',
+	)
+);
+
+resolver_smoke_assert( false === ( $rejection_only_accept['success'] ?? true ), 'rejection-only system resolver cannot accept', $failures, $passes );
+resolver_smoke_assert( 1 === $legacy_apply_calls, 'rejection-only accept denial does not invoke apply handler', $failures, $passes );
+
+PendingActionStore::store(
+	'act_legacy_reject',
+	array(
+		'kind'            => 'legacy_kind',
+		'summary'         => 'Reject legacy handler.',
+		'apply_input'     => array( 'target' => 'diff-456' ),
+		'resolver_grants' => array(
+			array(
+				'type'      => 'system_task',
+				'decision'  => 'rejected',
+				'resolvers' => array( 'system:test-resolver' ),
+			),
+		),
 	)
 );
 
@@ -284,9 +368,10 @@ $rejected = ResolvePendingActionAbility::execute(
 
 resolver_smoke_assert( true === ( $rejected['success'] ?? false ), 'rejected legacy resolution succeeds', $failures, $passes );
 resolver_smoke_assert( 'rejected' === ( $rejected['decision'] ?? null ), 'rejected response keeps Data Machine decision string', $failures, $passes );
-resolver_smoke_assert( 'safe-test' === ( $legacy_permission_seen[0]['context']['reason'] ?? null ), 'legacy can_resolve receives resolver context', $failures, $passes );
-resolver_smoke_assert( 'system:test-resolver' === ( $legacy_permission_seen[0]['context']['resolver'] ?? null ), 'legacy can_resolve receives resolver identity', $failures, $passes );
-resolver_smoke_assert( 0 === $legacy_apply_calls, 'rejected resolution does not invoke apply handler', $failures, $passes );
+$legacy_reject_permission = end( $legacy_permission_seen );
+resolver_smoke_assert( 'safe-test' === ( $legacy_reject_permission['context']['reason'] ?? null ), 'legacy can_resolve receives resolver context', $failures, $passes );
+resolver_smoke_assert( 'system:test-resolver' === ( $legacy_reject_permission['context']['resolver'] ?? null ), 'legacy can_resolve receives resolver identity', $failures, $passes );
+resolver_smoke_assert( 1 === $legacy_apply_calls, 'rejected resolution does not invoke apply handler', $failures, $passes );
 
 $denied_apply_calls = 0;
 $denying_handler    = new class( $denied_apply_calls ) implements WP_Agent_Pending_Action_Handler {


### PR DESCRIPTION
## Summary
- Adds explicit `resolver_grants` to staged pending actions and persists them through durable metadata for inspection and replay.
- Enforces grants before handler resolution for non-human resolvers such as `agent:*`, `system:*`, `system_task:*`, and operators while preserving default human and signed URL approvals.
- Covers strict default denial, granted agent/system resolution, rejection-only grants, and signed approval compatibility.

Fixes #2437.

## Tests
- `php tests/pending-action-resolver-contract-smoke.php`
- `php tests/signed-pending-action-resolution-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/Actions/ResolvePendingActionAbility.php inc/Engine/AI/Actions/PendingActionHelper.php inc/Engine/AI/Actions/PendingActionStore.php tests/pending-action-resolver-contract-smoke.php`
- `homeboy test data-machine` passed once before the final durable metadata refinement: 1310 passed, 3 skipped

## Notes
- Final full `homeboy test data-machine` retry did not reach tests due to Homeboy/WP Codebox lab bootstrap issues: first the local tool call timed out, then the lab mount failed before PHPUnit with missing `vendor/composer/autoload_real.php`.
- `homeboy lint data-machine` currently reports an unrelated existing PHPCS finding in `inc/Core/FilesRepository/MediaValidator.php:336` for deprecated `finfo_close()`; changed-file PHPCS is clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the pending-action resolver grant contract, adding smoke coverage, running validation, and drafting this PR description. Chris remains responsible for review and merge.