### PR TITLE
Expose selected abilities as model-facing tools

### DIFF
--- a/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
+++ b/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Ability-backed tool source.
+ *
+ * Exposes selected registered WordPress abilities as model-facing tools without
+ * requiring hand-written BaseTool wrappers. Execution remains ability-native via
+ * ToolExecutionCore because generated declarations include the `ability` key.
+ *
+ * @package DataMachine\Engine\AI\Tools\Sources
+ */
+
+namespace DataMachine\Engine\AI\Tools\Sources;
+
+use DataMachine\Engine\AI\Tools\ToolManager;
+use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
+
+defined( 'ABSPATH' ) || exit;
+
+final class AbilityToolSource {
+
+	private ToolManager $tool_manager;
+
+	/**
+	 * Metadata keys that tool authors may override on generated declarations.
+	 *
+	 * @var string[]
+	 */
+	private const OVERRIDE_KEYS = array(
+		'access_level',
+		'action_kind',
+		'action_policy',
+		'action_policy_chat',
+		'action_policy_pipeline',
+		'action_policy_system',
+		'action_preview_redact',
+		'build_action_preview',
+		'build_action_summary',
+		'client_context_bindings',
+		'description',
+		'label',
+		'mandatory',
+		'modes',
+		'parameters',
+		'requires_config',
+		'requires_opt_in',
+		'runtime',
+	);
+
+	public function __construct( ToolManager $tool_manager ) {
+		$this->tool_manager = $tool_manager;
+	}
+
+	/**
+	 * Gather selected abilities as Data Machine tool declarations.
+	 *
+	 * Plugins opt in through `datamachine_ability_tools`:
+	 *
+	 *     $tools['my_tool'] = array(
+	 *         'ability' => 'my-plugin/my-ability',
+	 *         'modes'   => array( 'chat', 'pipeline' ),
+	 *     );
+	 *
+	 * @param array $modes Active agent modes.
+	 * @param array $args  Resolution args.
+	 * @return array<string,array<string,mixed>> Tool declarations keyed by tool name.
+	 */
+	public function __invoke( array $modes, array $args = array() ): array {
+		if ( ! class_exists( '\WP_Abilities_Registry' ) ) {
+			return array();
+		}
+
+		$registry = \WP_Abilities_Registry::get_instance();
+		if ( ! $registry || ! method_exists( $registry, 'get_registered' ) ) {
+			return array();
+		}
+
+		$declared = apply_filters( 'datamachine_ability_tools', array(), $args );
+		if ( ! is_array( $declared ) ) {
+			return array();
+		}
+
+		$tools = array();
+		foreach ( $declared as $tool_name => $declaration ) {
+			if ( ! is_string( $tool_name ) || '' === $tool_name || ! is_array( $declaration ) ) {
+				continue;
+			}
+
+			$tool = $this->buildToolDefinition( $tool_name, $declaration, $registry, $args );
+			if ( empty( $tool ) ) {
+				continue;
+			}
+
+			if ( ! $this->matchesModes( $tool, $modes ) ) {
+				continue;
+			}
+
+			if ( ! ToolPolicyResolver::isOptInToolAllowed( $tool, $tool_name, $args ) ) {
+				continue;
+			}
+
+			if ( ! empty( $tool['requires_config'] ) ) {
+				if ( ! $this->tool_manager->is_tool_available( $tool_name, null ) ) {
+					continue;
+				}
+			} elseif ( ! $this->tool_manager->is_globally_enabled( $tool_name ) ) {
+				continue;
+			}
+
+			$tools[ $tool_name ] = $tool;
+		}
+
+		return $tools;
+	}
+
+	/**
+	 * Build one tool declaration from a registered ability and optional overrides.
+	 *
+	 * @param string $tool_name   Tool name.
+	 * @param array  $declaration Ability tool declaration.
+	 * @param object $registry    WP_Abilities_Registry instance.
+	 * @param array  $args        Resolution args.
+	 * @return array<string,mixed>
+	 */
+	private function buildToolDefinition( string $tool_name, array $declaration, object $registry, array $args ): array {
+		$ability_slug = isset( $declaration['ability'] ) && is_string( $declaration['ability'] ) ? $declaration['ability'] : '';
+		if ( '' === $ability_slug ) {
+			return array();
+		}
+
+		if ( method_exists( $registry, 'is_registered' ) && ! $registry->is_registered( $ability_slug ) ) {
+			return array();
+		}
+
+		$ability = $registry->get_registered( $ability_slug );
+		if ( ! is_object( $ability ) ) {
+			return array();
+		}
+
+		$meta        = method_exists( $ability, 'get_meta' ) ? $ability->get_meta() : array();
+		$meta        = is_array( $meta ) ? $meta : array();
+		$annotations = is_array( $meta['annotations'] ?? null ) ? $meta['annotations'] : array();
+
+		$tool = array(
+			'ability'          => $ability_slug,
+			'ability_category' => method_exists( $ability, 'get_category' ) ? (string) $ability->get_category() : '',
+			'annotations'      => $annotations,
+			'description'      => method_exists( $ability, 'get_description' ) ? (string) $ability->get_description() : '',
+			'label'            => method_exists( $ability, 'get_label' ) ? (string) $ability->get_label() : $tool_name,
+			'modes'            => array( ToolPolicyResolver::MODE_CHAT ),
+			'parameters'       => method_exists( $ability, 'get_input_schema' ) ? $ability->get_input_schema() : array(),
+		);
+
+		foreach ( self::OVERRIDE_KEYS as $key ) {
+			if ( array_key_exists( $key, $declaration ) ) {
+				$tool[ $key ] = $declaration[ $key ];
+			}
+		}
+
+		if ( ! is_array( $tool['parameters'] ?? null ) ) {
+			$tool['parameters'] = array();
+		}
+
+		$tool['modes'] = ToolPolicyResolver::normalizeModes( $tool['modes'] ?? array( ToolPolicyResolver::MODE_CHAT ) );
+
+		/**
+		 * Filter a generated ability-backed tool declaration before policy handling.
+		 *
+		 * @param array  $tool         Generated tool declaration.
+		 * @param string $tool_name    Model-facing tool name.
+		 * @param string $ability_slug Registered ability slug.
+		 * @param object $ability      Registered WP_Ability instance.
+		 * @param array  $declaration  Raw `datamachine_ability_tools` declaration.
+		 * @param array  $args         Tool resolution args.
+		 */
+		$filtered = apply_filters( 'datamachine_ability_tool_definition', $tool, $tool_name, $ability_slug, $ability, $declaration, $args );
+		$tool     = is_array( $filtered ) ? $filtered : $tool;
+
+		if ( ! is_array( $tool['parameters'] ?? null ) ) {
+			$tool['parameters'] = array();
+		}
+
+		$tool['modes'] = ToolPolicyResolver::normalizeModes( $tool['modes'] ?? array( ToolPolicyResolver::MODE_CHAT ) );
+
+		return $tool;
+	}
+
+	/**
+	 * Whether a tool declaration matches any active mode.
+	 *
+	 * @param array $tool  Tool declaration.
+	 * @param array $modes Active modes.
+	 * @return bool Whether the tool should be considered for the run.
+	 */
+	private function matchesModes( array $tool, array $modes ): bool {
+		$tool_modes = $tool['modes'] ?? array();
+		$tool_modes = is_array( $tool_modes ) ? $tool_modes : array( $tool_modes );
+
+		return ! empty( array_intersect( ToolPolicyResolver::normalizeModes( $tool_modes ), $modes ) );
+	}
+
+}

--- a/inc/Engine/AI/Tools/ToolSourceRegistry.php
+++ b/inc/Engine/AI/Tools/ToolSourceRegistry.php
@@ -11,6 +11,7 @@ namespace DataMachine\Engine\AI\Tools;
 
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Source_Registry;
 use DataMachine\Engine\AI\Tools\Sources\AdjacentHandlerToolSource;
+use DataMachine\Engine\AI\Tools\Sources\AbilityToolSource;
 use DataMachine\Engine\AI\Tools\Sources\DataMachineToolRegistrySource;
 use DataMachine\Engine\AI\Tools\Sources\RuntimeToolSource;
 
@@ -21,6 +22,7 @@ class ToolSourceRegistry {
 	public const SOURCE_STATIC_REGISTRY   = 'static_registry';
 	public const SOURCE_ADJACENT_HANDLERS = 'adjacent_handlers';
 	public const SOURCE_RUNTIME_TOOLS     = 'runtime_tools';
+	public const SOURCE_ABILITY_TOOLS     = 'ability_tools';
 
 	private ToolManager $tool_manager;
 	private WP_Agent_Tool_Source_Registry $registry;
@@ -70,6 +72,7 @@ class ToolSourceRegistry {
 		$runtime_source = new RuntimeToolSource();
 		$static_source  = new DataMachineToolRegistrySource( $this->tool_manager );
 		$handler_source = new AdjacentHandlerToolSource();
+		$ability_source = new AbilityToolSource( $this->tool_manager );
 
 		$this->registry->registerSource(
 			self::SOURCE_RUNTIME_TOOLS,
@@ -94,6 +97,14 @@ class ToolSourceRegistry {
 				return $static_source( $modes, $context );
 			}
 		);
+
+		$this->registry->registerSource(
+			self::SOURCE_ABILITY_TOOLS,
+			static function ( array $context ) use ( $ability_source ): array {
+				$modes = ToolPolicyResolver::normalizeModes( $context['modes'] ?? array() );
+				return $ability_source( $modes, $context );
+			}
+		);
 	}
 
 	/**
@@ -112,8 +123,8 @@ class ToolSourceRegistry {
 		$modes = ToolPolicyResolver::normalizeModes( $context['modes'] ?? array() );
 
 		$sources = in_array( ToolPolicyResolver::MODE_PIPELINE, $modes, true )
-			? array( self::SOURCE_RUNTIME_TOOLS, self::SOURCE_ADJACENT_HANDLERS, self::SOURCE_STATIC_REGISTRY )
-			: array( self::SOURCE_RUNTIME_TOOLS, self::SOURCE_STATIC_REGISTRY );
+			? array( self::SOURCE_RUNTIME_TOOLS, self::SOURCE_ADJACENT_HANDLERS, self::SOURCE_STATIC_REGISTRY, self::SOURCE_ABILITY_TOOLS )
+			: array( self::SOURCE_RUNTIME_TOOLS, self::SOURCE_STATIC_REGISTRY, self::SOURCE_ABILITY_TOOLS );
 
 		return array_values(
 			array_filter(

--- a/tests/ability-tool-source-smoke.php
+++ b/tests/ability-tool-source-smoke.php
@@ -1,0 +1,358 @@
+<?php
+/**
+ * Pure-PHP smoke test for ability-backed tool declarations (#2448).
+ *
+ * Run with: php tests/ability-tool-source-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$__filters = array();
+
+function ability_tool_smoke_filter_id( callable $callback ): string {
+	if ( is_array( $callback ) ) {
+		$owner = is_object( $callback[0] ) ? spl_object_hash( $callback[0] ) : (string) $callback[0];
+		return $owner . '::' . (string) $callback[1];
+	}
+
+	if ( $callback instanceof Closure ) {
+		return spl_object_hash( $callback );
+	}
+
+	return is_string( $callback ) ? $callback : spl_object_hash( (object) $callback );
+}
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	$GLOBALS['__filters'][ $hook ][ $priority ][ ability_tool_smoke_filter_id( $callback ) ] = array( $callback, $accepted_args );
+}
+
+function apply_filters( string $hook, $value, ...$args ) {
+	if ( empty( $GLOBALS['__filters'][ $hook ] ) ) {
+		return $value;
+	}
+
+	ksort( $GLOBALS['__filters'][ $hook ] );
+	foreach ( $GLOBALS['__filters'][ $hook ] as $callbacks ) {
+		foreach ( $callbacks as $entry ) {
+			$callback      = $entry[0];
+			$accepted_args = $entry[1];
+			$call_args     = array_slice( array_merge( array( $value ), $args ), 0, $accepted_args );
+			$value         = $callback( ...$call_args );
+		}
+	}
+
+	return $value;
+}
+
+function do_action( string $hook, ...$args ): void {}
+
+function did_action( string $hook ): int {
+	return 1;
+}
+
+function current_action(): string {
+	return '';
+}
+
+function get_option( string $key, $default_value = false ) {
+	return $default_value;
+}
+
+function is_wp_error( $value ): bool {
+	return false;
+}
+
+class WP_Abilities_Registry {
+	/** @var array<string, Ability_Tool_Source_Smoke_Ability> */
+	private static array $abilities = array();
+
+	public static function reset(): void {
+		self::$abilities = array();
+	}
+
+	public static function get_instance(): self {
+		return new self();
+	}
+
+	public function register_for_smoke( string $slug, Ability_Tool_Source_Smoke_Ability $ability ): void {
+		self::$abilities[ $slug ] = $ability;
+	}
+
+	public function is_registered( string $slug ): bool {
+		return isset( self::$abilities[ $slug ] );
+	}
+
+	public function get_registered( string $slug ) {
+		return self::$abilities[ $slug ] ?? null;
+	}
+}
+
+class Ability_Tool_Source_Smoke_Ability {
+	public int $execute_count = 0;
+
+	public function __construct(
+		private string $name,
+		private string $label,
+		private string $description,
+		private string $category,
+		private array $input_schema,
+		private array $meta = array(),
+		private bool $permitted = true
+	) {}
+
+	public function get_name(): string {
+		return $this->name;
+	}
+
+	public function get_label(): string {
+		return $this->label;
+	}
+
+	public function get_description(): string {
+		return $this->description;
+	}
+
+	public function get_category(): string {
+		return $this->category;
+	}
+
+	public function get_input_schema(): array {
+		return $this->input_schema;
+	}
+
+	public function get_meta(): array {
+		return $this->meta;
+	}
+
+	public function check_permissions( $input = null ): bool {
+		unset( $input );
+		return $this->permitted;
+	}
+
+	public function execute( $input = null ): array {
+		++$this->execute_count;
+		return array(
+			'success'  => true,
+			'received' => $input,
+		);
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/PluginSettings.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-access-policy.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-declaration.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-parameters.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-call.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-result.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-executor.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-execution-core.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-policy-filter.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-policy.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-tool-source-registry.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Approvals/class-wp-agent-approval-memory-store.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Approvals/class-wp-agent-null-approval-memory-store.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Workspace/class-wp-agent-workspace-scope.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-action-policy.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-action-policy-provider.php';
+require_once __DIR__ . '/../vendor/automattic/agents-api/src/Tools/class-wp-agent-action-policy-resolver.php';
+require_once __DIR__ . '/../inc/Core/AbilityResult.php';
+require_once __DIR__ . '/../inc/Core/Workspace/WordPressWorkspaceScope.php';
+require_once __DIR__ . '/../inc/Core/WordPress/PostTracking.php';
+require_once __DIR__ . '/../inc/Engine/AI/Actions/DataMachineModeActionPolicyProvider.php';
+require_once __DIR__ . '/../inc/Engine/AI/Actions/ActionPolicyResolver.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Execution/ToolExecutionCore.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolExecutor.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineAgentToolPolicyProvider.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineMandatoryToolPolicy.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineToolAccessPolicy.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/RuntimeToolSource.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AbilityToolSource.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
+
+use DataMachine\Engine\AI\Tools\ToolExecutor;
+use DataMachine\Engine\AI\Tools\ToolManager;
+use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
+use DataMachine\Engine\AI\Tools\Sources\AbilityToolSource;
+
+class AbilityToolSourceSmokeManager extends ToolManager {
+	public function get_all_tools(): array {
+		return array(
+			'collision_tool' => array(
+				'description' => 'Static tool wins collisions.',
+				'modes'       => array( 'pipeline' ),
+				'origin'      => 'static',
+			),
+		);
+	}
+
+	public function is_tool_available( string $tool_id, ?string $context_id = null ): bool {
+		unset( $context_id );
+		return 'disabled_ability_tool' !== $tool_id;
+	}
+
+	public function is_globally_enabled( string $tool_id ): bool {
+		return 'disabled_ability_tool' !== $tool_id;
+	}
+}
+
+$failures = array();
+$passes   = 0;
+
+function assert_ability_tool_source_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function resolve_ability_source_tools( string|array $modes, array $extra = array() ): array {
+	$resolver = new ToolPolicyResolver( new AbilityToolSourceSmokeManager() );
+
+	return $resolver->resolve(
+		array_merge(
+			array(
+				'modes'                => is_array( $modes ) ? $modes : array( $modes ),
+				'agent_id'             => 0,
+				'previous_step_config' => null,
+				'next_step_config'     => null,
+				'engine_data'          => array(),
+				'categories'           => array(),
+			),
+			$extra
+		)
+	);
+}
+
+echo "ability-tool-source-smoke\n";
+
+WP_Abilities_Registry::reset();
+$registry = WP_Abilities_Registry::get_instance();
+$ability  = new Ability_Tool_Source_Smoke_Ability(
+	'demo/summarize',
+	'Summarize Demo',
+	'Summarize a demo payload.',
+	'demo-category',
+	array(
+		'type'       => 'object',
+		'required'   => array( 'message' ),
+		'properties' => array(
+			'message' => array(
+				'type'        => 'string',
+				'description' => 'Message to summarize.',
+			),
+		),
+	),
+	array(
+		'annotations' => array(
+			'readonly'   => true,
+			'idempotent' => true,
+		),
+	)
+);
+$registry->register_for_smoke( 'demo/summarize', $ability );
+
+$disabled = new Ability_Tool_Source_Smoke_Ability(
+	'demo/disabled',
+	'Disabled Demo',
+	'Disabled ability.',
+	'demo-category',
+	array( 'type' => 'object' )
+);
+$registry->register_for_smoke( 'demo/disabled', $disabled );
+
+add_filter(
+	'datamachine_ability_tools',
+	static function ( array $tools ): array {
+		$tools['summarize_demo'] = array(
+			'ability'              => 'demo/summarize',
+			'modes'                => array( 'chat', 'pipeline' ),
+			'action_policy'        => 'direct',
+			'requires_opt_in'      => true,
+			'client_context_bindings' => array( 'job_id' ),
+		);
+		$tools['collision_tool'] = array(
+			'ability' => 'demo/summarize',
+			'modes'   => array( 'pipeline' ),
+		);
+		$tools['disabled_ability_tool'] = array(
+			'ability'         => 'demo/disabled',
+			'modes'           => array( 'pipeline' ),
+			'requires_config' => true,
+		);
+		$tools['missing_ability_tool'] = array(
+			'ability' => 'demo/missing',
+			'modes'   => array( 'pipeline' ),
+		);
+		return $tools;
+	},
+	10,
+	1
+);
+
+add_filter(
+	'datamachine_ability_tool_definition',
+	static function ( array $tool, string $tool_name ): array {
+		if ( 'summarize_demo' === $tool_name ) {
+			$tool['description'] = 'Model-facing summary override.';
+		}
+		return $tool;
+	},
+	10,
+	2
+);
+
+echo "\n[1] ability metadata becomes a model-facing tool declaration:\n";
+$source = new AbilityToolSource( new AbilityToolSourceSmokeManager() );
+$tools  = $source( array( 'chat' ), array( 'allow_only' => array( 'summarize_demo' ) ) );
+assert_ability_tool_source_equals( true, isset( $tools['summarize_demo'] ), 'chat mode exposes selected ability tool when opted in', $failures, $passes );
+assert_ability_tool_source_equals( 'demo/summarize', $tools['summarize_demo']['ability'] ?? '', 'generated tool links ability slug', $failures, $passes );
+assert_ability_tool_source_equals( 'Summarize Demo', $tools['summarize_demo']['label'] ?? '', 'generated tool carries ability label', $failures, $passes );
+assert_ability_tool_source_equals( 'demo-category', $tools['summarize_demo']['ability_category'] ?? '', 'generated tool carries ability category', $failures, $passes );
+assert_ability_tool_source_equals( 'Model-facing summary override.', $tools['summarize_demo']['description'] ?? '', 'definition filter can override model-facing description', $failures, $passes );
+assert_ability_tool_source_equals( array( 'message' ), $tools['summarize_demo']['parameters']['required'] ?? array(), 'generated parameters come from ability input schema', $failures, $passes );
+assert_ability_tool_source_equals( true, $tools['summarize_demo']['annotations']['readonly'] ?? false, 'generated tool carries ability annotations', $failures, $passes );
+
+echo "\n[2] source policy handles opt-in, missing abilities, config, and modes:\n";
+$no_opt_in = $source( array( 'pipeline' ), array() );
+assert_ability_tool_source_equals( false, isset( $no_opt_in['summarize_demo'] ), 'requires_opt_in hides ability tool without allowlist', $failures, $passes );
+$with_opt_in = $source( array( 'pipeline' ), array( 'allow_only' => array( 'summarize_demo' ) ) );
+assert_ability_tool_source_equals( true, isset( $with_opt_in['summarize_demo'] ), 'allow_only exposes opt-in ability tool', $failures, $passes );
+assert_ability_tool_source_equals( false, isset( $with_opt_in['missing_ability_tool'] ), 'missing ability declaration is skipped', $failures, $passes );
+assert_ability_tool_source_equals( false, isset( $with_opt_in['disabled_ability_tool'] ), 'requires_config ability tool respects tool availability', $failures, $passes );
+$chat_only = $source( array( 'chat' ), array( 'allow_only' => array( 'summarize_demo' ) ) );
+assert_ability_tool_source_equals( false, isset( $chat_only['collision_tool'] ), 'mode filtering hides unrelated ability tools', $failures, $passes );
+
+echo "\n[3] composed resolver keeps static tools ahead of generated ability tools:\n";
+$resolved = resolve_ability_source_tools( 'pipeline', array( 'allow_only' => array( 'summarize_demo', 'collision_tool' ) ) );
+assert_ability_tool_source_equals( array( 'collision_tool', 'summarize_demo' ), array_keys( $resolved ), 'static registry wins generated ability tool name collisions', $failures, $passes );
+assert_ability_tool_source_equals( 'static', $resolved['collision_tool']['origin'] ?? '', 'collision preserves static declaration', $failures, $passes );
+
+echo "\n[4] generated declaration executes through ability-native ToolExecutionCore:\n";
+$result = ToolExecutor::executeTool(
+	'summarize_demo',
+	array( 'message' => 'hello' ),
+	array( 'summarize_demo' => $with_opt_in['summarize_demo'] ),
+	array( 'job_id' => 123 ),
+	ToolPolicyResolver::MODE_PIPELINE
+);
+assert_ability_tool_source_equals( true, $result['success'] ?? false, 'generated ability tool executes successfully', $failures, $passes );
+assert_ability_tool_source_equals( 1, $ability->execute_count, 'ability execute callback ran once', $failures, $passes );
+assert_ability_tool_source_equals( 'hello', $result['result']['received']['message'] ?? '', 'AI parameter reached ability input', $failures, $passes );
+assert_ability_tool_source_equals( 123, $result['result']['received']['job_id'] ?? 0, 'payload context reached ability input through existing binding path', $failures, $passes );
+
+echo "\nAssertions: {$passes} passed, " . count( $failures ) . ' failed, ' . ( $passes + count( $failures ) ) . " total\n";
+exit( count( $failures ) );

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -112,6 +112,7 @@ require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineToolAccessPoli
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/RuntimeToolSource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AbilityToolSource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
 


### PR DESCRIPTION
## Summary
- Adds an `AbilityToolSource` that exposes selected registered WordPress abilities as Data Machine chat/pipeline tools from ability metadata.
- Wires the source into Data Machine tool source composition after existing static/adjacent sources so current wrappers keep precedence during migration.
- Adds smoke coverage for metadata generation, opt-in/config filtering, collision precedence, and ability-native execution through `ToolExecutionCore`.

Fixes #2448

## Testing
- `php tests/ability-tool-source-smoke.php`
- `php tests/tool-source-registry-smoke.php`
- `php tests/tool-executor-ability-native-smoke.php`
- `php -l inc/Engine/AI/Tools/Sources/AbilityToolSource.php`
- `php -l tests/ability-tool-source-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the ability-backed tool source primitive, drafted smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.