### PR TITLE
Parse named text tool calls

### DIFF
--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1530,11 +1530,33 @@ function datamachine_extract_tool_calls( $result ): array {
 				continue;
 			}
 
-			$tool_calls = array_merge( $tool_calls, datamachine_extract_xml_tool_calls( $text ), datamachine_extract_json_tool_calls( $text ), datamachine_extract_tag_tool_calls( $text ) );
+			$tool_calls = array_merge( $tool_calls, datamachine_extract_xml_tool_calls( $text ), datamachine_extract_json_tool_calls( $text ), datamachine_extract_tag_tool_calls( $text ), datamachine_extract_named_text_tool_calls( $text ) );
 		}
 	}
 
-	return $tool_calls;
+	return datamachine_dedupe_tool_calls( $tool_calls );
+}
+
+/**
+ * Remove exact duplicate tool calls produced by fallback text parsers.
+ *
+ * @param array<int, array{name:string,parameters:array,id:mixed}> $tool_calls Tool calls.
+ * @return array<int, array{name:string,parameters:array,id:mixed}>
+ */
+function datamachine_dedupe_tool_calls( array $tool_calls ): array {
+	$seen   = array();
+	$result = array();
+	foreach ( $tool_calls as $tool_call ) {
+		$key = ( $tool_call['name'] ?? '' ) . ':' . wp_json_encode( $tool_call['parameters'] ?? array() );
+		if ( isset( $seen[ $key ] ) ) {
+			continue;
+		}
+
+		$seen[ $key ] = true;
+		$result[]     = $tool_call;
+	}
+
+	return $result;
 }
 
 /**
@@ -1578,6 +1600,180 @@ function datamachine_extract_xml_tool_calls( string $text ): array {
 	}
 
 	return $tool_calls;
+}
+
+/**
+ * Extract named tool calls emitted as plain text by models that do not use the
+ * provider's structured tool-call transport.
+ *
+ * @param string $text Text candidate content.
+ * @return array<int, array{name:string,parameters:array,id:mixed}>
+ */
+function datamachine_extract_named_text_tool_calls( string $text ): array {
+	$tool_calls = array();
+
+	$patterns = array(
+		'/<(?P<name>[a-zA-Z][a-zA-Z0-9_\-]*)\s+(?P<attrs>[^<>]*?)\s*\/?>(?:\s*<\/\1>)?/s',
+		'/\[(?P<name>[a-zA-Z][a-zA-Z0-9_\-]*)\s+(?P<attrs>[^\]]*?)\](?:.*?\[\/\1\])?/s',
+	);
+	foreach ( $patterns as $pattern ) {
+		if ( ! preg_match_all( $pattern, $text, $matches, PREG_SET_ORDER ) ) {
+			continue;
+		}
+
+		foreach ( $matches as $match ) {
+			$name       = sanitize_key( (string) $match['name'] );
+			$parameters = datamachine_parse_text_tool_attributes( (string) $match['attrs'] );
+			if ( ! datamachine_is_plausible_text_tool_name( $name ) || empty( $parameters ) ) {
+				continue;
+			}
+
+			$tool_calls[] = array(
+				'name'       => $name,
+				'parameters' => $parameters,
+				'id'         => 'text-tool-call-' . ( count( $tool_calls ) + 1 ),
+			);
+		}
+	}
+
+	if ( preg_match_all( '/<tool\s+name=["\']([^"\']+)["\']\s*>(.*?)<\/tool>/is', $text, $matches, PREG_SET_ORDER ) ) {
+		foreach ( $matches as $match ) {
+			$name       = sanitize_key( (string) $match[1] );
+			$parameters = array();
+			if ( preg_match_all( '/<param\s+name=["\']([^"\']+)["\']\s*>(.*?)<\/param>/is', (string) $match[2], $parameter_matches, PREG_SET_ORDER ) ) {
+				foreach ( $parameter_matches as $parameter_match ) {
+					$parameter_name = sanitize_key( (string) $parameter_match[1] );
+					if ( '' === $parameter_name ) {
+						continue;
+					}
+
+					$parameter_value               = function_exists( '\wp_strip_all_tags' )
+						? \wp_strip_all_tags( (string) $parameter_match[2] )
+						: (string) preg_replace( '/<[^>]*>/', '', (string) $parameter_match[2] );
+					$parameters[ $parameter_name ] = html_entity_decode( trim( $parameter_value ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+				}
+			}
+
+			if ( ! datamachine_is_plausible_text_tool_name( $name ) || empty( $parameters ) ) {
+				continue;
+			}
+
+			$tool_calls[] = array(
+				'name'       => $name,
+				'parameters' => $parameters,
+				'id'         => 'text-tool-call-' . ( count( $tool_calls ) + 1 ),
+			);
+		}
+	}
+
+	if ( preg_match_all( '/(?:^|\s)to=(?P<name>[a-zA-Z][a-zA-Z0-9_\-]*)\s+(?P<json>\{.*?\})(?=\s|$)/s', $text, $matches, PREG_SET_ORDER ) ) {
+		foreach ( $matches as $match ) {
+			$name       = sanitize_key( (string) $match['name'] );
+			$parameters = json_decode( (string) $match['json'], true );
+			if ( ! datamachine_is_plausible_text_tool_name( $name ) || ! is_array( $parameters ) ) {
+				continue;
+			}
+
+			$tool_calls[] = array(
+				'name'       => $name,
+				'parameters' => $parameters,
+				'id'         => 'text-tool-call-' . ( count( $tool_calls ) + 1 ),
+			);
+		}
+	}
+
+	if ( preg_match_all( '/```(?P<name>[a-zA-Z][a-zA-Z0-9_\-]*)\s*(?P<json>\{.*?\})\s*```/is', $text, $matches, PREG_SET_ORDER ) ) {
+		foreach ( $matches as $match ) {
+			$name       = sanitize_key( (string) $match['name'] );
+			$parameters = json_decode( (string) $match['json'], true );
+			if ( ! datamachine_is_plausible_text_tool_name( $name ) || ! is_array( $parameters ) ) {
+				continue;
+			}
+
+			$tool_calls[] = array(
+				'name'       => $name,
+				'parameters' => $parameters,
+				'id'         => 'text-tool-call-' . ( count( $tool_calls ) + 1 ),
+			);
+		}
+	}
+
+	if ( preg_match_all( '/(?P<name>[a-zA-Z][a-zA-Z0-9_\-]*)\((?P<value>["\']?[^\)]*?["\']?)\)/', $text, $matches, PREG_SET_ORDER ) ) {
+		foreach ( $matches as $match ) {
+			$name  = sanitize_key( (string) $match['name'] );
+			$value = trim( (string) $match['value'], " \t\n\r\0\x0B\"'" );
+			if ( ! datamachine_is_plausible_text_tool_name( $name ) || '' === $value ) {
+				continue;
+			}
+
+			$tool_calls[] = array(
+				'name'       => $name,
+				'parameters' => array( 'path' => html_entity_decode( $value, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) ),
+				'id'         => 'text-tool-call-' . ( count( $tool_calls ) + 1 ),
+			);
+		}
+	}
+
+	if ( preg_match_all( '/(?:^|\s)(?P<name>[a-zA-Z][a-zA-Z0-9_\-]*)\s+(?P<attrs>(?:[a-zA-Z_][a-zA-Z0-9_\-]*=(?:"[^"]*"|\'[^\']*\'|\S+)\s*){2,})/s', $text, $matches, PREG_SET_ORDER ) ) {
+		foreach ( $matches as $match ) {
+			$name       = sanitize_key( (string) $match['name'] );
+			$parameters = datamachine_parse_text_tool_attributes( (string) $match['attrs'] );
+			if ( ! datamachine_is_plausible_text_tool_name( $name ) || empty( $parameters ) ) {
+				continue;
+			}
+
+			$tool_calls[] = array(
+				'name'       => $name,
+				'parameters' => $parameters,
+				'id'         => 'text-tool-call-' . ( count( $tool_calls ) + 1 ),
+			);
+		}
+	}
+
+	return $tool_calls;
+}
+
+/**
+ * Determine whether a bare text token looks like a tool name, not wrapper text.
+ *
+ * @param string $name Sanitized candidate tool name.
+ * @return bool
+ */
+function datamachine_is_plausible_text_tool_name( string $name ): bool {
+	if ( '' === $name || ! str_contains( $name, '_' ) ) {
+		return false;
+	}
+
+	return ! in_array( $name, array( 'function_calls', 'tool_call' ), true );
+}
+
+/**
+ * Parse key=value attributes from text tool-call forms.
+ *
+ * @param string $attributes Attribute text.
+ * @return array<string, string>
+ */
+function datamachine_parse_text_tool_attributes( string $attributes ): array {
+	$parameters = array();
+	if ( ! preg_match_all( '/([a-zA-Z_][a-zA-Z0-9_\-]*)=("[^"]*"|\'[^\']*\'|[^\s>\]]+)/', $attributes, $matches, PREG_SET_ORDER ) ) {
+		return $parameters;
+	}
+
+	foreach ( $matches as $match ) {
+		$name = sanitize_key( (string) $match[1] );
+		if ( '' === $name ) {
+			continue;
+		}
+
+		$value = trim( (string) $match[2] );
+		if ( ( str_starts_with( $value, '"' ) && str_ends_with( $value, '"' ) ) || ( str_starts_with( $value, "'" ) && str_ends_with( $value, "'" ) ) ) {
+			$value = substr( $value, 1, -1 );
+		}
+
+		$parameters[ $name ] = html_entity_decode( $value, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+	}
+
+	return $parameters;
 }
 
 /**
@@ -1655,7 +1851,11 @@ function datamachine_extract_tag_tool_calls( string $text ): array {
 				continue;
 			}
 
-			$parameters = datamachine_normalize_function_args( html_entity_decode( trim( (string) $match[2] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ) );
+			$body       = html_entity_decode( trim( (string) $match[2] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+			$parameters = datamachine_normalize_function_args( $body );
+			if ( '' !== $body && empty( $parameters ) ) {
+				continue;
+			}
 			++$index;
 			$tool_calls[] = array(
 				'name'       => $name,

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -854,6 +854,85 @@ assert_runner_request( 'workspace_read' === ( $named_tag_tool_sandbox_metadata['
 assert_runner_request( array( 'path' => 'README.md' ) === ( $named_tag_tool_sandbox_metadata['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline named tag tool parameters are parsed' );
 assert_runner_request( 1 === count( $named_tag_tool_sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline named tag tool call executes a workspace tool' );
 
+// 4g. Sandbox/pipeline runs also execute named text tool calls emitted by Codex-style responses.
+$named_text_dispatch_count = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$named_text_dispatch_count ) {
+		++$named_text_dispatch_count;
+
+		if ( 1 === $named_text_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content' => '<tool name="workspace_read"><param name="path">README.md</param></tool>'
+						. '[workspace_read path="README.md"][/workspace_read]'
+						. 'to=workspace_read {"path":"README.md"}'
+						. "```workspace_read\n{\"path\":\"README.md\"}\n```"
+						. ' workspace_read("README.md")'
+						. ' workspace_edit path=README.md old="before" new="after"',
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content' => 'named text sandbox complete',
+			),
+		);
+	}
+);
+
+$named_text_sandbox_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'read and edit the sandbox README using named text syntax' ) ),
+	array(
+		'workspace_read' => array(
+			'name'        => 'workspace_read',
+			'description' => 'Read a file from the sandbox workspace.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(
+					'path' => array( 'type' => 'string' ),
+				),
+				'required'   => array( 'path' ),
+			),
+			'class'       => SandboxPipelineSmokeTool::class,
+			'method'      => 'execute',
+		),
+		'workspace_edit' => array(
+			'name'        => 'workspace_edit',
+			'description' => 'Edit a file in the sandbox workspace.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(
+					'path' => array( 'type' => 'string' ),
+					'old'  => array( 'type' => 'string' ),
+					'new'  => array( 'type' => 'string' ),
+				),
+				'required'   => array( 'path', 'old', 'new' ),
+			),
+			'class'       => SandboxPipelineSmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	array( 'sandbox', 'pipeline' ),
+	array(),
+	3
+);
+$named_text_sandbox_metadata = datamachine_conversation_metadata( $named_text_sandbox_result );
+
+assert_runner_request( 2 === $named_text_dispatch_count, 'sandbox/pipeline named text tool calls return to provider for final answer' );
+assert_runner_request( 'named text sandbox complete' === ( $named_text_sandbox_result['final_content'] ?? null ), 'sandbox/pipeline named text tool calls preserve final answer' );
+assert_runner_request( 2 === count( $named_text_sandbox_metadata['tool_calls'] ?? array() ), 'sandbox/pipeline named text tool calls are parsed and deduped' );
+assert_runner_request( 'workspace_read' === ( $named_text_sandbox_metadata['tool_calls'][0]['name'] ?? null ), 'sandbox/pipeline named text read tool name is parsed' );
+assert_runner_request( array( 'path' => 'README.md' ) === ( $named_text_sandbox_metadata['tool_calls'][0]['parameters'] ?? null ), 'sandbox/pipeline named text read parameters are parsed' );
+assert_runner_request( 'workspace_edit' === ( $named_text_sandbox_metadata['tool_calls'][1]['name'] ?? null ), 'sandbox/pipeline named text edit tool name is parsed' );
+assert_runner_request( array( 'path' => 'README.md', 'old' => 'before', 'new' => 'after' ) === ( $named_text_sandbox_metadata['tool_calls'][1]['parameters'] ?? null ), 'sandbox/pipeline named text edit parameters are parsed' );
+assert_runner_request( 2 === count( $named_text_sandbox_result['tool_execution_results'] ?? array() ), 'sandbox/pipeline named text tool calls execute workspace tools' );
+
 // 5. Client runtime tools are fulfilled by the transport callback, not PHP ToolExecutor.
 $runtime_dispatch_count = 0;
 $runtime_requests       = array();


### PR DESCRIPTION
## Summary
- Parse named text tool-call forms such as `<workspace_read path=... />`, `<tool name=...>`, `to=workspace_read {...}`, fenced named JSON, function-style calls, and key/value calls.
- Dedupe exact fallback parser matches so repeated model attempts do not execute the same tool repeatedly.
- Add sandbox/pipeline smoke coverage for the Codex-style text response shape observed in live Codebox fan-out.

## Verification
- `php -l inc/Engine/AI/conversation-loop.php`
- `php -l tests/agent-conversation-runner-request-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the live Codebox/Codex tool-call extraction failure, drafted the parser/test change, and ran local verification. Chris remains responsible for review and merge.