### PR TITLE
Expose agents chat tool execution summaries

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -206,15 +206,17 @@ class AgentsChatHandler {
 	private function toCanonicalOutput( array $result ): array {
 		$metadata                = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
 		$datamachine_metadata    = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
+		$tool_execution_summary  = $this->toToolExecutionSummary( $result );
 		$datamachine_metadata    = array_filter(
 			array_merge(
 				$datamachine_metadata,
 				array(
-					'tool_calls'   => $result['tool_calls'] ?? null,
-					'conversation' => $result['conversation'] ?? null,
-					'max_turns'    => $result['max_turns'] ?? null,
-					'turn_number'  => $result['turn_number'] ?? null,
-					'interrupted'  => $result['interrupted'] ?? null,
+					'tool_calls'             => $result['tool_calls'] ?? null,
+					'tool_execution_summary' => $tool_execution_summary,
+					'conversation'           => $result['conversation'] ?? null,
+					'max_turns'              => $result['max_turns'] ?? null,
+					'turn_number'            => $result['turn_number'] ?? null,
+					'interrupted'            => $result['interrupted'] ?? null,
 				)
 			),
 			static fn( $value ): bool => null !== $value
@@ -228,6 +230,55 @@ class AgentsChatHandler {
 			'messages'   => $this->toCanonicalMessages( $result['conversation'] ?? array() ),
 			'completed'  => $completed,
 			'metadata'   => $metadata,
+		);
+	}
+
+	/**
+	 * Build the bounded tool execution diagnostics exposed through canonical metadata.
+	 *
+	 * @param array $result Data Machine chat response.
+	 * @return array<int,array<string,mixed>>|null
+	 */
+	private function toToolExecutionSummary( array $result ): ?array {
+		if ( is_array( $result['tool_execution_summary'] ?? null ) ) {
+			return $result['tool_execution_summary'];
+		}
+
+		$tool_execution_results = is_array( $result['tool_execution_results'] ?? null ) ? $result['tool_execution_results'] : array();
+		if ( empty( $tool_execution_results ) ) {
+			return null;
+		}
+
+		$summary_function = '\\DataMachine\\Engine\\AI\\datamachine_summarize_tool_execution_results';
+		if ( function_exists( $summary_function ) ) {
+			return $summary_function( $tool_execution_results, false );
+		}
+
+		return array_values(
+			array_filter(
+				array_map(
+					static function ( $result ): ?array {
+						if ( ! is_array( $result ) ) {
+							return null;
+						}
+						$tool_name   = isset( $result['tool_name'] ) ? sanitize_key( (string) $result['tool_name'] ) : '';
+						$tool_result = is_array( $result['result'] ?? null ) ? $result['result'] : array();
+						if ( '' === $tool_name ) {
+							return null;
+						}
+						return array_filter(
+							array(
+								'tool_name'  => $tool_name,
+								'success'    => true === ( $tool_result['success'] ?? false ),
+								'turn_count' => isset( $result['turn_count'] ) ? (int) $result['turn_count'] : null,
+								'summary'    => isset( $tool_result['message'] ) ? sanitize_text_field( (string) $tool_result['message'] ) : null,
+							),
+							static fn( $value ): bool => null !== $value && '' !== $value
+						);
+					},
+					$tool_execution_results
+				)
+			)
 		);
 	}
 

--- a/tests/agents-chat-handler-smoke.php
+++ b/tests/agents-chat-handler-smoke.php
@@ -83,7 +83,8 @@ $assert( str_contains( $handler_source, "'selected_pipeline_id' => (int) ( $" . 
 $assert( str_contains( $handler_source, "'request_id'           => $" . "input['request_id'] ?? null" ), 'AgentsChatHandler forwards request id for session dedupe' );
 $assert( str_contains( $handler_source, "'interrupt_source'     => is_callable( $" . "input['interrupt_source'] ?? null ) ? $" . "input['interrupt_source'] : null" ), 'AgentsChatHandler explicitly forwards callable interrupt sources' );
 $assert( str_contains( $handler_source, "'agent_slug'           => $" . "identity ? $" . "identity->agent_slug : ''" ), 'AgentsChatHandler forwards resolved agent targeting to the chat runtime' );
-$assert( str_contains( $handler_source, "'interrupted'  => $" . "result['interrupted'] ?? null" ), 'AgentsChatHandler returns interrupted diagnostics in canonical metadata' );
+$assert( str_contains( $handler_source, "'interrupted'" ) && str_contains( $handler_source, "$" . "result['interrupted'] ?? null" ), 'AgentsChatHandler returns interrupted diagnostics in canonical metadata' );
+$assert( str_contains( $handler_source, "'tool_execution_summary'" ), 'AgentsChatHandler returns bounded tool execution diagnostics in canonical metadata' );
 $assert( ! file_exists( $root . '/inc/Abilities/Chat/SendMessageAbility.php' ), 'datamachine/send-message facade class is removed' );
 $assert( ! str_contains( $chat_abilities, 'SendMessageAbility' ), 'ChatAbilities no longer registers datamachine/send-message' );
 $assert( str_contains( $chat_api, "wp_get_ability( 'agents/chat' )" ), 'REST chat endpoint dispatches directly through canonical agents/chat' );

--- a/tests/agents-chat-tool-continuation-smoke.php
+++ b/tests/agents-chat-tool-continuation-smoke.php
@@ -17,6 +17,24 @@ if ( ! function_exists( 'add_filter' ) ) {
 	}
 }
 
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $key ) ) ?? '';
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( string $text ): string {
+		return trim( preg_replace( '/[\r\n\t ]+/', ' ', strip_tags( $text ) ) ?? '' );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $flags = 0 ) {
+		return json_encode( $data, $flags );
+	}
+}
+
 if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
@@ -38,8 +56,9 @@ datamachine_agents_chat_tool_continuation_assert(
 
 require_once __DIR__ . '/../inc/Abilities/Chat/AgentsChatHandler.php';
 
-$handler = new DataMachine\Abilities\Chat\AgentsChatHandler();
-$method  = new ReflectionMethod( $handler, 'toCanonicalMessages' );
+$handler_reflection = new ReflectionClass( DataMachine\Abilities\Chat\AgentsChatHandler::class );
+$handler            = $handler_reflection->newInstanceWithoutConstructor();
+$method             = new ReflectionMethod( $handler, 'toCanonicalMessages' );
 
 $messages = $method->invoke(
 	$handler,
@@ -106,6 +125,60 @@ datamachine_agents_chat_tool_continuation_assert(
 datamachine_agents_chat_tool_continuation_assert(
 	true === ( $output['metadata']['datamachine']['max_turns_reached'] ?? null ),
 	'Canonical Agents API chat output should preserve Data Machine max-turn diagnostics.'
+);
+++ $assertions;
+
+$tool_output = $output_method->invoke(
+	$handler,
+	array(
+		'session_id'              => 'session-2',
+		'response'                => 'I checked the workspace.',
+		'tool_execution_results'  => array(
+			array(
+				'tool_name'  => 'workspace_read',
+				'turn_count' => 2,
+				'parameters' => array(
+					'path' => 'README.md',
+				),
+				'result'     => array(
+					'success' => true,
+					'message' => 'Read file content.',
+					'content' => 'raw file content should not be copied into canonical metadata',
+				),
+			),
+			array(
+				'tool_name'  => 'workspace_edit',
+				'turn_count' => 3,
+				'result'     => array(
+					'success' => false,
+					'message' => 'old_string not found in file content.',
+				),
+			),
+		),
+	)
+);
+
+datamachine_agents_chat_tool_continuation_assert(
+	2 === count( $tool_output['metadata']['datamachine']['tool_execution_summary'] ?? array() ),
+	'Canonical Agents API chat output should preserve bounded tool execution diagnostics.'
+);
+++ $assertions;
+
+datamachine_agents_chat_tool_continuation_assert(
+	'workspace_read' === ( $tool_output['metadata']['datamachine']['tool_execution_summary'][0]['tool_name'] ?? null ),
+	'Canonical Agents API chat output should preserve tool names.'
+);
+++ $assertions;
+
+datamachine_agents_chat_tool_continuation_assert(
+	false === ( $tool_output['metadata']['datamachine']['tool_execution_summary'][1]['success'] ?? null ),
+	'Canonical Agents API chat output should preserve failed tool execution status.'
+);
+++ $assertions;
+
+datamachine_agents_chat_tool_continuation_assert(
+	! str_contains( wp_json_encode( $tool_output['metadata']['datamachine']['tool_execution_summary'] ), 'raw file content' ),
+	'Canonical Agents API chat output should not copy raw tool content into metadata summaries.'
 );
 ++ $assertions;
 


### PR DESCRIPTION
## Summary
- Preserve bounded tool execution diagnostics in canonical `agents/chat` metadata as `metadata.datamachine.tool_execution_summary`.
- Add smoke coverage for successful and failed tool executions while keeping raw tool content out of canonical metadata.

## Verification
- `php tests/agents-chat-tool-continuation-smoke.php`
- `php tests/agents-chat-handler-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine-release-main --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the canonical chat adapter gap, drafted the code/test changes, and ran focused verification. Chris requested the PR and immediate merge.