### PR TITLE
Carry chat tool summaries from orchestrator

### DIFF
--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -28,6 +28,7 @@ use WP_Error;
 
 use function DataMachine\Engine\AI\datamachine_run_conversation;
 use function DataMachine\Engine\AI\datamachine_conversation_metadata;
+use function DataMachine\Engine\AI\datamachine_summarize_tool_execution_results;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -303,14 +304,15 @@ class ChatOrchestrator {
 
 		// --- Build response data ---
 		$response_data = array(
-			'session_id'   => $session_id,
-			'response'     => $result['final_content'],
-			'tool_calls'   => $loop_metadata['tool_calls'] ?? $loop_metadata['last_tool_calls'] ?? array(),
-			'conversation' => $result['messages'],
-			'metadata'     => $metadata,
-			'completed'    => $is_completed,
-			'max_turns'    => $max_turns,
-			'turn_number'  => $result['turn_count'],
+			'session_id'             => $session_id,
+			'response'               => $result['final_content'],
+			'tool_calls'             => $loop_metadata['tool_calls'] ?? $loop_metadata['last_tool_calls'] ?? array(),
+			'tool_execution_summary' => datamachine_summarize_tool_execution_results( $result['tool_execution_results'] ?? array(), false ),
+			'conversation'           => $result['messages'],
+			'metadata'               => $metadata,
+			'completed'              => $is_completed,
+			'max_turns'              => $max_turns,
+			'turn_number'            => $result['turn_count'],
 		);
 		if ( ! empty( $loop_metadata['runtime_tool_pending_requests'] ) ) {
 			$response_data['runtime_tool_pending_requests'] = $loop_metadata['runtime_tool_pending_requests'];

--- a/tests/agents-chat-handler-smoke.php
+++ b/tests/agents-chat-handler-smoke.php
@@ -72,6 +72,7 @@ $assert = static function ( bool $condition, string $label ) use ( &$passes, &$f
 
 $root           = dirname( __DIR__ );
 $handler_source = (string) file_get_contents( $root . '/inc/Abilities/Chat/AgentsChatHandler.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Source smoke fixture.
+$orchestrator   = (string) file_get_contents( $root . '/inc/Api/Chat/ChatOrchestrator.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Source smoke fixture.
 $chat_abilities = (string) file_get_contents( $root . '/inc/Abilities/ChatAbilities.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Source smoke fixture.
 $chat_api       = (string) file_get_contents( $root . '/inc/Api/Chat/Chat.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Source smoke fixture.
 
@@ -85,6 +86,7 @@ $assert( str_contains( $handler_source, "'interrupt_source'     => is_callable( 
 $assert( str_contains( $handler_source, "'agent_slug'           => $" . "identity ? $" . "identity->agent_slug : ''" ), 'AgentsChatHandler forwards resolved agent targeting to the chat runtime' );
 $assert( str_contains( $handler_source, "'interrupted'" ) && str_contains( $handler_source, "$" . "result['interrupted'] ?? null" ), 'AgentsChatHandler returns interrupted diagnostics in canonical metadata' );
 $assert( str_contains( $handler_source, "'tool_execution_summary'" ), 'AgentsChatHandler returns bounded tool execution diagnostics in canonical metadata' );
+$assert( str_contains( $orchestrator, "'tool_execution_summary'" ) && str_contains( $orchestrator, 'datamachine_summarize_tool_execution_results' ), 'ChatOrchestrator forwards bounded tool execution diagnostics to chat adapters' );
 $assert( ! file_exists( $root . '/inc/Abilities/Chat/SendMessageAbility.php' ), 'datamachine/send-message facade class is removed' );
 $assert( ! str_contains( $chat_abilities, 'SendMessageAbility' ), 'ChatAbilities no longer registers datamachine/send-message' );
 $assert( str_contains( $chat_api, "wp_get_ability( 'agents/chat' )" ), 'REST chat endpoint dispatches directly through canonical agents/chat' );


### PR DESCRIPTION
## Summary
- Forward bounded `tool_execution_summary` diagnostics from `ChatOrchestrator::processChat()` so canonical chat adapters can expose tool outcomes.
- Extend the agents chat handler smoke to guard the orchestrator-to-adapter handoff.

## Verification
- `php -l inc/Api/Chat/ChatOrchestrator.php`
- `php tests/agents-chat-handler-smoke.php`
- `php tests/agents-chat-tool-continuation-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine-release-main --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the remaining chat response handoff gap, drafted the small propagation fix/test guard, and ran verification. Chris requested continuing the fan-out proof path.