### PR TITLE
Route chat sessions through canonical Agents API abilities

### DIFF
--- a/docs/api/endpoints/chat-sessions.md
+++ b/docs/api/endpoints/chat-sessions.md
@@ -3,6 +3,15 @@
 **Implementation**: `inc/Api/Chat/Chat.php`
 
 Data Machine stores chat conversations as user-scoped sessions in `wp_datamachine_chat_sessions`.
+Generic session CRUD is exposed through the canonical Agents API abilities backed by Data Machine's active conversation store:
+
+- `agents/list-conversation-sessions`
+- `agents/get-conversation-session`
+- `agents/create-conversation-session`
+- `agents/update-conversation-session-title`
+- `agents/delete-conversation-session`
+
+Data Machine keeps product-owned session behavior such as read state, retention, reporting, and admin UX on Data Machine-specific APIs.
 
 ## Authentication
 
@@ -19,13 +28,15 @@ Session routes return:
 }
 ```
 
-The `data` shape is the corresponding Chat Session ability result.
+The `data` shape is the corresponding canonical Agents API conversation-session ability result, except product-only routes such as read-state updates continue to use Data Machine-specific abilities.
 
 ## Routes
 
 ### GET `/wp-json/datamachine/v1/chat/sessions`
 
 List sessions for the current user and scoped agent.
+
+Delegates to `agents/list-conversation-sessions`.
 
 **Query parameters**:
 
@@ -40,13 +51,19 @@ List sessions for the current user and scoped agent.
 
 Retrieve one session by UUID-like session ID (`[a-f0-9-]+`).
 
+Delegates to `agents/get-conversation-session`.
+
 ### DELETE `/wp-json/datamachine/v1/chat/{session_id}`
 
 Delete one session by UUID-like session ID.
 
+Delegates to `agents/delete-conversation-session`.
+
 ### POST `/wp-json/datamachine/v1/chat/sessions/{session_id}/read`
 
 Mark a session read for the current user.
+
+This is a Data Machine product-owned read-state operation and remains on `datamachine/mark-session-read`.
 
 ## Errors
 

--- a/inc/Api/Chat/Chat.php
+++ b/inc/Api/Chat/Chat.php
@@ -16,7 +16,9 @@ namespace DataMachine\Api\Chat;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\AbilityResult;
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
+use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 use DataMachine\Engine\AI\WpAiClientProviderAdmin;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -369,14 +371,16 @@ class Chat {
 	 * @return WP_REST_Response|WP_Error Response data or error.
 	 */
 	public static function list_sessions( WP_REST_Request $request ) {
-		return self::execute_ability(
-			'datamachine/list-chat-sessions',
+		$agent_id   = PermissionHelper::resolve_scoped_agent_id( $request );
+		$agent_slug = null !== $agent_id ? ConversationStoreFactory::resolve_agent_slug_for_transcript( (int) $agent_id ) : '';
+
+		return self::execute_conversation_session_ability(
+			'agents/list-conversation-sessions',
 			array(
-				'user_id'  => get_current_user_id(),
-				'agent_id' => PermissionHelper::resolve_scoped_agent_id( $request ),
-				'limit'    => (int) $request->get_param( 'limit' ),
-				'offset'   => (int) $request->get_param( 'offset' ),
-				'mode'     => $request->get_param( 'mode' ),
+				'limit'   => (int) $request->get_param( 'limit' ),
+				'offset'  => (int) $request->get_param( 'offset' ),
+				'context' => $request->get_param( 'mode' ),
+				'agent'   => $agent_slug,
 			)
 		);
 	}
@@ -406,11 +410,10 @@ class Chat {
 	 * @return WP_REST_Response|WP_Error Response data or error.
 	 */
 	public static function delete_session( WP_REST_Request $request ) {
-		return self::execute_ability(
-			'datamachine/delete-chat-session',
+		return self::execute_conversation_session_ability(
+			'agents/delete-conversation-session',
 			array(
 				'session_id' => sanitize_text_field( $request->get_param( 'session_id' ) ),
-				'user_id'    => get_current_user_id(),
 			)
 		);
 	}
@@ -422,11 +425,10 @@ class Chat {
 	 * @return WP_REST_Response|WP_Error Response data or error.
 	 */
 	public static function get_session( WP_REST_Request $request ) {
-		return self::execute_ability(
-			'datamachine/get-chat-session',
+		return self::execute_conversation_session_ability(
+			'agents/get-conversation-session',
 			array(
 				'session_id' => sanitize_text_field( $request->get_param( 'session_id' ) ),
-				'user_id'    => get_current_user_id(),
 			)
 		);
 	}
@@ -736,5 +738,23 @@ class Chat {
 				'data'    => $result,
 			)
 		);
+	}
+
+	/**
+	 * Execute a canonical Agents API conversation-session ability.
+	 *
+	 * The REST endpoint keeps Data Machine's response envelope, but generic
+	 * session CRUD now goes through the canonical Agents API ability slugs.
+	 *
+	 * @since next
+	 *
+	 * @param string $slug  Canonical ability slug.
+	 * @param array  $input Ability input.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private static function execute_conversation_session_ability( string $slug, array $input = array() ) {
+		$input['workspace'] ??= WordPressWorkspaceScope::current()->to_array();
+
+		return self::execute_ability( $slug, array_filter( $input, static fn( $value ) => null !== $value && '' !== $value ) );
 	}
 }

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -696,7 +696,7 @@ class ChatOrchestrator {
 			);
 		}
 
-		$ability = wp_get_ability( 'datamachine/create-chat-session' );
+		$ability = wp_get_ability( 'agents/create-conversation-session' );
 
 		if ( ! $ability ) {
 			return new WP_Error(
@@ -708,17 +708,21 @@ class ChatOrchestrator {
 
 		$agent_slug = ConversationStoreFactory::resolve_agent_slug_for_transcript( $agent_id );
 		$input      = array(
-			'user_id'    => $user_id,
-			'agent_slug' => $agent_slug,
-			'mode'       => $mode,
+			'workspace' => WordPressWorkspaceScope::current()->to_array(),
+			'agent'     => $agent_slug,
+			'context'   => $mode,
+			'metadata'  => array(
+				'started_at'    => current_time( 'mysql', true ),
+				'message_count' => 0,
+			),
 		);
 
 		if ( null !== $transcript_owner ) {
-			$input['transcript_owner'] = $transcript_owner;
+			$input['session_owner'] = $transcript_owner;
 		}
 
 		if ( $source ) {
-			$input['source'] = $source;
+			$input['metadata']['source'] = $source;
 		}
 
 		$result = \DataMachine\Abilities\PermissionHelper::run_as_authenticated(
@@ -731,15 +735,17 @@ class ChatOrchestrator {
 			return $result;
 		}
 
-		if ( empty( $result['success'] ) || empty( $result['session_id'] ) ) {
+		$session_id = (string) ( $result['session']['session_id'] ?? '' );
+
+		if ( '' === $session_id ) {
 			return new WP_Error(
 				'session_creation_failed',
-				$result['error'] ?? __( 'Failed to create chat session', 'data-machine' ),
+				__( 'Failed to create chat session', 'data-machine' ),
 				array( 'status' => 500 )
 			);
 		}
 
-		return $result['session_id'];
+		return $session_id;
 	}
 
 	/**

--- a/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
+++ b/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
@@ -24,6 +24,7 @@ use DataMachine\Core\Database\Chat\ConversationRetentionInterface;
 use DataMachine\Core\Database\Chat\ConversationSessionIndexInterface;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Chat\ConversationStoreInterface;
+use AgentsAPI\AI\WP_Agent_Execution_Principal;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Lock;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Store;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
@@ -449,6 +450,88 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		$this->assertCount( 1, $result['sessions'] );
 		$this->assertSame( $session_id, $result['sessions'][0]['session_id'] );
 		$this->assertSame( 'hello', $result['sessions'][0]['first_message'] );
+	}
+
+	public function test_canonical_conversation_session_abilities_route_through_swapped_store(): void {
+		$memory_store = new InMemoryConversationStore();
+		$user_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$principal    = WP_Agent_Execution_Principal::user_session( $user_id, 'memory-agent' );
+		$workspace    = $this->workspace()->to_array();
+
+		add_filter(
+			'datamachine_conversation_store',
+			static fn() => $memory_store,
+			10,
+			1
+		);
+		ConversationStoreFactory::reset();
+
+		if ( ! did_action( 'wp_abilities_api_init' ) ) {
+			do_action( 'wp_abilities_api_init' );
+		}
+
+		$create = wp_get_ability( 'agents/create-conversation-session' );
+		$list   = wp_get_ability( 'agents/list-conversation-sessions' );
+		$get    = wp_get_ability( 'agents/get-conversation-session' );
+		$title  = wp_get_ability( 'agents/update-conversation-session-title' );
+		$delete = wp_get_ability( 'agents/delete-conversation-session' );
+
+		$this->assertNotFalse( $create );
+		$this->assertNotFalse( $list );
+		$this->assertNotFalse( $get );
+		$this->assertNotFalse( $title );
+		$this->assertNotFalse( $delete );
+
+		$created = $create->execute(
+			array(
+				'principal' => $principal,
+				'workspace' => $workspace,
+				'agent'     => 'memory-agent',
+				'context'   => 'chat',
+				'metadata'  => array( 'source' => 'canonical-test' ),
+			)
+		);
+		$this->assertIsArray( $created );
+		$session_id = (string) ( $created['session']['session_id'] ?? '' );
+		$this->assertNotSame( '', $session_id );
+
+		$listed = $list->execute(
+			array(
+				'principal' => $principal,
+				'workspace' => $workspace,
+				'agent'     => 'memory-agent',
+			)
+		);
+		$this->assertSame( $session_id, $listed['sessions'][0]['session_id'] ?? '' );
+
+		$titled = $title->execute(
+			array(
+				'principal'  => $principal,
+				'workspace'  => $workspace,
+				'session_id' => $session_id,
+				'title'      => 'Canonical Session',
+			)
+		);
+		$this->assertSame( 'Canonical Session', $titled['session']['title'] ?? '' );
+
+		$loaded = $get->execute(
+			array(
+				'principal'  => $principal,
+				'workspace'  => $workspace,
+				'session_id' => $session_id,
+			)
+		);
+		$this->assertSame( 'canonical-test', $loaded['session']['metadata']['source'] ?? '' );
+
+		$deleted = $delete->execute(
+			array(
+				'principal'  => $principal,
+				'workspace'  => $workspace,
+				'session_id' => $session_id,
+			)
+		);
+		$this->assertTrue( $deleted['deleted'] ?? false );
+		$this->assertNull( $memory_store->get_session( $session_id ) );
 	}
 
 	private function workspace(): WP_Agent_Workspace_Scope {

--- a/tests/chat-session-canonical-path-smoke.php
+++ b/tests/chat-session-canonical-path-smoke.php
@@ -25,8 +25,13 @@ $assert = static function ( bool $condition, string $message ) use ( &$failures 
 };
 
 $assert(
-	false !== strpos( $chat_orchestrator, "wp_get_ability( 'datamachine/create-chat-session' )" ),
-	'ChatOrchestrator resolves the create-chat-session ability'
+	false !== strpos( $chat_orchestrator, "wp_get_ability( 'agents/create-conversation-session' )" ),
+	'ChatOrchestrator resolves the canonical create-conversation-session ability'
+);
+
+$assert(
+	false !== strpos( $chat_orchestrator, "'session_owner'" ),
+	'ChatOrchestrator passes opaque owners through the canonical session_owner input'
 );
 
 $assert(


### PR DESCRIPTION
## Summary
- Route Data Machine REST chat session list/get/delete and orchestrator session creation through canonical `agents/*conversation-session*` abilities.
- Keep Data Machine product-owned session behavior in place, including read-state routes, retention/reporting surfaces, and the active Data Machine conversation store.
- Add coverage proving canonical Agents API conversation-session abilities operate against Data Machine's swapped conversation store.

## Verification
- `php -l inc/Api/Chat/Chat.php`
- `php -l inc/Api/Chat/ChatOrchestrator.php`
- `php -l tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php`
- `php tests/chat-session-canonical-path-smoke.php`
- `composer lint -- inc/Api/Chat/Chat.php inc/Api/Chat/ChatOrchestrator.php tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php`
- `composer test` passed via Homeboy/WP Codebox: 1313 passed, 3 skipped

Note: Homeboy printed a non-fatal post-run parser notice after the successful test JSON: `/home/chubes/.config/homeboy/extensions/scripts/lib/test-result-adapters.sh: No such file or directory`.

Closes #2455.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** implementation draft, tests, and verification