### PR TITLE
Preserve chat tool execution summaries

### DIFF
--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -307,7 +307,7 @@ class ChatOrchestrator {
 			'session_id'             => $session_id,
 			'response'               => $result['final_content'],
 			'tool_calls'             => $loop_metadata['tool_calls'] ?? $loop_metadata['last_tool_calls'] ?? array(),
-			'tool_execution_summary' => datamachine_summarize_tool_execution_results( $result['tool_execution_results'] ?? array(), false ),
+			'tool_execution_summary' => $loop_metadata['tool_execution_summary'] ?? datamachine_summarize_tool_execution_results( $result['tool_execution_results'] ?? array(), false ),
 			'conversation'           => $result['messages'],
 			'metadata'               => $metadata,
 			'completed'              => $is_completed,

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -318,6 +318,9 @@ function datamachine_run_conversation(
 		'last_tool_calls' => $last_tool_calls,
 		'tool_calls'      => $all_tool_calls,
 	);
+	if ( ! empty( $tool_execution_results ) ) {
+		$datamachine_metadata['tool_execution_summary'] = datamachine_summarize_tool_execution_results( $tool_execution_results, false );
+	}
 	if ( 'interrupted' === ( $result['status'] ?? '' ) && isset( $result['interrupted'] ) ) {
 		$datamachine_metadata['interrupted'] = $result['interrupted'];
 	}

--- a/tests/agents-chat-tool-continuation-smoke.php
+++ b/tests/agents-chat-tool-continuation-smoke.php
@@ -54,6 +54,12 @@ datamachine_agents_chat_tool_continuation_assert(
 );
 ++ $assertions;
 
+datamachine_agents_chat_tool_continuation_assert(
+	str_contains( $chat_orchestrator_source, "\$loop_metadata['tool_execution_summary']" ),
+	'ChatOrchestrator should preserve tool execution summaries from conversation loop metadata.'
+);
+++ $assertions;
+
 require_once __DIR__ . '/../inc/Abilities/Chat/AgentsChatHandler.php';
 
 $handler_reflection = new ReflectionClass( DataMachine\Abilities\Chat\AgentsChatHandler::class );
@@ -179,6 +185,35 @@ datamachine_agents_chat_tool_continuation_assert(
 datamachine_agents_chat_tool_continuation_assert(
 	! str_contains( wp_json_encode( $tool_output['metadata']['datamachine']['tool_execution_summary'] ), 'raw file content' ),
 	'Canonical Agents API chat output should not copy raw tool content into metadata summaries.'
+);
+++ $assertions;
+
+$summary_output = $output_method->invoke(
+	$handler,
+	array(
+		'session_id'              => 'session-3',
+		'response'                => 'I checked the workspace.',
+		'tool_execution_summary'  => array(
+			array(
+				'tool_name'  => 'workspace_read',
+				'success'    => true,
+				'turn_count' => 1,
+				'summary'    => 'Read README.md.',
+			),
+		),
+		'tool_execution_results'  => array(),
+	),
+);
+
+datamachine_agents_chat_tool_continuation_assert(
+	1 === count( $summary_output['metadata']['datamachine']['tool_execution_summary'] ?? array() ),
+	'Canonical Agents API chat output should preserve non-empty precomputed tool execution summaries.'
+);
+++ $assertions;
+
+datamachine_agents_chat_tool_continuation_assert(
+	'workspace_read' === ( $summary_output['metadata']['datamachine']['tool_execution_summary'][0]['tool_name'] ?? null ),
+	'Canonical Agents API chat output should expose executed tool summaries without requiring raw tool results.'
 );
 ++ $assertions;
 


### PR DESCRIPTION
## Summary
- Preserve bounded `tool_execution_summary` diagnostics in Data Machine conversation metadata when tools execute.
- Forward the preserved loop summary through `ChatOrchestrator::processChat()` into canonical `agents/chat` output.
- Extend the agents/chat smoke test to cover non-empty precomputed summary propagation without raw tool results.

Fixes #2457.

## Verification
- `php tests/agents-chat-tool-continuation-smoke.php`
- `vendor/bin/phpcs inc/Api/Chat/ChatOrchestrator.php inc/Engine/AI/conversation-loop.php tests/agents-chat-tool-continuation-smoke.php`
- `php tests/agents-chat-handler-smoke.php`
- `php tests/job-artifacts-daily-memory-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the chat tool summary propagation path, implemented the targeted Data Machine fix, added smoke coverage, and ran focused validation. Chris remains responsible for review and merge.