### PR TITLE
Remove legacy AI provider bridge

### DIFF
--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -884,7 +884,7 @@ class ChatOrchestrator {
 				);
 
 				return new WP_Error(
-					'chubes_ai_request_failed',
+					'wp_ai_client_request_failed',
 					$loop_result['error'],
 					array( 'status' => 500 )
 				);

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -97,24 +97,6 @@ function datamachine_register_core_actions() {
 		3
 	);
 
-	// AI library error logging — universal handler for all AI interactions (pipeline agents, chat agents).
-	add_action(
-		'chubes_ai_library_error',
-		function ( $error_data ) {
-			do_action(
-				'datamachine_log',
-				'error',
-				'AI Library Error: ' . $error_data['component'] . ' - ' . $error_data['message'],
-				array(
-					'component' => $error_data['component'],
-					'message'   => $error_data['message'],
-					'context'   => $error_data['context'],
-					'timestamp' => $error_data['timestamp'],
-				)
-			);
-		}
-	);
-
 	\DataMachine\Engine\Actions\ImportExport::register();
 
 	// Pipeline batch fan-out: process chunks and track child completion.


### PR DESCRIPTION
## Summary
- Removes the remaining legacy `chubes_ai_library_error` listener from Data Machine action registration.
- Renames the chat AI-loop failure error code from `chubes_ai_request_failed` to `wp_ai_client_request_failed`.
- Leaves current `wp-ai-client` provider/admin plumbing from `main` intact; this PR is now a small cleanup on top of the already-merged migration work.

## Testing
- `homeboy lint --path "." --changed-only` — passed, no findings, PHPStan passed
- `homeboy test --path "."` — passed, 1313 passed / 3 skipped

## Notes
- `php tests/wp-ai-client-runtime-gate-smoke.php` currently fails in the pure-PHP local bootstrap because `WordPress\AiClient\Messages\DTO\MessagePart` is unavailable there. The full WP Codebox/Homeboy test suite passes against the restored Composer dependencies.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Rebuilt the conflicted branch on current `main`, reduced the diff to the remaining legacy-provider cleanup, ran verification, and updated the PR branch/description. Chris remains responsible for review and final acceptance.