### PR TITLE
Pass agent context to manual system task runs

### DIFF
--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -578,6 +578,8 @@ class SystemAbilities {
 			);
 		}
 
+		$task_context = self::extractRunTaskContext( $task_params );
+
 		$validation = self::validateRunTaskParams( $task_type, $meta, $task_params );
 		if ( ! $validation['success'] ) {
 			return array(
@@ -592,7 +594,7 @@ class SystemAbilities {
 		$job_id = TaskScheduler::schedule( $task_type, array_merge( $task_params, array(
 			'source'       => 'admin_run_now',
 			'triggered_by' => get_current_user_id(),
-		) ) );
+		) ), $task_context );
 
 		if ( ! $job_id ) {
 			return array(
@@ -610,6 +612,24 @@ class SystemAbilities {
 			'job_id'    => $job_id,
 			'message'   => "{$label} scheduled (Job #{$job_id}).",
 		);
+	}
+
+	/**
+	 * Extract scheduler context from manual run params.
+	 *
+	 * @param array $params Task params passed by reference.
+	 * @return array Scheduler context.
+	 */
+	private static function extractRunTaskContext( array &$params ): array {
+		$context = array();
+		foreach ( array( 'agent_id', 'agent_slug' ) as $key ) {
+			if ( array_key_exists( $key, $params ) ) {
+				$context[ $key ] = $params[ $key ];
+				unset( $params[ $key ] );
+			}
+		}
+
+		return $context;
 	}
 
 	/**

--- a/tests/system-task-agent-context-smoke.php
+++ b/tests/system-task-agent-context-smoke.php
@@ -347,9 +347,11 @@ $ai_step_source          = file_get_contents( dirname( __DIR__ ) . '/inc/Core/St
 $system_task_step_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Steps/SystemTask/SystemTaskStep.php' );
 $scheduler_source        = file_get_contents( dirname( __DIR__ ) . '/inc/Engine/Tasks/TaskScheduler.php' );
 $provider_source         = file_get_contents( dirname( __DIR__ ) . '/inc/Engine/AI/System/SystemAgentServiceProvider.php' );
+$system_abilities_source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/SystemAbilities.php' );
 $assert( 'AIStep has explicit missing-agent failure', str_contains( $ai_step_source, 'ai_agent_context_required' ) );
 $assert( 'SystemTaskStep has explicit missing-agent failure', str_contains( $system_task_step_source, 'system_task_agent_context_required' ) );
 $assert( 'TaskScheduler refuses agent-less queued task scheduling', str_contains( $scheduler_source, 'task_scheduler_agent_context_required' ) );
+$assert( 'Manual system task runs extract scheduler context', str_contains( $system_abilities_source, 'extractRunTaskContext' ) && str_contains( $system_abilities_source, 'TaskScheduler::schedule( $task_type, array_merge( $task_params' ) && str_contains( $system_abilities_source, '$task_context' ) );
 $assert( 'SystemTask exposes explicit agent-context contract', str_contains( file_get_contents( dirname( __DIR__ ) . '/inc/Engine/AI/System/Tasks/SystemTask.php' ), 'function requiresAgentContext(): bool' ) );
 $assert( 'Retention tasks explicitly opt out of agent context', str_contains( file_get_contents( dirname( __DIR__ ) . '/inc/Engine/AI/System/Tasks/Retention/RetentionTask.php' ), 'function requiresAgentContext(): bool' ) );
 $assert( 'Recurring per-agent schedules do not fall back to a site-scoped task', str_contains( $provider_source, 'recurring_task_agent_context_required' ) && ! str_contains( $provider_source, 'pre-multi-agent behaviour' ) );


### PR DESCRIPTION
## Summary
- Extracts `agent_id` / `agent_slug` from manual `datamachine system run` task params and passes them to `TaskScheduler` as scheduler context.
- Removes those identity keys from task params before schema validation so task-specific params remain strict.
- Extends the system-task agent-context smoke test to cover the manual run path.

## Why
Queued system tasks correctly require agent context, but manual `datamachine system run` had no way to provide that context. This made agent-owned manual maintenance tasks fail with `task_scheduler_agent_context_required` even when operators supplied `agent_slug`.

## Verification
- `php tests/system-task-agent-context-smoke.php`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-system-run-agent-context --changed-only`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the manual system-task scheduling failure, drafting the fix and smoke assertion, and running verification; Chris retains review responsibility for the final patch.