### PR TITLE
Enforce token ability scopes in permission lifecycle

### DIFF
--- a/inc/Abilities/AbilityScopePermissionFilter.php
+++ b/inc/Abilities/AbilityScopePermissionFilter.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Data Machine ability-scope permission lifecycle filter.
+ *
+ * @package DataMachine\Abilities
+ */
+
+namespace DataMachine\Abilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Applies Data Machine agent-token ability scopes to direct WP_Ability execution.
+ */
+final class AbilityScopePermissionFilter {
+
+	/**
+	 * Register the core ability permission lifecycle filter.
+	 */
+	public static function register(): void {
+		add_filter( 'wp_ability_permission_result', array( self::class, 'filter_permission_result' ), 10, 4 );
+	}
+
+	/**
+	 * Deny direct ability execution when the active agent-token scope excludes it.
+	 *
+	 * @param bool|\WP_Error $permission   Permission result returned by the ability.
+	 * @param string         $ability_name Ability slug.
+	 * @param mixed          $input        Input passed to the ability permission check.
+	 * @param object         $ability      Ability instance.
+	 * @return bool|\WP_Error Permission result.
+	 */
+	public static function filter_permission_result( $permission, string $ability_name, $input, $ability ) {
+		unset( $input );
+
+		if ( is_wp_error( $permission ) || true !== $permission ) {
+			return $permission;
+		}
+
+		if ( ! str_starts_with( $ability_name, 'datamachine/' ) ) {
+			return $permission;
+		}
+
+		$category = is_object( $ability ) && method_exists( $ability, 'get_category' ) ? (string) $ability->get_category() : '';
+		if ( PermissionHelper::can_use_ability( $ability_name, $category ) ) {
+			return $permission;
+		}
+
+		return new \WP_Error(
+			'datamachine_ability_scope_denied',
+			__( 'The active agent token is not allowed to execute this Data Machine ability.', 'data-machine' ),
+			array(
+				'ability' => $ability_name,
+				'status'  => 403,
+			)
+		);
+	}
+}

--- a/inc/Engine/AI/Tools/Policy/DataMachineToolAccessPolicy.php
+++ b/inc/Engine/AI/Tools/Policy/DataMachineToolAccessPolicy.php
@@ -75,7 +75,7 @@ final class DataMachineToolAccessPolicy {
 					return false;
 				}
 
-				if ( ! $ability || ! $ability->check_permissions() ) {
+				if ( ! $ability || true !== $ability->check_permissions() ) {
 					return false;
 				}
 			}

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -71,6 +71,7 @@ use DataMachine\Engine\AI\IterationBudgetRegistry;
 use DataMachine\Engine\AI\WpAiClientCache;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
+use DataMachine\Abilities\AbilityScopePermissionFilter;
 use DataMachine\Core\Content\ContentFormat;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Auth\AgentAccessStoreAdapter;
@@ -79,6 +80,7 @@ use DataMachine\Core\OAuth\HttpBasicAuthProvider;
 use DataMachine\Core\PluginSettings;
 
 add_action( 'plugins_loaded', array( WpAiClientCache::class, 'install' ), 20 );
+AbilityScopePermissionFilter::register();
 ContentFormat::register();
 
 add_filter(

--- a/tests/Unit/Abilities/PermissionHelperTest.php
+++ b/tests/Unit/Abilities/PermissionHelperTest.php
@@ -13,6 +13,7 @@
 namespace DataMachine\Tests\Unit\Abilities;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Abilities\AbilityScopePermissionFilter;
 use WP_UnitTestCase;
 
 class PermissionHelperTest extends WP_UnitTestCase {
@@ -248,6 +249,66 @@ class PermissionHelperTest extends WP_UnitTestCase {
 		$this->assertTrue( PermissionHelper::can_use_ability( 'datamachine/wiki', 'datamachine-system' ) );
 		$this->assertFalse( PermissionHelper::can_use_ability( 'datamachine/delete-post', 'datamachine-content' ) );
 		$this->assertFalse( PermissionHelper::can_use_ability( 'datamachine/update-settings', 'datamachine-settings' ) );
+	}
+
+	public function test_ability_scope_filter_denies_excluded_datamachine_ability(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$ability = new class() {
+			public function get_category(): string {
+				return 'datamachine-settings';
+			}
+		};
+
+		PermissionHelper::set_agent_context(
+			123,
+			$user_id,
+			array(
+				'scope'              => 'content_only',
+				'label'              => 'Content only',
+				'ability_categories' => array( 'datamachine-content' ),
+				'ability_allow'      => array(),
+				'ability_deny'       => array(),
+				'capabilities'       => array( 'datamachine_manage_settings' ),
+			),
+			456
+		);
+
+		$result = AbilityScopePermissionFilter::filter_permission_result( true, 'datamachine/update-settings', array(), $ability );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'datamachine_ability_scope_denied', $result->get_error_code() );
+	}
+
+	public function test_structured_scope_denies_direct_ability_execution(): void {
+		if ( version_compare( get_bloginfo( 'version' ), '7.1-alpha', '<' ) ) {
+			$this->markTestSkipped( 'Core ability permission lifecycle filter requires WordPress 7.1+.' );
+		}
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$ability = wp_get_ability( 'datamachine/update-settings' );
+
+		if ( ! $ability ) {
+			$this->markTestSkipped( 'datamachine/update-settings ability not registered.' );
+		}
+
+		PermissionHelper::set_agent_context(
+			123,
+			$user_id,
+			array(
+				'scope'              => 'content_only',
+				'label'              => 'Content only',
+				'ability_categories' => array( 'datamachine-content' ),
+				'ability_allow'      => array(),
+				'ability_deny'       => array(),
+				'capabilities'       => array( 'datamachine_manage_settings' ),
+			),
+			456
+		);
+
+		$result = $ability->execute( array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'datamachine_ability_scope_denied', $result->get_error_code() );
 	}
 
 	public function test_user_session_agent_context_uses_owner_ceiling_without_token_id(): void {


### PR DESCRIPTION
## Summary
- Adds a Data Machine permission lifecycle filter so active agent-token ability scopes can deny direct `datamachine/*` ability execution through `wp_ability_permission_result`.
- Keeps tool exposure fail-closed when an ability permission check returns anything other than `true`.
- Adds coverage for the filter path now and direct ability execution on WordPress versions that expose the core permission lifecycle hook.

## Testing
- `homeboy test --path "/Users/chubes/Developer/data-machine@fix-ability-permission-scope" --extension wordpress -- --filter=PermissionHelperTest`
- `homeboy lint --path "/Users/chubes/Developer/data-machine@fix-ability-permission-scope" --extension wordpress`

## Notes
- Current Homeboy WordPress test runtime is WordPress 7.0, so the direct `$ability->execute()` lifecycle assertion skips until the runner is on WordPress 7.1+ where `wp_ability_permission_result` exists. The Data Machine filter logic itself is covered in the current runtime.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the permission lifecycle filter, tests, verification commands, and PR description for Chris to review.