### PR TITLE
Drain targeted jobs reliably

### DIFF
--- a/inc/Cli/Commands/DrainCommand.php
+++ b/inc/Cli/Commands/DrainCommand.php
@@ -352,7 +352,7 @@ class DrainCommand extends BaseCommand {
 		$warnings    = array();
 		$claim       = null;
 		$stop_reason = '';
-		$claim_size  = '' === $lane ? $batch_size : max( $batch_size, min( 1000, $batch_size * 20 ) );
+		$claim_size  = self::claimSizeForScope( $batch_size, $hooks, $job_ids, $lane );
 		$processed   = 0;
 
 		try {
@@ -418,6 +418,101 @@ class DrainCommand extends BaseCommand {
 			'stop_reason'       => $stop_reason,
 			'actions_processed' => $processed,
 		);
+	}
+
+	/**
+	 * Determine how many due actions must be claimed to reach a scoped target.
+	 *
+	 * Action Scheduler claims by due order, but does not support filtering a claim
+	 * by serialized job IDs. When a targeted drain is requested, size the claim
+	 * through the first matching job action so the post-claim filter can process it.
+	 *
+	 * @param int           $batch_size Maximum matching actions to process.
+	 * @param string[]|null $hooks      Hook scope, or null for all hooks in the group.
+	 * @param int[]         $job_ids    Optional job ID scope.
+	 */
+	private static function claimSizeForScope( int $batch_size, ?array $hooks, array $job_ids, string $lane ): int {
+		$claim_size = '' === $lane ? $batch_size : max( $batch_size, min( 1000, $batch_size * 20 ) );
+
+		if ( empty( $job_ids ) ) {
+			return $claim_size;
+		}
+
+		return max( $claim_size, self::claimSizeThroughFirstJobAction( $hooks, $job_ids ) );
+	}
+
+	/**
+	 * Count due group actions through the first due action matching a job scope.
+	 *
+	 * @param string[]|null $hooks   Hook scope, or null for all hooks in the group.
+	 * @param int[]         $job_ids Job ID scope.
+	 */
+	private static function claimSizeThroughFirstJobAction( ?array $hooks, array $job_ids ): int {
+		global $wpdb;
+
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$groups_table  = $wpdb->prefix . 'actionscheduler_groups';
+		$hook_sql      = self::hookWhereSql( $hooks, $job_ids );
+		$now           = gmdate( 'Y-m-d H:i:s' );
+		$values        = array_merge(
+			array( $actions_table, $groups_table ),
+			$hook_sql['values'],
+			array( self::GROUP, $now )
+		);
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic hook/job scope is constructed from normalized placeholders and values.
+		$target = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT a.action_id, a.scheduled_date_gmt, a.priority
+				FROM %i a
+				INNER JOIN %i g ON g.group_id = a.group_id
+				WHERE ' . $hook_sql['sql'] . 'a.status = \'pending\'
+				AND g.slug = %s
+				AND a.scheduled_date_gmt <= %s
+				ORDER BY a.scheduled_date_gmt ASC, a.priority ASC, a.action_id ASC
+				LIMIT 1',
+				$values
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		if ( ! is_array( $target ) ) {
+			return 0;
+		}
+
+		$hook_sql = self::hookWhereSql( $hooks );
+		$values   = array_merge(
+			array( $actions_table, $groups_table ),
+			$hook_sql['values'],
+			array(
+				self::GROUP,
+				(string) $target['scheduled_date_gmt'],
+				(string) $target['scheduled_date_gmt'],
+				(int) $target['priority'],
+				(string) $target['scheduled_date_gmt'],
+				(int) $target['priority'],
+				(int) $target['action_id'],
+			)
+		);
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic hook scope is constructed from normalized placeholders and values.
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*)
+				FROM %i a
+				INNER JOIN %i g ON g.group_id = a.group_id
+				WHERE ' . $hook_sql['sql'] . 'a.status = \'pending\'
+				AND g.slug = %s
+				AND (
+					a.scheduled_date_gmt < %s
+					OR (a.scheduled_date_gmt = %s AND a.priority < %d)
+					OR (a.scheduled_date_gmt = %s AND a.priority = %d AND a.action_id <= %d)
+				)',
+				$values
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 	}
 
 	/**

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -56,6 +56,9 @@ assert_drain_contains( '"parent_job_id":', $drain_src, 'drain can filter batch a
 assert_drain_contains( "a.status = \\'pending\\'", $drain_src, 'drain queries pending actions in the Data Machine group' );
 assert_drain_contains( 'runActionSchedulerTimeoutCleanup( $store )', $drain_src, 'drain resets stale Action Scheduler claims before claiming work' );
 assert_drain_contains( 'stake_claim( $claim_size, null, $hooks ?? array(), self::GROUP )', $drain_src, 'drain claims due Data Machine actions through Action Scheduler' );
+assert_drain_contains( 'claimSizeForScope( $batch_size, $hooks, $job_ids, $lane )', $drain_src, 'drain sizes claims using the requested job and lane scope' );
+assert_drain_contains( 'claimSizeThroughFirstJobAction', $drain_src, 'job-scoped drain claims through the first matching job action' );
+assert_drain_contains( 'ORDER BY a.scheduled_date_gmt ASC, a.priority ASC, a.action_id ASC', $drain_src, 'job-scoped drain follows Action Scheduler due-order claim semantics' );
 assert_drain_contains( 'actionMatchesLane', $drain_src, 'drain filters claimed actions by lane when requested' );
 assert_drain_contains( 'stepTypeFromExecuteStepArgs', $drain_src, 'drain resolves publish lane from execute-step step type' );
 assert_drain_contains( '$deadline_at = $started_at + max( 0, $time_limit - $stop_before_timeout )', $drain_src, 'drain computes an action-level deadline for claimed batches' );


### PR DESCRIPTION
## Summary
- Sizes `datamachine drain --job-id` Action Scheduler claims through the first due action matching the requested job scope.
- Keeps the existing post-claim job/lane filters and claim ownership checks.
- Adds smoke coverage for job-scoped claim sizing and Action Scheduler due-order semantics.

## Verification
- `php -l inc/Cli/Commands/DrainCommand.php`
- `php tests/flow-run-cli-drain-smoke.php`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-drain-job-id-claim --changed-only`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the targeted drain no-progress path, drafting the fix and smoke coverage, and running verification; Chris retains review responsibility for the final patch.