### PR TITLE
Require explicit tool context bindings

### DIFF
--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -469,12 +469,13 @@ abstract class FetchHandler {
 	 */
 	private static function getRejectSourceToolDefinition( string $handler_slug, array $handler_config ): array {
 		return array(
-			'class'          => FetchItemDispositionTool::class,
-			'method'         => 'handle_tool_call',
-			'handler'        => $handler_slug,
-			'disposition'    => 'reject_source',
-			'description'    => 'Reject this fetched source item after reasoned content/source evaluation. Use when the source itself is irrelevant, too thin, duplicate, noisy, spammy, or otherwise fails the pipeline quality or relevance criteria. The source item will be marked as processed and will not normally be refetched.',
-			'parameters'     => array(
+			'class'                   => FetchItemDispositionTool::class,
+			'client_context_bindings' => array( 'job_id' ),
+			'method'                  => 'handle_tool_call',
+			'handler'                 => $handler_slug,
+			'disposition'             => 'reject_source',
+			'description'             => 'Reject this fetched source item after reasoned content/source evaluation. Use when the source itself is irrelevant, too thin, duplicate, noisy, spammy, or otherwise fails the pipeline quality or relevance criteria. The source item will be marked as processed and will not normally be refetched.',
+			'parameters'              => array(
 				'type'       => 'object',
 				'properties' => array(
 					'reason' => array(
@@ -484,7 +485,7 @@ abstract class FetchHandler {
 				),
 				'required'   => array( 'reason' ),
 			),
-			'handler_config' => $handler_config,
+			'handler_config'          => $handler_config,
 		);
 	}
 
@@ -498,12 +499,13 @@ abstract class FetchHandler {
 	 */
 	private static function getDeferItemToolDefinition( string $handler_slug, array $handler_config ): array {
 		return array(
-			'class'          => FetchItemDispositionTool::class,
-			'method'         => 'handle_tool_call',
-			'handler'        => $handler_slug,
-			'disposition'    => 'defer_item',
-			'description'    => 'Defer this fetched source item when the agent cannot safely complete processing now because of runtime failures, tool errors, missing context, uncertainty, or temporary limitations. The source claim will be released and the item will remain eligible to be fetched and retried later; it will not be marked processed.',
-			'parameters'     => array(
+			'class'                   => FetchItemDispositionTool::class,
+			'client_context_bindings' => array( 'job_id' ),
+			'method'                  => 'handle_tool_call',
+			'handler'                 => $handler_slug,
+			'disposition'             => 'defer_item',
+			'description'             => 'Defer this fetched source item when the agent cannot safely complete processing now because of runtime failures, tool errors, missing context, uncertainty, or temporary limitations. The source claim will be released and the item will remain eligible to be fetched and retried later; it will not be marked processed.',
+			'parameters'              => array(
 				'type'       => 'object',
 				'properties' => array(
 					'reason' => array(
@@ -513,7 +515,7 @@ abstract class FetchHandler {
 				),
 				'required'   => array( 'reason' ),
 			),
-			'handler_config' => $handler_config,
+			'handler_config'          => $handler_config,
 		);
 	}
 }

--- a/inc/Core/Steps/Publish/Handlers/Email/Email.php
+++ b/inc/Core/Steps/Publish/Handlers/Email/Email.php
@@ -39,11 +39,12 @@ class Email extends PublishHandler {
 			function ( $tools, $handler_slug, $handler_config ) {
 				if ( 'email_publish' === $handler_slug ) {
 					$tools['email_send'] = array(
-						'class'          => self::class,
-						'method'         => 'handle_tool_call',
-						'handler'        => 'email_publish',
-						'description'    => 'Send an email. Compose the subject and body (HTML). Optionally override recipients and attach files by providing server file paths.',
-						'parameters'     => array(
+						'class'                   => self::class,
+						'client_context_bindings' => array( 'job_id' ),
+						'method'                  => 'handle_tool_call',
+						'handler'                 => 'email_publish',
+						'description'             => 'Send an email. Compose the subject and body (HTML). Optionally override recipients and attach files by providing server file paths.',
+						'parameters'              => array(
 							'type'       => 'object',
 							'properties' => array(
 								'to'          => array(
@@ -66,7 +67,7 @@ class Email extends PublishHandler {
 							),
 							'required'   => array( 'subject', 'body' ),
 						),
-						'handler_config' => $handler_config,
+						'handler_config'          => $handler_config,
 					);
 				}
 				return $tools;

--- a/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php
+++ b/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php
@@ -77,12 +77,13 @@ class WordPress extends PublishHandler {
 					}
 
 					$tools['wordpress_publish'] = array(
-						'class'          => self::class,
-						'method'         => 'handle_tool_call',
-						'handler'        => 'wordpress_publish',
-						'description'    => 'Create WordPress posts and pages with automatic taxonomy assignment, featured image processing, and source URL attribution.',
-						'parameters'     => $tool_parameters,
-						'handler_config' => $handler_config,
+						'class'                   => self::class,
+						'client_context_bindings' => array( 'job_id' ),
+						'method'                  => 'handle_tool_call',
+						'handler'                 => 'wordpress_publish',
+						'description'             => 'Create WordPress posts and pages with automatic taxonomy assignment, featured image processing, and source URL attribution.',
+						'parameters'              => $tool_parameters,
+						'handler_config'          => $handler_config,
 					);
 				}
 				return $tools;

--- a/inc/Core/Steps/Upsert/Handlers/WordPress/WordPress.php
+++ b/inc/Core/Steps/Upsert/Handlers/WordPress/WordPress.php
@@ -37,11 +37,12 @@ class WordPress extends UpsertHandler {
 	public static function registerTools( $tools, $handler_slug, $handler_config ) {
 		if ( 'wordpress_update' === $handler_slug ) {
 			$tools['wordpress_update'] = array(
-				'class'       => self::class,
-				'method'      => 'handle_tool_call',
-				'handler'     => 'wordpress_update',
-				'description' => 'Update an existing WordPress post. Supports surgical text find/replace, block-level edits by index, full content replacement, title updates, and taxonomy assignment. Requires source_url from previous fetch step.',
-				'parameters'  => array(
+				'class'                   => self::class,
+				'client_context_bindings' => array( 'job_id' ),
+				'method'                  => 'handle_tool_call',
+				'handler'                 => 'wordpress_update',
+				'description'             => 'Update an existing WordPress post. Supports surgical text find/replace, block-level edits by index, full content replacement, title updates, and taxonomy assignment. Requires source_url from previous fetch step.',
+				'parameters'              => array(
 					'type'       => 'object',
 					'properties' => array(
 						'content'       => array(

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -339,8 +339,6 @@ class ToolManager {
 					$tool_def['access_level'] = $access_level;
 				}
 
-				$tool_def = self::withHandlerContextBindings( $tool_def );
-
 				$resolved[ $tool_name ] = $tool_def;
 			}
 		}
@@ -350,28 +348,6 @@ class ToolManager {
 		}
 
 		return $resolved;
-	}
-
-	/**
-	 * Add the explicit runtime context bindings owned by handler tools.
-	 *
-	 * Handler tools execute inside a pipeline job and may write audit or origin
-	 * metadata against that job. Keep that binding narrow and visible on the
-	 * resolved tool declaration instead of letting every payload key satisfy
-	 * tool parameters implicitly.
-	 *
-	 * @param array $tool_def Resolved handler tool definition.
-	 * @return array Tool definition with handler-owned context bindings.
-	 */
-	private static function withHandlerContextBindings( array $tool_def ): array {
-		$bindings = is_array( $tool_def['client_context_bindings'] ?? null ) ? $tool_def['client_context_bindings'] : array();
-		if ( ! array_key_exists( 'job_id', $bindings ) && ! in_array( 'job_id', $bindings, true ) ) {
-			$bindings['job_id'] = 'job_id';
-		}
-
-		$tool_def['client_context_bindings'] = $bindings;
-
-		return $tool_def;
 	}
 
 	/**

--- a/tests/Unit/AI/Tools/HandlerToolResolutionTest.php
+++ b/tests/Unit/AI/Tools/HandlerToolResolutionTest.php
@@ -87,6 +87,38 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 		$this->assertSame( 'widget_publish', $resolved['widget_publish']['_observed']['slug'] );
 		$this->assertSame( array( 'site_id' => 42 ), $resolved['widget_publish']['_observed']['config'] );
 		$this->assertSame( array( 'job_id' => 99 ), $resolved['widget_publish']['_observed']['engine'] );
+		$this->assertArrayNotHasKey( 'client_context_bindings', $resolved['widget_publish'] );
+	}
+
+	public function test_preserves_explicit_handler_context_bindings(): void {
+		add_filter(
+			'datamachine_tools',
+			function ( array $tools ): array {
+				$tools['__handler_tools_widget_publish_bound'] = array(
+					'_handler_callable' => static function () {
+						return array(
+							'widget_publish_bound' => array(
+								'description'             => 'Publish to widget with job context',
+								'client_context_bindings' => array( 'job_id' ),
+							),
+						);
+					},
+					'handler'           => 'widget_publish_bound',
+					'modes'             => array( 'pipeline' ),
+				);
+				return $tools;
+			}
+		);
+
+		$resolved = $this->tool_manager->resolveHandlerTools(
+			'widget_publish_bound',
+			array(),
+			array( 'job_id' => 99 ),
+			'flow_step_xyz'
+		);
+
+		$this->assertArrayHasKey( 'widget_publish_bound', $resolved );
+		$this->assertSame( array( 'job_id' ), $resolved['widget_publish_bound']['client_context_bindings'] );
 	}
 
 	public function test_resolves_three_param_filter_style_handler_callable_before_static_tool(): void {

--- a/tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php
@@ -100,12 +100,13 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
                 '_handler_callable' => static function (string $slug, array $config): array {
                     return array(
                         'fake_publish_tool' => array(
-                            'description'    => 'Publish synthetic content for the pipeline contract test.',
-                            'class'          => FakePipelinePublishTool::class,
-                            'method'         => 'handle',
-                            'handler'        => $slug,
-                            'handler_config' => $config,
-                            'parameters'     => array(
+                            'description'             => 'Publish synthetic content for the pipeline contract test.',
+                            'class'                   => FakePipelinePublishTool::class,
+                            'client_context_bindings' => array( 'job_id' ),
+                            'method'                  => 'handle',
+                            'handler'                 => $slug,
+                            'handler_config'          => $config,
+                            'parameters'              => array(
                                 'title'   => array(
                                     'type'     => 'string',
                                     'required' => true,

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -73,6 +73,7 @@ require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineToolAccessPoli
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/RuntimeToolSource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AbilityToolSource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
 

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -80,6 +80,10 @@ function get_option( string $key, $default_value = false ) {
 	return $default_value;
 }
 
+function wp_json_encode( $value, int $flags = 0, int $depth = 512 ) {
+	return json_encode( $value, $flags, $depth );
+}
+
 class WP_Abilities_Registry {
 	public static function get_instance(): self {
 		return new self();
@@ -242,6 +246,38 @@ assert_source_equals( array( 'chat_static_tool' ), array_keys( resolve_source_to
 assert_source_equals( array(), $manager->handler_calls, 'chat mode does not query adjacent handlers', $failures, $passes );
 assert_source_equals( array( 'system_static_tool' ), array_keys( resolve_source_tools( ToolPolicyResolver::MODE_SYSTEM, new SourcePolicyToolManager() ) ), 'system mode gets static system tools only', $failures, $passes );
 assert_source_equals( array( 'custom_static_tool' ), array_keys( resolve_source_tools( 'custom_mode', new SourcePolicyToolManager() ) ), 'custom mode gets static custom-mode tools only', $failures, $passes );
+
+echo "\n[2b] handler runtime context bindings stay declaration-owned:\n";
+remove_all_filters_for_source_smoke();
+add_filter(
+	'datamachine_tools',
+	static function ( array $tools ): array {
+		$tools['__handler_tools_context_smoke'] = array(
+			'_handler_callable' => static function (): array {
+				return array(
+					'unbound_handler_tool' => array(
+						'description' => 'Handler tool without runtime context.',
+					),
+					'bound_handler_tool'   => array(
+						'description'             => 'Handler tool with explicit job context.',
+						'client_context_bindings' => array( 'job_id' ),
+					),
+				);
+			},
+			'handler'           => 'context_smoke',
+			'modes'             => array( 'pipeline' ),
+		);
+		return $tools;
+	}
+);
+$handler_context_tools = ( new ToolManager() )->resolveHandlerTools(
+	'context_smoke',
+	array(),
+	array( 'job_id' => 99 ),
+	'context_scope'
+);
+assert_source_equals( false, isset( $handler_context_tools['unbound_handler_tool']['client_context_bindings'] ), 'handler tools do not receive implicit job_id bindings', $failures, $passes );
+assert_source_equals( array( 'job_id' ), $handler_context_tools['bound_handler_tool']['client_context_bindings'] ?? null, 'handler tools keep explicit job_id bindings', $failures, $passes );
 
 echo "\n[3] filters can add a source without disturbing default order:\n";
 remove_all_filters_for_source_smoke();


### PR DESCRIPTION
## Summary
- Removes the remaining implicit handler-wide `job_id` context binding from `ToolManager::resolveHandlerTools()`.
- Adds explicit `client_context_bindings` only to built-in handler tools that require runtime job context.
- Extends smoke/unit coverage so undeclared handler tools do not receive ambient context while explicitly bound tools still do.

Closes https://github.com/Extra-Chill/data-machine/issues/2467

## Testing
- `php tests/tool-executor-ability-native-smoke.php`
- `php tests/ability-tool-source-smoke.php`
- `php tests/tool-source-registry-smoke.php`
- `php tests/tool-policy-resolver-adjacency-smoke.php`
- `php tests/agents-chat-tool-continuation-smoke.php`
- `php tests/agents-chat-handler-smoke.php`
- `php tests/pipeline-tool-policy-surfaces-smoke.php`
- `php tests/pipeline-tool-policy-snapshot-smoke.php`
- `vendor/bin/phpcs tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php tests/tool-source-registry-smoke.php tests/Unit/AI/Tools/HandlerToolResolutionTest.php inc/Engine/AI/Tools/ToolManager.php inc/Core/Steps/Fetch/Handlers/FetchHandler.php inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php inc/Core/Steps/Publish/Handlers/Email/Email.php inc/Core/Steps/Upsert/Handlers/WordPress/WordPress.php tests/pipeline-tool-policy-snapshot-smoke.php`
- `composer test` — WP Codebox PHPUnit: 1319 tests, 4218 assertions, 4 skipped

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the explicit Data Machine tool-context binding changes, added smoke/unit coverage, and ran verification for Chris to review.