### PR TITLE
fix: honor import-agent ability scope

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -396,7 +396,8 @@ class AgentAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'importAgent' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can_manage()
+						|| ( PermissionHelper::in_agent_context() && PermissionHelper::can_use_ability( 'datamachine/import-agent', 'datamachine-agent' ) ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);


### PR DESCRIPTION
## Summary
- Allows `datamachine/import-agent` to execute for authenticated agent contexts whose token scope explicitly allows that ability.
- Keeps the existing manage-permission path for normal admin/user callers.

## Testing
- `php -l inc/Abilities/AgentAbilities.php`
- `homeboy lint data-machine --path "/Users/chubes/Developer/data-machine@fix-ability-permission-scope" --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the browser sandbox import permission failure, drafted the scoped permission change, and ran lint verification for Chris to review/test.