### PR TITLE
Handle generic runtime agent bundle imports

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -2310,4 +2310,88 @@ class AgentAbilities {
 			'message'       => sprintf( 'Agent "%s" (ID: %d) deleted.%s', $slug, $agent_id, $files_deleted ? ' Files removed.' : '' ),
 		);
 	}
+
+	/**
+	 * Import an agent bundle staged by a disposable agent runtime.
+	 *
+	 * @param mixed $result Previous importer result, or null when unhandled.
+	 * @param array $spec   Original bundle spec.
+	 * @param array $input  Staged datamachine/import-agent input.
+	 * @param int   $index  Bundle index in the runtime request.
+	 * @return mixed Import result or WP_Error.
+	 */
+	public static function importRuntimeAgentBundle( $result, array $spec, array $input, int $index ) {
+		unset( $index );
+
+		if ( null !== $result ) {
+			return $result;
+		}
+
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/import-agent' ) : null;
+		if ( ! $ability instanceof \WP_Ability ) {
+			return new \WP_Error(
+				'datamachine_import_agent_unavailable',
+				__( 'The Data Machine import-agent ability is not available inside the runtime site.', 'data-machine' )
+			);
+		}
+
+		$principal = self::runtimeAgentBundleImportPrincipal( $spec, $input );
+		if ( is_wp_error( $principal ) ) {
+			return $principal;
+		}
+
+		PermissionHelper::set_agent_context( (int) $principal['agent_id'], (int) $principal['owner_id'], $principal['scope'], $principal['token_id'] );
+		try {
+			return $ability->execute( $input );
+		} finally {
+			PermissionHelper::clear_agent_context();
+		}
+	}
+
+	/**
+	 * Resolve the Data Machine principal used for browser runtime bundle imports.
+	 *
+	 * @param array $spec  Original bundle spec.
+	 * @param array $input Staged datamachine/import-agent input.
+	 * @return array|\WP_Error
+	 */
+	private static function runtimeAgentBundleImportPrincipal( array $spec, array $input ) {
+		$principal       = is_array( $spec['import_principal'] ?? null ) ? $spec['import_principal'] : array();
+		$agent_id        = (int) ( $principal['agent_id'] ?? 1 );
+		$current_user_id = get_current_user_id();
+		if ( $agent_id <= 0 ) {
+			return new \WP_Error( 'datamachine_browser_bundle_import_principal_missing_agent', __( 'Agent bundle import principals require a positive agent_id.', 'data-machine' ) );
+		}
+
+		$capabilities = array_values( array_filter( array_map( 'strval', is_array( $principal['capabilities'] ?? null ) ? $principal['capabilities'] : array() ) ) );
+		if ( empty( $capabilities ) ) {
+			$capabilities = array( 'datamachine_manage_agents' );
+		}
+
+		$scope = is_array( $principal['scope'] ?? null ) ? $principal['scope'] : array();
+
+		$scope = array_merge(
+			array(
+				'scope'              => 'agent_bundle_import',
+				'label'              => 'Agent bundle import',
+				'ability_categories' => array(),
+				'ability_allow'      => array( 'datamachine/import-agent' ),
+				'ability_deny'       => array(),
+				'capabilities'       => $capabilities,
+			),
+			$scope
+		);
+
+		$scope['capabilities'] = array_values( array_filter( array_map( 'strval', is_array( $scope['capabilities'] ?? null ) ? $scope['capabilities'] : $capabilities ) ) );
+		if ( empty( $scope['capabilities'] ) ) {
+			$scope['capabilities'] = $capabilities;
+		}
+
+		return array(
+			'agent_id' => $agent_id,
+			'owner_id' => (int) ( $principal['owner_id'] ?? $input['owner_id'] ?? ( $current_user_id ? $current_user_id : 1 ) ),
+			'scope'    => $scope,
+			'token_id' => isset( $principal['token_id'] ) && (int) $principal['token_id'] > 0 ? (int) $principal['token_id'] : null,
+		);
+	}
 }

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -16,6 +16,7 @@
 
 namespace DataMachine\Api\Chat;
 
+use AgentsAPI\AI\WP_Agent_Execution_Principal;
 use DataMachine\Abilities\Chat\ChatTranscriptOwner;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
@@ -711,6 +712,13 @@ class ChatOrchestrator {
 			'workspace' => WordPressWorkspaceScope::current()->to_array(),
 			'agent'     => $agent_slug,
 			'context'   => $mode,
+			'principal' => WP_Agent_Execution_Principal::user_session(
+				$user_id,
+				$agent_slug,
+				WP_Agent_Execution_Principal::REQUEST_CONTEXT_CHAT,
+				array(),
+				WordPressWorkspaceScope::current()->key()
+			),
 			'metadata'  => array(
 				'started_at'    => current_time( 'mysql', true ),
 				'message_count' => 0,

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -72,6 +72,7 @@ use DataMachine\Engine\AI\WpAiClientCache;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
 use DataMachine\Abilities\AbilityScopePermissionFilter;
+use DataMachine\Abilities\AgentAbilities;
 use DataMachine\Core\Content\ContentFormat;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Auth\AgentAccessStoreAdapter;
@@ -82,6 +83,8 @@ use DataMachine\Core\PluginSettings;
 add_action( 'plugins_loaded', array( WpAiClientCache::class, 'install' ), 20 );
 AbilityScopePermissionFilter::register();
 ContentFormat::register();
+
+add_filter( 'wp_agent_runtime_import_bundle', array( AgentAbilities::class, 'importRuntimeAgentBundle' ), 10, 4 );
 
 add_filter(
 	'datamachine_auth_providers',

--- a/tests/chat-session-canonical-path-smoke.php
+++ b/tests/chat-session-canonical-path-smoke.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 $root              = dirname( __DIR__ );
 $chat_orchestrator = file_get_contents( $root . '/inc/Api/Chat/ChatOrchestrator.php' );
+$bootstrap         = file_get_contents( $root . '/inc/bootstrap.php' );
+$agent_abilities   = file_get_contents( $root . '/inc/Abilities/AgentAbilities.php' );
 
 $failures = array();
 
@@ -32,6 +34,26 @@ $assert(
 $assert(
 	false !== strpos( $chat_orchestrator, "'session_owner'" ),
 	'ChatOrchestrator passes opaque owners through the canonical session_owner input'
+);
+
+$assert(
+	false !== strpos( $chat_orchestrator, 'WP_Agent_Execution_Principal::user_session' ),
+	'ChatOrchestrator passes a bounded user-session principal for non-REST canonical session creation'
+);
+
+$assert(
+	false !== strpos( $bootstrap, "'wp_agent_runtime_import_bundle'" ) && false !== strpos( $bootstrap, 'importRuntimeAgentBundle' ),
+	'Data Machine registers the generic agent runtime bundle importer hook'
+);
+
+$assert(
+	false !== strpos( $agent_abilities, "wp_get_ability( 'datamachine/import-agent' )" ) && false !== strpos( $agent_abilities, 'PermissionHelper::set_agent_context' ),
+	'Data Machine owns Data Machine agent bundle import mechanics for generic agent runtimes'
+);
+
+$assert(
+	false === strpos( $bootstrap, 'wp_codebox_' ) && false === strpos( $agent_abilities, 'wp_codebox_' ),
+	'Data Machine does not reference WP Codebox-specific runtime hooks'
 );
 
 $assert(


### PR DESCRIPTION
## Summary
- Registers Data Machine on the generic `wp_agent_runtime_import_bundle` hook to import Data Machine agent bundles in disposable runtimes.
- Keeps Data Machine-specific import mechanics, scope defaults, and `datamachine/import-agent` execution inside Data Machine.
- Passes an explicit Agents API user-session principal when creating canonical conversation sessions from non-REST chat execution.

## Tests
- `php -l inc/Abilities/AgentAbilities.php && php -l inc/bootstrap.php && php -l inc/Api/Chat/ChatOrchestrator.php && php tests/chat-session-canonical-path-smoke.php`
- `homeboy lint data-machine --path \"/Users/chubes/Developer/data-machine@fix-ability-permission-scope\" --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic runtime importer implementation and boundary smoke coverage; Chris reviewed direction and boundary requirements.