### PR TITLE
Preserve Agents API tool result payloads

### DIFF
--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -17,6 +17,15 @@ defined( 'ABSPATH' ) || exit;
 
 class ConversationManager {
 
+	/** Maximum JSON bytes to expose in a model-facing tool result payload. */
+	private const MODEL_FACING_TOOL_DATA_MAX_BYTES = 12000;
+
+	/** Maximum string bytes to expose inside a model-facing tool result payload. */
+	private const MODEL_FACING_TOOL_DATA_STRING_MAX_BYTES = 1000;
+
+	/** Maximum nested depth to expose inside a model-facing tool result payload. */
+	private const MODEL_FACING_TOOL_DATA_MAX_DEPTH = 6;
+
 	/**
 	 * Build standardized conversation message envelope.
 	 *
@@ -166,7 +175,7 @@ class ConversationManager {
 
 			// Still append to content for AI context, but frontend can use metadata to hide it
 			if ( ! $is_handler_tool ) {
-				$content .= "\n\n" . wp_json_encode( $tool_data );
+				$content .= "\n\n" . self::modelFacingToolDataJson( $tool_data );
 			}
 		}
 
@@ -230,8 +239,12 @@ class ConversationManager {
 	 */
 	private static function modelFacingToolData( array $tool_result ): array {
 		$data = array();
-		if ( ! empty( $tool_result['data'] ) && is_array( $tool_result['data'] ) ) {
+		if ( is_array( $tool_result['data'] ?? null ) ) {
 			$data = $tool_result['data'];
+		} elseif ( is_array( $tool_result['result'] ?? null ) ) {
+			$data = $tool_result['result'];
+		} elseif ( array_key_exists( 'result', $tool_result ) && ( is_scalar( $tool_result['result'] ) || null === $tool_result['result'] ) ) {
+			$data = array( 'result' => $tool_result['result'] );
 		}
 
 		$public_keys = array(
@@ -252,7 +265,92 @@ class ConversationManager {
 			}
 		}
 
-		return $data;
+		return self::boundModelFacingToolData( $data );
+	}
+
+	/**
+	 * Encode bounded model-facing tool data.
+	 *
+	 * @param array<string,mixed> $tool_data Bounded tool data.
+	 * @return string JSON string.
+	 */
+	private static function modelFacingToolDataJson( array $tool_data ): string {
+		$json = wp_json_encode( $tool_data );
+
+		return is_string( $json ) ? $json : '{}';
+	}
+
+	/**
+	 * Bound model-facing tool data while preserving useful payload shape.
+	 *
+	 * @param array<string,mixed> $data Tool data payload.
+	 * @return array<string,mixed>
+	 */
+	private static function boundModelFacingToolData( array $data ): array {
+		foreach ( array( 50, 20, 10 ) as $max_items ) {
+			$bounded = self::boundModelFacingToolValue( $data, 0, $max_items );
+			$json    = self::modelFacingToolDataJson( $bounded );
+
+			if ( strlen( $json ) <= self::MODEL_FACING_TOOL_DATA_MAX_BYTES ) {
+				return $bounded;
+			}
+		}
+
+		$keys = array_slice( array_keys( $data ), 0, 50 );
+
+		return array(
+			'__truncated__' => true,
+			'keys'          => $keys,
+			'preview'       => substr( self::modelFacingToolDataJson( self::boundModelFacingToolValue( $data, 0, 3 ) ), 0, self::MODEL_FACING_TOOL_DATA_MAX_BYTES ),
+		);
+	}
+
+	/**
+	 * Bound a model-facing tool result value recursively.
+	 *
+	 * @param mixed $value     Value to bound.
+	 * @param int   $depth     Current depth.
+	 * @param int   $max_items Maximum array entries to preserve at each level.
+	 * @return mixed
+	 */
+	private static function boundModelFacingToolValue( $value, int $depth, int $max_items ) {
+		if ( is_string( $value ) ) {
+			if ( strlen( $value ) <= self::MODEL_FACING_TOOL_DATA_STRING_MAX_BYTES ) {
+				return $value;
+			}
+
+			return substr( $value, 0, self::MODEL_FACING_TOOL_DATA_STRING_MAX_BYTES ) . '... [truncated]';
+		}
+
+		if ( is_scalar( $value ) || null === $value ) {
+			return $value;
+		}
+
+		if ( ! is_array( $value ) ) {
+			return '[unserializable]';
+		}
+
+		if ( $depth >= self::MODEL_FACING_TOOL_DATA_MAX_DEPTH ) {
+			return array(
+				'__truncated__' => true,
+				'reason'        => 'max_depth',
+			);
+		}
+
+		$bounded = array();
+		$count   = 0;
+		foreach ( $value as $key => $child ) {
+			if ( $count >= $max_items ) {
+				$bounded['__truncated__'] = true;
+				$bounded['__omitted__']   = max( 0, count( $value ) - $count );
+				break;
+			}
+
+			$bounded[ $key ] = self::boundModelFacingToolValue( $child, $depth + 1, $max_items );
+			++$count;
+		}
+
+		return $bounded;
 	}
 
 	/**

--- a/tests/ai-message-envelope-smoke.php
+++ b/tests/ai-message-envelope-smoke.php
@@ -137,6 +137,60 @@ datamachine_message_envelope_count();
 datamachine_message_envelope_assert( 'Issue created.' === ( $merged_tool_result_envelope['payload']['tool_data']['message'] ?? null ), 'Existing nested tool data is preserved when top-level fields are merged.' );
 datamachine_message_envelope_count();
 
+$agents_api_result_tool_result = ConversationManager::formatToolResultMessage(
+	'workspace_ls',
+	array(
+		'success'   => true,
+		'tool_name' => 'workspace_ls',
+		'result'    => array(
+			'path'    => '.',
+			'entries' => array(
+				array(
+					'name' => 'composer.json',
+					'type' => 'file',
+				),
+				array(
+					'name' => 'inc',
+					'type' => 'directory',
+				),
+			),
+		),
+	),
+	array(),
+	false,
+	5
+);
+$agents_api_result_envelope = WP_Agent_Message::normalize( $agents_api_result_tool_result );
+datamachine_message_envelope_assert( 'composer.json' === ( $agents_api_result_envelope['payload']['tool_data']['entries'][0]['name'] ?? null ), 'Agents API result envelope entries are promoted to model-facing tool_data.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( str_contains( $agents_api_result_tool_result['content'], 'composer.json' ), 'Agents API result envelope entries are included in model-facing content.' );
+datamachine_message_envelope_count();
+
+$large_entries = array();
+for ( $i = 0; $i < 80; ++$i ) {
+	$large_entries[] = array(
+		'name'    => 'file-' . $i . '.txt',
+		'content' => str_repeat( 'x', 2000 ),
+	);
+}
+$large_tool_result = ConversationManager::formatToolResultMessage(
+	'workspace_ls',
+	array(
+		'success' => true,
+		'result'  => array(
+			'entries' => $large_entries,
+		),
+	),
+	array(),
+	false,
+	6
+);
+$large_tool_result_envelope = WP_Agent_Message::normalize( $large_tool_result );
+datamachine_message_envelope_assert( true === ( $large_tool_result_envelope['payload']['tool_data']['__truncated__'] ?? $large_tool_result_envelope['payload']['tool_data']['entries']['__truncated__'] ?? false ), 'Large model-facing tool result payloads are marked as truncated.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( strlen( $large_tool_result['content'] ) < 13000, 'Large model-facing tool result content is bounded.' );
+datamachine_message_envelope_count();
+
 $typed_final_result = array(
 	'schema'   => WP_Agent_Message::SCHEMA,
 	'version'  => WP_Agent_Message::VERSION,


### PR DESCRIPTION
## Summary
- Preserve model-facing tool result payloads from both Data Machine `data` envelopes and Agents API `result` envelopes.
- Bound/truncate the serialized tool payload before appending it to the conversation transcript so large tool results stay useful without becoming unbounded.
- Add regression coverage for `workspace_ls`-style `result.entries` payloads and large truncated results.

Fixes https://github.com/Extra-Chill/data-machine/issues/2470
Parent tracker: https://github.com/Extra-Chill/homeboy/issues/3378

## Verification
- `php -l inc/Engine/AI/ConversationManager.php`
- `php -l tests/ai-message-envelope-smoke.php`
- `./vendor/bin/phpcs inc/Engine/AI/ConversationManager.php tests/ai-message-envelope-smoke.php`
- `php tests/ai-message-envelope-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`
- `composer test` (WP Codebox PHPUnit: 1318 tests, 1314 passed, 4 skipped)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the bridge fix, drafted regression coverage, and ran verification; Chris remains responsible for review and merge.