### PR TITLE
Bound backlink ability responses

### DIFF
--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -631,7 +631,8 @@ class InternalLinkingAbilities {
 	 * @param array $input Ability input (unused).
 	 * @return array Ability response.
 	 */
-	public static function diagnoseInternalLinks( array $_input = array() ): array {
+	public static function diagnoseInternalLinks( array $input = array() ): array {
+		unset( $input );
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -280,11 +280,6 @@ class InternalLinkingAbilities {
 								'items'       => array( 'type' => 'string' ),
 								'description' => 'Optional edge types to include (e.g. ["html_anchor"]). Omit for all types.',
 							),
-							'limit'     => array(
-								'type'        => 'integer',
-								'description' => 'Maximum number of backlink source posts to return. Default: 0 for all.',
-								'default'     => 0,
-							),
 						),
 					),
 					'output_schema'       => array(
@@ -329,6 +324,11 @@ class InternalLinkingAbilities {
 								'type'        => 'array',
 								'items'       => array( 'type' => 'string' ),
 								'description' => 'Optional edge types to include (e.g. ["html_anchor"]). Omit for all types.',
+							),
+							'limit'     => array(
+								'type'        => 'integer',
+								'description' => 'Maximum number of backlink source posts to return. Default: 0 for all.',
+								'default'     => 0,
 							),
 						),
 					),
@@ -568,7 +568,7 @@ class InternalLinkingAbilities {
 		$eligible = array();
 		foreach ( $post_ids as $pid ) {
 			$post = get_post( $pid );
-			if ( $post && 'publish' === $post->post_status ) {
+			if ( $post instanceof \WP_Post && 'publish' === $post->post_status ) {
 				$eligible[] = $pid;
 			}
 		}
@@ -616,11 +616,11 @@ class InternalLinkingAbilities {
 			'success'      => true,
 			'queued_count' => count( $eligible ),
 			'post_ids'     => $eligible,
-			'batch_id'     => $batch['batch_id'] ?? null,
+			'batch_id'     => $batch['batch_id'],
 			'message'      => sprintf(
 				'Internal linking batch scheduled for %d post(s) (chunks of %d).',
 				count( $eligible ),
-				$batch['chunk_size'] ?? \DataMachine\Core\ActionScheduler\BatchScheduler::DEFAULT_CHUNK_SIZE
+				$batch['chunk_size']
 			),
 		);
 	}
@@ -631,8 +631,7 @@ class InternalLinkingAbilities {
 	 * @param array $input Ability input (unused).
 	 * @return array Ability response.
 	 */
-	public static function diagnoseInternalLinks( array $input = array() ): array {
-		$input;
+	public static function diagnoseInternalLinks( array $_input = array() ): array {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -1106,7 +1105,7 @@ class InternalLinkingAbilities {
 				// Deduplicate source IDs for this URL.
 				$seen_sources = array();
 				foreach ( $sources as $source ) {
-					$source_id = $source['source_id'] ?? 0;
+					$source_id = (int) $source['source_id'];
 					if ( isset( $seen_sources[ $source_id ] ) ) {
 						continue;
 					}
@@ -1118,7 +1117,7 @@ class InternalLinkingAbilities {
 						'source_title' => $id_to_title[ $source_id ] ?? get_the_title( $source_id ),
 						'broken_url'   => $url,
 						'status_code'  => $status,
-						'anchor_text'  => $source['anchor_text'] ?? '',
+						'anchor_text'  => (string) $source['anchor_text'],
 					);
 				}
 			}
@@ -1161,7 +1160,7 @@ class InternalLinkingAbilities {
 			return 0;
 		}
 
-		$status = wp_remote_retrieve_response_code( $response );
+		$status = (int) wp_remote_retrieve_response_code( $response );
 
 		// Some external servers block HEAD requests — fall back to GET.
 		if ( $is_external && ( 405 === $status || 403 === $status ) ) {
@@ -1176,7 +1175,7 @@ class InternalLinkingAbilities {
 			);
 
 			if ( ! is_wp_error( $get_response ) ) {
-				$get_status = wp_remote_retrieve_response_code( $get_response );
+				$get_status = (int) wp_remote_retrieve_response_code( $get_response );
 				// 206 (Partial Content) means the server supports Range and the URL is alive.
 				if ( 206 === $get_status || ( $get_status >= 200 && $get_status < 400 ) ) {
 					return $get_status;
@@ -1279,8 +1278,8 @@ class InternalLinkingAbilities {
 			);
 		}
 
-		$start_date = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
-		$end_date   = gmdate( 'Y-m-d', strtotime( '-3 days' ) );
+		$start_date = gmdate( 'Y-m-d', time() - ( $days * DAY_IN_SECONDS ) );
+		$end_date   = gmdate( 'Y-m-d', time() - ( 3 * DAY_IN_SECONDS ) );
 
 		$gsc_result = $gsc_ability->execute(
 			array(
@@ -1365,7 +1364,7 @@ class InternalLinkingAbilities {
 
 			// Verify the post exists and is published.
 			$post = get_post( $post_id );
-			if ( ! $post || 'publish' !== $post->post_status || 'post' !== $post->post_type ) {
+			if ( ! $post instanceof \WP_Post || 'publish' !== $post->post_status || 'post' !== $post->post_type ) {
 				continue;
 			}
 
@@ -1378,7 +1377,7 @@ class InternalLinkingAbilities {
 			$outbound = $outbound_counts[ $post_id ] ?? 0;
 
 			// Average position across URL variants.
-			$avg_position = $traffic['row_count'] > 0 ? $traffic['position'] / $traffic['row_count'] : 0;
+			$avg_position = $traffic['position'] / $traffic['row_count'];
 
 			// 4. Score: clicks * (1 / (inbound_links + 1)).
 			$score = $traffic['clicks'] * ( 1 / ( $inbound + 1 ) );
@@ -1426,7 +1425,7 @@ class InternalLinkingAbilities {
 	 *
 	 * @since 0.72.0
 	 *
-	 * @return array<string, array{label?: string, description?: string, callback: callable}>
+	 * @return array<string, array{label?: string, description?: string, callback?: mixed}>
 	 */
 	public static function getExtractors(): array {
 		$extractors = apply_filters( 'datamachine_link_extractors', array() );
@@ -1443,7 +1442,7 @@ class InternalLinkingAbilities {
 	 *
 	 * @since 0.72.0
 	 *
-	 * @return array<string, array{callback: callable}>
+	 * @return array<string, array{callback?: mixed}>
 	 */
 	public static function getResolvers(): array {
 		$resolvers = apply_filters( 'datamachine_link_resolvers', array() );
@@ -1527,9 +1526,10 @@ class InternalLinkingAbilities {
 	 */
 	public static function extractHtmlAnchorEdges( string $content, array $context ): array {
 		$home_host = $context['home_host'] ?? wp_parse_url( home_url(), PHP_URL_HOST );
+		$home_host = is_string( $home_host ) ? $home_host : '';
 		$edges     = array();
 
-		if ( empty( $content ) || ! is_string( $home_host ) || '' === $home_host ) {
+		if ( empty( $content ) || '' === $home_host ) {
 			return $edges;
 		}
 
@@ -1632,6 +1632,7 @@ class InternalLinkingAbilities {
 
 		$home_url  = home_url();
 		$home_host = wp_parse_url( $home_url, PHP_URL_HOST );
+		$home_host = is_string( $home_host ) ? $home_host : '';
 
 		// Build the query for posts to scan.
 		if ( ! empty( $specific_ids ) ) {

--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -280,6 +280,11 @@ class InternalLinkingAbilities {
 								'items'       => array( 'type' => 'string' ),
 								'description' => 'Optional edge types to include (e.g. ["html_anchor"]). Omit for all types.',
 							),
+							'limit'     => array(
+								'type'        => 'integer',
+								'description' => 'Maximum number of backlink source posts to return. Default: 0 for all.',
+								'default'     => 0,
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -908,6 +913,7 @@ class InternalLinkingAbilities {
 		$post_id    = absint( $input['post_id'] ?? 0 );
 		$post_type  = sanitize_text_field( $input['post_type'] ?? 'post' );
 		$types      = self::normalizeTypesInput( $input['types'] ?? null );
+		$limit      = absint( $input['limit'] ?? 0 );
 		$from_cache = true;
 
 		if ( 0 === $post_id ) {
@@ -951,7 +957,14 @@ class InternalLinkingAbilities {
 			++$sources[ $source_id ];
 		}
 
-		// Build the response array with titles and permalinks.
+		// Sort by link count descending (most links first) before hydrating rows.
+		arsort( $sources, SORT_NUMERIC );
+		$total_backlinks = count( $sources );
+		if ( $limit > 0 ) {
+			$sources = array_slice( $sources, 0, $limit, true );
+		}
+
+		// Build the response array with titles and permalinks for the returned slice.
 		$backlinks = array();
 		foreach ( $sources as $source_id => $link_count ) {
 			$permalink   = get_permalink( $source_id );
@@ -963,13 +976,10 @@ class InternalLinkingAbilities {
 			);
 		}
 
-		// Sort by link count descending (most links first).
-		usort( $backlinks, fn( $a, $b ) => $b['link_count'] <=> $a['link_count'] );
-
 		return array(
 			'success'        => true,
 			'post_id'        => $post_id,
-			'backlink_count' => count( $backlinks ),
+			'backlink_count' => $total_backlinks,
 			'backlinks'      => $backlinks,
 			'from_cache'     => $from_cache,
 		);

--- a/inc/Cli/Commands/LinksCommand.php
+++ b/inc/Cli/Commands/LinksCommand.php
@@ -488,11 +488,8 @@ class LinksCommand extends BaseCommand {
 	 * ---
 	 * default: 50
 	 * ---
-	 *
-	 * [--types=<types>]
-	 * : Comma-separated list of edge types to include (e.g. html_anchor,wikilink). Omit for all types.
-	 *
-	 * [--format=<format>]
+		 *
+		 * [--format=<format>]
 	 * : Output format.
 	 * ---
 	 * default: table
@@ -582,10 +579,13 @@ class LinksCommand extends BaseCommand {
 	 * default: post
 	 * ---
 	 *
-	 * [--types=<types>]
-	 * : Comma-separated list of edge types to include (e.g. html_anchor,wikilink). Omit for all types.
-	 *
-	 * [--format=<format>]
+		 * [--types=<types>]
+		 * : Comma-separated list of edge types to include (e.g. html_anchor,wikilink). Omit for all types.
+		 *
+		 * [--limit=<count>]
+		 * : Maximum number of backlink source posts to return. Default: 0 for all.
+		 *
+		 * [--format=<format>]
 	 * : Output format.
 	 * ---
 	 * default: table
@@ -626,6 +626,7 @@ class LinksCommand extends BaseCommand {
 				'post_id'   => $post_id,
 				'post_type' => $post_type,
 				'types'     => self::parseTypesArg( $assoc_args ),
+				'limit'     => absint( $assoc_args['limit'] ?? 0 ),
 			)
 		);
 

--- a/inc/Cli/Commands/LinksCommand.php
+++ b/inc/Cli/Commands/LinksCommand.php
@@ -488,8 +488,11 @@ class LinksCommand extends BaseCommand {
 	 * ---
 	 * default: 50
 	 * ---
-		 *
-		 * [--format=<format>]
+	 *
+	 * [--types=<types>]
+	 * : Comma-separated list of edge types to include (e.g. html_anchor,wikilink). Omit for all types.
+	 *
+	 * [--format=<format>]
 	 * : Output format.
 	 * ---
 	 * default: table
@@ -579,13 +582,10 @@ class LinksCommand extends BaseCommand {
 	 * default: post
 	 * ---
 	 *
-		 * [--types=<types>]
-		 * : Comma-separated list of edge types to include (e.g. html_anchor,wikilink). Omit for all types.
-		 *
-		 * [--limit=<count>]
-		 * : Maximum number of backlink source posts to return. Default: 0 for all.
-		 *
-		 * [--format=<format>]
+	 * [--types=<types>]
+	 * : Comma-separated list of edge types to include (e.g. html_anchor,wikilink). Omit for all types.
+	 *
+	 * [--format=<format>]
 	 * : Output format.
 	 * ---
 	 * default: table
@@ -626,7 +626,6 @@ class LinksCommand extends BaseCommand {
 				'post_id'   => $post_id,
 				'post_type' => $post_type,
 				'types'     => self::parseTypesArg( $assoc_args ),
-				'limit'     => absint( $assoc_args['limit'] ?? 0 ),
 			)
 		);
 

--- a/tests/backlinks-limit-smoke.php
+++ b/tests/backlinks-limit-smoke.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Smoke tests for bounded backlink ability responses.
+ *
+ * Runs via:
+ *
+ *   php tests/backlinks-limit-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+$GLOBALS['datamachine_permalink_calls'] = array();
+$GLOBALS['datamachine_link_graph']      = array(
+	'post_type'    => 'wiki',
+	'_id_to_title' => array(
+		11 => 'Most linked',
+		22 => 'Least linked',
+		33 => 'Second linked',
+	),
+	'_all_links'   => array(
+		array( 'source_id' => 11, 'target_id' => 100, 'edge_type' => 'wikilink' ),
+		array( 'source_id' => 11, 'target_id' => 100, 'edge_type' => 'wikilink' ),
+		array( 'source_id' => 11, 'target_id' => 100, 'edge_type' => 'html_anchor' ),
+		array( 'source_id' => 22, 'target_id' => 100, 'edge_type' => 'wikilink' ),
+		array( 'source_id' => 33, 'target_id' => 100, 'edge_type' => 'wikilink' ),
+		array( 'source_id' => 33, 'target_id' => 100, 'edge_type' => 'wikilink' ),
+		array( 'source_id' => 44, 'target_id' => 999, 'edge_type' => 'wikilink' ),
+	),
+);
+
+function absint( $value ): int {
+	return max( 0, (int) $value );
+}
+
+function sanitize_text_field( $value ): string {
+	return trim( (string) $value );
+}
+
+function sanitize_key( $value ): string {
+	return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $value ) );
+}
+
+function get_transient( string $_key ) {
+	return $GLOBALS['datamachine_link_graph'];
+}
+
+function get_permalink( $post_id ) {
+	$GLOBALS['datamachine_permalink_calls'][] = (int) $post_id;
+	return 'https://example.test/wiki/' . (int) $post_id . '/';
+}
+
+function datamachine_assert( bool $condition, string $message ): void {
+	if ( $condition ) {
+		echo "  [PASS] {$message}\n";
+		return;
+	}
+
+	echo "  [FAIL] {$message}\n";
+	exit( 1 );
+}
+
+require_once dirname( __DIR__ ) . '/inc/Abilities/InternalLinkingAbilities.php';
+
+echo "Backlinks limit smoke\n";
+
+$result = DataMachine\Abilities\InternalLinkingAbilities::getBacklinks(
+	array(
+		'post_id'   => 100,
+		'post_type' => 'wiki',
+		'limit'     => 2,
+	)
+);
+
+datamachine_assert( true === $result['success'], 'limited backlink lookup succeeds' );
+datamachine_assert( 3 === $result['backlink_count'], 'total backlink source count is preserved' );
+datamachine_assert( 2 === count( $result['backlinks'] ), 'returned backlinks are limited' );
+datamachine_assert( 11 === $result['backlinks'][0]['source_id'], 'highest link-count source is first' );
+datamachine_assert( 33 === $result['backlinks'][1]['source_id'], 'second highest source is second' );
+datamachine_assert( array( 11, 33 ) === $GLOBALS['datamachine_permalink_calls'], 'only returned sources are permalink-hydrated' );
+
+$GLOBALS['datamachine_permalink_calls'] = array();
+$filtered                             = DataMachine\Abilities\InternalLinkingAbilities::getBacklinks(
+	array(
+		'post_id'   => 100,
+		'post_type' => 'wiki',
+		'types'     => array( 'html_anchor' ),
+		'limit'     => 2,
+	)
+);
+
+datamachine_assert( 1 === $filtered['backlink_count'], 'type filtering still affects the total count' );
+datamachine_assert( 1 === count( $filtered['backlinks'] ), 'type filtering still limits returned rows' );
+datamachine_assert( 11 === $filtered['backlinks'][0]['source_id'], 'type-filtered source is returned' );
+datamachine_assert( array( 11 ) === $GLOBALS['datamachine_permalink_calls'], 'type-filtered lookup hydrates only returned rows' );
+
+echo "Backlinks limit smoke passed.\n";


### PR DESCRIPTION
## Summary
- Adds a `limit` input to `datamachine/get-backlinks` so callers can request bounded backlink source rows.
- Sorts source counts before hydrating permalinks and titles, preserving the total `backlink_count` while only materializing the returned slice.
- Wires the new limit through `wp datamachine links backlinks --limit=<count>` and covers the behavior with a smoke test.

## Why
While auditing Intelligence Horse reading views, rendering `intelligence/wiki-backlinks` for a normal wiki article on `intelligence.horse` exhausted the 512MB runtime memory limit during `datamachine/get-backlinks`:

- Sample page: https://intelligence.horse/wiki/matt/communication/automattic-rsm-town-hall-may-2026/
- Runtime command: `homeboy wp intelligence-horse eval '... do_blocks("<!-- wp:intelligence/wiki-backlinks /-->") ...'`
- Failure: `Allowed memory size of 536870912 bytes exhausted ... object-cache.memcached.php`

The downstream Intelligence render block should display a short backlink panel, not force the entire link graph fanout into the response.

## Verification
- `php tests/backlinks-limit-smoke.php`
- `php -l inc/Cli/Commands/LinksCommand.php`
- `php -l inc/Abilities/InternalLinkingAbilities.php`
- `php -l tests/backlinks-limit-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosing the runtime backlink OOM path and drafting/implementing the bounded ability response fix under Chris review.