### PR TITLE
Expose ability tool projection helper

### DIFF
--- a/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
+++ b/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
@@ -53,7 +53,8 @@ final class AbilityToolSource {
 	/**
 	 * Gather selected abilities as Data Machine tool declarations.
 	 *
-	 * Plugins opt in through `datamachine_ability_tools`:
+	 * Plugins opt in through `datamachine_ability_tool_projections` or the
+	 * `datamachine_register_ability_tool()` helper:
 	 *
 	 *     $tools['my_tool'] = array(
 	 *         'ability' => 'my-plugin/my-ability',
@@ -74,7 +75,8 @@ final class AbilityToolSource {
 			return array();
 		}
 
-		$declared = apply_filters( 'datamachine_ability_tools', array(), $args );
+		$declared = apply_filters( 'datamachine_ability_tool_projections', array(), $args );
+		$declared = apply_filters( 'datamachine_ability_tools', $declared, $args );
 		if ( ! is_array( $declared ) ) {
 			return array();
 		}

--- a/inc/Engine/AI/Tools/ability-tool-projections.php
+++ b/inc/Engine/AI/Tools/ability-tool-projections.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Ability tool projection helpers.
+ *
+ * @package DataMachine\Engine\AI\Tools
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'datamachine_register_ability_tool' ) ) {
+	/**
+	 * Register an ability as a model-facing tool projection.
+	 *
+	 * The declaration must include an `ability` slug. Optional keys such as
+	 * `modes`, `description`, `parameters`, `requires_opt_in`, `action_policy`,
+	 * and `runtime` are passed through AbilityToolSource.
+	 *
+	 * @param string $tool_name   Model-facing tool name.
+	 * @param array  $declaration Ability projection declaration.
+	 * @return bool Whether the projection was registered.
+	 */
+	function datamachine_register_ability_tool( string $tool_name, array $declaration ): bool {
+		if ( '' === $tool_name || empty( $declaration['ability'] ) || ! is_string( $declaration['ability'] ) ) {
+			return false;
+		}
+
+		add_filter(
+			'datamachine_ability_tool_projections',
+			static function ( array $tools ) use ( $tool_name, $declaration ): array {
+				$tools[ $tool_name ] = $declaration;
+				return $tools;
+			}
+		);
+
+		return true;
+	}
+}

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -28,6 +28,7 @@ require_once __DIR__ . '/Engine/MCP/functions.php';
 require_once __DIR__ . '/Engine/Filters/OAuth.php';
 require_once __DIR__ . '/Engine/Actions/DataMachineActions.php';
 require_once __DIR__ . '/Engine/Filters/EngineData.php';
+require_once __DIR__ . '/Engine/AI/Tools/ability-tool-projections.php';
 require_once __DIR__ . '/Core/Admin/Settings/SettingsFilters.php';
 
 /*

--- a/tests/ability-tool-source-smoke.php
+++ b/tests/ability-tool-source-smoke.php
@@ -167,6 +167,7 @@ require_once __DIR__ . '/../inc/Engine/AI/Actions/ActionPolicyResolver.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Execution/ToolExecutionCore.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolExecutor.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ability-tool-projections.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineAgentToolPolicyProvider.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineMandatoryToolPolicy.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineToolAccessPolicy.php';
@@ -274,8 +275,16 @@ $disabled = new Ability_Tool_Source_Smoke_Ability(
 );
 $registry->register_for_smoke( 'demo/disabled', $disabled );
 
+$helper_registered = datamachine_register_ability_tool(
+	'helper_demo',
+	array(
+		'ability' => 'demo/summarize',
+		'modes'   => array( 'chat' ),
+	)
+);
+
 add_filter(
-	'datamachine_ability_tools',
+	'datamachine_ability_tool_projections',
 	static function ( array $tools ): array {
 		$tools['summarize_demo'] = array(
 			'ability'              => 'demo/summarize',
@@ -304,6 +313,19 @@ add_filter(
 );
 
 add_filter(
+	'datamachine_ability_tools',
+	static function ( array $tools ): array {
+		$tools['legacy_alias_demo'] = array(
+			'ability' => 'demo/summarize',
+			'modes'   => array( 'chat' ),
+		);
+		return $tools;
+	},
+	10,
+	1
+);
+
+add_filter(
 	'datamachine_ability_tool_definition',
 	static function ( array $tool, string $tool_name ): array {
 		if ( 'summarize_demo' === $tool_name ) {
@@ -318,7 +340,10 @@ add_filter(
 echo "\n[1] ability metadata becomes a model-facing tool declaration:\n";
 $source = new AbilityToolSource( new AbilityToolSourceSmokeManager() );
 $tools  = $source( array( 'chat' ), array( 'allow_only' => array( 'summarize_demo' ) ) );
+assert_ability_tool_source_equals( true, $helper_registered, 'helper registers a valid ability tool projection', $failures, $passes );
 assert_ability_tool_source_equals( true, isset( $tools['summarize_demo'] ), 'chat mode exposes selected ability tool when opted in', $failures, $passes );
+assert_ability_tool_source_equals( true, isset( $tools['helper_demo'] ), 'helper projection feeds ability tool source', $failures, $passes );
+assert_ability_tool_source_equals( true, isset( $tools['legacy_alias_demo'] ), 'legacy ability tools filter remains supported', $failures, $passes );
 assert_ability_tool_source_equals( 'demo/summarize', $tools['summarize_demo']['ability'] ?? '', 'generated tool links ability slug', $failures, $passes );
 assert_ability_tool_source_equals( 'Summarize Demo', $tools['summarize_demo']['label'] ?? '', 'generated tool carries ability label', $failures, $passes );
 assert_ability_tool_source_equals( 'demo-category', $tools['summarize_demo']['ability_category'] ?? '', 'generated tool carries ability category', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds `datamachine_register_ability_tool()` and the canonical `datamachine_ability_tool_projections` filter for ability-native model-tool projection.
- Keeps existing `datamachine_ability_tools` declarations working while feeding the same AbilityToolSource policy and execution path.
- Extends smoke coverage for helper registration, canonical projection filtering, legacy filter compatibility, policy filtering, and ability execution.

Fixes #2473

## Tests
- `php tests/ability-tool-source-smoke.php`
- `php tests/tool-source-registry-smoke.php`
- `php tests/tool-executor-ability-native-smoke.php`
- `php -l inc/Engine/AI/Tools/ability-tool-projections.php && php -l inc/Engine/AI/Tools/Sources/AbilityToolSource.php && php -l inc/bootstrap.php && php -l tests/ability-tool-source-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Inspected the existing tool/ability projection path, implemented the helper/filter surface and smoke coverage, and ran focused verification. Chris remains responsible for review and merge.