### PR TITLE
Fix cold-cache backlink lookups on large sites

### DIFF
--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -925,13 +925,7 @@ class InternalLinkingAbilities {
 
 		$graph = get_transient( self::GRAPH_TRANSIENT_KEY );
 		if ( false === $graph || ! is_array( $graph ) || ( $graph['post_type'] ?? '' ) !== $post_type ) {
-			// No cache — run audit.
-			$graph = self::buildLinkGraph( $post_type, '', array() );
-			if ( isset( $graph['error'] ) ) {
-				return $graph;
-			}
-			set_transient( self::GRAPH_TRANSIENT_KEY, $graph, self::GRAPH_CACHE_TTL );
-			$from_cache = false;
+			return self::scanBacklinksForTarget( $post_id, $post_type, $types, $limit );
 		}
 
 		$all_links   = $graph['_all_links'] ?? array();
@@ -982,6 +976,136 @@ class InternalLinkingAbilities {
 			'backlink_count' => $total_backlinks,
 			'backlinks'      => $backlinks,
 			'from_cache'     => $from_cache,
+		);
+	}
+
+	/**
+	 * Scan source posts for backlinks to one target without materializing the full graph.
+	 *
+	 * This is the cold-cache path for render-time backlink lookups. Full graph
+	 * construction is still available through audit workflows, but a single
+	 * backlinks block should not need to build/cache every edge on a large site.
+	 *
+	 * @since 0.139.7
+	 *
+	 * @param int        $post_id   Target post ID.
+	 * @param string     $post_type Source post type scope.
+	 * @param array|null $types     Optional edge types to include.
+	 * @param int        $limit     Maximum source rows to return. 0 for all.
+	 * @return array Ability response.
+	 */
+	private static function scanBacklinksForTarget( int $post_id, string $post_type, ?array $types, int $limit ): array {
+		global $wpdb;
+
+		$target_permalink = get_permalink( $post_id );
+		$url_to_id        = array();
+		if ( false !== $target_permalink && '' !== $target_permalink ) {
+			$url_to_id[ untrailingslashit( $target_permalink ) ] = $post_id;
+			$url_to_id[ trailingslashit( $target_permalink ) ]   = $post_id;
+		}
+
+		$home_url  = home_url();
+		$home_host = wp_parse_url( $home_url, PHP_URL_HOST );
+		$home_host = is_string( $home_host ) ? $home_host : '';
+		$types_set = null === $types ? null : array_flip( array_map( 'strval', $types ) );
+
+		$sources = array();
+		$titles  = array();
+		$last_id = 0;
+		$chunk   = 100;
+
+		do {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$posts = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT ID, post_title, post_content FROM {$wpdb->posts}
+					WHERE post_type = %s AND post_status = %s AND ID > %d
+					ORDER BY ID ASC LIMIT %d",
+					$post_type,
+					'publish',
+					$last_id,
+					$chunk
+				)
+			);
+
+			if ( ! is_array( $posts ) || empty( $posts ) ) {
+				break;
+			}
+			$post_count = count( $posts );
+
+			foreach ( $posts as $source_post ) {
+				if ( ! is_object( $source_post ) || empty( $source_post->ID ) ) {
+					continue;
+				}
+
+				$source_id = (int) $source_post->ID;
+				$last_id   = max( $last_id, $source_id );
+
+				if ( $source_id === $post_id || empty( $source_post->post_content ) ) {
+					continue;
+				}
+
+				$extract_context = array(
+					'post_id'        => $source_id,
+					'post_type'      => $post_type,
+					'home_host'      => $home_host,
+					'home_url'       => $home_url,
+					'target_post_id' => $post_id,
+					'url_to_id'      => $url_to_id,
+				);
+
+				$edges = self::dispatchExtractors( (string) $source_post->post_content, $extract_context );
+				foreach ( $edges as $edge ) {
+					$target_hint = $edge['target_hint'] ?? '';
+					$edge_type   = (string) ( $edge['edge_type'] ?? '' );
+					if ( '' === $target_hint || '' === $edge_type ) {
+						continue;
+					}
+					if ( null !== $types_set && ! isset( $types_set[ $edge_type ] ) ) {
+						continue;
+					}
+
+					$resolve_context             = $extract_context;
+					$resolve_context['edge']     = $edge;
+					$resolve_context['post_ids'] = array( $post_id );
+
+					$target_id = self::dispatchResolver( (string) $target_hint, $edge_type, $resolve_context );
+					if ( $target_id !== $post_id ) {
+						continue;
+					}
+
+					if ( ! isset( $sources[ $source_id ] ) ) {
+						$sources[ $source_id ] = 0;
+						$titles[ $source_id ]  = (string) ( $source_post->post_title ?? '' );
+					}
+					++$sources[ $source_id ];
+				}
+			}
+		} while ( $post_count === $chunk );
+
+		arsort( $sources, SORT_NUMERIC );
+		$total_backlinks = count( $sources );
+		if ( $limit > 0 ) {
+			$sources = array_slice( $sources, 0, $limit, true );
+		}
+
+		$backlinks = array();
+		foreach ( $sources as $source_id => $link_count ) {
+			$permalink   = get_permalink( $source_id );
+			$backlinks[] = array(
+				'source_id'  => $source_id,
+				'title'      => $titles[ $source_id ] ?? '',
+				'permalink'  => false !== $permalink ? $permalink : '',
+				'link_count' => $link_count,
+			);
+		}
+
+		return array(
+			'success'        => true,
+			'post_id'        => $post_id,
+			'backlink_count' => $total_backlinks,
+			'backlinks'      => $backlinks,
+			'from_cache'     => false,
 		);
 	}
 

--- a/tests/backlinks-limit-smoke.php
+++ b/tests/backlinks-limit-smoke.php
@@ -31,6 +31,63 @@ $GLOBALS['datamachine_link_graph']      = array(
 		array( 'source_id' => 44, 'target_id' => 999, 'edge_type' => 'wikilink' ),
 	),
 );
+$GLOBALS['datamachine_filters']         = array();
+
+class Datamachine_Backlinks_Limit_Wpdb {
+	/**
+	 * Posts table name.
+	 *
+	 * @var string
+	 */
+	public string $posts = 'wp_posts';
+
+	/**
+	 * Source rows.
+	 *
+	 * @var array<int, object>
+	 */
+	public array $rows = array();
+
+	/**
+	 * Prepare query args for the fake get_results implementation.
+	 *
+	 * @param string $query SQL query.
+	 * @param mixed  ...$args Query args.
+	 * @return array{query:string,args:array}
+	 */
+	public function prepare( string $query, ...$args ): array {
+		return array(
+			'query' => $query,
+			'args'  => $args,
+		);
+	}
+
+	/**
+	 * Return a post chunk matching ID > last_id.
+	 *
+	 * @param array $prepared Prepared query payload.
+	 * @return array<int, object>
+	 */
+	public function get_results( array $prepared ): array {
+		$last_id = (int) ( $prepared['args'][2] ?? 0 );
+		$limit   = (int) ( $prepared['args'][3] ?? 100 );
+		$rows    = array_values(
+			array_filter(
+				$this->rows,
+				static fn( $row ) => (int) $row->ID > $last_id
+			)
+		);
+
+		usort(
+			$rows,
+			static fn( $a, $b ) => (int) $a->ID <=> (int) $b->ID
+		);
+
+		return array_slice( $rows, 0, $limit );
+	}
+}
+
+$GLOBALS['wpdb'] = new Datamachine_Backlinks_Limit_Wpdb();
 
 function absint( $value ): int {
 	return max( 0, (int) $value );
@@ -48,9 +105,44 @@ function get_transient( string $_key ) {
 	return $GLOBALS['datamachine_link_graph'];
 }
 
+function set_transient( string $_key, $_value, int $_ttl ): bool {
+	return true;
+}
+
 function get_permalink( $post_id ) {
 	$GLOBALS['datamachine_permalink_calls'][] = (int) $post_id;
 	return 'https://example.test/wiki/' . (int) $post_id . '/';
+}
+
+function home_url( string $path = '' ): string {
+	return 'https://example.test' . $path;
+}
+
+function wp_parse_url( string $url, int $component = -1 ) {
+	$parsed = parse_url( $url );
+	if ( -1 === $component ) {
+		return $parsed;
+	}
+	if ( PHP_URL_HOST === $component ) {
+		return $parsed['host'] ?? null;
+	}
+	return null;
+}
+
+function untrailingslashit( string $value ): string {
+	return rtrim( $value, '/' );
+}
+
+function trailingslashit( string $value ): string {
+	return rtrim( $value, '/' ) . '/';
+}
+
+function url_to_postid( string $url ): int {
+	return false !== strpos( $url, '/wiki/100' ) ? 100 : 0;
+}
+
+function apply_filters( string $tag, $value ) {
+	return $GLOBALS['datamachine_filters'][ $tag ] ?? $value;
 }
 
 function datamachine_assert( bool $condition, string $message ): void {
@@ -96,5 +188,53 @@ datamachine_assert( 1 === $filtered['backlink_count'], 'type filtering still aff
 datamachine_assert( 1 === count( $filtered['backlinks'] ), 'type filtering still limits returned rows' );
 datamachine_assert( 11 === $filtered['backlinks'][0]['source_id'], 'type-filtered source is returned' );
 datamachine_assert( array( 11 ) === $GLOBALS['datamachine_permalink_calls'], 'type-filtered lookup hydrates only returned rows' );
+
+$GLOBALS['datamachine_link_graph']      = false;
+$GLOBALS['datamachine_permalink_calls'] = array();
+$GLOBALS['datamachine_filters']         = array(
+	'datamachine_link_extractors' => array(
+		'html_anchor' => array(
+			'callback' => array( DataMachine\Abilities\InternalLinkingAbilities::class, 'extractHtmlAnchorEdges' ),
+		),
+	),
+	'datamachine_link_resolvers'  => array(
+		'html_anchor' => array(
+			'callback' => array( DataMachine\Abilities\InternalLinkingAbilities::class, 'resolveHtmlAnchor' ),
+		),
+	),
+);
+$GLOBALS['wpdb']->rows                  = array(
+	(object) array(
+		'ID'           => 201,
+		'post_title'   => 'Cold most linked',
+		'post_content' => '<a href="https://example.test/wiki/100/">Target</a><a href="https://example.test/wiki/100/">Target again</a>',
+	),
+	(object) array(
+		'ID'           => 202,
+		'post_title'   => 'Cold least linked',
+		'post_content' => '<a href="https://example.test/wiki/100/">Target</a>',
+	),
+	(object) array(
+		'ID'           => 203,
+		'post_title'   => 'Other target',
+		'post_content' => '<a href="https://example.test/wiki/999/">Other</a>',
+	),
+);
+
+$cold = DataMachine\Abilities\InternalLinkingAbilities::getBacklinks(
+	array(
+		'post_id'   => 100,
+		'post_type' => 'wiki',
+		'limit'     => 1,
+	)
+);
+
+datamachine_assert( true === $cold['success'], 'cold-cache backlink lookup succeeds without graph cache' );
+datamachine_assert( false === $cold['from_cache'], 'cold-cache lookup reports from_cache=false' );
+datamachine_assert( 2 === $cold['backlink_count'], 'cold-cache total source count is preserved' );
+datamachine_assert( 1 === count( $cold['backlinks'] ), 'cold-cache returned backlinks are limited' );
+datamachine_assert( 201 === $cold['backlinks'][0]['source_id'], 'cold-cache sources sort by link count' );
+datamachine_assert( 'Cold most linked' === $cold['backlinks'][0]['title'], 'cold-cache source titles are hydrated from scanned rows' );
+datamachine_assert( array( 100, 201 ) === $GLOBALS['datamachine_permalink_calls'], 'cold-cache hydrates target plus returned sources only' );
 
 echo "Backlinks limit smoke passed.\n";


### PR DESCRIPTION
## Summary
- Avoid building the full link graph when a single backlink lookup runs without a warm cache.
- Stream source posts in bounded chunks and resolve only edges that can target the requested post.
- Extend the backlinks smoke test to cover the cold-cache path, limit handling, sorting, and permalink hydration.

## Testing
- php tests/backlinks-limit-smoke.php
- homeboy lint data-machine --path \"/Users/chubes/Developer/data-machine@fix-backlinks-cold-cache-oom\" --changed-since 53a97ace

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation and targeted tests; Chris directed the runtime debugging and release/deploy workflow.