### PR TITLE
Honor Agents API chat runtime controls

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -112,6 +112,9 @@ class AgentsChatHandler {
 				'agent_slug'           => $identity ? $identity->agent_slug : '',
 				'attachments'          => $input['attachments'] ?? array(),
 				'client_context'       => $client_context,
+				'tool_policy'          => is_array( $input['tool_policy'] ?? null ) ? $input['tool_policy'] : null,
+				'allow_only'           => is_array( $input['allow_only'] ?? null ) ? $input['allow_only'] : null,
+				'completion_assertions' => is_array( $input['completion_assertions'] ?? null ) ? $input['completion_assertions'] : null,
 				'session_owner'        => is_array( $input['session_owner'] ?? null ) ? $input['session_owner'] : null,
 				'transcript_owner'     => is_array( $input['transcript_owner'] ?? null ) ? $input['transcript_owner'] : null,
 			)
@@ -121,7 +124,8 @@ class AgentsChatHandler {
 			return $result;
 		}
 
-		return $this->toCanonicalOutput( $result );
+		$output = $this->toCanonicalOutput( $result );
+		return $this->withInputControlDiagnostics( $output, $input );
 	}
 
 	/**
@@ -231,6 +235,36 @@ class AgentsChatHandler {
 			'completed'  => $completed,
 			'metadata'   => $metadata,
 		);
+	}
+
+	/**
+	 * Add bounded diagnostics showing which caller-owned controls reached the runtime adapter.
+	 *
+	 * @param array $output Canonical output.
+	 * @param array $input  Canonical input received by the handler.
+	 * @return array Output with namespaced Data Machine diagnostics.
+	 */
+	private function withInputControlDiagnostics( array $output, array $input ): array {
+		$metadata             = is_array( $output['metadata'] ?? null ) ? $output['metadata'] : array();
+		$datamachine_metadata = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
+		$tool_policy          = is_array( $input['tool_policy'] ?? null ) ? $input['tool_policy'] : array();
+		$assertions           = is_array( $input['completion_assertions'] ?? null ) ? $input['completion_assertions'] : array();
+
+		$datamachine_metadata['input_controls'] = array_filter(
+			array(
+				'has_tool_policy'              => is_array( $input['tool_policy'] ?? null ),
+				'tool_policy_mode'             => is_scalar( $tool_policy['mode'] ?? null ) ? (string) $tool_policy['mode'] : null,
+				'tool_policy_tools'            => is_array( $tool_policy['tools'] ?? null ) ? array_values( array_map( 'strval', $tool_policy['tools'] ) ) : null,
+				'allow_only'                   => is_array( $input['allow_only'] ?? null ) ? array_values( array_map( 'strval', $input['allow_only'] ) ) : null,
+				'completion_required_tool_names' => is_array( $assertions['required_tool_names'] ?? null ) ? array_values( array_map( 'strval', $assertions['required_tool_names'] ) ) : null,
+			),
+			static fn( $value ): bool => null !== $value
+		);
+
+		$metadata['datamachine'] = $datamachine_metadata;
+		$output['metadata']      = $metadata;
+
+		return $output;
 	}
 
 	/**

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -228,6 +228,9 @@ class ChatOrchestrator {
 				'agent_slug'           => $agent_slug,
 				'interrupt_source'     => $interrupt_source,
 				'client_context'       => $options['client_context'] ?? array(),
+				'tool_policy'          => is_array( $options['tool_policy'] ?? null ) ? $options['tool_policy'] : null,
+				'allow_only'           => is_array( $options['allow_only'] ?? null ) ? $options['allow_only'] : null,
+				'completion_assertions' => is_array( $options['completion_assertions'] ?? null ) ? $options['completion_assertions'] : null,
 			)
 		);
 
@@ -303,13 +306,20 @@ class ChatOrchestrator {
 		}
 
 		// --- Build response data ---
+		$response_metadata = is_array( $loop_result['metadata'] ?? null ) ? $loop_result['metadata'] : array();
+		if ( empty( $response_metadata ) ) {
+			$response_metadata = $metadata;
+		} else {
+			$response_metadata = array_merge( $metadata, $response_metadata );
+		}
+
 		$response_data = array(
 			'session_id'             => $session_id,
 			'response'               => $result['final_content'],
 			'tool_calls'             => $loop_metadata['tool_calls'] ?? $loop_metadata['last_tool_calls'] ?? array(),
 			'tool_execution_summary' => $loop_metadata['tool_execution_summary'] ?? datamachine_summarize_tool_execution_results( $result['tool_execution_results'] ?? array(), false ),
 			'conversation'           => $result['messages'],
-			'metadata'               => $metadata,
+			'metadata'               => $response_metadata,
 			'completed'              => $is_completed,
 			'max_turns'              => $max_turns,
 			'turn_number'            => $result['turn_count'],
@@ -811,6 +821,8 @@ class ChatOrchestrator {
 					'user_id'        => $user_id,
 					'interactive'    => true,
 					'client_context' => is_array( $client_context ) ? $client_context : array(),
+					'tool_policy'    => is_array( $options['tool_policy'] ?? null ) ? $options['tool_policy'] : null,
+					'allow_only'     => is_array( $options['allow_only'] ?? null ) ? $options['allow_only'] : array(),
 				)
 			);
 
@@ -842,6 +854,9 @@ class ChatOrchestrator {
 			}
 			if ( ! empty( $client_context ) ) {
 				$loop_context['client_context'] = $client_context;
+			}
+			if ( is_array( $options['completion_assertions'] ?? null ) ) {
+				$loop_context['completion_assertions'] = $options['completion_assertions'];
 			}
 			if ( null !== $interrupt_source ) {
 				$loop_context['interrupt_source'] = $interrupt_source;

--- a/inc/Engine/Agents/datamachine-register-agents.php
+++ b/inc/Engine/Agents/datamachine-register-agents.php
@@ -154,3 +154,23 @@ function datamachine_register_persisted_agents(): void {
 	PersistedAgentProjector::register_persisted_agents();
 }
 add_action( 'wp_agents_api_init', 'datamachine_register_persisted_agents', 20 );
+
+/**
+ * Materialize runtime-imported Agents API bundles for Data Machine chat.
+ *
+ * Browser runtimes can import a request-local agent bundle immediately before
+ * calling `agents/chat`. The generic importer registers that definition in the
+ * Agents API registry; Data Machine still needs a persisted identity row so its
+ * chat handler can resolve owner, model config, and tool policy.
+ *
+ * @param mixed $result Runtime bundle import result.
+ * @return mixed Import result.
+ */
+function datamachine_reconcile_runtime_agent_bundle_import( $result ) {
+	if ( is_array( $result ) && ! empty( $result['success'] ) && ! empty( $result['agent_slug'] ) ) {
+		AgentRegistry::reconcile();
+	}
+
+	return $result;
+}
+add_filter( 'wp_agent_runtime_import_bundle', 'datamachine_reconcile_runtime_agent_bundle_import', 20, 1 );

--- a/tests/agents-chat-handler-smoke.php
+++ b/tests/agents-chat-handler-smoke.php
@@ -84,9 +84,13 @@ $assert( str_contains( $handler_source, "'selected_pipeline_id' => (int) ( $" . 
 $assert( str_contains( $handler_source, "'request_id'           => $" . "input['request_id'] ?? null" ), 'AgentsChatHandler forwards request id for session dedupe' );
 $assert( str_contains( $handler_source, "'interrupt_source'     => is_callable( $" . "input['interrupt_source'] ?? null ) ? $" . "input['interrupt_source'] : null" ), 'AgentsChatHandler explicitly forwards callable interrupt sources' );
 $assert( str_contains( $handler_source, "'agent_slug'           => $" . "identity ? $" . "identity->agent_slug : ''" ), 'AgentsChatHandler forwards resolved agent targeting to the chat runtime' );
+$assert( str_contains( $handler_source, "'tool_policy'" ) && str_contains( $handler_source, "input['tool_policy']" ), 'AgentsChatHandler forwards caller tool policy to the chat runtime' );
+$assert( str_contains( $handler_source, "'allow_only'" ) && str_contains( $orchestrator, "options['allow_only']" ), 'agents/chat forwards caller allow_only through tool resolution' );
+$assert( str_contains( $handler_source, "'completion_assertions'" ) && str_contains( $orchestrator, "loop_context['completion_assertions']" ), 'agents/chat forwards completion assertions into the loop context' );
 $assert( str_contains( $handler_source, "'interrupted'" ) && str_contains( $handler_source, "$" . "result['interrupted'] ?? null" ), 'AgentsChatHandler returns interrupted diagnostics in canonical metadata' );
 $assert( str_contains( $handler_source, "'tool_execution_summary'" ), 'AgentsChatHandler returns bounded tool execution diagnostics in canonical metadata' );
 $assert( str_contains( $orchestrator, "'tool_execution_summary'" ) && str_contains( $orchestrator, 'datamachine_summarize_tool_execution_results' ), 'ChatOrchestrator forwards bounded tool execution diagnostics to chat adapters' );
+$assert( str_contains( $orchestrator, '$response_metadata = is_array( $loop_result[\'metadata\'] ?? null )' ), 'ChatOrchestrator exposes loop metadata in chat adapter responses' );
 $assert( ! file_exists( $root . '/inc/Abilities/Chat/SendMessageAbility.php' ), 'datamachine/send-message facade class is removed' );
 $assert( ! str_contains( $chat_abilities, 'SendMessageAbility' ), 'ChatAbilities no longer registers datamachine/send-message' );
 $assert( str_contains( $chat_api, "wp_get_ability( 'agents/chat' )" ), 'REST chat endpoint dispatches directly through canonical agents/chat' );

--- a/tests/runtime-agent-bundle-reconcile-smoke.php
+++ b/tests/runtime-agent-bundle-reconcile-smoke.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Smoke checks for runtime agent bundle reconciliation.
+ *
+ * @package DataMachine
+ */
+
+$root   = dirname( __DIR__ );
+$source = file_get_contents( $root . '/inc/Engine/Agents/datamachine-register-agents.php' );
+
+$assert = static function ( bool $condition, string $label ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$label}\n" );
+		exit( 1 );
+	}
+
+	fwrite( STDOUT, "PASS: {$label}\n" );
+};
+
+$assert( false !== $source, 'agent-registration-source-readable' );
+$assert( str_contains( $source, 'function datamachine_reconcile_runtime_agent_bundle_import' ), 'runtime-import-reconcile-function-exists' );
+$assert( str_contains( $source, "add_filter( 'wp_agent_runtime_import_bundle', 'datamachine_reconcile_runtime_agent_bundle_import', 20, 1 )" ), 'runtime-import-reconcile-filter-registered-after-importer' );
+$assert( str_contains( $source, "! empty( \$result['success'] )" ), 'runtime-import-reconcile-requires-success' );
+$assert( str_contains( $source, "! empty( \$result['agent_slug'] )" ), 'runtime-import-reconcile-requires-agent-slug' );
+$assert( str_contains( $source, 'AgentRegistry::reconcile();' ), 'runtime-import-reconcile-materializes-agent' );
+
+fwrite( STDOUT, "Runtime agent bundle reconcile smoke passed.\n" );


### PR DESCRIPTION
## Summary
- Reconcile runtime-imported Agents API bundles into Data Machine agent rows before `agents/chat` resolves identity/config.
- Forward caller-supplied `tool_policy`, `allow_only`, and `completion_assertions` through Data Machine chat execution.
- Preserve loop metadata in canonical chat responses and add bounded input-control diagnostics.

## Verification
- `php -l inc/Abilities/Chat/AgentsChatHandler.php`
- `php -l inc/Api/Chat/ChatOrchestrator.php`
- `php -l inc/Engine/Agents/datamachine-register-agents.php`
- `php tests/agents-chat-handler-smoke.php`
- `php tests/runtime-agent-bundle-reconcile-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted the implementation and smoke coverage; Chris remains responsible for review and merge decisions.