### PR TITLE
fix: guard against agents-api dual-load version skew on bootstrap

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -28,6 +28,12 @@ if ( ! defined( 'AGENTS_API_LOADED' ) ) {
 	require_once __DIR__ . '/vendor/wordpress/agents-api/agents-api.php';
 }
 
+// Guard against agents-api dual-load version skew. When an older standalone copy of the
+// substrate won the load race, its coarse AGENTS_API_LOADED guard prevents our newer
+// bundled copy from loading its newer classes — self-heal where safe, fail loud otherwise.
+require_once __DIR__ . '/inc/agents-api-guardrail.php';
+datamachine_agents_api_run_guardrail( __DIR__ . '/vendor/wordpress/agents-api' );
+
 // WP-CLI integration
 // @phpstan-ignore-next-line Runtime constant may be defined false outside PHPStan's configured CLI context.
 if ( defined( 'WP_CLI' ) && (bool) constant( 'WP_CLI' ) ) {

--- a/inc/agents-api-guardrail.php
+++ b/inc/agents-api-guardrail.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Agents API dual-load version-skew guardrail.
+ *
+ * The agents-api substrate guards its entire class-loading block with a single
+ * coarse `AGENTS_API_LOADED` constant:
+ *
+ *     if ( defined( 'AGENTS_API_LOADED' ) ) { return; }
+ *     define( 'AGENTS_API_LOADED', true );
+ *     // ... require_once every class file ...
+ *
+ * That guard is correct for preventing a double-define, but it is *all-or-nothing
+ * per-constant*: the first copy of the substrate to define the constant freezes the
+ * class set for the request. When two different versions of the substrate coexist on
+ * one network — data-machine's bundled (vendored composer) copy AND a separately
+ * activated standalone `agents-api` plugin — and the OLDER copy wins the load race, the
+ * newer bundled copy early-returns before requiring its newer class files. Any code
+ * path that touches a class only present in the newer bundled set then fatals with a
+ * bare "Class ... not found" (e.g. `WP_Agent_Package_Artifact_Hasher` during
+ * `agent export`).
+ *
+ * The durable fix belongs upstream in Automattic/agents-api (idempotent per-class
+ * loading independent of the bootstrap constant). This file is data-machine's
+ * guardrail: when the skew is detected, top up the missing classes from data-machine's
+ * OWN bundled copy where it is safe, and otherwise fail LOUD and CLEAR instead of
+ * degrading into a cryptic fatal.
+ *
+ * @package DataMachine
+ */
+
+defined( 'WPINC' ) || exit;
+
+/**
+ * A representative class from the newer bundled agents-api copy used as the canary for
+ * the version-skew collision. If `AGENTS_API_LOADED` is defined but this class is
+ * missing, an older copy of the substrate won the load race.
+ */
+if ( ! defined( 'DATAMACHINE_AGENTS_API_CANARY_CLASS' ) ) {
+	define( 'DATAMACHINE_AGENTS_API_CANARY_CLASS', 'WP_Agent_Package_Artifact_Hasher' );
+}
+
+/**
+ * Detect the agents-api version-skew collision.
+ *
+ * The collision is present when the bootstrap constant is defined (some copy of the
+ * substrate loaded) but the canary class from the newer bundled copy is absent (an
+ * older copy froze the class set).
+ *
+ * @return bool True when the version-skew collision is present.
+ */
+function datamachine_agents_api_skew_detected(): bool {
+	return defined( 'AGENTS_API_LOADED' ) && ! class_exists( DATAMACHINE_AGENTS_API_CANARY_CLASS );
+}
+
+/**
+ * Extract the class-file require targets from a bundled agents-api bootstrap file.
+ *
+ * The bundled bootstrap requires each class file as
+ * `require_once AGENTS_API_PATH . 'src/.../file.php';`. We parse those literal relative
+ * paths rather than hardcoding a list so the guardrail self-updates whenever the bundled
+ * copy changes. Only `src/` paths are considered (the class/registration files); the
+ * side-effect `add_action` registrations at the foot of the bootstrap are deliberately
+ * not re-run here — the older copy already registered its hooks, and the top-up only
+ * needs the missing class declarations.
+ *
+ * @param string $bootstrap_path Absolute path to the bundled agents-api.php bootstrap.
+ * @return string[] Relative paths (e.g. `src/Packages/class-...php`) in bootstrap order.
+ */
+function datamachine_agents_api_bundled_require_targets( string $bootstrap_path ): array {
+	if ( ! is_readable( $bootstrap_path ) ) {
+		return array();
+	}
+
+	$source = file_get_contents( $bootstrap_path );
+	if ( ! is_string( $source ) || '' === $source ) {
+		return array();
+	}
+
+	// Match: require_once AGENTS_API_PATH . 'src/.../file.php';
+	if ( ! preg_match_all(
+		"/require_once\s+AGENTS_API_PATH\s*\.\s*'(src\/[^']+\.php)'/",
+		$source,
+		$matches
+	) ) {
+		return array();
+	}
+
+	return array_values( array_unique( $matches[1] ) );
+}
+
+/**
+ * Attempt to self-heal the agents-api version skew from data-machine's bundled copy.
+ *
+ * Re-runs each class-file require target from the bundled bootstrap against the bundled
+ * agents-api tree. Every include uses `require_once`, so files already loaded by the
+ * older copy are skipped and only the missing newer classes are topped up. This makes
+ * data-machine's newer surface (export, packages, etc.) work even when an older
+ * standalone copy won the load race.
+ *
+ * @param string $bundled_dir Absolute path to data-machine's bundled agents-api dir
+ *                            (trailing slash optional).
+ * @return bool True when the canary class is available after the top-up.
+ */
+function datamachine_agents_api_self_heal( string $bundled_dir ): bool {
+	$bundled_dir   = rtrim( $bundled_dir, '/\\' ) . '/';
+	$bootstrap_path = $bundled_dir . 'agents-api.php';
+
+	$targets = datamachine_agents_api_bundled_require_targets( $bootstrap_path );
+	if ( empty( $targets ) ) {
+		return class_exists( DATAMACHINE_AGENTS_API_CANARY_CLASS );
+	}
+
+	foreach ( $targets as $relative_path ) {
+		$file = $bundled_dir . $relative_path;
+		if ( is_readable( $file ) ) {
+			require_once $file;
+		}
+	}
+
+	return class_exists( DATAMACHINE_AGENTS_API_CANARY_CLASS );
+}
+
+/**
+ * Build the operator-facing message describing the unresolved version skew.
+ *
+ * @return string Plain-text guidance message.
+ */
+function datamachine_agents_api_skew_message(): string {
+	$bundled_version = defined( 'DATAMACHINE_VERSION' ) ? (string) constant( 'DATAMACHINE_VERSION' ) : 'unknown';
+
+	return sprintf(
+		/* translators: %s: Data Machine plugin version. */
+		'Data Machine: agents-api version skew detected. An older standalone "agents-api" plugin loaded before Data Machine\'s bundled copy (Data Machine v%s), so newer substrate classes such as "%s" are missing and exports/packages will fatal. Deactivate or remove the standalone agents-api plugin, or update it to a version >= the copy bundled with Data Machine.',
+		$bundled_version,
+		DATAMACHINE_AGENTS_API_CANARY_CLASS
+	);
+}
+
+/**
+ * Run the agents-api dual-load guardrail.
+ *
+ * Call after Composer's autoloader and the agents-api require block have run. When the
+ * version skew is detected, attempt a safe self-heal from the bundled copy; if that
+ * still leaves the substrate incomplete, surface a clear admin notice and (under WP-CLI)
+ * a hard CLI error so the failure mode is loud and actionable rather than a bare fatal.
+ *
+ * @param string $bundled_dir Absolute path to data-machine's bundled agents-api dir.
+ * @return void
+ */
+function datamachine_agents_api_run_guardrail( string $bundled_dir ): void {
+	if ( ! datamachine_agents_api_skew_detected() ) {
+		return;
+	}
+
+	if ( datamachine_agents_api_self_heal( $bundled_dir ) ) {
+		return;
+	}
+
+	$message = datamachine_agents_api_skew_message();
+
+	add_action(
+		'admin_notices',
+		static function () use ( $message ): void {
+			printf(
+				'<div class="notice notice-error"><p>%s</p></div>',
+				esc_html( $message )
+			);
+		}
+	);
+
+	if ( defined( 'WP_CLI' ) && (bool) constant( 'WP_CLI' ) && class_exists( '\WP_CLI' ) ) {
+		\WP_CLI::error( $message );
+	}
+}

--- a/inc/agents-api-guardrail.php
+++ b/inc/agents-api-guardrail.php
@@ -71,12 +71,12 @@ function datamachine_agents_api_bundled_require_targets( string $bootstrap_path 
 		return array();
 	}
 
-	$source = file_get_contents( $bootstrap_path );
+	$source = file_get_contents( $bootstrap_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a bundled PHP file from disk at bootstrap, before the WordPress filesystem abstraction is available.
 	if ( ! is_string( $source ) || '' === $source ) {
 		return array();
 	}
 
-	// Match: require_once AGENTS_API_PATH . 'src/.../file.php';
+	// Match each require_once AGENTS_API_PATH . 'src/.../file.php' bootstrap line.
 	if ( ! preg_match_all(
 		"/require_once\s+AGENTS_API_PATH\s*\.\s*'(src\/[^']+\.php)'/",
 		$source,
@@ -102,7 +102,7 @@ function datamachine_agents_api_bundled_require_targets( string $bootstrap_path 
  * @return bool True when the canary class is available after the top-up.
  */
 function datamachine_agents_api_self_heal( string $bundled_dir ): bool {
-	$bundled_dir   = rtrim( $bundled_dir, '/\\' ) . '/';
+	$bundled_dir    = rtrim( $bundled_dir, '/\\' ) . '/';
 	$bootstrap_path = $bundled_dir . 'agents-api.php';
 
 	$targets = datamachine_agents_api_bundled_require_targets( $bootstrap_path );

--- a/tests/agents-api-dualload-guardrail-smoke.php
+++ b/tests/agents-api-dualload-guardrail-smoke.php
@@ -55,28 +55,35 @@ agents_api_smoke_assert_equals(
 require_once dirname( __DIR__ ) . '/inc/agents-api-guardrail.php';
 
 echo "\n[1] Require-target parser reads the bundled bootstrap require list:\n";
-$targets = datamachine_agents_api_bundled_require_targets( $bootstrap_path );
+$require_targets = datamachine_agents_api_bundled_require_targets( $bootstrap_path );
 agents_api_smoke_assert_equals(
 	true,
-	count( $targets ) > 10,
+	count( $require_targets ) > 10,
 	'parser extracts the bundled src/ require targets',
 	$failures,
 	$passes
 );
 agents_api_smoke_assert_equals(
 	true,
-	in_array( 'src/Packages/class-wp-agent-package-artifact-hasher.php', $targets, true ),
+	in_array( 'src/Packages/class-wp-agent-package-artifact-hasher.php', $require_targets, true ),
 	'parser includes the canary class file target',
 	$failures,
 	$passes
 );
-foreach ( $targets as $relative_path ) {
+$only_src_targets = true;
+foreach ( $require_targets as $relative_path ) {
 	if ( ! str_starts_with( $relative_path, 'src/' ) ) {
-		$failures[] = 'parser only returns src/ targets';
-		echo "  FAIL parser only returns src/ targets (got {$relative_path})\n";
+		$only_src_targets = false;
 		break;
 	}
 }
+agents_api_smoke_assert_equals(
+	true,
+	$only_src_targets,
+	'parser only returns src/ require targets',
+	$failures,
+	$passes
+);
 
 echo "\n[2] Simulate the collision: older copy won, canary class is absent:\n";
 // Mimic the older standalone copy winning the load race.

--- a/tests/agents-api-dualload-guardrail-smoke.php
+++ b/tests/agents-api-dualload-guardrail-smoke.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Pure-PHP smoke test for the agents-api dual-load version-skew guardrail (#2477).
+ *
+ * Simulates the collision: an OLDER standalone copy of agents-api wins the load race,
+ * defines AGENTS_API_LOADED, and freezes a class set that lacks the newer bundled
+ * classes (canary: WP_Agent_Package_Artifact_Hasher). The guardrail must (a) detect the
+ * skew, then (b) self-heal by topping up the missing class files from data-machine's OWN
+ * bundled copy — without ever fataling on a bare "Class ... not found".
+ *
+ * Run with: php tests/agents-api-dualload-guardrail-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+if ( ! defined( 'WPINC' ) ) {
+	define( 'WPINC', 'wp-includes' );
+}
+if ( ! defined( 'DATAMACHINE_VERSION' ) ) {
+	define( 'DATAMACHINE_VERSION', 'test' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-dualload-guardrail-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+$bundled_dir    = dirname( __DIR__ ) . '/vendor/wordpress/agents-api';
+$bootstrap_path = $bundled_dir . '/agents-api.php';
+$canary         = 'WP_Agent_Package_Artifact_Hasher';
+
+// Pre-conditions: the bundled copy must ship the canary file (otherwise the whole repro
+// premise is wrong). This documents the dependency the guardrail relies on.
+agents_api_smoke_assert_equals(
+	true,
+	is_readable( $bootstrap_path ),
+	'bundled agents-api bootstrap is present',
+	$failures,
+	$passes
+);
+agents_api_smoke_assert_equals(
+	true,
+	is_readable( $bundled_dir . '/src/Packages/class-wp-agent-package-artifact-hasher.php' ),
+	'bundled agents-api ships the canary class file',
+	$failures,
+	$passes
+);
+
+// Load the guardrail under test.
+require_once dirname( __DIR__ ) . '/inc/agents-api-guardrail.php';
+
+echo "\n[1] Require-target parser reads the bundled bootstrap require list:\n";
+$targets = datamachine_agents_api_bundled_require_targets( $bootstrap_path );
+agents_api_smoke_assert_equals(
+	true,
+	count( $targets ) > 10,
+	'parser extracts the bundled src/ require targets',
+	$failures,
+	$passes
+);
+agents_api_smoke_assert_equals(
+	true,
+	in_array( 'src/Packages/class-wp-agent-package-artifact-hasher.php', $targets, true ),
+	'parser includes the canary class file target',
+	$failures,
+	$passes
+);
+foreach ( $targets as $relative_path ) {
+	if ( ! str_starts_with( $relative_path, 'src/' ) ) {
+		$failures[] = 'parser only returns src/ targets';
+		echo "  FAIL parser only returns src/ targets (got {$relative_path})\n";
+		break;
+	}
+}
+
+echo "\n[2] Simulate the collision: older copy won, canary class is absent:\n";
+// Mimic the older standalone copy winning the load race.
+if ( ! defined( 'AGENTS_API_LOADED' ) ) {
+	define( 'AGENTS_API_LOADED', true );
+}
+agents_api_smoke_assert_equals(
+	false,
+	class_exists( $canary, false ),
+	'canary class is not loaded before self-heal',
+	$failures,
+	$passes
+);
+agents_api_smoke_assert_equals(
+	true,
+	datamachine_agents_api_skew_detected(),
+	'guardrail detects the version-skew collision',
+	$failures,
+	$passes
+);
+
+echo "\n[3] Self-heal tops up the missing class from the bundled copy:\n";
+// Provide the AGENTS_API_PATH constant the bundled class files expect, pointing at the
+// bundled tree (as the bundled bootstrap would have, had it not early-returned).
+if ( ! defined( 'AGENTS_API_PATH' ) ) {
+	define( 'AGENTS_API_PATH', rtrim( $bundled_dir, '/' ) . '/' );
+}
+datamachine_agents_api_run_guardrail( $bundled_dir );
+agents_api_smoke_assert_equals(
+	true,
+	class_exists( $canary ),
+	'canary class is available after guardrail self-heal',
+	$failures,
+	$passes
+);
+agents_api_smoke_assert_equals(
+	false,
+	datamachine_agents_api_skew_detected(),
+	'skew no longer detected after self-heal',
+	$failures,
+	$passes
+);
+
+echo "\n[4] Guardrail is idempotent — a second run is a no-op:\n";
+datamachine_agents_api_run_guardrail( $bundled_dir );
+agents_api_smoke_assert_equals(
+	true,
+	class_exists( $canary ),
+	'canary class remains available after a second guardrail run',
+	$failures,
+	$passes
+);
+
+agents_api_smoke_finish( 'Agents API dual-load guardrail', $failures, $passes );


### PR DESCRIPTION
Fixes #2477

## What this is — and isn't

This is the **data-machine consumer-side guardrail** for the agents-api dual-load version-skew fatal. It is **not** the durable substrate fix. The root cause lives in `automattic/agents-api`'s all-or-nothing `AGENTS_API_LOADED` guard; the durable fix (idempotent per-class loading) is tracked upstream in **Automattic/agents-api#291** and is intentionally out of scope here.

## Problem (from #2477)

The agents-api substrate guards its entire class-loading block with one coarse constant:

```php
if ( defined( 'AGENTS_API_LOADED' ) ) { return; }
define( 'AGENTS_API_LOADED', true );
// ... require_once every class file ...
```

When two different versions of the substrate coexist on a network — data-machine's bundled (vendored) copy **and** a separately activated standalone `agents-api` plugin — and the **older** copy wins the load race, the newer bundled copy early-returns before requiring its newer classes. `agent export` (and any newer-only class path) then fatals with a bare `Class "WP_Agent_Package_Artifact_Hasher" not found`. All export profiles (`share`, `backup`, `fork`) were dead.

## The guardrail

After the agents-api require block in `data-machine.php`, run a guardrail that:

1. **Detects** the skew: `defined('AGENTS_API_LOADED') && ! class_exists('WP_Agent_Package_Artifact_Hasher')` (the hasher is the canary).
2. **Self-heals where safe:** tops up the missing class files from data-machine's **own** bundled copy. It is **drift-free** — it parses the bundled bootstrap's `require_once AGENTS_API_PATH . 'src/...'` list rather than hardcoding it, and every include is `require_once` so already-loaded files are skipped and only missing classes are topped up. This makes export work even when an older standalone copy won the race.
3. **Fails loud, not cryptic:** if self-heal can't complete, it registers an `admin_notices` error and (under WP-CLI) calls `WP_CLI::error()` with a clear message naming the cause and the fix (deactivate/remove the older standalone agents-api plugin, or update it to >= the bundled version). Never degrades into a bare "class not found" fatal.

It does **not** refactor the bootstrap and does **not** touch the vendored agents-api files (composer artifact).

## Files changed

- `inc/agents-api-guardrail.php` (new) — detection + self-heal + clear-error helpers.
- `data-machine.php` — require + invoke the guardrail right after the agents-api require block.
- `tests/agents-api-dualload-guardrail-smoke.php` (new) — simulates the collision and asserts detection → self-heal → idempotency.

## Test results

```
$ php tests/agents-api-dualload-guardrail-smoke.php
All 9 Agents API dual-load guardrail assertions passed.

$ php tests/agents-api-bootstrap-smoke.php
All 419 Agents API bootstrap assertions passed.

$ php tests/export-agent-ability-smoke.php
All export-agent ability smoke assertions passed. (18)

$ php tests/release-bundled-agents-api-smoke.php
Release bundle smoke passed (10 assertions).

$ vendor/bin/phpcs inc/agents-api-guardrail.php tests/agents-api-dualload-guardrail-smoke.php data-machine.php
EXIT=0
```

The new smoke simulates the exact collision (define `AGENTS_API_LOADED` with the canary class absent), then asserts the guardrail detects it, self-heals the canary from the bundled copy, and is idempotent on a second run. (On the live VPS the standalone duplicate has already been removed, so the smoke is the durable way to exercise the guardrail.)

## Durable fix tracked upstream

The real fix — idempotent per-class loading independent of the `AGENTS_API_LOADED` bootstrap constant — is filed at **Automattic/agents-api#291**. This PR is the guardrail so data-machine fails safely (and self-heals) until the substrate ships that fix.