### PR TITLE
Fix scoped tool source ordering

### DIFF
--- a/inc/Engine/AI/Tools/ToolSourceRegistry.php
+++ b/inc/Engine/AI/Tools/ToolSourceRegistry.php
@@ -26,22 +26,12 @@ class ToolSourceRegistry {
 
 	private ToolManager $tool_manager;
 	private WP_Agent_Tool_Source_Registry $registry;
-	/**
-	 * Data Machine-owned Agents API registries that should use DM source ordering.
-	 *
-	 * @var \WeakMap<WP_Agent_Tool_Source_Registry, bool>|null
-	 */
-	private static ?\WeakMap $ordered_registries = null;
 
 	public function __construct( ToolManager $tool_manager ) {
 		$this->tool_manager = $tool_manager;
 		$this->registry     = new WP_Agent_Tool_Source_Registry();
 
 		$this->registerDataMachineSources();
-		if ( function_exists( 'add_filter' ) ) {
-			add_filter( 'agents_api_tool_source_order', array( self::class, 'orderSourcesForContext' ), 5, 3 );
-		}
-		$this->registerOrderedRegistry( $this->registry );
 	}
 
 	/**
@@ -52,15 +42,26 @@ class ToolSourceRegistry {
 	 * @return array Tools keyed by tool name.
 	 */
 	public function gather( array $modes, array $args ): array {
-		return $this->registry->gather(
-			array_merge(
-				$args,
-				array(
-					'modes'        => $modes,
-					'tool_manager' => $this->tool_manager,
+		$callback = array( $this, 'orderSourcesForContext' );
+		if ( function_exists( 'add_filter' ) ) {
+			add_filter( 'agents_api_tool_source_order', $callback, 5, 3 );
+		}
+
+		try {
+			return $this->registry->gather(
+				array_merge(
+					$args,
+					array(
+						'modes'        => $modes,
+						'tool_manager' => $this->tool_manager,
+					)
 				)
-			)
-		);
+			);
+		} finally {
+			if ( function_exists( 'remove_filter' ) ) {
+				remove_filter( 'agents_api_tool_source_order', $callback, 5 );
+			}
+		}
 	}
 
 	/**
@@ -115,8 +116,8 @@ class ToolSourceRegistry {
 	 * @param WP_Agent_Tool_Source_Registry $registry Source registry instance.
 	 * @return array<int, string> Source slugs in precedence order.
 	 */
-	public static function orderSourcesForContext( array $order, array $context, WP_Agent_Tool_Source_Registry $registry ): array {
-		if ( null === self::$ordered_registries || ! isset( self::$ordered_registries[ $registry ] ) ) {
+	public function orderSourcesForContext( array $order, array $context, WP_Agent_Tool_Source_Registry $registry ): array {
+		if ( $registry !== $this->registry ) {
 			return $order;
 		}
 
@@ -132,17 +133,6 @@ class ToolSourceRegistry {
 				static fn( $source ) => is_string( $source ) && '' !== $source && in_array( $source, $order, true )
 			)
 		);
-	}
-
-	/**
-	 * Mark an Agents API registry as Data Machine-owned for the shared order hook.
-	 *
-	 * @param WP_Agent_Tool_Source_Registry $registry Source registry instance.
-	 * @return void
-	 */
-	private function registerOrderedRegistry( WP_Agent_Tool_Source_Registry $registry ): void {
-		self::$ordered_registries ??= new \WeakMap();
-		self::$ordered_registries[ $registry ] = true;
 	}
 
 }

--- a/tests/adjacent-handler-tool-policy-smoke.php
+++ b/tests/adjacent-handler-tool-policy-smoke.php
@@ -47,6 +47,7 @@ namespace {
 	require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/RuntimeToolSource.php';
 	require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php';
 	require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php';
+	require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AbilityToolSource.php';
 	require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
 	require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
 

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -31,6 +31,17 @@ function add_filter( string $hook, callable $callback, int $priority = 10, int $
 	$GLOBALS['__filters'][ $hook ][ $priority ][ source_smoke_filter_id( $callback ) ] = array( $callback, $accepted_args );
 }
 
+function remove_filter( string $hook, callable $callback, int $priority = 10 ): void {
+	$callback_id = source_smoke_filter_id( $callback );
+	unset( $GLOBALS['__filters'][ $hook ][ $priority ][ $callback_id ] );
+	if ( empty( $GLOBALS['__filters'][ $hook ][ $priority ] ) ) {
+		unset( $GLOBALS['__filters'][ $hook ][ $priority ] );
+	}
+	if ( empty( $GLOBALS['__filters'][ $hook ] ) ) {
+		unset( $GLOBALS['__filters'][ $hook ] );
+	}
+}
+
 function remove_all_filters_for_source_smoke(): void {
 	$GLOBALS['__filters'] = array();
 }
@@ -525,15 +536,17 @@ assert_source_equals( true, false !== strpos( $datamachine_tool_source, 'get_all
 assert_source_equals( true, false !== strpos( $registry_source, 'WP_Agent_Tool_Source_Registry' ), 'ToolSourceRegistry delegates source composition to Agents API registry', $failures, $passes );
 assert_source_equals( true, false !== strpos( $registry_source, 'agents_api_tool_source_order' ), 'Data Machine mode ordering uses Agents API source-order hook', $failures, $passes );
 
-echo "\n[8] source ordering uses one shared global callback:\n";
+echo "\n[8] source ordering is attached only while gathering:\n";
 remove_all_filters_for_source_smoke();
+$instance_registry = new ToolSourceRegistry( new SourcePolicyToolManager() );
 new ToolSourceRegistry( new SourcePolicyToolManager() );
 new ToolSourceRegistry( new SourcePolicyToolManager() );
-new ToolSourceRegistry( new SourcePolicyToolManager() );
-assert_source_equals( 1, count_source_smoke_callbacks( 'agents_api_tool_source_order' ), 'multiple registry instances do not accumulate duplicate source-order callbacks', $failures, $passes );
+assert_source_equals( 0, count_source_smoke_callbacks( 'agents_api_tool_source_order' ), 'constructing registry instances does not leave source-order callbacks registered', $failures, $passes );
+resolve_source_tools( ToolPolicyResolver::MODE_PIPELINE, new SourcePolicyToolManager() );
+assert_source_equals( 0, count_source_smoke_callbacks( 'agents_api_tool_source_order' ), 'gather removes its instance-scoped source-order callback', $failures, $passes );
 assert_source_equals(
 	array( 'static_registry', 'adjacent_handlers', 'runtime_tools' ),
-	ToolSourceRegistry::orderSourcesForContext( array( 'static_registry', 'adjacent_handlers', 'runtime_tools' ), array( 'modes' => array( ToolPolicyResolver::MODE_CHAT ) ), new AgentsAPI\AI\Tools\WP_Agent_Tool_Source_Registry() ),
+	$instance_registry->orderSourcesForContext( array( 'static_registry', 'adjacent_handlers', 'runtime_tools' ), array( 'modes' => array( ToolPolicyResolver::MODE_CHAT ) ), new AgentsAPI\AI\Tools\WP_Agent_Tool_Source_Registry() ),
 	'ordering callback leaves non-Data Machine registries unchanged',
 	$failures,
 	$passes


### PR DESCRIPTION
## Summary
- Scope Data Machine's Agents API source-order hook to the active gather call instead of static WeakMap registry tracking.
- Keep ordering guarded by the exact Data Machine-owned registry instance so adjacent handler tools remain available without affecting other Agents API registries.
- Update smoke coverage for scoped hook attachment/removal and the adjacent-handler bootstrap.

## Verification
- `php tests/tool-source-registry-smoke.php`
- `php tests/adjacent-handler-tool-policy-smoke.php`
- `php -l inc/Engine/AI/Tools/ToolSourceRegistry.php && php -l tests/tool-source-registry-smoke.php && php -l tests/adjacent-handler-tool-policy-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/Tools/ToolSourceRegistry.php tests/tool-source-registry-smoke.php tests/adjacent-handler-tool-policy-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the handler-tool source ordering regression, drafting the scoped registry fix, updating smoke tests, and running local verification. Chris remains responsible for review and merge.