### PR TITLE
Document corpus refresh processed-item conventions

### DIFF
--- a/docs/api/endpoints/processed-items.md
+++ b/docs/api/endpoints/processed-items.md
@@ -10,6 +10,40 @@ Processed items are the deduplication records Data Machine uses to avoid re-proc
 
 For richer read/check/stale-history operations, use the `datamachine/*` abilities in `ProcessedItemsAbilities` or the WP-CLI `wp datamachine processed-items` command.
 
+## Corpus Refresh Conventions
+
+Corpus indexing workloads should use processed items as revision-level dedupe records. The generic helper `DataMachine\Core\Corpus\CorpusRefreshConventions` defines shared `source_type` values and stable `item_identifier` builders for document, chunk, and embedding refreshes. These conventions are generic Data Machine contracts and do not depend on Intelligence classes.
+
+Recommended `source_type` values:
+
+| Source type | Use |
+|-------------|-----|
+| `corpus_document_revision` | A source document revision has been read and normalized. |
+| `corpus_chunk_revision` | A chunk revision has been generated from document content. |
+| `corpus_embedding_revision` | An embedding has been generated for a provider/model/chunk-hash tuple. |
+
+Recommended processed-item keys:
+
+| Helper | Key parts | Use |
+|--------|-----------|-----|
+| `CorpusRefreshConventions::document_key()` | corpus ID + document ID + source hash | Skip unchanged source documents across scheduled refreshes. |
+| `CorpusRefreshConventions::chunk_key()` | corpus ID + chunk ID + chunk hash | Skip unchanged chunks after document refresh. |
+| `CorpusRefreshConventions::embedding_key()` | corpus ID + provider + embedding model + chunk hash | Skip embeddings that already exist for the same model and content. |
+
+Example:
+
+```php
+use DataMachine\Core\Corpus\CorpusRefreshConventions;
+
+$processed_items->has_item_been_processed(
+	$flow_step_id,
+	CorpusRefreshConventions::SOURCE_DOCUMENT,
+	CorpusRefreshConventions::document_key( $corpus_id, $document_id, $source_hash )
+);
+```
+
+Batch jobs should store corpus refresh progress with the generic run metric count names `selected`, `skipped`, `processed`, `failed`, and `retried`. `CorpusRefreshConventions::batch_metadata()` returns a normalized metadata shape with `workload: corpus_refresh` and these counters. `RunMetrics::fromJob()` also reads the same counters from `engine_data.batch_results`, so batch parent jobs can report corpus refresh progress without a corpus-specific metrics table.
+
 ## Authentication
 
 The REST endpoint requires `PermissionHelper::can( 'manage_flows' )`. Administrators pass through the mapped Data Machine capability fallback.

--- a/inc/Core/Corpus/CorpusRefreshConventions.php
+++ b/inc/Core/Corpus/CorpusRefreshConventions.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Corpus refresh processed-item and batch metadata conventions.
+ *
+ * @package DataMachine\Core\Corpus
+ */
+
+namespace DataMachine\Core\Corpus;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Shared key and metadata shapes for corpus-style refresh workloads.
+ */
+class CorpusRefreshConventions {
+
+	public const SOURCE_DOCUMENT  = 'corpus_document_revision';
+	public const SOURCE_CHUNK     = 'corpus_chunk_revision';
+	public const SOURCE_EMBEDDING = 'corpus_embedding_revision';
+
+	/**
+	 * Build a processed-item identifier for a source document revision.
+	 *
+	 * @param string $corpus_id   Stable corpus ID.
+	 * @param string $document_id Stable document ID inside the corpus.
+	 * @param string $source_hash Hash of the source document payload/revision.
+	 * @return string Processed-item identifier.
+	 */
+	public static function document_key( string $corpus_id, string $document_id, string $source_hash ): string {
+		return self::key(
+			'doc',
+			array(
+				'corpus'   => $corpus_id,
+				'document' => $document_id,
+				'hash'     => $source_hash,
+			)
+		);
+	}
+
+	/**
+	 * Build a processed-item identifier for a chunk revision.
+	 *
+	 * @param string $corpus_id  Stable corpus ID.
+	 * @param string $chunk_id   Stable chunk ID inside the corpus.
+	 * @param string $chunk_hash Hash of the chunk text/content.
+	 * @return string Processed-item identifier.
+	 */
+	public static function chunk_key( string $corpus_id, string $chunk_id, string $chunk_hash ): string {
+		return self::key(
+			'chunk',
+			array(
+				'corpus' => $corpus_id,
+				'chunk'  => $chunk_id,
+				'hash'   => $chunk_hash,
+			)
+		);
+	}
+
+	/**
+	 * Build a processed-item identifier for an embedding revision.
+	 *
+	 * @param string $corpus_id       Stable corpus ID.
+	 * @param string $provider        Embedding provider ID.
+	 * @param string $embedding_model Embedding model ID.
+	 * @param string $chunk_hash      Hash of the chunk text/content.
+	 * @return string Processed-item identifier.
+	 */
+	public static function embedding_key( string $corpus_id, string $provider, string $embedding_model, string $chunk_hash ): string {
+		return self::key(
+			'embedding',
+			array(
+				'corpus'   => $corpus_id,
+				'provider' => $provider,
+				'model'    => $embedding_model,
+				'hash'     => $chunk_hash,
+			)
+		);
+	}
+
+	/**
+	 * Build normalized batch metadata for corpus refresh jobs.
+	 *
+	 * @param array $metadata Batch metadata and count overrides.
+	 * @return array Normalized metadata.
+	 */
+	public static function batch_metadata( array $metadata = array() ): array {
+		$counts = is_array( $metadata['counts'] ?? null ) ? $metadata['counts'] : array();
+		foreach ( array( 'selected', 'skipped', 'processed', 'failed', 'retried' ) as $key ) {
+			$counts[ $key ] = max( 0, (int) ( $counts[ $key ] ?? ( $metadata[ $key ] ?? 0 ) ) );
+		}
+
+		$out = array(
+			'workload' => 'corpus_refresh',
+			'counts'   => $counts,
+		);
+
+		foreach ( array( 'corpus_id', 'batch_id', 'refresh_id', 'source_type' ) as $key ) {
+			if ( isset( $metadata[ $key ] ) && is_scalar( $metadata[ $key ] ) && '' !== (string) $metadata[ $key ] ) {
+				$out[ $key ] = (string) $metadata[ $key ];
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Build a stable string identifier from ordered scalar key parts.
+	 *
+	 * @param string $kind Key kind prefix.
+	 * @param array  $parts Ordered key parts.
+	 * @return string Stable key.
+	 */
+	private static function key( string $kind, array $parts ): string {
+		$segments = array( 'corpus', $kind );
+		foreach ( $parts as $name => $value ) {
+			$segments[] = self::clean_segment( (string) $name ) . '=' . self::clean_segment( (string) $value );
+		}
+
+		return implode( '|', $segments );
+	}
+
+	/**
+	 * Normalize a key segment without losing hash/model delimiters that help humans debug.
+	 *
+	 * @param string $value Raw segment.
+	 * @return string Normalized segment.
+	 */
+	private static function clean_segment( string $value ): string {
+		$value = strtolower( trim( $value ) );
+		$value = preg_replace( '/[^a-z0-9._:\/-]+/', '-', $value ) ?? '';
+
+		return trim( $value, '-|' );
+	}
+}

--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -19,6 +19,7 @@ class RunMetrics {
 	private const KEY = 'run_metrics';
 
 	private const COUNT_KEYS = array(
+		'selected',
 		'processed',
 		'skipped',
 		'failed',
@@ -262,9 +263,11 @@ class RunMetrics {
 		$counts = array();
 
 		if ( isset( $engine['batch_results'] ) && is_array( $engine['batch_results'] ) ) {
-			$counts['processed'] = (int) ( $engine['batch_results']['completed'] ?? 0 );
+			$counts['selected']  = (int) ( $engine['batch_results']['selected'] ?? 0 );
+			$counts['processed'] = (int) ( $engine['batch_results']['processed'] ?? ( $engine['batch_results']['completed'] ?? 0 ) );
 			$counts['failed']    = (int) ( $engine['batch_results']['failed'] ?? 0 );
 			$counts['skipped']   = (int) ( $engine['batch_results']['skipped'] ?? 0 );
+			$counts['retried']   = (int) ( $engine['batch_results']['retried'] ?? 0 );
 		}
 
 		foreach ( array( 'batch_scheduled', 'tasks_scheduled' ) as $key ) {

--- a/tests/corpus-refresh-conventions-smoke.php
+++ b/tests/corpus-refresh-conventions-smoke.php
@@ -44,11 +44,11 @@ final class CorpusRefreshLedgerForSmoke {
 
 echo "=== corpus-refresh-conventions-smoke ===\n";
 
-$doc_key       = CorpusRefreshConventions::document_key( 'Core Brain', 'Doc 42', 'SHA256:ABC123' );
-$same_doc_key  = CorpusRefreshConventions::document_key( 'core brain', 'doc 42', 'sha256:abc123' );
-$new_doc_key   = CorpusRefreshConventions::document_key( 'Core Brain', 'Doc 42', 'SHA256:DEF456' );
-$chunk_key     = CorpusRefreshConventions::chunk_key( 'Core Brain', 'chunk/7', 'chunkhash' );
-$embedding_key = CorpusRefreshConventions::embedding_key( 'Core Brain', 'OpenAI', 'text-embedding-3-large', 'chunkhash' );
+$doc_key       = CorpusRefreshConventions::document_key( 'Docs Corpus', 'Doc 42', 'SHA256:ABC123' );
+$same_doc_key  = CorpusRefreshConventions::document_key( 'docs corpus', 'doc 42', 'sha256:abc123' );
+$new_doc_key   = CorpusRefreshConventions::document_key( 'Docs Corpus', 'Doc 42', 'SHA256:DEF456' );
+$chunk_key     = CorpusRefreshConventions::chunk_key( 'Docs Corpus', 'chunk/7', 'chunkhash' );
+$embedding_key = CorpusRefreshConventions::embedding_key( 'Docs Corpus', 'OpenAI', 'text-embedding-3-large', 'chunkhash' );
 
 datamachine_corpus_conventions_assert( $doc_key === $same_doc_key, 'document key is stable across casing' );
 datamachine_corpus_conventions_assert( $doc_key !== $new_doc_key, 'document key changes when source hash changes' );
@@ -64,7 +64,7 @@ datamachine_corpus_conventions_assert( ! $ledger->should_skip( CorpusRefreshConv
 
 $metadata = CorpusRefreshConventions::batch_metadata(
 	array(
-		'corpus_id' => 'core-brain',
+		'corpus_id' => 'docs-corpus',
 		'batch_id'  => 'refresh-2026-06-03-1',
 		'selected'  => 10,
 		'skipped'   => 4,
@@ -75,7 +75,7 @@ $metadata = CorpusRefreshConventions::batch_metadata(
 );
 
 datamachine_corpus_conventions_assert( 'corpus_refresh' === $metadata['workload'], 'batch metadata identifies corpus refresh workload' );
-datamachine_corpus_conventions_assert( 'core-brain' === $metadata['corpus_id'], 'batch metadata carries corpus id' );
+datamachine_corpus_conventions_assert( 'docs-corpus' === $metadata['corpus_id'], 'batch metadata carries corpus id' );
 datamachine_corpus_conventions_assert( 10 === $metadata['counts']['selected'], 'batch metadata carries selected count' );
 datamachine_corpus_conventions_assert( 4 === $metadata['counts']['skipped'], 'batch metadata carries skipped count' );
 datamachine_corpus_conventions_assert( 5 === $metadata['counts']['processed'], 'batch metadata carries processed count' );

--- a/tests/corpus-refresh-conventions-smoke.php
+++ b/tests/corpus-refresh-conventions-smoke.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Pure-PHP smoke test for corpus refresh processed-item conventions.
+ *
+ * Run with: php tests/corpus-refresh-conventions-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../inc/Core/Corpus/CorpusRefreshConventions.php';
+
+use DataMachine\Core\Corpus\CorpusRefreshConventions;
+
+function datamachine_corpus_conventions_assert( bool $cond, string $msg ): void {
+	if ( $cond ) {
+		echo "  [PASS] {$msg}\n";
+		return;
+	}
+
+	echo "  [FAIL] {$msg}\n";
+	exit( 1 );
+}
+
+final class CorpusRefreshLedgerForSmoke {
+	/** @var array<string,bool> */
+	private array $processed = array();
+
+	public function mark_processed( string $source_type, string $item_identifier ): void {
+		$this->processed[ $this->key( $source_type, $item_identifier ) ] = true;
+	}
+
+	public function should_skip( string $source_type, string $item_identifier ): bool {
+		return isset( $this->processed[ $this->key( $source_type, $item_identifier ) ] );
+	}
+
+	private function key( string $source_type, string $item_identifier ): string {
+		return $source_type . '|' . $item_identifier;
+	}
+}
+
+echo "=== corpus-refresh-conventions-smoke ===\n";
+
+$doc_key       = CorpusRefreshConventions::document_key( 'Core Brain', 'Doc 42', 'SHA256:ABC123' );
+$same_doc_key  = CorpusRefreshConventions::document_key( 'core brain', 'doc 42', 'sha256:abc123' );
+$new_doc_key   = CorpusRefreshConventions::document_key( 'Core Brain', 'Doc 42', 'SHA256:DEF456' );
+$chunk_key     = CorpusRefreshConventions::chunk_key( 'Core Brain', 'chunk/7', 'chunkhash' );
+$embedding_key = CorpusRefreshConventions::embedding_key( 'Core Brain', 'OpenAI', 'text-embedding-3-large', 'chunkhash' );
+
+datamachine_corpus_conventions_assert( $doc_key === $same_doc_key, 'document key is stable across casing' );
+datamachine_corpus_conventions_assert( $doc_key !== $new_doc_key, 'document key changes when source hash changes' );
+datamachine_corpus_conventions_assert( str_starts_with( $doc_key, 'corpus|doc|' ), 'document key uses corpus doc namespace' );
+datamachine_corpus_conventions_assert( str_contains( $chunk_key, 'chunk=chunk/7' ), 'chunk key includes chunk id' );
+datamachine_corpus_conventions_assert( str_contains( $embedding_key, 'provider=openai' ), 'embedding key includes provider' );
+datamachine_corpus_conventions_assert( str_contains( $embedding_key, 'model=text-embedding-3-large' ), 'embedding key includes embedding model' );
+
+$ledger = new CorpusRefreshLedgerForSmoke();
+$ledger->mark_processed( CorpusRefreshConventions::SOURCE_DOCUMENT, $doc_key );
+datamachine_corpus_conventions_assert( $ledger->should_skip( CorpusRefreshConventions::SOURCE_DOCUMENT, $same_doc_key ), 'unchanged document revision skips on later refresh run' );
+datamachine_corpus_conventions_assert( ! $ledger->should_skip( CorpusRefreshConventions::SOURCE_DOCUMENT, $new_doc_key ), 'changed document source hash remains eligible on later refresh run' );
+
+$metadata = CorpusRefreshConventions::batch_metadata(
+	array(
+		'corpus_id' => 'core-brain',
+		'batch_id'  => 'refresh-2026-06-03-1',
+		'selected'  => 10,
+		'skipped'   => 4,
+		'processed' => 5,
+		'failed'    => 1,
+		'retried'   => 2,
+	)
+);
+
+datamachine_corpus_conventions_assert( 'corpus_refresh' === $metadata['workload'], 'batch metadata identifies corpus refresh workload' );
+datamachine_corpus_conventions_assert( 'core-brain' === $metadata['corpus_id'], 'batch metadata carries corpus id' );
+datamachine_corpus_conventions_assert( 10 === $metadata['counts']['selected'], 'batch metadata carries selected count' );
+datamachine_corpus_conventions_assert( 4 === $metadata['counts']['skipped'], 'batch metadata carries skipped count' );
+datamachine_corpus_conventions_assert( 5 === $metadata['counts']['processed'], 'batch metadata carries processed count' );
+datamachine_corpus_conventions_assert( 1 === $metadata['counts']['failed'], 'batch metadata carries failed count' );
+datamachine_corpus_conventions_assert( 2 === $metadata['counts']['retried'], 'batch metadata carries retried count' );
+
+$source = file_get_contents( __DIR__ . '/../inc/Core/Corpus/CorpusRefreshConventions.php' );
+datamachine_corpus_conventions_assert( ! str_contains( $source, 'Intelligence\\' ), 'conventions do not depend on Intelligence classes' );
+
+echo "\n=== corpus-refresh-conventions-smoke: ALL PASS ===\n";

--- a/tests/run-metrics-smoke.php
+++ b/tests/run-metrics-smoke.php
@@ -63,9 +63,11 @@ $metrics = RunMetrics::fromJob(
 				'started_at' => '2026-05-03 10:00:00',
 			),
 			'batch_results' => array(
+				'selected'  => 11,
 				'completed' => 8,
 				'failed'    => 1,
 				'skipped'   => 2,
+				'retried'   => 1,
 			),
 			'token_usage'   => array(
 				'total_tokens' => 99,
@@ -75,9 +77,11 @@ $metrics = RunMetrics::fromJob(
 );
 
 dm_assert( 123 === $metrics['job_id'], 'job_id surfaced' );
+dm_assert( 11 === $metrics['counts']['selected'], 'batch selected count surfaced' );
 dm_assert( 8 === $metrics['counts']['processed'], 'batch completed count maps to processed' );
 dm_assert( 2 === $metrics['counts']['skipped'], 'batch skipped count surfaced' );
 dm_assert( 1 === $metrics['counts']['failed'], 'batch failed count surfaced' );
+dm_assert( 1 === $metrics['counts']['retried'], 'batch retried count surfaced' );
 dm_assert( 3 === $metrics['counts']['staged_actions'], 'staged action count surfaced' );
 dm_assert( 2 === $metrics['counts']['accepted_actions'], 'accepted action count surfaced' );
 dm_assert( 300 === $metrics['duration_seconds'], 'duration uses started/completed timestamps' );


### PR DESCRIPTION
## Summary
- Adds generic corpus refresh processed-item key conventions for document, chunk, and embedding revision dedupe.
- Documents the corpus refresh source types, key shapes, and batch metadata counters.
- Surfaces `selected` and `retried` batch result counts through run metrics and covers the convention with smoke tests.

Closes https://github.com/Extra-Chill/data-machine/issues/2489

## Tests run
- `php tests/corpus-refresh-conventions-smoke.php`
- `php tests/run-metrics-smoke.php`
- `php tests/processed-item-claims-smoke.php`
- `./vendor/bin/phpcs inc/Core/Corpus/CorpusRefreshConventions.php inc/Core/RunMetrics.php tests/corpus-refresh-conventions-smoke.php tests/run-metrics-smoke.php`

## Remaining risks
- This PR defines generic conventions and metrics plumbing only; corpus consumers still need to adopt these keys in their own refresh jobs.
- No dependency on another issue or PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation, documentation, smoke tests, self-review cleanup, and verification commands for Chris to review.