### PR TITLE
Expose corpus job artifact surfaces

### DIFF
--- a/inc/Abilities/Job/JobHelpers.php
+++ b/inc/Abilities/Job/JobHelpers.php
@@ -15,6 +15,7 @@ use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Abilities\Flow\QueueAbility;
 
 use DataMachine\Core\Admin\DateFormatter;
+use DataMachine\Core\CorpusJobSurfaces;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\Pipelines\Pipelines;
@@ -119,6 +120,13 @@ trait JobHelpers {
 
 		if ( isset( $job['completed_at'] ) ) {
 			$job['completed_at_display'] = DateFormatter::format_for_display( $job['completed_at'] );
+		}
+
+		if ( is_array( $job['engine_data'] ?? null ) ) {
+			$job_summary = CorpusJobSurfaces::summary( $job, $job['engine_data'] );
+			if ( ! empty( $job_summary ) ) {
+				$job['job_summary'] = $job_summary;
+			}
 		}
 
 		// Compute display_label for UI

--- a/inc/Cli/Commands/RetentionCommand.php
+++ b/inc/Cli/Commands/RetentionCommand.php
@@ -242,35 +242,35 @@ class RetentionCommand extends BaseCommand {
 	 */
 	private function get_retention_policies(): array {
 		return array(
-			'Completed jobs'  => array(
+			'Completed jobs'   => array(
 				'retention' => apply_filters( 'datamachine_completed_jobs_max_age_days', 30 ) . ' days',
 				'filter'    => 'datamachine_completed_jobs_max_age_days',
 			),
-			'Failed jobs'     => array(
+			'Failed jobs'      => array(
 				'retention' => apply_filters( 'datamachine_failed_jobs_max_age_days', 30 ) . ' days',
 				'filter'    => 'datamachine_failed_jobs_max_age_days',
 			),
-			'Pipeline logs'   => array(
+			'Pipeline logs'    => array(
 				'retention' => apply_filters( 'datamachine_log_max_age_days', 7 ) . ' days',
 				'filter'    => 'datamachine_log_max_age_days',
 			),
-			'Processed items' => array(
+			'Processed items'  => array(
 				'retention' => apply_filters( 'datamachine_processed_items_max_age_days', 30 ) . ' days',
 				'filter'    => 'datamachine_processed_items_max_age_days',
 			),
-			'AS actions'      => array(
+			'AS actions'       => array(
 				'retention' => apply_filters( 'datamachine_as_actions_max_age_days', 7 ) . ' days',
 				'filter'    => 'datamachine_as_actions_max_age_days',
 			),
-			'Stale claims'    => array(
+			'Stale claims'     => array(
 				'retention' => round( apply_filters( 'datamachine_stale_claim_max_age', DAY_IN_SECONDS ) / 3600 ) . ' hours',
 				'filter'    => 'datamachine_stale_claim_max_age',
 			),
-			'Chat sessions'   => array(
+			'Chat sessions'    => array(
 				'retention' => \DataMachine\Core\PluginSettings::get( 'chat_retention_days', 90 ) . ' days',
 				'filter'    => 'setting: chat_retention_days',
 			),
-			'File cleanup'    => array(
+			'File cleanup'     => array(
 				'retention' => \DataMachine\Core\PluginSettings::get( 'file_retention_days', 7 ) . ' days',
 				'filter'    => 'setting: file_retention_days',
 			),

--- a/inc/Cli/Commands/RetentionCommand.php
+++ b/inc/Cli/Commands/RetentionCommand.php
@@ -226,6 +226,12 @@ class RetentionCommand extends BaseCommand {
 				'threshold' => RetentionCleanup::chatRetentionDays() . ' days',
 				'count'     => array( RetentionCleanup::class, 'countChatSessions' ),
 			),
+			array(
+				'label'     => 'Corpus artifacts',
+				'task_type' => RetentionCleanup::TASK_CORPUS_ARTIFACTS,
+				'threshold' => RetentionCleanup::corpusArtifactsMaxAgeDays() . ' days',
+				'count'     => array( RetentionCleanup::class, 'countCorpusArtifacts' ),
+			),
 		);
 	}
 
@@ -267,6 +273,10 @@ class RetentionCommand extends BaseCommand {
 			'File cleanup'    => array(
 				'retention' => \DataMachine\Core\PluginSettings::get( 'file_retention_days', 7 ) . ' days',
 				'filter'    => 'setting: file_retention_days',
+			),
+			'Corpus artifacts' => array(
+				'retention' => RetentionCleanup::corpusArtifactsMaxAgeDays() . ' days',
+				'filter'    => 'datamachine_corpus_artifacts_max_age_days',
 			),
 		);
 	}

--- a/inc/Core/CorpusJobSurfaces.php
+++ b/inc/Core/CorpusJobSurfaces.php
@@ -11,10 +11,10 @@ defined( 'ABSPATH' ) || exit;
 
 class CorpusJobSurfaces {
 
-	public const WORKLOAD_TYPE = 'corpus_indexing';
+	public const WORKLOAD_TYPE   = 'corpus_indexing';
 	public const RETENTION_SCOPE = 'corpus_indexing';
 
-	private const SUMMARY_SCHEMA_VERSION = 1;
+	private const SUMMARY_SCHEMA_VERSION  = 1;
 	private const ARTIFACT_SCHEMA_VERSION = 1;
 
 	private const CORPUS_COUNT_KEYS = array(
@@ -61,13 +61,13 @@ class CorpusJobSurfaces {
 		return self::filterEmpty(
 			array(
 				'schema_version' => self::SUMMARY_SCHEMA_VERSION,
-				'workload_type'   => self::WORKLOAD_TYPE,
-				'headline'        => self::boundedText( $summary['headline'] ?? ( $summary['summary'] ?? ( $corpus['headline'] ?? ( $corpus['summary'] ?? '' ) ) ), 280 ),
-				'status'          => isset( $job['status'] ) ? (string) $job['status'] : null,
-				'counts'          => $counts,
-				'artifact_refs'   => self::artifactRefs( $engine_data ),
-				'notes'           => self::boundedText( $summary['notes'] ?? ( $corpus['notes'] ?? '' ), 1000 ),
-				'updated_at'      => self::text( $summary['updated_at'] ?? ( $corpus['updated_at'] ?? '' ) ),
+				'workload_type'  => self::WORKLOAD_TYPE,
+				'headline'       => self::boundedText( $summary['headline'] ?? ( $summary['summary'] ?? ( $corpus['headline'] ?? ( $corpus['summary'] ?? '' ) ) ), 280 ),
+				'status'         => isset( $job['status'] ) ? (string) $job['status'] : null,
+				'counts'         => $counts,
+				'artifact_refs'  => self::artifactRefs( $engine_data ),
+				'notes'          => self::boundedText( $summary['notes'] ?? ( $corpus['notes'] ?? '' ), 1000 ),
+				'updated_at'     => self::text( $summary['updated_at'] ?? ( $corpus['updated_at'] ?? '' ) ),
 			)
 		);
 	}
@@ -258,7 +258,8 @@ class CorpusJobSurfaces {
 			return sanitize_key( $value );
 		}
 
-		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $value ) ) ?: '';
+		$key = preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $value ) );
+		return '' !== $key ? $key : '';
 	}
 
 	private static function text( mixed $value ): string {
@@ -267,7 +268,7 @@ class CorpusJobSurfaces {
 			return sanitize_text_field( $value );
 		}
 
-		return trim( strip_tags( $value ) );
+		return trim( preg_replace( '/<[^>]*>/', '', $value ) ?? '' );
 	}
 
 	private static function boundedText( mixed $value, int $max_chars ): string {

--- a/inc/Core/CorpusJobSurfaces.php
+++ b/inc/Core/CorpusJobSurfaces.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * Generic corpus-style job summary and artifact conventions.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+class CorpusJobSurfaces {
+
+	public const WORKLOAD_TYPE = 'corpus_indexing';
+	public const RETENTION_SCOPE = 'corpus_indexing';
+
+	private const SUMMARY_SCHEMA_VERSION = 1;
+	private const ARTIFACT_SCHEMA_VERSION = 1;
+
+	private const CORPUS_COUNT_KEYS = array(
+		'items_total',
+		'items_seen',
+		'items_indexed',
+		'items_unchanged',
+		'items_skipped',
+		'extraction_failures',
+		'chunks_created',
+		'chunking_failures',
+		'embeddings_created',
+		'embedding_failures',
+		'retrieval_evaluations',
+	);
+
+	private const CORPUS_ARTIFACT_TYPES = array(
+		'extraction_failures',
+		'chunking_summary',
+		'embedding_failures',
+		'retrieval_evaluation',
+		'skipped_items',
+		'unchanged_items',
+	);
+
+	/**
+	 * Normalize a concise operator-facing summary for corpus-style jobs.
+	 *
+	 * @param array<string,mixed> $job Job row.
+	 * @param array<string,mixed> $engine_data Job engine data.
+	 * @return array<string,mixed>
+	 */
+	public static function summary( array $job, array $engine_data ): array {
+		$summary = is_array( $engine_data['job_summary'] ?? null ) ? $engine_data['job_summary'] : array();
+		$corpus  = self::corpusData( $engine_data );
+
+		if ( empty( $summary ) && empty( $corpus ) ) {
+			return array();
+		}
+
+		$metrics = is_array( $engine_data['run_metrics'] ?? null ) ? RunMetrics::normalize( $engine_data['run_metrics'] ) : array();
+		$counts  = self::countsFrom( $summary, $corpus, $metrics['counts'] ?? array() );
+
+		return self::filterEmpty(
+			array(
+				'schema_version' => self::SUMMARY_SCHEMA_VERSION,
+				'workload_type'   => self::WORKLOAD_TYPE,
+				'headline'        => self::boundedText( $summary['headline'] ?? ( $summary['summary'] ?? ( $corpus['headline'] ?? ( $corpus['summary'] ?? '' ) ) ), 280 ),
+				'status'          => isset( $job['status'] ) ? (string) $job['status'] : null,
+				'counts'          => $counts,
+				'artifact_refs'   => self::artifactRefs( $engine_data ),
+				'notes'           => self::boundedText( $summary['notes'] ?? ( $corpus['notes'] ?? '' ), 1000 ),
+				'updated_at'      => self::text( $summary['updated_at'] ?? ( $corpus['updated_at'] ?? '' ) ),
+			)
+		);
+	}
+
+	/**
+	 * Normalize artifact references recorded by corpus-style workloads.
+	 *
+	 * @param array<string,mixed> $engine_data Job engine data.
+	 * @return array<string,array<string,mixed>>
+	 */
+	public static function artifactRefs( array $engine_data ): array {
+		$refs = array();
+		foreach ( self::artifactSources( $engine_data ) as $artifact_key => $artifact ) {
+			$normalized = self::normalizeArtifact( $artifact_key, $artifact );
+			if ( empty( $normalized ) ) {
+				continue;
+			}
+
+			$refs[ $normalized['artifact_key'] ] = $normalized;
+		}
+
+		ksort( $refs, SORT_STRING );
+		return $refs;
+	}
+
+	/**
+	 * Return artifact retention policy definitions for corpus indexing surfaces.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	public static function retentionPolicies(): array {
+		$max_age_days = self::positiveDays( self::filter( 'datamachine_corpus_artifacts_max_age_days', 30 ), 30 );
+		$policies     = array(
+			self::RETENTION_SCOPE => array(
+				'label'           => 'Corpus indexing artifacts',
+				'retention_scope' => self::RETENTION_SCOPE,
+				'artifact_types'  => self::corpusArtifactTypes(),
+				'max_age_days'    => $max_age_days,
+				'filter'          => 'datamachine_corpus_artifacts_max_age_days',
+			),
+		);
+
+		$policies = self::filter( 'datamachine_job_artifact_retention_policies', $policies );
+		return is_array( $policies ) ? $policies : array();
+	}
+
+	/**
+	 * @return array<int,string>
+	 */
+	public static function corpusArtifactTypes(): array {
+		$types = self::filter( 'datamachine_corpus_job_artifact_types', self::CORPUS_ARTIFACT_TYPES );
+		if ( ! is_array( $types ) ) {
+			return self::CORPUS_ARTIFACT_TYPES;
+		}
+
+		$out = array();
+		foreach ( $types as $type ) {
+			$type = self::key( $type );
+			if ( '' !== $type ) {
+				$out[] = $type;
+			}
+		}
+
+		return array_values( array_unique( $out ) );
+	}
+
+	/**
+	 * @param array<string,mixed> $engine_data Job engine data.
+	 * @return array<string,mixed>
+	 */
+	private static function corpusData( array $engine_data ): array {
+		foreach ( array( 'corpus_indexing', 'corpus_indexing_summary' ) as $key ) {
+			if ( is_array( $engine_data[ $key ] ?? null ) ) {
+				return $engine_data[ $key ];
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private static function countsFrom( array $summary, array $corpus, array $metrics_counts ): array {
+		$counts = array();
+		foreach ( self::CORPUS_COUNT_KEYS as $key ) {
+			$value = $summary[ $key ] ?? ( $corpus[ $key ] ?? null );
+			if ( null !== $value ) {
+				$counts[ $key ] = max( 0, (int) $value );
+			}
+		}
+
+		$aliases = array(
+			'processed' => 'items_indexed',
+			'skipped'   => 'items_skipped',
+			'failed'    => 'extraction_failures',
+		);
+		foreach ( $aliases as $metrics_key => $count_key ) {
+			if ( ! isset( $counts[ $count_key ] ) && isset( $metrics_counts[ $metrics_key ] ) ) {
+				$counts[ $count_key ] = max( 0, (int) $metrics_counts[ $metrics_key ] );
+			}
+		}
+
+		ksort( $counts, SORT_STRING );
+		return $counts;
+	}
+
+	/**
+	 * @param array<string,mixed> $engine_data Job engine data.
+	 * @return array<string,array<string,mixed>>
+	 */
+	private static function artifactSources( array $engine_data ): array {
+		$sources = array();
+		foreach ( array( 'artifact_refs', 'artifact_files', 'corpus_artifacts' ) as $key ) {
+			if ( is_array( $engine_data[ $key ] ?? null ) ) {
+				$sources = array_replace( $sources, self::normalizeSourceList( $engine_data[ $key ] ) );
+			}
+		}
+
+		$corpus = self::corpusData( $engine_data );
+		if ( is_array( $corpus['artifacts'] ?? null ) ) {
+			$sources = array_replace( $sources, self::normalizeSourceList( $corpus['artifacts'] ) );
+		}
+
+		return $sources;
+	}
+
+	/**
+	 * @return array<string,array<string,mixed>>
+	 */
+	private static function normalizeSourceList( array $artifacts ): array {
+		$out = array();
+		foreach ( $artifacts as $key => $artifact ) {
+			if ( ! is_array( $artifact ) ) {
+				continue;
+			}
+
+			$artifact_key         = is_string( $key ) ? $key : (string) ( $artifact['artifact_key'] ?? ( $artifact['artifact_type'] ?? '' ) );
+			$out[ $artifact_key ] = $artifact;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private static function normalizeArtifact( string $artifact_key, array $artifact ): array {
+		$artifact_type = self::key( $artifact['artifact_type'] ?? $artifact_key );
+		$retention     = self::key( $artifact['retention_scope'] ?? '' );
+		if ( '' === $retention && in_array( $artifact_type, self::corpusArtifactTypes(), true ) ) {
+			$retention = self::RETENTION_SCOPE;
+		}
+
+		if ( self::RETENTION_SCOPE !== $retention && ! in_array( $artifact_type, self::corpusArtifactTypes(), true ) ) {
+			return array();
+		}
+
+		return self::filterEmpty(
+			array(
+				'schema_version'  => self::ARTIFACT_SCHEMA_VERSION,
+				'artifact_key'    => self::key( $artifact['artifact_key'] ?? $artifact_key ),
+				'artifact_type'   => $artifact_type,
+				'artifact_ref'    => self::text( $artifact['artifact_ref'] ?? '' ),
+				'label'           => self::text( $artifact['label'] ?? '' ),
+				'retention_scope' => '' !== $retention ? $retention : self::RETENTION_SCOPE,
+				'relative_path'   => self::text( $artifact['relative_path'] ?? '' ),
+				'url'             => self::url( $artifact['url'] ?? '' ),
+				'sha256'          => self::text( $artifact['sha256'] ?? '' ),
+				'bytes'           => isset( $artifact['bytes'] ) ? max( 0, (int) $artifact['bytes'] ) : null,
+				'created_at'      => self::text( $artifact['created_at'] ?? ( $artifact['written_at'] ?? '' ) ),
+			)
+		);
+	}
+
+	private static function positiveDays( mixed $value, int $fallback ): int {
+		$days = (int) $value;
+		return $days > 0 ? $days : $fallback;
+	}
+
+	private static function filter( string $hook, mixed $value ): mixed {
+		return function_exists( 'apply_filters' ) ? apply_filters( $hook, $value ) : $value;
+	}
+
+	private static function key( mixed $value ): string {
+		$value = (string) $value;
+		if ( function_exists( 'sanitize_key' ) ) {
+			return sanitize_key( $value );
+		}
+
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $value ) ) ?: '';
+	}
+
+	private static function text( mixed $value ): string {
+		$value = (string) $value;
+		if ( function_exists( 'sanitize_text_field' ) ) {
+			return sanitize_text_field( $value );
+		}
+
+		return trim( strip_tags( $value ) );
+	}
+
+	private static function boundedText( mixed $value, int $max_chars ): string {
+		$text = self::text( $value );
+		return strlen( $text ) > $max_chars ? substr( $text, 0, $max_chars ) : $text;
+	}
+
+	private static function url( mixed $value ): string {
+		$value = (string) $value;
+		return function_exists( 'esc_url_raw' ) ? esc_url_raw( $value ) : filter_var( $value, FILTER_SANITIZE_URL );
+	}
+
+	/**
+	 * @param array<string,mixed> $value Input array.
+	 * @return array<string,mixed>
+	 */
+	private static function filterEmpty( array $value ): array {
+		return array_filter(
+			$value,
+			static fn( $item ) => null !== $item && '' !== $item && array() !== $item
+		);
+	}
+}

--- a/inc/Core/FilesRepository/FileCleanup.php
+++ b/inc/Core/FilesRepository/FileCleanup.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Core\FilesRepository;
 
+use DataMachine\Core\CorpusJobSurfaces;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -208,5 +210,87 @@ class FileCleanup {
 		}
 
 		return $deleted_count;
+	}
+
+	/**
+	 * Count old artifact files for a retention scope.
+	 *
+	 * @param string $retention_scope Retention scope to match.
+	 * @param int    $retention_days  Files older than this many days are eligible.
+	 * @return int Eligible artifact file count.
+	 */
+	public function count_old_job_artifacts( string $retention_scope, int $retention_days ): int {
+		return $this->walk_old_job_artifacts( $retention_scope, $retention_days, false );
+	}
+
+	/**
+	 * Clean up old artifact files for a retention scope.
+	 *
+	 * @param string $retention_scope Retention scope to match.
+	 * @param int    $retention_days  Files older than this many days are eligible.
+	 * @return int Deleted artifact file count.
+	 */
+	public function cleanup_old_job_artifacts( string $retention_scope, int $retention_days ): int {
+		return $this->walk_old_job_artifacts( $retention_scope, $retention_days, true );
+	}
+
+	private function walk_old_job_artifacts( string $retention_scope, int $retention_days, bool $delete ): int {
+		$upload_dir      = wp_upload_dir();
+		$base            = trailingslashit( $upload_dir['basedir'] ) . 'datamachine-artifacts/jobs';
+		$cutoff_time     = time() - ( $retention_days * DAY_IN_SECONDS );
+		$retention_scope = sanitize_key( $retention_scope );
+		$count           = 0;
+
+		if ( '' === $retention_scope || ! is_dir( $base ) ) {
+			return 0;
+		}
+
+		$job_dirs = glob( trailingslashit( $base ) . '*', GLOB_ONLYDIR );
+		if ( false === $job_dirs ) {
+			return 0;
+		}
+
+		foreach ( $job_dirs as $job_dir ) {
+			$files = glob( trailingslashit( $job_dir ) . '*.json' );
+			if ( false === $files ) {
+				continue;
+			}
+
+			foreach ( $files as $file ) {
+				if ( ! is_file( $file ) || filemtime( $file ) >= $cutoff_time || ! $this->artifact_matches_retention_scope( $file, $retention_scope ) ) {
+					continue;
+				}
+
+				if ( ! $delete || wp_delete_file( $file ) ) {
+					++$count;
+				}
+			}
+
+			if ( $delete && empty( glob( trailingslashit( $job_dir ) . '*' ) ) ) {
+				$this->remove_directory( $job_dir );
+			}
+		}
+
+		return $count;
+	}
+
+	private function artifact_matches_retention_scope( string $file_path, string $retention_scope ): bool {
+		$contents = file_get_contents( $file_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		if ( ! is_string( $contents ) || '' === $contents ) {
+			return false;
+		}
+
+		$payload = json_decode( $contents, true );
+		if ( ! is_array( $payload ) ) {
+			return false;
+		}
+
+		$scope = isset( $payload['retention_scope'] ) ? sanitize_key( (string) $payload['retention_scope'] ) : '';
+		if ( $retention_scope === $scope ) {
+			return true;
+		}
+
+		$artifact_type = isset( $payload['artifact_type'] ) ? sanitize_key( (string) $payload['artifact_type'] ) : '';
+		return CorpusJobSurfaces::RETENTION_SCOPE === $retention_scope && in_array( $artifact_type, CorpusJobSurfaces::corpusArtifactTypes(), true );
 	}
 }

--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -62,6 +62,8 @@ class JobArtifacts {
 			'status'                 => (string) ( $job['status'] ?? '' ),
 			'agent_id'               => $agent['agent_id'],
 			'agent_slug'             => $agent['agent_slug'],
+			'job_summary'            => CorpusJobSurfaces::summary( $job, $engine_data ),
+			'corpus_artifacts'       => CorpusJobSurfaces::artifactRefs( $engine_data ),
 			'disposition_diagnostic' => $this->disposition_diagnostic( $engine_data ),
 			'required_tool_names'    => $this->tool_names_from_assertions( $engine_data['completion_assertions_required'] ?? array() ),
 			'satisfied_tool_names'   => $this->tool_names_from_assertions( $engine_data['completion_assertions_satisfied'] ?? array() ),
@@ -242,22 +244,23 @@ class JobArtifacts {
 		$artifact_files = is_array( $engine_data['artifact_files'] ?? null ) ? $engine_data['artifact_files'] : array();
 		$out            = array();
 
-		foreach ( array( 'transcript', 'tool_trace' ) as $key ) {
-			if ( ! is_array( $artifact_files[ $key ] ?? null ) ) {
+		foreach ( $artifact_files as $key => $artifact_file ) {
+			if ( ! is_string( $key ) || ! is_array( $artifact_file ) ) {
 				continue;
 			}
 
 			$out[ $key ] = $this->filter_empty(
 				array(
-					'artifact_type'  => isset( $artifact_files[ $key ]['artifact_type'] ) ? sanitize_key( (string) $artifact_files[ $key ]['artifact_type'] ) : null,
-					'artifact_ref'   => isset( $artifact_files[ $key ]['artifact_ref'] ) ? sanitize_text_field( (string) $artifact_files[ $key ]['artifact_ref'] ) : null,
-					'relative_path'  => isset( $artifact_files[ $key ]['relative_path'] ) ? sanitize_text_field( (string) $artifact_files[ $key ]['relative_path'] ) : null,
-					'path'           => isset( $artifact_files[ $key ]['path'] ) ? (string) $artifact_files[ $key ]['path'] : null,
-					'url'            => isset( $artifact_files[ $key ]['url'] ) ? esc_url_raw( (string) $artifact_files[ $key ]['url'] ) : null,
-					'sha256'         => isset( $artifact_files[ $key ]['sha256'] ) ? sanitize_text_field( (string) $artifact_files[ $key ]['sha256'] ) : null,
-					'payload_sha256' => isset( $artifact_files[ $key ]['payload_sha256'] ) ? sanitize_text_field( (string) $artifact_files[ $key ]['payload_sha256'] ) : null,
-					'bytes'          => isset( $artifact_files[ $key ]['bytes'] ) ? (int) $artifact_files[ $key ]['bytes'] : null,
-					'written_at'     => isset( $artifact_files[ $key ]['written_at'] ) ? sanitize_text_field( (string) $artifact_files[ $key ]['written_at'] ) : null,
+					'artifact_type'   => isset( $artifact_file['artifact_type'] ) ? sanitize_key( (string) $artifact_file['artifact_type'] ) : null,
+					'artifact_ref'    => isset( $artifact_file['artifact_ref'] ) ? sanitize_text_field( (string) $artifact_file['artifact_ref'] ) : null,
+					'retention_scope' => isset( $artifact_file['retention_scope'] ) ? sanitize_key( (string) $artifact_file['retention_scope'] ) : null,
+					'relative_path'   => isset( $artifact_file['relative_path'] ) ? sanitize_text_field( (string) $artifact_file['relative_path'] ) : null,
+					'path'            => isset( $artifact_file['path'] ) ? (string) $artifact_file['path'] : null,
+					'url'             => isset( $artifact_file['url'] ) ? esc_url_raw( (string) $artifact_file['url'] ) : null,
+					'sha256'          => isset( $artifact_file['sha256'] ) ? sanitize_text_field( (string) $artifact_file['sha256'] ) : null,
+					'payload_sha256'  => isset( $artifact_file['payload_sha256'] ) ? sanitize_text_field( (string) $artifact_file['payload_sha256'] ) : null,
+					'bytes'           => isset( $artifact_file['bytes'] ) ? (int) $artifact_file['bytes'] : null,
+					'written_at'      => isset( $artifact_file['written_at'] ) ? sanitize_text_field( (string) $artifact_file['written_at'] ) : null,
 				)
 			);
 		}

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -29,6 +29,7 @@ use DataMachine\Engine\AI\System\Tasks\Retention\RetentionActionSchedulerTask;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionChatSessionsTask;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionCleanup;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionCompletedJobsTask;
+use DataMachine\Engine\AI\System\Tasks\Retention\RetentionCorpusArtifactsTask;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionFailedJobsTask;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionFilesTask;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionLogsTask;
@@ -85,14 +86,15 @@ class SystemAgentServiceProvider {
 		$tasks['internal_linking']                       = InternalLinkingTask::class;
 		$tasks['daily_memory_generation']                = DailyMemoryTask::class;
 		$tasks['meta_description_generation']            = MetaDescriptionTask::class;
-		$tasks[ RetentionCleanup::TASK_COMPLETED_JOBS ]  = RetentionCompletedJobsTask::class;
-		$tasks[ RetentionCleanup::TASK_FAILED_JOBS ]     = RetentionFailedJobsTask::class;
-		$tasks[ RetentionCleanup::TASK_LOGS ]            = RetentionLogsTask::class;
-		$tasks[ RetentionCleanup::TASK_PROCESSED_ITEMS ] = RetentionProcessedItemsTask::class;
-		$tasks[ RetentionCleanup::TASK_AS_ACTIONS ]      = RetentionActionSchedulerTask::class;
-		$tasks[ RetentionCleanup::TASK_STALE_CLAIMS ]    = RetentionStaleClaimsTask::class;
-		$tasks[ RetentionCleanup::TASK_FILES ]           = RetentionFilesTask::class;
-		$tasks[ RetentionCleanup::TASK_CHAT_SESSIONS ]   = RetentionChatSessionsTask::class;
+		$tasks[ RetentionCleanup::TASK_COMPLETED_JOBS ]   = RetentionCompletedJobsTask::class;
+		$tasks[ RetentionCleanup::TASK_FAILED_JOBS ]      = RetentionFailedJobsTask::class;
+		$tasks[ RetentionCleanup::TASK_LOGS ]             = RetentionLogsTask::class;
+		$tasks[ RetentionCleanup::TASK_PROCESSED_ITEMS ]  = RetentionProcessedItemsTask::class;
+		$tasks[ RetentionCleanup::TASK_AS_ACTIONS ]       = RetentionActionSchedulerTask::class;
+		$tasks[ RetentionCleanup::TASK_STALE_CLAIMS ]     = RetentionStaleClaimsTask::class;
+		$tasks[ RetentionCleanup::TASK_FILES ]            = RetentionFilesTask::class;
+		$tasks[ RetentionCleanup::TASK_CHAT_SESSIONS ]    = RetentionChatSessionsTask::class;
+		$tasks[ RetentionCleanup::TASK_CORPUS_ARTIFACTS ] = RetentionCorpusArtifactsTask::class;
 
 		return $tasks;
 	}
@@ -214,6 +216,16 @@ class SystemAgentServiceProvider {
 					'enabled_setting' => 'retention_chat_sessions_enabled',
 					'default_enabled' => true,
 					'label'           => 'Daily chat-session cleanup',
+				)
+			),
+			RetentionCleanup::TASK_CORPUS_ARTIFACTS => array_merge(
+				$daily_first_run,
+				array(
+					'task_type'       => RetentionCleanup::TASK_CORPUS_ARTIFACTS,
+					'interval'        => 'daily',
+					'enabled_setting' => 'retention_corpus_artifacts_enabled',
+					'default_enabled' => true,
+					'label'           => 'Daily corpus-artifact cleanup',
 				)
 			),
 		);

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -76,16 +76,16 @@ class SystemAgentServiceProvider {
 	 * @return array Task handlers including built-in ones.
 	 */
 	public function getBuiltInTasks( array $tasks ): array {
-		$tasks['agent_call']                             = AgentCallTask::class;
-		$tasks['dispatch_message']                       = DispatchMessageTask::class;
-		$tasks['emit_data_packets']                      = EmitDataPacketsTask::class;
-		$tasks['source_inventory']                       = SourceInventoryTask::class;
-		$tasks['image_generation']                       = ImageGenerationTask::class;
-		$tasks['image_optimization']                     = ImageOptimizationTask::class;
-		$tasks['alt_text_generation']                    = AltTextTask::class;
-		$tasks['internal_linking']                       = InternalLinkingTask::class;
-		$tasks['daily_memory_generation']                = DailyMemoryTask::class;
-		$tasks['meta_description_generation']            = MetaDescriptionTask::class;
+		$tasks['agent_call']                              = AgentCallTask::class;
+		$tasks['dispatch_message']                        = DispatchMessageTask::class;
+		$tasks['emit_data_packets']                       = EmitDataPacketsTask::class;
+		$tasks['source_inventory']                        = SourceInventoryTask::class;
+		$tasks['image_generation']                        = ImageGenerationTask::class;
+		$tasks['image_optimization']                      = ImageOptimizationTask::class;
+		$tasks['alt_text_generation']                     = AltTextTask::class;
+		$tasks['internal_linking']                        = InternalLinkingTask::class;
+		$tasks['daily_memory_generation']                 = DailyMemoryTask::class;
+		$tasks['meta_description_generation']             = MetaDescriptionTask::class;
 		$tasks[ RetentionCleanup::TASK_COMPLETED_JOBS ]   = RetentionCompletedJobsTask::class;
 		$tasks[ RetentionCleanup::TASK_FAILED_JOBS ]      = RetentionFailedJobsTask::class;
 		$tasks[ RetentionCleanup::TASK_LOGS ]             = RetentionLogsTask::class;
@@ -139,7 +139,7 @@ class SystemAgentServiceProvider {
 		);
 
 		return array(
-			RetentionCleanup::TASK_COMPLETED_JOBS  => array_merge(
+			RetentionCleanup::TASK_COMPLETED_JOBS   => array_merge(
 				$daily_first_run,
 				array(
 					'task_type'       => RetentionCleanup::TASK_COMPLETED_JOBS,
@@ -149,7 +149,7 @@ class SystemAgentServiceProvider {
 					'label'           => 'Daily completed-jobs cleanup',
 				)
 			),
-			RetentionCleanup::TASK_FAILED_JOBS     => array_merge(
+			RetentionCleanup::TASK_FAILED_JOBS      => array_merge(
 				$daily_first_run,
 				array(
 					'task_type'       => RetentionCleanup::TASK_FAILED_JOBS,
@@ -159,7 +159,7 @@ class SystemAgentServiceProvider {
 					'label'           => 'Daily failed-jobs cleanup',
 				)
 			),
-			RetentionCleanup::TASK_LOGS            => array_merge(
+			RetentionCleanup::TASK_LOGS             => array_merge(
 				$daily_first_run,
 				array(
 					'task_type'       => RetentionCleanup::TASK_LOGS,
@@ -169,7 +169,7 @@ class SystemAgentServiceProvider {
 					'label'           => 'Daily log cleanup',
 				)
 			),
-			RetentionCleanup::TASK_PROCESSED_ITEMS => array_merge(
+			RetentionCleanup::TASK_PROCESSED_ITEMS  => array_merge(
 				$daily_first_run,
 				array(
 					'task_type'       => RetentionCleanup::TASK_PROCESSED_ITEMS,
@@ -179,7 +179,7 @@ class SystemAgentServiceProvider {
 					'label'           => 'Daily processed-items cleanup',
 				)
 			),
-			RetentionCleanup::TASK_AS_ACTIONS      => array_merge(
+			RetentionCleanup::TASK_AS_ACTIONS       => array_merge(
 				$daily_first_run,
 				array(
 					'task_type'       => RetentionCleanup::TASK_AS_ACTIONS,
@@ -189,7 +189,7 @@ class SystemAgentServiceProvider {
 					'label'           => 'Daily Action Scheduler action cleanup',
 				)
 			),
-			RetentionCleanup::TASK_STALE_CLAIMS    => array_merge(
+			RetentionCleanup::TASK_STALE_CLAIMS     => array_merge(
 				$daily_first_run,
 				array(
 					'task_type'       => RetentionCleanup::TASK_STALE_CLAIMS,
@@ -199,7 +199,7 @@ class SystemAgentServiceProvider {
 					'label'           => 'Daily stale-claims cleanup',
 				)
 			),
-			RetentionCleanup::TASK_FILES           => array(
+			RetentionCleanup::TASK_FILES            => array(
 				'task_type'          => RetentionCleanup::TASK_FILES,
 				'interval'           => 'weekly',
 				'enabled_setting'    => 'retention_files_enabled',
@@ -208,7 +208,7 @@ class SystemAgentServiceProvider {
 				'first_run_callback' => 'strtotime',
 				'first_run_arg'      => '+1 week',
 			),
-			RetentionCleanup::TASK_CHAT_SESSIONS   => array_merge(
+			RetentionCleanup::TASK_CHAT_SESSIONS    => array_merge(
 				$daily_first_run,
 				array(
 					'task_type'       => RetentionCleanup::TASK_CHAT_SESSIONS,

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -15,19 +15,21 @@ use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\Logs\LogRepository;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\CorpusJobSurfaces;
 use DataMachine\Core\FilesRepository\FileCleanup;
 use DataMachine\Core\PluginSettings;
 
 class RetentionCleanup {
 
-	public const TASK_COMPLETED_JOBS  = 'retention_completed_jobs';
-	public const TASK_FAILED_JOBS     = 'retention_failed_jobs';
-	public const TASK_LOGS            = 'retention_logs';
-	public const TASK_PROCESSED_ITEMS = 'retention_processed_items';
-	public const TASK_AS_ACTIONS      = 'retention_as_actions';
-	public const TASK_STALE_CLAIMS    = 'retention_stale_claims';
-	public const TASK_FILES           = 'retention_files';
-	public const TASK_CHAT_SESSIONS   = 'retention_chat_sessions';
+	public const TASK_COMPLETED_JOBS   = 'retention_completed_jobs';
+	public const TASK_FAILED_JOBS      = 'retention_failed_jobs';
+	public const TASK_LOGS             = 'retention_logs';
+	public const TASK_PROCESSED_ITEMS  = 'retention_processed_items';
+	public const TASK_AS_ACTIONS       = 'retention_as_actions';
+	public const TASK_STALE_CLAIMS     = 'retention_stale_claims';
+	public const TASK_FILES            = 'retention_files';
+	public const TASK_CHAT_SESSIONS    = 'retention_chat_sessions';
+	public const TASK_CORPUS_ARTIFACTS = 'retention_corpus_artifacts';
 
 	public static function completedJobsMaxAgeDays(): int {
 		return self::positiveDays( apply_filters( 'datamachine_completed_jobs_max_age_days', 30 ), 30 );
@@ -64,6 +66,15 @@ class RetentionCleanup {
 
 	public static function transcriptRetentionDays(): int {
 		return (int) get_option( 'datamachine_pipeline_transcript_retention_days', 30 );
+	}
+
+	public static function corpusArtifactsMaxAgeDays(): int {
+		$policy = CorpusJobSurfaces::retentionPolicies()[ CorpusJobSurfaces::RETENTION_SCOPE ] ?? array();
+		return self::positiveDays( $policy['max_age_days'] ?? 30, 30 );
+	}
+
+	public static function jobArtifactRetentionPolicies(): array {
+		return CorpusJobSurfaces::retentionPolicies();
 	}
 
 	public static function countCompletedJobs(): int {
@@ -416,6 +427,32 @@ class RetentionCleanup {
 		return array(
 			'deleted'        => (int) $deleted,
 			'retention_days' => $retention_days,
+		);
+	}
+
+	public static function countCorpusArtifacts(): int {
+		return ( new FileCleanup() )->count_old_job_artifacts( CorpusJobSurfaces::RETENTION_SCOPE, self::corpusArtifactsMaxAgeDays() );
+	}
+
+	public static function cleanupCorpusArtifacts(): array {
+		$retention_days = self::corpusArtifactsMaxAgeDays();
+		$deleted        = ( new FileCleanup() )->cleanup_old_job_artifacts( CorpusJobSurfaces::RETENTION_SCOPE, $retention_days );
+
+		if ( $deleted > 0 ) {
+			self::log(
+				'Scheduled cleanup: deleted old corpus indexing artifacts',
+				array(
+					'artifacts_deleted' => $deleted,
+					'retention_scope'   => CorpusJobSurfaces::RETENTION_SCOPE,
+					'max_age_days'      => $retention_days,
+				)
+			);
+		}
+
+		return array(
+			'deleted'         => (int) $deleted,
+			'retention_scope' => CorpusJobSurfaces::RETENTION_SCOPE,
+			'max_age_days'    => $retention_days,
 		);
 	}
 

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCorpusArtifactsTask.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCorpusArtifactsTask.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DataMachine\Engine\AI\System\Tasks\Retention;
+
+defined( 'ABSPATH' ) || exit;
+
+class RetentionCorpusArtifactsTask extends RetentionTask {
+
+	public function getTaskType(): string {
+		return RetentionCleanup::TASK_CORPUS_ARTIFACTS;
+	}
+
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Retention: corpus indexing artifacts',
+			'description'     => 'Deletes corpus indexing artifact files older than the configured retention window.',
+			'setting_key'     => 'retention_corpus_artifacts_enabled',
+			'default_enabled' => true,
+			'supports_run'    => true,
+		);
+	}
+
+	protected function runRetentionCleanup(): array {
+		return RetentionCleanup::cleanupCorpusArtifacts();
+	}
+}

--- a/tests/corpus-job-surfaces-smoke.php
+++ b/tests/corpus-job-surfaces-smoke.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Pure-PHP smoke test for corpus-style job summary/artifact conventions (#2490).
+ *
+ * Run with: php tests/corpus-job-surfaces-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/RunMetrics.php';
+require_once __DIR__ . '/../inc/Core/CorpusJobSurfaces.php';
+
+use DataMachine\Core\CorpusJobSurfaces;
+
+$failures = 0;
+$total    = 0;
+
+$assert = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$label}\n";
+		return;
+	}
+
+	++$failures;
+	echo "  [FAIL] {$label}\n";
+};
+
+echo "=== corpus-job-surfaces-smoke ===\n";
+
+$engine_data = array(
+	'job_summary'     => array(
+		'headline'          => 'Indexed handbook corpus with recoverable embedding misses.',
+		'items_total'       => 12,
+		'items_indexed'     => 9,
+		'items_unchanged'   => 2,
+		'embedding_failures' => 1,
+	),
+	'run_metrics'     => array(
+		'counts' => array(
+			'processed' => 9,
+			'skipped'   => 2,
+			'failed'    => 1,
+		),
+	),
+	'corpus_artifacts' => array(
+		'embedding_failures' => array(
+			'artifact_type'   => 'embedding_failures',
+			'artifact_ref'    => 'datamachine://jobs/77/artifacts/embedding-failures',
+			'relative_path'   => 'datamachine-artifacts/jobs/77/embedding-failures.json',
+			'sha256'          => str_repeat( 'a', 64 ),
+			'bytes'           => 512,
+			'retention_scope' => 'corpus_indexing',
+		),
+	),
+);
+
+$summary = CorpusJobSurfaces::summary(
+	array(
+		'job_id' => 77,
+		'status' => 'completed',
+	),
+	$engine_data
+);
+
+$assert( 'summary declares corpus workload type', 'corpus_indexing' === ( $summary['workload_type'] ?? '' ) );
+$assert( 'summary keeps concise headline', 'Indexed handbook corpus with recoverable embedding misses.' === ( $summary['headline'] ?? '' ) );
+$assert( 'summary exposes corpus counts', 12 === ( $summary['counts']['items_total'] ?? 0 ) && 1 === ( $summary['counts']['embedding_failures'] ?? 0 ) );
+$assert( 'summary preserves artifact references', 'datamachine://jobs/77/artifacts/embedding-failures' === ( $summary['artifact_refs']['embedding_failures']['artifact_ref'] ?? '' ) );
+
+$refs = CorpusJobSurfaces::artifactRefs(
+	array(
+		'artifact_files' => array(
+			'chunking_summary' => array(
+				'artifact_type' => 'chunking_summary',
+				'artifact_ref'  => 'datamachine://jobs/77/artifacts/chunking-summary',
+				'bytes'         => 128,
+			),
+			'tool_trace'       => array(
+				'artifact_type' => 'tool_trace',
+				'artifact_ref'  => 'datamachine://jobs/77/artifacts/tool-trace',
+			),
+		),
+	)
+);
+
+$assert( 'corpus artifact refs can come from runtime artifact_files', isset( $refs['chunking_summary'] ) );
+$assert( 'normal run artifacts are not mislabeled as corpus artifacts', ! isset( $refs['tool_trace'] ) );
+$assert( 'artifact refs get corpus retention scope by convention', 'corpus_indexing' === ( $refs['chunking_summary']['retention_scope'] ?? '' ) );
+
+$policies = CorpusJobSurfaces::retentionPolicies();
+$assert( 'corpus retention policy is separate and named', isset( $policies['corpus_indexing'] ) );
+$assert( 'corpus retention policy declares artifact type selectors', in_array( 'retrieval_evaluation', $policies['corpus_indexing']['artifact_types'] ?? array(), true ) );
+$assert( 'corpus retention policy documents max age', 30 === ( $policies['corpus_indexing']['max_age_days'] ?? 0 ) );
+
+$job_artifacts_source = file_get_contents( __DIR__ . '/../inc/Core/JobArtifacts.php' ) ?: '';
+$retention_source     = file_get_contents( __DIR__ . '/../inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php' ) ?: '';
+$file_cleanup_source  = file_get_contents( __DIR__ . '/../inc/Core/FilesRepository/FileCleanup.php' ) ?: '';
+$assert( 'JobArtifacts projects corpus job summaries', str_contains( $job_artifacts_source, 'CorpusJobSurfaces::summary' ) );
+$assert( 'JobArtifacts preserves generic corpus artifact refs', str_contains( $job_artifacts_source, 'CorpusJobSurfaces::artifactRefs' ) );
+$job_helpers_source = file_get_contents( __DIR__ . '/../inc/Abilities/Job/JobHelpers.php' ) ?: '';
+$assert( 'jobs list/detail surfaces expose concise summaries', str_contains( $job_helpers_source, "job['job_summary']" ) );
+$assert( 'retention cleanup exposes corpus artifact policy surface', str_contains( $retention_source, 'jobArtifactRetentionPolicies' ) );
+$assert( 'file cleanup targets corpus retention scope from artifact payloads', str_contains( $file_cleanup_source, 'artifact_matches_retention_scope' ) );
+
+if ( $failures > 0 ) {
+	echo "\n=== corpus-job-surfaces-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";
+	exit( 1 );
+}
+
+echo "\n=== corpus-job-surfaces-smoke: ALL PASS ({$total} assertions) ===\n";

--- a/tests/retention-system-tasks-smoke.php
+++ b/tests/retention-system-tasks-smoke.php
@@ -21,6 +21,7 @@ $sources = array(
 	'files'     => file_get_contents( $root . '/inc/Core/FilesRepository/FileCleanup.php' ) ?: '',
 	'chat'      => file_get_contents( $root . '/inc/Core/Database/Chat/Chat.php' ) ?: '',
 	'cleanup'   => file_get_contents( $root . '/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php' ) ?: '',
+	'corpus'    => file_get_contents( $root . '/inc/Core/CorpusJobSurfaces.php' ) ?: '',
 );
 
 $failed = 0;
@@ -68,6 +69,7 @@ $task_classes = array(
 	'RetentionStaleClaimsTask',
 	'RetentionFilesTask',
 	'RetentionChatSessionsTask',
+	'RetentionCorpusArtifactsTask',
 );
 
 foreach ( $task_classes as $task_class ) {
@@ -88,6 +90,7 @@ $task_constants = array(
 	'TASK_STALE_CLAIMS',
 	'TASK_FILES',
 	'TASK_CHAT_SESSIONS',
+	'TASK_CORPUS_ARTIFACTS',
 );
 
 foreach ( $task_constants as $constant ) {
@@ -128,6 +131,11 @@ assert_retention(
 	'file dry-run counter includes old job directories',
 	str_contains( $sources['cleanup'], '$jobs_dir = "{$flow_dir}/jobs";' )
 		&& str_contains( $sources['cleanup'], '++$count;' )
+);
+assert_retention(
+	'corpus artifact retention has separate scope policy hook',
+	str_contains( $sources['corpus'], 'datamachine_corpus_artifacts_max_age_days' )
+		&& str_contains( $sources['cleanup'], 'TASK_CORPUS_ARTIFACTS' )
 );
 
 if ( retention_failed_count() > 0 ) {


### PR DESCRIPTION
## Summary
- Adds generic corpus indexing job summary conventions so job list/detail and job artifact payloads can expose concise operator-facing counts and artifact references.
- Preserves corpus artifact metadata through job artifact projection without narrowing Data Machine to a product-specific corpus implementation.
- Adds a separate corpus artifact retention policy hook, CLI/system-task retention surface, and scoped artifact-file cleanup path.

Closes #2490.

## Tests
- `php tests/corpus-job-surfaces-smoke.php`
- `php tests/retention-system-tasks-smoke.php`
- `vendor/bin/phpcs inc/Abilities/Job/JobHelpers.php inc/Core/CorpusJobSurfaces.php inc/Core/JobArtifacts.php inc/Core/FilesRepository/FileCleanup.php inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php inc/Engine/AI/System/SystemAgentServiceProvider.php inc/Engine/AI/System/Tasks/Retention/RetentionCorpusArtifactsTask.php inc/Cli/Commands/RetentionCommand.php tests/corpus-job-surfaces-smoke.php tests/retention-system-tasks-smoke.php`
- `git diff --check`

## Remaining risks
- The new artifact retention cleanup targets JSON files under the existing Data Machine job artifact directory and relies on artifact payload `retention_scope` or known generic corpus artifact types; consumers still need to write artifact payloads using those conventions.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted and verified the generic job summary, artifact projection, retention hooks, and smoke test changes for Chris to review.