### PR TITLE
Add generic corpus system tasks

### DIFF
--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -18,6 +18,10 @@ defined( 'ABSPATH' ) || exit;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Engine\AI\System\Tasks\AgentCallTask;
 use DataMachine\Engine\AI\System\Tasks\AltTextTask;
+use DataMachine\Engine\AI\System\Tasks\Corpus\CorpusEmbedChunksTask;
+use DataMachine\Engine\AI\System\Tasks\Corpus\CorpusIndexTask;
+use DataMachine\Engine\AI\System\Tasks\Corpus\CorpusRefreshTask;
+use DataMachine\Engine\AI\System\Tasks\Corpus\CorpusRetrieveEvalTask;
 use DataMachine\Engine\AI\System\Tasks\DailyMemoryTask;
 use DataMachine\Engine\AI\System\Tasks\DispatchMessageTask;
 use DataMachine\Engine\AI\System\Tasks\EmitDataPacketsTask;
@@ -76,6 +80,10 @@ class SystemAgentServiceProvider {
 	 */
 	public function getBuiltInTasks( array $tasks ): array {
 		$tasks['agent_call']                             = AgentCallTask::class;
+		$tasks['corpus_index']                           = CorpusIndexTask::class;
+		$tasks['corpus_refresh']                         = CorpusRefreshTask::class;
+		$tasks['corpus_embed_chunks']                    = CorpusEmbedChunksTask::class;
+		$tasks['corpus_retrieve_eval']                   = CorpusRetrieveEvalTask::class;
 		$tasks['dispatch_message']                       = DispatchMessageTask::class;
 		$tasks['emit_data_packets']                      = EmitDataPacketsTask::class;
 		$tasks['source_inventory']                       = SourceInventoryTask::class;

--- a/inc/Engine/AI/System/Tasks/Corpus/CorpusEmbedChunksTask.php
+++ b/inc/Engine/AI/System/Tasks/Corpus/CorpusEmbedChunksTask.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Generic corpus chunk embedding task.
+ *
+ * @package DataMachine\Engine\AI\System\Tasks\Corpus
+ */
+
+namespace DataMachine\Engine\AI\System\Tasks\Corpus;
+
+defined( 'ABSPATH' ) || exit;
+
+class CorpusEmbedChunksTask extends CorpusPacketTask {
+
+	public function getTaskType(): string {
+		return 'corpus_embed_chunks';
+	}
+
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Corpus Embed Chunks',
+			'description'     => 'Normalize corpus chunk work into DataPackets for product-owned embedding workflows.',
+			'setting_key'     => null,
+			'default_enabled' => true,
+			'trigger'         => 'On-demand via workflow system_task step',
+			'trigger_type'    => 'manual',
+			'supports_run'    => true,
+			'mutates'         => false,
+			'params_schema'   => array(
+				'type'       => 'object',
+				'properties' => array(
+					'corpus' => array( 'type' => 'object' ),
+					'chunks' => array( 'type' => 'array' ),
+					'chunk'  => array( 'type' => 'object' ),
+				),
+			),
+		);
+	}
+
+	protected function getCorpusOperation(): string {
+		return 'embed_chunks';
+	}
+
+	protected function getOutputPacketType(): string {
+		return 'corpus_chunk';
+	}
+
+	protected function getAcceptedItemKeys(): array {
+		return array( 'chunks', 'chunk', 'items', 'item' );
+	}
+
+	protected function getChunkIdentifierKeys(): array {
+		return array( 'chunk_id', 'id' );
+	}
+}

--- a/inc/Engine/AI/System/Tasks/Corpus/CorpusIndexTask.php
+++ b/inc/Engine/AI/System/Tasks/Corpus/CorpusIndexTask.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Generic corpus index task.
+ *
+ * @package DataMachine\Engine\AI\System\Tasks\Corpus
+ */
+
+namespace DataMachine\Engine\AI\System\Tasks\Corpus;
+
+defined( 'ABSPATH' ) || exit;
+
+class CorpusIndexTask extends CorpusPacketTask {
+
+	public function getTaskType(): string {
+		return 'corpus_index';
+	}
+
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Corpus Index',
+			'description'     => 'Normalize corpus document work into DataPackets for product-owned indexing workflows.',
+			'setting_key'     => null,
+			'default_enabled' => true,
+			'trigger'         => 'On-demand via workflow system_task step',
+			'trigger_type'    => 'manual',
+			'supports_run'    => true,
+			'mutates'         => false,
+			'params_schema'   => self::documentParamsSchema(),
+		);
+	}
+
+	protected function getCorpusOperation(): string {
+		return 'index';
+	}
+
+	protected function getOutputPacketType(): string {
+		return 'corpus_document';
+	}
+
+	protected function getAcceptedItemKeys(): array {
+		return array( 'documents', 'document', 'items', 'item' );
+	}
+
+	protected function getDocumentIdentifierKeys(): array {
+		return array( 'document_id', 'id' );
+	}
+
+	protected static function documentParamsSchema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'corpus'    => array( 'type' => 'object' ),
+				'documents' => array( 'type' => 'array' ),
+				'document'  => array( 'type' => 'object' ),
+			),
+		);
+	}
+}

--- a/inc/Engine/AI/System/Tasks/Corpus/CorpusPacketTask.php
+++ b/inc/Engine/AI/System/Tasks/Corpus/CorpusPacketTask.php
@@ -87,7 +87,14 @@ abstract class CorpusPacketTask extends SystemTask {
 	 */
 	protected function normalizeCorpus( array $input ): array {
 		$corpus = isset( $input['corpus'] ) && is_array( $input['corpus'] ) ? $input['corpus'] : array();
-		foreach ( array( 'id' => 'corpus_id', 'ref' => 'corpus_ref', 'key' => 'corpus_key', 'label' => 'corpus_label' ) as $target => $source ) {
+		foreach (
+			array(
+				'id'    => 'corpus_id',
+				'ref'   => 'corpus_ref',
+				'key'   => 'corpus_key',
+				'label' => 'corpus_label',
+			) as $target => $source
+		) {
 			if ( ! array_key_exists( $target, $corpus ) && array_key_exists( $source, $input ) ) {
 				$corpus[ $target ] = $input[ $source ];
 			}

--- a/inc/Engine/AI/System/Tasks/Corpus/CorpusPacketTask.php
+++ b/inc/Engine/AI/System/Tasks/Corpus/CorpusPacketTask.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Generic corpus workflow packet task base.
+ *
+ * @package DataMachine\Engine\AI\System\Tasks\Corpus
+ */
+
+namespace DataMachine\Engine\AI\System\Tasks\Corpus;
+
+use DataMachine\Core\JobStatus;
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
+
+defined( 'ABSPATH' ) || exit;
+
+abstract class CorpusPacketTask extends SystemTask {
+
+	/**
+	 * Corpus workflow operation represented by this task.
+	 */
+	abstract protected function getCorpusOperation(): string;
+
+	/**
+	 * Packet type emitted for each normalized item.
+	 */
+	abstract protected function getOutputPacketType(): string;
+
+	/**
+	 * Accepted parameter keys that may contain work items.
+	 *
+	 * @return array<int,string>
+	 */
+	abstract protected function getAcceptedItemKeys(): array;
+
+	/**
+	 * Execute the task by normalizing corpus work items into DataPackets.
+	 *
+	 * @param int                 $jobId  Job ID.
+	 * @param array<string,mixed> $params Task params.
+	 */
+	public function executeTask( int $jobId, array $params ): void {
+		$input  = $this->normalizeInput( $params );
+		$corpus = $this->normalizeCorpus( $input );
+		$items  = $this->normalizeItems( $input );
+
+		$packets = array();
+		foreach ( $items as $item ) {
+			$packets[] = $this->buildPacket( $corpus, $item );
+		}
+
+		$result = array(
+			'output_data_packets'    => $packets,
+			'replace_data_packets'   => ! empty( $input['replace_data_packets'] ),
+			'suppress_result_packet' => ! empty( $input['suppress_result_packet'] ),
+			'operation'              => $this->getCorpusOperation(),
+			'corpus'                 => $corpus,
+			'corpus_id'              => (string) ( $corpus['id'] ?? '' ),
+			'corpus_ref'             => (string) ( $corpus['ref'] ?? '' ),
+			'document_ids'           => $this->collectIdentifiers( $items, $this->getDocumentIdentifierKeys() ),
+			'chunk_ids'              => $this->collectIdentifiers( $items, $this->getChunkIdentifierKeys() ),
+			'item_count'             => count( $items ),
+			'packet_count'           => count( $packets ),
+			'completed_at'           => current_time( 'mysql' ),
+		);
+
+		if ( empty( $items ) ) {
+			$result['job_status'] = JobStatus::COMPLETED_NO_ITEMS;
+		}
+
+		$this->completeJob( $jobId, $result );
+	}
+
+	/**
+	 * Normalize the task input envelope.
+	 *
+	 * @param array<string,mixed> $params Raw task params.
+	 * @return array<string,mixed>
+	 */
+	protected function normalizeInput( array $params ): array {
+		return isset( $params['input'] ) && is_array( $params['input'] ) ? $params['input'] : $params;
+	}
+
+	/**
+	 * Normalize optional corpus identifiers.
+	 *
+	 * @param array<string,mixed> $input Task input.
+	 * @return array<string,mixed>
+	 */
+	protected function normalizeCorpus( array $input ): array {
+		$corpus = isset( $input['corpus'] ) && is_array( $input['corpus'] ) ? $input['corpus'] : array();
+		foreach ( array( 'id' => 'corpus_id', 'ref' => 'corpus_ref', 'key' => 'corpus_key', 'label' => 'corpus_label' ) as $target => $source ) {
+			if ( ! array_key_exists( $target, $corpus ) && array_key_exists( $source, $input ) ) {
+				$corpus[ $target ] = $input[ $source ];
+			}
+		}
+
+		return $corpus;
+	}
+
+	/**
+	 * Normalize accepted item keys into a flat list.
+	 *
+	 * @param array<string,mixed> $input Task input.
+	 * @return array<int,array<string,mixed>>
+	 */
+	protected function normalizeItems( array $input ): array {
+		foreach ( $this->getAcceptedItemKeys() as $key ) {
+			if ( ! array_key_exists( $key, $input ) ) {
+				continue;
+			}
+
+			$value = $input[ $key ];
+			if ( is_array( $value ) && array_is_list( $value ) ) {
+				return array_values( array_filter( $value, 'is_array' ) );
+			}
+
+			if ( is_array( $value ) ) {
+				return array( $value );
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Build one output packet.
+	 *
+	 * @param array<string,mixed> $corpus Corpus identifiers.
+	 * @param array<string,mixed> $item   Work item.
+	 * @return array<string,mixed>
+	 */
+	protected function buildPacket( array $corpus, array $item ): array {
+		$metadata = array(
+			'source_type' => 'corpus_workflow',
+			'task_type'   => $this->getTaskType(),
+			'operation'   => $this->getCorpusOperation(),
+			'corpus_id'   => (string) ( $corpus['id'] ?? '' ),
+			'corpus_ref'  => (string) ( $corpus['ref'] ?? '' ),
+			'document_id' => $this->firstIdentifier( $item, $this->getDocumentIdentifierKeys() ),
+			'chunk_id'    => $this->firstIdentifier( $item, $this->getChunkIdentifierKeys() ),
+			'success'     => true,
+		);
+
+		return array(
+			'type'     => $this->getOutputPacketType(),
+			'data'     => array(
+				'operation' => $this->getCorpusOperation(),
+				'corpus'    => $corpus,
+				'item'      => $item,
+			),
+			'metadata' => $metadata,
+		);
+	}
+
+	/**
+	 * Candidate item keys that identify source documents.
+	 *
+	 * @return array<int,string>
+	 */
+	protected function getDocumentIdentifierKeys(): array {
+		return array( 'document_id' );
+	}
+
+	/**
+	 * Candidate item keys that identify chunks.
+	 *
+	 * @return array<int,string>
+	 */
+	protected function getChunkIdentifierKeys(): array {
+		return array( 'chunk_id' );
+	}
+
+	/**
+	 * Return the first non-empty identifier value for the requested keys.
+	 *
+	 * @param array<string,mixed> $item Work item.
+	 * @param array<int,string>   $keys Candidate keys.
+	 */
+	private function firstIdentifier( array $item, array $keys ): string {
+		foreach ( $keys as $key ) {
+			if ( isset( $item[ $key ] ) && '' !== (string) $item[ $key ] ) {
+				return (string) $item[ $key ];
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Collect stable identifiers for job summaries.
+	 *
+	 * @param array<int,array<string,mixed>> $items Work items.
+	 * @param array<int,string>              $keys  Candidate keys.
+	 * @return array<int,string>
+	 */
+	private function collectIdentifiers( array $items, array $keys ): array {
+		$ids = array();
+		foreach ( $items as $item ) {
+			foreach ( $keys as $key ) {
+				if ( isset( $item[ $key ] ) && '' !== (string) $item[ $key ] ) {
+					$ids[] = (string) $item[ $key ];
+					break;
+				}
+			}
+		}
+
+		return array_values( array_unique( $ids ) );
+	}
+}

--- a/inc/Engine/AI/System/Tasks/Corpus/CorpusRefreshTask.php
+++ b/inc/Engine/AI/System/Tasks/Corpus/CorpusRefreshTask.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Generic corpus refresh task.
+ *
+ * @package DataMachine\Engine\AI\System\Tasks\Corpus
+ */
+
+namespace DataMachine\Engine\AI\System\Tasks\Corpus;
+
+defined( 'ABSPATH' ) || exit;
+
+class CorpusRefreshTask extends CorpusIndexTask {
+
+	public function getTaskType(): string {
+		return 'corpus_refresh';
+	}
+
+	public static function getTaskMeta(): array {
+		$meta                = parent::getTaskMeta();
+		$meta['label']       = 'Corpus Refresh';
+		$meta['description'] = 'Normalize changed corpus document work into DataPackets for product-owned refresh workflows.';
+		return $meta;
+	}
+
+	protected function getCorpusOperation(): string {
+		return 'refresh';
+	}
+}

--- a/inc/Engine/AI/System/Tasks/Corpus/CorpusRetrieveEvalTask.php
+++ b/inc/Engine/AI/System/Tasks/Corpus/CorpusRetrieveEvalTask.php
@@ -28,7 +28,7 @@ class CorpusRetrieveEvalTask extends CorpusPacketTask {
 			'params_schema'   => array(
 				'type'       => 'object',
 				'properties' => array(
-					'corpus' => array( 'type' => 'object' ),
+					'corpus'  => array( 'type' => 'object' ),
 					'queries' => array( 'type' => 'array' ),
 					'query'   => array( 'type' => 'object' ),
 					'evals'   => array( 'type' => 'array' ),

--- a/inc/Engine/AI/System/Tasks/Corpus/CorpusRetrieveEvalTask.php
+++ b/inc/Engine/AI/System/Tasks/Corpus/CorpusRetrieveEvalTask.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Generic corpus retrieval evaluation task.
+ *
+ * @package DataMachine\Engine\AI\System\Tasks\Corpus
+ */
+
+namespace DataMachine\Engine\AI\System\Tasks\Corpus;
+
+defined( 'ABSPATH' ) || exit;
+
+class CorpusRetrieveEvalTask extends CorpusPacketTask {
+
+	public function getTaskType(): string {
+		return 'corpus_retrieve_eval';
+	}
+
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Corpus Retrieve Eval',
+			'description'     => 'Normalize retrieval-evaluation cases into DataPackets for product-owned eval workflows.',
+			'setting_key'     => null,
+			'default_enabled' => true,
+			'trigger'         => 'On-demand via workflow system_task step',
+			'trigger_type'    => 'manual',
+			'supports_run'    => true,
+			'mutates'         => false,
+			'params_schema'   => array(
+				'type'       => 'object',
+				'properties' => array(
+					'corpus' => array( 'type' => 'object' ),
+					'queries' => array( 'type' => 'array' ),
+					'query'   => array( 'type' => 'object' ),
+					'evals'   => array( 'type' => 'array' ),
+					'eval'    => array( 'type' => 'object' ),
+				),
+			),
+		);
+	}
+
+	protected function getCorpusOperation(): string {
+		return 'retrieve_eval';
+	}
+
+	protected function getOutputPacketType(): string {
+		return 'corpus_retrieval_eval';
+	}
+
+	protected function getAcceptedItemKeys(): array {
+		return array( 'queries', 'query', 'evals', 'eval', 'items', 'item' );
+	}
+}

--- a/tests/corpus-system-tasks-smoke.php
+++ b/tests/corpus-system-tasks-smoke.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Pure-PHP smoke test for generic corpus system tasks (#2488).
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\Database\Jobs {
+	final class Jobs {
+		public function retrieve_engine_data( int $job_id ): array {
+			return $GLOBALS['datamachine_corpus_task_jobs'][ $job_id ] ?? array();
+		}
+
+		public function store_engine_data( int $job_id, array $engine_data ): void {
+			$GLOBALS['datamachine_corpus_task_jobs'][ $job_id ] = $engine_data;
+		}
+
+		public function complete_job( int $job_id, string $status ): void {
+			$GLOBALS['datamachine_corpus_task_status'][ $job_id ] = $status;
+		}
+	}
+}
+
+namespace {
+	const ABSPATH = __DIR__;
+
+	if ( ! function_exists( 'current_time' ) ) {
+		function current_time( string $type ): string {
+			unset( $type );
+			return '2026-06-03 00:00:00';
+		}
+	}
+
+	require_once __DIR__ . '/../inc/Engine/AI/System/Tasks/SystemTask.php';
+	require_once __DIR__ . '/../inc/Core/JobStatus.php';
+	require_once __DIR__ . '/../inc/Engine/AI/System/Tasks/Corpus/CorpusPacketTask.php';
+	require_once __DIR__ . '/../inc/Engine/AI/System/Tasks/Corpus/CorpusIndexTask.php';
+	require_once __DIR__ . '/../inc/Engine/AI/System/Tasks/Corpus/CorpusRefreshTask.php';
+	require_once __DIR__ . '/../inc/Engine/AI/System/Tasks/Corpus/CorpusEmbedChunksTask.php';
+	require_once __DIR__ . '/../inc/Engine/AI/System/Tasks/Corpus/CorpusRetrieveEvalTask.php';
+
+	use DataMachine\Engine\AI\System\Tasks\Corpus\CorpusEmbedChunksTask;
+	use DataMachine\Engine\AI\System\Tasks\Corpus\CorpusIndexTask;
+	use DataMachine\Engine\AI\System\Tasks\Corpus\CorpusRefreshTask;
+	use DataMachine\Engine\AI\System\Tasks\Corpus\CorpusRetrieveEvalTask;
+
+	$failures = array();
+	$passes   = 0;
+
+	$assert = static function ( string $label, bool $condition ) use ( &$failures, &$passes ): void {
+		if ( $condition ) {
+			++$passes;
+			echo "PASS: {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "FAIL: {$label}\n";
+	};
+
+	$GLOBALS['datamachine_corpus_task_jobs']   = array();
+	$GLOBALS['datamachine_corpus_task_status'] = array();
+
+	$index = new CorpusIndexTask();
+	$index->executeTask(
+		101,
+		array(
+			'corpus_id' => 'docs',
+			'documents' => array(
+				array( 'document_id' => 'doc-1', 'title' => 'One' ),
+				array( 'id' => 'doc-2', 'title' => 'Two' ),
+			),
+		)
+	);
+	$index_data = $GLOBALS['datamachine_corpus_task_jobs'][101] ?? array();
+	$assert( 'corpus_index emits one packet per document', 2 === count( $index_data['output_data_packets'] ?? array() ) );
+	$assert( 'corpus_index packet type is corpus_document', 'corpus_document' === ( $index_data['output_data_packets'][0]['type'] ?? '' ) );
+	$assert( 'corpus_index summary exposes corpus id', 'docs' === ( $index_data['corpus_id'] ?? '' ) );
+	$assert( 'corpus_index summary exposes document identifiers', array( 'doc-1', 'doc-2' ) === ( $index_data['document_ids'] ?? array() ) );
+	$assert( 'corpus_index completes job', 'completed' === ( $GLOBALS['datamachine_corpus_task_status'][101] ?? '' ) );
+
+	$embed = new CorpusEmbedChunksTask();
+	$embed->executeTask(
+		102,
+		array(
+			'corpus' => array( 'ref' => 'example/ref' ),
+			'chunks' => array(
+				array( 'document_id' => 'doc-1', 'chunk_id' => 'chunk-1', 'text' => 'Alpha' ),
+			),
+		)
+	);
+	$embed_data = $GLOBALS['datamachine_corpus_task_jobs'][102] ?? array();
+	$assert( 'corpus_embed_chunks emits chunk packets', 'corpus_chunk' === ( $embed_data['output_data_packets'][0]['type'] ?? '' ) );
+	$assert( 'corpus_embed_chunks summary exposes chunk identifiers', array( 'chunk-1' ) === ( $embed_data['chunk_ids'] ?? array() ) );
+	$assert( 'corpus_embed_chunks metadata carries corpus ref', 'example/ref' === ( $embed_data['output_data_packets'][0]['metadata']['corpus_ref'] ?? '' ) );
+
+	$refresh = new CorpusRefreshTask();
+	$refresh->executeTask( 103, array( 'corpus_id' => 'docs' ) );
+	$refresh_data = $GLOBALS['datamachine_corpus_task_jobs'][103] ?? array();
+	$assert( 'empty corpus_refresh completes with no-items status marker', 'completed_no_items' === ( $refresh_data['job_status'] ?? '' ) );
+
+	$eval = new CorpusRetrieveEvalTask();
+	$eval->executeTask( 104, array( 'query' => array( 'id' => 'q-1', 'text' => 'What changed?' ) ) );
+	$eval_data = $GLOBALS['datamachine_corpus_task_jobs'][104] ?? array();
+	$assert( 'corpus_retrieve_eval emits eval packets', 'corpus_retrieval_eval' === ( $eval_data['output_data_packets'][0]['type'] ?? '' ) );
+	$assert( 'corpus_retrieve_eval does not treat query IDs as document IDs', array() === ( $eval_data['document_ids'] ?? array() ) );
+	$assert( 'corpus_retrieve_eval does not treat query IDs as chunk IDs', array() === ( $eval_data['chunk_ids'] ?? array() ) );
+
+	$provider_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/System/SystemAgentServiceProvider.php' );
+	$assert( 'provider registers corpus_index', str_contains( $provider_source, "\$tasks['corpus_index']" ) );
+	$assert( 'provider registers corpus_refresh', str_contains( $provider_source, "\$tasks['corpus_refresh']" ) );
+	$assert( 'provider registers corpus_embed_chunks', str_contains( $provider_source, "\$tasks['corpus_embed_chunks']" ) );
+	$assert( 'provider registers corpus_retrieve_eval', str_contains( $provider_source, "\$tasks['corpus_retrieve_eval']" ) );
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFAILED: " . count( $failures ) . " corpus system task assertion(s) failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$passes} corpus system task assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Adds generic corpus workflow system tasks for `corpus_index`, `corpus_refresh`, `corpus_embed_chunks`, and `corpus_retrieve_eval`.
- Uses the existing `system_task` + DataPacket handoff substrate so product plugins own extraction, chunking, embedding, retrieval, and eval policy.
- Exposes corpus/document/chunk identifiers in task output metadata and job summaries when supplied by the caller.

Closes https://github.com/Extra-Chill/data-machine/issues/2488

## Tests
- `php tests/corpus-system-tasks-smoke.php`
- `php tests/system-task-output-packets-smoke.php`
- `php tests/system-task-contract-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/System/Tasks/Corpus/CorpusPacketTask.php inc/Engine/AI/System/Tasks/Corpus/CorpusIndexTask.php inc/Engine/AI/System/Tasks/Corpus/CorpusRefreshTask.php inc/Engine/AI/System/Tasks/Corpus/CorpusEmbedChunksTask.php inc/Engine/AI/System/Tasks/Corpus/CorpusRetrieveEvalTask.php tests/corpus-system-tasks-smoke.php`

## Remaining risks
- This is a runtime substrate slice only; consumer plugins still need to provide source-specific indexing, embedding, retry, and evaluation workflow steps.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted and verified the generic corpus system task implementation and smoke coverage; Chris remains responsible for review and testing.