### PR TITLE
Preserve typed tool transcripts for wp-ai-client replay

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -115,6 +115,7 @@ class AgentsChatHandler {
 				'tool_policy'          => is_array( $input['tool_policy'] ?? null ) ? $input['tool_policy'] : null,
 				'allow_only'           => is_array( $input['allow_only'] ?? null ) ? $input['allow_only'] : null,
 				'completion_assertions' => is_array( $input['completion_assertions'] ?? null ) ? $input['completion_assertions'] : null,
+				'event_sink'            => $input['event_sink'] ?? null,
 				'session_owner'        => is_array( $input['session_owner'] ?? null ) ? $input['session_owner'] : null,
 				'transcript_owner'     => is_array( $input['transcript_owner'] ?? null ) ? $input['transcript_owner'] : null,
 			)

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -232,6 +232,7 @@ class ChatOrchestrator {
 				'tool_policy'          => is_array( $options['tool_policy'] ?? null ) ? $options['tool_policy'] : null,
 				'allow_only'           => is_array( $options['allow_only'] ?? null ) ? $options['allow_only'] : null,
 				'completion_assertions' => is_array( $options['completion_assertions'] ?? null ) ? $options['completion_assertions'] : null,
+				'event_sink'           => $options['event_sink'] ?? null,
 			)
 		);
 
@@ -865,6 +866,9 @@ class ChatOrchestrator {
 			}
 			if ( is_array( $options['completion_assertions'] ?? null ) ) {
 				$loop_context['completion_assertions'] = $options['completion_assertions'];
+			}
+			if ( isset( $options['event_sink'] ) ) {
+				$loop_context['event_sink'] = $options['event_sink'];
 			}
 			if ( null !== $interrupt_source ) {
 				$loop_context['interrupt_source'] = $interrupt_source;

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -308,7 +308,7 @@ class RequestBuilder {
 	 */
 	private static function wpAiClientHistoryMessage( array $message ): ?\WordPress\AiClient\Messages\DTO\Message {
 		$role  = (string) ( $message['role'] ?? '' );
-		$parts = self::wpAiClientMessageParts( $message['content'] ?? '' );
+		$parts = self::wpAiClientMessagePartsFromMessage( $message );
 		if ( empty( $parts ) ) {
 			return null;
 		}
@@ -353,9 +353,6 @@ class RequestBuilder {
 
 			$role    = (string) ( $message['role'] ?? '' );
 			$content = $message['content'] ?? '';
-			if ( '' === $content || array() === $content ) {
-				continue;
-			}
 
 			if ( 'system' === $role && is_string( $content ) ) {
 				$system_parts[] = $content;
@@ -366,7 +363,7 @@ class RequestBuilder {
 				continue;
 			}
 
-			$candidate_parts = self::wpAiClientMessageParts( $content );
+			$candidate_parts = self::wpAiClientMessagePartsFromMessage( $message );
 			if ( ! empty( $candidate_parts ) ) {
 				$prompt_index = $index;
 				$prompt_parts = $candidate_parts;
@@ -392,6 +389,69 @@ class RequestBuilder {
 			'system_parts' => $system_parts,
 			'history'      => $history,
 		);
+	}
+
+	/**
+	 * Convert a canonical message envelope into wp-ai-client MessagePart objects.
+	 *
+	 * @param array $message Canonical message envelope or legacy role/content message.
+	 * @return array<int,\WordPress\AiClient\Messages\DTO\MessagePart>
+	 */
+	private static function wpAiClientMessagePartsFromMessage( array $message ): array {
+		try {
+			$envelope = \AgentsAPI\AI\WP_Agent_Message::normalize( $message );
+		} catch ( \Throwable $e ) {
+			return self::wpAiClientMessageParts( $message['content'] ?? '' );
+		}
+
+		$type     = (string) ( $envelope['type'] ?? \AgentsAPI\AI\WP_Agent_Message::TYPE_TEXT );
+		$payload  = is_array( $envelope['payload'] ?? null ) ? $envelope['payload'] : array();
+		$metadata = is_array( $envelope['metadata'] ?? null ) ? $envelope['metadata'] : array();
+
+		if ( \AgentsAPI\AI\WP_Agent_Message::TYPE_TOOL_CALL === $type ) {
+			$tool_name = isset( $payload['tool_name'] ) ? (string) $payload['tool_name'] : '';
+			$call_id   = isset( $metadata['tool_call_id'] ) ? (string) $metadata['tool_call_id'] : '';
+			if ( '' === $call_id ) {
+				$call_id = isset( $payload['tool_call_id'] ) ? (string) $payload['tool_call_id'] : '';
+			}
+			if ( '' === $tool_name && '' === $call_id ) {
+				return array();
+			}
+
+			$parameters = is_array( $payload['parameters'] ?? null ) ? $payload['parameters'] : array();
+			return array(
+				new \WordPress\AiClient\Messages\DTO\MessagePart(
+					new \WordPress\AiClient\Tools\DTO\FunctionCall(
+						'' !== $call_id ? $call_id : null,
+						'' !== $tool_name ? $tool_name : null,
+						$parameters
+					)
+				),
+			);
+		}
+
+		if ( \AgentsAPI\AI\WP_Agent_Message::TYPE_TOOL_RESULT === $type ) {
+			$tool_name = isset( $payload['tool_name'] ) ? (string) $payload['tool_name'] : '';
+			$call_id   = isset( $metadata['tool_call_id'] ) ? (string) $metadata['tool_call_id'] : '';
+			if ( '' === $call_id ) {
+				$call_id = isset( $payload['tool_call_id'] ) ? (string) $payload['tool_call_id'] : '';
+			}
+			if ( '' === $tool_name && '' === $call_id ) {
+				return array();
+			}
+
+			return array(
+				new \WordPress\AiClient\Messages\DTO\MessagePart(
+					new \WordPress\AiClient\Tools\DTO\FunctionResponse(
+						'' !== $call_id ? $call_id : null,
+						'' !== $tool_name ? $tool_name : null,
+						$payload
+					)
+				),
+			);
+		}
+
+		return self::wpAiClientMessageParts( $envelope['content'] ?? '' );
 	}
 
 	/**

--- a/tests/Unit/Engine/AI/RequestBuilderMultimodalTest.php
+++ b/tests/Unit/Engine/AI/RequestBuilderMultimodalTest.php
@@ -29,6 +29,8 @@ use DataMachine\Engine\AI\RequestBuilder;
 use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
+use AgentsAPI\AI\WP_Agent_Message;
+use WordPress\AiClient\Messages\DTO\ModelMessage;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\UserMessage;
@@ -274,6 +276,54 @@ class RequestBuilderMultimodalTest extends TestCase {
 		);
 		$this->assertCount( 1, $file_parts, 'Exactly one file MessagePart must flow into the builder' );
 		$this->assertSame( 'image/jpeg', (string) $file_parts[0]->getFile()->getMimeType() );
+	}
+
+	/**
+	 * Tool-call transcripts must survive the canonical envelope → wp-ai-client
+	 * conversion as typed function call/response parts so Responses API providers
+	 * can replay the loop without flattening tool output into plain user text.
+	 */
+	public function test_prompt_context_preserves_tool_call_and_result_parts(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => 'Create the site.',
+			),
+			WP_Agent_Message::toolCall(
+				'',
+				'client/filesystem-write',
+				array( 'path' => 'index.html' ),
+				1,
+				array( 'tool_call_id' => 'call_123' )
+			),
+			WP_Agent_Message::toolResult(
+				'{"success":true}',
+				'client/filesystem-write',
+				array(
+					'success' => true,
+					'result'  => array( 'path' => 'index.html' ),
+				),
+				array( 'tool_call_id' => 'call_123' )
+			),
+		);
+
+		$context = $this->invokePrivate( 'wpAiClientPromptContext', array( $messages ) );
+
+		$this->assertCount( 2, $context['history'], 'Initial user prompt and assistant tool call remain in history' );
+		$this->assertInstanceOf( ModelMessage::class, $context['history'][1] );
+
+		$function_call = $context['history'][1]->getParts()[0]->getFunctionCall();
+		$this->assertNotNull( $function_call, 'Assistant tool call converts to a function call part' );
+		$this->assertSame( 'call_123', $function_call->getId() );
+		$this->assertSame( 'client/filesystem-write', $function_call->getName() );
+		$this->assertSame( array( 'path' => 'index.html' ), $function_call->getArgs() );
+
+		$this->assertCount( 1, $context['prompt_parts'], 'Latest tool result becomes the current prompt part' );
+		$function_response = $context['prompt_parts'][0]->getFunctionResponse();
+		$this->assertNotNull( $function_response, 'Tool result converts to a function response part' );
+		$this->assertSame( 'call_123', $function_response->getId() );
+		$this->assertSame( 'client/filesystem-write', $function_response->getName() );
+		$this->assertTrue( $function_response->getResponse()['success'] );
 	}
 
 	/**

--- a/tests/Unit/Support/WpAiClientTestDoubles.php
+++ b/tests/Unit/Support/WpAiClientTestDoubles.php
@@ -552,20 +552,24 @@ namespace WordPress\AiClient\Messages\DTO {
 			private ?string $text                                                          = null;
 			private ?\WordPress\AiClient\Files\DTO\File $file                              = null;
 			private ?\WordPress\AiClient\Tools\DTO\FunctionCall $function_call             = null;
+			private ?\WordPress\AiClient\Tools\DTO\FunctionResponse $function_response     = null;
 
 			/**
-			 * Accepts a string (text part), a File (file part), or a FunctionCall.
+			 * Accepts a string (text part), a File (file part), a FunctionCall,
+			 * or a FunctionResponse.
 			 * Matches the production MessagePart constructor surface used by Data
 			 * Machine for multimodal vision input.
 			 *
-			 * @param string|\WordPress\AiClient\Files\DTO\File|\WordPress\AiClient\Tools\DTO\FunctionCall|null $content Part content.
-			 * @param \WordPress\AiClient\Tools\DTO\FunctionCall|null                                          $function_call Back-compat positional function call.
+			 * @param string|\WordPress\AiClient\Files\DTO\File|\WordPress\AiClient\Tools\DTO\FunctionCall|\WordPress\AiClient\Tools\DTO\FunctionResponse|null $content Part content.
+			 * @param \WordPress\AiClient\Tools\DTO\FunctionCall|null                                                                                              $function_call Back-compat positional function call.
 			 */
 			public function __construct( $content = null, ?\WordPress\AiClient\Tools\DTO\FunctionCall $function_call = null ) {
 				if ( $content instanceof \WordPress\AiClient\Files\DTO\File ) {
 					$this->file = $content;
 				} elseif ( $content instanceof \WordPress\AiClient\Tools\DTO\FunctionCall ) {
 					$this->function_call = $content;
+				} elseif ( $content instanceof \WordPress\AiClient\Tools\DTO\FunctionResponse ) {
+					$this->function_response = $content;
 				} elseif ( is_string( $content ) ) {
 					$this->text = $content;
 				}
@@ -589,6 +593,10 @@ namespace WordPress\AiClient\Messages\DTO {
 
 			public function getFunctionCall(): ?\WordPress\AiClient\Tools\DTO\FunctionCall {
 				return $this->function_call;
+			}
+
+			public function getFunctionResponse(): ?\WordPress\AiClient\Tools\DTO\FunctionResponse {
+				return $this->function_response;
 			}
 		}
 	}
@@ -633,17 +641,24 @@ namespace WordPress\AiClient\Tools\DTO {
 
 	if ( ! class_exists( FunctionCall::class ) ) {
 		class FunctionCall {
-			private string $name;
+			private ?string $name;
 			private array $args;
 			private ?string $id;
 
-			public function __construct( string $name, array $args = array(), ?string $id = null ) {
-				$this->name = $name;
-				$this->args = $args;
-				$this->id   = $id;
+			public function __construct( ?string $id_or_name = null, $name_or_args = null, $args_or_id = null ) {
+				if ( is_array( $name_or_args ) || null === $name_or_args ) {
+					$this->id   = is_string( $args_or_id ) ? $args_or_id : null;
+					$this->name = $id_or_name;
+					$this->args = is_array( $name_or_args ) ? $name_or_args : array();
+					return;
+				}
+
+				$this->id   = $id_or_name;
+				$this->name = is_string( $name_or_args ) ? $name_or_args : null;
+				$this->args = is_array( $args_or_id ) ? $args_or_id : array();
 			}
 
-			public function getName(): string {
+			public function getName(): ?string {
 				return $this->name;
 			}
 
@@ -653,6 +668,32 @@ namespace WordPress\AiClient\Tools\DTO {
 
 			public function getId(): ?string {
 				return $this->id;
+			}
+		}
+	}
+
+	if ( ! class_exists( FunctionResponse::class ) ) {
+		class FunctionResponse {
+			private ?string $id;
+			private ?string $name;
+			private $response;
+
+			public function __construct( ?string $id = null, ?string $name = null, $response = null ) {
+				$this->id       = $id;
+				$this->name     = $name;
+				$this->response = $response;
+			}
+
+			public function getId(): ?string {
+				return $this->id;
+			}
+
+			public function getName(): ?string {
+				return $this->name;
+			}
+
+			public function getResponse() {
+				return $this->response;
 			}
 		}
 	}

--- a/tests/request-builder-tool-transcript-smoke.php
+++ b/tests/request-builder-tool-transcript-smoke.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Smoke test for RequestBuilder tool-call transcript conversion.
+ *
+ * Run with: php tests/request-builder-tool-transcript-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+require_once __DIR__ . '/bootstrap-unit.php';
+require_once __DIR__ . '/Unit/Support/WpAiClientTestDoubles.php';
+
+use AgentsAPI\AI\WP_Agent_Message;
+use DataMachine\Engine\AI\RequestBuilder;
+use WordPress\AiClient\Messages\DTO\ModelMessage;
+
+function datamachine_request_builder_tool_transcript_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+$messages = array(
+	array(
+		'role'    => 'user',
+		'content' => 'Create the site.',
+	),
+	WP_Agent_Message::toolCall(
+		'',
+		'client/filesystem-write',
+		array( 'path' => 'index.html' ),
+		1,
+		array( 'tool_call_id' => 'call_123' )
+	),
+	WP_Agent_Message::toolResult(
+		'{"success":true}',
+		'client/filesystem-write',
+		array(
+			'success' => true,
+			'result'  => array( 'path' => 'index.html' ),
+		),
+		array( 'tool_call_id' => 'call_123' )
+	),
+);
+
+$reflection = new ReflectionMethod( RequestBuilder::class, 'wpAiClientPromptContext' );
+$context = $reflection->invokeArgs( null, array( $messages ) );
+
+datamachine_request_builder_tool_transcript_assert( 2 === count( $context['history'] ), 'Initial user prompt and assistant tool call remain in history.' );
+datamachine_request_builder_tool_transcript_assert( $context['history'][1] instanceof ModelMessage, 'Assistant tool call remains a model message.' );
+
+$function_call = $context['history'][1]->getParts()[0]->getFunctionCall();
+datamachine_request_builder_tool_transcript_assert( null !== $function_call, 'Assistant tool call converts to a function call part.' );
+datamachine_request_builder_tool_transcript_assert( 'call_123' === $function_call->getId(), 'Function call id is preserved.' );
+datamachine_request_builder_tool_transcript_assert( 'client/filesystem-write' === $function_call->getName(), 'Function call name is preserved.' );
+datamachine_request_builder_tool_transcript_assert( array( 'path' => 'index.html' ) === $function_call->getArgs(), 'Function call parameters are preserved.' );
+
+datamachine_request_builder_tool_transcript_assert( 1 === count( $context['prompt_parts'] ), 'Latest tool result becomes the current prompt part.' );
+$function_response = $context['prompt_parts'][0]->getFunctionResponse();
+datamachine_request_builder_tool_transcript_assert( null !== $function_response, 'Tool result converts to a function response part.' );
+datamachine_request_builder_tool_transcript_assert( 'call_123' === $function_response->getId(), 'Function response id is preserved.' );
+datamachine_request_builder_tool_transcript_assert( 'client/filesystem-write' === $function_response->getName(), 'Function response name is preserved.' );
+datamachine_request_builder_tool_transcript_assert( true === $function_response->getResponse()['success'], 'Function response payload is preserved.' );
+
+echo "RequestBuilder tool transcript smoke passed.\n";


### PR DESCRIPTION
## Summary
- Preserve Agents API typed tool-call and tool-result envelopes when Data Machine converts conversation history into wp-ai-client messages.
- Forward the optional loop event sink through chat orchestration so browser/runtime callers can capture loop diagnostics.
- Add smoke coverage for function-call/function-response replay through the RequestBuilder conversion path.

## Tests
- `php -l inc/Engine/AI/RequestBuilder.php`
- `php -l tests/request-builder-tool-transcript-smoke.php`
- `php tests/request-builder-tool-transcript-smoke.php`
- `php tests/ai-message-envelope-smoke.php`
- `php tests/agents-chat-tool-continuation-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the browser runtime transcript replay failure, drafted the RequestBuilder/test changes, and ran the local verification commands; Chris remains responsible for review and final acceptance.