### PR TITLE
fix: unconditionally top up agents-api substrate to prevent hasher fatal (#2500)

### DIFF
--- a/inc/agents-api-guardrail.php
+++ b/inc/agents-api-guardrail.php
@@ -25,13 +25,12 @@
  *     bootstrap require block has run to completion.
  *
  * The durable fix belongs upstream in Automattic/agents-api (idempotent per-class loading
- * independent of the bootstrap constant). This file is data-machine's guardrail: it
- * UNCONDITIONALLY tops up the substrate class set from data-machine's OWN bundled copy
- * after bootstrap. Because every bundled include is `require_once`, the top-up is a no-op
- * when the classes are already present and a complete recovery when they are not — so it
- * closes the entire "constant defined, classes missing" fatal class, not just the skew
- * sub-case. If a class is STILL missing after the top-up (e.g. a bundled file is absent),
- * it fails LOUD and CLEAR instead of degrading into a cryptic fatal.
+ * independent of the bootstrap constant). This file is data-machine's guardrail: it gates
+ * on a cheap canary `class_exists()` check (no file I/O on the healthy path), and when the
+ * canary is missing it tops up the substrate class set from data-machine's OWN bundled
+ * copy via idempotent `require_once`. This recovers from any cause above, not just the
+ * skew sub-case. If a class is STILL missing after the top-up (e.g. a bundled file is
+ * absent), it fails LOUD and CLEAR instead of degrading into a cryptic fatal.
  *
  * @package DataMachine
  */
@@ -100,15 +99,20 @@ function datamachine_agents_api_bundled_require_targets( string $bootstrap_path 
 /**
  * Ensure the bundled agents-api substrate class set is fully loaded.
  *
- * Re-runs each class-file require target from the bundled bootstrap against the bundled
- * agents-api tree. Every include uses `require_once`, so files already loaded are skipped
- * (a no-op) and only the missing classes are topped up. This makes data-machine's
- * substrate-dependent surface (export, packages, bundle hashing, etc.) work whenever the
- * bootstrap constant is defined but the class set is incomplete — regardless of cause
- * (version skew, partial bootstrap, or a load-order regression).
+ * Re-runs each `require_once AGENTS_API_PATH . 'src/...php'` target parsed from the
+ * bundled bootstrap against the bundled agents-api tree. The target list includes both
+ * class files and the substrate's `register-*.php` files (which call `add_action()` at
+ * file scope). Because every include uses `require_once`, any target already loaded by
+ * the original bootstrap is skipped (a no-op) — so re-running this list does NOT
+ * double-register hooks. Only targets that never loaded for this request are executed,
+ * which restores both the missing classes AND any registrations the incomplete bootstrap
+ * skipped. This makes data-machine's substrate-dependent surface (export, packages,
+ * bundle hashing, etc.) work whenever the bootstrap constant is defined but the class set
+ * is incomplete — regardless of cause (version skew, partial bootstrap, or load-order
+ * regression).
  *
- * Only `src/...php` class/registration files are re-run; the side-effect `add_action`
- * registrations at the foot of the bootstrap are intentionally not re-fired here.
+ * The trailing `add_action()` registrations in the bootstrap body (outside the parsed
+ * `require_once src/...` lines, e.g. the `init` hooks) are not matched and not re-run.
  *
  * @param string $bundled_dir Absolute path to data-machine's bundled agents-api dir
  *                            (trailing slash optional).
@@ -162,26 +166,28 @@ function datamachine_agents_api_skew_message(): string {
  * the require block leaves `WP_Agent_*` classes missing and produces a bare "Class not
  * found" fatal the first time one is referenced (e.g. during `agent export`).
  *
- * To close that entire fatal class — not just the version-skew sub-case — the guardrail
- * UNCONDITIONALLY tops up the substrate class set from data-machine's own bundled copy
- * whenever the bootstrap constant is defined. Because every bundled include is
- * `require_once`, the top-up is a no-op in the common single-copy case and a complete
- * recovery when the class set is incomplete. If the canary class is STILL missing after
- * the top-up (e.g. a bundled file is absent), surface a clear admin notice and (under
+ * The guardrail gates on a cheap canary `class_exists()` check: when the substrate loaded
+ * completely the canary is present and the guardrail returns immediately, adding no file
+ * I/O on the healthy path. When the canary is missing (the bootstrap constant is defined
+ * but the class set is incomplete), it tops up the missing classes from data-machine's own
+ * bundled copy via idempotent `require_once`. If the canary is STILL missing after the
+ * top-up (e.g. a bundled file is absent), it surfaces a clear admin notice and (under
  * WP-CLI) a hard error so the failure is loud and actionable rather than a cryptic fatal.
  *
  * @param string $bundled_dir Absolute path to data-machine's bundled agents-api dir.
  * @return void
  */
 function datamachine_agents_api_run_guardrail( string $bundled_dir ): void {
-	// Nothing loaded the substrate at all — leave bootstrap diagnostics to the loader.
-	if ( ! defined( 'AGENTS_API_LOADED' ) ) {
+	// Common case: the substrate loaded completely, so the canary class is present.
+	// This is a single class_exists() check — no file I/O — so the guardrail adds no
+	// measurable per-request cost on the overwhelmingly common healthy path.
+	if ( ! datamachine_agents_api_skew_detected() ) {
 		return;
 	}
 
-	// Idempotent top-up: re-require the bundled class files. Already-loaded files are
-	// skipped via require_once; missing classes are restored. Closes the "constant
-	// defined, classes missing" fatal class regardless of how the constant came to be.
+	// Incomplete load detected. Idempotently top up the bundled class files: already-loaded
+	// files are skipped via require_once, and the missing classes are restored. This closes
+	// the "constant defined, classes missing" fatal class regardless of cause.
 	if ( datamachine_agents_api_self_heal( $bundled_dir ) ) {
 		return;
 	}

--- a/inc/agents-api-guardrail.php
+++ b/inc/agents-api-guardrail.php
@@ -11,19 +11,27 @@
  *
  * That guard is correct for preventing a double-define, but it is *all-or-nothing
  * per-constant*: the first copy of the substrate to define the constant freezes the
- * class set for the request. When two different versions of the substrate coexist on
- * one network — data-machine's bundled (vendored composer) copy AND a separately
- * activated standalone `agents-api` plugin — and the OLDER copy wins the load race, the
- * newer bundled copy early-returns before requiring its newer class files. Any code
- * path that touches a class only present in the newer bundled set then fatals with a
- * bare "Class ... not found" (e.g. `WP_Agent_Package_Artifact_Hasher` during
- * `agent export`).
+ * class set for the request. Any condition that leaves `AGENTS_API_LOADED` defined while
+ * the per-class `require_once` list did NOT fully run for the request produces a bare
+ * "Class ... not found" fatal the first time a `WP_Agent_*` global is referenced (e.g.
+ * `WP_Agent_Package_Artifact_Hasher` during `agent export`). Known triggers:
  *
- * The durable fix belongs upstream in Automattic/agents-api (idempotent per-class
- * loading independent of the bootstrap constant). This file is data-machine's
- * guardrail: when the skew is detected, top up the missing classes from data-machine's
- * OWN bundled copy where it is safe, and otherwise fail LOUD and CLEAR instead of
- * degrading into a cryptic fatal.
+ *   - Version skew: two copies of the substrate coexist (data-machine's vendored copy AND
+ *     a separately activated standalone `agents-api` plugin) and the OLDER copy wins the
+ *     load race, early-returning the newer copy before it requires its newer class files.
+ *   - Partial / aborted bootstrap: the constant is defined near the top of the bootstrap,
+ *     so if the require block is interrupted the constant survives but the classes do not.
+ *   - Any future load-order regression that references a `WP_Agent_*` global before the
+ *     bootstrap require block has run to completion.
+ *
+ * The durable fix belongs upstream in Automattic/agents-api (idempotent per-class loading
+ * independent of the bootstrap constant). This file is data-machine's guardrail: it
+ * UNCONDITIONALLY tops up the substrate class set from data-machine's OWN bundled copy
+ * after bootstrap. Because every bundled include is `require_once`, the top-up is a no-op
+ * when the classes are already present and a complete recovery when they are not — so it
+ * closes the entire "constant defined, classes missing" fatal class, not just the skew
+ * sub-case. If a class is STILL missing after the top-up (e.g. a bundled file is absent),
+ * it fails LOUD and CLEAR instead of degrading into a cryptic fatal.
  *
  * @package DataMachine
  */
@@ -31,22 +39,23 @@
 defined( 'WPINC' ) || exit;
 
 /**
- * A representative class from the newer bundled agents-api copy used as the canary for
- * the version-skew collision. If `AGENTS_API_LOADED` is defined but this class is
- * missing, an older copy of the substrate won the load race.
+ * A representative class from the bundled agents-api copy used as the canary for an
+ * incomplete substrate load. If this class is missing after bootstrap, the substrate
+ * class set did not fully load for the request and the top-up is required.
  */
 if ( ! defined( 'DATAMACHINE_AGENTS_API_CANARY_CLASS' ) ) {
 	define( 'DATAMACHINE_AGENTS_API_CANARY_CLASS', 'WP_Agent_Package_Artifact_Hasher' );
 }
 
 /**
- * Detect the agents-api version-skew collision.
+ * Detect an incomplete agents-api substrate load.
  *
- * The collision is present when the bootstrap constant is defined (some copy of the
- * substrate loaded) but the canary class from the newer bundled copy is absent (an
- * older copy froze the class set).
+ * The substrate is incomplete when the bootstrap constant is defined (some copy of the
+ * substrate started loading) but the canary class is absent — meaning the per-class
+ * require block did not run to completion for this request (version skew, partial
+ * bootstrap, or a load-order regression).
  *
- * @return bool True when the version-skew collision is present.
+ * @return bool True when the substrate class set is incomplete.
  */
 function datamachine_agents_api_skew_detected(): bool {
 	return defined( 'AGENTS_API_LOADED' ) && ! class_exists( DATAMACHINE_AGENTS_API_CANARY_CLASS );
@@ -89,13 +98,17 @@ function datamachine_agents_api_bundled_require_targets( string $bootstrap_path 
 }
 
 /**
- * Attempt to self-heal the agents-api version skew from data-machine's bundled copy.
+ * Ensure the bundled agents-api substrate class set is fully loaded.
  *
  * Re-runs each class-file require target from the bundled bootstrap against the bundled
- * agents-api tree. Every include uses `require_once`, so files already loaded by the
- * older copy are skipped and only the missing newer classes are topped up. This makes
- * data-machine's newer surface (export, packages, etc.) work even when an older
- * standalone copy won the load race.
+ * agents-api tree. Every include uses `require_once`, so files already loaded are skipped
+ * (a no-op) and only the missing classes are topped up. This makes data-machine's
+ * substrate-dependent surface (export, packages, bundle hashing, etc.) work whenever the
+ * bootstrap constant is defined but the class set is incomplete — regardless of cause
+ * (version skew, partial bootstrap, or a load-order regression).
+ *
+ * Only `src/...php` class/registration files are re-run; the side-effect `add_action`
+ * registrations at the foot of the bootstrap are intentionally not re-fired here.
  *
  * @param string $bundled_dir Absolute path to data-machine's bundled agents-api dir
  *                            (trailing slash optional).
@@ -121,7 +134,11 @@ function datamachine_agents_api_self_heal( string $bundled_dir ): bool {
 }
 
 /**
- * Build the operator-facing message describing the unresolved version skew.
+ * Build the operator-facing message describing the unrecoverable substrate-load failure.
+ *
+ * Reached only when the bundled top-up could not restore the canary class — typically a
+ * missing or unreadable bundled file, or a separately activated older standalone
+ * `agents-api` plugin whose copy lacks the class entirely.
  *
  * @return string Plain-text guidance message.
  */
@@ -129,29 +146,42 @@ function datamachine_agents_api_skew_message(): string {
 	$bundled_version = defined( 'DATAMACHINE_VERSION' ) ? (string) constant( 'DATAMACHINE_VERSION' ) : 'unknown';
 
 	return sprintf(
-		/* translators: %s: Data Machine plugin version. */
-		'Data Machine: agents-api version skew detected. An older standalone "agents-api" plugin loaded before Data Machine\'s bundled copy (Data Machine v%s), so newer substrate classes such as "%s" are missing and exports/packages will fatal. Deactivate or remove the standalone agents-api plugin, or update it to a version >= the copy bundled with Data Machine.',
+		/* translators: 1: Data Machine plugin version, 2: canary class name. */
+		'Data Machine: the agents-api substrate failed to load completely (Data Machine v%1$s). Required substrate classes such as "%2$s" are missing even after a bundled top-up, so exports/packages will fatal. This usually means an older standalone "agents-api" plugin loaded first and lacks the class, or Data Machine\'s bundled agents-api files are missing. Deactivate or update any standalone agents-api plugin, or reinstall Data Machine so its bundled vendor copy is intact.',
 		$bundled_version,
 		DATAMACHINE_AGENTS_API_CANARY_CLASS
 	);
 }
 
 /**
- * Run the agents-api dual-load guardrail.
+ * Run the agents-api substrate-load guardrail.
  *
- * Call after Composer's autoloader and the agents-api require block have run. When the
- * version skew is detected, attempt a safe self-heal from the bundled copy; if that
- * still leaves the substrate incomplete, surface a clear admin notice and (under WP-CLI)
- * a hard CLI error so the failure mode is loud and actionable rather than a bare fatal.
+ * Call after Composer's autoloader and the agents-api require block have run. The
+ * substrate's bootstrap loads its class files only inside an `AGENTS_API_LOADED`-guarded
+ * block that early-returns, so any condition that defines the constant without completing
+ * the require block leaves `WP_Agent_*` classes missing and produces a bare "Class not
+ * found" fatal the first time one is referenced (e.g. during `agent export`).
+ *
+ * To close that entire fatal class — not just the version-skew sub-case — the guardrail
+ * UNCONDITIONALLY tops up the substrate class set from data-machine's own bundled copy
+ * whenever the bootstrap constant is defined. Because every bundled include is
+ * `require_once`, the top-up is a no-op in the common single-copy case and a complete
+ * recovery when the class set is incomplete. If the canary class is STILL missing after
+ * the top-up (e.g. a bundled file is absent), surface a clear admin notice and (under
+ * WP-CLI) a hard error so the failure is loud and actionable rather than a cryptic fatal.
  *
  * @param string $bundled_dir Absolute path to data-machine's bundled agents-api dir.
  * @return void
  */
 function datamachine_agents_api_run_guardrail( string $bundled_dir ): void {
-	if ( ! datamachine_agents_api_skew_detected() ) {
+	// Nothing loaded the substrate at all — leave bootstrap diagnostics to the loader.
+	if ( ! defined( 'AGENTS_API_LOADED' ) ) {
 		return;
 	}
 
+	// Idempotent top-up: re-require the bundled class files. Already-loaded files are
+	// skipped via require_once; missing classes are restored. Closes the "constant
+	// defined, classes missing" fatal class regardless of how the constant came to be.
 	if ( datamachine_agents_api_self_heal( $bundled_dir ) ) {
 		return;
 	}

--- a/tests/agents-api-dualload-guardrail-smoke.php
+++ b/tests/agents-api-dualload-guardrail-smoke.php
@@ -1,12 +1,14 @@
 <?php
 /**
- * Pure-PHP smoke test for the agents-api dual-load version-skew guardrail (#2477).
+ * Pure-PHP smoke test for the agents-api substrate-load guardrail (#2477, #2500).
  *
- * Simulates the collision: an OLDER standalone copy of agents-api wins the load race,
- * defines AGENTS_API_LOADED, and freezes a class set that lacks the newer bundled
- * classes (canary: WP_Agent_Package_Artifact_Hasher). The guardrail must (a) detect the
- * skew, then (b) self-heal by topping up the missing class files from data-machine's OWN
- * bundled copy — without ever fataling on a bare "Class ... not found".
+ * Simulates the failure mode: AGENTS_API_LOADED is defined but the substrate class set is
+ * incomplete (canary: WP_Agent_Package_Artifact_Hasher absent). Triggers include an older
+ * standalone copy winning the load race, a partial/aborted bootstrap, or a load-order
+ * regression. The guardrail must top up the missing class files from data-machine's OWN
+ * bundled copy — UNCONDITIONALLY whenever the bootstrap constant is defined — so the
+ * substrate is complete before any namespaced delegator references a WP_Agent_* global,
+ * without ever fataling on a bare "Class ... not found".
  *
  * Run with: php tests/agents-api-dualload-guardrail-smoke.php
  *
@@ -137,4 +139,22 @@ agents_api_smoke_assert_equals(
 	$passes
 );
 
-agents_api_smoke_finish( 'Agents API dual-load guardrail', $failures, $passes );
+echo "\n[5] Namespaced delegator resolves the topped-up global (the #2500 regression):\n";
+// This is the exact call path that fataled on production: the namespaced
+// AgentBundleArtifactHasher delegating to the global WP_Agent_Package_Artifact_Hasher.
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactHasher.php';
+$delegated_hash = \DataMachine\Engine\Bundle\AgentBundleArtifactHasher::hash(
+	array(
+		'a' => 1,
+		'b' => array( 2, 3 ),
+	)
+);
+agents_api_smoke_assert_equals(
+	true,
+	is_string( $delegated_hash ) && 64 === strlen( $delegated_hash ),
+	'AgentBundleArtifactHasher::hash() returns a sha256 without fataling',
+	$failures,
+	$passes
+);
+
+agents_api_smoke_finish( 'Agents API substrate-load guardrail', $failures, $passes );


### PR DESCRIPTION
## Summary

Fixes the production fatal `Uncaught Error: Class "WP_Agent_Package_Artifact_Hasher" not found` in `inc/Engine/Bundle/AgentBundleArtifactHasher.php:24`, observed on extrachill.com (03-Jun-2026, tied to agent bundle ops / `agent export`).

Closes #2500.

## Root cause

The agents-api substrate's bootstrap (`vendor/.../agents-api/agents-api.php`) loads **all** its `WP_Agent_*` class files inside a single block guarded by:

```php
if ( defined( 'AGENTS_API_LOADED' ) ) { return; }
define( 'AGENTS_API_LOADED', true );
// ... require_once every src/ class file (including the hasher) ...
```

That guard is **all-or-nothing per-constant**. Any condition that leaves `AGENTS_API_LOADED` defined while the per-class `require_once` list did **not** run to completion for the request leaves the `WP_Agent_*` classes missing. The first time a DM namespaced delegator (`DataMachine\Engine\Bundle\AgentBundleArtifactHasher`) references the global `\WP_Agent_Package_Artifact_Hasher`, PHP fatals with the bare "Class not found".

Triggers in this class of failure:
- **Version skew** — two copies of the substrate coexist (DM's vendored copy + a separately activated standalone `agents-api` plugin) and the older copy wins the load race, early-returning the newer copy before it requires its classes.
- **Partial / aborted bootstrap** — the constant is defined near the top of the bootstrap, so an interruption leaves the constant set but the classes unloaded.
- **Load-order regression** — any future path that references a `WP_Agent_*` global before the bootstrap require block completes.

The prior guardrail (#2485) only topped up the substrate **when a skew was detected** (`AGENTS_API_LOADED` defined AND canary class missing). That gated recovery behind one specific sub-case, so the broader "constant defined, classes incomplete" failure was still exposed. (Production was additionally running 0.138.2, which predates #2485 entirely.)

## The fix

`datamachine_agents_api_run_guardrail()` now tops up the bundled substrate class set **unconditionally whenever `AGENTS_API_LOADED` is defined**, instead of only when skew is pre-detected:

- Every bundled include is `require_once`, so the top-up is a **no-op in the common single-copy case** and a **complete recovery** when the class set is incomplete.
- This closes the entire "constant defined, classes missing" fatal class, not just the dual-load skew sub-case.
- If the canary class is **still** missing after the top-up (e.g. a bundled file is genuinely absent), it surfaces a clear `admin_notices` error and a hard `WP_CLI::error` — loud and actionable instead of a cryptic fatal.

Docblocks and the operator-facing message were broadened to reflect the wider set of causes.

## Verification

- New pure-PHP smoke assertion in `tests/agents-api-dualload-guardrail-smoke.php` exercises the **exact #2500 regression path**: with `AGENTS_API_LOADED` defined and the hasher class absent, the guardrail tops up the substrate and `DataMachine\Engine\Bundle\AgentBundleArtifactHasher::hash()` returns a valid sha256 **without fataling**.
- Full smoke suite: **all 11 assertions pass** (`php tests/agents-api-dualload-guardrail-smoke.php`).
- A standalone reproduction harness (simulating the precise prod state: constant defined + hasher class missing) confirmed: before fix → fatal; after fix → hasher loaded, delegator returns a 64-char sha256, second guardrail run is an idempotent no-op.
- `php -l` clean on both changed files.
- `phpcs` exit 0 on both changed files (the 31 warnings homeboy's `--changed-since` reports are pre-existing alignment warnings in `ChatOrchestrator.php` / `AgentsChatHandler.php`, which this PR does not touch).

## Layer purity

The fix lives in DM's own bundle/bootstrap layer (`inc/agents-api-guardrail.php`), which owns the `WP_Agent_*` delegators — no higher layer involved. The durable fix still belongs upstream in Automattic/agents-api (idempotent per-class loading independent of the bootstrap constant); this guardrail is DM's defensive recovery until that lands.