### PR TITLE
Adapt runtime tool broker contracts

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -818,12 +818,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "824a01be4c0758936d136b688396b4f1439daf6f"
+                "reference": "21987be9b4d68d02040df9df6de2ec3fa2d9bbd0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/824a01be4c0758936d136b688396b4f1439daf6f",
-                "reference": "824a01be4c0758936d136b688396b4f1439daf6f",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/21987be9b4d68d02040df9df6de2ec3fa2d9bbd0",
+                "reference": "21987be9b4d68d02040df9df6de2ec3fa2d9bbd0",
                 "shasum": ""
             },
             "require": {
@@ -938,7 +938,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-06-04T13:51:48+00:00"
+            "time": "2026-06-04T14:41:00+00:00"
         }
     ],
     "packages-dev": [

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1239,17 +1239,17 @@ function datamachine_defer_runtime_tool_call( array $request, array $payload ): 
 			),
 			'metadata'     => array(
 				'datamachine' => array(
-					'job_id'          => (int) $job_id,
+					'job_id'             => (int) $job_id,
 					'persistence_status' => 'pending',
-					'session_id'      => (string) ( $request['session_id'] ?? '' ),
-					'user_id'         => (int) ( $payload['user_id'] ?? 0 ),
-					'agent_id'        => (int) ( $payload['agent_id'] ?? 0 ),
-					'mode'            => (string) ( $request['mode'] ?? '' ),
-					'modes'           => is_array( $request['modes'] ?? null ) ? $request['modes'] : array(),
-					'turn_count'      => (int) ( $request['turn_count'] ?? 0 ),
-					'created_at'      => $created_at,
-					'expires_at'      => $expires_at,
-					'timeout_seconds' => $timeout_seconds,
+					'session_id'         => (string) ( $request['session_id'] ?? '' ),
+					'user_id'            => (int) ( $payload['user_id'] ?? 0 ),
+					'agent_id'           => (int) ( $payload['agent_id'] ?? 0 ),
+					'mode'               => (string) ( $request['mode'] ?? '' ),
+					'modes'              => is_array( $request['modes'] ?? null ) ? $request['modes'] : array(),
+					'turn_count'         => (int) ( $request['turn_count'] ?? 0 ),
+					'created_at'         => $created_at,
+					'expires_at'         => $expires_at,
+					'timeout_seconds'    => $timeout_seconds,
 				),
 			),
 		)
@@ -1332,8 +1332,8 @@ function datamachine_runtime_tool_request_store(): WP_Agent_Runtime_Tool_Request
 				$datamachine_metadata['persistence_status'] = ! empty( $result['success'] ) ? 'fulfilled' : 'failed';
 				$datamachine_metadata['fulfilled_at']       = gmdate( 'c' );
 				$datamachine_metadata['result']             = $result;
-				$request['metadata']['datamachine']          = $datamachine_metadata;
-				$engine_data['runtime_tool_request']         = $request;
+				$request['metadata']['datamachine']         = $datamachine_metadata;
+				$engine_data['runtime_tool_request']        = $request;
 
 				$jobs_db->store_engine_data( $job_id, $engine_data );
 				$jobs_db->complete_job( $job_id, ! empty( $result['success'] ) ? 'completed' : 'failed' );
@@ -1447,11 +1447,14 @@ function datamachine_submit_runtime_tool_result( string $request_id, $result ): 
 
 	$metadata = is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array();
 	if ( is_array( $metadata['runtime_tool_requests'] ?? null ) && isset( $metadata['runtime_tool_requests'][ $request_id ] ) ) {
-		$request_metadata                                          = datamachine_runtime_tool_datamachine_metadata( $metadata['runtime_tool_requests'][ $request_id ] );
-		$request_metadata['persistence_status']                    = ! empty( $tool_result['success'] ) ? 'fulfilled' : 'failed';
-		$request_metadata['fulfilled_at']                          = gmdate( 'c' );
-		$request_metadata['result']                                = $canonical_result;
-		$metadata['runtime_tool_requests'][ $request_id ]['metadata']['datamachine'] = $request_metadata;
+		$session_request                        = $metadata['runtime_tool_requests'][ $request_id ];
+		$request_metadata                       = datamachine_runtime_tool_datamachine_metadata( $session_request );
+		$request_metadata['persistence_status'] = ! empty( $tool_result['success'] ) ? 'fulfilled' : 'failed';
+		$request_metadata['fulfilled_at']       = gmdate( 'c' );
+		$request_metadata['result']             = $canonical_result;
+
+		$session_request['metadata']['datamachine']       = $request_metadata;
+		$metadata['runtime_tool_requests'][ $request_id ] = $session_request;
 	}
 	$metadata['runtime_tool_last_result'] = array(
 		'request_id' => $request_id,

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -21,6 +21,9 @@ use AgentsAPI\AI\WP_Agent_Transcript_Persister;
 use AgentsAPI\AI\WP_Agent_Message;
 use AgentsAPI\AI\WP_Agent_Null_Transcript_Persister;
 use AgentsAPI\AI\WP_Agent_Provider_Turn_Request;
+use AgentsAPI\AI\WP_Agent_Runtime_Tool_Request;
+use AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Store;
+use AgentsAPI\AI\WP_Agent_Runtime_Tool_Result;
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Executor;
 use DataMachine\Core\JobArtifacts;
 use DataMachine\Core\PluginSettings;
@@ -1220,33 +1223,40 @@ function datamachine_defer_runtime_tool_call( array $request, array $payload ): 
 	$request_id      = 'runtime_tool_' . (int) $job_id;
 	$client_context  = is_array( $payload['client_context'] ?? null ) ? $payload['client_context'] : array();
 	$timeout_seconds = max( 5, (int) ( $client_context['runtime_tool_timeout'] ?? 300 ) );
-	$pending_request = array(
-		'request_id'      => $request_id,
-		'job_id'          => (int) $job_id,
-		'status'          => 'pending',
-		'tool_name'       => (string) ( $request['tool_name'] ?? '' ),
-		'call_id'         => (string) ( $request['call_id'] ?? '' ),
-		'parameters'      => is_array( $request['parameters'] ?? null ) ? $request['parameters'] : array(),
-		'turn_count'      => (int) ( $request['turn_count'] ?? 0 ),
-		'session_id'      => (string) ( $request['session_id'] ?? '' ),
-		'user_id'         => (int) ( $payload['user_id'] ?? 0 ),
-		'agent_id'        => (int) ( $payload['agent_id'] ?? 0 ),
-		'mode'            => (string) ( $request['mode'] ?? '' ),
-		'modes'           => is_array( $request['modes'] ?? null ) ? $request['modes'] : array(),
-		'created_at'      => gmdate( 'c' ),
-		'expires_at'      => gmdate( 'c', time() + $timeout_seconds ),
-		'timeout_seconds' => $timeout_seconds,
+	$created_at      = gmdate( 'c' );
+	$expires_at      = gmdate( 'c', time() + $timeout_seconds );
+	$pending_request = WP_Agent_Runtime_Tool_Request::normalize(
+		array(
+			'request_id'   => $request_id,
+			'tool_name'    => (string) ( $request['tool_name'] ?? '' ),
+			'tool_call_id' => (string) ( $request['call_id'] ?? $request_id ),
+			'parameters'   => is_array( $request['parameters'] ?? null ) ? $request['parameters'] : array(),
+			'run_id'       => (string) ( $request['session_id'] ?? '' ),
+			'timeout_at'   => $expires_at,
+			'runtime'      => array(
+				'executor' => 'client',
+				'scope'    => 'run',
+			),
+			'metadata'     => array(
+				'datamachine' => array(
+					'job_id'          => (int) $job_id,
+					'persistence_status' => 'pending',
+					'session_id'      => (string) ( $request['session_id'] ?? '' ),
+					'user_id'         => (int) ( $payload['user_id'] ?? 0 ),
+					'agent_id'        => (int) ( $payload['agent_id'] ?? 0 ),
+					'mode'            => (string) ( $request['mode'] ?? '' ),
+					'modes'           => is_array( $request['modes'] ?? null ) ? $request['modes'] : array(),
+					'turn_count'      => (int) ( $request['turn_count'] ?? 0 ),
+					'created_at'      => $created_at,
+					'expires_at'      => $expires_at,
+					'timeout_seconds' => $timeout_seconds,
+				),
+			),
+		)
 	);
 
 	$jobs_db->start_job( (int) $job_id, 'pending_runtime_tool' );
-	$jobs_db->store_engine_data(
-		(int) $job_id,
-		array(
-			'task_type'            => 'runtime_tool_request',
-			'runtime_tool_request' => $pending_request,
-		)
-	);
-	datamachine_store_runtime_tool_request_on_session( $pending_request );
+	datamachine_runtime_tool_request_store()->create( $pending_request );
 
 	if ( function_exists( 'as_schedule_single_action' ) ) {
 		as_schedule_single_action( time() + $timeout_seconds, 'datamachine_runtime_tool_timeout', array( $request_id ), 'datamachine-runtime-tools' );
@@ -1265,13 +1275,105 @@ function datamachine_defer_runtime_tool_call( array $request, array $payload ): 
 	);
 }
 
+/** Return Data Machine's Agents API runtime-tool request store adapter. */
+function datamachine_runtime_tool_request_store(): WP_Agent_Runtime_Tool_Request_Store {
+	static $store = null;
+
+	if ( ! $store instanceof WP_Agent_Runtime_Tool_Request_Store ) {
+		$store = new class() implements WP_Agent_Runtime_Tool_Request_Store {
+			public function create( array $request ): void {
+				$job_id = datamachine_runtime_tool_job_id_from_request( $request );
+				if ( $job_id <= 0 ) {
+					return;
+				}
+
+				$jobs_db = new \DataMachine\Core\Database\Jobs\Jobs();
+				$jobs_db->store_engine_data(
+					$job_id,
+					array(
+						'task_type'            => 'runtime_tool_request',
+						'runtime_tool_request' => $request,
+					)
+				);
+				datamachine_store_runtime_tool_request_on_session( $request );
+			}
+
+			public function get( string $request_id ): ?array {
+				$job_id = datamachine_runtime_tool_job_id_from_request_id( $request_id );
+				if ( $job_id <= 0 ) {
+					return null;
+				}
+
+				$engine_data = ( new \DataMachine\Core\Database\Jobs\Jobs() )->retrieve_engine_data( $job_id );
+				$request     = is_array( $engine_data['runtime_tool_request'] ?? null ) ? $engine_data['runtime_tool_request'] : array();
+				if ( empty( $request ) ) {
+					return null;
+				}
+
+				return WP_Agent_Runtime_Tool_Request::normalize( $request );
+			}
+
+			public function complete( string $request_id, array $result ): void {
+				$job_id = datamachine_runtime_tool_job_id_from_request_id( $request_id );
+				if ( $job_id <= 0 ) {
+					return;
+				}
+
+				$jobs_db     = new \DataMachine\Core\Database\Jobs\Jobs();
+				$engine_data = $jobs_db->retrieve_engine_data( $job_id );
+				$request     = is_array( $engine_data['runtime_tool_request'] ?? null ) ? $engine_data['runtime_tool_request'] : array();
+				if ( empty( $request ) ) {
+					return;
+				}
+
+				$datamachine_metadata                       = datamachine_runtime_tool_datamachine_metadata( $request );
+				$datamachine_metadata['persistence_status'] = ! empty( $result['success'] ) ? 'fulfilled' : 'failed';
+				$datamachine_metadata['fulfilled_at']       = gmdate( 'c' );
+				$datamachine_metadata['result']             = $result;
+				$request['metadata']['datamachine']          = $datamachine_metadata;
+				$engine_data['runtime_tool_request']         = $request;
+
+				$jobs_db->store_engine_data( $job_id, $engine_data );
+				$jobs_db->complete_job( $job_id, ! empty( $result['success'] ) ? 'completed' : 'failed' );
+			}
+
+			public function timeout( string $request_id ): void {
+				$request = $this->get( $request_id );
+				if ( null === $request ) {
+					return;
+				}
+
+				$this->complete(
+					$request_id,
+					WP_Agent_Runtime_Tool_Result::normalize(
+						array(
+							'request_id' => $request_id,
+							'tool_name'  => (string) ( $request['tool_name'] ?? '' ),
+							'success'    => false,
+							'error'      => 'Client runtime tool request timed out.',
+							'metadata'   => array(
+								'datamachine' => array(
+									'code' => WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT,
+								),
+							),
+						)
+					)
+				);
+			}
+		};
+	}
+
+	return $store;
+}
+
 /**
  * Store pending runtime tool request metadata on the owning chat session.
  *
  * @param array<string,mixed> $pending_request Pending request metadata.
  */
 function datamachine_store_runtime_tool_request_on_session( array $pending_request ): void {
-	$session_id = (string) ( $pending_request['session_id'] ?? '' );
+	$datamachine_metadata = datamachine_runtime_tool_datamachine_metadata( $pending_request );
+	$session_id           = (string) ( $datamachine_metadata['session_id'] ?? '' );
 	if ( '' === $session_id || ! class_exists( \DataMachine\Core\Database\Chat\ConversationStoreFactory::class ) ) {
 		return;
 	}
@@ -1308,20 +1410,20 @@ function datamachine_store_runtime_tool_request_on_session( array $pending_reque
  * @return array<string,mixed>|\WP_Error Submission result.
  */
 function datamachine_submit_runtime_tool_result( string $request_id, $result ): array|\WP_Error {
-	$job_id = datamachine_runtime_tool_job_id_from_request_id( $request_id );
-	if ( $job_id <= 0 ) {
+	$store   = datamachine_runtime_tool_request_store();
+	$request = $store->get( $request_id );
+	if ( null === $request ) {
 		return new \WP_Error( 'runtime_tool_request_invalid', 'Runtime tool request id is invalid.' );
 	}
 
-	$jobs_db     = new \DataMachine\Core\Database\Jobs\Jobs();
-	$engine_data = $jobs_db->retrieve_engine_data( $job_id );
-	$request     = is_array( $engine_data['runtime_tool_request'] ?? null ) ? $engine_data['runtime_tool_request'] : array();
-	if ( empty( $request ) || 'pending' !== (string) ( $request['status'] ?? '' ) ) {
+	$datamachine_metadata = datamachine_runtime_tool_datamachine_metadata( $request );
+	if ( 'pending' !== (string) ( $datamachine_metadata['persistence_status'] ?? '' ) ) {
 		return new \WP_Error( 'runtime_tool_request_not_pending', 'Runtime tool request is not pending.' );
 	}
 
-	$tool_result = datamachine_normalize_runtime_tool_result( (string) ( $request['tool_name'] ?? '' ), $result );
-	$session_id  = (string) ( $request['session_id'] ?? '' );
+	$canonical_result = datamachine_normalize_runtime_tool_submission( $request_id, (string) ( $request['tool_name'] ?? '' ), $result );
+	$tool_result      = datamachine_runtime_tool_result_for_transcript( $canonical_result );
+	$session_id       = (string) ( $datamachine_metadata['session_id'] ?? '' );
 	if ( '' === $session_id || ! class_exists( \DataMachine\Core\Database\Chat\ConversationStoreFactory::class ) ) {
 		return new \WP_Error( 'runtime_tool_session_missing', 'Runtime tool request has no resumable chat session.' );
 	}
@@ -1338,14 +1440,16 @@ function datamachine_submit_runtime_tool_result( string $request_id, $result ): 
 		$tool_result,
 		is_array( $request['parameters'] ?? null ) ? $request['parameters'] : array(),
 		false,
-		(int) ( $request['turn_count'] ?? 0 )
+		(int) ( $datamachine_metadata['turn_count'] ?? 0 )
 	);
 
 	$metadata = is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array();
 	if ( is_array( $metadata['runtime_tool_requests'] ?? null ) && isset( $metadata['runtime_tool_requests'][ $request_id ] ) ) {
-		$metadata['runtime_tool_requests'][ $request_id ]['status']       = ! empty( $tool_result['success'] ) ? 'fulfilled' : 'failed';
-		$metadata['runtime_tool_requests'][ $request_id ]['fulfilled_at'] = gmdate( 'c' );
-		$metadata['runtime_tool_requests'][ $request_id ]['result']       = $tool_result;
+		$request_metadata                                          = datamachine_runtime_tool_datamachine_metadata( $metadata['runtime_tool_requests'][ $request_id ] );
+		$request_metadata['persistence_status']                    = ! empty( $tool_result['success'] ) ? 'fulfilled' : 'failed';
+		$request_metadata['fulfilled_at']                          = gmdate( 'c' );
+		$request_metadata['result']                                = $canonical_result;
+		$metadata['runtime_tool_requests'][ $request_id ]['metadata']['datamachine'] = $request_metadata;
 	}
 	$metadata['runtime_tool_last_result'] = array(
 		'request_id' => $request_id,
@@ -1365,12 +1469,7 @@ function datamachine_submit_runtime_tool_result( string $request_id, $result ): 
 		(string) ( $session['model'] ?? '' )
 	);
 
-	$request['status']                   = ! empty( $tool_result['success'] ) ? 'fulfilled' : 'failed';
-	$request['fulfilled_at']             = gmdate( 'c' );
-	$request['result']                   = $tool_result;
-	$engine_data['runtime_tool_request'] = $request;
-	$jobs_db->store_engine_data( $job_id, $engine_data );
-	$jobs_db->complete_job( $job_id, ! empty( $tool_result['success'] ) ? 'completed' : 'failed' );
+	$store->complete( $request_id, $canonical_result );
 
 	if ( function_exists( 'as_enqueue_async_action' ) ) {
 		as_enqueue_async_action( 'datamachine_runtime_tool_resume', array( $request_id ), 'datamachine-runtime-tools' );
@@ -1381,40 +1480,41 @@ function datamachine_submit_runtime_tool_result( string $request_id, $result ): 
 	return array(
 		'success'    => true,
 		'request_id' => $request_id,
-		'job_id'     => $job_id,
+		'job_id'     => datamachine_runtime_tool_job_id_from_request_id( $request_id ),
 		'scheduled'  => function_exists( 'as_enqueue_async_action' ),
 	);
 }
 
 /** Resume a deferred runtime tool conversation. */
 function datamachine_resume_runtime_tool_request( string $request_id ): void {
-	$job_id = datamachine_runtime_tool_job_id_from_request_id( $request_id );
-	if ( $job_id <= 0 || ! class_exists( \DataMachine\Api\Chat\ChatOrchestrator::class ) ) {
+	if ( ! class_exists( \DataMachine\Api\Chat\ChatOrchestrator::class ) ) {
 		return;
 	}
 
-	$engine_data = ( new \DataMachine\Core\Database\Jobs\Jobs() )->retrieve_engine_data( $job_id );
-	$request     = is_array( $engine_data['runtime_tool_request'] ?? null ) ? $engine_data['runtime_tool_request'] : array();
-	if ( empty( $request ) || 'pending' === (string) ( $request['status'] ?? '' ) ) {
+	$request = datamachine_runtime_tool_request_store()->get( $request_id );
+	if ( null === $request ) {
+		return;
+	}
+	$datamachine_metadata = datamachine_runtime_tool_datamachine_metadata( $request );
+	if ( 'pending' === (string) ( $datamachine_metadata['persistence_status'] ?? '' ) ) {
 		return;
 	}
 
 	\DataMachine\Api\Chat\ChatOrchestrator::processContinue(
-		(string) ( $request['session_id'] ?? '' ),
-		(int) ( $request['user_id'] ?? 0 )
+		(string) ( $datamachine_metadata['session_id'] ?? '' ),
+		(int) ( $datamachine_metadata['user_id'] ?? 0 )
 	);
 }
 
 /** Fail and resume an expired runtime tool request. */
 function datamachine_timeout_runtime_tool_request( string $request_id ): void {
-	$job_id = datamachine_runtime_tool_job_id_from_request_id( $request_id );
-	if ( $job_id <= 0 ) {
+	$request = datamachine_runtime_tool_request_store()->get( $request_id );
+	if ( null === $request ) {
 		return;
 	}
 
-	$engine_data = ( new \DataMachine\Core\Database\Jobs\Jobs() )->retrieve_engine_data( $job_id );
-	$request     = is_array( $engine_data['runtime_tool_request'] ?? null ) ? $engine_data['runtime_tool_request'] : array();
-	if ( empty( $request ) || 'pending' !== (string) ( $request['status'] ?? '' ) ) {
+	$datamachine_metadata = datamachine_runtime_tool_datamachine_metadata( $request );
+	if ( 'pending' !== (string) ( $datamachine_metadata['persistence_status'] ?? '' ) ) {
 		return;
 	}
 
@@ -1427,7 +1527,7 @@ function datamachine_timeout_runtime_tool_request( string $request_id ): void {
 /** @param array<string,mixed> $metadata Session metadata. */
 function datamachine_session_has_pending_runtime_tools( array $metadata ): bool {
 	foreach ( (array) ( $metadata['runtime_tool_requests'] ?? array() ) as $request ) {
-		if ( is_array( $request ) && 'pending' === (string) ( $request['status'] ?? '' ) ) {
+		if ( is_array( $request ) && 'pending' === (string) ( datamachine_runtime_tool_datamachine_metadata( $request )['persistence_status'] ?? '' ) ) {
 			return true;
 		}
 	}
@@ -1441,6 +1541,29 @@ function datamachine_runtime_tool_job_id_from_request_id( string $request_id ): 
 	}
 
 	return max( 0, (int) substr( $request_id, strlen( 'runtime_tool_' ) ) );
+}
+
+/** @param array<string,mixed> $request Canonical runtime tool request. */
+function datamachine_runtime_tool_job_id_from_request( array $request ): int {
+	$metadata = datamachine_runtime_tool_datamachine_metadata( $request );
+	$job_id   = (int) ( $metadata['job_id'] ?? 0 );
+
+	return $job_id > 0 ? $job_id : datamachine_runtime_tool_job_id_from_request_id( (string) ( $request['request_id'] ?? '' ) );
+}
+
+/**
+ * Read Data Machine-owned metadata from a canonical runtime-tool payload.
+ *
+ * @param array<string,mixed> $payload Canonical runtime-tool request or result.
+ * @return array<string,mixed>
+ */
+function datamachine_runtime_tool_datamachine_metadata( array $payload ): array {
+	$metadata = is_array( $payload['metadata'] ?? null ) ? $payload['metadata'] : array();
+	if ( is_array( $metadata['datamachine'] ?? null ) ) {
+		return $metadata['datamachine'];
+	}
+
+	return array();
 }
 
 if ( function_exists( 'add_action' ) ) {
@@ -1492,6 +1615,99 @@ function datamachine_normalize_runtime_tool_result( string $tool_name, $result )
 		'executor'  => 'client',
 		'result'    => $result,
 	);
+}
+
+/**
+ * Normalize an async client-submitted runtime tool result through Agents API.
+ *
+ * @param string $request_id Canonical request id.
+ * @param string $tool_name Tool name.
+ * @param mixed  $result Raw client result.
+ * @return array<string,mixed> Canonical runtime tool result.
+ */
+function datamachine_normalize_runtime_tool_submission( string $request_id, string $tool_name, $result ): array {
+	$datamachine_metadata = array();
+
+	if ( $result instanceof \WP_Error ) {
+		$datamachine_metadata['code'] = $result->get_error_code();
+		return WP_Agent_Runtime_Tool_Result::normalize(
+			array(
+				'request_id' => $request_id,
+				'tool_name'  => $tool_name,
+				'success'    => false,
+				'error'      => $result->get_error_message(),
+				'metadata'   => array( 'datamachine' => $datamachine_metadata ),
+			)
+		);
+	}
+
+	if ( null === $result ) {
+		$datamachine_metadata['code'] = 'runtime_tool_unfulfilled';
+		return WP_Agent_Runtime_Tool_Result::normalize(
+			array(
+				'request_id' => $request_id,
+				'tool_name'  => $tool_name,
+				'success'    => false,
+				'error'      => sprintf( 'Client runtime tool "%s" did not return a result.', $tool_name ),
+				'metadata'   => array( 'datamachine' => $datamachine_metadata ),
+			)
+		);
+	}
+
+	if ( is_array( $result ) ) {
+		$success = array_key_exists( 'success', $result ) ? (bool) $result['success'] : true;
+		$payload = $result['result'] ?? $result['data'] ?? $result;
+		$error   = $result['error'] ?? 'Runtime tool execution failed.';
+		if ( isset( $result['code'] ) && is_string( $result['code'] ) ) {
+			$datamachine_metadata['code'] = $result['code'];
+		}
+
+		return WP_Agent_Runtime_Tool_Result::normalize(
+			array(
+				'request_id' => $request_id,
+				'tool_name'  => is_string( $result['tool_name'] ?? null ) ? $result['tool_name'] : $tool_name,
+				'success'    => $success,
+				'result'     => $payload,
+				'error'      => $error,
+				'metadata'   => array( 'datamachine' => $datamachine_metadata ),
+			)
+		);
+	}
+
+	return WP_Agent_Runtime_Tool_Result::normalize(
+		array(
+			'request_id' => $request_id,
+			'tool_name'  => $tool_name,
+			'success'    => true,
+			'result'     => $result,
+			'metadata'   => array( 'datamachine' => $datamachine_metadata ),
+		)
+	);
+}
+
+/**
+ * Convert a canonical async result into Data Machine's transcript tool result.
+ *
+ * @param array<string,mixed> $canonical_result Canonical runtime tool result.
+ * @return array<string,mixed> Transcript-compatible tool result.
+ */
+function datamachine_runtime_tool_result_for_transcript( array $canonical_result ): array {
+	$tool_result = array(
+		'success'   => ! empty( $canonical_result['success'] ),
+		'tool_name' => (string) ( $canonical_result['tool_name'] ?? '' ),
+		'executor'  => 'client',
+		'result'    => is_array( $canonical_result['result'] ?? null ) ? $canonical_result['result'] : ( $canonical_result['result'] ?? array() ),
+	);
+
+	if ( empty( $tool_result['success'] ) ) {
+		$tool_result['error'] = (string) ( $canonical_result['error'] ?? 'Runtime tool execution failed.' );
+		$metadata             = datamachine_runtime_tool_datamachine_metadata( $canonical_result );
+		if ( isset( $metadata['code'] ) && is_string( $metadata['code'] ) ) {
+			$tool_result['code'] = $metadata['code'];
+		}
+	}
+
+	return $tool_result;
 }
 
 /** @return array<int,string> */

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1305,12 +1305,14 @@ function datamachine_runtime_tool_request_store(): WP_Agent_Runtime_Tool_Request
 				}
 
 				$engine_data = ( new \DataMachine\Core\Database\Jobs\Jobs() )->retrieve_engine_data( $job_id );
-				$request     = is_array( $engine_data['runtime_tool_request'] ?? null ) ? $engine_data['runtime_tool_request'] : array();
+				$request     = is_array( $engine_data['runtime_tool_request'] ?? null )
+					? datamachine_normalize_stored_runtime_tool_request( $engine_data['runtime_tool_request'] )
+					: null;
 				if ( empty( $request ) ) {
 					return null;
 				}
 
-				return WP_Agent_Runtime_Tool_Request::normalize( $request );
+				return $request;
 			}
 
 			public function complete( string $request_id, array $result ): void {
@@ -1552,6 +1554,51 @@ function datamachine_runtime_tool_job_id_from_request( array $request ): int {
 }
 
 /**
+ * Normalize a stored runtime-tool request, including rows persisted before the canonical request contract.
+ *
+ * @param array<string,mixed> $request Stored request payload.
+ * @return array<string,mixed>|null Canonical request or null when invalid.
+ */
+function datamachine_normalize_stored_runtime_tool_request( array $request ): ?array {
+	$metadata             = is_array( $request['metadata'] ?? null ) ? $request['metadata'] : array();
+	$datamachine_metadata = datamachine_runtime_tool_datamachine_metadata( $request );
+	$legacy_status        = is_string( $request['status'] ?? null ) ? $request['status'] : '';
+
+	foreach ( array( 'job_id', 'session_id', 'user_id', 'agent_id', 'mode', 'modes', 'turn_count', 'created_at', 'expires_at', 'timeout_seconds', 'fulfilled_at', 'result' ) as $key ) {
+		if ( ! array_key_exists( $key, $datamachine_metadata ) && array_key_exists( $key, $request ) ) {
+			$datamachine_metadata[ $key ] = $request[ $key ];
+		}
+	}
+
+	if ( ! isset( $datamachine_metadata['persistence_status'] ) && '' !== $legacy_status ) {
+		$datamachine_metadata['persistence_status'] = WP_Agent_Runtime_Tool_Request::STATUS_PENDING === $legacy_status ? 'pending' : $legacy_status;
+	}
+
+	$metadata['datamachine'] = $datamachine_metadata;
+
+	try {
+		return WP_Agent_Runtime_Tool_Request::normalize(
+			array(
+				'request_id'   => (string) ( $request['request_id'] ?? '' ),
+				'tool_name'    => (string) ( $request['tool_name'] ?? '' ),
+				'tool_call_id' => (string) ( $request['tool_call_id'] ?? $request['call_id'] ?? $request['request_id'] ?? '' ),
+				'parameters'   => is_array( $request['parameters'] ?? null ) ? $request['parameters'] : array(),
+				'run_id'       => (string) ( $request['run_id'] ?? $request['session_id'] ?? '' ),
+				'timeout_at'   => (string) ( $request['timeout_at'] ?? $request['expires_at'] ?? '' ),
+				'runtime'      => is_array( $request['runtime'] ?? null ) ? $request['runtime'] : array(
+					'executor' => 'client',
+					'scope'    => 'run',
+				),
+				'metadata'     => $metadata,
+			)
+		);
+	} catch ( \InvalidArgumentException $e ) {
+		unset( $e );
+		return null;
+	}
+}
+
+/**
  * Read Data Machine-owned metadata from a canonical runtime-tool payload.
  *
  * @param array<string,mixed> $payload Canonical runtime-tool request or result.
@@ -1561,6 +1608,21 @@ function datamachine_runtime_tool_datamachine_metadata( array $payload ): array 
 	$metadata = is_array( $payload['metadata'] ?? null ) ? $payload['metadata'] : array();
 	if ( is_array( $metadata['datamachine'] ?? null ) ) {
 		return $metadata['datamachine'];
+	}
+
+	$legacy = array();
+	foreach ( array( 'job_id', 'session_id', 'user_id', 'agent_id', 'mode', 'modes', 'turn_count', 'created_at', 'expires_at', 'timeout_seconds', 'fulfilled_at', 'result' ) as $key ) {
+		if ( array_key_exists( $key, $payload ) ) {
+			$legacy[ $key ] = $payload[ $key ];
+		}
+	}
+
+	if ( isset( $payload['status'] ) && is_string( $payload['status'] ) ) {
+		$legacy['persistence_status'] = WP_Agent_Runtime_Tool_Request::STATUS_PENDING === $payload['status'] ? 'pending' : $payload['status'];
+	}
+
+	if ( ! empty( $legacy ) ) {
+		return $legacy;
 	}
 
 	return array();

--- a/tests/runtime-tool-async-broker-smoke.php
+++ b/tests/runtime-tool-async-broker-smoke.php
@@ -35,8 +35,20 @@ datamachine_runtime_async_assert(
 	$passes
 );
 datamachine_runtime_async_assert(
+	str_contains( $loop_source, 'WP_Agent_Runtime_Tool_Request::normalize' ) && str_contains( $loop_source, 'WP_Agent_Runtime_Tool_Request_Store' ),
+	'pending runtime tool requests normalize through the Agents API request/store contracts',
+	$failures,
+	$passes
+);
+datamachine_runtime_async_assert(
 	str_contains( $loop_source, "'source'      => 'runtime_tool'" ) && str_contains( $loop_source, "'pending_runtime_tool'" ),
 	'deferred runtime tool requests are represented as Data Machine jobs',
+	$failures,
+	$passes
+);
+datamachine_runtime_async_assert(
+	str_contains( $loop_source, "'metadata'     => array" ) && str_contains( $loop_source, "'datamachine' => array" ) && str_contains( $loop_source, "'persistence_status' => 'pending'" ),
+	'Data Machine runtime tool request metadata is namespaced under metadata.datamachine',
 	$failures,
 	$passes
 );
@@ -53,8 +65,20 @@ datamachine_runtime_async_assert(
 	$passes
 );
 datamachine_runtime_async_assert(
+	str_contains( $loop_source, 'WP_Agent_Runtime_Tool_Result::normalize' ) && str_contains( $loop_source, 'datamachine_normalize_runtime_tool_submission' ),
+	'submitted runtime tool results normalize through the Agents API result contract',
+	$failures,
+	$passes
+);
+datamachine_runtime_async_assert(
 	str_contains( $loop_source, 'as_enqueue_async_action' ) && str_contains( $loop_source, 'datamachine_runtime_tool_resume' ),
 	'submitted runtime tool results enqueue async conversation resume',
+	$failures,
+	$passes
+);
+datamachine_runtime_async_assert(
+	str_contains( $loop_source, 'public function create( array $request ): void' ) && str_contains( $loop_source, 'public function get( string $request_id ): ?array' ) && str_contains( $loop_source, 'public function complete( string $request_id, array $result ): void' ) && str_contains( $loop_source, 'public function timeout( string $request_id ): void' ),
+	'Data Machine provides a complete Agents API runtime tool request store adapter',
 	$failures,
 	$passes
 );

--- a/tests/runtime-tool-contract-store-smoke.php
+++ b/tests/runtime-tool-contract-store-smoke.php
@@ -104,6 +104,7 @@ namespace {
 	use DataMachine\Core\Database\Jobs\Jobs;
 	use function DataMachine\Engine\AI\datamachine_defer_runtime_tool_call;
 	use function DataMachine\Engine\AI\datamachine_runtime_tool_request_store;
+	use function DataMachine\Engine\AI\datamachine_session_has_pending_runtime_tools;
 	use function DataMachine\Engine\AI\datamachine_submit_runtime_tool_result;
 	use function DataMachine\Engine\AI\datamachine_timeout_runtime_tool_request;
 
@@ -231,6 +232,33 @@ namespace {
 	$assert( 'failed' === ( $timeout_stored['metadata']['datamachine']['persistence_status'] ?? '' ), 'timeout marks namespaced Data Machine status failed' );
 	$assert( 'runtime_tool_timeout' === ( $timeout_stored['metadata']['datamachine']['result']['metadata']['datamachine']['code'] ?? '' ), 'timeout stores canonical error result metadata' );
 	$assert( 'failed' === ( Jobs::$jobs[2]['status'] ?? '' ), 'timeout fails the Data Machine job' );
+
+	$chat_db->sessions['legacy-session'] = array( 'messages' => array(), 'metadata' => array(), 'provider' => 'openai', 'model' => 'gpt' );
+	Jobs::$jobs[3]                       = array( 'status' => 'pending_runtime_tool' );
+	Jobs::$engine_data[3]                = array(
+		'task_type'            => 'runtime_tool_request',
+		'runtime_tool_request' => array(
+			'request_id'      => 'runtime_tool_3',
+			'job_id'          => 3,
+			'status'          => 'pending',
+			'tool_name'       => 'client/legacy_select',
+			'call_id'         => 'legacy-call-1',
+			'parameters'      => array( 'label' => 'Legacy' ),
+			'turn_count'      => 5,
+			'session_id'      => 'legacy-session',
+			'user_id'         => 7,
+			'created_at'      => gmdate( 'c' ),
+			'expires_at'      => gmdate( 'c', time() + 30 ),
+			'timeout_seconds' => 30,
+		),
+	);
+	$legacy_request                      = datamachine_runtime_tool_request_store()->get( 'runtime_tool_3' );
+	$assert( 'legacy-call-1' === ( $legacy_request['tool_call_id'] ?? '' ), 'store adapter normalizes legacy call_id to canonical tool_call_id' );
+	$assert( 'pending' === ( $legacy_request['metadata']['datamachine']['persistence_status'] ?? '' ), 'store adapter preserves legacy pending status in namespaced metadata' );
+	$assert( datamachine_session_has_pending_runtime_tools( array( 'runtime_tool_requests' => array( 'runtime_tool_3' => Jobs::$engine_data[3]['runtime_tool_request'] ) ) ), 'pending-session check recognizes legacy request metadata' );
+	$legacy_submission = datamachine_submit_runtime_tool_result( 'runtime_tool_3', array( 'selected_id' => 'legacy-block' ) );
+	$assert( true === ( $legacy_submission['success'] ?? false ), 'legacy pending request can still be submitted after contract migration' );
+	$assert( 'completed' === ( Jobs::$jobs[3]['status'] ?? '' ), 'legacy pending request submission completes its job' );
 
 	if ( $failures ) {
 		echo "\nFAILED: " . count( $failures ) . " runtime tool contract store assertions failed.\n";

--- a/tests/runtime-tool-contract-store-smoke.php
+++ b/tests/runtime-tool-contract-store-smoke.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Smoke assertions for the runtime-tool Agents API contract store adapter.
+ *
+ * Run with: php tests/runtime-tool-contract-store-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+namespace DataMachine\Core {
+	class PluginSettings {
+		public const DEFAULT_MAX_TURNS = 8;
+	}
+}
+
+namespace DataMachine\Core\Database\Jobs {
+	class Jobs {
+		public static array $jobs        = array();
+		public static array $engine_data = array();
+		public static int $next_id       = 1;
+
+		public function create_job( array $job ): int {
+			$job_id              = self::$next_id++;
+			self::$jobs[ $job_id ] = array_merge( $job, array( 'status' => 'created' ) );
+
+			return $job_id;
+		}
+
+		public function start_job( int $job_id, string $status ): void {
+			self::$jobs[ $job_id ]['status'] = $status;
+		}
+
+		public function store_engine_data( int $job_id, array $data ): void {
+			self::$engine_data[ $job_id ] = $data;
+		}
+
+		public function retrieve_engine_data( int $job_id ): array {
+			return self::$engine_data[ $job_id ] ?? array();
+		}
+
+		public function complete_job( int $job_id, string $status ): void {
+			self::$jobs[ $job_id ]['status'] = $status;
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Chat {
+	class RuntimeToolContractStoreSmokeSessionStore {
+		public array $sessions = array();
+
+		public function get_session( string $session_id ): ?array {
+			return $this->sessions[ $session_id ] ?? null;
+		}
+
+		public function update_session( string $session_id, array $messages, array $metadata, string $provider, string $model ): bool {
+			$this->sessions[ $session_id ] = array_merge(
+				$this->sessions[ $session_id ] ?? array(),
+				array(
+					'messages' => $messages,
+					'metadata' => $metadata,
+					'provider' => $provider,
+					'model'    => $model,
+				)
+			);
+
+			return true;
+		}
+	}
+
+	class ConversationStoreFactory {
+		public static ?RuntimeToolContractStoreSmokeSessionStore $store = null;
+
+		public static function get(): RuntimeToolContractStoreSmokeSessionStore {
+			if ( null === self::$store ) {
+				self::$store = new RuntimeToolContractStoreSmokeSessionStore();
+			}
+
+			return self::$store;
+		}
+	}
+}
+
+namespace DataMachine\Engine\AI {
+	class ConversationManager {
+		public static function formatToolResultMessage( string $tool_name, array $tool_result, array $tool_parameters, bool $is_handler_tool = false, int $turn_count = 0 ): array {
+			unset( $tool_parameters, $is_handler_tool );
+
+			return array(
+				'role'       => 'tool',
+				'tool_name'  => $tool_name,
+				'turn_count' => $turn_count,
+				'payload'    => $tool_result,
+			);
+		}
+	}
+}
+
+namespace {
+	use AgentsAPI\AI\WP_Agent_Runtime_Tool_Request;
+	use AgentsAPI\AI\WP_Agent_Runtime_Tool_Result;
+	use DataMachine\Core\Database\Chat\ConversationStoreFactory;
+	use DataMachine\Core\Database\Jobs\Jobs;
+	use function DataMachine\Engine\AI\datamachine_defer_runtime_tool_call;
+	use function DataMachine\Engine\AI\datamachine_runtime_tool_request_store;
+	use function DataMachine\Engine\AI\datamachine_submit_runtime_tool_result;
+	use function DataMachine\Engine\AI\datamachine_timeout_runtime_tool_request;
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/../' );
+	}
+
+	class WP_Error {
+		private string $code;
+		private string $message;
+
+		public function __construct( string $code, string $message ) {
+			$this->code    = $code;
+			$this->message = $message;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+
+	function current_time( string $type, bool $gmt = false ): string {
+		unset( $type, $gmt );
+
+		return gmdate( 'Y-m-d H:i:s' );
+	}
+
+	$GLOBALS['datamachine_runtime_tool_scheduled'] = array();
+	$GLOBALS['datamachine_runtime_tool_enqueued']  = array();
+
+	function as_schedule_single_action( int $timestamp, string $hook, array $args, string $group ): void {
+		$GLOBALS['datamachine_runtime_tool_scheduled'][] = compact( 'timestamp', 'hook', 'args', 'group' );
+	}
+
+	function as_enqueue_async_action( string $hook, array $args, string $group ): void {
+		$GLOBALS['datamachine_runtime_tool_enqueued'][] = compact( 'hook', 'args', 'group' );
+	}
+
+	function do_action( string $hook, ...$args ): void {
+		unset( $hook, $args );
+	}
+
+	function add_action( string $hook, callable|string $callback ): void {
+		unset( $hook, $callback );
+	}
+
+	require __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-runtime-tool-request.php';
+	require __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-runtime-tool-result.php';
+	require __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-runtime-tool-request-store.php';
+	require __DIR__ . '/../inc/Engine/AI/conversation-loop.php';
+
+	$failures = array();
+	$passes   = 0;
+
+	$assert = static function ( bool $condition, string $message ) use ( &$failures, &$passes ): void {
+		if ( $condition ) {
+			++$passes;
+			echo "  ✓ {$message}\n";
+			return;
+		}
+
+		$failures[] = $message;
+		echo "  ✗ {$message}\n";
+	};
+
+	echo "runtime-tool-contract-store-smoke\n\n";
+
+	$chat_db                              = ConversationStoreFactory::get();
+	$chat_db->sessions['session-1']       = array( 'messages' => array(), 'metadata' => array(), 'provider' => 'openai', 'model' => 'gpt' );
+	$chat_db->sessions['session-timeout'] = array( 'messages' => array(), 'metadata' => array(), 'provider' => 'openai', 'model' => 'gpt' );
+
+	$pending = datamachine_defer_runtime_tool_call(
+		array(
+			'tool_name'  => 'client/select_block',
+			'call_id'    => 'call-1',
+			'parameters' => array( 'label' => 'Hero' ),
+			'turn_count' => 3,
+			'session_id' => 'session-1',
+			'mode'       => 'chat',
+			'modes'      => array( 'chat' ),
+		),
+		array(
+			'user_id'        => 7,
+			'agent_id'       => 11,
+			'client_context' => array( 'runtime_tool_timeout' => 30 ),
+		)
+	);
+
+	$request    = $pending['runtime_tool_request'] ?? array();
+	$request_id = (string) ( $request['request_id'] ?? '' );
+	$assert( WP_Agent_Runtime_Tool_Request::STATUS_PENDING === ( $request['status'] ?? '' ), 'deferred request uses canonical pending status' );
+	$assert( 'call-1' === ( $request['tool_call_id'] ?? '' ), 'deferred request carries canonical tool_call_id' );
+	$assert( 'pending' === ( $request['metadata']['datamachine']['persistence_status'] ?? '' ), 'deferred request keeps Data Machine persistence status namespaced' );
+	$assert( isset( Jobs::$engine_data[1]['runtime_tool_request'] ), 'store adapter persists request in job engine data' );
+	$assert( isset( $chat_db->sessions['session-1']['metadata']['runtime_tool_requests'][ $request_id ] ), 'store adapter mirrors request into session metadata' );
+	$assert( 'datamachine_runtime_tool_timeout' === ( $GLOBALS['datamachine_runtime_tool_scheduled'][0]['hook'] ?? '' ), 'deferred request schedules timeout action' );
+	$assert( null !== datamachine_runtime_tool_request_store()->get( $request_id ), 'store adapter reads the pending request back' );
+
+	$submission = datamachine_submit_runtime_tool_result( $request_id, array( 'selected_id' => 'block-1' ) );
+	$stored     = Jobs::$engine_data[1]['runtime_tool_request'];
+	$assert( true === ( $submission['success'] ?? false ), 'result submission succeeds' );
+	$assert( WP_Agent_Runtime_Tool_Result::STATUS_SUBMITTED === ( $stored['metadata']['datamachine']['result']['status'] ?? '' ), 'submitted result is stored in canonical result shape' );
+	$assert( 'fulfilled' === ( $stored['metadata']['datamachine']['persistence_status'] ?? '' ), 'submitted result completes namespaced Data Machine status' );
+	$assert( 'completed' === ( Jobs::$jobs[1]['status'] ?? '' ), 'successful result completes the Data Machine job' );
+	$assert( 1 === count( $chat_db->sessions['session-1']['messages'] ), 'submitted result appends a transcript tool message' );
+	$assert( false === ( $chat_db->sessions['session-1']['metadata']['has_pending_tools'] ?? true ), 'submitted result clears pending session state' );
+	$assert( 'datamachine_runtime_tool_resume' === ( $GLOBALS['datamachine_runtime_tool_enqueued'][0]['hook'] ?? '' ), 'submitted result enqueues resume action' );
+
+	$timeout_pending = datamachine_defer_runtime_tool_call(
+		array(
+			'tool_name'  => 'client/confirm',
+			'call_id'    => 'call-timeout',
+			'parameters' => array(),
+			'turn_count' => 1,
+			'session_id' => 'session-timeout',
+		),
+		array( 'user_id' => 7, 'agent_id' => 11 )
+	);
+	datamachine_timeout_runtime_tool_request( (string) ( $timeout_pending['runtime_tool_request']['request_id'] ?? '' ) );
+	$timeout_stored = Jobs::$engine_data[2]['runtime_tool_request'];
+	$assert( 'failed' === ( $timeout_stored['metadata']['datamachine']['persistence_status'] ?? '' ), 'timeout marks namespaced Data Machine status failed' );
+	$assert( 'runtime_tool_timeout' === ( $timeout_stored['metadata']['datamachine']['result']['metadata']['datamachine']['code'] ?? '' ), 'timeout stores canonical error result metadata' );
+	$assert( 'failed' === ( Jobs::$jobs[2]['status'] ?? '' ), 'timeout fails the Data Machine job' );
+
+	if ( $failures ) {
+		echo "\nFAILED: " . count( $failures ) . " runtime tool contract store assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$passes} runtime tool contract store assertions passed.\n";
+}

--- a/tests/runtime-tool-contract-store-smoke.php
+++ b/tests/runtime-tool-contract-store-smoke.php
@@ -155,6 +155,7 @@ namespace {
 		unset( $hook, $callback );
 	}
 
+	require __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-citation-metadata.php';
 	require __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-runtime-tool-request.php';
 	require __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-runtime-tool-result.php';
 	require __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-runtime-tool-request-store.php';

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -83,8 +83,26 @@ function did_action( string $hook ): int {
 	return 1;
 }
 
+function doing_action( string $hook ): bool {
+	unset( $hook );
+	return false;
+}
+
 function current_action(): string {
 	return '';
+}
+
+function is_user_logged_in(): bool {
+	return true;
+}
+
+function get_current_user_id(): int {
+	return 1;
+}
+
+function user_can( int $user_id, string $capability ): bool {
+	unset( $user_id, $capability );
+	return true;
 }
 
 function get_option( string $key, $default_value = false ) {
@@ -118,6 +136,7 @@ require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-policy.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-source-registry.php';
 require_once __DIR__ . '/../inc/Core/AbilityResult.php';
+require_once __DIR__ . '/../inc/Abilities/PermissionHelper.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Execution/ToolExecutionCore.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolExecutor.php';


### PR DESCRIPTION
## Summary
- Normalize deferred client/runtime tool requests through `WP_Agent_Runtime_Tool_Request` before persisting them.
- Add a Data Machine job/session-backed `WP_Agent_Runtime_Tool_Request_Store` adapter for create/get/complete/timeout operations.
- Normalize submitted async client results through `WP_Agent_Runtime_Tool_Result` while preserving transcript formatting, timeout handling, session metadata, and resume scheduling.
- Preserve pending runtime-tool requests stored before this migration by canonicalizing legacy `call_id` / top-level metadata rows on read.
- Update the bundled Agents API dependency to include Automattic/agents-api#304, which keeps Data Machine host/source tools visible while preserving client runtime declarations.

Fixes #2499

## Tests
- `php tests/tool-source-registry-smoke.php`
- `php tests/runtime-tool-async-broker-smoke.php`
- `php tests/runtime-tool-contract-store-smoke.php`
- `homeboy --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/data-machine-2504-lint-final.json lint data-machine --path /Users/chubes/Developer/data-machine@issue-2499-runtime-tool-contracts --changed-since origin/main`
- `homeboy --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/data-machine-2504-test-final.json test data-machine --path /Users/chubes/Developer/data-machine@issue-2499-runtime-tool-contracts --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runtime-tool broker contract adapter, focused smoke coverage, persisted-request compatibility fix, upstream Agents API dependency fix, and local verification; Chris remains responsible for review and merge.