### PR TITLE
Add headless agent bundle runner

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -20,6 +20,7 @@ use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Engine\Bundle\AgentBundleDirectory;
 use DataMachine\Engine\Bundle\AgentBundleAbilityService;
 use DataMachine\Engine\Bundle\AgentBundleArtifactRebase;
+use DataMachine\Engine\Bundle\AgentBundleRunner;
 use DataMachine\Engine\Bundle\BundleSource;
 use DataMachine\Engine\Bundle\BundleSourceAuth;
 use DataMachine\Engine\Bundle\BundleValidationException;
@@ -562,6 +563,27 @@ class AgentAbilities {
 					'execute_callback'    => array( self::class, 'resolveAgentBundleUpgradeAction' ),
 					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			self::registerAbility(
+				'datamachine/run-agent-bundle',
+				array(
+					'label'               => 'Run Agent Bundle',
+					'description'         => 'Run a flow from a portable agent bundle as a headless ephemeral workflow without requiring callers to synthesize Data Machine internals.',
+					'category'            => 'datamachine-agent',
+					'input_schema'        => self::runAgentBundleInputSchema(),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'runAgentBundle' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => false,
+						),
+					),
 				)
 			);
 
@@ -1443,8 +1465,68 @@ class AgentAbilities {
 		return self::bundleLifecycleService()->apply_pending_action( (string) ( $input['pending_action_id'] ?? $input['action_id'] ?? '' ) );
 	}
 
+	/**
+	 * Run a bundle flow through Data Machine's headless workflow contract.
+	 *
+	 * @param array $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public static function runAgentBundle( array $input ): array {
+		return ( new AgentBundleRunner() )->run( $input );
+	}
+
 	private static function bundleLifecycleService(): AgentBundleAbilityService {
 		return new AgentBundleAbilityService();
+	}
+
+	/** @return array<string,mixed> */
+	private static function runAgentBundleInputSchema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'source' ),
+			'properties' => array(
+				'source'       => array(
+					'type'        => 'string',
+					'description' => 'Bundle source: local path (directory, .zip, .json) or remote URL.',
+				),
+				'flow'         => array(
+					'type'        => 'string',
+					'description' => 'Optional bundle flow slug. Defaults to the first flow in the bundle.',
+				),
+				'flow_slug'    => array(
+					'type'        => 'string',
+					'description' => 'Alias for flow.',
+				),
+				'initial_data' => array(
+					'type'        => 'object',
+					'description' => 'Initial engine data merged into the ephemeral workflow job.',
+				),
+				'timestamp'    => array(
+					'type'        => array( 'integer', 'null' ),
+					'description' => 'Future Unix timestamp for delayed execution. Omit for immediate execution.',
+				),
+				'dry_run'      => array(
+					'type'        => 'boolean',
+					'description' => 'Return the projected workflow and initial_data without creating a job.',
+				),
+				'token'        => array(
+					'type'        => 'string',
+					'description' => 'Auth token for private archive downloads. Used for this single resolve(); never persisted or logged.',
+				),
+				'token_env'    => array(
+					'type'        => 'string',
+					'description' => 'Environment variable or PHP constant name to read the auth token from.',
+				),
+				'job_source'   => array(
+					'type'        => 'string',
+					'description' => 'Optional job source label. Defaults to agent_bundle.',
+				),
+				'job_label'    => array(
+					'type'        => 'string',
+					'description' => 'Optional job label. Defaults to the selected flow name.',
+				),
+			),
+		);
 	}
 
 	private static function bundleLifecycleInputSchema( bool $include_rebase = false ): array {

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -84,6 +84,64 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	/**
+	 * Run a flow from a portable agent package as a headless ephemeral workflow.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <path>
+	 * : Package path (.zip, .json, or directory) or remote URL.
+	 *
+	 * [--flow=<slug>]
+	 * : Flow slug to run. Defaults to the first flow in the bundle.
+	 *
+	 * [--initial-data=<json>]
+	 * : JSON object merged into the workflow engine data.
+	 *
+	 * [--timestamp=<timestamp>]
+	 * : Future Unix timestamp for delayed execution. Omit for immediate execution.
+	 *
+	 * [--dry-run]
+	 * : Return projected workflow and initial data without creating a job.
+	 *
+	 * [--token=<token>]
+	 * : Auth token for private archive downloads. Used for this single resolve(); never persisted, never logged.
+	 *
+	 * [--token-env=<varname>]
+	 * : Environment variable (or PHP constant) name to read the auth token from. Preferred over --token for shell-history hygiene.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: json
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * @subcommand run-bundle
+	 */
+	public function run_bundle( array $args, array $assoc_args ): void {
+		$source = (string) ( $args[0] ?? '' );
+		if ( '' === $source ) {
+			WP_CLI::error( 'Bundle source is required.' );
+		}
+
+		$input = array(
+			'source'       => $source,
+			'flow'         => (string) ( $assoc_args['flow'] ?? '' ),
+			'initial_data' => $this->json_assoc_arg( $assoc_args, 'initial-data' ),
+			'timestamp'    => isset( $assoc_args['timestamp'] ) ? (int) $assoc_args['timestamp'] : null,
+			'dry_run'      => \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false ),
+			'token'        => (string) ( $assoc_args['token'] ?? '' ),
+			'token_env'    => (string) ( $assoc_args['token-env'] ?? '' ),
+		);
+
+		$result                 = AgentAbilities::runAgentBundle( array_filter( $input, static fn( $value ) => null !== $value && '' !== $value && array() !== $value ) );
+		$assoc_args['format']   = $assoc_args['format'] ?? 'json';
+		$this->output( $result, $assoc_args, array( 'success', 'schema', 'dry_run', 'job_id', 'message', 'error' ) );
+	}
+
+	/**
 	 * List installed package-backed agents.
 	 *
 	 * ## OPTIONS
@@ -695,6 +753,20 @@ class AgentBundleCommand extends BaseCommand {
 		}
 
 		return $bundle;
+	}
+
+	/** @return array<string,mixed> */
+	private function json_assoc_arg( array $assoc_args, string $key ): array {
+		if ( ! isset( $assoc_args[ $key ] ) || '' === trim( (string) $assoc_args[ $key ] ) ) {
+			return array();
+		}
+
+		$decoded = json_decode( (string) $assoc_args[ $key ], true );
+		if ( ! is_array( $decoded ) || array_is_list( $decoded ) ) {
+			WP_CLI::error( sprintf( '--%s must be a JSON object.', $key ) );
+		}
+
+		return $decoded;
 	}
 
 	/**

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -136,8 +136,8 @@ class AgentBundleCommand extends BaseCommand {
 			'token_env'    => (string) ( $assoc_args['token-env'] ?? '' ),
 		);
 
-		$result                 = AgentAbilities::runAgentBundle( array_filter( $input, static fn( $value ) => null !== $value && '' !== $value && array() !== $value ) );
-		$assoc_args['format']   = $assoc_args['format'] ?? 'json';
+		$result               = AgentAbilities::runAgentBundle( array_filter( $input, static fn( $value ) => null !== $value && '' !== $value && array() !== $value ) );
+		$assoc_args['format'] = $assoc_args['format'] ?? 'json';
 		$this->output( $result, $assoc_args, array( 'success', 'schema', 'dry_run', 'job_id', 'message', 'error' ) );
 	}
 

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -57,9 +57,9 @@ final class AgentBundleRunner {
 			'flow_slug'       => (string) ( $selection['flow_slug'] ?? '' ),
 			'pipeline_slug'   => (string) ( $selection['pipeline_slug'] ?? '' ),
 		);
-		$initial_data['agent_slug'] = (string) ( $manifest['agent']['slug'] ?? '' );
-		$initial_data['job_source'] = (string) ( $input['job_source'] ?? 'agent_bundle' );
-		$initial_data['job_label']  = (string) ( $input['job_label'] ?? ( $selection['flow_name'] ?? 'Agent Bundle Workflow' ) );
+		$initial_data['agent_slug']  = (string) ( $manifest['agent']['slug'] ?? '' );
+		$initial_data['job_source']  = (string) ( $input['job_source'] ?? 'agent_bundle' );
+		$initial_data['job_label']   = (string) ( $input['job_label'] ?? ( $selection['flow_name'] ?? 'Agent Bundle Workflow' ) );
 
 		if ( ! empty( $input['dry_run'] ) ) {
 			return array(
@@ -163,7 +163,7 @@ final class AgentBundleRunner {
 			$flow = null;
 			foreach ( $flows as $candidate ) {
 				$data = $candidate->to_array();
-				if ( $requested_slug === (string) ( $data['slug'] ?? '' ) ) {
+				if ( (string) ( $data['slug'] ?? '' ) === $requested_slug ) {
 					$flow = $candidate;
 					break;
 				}
@@ -180,7 +180,7 @@ final class AgentBundleRunner {
 		$pipeline_slug = (string) ( $flow_data['pipeline_slug'] ?? '' );
 		foreach ( $directory->pipelines() as $pipeline ) {
 			$pipeline_data = $pipeline->to_array();
-			if ( $pipeline_slug === (string) ( $pipeline_data['slug'] ?? '' ) ) {
+			if ( (string) ( $pipeline_data['slug'] ?? '' ) === $pipeline_slug ) {
 				return array(
 					'success'       => true,
 					'flow'          => $flow_data,
@@ -210,8 +210,8 @@ final class AgentBundleRunner {
 			if ( ! is_array( $flow_step ) ) {
 				continue;
 			}
-			$position      = (int) ( $flow_step['step_position'] ?? 0 );
-			$pipeline_step = $pipeline_steps[ $position ] ?? array();
+			$position         = (int) ( $flow_step['step_position'] ?? 0 );
+			$pipeline_step    = $pipeline_steps[ $position ] ?? array();
 			$workflow_steps[] = array_merge(
 				is_array( $pipeline_step['step_config'] ?? null ) ? $pipeline_step['step_config'] : array(),
 				$flow_step,

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Headless agent bundle runner.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+use DataMachine\Abilities\Job\ExecuteWorkflowAbility;
+use DataMachine\Core\Agents\AgentBundler;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Converts a portable bundle flow into Data Machine's ephemeral workflow runner.
+ */
+final class AgentBundleRunner {
+
+	private AgentBundler $bundler;
+
+	public function __construct( ?AgentBundler $bundler = null ) {
+		$this->bundler = $bundler ?? new AgentBundler();
+	}
+
+	/** @return array<string,mixed> */
+	public function run( array $input ): array {
+		$source = trim( (string) ( $input['source'] ?? '' ) );
+		if ( '' === $source ) {
+			return array(
+				'success' => false,
+				'error'   => 'Bundle source is required.',
+			);
+		}
+
+		$loaded = $this->load_bundle( $source, $input );
+		if ( empty( $loaded['success'] ) ) {
+			return $loaded;
+		}
+
+		$bundle    = $loaded['bundle'];
+		$directory = AgentBundleArrayAdapter::from_array_bundle( $bundle );
+		$selection = $this->select_flow( $directory, (string) ( $input['flow'] ?? $input['flow_slug'] ?? '' ) );
+		if ( empty( $selection['success'] ) ) {
+			return $selection;
+		}
+
+		$workflow     = $this->workflow_from_bundle_flow( $selection['flow'], $selection['pipeline'] );
+		$initial_data = is_array( $input['initial_data'] ?? null ) ? $input['initial_data'] : array();
+		$manifest     = $directory->manifest()->to_array();
+
+		$initial_data['agent_bundle'] = array(
+			'bundle_slug'     => (string) ( $manifest['bundle_slug'] ?? '' ),
+			'bundle_version'  => (string) ( $manifest['bundle_version'] ?? '' ),
+			'source_ref'      => (string) ( $manifest['source_ref'] ?? $source ),
+			'source_revision' => (string) ( $manifest['source_revision'] ?? ( $loaded['source_revision'] ?? '' ) ),
+			'flow_slug'       => (string) ( $selection['flow_slug'] ?? '' ),
+			'pipeline_slug'   => (string) ( $selection['pipeline_slug'] ?? '' ),
+		);
+		$initial_data['agent_slug'] = (string) ( $manifest['agent']['slug'] ?? '' );
+		$initial_data['job_source'] = (string) ( $input['job_source'] ?? 'agent_bundle' );
+		$initial_data['job_label']  = (string) ( $input['job_label'] ?? ( $selection['flow_name'] ?? 'Agent Bundle Workflow' ) );
+
+		if ( ! empty( $input['dry_run'] ) ) {
+			return array(
+				'success'      => true,
+				'schema'       => 'datamachine/agent-bundle-run/v1',
+				'dry_run'      => true,
+				'bundle'       => $initial_data['agent_bundle'],
+				'workflow'     => $workflow,
+				'initial_data' => $initial_data,
+			);
+		}
+
+		$result = ( new ExecuteWorkflowAbility() )->execute(
+			array(
+				'workflow'     => $workflow,
+				'initial_data' => $initial_data,
+				'timestamp'    => $input['timestamp'] ?? null,
+			)
+		);
+
+		return array_merge(
+			array(
+				'schema'  => 'datamachine/agent-bundle-run/v1',
+				'dry_run' => false,
+				'bundle'  => $initial_data['agent_bundle'],
+			),
+			$result
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private function load_bundle( string $source, array $input ): array {
+		$resolved = BundleSource::resolve( $source, $this->resolve_context( $input ) );
+		if ( is_wp_error( $resolved ) ) {
+			return array(
+				'success' => false,
+				'error'   => $resolved->get_error_message(),
+			);
+		}
+
+		$revision = BundleSource::is_remote( $source ) ? BundleSource::last_resolved_revision() : null;
+		$bundle   = null;
+		try {
+			if ( is_dir( $resolved ) ) {
+				$bundle = $this->bundler->from_directory( $resolved );
+			} elseif ( preg_match( '/\.zip$/i', $resolved ) ) {
+				$bundle = $this->bundler->from_zip( $resolved );
+			} elseif ( preg_match( '/\.json$/i', $resolved ) ) {
+				$bundle = $this->bundler->from_json( (string) file_get_contents( $resolved ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			}
+		} catch ( BundleValidationException $e ) {
+			BundleSource::cleanup( $resolved, $source );
+			return array(
+				'success' => false,
+				'error'   => $e->getMessage(),
+			);
+		}
+
+		BundleSource::cleanup( $resolved, $source );
+		if ( ! is_array( $bundle ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to parse bundle. Use a bundle directory, .json file, or .zip archive.',
+			);
+		}
+		if ( BundleSource::is_remote( $source ) && empty( $bundle['source_ref'] ) ) {
+			$bundle['source_ref'] = $source;
+		}
+		if ( null !== $revision && empty( $bundle['source_revision'] ) ) {
+			$bundle['source_revision'] = $revision;
+		}
+
+		return array(
+			'success'         => true,
+			'bundle'          => $bundle,
+			'source_revision' => $revision,
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private function resolve_context( array $input ): array {
+		$token     = isset( $input['token'] ) ? (string) $input['token'] : null;
+		$token_env = isset( $input['token_env'] ) ? (string) $input['token_env'] : null;
+
+		return BundleSourceAuth::build_resolve_context( $token, $token_env );
+	}
+
+	/** @return array<string,mixed> */
+	private function select_flow( AgentBundleDirectory $directory, string $requested_slug ): array {
+		$flows = $directory->flows();
+		if ( empty( $flows ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Bundle does not contain any flows to run.',
+			);
+		}
+
+		$requested_slug = '' !== $requested_slug ? PortableSlug::normalize( $requested_slug, 'flow' ) : '';
+		$flow           = $flows[0];
+		if ( '' !== $requested_slug ) {
+			$flow = null;
+			foreach ( $flows as $candidate ) {
+				$data = $candidate->to_array();
+				if ( $requested_slug === (string) ( $data['slug'] ?? '' ) ) {
+					$flow = $candidate;
+					break;
+				}
+			}
+			if ( null === $flow ) {
+				return array(
+					'success' => false,
+					'error'   => sprintf( 'Bundle flow "%s" not found.', $requested_slug ),
+				);
+			}
+		}
+
+		$flow_data     = $flow->to_array();
+		$pipeline_slug = (string) ( $flow_data['pipeline_slug'] ?? '' );
+		foreach ( $directory->pipelines() as $pipeline ) {
+			$pipeline_data = $pipeline->to_array();
+			if ( $pipeline_slug === (string) ( $pipeline_data['slug'] ?? '' ) ) {
+				return array(
+					'success'       => true,
+					'flow'          => $flow_data,
+					'flow_slug'     => (string) ( $flow_data['slug'] ?? '' ),
+					'flow_name'     => (string) ( $flow_data['name'] ?? '' ),
+					'pipeline'      => $pipeline_data,
+					'pipeline_slug' => $pipeline_slug,
+				);
+			}
+		}
+
+		return array(
+			'success' => false,
+			'error'   => sprintf( 'Bundle pipeline "%s" for selected flow was not found.', $pipeline_slug ),
+		);
+	}
+
+	/** @return array<string,array<int,array<string,mixed>>> */
+	private function workflow_from_bundle_flow( array $flow, array $pipeline ): array {
+		$pipeline_steps = array();
+		foreach ( $pipeline['steps'] ?? array() as $step ) {
+			$pipeline_steps[ (int) ( $step['step_position'] ?? 0 ) ] = is_array( $step ) ? $step : array();
+		}
+
+		$workflow_steps = array();
+		foreach ( $flow['steps'] ?? array() as $flow_step ) {
+			if ( ! is_array( $flow_step ) ) {
+				continue;
+			}
+			$position      = (int) ( $flow_step['step_position'] ?? 0 );
+			$pipeline_step = $pipeline_steps[ $position ] ?? array();
+			$workflow_steps[] = array_merge(
+				is_array( $pipeline_step['step_config'] ?? null ) ? $pipeline_step['step_config'] : array(),
+				$flow_step,
+				array(
+					'step_type' => (string) ( $flow_step['step_type'] ?? $pipeline_step['step_type'] ?? '' ),
+					'label'     => (string) ( $pipeline_step['name'] ?? $pipeline_step['label'] ?? $flow_step['label'] ?? '' ),
+				)
+			);
+		}
+
+		return array( 'steps' => $workflow_steps );
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -57,9 +57,9 @@ final class AgentBundleRunner {
 			'flow_slug'       => (string) ( $selection['flow_slug'] ?? '' ),
 			'pipeline_slug'   => (string) ( $selection['pipeline_slug'] ?? '' ),
 		);
-		$initial_data['agent_slug']  = (string) ( $manifest['agent']['slug'] ?? '' );
-		$initial_data['job_source']  = (string) ( $input['job_source'] ?? 'agent_bundle' );
-		$initial_data['job_label']   = (string) ( $input['job_label'] ?? ( $selection['flow_name'] ?? 'Agent Bundle Workflow' ) );
+		$initial_data['agent_slug']   = (string) ( $manifest['agent']['slug'] ?? '' );
+		$initial_data['job_source']   = (string) ( $input['job_source'] ?? 'agent_bundle' );
+		$initial_data['job_label']    = (string) ( $input['job_label'] ?? ( $selection['flow_name'] ?? 'Agent Bundle Workflow' ) );
 
 		if ( ! empty( $input['dry_run'] ) ) {
 			return array(

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -51,7 +51,7 @@ foreach ( array(
 	'ExecuteWorkflowAbility'                     => 'runner reuses existing headless workflow executor',
 	"'schema'       => 'datamachine/agent-bundle-run/v1'" => 'runner returns stable response schema',
 	"'dry_run'      => true"                     => 'runner supports dry-run projection without job creation',
-	"\$initial_data['job_source'] = (string) ( \$input['job_source'] ?? 'agent_bundle' );" => 'runner stamps agent_bundle job source by default',
+	"\$initial_data['job_source']  = (string) ( \$input['job_source'] ?? 'agent_bundle' );" => 'runner stamps agent_bundle job source by default',
 ) as $needle => $label ) {
 	datamachine_bundle_runner_contains( $runner, $needle, $label, $failures, $passes );
 }

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -51,7 +51,7 @@ foreach ( array(
 	'ExecuteWorkflowAbility'                     => 'runner reuses existing headless workflow executor',
 	"'schema'       => 'datamachine/agent-bundle-run/v1'" => 'runner returns stable response schema',
 	"'dry_run'      => true"                     => 'runner supports dry-run projection without job creation',
-	"\$initial_data['job_source']  = (string) ( \$input['job_source'] ?? 'agent_bundle' );" => 'runner stamps agent_bundle job source by default',
+	"\$initial_data['job_source']   = (string) ( \$input['job_source'] ?? 'agent_bundle' );" => 'runner stamps agent_bundle job source by default',
 ) as $needle => $label ) {
 	datamachine_bundle_runner_contains( $runner, $needle, $label, $failures, $passes );
 }

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Smoke test for the headless agent bundle runner contract.
+ *
+ * Run with: php tests/agent-bundle-runner-contract-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$root     = dirname( __DIR__ );
+$failures = array();
+$passes   = 0;
+
+function datamachine_bundle_runner_assert( bool $condition, string $label, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "  PASS {$label}\n";
+		return;
+	}
+
+	$failures[] = $label;
+	echo "  FAIL {$label}\n";
+}
+
+function datamachine_bundle_runner_contains( string $source, string $needle, string $label, array &$failures, int &$passes ): void {
+	datamachine_bundle_runner_assert( false !== strpos( $source, $needle ), $label, $failures, $passes );
+}
+
+$abilities = (string) file_get_contents( $root . '/inc/Abilities/AgentAbilities.php' );
+$cli       = (string) file_get_contents( $root . '/inc/Cli/Commands/AgentBundleCommand.php' );
+$runner    = (string) file_get_contents( $root . '/inc/Engine/Bundle/AgentBundleRunner.php' );
+
+echo "agent-bundle-runner-contract-smoke\n";
+
+echo "\n[1] Ability exposes the headless runner contract\n";
+foreach ( array(
+	'datamachine/run-agent-bundle' => 'run-agent-bundle ability registered',
+	'runAgentBundleInputSchema'    => 'dedicated input schema declared',
+	'AgentBundleRunner'            => 'ability delegates to runner service',
+	"'show_in_rest' => true"      => 'ability is REST-visible for headless callers',
+	"'readonly'    => false"      => 'ability marks execution as mutating',
+) as $needle => $label ) {
+	datamachine_bundle_runner_contains( $abilities, $needle, $label, $failures, $passes );
+}
+
+echo "\n[2] Runner projects bundles to ephemeral workflows\n";
+foreach ( array(
+	'AgentBundleArrayAdapter::from_array_bundle' => 'runner consumes portable bundle documents',
+	'BundleSourceAuth::build_resolve_context'    => 'runner shares bundle token resolution with import/install surfaces',
+	'workflow_from_bundle_flow'                  => 'runner converts selected bundle flow to workflow steps',
+	'ExecuteWorkflowAbility'                     => 'runner reuses existing headless workflow executor',
+	"'schema'       => 'datamachine/agent-bundle-run/v1'" => 'runner returns stable response schema',
+	"'dry_run'      => true"                     => 'runner supports dry-run projection without job creation',
+	"\$initial_data['job_source'] = (string) ( \$input['job_source'] ?? 'agent_bundle' );" => 'runner stamps agent_bundle job source by default',
+) as $needle => $label ) {
+	datamachine_bundle_runner_contains( $runner, $needle, $label, $failures, $passes );
+}
+
+echo "\n[3] WP-CLI wraps the same ability instead of duplicating runner internals\n";
+foreach ( array(
+	'@subcommand run-bundle'       => 'run-bundle subcommand declared',
+	'AgentAbilities::runAgentBundle' => 'CLI calls ability callback',
+	'--initial-data=<json>'        => 'CLI accepts JSON initial data',
+	'--dry-run'                    => 'CLI exposes dry-run projection',
+) as $needle => $label ) {
+	datamachine_bundle_runner_contains( $cli, $needle, $label, $failures, $passes );
+}
+
+echo "\n[4] Boundary stays generic\n";
+foreach ( array( 'homeboy', 'wp-codebox' ) as $forbidden ) {
+	datamachine_bundle_runner_assert( false === stripos( $runner, $forbidden ), "runner does not mention {$forbidden}", $failures, $passes );
+}
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " bundle runner assertion(s) failed.\n";
+	exit( 1 );
+}
+
+echo "\nAgent bundle runner contract smoke passed ({$passes} assertions).\n";


### PR DESCRIPTION
## Summary
- Adds `datamachine/run-agent-bundle`, a headless ability that resolves a portable agent bundle, selects a bundle flow, projects it into an ephemeral workflow, and runs it through Data Machine's existing `execute-workflow` path.
- Adds `wp datamachine agent run-bundle` as the WP-CLI wrapper for the same ability, including dry-run projection and JSON `initial_data` support.
- Keeps the boundary generic: this PR does not add Homeboy or WP Codebox coupling. Codebox can consume this primitive inside a sandbox and continue returning generic Codebox task results to Homeboy.

## Why
This makes Data Machine usable as an invisible workflow engine inside headless runtimes like WP Codebox. Parent orchestrators should not synthesize Data Machine flow/pipeline internals; they should call one bundle-runner contract through the runtime that owns the sandbox.

## Verification
- `php -l inc/Engine/Bundle/AgentBundleRunner.php`
- `php -l inc/Abilities/AgentAbilities.php`
- `php -l inc/Cli/Commands/AgentBundleCommand.php`
- `php tests/agent-bundle-runner-contract-smoke.php`
- `php tests/agent-bundle-ability-contract-smoke.php`
- `git diff --check`

## Not run
- `vendor/bin/phpcs ...` because `vendor/bin/phpcs` is not installed in this worktree.

## Related
- Enables a follow-up WP Codebox integration that calls `datamachine/run-agent-bundle` inside the sandbox instead of making Homeboy know Data Machine internals.
- Downstream boundary cleanup follows Automattic/wp-codebox#594 and Extra-Chill/homeboy-extensions#1058.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the headless bundle runner ability/CLI wrapper, adding focused smoke coverage, and running targeted verification; Chris remains responsible for review and merge.