### PR TITLE
fix: bump agents-api lock to restore host tool visibility

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -818,12 +818,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "824a01be4c0758936d136b688396b4f1439daf6f"
+                "reference": "21987be9b4d68d02040df9df6de2ec3fa2d9bbd0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/824a01be4c0758936d136b688396b4f1439daf6f",
-                "reference": "824a01be4c0758936d136b688396b4f1439daf6f",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/21987be9b4d68d02040df9df6de2ec3fa2d9bbd0",
+                "reference": "21987be9b4d68d02040df9df6de2ec3fa2d9bbd0",
                 "shasum": ""
             },
             "require": {
@@ -938,7 +938,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-06-04T13:51:48+00:00"
+            "time": "2026-06-04T14:41:00+00:00"
         }
     ],
     "packages-dev": [
@@ -1634,6 +1634,6 @@
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/Unit/Engine/AI/Tools/ToolPolicyResolverTest.php
+++ b/tests/Unit/Engine/AI/Tools/ToolPolicyResolverTest.php
@@ -115,22 +115,20 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		// filter. Only the use_tools cap is stripped here — chat remains.
 		add_filter( 'user_has_cap', array( $this, 'deny_use_tools_cap' ), 10, 4 );
 
-		add_filter(
-			'datamachine_tools',
-			function ( $tools ) {
-				$tools['test_authenticated_tool'] = array(
-					'label'        => 'Test Authenticated Tool',
-					'description'  => 'Visible to authenticated users.',
-					'class'        => 'NonExistentClass',
-					'method'       => 'handle_tool_call',
-					'parameters'   => array(),
-					'modes'        => array( 'chat' ),
-					'access_level' => 'authenticated',
-				);
+		$tools_filter = function ( $tools ) {
+			$tools['test_authenticated_tool'] = array(
+				'label'        => 'Test Authenticated Tool',
+				'description'  => 'Visible to authenticated users.',
+				'class'        => 'NonExistentClass',
+				'method'       => 'handle_tool_call',
+				'parameters'   => array(),
+				'modes'        => array( 'chat' ),
+				'access_level' => 'authenticated',
+			);
 
-				return $tools;
-			}
-		);
+			return $tools;
+		};
+		add_filter( 'datamachine_tools', $tools_filter );
 
 		ToolManager::clearCache();
 
@@ -146,7 +144,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'test_authenticated_tool', $tools );
 
 		remove_filter( 'user_has_cap', array( $this, 'deny_use_tools_cap' ), 10 );
-		remove_all_filters( 'datamachine_tools' );
+		remove_filter( 'datamachine_tools', $tools_filter );
 		wp_set_current_user( 0 );
 		ToolManager::clearCache();
 	}
@@ -155,22 +153,20 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		add_filter( 'user_has_cap', array( $this, 'deny_all_datamachine_caps' ), 10, 4 );
 		add_filter( 'datamachine_require_use_tools_for_chat_tools', '__return_true' );
 
-		add_filter(
-			'datamachine_tools',
-			function ( $tools ) {
-				$tools['test_authenticated_tool'] = array(
-					'label'        => 'Test Authenticated Tool',
-					'description'  => 'Visible to authenticated users.',
-					'class'        => 'NonExistentClass',
-					'method'       => 'handle_tool_call',
-					'parameters'   => array(),
-					'modes'        => array( 'chat' ),
-					'access_level' => 'authenticated',
-				);
+		$tools_filter = function ( $tools ) {
+			$tools['test_authenticated_tool'] = array(
+				'label'        => 'Test Authenticated Tool',
+				'description'  => 'Visible to authenticated users.',
+				'class'        => 'NonExistentClass',
+				'method'       => 'handle_tool_call',
+				'parameters'   => array(),
+				'modes'        => array( 'chat' ),
+				'access_level' => 'authenticated',
+			);
 
-				return $tools;
-			}
-		);
+			return $tools;
+		};
+		add_filter( 'datamachine_tools', $tools_filter );
 
 		ToolManager::clearCache();
 
@@ -187,7 +183,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 		remove_filter( 'user_has_cap', array( $this, 'deny_all_datamachine_caps' ), 10 );
 		remove_filter( 'datamachine_require_use_tools_for_chat_tools', '__return_true' );
-		remove_all_filters( 'datamachine_tools' );
+		remove_filter( 'datamachine_tools', $tools_filter );
 		wp_set_current_user( 0 );
 		ToolManager::clearCache();
 	}
@@ -195,22 +191,20 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	public function test_chat_allows_public_tools_for_anonymous_users(): void {
 		wp_set_current_user( 0 );
 
-		add_filter(
-			'datamachine_tools',
-			function ( $tools ) {
-				$tools['test_public_tool'] = array(
-					'label'        => 'Test Public Tool',
-					'description'  => 'Visible without login.',
-					'class'        => 'NonExistentClass',
-					'method'       => 'handle_tool_call',
-					'parameters'   => array(),
-					'modes'        => array( 'chat' ),
-					'access_level' => 'public',
-				);
+		$tools_filter = function ( $tools ) {
+			$tools['test_public_tool'] = array(
+				'label'        => 'Test Public Tool',
+				'description'  => 'Visible without login.',
+				'class'        => 'NonExistentClass',
+				'method'       => 'handle_tool_call',
+				'parameters'   => array(),
+				'modes'        => array( 'chat' ),
+				'access_level' => 'public',
+			);
 
-				return $tools;
-			}
-		);
+			return $tools;
+		};
+		add_filter( 'datamachine_tools', $tools_filter );
 
 		ToolManager::clearCache();
 
@@ -222,28 +216,26 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'test_public_tool', $tools );
 
-		remove_all_filters( 'datamachine_tools' );
+		remove_filter( 'datamachine_tools', $tools_filter );
 		ToolManager::clearCache();
 	}
 
 	public function test_chat_keeps_untagged_tools_admin_only_for_anonymous_users(): void {
 		wp_set_current_user( 0 );
 
-		add_filter(
-			'datamachine_tools',
-			function ( $tools ) {
-				$tools['test_untagged_tool'] = array(
-					'label'       => 'Test Untagged Tool',
-					'description' => 'No access metadata.',
-					'class'       => 'NonExistentClass',
-					'method'      => 'handle_tool_call',
-					'parameters'  => array(),
-					'modes'       => array( 'chat' ),
-				);
+		$tools_filter = function ( $tools ) {
+			$tools['test_untagged_tool'] = array(
+				'label'       => 'Test Untagged Tool',
+				'description' => 'No access metadata.',
+				'class'       => 'NonExistentClass',
+				'method'      => 'handle_tool_call',
+				'parameters'  => array(),
+				'modes'       => array( 'chat' ),
+			);
 
-				return $tools;
-			}
-		);
+			return $tools;
+		};
+		add_filter( 'datamachine_tools', $tools_filter );
 
 		ToolManager::clearCache();
 
@@ -255,7 +247,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 		$this->assertArrayNotHasKey( 'test_untagged_tool', $tools );
 
-		remove_all_filters( 'datamachine_tools' );
+		remove_filter( 'datamachine_tools', $tools_filter );
 		ToolManager::clearCache();
 	}
 
@@ -336,20 +328,18 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_system_includes_system_context_tools(): void {
-		add_filter(
-			'datamachine_tools',
-			function ( $tools ) {
-				$tools['test_system_tool'] = array(
-					'label'       => 'Test System Tool',
-					'description' => 'Only available to system tasks.',
-					'class'       => 'NonExistentClass',
-					'method'      => 'handle_tool_call',
-					'parameters'  => array(),
-					'modes'       => array( 'system' ),
-				);
-				return $tools;
-			}
-		);
+		$tools_filter = function ( $tools ) {
+			$tools['test_system_tool'] = array(
+				'label'       => 'Test System Tool',
+				'description' => 'Only available to system tasks.',
+				'class'       => 'NonExistentClass',
+				'method'      => 'handle_tool_call',
+				'parameters'  => array(),
+				'modes'       => array( 'system' ),
+			);
+			return $tools;
+		};
+		add_filter( 'datamachine_tools', $tools_filter );
 
 		ToolManager::clearCache();
 
@@ -361,7 +351,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'test_system_tool', $tools );
 
-		remove_all_filters( 'datamachine_tools' );
+		remove_filter( 'datamachine_tools', $tools_filter );
 		ToolManager::clearCache();
 	}
 
@@ -507,20 +497,18 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	public function test_custom_context_resolves_registered_tools(): void {
 		// Third parties can register tools with custom contexts and
 		// resolve them through the same path as built-in contexts.
-		add_filter(
-			'datamachine_tools',
-			function ( $tools ) {
-				$tools['custom_automation_tool'] = array(
-					'label'       => 'Custom Automation Tool',
-					'description' => 'Only available in the automation context.',
-					'class'       => 'NonExistentClass',
-					'method'      => 'handle_tool_call',
-					'parameters'  => array(),
-					'modes'       => array( 'automation' ),
-				);
-				return $tools;
-			}
-		);
+		$tools_filter = function ( $tools ) {
+			$tools['custom_automation_tool'] = array(
+				'label'       => 'Custom Automation Tool',
+				'description' => 'Only available in the automation context.',
+				'class'       => 'NonExistentClass',
+				'method'      => 'handle_tool_call',
+				'parameters'  => array(),
+				'modes'       => array( 'automation' ),
+			);
+			return $tools;
+		};
+		add_filter( 'datamachine_tools', $tools_filter );
 
 		ToolManager::clearCache();
 
@@ -535,7 +523,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		// Built-in tools that don't declare 'automation' are excluded.
 		$this->assertArrayNotHasKey( 'web_fetch', $tools );
 
-		remove_all_filters( 'datamachine_tools' );
+		remove_filter( 'datamachine_tools', $tools_filter );
 		ToolManager::clearCache();
 	}
 


### PR DESCRIPTION
## Root cause

`ToolPolicyResolver::resolve()` returned **zero tools** for chat/pipeline/system modes under the WP Codebox / Playground test runner, failing **14 `ToolPolicyResolverTest`** cases (`web_fetch` and every host tool missing). It passed in CI only because CI runs scoped test subsets that happen to exclude this file, and passed against the deployed/local agents-api because that copy predates the breaking change.

I traced the resolution pipeline stage-by-stage with throwaway probe tests in the Codebox sandbox:

```
gatherByModes()                 -> 17 tools (web_fetch present)   OK
filter_by_mode('')              -> 17                              OK
filter_by_access_checker()      -> 16 (web_fetch survives)        OK
filter_runtime_tools_by_policy_opt_in()  -> 0                     ALL DROPPED
```

The drop happens in agents-api's `WP_Agent_Tool_Policy_Filter`:

- `WP_Agent_Tool_Declaration::normalizeForServer()` defaults **every** host tool to `executor: 'host'`, `scope: 'run'`.
- `is_runtime_tool()` (at the pinned version) classified any tool with `scope === 'run'` as a caller-provided runtime tool requiring explicit opt-in.
- With no opt-in list present, `filter_runtime_tools_by_policy_opt_in()` then dropped **all** host tools → empty tool set.

This was a **stale `composer.lock` pin**, not a code bug in DM. DM tracks `wordpress/agents-api: dev-main`, but the lock was pinned to `824a01b` (agents-api PR #303), which predates the upstream fix:

- `82463a3` "Add runtime tool policy opt-in" — **introduced** the `scope === 'run'` clause (the bug).
- `3e2965f` "Keep host tools visible in runtime policies" — **already removed** it upstream.

DM just needed to re-lock to current agents-api main (`21987be`), which contains `3e2965f`.

## The fix

1. **`composer update wordpress/agents-api`** — re-locks `composer.lock` from `824a01b` to `21987be` (current main). On the new version, `is_runtime_tool()` no longer treats host tools (`scope: 'run'`) as runtime tools, so they remain visible. This is the actual fix.
2. **Harden `ToolPolicyResolverTest`** — the test-only `datamachine_tools` filter cleanups used `remove_all_filters('datamachine_tools')`, which wipes the **built-in** tool registrations (added once at plugin bootstrap) for the rest of the run. Switched to tracking each test's own closure and calling `remove_filter()` on only that callback, so the suite stays clean under full-suite ordering. (Not the root cause here, but a latent pollution hazard worth removing.)

## Test plan

- [x] Reproduced the 14 failures in the WP Codebox sandbox; isolated the exact filter stage with probe tests.
- [x] `composer update wordpress/agents-api` re-locks to `21987be`; vendored `is_runtime_tool()` confirmed fixed.
- [x] Full WP Codebox suite: **14 failures → 0** (1316 passed, 4 skipped).
- [x] `homeboy lint data-machine --changed-since origin/main` — passed.

> Note: agents-api has the fix committed on `main` but has **not cut a new tagged release** (still `0.2.1`). Since DM tracks `dev-main`, the lock bump is sufficient. If agents-api later pins to tagged releases, it should tag a release containing `3e2965f`.

Fixes the `ToolPolicyResolverTest` full-suite failures referenced in #2508.