### PR TITLE
fix: prevent duplicate recurring chains in RecurringScheduler (#2512)

### DIFF
--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -131,6 +131,18 @@ class RecurringScheduler {
 				);
 			}
 
+			// Datastore-readiness guard. If we cannot confirm AS is ready to
+			// answer queries, do NOT proceed to unschedule()+schedule(): the
+			// unschedule would be a no-op while the schedule later succeeds,
+			// creating a duplicate chain. Bail so the caller retries later.
+			if ( ! self::isActionSchedulerDataStoreReady() ) {
+				return self::error(
+					'datastore_not_ready',
+					'Action Scheduler datastore not ready; deferring schedule to avoid creating a duplicate chain.',
+					array( 'status' => 503 )
+				);
+			}
+
 			if ( empty( $options['force_reschedule'] ) && self::hasMatchingSingleAction( $hook, $args, $group, (int) $timestamp ) ) {
 				return array(
 					'interval'       => 'one_time',
@@ -192,6 +204,19 @@ class RecurringScheduler {
 			);
 		}
 
+		// Datastore-readiness guard. If we cannot confirm AS is ready to answer
+		// queries, do NOT proceed to unschedule()+schedule(): the unschedule
+		// would be a no-op (AS not ready) while as_schedule_recurring_action
+		// later succeeds in the same request — creating a SECOND parallel
+		// recurring chain. Bail so the caller retries when AS is ready.
+		if ( ! self::isActionSchedulerDataStoreReady() ) {
+			return self::error(
+				'datastore_not_ready',
+				'Action Scheduler datastore not ready; deferring schedule to avoid creating a duplicate chain.',
+				array( 'status' => 503 )
+			);
+		}
+
 		// Determine first-run timestamp. Caller override wins (e.g. "tomorrow
 		// midnight UTC" for daily memory). Otherwise compute from stagger seed.
 		if ( isset( $options['first_run_timestamp'] ) ) {
@@ -205,6 +230,30 @@ class RecurringScheduler {
 		}
 
 		if ( empty( $options['force_reschedule'] ) && self::hasMatchingRecurringAction( $hook, $args, $group, (int) $interval_seconds ) ) {
+			// Self-healing dedup: if a previous call already created MORE THAN
+			// ONE matching pending chain for this signature, collapse them to a
+			// single chain now instead of preserving the duplicates.
+			if ( self::countMatchingPendingActions( $hook, $args, $group ) > 1 ) {
+				self::unschedule( $hook, $args, $group );
+				as_schedule_recurring_action( $first_run_time, $interval_seconds, $hook, $args, $group );
+
+				if ( ! self::isScheduled( $hook, $args, $group ) ) {
+					return self::error(
+						'schedule_not_persisted',
+						'Action Scheduler accepted the schedule but no pending action was found. AS tables may not be ready.',
+						array( 'status' => 500 )
+					);
+				}
+
+				return array(
+					'interval'         => $resolved_interval,
+					'scheduled'        => true,
+					'interval_seconds' => (int) $interval_seconds,
+					'first_run'        => wp_date( 'c', $first_run_time ),
+					'deduplicated'     => true,
+				);
+			}
+
 			return array(
 				'interval'         => $resolved_interval,
 				'scheduled'        => true,
@@ -332,6 +381,42 @@ class RecurringScheduler {
 
 		$action = reset( $actions );
 		return is_object( $action ) ? $action : null;
+	}
+
+	/**
+	 * Count ALL pending Action Scheduler actions matching (hook, args, group).
+	 *
+	 * Used to detect duplicate recurring/cron chains for the same signature so
+	 * ensureSchedule can self-heal (collapse N>1 chains to exactly one) even on
+	 * the preserve fast path. Unlike getPendingAction() (per_page=1), this asks
+	 * for more than one row so duplicates are visible.
+	 *
+	 * @param string $hook  Hook name.
+	 * @param array  $args  Action args.
+	 * @param string $group AS group.
+	 * @return int Number of matching pending actions (0 when AS is not ready).
+	 */
+	private static function countMatchingPendingActions( string $hook, array $args, string $group ): int {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+			return 0;
+		}
+
+		if ( ! self::isActionSchedulerDataStoreReady() ) {
+			return 0;
+		}
+
+		$actions = as_get_scheduled_actions(
+			array(
+				'hook'     => $hook,
+				'args'     => $args,
+				'group'    => $group,
+				'status'   => 'pending',
+				'per_page' => 100,
+			),
+			'ids'
+		);
+
+		return is_array( $actions ) ? count( $actions ) : 0;
 	}
 
 	/**
@@ -575,7 +660,41 @@ class RecurringScheduler {
 			);
 		}
 
+		// Datastore-readiness guard — same asymmetry as the recurring/one_time
+		// branches: a not-ready unschedule is a no-op but the schedule succeeds,
+		// duplicating the chain. Bail and let the caller retry when AS is ready.
+		if ( ! self::isActionSchedulerDataStoreReady() ) {
+			return self::error(
+				'datastore_not_ready',
+				'Action Scheduler datastore not ready; deferring cron schedule to avoid creating a duplicate chain.',
+				array( 'status' => 503 )
+			);
+		}
+
 		if ( ! $force_reschedule && self::hasMatchingCronAction( $hook, $args, $group, $cron_expression ) ) {
+			// Self-healing dedup: collapse an already-duplicated signature to a
+			// single chain instead of preserving the duplicates.
+			if ( self::countMatchingPendingActions( $hook, $args, $group ) > 1 ) {
+				self::unschedule( $hook, $args, $group );
+				$action_id = as_schedule_cron_action( time(), $cron_expression, $hook, $args, $group );
+
+				if ( ! self::isScheduled( $hook, $args, $group ) ) {
+					return self::error(
+						'schedule_not_persisted',
+						'Action Scheduler accepted the cron schedule but no pending action was found.',
+						array( 'status' => 500 )
+					);
+				}
+
+				return array(
+					'interval'        => 'cron',
+					'scheduled'       => true,
+					'cron_expression' => $cron_expression,
+					'action_id'       => $action_id,
+					'deduplicated'    => true,
+				);
+			}
+
 			return array(
 				'interval'        => 'cron',
 				'scheduled'       => true,

--- a/tests/recurring-scheduler-idempotency-smoke.php
+++ b/tests/recurring-scheduler-idempotency-smoke.php
@@ -83,6 +83,26 @@ if ( ! function_exists( 'apply_filters' ) ) {
 	}
 }
 
+/**
+ * Action Scheduler datastore-readiness stub.
+ *
+ * RecurringScheduler::isActionSchedulerDataStoreReady() checks:
+ *   1. did_action( 'action_scheduler_init' ) > 0 (only when did_action exists)
+ *   2. \ActionScheduler::is_initialized()        (only when the class exists)
+ *
+ * We define \ActionScheduler here so the readiness guard is controllable from
+ * the tests via ActionScheduler::$initialized. did_action is intentionally NOT
+ * defined so the first branch is skipped and the class flag is authoritative.
+ */
+class ActionScheduler {
+	public static bool $initialized = true;
+
+	public static function is_initialized( $function_name = null ): bool {
+		unset( $function_name );
+		return self::$initialized;
+	}
+}
+
 class DmRecurringSchedulerFakeSchedule {
 	private bool $recurring;
 	/**
@@ -132,8 +152,23 @@ function dm_rs_key( string $hook, array $args, string $group ): string {
 	return $group . '|' . $hook . '|' . serialize( $args );
 }
 
+/**
+ * Seed an additional pending action for a signature.
+ *
+ * The store keeps a LIST per signature so the harness can model the live
+ * duplicate-chain bug (two parallel pending actions for one hook/args/group).
+ */
 function dm_rs_seed_action( string $hook, array $args, string $group, DmRecurringSchedulerFakeSchedule $schedule ): void {
-	$GLOBALS['dm_rs_actions'][ dm_rs_key( $hook, $args, $group ) ] = new DmRecurringSchedulerFakeAction( $schedule );
+	$key = dm_rs_key( $hook, $args, $group );
+	if ( ! isset( $GLOBALS['dm_rs_actions'][ $key ] ) ) {
+		$GLOBALS['dm_rs_actions'][ $key ] = array();
+	}
+	$GLOBALS['dm_rs_actions'][ $key ][] = new DmRecurringSchedulerFakeAction( $schedule );
+}
+
+function dm_rs_pending_count( string $hook, array $args, string $group ): int {
+	$key = dm_rs_key( $hook, $args, $group );
+	return isset( $GLOBALS['dm_rs_actions'][ $key ] ) ? count( $GLOBALS['dm_rs_actions'][ $key ] ) : 0;
 }
 
 function dm_rs_reset(): void {
@@ -142,6 +177,7 @@ function dm_rs_reset(): void {
 	$GLOBALS['dm_rs_scheduled_recurring'] = 0;
 	$GLOBALS['dm_rs_scheduled_cron']      = 0;
 	$GLOBALS['dm_rs_unscheduled']         = 0;
+	ActionScheduler::$initialized         = true;
 }
 
 function dm_rs_counter( string $key ): int {
@@ -149,17 +185,28 @@ function dm_rs_counter( string $key ): int {
 }
 
 function as_get_scheduled_actions( array $args = array(), $return_format = OBJECT ): array {
-	$key = dm_rs_key( $args['hook'], $args['args'] ?? array(), $args['group'] ?? '' );
-	return isset( $GLOBALS['dm_rs_actions'][ $key ] ) ? array( 1 => $GLOBALS['dm_rs_actions'][ $key ] ) : array();
+	$key      = dm_rs_key( $args['hook'], $args['args'] ?? array(), $args['group'] ?? '' );
+	$matches  = $GLOBALS['dm_rs_actions'][ $key ] ?? array();
+	$per_page = isset( $args['per_page'] ) ? (int) $args['per_page'] : count( $matches );
+	if ( $per_page > 0 ) {
+		$matches = array_slice( $matches, 0, $per_page );
+	}
+
+	if ( 'ids' === $return_format ) {
+		return array_keys( $matches );
+	}
+
+	return $matches;
 }
 
 function as_next_scheduled_action( string $hook, ?array $args = null, string $group = '' ) {
 	$key = dm_rs_key( $hook, $args ?? array(), $group );
-	if ( ! isset( $GLOBALS['dm_rs_actions'][ $key ] ) ) {
+	if ( empty( $GLOBALS['dm_rs_actions'][ $key ] ) ) {
 		return false;
 	}
 
-	return $GLOBALS['dm_rs_actions'][ $key ]->get_schedule()->get_date()->getTimestamp();
+	$first = reset( $GLOBALS['dm_rs_actions'][ $key ] );
+	return $first->get_schedule()->get_date()->getTimestamp();
 }
 
 function as_unschedule_all_actions( string $hook, array $args = array(), string $group = '' ): void {
@@ -263,5 +310,65 @@ $result = dm_assert_schedule_result( RecurringScheduler::ensureSchedule( 'dm_onc
 dm_assert( empty( $result['preserved'] ), 'changed one-time action is not marked preserved' );
 dm_assert( 1 === dm_rs_counter( 'dm_rs_unscheduled' ), 'changed one-time action was unscheduled' );
 dm_assert( 1 === dm_rs_counter( 'dm_rs_scheduled_single' ), 'changed one-time action was recreated' );
+
+echo "\n[8] calling ensureSchedule twice yields exactly ONE recurring chain (#2512)\n";
+dm_rs_reset();
+$result = dm_assert_schedule_result( RecurringScheduler::ensureSchedule( 'dm_dup', array(), 'hourly' ) );
+dm_assert( 1 === dm_rs_counter( 'dm_rs_scheduled_recurring' ), 'first call creates one recurring chain' );
+dm_assert( 1 === dm_rs_pending_count( 'dm_dup', array(), RecurringScheduler::GROUP ), 'one pending action after first call' );
+$result = dm_assert_schedule_result( RecurringScheduler::ensureSchedule( 'dm_dup', array(), 'hourly' ) );
+dm_assert( true === ( $result['preserved'] ?? false ), 'second call preserves the single matching chain' );
+dm_assert( 1 === dm_rs_counter( 'dm_rs_scheduled_recurring' ), 'second call does NOT create a second chain' );
+dm_assert( 1 === dm_rs_pending_count( 'dm_dup', array(), RecurringScheduler::GROUP ), 'still exactly one pending action after second call' );
+
+echo "\n[9] datastore-not-ready bails instead of creating a duplicate recurring chain (#2512)\n";
+dm_rs_reset();
+// Existing live chain (created earlier when AS was ready).
+dm_rs_seed_action( 'dm_dup', array(), RecurringScheduler::GROUP, new DmRecurringSchedulerFakeSchedule( true, 3600, time() + 600 ) );
+ActionScheduler::$initialized = false; // AS datastore reports NOT ready.
+$result                       = RecurringScheduler::ensureSchedule( 'dm_dup', array(), 'hourly' );
+dm_assert( $result instanceof WP_Error, 'not-ready datastore returns WP_Error' );
+dm_assert( 'datastore_not_ready' === $result->get_error_code(), 'error code is datastore_not_ready' );
+dm_assert( 0 === dm_rs_counter( 'dm_rs_scheduled_recurring' ), 'no new recurring chain created while AS not ready' );
+dm_assert( 0 === dm_rs_counter( 'dm_rs_unscheduled' ), 'no unschedule attempted while AS not ready' );
+dm_assert( 1 === dm_rs_pending_count( 'dm_dup', array(), RecurringScheduler::GROUP ), 'existing chain left intact — still exactly one' );
+
+echo "\n[10] an already-duplicated recurring signature self-heals to one chain (#2512)\n";
+dm_rs_reset();
+// Simulate the live bug: two parallel pending chains for the same signature.
+dm_rs_seed_action( 'dm_dup', array(), RecurringScheduler::GROUP, new DmRecurringSchedulerFakeSchedule( true, 3600, time() + 600 ) );
+dm_rs_seed_action( 'dm_dup', array(), RecurringScheduler::GROUP, new DmRecurringSchedulerFakeSchedule( true, 3600, time() + 700 ) );
+dm_assert( 2 === dm_rs_pending_count( 'dm_dup', array(), RecurringScheduler::GROUP ), 'two duplicate chains seeded' );
+$result = dm_assert_schedule_result( RecurringScheduler::ensureSchedule( 'dm_dup', array(), 'hourly' ) );
+dm_assert( true === ( $result['deduplicated'] ?? false ), 'result marks deduplicated' );
+dm_assert( 1 === dm_rs_counter( 'dm_rs_unscheduled' ), 'duplicates were unscheduled' );
+dm_assert( 1 === dm_rs_counter( 'dm_rs_scheduled_recurring' ), 'exactly one chain recreated' );
+dm_assert( 1 === dm_rs_pending_count( 'dm_dup', array(), RecurringScheduler::GROUP ), 'collapsed to exactly one pending action' );
+
+echo "\n[11] cron branch also bails when datastore not ready (#2512)\n";
+dm_rs_reset();
+ActionScheduler::$initialized = false;
+$result                       = RecurringScheduler::ensureSchedule( 'dm_cron', array(), 'cron', array( 'cron_expression' => '0 0 * * *' ) );
+dm_assert( $result instanceof WP_Error, 'cron not-ready datastore returns WP_Error' );
+dm_assert( 'datastore_not_ready' === $result->get_error_code(), 'cron error code is datastore_not_ready' );
+dm_assert( 0 === dm_rs_counter( 'dm_rs_scheduled_cron' ), 'no cron chain created while AS not ready' );
+
+echo "\n[12] one_time branch also bails when datastore not ready (#2512)\n";
+dm_rs_reset();
+ActionScheduler::$initialized = false;
+$result                       = RecurringScheduler::ensureSchedule( 'dm_once', array(), 'one_time', array( 'timestamp' => time() + 3600 ) );
+dm_assert( $result instanceof WP_Error, 'one_time not-ready datastore returns WP_Error' );
+dm_assert( 'datastore_not_ready' === $result->get_error_code(), 'one_time error code is datastore_not_ready' );
+dm_assert( 0 === dm_rs_counter( 'dm_rs_scheduled_single' ), 'no one_time action created while AS not ready' );
+
+echo "\n[13] an already-duplicated cron signature self-heals to one chain (#2512)\n";
+dm_rs_reset();
+dm_rs_seed_action( 'dm_cron', array(), RecurringScheduler::GROUP, new DmRecurringSchedulerFakeSchedule( true, '0 0 * * *', time() + 600 ) );
+dm_rs_seed_action( 'dm_cron', array(), RecurringScheduler::GROUP, new DmRecurringSchedulerFakeSchedule( true, '0 0 * * *', time() + 700 ) );
+$result = dm_assert_schedule_result( RecurringScheduler::ensureSchedule( 'dm_cron', array(), 'cron', array( 'cron_expression' => '0 0 * * *' ) ) );
+dm_assert( true === ( $result['deduplicated'] ?? false ), 'cron result marks deduplicated' );
+dm_assert( 1 === dm_rs_counter( 'dm_rs_unscheduled' ), 'cron duplicates were unscheduled' );
+dm_assert( 1 === dm_rs_counter( 'dm_rs_scheduled_cron' ), 'exactly one cron chain recreated' );
+dm_assert( 1 === dm_rs_pending_count( 'dm_cron', array(), RecurringScheduler::GROUP ), 'cron collapsed to exactly one pending action' );
 
 echo "\nAll recurring scheduler idempotency assertions passed.\n";


### PR DESCRIPTION
## Root cause

`RecurringScheduler::ensureSchedule()` could create **duplicate recurring chains** for the same `(hook, args, group)` signature due to a **datastore-not-ready asymmetry**:

- The preserve-check (`hasMatchingRecurringAction()` → `getPendingAction()`) returns `null`/`false` whenever `isActionSchedulerDataStoreReady()` is false, so it silently misses an existing live chain.
- The subsequent `self::unschedule()` (`as_unschedule_all_actions`) is **also a no-op** when AS is not ready — but `as_schedule_recurring_action()` later **succeeds** once AS comes up in the same request.

Net result: the existing chain is never cleared and a **second parallel chain** is created. Confirmed live on extrachill.com — `ec_notifications_email_digest` had two hourly chains (first_timestamp `2026-06-01 04:43` and `2026-06-02 03:55`), producing two identical pending actions on every hourly tick. The same asymmetry applied to the `one_time` and `cron` branches.

## The fix — three layers

**A) Symmetric datastore-readiness guard.** Before the `unschedule()` + `as_schedule_*()` create path in all three branches (recurring, `one_time`, `cron`), bail early with `WP_Error( 'datastore_not_ready' )` when `isActionSchedulerDataStoreReady()` is false. The caller retries later when AS is ready instead of blindly creating a possibly-duplicate chain. Both existing callers already handle the `WP_Error` return gracefully (`FlowScheduling` propagates it; `SystemAgentServiceProvider` logs a warning) and re-run on the next reconcile pass.

**B) Self-healing dedup.** New `countMatchingPendingActions()` helper (queries with `per_page => 100`, returns `ids`) counts ALL matching pending actions for the signature. On the preserve fast path, if `> 1` matching chains exist, unschedule all and recreate exactly one — so an already-duplicated signature collapses to one on the next `ensureSchedule` call. Result is marked `'deduplicated' => true`.

**C) Preserve-on-single-match fast path is unchanged** for the common (single matching chain) case.

## Verification

Extended `tests/recurring-scheduler-idempotency-smoke.php` (pure-PHP smoke, AS procedural API stubbed; harness now models a LIST of pending actions per signature and a controllable `ActionScheduler::is_initialized()` flag). New cases:

- **[8]** calling `ensureSchedule` twice for the same `(hook,args,group,interval)` yields exactly ONE pending recurring chain, never two.
- **[9]** datastore-not-ready returns `WP_Error('datastore_not_ready')`, creates no new chain, attempts no unschedule, and leaves the existing single chain intact.
- **[10]** an already-duplicated recurring signature self-heals to exactly one chain (`deduplicated`).
- **[11]/[12]** cron and one_time branches also bail with `datastore_not_ready`.
- **[13]** an already-duplicated cron signature self-heals to one chain.

```
$ php tests/recurring-scheduler-idempotency-smoke.php
All recurring scheduler idempotency assertions passed.   (cases [1]–[13], EXIT 0)

$ php tests/recurring-scheduler-as-readiness-smoke.php
All recurring scheduler AS readiness assertions passed.  (EXIT 0)

$ php -l inc/Engine/Tasks/RecurringScheduler.php
No syntax errors detected

$ vendor/bin/phpcs inc/Engine/Tasks/RecurringScheduler.php tests/recurring-scheduler-idempotency-smoke.php
(clean, EXIT 0)
```

Closes #2512