### PR TITLE
Allow agent bundle runs to return final engine data

### DIFF
--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -260,8 +260,11 @@ Agent package operations live under `wp datamachine agent`:
 - `upgrade <path|url>` applies clean updates and stages locally modified artifacts as PendingActions.
 - `rebase <path|url>` previews 3-way merges for locally modified bundle artifacts.
 - `apply <pending_action_id>` accepts a staged bundle PendingAction.
+- `run-bundle <path|url>` starts a selected bundle flow as a headless ephemeral workflow.
 
 Every read/preview command supports `--format=json` for automation.
+
+`run-bundle` returns `datamachine/agent-bundle-run/v1`. By default it is a job-start envelope with `job_id`, `execution_type`, and bundle metadata. Pass `--wait` to drain the created job in the current request and include terminal `job_status`, `wait_result`, and final `engine_data`. `--step-budget` and `--time-budget-ms` bound synchronous drains for one-shot CI or sandbox runtimes.
 
 `install`, `import`, `upgrade`, and `diff` accept `--token=<token>` and `--token-env=<varname>` for one-off authenticated downloads — see [Authenticated Bundle Sources](#authenticated-bundle-sources).
 

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -1485,27 +1485,27 @@ class AgentAbilities {
 			'type'       => 'object',
 			'required'   => array( 'source' ),
 			'properties' => array(
-				'source'       => array(
+				'source'              => array(
 					'type'        => 'string',
 					'description' => 'Bundle source: local path (directory, .zip, .json) or remote URL.',
 				),
-				'flow'         => array(
+				'flow'                => array(
 					'type'        => 'string',
 					'description' => 'Optional bundle flow slug. Defaults to the first flow in the bundle.',
 				),
-				'flow_slug'    => array(
+				'flow_slug'           => array(
 					'type'        => 'string',
 					'description' => 'Alias for flow.',
 				),
-				'initial_data' => array(
+				'initial_data'        => array(
 					'type'        => 'object',
 					'description' => 'Initial engine data merged into the ephemeral workflow job.',
 				),
-				'timestamp'    => array(
+				'timestamp'           => array(
 					'type'        => array( 'integer', 'null' ),
 					'description' => 'Future Unix timestamp for delayed execution. Omit for immediate execution.',
 				),
-				'dry_run'      => array(
+				'dry_run'             => array(
 					'type'        => 'boolean',
 					'description' => 'Return the projected workflow and initial_data without creating a job.',
 				),
@@ -1513,27 +1513,27 @@ class AgentAbilities {
 					'type'        => 'boolean',
 					'description' => 'Synchronously drain the created job and include terminal job_status plus engine_data in the response.',
 				),
-				'wait'         => array(
+				'wait'                => array(
 					'type'        => 'boolean',
 					'description' => 'Alias for wait_for_completion.',
 				),
-				'step_budget'  => array(
+				'step_budget'         => array(
 					'type'        => 'integer',
 					'description' => 'Maximum number of scheduled job actions to drain when wait_for_completion is true.',
 				),
-				'time_budget_ms' => array(
+				'time_budget_ms'      => array(
 					'type'        => 'integer',
 					'description' => 'Maximum wall-clock milliseconds to drain when wait_for_completion is true.',
 				),
-				'token'        => array(
+				'token'               => array(
 					'type'        => 'string',
 					'description' => 'Auth token for private archive downloads. Used for this single resolve(); never persisted or logged.',
 				),
-				'token_env'    => array(
+				'token_env'           => array(
 					'type'        => 'string',
 					'description' => 'Environment variable or PHP constant name to read the auth token from.',
 				),
-				'job_source'   => array(
+				'job_source'          => array(
 					'type'        => 'string',
 					'description' => 'Optional job source label. Defaults to agent_bundle.',
 				),

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -1537,7 +1537,7 @@ class AgentAbilities {
 					'type'        => 'string',
 					'description' => 'Optional job source label. Defaults to agent_bundle.',
 				),
-				'job_label'    => array(
+				'job_label'           => array(
 					'type'        => 'string',
 					'description' => 'Optional job label. Defaults to the selected flow name.',
 				),

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -1509,6 +1509,22 @@ class AgentAbilities {
 					'type'        => 'boolean',
 					'description' => 'Return the projected workflow and initial_data without creating a job.',
 				),
+				'wait_for_completion' => array(
+					'type'        => 'boolean',
+					'description' => 'Synchronously drain the created job and include terminal job_status plus engine_data in the response.',
+				),
+				'wait'         => array(
+					'type'        => 'boolean',
+					'description' => 'Alias for wait_for_completion.',
+				),
+				'step_budget'  => array(
+					'type'        => 'integer',
+					'description' => 'Maximum number of scheduled job actions to drain when wait_for_completion is true.',
+				),
+				'time_budget_ms' => array(
+					'type'        => 'integer',
+					'description' => 'Maximum wall-clock milliseconds to drain when wait_for_completion is true.',
+				),
 				'token'        => array(
 					'type'        => 'string',
 					'description' => 'Auth token for private archive downloads. Used for this single resolve(); never persisted or logged.',

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -136,16 +136,16 @@ class AgentBundleCommand extends BaseCommand {
 		}
 
 		$input = array(
-			'source'       => $source,
-			'flow'         => (string) ( $assoc_args['flow'] ?? '' ),
-			'initial_data' => $this->json_assoc_arg( $assoc_args, 'initial-data' ),
-			'timestamp'    => isset( $assoc_args['timestamp'] ) ? (int) $assoc_args['timestamp'] : null,
-			'dry_run'      => \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false ),
+			'source'              => $source,
+			'flow'                => (string) ( $assoc_args['flow'] ?? '' ),
+			'initial_data'        => $this->json_assoc_arg( $assoc_args, 'initial-data' ),
+			'timestamp'           => isset( $assoc_args['timestamp'] ) ? (int) $assoc_args['timestamp'] : null,
+			'dry_run'             => \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false ),
 			'wait_for_completion' => \WP_CLI\Utils\get_flag_value( $assoc_args, 'wait', false ),
-			'step_budget'  => isset( $assoc_args['step-budget'] ) ? (int) $assoc_args['step-budget'] : null,
-			'time_budget_ms' => isset( $assoc_args['time-budget-ms'] ) ? (int) $assoc_args['time-budget-ms'] : null,
-			'token'        => (string) ( $assoc_args['token'] ?? '' ),
-			'token_env'    => (string) ( $assoc_args['token-env'] ?? '' ),
+			'step_budget'         => isset( $assoc_args['step-budget'] ) ? (int) $assoc_args['step-budget'] : null,
+			'time_budget_ms'      => isset( $assoc_args['time-budget-ms'] ) ? (int) $assoc_args['time-budget-ms'] : null,
+			'token'               => (string) ( $assoc_args['token'] ?? '' ),
+			'token_env'           => (string) ( $assoc_args['token-env'] ?? '' ),
 		);
 
 		$result               = AgentAbilities::runAgentBundle( array_filter( $input, static fn( $value ) => null !== $value && '' !== $value && array() !== $value ) );

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -103,6 +103,15 @@ class AgentBundleCommand extends BaseCommand {
 	 * [--dry-run]
 	 * : Return projected workflow and initial data without creating a job.
 	 *
+	 * [--wait]
+	 * : Drain the created job until terminal or budgeted and include job_status plus engine_data.
+	 *
+	 * [--step-budget=<count>]
+	 * : Maximum number of scheduled job actions to drain when --wait is used.
+	 *
+	 * [--time-budget-ms=<milliseconds>]
+	 * : Maximum wall-clock milliseconds to drain when --wait is used.
+	 *
 	 * [--token=<token>]
 	 * : Auth token for private archive downloads. Used for this single resolve(); never persisted, never logged.
 	 *
@@ -132,6 +141,9 @@ class AgentBundleCommand extends BaseCommand {
 			'initial_data' => $this->json_assoc_arg( $assoc_args, 'initial-data' ),
 			'timestamp'    => isset( $assoc_args['timestamp'] ) ? (int) $assoc_args['timestamp'] : null,
 			'dry_run'      => \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false ),
+			'wait_for_completion' => \WP_CLI\Utils\get_flag_value( $assoc_args, 'wait', false ),
+			'step_budget'  => isset( $assoc_args['step-budget'] ) ? (int) $assoc_args['step-budget'] : null,
+			'time_budget_ms' => isset( $assoc_args['time-budget-ms'] ) ? (int) $assoc_args['time-budget-ms'] : null,
 			'token'        => (string) ( $assoc_args['token'] ?? '' ),
 			'token_env'    => (string) ( $assoc_args['token-env'] ?? '' ),
 		);

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -8,7 +8,9 @@
 namespace DataMachine\Engine\Bundle;
 
 use DataMachine\Abilities\Job\ExecuteWorkflowAbility;
+use DataMachine\Abilities\Engine\DrainJobAbility;
 use DataMachine\Core\Agents\AgentBundler;
+use DataMachine\Core\Database\Jobs\Jobs;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -80,7 +82,7 @@ final class AgentBundleRunner {
 			)
 		);
 
-		return array_merge(
+		$response = array_merge(
 			array(
 				'schema'  => 'datamachine/agent-bundle-run/v1',
 				'dry_run' => false,
@@ -88,6 +90,47 @@ final class AgentBundleRunner {
 			),
 			$result
 		);
+
+		if ( ! empty( $input['wait_for_completion'] ) || ! empty( $input['wait'] ) ) {
+			$response = $this->wait_for_completion( $response, $input );
+		}
+
+		return $response;
+	}
+
+	/** @return array<string,mixed> */
+	private function wait_for_completion( array $response, array $input ): array {
+		$job_id = (int) ( $response['job_id'] ?? 0 );
+		if ( $job_id <= 0 || empty( $response['success'] ) ) {
+			return $response;
+		}
+
+		if ( 'delayed' === (string) ( $response['execution_type'] ?? '' ) ) {
+			$response['wait_result'] = array(
+				'success' => false,
+				'error'   => 'Cannot wait for delayed agent bundle runs.',
+			);
+			return $response;
+		}
+
+		$drain_result = ( new DrainJobAbility() )->execute(
+			array(
+				'job_id'         => $job_id,
+				'step_budget'    => max( 1, (int) ( $input['step_budget'] ?? 50 ) ),
+				'time_budget_ms' => max( 1, (int) ( $input['time_budget_ms'] ?? 300000 ) ),
+			)
+		);
+
+		$job         = ( new Jobs() )->get_job( $job_id );
+		$job_status  = is_array( $job ) ? (string) ( $job['status'] ?? '' ) : '';
+		$engine_data = function_exists( 'datamachine_get_engine_data' ) ? datamachine_get_engine_data( $job_id ) : array();
+
+		$response['wait_for_completion'] = true;
+		$response['wait_result']         = $drain_result;
+		$response['job_status']          = $job_status;
+		$response['engine_data']         = $engine_data;
+
+		return $response;
 	}
 
 	/** @return array<string,mixed> */

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -49,6 +49,9 @@ foreach ( array(
 	'BundleSourceAuth::build_resolve_context'    => 'runner shares bundle token resolution with import/install surfaces',
 	'workflow_from_bundle_flow'                  => 'runner converts selected bundle flow to workflow steps',
 	'ExecuteWorkflowAbility'                     => 'runner reuses existing headless workflow executor',
+	'DrainJobAbility'                            => 'runner can drain jobs for final result callers',
+	"'wait_for_completion'"                     => 'runner exposes opt-in final result mode',
+	"'engine_data'"                              => 'runner returns final engine data after waiting',
 	"'schema'       => 'datamachine/agent-bundle-run/v1'" => 'runner returns stable response schema',
 	"'dry_run'      => true"                     => 'runner supports dry-run projection without job creation',
 	"\$initial_data['job_source']   = (string) ( \$input['job_source'] ?? 'agent_bundle' );" => 'runner stamps agent_bundle job source by default',
@@ -62,6 +65,7 @@ foreach ( array(
 	'AgentAbilities::runAgentBundle' => 'CLI calls ability callback',
 	'--initial-data=<json>'        => 'CLI accepts JSON initial data',
 	'--dry-run'                    => 'CLI exposes dry-run projection',
+	'--wait'                       => 'CLI exposes final result mode',
 ) as $needle => $label ) {
 	datamachine_bundle_runner_contains( $cli, $needle, $label, $failures, $passes );
 }


### PR DESCRIPTION
## Summary
- Add an opt-in `wait_for_completion` / `wait` mode to `datamachine/run-agent-bundle`.
- Drain the created bundle job through the existing `datamachine/drain-job` ability and return `job_status`, `wait_result`, and final `engine_data`.
- Document and test the CLI `run-bundle --wait` contract so sandbox callers do not need Data Machine internals.

## Testing
- `php tests/agent-bundle-runner-contract-smoke.php`
- `php -l inc/Engine/Bundle/AgentBundleRunner.php && php -l inc/Abilities/AgentAbilities.php && php -l inc/Cli/Commands/AgentBundleCommand.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the wp-site-generator Site Generation Loop failure, implemented the public Data Machine final-result contract, updated docs/tests, and ran targeted verification. Chris remains responsible for review and merge.