### PR TITLE
Add runtime agent bundle runner contract

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -1475,6 +1475,36 @@ class AgentAbilities {
 		return ( new AgentBundleRunner() )->run( $input );
 	}
 
+	/**
+	 * Run a Data Machine runtime bundle through the generic agent runtime seam.
+	 *
+	 * @param mixed $result         Previous runner result, or null when unhandled.
+	 * @param array $task_config    Generic task/bundle execution config.
+	 * @param array $runtime_config Generic runtime config supplied by the sandbox owner.
+	 * @param int   $index          Bundle/task index in the runtime request.
+	 * @return mixed Runtime bundle run result.
+	 */
+	public static function runRuntimeAgentBundle( $result, array $task_config, array $runtime_config = array(), int $index = 0 ) {
+		unset( $index );
+
+		if ( null !== $result ) {
+			return $result;
+		}
+
+		$input = array_merge( $runtime_config, $task_config );
+		if ( isset( $task_config['bundle'] ) && is_array( $task_config['bundle'] ) && ! isset( $input['runtime_bundle'] ) ) {
+			$input['runtime_bundle'] = $task_config['bundle'];
+		}
+		if ( isset( $task_config['bundles'] ) && is_array( $task_config['bundles'] ) && ! isset( $input['runtime_bundles'] ) ) {
+			$input['runtime_bundles'] = $task_config['bundles'];
+		}
+		if ( isset( $runtime_config['import'] ) && is_array( $runtime_config['import'] ) && ! isset( $input['runtime_import'] ) ) {
+			$input['runtime_import'] = $runtime_config['import'];
+		}
+
+		return self::runAgentBundle( $input );
+	}
+
 	private static function bundleLifecycleService(): AgentBundleAbilityService {
 		return new AgentBundleAbilityService();
 	}
@@ -1483,7 +1513,7 @@ class AgentAbilities {
 	private static function runAgentBundleInputSchema(): array {
 		return array(
 			'type'       => 'object',
-			'required'   => array( 'source' ),
+			'required'   => array(),
 			'properties' => array(
 				'source'              => array(
 					'type'        => 'string',
@@ -1532,6 +1562,36 @@ class AgentAbilities {
 				'token_env'           => array(
 					'type'        => 'string',
 					'description' => 'Environment variable or PHP constant name to read the auth token from.',
+				),
+				'runtime_bundle'      => array(
+					'type'        => 'object',
+					'description' => 'Single generic runtime bundle spec to import before running. Uses wp_agent_runtime_import_bundle internally.',
+				),
+				'runtime_bundles'     => array(
+					'type'        => 'array',
+					'description' => 'Generic runtime bundle specs to import before running. Uses wp_agent_import_runtime_bundles/wp_agent_runtime_import_bundle internally.',
+					'items'       => array( 'type' => 'object' ),
+				),
+				'agent_bundles'       => array(
+					'type'        => 'array',
+					'description' => 'Alias for runtime_bundles used by sandbox task payloads.',
+					'items'       => array( 'type' => 'object' ),
+				),
+				'runtime_import'      => array(
+					'type'        => 'object',
+					'description' => 'Defaults passed to the generic runtime bundle import seam, such as owner_id.',
+				),
+				'runtime_tools'       => array(
+					'type'        => 'object',
+					'description' => 'Runtime-scoped Data Machine tool definitions merged through datamachine_resolved_tools only for this run.',
+				),
+				'tools'               => array(
+					'type'        => array( 'object', 'array' ),
+					'description' => 'Alias for runtime_tools; accepts keyed tool definitions or a list with name/tool fields.',
+				),
+				'disable_directives'  => array(
+					'type'        => 'boolean',
+					'description' => 'Disable Data Machine directives only while this runtime bundle run executes.',
 				),
 				'job_source'          => array(
 					'type'        => 'string',

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -257,9 +257,10 @@ final class AgentBundleRunner {
 		}
 
 		$import_input = is_array( $input['runtime_import'] ?? null ) ? $input['runtime_import'] : array();
+		$owner_id     = get_current_user_id();
 		$import_input = array_merge(
 			array(
-				'owner_id' => get_current_user_id() ?: 1,
+				'owner_id' => 0 !== $owner_id ? $owner_id : 1,
 			),
 			$import_input
 		);
@@ -380,7 +381,7 @@ final class AgentBundleRunner {
 
 				return $tools;
 			};
-			$filters[] = array( 'datamachine_resolved_tools', $tool_filter, 100 );
+			$filters[]   = array( 'datamachine_resolved_tools', $tool_filter, 100 );
 			add_filter( 'datamachine_resolved_tools', $tool_filter, 100, 1 );
 		}
 

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -27,24 +27,40 @@ final class AgentBundleRunner {
 
 	/** @return array<string,mixed> */
 	public function run( array $input ): array {
-		$source = trim( (string) ( $input['source'] ?? '' ) );
+		$runtime_imports = $this->import_runtime_bundles( $input );
+		if ( ! empty( $runtime_imports['required'] ) && empty( $runtime_imports['success'] ) ) {
+			return $this->response(
+				array(
+					'success' => false,
+					'error'   => (string) ( $runtime_imports['error'] ?? 'Runtime bundle import failed.' ),
+				),
+				$input,
+				$runtime_imports
+			);
+		}
+
+		$source = trim( (string) ( $input['source'] ?? $this->first_runtime_bundle_source( $input ) ) );
 		if ( '' === $source ) {
-			return array(
-				'success' => false,
-				'error'   => 'Bundle source is required.',
+			return $this->response(
+				array(
+					'success' => false,
+					'error'   => 'Bundle source is required.',
+				),
+				$input,
+				$runtime_imports
 			);
 		}
 
 		$loaded = $this->load_bundle( $source, $input );
 		if ( empty( $loaded['success'] ) ) {
-			return $loaded;
+			return $this->response( $loaded, $input, $runtime_imports );
 		}
 
 		$bundle    = $loaded['bundle'];
 		$directory = AgentBundleArrayAdapter::from_array_bundle( $bundle );
 		$selection = $this->select_flow( $directory, (string) ( $input['flow'] ?? $input['flow_slug'] ?? '' ) );
 		if ( empty( $selection['success'] ) ) {
-			return $selection;
+			return $this->response( $selection, $input, $runtime_imports );
 		}
 
 		$workflow     = $this->workflow_from_bundle_flow( $selection['flow'], $selection['pipeline'] );
@@ -64,38 +80,138 @@ final class AgentBundleRunner {
 		$initial_data['job_label']    = (string) ( $input['job_label'] ?? ( $selection['flow_name'] ?? 'Agent Bundle Workflow' ) );
 
 		if ( ! empty( $input['dry_run'] ) ) {
-			return array(
-				'success'      => true,
-				'schema'       => 'datamachine/agent-bundle-run/v1',
-				'dry_run'      => true,
-				'bundle'       => $initial_data['agent_bundle'],
-				'workflow'     => $workflow,
-				'initial_data' => $initial_data,
+			return $this->response(
+				array(
+					'success'      => true,
+					'schema'       => 'datamachine/agent-bundle-run/v1',
+					'dry_run'      => true,
+					'bundle'       => $initial_data['agent_bundle'],
+					'workflow'     => $workflow,
+					'initial_data' => $initial_data,
+				),
+				$input,
+				$runtime_imports,
+				$selection
 			);
 		}
 
-		$result = ( new ExecuteWorkflowAbility() )->execute(
+		$response = $this->with_runtime_controls(
+			$input,
+			function () use ( $workflow, $initial_data, $input ): array {
+				$result = ( new ExecuteWorkflowAbility() )->execute(
+					array(
+						'workflow'     => $workflow,
+						'initial_data' => $initial_data,
+						'timestamp'    => $input['timestamp'] ?? null,
+					)
+				);
+
+				$response = array_merge(
+					array(
+						'schema'  => 'datamachine/agent-bundle-run/v1',
+						'dry_run' => false,
+						'bundle'  => $initial_data['agent_bundle'],
+					),
+					$result
+				);
+
+				if ( ! empty( $input['wait_for_completion'] ) || ! empty( $input['wait'] ) ) {
+					$response = $this->wait_for_completion( $response, $input );
+				}
+
+				return $response;
+			}
+		);
+
+		return $this->response( $response, $input, $runtime_imports, $selection );
+	}
+
+	/** @return array<string,mixed> */
+	private function response( array $response, array $input, array $runtime_imports = array(), array $selection = array() ): array {
+		$response['schema'] ??= 'datamachine/agent-bundle-run/v1';
+		$response['status']   = $this->status_from_response( $response );
+
+		if ( ! empty( $runtime_imports ) ) {
+			$response['runtime_imports'] = $runtime_imports;
+		}
+
+		$response['diagnostics'] = self::compact_response_array(
 			array(
-				'workflow'     => $workflow,
-				'initial_data' => $initial_data,
-				'timestamp'    => $input['timestamp'] ?? null,
+				'contract'              => 'datamachine/run-agent-bundle',
+				'runtime_bundle_count'  => count( $this->runtime_bundle_specs( $input ) ),
+				'runtime_import_status' => (string) ( $runtime_imports['status'] ?? '' ),
+				'flow_slug'             => (string) ( $selection['flow_slug'] ?? '' ),
+				'pipeline_slug'         => (string) ( $selection['pipeline_slug'] ?? '' ),
+				'wait_for_completion'   => ! empty( $response['wait_for_completion'] ),
 			)
 		);
 
-		$response = array_merge(
-			array(
-				'schema'  => 'datamachine/agent-bundle-run/v1',
-				'dry_run' => false,
-				'bundle'  => $initial_data['agent_bundle'],
-			),
-			$result
-		);
-
-		if ( ! empty( $input['wait_for_completion'] ) || ! empty( $input['wait'] ) ) {
-			$response = $this->wait_for_completion( $response, $input );
-		}
+		$response['completion_outcome'] = $this->completion_outcome( $response );
+		$response['transcript_refs']    = $this->transcript_refs( $response );
+		$response['export_refs']        = $this->export_refs( $response );
 
 		return $response;
+	}
+
+	private function status_from_response( array $response ): string {
+		if ( empty( $response['success'] ) ) {
+			return 'failed';
+		}
+
+		$job_status = (string) ( $response['job_status'] ?? '' );
+		if ( '' !== $job_status ) {
+			return $job_status;
+		}
+
+		return ! empty( $response['dry_run'] ) ? 'dry_run' : 'scheduled';
+	}
+
+	/** @return array<string,mixed> */
+	private function completion_outcome( array $response ): array {
+		$engine_data = is_array( $response['engine_data'] ?? null ) ? $response['engine_data'] : array();
+		$status      = (string) ( $response['status'] ?? '' );
+
+		return self::compact_response_array(
+			array(
+				'status'      => $status,
+				'completed'   => 'completed' === $status,
+				'success'     => ! empty( $response['success'] ) && 'failed' !== $status,
+				'error'       => (string) ( $response['error'] ?? $engine_data['error_message'] ?? '' ),
+				'token_usage' => is_array( $engine_data['token_usage'] ?? null ) ? $engine_data['token_usage'] : null,
+			)
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function compact_response_array( array $values ): array {
+		return array_filter(
+			$values,
+			static fn( $value ): bool => null !== $value && '' !== $value && array() !== $value
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private function transcript_refs( array $response ): array {
+		$engine_data = is_array( $response['engine_data'] ?? null ) ? $response['engine_data'] : array();
+		$session_id  = (string) ( $engine_data['transcript_session_id'] ?? '' );
+
+		return array_filter(
+			array(
+				'session_id' => $session_id,
+			)
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private function export_refs( array $response ): array {
+		$engine_data = is_array( $response['engine_data'] ?? null ) ? $response['engine_data'] : array();
+
+		return array_filter(
+			array(
+				'job_artifacts' => is_array( $engine_data['job_artifacts'] ?? null ) ? $engine_data['job_artifacts'] : null,
+				'exports'       => is_array( $engine_data['exports'] ?? null ) ? $engine_data['exports'] : null,
+			)
+		);
 	}
 
 	/** @return array<string,mixed> */
@@ -131,6 +247,150 @@ final class AgentBundleRunner {
 		$response['engine_data']         = $engine_data;
 
 		return $response;
+	}
+
+	/** @return array<string,mixed> */
+	private function import_runtime_bundles( array $input ): array {
+		$bundle_specs = $this->runtime_bundle_specs( $input );
+		if ( empty( $bundle_specs ) ) {
+			return array( 'status' => 'not_requested' );
+		}
+
+		$import_input = is_array( $input['runtime_import'] ?? null ) ? $input['runtime_import'] : array();
+		$import_input = array_merge(
+			array(
+				'owner_id' => get_current_user_id() ?: 1,
+			),
+			$import_input
+		);
+
+		if ( function_exists( 'wp_agent_import_runtime_bundles' ) ) {
+			$imports = wp_agent_import_runtime_bundles( $bundle_specs, $import_input );
+		} else {
+			$imports = $this->import_runtime_bundles_via_filter( $bundle_specs, $import_input );
+		}
+
+		$failed = array_values(
+			array_filter(
+				is_array( $imports ) ? $imports : array(),
+				static fn( $import ): bool => ! is_array( $import ) || empty( $import['success'] )
+			)
+		);
+
+		return array(
+			'required' => true,
+			'success'  => empty( $failed ),
+			'status'   => empty( $failed ) ? 'imported' : 'failed',
+			'imports'  => is_array( $imports ) ? $imports : array(),
+			'failed'   => $failed,
+			'error'    => empty( $failed ) ? '' : 'One or more runtime agent bundles failed to import.',
+		);
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private function runtime_bundle_specs( array $input ): array {
+		$specs = $input['runtime_bundles'] ?? $input['agent_bundles'] ?? array();
+		if ( is_array( $input['runtime_bundle'] ?? null ) ) {
+			$specs = array( $input['runtime_bundle'] );
+		}
+
+		return array_values( array_filter( is_array( $specs ) ? $specs : array(), 'is_array' ) );
+	}
+
+	private function first_runtime_bundle_source( array $input ): string {
+		foreach ( $this->runtime_bundle_specs( $input ) as $spec ) {
+			$source = trim( (string) ( $spec['source'] ?? '' ) );
+			if ( '' !== $source ) {
+				return $source;
+			}
+		}
+
+		return '';
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private function import_runtime_bundles_via_filter( array $bundle_specs, array $defaults ): array {
+		$imports = array();
+		foreach ( $bundle_specs as $index => $spec ) {
+			$input = array_merge(
+				array(
+					'on_conflict' => (string) ( $spec['on_conflict'] ?? 'upgrade' ),
+				),
+				$defaults
+			);
+
+			foreach ( array( 'source', 'slug', 'token_env' ) as $field ) {
+				if ( isset( $spec[ $field ] ) && '' !== trim( (string) $spec[ $field ] ) ) {
+					$input[ $field ] = trim( (string) $spec[ $field ] );
+				}
+			}
+
+			if ( isset( $spec['import_principal'] ) && is_array( $spec['import_principal'] ) ) {
+				$input['import_principal'] = $spec['import_principal'];
+			}
+
+			$result = apply_filters( 'wp_agent_runtime_import_bundle', null, $spec, $input, $index );
+			if ( is_wp_error( $result ) ) {
+				$imports[] = array(
+					'success' => false,
+					'index'   => $index,
+					'error'   => array(
+						'code'    => $result->get_error_code(),
+						'message' => $result->get_error_message(),
+						'data'    => $result->get_error_data(),
+					),
+				);
+				continue;
+			}
+
+			$imports[] = array_merge(
+				array(
+					'success' => is_array( $result ) && ! empty( $result['success'] ),
+					'index'   => $index,
+				),
+				is_array( $result ) ? $result : array( 'result' => $result )
+			);
+		}
+
+		return $imports;
+	}
+
+	/** @param callable():array<string,mixed> $callback */
+	private function with_runtime_controls( array $input, callable $callback ): array {
+		$filters = array();
+
+		if ( ! empty( $input['disable_datamachine_directives'] ) || ! empty( $input['disable_directives'] ) ) {
+			$filters[] = array( 'datamachine_directives_enabled', '__return_false', 100 );
+			add_filter( 'datamachine_directives_enabled', '__return_false', 100, 3 );
+		}
+
+		$runtime_tools = is_array( $input['runtime_tools'] ?? null ) ? $input['runtime_tools'] : ( is_array( $input['tools'] ?? null ) ? $input['tools'] : array() );
+		if ( ! empty( $runtime_tools ) ) {
+			$tool_filter = static function ( array $tools ) use ( $runtime_tools ): array {
+				foreach ( $runtime_tools as $name => $definition ) {
+					if ( ! is_array( $definition ) ) {
+						continue;
+					}
+
+					$tool_name = is_string( $name ) ? $name : (string) ( $definition['name'] ?? $definition['tool'] ?? '' );
+					if ( '' !== $tool_name ) {
+						$tools[ $tool_name ] = $definition;
+					}
+				}
+
+				return $tools;
+			};
+			$filters[] = array( 'datamachine_resolved_tools', $tool_filter, 100 );
+			add_filter( 'datamachine_resolved_tools', $tool_filter, 100, 1 );
+		}
+
+		try {
+			return $callback();
+		} finally {
+			foreach ( $filters as $filter ) {
+				remove_filter( $filter[0], $filter[1], $filter[2] );
+			}
+		}
 	}
 
 	/** @return array<string,mixed> */

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -86,6 +86,7 @@ AbilityScopePermissionFilter::register();
 ContentFormat::register();
 
 add_filter( 'wp_agent_runtime_import_bundle', array( AgentAbilities::class, 'importRuntimeAgentBundle' ), 10, 4 );
+add_filter( 'wp_agent_runtime_run_bundle', array( AgentAbilities::class, 'runRuntimeAgentBundle' ), 10, 4 );
 
 add_filter(
 	'datamachine_auth_providers',

--- a/tests/ability-tool-source-smoke.php
+++ b/tests/ability-tool-source-smoke.php
@@ -147,6 +147,7 @@ require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-declaration.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-parameters.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-call.php';
+require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-citation-metadata.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-result.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-executor.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-execution-core.php';

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -29,6 +29,7 @@ function datamachine_bundle_runner_contains( string $source, string $needle, str
 $abilities = (string) file_get_contents( $root . '/inc/Abilities/AgentAbilities.php' );
 $cli       = (string) file_get_contents( $root . '/inc/Cli/Commands/AgentBundleCommand.php' );
 $runner    = (string) file_get_contents( $root . '/inc/Engine/Bundle/AgentBundleRunner.php' );
+$bootstrap = (string) file_get_contents( $root . '/inc/bootstrap.php' );
 
 echo "agent-bundle-runner-contract-smoke\n";
 
@@ -37,11 +38,13 @@ foreach ( array(
 	'datamachine/run-agent-bundle' => 'run-agent-bundle ability registered',
 	'runAgentBundleInputSchema'    => 'dedicated input schema declared',
 	'AgentBundleRunner'            => 'ability delegates to runner service',
+	'runRuntimeAgentBundle'        => 'generic runtime run adapter declared',
 	"'show_in_rest' => true"      => 'ability is REST-visible for headless callers',
 	"'readonly'    => false"      => 'ability marks execution as mutating',
 ) as $needle => $label ) {
 	datamachine_bundle_runner_contains( $abilities, $needle, $label, $failures, $passes );
 }
+datamachine_bundle_runner_contains( $bootstrap, "add_filter( 'wp_agent_runtime_run_bundle'", 'Data Machine registers generic runtime run seam', $failures, $passes );
 
 echo "\n[2] Runner projects bundles to ephemeral workflows\n";
 foreach ( array(
@@ -50,6 +53,14 @@ foreach ( array(
 	'workflow_from_bundle_flow'                  => 'runner converts selected bundle flow to workflow steps',
 	'ExecuteWorkflowAbility'                     => 'runner reuses existing headless workflow executor',
 	'DrainJobAbility'                            => 'runner can drain jobs for final result callers',
+	'wp_agent_import_runtime_bundles'            => 'runner uses generic runtime bundle import helper when available',
+	"apply_filters( 'wp_agent_runtime_import_bundle'" => 'runner falls back to generic runtime bundle import filter',
+	"'runtime_imports'"                         => 'runner returns runtime import diagnostics',
+	"'completion_outcome'"                      => 'runner returns completion outcome summary',
+	"'transcript_refs'"                         => 'runner returns transcript references',
+	"'export_refs'"                             => 'runner returns export references',
+	'datamachine_directives_enabled'             => 'runner owns directive controls inside Data Machine',
+	'datamachine_resolved_tools'                 => 'runner owns runtime tool controls inside Data Machine',
 	"'wait_for_completion'"                     => 'runner exposes opt-in final result mode',
 	"'engine_data'"                              => 'runner returns final engine data after waiting',
 	"'schema'       => 'datamachine/agent-bundle-run/v1'" => 'runner returns stable response schema',
@@ -73,6 +84,9 @@ foreach ( array(
 echo "\n[4] Boundary stays generic\n";
 foreach ( array( 'homeboy', 'wp-codebox' ) as $forbidden ) {
 	datamachine_bundle_runner_assert( false === stripos( $runner, $forbidden ), "runner does not mention {$forbidden}", $failures, $passes );
+}
+foreach ( array( 'DataMachine\\Core\\Database\\Agents', 'DataMachine\\Core\\Database\\Flows', 'DataMachine\\Core\\Database\\Pipelines' ) as $forbidden ) {
+	datamachine_bundle_runner_assert( false === strpos( $runner, $forbidden ), "runtime runner does not require caller-facing {$forbidden}", $failures, $passes );
 }
 
 if ( $failures ) {


### PR DESCRIPTION
## Summary
- Adds a Data Machine-owned runtime bundle run adapter through `datamachine/run-agent-bundle` and the generic `wp_agent_runtime_run_bundle` filter seam.
- Routes runtime bundle specs through `wp_agent_import_runtime_bundles` / `wp_agent_runtime_import_bundle`, then returns normalized status, diagnostics, completion outcome, transcript refs, export refs, runtime import details, job id, and engine data.
- Keeps Data Machine-specific directive/tool controls scoped inside `AgentBundleRunner`, including during synchronous drain, so callers no longer need to import Data Machine database classes or compose low-level import/run/drain calls.

Fixes #2515

## Tests
- `php -l inc/Engine/Bundle/AgentBundleRunner.php`
- `php -l inc/Abilities/AgentAbilities.php`
- `php tests/agent-bundle-runner-contract-smoke.php`
- `php tests/runtime-agent-bundle-reconcile-smoke.php`
- `php tests/chat-session-canonical-path-smoke.php`
- `php tests/ability-tool-source-smoke.php`
- `./vendor/bin/phpcs inc/Engine/Bundle/AgentBundleRunner.php inc/Abilities/AgentAbilities.php inc/bootstrap.php tests/agent-bundle-runner-contract-smoke.php tests/ability-tool-source-smoke.php`
- `git diff --check`

## Downstream follow-up
- Update Homeboy Extensions to replace `wordpress/scripts/agent/datamachine-agent-workload.php` direct Data Machine internals usage with the new public runtime runner contract.
- WP Codebox can keep using the generic runtime bundle import seam; it can optionally call `wp_agent_runtime_run_bundle` for Data Machine-owned execution when orchestrating agent bundle workloads.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Data Machine runtime runner contract implementation, smoke coverage updates, and verification commands for Chris to review.