### PR TITLE
Allow bundle runs to set pipeline model config

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -1501,6 +1501,14 @@ class AgentAbilities {
 					'type'        => 'object',
 					'description' => 'Initial engine data merged into the ephemeral workflow job.',
 				),
+				'provider'            => array(
+					'type'        => 'string',
+					'description' => 'Optional wp-ai-client provider slug to use as the run-scoped pipeline model default.',
+				),
+				'model'               => array(
+					'type'        => 'string',
+					'description' => 'Optional wp-ai-client model slug to use as the run-scoped pipeline model default.',
+				),
 				'timestamp'           => array(
 					'type'        => array( 'integer', 'null' ),
 					'description' => 'Future Unix timestamp for delayed execution. Omit for immediate execution.',

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -91,7 +91,7 @@ class AIStep extends Step {
 		// Model/provider resolved exclusively via mode system (agent → site → network).
 		// Pipeline-level model/provider fields are ignored — mode_models is the authority.
 		$execution_modes = self::resolveExecutionModes( $pipeline_step_config, $this->flow_step_config );
-		$mode_model      = self::resolveModelForExecutionModes( $agent_id, $execution_modes );
+		$mode_model      = self::resolveModelForExecutionModes( $agent_id, $execution_modes, $job_snapshot );
 		$provider_name   = $mode_model['provider'];
 		if ( empty( $provider_name ) ) {
 			do_action(
@@ -181,7 +181,7 @@ class AIStep extends Step {
 		$execution_modes      = self::resolveExecutionModes( $pipeline_step_config, $this->flow_step_config );
 
 		// Model/provider resolved exclusively via mode system — pipeline config is ignored.
-		$mode_model    = self::resolveModelForExecutionModes( $agent_id, $execution_modes );
+		$mode_model    = self::resolveModelForExecutionModes( $agent_id, $execution_modes, $job_snapshot );
 		$provider_name = $mode_model['provider'];
 		$model_name    = $mode_model['model'];
 		$mode_label    = implode( ',', $execution_modes );
@@ -782,8 +782,54 @@ class AIStep extends Step {
 	 * @param array $modes    Active mode slugs.
 	 * @return array{provider:string,model:string}
 	 */
-	private static function resolveModelForExecutionModes( int $agent_id, array $modes ): array {
+	private static function resolveModelForExecutionModes( int $agent_id, array $modes, array $job_snapshot = array() ): array {
+		$job_model = self::resolveModelFromJobSnapshot( $job_snapshot, $modes );
+		if ( '' !== $job_model['provider'] && '' !== $job_model['model'] ) {
+			return $job_model;
+		}
+
 		return PluginSettings::resolveModelForAgentModes( $agent_id, $modes, ToolPolicyResolver::MODE_PIPELINE );
+	}
+
+	/**
+	 * Resolve run-scoped model config from the job snapshot.
+	 *
+	 * @param array $job_snapshot Portable job snapshot from engine data.
+	 * @param array $modes Active mode slugs.
+	 * @return array{provider:string,model:string}
+	 */
+	private static function resolveModelFromJobSnapshot( array $job_snapshot, array $modes ): array {
+		$mode_models = is_array( $job_snapshot['mode_models'] ?? null ) ? $job_snapshot['mode_models'] : array();
+		$modes       = array_values( array_unique( array_map( 'sanitize_key', $modes ) ) );
+
+		foreach ( $modes as $mode ) {
+			$mode_config = is_array( $mode_models[ $mode ] ?? null ) ? $mode_models[ $mode ] : array();
+			$provider    = sanitize_text_field( (string) ( $mode_config['provider'] ?? '' ) );
+			$model       = sanitize_text_field( (string) ( $mode_config['model'] ?? '' ) );
+			if ( '' !== $provider && '' !== $model ) {
+				return array(
+					'provider' => $provider,
+					'model'    => $model,
+				);
+			}
+		}
+
+		$pipeline_config = is_array( $mode_models[ ToolPolicyResolver::MODE_PIPELINE ] ?? null ) ? $mode_models[ ToolPolicyResolver::MODE_PIPELINE ] : array();
+		$provider        = sanitize_text_field( (string) ( $pipeline_config['provider'] ?? '' ) );
+		$model           = sanitize_text_field( (string) ( $pipeline_config['model'] ?? '' ) );
+		if ( '' !== $provider && '' !== $model ) {
+			return array(
+				'provider' => $provider,
+				'model'    => $model,
+			);
+		}
+
+		$provider = sanitize_text_field( (string) ( $job_snapshot['default_provider'] ?? '' ) );
+		$model    = sanitize_text_field( (string) ( $job_snapshot['default_model'] ?? '' ) );
+		return array(
+			'provider' => $provider,
+			'model'    => $model,
+		);
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -62,6 +62,7 @@ final class AgentBundleRunner {
 		$initial_data['agent_slug']   = (string) ( $manifest['agent']['slug'] ?? '' );
 		$initial_data['job_source']   = (string) ( $input['job_source'] ?? 'agent_bundle' );
 		$initial_data['job_label']    = (string) ( $input['job_label'] ?? ( $selection['flow_name'] ?? 'Agent Bundle Workflow' ) );
+		$this->apply_runtime_model_config( $initial_data, $input );
 
 		if ( ! empty( $input['dry_run'] ) ) {
 			return array(
@@ -96,6 +97,34 @@ final class AgentBundleRunner {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Project explicit headless model config into the job snapshot.
+	 *
+	 * @param array<string,mixed> $initial_data Initial workflow engine data.
+	 * @param array<string,mixed> $input Bundle run input.
+	 */
+	private function apply_runtime_model_config( array &$initial_data, array $input ): void {
+		$provider = sanitize_text_field( (string) ( $input['provider'] ?? '' ) );
+		$model    = sanitize_text_field( (string) ( $input['model'] ?? '' ) );
+		if ( '' === $provider || '' === $model ) {
+			return;
+		}
+
+		$job_snapshot = is_array( $initial_data['job'] ?? null ) ? $initial_data['job'] : array();
+		$mode_models  = is_array( $job_snapshot['mode_models'] ?? null ) ? $job_snapshot['mode_models'] : array();
+
+		$job_snapshot['default_provider']         = $provider;
+		$job_snapshot['default_model']            = $model;
+		$mode_models['pipeline']                  = array(
+			'provider' => $provider,
+			'model'    => $model,
+		);
+		$job_snapshot['mode_models']              = $mode_models;
+		$initial_data['job']                      = $job_snapshot;
+		$initial_data['agent_bundle']['provider'] = $provider;
+		$initial_data['agent_bundle']['model']    = $model;
 	}
 
 	/** @return array<string,mixed> */

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -29,6 +29,7 @@ function datamachine_bundle_runner_contains( string $source, string $needle, str
 $abilities = (string) file_get_contents( $root . '/inc/Abilities/AgentAbilities.php' );
 $cli       = (string) file_get_contents( $root . '/inc/Cli/Commands/AgentBundleCommand.php' );
 $runner    = (string) file_get_contents( $root . '/inc/Engine/Bundle/AgentBundleRunner.php' );
+$ai_step   = (string) file_get_contents( $root . '/inc/Core/Steps/AI/AIStep.php' );
 
 echo "agent-bundle-runner-contract-smoke\n";
 
@@ -70,7 +71,21 @@ foreach ( array(
 	datamachine_bundle_runner_contains( $cli, $needle, $label, $failures, $passes );
 }
 
-echo "\n[4] Boundary stays generic\n";
+echo "\n[4] Runner supports run-scoped provider/model config\n";
+foreach ( array(
+	"'provider'            => array("                                           => 'run-agent-bundle schema accepts provider',
+	"'model'               => array("                                           => 'run-agent-bundle schema accepts model',
+	'apply_runtime_model_config'                                              => 'runner projects provider/model into initial data',
+	"\$job_snapshot['default_provider']"                                      => 'runner stamps job-scoped default provider',
+	"\$job_snapshot['default_model']"                                         => 'runner stamps job-scoped default model',
+	"\$mode_models['pipeline']"                                               => 'runner stamps pipeline mode model config',
+	'resolveModelFromJobSnapshot'                                             => 'AI step reads run-scoped model config',
+	'resolveModelForExecutionModes( $agent_id, $execution_modes, $job_snapshot )' => 'AI validation uses job-scoped model config',
+) as $needle => $label ) {
+	datamachine_bundle_runner_contains( $abilities . $runner . $ai_step, $needle, $label, $failures, $passes );
+}
+
+echo "\n[5] Boundary stays generic\n";
 foreach ( array( 'homeboy', 'wp-codebox' ) as $forbidden ) {
 	datamachine_bundle_runner_assert( false === stripos( $runner, $forbidden ), "runner does not mention {$forbidden}", $failures, $passes );
 }

--- a/tests/ai-step-agent-mode-plumbing-smoke.php
+++ b/tests/ai-step-agent-mode-plumbing-smoke.php
@@ -30,7 +30,7 @@ $assert(
 
 $assert(
 	'model resolution uses resolved execution modes',
-	false !== strpos( $source, 'resolveModelForExecutionModes( $agent_id, $execution_modes )' )
+	false !== strpos( $source, 'resolveModelForExecutionModes( $agent_id, $execution_modes, $job_snapshot )' )
 );
 
 $assert(


### PR DESCRIPTION
## Summary
- Adds explicit `provider` and `model` inputs to `datamachine/run-agent-bundle` for run-scoped pipeline model defaults.
- Projects those inputs into the job snapshot so `AIStep` can resolve provider/model without relying on pre-mutated site settings.
- Extends the bundle runner contract smoke test to cover the new headless model config path.

## Testing
- `homeboy lint data-machine`
- `php -l inc/Engine/Bundle/AgentBundleRunner.php`
- `php -l inc/Core/Steps/AI/AIStep.php`
- `php -l inc/Abilities/AgentAbilities.php`
- `php tests/agent-bundle-runner-contract-smoke.php`
- `php tests/agent-bundle-runtime-drift-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, targeted smoke coverage, and verification commands; Chris remains responsible for review and merge.