### PR TITLE
Expose semantic bundle run outputs

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -573,7 +573,7 @@ class AgentAbilities {
 					'description'         => 'Run a flow from a portable agent bundle as a headless ephemeral workflow without requiring callers to synthesize Data Machine internals.',
 					'category'            => 'datamachine-agent',
 					'input_schema'        => self::runAgentBundleInputSchema(),
-					'output_schema'       => array( 'type' => 'object' ),
+					'output_schema'       => self::runAgentBundleOutputSchema(),
 					'execute_callback'    => array( self::class, 'runAgentBundle' ),
 					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array(
@@ -1609,6 +1609,31 @@ class AgentAbilities {
 					'type'        => 'string',
 					'description' => 'Optional job label. Defaults to the selected flow name.',
 				),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function runAgentBundleOutputSchema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success'            => array( 'type' => 'boolean' ),
+				'status'             => array( 'type' => 'string' ),
+				'job_id'             => array( 'type' => 'integer' ),
+				'outputs'            => array(
+					'type'        => 'object',
+					'description' => 'Semantic output map projected from declared or common task outputs in engine data.',
+				),
+				'output_diagnostics' => array(
+					'type'        => 'object',
+					'description' => 'Declared, present, and missing semantic output keys for downstream diagnostics.',
+				),
+				'engine_data'        => array(
+					'type'        => 'object',
+					'description' => 'Raw final engine data retained for diagnostics when wait_for_completion is used.',
+				),
+				'diagnostics'        => array( 'type' => 'object' ),
 			),
 		);
 	}

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -150,6 +150,9 @@ final class AgentBundleRunner {
 		$response['completion_outcome'] = $this->completion_outcome( $response );
 		$response['transcript_refs']    = $this->transcript_refs( $response );
 		$response['export_refs']        = $this->export_refs( $response );
+		$output_projection             = $this->output_projection( $response );
+		$response['outputs']           = $output_projection['outputs'];
+		$response['output_diagnostics'] = $output_projection['diagnostics'];
 
 		return $response;
 	}
@@ -241,6 +244,100 @@ final class AgentBundleRunner {
 				'exports'       => is_array( $engine_data['exports'] ?? null ) ? $engine_data['exports'] : null,
 			)
 		);
+	}
+
+	/** @return array{outputs:array<string,mixed>,diagnostics:array<string,mixed>} */
+	private function output_projection( array $response ): array {
+		$engine_data = is_array( $response['engine_data'] ?? null ) ? $response['engine_data'] : array();
+		$declared    = $this->declared_output_keys( $engine_data );
+		$outputs     = array();
+
+		foreach ( $declared as $key ) {
+			if ( $this->has_output_value( $engine_data[ $key ] ?? null ) ) {
+				$outputs[ $key ] = $engine_data[ $key ];
+			}
+		}
+
+		if ( is_array( $engine_data['outputs'] ?? null ) ) {
+			foreach ( $engine_data['outputs'] as $key => $value ) {
+				$key = sanitize_key( (string) $key );
+				if ( '' !== $key && $this->has_output_value( $value ) ) {
+					$outputs[ $key ] = $value;
+				}
+			}
+		}
+
+		foreach ( $engine_data as $key => $value ) {
+			$key = (string) $key;
+			if ( ! isset( $outputs[ $key ] ) && $this->is_common_output_key( $key ) && $this->has_output_value( $value ) ) {
+				$outputs[ $key ] = $value;
+			}
+		}
+
+		$present = array_keys( $outputs );
+		$missing = array_values( array_diff( $declared, $present ) );
+
+		return array(
+			'outputs'     => $outputs,
+			'diagnostics' => self::compact_response_array(
+				array(
+					'declared_outputs' => $declared,
+					'present_outputs'  => $present,
+					'missing_outputs'  => $missing,
+				)
+			),
+		);
+	}
+
+	/** @return array<int,string> */
+	private function declared_output_keys( array $engine_data ): array {
+		$keys = array();
+		foreach ( array( 'completion_assertions_required', 'completion_assertions_satisfied' ) as $group ) {
+			$assertions = is_array( $engine_data[ $group ] ?? null ) ? $engine_data[ $group ] : array();
+			if ( is_array( $assertions['engine_data_keys'] ?? null ) ) {
+				$keys = array_merge( $keys, $assertions['engine_data_keys'] );
+			}
+		}
+
+		$missing = is_array( $engine_data['completion_assertions_missing'] ?? null ) ? $engine_data['completion_assertions_missing'] : array();
+		if ( is_array( $missing['engine_data_keys'] ?? null ) ) {
+			$keys = array_merge( $keys, $missing['engine_data_keys'] );
+		}
+
+		$keys = array_map( static fn( $key ): string => sanitize_key( (string) $key ), $keys );
+		$keys = array_filter( $keys, static fn( string $key ): bool => '' !== $key );
+
+		return array_values( array_unique( $keys ) );
+	}
+
+	private function has_output_value( mixed $value ): bool {
+		return null !== $value && '' !== $value && array() !== $value;
+	}
+
+	private function is_common_output_key( string $key ): bool {
+		$key = sanitize_key( $key );
+		if ( '' === $key ) {
+			return false;
+		}
+
+		$internal_keys = array(
+			'action_id',
+			'agent_id',
+			'agent_slug',
+			'flow_id',
+			'flow_step_id',
+			'job_id',
+			'parent_job_id',
+			'pipeline_id',
+			'pipeline_step_id',
+			'post_id',
+			'user_id',
+		);
+		if ( in_array( $key, $internal_keys, true ) ) {
+			return false;
+		}
+
+		return 1 === preg_match( '/(^|_)(id|ids|number|path|paths|slug|title|url|urls)$/', $key );
 	}
 
 	/** @return array<string,mixed> */

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -150,8 +150,8 @@ final class AgentBundleRunner {
 		$response['completion_outcome'] = $this->completion_outcome( $response );
 		$response['transcript_refs']    = $this->transcript_refs( $response );
 		$response['export_refs']        = $this->export_refs( $response );
-		$output_projection             = $this->output_projection( $response );
-		$response['outputs']           = $output_projection['outputs'];
+		$output_projection              = $this->output_projection( $response );
+		$response['outputs']            = $output_projection['outputs'];
 		$response['output_diagnostics'] = $output_projection['diagnostics'];
 
 		return $response;

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -11,6 +11,14 @@ $root     = dirname( __DIR__ );
 $failures = array();
 $passes   = 0;
 
+defined( 'ABSPATH' ) || define( 'ABSPATH', $root . '/' );
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $key ) ) ?? '';
+	}
+}
+
 function datamachine_bundle_runner_assert( bool $condition, string $label, array &$failures, int &$passes ): void {
 	if ( $condition ) {
 		++$passes;
@@ -38,6 +46,7 @@ echo "\n[1] Ability exposes the headless runner contract\n";
 foreach ( array(
 	'datamachine/run-agent-bundle' => 'run-agent-bundle ability registered',
 	'runAgentBundleInputSchema'    => 'dedicated input schema declared',
+	'runAgentBundleOutputSchema'   => 'dedicated output schema declared',
 	'AgentBundleRunner'            => 'ability delegates to runner service',
 	'runRuntimeAgentBundle'        => 'generic runtime run adapter declared',
 	"'show_in_rest' => true"      => 'ability is REST-visible for headless callers',
@@ -58,6 +67,8 @@ foreach ( array(
 	"apply_filters( 'wp_agent_runtime_import_bundle'" => 'runner falls back to generic runtime bundle import filter',
 	"'runtime_imports'"                         => 'runner returns runtime import diagnostics',
 	"'completion_outcome'"                      => 'runner returns completion outcome summary',
+	"'outputs'"                                 => 'runner returns semantic output map',
+	"'output_diagnostics'"                      => 'runner returns semantic output diagnostics',
 	"'transcript_refs'"                         => 'runner returns transcript references',
 	"'export_refs'"                             => 'runner returns export references',
 	'datamachine_directives_enabled'             => 'runner owns directive controls inside Data Machine',
@@ -70,8 +81,35 @@ foreach ( array(
 ) as $needle => $label ) {
 	datamachine_bundle_runner_contains( $runner, $needle, $label, $failures, $passes );
 }
+datamachine_bundle_runner_contains( $abilities, "'outputs'", 'ability output schema advertises semantic outputs', $failures, $passes );
+datamachine_bundle_runner_contains( $abilities, "'output_diagnostics'", 'ability output schema advertises semantic output diagnostics', $failures, $passes );
 
-echo "\n[3] WP-CLI wraps the same ability instead of duplicating runner internals\n";
+echo "\n[3] Runner exposes semantic outputs without hiding raw engine data\n";
+require_once $root . '/inc/Engine/Bundle/AgentBundleRunner.php';
+$runner_reflection = new ReflectionClass( DataMachine\Engine\Bundle\AgentBundleRunner::class );
+$runner_instance   = $runner_reflection->newInstanceWithoutConstructor();
+$output_projection = $runner_reflection->getMethod( 'output_projection' );
+$projected_outputs = $output_projection->invoke(
+	$runner_instance,
+	array(
+		'engine_data' => array(
+			'completion_assertions_required' => array( 'engine_data_keys' => array( 'issue_number', 'issue_url', 'missing_result_url' ) ),
+			'issue_number'                   => 123,
+			'issue_url'                      => 'https://github.com/Extra-Chill/data-machine/issues/2519',
+			'result_path'                    => 'artifacts/result.json',
+			'agent_id'                       => 7,
+			'outputs'                        => array( 'summary_title' => 'semantic output projection' ),
+		),
+	)
+);
+datamachine_bundle_runner_assert( 123 === ( $projected_outputs['outputs']['issue_number'] ?? null ), 'declared issue_number output is projected', $failures, $passes );
+datamachine_bundle_runner_assert( 'https://github.com/Extra-Chill/data-machine/issues/2519' === ( $projected_outputs['outputs']['issue_url'] ?? null ), 'declared issue_url output is projected', $failures, $passes );
+datamachine_bundle_runner_assert( 'artifacts/result.json' === ( $projected_outputs['outputs']['result_path'] ?? null ), 'common scalar task output is projected', $failures, $passes );
+datamachine_bundle_runner_assert( 'semantic output projection' === ( $projected_outputs['outputs']['summary_title'] ?? null ), 'explicit outputs map is projected', $failures, $passes );
+datamachine_bundle_runner_assert( ! isset( $projected_outputs['outputs']['agent_id'] ), 'runtime identity fields are not projected as outputs', $failures, $passes );
+datamachine_bundle_runner_assert( array( 'missing_result_url' ) === ( $projected_outputs['diagnostics']['missing_outputs'] ?? null ), 'missing declared outputs are diagnosed semantically', $failures, $passes );
+
+echo "\n[4] WP-CLI wraps the same ability instead of duplicating runner internals\n";
 foreach ( array(
 	'@subcommand run-bundle'       => 'run-bundle subcommand declared',
 	'AgentAbilities::runAgentBundle' => 'CLI calls ability callback',
@@ -82,7 +120,7 @@ foreach ( array(
 	datamachine_bundle_runner_contains( $cli, $needle, $label, $failures, $passes );
 }
 
-echo "\n[4] Runner supports run-scoped provider/model config\n";
+echo "\n[5] Runner supports run-scoped provider/model config\n";
 foreach ( array(
 	"'provider'            => array("                                           => 'run-agent-bundle schema accepts provider',
 	"'model'               => array("                                           => 'run-agent-bundle schema accepts model',
@@ -96,7 +134,7 @@ foreach ( array(
 	datamachine_bundle_runner_contains( $abilities . $runner . $ai_step, $needle, $label, $failures, $passes );
 }
 
-echo "\n[5] Boundary stays generic\n";
+echo "\n[6] Boundary stays generic\n";
 foreach ( array( 'homeboy', 'wp-codebox' ) as $forbidden ) {
 	datamachine_bundle_runner_assert( false === stripos( $runner, $forbidden ), "runner does not mention {$forbidden}", $failures, $passes );
 }


### PR DESCRIPTION
## Summary
- Adds a stable `outputs` object to `datamachine/run-agent-bundle` responses, projected from declared completion assertion engine data keys, explicit `engine_data.outputs`, and narrow common scalar task output keys.
- Adds `output_diagnostics` with declared, present, and missing output keys so downstream callers can report semantic missing outputs instead of traversing raw engine internals.
- Advertises the new response fields in the run-agent-bundle output schema and extends the bundle runner smoke coverage.

Fixes #2519.

## Tests
- `php -l inc/Abilities/AgentAbilities.php`
- `php -l inc/Engine/Bundle/AgentBundleRunner.php`
- `php -l tests/agent-bundle-runner-contract-smoke.php`
- `php tests/agent-bundle-runner-contract-smoke.php`
- `vendor/bin/phpcs inc/Abilities/AgentAbilities.php inc/Engine/Bundle/AgentBundleRunner.php tests/agent-bundle-runner-contract-smoke.php`
- `composer lint`

## Test caveat
- `composer test` attempted the Homeboy/WP Codebox path, but the runner failed before tests executed: `Recipe workflow steps[0] failed: fetch failed`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the generic response projection, schema update, and smoke coverage; Chris remains responsible for review and merge.