### PR TITLE
Fix Action Scheduler data-machine group registration

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -48,6 +48,12 @@ if ( ! class_exists( 'ActionScheduler' ) ) {
 	require_once __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';
 }
 
+add_action(
+	'action_scheduler_init',
+	array( \DataMachine\Core\ActionScheduler\GroupRegistrar::class, 'ensureDataMachineGroup' ),
+	0
+);
+
 if ( function_exists( 'wp_installing' ) && wp_installing() ) {
 	add_action( 'wp_loaded', 'datamachine_skip_action_scheduler_migration_during_install', 0 );
 }

--- a/inc/Cli/Commands/DrainCommand.php
+++ b/inc/Cli/Commands/DrainCommand.php
@@ -9,6 +9,7 @@ namespace DataMachine\Cli\Commands;
 
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Cli\WorkerLock;
+use DataMachine\Core\ActionScheduler\GroupRegistrar;
 use WP_CLI;
 
 defined( 'ABSPATH' ) || exit;
@@ -356,6 +357,7 @@ class DrainCommand extends BaseCommand {
 		$processed   = 0;
 
 		try {
+			GroupRegistrar::ensureDataMachineGroup();
 			self::runActionSchedulerTimeoutCleanup( $store );
 			$claim = $store->stake_claim( $claim_size, null, $hooks ?? array(), self::GROUP );
 		} catch ( \Throwable $throwable ) {

--- a/inc/Core/ActionScheduler/GroupRegistrar.php
+++ b/inc/Core/ActionScheduler/GroupRegistrar.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Action Scheduler group registration helpers.
+ *
+ * @package DataMachine\Core\ActionScheduler
+ */
+
+namespace DataMachine\Core\ActionScheduler;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Keeps the Data Machine Action Scheduler group present in every AS store.
+ */
+class GroupRegistrar {
+
+	public const GROUP = 'data-machine';
+
+	/**
+	 * Ensure Action Scheduler can resolve Data Machine's group for claims/runs.
+	 */
+	public static function ensureDataMachineGroup(): void {
+		self::ensureCustomTableGroup( self::GROUP );
+		self::ensurePostStoreGroup( self::GROUP );
+	}
+
+	/**
+	 * Ensure the custom-table data store has the group row.
+	 */
+	private static function ensureCustomTableGroup( string $group ): void {
+		global $wpdb;
+
+		if ( ! isset( $wpdb ) ) {
+			return;
+		}
+
+		$table = isset( $wpdb->actionscheduler_groups )
+			? (string) $wpdb->actionscheduler_groups
+			: $wpdb->prefix . 'actionscheduler_groups';
+		if ( '' === $table || ! self::tableExists( $table ) ) {
+			return;
+		}
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Action Scheduler validates this table before claiming.
+		$group_id = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT group_id FROM %i WHERE slug = %s LIMIT 1', $table, $group ) );
+		if ( $group_id > 0 ) {
+			return;
+		}
+
+		$wpdb->insert( $table, array( 'slug' => $group ), array( '%s' ) );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	}
+
+	/**
+	 * Ensure the legacy post-store taxonomy has the group term.
+	 */
+	private static function ensurePostStoreGroup( string $group ): void {
+		$has_post_store = class_exists( '\ActionScheduler_wpPostStore', false )
+			&& defined( 'ActionScheduler_wpPostStore::GROUP_TAXONOMY' );
+		$taxonomy       = $has_post_store
+			? \ActionScheduler_wpPostStore::GROUP_TAXONOMY
+			: 'action-group';
+		if ( ! function_exists( 'taxonomy_exists' ) || ! taxonomy_exists( $taxonomy ) ) {
+			return;
+		}
+
+		if ( function_exists( 'term_exists' ) && term_exists( $group, $taxonomy ) ) {
+			return;
+		}
+
+		if ( function_exists( 'wp_insert_term' ) ) {
+			wp_insert_term( $group, $taxonomy, array( 'slug' => $group ) );
+		}
+	}
+
+	/**
+	 * Check whether a table exists before touching it.
+	 */
+	private static function tableExists( string $table ): bool {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Guarding optional Action Scheduler tables.
+		return $table === (string) $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	}
+}

--- a/tests/action-scheduler-group-registration-smoke.php
+++ b/tests/action-scheduler-group-registration-smoke.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Pure-PHP smoke test for Action Scheduler group registration (#2528).
+ *
+ * Run with: php tests/action-scheduler-group-registration-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/wordpress/' );
+}
+
+class ActionSchedulerGroupRegistrationWpdb {
+	public string $prefix = 'wp_';
+	public string $actionscheduler_groups = 'wp_actionscheduler_groups';
+	public bool $group_exists = false;
+	public array $inserted = array();
+
+	public function prepare( string $query, ...$args ) {
+		return array(
+			'query' => $query,
+			'args'  => $args,
+		);
+	}
+
+	public function get_var( $prepared ) {
+		$query = is_array( $prepared ) ? (string) $prepared['query'] : (string) $prepared;
+		if ( false !== strpos( $query, 'SHOW TABLES LIKE' ) ) {
+			return $this->actionscheduler_groups;
+		}
+
+		if ( false !== strpos( $query, 'SELECT group_id' ) ) {
+			return $this->group_exists ? 7 : 0;
+		}
+
+		return null;
+	}
+
+	public function insert( string $table, array $data, array $format = array() ): bool {
+		unset( $format );
+		$this->inserted[] = array(
+			'table' => $table,
+			'data'  => $data,
+		);
+		$this->group_exists = true;
+
+		return true;
+	}
+}
+
+function taxonomy_exists( string $taxonomy ): bool {
+	return 'action-group' === $taxonomy;
+}
+
+function term_exists( string $term, string $taxonomy ): bool {
+	unset( $taxonomy );
+	return in_array( $term, $GLOBALS['action_scheduler_group_terms'] ?? array(), true );
+}
+
+function wp_insert_term( string $term, string $taxonomy, array $args = array() ): array {
+	unset( $taxonomy, $args );
+	$GLOBALS['action_scheduler_group_terms'][] = $term;
+
+	return array( 'term_id' => count( $GLOBALS['action_scheduler_group_terms'] ) );
+}
+
+$GLOBALS['wpdb']                         = new ActionSchedulerGroupRegistrationWpdb();
+$GLOBALS['action_scheduler_group_terms'] = array();
+
+$root       = dirname( __DIR__ );
+$plugin_src = file_get_contents( $root . '/data-machine.php' ) ?: '';
+$group_src  = file_get_contents( $root . '/inc/Core/ActionScheduler/GroupRegistrar.php' ) ?: '';
+$drain_src  = file_get_contents( $root . '/inc/Cli/Commands/DrainCommand.php' ) ?: '';
+require_once $root . '/inc/Core/ActionScheduler/GroupRegistrar.php';
+
+$assertions = 0;
+
+function assert_action_scheduler_group_true( bool $condition, string $message ): void {
+	global $assertions;
+	++$assertions;
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+function assert_action_scheduler_group_contains( string $needle, string $haystack, string $message ): void {
+	assert_action_scheduler_group_true( false !== strpos( $haystack, $needle ), $message );
+}
+
+assert_action_scheduler_group_contains( 'action_scheduler_init', $plugin_src, 'plugin registers an Action Scheduler init hook' );
+assert_action_scheduler_group_contains( 'GroupRegistrar::class', $plugin_src, 'plugin hooks the Data Machine group registrar' );
+assert_action_scheduler_group_contains( 'ensureDataMachineGroup', $plugin_src, 'plugin ensures Data Machine group during AS init' );
+
+assert_action_scheduler_group_contains( "public const GROUP = 'data-machine'", $group_src, 'group registrar owns the Data Machine group slug' );
+assert_action_scheduler_group_contains( 'ensureCustomTableGroup( self::GROUP )', $group_src, 'group registrar ensures custom-table group storage' );
+assert_action_scheduler_group_contains( 'ensurePostStoreGroup( self::GROUP )', $group_src, 'group registrar ensures legacy post-store taxonomy storage' );
+assert_action_scheduler_group_contains( 'actionscheduler_groups', $group_src, 'custom-table group storage targets Action Scheduler groups table' );
+assert_action_scheduler_group_contains( 'wp_insert_term( $group, $taxonomy', $group_src, 'legacy post-store group storage creates missing action-group term' );
+
+$ensure_pos = strpos( $drain_src, 'GroupRegistrar::ensureDataMachineGroup()' );
+$claim_pos  = strpos( $drain_src, 'stake_claim( $claim_size, null, $hooks ?? array(), self::GROUP )' );
+
+assert_action_scheduler_group_true( false !== $ensure_pos, 'drain defensively ensures AS group before claiming' );
+assert_action_scheduler_group_true( false !== $claim_pos, 'drain stakes a group-scoped claim' );
+assert_action_scheduler_group_true( $ensure_pos < $claim_pos, 'drain ensures group before staking group claim' );
+
+\DataMachine\Core\ActionScheduler\GroupRegistrar::ensureDataMachineGroup();
+
+assert_action_scheduler_group_true(
+	array( 'table' => 'wp_actionscheduler_groups', 'data' => array( 'slug' => 'data-machine' ) ) === $GLOBALS['wpdb']->inserted[0],
+	'group registrar creates the custom-table group row when missing'
+);
+assert_action_scheduler_group_true(
+	in_array( 'data-machine', $GLOBALS['action_scheduler_group_terms'], true ),
+	'group registrar creates the legacy action-group taxonomy term when missing'
+);
+
+$insert_count = count( $GLOBALS['wpdb']->inserted );
+\DataMachine\Core\ActionScheduler\GroupRegistrar::ensureDataMachineGroup();
+assert_action_scheduler_group_true(
+	$insert_count === count( $GLOBALS['wpdb']->inserted ),
+	'group registrar does not duplicate the custom-table group row'
+);
+
+echo "OK ({$assertions} assertions)\n";

--- a/tests/drain-claim-ownership-smoke.php
+++ b/tests/drain-claim-ownership-smoke.php
@@ -31,6 +31,7 @@ function assert_not_contains( string $needle, string $haystack, string $message 
 
 assert_contains( 'runActionSchedulerBatch', $drain_src, 'drain processes Action Scheduler batches' );
 assert_contains( '\ActionScheduler_Store::instance()', $drain_src, 'drain uses the Action Scheduler store' );
+assert_contains( 'GroupRegistrar::ensureDataMachineGroup()', $drain_src, 'drain ensures the Data Machine group exists before claiming' );
 assert_contains( 'runActionSchedulerTimeoutCleanup( $store )', $drain_src, 'drain runs Action Scheduler timeout cleanup before claiming work' );
 assert_contains( 'stake_claim( $claim_size, null, $hooks ?? array(), self::GROUP )', $drain_src, 'drain stakes a group-scoped Action Scheduler claim' );
 assert_contains( '$claim->get_actions()', $drain_src, 'drain processes actions from the claim' );
@@ -44,6 +45,7 @@ assert_contains( '$store->release_claim( $claim )', $drain_src, 'drain releases 
 assert_not_contains( 'getDuePendingActionIds', $drain_src, 'drain no longer preselects due action IDs outside Action Scheduler claims' );
 assert_contains( 'laneActionRows', $drain_src, 'drain only selects action IDs for lane filtering/status, not direct processing' );
 
+$ensure_pos  = strpos( $drain_src, 'GroupRegistrar::ensureDataMachineGroup()' );
 $cleanup_pos = strpos( $drain_src, 'runActionSchedulerTimeoutCleanup( $store )' );
 $stake_pos   = strpos( $drain_src, 'stake_claim( $claim_size, null, $hooks ?? array(), self::GROUP )' );
 $verify_pos  = strpos( $drain_src, 'find_actions_by_claim_id( $claim->get_id() )' );
@@ -52,6 +54,7 @@ $flush_pos   = strpos( $drain_src, 'flushRuntimeCache()' );
 $memory_pos  = strpos( $drain_src, 'isMemorySoftLimitReached()' );
 $release_pos = strpos( $drain_src, '$store->release_claim( $claim )' );
 
+assert_true( false !== $ensure_pos, 'group registration position found' );
 assert_true( false !== $cleanup_pos, 'timeout cleanup position found' );
 assert_true( false !== $stake_pos, 'claim staking position found' );
 assert_true( false !== $verify_pos, 'claim verification position found' );
@@ -59,6 +62,7 @@ assert_true( false !== $process_pos, 'claimed action processing position found' 
 assert_true( false !== $flush_pos, 'runtime cache flush position found' );
 assert_true( false !== $memory_pos, 'memory soft-limit check position found' );
 assert_true( false !== $release_pos, 'claim release position found' );
+assert_true( $ensure_pos < $stake_pos, 'drain ensures group before staking a claim' );
 assert_true( $cleanup_pos < $stake_pos, 'drain cleans stale claims before staking a claim' );
 assert_true( $stake_pos < $verify_pos, 'drain stakes a claim before verifying ownership' );
 assert_true( $verify_pos < $process_pos, 'drain verifies ownership before processing' );

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -54,6 +54,7 @@ assert_drain_contains( 'hookWhereSql( $hooks, $job_ids )', $drain_src, 'drain su
 assert_drain_contains( 'a.args LIKE %s', $drain_src, 'drain can filter pending actions by serialized job_id args' );
 assert_drain_contains( '"parent_job_id":', $drain_src, 'drain can filter batch actions by serialized parent_job_id args' );
 assert_drain_contains( "a.status = \\'pending\\'", $drain_src, 'drain queries pending actions in the Data Machine group' );
+assert_drain_contains( 'GroupRegistrar::ensureDataMachineGroup()', $drain_src, 'drain ensures Action Scheduler can resolve the Data Machine group before claiming' );
 assert_drain_contains( 'runActionSchedulerTimeoutCleanup( $store )', $drain_src, 'drain resets stale Action Scheduler claims before claiming work' );
 assert_drain_contains( 'stake_claim( $claim_size, null, $hooks ?? array(), self::GROUP )', $drain_src, 'drain claims due Data Machine actions through Action Scheduler' );
 assert_drain_contains( 'claimSizeForScope( $batch_size, $hooks, $job_ids, $lane )', $drain_src, 'drain sizes claims using the requested job and lane scope' );


### PR DESCRIPTION
## Summary
- Ensure the Data Machine Action Scheduler group is registered during `action_scheduler_init` across both custom-table and legacy post-store group storage.
- Defensively ensure the group immediately before `wp datamachine drain` stakes its group-scoped Action Scheduler claim.
- Add focused smoke coverage for the group registration contract and the drain claim ordering.

## Root cause
`ActionScheduler_HybridStore::stake_claim()` asks the legacy post store to claim first, and `ActionScheduler_wpPostStore` throws when the `action-group` taxonomy term is missing. On intelligence.horse the custom-table group row exists, so `action list --group=data-machine` can show pending rows, but group-scoped claim/run rejects the slug before reaching the custom-table claim path.

## Validation
- `php tests/action-scheduler-group-registration-smoke.php`
- `php tests/flow-run-cli-drain-smoke.php`
- `php tests/drain-claim-ownership-smoke.php`
- `php -l data-machine.php && php -l inc/Core/ActionScheduler/GroupRegistrar.php && php -l inc/Cli/Commands/DrainCommand.php && php -l tests/action-scheduler-group-registration-smoke.php`
- `git diff --check HEAD~1..HEAD`

## Known validation caveats
- `composer test` did not reach PHPUnit. The Homeboy/WP Codebox harness mounted the plugin without `vendor/autoload.php` and also reported `/home/chubes/.config/homeboy/extensions/scripts/lib/test-result-adapters.sh: No such file or directory` from the runner-side parser.
- `vendor/bin/phpcs ...` is not currently actionable for this repo/worktree because the configured standard flags the repo's established WordPress tab/bracing/test-helper style heavily, including unchanged files.

Closes #2528.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Root-cause analysis, implementation, focused smoke coverage, validation, and PR drafting. Chris remains responsible for review and testing.