### PR TITLE
Honor runtime principals for agents chat

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -39,6 +39,13 @@ class AgentsChatHandler {
 	 * @return bool
 	 */
 	public function checkPermission( bool $allowed, array $input ): bool {
+		if ( ! $allowed ) {
+			$principal = $this->resolveCallerPrincipal( $input );
+			if ( null !== $principal && (bool) apply_filters( 'agents_chat_runtime_principal_permission', false, $principal, $input ) ) {
+				return true;
+			}
+		}
+
 		$agent = trim( (string) ( $input['agent'] ?? '' ) );
 		if ( '' === $agent ) {
 			return $allowed || PermissionHelper::can( 'chat' );
@@ -50,6 +57,34 @@ class AgentsChatHandler {
 		}
 
 		return $allowed || \WP_Agent_Access::can_current_principal_access_agent( $identity->agent_slug, \WP_Agent_Access_Grant::ROLE_VIEWER );
+	}
+
+	/**
+	 * Resolve an explicit non-REST runtime principal supplied by trusted runtime code.
+	 *
+	 * @param array $input Canonical chat input.
+	 * @return object|null
+	 */
+	private function resolveCallerPrincipal( array $input ): ?object {
+		$principal_class = '\AgentsAPI\AI\WP_Agent_Execution_Principal';
+		if ( defined( 'REST_REQUEST' ) || ! class_exists( $principal_class ) ) {
+			return null;
+		}
+
+		$principal = $input['principal'] ?? null;
+		if ( $principal instanceof \AgentsAPI\AI\WP_Agent_Execution_Principal ) {
+			return $principal;
+		}
+
+		if ( is_array( $principal ) ) {
+			try {
+				return \AgentsAPI\AI\WP_Agent_Execution_Principal::from_array( $principal );
+			} catch ( \InvalidArgumentException ) {
+				return null;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/tests/agents-chat-handler-smoke.php
+++ b/tests/agents-chat-handler-smoke.php
@@ -80,10 +80,13 @@ $assert( str_contains( $chat_abilities, 'new AgentsChatHandler();' ), 'ChatAbili
 $assert( str_contains( $handler_source, "register_chat_handler( array( $" . "this, 'execute' ) )" ), 'AgentsChatHandler attaches to canonical Agents API chat handler seam' );
 $assert( ! str_contains( $handler_source, "wp_agent_chat_handler" ), 'AgentsChatHandler no longer falls back to legacy chat handler filter' );
 $assert( str_contains( $handler_source, 'ChatOrchestrator::processChat(' ), 'AgentsChatHandler owns the single ChatOrchestrator runtime call' );
-$assert( str_contains( $handler_source, "'selected_pipeline_id' => (int) ( $" . "input['selected_pipeline_id'] ?? 0 )" ), 'AgentsChatHandler forwards selected pipeline context' );
-$assert( str_contains( $handler_source, "'request_id'           => $" . "input['request_id'] ?? null" ), 'AgentsChatHandler forwards request id for session dedupe' );
-$assert( str_contains( $handler_source, "'interrupt_source'     => is_callable( $" . "input['interrupt_source'] ?? null ) ? $" . "input['interrupt_source'] : null" ), 'AgentsChatHandler explicitly forwards callable interrupt sources' );
-$assert( str_contains( $handler_source, "'agent_slug'           => $" . "identity ? $" . "identity->agent_slug : ''" ), 'AgentsChatHandler forwards resolved agent targeting to the chat runtime' );
+$assert( str_contains( $handler_source, "'selected_pipeline_id'  => (int) ( $" . "input['selected_pipeline_id'] ?? 0 )" ), 'AgentsChatHandler forwards selected pipeline context' );
+$assert( str_contains( $handler_source, "'request_id'            => $" . "input['request_id'] ?? null" ), 'AgentsChatHandler forwards request id for session dedupe' );
+$assert( str_contains( $handler_source, "'interrupt_source'      => is_callable( $" . "input['interrupt_source'] ?? null ) ? $" . "input['interrupt_source'] : null" ), 'AgentsChatHandler explicitly forwards callable interrupt sources' );
+$assert( str_contains( $handler_source, "'agent_slug'            => $" . "identity ? $" . "identity->agent_slug : ''" ), 'AgentsChatHandler forwards resolved agent targeting to the chat runtime' );
+$assert( str_contains( $handler_source, "apply_filters( 'agents_chat_runtime_principal_permission'" ), 'AgentsChatHandler delegates explicit runtime principal permission decisions' );
+$assert( str_contains( $handler_source, "\\AgentsAPI\\AI\\WP_Agent_Execution_Principal" ), 'AgentsChatHandler resolves canonical Agents API runtime principals' );
+$assert( str_contains( $handler_source, "defined( 'REST_REQUEST' )" ), 'AgentsChatHandler ignores caller-supplied principals during REST requests' );
 $assert( str_contains( $handler_source, "'tool_policy'" ) && str_contains( $handler_source, "input['tool_policy']" ), 'AgentsChatHandler forwards caller tool policy to the chat runtime' );
 $assert( str_contains( $handler_source, "'allow_only'" ) && str_contains( $orchestrator, "options['allow_only']" ), 'agents/chat forwards caller allow_only through tool resolution' );
 $assert( str_contains( $handler_source, "'completion_assertions'" ) && str_contains( $orchestrator, "loop_context['completion_assertions']" ), 'agents/chat forwards completion assertions into the loop context' );


### PR DESCRIPTION
## Summary
- Allow Data Machine's `agents/chat` permission handler to honor explicit Agents API runtime principals supplied by trusted non-REST runtime code.
- Delegate those principal checks through the existing `agents_chat_runtime_principal_permission` seam before falling back to user/capability/agent-access checks.
- Extend the chat handler smoke test to cover the runtime-principal seam and REST spoofing guard.

Closes #2531.

## Evidence
- Downstream loop failure: https://github.com/chubes4/wp-site-generator/actions/runs/26978929650
- Failure observed in `Run Homeboy agent-task plan`: `Ability "agents/chat" does not have necessary permission.`
- WP Codebox already injects a runtime principal and registers the `agents_chat_runtime_principal_permission` filter; Data Machine was not consulting it.

## Testing
- `php tests/agents-chat-handler-smoke.php`
- `php -l inc/Abilities/Chat/AgentsChatHandler.php && php -l tests/agents-chat-handler-smoke.php && git diff --check`
- `homeboy lint data-machine --changed-since origin/main`

Note: `homeboy test data-machine` still fails before tests run in the lab runner because the mounted plugin is missing `vendor/autoload.php`; this is unrelated to the changed files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the downstream permission failure, implemented the runtime-principal permission bridge, added smoke coverage, and ran focused validation; Chris remains responsible for review and merge.