### PR TITLE
Preserve runtime chat permission grants

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -53,7 +53,7 @@ class AgentsChatHandler {
 
 		$identity = $this->resolveAgentIdentity( $agent );
 		if ( $identity instanceof WP_Error || ! class_exists( '\WP_Agent_Access' ) || ! class_exists( '\WP_Agent_Access_Grant' ) ) {
-			return false;
+			return $allowed;
 		}
 
 		return $allowed || \WP_Agent_Access::can_current_principal_access_agent( $identity->agent_slug, \WP_Agent_Access_Grant::ROLE_VIEWER );

--- a/tests/agents-chat-access-permission-smoke.php
+++ b/tests/agents-chat-access-permission-smoke.php
@@ -130,6 +130,7 @@ namespace {
 
 	$GLOBALS['datamachine_agents_chat_access_grants'] = array( 'wiki-brain' => false );
 	$assert_same( true, $handler->checkPermission( true, array( 'agent' => 'wiki-brain' ) ), 'explicit upstream admin/operator override can chat with the agent' );
+	$assert_same( true, $handler->checkPermission( true, array( 'agent' => 'wp-codebox-sandbox' ) ), 'explicit upstream runtime-principal override is preserved for runtime agent slugs' );
 
 	$GLOBALS['datamachine_agents_chat_access_broad_chat'] = true;
 	$GLOBALS['datamachine_agents_chat_access_grants']     = array( 'wiki-brain' => false );


### PR DESCRIPTION
## Summary
- Preserve an existing `agents/chat` permission grant when Data Machine cannot resolve agent-specific access metadata.
- Add a regression smoke for the WP Codebox sandbox runtime-principal path, where the runtime agent slug may not exist as a persisted Data Machine agent.

## Verification
- `php tests/agents-chat-handler-smoke.php`
- `php tests/agents-chat-access-permission-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Site Generation Loop permission failure, drafted the focused fix and regression smoke, and ran local verification; Chris remains responsible for review and merge.