### PR TITLE
Implement Agents API workflow recorder lookups

### DIFF
--- a/inc/Core/AgentsApiWorkflowJobRecorder.php
+++ b/inc/Core/AgentsApiWorkflowJobRecorder.php
@@ -115,8 +115,8 @@ class AgentsApiWorkflowJobRecorder implements WP_Agent_Workflow_Run_Recorder {
 	 * @return WP_Agent_Workflow_Run_Result[]
 	 */
 	public function recent( array $args = array() ): array {
-		$limit  = max( 1, min( 100, (int) ( $args['limit'] ?? 10 ) ) );
-		$offset = max( 0, (int) ( $args['offset'] ?? 0 ) );
+		$limit   = max( 1, min( 100, (int) ( $args['limit'] ?? 10 ) ) );
+		$offset  = max( 0, (int) ( $args['offset'] ?? 0 ) );
 		$markers = array();
 
 		if ( is_string( $args['workflow_id'] ?? null ) && '' !== $args['workflow_id'] ) {

--- a/inc/Core/AgentsApiWorkflowJobRecorder.php
+++ b/inc/Core/AgentsApiWorkflowJobRecorder.php
@@ -94,7 +94,17 @@ class AgentsApiWorkflowJobRecorder implements WP_Agent_Workflow_Run_Recorder {
 	 * @return WP_Agent_Workflow_Run_Result|null
 	 */
 	public function find( string $run_id ): ?WP_Agent_Workflow_Run_Result {
-		unset( $run_id );
+		if ( '' === $run_id ) {
+			return null;
+		}
+
+		foreach ( $this->query_jobs( array( $this->json_field_marker( 'run_id', $run_id ) ), 1, 0 ) as $job ) {
+			$result = $this->result_from_job( $job );
+			if ( $result && $run_id === $result->get_run_id() ) {
+				return $result;
+			}
+		}
+
 		return null;
 	}
 
@@ -105,8 +115,67 @@ class AgentsApiWorkflowJobRecorder implements WP_Agent_Workflow_Run_Recorder {
 	 * @return WP_Agent_Workflow_Run_Result[]
 	 */
 	public function recent( array $args = array() ): array {
-		unset( $args );
-		return array();
+		$limit  = max( 1, min( 100, (int) ( $args['limit'] ?? 10 ) ) );
+		$offset = max( 0, (int) ( $args['offset'] ?? 0 ) );
+		$markers = array();
+
+		if ( is_string( $args['workflow_id'] ?? null ) && '' !== $args['workflow_id'] ) {
+			$markers[] = $this->json_field_marker( 'workflow_id', $args['workflow_id'] );
+		}
+
+		$results = array();
+		foreach ( $this->query_jobs( $markers, $limit, $offset ) as $job ) {
+			$result = $this->result_from_job( $job );
+			if ( $result ) {
+				$results[] = $result;
+			}
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Query Agents API workflow jobs with optional exact JSON field markers.
+	 *
+	 * @param string[] $engine_data_markers JSON fragments that must be present.
+	 * @param int      $limit Bounded result limit.
+	 * @param int      $offset Result offset.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function query_jobs( array $engine_data_markers, int $limit, int $offset ): array {
+		if ( ! method_exists( $this->jobs, 'get_jobs_for_list_table' ) ) {
+			return array();
+		}
+
+		return $this->jobs->get_jobs_for_list_table(
+			array(
+				'source'               => 'agents_api_workflow',
+				'engine_data_contains' => $engine_data_markers,
+				'fields'               => array( 'job_id', 'engine_data', 'created_at' ),
+				'orderby'              => 'j.job_id',
+				'order'                => 'DESC',
+				'per_page'             => $limit,
+				'offset'               => $offset,
+			)
+		);
+	}
+
+	/**
+	 * Rebuild an Agents API workflow result from Data Machine job engine data.
+	 *
+	 * @param array<string, mixed> $job Data Machine job row.
+	 */
+	private function result_from_job( array $job ): ?WP_Agent_Workflow_Run_Result {
+		$engine_data = $job['engine_data'] ?? array();
+		if ( ! is_array( $engine_data ) || ! is_array( $engine_data['workflow_run_result'] ?? null ) ) {
+			return null;
+		}
+
+		return WP_Agent_Workflow_Run_Result::from_array( $engine_data['workflow_run_result'] );
+	}
+
+	private function json_field_marker( string $field, string $value ): string {
+		return '"' . $field . '":' . wp_json_encode( $value );
 	}
 
 	private function persist_result( WP_Agent_Workflow_Run_Result $result ): void {

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -604,6 +604,15 @@ class Jobs extends BaseRepository {
 			}
 		}
 
+		foreach ( array_filter( (array) ( $args['engine_data_contains'] ?? array() ), 'is_string' ) as $engine_data_marker ) {
+			if ( '' === $engine_data_marker ) {
+				continue;
+			}
+
+			$where_clauses[] = 'j.engine_data LIKE %s';
+			$where_values[]  = '%' . $this->wpdb->esc_like( $engine_data_marker ) . '%';
+		}
+
 		if ( isset( $args['user_id'] ) ) {
 			$where_clauses[] = 'j.user_id = %d';
 			$where_values[]  = absint( $args['user_id'] );

--- a/tests/agents-api-workflow-bridge-smoke.php
+++ b/tests/agents-api-workflow-bridge-smoke.php
@@ -33,6 +33,28 @@ namespace DataMachine\Core\Database\Jobs {
 			$this->engine_data[ $job_id ] = $data;
 			return true;
 		}
+
+		public function get_jobs_for_list_table( array $args ): array {
+			$rows = array();
+			foreach ( $this->jobs as $job_id => $job ) {
+				if ( isset( $args['source'] ) && ( $job['source'] ?? null ) !== $args['source'] ) {
+					continue;
+				}
+
+				$engine_data = $this->engine_data[ $job_id ] ?? array();
+				$encoded     = json_encode( $engine_data );
+				foreach ( (array) ( $args['engine_data_contains'] ?? array() ) as $marker ) {
+					if ( is_string( $marker ) && '' !== $marker && false === strpos( $encoded, $marker ) ) {
+						continue 2;
+					}
+				}
+
+				$rows[] = array_merge( array( 'job_id' => $job_id, 'engine_data' => $engine_data ), $job );
+			}
+
+			usort( $rows, static fn( array $a, array $b ): int => $b['job_id'] <=> $a['job_id'] );
+			return array_slice( $rows, (int) ( $args['offset'] ?? 0 ), (int) ( $args['per_page'] ?? 20 ) );
+		}
 	}
 }
 
@@ -55,6 +77,7 @@ defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
 	function apply_filters( string $hook, $value ) { unset( $hook ); return $value; }
 	function get_current_user_id(): int { return 7; }
 	function current_time( string $type, bool $gmt = false ): string { unset( $type, $gmt ); return '2026-05-28 00:00:00'; }
+	function wp_json_encode( $value ): string { return json_encode( $value ); }
 
 	$GLOBALS['__abilities'] = array();
 	function wp_get_ability( string $name ) { return $GLOBALS['__abilities'][ $name ] ?? null; }
@@ -140,6 +163,12 @@ defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
 	assert_agent_workflow_bridge_equals( 'started', $jobs->engine_data[100]['logs'][0]['message'], 'ability workflow records metadata logs explicitly', $failures, $passes );
 	assert_agent_workflow_bridge_equals( 'WP_Agent_Workflow_Runner', $jobs->engine_data[100]['provenance']['execution'], 'ability workflow records runner provenance', $failures, $passes );
 
+	$recorder     = new \DataMachine\Core\AgentsApiWorkflowJobRecorder( $jobs, array() );
+	$found_result = $recorder->find( 'run-ability-1' );
+	assert_agent_workflow_bridge_equals( 'run-ability-1', $found_result?->get_run_id(), 'recorder find returns recorded run id', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'succeeded', $found_result?->get_status(), 'recorder find reconstructs succeeded status', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'COOK', $found_result?->get_steps()[0]['output']['value'] ?? null, 'recorder find reconstructs step output', $failures, $passes );
+
 	$agent_result = $bridge->execute(
 		array(
 			'run_id' => 'run-agent-1',
@@ -155,6 +184,36 @@ defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
 	assert_agent_workflow_bridge_equals( true, $agent_result['success'], 'agent workflow succeeds when agents/chat is registered', $failures, $passes );
 	assert_agent_workflow_bridge_equals( 101, $agent_result['job_id'], 'agent workflow returns job id', $failures, $passes );
 	assert_agent_workflow_bridge_equals( 'demo-agent: hello', $jobs->engine_data[101]['step_outcomes'][0]['output']['reply'], 'agent workflow records agent step output', $failures, $passes );
+
+	$recent = $recorder->recent( array( 'limit' => 2 ) );
+	assert_agent_workflow_bridge_equals( array( 'run-agent-1', 'run-ability-1' ), array_map( static fn( $result ): string => $result->get_run_id(), $recent ), 'recorder recent returns newest workflow runs', $failures, $passes );
+
+	$recent_ability = $recorder->recent( array( 'workflow_id' => 'demo/ability-workflow' ) );
+	assert_agent_workflow_bridge_equals( array( 'run-ability-1' ), array_map( static fn( $result ): string => $result->get_run_id(), $recent_ability ), 'recorder recent filters by workflow id', $failures, $passes );
+
+	$missing_input = $bridge->execute(
+		array(
+			'run_id' => 'run-missing-input',
+			'spec'   => array(
+				'id'     => 'demo/missing-input-workflow',
+				'inputs' => array( 'text' => array( 'type' => 'string', 'required' => true ) ),
+				'steps'  => array(
+					array( 'id' => 'upper', 'type' => 'ability', 'ability' => 'demo/uppercase', 'args' => array( 'text' => '${inputs.text}' ) ),
+				),
+			),
+		)
+	);
+
+	assert_agent_workflow_bridge_equals( false, $missing_input['success'], 'missing input workflow fails', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'failed - missing_required_input', $jobs->jobs[102]['status'], 'failed workflow maps to failed job reason', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'failed', $recorder->find( 'run-missing-input' )?->get_status(), 'recorder find reconstructs failed status', $failures, $passes );
+
+	$skipped_recorder = new \DataMachine\Core\AgentsApiWorkflowJobRecorder( $jobs, array() );
+	$skipped_result   = new \AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Result( 'run-skipped', 'demo/skipped-workflow', 'skipped', array(), array(), array(), array(), 1, 2, array() );
+	$skipped_recorder->start( $skipped_result );
+	$skipped_recorder->update( $skipped_result );
+	assert_agent_workflow_bridge_equals( 'failed - agents_api_workflow_skipped', $jobs->jobs[103]['status'], 'skipped workflow maps to skipped failure reason', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'skipped', $recorder->find( 'run-skipped' )?->get_status(), 'recorder find reconstructs skipped status', $failures, $passes );
 
 	$unsupported = $bridge->execute(
 		array(


### PR DESCRIPTION
## Summary
- Implement `AgentsApiWorkflowJobRecorder::find()` and `recent()` by querying recorded Data Machine jobs and reconstructing `WP_Agent_Workflow_Run_Result` from stored engine data.
- Add a bounded engine-data marker filter to the jobs list query so workflow run lookups can match exact serialized `run_id` / `workflow_id` fields.
- Expand the Agents API workflow bridge smoke test to cover `find()`, `recent()`, workflow filtering, and failed/skipped status mapping.

## Tests
- `php tests/agents-api-workflow-bridge-smoke.php`
- `php -l inc/Core/AgentsApiWorkflowJobRecorder.php && php -l inc/Core/Database/Jobs/Jobs.php && php -l tests/agents-api-workflow-bridge-smoke.php`
- `composer lint`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing and testing Agents API workflow recorder lookup behavior; Chris remains responsible for review and validation.

Fixes #2524.