### PR TITLE
Migrate taxonomy ability failures to WP_Error

### DIFF
--- a/inc/Abilities/Taxonomy/AbstractTaxonomyAbility.php
+++ b/inc/Abilities/Taxonomy/AbstractTaxonomyAbility.php
@@ -31,6 +31,18 @@ abstract class AbstractTaxonomyAbility {
 	 */
 	abstract protected function getAbilityArgs(): array;
 
+	/**
+	 * Build a native Abilities API failure.
+	 *
+	 * @param string $code    Machine-readable error code.
+	 * @param string $message Human-readable error message.
+	 * @param int    $status  HTTP status for REST presentation.
+	 * @return \WP_Error
+	 */
+	protected function abilityError( string $code, string $message, int $status = 400 ): \WP_Error {
+		return new \WP_Error( $code, $message, array( 'status' => $status ) );
+	}
+
 	private function registerAbility(): void {
 		$register_callback = function () {
 			wp_register_ability( $this->getAbilityName(), $this->getAbilityArgs() );

--- a/inc/Abilities/Taxonomy/CreateTaxonomyTermAbility.php
+++ b/inc/Abilities/Taxonomy/CreateTaxonomyTermAbility.php
@@ -76,9 +76,9 @@ class CreateTaxonomyTermAbility extends AbstractTaxonomyAbility {
 	 * Execute create taxonomy term ability.
 	 *
 	 * @param array $input Input parameters.
-	 * @return array Result with created taxonomy term data.
+	 * @return array|\WP_Error Result with created taxonomy term data or failure.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$taxonomy    = $input['taxonomy'] ?? null;
 		$name        = $input['name'] ?? null;
 		$slug        = $input['slug'] ?? null;
@@ -87,32 +87,20 @@ class CreateTaxonomyTermAbility extends AbstractTaxonomyAbility {
 
 		// Validate required fields
 		if ( empty( $taxonomy ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'taxonomy parameter is required',
-			);
+			return $this->abilityError( 'taxonomy_required', 'taxonomy parameter is required', 400 );
 		}
 
 		if ( empty( $name ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'name parameter is required',
-			);
+			return $this->abilityError( 'term_name_required', 'name parameter is required', 400 );
 		}
 
 		// Validate taxonomy
 		if ( ! taxonomy_exists( $taxonomy ) ) {
-			return array(
-				'success' => false,
-				'error'   => "Taxonomy '{$taxonomy}' does not exist",
-			);
+			return $this->abilityError( 'taxonomy_not_found', "Taxonomy '{$taxonomy}' does not exist", 404 );
 		}
 
 		if ( TaxonomyHandler::shouldSkipTaxonomy( $taxonomy ) ) {
-			return array(
-				'success' => false,
-				'error'   => "Taxonomy '{$taxonomy}' is a system taxonomy and cannot be modified",
-			);
+			return $this->abilityError( 'taxonomy_not_modifiable', "Taxonomy '{$taxonomy}' is a system taxonomy and cannot be modified", 403 );
 		}
 
 		// Sanitize inputs
@@ -158,20 +146,18 @@ class CreateTaxonomyTermAbility extends AbstractTaxonomyAbility {
 		$result = wp_insert_term( $name, $taxonomy, $args );
 
 		if ( is_wp_error( $result ) ) {
-			return array(
-				'success' => false,
-				'error'   => $result->get_error_message(),
-			);
+			return $result;
 		}
 
 		$term_id = $result['term_id'];
 		$term    = get_term( $term_id, $taxonomy );
 
 		if ( ! $term || is_wp_error( $term ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to retrieve created term',
-			);
+			if ( is_wp_error( $term ) ) {
+				return $term;
+			}
+
+			return $this->abilityError( 'term_retrieval_failed', 'Failed to retrieve created term', 500 );
 		}
 
 		do_action(

--- a/inc/Abilities/Taxonomy/DeleteTaxonomyTermAbility.php
+++ b/inc/Abilities/Taxonomy/DeleteTaxonomyTermAbility.php
@@ -67,50 +67,35 @@ class DeleteTaxonomyTermAbility extends AbstractTaxonomyAbility {
 	 * Execute delete taxonomy term ability.
 	 *
 	 * @param array $input Input parameters.
-	 * @return array Result with deletion status.
+	 * @return array|\WP_Error Result with deletion status or failure.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$term_identifier = $input['term'] ?? null;
 		$taxonomy        = $input['taxonomy'] ?? null;
 		$reassign        = $input['reassign'] ?? null;
 
 		// Validate required fields
 		if ( empty( $term_identifier ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'term parameter is required',
-			);
+			return $this->abilityError( 'term_required', 'term parameter is required', 400 );
 		}
 
 		if ( empty( $taxonomy ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'taxonomy parameter is required',
-			);
+			return $this->abilityError( 'taxonomy_required', 'taxonomy parameter is required', 400 );
 		}
 
 		// Validate taxonomy
 		if ( ! taxonomy_exists( $taxonomy ) ) {
-			return array(
-				'success' => false,
-				'error'   => "Taxonomy '{$taxonomy}' does not exist",
-			);
+			return $this->abilityError( 'taxonomy_not_found', "Taxonomy '{$taxonomy}' does not exist", 404 );
 		}
 
 		if ( TaxonomyHandler::shouldSkipTaxonomy( $taxonomy ) ) {
-			return array(
-				'success' => false,
-				'error'   => "Taxonomy '{$taxonomy}' is a system taxonomy and cannot be modified",
-			);
+			return $this->abilityError( 'taxonomy_not_modifiable', "Taxonomy '{$taxonomy}' is a system taxonomy and cannot be modified", 403 );
 		}
 
 		// Find the term using centralized resolver
 		$resolved = ResolveTermAbility::resolve( $term_identifier, $taxonomy, false );
 		if ( ! $resolved['success'] ) {
-			return array(
-				'success' => false,
-				'error'   => $resolved['error'] ?? "Term '{$term_identifier}' not found in taxonomy '{$taxonomy}'",
-			);
+			return $this->abilityError( 'term_not_found', $resolved['error'] ?? "Term '{$term_identifier}' not found in taxonomy '{$taxonomy}'", 404 );
 		}
 		$term = get_term( $resolved['term_id'], $taxonomy );
 
@@ -118,18 +103,16 @@ class DeleteTaxonomyTermAbility extends AbstractTaxonomyAbility {
 		if ( null !== $reassign ) {
 			$reassign_term = get_term( absint( $reassign ), $taxonomy );
 			if ( ! $reassign_term || is_wp_error( $reassign_term ) ) {
-				return array(
-					'success' => false,
-					'error'   => "Reassign term ID '{$reassign}' not found in taxonomy '{$taxonomy}'",
-				);
+				if ( is_wp_error( $reassign_term ) ) {
+					return $reassign_term;
+				}
+
+				return $this->abilityError( 'reassign_term_not_found', "Reassign term ID '{$reassign}' not found in taxonomy '{$taxonomy}'", 404 );
 			}
 
 			// Cannot reassign to itself
 			if ( $reassign_term->term_id === $term->term_id ) {
-				return array(
-					'success' => false,
-					'error'   => 'Cannot reassign term to itself',
-				);
+				return $this->abilityError( 'reassign_term_invalid', 'Cannot reassign term to itself', 400 );
 			}
 		}
 
@@ -142,17 +125,11 @@ class DeleteTaxonomyTermAbility extends AbstractTaxonomyAbility {
 		$result = wp_delete_term( $term->term_id, $taxonomy, $args );
 
 		if ( is_wp_error( $result ) ) {
-			return array(
-				'success' => false,
-				'error'   => $result->get_error_message(),
-			);
+			return $result;
 		}
 
 		if ( false === $result ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to delete term (unknown error)',
-			);
+			return $this->abilityError( 'term_delete_failed', 'Failed to delete term (unknown error)', 500 );
 		}
 
 		do_action(

--- a/inc/Abilities/Taxonomy/GetTaxonomyTermsAbility.php
+++ b/inc/Abilities/Taxonomy/GetTaxonomyTermsAbility.php
@@ -96,9 +96,9 @@ class GetTaxonomyTermsAbility extends AbstractTaxonomyAbility {
 	 * Execute get taxonomy terms ability.
 	 *
 	 * @param array $input Input parameters.
-	 * @return array Result with taxonomy terms data.
+	 * @return array|\WP_Error Result with taxonomy terms data or failure.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$taxonomy   = $input['taxonomy'] ?? null;
 		$search     = $input['search'] ?? '';
 		$parent     = $input['parent'] ?? null;
@@ -110,17 +110,11 @@ class GetTaxonomyTermsAbility extends AbstractTaxonomyAbility {
 
 		// Validate taxonomy
 		if ( ! empty( $taxonomy ) && ! taxonomy_exists( $taxonomy ) ) {
-			return array(
-				'success' => false,
-				'error'   => "Taxonomy '{$taxonomy}' does not exist",
-			);
+			return $this->abilityError( 'taxonomy_not_found', "Taxonomy '{$taxonomy}' does not exist", 404 );
 		}
 
 		if ( ! empty( $taxonomy ) && TaxonomyHandler::shouldSkipTaxonomy( $taxonomy ) ) {
-			return array(
-				'success' => false,
-				'error'   => "Taxonomy '{$taxonomy}' is a system taxonomy and cannot be accessed",
-			);
+			return $this->abilityError( 'taxonomy_not_accessible', "Taxonomy '{$taxonomy}' is a system taxonomy and cannot be accessed", 403 );
 		}
 
 		// Build get_terms arguments
@@ -151,10 +145,7 @@ class GetTaxonomyTermsAbility extends AbstractTaxonomyAbility {
 		$terms = get_terms( $args );
 
 		if ( is_wp_error( $terms ) ) {
-			return array(
-				'success' => false,
-				'error'   => $terms->get_error_message(),
-			);
+			return $terms;
 		}
 
 		// Format terms data

--- a/inc/Abilities/Taxonomy/MergeTermMetaAbility.php
+++ b/inc/Abilities/Taxonomy/MergeTermMetaAbility.php
@@ -104,9 +104,9 @@ class MergeTermMetaAbility {
 	 * Execute the merge.
 	 *
 	 * @param array $input Input shape — see input_schema above.
-	 * @return array Output shape — see output_schema above.
+	 * @return array|\WP_Error Output shape or failure.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$term_id     = (int) ( $input['term_id'] ?? 0 );
 		$taxonomy    = trim( (string) ( $input['taxonomy'] ?? '' ) );
 		$data        = is_array( $input['data'] ?? null ) ? $input['data'] : array();
@@ -115,32 +115,36 @@ class MergeTermMetaAbility {
 		$description = array_key_exists( 'description', $input ) ? (string) $input['description'] : null;
 
 		if ( $term_id <= 0 ) {
-			return $this->error_response( 'term_id is required' );
+			return $this->error_response( 'term_id_required', 'term_id is required', 400 );
 		}
 
 		if ( '' === $taxonomy ) {
-			return $this->error_response( 'taxonomy is required' );
+			return $this->error_response( 'taxonomy_required', 'taxonomy is required', 400 );
 		}
 
 		if ( ! taxonomy_exists( $taxonomy ) ) {
-			return $this->error_response( "Taxonomy '{$taxonomy}' does not exist" );
+			return $this->error_response( 'taxonomy_not_found', "Taxonomy '{$taxonomy}' does not exist", 404 );
 		}
 
 		if ( TaxonomyHandler::shouldSkipTaxonomy( $taxonomy ) ) {
-			return $this->error_response( "Cannot write meta for system taxonomy '{$taxonomy}'" );
+			return $this->error_response( 'taxonomy_not_modifiable', "Cannot write meta for system taxonomy '{$taxonomy}'", 403 );
 		}
 
 		if ( empty( $field_map ) ) {
-			return $this->error_response( 'field_map is required and cannot be empty' );
+			return $this->error_response( 'field_map_required', 'field_map is required and cannot be empty', 400 );
 		}
 
 		if ( ! in_array( $strategy, array( self::STRATEGY_FILL_EMPTY, self::STRATEGY_OVERWRITE ), true ) ) {
-			return $this->error_response( "Unknown strategy '{$strategy}'" );
+			return $this->error_response( 'strategy_invalid', "Unknown strategy '{$strategy}'", 400 );
 		}
 
 		$term = get_term( $term_id, $taxonomy );
 		if ( ! $term || is_wp_error( $term ) ) {
-			return $this->error_response( "Term {$term_id} not found in taxonomy '{$taxonomy}'" );
+			if ( is_wp_error( $term ) ) {
+				return $term;
+			}
+
+			return $this->error_response( 'term_not_found', "Term {$term_id} not found in taxonomy '{$taxonomy}'", 404 );
 		}
 
 		$updated = array();
@@ -198,7 +202,7 @@ class MergeTermMetaAbility {
 				);
 
 				if ( is_wp_error( $result ) ) {
-					return $this->error_response( $result->get_error_message() );
+					return $result;
 				}
 
 				$description_updated = true;
@@ -218,14 +222,13 @@ class MergeTermMetaAbility {
 	/**
 	 * Build error response.
 	 *
+	 * @param string $code    Machine-readable error code.
 	 * @param string $message Error message.
-	 * @return array
+	 * @param int    $status  HTTP status for REST presentation.
+	 * @return \WP_Error
 	 */
-	private function error_response( string $message ): array {
-		return array(
-			'success' => false,
-			'error'   => $message,
-		);
+	private function error_response( string $code, string $message, int $status ): \WP_Error {
+		return new \WP_Error( $code, $message, array( 'status' => $status ) );
 	}
 
 	/**
@@ -268,6 +271,14 @@ class MergeTermMetaAbility {
 			$input['description'] = $description;
 		}
 
-		return ( new self() )->execute( $input );
+		$result = ( new self() )->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success' => false,
+				'error'   => $result->get_error_message(),
+			);
+		}
+
+		return $result;
 	}
 }

--- a/inc/Abilities/Taxonomy/ResolveTermAbility.php
+++ b/inc/Abilities/Taxonomy/ResolveTermAbility.php
@@ -114,9 +114,9 @@ class ResolveTermAbility {
 	 * 4. If create=true and not found, create via wp_insert_term()
 	 *
 	 * @param array $input Input with identifier, taxonomy, create flag, optional args.
-	 * @return array Success with term data or error.
+	 * @return array|\WP_Error Success with term data or failure.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$identifier = trim( (string) ( $input['identifier'] ?? '' ) );
 		$taxonomy   = trim( (string) ( $input['taxonomy'] ?? '' ) );
 		$create     = (bool) ( $input['create'] ?? false );
@@ -125,19 +125,19 @@ class ResolveTermAbility {
 
 		// Validate inputs.
 		if ( empty( $identifier ) ) {
-			return $this->error_response( 'identifier is required' );
+			return $this->error_response( 'identifier_required', 'identifier is required', 400 );
 		}
 
 		if ( empty( $taxonomy ) ) {
-			return $this->error_response( 'taxonomy is required' );
+			return $this->error_response( 'taxonomy_required', 'taxonomy is required', 400 );
 		}
 
 		if ( ! taxonomy_exists( $taxonomy ) ) {
-			return $this->error_response( "Taxonomy '{$taxonomy}' does not exist" );
+			return $this->error_response( 'taxonomy_not_found', "Taxonomy '{$taxonomy}' does not exist", 404 );
 		}
 
 		if ( TaxonomyHandler::shouldSkipTaxonomy( $taxonomy ) ) {
-			return $this->error_response( "Cannot resolve terms in system taxonomy '{$taxonomy}'" );
+			return $this->error_response( 'taxonomy_not_modifiable', "Cannot resolve terms in system taxonomy '{$taxonomy}'", 403 );
 		}
 
 		// 1. Check if numeric - try by ID first.
@@ -175,7 +175,7 @@ class ResolveTermAbility {
 			$insert_args = $this->normalize_term_args( $term_args );
 			$result      = wp_insert_term( $identifier, $taxonomy, $insert_args );
 			if ( is_wp_error( $result ) ) {
-				return $this->error_response( $result->get_error_message() );
+				return $result;
 			}
 			$term = get_term( $result['term_id'], $taxonomy );
 			if ( $term && ! is_wp_error( $term ) ) {
@@ -194,7 +194,7 @@ class ResolveTermAbility {
 			}
 		}
 
-		return $this->error_response( "Term '{$identifier}' not found in taxonomy '{$taxonomy}'" );
+		return $this->error_response( 'term_not_found', "Term '{$identifier}' not found in taxonomy '{$taxonomy}'", 404 );
 	}
 
 	/**
@@ -342,14 +342,13 @@ class ResolveTermAbility {
 	/**
 	 * Build error response.
 	 *
+	 * @param string $code    Machine-readable error code.
 	 * @param string $message Error message.
-	 * @return array
+	 * @param int    $status  HTTP status for REST presentation.
+	 * @return \WP_Error
 	 */
-	private function error_response( string $message ): array {
-		return array(
-			'success' => false,
-			'error'   => $message,
-		);
+	private function error_response( string $code, string $message, int $status ): \WP_Error {
+		return new \WP_Error( $code, $message, array( 'status' => $status ) );
 	}
 
 	/**
@@ -376,7 +375,7 @@ class ResolveTermAbility {
 	 */
 	public static function resolve( string $identifier, string $taxonomy, bool $create = false, array $args = array(), bool $fuzzy = false ): array {
 		$instance = new self();
-		return $instance->execute(
+		$result   = $instance->execute(
 			array(
 				'identifier' => $identifier,
 				'taxonomy'   => $taxonomy,
@@ -385,5 +384,14 @@ class ResolveTermAbility {
 				'fuzzy'      => $fuzzy,
 			)
 		);
+
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success' => false,
+				'error'   => $result->get_error_message(),
+			);
+		}
+
+		return $result;
 	}
 }

--- a/inc/Abilities/Taxonomy/UpdateTaxonomyTermAbility.php
+++ b/inc/Abilities/Taxonomy/UpdateTaxonomyTermAbility.php
@@ -80,9 +80,9 @@ class UpdateTaxonomyTermAbility extends AbstractTaxonomyAbility {
 	 * Execute update taxonomy term ability.
 	 *
 	 * @param array $input Input parameters.
-	 * @return array Result with updated taxonomy term data.
+	 * @return array|\WP_Error Result with updated taxonomy term data or failure.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$term_identifier = $input['term'] ?? null;
 		$taxonomy        = $input['taxonomy'] ?? null;
 		$name            = $input['name'] ?? null;
@@ -92,41 +92,26 @@ class UpdateTaxonomyTermAbility extends AbstractTaxonomyAbility {
 
 		// Validate required fields
 		if ( empty( $term_identifier ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'term parameter is required',
-			);
+			return $this->abilityError( 'term_required', 'term parameter is required', 400 );
 		}
 
 		if ( empty( $taxonomy ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'taxonomy parameter is required',
-			);
+			return $this->abilityError( 'taxonomy_required', 'taxonomy parameter is required', 400 );
 		}
 
 		// Validate taxonomy
 		if ( ! taxonomy_exists( $taxonomy ) ) {
-			return array(
-				'success' => false,
-				'error'   => "Taxonomy '{$taxonomy}' does not exist",
-			);
+			return $this->abilityError( 'taxonomy_not_found', "Taxonomy '{$taxonomy}' does not exist", 404 );
 		}
 
 		if ( TaxonomyHandler::shouldSkipTaxonomy( $taxonomy ) ) {
-			return array(
-				'success' => false,
-				'error'   => "Taxonomy '{$taxonomy}' is a system taxonomy and cannot be modified",
-			);
+			return $this->abilityError( 'taxonomy_not_modifiable', "Taxonomy '{$taxonomy}' is a system taxonomy and cannot be modified", 403 );
 		}
 
 		// Find the term using centralized resolver
 		$resolved = ResolveTermAbility::resolve( $term_identifier, $taxonomy, false );
 		if ( ! $resolved['success'] ) {
-			return array(
-				'success' => false,
-				'error'   => $resolved['error'] ?? "Term '{$term_identifier}' not found in taxonomy '{$taxonomy}'",
-			);
+			return $this->abilityError( 'term_not_found', $resolved['error'] ?? "Term '{$term_identifier}' not found in taxonomy '{$taxonomy}'", 404 );
 		}
 		$term = get_term( $resolved['term_id'], $taxonomy );
 
@@ -208,19 +193,17 @@ class UpdateTaxonomyTermAbility extends AbstractTaxonomyAbility {
 		$result = wp_update_term( $term->term_id, $taxonomy, $args );
 
 		if ( is_wp_error( $result ) ) {
-			return array(
-				'success' => false,
-				'error'   => $result->get_error_message(),
-			);
+			return $result;
 		}
 
 		$updated_term = get_term( $term->term_id, $taxonomy );
 
 		if ( ! $updated_term || is_wp_error( $updated_term ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to retrieve updated term',
-			);
+			if ( is_wp_error( $updated_term ) ) {
+				return $updated_term;
+			}
+
+			return $this->abilityError( 'term_retrieval_failed', 'Failed to retrieve updated term', 500 );
 		}
 
 		do_action(

--- a/tests/Unit/Abilities/TaxonomyAbilityWpErrorTest.php
+++ b/tests/Unit/Abilities/TaxonomyAbilityWpErrorTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Tests for taxonomy ability WP_Error failures.
+ *
+ * @package DataMachine\Tests\Unit\Abilities
+ */
+
+namespace DataMachine\Tests\Unit\Abilities;
+
+use DataMachine\Abilities\Taxonomy\CreateTaxonomyTermAbility;
+use DataMachine\Abilities\Taxonomy\GetTaxonomyTermsAbility;
+use DataMachine\Abilities\Taxonomy\MergeTermMetaAbility;
+use DataMachine\Abilities\Taxonomy\ResolveTermAbility;
+use WP_Error;
+use WP_UnitTestCase;
+
+class TaxonomyAbilityWpErrorTest extends WP_UnitTestCase {
+
+	private const TEST_TAXONOMY = 'dm_wp_error_terms';
+
+	public function set_up(): void {
+		parent::set_up();
+
+		register_taxonomy(
+			self::TEST_TAXONOMY,
+			array( 'post' ),
+			array(
+				'public'       => true,
+				'hierarchical' => true,
+			)
+		);
+	}
+
+	public function tear_down(): void {
+		unregister_taxonomy( self::TEST_TAXONOMY );
+
+		parent::tear_down();
+	}
+
+	public function test_create_taxonomy_term_validation_failure_returns_wp_error(): void {
+		$result = ( new CreateTaxonomyTermAbility() )->execute( array( 'name' => 'Charleston' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'taxonomy_required', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] ?? null );
+	}
+
+	public function test_get_taxonomy_terms_not_found_returns_wp_error(): void {
+		$result = ( new GetTaxonomyTermsAbility() )->execute( array( 'taxonomy' => 'missing_taxonomy' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'taxonomy_not_found', $result->get_error_code() );
+		$this->assertSame( 404, $result->get_error_data()['status'] ?? null );
+	}
+
+	public function test_resolve_term_callback_failure_returns_wp_error(): void {
+		$result = ( new ResolveTermAbility() )->execute(
+			array(
+				'identifier' => 'Missing Term',
+				'taxonomy'   => self::TEST_TAXONOMY,
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'term_not_found', $result->get_error_code() );
+		$this->assertSame( 404, $result->get_error_data()['status'] ?? null );
+	}
+
+	public function test_resolve_term_static_helper_preserves_legacy_failure_array(): void {
+		$result = ResolveTermAbility::resolve( 'Missing Term', self::TEST_TAXONOMY );
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'Missing Term', $result['error'] );
+	}
+
+	public function test_merge_term_meta_callback_failure_returns_wp_error(): void {
+		$result = ( new MergeTermMetaAbility() )->execute(
+			array(
+				'term_id'   => 0,
+				'taxonomy'  => self::TEST_TAXONOMY,
+				'data'      => array( 'name' => 'Charleston' ),
+				'field_map' => array( 'name' => 'dm_name' ),
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'term_id_required', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] ?? null );
+	}
+
+	public function test_merge_term_meta_static_helper_preserves_legacy_failure_array(): void {
+		$result = MergeTermMetaAbility::merge(
+			0,
+			self::TEST_TAXONOMY,
+			array( 'name' => 'Charleston' ),
+			array( 'name' => 'dm_name' )
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'term_id is required', $result['error'] );
+	}
+}


### PR DESCRIPTION
## Summary
- Migrates taxonomy ability callback failures from legacy `success => false` arrays to native `WP_Error` results with explicit error codes and REST status data.
- Preserves successful taxonomy ability payloads and keeps `ResolveTermAbility::resolve()` / `MergeTermMetaAbility::merge()` returning legacy failure arrays for existing internal callers.
- Adds focused coverage for callback `WP_Error` failures and static-helper compatibility.

## Scope
This is the taxonomy ability slice of #2522. The full migration remains broader across chat, content, engine, flow, pipeline, media, SEO, settings, file, auth, and other ability families.

Refs #2522

## Tests
- `php -l inc/Abilities/Taxonomy/AbstractTaxonomyAbility.php`
- `php -l inc/Abilities/Taxonomy/CreateTaxonomyTermAbility.php`
- `php -l inc/Abilities/Taxonomy/UpdateTaxonomyTermAbility.php`
- `php -l inc/Abilities/Taxonomy/DeleteTaxonomyTermAbility.php`
- `php -l inc/Abilities/Taxonomy/GetTaxonomyTermsAbility.php`
- `php -l inc/Abilities/Taxonomy/ResolveTermAbility.php`
- `php -l inc/Abilities/Taxonomy/MergeTermMetaAbility.php`
- `php -l tests/Unit/Abilities/TaxonomyAbilityWpErrorTest.php`
- `composer test` — passed: 1322 passed, 4 skipped
- `composer lint`

## Notes
- `composer test` completed successfully, then Homeboy printed a non-fatal adapter-path notice after the passed result: `/home/chubes/.config/homeboy/extensions/scripts/lib/test-result-adapters.sh: No such file or directory`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Auditing the ability failure migration scope, implementing the taxonomy `WP_Error` slice, adding tests, and preparing this PR description. Chris remains responsible for review and validation.