### PR TITLE
Avoid unsafe late ability registration

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -488,10 +488,10 @@ require_once __DIR__ . '/inc/Abilities/AbilityCategories.php';
  * notice flood in debug.log. See: Extra-Chill/data-machine#2290.
  *
  * Registration is cheap (two ability definitions, both schema-only until
- * actually executed). The class's `ensure_registered()` uses the same
- * three-state defensive pattern as `AbilityCategories::ensure_registered()`
- * adopted in #2288, so it tolerates the lazy abilities-registry
- * instantiation race described there.
+ * actually executed). The class's `ensure_registered()` uses the public
+ * Abilities API lifecycle only: register during `wp_abilities_api_init`, hook
+ * before it fires, and no-op after it has fired instead of mutating registry
+ * internals.
  */
 require_once __DIR__ . '/inc/Abilities/Media/ImageTemplateAbilities.php';
 \DataMachine\Abilities\Media\ImageTemplateAbilities::ensure_registered();

--- a/inc/Abilities/AbilityCategories.php
+++ b/inc/Abilities/AbilityCategories.php
@@ -77,15 +77,11 @@ class AbilityCategories {
 	 *      land in this same dispatch pass.
 	 *   2. `! did_action( wp_abilities_api_categories_init )` — the action
 	 *      has not fired yet. Attach a hook for the lazy fire.
-	 *   3. otherwise — the action has already fired and completed. The
-	 *      categories registry singleton exists; call its instance method
-	 *      directly so the categories still land in the registry. The
-	 *      public `wp_register_ability_category()` helper enforces
-	 *      `doing_action()`, but the underlying registry method does not.
-	 *
-	 * This mirrors the defensive pattern used by `block-format-bridge`
-	 * (see `vendor/chubes4/block-format-bridge/includes/abilities.php`)
-	 * and by sibling extension plugins.
+	 *   3. otherwise — the action has already fired and completed. Do not
+	 *      register; the public `wp_register_ability_category()` helper
+	 *      intentionally enforces this lifecycle, and Data Machine must not
+	 *      bypass it by writing through `WP_Ability_Categories_Registry`
+	 *      directly.
 	 *
 	 * @return void
 	 */
@@ -104,30 +100,13 @@ class AbilityCategories {
 			return;
 		}
 
-		// Action already fired and completed. The categories registry
-		// singleton exists; register directly via the instance method so
-		// late-loaded contexts (e.g. lazy abilities-registry instantiation
-		// triggered before our `plugins_loaded` hook attached) still get
-		// the Data Machine categories. The instance-method path bypasses
-		// the public helper's `doing_action()` guard.
-		$registry = \WP_Ability_Categories_Registry::get_instance();
-		if ( null === $registry ) {
-			return;
-		}
-
-		foreach ( self::get_category_definitions() as $slug => $args ) {
-			if ( $registry->is_registered( $slug ) ) {
-				continue;
-			}
-			$registry->register( $slug, $args );
-		}
-
-		self::$registered = true;
+		// The public Abilities API does not expose a late category-registration
+		// surface. Once the init action has fired, avoid mutating registry internals.
 	}
 
 	/**
-	 * Category definitions used by both `register()` and the late-fire
-	 * recovery path in `ensure_registered()`.
+	 * Category definitions used by both `register()` and lifecycle-safe
+	 * registration checks in `ensure_registered()`.
 	 *
 	 * @return array<string, array<string, string>>
 	 */

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -33,28 +33,22 @@ class AgentAbilities {
 	private const ACTIVE_AGENT_META_KEY = 'datamachine_active_agent_slug';
 
 	/**
-	 * Register an ability during or after the Abilities API init hook.
+	 * Register an ability only during the public Abilities API init lifecycle.
 	 *
-	 * WordPress' public helper intentionally only works while
-	 * `wp_abilities_api_init` is firing. Agent bundle import may lazy-load this
-	 * registry after that hook has completed inside browser Playgrounds, so late
-	 * registration needs to go through the registry instance directly.
+	 * WordPress' public helper is intentionally scoped to
+	 * `wp_abilities_api_init`. Data Machine must not bypass that lifecycle by
+	 * writing through `WP_Abilities_Registry` directly.
 	 *
 	 * @param string $name Ability name.
 	 * @param array  $args Ability arguments.
-	 * @return \WP_Ability|null Registered ability, or null on failure.
+	 * @return \WP_Ability|null Registered ability, or null when called outside the official lifecycle.
 	 */
 	private static function registerAbility( string $name, array $args ): ?\WP_Ability {
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			return \wp_register_ability( $name, $args );
-		}
-
-		$registry = \WP_Abilities_Registry::get_instance();
-		if ( null === $registry || $registry->is_registered( $name ) ) {
+		if ( ! doing_action( 'wp_abilities_api_init' ) ) {
 			return null;
 		}
 
-		return $registry->register( $name, $args );
+		return \wp_register_ability( $name, $args );
 	}
 
 	public function __construct() {
@@ -62,9 +56,9 @@ class AgentAbilities {
 			return;
 		}
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
 			$this->registerAbilities();
-		} else {
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
 			add_action( 'wp_abilities_api_init', array( $this, 'registerAbilities' ) );
 		}
 		self::$registered = true;

--- a/inc/Abilities/Media/ImageTemplateAbilities.php
+++ b/inc/Abilities/Media/ImageTemplateAbilities.php
@@ -35,19 +35,10 @@ class ImageTemplateAbilities {
 	 *      so the abilities land in this same dispatch pass.
 	 *   2. `! did_action( wp_abilities_api_init )` — the action has not
 	 *      fired yet. Attach a hook for the lazy fire.
-	 *   3. otherwise — the action has already fired and completed. The
-	 *      abilities registry singleton exists; call its instance method
-	 *      directly so the abilities still land in the registry. The
-	 *      public `wp_register_ability()` helper enforces `doing_action()`,
-	 *      but the underlying registry method does not.
-	 *
-	 * Without state (3), late-loaded contexts silently drop registrations
-	 * — for example a lite-mode frontend request that triggers
-	 * `wp_get_ability()` from a plugin running ahead of our
-	 * `plugins_loaded` hook will instantiate the abilities registry, fire
-	 * `wp_abilities_api_init` to completion, and only then reach our
-	 * loader. This is the same race `AbilityCategories::ensure_registered()`
-	 * defends against after #2288.
+	 *   3. otherwise — the action has already fired and completed. Do not
+	 *      register; the public `wp_register_ability()` helper intentionally
+	 *      enforces this lifecycle, and Data Machine must not bypass it by
+	 *      writing through `WP_Abilities_Registry` directly.
 	 *
 	 * @return void
 	 */
@@ -84,22 +75,8 @@ class ImageTemplateAbilities {
 			return;
 		}
 
-		// State 3: action already fired. Bypass the helper's `doing_action()`
-		// guard by writing through the registry instance directly.
-		if ( ! class_exists( '\WP_Abilities_Registry' ) ) {
-			return;
-		}
-		$registry = \WP_Abilities_Registry::get_instance();
-		if ( null === $registry ) {
-			return;
-		}
-		foreach ( $definitions as $name => $args ) {
-			if ( $registry->is_registered( $name ) ) {
-				continue;
-			}
-			$registry->register( $name, $args );
-		}
-		self::$registered = true;
+		// The public Abilities API does not expose a late-registration surface.
+		// Once the init action has fired, avoid mutating registry internals.
 	}
 
 	/**

--- a/inc/Abilities/Publish/SendEmailAbility.php
+++ b/inc/Abilities/Publish/SendEmailAbility.php
@@ -88,20 +88,8 @@ class SendEmailAbility {
 			return;
 		}
 
-		if ( ! class_exists( '\WP_Abilities_Registry' ) ) {
-			return;
-		}
-		$registry = \WP_Abilities_Registry::get_instance();
-		if ( null === $registry ) {
-			return;
-		}
-		foreach ( self::get_ability_definitions( self::$instance ) as $name => $args ) {
-			if ( $registry->is_registered( $name ) ) {
-				continue;
-			}
-			$registry->register( $name, $args );
-		}
-		self::$registered = true;
+		// The public Abilities API does not expose a late-registration surface.
+		// Once the init action has fired, avoid mutating registry internals.
 	}
 
 	/**

--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -109,20 +109,8 @@ class SendEmailQueuedAbility {
 			return;
 		}
 
-		if ( ! class_exists( '\WP_Abilities_Registry' ) ) {
-			return;
-		}
-		$registry = \WP_Abilities_Registry::get_instance();
-		if ( null === $registry ) {
-			return;
-		}
-		foreach ( self::get_ability_definitions( self::$instance ) as $name => $args ) {
-			if ( $registry->is_registered( $name ) ) {
-				continue;
-			}
-			$registry->register( $name, $args );
-		}
-		self::$registered = true;
+		// The public Abilities API does not expose a late-registration surface.
+		// Once the init action has fired, avoid mutating registry internals.
 	}
 
 	/**

--- a/tests/abilities-categories-load-order-smoke.php
+++ b/tests/abilities-categories-load-order-smoke.php
@@ -13,10 +13,10 @@
  *    available on every request that touches the abilities API.
  *
  * 2. Behavioral assertions — `AbilityCategories::ensure_registered()` must
- *    handle all three timing states defensively:
+ *    use the public lifecycle-safe registration path:
  *      - `doing_action()` → register immediately
  *      - `! did_action()` → hook for later
- *      - already-fired → register directly via the registry instance
+ *      - already-fired → no-op instead of writing through registry internals
  *
  * Run with: php tests/abilities-categories-load-order-smoke.php
  *
@@ -75,7 +75,7 @@ $assert(
 );
 
 // ============================================================
-// Behavioral assertions: defensive three-state pattern
+// Behavioral assertions: lifecycle-safe registration pattern
 // ============================================================
 
 $assert(
@@ -90,14 +90,14 @@ $assert(
 );
 
 $assert(
-	'ensure_registered() handles post-action state via registry instance',
-	str_contains( $categories, 'WP_Ability_Categories_Registry::get_instance()' )
-		&& str_contains( $categories, '$registry->register(' )
+	'ensure_registered() avoids post-action registry writes',
+	! str_contains( $categories, 'WP_Ability_Categories_Registry::get_instance()' )
+		&& ! str_contains( $categories, '$registry->register(' )
 );
 
 $assert(
-	'post-action recovery path is idempotent (skips already-registered slugs)',
-	str_contains( $categories, '$registry->is_registered( $slug )' )
+	'ensure_registered() documents missing late category registration surface',
+	str_contains( $categories, 'does not expose a late category-registration' )
 );
 
 $assert(
@@ -158,35 +158,6 @@ if ( ! function_exists( 'wp_register_ability_category' ) ) {
 	}
 }
 
-// Stub the categories registry singleton for the post-action recovery test.
-if ( ! class_exists( 'WP_Ability_Categories_Registry' ) ) {
-	class WP_Ability_Categories_Registry {
-		/** @var array<string, array<string, mixed>> */
-		public array $registered = array();
-		private static ?self $instance = null;
-
-		public static function get_instance(): ?self {
-			if ( null === self::$instance ) {
-				self::$instance = new self();
-			}
-			return self::$instance;
-		}
-
-		public static function reset(): void {
-			self::$instance = null;
-		}
-
-		public function is_registered( string $slug ): bool {
-			return isset( $this->registered[ $slug ] );
-		}
-
-		public function register( string $slug, array $args ): bool {
-			$this->registered[ $slug ] = $args;
-			return true;
-		}
-	}
-}
-
 $GLOBALS['dm_2287_state'] = $state;
 
 require_once $plugin_root . '/inc/Abilities/AbilityCategories.php';
@@ -201,10 +172,8 @@ $reset = static function (): void {
 
 	$reflection = new ReflectionClass( \DataMachine\Abilities\AbilityCategories::class );
 	$prop       = $reflection->getProperty( 'registered' );
-	$prop->setAccessible( true );
 	$prop->setValue( null, false );
 
-	WP_Ability_Categories_Registry::reset();
 };
 
 // --- State 1: doing_action — register immediately via helper.
@@ -232,35 +201,23 @@ $assert(
 		&& empty( $state->registered )
 );
 
-// --- State 3: post-action — register directly via registry instance.
-//
-// This is the #2287 scenario: the abilities registry was instantiated by a
-// frontend `wp_get_ability()` call (e.g. Frontend Agent Chat enqueue) before
-// Data Machine's hook was attached. Without the recovery path, every
-// `wp_register_ability( ..., [ 'category' => 'datamachine-publishing' ] )`
-// in extension plugins triggers a `_doing_it_wrong` notice and the ability
-// is dropped from the registry.
+// --- State 3: post-action — no-op instead of mutating registry internals.
 $reset();
 $state->doing = false;
 $state->did   = 1; // action has fired and completed
 \DataMachine\Abilities\AbilityCategories::ensure_registered();
-$registry = WP_Ability_Categories_Registry::get_instance();
 $assert(
-	'state 3 (regression for #2287): when action already fired, categories register directly via registry instance',
-	$registry instanceof WP_Ability_Categories_Registry
-		&& $registry->is_registered( 'datamachine-publishing' )
-		&& $registry->is_registered( 'datamachine-fetch' )
-		&& $registry->is_registered( 'datamachine-analytics' )
-		&& $registry->is_registered( 'datamachine-media' )
+	'state 3: when action already fired, categories do not register late',
+	empty( $state->registered )
 );
 
 $assert(
-	'state 3: recovery path does not call wp_register_ability_category() (which would fire _doing_it_wrong)',
+	'state 3: no-op path does not call wp_register_ability_category() (which would fire _doing_it_wrong)',
 	0 === ( $state->doing_it_wrong ?? 0 )
 );
 
 $assert(
-	'state 3: recovery path does not double-hook the action',
+	'state 3: no-op path does not double-hook the action',
 	empty( $state->hooked )
 );
 

--- a/tests/abilities-image-template-load-order-smoke.php
+++ b/tests/abilities-image-template-load-order-smoke.php
@@ -69,7 +69,7 @@ $assert(
 );
 
 // ============================================================
-// Behavioral assertions: defensive three-state pattern
+// Behavioral assertions: lifecycle-safe registration pattern
 // ============================================================
 
 $assert(
@@ -84,14 +84,14 @@ $assert(
 );
 
 $assert(
-	'ensure_registered() handles post-action state via registry instance',
-	str_contains( $class_source, '\WP_Abilities_Registry::get_instance()' )
-		&& str_contains( $class_source, '$registry->register( $name, $args )' )
+	'ensure_registered() avoids post-action registry writes',
+	! str_contains( $class_source, '\WP_Abilities_Registry::get_instance()' )
+		&& ! str_contains( $class_source, '$registry->register( $name, $args )' )
 );
 
 $assert(
-	'post-action recovery path is idempotent (skips already-registered abilities)',
-	str_contains( $class_source, '$registry->is_registered( $name )' )
+	'ensure_registered() documents missing late registration surface',
+	str_contains( $class_source, 'does not expose a late-registration surface' )
 );
 
 $assert(
@@ -156,35 +156,6 @@ if ( ! function_exists( 'wp_register_ability' ) ) {
 	}
 }
 
-// Stub the abilities registry singleton for the post-action recovery test.
-if ( ! class_exists( 'WP_Abilities_Registry' ) ) {
-	class WP_Abilities_Registry {
-		/** @var array<string, array<string, mixed>> */
-		public array $registered = array();
-		private static ?self $instance = null;
-
-		public static function get_instance(): ?self {
-			if ( null === self::$instance ) {
-				self::$instance = new self();
-			}
-			return self::$instance;
-		}
-
-		public static function reset(): void {
-			self::$instance = null;
-		}
-
-		public function is_registered( string $name ): bool {
-			return isset( $this->registered[ $name ] );
-		}
-
-		public function register( string $name, array $args ): bool {
-			$this->registered[ $name ] = $args;
-			return true;
-		}
-	}
-}
-
 // Stub PermissionHelper which the ability definitions reference.
 if ( ! class_exists( 'DataMachine\\Abilities\\PermissionHelper' ) ) {
 	eval(
@@ -207,10 +178,8 @@ $reset = static function (): void {
 
 	$reflection = new ReflectionClass( \DataMachine\Abilities\Media\ImageTemplateAbilities::class );
 	$prop       = $reflection->getProperty( 'registered' );
-	$prop->setAccessible( true );
 	$prop->setValue( null, false );
 
-	WP_Abilities_Registry::reset();
 };
 
 // --- State 1: doing_action — register immediately.
@@ -234,40 +203,31 @@ $assert(
 		&& empty( $GLOBALS['dm_2290_state']->registered )
 );
 
-// --- State 3: post-action — register directly via registry instance.
-//
-// This is the #2290 scenario: a lite frontend request triggered the abilities
-// registry to instantiate and fire `wp_abilities_api_init` to completion
-// before the Data Machine plugin's `plugins_loaded` callback ran. Without
-// the recovery path, `wp_get_ability( 'datamachine/render-image-template' )`
-// would return `null` and emit `_doing_it_wrong`.
+// --- State 3: post-action — no-op instead of mutating registry internals.
 $reset();
 $GLOBALS['dm_2290_state']->did = 1;
 \DataMachine\Abilities\Media\ImageTemplateAbilities::ensure_registered();
-$registry = WP_Abilities_Registry::get_instance();
 $assert(
-	'state 3 (regression for #2290): when action already fired, abilities register directly via registry instance',
-	$registry instanceof WP_Abilities_Registry
-		&& $registry->is_registered( 'datamachine/render-image-template' )
-		&& $registry->is_registered( 'datamachine/list-image-templates' )
+	'state 3: when action already fired, abilities do not register late',
+	empty( $GLOBALS['dm_2290_state']->registered )
 );
 
 $assert(
-	'state 3: recovery path does not call wp_register_ability() (which would fire _doing_it_wrong)',
+	'state 3: no-op path does not call wp_register_ability() (which would fire _doing_it_wrong)',
 	0 === $GLOBALS['dm_2290_state']->doing_it_wrong
 );
 
 $assert(
-	'state 3: recovery path does not double-hook the action',
+	'state 3: no-op path does not double-hook the action',
 	empty( $GLOBALS['dm_2290_state']->hooked )
 );
 
-// --- Idempotency: a second ensure_registered() after success is a no-op.
-$prior_registered = $registry->registered;
+// --- Idempotency: a second post-action ensure_registered() remains a no-op.
+$prior_registered = $GLOBALS['dm_2290_state']->registered;
 \DataMachine\Abilities\Media\ImageTemplateAbilities::ensure_registered();
 $assert(
-	'idempotent: second ensure_registered() call is a no-op (static guard)',
-	$registry->registered === $prior_registered
+	'idempotent: second post-action ensure_registered() call is a no-op',
+	$GLOBALS['dm_2290_state']->registered === $prior_registered
 		&& 0 === $GLOBALS['dm_2290_state']->doing_it_wrong
 );
 

--- a/tests/abilities-send-email-load-order-smoke.php
+++ b/tests/abilities-send-email-load-order-smoke.php
@@ -69,13 +69,13 @@ foreach ( array( 'send-email' => $send_source, 'send-email-queued' => $queue_sou
 			&& str_contains( $source, "add_action(\n\t\t\t\t'wp_abilities_api_init'" )
 	);
 	$assert(
-		"{$label}: ensure_registered() handles post-action state via registry instance",
-		str_contains( $source, '\\WP_Abilities_Registry::get_instance()' )
-			&& str_contains( $source, '$registry->register( $name, $args )' )
+		"{$label}: ensure_registered() avoids post-action registry writes",
+		! str_contains( $source, '\\WP_Abilities_Registry::get_instance()' )
+			&& ! str_contains( $source, '$registry->register( $name, $args )' )
 	);
 	$assert(
-		"{$label}: recovery path skips already-registered abilities",
-		str_contains( $source, '$registry->is_registered( $name )' )
+		"{$label}: ensure_registered() documents missing late registration surface",
+		str_contains( $source, 'does not expose a late-registration surface' )
 	);
 	$assert(
 		"{$label}: definitions are shared across timing branches",
@@ -135,34 +135,6 @@ if ( ! function_exists( 'wp_register_ability' ) ) {
 	}
 }
 
-if ( ! class_exists( 'WP_Abilities_Registry' ) ) {
-	class WP_Abilities_Registry {
-		/** @var array<string, array<string, mixed>> */
-		public array $registered = array();
-		private static ?self $instance = null;
-
-		public static function get_instance(): ?self {
-			if ( null === self::$instance ) {
-				self::$instance = new self();
-			}
-			return self::$instance;
-		}
-
-		public static function reset(): void {
-			self::$instance = null;
-		}
-
-		public function is_registered( string $name ): bool {
-			return isset( $this->registered[ $name ] );
-		}
-
-		public function register( string $name, array $args ): bool {
-			$this->registered[ $name ] = $args;
-			return true;
-		}
-	}
-}
-
 if ( ! class_exists( 'DataMachine\\Abilities\\PermissionHelper' ) ) {
 	eval(
 		'namespace DataMachine\\Abilities;
@@ -200,7 +172,6 @@ $reset = static function () use ( $reset_class ): void {
 
 	$reset_class( \DataMachine\Abilities\Publish\SendEmailAbility::class );
 	$reset_class( \DataMachine\Abilities\Publish\SendEmailQueuedAbility::class );
-	WP_Abilities_Registry::reset();
 };
 
 $reset();
@@ -227,25 +198,22 @@ $reset();
 $GLOBALS['datamachine_2303_state']->did = 1;
 \DataMachine\Abilities\Publish\SendEmailAbility::ensure_registered();
 \DataMachine\Abilities\Publish\SendEmailQueuedAbility::ensure_registered();
-$registry = WP_Abilities_Registry::get_instance();
 $assert(
-	'state 3: post-action registers both email abilities directly via registry instance',
-	$registry instanceof WP_Abilities_Registry
-		&& $registry->is_registered( 'datamachine/send-email' )
-		&& $registry->is_registered( 'datamachine/send-email-queued' )
+	'state 3: post-action does not register email abilities late',
+	empty( $GLOBALS['datamachine_2303_state']->registered )
 );
 
 $assert(
-	'state 3: recovery path avoids wp_register_ability() doing-it-wrong notices',
+	'state 3: no-op path avoids wp_register_ability() doing-it-wrong notices',
 	0 === $GLOBALS['datamachine_2303_state']->doing_it_wrong
 );
 
-$prior_registered = $registry->registered;
+$prior_registered = $GLOBALS['datamachine_2303_state']->registered;
 \DataMachine\Abilities\Publish\SendEmailAbility::ensure_registered();
 \DataMachine\Abilities\Publish\SendEmailQueuedAbility::ensure_registered();
 $assert(
-	'idempotent: repeated ensure_registered() calls are no-ops after success',
-	$registry->registered === $prior_registered
+	'idempotent: repeated post-action ensure_registered() calls remain no-ops',
+	$GLOBALS['datamachine_2303_state']->registered === $prior_registered
 		&& 0 === $GLOBALS['datamachine_2303_state']->doing_it_wrong
 );
 

--- a/tests/agent-abilities-late-registration-smoke.php
+++ b/tests/agent-abilities-late-registration-smoke.php
@@ -8,23 +8,41 @@
 namespace {
 	define( 'ABSPATH', sys_get_temp_dir() . '/datamachine-agent-abilities-late-registration/' );
 
-	$GLOBALS['datamachine_test_registered_abilities'] = array();
-	$GLOBALS['datamachine_test_added_actions']        = array();
+	$GLOBALS['datamachine_test_state'] = (object) array(
+		'doing'         => false,
+		'did'           => 0,
+		'registered'    => array(),
+		'added_actions' => array(),
+	);
+
+	class WP_Ability {}
 
 	function doing_action( string $hook = '' ): bool {
-		return false;
+		return 'wp_abilities_api_init' === $hook && $GLOBALS['datamachine_test_state']->doing;
 	}
 
 	function did_action( string $hook = '' ): int {
-		return 'wp_abilities_api_init' === $hook ? 1 : 0;
+		return 'wp_abilities_api_init' === $hook ? $GLOBALS['datamachine_test_state']->did : 0;
 	}
 
 	function add_action( string $hook, callable $callback ): void {
-		$GLOBALS['datamachine_test_added_actions'][] = array( $hook, $callback );
+		$GLOBALS['datamachine_test_state']->added_actions[] = array( $hook, $callback );
 	}
 
-	function wp_register_ability( string $name, array $args ): void {
-		$GLOBALS['datamachine_test_registered_abilities'][ $name ] = $args;
+	function wp_register_ability( string $name, array $args ): ?WP_Ability {
+		if ( ! doing_action( 'wp_abilities_api_init' ) ) {
+			return null;
+		}
+
+		$GLOBALS['datamachine_test_state']->registered[ $name ] = $args;
+		return new WP_Ability();
+	}
+}
+
+namespace DataMachine\Engine\Bundle {
+	class AgentBundleArtifactRebase {
+		public const POLICY_CONSERVATIVE = 'conservative';
+		public const POLICY_BURN_IN_SAFE = 'burn-in-safe';
 	}
 }
 
@@ -46,14 +64,46 @@ namespace {
 		echo "ok - {$label}\n";
 	};
 
-	echo "=== AgentAbilities Registration Timing Smoke (#1846) ===\n";
+	$reset_registered_guard = static function (): void {
+		$reflection = new ReflectionClass( AgentAbilities::class );
+		$prop       = $reflection->getProperty( 'registered' );
+		$prop->setValue( null, false );
+	};
 
+	$reset_state = static function () use ( $reset_registered_guard ): void {
+		$GLOBALS['datamachine_test_state']->doing         = false;
+		$GLOBALS['datamachine_test_state']->did           = 0;
+		$GLOBALS['datamachine_test_state']->registered    = array();
+		$GLOBALS['datamachine_test_state']->added_actions = array();
+		$reset_registered_guard();
+	};
+
+	echo "=== AgentAbilities Registration Timing Smoke (#2523) ===\n";
+
+	$source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/AgentAbilities.php' ) ?: '';
+	$assert( 'agent abilities avoid direct WP_Abilities_Registry registration', ! str_contains( $source, 'WP_Abilities_Registry::get_instance()' ) );
+	$assert( 'agent abilities document lifecycle-scoped registration', str_contains( $source, 'official lifecycle' ) );
+
+	$reset_state();
 	new AgentAbilities();
+	$assert( 'pre-action constructor hooks wp_abilities_api_init registration', 1 === count( $GLOBALS['datamachine_test_state']->added_actions ) );
+	$assert( 'pre-action constructor does not register immediately', array() === $GLOBALS['datamachine_test_state']->registered );
 
-	$registered = array_keys( $GLOBALS['datamachine_test_registered_abilities'] );
+	$GLOBALS['datamachine_test_state']->doing = true;
+	$GLOBALS['datamachine_test_state']->did   = 1;
+	foreach ( $GLOBALS['datamachine_test_state']->added_actions as $action ) {
+		$action[1]();
+	}
+	$GLOBALS['datamachine_test_state']->doing = false;
 
-	$assert( 'does not call wp_register_ability after wp_abilities_api_init has fired', array() === $registered );
-	$assert( 'does not defer to an already-fired action', array() === $GLOBALS['datamachine_test_added_actions'] );
+	$registered = array_keys( $GLOBALS['datamachine_test_state']->registered );
+	$assert( 'normal bootstrap registers agent bundle/import abilities during wp_abilities_api_init', in_array( 'datamachine/import-agent', $registered, true ) && in_array( 'datamachine/run-agent-bundle', $registered, true ) );
+
+	$reset_state();
+	$GLOBALS['datamachine_test_state']->did = 1;
+	new AgentAbilities();
+	$assert( 'post-action constructor does not call wp_register_ability after wp_abilities_api_init has fired', array() === $GLOBALS['datamachine_test_state']->registered );
+	$assert( 'post-action constructor does not defer to an already-fired action', array() === $GLOBALS['datamachine_test_state']->added_actions );
 
 	$plugin_source   = file_get_contents( dirname( __DIR__ ) . '/data-machine.php' ) ?: '';
 	$provider_offset = strpos( $plugin_source, 'new \\DataMachine\\Engine\\AI\\System\\SystemAgentServiceProvider();' );


### PR DESCRIPTION
## Summary
- Remove Data Machine's direct late-registration writes through `WP_Abilities_Registry` and `WP_Ability_Categories_Registry`.
- Keep ability/category registration on the lifecycle-safe public path: register while the Abilities API init action is firing, hook before it fires, and no-op after it has already fired.
- Update timing smokes to prove normal bootstrap registration still happens during `wp_abilities_api_init` and post-action calls no longer rely on private registry behavior.

Closes https://github.com/Extra-Chill/data-machine/issues/2523

## Tests
- `php tests/agent-abilities-late-registration-smoke.php && php tests/abilities-image-template-load-order-smoke.php && php tests/abilities-send-email-load-order-smoke.php && php tests/abilities-categories-load-order-smoke.php`
- `composer lint`
- `composer test` — 1320 total, 1316 passed, 4 skipped

## Blockers
- No code blocker. The available Abilities API surface does not expose a public late ability/category registration contract, so this PR avoids late registration instead of replacing it with another late-registration API.
- `npm test -- --runInBand` is not available because `package.json` has no `test` script.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Auditing Data Machine ability registration lifecycle paths, drafting the lifecycle-safe code/test changes, and running verification.