### PR TITLE
Project global tools through abilities

### DIFF
--- a/docs/ai-tools/tools-overview.md
+++ b/docs/ai-tools/tools-overview.md
@@ -1,6 +1,8 @@
 # AI Tools Overview
 
-AI tools are registered by `inc/Engine/AI/Tools/ToolServiceProvider.php` into the unified Data Machine tool registry. Tools declare where they can run (`chat`, `pipeline`, or pipeline-policy mode) and the ability or access level required to execute them.
+AI tools should be exposed as WordPress Ability projections whenever a single registered ability already owns the execution contract. `inc/Engine/AI/Tools/ToolServiceProvider.php` still instantiates tool classes so they can register configuration handlers and ability projections, but the model-facing declaration should use `datamachine_register_ability_tool()` instead of a class/method handler when possible.
+
+The legacy `datamachine_tools` class/method registry remains for composite orchestration tools and adjacent handler tools that do not map cleanly to one public ability. Tools declare where they can run (`chat`, `pipeline`, or pipeline-policy mode) and the ability or access level required to execute them.
 
 ## Registered Tool Inventory
 
@@ -119,7 +121,22 @@ Common extension tools include:
 
 ## Tool Architecture
 
-Tool classes extend `BaseTool` and register themselves with `registerTool()`. Registration declares:
+Ability-native projections are the preferred model-tool path:
+
+- Register the underlying WordPress ability with `wp_register_ability()`.
+- Expose it to model runs with `datamachine_register_ability_tool()` or the `datamachine_ability_tool_projections` filter.
+- Put model-facing overrides such as `description`, `modes`, `parameters`, `requires_config`, and action-policy metadata on the projection declaration.
+
+Class/method tool declarations are still explicit exceptions:
+
+- `agent_memory` and `agent_daily_memory` compose several file/memory abilities behind one action router and resolve agent/user scope before dispatch.
+- `internal_link_audit` composes several internal-link abilities behind one action router and strips internal response keys.
+- `queue_validator` contains duplicate-prevention orchestration across published posts and queue state that is reused by queue-add behavior.
+- `web_fetch` has no registered WordPress ability yet; it remains a class/method tool until a first-class fetch ability exists.
+- Chat-only workflow/admin tools in `inc/Api/Chat/Tools/` remain Data Machine product tools until each one has a public ability contract worth projecting.
+- Adjacent handler tools remain runtime-generated class/method declarations because their schemas depend on neighboring pipeline handler configuration.
+
+Legacy tool classes extend `BaseTool` and register themselves with `registerTool()`. Registration declares:
 
 - tool slug
 - definition callback

--- a/inc/Engine/AI/Tools/Global/ImageGeneration.php
+++ b/inc/Engine/AI/Tools/Global/ImageGeneration.php
@@ -26,7 +26,20 @@ class ImageGeneration extends BaseTool {
 
 	public function __construct() {
 		$this->registerConfigurationHandlers( 'image_generation' );
-		$this->registerTool( 'image_generation', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ), array( 'ability' => 'datamachine/generate-image' ) );
+		if ( ! function_exists( '\datamachine_register_ability_tool' ) ) {
+			return;
+		}
+
+		\datamachine_register_ability_tool(
+			'image_generation',
+			array_merge(
+				$this->getToolDefinition(),
+				array(
+					'ability' => 'datamachine/generate-image',
+					'modes'   => array( 'chat', 'pipeline' ),
+				)
+			)
+		);
 	}
 
 	/**
@@ -93,8 +106,6 @@ class ImageGeneration extends BaseTool {
 	 */
 	public function getToolDefinition(): array {
 		return array(
-			'class'           => __CLASS__,
-			'method'          => 'handle_tool_call',
 			'description'     => 'Generate images using wp-ai-client image models. Returns a pending image-generation job that will sideload the generated image and optionally set it as featured media. Use descriptive, detailed prompts for best results. Default aspect ratio is 3:4 (portrait, ideal for Pinterest and blog featured images).',
 			'requires_config' => true,
 			'parameters'      => array(

--- a/inc/Engine/AI/Tools/Global/LocalSearch.php
+++ b/inc/Engine/AI/Tools/Global/LocalSearch.php
@@ -17,7 +17,20 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class LocalSearch extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'local_search', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ), array( 'ability' => 'datamachine/local-search' ) );
+		if ( ! function_exists( '\datamachine_register_ability_tool' ) ) {
+			return;
+		}
+
+		\datamachine_register_ability_tool(
+			'local_search',
+			array_merge(
+				$this->getToolDefinition(),
+				array(
+					'ability' => 'datamachine/local-search',
+					'modes'   => array( 'chat', 'pipeline' ),
+				)
+			)
+		);
 	}
 
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
@@ -65,8 +78,6 @@ class LocalSearch extends BaseTool {
 
 	public function getToolDefinition(): array {
 		return array(
-			'class'           => __CLASS__,
-			'method'          => 'handle_tool_call',
 			'description'     => 'Search this WordPress site for posts by title or content. Returns up to 10 results with titles, excerpts, permalinks, and metadata. Automatically tries multiple search strategies (standard search, title matching, split queries) if initial search returns no results. For best results, search for ONE item at a time. Use title_only=true for precise title matching.',
 			'requires_config' => false,
 			'parameters'      => array(

--- a/inc/Engine/AI/Tools/Global/WordPressPostReader.php
+++ b/inc/Engine/AI/Tools/Global/WordPressPostReader.php
@@ -17,7 +17,20 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class WordPressPostReader extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'wordpress_post_reader', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ), array( 'ability' => 'datamachine/get-wordpress-post' ) );
+		if ( ! function_exists( '\datamachine_register_ability_tool' ) ) {
+			return;
+		}
+
+		\datamachine_register_ability_tool(
+			'wordpress_post_reader',
+			array_merge(
+				$this->getToolDefinition(),
+				array(
+					'ability' => 'datamachine/get-wordpress-post',
+					'modes'   => array( 'chat', 'pipeline' ),
+				)
+			)
+		);
 	}
 
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
@@ -100,8 +113,6 @@ class WordPressPostReader extends BaseTool {
 	 */
 	public function getToolDefinition(): array {
 		return array(
-			'class'           => __CLASS__,
-			'method'          => 'handle_tool_call',
 			'name'            => 'WordPress Post Reader',
 			'description'     => 'Read full content and metadata from a specific WordPress post by permalink URL. Use after Local Search when you need complete post content instead of excerpts. Accepts standard WordPress permalinks (e.g., /post-slug/) or shortlinks (?p=123). Does NOT accept REST API URLs (/wp-json/...). Essential for content analysis before WordPress Update operations.',
 			'requires_config' => false,

--- a/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
+++ b/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
@@ -13,6 +13,7 @@ namespace DataMachine\Engine\AI\Tools\Sources;
 
 use DataMachine\Engine\AI\Tools\ToolManager;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
+use DataMachine\Core\PluginSettings;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -96,15 +97,13 @@ final class AbilityToolSource {
 				continue;
 			}
 
-			if ( ! ToolPolicyResolver::isOptInToolAllowed( $tool, $tool_name, $args ) ) {
+			$include_unavailable = ! empty( $args['include_unavailable'] );
+
+			if ( ! $include_unavailable && ! ToolPolicyResolver::isOptInToolAllowed( $tool, $tool_name, $args ) ) {
 				continue;
 			}
 
-			if ( ! empty( $tool['requires_config'] ) ) {
-				if ( ! $this->tool_manager->is_tool_available( $tool_name, null ) ) {
-					continue;
-				}
-			} elseif ( ! $this->tool_manager->is_globally_enabled( $tool_name ) ) {
+			if ( ! $include_unavailable && ! $this->isToolAvailable( $tool_name, $tool ) ) {
 				continue;
 			}
 
@@ -198,6 +197,31 @@ final class AbilityToolSource {
 		$tool_modes = is_array( $tool_modes ) ? $tool_modes : array( $tool_modes );
 
 		return ! empty( array_intersect( ToolPolicyResolver::normalizeModes( $tool_modes ), $modes ) );
+	}
+
+	/**
+	 * Whether a generated ability projection is enabled and configured.
+	 *
+	 * Ability-native tools are not necessarily present in ToolManager's static
+	 * `datamachine_tools` registry, so source-level availability must evaluate
+	 * the generated declaration directly instead of asking ToolManager to look the
+	 * tool up by name.
+	 *
+	 * @param string $tool_name Tool name.
+	 * @param array  $tool      Generated tool declaration.
+	 * @return bool Whether the tool is available.
+	 */
+	private function isToolAvailable( string $tool_name, array $tool ): bool {
+		$disabled_tools = PluginSettings::get( 'disabled_tools', array() );
+		if ( isset( $disabled_tools[ $tool_name ] ) ) {
+			return false;
+		}
+
+		if ( empty( $tool['requires_config'] ) ) {
+			return true;
+		}
+
+		return (bool) apply_filters( 'datamachine_tool_configured', false, $tool_name );
 	}
 
 }

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -16,6 +16,7 @@
 namespace DataMachine\Engine\AI\Tools;
 
 use DataMachine\Core\PluginSettings;
+use DataMachine\Engine\AI\Tools\Sources\AbilityToolSource;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -454,7 +455,7 @@ class ToolManager {
 	 * @return bool True if requires config
 	 */
 	public function requires_configuration( string $tool_id ): bool {
-		$tools = $this->get_all_tools();
+		$tools = $this->get_all_tool_declarations();
 		return ! empty( $tools[ $tool_id ]['requires_config'] );
 	}
 
@@ -520,7 +521,7 @@ class ToolManager {
 	 * @return bool True if tool is available
 	 */
 	public function is_tool_available( string $tool_id, ?string $context_id = null ): bool {
-		$tools       = $this->get_all_tools();
+		$tools       = $this->get_all_tool_declarations();
 		$tool_config = $tools[ $tool_id ] ?? null;
 
 		if ( ! $tool_config ) {
@@ -558,7 +559,7 @@ class ToolManager {
 	 * @return bool True if valid selection
 	 */
 	public function validate_tool_selection( string $tool_id ): bool {
-		$tools = $this->get_all_tools();
+		$tools = $this->get_all_tool_declarations();
 		if ( ! isset( $tools[ $tool_id ] ) ) {
 			return false; // Tool doesn't exist
 		}
@@ -613,7 +614,7 @@ class ToolManager {
 	 */
 	public function get_tools_for_step_modal( string $context_id ): array {
 		return array(
-			'global_tools'         => $this->get_all_tools(),
+			'global_tools'         => $this->get_all_tool_declarations(),
 			'modal_disabled_tools' => $this->get_step_disabled_tools( $context_id ),
 			'pipeline_step_id'     => $context_id,
 		);
@@ -625,7 +626,7 @@ class ToolManager {
 	 * @return array All global tools with status
 	 */
 	public function get_tools_for_settings_page(): array {
-		$tools = $this->get_all_tools();
+		$tools = $this->get_all_tool_declarations();
 		$data  = array();
 
 		foreach ( $tools as $tool_id => $tool_config ) {
@@ -638,6 +639,27 @@ class ToolManager {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Get static and ability-projected tool declarations for management surfaces.
+	 *
+	 * Runtime source resolution keeps legacy registry tools and ability projections
+	 * separate. Settings and selection validation need a complete declaration list
+	 * so ability-native tools can be configured and saved without retaining a
+	 * duplicate class/method registry shadow.
+	 *
+	 * @return array<string,array<string,mixed>> Tool declarations keyed by tool name.
+	 */
+	private function get_all_tool_declarations(): array {
+		$static_tools   = $this->get_all_tools();
+		$ability_source = new AbilityToolSource( $this );
+		$ability_tools  = $ability_source(
+			array( ToolPolicyResolver::MODE_CHAT, ToolPolicyResolver::MODE_PIPELINE, ToolPolicyResolver::MODE_SYSTEM ),
+			array( 'include_unavailable' => true )
+		);
+
+		return array_merge( $ability_tools, $static_tools );
 	}
 
 	/**

--- a/tests/ability-tool-source-smoke.php
+++ b/tests/ability-tool-source-smoke.php
@@ -303,6 +303,11 @@ add_filter(
 			'modes'           => array( 'pipeline' ),
 			'requires_config' => true,
 		);
+		$tools['configured_ability_tool'] = array(
+			'ability'         => 'demo/summarize',
+			'modes'           => array( 'pipeline' ),
+			'requires_config' => true,
+		);
 		$tools['missing_ability_tool'] = array(
 			'ability' => 'demo/missing',
 			'modes'   => array( 'pipeline' ),
@@ -311,6 +316,15 @@ add_filter(
 	},
 	10,
 	1
+);
+
+add_filter(
+	'datamachine_tool_configured',
+	static function ( bool $configured, string $tool_name ): bool {
+		return 'configured_ability_tool' === $tool_name ? true : $configured;
+	},
+	10,
+	2
 );
 
 add_filter(
@@ -359,8 +373,13 @@ $with_opt_in = $source( array( 'pipeline' ), array( 'allow_only' => array( 'summ
 assert_ability_tool_source_equals( true, isset( $with_opt_in['summarize_demo'] ), 'allow_only exposes opt-in ability tool', $failures, $passes );
 assert_ability_tool_source_equals( false, isset( $with_opt_in['missing_ability_tool'] ), 'missing ability declaration is skipped', $failures, $passes );
 assert_ability_tool_source_equals( false, isset( $with_opt_in['disabled_ability_tool'] ), 'requires_config ability tool respects tool availability', $failures, $passes );
+assert_ability_tool_source_equals( true, isset( $with_opt_in['configured_ability_tool'] ), 'requires_config ability projection can be available without static registry entry', $failures, $passes );
 $chat_only = $source( array( 'chat' ), array( 'allow_only' => array( 'summarize_demo' ) ) );
 assert_ability_tool_source_equals( false, isset( $chat_only['collision_tool'] ), 'mode filtering hides unrelated ability tools', $failures, $passes );
+
+$manager_tools = ( new ToolManager() )->get_tools_for_settings_page();
+assert_ability_tool_source_equals( true, isset( $manager_tools['configured_ability_tool'] ), 'ToolManager settings data includes ability projection without static registry entry', $failures, $passes );
+assert_ability_tool_source_equals( true, $manager_tools['configured_ability_tool']['requires_config'] ?? false, 'ToolManager preserves ability projection configuration requirement', $failures, $passes );
 
 echo "\n[3] composed resolver keeps static tools ahead of generated ability tools:\n";
 $resolved = resolve_ability_source_tools( 'pipeline', array( 'allow_only' => array( 'summarize_demo', 'collision_tool' ) ) );

--- a/tests/global-ability-projections-smoke.php
+++ b/tests/global-ability-projections-smoke.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Pure-PHP smoke test for global AI tools migrated to ability projections.
+ *
+ * Run with: php tests/global-ability-projections-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$root     = dirname( __DIR__ );
+$failures = array();
+$passes   = 0;
+
+function assert_global_projection( bool $condition, string $message, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "  ✓ {$message}\n";
+		return;
+	}
+
+	$failures[] = $message;
+	echo "  ✗ {$message}\n";
+}
+
+function read_global_tool_source( string $relative_path, string $root ): string {
+	$source = file_get_contents( $root . '/' . $relative_path );
+	return is_string( $source ) ? $source : '';
+}
+
+echo "global-ability-projections-smoke\n";
+
+$migrated = array(
+	'inc/Engine/AI/Tools/Global/LocalSearch.php'         => array( 'local_search', 'datamachine/local-search' ),
+	'inc/Engine/AI/Tools/Global/ImageGeneration.php'     => array( 'image_generation', 'datamachine/generate-image' ),
+	'inc/Engine/AI/Tools/Global/WordPressPostReader.php' => array( 'wordpress_post_reader', 'datamachine/get-wordpress-post' ),
+);
+
+foreach ( $migrated as $path => $expectations ) {
+	$source       = read_global_tool_source( $path, $root );
+	$tool_name    = $expectations[0];
+	$ability_slug = $expectations[1];
+
+	assert_global_projection( false !== strpos( $source, 'datamachine_register_ability_tool' ), "{$tool_name} registers an ability projection", $failures, $passes );
+	assert_global_projection( false !== strpos( $source, "'{$ability_slug}'" ), "{$tool_name} projection links {$ability_slug}", $failures, $passes );
+	assert_global_projection( false === strpos( $source, "'class'           => __CLASS__" ), "{$tool_name} no longer declares a class handler", $failures, $passes );
+	assert_global_projection( false === strpos( $source, "'method'          => 'handle_tool_call'" ), "{$tool_name} no longer declares a method handler", $failures, $passes );
+}
+
+$exceptions = array(
+	'inc/Engine/AI/Tools/Global/AgentMemory.php'       => 'agent_memory',
+	'inc/Engine/AI/Tools/Global/AgentDailyMemory.php'  => 'agent_daily_memory',
+	'inc/Engine/AI/Tools/Global/InternalLinkAudit.php' => 'internal_link_audit',
+	'inc/Engine/AI/Tools/Global/QueueValidator.php'    => 'queue_validator',
+	'inc/Engine/AI/Tools/Global/WebFetch.php'          => 'web_fetch',
+);
+
+foreach ( $exceptions as $path => $tool_name ) {
+	$source = read_global_tool_source( $path, $root );
+	assert_global_projection( false !== strpos( $source, "'method'" ), "{$tool_name} remains an explicit class/method exception", $failures, $passes );
+}
+
+$docs = read_global_tool_source( 'docs/ai-tools/tools-overview.md', $root );
+foreach ( $exceptions as $tool_name ) {
+	assert_global_projection( false !== strpos( $docs, "`{$tool_name}`" ), "{$tool_name} exception is documented", $failures, $passes );
+}
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " global projection assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} global projection assertions passed.\n";

--- a/tests/global-tool-array-items-smoke.php
+++ b/tests/global-tool-array-items-smoke.php
@@ -47,6 +47,7 @@ if ( ! function_exists( 'add_filter' ) ) {
 }
 
 require_once $root . '/inc/Engine/AI/Tools/BaseTool.php';
+require_once $root . '/inc/Engine/AI/Tools/ToolPolicyResolver.php';
 
 $tools_dir = $root . '/inc/Engine/AI/Tools/Global';
 $tool_files = glob( $tools_dir . '/*.php' ) ?: array();

--- a/tests/global-tool-pipeline-modes-smoke.php
+++ b/tests/global-tool-pipeline-modes-smoke.php
@@ -151,11 +151,8 @@ assert_true_for_pipeline_modes(
 );
 
 $pipeline_tools = array(
-	'web_fetch'             => array( 'inc/Engine/AI/Tools/Global/WebFetch.php', 'DataMachine\Engine\AI\Tools\Global\WebFetch' ),
-	'wordpress_post_reader' => array( 'inc/Engine/AI/Tools/Global/WordPressPostReader.php', 'DataMachine\Engine\AI\Tools\Global\WordPressPostReader' ),
-	'image_generation'      => array( 'inc/Engine/AI/Tools/Global/ImageGeneration.php', 'DataMachine\Engine\AI\Tools\Global\ImageGeneration' ),
-	'local_search'          => array( 'inc/Engine/AI/Tools/Global/LocalSearch.php', 'DataMachine\Engine\AI\Tools\Global\LocalSearch' ),
-	'internal_link_audit'   => array( 'inc/Engine/AI/Tools/Global/InternalLinkAudit.php', 'DataMachine\Engine\AI\Tools\Global\InternalLinkAudit' ),
+	'web_fetch'           => array( 'inc/Engine/AI/Tools/Global/WebFetch.php', 'DataMachine\Engine\AI\Tools\Global\WebFetch' ),
+	'internal_link_audit' => array( 'inc/Engine/AI/Tools/Global/InternalLinkAudit.php', 'DataMachine\Engine\AI\Tools\Global\InternalLinkAudit' ),
 );
 
 foreach ( $pipeline_tools as $tool => [ $path, $class_name ] ) {
@@ -167,6 +164,22 @@ foreach ( $pipeline_tools as $tool => $unused ) {
 	assert_true_for_pipeline_modes(
 		isset( $resolved_pipeline_tools[ $tool ] ),
 		"{$tool} remains pipeline-visible",
+		$failures,
+		$passes
+	);
+}
+
+$projected_pipeline_tools = array(
+	'wordpress_post_reader' => 'inc/Engine/AI/Tools/Global/WordPressPostReader.php',
+	'image_generation'      => 'inc/Engine/AI/Tools/Global/ImageGeneration.php',
+	'local_search'          => 'inc/Engine/AI/Tools/Global/LocalSearch.php',
+);
+
+foreach ( $projected_pipeline_tools as $tool => $path ) {
+	assert_true_for_pipeline_modes(
+		file_contains_for_pipeline_modes( $path, 'datamachine_register_ability_tool' )
+			&& file_contains_for_pipeline_modes( $path, "'modes'   => array( 'chat', 'pipeline' )" ),
+		"{$tool} remains pipeline-visible through ability projection",
 		$failures,
 		$passes
 	);

--- a/tests/tool-executor-ability-native-smoke.php
+++ b/tests/tool-executor-ability-native-smoke.php
@@ -159,6 +159,7 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 	require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-declaration.php';
 	require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-parameters.php';
 	require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-call.php';
+	require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Runtime/class-wp-agent-citation-metadata.php';
 	require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-result.php';
 	require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-executor.php';
 	require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-execution-core.php';


### PR DESCRIPTION
## Summary
- Project `local_search`, `image_generation`, and `wordpress_post_reader` from registered WordPress abilities instead of class/method tool definitions.
- Let ability projections participate in ToolManager settings/selection surfaces without keeping static registry shadows.
- Document the remaining class/method exceptions and add smoke coverage for the migration boundary.

Fixes #2520

## Tests
- `php tests/ability-tool-source-smoke.php`
- `php tests/global-ability-projections-smoke.php`
- `php tests/tool-source-registry-smoke.php`
- `php tests/global-tool-pipeline-modes-smoke.php`
- `php tests/global-tool-array-items-smoke.php`
- `php tests/tool-executor-ability-native-smoke.php`
- `./vendor/bin/phpcs inc/Engine/AI/Tools/Sources/AbilityToolSource.php inc/Engine/AI/Tools/ToolManager.php inc/Engine/AI/Tools/Global/LocalSearch.php inc/Engine/AI/Tools/Global/ImageGeneration.php inc/Engine/AI/Tools/Global/WordPressPostReader.php tests/ability-tool-source-smoke.php tests/global-ability-projections-smoke.php tests/global-tool-pipeline-modes-smoke.php tests/global-tool-array-items-smoke.php tests/tool-executor-ability-native-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Auditing the remaining class/method tool boundary, drafting the ability-projection migration, updating smoke coverage, and preparing this PR body for Chris to review and test.