### PR TITLE
Fix declared tool context bindings

### DIFF
--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -62,6 +62,7 @@ class ToolExecutor {
 	): array {
 		$core            = new WP_Agent_Tool_Execution_Core();
 		$execution       = new ToolExecutionCore();
+		$tool_parameters = self::applyDeclaredContextBindings( $tool_name, $tool_parameters, $available_tools, $payload, $client_context );
 		$prepared        = $core->prepareWP_Agent_Tool_Call( $tool_name, $tool_parameters, $available_tools, $payload );
 		if ( empty( $prepared['ready'] ) ) {
 			unset( $prepared['ready'] );
@@ -182,6 +183,51 @@ class ToolExecutor {
 		}
 
 		return $tool_result;
+	}
+
+	/**
+	 * Apply explicit client_context_bindings from Data Machine invocation context.
+	 *
+	 * Agents API also applies this contract, but Data Machine may receive a
+	 * prepared tool call from the substrate after host-only fields have been
+	 * normalized. Re-applying the same explicit declaration against the original
+	 * Data Machine payload keeps handler tools from depending on model-supplied
+	 * job identifiers without falling back to ambient key-name matching.
+	 *
+	 * @param string $tool_name       Tool name to execute.
+	 * @param array  $tool_parameters Parameters from the model/substrate.
+	 * @param array  $available_tools Available tool definitions.
+	 * @param array  $payload         Data Machine loop payload.
+	 * @param array  $client_context  Nested client context from the payload.
+	 * @return array Parameters with declared context bindings applied.
+	 */
+	private static function applyDeclaredContextBindings( string $tool_name, array $tool_parameters, array $available_tools, array $payload, array $client_context ): array {
+		$tool_def = is_array( $available_tools[ $tool_name ] ?? null ) ? $available_tools[ $tool_name ] : array();
+		$bindings = is_array( $tool_def['client_context_bindings'] ?? null ) ? $tool_def['client_context_bindings'] : array();
+		if ( empty( $bindings ) ) {
+			return $tool_parameters;
+		}
+
+		$context = array_merge( $payload, $client_context );
+		foreach ( $bindings as $parameter_name => $context_key ) {
+			if ( is_int( $parameter_name ) ) {
+				$parameter_name = $context_key;
+			}
+
+			if ( ! is_string( $parameter_name ) || '' === $parameter_name || ! is_string( $context_key ) || '' === $context_key ) {
+				continue;
+			}
+			if ( array_key_exists( $parameter_name, $tool_parameters ) && null !== $tool_parameters[ $parameter_name ] && '' !== $tool_parameters[ $parameter_name ] ) {
+				continue;
+			}
+			if ( ! array_key_exists( $context_key, $context ) || null === $context[ $context_key ] || '' === $context[ $context_key ] ) {
+				continue;
+			}
+
+			$tool_parameters[ $parameter_name ] = $context[ $context_key ];
+		}
+
+		return $tool_parameters;
 	}
 
 	/**

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -73,7 +73,9 @@ function datamachine_run_conversation(
 	$interrupt_source     = is_callable( $payload['interrupt_source'] ?? null ) ? $payload['interrupt_source'] : null;
 
 	// Strip runtime objects from the loop payload before passing to tools/requests.
-	$loop_payload = datamachine_payload_without_runtime_objects( $payload );
+	$loop_payload = datamachine_payload_with_client_context_bindings(
+		datamachine_payload_without_runtime_objects( $payload )
+	);
 
 	// Build the turns budget through DM's registry (site-config-aware ceiling
 	// resolution). The upstream loop owns increment + exceeded checks.
@@ -2512,6 +2514,41 @@ function datamachine_payload_with_inflight_run_artifacts( array $payload, array 
 	}
 
 	$payload['run_artifacts'] = $artifact_result['artifacts'];
+	return $payload;
+}
+
+/**
+ * Mirror safe run context into client_context for declared tool bindings.
+ *
+ * Agents API only satisfies tool parameters through explicit
+ * `client_context_bindings`, but Data Machine pipeline context historically
+ * stores run identifiers at the top level of the loop payload. Keep the
+ * binding source auditable by copying only the fields tools already declare as
+ * context-bindable instead of matching arbitrary parameter names.
+ *
+ * @param array $payload Clean loop payload.
+ * @return array Payload with context-bindable run fields in client_context.
+ */
+function datamachine_payload_with_client_context_bindings( array $payload ): array {
+	$client_context = is_array( $payload['client_context'] ?? null ) ? $payload['client_context'] : array();
+
+	foreach ( array( 'job_id', 'flow_step_id', 'step_id', 'user_id', 'agent_id', 'agent_slug' ) as $key ) {
+		if ( array_key_exists( $key, $client_context ) || ! array_key_exists( $key, $payload ) ) {
+			continue;
+		}
+
+		$value = $payload[ $key ];
+		if ( null === $value || '' === $value || is_array( $value ) || is_object( $value ) ) {
+			continue;
+		}
+
+		$client_context[ $key ] = $value;
+	}
+
+	if ( ! empty( $client_context ) ) {
+		$payload['client_context'] = $client_context;
+	}
+
 	return $payload;
 }
 

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -525,12 +525,16 @@ assert_source_equals(
 );
 
 $executor_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/ToolExecutor.php' );
+$loop_source     = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/conversation-loop.php' );
 $client_guard    = strpos( $executor_source, "'client' === (string) ( $" . "tool_def['executor'] ?? '' )" );
 $policy_resolver = strpos( $executor_source, 'new ActionPolicyResolver()' );
 $direct_execute  = strpos( $executor_source, 'executePreparedTool' );
 assert_source_equals( true, false !== $client_guard, 'ToolExecutor has an explicit client-executor guard', $failures, $passes );
 assert_source_equals( true, false !== $client_guard && false !== $policy_resolver && $client_guard < $policy_resolver, 'client-executor guard runs before action-policy/direct execution setup', $failures, $passes );
 assert_source_equals( true, false !== $client_guard && false !== $direct_execute && $client_guard < $direct_execute, 'client-executor guard runs before direct PHP tool execution', $failures, $passes );
+assert_source_equals( true, false !== strpos( $executor_source, 'applyDeclaredContextBindings' ), 'ToolExecutor reapplies explicit context bindings before execution', $failures, $passes );
+assert_source_equals( true, false !== strpos( $executor_source, "tool_def['client_context_bindings']" ), 'ToolExecutor reads declared client_context_bindings only', $failures, $passes );
+assert_source_equals( true, false !== strpos( $loop_source, 'datamachine_payload_with_client_context_bindings' ), 'conversation loop mirrors safe run fields into client_context', $failures, $passes );
 
 $client_execution = ToolExecutor::executeTool(
 	'client/select_block',


### PR DESCRIPTION
## Summary
- Mirror safe run context fields into `client_context` before Data Machine enters the Agents API conversation loop.
- Re-apply declared `client_context_bindings` in the Data Machine tool executor before direct PHP execution, preserving explicit binding semantics without ambient key matching.
- Add smoke assertions for the binding path.

## Verification
- `php tests/tool-source-registry-smoke.php`
- `php tests/agent-bundle-runner-contract-smoke.php`
- `php tests/agents-chat-handler-smoke.php`
- `php -l inc/Engine/AI/conversation-loop.php && php -l inc/Engine/AI/Tools/ToolExecutor.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the missing `job_id` in downstream publish tool calls, drafting the context-binding fix, and running focused verification.