### PR TITLE
Project declared bundle outputs

### DIFF
--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -157,7 +157,7 @@ final class AgentBundleRunner {
 		$response['completion_outcome'] = $this->completion_outcome( $response );
 		$response['transcript_refs']    = $this->transcript_refs( $response );
 		$response['export_refs']        = $this->export_refs( $response );
-		$output_projection              = $this->output_projection( $response );
+		$output_projection              = $this->output_projection( $response, $input );
 		$response['outputs']            = $output_projection['outputs'];
 		$response['output_diagnostics'] = $output_projection['diagnostics'];
 
@@ -254,13 +254,21 @@ final class AgentBundleRunner {
 	}
 
 	/** @return array{outputs:array<string,mixed>,diagnostics:array<string,mixed>} */
-	private function output_projection( array $response ): array {
+	private function output_projection( array $response, array $input = array() ): array {
 		$engine_data = is_array( $response['engine_data'] ?? null ) ? $response['engine_data'] : array();
-		$declared    = $this->declared_output_keys( $engine_data );
+		$mappings    = $this->declared_output_mappings( $input );
+		$declared    = array_values( array_unique( array_merge( $this->declared_output_keys( $engine_data ), array_keys( $mappings ) ) ) );
 		$outputs     = array();
 
+		foreach ( $mappings as $key => $path ) {
+			$value = $this->mapped_output_value( $response, $path );
+			if ( $this->has_output_value( $value ) ) {
+				$outputs[ $key ] = $value;
+			}
+		}
+
 		foreach ( $declared as $key ) {
-			if ( $this->has_output_value( $engine_data[ $key ] ?? null ) ) {
+			if ( ! isset( $outputs[ $key ] ) && $this->has_output_value( $engine_data[ $key ] ?? null ) ) {
 				$outputs[ $key ] = $engine_data[ $key ];
 			}
 		}
@@ -294,6 +302,45 @@ final class AgentBundleRunner {
 				)
 			),
 		);
+	}
+
+	/** @return array<string,string> */
+	private function declared_output_mappings( array $input ): array {
+		$mappings = is_array( $input['engine_data_outputs'] ?? null ) ? $input['engine_data_outputs'] : array();
+		$outputs  = array();
+
+		foreach ( $mappings as $key => $path ) {
+			$key  = sanitize_key( (string) $key );
+			$path = is_scalar( $path ) ? trim( (string) $path ) : '';
+			if ( '' !== $key && '' !== $path ) {
+				$outputs[ $key ] = $path;
+			}
+		}
+
+		return $outputs;
+	}
+
+	private function mapped_output_value( array $response, string $path ): mixed {
+		$engine_data = is_array( $response['engine_data'] ?? null ) ? $response['engine_data'] : array();
+		$source      = array(
+			'metadata'    => array( 'engine_data' => $engine_data ),
+			'engine_data' => $engine_data,
+			'response'    => $response,
+		);
+
+		return $this->path_value( $source, $path );
+	}
+
+	private function path_value( array $source, string $path ): mixed {
+		$value = $source;
+		foreach ( array_filter( explode( '.', $path ), static fn( string $part ): bool => '' !== $part ) as $part ) {
+			if ( ! is_array( $value ) || ! array_key_exists( $part, $value ) ) {
+				return null;
+			}
+			$value = $value[ $part ];
+		}
+
+		return $value;
 	}
 
 	/** @return array<int,string> */

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -102,7 +102,18 @@ $projected_outputs = $output_projection->invoke(
 			'issue_url'                      => 'https://github.com/Extra-Chill/data-machine/issues/2519',
 			'result_path'                    => 'artifacts/result.json',
 			'agent_id'                       => 7,
+			'store_idea_agent'              => array(
+				'issue_number' => 456,
+				'issue_url'    => 'https://github.com/chubes4/wp-site-generator/issues/456',
+			),
 			'outputs'                        => array( 'summary_title' => 'semantic output projection' ),
+		),
+	),
+	array(
+		'engine_data_outputs' => array(
+			'store_issue_number' => 'metadata.engine_data.store_idea_agent.issue_number',
+			'store_issue_url'    => 'metadata.engine_data.store_idea_agent.issue_url',
+			'missing_store_url'  => 'metadata.engine_data.store_idea_agent.missing_url',
 		),
 	)
 );
@@ -110,8 +121,10 @@ datamachine_bundle_runner_assert( 123 === ( $projected_outputs['outputs']['issue
 datamachine_bundle_runner_assert( 'https://github.com/Extra-Chill/data-machine/issues/2519' === ( $projected_outputs['outputs']['issue_url'] ?? null ), 'declared issue_url output is projected', $failures, $passes );
 datamachine_bundle_runner_assert( 'artifacts/result.json' === ( $projected_outputs['outputs']['result_path'] ?? null ), 'common scalar task output is projected', $failures, $passes );
 datamachine_bundle_runner_assert( 'semantic output projection' === ( $projected_outputs['outputs']['summary_title'] ?? null ), 'explicit outputs map is projected', $failures, $passes );
+datamachine_bundle_runner_assert( 456 === ( $projected_outputs['outputs']['store_issue_number'] ?? null ), 'declared nested engine_data output number is projected', $failures, $passes );
+datamachine_bundle_runner_assert( 'https://github.com/chubes4/wp-site-generator/issues/456' === ( $projected_outputs['outputs']['store_issue_url'] ?? null ), 'declared nested engine_data output URL is projected', $failures, $passes );
 datamachine_bundle_runner_assert( ! isset( $projected_outputs['outputs']['agent_id'] ), 'runtime identity fields are not projected as outputs', $failures, $passes );
-datamachine_bundle_runner_assert( array( 'missing_result_url' ) === ( $projected_outputs['diagnostics']['missing_outputs'] ?? null ), 'missing declared outputs are diagnosed semantically', $failures, $passes );
+datamachine_bundle_runner_assert( array( 'missing_result_url', 'missing_store_url' ) === ( $projected_outputs['diagnostics']['missing_outputs'] ?? null ), 'missing declared outputs are diagnosed semantically', $failures, $passes );
 
 echo "\n[4] WP-CLI wraps the same ability instead of duplicating runner internals\n";
 foreach ( array(


### PR DESCRIPTION
## Summary
- Resolve `engine_data_outputs` mappings during `datamachine/run-agent-bundle` response projection.
- Project nested paths such as `metadata.engine_data.store_idea_agent.issue_number` into the top-level `outputs` map that callers validate first.
- Keep missing declared mapped outputs visible in `output_diagnostics`.

## Evidence
- Site Generation Loop run https://github.com/chubes4/wp-site-generator/actions/runs/27014304965 reached successful `github_issue_publish` calls for issues #413 and #414, but Homeboy aggregation failed because declared semantic outputs were not present in the bundle-run `outputs` map.

## Verification
- `php tests/agent-bundle-runner-contract-smoke.php`
- `php tests/tool-source-registry-smoke.php`
- `php -l inc/Engine/Bundle/AgentBundleRunner.php && php -l tests/agent-bundle-runner-contract-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the Site Generation Loop semantic-output aggregation failure, drafting the output projection fix, and running focused verification.