### PR TITLE
Apply agent bundle flow step patches

### DIFF
--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -849,7 +849,7 @@ final class AgentBundleRunner {
 	/** @param array<string,mixed> $workflow_step */
 	private function flow_step_patch_matches( array $workflow_step, array $patch ): bool {
 		foreach ( array( 'flow_step_id', 'pipeline_step_id', 'step_type' ) as $selector_key ) {
-			if ( isset( $patch[ $selector_key ] ) && (string) $patch[ $selector_key ] !== (string) ( $workflow_step[ $selector_key ] ?? '' ) ) {
+			if ( isset( $patch[ $selector_key ] ) && (string) ( $workflow_step[ $selector_key ] ?? '' ) !== (string) $patch[ $selector_key ] ) {
 				return false;
 			}
 		}

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -64,7 +64,7 @@ final class AgentBundleRunner {
 			return $this->response( $selection, $input, $runtime_imports );
 		}
 
-		$workflow     = $this->workflow_from_bundle_flow( $selection['flow'], $selection['pipeline'] );
+		$workflow     = $this->workflow_from_bundle_flow( $selection['flow'], $selection['pipeline'], $input );
 		$initial_data = is_array( $input['initial_data'] ?? null ) ? $input['initial_data'] : array();
 		$manifest     = $directory->manifest()->to_array();
 
@@ -776,7 +776,7 @@ final class AgentBundleRunner {
 	}
 
 	/** @return array<string,array<int,array<string,mixed>>> */
-	private function workflow_from_bundle_flow( array $flow, array $pipeline ): array {
+	private function workflow_from_bundle_flow( array $flow, array $pipeline, array $input = array() ): array {
 		$pipeline_steps = array();
 		foreach ( $pipeline['steps'] ?? array() as $step ) {
 			$pipeline_steps[ (int) ( $step['step_position'] ?? 0 ) ] = is_array( $step ) ? $step : array();
@@ -799,6 +799,84 @@ final class AgentBundleRunner {
 			);
 		}
 
+		$this->apply_flow_step_patches( $workflow_steps, is_array( $input['flow_step_patches'] ?? null ) ? $input['flow_step_patches'] : array() );
+
 		return array( 'steps' => $workflow_steps );
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $workflow_steps Workflow steps to mutate.
+	 * @param array<int,mixed>               $patches Run-scoped step patch definitions.
+	 */
+	private function apply_flow_step_patches( array &$workflow_steps, array $patches ): void {
+		foreach ( $patches as $patch ) {
+			if ( ! is_array( $patch ) ) {
+				continue;
+			}
+
+			$payload = $this->flow_step_patch_payload( $patch );
+			if ( empty( $payload ) ) {
+				continue;
+			}
+
+			foreach ( $workflow_steps as &$workflow_step ) {
+				if ( ! $this->flow_step_patch_matches( $workflow_step, $patch ) ) {
+					continue;
+				}
+
+				$workflow_step = $this->recursive_array_merge( $workflow_step, $payload );
+			}
+			unset( $workflow_step );
+		}
+	}
+
+	/** @return array<string,mixed> */
+	private function flow_step_patch_payload( array $patch ): array {
+		foreach ( array( 'merge', 'config', 'patch' ) as $payload_key ) {
+			if ( isset( $patch[ $payload_key ] ) && is_array( $patch[ $payload_key ] ) ) {
+				return $patch[ $payload_key ];
+			}
+		}
+
+		$payload = $patch;
+		foreach ( array( 'flow_step_id', 'pipeline_step_id', 'step_type', 'slug' ) as $selector_key ) {
+			unset( $payload[ $selector_key ] );
+		}
+
+		return $payload;
+	}
+
+	/** @param array<string,mixed> $workflow_step */
+	private function flow_step_patch_matches( array $workflow_step, array $patch ): bool {
+		foreach ( array( 'flow_step_id', 'pipeline_step_id', 'step_type' ) as $selector_key ) {
+			if ( isset( $patch[ $selector_key ] ) && (string) $patch[ $selector_key ] !== (string) ( $workflow_step[ $selector_key ] ?? '' ) ) {
+				return false;
+			}
+		}
+
+		if ( isset( $patch['slug'] ) ) {
+			$slug = (string) $patch['slug'];
+			return in_array( $slug, array( (string) ( $workflow_step['flow_step_id'] ?? '' ), (string) ( $workflow_step['pipeline_step_id'] ?? '' ) ), true );
+		}
+
+		return isset( $patch['flow_step_id'] ) || isset( $patch['pipeline_step_id'] ) || isset( $patch['step_type'] );
+	}
+
+	/** @return array<string,mixed> */
+	private function recursive_array_merge( array $base, array $overrides ): array {
+		foreach ( $overrides as $key => $value ) {
+			if ( is_array( $value ) && isset( $base[ $key ] ) && is_array( $base[ $key ] ) && self::is_associative_array( $value ) && self::is_associative_array( $base[ $key ] ) ) {
+				$base[ $key ] = $this->recursive_array_merge( $base[ $key ], $value );
+				continue;
+			}
+
+			$base[ $key ] = $value;
+		}
+
+		return $base;
+	}
+
+	private static function is_associative_array( array $value ): bool {
+		return array_keys( $value ) !== range( 0, count( $value ) - 1 );
 	}
 }

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -126,6 +126,51 @@ datamachine_bundle_runner_assert( 'https://github.com/chubes4/wp-site-generator/
 datamachine_bundle_runner_assert( ! isset( $projected_outputs['outputs']['agent_id'] ), 'runtime identity fields are not projected as outputs', $failures, $passes );
 datamachine_bundle_runner_assert( array( 'missing_result_url', 'missing_store_url' ) === ( $projected_outputs['diagnostics']['missing_outputs'] ?? null ), 'missing declared outputs are diagnosed semantically', $failures, $passes );
 
+echo "\n[3b] Runner applies run-scoped flow step patches\n";
+$workflow_from_bundle_flow = $runner_reflection->getMethod( 'workflow_from_bundle_flow' );
+$patched_workflow          = $workflow_from_bundle_flow->invoke(
+	$runner_instance,
+	array(
+		'steps' => array(
+			array(
+				'flow_step_id'     => 'fetch-issue',
+				'pipeline_step_id' => 'fetch-pipeline',
+				'step_position'    => 0,
+				'step_type'        => 'fetch',
+				'handler_configs'  => array(
+					'github' => array(
+						'repo'   => 'chubes4/wp-site-generator',
+						'labels' => 'status:idea-ready',
+					),
+				),
+			),
+		),
+	),
+	array(
+		'steps' => array(
+			array(
+				'step_position' => 0,
+				'step_type'     => 'fetch',
+				'step_config'   => array( 'queue_mode' => 'static' ),
+			),
+		),
+	),
+	array(
+		'flow_step_patches' => array(
+			array(
+				'step_type' => 'fetch',
+				'merge'     => array(
+					'handler_configs' => array(
+						'github' => array( 'issue_number' => 429 ),
+					),
+				),
+			),
+		),
+	)
+);
+datamachine_bundle_runner_assert( 429 === ( $patched_workflow['steps'][0]['handler_configs']['github']['issue_number'] ?? null ), 'flow step patch merges nested handler config', $failures, $passes );
+datamachine_bundle_runner_assert( 'chubes4/wp-site-generator' === ( $patched_workflow['steps'][0]['handler_configs']['github']['repo'] ?? null ), 'flow step patch preserves existing handler config', $failures, $passes );
+
 echo "\n[4] WP-CLI wraps the same ability instead of duplicating runner internals\n";
 foreach ( array(
 	'@subcommand run-bundle'       => 'run-bundle subcommand declared',


### PR DESCRIPTION
## Summary
- Apply run-scoped `flow_step_patches` while projecting bundle flows into ephemeral workflows.
- Merge nested associative patch payloads so targeted handler config, such as GitHub issue numbers, preserves existing flow config.
- Cover the patch behavior in the agent bundle runner contract smoke test.

## Testing
- `php tests/agent-bundle-runner-contract-smoke.php`
- `php -l inc/Engine/Bundle/AgentBundleRunner.php && php -l tests/agent-bundle-runner-contract-smoke.php`
- `git diff --check origin/main..HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the bundle workflow patch gap, drafting the Data Machine fix and smoke coverage, and running local verification. Chris remains responsible for review and acceptance.