### PR TITLE
Fail agent bundle no-item outcomes

### DIFF
--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -138,6 +138,7 @@ final class AgentBundleRunner {
 	private function response( array $response, array $input, array $runtime_imports = array(), array $selection = array() ): array {
 		$response['schema'] ??= 'datamachine/agent-bundle-run/v1';
 		$response['status']   = $this->status_from_response( $response );
+		$response['success']  = ! empty( $response['success'] ) && self::is_success_status( $response['status'] );
 
 		if ( ! empty( $runtime_imports ) ) {
 			$response['runtime_imports'] = $runtime_imports;
@@ -214,11 +215,15 @@ final class AgentBundleRunner {
 			array(
 				'status'      => $status,
 				'completed'   => 'completed' === $status,
-				'success'     => ! empty( $response['success'] ) && 'failed' !== $status,
+				'success'     => ! empty( $response['success'] ) && self::is_success_status( $status ),
 				'error'       => (string) ( $response['error'] ?? $engine_data['error_message'] ?? '' ),
 				'token_usage' => is_array( $engine_data['token_usage'] ?? null ) ? $engine_data['token_usage'] : null,
 			)
 		);
+	}
+
+	private static function is_success_status( string $status ): bool {
+		return ! in_array( $status, array( 'failed', 'completed_no_items', 'cancelled', 'timed_out', 'timeout' ), true );
 	}
 
 	/** @return array<string,mixed> */

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -171,6 +171,20 @@ $patched_workflow          = $workflow_from_bundle_flow->invoke(
 datamachine_bundle_runner_assert( 429 === ( $patched_workflow['steps'][0]['handler_configs']['github']['issue_number'] ?? null ), 'flow step patch merges nested handler config', $failures, $passes );
 datamachine_bundle_runner_assert( 'chubes4/wp-site-generator' === ( $patched_workflow['steps'][0]['handler_configs']['github']['repo'] ?? null ), 'flow step patch preserves existing handler config', $failures, $passes );
 
+echo "\n[3c] Runner does not treat no-item terminal states as success\n";
+$response_method = $runner_reflection->getMethod( 'response' );
+$no_item_response = $response_method->invoke(
+	$runner_instance,
+	array(
+		'success'    => true,
+		'job_status' => 'completed_no_items',
+	),
+	array( 'wait_for_completion' => true )
+);
+datamachine_bundle_runner_assert( 'completed_no_items' === ( $no_item_response['status'] ?? null ), 'no-item terminal status is preserved', $failures, $passes );
+datamachine_bundle_runner_assert( false === ( $no_item_response['success'] ?? null ), 'no-item terminal status is not a successful bundle run', $failures, $passes );
+datamachine_bundle_runner_assert( false === ( $no_item_response['completion_outcome']['success'] ?? null ), 'no-item completion outcome is not successful', $failures, $passes );
+
 echo "\n[4] WP-CLI wraps the same ability instead of duplicating runner internals\n";
 foreach ( array(
 	'@subcommand run-bundle'       => 'run-bundle subcommand declared',


### PR DESCRIPTION
## Summary
- Mark `datamachine/run-agent-bundle` responses unsuccessful when the waited workflow reaches `completed_no_items` or other failed terminal statuses.
- Preserve the engine status for diagnostics while exposing truthful top-level and completion-outcome success booleans.
- Add smoke coverage so no-item terminal states cannot be reported as successful bundle runs.

## Testing
- `php tests/agent-bundle-runner-contract-smoke.php`
- `php -l inc/Engine/Bundle/AgentBundleRunner.php && php -l tests/agent-bundle-runner-contract-smoke.php`
- `git diff --check origin/main..HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the no-item bundle outcome regression from Site Generation Loop artifacts, drafting the Data Machine fix and smoke coverage, and running local verification. Chris remains responsible for review and acceptance.