### PR TITLE
Fail fetch steps on handler errors

### DIFF
--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -226,6 +226,31 @@ class FetchStep extends Step {
 
 		$packets = $this->execute_handler_as_owner( $handler, $handler_settings, (string) $this->job_id, $owner_user_id );
 
+		if ( is_wp_error( $packets ) ) {
+			$this->log( 'error', 'Fetch handler failed: ' . $packets->get_error_message() );
+			RunMetrics::recordStepResult(
+				$this->job_id,
+				$this->flow_step_id,
+				array_merge(
+					$this->extractHandlerOutcomeIds( $handler_settings ),
+					array(
+						'step_type'    => 'fetch',
+						'result'       => 'failed',
+						'handler_slug' => (string) $handler,
+						'packet_count' => 0,
+						'reason'       => 'handler_failed',
+						'error'        => $packets->get_error_message(),
+					)
+				)
+			);
+
+			return array(
+				'status'  => 'failed',
+				'packets' => $this->dataPackets,
+				'reason'  => 'handler_failed',
+			);
+		}
+
 		if ( empty( $packets ) ) {
 			$this->log( 'error', 'Fetch handler returned no content' );
 			RunMetrics::recordStepResult(
@@ -284,9 +309,9 @@ class FetchStep extends Step {
 	 * @param string $handler_name    Handler slug.
 	 * @param array  $handler_settings Handler settings (includes pipeline_id, flow_id).
 	 * @param string $job_id          Job ID.
-	 * @return DataPacket[] Array of DataPackets, or empty array on failure.
+	 * @return DataPacket[]|\WP_Error Array of DataPackets, or error on handler failure.
 	 */
-	private function execute_handler( string $handler_name, array $handler_settings, string $job_id ): array {
+	private function execute_handler( string $handler_name, array $handler_settings, string $job_id ): array|\WP_Error {
 		$handler = $this->get_handler_object( $handler_name );
 		if ( ! $handler ) {
 			$this->log(
@@ -296,7 +321,7 @@ class FetchStep extends Step {
 					'handler' => $handler_name,
 				)
 			);
-			return array();
+			return new \WP_Error( 'fetch_handler_not_found', sprintf( 'Fetch handler "%s" was not found.', $handler_name ) );
 		}
 
 		try {
@@ -304,7 +329,7 @@ class FetchStep extends Step {
 
 			if ( empty( $pipeline_id ) ) {
 				$this->log( 'error', 'Pipeline ID not found in handler settings' );
-				return array();
+				return new \WP_Error( 'fetch_handler_missing_pipeline_id', 'Pipeline ID not found in handler settings.' );
 			}
 
 			return $handler->get_fetch_data( $pipeline_id, $handler_settings, $job_id );
@@ -317,7 +342,7 @@ class FetchStep extends Step {
 					'exception' => $e->getMessage(),
 				)
 			);
-			return array();
+			return new \WP_Error( 'fetch_handler_execution_failed', $e->getMessage() );
 		}
 	}
 
@@ -333,9 +358,9 @@ class FetchStep extends Step {
 	 * @param array  $handler_settings Handler settings.
 	 * @param string $job_id Job ID.
 	 * @param int    $owner_user_id Flow owner user ID.
-	 * @return DataPacket[] Array of DataPackets, or empty array on failure.
+	 * @return DataPacket[]|\WP_Error Array of DataPackets, or error on handler failure.
 	 */
-	private function execute_handler_as_owner( string $handler_name, array $handler_settings, string $job_id, int $owner_user_id ): array {
+	private function execute_handler_as_owner( string $handler_name, array $handler_settings, string $job_id, int $owner_user_id ): array|\WP_Error {
 		if ( $owner_user_id <= 0 || ! function_exists( 'wp_set_current_user' ) || ! function_exists( 'get_current_user_id' ) ) {
 			return $this->execute_handler( $handler_name, $handler_settings, $job_id );
 		}

--- a/tests/Unit/Core/Steps/Fetch/FetchHandlerDataPacketTest.php
+++ b/tests/Unit/Core/Steps/Fetch/FetchHandlerDataPacketTest.php
@@ -252,12 +252,23 @@ class FetchHandlerDataPacketTest extends TestCase {
 		$this->assertTrue( $reflection->isSubclassOf( \DataMachine\Core\Steps\Step::class ) );
 	}
 
-	public function test_fetchstep_execute_handler_returns_array(): void {
+	public function test_fetchstep_execute_handler_returns_array_or_error(): void {
 		$method = new ReflectionMethod( \DataMachine\Core\Steps\Fetch\FetchStep::class, 'execute_handler' );
 		$this->assertTrue( $method->isPrivate() );
 
 		$return_type = $method->getReturnType();
 		$this->assertNotNull( $return_type );
+
+		if ( $return_type instanceof \ReflectionUnionType ) {
+			$type_names = array_map(
+				static fn ( \ReflectionNamedType $type ): string => $type->getName(),
+				$return_type->getTypes()
+			);
+			$this->assertContains( 'array', $type_names );
+			$this->assertContains( 'WP_Error', $type_names );
+			return;
+		}
+
 		$this->assertSame( 'array', $return_type->getName() );
 	}
 

--- a/tests/fetch-handler-failure-status-smoke.php
+++ b/tests/fetch-handler-failure-status-smoke.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Pure-PHP smoke test for fetch handler failure status propagation.
+ *
+ * Run with: php tests/fetch-handler-failure-status-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$root = dirname( __DIR__ );
+$file = file_get_contents( $root . '/inc/Core/Steps/Fetch/FetchStep.php' ) ?: '';
+
+$failed = 0;
+$total  = 0;
+
+function assert_fetch_handler_failure_status( string $name, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+
+	++$failed;
+	echo "  [FAIL] {$name}\n";
+}
+
+echo "=== fetch-handler-failure-status-smoke ===\n";
+
+assert_fetch_handler_failure_status(
+	'FetchStep accepts handler WP_Error results',
+	str_contains( $file, 'if ( is_wp_error( $packets ) )' )
+);
+
+assert_fetch_handler_failure_status(
+	'FetchStep records handler failures as failed step results',
+	str_contains( $file, "'result'       => 'failed'," ) && str_contains( $file, "'reason'       => 'handler_failed'," )
+);
+
+assert_fetch_handler_failure_status(
+	'FetchStep returns explicit failed result shape for handler failures',
+	str_contains( $file, "'status'  => 'failed'," ) && str_contains( $file, "'reason'  => 'handler_failed'," )
+);
+
+assert_fetch_handler_failure_status(
+	'execute_handler preserves handler exceptions as WP_Error',
+	str_contains( $file, "new \\WP_Error( 'fetch_handler_execution_failed', \$e->getMessage() )" )
+);
+
+if ( $failed > 0 ) {
+	echo "\nfetch-handler-failure-status-smoke failed: {$failed}/{$total} assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nfetch-handler-failure-status-smoke passed: {$total} assertions.\n";


### PR DESCRIPTION
## Summary
- Preserve fetch handler exceptions as failed step results instead of allowing zero-packet fetches to be classified as completed_no_items.
- Return explicit failed step output for handler failures so downstream agent-bundle status reflects the real failure.
- Add smoke coverage for the fetch handler failure contract.

## Testing
- `php -l inc/Core/Steps/Fetch/FetchStep.php`
- `php tests/fetch-handler-failure-status-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the site-generation loop failure path, drafted the fetch-step error propagation change, and added focused smoke coverage for Chris to review and verify.