### PR TITLE
Preserve step execution error messages

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -252,7 +252,7 @@ class ExecuteStepAbility {
 					'packet_count' => $execution_result['packet_count'],
 					'status'       => $recorded_status,
 					'reason'       => $result['reason'] ?? ( $execution_result['reason'] ?? ( $result['error'] ?? null ) ),
-					'error'        => $result['error'] ?? null,
+					'error'        => $result['error'] ?? ( $execution_result['error'] ?? null ),
 				)
 			);
 

--- a/inc/Core/StepExecutionResult.php
+++ b/inc/Core/StepExecutionResult.php
@@ -34,18 +34,20 @@ class StepExecutionResult {
 	 *     'status'          => 'succeeded|failed|completed_no_items|blocked',
 	 *     'packets'         => array(),
 	 *     'reason'          => '...',
+	 *     'error'           => '...',
 	 *     'terminal_status' => null,
 	 * )
 	 *
 	 * @param mixed  $step_output Step return value.
 	 * @param string $step_type   Step type identifier.
-	 * @return array{status: string, packets: array, reason: string, terminal_status: ?string, success: bool, packet_count: int}
+	 * @return array{status: string, packets: array, reason: string, error: ?string, terminal_status: ?string, success: bool, packet_count: int}
 	 */
 	public static function fromStepOutput( $step_output, string $step_type = '' ): array {
 		if ( self::isExplicitResult( $step_output ) ) {
 			$packets = self::normalizePackets( $step_output['packets'] ?? ( $step_output['data_packets'] ?? array() ) );
 			$status  = self::normalizeStatus( $step_output['status'] ?? '' );
 			$reason  = is_scalar( $step_output['reason'] ?? null ) ? self::sanitizeReason( $step_output['reason'] ) : '';
+			$error   = self::normalizeError( $step_output['error'] ?? ( $step_output['error_message'] ?? null ) );
 
 			if ( '' === $status ) {
 				$classified = self::classify( $packets, $step_type );
@@ -60,7 +62,7 @@ class StepExecutionResult {
 			$terminal_status = $step_output['terminal_status'] ?? null;
 			$terminal_status = is_scalar( $terminal_status ) && '' !== trim( (string) $terminal_status ) ? trim( (string) $terminal_status ) : null;
 
-			return self::buildResult( $status, $packets, $reason, $terminal_status );
+			return self::buildResult( $status, $packets, $reason, $terminal_status, $error );
 		}
 
 		return self::classify( self::normalizePackets( $step_output ), $step_type );
@@ -71,7 +73,7 @@ class StepExecutionResult {
 	 *
 	 * @param array  $data_packets Returned data packets.
 	 * @param string $step_type    Step type identifier.
-	 * @return array{status: string, packets: array, reason: string, terminal_status: ?string, success: bool, packet_count: int}
+	 * @return array{status: string, packets: array, reason: string, error: ?string, terminal_status: ?string, success: bool, packet_count: int}
 	 */
 	public static function classify( array $data_packets, string $step_type = '' ): array {
 		$data_packets = self::normalizePackets( $data_packets );
@@ -94,7 +96,7 @@ class StepExecutionResult {
 
 			if ( array_key_exists( 'step_execution_success', $metadata ) ) {
 				if ( false === (bool) $metadata['step_execution_success'] ) {
-					return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'step_execution_failed' ), null );
+					return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'step_execution_failed' ), null, self::errorFromMetadata( $metadata ) );
 				}
 
 				$has_success_packet = true;
@@ -102,7 +104,7 @@ class StepExecutionResult {
 			}
 
 			if ( isset( $metadata['success'] ) && false === $metadata['success'] ) {
-				return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'packet_failure' ), null );
+				return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'packet_failure' ), null, self::errorFromMetadata( $metadata ) );
 			}
 
 			if ( isset( $metadata['tool_success'] ) && false === $metadata['tool_success'] ) {
@@ -115,7 +117,7 @@ class StepExecutionResult {
 					continue;
 				}
 
-				return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'tool_result_failed' ), null );
+				return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'tool_result_failed' ), null, self::errorFromMetadata( $metadata ) );
 			}
 
 			if ( ! isset( self::NON_SUCCESS_PACKET_TYPES[ $type ] ) ) {
@@ -131,7 +133,7 @@ class StepExecutionResult {
 		);
 	}
 
-	private static function buildResult( string $status, array $packets, string $reason, ?string $terminal_status ): array {
+	private static function buildResult( string $status, array $packets, string $reason, ?string $terminal_status, ?string $error = null ): array {
 		$status = self::normalizeStatus( $status );
 		if ( '' === $status ) {
 			$status = self::STATUS_FAILED;
@@ -141,10 +143,24 @@ class StepExecutionResult {
 			'status'          => $status,
 			'packets'         => $packets,
 			'reason'          => self::sanitizeReason( $reason ),
+			'error'           => self::normalizeError( $error ),
 			'terminal_status' => $terminal_status,
 			'success'         => self::STATUS_SUCCEEDED === $status,
 			'packet_count'    => count( $packets ),
 		);
+	}
+
+	private static function errorFromMetadata( array $metadata ): ?string {
+		return self::normalizeError( $metadata['error'] ?? ( $metadata['error_message'] ?? null ) );
+	}
+
+	private static function normalizeError( $error ): ?string {
+		if ( ! is_scalar( $error ) ) {
+			return null;
+		}
+
+		$error = trim( (string) $error );
+		return '' !== $error ? $error : null;
 	}
 
 	private static function isExplicitResult( $step_output ): bool {

--- a/tests/step-execution-result-error-smoke.php
+++ b/tests/step-execution-result-error-smoke.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Pure-PHP smoke test for step execution result error propagation.
+ *
+ * Run with: php tests/step-execution-result-error-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/wordpress/' );
+}
+
+require_once dirname( __DIR__ ) . '/inc/Core/StepExecutionResult.php';
+
+use DataMachine\Core\StepExecutionResult;
+
+$failed = 0;
+$total  = 0;
+
+function assert_step_execution_result_error( string $name, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+
+	++$failed;
+	echo "  [FAIL] {$name}\n";
+}
+
+echo "=== step-execution-result-error-smoke ===\n";
+
+$explicit_error_result = StepExecutionResult::fromStepOutput(
+	array(
+		'status' => 'failed',
+		'reason' => 'handler_failed',
+		'error'  => 'GitHub API request failed: 404 Not Found',
+	),
+	'fetch'
+);
+
+assert_step_execution_result_error(
+	'explicit result preserves human error message',
+	'GitHub API request failed: 404 Not Found' === $explicit_error_result['error']
+);
+
+assert_step_execution_result_error(
+	'explicit result keeps sanitized reason separate from error',
+	'handler_failed' === $explicit_error_result['reason']
+);
+
+$metadata_error_result = StepExecutionResult::classify(
+	array(
+		array(
+			'type'     => 'handler_result',
+			'metadata' => array(
+				'tool_success'   => false,
+				'failure_reason' => 'handler_failed',
+				'error_message'  => 'GitHub App installation token exchange failed.',
+			),
+		),
+	),
+	'fetch'
+);
+
+assert_step_execution_result_error(
+	'packet metadata errors propagate to execution result',
+	'GitHub App installation token exchange failed.' === $metadata_error_result['error']
+);
+
+if ( $failed > 0 ) {
+	echo "\nstep-execution-result-error-smoke failed: {$failed}/{$total} assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nstep-execution-result-error-smoke passed: {$total} assertions.\n";


### PR DESCRIPTION
## Summary
- Preserve human-readable step execution error messages in `StepExecutionResult` alongside sanitized machine reasons.
- Record execution-result errors in step metrics when routing does not produce a separate error.
- Add a pure-PHP smoke test covering explicit result and packet metadata error propagation.

## Verification
- `php tests/step-execution-result-error-smoke.php`
- `php tests/fetch-handler-failure-status-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the Data Machine step-result diagnostic gap, drafting the patch and smoke coverage, and running focused verification. Chris remains responsible for review and testing.