### PR TITLE
Preserve fetch handler error messages

### DIFF
--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -248,6 +248,7 @@ class FetchStep extends Step {
 				'status'  => 'failed',
 				'packets' => $this->dataPackets,
 				'reason'  => 'handler_failed',
+				'error'   => $packets->get_error_message(),
 			);
 		}
 

--- a/tests/fetch-handler-failure-status-smoke.php
+++ b/tests/fetch-handler-failure-status-smoke.php
@@ -43,6 +43,11 @@ assert_fetch_handler_failure_status(
 );
 
 assert_fetch_handler_failure_status(
+	'FetchStep preserves handler failure messages in explicit results',
+	str_contains( $file, "'error'   => \$packets->get_error_message()," )
+);
+
+assert_fetch_handler_failure_status(
 	'execute_handler preserves handler exceptions as WP_Error',
 	str_contains( $file, "new \\WP_Error( 'fetch_handler_execution_failed', \$e->getMessage() )" )
 );


### PR DESCRIPTION
## Summary
- Include handler failure messages in the explicit failed result returned by `FetchStep`.
- Extend the fetch-handler smoke test so future failures do not regress back to `handler_failed` without the underlying message.

## Verification
- `php tests/fetch-handler-failure-status-smoke.php`
- `php tests/step-execution-result-error-smoke.php`
- `php -l inc/Core/Steps/Fetch/FetchStep.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Tracing the remaining Data Machine diagnostic drop, drafting the minimal fetch-step patch, and running focused verification. Chris remains responsible for review and testing.