### PR TITLE
Record bundle tool results into engine data

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -351,6 +351,14 @@ class AIStep extends Step {
 				$payload['tool_runtime_rules'] = $tool_runtime_rules;
 			}
 
+			$tool_recorders = self::mergeListConfigField(
+				is_array( $pipeline_step_config['tool_recorders'] ?? null ) ? $pipeline_step_config['tool_recorders'] : array(),
+				is_array( $this->flow_step_config['tool_recorders'] ?? null ) ? $this->flow_step_config['tool_recorders'] : array()
+			);
+			if ( ! empty( $tool_recorders ) ) {
+				$payload['tool_recorders'] = $tool_recorders;
+			}
+
 			// Tool categories can be specified at the pipeline step level or pipeline level.
 			// This allows pipelines to declare which ability categories are relevant,
 			// reducing tool bloat by excluding irrelevant tools from the AI context.

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -323,6 +323,7 @@ function datamachine_run_conversation(
 		);
 		if ( ! empty( $tool_execution_results ) ) {
 			$result['tool_execution_results'] = $tool_execution_results;
+			datamachine_record_tool_results_to_engine_data( $loop_payload, $tool_execution_results );
 			datamachine_persist_inflight_tool_summary( $loop_payload, $tool_execution_results );
 		}
 	} catch ( \InvalidArgumentException $e ) {
@@ -1928,6 +1929,131 @@ function datamachine_persist_inflight_tool_summary( array $loop_payload, array $
 			'tool_execution_summary' => datamachine_summarize_tool_execution_results( $tool_execution_results, true ),
 		)
 	);
+}
+
+/**
+ * Record configured successful tool result fields into job engine_data.
+ *
+ * @param array<string,mixed>            $loop_payload           Loop payload.
+ * @param array<int,array<string,mixed>> $tool_execution_results Tool execution results accumulated by the loop.
+ */
+function datamachine_record_tool_results_to_engine_data( array $loop_payload, array $tool_execution_results ): void {
+	$job_id    = (int) ( $loop_payload['job_id'] ?? 0 );
+	$recorders = is_array( $loop_payload['tool_recorders'] ?? null ) ? $loop_payload['tool_recorders'] : array();
+	if ( $job_id <= 0 || empty( $recorders ) || ! function_exists( '\datamachine_merge_engine_data' ) ) {
+		return;
+	}
+
+	$engine_data = array();
+	foreach ( $tool_execution_results as $entry ) {
+		if ( ! is_array( $entry ) ) {
+			continue;
+		}
+
+		$tool_name = (string) ( $entry['tool_name'] ?? $entry['name'] ?? '' );
+		$result    = is_array( $entry['result'] ?? null ) ? $entry['result'] : array();
+		if ( '' === $tool_name || empty( $result['success'] ) ) {
+			continue;
+		}
+
+		foreach ( $recorders as $recorder ) {
+			if ( ! is_array( $recorder ) || $tool_name !== (string) ( $recorder['tool'] ?? '' ) ) {
+				continue;
+			}
+
+			$record = is_array( $recorder['record'] ?? null ) ? $recorder['record'] : array();
+			$key    = sanitize_key( (string) ( $record['engine_key'] ?? '' ) );
+			$fields = is_array( $record['fields'] ?? null ) ? $record['fields'] : array();
+			if ( '' === $key || empty( $fields ) ) {
+				continue;
+			}
+
+			$values = datamachine_tool_result_record_values( $result, $fields );
+			if ( ! empty( $values ) ) {
+				$engine_data[ $key ] = array_merge( is_array( $engine_data[ $key ] ?? null ) ? $engine_data[ $key ] : array(), $values );
+			}
+		}
+	}
+
+	if ( ! empty( $engine_data ) ) {
+		\datamachine_merge_engine_data( $job_id, $engine_data );
+	}
+}
+
+/**
+ * @param array<string,mixed> $result Tool result.
+ * @param array<string,mixed> $fields Field mapping config.
+ * @return array<string,mixed>
+ */
+function datamachine_tool_result_record_values( array $result, array $fields ): array {
+	$values = array();
+	$source = array(
+		'data'     => is_array( $result['data'] ?? null ) ? $result['data'] : array(),
+		'result'   => $result,
+		'metadata' => is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array(),
+	);
+
+	foreach ( $fields as $field => $selector ) {
+		$field = sanitize_key( (string) $field );
+		if ( '' === $field ) {
+			continue;
+		}
+
+		$value = datamachine_tool_result_record_value( $source, $selector );
+		if ( null !== $value && '' !== $value && array() !== $value ) {
+			$values[ $field ] = $value;
+		}
+	}
+
+	return $values;
+}
+
+/**
+ * @param array<string,mixed> $source   Tool result source map.
+ * @param mixed               $selector Field selector.
+ * @return mixed
+ */
+function datamachine_tool_result_record_value( array $source, mixed $selector ): mixed {
+	if ( is_scalar( $selector ) ) {
+		return datamachine_tool_result_path_value( $source, (string) $selector );
+	}
+
+	if ( ! is_array( $selector ) ) {
+		return null;
+	}
+
+	$paths = is_array( $selector['paths'] ?? null ) ? $selector['paths'] : array();
+	foreach ( $paths as $path ) {
+		if ( ! is_scalar( $path ) ) {
+			continue;
+		}
+
+		$value = datamachine_tool_result_path_value( $source, (string) $path );
+		if ( null === $value || '' === $value || array() === $value ) {
+			continue;
+		}
+
+		if ( is_scalar( $value ) && is_scalar( $selector['strip_prefix'] ?? null ) ) {
+			$prefix = (string) $selector['strip_prefix'];
+			$value  = str_starts_with( (string) $value, $prefix ) ? substr( (string) $value, strlen( $prefix ) ) : $value;
+		}
+
+		return $value;
+	}
+
+	return null;
+}
+
+function datamachine_tool_result_path_value( array $source, string $path ): mixed {
+	$value = $source;
+	foreach ( array_filter( explode( '.', $path ), static fn( string $part ): bool => '' !== $part ) as $part ) {
+		if ( ! is_array( $value ) || ! array_key_exists( $part, $value ) ) {
+			return null;
+		}
+		$value = $value[ $part ];
+	}
+
+	return $value;
 }
 
 /**

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1957,7 +1957,7 @@ function datamachine_record_tool_results_to_engine_data( array $loop_payload, ar
 		}
 
 		foreach ( $recorders as $recorder ) {
-			if ( ! is_array( $recorder ) || $tool_name !== (string) ( $recorder['tool'] ?? '' ) ) {
+			if ( ! is_array( $recorder ) || (string) ( $recorder['tool'] ?? '' ) !== $tool_name ) {
 				continue;
 			}
 

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -19,6 +19,16 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 	}
 }
 
+if ( ! function_exists( 'datamachine_merge_engine_data' ) ) {
+	function datamachine_merge_engine_data( int $job_id, array $data ): bool {
+		$GLOBALS['datamachine_bundle_runner_engine_data_merges'][] = array(
+			'job_id' => $job_id,
+			'data'   => $data,
+		);
+		return true;
+	}
+}
+
 function datamachine_bundle_runner_assert( bool $condition, string $label, array &$failures, int &$passes ): void {
 	if ( $condition ) {
 		++$passes;
@@ -87,6 +97,7 @@ foreach ( array(
 }
 datamachine_bundle_runner_contains( $abilities, "'outputs'", 'ability output schema advertises semantic outputs', $failures, $passes );
 datamachine_bundle_runner_contains( $abilities, "'output_diagnostics'", 'ability output schema advertises semantic output diagnostics', $failures, $passes );
+datamachine_bundle_runner_contains( $ai_step, "\$payload['tool_recorders']", 'AI step forwards configured tool recorders to the loop', $failures, $passes );
 
 echo "\n[3] Runner exposes semantic outputs without hiding raw engine data\n";
 require_once $root . '/inc/Engine/Bundle/AgentBundleRunner.php';
@@ -125,6 +136,48 @@ datamachine_bundle_runner_assert( 456 === ( $projected_outputs['outputs']['store
 datamachine_bundle_runner_assert( 'https://github.com/chubes4/wp-site-generator/issues/456' === ( $projected_outputs['outputs']['store_issue_url'] ?? null ), 'declared nested engine_data output URL is projected', $failures, $passes );
 datamachine_bundle_runner_assert( ! isset( $projected_outputs['outputs']['agent_id'] ), 'runtime identity fields are not projected as outputs', $failures, $passes );
 datamachine_bundle_runner_assert( array( 'missing_result_url', 'missing_store_url' ) === ( $projected_outputs['diagnostics']['missing_outputs'] ?? null ), 'missing declared outputs are diagnosed semantically', $failures, $passes );
+
+echo "\n[3a] Successful tool results can be recorded into engine data\n";
+require_once $root . '/inc/Engine/AI/conversation-loop.php';
+$GLOBALS['datamachine_bundle_runner_engine_data_merges'] = array();
+\DataMachine\Engine\AI\datamachine_record_tool_results_to_engine_data(
+	array(
+		'job_id'         => 77,
+		'tool_recorders' => array(
+			array(
+				'tool'   => 'github_pull_request_publish',
+				'record' => array(
+					'engine_key' => 'static_site_agent',
+					'fields'     => array(
+						'branch' => 'data.head',
+						'pr_url' => 'data.html_url',
+						'slug'   => array(
+							'paths'        => array( 'data.head' ),
+							'strip_prefix' => 'static/',
+						),
+					),
+				),
+			),
+		),
+	),
+	array(
+		array(
+			'tool_name' => 'github_pull_request_publish',
+			'result'    => array(
+				'success' => true,
+				'data'    => array(
+					'head'     => 'static/issue-460-design-direction',
+					'html_url' => 'https://github.com/chubes4/wp-site-generator/pull/461',
+				),
+			),
+		),
+	)
+);
+$recorded_merge = $GLOBALS['datamachine_bundle_runner_engine_data_merges'][0] ?? array();
+datamachine_bundle_runner_assert( 77 === ( $recorded_merge['job_id'] ?? null ), 'tool recorder writes to the owning job', $failures, $passes );
+datamachine_bundle_runner_assert( 'static/issue-460-design-direction' === ( $recorded_merge['data']['static_site_agent']['branch'] ?? null ), 'tool recorder maps branch from result data', $failures, $passes );
+datamachine_bundle_runner_assert( 'https://github.com/chubes4/wp-site-generator/pull/461' === ( $recorded_merge['data']['static_site_agent']['pr_url'] ?? null ), 'tool recorder maps PR URL from result data', $failures, $passes );
+datamachine_bundle_runner_assert( 'issue-460-design-direction' === ( $recorded_merge['data']['static_site_agent']['slug'] ?? null ), 'tool recorder applies strip_prefix transforms', $failures, $passes );
 
 echo "\n[3b] Runner applies run-scoped flow step patches\n";
 $workflow_from_bundle_flow = $runner_reflection->getMethod( 'workflow_from_bundle_flow' );


### PR DESCRIPTION
## Summary
- Forward configured `tool_recorders` from AI steps into the conversation loop.
- Record successful matching tool result fields into job `engine_data` so bundle `engine_data_outputs` can project semantic outputs.
- Cover the static-site PR publish result shape, including `strip_prefix` slug projection, in the bundle runner smoke test.

## Verification
- `php -l inc/Engine/AI/conversation-loop.php`
- `php -l inc/Core/Steps/AI/AIStep.php`
- `php tests/agent-bundle-runner-contract-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing proof-run artifacts, drafting the Data Machine patch, and adding focused smoke coverage; Chris remains responsible for review and merge.