### PR TITLE
Record wrapped tool result data

### DIFF
--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1968,7 +1968,7 @@ function datamachine_record_tool_results_to_engine_data( array $loop_payload, ar
 				continue;
 			}
 
-			$values = datamachine_tool_result_record_values( $result, $fields );
+			$values = datamachine_tool_result_record_values( $entry, $fields );
 			if ( ! empty( $values ) ) {
 				$engine_data[ $key ] = array_merge( is_array( $engine_data[ $key ] ?? null ) ? $engine_data[ $key ] : array(), $values );
 			}
@@ -1981,16 +1981,24 @@ function datamachine_record_tool_results_to_engine_data( array $loop_payload, ar
 }
 
 /**
- * @param array<string,mixed> $result Tool result.
+ * @param array<string,mixed> $entry  Tool result entry.
  * @param array<string,mixed> $fields Field mapping config.
  * @return array<string,mixed>
  */
-function datamachine_tool_result_record_values( array $result, array $fields ): array {
-	$values = array();
-	$source = array(
-		'data'     => is_array( $result['data'] ?? null ) ? $result['data'] : array(),
-		'result'   => $result,
-		'metadata' => is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array(),
+function datamachine_tool_result_record_values( array $entry, array $fields ): array {
+	$values               = array();
+	$result               = is_array( $entry['result'] ?? null ) ? $entry['result'] : $entry;
+	$nested_result        = is_array( $result['result'] ?? null ) ? $result['result'] : array();
+	$tool_result_data     = is_array( $entry['tool_result_data'] ?? null ) ? $entry['tool_result_data'] : ( is_array( $result['tool_result_data'] ?? null ) ? $result['tool_result_data'] : array() );
+	$tool_result_envelope = is_array( $entry['tool_result_envelope'] ?? null ) ? $entry['tool_result_envelope'] : ( is_array( $result['tool_result_envelope'] ?? null ) ? $result['tool_result_envelope'] : array() );
+	$envelope_result      = is_array( $tool_result_envelope['result'] ?? null ) ? $tool_result_envelope['result'] : array();
+	$source               = array(
+		'data'                 => datamachine_first_tool_result_data( $result, $nested_result, $tool_result_data, $tool_result_envelope, $envelope_result ),
+		'entry'                => $entry,
+		'result'               => $result,
+		'tool_result_data'     => $tool_result_data,
+		'tool_result_envelope' => $tool_result_envelope,
+		'metadata'             => is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array(),
 	);
 
 	foreach ( $fields as $field => $selector ) {
@@ -2006,6 +2014,20 @@ function datamachine_tool_result_record_values( array $result, array $fields ): 
 	}
 
 	return $values;
+}
+
+/**
+ * @param array<string,mixed> ...$candidates Candidate result containers.
+ * @return array<string,mixed>
+ */
+function datamachine_first_tool_result_data( array ...$candidates ): array {
+	foreach ( $candidates as $candidate ) {
+		if ( is_array( $candidate['data'] ?? null ) && ! empty( $candidate['data'] ) ) {
+			return $candidate['data'];
+		}
+	}
+
+	return array();
 }
 
 /**

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -179,6 +179,40 @@ datamachine_bundle_runner_assert( 'static/issue-460-design-direction' === ( $rec
 datamachine_bundle_runner_assert( 'https://github.com/chubes4/wp-site-generator/pull/461' === ( $recorded_merge['data']['static_site_agent']['pr_url'] ?? null ), 'tool recorder maps PR URL from result data', $failures, $passes );
 datamachine_bundle_runner_assert( 'issue-460-design-direction' === ( $recorded_merge['data']['static_site_agent']['slug'] ?? null ), 'tool recorder applies strip_prefix transforms', $failures, $passes );
 
+$GLOBALS['datamachine_bundle_runner_engine_data_merges'] = array();
+\DataMachine\Engine\AI\datamachine_record_tool_results_to_engine_data(
+	array(
+		'job_id'         => 78,
+		'tool_recorders' => array(
+			array(
+				'tool'   => 'github_pull_request_publish',
+				'record' => array(
+					'engine_key' => 'static_site_agent',
+					'fields'     => array(
+						'branch' => 'data.head',
+						'pr_url' => 'data.html_url',
+					),
+				),
+			),
+		),
+	),
+	array(
+		array(
+			'tool_name'        => 'github_pull_request_publish',
+			'result'           => array( 'success' => true ),
+			'tool_result_data' => array(
+				'data' => array(
+					'head'     => 'static/issue-468-design-direction',
+					'html_url' => 'https://github.com/chubes4/wp-site-generator/pull/470',
+				),
+			),
+		),
+	)
+);
+$recorded_envelope_merge = $GLOBALS['datamachine_bundle_runner_engine_data_merges'][0] ?? array();
+datamachine_bundle_runner_assert( 'static/issue-468-design-direction' === ( $recorded_envelope_merge['data']['static_site_agent']['branch'] ?? null ), 'tool recorder maps branch from wrapped tool_result_data', $failures, $passes );
+datamachine_bundle_runner_assert( 'https://github.com/chubes4/wp-site-generator/pull/470' === ( $recorded_envelope_merge['data']['static_site_agent']['pr_url'] ?? null ), 'tool recorder maps PR URL from wrapped tool_result_data', $failures, $passes );
+
 echo "\n[3b] Runner applies run-scoped flow step patches\n";
 $workflow_from_bundle_flow = $runner_reflection->getMethod( 'workflow_from_bundle_flow' );
 $patched_workflow          = $workflow_from_bundle_flow->invoke(


### PR DESCRIPTION
## Summary
- Resolve tool recorder `data.*` mappings from wrapped tool result containers such as `tool_result_data.data`.
- Preserve the bundle-facing recorder path contract (`data.head`, `data.html_url`) while handling the canonical result shape emitted in run artifacts.
- Add smoke coverage using the `wp-site-generator` static-site PR publish shape from proof run `27040750096`.

## Verification
- `php -l inc/Engine/AI/conversation-loop.php`
- `php tests/agent-bundle-runner-contract-smoke.php`

## Context
The Site Generation Loop reached static-site publish and opened PRs, but bundle `engine_data_outputs` were still missing because the recorder saw the successful tool call without resolving the wrapped `tool_result_data.data` payload.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting proof-run artifacts, identifying the wrapped result shape, and drafting the focused recorder fix and regression smoke.