### PR TITLE
Project bundle tool recorders onto AI steps

### DIFF
--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -825,7 +825,7 @@ final class AgentBundleRunner {
 				continue;
 			}
 
-			$existing = is_array( $workflow_step['tool_recorders'] ?? null ) ? $workflow_step['tool_recorders'] : array();
+			$existing                         = is_array( $workflow_step['tool_recorders'] ?? null ) ? $workflow_step['tool_recorders'] : array();
 			$workflow_step['tool_recorders'] = array_merge( $existing, $recorders );
 		}
 		unset( $workflow_step );

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -805,8 +805,30 @@ final class AgentBundleRunner {
 		}
 
 		$this->apply_flow_step_patches( $workflow_steps, is_array( $input['flow_step_patches'] ?? null ) ? $input['flow_step_patches'] : array() );
+		$this->apply_run_tool_recorders( $workflow_steps, $input );
 
 		return array( 'steps' => $workflow_steps );
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $workflow_steps Workflow steps to mutate.
+	 * @param array<string,mixed>            $input          Bundle run input.
+	 */
+	private function apply_run_tool_recorders( array &$workflow_steps, array $input ): void {
+		$recorders = array_values( array_filter( is_array( $input['tool_recorders'] ?? null ) ? $input['tool_recorders'] : array(), 'is_array' ) );
+		if ( empty( $recorders ) ) {
+			return;
+		}
+
+		foreach ( $workflow_steps as &$workflow_step ) {
+			if ( 'ai' !== (string) ( $workflow_step['step_type'] ?? '' ) ) {
+				continue;
+			}
+
+			$existing = is_array( $workflow_step['tool_recorders'] ?? null ) ? $workflow_step['tool_recorders'] : array();
+			$workflow_step['tool_recorders'] = array_merge( $existing, $recorders );
+		}
+		unset( $workflow_step );
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -825,7 +825,7 @@ final class AgentBundleRunner {
 				continue;
 			}
 
-			$existing                         = is_array( $workflow_step['tool_recorders'] ?? null ) ? $workflow_step['tool_recorders'] : array();
+			$existing                        = is_array( $workflow_step['tool_recorders'] ?? null ) ? $workflow_step['tool_recorders'] : array();
 			$workflow_step['tool_recorders'] = array_merge( $existing, $recorders );
 		}
 		unset( $workflow_step );

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -231,6 +231,12 @@ $patched_workflow          = $workflow_from_bundle_flow->invoke(
 					),
 				),
 			),
+			array(
+				'flow_step_id'     => 'publish-static-site',
+				'pipeline_step_id' => 'publish-pipeline',
+				'step_position'    => 1,
+				'step_type'        => 'ai',
+			),
 		),
 	),
 	array(
@@ -238,6 +244,11 @@ $patched_workflow          = $workflow_from_bundle_flow->invoke(
 			array(
 				'step_position' => 0,
 				'step_type'     => 'fetch',
+				'step_config'   => array( 'queue_mode' => 'static' ),
+			),
+			array(
+				'step_position' => 1,
+				'step_type'     => 'ai',
 				'step_config'   => array( 'queue_mode' => 'static' ),
 			),
 		),
@@ -253,10 +264,20 @@ $patched_workflow          = $workflow_from_bundle_flow->invoke(
 				),
 			),
 		),
+		'tool_recorders'     => array(
+			array(
+				'tool'   => 'github_pull_request_publish',
+				'record' => array(
+					'engine_key' => 'static_site_agent',
+					'fields'     => array( 'branch' => 'data.head' ),
+				),
+			),
+		),
 	)
 );
 datamachine_bundle_runner_assert( 429 === ( $patched_workflow['steps'][0]['handler_configs']['github']['issue_number'] ?? null ), 'flow step patch merges nested handler config', $failures, $passes );
 datamachine_bundle_runner_assert( 'chubes4/wp-site-generator' === ( $patched_workflow['steps'][0]['handler_configs']['github']['repo'] ?? null ), 'flow step patch preserves existing handler config', $failures, $passes );
+datamachine_bundle_runner_assert( 'github_pull_request_publish' === ( $patched_workflow['steps'][1]['tool_recorders'][0]['tool'] ?? null ), 'run-scoped tool recorders are projected onto AI workflow steps', $failures, $passes );
 
 echo "\n[3c] Runner does not treat no-item terminal states as success\n";
 $response_method = $runner_reflection->getMethod( 'response' );


### PR DESCRIPTION
## Summary
- Projects run-scoped `tool_recorders` from `datamachine/run-agent-bundle` onto generated AI workflow steps.
- Adds smoke coverage for the bundle runner projection so recorder config reaches `AIStep` before the loop executes.

## Verification
- `php -l inc/Engine/Bundle/AgentBundleRunner.php`
- `php tests/agent-bundle-runner-contract-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed proof-run artifacts, drafted the Data Machine projection fix, and ran focused smoke verification; Chris remains responsible for review and merge.