### PR TITLE
ci: reduce no-op release checks

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -5,12 +5,11 @@ on:
     branches: [main]
   push:
     branches: [main]
-    tags: ['v*']
   workflow_dispatch:
 
 concurrency:
   group: homeboy-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -19,10 +18,11 @@ permissions:
 
 jobs:
   homeboy:
+    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'release:') }}
     uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2
     with:
-      commands: audit,lint,test
-      expected-commands: audit,lint,test
-      autofix: 'true'
+      commands: ${{ github.event_name == 'pull_request' && 'audit,lint,test' || github.event_name == 'workflow_dispatch' && 'audit,lint,test' || 'test' }}
+      expected-commands: ${{ github.event_name == 'pull_request' && 'audit,lint,test' || github.event_name == 'workflow_dispatch' && 'audit,lint,test' || 'test' }}
+      autofix: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
       autofix-commands: 'lint --fix'
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
   # ── Step 1: Check for releasable commits ──
   check:
     name: Check for releasable commits
+    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'release:') }}
     runs-on: ubuntu-latest
     outputs:
       should-release: ${{ steps.check.outputs.should-release }}
@@ -50,8 +51,43 @@ jobs:
           restore-keys: |
             release-last-failed-${{ github.ref_name }}-
 
+      - name: Check failed release marker
+        id: failed-release
+        run: |
+          HEAD_SHA="$(git rev-parse HEAD)"
+          FAILURE_MARKER="${RUNNER_TEMP}/homeboy-release-last-failed"
+          if [ -f "${FAILURE_MARKER}" ]; then
+            LAST_FAILED="$(tr -d '[:space:]' < "${FAILURE_MARKER}")"
+            if [ "${HEAD_SHA}" = "${LAST_FAILED}" ]; then
+              echo "::notice::HEAD ${HEAD_SHA:0:8} matches last failed release attempt — skipping until new commits"
+              echo "blocked=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          echo "blocked=false" >> "$GITHUB_OUTPUT"
+
+      - name: Check for releasable commit messages
+        id: commit-check
+        if: steps.failed-release.outputs.blocked != 'true'
+        run: |
+          LAST_TAG="$(git describe --tags --match 'v[0-9]*' --abbrev=0 2>/dev/null || true)"
+          if [ -n "${LAST_TAG}" ]; then
+            RANGE="${LAST_TAG}..HEAD"
+          else
+            RANGE="HEAD"
+          fi
+
+          if git log --format=%B "${RANGE}" | grep -Eq '^(feat|fix)(\([^)]+\))?!?:|^BREAKING CHANGE:'; then
+            echo "could-release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No releasable conventional commits in ${RANGE}"
+            echo "could-release=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Dry-run release check
         id: release-check
+        if: steps.commit-check.outputs.could-release == 'true'
         uses: Extra-Chill/homeboy-action@v2
         with:
           commands: release
@@ -61,14 +97,15 @@ jobs:
         id: check
         run: |
           HEAD_SHA="$(git rev-parse HEAD)"
-          FAILURE_MARKER="${RUNNER_TEMP}/homeboy-release-last-failed"
-          if [ -f "${FAILURE_MARKER}" ]; then
-            LAST_FAILED="$(tr -d '[:space:]' < "${FAILURE_MARKER}")"
-            if [ "${HEAD_SHA}" = "${LAST_FAILED}" ]; then
-              echo "::notice::HEAD ${HEAD_SHA:0:8} matches last failed release attempt — skipping until new commits"
-              echo "should-release=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
+          if [ "${{ steps.failed-release.outputs.blocked }}" = "true" ]; then
+            echo "should-release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ steps.commit-check.outputs.could-release }}" != "true" ]; then
+            echo "should-release=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No releasable commits at HEAD ${HEAD_SHA:0:8}"
+            exit 0
           fi
 
           RELEASE_VERSION="${{ steps.release-check.outputs.release-version }}"


### PR DESCRIPTION
## Summary
- Stop Homeboy from running on release commits or release tags, and cancel stale Homeboy runs instead of queueing main-branch checks behind obsolete pushes.
- Keep full `audit,lint,test` for PRs and manual runs while reducing main-push Homeboy to `test`, so known full-tree audit/lint baseline drift does not repeatedly block release churn.
- Move cheap release skip checks ahead of `homeboy release --dry-run`, avoiding dependency setup when HEAD already failed or has no releasable conventional commits.

## Verification
- Parsed `.github/workflows/homeboy.yml` and `.github/workflows/release.yml` with Ruby YAML.
- Ran the cheap release precheck locally on current main HEAD; `v0.139.39..HEAD` returned `could-release=false`.
- `actionlint` is not installed locally, so dedicated actionlint validation was not available.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated failing main workflow runs, drafted the workflow changes, and ran local syntax/precheck validation for Chris to review.