### PR TITLE
Harden tool ability execution contract

### DIFF
--- a/inc/Engine/AI/Tools/BaseTool.php
+++ b/inc/Engine/AI/Tools/BaseTool.php
@@ -32,8 +32,10 @@ abstract class BaseTool {
 	 *
 	 * Tools should also declare which ability they wrap via the `ability` key
 	 * (or `abilities` for composed tools). The ToolPolicyResolver uses this to
-	 * check the ability's permission_callback before offering the tool to AI agents.
-	 * Tools without an ability declaration default to admin-only access.
+	 * check the ability's permission_callback before offering the tool to AI agents;
+	 * class/method tools still execute their wrapper methods. Direct ability-backed
+	 * tools must declare the explicit `execution_ability` marker. Tools without an
+	 * ability declaration default to admin-only access.
 	 *
 	 * Tools may also expose top-level `runtime` metadata in their definition to
 	 * describe loop behavior without hardcoding tool names in core. Supported keys
@@ -56,7 +58,8 @@ abstract class BaseTool {
 	 * @param array|callable $toolDefinition Tool definition array OR callable that returns it.
 	 * @param array          $modes          Agent modes where this tool is available (e.g. ['chat', 'pipeline']).
 	 * @param array          $meta           Optional metadata for permission resolution. {
-	 *     @type string   $ability      Single ability slug this tool wraps (e.g. 'datamachine/local-search').
+	 *     @type string   $ability      Single ability slug this tool wraps for permission checks (e.g. 'datamachine/local-search').
+	 *     @type string   $execution_ability Ability slug to execute directly instead of a class/method wrapper.
 	 *     @type string[] $abilities    Multiple ability slugs for composed tools. ALL must pass permission check.
 	 *     @type string   $access_level Fallback for tools without a linked ability.
 	 *                                  One of: 'public', 'authenticated', 'author', 'editor', 'admin'. Default: 'admin'.
@@ -84,6 +87,9 @@ abstract class BaseTool {
 				// Merge permission metadata into the tool entry.
 				if ( ! empty( $meta['ability'] ) ) {
 					$tools[ $toolName ]['ability'] = $meta['ability'];
+				}
+				if ( ! empty( $meta['execution_ability'] ) ) {
+					$tools[ $toolName ]['execution_ability'] = $meta['execution_ability'];
 				}
 				if ( ! empty( $meta['abilities'] ) ) {
 					$tools[ $toolName ]['abilities'] = $meta['abilities'];

--- a/inc/Engine/AI/Tools/Execution/ToolExecutionCore.php
+++ b/inc/Engine/AI/Tools/Execution/ToolExecutionCore.php
@@ -33,8 +33,19 @@ class ToolExecutionCore implements WP_Agent_Tool_Executor {
 		$tool_name  = (string) ( $tool_call['tool_name'] ?? '' );
 		$parameters = is_array( $tool_call['parameters'] ?? null ) ? $tool_call['parameters'] : array();
 
-		if ( ! empty( $tool_definition['ability'] ) ) {
+		if ( ! empty( $tool_definition['execution_ability'] ) ) {
 			return $this->executeAbilityTool( $tool_name, $parameters, $tool_definition );
+		}
+
+		if ( empty( $tool_definition['class'] ) && ( ! empty( $tool_definition['ability'] ) || ! empty( $tool_definition['abilities'] ) ) ) {
+			return array(
+				'success'   => false,
+				'error'     => sprintf( "Tool '%s' declares ability permission metadata but does not declare 'execution_ability' or a class/method wrapper.", $tool_name ),
+				'tool_name' => $tool_name,
+				'metadata'  => array(
+					'error_type' => 'ambiguous_tool_execution_contract',
+				),
+			);
 		}
 
 		return $this->executeClassMethodTool( $tool_name, $parameters, $tool_definition );
@@ -49,7 +60,7 @@ class ToolExecutionCore implements WP_Agent_Tool_Executor {
 	 * @return array Tool execution result.
 	 */
 	private function executeAbilityTool( string $tool_name, array $parameters, array $tool_definition ): array {
-		$ability_slug = (string) $tool_definition['ability'];
+		$ability_slug = (string) $tool_definition['execution_ability'];
 		if ( ! class_exists( '\\WP_Abilities_Registry' ) ) {
 			return array(
 				'success'   => false,

--- a/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
+++ b/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
@@ -4,7 +4,8 @@
  *
  * Exposes selected registered WordPress abilities as model-facing tools without
  * requiring hand-written BaseTool wrappers. Execution remains ability-native via
- * ToolExecutionCore because generated declarations include the `ability` key.
+ * ToolExecutionCore because generated declarations include the explicit
+ * `execution_ability` marker.
  *
  * @package DataMachine\Engine\AI\Tools\Sources
  */
@@ -142,13 +143,14 @@ final class AbilityToolSource {
 		$annotations = is_array( $meta['annotations'] ?? null ) ? $meta['annotations'] : array();
 
 		$tool = array(
-			'ability'          => $ability_slug,
-			'ability_category' => method_exists( $ability, 'get_category' ) ? (string) $ability->get_category() : '',
-			'annotations'      => $annotations,
-			'description'      => method_exists( $ability, 'get_description' ) ? (string) $ability->get_description() : '',
-			'label'            => method_exists( $ability, 'get_label' ) ? (string) $ability->get_label() : $tool_name,
-			'modes'            => array( ToolPolicyResolver::MODE_CHAT ),
-			'parameters'       => method_exists( $ability, 'get_input_schema' ) ? $ability->get_input_schema() : array(),
+			'ability'           => $ability_slug,
+			'execution_ability' => $ability_slug,
+			'ability_category'  => method_exists( $ability, 'get_category' ) ? (string) $ability->get_category() : '',
+			'annotations'       => $annotations,
+			'description'       => method_exists( $ability, 'get_description' ) ? (string) $ability->get_description() : '',
+			'label'             => method_exists( $ability, 'get_label' ) ? (string) $ability->get_label() : $tool_name,
+			'modes'             => array( ToolPolicyResolver::MODE_CHAT ),
+			'parameters'        => method_exists( $ability, 'get_input_schema' ) ? $ability->get_input_schema() : array(),
 		);
 
 		foreach ( self::OVERRIDE_KEYS as $key ) {

--- a/inc/Engine/AI/Tools/ability-tool-projections.php
+++ b/inc/Engine/AI/Tools/ability-tool-projections.php
@@ -11,9 +11,10 @@ if ( ! function_exists( 'datamachine_register_ability_tool' ) ) {
 	/**
 	 * Register an ability as a model-facing tool projection.
 	 *
-	 * The declaration must include an `ability` slug. Optional keys such as
-	 * `modes`, `description`, `parameters`, `requires_opt_in`, `action_policy`,
-	 * and `runtime` are passed through AbilityToolSource.
+	 * The declaration must include an `ability` slug. AbilityToolSource uses that
+	 * slug as both permission metadata and the explicit direct-execution marker.
+	 * Optional keys such as `modes`, `description`, `parameters`,
+	 * `requires_opt_in`, `action_policy`, and `runtime` are passed through.
 	 *
 	 * @param string $tool_name   Model-facing tool name.
 	 * @param array  $declaration Ability projection declaration.

--- a/tests/ability-tool-source-smoke.php
+++ b/tests/ability-tool-source-smoke.php
@@ -360,6 +360,7 @@ assert_ability_tool_source_equals( true, isset( $tools['summarize_demo'] ), 'cha
 assert_ability_tool_source_equals( true, isset( $tools['helper_demo'] ), 'helper projection feeds ability tool source', $failures, $passes );
 assert_ability_tool_source_equals( true, isset( $tools['legacy_alias_demo'] ), 'legacy ability tools filter remains supported', $failures, $passes );
 assert_ability_tool_source_equals( 'demo/summarize', $tools['summarize_demo']['ability'] ?? '', 'generated tool links ability slug', $failures, $passes );
+assert_ability_tool_source_equals( 'demo/summarize', $tools['summarize_demo']['execution_ability'] ?? '', 'generated tool declares explicit direct-execution ability marker', $failures, $passes );
 assert_ability_tool_source_equals( 'Summarize Demo', $tools['summarize_demo']['label'] ?? '', 'generated tool carries ability label', $failures, $passes );
 assert_ability_tool_source_equals( 'demo-category', $tools['summarize_demo']['ability_category'] ?? '', 'generated tool carries ability category', $failures, $passes );
 assert_ability_tool_source_equals( 'Model-facing summary override.', $tools['summarize_demo']['description'] ?? '', 'definition filter can override model-facing description', $failures, $passes );

--- a/tests/tool-executor-ability-native-smoke.php
+++ b/tests/tool-executor-ability-native-smoke.php
@@ -218,6 +218,26 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 		}
 	}
 
+	class CompositeIssueTool {
+		public static int $calls = 0;
+
+		public function execute( array $parameters, array $tool_def ): array {
+			++self::$calls;
+			$action       = (string) ( $parameters['action'] ?? 'update' );
+			$ability_slug = 'comment' === $action ? 'datamachine/comment-issue' : 'datamachine/update-issue';
+			$ability      = \WP_Abilities_Registry::get_instance()->get_registered( $ability_slug );
+
+			return $ability->execute(
+				array(
+					'action'    => $action,
+					'issue'     => $parameters['issue'] ?? 0,
+					'body'      => $parameters['body'] ?? '',
+					'tool_name' => $tool_def['name'] ?? 'composite_issue_tool',
+				)
+			);
+		}
+	}
+
 	function execute_tool( string $tool_name, array $tool_parameters, array $tool_def, array $payload = array() ): array {
 		return ToolExecutor::executeTool(
 			$tool_name,
@@ -254,9 +274,10 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 		'ability_only_tool',
 		array( 'message' => 'hello' ),
 		array(
-			'ability'     => 'datamachine/smoke-ability',
-			'description' => 'Ability-only smoke tool',
-			'parameters'  => array(
+			'ability'           => 'datamachine/smoke-ability',
+			'execution_ability' => 'datamachine/smoke-ability',
+			'description'       => 'Ability-only smoke tool',
+			'parameters'        => array(
 				'message' => array(
 					'type'     => 'string',
 					'required' => true,
@@ -284,6 +305,7 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 		array( 'message' => 'hello' ),
 		array(
 			'ability'                 => 'datamachine/bound-ability',
+			'execution_ability'       => 'datamachine/bound-ability',
 			'client_context_bindings' => array( 'job_id' ),
 			'parameters'              => array(
 				'message' => array(
@@ -313,8 +335,9 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 		'runtime_keys_tool',
 		array( 'message' => 'hello' ),
 		array(
-			'ability'    => 'datamachine/runtime-keys-ability',
-			'parameters' => array(
+			'ability'           => 'datamachine/runtime-keys-ability',
+			'execution_ability' => 'datamachine/runtime-keys-ability',
+			'parameters'        => array(
 				'message'      => array(
 					'type'     => 'string',
 					'required' => true,
@@ -364,8 +387,9 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 		array( 'message' => 'core' ),
 		array(
 			'core_ability_tool' => array(
-				'ability'    => 'datamachine/core-ability',
-				'parameters' => array(
+				'ability'           => 'datamachine/core-ability',
+				'execution_ability' => 'datamachine/core-ability',
+				'parameters'        => array(
 					'message' => array(
 						'type'     => 'string',
 						'required' => true,
@@ -396,10 +420,11 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 		'preview_tool',
 		array( 'message' => 'needs approval' ),
 		array(
-			'ability'       => 'datamachine/preview-ability',
-			'action_policy' => ActionPolicyResolver::POLICY_PREVIEW,
-			'action_kind'   => 'preview_kind',
-			'parameters'    => array(
+			'ability'           => 'datamachine/preview-ability',
+			'execution_ability' => 'datamachine/preview-ability',
+			'action_policy'     => ActionPolicyResolver::POLICY_PREVIEW,
+			'action_kind'       => 'preview_kind',
+			'parameters'        => array(
 				'message' => array(
 					'type'     => 'string',
 					'required' => true,
@@ -424,9 +449,10 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 		'preview_missing_metadata_tool',
 		array( 'message' => 'needs approval' ),
 		array(
-			'ability'       => 'datamachine/missing-metadata-ability',
-			'action_policy' => ActionPolicyResolver::POLICY_PREVIEW,
-			'parameters'    => array(
+			'ability'           => 'datamachine/missing-metadata-ability',
+			'execution_ability' => 'datamachine/missing-metadata-ability',
+			'action_policy'     => ActionPolicyResolver::POLICY_PREVIEW,
+			'parameters'        => array(
 				'message' => array(
 					'type'     => 'string',
 					'required' => true,
@@ -439,28 +465,91 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 	assert_smoke( 'preview without action_kind does not stage ambiguous action', 0 === count( PendingActionHelper::$staged ) );
 	assert_smoke( 'preview without action_kind does not execute ability directly', 0 === ability_execute_count( $missing_metadata_ability ) );
 
-	echo "\n[ability:2] Linked ability takes precedence over class/method metadata\n";
+	echo "\n[ability:2] Class/method tool executes wrapper when ability metadata is present\n";
 	LegacyTool::$calls = 0;
 	$result            = execute_tool(
-		'ability_precedence_tool',
-		array( 'message' => 'ability' ),
+		'wrapper_with_ability_metadata_tool',
+		array( 'message' => 'wrapper' ),
 		array(
-			'name'    => 'ability_precedence_tool',
+			'name'    => 'wrapper_with_ability_metadata_tool',
 			'class'   => LegacyTool::class,
 			'method'  => 'execute',
 			'ability' => 'datamachine/smoke-ability',
 		)
 	);
-	assert_smoke( 'ability precedence result succeeds', true === ( $result['success'] ?? false ) );
-	assert_smoke( 'linked ability wins over class/method metadata', true === ( $result['result']['ability'] ?? false ) );
-	assert_smoke( 'class/method fallback is not called when ability exists', 0 === LegacyTool::$calls );
+	assert_smoke( 'wrapper-with-ability-metadata result succeeds', true === ( $result['success'] ?? false ) );
+	assert_smoke( 'class/method wrapper wins over permission ability metadata', true === ( $result['result']['legacy'] ?? false ) );
+	assert_smoke( 'ability metadata does not bypass class/method wrapper', 1 === LegacyTool::$calls );
+	assert_smoke( 'permission ability is not executed directly for wrapper tool', 1 === ability_execute_count( $ability ) );
+
+	echo "\n[ability:2b] Composite wrapper routes based on arguments despite ability metadata\n";
+	$update_issue = new \Ability_Native_Smoke_Ability(
+		fn( $input ) => true,
+		fn( $input ) => array(
+			'success' => true,
+			'route'   => 'update',
+			'input'   => $input,
+		)
+	);
+	$comment_issue = new \Ability_Native_Smoke_Ability(
+		fn( $input ) => true,
+		fn( $input ) => array(
+			'success' => true,
+			'route'   => 'comment',
+			'input'   => $input,
+		)
+	);
+	$registry->register_for_smoke( 'datamachine/update-issue', $update_issue );
+	$registry->register_for_smoke( 'datamachine/comment-issue', $comment_issue );
+	CompositeIssueTool::$calls = 0;
+	$result                    = execute_tool(
+		'manage_issue_tool',
+		array(
+			'action' => 'comment',
+			'issue'  => 487,
+			'body'   => 'regression smoke',
+		),
+		array(
+			'name'       => 'manage_issue_tool',
+			'class'      => CompositeIssueTool::class,
+			'method'     => 'execute',
+			'ability'    => 'datamachine/update-issue',
+			'parameters' => array(
+				'action' => array( 'type' => 'string' ),
+				'issue'  => array( 'type' => 'integer' ),
+				'body'   => array( 'type' => 'string' ),
+			),
+		)
+	);
+	assert_smoke( 'composite wrapper result succeeds', true === ( $result['success'] ?? false ) );
+	assert_smoke( 'composite wrapper selected comment route', 'comment' === ( $result['result']['route'] ?? null ) );
+	assert_smoke( 'composite wrapper executed exactly once', 1 === CompositeIssueTool::$calls );
+	assert_smoke( 'permission metadata ability was not executed as the route', 0 === ability_execute_count( $update_issue ) );
+	assert_smoke( 'routed comment ability executed exactly once', 1 === ability_execute_count( $comment_issue ) );
+
+	echo "\n[ability:2c] Ambiguous ability metadata without execution marker is rejected\n";
+	$ambiguous = new \Ability_Native_Smoke_Ability(
+		fn( $input ) => true,
+		fn( $input ) => array( 'success' => true )
+	);
+	$registry->register_for_smoke( 'datamachine/ambiguous-ability', $ambiguous );
+	$result = execute_tool(
+		'ambiguous_ability_metadata_tool',
+		array(),
+		array(
+			'ability' => 'datamachine/ambiguous-ability',
+		)
+	);
+	assert_smoke( 'ambiguous ability-only metadata fails closed', false === ( $result['success'] ?? true ) );
+	assert_smoke( 'ambiguous ability-only metadata reports stable error type', 'ambiguous_tool_execution_contract' === ( $result['metadata']['error_type'] ?? null ) );
+	assert_smoke( 'ambiguous ability-only metadata does not execute ability', 0 === ability_execute_count( $ambiguous ) );
 
 	echo "\n[ability:3] Missing ability returns a clear failure\n";
 	$result = execute_tool(
 		'missing_ability_tool',
 		array(),
 		array(
-			'ability' => 'datamachine/not-registered',
+			'execution_ability' => 'datamachine/not-registered',
 		)
 	);
 	assert_smoke( 'missing ability fails', false === ( $result['success'] ?? true ) );
@@ -476,7 +565,8 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 		'denied_ability_tool',
 		array(),
 		array(
-			'ability' => 'datamachine/denied-ability',
+			'ability'           => 'datamachine/denied-ability',
+			'execution_ability' => 'datamachine/denied-ability',
 		)
 	);
 	assert_smoke( 'permission-denied ability fails', false === ( $result['success'] ?? true ) );


### PR DESCRIPTION
## Summary
- Split permission ability metadata from direct ability execution by requiring `execution_ability` for ability-native execution.
- Keep generated ability projections direct-executable by adding `execution_ability` alongside `ability`.
- Add regression smoke coverage for class/method wrappers with ability metadata, including a composite wrapper that routes comment/update behavior from arguments.

Closes #2555.

## Tests
- `php tests/tool-executor-ability-native-smoke.php`
- `php tests/ability-tool-source-smoke.php`
- `php tests/tool-source-registry-smoke.php`
- `php tests/pipeline-tool-policy-snapshot-smoke.php`
- `php -l inc/Engine/AI/Tools/Execution/ToolExecutionCore.php && php -l inc/Engine/AI/Tools/BaseTool.php && php -l inc/Engine/AI/Tools/Sources/AbilityToolSource.php && php -l inc/Engine/AI/Tools/ability-tool-projections.php && php -l tests/tool-executor-ability-native-smoke.php && php -l tests/ability-tool-source-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/Tools/Execution/ToolExecutionCore.php inc/Engine/AI/Tools/BaseTool.php inc/Engine/AI/Tools/Sources/AbilityToolSource.php inc/Engine/AI/Tools/ability-tool-projections.php tests/tool-executor-ability-native-smoke.php tests/ability-tool-source-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the execution-contract change and smoke coverage; Chris remains responsible for review and merge.