### PR TITLE
feat: escalate recurring schedules rejected on every tick

### DIFF
--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -19,6 +19,7 @@ use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\PluginSettings;
+use DataMachine\Engine\Tasks\RecurringRejectionTracker;
 use DataMachine\Engine\Tasks\RecurringScheduler;
 use DataMachine\Engine\Tasks\TaskScheduler;
 use DataMachine\Engine\Tasks\TaskRegistry;
@@ -253,24 +254,57 @@ class SystemAbilities {
 		$due             = $this->getActionSchedulerGroupStats( 'pending', true );
 		$daily_memory    = $this->getActionSchedulerHookStats( 'datamachine_recurring_daily_memory_generation' );
 
+		// Recurring bindings rejected by TaskScheduler::schedule() on every
+		// tick are a silent, permanent failure: the task never runs and the
+		// only signal is N identical error rows. RecurringRejectionTracker
+		// correlates those rejections per schedule_id; a degraded schedule
+		// here is the worst scheduler state, so it outranks 'stale'.
+		$rejected_schedules = RecurringRejectionTracker::degraded();
+
 		$status = 'ok';
 		if ( ! function_exists( 'as_get_scheduled_actions' ) || ! class_exists( '\\ActionScheduler' ) ) {
 			$status = 'unavailable';
+		} elseif ( ! empty( $rejected_schedules ) ) {
+			$status = 'failing';
 		} elseif ( $due['count'] > 0 || ( null !== $wp_cron_overdue && $wp_cron_overdue > $stale_threshold ) ) {
 			$status = 'stale';
 		}
 
 		$message = match ( $status ) {
 			'ok'          => __( 'scheduler current', 'data-machine' ),
+			'failing'     => sprintf(
+				/* translators: %d: number of recurring schedules rejected on every tick. */
+				_n(
+					'%d recurring schedule rejected on every tick and never running',
+					'%d recurring schedules rejected on every tick and never running',
+					count( $rejected_schedules ),
+					'data-machine'
+				),
+				count( $rejected_schedules )
+			),
 			'stale'       => __( 'scheduler has overdue work; invoke WordPress cron or run wp datamachine drain', 'data-machine' ),
 			'unavailable' => __( 'Action Scheduler is unavailable', 'data-machine' ),
 			default       => __( 'scheduler status unknown', 'data-machine' ),
 		};
 
+		// Compact, render-friendly view of each persistently-rejected binding.
+		$rejected_report = array();
+		foreach ( $rejected_schedules as $schedule_id => $entry ) {
+			$rejected_report[] = array(
+				'schedule_id'        => $schedule_id,
+				'task_type'          => $entry['task_type'] ?? '',
+				'consecutive_count'  => (int) ( $entry['count'] ?? 0 ),
+				'reason'             => $entry['reason'] ?? '',
+				'first_rejected_gmt' => $entry['first_rejected_gmt'] ?? null,
+				'last_rejected_gmt'  => $entry['last_rejected_gmt'] ?? null,
+			);
+		}
+
 		return array(
 			'status'                  => $status,
 			'message'                 => $message,
 			'stale_threshold_seconds' => $stale_threshold,
+			'rejected_schedules'      => $rejected_report,
 			'action_scheduler'        => array(
 				'available'        => function_exists( 'as_get_scheduled_actions' ),
 				'class_loaded'     => class_exists( '\\ActionScheduler' ),
@@ -290,9 +324,11 @@ class SystemAbilities {
 				'next_pending_gmt' => $daily_memory['pending']['oldest_gmt'],
 				'last_attempt_gmt' => $daily_memory['complete']['last_attempt_gmt'],
 			),
-			'recommendation'          => 'stale' === $status
-				? __( 'For local or low-traffic installs, schedule an external wake-up such as wp cron event run --due-now or wp datamachine drain.', 'data-machine' )
-				: null,
+			'recommendation'          => match ( $status ) {
+				'failing' => __( 'One or more recurring schedules are rejected on every tick and never run. Inspect them with wp datamachine logs (filter error_code recurring_schedule_persistently_rejected) and fix the binding or its prerequisites (agent ownership, task registration, ability availability).', 'data-machine' ),
+				'stale'   => __( 'For local or low-traffic installs, schedule an external wake-up such as wp cron event run --due-now or wp datamachine drain.', 'data-machine' ),
+				default   => null,
+			},
 		);
 	}
 

--- a/inc/Cli/Commands/SystemCommand.php
+++ b/inc/Cli/Commands/SystemCommand.php
@@ -131,6 +131,20 @@ class SystemCommand extends BaseCommand {
 					WP_CLI::log( sprintf( '  Daily memory:   last attempted %s GMT', $daily_memory['last_attempt_gmt'] ) );
 				}
 			}
+			if ( ! empty( $check_result['rejected_schedules'] ) && is_array( $check_result['rejected_schedules'] ) ) {
+				WP_CLI::log( sprintf( '  Rejected schedules: %d (rejected every tick, never running)', count( $check_result['rejected_schedules'] ) ) );
+				foreach ( $check_result['rejected_schedules'] as $rejected ) {
+					WP_CLI::log(
+						sprintf(
+							'    - %s (task %s): %d consecutive rejections since %s GMT',
+							$rejected['schedule_id'] ?? '?',
+							$rejected['task_type'] ?? '?',
+							(int) ( $rejected['consecutive_count'] ?? 0 ),
+							$rejected['first_rejected_gmt'] ?? '?'
+						)
+					);
+				}
+			}
 			if ( isset( $check_result['unowned_pipelines'] ) || isset( $check_result['unowned_flows'] ) ) {
 				WP_CLI::log( sprintf( '  Unowned pipelines: %d', (int) ( $check_result['unowned_pipelines'] ?? 0 ) ) );
 				WP_CLI::log( sprintf( '  Unowned flows:     %d', (int) ( $check_result['unowned_flows'] ?? 0 ) ) );

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -41,6 +41,7 @@ use DataMachine\Engine\AI\System\Tasks\Retention\RetentionProcessedItemsTask;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionStaleClaimsTask;
 use DataMachine\Engine\AI\System\Tasks\SourceInventoryTask;
 use DataMachine\Engine\AI\System\Tasks\SystemTask;
+use DataMachine\Engine\Tasks\RecurringRejectionTracker;
 use DataMachine\Engine\Tasks\RecurringScheduleRegistry;
 use DataMachine\Engine\Tasks\RecurringScheduler;
 use DataMachine\Engine\Tasks\TaskRegistry;
@@ -312,9 +313,21 @@ class SystemAgentServiceProvider {
 								'error_code'  => 'recurring_task_agent_context_required',
 							)
 						);
+						// A persistent "no agents" condition is the same class of
+						// silent recurring-binding failure as a gate rejection:
+						// nothing ever runs. Track it so it escalates.
+						RecurringRejectionTracker::record_rejection(
+							$schedule_id,
+							$task_type,
+							'recurring_task_agent_context_required'
+						);
 						return;
 					}
 
+					// For per-agent schedules, a tick "ran" if at least one
+					// agent fan-out was accepted. Only when every fan-out is
+					// rejected is the recurring binding effectively dead.
+					$any_scheduled = false;
 					foreach ( $agents as $agent ) {
 						$agent_id = (int) ( $agent['agent_id'] ?? 0 );
 						$owner_id = (int) ( $agent['owner_id'] ?? 0 );
@@ -327,7 +340,7 @@ class SystemAgentServiceProvider {
 						$agent_params['agent_id'] = $agent_id;
 						$agent_params['user_id']  = $owner_id;
 
-						TaskScheduler::schedule(
+						$scheduled = TaskScheduler::schedule(
 							$task_type,
 							$agent_params,
 							array(
@@ -335,11 +348,33 @@ class SystemAgentServiceProvider {
 								'user_id'  => $owner_id,
 							)
 						);
+						if ( false !== $scheduled ) {
+							$any_scheduled = true;
+						}
+					}
+
+					if ( $any_scheduled ) {
+						RecurringRejectionTracker::record_success( $schedule_id );
+					} else {
+						RecurringRejectionTracker::record_rejection(
+							$schedule_id,
+							$task_type,
+							'task_scheduler_rejected'
+						);
 					}
 					return;
 				}
 
-				TaskScheduler::schedule( $task_type, $params );
+				$scheduled = TaskScheduler::schedule( $task_type, $params );
+				if ( false === $scheduled ) {
+					RecurringRejectionTracker::record_rejection(
+						$schedule_id,
+						$task_type,
+						'task_scheduler_rejected'
+					);
+				} else {
+					RecurringRejectionTracker::record_success( $schedule_id );
+				}
 			};
 
 			add_action( $hook, $dispatch_schedule );

--- a/inc/Engine/Tasks/RecurringRejectionTracker.php
+++ b/inc/Engine/Tasks/RecurringRejectionTracker.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Recurring Rejection Tracker — correlates repeated recurring-schedule rejections.
+ *
+ * A one-off scheduling failure is a transient event: log an error, move on.
+ * A *recurring* binding that is rejected by TaskScheduler::schedule() on every
+ * tick is a different, worse failure class — a permanent misconfiguration that
+ * silently disables a scheduled task. Without correlation across ticks, the two
+ * look identical in the log (N identical error rows), and a dead recurring
+ * binding can stay invisible for days.
+ *
+ * This tracker counts consecutive rejections per schedule_id (persisted in a
+ * single autoloaded option), escalates once a small threshold is crossed by
+ * emitting a distinct, dedup-aware log signal instead of yet another identical
+ * row, and exposes the degraded set so the system health surface can flag it.
+ *
+ * It does NOT change the scheduler's accept/reject decision — it only observes
+ * the int|false return of TaskScheduler::schedule() at the recurring dispatch
+ * seam. It is reason-agnostic: any rejection (unknown task type, missing
+ * ability, agent-context required, …) increments the same per-schedule counter.
+ *
+ * @package DataMachine\Engine\Tasks
+ * @since   0.139.0
+ */
+
+namespace DataMachine\Engine\Tasks;
+
+defined( 'ABSPATH' ) || exit;
+
+class RecurringRejectionTracker {
+
+	/**
+	 * Option key storing the per-schedule consecutive-rejection state.
+	 *
+	 * Shape: array<string schedule_id, array{
+	 *     count:int,
+	 *     task_type:string,
+	 *     reason:string,
+	 *     first_rejected_gmt:string,
+	 *     last_rejected_gmt:string,
+	 *     escalated:bool
+	 * }>
+	 */
+	public const OPTION = 'datamachine_recurring_rejections';
+
+	/**
+	 * Consecutive rejection ticks before a recurring binding is treated as
+	 * persistently rejected (degraded) and escalated.
+	 *
+	 * Small on purpose: three consecutive ticks is enough to distinguish a
+	 * permanent misconfiguration from a transient blip, without waiting days.
+	 */
+	public const DEFAULT_THRESHOLD = 3;
+
+	/**
+	 * The escalating log error code emitted once the threshold is crossed.
+	 *
+	 * Distinct from the per-tick gate error codes (e.g.
+	 * task_scheduler_agent_context_required) so it reads as one escalating
+	 * problem rather than N unrelated errors.
+	 */
+	public const ESCALATION_ERROR_CODE = 'recurring_schedule_persistently_rejected';
+
+	/**
+	 * Resolve the consecutive-rejection threshold.
+	 *
+	 * @return int Threshold (minimum 1).
+	 */
+	public static function threshold(): int {
+		$threshold = (int) apply_filters(
+			'datamachine_recurring_rejection_threshold',
+			self::DEFAULT_THRESHOLD
+		);
+
+		return max( 1, $threshold );
+	}
+
+	/**
+	 * Record that a recurring binding was rejected on this tick.
+	 *
+	 * Increments the per-schedule consecutive counter. When the count first
+	 * reaches the threshold, emits a distinct escalating log entry (once per
+	 * escalation, not once per tick) carrying the running count.
+	 *
+	 * @param string $schedule_id Recurring schedule identifier.
+	 * @param string $task_type   Bound task type (for diagnostics).
+	 * @param string $reason      Optional rejection reason / error code.
+	 * @return int The new consecutive-rejection count.
+	 */
+	public static function record_rejection( string $schedule_id, string $task_type = '', string $reason = '' ): int {
+		if ( '' === $schedule_id ) {
+			return 0;
+		}
+
+		$state = self::all();
+		$now   = gmdate( 'Y-m-d H:i:s' );
+		$entry = $state[ $schedule_id ] ?? array(
+			'count'              => 0,
+			'task_type'          => $task_type,
+			'reason'             => $reason,
+			'first_rejected_gmt' => $now,
+			'last_rejected_gmt'  => $now,
+			'escalated'          => false,
+		);
+
+		$entry['count']             = (int) $entry['count'] + 1;
+		$entry['task_type']         = '' !== $task_type ? $task_type : ( $entry['task_type'] ?? '' );
+		$entry['reason']            = '' !== $reason ? $reason : ( $entry['reason'] ?? '' );
+		$entry['last_rejected_gmt'] = $now;
+		if ( empty( $entry['first_rejected_gmt'] ) ) {
+			$entry['first_rejected_gmt'] = $now;
+		}
+
+		$threshold     = self::threshold();
+		$just_escalated = false;
+		if ( $entry['count'] >= $threshold && empty( $entry['escalated'] ) ) {
+			$entry['escalated'] = true;
+			$just_escalated     = true;
+		}
+
+		$state[ $schedule_id ] = $entry;
+		self::save( $state );
+
+		// Emit the distinct escalating signal exactly once per escalation,
+		// rather than appending another identical per-tick error row.
+		if ( $just_escalated ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				sprintf(
+					'Recurring schedule "%s" persistently rejected: %d consecutive ticks rejected, task never ran.',
+					$schedule_id,
+					$entry['count']
+				),
+				array(
+					'context'            => 'system',
+					'schedule_id'        => $schedule_id,
+					'task_type'          => $entry['task_type'],
+					'rejection_reason'   => $entry['reason'],
+					'consecutive_count'  => $entry['count'],
+					'threshold'          => $threshold,
+					'first_rejected_gmt' => $entry['first_rejected_gmt'],
+					'error_code'         => self::ESCALATION_ERROR_CODE,
+					'recommendation'     => 'A recurring binding has been rejected every tick. Fix the schedule registration or its prerequisites (agent ownership, task registration, ability availability); it will not run until the rejection stops.',
+				)
+			);
+		}
+
+		return $entry['count'];
+	}
+
+	/**
+	 * Record that a recurring binding scheduled successfully on this tick.
+	 *
+	 * Clears any accumulated consecutive-rejection state for the schedule, so
+	 * a recovered binding stops showing as degraded.
+	 *
+	 * @param string $schedule_id Recurring schedule identifier.
+	 * @return void
+	 */
+	public static function record_success( string $schedule_id ): void {
+		if ( '' === $schedule_id ) {
+			return;
+		}
+
+		$state = self::all();
+		if ( ! isset( $state[ $schedule_id ] ) ) {
+			return;
+		}
+
+		unset( $state[ $schedule_id ] );
+		self::save( $state );
+	}
+
+	/**
+	 * All tracked rejection state.
+	 *
+	 * @return array<string, array>
+	 */
+	public static function all(): array {
+		$state = get_option( self::OPTION, array() );
+		return is_array( $state ) ? $state : array();
+	}
+
+	/**
+	 * Schedules currently degraded (consecutive rejections at/over threshold).
+	 *
+	 * @return array<string, array> Keyed by schedule_id.
+	 */
+	public static function degraded(): array {
+		$threshold = self::threshold();
+		$degraded  = array();
+		foreach ( self::all() as $schedule_id => $entry ) {
+			if ( (int) ( $entry['count'] ?? 0 ) >= $threshold ) {
+				$degraded[ $schedule_id ] = $entry;
+			}
+		}
+
+		return $degraded;
+	}
+
+	/**
+	 * Persist the rejection state.
+	 *
+	 * @param array $state State map.
+	 * @return void
+	 */
+	private static function save( array $state ): void {
+		if ( empty( $state ) ) {
+			delete_option( self::OPTION );
+			return;
+		}
+
+		update_option( self::OPTION, $state, false );
+	}
+}

--- a/tests/recurring-rejection-escalation-smoke.php
+++ b/tests/recurring-rejection-escalation-smoke.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Smoke test for RecurringRejectionTracker escalation behavior.
+ *
+ * Run with: php tests/recurring-rejection-escalation-smoke.php
+ *
+ * Verifies the core robustness contract from data-machine#2558:
+ *
+ *   (a) A single (transient) rejection does NOT escalate and does NOT mark
+ *       the schedule degraded — it behaves exactly as a one-off failure.
+ *   (b) N consecutive rejections for the same schedule_id flip the schedule
+ *       into the degraded set and emit the distinct
+ *       `recurring_schedule_persistently_rejected` log signal EXACTLY ONCE
+ *       (not once per tick).
+ *   (c) A success for that schedule_id clears the counter, so a recovered
+ *       binding stops showing as degraded.
+ *
+ * The class only depends on get_option/update_option/delete_option,
+ * apply_filters, do_action and gmdate, so this harness stubs an in-memory
+ * options store and a log recorder and exercises the real production class.
+ *
+ * Also asserts the production wiring (source-grep) so the seam in
+ * SystemAgentServiceProvider and the health surface in SystemAbilities
+ * cannot silently drift away from the tracker.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+// ─── In-memory WordPress option + hook stubs ────────────────────────
+
+$GLOBALS['dm_test_options'] = array();
+$GLOBALS['dm_test_logs']    = array();
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $name, $default = false ) {
+		return $GLOBALS['dm_test_options'][ $name ] ?? $default;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( string $name, $value, $autoload = null ): bool {
+		$GLOBALS['dm_test_options'][ $name ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'delete_option' ) ) {
+	function delete_option( string $name ): bool {
+		unset( $GLOBALS['dm_test_options'][ $name ] );
+		return true;
+	}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		return $value;
+	}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		if ( 'datamachine_log' === $hook ) {
+			$GLOBALS['dm_test_logs'][] = array(
+				'level'   => $args[0] ?? '',
+				'message' => $args[1] ?? '',
+				'context' => $args[2] ?? array(),
+			);
+		}
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Engine/Tasks/RecurringRejectionTracker.php';
+
+use DataMachine\Engine\Tasks\RecurringRejectionTracker;
+
+// ─── Tiny assertion helpers ─────────────────────────────────────────
+
+$failures = 0;
+$total    = 0;
+
+$assert = function ( string $label, bool $cond ) use ( &$failures, &$total ): void {
+	$total++;
+	if ( $cond ) {
+		echo "  [PASS] {$label}\n";
+	} else {
+		$failures++;
+		echo "  [FAIL] {$label}\n";
+	}
+};
+
+$reset_state = function (): void {
+	$GLOBALS['dm_test_options'] = array();
+	$GLOBALS['dm_test_logs']    = array();
+};
+
+$escalation_logs = static function (): array {
+	return array_values(
+		array_filter(
+			$GLOBALS['dm_test_logs'],
+			static fn( array $log ): bool =>
+				( $log['context']['error_code'] ?? '' ) === RecurringRejectionTracker::ESCALATION_ERROR_CODE
+		)
+	);
+};
+
+echo "=== recurring-rejection-escalation-smoke ===\n";
+
+$threshold = RecurringRejectionTracker::threshold();
+
+// ─── (a) A single transient rejection does not escalate ─────────────
+
+echo "\n[a] One rejection is transient — no escalation, not degraded\n";
+$reset_state();
+$count = RecurringRejectionTracker::record_rejection( 'workspace_disk_emergency_cleanup', 'workspace_disk_emergency_cleanup', 'task_scheduler_agent_context_required' );
+$assert( 'count is 1 after one rejection', 1 === $count );
+$assert( 'threshold is at least 2 so one rejection is below it', $threshold >= 2 );
+$assert( 'schedule is NOT degraded after one rejection', ! isset( RecurringRejectionTracker::degraded()['workspace_disk_emergency_cleanup'] ) );
+$assert( 'no escalation log emitted for a single rejection', 0 === count( $escalation_logs() ) );
+
+// ─── (b) N consecutive rejections escalate exactly once ─────────────
+
+echo "\n[b] N consecutive rejections flip degraded + escalate exactly once\n";
+$reset_state();
+for ( $i = 1; $i <= $threshold; $i++ ) {
+	RecurringRejectionTracker::record_rejection( 'workspace_disk_emergency_cleanup', 'workspace_disk_emergency_cleanup', 'task_scheduler_agent_context_required' );
+}
+$degraded = RecurringRejectionTracker::degraded();
+$assert( 'schedule is degraded once threshold reached', isset( $degraded['workspace_disk_emergency_cleanup'] ) );
+$assert( 'degraded count equals threshold', $threshold === (int) $degraded['workspace_disk_emergency_cleanup']['count'] );
+$assert( 'exactly one escalation log emitted at threshold', 1 === count( $escalation_logs() ) );
+$escalation = $escalation_logs()[0] ?? array();
+$assert( 'escalation log is error level', 'error' === ( $escalation['level'] ?? '' ) );
+$assert( 'escalation carries schedule_id', 'workspace_disk_emergency_cleanup' === ( $escalation['context']['schedule_id'] ?? '' ) );
+$assert( 'escalation carries running consecutive_count', $threshold === (int) ( $escalation['context']['consecutive_count'] ?? 0 ) );
+$assert( 'escalation carries the rejection reason', 'task_scheduler_agent_context_required' === ( $escalation['context']['rejection_reason'] ?? '' ) );
+
+echo "\n[b2] Further rejections keep counting but do NOT re-escalate (no duplicate rows)\n";
+RecurringRejectionTracker::record_rejection( 'workspace_disk_emergency_cleanup', 'workspace_disk_emergency_cleanup', 'task_scheduler_agent_context_required' );
+RecurringRejectionTracker::record_rejection( 'workspace_disk_emergency_cleanup', 'workspace_disk_emergency_cleanup', 'task_scheduler_agent_context_required' );
+$assert( 'still exactly one escalation log after extra ticks', 1 === count( $escalation_logs() ) );
+$assert( 'count keeps climbing past threshold', ( $threshold + 2 ) === (int) RecurringRejectionTracker::degraded()['workspace_disk_emergency_cleanup']['count'] );
+
+// ─── (c) A success resets the counter ───────────────────────────────
+
+echo "\n[c] A success clears the counter — recovered binding is not degraded\n";
+RecurringRejectionTracker::record_success( 'workspace_disk_emergency_cleanup' );
+$assert( 'schedule no longer degraded after success', ! isset( RecurringRejectionTracker::degraded()['workspace_disk_emergency_cleanup'] ) );
+$assert( 'tracker state for schedule is fully cleared', ! isset( RecurringRejectionTracker::all()['workspace_disk_emergency_cleanup'] ) );
+
+echo "\n[c2] After reset, a fresh rejection streak escalates again\n";
+$GLOBALS['dm_test_logs'] = array();
+for ( $i = 1; $i <= $threshold; $i++ ) {
+	RecurringRejectionTracker::record_rejection( 'workspace_disk_emergency_cleanup', 'workspace_disk_emergency_cleanup', 'task_scheduler_agent_context_required' );
+}
+$assert( 'escalation fires again on a new streak', 1 === count( $escalation_logs() ) );
+
+// ─── Isolation: independent schedules track independently ───────────
+
+echo "\n[d] Distinct schedules track independently\n";
+$reset_state();
+RecurringRejectionTracker::record_rejection( 'schedule_a', 'task_a', 'task_scheduler_rejected' );
+for ( $i = 1; $i <= $threshold; $i++ ) {
+	RecurringRejectionTracker::record_rejection( 'schedule_b', 'task_b', 'task_scheduler_rejected' );
+}
+$degraded = RecurringRejectionTracker::degraded();
+$assert( 'schedule_a (one rejection) is not degraded', ! isset( $degraded['schedule_a'] ) );
+$assert( 'schedule_b (threshold rejections) is degraded', isset( $degraded['schedule_b'] ) );
+$assert( 'a success on schedule_b does not touch schedule_a', ( static function () {
+	RecurringRejectionTracker::record_success( 'schedule_b' );
+	return 1 === (int) ( RecurringRejectionTracker::all()['schedule_a']['count'] ?? 0 );
+} )() );
+
+// ─── Production wiring (source-grep) ────────────────────────────────
+
+echo "\n[e] Production wiring is in place\n";
+$provider_source = file_get_contents( dirname( __DIR__ ) . '/inc/Engine/AI/System/SystemAgentServiceProvider.php' );
+$abilities_source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/SystemAbilities.php' );
+$command_source   = file_get_contents( dirname( __DIR__ ) . '/inc/Cli/Commands/SystemCommand.php' );
+$assert( 'dispatch seam records rejections', str_contains( $provider_source, 'RecurringRejectionTracker::record_rejection' ) );
+$assert( 'dispatch seam records successes', str_contains( $provider_source, 'RecurringRejectionTracker::record_success' ) );
+$assert( 'health surface reads degraded schedules', str_contains( $abilities_source, 'RecurringRejectionTracker::degraded()' ) );
+$assert( 'health surface exposes failing status', str_contains( $abilities_source, "\$status = 'failing'" ) );
+$assert( 'health surface exposes rejected_schedules', str_contains( $abilities_source, "'rejected_schedules'" ) );
+$assert( 'CLI renders rejected schedules', str_contains( $command_source, 'Rejected schedules:' ) );
+$assert( 'gate decision (return false) is untouched in TaskScheduler', str_contains( file_get_contents( dirname( __DIR__ ) . '/inc/Engine/Tasks/TaskScheduler.php' ), 'task_scheduler_agent_context_required' ) );
+
+echo "\n";
+if ( $failures > 0 ) {
+	echo "=== recurring-rejection-escalation-smoke: {$failures}/{$total} FAILED ===\n";
+	exit( 1 );
+}
+echo "=== recurring-rejection-escalation-smoke: ALL PASS ({$total} assertions) ===\n";


### PR DESCRIPTION
Closes #2558

## Problem

A DMC recurring schedule (`workspace_disk_emergency_cleanup`, hourly) was rejected by `TaskScheduler::schedule()` at the agent-context gate on **every tick for 7+ days** — 213 identical `error`-level rows, the task never ran, and nothing escalated. A permanent recurring-binding failure looked identical to a transient one-off failure, so it stayed invisible until someone eyeballed the raw log.

## Design (and why)

A new generic, reason-agnostic tracker plugged into the two existing surfaces the issue pointed at — the recurring dispatch seam and `wp datamachine system health`:

```
recurring tick (Action Scheduler hook)
        │
        ▼
SystemAgentServiceProvider dispatch closure   ← knows schedule_id + task_type,
        │   reads schedule()'s int|false          gets the accept/reject result
        ▼
RecurringRejectionTracker                      ← per-schedule_id consecutive counter
   record_rejection() on false  ──┐               (single autoloaded option)
   record_success()   on int   ──┘
        │  threshold (3) crossed → ONE distinct escalation log:
        │     error_code = recurring_schedule_persistently_rejected
        ▼
SystemAbilities::runSchedulerDiagnostics()     ← reads ::degraded(),
   status → 'failing' (outranks 'stale')          lists each dead binding
        ▼
wp datamachine system health  (+ JSON)         ← operator-visible
```

**Why the dispatch seam, not `TaskScheduler::schedule()`:** the closure is the only place that knows a given `schedule()` call came from a recurring binding *and* which `schedule_id` it was. `schedule()` itself is task-agnostic and must not change its decision. Tracking here keeps the gate 100% untouched.

**Why the health surface (issue option 1):** it plugs into the command operators already run, and `runSchedulerDiagnostics()` already emits a `status`/`message`/`recommendation` contract. Adding a `failing` status + `rejected_schedules` block is the minimal extension. The escalation log (issue option 3) is included too as the cheap floor — emitted once per escalation, not once per tick.

**Why reason-agnostic:** the counter keys on `schedule_id` + reason, so it covers any rejection cause (unknown task type, missing ability, agent-context required, per-agent "no agents"), not just the agent-context branch that bit us. For `per_agent` schedules a tick counts as a success if *any* agent fan-out was accepted, and a rejection only when *every* fan-out was rejected.

**Persistence:** single autoloaded option `datamachine_recurring_rejections` (not engine_data — these rejections never create a job). Cleared entirely on success.

## Threshold

`3` consecutive ticks (filterable via `datamachine_recurring_rejection_threshold`). Small enough to surface a dead binding fast, large enough not to fire on a transient blip.

## Guarantees

- **Gate decision unchanged** — the agent-context block (`task_scheduler_agent_context_required`, `return false`) is byte-for-byte the same; verified by the existing `system-task-agent-context-smoke` test (47/47 pass).
- **Transient one-offs unchanged** — a single rejection logs the same error and returns false; it does not escalate and is not degraded (below threshold).
- **No duplicate escalation rows** — the distinct escalation log fires exactly once when the threshold is first crossed, then the per-tick counter keeps climbing silently.

## Evidence

`php -l` — clean on all touched files:
```
inc/Engine/Tasks/RecurringRejectionTracker.php          OK
inc/Engine/AI/System/SystemAgentServiceProvider.php     OK
inc/Abilities/SystemAbilities.php                       OK
inc/Cli/Commands/SystemCommand.php                      OK
tests/recurring-rejection-escalation-smoke.php          OK
```

`phpcs` — clean (no output) on all changed files.

New test `tests/recurring-rejection-escalation-smoke.php` — **26/26 pass**, proving:
- (a) one rejection does not escalate / is not degraded
- (b) N consecutive rejections flip degraded + emit the escalation log **exactly once**, with running count, and keep counting without re-escalating
- (c) a success resets the counter so a recovered binding is no longer degraded
- (d) distinct schedules track independently
- (e) production wiring + untouched gate (source-grep)

Existing `system-health-scheduler-smoke` and `system-task-agent-context-smoke` both still pass.