### PR TITLE
fix: auto-bind job_id for handler-class tools (#2560)

### DIFF
--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -328,6 +328,27 @@ class ToolManager {
 					$tool_def['handler_config'] = $handler_config;
 				}
 
+				// Auto-attach the job_id context binding for handler-class
+				// tools. Handler tools route through the *Handler base classes
+				// (Upsert/Publish/Fetch) via handle_tool_call(), all of which
+				// require the run's job_id to load engine_data — and after the
+				// explicit-context-bindings migration, job_id only reaches a
+				// tool when it is named in client_context_bindings. Defaulting
+				// the binding here means satellite plugins (events, socials,
+				// business, third parties) no longer have to declare it
+				// per-tool-def and cannot silently regress into rejecting
+				// every tool call. Tools that explicitly declare their own
+				// bindings keep them untouched.
+				if ( 'handle_tool_call' === ( $tool_def['method'] ?? '' ) ) {
+					$existing = is_array( $tool_def['client_context_bindings'] ?? null )
+						? $tool_def['client_context_bindings']
+						: array();
+					if ( ! in_array( 'job_id', $existing, true ) && ! array_key_exists( 'job_id', $existing ) ) {
+						$existing[]                          = 'job_id';
+						$tool_def['client_context_bindings'] = $existing;
+					}
+				}
+
 				// Apply registry-level meta unless the resolved tool
 				// explicitly overrides.
 				if ( ! isset( $tool_def['modes'] ) ) {

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -575,6 +575,23 @@ assert_source_equals(
 	$passes
 );
 
+echo "\n[9] handler-class tools auto-bind job_id context:\n";
+$tool_manager_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php' );
+assert_source_equals(
+	true,
+	false !== strpos( $tool_manager_source, "'handle_tool_call' === ( \$tool_def['method'] ?? '' )" ),
+	'ToolManager auto-binds job_id for handler-class tools (handle_tool_call method)',
+	$failures,
+	$passes
+);
+assert_source_equals(
+	true,
+	false !== strpos( $tool_manager_source, "\$tool_def['client_context_bindings'] = \$existing" ),
+	'ToolManager writes the resolved client_context_bindings back onto handler tool defs',
+	$failures,
+	$passes
+);
+
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " tool source assertions failed.\n";
 	exit( 1 );


### PR DESCRIPTION
## Summary
Systemic fix for #2560. Auto-attaches the `job_id` context binding for every handler-resolved tool whose `method` is `handle_tool_call`, in `ToolManager::resolveHandlerTools()`.

After the explicit-context-bindings migration (`eeb4affa`, v0.139.6), `job_id` only reaches a tool when named in `client_context_bindings`. Core handlers were updated; satellite handler tool defs (events `upsert_event`, socials publish handlers) were not, so they silently rejected **every** tool call at the base `*Handler` `job_id` guard — producing an active event-publish degradation on events.extrachill.com (9k+ rejected upsert calls, new event writes stalled ~16:00 UTC June 6).

## What changed
- `ToolManager::resolveHandlerTools()` now defaults `client_context_bindings => ['job_id']` for handler-class tools (`method === 'handle_tool_call'`), without clobbering explicit declarations.
- Added two source-level assertions to `tests/tool-source-registry-smoke.php`.

## Why here
Handler tools route through the `*Handler` base classes (Upsert/Publish/Fetch) via `handle_tool_call()`, all of which require the run's `job_id` to load engine_data. Putting the default where these tools are resolved means satellite plugins (events, socials, business, third parties) no longer have to declare the binding per-tool-def and **cannot regress into a silent rejection storm**.

## Testing
- `php tests/tool-source-registry-smoke.php` → all 57 assertions pass.
- `php -l` clean on changed files.

## Related
- Companion fixes declaring the binding explicitly (correct regardless of core version): data-machine-events, data-machine-socials.
- data-machine-business audited: its tools extend `BaseTool` (not `*Handler`), register via `registerTool()` (static registry, not the handler resolver), and do not use `job_id` — no change needed.

Fixes #2560