### PR TITLE
Add generic principal audit context to pending actions

### DIFF
--- a/inc/Cli/Commands/PendingActionsCommand.php
+++ b/inc/Cli/Commands/PendingActionsCommand.php
@@ -78,7 +78,7 @@ class PendingActionsCommand extends BaseCommand {
 			WP_CLI::error( $result->get_error_message() );
 		}
 
-		$rows = is_array( $result['actions'] ?? null ) ? $result['actions'] : array();
+		$rows = PendingActionInspectionAbility::normalize_action_rows( is_array( $result['actions'] ?? null ) ? $result['actions'] : array() );
 
 		$fields = array( 'action_id', 'kind', 'summary', 'status', 'agent_id', 'created_by', 'created_at_iso', 'expires_at_iso' );
 		$this->format_items( $rows, $fields, $assoc_args, 'action_id' );
@@ -124,6 +124,7 @@ class PendingActionsCommand extends BaseCommand {
 			WP_CLI::error( 'Pending action not found.' );
 		}
 
+		$action = PendingActionInspectionAbility::normalize_action_row( $action );
 		$format = $assoc_args['format'] ?? 'json';
 		WP_CLI\Utils\format_items( $format, array( $action ), array_keys( $action ) );
 	}

--- a/inc/Engine/AI/Actions/PendingActionHelper.php
+++ b/inc/Engine/AI/Actions/PendingActionHelper.php
@@ -65,6 +65,7 @@ class PendingActionHelper {
 		$context      = isset( $args['context'] ) && is_array( $args['context'] ) ? $args['context'] : array();
 		$action_id    = isset( $args['action_id'] ) ? (string) $args['action_id'] : '';
 		$grants       = isset( $args['resolver_grants'] ) && is_array( $args['resolver_grants'] ) ? $args['resolver_grants'] : array();
+		$metadata     = isset( $args['metadata'] ) && is_array( $args['metadata'] ) ? $args['metadata'] : array();
 
 		if ( '' === $kind ) {
 			return array(
@@ -91,6 +92,18 @@ class PendingActionHelper {
 		$grants = apply_filters( 'datamachine_pending_action_resolver_grants', $grants, $args );
 		$grants = is_array( $grants ) ? array_values( array_filter( $grants, 'is_array' ) ) : array();
 
+		$datamachine_metadata = isset( $metadata['datamachine'] ) && is_array( $metadata['datamachine'] ) ? $metadata['datamachine'] : array();
+		$metadata['datamachine'] = array_merge(
+			$datamachine_metadata,
+			array(
+				'agent_id'        => $agent_id,
+				'created_by'      => $user_id,
+				'context'         => $context,
+				'resolver_grants' => $grants,
+				'resolve_with'    => 'resolve_pending_action',
+			)
+		);
+
 		$payload = array(
 			'kind'            => $kind,
 			'summary'         => wp_strip_all_tags( $summary ),
@@ -102,15 +115,7 @@ class PendingActionHelper {
 			'created_by'      => $user_id,
 			'creator'         => $user_id > 0 ? 'user:' . $user_id : null,
 			'context'         => $context,
-			'metadata'        => array(
-				'datamachine' => array(
-					'agent_id'        => $agent_id,
-					'created_by'      => $user_id,
-					'context'         => $context,
-					'resolver_grants' => $grants,
-					'resolve_with'    => 'resolve_pending_action',
-				),
-			),
+			'metadata'        => $metadata,
 		);
 		if ( isset( $args['ttl'] ) ) {
 			$payload['ttl'] = (int) $args['ttl'];

--- a/inc/Engine/AI/Actions/PendingActionHelper.php
+++ b/inc/Engine/AI/Actions/PendingActionHelper.php
@@ -92,7 +92,7 @@ class PendingActionHelper {
 		$grants = apply_filters( 'datamachine_pending_action_resolver_grants', $grants, $args );
 		$grants = is_array( $grants ) ? array_values( array_filter( $grants, 'is_array' ) ) : array();
 
-		$datamachine_metadata = isset( $metadata['datamachine'] ) && is_array( $metadata['datamachine'] ) ? $metadata['datamachine'] : array();
+		$datamachine_metadata    = isset( $metadata['datamachine'] ) && is_array( $metadata['datamachine'] ) ? $metadata['datamachine'] : array();
 		$metadata['datamachine'] = array_merge(
 			$datamachine_metadata,
 			array(

--- a/inc/Engine/AI/Actions/PendingActionInspectionAbility.php
+++ b/inc/Engine/AI/Actions/PendingActionInspectionAbility.php
@@ -154,7 +154,7 @@ final class PendingActionInspectionAbility {
 
 		return array(
 			'success' => true,
-			'actions' => is_array( $result['actions'] ?? null ) ? $result['actions'] : array(),
+			'actions' => self::normalize_action_rows( is_array( $result['actions'] ?? null ) ? $result['actions'] : array() ),
 		);
 	}
 
@@ -195,8 +195,69 @@ final class PendingActionInspectionAbility {
 
 		return array(
 			'success' => true,
-			'action'  => $action,
+			'action'  => self::normalize_action_row( $action ),
 		);
+	}
+
+	/**
+	 * Normalize action rows for frontend/CLI inspection.
+	 *
+	 * @param array<int,array<string,mixed>> $actions Canonical action rows.
+	 * @return array<int,array<string,mixed>> Rows with stable flattened Data Machine fields.
+	 */
+	public static function normalize_action_rows( array $actions ): array {
+		return array_map( array( self::class, 'normalize_action_row' ), array_values( array_filter( $actions, 'is_array' ) ) );
+	}
+
+	/**
+	 * Normalize one canonical pending-action row for frontend/CLI inspection.
+	 *
+	 * Agents API rows are intentionally generic. Data Machine consumers also need
+	 * stable scalar fields for table output, filtering evidence, and review UIs.
+	 *
+	 * @param array<string,mixed> $action Canonical action row.
+	 * @return array<string,mixed> Normalized action row.
+	 */
+	public static function normalize_action_row( array $action ): array {
+		$metadata    = isset( $action['metadata'] ) && is_array( $action['metadata'] ) ? $action['metadata'] : array();
+		$datamachine = isset( $metadata['datamachine'] ) && is_array( $metadata['datamachine'] ) ? $metadata['datamachine'] : array();
+		$context     = isset( $datamachine['context'] ) && is_array( $datamachine['context'] ) ? $datamachine['context'] : array();
+		$workspace   = isset( $action['workspace'] ) && is_array( $action['workspace'] ) ? $action['workspace'] : array();
+
+		$action['preview_data']      = $action['preview'] ?? $action['preview_data'] ?? array();
+		$action['agent_id']          = isset( $datamachine['agent_id'] ) ? (int) $datamachine['agent_id'] : self::id_from_canonical_ref( $action['agent'] ?? null, 'agent' );
+		$action['created_by']        = isset( $datamachine['created_by'] ) ? (int) $datamachine['created_by'] : self::id_from_canonical_ref( $action['creator'] ?? null, 'user' );
+		$action['context']           = $context;
+		$action['workspace_type']    = isset( $workspace['workspace_type'] ) ? (string) $workspace['workspace_type'] : null;
+		$action['workspace_id']      = isset( $workspace['workspace_id'] ) ? (string) $workspace['workspace_id'] : null;
+		$action['created_at_iso']    = isset( $action['created_at'] ) ? (string) $action['created_at'] : null;
+		$action['expires_at_iso']    = isset( $action['expires_at'] ) ? $action['expires_at'] : null;
+		$action['resolved_at_iso']   = isset( $action['resolved_at'] ) ? $action['resolved_at'] : null;
+		$action['audit_context']     = isset( $datamachine['audit_context'] ) && is_array( $datamachine['audit_context'] ) ? $datamachine['audit_context'] : array();
+		$action['principal_context'] = isset( $action['audit_context']['principal_context'] ) && is_array( $action['audit_context']['principal_context'] ) ? $action['audit_context']['principal_context'] : array();
+		$action['resolve_with']      = isset( $datamachine['resolve_with'] ) ? (string) $datamachine['resolve_with'] : 'resolve_pending_action';
+		$action['resolve_params']    = array(
+			'action_id' => (string) ( $action['action_id'] ?? '' ),
+			'decision'  => '<accepted|rejected>',
+		);
+
+		return $action;
+	}
+
+	/**
+	 * Extract numeric IDs from canonical refs such as agent:7 or user:12.
+	 *
+	 * @param mixed  $value  Canonical ref.
+	 * @param string $prefix Expected prefix.
+	 * @return int Positive ID or 0.
+	 */
+	private static function id_from_canonical_ref( $value, string $prefix ): int {
+		if ( ! is_string( $value ) ) {
+			return 0;
+		}
+
+		$match = array();
+		return preg_match( '/^' . preg_quote( $prefix, '/' ) . ':(\d+)$/', $value, $match ) ? (int) $match[1] : 0;
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -14,6 +14,7 @@ namespace DataMachine\Engine\AI\Tools;
 use AgentsAPI\AI\Tools\WP_Agent_Action_Policy;
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Execution_Core;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 use DataMachine\Core\WordPress\PostTracking;
 use DataMachine\Engine\AI\Actions\ActionPolicyResolver;
@@ -72,6 +73,7 @@ class ToolExecutor {
 		$tool_def            = $prepared['tool_def'];
 		$tool_call           = $prepared['tool_call'];
 		$complete_parameters = is_array( $tool_call['parameters'] ?? null ) ? $tool_call['parameters'] : array();
+		$audit_context       = self::buildToolAuditContext( $tool_name, $complete_parameters, $tool_def, $payload, $agent_id, $client_context );
 
 		if ( 'client' === (string) ( $tool_def['executor'] ?? '' ) || ! empty( $tool_def['external_executor'] ) ) {
 			return array(
@@ -98,11 +100,14 @@ class ToolExecutor {
 		);
 
 		if ( WP_Agent_Action_Policy::refusesExecution( $policy ) ) {
+			self::dispatchToolAudit( array_merge( $audit_context, array( 'result_status' => 'forbidden' ) ) );
+
 			return array(
 				'success'        => false,
 				'error'          => sprintf( 'Tool "%s" is not permitted in the current context (action_policy=forbidden).', $tool_name ),
 				'tool_name'      => $tool_name,
 				'action_policy'  => $policy,
+				'audit_context'  => array_merge( $audit_context, array( 'result_status' => 'forbidden' ) ),
 			);
 		}
 
@@ -139,6 +144,7 @@ class ToolExecutor {
 						'apply_input'  => $complete_parameters,
 						'preview_data' => self::buildActionPreviewData( $complete_parameters, $tool_def ),
 						'agent_id'     => $agent_id,
+						'user_id'      => self::resolveActingUserId( $payload, $client_context ),
 						'context'      => array_filter(
 							array(
 								'mode'           => $mode,
@@ -149,8 +155,14 @@ class ToolExecutor {
 							),
 							fn( $v ) => null !== $v && '' !== $v
 						),
+						'metadata'     => array(
+							'datamachine' => array(
+								'audit_context' => array_merge( $audit_context, array( 'result_status' => 'staged' ) ),
+							),
+						),
 					)
 				);
+				self::dispatchToolAudit( array_merge( $audit_context, array( 'result_status' => ! empty( $staged['staged'] ) ? 'staged' : 'stage_failed' ) ) );
 
 				return array_merge(
 					array(
@@ -165,6 +177,8 @@ class ToolExecutor {
 
 		// Policy is 'direct' — execute the tool normally.
 		$tool_result = $core->executePreparedTool( $tool_call, $tool_def, $execution, $tool_context );
+		$tool_result = self::attachToolAuditContext( $tool_result, array_merge( $audit_context, array( 'result_status' => ! empty( $tool_result['success'] ) ? 'success' : 'error' ) ) );
+		self::dispatchToolAudit( $tool_result['metadata']['datamachine']['audit_context'] ?? array_merge( $audit_context, array( 'result_status' => ! empty( $tool_result['success'] ) ? 'success' : 'error' ) ) );
 
 		// Automatic post origin tracking — applies to every tool whose result
 		// contains an extractable post_id. This covers both handler tools
@@ -183,6 +197,194 @@ class ToolExecutor {
 		}
 
 		return $tool_result;
+	}
+
+	/**
+	 * Build safe audit metadata for a tool invocation.
+	 *
+	 * @param string $tool_name       Tool name.
+	 * @param array  $parameters      Complete tool parameters.
+	 * @param array  $tool_def        Tool definition.
+	 * @param array  $payload         Data Machine loop payload.
+	 * @param int    $agent_id        Acting agent ID.
+	 * @param array  $client_context  Client context.
+	 * @return array<string,mixed>
+	 */
+	private static function buildToolAuditContext( string $tool_name, array $parameters, array $tool_def, array $payload, int $agent_id, array $client_context ): array {
+		return array_filter(
+			array(
+				'tool_name'           => $tool_name,
+				'tool_source'         => self::toolSourceSummary( $tool_def ),
+				'principal_context'   => self::buildSafePrincipalContext( $payload, $agent_id, $client_context ),
+				'parameters_redacted' => self::redactForAudit( $parameters ),
+				'executed_at'         => gmdate( 'c' ),
+			),
+			static fn( $value ): bool => null !== $value && array() !== $value && '' !== $value
+		);
+	}
+
+	/**
+	 * Attach audit metadata to a tool result without replacing existing metadata.
+	 *
+	 * @param array $tool_result   Tool result.
+	 * @param array $audit_context Safe audit context.
+	 * @return array<string,mixed>
+	 */
+	private static function attachToolAuditContext( array $tool_result, array $audit_context ): array {
+		$metadata                        = is_array( $tool_result['metadata'] ?? null ) ? $tool_result['metadata'] : array();
+		$datamachine                     = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
+		$datamachine['audit_context']    = $audit_context;
+		$metadata['datamachine']         = $datamachine;
+		$tool_result['metadata']         = $metadata;
+		$tool_result['audit_context']    = $audit_context;
+
+		return $tool_result;
+	}
+
+	/**
+	 * Emit a generic audit hook for integrations that persist external logs.
+	 *
+	 * @param array $audit_context Safe audit context.
+	 */
+	private static function dispatchToolAudit( array $audit_context ): void {
+		if ( ! function_exists( 'do_action' ) ) {
+			return;
+		}
+
+		do_action( 'datamachine_tool_execution_audit', $audit_context );
+	}
+
+	/**
+	 * Build a non-secret principal summary for audit and review surfaces.
+	 *
+	 * @param array $payload        Loop payload.
+	 * @param int   $agent_id       Acting agent ID.
+	 * @param array $client_context Client context.
+	 * @return array<string,mixed>
+	 */
+	private static function buildSafePrincipalContext( array $payload, int $agent_id, array $client_context ): array {
+		$principal = class_exists( PermissionHelper::class ) ? PermissionHelper::get_execution_principal() : null;
+		$context   = array();
+
+		if ( null !== $principal ) {
+			$owner = $principal->conversation_owner();
+			$context = array_filter(
+				array(
+					'principal_class'    => $principal->auth_source,
+					'auth_source'        => $principal->auth_source,
+					'request_context'    => $principal->request_context,
+					'effective_agent_id' => $principal->effective_agent_id,
+					'acting_user_id'     => $principal->acting_user_id > 0 ? $principal->acting_user_id : null,
+					'token_id'           => $principal->token_id,
+					'workspace_id'       => $principal->workspace_id,
+					'client_id'          => $principal->client_id,
+					'owner_type'         => is_array( $owner ) ? ( $owner['type'] ?? null ) : null,
+				),
+				static fn( $value ): bool => null !== $value && '' !== $value
+			);
+		}
+
+		$user_id = self::resolveActingUserId( $payload, $client_context );
+		if ( $user_id > 0 && empty( $context['acting_user_id'] ) ) {
+			$context['acting_user_id'] = $user_id;
+		}
+
+		if ( $agent_id > 0 && empty( $context['effective_agent_id'] ) ) {
+			$context['effective_agent_id'] = 'agent:' . $agent_id;
+		}
+
+		if ( empty( $context['principal_class'] ) ) {
+			$context['principal_class'] = class_exists( PermissionHelper::class ) && PermissionHelper::in_agent_context() ? 'agent_token' : ( $user_id > 0 ? 'user' : 'system' );
+		}
+		$context['credential_scope'] = self::credentialScopeForPrincipalClass( (string) $context['principal_class'] );
+
+		foreach ( array( 'session_id', 'transcript_session_id', 'request_id' ) as $key ) {
+			$value = self::firstNonEmptyString( $payload, $client_context, $key );
+			if ( '' !== $value ) {
+				$context[ $key ] = $value;
+			}
+		}
+
+		return $context;
+	}
+
+	/**
+	 * Map principal classes to generic credential scopes.
+	 *
+	 * @param string $principal_class Principal/auth source.
+	 * @return string Generic credential scope.
+	 */
+	private static function credentialScopeForPrincipalClass( string $principal_class ): string {
+		return match ( $principal_class ) {
+			'agent_token' => 'agent',
+			'user', 'application_password' => 'user',
+			'runtime', 'audience' => 'runtime',
+			default => 'site',
+		};
+	}
+
+	/**
+	 * Return a stable source/provider summary for a tool definition.
+	 *
+	 * @param array $tool_def Tool definition.
+	 * @return array<string,string>|null
+	 */
+	private static function toolSourceSummary( array $tool_def ): ?array {
+		$source = array();
+		foreach ( array( 'source', 'provider', 'category', 'class', 'method', 'ability', 'handler' ) as $key ) {
+			if ( isset( $tool_def[ $key ] ) && is_scalar( $tool_def[ $key ] ) && '' !== trim( (string) $tool_def[ $key ] ) ) {
+				$source[ $key ] = (string) $tool_def[ $key ];
+			}
+		}
+
+		return empty( $source ) ? null : $source;
+	}
+
+	/**
+	 * Redact secrets and oversized values from audit metadata.
+	 *
+	 * @param mixed $value Value to redact.
+	 * @param string $key Current key.
+	 * @return mixed Redacted value.
+	 */
+	private static function redactForAudit( $value, string $key = '' ) {
+		if ( '' !== $key && preg_match( '/(token|secret|password|pass|cookie|authorization|auth|key|credential|nonce|session)/i', $key ) ) {
+			return '[redacted]';
+		}
+
+		if ( is_array( $value ) ) {
+			$redacted = array();
+			foreach ( $value as $child_key => $child_value ) {
+				$redacted[ $child_key ] = self::redactForAudit( $child_value, is_scalar( $child_key ) ? (string) $child_key : '' );
+			}
+			return $redacted;
+		}
+
+		if ( is_string( $value ) && strlen( $value ) > 500 ) {
+			return substr( $value, 0, 500 ) . '... [truncated]';
+		}
+
+		return is_scalar( $value ) || null === $value ? $value : '[' . gettype( $value ) . ']';
+	}
+
+	/**
+	 * Resolve the acting user ID from explicit context or PermissionHelper.
+	 *
+	 * @param array $payload        Loop payload.
+	 * @param array $client_context Client context.
+	 * @return int Acting user ID, or 0.
+	 */
+	private static function resolveActingUserId( array $payload, array $client_context ): int {
+		$user_id = self::firstPositiveInt( $payload, $client_context, 'acting_user_id', 'calling_user_id', 'user_id' );
+		if ( $user_id > 0 ) {
+			return $user_id;
+		}
+
+		if ( class_exists( PermissionHelper::class ) ) {
+			return PermissionHelper::acting_user_id();
+		}
+
+		return function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
 	}
 
 	/**

--- a/tests/pending-action-inspection-normalization-smoke.php
+++ b/tests/pending-action-inspection-normalization-smoke.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Pure-PHP smoke test for pending-action inspection normalization.
+ *
+ * Run with: php tests/pending-action-inspection-normalization-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+
+require_once __DIR__ . '/../inc/Engine/AI/Actions/PendingActionInspectionAbility.php';
+
+$assertions = 0;
+
+function datamachine_pending_inspection_assert( bool $condition, string $message ): void {
+	global $assertions;
+	++$assertions;
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+$rows = \DataMachine\Engine\AI\Actions\PendingActionInspectionAbility::normalize_action_rows(
+	array(
+		array(
+			'action_id'   => 'act_bundle_upgrade',
+			'kind'        => 'bundle_upgrade',
+			'summary'     => 'Upgrade bundle',
+			'preview'     => array( 'bundle' => 'example' ),
+			'apply_input' => array( 'bundle' => 'example' ),
+			'workspace'   => array(
+				'workspace_type' => 'wordpress-site',
+				'workspace_id'   => 'site-1',
+			),
+			'agent'       => 'agent:44',
+			'creator'     => 'user:9',
+			'status'      => 'pending',
+			'created_at'  => '2026-06-06T00:00:00+00:00',
+			'expires_at'  => null,
+			'metadata'    => array(
+				'datamachine' => array(
+					'audit_context' => array(
+						'tool_name'           => 'upgrade_bundle',
+						'parameters_redacted' => array(
+							'token' => '[redacted]',
+						),
+						'principal_context'   => array(
+							'principal_class'    => 'agent_token',
+							'effective_agent_id' => 'agent:44',
+						),
+					),
+					'context'       => array( 'session_id' => 'sess-1' ),
+					'resolve_with'  => 'resolve_pending_action',
+				),
+			),
+		),
+	)
+);
+
+$row = $rows[0] ?? array();
+
+datamachine_pending_inspection_assert( 44 === $row['agent_id'], 'agent_id is flattened from canonical agent ref' );
+datamachine_pending_inspection_assert( 9 === $row['created_by'], 'created_by is flattened from canonical creator ref' );
+datamachine_pending_inspection_assert( '2026-06-06T00:00:00+00:00' === $row['created_at_iso'], 'created_at_iso is available for CLI tables' );
+datamachine_pending_inspection_assert( 'wordpress-site' === $row['workspace_type'], 'workspace_type is flattened for dashboards' );
+datamachine_pending_inspection_assert( 'site-1' === $row['workspace_id'], 'workspace_id is flattened for dashboards' );
+datamachine_pending_inspection_assert( 'sess-1' === $row['context']['session_id'], 'Data Machine context is surfaced' );
+datamachine_pending_inspection_assert( 'agent_token' === $row['principal_context']['principal_class'], 'safe principal context is surfaced' );
+datamachine_pending_inspection_assert( '[redacted]' === $row['audit_context']['parameters_redacted']['token'], 'redacted audit parameters are preserved' );
+datamachine_pending_inspection_assert( 'resolve_pending_action' === $row['resolve_with'], 'frontend resolver hint is present' );
+datamachine_pending_inspection_assert( 'act_bundle_upgrade' === $row['resolve_params']['action_id'], 'frontend resolve params include action id' );
+
+echo "OK ({$assertions} assertions)\n";


### PR DESCRIPTION
## Summary
- Adds generic, redacted tool execution audit context with principal class, credential scope, source summary, timestamp, and result status.
- Carries that audit metadata into staged pending actions and exposes frontend-ready pending-action list/get rows with flattened fields and resolve hints.
- Normalizes CLI pending-action rows so action kinds like `bundle_upgrade` can list without requiring legacy top-level `agent_id` fields.

Closes #2563.
Refs #2564.
Refs #2526.

## Verification
- `php tests/pending-action-inspection-normalization-smoke.php`
- `php tests/tool-executor-ability-native-smoke.php`
- `php -l inc/Engine/AI/Tools/ToolExecutor.php && php -l inc/Engine/AI/Actions/PendingActionInspectionAbility.php && php -l inc/Engine/AI/Actions/PendingActionHelper.php && php -l inc/Cli/Commands/PendingActionsCommand.php && php -l tests/pending-action-inspection-normalization-smoke.php`
- `git diff --check`

## Notes
- `vendor/bin/phpcs <edited files>` is not currently usable as a targeted signal without a repo config; it flags existing project tab indentation/docblock style across unchanged lines.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the generic audit/pending-action mechanics, drafting the smoke coverage, and running targeted verification. Chris remains responsible for review and merge.