### PR TITLE
feat: expose registered injectable memory files as a queryable list

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -211,6 +211,7 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/AgentRemoteCallAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/AgentAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/AgentMemoryAbilities.php';
+	require_once __DIR__ . '/inc/Abilities/InjectableMemoryFilesAbility.php';
 	require_once __DIR__ . '/inc/Abilities/DailyMemoryAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/ChatAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/InternalLinkingAbilities.php';
@@ -320,6 +321,7 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\AgentAbilities();
 	new \DataMachine\Abilities\AgentTokenAbilities();
 	new \DataMachine\Abilities\AgentMemoryAbilities();
+	new \DataMachine\Abilities\InjectableMemoryFilesAbility();
 	new \DataMachine\Abilities\DailyMemoryAbilities();
 	new \DataMachine\Abilities\ChatAbilities();
 	new \DataMachine\Abilities\InternalLinkingAbilities();

--- a/inc/Abilities/InjectableMemoryFilesAbility.php
+++ b/inc/Abilities/InjectableMemoryFilesAbility.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Injectable Memory Files Ability
+ *
+ * Exposes — as a queryable list — the memory files registered for injection
+ * for a given agent, resolved to absolute on-disk paths plus metadata. This is
+ * the same "which registered files should be in agent context?" answer that
+ * CoreMemoryFilesDirective computes internally for Data Machine's own AI calls,
+ * surfaced so other consumers can ask for it.
+ *
+ * AGNOSTIC BY CONTRACT: this ability answers only a question about Data
+ * Machine's OWN registry state. It knows nothing about how the list is
+ * consumed — no session host, runtime, or config-file format. It emits generic
+ * resolved paths + metadata; the consumer decides what to do with them.
+ *
+ * @package DataMachine\Abilities
+ * @see https://github.com/Extra-Chill/data-machine/issues/2568
+ */
+
+namespace DataMachine\Abilities;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\FilesRepository\AgentMemory;
+use DataMachine\Engine\AI\MemoryFileRegistry;
+
+defined( 'ABSPATH' ) || exit;
+
+class InjectableMemoryFilesAbility {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbility();
+		self::$registered = true;
+	}
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/list-injectable-memory-files',
+				array(
+					'label'               => 'List Injectable Memory Files',
+					'description'         => 'List the memory files registered for injection for an agent, resolved to absolute on-disk paths plus layer metadata. Agnostic to how the list is consumed.',
+					'category'            => 'datamachine-memory',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'agent_id' => array(
+								'type'        => array( 'integer', 'null' ),
+								'description' => 'Agent ID. Takes priority over user_id when provided.',
+							),
+							'user_id'  => array(
+								'type'        => 'integer',
+								'description' => 'WordPress user ID for multi-agent scoping. Defaults to 0 (shared agent).',
+								'default'     => 0,
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'files'   => array(
+								'type'  => 'array',
+								'items' => array(
+									'type'       => 'object',
+									'properties' => array(
+										'filename' => array( 'type' => 'string' ),
+										'layer'    => array( 'type' => 'string' ),
+										'path'     => array( 'type' => 'string' ),
+										'priority' => array( 'type' => 'integer' ),
+									),
+								),
+							),
+						),
+					),
+					'execute_callback'    => array( self::class, 'listInjectableFiles' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Resolve the agent's injectable memory files to absolute paths.
+	 *
+	 * Queries the registry for files marked always-injected across the
+	 * interactive injection contexts (agent identity, agent memory, user
+	 * profile) plus all-mode shared/network files — the same union
+	 * CoreMemoryFilesDirective would inject — then resolves each to an
+	 * absolute path and keeps only those that exist on disk.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array{success: bool, files: array<int, array{filename: string, layer: string, path: string, priority: int}>}
+	 */
+	public static function listInjectableFiles( array $input ): array {
+		$agent_id = (int) ( $input['agent_id'] ?? 0 );
+		$user_id  = (int) ( $input['user_id'] ?? 0 );
+
+		$injection_contexts = array(
+			MemoryFileRegistry::INJECTION_AGENT_IDENTITY,
+			MemoryFileRegistry::INJECTION_AGENT_MEMORY,
+			MemoryFileRegistry::INJECTION_USER_PROFILE,
+		);
+
+		// Pass the all-mode marker so shared/network files registered with
+		// modes => array( MODE_ALL ) are included alongside the
+		// injection-context-gated agent/user files.
+		$registered = MemoryFileRegistry::get_for_modes(
+			array( MemoryFileRegistry::MODE_ALL ),
+			$injection_contexts
+		);
+
+		$files = array();
+		foreach ( $registered as $filename => $meta ) {
+			$layer  = $meta['layer'] ?? MemoryFileRegistry::LAYER_AGENT;
+			$memory = new AgentMemory( $user_id, $agent_id, $filename, $layer );
+			$path   = $memory->get_file_path();
+
+			if ( '' === $path || ! file_exists( $path ) ) {
+				continue;
+			}
+
+			$files[] = array(
+				'filename' => $filename,
+				'layer'    => $layer,
+				'path'     => $path,
+				'priority' => (int) ( $meta['priority'] ?? 50 ),
+			);
+		}
+
+		// Stable order by registry priority (lower loads first), matching
+		// the directive's load order.
+		usort(
+			$files,
+			static fn( array $a, array $b ): int => $a['priority'] <=> $b['priority']
+		);
+
+		return array(
+			'success' => true,
+			'files'   => $files,
+		);
+	}
+}

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -1052,6 +1052,75 @@ class MemoryCommand extends BaseCommand {
 		return $directory_manager->get_agent_identity_directory_for_user( $user_id );
 	}
 
+	/**
+	 * List the memory files registered for injection for an agent.
+	 *
+	 * Returns the files Data Machine marks for injection into an agent's
+	 * context — resolved to absolute on-disk paths plus layer metadata. This
+	 * is a generic read surface over Data Machine's own registry; it is
+	 * agnostic to how the list is consumed.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--agent=<slug>]
+	 * : Agent slug or numeric ID. Defaults to the effective context.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # List injectable files for an agent as JSON
+	 *     wp datamachine memory injectable-files --agent=extra-chill-bot --format=json
+	 *
+	 *     # List for the effective context as a table
+	 *     wp datamachine memory injectable-files
+	 *
+	 * @subcommand injectable-files
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function injectable_files( array $args, array $assoc_args ): void {
+		$ability = wp_get_ability( 'datamachine/list-injectable-memory-files' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Ability datamachine/list-injectable-memory-files is not available.' );
+		}
+
+		$scoping = $this->resolveMemoryScoping( $assoc_args );
+		$result  = $ability->execute( $scoping );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['message'] ?? 'Failed to list injectable memory files.' );
+		}
+
+		$files  = $result['files'] ?? array();
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $files ) ) {
+			if ( 'json' === $format ) {
+				WP_CLI::line( '[]' );
+				return;
+			}
+			WP_CLI::log( 'No injectable memory files found.' );
+			return;
+		}
+
+		WP_CLI\Utils\format_items( $format, $files, array( 'filename', 'layer', 'priority', 'path' ) );
+	}
+
 	// =========================================================================
 	// Composable files
 	// =========================================================================


### PR DESCRIPTION
## Summary

Adds a generic read surface — `datamachine/list-injectable-memory-files` ability + `wp datamachine memory injectable-files` CLI — that returns the memory files registered for injection for an agent, resolved to **absolute on-disk paths + layer metadata**, ordered by registry priority.

Refs #2568. Unblocks the consumer side (wp-coding-agents#192).

## Why

DM's `MemoryFileRegistry` is the source of truth for which memory files inject into agent context, but that knowledge was only consumed **internally** by `CoreMemoryFilesDirective`. No other consumer could ask DM "what should this agent have in context?" — so consumers maintained their own hand-written, parallel file lists that silently drift whenever a new memory file is registered (e.g. WAKE.md from #2557 registers fine but no external consumer can discover it).

This exposes that answer as a queryable list, so the injection set can be **derived** from the registry instead of duplicated by hand.

## Agnostic by contract (the whole point — per #2568)

The ability answers only a question about DM's **own** registry state. It does **not** know how the list is consumed:
- No `opencode`/`kimaki`/runtime/vendor names anywhere — **grep-clean verified** (`grep -riE 'opencode|kimaki|discord|…'` on the new code returns nothing).
- No consumer-shaped output mode (no "instructions array" format). Emits generic resolved paths + metadata; the consumer decides what to do with them.
- The vendor-specific glue (turning this into a particular runtime's session context) lives in the consuming integration layer, not here.

## How it works

`listInjectableFiles()` queries `MemoryFileRegistry::get_for_modes()` with the interactive injection contexts (agent identity, agent memory, user profile) + the all-mode marker — the same union `CoreMemoryFilesDirective` injects — resolves each file to an absolute path via `AgentMemory::get_file_path()`, drops any that don't exist on disk, and sorts by registry priority.

## Verification

- `php -l` clean on all 3 files; **homeboy lint (PHPCS + PHPStan) passes, 0 findings**.
- **Ran live against the primary agent:**
  ```
  NETWORK.md (network, p5)
  SITE.md    (shared,  p10)
  RULES.md   (shared,  p15)
  SOUL.md    (agent,   p20)
  USER.md    (user,    p25)
  MEMORY.md  (agent,   p30)
  ```
  This is **exactly** the set currently hardcoded in the opencode `instructions` list elsewhere — proving the ability correctly derives the hand-maintained list. WAKE.md (priority 35) is absent only because #2567 isn't deployed to the live install yet; it will appear automatically once present, with zero hand-edits.

## Wiring

- Ability registered in `data-machine.php` (require + instantiate, mirroring `AgentMemoryAbilities`).
- CLI subcommand `injectable-files` added to `MemoryCommand`, reusing the existing `resolveMemoryScoping()` agent/user resolution; thin wrapper that calls the ability (Abilities API pattern — logic lives in the ability).

## Constraints honored

- Conventional commit (`feat:`).
- No CHANGELOG edits, no version bumps (homeboy owns both).
- Layer purity is the point — grep-clean of runtime/vendor names.