### PR TITLE
fix: correct stale AIStep comments implying per-step model fields exist

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -88,8 +88,10 @@ class AIStep extends Step {
 		$job_snapshot         = is_array( $job_snapshot ) ? $job_snapshot : array();
 		$agent_id             = $this->resolveAgentIdFromJobSnapshot( $job_snapshot );
 
-		// Model/provider resolved exclusively via mode system (agent → site → network).
-		// Pipeline-level model/provider fields are ignored — mode_models is the authority.
+		// Model/provider are resolved exclusively via the mode system
+		// (agent mode_models → site → network → default). There are no
+		// per-pipeline-step model/provider fields: the editor does not write
+		// them (see Api\Pipelines\PipelineSteps) and AIStep does not read them.
 		$execution_modes = self::resolveExecutionModes( $pipeline_step_config, $this->flow_step_config );
 		$mode_model      = self::resolveModelForExecutionModes( $agent_id, $execution_modes, $job_snapshot );
 		$provider_name   = $mode_model['provider'];
@@ -180,7 +182,9 @@ class AIStep extends Step {
 		$pipeline_step_config = $this->engine->getPipelineStepConfig( $pipeline_step_id );
 		$execution_modes      = self::resolveExecutionModes( $pipeline_step_config, $this->flow_step_config );
 
-		// Model/provider resolved exclusively via mode system — pipeline config is ignored.
+		// Model/provider are resolved exclusively via the mode system. There is no
+		// per-pipeline-step model override — pipeline_config carries only modes,
+		// prompts, and tool policy, never a model/provider field.
 		$mode_model    = self::resolveModelForExecutionModes( $agent_id, $execution_modes, $job_snapshot );
 		$provider_name = $mode_model['provider'];
 		$model_name    = $mode_model['model'];


### PR DESCRIPTION
Fixes #2571

## TL;DR

The reported footgun — *"the editor lets you set a per-step model, it's stored in `pipeline_config`, and it's silently discarded at runtime"* — **was true on the deployed build, but is already resolved on `main`.** The maintainers chose **option (b)** from the issue (remove the per-step model selector and treat model as agent/settings-scoped) back in April 2026 via #1181.

The only thing left over from that change is **two stale comments in `AIStep.php`** that still say *"pipeline-level model/provider fields are ignored"* — wording that implies such fields exist and are silently dropped. That comment is literally what the issue quotes. This PR rewrites those comments to state the actual behavior. No code behavior changes.

## Why not "honor the pipeline-step model" (issue option a)

The issue's preferred fix was to make the pipeline-step model the highest-priority source. I have a **concrete reason not to**: there is no pipeline-step model to honor anymore. PR #1181 (`18a3ddad`, *"cleanup(pipelines): remove legacy provider/model fields from AI step config"*) already:

- removed `provider` + `model` from the REST schema (`PipelineSteps::get_step_config_args`),
- removed the "AI Provider / Model" block from the editor (`FlowStepCard.jsx` has **zero** provider/model refs),
- stripped `stepData.provider`/`stepData.model` from the React Query cache,
- added a migration (`datamachine_strip_pipeline_step_provider_model`) that walks every `pipeline_config` row and removes the dead keys,
- and `PipelineSteps` now actively `unset()`s any lingering `provider`/`model` keys on every write.

Resurrecting per-step model config would directly contradict that deliberate architectural decision and re-introduce the very "inspection ≠ execution" footgun the issue is about, just inverted. So honoring it is the wrong move.

`ProviderModelSelector.jsx` still exists and is used — but only in `AgentSettings.jsx` (agent-scoped), which is correct.

## Verification of the resolution path (end to end)

```
AIStep::executeStep()  /  AIStep::checkRequiredConfig()
        │
        ▼
resolveModelForExecutionModes($agent_id, $modes, $job_snapshot)
        │
        ├─► resolveModelFromJobSnapshot($job_snapshot, $modes)
        │       1. mode_models[<mode>]            (provider + model)
        │       2. mode_models[pipeline]          (provider + model)
        │       3. job_snapshot.default_provider / default_model
        │
        └─► PluginSettings::resolveModelForAgentModes($agent_id, $modes, MODE_PIPELINE)
                agent_config.mode_models[mode] → agent_config.default_provider/default_model
                → site/network mode overrides → site/network global defaults
```

At **no point** does anything read a `model` / `providers` field off `pipeline_step_config`. The pipeline step config is consulted only for `agent_modes` (via `resolveExecutionModes`), prompts, and tool policy. The effective `model_id` **is** already recorded in `RunMetrics::recordStepResult` at request time, so the model that actually runs is observable in run metrics/logs.

## Changes

- `inc/Core/Steps/AI/AIStep.php` — rewrite the two stale comments (lines ~91 and ~183) to say there is **no** per-pipeline-step model override, and that model/provider come solely from the mode system. Comment-only.

## Verification

- `php -l inc/Core/Steps/AI/AIStep.php` → no syntax errors.
- `vendor/bin/phpcs inc/Core/Steps/AI/AIStep.php` → no violations.
- `homeboy test data-machine` could **not** run locally: the host was hot (load avg 10.2 / 8 CPU) and homeboy's resource policy refused to start tests from a non-interactive shell. Given this is a comment-only change with zero behavioral impact, the suite is not load-bearing here — but CI should still exercise it on this PR.

## Recommended follow-up (not in this PR — maintainer call)

The genuinely useful diagnosability win — and the follow-up #1181 explicitly deferred (*"Surfacing the resolved mode-model on the card is tracked as a follow-up"*) — is to surface the **effective resolved model** in the editor / `wp datamachine pipeline get`, so inspection matches execution. I deliberately did **not** attempt it here because the effective model depends on the **per-flow agent** (and mode/site/network overrides), not the pipeline alone. Resolving it at the pipeline level (no agent context) would surface a *different* model than a given flow actually runs — recreating the same footgun. That belongs in its own scoped PR with a clear decision on which agent context to resolve against.

---

AI assistance
- AI assistance: Yes
- Tool(s): Claude (Extra Chill Bot)
- Used for: Traced the resolution path against fresh `origin/main`, confirmed #1181 already removed the per-step selector, scoped the fix to the stale comments, ran php -l + phpcs.