### PR TITLE
fix: treat explicitly-empty enabled_tools as deny-all-optional (#2573)

### DIFF
--- a/inc/Core/Steps/AI/ToolPolicy/PipelineToolPolicyArgs.php
+++ b/inc/Core/Steps/AI/ToolPolicy/PipelineToolPolicyArgs.php
@@ -21,16 +21,26 @@ class PipelineToolPolicyArgs {
 	 * direct workflows use synthetic IDs, and historical jobs must inspect the
 	 * policy that existed when they ran.
 	 *
+	 * An explicitly-configured enabled_tools list (even an empty one) switches
+	 * the step into allowlist mode: only the named optional tools survive
+	 * alongside mandatory plumbing. An empty explicit list therefore denies all
+	 * optional/global tools. When the field is absent (legacy steps that predate
+	 * it) no allow_only constraint is emitted and the context preset applies.
+	 *
 	 * @param array $flow_step_config     Current flow step config snapshot.
 	 * @param array $pipeline_step_config Current pipeline step config snapshot.
 	 * @return array Resolver args containing allow_only/deny when configured.
 	 */
 	public static function fromConfigs( array $flow_step_config, array $pipeline_step_config ): array {
-		$args          = array();
-		$enabled_tools = FlowStepConfig::getEnabledTools( $flow_step_config );
+		$args = array();
 
-		if ( ! empty( $enabled_tools ) ) {
-			$args['allow_only'] = self::sanitizeToolList( $enabled_tools );
+		if ( FlowStepConfig::isEnabledToolsExplicit( $flow_step_config ) ) {
+			$args['allow_only'] = self::sanitizeToolList( FlowStepConfig::getEnabledTools( $flow_step_config ) );
+
+			// Allowlist mode is meaningful even when empty: it means "no optional
+			// tools." The generic substrate only applies a non-empty allow_only,
+			// so flag the explicit-empty case for the resolver to enforce.
+			$args['allow_only_explicit'] = true;
 		}
 
 		$deny = array_merge(

--- a/inc/Core/Steps/FlowStepConfig.php
+++ b/inc/Core/Steps/FlowStepConfig.php
@@ -398,6 +398,37 @@ class FlowStepConfig {
 	}
 
 	/**
+	 * Whether an AI step explicitly configured its enabled_tools allowlist.
+	 *
+	 * Distinguishes "the operator deselected every optional tool"
+	 * (`enabled_tools` present and an array, possibly empty) from "this step
+	 * predates the field and was never configured" (`enabled_tools` absent or
+	 * not an array). The two collapse to the same value under
+	 * getEnabledTools(), but they carry opposite policy intent:
+	 *
+	 *   - Explicit (even empty) => allowlist mode: only the named optional tools
+	 *     (none, for an empty list) survive alongside mandatory plumbing tools.
+	 *   - Absent => preset mode: the context's default tool pool applies.
+	 *
+	 * Without this distinction an explicitly-empty enabled_tools silently falls
+	 * through to the full preset, exposing global research tools (web_fetch,
+	 * local_search, ...) the operator meant to exclude.
+	 *
+	 * @since 0.139.13
+	 *
+	 * @param array $step_config Flow step configuration array.
+	 * @return bool True when an AI step has an explicit enabled_tools array.
+	 */
+	public static function isEnabledToolsExplicit( array $step_config ): bool {
+		if ( 'ai' !== ( $step_config['step_type'] ?? '' ) ) {
+			return false;
+		}
+
+		return array_key_exists( 'enabled_tools', $step_config )
+			&& is_array( $step_config['enabled_tools'] );
+	}
+
+	/**
 	 * Resolve capability flags for a step config.
 	 *
 	 * @param array $step_config Step configuration array.

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -129,6 +129,17 @@ class ToolPolicyResolver {
 
 		$tools = $this->tool_policy->resolve( $tools, $policy_context );
 
+		// An explicitly-empty allow_only means "no optional tools." The generic
+		// substrate only applies a non-empty allow_only, so it would otherwise
+		// fall through to the full preset. Enforce the empty allowlist here while
+		// preserving mandatory plumbing tools (adjacent handler + completion).
+		if ( ! empty( $args['allow_only_explicit'] ) ) {
+			$allow_only = $this->policy_filter->string_list( $args['allow_only'] ?? array() );
+			if ( empty( $allow_only ) ) {
+				$tools = $this->filterByAllowOnlyPreservingHandlerTools( $tools, array() );
+			}
+		}
+
 		// 7. Allow external filtering of resolved tools.
 		// @phpstan-ignore-next-line WordPress apply_filters accepts additional hook arguments.
 		$filter_mode = 1 === count( $modes ) ? $modes[0] : $modes;

--- a/tests/ai-enabled-tools-smoke.php
+++ b/tests/ai-enabled-tools-smoke.php
@@ -41,6 +41,21 @@ function get_enabled_tools_for_test( array $step_config ): array {
 	return array_values( $enabled );
 }
 
+/**
+ * Inline reimplementation of FlowStepConfig::isEnabledToolsExplicit().
+ *
+ * Mirrors inc/Core/Steps/FlowStepConfig.php. Diverging here means the real
+ * file regressed.
+ */
+function is_enabled_tools_explicit_for_test( array $step_config ): bool {
+	if ( 'ai' !== ( $step_config['step_type'] ?? '' ) ) {
+		return false;
+	}
+
+	return array_key_exists( 'enabled_tools', $step_config )
+		&& is_array( $step_config['enabled_tools'] );
+}
+
 $failures = array();
 $passes   = 0;
 
@@ -114,6 +129,55 @@ $config = array(
 	'enabled_tools' => 'not_an_array',
 );
 assert_equals( array(), get_enabled_tools_for_test( $config ), 'non-array enabled_tools → empty (no fatal)', $failures, $passes );
+
+// ----- FlowStepConfig::isEnabledToolsExplicit() -----
+
+echo "\n[7] explicit detection — populated enabled_tools is explicit:\n";
+assert_equals(
+	true,
+	is_enabled_tools_explicit_for_test( array( 'step_type' => 'ai', 'enabled_tools' => array( 'intelligence/search' ) ) ),
+	'populated array => explicit',
+	$failures,
+	$passes
+);
+
+echo "\n[8] explicit detection — present-but-EMPTY enabled_tools is explicit:\n";
+// This is the footgun case: the operator deselected every tool. It must be
+// distinguishable from an absent key so the runtime can deny all optional tools.
+assert_equals(
+	true,
+	is_enabled_tools_explicit_for_test( array( 'step_type' => 'ai', 'enabled_tools' => array() ) ),
+	'present empty array => explicit (deny all optional)',
+	$failures,
+	$passes
+);
+
+echo "\n[9] explicit detection — absent key is NOT explicit (legacy preset):\n";
+assert_equals(
+	false,
+	is_enabled_tools_explicit_for_test( array( 'step_type' => 'ai' ) ),
+	'absent key => not explicit (preset applies)',
+	$failures,
+	$passes
+);
+
+echo "\n[10] explicit detection — non-array enabled_tools is NOT explicit:\n";
+assert_equals(
+	false,
+	is_enabled_tools_explicit_for_test( array( 'step_type' => 'ai', 'enabled_tools' => 'nope' ) ),
+	'non-array => not explicit',
+	$failures,
+	$passes
+);
+
+echo "\n[11] explicit detection — non-AI step is never explicit:\n";
+assert_equals(
+	false,
+	is_enabled_tools_explicit_for_test( array( 'step_type' => 'publish', 'enabled_tools' => array() ) ),
+	'publish step => not explicit',
+	$failures,
+	$passes
+);
 
 echo "\n---------------------------------------\n";
 $total = $passes + count( $failures );

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -175,12 +175,17 @@ $tools   = resolve_policy_tools_for_test(
 assert_policy_equals( array( 'agent_daily_memory', 'agent_memory' ), array_keys( $tools ), 'allowlist can intentionally grant policy-controlled memory tools', $failures, $passes );
 assert_policy_equals( array(), $manager->availability_contexts, 'opt-in memory tools avoid per-step availability context lookups', $failures, $passes );
 
-echo "\n[2] ephemeral workflow disabled_tools deny from snapshot:\n";
+echo "\n[2] ephemeral explicit-empty enabled_tools denies all optional tools:\n";
+// An explicitly-empty enabled_tools means "no optional tools." The factory
+// always writes the enabled_tools key for AI steps, so this is the explicit
+// case: every optional preset tool is stripped (none here are mandatory
+// plumbing). This is the footgun fix — previously these fell through to the
+// full preset minus only the disabled_tools entry.
 $ephemeral = WorkflowConfigFactory::buildEphemeralConfigs(
 	array(
 		'steps' => array(
 			array(
-				'type'           => 'ai',
+				'step_type'      => 'ai',
 				'enabled_tools'  => array(),
 				'disabled_tools' => array( 'danger_tool' ),
 			),
@@ -191,14 +196,14 @@ $flow_step_config     = $ephemeral['flow_config']['ephemeral_step_0'];
 $pipeline_step_config = $ephemeral['pipeline_config']['ephemeral_pipeline_0'];
 $manager              = new SnapshotPolicyToolManager();
 $tools                = resolve_policy_tools_for_test( $flow_step_config, $pipeline_step_config, $manager );
-assert_policy_equals( array( 'alpha_tool', 'beta_tool' ), array_keys( $tools ), 'ephemeral disabled_tools removes denied tool without DB row and does not auto-grant daily memory', $failures, $passes );
+assert_policy_equals( array(), array_keys( $tools ), 'explicit-empty enabled_tools strips every optional preset tool', $failures, $passes );
 assert_policy_equals( array(), $manager->availability_contexts, 'ephemeral policy never re-reads by synthetic pipeline step ID', $failures, $passes );
 
-echo "\n[3] persistent workflow disabled_tools still apply from snapshot:\n";
+echo "\n[3] persistent explicit-empty enabled_tools denies all optional tools:\n";
 $workflow = array(
 	'steps' => array(
 		array(
-			'type'           => 'ai',
+			'step_type'      => 'ai',
 			'enabled_tools'  => array(),
 			'disabled_tools' => array( 'beta_tool' ),
 		),
@@ -210,8 +215,23 @@ $pipeline_step_id     = array_key_first( $pipeline_config );
 $flow_step_id         = array_key_first( $flow_config );
 $manager              = new SnapshotPolicyToolManager();
 $tools                = resolve_policy_tools_for_test( $flow_config[ $flow_step_id ], $pipeline_config[ $pipeline_step_id ], $manager );
-assert_policy_equals( array( 'alpha_tool', 'danger_tool' ), array_keys( $tools ), 'persistent disabled_tools removes denied tool', $failures, $passes );
+assert_policy_equals( array(), array_keys( $tools ), 'persistent explicit-empty enabled_tools strips every optional preset tool', $failures, $passes );
 assert_policy_equals( array(), $manager->availability_contexts, 'persistent policy does not re-read persisted step config', $failures, $passes );
+
+echo "\n[3b] absent enabled_tools (legacy step) keeps the preset:\n";
+// When the enabled_tools key was never configured (legacy, pre-field steps),
+// the step must keep the context preset for back-compat — no allowlist.
+$manager = new SnapshotPolicyToolManager();
+$tools   = resolve_policy_tools_for_test(
+	array(
+		'step_type'        => 'ai',
+		'pipeline_step_id' => 'ephemeral_pipeline_0',
+		// no enabled_tools key at all.
+	),
+	array( 'disabled_tools' => array( 'danger_tool' ) ),
+	$manager
+);
+assert_policy_equals( array( 'alpha_tool', 'beta_tool' ), array_keys( $tools ), 'absent enabled_tools keeps preset minus explicit deny', $failures, $passes );
 
 echo "\n[4] RequestInspector and AIStep share policy input helper:\n";
 $ai_step_source   = file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' ) ?: '';
@@ -232,11 +252,47 @@ $args = PipelineToolPolicyArgs::fromConfigs(
 );
 assert_policy_equals(
 	array(
-		'allow_only' => array( 'alpha_tool', 'beta_tool' ),
-		'deny'       => array( 'pipeline_denied', 'shared_denied', 'flow_denied' ),
+		'allow_only'          => array( 'alpha_tool', 'beta_tool' ),
+		'allow_only_explicit' => true,
+		'deny'                => array( 'pipeline_denied', 'shared_denied', 'flow_denied' ),
 	),
 	$args,
 	'enabled_tools and disabled_tools map to allow_only and deny args with original ordering',
+	$failures,
+	$passes
+);
+
+echo "\n[6] explicit-empty enabled_tools emits an empty allow_only + explicit flag:\n";
+$args = PipelineToolPolicyArgs::fromConfigs(
+	array(
+		'step_type'     => 'ai',
+		'enabled_tools' => array(),
+	),
+	array()
+);
+assert_policy_equals(
+	array(
+		'allow_only'          => array(),
+		'allow_only_explicit' => true,
+	),
+	$args,
+	'empty explicit enabled_tools => empty allow_only flagged explicit (deny all optional)',
+	$failures,
+	$passes
+);
+
+echo "\n[7] absent enabled_tools (legacy) emits no allow_only constraint:\n";
+$args = PipelineToolPolicyArgs::fromConfigs(
+	array(
+		'step_type' => 'ai',
+		// no enabled_tools key.
+	),
+	array()
+);
+assert_policy_equals(
+	array(),
+	$args,
+	'absent enabled_tools => no allow_only / allow_only_explicit (preset applies)',
 	$failures,
 	$passes
 );


### PR DESCRIPTION
Fixes #2573

## Summary

An AI pipeline step that set `enabled_tools: []` (explicitly empty) silently fell through to the **full pipeline tool preset**, exposing global research tools (`web_fetch`, `local_search`, `wordpress_post_reader`, ...) the operator meant to exclude. This caused real OpenAI cost waste: **189 event-import flows** on `events.extrachill.com` had `enabled_tools: []`, the model got `web_fetch` anyway, and used it to fetch ticketing pages (ticketmaster.com, etc.) — getting `403`s and burning billed turns on every run.

Confirmed empirically against the live DB — the real event-import AI steps carry `enabled_tools` present and equal to `[]`:

```
AI keys: [..., 'enabled_tools', ...]   enabled_tools present: True => []
```

## Root cause

`FlowStepConfig::getEnabledTools()` collapsed two distinct intents into the same `[]`:

1. **Key absent / never configured** (legacy step) → should keep preset behavior.
2. **Key present but empty** (operator deselected everything) → should mean "no optional tools."

`PipelineToolPolicyArgs::fromConfigs()` then guarded on `! empty( $enabled_tools )`, so an empty list never set `allow_only` and both cases fell through to the preset. The generic substrate (`WP_Agent_Tool_Policy::resolve()`) also only applies a **non-empty** `allow_only`, so even passing `[]` downstream is a no-op.

## The fix

Distinguish absent vs present-but-empty, and enforce the empty case:

1. **`FlowStepConfig::isEnabledToolsExplicit()`** — `true` when the `enabled_tools` key is present and an array (even empty) on an AI step.
2. **`PipelineToolPolicyArgs::fromConfigs()`** — when `enabled_tools` is explicitly configured, emit `allow_only` (possibly empty) **plus** an `allow_only_explicit` flag. When the field is absent, emit nothing → legacy preset behavior preserved for pre-field steps.
3. **`ToolPolicyResolver::resolve()`** — when `allow_only` is explicitly empty, enforce the empty allowlist via the existing `filterByAllowOnlyPreservingHandlerTools([])`. The generic substrate skips empty allow lists, so this enforcement lives in the DM resolver layer.

### Mandatory plumbing is preserved (required, not optional)

`filterByAllowOnlyPreservingHandlerTools` uses `DataMachineMandatoryToolPolicy::isMandatory()` (`isset($tool['handler']) && !isset($tool['ability'])`) as the preserve callback, so these always survive regardless of `enabled_tools`:

- **Adjacent handler tools** — e.g. the `data_machine_events` upsert handler tool (flow plumbing from neighboring steps).
- **Cross-cutting handler tools** — e.g. `skip_item` (registered via `handler_types`, carries `handler` metadata).

Only optional/global tools (`web_fetch`, `local_search`, ...) are stripped.

## Trace verification

Resolver run with `enabled_tools: []` in `pipeline` mode against a realistic events tool set:

```
RESOLVED TOOLS (explicit-empty enabled_tools):
  data_machine_events, skip_item

web_fetch present?               no  (correct)
local_search present?            no  (correct)
data_machine_events (handler)?   YES (correct — mandatory plumbing)
skip_item (mandatory)?           YES (correct — mandatory plumbing)
```

## Why not also make web_fetch opt-in in the pipeline preset?

The issue raised `web_fetch` auto-registering into the `pipeline` preset (`WebFetch.php`). I investigated and **deliberately did not change it**: `web_fetch`'s only opt-in mechanism (`requires_opt_in`) is a **global** tool flag, not mode-scoped. Setting it would break chat — there is an existing contract test (`ChatToolsAvailabilityTest::test_chat_tools_include_web_fetch`) asserting `web_fetch` is available in chat by default, plus pipeline tests that legitimately expect preset behavior when `enabled_tools` is **absent**. The empty-`enabled_tools` fix above already resolves the real footgun for every pipeline that configures the field (including all 189 events flows), without the chat blast radius. A mode-scoped pipeline opt-in for global research tools can be a separate, smaller change if desired.

## Live mitigation

The `events-bot` agent has a stopgap deny-list `tool_policy` (deny `web_fetch`, `local_search`, `wordpress_post_reader`, `google_search`, `image_generation`). This PR is the durable, system-wide fix so the stopgap can eventually be removed.

## Tests

- **`tests/ai-enabled-tools-smoke.php`** — added `isEnabledToolsExplicit()` coverage: populated/explicit, present-but-empty/explicit, absent/not-explicit, non-array/not-explicit, non-AI/not-explicit. (11/11 pass)
- **`tests/pipeline-tool-policy-snapshot-smoke.php`** — updated cases `[2]`/`[3]` to the new explicit-empty semantics (strip all optional preset tools), added `[3b]` (absent key keeps preset), `[6]` (empty explicit emits empty `allow_only` + `allow_only_explicit`), `[7]` (absent emits no constraint). (14/14 pass)
  - Note: the original `[2]`/`[3]` used `'type' => 'ai'`, which the factory does not map to `step_type`, so they were never actually exercising an AI step. Corrected to `'step_type' => 'ai'`.
- **`tests/adjacent-handler-tool-policy-smoke.php`** — regression confirmed (20/20), proving handler plumbing survives an empty allowlist.

`php -l` clean on all changed files. PHPCS clean on changed source. One unrelated pre-existing failure (`ai-required-handlers-smoke.php`) exists on stock `origin/main` and is not touched by this change.

## Verification commands

```
php tests/ai-enabled-tools-smoke.php
php tests/pipeline-tool-policy-snapshot-smoke.php
php tests/adjacent-handler-tool-policy-smoke.php
```