### PR TITLE
Fix Agents API conversation turn runner

### DIFF
--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -243,7 +243,7 @@ function datamachine_run_conversation(
 	try {
 		$result = WP_Agent_Conversation_Loop::run(
 			$messages,
-			null,
+			$provider_turn_adapter,
 			array(
 				'max_turns'             => $max_turns,
 				'budgets'               => array( $turn_budget ),

--- a/tests/chat-session-canonical-path-smoke.php
+++ b/tests/chat-session-canonical-path-smoke.php
@@ -74,8 +74,8 @@ $assert(
 );
 
 $assert(
-	false !== strpos( $conversation_loop, "WP_Agent_Conversation_Loop::run(\n\t\t\t\$messages,\n\t\t\tnull," ),
-	'Data Machine lets the Agents API loop wrap the provider turn adapter'
+	false !== strpos( $conversation_loop, "WP_Agent_Conversation_Loop::run(\n\t\t\t\$messages,\n\t\t\t\$provider_turn_adapter," ),
+	'Data Machine passes its callable provider turn adapter to the Agents API loop'
 );
 
 $assert(


### PR DESCRIPTION
## Summary
- Passes Data Machine's provider turn adapter as the callable turn runner required by `WP_Agent_Conversation_Loop::run()`.
- Updates the canonical chat-session smoke assertion so it no longer preserves the broken null turn-runner contract.

## Verification
- `php tests/chat-session-canonical-path-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`
- `php tests/agent-bundle-runner-contract-smoke.php`

## Evidence
- Studio Web Workflow Bench direct live verification with this branch no longer fails with `WP_Agent_Conversation_Loop::run(): Argument #2 ($turn_runner) must be of type callable, null given`.
- The next exposed failure is a separate provider tool-name validation issue: `Invalid 'tools[0].name': string does not match pattern`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the Data Machine/Agents API runtime contract failure, drafted the call-site fix and smoke update, and ran targeted checks for Chris to review.