### PR TITLE
Fix inline runtime agent bundle imports

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -344,17 +344,13 @@ class AgentAbilities {
 					'category'            => 'datamachine-agent',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'anyOf'      => array(
-							array( 'required' => array( 'source' ) ),
-							array( 'required' => array( 'bundle' ) ),
-						),
 						'properties' => array(
 							'source'      => array(
 								'type'        => 'string',
 								'description' => 'Bundle source: local path (directory, .zip, .json) or remote URL (HTTPS to a .zip/.json or a GitHub blob/tree/archive URL).',
 							),
 							'bundle'      => array(
-								'type'        => 'object',
+								'type'        => array( 'object', 'array' ),
 								'description' => 'Already-parsed portable Data Machine agent bundle array.',
 							),
 							'slug'        => array(

--- a/tests/import-agent-ability-smoke.php
+++ b/tests/import-agent-ability-smoke.php
@@ -268,7 +268,7 @@ namespace {
 	};
 
 	$agent_abilities_source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/AgentAbilities.php' );
-	$assert( 'import-agent schema accepts either source or bundle', false !== strpos( $agent_abilities_source, "array( 'required' => array( 'source' ) )" ) && false !== strpos( $agent_abilities_source, "array( 'required' => array( 'bundle' ) )" ) );
+	$assert( 'import-agent execution validates source-or-bundle requirement', false !== strpos( $agent_abilities_source, 'Bundle source or inline bundle is required.' ) && false === strpos( $agent_abilities_source, "array( 'required' => array( 'bundle' ) )" ) );
 	$assert( 'import-agent schema exposes inline bundle input', false !== strpos( $agent_abilities_source, "'bundle'      => array(" ) && false !== strpos( $agent_abilities_source, 'Already-parsed portable Data Machine agent bundle array' ) );
 	$assert( 'runtime importer does not stage bundles through temp files', false === strpos( $agent_abilities_source, 'tempnam' ) && false === strpos( $agent_abilities_source, 'wp_tempnam' ) );
 


### PR DESCRIPTION
## Summary
- Allows `datamachine/import-agent` to accept inline runtime bundle arrays while keeping the source-or-bundle requirement enforced by execution.
- Updates import-agent smoke coverage for inline runtime bundle imports through the canonical ability path.

## Testing
- `php tests/import-agent-ability-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the browser runtime bundle import failure, drafting the schema/coverage update, and running targeted verification. Chris remains responsible for review and testing.