### PR TITLE
Fix provider-safe runtime tool names

### DIFF
--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -58,12 +58,13 @@ class RequestBuilder {
 		$mode_label       = implode( ',', $modes );
 		$assembled        = self::assemble( $messages, $provider, $model, $tools, $modes, $payload );
 		$request          = $assembled['request'];
-		$provider_request = ProviderRequestAssembler::toProviderRequest( $request );
-		$prompt_context   = self::wpAiClientPromptContext( $request['messages'] ?? array() );
+		$structured_tools        = $assembled['structured_tools'];
+		$provider_tool_name_map  = self::providerToolNameMap( $structured_tools );
+		$provider_request        = ProviderRequestAssembler::toProviderRequest( $request );
+		$prompt_context          = self::wpAiClientPromptContext( $request['messages'] ?? array(), $provider_tool_name_map );
 		if ( '' !== $prompt_context['prompt'] ) {
 			$provider_request['prompt'] = $prompt_context['prompt'];
 		}
-		$structured_tools   = $assembled['structured_tools'];
 		$applied_directives = $assembled['applied_directives'];
 		$directive_metadata = $assembled['directive_metadata'];
 
@@ -249,9 +250,10 @@ class RequestBuilder {
 				if ( '' === $name ) {
 					continue;
 				}
+				$provider_name = $provider_tool_name_map[ $name ] ?? self::providerSafeToolName( $name );
 
 				$function_declarations[] = new \WordPress\AiClient\Tools\DTO\FunctionDeclaration(
-					$name,
+					$provider_name,
 					(string) ( $tool_config['description'] ?? '' ),
 					self::normalizeToolSchema( $tool_config['parameters'] ?? array() )
 				);
@@ -294,6 +296,54 @@ class RequestBuilder {
 	}
 
 	/**
+	 * Build provider-safe aliases for canonical tool names.
+	 *
+	 * Data Machine tool IDs may include namespace separators such as `/`; OpenAI
+	 * function names only allow letters, numbers, underscores, and hyphens.
+	 *
+	 * @param array<string,array<string,mixed>> $tools Tool declarations keyed by canonical name.
+	 * @return array<string,string> Map of canonical tool name to provider-safe alias.
+	 */
+	public static function providerToolNameMap( array $tools ): array {
+		$map  = array();
+		$used = array();
+
+		foreach ( $tools as $tool_name => $tool_config ) {
+			$canonical_name = (string) ( is_array( $tool_config ) ? ( $tool_config['name'] ?? $tool_name ) : $tool_name );
+			if ( '' === $canonical_name ) {
+				continue;
+			}
+
+			$provider_name = self::providerSafeToolName( $canonical_name );
+			if ( isset( $used[ $provider_name ] ) && $used[ $provider_name ] !== $canonical_name ) {
+				$provider_name .= '_' . substr( hash( 'sha256', $canonical_name ), 0, 8 );
+			}
+
+			$map[ $canonical_name ]       = $provider_name;
+			$used[ $provider_name ]       = $canonical_name;
+		}
+
+		return $map;
+	}
+
+	/**
+	 * Convert a canonical tool name into a provider-safe function name.
+	 *
+	 * @param string $tool_name Canonical tool name.
+	 * @return string Provider-safe function name.
+	 */
+	public static function providerSafeToolName( string $tool_name ): string {
+		$safe_name = (string) preg_replace( '/[^a-zA-Z0-9_-]+/', '_', $tool_name );
+		$safe_name = trim( $safe_name, '_' );
+
+		if ( '' !== $safe_name ) {
+			return $safe_name;
+		}
+
+		return 'tool_' . substr( hash( 'sha256', $tool_name ), 0, 12 );
+	}
+
+	/**
 	 * Convert Data Machine's canonical provider-message array into a wp-ai-client message DTO.
 	 *
 	 * Walks all content blocks (text, file, image_url) and builds a full
@@ -306,9 +356,9 @@ class RequestBuilder {
 	 * @param array $message Provider-message array.
 	 * @return \WordPress\AiClient\Messages\DTO\Message|null Message DTO, or null when the shape is unsupported.
 	 */
-	private static function wpAiClientHistoryMessage( array $message ): ?\WordPress\AiClient\Messages\DTO\Message {
+	private static function wpAiClientHistoryMessage( array $message, array $provider_tool_name_map = array() ): ?\WordPress\AiClient\Messages\DTO\Message {
 		$role  = (string) ( $message['role'] ?? '' );
-		$parts = self::wpAiClientMessagePartsFromMessage( $message );
+		$parts = self::wpAiClientMessagePartsFromMessage( $message, $provider_tool_name_map );
 		if ( empty( $parts ) ) {
 			return null;
 		}
@@ -340,7 +390,7 @@ class RequestBuilder {
 	 * @param array $messages Canonical message envelopes.
 	 * @return array{prompt:string,prompt_parts:array<int,\WordPress\AiClient\Messages\DTO\MessagePart>,system_parts:array<int,string>,history:array<int,\WordPress\AiClient\Messages\DTO\Message>}
 	 */
-	private static function wpAiClientPromptContext( array $messages ): array {
+	private static function wpAiClientPromptContext( array $messages, array $provider_tool_name_map = array() ): array {
 		$prompt_index = null;
 		$prompt       = '';
 		$prompt_parts = array();
@@ -363,7 +413,7 @@ class RequestBuilder {
 				continue;
 			}
 
-			$candidate_parts = self::wpAiClientMessagePartsFromMessage( $message );
+			$candidate_parts = self::wpAiClientMessagePartsFromMessage( $message, $provider_tool_name_map );
 			if ( ! empty( $candidate_parts ) ) {
 				$prompt_index = $index;
 				$prompt_parts = $candidate_parts;
@@ -377,7 +427,7 @@ class RequestBuilder {
 				continue;
 			}
 
-			$history_message = self::wpAiClientHistoryMessage( $message );
+			$history_message = self::wpAiClientHistoryMessage( $message, $provider_tool_name_map );
 			if ( null !== $history_message ) {
 				$history[] = $history_message;
 			}
@@ -397,7 +447,7 @@ class RequestBuilder {
 	 * @param array $message Canonical message envelope or legacy role/content message.
 	 * @return array<int,\WordPress\AiClient\Messages\DTO\MessagePart>
 	 */
-	private static function wpAiClientMessagePartsFromMessage( array $message ): array {
+	private static function wpAiClientMessagePartsFromMessage( array $message, array $provider_tool_name_map = array() ): array {
 		try {
 			$envelope = \AgentsAPI\AI\WP_Agent_Message::normalize( $message );
 		} catch ( \Throwable $e ) {
@@ -410,6 +460,7 @@ class RequestBuilder {
 
 		if ( \AgentsAPI\AI\WP_Agent_Message::TYPE_TOOL_CALL === $type ) {
 			$tool_name = isset( $payload['tool_name'] ) ? (string) $payload['tool_name'] : '';
+			$provider_tool_name = '' !== $tool_name ? ( $provider_tool_name_map[ $tool_name ] ?? self::providerSafeToolName( $tool_name ) ) : '';
 			$call_id   = isset( $metadata['tool_call_id'] ) ? (string) $metadata['tool_call_id'] : '';
 			if ( '' === $call_id ) {
 				$call_id = isset( $payload['tool_call_id'] ) ? (string) $payload['tool_call_id'] : '';
@@ -423,7 +474,7 @@ class RequestBuilder {
 				new \WordPress\AiClient\Messages\DTO\MessagePart(
 					new \WordPress\AiClient\Tools\DTO\FunctionCall(
 						'' !== $call_id ? $call_id : null,
-						'' !== $tool_name ? $tool_name : null,
+						'' !== $provider_tool_name ? $provider_tool_name : null,
 						$parameters
 					)
 				),
@@ -432,6 +483,7 @@ class RequestBuilder {
 
 		if ( \AgentsAPI\AI\WP_Agent_Message::TYPE_TOOL_RESULT === $type ) {
 			$tool_name = isset( $payload['tool_name'] ) ? (string) $payload['tool_name'] : '';
+			$provider_tool_name = '' !== $tool_name ? ( $provider_tool_name_map[ $tool_name ] ?? self::providerSafeToolName( $tool_name ) ) : '';
 			$call_id   = isset( $metadata['tool_call_id'] ) ? (string) $metadata['tool_call_id'] : '';
 			if ( '' === $call_id ) {
 				$call_id = isset( $payload['tool_call_id'] ) ? (string) $payload['tool_call_id'] : '';
@@ -444,7 +496,7 @@ class RequestBuilder {
 				new \WordPress\AiClient\Messages\DTO\MessagePart(
 					new \WordPress\AiClient\Tools\DTO\FunctionResponse(
 						'' !== $call_id ? $call_id : null,
-						'' !== $tool_name ? $tool_name : null,
+						'' !== $provider_tool_name ? $provider_tool_name : null,
 						$payload
 					)
 				),

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -869,7 +869,7 @@ function datamachine_build_provider_turn_adapter(
 
 		/** @var \WordPress\AiClient\Results\DTO\GenerativeAiResult $ai_result */
 		$ai_result       = $ai_response;
-		$tool_calls      = datamachine_extract_tool_calls( $ai_result );
+		$tool_calls      = datamachine_restore_canonical_tool_call_names( datamachine_extract_tool_calls( $ai_result ), $tools );
 		$ai_content      = RequestBuilder::resultText( $ai_result );
 		$last_tool_calls = $tool_calls;
 		foreach ( $tool_calls as $tool_call ) {
@@ -990,6 +990,7 @@ function datamachine_build_provider_turn_adapter(
 
 		return array(
 			'content'               => $ai_content,
+			'tool_calls'            => array(),
 			'continuation_messages' => $continuation_messages,
 			'request_metadata'      => $request_metadata,
 			'usage'                 => $turn_usage,
@@ -2140,6 +2141,30 @@ function datamachine_extract_tool_calls( $result ): array {
 	}
 
 	return datamachine_dedupe_tool_calls( $tool_calls );
+}
+
+/**
+ * Restore canonical tool names after provider-safe aliases return from wp-ai-client.
+ *
+ * @param array<int,array{name:string,parameters:array,id:mixed}> $tool_calls Tool calls from the provider result.
+ * @param array<string,array<string,mixed>>                      $tools      Canonical tool declarations.
+ * @return array<int,array{name:string,parameters:array,id:mixed}> Tool calls keyed to canonical runtime tool names.
+ */
+function datamachine_restore_canonical_tool_call_names( array $tool_calls, array $tools ): array {
+	if ( empty( $tool_calls ) || empty( $tools ) ) {
+		return $tool_calls;
+	}
+
+	$provider_to_canonical = array_flip( RequestBuilder::providerToolNameMap( $tools ) );
+	foreach ( $tool_calls as &$tool_call ) {
+		$provider_name = (string) ( $tool_call['name'] ?? '' );
+		if ( isset( $provider_to_canonical[ $provider_name ] ) ) {
+			$tool_call['name'] = $provider_to_canonical[ $provider_name ];
+		}
+	}
+	unset( $tool_call );
+
+	return $tool_calls;
 }
 
 /**

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -243,7 +243,7 @@ function datamachine_run_conversation(
 	try {
 		$result = WP_Agent_Conversation_Loop::run(
 			$messages,
-			null,
+			$provider_turn_adapter,
 			array(
 				'max_turns'             => $max_turns,
 				'budgets'               => array( $turn_budget ),

--- a/tests/Unit/Engine/AI/RequestBuilderMultimodalTest.php
+++ b/tests/Unit/Engine/AI/RequestBuilderMultimodalTest.php
@@ -315,14 +315,14 @@ class RequestBuilderMultimodalTest extends TestCase {
 		$function_call = $context['history'][1]->getParts()[0]->getFunctionCall();
 		$this->assertNotNull( $function_call, 'Assistant tool call converts to a function call part' );
 		$this->assertSame( 'call_123', $function_call->getId() );
-		$this->assertSame( 'client/filesystem-write', $function_call->getName() );
+		$this->assertSame( 'client_filesystem-write', $function_call->getName() );
 		$this->assertSame( array( 'path' => 'index.html' ), $function_call->getArgs() );
 
 		$this->assertCount( 1, $context['prompt_parts'], 'Latest tool result becomes the current prompt part' );
 		$function_response = $context['prompt_parts'][0]->getFunctionResponse();
 		$this->assertNotNull( $function_response, 'Tool result converts to a function response part' );
 		$this->assertSame( 'call_123', $function_response->getId() );
-		$this->assertSame( 'client/filesystem-write', $function_response->getName() );
+		$this->assertSame( 'client_filesystem-write', $function_response->getName() );
 		$this->assertTrue( $function_response->getResponse()['success'] );
 	}
 

--- a/tests/chat-session-canonical-path-smoke.php
+++ b/tests/chat-session-canonical-path-smoke.php
@@ -74,8 +74,8 @@ $assert(
 );
 
 $assert(
-	false !== strpos( $conversation_loop, "WP_Agent_Conversation_Loop::run(\n\t\t\t\$messages,\n\t\t\tnull," ),
-	'Data Machine lets the Agents API loop wrap the provider turn adapter'
+	false !== strpos( $conversation_loop, "WP_Agent_Conversation_Loop::run(\n\t\t\t\$messages,\n\t\t\t\$provider_turn_adapter," ),
+	'Data Machine passes its callable provider turn adapter to the Agents API loop'
 );
 
 $assert(

--- a/tests/request-builder-tool-transcript-smoke.php
+++ b/tests/request-builder-tool-transcript-smoke.php
@@ -52,14 +52,14 @@ datamachine_request_builder_tool_transcript_assert( $context['history'][1] insta
 $function_call = $context['history'][1]->getParts()[0]->getFunctionCall();
 datamachine_request_builder_tool_transcript_assert( null !== $function_call, 'Assistant tool call converts to a function call part.' );
 datamachine_request_builder_tool_transcript_assert( 'call_123' === $function_call->getId(), 'Function call id is preserved.' );
-datamachine_request_builder_tool_transcript_assert( 'client/filesystem-write' === $function_call->getName(), 'Function call name is preserved.' );
+datamachine_request_builder_tool_transcript_assert( 'client_filesystem-write' === $function_call->getName(), 'Function call name is provider-safe.' );
 datamachine_request_builder_tool_transcript_assert( array( 'path' => 'index.html' ) === $function_call->getArgs(), 'Function call parameters are preserved.' );
 
 datamachine_request_builder_tool_transcript_assert( 1 === count( $context['prompt_parts'] ), 'Latest tool result becomes the current prompt part.' );
 $function_response = $context['prompt_parts'][0]->getFunctionResponse();
 datamachine_request_builder_tool_transcript_assert( null !== $function_response, 'Tool result converts to a function response part.' );
 datamachine_request_builder_tool_transcript_assert( 'call_123' === $function_response->getId(), 'Function response id is preserved.' );
-datamachine_request_builder_tool_transcript_assert( 'client/filesystem-write' === $function_response->getName(), 'Function response name is preserved.' );
+datamachine_request_builder_tool_transcript_assert( 'client_filesystem-write' === $function_response->getName(), 'Function response name is provider-safe.' );
 datamachine_request_builder_tool_transcript_assert( true === $function_response->getResponse()['success'], 'Function response payload is preserved.' );
 
 echo "RequestBuilder tool transcript smoke passed.\n";


### PR DESCRIPTION
## Summary
- Converts canonical Data Machine tool IDs such as `client/filesystem-write` to provider-safe function names before dispatching through wp-ai-client.
- Maps provider-safe aliases back to canonical tool names before Agents API mediates tool execution.
- Ensures natural no-tool final turns return `tool_calls: []` so mediated loops stay on the canonical Agents API path.

## Verification
- `php tests/request-builder-tool-transcript-smoke.php`
- `php tests/chat-session-canonical-path-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`
- `php tests/agent-bundle-runner-contract-smoke.php`

## Evidence
- Studio Web Workflow Bench live verification no longer fails with OpenAI `Invalid 'tools[0].name'`.
- Follow-up live verification no longer fails with `invalid_agent_conversation_result: messages must be an array` after a natural final assistant turn.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed provider tool-name and natural-final-turn contract failures, drafted the Data Machine alias mapping and mediated final-turn fix, and ran targeted verification for Chris to review.