### PR TITLE
Fix direct tool metadata recorder payloads

### DIFF
--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1989,7 +1989,12 @@ function datamachine_tool_result_record_values( array $entry, array $fields ): a
 	$values               = array();
 	$result               = is_array( $entry['result'] ?? null ) ? $entry['result'] : $entry;
 	$nested_result        = is_array( $result['result'] ?? null ) ? $result['result'] : array();
-	$tool_result_data     = is_array( $entry['tool_result_data'] ?? null ) ? $entry['tool_result_data'] : ( is_array( $result['tool_result_data'] ?? null ) ? $result['tool_result_data'] : array() );
+	$metadata             = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
+	$tool_result_data     = datamachine_first_tool_result_data_container(
+		is_array( $entry['tool_result_data'] ?? null ) ? $entry['tool_result_data'] : array(),
+		is_array( $result['tool_result_data'] ?? null ) ? $result['tool_result_data'] : array(),
+		is_array( $metadata['tool_result_data'] ?? null ) ? $metadata['tool_result_data'] : array()
+	);
 	$tool_result_envelope = is_array( $entry['tool_result_envelope'] ?? null ) ? $entry['tool_result_envelope'] : ( is_array( $result['tool_result_envelope'] ?? null ) ? $result['tool_result_envelope'] : array() );
 	$envelope_result      = is_array( $tool_result_envelope['result'] ?? null ) ? $tool_result_envelope['result'] : array();
 	$source               = array(
@@ -1998,7 +2003,7 @@ function datamachine_tool_result_record_values( array $entry, array $fields ): a
 		'result'               => $result,
 		'tool_result_data'     => $tool_result_data,
 		'tool_result_envelope' => $tool_result_envelope,
-		'metadata'             => is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array(),
+		'metadata'             => $metadata,
 	);
 
 	foreach ( $fields as $field => $selector ) {
@@ -2014,6 +2019,20 @@ function datamachine_tool_result_record_values( array $entry, array $fields ): a
 	}
 
 	return $values;
+}
+
+/**
+ * @param array<string,mixed> ...$candidates Candidate tool result data containers.
+ * @return array<string,mixed>
+ */
+function datamachine_first_tool_result_data_container( array ...$candidates ): array {
+	foreach ( $candidates as $candidate ) {
+		if ( ! empty( $candidate ) ) {
+			return $candidate;
+		}
+	}
+
+	return array();
 }
 
 /**

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -218,6 +218,42 @@ $recorded_envelope_merge = $GLOBALS['datamachine_bundle_runner_engine_data_merge
 datamachine_bundle_runner_assert( 'static/issue-468-design-direction' === ( $recorded_envelope_merge['data']['static_site_agent']['branch'] ?? null ), 'tool recorder maps branch from wrapped tool_result_data', $failures, $passes );
 datamachine_bundle_runner_assert( 'https://github.com/chubes4/wp-site-generator/pull/470' === ( $recorded_envelope_merge['data']['static_site_agent']['pr_url'] ?? null ), 'tool recorder maps PR URL from wrapped tool_result_data', $failures, $passes );
 
+$GLOBALS['datamachine_bundle_runner_engine_data_merges'] = array();
+\DataMachine\Engine\AI\datamachine_record_tool_results_to_engine_data(
+	array(
+		'job_id'         => 79,
+		'tool_recorders' => array(
+			array(
+				'tool'   => 'create_github_issue',
+				'record' => array(
+					'engine_key' => 'design_agent',
+					'fields'     => array(
+						'issue_number' => 'tool_result_data.issue_number',
+						'issue_url'    => 'tool_result_data.issue_url',
+					),
+				),
+			),
+		),
+	),
+	array(
+		array(
+			'tool_name' => 'create_github_issue',
+			'result'    => array(
+				'success'  => true,
+				'metadata' => array(
+					'tool_result_data' => array(
+						'issue_number' => 516,
+						'issue_url'    => 'https://github.com/chubes4/wp-site-generator/issues/516',
+					),
+				),
+			),
+		),
+	)
+);
+$recorded_direct_tool_merge = $GLOBALS['datamachine_bundle_runner_engine_data_merges'][0] ?? array();
+datamachine_bundle_runner_assert( 516 === ( $recorded_direct_tool_merge['data']['design_agent']['issue_number'] ?? null ), 'tool recorder maps issue number from direct tool metadata payload', $failures, $passes );
+datamachine_bundle_runner_assert( 'https://github.com/chubes4/wp-site-generator/issues/516' === ( $recorded_direct_tool_merge['data']['design_agent']['issue_url'] ?? null ), 'tool recorder maps issue URL from direct tool metadata payload', $failures, $passes );
+
 echo "\n[3b] Runner applies run-scoped flow step patches\n";
 $workflow_from_bundle_flow = $runner_reflection->getMethod( 'workflow_from_bundle_flow' );
 $patched_workflow          = $workflow_from_bundle_flow->invoke(


### PR DESCRIPTION
## Summary
- Record tool result metadata payloads exposed as `result.metadata.tool_result_data` so direct runtime tools can populate engine data.
- Add smoke coverage for `create_github_issue` recorder selectors using `tool_result_data.issue_number` and `tool_result_data.issue_url`.

## Testing
- `php -l inc/Engine/AI/conversation-loop.php`
- `php -l tests/agent-bundle-runner-contract-smoke.php`
- `php tests/agent-bundle-runner-contract-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the recorder payload shape, drafted the patch and regression test, and ran targeted verification for Chris to review.