### PR TITLE
Fix direct tool result envelope recorders

### DIFF
--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1993,7 +1993,8 @@ function datamachine_tool_result_record_values( array $entry, array $fields ): a
 	$tool_result_data     = datamachine_first_tool_result_data_container(
 		is_array( $entry['tool_result_data'] ?? null ) ? $entry['tool_result_data'] : array(),
 		is_array( $result['tool_result_data'] ?? null ) ? $result['tool_result_data'] : array(),
-		is_array( $metadata['tool_result_data'] ?? null ) ? $metadata['tool_result_data'] : array()
+		is_array( $metadata['tool_result_data'] ?? null ) ? $metadata['tool_result_data'] : array(),
+		$nested_result
 	);
 	$tool_result_envelope = is_array( $entry['tool_result_envelope'] ?? null ) ? $entry['tool_result_envelope'] : ( is_array( $result['tool_result_envelope'] ?? null ) ? $result['tool_result_envelope'] : array() );
 	$envelope_result      = is_array( $tool_result_envelope['result'] ?? null ) ? $tool_result_envelope['result'] : array();

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -254,6 +254,41 @@ $recorded_direct_tool_merge = $GLOBALS['datamachine_bundle_runner_engine_data_me
 datamachine_bundle_runner_assert( 516 === ( $recorded_direct_tool_merge['data']['design_agent']['issue_number'] ?? null ), 'tool recorder maps issue number from direct tool metadata payload', $failures, $passes );
 datamachine_bundle_runner_assert( 'https://github.com/chubes4/wp-site-generator/issues/516' === ( $recorded_direct_tool_merge['data']['design_agent']['issue_url'] ?? null ), 'tool recorder maps issue URL from direct tool metadata payload', $failures, $passes );
 
+$GLOBALS['datamachine_bundle_runner_engine_data_merges'] = array();
+\DataMachine\Engine\AI\datamachine_record_tool_results_to_engine_data(
+	array(
+		'job_id'         => 80,
+		'tool_recorders' => array(
+			array(
+				'tool'   => 'create_github_issue',
+				'record' => array(
+					'engine_key' => 'design_agent',
+					'fields'     => array(
+						'issue_number' => 'tool_result_data.issue_number',
+						'issue_url'    => 'tool_result_data.issue_url',
+					),
+				),
+			),
+		),
+	),
+	array(
+		array(
+			'tool_name' => 'create_github_issue',
+			'result'    => array(
+				'success' => true,
+				'result'  => array(
+					'kind'         => 'issue',
+					'issue_number' => 522,
+					'issue_url'    => 'https://github.com/chubes4/wp-site-generator/issues/522',
+				),
+			),
+		),
+	)
+);
+$recorded_direct_envelope_merge = $GLOBALS['datamachine_bundle_runner_engine_data_merges'][0] ?? array();
+datamachine_bundle_runner_assert( 522 === ( $recorded_direct_envelope_merge['data']['design_agent']['issue_number'] ?? null ), 'tool recorder maps issue number from direct result envelope payload', $failures, $passes );
+datamachine_bundle_runner_assert( 'https://github.com/chubes4/wp-site-generator/issues/522' === ( $recorded_direct_envelope_merge['data']['design_agent']['issue_url'] ?? null ), 'tool recorder maps issue URL from direct result envelope payload', $failures, $passes );
+
 echo "\n[3b] Runner applies run-scoped flow step patches\n";
 $workflow_from_bundle_flow = $runner_reflection->getMethod( 'workflow_from_bundle_flow' );
 $patched_workflow          = $workflow_from_bundle_flow->invoke(


### PR DESCRIPTION
## Summary
- Treat direct tool result envelopes (`result.result`) as recorder `tool_result_data` when no explicit projected payload exists.
- Add regression coverage for `create_github_issue` selectors reading `tool_result_data.issue_number` and `tool_result_data.issue_url` from direct result envelopes.

## Testing
- `php -l inc/Engine/AI/conversation-loop.php`
- `php -l tests/agent-bundle-runner-contract-smoke.php`
- `php tests/agent-bundle-runner-contract-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the WPSG loop artifact payload, identified the remaining direct result envelope recorder gap, drafted the fix and regression test, and ran targeted verification for Chris to review.