### PR TITLE
Update Block Format Bridge dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=8.2",
 		"wordpress/agents-api": "dev-main",
 		"woocommerce/action-scheduler": "^3.9",
-		"chubes4/block-format-bridge": "^0.6"
+		"chubes4/block-format-bridge": "^0.8"
 	},
 	"require-dev": {
 		"php-stubs/wordpress-stubs": "^6.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49b177c57ab84bed2d5a57b6262ff60c",
+    "content-hash": "d2d6f0b91d3e4bd6482dede51af142d5",
     "packages": [
         {
             "name": "chubes4/block-format-bridge",
-            "version": "v0.6.6",
+            "version": "v0.8.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/chubes4/block-format-bridge.git",
-                "reference": "535cb7bf36dee34cfe8394d66fa506d6c1d06dca"
+                "url": "git@github.com:chubes4/block-format-bridge.git",
+                "reference": "a77266bd18461cd6157acd8b96d1343c232f7bcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/535cb7bf36dee34cfe8394d66fa506d6c1d06dca",
-                "reference": "535cb7bf36dee34cfe8394d66fa506d6c1d06dca",
+                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/a77266bd18461cd6157acd8b96d1343c232f7bcf",
+                "reference": "a77266bd18461cd6157acd8b96d1343c232f7bcf",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,7 @@
                 "php": "^8.1"
             },
             "require-dev": {
-                "chubes4/html-to-blocks-converter": "^0.6",
+                "chubes4/html-to-blocks-converter": "dev-main",
                 "humbug/php-scoper": "^0.18.19"
             },
             "type": "wordpress-plugin",
@@ -51,11 +51,7 @@
             ],
             "description": "WordPress plugin orchestrating bidirectional content format conversion (HTML, Blocks, Markdown) via a unified adapter API.",
             "homepage": "https://github.com/chubes4/block-format-bridge",
-            "support": {
-                "source": "https://github.com/chubes4/block-format-bridge/tree/v0.6.6",
-                "issues": "https://github.com/chubes4/block-format-bridge/issues"
-            },
-            "time": "2026-04-30T03:18:01+00:00"
+            "time": "2026-06-07T20:03:54+00:00"
         },
         {
             "name": "dflydev/dot-access-data",


### PR DESCRIPTION
## Summary
- Update Data Machine's Block Format Bridge constraint from `^0.6` to `^0.8`.
- Refresh the lockfile to consume `chubes4/block-format-bridge` `v0.8.1`, which includes the h2bc static toggle chrome conversion.
- Avoid Data Machine shadowing newer BFB copies from downstream plugins with the older `v0.6.6` bundle.

## Verification
- `php tests/content-format-abilities-smoke.php && php tests/content-format-convert-filter-smoke.php && php tests/content-format-helper-smoke.php`
- `studio wp --skip-plugins=data-machine,static-site-importer eval 'require_once "/Users/chubes/Developer/data-machine@refresh-bfb-toggle-chrome/data-machine.php"; ...'` confirmed Data Machine resolves BFB from the worktree vendor path and converts static nav toggle chrome with `html=0`.

Note: `php tests/bfb-substrate-bundle-smoke.php` passed its BFB assertions, then hit an existing standalone-test shim gap for `wp_has_ability_category()` in the bundled Agents API ability registration path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updated the Composer dependency, verified the runtime BFB path, and ran focused smoke checks. Chris remains responsible for review and acceptance.