### PR TITLE
fix: register wake_briefing_enabled in the settings allowlist

### DIFF
--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -103,6 +103,7 @@ class SettingsAbilities {
 						'jobs_per_page'                  => array( 'type' => 'integer' ),
 						'site_context_enabled'           => array( 'type' => 'boolean' ),
 						'daily_memory_enabled'           => array( 'type' => 'boolean' ),
+						'wake_briefing_enabled'          => array( 'type' => 'boolean' ),
 						'default_provider'               => array( 'type' => 'string' ),
 						'default_model'                  => array( 'type' => 'string' ),
 						'mode_models'                    => array(
@@ -369,6 +370,7 @@ class SettingsAbilities {
 				'jobs_per_page'                           => $settings['jobs_per_page'] ?? 50,
 				'site_context_enabled'                    => $settings['site_context_enabled'] ?? false,
 				'daily_memory_enabled'                    => $settings['daily_memory_enabled'] ?? false,
+				'wake_briefing_enabled'                   => $settings['wake_briefing_enabled'] ?? false,
 				'default_provider'                        => $settings['default_provider'] ?? '',
 				'default_model'                           => $settings['default_model'] ?? '',
 				'mode_models'                             => $settings['mode_models'] ?? array(),
@@ -449,6 +451,11 @@ class SettingsAbilities {
 		if ( isset( $input['daily_memory_enabled'] ) ) {
 			$all_settings['daily_memory_enabled'] = (bool) $input['daily_memory_enabled'];
 			$handled_keys[]                       = 'daily_memory_enabled';
+		}
+
+		if ( isset( $input['wake_briefing_enabled'] ) ) {
+			$all_settings['wake_briefing_enabled'] = (bool) $input['wake_briefing_enabled'];
+			$handled_keys[]                        = 'wake_briefing_enabled';
 		}
 
 		if ( isset( $input['default_provider'] ) ) {


### PR DESCRIPTION
## Summary

The `wake_briefing` task (v0.141.0, #2557/#2567) declares `setting_key => wake_briefing_enabled` and its recurring schedule gates on it, but the key was never added to `SettingsAbilities`. So `wp datamachine settings set wake_briefing_enabled 1` is rejected with "not a recognized setting key" and the hourly schedule can't be toggled through the normal settings path.

Found while deploying + enabling the feature on prod — had to set the value through the underlying mechanism instead.

## Fix

Registers `wake_briefing_enabled` in the three places `daily_memory_enabled` already lives in `SettingsAbilities.php`:
1. Input schema (`'type' => 'boolean'`)
2. Settings read defaults (`?? false`)
3. Save handler (cast + handled-keys)

Now the hourly `wake_briefing` schedule can be enabled/disabled like every other task toggle.

## Verification

- `php -l` clean; **homeboy lint (PHPCS + PHPStan) passes, 0 findings.**
- Mirrors the exact pattern of `daily_memory_enabled` (the adjacent task toggle).

Refs #2557.

## Constraints honored

- Conventional commit (`fix:`).
- No CHANGELOG edits / version bumps (homeboy-managed).