### PR TITLE
Prioritize Data Machine runtime bundle imports

### DIFF
--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -85,7 +85,7 @@ add_action( 'plugins_loaded', array( WpAiClientCache::class, 'install' ), 20 );
 AbilityScopePermissionFilter::register();
 ContentFormat::register();
 
-add_filter( 'wp_agent_runtime_import_bundle', array( AgentAbilities::class, 'importRuntimeAgentBundle' ), 10, 4 );
+add_filter( 'wp_agent_runtime_import_bundle', array( AgentAbilities::class, 'importRuntimeAgentBundle' ), 5, 4 );
 add_filter( 'wp_agent_runtime_run_bundle', array( AgentAbilities::class, 'runRuntimeAgentBundle' ), 10, 4 );
 
 add_filter(

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -64,6 +64,7 @@ foreach ( array(
 ) as $needle => $label ) {
 	datamachine_bundle_runner_contains( $abilities, $needle, $label, $failures, $passes );
 }
+datamachine_bundle_runner_contains( $bootstrap, "add_filter( 'wp_agent_runtime_import_bundle', array( AgentAbilities::class, 'importRuntimeAgentBundle' ), 5, 4 )", 'Data Machine importer runs before generic runtime bundle fallback', $failures, $passes );
 datamachine_bundle_runner_contains( $bootstrap, "add_filter( 'wp_agent_runtime_run_bundle'", 'Data Machine registers generic runtime run seam', $failures, $passes );
 
 echo "\n[2] Runner projects bundles to ephemeral workflows\n";


### PR DESCRIPTION
## Summary
- run Data Machine's runtime bundle importer before the generic Agents API fallback
- add smoke coverage for the import hook priority

## Testing
- php tests/agent-bundle-runner-contract-smoke.php
- php tests/runtime-agent-bundle-reconcile-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runtime bundle import ordering issue, drafted the hook priority fix, and ran focused smoke tests. Chris remains responsible for review and merge.
