### PR TITLE
fix: delegate context bindings to Agents API

### DIFF
--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -60,10 +60,10 @@ class ToolExecutor {
 		int $agent_id = 0,
 		array $client_context = array()
 	): array {
-		$core            = new WP_Agent_Tool_Execution_Core();
-		$execution       = new ToolExecutionCore();
-		$tool_parameters = self::applyDeclaredContextBindings( $tool_name, $tool_parameters, $available_tools, $payload, $client_context );
-		$prepared        = $core->prepareWP_Agent_Tool_Call( $tool_name, $tool_parameters, $available_tools, $payload );
+		$core           = new WP_Agent_Tool_Execution_Core();
+		$execution      = new ToolExecutionCore();
+		$tool_context   = array_merge( $payload, $client_context );
+		$prepared       = $core->prepareWP_Agent_Tool_Call( $tool_name, $tool_parameters, $available_tools, $tool_context );
 		if ( empty( $prepared['ready'] ) ) {
 			unset( $prepared['ready'] );
 			return $prepared;
@@ -164,7 +164,7 @@ class ToolExecutor {
 		}
 
 		// Policy is 'direct' — execute the tool normally.
-		$tool_result = $core->executePreparedTool( $tool_call, $tool_def, $execution, $payload );
+		$tool_result = $core->executePreparedTool( $tool_call, $tool_def, $execution, $tool_context );
 
 		// Automatic post origin tracking — applies to every tool whose result
 		// contains an extractable post_id. This covers both handler tools
@@ -183,51 +183,6 @@ class ToolExecutor {
 		}
 
 		return $tool_result;
-	}
-
-	/**
-	 * Apply explicit client_context_bindings from Data Machine invocation context.
-	 *
-	 * Agents API also applies this contract, but Data Machine may receive a
-	 * prepared tool call from the substrate after host-only fields have been
-	 * normalized. Re-applying the same explicit declaration against the original
-	 * Data Machine payload keeps handler tools from depending on model-supplied
-	 * job identifiers without falling back to ambient key-name matching.
-	 *
-	 * @param string $tool_name       Tool name to execute.
-	 * @param array  $tool_parameters Parameters from the model/substrate.
-	 * @param array  $available_tools Available tool definitions.
-	 * @param array  $payload         Data Machine loop payload.
-	 * @param array  $client_context  Nested client context from the payload.
-	 * @return array Parameters with declared context bindings applied.
-	 */
-	private static function applyDeclaredContextBindings( string $tool_name, array $tool_parameters, array $available_tools, array $payload, array $client_context ): array {
-		$tool_def = is_array( $available_tools[ $tool_name ] ?? null ) ? $available_tools[ $tool_name ] : array();
-		$bindings = is_array( $tool_def['client_context_bindings'] ?? null ) ? $tool_def['client_context_bindings'] : array();
-		if ( empty( $bindings ) ) {
-			return $tool_parameters;
-		}
-
-		$context = array_merge( $payload, $client_context );
-		foreach ( $bindings as $parameter_name => $context_key ) {
-			if ( is_int( $parameter_name ) ) {
-				$parameter_name = $context_key;
-			}
-
-			if ( ! is_string( $parameter_name ) || '' === $parameter_name || ! is_string( $context_key ) || '' === $context_key ) {
-				continue;
-			}
-			if ( array_key_exists( $parameter_name, $tool_parameters ) && null !== $tool_parameters[ $parameter_name ] && '' !== $tool_parameters[ $parameter_name ] ) {
-				continue;
-			}
-			if ( ! array_key_exists( $context_key, $context ) || null === $context[ $context_key ] || '' === $context[ $context_key ] ) {
-				continue;
-			}
-
-			$tool_parameters[ $parameter_name ] = $context[ $context_key ];
-		}
-
-		return $tool_parameters;
 	}
 
 	/**

--- a/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
+++ b/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
@@ -179,6 +179,64 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'query', $result['error'] );
 	}
 
+	public function test_execute_tool_uses_agents_api_for_declared_client_context_bindings(): void {
+		$available_tools = array(
+			'bound_context_tool' => array(
+				'class'                   => TestToolHandler::class,
+				'method'                  => 'handle_tool_call',
+				'parameters'              => array(
+					'query' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+				),
+				'client_context_bindings' => array( 'query' => 'search_query' ),
+			),
+		);
+
+		$result = ToolExecutor::executeTool(
+			'bound_context_tool',
+			array(),
+			$available_tools,
+			array(),
+			'chat',
+			0,
+			array( 'search_query' => 'from client context' )
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'from client context', $result['result']['data']['query'] ?? null );
+	}
+
+	public function test_execute_tool_does_not_satisfy_required_params_from_ambient_context_keys(): void {
+		$available_tools = array(
+			'unbound_context_tool' => array(
+				'class'      => TestToolHandler::class,
+				'method'     => 'handle_tool_call',
+				'parameters' => array(
+					'query' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+				),
+			),
+		);
+
+		$result = ToolExecutor::executeTool(
+			'unbound_context_tool',
+			array(),
+			$available_tools,
+			array(),
+			'chat',
+			0,
+			array( 'query' => 'ambient context value' )
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'missing_required_parameters', $result['metadata']['error_type'] ?? null );
+		$this->assertSame( array( 'query' ), $result['metadata']['missing_parameters'] ?? array() );
+	}
+
 	public function test_execute_tool_returns_error_for_missing_tool(): void {
 		$result = ToolExecutor::executeTool(
 			'missing_tool',

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -126,19 +126,30 @@ class WP_Abilities_Registry {
 require_once __DIR__ . '/../inc/Core/PluginSettings.php';
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-access-policy.php';
+require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Approvals/class-wp-agent-approval-memory-store.php';
+require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Approvals/class-wp-agent-null-approval-memory-store.php';
+require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Workspace/class-wp-agent-workspace-scope.php';
+require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-citation-metadata.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-declaration.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-parameters.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-call.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-result.php';
+require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-action-policy.php';
+require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-action-policy-provider.php';
+require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-action-policy-resolver.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-executor.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-execution-core.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-policy-filter.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-policy.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-source-registry.php';
 require_once __DIR__ . '/../inc/Core/AbilityResult.php';
+require_once __DIR__ . '/../inc/Core/WordPress/PostTracking.php';
+require_once __DIR__ . '/../inc/Core/Workspace/WordPressWorkspaceScope.php';
 require_once __DIR__ . '/../inc/Abilities/PermissionHelper.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Execution/ToolExecutionCore.php';
+require_once __DIR__ . '/../inc/Engine/AI/Actions/DataMachineModeActionPolicyProvider.php';
+require_once __DIR__ . '/../inc/Engine/AI/Actions/ActionPolicyResolver.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolExecutor.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineAgentToolPolicyProvider.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineMandatoryToolPolicy.php';
@@ -197,6 +208,19 @@ class SourcePolicyToolManager extends ToolManager {
 		}
 
 		return array();
+	}
+}
+
+class SourceSmokeBoundContextTool {
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		unset( $tool_def );
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'query' => $parameters['query'] ?? '',
+			),
+		);
 	}
 }
 
@@ -532,9 +556,57 @@ $direct_execute  = strpos( $executor_source, 'executePreparedTool' );
 assert_source_equals( true, false !== $client_guard, 'ToolExecutor has an explicit client-executor guard', $failures, $passes );
 assert_source_equals( true, false !== $client_guard && false !== $policy_resolver && $client_guard < $policy_resolver, 'client-executor guard runs before action-policy/direct execution setup', $failures, $passes );
 assert_source_equals( true, false !== $client_guard && false !== $direct_execute && $client_guard < $direct_execute, 'client-executor guard runs before direct PHP tool execution', $failures, $passes );
-assert_source_equals( true, false !== strpos( $executor_source, 'applyDeclaredContextBindings' ), 'ToolExecutor reapplies explicit context bindings before execution', $failures, $passes );
-assert_source_equals( true, false !== strpos( $executor_source, "tool_def['client_context_bindings']" ), 'ToolExecutor reads declared client_context_bindings only', $failures, $passes );
+assert_source_equals( false, false !== strpos( $executor_source, 'applyDeclaredContextBindings' ), 'ToolExecutor does not duplicate Agents API context binding application', $failures, $passes );
+assert_source_equals( false, false !== strpos( $executor_source, "tool_def['client_context_bindings']" ), 'ToolExecutor does not read client_context_bindings locally', $failures, $passes );
 assert_source_equals( true, false !== strpos( $loop_source, 'datamachine_payload_with_client_context_bindings' ), 'conversation loop mirrors safe run fields into client_context', $failures, $passes );
+
+$bound_server_tools = array(
+	'bound_context_tool'   => array(
+		'class'                   => SourceSmokeBoundContextTool::class,
+		'method'                  => 'handle_tool_call',
+		'parameters'              => array(
+			'query' => array(
+				'type'     => 'string',
+				'required' => true,
+			),
+		),
+		'client_context_bindings' => array( 'query' => 'search_query' ),
+	),
+	'unbound_context_tool' => array(
+		'class'      => SourceSmokeBoundContextTool::class,
+		'method'     => 'handle_tool_call',
+		'parameters' => array(
+			'query' => array(
+				'type'     => 'string',
+				'required' => true,
+			),
+		),
+	),
+);
+
+$bound_server_execution = ToolExecutor::executeTool(
+	'bound_context_tool',
+	array(),
+	$bound_server_tools,
+	array(),
+	ToolPolicyResolver::MODE_CHAT,
+	0,
+	array( 'search_query' => 'from client context' )
+);
+assert_source_equals( true, $bound_server_execution['success'] ?? null, 'declared client_context_bindings satisfy required parameters through Agents API', $failures, $passes );
+assert_source_equals( 'from client context', $bound_server_execution['result']['data']['query'] ?? null, 'bound client context value reaches server tool parameters', $failures, $passes );
+
+$unbound_server_execution = ToolExecutor::executeTool(
+	'unbound_context_tool',
+	array(),
+	$bound_server_tools,
+	array(),
+	ToolPolicyResolver::MODE_CHAT,
+	0,
+	array( 'query' => 'ambient context value' )
+);
+assert_source_equals( false, $unbound_server_execution['success'] ?? null, 'ambient context keys do not satisfy required parameters without explicit bindings', $failures, $passes );
+assert_source_equals( 'missing_required_parameters', $unbound_server_execution['metadata']['error_type'] ?? null, 'unbound ambient context produces the required-parameter error', $failures, $passes );
 
 $client_execution = ToolExecutor::executeTool(
 	'client/select_block',


### PR DESCRIPTION
## Summary
- Remove duplicate `client_context_bindings` application from Data Machine `ToolExecutor`.
- Pass flattened host context into Agents API tool preparation/execution so explicit bindings from `client_context` still resolve there.
- Add focused smoke/unit coverage for declared bindings and the no ambient key-name matching security requirement.

Fixes #2592.

## Tests
- `php tests/tool-source-registry-smoke.php` passed: all 61 assertions.
- `php -l inc/Engine/AI/Tools/ToolExecutor.php` passed.
- `php -l tests/tool-source-registry-smoke.php` passed.
- `php -l tests/Unit/AI/Tools/ToolExecutorValidationTest.php` passed.

## Blockers
- `homeboy test data-machine --skip-lint -- tests/Unit/AI/Tools/ToolExecutorValidationTest.php` could not run PHPUnit because the selected Homeboy Lab/WP Codebox runner failed before tests with `WP Codebox recipe builder export buildWordPressPhpunitRecipe is unavailable` and missing `@automattic/wp-codebox-core`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the ToolExecutor binding handoff change, updated focused tests, ran local smoke/syntax verification, and drafted this PR. Chris remains responsible for review and testing.