### PR TITLE
fix: degrade orphaned-pipeline and external HTTP failures to warning

### DIFF
--- a/inc/Core/Database/Pipelines/Pipelines.php
+++ b/inc/Core/Database/Pipelines/Pipelines.php
@@ -688,13 +688,23 @@ class Pipelines extends BaseRepository {
 		$pipeline_config = $pipeline['pipeline_config'] ?? array();
 
 		if ( ! isset( $pipeline_config[ $pipeline_step_id ] ) ) {
+			// A flow referencing a step that is absent from the pipeline config is a
+			// recoverable config state, not a runtime fault — most commonly an
+			// orphaned flow whose pipeline lost its step definitions (empty config)
+			// while the flow kept firing. Degrade gracefully and log at `warning`
+			// rather than emitting a per-run `error` on every scheduled lookup.
+			$is_orphaned_empty_config = empty( $pipeline_config );
+
 			do_action(
 				'datamachine_log',
-				'error',
-				'Pipeline step not found in pipeline config',
+				'warning',
+				$is_orphaned_empty_config
+					? 'Pipeline config empty, flow orphaned — skipping step lookup'
+					: 'Pipeline step not found in pipeline config',
 				array(
 					'pipeline_step_id' => $pipeline_step_id,
 					'pipeline_id'      => $pipeline_id,
+					'empty_config'     => $is_orphaned_empty_config,
 				)
 			);
 			return array();

--- a/inc/Core/HttpClient.php
+++ b/inc/Core/HttpClient.php
@@ -405,9 +405,13 @@ class HttpClient {
 			$error_message .= ': ' . $error_details;
 		}
 
+		// A received-but-non-2xx response is expected external attrition when probing
+		// third-party sites (403 bot-blocks, 404 moved pages, 5xx origin-down) and is
+		// not a Data-Machine-side fault. Log it at `warning`; true transport failures
+		// (no response at all) are handled separately in handleWpError() and stay `error`.
 		do_action(
 			'datamachine_log',
-			'error',
+			'warning',
 			'HTTP Request: Error response',
 			array(
 				'context'      => $context,


### PR DESCRIPTION
## Summary

Two log-level resilience fixes so a lost-config pipeline and normal web-scraping attrition stop flooding the error log and burying real signal. This is the **code-resilience layer** for #2589 — the pipeline-20 ("Nashville Events") prod **data** state was already restored separately by hand; these changes ensure the bug class cannot recur silently.

Fixes #2589

## Changes

### 1. Graceful handling of empty/missing pipeline_config with attached flows
**File:** `inc/Core/Database/Pipelines/Pipelines.php` (`get_pipeline_step_config()`, ~line 690)

- Downgraded the per-lookup log from `error` → `warning`. A flow referencing a step absent from the pipeline config is a **recoverable config state, not a runtime fault**, so it should not emit a per-run `ERROR` on every scheduled interval forever.
- When the pipeline config is **entirely empty** (the orphaned-flow condition that produced ~121 ERROR/day on blog 7), the message now reads `Pipeline config empty, flow orphaned — skipping step lookup` and the log context carries `empty_config => true`, making the orphan state obvious at a glance.

**Approach chosen: downgrade-to-warning (not auto-pause).** Auto-pausing a flow from inside a read-only config accessor (`get_pipeline_step_config()` is called from abilities, tool manager, and directive code paths — not just the scheduler) would be an invasive side effect in the wrong layer and risks pausing flows during transient/partial reads. The smallest change that achieves graceful degradation is to stop the per-run ERROR spam and clearly label the orphan/empty-config condition at `warning`. This matches the issue's stated fallback ("at minimum downgrade the level to warning and make the message clearly state the orphan/empty-config condition") without over-engineering a new auto-pause subsystem.

### 2. External HTTP fetch failures log at `warning`, not `error`
**File:** `inc/Core/HttpClient.php` (`handleHttpError()`, ~line 408)

- Changed the "HTTP Request: Error response" log from `error` → `warning`.

**How the expected-external vs DM-side-fault distinction is made:** the request method (`request()`, ~line 96–105) already branches cleanly:
- `is_wp_error( $response )` → `handleWpError()` → logs `error` `"HTTP Request: Connection failed"` — a **true transport failure** (no response received at all: DNS, timeout, connection refused). **Left at `error`.**
- A response **was received** but is non-2xx → `handleHttpError()` → logs `"HTTP Request: Error response"`. This is **expected external attrition** when fetch handlers probe 177+ third-party venue URLs (403 bot-blocks, 404 moved pages, 5xx origin-down). **Downgraded to `warning`.**

So the existing two-branch structure already separates "remote site answered with a non-2xx" from "we never reached the remote site" — only the former is downgraded; the latter stays `error`. No logging-API redesign.

## Verification

- `php -l` clean on both changed files.
- `homeboy lint --changed-since origin/main data-machine` → **phpcs 0 findings, phpstan passed, eslint 0 findings, overall status: passed.**
- The pre-existing `duplicate-tool-call-mode-aware-smoke.php` failure (`wp_json_encode()` undefined, #2588) is unrelated to these changes — neither touched file is involved.

## Note on prod data

Pipeline 20's empty-config prod **data** was already restored separately. This PR adds only the code-resilience layer so an orphaned/empty-config pipeline (Finding 1) and normal scraper attrition (Finding 2) degrade to `warning` instead of silently spamming the error log.