### PR TITLE
Use Agents API identity store for agent materialization

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -814,12 +814,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "1325b46960a30db624c47a6bece06aef54f62f8a"
+                "reference": "995e94571dc26ffd3d0fe3eda95ddf25ff1fe215"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/1325b46960a30db624c47a6bece06aef54f62f8a",
-                "reference": "1325b46960a30db624c47a6bece06aef54f62f8a",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/995e94571dc26ffd3d0fe3eda95ddf25ff1fe215",
+                "reference": "995e94571dc26ffd3d0fe3eda95ddf25ff1fe215",
                 "shasum": ""
             },
             "require": {
@@ -874,12 +874,14 @@
                     "php tests/approval-resolver-contract-smoke.php",
                     "php tests/pending-action-abilities-smoke.php",
                     "php tests/identity-smoke.php",
+                    "php tests/identity-store-materialization-smoke.php",
                     "php tests/memory-metadata-contract-smoke.php",
                     "php tests/memory-store-resolver-smoke.php",
                     "php tests/ability-lifecycle-bridge-smoke.php",
                     "php tests/pre-execute-approval-smoke.php",
                     "php tests/approval-action-value-shape-smoke.php",
                     "php tests/workspace-scope-smoke.php",
+                    "php tests/safe-execution-workspace-smoke.php",
                     "php tests/compaction-item-smoke.php",
                     "php tests/compaction-conservation-smoke.php",
                     "php tests/conversation-runner-contracts-smoke.php",
@@ -905,6 +907,7 @@
                     "php tests/conversation-loop-budgets-smoke.php",
                     "php tests/channels-smoke.php",
                     "php tests/chat-run-control-smoke.php",
+                    "php tests/task-execution-smoke.php",
                     "php tests/frontend-chat-rest-smoke.php",
                     "php tests/agents-chat-jsonrpc-route-smoke.php",
                     "php tests/agents-dispatch-message-ability-smoke.php",
@@ -935,7 +938,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-06-04T22:12:12+00:00"
+            "time": "2026-06-08T03:16:09+00:00"
         }
     ],
     "packages-dev": [

--- a/inc/Core/Bootstrap/DependencyChecker.php
+++ b/inc/Core/Bootstrap/DependencyChecker.php
@@ -15,14 +15,14 @@ defined( 'ABSPATH' ) || exit;
  */
 class DependencyChecker {
 
-	public const CHECK_AGENTS_API_ACCESS_STORE = 'agents_api_access_store';
+	public const CHECK_AGENTS_API_ACCESS_STORE   = 'agents_api_access_store';
 	public const CHECK_AGENTS_API_IDENTITY_STORE = 'agents_api_identity_store';
-	public const CHECK_ACTION_SCHEDULER        = 'action_scheduler';
-	public const CHECK_FILESYSTEM_WRITES       = 'filesystem_writes';
-	public const CHECK_IMAP                    = 'imap';
-	public const CHECK_PENDING_ACTION_OBSERVER = 'pending_action_observer';
-	public const CHECK_WORDPRESS_ABILITIES     = 'wordpress_abilities';
-	public const CHECK_ZIP_ARCHIVE             = 'zip_archive';
+	public const CHECK_ACTION_SCHEDULER          = 'action_scheduler';
+	public const CHECK_FILESYSTEM_WRITES         = 'filesystem_writes';
+	public const CHECK_IMAP                      = 'imap';
+	public const CHECK_PENDING_ACTION_OBSERVER   = 'pending_action_observer';
+	public const CHECK_WORDPRESS_ABILITIES       = 'wordpress_abilities';
+	public const CHECK_ZIP_ARCHIVE               = 'zip_archive';
 
 	/**
 	 * Run a named dependency/capability check.
@@ -32,15 +32,15 @@ class DependencyChecker {
 	 */
 	public static function has( string $check ): bool {
 		return match ( $check ) {
-			self::CHECK_AGENTS_API_ACCESS_STORE => self::has_agents_api_access_store_contracts(),
+			self::CHECK_AGENTS_API_ACCESS_STORE   => self::has_agents_api_access_store_contracts(),
 			self::CHECK_AGENTS_API_IDENTITY_STORE => self::has_agents_api_identity_store_contracts(),
-			self::CHECK_ACTION_SCHEDULER        => self::has_action_scheduler(),
-			self::CHECK_FILESYSTEM_WRITES       => self::has_filesystem_writes(),
-			self::CHECK_IMAP                    => self::has_imap(),
-			self::CHECK_PENDING_ACTION_OBSERVER => self::has_pending_action_observer_contract(),
-			self::CHECK_WORDPRESS_ABILITIES     => self::has_wordpress_abilities(),
-			self::CHECK_ZIP_ARCHIVE             => self::has_zip_archive(),
-			default                             => false,
+			self::CHECK_ACTION_SCHEDULER          => self::has_action_scheduler(),
+			self::CHECK_FILESYSTEM_WRITES         => self::has_filesystem_writes(),
+			self::CHECK_IMAP                      => self::has_imap(),
+			self::CHECK_PENDING_ACTION_OBSERVER   => self::has_pending_action_observer_contract(),
+			self::CHECK_WORDPRESS_ABILITIES       => self::has_wordpress_abilities(),
+			self::CHECK_ZIP_ARCHIVE               => self::has_zip_archive(),
+			default                               => false,
 		};
 	}
 

--- a/inc/Core/Bootstrap/DependencyChecker.php
+++ b/inc/Core/Bootstrap/DependencyChecker.php
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit;
 class DependencyChecker {
 
 	public const CHECK_AGENTS_API_ACCESS_STORE = 'agents_api_access_store';
+	public const CHECK_AGENTS_API_IDENTITY_STORE = 'agents_api_identity_store';
 	public const CHECK_ACTION_SCHEDULER        = 'action_scheduler';
 	public const CHECK_FILESYSTEM_WRITES       = 'filesystem_writes';
 	public const CHECK_IMAP                    = 'imap';
@@ -32,6 +33,7 @@ class DependencyChecker {
 	public static function has( string $check ): bool {
 		return match ( $check ) {
 			self::CHECK_AGENTS_API_ACCESS_STORE => self::has_agents_api_access_store_contracts(),
+			self::CHECK_AGENTS_API_IDENTITY_STORE => self::has_agents_api_identity_store_contracts(),
 			self::CHECK_ACTION_SCHEDULER        => self::has_action_scheduler(),
 			self::CHECK_FILESYSTEM_WRITES       => self::has_filesystem_writes(),
 			self::CHECK_IMAP                    => self::has_imap(),
@@ -49,6 +51,15 @@ class DependencyChecker {
 	 */
 	public static function has_agents_api_access_store_contracts(): bool {
 		return interface_exists( 'WP_Agent_Access_Store' ) && interface_exists( 'WP_Agent_Principal_Access_Store' );
+	}
+
+	/**
+	 * Determine whether the Agents API identity-store contracts are available.
+	 *
+	 * @return bool True when the adapter can safely register.
+	 */
+	public static function has_agents_api_identity_store_contracts(): bool {
+		return interface_exists( '\AgentsAPI\Core\Identity\WP_Agent_Identity_Store' ) && class_exists( '\AgentsAPI\Core\Identity\WP_Agent_Materialized_Identity' );
 	}
 
 	/**

--- a/inc/Core/Identity/AgentIdentityStoreAdapter.php
+++ b/inc/Core/Identity/AgentIdentityStoreAdapter.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Agents API identity-store adapter for Data Machine agents.
+ *
+ * @package DataMachine\Core\Identity
+ */
+
+namespace DataMachine\Core\Identity;
+
+use AgentsAPI\Core\Identity\WP_Agent_Identity_Scope;
+use AgentsAPI\Core\Identity\WP_Agent_Identity_Store;
+use AgentsAPI\Core\Identity\WP_Agent_Materialized_Identity;
+use DataMachine\Abilities\File\ScaffoldAbilities;
+use DataMachine\Core\Database\Agents\AgentAccess;
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\FilesRepository\DirectoryManager;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Exposes Data Machine's existing agent table through Agents API.
+ */
+class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
+
+	private Agents $agents_repository;
+
+	public function __construct( ?Agents $agents_repository = null ) {
+		$this->agents_repository = $agents_repository ?? new Agents();
+	}
+
+	/**
+	 * Register this adapter as the Agents API identity store when no host supplied one.
+	 */
+	public static function register(): void {
+		add_filter( 'wp_agent_identity_store', array( self::class, 'filter_identity_store' ) );
+	}
+
+	/**
+	 * Provide Data Machine's store unless another host already provided one.
+	 *
+	 * @param mixed $store Existing filtered store.
+	 * @return mixed
+	 */
+	public static function filter_identity_store( $store ) {
+		if ( $store instanceof WP_Agent_Identity_Store ) {
+			return $store;
+		}
+
+		static $adapter = null;
+		if ( null === $adapter ) {
+			$adapter = new self();
+		}
+
+		return $adapter;
+	}
+
+	/** @inheritDoc */
+	public function resolve( WP_Agent_Identity_Scope $scope ): ?WP_Agent_Materialized_Identity {
+		$row = $this->agents_repository->get_by_slug( $scope->normalize()->agent_slug );
+		return is_array( $row ) ? $this->identity_from_row( $row, $scope ) : null;
+	}
+
+	/** @inheritDoc */
+	public function get( int $identity_id ): ?WP_Agent_Materialized_Identity {
+		$row = $this->agents_repository->get_agent( $identity_id );
+		return is_array( $row ) ? $this->identity_from_row( $row ) : null;
+	}
+
+	/** @inheritDoc */
+	public function materialize( WP_Agent_Identity_Scope $scope, array $default_config = array(), array $meta = array() ): WP_Agent_Materialized_Identity {
+		$scope    = $scope->normalize();
+		$existing = $this->agents_repository->get_by_slug( $scope->agent_slug );
+		if ( is_array( $existing ) ) {
+			return $this->identity_from_row( $existing, $scope );
+		}
+
+		$agent_id = $this->agents_repository->create_if_missing(
+			$scope->agent_slug,
+			$this->label_from_meta( $meta, $scope->agent_slug ),
+			$scope->owner_user_id,
+			$default_config
+		);
+
+		$row = $this->agents_repository->get_agent( $agent_id );
+		if ( ! is_array( $row ) ) {
+			$row = array(
+				'agent_id'     => $agent_id,
+				'agent_slug'   => $scope->agent_slug,
+				'agent_name'   => $this->label_from_meta( $meta, $scope->agent_slug ),
+				'owner_id'     => $scope->owner_user_id,
+				'agent_config' => $default_config,
+			);
+		}
+
+		$this->after_created( $agent_id, $scope, $meta );
+
+		return $this->identity_from_row( $row, $scope, $meta );
+	}
+
+	/** @inheritDoc */
+	public function update( WP_Agent_Materialized_Identity $identity ): WP_Agent_Materialized_Identity {
+		$this->agents_repository->update_agent( $identity->id, array( 'agent_config' => $identity->config ) );
+		return $this->get( $identity->id ) ?? $identity;
+	}
+
+	/** @inheritDoc */
+	public function delete( WP_Agent_Identity_Scope $scope ): bool {
+		unset( $scope );
+		return false;
+	}
+
+	/**
+	 * Run Data Machine side effects for newly-created identities.
+	 *
+	 * @param int                     $agent_id Created Data Machine agent ID.
+	 * @param WP_Agent_Identity_Scope $scope    Normalized identity scope.
+	 * @param array<string,mixed>     $meta     Materialization metadata.
+	 */
+	private function after_created( int $agent_id, WP_Agent_Identity_Scope $scope, array $meta ): void {
+		if ( class_exists( AgentAccess::class ) ) {
+			( new AgentAccess() )->bootstrap_owner_access( $agent_id, $scope->owner_user_id );
+		}
+
+		if ( class_exists( DirectoryManager::class ) ) {
+			$dir_mgr   = new DirectoryManager();
+			$agent_dir = $dir_mgr->get_agent_identity_directory( $scope->agent_slug );
+			$dir_mgr->ensure_directory_exists( $agent_dir );
+		}
+
+		$scaffold = ScaffoldAbilities::get_ability();
+		if ( $scaffold ) {
+			$scaffold->execute(
+				array(
+					'layer'      => 'agent',
+					'agent_slug' => $scope->agent_slug,
+					'agent_id'   => $agent_id,
+				)
+			);
+		}
+
+		do_action( 'datamachine_registered_agent_reconciled', $agent_id, $scope->agent_slug, $meta['datamachine_definition'] ?? $meta );
+	}
+
+	/**
+	 * Convert a Data Machine agent row to the Agents API identity value object.
+	 *
+	 * @param array<string,mixed>          $row   Agent row.
+	 * @param WP_Agent_Identity_Scope|null $scope Optional requested scope.
+	 * @param array<string,mixed>          $meta  Additional metadata.
+	 */
+	private function identity_from_row( array $row, ?WP_Agent_Identity_Scope $scope = null, array $meta = array() ): WP_Agent_Materialized_Identity {
+		$scope ??= new WP_Agent_Identity_Scope(
+			(string) ( $row['agent_slug'] ?? '' ),
+			(int) ( $row['owner_id'] ?? 0 )
+		);
+
+		return new WP_Agent_Materialized_Identity(
+			(int) ( $row['agent_id'] ?? 0 ),
+			$scope->normalize(),
+			is_array( $row['agent_config'] ?? null ) ? $row['agent_config'] : array(),
+			array_merge(
+				$meta,
+				array(
+					'datamachine_agent_id' => (int) ( $row['agent_id'] ?? 0 ),
+					'datamachine_owner_id' => (int) ( $row['owner_id'] ?? 0 ),
+				)
+			),
+			$this->timestamp_from_row( $row, 'created_at' ),
+			$this->timestamp_from_row( $row, 'updated_at' )
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $meta Agent metadata.
+	 */
+	private function label_from_meta( array $meta, string $fallback_slug ): string {
+		$label = is_scalar( $meta['label'] ?? null ) ? trim( (string) $meta['label'] ) : '';
+		return '' !== $label ? $label : $fallback_slug;
+	}
+
+	/**
+	 * @param array<string,mixed> $row Agent row.
+	 */
+	private function timestamp_from_row( array $row, string $field ): ?int {
+		$value = $row[ $field ] ?? null;
+		if ( ! is_scalar( $value ) || '' === (string) $value ) {
+			return null;
+		}
+
+		$timestamp = strtotime( (string) $value );
+		return false === $timestamp ? null : $timestamp;
+	}
+}

--- a/inc/Engine/Agents/AgentMaterializer.php
+++ b/inc/Engine/Agents/AgentMaterializer.php
@@ -10,9 +10,8 @@
 
 namespace DataMachine\Engine\Agents;
 
-use DataMachine\Abilities\File\ScaffoldAbilities;
-use DataMachine\Core\Database\Agents\AgentAccess;
-use DataMachine\Core\Database\Agents\Agents;
+use AgentsAPI\Core\Identity\WP_Agent_Identity_Scope;
+use DataMachine\Core\Identity\AgentIdentityStoreAdapter;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 
 defined( 'ABSPATH' ) || exit;
@@ -46,74 +45,50 @@ class AgentMaterializer {
 			'skipped'  => array(),
 		);
 
-		if ( ! class_exists( Agents::class ) ) {
+		if ( ! function_exists( 'wp_get_agent' ) || ! function_exists( 'wp_materialize_agent_identity' ) || ! class_exists( AgentIdentityStoreAdapter::class ) ) {
 			return $summary;
 		}
 
-		$repo = new Agents();
+		$store = new AgentIdentityStoreAdapter();
 
 		foreach ( $definitions as $slug => $def ) {
-			$existing = $repo->get_by_slug( $slug );
-			if ( $existing ) {
-				$summary['existing'][] = $slug;
-				continue;
-			}
-
 			$owner_id = self::resolve_owner( $def );
 			if ( $owner_id <= 0 ) {
 				$summary['skipped'][] = $slug;
 				continue;
 			}
 
-			$agent_id = $repo->create_if_missing(
-				$slug,
-				$def['label'],
-				$owner_id,
-				$def['default_config']
-			);
+			$scope = new WP_Agent_Identity_Scope( $slug, $owner_id );
+			if ( null !== $store->resolve( $scope ) ) {
+				$summary['existing'][] = $slug;
+				continue;
+			}
 
-			if ( $agent_id <= 0 ) {
+			$agent = wp_get_agent( $slug );
+			if ( ! $agent instanceof \WP_Agent ) {
 				$summary['skipped'][] = $slug;
 				continue;
 			}
 
-			// Bootstrap owner access (mirrors AgentAbilities::createAgent()).
-			if ( class_exists( AgentAccess::class ) ) {
-				( new AgentAccess() )->bootstrap_owner_access( $agent_id, $owner_id );
-			}
+			$identity = wp_materialize_agent_identity(
+				$agent,
+				$store,
+				array(
+					'owner_user_id' => $owner_id,
+					'meta'          => array_merge(
+						is_array( $def['meta'] ?? null ) ? $def['meta'] : array(),
+						array(
+							'label'                  => (string) ( $def['label'] ?? $slug ),
+							'datamachine_definition' => $def,
+						)
+					),
+				)
+			);
 
-			// Ensure agent directory exists.
-			if ( class_exists( DirectoryManager::class ) ) {
-				$dir_mgr   = new DirectoryManager();
-				$agent_dir = $dir_mgr->get_agent_identity_directory( $slug );
-				$dir_mgr->ensure_directory_exists( $agent_dir );
+			if ( ! $identity instanceof \AgentsAPI\Core\Identity\WP_Agent_Materialized_Identity ) {
+				$summary['skipped'][] = $slug;
+				continue;
 			}
-
-			// Scaffold agent-layer memory files (SOUL.md, MEMORY.md, etc.).
-			// The scaffold filter consults AgentRegistry for a matching
-			// `memory_seeds` entry per filename and substitutes bundled
-			// content when present.
-			$scaffold = ScaffoldAbilities::get_ability();
-			if ( $scaffold ) {
-				$scaffold->execute(
-					array(
-						'layer'      => 'agent',
-						'agent_slug' => $slug,
-						'agent_id'   => $agent_id,
-					)
-				);
-			}
-
-			/**
-			 * Fires after a registered agent is materialized into the database.
-			 *
-			 * @since 0.71.0
-			 *
-			 * @param int    $agent_id Newly created agent row ID.
-			 * @param string $slug     Registered slug.
-			 * @param array  $def      Full registration definition.
-			 */
-			do_action( 'datamachine_registered_agent_reconciled', $agent_id, $slug, $def );
 
 			$summary['created'][] = $slug;
 		}

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -78,6 +78,7 @@ use DataMachine\Core\Content\ContentFormat;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Auth\AgentAccessStoreAdapter;
 use DataMachine\Core\Bootstrap\DependencyChecker;
+use DataMachine\Core\Identity\AgentIdentityStoreAdapter;
 use DataMachine\Core\OAuth\HttpBasicAuthProvider;
 use DataMachine\Core\PluginSettings;
 
@@ -111,6 +112,10 @@ add_filter(
 
 if ( DependencyChecker::has( DependencyChecker::CHECK_AGENTS_API_ACCESS_STORE ) ) {
 	AgentAccessStoreAdapter::register();
+}
+
+if ( DependencyChecker::has( DependencyChecker::CHECK_AGENTS_API_IDENTITY_STORE ) ) {
+	AgentIdentityStoreAdapter::register();
 }
 
 add_filter(

--- a/tests/agent-registry-materializer-smoke.php
+++ b/tests/agent-registry-materializer-smoke.php
@@ -74,6 +74,16 @@ namespace DataMachine\Core\Database\Agents {
 			return self::$rows[ $agent_slug ] ?? null;
 		}
 
+		public function get_agent( int $agent_id ): ?array {
+			foreach ( self::$rows as $row ) {
+				if ( (int) ( $row['agent_id'] ?? 0 ) === $agent_id ) {
+					return $row;
+				}
+			}
+
+			return null;
+		}
+
 		public function create_if_missing( string $agent_slug, string $agent_name, int $owner_id, array $agent_config = array() ): int {
 			if ( isset( self::$rows[ $agent_slug ] ) ) {
 				return (int) self::$rows[ $agent_slug ]['agent_id'];
@@ -89,6 +99,22 @@ namespace DataMachine\Core\Database\Agents {
 			);
 
 			return $agent_id;
+		}
+
+		public function update_agent( int $agent_id, array $data ): bool {
+			foreach ( self::$rows as &$row ) {
+				if ( (int) ( $row['agent_id'] ?? 0 ) !== $agent_id ) {
+					continue;
+				}
+
+				if ( array_key_exists( 'agent_config', $data ) ) {
+					$row['agent_config'] = $data['agent_config'];
+				}
+
+				return true;
+			}
+
+			return false;
 		}
 	}
 
@@ -149,6 +175,7 @@ namespace DataMachine\Abilities\File {
 namespace {
 	require_once __DIR__ . '/agents-api-loader.php';
 	datamachine_tests_require_agents_api();
+	require_once __DIR__ . '/../inc/Core/Identity/AgentIdentityStoreAdapter.php';
 	require_once __DIR__ . '/../inc/Engine/Agents/AgentMaterializer.php';
 	require_once __DIR__ . '/../inc/Engine/Agents/AgentRegistry.php';
 	require_once __DIR__ . '/../inc/Engine/Agents/datamachine-register-agents.php';
@@ -284,14 +311,16 @@ namespace {
 	assert_agent_materializer_equals( 1, count( ScaffoldAbilities::$ability->calls ), 'existing row does not scaffold again', $failures, $passes );
 
 	echo "\n[4] materializer owns Data Machine side-effect dependencies:\n";
-	$registration_source = (string) file_get_contents( AGENTS_API_PATH . 'inc/register-agents.php' );
+	$registration_source = (string) file_get_contents( AGENTS_API_PATH . 'src/Registry/register-agents.php' );
 	$registry_source     = (string) file_get_contents( __DIR__ . '/../inc/Engine/Agents/AgentRegistry.php' );
 	$materializer_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/Agents/AgentMaterializer.php' );
 	assert_agent_materializer_equals( false, false !== strpos( $registration_source, 'datamachine_register_agent' ), 'Agents API registration helper does not define Data Machine legacy wrapper', $failures, $passes );
 	assert_agent_materializer_equals( false, false !== strpos( $registry_source, 'Core\\Database\\Agents' ), 'registry no longer imports agent database repositories', $failures, $passes );
 	assert_agent_materializer_equals( false, false !== strpos( $registry_source, 'ScaffoldAbilities' ), 'registry no longer imports scaffold ability', $failures, $passes );
-	assert_agent_materializer_equals( true, false !== strpos( $materializer_source, 'Core\\Database\\Agents' ), 'materializer owns agent database repositories', $failures, $passes );
-	assert_agent_materializer_equals( true, false !== strpos( $materializer_source, 'ScaffoldAbilities' ), 'materializer owns scaffold ability', $failures, $passes );
+	$identity_store_source = (string) file_get_contents( __DIR__ . '/../inc/Core/Identity/AgentIdentityStoreAdapter.php' );
+	assert_agent_materializer_equals( false, false !== strpos( $materializer_source, 'Core\\Database\\Agents' ), 'materializer delegates database storage to identity store adapter', $failures, $passes );
+	assert_agent_materializer_equals( true, false !== strpos( $identity_store_source, 'Core\\Database\\Agents' ), 'identity store adapter owns agent database repositories', $failures, $passes );
+	assert_agent_materializer_equals( true, false !== strpos( $identity_store_source, 'ScaffoldAbilities' ), 'identity store adapter owns scaffold ability', $failures, $passes );
 
 	if ( $failures ) {
 		echo "\nFAILED: " . count( $failures ) . " agent registry/materializer assertions failed.\n";


### PR DESCRIPTION
## Summary
- Add a Data Machine `WP_Agent_Identity_Store` adapter around the existing `datamachine_agents` table.
- Register the adapter through the canonical Agents API `wp_agent_identity_store` resolver.
- Route registered-agent reconciliation through `wp_materialize_agent_identity()` while preserving Data Machine owner access, directory, scaffold, and reconciliation hook side effects.
- Update the bundled Agents API lock to the commit containing the identity-store lifecycle.

Fixes #2593.
Requires Automattic/agents-api#319, now merged.

## Testing
- `php -l inc/Core/Identity/AgentIdentityStoreAdapter.php && php -l inc/Engine/Agents/AgentMaterializer.php && php -l inc/Core/Bootstrap/DependencyChecker.php && php -l inc/bootstrap.php`
- `./vendor/bin/phpcs inc/Core/Identity/AgentIdentityStoreAdapter.php inc/Core/Bootstrap/DependencyChecker.php inc/Engine/Agents/AgentMaterializer.php inc/bootstrap.php tests/agent-registry-materializer-smoke.php`
- `php tests/agent-registry-materializer-smoke.php`
- `php tests/agents-api-persisted-agent-registry-smoke.php`

`composer test` did not run tests: the Homeboy lab runner failed before PHPUnit because `@automattic/wp-codebox-core` was unavailable to the lab recipe builder.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the Data Machine identity-store adapter and reconciliation cleanup; Chris remains responsible for review and validation.