### PR TITLE
test: cover host context binding precedence

### DIFF
--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -62,7 +62,7 @@ class ToolExecutor {
 	): array {
 		$core           = new WP_Agent_Tool_Execution_Core();
 		$execution      = new ToolExecutionCore();
-		$tool_context   = array_merge( $payload, $client_context );
+		$tool_context   = array_merge( $client_context, $payload );
 		$prepared       = $core->prepareWP_Agent_Tool_Call( $tool_name, $tool_parameters, $available_tools, $tool_context );
 		if ( empty( $prepared['ready'] ) ) {
 			unset( $prepared['ready'] );

--- a/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
+++ b/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
@@ -208,6 +208,35 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 		$this->assertSame( 'from client context', $result['result']['data']['query'] ?? null );
 	}
 
+	public function test_execute_tool_prefers_host_payload_for_declared_context_bindings(): void {
+		$available_tools = array(
+			'bound_context_tool' => array(
+				'class'                   => TestToolHandler::class,
+				'method'                  => 'handle_tool_call',
+				'parameters'              => array(
+					'query' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+				),
+				'client_context_bindings' => array( 'query' => 'job_id' ),
+			),
+		);
+
+		$result = ToolExecutor::executeTool(
+			'bound_context_tool',
+			array(),
+			$available_tools,
+			array( 'job_id' => 42 ),
+			'chat',
+			0,
+			array( 'job_id' => 7 )
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 42, $result['result']['data']['query'] ?? null );
+	}
+
 	public function test_execute_tool_does_not_satisfy_required_params_from_ambient_context_keys(): void {
 		$available_tools = array(
 			'unbound_context_tool' => array(

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -596,6 +596,23 @@ $bound_server_execution = ToolExecutor::executeTool(
 assert_source_equals( true, $bound_server_execution['success'] ?? null, 'declared client_context_bindings satisfy required parameters through Agents API', $failures, $passes );
 assert_source_equals( 'from client context', $bound_server_execution['result']['data']['query'] ?? null, 'bound client context value reaches server tool parameters', $failures, $passes );
 
+$payload_host_execution = ToolExecutor::executeTool(
+	'bound_context_tool',
+	array(),
+	array(
+		'bound_context_tool' => array_merge(
+			$bound_server_tools['bound_context_tool'],
+			array( 'client_context_bindings' => array( 'query' => 'job_id' ) )
+		),
+	),
+	array( 'job_id' => 42 ),
+	ToolPolicyResolver::MODE_CHAT,
+	0,
+	array( 'job_id' => 7 )
+);
+assert_source_equals( true, $payload_host_execution['success'] ?? null, 'declared binding can read host payload context values', $failures, $passes );
+assert_source_equals( 42, $payload_host_execution['result']['data']['query'] ?? null, 'host payload values win over same-named client_context values', $failures, $passes );
+
 $unbound_server_execution = ToolExecutor::executeTool(
 	'unbound_context_tool',
 	array(),


### PR DESCRIPTION
## Summary
- Tighten the Data Machine-to-Agents API context handoff so top-level host payload fields win over same-named `client_context` keys.
- Add focused smoke/unit assertions for explicit `client_context_bindings` reading authoritative host payload values.

Follow-up to #2594 after a self-review pass on #2592.

## Tests
- `php tests/tool-source-registry-smoke.php` passed: all 63 assertions.
- `php -l inc/Engine/AI/Tools/ToolExecutor.php` passed.
- `php -l tests/tool-source-registry-smoke.php` passed.
- `php -l tests/Unit/AI/Tools/ToolExecutorValidationTest.php` passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Performed a self-review pass, identified the host/context precedence edge case, implemented the small follow-up, and ran focused verification. Chris remains responsible for review and testing.