### PR TITLE
Fix provider-safe runtime tool aliases

### DIFF
--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -58,12 +58,13 @@ class RequestBuilder {
 		$mode_label       = implode( ',', $modes );
 		$assembled        = self::assemble( $messages, $provider, $model, $tools, $modes, $payload );
 		$request          = $assembled['request'];
-		$provider_request = ProviderRequestAssembler::toProviderRequest( $request );
-		$prompt_context   = self::wpAiClientPromptContext( $request['messages'] ?? array() );
+		$structured_tools       = $assembled['structured_tools'];
+		$provider_tool_aliases  = self::providerToolNameAliases( $structured_tools );
+		$provider_request       = ProviderRequestAssembler::toProviderRequest( $request );
+		$prompt_context         = self::wpAiClientPromptContext( $request['messages'] ?? array(), $provider_tool_aliases['logical_to_provider'] );
 		if ( '' !== $prompt_context['prompt'] ) {
 			$provider_request['prompt'] = $prompt_context['prompt'];
 		}
-		$structured_tools   = $assembled['structured_tools'];
 		$applied_directives = $assembled['applied_directives'];
 		$directive_metadata = $assembled['directive_metadata'];
 
@@ -75,6 +76,9 @@ class RequestBuilder {
 			$model,
 			$mode_label
 		);
+		if ( ! empty( $provider_tool_aliases['logical_to_provider'] ) ) {
+			$request_metadata['tool_name_aliases'] = $provider_tool_aliases;
+		}
 		RequestMetadata::warn_if_oversized( $request_metadata, $payload );
 
 		do_action(
@@ -249,9 +253,10 @@ class RequestBuilder {
 				if ( '' === $name ) {
 					continue;
 				}
+				$provider_name = $provider_tool_aliases['logical_to_provider'][ $name ] ?? $name;
 
 				$function_declarations[] = new \WordPress\AiClient\Tools\DTO\FunctionDeclaration(
-					$name,
+					$provider_name,
 					(string) ( $tool_config['description'] ?? '' ),
 					self::normalizeToolSchema( $tool_config['parameters'] ?? array() )
 				);
@@ -306,9 +311,9 @@ class RequestBuilder {
 	 * @param array $message Provider-message array.
 	 * @return \WordPress\AiClient\Messages\DTO\Message|null Message DTO, or null when the shape is unsupported.
 	 */
-	private static function wpAiClientHistoryMessage( array $message ): ?\WordPress\AiClient\Messages\DTO\Message {
+	private static function wpAiClientHistoryMessage( array $message, array $tool_name_aliases = array() ): ?\WordPress\AiClient\Messages\DTO\Message {
 		$role  = (string) ( $message['role'] ?? '' );
-		$parts = self::wpAiClientMessagePartsFromMessage( $message );
+		$parts = self::wpAiClientMessagePartsFromMessage( $message, $tool_name_aliases );
 		if ( empty( $parts ) ) {
 			return null;
 		}
@@ -340,7 +345,7 @@ class RequestBuilder {
 	 * @param array $messages Canonical message envelopes.
 	 * @return array{prompt:string,prompt_parts:array<int,\WordPress\AiClient\Messages\DTO\MessagePart>,system_parts:array<int,string>,history:array<int,\WordPress\AiClient\Messages\DTO\Message>}
 	 */
-	private static function wpAiClientPromptContext( array $messages ): array {
+	private static function wpAiClientPromptContext( array $messages, array $tool_name_aliases = array() ): array {
 		$prompt_index = null;
 		$prompt       = '';
 		$prompt_parts = array();
@@ -363,7 +368,7 @@ class RequestBuilder {
 				continue;
 			}
 
-			$candidate_parts = self::wpAiClientMessagePartsFromMessage( $message );
+			$candidate_parts = self::wpAiClientMessagePartsFromMessage( $message, $tool_name_aliases );
 			if ( ! empty( $candidate_parts ) ) {
 				$prompt_index = $index;
 				$prompt_parts = $candidate_parts;
@@ -377,7 +382,7 @@ class RequestBuilder {
 				continue;
 			}
 
-			$history_message = self::wpAiClientHistoryMessage( $message );
+			$history_message = self::wpAiClientHistoryMessage( $message, $tool_name_aliases );
 			if ( null !== $history_message ) {
 				$history[] = $history_message;
 			}
@@ -397,7 +402,7 @@ class RequestBuilder {
 	 * @param array $message Canonical message envelope or legacy role/content message.
 	 * @return array<int,\WordPress\AiClient\Messages\DTO\MessagePart>
 	 */
-	private static function wpAiClientMessagePartsFromMessage( array $message ): array {
+	private static function wpAiClientMessagePartsFromMessage( array $message, array $tool_name_aliases = array() ): array {
 		try {
 			$envelope = \AgentsAPI\AI\WP_Agent_Message::normalize( $message );
 		} catch ( \Throwable $e ) {
@@ -410,6 +415,7 @@ class RequestBuilder {
 
 		if ( \AgentsAPI\AI\WP_Agent_Message::TYPE_TOOL_CALL === $type ) {
 			$tool_name = isset( $payload['tool_name'] ) ? (string) $payload['tool_name'] : '';
+			$tool_name = $tool_name_aliases[ $tool_name ] ?? $tool_name;
 			$call_id   = isset( $metadata['tool_call_id'] ) ? (string) $metadata['tool_call_id'] : '';
 			if ( '' === $call_id ) {
 				$call_id = isset( $payload['tool_call_id'] ) ? (string) $payload['tool_call_id'] : '';
@@ -432,6 +438,7 @@ class RequestBuilder {
 
 		if ( \AgentsAPI\AI\WP_Agent_Message::TYPE_TOOL_RESULT === $type ) {
 			$tool_name = isset( $payload['tool_name'] ) ? (string) $payload['tool_name'] : '';
+			$tool_name = $tool_name_aliases[ $tool_name ] ?? $tool_name;
 			$call_id   = isset( $metadata['tool_call_id'] ) ? (string) $metadata['tool_call_id'] : '';
 			if ( '' === $call_id ) {
 				$call_id = isset( $payload['tool_call_id'] ) ? (string) $payload['tool_call_id'] : '';
@@ -748,6 +755,104 @@ class RequestBuilder {
 			'request_options_used'            => false,
 			'curl_hook_installed'             => false,
 		);
+	}
+
+	/**
+	 * Build provider-safe function-name aliases for wp-ai-client tool declarations.
+	 *
+	 * Data Machine and Agents API use slash-bearing logical tool names such as
+	 * `client/filesystem-write`. OpenAI-compatible providers reject those names, so
+	 * the wp-ai-client boundary uses a request-local alias while the conversation
+	 * loop maps returned calls back to the logical tool name before execution.
+	 *
+	 * @param array<string,array<string,mixed>> $tools Structured logical tools.
+	 * @return array{logical_to_provider:array<string,string>,provider_to_logical:array<string,string>}
+	 */
+	public static function providerToolNameAliases( array $tools ): array {
+		$logical_to_provider = array();
+		$provider_to_logical = array();
+		$used               = array();
+
+		foreach ( $tools as $tool_name => $tool_config ) {
+			$logical_name = (string) ( $tool_config['name'] ?? $tool_name );
+			if ( '' === $logical_name ) {
+				continue;
+			}
+
+			$provider_name = self::providerToolName( $logical_name, $tool_config );
+			if ( isset( $used[ $provider_name ] ) && $used[ $provider_name ] !== $logical_name ) {
+				$provider_name = self::uniqueProviderToolName( $provider_name, $logical_name, $used );
+			}
+
+			$used[ $provider_name ] = $logical_name;
+			if ( $provider_name !== $logical_name ) {
+				$logical_to_provider[ $logical_name ] = $provider_name;
+				$provider_to_logical[ $provider_name ] = $logical_name;
+			}
+		}
+
+		return array(
+			'logical_to_provider' => $logical_to_provider,
+			'provider_to_logical' => $provider_to_logical,
+		);
+	}
+
+	/**
+	 * Resolve the provider-facing tool name for one logical tool declaration.
+	 *
+	 * @param string $logical_name Logical tool name.
+	 * @param array<string,mixed> $tool_config Tool declaration.
+	 * @return string Provider-safe tool name.
+	 */
+	private static function providerToolName( string $logical_name, array $tool_config ): string {
+		$runtime_tool_id = is_string( $tool_config['runtime_tool_id'] ?? null ) ? trim( (string) $tool_config['runtime_tool_id'] ) : '';
+		if ( self::isProviderSafeToolName( $runtime_tool_id ) ) {
+			return $runtime_tool_id;
+		}
+
+		if ( self::isProviderSafeToolName( $logical_name ) ) {
+			return $logical_name;
+		}
+
+		$provider_name = preg_replace( '/[^a-zA-Z0-9_-]+/', '_', $logical_name );
+		$provider_name = is_string( $provider_name ) ? trim( $provider_name, '_' ) : '';
+		if ( '' === $provider_name || ! preg_match( '/^[a-zA-Z0-9_]/', $provider_name ) ) {
+			$provider_name = 'tool_' . $provider_name;
+		}
+
+		return self::isProviderSafeToolName( $provider_name ) ? $provider_name : 'tool_' . substr( sha1( $logical_name ), 0, 12 );
+	}
+
+	/**
+	 * Ensure an aliased provider tool name is unique within one request.
+	 *
+	 * @param string $provider_name Base provider name.
+	 * @param string $logical_name Logical tool name.
+	 * @param array<string,string> $used Provider names already assigned.
+	 * @return string Unique provider-safe tool name.
+	 */
+	private static function uniqueProviderToolName( string $provider_name, string $logical_name, array $used ): string {
+		$suffix = '_' . substr( sha1( $logical_name ), 0, 8 );
+		$base   = substr( $provider_name, 0, max( 1, 64 - strlen( $suffix ) ) );
+		$unique = $base . $suffix;
+		$count  = 2;
+		while ( isset( $used[ $unique ] ) ) {
+			$extra  = '_' . $count;
+			$unique = substr( $base, 0, max( 1, 64 - strlen( $suffix ) - strlen( $extra ) ) ) . $suffix . $extra;
+			++$count;
+		}
+
+		return $unique;
+	}
+
+	/**
+	 * Check the OpenAI-compatible provider function-name grammar.
+	 *
+	 * @param string $name Candidate name.
+	 * @return bool Whether the name can be sent as a provider tool/function name.
+	 */
+	private static function isProviderSafeToolName( string $name ): bool {
+		return '' !== $name && 1 === preg_match( '/^[a-zA-Z0-9_-]+$/', $name );
 	}
 
 	/**

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -869,7 +869,7 @@ function datamachine_build_provider_turn_adapter(
 
 		/** @var \WordPress\AiClient\Results\DTO\GenerativeAiResult $ai_result */
 		$ai_result       = $ai_response;
-		$tool_calls      = datamachine_extract_tool_calls( $ai_result );
+		$tool_calls      = datamachine_apply_provider_tool_name_aliases( datamachine_extract_tool_calls( $ai_result ), $request_metadata );
 		$ai_content      = RequestBuilder::resultText( $ai_result );
 		$last_tool_calls = $tool_calls;
 		foreach ( $tool_calls as $tool_call ) {
@@ -2130,6 +2130,31 @@ function datamachine_completion_nudge_diagnostic( array $decision_context, int $
  */
 function datamachine_extract_tool_calls( $result ): array {
 	return \AgentsAPI\AI\WP_Agent_Provider_Turn_Result::extract_tool_calls( $result );
+}
+
+/**
+ * Map provider-safe function names back to Data Machine/Agents API logical names.
+ *
+ * @param array<int,array<string,mixed>> $tool_calls Tool calls extracted from the provider result.
+ * @param array<string,mixed>            $request_metadata Request metadata emitted by RequestBuilder.
+ * @return array<int,array<string,mixed>> Tool calls with logical names restored where aliases exist.
+ */
+function datamachine_apply_provider_tool_name_aliases( array $tool_calls, array $request_metadata ): array {
+	$aliases = $request_metadata['tool_name_aliases']['provider_to_logical'] ?? array();
+	if ( empty( $aliases ) || ! is_array( $aliases ) ) {
+		return $tool_calls;
+	}
+
+	foreach ( $tool_calls as &$tool_call ) {
+		$name = is_string( $tool_call['name'] ?? null ) ? $tool_call['name'] : '';
+		if ( isset( $aliases[ $name ] ) && is_string( $aliases[ $name ] ) && '' !== $aliases[ $name ] ) {
+			$tool_call['provider_name'] = $name;
+			$tool_call['name']          = $aliases[ $name ];
+		}
+	}
+	unset( $tool_call );
+
+	return $tool_calls;
 }
 
 /**

--- a/tests/Unit/Engine/AI/RequestBuilderMultimodalTest.php
+++ b/tests/Unit/Engine/AI/RequestBuilderMultimodalTest.php
@@ -208,7 +208,16 @@ class RequestBuilderMultimodalTest extends TestCase {
 			),
 		);
 
-		$context = $this->invokePrivate( 'wpAiClientPromptContext', array( $messages ) );
+		$aliases = RequestBuilder::providerToolNameAliases(
+			array(
+				'client/filesystem-write' => array(
+					'name'            => 'client/filesystem-write',
+					'runtime_tool_id' => 'filesystem_write',
+				),
+			)
+		);
+
+		$context = $this->invokePrivate( 'wpAiClientPromptContext', array( $messages, $aliases['logical_to_provider'] ) );
 
 		$this->assertSame( array( 'You are an alt-text writer.' ), $context['system_parts'] );
 		$this->assertCount( 1, $context['history'], 'Earlier user turn becomes history' );
@@ -315,15 +324,16 @@ class RequestBuilderMultimodalTest extends TestCase {
 		$function_call = $context['history'][1]->getParts()[0]->getFunctionCall();
 		$this->assertNotNull( $function_call, 'Assistant tool call converts to a function call part' );
 		$this->assertSame( 'call_123', $function_call->getId() );
-		$this->assertSame( 'client/filesystem-write', $function_call->getName() );
+		$this->assertSame( 'filesystem_write', $function_call->getName() );
 		$this->assertSame( array( 'path' => 'index.html' ), $function_call->getArgs() );
 
 		$this->assertCount( 1, $context['prompt_parts'], 'Latest tool result becomes the current prompt part' );
 		$function_response = $context['prompt_parts'][0]->getFunctionResponse();
 		$this->assertNotNull( $function_response, 'Tool result converts to a function response part' );
 		$this->assertSame( 'call_123', $function_response->getId() );
-		$this->assertSame( 'client/filesystem-write', $function_response->getName() );
+		$this->assertSame( 'filesystem_write', $function_response->getName() );
 		$this->assertTrue( $function_response->getResponse()['success'] );
+		$this->assertSame( 'client/filesystem-write', $aliases['provider_to_logical']['filesystem_write'] );
 	}
 
 	/**

--- a/tests/request-builder-tool-transcript-smoke.php
+++ b/tests/request-builder-tool-transcript-smoke.php
@@ -43,8 +43,17 @@ $messages = array(
 	),
 );
 
+$aliases = RequestBuilder::providerToolNameAliases(
+	array(
+		'client/filesystem-write' => array(
+			'name'            => 'client/filesystem-write',
+			'runtime_tool_id' => 'filesystem_write',
+		),
+	)
+);
+
 $reflection = new ReflectionMethod( RequestBuilder::class, 'wpAiClientPromptContext' );
-$context = $reflection->invokeArgs( null, array( $messages ) );
+$context = $reflection->invokeArgs( null, array( $messages, $aliases['logical_to_provider'] ) );
 
 datamachine_request_builder_tool_transcript_assert( 2 === count( $context['history'] ), 'Initial user prompt and assistant tool call remain in history.' );
 datamachine_request_builder_tool_transcript_assert( $context['history'][1] instanceof ModelMessage, 'Assistant tool call remains a model message.' );
@@ -52,14 +61,29 @@ datamachine_request_builder_tool_transcript_assert( $context['history'][1] insta
 $function_call = $context['history'][1]->getParts()[0]->getFunctionCall();
 datamachine_request_builder_tool_transcript_assert( null !== $function_call, 'Assistant tool call converts to a function call part.' );
 datamachine_request_builder_tool_transcript_assert( 'call_123' === $function_call->getId(), 'Function call id is preserved.' );
-datamachine_request_builder_tool_transcript_assert( 'client/filesystem-write' === $function_call->getName(), 'Function call name is preserved.' );
+datamachine_request_builder_tool_transcript_assert( 'filesystem_write' === $function_call->getName(), 'Function call name uses the provider-safe alias.' );
 datamachine_request_builder_tool_transcript_assert( array( 'path' => 'index.html' ) === $function_call->getArgs(), 'Function call parameters are preserved.' );
 
 datamachine_request_builder_tool_transcript_assert( 1 === count( $context['prompt_parts'] ), 'Latest tool result becomes the current prompt part.' );
 $function_response = $context['prompt_parts'][0]->getFunctionResponse();
 datamachine_request_builder_tool_transcript_assert( null !== $function_response, 'Tool result converts to a function response part.' );
 datamachine_request_builder_tool_transcript_assert( 'call_123' === $function_response->getId(), 'Function response id is preserved.' );
-datamachine_request_builder_tool_transcript_assert( 'client/filesystem-write' === $function_response->getName(), 'Function response name is preserved.' );
+datamachine_request_builder_tool_transcript_assert( 'filesystem_write' === $function_response->getName(), 'Function response name uses the provider-safe alias.' );
 datamachine_request_builder_tool_transcript_assert( true === $function_response->getResponse()['success'], 'Function response payload is preserved.' );
+datamachine_request_builder_tool_transcript_assert( 'client/filesystem-write' === $aliases['provider_to_logical']['filesystem_write'], 'Alias map can restore the logical tool name.' );
+
+if ( function_exists( 'DataMachine\\Engine\\AI\\datamachine_apply_provider_tool_name_aliases' ) ) {
+	$restored = DataMachine\Engine\AI\datamachine_apply_provider_tool_name_aliases(
+		array(
+			array(
+				'name'       => 'filesystem_write',
+				'parameters' => array( 'path' => 'index.html' ),
+			),
+		),
+		array( 'tool_name_aliases' => $aliases )
+	);
+	datamachine_request_builder_tool_transcript_assert( 'client/filesystem-write' === $restored[0]['name'], 'Provider-safe tool calls are restored to logical names before execution.' );
+	datamachine_request_builder_tool_transcript_assert( 'filesystem_write' === $restored[0]['provider_name'], 'Restored calls retain the provider alias for diagnostics.' );
+}
 
 echo "RequestBuilder tool transcript smoke passed.\n";


### PR DESCRIPTION
## Summary
- Adds request-local provider-safe aliases for slash-bearing logical tool names before sending wp-ai-client function declarations.
- Restores provider-returned aliases back to logical Data Machine / Agents API tool names before tool execution.
- Covers transcript/history conversion and alias restoration in the request-builder smoke path.

## Testing
- `php tests/request-builder-tool-transcript-smoke.php`
- `php -l inc/Engine/AI/RequestBuilder.php`
- `php -l inc/Engine/AI/conversation-loop.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the OpenAI-compatible provider tool-name rejection, drafted the Data Machine aliasing fix, and ran targeted local verification. Chris remains responsible for review and merge.