### PR TITLE
Fix completion assertions for runtime tool aliases

### DIFF
--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -77,6 +77,11 @@ class DataMachineCompletionAssertions {
 			$tool_result['_parameters']                    = $tool_parameters;
 			$this->executed_tool_names[]                   = $tool_name;
 			$this->successful_tool_results[ $tool_name ][] = $tool_result;
+
+			foreach ( $this->toolAliases( $tool_name, $tool_def ) as $alias ) {
+				$this->executed_tool_names[]               = $alias;
+				$this->successful_tool_results[ $alias ][] = $tool_result;
+			}
 		}
 
 		$is_handler_tool = is_array( $tool_def ) && isset( $tool_def['handler'] );
@@ -197,7 +202,54 @@ class DataMachineCompletionAssertions {
 			return array();
 		}
 
-		return array_values( array_diff( array_values( array_unique( $required_tool_names ) ), array_keys( $tools ) ) );
+		return array_values( array_diff( array_values( array_unique( $required_tool_names ) ), self::availableToolNames( $tools ) ) );
+	}
+
+	/**
+	 * Return logical and runtime/provider-safe names available for completion assertions.
+	 *
+	 * @param array $tools Available tools keyed by logical tool name.
+	 * @return array<int, string>
+	 */
+	private static function availableToolNames( array $tools ): array {
+		$names = array();
+		foreach ( $tools as $tool_name => $tool_def ) {
+			$logical_name = (string) $tool_name;
+			if ( '' !== $logical_name ) {
+				$names[] = $logical_name;
+			}
+
+			if ( is_array( $tool_def ) ) {
+				foreach ( self::toolAliases( $logical_name, $tool_def ) as $alias ) {
+					$names[] = $alias;
+				}
+			}
+		}
+
+		return array_values( array_unique( array_filter( $names ) ) );
+	}
+
+	/**
+	 * Return assertion aliases for one tool definition.
+	 *
+	 * @param string     $tool_name Logical tool name.
+	 * @param array|null $tool_def Tool definition.
+	 * @return array<int, string>
+	 */
+	private static function toolAliases( string $tool_name, ?array $tool_def ): array {
+		if ( ! is_array( $tool_def ) ) {
+			return array();
+		}
+
+		$aliases = array();
+		foreach ( array( 'name', 'runtime_tool_id' ) as $key ) {
+			$value = is_string( $tool_def[ $key ] ?? null ) ? trim( (string) $tool_def[ $key ] ) : '';
+			if ( '' !== $value && $value !== $tool_name ) {
+				$aliases[] = $value;
+			}
+		}
+
+		return array_values( array_unique( $aliases ) );
 	}
 
 	/**
@@ -335,7 +387,7 @@ class DataMachineCompletionAssertions {
 	private function hasAvailableOutcomePath( array $tools ): bool {
 		foreach ( $this->complete_when_any as $outcome ) {
 			$names = array_map( static fn( array $tool ): string => $tool['name'], $outcome['tools'] );
-			if ( empty( array_diff( $names, array_keys( $tools ) ) ) ) {
+			if ( empty( array_diff( $names, self::availableToolNames( $tools ) ) ) ) {
 				return true;
 			}
 		}

--- a/tests/request-builder-tool-transcript-smoke.php
+++ b/tests/request-builder-tool-transcript-smoke.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/bootstrap-unit.php';
 require_once __DIR__ . '/Unit/Support/WpAiClientTestDoubles.php';
 
 use AgentsAPI\AI\WP_Agent_Message;
+use DataMachine\Engine\AI\DataMachineCompletionAssertions;
 use DataMachine\Engine\AI\RequestBuilder;
 use WordPress\AiClient\Messages\DTO\ModelMessage;
 
@@ -85,5 +86,22 @@ if ( function_exists( 'DataMachine\\Engine\\AI\\datamachine_apply_provider_tool_
 	datamachine_request_builder_tool_transcript_assert( 'client/filesystem-write' === $restored[0]['name'], 'Provider-safe tool calls are restored to logical names before execution.' );
 	datamachine_request_builder_tool_transcript_assert( 'filesystem_write' === $restored[0]['provider_name'], 'Restored calls retain the provider alias for diagnostics.' );
 }
+
+$assertions = new DataMachineCompletionAssertions(
+	array(
+		'required_tool_names' => array( 'filesystem_write' ),
+	)
+);
+$tools      = array(
+	'client/filesystem-write' => array(
+		'name'            => 'client/filesystem-write',
+		'runtime_tool_id' => 'filesystem_write',
+	),
+);
+datamachine_request_builder_tool_transcript_assert( array() === $assertions->unavailableRequiredToolNames( $tools ), 'Completion assertions accept provider-safe runtime tool aliases as available.' );
+$assertions->recordToolResult( 'client/filesystem-write', $tools['client/filesystem-write'], array( 'success' => true ), array( 'path' => 'index.html' ) );
+$evaluation = $assertions->evaluate( array(), '' );
+datamachine_request_builder_tool_transcript_assert( true === $evaluation['complete'], 'Completion assertions are satisfied when the logical tool executes for a runtime alias requirement.' );
+datamachine_request_builder_tool_transcript_assert( array( 'filesystem_write' ) === ( $evaluation['satisfied']['tool_names'] ?? array() ), 'Satisfied assertions report the requested runtime alias name.' );
 
 echo "RequestBuilder tool transcript smoke passed.\n";


### PR DESCRIPTION
## Summary
- Treat each tool's logical name, declared `name`, and provider/runtime-safe `runtime_tool_id` as valid completion assertion names.
- Record successful tool results under runtime aliases as well as logical names so alias-based requirements can complete.
- Covers the `filesystem_write` requirement with logical `client/filesystem-write` execution in the request-builder smoke test.

## Why
Latest WP Codebox exposed Studio Web browser generation failing before tool execution with:

`Completion assertions require unavailable tool(s): filesystem_write.`

The model sees the provider-safe alias, while Data Machine executes the logical Agents API tool name. Completion assertions need to understand both names instead of rejecting the request before generation.

## Testing
- `php tests/request-builder-tool-transcript-smoke.php`
- `php -l inc/Engine/AI/DataMachineCompletionAssertions.php`
- `php -l tests/request-builder-tool-transcript-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the latest WP Codebox lab failure, drafted the completion-assertion alias handling, and ran targeted local verification. Chris remains responsible for review and merge.