### PR TITLE
Preserve failed tool diagnostics

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -384,6 +384,7 @@ class ExecuteStepAbility {
 					'status'       => $execution_result['status'] ?? 'failed',
 					'reason'       => $execution_result['reason'] ?? 'step_execution_failed',
 					'packet_count' => $execution_result['packet_count'] ?? 0,
+					'diagnostics'  => is_array( $execution_result['diagnostics'] ?? null ) ? $execution_result['diagnostics'] : array(),
 				)
 			);
 		}
@@ -690,15 +691,23 @@ class ExecuteStepAbility {
 		);
 		$empty_packet_reason = $this->getFailureReasonFromPackets( $dataPackets, $execution_result['reason'] ?? 'empty_data_packet_returned' );
 
+		$failure_context = array(
+			'flow_step_id' => $flow_step_id,
+			'class'        => $step_class,
+			'reason'       => $empty_packet_reason,
+		);
+		if ( ! empty( $execution_result['diagnostics'] ) && is_array( $execution_result['diagnostics'] ) ) {
+			$failure_context['diagnostics'] = $execution_result['diagnostics'];
+		}
+		if ( ! empty( $execution_result['error'] ) ) {
+			$failure_context['error_message'] = $execution_result['error'];
+		}
+
 		do_action(
 			'datamachine_fail_job',
 			$job_id,
 			'step_execution_failure',
-			array(
-				'flow_step_id' => $flow_step_id,
-				'class'        => $step_class,
-				'reason'       => $empty_packet_reason,
-			)
+			$failure_context
 		);
 
 		return array(

--- a/inc/Core/StepExecutionResult.php
+++ b/inc/Core/StepExecutionResult.php
@@ -40,7 +40,7 @@ class StepExecutionResult {
 	 *
 	 * @param mixed  $step_output Step return value.
 	 * @param string $step_type   Step type identifier.
-	 * @return array{status: string, packets: array, reason: string, error: ?string, terminal_status: ?string, success: bool, packet_count: int}
+	 * @return array{status: string, packets: array, reason: string, error: ?string, diagnostics: array, terminal_status: ?string, success: bool, packet_count: int}
 	 */
 	public static function fromStepOutput( $step_output, string $step_type = '' ): array {
 		if ( self::isExplicitResult( $step_output ) ) {
@@ -73,7 +73,7 @@ class StepExecutionResult {
 	 *
 	 * @param array  $data_packets Returned data packets.
 	 * @param string $step_type    Step type identifier.
-	 * @return array{status: string, packets: array, reason: string, error: ?string, terminal_status: ?string, success: bool, packet_count: int}
+	 * @return array{status: string, packets: array, reason: string, error: ?string, diagnostics: array, terminal_status: ?string, success: bool, packet_count: int}
 	 */
 	public static function classify( array $data_packets, string $step_type = '' ): array {
 		$data_packets = self::normalizePackets( $data_packets );
@@ -96,7 +96,7 @@ class StepExecutionResult {
 
 			if ( array_key_exists( 'step_execution_success', $metadata ) ) {
 				if ( false === (bool) $metadata['step_execution_success'] ) {
-					return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'step_execution_failed' ), null, self::errorFromMetadata( $metadata ) );
+					return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'step_execution_failed' ), null, self::errorFromMetadata( $metadata ), self::diagnosticsFromMetadata( $metadata ) );
 				}
 
 				$has_success_packet = true;
@@ -104,7 +104,7 @@ class StepExecutionResult {
 			}
 
 			if ( isset( $metadata['success'] ) && false === $metadata['success'] ) {
-				return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'packet_failure' ), null, self::errorFromMetadata( $metadata ) );
+				return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'packet_failure' ), null, self::errorFromMetadata( $metadata ), self::diagnosticsFromMetadata( $metadata ) );
 			}
 
 			if ( isset( $metadata['tool_success'] ) && false === $metadata['tool_success'] ) {
@@ -117,7 +117,7 @@ class StepExecutionResult {
 					continue;
 				}
 
-				return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'tool_result_failed' ), null, self::errorFromMetadata( $metadata ) );
+				return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'tool_result_failed' ), null, self::errorFromMetadata( $metadata ), self::diagnosticsFromMetadata( $metadata ) );
 			}
 
 			if ( ! isset( self::NON_SUCCESS_PACKET_TYPES[ $type ] ) ) {
@@ -133,7 +133,7 @@ class StepExecutionResult {
 		);
 	}
 
-	private static function buildResult( string $status, array $packets, string $reason, ?string $terminal_status, ?string $error = null ): array {
+	private static function buildResult( string $status, array $packets, string $reason, ?string $terminal_status, ?string $error = null, array $diagnostics = array() ): array {
 		$status = self::normalizeStatus( $status );
 		if ( '' === $status ) {
 			$status = self::STATUS_FAILED;
@@ -144,6 +144,7 @@ class StepExecutionResult {
 			'packets'         => $packets,
 			'reason'          => self::sanitizeReason( $reason ),
 			'error'           => self::normalizeError( $error ),
+			'diagnostics'     => $diagnostics,
 			'terminal_status' => $terminal_status,
 			'success'         => self::STATUS_SUCCEEDED === $status,
 			'packet_count'    => count( $packets ),
@@ -151,7 +152,49 @@ class StepExecutionResult {
 	}
 
 	private static function errorFromMetadata( array $metadata ): ?string {
-		return self::normalizeError( $metadata['error'] ?? ( $metadata['error_message'] ?? null ) );
+		$error = self::normalizeError( $metadata['error'] ?? ( $metadata['error_message'] ?? null ) );
+		if ( null !== $error ) {
+			return $error;
+		}
+
+		$envelope = is_array( $metadata['tool_result_envelope'] ?? null ) ? $metadata['tool_result_envelope'] : array();
+		return self::normalizeError( $envelope['error'] ?? ( $envelope['error_message'] ?? ( $envelope['message'] ?? null ) ) );
+	}
+
+	private static function diagnosticsFromMetadata( array $metadata ): array {
+		$diagnostics = array_filter(
+			array(
+				'tool_name'      => self::normalizeDiagnosticScalar( $metadata['tool_name'] ?? null ),
+				'handler_tool'   => self::normalizeDiagnosticScalar( $metadata['handler_tool'] ?? null ),
+				'failure_reason' => self::normalizeDiagnosticScalar( $metadata['failure_reason'] ?? null ),
+				'error'          => self::errorFromMetadata( $metadata ),
+			),
+			fn( $value ) => null !== $value && '' !== $value
+		);
+
+		$envelope = is_array( $metadata['tool_result_envelope'] ?? null ) ? $metadata['tool_result_envelope'] : array();
+		if ( array() !== $envelope ) {
+			$diagnostics['tool_result'] = array_filter(
+				array(
+					'success' => isset( $envelope['success'] ) ? (bool) $envelope['success'] : null,
+					'status'  => self::normalizeDiagnosticScalar( $envelope['status'] ?? null ),
+					'code'    => self::normalizeDiagnosticScalar( $envelope['code'] ?? ( $envelope['error_code'] ?? null ) ),
+					'message' => self::normalizeDiagnosticScalar( $envelope['message'] ?? ( $envelope['error_message'] ?? ( $envelope['error'] ?? null ) ) ),
+				),
+				fn( $value ) => null !== $value && '' !== $value
+			);
+		}
+
+		return $diagnostics;
+	}
+
+	private static function normalizeDiagnosticScalar( $value ): ?string {
+		if ( ! is_scalar( $value ) ) {
+			return null;
+		}
+
+		$value = trim( (string) $value );
+		return '' !== $value ? $value : null;
 	}
 
 	private static function normalizeError( $error ): ?string {

--- a/tests/ai-error-status-propagation-smoke.php
+++ b/tests/ai-error-status-propagation-smoke.php
@@ -144,6 +144,44 @@ $invoke_empty_ai_route = function ( string $status ) use ( $build_ability ): arr
 	);
 };
 
+$invoke_failed_tool_route = function () use ( $build_ability ): array {
+	list( $ability, $route ) = $build_ability( 'processing' );
+
+	$packets = array(
+		array(
+			'type'     => 'tool_result',
+			'metadata' => array(
+				'tool_name'            => 'create_github_pull_request',
+				'tool_success'         => false,
+				'tool_result_envelope' => array(
+					'success' => false,
+					'code'    => 'not_found',
+					'message' => 'GitHub App installation token exchange failed.',
+				),
+			),
+		),
+	);
+	$execution_result = \DataMachine\Core\StepExecutionResult::classify( $packets, 'ai' );
+
+	return $route->invoke(
+		$ability,
+		123,
+		'ai_step',
+		9,
+		array(
+			'pipeline_id' => 3,
+			'step_type'   => 'ai',
+		),
+		'ai',
+		'DataMachine\\Core\\Steps\\AI\\AIStep',
+		$packets,
+		array( 'data' => $packets ),
+		false,
+		null,
+		$execution_result
+	);
+};
+
 $invoke_empty_fetch_route = function ( string $status ) use ( $build_ability ): array {
 	list( $ability, $route ) = $build_ability( $status );
 
@@ -262,6 +300,21 @@ $assert( 'fetch route surfaces provider failure status', 'failed - mcp_provider_
 $assert( 'fetch route does not emit a second fail-job action', empty( $failed_jobs ) );
 $assert( 'fetch route does not complete failed job as no-items', null === $completed_status );
 $assert( 'fetch route logs the short-circuit message', 1 <= count( $debug_logs ) );
+
+echo "\n[6] failed tool packets preserve diagnostics in fail-job context\n";
+$datamachine_action_log       = datamachine_empty_action_log();
+$datamachine_test_engine_data = array();
+$result                       = $invoke_failed_tool_route();
+$failed_jobs                  = $actions_by_hook( 'datamachine_fail_job' );
+$last_failure                 = end( $failed_jobs );
+$failure_context              = is_array( $last_failure ) ? ( $last_failure['args'][2] ?? array() ) : array();
+
+$assert( 'failed tool packet route still fails', 'failed' === ( $result['outcome'] ?? '' ) );
+$assert( 'failed tool emits fail-job action', 1 === count( $failed_jobs ) );
+$assert( 'failed tool route uses tool_result_failed reason', 'tool_result_failed' === ( $failure_context['reason'] ?? '' ) );
+$assert( 'failed tool context preserves tool name', 'create_github_pull_request' === ( $failure_context['diagnostics']['tool_name'] ?? '' ) );
+$assert( 'failed tool context preserves envelope message', 'GitHub App installation token exchange failed.' === ( $failure_context['diagnostics']['tool_result']['message'] ?? '' ) );
+$assert( 'failed tool context exposes human error message', 'GitHub App installation token exchange failed.' === ( $failure_context['error_message'] ?? '' ) );
 
 if ( $failures > 0 ) {
 	echo "\n=== ai-error-status-propagation-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";

--- a/tests/step-execution-result-error-smoke.php
+++ b/tests/step-execution-result-error-smoke.php
@@ -56,9 +56,14 @@ $metadata_error_result = StepExecutionResult::classify(
 		array(
 			'type'     => 'handler_result',
 			'metadata' => array(
-				'tool_success'   => false,
-				'failure_reason' => 'handler_failed',
-				'error_message'  => 'GitHub App installation token exchange failed.',
+				'tool_name'            => 'create_github_pull_request',
+				'tool_success'         => false,
+				'failure_reason'       => 'handler_failed',
+				'tool_result_envelope' => array(
+					'success' => false,
+					'code'    => 'not_found',
+					'message' => 'GitHub App installation token exchange failed.',
+				),
 			),
 		),
 	),
@@ -68,6 +73,21 @@ $metadata_error_result = StepExecutionResult::classify(
 assert_step_execution_result_error(
 	'packet metadata errors propagate to execution result',
 	'GitHub App installation token exchange failed.' === $metadata_error_result['error']
+);
+
+assert_step_execution_result_error(
+	'failed tool diagnostic preserves tool name',
+	'create_github_pull_request' === ( $metadata_error_result['diagnostics']['tool_name'] ?? '' )
+);
+
+assert_step_execution_result_error(
+	'failed tool diagnostic preserves envelope code',
+	'not_found' === ( $metadata_error_result['diagnostics']['tool_result']['code'] ?? '' )
+);
+
+assert_step_execution_result_error(
+	'failed tool diagnostic preserves envelope message',
+	'GitHub App installation token exchange failed.' === ( $metadata_error_result['diagnostics']['tool_result']['message'] ?? '' )
 );
 
 if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary
- Preserve compact diagnostics for failed step packets, including failed tool name, handler, result code/message, and human error text.
- Pass failed tool diagnostics through the `datamachine_fail_job` context so runner/eval layers can report why `tool_result_failed` happened.
- Extend existing smoke coverage for classifier-level and route-level failed-tool diagnostics.

## Why
Build With WordPress Docs Agent runs can currently collapse to opaque `failed - tool_result_failed` statuses after retryable OpenAI transport errors. The uploaded evidence has the final status but loses the failed tool identity/message needed to distinguish a real tool failure from retry/resume plumbing.

Evidence runs:
- https://github.com/Automattic/build-with-wordpress/actions/runs/27388919655
- https://github.com/Automattic/build-with-wordpress/actions/runs/27389412002

## Verification
- `php tests/step-execution-result-error-smoke.php`
- `php tests/ai-error-status-propagation-smoke.php`
- `php tests/step-execution-result-contract-smoke.php`
- `php tests/job-status-accounting-smoke.php`
- `php -l inc/Core/StepExecutionResult.php`
- `php -l inc/Abilities/Engine/ExecuteStepAbility.php`
- `php -l tests/step-execution-result-error-smoke.php`
- `php -l tests/ai-error-status-propagation-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the opaque runner failure evidence, drafted the diagnostic propagation change and smoke coverage, and ran focused verification. Chris remains responsible for review and merge.