### PR TITLE
Persist fail-job diagnostics in engine data

### DIFF
--- a/inc/Engine/Actions/Handlers/FailJobHandler.php
+++ b/inc/Engine/Actions/Handlers/FailJobHandler.php
@@ -53,16 +53,19 @@ class FailJobHandler {
 		// Persist structured error context into engine_data so it is
 		// available from `wp datamachine jobs show` without grepping PHP logs.
 		$error_data = array(
-			'error_reason'  => $specific_reason,
-			'error_step_id' => $context_data['flow_step_id'] ?? null,
-			'error_message' => $context_data['exception_message']
+			'error_reason'      => $specific_reason,
+			'error_step_id'     => $context_data['flow_step_id'] ?? null,
+			'error_message'     => $context_data['exception_message']
 				?? $context_data['error_message']
 				?? $context_data['ai_error']
 				?? $reason,
-			'error_trace'   => isset( $context_data['exception_trace'] )
+			'error_diagnostics' => is_array( $context_data['diagnostics'] ?? null )
+				? $context_data['diagnostics']
+				: null,
+			'error_trace'       => isset( $context_data['exception_trace'] )
 				? mb_substr( $context_data['exception_trace'], 0, 2000 )
 				: null,
-			'retry_result'  => $retry_result,
+			'retry_result'      => $retry_result,
 		);
 		// Strip null values so we only store keys that carry information.
 		$error_data = array_filter( $error_data, fn( $v ) => null !== $v );

--- a/tests/job-retry-policy-smoke.php
+++ b/tests/job-retry-policy-smoke.php
@@ -138,6 +138,7 @@ assert_retry_policy_smoke( 'policy records retry metadata', str_contains( $polic
 assert_retry_policy_smoke( 'policy records retry classification metadata', str_contains( $policy_src, "'retry_class'" ) );
 assert_retry_policy_smoke( 'policy records poison item isolation metadata', str_contains( $policy_src, "'poison_item'" ) );
 assert_retry_policy_smoke( 'fail handler tries retry before final failure', strpos( $fail_src, 'maybeRetry' ) < strpos( $fail_src, 'complete_job' ) );
+assert_retry_policy_smoke( 'fail handler persists structured diagnostics', str_contains( $fail_src, "'error_diagnostics'" ) && str_contains( $fail_src, "\$context_data['diagnostics']" ) );
 assert_retry_policy_smoke( 'AI failures pass retry and transport context', str_contains( $ai_src, "'retry_after'" ) && str_contains( $ai_src, "'headers'" ) && str_contains( $ai_src, "'transport_profile'" ) );
 
 echo "\nJob retry policy smoke complete: {$total} assertions, {$failed} failures.\n";


### PR DESCRIPTION
## Summary
- Persists structured fail-job diagnostics into engine data as `error_diagnostics`.
- Extends the retry policy smoke contract so failed tool diagnostics remain visible after final job failure.

## Testing
- `php tests/job-retry-policy-smoke.php`
- `php tests/ai-error-status-propagation-smoke.php`
- `php -l inc/Engine/Actions/Handlers/FailJobHandler.php && php -l tests/job-retry-policy-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the minimal persistence patch and focused smoke coverage; Chris remains responsible for review and testing.