### PR TITLE
Fix recovered tool result classification

### DIFF
--- a/inc/Core/StepExecutionResult.php
+++ b/inc/Core/StepExecutionResult.php
@@ -89,6 +89,7 @@ class StepExecutionResult {
 
 		$successful_handlers = self::collectSuccessfulHandlerTools( $data_packets );
 		$has_success_packet  = false;
+		$failed_tool_packet  = null;
 
 		foreach ( $data_packets as $packet ) {
 			$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
@@ -117,12 +118,19 @@ class StepExecutionResult {
 					continue;
 				}
 
-				return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'tool_result_failed' ), null, self::errorFromMetadata( $metadata ), self::diagnosticsFromMetadata( $metadata ) );
+				$failed_tool_packet ??= $packet;
+				continue;
 			}
 
 			if ( ! isset( self::NON_SUCCESS_PACKET_TYPES[ $type ] ) ) {
 				$has_success_packet = true;
 			}
+		}
+
+		if ( ! $has_success_packet && null !== $failed_tool_packet ) {
+			$metadata = is_array( $failed_tool_packet['metadata'] ?? null ) ? $failed_tool_packet['metadata'] : array();
+
+			return self::buildResult( self::STATUS_FAILED, $data_packets, self::sanitizeReason( $metadata['failure_reason'] ?? 'tool_result_failed' ), null, self::errorFromMetadata( $metadata ), self::diagnosticsFromMetadata( $metadata ) );
 		}
 
 		return self::buildResult(

--- a/tests/step-execution-result-contract-smoke.php
+++ b/tests/step-execution-result-contract-smoke.php
@@ -119,6 +119,43 @@ $result = StepExecutionResult::classify(
 $assert( 'non-fatal failed tool packet is retained without failing step', 'succeeded' === $result['status'] );
 $assert( 'successful later tool packet determines AI success', true === $result['success'] );
 
+echo "\n[6] recovered failed runtime tool packet does not fail successful AI step\n";
+$result = StepExecutionResult::classify(
+	array(
+		array(
+			'type'     => 'tool_result',
+			'metadata' => array(
+				'tool_name'            => 'workspace_read',
+				'tool_success'         => false,
+				'tool_result_envelope' => array(
+					'success' => false,
+					'code'    => 'file_too_large',
+					'message' => 'File exceeds max_size.',
+				),
+			),
+		),
+		array(
+			'type'     => 'tool_result',
+			'metadata' => array(
+				'tool_name'    => 'workspace_read',
+				'tool_success' => true,
+			),
+		),
+		array(
+			'type'     => 'tool_result',
+			'metadata' => array(
+				'tool_name'    => 'workspace_write',
+				'tool_success' => true,
+			),
+		),
+	),
+	'ai'
+);
+
+$assert( 'recovered failed runtime tool does not fail final step', 'succeeded' === $result['status'] );
+$assert( 'recovered failed runtime tool packet remains in audit packets', false === ( $result['packets'][0]['metadata']['tool_success'] ?? null ) );
+$assert( 'recovered failed runtime tool diagnostics remain in packet history', 'file_too_large' === ( $result['packets'][0]['metadata']['tool_result_envelope']['code'] ?? '' ) );
+
 if ( $failures > 0 ) {
 	echo "\n=== step-execution-result-contract-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";
 	exit( 1 );


### PR DESCRIPTION
## Summary
- Defer terminal failed-tool classification until all packets have been inspected, so a later successful continuation can recover the AI step.
- Preserve failed tool packets in the returned packet history for diagnostics/audit trails.
- Add smoke coverage for a failed `workspace_read` followed by successful tool continuations.

## Tests
- `php tests/step-execution-result-contract-smoke.php`
- `php tests/job-status-accounting-smoke.php`
- `php tests/ai-error-status-propagation-smoke.php`
- `php -l inc/Core/StepExecutionResult.php && php -l tests/step-execution-result-contract-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Classified the recovered tool failure path, drafted the minimal code/test patch, and ran focused verification. Chris reviewed via the PR workflow.