### PR TITLE
fix: terminal disposition tools end the conversation and never overwrite each other

### DIFF
--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -474,6 +474,7 @@ abstract class FetchHandler {
 			'method'                  => 'handle_tool_call',
 			'handler'                 => $handler_slug,
 			'disposition'             => 'reject_source',
+			'runtime'                 => array( 'completion_signal' => 'terminal' ),
 			'description'             => 'Reject this fetched source item after reasoned content/source evaluation. Use when the source itself is irrelevant, too thin, duplicate, noisy, spammy, or otherwise fails the pipeline quality or relevance criteria. The source item will be marked as processed and will not normally be refetched.',
 			'parameters'              => array(
 				'type'       => 'object',
@@ -504,6 +505,7 @@ abstract class FetchHandler {
 			'method'                  => 'handle_tool_call',
 			'handler'                 => $handler_slug,
 			'disposition'             => 'defer_item',
+			'runtime'                 => array( 'completion_signal' => 'terminal' ),
 			'description'             => 'Defer this fetched source item when the agent cannot safely complete processing now because of runtime failures, tool errors, missing context, uncertainty, or temporary limitations. The source claim will be released and the item will remain eligible to be fetched and retried later; it will not be marked processed.',
 			'parameters'              => array(
 				'type'       => 'object',

--- a/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
+++ b/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
@@ -74,6 +74,12 @@ class FetchItemDispositionTool {
 			);
 		}
 
+		// Dispositions are first-write-wins: never overwrite an earlier terminal disposition.
+		$existing = $this->existingDisposition( $job_id );
+		if ( null !== $existing ) {
+			return $this->alreadyDispositionedResult( $tool_name, $existing, $job_id );
+		}
+
 		// Get engine data for item identification.
 		$engine = $this->resolveEngineData( $parameters, $job_id );
 		if ( ! $engine ) {
@@ -211,6 +217,13 @@ class FetchItemDispositionTool {
 			);
 		}
 
+		// Dispositions are first-write-wins: defer_item must never downgrade an
+		// earlier rejection (agent_skipped - source-rejected) to a failed status.
+		$existing = $this->existingDisposition( $job_id );
+		if ( null !== $existing ) {
+			return $this->alreadyDispositionedResult( $tool_name, $existing, $job_id );
+		}
+
 		$engine = $this->resolveEngineData( $parameters, $job_id );
 		if ( ! $engine ) {
 			return array(
@@ -285,6 +298,82 @@ class FetchItemDispositionTool {
 			'disposition'     => self::DISPOSITION_DEFER_ITEM,
 			'reason'          => $reason,
 			'released'        => $released,
+		);
+	}
+
+	/**
+	 * Return the disposition already recorded for a job, if any.
+	 *
+	 * Reads the persisted engine snapshot rather than the runtime engine object
+	 * because the runtime snapshot may predate an earlier disposition call in
+	 * the same conversation.
+	 *
+	 * @param int $job_id Job ID.
+	 * @return array{disposition:string,job_status:string,reason:string}|null
+	 */
+	private function existingDisposition( int $job_id ): ?array {
+		$engine_data = EngineData::retrieve( $job_id );
+
+		$diagnostic  = is_array( $engine_data['disposition_diagnostic'] ?? null ) ? $engine_data['disposition_diagnostic'] : array();
+		$disposition = (string) ( $diagnostic['disposition'] ?? '' );
+
+		if ( '' === $disposition && isset( $engine_data['source_rejection'] ) ) {
+			$disposition = self::DISPOSITION_REJECT_SOURCE;
+		}
+
+		if ( '' === $disposition && isset( $engine_data['item_deferral'] ) ) {
+			$disposition = self::DISPOSITION_DEFER_ITEM;
+		}
+
+		if ( '' === $disposition ) {
+			return null;
+		}
+
+		$record = self::DISPOSITION_DEFER_ITEM === $disposition
+			? ( is_array( $engine_data['item_deferral'] ?? null ) ? $engine_data['item_deferral'] : array() )
+			: ( is_array( $engine_data['source_rejection'] ?? null ) ? $engine_data['source_rejection'] : array() );
+
+		return array(
+			'disposition' => $disposition,
+			'job_status'  => (string) ( $engine_data['job_status'] ?? '' ),
+			'reason'      => (string) ( $record['reason'] ?? $diagnostic['reason'] ?? '' ),
+		);
+	}
+
+	/**
+	 * Build the idempotent success result for an already-dispositioned job.
+	 *
+	 * Returned as success so the model is not pushed into error-retry loops;
+	 * the original disposition remains authoritative (first-write-wins).
+	 *
+	 * @param string                                              $tool_name Tool that attempted the second disposition.
+	 * @param array{disposition:string,job_status:string,reason:string} $existing  Existing disposition record.
+	 * @param int                                                 $job_id    Job ID.
+	 * @return array Tool result.
+	 */
+	private function alreadyDispositionedResult( string $tool_name, array $existing, int $job_id ): array {
+		$label = self::DISPOSITION_DEFER_ITEM === $existing['disposition'] ? 'item-deferred' : 'source-rejected';
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'FetchItemDispositionTool: Ignoring repeat disposition call - job already dispositioned',
+			array(
+				'job_id'               => $job_id,
+				'attempted_tool'       => $tool_name,
+				'existing_disposition' => $existing['disposition'],
+				'existing_job_status'  => $existing['job_status'],
+			)
+		);
+
+		return array(
+			'success'              => true,
+			'message'              => "Item already dispositioned ({$label}); no further action needed.",
+			'status'               => $existing['job_status'],
+			'tool_name'            => $tool_name,
+			'disposition'          => $existing['disposition'],
+			'reason'               => $existing['reason'],
+			'already_dispositioned' => true,
 		);
 	}
 

--- a/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
+++ b/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
@@ -23,6 +23,9 @@ class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Comple
 	/** @var array Handler slugs that have completed successfully. */
 	private array $executed_handler_slugs = array();
 
+	/** @var bool Whether a successful tool declared a terminal completion signal. */
+	private bool $terminal_signal_recorded = false;
+
 	/** @var DataMachineCompletionAssertions Generic completion assertions. */
 	private DataMachineCompletionAssertions $assertions;
 
@@ -48,6 +51,19 @@ class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Comple
 			$tool_result,
 			! empty( $mediated_tool_parameters ) ? $mediated_tool_parameters : ( is_array( $runtime_context['tool_parameters'] ?? null ) ? $runtime_context['tool_parameters'] : array() )
 		);
+
+		if ( ( $tool_result['success'] ?? false ) && $this->hasTerminalCompletionSignal( $tool_def, $tool_result ) ) {
+			$this->terminal_signal_recorded = true;
+
+			return WP_Agent_Conversation_Completion_Decision::complete(
+				'AIConversationLoop: Tool declared terminal completion signal, ending conversation',
+				array(
+					'tool_name'         => $tool_name,
+					'turn_count'        => $turn_count,
+					'completion_signal' => 'terminal',
+				)
+			);
+		}
 
 		$is_handler_tool = is_array( $tool_def ) && isset( $tool_def['handler'] );
 		$modes           = is_array( $runtime_context['modes'] ?? null ) ? $runtime_context['modes'] : array( (string) ( $runtime_context['mode'] ?? '' ) );
@@ -117,6 +133,16 @@ class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Comple
 	 * @inheritDoc
 	 */
 	public function recordNaturalCompletion( array $messages, string $assistant_text, array $runtime_context, int $turn_count ): WP_Agent_Conversation_Completion_Decision {
+		if ( $this->terminal_signal_recorded ) {
+			return WP_Agent_Conversation_Completion_Decision::complete(
+				'AIConversationLoop: Terminal completion signal already recorded, ending conversation',
+				array(
+					'turn_count'        => $turn_count,
+					'completion_signal' => 'terminal',
+				)
+			);
+		}
+
 		$remaining_handlers = $this->remainingConfiguredHandlers();
 		if ( ! empty( $remaining_handlers ) ) {
 			return WP_Agent_Conversation_Completion_Decision::incomplete(
@@ -151,6 +177,26 @@ class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Comple
 				'continuation_message' => DataMachineCompletionAssertions::buildNudge( $evaluation['missing'], $messages ),
 			)
 		);
+	}
+
+	/**
+	 * Whether a tool definition/result pair declares a terminal completion signal.
+	 *
+	 * Tools can declare `runtime => array( 'completion_signal' => 'terminal' )`
+	 * in their definition (or result) to mark a successful execution as a
+	 * terminal pipeline outcome — e.g. an explicit item disposition — without
+	 * this policy hardcoding tool names.
+	 *
+	 * @param array|null $tool_def    Tool definition.
+	 * @param array      $tool_result Tool execution result.
+	 * @return bool
+	 */
+	private function hasTerminalCompletionSignal( ?array $tool_def, array $tool_result ): bool {
+		$definition_runtime = is_array( $tool_def['runtime'] ?? null ) ? $tool_def['runtime'] : array();
+		$result_runtime     = is_array( $tool_result['runtime'] ?? null ) ? $tool_result['runtime'] : array();
+		$runtime            = array_merge( $definition_runtime, $result_runtime );
+
+		return 'terminal' === (string) ( $runtime['completion_signal'] ?? '' );
 	}
 
 	/**

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -241,6 +241,56 @@ $natural_before_handler_decision = $natural_before_handler_policy->recordNatural
 assert_runtime_policy( ! $natural_before_handler_decision->isComplete(), 'handler policy rejects natural completion before configured handlers fire' );
 assert_runtime_policy( array( 'wiki_upsert' ) === ( $natural_before_handler_decision->context()['remaining_handlers'] ?? null ), 'handler policy reports remaining handlers on natural completion' );
 
+// 1b. Tools declaring runtime completion_signal=terminal complete the conversation
+// even when configured handlers never execute (e.g. legitimate item dispositions, #2609).
+$terminal_signal_policy   = new DataMachineHandlerCompletionPolicy( array( 'upsert_event' ) );
+$terminal_signal_decision = $terminal_signal_policy->recordToolResult(
+	'reject_source',
+	array(
+		'handler' => 'ticketmaster',
+		'runtime' => array( 'completion_signal' => 'terminal' ),
+	),
+	array( 'success' => true ),
+	array( 'mode' => 'pipeline' ),
+	1
+);
+assert_runtime_policy( $terminal_signal_decision->isComplete(), 'terminal completion signal completes despite unexecuted configured handlers' );
+assert_runtime_policy( 'terminal' === ( $terminal_signal_decision->context()['completion_signal'] ?? '' ), 'terminal completion decision reports completion_signal context' );
+
+$terminal_natural_decision = $terminal_signal_policy->recordNaturalCompletion(
+	array( array( 'role' => 'user', 'content' => 'process the event' ) ),
+	'Item rejected as non-music.',
+	array( 'mode' => 'pipeline' ),
+	2
+);
+assert_runtime_policy( $terminal_natural_decision->isComplete(), 'natural completion after terminal signal does not nudge' );
+
+$terminal_failed_policy   = new DataMachineHandlerCompletionPolicy( array( 'upsert_event' ) );
+$terminal_failed_decision = $terminal_failed_policy->recordToolResult(
+	'reject_source',
+	array(
+		'handler' => 'ticketmaster',
+		'runtime' => array( 'completion_signal' => 'terminal' ),
+	),
+	array( 'success' => false ),
+	array( 'mode' => 'pipeline' ),
+	1
+);
+assert_runtime_policy( ! $terminal_failed_decision->isComplete(), 'failed terminal-signal tool does not complete the conversation' );
+
+$terminal_result_policy   = new DataMachineHandlerCompletionPolicy( array( 'upsert_event' ) );
+$terminal_result_decision = $terminal_result_policy->recordToolResult(
+	'defer_item',
+	array( 'handler' => 'ticketmaster' ),
+	array(
+		'success' => true,
+		'runtime' => array( 'completion_signal' => 'terminal' ),
+	),
+	array( 'mode' => 'pipeline' ),
+	1
+);
+assert_runtime_policy( $terminal_result_decision->isComplete(), 'terminal completion signal in tool result completes the conversation' );
+
 // 2. Injected completion/transcript collaborators steer the loop without leaking into provider payloads.
 $natural_dispatch_count = 0;
 WpAiClientTestDouble::reset();

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -49,6 +49,22 @@ if ( ! function_exists( 'datamachine_merge_engine_data' ) ) {
 	}
 }
 
+// Under a real WordPress runtime (e.g. the wp-codebox smoke harness) the
+// do_action stub above is never defined, so bridge the hooks this test
+// observes into the same capture buffer via real add_action.
+if ( defined( 'WPINC' ) ) {
+	foreach ( array( 'datamachine_log', 'datamachine_ai_completion_nudge_added' ) as $runtime_policy_captured_hook ) {
+		add_action(
+			$runtime_policy_captured_hook,
+			static function ( ...$args ) use ( $runtime_policy_captured_hook ): void {
+				$GLOBALS['datamachine_runtime_policy_logs'][] = array_merge( array( $runtime_policy_captured_hook ), $args );
+			},
+			10,
+			10
+		);
+	}
+}
+
 if ( ! function_exists( 'wp_json_encode' ) ) {
 	function wp_json_encode( $data, int $flags = 0 ) {
 		return json_encode( $data, $flags );

--- a/tests/fetch-item-dispositions-smoke.php
+++ b/tests/fetch-item-dispositions-smoke.php
@@ -29,38 +29,66 @@ namespace {
 	$GLOBALS['fetch_disposition_smoke_released']  = array();
 	$GLOBALS['fetch_disposition_smoke_engine']    = array();
 
-	function do_action( string $hook, ...$args ): void {
-		if ( 'datamachine_mark_item_processed' === $hook ) {
-			$GLOBALS['fetch_disposition_smoke_processed'][] = $args;
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( string $hook, ...$args ): void {
+			if ( 'datamachine_mark_item_processed' === $hook ) {
+				$GLOBALS['fetch_disposition_smoke_processed'][] = $args;
+			}
 		}
 	}
 
-	function datamachine_merge_engine_data( int $job_id, array $data ): void {
-		$GLOBALS['fetch_disposition_smoke_engine'][ $job_id ] = array_merge(
-			$GLOBALS['fetch_disposition_smoke_engine'][ $job_id ] ?? array(),
-			$data
+	// Under a real WordPress runtime (e.g. the wp-codebox smoke harness) the
+	// do_action stub above never installs, so bridge the observed hook into the
+	// same capture buffer via real add_action.
+	if ( defined( 'WPINC' ) ) {
+		add_action(
+			'datamachine_mark_item_processed',
+			static function ( ...$args ): void {
+				$GLOBALS['fetch_disposition_smoke_processed'][] = $args;
+			},
+			10,
+			10
 		);
-
-		// Mirror into the persisted snapshot so EngineData::retrieve() sees
-		// merged data, matching production EngineData::merge() behavior.
-		$GLOBALS['fetch_disposition_smoke_persisted_engine'][ $job_id ] = array_merge(
-			$GLOBALS['fetch_disposition_smoke_persisted_engine'][ $job_id ] ?? array(),
-			$data
-		);
 	}
 
-	function wp_cache_get( $key, string $group = '' ) {
-		unset( $key, $group );
-		return false;
+	if ( ! function_exists( 'datamachine_merge_engine_data' ) ) {
+		function datamachine_merge_engine_data( int $job_id, array $data ): void {
+			$GLOBALS['fetch_disposition_smoke_engine'][ $job_id ] = array_merge(
+				$GLOBALS['fetch_disposition_smoke_engine'][ $job_id ] ?? array(),
+				$data
+			);
+
+			// Mirror into the persisted snapshot so EngineData::retrieve() sees
+			// merged data, matching production EngineData::merge() behavior.
+			$GLOBALS['fetch_disposition_smoke_persisted_engine'][ $job_id ] = array_merge(
+				$GLOBALS['fetch_disposition_smoke_persisted_engine'][ $job_id ] ?? array(),
+				$data
+			);
+
+			// Keep the (possibly real) object cache coherent with the snapshot
+			// so EngineData::retrieve() never serves a stale pre-merge value.
+			wp_cache_set( $job_id, $GLOBALS['fetch_disposition_smoke_persisted_engine'][ $job_id ], 'datamachine_engine_data' );
+		}
 	}
 
-	function wp_cache_set( $key, $value, string $group = '' ): bool {
-		unset( $key, $value, $group );
-		return true;
+	if ( ! function_exists( 'wp_cache_get' ) ) {
+		function wp_cache_get( $key, string $group = '' ) {
+			unset( $key, $group );
+			return false;
+		}
 	}
 
-	function wp_strip_all_tags( string $text ): string {
-		return strip_tags( $text );
+	if ( ! function_exists( 'wp_cache_set' ) ) {
+		function wp_cache_set( $key, $value, string $group = '' ): bool {
+			unset( $key, $value, $group );
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+		function wp_strip_all_tags( string $text ): string {
+			return strip_tags( $text );
+		}
 	}
 }
 

--- a/tests/fetch-item-dispositions-smoke.php
+++ b/tests/fetch-item-dispositions-smoke.php
@@ -40,6 +40,13 @@ namespace {
 			$GLOBALS['fetch_disposition_smoke_engine'][ $job_id ] ?? array(),
 			$data
 		);
+
+		// Mirror into the persisted snapshot so EngineData::retrieve() sees
+		// merged data, matching production EngineData::merge() behavior.
+		$GLOBALS['fetch_disposition_smoke_persisted_engine'][ $job_id ] = array_merge(
+			$GLOBALS['fetch_disposition_smoke_persisted_engine'][ $job_id ] ?? array(),
+			$data
+		);
 	}
 
 	function wp_cache_get( $key, string $group = '' ) {
@@ -185,6 +192,47 @@ namespace {
 	);
 	assert_fetch_disposition_smoke( 'reject_source succeeds with persisted engine data', true === ( $reject_hydrated['success'] ?? false ) );
 	assert_fetch_disposition_smoke( 'persisted engine data marks processed source identity', array( 'fetch-step_8', 'mcp', 'source-456', 1816 ) === ( $GLOBALS['fetch_disposition_smoke_processed'][0] ?? null ) );
+
+	echo "Case 2c: dispositions are first-write-wins (#2609)\n";
+	$GLOBALS['fetch_disposition_smoke_processed'] = array();
+	$GLOBALS['fetch_disposition_smoke_released']  = array();
+	$defer_after_reject = $tool->handle_tool_call(
+		array(
+			'job_id'       => 1814,
+			'flow_step_id' => 'ai-step_7',
+			'engine'       => $engine,
+			'data'         => $data_packets,
+			'reason'       => 'already rejected; nothing left to do',
+		),
+		array( 'disposition' => 'defer_item' )
+	);
+	assert_fetch_disposition_smoke( 'second disposition returns success (no error-retry loop)', true === ( $defer_after_reject['success'] ?? false ) );
+	assert_fetch_disposition_smoke( 'second disposition reports already_dispositioned', true === ( $defer_after_reject['already_dispositioned'] ?? false ) );
+	assert_fetch_disposition_smoke( 'second disposition message references existing disposition', str_contains( $defer_after_reject['message'] ?? '', 'already dispositioned (source-rejected)' ) );
+	assert_fetch_disposition_smoke( 'defer_item does not downgrade source-rejected status', 'agent_skipped - source-rejected' === ( $GLOBALS['fetch_disposition_smoke_engine'][1814]['job_status'] ?? '' ) );
+	assert_fetch_disposition_smoke( 'second disposition preserves original disposition record', 'reject_source' === ( $GLOBALS['fetch_disposition_smoke_engine'][1814]['disposition_diagnostic']['disposition'] ?? '' ) );
+	assert_fetch_disposition_smoke( 'second disposition does not write item_deferral record', ! isset( $GLOBALS['fetch_disposition_smoke_engine'][1814]['item_deferral'] ) );
+	assert_fetch_disposition_smoke( 'second disposition does not release the processed claim', array() === $GLOBALS['fetch_disposition_smoke_released'] );
+	assert_fetch_disposition_smoke( 'second disposition does not re-mark processed', array() === $GLOBALS['fetch_disposition_smoke_processed'] );
+
+	$reject_after_defer = $tool->handle_tool_call(
+		array(
+			'job_id'       => 1815,
+			'flow_step_id' => 'ai-step_7',
+			'engine'       => $engine,
+			'data'         => $data_packets,
+			'reason'       => 'second thoughts',
+		),
+		array( 'disposition' => 'reject_source' )
+	);
+	assert_fetch_disposition_smoke( 'reject_source after defer_item returns success', true === ( $reject_after_defer['success'] ?? false ) );
+	assert_fetch_disposition_smoke( 'reject_source after defer_item reports already_dispositioned', true === ( $reject_after_defer['already_dispositioned'] ?? false ) );
+	assert_fetch_disposition_smoke( 'reject_source does not overwrite item-deferred status', 'failed - item-deferred' === ( $GLOBALS['fetch_disposition_smoke_engine'][1815]['job_status'] ?? '' ) );
+	assert_fetch_disposition_smoke( 'reject_source after defer does not mark processed', array() === $GLOBALS['fetch_disposition_smoke_processed'] );
+
+	echo "Case 2d: disposition tools declare terminal completion signal (#2609)\n";
+	$fetch_handler_src = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/FetchHandler.php' );
+	assert_fetch_disposition_smoke( 'both disposition tool definitions declare runtime completion_signal terminal', 2 === substr_count( $fetch_handler_src, "'runtime'                 => array( 'completion_signal' => 'terminal' )" ) );
 
 	echo "Case 3: production tool surface exposes positive affordances\n";
 	$fetch_handler = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/FetchHandler.php' );


### PR DESCRIPTION
## Summary

Closes findings A/B of #2609 (Refs #2609 — the defer-cap and feed-window observability proposals are follow-ups, intentionally out of scope here).

Two related defects in the pipeline conversation loop, post-agents-api migration, verified on events.extrachill.com (blog 7):

### Fix 1 — disposition success terminates the conversation

`DataMachineHandlerCompletionPolicy` only completed when all `configured_handlers` (e.g. `upsert_event`) had executed. When the model legitimately calls `reject_source`, the publish handler *correctly* never runs, so the policy nudged forever ("Please continue. The task is not complete yet…" — avg **6.15 nudges/job**, observed up to 10) until the model escaped by also calling `defer_item`.

**Mechanism (generic, layer-pure):**
- `FetchHandler` disposition tool definitions now declare `'runtime' => array( 'completion_signal' => 'terminal' )` — the same top-level `runtime` metadata channel already used by `completion_signal => progress` (`AgentDailyMemory`) and honored by `datamachine_tool_runtime_metadata()`. `terminal` is product-neutral; agents-api's `WP_Agent_Tool_Declaration::normalizeRuntimeMetadata()` preserves it through declaration normalization, and `executePreparedTool()` merges definition runtime into the result, so the signal reaches the policy on both the mediated and turn-runner paths.
- `DataMachineHandlerCompletionPolicy::recordToolResult()` completes immediately when a **successful** tool carries the terminal signal (from definition or result) — no tool names are hardcoded in the policy. Failed disposition calls do not complete.
- `recordNaturalCompletion()` short-circuits once a terminal signal has been recorded, so no further nudges fire after a disposition.

### Fix 2 — dispositions are first-write-wins

`deferItem()` blindly overwrote an earlier `agent_skipped - source-rejected` job_status override with `failed - item-deferred`. On prod, **629 of 2,372** deferred jobs in 14d were clean by-design rejections mislabeled as failures (pure job-accounting corruption — no data loss, since `release_claim()` only deletes `status=claimed` dedupe rows).

`FetchItemDispositionTool` now checks the persisted engine snapshot (`EngineData::retrieve()` — `disposition_diagnostic` / `source_rejection` / `item_deferral` keys) before either disposition path runs. If the job is already dispositioned, it returns `success: true` with `already_dispositioned: true` and the message *"Item already dispositioned (source-rejected); no further action needed."* so the model is not pushed into error-retry loops. The second call does **not** touch `job_status`, does not release claims, and does not re-mark processed. Symmetric in both directions: `defer_item` can never downgrade a rejection, and `reject_source` can never overwrite a deferral.

With Fix 1 in place the double-disposition sequence should no longer occur at all (the conversation ends at the first disposition); Fix 2 is the belt-and-suspenders invariant.

## Test results

All run with `php tests/<file>.php` in the worktree:

```
php -l inc/Engine/AI/DataMachineHandlerCompletionPolicy.php    — No syntax errors
php -l inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php — No syntax errors
php -l inc/Core/Steps/Fetch/Handlers/FetchHandler.php          — No syntax errors

tests/fetch-item-dispositions-smoke.php          — 38 assertions, 0 failures (was 25; +13 new)
tests/agent-conversation-runtime-policy-smoke.php — 98 assertions passed (was 93; +5 new)
tests/ai-error-status-propagation-smoke.php       — ALL PASS (25 assertions)
tests/job-outcome-metrics-smoke.php               — ALL PASS (28 assertions)
tests/adjacent-handler-tool-policy-smoke.php      — all assertions passed
tests/pipeline-tool-policy-surfaces-smoke.php     — ALL PASS (10)
tests/react-pipeline-tool-policy-contract-smoke.php — PASSED: 15 assertions
tests/pipeline-tool-policy-snapshot-smoke.php     — PASS
tests/tool-policy-resolver-adjacency-smoke.php    — PASS
tests/batch-completion-strategy-smoke.php         — PASS
```

PHPCS clean on all three changed source files.

Pre-existing baseline failures (verified failing on origin/main before this change, unrelated): `ai-completion-assertion-packet-smoke.php`, `agents-api-memory-contract-adoption-smoke.php`, `agents-api-standalone-skeleton-plan-smoke.php`, `agents-api-wp-ai-client-vocabulary-smoke.php`.

New coverage:
- terminal completion signal completes despite unexecuted configured handlers (definition-declared and result-declared variants)
- natural completion after terminal signal does not nudge
- failed terminal-signal tool does NOT complete the conversation
- `defer_item` after `reject_source` returns idempotent success and does not downgrade `agent_skipped - source-rejected`
- `reject_source` after `defer_item` does not overwrite `failed - item-deferred` and does not mark processed
- second disposition releases no claims, writes no second disposition record
- both disposition tool definitions declare the terminal runtime signal