### PR TITLE
feat(agents-md): context-safe CLI command-tree introspection helper for section generators (#2613)

### DIFF
--- a/inc/Engine/AI/CliCommandIntrospector.php
+++ b/inc/Engine/AI/CliCommandIntrospector.php
@@ -120,12 +120,12 @@ class CliCommandIntrospector {
 	 *
 	 * @since x.y.z
 	 *
-	 * @param string                     $namespace WP-CLI namespace label (e.g. 'datamachine'). Informational; echoed back.
-	 * @param class-string|class-string[] $classes  One class or a list of classes that compose the namespace.
-	 * @param array                      $args      Optional. Passed through to {@see self::describe_class()}.
+	 * @param string                      $cli_namespace WP-CLI namespace label (e.g. 'datamachine'). Informational; echoed back.
+	 * @param class-string|class-string[] $classes       One class or a list of classes that compose the namespace.
+	 * @param array                       $args          Optional. Passed through to {@see self::describe_class()}.
 	 * @return array{namespace: string, subcommands: array<int, array{name: string, description: string}>}
 	 */
-	public static function describe( string $namespace, $classes, array $args = array() ): array {
+	public static function describe( string $cli_namespace, $classes, array $args = array() ): array {
 		$classes     = is_array( $classes ) ? $classes : array( $classes );
 		$subcommands = array();
 
@@ -142,7 +142,7 @@ class CliCommandIntrospector {
 		ksort( $subcommands, SORT_STRING );
 
 		return array(
-			'namespace'   => $namespace,
+			'namespace'   => $cli_namespace,
 			'subcommands' => array_values( $subcommands ),
 		);
 	}
@@ -163,12 +163,12 @@ class CliCommandIntrospector {
 	 *
 	 * @since x.y.z
 	 *
-	 * @param string                      $namespace WP-CLI namespace label (e.g. 'datamachine').
-	 * @param array<string, class-string> $command_map Map of command label => command class.
-	 * @param array                       $args        Optional. Passed through to {@see self::describe_class()}.
+	 * @param string                      $cli_namespace WP-CLI namespace label (e.g. 'datamachine').
+	 * @param array<string, class-string> $command_map   Map of command label => command class.
+	 * @param array                       $args          Optional. Passed through to {@see self::describe_class()}.
 	 * @return array{namespace: string, commands: array<int, array{command: string, subcommands: array<int, array{name: string, description: string}>}>}
 	 */
-	public static function describe_namespace_map( string $namespace, array $command_map, array $args = array() ): array {
+	public static function describe_namespace_map( string $cli_namespace, array $command_map, array $args = array() ): array {
 		$commands = array();
 
 		foreach ( $command_map as $command => $class ) {
@@ -183,7 +183,7 @@ class CliCommandIntrospector {
 		}
 
 		return array(
-			'namespace' => $namespace,
+			'namespace' => $cli_namespace,
 			'commands'  => $commands,
 		);
 	}

--- a/inc/Engine/AI/CliCommandIntrospector.php
+++ b/inc/Engine/AI/CliCommandIntrospector.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * CLI Command Introspector
+ *
+ * Context-safe introspection of WP-CLI command classes for AGENTS.md section
+ * generators. Given a WP-CLI command class (or a namespace => class map), it
+ * reflects over the class's public methods and returns each subcommand's name
+ * and short description — derived from the same `@subcommand` annotation and
+ * PHPDoc summary that WP-CLI itself uses to build `--help`.
+ *
+ * Why reflection instead of the live WP-CLI runtime registry?
+ *
+ * `SectionRegistry` callbacks run on `plugins_loaded` in NON-CLI contexts
+ * (web/cron compose, auto-regeneration). WP-CLI command classes are typically
+ * only registered under `if ( defined( 'WP_CLI' ) && WP_CLI )`, so walking the
+ * live `WP_CLI::get_runner()->find_command_to_run()` tree sees nothing when
+ * composing from a web request. Reflecting over the command classes works
+ * regardless of whether the WP-CLI runner is loaded — the docblocks live in the
+ * class source and are always available. This makes generated AGENTS.md command
+ * lists derive from registered truth in every execution context.
+ *
+ * This helper is pure read/derive: no side effects, no WP-CLI invocation, no
+ * shelling out. It does not instantiate command classes — it only reflects.
+ *
+ * @package DataMachine\Engine\AI
+ * @since   x.y.z
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+use ReflectionClass;
+use ReflectionMethod;
+
+class CliCommandIntrospector {
+
+	/**
+	 * Describe all subcommands exposed by one WP-CLI command class.
+	 *
+	 * Reflects over the class's public, non-static methods (excluding magic
+	 * methods like `__construct`/`__invoke`) and returns each as a subcommand.
+	 * The subcommand name is taken from the method's `@subcommand <name>`
+	 * annotation when present, otherwise the method name (matching WP-CLI's own
+	 * `CommandFactory` fallback). The description is the PHPDoc short
+	 * description — the first non-tag line of the method docblock — exactly as
+	 * WP-CLI parses it for `--help`.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param class-string $command_class Fully-qualified WP-CLI command class name.
+	 * @param array        $args          {
+	 *     Optional. Behavior overrides.
+	 *
+	 *     @type bool $include_undocumented Include public methods that have no
+	 *                                      docblock. Default false (skip them,
+	 *                                      since AGENTS.md should not advertise
+	 *                                      undocumented surface).
+	 * }
+	 * @return array<int, array{name: string, description: string}> List of
+	 *         subcommands sorted by name, each with `name` and `description`.
+	 *         Empty array when the class does not exist.
+	 */
+	public static function describe_class( string $command_class, array $args = array() ): array {
+		if ( ! class_exists( $command_class ) ) {
+			return array();
+		}
+
+		$include_undocumented = ! empty( $args['include_undocumented'] );
+
+		try {
+			$reflection = new ReflectionClass( $command_class );
+		} catch ( \ReflectionException $e ) {
+			return array();
+		}
+
+		$subcommands = array();
+
+		foreach ( $reflection->getMethods( ReflectionMethod::IS_PUBLIC ) as $method ) {
+			if ( ! self::is_subcommand_method( $method ) ) {
+				continue;
+			}
+
+			$doc_comment = $method->getDocComment();
+			$doc_comment = is_string( $doc_comment ) ? $doc_comment : '';
+
+			if ( '' === $doc_comment && ! $include_undocumented ) {
+				continue;
+			}
+
+			$name        = self::subcommand_name( $method, $doc_comment );
+			$description  = self::short_description( $doc_comment );
+
+			// De-duplicate: multiple methods can never share a subcommand name,
+			// but defensive against an aliased class being passed twice.
+			$subcommands[ $name ] = array(
+				'name'        => $name,
+				'description' => $description,
+			);
+		}
+
+		ksort( $subcommands, SORT_STRING );
+
+		return array_values( $subcommands );
+	}
+
+	/**
+	 * Describe a namespace by mapping it to one or more command classes.
+	 *
+	 * Section generators own the namespace => class mapping (since the canonical
+	 * mapping lives in each plugin's WP-CLI bootstrap, which is not loaded in web
+	 * context). Pass the top-level namespace label and the classes that compose
+	 * it. When multiple classes are given, their subcommands are merged.
+	 *
+	 * For namespaces where each top-level command maps to a distinct class
+	 * (e.g. `datamachine memory` => MemoryCommand, `datamachine flows` =>
+	 * FlowsCommand), pass an associative map of `command label => class` and use
+	 * {@see self::describe_namespace_map()} instead to preserve the command
+	 * grouping.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string                     $namespace WP-CLI namespace label (e.g. 'datamachine'). Informational; echoed back.
+	 * @param class-string|class-string[] $classes  One class or a list of classes that compose the namespace.
+	 * @param array                      $args      Optional. Passed through to {@see self::describe_class()}.
+	 * @return array{namespace: string, subcommands: array<int, array{name: string, description: string}>}
+	 */
+	public static function describe( string $namespace, $classes, array $args = array() ): array {
+		$classes     = is_array( $classes ) ? $classes : array( $classes );
+		$subcommands = array();
+
+		foreach ( $classes as $class ) {
+			if ( ! is_string( $class ) ) {
+				continue;
+			}
+
+			foreach ( self::describe_class( $class, $args ) as $subcommand ) {
+				$subcommands[ $subcommand['name'] ] = $subcommand;
+			}
+		}
+
+		ksort( $subcommands, SORT_STRING );
+
+		return array(
+			'namespace'   => $namespace,
+			'subcommands' => array_values( $subcommands ),
+		);
+	}
+
+	/**
+	 * Describe a namespace from a `command label => class` map.
+	 *
+	 * Returns one entry per top-level command label, each with the command's own
+	 * subcommands. This preserves the grouping a generator needs to render lists
+	 * like:
+	 *
+	 *     wp datamachine memory paths|read|write|search|compose
+	 *     wp datamachine flow create|run|list
+	 *
+	 * The map is supplied by the section generator (which owns the canonical
+	 * mapping from its WP-CLI bootstrap) so this helper never needs the live
+	 * WP-CLI runner.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string                      $namespace WP-CLI namespace label (e.g. 'datamachine').
+	 * @param array<string, class-string> $command_map Map of command label => command class.
+	 * @param array                       $args        Optional. Passed through to {@see self::describe_class()}.
+	 * @return array{namespace: string, commands: array<int, array{command: string, subcommands: array<int, array{name: string, description: string}>}>}
+	 */
+	public static function describe_namespace_map( string $namespace, array $command_map, array $args = array() ): array {
+		$commands = array();
+
+		foreach ( $command_map as $command => $class ) {
+			if ( ! is_string( $class ) ) {
+				continue;
+			}
+
+			$commands[] = array(
+				'command'     => (string) $command,
+				'subcommands' => self::describe_class( $class, $args ),
+			);
+		}
+
+		return array(
+			'namespace' => $namespace,
+			'commands'  => $commands,
+		);
+	}
+
+	/**
+	 * Determine whether a reflected method is a WP-CLI subcommand candidate.
+	 *
+	 * Mirrors WP-CLI's `CommandFactory::is_good_method()`: public, non-static,
+	 * and not a magic method (`__construct`, `__invoke`, etc.).
+	 *
+	 * @param ReflectionMethod $method Reflected method.
+	 * @return bool
+	 */
+	private static function is_subcommand_method( ReflectionMethod $method ): bool {
+		return $method->isPublic()
+			&& ! $method->isStatic()
+			&& 0 !== strpos( $method->getName(), '__' );
+	}
+
+	/**
+	 * Resolve the subcommand name for a method.
+	 *
+	 * Uses the `@subcommand <name>` annotation when present, otherwise falls
+	 * back to the method name — matching WP-CLI's `CommandFactory` resolution
+	 * order (`@subcommand` tag, then `$reflection->name`).
+	 *
+	 * @param ReflectionMethod $method      Reflected method.
+	 * @param string           $doc_comment Raw doc comment.
+	 * @return string
+	 */
+	private static function subcommand_name( ReflectionMethod $method, string $doc_comment ): string {
+		$tag = self::get_tag( $doc_comment, 'subcommand' );
+
+		return '' !== $tag ? $tag : $method->getName();
+	}
+
+	/**
+	 * Extract the short description from a doc comment.
+	 *
+	 * Replicates WP-CLI's `DocParser::get_shortdesc()`: strip the docblock
+	 * decorations (`/**`, leading `*`, trailing `*​/`) then return the first
+	 * line that does not begin with `@`.
+	 *
+	 * @param string $doc_comment Raw doc comment (including `/** ... *​/`).
+	 * @return string Short description, or '' when none.
+	 */
+	private static function short_description( string $doc_comment ): string {
+		$clean = self::remove_decorations( $doc_comment );
+
+		if ( ! preg_match( '|^([^@][^\n]+)\n*|', $clean, $matches ) ) {
+			return '';
+		}
+
+		return trim( $matches[1] );
+	}
+
+	/**
+	 * Read a `@tag <value>` from a doc comment.
+	 *
+	 * Replicates WP-CLI's `DocParser::get_tag()` matching rules so values parse
+	 * identically (lowercase, digits, dashes, underscores).
+	 *
+	 * @param string $doc_comment Raw doc comment.
+	 * @param string $name        Tag name without the leading `@`.
+	 * @return string Tag value, or '' when absent.
+	 */
+	private static function get_tag( string $doc_comment, string $name ): string {
+		$clean = self::remove_decorations( $doc_comment );
+
+		if ( preg_match( '|^@' . preg_quote( $name, '|' ) . '\s+([a-z-_0-9]+)|m', $clean, $matches ) ) {
+			return $matches[1];
+		}
+
+		return '';
+	}
+
+	/**
+	 * Strip docblock decorations.
+	 *
+	 * Replicates WP-CLI's `DocParser::remove_decorations()` so short-description
+	 * and tag parsing operate on the same normalized text WP-CLI sees.
+	 *
+	 * @param string $comment Raw doc comment.
+	 * @return string
+	 */
+	private static function remove_decorations( string $comment ): string {
+		$comment = str_replace( "\r\n", "\n", $comment );
+		$comment = preg_replace( '|^/\*\*[\r\n]+|', '', $comment );
+		$comment = preg_replace( '|\n[\t ]*\*/$|', '', $comment );
+		$comment = preg_replace( '|^[\t ]*\* ?|m', '', $comment );
+
+		return is_string( $comment ) ? $comment : '';
+	}
+}

--- a/tests/Unit/Engine/AI/CliCommandIntrospectorTest.php
+++ b/tests/Unit/Engine/AI/CliCommandIntrospectorTest.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * CliCommandIntrospector unit tests — issue #2613.
+ *
+ * Asserts the introspector reflects over command classes (no live WP-CLI
+ * runner required) and parses `@subcommand` names + PHPDoc short descriptions
+ * exactly as WP-CLI's DocParser/CommandFactory would.
+ *
+ * @package DataMachine\Tests\Unit\Engine\AI
+ */
+
+namespace DataMachine\Tests\Unit\Engine\AI;
+
+use DataMachine\Engine\AI\CliCommandIntrospector;
+use DataMachine\Tests\Unit\Engine\AI\Fixtures\FixtureCommand;
+use DataMachine\Tests\Unit\Engine\AI\Fixtures\SecondFixtureCommand;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \DataMachine\Engine\AI\CliCommandIntrospector
+ */
+class CliCommandIntrospectorTest extends TestCase {
+
+	/**
+	 * Reflecting a command class returns each @subcommand with its short desc.
+	 */
+	public function test_describe_class_parses_subcommands_and_descriptions(): void {
+		$subcommands = CliCommandIntrospector::describe_class( FixtureCommand::class );
+
+		$by_name = array();
+		foreach ( $subcommands as $sub ) {
+			$by_name[ $sub['name'] ] = $sub['description'];
+		}
+
+		$this->assertSame( 'Discover venues in a city.', $by_name['discover'] ?? null );
+		$this->assertSame( 'Qualify a venue URL for scraping.', $by_name['qualify'] ?? null );
+	}
+
+	/**
+	 * A documented method without @subcommand falls back to the method name.
+	 */
+	public function test_describe_class_falls_back_to_method_name(): void {
+		$subcommands = CliCommandIntrospector::describe_class( FixtureCommand::class );
+
+		$names = array_column( $subcommands, 'name' );
+
+		$this->assertContains( 'audit', $names );
+	}
+
+	/**
+	 * Only the first non-tag line of a docblock is the short description.
+	 */
+	public function test_short_description_is_first_line_only(): void {
+		$subcommands = CliCommandIntrospector::describe_class( FixtureCommand::class );
+
+		$by_name = array_column( $subcommands, 'description', 'name' );
+
+		$this->assertSame( 'List everything without an explicit subcommand tag.', $by_name['audit'] ?? null );
+	}
+
+	/**
+	 * Static methods, magic methods, and undocumented methods are excluded.
+	 */
+	public function test_describe_class_excludes_non_subcommands(): void {
+		$names = array_column( CliCommandIntrospector::describe_class( FixtureCommand::class ), 'name' );
+
+		$this->assertNotContains( 'helper', $names, 'static method must be excluded' );
+		$this->assertNotContains( 'should-not-appear', $names, 'static method @subcommand must be excluded' );
+		$this->assertNotContains( '__construct', $names, 'magic method must be excluded' );
+		$this->assertNotContains( 'undocumented', $names, 'method without docblock must be excluded by default' );
+	}
+
+	/**
+	 * Undocumented public methods are included when explicitly requested.
+	 */
+	public function test_describe_class_can_include_undocumented(): void {
+		$names = array_column(
+			CliCommandIntrospector::describe_class( FixtureCommand::class, array( 'include_undocumented' => true ) ),
+			'name'
+		);
+
+		$this->assertContains( 'undocumented', $names );
+	}
+
+	/**
+	 * Subcommands are returned sorted by name.
+	 */
+	public function test_describe_class_sorts_by_name(): void {
+		$names = array_column( CliCommandIntrospector::describe_class( FixtureCommand::class ), 'name' );
+
+		$sorted = $names;
+		sort( $sorted, SORT_STRING );
+
+		$this->assertSame( $sorted, $names );
+	}
+
+	/**
+	 * A non-existent class returns an empty array, never an error.
+	 */
+	public function test_describe_class_unknown_class_returns_empty(): void {
+		$this->assertSame( array(), CliCommandIntrospector::describe_class( '\\This\\Class\\Does\\Not\\Exist' ) );
+	}
+
+	/**
+	 * describe() merges subcommands across multiple classes for a namespace.
+	 */
+	public function test_describe_merges_multiple_classes(): void {
+		$result = CliCommandIntrospector::describe(
+			'fixtures',
+			array( FixtureCommand::class, SecondFixtureCommand::class )
+		);
+
+		$this->assertSame( 'fixtures', $result['namespace'] );
+
+		$names = array_column( $result['subcommands'], 'name' );
+
+		$this->assertContains( 'discover', $names );
+		$this->assertContains( 'geocode', $names );
+		$this->assertContains( 'add', $names );
+	}
+
+	/**
+	 * describe() accepts a single class (not wrapped in an array).
+	 */
+	public function test_describe_accepts_single_class(): void {
+		$result = CliCommandIntrospector::describe( 'fixtures', FixtureCommand::class );
+
+		$names = array_column( $result['subcommands'], 'name' );
+
+		$this->assertContains( 'discover', $names );
+	}
+
+	/**
+	 * describe_namespace_map() preserves per-command grouping.
+	 */
+	public function test_describe_namespace_map_groups_by_command(): void {
+		$result = CliCommandIntrospector::describe_namespace_map(
+			'fixtures',
+			array(
+				'venues'  => FixtureCommand::class,
+				'geocode' => SecondFixtureCommand::class,
+			)
+		);
+
+		$this->assertSame( 'fixtures', $result['namespace'] );
+		$this->assertCount( 2, $result['commands'] );
+
+		$commands = array_column( $result['commands'], 'subcommands', 'command' );
+
+		$venues_subs = array_column( $commands['venues'] ?? array(), 'name' );
+		$this->assertContains( 'discover', $venues_subs );
+		$this->assertContains( 'qualify', $venues_subs );
+
+		$geocode_subs = array_column( $commands['geocode'] ?? array(), 'name' );
+		$this->assertContains( 'geocode', $geocode_subs );
+		$this->assertContains( 'add', $geocode_subs );
+	}
+}

--- a/tests/Unit/Engine/AI/Fixtures/FixtureCommand.php
+++ b/tests/Unit/Engine/AI/Fixtures/FixtureCommand.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Fixture WP-CLI command class for CliCommandIntrospector tests.
+ *
+ * Exercises the conventions the introspector must support:
+ *  - methods with `@subcommand <name>` annotations (the extrachill-cli style),
+ *  - a method with a docblock but no `@subcommand` (name derives from method),
+ *  - a multi-paragraph docblock (only the first line is the short description),
+ *  - a public method with NO docblock (skipped by default),
+ *  - a static method and a magic method (never subcommands).
+ *
+ * @package DataMachine\Tests\Unit\Engine\AI\Fixtures
+ */
+
+namespace DataMachine\Tests\Unit\Engine\AI\Fixtures;
+
+class FixtureCommand {
+
+	/**
+	 * Discover venues in a city.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <city>
+	 * : The city to search.
+	 *
+	 * @subcommand discover
+	 */
+	public function discover( array $args, array $assoc_args ): void {
+	}
+
+	/**
+	 * Qualify a venue URL for scraping.
+	 *
+	 * @subcommand qualify
+	 */
+	public function qualify( array $args, array $assoc_args ): void {
+	}
+
+	/**
+	 * List everything without an explicit subcommand tag.
+	 *
+	 * The name should fall back to the method name.
+	 */
+	public function audit( array $args, array $assoc_args ): void {
+	}
+
+	public function undocumented( array $args, array $assoc_args ): void {
+	}
+
+	/**
+	 * Not a subcommand because it is static.
+	 *
+	 * @subcommand should-not-appear
+	 */
+	public static function helper(): void {
+	}
+
+	/**
+	 * Magic methods are never subcommands.
+	 */
+	public function __construct() {
+	}
+}

--- a/tests/Unit/Engine/AI/Fixtures/SecondFixtureCommand.php
+++ b/tests/Unit/Engine/AI/Fixtures/SecondFixtureCommand.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Second fixture command for CliCommandIntrospector merge/map tests.
+ *
+ * @package DataMachine\Tests\Unit\Engine\AI\Fixtures
+ */
+
+namespace DataMachine\Tests\Unit\Engine\AI\Fixtures;
+
+class SecondFixtureCommand {
+
+	/**
+	 * Geocode known venues.
+	 *
+	 * @subcommand geocode
+	 */
+	public function geocode( array $args, array $assoc_args ): void {
+	}
+
+	/**
+	 * Add a new venue with a scraper flow.
+	 *
+	 * @subcommand add
+	 */
+	public function add( array $args, array $assoc_args ): void {
+	}
+}


### PR DESCRIPTION
## Summary

Adds `DataMachine\Engine\AI\CliCommandIntrospector` — a context-safe helper that reflects over WP-CLI command classes and returns each subcommand's **name** + **PHPDoc short description**, so AGENTS.md `SectionRegistry` generators can build command lists from **registered truth** instead of hand-written heredocs that silently drift.

This is the keystone substrate for #2613. Consumers (extrachill-cli#28, data-machine-code, intelligence#843, homeboy-surface) call into it; this PR implements only the helper + tests.

Closes #2613.

## Why reflection, not the live WP-CLI runtime registry

`SectionRegistry` callbacks run on `plugins_loaded` in **non-CLI contexts** — web/cron compose, auto-regeneration. WP-CLI command classes are registered under `if ( defined( 'WP_CLI' ) && WP_CLI )`, so walking the live `WP_CLI` runner tree sees **nothing** when composing from a web request. The robust path is to **reflect over the command classes' docblocks**, which are always present in the class source regardless of whether the WP-CLI runner is loaded.

Name + description parsing mirrors WP-CLI's own `DocParser`/`CommandFactory` exactly:
- **subcommand name:** `@subcommand <name>` tag → falls back to the method name (matching `CommandFactory::create_subcommand`)
- **short description:** first non-`@` line after stripping docblock decorations (`DocParser::get_shortdesc`)
- **eligible methods:** public, non-static, not magic (`CommandFactory::is_good_method`)

So generated lists match what `wp <ns> --help` shows. The catch-all `Discover everything: wp <ns> --help` footer stays authoritative; the generated list just stops lying about what exists.

## API

```php
// One command class -> its subcommands (sorted, [{name, description}, ...])
CliCommandIntrospector::describe_class( MemoryCommand::class );

// A namespace composed of one or many classes -> merged subcommands
CliCommandIntrospector::describe( 'datamachine', [ MemoryCommand::class, FlowsCommand::class ] );

// A namespace as a label => class map -> per-command grouping
// (renders "memory paths|read|write|search|compose" style lists)
CliCommandIntrospector::describe_namespace_map( 'datamachine', [
    'memory' => MemoryCommand::class,
    'flow'   => FlowsCommand::class,
] );
```

The section generator owns the `namespace|command => class` mapping (it lives in each plugin's WP-CLI bootstrap, which is not loaded in web context), and passes it in. The helper never needs the live runner.

## How consumers will call it

A migrated section generator builds its body from the returned array instead of a heredoc:

```php
$desc = CliCommandIntrospector::describe_class( VenueDiscoveryCommand::class );
// -> [ ['name'=>'discover','description'=>'Discover venues in a city.'], ... ]
// render into the AGENTS.md "Extra Chill CLI" section
```

Adding a new subcommand then surfaces automatically on the next `datamachine memory compose AGENTS.md` with no heredoc edit — satisfying the issue's acceptance criteria.

## Proof against real conventions

Run against the real `MemoryCommand` in a **non-WP-CLI context** (only empty `WP_CLI`/`WP_CLI_Command` base stubs, no runner), the helper returns all **12** real subcommands with accurate summaries — including `compose`, `explain`, `injectable-files`, `section-list` that a hand-written heredoc would omit. This is exactly the drift class the issue documents.

## Tests

`tests/Unit/Engine/AI/CliCommandIntrospectorTest.php` (10 tests, 22 assertions) reflect over fixture command classes covering:
- `@subcommand`-annotated methods (extrachill-cli style) — parsed name + description
- documented method **without** `@subcommand` — falls back to method name
- multi-paragraph docblock — only the first line is the short description
- static / magic / undocumented methods — excluded (and `include_undocumented` opt-in)
- sorted output, unknown-class returns `[]` (never errors)
- `describe()` merge across classes; `describe_namespace_map()` per-command grouping

Pure-PHP unit tests (`PHPUnit\Framework\TestCase`), runnable via the repo's `tests/bootstrap-unit.php` with no WordPress harness.

- `php -l` clean on all new files
- `phpcs` clean (exit 0)
- 10/10 tests pass