### PR TITLE
style(agents-md): clear CliCommandIntrospector lint alignment warning

### DIFF
--- a/inc/Engine/AI/CliCommandIntrospector.php
+++ b/inc/Engine/AI/CliCommandIntrospector.php
@@ -89,7 +89,7 @@ class CliCommandIntrospector {
 			}
 
 			$name        = self::subcommand_name( $method, $doc_comment );
-			$description  = self::short_description( $doc_comment );
+			$description = self::short_description( $doc_comment );
 
 			// De-duplicate: multiple methods can never share a subcommand name,
 			// but defensive against an aliased class being passed twice.


### PR DESCRIPTION
## Summary

Follow-up to #2614. That PR was squash-merged (`7ab7a8b8`) at the commit before the equals-sign alignment fix landed on the branch, so `main` now carries a `Generic.Formatting.MultipleStatementAlignment.NotSameWarning` on the `$description` assignment in `CliCommandIntrospector::describe_class()`. The lint gate fails on warnings.

This is the one-line whitespace fix (two spaces → one before `=`), nothing else.

Refs #2613, #2614.