### PR TITLE
fix: clear PHPCS lint debt from AS retention cleanup + neighbouring alignment

### DIFF
--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -54,14 +54,14 @@ class RequestBuilder {
 	) {
 		WpAiClientCache::install();
 
-		$modes            = self::normalizeModes( $modes );
-		$mode_label       = implode( ',', $modes );
-		$assembled        = self::assemble( $messages, $provider, $model, $tools, $modes, $payload );
-		$request          = $assembled['request'];
-		$structured_tools       = $assembled['structured_tools'];
-		$provider_tool_aliases  = self::providerToolNameAliases( $structured_tools );
-		$provider_request       = ProviderRequestAssembler::toProviderRequest( $request );
-		$prompt_context         = self::wpAiClientPromptContext( $request['messages'] ?? array(), $provider_tool_aliases['logical_to_provider'] );
+		$modes                 = self::normalizeModes( $modes );
+		$mode_label            = implode( ',', $modes );
+		$assembled             = self::assemble( $messages, $provider, $model, $tools, $modes, $payload );
+		$request               = $assembled['request'];
+		$structured_tools      = $assembled['structured_tools'];
+		$provider_tool_aliases = self::providerToolNameAliases( $structured_tools );
+		$provider_request      = ProviderRequestAssembler::toProviderRequest( $request );
+		$prompt_context        = self::wpAiClientPromptContext( $request['messages'] ?? array(), $provider_tool_aliases['logical_to_provider'] );
 		if ( '' !== $prompt_context['prompt'] ) {
 			$provider_request['prompt'] = $prompt_context['prompt'];
 		}

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -771,7 +771,7 @@ class RequestBuilder {
 	public static function providerToolNameAliases( array $tools ): array {
 		$logical_to_provider = array();
 		$provider_to_logical = array();
-		$used               = array();
+		$used                = array();
 
 		foreach ( $tools as $tool_name => $tool_config ) {
 			$logical_name = (string) ( $tool_config['name'] ?? $tool_name );
@@ -786,7 +786,7 @@ class RequestBuilder {
 
 			$used[ $provider_name ] = $logical_name;
 			if ( $provider_name !== $logical_name ) {
-				$logical_to_provider[ $logical_name ] = $provider_name;
+				$logical_to_provider[ $logical_name ]  = $provider_name;
 				$provider_to_logical[ $provider_name ] = $logical_name;
 			}
 		}

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -332,42 +332,62 @@ class RetentionCleanup {
 		$logs_count    = 0;
 
 		foreach ( self::actionSchedulerCleanupWindows() as $window ) {
-			$cutoff    = $window['cutoff'];
-			$hook      = $window['hook'];
-			$hook_args = null === $hook ? array() : array( $hook );
+			$cutoff = $window['cutoff'];
+			$hook   = $window['hook'];
 
-			$actions_args = array_merge(
-				array( $actions_table, 'complete', 'failed', 'canceled', $cutoff ),
-				$hook_args
-			);
+			if ( null === $hook ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$actions_count += (int) $wpdb->get_var(
+					$wpdb->prepare(
+						'SELECT COUNT(*) FROM %i WHERE status IN (%s, %s, %s) AND last_attempt_gmt < %s',
+						$actions_table,
+						'complete',
+						'failed',
+						'canceled',
+						$cutoff
+					)
+				);
 
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$actions_count += (int) $wpdb->get_var(
-				$wpdb->prepare(
-					'SELECT COUNT(*) FROM %i
-					WHERE status IN (%s, %s, %s)
-					AND last_attempt_gmt < %s'
-					. ( null === $hook ? '' : ' AND hook = %s' ),
-					$actions_args
-				)
-			);
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$logs_count += (int) $wpdb->get_var(
+					$wpdb->prepare(
+						'SELECT COUNT(*) FROM %i l INNER JOIN %i a ON l.action_id = a.action_id WHERE a.status IN (%s, %s, %s) AND a.last_attempt_gmt < %s',
+						$logs_table,
+						$actions_table,
+						'complete',
+						'failed',
+						'canceled',
+						$cutoff
+					)
+				);
+			} else {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$actions_count += (int) $wpdb->get_var(
+					$wpdb->prepare(
+						'SELECT COUNT(*) FROM %i WHERE status IN (%s, %s, %s) AND last_attempt_gmt < %s AND hook = %s',
+						$actions_table,
+						'complete',
+						'failed',
+						'canceled',
+						$cutoff,
+						$hook
+					)
+				);
 
-			$logs_args = array_merge(
-				array( $logs_table, $actions_table, 'complete', 'failed', 'canceled', $cutoff ),
-				$hook_args
-			);
-
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$logs_count += (int) $wpdb->get_var(
-				$wpdb->prepare(
-					'SELECT COUNT(*) FROM %i l
-					INNER JOIN %i a ON l.action_id = a.action_id
-					WHERE a.status IN (%s, %s, %s)
-					AND a.last_attempt_gmt < %s'
-					. ( null === $hook ? '' : ' AND a.hook = %s' ),
-					$logs_args
-				)
-			);
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$logs_count += (int) $wpdb->get_var(
+					$wpdb->prepare(
+						'SELECT COUNT(*) FROM %i l INNER JOIN %i a ON l.action_id = a.action_id WHERE a.status IN (%s, %s, %s) AND a.last_attempt_gmt < %s AND a.hook = %s',
+						$logs_table,
+						$actions_table,
+						'complete',
+						'failed',
+						'canceled',
+						$cutoff,
+						$hook
+					)
+				);
+			}
 		}
 
 		return array(
@@ -380,17 +400,16 @@ class RetentionCleanup {
 	public static function cleanupActionSchedulerActions(): array {
 		global $wpdb;
 
-		$max_age_days     = self::actionSchedulerMaxAgeDays();
-		$batch_size       = self::actionSchedulerBatchSize();
-		$max_iterations   = self::actionSchedulerMaxIterations();
-		$max_runtime      = self::actionSchedulerMaxRuntimeSeconds();
-		$actions_table    = $wpdb->prefix . 'actionscheduler_actions';
-		$logs_table       = $wpdb->prefix . 'actionscheduler_logs';
-		$started_at       = microtime( true );
-		$deadline         = $started_at + $max_runtime;
-		$iterations_used  = 0;
-		$hit_limit        = false;
-
+		$max_age_days    = self::actionSchedulerMaxAgeDays();
+		$batch_size      = self::actionSchedulerBatchSize();
+		$max_iterations  = self::actionSchedulerMaxIterations();
+		$max_runtime     = self::actionSchedulerMaxRuntimeSeconds();
+		$actions_table   = $wpdb->prefix . 'actionscheduler_actions';
+		$logs_table      = $wpdb->prefix . 'actionscheduler_logs';
+		$started_at      = microtime( true );
+		$deadline        = $started_at + $max_runtime;
+		$iterations_used = 0;
+		$hit_limit       = false;
 		$logs_deleted    = 0;
 		$actions_deleted = 0;
 
@@ -524,8 +543,7 @@ class RetentionCleanup {
 	): int {
 		global $wpdb;
 
-		$deleted   = 0;
-		$hook_args = null === $hook ? array() : array( $hook );
+		$deleted = 0;
 
 		do {
 			if ( $iterations_used >= $max_iterations || microtime( true ) >= $deadline ) {
@@ -534,28 +552,38 @@ class RetentionCleanup {
 			}
 			++$iterations_used;
 
-			$query_args = array_merge(
-				array( $logs_table, $logs_table, $actions_table, 'complete', 'failed', 'canceled', $cutoff ),
-				$hook_args,
-				array( $batch_size )
-			);
-
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$affected = $wpdb->query(
-				$wpdb->prepare(
-					'DELETE FROM %i WHERE log_id IN (
-						SELECT log_id FROM (
-							SELECT l.log_id FROM %i l
-							INNER JOIN %i a ON l.action_id = a.action_id
-							WHERE a.status IN (%s, %s, %s)
-							AND a.last_attempt_gmt < %s'
-							. ( null === $hook ? '' : ' AND a.hook = %s' ) .
-							' LIMIT %d
-						) AS tmp
-					)',
-					$query_args
-				)
-			);
+			if ( null === $hook ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$affected = $wpdb->query(
+					$wpdb->prepare(
+						'DELETE FROM %i WHERE log_id IN ( SELECT log_id FROM ( SELECT l.log_id FROM %i l INNER JOIN %i a ON l.action_id = a.action_id WHERE a.status IN (%s, %s, %s) AND a.last_attempt_gmt < %s LIMIT %d ) AS tmp )',
+						$logs_table,
+						$logs_table,
+						$actions_table,
+						'complete',
+						'failed',
+						'canceled',
+						$cutoff,
+						$batch_size
+					)
+				);
+			} else {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$affected = $wpdb->query(
+					$wpdb->prepare(
+						'DELETE FROM %i WHERE log_id IN ( SELECT log_id FROM ( SELECT l.log_id FROM %i l INNER JOIN %i a ON l.action_id = a.action_id WHERE a.status IN (%s, %s, %s) AND a.last_attempt_gmt < %s AND a.hook = %s LIMIT %d ) AS tmp )',
+						$logs_table,
+						$logs_table,
+						$actions_table,
+						'complete',
+						'failed',
+						'canceled',
+						$cutoff,
+						$hook,
+						$batch_size
+					)
+				);
+			}
 
 			$affected = false !== $affected ? (int) $affected : 0;
 			$deleted += $affected;
@@ -589,8 +617,7 @@ class RetentionCleanup {
 	): int {
 		global $wpdb;
 
-		$deleted   = 0;
-		$hook_args = null === $hook ? array() : array( $hook );
+		$deleted = 0;
 
 		do {
 			if ( $iterations_used >= $max_iterations || microtime( true ) >= $deadline ) {
@@ -599,27 +626,36 @@ class RetentionCleanup {
 			}
 			++$iterations_used;
 
-			$query_args = array_merge(
-				array( $actions_table, $actions_table, 'complete', 'failed', 'canceled', $cutoff ),
-				$hook_args,
-				array( $batch_size )
-			);
-
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$affected = $wpdb->query(
-				$wpdb->prepare(
-					'DELETE FROM %i WHERE action_id IN (
-						SELECT action_id FROM (
-							SELECT a.action_id FROM %i a
-							WHERE a.status IN (%s, %s, %s)
-							AND a.last_attempt_gmt < %s'
-							. ( null === $hook ? '' : ' AND a.hook = %s' ) .
-							' LIMIT %d
-						) AS tmp
-					)',
-					$query_args
-				)
-			);
+			if ( null === $hook ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$affected = $wpdb->query(
+					$wpdb->prepare(
+						'DELETE FROM %i WHERE action_id IN ( SELECT action_id FROM ( SELECT a.action_id FROM %i a WHERE a.status IN (%s, %s, %s) AND a.last_attempt_gmt < %s LIMIT %d ) AS tmp )',
+						$actions_table,
+						$actions_table,
+						'complete',
+						'failed',
+						'canceled',
+						$cutoff,
+						$batch_size
+					)
+				);
+			} else {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$affected = $wpdb->query(
+					$wpdb->prepare(
+						'DELETE FROM %i WHERE action_id IN ( SELECT action_id FROM ( SELECT a.action_id FROM %i a WHERE a.status IN (%s, %s, %s) AND a.last_attempt_gmt < %s AND a.hook = %s LIMIT %d ) AS tmp )',
+						$actions_table,
+						$actions_table,
+						'complete',
+						'failed',
+						'canceled',
+						$cutoff,
+						$hook,
+						$batch_size
+					)
+				);
+			}
 
 			$affected = false !== $affected ? (int) $affected : 0;
 			$deleted += $affected;

--- a/inc/Engine/Tasks/RecurringRejectionTracker.php
+++ b/inc/Engine/Tasks/RecurringRejectionTracker.php
@@ -111,7 +111,7 @@ class RecurringRejectionTracker {
 			$entry['first_rejected_gmt'] = $now;
 		}
 
-		$threshold     = self::threshold();
+		$threshold      = self::threshold();
 		$just_escalated = false;
 		if ( $entry['count'] >= $threshold && empty( $entry['escalated'] ) ) {
 			$entry['escalated'] = true;


### PR DESCRIPTION
## Summary

PR #2617 (the Action Scheduler retention batching feature) was merged before its lint fix landed, so `main` currently carries PHPCS errors in the retention cleanup. This PR pays down that debt plus the adjacent auto-fixable alignment warnings the whole-repo lint surfaced.

## What changed

1. **`RetentionCleanup.php` — fix 20 PHPCS errors** (`WordPress.DB.PreparedSQL.NotPrepared` + `PreparedSQLPlaceholders.ReplacementsWrongNumber`). The `$wpdb->prepare()` calls in the count/breakdown and batched-delete paths concatenated a ternary hook clause into the query string and passed args as a single array variable, which the sniff can't statically verify. Reworked each into explicit hook / no-hook branches with **fully literal query strings and positional args**. No behavioural change — same windows, same batching, same per-hook logic (covered by `tests/retention-action-scheduler-batching-smoke.php`).

2. **`RequestBuilder.php` + `RecurringRejectionTracker.php` — fix 11 alignment warnings** (`Generic.Formatting.MultipleStatementAlignment`). Aligned the `=` signs within the affected contiguous assignment blocks. No behavioural change.

## Why these landed as debt

The feature PR's first commit merged + auto-released (v0.145.0) before the follow-up lint fix and the alignment cleanup were reviewed. This PR brings `main` lint back to green.

## Verification
- All three files pass `php -l`.
- `=`-column alignment verified uniform per contiguous block.
- Retention smoke tests pass: `retention-system-tasks-smoke.php` (75 assertions) + `retention-action-scheduler-batching-smoke.php` (21 assertions).

> Note: the unrelated pre-existing `main` test failures (RequestBuilderMultimodalTest tool-name drift #2619; abilities-categories-load-order host-smoke crash #2620) are tracked separately and are not addressed here.