### PR TITLE
feat: shed engine_data from terminal jobs via retention (#2622)

### DIFF
--- a/inc/Cli/Commands/RetentionCommand.php
+++ b/inc/Cli/Commands/RetentionCommand.php
@@ -166,6 +166,7 @@ class RetentionCommand extends BaseCommand {
 		);
 
 		$this->report_action_scheduler_detail( $assoc_args );
+		$this->report_engine_data_detail();
 
 		if ( ! $dry_run ) {
 			$total = array_sum( array_column( $results, 'eligible' ) );
@@ -239,6 +240,47 @@ class RetentionCommand extends BaseCommand {
 	}
 
 	/**
+	 * Report terminal-job engine_data shedding detail: eligible rows, the short
+	 * terminal window, and the reclaimable blob bytes a shed pass would free.
+	 *
+	 * engine_data shedding runs asynchronously via a scheduled SystemTask, so
+	 * the actual jobs-updated / OPTIMIZE outcome is logged via `datamachine_log`
+	 * (and stored on the job result) when the task runs. This summary makes the
+	 * planned behaviour visible from the CLI.
+	 */
+	private function report_engine_data_detail(): void {
+		$days = RetentionCleanup::engineDataTerminalMaxAgeDays();
+
+		WP_CLI::log( '' );
+		WP_CLI::log( WP_CLI::colorize( '%BTerminal-job engine_data shedding%n' ) );
+		WP_CLI::log( '' );
+
+		if ( $days <= 0 ) {
+			WP_CLI::log( 'Shedding:        disabled (filter datamachine_engine_data_terminal_max_age_days)' );
+			return;
+		}
+
+		$eligible    = RetentionCleanup::countEngineDataTerminalJobs();
+		$reclaimable = RetentionCleanup::countEngineDataReclaimableBytes();
+
+		WP_CLI::log( sprintf( 'Terminal window: %s after completion', $this->format_days( $days ) ) );
+		WP_CLI::log( sprintf( 'Eligible jobs:   %d (row kept, engine_data blob shed)', $eligible ) );
+		WP_CLI::log( sprintf( 'Reclaimable:     %.1f MB of engine_data blob', $reclaimable / 1024 / 1024 ) );
+		WP_CLI::log( sprintf( 'Batch size:      %d rows/iteration', RetentionCleanup::actionSchedulerBatchSize() ) );
+
+		if ( RetentionCleanup::actionSchedulerOptimizeEnabled() ) {
+			WP_CLI::log(
+				sprintf(
+					'OPTIMIZE TABLE:  enabled (threshold %d rows changed)',
+					RetentionCleanup::actionSchedulerOptimizeThreshold()
+				)
+			);
+		} else {
+			WP_CLI::log( 'OPTIMIZE TABLE:  disabled (filter datamachine_retention_optimize_tables)' );
+		}
+	}
+
+	/**
 	 * Format a fractional-day window for human-readable CLI output.
 	 *
 	 * @param float $days Window in days (may be fractional, e.g. 0.25).
@@ -270,6 +312,12 @@ class RetentionCommand extends BaseCommand {
 				'task_type' => RetentionCleanup::TASK_FAILED_JOBS,
 				'threshold' => RetentionCleanup::failedJobsMaxAgeDays() . ' days',
 				'count'     => array( RetentionCleanup::class, 'countFailedJobs' ),
+			),
+			array(
+				'label'     => 'Terminal engine_data',
+				'task_type' => RetentionCleanup::TASK_ENGINE_DATA,
+				'threshold' => $this->format_days( RetentionCleanup::engineDataTerminalMaxAgeDays() ),
+				'count'     => array( RetentionCleanup::class, 'countEngineDataTerminalJobs' ),
 			),
 			array(
 				'label'     => 'Pipeline logs',
@@ -330,6 +378,10 @@ class RetentionCommand extends BaseCommand {
 			'Failed jobs'     => array(
 				'retention' => apply_filters( 'datamachine_failed_jobs_max_age_days', 30 ) . ' days',
 				'filter'    => 'datamachine_failed_jobs_max_age_days',
+			),
+			'Terminal engine_data' => array(
+				'retention' => $this->format_days( RetentionCleanup::engineDataTerminalMaxAgeDays() ),
+				'filter'    => 'datamachine_engine_data_terminal_max_age_days',
 			),
 			'Pipeline logs'   => array(
 				'retention' => apply_filters( 'datamachine_log_max_age_days', 7 ) . ' days',

--- a/inc/Cli/Commands/RetentionCommand.php
+++ b/inc/Cli/Commands/RetentionCommand.php
@@ -371,11 +371,11 @@ class RetentionCommand extends BaseCommand {
 	 */
 	private function get_retention_policies(): array {
 		return array(
-			'Completed jobs'  => array(
+			'Completed jobs'       => array(
 				'retention' => apply_filters( 'datamachine_completed_jobs_max_age_days', 30 ) . ' days',
 				'filter'    => 'datamachine_completed_jobs_max_age_days',
 			),
-			'Failed jobs'     => array(
+			'Failed jobs'          => array(
 				'retention' => apply_filters( 'datamachine_failed_jobs_max_age_days', 30 ) . ' days',
 				'filter'    => 'datamachine_failed_jobs_max_age_days',
 			),
@@ -383,32 +383,32 @@ class RetentionCommand extends BaseCommand {
 				'retention' => $this->format_days( RetentionCleanup::engineDataTerminalMaxAgeDays() ),
 				'filter'    => 'datamachine_engine_data_terminal_max_age_days',
 			),
-			'Pipeline logs'   => array(
+			'Pipeline logs'        => array(
 				'retention' => apply_filters( 'datamachine_log_max_age_days', 7 ) . ' days',
 				'filter'    => 'datamachine_log_max_age_days',
 			),
-			'Processed items' => array(
+			'Processed items'      => array(
 				'retention' => apply_filters( 'datamachine_processed_items_max_age_days', 30 ) . ' days',
 				'filter'    => 'datamachine_processed_items_max_age_days',
 			),
-			'AS actions'      => array(
+			'AS actions'           => array(
 				'retention' => apply_filters( 'datamachine_as_actions_max_age_days', 7 ) . ' days'
 					. ( empty( RetentionCleanup::actionSchedulerHookMaxAgeDays() ) ? '' : ' (+per-hook)' ),
 				'filter'    => 'datamachine_as_actions_max_age_days',
 			),
-			'Stale claims'    => array(
+			'Stale claims'         => array(
 				'retention' => round( apply_filters( 'datamachine_stale_claim_max_age', DAY_IN_SECONDS ) / 3600 ) . ' hours',
 				'filter'    => 'datamachine_stale_claim_max_age',
 			),
-			'Chat sessions'   => array(
+			'Chat sessions'        => array(
 				'retention' => \DataMachine\Core\PluginSettings::get( 'chat_retention_days', 90 ) . ' days',
 				'filter'    => 'setting: chat_retention_days',
 			),
-			'File cleanup'    => array(
+			'File cleanup'         => array(
 				'retention' => \DataMachine\Core\PluginSettings::get( 'file_retention_days', 7 ) . ' days',
 				'filter'    => 'setting: file_retention_days',
 			),
-			'Job artifacts'   => array(
+			'Job artifacts'        => array(
 				'retention' => RetentionCleanup::jobArtifactsMaxAgeDays() . ' days',
 				'filter'    => 'datamachine_job_artifacts_max_age_days',
 			),

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -209,10 +209,10 @@ class Jobs extends BaseRepository {
 		if ( ! empty( $args['handler'] ) ) {
 			$handler = sanitize_key( (string) $args['handler'] );
 			if ( '' !== $handler ) {
-				$where_clauses[] = '(engine_data LIKE %s OR engine_data LIKE %s OR engine_data LIKE %s)';
-				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler_slug":"' . $handler . '"' ) . '%';
-				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler":"' . $handler . '"' ) . '%';
-				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler_slugs":["' . $handler . '"' ) . '%';
+				// Match the promoted handler_slug column so filtering survives
+				// engine_data being shed from terminal jobs by retention.
+				$where_clauses[] = 'handler_slug = %s';
+				$where_values[]  = $handler;
 			}
 		}
 
@@ -320,10 +320,10 @@ class Jobs extends BaseRepository {
 		if ( ! empty( $args['handler'] ) ) {
 			$handler = sanitize_key( (string) $args['handler'] );
 			if ( '' !== $handler ) {
-				$where_clauses[] = '(' . $prefix . 'engine_data LIKE %s OR ' . $prefix . 'engine_data LIKE %s OR ' . $prefix . 'engine_data LIKE %s)';
-				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler_slug":"' . $handler . '"' ) . '%';
-				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler":"' . $handler . '"' ) . '%';
-				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler_slugs":["' . $handler . '"' ) . '%';
+				// Match the promoted handler_slug column so filtering survives
+				// engine_data being shed from terminal jobs by retention.
+				$where_clauses[] = $prefix . 'handler_slug = %s';
+				$where_values[]  = $handler;
 			}
 		}
 
@@ -447,22 +447,21 @@ class Jobs extends BaseRepository {
 			);
 		}
 
+		// Aggregate from the promoted handler_slug column rather than scanning
+		// engine_data. This keeps handler summaries correct even after
+		// retention sheds engine_data from terminal jobs (the column survives).
 		$handler_where = '' === $where_sql
-			? 'WHERE j.engine_data LIKE %s'
-			: $where_sql . ' AND j.engine_data LIKE %s';
-		$values        = array_merge( $where_values, array( '%"handler_slug":"%' ) );
+			? "WHERE j.handler_slug IS NOT NULL AND j.handler_slug != ''"
+			: $where_sql . " AND j.handler_slug IS NOT NULL AND j.handler_slug != ''";
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		$query = $this->wpdb->prepare(
-			"SELECT
-				SUBSTRING_INDEX(SUBSTRING_INDEX(REGEXP_SUBSTR(j.engine_data, '\"handler_slug\":\"[^\"]+\"'), ':\"', -1), '\"', 1) AS handler_slug,
-				COUNT(*) AS count
+			"SELECT j.handler_slug AS handler_slug, COUNT(*) AS count
 			 FROM %i j
 			 {$handler_where}
-			 GROUP BY handler_slug
-			 HAVING handler_slug IS NOT NULL AND handler_slug != ''
+			 GROUP BY j.handler_slug
 			 ORDER BY count DESC",
-			array_merge( array( $this->table_name ), $values )
+			array_merge( array( $this->table_name ), $where_values )
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
@@ -597,10 +596,10 @@ class Jobs extends BaseRepository {
 		if ( ! empty( $args['handler'] ) ) {
 			$handler = sanitize_key( (string) $args['handler'] );
 			if ( '' !== $handler ) {
-				$where_clauses[] = '(j.engine_data LIKE %s OR j.engine_data LIKE %s OR j.engine_data LIKE %s)';
-				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler_slug":"' . $handler . '"' ) . '%';
-				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler":"' . $handler . '"' ) . '%';
-				$where_values[]  = '%' . $this->wpdb->esc_like( '"handler_slugs":["' . $handler . '"' ) . '%';
+				// Match the promoted handler_slug column so filtering survives
+				// engine_data being shed from terminal jobs by retention.
+				$where_clauses[] = 'j.handler_slug = %s';
+				$where_values[]  = $handler;
 			}
 		}
 
@@ -1073,6 +1072,17 @@ class Jobs extends BaseRepository {
 			$format[]                 = '%s';
 		}
 
+		// Promote the first handler_slug to its own column so handler
+		// summaries / filtering survive engine_data being shed from terminal
+		// jobs by retention (see RetentionCleanup::cleanupEngineData()).
+		// Extracted from the encoded blob so the column matches exactly what
+		// the legacy REGEXP_SUBSTR( engine_data, ... ) aggregation produced.
+		$handler_slug = self::extract_handler_slug( is_string( $encoded ) ? $encoded : '' );
+		if ( '' !== $handler_slug ) {
+			$update_data['handler_slug'] = $handler_slug;
+			$format[]                    = '%s';
+		}
+
 		$result = $this->wpdb->update(
 			$this->table_name,
 			$update_data,
@@ -1120,6 +1130,30 @@ class Jobs extends BaseRepository {
 		}
 
 		return array();
+	}
+
+	/**
+	 * Extract the first handler_slug from an encoded engine_data blob.
+	 *
+	 * Mirrors the legacy `REGEXP_SUBSTR( engine_data, '"handler_slug":"[^"]+"' )`
+	 * aggregation so the promoted handler_slug column carries the exact value
+	 * the handler-summary query used to derive on the fly. Promoting it lets
+	 * retention shed the heavy engine_data blob from terminal jobs without
+	 * losing handler stats/filtering (see RetentionCleanup::cleanupEngineData()).
+	 *
+	 * @param string $encoded JSON-encoded engine_data.
+	 * @return string Handler slug, or '' when none present.
+	 */
+	private static function extract_handler_slug( string $encoded ): string {
+		if ( '' === $encoded || ! str_contains( $encoded, '"handler_slug"' ) ) {
+			return '';
+		}
+
+		if ( preg_match( '/"handler_slug":"([^"]+)"/', $encoded, $matches ) ) {
+			return sanitize_key( $matches[1] );
+		}
+
+		return '';
 	}
 
 	// ---------------------------------------------------------------------
@@ -1432,6 +1466,7 @@ class Jobs extends BaseRepository {
             parent_job_id bigint(20) unsigned NULL DEFAULT NULL,
             status varchar(255) NOT NULL,
             engine_data longtext NULL,
+            handler_slug varchar(100) NULL DEFAULT NULL,
             created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
             completed_at datetime NULL DEFAULT NULL,
             PRIMARY KEY  (job_id),
@@ -1451,6 +1486,7 @@ class Jobs extends BaseRepository {
 
 		self::migrate_columns( $table_name );
 		self::migrate_task_type_column( $table_name );
+		self::migrate_handler_slug_column( $table_name );
 		self::migrate_indexes( $table_name );
 
 		do_action(
@@ -1738,6 +1774,108 @@ class Jobs extends BaseRepository {
 	}
 
 	/**
+	 * Add handler_slug column for indexed handler summaries / filtering.
+	 *
+	 * Promotes the first `"handler_slug":"..."` value out of the engine_data
+	 * blob into a dedicated indexed column. This lets retention shed the heavy
+	 * engine_data longtext from terminal jobs without losing the handler stats
+	 * and filtering that previously REGEXP_SUBSTR-scanned the blob (#2622).
+	 *
+	 * The column is populated by store_engine_data() going forward and
+	 * backfilled here from existing engine_data on migration. Backfill runs in
+	 * bounded id-ranged chunks so it never loads or rewrites the whole table at
+	 * once on large installs.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $table_name Fully qualified table name.
+	 */
+	private static function migrate_handler_slug_column( string $table_name ): void {
+		global $wpdb;
+
+		if ( BaseRepository::column_exists( $table_name, 'handler_slug', $wpdb ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+		// `AFTER <col>` is MySQL-only; SQLite (Studio) rejects it.
+		$result = $wpdb->query(
+			"ALTER TABLE {$table_name}
+			 ADD COLUMN handler_slug varchar(100) NULL DEFAULT NULL,
+			 ADD KEY idx_handler_slug (handler_slug)"
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL
+
+		if ( false === $result ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Failed to add handler_slug column to jobs table',
+				array(
+					'table_name' => $table_name,
+					'db_error'   => $wpdb->last_error,
+				)
+			);
+			return;
+		}
+
+		// Backfill handler_slug from engine_data in bounded id-ranged chunks.
+		// Uses PHP regex (not MySQL REGEXP) for SQLite compatibility, and walks
+		// job_id ranges so memory stays flat regardless of table size.
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+		$max_id     = (int) $wpdb->get_var( "SELECT MAX(job_id) FROM {$table_name}" );
+		$chunk_size = 5000;
+		// phpcs:enable WordPress.DB.PreparedSQL
+
+		for ( $start = 0; $start < $max_id; $start += $chunk_size ) {
+			$end = $start + $chunk_size;
+
+			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT job_id, engine_data
+					 FROM {$table_name}
+					 WHERE job_id > %d AND job_id <= %d
+					 AND engine_data IS NOT NULL
+					 AND engine_data LIKE %s
+					 AND handler_slug IS NULL",
+					$start,
+					$end,
+					'%' . $wpdb->esc_like( '"handler_slug"' ) . '%'
+				)
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL
+
+			if ( empty( $rows ) ) {
+				continue;
+			}
+
+			foreach ( $rows as $row ) {
+				$handler_slug = self::extract_handler_slug( (string) $row->engine_data );
+				if ( '' === $handler_slug ) {
+					continue;
+				}
+
+				$wpdb->update(
+					$table_name,
+					array( 'handler_slug' => $handler_slug ),
+					array( 'job_id' => $row->job_id ),
+					array( '%s' ),
+					array( '%d' )
+				);
+			}
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Added handler_slug column to jobs table for indexed handler summaries',
+			array( 'table_name' => $table_name )
+		);
+	}
+
+	/**
 	 * Ensure performance indexes exist on the jobs table.
 	 *
 	 * dbDelta() is unreliable at adding indexes to existing tables, so this
@@ -1769,6 +1907,7 @@ class Jobs extends BaseRepository {
 			'idx_flow_created'   => '(flow_id, created_at)',
 			'idx_status_created' => '(status(50), created_at)',
 			'idx_source_created' => '(source, created_at)',
+			'idx_handler_slug'   => '(handler_slug)',
 		);
 
 		$added = array();

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -33,6 +33,7 @@ use DataMachine\Engine\AI\System\Tasks\Retention\RetentionActionSchedulerTask;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionChatSessionsTask;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionCleanup;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionCompletedJobsTask;
+use DataMachine\Engine\AI\System\Tasks\Retention\RetentionEngineDataTask;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionFailedJobsTask;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionFilesTask;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionJobArtifactsTask;
@@ -99,6 +100,7 @@ class SystemAgentServiceProvider {
 		$tasks['meta_description_generation']            = MetaDescriptionTask::class;
 		$tasks[ RetentionCleanup::TASK_COMPLETED_JOBS ]  = RetentionCompletedJobsTask::class;
 		$tasks[ RetentionCleanup::TASK_FAILED_JOBS ]     = RetentionFailedJobsTask::class;
+		$tasks[ RetentionCleanup::TASK_ENGINE_DATA ]     = RetentionEngineDataTask::class;
 		$tasks[ RetentionCleanup::TASK_LOGS ]            = RetentionLogsTask::class;
 		$tasks[ RetentionCleanup::TASK_PROCESSED_ITEMS ] = RetentionProcessedItemsTask::class;
 		$tasks[ RetentionCleanup::TASK_AS_ACTIONS ]      = RetentionActionSchedulerTask::class;
@@ -184,6 +186,16 @@ class SystemAgentServiceProvider {
 					'enabled_setting' => 'retention_failed_jobs_enabled',
 					'default_enabled' => true,
 					'label'           => 'Daily failed-jobs cleanup',
+				)
+			),
+			RetentionCleanup::TASK_ENGINE_DATA     => array_merge(
+				$daily_first_run,
+				array(
+					'task_type'       => RetentionCleanup::TASK_ENGINE_DATA,
+					'interval'        => 'daily',
+					'enabled_setting' => 'retention_engine_data_enabled',
+					'default_enabled' => true,
+					'label'           => 'Daily terminal-job engine_data shedding',
 				)
 			),
 			RetentionCleanup::TASK_LOGS            => array_merge(

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -24,6 +24,7 @@ class RetentionCleanup {
 
 	public const TASK_COMPLETED_JOBS  = 'retention_completed_jobs';
 	public const TASK_FAILED_JOBS     = 'retention_failed_jobs';
+	public const TASK_ENGINE_DATA     = 'retention_engine_data';
 	public const TASK_LOGS            = 'retention_logs';
 	public const TASK_PROCESSED_ITEMS = 'retention_processed_items';
 	public const TASK_AS_ACTIONS      = 'retention_as_actions';
@@ -38,6 +39,33 @@ class RetentionCleanup {
 
 	public static function failedJobsMaxAgeDays(): int {
 		return self::positiveDays( apply_filters( 'datamachine_failed_jobs_max_age_days', 30 ), 30 );
+	}
+
+	/**
+	 * Age (in days) after a job goes terminal before its engine_data is shed.
+	 *
+	 * engine_data is the engine's working memory for a job (data packets, AI
+	 * tool-call context, intermediate step results). It is required *while the
+	 * job runs*, but carries no value once the job is terminal — yet it is the
+	 * single heaviest column on the jobs table (a multi-KB longtext per row).
+	 * On high-volume installs that is hundreds of MB of dead blob resident for
+	 * the entire whole-row retention window (14-30d).
+	 *
+	 * This is a *short* window (hours, not days) measured against
+	 * `completed_at`: shed the blob soon after the job finishes while KEEPING
+	 * the row (status, timing, counts, promoted handler_slug) for
+	 * stats/history/dedup. The longer whole-row deletion windows
+	 * (completedJobsMaxAgeDays / failedJobsMaxAgeDays) are untouched.
+	 *
+	 * Fractional days are allowed so operators can express sub-day windows
+	 * (e.g. `0.25` for 6h). Default is 1 day. A value of `0` (or less) disables
+	 * engine_data shedding entirely.
+	 *
+	 * @return float Window in days (>= 0; 0 disables shedding).
+	 */
+	public static function engineDataTerminalMaxAgeDays(): float {
+		$days = (float) apply_filters( 'datamachine_engine_data_terminal_max_age_days', 1.0 );
+		return $days > 0 ? $days : 0.0;
 	}
 
 	public static function logsMaxAgeDays(): int {
@@ -247,6 +275,164 @@ class RetentionCleanup {
 		);
 	}
 
+	/**
+	 * Count terminal jobs whose engine_data is eligible to be shed.
+	 *
+	 * Terminal == `completed_at` is set (every final status path stamps it).
+	 * Eligible == still carrying a non-empty engine_data blob older than the
+	 * short terminal window. Returns 0 when shedding is disabled.
+	 *
+	 * @return int Eligible job count.
+	 */
+	public static function countEngineDataTerminalJobs(): int {
+		global $wpdb;
+
+		$days = self::engineDataTerminalMaxAgeDays();
+		if ( $days <= 0 ) {
+			return 0;
+		}
+
+		$table  = $wpdb->prefix . 'datamachine_jobs';
+		$cutoff = gmdate( 'Y-m-d H:i:s', time() - (int) round( $days * DAY_IN_SECONDS ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM %i WHERE completed_at IS NOT NULL AND completed_at < %s AND engine_data IS NOT NULL AND engine_data != ''",
+				$table,
+				$cutoff
+			)
+		);
+	}
+
+	/**
+	 * Estimate reclaimable engine_data bytes on eligible terminal jobs.
+	 *
+	 * Powers CLI dry-run reporting. Uses CHAR_LENGTH so the figure reflects
+	 * the live blob weight that the shed will free inside the tablespace.
+	 * Skipped (returns 0) on SQLite, where the byte sizing functions and the
+	 * disk-reclaim concern do not apply.
+	 *
+	 * @return int Reclaimable bytes (approximate).
+	 */
+	public static function countEngineDataReclaimableBytes(): int {
+		global $wpdb;
+
+		$days = self::engineDataTerminalMaxAgeDays();
+		if ( $days <= 0 ) {
+			return 0;
+		}
+
+		if ( class_exists( BaseRepository::class ) && BaseRepository::is_sqlite() ) {
+			return 0;
+		}
+
+		$table  = $wpdb->prefix . 'datamachine_jobs';
+		$cutoff = gmdate( 'Y-m-d H:i:s', time() - (int) round( $days * DAY_IN_SECONDS ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COALESCE(SUM(LENGTH(engine_data)), 0) FROM %i WHERE completed_at IS NOT NULL AND completed_at < %s AND engine_data IS NOT NULL AND engine_data != ''",
+				$table,
+				$cutoff
+			)
+		);
+	}
+
+	/**
+	 * Shed engine_data from terminal jobs older than the short window.
+	 *
+	 * Sets `engine_data = NULL` on jobs that have been terminal for longer than
+	 * engineDataTerminalMaxAgeDays(), KEEPING the row. The heavy working-state
+	 * blob is the only thing dropped; status, timing, counts and the promoted
+	 * handler_slug column survive for stats/history/dedup. Whole-row deletion
+	 * (cleanupCompletedJobs/cleanupFailedJobs) handles the longer window.
+	 *
+	 * The UPDATE is batched by id (bounded LIMIT per pass, shared iteration +
+	 * wall-clock caps) so it never locks or times out on a multi-hundred-K-row
+	 * table — the same batching contract #2617 introduced for AS deletes. Disk
+	 * reclaim reuses the opt-in OPTIMIZE path (an UPDATE frees space inside the
+	 * tablespace but not to the OS without a rebuild).
+	 *
+	 * @return array Result summary.
+	 */
+	public static function cleanupEngineData(): array {
+		global $wpdb;
+
+		$days = self::engineDataTerminalMaxAgeDays();
+		if ( $days <= 0 ) {
+			return array(
+				'updated'      => 0,
+				'max_age_days' => 0,
+				'batch_size'   => 0,
+				'iterations'   => 0,
+				'hit_limit'    => false,
+				'optimized'    => array(),
+			);
+		}
+
+		$table          = $wpdb->prefix . 'datamachine_jobs';
+		$cutoff         = gmdate( 'Y-m-d H:i:s', time() - (int) round( $days * DAY_IN_SECONDS ) );
+		$batch_size     = self::actionSchedulerBatchSize();
+		$max_iterations = self::actionSchedulerMaxIterations();
+		$max_runtime    = self::actionSchedulerMaxRuntimeSeconds();
+		$deadline       = microtime( true ) + $max_runtime;
+		$iterations     = 0;
+		$hit_limit      = false;
+		$updated        = 0;
+
+		do {
+			if ( $iterations >= $max_iterations || microtime( true ) >= $deadline ) {
+				$hit_limit = true;
+				break;
+			}
+			++$iterations;
+
+			// Bound each UPDATE by selecting a batch of eligible ids and
+			// updating by primary key — reliable and index-fast, never a
+			// single unbounded UPDATE across the whole table.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$affected = $wpdb->query(
+				$wpdb->prepare(
+					"UPDATE %i SET engine_data = NULL WHERE job_id IN ( SELECT job_id FROM ( SELECT job_id FROM %i WHERE completed_at IS NOT NULL AND completed_at < %s AND engine_data IS NOT NULL AND engine_data != '' LIMIT %d ) AS tmp )",
+					$table,
+					$table,
+					$cutoff,
+					$batch_size
+				)
+			);
+
+			$affected = false !== $affected ? (int) $affected : 0;
+			$updated += $affected;
+		} while ( $affected > 0 );
+
+		$optimized = self::maybeOptimizeTables( array( $table => $updated ) );
+
+		if ( $updated > 0 || $hit_limit ) {
+			self::log(
+				'Scheduled cleanup: shed engine_data from terminal jobs',
+				array(
+					'jobs_updated' => $updated,
+					'max_age_days' => $days,
+					'batch_size'   => $batch_size,
+					'iterations'   => $iterations,
+					'hit_limit'    => $hit_limit,
+					'optimized'    => $optimized,
+				)
+			);
+		}
+
+		return array(
+			'updated'      => $updated,
+			'max_age_days' => $days,
+			'batch_size'   => $batch_size,
+			'iterations'   => $iterations,
+			'hit_limit'    => $hit_limit,
+			'optimized'    => $optimized,
+		);
+	}
+
 	public static function countLogs(): int {
 		global $wpdb;
 
@@ -448,7 +634,7 @@ class RetentionCleanup {
 		// InnoDB never returns DELETE-freed space to the OS; only a table
 		// rebuild does. Optionally OPTIMIZE the tables when a pass deleted
 		// enough rows to justify the lock/temp-space cost.
-		$optimized = self::maybeOptimizeActionSchedulerTables(
+		$optimized = self::maybeOptimizeTables(
 			array(
 				$actions_table => $actions_deleted,
 				$logs_table    => $logs_deleted,
@@ -665,16 +851,19 @@ class RetentionCleanup {
 	}
 
 	/**
-	 * Optionally OPTIMIZE Action Scheduler tables after a cleanup pass.
+	 * Optionally OPTIMIZE tables after a cleanup pass to reclaim disk.
 	 *
-	 * Opt-in (`datamachine_retention_optimize_tables`, default off) and gated by
-	 * a per-table row-count threshold so the rebuild only runs when enough rows
-	 * were deleted to reclaim meaningful disk. Skipped entirely on SQLite.
+	 * Generic across cleanup passes (Action Scheduler deletes, engine_data
+	 * shedding) — InnoDB never returns DELETE/UPDATE-freed space to the OS;
+	 * only a table rebuild does. Opt-in (`datamachine_retention_optimize_tables`,
+	 * default off) and gated by a per-table row-count threshold so the rebuild
+	 * only runs when enough rows changed to justify the lock/temp-space cost.
+	 * Skipped entirely on SQLite.
 	 *
-	 * @param array<string, int> $tables_deleted Map of table name => rows deleted.
+	 * @param array<string, int> $tables_affected Map of table name => rows changed.
 	 * @return array<int, string> Names of tables that were optimized.
 	 */
-	private static function maybeOptimizeActionSchedulerTables( array $tables_deleted ): array {
+	private static function maybeOptimizeTables( array $tables_affected ): array {
 		global $wpdb;
 
 		if ( ! self::actionSchedulerOptimizeEnabled() ) {
@@ -688,8 +877,8 @@ class RetentionCleanup {
 		$threshold = self::actionSchedulerOptimizeThreshold();
 		$optimized = array();
 
-		foreach ( $tables_deleted as $table => $deleted ) {
-			if ( (int) $deleted < $threshold ) {
+		foreach ( $tables_affected as $table => $affected ) {
+			if ( (int) $affected < $threshold ) {
 				continue;
 			}
 
@@ -700,7 +889,7 @@ class RetentionCleanup {
 
 		if ( ! empty( $optimized ) ) {
 			self::log(
-				'Scheduled cleanup: optimized Action Scheduler tables to reclaim disk',
+				'Scheduled cleanup: optimized tables to reclaim disk',
 				array(
 					'tables_optimized' => $optimized,
 					'threshold'        => $threshold,

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionEngineDataTask.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionEngineDataTask.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DataMachine\Engine\AI\System\Tasks\Retention;
+
+defined( 'ABSPATH' ) || exit;
+
+class RetentionEngineDataTask extends RetentionTask {
+
+	public function getTaskType(): string {
+		return RetentionCleanup::TASK_ENGINE_DATA;
+	}
+
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Retention: terminal-job engine_data',
+			'description'     => 'Sheds the heavy engine_data working-state blob from terminal jobs shortly after completion, keeping the job ledger row.',
+			'setting_key'     => 'retention_engine_data_enabled',
+			'default_enabled' => true,
+			'supports_run'    => true,
+		);
+	}
+
+	protected function runRetentionCleanup(): array {
+		return RetentionCleanup::cleanupEngineData();
+	}
+}

--- a/tests/retention-engine-data-shedding-smoke.php
+++ b/tests/retention-engine-data-shedding-smoke.php
@@ -1,0 +1,367 @@
+<?php
+/**
+ * Smoke coverage for terminal-job engine_data shedding retention (#2622).
+ *
+ * Run with: php tests/retention-engine-data-shedding-smoke.php
+ *
+ * Pins the bloat fix: retention nulls the heavy engine_data blob on TERMINAL
+ * jobs older than a short window while KEEPING the row, leaves fresh /
+ * non-terminal jobs untouched, batches the UPDATE by id (bounded LIMIT,
+ * iteration + wall-clock caps), reuses the opt-in OPTIMIZE path, and the
+ * dry-run/count path reads without mutating. Also pins that the handler_slug
+ * slice is promoted out of engine_data (so handler summaries survive the
+ * shed) by exercising Jobs::extract_handler_slug via reflection.
+ *
+ * The functional half drives RetentionCleanup against an in-memory fake $wpdb
+ * so the batching loop executes for real.
+ *
+ * @package DataMachine\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {
+
+	use DataMachine\Engine\AI\System\Tasks\Retention\RetentionCleanup;
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/../' );
+	}
+	if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+		define( 'DAY_IN_SECONDS', 86400 );
+	}
+
+	$root = dirname( __DIR__ );
+
+	$failed = 0;
+	$total  = 0;
+
+	$GLOBALS['__retention_filters'] = array();
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, $value ) {
+			if ( array_key_exists( $hook, $GLOBALS['__retention_filters'] ) ) {
+				return $GLOBALS['__retention_filters'][ $hook ];
+			}
+			return $value;
+		}
+	}
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( ...$args ) {}
+	}
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( $key ) {
+			return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $key ) );
+		}
+	}
+
+	function eds_set_filter( string $hook, $value ): void {
+		$GLOBALS['__retention_filters'][ $hook ] = $value;
+	}
+
+	function assert_eds( string $name, bool $condition, string $detail = '' ): void {
+		global $failed, $total;
+		++$total;
+		if ( $condition ) {
+			echo "  [PASS] {$name}\n";
+			return;
+		}
+
+		++$failed;
+		echo "  [FAIL] {$name}" . ( $detail ? " — {$detail}" : '' ) . "\n";
+	}
+
+	echo "=== retention-engine-data-shedding-smoke ===\n";
+
+	// -----------------------------------------------------------------------
+	// 1. Source-string assertions (structural guarantees).
+	// -----------------------------------------------------------------------
+
+	$cleanup  = file_get_contents( $root . '/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php' ) ?: '';
+	$command  = file_get_contents( $root . '/inc/Cli/Commands/RetentionCommand.php' ) ?: '';
+	$provider = file_get_contents( $root . '/inc/Engine/AI/System/SystemAgentServiceProvider.php' ) ?: '';
+	$jobs     = file_get_contents( $root . '/inc/Core/Database/Jobs/Jobs.php' ) ?: '';
+	$task     = file_get_contents( $root . '/inc/Engine/AI/System/Tasks/Retention/RetentionEngineDataTask.php' ) ?: '';
+
+	assert_eds(
+		'window is filterable via datamachine_engine_data_terminal_max_age_days',
+		str_contains( $cleanup, "apply_filters( 'datamachine_engine_data_terminal_max_age_days'" )
+	);
+	assert_eds(
+		'shed UPDATE nulls engine_data via id-subquery with LIMIT (batched)',
+		str_contains( $cleanup, 'UPDATE %i SET engine_data = NULL WHERE job_id IN (' )
+			&& str_contains( $cleanup, 'LIMIT %d' )
+	);
+	assert_eds(
+		'shed targets terminal rows via completed_at + non-empty engine_data',
+		str_contains( $cleanup, "completed_at IS NOT NULL AND completed_at < %s AND engine_data IS NOT NULL AND engine_data != ''" )
+	);
+	assert_eds(
+		'shed reuses shared batch / iteration / runtime caps (#2617)',
+		str_contains( $cleanup, 'self::actionSchedulerBatchSize()' )
+			&& str_contains( $cleanup, 'self::actionSchedulerMaxIterations()' )
+			&& str_contains( $cleanup, 'self::actionSchedulerMaxRuntimeSeconds()' )
+	);
+	assert_eds(
+		'shed reuses the generic opt-in OPTIMIZE path (no second mechanism)',
+		str_contains( $cleanup, 'self::maybeOptimizeTables(' )
+			&& ! str_contains( $cleanup, 'maybeOptimizeActionSchedulerTables' )
+	);
+	assert_eds(
+		'cleanup defines TASK_ENGINE_DATA',
+		str_contains( $cleanup, 'const TASK_ENGINE_DATA' )
+	);
+	assert_eds(
+		'task class supports manual system run',
+		str_contains( $task, "'supports_run'    => true" )
+	);
+	assert_eds(
+		'provider imports + registers + schedules RetentionEngineDataTask',
+		str_contains( $provider, 'RetentionEngineDataTask;' )
+			&& str_contains( $provider, '= RetentionEngineDataTask::class;' )
+			&& substr_count( $provider, 'RetentionCleanup::TASK_ENGINE_DATA' ) >= 2
+	);
+	assert_eds(
+		'CLI surfaces engine_data shedding detail (eligible + reclaimable)',
+		str_contains( $command, 'report_engine_data_detail' )
+			&& str_contains( $command, 'countEngineDataReclaimableBytes' )
+			&& str_contains( $command, 'Terminal engine_data' )
+	);
+	assert_eds(
+		'Jobs promotes handler_slug column + populates it from engine_data',
+		str_contains( $jobs, "ADD COLUMN handler_slug varchar(100)" )
+			&& str_contains( $jobs, 'extract_handler_slug' )
+			&& str_contains( $jobs, "\$update_data['handler_slug']" )
+	);
+	assert_eds(
+		'handler summary reads the promoted column, not the engine_data blob',
+		str_contains( $jobs, 'SELECT j.handler_slug AS handler_slug, COUNT(*) AS count' )
+			&& ! str_contains( $jobs, 'REGEXP_SUBSTR(j.engine_data' )
+			&& ! str_contains( $jobs, "REGEXP_SUBSTR(\n" )
+	);
+
+	// -----------------------------------------------------------------------
+	// 2. Functional assertions (drive the real batching loop).
+	// -----------------------------------------------------------------------
+
+	require_once __DIR__ . '/fixtures/retention-batching-stubs.php';
+	require_once $root . '/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php';
+	require_once $root . '/inc/Core/Database/Jobs/Jobs.php';
+
+	// handler_slug extraction matches the legacy REGEXP_SUBSTR slice.
+	$ref = new \ReflectionMethod( \DataMachine\Core\Database\Jobs\Jobs::class, 'extract_handler_slug' );
+	$ref->setAccessible( true );
+	assert_eds(
+		'extract_handler_slug pulls the first handler_slug from the blob',
+		'rss' === $ref->invoke( null, '{"x":1,"handler_slug":"rss","more":"y"}' )
+	);
+	assert_eds(
+		'extract_handler_slug returns empty when no handler_slug present',
+		'' === $ref->invoke( null, '{"x":1,"task_type":"foo"}' )
+	);
+
+	$fake_wpdb = new class() {
+		public string $prefix = 'wp_';
+
+		/** @var array<int, array{job_id:int, completed_at:?string, engine_data:?string}> */
+		public array $jobs = array();
+
+		public int $update_queries = 0;
+		public int $optimize_calls = 0;
+
+		/** @var array<int, int> */
+		public array $batch_sizes = array();
+
+		public function prepare( string $query, ...$args ): array {
+			if ( 1 === count( $args ) && is_array( $args[0] ) ) {
+				$args = $args[0];
+			}
+			return array(
+				'sql'  => $query,
+				'args' => $args,
+			);
+		}
+
+		public function get_var( $prepared ): int {
+			$sql    = $prepared['sql'];
+			$args   = $prepared['args'];
+			$cutoff = $this->extract_cutoff( $args );
+
+			$matching = $this->matching_jobs( $cutoff );
+
+			if ( str_contains( $sql, 'SUM(LENGTH' ) ) {
+				$bytes = 0;
+				foreach ( $matching as $row ) {
+					$bytes += strlen( (string) $row['engine_data'] );
+				}
+				return $bytes;
+			}
+
+			return count( $matching );
+		}
+
+		public function query( $prepared ): int {
+			$sql  = $prepared['sql'];
+			$args = $prepared['args'];
+
+			if ( str_contains( $sql, 'OPTIMIZE TABLE' ) ) {
+				++$this->optimize_calls;
+				return 0;
+			}
+
+			++$this->update_queries;
+			$cutoff              = $this->extract_cutoff( $args );
+			$limit               = (int) end( $args );
+			$this->batch_sizes[] = $limit;
+
+			$matching = array_slice( $this->matching_jobs( $cutoff ), 0, $limit, true );
+			foreach ( array_keys( $matching ) as $job_id ) {
+				$this->jobs[ $job_id ]['engine_data'] = null;
+			}
+			return count( $matching );
+		}
+
+		private function extract_cutoff( array $args ): string {
+			foreach ( $args as $arg ) {
+				if ( is_string( $arg ) && preg_match( '/^\d{4}-\d{2}-\d{2} /', $arg ) ) {
+					return $arg;
+				}
+			}
+			return '';
+		}
+
+		private function matching_jobs( string $cutoff ): array {
+			$out = array();
+			foreach ( $this->jobs as $id => $row ) {
+				if ( null === $row['completed_at'] ) {
+					continue;
+				}
+				if ( $row['completed_at'] >= $cutoff ) {
+					continue;
+				}
+				if ( null === $row['engine_data'] || '' === $row['engine_data'] ) {
+					continue;
+				}
+				$out[ $id ] = $row;
+			}
+			return $out;
+		}
+	};
+
+	// Seed: 2500 terminal jobs older than the 1-day window (blob present), 5
+	// terminal jobs within the window (must keep blob), 10 in-flight jobs with
+	// no completed_at (must keep blob).
+	$now      = time();
+	$two_days = gmdate( 'Y-m-d H:i:s', $now - ( 2 * DAY_IN_SECONDS ) );
+	$one_hour = gmdate( 'Y-m-d H:i:s', $now - 3600 );
+	$jid      = 1;
+	$blob     = str_repeat( 'x', 4096 );
+
+	for ( $i = 0; $i < 2500; $i++ ) {
+		$fake_wpdb->jobs[ $jid ] = array(
+			'job_id'       => $jid,
+			'completed_at' => $two_days,
+			'engine_data'  => $blob,
+		);
+		++$jid;
+	}
+	for ( $i = 0; $i < 5; $i++ ) {
+		$fake_wpdb->jobs[ $jid ] = array(
+			'job_id'       => $jid,
+			'completed_at' => $one_hour,
+			'engine_data'  => $blob,
+		);
+		++$jid;
+	}
+	for ( $i = 0; $i < 10; $i++ ) {
+		$fake_wpdb->jobs[ $jid ] = array(
+			'job_id'       => $jid,
+			'completed_at' => null,
+			'engine_data'  => $blob,
+		);
+		++$jid;
+	}
+
+	$GLOBALS['wpdb'] = $fake_wpdb;
+
+	// Dry-run path: count + reclaimable bytes must not mutate.
+	$eligible_before = RetentionCleanup::countEngineDataTerminalJobs();
+	$reclaimable     = RetentionCleanup::countEngineDataReclaimableBytes();
+	assert_eds(
+		'count covers only old terminal jobs with a blob (2500)',
+		2500 === $eligible_before,
+		"got {$eligible_before}"
+	);
+	assert_eds(
+		'reclaimable bytes sum the eligible blobs (2500 * 4096)',
+		( 2500 * 4096 ) === $reclaimable,
+		"got {$reclaimable}"
+	);
+	assert_eds(
+		'count/dry-run does not mutate rows',
+		0 === $fake_wpdb->update_queries
+	);
+
+	// Force the batching loop to iterate (clamp tiny batch to 1000 floor).
+	eds_set_filter( 'datamachine_retention_batch_size', 1 );
+	$result = RetentionCleanup::cleanupEngineData();
+
+	assert_eds(
+		'shed looped more than twice (multiple bounded UPDATEs)',
+		$fake_wpdb->update_queries > 2,
+		"update_queries={$fake_wpdb->update_queries}"
+	);
+	assert_eds(
+		'every UPDATE was bounded by the batch size (<=1000)',
+		! empty( $fake_wpdb->batch_sizes ) && max( $fake_wpdb->batch_sizes ) <= 1000
+	);
+	assert_eds(
+		'result reports jobs updated + batch metadata',
+		2500 === $result['updated']
+			&& 1000 === $result['batch_size']
+			&& isset( $result['iterations'] )
+			&& false === $result['hit_limit'],
+		"updated={$result['updated']}"
+	);
+
+	$shed   = array_filter( $fake_wpdb->jobs, static fn( $r ) => null === $r['engine_data'] );
+	$kept   = array_filter( $fake_wpdb->jobs, static fn( $r ) => null !== $r['engine_data'] );
+	$rows   = count( $fake_wpdb->jobs );
+	assert_eds(
+		'all old terminal jobs had engine_data shed (2500)',
+		2500 === count( $shed )
+	);
+	assert_eds(
+		'fresh + in-flight jobs kept engine_data (15)',
+		15 === count( $kept )
+	);
+	assert_eds(
+		'shedding keeps the row (no jobs deleted)',
+		2515 === $rows,
+		"rows={$rows}"
+	);
+
+	// OPTIMIZE is opt-in: default off => no rebuild.
+	assert_eds(
+		'OPTIMIZE TABLE not run when filter is off (default)',
+		0 === $fake_wpdb->optimize_calls && array() === $result['optimized']
+	);
+
+	// Disabled window => no-op.
+	$fake_wpdb->update_queries = 0;
+	eds_set_filter( 'datamachine_engine_data_terminal_max_age_days', 0 );
+	$disabled = RetentionCleanup::cleanupEngineData();
+	assert_eds(
+		'window of 0 disables shedding entirely',
+		0 === $disabled['updated']
+			&& 0 === $fake_wpdb->update_queries
+			&& 0 === RetentionCleanup::countEngineDataTerminalJobs()
+	);
+
+	if ( $failed > 0 ) {
+		echo "\nretention-engine-data-shedding-smoke failed: {$failed}/{$total} assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nretention-engine-data-shedding-smoke passed: {$total} assertions.\n";
+}

--- a/tests/retention-engine-data-shedding-smoke.php
+++ b/tests/retention-engine-data-shedding-smoke.php
@@ -36,7 +36,14 @@ namespace {
 	$failed = 0;
 	$total  = 0;
 
+	// Filter override registry. Works in both the pure-PHP path (shimmed
+	// apply_filters reads it) and under real WordPress (a single real
+	// add_filter per hook returns the latest registered override). Keeping
+	// the registry keyed by hook lets eds_set_filter() change the value
+	// repeatedly without stacking duplicate WP callbacks.
 	$GLOBALS['__retention_filters'] = array();
+
+	$using_real_wp = function_exists( 'apply_filters' ) && function_exists( 'add_filter' );
 
 	if ( ! function_exists( 'apply_filters' ) ) {
 		function apply_filters( string $hook, $value ) {
@@ -55,8 +62,25 @@ namespace {
 		}
 	}
 
+	$GLOBALS['__retention_real_wp']       = $using_real_wp;
+	$GLOBALS['__retention_bound_filters'] = array();
+
 	function eds_set_filter( string $hook, $value ): void {
 		$GLOBALS['__retention_filters'][ $hook ] = $value;
+
+		// Under real WordPress, bind one persistent callback per hook that
+		// always returns the current registry value (so repeated set calls
+		// just update the registry, never stack callbacks).
+		if ( ! empty( $GLOBALS['__retention_real_wp'] ) && empty( $GLOBALS['__retention_bound_filters'][ $hook ] ) ) {
+			add_filter(
+				$hook,
+				static function () use ( $hook ) {
+					return $GLOBALS['__retention_filters'][ $hook ];
+				},
+				99
+			);
+			$GLOBALS['__retention_bound_filters'][ $hook ] = true;
+		}
 	}
 
 	function assert_eds( string $name, bool $condition, string $detail = '' ): void {

--- a/tests/retention-system-tasks-smoke.php
+++ b/tests/retention-system-tasks-smoke.php
@@ -63,6 +63,7 @@ foreach ( $legacy_files as $legacy_file ) {
 $task_classes = array(
 	'RetentionCompletedJobsTask',
 	'RetentionFailedJobsTask',
+	'RetentionEngineDataTask',
 	'RetentionLogsTask',
 	'RetentionProcessedItemsTask',
 	'RetentionActionSchedulerTask',
@@ -84,6 +85,7 @@ foreach ( $task_classes as $task_class ) {
 $task_constants = array(
 	'TASK_COMPLETED_JOBS',
 	'TASK_FAILED_JOBS',
+	'TASK_ENGINE_DATA',
 	'TASK_LOGS',
 	'TASK_PROCESSED_ITEMS',
 	'TASK_AS_ACTIONS',


### PR DESCRIPTION
Closes #2622

## The bloat
On the events site (`events.extrachill.com`, blog 7), `c8c_7_datamachine_jobs` was **1.1GB / 120K rows** — and **722MB of that was the `engine_data` longtext** retained in full on **terminal** jobs (`completed` / `completed_no_items` / `agent_skipped` / `failed`). `engine_data` is the engine's working memory for a job (data packets, AI tool-call context, intermediate step results): required *while a job runs*, useless once it's terminal. ~90% of the blob weight sat on terminal jobs for the entire whole-row retention window (14-30d). Same retention-gap shape as #2616.

## The fix (issue option 1 — keep the row, shed the blob)
A new short-window retention pass NULLs `engine_data` on **terminal** jobs older than a small window while **keeping the row** — the job ledger (status, timing, counts, promoted `handler_slug`) survives for stats/history/dedup; only the heavy working-state blob is dropped. The existing whole-row deletion (`cleanupCompletedJobs`/`cleanupFailedJobs`) is untouched for the longer window.

- **Terminal signal:** `completed_at IS NOT NULL` (every final-status path stamps it) + non-empty `engine_data`.
- **Batched UPDATE:** chunked by id (`UPDATE ... WHERE job_id IN (SELECT ... LIMIT %d)`), reusing the **#2617** shared `actionSchedulerBatchSize` / `MaxIterations` / `MaxRuntimeSeconds` caps — never a single unbounded UPDATE on a multi-hundred-K-row table.
- **Disk reclaim:** reuses the **#2617** opt-in OPTIMIZE path (refactored `maybeOptimizeActionSchedulerTables` → generic `maybeOptimizeTables`, both AS deletes and engine_data shedding call it). No second batching or OPTIMIZE mechanism.

## New filter + defaults
| Filter | Default | Meaning |
|---|---|---|
| `datamachine_engine_data_terminal_max_age_days` | `1.0` | Days after a job goes terminal before its `engine_data` is shed. Fractional allowed (`0.25` = 6h). `0` disables shedding. |

Reuses existing #2617 knobs unchanged: `datamachine_retention_batch_size`, `datamachine_retention_max_iterations`, `datamachine_retention_max_runtime_seconds`, `datamachine_retention_optimize_tables` (opt-in OPTIMIZE), `datamachine_retention_optimize_threshold`.

## Readers audit (checked before nulling)
| Reader | Touches terminal jobs? | Handling |
|---|---|---|
| `Jobs::get_handler_summary_rows` (handler summary) | **Yes** — REGEXP_SUBSTR'd `handler_slug` from the blob across all jobs | **Gap.** Promoted `handler_slug` to a dedicated indexed column (mirrors the existing `task_type` column precedent), populated in `store_engine_data()`, backfilled in bounded chunks on migration. Summary query now reads the column. |
| `Jobs` handler **filter** (`get_jobs_count` / `build_jobs_summary_where` / `get_jobs_for_list_table`) | **Yes** — `engine_data LIKE` | Switched to the `handler_slug` column. |
| `RequestInspector::inspectPipelineJob` | No — explicit per-job inspection of in-flight/recent jobs; returns a graceful error on empty snapshot | Safe. |
| `DataMachineCompletionAssertions` | No — operates on live runtime context, not terminal DB rows | Safe. |
| `handleTaskRetry` (`engine_data['task_type']`) | No — only on jobs actively being retried (not terminal) | Safe. |

Scoped the new storage to **only** the gap (the one `handler_slug` slice), per the issue — not a parallel system. The `handler_slug` column value is extracted from the encoded blob via the same `"handler_slug":"..."` pattern the old REGEXP matched, so the promoted column equals what the query used to derive on the fly.

## CLI
`wp datamachine retention show` and `run --dry-run` now report the terminal window, eligible terminal jobs, and **reclaimable engine_data MB**, plus the batch/OPTIMIZE config — consistent with the #2617 Action Scheduler reporting.

## Tests (local, ground truth — homeboy CI harness is environmentally broken here)
- `php tests/retention-engine-data-shedding-smoke.php` — **24 assertions pass**. Proves: old terminal jobs get `engine_data` nulled; fresh + in-flight jobs keep it; the UPDATE is batched/bounded; the row is kept (no deletes); dry-run/count does not mutate; window `0` disables; OPTIMIZE is opt-in; `handler_slug` extraction matches the legacy slice; summary reads the column not the blob.
- `php tests/retention-system-tasks-smoke.php` — **81 pass** (extended for the new task).
- `php tests/retention-action-scheduler-batching-smoke.php` — **21 pass** (#2617 unaffected).
- `jobs-list-efficiency`, `jobs-get-children`, `job-status-accounting`, `jobs-trim-runtime-queues` — all pass.
- `composer lint` (phpcs) — **exit 0** (PHP 8.4 deprecation notices from system composer/json-schema libs are noise, not lint failures).

No CHANGELOG / version edits — homeboy owns both.