### PR TITLE
test: skip stub-driven abilities load-order simulation under real WordPress (#2620)

### DIFF
--- a/tests/abilities-categories-load-order-smoke.php
+++ b/tests/abilities-categories-load-order-smoke.php
@@ -108,6 +108,28 @@ $assert(
 // ============================================================
 // Behavioral simulation: load class under three stubbed states
 // ============================================================
+//
+// This block stubs WordPress lifecycle functions (doing_action/did_action/
+// add_action/wp_register_ability_category) to drive AbilityCategories through
+// its three timing states. Those stubs are only installed when the real
+// functions are absent (`if ( ! function_exists() )`), so under a real
+// WordPress runtime — e.g. the wp-codebox host-smoke harness — they are inert:
+// `doing_action( 'wp_abilities_api_categories_init' )` reflects the live
+// dispatch state (false during the test) and the simulation can't control it,
+// which made state 1 fail spuriously. The source-string assertions above
+// already lock the real contract (unconditional call site + lifecycle-safe
+// branches) in every backend, and the behavioral path is fully exercised in
+// the pure-PHP / PHPUnit context, so skip the stub-driven simulation under a
+// real WordPress runtime.
+if ( defined( 'WPINC' ) ) {
+	if ( $failed > 0 ) {
+		fwrite( STDERR, "\nabilities-categories-load-order-smoke: {$failed}/{$total} assertions failed\n" );
+		exit( 1 );
+	}
+
+	echo "\nAll {$total} abilities-categories-load-order source-string assertions passed (behavioral simulation skipped under real WordPress).\n";
+	return;
+}
 
 if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', '/tmp/' );

--- a/tests/abilities-image-template-load-order-smoke.php
+++ b/tests/abilities-image-template-load-order-smoke.php
@@ -102,6 +102,23 @@ $assert(
 // ============================================================
 // Behavioral simulation: load class under three stubbed states
 // ============================================================
+//
+// The stubs below (doing_action/did_action/add_action/wp_register_ability) are
+// only installed when the real functions are absent, so under a real WordPress
+// runtime — e.g. the wp-codebox host-smoke harness — they are inert and the
+// simulation cannot control `doing_action()`, making state 1 fail spuriously.
+// The source-string assertions above lock the real contract in every backend
+// and the behavioral path is covered in the pure-PHP / PHPUnit context, so skip
+// the stub-driven simulation under a real WordPress runtime.
+if ( defined( 'WPINC' ) ) {
+	if ( $failed > 0 ) {
+		fwrite( STDERR, "\nabilities-image-template-load-order-smoke: {$failed}/{$total} assertions failed\n" );
+		exit( 1 );
+	}
+
+	echo "\nAll {$total} abilities-image-template-load-order source-string assertions passed (behavioral simulation skipped under real WordPress).\n";
+	return;
+}
 
 if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', '/tmp/' );

--- a/tests/abilities-send-email-load-order-smoke.php
+++ b/tests/abilities-send-email-load-order-smoke.php
@@ -83,6 +83,23 @@ foreach ( array( 'send-email' => $send_source, 'send-email-queued' => $queue_sou
 	);
 }
 
+// The behavioral simulation below stubs WordPress lifecycle functions, which
+// are only installed when the real ones are absent. Under a real WordPress
+// runtime — e.g. the wp-codebox host-smoke harness — those stubs are inert and
+// the simulation cannot control `doing_action()`, making state 1 fail
+// spuriously. The source-string assertions above lock the real contract in
+// every backend and the behavioral path is covered in the pure-PHP / PHPUnit
+// context, so skip the stub-driven simulation under a real WordPress runtime.
+if ( defined( 'WPINC' ) ) {
+	if ( $failed > 0 ) {
+		fwrite( STDERR, "\nabilities-send-email-load-order-smoke: {$failed}/{$total} assertions failed\n" );
+		exit( 1 );
+	}
+
+	echo "\nAll {$total} abilities-send-email-load-order source-string assertions passed (behavioral simulation skipped under real WordPress).\n";
+	return;
+}
+
 if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', '/tmp/' );
 }


### PR DESCRIPTION
## Summary

The `homeboy / Test` host-smoke phase crashes on `abilities-categories-load-order-smoke.php` (`run-php` exit 255 / `state 1` assertion failure), which aborts the entire host-smoke run — it stops on the first alphabetical failure. Two sibling tests (`abilities-image-template-load-order-smoke.php`, `abilities-send-email-load-order-smoke.php`) have the identical defect and would crash next, so all three are fixed here.

Closes #2620

## Root cause

These three smoke tests drive `ensure_registered()` through its three timing states (`doing_action` → register now, `! did_action` → hook, post-action → no-op) by **stubbing** the WordPress lifecycle functions (`doing_action`, `did_action`, `add_action`, `wp_register_ability_category` / `wp_register_ability`). The stubs are installed only when the real functions are absent:

```php
if ( ! function_exists( 'doing_action' ) ) { function doing_action( $hook ) { ... } }
```

The wp-codebox host-smoke backend runs every `tests/*-smoke.php` **inside a real WordPress**, where all those functions already exist — so the stubs are never installed and are **inert**. The simulation sets `$state->doing = true` to fake "the init action is firing", but real `doing_action( 'wp_abilities_api_categories_init' )` returns `false` during the test, so categories never register immediately and the **state 1 assertion fails** → `exit(1)` → host-smoke aborts.

This is a test-harness incompatibility, **not** a production regression. The runtime registration logic is correct (and is the same code that boots categories on every request).

## Fix

Guard the stub-driven behavioral simulation behind `! defined( 'WPINC' )` — the established real-WP detector already used by `agent-conversation-runtime-policy-smoke.php`. Under real WordPress the test runs only the **source-string assertions** (which lock the real contract: unconditional registration call site + lifecycle-safe `doing_action`/`did_action`/no-op branches) and exits 0. In the pure-PHP / PHPUnit context the **full behavioral simulation still runs**.

No production code changed — test-only.

## Verification

Each of the three tests validated in both modes:

| Test | standalone (full sim) | real-WP (`WPINC` defined) |
|------|----------------------|---------------------------|
| categories-load-order | 14 assertions ✓ exit 0 | 8 source assertions ✓ exit 0 |
| image-template-load-order | ✓ exit 0 | ✓ exit 0 |
| send-email-load-order | ✓ exit 0 | ✓ exit 0 |