### PR TITLE
fix: race-safe add_processed_item via atomic upsert (#2626)

### DIFF
--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -280,59 +280,35 @@ class ProcessedItems extends BaseRepository {
 	public function add_processed_item( string $flow_step_id, string $source_type, string $item_identifier, int $job_id ): bool {
 		$now = current_time( 'mysql', true );
 
-		// Convert an existing in-flight claim to final processed state, or refresh
-		// an existing processed row idempotently. The unique key guarantees one row
-		// per source item, so this is safe across child-job races.
+		// Single atomic upsert keyed on the `flow_source_item` unique index. This
+		// records a fresh processed row, OR — when an in-flight claim or an
+		// already-processed row exists — converts it to final processed state with
+		// the latest job_id/timestamp and clears any claim. A bare INSERT (or a
+		// check-then-insert) races between concurrent Action Scheduler workers and
+		// makes the loser log a hard "Duplicate entry" DB error on every collision.
+		// INSERT ... ON DUPLICATE KEY UPDATE turns that race into a normal no-op:
+		// the unique key still guarantees exactly one row per source item, and no
+		// duplicate-key error is ever raised.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with %i table placeholder.
-		$updated = $this->wpdb->query(
+		$result = $this->wpdb->query(
 			$this->wpdb->prepare(
-				'UPDATE %i SET job_id = %d, status = %s, processed_timestamp = %s, claim_expires_at = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s',
+				'INSERT INTO %i (flow_step_id, source_type, item_identifier, job_id, status, processed_timestamp, claim_expires_at)
+				VALUES (%s, %s, %s, %d, %s, %s, NULL)
+				ON DUPLICATE KEY UPDATE job_id = VALUES(job_id), status = VALUES(status), processed_timestamp = VALUES(processed_timestamp), claim_expires_at = NULL',
 				$this->table_name,
-				$job_id,
-				self::STATUS_PROCESSED,
-				$now,
 				$flow_step_id,
 				$source_type,
-				$item_identifier
+				$item_identifier,
+				$job_id,
+				self::STATUS_PROCESSED,
+				$now
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
-		if ( false !== $updated && $updated > 0 ) {
-			return true;
-		}
-
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$result = $this->wpdb->insert(
-			$this->table_name,
-			array(
-				'flow_step_id'    => $flow_step_id,
-				'source_type'     => $source_type,
-				'item_identifier' => $item_identifier,
-				'job_id'          => $job_id,
-				'status'          => self::STATUS_PROCESSED,
-				// processed_timestamp defaults to NOW().
-			),
-			array(
-				'%s', // flow_step_id
-				'%s', // source_type
-				'%s', // item_identifier
-				'%d', // job_id
-				'%s', // status
-			)
-		);
-
 		if ( false === $result ) {
-			// Log error - but check if it's a duplicate key error first
-			$db_error = $this->wpdb->last_error;
-
-			// If it's a duplicate key error, treat as success (race condition handling)
-			if ( false !== strpos( $db_error, 'Duplicate entry' ) ) {
-				return true; // Treat duplicate as success
-			}
-
-			// Use Logger Service if available for actual errors
+			// A genuine failure (not a duplicate — the upsert never raises one).
 			do_action(
 				'datamachine_log',
 				'error',
@@ -342,7 +318,7 @@ class ProcessedItems extends BaseRepository {
 					'source_type'     => $source_type,
 					'item_identifier' => substr( $item_identifier, 0, 100 ) . '...', // Avoid logging potentially huge identifiers
 					'job_id'          => $job_id,
-					'db_error'        => $db_error,
+					'db_error'        => $this->wpdb->last_error,
 				)
 			);
 			return false;


### PR DESCRIPTION
## Summary

Fixes #2626. `ProcessedItems->add_processed_item()` raced between its `UPDATE` and a bare `INSERT`, so concurrent Action Scheduler workers processing the same source item collided on the `flow_source_item` unique key. `wpdb->insert()` logged a hard `Duplicate entry` DB error to `debug.log` on **every** collision (~2,809 entries/day on the events site, blog 7) even though the code caught the duplicate string and returned `true` afterward.

The unique key was correctly preventing dupes — the bug was that the bare INSERT logged a hard DB error on every race instead of treating "already processed" as a normal no-op.

## Fix

Replaced the `UPDATE`-then-bare-`INSERT` pair with a **single atomic** `INSERT ... ON DUPLICATE KEY UPDATE` keyed on `flow_source_item`:

- Fresh item → inserted as `processed`.
- Existing in-flight `claimed` row → converted to final `processed` state (new `job_id`/`processed_timestamp`, `claim_expires_at` cleared) — same end state as the old UPDATE path.
- Concurrent racing worker → clean no-op update, **no logged `Duplicate entry` DB error**.

A check-then-insert would not be sufficient (the race is between check and insert); this is a single atomic statement. Dedup behavior is unchanged: exactly one row per `(flow_step_id, source_type, item_identifier)`.

## Verification

- `php -l` clean on the changed file.
- `composer lint` (phpcs) on the changed file exits `0`.
- `php tests/processed-item-claims-smoke.php` → 21 assertions, 0 failures.
- Validated the exact SQL against real MySQL on a temp table with the production schema:
  - pre-existing `claimed` row → converted to `processed`, claim cleared
  - two racing upserts on the same item → exactly **one** row, no duplicate-key error
  - fresh item → inserted normally
  - total rows = one per unique source item (dedup preserved)

Spans the affected handlers (`universal_web_scraper`, `dice_fm`, `ticketmaster`, `vision_flyer`) since the fix is in the shared write path.

Fixes #2626