### PR TITLE
Emit required tool resolution evidence

### DIFF
--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -67,6 +67,7 @@ class JobArtifacts {
 			'disposition_diagnostic' => $this->disposition_diagnostic( $engine_data ),
 			'required_tool_names'    => $this->tool_names_from_assertions( $engine_data['completion_assertions_required'] ?? array() ),
 			'satisfied_tool_names'   => $this->tool_names_from_assertions( $engine_data['completion_assertions_satisfied'] ?? array() ),
+			'tool_resolution_evidence' => is_array( $engine_data['tool_resolution_evidence'] ?? null ) ? $engine_data['tool_resolution_evidence'] : array(),
 			'successful_tool_calls'  => $tool_calls,
 			'tool_trace'             => $this->tool_trace( $engine_data, $additional_tool_summaries ),
 			'transcript'             => $this->transcript_metadata( $job_id, $engine_data ),

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -370,22 +370,28 @@ class AIStep extends Step {
 				?? $this->engine->get( 'pipeline_tool_categories' )
 				?? array();
 
-			$resolver        = new ToolPolicyResolver();
-			$available_tools = $resolver->resolve(
-				array_merge(
-					array(
-						'modes'                => $execution_modes,
-						'agent_id'             => $agent_id,
-						'agent_slug'           => $agent_slug,
-						'previous_step_config' => $previous_step_config,
-						'next_step_config'     => $next_step_config,
-						'pipeline_step_id'     => $pipeline_step_id,
-						'engine_data'          => $engine_data,
-						'categories'           => $tool_categories,
-					),
-					PipelineToolPolicyArgs::fromConfigs( $this->flow_step_config, $pipeline_step_config )
-				)
+			$resolver                 = new ToolPolicyResolver();
+			$tool_resolution_args     = array_merge(
+				array(
+					'modes'                => $execution_modes,
+					'agent_id'             => $agent_id,
+					'agent_slug'           => $agent_slug,
+					'previous_step_config' => $previous_step_config,
+					'next_step_config'     => $next_step_config,
+					'pipeline_step_id'     => $pipeline_step_id,
+					'engine_data'          => $engine_data,
+					'categories'           => $tool_categories,
+				),
+				PipelineToolPolicyArgs::fromConfigs( $this->flow_step_config, $pipeline_step_config )
 			);
+			$tool_resolution          = $resolver->resolveWithEvidence(
+				$tool_resolution_args,
+				self::completionAssertionRequiredToolNames( $completion_assertions ),
+				FlowStepConfig::getEnabledTools( $this->flow_step_config )
+			);
+			$available_tools          = $tool_resolution['tools'];
+			$tool_resolution_evidence = $tool_resolution['evidence'];
+			self::persistToolResolutionEvidence( $this->job_id, $tool_resolution_evidence );
 
 			// Required adjacent handler tools are flow plumbing, not optional research
 			// tools. If a publish/upsert handler required by the flow shape cannot be
@@ -404,6 +410,7 @@ class AIStep extends Step {
 							'required_handler_slugs'       => $required_handler_slugs,
 							'missing_required_handler_slugs' => $missing_handler_slugs,
 							'available_handler_tool_slugs' => FlowStepConfig::getAvailableRequiredHandlerSlugsForAi( $required_handler_slugs, $available_tools ),
+							'tool_resolution_evidence'     => $tool_resolution_evidence,
 							'error_message'                => 'AI step requires adjacent handler tools that are not available to the model.',
 						)
 					);
@@ -497,6 +504,7 @@ class AIStep extends Step {
 						'ai_error'                        => $loop_result['error'],
 						'error_code'                      => $loop_result['error_code'] ?? null,
 						'unavailable_required_tool_names' => is_array( $loop_result['unavailable_required_tool_names'] ?? null ) ? $loop_result['unavailable_required_tool_names'] : array(),
+						'tool_resolution_evidence'        => $tool_resolution_evidence,
 						'ai_provider'                     => $provider_name,
 						'request_metadata'                => $request_metadata,
 						'transport_profile'               => is_array( $request_metadata['transport'] ?? null ) ? $request_metadata['transport'] : array(),
@@ -536,6 +544,7 @@ class AIStep extends Step {
 			if ( $this->job_id > 0 ) {
 				$artifact_engine_data                           = datamachine_get_engine_data( $this->job_id );
 				$artifact_engine_data['tool_execution_summary'] = self::summarizeToolExecutions( $loop_result );
+				$artifact_engine_data['tool_resolution_evidence'] = $tool_resolution_evidence;
 				if ( isset( $loop_result['runtime_provenance'] ) && is_array( $loop_result['runtime_provenance'] ) ) {
 					$artifact_engine_data['runtime_provenance'] = $loop_result['runtime_provenance'];
 				}
@@ -724,6 +733,36 @@ class AIStep extends Step {
 		}
 
 		return $merged;
+	}
+
+	/**
+	 * Extract required tool names from merged completion assertions.
+	 *
+	 * @param array $completion_assertions Merged assertion config.
+	 * @return array<int,string>
+	 */
+	private static function completionAssertionRequiredToolNames( array $completion_assertions ): array {
+		return self::normalizeCompletionAssertionList( $completion_assertions['required_tool_names'] ?? array() );
+	}
+
+	/**
+	 * Persist required-tool resolution evidence where job artifacts can surface it.
+	 *
+	 * @param int   $job_id   Job ID.
+	 * @param array $evidence Tool resolution evidence.
+	 * @return void
+	 */
+	private static function persistToolResolutionEvidence( int $job_id, array $evidence ): void {
+		if ( $job_id <= 0 || empty( $evidence ) || ! function_exists( 'datamachine_merge_engine_data' ) ) {
+			return;
+		}
+
+		datamachine_merge_engine_data(
+			$job_id,
+			array(
+				'tool_resolution_evidence' => $evidence,
+			)
+		);
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php
+++ b/inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php
@@ -41,6 +41,8 @@ final class DataMachineToolRegistrySource {
 				continue;
 			}
 
+			$include_unavailable = ! empty( $args['include_unavailable'] );
+
 			// Handler-wrapper tools belong to the adjacent-handler source.
 			// Skip them here regardless of mode so they cannot leak into
 			// the static-registry surface — including via mode inheritance.
@@ -48,12 +50,17 @@ final class DataMachineToolRegistrySource {
 				continue;
 			}
 
-			if ( ! ToolPolicyResolver::isOptInToolAllowed( $tool_config, $tool_name, $args ) ) {
+			if ( ! $include_unavailable && ! ToolPolicyResolver::isOptInToolAllowed( $tool_config, $tool_name, $args ) ) {
 				continue;
 			}
 
 			// Tools with requires_config go through availability checks.
 			// Tools without it are always available unless globally disabled.
+			if ( $include_unavailable ) {
+				$available_tools[ $tool_name ] = $tool_config;
+				continue;
+			}
+
 			if ( ! empty( $tool_config['requires_config'] ) ) {
 				if ( ! $this->tool_manager->is_tool_available( $tool_name, null ) ) {
 					continue;

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -149,6 +149,164 @@ class ToolPolicyResolver {
 	}
 
 	/**
+	 * Resolve tools and return bounded evidence for required-tool diagnostics.
+	 *
+	 * @param array $args                 Resolution arguments.
+	 * @param array $required_tool_names  Completion assertion required tool names.
+	 * @param array $requested_tool_names Requested/enabled tool names from the step config.
+	 * @return array{tools: array<string,array<string,mixed>>, evidence: array<string,mixed>}
+	 */
+	public function resolveWithEvidence( array $args, array $required_tool_names = array(), array $requested_tool_names = array() ): array {
+		$tools    = $this->resolve( $args );
+		$evidence = $this->buildResolutionEvidence( $args, $tools, $required_tool_names, $requested_tool_names );
+
+		return array(
+			'tools'    => $tools,
+			'evidence' => $evidence,
+		);
+	}
+
+	/**
+	 * Build the local Data Machine view of requested, required, gathered, and resolved tools.
+	 *
+	 * @param array $args                 Resolution arguments.
+	 * @param array $resolved_tools       Final resolved tools keyed by name.
+	 * @param array $required_tool_names  Completion assertion required tool names.
+	 * @param array $requested_tool_names Requested/enabled tool names from the step config.
+	 * @return array<string,mixed>
+	 */
+	private function buildResolutionEvidence( array $args, array $resolved_tools, array $required_tool_names, array $requested_tool_names ): array {
+		$modes                = self::normalizeModes( $args['modes'] ?? ( array_key_exists( 'mode', $args ) ? array( $args['mode'] ) : array( self::MODE_PIPELINE ) ) );
+		$requested_tool_names = $this->policy_filter->string_list( $requested_tool_names );
+		if ( empty( $requested_tool_names ) && ! empty( $args['allow_only_explicit'] ) ) {
+			$requested_tool_names = $this->policy_filter->string_list( $args['allow_only'] ?? array() );
+		}
+		$required_tool_names = $this->policy_filter->string_list( $required_tool_names );
+		$resolved_tool_names = array_keys( $resolved_tools );
+
+		$source_snapshot = $this->tool_source_registry->gatherWithMetadata(
+			$modes,
+			array_merge(
+				$args,
+				array(
+					'modes'               => $modes,
+					'include_unavailable' => true,
+				)
+			)
+		);
+		$source_tools    = is_array( $source_snapshot['tools'] ?? null ) ? $source_snapshot['tools'] : array();
+		$sources         = is_array( $source_snapshot['sources'] ?? null ) ? $source_snapshot['sources'] : array();
+
+		$source_by_tool = array();
+		foreach ( $sources as $source ) {
+			if ( ! is_array( $source ) ) {
+				continue;
+			}
+			$source_slug = is_string( $source['source'] ?? null ) ? $source['source'] : '';
+			foreach ( $source['accepted_tool_names'] ?? array() as $tool_name ) {
+				if ( is_string( $tool_name ) && '' !== $tool_name && ! isset( $source_by_tool[ $tool_name ] ) ) {
+					$source_by_tool[ $tool_name ] = $source_slug;
+				}
+			}
+		}
+
+		$available_names              = $this->availableToolNamesForEvidence( $resolved_tools );
+		$unavailable_required_tools   = array_values( array_diff( array_values( array_unique( $required_tool_names ) ), $available_names ) );
+		$required_resolution_evidence = array();
+		foreach ( $required_tool_names as $tool_name ) {
+			$resolved_name = $this->resolvedToolNameForEvidence( $tool_name, $resolved_tools );
+			if ( '' !== $resolved_name ) {
+				$required_resolution_evidence[] = array(
+					'tool_name'     => $tool_name,
+					'status'        => 'resolved',
+					'reason'        => 'resolved',
+					'resolved_name' => $resolved_name,
+					'source'        => $source_by_tool[ $resolved_name ] ?? ( $resolved_tools[ $resolved_name ]['source'] ?? 'unknown' ),
+				);
+				continue;
+			}
+
+			$reason = 'unknown';
+			if ( in_array( $tool_name, $this->policy_filter->string_list( $args['deny'] ?? array() ), true ) ) {
+				$reason = 'tool_disabled';
+			} elseif ( isset( $source_tools[ $tool_name ] ) ) {
+				$reason = 'policy_filtered';
+			}
+
+			$required_resolution_evidence[] = array(
+				'tool_name' => $tool_name,
+				'status'    => 'unavailable',
+				'reason'    => $reason,
+				'source'    => $source_by_tool[ $tool_name ] ?? null,
+			);
+		}
+
+		return array(
+			'schema_version'                  => 1,
+			'modes'                           => $modes,
+			'requested_tool_names'            => $requested_tool_names,
+			'required_tool_names'             => $required_tool_names,
+			'resolved_tool_ids'               => $resolved_tool_names,
+			'unavailable_required_tool_names' => $unavailable_required_tools,
+			'available_tool_sources'          => $sources,
+			'required_tool_resolution'        => $required_resolution_evidence,
+			'filtering'                       => array_filter(
+				array(
+					'allow_only'          => $this->policy_filter->string_list( $args['allow_only'] ?? array() ),
+					'allow_only_explicit' => ! empty( $args['allow_only_explicit'] ),
+					'deny'                => $this->policy_filter->string_list( $args['deny'] ?? array() ),
+					'categories'          => $this->policy_filter->string_list( $args['categories'] ?? array() ),
+					'tool_policy'         => is_array( $args['tool_policy'] ?? null ) ? array(
+						'mode'       => is_string( $args['tool_policy']['mode'] ?? null ) ? $args['tool_policy']['mode'] : '',
+						'tools'      => $this->policy_filter->string_list( $args['tool_policy']['tools'] ?? array() ),
+						'categories' => $this->policy_filter->string_list( $args['tool_policy']['categories'] ?? array() ),
+					) : null,
+				),
+				static fn( $value ) => null !== $value && array() !== $value
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,array<string,mixed>> $tools Tools keyed by logical name.
+	 * @return array<int,string>
+	 */
+	private function availableToolNamesForEvidence( array $tools ): array {
+		$names = array();
+		foreach ( $tools as $tool_name => $tool_def ) {
+			$names[] = (string) $tool_name;
+			foreach ( array( 'name', 'runtime_tool_id' ) as $key ) {
+				$value = is_string( $tool_def[ $key ] ?? null ) ? trim( (string) $tool_def[ $key ] ) : '';
+				if ( '' !== $value ) {
+					$names[] = $value;
+				}
+			}
+		}
+
+		return array_values( array_unique( array_filter( $names ) ) );
+	}
+
+	/**
+	 * @param string $required_name Required assertion tool name.
+	 * @param array  $tools         Tools keyed by logical name.
+	 */
+	private function resolvedToolNameForEvidence( string $required_name, array $tools ): string {
+		foreach ( $tools as $tool_name => $tool_def ) {
+			if ( $required_name === $tool_name ) {
+				return (string) $tool_name;
+			}
+
+			foreach ( array( 'name', 'runtime_tool_id' ) as $key ) {
+				if ( $required_name === ( $tool_def[ $key ] ?? null ) ) {
+					return (string) $tool_name;
+				}
+			}
+		}
+
+		return '';
+	}
+
+	/**
 	 * Gather tools by mode preset.
 	 *
 	 * @param array $modes Agent mode slugs.

--- a/inc/Engine/AI/Tools/ToolSourceRegistry.php
+++ b/inc/Engine/AI/Tools/ToolSourceRegistry.php
@@ -65,6 +65,76 @@ class ToolSourceRegistry {
 	}
 
 	/**
+	 * Gather tools with bounded source-level metadata for diagnostics.
+	 *
+	 * @param array $modes Agent mode slugs.
+	 * @param array $args  Full resolution arguments.
+	 * @return array{tools: array<string,array<string,mixed>>, sources: array<int,array<string,mixed>>}
+	 */
+	public function gatherWithMetadata( array $modes, array $args ): array {
+		$context  = array_merge(
+			$args,
+			array(
+				'modes'        => $modes,
+				'tool_manager' => $this->tool_manager,
+			)
+		);
+		$callback = array( $this, 'orderSourcesForContext' );
+		if ( function_exists( 'add_filter' ) ) {
+			add_filter( 'agents_api_tool_source_order', $callback, 5, 3 );
+		}
+
+		try {
+			$sources = $this->registry->getSources( $context );
+			$order   = array_keys( $sources );
+			if ( function_exists( 'apply_filters' ) ) {
+				$order = apply_filters( 'agents_api_tool_source_order', $order, $context, $this->registry, $sources );
+			}
+			$order = is_array( $order ) ? array_values( array_filter( $order, static fn( $source ): bool => is_string( $source ) && isset( $sources[ $source ] ) ) ) : array();
+
+			$tools           = array();
+			$source_metadata = array();
+			foreach ( $order as $source_slug ) {
+				$source_tools = call_user_func( $sources[ $source_slug ], $context, $this->registry );
+				if ( function_exists( 'apply_filters' ) ) {
+					$source_tools = apply_filters( 'agents_api_tool_source_tools', $source_tools, $source_slug, $context, $this->registry );
+				}
+
+				$source_tools   = is_array( $source_tools ) ? $source_tools : array();
+				$produced_names = array_values( array_filter( array_keys( $source_tools ), 'is_string' ) );
+				$accepted_names = array();
+				foreach ( $source_tools as $tool_name => $tool_definition ) {
+					if ( ! is_string( $tool_name ) || isset( $tools[ $tool_name ] ) || ! is_array( $tool_definition ) ) {
+						continue;
+					}
+
+					$tools[ $tool_name ] = $tool_definition;
+					$accepted_names[]    = $tool_name;
+				}
+
+				$source_metadata[] = array(
+					'source'              => $source_slug,
+					'consulted'           => true,
+					'produced_tool_names'  => $produced_names,
+					'accepted_tool_names'  => $accepted_names,
+					'filtered_tool_names'  => array_values( array_diff( $produced_names, $accepted_names ) ),
+					'produced_tool_count'  => count( $produced_names ),
+					'accepted_tool_count'  => count( $accepted_names ),
+				);
+			}
+
+			return array(
+				'tools'   => $tools,
+				'sources' => $source_metadata,
+			);
+		} finally {
+			if ( function_exists( 'remove_filter' ) ) {
+				remove_filter( 'agents_api_tool_source_order', $callback, 5 );
+			}
+		}
+	}
+
+	/**
 	 * Register Data Machine-owned sources with the Agents API source registry.
 	 *
 	 * @return void

--- a/tests/ai-completion-assertion-packet-smoke.php
+++ b/tests/ai-completion-assertion-packet-smoke.php
@@ -63,6 +63,7 @@ require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-policy.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-source-registry.php';
 require_once __DIR__ . '/../inc/Engine/AI/ConversationManager.php';
+require_once __DIR__ . '/../inc/Engine/AI/conversation-loop.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineAgentToolPolicyProvider.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineMandatoryToolPolicy.php';
@@ -98,14 +99,18 @@ $missing_method = new ReflectionMethod( AIStep::class, 'missingCompletionAsserti
 
 $result = $method->invoke(
 	null,
-	array(
-		'messages'                       => array(),
-		'tool_execution_results'         => array(),
-		'completion_assertions_complete'  => true,
-		'completion_assertions_satisfied' => array(
-			'complete_when_any' => array( 'design_comment_and_labels' ),
+	\DataMachine\Engine\AI\datamachine_with_conversation_metadata(
+		array(
+			'messages'               => array(),
+			'tool_execution_results' => array(),
 		),
-		'completion_assertions_missing'   => array(),
+		array(
+			'completion_assertions_complete'  => true,
+			'completion_assertions_satisfied' => array(
+				'complete_when_any' => array( 'design_comment_and_labels' ),
+			),
+			'completion_assertions_missing'   => array(),
+		)
 	),
 	array(
 		array(
@@ -124,6 +129,7 @@ assert_completion_packet( array( 'design_comment_and_labels' ) === ( $result[0][
 
 $missing_failure = $missing_method->invoke(
 	null,
+	array(),
 	array(
 		'completion_assertions_complete'  => false,
 		'completion_assertions_missing'   => array( 'tool_names' => array( 'comment_github_pull_request' ) ),
@@ -138,6 +144,7 @@ assert_completion_packet( array( 'comment_github_pull_request' ) === ( $missing_
 
 $complete_failure = $missing_method->invoke(
 	null,
+	array(),
 	array(
 		'completion_assertions_complete'  => true,
 		'completion_assertions_missing'   => array(),

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -146,6 +146,27 @@ function resolve_policy_tools_for_test( array $flow_step_config, array $pipeline
 	);
 }
 
+function resolve_policy_tools_with_evidence_for_test( array $flow_step_config, array $pipeline_step_config, SnapshotPolicyToolManager $manager, array $required_tool_names ): array {
+	$resolver = new ToolPolicyResolver( $manager );
+
+	return $resolver->resolveWithEvidence(
+		array_merge(
+			array(
+				'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
+				'agent_id'             => 0,
+				'previous_step_config' => null,
+				'next_step_config'     => null,
+				'pipeline_step_id'     => (string) ( $flow_step_config['pipeline_step_id'] ?? '' ),
+				'engine_data'          => array(),
+				'categories'           => array(),
+			),
+			PipelineToolPolicyArgs::fromConfigs( $flow_step_config, $pipeline_step_config )
+		),
+		$required_tool_names,
+		is_array( $flow_step_config['enabled_tools'] ?? null ) ? $flow_step_config['enabled_tools'] : array()
+	);
+}
+
 echo "pipeline-tool-policy-snapshot-smoke\n";
 
 echo "\n[1] non-empty enabled_tools narrows pipeline tools:\n";
@@ -296,6 +317,40 @@ assert_policy_equals(
 	$failures,
 	$passes
 );
+
+echo "\n[8] required-tool evidence reports policy-filtered unavailable tools:\n";
+$resolution = resolve_policy_tools_with_evidence_for_test(
+	array(
+		'step_type'        => 'ai',
+		'pipeline_step_id' => 'ephemeral_pipeline_0',
+		'enabled_tools'    => array( 'beta_tool' ),
+	),
+	array(),
+	new SnapshotPolicyToolManager(),
+	array( 'alpha_tool' )
+);
+assert_policy_equals( array( 'beta_tool' ), array_keys( $resolution['tools'] ), 'evidence test allowlist resolves enabled tool only', $failures, $passes );
+assert_policy_equals( array( 'beta_tool' ), $resolution['evidence']['requested_tool_names'] ?? null, 'evidence preserves requested tool names', $failures, $passes );
+assert_policy_equals( array( 'alpha_tool' ), $resolution['evidence']['required_tool_names'] ?? null, 'evidence preserves required tool names', $failures, $passes );
+assert_policy_equals( array( 'alpha_tool' ), $resolution['evidence']['unavailable_required_tool_names'] ?? null, 'evidence reports unavailable required tool names', $failures, $passes );
+assert_policy_equals( 'policy_filtered', $resolution['evidence']['required_tool_resolution'][0]['reason'] ?? null, 'evidence categorizes gathered-but-filtered required tool', $failures, $passes );
+assert_policy_equals( 'static_registry', $resolution['evidence']['required_tool_resolution'][0]['source'] ?? null, 'evidence identifies source for filtered required tool', $failures, $passes );
+
+echo "\n[9] required-tool evidence reports resolved tools:\n";
+$resolution = resolve_policy_tools_with_evidence_for_test(
+	array(
+		'step_type'        => 'ai',
+		'pipeline_step_id' => 'ephemeral_pipeline_0',
+		'enabled_tools'    => array( 'alpha_tool' ),
+	),
+	array(),
+	new SnapshotPolicyToolManager(),
+	array( 'alpha_tool' )
+);
+assert_policy_equals( array( 'alpha_tool' ), array_keys( $resolution['tools'] ), 'resolved evidence keeps required tool', $failures, $passes );
+assert_policy_equals( array(), $resolution['evidence']['unavailable_required_tool_names'] ?? null, 'resolved evidence has no unavailable required tools', $failures, $passes );
+assert_policy_equals( 'resolved', $resolution['evidence']['required_tool_resolution'][0]['status'] ?? null, 'resolved evidence marks required tool resolved', $failures, $passes );
+assert_policy_equals( 'alpha_tool', $resolution['evidence']['required_tool_resolution'][0]['resolved_name'] ?? null, 'resolved evidence preserves resolved logical name', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " pipeline policy assertions failed.\n";


### PR DESCRIPTION
## Summary
- Add structured tool resolution evidence for AI steps, including requested tools, required tools, resolved tool IDs, unavailable required tools, consulted sources, and filtering metadata.
- Persist the evidence into job engine data/artifacts and include it on required-tool failure diagnostics.
- Cover required-tool unavailable and resolved paths with pipeline tool policy smoke tests.

## Tests
- `php -l inc/Core/Steps/AI/AIStep.php && vendor/bin/phpcs inc/Core/Steps/AI/AIStep.php inc/Engine/AI/Tools/ToolPolicyResolver.php inc/Engine/AI/Tools/ToolSourceRegistry.php inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php inc/Core/JobArtifacts.php tests/pipeline-tool-policy-snapshot-smoke.php tests/ai-completion-assertion-packet-smoke.php`
- `php tests/pipeline-tool-policy-snapshot-smoke.php`
- `php tests/tool-source-registry-smoke.php`
- `php tests/ai-completion-assertion-packet-smoke.php`

Closes #2630