### PR TITLE
fix: load runtime for agent execution contexts

### DIFF
--- a/inc/Core/Bootstrap/RuntimeEnvironment.php
+++ b/inc/Core/Bootstrap/RuntimeEnvironment.php
@@ -43,7 +43,7 @@ class RuntimeEnvironment {
 	 * @return bool True when full runtime registration should run.
 	 */
 	public static function should_load_full_runtime(): bool {
-		if ( self::is_wp_codebox_agent_runtime() ) {
+		if ( self::is_agent_runtime() ) {
 			return true;
 		}
 
@@ -70,12 +70,12 @@ class RuntimeEnvironment {
 	}
 
 	/**
-	 * Determine whether WP Codebox is executing an agent/runtime task.
+	 * Determine whether a host is executing an agent/runtime task.
 	 *
 	 * @return bool True when the host-owned execution context requires full runtime registration.
 	 */
-	private static function is_wp_codebox_agent_runtime(): bool {
-		$value = getenv( 'WP_CODEBOX_AGENT_RUNTIME' );
+	private static function is_agent_runtime(): bool {
+		$value = getenv( 'WP_AGENT_RUNTIME' );
 
 		return is_string( $value ) && in_array( strtolower( trim( $value ) ), array( '1', 'true', 'yes', 'on' ), true );
 	}

--- a/inc/Core/Bootstrap/RuntimeEnvironment.php
+++ b/inc/Core/Bootstrap/RuntimeEnvironment.php
@@ -43,6 +43,10 @@ class RuntimeEnvironment {
 	 * @return bool True when full runtime registration should run.
 	 */
 	public static function should_load_full_runtime(): bool {
+		if ( self::is_wp_codebox_agent_runtime() ) {
+			return true;
+		}
+
 		if ( self::is_wordpress_tests() || self::is_wp_cli() ) {
 			return true;
 		}
@@ -63,5 +67,16 @@ class RuntimeEnvironment {
 		}
 
 		return (bool) apply_filters( 'datamachine_should_load_full_runtime', false );
+	}
+
+	/**
+	 * Determine whether WP Codebox is executing an agent/runtime task.
+	 *
+	 * @return bool True when the host-owned execution context requires full runtime registration.
+	 */
+	private static function is_wp_codebox_agent_runtime(): bool {
+		$value = getenv( 'WP_CODEBOX_AGENT_RUNTIME' );
+
+		return is_string( $value ) && in_array( strtolower( trim( $value ) ), array( '1', 'true', 'yes', 'on' ), true );
 	}
 }

--- a/tests/bootstrap-runtime-environment-smoke.php
+++ b/tests/bootstrap-runtime-environment-smoke.php
@@ -105,21 +105,21 @@ namespace {
 
 	$_SERVER['REQUEST_URI'] = '/frontend-page/';
 	unset( $_GET['rest_route'] );
-	putenv( 'WP_CODEBOX_AGENT_RUNTIME' );
+	putenv( 'WP_AGENT_RUNTIME' );
 
 	$assert(
 		'normal frontend request remains lazy by default',
 		! RuntimeEnvironment::should_load_full_runtime()
 	);
 
-	putenv( 'WP_CODEBOX_AGENT_RUNTIME=1' );
+	putenv( 'WP_AGENT_RUNTIME=1' );
 
 	$assert(
-		'wp codebox agent runtime signal loads full runtime',
+		'agent runtime signal loads full runtime',
 		RuntimeEnvironment::should_load_full_runtime()
 	);
 
-	putenv( 'WP_CODEBOX_AGENT_RUNTIME' );
+	putenv( 'WP_AGENT_RUNTIME' );
 
 }
 

--- a/tests/bootstrap-runtime-environment-smoke.php
+++ b/tests/bootstrap-runtime-environment-smoke.php
@@ -11,6 +11,7 @@ declare( strict_types = 1 );
 
 namespace {
 	use DataMachine\Core\Bootstrap\DependencyChecker;
+	use DataMachine\Core\Bootstrap\RuntimeEnvironment;
 
 	if ( ! defined( 'ABSPATH' ) ) {
 		define( 'ABSPATH', '/tmp/' );
@@ -59,6 +60,66 @@ namespace {
 			&& DependencyChecker::CHECK_WORDPRESS_ABILITIES === 'wordpress_abilities'
 			&& DependencyChecker::CHECK_ZIP_ARCHIVE === 'zip_archive'
 	);
+
+	if ( ! function_exists( 'is_admin' ) ) {
+		function is_admin(): bool {
+			return false;
+		}
+	}
+
+	if ( ! function_exists( 'wp_doing_ajax' ) ) {
+		function wp_doing_ajax(): bool {
+			return false;
+		}
+	}
+
+	if ( ! function_exists( 'wp_doing_cron' ) ) {
+		function wp_doing_cron(): bool {
+			return false;
+		}
+	}
+
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $value ): string {
+			return is_scalar( $value ) ? (string) $value : '';
+		}
+	}
+
+	if ( ! function_exists( 'wp_unslash' ) ) {
+		function wp_unslash( $value ) {
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'wp_parse_url' ) ) {
+		function wp_parse_url( string $url, int $component = -1 ) {
+			return parse_url( $url, $component );
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook_name, $value ) {
+			return $value;
+		}
+	}
+
+	$_SERVER['REQUEST_URI'] = '/frontend-page/';
+	unset( $_GET['rest_route'] );
+	putenv( 'WP_CODEBOX_AGENT_RUNTIME' );
+
+	$assert(
+		'normal frontend request remains lazy by default',
+		! RuntimeEnvironment::should_load_full_runtime()
+	);
+
+	putenv( 'WP_CODEBOX_AGENT_RUNTIME=1' );
+
+	$assert(
+		'wp codebox agent runtime signal loads full runtime',
+		RuntimeEnvironment::should_load_full_runtime()
+	);
+
+	putenv( 'WP_CODEBOX_AGENT_RUNTIME' );
 
 }
 

--- a/tests/frontend-runtime-gate-smoke.php
+++ b/tests/frontend-runtime-gate-smoke.php
@@ -39,6 +39,7 @@ $assert( 'admin-ajax-cron-get-full-runtime', str_contains( $runtime, 'is_admin()
 $assert( 'rest-path-gets-full-runtime', str_contains( $runtime, 'str_starts_with( $path, \'/wp-json/\' )' ) );
 $assert( 'oauth-callback-gets-full-runtime', str_contains( $runtime, 'str_starts_with( $path, \'/datamachine-auth/\' )' ) );
 $assert( 'plain-permalink-rest-route-gets-full-runtime', str_contains( $runtime, 'isset( $_GET[\'rest_route\'] )' ) );
+$assert( 'wp-codebox-agent-runtime-gets-full-runtime', str_contains( $runtime, "getenv( 'WP_CODEBOX_AGENT_RUNTIME' )" ) );
 $assert( 'extensions-can-opt-in', str_contains( $runtime, "apply_filters( 'datamachine_should_load_full_runtime'" ) );
 $assert( 'frontend-default-is-lazy', str_contains( $runtime, "apply_filters( 'datamachine_should_load_full_runtime', false" ) );
 

--- a/tests/frontend-runtime-gate-smoke.php
+++ b/tests/frontend-runtime-gate-smoke.php
@@ -39,7 +39,7 @@ $assert( 'admin-ajax-cron-get-full-runtime', str_contains( $runtime, 'is_admin()
 $assert( 'rest-path-gets-full-runtime', str_contains( $runtime, 'str_starts_with( $path, \'/wp-json/\' )' ) );
 $assert( 'oauth-callback-gets-full-runtime', str_contains( $runtime, 'str_starts_with( $path, \'/datamachine-auth/\' )' ) );
 $assert( 'plain-permalink-rest-route-gets-full-runtime', str_contains( $runtime, 'isset( $_GET[\'rest_route\'] )' ) );
-$assert( 'wp-codebox-agent-runtime-gets-full-runtime', str_contains( $runtime, "getenv( 'WP_CODEBOX_AGENT_RUNTIME' )" ) );
+$assert( 'agent-runtime-signal-gets-full-runtime', str_contains( $runtime, "getenv( 'WP_AGENT_RUNTIME' )" ) );
 $assert( 'extensions-can-opt-in', str_contains( $runtime, "apply_filters( 'datamachine_should_load_full_runtime'" ) );
 $assert( 'frontend-default-is-lazy', str_contains( $runtime, "apply_filters( 'datamachine_should_load_full_runtime', false" ) );
 


### PR DESCRIPTION
## Summary
- Treat `WP_AGENT_RUNTIME=1` as a neutral host-owned full-runtime execution signal for agent/runtime tasks.
- Keep normal frontend requests lazy unless an existing full-runtime request shape or filter applies.
- Add runtime smoke coverage for the neutral agent runtime signal and default frontend lazy behavior.

Fixes #2632.

## Testing
- `php tests/frontend-runtime-gate-smoke.php`
- `php tests/bootstrap-runtime-environment-smoke.php`
- `composer lint`
- `composer test` fails after reporting `Total: 1341, Passed: 1337, Failed: 0, Skipped: 4` due to an existing real-WordPress smoke infrastructure crash: `tests/adjacent-handler-tool-policy-smoke.php` redeclares WordPress core `do_action()` inside `wordpress.run-php`.