### PR TITLE
fix: analytics ga path_sequence table output floods 'Array to string conversion'

### DIFF
--- a/inc/Cli/Commands/AnalyticsCommand.php
+++ b/inc/Cli/Commands/AnalyticsCommand.php
@@ -236,7 +236,10 @@ class AnalyticsCommand extends BaseCommand {
 	 * Flatten a result row for table display.
 	 *
 	 * Converts nested arrays (like GA4 dimension/metric values) into flat key-value pairs.
-	 * Arrays within rows become comma-separated strings.
+	 * Scalar arrays (like GSC's 'keys') become comma-separated strings. Arrays whose
+	 * elements are themselves arrays/objects (like path_sequence's 'next_hosts') are
+	 * rendered readably rather than blindly imploded, which would otherwise trigger
+	 * "Array to string conversion" warnings.
 	 *
 	 * @param array $row Result row.
 	 * @return array Flat row.
@@ -245,13 +248,53 @@ class AnalyticsCommand extends BaseCommand {
 		$flat = array();
 		foreach ( $row as $key => $value ) {
 			if ( is_array( $value ) ) {
-				// For arrays like GSC's 'keys', join them.
-				$flat[ $key ] = implode( ', ', array_map( 'strval', $value ) );
+				$flat[ $key ] = $this->stringify_cell( $value );
 			} else {
 				$flat[ $key ] = $value;
 			}
 		}
 		return $flat;
+	}
+
+	/**
+	 * Render an array cell value as a readable string for table/CSV output.
+	 *
+	 * Scalar arrays are comma-joined (preserving the GSC 'keys' behavior). Arrays
+	 * containing nested arrays/objects are rendered as compact, readable summaries:
+	 * arrays of {next_host, users} pairs (path_sequence's 'next_hosts') become
+	 * "host:users; host:users", and any other non-scalar structure falls back to a
+	 * JSON encoding so the cell never triggers an "Array to string conversion" warning.
+	 *
+	 * @param array $value Array cell value.
+	 * @return string Readable string representation.
+	 */
+	private function stringify_cell( array $value ): string {
+		$has_nested = false;
+		foreach ( $value as $element ) {
+			if ( is_array( $element ) || is_object( $element ) ) {
+				$has_nested = true;
+				break;
+			}
+		}
+
+		// Scalar arrays (e.g. GSC's 'keys'): join as before.
+		if ( ! $has_nested ) {
+			return implode( ', ', array_map( 'strval', $value ) );
+		}
+
+		// Targeted rendering for path_sequence's next_host/users pairs.
+		$pairs = array();
+		foreach ( $value as $element ) {
+			$element = (array) $element;
+			if ( isset( $element['next_host'] ) && isset( $element['users'] ) ) {
+				$pairs[] = $element['next_host'] . ':' . $element['users'];
+			} else {
+				// Unknown nested shape: fall back to JSON for the whole cell.
+				return (string) wp_json_encode( $value );
+			}
+		}
+
+		return implode( '; ', $pairs );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes #2633. `wp datamachine analytics ga path_sequence` floods `Warning: Array to string conversion` (AnalyticsCommand.php:249) in the default table format and prints no usable output. `--format=json` was unaffected.

## Root cause

`path_sequence` (GA4 v1alpha funnel action, dmb#35) returns rows whose `next_hosts` value is an **array of objects** — `[{next_host, users}, ...]`, i.e. a nested array-of-arrays per host.

`flatten_row()` only handled one level of nesting:
```php
$flat[ $key ] = implode( ', ', array_map( 'strval', $value ) );
```
When `$value` is `next_hosts`, `strval()` is called on each inner **array** → "Array to string conversion", once per inner element (hence the flood), and the imploded cell came out empty/garbage.

## The fix

Extracted cell rendering into a new `stringify_cell()` helper called from `flatten_row()`:

- **Scalar arrays** (e.g. GSC's `keys`) — comma-joined exactly as before, so that path is unchanged.
- **`next_hosts` pairs** — rendered as compact, readable `host:users; host:users` (e.g. `community.extrachill.com:34; events.extrachill.com:18`).
- **Any other nested/non-scalar structure** — falls back to `wp_json_encode()` so a cell can never trigger an "Array to string conversion" warning again.

## Verification

Logic verified in isolation against representative rows — zero warnings under `E_ALL`:

| Input | Output |
|---|---|
| `next_hosts: [{community,34},{events,18}]` | `community.extrachill.com:34; events.extrachill.com:18` |
| `next_hosts: []` | empty string (no warning) |
| GSC `keys: [music, charleston]` | `music, charleston` (unchanged) |
| unknown nested `[{a:1},{b:2}]` | `[{"a":1},{"b":2}]` (JSON fallback) |

- Other GA actions (`page_stats`, `traffic_sources`, `network_density`, etc.) and the `--format=json` path are unaffected — only nested-array cells take the new branch; scalar and scalar-array cells behave identically.
- `php -l` clean. No new phpcs findings introduced (pre-existing repo-wide PSR-4/doc-comment violations are untouched).