### PR TITLE
feat: make CliCommandIntrospector handle __invoke/__default so #2613 consumers can delegate

### DIFF
--- a/inc/Engine/AI/CliCommandIntrospector.php
+++ b/inc/Engine/AI/CliCommandIntrospector.php
@@ -38,13 +38,21 @@ class CliCommandIntrospector {
 	/**
 	 * Describe all subcommands exposed by one WP-CLI command class.
 	 *
-	 * Reflects over the class's public, non-static methods (excluding magic
-	 * methods like `__construct`/`__invoke`) and returns each as a subcommand.
-	 * The subcommand name is taken from the method's `@subcommand <name>`
-	 * annotation when present, otherwise the method name (matching WP-CLI's own
+	 * Reflects over the class's public, non-static methods and returns each as a
+	 * subcommand. The subcommand name is taken from the method's
+	 * `@subcommand <name>` annotation when present, otherwise the method name
+	 * with underscores converted to hyphens (matching WP-CLI's own
 	 * `CommandFactory` fallback). The description is the PHPDoc short
 	 * description — the first non-tag line of the method docblock — exactly as
 	 * WP-CLI parses it for `--help`.
+	 *
+	 * A class whose only public command method is `__invoke` (the dominant
+	 * "flat command" shape — `wp extrachill venues`, `wp intelligence wiki
+	 * brain`, every `datamachine analytics *` command) is the namespace's
+	 * directly-invokable command. It reflects to a single `__default`
+	 * pseudo-subcommand carrying the `__invoke` docblock's short description,
+	 * so consumers can render it as the namespace headline. Other magic methods
+	 * (`__construct`, `__destruct`, …) are always skipped.
 	 *
 	 * @since x.y.z
 	 *
@@ -59,7 +67,8 @@ class CliCommandIntrospector {
 	 * }
 	 * @return array<int, array{name: string, description: string}> List of
 	 *         subcommands sorted by name, each with `name` and `description`.
-	 *         Empty array when the class does not exist.
+	 *         A single `__default` entry for an `__invoke`-only command. Empty
+	 *         array when the class does not exist.
 	 */
 	public static function describe_class( string $command_class, array $args = array() ): array {
 		if ( ! class_exists( $command_class ) ) {
@@ -161,6 +170,11 @@ class CliCommandIntrospector {
 	 * mapping from its WP-CLI bootstrap) so this helper never needs the live
 	 * WP-CLI runner.
 	 *
+	 * This is the canonical path for consumers that own a `command-string =>
+	 * class` map (the extrachill-cli / intelligence shape). A flat `__invoke`
+	 * command surfaces as a single `__default` subcommand entry; consumers
+	 * render that as the command's own headline rather than a sub-verb.
+	 *
 	 * @since x.y.z
 	 *
 	 * @param string                      $cli_namespace WP-CLI namespace label (e.g. 'datamachine').
@@ -191,24 +205,45 @@ class CliCommandIntrospector {
 	/**
 	 * Determine whether a reflected method is a WP-CLI subcommand candidate.
 	 *
-	 * Mirrors WP-CLI's `CommandFactory::is_good_method()`: public, non-static,
-	 * and not a magic method (`__construct`, `__invoke`, etc.).
+	 * Mirrors WP-CLI's `CommandFactory::is_good_method()` with one deliberate
+	 * addition: `__invoke` IS a subcommand candidate. WP-CLI registers a class
+	 * whose handler is `__invoke` as a directly-invokable command (the flat
+	 * "one command, no sub-verbs" shape). It is reflected here as the
+	 * `__default` pseudo-subcommand (see {@see self::subcommand_name()}).
+	 *
+	 * All other magic methods (`__construct`, `__destruct`, `__get`, …) and
+	 * static methods are not subcommands and are skipped.
 	 *
 	 * @param ReflectionMethod $method Reflected method.
 	 * @return bool
 	 */
 	private static function is_subcommand_method( ReflectionMethod $method ): bool {
-		return $method->isPublic()
-			&& ! $method->isStatic()
-			&& 0 !== strpos( $method->getName(), '__' );
+		if ( ! $method->isPublic() || $method->isStatic() ) {
+			return false;
+		}
+
+		$name = $method->getName();
+
+		// `__invoke` is the directly-invokable command handler — keep it.
+		if ( '__invoke' === $name ) {
+			return true;
+		}
+
+		// Skip every other magic method (`__construct`, `__destruct`, etc.).
+		return 0 !== strpos( $name, '__' );
 	}
 
 	/**
 	 * Resolve the subcommand name for a method.
 	 *
-	 * Uses the `@subcommand <name>` annotation when present, otherwise falls
-	 * back to the method name — matching WP-CLI's `CommandFactory` resolution
-	 * order (`@subcommand` tag, then `$reflection->name`).
+	 * Resolution order mirrors WP-CLI's `CommandFactory`:
+	 *
+	 * 1. The `@subcommand <name>` annotation when present.
+	 * 2. For `__invoke` (with no annotation), the `__default` pseudo-subcommand
+	 *    — the namespace's directly-invokable command, which consumers render as
+	 *    the namespace headline rather than a sub-verb.
+	 * 3. Otherwise the method name with underscores converted to hyphens, which
+	 *    is exactly how WP-CLI derives a subcommand name from a method name.
 	 *
 	 * @param ReflectionMethod $method      Reflected method.
 	 * @param string           $doc_comment Raw doc comment.
@@ -217,7 +252,15 @@ class CliCommandIntrospector {
 	private static function subcommand_name( ReflectionMethod $method, string $doc_comment ): string {
 		$tag = self::get_tag( $doc_comment, 'subcommand' );
 
-		return '' !== $tag ? $tag : $method->getName();
+		if ( '' !== $tag ) {
+			return $tag;
+		}
+
+		if ( '__invoke' === $method->getName() ) {
+			return '__default';
+		}
+
+		return str_replace( '_', '-', $method->getName() );
 	}
 
 	/**

--- a/tests/cli-command-introspector-invoke-smoke.php
+++ b/tests/cli-command-introspector-invoke-smoke.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Smoke test for CliCommandIntrospector __invoke / __default support.
+ *
+ * Exercises both WP-CLI command shapes the shared reflector must handle:
+ *
+ *   1. A flat command whose only public method is `__invoke` (the dominant
+ *      shape across the network — `wp extrachill venues`, `wp intelligence
+ *      wiki brain`, every `datamachine analytics *` command). It must reflect
+ *      to a single `__default` entry carrying the `__invoke` docblock's short
+ *      description — NOT an empty array.
+ *
+ *   2. A multi-subcommand command using `@subcommand` annotations (DMC's
+ *      WorkspaceCommand / GitHubCommand shape). It must reflect exactly as
+ *      before — no regression — with magic methods still skipped.
+ *
+ * Run with: php tests/cli-command-introspector-invoke-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../inc/Engine/AI/CliCommandIntrospector.php';
+
+use DataMachine\Engine\AI\CliCommandIntrospector;
+
+/**
+ * Flat command: only a `__invoke` handler. Should reflect to `__default`.
+ */
+class Introspector_Invoke_Only_Stub {
+
+	/**
+	 * Discover music venues in a city using Google Places API.
+	 *
+	 * @param array $args Positional args.
+	 */
+	public function __invoke( $args ) {
+		// no-op
+	}
+
+	/**
+	 * Internal helper — must never surface as a subcommand.
+	 */
+	private function resolve( $thing ) {
+		return $thing;
+	}
+}
+
+/**
+ * Multi-subcommand command using @subcommand annotations plus an underscore
+ * method name. Mirrors DMC's WorkspaceCommand / GitHubCommand shape.
+ */
+class Introspector_Subcommand_Stub {
+
+	/**
+	 * Construct should never be reflected as a subcommand.
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * Add a new worktree.
+	 *
+	 * @subcommand add
+	 */
+	public function add_worktree( $args ) {
+	}
+
+	/**
+	 * List the registered worktrees.
+	 *
+	 * @subcommand list
+	 */
+	public function list_worktrees( $args ) {
+	}
+
+	/**
+	 * Refresh agent context.
+	 *
+	 * No @subcommand annotation — name derives from the method name with
+	 * underscores converted to hyphens (refresh_context => refresh-context).
+	 */
+	public function refresh_context( $args ) {
+	}
+
+	/**
+	 * A static helper must never be a subcommand.
+	 */
+	public static function helper() {
+	}
+}
+
+$failed = 0;
+$total  = 0;
+
+$assert = static function ( string $label, bool $condition ) use ( &$failed, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	++$failed;
+	echo "FAIL: {$label}\n";
+};
+
+// ---------------------------------------------------------------------------
+// Shape 1: __invoke-only command => single __default entry.
+// ---------------------------------------------------------------------------
+$invoke = CliCommandIntrospector::describe_class( Introspector_Invoke_Only_Stub::class );
+
+$assert( '__invoke command yields exactly one entry', 1 === count( $invoke ) );
+$assert( '__invoke entry name is __default', '__default' === ( $invoke[0]['name'] ?? null ) );
+$assert(
+	'__invoke entry carries the __invoke docblock short description',
+	'Discover music venues in a city using Google Places API.' === ( $invoke[0]['description'] ?? null )
+);
+$assert(
+	'private helper does not leak as a subcommand',
+	! in_array( 'resolve', array_column( $invoke, 'name' ), true )
+);
+
+// ---------------------------------------------------------------------------
+// Shape 2: @subcommand command => named entries, no regression.
+// ---------------------------------------------------------------------------
+$subs  = CliCommandIntrospector::describe_class( Introspector_Subcommand_Stub::class );
+$names = array_column( $subs, 'name' );
+
+$assert( '@subcommand command yields three entries', 3 === count( $subs ) );
+$assert( '@subcommand add is present', in_array( 'add', $names, true ) );
+$assert( '@subcommand list is present', in_array( 'list', $names, true ) );
+$assert(
+	'unannotated method derives hyphenated name (refresh_context => refresh-context)',
+	in_array( 'refresh-context', $names, true )
+);
+$assert( '__construct is not reflected as a subcommand', ! in_array( '__construct', $names, true ) );
+$assert( '__default does not appear for an annotated command', ! in_array( '__default', $names, true ) );
+$assert( 'static helper is not reflected as a subcommand', ! in_array( 'helper', $names, true ) );
+
+$add = null;
+foreach ( $subs as $sub ) {
+	if ( 'add' === $sub['name'] ) {
+		$add = $sub;
+		break;
+	}
+}
+$assert(
+	'@subcommand entry keeps its docblock short description',
+	null !== $add && 'Add a new worktree.' === $add['description']
+);
+
+// Entries are sorted by name for deterministic output.
+$assert( 'subcommands are sorted by name', $names === array( 'add', 'list', 'refresh-context' ) );
+
+// ---------------------------------------------------------------------------
+// Namespace-map path surfaces __default for flat commands.
+// ---------------------------------------------------------------------------
+$map = CliCommandIntrospector::describe_namespace_map(
+	'extrachill',
+	array(
+		'extrachill venues' => Introspector_Invoke_Only_Stub::class,
+		'extrachill flow'   => Introspector_Subcommand_Stub::class,
+	)
+);
+
+$assert( 'namespace-map echoes the namespace label', 'extrachill' === ( $map['namespace'] ?? null ) );
+$assert( 'namespace-map returns one entry per command label', 2 === count( $map['commands'] ?? array() ) );
+
+$venues = null;
+$flow   = null;
+foreach ( $map['commands'] as $command ) {
+	if ( 'extrachill venues' === $command['command'] ) {
+		$venues = $command;
+	}
+	if ( 'extrachill flow' === $command['command'] ) {
+		$flow = $command;
+	}
+}
+$assert(
+	'flat command in namespace-map carries a __default subcommand',
+	null !== $venues && '__default' === ( $venues['subcommands'][0]['name'] ?? null )
+);
+$assert(
+	'multi-subcommand command in namespace-map preserves its grouped subcommands',
+	null !== $flow && 3 === count( $flow['subcommands'] ?? array() )
+);
+
+// Missing class yields an empty array (unchanged contract).
+$assert(
+	'unknown class yields an empty subcommand list',
+	array() === CliCommandIntrospector::describe_class( 'No_Such_Introspector_Class' )
+);
+
+if ( $failed > 0 ) {
+	echo "=== cli-command-introspector-invoke-smoke: {$failed} FAIL of {$total} ===\n";
+	exit( 1 );
+}
+
+echo "=== cli-command-introspector-invoke-smoke: ALL PASS ({$total}) ===\n";


### PR DESCRIPTION
## Summary

Closes the one gap blocking every `#2613` consumer from delegating to the shared `DataMachine\Engine\AI\CliCommandIntrospector`: it dropped `__invoke` commands, reflecting the dominant "flat command" shape to an **empty** subcommand list.

Fixes #2639.

## The `__invoke` gap

`CliCommandIntrospector::is_subcommand_method()` excluded *any* method starting with `__`, so a class whose only public method is `__invoke` reflected to `[]`. That shape is the majority of real commands across the network — `wp extrachill venues`, `wp intelligence wiki brain`, every `datamachine analytics *` command, DMB's `ga/gsc/bing/pagespeed/media`. Because the shared helper was useless for them, both consumers rolled their own local reflectors instead of delegating.

## The fix

Brings the helper up to the bar the consumers already set locally (proven logic copied from `extrachill-cli/inc/AgentsMdSection.php::reflect_subcommands()` and `intelligence/inc/sections/command-introspection.php`):

- **`is_subcommand_method()`** now keeps `__invoke` as a subcommand candidate while still skipping `__construct`, `__destruct`, every other magic method, and static methods.
- **`subcommand_name()`** maps `__invoke` → the `__default` pseudo-subcommand (carrying the `__invoke` docblock's short description), honors `@subcommand <name>` when present, and otherwise falls back to the method name with underscores converted to hyphens — exactly WP-CLI's own `CommandFactory` convention.
- **`describe_namespace_map()`** now surfaces `__default` for flat commands, giving a consumer that owns a `command-string => class` map (the extrachill-cli / intelligence shape) the clean grouped path it needs.
- **Context-safety preserved:** reflection over classes only, never the live WP-CLI runner.

## Regression safety for `@subcommand`

`@subcommand` commands (DMC's multi-subcommand `WorkspaceCommand` / `GitHubCommand`) reflect **exactly as before** — verified in the smoke test: annotated names, hyphenated fallback names, magic/static methods skipped, sorted output, descriptions intact.

## Verification

Added `tests/cli-command-introspector-invoke-smoke.php` exercising both shapes plus the namespace-map path:

```
php tests/cli-command-introspector-invoke-smoke.php
=== cli-command-introspector-invoke-smoke: ALL PASS (18) ===
```

- `__invoke`-only stub → single `{name: '__default', description: <invoke shortdesc>}` entry (not empty).
- `@subcommand` stub → named entries; `__construct` / static / private helpers excluded; sorted; descriptions preserved.
- namespace-map path surfaces `__default` for flat commands and preserves grouped subcommands for multi-subcommand commands.
- Unknown class → empty array (unchanged contract).

`php -l` clean on both files. (phpcs vendor not present locally; CI lint/test harness may hit the known `runner-steps.sh` env error — ran the smoke directly per repo convention.)

## Why this matters

This is the keystone for the AGENTS.md dynamic-CLI migration fleet — it unblocks the `#2613` consumer migrations (core-owns-its-section, DMC, events, socials, DMB) that were all waiting for this to become the canonical reflector they can delegate to.