### PR TITLE
fix: add scoped daily memory remediation

### DIFF
--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -282,7 +282,7 @@ class SystemAbilities {
 				),
 				count( $rejected_schedules )
 			),
-			'stale'       => __( 'scheduler has overdue work; invoke WordPress cron or run wp datamachine drain', 'data-machine' ),
+			'stale'       => __( 'scheduler has overdue work; invoke WordPress cron, run wp datamachine drain, or run a specific task with wp datamachine system run <task_type> --wait', 'data-machine' ),
 			'unavailable' => __( 'Action Scheduler is unavailable', 'data-machine' ),
 			default       => __( 'scheduler status unknown', 'data-machine' ),
 		};
@@ -326,7 +326,7 @@ class SystemAbilities {
 			),
 			'recommendation'          => match ( $status ) {
 				'failing' => __( 'One or more recurring schedules are rejected on every tick and never run. Inspect them with wp datamachine logs (filter error_code recurring_schedule_persistently_rejected) and fix the binding or its prerequisites (agent ownership, task registration, ability availability).', 'data-machine' ),
-				'stale'   => __( 'For local or low-traffic installs, schedule an external wake-up such as wp cron event run --due-now or wp datamachine drain.', 'data-machine' ),
+				'stale'   => __( 'For local or low-traffic installs, schedule an external wake-up such as wp cron event run --due-now. To remediate only daily memory for an affected agent, run wp datamachine system run daily_memory_generation --param=agent_slug=<slug> --wait; for all overdue work, run wp datamachine drain.', 'data-machine' ),
 				default   => null,
 			},
 		);

--- a/inc/Cli/Commands/SystemCommand.php
+++ b/inc/Cli/Commands/SystemCommand.php
@@ -12,6 +12,7 @@ namespace DataMachine\Cli\Commands;
 
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
+use DataMachine\Abilities\Engine\DrainJobAbility;
 use DataMachine\Abilities\SystemAbilities;
 use DataMachine\Engine\Tasks\TaskRegistry;
 use DataMachine\Engine\AI\System\Tasks\SystemTask;
@@ -245,6 +246,22 @@ class SystemCommand extends BaseCommand {
 	 * [--apply]
 	 * : Request apply mode for mutating tasks.
 	 *
+	 * [--wait]
+	 * : After scheduling, synchronously drain only the created job. Does not drain
+	 * unrelated overdue Data Machine work.
+	 *
+	 * [--step-budget=<number>]
+	 * : Maximum due job actions to execute with --wait.
+	 * ---
+	 * default: 50
+	 * ---
+	 *
+	 * [--time-budget-ms=<milliseconds>]
+	 * : Maximum wall-clock milliseconds to drain with --wait.
+	 * ---
+	 * default: 300000
+	 * ---
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -257,6 +274,8 @@ class SystemCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     wp datamachine system run daily_memory_generation --agent=intelligence-chubes4
+	 *     wp datamachine system run daily_memory_generation
+	 *     wp datamachine system run daily_memory_generation --param=agent_slug=my-agent --wait
 	 *     wp datamachine system run alt_text_generation --format=json
 	 *     wp datamachine system run retention_logs --dry-run
 	 *
@@ -284,17 +303,55 @@ class SystemCommand extends BaseCommand {
 			)
 		);
 
+		if ( ! $result['success'] ) {
+			if ( 'json' === $format ) {
+				WP_CLI::line( (string) wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+				return;
+			}
+
+			WP_CLI::error( $result['error'] ?? $result['message'] ?? 'Failed to run task.' );
+			return;
+		}
+
+		if ( ! empty( $assoc_args['wait'] ) ) {
+			$step_budget    = isset( $assoc_args['step-budget'] ) ? max( 1, (int) $assoc_args['step-budget'] ) : 50;
+			$time_budget_ms = isset( $assoc_args['time-budget-ms'] ) ? max( 1, (int) $assoc_args['time-budget-ms'] ) : 300000;
+
+			$result['drain'] = ( new DrainJobAbility() )->execute(
+				array(
+					'job_id'         => (int) ( $result['job_id'] ?? 0 ),
+					'step_budget'    => $step_budget,
+					'time_budget_ms' => $time_budget_ms,
+				)
+			);
+		}
+
 		if ( 'json' === $format ) {
 			WP_CLI::line( (string) wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 			return;
 		}
 
-		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['error'] ?? $result['message'] ?? 'Failed to run task.' );
-			return;
-		}
-
 		WP_CLI::success( $result['message'] );
+		if ( isset( $result['drain'] ) ) {
+			$drain = $result['drain'];
+			if ( ! empty( $drain['success'] ) ) {
+				WP_CLI::success(
+					sprintf(
+						'Job #%d drained to %s.',
+						(int) ( $drain['job_id'] ?? 0 ),
+						(string) ( $drain['terminal_state'] ?? 'terminal' )
+					)
+				);
+				return;
+			}
+
+			WP_CLI::error(
+				$drain['error'] ?? sprintf(
+					'Job #%d did not reach a terminal state before the wait budget was exhausted.',
+					(int) ( $drain['job_id'] ?? 0 )
+				)
+			);
+		}
 	}
 
 	/**

--- a/tests/system-health-scheduler-smoke.php
+++ b/tests/system-health-scheduler-smoke.php
@@ -33,7 +33,10 @@ datamachine_scheduler_health_assert_contains( "'scheduler' => array", $system_ab
 datamachine_scheduler_health_assert_contains( "wp_next_scheduled( 'action_scheduler_run_queue' )", $system_abilities, 'WP-Cron runner lag is inspected' );
 datamachine_scheduler_health_assert_contains( 'RecurringScheduler::GROUP', $system_abilities, 'diagnostics scope to Data Machine actions' );
 datamachine_scheduler_health_assert_contains( 'wp datamachine drain', $system_abilities, 'stale scheduler output recommends an explicit drain' );
+datamachine_scheduler_health_assert_contains( 'wp datamachine system run daily_memory_generation --param=agent_slug=<slug> --wait', $system_abilities, 'stale scheduler output recommends scoped daily memory remediation' );
 datamachine_scheduler_health_assert_contains( 'Due now:', $system_command, 'CLI table output shows due Action Scheduler work' );
 datamachine_scheduler_health_assert_contains( 'Daily memory:', $system_command, 'CLI table output shows daily memory schedule state' );
+datamachine_scheduler_health_assert_contains( '[--wait]', $system_command, 'system run exposes a job-scoped wait option' );
+datamachine_scheduler_health_assert_contains( 'DrainJobAbility', $system_command, 'system run drains only the created job when waiting' );
 
 echo "\nAll scheduler health smoke assertions passed.\n";


### PR DESCRIPTION
## Summary
- Add `wp datamachine system run <task_type> --wait` to process only the job created by a manual system task run.
- Update scheduler health guidance to show a daily-memory-specific remediation command for an affected agent.
- Extend scheduler health smoke coverage for the new recommendation and CLI wait path.

Fixes #2646.

## Verification
- `php tests/system-health-scheduler-smoke.php`
- `php -l inc/Cli/Commands/SystemCommand.php && php -l inc/Abilities/SystemAbilities.php && php -l tests/system-health-scheduler-smoke.php`
- `homeboy lint data-machine --file inc/Cli/Commands/SystemCommand.php`
- `homeboy lint data-machine --file tests/system-health-scheduler-smoke.php`

## Notes
- `composer lint -- --standard=phpcs.xml.dist ...` could not run locally because `phpcs` is not installed in this worktree.
- `composer test` is blocked by Homeboy extension metadata for `wordpress`.
- Full `homeboy lint data-machine` reports existing repo-wide findings; targeted lint on `inc/Abilities/SystemAbilities.php` is blocked by pre-existing PHPStan issues in that file, while PHPCS passes.