### PR TITLE
Surface TaskScheduler run failures

### DIFF
--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -633,6 +633,15 @@ class SystemAbilities {
 		) ), $task_context );
 
 		if ( ! $job_id ) {
+			$scheduler_error = TaskScheduler::getLastScheduleError();
+			if ( is_array( $scheduler_error ) && ! empty( $scheduler_error['message'] ) ) {
+				return array(
+					'success' => false,
+					'error'   => $scheduler_error['error'],
+					'message' => $scheduler_error['message'],
+				);
+			}
+
 			return array(
 				'success' => false,
 				'error'   => 'Failed to schedule task.',

--- a/inc/Engine/Tasks/TaskScheduler.php
+++ b/inc/Engine/Tasks/TaskScheduler.php
@@ -44,6 +44,39 @@ class TaskScheduler {
 	public const BATCH_CONTEXT = 'task';
 
 	/**
+	 * Details for the last failed schedule() call in this request.
+	 *
+	 * @var array{error:string,message:string,error_code?:string}|null
+	 */
+	private static ?array $last_schedule_error = null;
+
+	/**
+	 * Return details for the last failed schedule() call in this request.
+	 *
+	 * @return array{error:string,message:string,error_code?:string}|null
+	 */
+	public static function getLastScheduleError(): ?array {
+		return self::$last_schedule_error;
+	}
+
+	/**
+	 * Store scheduler failure details while preserving schedule()'s int|false API.
+	 *
+	 * @param string $message    Human-readable failure message.
+	 * @param string $error_code Machine-readable error code.
+	 */
+	private static function recordScheduleError( string $message, string $error_code = '' ): void {
+		self::$last_schedule_error = array(
+			'error'   => '' !== $error_code ? $error_code : 'Failed to schedule task.',
+			'message' => $message,
+		);
+
+		if ( '' !== $error_code ) {
+			self::$last_schedule_error['error_code'] = $error_code;
+		}
+	}
+
+	/**
 	 * Schedule an async task via the workflow engine.
 	 *
 	 * Resolves the task handler, calls getWorkflow() to build the step
@@ -56,11 +89,14 @@ class TaskScheduler {
 	 * @return int|false Job ID on success, false on failure.
 	 */
 	public static function schedule( string $taskType, array $params, array $context = array(), int $parentJobId = 0 ): int|false {
+		self::$last_schedule_error = null;
+
 		if ( ! TaskRegistry::isRegistered( $taskType ) ) {
+			$message = "TaskScheduler: Unknown task type '{$taskType}'";
 			do_action(
 				'datamachine_log',
 				'error',
-				"TaskScheduler: Unknown task type '{$taskType}'",
+				$message,
 				array(
 					'task_type' => $taskType,
 					'context'   => 'system',
@@ -68,6 +104,7 @@ class TaskScheduler {
 					'route'     => $context,
 				)
 			);
+			self::recordScheduleError( $message, 'task_scheduler_unknown_task_type' );
 			return false;
 		}
 
@@ -75,44 +112,50 @@ class TaskScheduler {
 		$handler_class = TaskRegistry::getHandler( $taskType );
 
 		if ( ! $handler_class || ! class_exists( $handler_class ) ) {
+			$message = "TaskScheduler: Handler class not found for '{$taskType}'";
 			do_action(
 				'datamachine_log',
 				'error',
-				"TaskScheduler: Handler class not found for '{$taskType}'",
+				$message,
 				array(
 					'task_type'     => $taskType,
 					'handler_class' => $handler_class,
 				)
 			);
+			self::recordScheduleError( $message, 'task_scheduler_handler_not_found' );
 			return false;
 		}
 
 		$handler = new $handler_class();
 		if ( ! $handler instanceof SystemTask ) {
+			$message = "TaskScheduler: Handler class for '{$taskType}' must extend SystemTask";
 			do_action(
 				'datamachine_log',
 				'error',
-				"TaskScheduler: Handler class for '{$taskType}' must extend SystemTask",
+				$message,
 				array(
 					'task_type'     => $taskType,
 					'handler_class' => $handler_class,
 				)
 			);
+			self::recordScheduleError( $message, 'task_scheduler_invalid_handler' );
 			return false;
 		}
 
 		$workflow = $handler->getWorkflow( $params );
 
 		if ( empty( $workflow['steps'] ) ) {
+			$message = "TaskScheduler: getWorkflow() returned empty steps for '{$taskType}'";
 			do_action(
 				'datamachine_log',
 				'error',
-				"TaskScheduler: getWorkflow() returned empty steps for '{$taskType}'",
+				$message,
 				array(
 					'task_type' => $taskType,
 					'params'    => $params,
 				)
 			);
+			self::recordScheduleError( $message, 'task_scheduler_empty_workflow' );
 			return false;
 		}
 
@@ -120,12 +163,14 @@ class TaskScheduler {
 		$ability = wp_get_ability( 'datamachine/execute-workflow' );
 
 		if ( ! $ability ) {
+			$message = 'TaskScheduler: datamachine/execute-workflow ability not available';
 			do_action(
 				'datamachine_log',
 				'error',
-				'TaskScheduler: datamachine/execute-workflow ability not available',
+				$message,
 				array( 'task_type' => $taskType )
 			);
+			self::recordScheduleError( $message, 'task_scheduler_execute_workflow_unavailable' );
 			return false;
 		}
 
@@ -144,10 +189,11 @@ class TaskScheduler {
 				$context_agent_id   = $identity->agent_id;
 				$context_agent_slug = $identity->agent_slug;
 			} catch ( \InvalidArgumentException $e ) {
+				$message = 'TaskScheduler: queued task received invalid agent context';
 				do_action(
 					'datamachine_log',
 					'error',
-					'TaskScheduler: queued task received invalid agent context',
+					$message,
 					array(
 						'task_type'  => $taskType,
 						'context'    => 'system',
@@ -156,13 +202,15 @@ class TaskScheduler {
 						'error_code' => 'task_scheduler_invalid_agent_context',
 					)
 				);
+				self::recordScheduleError( $message, 'task_scheduler_invalid_agent_context' );
 				return false;
 			}
 		} elseif ( $requires_agent_context ) {
+			$message = 'TaskScheduler: queued task requires agent context';
 			do_action(
 				'datamachine_log',
 				'error',
-				'TaskScheduler: queued task requires agent context',
+				$message,
 				array(
 					'task_type'      => $taskType,
 					'context'        => 'system',
@@ -171,6 +219,7 @@ class TaskScheduler {
 					'recommendation' => 'Provide agent_id or agent_slug, or reassign unowned flows/pipelines with --where-null before scheduling queued work.',
 				)
 			);
+			self::recordScheduleError( $message, 'task_scheduler_agent_context_required' );
 			return false;
 		}
 
@@ -212,16 +261,19 @@ class TaskScheduler {
 		) ) );
 
 		if ( empty( $result['success'] ) ) {
+			$message    = 'TaskScheduler: Workflow execution failed for ' . $taskType . ': ' . ( $result['error'] ?? 'Unknown error' );
+			$error_code = is_string( $result['error'] ?? null ) && '' !== $result['error'] ? $result['error'] : 'task_scheduler_workflow_execution_failed';
 			do_action(
 				'datamachine_log',
 				'error',
-				'TaskScheduler: Workflow execution failed for ' . $taskType . ': ' . ( $result['error'] ?? 'Unknown error' ),
+				$message,
 				array(
 					'task_type' => $taskType,
 					'context'   => 'system',
 					'error'     => $result['error'] ?? '',
 				)
 			);
+			self::recordScheduleError( $message, $error_code );
 			return false;
 		}
 

--- a/tests/system-run-task-params-smoke.php
+++ b/tests/system-run-task-params-smoke.php
@@ -228,6 +228,22 @@ function smoke_default_system_task_workflow( string $task_type, array $params ):
 	);
 }
 
+function smoke_system_run_schedule_failure_response( ?array $scheduler_error ): array {
+	if ( is_array( $scheduler_error ) && ! empty( $scheduler_error['message'] ) ) {
+		return array(
+			'success' => false,
+			'error'   => $scheduler_error['error'],
+			'message' => $scheduler_error['message'],
+		);
+	}
+
+	return array(
+		'success' => false,
+		'error'   => 'Failed to schedule task.',
+		'message' => 'TaskScheduler returned false — check logs for details.',
+	);
+}
+
 echo "\n[1] CLI structured params parse\n";
 $params = smoke_parse_run_task_params(
 	array(
@@ -328,6 +344,19 @@ $assert( 'SystemTask workflow stores params in flow_step_settings', $scheduled_p
 $assert( 'SystemTask workflow stores canonical task_type', 'wiki_maintain' === $workflow['steps'][0]['flow_step_settings']['task_type'] );
 $assert( 'SystemTask workflow does not store legacy task alias', ! array_key_exists( 'task', $workflow['steps'][0]['flow_step_settings'] ) );
 
+echo "\n[3b] Scheduler rejection details surface in run response\n";
+$response = smoke_system_run_schedule_failure_response(
+	array(
+		'error'      => 'task_scheduler_agent_context_required',
+		'error_code' => 'task_scheduler_agent_context_required',
+		'message'    => 'TaskScheduler: queued task requires agent context',
+	)
+);
+$assert( 'scheduler error code becomes run error', 'task_scheduler_agent_context_required' === $response['error'] );
+$assert( 'scheduler log message becomes run message', 'TaskScheduler: queued task requires agent context' === $response['message'] );
+$response = smoke_system_run_schedule_failure_response( null );
+$assert( 'missing scheduler details preserve generic fallback', 'Failed to schedule task.' === $response['error'] );
+
 echo "\n[4] Source tripwires\n";
 $system_command = file_get_contents( __DIR__ . '/../inc/Cli/Commands/SystemCommand.php' );
 $abilities      = file_get_contents( __DIR__ . '/../inc/Abilities/SystemAbilities.php' );
@@ -343,9 +372,11 @@ $assert( 'CLI forwards task_params to runTask', str_contains( $system_command, "
 $assert( 'run-task ability schema accepts task_params', str_contains( $abilities, "'task_params' => array" ) );
 $assert( 'run-task ability extracts agent alias before validation', str_contains( $abilities, "array_key_exists( 'agent', $" . 'params' ) && str_contains( $abilities, "'agent_slug'" ) );
 $assert( 'run-task ability schedules merged task params', str_contains( $abilities, 'array_merge( $task_params' ) );
+$assert( 'run-task ability surfaces scheduler errors', str_contains( $abilities, 'TaskScheduler::getLastScheduleError()' ) );
 $assert( 'TaskRegistry exposes mutates metadata', str_contains( $registry, "'mutates'" ) );
 $assert( 'TaskRegistry exposes requires_scope metadata', str_contains( $registry, "'requires_scope'" ) );
 $assert( 'TaskScheduler passes system job source to execute-workflow', str_contains( $scheduler, "'job_source'    => 'system'" ) );
+$assert( 'TaskScheduler records rejection details for callers', str_contains( $scheduler, 'recordScheduleError' ) && str_contains( $scheduler, 'getLastScheduleError' ) );
 $assert( 'execute-workflow honors caller job source', str_contains( $workflow_ability, "'source'      => $" . 'job_source' ) );
 
 echo "\nAssertions: {$total}, Failures: {$failures}\n";


### PR DESCRIPTION
## Summary
- Preserve `TaskScheduler::schedule()`'s existing `int|false` API while recording the latest scheduler failure details in-request.
- Return those scheduler error codes/messages from `system run` instead of the generic fallback when scheduling rejects a task.
- Add focused smoke coverage for scheduler rejection details in run responses.

Closes #2645

## Verification
- `php -l inc/Abilities/SystemAbilities.php && php -l inc/Engine/Tasks/TaskScheduler.php && php -l tests/system-run-task-params-smoke.php`
- `php tests/system-run-task-params-smoke.php`
- `php tests/system-task-agent-context-smoke.php`
- `composer run lint` blocked locally: `phpcs` is not installed on PATH and no `vendor/bin/phpcs` exists in this worktree.
- `composer run test` blocked before tests start by Homeboy extension metadata: local `wordpress` extension has no sourceUrl/.source-url metadata.
- `homeboy lint data-machine --changed-only --summary --force-hot` passes PHPCS for changed files but fails PHPStan on existing file-scoped findings in unrelated `SystemAbilities.php` lines 286, 311, 827, 856, and 876.