### PR TITLE
test: add namespaced WP-fn stubs so smokes resolve unqualified core calls (#2643)

### DIFF
--- a/tests/bfb-substrate-bundle-smoke.php
+++ b/tests/bfb-substrate-bundle-smoke.php
@@ -201,41 +201,77 @@ foreach ( $h2bc_globals as $class_name ) {
 	assert_bfb_bundle( "global-{$class_name}-not-created", ! class_exists( $class_name, false ) );
 }
 
-$registered_actions = $GLOBALS['__bfb_bundle_actions'];
-/** @var array<int, array{hook:string, callback:mixed}> $registered_actions */
-foreach ( $registered_actions as $action ) {
-	if ( 'wp_abilities_api_categories_init' === $action['hook'] && is_callable( $action['callback'] ) ) {
-		call_user_func( $action['callback'] );
-	}
-}
-
-$registered_actions = $GLOBALS['__bfb_bundle_actions'];
-/** @var array<int, array{hook:string, callback:mixed}> $registered_actions */
-foreach ( $registered_actions as $action ) {
-	if ( 'wp_abilities_api_init' === $action['hook'] && is_callable( $action['callback'] ) ) {
-		call_user_func( $action['callback'] );
-	}
-}
-
-$registered_ability_categories = $GLOBALS['__bfb_bundle_ability_categories'];
-$registered_abilities          = $GLOBALS['__bfb_bundle_abilities'];
-/** @var array<string, array<string, mixed>> $registered_ability_categories */
-/** @var array<string, array<string, mixed>> $registered_abilities */
-
-assert_bfb_bundle( 'bfb-ability-category-registered', isset( $registered_ability_categories['block-format-bridge'] ) );
-
 $bfb_ability_names = array(
 	'block-format-bridge/get-capabilities',
 	'block-format-bridge/convert',
 	'block-format-bridge/normalize',
 );
 
-foreach ( $bfb_ability_names as $ability_name ) {
-	assert_bfb_bundle( "{$ability_name}-registered", isset( $registered_abilities[ $ability_name ] ) );
-	assert_bfb_bundle(
-		"{$ability_name}-has-category",
-		'block-format-bridge' === ( $registered_abilities[ $ability_name ]['category'] ?? null )
-	);
+/*
+ * The ability-registration assertions below check that loading the bundled BFB
+ * substrate registers the `block-format-bridge` ability category and abilities.
+ *
+ * This smoke supports two execution contexts:
+ *
+ *  - Pure-PHP (standalone `php tests/...`): WordPress is not loaded, so the smoke
+ *    provides global recording stubs for `add_action` / `wp_register_ability*`
+ *    that capture registrations into `$GLOBALS` arrays. We fire the bundle's
+ *    registration callbacks by hand and assert against those recorders.
+ *
+ *  - Real WordPress (wp-codebox CI harness): WP core defines the abilities API and
+ *    fires `wp_abilities_api_*_init` during normal init, so the BFB bundle has
+ *    already registered into WP's real registry before this smoke runs. The
+ *    pure-PHP recorders are never populated (registrations go through core), so we
+ *    assert against the real registry instead.
+ *
+ * `wp_get_ability_category()` is a real WP-core abilities-API function that this
+ * smoke does not stub, so its presence is a reliable "running under real WP"
+ * marker.
+ */
+$is_real_wp = function_exists( 'wp_get_ability_category' );
+
+if ( $is_real_wp ) {
+	assert_bfb_bundle( 'bfb-ability-category-registered', wp_has_ability_category( 'block-format-bridge' ) );
+
+	foreach ( $bfb_ability_names as $ability_name ) {
+		$ability = wp_get_ability( $ability_name );
+		assert_bfb_bundle( "{$ability_name}-registered", null !== $ability );
+		assert_bfb_bundle(
+			"{$ability_name}-has-category",
+			null !== $ability && 'block-format-bridge' === $ability->get_category()
+		);
+	}
+} else {
+	$registered_actions = $GLOBALS['__bfb_bundle_actions'];
+	/** @var array<int, array{hook:string, callback:mixed}> $registered_actions */
+	foreach ( $registered_actions as $action ) {
+		if ( 'wp_abilities_api_categories_init' === $action['hook'] && is_callable( $action['callback'] ) ) {
+			call_user_func( $action['callback'] );
+		}
+	}
+
+	$registered_actions = $GLOBALS['__bfb_bundle_actions'];
+	/** @var array<int, array{hook:string, callback:mixed}> $registered_actions */
+	foreach ( $registered_actions as $action ) {
+		if ( 'wp_abilities_api_init' === $action['hook'] && is_callable( $action['callback'] ) ) {
+			call_user_func( $action['callback'] );
+		}
+	}
+
+	$registered_ability_categories = $GLOBALS['__bfb_bundle_ability_categories'];
+	$registered_abilities          = $GLOBALS['__bfb_bundle_abilities'];
+	/** @var array<string, array<string, mixed>> $registered_ability_categories */
+	/** @var array<string, array<string, mixed>> $registered_abilities */
+
+	assert_bfb_bundle( 'bfb-ability-category-registered', isset( $registered_ability_categories['block-format-bridge'] ) );
+
+	foreach ( $bfb_ability_names as $ability_name ) {
+		assert_bfb_bundle( "{$ability_name}-registered", isset( $registered_abilities[ $ability_name ] ) );
+		assert_bfb_bundle(
+			"{$ability_name}-has-category",
+			'block-format-bridge' === ( $registered_abilities[ $ability_name ]['category'] ?? null )
+		);
+	}
 }
 
 echo "\nBFB substrate bundle smoke: {$total} assertions, {$failed} failures.\n";

--- a/tests/bfb-substrate-bundle-smoke.php
+++ b/tests/bfb-substrate-bundle-smoke.php
@@ -15,6 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+require_once __DIR__ . '/fixtures/namespaced-wp-fn-stubs.php';
+
 $failed = 0;
 $total  = 0;
 

--- a/tests/duplicate-tool-call-mode-aware-smoke.php
+++ b/tests/duplicate-tool-call-mode-aware-smoke.php
@@ -13,6 +13,7 @@
  * @package DataMachine\Tests
  */
 
+require_once __DIR__ . '/fixtures/namespaced-wp-fn-stubs.php';
 require_once __DIR__ . '/bootstrap-unit.php';
 
 use AgentsAPI\AI\WP_Agent_Message;

--- a/tests/fixtures/namespaced-wp-fn-stubs.php
+++ b/tests/fixtures/namespaced-wp-fn-stubs.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * Namespaced polyfills for pure-PHP smokes.
+ *
+ * When production (or bundled vendor) code inside a namespace calls a WordPress
+ * core function unqualified — e.g. `wp_json_encode( ... )` inside
+ * `namespace DataMachine\Engine\AI`, or `wp_has_ability_category( ... )` inside
+ * `namespace AgentsAPI\AI\Auth` — PHP resolves the call to the CURRENT namespace
+ * first and only falls back to the global function for INTERNAL functions. A
+ * user-defined global stub is not an internal function, so there is no fallback
+ * and the call fatals under a pure-PHP (no-WordPress) smoke run. Real WordPress
+ * avoids this because its core functions are global and internal-like, so the
+ * namespaced lookup falls through to them.
+ *
+ * Defining the stub inside the SAME namespace as the call site makes the
+ * unqualified call resolve here. Each stub is function_exists-guarded so it stays
+ * inert under the real-WordPress CI smoke harness (where WP core already defines
+ * the global function), and the ability helpers delegate to the global smoke
+ * stubs so registrations still flow into whatever tracking globals a smoke sets.
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Engine\AI {
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_json_encode' ) ) {
+		function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+			return json_encode( $data, $options, $depth );
+		}
+	}
+}
+
+// The Agents API registers ability categories and abilities from callbacks that
+// live in this namespace and call the helpers unqualified.
+namespace AgentsAPI\AI\Auth {
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability_category' ) ) {
+		function wp_has_ability_category( string $slug ): bool {
+			return function_exists( '\\wp_has_ability_category' ) ? \wp_has_ability_category( $slug ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability' ) ) {
+		function wp_has_ability( string $name ): bool {
+			return function_exists( '\\wp_has_ability' ) ? \wp_has_ability( $name ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability_category' ) ) {
+		function wp_register_ability_category( string $slug, array $args ): void {
+			if ( function_exists( '\\wp_register_ability_category' ) ) {
+				\wp_register_ability_category( $slug, $args );
+			}
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability' ) ) {
+		function wp_register_ability( string $name, array $args ): void {
+			if ( function_exists( '\\wp_register_ability' ) ) {
+				\wp_register_ability( $name, $args );
+			}
+		}
+	}
+}
+
+// The Agents API registers ability categories and abilities from callbacks that
+// live in this namespace and call the helpers unqualified.
+namespace AgentsAPI\AI\Approvals {
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability_category' ) ) {
+		function wp_has_ability_category( string $slug ): bool {
+			return function_exists( '\\wp_has_ability_category' ) ? \wp_has_ability_category( $slug ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability' ) ) {
+		function wp_has_ability( string $name ): bool {
+			return function_exists( '\\wp_has_ability' ) ? \wp_has_ability( $name ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability_category' ) ) {
+		function wp_register_ability_category( string $slug, array $args ): void {
+			if ( function_exists( '\\wp_register_ability_category' ) ) {
+				\wp_register_ability_category( $slug, $args );
+			}
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability' ) ) {
+		function wp_register_ability( string $name, array $args ): void {
+			if ( function_exists( '\\wp_register_ability' ) ) {
+				\wp_register_ability( $name, $args );
+			}
+		}
+	}
+}
+
+// The Agents API registers ability categories and abilities from callbacks that
+// live in this namespace and call the helpers unqualified.
+namespace AgentsAPI\AI\Channels {
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability_category' ) ) {
+		function wp_has_ability_category( string $slug ): bool {
+			return function_exists( '\\wp_has_ability_category' ) ? \wp_has_ability_category( $slug ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability' ) ) {
+		function wp_has_ability( string $name ): bool {
+			return function_exists( '\\wp_has_ability' ) ? \wp_has_ability( $name ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability_category' ) ) {
+		function wp_register_ability_category( string $slug, array $args ): void {
+			if ( function_exists( '\\wp_register_ability_category' ) ) {
+				\wp_register_ability_category( $slug, $args );
+			}
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability' ) ) {
+		function wp_register_ability( string $name, array $args ): void {
+			if ( function_exists( '\\wp_register_ability' ) ) {
+				\wp_register_ability( $name, $args );
+			}
+		}
+	}
+}
+
+// The Agents API registers ability categories and abilities from callbacks that
+// live in this namespace and call the helpers unqualified.
+namespace AgentsAPI\AI\Tasks {
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability_category' ) ) {
+		function wp_has_ability_category( string $slug ): bool {
+			return function_exists( '\\wp_has_ability_category' ) ? \wp_has_ability_category( $slug ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability' ) ) {
+		function wp_has_ability( string $name ): bool {
+			return function_exists( '\\wp_has_ability' ) ? \wp_has_ability( $name ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability_category' ) ) {
+		function wp_register_ability_category( string $slug, array $args ): void {
+			if ( function_exists( '\\wp_register_ability_category' ) ) {
+				\wp_register_ability_category( $slug, $args );
+			}
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability' ) ) {
+		function wp_register_ability( string $name, array $args ): void {
+			if ( function_exists( '\\wp_register_ability' ) ) {
+				\wp_register_ability( $name, $args );
+			}
+		}
+	}
+}
+
+// The Agents API registers ability categories and abilities from callbacks that
+// live in this namespace and call the helpers unqualified.
+namespace AgentsAPI\AI\Tools {
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability_category' ) ) {
+		function wp_has_ability_category( string $slug ): bool {
+			return function_exists( '\\wp_has_ability_category' ) ? \wp_has_ability_category( $slug ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability' ) ) {
+		function wp_has_ability( string $name ): bool {
+			return function_exists( '\\wp_has_ability' ) ? \wp_has_ability( $name ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability_category' ) ) {
+		function wp_register_ability_category( string $slug, array $args ): void {
+			if ( function_exists( '\\wp_register_ability_category' ) ) {
+				\wp_register_ability_category( $slug, $args );
+			}
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability' ) ) {
+		function wp_register_ability( string $name, array $args ): void {
+			if ( function_exists( '\\wp_register_ability' ) ) {
+				\wp_register_ability( $name, $args );
+			}
+		}
+	}
+}
+
+// The Agents API registers ability categories and abilities from callbacks that
+// live in this namespace and call the helpers unqualified.
+namespace AgentsAPI\AI\Workflows {
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability_category' ) ) {
+		function wp_has_ability_category( string $slug ): bool {
+			return function_exists( '\\wp_has_ability_category' ) ? \wp_has_ability_category( $slug ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability' ) ) {
+		function wp_has_ability( string $name ): bool {
+			return function_exists( '\\wp_has_ability' ) ? \wp_has_ability( $name ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability_category' ) ) {
+		function wp_register_ability_category( string $slug, array $args ): void {
+			if ( function_exists( '\\wp_register_ability_category' ) ) {
+				\wp_register_ability_category( $slug, $args );
+			}
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability' ) ) {
+		function wp_register_ability( string $name, array $args ): void {
+			if ( function_exists( '\\wp_register_ability' ) ) {
+				\wp_register_ability( $name, $args );
+			}
+		}
+	}
+}
+
+// The Agents API registers ability categories and abilities from callbacks that
+// live in this namespace and call the helpers unqualified.
+namespace AgentsAPI\Core\Database\Chat {
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability_category' ) ) {
+		function wp_has_ability_category( string $slug ): bool {
+			return function_exists( '\\wp_has_ability_category' ) ? \wp_has_ability_category( $slug ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability' ) ) {
+		function wp_has_ability( string $name ): bool {
+			return function_exists( '\\wp_has_ability' ) ? \wp_has_ability( $name ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability_category' ) ) {
+		function wp_register_ability_category( string $slug, array $args ): void {
+			if ( function_exists( '\\wp_register_ability_category' ) ) {
+				\wp_register_ability_category( $slug, $args );
+			}
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability' ) ) {
+		function wp_register_ability( string $name, array $args ): void {
+			if ( function_exists( '\\wp_register_ability' ) ) {
+				\wp_register_ability( $name, $args );
+			}
+		}
+	}
+}
+
+// The Agents API registers ability categories and abilities from callbacks that
+// live in this namespace and call the helpers unqualified.
+namespace AgentsAPI\Core\Workspace {
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability_category' ) ) {
+		function wp_has_ability_category( string $slug ): bool {
+			return function_exists( '\\wp_has_ability_category' ) ? \wp_has_ability_category( $slug ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_has_ability' ) ) {
+		function wp_has_ability( string $name ): bool {
+			return function_exists( '\\wp_has_ability' ) ? \wp_has_ability( $name ) : false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability_category' ) ) {
+		function wp_register_ability_category( string $slug, array $args ): void {
+			if ( function_exists( '\\wp_register_ability_category' ) ) {
+				\wp_register_ability_category( $slug, $args );
+			}
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_register_ability' ) ) {
+		function wp_register_ability( string $name, array $args ): void {
+			if ( function_exists( '\\wp_register_ability' ) ) {
+				\wp_register_ability( $name, $args );
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #2647 (merged). After the redeclare-guard sweep landed, **2 smokes still fataled standalone with `undefined function`** — a different failure mode than the redeclares. This adds namespaced polyfills so those calls resolve.

### Why these are different from the redeclare guards

Production/vendor code calls WP core functions **unqualified from inside a namespace**:
- `wp_json_encode( ... )` inside `namespace DataMachine\Engine\AI` (`ConversationManager`)
- `wp_has_ability_category( ... )` / `wp_register_ability( ... )` etc. inside the `AgentsAPI\*` namespaces that register abilities from `wp_abilities_api_*_init` callbacks

PHP resolves an unqualified call to the **current namespace first** and only falls back to the global function for **internal** functions. A user-defined *global* stub is not internal, so there is no fallback — it fatals under a pure-PHP smoke. Real WordPress is fine because its core functions are global and internal-like, so the namespaced lookup falls through to them. The global guarded stubs from #2647 are therefore invisible to these calls.

## Fix

- New `tests/fixtures/namespaced-wp-fn-stubs.php` defines guarded stubs **in the same namespace as each call site**:
  - `wp_json_encode` in `DataMachine\Engine\AI`
  - `wp_has_ability_category`, `wp_has_ability`, `wp_register_ability_category`, `wp_register_ability` in every `AgentsAPI` namespace that registers categories/abilities from `wp_abilities_api_*_init` callbacks (`Auth`, `Approvals`, `Channels`, `Tasks`, `Tools`, `Workflows`, `Core\Database\Chat`, `Core\Workspace`).
  - The ability stubs **delegate to the global smoke stubs** so registrations still flow into each smoke's tracking globals; every stub is `function_exists`-guarded so it stays inert under the real-WordPress CI harness.
- Require the fixture before the autoload / callback-invocation in `duplicate-tool-call-mode-aware-smoke.php` and `bfb-substrate-bundle-smoke.php`.

## Verification

- `duplicate-tool-call-mode-aware-smoke.php`: **exit 0** (14 assertions) ✔
- `bfb-substrate-bundle-smoke.php`: **exit 0** (22 assertions) ✔
- **Zero `Cannot redeclare` / `undefined function` fatals remain across `tests/*-smoke.php`** (verified: `for f in tests/*-smoke.php; do php "$f" 2>&1 | grep -qiE "Cannot redeclare|undefined function" && echo "$f"; done` prints nothing). ✔
- `php -l` clean on all 3 changed files.

## Out of scope (pre-existing, unrelated)

The ~25 remaining standalone failures are **pre-existing product-behavior/assertion failures on `origin/main`** (verified to fail identically on unmodified main) — refactor-drift `str_contains()` assertions, missing-class autoload ordering (resolves under real WP where the plugin is loaded), and env issues. **None are redeclare/undefined-function fatals.** They need product/refactor judgment and are not addressed here.

Conventional commit. CHANGELOG / version untouched (homeboy owns both).