### PR TITLE
test: register adjacent handler smoke fixture in WordPress

### DIFF
--- a/tests/adjacent-handler-tool-policy-smoke.php
+++ b/tests/adjacent-handler-tool-policy-smoke.php
@@ -22,20 +22,28 @@ namespace {
 		function do_action( string $_hook, ...$_args ): void {}
 	}
 
-	if ( ! function_exists( 'apply_filters' ) ) {
+	$datamachine_step_types = static function ( $value ) {
+		return array(
+			'ai'           => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'system_task'  => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'webhook_gate' => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'fetch'        => array( 'uses_handler' => true, 'multi_handler' => false ),
+			'publish'      => array( 'uses_handler' => true, 'multi_handler' => true ),
+			'upsert'       => array( 'uses_handler' => true, 'multi_handler' => true ),
+		);
+	};
+
+	if ( function_exists( 'add_filter' ) ) {
+		add_filter( 'datamachine_step_types', $datamachine_step_types );
+	} elseif ( ! function_exists( 'apply_filters' ) ) {
+		$GLOBALS['datamachine_step_types_filter'] = $datamachine_step_types;
+
 		function apply_filters( string $hook, $value ) {
 			if ( 'datamachine_step_types' !== $hook ) {
 				return $value;
 			}
 
-			return array(
-				'ai'           => array( 'uses_handler' => false, 'multi_handler' => false ),
-				'system_task'  => array( 'uses_handler' => false, 'multi_handler' => false ),
-				'webhook_gate' => array( 'uses_handler' => false, 'multi_handler' => false ),
-				'fetch'        => array( 'uses_handler' => true, 'multi_handler' => false ),
-				'publish'      => array( 'uses_handler' => true, 'multi_handler' => true ),
-				'upsert'       => array( 'uses_handler' => true, 'multi_handler' => true ),
-			);
+			return $GLOBALS['datamachine_step_types_filter']( $value );
 		}
 	}
 

--- a/tests/agent-bundle-artifact-rebase-smoke.php
+++ b/tests/agent-bundle-artifact-rebase-smoke.php
@@ -24,6 +24,14 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 	}
 }
 
+if ( ! class_exists( 'WP_Agent_Package_Artifact_Hasher' ) ) {
+	class WP_Agent_Package_Artifact_Hasher {
+		public static function hash( $artifact ): string {
+			return hash( 'sha256', (string) wp_json_encode( $artifact, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+		}
+	}
+}
+
 // Use direct requires (not the composer autoloader) to avoid pulling in
 // vendor packages that need a full WordPress environment to bootstrap.
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSchema.php';


### PR DESCRIPTION
## Summary
- Preserve standalone smoke-test filter stubs.
- Register the same `datamachine_step_types` fixture with `add_filter()` when the smoke runs inside a real WordPress harness.
- Avoid relying on redeclared hook stubs when WordPress has already loaded core hook functions.

This unblocks PR checks currently failing with `Cannot redeclare do_action()` / real-WordPress smoke harness behavior around `tests/adjacent-handler-tool-policy-smoke.php`.

## Verification
- `php -l tests/adjacent-handler-tool-policy-smoke.php`

Standalone execution in this fresh `--skip-bootstrap` worktree is blocked by missing `vendor/wordpress/agents-api` dependencies.