### PR TITLE
Fix runtime ability tools for agent bundle runs

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -1641,6 +1641,10 @@ class AgentAbilities {
 					'type'        => 'object',
 					'description' => 'Runtime-scoped Data Machine tool definitions merged through datamachine_resolved_tools only for this run.',
 				),
+				'ability_tools'       => array(
+					'type'        => array( 'object', 'array' ),
+					'description' => 'Runtime-scoped generic ability-backed tools. Accepts a keyed map or list entries with name and ability, e.g. [{"name":"my_tool","ability":"plugin/ability"}].',
+				),
 				'tools'               => array(
 					'type'        => array( 'object', 'array' ),
 					'description' => 'Alias for runtime_tools; accepts keyed tool definitions or a list with name/tool fields.',

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -380,6 +380,7 @@ class AIStep extends Step {
 					'next_step_config'     => $next_step_config,
 					'pipeline_step_id'     => $pipeline_step_id,
 					'engine_data'          => $engine_data,
+					'ability_tools'        => is_array( $job_snapshot['ability_tools'] ?? null ) ? $job_snapshot['ability_tools'] : array(),
 					'categories'           => $tool_categories,
 				),
 				PipelineToolPolicyArgs::fromConfigs( $this->flow_step_config, $pipeline_step_config )

--- a/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
+++ b/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
@@ -77,7 +77,8 @@ final class AbilityToolSource {
 			return array();
 		}
 
-		$declared = apply_filters( 'datamachine_ability_tool_projections', array(), $args );
+		$declared = $this->declarationsFromContext( $args );
+		$declared = apply_filters( 'datamachine_ability_tool_projections', $declared, $args );
 		$declared = apply_filters( 'datamachine_ability_tools', $declared, $args );
 		if ( ! is_array( $declared ) ) {
 			return array();
@@ -112,6 +113,51 @@ final class AbilityToolSource {
 		}
 
 		return $tools;
+	}
+
+	/**
+	 * Extract run-scoped ability tool declarations from resolver context.
+	 *
+	 * Accepts keyed maps and list entries with a `name` field:
+	 *
+	 *     array( 'my_tool' => array( 'ability' => 'plugin/ability' ) )
+	 *     array( array( 'name' => 'my_tool', 'ability' => 'plugin/ability' ) )
+	 *
+	 * @param array $args Full resolution arguments.
+	 * @return array<string,array<string,mixed>> Declarations keyed by model-facing tool name.
+	 */
+	private function declarationsFromContext( array $args ): array {
+		$sets = array( $args['ability_tools'] ?? null );
+
+		$engine_data = is_array( $args['engine_data'] ?? null ) ? $args['engine_data'] : array();
+		$job_snapshot = is_array( $engine_data['job'] ?? null ) ? $engine_data['job'] : array();
+		$sets[] = $job_snapshot['ability_tools'] ?? null;
+
+		$client_context = is_array( $args['client_context'] ?? null ) ? $args['client_context'] : array();
+		$sets[] = $client_context['ability_tools'] ?? null;
+
+		$declared = array();
+		foreach ( $sets as $set ) {
+			if ( ! is_array( $set ) ) {
+				continue;
+			}
+
+			foreach ( $set as $name => $declaration ) {
+				if ( ! is_array( $declaration ) ) {
+					continue;
+				}
+
+				$tool_name = is_string( $name ) && '' !== $name ? $name : (string) ( $declaration['name'] ?? '' );
+				if ( '' === $tool_name ) {
+					continue;
+				}
+
+				unset( $declaration['name'] );
+				$declared[ $tool_name ] = $declaration;
+			}
+		}
+
+		return $declared;
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -79,7 +79,7 @@ final class AgentBundleRunner {
 		$initial_data['agent_slug']   = (string) ( $manifest['agent']['slug'] ?? '' );
 		$initial_data['job_source']   = (string) ( $input['job_source'] ?? 'agent_bundle' );
 		$initial_data['job_label']    = (string) ( $input['job_label'] ?? ( $selection['flow_name'] ?? 'Agent Bundle Workflow' ) );
-		$this->apply_runtime_ability_tools( $initial_data, $input );
+		$this->apply_runtime_ability_tools( $initial_data, $input, $bundle );
 		$this->apply_runtime_model_config( $initial_data, $input );
 
 		if ( ! empty( $input['dry_run'] ) ) {
@@ -199,9 +199,14 @@ final class AgentBundleRunner {
 	 *
 	 * @param array<string,mixed> $initial_data Initial workflow engine data.
 	 * @param array<string,mixed> $input Bundle run input.
+	 * @param array<string,mixed> $bundle Loaded bundle document.
 	 */
-	private function apply_runtime_ability_tools( array &$initial_data, array $input ): void {
+	private function apply_runtime_ability_tools( array &$initial_data, array $input, array $bundle = array() ): void {
 		$ability_tools = is_array( $input['ability_tools'] ?? null ) ? $input['ability_tools'] : array();
+		if ( empty( $ability_tools ) ) {
+			$metadata_tools = $this->path_value( $bundle, 'metadata.codebox.agent_runtime.bundle.ability_tools' );
+			$ability_tools  = is_array( $metadata_tools ) ? $metadata_tools : array();
+		}
 		if ( empty( $ability_tools ) ) {
 			return;
 		}

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -79,6 +79,7 @@ final class AgentBundleRunner {
 		$initial_data['agent_slug']   = (string) ( $manifest['agent']['slug'] ?? '' );
 		$initial_data['job_source']   = (string) ( $input['job_source'] ?? 'agent_bundle' );
 		$initial_data['job_label']    = (string) ( $input['job_label'] ?? ( $selection['flow_name'] ?? 'Agent Bundle Workflow' ) );
+		$this->apply_runtime_ability_tools( $initial_data, $input );
 		$this->apply_runtime_model_config( $initial_data, $input );
 
 		if ( ! empty( $input['dry_run'] ) ) {
@@ -191,6 +192,23 @@ final class AgentBundleRunner {
 		$initial_data['job']                      = $job_snapshot;
 		$initial_data['agent_bundle']['provider'] = $provider;
 		$initial_data['agent_bundle']['model']    = $model;
+	}
+
+	/**
+	 * Project run-scoped ability tool declarations into the job snapshot.
+	 *
+	 * @param array<string,mixed> $initial_data Initial workflow engine data.
+	 * @param array<string,mixed> $input Bundle run input.
+	 */
+	private function apply_runtime_ability_tools( array &$initial_data, array $input ): void {
+		$ability_tools = is_array( $input['ability_tools'] ?? null ) ? $input['ability_tools'] : array();
+		if ( empty( $ability_tools ) ) {
+			return;
+		}
+
+		$job_snapshot                  = is_array( $initial_data['job'] ?? null ) ? $initial_data['job'] : array();
+		$job_snapshot['ability_tools'] = $ability_tools;
+		$initial_data['job']           = $job_snapshot;
 	}
 
 	private function status_from_response( array $response ): string {

--- a/tests/ability-tool-source-smoke.php
+++ b/tests/ability-tool-source-smoke.php
@@ -410,6 +410,40 @@ $resolved = resolve_ability_source_tools( 'pipeline', array( 'allow_only' => arr
 assert_ability_tool_source_equals( array( 'collision_tool', 'summarize_demo' ), array_keys( $resolved ), 'static registry wins generated ability tool name collisions', $failures, $passes );
 assert_ability_tool_source_equals( 'static', $resolved['collision_tool']['origin'] ?? '', 'collision preserves static declaration', $failures, $passes );
 
+$runtime_declared = resolve_ability_source_tools(
+	'pipeline',
+	array(
+		'ability_tools' => array(
+			array(
+				'name'    => 'runtime_summarize_demo',
+				'ability' => 'demo/summarize',
+				'modes'   => array( 'pipeline' ),
+			),
+		),
+		'allow_only'    => array( 'runtime_summarize_demo' ),
+	)
+);
+assert_ability_tool_source_equals( true, isset( $runtime_declared['runtime_summarize_demo'] ), 'resolver context ability_tools list exposes runtime ability tool', $failures, $passes );
+assert_ability_tool_source_equals( 'demo/summarize', $runtime_declared['runtime_summarize_demo']['execution_ability'] ?? '', 'runtime ability tool keeps direct execution marker', $failures, $passes );
+
+$job_declared = resolve_ability_source_tools(
+	'pipeline',
+	array(
+		'engine_data' => array(
+			'job' => array(
+				'ability_tools' => array(
+					'job_summarize_demo' => array(
+						'ability' => 'demo/summarize',
+						'modes'   => array( 'pipeline' ),
+					),
+				),
+			),
+		),
+		'allow_only'  => array( 'job_summarize_demo' ),
+	)
+);
+assert_ability_tool_source_equals( true, isset( $job_declared['job_summarize_demo'] ), 'job snapshot ability_tools map exposes runtime ability tool', $failures, $passes );
+
 echo "\n[4] generated declaration executes through ability-native ToolExecutionCore:\n";
 $result = ToolExecutor::executeTool(
 	'summarize_demo',

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -398,6 +398,7 @@ foreach ( array(
 	"'ability_tools'       => array("                                           => 'run-agent-bundle schema accepts runtime ability tools',
 	'apply_runtime_model_config'                                              => 'runner projects provider/model into initial data',
 	'apply_runtime_ability_tools'                                             => 'runner projects ability tools into initial data',
+	'metadata.codebox.agent_runtime.bundle.ability_tools'                     => 'runner consumes bundle metadata ability tools fallback',
 	"\$job_snapshot['ability_tools']"                                         => 'runner stamps job-scoped ability tool declarations',
 	"\$job_snapshot['default_provider']"                                      => 'runner stamps job-scoped default provider',
 	"\$job_snapshot['default_model']"                                         => 'runner stamps job-scoped default model',

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -395,10 +395,14 @@ echo "\n[5] Runner supports run-scoped provider/model config\n";
 foreach ( array(
 	"'provider'            => array("                                           => 'run-agent-bundle schema accepts provider',
 	"'model'               => array("                                           => 'run-agent-bundle schema accepts model',
+	"'ability_tools'       => array("                                           => 'run-agent-bundle schema accepts runtime ability tools',
 	'apply_runtime_model_config'                                              => 'runner projects provider/model into initial data',
+	'apply_runtime_ability_tools'                                             => 'runner projects ability tools into initial data',
+	"\$job_snapshot['ability_tools']"                                         => 'runner stamps job-scoped ability tool declarations',
 	"\$job_snapshot['default_provider']"                                      => 'runner stamps job-scoped default provider',
 	"\$job_snapshot['default_model']"                                         => 'runner stamps job-scoped default model',
 	"\$mode_models['pipeline']"                                               => 'runner stamps pipeline mode model config',
+	"'ability_tools'        => is_array( \$job_snapshot['ability_tools'] ?? null )" => 'AI step passes job-scoped ability tools to resolver',
 	'resolveModelFromJobSnapshot'                                             => 'AI step reads run-scoped model config',
 	'resolveModelForExecutionModes( $agent_id, $execution_modes, $job_snapshot )' => 'AI validation uses job-scoped model config',
 ) as $needle => $label ) {


### PR DESCRIPTION
## Summary
- add a generic `ability_tools` input to `datamachine/run-agent-bundle`
- persist run-scoped ability tool declarations into the job snapshot
- feed those declarations into `AbilityToolSource` during AI tool resolution from direct resolver args, job engine data, or client context
- support both keyed maps and list entries like `[{"name":"wpsg_materialize_packet","ability":"wp-site-generator/materialize-packet"}]`

Fixes #2653.

## Verification
- `php tests/ability-tool-source-smoke.php`
- `php tests/agent-bundle-runner-contract-smoke.php`
- `php -l inc/Engine/AI/Tools/Sources/AbilityToolSource.php && php -l inc/Engine/Bundle/AgentBundleRunner.php && php -l inc/Core/Steps/AI/AIStep.php && php -l inc/Abilities/AgentAbilities.php`