### PR TITLE
fix: cook stale main issue backlog

### DIFF
--- a/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
+++ b/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
@@ -170,6 +170,7 @@ class QueryWordPressPostsAbility {
 		);
 
 		if ( ! empty( $tax_query ) ) {
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Fetch configurations intentionally support taxonomy filters.
 			$query_args['tax_query'] = $tax_query;
 		}
 

--- a/inc/Api/AgentBundles.php
+++ b/inc/Api/AgentBundles.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * REST wrappers for agent bundle lifecycle abilities.
+ *
+ * @package DataMachine\Api
+ */
+
+namespace DataMachine\Api;
+
+use DataMachine\Abilities\AgentAbilities;
+use DataMachine\Abilities\PermissionHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+add_action(
+	'rest_api_init',
+	static function (): void {
+		register_rest_route(
+			'datamachine/v1',
+			'/agent-bundles',
+			array(
+				'methods'             => 'GET',
+				'callback'            => static fn(): array => AgentAbilities::listAgentBundles(),
+				'permission_callback' => static fn(): bool => PermissionHelper::can_manage(),
+			)
+		);
+
+		register_rest_route(
+			'datamachine/v1',
+			'/agent-bundles/(?P<slug>[a-zA-Z0-9_\-]+)',
+			array(
+				'methods'             => 'GET',
+				'callback'            => static fn( \WP_REST_Request $request ): array => AgentAbilities::getAgentBundleStatus(
+					array( 'slug' => (string) $request['slug'] )
+				),
+				'permission_callback' => static fn(): bool => PermissionHelper::can_manage(),
+			)
+		);
+
+		$routes = array(
+			'/agent-bundles/inspect' => array( AgentAbilities::class, 'inspectAgentBundle' ),
+			'/agent-bundles/validate' => array( AgentAbilities::class, 'validateAgentBundle' ),
+			'/agent-bundles/plan'    => array( AgentAbilities::class, 'planAgentBundleUpgrade' ),
+			'/agent-bundles/rebase'  => array( AgentAbilities::class, 'rebaseAgentBundleArtifacts' ),
+			'/agent-bundles/upgrade' => array( AgentAbilities::class, 'applyAgentBundleUpgrade' ),
+		);
+
+		foreach ( $routes as $route => $callback ) {
+			register_rest_route(
+				'datamachine/v1',
+				$route,
+				array(
+					'methods'             => 'POST',
+					'callback'            => static fn( \WP_REST_Request $request ): array => call_user_func( $callback, $request->get_json_params() ?: array() ),
+					'permission_callback' => static fn(): bool => PermissionHelper::can_manage(),
+				)
+			);
+		}
+	}
+);

--- a/inc/Api/Chat/Tools/MergeTaxonomyTerms.php
+++ b/inc/Api/Chat/Tools/MergeTaxonomyTerms.php
@@ -131,22 +131,15 @@ class MergeTaxonomyTerms extends BaseTool {
 			);
 		}
 
-		// Get all posts with source term
-		$posts = get_posts(
-			array(
-				'post_type'      => 'any',
-				'post_status'    => 'any',
-				'tax_query'      => array(
-					array(
-						'taxonomy' => $taxonomy,
-						'field'    => 'term_id',
-						'terms'    => $source_term->term_id,
-					),
-				),
-				'posts_per_page' => -1,
-				'fields'         => 'ids',
-			)
-		);
+		$posts = get_objects_in_term( $source_term->term_id, $taxonomy );
+		if ( is_wp_error( $posts ) ) {
+			return array(
+				'success'   => false,
+				'error'     => $posts->get_error_message(),
+				'tool_name' => 'merge_taxonomy_terms',
+			);
+		}
+		$posts = array_values( array_filter( array_map( 'absint', (array) $posts ) ) );
 
 		$posts_reassigned = 0;
 

--- a/inc/Cli/Commands/ProcessedItemsCommand.php
+++ b/inc/Cli/Commands/ProcessedItemsCommand.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- This CLI command reports and repairs Data Machine custom-table state; fresh reads are required.
 /**
  * WP-CLI Processed Items Command
  *

--- a/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
@@ -25,6 +25,7 @@ import AgentFileEditor from './components/AgentFileEditor';
 import AgentEmptyState from './components/AgentEmptyState';
 import AgentSettings from './components/AgentSettings';
 import AgentToolsTab from './components/AgentToolsTab';
+import AgentBundlesTab from './components/AgentBundlesTab';
 import AgentEditView from './components/AgentEditView';
 import SystemTasksTab from './components/SystemTasksTab';
 import { useAgentFiles } from './queries/agentFiles';
@@ -35,6 +36,7 @@ const TABS = [
 	{ name: 'manage', title: 'Manage' },
 	{ name: 'system-tasks', title: 'System Tasks' },
 	{ name: 'tools', title: 'Tools' },
+	{ name: 'bundles', title: 'Bundles' },
 	{ name: 'configuration', title: 'Configuration' },
 ];
 
@@ -159,6 +161,10 @@ const AgentApp = () => {
 							);
 						}
 						return <AgentToolsTab />;
+					}
+
+					if ( tab.name === 'bundles' ) {
+						return <AgentBundlesTab />;
 					}
 
 					// Configuration tab works without agent selection (global config)

--- a/inc/Core/Admin/Pages/Agent/assets/react/api/agentBundles.js
+++ b/inc/Core/Admin/Pages/Agent/assets/react/api/agentBundles.js
@@ -1,0 +1,28 @@
+/**
+ * Agent bundle lifecycle API.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { client } from '@shared/utils/api';
+
+export const fetchBundles = () => client.get( '/agent-bundles' );
+
+export const fetchBundleStatus = ( slug ) =>
+	client.get( `/agent-bundles/${ slug }` );
+
+export const planBundleUpgrade = ( data ) =>
+	client.post( '/agent-bundles/plan', data );
+
+export const rebaseBundleArtifacts = ( data ) =>
+	client.post( '/agent-bundles/rebase', data );
+
+export const applyBundleUpgrade = ( data ) =>
+	client.post( '/agent-bundles/upgrade', data );
+
+export const fetchBundlePendingActions = () =>
+	client.get( '/actions', { kind: 'bundle_upgrade', status: 'pending' } );
+
+export const resolvePendingAction = ( data ) =>
+	client.post( '/actions/resolve', data );

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentBundlesTab.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentBundlesTab.jsx
@@ -1,0 +1,276 @@
+/**
+ * Agent bundles tab.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import { Button, Notice, Spinner, TextControl } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	useAgentBundles,
+	useAgentBundleStatus,
+	useApplyBundleUpgrade,
+	useBundlePendingActions,
+	usePlanBundleUpgrade,
+	useRebaseBundleArtifacts,
+	useResolveBundlePendingAction,
+} from '../queries/agentBundles';
+
+const asArray = ( value ) => ( Array.isArray( value ) ? value : [] );
+
+const countPlanItems = ( plan ) => {
+	const counts = plan?.counts || {};
+	return {
+		autoApply: counts.auto_apply ?? asArray( plan?.auto_apply ).length,
+		needsApproval:
+			counts.needs_approval ?? asArray( plan?.needs_approval ).length,
+		warnings: counts.warnings ?? asArray( plan?.warnings ).length,
+		noOp: counts.no_op ?? asArray( plan?.no_op ).length,
+	};
+};
+
+const artifactLabel = ( artifact ) =>
+	artifact.artifact_key ||
+	artifact.source_path ||
+	[ artifact.artifact_type, artifact.artifact_id ].filter( Boolean ).join( ':' ) ||
+	__( 'Artifact', 'data-machine' );
+
+const ResultNotice = ( { result } ) => {
+	if ( ! result ) {
+		return null;
+	}
+
+	if ( result.success === false ) {
+		return (
+			<Notice status="error" isDismissible={ false }>
+				{ result.message || result.error || __( 'Request failed.', 'data-machine' ) }
+			</Notice>
+		);
+	}
+
+	return (
+		<Notice status="success" isDismissible={ false }>
+			{ result.message || __( 'Request completed.', 'data-machine' ) }
+		</Notice>
+	);
+};
+
+export default function AgentBundlesTab() {
+	const bundlesQuery = useAgentBundles();
+	const pendingActionsQuery = useBundlePendingActions();
+	const bundles = asArray( bundlesQuery.data?.bundles );
+	const [ selectedSlug, setSelectedSlug ] = useState( '' );
+	const selectedBundle = bundles.find(
+		( bundle ) => bundle.agent_slug === selectedSlug
+	);
+	const [ source, setSource ] = useState( '' );
+	const [ planResult, setPlanResult ] = useState( null );
+	const [ rebaseResult, setRebaseResult ] = useState( null );
+	const [ applyResult, setApplyResult ] = useState( null );
+
+	const statusQuery = useAgentBundleStatus( selectedSlug );
+	const planMutation = usePlanBundleUpgrade();
+	const rebaseMutation = useRebaseBundleArtifacts();
+	const applyMutation = useApplyBundleUpgrade();
+	const resolveMutation = useResolveBundlePendingAction();
+
+	useEffect( () => {
+		if ( ! selectedSlug && bundles.length > 0 ) {
+			setSelectedSlug( bundles[ 0 ].agent_slug );
+		}
+	}, [ bundles, selectedSlug ] );
+
+	useEffect( () => {
+		setSource( selectedBundle?.source_ref || '' );
+		setPlanResult( null );
+		setRebaseResult( null );
+		setApplyResult( null );
+	}, [ selectedBundle?.agent_slug, selectedBundle?.source_ref ] );
+
+	const requestInput = () => ( {
+		slug: selectedSlug,
+		source,
+	} );
+
+	const plan = planResult?.plan;
+	const planCounts = countPlanItems( plan );
+	const planRows = [
+		...asArray( plan?.auto_apply ),
+		...asArray( plan?.needs_approval ),
+		...asArray( plan?.warnings ),
+		...asArray( plan?.no_op ),
+	];
+	const artifacts = asArray( statusQuery.data?.artifacts );
+	const pendingActions = asArray( pendingActionsQuery.data?.actions );
+
+	if ( bundlesQuery.isLoading ) {
+		return <Spinner />;
+	}
+
+	if ( bundlesQuery.error ) {
+		return (
+			<Notice status="error" isDismissible={ false }>
+				{ bundlesQuery.error.message }
+			</Notice>
+		);
+	}
+
+	return (
+		<div className="datamachine-agent-bundles-tab">
+			<h2>{ __( 'Installed Bundles', 'data-machine' ) }</h2>
+			{ bundles.length === 0 ? (
+				<p>{ __( 'No installed agent bundles found.', 'data-machine' ) }</p>
+			) : (
+				<table className="widefat striped">
+					<thead>
+						<tr>
+							<th>{ __( 'Agent', 'data-machine' ) }</th>
+							<th>{ __( 'Bundle', 'data-machine' ) }</th>
+							<th>{ __( 'Version', 'data-machine' ) }</th>
+							<th>{ __( 'Artifacts', 'data-machine' ) }</th>
+							<th>{ __( 'Source', 'data-machine' ) }</th>
+						</tr>
+					</thead>
+					<tbody>
+						{ bundles.map( ( bundle ) => (
+							<tr key={ bundle.agent_slug }>
+								<td>
+									<Button
+										variant={ selectedSlug === bundle.agent_slug ? 'primary' : 'link' }
+										onClick={ () => setSelectedSlug( bundle.agent_slug ) }
+									>
+										{ bundle.agent_slug }
+									</Button>
+								</td>
+								<td>{ bundle.bundle_slug }</td>
+								<td>{ bundle.bundle_version || bundle.template_version || '-' }</td>
+								<td>{ bundle.artifacts ?? '-' }</td>
+								<td>{ bundle.source_ref || '-' }</td>
+							</tr>
+						) ) }
+					</tbody>
+				</table>
+			) }
+
+			{ selectedBundle && (
+				<div className="datamachine-agent-bundles-tab__detail">
+					<h3>
+						{ sprintf(
+							/* translators: %s: agent slug */
+							__( 'Bundle Status: %s', 'data-machine' ),
+							selectedSlug
+						) }
+					</h3>
+
+					<TextControl
+						label={ __( 'Bundle source', 'data-machine' ) }
+						value={ source }
+						onChange={ setSource }
+						help={ __( 'Path or URL used for planning, rebasing, and applying bundle upgrades.', 'data-machine' ) }
+					/>
+
+					<div className="datamachine-agent-bundles-tab__actions">
+						<Button
+							variant="secondary"
+							disabled={ ! source || planMutation.isPending }
+							onClick={ async () => setPlanResult( await planMutation.mutateAsync( requestInput() ) ) }
+						>
+							{ __( 'Plan Upgrade', 'data-machine' ) }
+						</Button>
+						<Button
+							variant="secondary"
+							disabled={ ! source || rebaseMutation.isPending }
+							onClick={ async () => setRebaseResult( await rebaseMutation.mutateAsync( { ...requestInput(), policy: 'conservative' } ) ) }
+						>
+							{ __( 'Preview Rebase', 'data-machine' ) }
+						</Button>
+						<Button
+							variant="primary"
+							disabled={ ! source || applyMutation.isPending }
+							onClick={ async () => setApplyResult( await applyMutation.mutateAsync( requestInput() ) ) }
+						>
+							{ __( 'Apply Clean Updates', 'data-machine' ) }
+						</Button>
+					</div>
+
+					<ResultNotice result={ planResult } />
+					<ResultNotice result={ rebaseResult } />
+					<ResultNotice result={ applyResult } />
+
+					{ plan && (
+						<div>
+							<h4>{ __( 'Upgrade Plan', 'data-machine' ) }</h4>
+							<p>
+								{ sprintf(
+									/* translators: 1: auto-apply count, 2: approval count, 3: warning count, 4: no-op count */
+									__( 'Auto-apply: %1$d. Needs approval: %2$d. Warnings: %3$d. No-op: %4$d.', 'data-machine' ),
+									planCounts.autoApply,
+									planCounts.needsApproval,
+									planCounts.warnings,
+									planCounts.noOp
+								) }
+							</p>
+							<ul>
+								{ planRows.map( ( item, index ) => (
+									<li key={ `${ artifactLabel( item ) }-${ index }` }>
+										<strong>{ artifactLabel( item ) }</strong>{ ' ' }
+										{ item.reason || item.status || item.summary || '' }
+									</li>
+								) ) }
+							</ul>
+						</div>
+					) }
+
+					<h4>{ __( 'Tracked Artifacts', 'data-machine' ) }</h4>
+					{ statusQuery.isLoading ? (
+						<Spinner />
+					) : artifacts.length > 0 ? (
+						<ul>
+							{ artifacts.map( ( artifact, index ) => (
+								<li key={ `${ artifactLabel( artifact ) }-${ index }` }>
+									<strong>{ artifactLabel( artifact ) }</strong>{ ' ' }
+									{ artifact.status || artifact.current_status || '' }
+								</li>
+							) ) }
+						</ul>
+					) : (
+						<pre>{ JSON.stringify( statusQuery.data || {}, null, 2 ) }</pre>
+					) }
+
+					<h4>{ __( 'Pending Bundle Decisions', 'data-machine' ) }</h4>
+					{ pendingActions.length === 0 ? (
+						<p>{ __( 'No pending bundle upgrade actions.', 'data-machine' ) }</p>
+					) : (
+						<ul>
+							{ pendingActions.map( ( action ) => (
+								<li key={ action.action_id || action.id }>
+									<strong>{ action.summary || action.action_id || action.id }</strong>{ ' ' }
+									<Button
+										variant="primary"
+										disabled={ resolveMutation.isPending }
+										onClick={ () => resolveMutation.mutate( { action_id: action.action_id || action.id, decision: 'accepted' } ) }
+									>
+										{ __( 'Approve', 'data-machine' ) }
+									</Button>{ ' ' }
+									<Button
+										variant="secondary"
+										disabled={ resolveMutation.isPending }
+										onClick={ () => resolveMutation.mutate( { action_id: action.action_id || action.id, decision: 'rejected' } ) }
+									>
+										{ __( 'Keep Local', 'data-machine' ) }
+									</Button>
+								</li>
+							) ) }
+						</ul>
+					) }
+				</div>
+			) }
+		</div>
+	);
+}

--- a/inc/Core/Admin/Pages/Agent/assets/react/queries/agentBundles.js
+++ b/inc/Core/Admin/Pages/Agent/assets/react/queries/agentBundles.js
@@ -1,0 +1,76 @@
+/**
+ * Agent bundle lifecycle query hooks.
+ */
+
+/**
+ * External dependencies
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+/**
+ * Internal dependencies
+ */
+import * as agentBundlesApi from '../api/agentBundles';
+
+const BUNDLES_KEY = [ 'agent-bundles' ];
+const BUNDLE_ACTIONS_KEY = [ 'agent-bundles', 'pending-actions' ];
+
+const unwrap = ( result, fallback ) => {
+	if ( result?.success === false ) {
+		throw new Error( result.message || result.error || fallback );
+	}
+	return result;
+};
+
+export const useAgentBundles = () =>
+	useQuery( {
+		queryKey: BUNDLES_KEY,
+		queryFn: async () => unwrap( await agentBundlesApi.fetchBundles(), 'Failed to fetch installed bundles' ),
+		staleTime: 30_000,
+	} );
+
+export const useAgentBundleStatus = ( slug ) =>
+	useQuery( {
+		queryKey: [ ...BUNDLES_KEY, 'status', slug ],
+		queryFn: async () => unwrap( await agentBundlesApi.fetchBundleStatus( slug ), 'Failed to fetch bundle status' ),
+		enabled: !! slug,
+	} );
+
+export const useBundlePendingActions = () =>
+	useQuery( {
+		queryKey: BUNDLE_ACTIONS_KEY,
+		queryFn: async () => unwrap( await agentBundlesApi.fetchBundlePendingActions(), 'Failed to fetch pending bundle actions' ),
+		staleTime: 15_000,
+	} );
+
+export const usePlanBundleUpgrade = () =>
+	useMutation( {
+		mutationFn: agentBundlesApi.planBundleUpgrade,
+	} );
+
+export const useRebaseBundleArtifacts = () =>
+	useMutation( {
+		mutationFn: agentBundlesApi.rebaseBundleArtifacts,
+	} );
+
+export const useApplyBundleUpgrade = () => {
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: agentBundlesApi.applyBundleUpgrade,
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: BUNDLES_KEY } );
+			queryClient.invalidateQueries( { queryKey: BUNDLE_ACTIONS_KEY } );
+		},
+	} );
+};
+
+export const useResolveBundlePendingAction = () => {
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: agentBundlesApi.resolvePendingAction,
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: BUNDLES_KEY } );
+			queryClient.invalidateQueries( { queryKey: BUNDLE_ACTIONS_KEY } );
+		},
+	} );
+};

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowHeader.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowHeader.jsx
@@ -7,14 +7,14 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
+import { useState, useEffect, useCallback } from '@wordpress/element';
 import { TextControl, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
 import { useUpdateFlowTitle } from '../../queries/flows';
-import { AUTO_SAVE_DELAY } from '../../utils/constants';
+import useDebouncedAutosave from '@shared/hooks/useDebouncedAutosave';
 
 /**
  * Flow Header Component.
@@ -43,7 +43,6 @@ export default function FlowHeader( {
 	runSuccess = false,
 } ) {
 	const [ localName, setLocalName ] = useState( flowName );
-	const saveTimeout = useRef( null );
 	const updateFlowTitleMutation = useUpdateFlowTitle();
 
 	/**
@@ -78,6 +77,7 @@ export default function FlowHeader( {
 		},
 		[ flowId, flowName, onNameChange, updateFlowTitleMutation ]
 	);
+	const scheduleSaveName = useDebouncedAutosave( saveName );
 
 	/**
 	 * Handle name change with debouncing
@@ -85,18 +85,9 @@ export default function FlowHeader( {
 	const handleNameChange = useCallback(
 		( value ) => {
 			setLocalName( value );
-
-			// Clear existing timeout
-			if ( saveTimeout.current ) {
-				clearTimeout( saveTimeout.current );
-			}
-
-			// Set new timeout for debounced save
-			saveTimeout.current = setTimeout( () => {
-				saveName( value );
-			}, AUTO_SAVE_DELAY );
+			scheduleSaveName( value );
 		},
-		[ saveName ]
+		[ scheduleSaveName ]
 	);
 
 	/**
@@ -112,17 +103,6 @@ export default function FlowHeader( {
 			onDelete( flowId );
 		}
 	}, [ flowId, onDelete ] );
-
-	/**
-	 * Cleanup timeout on unmount
-	 */
-	useEffect( () => {
-		return () => {
-			if ( saveTimeout.current ) {
-				clearTimeout( saveTimeout.current );
-			}
-		};
-	}, [] );
 
 	return (
 		<div className="datamachine-flow-header">

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/InlineStepConfig.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/InlineStepConfig.jsx
@@ -19,7 +19,7 @@ import { useState, useCallback, useRef, useEffect, useMemo } from '@wordpress/el
 import HandlerSettingField from '../modals/handler-settings/HandlerSettingField';
 import { useHandlerDetails } from '../../queries/handlers';
 import { useUpdateFlowStepConfig } from '../../queries/flows';
-import { AUTO_SAVE_DELAY } from '../../utils/constants';
+import useDebouncedAutosave from '@shared/hooks/useDebouncedAutosave';
 
 /**
  * InlineStepConfig Component.
@@ -70,7 +70,6 @@ export default function InlineStepConfig( {
 
 	// Local state for controlled inputs, initialized from derived values.
 	const [ localValues, setLocalValues ] = useState( initialValues );
-	const saveTimeout = useRef( null );
 	const localValuesRef = useRef( localValues );
 
 	const updateConfigMutation = useUpdateFlowStepConfig();
@@ -87,14 +86,33 @@ export default function InlineStepConfig( {
 		localValuesRef.current = localValues;
 	}, [ localValues ] );
 
-	// Cleanup on unmount.
-	useEffect( () => {
-		return () => {
-			if ( saveTimeout.current ) {
-				clearTimeout( saveTimeout.current );
+	const saveField = useCallback(
+		async ( fieldKey, value ) => {
+			try {
+				const currentValues = {
+					...localValuesRef.current,
+					[ fieldKey ]: value,
+				};
+				const response = await updateConfigMutation.mutateAsync( {
+					flowStepId,
+					config: { handler_config: currentValues },
+					pipelineId,
+					flowId,
+				} );
+				if ( ! response?.success && onError ) {
+					onError( response?.message || 'Failed to save settings' );
+				}
+			} catch ( err ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Inline config save error:', err );
+				if ( onError ) {
+					onError( err.message || 'An error occurred' );
+				}
 			}
-		};
-	}, [] );
+		},
+		[ flowStepId, pipelineId, flowId, onError, updateConfigMutation ]
+	);
+	const scheduleSaveField = useDebouncedAutosave( saveField );
 
 	/**
 	 * Handle field change with debounced save.
@@ -102,38 +120,9 @@ export default function InlineStepConfig( {
 	const handleFieldChange = useCallback(
 		( fieldKey, value ) => {
 			setLocalValues( ( prev ) => ( { ...prev, [ fieldKey ]: value } ) );
-
-			if ( saveTimeout.current ) {
-				clearTimeout( saveTimeout.current );
-			}
-
-			saveTimeout.current = setTimeout( async () => {
-				try {
-					const currentValues = {
-						...localValuesRef.current,
-						[ fieldKey ]: value,
-					};
-					const response = await updateConfigMutation.mutateAsync( {
-						flowStepId,
-						config: { handler_config: currentValues },
-						pipelineId,
-						flowId,
-					} );
-					if ( ! response?.success && onError ) {
-						onError(
-							response?.message || 'Failed to save settings'
-						);
-					}
-				} catch ( err ) {
-					// eslint-disable-next-line no-console
-					console.error( 'Inline config save error:', err );
-					if ( onError ) {
-						onError( err.message || 'An error occurred' );
-					}
-				}
-			}, AUTO_SAVE_DELAY );
+			scheduleSaveField( fieldKey, value );
 		},
-		[ flowStepId, pipelineId, flowId, onError, updateConfigMutation ]
+		[ scheduleSaveField ]
 	);
 
 	// Don't render until we have the field schema.

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/QueueablePromptField.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/QueueablePromptField.jsx
@@ -8,7 +8,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
+import { useState, useEffect, useCallback } from '@wordpress/element';
 import { Button, TextareaControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -16,7 +16,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useUpdateQueueItem, useAddToQueue } from '../../queries/queue';
-import { AUTO_SAVE_DELAY } from '../../utils/constants';
+import useDebouncedAutosave from '@shared/hooks/useDebouncedAutosave';
 
 /**
  * QueueablePromptField Component.
@@ -60,7 +60,6 @@ export default function QueueablePromptField( {
 		firstQueuePrompt || prompt || ''
 	);
 	const [ isSaving, setIsSaving ] = useState( false );
-	const saveTimeout = useRef( null );
 
 	const updateQueueItemMutation = useUpdateQueueItem();
 	const addToQueueMutation = useAddToQueue();
@@ -69,15 +68,6 @@ export default function QueueablePromptField( {
 	useEffect( () => {
 		setLocalValue( firstQueuePrompt || prompt || '' );
 	}, [ firstQueuePrompt, prompt ] );
-
-	// Cleanup timeout on unmount.
-	useEffect( () => {
-		return () => {
-			if ( saveTimeout.current ) {
-				clearTimeout( saveTimeout.current );
-			}
-		};
-	}, [] );
 
 	/**
 	 * Save to queue (add or update index 0).
@@ -149,6 +139,13 @@ export default function QueueablePromptField( {
 			onError,
 		]
 	);
+	const scheduleSave = useDebouncedAutosave( ( value ) => {
+		if ( shouldUseQueue ) {
+			saveToQueue( value );
+		} else if ( onSave ) {
+			onSave( value );
+		}
+	} );
 
 	/**
 	 * Handle value change with debounced save.
@@ -156,20 +153,9 @@ export default function QueueablePromptField( {
 	const handleChange = useCallback(
 		( value ) => {
 			setLocalValue( value );
-
-			if ( saveTimeout.current ) {
-				clearTimeout( saveTimeout.current );
-			}
-
-			saveTimeout.current = setTimeout( () => {
-				if ( shouldUseQueue ) {
-					saveToQueue( value );
-				} else if ( onSave ) {
-					onSave( value );
-				}
-			}, AUTO_SAVE_DELAY );
+			scheduleSave( value );
 		},
-		[ shouldUseQueue, saveToQueue, onSave ]
+		[ scheduleSave ]
 	);
 
 	/**

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineHeader.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineHeader.jsx
@@ -7,7 +7,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
+import { useState, useEffect, useCallback } from '@wordpress/element';
 import { TextControl, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 /**
@@ -15,7 +15,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { updatePipelineTitle } from '../../utils/api';
 import { useDeletePipeline } from '../../queries/pipelines';
-import { AUTO_SAVE_DELAY } from '../../utils/constants';
+import useDebouncedAutosave from '@shared/hooks/useDebouncedAutosave';
 
 /**
  * Pipeline Header Component
@@ -38,7 +38,6 @@ export default function PipelineHeader( {
 	onOpenMemoryFiles,
 } ) {
 	const [ localName, setLocalName ] = useState( pipelineName );
-	const saveTimeout = useRef( null );
 
 	// Use mutation hook for pipeline deletion
 	const deletePipelineMutation = useDeletePipeline();
@@ -71,6 +70,7 @@ export default function PipelineHeader( {
 		},
 		[ pipelineId, pipelineName, onNameChange ]
 	);
+	const scheduleSaveName = useDebouncedAutosave( saveName );
 
 	/**
 	 * Handle name input change with debouncing
@@ -78,18 +78,9 @@ export default function PipelineHeader( {
 	const handleNameChange = useCallback(
 		( value ) => {
 			setLocalName( value );
-
-			// Clear existing timeout
-			if ( saveTimeout.current ) {
-				clearTimeout( saveTimeout.current );
-			}
-
-			// Set new timeout for debounced save
-			saveTimeout.current = setTimeout( () => {
-				saveName( value );
-			}, AUTO_SAVE_DELAY );
+			scheduleSaveName( value );
 		},
-		[ saveName ]
+		[ scheduleSaveName ]
 	);
 
 	/**
@@ -124,17 +115,6 @@ export default function PipelineHeader( {
 			);
 		}
 	}, [ pipelineId, onDelete, deletePipelineMutation ] );
-
-	/**
-	 * Cleanup timeout on unmount
-	 */
-	useEffect( () => {
-		return () => {
-			if ( saveTimeout.current ) {
-				clearTimeout( saveTimeout.current );
-			}
-		};
-	}, [] );
 
 	return (
 		<div className="datamachine-pipeline-header">

--- a/inc/Core/Admin/shared/components/PromptField.jsx
+++ b/inc/Core/Admin/shared/components/PromptField.jsx
@@ -16,9 +16,9 @@ import { TextareaControl, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Auto-save delay in milliseconds.
+ * Internal dependencies
  */
-const AUTO_SAVE_DELAY = 500;
+import useDebouncedAutosave from '@shared/hooks/useDebouncedAutosave';
 
 /**
  * PromptField Component
@@ -49,7 +49,6 @@ export default function PromptField( {
 	const [ localValue, setLocalValue ] = useState( value );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ error, setError ] = useState( null );
-	const saveTimeout = useRef( null );
 	const lastSavedValue = useRef( value );
 
 	/**
@@ -103,6 +102,7 @@ export default function PromptField( {
 		},
 		[ onSave ]
 	);
+	const scheduleSave = useDebouncedAutosave( saveValue );
 
 	/**
 	 * Handle value change with debouncing
@@ -116,31 +116,12 @@ export default function PromptField( {
 				onChange( newValue );
 			}
 
-			// Clear existing timeout
-			if ( saveTimeout.current ) {
-				clearTimeout( saveTimeout.current );
-			}
-
-			// Set new timeout for debounced save
 			if ( onSave ) {
-				saveTimeout.current = setTimeout( () => {
-					saveValue( newValue );
-				}, AUTO_SAVE_DELAY );
+				scheduleSave( newValue );
 			}
 		},
-		[ onChange, onSave, saveValue ]
+		[ onChange, onSave, scheduleSave ]
 	);
-
-	/**
-	 * Cleanup timeout on unmount
-	 */
-	useEffect( () => {
-		return () => {
-			if ( saveTimeout.current ) {
-				clearTimeout( saveTimeout.current );
-			}
-		};
-	}, [] );
 
 	/**
 	 * Get help text with saving indicator

--- a/inc/Core/Admin/shared/hooks/useDebouncedAutosave.js
+++ b/inc/Core/Admin/shared/hooks/useDebouncedAutosave.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Auto-save delay in milliseconds.
+ */
+export const AUTO_SAVE_DELAY = 500;
+
+/**
+ * Return a debounced callback and clear its pending save on unmount.
+ *
+ * @param {Function} callback Callback to run after the debounce delay.
+ * @param {number}   delay    Delay in milliseconds.
+ * @return {Function} Debounced callback.
+ */
+export default function useDebouncedAutosave(
+	callback,
+	delay = AUTO_SAVE_DELAY
+) {
+	const saveTimeout = useRef( null );
+
+	useEffect( () => {
+		return () => {
+			if ( saveTimeout.current ) {
+				clearTimeout( saveTimeout.current );
+			}
+		};
+	}, [] );
+
+	return useCallback(
+		( ...args ) => {
+			if ( saveTimeout.current ) {
+				clearTimeout( saveTimeout.current );
+			}
+
+			saveTimeout.current = setTimeout( () => {
+				callback( ...args );
+			}, delay );
+		},
+		[ callback, delay ]
+	);
+}

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Data Machine owns the datamachine_jobs custom table; job lifecycle reads require fresh queue state and schema methods perform one-time table maintenance.
 /**
  * Jobs Database Repository
  *

--- a/inc/Core/Database/Pipelines/Pipelines.php
+++ b/inc/Core/Database/Pipelines/Pipelines.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Data Machine owns the datamachine_pipelines custom table; repository reads require fresh workflow state and schema methods perform one-time table maintenance.
 /**
  * Pipeline Database Operations
  *

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Data Machine owns the datamachine_processed_items custom table; duplicate/claim checks require fresh state and schema methods perform one-time table maintenance.
 /**
  * ProcessedItems database service - prevents duplicate processing at flow step level.
  *

--- a/inc/Core/FilesRepository/DirectoryManager.php
+++ b/inc/Core/FilesRepository/DirectoryManager.php
@@ -381,14 +381,19 @@ class DirectoryManager {
 			return $default_id;
 		}
 
-		// First admin user.
-		$admins = get_users( array(
-			'role'    => 'administrator',
-			'number'  => 1,
-			'orderby' => 'ID',
-			'order'   => 'ASC',
-			'fields'  => 'ID',
-		) );
+
+		// Activation can run before the users table exists in WP-PHPUnit/Playground bootstraps.
+		try {
+			$admins = get_users( array(
+				'role'    => 'administrator',
+				'number'  => 1,
+				'orderby' => 'ID',
+				'order'   => 'ASC',
+				'fields'  => 'ID',
+			) );
+		} catch ( \Throwable $e ) {
+			$admins = array();
+		}
 
 		$default_id = ! empty( $admins ) ? absint( $admins[0] ) : 1;
 		return $default_id;

--- a/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
@@ -408,6 +408,7 @@ class GuidelineAgentMemoryStore implements WP_Agent_Memory_Store {
 				'post_status'    => 'any',
 				'posts_per_page' => -1,
 				'no_found_rows'  => true,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Guideline-backed memory files are isolated by the Data Machine memory term.
 				'tax_query'      => array(
 					array(
 						'taxonomy' => self::TAXONOMY,
@@ -415,7 +416,7 @@ class GuidelineAgentMemoryStore implements WP_Agent_Memory_Store {
 						'terms'    => array( self::TERM_MEMORY ),
 					),
 				),
-				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Agent/file scope is stored as guideline metadata by this backend.
 				'meta_query'     => $meta_query,
 				'orderby'        => 'ID',
 				'order'          => 'ASC',

--- a/inc/Core/Steps/Fetch/Handlers/WordPress/WordPress.php
+++ b/inc/Core/Steps/Fetch/Handlers/WordPress/WordPress.php
@@ -158,6 +158,7 @@ class WordPress extends FetchHandler {
 			'exclude_keywords'  => trim( $config['exclude_keywords'] ?? '' ),
 			'randomize'         => ! empty( $config['randomize_selection'] ),
 			'posts_per_page'    => 10,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Handler-level taxonomy filters are passed to QueryWordPressPostsAbility intentionally.
 			'tax_query'         => $tax_query,
 			'include_file_info' => true,
 		);

--- a/inc/Engine/AI/Actions/SignPendingActionResolutionAbility.php
+++ b/inc/Engine/AI/Actions/SignPendingActionResolutionAbility.php
@@ -58,9 +58,12 @@ final class SignPendingActionResolutionAbility {
 			);
 		};
 
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- External WordPress Abilities API registration hook.
 		if ( doing_action( 'wp_abilities_api_init' ) ) {
 			$register();
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- External WordPress Abilities API registration hook.
 		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- External WordPress Abilities API registration hook.
 			add_action( 'wp_abilities_api_init', $register );
 		}
 	}
@@ -69,6 +72,7 @@ final class SignPendingActionResolutionAbility {
 	 * Register the public resolution endpoint.
 	 */
 	private function register_rest_route(): void {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WordPress core REST API registration hook.
 		add_action(
 			'rest_api_init',
 			function () {
@@ -96,6 +100,7 @@ final class SignPendingActionResolutionAbility {
 	 * Serve browser confirmation responses as raw HTML instead of JSON strings.
 	 */
 	private function register_html_response_sender(): void {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WordPress core REST response filter.
 		add_filter(
 			'rest_pre_serve_request',
 			static function ( bool $served, $result, \WP_REST_Request $request ): bool {

--- a/inc/Engine/AI/RequestMetadata.php
+++ b/inc/Engine/AI/RequestMetadata.php
@@ -153,6 +153,7 @@ class RequestMetadata {
 	}
 
 	private static function threshold( string $filter, int $default_value ): int {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound -- Filter names are selected from warning_thresholds() and all use datamachine_ prefixes.
 		$value = (int) apply_filters( $filter, $default_value );
 		return max( 0, $value );
 	}

--- a/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
+++ b/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
@@ -382,21 +382,23 @@ class InternalLinkingTask extends SystemTask {
 		$query = new \WP_Query( array(
 			'post_type'      => 'post',
 			'post_status'    => 'publish',
-			'post__not_in'   => array( $post_id ),
-			'posts_per_page' => 50,
+			'posts_per_page' => 51,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Related-post discovery intentionally matches shared categories/tags.
 			'tax_query'      => $tax_query,
 			'fields'         => 'ids',
 			'no_found_rows'  => true,
 		) );
 
-		if ( empty( $query->posts ) ) {
+		$candidate_ids = array_slice( array_values( array_filter( array_map( 'absint', $query->posts ), static fn( int $candidate_id ): bool => $candidate_id !== $post_id ) ), 0, 50 );
+
+		if ( empty( $candidate_ids ) ) {
 			return array();
 		}
 
 		$source_words = $this->extractTitleWords( $source_title );
 
 		$candidate_titles = array();
-		foreach ( $query->posts as $candidate_id ) {
+		foreach ( $candidate_ids as $candidate_id ) {
 			$candidate_titles[ $candidate_id ] = get_the_title( $candidate_id );
 		}
 
@@ -404,7 +406,7 @@ class InternalLinkingTask extends SystemTask {
 
 		$scored = array();
 
-		foreach ( $query->posts as $candidate_id ) {
+		foreach ( $candidate_ids as $candidate_id ) {
 			$score          = 0;
 			$candidate_cats = wp_get_post_categories( $candidate_id, array( 'fields' => 'ids' ) );
 			$candidate_tags = wp_get_post_tags( $candidate_id, array( 'fields' => 'ids' ) );

--- a/inc/Engine/AI/Tools/ToolSourceRegistry.php
+++ b/inc/Engine/AI/Tools/ToolSourceRegistry.php
@@ -44,6 +44,7 @@ class ToolSourceRegistry {
 	public function gather( array $modes, array $args ): array {
 		$callback = array( $this, 'orderSourcesForContext' );
 		if ( function_exists( 'add_filter' ) ) {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical Agents API tool-source compatibility hook.
 			add_filter( 'agents_api_tool_source_order', $callback, 5, 3 );
 		}
 
@@ -59,6 +60,7 @@ class ToolSourceRegistry {
 			);
 		} finally {
 			if ( function_exists( 'remove_filter' ) ) {
+				// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical Agents API tool-source compatibility hook.
 				remove_filter( 'agents_api_tool_source_order', $callback, 5 );
 			}
 		}
@@ -81,6 +83,7 @@ class ToolSourceRegistry {
 		);
 		$callback = array( $this, 'orderSourcesForContext' );
 		if ( function_exists( 'add_filter' ) ) {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical Agents API tool-source compatibility hook.
 			add_filter( 'agents_api_tool_source_order', $callback, 5, 3 );
 		}
 
@@ -88,6 +91,7 @@ class ToolSourceRegistry {
 			$sources = $this->registry->getSources( $context );
 			$order   = array_keys( $sources );
 			if ( function_exists( 'apply_filters' ) ) {
+				// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical Agents API tool-source compatibility hook.
 				$order = apply_filters( 'agents_api_tool_source_order', $order, $context, $this->registry, $sources );
 			}
 			$order = is_array( $order ) ? array_values( array_filter( $order, static fn( $source ): bool => is_string( $source ) && isset( $sources[ $source ] ) ) ) : array();
@@ -97,6 +101,7 @@ class ToolSourceRegistry {
 			foreach ( $order as $source_slug ) {
 				$source_tools = call_user_func( $sources[ $source_slug ], $context, $this->registry );
 				if ( function_exists( 'apply_filters' ) ) {
+					// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical Agents API tool-source compatibility hook.
 					$source_tools = apply_filters( 'agents_api_tool_source_tools', $source_tools, $source_slug, $context, $this->registry );
 				}
 
@@ -136,6 +141,7 @@ class ToolSourceRegistry {
 			);
 		} finally {
 			if ( function_exists( 'remove_filter' ) ) {
+				// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical Agents API tool-source compatibility hook.
 				remove_filter( 'agents_api_tool_source_order', $callback, 5 );
 			}
 		}

--- a/inc/Engine/Bundle/AgentBundleAbilityService.php
+++ b/inc/Engine/Bundle/AgentBundleAbilityService.php
@@ -351,6 +351,7 @@ final class AgentBundleAbilityService {
 
 	public static function capability_report( \WP_Agent_Package $package ): \WP_Agent_Package_Capability_Report {
 		if ( 0 === did_action( 'wp_agent_package_artifacts_init' ) ) {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical wp-agent package artifact registry hook.
 			do_action( 'wp_agent_package_artifacts_init' );
 		}
 

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -50,6 +50,7 @@ require_once __DIR__ . '/Api/Providers.php';
 require_once __DIR__ . '/Api/StepTypes.php';
 require_once __DIR__ . '/Api/Handlers.php';
 require_once __DIR__ . '/Api/Tools.php';
+require_once __DIR__ . '/Api/AgentBundles.php';
 require_once __DIR__ . '/Api/Chat/ChatFilters.php';
 require_once __DIR__ . '/Engine/Bundle/register-agent-package-artifacts.php';
 require_once __DIR__ . '/Engine/Bundle/AgentBundleUpgradeActionHandlers.php';


### PR DESCRIPTION
## Summary
- harden activation default-agent lookup for pre-schema WP-PHPUnit/Playground bootstraps
- reduce/justify Plugin Check findings for external hooks, intentional WP queries, and Data Machine custom-table repositories
- consolidate repeated React autosave debounce logic into a shared hook
- add an Agents > Bundles admin tab backed by thin bundle lifecycle REST wrappers

## Issues
- Fixes #2427
- Addresses #2300
- Addresses #2299
- Addresses #2298
- Addresses #2209
- Addresses #1540

## Verification
- npm run build
- composer lint
- php -l on changed PHP files
- git diff --check

## Test note
- composer test did not reach the Data Machine test suite because Homeboy lab failed before execution: Extension 'wordpress' has no sourceUrl or .source-url metadata.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Implementing the stale issue backlog fixes, drafting the admin UI slice, and running verification; Chris remains responsible for review and merge.