### PR TITLE
fix: reject duplicate daily memory archives

### DIFF
--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -381,6 +381,31 @@ class DailyMemoryTask extends SystemTask {
 			)
 		);
 
+		/**
+		 * Filter the maximum combined size ratio for daily memory compaction.
+		 *
+		 * The persistent section plus archived section should account for the
+		 * original MEMORY.md without substantially exceeding it. A large expansion
+		 * indicates the model duplicated content into both sections, which makes the
+		 * archive log misleading and leaves MEMORY.md bloated.
+		 *
+		 * @since 0.148.4
+		 *
+		 * @param float $threshold Default 1.10. Set to 0 to disable.
+		 * @param array $context   date, original_size, new_size, archived_size, job_id.
+		 */
+		$max_combined_ratio = (float) apply_filters(
+			'datamachine_daily_memory_max_combined_ratio',
+			1.10,
+			array(
+				'date'          => $date,
+				'original_size' => $original_size,
+				'new_size'      => $new_size,
+				'archived_size' => $archived_size,
+				'job_id'        => $jobId,
+			)
+		);
+
 		$policy = array(
 			'conservation_enabled'         => $conservation_threshold > 0,
 			'minimum_conserved_byte_ratio' => $conservation_threshold,
@@ -457,6 +482,48 @@ class DailyMemoryTask extends SystemTask {
 				),
 				'message'  => 'Conservation check failed -- AI emitted a lossy split. MEMORY.md unchanged.',
 			);
+		}
+
+		if ( $conservation_threshold > 0 && $max_combined_ratio > 0 ) {
+			$max_combined_size = (int) ceil( $original_size * $max_combined_ratio );
+			if ( $combined_size > $max_combined_size ) {
+				do_action(
+					'datamachine_log',
+					'warning',
+					sprintf(
+						'Daily memory aborted -- compaction expanded content: persistent (%s) + archived (%s) = %s, allowed at most %s of %s original. AI likely duplicated archived content instead of moving it.',
+						size_format( $new_size ),
+						size_format( $archived_size ),
+						size_format( $combined_size ),
+						size_format( $max_combined_size ),
+						size_format( $original_size )
+					),
+					array(
+						'date'              => $date,
+						'original_size'     => $original_size,
+						'new_size'          => $new_size,
+						'archived_size'     => $archived_size,
+						'combined_size'     => $combined_size,
+						'max_combined_size' => $max_combined_size,
+						'max_ratio'         => $max_combined_ratio,
+						'compaction'        => $metadata,
+					)
+				);
+
+				$metadata['status'] = 'failed';
+				return array(
+					'success'  => false,
+					'parsed'   => $parsed,
+					'metadata' => $metadata,
+					'events'   => array(
+						array(
+							'type'     => 'compaction_failed',
+							'metadata' => $metadata,
+						),
+					),
+					'message'  => 'Compaction expanded content -- AI likely duplicated archived content. MEMORY.md unchanged.',
+				);
+			}
 		}
 
 		return array(

--- a/tests/daily-memory-conservation-smoke.php
+++ b/tests/daily-memory-conservation-smoke.php
@@ -12,8 +12,10 @@
  * written. After this fix the task verifies that
  * persistent_size + archived_size ≈ original_size before writing.
  *
- * The check is filterable via
- * `datamachine_daily_memory_conservation_threshold` (default 0.85).
+ * The lower-bound check is filterable via
+ * `datamachine_daily_memory_conservation_threshold` (default 0.85). The
+ * upper-bound expansion check is filterable via
+ * `datamachine_daily_memory_max_combined_ratio` (default 1.10).
  *
  * The guard now delegates to Agents API conservation metadata while keeping
  * Data Machine-owned raw MEMORY.md byte accounting. This smoke exercises the
@@ -70,12 +72,20 @@ function evaluate_conservation(
 	int $original_size,
 	int $persistent_size,
 	int $archived_size,
-	float $threshold = 0.85
+	float $threshold = 0.85,
+	float $max_combined_ratio = 1.10
 ): array {
 	add_filter(
 		'datamachine_daily_memory_conservation_threshold',
 		static function () use ( $threshold ): float {
 			return $threshold;
+		}
+	);
+
+	add_filter(
+		'datamachine_daily_memory_max_combined_ratio',
+		static function () use ( $max_combined_ratio ): float {
+			return $max_combined_ratio;
 		}
 	);
 
@@ -183,12 +193,24 @@ echo "\n[8] no-op case (persistent == original, archive empty):\n";
 $result = evaluate_conservation( 5000, 5000, 0 );
 assert_committed( true, $result, 'no-op compaction commits', $failures, $passes );
 
-// Test 9: combined > original (AI duplicated content into both
-// sections). Should still commit — we only enforce the lower bound.
-// Filtering for double-write would belong elsewhere.
+// Test 9: combined substantially exceeds original (AI duplicated content into
+// both sections). This used to commit, yielding logs such as
+// "9 KB -> 9 KB (2 KB archived)" while MEMORY.md stayed oversized.
 echo "\n[9] combined > original (AI duplicated into both sections):\n";
 $result = evaluate_conservation( 1000, 800, 600 );
-assert_committed( true, $result, 'duplicate split commits (only lower bound enforced)', $failures, $passes );
+assert_committed( false, $result, 'duplicate split rejects by default', $failures, $passes );
+
+// Test 10: small expansion is allowed for headings, bullets, and formatting
+// churn in otherwise valid model output.
+echo "\n[10] small formatting expansion is allowed:\n";
+$result = evaluate_conservation( 1000, 700, 375 );
+assert_committed( true, $result, '7.5% expansion commits', $failures, $passes );
+
+// Test 11: the expansion guard can be disabled independently for installs
+// that intentionally tolerate larger rewritten output.
+echo "\n[11] max combined ratio = 0 disables expansion check:\n";
+$result = evaluate_conservation( 1000, 800, 600, 0.85, 0.0 );
+assert_committed( true, $result, 'disabled expansion check lets duplicate split through', $failures, $passes );
 
 echo "\n-------------------------------\n";
 $total = $passes + count( $failures );


### PR DESCRIPTION
## Summary
- reject daily memory compaction outputs where persistent + archived content substantially exceeds the original MEMORY.md size
- add a filterable maximum combined-size ratio guard to catch duplicated archived content
- update the conservation smoke to cover the observed `9 KB -> 9 KB (2 KB archived)` failure shape

## Testing
- `composer install`
- `php tests/daily-memory-conservation-smoke.php`
- `php -l inc/Engine/AI/System/Tasks/DailyMemoryTask.php && php -l tests/daily-memory-conservation-smoke.php`
- `./vendor/bin/phpcs inc/Engine/AI/System/Tasks/DailyMemoryTask.php tests/daily-memory-conservation-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Debugged the daily memory follow-up failure, drafted the guard and smoke coverage, and ran local verification. Chris remains responsible for review and merge.