### PR TITLE
fix: iterate daily memory until completion

### DIFF
--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -27,8 +27,10 @@ use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Core\FilesRepository\AgentMemory;
 use DataMachine\Core\FilesRepository\DailyMemory;
-use DataMachine\Engine\AI\RequestBuilder;
+use DataMachine\Engine\AI\NaturalCompletionPolicyInterface;
 use AgentsAPI\AI\WP_Agent_Compaction_Conservation;
+use AgentsAPI\AI\WP_Agent_Conversation_Completion_Decision;
+use AgentsAPI\AI\WP_Agent_Conversation_Completion_Policy;
 use AgentsAPI\AI\WP_Agent_Markdown_Section_Compaction_Adapter;
 
 class DailyMemoryTask extends SystemTask {
@@ -161,27 +163,43 @@ class DailyMemoryTask extends SystemTask {
 			$ai_payload['user_id'] = $user_id;
 		}
 
-		$response = RequestBuilder::build(
+		$response = $this->runAiConversation(
 			$messages,
 			$provider,
 			$model,
-			array(),
-			array( 'system' ),
-			$ai_payload
+			$ai_payload,
+			$this->buildCleanupCompletionPolicy( $memory_content, $date, $jobId, $provider, $model ),
+			(int) apply_filters(
+				'datamachine_daily_memory_max_turns',
+				3,
+				array(
+					'job_id'        => $jobId,
+					'date'          => $date,
+					'original_size' => $original_size,
+				)
+			)
 		);
 
-		if ( $response instanceof \WP_Error ) {
+		$datamachine_metadata = is_array( $response['metadata']['datamachine'] ?? null ) ? $response['metadata']['datamachine'] : array();
+		if ( empty( $datamachine_metadata['completed'] ) ) {
 			do_action(
 				'datamachine_log',
 				'warning',
-				'Daily memory AI request failed: ' . $response->get_error_message(),
-				array( 'date' => $date )
+				'Daily memory AI conversation did not satisfy completion policy.',
+				array(
+					'date'         => $date,
+					'job_id'       => $jobId,
+					'status'       => $response['status'] ?? '',
+					'turn_count'   => $response['turn_count'] ?? 0,
+					'datamachine'  => $datamachine_metadata,
+					'error'        => $response['error'] ?? null,
+				)
 			);
-			$this->failJob( $jobId, 'AI request failed: ' . $response->get_error_message() );
+			$this->failJob( $jobId, $response['error'] ?? 'Daily memory completion policy was not satisfied. MEMORY.md unchanged.' );
 			return;
 		}
 
-		$ai_output = trim( RequestBuilder::resultText( $response ) );
+		$ai_output = trim( (string) ( $response['final_content'] ?? '' ) );
 		$ai_output = str_replace( '\n', "\n", $ai_output );
 
 		if ( empty( $ai_output ) ) {
@@ -537,6 +555,99 @@ class DailyMemoryTask extends SystemTask {
 				),
 			),
 		);
+	}
+
+	/**
+	 * Build a completion policy for daily memory cleanup responses.
+	 *
+	 * The model may need more than one pass to satisfy a size target without
+	 * losing information. This policy keeps iteration inside the shared Agents API
+	 * conversation loop instead of hand-rolling retries in the task.
+	 *
+	 * @param string $original_content Current MEMORY.md content.
+	 * @param string $date             Archive date.
+	 * @param int    $jobId            Job ID.
+	 * @param string $provider         Summary provider.
+	 * @param string $model            Summary model.
+	 * @return WP_Agent_Conversation_Completion_Policy
+	 */
+	private function buildCleanupCompletionPolicy( string $original_content, string $date, int $jobId, string $provider, string $model ): WP_Agent_Conversation_Completion_Policy {
+		$validator = function ( string $assistant_text, int $turn_count ) use ( $original_content, $date, $jobId, $provider, $model ): WP_Agent_Conversation_Completion_Decision {
+			$parsed = $this->parseCleanupResponse( $assistant_text );
+			if ( empty( $parsed['persistent'] ) ) {
+				return WP_Agent_Conversation_Completion_Decision::incomplete(
+					'Daily memory completion policy: missing persistent section.',
+					array(
+						'turn_count'           => $turn_count,
+						'continuation_message' => 'Your response must use the exact required format with both `===PERSISTENT===` and `===ARCHIVED===`. Return the full corrected split now.',
+					)
+				);
+			}
+
+			$plan = $this->planMemoryCompaction( $original_content, $assistant_text, $date, $jobId, $provider, $model );
+			if ( empty( $plan['success'] ) ) {
+				return WP_Agent_Conversation_Completion_Decision::incomplete(
+					'Daily memory completion policy: conservation check failed.',
+					array(
+						'turn_count'           => $turn_count,
+						'plan_message'         => $plan['message'] ?? 'Compaction failed conservation checks.',
+						'continuation_message' => 'The split failed the conservation checks. Return a corrected full split that preserves every fact exactly once: persistent facts in `===PERSISTENT===`, archived/session-specific detail in `===ARCHIVED===`, with no duplicated archived content.',
+					)
+				);
+			}
+
+			$persistent_size = strlen( (string) $parsed['persistent'] );
+			$original_size   = strlen( $original_content );
+			if ( $original_size > AgentMemory::MAX_FILE_SIZE && $persistent_size > AgentMemory::MAX_FILE_SIZE ) {
+				return WP_Agent_Conversation_Completion_Decision::incomplete(
+					'Daily memory completion policy: persistent memory remains oversized.',
+					array(
+						'turn_count'           => $turn_count,
+						'original_size'        => $original_size,
+						'persistent_size'      => $persistent_size,
+						'max_size'             => AgentMemory::MAX_FILE_SIZE,
+						'continuation_message' => sprintf(
+							'The `===PERSISTENT===` section is still %s, above the target %s. Return a corrected full split. Keep durable facts, archive session-specific detail, condense overlapping entries, and ensure `===PERSISTENT===` is at or below %s without discarding information.',
+							size_format( $persistent_size ),
+							size_format( AgentMemory::MAX_FILE_SIZE ),
+							size_format( AgentMemory::MAX_FILE_SIZE )
+						),
+					)
+				);
+			}
+
+			return WP_Agent_Conversation_Completion_Decision::complete(
+				'Daily memory completion policy satisfied.',
+				array(
+					'turn_count'      => $turn_count,
+					'original_size'   => $original_size,
+					'persistent_size' => $persistent_size,
+					'max_size'        => AgentMemory::MAX_FILE_SIZE,
+				)
+			);
+		};
+
+		return new class( $validator ) implements WP_Agent_Conversation_Completion_Policy, NaturalCompletionPolicyInterface {
+			/** @var callable */
+			private $validator;
+
+			/** @param callable $validator Completion validator. */
+			public function __construct( callable $validator ) {
+				$this->validator = $validator;
+			}
+
+			/** @inheritDoc */
+			public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, array $runtime_context, int $turn_count ): WP_Agent_Conversation_Completion_Decision {
+				unset( $tool_name, $tool_def, $tool_result, $runtime_context, $turn_count );
+				return WP_Agent_Conversation_Completion_Decision::incomplete();
+			}
+
+			/** @inheritDoc */
+			public function recordNaturalCompletion( array $messages, string $assistant_text, array $runtime_context, int $turn_count ): WP_Agent_Conversation_Completion_Decision {
+				unset( $messages, $runtime_context );
+				return call_user_func( $this->validator, $assistant_text, $turn_count );
+			}
+		};
 	}
 
 	/**

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -46,6 +46,7 @@ use DataMachine\Abilities\Flow\QueueAbility;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\AI\System\SystemTaskPromptRegistry;
+use AgentsAPI\AI\WP_Agent_Conversation_Completion_Policy;
 
 abstract class SystemTask {
 
@@ -113,6 +114,45 @@ abstract class SystemTask {
 	 * @return string Task type identifier.
 	 */
 	abstract public function getTaskType(): string;
+
+	/**
+	 * Run a system-task AI conversation through Data Machine's conversation loop.
+	 *
+	 * System tasks historically used one-shot RequestBuilder calls. Tasks that
+	 * need bounded iteration, completion policies, transcript events, or runtime
+	 * loop diagnostics should use this helper instead of open-coding retries.
+	 *
+	 * @param array                                     $messages          Initial canonical message envelopes.
+	 * @param string                                    $provider          AI provider identifier.
+	 * @param string                                    $model             AI model identifier.
+	 * @param array                                     $payload           System-task payload / runtime context.
+	 * @param WP_Agent_Conversation_Completion_Policy|null $completion_policy Optional completion policy.
+	 * @param int|null                                  $max_turns         Optional maximum turns.
+	 * @return array Normalized Data Machine conversation result.
+	 */
+	protected function runAiConversation( array $messages, string $provider, string $model, array $payload = array(), ?WP_Agent_Conversation_Completion_Policy $completion_policy = null, ?int $max_turns = null ): array {
+		$payload = array_merge(
+			array(
+				'task_type' => $this->getTaskType(),
+			),
+			$payload
+		);
+
+		if ( null !== $completion_policy ) {
+			$payload['completion_policy'] = $completion_policy;
+		}
+
+		return \DataMachine\Engine\AI\datamachine_run_conversation(
+			$messages,
+			array(),
+			$provider,
+			$model,
+			array( 'system' ),
+			$payload,
+			$max_turns ?? PluginSettings::DEFAULT_MAX_TURNS,
+			false
+		);
+	}
 
 	/**
 	 * Get task metadata for registry, UI display, and manual-run safety.

--- a/tests/daily-memory-conservation-smoke.php
+++ b/tests/daily-memory-conservation-smoke.php
@@ -59,6 +59,8 @@ if ( ! function_exists( 'do_action' ) ) {
 
 require_once __DIR__ . '/agents-api-loader.php';
 datamachine_tests_require_agents_api();
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemory.php';
+require_once __DIR__ . '/../inc/Engine/AI/NaturalCompletionPolicyInterface.php';
 require_once __DIR__ . '/../inc/Engine/AI/System/Tasks/SystemTask.php';
 require_once __DIR__ . '/../inc/Engine/AI/System/Tasks/DailyMemoryTask.php';
 
@@ -113,6 +115,39 @@ function evaluate_conservation(
 		'committed' => true,
 		'reason'    => 'conservation ok',
 		'plan'      => $plan,
+	);
+}
+
+/**
+ * Evaluate the daily-memory natural completion policy for synthetic output.
+ */
+function evaluate_completion_policy(
+	int $original_size,
+	int $persistent_size,
+	int $archived_size
+): array {
+	$task   = new DataMachine\Engine\AI\System\Tasks\DailyMemoryTask();
+	$method = new ReflectionMethod( $task, 'buildCleanupCompletionPolicy' );
+	$policy = $method->invoke(
+		$task,
+		str_repeat( 'o', $original_size ),
+		'2026-05-01',
+		123,
+		'openai',
+		'gpt-test'
+	);
+
+	$decision = $policy->recordNaturalCompletion(
+		array(),
+		"===PERSISTENT===\n" . str_repeat( 'p', $persistent_size ) . "\n===ARCHIVED===\n" . str_repeat( 'a', $archived_size ),
+		array(),
+		1
+	);
+
+	return array(
+		'complete' => $decision->isComplete(),
+		'message'  => $decision->message(),
+		'context'  => $decision->context(),
 	);
 }
 
@@ -211,6 +246,19 @@ assert_committed( true, $result, '7.5% expansion commits', $failures, $passes );
 echo "\n[11] max combined ratio = 0 disables expansion check:\n";
 $result = evaluate_conservation( 1000, 800, 600, 0.85, 0.0 );
 assert_committed( true, $result, 'disabled expansion check lets duplicate split through', $failures, $passes );
+
+// Test 12: system task conversation completion policy rejects a cleanup that
+// remains over MEMORY.md's target size. This covers the live follow-up shape:
+// 9301B original -> 9233B persistent + 643B archived should iterate, not commit.
+echo "\n[12] daily-memory completion policy enforces target size:\n";
+$policy_result = evaluate_completion_policy( 9301, 9233, 643 );
+assert_committed( false, array( 'committed' => $policy_result['complete'], 'reason' => $policy_result['message'] ), 'oversized persistent output requests another turn', $failures, $passes );
+assert_committed( true, array( 'committed' => ! empty( $policy_result['context']['continuation_message'] ), 'reason' => 'continuation context' ), 'oversized output includes continuation nudge', $failures, $passes );
+
+$policy_result = evaluate_completion_policy( 9301, 7600, 1700 );
+assert_committed( true, array( 'committed' => $policy_result['complete'], 'reason' => $policy_result['message'] ), 'under-target persistent output completes', $failures, $passes );
+
+assert_committed( true, array( 'committed' => method_exists( $task ?? new DataMachine\Engine\AI\System\Tasks\DailyMemoryTask(), 'runAiConversation' ), 'reason' => 'system task helper' ), 'system tasks expose generic AI conversation loop helper', $failures, $passes );
 
 echo "\n-------------------------------\n";
 $total = $passes + count( $failures );


### PR DESCRIPTION
## Summary
- add a generic `SystemTask::runAiConversation()` helper that routes system-task AI work through Data Machine's shared conversation loop
- move daily memory from a one-shot `RequestBuilder` call to the shared completion-policy loop
- require daily memory natural completion to parse, pass conservation checks, and bring oversized `MEMORY.md` under the target before the task can commit
- preserve existing write-time fail-closed conservation checks as the final safety net

## Why
A local `v0.148.4` run completed with `Daily memory complete: 9 KB -> 9 KB (643 B archived)`, leaving `MEMORY.md` over the 8 KB threshold. That should be an iteration prompt, not a successful cleanup.

## Testing
- `composer install`
- `php tests/daily-memory-conservation-smoke.php`
- `php -l inc/Engine/AI/System/Tasks/SystemTask.php && php -l inc/Engine/AI/System/Tasks/DailyMemoryTask.php && php -l tests/daily-memory-conservation-smoke.php`
- `./vendor/bin/phpcs inc/Engine/AI/System/Tasks/SystemTask.php inc/Engine/AI/System/Tasks/DailyMemoryTask.php tests/daily-memory-conservation-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the system-task AI path, drafted the generic loop helper and daily-memory completion policy, and ran local verification. Chris remains responsible for review and merge.