### PR TITLE
Enforce required bundle run outputs

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -1579,6 +1579,18 @@ class AgentAbilities {
 					'type'        => 'object',
 					'description' => 'Initial engine data merged into the ephemeral workflow job.',
 				),
+				'required_outputs'    => array(
+					'type'        => array( 'array', 'object' ),
+					'description' => 'Semantic output keys that must be present and non-empty when a completed bundle run is returned.',
+				),
+				'required_artifacts'   => array(
+					'type'        => array( 'array', 'object' ),
+					'description' => 'Typed artifact output keys that must be present and non-empty when a completed bundle run is returned.',
+				),
+				'engine_data_outputs' => array(
+					'type'        => 'object',
+					'description' => 'Map semantic output keys to engine_data/response paths for stable caller-facing outputs.',
+				),
 				'provider'            => array(
 					'type'        => 'string',
 					'description' => 'Optional wp-ai-client provider slug to use as the run-scoped pipeline model default.',

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -1583,7 +1583,7 @@ class AgentAbilities {
 					'type'        => array( 'array', 'object' ),
 					'description' => 'Semantic output keys that must be present and non-empty when a completed bundle run is returned.',
 				),
-				'required_artifacts'   => array(
+				'required_artifacts'  => array(
 					'type'        => array( 'array', 'object' ),
 					'description' => 'Typed artifact output keys that must be present and non-empty when a completed bundle run is returned.',
 				),

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -138,8 +138,6 @@ final class AgentBundleRunner {
 	/** @return array<string,mixed> */
 	private function response( array $response, array $input, array $runtime_imports = array(), array $selection = array() ): array {
 		$response['schema'] ??= 'datamachine/agent-bundle-run/v1';
-		$response['status']   = $this->status_from_response( $response );
-		$response['success']  = ! empty( $response['success'] ) && self::is_success_status( $response['status'] );
 
 		if ( ! empty( $runtime_imports ) ) {
 			$response['runtime_imports'] = $runtime_imports;
@@ -162,6 +160,10 @@ final class AgentBundleRunner {
 		$output_projection              = $this->output_projection( $response, $input );
 		$response['outputs']            = $output_projection['outputs'];
 		$response['output_diagnostics'] = $output_projection['diagnostics'];
+		$response                       = $this->enforce_required_outputs( $response, $input );
+		$response['status']             = $this->status_from_response( $response );
+		$response['success']            = ! empty( $response['success'] ) && self::is_success_status( $response['status'] );
+		$response['completion_outcome'] = $this->completion_outcome( $response );
 
 		return $response;
 	}
@@ -292,7 +294,9 @@ final class AgentBundleRunner {
 	private function output_projection( array $response, array $input = array() ): array {
 		$engine_data = is_array( $response['engine_data'] ?? null ) ? $response['engine_data'] : array();
 		$mappings    = $this->declared_output_mappings( $input );
-		$declared    = array_values( array_unique( array_merge( $this->declared_output_keys( $engine_data ), array_keys( $mappings ) ) ) );
+		$required    = $this->required_output_keys( $engine_data, $input );
+		$artifacts   = $this->required_artifact_keys( $input );
+		$declared    = array_values( array_unique( array_merge( $required, $artifacts, array_keys( $mappings ) ) ) );
 		$outputs     = array();
 
 		foreach ( $mappings as $key => $path ) {
@@ -331,12 +335,68 @@ final class AgentBundleRunner {
 			'outputs'     => $outputs,
 			'diagnostics' => self::compact_response_array(
 				array(
-					'declared_outputs' => $declared,
-					'present_outputs'  => $present,
-					'missing_outputs'  => $missing,
+					'declared_outputs'  => $declared,
+					'required_outputs'  => $required,
+					'required_artifacts' => $artifacts,
+					'present_outputs'   => $present,
+					'missing_outputs'   => $missing,
 				)
 			),
 		);
+	}
+
+	/** @return array<string,mixed> */
+	private function enforce_required_outputs( array $response, array $input ): array {
+		$diagnostics = is_array( $response['output_diagnostics'] ?? null ) ? $response['output_diagnostics'] : array();
+		$required    = array_values(
+			array_unique(
+				array_merge(
+					is_array( $diagnostics['required_outputs'] ?? null ) ? $diagnostics['required_outputs'] : array(),
+					is_array( $diagnostics['required_artifacts'] ?? null ) ? $diagnostics['required_artifacts'] : array()
+				)
+			)
+		);
+		if ( empty( $required ) || empty( $response['success'] ) || ! $this->can_enforce_required_outputs( $response, $input ) ) {
+			return $response;
+		}
+
+		$outputs = is_array( $response['outputs'] ?? null ) ? $response['outputs'] : array();
+		$missing = array_values(
+			array_filter(
+				$required,
+				function ( string $key ) use ( $outputs ): bool {
+					return ! array_key_exists( $key, $outputs ) || ! $this->has_output_value( $outputs[ $key ] );
+				}
+			)
+		);
+		if ( empty( $missing ) ) {
+			return $response;
+		}
+
+		$response['success'] = false;
+		$response['error']   = sprintf( 'Agent bundle run completed without required semantic outputs: %s.', implode( ', ', $missing ) );
+		$response['output_diagnostics'] = array_merge(
+			$diagnostics,
+			array(
+				'enforcement'     => 'failed_missing_required_outputs',
+				'missing_required' => $missing,
+			)
+		);
+
+		return $response;
+	}
+
+	private function can_enforce_required_outputs( array $response, array $input ): bool {
+		if ( ! empty( $response['dry_run'] ) ) {
+			return false;
+		}
+
+		if ( ! empty( $response['wait_for_completion'] ) || ! empty( $input['wait_for_completion'] ) || ! empty( $input['wait'] ) ) {
+			return true;
+		}
+
+		$status = (string) ( $response['status'] ?? $response['job_status'] ?? '' );
+		return '' !== $status && 'scheduled' !== $status && 'pending' !== $status;
 	}
 
 	/** @return array<string,string> */
@@ -379,14 +439,15 @@ final class AgentBundleRunner {
 	}
 
 	/** @return array<int,string> */
-	private function declared_output_keys( array $engine_data ): array {
+	private function required_output_keys( array $engine_data, array $input = array() ): array {
 		$keys = array();
-		foreach ( array( 'completion_assertions_required', 'completion_assertions_satisfied' ) as $group ) {
+		foreach ( array( 'completion_assertions_required' ) as $group ) {
 			$assertions = is_array( $engine_data[ $group ] ?? null ) ? $engine_data[ $group ] : array();
 			if ( is_array( $assertions['engine_data_keys'] ?? null ) ) {
 				$keys = array_merge( $keys, $assertions['engine_data_keys'] );
 			}
 		}
+		$keys = array_merge( $keys, $this->normalize_required_key_list( $input['required_outputs'] ?? array() ) );
 
 		$missing = is_array( $engine_data['completion_assertions_missing'] ?? null ) ? $engine_data['completion_assertions_missing'] : array();
 		if ( is_array( $missing['engine_data_keys'] ?? null ) ) {
@@ -395,6 +456,29 @@ final class AgentBundleRunner {
 
 		$keys = array_map( static fn( $key ): string => sanitize_key( (string) $key ), $keys );
 		$keys = array_filter( $keys, static fn( string $key ): bool => '' !== $key );
+
+		return array_values( array_unique( $keys ) );
+	}
+
+	/** @return array<int,string> */
+	private function required_artifact_keys( array $input ): array {
+		return $this->normalize_required_key_list( $input['required_artifacts'] ?? array() );
+	}
+
+	/** @return array<int,string> */
+	private function normalize_required_key_list( mixed $raw ): array {
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$keys = array();
+		foreach ( $raw as $key => $value ) {
+			$candidate = is_string( $key ) ? $key : ( is_scalar( $value ) ? (string) $value : '' );
+			$candidate = sanitize_key( $candidate );
+			if ( '' !== $candidate ) {
+				$keys[] = $candidate;
+			}
+		}
 
 		return array_values( array_unique( $keys ) );
 	}

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -335,11 +335,11 @@ final class AgentBundleRunner {
 			'outputs'     => $outputs,
 			'diagnostics' => self::compact_response_array(
 				array(
-					'declared_outputs'  => $declared,
-					'required_outputs'  => $required,
+					'declared_outputs'   => $declared,
+					'required_outputs'   => $required,
 					'required_artifacts' => $artifacts,
-					'present_outputs'   => $present,
-					'missing_outputs'   => $missing,
+					'present_outputs'    => $present,
+					'missing_outputs'    => $missing,
 				)
 			),
 		);
@@ -373,12 +373,12 @@ final class AgentBundleRunner {
 			return $response;
 		}
 
-		$response['success'] = false;
-		$response['error']   = sprintf( 'Agent bundle run completed without required semantic outputs: %s.', implode( ', ', $missing ) );
+		$response['success']            = false;
+		$response['error']              = sprintf( 'Agent bundle run completed without required semantic outputs: %s.', implode( ', ', $missing ) );
 		$response['output_diagnostics'] = array_merge(
 			$diagnostics,
 			array(
-				'enforcement'     => 'failed_missing_required_outputs',
+				'enforcement'      => 'failed_missing_required_outputs',
 				'missing_required' => $missing,
 			)
 		);

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -98,6 +98,9 @@ foreach ( array(
 }
 datamachine_bundle_runner_contains( $abilities, "'outputs'", 'ability output schema advertises semantic outputs', $failures, $passes );
 datamachine_bundle_runner_contains( $abilities, "'output_diagnostics'", 'ability output schema advertises semantic output diagnostics', $failures, $passes );
+datamachine_bundle_runner_contains( $abilities, "'required_outputs'", 'ability input schema accepts required semantic outputs', $failures, $passes );
+datamachine_bundle_runner_contains( $abilities, "'required_artifacts'", 'ability input schema accepts required typed artifacts', $failures, $passes );
+datamachine_bundle_runner_contains( $abilities, "'engine_data_outputs'", 'ability input schema accepts semantic output mappings', $failures, $passes );
 datamachine_bundle_runner_contains( $ai_step, "\$payload['tool_recorders']", 'AI step forwards configured tool recorders to the loop', $failures, $passes );
 
 echo "\n[3] Runner exposes semantic outputs without hiding raw engine data\n";
@@ -127,6 +130,8 @@ $projected_outputs = $output_projection->invoke(
 		),
 	),
 	array(
+		'required_outputs'    => array( 'issue_number', 'issue_url' ),
+		'required_artifacts'   => array( 'concept_packet' ),
 		'engine_data_outputs' => array(
 			'store_issue_number' => 'metadata.engine_data.store_idea_agent.issue_number',
 			'store_issue_url'    => 'metadata.engine_data.store_idea_agent.issue_url',
@@ -141,7 +146,9 @@ datamachine_bundle_runner_assert( 'semantic output projection' === ( $projected_
 datamachine_bundle_runner_assert( 456 === ( $projected_outputs['outputs']['store_issue_number'] ?? null ), 'declared nested engine_data output number is projected', $failures, $passes );
 datamachine_bundle_runner_assert( 'https://github.com/chubes4/wp-site-generator/issues/456' === ( $projected_outputs['outputs']['store_issue_url'] ?? null ), 'declared nested engine_data output URL is projected', $failures, $passes );
 datamachine_bundle_runner_assert( ! isset( $projected_outputs['outputs']['agent_id'] ), 'runtime identity fields are not projected as outputs', $failures, $passes );
-datamachine_bundle_runner_assert( array( 'missing_result_url', 'missing_store_url' ) === ( $projected_outputs['diagnostics']['missing_outputs'] ?? null ), 'missing declared outputs are diagnosed semantically', $failures, $passes );
+datamachine_bundle_runner_assert( array( 'issue_number', 'issue_url', 'missing_result_url' ) === ( $projected_outputs['diagnostics']['required_outputs'] ?? null ), 'required semantic outputs are diagnosed', $failures, $passes );
+datamachine_bundle_runner_assert( array( 'concept_packet' ) === ( $projected_outputs['diagnostics']['required_artifacts'] ?? null ), 'required typed artifacts are diagnosed', $failures, $passes );
+datamachine_bundle_runner_assert( array( 'missing_result_url', 'concept_packet', 'missing_store_url' ) === ( $projected_outputs['diagnostics']['missing_outputs'] ?? null ), 'missing declared outputs are diagnosed semantically', $failures, $passes );
 
 echo "\n[3a] Failed terminal status families are not successful\n";
 $success_status = $runner_reflection->getMethod( 'is_success_status' );
@@ -379,6 +386,57 @@ $no_item_response = $response_method->invoke(
 datamachine_bundle_runner_assert( 'completed_no_items' === ( $no_item_response['status'] ?? null ), 'no-item terminal status is preserved', $failures, $passes );
 datamachine_bundle_runner_assert( false === ( $no_item_response['success'] ?? null ), 'no-item terminal status is not a successful bundle run', $failures, $passes );
 datamachine_bundle_runner_assert( false === ( $no_item_response['completion_outcome']['success'] ?? null ), 'no-item completion outcome is not successful', $failures, $passes );
+
+echo "\n[3d] Completed bundle runs enforce required semantic outputs\n";
+$missing_artifact_response = $response_method->invoke(
+	$runner_instance,
+	array(
+		'success'     => true,
+		'job_status'  => 'completed',
+		'engine_data' => array(
+			'outputs' => array(
+				'concept_packet' => array(),
+			),
+		),
+	),
+	array(
+		'wait_for_completion' => true,
+		'required_artifacts'   => array( 'concept_packet' ),
+	)
+);
+datamachine_bundle_runner_assert( false === ( $missing_artifact_response['success'] ?? null ), 'empty required artifact output fails a completed run', $failures, $passes );
+datamachine_bundle_runner_assert( array( 'concept_packet' ) === ( $missing_artifact_response['output_diagnostics']['missing_required'] ?? null ), 'missing required artifact is identified', $failures, $passes );
+datamachine_bundle_runner_assert( false !== strpos( (string) ( $missing_artifact_response['error'] ?? '' ), 'concept_packet' ), 'failure message names missing artifact output', $failures, $passes );
+
+$present_artifact_response = $response_method->invoke(
+	$runner_instance,
+	array(
+		'success'     => true,
+		'job_status'  => 'completed',
+		'engine_data' => array(
+			'outputs' => array(
+				'concept_packet' => array( 'title' => 'Concept Packet' ),
+			),
+		),
+	),
+	array(
+		'wait_for_completion' => true,
+		'required_artifacts'   => array( 'concept_packet' ),
+	)
+);
+datamachine_bundle_runner_assert( true === ( $present_artifact_response['success'] ?? null ), 'non-empty required artifact output keeps completed run successful', $failures, $passes );
+
+$scheduled_required_response = $response_method->invoke(
+	$runner_instance,
+	array(
+		'success' => true,
+	),
+	array(
+		'required_outputs' => array( 'future_result_url' ),
+	)
+);
+datamachine_bundle_runner_assert( true === ( $scheduled_required_response['success'] ?? null ), 'required outputs do not fail an async scheduled run before completion', $failures, $passes );
+datamachine_bundle_runner_assert( array( 'future_result_url' ) === ( $scheduled_required_response['output_diagnostics']['missing_outputs'] ?? null ), 'async scheduled run still exposes missing output diagnostics', $failures, $passes );
 
 echo "\n[4] WP-CLI wraps the same ability instead of duplicating runner internals\n";
 foreach ( array(


### PR DESCRIPTION
## Summary
- Add generic required_outputs and required_artifacts declarations to datamachine/run-agent-bundle.
- Include required semantic outputs/artifacts in output diagnostics and projected output handling.
- Fail completed or waited bundle runs when required semantic outputs are missing or empty, while leaving async scheduled runs schedulable with diagnostics.

Closes #2660.

## Verification
- php -l inc/Engine/Bundle/AgentBundleRunner.php
- php -l inc/Abilities/AgentAbilities.php
- php tests/agent-bundle-runner-contract-smoke.php
- php tests/run-artifact-egress-policy-smoke.php
- php tests/agent-abilities-registration-smoke.php
- vendor/bin/phpcs inc/Abilities/AgentAbilities.php inc/Engine/Bundle/AgentBundleRunner.php tests/agent-bundle-runner-contract-smoke.php

No local Cargo commands were run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic runner enforcement change, updated contract coverage, and ran local PHP verification. Chris remains responsible for review and acceptance.