### PR TITLE
fix: mark unsatisfied natural completion incomplete

### DIFF
--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -301,9 +301,14 @@ function datamachine_run_conversation(
 	// Normalize the substrate result and augment with DM-specific fields.
 	try {
 		$result = WP_Agent_Conversation_Result::normalize( $result );
+		$completion_policy_stopped = false;
 		foreach ( is_array( $result['events'] ?? null ) ? $result['events'] : array() as $event ) {
 			if ( ! is_array( $event ) || ! in_array( (string) ( $event['type'] ?? '' ), array( 'completion_policy_stop', 'completion_policy_continue' ), true ) ) {
 				continue;
+			}
+
+			if ( 'completion_policy_stop' === (string) ( $event['type'] ?? '' ) ) {
+				$completion_policy_stopped = true;
 			}
 
 			$event_metadata = is_array( $event['metadata'] ?? null ) ? $event['metadata'] : array();
@@ -387,6 +392,14 @@ function datamachine_run_conversation(
 		$datamachine_metadata['completion_assertions_required']  = $latest_nudge['completion_assertions_required'] ?? array();
 		$datamachine_metadata['completion_assertions_missing']   = $latest_nudge['completion_assertions_missing'] ?? array();
 		$datamachine_metadata['completion_assertions_satisfied'] = $latest_nudge['completion_assertions_satisfied'] ?? array();
+		if ( ! $completion_policy_stopped && (int) ( $result['turn_count'] ?? 0 ) >= $turn_budget->ceiling() ) {
+			$datamachine_metadata['completed']         = false;
+			$datamachine_metadata['max_turns_reached'] = true;
+			$datamachine_metadata['warning']           = sprintf(
+				'Maximum conversation turns (%d) reached before completion policy was satisfied.',
+				$turn_budget->ceiling()
+			);
+		}
 	}
 	if ( $assertions->hasAssertions() ) {
 		$evaluation = $assertions->evaluate( $loop_payload, $result['final_content'] ?? '' );

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -466,6 +466,40 @@ assert_runtime_policy( str_contains( wp_json_encode( $nudge_transcript->calls[0]
 assert_runtime_policy( 1 === ( $GLOBALS['datamachine_runtime_engine_merges'][4242][0]['completion_nudge_count'] ?? 0 ), 'job engine_data merge includes nudge count' );
 assert_runtime_policy( array( 'runtime_policy_tool' ) === ( $GLOBALS['datamachine_runtime_engine_merges'][4242][0]['completion_assertions_missing']['tool_names'] ?? null ), 'job engine_data merge includes missing assertions' );
 
+$exhausted_dispatch_count = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$exhausted_dispatch_count ) {
+		++$exhausted_dispatch_count;
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => 'Still not the required output.',
+				'tool_calls' => array(),
+			),
+		);
+	}
+);
+
+$exhausted_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'finish only with the missing packet type' ) ),
+	array(),
+	'openai',
+	'gpt-smoke',
+	array( 'system' ),
+	array(
+		'completion_assertions' => array(
+			'required_output_packet_types' => array( 'impossible_packet_type' ),
+		),
+	),
+	2
+);
+$exhausted_metadata = datamachine_conversation_metadata( $exhausted_result );
+assert_runtime_policy( 2 === $exhausted_dispatch_count, 'unsatisfied natural completion policy uses full turn budget' );
+assert_runtime_policy( false === ( $exhausted_metadata['completed'] ?? true ), 'unsatisfied natural completion policy marks run incomplete at max turns' );
+assert_runtime_policy( true === ( $exhausted_metadata['max_turns_reached'] ?? null ), 'unsatisfied natural completion policy sets max-turn diagnostic' );
+
 $minimum_count_dispatch_count = 0;
 WpAiClientTestDouble::reset();
 WpAiClientTestDouble::set_response_callback(


### PR DESCRIPTION
## Summary
- mark conversation-loop runs incomplete when natural completion policy nudges are exhausted at max turns without a completion-policy stop event
- preserve successful runs that had earlier nudges but later emitted `completion_policy_stop`
- add regression coverage for unsatisfied natural completion assertions reaching max turns

## Why
The local `v0.148.5` daily-memory run correctly iterated and failed closed, but exposed shared metadata drift: natural-completion policy exhaustion can still look completed unless the result status is explicitly marked incomplete.

## Testing
- `composer install`
- `php -l inc/Engine/AI/conversation-loop.php && php -l tests/agent-conversation-runtime-policy-smoke.php`
- `./vendor/bin/phpcs inc/Engine/AI/conversation-loop.php tests/agent-conversation-runtime-policy-smoke.php`
- `git diff --check`
- Partial: `php tests/agent-conversation-runtime-policy-smoke.php` verifies the new regression assertions, but this broader smoke currently has unrelated existing failures in older continuation scenarios.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the natural-completion max-turn metadata gap, drafted the loop metadata guard and regression assertion, and ran local verification. Chris remains responsible for review and merge.