### PR TITLE
fix: tighten daily memory archive prompt

### DIFF
--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -187,12 +187,12 @@ class DailyMemoryTask extends SystemTask {
 				'warning',
 				'Daily memory AI conversation did not satisfy completion policy.',
 				array(
-					'date'         => $date,
-					'job_id'       => $jobId,
-					'status'       => $response['status'] ?? '',
-					'turn_count'   => $response['turn_count'] ?? 0,
-					'datamachine'  => $datamachine_metadata,
-					'error'        => $response['error'] ?? null,
+					'date'        => $date,
+					'job_id'      => $jobId,
+					'status'      => $response['status'] ?? '',
+					'turn_count' => $response['turn_count'] ?? 0,
+					'datamachine' => $datamachine_metadata,
+					'error'       => $response['error'] ?? null,
 				)
 			);
 			$this->failJob( $jobId, $response['error'] ?? 'Daily memory completion policy was not satisfied. MEMORY.md unchanged.' );

--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -190,7 +190,7 @@ class DailyMemoryTask extends SystemTask {
 					'date'        => $date,
 					'job_id'      => $jobId,
 					'status'      => $response['status'] ?? '',
-					'turn_count' => $response['turn_count'] ?? 0,
+					'turn_count'  => $response['turn_count'] ?? 0,
 					'datamachine' => $datamachine_metadata,
 					'error'       => $response['error'] ?? null,
 				)


### PR DESCRIPTION
## Summary
- Rewrite the default daily-memory prompt as a true PERSISTENT/ARCHIVED partition contract.
- Make the MEMORY.md size target an explicit acceptance criterion.
- Remove stale preserve-everything wording from the conservation failure log.
- Add smoke coverage for the prompt contract so future edits do not reintroduce duplicate-preserving instructions.

## Testing
- Passed: `php tests/daily-memory-conservation-smoke.php`
- Noted: `php tests/agent-conversation-runtime-policy-smoke.php` currently fails on unrelated runtime-policy assertions on current `origin/main`; this PR does not touch that runtime path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the prompt wording, updated smoke coverage, and ran local verification for Chris to review.
