### PR TITLE
fix: clarify daily memory conservation retries

### DIFF
--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -586,12 +586,35 @@ class DailyMemoryTask extends SystemTask {
 
 			$plan = $this->planMemoryCompaction( $original_content, $assistant_text, $date, $jobId, $provider, $model );
 			if ( empty( $plan['success'] ) ) {
+				$persistent_size    = strlen( (string) $parsed['persistent'] );
+				$archived_size      = strlen( (string) $parsed['archived'] );
+				$combined_size      = $persistent_size + $archived_size;
+				$max_combined_ratio = (float) apply_filters( 'datamachine_daily_memory_max_combined_ratio', 1.10 );
+				$max_combined_size  = $max_combined_ratio > 0 ? (int) ceil( strlen( $original_content ) * $max_combined_ratio ) : 0;
+				$continuation       = 'The split failed the conservation checks. Return a corrected full split that preserves every fact exactly once: persistent facts in `===PERSISTENT===`, archived/session-specific detail in `===ARCHIVED===`, with no duplicated archived content.';
+
+				if ( $max_combined_size > 0 && $combined_size > $max_combined_size ) {
+					$continuation = sprintf(
+						'The split failed because total output expanded too much: `===PERSISTENT===` is %s, `===ARCHIVED===` is %s, combined is %s, and the allowed combined maximum is %s. Return a corrected full split with `===PERSISTENT===` at or below %s and combined PERSISTENT + ARCHIVED at or below %s. Condense ARCHIVED into compact retrievable notes instead of preserving verbose prose or duplicated context.',
+						size_format( $persistent_size ),
+						size_format( $archived_size ),
+						size_format( $combined_size ),
+						size_format( $max_combined_size ),
+						size_format( AgentMemory::MAX_FILE_SIZE ),
+						size_format( $max_combined_size )
+					);
+				}
+
 				return WP_Agent_Conversation_Completion_Decision::incomplete(
 					'Daily memory completion policy: conservation check failed.',
 					array(
 						'turn_count'           => $turn_count,
 						'plan_message'         => $plan['message'] ?? 'Compaction failed conservation checks.',
-						'continuation_message' => 'The split failed the conservation checks. Return a corrected full split that preserves every fact exactly once: persistent facts in `===PERSISTENT===`, archived/session-specific detail in `===ARCHIVED===`, with no duplicated archived content.',
+						'persistent_size'      => $persistent_size,
+						'archived_size'        => $archived_size,
+						'combined_size'        => $combined_size,
+						'max_combined_size'    => $max_combined_size,
+						'continuation_message' => $continuation,
 					)
 				);
 			}

--- a/tests/daily-memory-conservation-smoke.php
+++ b/tests/daily-memory-conservation-smoke.php
@@ -126,6 +126,13 @@ function evaluate_completion_policy(
 	int $persistent_size,
 	int $archived_size
 ): array {
+	add_filter(
+		'datamachine_daily_memory_max_combined_ratio',
+		static function (): float {
+			return 1.10;
+		}
+	);
+
 	$task   = new DataMachine\Engine\AI\System\Tasks\DailyMemoryTask();
 	$method = new ReflectionMethod( $task, 'buildCleanupCompletionPolicy' );
 	$policy = $method->invoke(
@@ -263,6 +270,16 @@ assert_committed( true, array( 'committed' => ! empty( $policy_result['context']
 
 $policy_result = evaluate_completion_policy( 9301, 7600, 1700 );
 assert_committed( true, array( 'committed' => $policy_result['complete'], 'reason' => $policy_result['message'] ), 'under-target persistent output completes', $failures, $passes );
+
+// Test 13: live prompt-follow-up shape after the partition prompt improved the
+// persistent size but over-expanded archived detail. The continuation must give
+// the model an explicit combined-output budget, otherwise it keeps producing a
+// valid-sized MEMORY.md plus an oversized archive split until max turns.
+echo "\n[13] conservation nudge includes combined-output budget:\n";
+$policy_result = evaluate_completion_policy( 9233, 4120, 8964 );
+assert_committed( false, array( 'committed' => $policy_result['complete'], 'reason' => $policy_result['message'] ), 'expanded archive output requests another turn', $failures, $passes );
+assert_committed( true, array( 'committed' => str_contains( (string) ( $policy_result['context']['continuation_message'] ?? '' ), 'allowed combined maximum' ), 'reason' => 'continuation context' ), 'expanded archive nudge includes allowed combined maximum', $failures, $passes );
+assert_committed( true, array( 'committed' => str_contains( (string) ( $policy_result['context']['continuation_message'] ?? '' ), 'Condense ARCHIVED into compact retrievable notes' ), 'reason' => 'continuation context' ), 'expanded archive nudge tells model to condense archive detail', $failures, $passes );
 
 assert_committed( true, array( 'committed' => method_exists( $task ?? new DataMachine\Engine\AI\System\Tasks\DailyMemoryTask(), 'runAiConversation' ), 'reason' => 'system task helper' ), 'system tasks expose generic AI conversation loop helper', $failures, $passes );
 


### PR DESCRIPTION
## Summary
- Add measured persistent/archive/combined sizes to daily-memory conservation retry context.
- Give the model an explicit combined-output budget when archive detail expands beyond the conservation limit.
- Cover the live failure shape where the partition prompt compressed MEMORY.md but over-expanded ARCHIVED output.

## Testing
- Passed: `homeboy lint data-machine --changed-since origin/main`
- Passed: `php tests/daily-memory-conservation-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the failed local daily-memory run, drafted the retry nudge, added smoke coverage, and ran local verification for Chris to review.
