### PR TITLE
fix: relax daily memory expansion cap

### DIFF
--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -409,12 +409,12 @@ class DailyMemoryTask extends SystemTask {
 		 *
 		 * @since 0.148.4
 		 *
-		 * @param float $threshold Default 1.10. Set to 0 to disable.
+		 * @param float $threshold Default 1.15. Set to 0 to disable.
 		 * @param array $context   date, original_size, new_size, archived_size, job_id.
 		 */
 		$max_combined_ratio = (float) apply_filters(
 			'datamachine_daily_memory_max_combined_ratio',
-			1.10,
+			1.15,
 			array(
 				'date'          => $date,
 				'original_size' => $original_size,
@@ -589,7 +589,7 @@ class DailyMemoryTask extends SystemTask {
 				$persistent_size    = strlen( (string) $parsed['persistent'] );
 				$archived_size      = strlen( (string) $parsed['archived'] );
 				$combined_size      = $persistent_size + $archived_size;
-				$max_combined_ratio = (float) apply_filters( 'datamachine_daily_memory_max_combined_ratio', 1.10 );
+				$max_combined_ratio = (float) apply_filters( 'datamachine_daily_memory_max_combined_ratio', 1.15 );
 				$max_combined_size  = $max_combined_ratio > 0 ? (int) ceil( strlen( $original_content ) * $max_combined_ratio ) : 0;
 				$continuation       = 'The split failed the conservation checks. Return a corrected full split that preserves every fact exactly once: persistent facts in `===PERSISTENT===`, archived/session-specific detail in `===ARCHIVED===`, with no duplicated archived content.';
 

--- a/tests/daily-memory-conservation-smoke.php
+++ b/tests/daily-memory-conservation-smoke.php
@@ -15,7 +15,7 @@
  * The lower-bound check is filterable via
  * `datamachine_daily_memory_conservation_threshold` (default 0.85). The
  * upper-bound expansion check is filterable via
- * `datamachine_daily_memory_max_combined_ratio` (default 1.10).
+ * `datamachine_daily_memory_max_combined_ratio` (default 1.15).
  *
  * The guard now delegates to Agents API conservation metadata while keeping
  * Data Machine-owned raw MEMORY.md byte accounting. This smoke exercises the
@@ -75,7 +75,7 @@ function evaluate_conservation(
 	int $persistent_size,
 	int $archived_size,
 	float $threshold = 0.85,
-	float $max_combined_ratio = 1.10
+	float $max_combined_ratio = 1.15
 ): array {
 	add_filter(
 		'datamachine_daily_memory_conservation_threshold',
@@ -129,7 +129,7 @@ function evaluate_completion_policy(
 	add_filter(
 		'datamachine_daily_memory_max_combined_ratio',
 		static function (): float {
-			return 1.10;
+			return 1.15;
 		}
 	);
 
@@ -253,6 +253,9 @@ assert_committed( false, $result, 'duplicate split rejects by default', $failure
 echo "\n[10] small formatting expansion is allowed:\n";
 $result = evaluate_conservation( 1000, 700, 375 );
 assert_committed( true, $result, '7.5% expansion commits', $failures, $passes );
+
+$result = evaluate_conservation( 9233, 4091, 6178 );
+assert_committed( true, $result, 'live compact archive shape within 15% expansion commits', $failures, $passes );
 
 // Test 11: the expansion guard can be disabled independently for installs
 // that intentionally tolerate larger rewritten output.


### PR DESCRIPTION
## Summary
- Loosen the daily-memory combined-output expansion cap from 1.10x to 1.15x.
- Keep the duplicate-output guard active while allowing compact archive splits with normal Markdown/heading overhead.
- Add smoke coverage for the live compact split shape that was 112 bytes over the old cap.

## Testing
- Passed: `homeboy lint data-machine --changed-since origin/main`
- Passed: `php tests/daily-memory-conservation-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the v0.148.9 local verification failure, adjusted the conservation cap, added smoke coverage, and ran local verification for Chris to review.
