### PR TITLE
feat: add `agent adopt` + symmetric bundle artifact matching

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -583,6 +583,20 @@ class AgentAbilities {
 			);
 
 			self::registerAbility(
+				'datamachine/adopt-agent-bundle',
+				array(
+					'label'               => 'Adopt Agent Bundle',
+					'description'         => 'Bind an already-live agent to a bundle without re-importing: backfill portable_slug, write the bundle header, and seed the artifact ledger from current live state so later upgrades diff cleanly instead of duplicating.',
+					'category'            => 'datamachine-agent',
+					'input_schema'        => self::bundleLifecycleInputSchema(),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'adoptAgentBundle' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			self::registerAbility(
 				'datamachine/resolve-agent-bundle-upgrade-action',
 				array(
 					'label'               => 'Resolve Agent Bundle Upgrade Action',
@@ -1501,6 +1515,16 @@ class AgentAbilities {
 	 */
 	public static function applyAgentBundleUpgrade( array $input ): array {
 		return self::bundleLifecycleService()->upgrade( $input );
+	}
+
+	/**
+	 * Bind an already-live agent to a bundle (one-time, idempotent adopt).
+	 *
+	 * @param array $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public static function adoptAgentBundle( array $input ): array {
+		return self::bundleLifecycleService()->adopt( $input );
 	}
 
 	/**

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -27,7 +27,7 @@ use DataMachine\Engine\Bundle\BundleStepIdRemapper;
 use DataMachine\Engine\Bundle\BundleValidationException;
 use DataMachine\Engine\Bundle\BundleSource;
 use DataMachine\Engine\Bundle\BundleSourceAuth;
-use DataMachine\Engine\Bundle\PortableSlug;
+use DataMachine\Engine\Bundle\AgentBundleSlugMatcher;
 use WP_CLI;
 
 defined( 'ABSPATH' ) || exit;
@@ -406,6 +406,66 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	/**
+	 * Bind an already-live agent to a bundle without re-importing its data.
+	 *
+	 * Live-origin agents (built in the UI/CLI then exported) have no package
+	 * provenance: pipeline/flow rows have portable_slug NULL, the ledger is
+	 * empty, and agent_config has no bundle header — so `upgrade` matches zero
+	 * artifacts and would insert a full duplicate set. `adopt` is the one-time,
+	 * idempotent bind: it backfills portable_slug on each matched row, writes
+	 * the bundle header, and seeds the ledger from current live state so the
+	 * next `upgrade` diffs cleanly instead of duplicating. Ambiguous name
+	 * collisions are surfaced and refused, never silently mismatched.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <path>
+	 * : Package path (.zip, .json, or directory) or remote URL.
+	 *
+	 * [--agent=<slug>]
+	 * : Target live agent slug. Defaults to the bundle's agent slug.
+	 *
+	 * [--slug=<slug>]
+	 * : Alias for --agent.
+	 *
+	 * [--dry-run]
+	 * : Report matched / unmatched / ambiguous counts without writing.
+	 *
+	 * [--token=<token>]
+	 * : Auth token for private archive downloads. Used for this single resolve(); never persisted, never logged.
+	 *
+	 * [--token-env=<varname>]
+	 * : Environment variable (or PHP constant) name to read the auth token from. Preferred over --token for shell-history hygiene.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function adopt( array $args, array $assoc_args ): void {
+		$input            = $this->bundle_ability_input( $args, $assoc_args );
+		$input['dry_run'] = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+		if ( isset( $assoc_args['agent'] ) && '' === (string) ( $assoc_args['slug'] ?? '' ) ) {
+			$input['slug'] = (string) $assoc_args['agent'];
+		}
+
+		$response = AgentAbilities::adoptAgentBundle( $input );
+		if ( empty( $response['success'] ) ) {
+			if ( 'json' === ( $assoc_args['format'] ?? 'table' ) ) {
+				WP_CLI::line( (string) wp_json_encode( $response, JSON_PRETTY_PRINT ) );
+			}
+			WP_CLI::error( (string) ( $response['error'] ?? 'Bundle adopt failed.' ) );
+			return;
+		}
+
+		$this->output_adopt( $response, $assoc_args );
+	}
+
+	/**
 	 * Resolve a staged package PendingAction.
 	 *
 	 * ## OPTIONS
@@ -660,20 +720,35 @@ class AgentBundleCommand extends BaseCommand {
 
 	/** @return array<int,array<string,mixed>> */
 	private function runtime_drifts_for_bundle( array $bundle, array $agent, string $decision ): array {
-		$agent_id                   = (int) ( $agent['agent_id'] ?? 0 );
-		$pipeline_id_map            = array();
-		$existing_pipelines_by_slug = array();
-		$drifts                     = array();
+		$agent_id        = (int) ( $agent['agent_id'] ?? 0 );
+		$pipeline_id_map = array();
+		$drifts          = array();
 
-		foreach ( $this->pipelines()->get_all_pipelines( null, $agent_id ) as $pipeline ) {
-			$existing_pipelines_by_slug[ (string) ( $pipeline['portable_slug'] ?? '' ) ] = $pipeline;
+		// Key existing pipelines under the SAME normalized slug the bundle side
+		// uses, falling back to the normalized pipeline_name when portable_slug
+		// is empty. Without this fallback, live-origin agents (portable_slug
+		// NULL on every row) never match and every artifact is misclassified.
+		$existing_pipelines_by_slug = AgentBundleSlugMatcher::index_existing(
+			$this->pipelines()->get_all_pipelines( null, $agent_id ),
+			'pipeline_name',
+			'pipeline'
+		)['matched'];
+
+		// Index existing flows per pipeline once, with the same name fallback,
+		// so flow rows with NULL portable_slug still resolve.
+		$existing_flows_by_pipeline = array();
+		foreach ( $this->flows()->get_all_flows( null, $agent_id ) as $existing_flow_row ) {
+			if ( ! is_array( $existing_flow_row ) ) {
+				continue;
+			}
+			$existing_flows_by_pipeline[ (int) ( $existing_flow_row['pipeline_id'] ?? 0 ) ][] = $existing_flow_row;
 		}
 
 		foreach ( $bundle['pipelines'] ?? array() as $pipeline ) {
 			if ( ! is_array( $pipeline ) ) {
 				continue;
 			}
-			$slug = PortableSlug::normalize( (string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ), 'pipeline' );
+			$slug = AgentBundleSlugMatcher::bundle_slug( $pipeline, 'pipeline_name', 'pipeline' );
 			if ( isset( $existing_pipelines_by_slug[ $slug ] ) ) {
 				$pipeline_id_map[ (int) ( $pipeline['original_id'] ?? 0 ) ] = (int) ( $existing_pipelines_by_slug[ $slug ]['pipeline_id'] ?? 0 );
 			}
@@ -688,9 +763,10 @@ class AgentBundleCommand extends BaseCommand {
 			if ( $new_pipeline_id <= 0 ) {
 				continue;
 			}
-			$flow_slug     = PortableSlug::normalize( (string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? 'flow' ) ), 'flow' );
-			$existing_flow = $this->flows()->get_by_portable_slug( $new_pipeline_id, $flow_slug );
-			if ( ! $existing_flow ) {
+			$flow_slug     = AgentBundleSlugMatcher::bundle_slug( $flow, 'flow_name', 'flow' );
+			$flow_index    = AgentBundleSlugMatcher::index_existing( $existing_flows_by_pipeline[ $new_pipeline_id ] ?? array(), 'flow_name', 'flow' );
+			$existing_flow = $flow_index['matched'][ $flow_slug ] ?? null;
+			if ( null === $existing_flow ) {
 				continue;
 			}
 			$target_flow = array_merge(
@@ -942,6 +1018,36 @@ class AgentBundleCommand extends BaseCommand {
 
 		if ( $rows ) {
 			$this->format_items( $rows, array( 'bucket', 'artifact_key', 'reason', 'summary' ), array( 'format' => 'table' ) );
+		}
+	}
+
+	private function output_adopt( array $response, array $assoc_args ): void {
+		if ( 'json' === ( $assoc_args['format'] ?? 'table' ) ) {
+			WP_CLI::line( (string) wp_json_encode( $response, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$counts = $response['counts'] ?? array();
+		WP_CLI::log( sprintf( 'Agent:     %s (#%d)', (string) ( $response['agent_slug'] ?? '' ), (int) ( $response['agent_id'] ?? 0 ) ) );
+		WP_CLI::log( sprintf( 'Mode:      %s', ! empty( $response['dry_run'] ) ? 'dry-run (no writes)' : 'applied' ) );
+		WP_CLI::log( sprintf( 'Matched:   %d', (int) ( $counts['matched'] ?? 0 ) ) );
+		WP_CLI::log( sprintf( 'Unmatched: %d', (int) ( $counts['unmatched'] ?? 0 ) ) );
+		WP_CLI::log( sprintf( 'Ambiguous: %d', (int) ( $counts['ambiguous'] ?? 0 ) ) );
+
+		$rows = array();
+		foreach ( array( 'matched', 'unmatched', 'ambiguous' ) as $bucket ) {
+			foreach ( $response[ $bucket ] ?? array() as $entry ) {
+				$rows[] = array(
+					'bucket'        => $bucket,
+					'artifact_type' => (string) ( $entry['artifact_type'] ?? '' ),
+					'artifact_id'   => (string) ( $entry['artifact_id'] ?? '' ),
+					'reason'        => (string) ( $entry['reason'] ?? '' ),
+				);
+			}
+		}
+
+		if ( $rows ) {
+			$this->format_items( $rows, array( 'bucket', 'artifact_type', 'artifact_id', 'reason' ), array( 'format' => 'table' ) );
 		}
 	}
 

--- a/inc/Engine/Bundle/AgentBundleAbilityService.php
+++ b/inc/Engine/Bundle/AgentBundleAbilityService.php
@@ -254,6 +254,245 @@ final class AgentBundleAbilityService {
 		return $response;
 	}
 
+	/**
+	 * Bind an already-live agent to a bundle without re-importing its data.
+	 *
+	 * Live-origin agents (built in the UI/CLI, then exported into a bundle)
+	 * carry no package provenance: pipeline/flow rows have portable_slug NULL,
+	 * the bundle_artifacts ledger is empty, and agent_config has no
+	 * datamachine_bundle header. A subsequent `upgrade` therefore matches zero
+	 * artifacts and would INSERT a full duplicate set.
+	 *
+	 * adopt() is the one-time, idempotent bind that:
+	 * - matches each bundle pipeline/flow to the live row by normalized
+	 *   portable_slug-or-name (refusing to guess on ambiguous name collisions),
+	 * - backfills portable_slug on each matched live row,
+	 * - writes the datamachine_bundle header onto agent_config,
+	 * - populates the ledger with installed_hash = current_hash = hash of the
+	 *   CURRENT live state, so the next upgrade diffs cleanly.
+	 *
+	 * @param array<string,mixed> $input { source, slug, dry_run, token, token_env }.
+	 * @return array<string,mixed>
+	 */
+	public function adopt( array $input ): array {
+		$loaded = $this->load_bundle_from_input( $input );
+		if ( empty( $loaded['success'] ) ) {
+			return $loaded;
+		}
+
+		$bundle  = $loaded['bundle'];
+		$slug    = (string) ( $input['slug'] ?? '' );
+		$dry_run = ! empty( $input['dry_run'] );
+
+		$agent = $this->resolve_bundle_agent( $bundle, $slug );
+		if ( ! $agent ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf(
+					'No live agent found for slug "%s". adopt binds an existing live agent to a bundle; use import to create a new one.',
+					'' !== $slug ? sanitize_title( $slug ) : sanitize_title( (string) ( $bundle['agent']['agent_slug'] ?? '' ) )
+				),
+			);
+		}
+
+		$agent_id  = (int) $agent['agent_id'];
+		$summary   = $this->bundle_summary( $bundle, $slug );
+		$matched   = array();
+		$unmatched = array();
+		$ambiguous = array();
+
+		// ---- Pipelines: match bundle entries to live rows by normalized slug.
+		$pipeline_rows  = $this->pipelines->get_all_pipelines( null, $agent_id );
+		$pipeline_index = AgentBundleSlugMatcher::index_existing( $pipeline_rows, 'pipeline_name', 'pipeline' );
+
+		// Map original bundle pipeline id -> live pipeline id so flows can be
+		// scoped to the right live pipeline.
+		$pipeline_id_map = array();
+
+		foreach ( $bundle['pipelines'] ?? array() as $bundle_pipeline ) {
+			if ( ! is_array( $bundle_pipeline ) ) {
+				continue;
+			}
+			$slug_key = AgentBundleSlugMatcher::bundle_slug( $bundle_pipeline, 'pipeline_name', 'pipeline' );
+
+			if ( isset( $pipeline_index['ambiguous'][ $slug_key ] ) ) {
+				$ambiguous[] = array(
+					'artifact_type' => 'pipeline',
+					'artifact_id'   => $slug_key,
+					'reason'        => sprintf( '%d live pipelines resolve to slug "%s".', count( $pipeline_index['ambiguous'][ $slug_key ] ), $slug_key ),
+				);
+				continue;
+			}
+
+			$live = $pipeline_index['matched'][ $slug_key ] ?? null;
+			if ( null === $live ) {
+				$unmatched[] = array(
+					'artifact_type' => 'pipeline',
+					'artifact_id'   => $slug_key,
+				);
+				continue;
+			}
+
+			$live_id = (int) ( $live['pipeline_id'] ?? 0 );
+
+			$pipeline_id_map[ (int) ( $bundle_pipeline['original_id'] ?? 0 ) ] = $live_id;
+
+			$matched[] = array(
+				'artifact_type'  => 'pipeline',
+				'artifact_id'    => $slug_key,
+				'record_id'      => $live_id,
+				'needs_backfill' => '' === trim( (string) ( $live['portable_slug'] ?? '' ) ),
+				'payload'        => AgentBundleArtifactPayloads::pipeline_payload( $live, $slug_key ),
+			);
+		}
+
+		// ---- Flows: scope each to its matched live pipeline, match by slug.
+		$flow_rows         = $this->flows->get_all_flows( null, $agent_id );
+		$flows_by_pipeline = array();
+		foreach ( $flow_rows as $flow_row ) {
+			if ( ! is_array( $flow_row ) ) {
+				continue;
+			}
+			$flows_by_pipeline[ (int) ( $flow_row['pipeline_id'] ?? 0 ) ][] = $flow_row;
+		}
+
+		foreach ( $bundle['flows'] ?? array() as $bundle_flow ) {
+			if ( ! is_array( $bundle_flow ) ) {
+				continue;
+			}
+			$slug_key        = AgentBundleSlugMatcher::bundle_slug( $bundle_flow, 'flow_name', 'flow' );
+			$old_pipeline_id = (int) ( $bundle_flow['original_pipeline_id'] ?? 0 );
+			$live_pipeline   = (int) ( $pipeline_id_map[ $old_pipeline_id ] ?? 0 );
+
+			if ( $live_pipeline <= 0 ) {
+				$unmatched[] = array(
+					'artifact_type' => 'flow',
+					'artifact_id'   => $slug_key,
+					'reason'        => 'parent pipeline unmatched',
+				);
+				continue;
+			}
+
+			$flow_index = AgentBundleSlugMatcher::index_existing( $flows_by_pipeline[ $live_pipeline ] ?? array(), 'flow_name', 'flow' );
+
+			if ( isset( $flow_index['ambiguous'][ $slug_key ] ) ) {
+				$ambiguous[] = array(
+					'artifact_type' => 'flow',
+					'artifact_id'   => $slug_key,
+					'reason'        => sprintf( '%d live flows on pipeline %d resolve to slug "%s".', count( $flow_index['ambiguous'][ $slug_key ] ), $live_pipeline, $slug_key ),
+				);
+				continue;
+			}
+
+			$live = $flow_index['matched'][ $slug_key ] ?? null;
+			if ( null === $live ) {
+				$unmatched[] = array(
+					'artifact_type' => 'flow',
+					'artifact_id'   => $slug_key,
+				);
+				continue;
+			}
+
+			$matched[] = array(
+				'artifact_type'  => 'flow',
+				'artifact_id'    => $slug_key,
+				'record_id'      => (int) ( $live['flow_id'] ?? 0 ),
+				'needs_backfill' => '' === trim( (string) ( $live['portable_slug'] ?? '' ) ),
+				'payload'        => AgentBundleArtifactPayloads::flow_payload( $live, $slug_key ),
+			);
+		}
+
+		$result = array(
+			'success'    => true,
+			'dry_run'    => $dry_run,
+			'agent_id'   => $agent_id,
+			'agent_slug' => (string) $agent['agent_slug'],
+			'bundle'     => $summary,
+			'counts'     => array(
+				'matched'   => count( $matched ),
+				'unmatched' => count( $unmatched ),
+				'ambiguous' => count( $ambiguous ),
+			),
+			'matched'    => $matched,
+			'unmatched'  => $unmatched,
+			'ambiguous'  => $ambiguous,
+		);
+
+		if ( ! empty( $ambiguous ) ) {
+			$result['success'] = false;
+			$result['error']   = sprintf(
+				'Refusing to adopt: %d artifact slug(s) are ambiguous (duplicate names collide). Rename or disambiguate the live rows, then retry.',
+				count( $ambiguous )
+			);
+			return $result;
+		}
+
+		if ( $dry_run ) {
+			return $result;
+		}
+
+		// ---- Write provenance: backfill slugs, ledger, bundle header. -------
+		$ledger_rows = array();
+		foreach ( $matched as $entry ) {
+			$type      = (string) $entry['artifact_type'];
+			$slug_key  = (string) $entry['artifact_id'];
+			$record_id = (int) $entry['record_id'];
+			$hash      = AgentBundleArtifactHasher::hash( $entry['payload'] );
+
+			if ( ! empty( $entry['needs_backfill'] ) && $record_id > 0 ) {
+				if ( 'pipeline' === $type ) {
+					$this->pipelines->update_pipeline( $record_id, array( 'portable_slug' => $slug_key ) );
+				} else {
+					$this->flows->update_flow( $record_id, array( 'portable_slug' => $slug_key ) );
+				}
+			}
+
+			$ledger_rows[] = array(
+				'bundle_slug'       => (string) $summary['bundle_slug'],
+				'bundle_version'    => (string) $summary['bundle_version'],
+				'artifact_type'     => $type,
+				'artifact_id'       => $slug_key,
+				'source_path'       => ( 'pipeline' === $type ? 'pipelines/' : 'flows/' ) . $slug_key . '.json',
+				'installed_hash'    => $hash,
+				'current_hash'      => $hash,
+				'installed_payload' => $entry['payload'],
+				'installed_at'      => current_time( 'mysql', true ),
+				'updated_at'        => current_time( 'mysql', true ),
+			);
+		}
+
+		$persisted = AgentBundleArtifactState::persist_for_agent_result( $agent_id, $ledger_rows );
+		if ( is_wp_error( $persisted ) ) {
+			return array(
+				'success' => false,
+				'error'   => $persisted->get_error_message(),
+			);
+		}
+
+		$config = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
+		if ( ! isset( $config['datamachine_bundle'] ) || ! is_array( $config['datamachine_bundle'] ) ) {
+			$config['datamachine_bundle'] = array();
+		}
+		$header = is_array( $bundle['agent']['agent_config']['datamachine_bundle'] ?? null ) ? $bundle['agent']['agent_config']['datamachine_bundle'] : array();
+
+		$config['datamachine_bundle']['bundle_slug']      = (string) $summary['bundle_slug'];
+		$config['datamachine_bundle']['bundle_version']   = (string) $summary['bundle_version'];
+		$config['datamachine_bundle']['template_slug']    = (string) ( $header['template_slug'] ?? $summary['bundle_slug'] );
+		$config['datamachine_bundle']['template_version'] = (string) ( $header['template_version'] ?? $summary['bundle_version'] );
+		$config['datamachine_bundle']['source_ref']       = (string) ( $bundle['source_ref'] ?? $header['source_ref'] ?? '' );
+		$config['datamachine_bundle']['source_revision']  = (string) ( $bundle['source_revision'] ?? $header['source_revision'] ?? '' );
+		$config['datamachine_bundle']['adopted']          = true;
+
+		if ( ! $this->agents->update_agent( $agent_id, array( 'agent_config' => $config ) ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Ledger written, but updating the agent_config bundle header failed.',
+			);
+		}
+
+		return $result;
+	}
+
 	/** @return array<string,mixed> */
 	public function apply_pending_action( string $action_id ): array {
 		$action_id = function_exists( 'sanitize_text_field' ) ? sanitize_text_field( $action_id ) : trim( $action_id );
@@ -420,20 +659,35 @@ final class AgentBundleAbilityService {
 
 	/** @return array<int,array<string,mixed>> */
 	private function runtime_drifts_for_bundle( array $bundle, array $agent, string $decision ): array {
-		$agent_id                   = (int) ( $agent['agent_id'] ?? 0 );
-		$pipeline_id_map            = array();
-		$existing_pipelines_by_slug = array();
-		$drifts                     = array();
+		$agent_id        = (int) ( $agent['agent_id'] ?? 0 );
+		$pipeline_id_map = array();
+		$drifts          = array();
 
-		foreach ( $this->pipelines->get_all_pipelines( null, $agent_id ) as $pipeline ) {
-			$existing_pipelines_by_slug[ (string) ( $pipeline['portable_slug'] ?? '' ) ] = $pipeline;
+		// Key existing pipelines under the SAME normalized slug the bundle side
+		// uses, falling back to the normalized pipeline_name when portable_slug
+		// is empty. Without this fallback, live-origin agents (portable_slug
+		// NULL on every row) never match and every artifact is misclassified.
+		$existing_pipelines_by_slug = AgentBundleSlugMatcher::index_existing(
+			$this->pipelines->get_all_pipelines( null, $agent_id ),
+			'pipeline_name',
+			'pipeline'
+		)['matched'];
+
+		// Index existing flows per pipeline once, with the same name fallback,
+		// so flow rows with NULL portable_slug still resolve.
+		$existing_flows_by_pipeline = array();
+		foreach ( $this->flows->get_all_flows( null, $agent_id ) as $existing_flow_row ) {
+			if ( ! is_array( $existing_flow_row ) ) {
+				continue;
+			}
+			$existing_flows_by_pipeline[ (int) ( $existing_flow_row['pipeline_id'] ?? 0 ) ][] = $existing_flow_row;
 		}
 
 		foreach ( $bundle['pipelines'] ?? array() as $pipeline ) {
 			if ( ! is_array( $pipeline ) ) {
 				continue;
 			}
-			$slug = PortableSlug::normalize( (string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ), 'pipeline' );
+			$slug = AgentBundleSlugMatcher::bundle_slug( $pipeline, 'pipeline_name', 'pipeline' );
 			if ( isset( $existing_pipelines_by_slug[ $slug ] ) ) {
 				$pipeline_id_map[ (int) ( $pipeline['original_id'] ?? 0 ) ] = (int) ( $existing_pipelines_by_slug[ $slug ]['pipeline_id'] ?? 0 );
 			}
@@ -448,9 +702,10 @@ final class AgentBundleAbilityService {
 			if ( $new_pipeline_id <= 0 ) {
 				continue;
 			}
-			$flow_slug     = PortableSlug::normalize( (string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? 'flow' ) ), 'flow' );
-			$existing_flow = $this->flows->get_by_portable_slug( $new_pipeline_id, $flow_slug );
-			if ( ! $existing_flow ) {
+			$flow_slug      = AgentBundleSlugMatcher::bundle_slug( $flow, 'flow_name', 'flow' );
+			$flow_index     = AgentBundleSlugMatcher::index_existing( $existing_flows_by_pipeline[ $new_pipeline_id ] ?? array(), 'flow_name', 'flow' );
+			$existing_flow  = $flow_index['matched'][ $flow_slug ] ?? null;
+			if ( null === $existing_flow ) {
 				continue;
 			}
 			$target_flow = array_merge(

--- a/inc/Engine/Bundle/AgentBundleLifecycleProjection.php
+++ b/inc/Engine/Bundle/AgentBundleLifecycleProjection.php
@@ -32,6 +32,7 @@ final class AgentBundleLifecycleProjection {
 		$agent_id                   = is_array( $agent ) ? (int) ( $agent['agent_id'] ?? 0 ) : 0;
 		$pipeline_id_map            = array();
 		$existing_pipelines_by_slug = array();
+		$existing_flows_by_pipeline = array();
 		$incoming_config            = is_array( $bundle['agent']['agent_config'] ?? null ) ? $bundle['agent']['agent_config'] : array();
 
 		$artifacts[] = array(
@@ -42,8 +43,20 @@ final class AgentBundleLifecycleProjection {
 		);
 
 		if ( $agent_id > 0 ) {
-			foreach ( $this->pipelines()->get_all_pipelines( null, $agent_id ) as $pipeline ) {
-				$existing_pipelines_by_slug[ (string) ( $pipeline['portable_slug'] ?? '' ) ] = $pipeline;
+			// Mirror the bundle-side key: prefer stored portable_slug, fall back
+			// to the normalized pipeline_name. Live-origin agents (portable_slug
+			// NULL) only become matchable through the name fallback.
+			$existing_pipelines_by_slug = AgentBundleSlugMatcher::index_existing(
+				$this->pipelines()->get_all_pipelines( null, $agent_id ),
+				'pipeline_name',
+				'pipeline'
+			)['matched'];
+
+			foreach ( $this->flows()->get_all_flows( null, $agent_id ) as $existing_flow_row ) {
+				if ( ! is_array( $existing_flow_row ) ) {
+					continue;
+				}
+				$existing_flows_by_pipeline[ (int) ( $existing_flow_row['pipeline_id'] ?? 0 ) ][] = $existing_flow_row;
 			}
 		}
 
@@ -52,7 +65,7 @@ final class AgentBundleLifecycleProjection {
 				continue;
 			}
 
-			$slug = PortableSlug::normalize( (string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ), 'pipeline' );
+			$slug = AgentBundleSlugMatcher::bundle_slug( $pipeline, 'pipeline_name', 'pipeline' );
 			if ( isset( $existing_pipelines_by_slug[ $slug ] ) ) {
 				$old_id = (int) ( $pipeline['original_id'] ?? 0 );
 				$new_id = (int) ( $existing_pipelines_by_slug[ $slug ]['pipeline_id'] ?? 0 );
@@ -78,10 +91,14 @@ final class AgentBundleLifecycleProjection {
 				continue;
 			}
 
-			$slug            = PortableSlug::normalize( (string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? 'flow' ) ), 'flow' );
+			$slug            = AgentBundleSlugMatcher::bundle_slug( $flow, 'flow_name', 'flow' );
 			$old_pipeline_id = (int) ( $flow['original_pipeline_id'] ?? 0 );
 			$new_pipeline_id = (int) ( $pipeline_id_map[ $old_pipeline_id ] ?? 0 );
-			$existing_flow   = $new_pipeline_id > 0 ? $this->flows()->get_by_portable_slug( $new_pipeline_id, $slug ) : null;
+			$existing_flow   = null;
+			if ( $new_pipeline_id > 0 ) {
+				$flow_index    = AgentBundleSlugMatcher::index_existing( $existing_flows_by_pipeline[ $new_pipeline_id ] ?? array(), 'flow_name', 'flow' );
+				$existing_flow = $flow_index['matched'][ $slug ] ?? null;
+			}
 
 			if ( $existing_flow ) {
 				$flow['flow_config'] = BundleStepIdRemapper::remap_flow_step_ids(

--- a/inc/Engine/Bundle/AgentBundleSlugMatcher.php
+++ b/inc/Engine/Bundle/AgentBundleSlugMatcher.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Symmetric portable-slug matching for live-origin agent bundles.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Builds a normalized lookup of existing pipeline/flow rows that mirrors the
+ * key the bundle (target) side uses.
+ *
+ * The bundle side already keys artifacts by
+ * `PortableSlug::normalize( portable_slug ?: display_name )`. The existing /
+ * live side historically keyed only by the stored `portable_slug`, so rows with
+ * a NULL/empty `portable_slug` (every row on a live-origin agent exported into a
+ * bundle) were keyed under `''` and never matched. This helper closes that
+ * asymmetry: it keys each existing row under the SAME normalized slug the bundle
+ * side computes, falling back to the normalized display name when the stored
+ * `portable_slug` is empty.
+ *
+ * Pure and persistence-free so it can be unit-tested directly.
+ */
+final class AgentBundleSlugMatcher {
+
+	/**
+	 * Index a set of existing rows by their effective normalized slug.
+	 *
+	 * When two or more rows resolve to the SAME normalized slug (e.g. four live
+	 * flows all named "Ticketmaster"), the slug is ambiguous: no single row can
+	 * be bound to the incoming bundle artifact without guessing. Ambiguous slugs
+	 * are omitted from the returned `matched` map and surfaced in `ambiguous`
+	 * so callers can refuse to guess.
+	 *
+	 * @param array<int,array<string,mixed>> $rows      Existing pipeline or flow rows.
+	 * @param string                         $name_key  Display-name field (pipeline_name / flow_name).
+	 * @param string                         $fallback  PortableSlug fallback (pipeline / flow).
+	 * @return array{
+	 *     matched: array<string,array<string,mixed>>,
+	 *     ambiguous: array<string,array<int,array<string,mixed>>>
+	 * }
+	 */
+	public static function index_existing( array $rows, string $name_key, string $fallback ): array {
+		$by_slug = array();
+
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$slug = self::effective_slug( $row, $name_key, $fallback );
+			if ( '' === $slug ) {
+				continue;
+			}
+
+			$by_slug[ $slug ][] = $row;
+		}
+
+		$matched   = array();
+		$ambiguous = array();
+		foreach ( $by_slug as $slug => $candidates ) {
+			if ( 1 === count( $candidates ) ) {
+				$matched[ $slug ] = $candidates[0];
+				continue;
+			}
+
+			$ambiguous[ $slug ] = $candidates;
+		}
+
+		return array(
+			'matched'   => $matched,
+			'ambiguous' => $ambiguous,
+		);
+	}
+
+	/**
+	 * Compute the effective normalized slug for a single existing row.
+	 *
+	 * Mirrors the bundle-side key: prefer the stored `portable_slug`, fall back
+	 * to the normalized display name when it is empty.
+	 *
+	 * @param array<string,mixed> $row      Existing pipeline or flow row.
+	 * @param string              $name_key Display-name field.
+	 * @param string              $fallback PortableSlug fallback.
+	 * @return string Normalized slug, or '' when neither slug nor name is usable.
+	 */
+	public static function effective_slug( array $row, string $name_key, string $fallback ): string {
+		$stored = trim( (string) ( $row['portable_slug'] ?? '' ) );
+		if ( '' !== $stored ) {
+			return PortableSlug::normalize( $stored, $fallback );
+		}
+
+		$name = trim( (string) ( $row[ $name_key ] ?? '' ) );
+		if ( '' === $name ) {
+			return '';
+		}
+
+		return PortableSlug::normalize( $name, $fallback );
+	}
+
+	/**
+	 * Compute the normalized slug the bundle (target) side uses for an artifact.
+	 *
+	 * @param array<string,mixed> $artifact Bundle pipeline or flow entry.
+	 * @param string              $name_key Display-name field (pipeline_name / flow_name).
+	 * @param string              $fallback PortableSlug fallback (pipeline / flow).
+	 * @return string Normalized slug.
+	 */
+	public static function bundle_slug( array $artifact, string $name_key, string $fallback ): string {
+		$candidate = (string) ( $artifact['portable_slug'] ?? ( $artifact[ $name_key ] ?? $fallback ) );
+
+		return PortableSlug::normalize( $candidate, $fallback );
+	}
+}

--- a/tests/agent-bundle-slug-matcher-smoke.php
+++ b/tests/agent-bundle-slug-matcher-smoke.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Pure-PHP smoke test for symmetric portable-slug matching.
+ *
+ * Verifies the matching asymmetry fix behind `agent adopt` / `agent upgrade`:
+ * live-origin rows with portable_slug NULL must resolve to the SAME normalized
+ * key the bundle side computes (via the display-name fallback), and duplicate
+ * names must surface as ambiguous instead of silently mismatching.
+ *
+ * Run with: php tests/agent-bundle-slug-matcher-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../inc/Engine/Bundle/PortableSlug.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleSlugMatcher.php';
+
+use DataMachine\Engine\Bundle\AgentBundleSlugMatcher;
+
+$failures = array();
+$passes   = 0;
+
+function agent_bundle_slug_matcher_assert( bool $condition, string $name, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+}
+
+echo "agent-bundle-slug-matcher-smoke\n";
+
+// ---- 1. NULL portable_slug rows resolve via the display-name fallback. -----
+$live_pipelines = array(
+	array( 'pipeline_id' => 101, 'pipeline_name' => 'Ticketmaster Columbus', 'portable_slug' => null ),
+	array( 'pipeline_id' => 102, 'pipeline_name' => 'Dice FM Austin', 'portable_slug' => '' ),
+);
+
+$index = AgentBundleSlugMatcher::index_existing( $live_pipelines, 'pipeline_name', 'pipeline' );
+
+agent_bundle_slug_matcher_assert(
+	isset( $index['matched']['ticketmaster-columbus'] ),
+	'NULL portable_slug pipeline resolves by normalized name',
+	$failures,
+	$passes
+);
+agent_bundle_slug_matcher_assert(
+	101 === ( $index['matched']['ticketmaster-columbus']['pipeline_id'] ?? 0 ),
+	'matched row is the correct live pipeline',
+	$failures,
+	$passes
+);
+agent_bundle_slug_matcher_assert(
+	isset( $index['matched']['dice-fm-austin'] ),
+	'empty-string portable_slug pipeline resolves by normalized name',
+	$failures,
+	$passes
+);
+agent_bundle_slug_matcher_assert(
+	empty( $index['ambiguous'] ),
+	'distinct names produce no ambiguity',
+	$failures,
+	$passes
+);
+
+// ---- 2. Bundle side computes the SAME key the existing side does. ----------
+$bundle_pipeline = array( 'original_id' => 9, 'pipeline_name' => 'Ticketmaster Columbus', 'portable_slug' => null );
+$bundle_key      = AgentBundleSlugMatcher::bundle_slug( $bundle_pipeline, 'pipeline_name', 'pipeline' );
+
+agent_bundle_slug_matcher_assert(
+	'ticketmaster-columbus' === $bundle_key,
+	'bundle-side slug matches existing-side slug (symmetric)',
+	$failures,
+	$passes
+);
+agent_bundle_slug_matcher_assert(
+	isset( $index['matched'][ $bundle_key ] ),
+	'a live-origin bundle artifact now resolves to its live row',
+	$failures,
+	$passes
+);
+
+// ---- 3. Stored portable_slug wins over the name fallback. -------------------
+$with_slug = array(
+	array( 'pipeline_id' => 200, 'pipeline_name' => 'Human Readable Name', 'portable_slug' => 'stable-slug' ),
+);
+$slug_index = AgentBundleSlugMatcher::index_existing( $with_slug, 'pipeline_name', 'pipeline' );
+agent_bundle_slug_matcher_assert(
+	isset( $slug_index['matched']['stable-slug'] ) && ! isset( $slug_index['matched']['human-readable-name'] ),
+	'stored portable_slug takes precedence over display name',
+	$failures,
+	$passes
+);
+
+// ---- 4. Duplicate names surface as ambiguous, never silently mismatched. ---
+$dupes = array(
+	array( 'flow_id' => 1, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+	array( 'flow_id' => 2, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+	array( 'flow_id' => 3, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+	array( 'flow_id' => 4, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+	array( 'flow_id' => 5, 'flow_name' => 'Unique Flow', 'portable_slug' => null ),
+);
+$flow_index = AgentBundleSlugMatcher::index_existing( $dupes, 'flow_name', 'flow' );
+
+agent_bundle_slug_matcher_assert(
+	isset( $flow_index['ambiguous']['ticketmaster'] ),
+	'four flows named "Ticketmaster" surface as ambiguous',
+	$failures,
+	$passes
+);
+agent_bundle_slug_matcher_assert(
+	4 === count( $flow_index['ambiguous']['ticketmaster'] ),
+	'all four colliding rows are recorded for the ambiguous slug',
+	$failures,
+	$passes
+);
+agent_bundle_slug_matcher_assert(
+	! isset( $flow_index['matched']['ticketmaster'] ),
+	'ambiguous slug is NOT placed in the matched map (no guessing)',
+	$failures,
+	$passes
+);
+agent_bundle_slug_matcher_assert(
+	isset( $flow_index['matched']['unique-flow'] ),
+	'unambiguous sibling still matches alongside ambiguous ones',
+	$failures,
+	$passes
+);
+
+// ---- 5. Rows with neither slug nor name are skipped, not keyed under ''. ----
+$blank = AgentBundleSlugMatcher::index_existing(
+	array( array( 'pipeline_id' => 1, 'pipeline_name' => '', 'portable_slug' => null ) ),
+	'pipeline_name',
+	'pipeline'
+);
+agent_bundle_slug_matcher_assert(
+	empty( $blank['matched'] ) && empty( $blank['ambiguous'] ),
+	'row with no slug and no name is skipped (never keyed under empty string)',
+	$failures,
+	$passes
+);
+
+// ---- 6. Acceptance: an all-NULL-portable_slug agent yields 0 would-create. --
+// Mirrors the adopt() matching loop on a fixture that reproduces the events-bot
+// shape (every live row portable_slug NULL). Before the fix, the existing map
+// keyed by '' and EVERY bundle artifact was classified new_artifact (would
+// INSERT a duplicate). After the fix, all resolve to matched / 0 unmatched.
+$live_all_null = array(
+	array( 'pipeline_id' => 11, 'pipeline_name' => 'Ticketmaster Columbus', 'portable_slug' => null ),
+	array( 'pipeline_id' => 12, 'pipeline_name' => 'Dice FM Austin', 'portable_slug' => null ),
+	array( 'pipeline_id' => 13, 'pipeline_name' => 'Bandsintown Nashville', 'portable_slug' => null ),
+);
+$bundle_pipelines = array(
+	array( 'original_id' => 1, 'pipeline_name' => 'Ticketmaster Columbus', 'portable_slug' => null ),
+	array( 'original_id' => 2, 'pipeline_name' => 'Dice FM Austin', 'portable_slug' => null ),
+	array( 'original_id' => 3, 'pipeline_name' => 'Bandsintown Nashville', 'portable_slug' => null ),
+);
+
+$accept_index = AgentBundleSlugMatcher::index_existing( $live_all_null, 'pipeline_name', 'pipeline' );
+$would_create = 0;
+$matched_cnt  = 0;
+foreach ( $bundle_pipelines as $bp ) {
+	$key = AgentBundleSlugMatcher::bundle_slug( $bp, 'pipeline_name', 'pipeline' );
+	if ( isset( $accept_index['matched'][ $key ] ) ) {
+		++$matched_cnt;
+	} else {
+		++$would_create;
+	}
+}
+
+agent_bundle_slug_matcher_assert(
+	3 === $matched_cnt,
+	'all-NULL agent: every bundle pipeline matches a live row',
+	$failures,
+	$passes
+);
+agent_bundle_slug_matcher_assert(
+	0 === $would_create,
+	'all-NULL agent: adopt dry-run would create 0 new artifacts (no duplication)',
+	$failures,
+	$passes
+);
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " agent bundle slug matcher assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} agent bundle slug matcher assertions passed.\n";
+}


### PR DESCRIPTION
Closes #2667.

## The problem

An agent **built live and then exported** into a bundle carries no package provenance: its pipeline/flow rows have `portable_slug` NULL, the `bundle_artifacts` ledger is empty, and `agent_config` has no `datamachine_bundle` header. `wp datamachine agent upgrade` then matches **zero** artifacts and classifies all of them as `new_artifact` — so the upgrade would **INSERT a full duplicate set** instead of updating. Confirmed on events-bot (agent 6, blog 7): 192 pipelines / 671 flows, all `portable_slug` NULL, dry-run = 863 `new_artifact`.

## Root cause: matching asymmetry

The bundle (target) side already fell back to a normalized name, but the existing/live side keyed by `portable_slug` only:

```php
// inc/Cli/Commands/AgentBundleCommand.php — BEFORE
// existing side (line ~669): portable_slug only → NULL rows key under '' and never match
$existing_pipelines_by_slug[ (string) ( $pipeline['portable_slug'] ?? '' ) ] = $pipeline;
// bundle side (line ~676): already falls back to normalized pipeline_name
$slug = PortableSlug::normalize( (string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ), 'pipeline' );
// flow side (line ~691/692): get_by_portable_slug() — no name fallback on the existing side
```

```php
// AFTER — both sides key under the SAME normalized slug via the shared matcher
$existing_pipelines_by_slug = AgentBundleSlugMatcher::index_existing(
    $this->pipelines()->get_all_pipelines( null, $agent_id ), 'pipeline_name', 'pipeline'
)['matched'];
$slug = AgentBundleSlugMatcher::bundle_slug( $pipeline, 'pipeline_name', 'pipeline' );
```

The same fix is applied in `AgentBundleLifecycleProjection::target_artifacts()` (the existing pipeline lookup **and** the flow `get_by_portable_slug()` call, now a per-pipeline name-fallback index) and in `AgentBundleAbilityService::runtime_drifts_for_bundle()`.

## What `agent adopt` does

New subcommand: `wp datamachine agent adopt <path> --agent=<slug>` (one-time, idempotent, `--dry-run`-able), wired through the new `datamachine/adopt-agent-bundle` ability mirroring install/upgrade. For an existing live agent it writes **all three provenance layers** plus the slug backfill:

1. **portable_slug backfill** — on each matched pipeline/flow row, from the normalized name.
2. **bundle header** — `agent_config['datamachine_bundle']`.
3. **ledger** — `bundle_artifacts` populated with `installed_hash = current_hash = hash of the CURRENT live state`, so the *next* `upgrade` shows real edits, not phantom `new_artifact`.

**Ambiguity is refused, not guessed.** When duplicate display names collide (e.g. events-bot's four flows all named "Ticketmaster"), they resolve to the same normalized slug; the matcher omits them from `matched` and reports them as `ambiguous`, and `adopt` fails with a clear error rather than binding to an arbitrary row.

## Verification (test fixture, not prod)

`tests/agent-bundle-slug-matcher-smoke.php` (pure PHP, `php tests/agent-bundle-slug-matcher-smoke.php`) — 14/14 pass. It includes an **all-`portable_slug`-NULL acceptance case** mirroring the events-bot shape: every bundle pipeline matches a live row and the adopt dry-run **would create 0 new artifacts** (before the fix, all would be `new_artifact`). It also asserts stored-slug precedence, the four-"Ticketmaster" ambiguity refusal, and that blank rows are never keyed under `''`.

Pre-existing related smokes (`agent-bundle-runtime-drift-smoke`) still pass. `agent-bundle-upgrade-planner-smoke` and `agent-bundle-template-upgrade-tracking-smoke` fail identically on `main` (standalone harness lacks the WP/package autoload) — confirmed by stashing this change and re-running; unrelated to this PR.

## Out of scope

`data-machine-events` is **untouched** — no events knowledge lives in core bundle code. No live data was modified; the events-bot repro was read-only.