### PR TITLE
feat: multisite-aware block-content abilities via optional blog_id

### DIFF
--- a/inc/Abilities/Content/BlogContext.php
+++ b/inc/Abilities/Content/BlogContext.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * BlogContext — multisite target-blog resolution for content abilities.
+ *
+ * The block-content abilities (`get_post_blocks`, `edit_post_blocks`,
+ * `replace_post_blocks`, `insert_content`) operate on a post by `post_id`.
+ * On a single-site install that post always lives on the only blog there is.
+ * On a multisite network the chat surface and the post can live on different
+ * blogs — e.g. a chat drawer running on one subsite editing a draft that was
+ * authored on the main site.
+ *
+ * Without a blog dimension the abilities silently resolve `post_id` against
+ * whatever blog the request landed on, which on multisite is the wrong post
+ * (or no post at all). This helper lets each ability accept an optional
+ * `blog_id` and run its post read/write inside `switch_to_blog()` when the
+ * target differs from the current blog.
+ *
+ * The dimension is deliberately scoped to the content abilities and their
+ * pending-action handlers — the generic PendingActionStore, PendingActionHelper,
+ * and ResolvePendingActionAbility need no change. `blog_id` rides inside the
+ * ability input (and, for staged edits, inside `apply_input`, which already
+ * round-trips through the store), so the same `switch_to_blog()` that runs the
+ * preview also runs the apply when the user accepts.
+ *
+ * On a non-multisite install, or when no `blog_id` is supplied, this helper is
+ * a no-op: every method falls through to the current blog and nothing switches.
+ *
+ * @package DataMachine\Abilities\Content
+ * @since   0.149.0
+ */
+
+namespace DataMachine\Abilities\Content;
+
+defined( 'ABSPATH' ) || exit;
+
+class BlogContext {
+
+	/**
+	 * Resolve the target blog id from an ability input array.
+	 *
+	 * Returns 0 when no targeting is requested or possible:
+	 *   - not a multisite install, or
+	 *   - no `blog_id` supplied, or
+	 *   - `blog_id` equals the current blog (no switch needed).
+	 *
+	 * A non-zero return means "switch to this blog for the post operation".
+	 * Validation of the blog's existence happens in switch_to(); this method
+	 * only normalizes intent.
+	 *
+	 * @param array $input Ability input. Reads the optional `blog_id` key.
+	 * @return int Target blog id to switch to, or 0 for "use current blog".
+	 */
+	public static function target_from_input( array $input ): int {
+		if ( ! is_multisite() ) {
+			return 0;
+		}
+
+		$blog_id = isset( $input['blog_id'] ) ? absint( $input['blog_id'] ) : 0;
+		if ( $blog_id <= 0 ) {
+			return 0;
+		}
+
+		if ( $blog_id === get_current_blog_id() ) {
+			return 0;
+		}
+
+		return $blog_id;
+	}
+
+	/**
+	 * Whether a target blog id refers to a real, usable site on the network.
+	 *
+	 * @param int $blog_id Candidate blog id.
+	 * @return bool
+	 */
+	public static function is_valid( int $blog_id ): bool {
+		if ( ! is_multisite() || $blog_id <= 0 ) {
+			return false;
+		}
+
+		$site = get_site( $blog_id );
+		if ( null === $site ) {
+			return false;
+		}
+
+		// Refuse archived/deleted/spam sites — there is no legitimate
+		// content-edit target there.
+		if ( (int) $site->archived === 1 || (int) $site->deleted === 1 || (int) $site->spam === 1 ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Switch to the target blog when one is requested, validating first.
+	 *
+	 * Returns a context token the caller passes to restore(). The token records
+	 * whether a switch actually happened so restore() is a safe no-op when it
+	 * didn't. Validation failure returns a WP_Error — the caller should surface
+	 * it rather than silently operating on the wrong blog.
+	 *
+	 * Usage:
+	 *
+	 *   $ctx = BlogContext::enter( $input );
+	 *   if ( is_wp_error( $ctx ) ) { return ...error...; }
+	 *   try {
+	 *       // post read/write runs in the target blog context
+	 *   } finally {
+	 *       BlogContext::leave( $ctx );
+	 *   }
+	 *
+	 * @param array $input Ability input (reads optional `blog_id`).
+	 * @return array{switched:bool,blog_id:int}|\WP_Error Context token, or error
+	 *                                                     when the blog is invalid.
+	 */
+	public static function enter( array $input ) {
+		$target = self::target_from_input( $input );
+
+		if ( $target <= 0 ) {
+			return array(
+				'switched' => false,
+				'blog_id'  => get_current_blog_id(),
+			);
+		}
+
+		if ( ! self::is_valid( $target ) ) {
+			return new \WP_Error(
+				'datamachine_invalid_blog',
+				sprintf(
+					/* translators: %d: requested blog id. */
+					__( 'Blog #%d is not a valid site on this network.', 'data-machine' ),
+					$target
+				)
+			);
+		}
+
+		switch_to_blog( $target );
+
+		return array(
+			'switched' => true,
+			'blog_id'  => $target,
+		);
+	}
+
+	/**
+	 * Add a `blog_id` key to an array only when it is a positive, meaningful
+	 * target.
+	 *
+	 * Used to stamp the resolved target blog into a staged action's
+	 * `apply_input` (and preview context) so the resolve-time replay re-enters
+	 * the same blog. A zero/absent blog_id is left out entirely so single-site
+	 * payloads stay clean and unchanged.
+	 *
+	 * @param array $data    Array to augment.
+	 * @param int   $blog_id Target blog id (0 = none).
+	 * @return array
+	 */
+	public static function with_blog_id( array $data, int $blog_id ): array {
+		if ( $blog_id > 0 ) {
+			$data['blog_id'] = $blog_id;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Restore the original blog context recorded by enter().
+	 *
+	 * Safe no-op when no switch happened.
+	 *
+	 * @param array|\WP_Error $ctx Context token from enter().
+	 * @return void
+	 */
+	public static function leave( $ctx ): void {
+		if ( is_array( $ctx ) && ! empty( $ctx['switched'] ) ) {
+			restore_current_blog();
+		}
+	}
+}

--- a/inc/Abilities/Content/BlogContext.php
+++ b/inc/Abilities/Content/BlogContext.php
@@ -60,7 +60,7 @@ class BlogContext {
 			return 0;
 		}
 
-		if ( $blog_id === get_current_blog_id() ) {
+		if ( get_current_blog_id() === $blog_id ) {
 			return 0;
 		}
 
@@ -85,7 +85,7 @@ class BlogContext {
 
 		// Refuse archived/deleted/spam sites — there is no legitimate
 		// content-edit target there.
-		if ( (int) $site->archived === 1 || (int) $site->deleted === 1 || (int) $site->spam === 1 ) {
+		if ( 1 === (int) $site->archived || 1 === (int) $site->deleted || 1 === (int) $site->spam ) {
 			return false;
 		}
 

--- a/inc/Abilities/Content/ContentActionHandlers.php
+++ b/inc/Abilities/Content/ContentActionHandlers.php
@@ -91,17 +91,32 @@ class ContentActionHandlers {
 			);
 		}
 
-		if ( $user_id > 0 ) {
-			if ( user_can( $user_id, 'edit_post', $post_id ) ) {
-				return true;
-			}
-		} elseif ( current_user_can( 'edit_post', $post_id ) ) {
-			return true;
+		// On multisite the staged post may live on another blog than the one
+		// the resolve request landed on. The `edit_post` meta-capability is
+		// mapped against the post (and its author) on the blog the post lives
+		// on, so the check must run in that blog's context — otherwise it
+		// evaluates against the wrong post id on the wrong site. blog_id was
+		// stamped into apply_input at staging time (see the content abilities).
+		$ctx = BlogContext::enter( $apply_input );
+		if ( is_wp_error( $ctx ) ) {
+			return $ctx;
 		}
 
-		return new \WP_Error(
-			'datamachine_forbidden',
-			__( 'You do not have permission to edit this post.', 'data-machine' )
-		);
+		try {
+			if ( $user_id > 0 ) {
+				if ( user_can( $user_id, 'edit_post', $post_id ) ) {
+					return true;
+				}
+			} elseif ( current_user_can( 'edit_post', $post_id ) ) {
+				return true;
+			}
+
+			return new \WP_Error(
+				'datamachine_forbidden',
+				__( 'You do not have permission to edit this post.', 'data-machine' )
+			);
+		} finally {
+			BlogContext::leave( $ctx );
+		}
 	}
 }

--- a/inc/Abilities/Content/EditPostBlocksAbility.php
+++ b/inc/Abilities/Content/EditPostBlocksAbility.php
@@ -49,6 +49,10 @@ class EditPostBlocksAbility {
 								'type'        => 'integer',
 								'description' => __( 'Post ID to edit', 'data-machine' ),
 							),
+							'blog_id' => array(
+								'type'        => 'integer',
+								'description' => __( 'Optional. Multisite blog ID the post lives on. Omit to use the current site. The edit (and its preview/apply) runs in that blog\'s context.', 'data-machine' ),
+							),
 							'edits'   => array(
 								'type'        => 'array',
 								'description' => __( 'Array of edit operations', 'data-machine' ),
@@ -134,6 +138,11 @@ class EditPostBlocksAbility {
 					'required'    => true,
 					'description' => 'Post ID to edit',
 				),
+				'blog_id' => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Optional multisite blog ID the post lives on. Omit for the current site.',
+				),
 				'edits'   => array(
 					'type'        => 'array',
 					'items'       => array(
@@ -181,7 +190,35 @@ class EditPostBlocksAbility {
 	 * @return array
 	 */
 	public static function execute( array $input ): array {
+		// Resolve the target blog. On multisite the post may live on another
+		// site than the one this request landed on; switch to it so the read,
+		// the preview staging, and the eventual apply all target the right
+		// post. blog_id rides inside apply_input below so the resolve replay
+		// re-enters the same context.
+		$ctx = BlogContext::enter( $input );
+		if ( is_wp_error( $ctx ) ) {
+			return array(
+				'success' => false,
+				'error'   => $ctx->get_error_message(),
+			);
+		}
+
+		try {
+			return self::execute_in_context( $input );
+		} finally {
+			BlogContext::leave( $ctx );
+		}
+	}
+
+	/**
+	 * Execute the edit within the (already-resolved) blog context.
+	 *
+	 * @param array $input Ability input.
+	 * @return array
+	 */
+	private static function execute_in_context( array $input ): array {
 		$post_id = absint( $input['post_id'] ?? 0 );
+		$blog_id = absint( $input['blog_id'] ?? 0 );
 		$edits   = $input['edits'] ?? array();
 		$preview = ! empty( $input['preview'] );
 
@@ -337,12 +374,15 @@ class EditPostBlocksAbility {
 					'action_id'    => $action_id,
 					'kind'         => 'edit_post_blocks',
 					'summary'      => sprintf( 'Preview edits to post #%d.', $post_id ),
-					'apply_input'  => array(
-						'post_id' => $post_id,
-						'edits'   => $edits,
+					'apply_input'  => BlogContext::with_blog_id(
+						array(
+							'post_id' => $post_id,
+							'edits'   => $edits,
+						),
+						$blog_id
 					),
 					'preview_data' => $diff,
-					'context'      => array( 'post_id' => $post_id ),
+					'context'      => BlogContext::with_blog_id( array( 'post_id' => $post_id ), $blog_id ),
 				)
 			);
 

--- a/inc/Abilities/Content/GetPostBlocksAbility.php
+++ b/inc/Abilities/Content/GetPostBlocksAbility.php
@@ -47,6 +47,10 @@ class GetPostBlocksAbility {
 								'type'        => 'integer',
 								'description' => __( 'Post ID to parse', 'data-machine' ),
 							),
+							'blog_id'     => array(
+								'type'        => 'integer',
+								'description' => __( 'Optional. Multisite blog ID the post lives on. Omit to use the current site. The read runs in that blog\'s context.', 'data-machine' ),
+							),
 							'block_types' => array(
 								'type'        => 'array',
 								'items'       => array( 'type' => 'string' ),
@@ -122,6 +126,11 @@ class GetPostBlocksAbility {
 					'required'    => true,
 					'description' => 'Post ID to parse',
 				),
+				'blog_id'     => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Optional multisite blog ID the post lives on. Omit for the current site.',
+				),
 				'block_types' => array(
 					'type'        => 'array',
 					'items'       => array( 'type' => 'string' ),
@@ -173,56 +182,70 @@ class GetPostBlocksAbility {
 			);
 		}
 
-		$post = get_post( $post_id );
-		if ( ! $post ) {
+		// Resolve the target blog. On multisite the post may live on another
+		// site than the one this request landed on; switch to it for the read.
+		$ctx = BlogContext::enter( $input );
+		if ( is_wp_error( $ctx ) ) {
 			return array(
 				'success' => false,
-				'error'   => sprintf( 'Post #%d does not exist', $post_id ),
+				'error'   => $ctx->get_error_message(),
 			);
 		}
 
-		$block_content = ContentFormat::storedToBlocks( (string) $post->post_content, (string) $post->post_type );
-		if ( is_wp_error( $block_content ) ) {
+		try {
+			$post = get_post( $post_id );
+			if ( ! $post ) {
+				return array(
+					'success' => false,
+					'error'   => sprintf( 'Post #%d does not exist', $post_id ),
+				);
+			}
+
+			$block_content = ContentFormat::storedToBlocks( (string) $post->post_content, (string) $post->post_type );
+			if ( is_wp_error( $block_content ) ) {
+				return array(
+					'success' => false,
+					'error'   => $block_content->get_error_message(),
+				);
+			}
+
+			$blocks  = parse_blocks( $block_content );
+			$results = array();
+
+			foreach ( $blocks as $index => $block ) {
+				// Skip empty/freeform blocks with no content.
+				$block_name = $block['blockName'] ?? null;
+				$inner_html = $block['innerHTML'] ?? '';
+
+				if ( null === $block_name && '' === trim( $inner_html ) ) {
+					continue;
+				}
+
+				// Filter by block type if specified.
+				if ( ! empty( $block_types ) && ! in_array( $block_name, $block_types, true ) ) {
+					continue;
+				}
+
+				// Filter by search text if specified.
+				if ( '' !== $search && false === stripos( $inner_html, $search ) ) {
+					continue;
+				}
+
+				$results[] = array(
+					'index'      => $index,
+					'block_name' => $block_name ?? 'core/freeform',
+					'inner_html' => $inner_html,
+				);
+			}
+
 			return array(
-				'success' => false,
-				'error'   => $block_content->get_error_message(),
+				'success'      => true,
+				'post_id'      => $post_id,
+				'total_blocks' => count( $blocks ),
+				'blocks'       => $results,
 			);
+		} finally {
+			BlogContext::leave( $ctx );
 		}
-
-		$blocks  = parse_blocks( $block_content );
-		$results = array();
-
-		foreach ( $blocks as $index => $block ) {
-			// Skip empty/freeform blocks with no content.
-			$block_name = $block['blockName'] ?? null;
-			$inner_html = $block['innerHTML'] ?? '';
-
-			if ( null === $block_name && '' === trim( $inner_html ) ) {
-				continue;
-			}
-
-			// Filter by block type if specified.
-			if ( ! empty( $block_types ) && ! in_array( $block_name, $block_types, true ) ) {
-				continue;
-			}
-
-			// Filter by search text if specified.
-			if ( '' !== $search && false === stripos( $inner_html, $search ) ) {
-				continue;
-			}
-
-			$results[] = array(
-				'index'      => $index,
-				'block_name' => $block_name ?? 'core/freeform',
-				'inner_html' => $inner_html,
-			);
-		}
-
-		return array(
-			'success'      => true,
-			'post_id'      => $post_id,
-			'total_blocks' => count( $blocks ),
-			'blocks'       => $results,
-		);
 	}
 }

--- a/inc/Abilities/Content/InsertContentAbility.php
+++ b/inc/Abilities/Content/InsertContentAbility.php
@@ -52,6 +52,10 @@ class InsertContentAbility {
 								'type'        => 'integer',
 								'description' => 'The post to insert content into.',
 							),
+							'blog_id'               => array(
+								'type'        => 'integer',
+								'description' => 'Optional. Multisite blog ID the post lives on. Omit to use the current site. The insertion (and its preview/apply) runs in that blog\'s context.',
+							),
 							'content'               => array(
 								'type'        => 'string',
 								'description' => 'The new content to insert (will be wrapped in WordPress paragraph blocks).',
@@ -121,6 +125,10 @@ class InsertContentAbility {
 					'type'        => 'integer',
 					'description' => 'The post ID to insert content into.',
 				),
+				'blog_id'               => array(
+					'type'        => 'integer',
+					'description' => 'Optional multisite blog ID the post lives on. Omit for the current site.',
+				),
 				'content'               => array(
 					'type'        => 'string',
 					'description' => 'The new content to insert (wrapped in paragraph blocks automatically).',
@@ -158,7 +166,35 @@ class InsertContentAbility {
 	 * @return array Result with canonical diff preview data.
 	 */
 	public static function execute( array $input ): array {
+		// Resolve the target blog. On multisite the post may live on another
+		// site than the one this request landed on; switch to it so the read,
+		// the edit_post capability check, the preview staging, and the eventual
+		// apply all target the right post. blog_id rides inside apply_input
+		// below so the resolve replay re-enters the same context.
+		$ctx = BlogContext::enter( $input );
+		if ( is_wp_error( $ctx ) ) {
+			return array(
+				'success' => false,
+				'error'   => $ctx->get_error_message(),
+			);
+		}
+
+		try {
+			return self::execute_in_context( $input );
+		} finally {
+			BlogContext::leave( $ctx );
+		}
+	}
+
+	/**
+	 * Execute the insertion within the (already-resolved) blog context.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result with canonical diff preview data.
+	 */
+	private static function execute_in_context( array $input ): array {
 		$post_id               = absint( $input['post_id'] ?? 0 );
+		$blog_id               = absint( $input['blog_id'] ?? 0 );
 		$content               = $input['content'] ?? '';
 		$position              = $input['position'] ?? 'end';
 		$target_paragraph_text = $input['target_paragraph_text'] ?? '';
@@ -295,14 +331,17 @@ class InsertContentAbility {
 				'action_id'    => $action_id,
 				'kind'         => 'insert_content',
 				'summary'      => sprintf( 'Preview content insertion %s on post #%d.', $insertion_point, $post_id ),
-				'apply_input'  => array(
-					'post_id'               => $post_id,
-					'content'               => $content,
-					'position'              => $position,
-					'target_paragraph_text' => $target_paragraph_text,
+				'apply_input'  => BlogContext::with_blog_id(
+					array(
+						'post_id'               => $post_id,
+						'content'               => $content,
+						'position'              => $position,
+						'target_paragraph_text' => $target_paragraph_text,
+					),
+					$blog_id
 				),
 				'preview_data' => $diff,
-				'context'      => array( 'post_id' => $post_id ),
+				'context'      => BlogContext::with_blog_id( array( 'post_id' => $post_id ), $blog_id ),
 			)
 		);
 

--- a/inc/Abilities/Content/ReplacePostBlocksAbility.php
+++ b/inc/Abilities/Content/ReplacePostBlocksAbility.php
@@ -48,6 +48,10 @@ class ReplacePostBlocksAbility {
 								'type'        => 'integer',
 								'description' => __( 'Post ID to edit', 'data-machine' ),
 							),
+							'blog_id'      => array(
+								'type'        => 'integer',
+								'description' => __( 'Optional. Multisite blog ID the post lives on. Omit to use the current site. The replacement (and its preview/apply) runs in that blog\'s context.', 'data-machine' ),
+							),
 							'replacements' => array(
 								'type'        => 'array',
 								'description' => __( 'Array of block replacement operations', 'data-machine' ),
@@ -129,6 +133,11 @@ class ReplacePostBlocksAbility {
 					'required'    => true,
 					'description' => 'Post ID to edit',
 				),
+				'blog_id'      => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Optional multisite blog ID the post lives on. Omit for the current site.',
+				),
 				'replacements' => array(
 					'type'        => 'array',
 					'items'       => array(
@@ -175,7 +184,35 @@ class ReplacePostBlocksAbility {
 	 * @return array
 	 */
 	public static function execute( array $input ): array {
+		// Resolve the target blog. On multisite the post may live on another
+		// site than the one this request landed on; switch to it so the read,
+		// the preview staging, and the eventual apply all target the right
+		// post. blog_id rides inside apply_input below so the resolve replay
+		// re-enters the same context.
+		$ctx = BlogContext::enter( $input );
+		if ( is_wp_error( $ctx ) ) {
+			return array(
+				'success' => false,
+				'error'   => $ctx->get_error_message(),
+			);
+		}
+
+		try {
+			return self::execute_in_context( $input );
+		} finally {
+			BlogContext::leave( $ctx );
+		}
+	}
+
+	/**
+	 * Execute the replacement within the (already-resolved) blog context.
+	 *
+	 * @param array $input Ability input.
+	 * @return array
+	 */
+	private static function execute_in_context( array $input ): array {
 		$post_id      = absint( $input['post_id'] ?? 0 );
+		$blog_id      = absint( $input['blog_id'] ?? 0 );
 		$replacements = $input['replacements'] ?? array();
 		$preview      = ! empty( $input['preview'] );
 
@@ -317,12 +354,15 @@ class ReplacePostBlocksAbility {
 					'action_id'    => $action_id,
 					'kind'         => 'replace_post_blocks',
 					'summary'      => sprintf( 'Preview block replacements on post #%d.', $post_id ),
-					'apply_input'  => array(
-						'post_id'      => $post_id,
-						'replacements' => $replacements,
+					'apply_input'  => BlogContext::with_blog_id(
+						array(
+							'post_id'      => $post_id,
+							'replacements' => $replacements,
+						),
+						$blog_id
 					),
 					'preview_data' => $diff,
-					'context'      => array( 'post_id' => $post_id ),
+					'context'      => BlogContext::with_blog_id( array( 'post_id' => $post_id ), $blog_id ),
 				)
 			);
 

--- a/tests/blog-context-content-smoke.php
+++ b/tests/blog-context-content-smoke.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Smoke test for BlogContext multisite targeting in content abilities.
+ *
+ * Exercises the target-resolution, validation, switch/restore, and
+ * apply_input stamping logic that lets the block-content abilities edit a
+ * post that lives on a different blog than the request landed on.
+ *
+ * Run with: php tests/blog-context-content-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! defined( 'STDERR' ) ) {
+	define( 'STDERR', fopen( 'php://stderr', 'w' ) );
+}
+
+// --- Minimal WordPress multisite stubs -------------------------------------
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private $data;
+
+		public function __construct( string $code = '', string $message = '', $data = null ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data() {
+			return $this->data;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ): int {
+		return abs( (int) $value );
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = 'default' ) {
+		return $text;
+	}
+}
+
+// Mutable test world: the current blog plus a registry of network sites.
+$GLOBALS['__test_is_multisite']   = true;
+$GLOBALS['__test_current_blog']   = 1;
+$GLOBALS['__test_switch_stack']   = array();
+$GLOBALS['__test_sites']          = array(
+	1  => (object) array( 'archived' => 0, 'deleted' => 0, 'spam' => 0 ),
+	12 => (object) array( 'archived' => 0, 'deleted' => 0, 'spam' => 0 ),
+	99 => (object) array( 'archived' => 1, 'deleted' => 0, 'spam' => 0 ), // archived
+);
+
+if ( ! function_exists( 'is_multisite' ) ) {
+	function is_multisite(): bool {
+		return (bool) $GLOBALS['__test_is_multisite'];
+	}
+}
+
+if ( ! function_exists( 'get_current_blog_id' ) ) {
+	function get_current_blog_id(): int {
+		return (int) $GLOBALS['__test_current_blog'];
+	}
+}
+
+if ( ! function_exists( 'get_site' ) ) {
+	function get_site( $blog_id ) {
+		return $GLOBALS['__test_sites'][ (int) $blog_id ] ?? null;
+	}
+}
+
+if ( ! function_exists( 'switch_to_blog' ) ) {
+	function switch_to_blog( $blog_id ): bool {
+		$GLOBALS['__test_switch_stack'][] = (int) $GLOBALS['__test_current_blog'];
+		$GLOBALS['__test_current_blog']   = (int) $blog_id;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'restore_current_blog' ) ) {
+	function restore_current_blog(): bool {
+		if ( empty( $GLOBALS['__test_switch_stack'] ) ) {
+			return false;
+		}
+		$GLOBALS['__test_current_blog'] = (int) array_pop( $GLOBALS['__test_switch_stack'] );
+		return true;
+	}
+}
+
+require_once __DIR__ . '/../inc/Abilities/Content/BlogContext.php';
+
+use DataMachine\Abilities\Content\BlogContext;
+
+$failed = 0;
+$total  = 0;
+
+$assert = static function ( string $label, bool $condition ) use ( &$failed, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+	++$failed;
+	echo "FAIL: {$label}\n";
+};
+
+// --- target_from_input ------------------------------------------------------
+
+$GLOBALS['__test_current_blog'] = 1;
+$assert( 'no blog_id resolves to current blog (0)', 0 === BlogContext::target_from_input( array() ) );
+$assert( 'blog_id matching current blog resolves to 0', 0 === BlogContext::target_from_input( array( 'blog_id' => 1 ) ) );
+$assert( 'cross-blog blog_id resolves to that blog', 12 === BlogContext::target_from_input( array( 'blog_id' => 12 ) ) );
+$assert( 'zero blog_id resolves to 0', 0 === BlogContext::target_from_input( array( 'blog_id' => 0 ) ) );
+
+$GLOBALS['__test_is_multisite'] = false;
+$assert( 'single-site install never targets a blog', 0 === BlogContext::target_from_input( array( 'blog_id' => 12 ) ) );
+$GLOBALS['__test_is_multisite'] = true;
+
+// --- is_valid ---------------------------------------------------------------
+
+$assert( 'valid network site passes', BlogContext::is_valid( 12 ) );
+$assert( 'unknown site id fails', ! BlogContext::is_valid( 7 ) );
+$assert( 'archived site fails', ! BlogContext::is_valid( 99 ) );
+$assert( 'zero blog id fails', ! BlogContext::is_valid( 0 ) );
+
+// --- enter / leave (switch + restore) --------------------------------------
+
+$GLOBALS['__test_current_blog'] = 1;
+$ctx = BlogContext::enter( array( 'blog_id' => 12 ) );
+$assert( 'enter() switches to the target blog', 12 === get_current_blog_id() );
+$assert( 'enter() reports switched=true', is_array( $ctx ) && true === $ctx['switched'] );
+BlogContext::leave( $ctx );
+$assert( 'leave() restores the original blog', 1 === get_current_blog_id() );
+
+// enter() with no target is a no-op.
+$ctx_noop = BlogContext::enter( array() );
+$assert( 'enter() with no target does not switch', 1 === get_current_blog_id() );
+$assert( 'enter() no-op reports switched=false', is_array( $ctx_noop ) && false === $ctx_noop['switched'] );
+BlogContext::leave( $ctx_noop );
+$assert( 'leave() on a no-op token keeps the current blog', 1 === get_current_blog_id() );
+
+// enter() on an invalid blog returns WP_Error and does NOT switch.
+$ctx_err = BlogContext::enter( array( 'blog_id' => 99 ) );
+$assert( 'enter() on an invalid blog returns WP_Error', is_wp_error( $ctx_err ) );
+$assert( 'enter() on an invalid blog does not switch', 1 === get_current_blog_id() );
+
+// Nested restore correctness: a stray leave() on an error token must not pop.
+BlogContext::leave( $ctx_err );
+$assert( 'leave() ignores a WP_Error token (no stray restore)', 1 === get_current_blog_id() );
+
+// --- with_blog_id (apply_input stamping) -----------------------------------
+
+$stamped = BlogContext::with_blog_id( array( 'post_id' => 5 ), 12 );
+$assert( 'with_blog_id stamps a positive blog id', 12 === ( $stamped['blog_id'] ?? null ) );
+$assert( 'with_blog_id preserves existing keys', 5 === ( $stamped['post_id'] ?? null ) );
+
+$unstamped = BlogContext::with_blog_id( array( 'post_id' => 5 ), 0 );
+$assert( 'with_blog_id omits a zero blog id', ! array_key_exists( 'blog_id', $unstamped ) );
+
+// --- round-trip: stamp then re-enter (mirrors stage -> resolve replay) ------
+
+$GLOBALS['__test_current_blog'] = 12; // resolve turn lands on the chat-surface blog
+$apply_input                    = BlogContext::with_blog_id( array( 'post_id' => 5 ), 1 );
+$ctx_replay                     = BlogContext::enter( $apply_input );
+$assert( 'resolve replay re-enters the stamped target blog', 1 === get_current_blog_id() );
+BlogContext::leave( $ctx_replay );
+$assert( 'resolve replay restores the calling blog', 12 === get_current_blog_id() );
+
+if ( $failed > 0 ) {
+	echo "=== blog-context-content-smoke: {$failed} FAIL of {$total} ===\n";
+	exit( 1 );
+}
+
+echo "=== blog-context-content-smoke: ALL PASS ({$total}) ===\n";


### PR DESCRIPTION
## Summary

Makes Data Machine's block-content editing stack **multisite-aware**. The four content abilities — `get_post_blocks`, `edit_post_blocks`, `replace_post_blocks`, `insert_content` — now accept an optional `blog_id` and run their post read/write (and the staged preview→apply cycle) in that blog's context via `switch_to_blog()`.

### The gap this closes

The content abilities resolved `post_id` against **whatever blog the request landed on**. On a single-site install that's always correct. On a multisite network where the chat surface and the post live on **different** blogs, it silently targeted the wrong post (or no post at all):

- `get_post()` / `wp_update_post()` / `current_user_can('edit_post', …)` are all current-blog-scoped.
- `PendingActionStore` is `$wpdb->prefix`-scoped (per-blog), so a staged diff lives in the *calling* blog's table.
- Both the propose turn **and** the accept/reject resolve turn land on the calling blog — so even when a diff card is staged, the apply hits the calling blog's post id.

This surfaced building a chat writing-assistant that edits a draft authored on the main site from a chat drawer running on another subsite (extrachill-roadie#48). The diff/accept-reject substrate (agents-api pending actions + chat DiffCards) is already generic; the missing piece was a **target-blog dimension** on the content layer.

### Design — minimal, content-layer-scoped

`blog_id` is threaded **only** through the content abilities and their pending-action handlers. The generic primitives are untouched:

- **No change** to `PendingActionStore`, `PendingActionHelper`, or `ResolvePendingActionAbility`.
- `blog_id` rides inside the ability input and, for staged edits, inside `apply_input` — which already round-trips through the per-blog store. The store is staged and resolved on the **same** (calling) blog, so no cross-blog store lookup is needed; the ability's own `switch_to_blog()` re-targets the post on both preview and apply.
- `ContentActionHandlers::can_resolve_post_edit()` switches to the target blog before the `edit_post` meta-cap check, since that capability is mapped against the post (and its author) on the blog it lives on.

A new shared `BlogContext` helper centralizes:
- target resolution (`target_from_input`) — returns 0 (no switch) on single-site, when `blog_id` is omitted, or when it equals the current blog;
- network-site validation (`is_valid`) — rejects unknown, archived, deleted, and spam sites;
- safe switch/restore (`enter`/`leave`) with a context token so `leave()` is a no-op when no switch happened (and ignores `WP_Error` tokens — no stray `restore_current_blog()`);
- `apply_input`/context stamping (`with_blog_id`) that omits a zero/absent blog_id so single-site payloads stay byte-identical.

Backward compatible: omit `blog_id` (or run on single-site) and behavior is unchanged.

## What changed

- **`inc/Abilities/Content/BlogContext.php`** (new) — the shared targeting/validation/switch helper.
- **`GetPostBlocksAbility`**, **`EditPostBlocksAbility`**, **`ReplacePostBlocksAbility`**, **`InsertContentAbility`** — added `blog_id` to ability input schema + chat-tool params; wrapped the post read/write in `BlogContext::enter()/leave()`; stamped `blog_id` into staged `apply_input` + preview context. Edit/Replace/Insert split their `execute()` into a thin context-entering wrapper + `execute_in_context()` so the switch/restore is guaranteed by `finally` with minimal churn.
- **`ContentActionHandlers`** — `can_resolve_post_edit()` now switches to the staged `blog_id` before the `edit_post` capability check.

## Tests

- **`tests/blog-context-content-smoke.php`** (new, 23 assertions, all pass) — covers target resolution (single-site no-op, same-blog no-op, cross-blog target), network-site validation (valid / unknown / archived / zero), enter/leave switch + restore, no-op tokens, `WP_Error` tokens, `with_blog_id` stamping/omission, and the **stage→resolve replay round-trip** (stamp on blog 1 while the resolve turn lands on blog 12, confirm it re-enters blog 1 and restores blog 12).
- `php -l` clean on all six touched/added files; `phpcs` (project ruleset) **0 findings** on all of them incl. the new test.

### CI note
The pre-existing `pending-action-helper-approval-envelope-smoke.php` fails identically on clean `main` (it depends on the agents-api package absent from a bare `composer install`) — unrelated to this change, confirmed by reproducing on a fresh clone. Matches the known standalone-smoke fixture debt.

## Manual acceptance

On a multisite network, from a chat surface on blog B editing a draft `#N` that lives on blog A:
1. `get_post_blocks` with `{post_id: N, blog_id: A}` returns blog A's blocks (not blog B's post N).
2. `edit_post_blocks` with `{post_id: N, blog_id: A, edits: […], preview: true}` stages a diff; on accept (`resolve_pending_action`) the edit applies to blog A's post N, and the `edit_post` gate is evaluated on blog A.
3. Omitting `blog_id` (or on single-site) behaves exactly as before.

## Follow-up

Unblocks extrachill-roadie#48 (Roadie writing-assistant editing a Studio draft on main) and any multisite DM install that wants cross-site inline content edits. The Roadie integration lands as a separate PR on top of this.