### PR TITLE
fix: key bundle artifact matcher + adopt backfill on the unique slug

### DIFF
--- a/inc/Engine/Bundle/AgentBundleSlugMatcher.php
+++ b/inc/Engine/Bundle/AgentBundleSlugMatcher.php
@@ -13,14 +13,17 @@ defined( 'ABSPATH' ) || exit;
  * Builds a normalized lookup of existing pipeline/flow rows that mirrors the
  * key the bundle (target) side uses.
  *
- * The bundle side already keys artifacts by
- * `PortableSlug::normalize( portable_slug ?: display_name )`. The existing /
- * live side historically keyed only by the stored `portable_slug`, so rows with
- * a NULL/empty `portable_slug` (every row on a live-origin agent exported into a
+ * The bundle side keys artifacts by
+ * `PortableSlug::normalize( portable_slug ?: slug ?: display_name )` — the
+ * artifact's UNIQUE `slug` is preferred over the non-unique display name, the
+ * same identity the upgrade planner keys its ledger on. The existing / live
+ * side historically keyed only by the stored `portable_slug`, so rows with a
+ * NULL/empty `portable_slug` (every row on a live-origin agent exported into a
  * bundle) were keyed under `''` and never matched. This helper closes that
  * asymmetry: it keys each existing row under the SAME normalized slug the bundle
  * side computes, falling back to the normalized display name when the stored
- * `portable_slug` is empty.
+ * `portable_slug` is empty. Once adopt backfills the bundle's unique slug into
+ * `portable_slug`, both sides agree on the unique identity.
  *
  * Pure and persistence-free so it can be unit-tested directly.
  */
@@ -79,8 +82,13 @@ final class AgentBundleSlugMatcher {
 	/**
 	 * Compute the effective normalized slug for a single existing row.
 	 *
-	 * Mirrors the bundle-side key: prefer the stored `portable_slug`, fall back
-	 * to the normalized display name when it is empty.
+	 * The stored `portable_slug` is the row's IDENTITY; the display name is only
+	 * a LABEL (and for flows it is non-unique by design). So this prefers the
+	 * stored `portable_slug` and only falls back to the normalized display name
+	 * when it is empty. After a correct {@see AgentBundleAbilityService::adopt()}
+	 * backfills `portable_slug` from the bundle artifact's unique
+	 * {@see self::bundle_slug()} value, this and `bundle_slug()` resolve to the
+	 * same unique identity, so the round-trip matches deterministically.
 	 *
 	 * @param array<string,mixed> $row      Existing pipeline or flow row.
 	 * @param string              $name_key Display-name field.
@@ -104,13 +112,33 @@ final class AgentBundleSlugMatcher {
 	/**
 	 * Compute the normalized slug the bundle (target) side uses for an artifact.
 	 *
+	 * Precedence: `portable_slug` -> `slug` -> display name. The bundle flow /
+	 * pipeline file carries a UNIQUE `slug` (the portable identity, e.g.
+	 * `ticketmaster`, `ticketmaster-4`) that the upgrade planner already keys
+	 * the ledger on. The display name is a NON-UNIQUE label — for flows it is
+	 * the source/handler ("Ticketmaster", "Dice.fm"), shared by hundreds of
+	 * rows — so keying on it collapses distinct artifacts into one slug and
+	 * makes adopt refuse them as ambiguous. Preferring the artifact's own
+	 * `slug` before the display name keeps the bundle side keyed on the same
+	 * unique identity the ledger uses, so same-named flows match deterministically.
+	 *
 	 * @param array<string,mixed> $artifact Bundle pipeline or flow entry.
 	 * @param string              $name_key Display-name field (pipeline_name / flow_name).
 	 * @param string              $fallback PortableSlug fallback (pipeline / flow).
 	 * @return string Normalized slug.
 	 */
 	public static function bundle_slug( array $artifact, string $name_key, string $fallback ): string {
-		$candidate = (string) ( $artifact['portable_slug'] ?? ( $artifact[ $name_key ] ?? $fallback ) );
+		$portable = trim( (string) ( $artifact['portable_slug'] ?? '' ) );
+		if ( '' !== $portable ) {
+			return PortableSlug::normalize( $portable, $fallback );
+		}
+
+		$slug = trim( (string) ( $artifact['slug'] ?? '' ) );
+		if ( '' !== $slug ) {
+			return PortableSlug::normalize( $slug, $fallback );
+		}
+
+		$candidate = (string) ( $artifact[ $name_key ] ?? $fallback );
 
 		return PortableSlug::normalize( $candidate, $fallback );
 	}

--- a/tests/agent-bundle-slug-matcher-smoke.php
+++ b/tests/agent-bundle-slug-matcher-smoke.php
@@ -190,6 +190,128 @@ agent_bundle_slug_matcher_assert(
 	$passes
 );
 
+// ---- 7. bundle_slug() prefers the artifact's UNIQUE slug over display name. -
+// Mirrors events-bot: hundreds of flows share the display name "Ticketmaster"
+// but each bundle flow artifact carries a DISTINCT unique `slug`
+// (ticketmaster, ticketmaster-4, ...). Keying on the unique slug instead of the
+// non-unique name means they resolve to distinct keys → 0 ambiguous, all match.
+$same_name_flows = array(
+	array( 'original_id' => 1, 'flow_name' => 'Ticketmaster', 'slug' => 'ticketmaster' ),
+	array( 'original_id' => 2, 'flow_name' => 'Ticketmaster', 'slug' => 'ticketmaster-4' ),
+	array( 'original_id' => 3, 'flow_name' => 'Ticketmaster', 'slug' => 'ticketmaster-9' ),
+	array( 'original_id' => 4, 'flow_name' => 'Dice.fm', 'slug' => 'dice-fm' ),
+	array( 'original_id' => 5, 'flow_name' => 'Dice.fm', 'slug' => 'dice-fm-2' ),
+);
+
+$bundle_slugs = array();
+foreach ( $same_name_flows as $bundle_flow ) {
+	$bundle_slugs[] = AgentBundleSlugMatcher::bundle_slug( $bundle_flow, 'flow_name', 'flow' );
+}
+
+agent_bundle_slug_matcher_assert(
+	array( 'ticketmaster', 'ticketmaster-4', 'ticketmaster-9', 'dice-fm', 'dice-fm-2' ) === $bundle_slugs,
+	'same-named flows with distinct slugs resolve to distinct bundle slugs',
+	$failures,
+	$passes
+);
+agent_bundle_slug_matcher_assert(
+	count( array_unique( $bundle_slugs ) ) === count( $bundle_slugs ),
+	'no two same-named flows collapse onto the same bundle slug (0 ambiguous)',
+	$failures,
+	$passes
+);
+
+// The matching live rows: NULL portable_slug, duplicate flow_name, but the
+// adopt backfill will write each unique bundle slug into portable_slug. Index
+// the POST-backfill rows (portable_slug = the unique bundle slug) and confirm
+// every bundle artifact resolves to exactly one live row.
+$post_backfill_live = array();
+foreach ( $same_name_flows as $i => $bundle_flow ) {
+	$post_backfill_live[] = array(
+		'flow_id'       => 100 + $i,
+		'flow_name'     => $bundle_flow['flow_name'],
+		'portable_slug' => $bundle_slugs[ $i ],
+	);
+}
+$post_index   = AgentBundleSlugMatcher::index_existing( $post_backfill_live, 'flow_name', 'flow' );
+$matched_all  = 0;
+$ambiguous_ct = count( $post_index['ambiguous'] );
+foreach ( $bundle_slugs as $key ) {
+	if ( isset( $post_index['matched'][ $key ] ) ) {
+		++$matched_all;
+	}
+}
+agent_bundle_slug_matcher_assert(
+	5 === $matched_all && 0 === $ambiguous_ct,
+	'events-bot shape: all 5 same-named flows match their unique slug, 0 ambiguous',
+	$failures,
+	$passes
+);
+
+// ---- 8. Degenerate fallback: NO slug + duplicate names still refuses. -------
+// Preserves #2668's four-"Ticketmaster" guarantee for the genuinely slug-less
+// case — when there is nothing unique to key on, adopt must still refuse.
+$slugless_dupes = array(
+	array( 'flow_id' => 1, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+	array( 'flow_id' => 2, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+	array( 'flow_id' => 3, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+	array( 'flow_id' => 4, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+);
+$slugless_index = AgentBundleSlugMatcher::index_existing( $slugless_dupes, 'flow_name', 'flow' );
+agent_bundle_slug_matcher_assert(
+	isset( $slugless_index['ambiguous']['ticketmaster'] ) && ! isset( $slugless_index['matched']['ticketmaster'] ),
+	'degenerate (no slug + duplicate names) still refuses as ambiguous',
+	$failures,
+	$passes
+);
+// And the slug-less bundle artifact (no portable_slug, no slug) keys on name.
+$slugless_artifact = AgentBundleSlugMatcher::bundle_slug(
+	array( 'flow_name' => 'Ticketmaster' ),
+	'flow_name',
+	'flow'
+);
+agent_bundle_slug_matcher_assert(
+	'ticketmaster' === $slugless_artifact,
+	'slug-less bundle artifact falls back to the normalized display name',
+	$failures,
+	$passes
+);
+
+// ---- 9. bundle_slug() precedence: portable_slug > slug > display_name. ------
+$precedence_all = AgentBundleSlugMatcher::bundle_slug(
+	array( 'flow_name' => 'Display Name', 'slug' => 'from-slug', 'portable_slug' => 'from-portable' ),
+	'flow_name',
+	'flow'
+);
+agent_bundle_slug_matcher_assert(
+	'from-portable' === $precedence_all,
+	'precedence: portable_slug wins over slug and display name',
+	$failures,
+	$passes
+);
+$precedence_slug = AgentBundleSlugMatcher::bundle_slug(
+	array( 'flow_name' => 'Display Name', 'slug' => 'from-slug', 'portable_slug' => '' ),
+	'flow_name',
+	'flow'
+);
+agent_bundle_slug_matcher_assert(
+	'from-slug' === $precedence_slug,
+	'precedence: slug wins over display name when portable_slug is empty',
+	$failures,
+	$passes
+);
+$precedence_name = AgentBundleSlugMatcher::bundle_slug(
+	array( 'flow_name' => 'Display Name', 'slug' => '', 'portable_slug' => '' ),
+	'flow_name',
+	'flow'
+);
+agent_bundle_slug_matcher_assert(
+	'display-name' === $precedence_name,
+	'precedence: display name used only when both portable_slug and slug are empty',
+	$failures,
+	$passes
+);
+
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " agent bundle slug matcher assertions failed.\n";
 	exit( 1 );


### PR DESCRIPTION
Closes #2670.

## The inconsistency

PR #2668 added `AgentBundleSlugMatcher`, keying both sides on `portable_slug ?: display_name`. But the upgrade *planner* already keys its ledger on the artifact's **unique** `slug` (`AgentBundleUpgradePlanner.php:74` → `'artifact_id' => $flow->slug()`). So today:

| side | keyed on | before |
|---|---|---|
| ledger (planner:74) | unique **slug** (`ticketmaster`, `ticketmaster-4`) | ✅ deterministic |
| live-row matcher (`bundle_slug()`) | non-unique **display name** | ❌ collapses |

For flows the display name is the source/handler label ("Ticketmaster", "Dice.fm"), non-unique by design. On the events-bot bundle (671 flows) name-normalization collapses **374 of 671** flows onto 3 slugs (`ticketmaster` ×189, `dice-fm` ×182, `dice` ×3), so `adopt` refuses nearly the whole bundle as ambiguous — even though every flow file already carries a distinct unique `slug`.

## The fix

**New precedence `portable_slug > slug > display_name`**, applied in **both** places that resolve a bundle artifact's key:

1. **`AgentBundleSlugMatcher::bundle_slug()`** — prefers the artifact's own unique `slug` field before falling back to the display name. `PortableSlug::normalize()` still applied. Pipelines are unaffected (their display names are already unique) but also carry a `slug`, so they get the same deterministic treatment.
2. **Adopt backfill value** — `AgentBundleAbilityService::adopt()` derives the `portable_slug` it writes onto each matched live pipeline/flow row from the **same** `bundle_slug()` result (`$slug_key`). So the value backfilled into `portable_slug` is now the unique bundle slug, not the normalized display name — which is exactly what makes future `upgrade` runs match deterministically.

`effective_slug()` (existing/live side) is unchanged in spirit — it already prefers the stored `portable_slug`. Once adopt backfills the unique bundle slug into `portable_slug`, `effective_slug()` and `bundle_slug()` resolve to the same identity, so the round-trip matches. Added docblocks noting **slug is the identity, the display name is only a label**.

The **ambiguity-refusal safety net stays** for the genuinely degenerate case only (no slug available **and** duplicate names) — with slug-preference it essentially never triggers on a well-formed bundle, but still refuses when there is nothing unique to key on.

## Verification

`tests/agent-bundle-slug-matcher-smoke.php` (pure PHP — `php tests/agent-bundle-slug-matcher-smoke.php`) extended from 14 → **22 assertions, all passing**:

- **events-bot shape:** flow artifacts sharing the display name "Ticketmaster" but with distinct unique slugs (`ticketmaster`, `ticketmaster-4`, …) → `bundle_slug()` returns distinct slugs → **0 ambiguous, all 5 match** their unique slug.
- **degenerate fallback preserved:** artifacts with NO slug AND duplicate names → still ambiguous (#2668's four-"Ticketmaster" guarantee intact); slug-less artifact falls back to the normalized display name.
- **precedence asserted:** `portable_slug` > `slug` > `display_name`.
- All existing #2668 cases still pass.

phpcs (repo ruleset) clean, exit 0 on both changed files. `agent-bundle-runtime-drift-smoke` (18) still passes. `agent-bundle-upgrade-planner-smoke` / `agent-bundle-template-upgrade-tracking-smoke` fail identically on `main` (standalone harness lacks WP/package autoload) — pre-existing and unrelated; both files untouched by this PR.

## Relationship to event-bundles#4

Complementary, not redundant. **event-bundles#4** renames the flow display names (data-side, unblocks events-bot even on the currently deployed matcher). **This PR** fixes it for **all** bundles regardless of display-name hygiene by keying on the unique identity that already exists. Either unblocks events-bot; both is best.

`data-machine-events` is **untouched**. No live data modified.

cc <@1493317298151489577>