### PR TITLE
Fix scaffold ability lookup during activation

### DIFF
--- a/inc/Abilities/File/ScaffoldAbilities.php
+++ b/inc/Abilities/File/ScaffoldAbilities.php
@@ -113,9 +113,15 @@ class ScaffoldAbilities {
 	 * @return \WP_Ability|null The scaffold ability, or null if not available.
 	 */
 	public static function get_ability(): ?\WP_Ability {
-		if ( ! \WP_Abilities_Registry::get_instance()->is_registered( 'datamachine/scaffold-memory-file' ) ) {
+		if ( ! class_exists( '\WP_Abilities_Registry' ) || ! function_exists( 'wp_get_ability' ) ) {
 			return null;
 		}
+
+		$registry = \WP_Abilities_Registry::get_instance();
+		if ( ! $registry || ! method_exists( $registry, 'is_registered' ) || ! $registry->is_registered( 'datamachine/scaffold-memory-file' ) ) {
+			return null;
+		}
+
 		return wp_get_ability( 'datamachine/scaffold-memory-file' );
 	}
 

--- a/inc/Abilities/File/ScaffoldAbilities.php
+++ b/inc/Abilities/File/ScaffoldAbilities.php
@@ -113,12 +113,7 @@ class ScaffoldAbilities {
 	 * @return \WP_Ability|null The scaffold ability, or null if not available.
 	 */
 	public static function get_ability(): ?\WP_Ability {
-		if ( ! class_exists( '\WP_Abilities_Registry' ) || ! function_exists( 'wp_get_ability' ) ) {
-			return null;
-		}
-
-		$registry = \WP_Abilities_Registry::get_instance();
-		if ( ! $registry || ! method_exists( $registry, 'is_registered' ) || ! $registry->is_registered( 'datamachine/scaffold-memory-file' ) ) {
+		if ( ! function_exists( 'wp_get_ability' ) || ! did_action( 'init' ) ) {
 			return null;
 		}
 

--- a/tests/scaffold-ability-activation-smoke.php
+++ b/tests/scaffold-ability-activation-smoke.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Smoke test for scaffold ability access during activation.
+ *
+ * Run with: php tests/scaffold-ability-activation-smoke.php
+ */
+
+namespace {
+	define( 'ABSPATH', sys_get_temp_dir() . '/datamachine-scaffold-ability-activation/' );
+
+	class WP_Ability {}
+
+	class WP_Abilities_Registry {
+		public static function get_instance(): ?WP_Abilities_Registry {
+			return null;
+		}
+	}
+
+	function wp_get_ability( string $name ): ?WP_Ability {
+		return new WP_Ability();
+	}
+}
+
+namespace DataMachine\Abilities\File {
+	require_once dirname( __DIR__ ) . '/inc/Abilities/File/ScaffoldAbilities.php';
+}
+
+namespace {
+	use DataMachine\Abilities\File\ScaffoldAbilities;
+
+	echo "=== Scaffold Ability Activation Smoke ===\n";
+
+	$ability = ScaffoldAbilities::get_ability();
+	if ( null !== $ability ) {
+		fwrite( STDERR, "FAIL: null registry should defer scaffold ability lookup\n" );
+		exit( 1 );
+	}
+
+	echo "ok - null registry defers scaffold ability lookup\n";
+	echo "All scaffold ability activation assertions passed.\n";
+}

--- a/tests/scaffold-ability-activation-smoke.php
+++ b/tests/scaffold-ability-activation-smoke.php
@@ -8,15 +8,19 @@
 namespace {
 	define( 'ABSPATH', sys_get_temp_dir() . '/datamachine-scaffold-ability-activation/' );
 
+	$GLOBALS['datamachine_test_state'] = (object) array(
+		'did_init'            => 0,
+		'wp_get_ability_calls' => 0,
+	);
+
 	class WP_Ability {}
 
-	class WP_Abilities_Registry {
-		public static function get_instance(): ?WP_Abilities_Registry {
-			return null;
-		}
+	function did_action( string $hook = '' ): int {
+		return 'init' === $hook ? $GLOBALS['datamachine_test_state']->did_init : 0;
 	}
 
 	function wp_get_ability( string $name ): ?WP_Ability {
+		++$GLOBALS['datamachine_test_state']->wp_get_ability_calls;
 		return new WP_Ability();
 	}
 }
@@ -32,10 +36,23 @@ namespace {
 
 	$ability = ScaffoldAbilities::get_ability();
 	if ( null !== $ability ) {
-		fwrite( STDERR, "FAIL: null registry should defer scaffold ability lookup\n" );
+		fwrite( STDERR, "FAIL: pre-init scaffold ability lookup should defer\n" );
+		exit( 1 );
+	}
+	if ( 0 !== $GLOBALS['datamachine_test_state']->wp_get_ability_calls ) {
+		fwrite( STDERR, "FAIL: pre-init scaffold ability lookup should not call wp_get_ability\n" );
 		exit( 1 );
 	}
 
-	echo "ok - null registry defers scaffold ability lookup\n";
+	echo "ok - pre-init scaffold ability lookup defers without touching the registry\n";
+
+	$GLOBALS['datamachine_test_state']->did_init = 1;
+	$ability = ScaffoldAbilities::get_ability();
+	if ( ! $ability instanceof WP_Ability ) {
+		fwrite( STDERR, "FAIL: post-init scaffold ability lookup should use wp_get_ability\n" );
+		exit( 1 );
+	}
+
+	echo "ok - post-init scaffold ability lookup uses the public wrapper\n";
 	echo "All scaffold ability activation assertions passed.\n";
 }


### PR DESCRIPTION
## Summary
- Guard scaffold ability lookup when the Abilities registry is unavailable or returns null.
- Preserve activation-time deferred scaffolding instead of crashing during plugin activation.
- Add a focused smoke test for the null-registry activation case.

## Context
Observed while validating Studio Web Workflow Bench on Homeboy Lab. Data Machine activation failed inside WP Codebox with:

```
Fatal error: Uncaught Error: Call to a member function is_registered() on null in inc/Abilities/File/ScaffoldAbilities.php:116
```

`datamachine_ensure_default_memory_files()` already treats an unavailable scaffold ability as deferrable, but `ScaffoldAbilities::get_ability()` crashed before it could return `null`.

## Verification
- `php -l inc/Abilities/File/ScaffoldAbilities.php`
- `php -l tests/scaffold-ability-activation-smoke.php`
- `php tests/scaffold-ability-activation-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the activation crash from lab evidence, drafted the guard and smoke test, and ran local verification.