### PR TITLE
fix: pipeline-scoped flow disambiguation for agent adopt (#2674)

### DIFF
--- a/inc/Engine/Bundle/AgentBundleAbilityService.php
+++ b/inc/Engine/Bundle/AgentBundleAbilityService.php
@@ -373,7 +373,8 @@ final class AgentBundleAbilityService {
 				continue;
 			}
 
-			$flow_index = AgentBundleSlugMatcher::index_existing( $flows_by_pipeline[ $live_pipeline ] ?? array(), 'flow_name', 'flow' );
+			$scoped_rows = $flows_by_pipeline[ $live_pipeline ] ?? array();
+			$flow_index  = AgentBundleSlugMatcher::index_existing( $scoped_rows, 'flow_name', 'flow' );
 
 			if ( isset( $flow_index['ambiguous'][ $slug_key ] ) ) {
 				$ambiguous[] = array(
@@ -385,6 +386,32 @@ final class AgentBundleAbilityService {
 			}
 
 			$live = $flow_index['matched'][ $slug_key ] ?? null;
+
+			// Pipeline-scoped fallback: live-origin flow rows carry no slug, so a
+			// bundle flow keyed on its UNIQUE slug (e.g. "ticketmaster-63") never
+			// meets the live row keyed on its source label ("ticketmaster"). The
+			// global pass above already bounded the candidates to this flow's
+			// matched parent pipeline, where the source label IS unique. So when
+			// the slug key misses, re-key BOTH sides on the normalized source
+			// label within this single pipeline. A unique match there is
+			// unambiguous; the unique bundle slug is still what gets backfilled
+			// onto the row. A genuine in-pipeline name collision stays ambiguous.
+			if ( null === $live ) {
+				$name_key   = AgentBundleSlugMatcher::bundle_name_key( $bundle_flow, 'flow_name', 'flow' );
+				$name_index = AgentBundleSlugMatcher::index_existing_by_name( $scoped_rows, 'flow_name', 'flow' );
+
+				if ( isset( $name_index['ambiguous'][ $name_key ] ) ) {
+					$ambiguous[] = array(
+						'artifact_type' => 'flow',
+						'artifact_id'   => $slug_key,
+						'reason'        => sprintf( '%d live flows on pipeline %d resolve to source label "%s".', count( $name_index['ambiguous'][ $name_key ] ), $live_pipeline, $name_key ),
+					);
+					continue;
+				}
+
+				$live = $name_index['matched'][ $name_key ] ?? null;
+			}
+
 			if ( null === $live ) {
 				$unmatched[] = array(
 					'artifact_type' => 'flow',

--- a/inc/Engine/Bundle/AgentBundleSlugMatcher.php
+++ b/inc/Engine/Bundle/AgentBundleSlugMatcher.php
@@ -80,6 +80,93 @@ final class AgentBundleSlugMatcher {
 	}
 
 	/**
+	 * Index a set of existing rows by their normalized display NAME (label).
+	 *
+	 * Where {@see self::index_existing()} keys on the row IDENTITY (stored
+	 * `portable_slug` first, name only as a fallback), this keys purely on the
+	 * normalized display name and ignores `portable_slug` entirely. It exists
+	 * for the pipeline-scoped flow fallback in adopt: a live-origin flow row has
+	 * no slug column, so its only stable identity WITHIN an already-matched
+	 * parent pipeline is its source label (`flow_name` = "Ticketmaster",
+	 * "Dice.fm"). Within one city pipeline that label is unique, so keying on it
+	 * is unambiguous; across the whole agent it is not, which is why callers must
+	 * only ever hand this the live rows of a SINGLE matched pipeline.
+	 *
+	 * The ambiguity guarantee is preserved: when two rows in the bounded set
+	 * resolve to the same normalized name (a genuine in-pipeline collision), the
+	 * name is surfaced in `ambiguous` and omitted from `matched` so the caller
+	 * still refuses to guess.
+	 *
+	 * @param array<int,array<string,mixed>> $rows     Existing rows for ONE pipeline.
+	 * @param string                         $name_key Display-name field (flow_name).
+	 * @param string                         $fallback PortableSlug fallback (flow).
+	 * @return array{
+	 *     matched: array<string,array<string,mixed>>,
+	 *     ambiguous: array<string,array<int,array<string,mixed>>>
+	 * }
+	 */
+	public static function index_existing_by_name( array $rows, string $name_key, string $fallback ): array {
+		$by_name = array();
+
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$name = trim( (string) ( $row[ $name_key ] ?? '' ) );
+			if ( '' === $name ) {
+				continue;
+			}
+
+			$key = PortableSlug::normalize( $name, $fallback );
+			if ( '' === $key ) {
+				continue;
+			}
+
+			$by_name[ $key ][] = $row;
+		}
+
+		$matched   = array();
+		$ambiguous = array();
+		foreach ( $by_name as $key => $candidates ) {
+			if ( 1 === count( $candidates ) ) {
+				$matched[ $key ] = $candidates[0];
+				continue;
+			}
+
+			$ambiguous[ $key ] = $candidates;
+		}
+
+		return array(
+			'matched'   => $matched,
+			'ambiguous' => $ambiguous,
+		);
+	}
+
+	/**
+	 * Compute the normalized source-label key for a bundle artifact.
+	 *
+	 * Unlike {@see self::bundle_slug()} (which prefers the artifact's UNIQUE
+	 * `slug`/`portable_slug`), this keys purely on the display name — the source
+	 * label ("Ticketmaster", "Dice.fm"). It is the bundle-side counterpart to
+	 * {@see self::index_existing_by_name()} and is used only for the
+	 * pipeline-scoped flow fallback: within a single matched pipeline the source
+	 * label uniquely identifies the flow, and the live row carries no slug to key
+	 * on, so both sides must meet on the normalized label. The unique slug is
+	 * then backfilled onto the matched live row by the caller.
+	 *
+	 * @param array<string,mixed> $artifact Bundle flow entry.
+	 * @param string              $name_key Display-name field (flow_name).
+	 * @param string              $fallback PortableSlug fallback (flow).
+	 * @return string Normalized source-label key.
+	 */
+	public static function bundle_name_key( array $artifact, string $name_key, string $fallback ): string {
+		$candidate = (string) ( $artifact[ $name_key ] ?? $fallback );
+
+		return PortableSlug::normalize( $candidate, $fallback );
+	}
+
+	/**
 	 * Compute the effective normalized slug for a single existing row.
 	 *
 	 * The stored `portable_slug` is the row's IDENTITY; the display name is only

--- a/tests/agent-bundle-slug-matcher-smoke.php
+++ b/tests/agent-bundle-slug-matcher-smoke.php
@@ -312,6 +312,161 @@ agent_bundle_slug_matcher_assert(
 	$passes
 );
 
+// ---- 10. Pipeline-scoped fallback: source label is unique within a pipeline.
+// Reproduces the events-bot live-origin shape end to end: N city pipelines,
+// each with a same-named "Ticketmaster" AND "Dice.fm" live flow (portable_slug
+// NULL, flow_name the bare source label). The bundle flow carries the UNIQUE
+// slug ("ticketmaster-63"), which the global slug pass can never match against a
+// slugless live row. The pipeline-scoped fallback re-keys both sides on the
+// normalized source label WITHIN the bounded pipeline, where it is unique.
+//
+// Mirror of the adopt() matching loop: pipelines match first, then each bundle
+// flow is bounded to its matched live pipeline; the unique-slug pass misses, so
+// the name-key fallback resolves it.
+$scoped_pipelines = array(
+	101 => array(
+		array( 'flow_id' => 1, 'pipeline_id' => 101, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+		array( 'flow_id' => 2, 'pipeline_id' => 101, 'flow_name' => 'Dice.fm', 'portable_slug' => null ),
+	),
+	102 => array(
+		array( 'flow_id' => 3, 'pipeline_id' => 102, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+		array( 'flow_id' => 4, 'pipeline_id' => 102, 'flow_name' => 'Dice.fm', 'portable_slug' => null ),
+	),
+	103 => array(
+		array( 'flow_id' => 5, 'pipeline_id' => 103, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+		array( 'flow_id' => 6, 'pipeline_id' => 103, 'flow_name' => 'Dice.fm', 'portable_slug' => null ),
+	),
+);
+
+// Bundle flows: each carries the UNIQUE deduped slug in portable_slug (exactly
+// what AgentBundleArrayAdapter writes) and the bare source label in flow_name.
+// original_pipeline_id maps to a matched live pipeline (id == live id here).
+$scoped_bundle_flows = array(
+	array( 'original_pipeline_id' => 101, 'flow_name' => 'Ticketmaster', 'portable_slug' => 'ticketmaster' ),
+	array( 'original_pipeline_id' => 101, 'flow_name' => 'Dice.fm', 'portable_slug' => 'dice-fm' ),
+	array( 'original_pipeline_id' => 102, 'flow_name' => 'Ticketmaster', 'portable_slug' => 'ticketmaster-2' ),
+	array( 'original_pipeline_id' => 102, 'flow_name' => 'Dice.fm', 'portable_slug' => 'dice-fm-2' ),
+	array( 'original_pipeline_id' => 103, 'flow_name' => 'Ticketmaster', 'portable_slug' => 'ticketmaster-3' ),
+	array( 'original_pipeline_id' => 103, 'flow_name' => 'Dice.fm', 'portable_slug' => 'dice-fm-3' ),
+);
+
+$scoped_matched   = 0;
+$scoped_unmatched = 0;
+$scoped_ambiguous = 0;
+$matched_flow_ids = array();
+foreach ( $scoped_bundle_flows as $bundle_flow ) {
+	$live_pipeline = (int) $bundle_flow['original_pipeline_id'];
+	$slug_key      = AgentBundleSlugMatcher::bundle_slug( $bundle_flow, 'flow_name', 'flow' );
+	$scoped_rows   = $scoped_pipelines[ $live_pipeline ] ?? array();
+
+	// Global unique-slug pass: misses, because live rows have no slug.
+	$slug_index = AgentBundleSlugMatcher::index_existing( $scoped_rows, 'flow_name', 'flow' );
+	$live       = $slug_index['matched'][ $slug_key ] ?? null;
+
+	// Pipeline-scoped fallback: re-key both sides on the source label.
+	if ( null === $live ) {
+		$name_key   = AgentBundleSlugMatcher::bundle_name_key( $bundle_flow, 'flow_name', 'flow' );
+		$name_index = AgentBundleSlugMatcher::index_existing_by_name( $scoped_rows, 'flow_name', 'flow' );
+		if ( isset( $name_index['ambiguous'][ $name_key ] ) ) {
+			++$scoped_ambiguous;
+			continue;
+		}
+		$live = $name_index['matched'][ $name_key ] ?? null;
+	}
+
+	if ( null === $live ) {
+		++$scoped_unmatched;
+		continue;
+	}
+
+	++$scoped_matched;
+	$matched_flow_ids[ $slug_key ] = (int) $live['flow_id'];
+}
+
+agent_bundle_slug_matcher_assert(
+	6 === $scoped_matched && 0 === $scoped_unmatched && 0 === $scoped_ambiguous,
+	'pipeline-scoped: all same-named live-origin flows match, 0 unmatched, 0 ambiguous',
+	$failures,
+	$passes
+);
+agent_bundle_slug_matcher_assert(
+	1 === ( $matched_flow_ids['ticketmaster'] ?? 0 )
+		&& 3 === ( $matched_flow_ids['ticketmaster-2'] ?? 0 )
+		&& 5 === ( $matched_flow_ids['ticketmaster-3'] ?? 0 ),
+	'pipeline-scoped: each Ticketmaster slug binds to the row in its OWN pipeline',
+	$failures,
+	$passes
+);
+agent_bundle_slug_matcher_assert(
+	2 === ( $matched_flow_ids['dice-fm'] ?? 0 )
+		&& 4 === ( $matched_flow_ids['dice-fm-2'] ?? 0 )
+		&& 6 === ( $matched_flow_ids['dice-fm-3'] ?? 0 ),
+	'pipeline-scoped: each Dice.fm slug binds to the row in its OWN pipeline',
+	$failures,
+	$passes
+);
+
+// ---- 11. Pipeline-scoped fallback STILL refuses a genuine in-pipeline tie. --
+// Two live flows with the SAME normalized source label inside ONE pipeline:
+// there is no unique signal, so the name fallback must surface ambiguous and
+// NEVER guess — preserving the #2668 guarantee at the per-pipeline scope.
+$tie_rows = array(
+	array( 'flow_id' => 11, 'pipeline_id' => 200, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+	array( 'flow_id' => 12, 'pipeline_id' => 200, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+);
+$tie_bundle = array( 'original_pipeline_id' => 200, 'flow_name' => 'Ticketmaster', 'portable_slug' => 'ticketmaster-77' );
+
+$tie_slug_key   = AgentBundleSlugMatcher::bundle_slug( $tie_bundle, 'flow_name', 'flow' );
+$tie_slug_index = AgentBundleSlugMatcher::index_existing( $tie_rows, 'flow_name', 'flow' );
+$tie_live       = $tie_slug_index['matched'][ $tie_slug_key ] ?? null;
+$tie_refused    = false;
+if ( null === $tie_live ) {
+	$tie_name_key   = AgentBundleSlugMatcher::bundle_name_key( $tie_bundle, 'flow_name', 'flow' );
+	$tie_name_index = AgentBundleSlugMatcher::index_existing_by_name( $tie_rows, 'flow_name', 'flow' );
+	$tie_refused    = isset( $tie_name_index['ambiguous'][ $tie_name_key ] )
+		&& ! isset( $tie_name_index['matched'][ $tie_name_key ] );
+}
+agent_bundle_slug_matcher_assert(
+	$tie_refused,
+	'pipeline-scoped: two same-named flows in ONE pipeline stay ambiguous (no guess)',
+	$failures,
+	$passes
+);
+
+// ---- 12. index_existing_by_name ignores portable_slug (keys on label only). -
+// Distinct from index_existing(): a row WITH a stored portable_slug is still
+// keyed under its normalized name here, because the per-pipeline fallback's only
+// stable cross-side signal is the source label.
+$name_only = AgentBundleSlugMatcher::index_existing_by_name(
+	array(
+		array( 'flow_id' => 1, 'flow_name' => 'Ticketmaster', 'portable_slug' => 'some-stored-slug' ),
+		array( 'flow_id' => 2, 'flow_name' => 'Dice.fm', 'portable_slug' => null ),
+	),
+	'flow_name',
+	'flow'
+);
+agent_bundle_slug_matcher_assert(
+	isset( $name_only['matched']['ticketmaster'] )
+		&& 1 === ( $name_only['matched']['ticketmaster']['flow_id'] ?? 0 )
+		&& isset( $name_only['matched']['dice-fm'] ),
+	'index_existing_by_name keys on normalized name regardless of portable_slug',
+	$failures,
+	$passes
+);
+
+// ---- 13. bundle_name_key keys on the source label, never the unique slug. ---
+$label_key = AgentBundleSlugMatcher::bundle_name_key(
+	array( 'flow_name' => 'Ticketmaster', 'portable_slug' => 'ticketmaster-63', 'slug' => 'ticketmaster-63' ),
+	'flow_name',
+	'flow'
+);
+agent_bundle_slug_matcher_assert(
+	'ticketmaster' === $label_key,
+	'bundle_name_key resolves the source label, ignoring the unique slug',
+	$failures,
+	$passes
+);
+
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " agent bundle slug matcher assertions failed.\n";
 	exit( 1 );


### PR DESCRIPTION
Closes #2674

## Problem

`agent adopt` (#2671, v0.150.2) keys the **bundle side** on the artifact's unique `slug`, which fixed the ambiguous-collapse case (#2670). But it surfaced the inverse structural gap for **live-origin agents**: the **live flow row has no slug column**, so the unique bundle slug has nothing to match against. Every same-named flow ends up **unmatched** instead of matched.

Live read-only dry-run of `events-bot` (events.extrachill.com) against the renamed bundle:

```
pipelines: 192   flows: 671   artifacts: 867
matched: 492   unmatched: 371   ambiguous: 0
```

- `ambiguous: 0` ✅ — #2671 did its job.
- **`unmatched: 371`** ❌ — exactly the colliding source flows (ticketmaster ×189, dice.fm ×182, dice ×3). Pipelines match 192/192.

Within one city pipeline the bundle flow keys on its unique slug `ticketmaster-63` while the live row keys on `normalize("Ticketmaster")` = `ticketmaster` — the two sides never meet.

## The fix (matcher-layer only)

A bundle flow is uniquely identified by (`pipeline_slug`, source label). **Within a single pipeline**, "Ticketmaster"/"Dice.fm" is unique, and the live row carries `pipeline_id` while pipelines already match cleanly (192/192). So:

1. **Match pipelines first** (unchanged — works).
2. The existing flow loop already **bounds each bundle flow to its matched parent pipeline**, then keys by the unique slug (the global/unique-slug pass — kept as the **first** pass).
3. **New fallback:** when the unique-slug pass misses, re-key **both sides on the normalized source label** (`flow_name`) **within that single bounded pipeline set**. Because the label is unique within a city pipeline, this is unambiguous.
4. On a unique in-pipeline match, **backfill the bundle flow's unique slug** onto the matched live row — exactly as the global path does today.
5. If — and only if — two live flows in the **same** pipeline share a normalized name, it stays **ambiguous** (never guesses). The #2668 "refuse on genuine ambiguity" guarantee is preserved at per-pipeline scope.

No flows schema change, no events-bundles change, no bundle-export change. Change is confined to the Bundle matcher/adopt layer.

### Changed
- `inc/Engine/Bundle/AgentBundleSlugMatcher.php` — adds `index_existing_by_name()` (keys live rows purely on normalized name, ignoring `portable_slug`) and `bundle_name_key()` (bundle-side source-label key). Both are scoped helpers for the per-pipeline fallback.
- `inc/Engine/Bundle/AgentBundleAbilityService.php::adopt()` — wires the source-label fallback into the already-pipeline-bounded flow loop, between the unique-slug match and the unmatched verdict.
- `tests/agent-bundle-slug-matcher-smoke.php` — new pipeline-scoped coverage.

## Verification

**Existing 22-assertion smoke stays green + 6 new pipeline-scoped assertions pass — 28 total:**

```
  ✓ pipeline-scoped: all same-named live-origin flows match, 0 unmatched, 0 ambiguous
  ✓ pipeline-scoped: each Ticketmaster slug binds to the row in its OWN pipeline
  ✓ pipeline-scoped: each Dice.fm slug binds to the row in its OWN pipeline
  ✓ pipeline-scoped: two same-named flows in ONE pipeline stay ambiguous (no guess)
  ✓ index_existing_by_name keys on normalized name regardless of portable_slug
  ✓ bundle_name_key resolves the source label, ignoring the unique slug

All 28 agent bundle slug matcher assertions passed.
```

New smoke covers exactly the issue's acceptance case: N city pipelines, each with a same-named "Ticketmaster" AND "Dice.fm" live flow, all `portable_slug` NULL, all live `flow_name` = the bare source label → after matching, ALL flows bind to their correct bundle slug **within their own pipeline**, 0 ambiguous, 0 unmatched. Plus the genuine in-pipeline tie (two same-named flows in ONE pipeline) is still refused as ambiguous.

**Lint:** `php -l` clean on all three files; `phpcbf --standard=WordPress` produced no formatting changes (additions follow the existing aligned-`=>` / Yoda style of the surrounding matcher code, which is already lint-clean from #2671). Note: phpcs's own reporter is non-functional under this host's PHP 8.4 (output/exit-code suppressed by the composer/jsonschema deprecation flood — a known environment quirk), so the smoke + `php -l` + phpcbf-no-op are the local signals; the homeboy Lint gate is authoritative on CI. Excludes the house-style PSR-4 class-filename baseline.

## Scope note

This is the **matcher-layer fix only**. The operator still runs the live `agent adopt` after merge + release + deploy — **not done here** (PR only; no merge, no release, no deploy, no live DB writes).