### PR TITLE
fix: stage content-edit pending actions on the calling blog, not the target

### DIFF
--- a/inc/Abilities/Content/BlogContext.php
+++ b/inc/Abilities/Content/BlogContext.php
@@ -177,4 +177,46 @@ class BlogContext {
 			restore_current_blog();
 		}
 	}
+
+	/**
+	 * Run a callback in the ORIGIN (calling) blog, temporarily leaving the
+	 * target blog entered by enter().
+	 *
+	 * The content abilities switch to the target blog to read/write the post,
+	 * but pending-action **staging** must happen on the calling blog: the
+	 * pending-action store is `$wpdb->prefix`-scoped (per-blog), and both the
+	 * propose turn and the later accept/resolve turn run on the calling blog.
+	 * Staging inside the target-blog switch would persist the action in the
+	 * wrong blog's table, and the resolve — running on the calling blog — would
+	 * never find it (the cross-site accept would silently fail).
+	 *
+	 * When no switch is active (single-site, same-blog, or invalid-target
+	 * no-op token), this simply runs the callback in place. Otherwise it pops
+	 * back to the origin blog for the duration of the callback and re-enters
+	 * the target blog afterward, so the surrounding `leave()` still balances.
+	 *
+	 * @template T
+	 * @param array|\WP_Error $ctx      Context token from enter().
+	 * @param callable        $callback Work to run on the origin blog.
+	 * @return mixed The callback's return value.
+	 */
+	public static function run_on_origin( $ctx, callable $callback ) {
+		$switched = is_array( $ctx ) && ! empty( $ctx['switched'] );
+
+		if ( ! $switched ) {
+			return $callback();
+		}
+
+		$target = (int) $ctx['blog_id'];
+
+		// Pop back to the origin blog for the staging write.
+		restore_current_blog();
+		try {
+			return $callback();
+		} finally {
+			// Re-enter the target blog so the caller's `leave()` still balances
+			// the original enter().
+			switch_to_blog( $target );
+		}
+	}
 }

--- a/inc/Abilities/Content/EditPostBlocksAbility.php
+++ b/inc/Abilities/Content/EditPostBlocksAbility.php
@@ -191,10 +191,15 @@ class EditPostBlocksAbility {
 	 */
 	public static function execute( array $input ): array {
 		// Resolve the target blog. On multisite the post may live on another
-		// site than the one this request landed on; switch to it so the read,
-		// the preview staging, and the eventual apply all target the right
-		// post. blog_id rides inside apply_input below so the resolve replay
-		// re-enters the same context.
+		// site than the one this request landed on; switch to it so the post
+		// read and the eventual apply target the right post. blog_id rides
+		// inside apply_input below so the resolve replay re-enters the same
+		// context.
+		//
+		// IMPORTANT: pending-action STAGING must NOT happen inside this switch
+		// — the store is per-blog and the resolve runs on the calling blog, so
+		// staging is bracketed back to the origin blog via
+		// BlogContext::run_on_origin() in the preview branch.
 		$ctx = BlogContext::enter( $input );
 		if ( is_wp_error( $ctx ) ) {
 			return array(
@@ -204,7 +209,7 @@ class EditPostBlocksAbility {
 		}
 
 		try {
-			return self::execute_in_context( $input );
+			return self::execute_in_context( $input, $ctx );
 		} finally {
 			BlogContext::leave( $ctx );
 		}
@@ -213,10 +218,11 @@ class EditPostBlocksAbility {
 	/**
 	 * Execute the edit within the (already-resolved) blog context.
 	 *
-	 * @param array $input Ability input.
+	 * @param array           $input Ability input.
+	 * @param array|\WP_Error $ctx   Blog context token from BlogContext::enter().
 	 * @return array
 	 */
-	private static function execute_in_context( array $input ): array {
+	private static function execute_in_context( array $input, $ctx ): array {
 		$post_id = absint( $input['post_id'] ?? 0 );
 		$blog_id = absint( $input['blog_id'] ?? 0 );
 		$edits   = $input['edits'] ?? array();
@@ -369,21 +375,31 @@ class EditPostBlocksAbility {
 				)
 			);
 
-			$envelope = PendingActionHelper::stage(
-				array(
-					'action_id'    => $action_id,
-					'kind'         => 'edit_post_blocks',
-					'summary'      => sprintf( 'Preview edits to post #%d.', $post_id ),
-					'apply_input'  => BlogContext::with_blog_id(
+			// Stage on the ORIGIN (calling) blog: the pending-action store is
+			// per-blog and the accept/resolve turn runs on the calling blog, so
+			// the action must persist there — not in the target blog we're
+			// currently switched into. The apply replay re-enters the target
+			// blog via the stamped blog_id in apply_input.
+			$envelope = BlogContext::run_on_origin(
+				$ctx,
+				static function () use ( $action_id, $post_id, $edits, $blog_id, $diff ) {
+					return PendingActionHelper::stage(
 						array(
-							'post_id' => $post_id,
-							'edits'   => $edits,
-						),
-						$blog_id
-					),
-					'preview_data' => $diff,
-					'context'      => BlogContext::with_blog_id( array( 'post_id' => $post_id ), $blog_id ),
-				)
+							'action_id'    => $action_id,
+							'kind'         => 'edit_post_blocks',
+							'summary'      => sprintf( 'Preview edits to post #%d.', $post_id ),
+							'apply_input'  => BlogContext::with_blog_id(
+								array(
+									'post_id' => $post_id,
+									'edits'   => $edits,
+								),
+								$blog_id
+							),
+							'preview_data' => $diff,
+							'context'      => BlogContext::with_blog_id( array( 'post_id' => $post_id ), $blog_id ),
+						)
+					);
+				}
 			);
 
 			if ( empty( $envelope['staged'] ) ) {

--- a/inc/Abilities/Content/InsertContentAbility.php
+++ b/inc/Abilities/Content/InsertContentAbility.php
@@ -168,9 +168,14 @@ class InsertContentAbility {
 	public static function execute( array $input ): array {
 		// Resolve the target blog. On multisite the post may live on another
 		// site than the one this request landed on; switch to it so the read,
-		// the edit_post capability check, the preview staging, and the eventual
-		// apply all target the right post. blog_id rides inside apply_input
-		// below so the resolve replay re-enters the same context.
+		// the edit_post capability check, and the eventual apply target the
+		// right post. blog_id rides inside apply_input below so the resolve
+		// replay re-enters the same context.
+		//
+		// IMPORTANT: pending-action STAGING must NOT happen inside this switch
+		// — the store is per-blog and the resolve runs on the calling blog, so
+		// staging is bracketed back to the origin blog via
+		// BlogContext::run_on_origin() in the preview branch.
 		$ctx = BlogContext::enter( $input );
 		if ( is_wp_error( $ctx ) ) {
 			return array(
@@ -180,7 +185,7 @@ class InsertContentAbility {
 		}
 
 		try {
-			return self::execute_in_context( $input );
+			return self::execute_in_context( $input, $ctx );
 		} finally {
 			BlogContext::leave( $ctx );
 		}
@@ -189,10 +194,11 @@ class InsertContentAbility {
 	/**
 	 * Execute the insertion within the (already-resolved) blog context.
 	 *
-	 * @param array $input Input parameters.
+	 * @param array           $input Input parameters.
+	 * @param array|\WP_Error $ctx   Blog context token from BlogContext::enter().
 	 * @return array Result with canonical diff preview data.
 	 */
-	private static function execute_in_context( array $input ): array {
+	private static function execute_in_context( array $input, $ctx ): array {
 		$post_id               = absint( $input['post_id'] ?? 0 );
 		$blog_id               = absint( $input['blog_id'] ?? 0 );
 		$content               = $input['content'] ?? '';
@@ -326,23 +332,31 @@ class InsertContentAbility {
 			)
 		);
 
-		$envelope = PendingActionHelper::stage(
-			array(
-				'action_id'    => $action_id,
-				'kind'         => 'insert_content',
-				'summary'      => sprintf( 'Preview content insertion %s on post #%d.', $insertion_point, $post_id ),
-				'apply_input'  => BlogContext::with_blog_id(
+		// Stage on the ORIGIN (calling) blog — see EditPostBlocksAbility for the
+		// full rationale: the per-blog pending-action store must hold the action
+		// where the accept/resolve turn will look for it.
+		$envelope = BlogContext::run_on_origin(
+			$ctx,
+			static function () use ( $action_id, $insertion_point, $post_id, $content, $position, $target_paragraph_text, $blog_id, $diff ) {
+				return PendingActionHelper::stage(
 					array(
-						'post_id'               => $post_id,
-						'content'               => $content,
-						'position'              => $position,
-						'target_paragraph_text' => $target_paragraph_text,
-					),
-					$blog_id
-				),
-				'preview_data' => $diff,
-				'context'      => BlogContext::with_blog_id( array( 'post_id' => $post_id ), $blog_id ),
-			)
+						'action_id'    => $action_id,
+						'kind'         => 'insert_content',
+						'summary'      => sprintf( 'Preview content insertion %s on post #%d.', $insertion_point, $post_id ),
+						'apply_input'  => BlogContext::with_blog_id(
+							array(
+								'post_id'               => $post_id,
+								'content'               => $content,
+								'position'              => $position,
+								'target_paragraph_text' => $target_paragraph_text,
+							),
+							$blog_id
+						),
+						'preview_data' => $diff,
+						'context'      => BlogContext::with_blog_id( array( 'post_id' => $post_id ), $blog_id ),
+					)
+				);
+			}
 		);
 
 		if ( empty( $envelope['staged'] ) ) {

--- a/inc/Abilities/Content/ReplacePostBlocksAbility.php
+++ b/inc/Abilities/Content/ReplacePostBlocksAbility.php
@@ -185,10 +185,15 @@ class ReplacePostBlocksAbility {
 	 */
 	public static function execute( array $input ): array {
 		// Resolve the target blog. On multisite the post may live on another
-		// site than the one this request landed on; switch to it so the read,
-		// the preview staging, and the eventual apply all target the right
-		// post. blog_id rides inside apply_input below so the resolve replay
-		// re-enters the same context.
+		// site than the one this request landed on; switch to it so the post
+		// read and the eventual apply target the right post. blog_id rides
+		// inside apply_input below so the resolve replay re-enters the same
+		// context.
+		//
+		// IMPORTANT: pending-action STAGING must NOT happen inside this switch
+		// — the store is per-blog and the resolve runs on the calling blog, so
+		// staging is bracketed back to the origin blog via
+		// BlogContext::run_on_origin() in the preview branch.
 		$ctx = BlogContext::enter( $input );
 		if ( is_wp_error( $ctx ) ) {
 			return array(
@@ -198,7 +203,7 @@ class ReplacePostBlocksAbility {
 		}
 
 		try {
-			return self::execute_in_context( $input );
+			return self::execute_in_context( $input, $ctx );
 		} finally {
 			BlogContext::leave( $ctx );
 		}
@@ -207,10 +212,11 @@ class ReplacePostBlocksAbility {
 	/**
 	 * Execute the replacement within the (already-resolved) blog context.
 	 *
-	 * @param array $input Ability input.
+	 * @param array           $input Ability input.
+	 * @param array|\WP_Error $ctx   Blog context token from BlogContext::enter().
 	 * @return array
 	 */
-	private static function execute_in_context( array $input ): array {
+	private static function execute_in_context( array $input, $ctx ): array {
 		$post_id      = absint( $input['post_id'] ?? 0 );
 		$blog_id      = absint( $input['blog_id'] ?? 0 );
 		$replacements = $input['replacements'] ?? array();
@@ -349,21 +355,29 @@ class ReplacePostBlocksAbility {
 				)
 			);
 
-			$envelope = PendingActionHelper::stage(
-				array(
-					'action_id'    => $action_id,
-					'kind'         => 'replace_post_blocks',
-					'summary'      => sprintf( 'Preview block replacements on post #%d.', $post_id ),
-					'apply_input'  => BlogContext::with_blog_id(
+			// Stage on the ORIGIN (calling) blog — see EditPostBlocksAbility for
+			// the full rationale: the per-blog pending-action store must hold
+			// the action where the accept/resolve turn will look for it.
+			$envelope = BlogContext::run_on_origin(
+				$ctx,
+				static function () use ( $action_id, $post_id, $replacements, $blog_id, $diff ) {
+					return PendingActionHelper::stage(
 						array(
-							'post_id'      => $post_id,
-							'replacements' => $replacements,
-						),
-						$blog_id
-					),
-					'preview_data' => $diff,
-					'context'      => BlogContext::with_blog_id( array( 'post_id' => $post_id ), $blog_id ),
-				)
+							'action_id'    => $action_id,
+							'kind'         => 'replace_post_blocks',
+							'summary'      => sprintf( 'Preview block replacements on post #%d.', $post_id ),
+							'apply_input'  => BlogContext::with_blog_id(
+								array(
+									'post_id'      => $post_id,
+									'replacements' => $replacements,
+								),
+								$blog_id
+							),
+							'preview_data' => $diff,
+							'context'      => BlogContext::with_blog_id( array( 'post_id' => $post_id ), $blog_id ),
+						)
+					);
+				}
 			);
 
 			if ( empty( $envelope['staged'] ) ) {

--- a/tests/blog-context-content-smoke.php
+++ b/tests/blog-context-content-smoke.php
@@ -192,6 +192,50 @@ $assert( 'resolve replay re-enters the stamped target blog', 1 === get_current_b
 BlogContext::leave( $ctx_replay );
 $assert( 'resolve replay restores the calling blog', 12 === get_current_blog_id() );
 
+// --- run_on_origin: STAGING happens on the calling blog, not the target -----
+//
+// Regression guard for the cross-site staging bug (data-machine#2678): the
+// content abilities enter() the target blog for the post read/apply, but the
+// pending-action store is per-blog and the accept/resolve turn runs on the
+// CALLING blog. Staging inside the target-blog switch persists the action in
+// the wrong blog's table, so the resolve never finds it and the accept fails.
+// run_on_origin() must execute the staging callback with the ORIGIN blog
+// active, then restore the target blog so the surrounding leave() balances.
+
+// Cross-site: chat on blog 12, post on blog 1.
+$GLOBALS['__test_current_blog'] = 12;
+$ctx_stage                      = BlogContext::enter( array( 'blog_id' => 1 ) );
+$assert( 'enter() switched to the target blog for the read', 1 === get_current_blog_id() );
+
+$blog_seen_during_stage = null;
+$stage_return           = BlogContext::run_on_origin(
+	$ctx_stage,
+	static function () use ( &$blog_seen_during_stage ) {
+		$blog_seen_during_stage = get_current_blog_id();
+		return 'staged';
+	}
+);
+$assert( 'run_on_origin runs the staging callback on the ORIGIN blog (12), not the target (1)', 12 === $blog_seen_during_stage );
+$assert( 'run_on_origin returns the callback value', 'staged' === $stage_return );
+$assert( 'run_on_origin re-enters the target blog afterward (leave stays balanced)', 1 === get_current_blog_id() );
+
+BlogContext::leave( $ctx_stage );
+$assert( 'leave() after run_on_origin restores the calling blog', 12 === get_current_blog_id() );
+
+// Same-blog / single-site: run_on_origin is a transparent pass-through.
+$GLOBALS['__test_current_blog'] = 1;
+$ctx_same                       = BlogContext::enter( array( 'blog_id' => 1 ) ); // target == current -> no switch
+$blog_seen_same                 = null;
+BlogContext::run_on_origin(
+	$ctx_same,
+	static function () use ( &$blog_seen_same ) {
+		$blog_seen_same = get_current_blog_id();
+	}
+);
+$assert( 'run_on_origin no-op (same blog) runs in place on blog 1', 1 === $blog_seen_same );
+BlogContext::leave( $ctx_same );
+$assert( 'same-blog run_on_origin leaves the blog unchanged', 1 === get_current_blog_id() );
+
 if ( $failed > 0 ) {
 	echo "=== blog-context-content-smoke: {$failed} FAIL of {$total} ===\n";
 	exit( 1 );


### PR DESCRIPTION
## Summary

Fixes a cross-site bug introduced by #2669: when a content edit targets a post on a different blog than the request landed on, the **preview** stages the pending action in the **wrong blog's** store, so the accept/resolve can't find it and silently fails. Closes #2678.

## The bug

`PendingActionStore` is `$wpdb->prefix`-scoped (per-blog). #2669 wrapped the entire `execute()` in `BlogContext::enter()` → `switch_to_blog( target )`, which put `PendingActionHelper::stage()` inside the switch. But both the propose turn and the accept/resolve turn run on the **calling** blog (e.g. a chat surface on blog 12 editing a draft on blog 1):

1. Chat on blog 12 → agent calls `edit_post_blocks({ post_id, blog_id: 1, preview: true })`.
2. `execute()` → `switch_to_blog(1)` → `stage()` writes to `c8c_datamachine_pending_actions` (blog 1).
3. User Accepts → resolve runs on blog 12 → `PendingActionStore::get()` reads `c8c_12_datamachine_pending_actions` → **not found** → accept fails.

Same-blog / single-site is unaffected (BlogContext is a no-op), which is why the original smoke (helper logic in isolation) didn't catch it.

## The fix

New `BlogContext::run_on_origin( $ctx, $callback )`: while a target-blog switch is active, it `restore_current_blog()` back to the origin blog, runs the callback (the staging write), then `switch_to_blog( target )` again so the surrounding `leave()` stays balanced. No-op pass-through when no switch is active.

All three write abilities (`edit` / `replace` / `insert`) now stage through it, so the pending action persists on the **calling** blog where the resolve looks. Unchanged and still correct:
- the post **read** + **apply** (`wp_update_post`) run in the target blog;
- the apply replay re-enters the target blog via the `blog_id` stamped into `apply_input`;
- the `can_resolve` `edit_post` check still switches to the target blog.

## Tests

- `tests/blog-context-content-smoke.php`: added a regression guard (now 30 assertions) asserting `run_on_origin` executes the staging callback on the **origin** blog (12), not the target (1), and re-enters the target afterward; plus the same-blog pass-through case. This directly fails against the pre-fix code path.
- `php -l` clean; `phpcs --standard=WordPress` 0 findings on all touched files incl. the test.
- Existing `pending-action-resolver-contract` (32) and `pending-action-scope` (15) smokes still pass.

## Impact

Unblocks the cross-site **accept** step of the Roadie writing assistant (extrachill-roadie#49 / #48 step 2): the writer accepts a diff card in the chat drawer on Studio, and the edit now correctly applies to the draft on main. Follows #2669.

Closes #2678.