### PR TITLE
fix: honor --dry-run on flows update (handler-config/set-user-message no longer persist) (#2680)

### DIFF
--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -1276,7 +1276,7 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		if ( $has_handler_config ) {
-			$step_config = $this->loadFlowStepConfig( $flow_id, (string) $handler_step );
+			$step_config      = $this->loadFlowStepConfig( $flow_id, (string) $handler_step );
 			$handler_slug     = null;
 			$unwrapped_config = $handler_config;
 
@@ -1442,8 +1442,8 @@ class FlowsCommand extends BaseCommand {
 			);
 		}
 
-		$ai_steps      = array();
-		$non_ai_steps  = array();
+		$ai_steps     = array();
+		$non_ai_steps = array();
 		foreach ( $flow_config as $step_id => $step_data ) {
 			if ( ! is_array( $step_data ) || ! isset( $step_data['step_type'] ) ) {
 				continue;

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -155,7 +155,11 @@ class FlowsCommand extends BaseCommand {
 	 * : Jaccard similarity threshold 0.0-1.0 (validate subcommand). Default: 0.65.
 	 *
 	 * [--dry-run]
-	 * : Validate without creating (create subcommand).
+	 * : Validate and preview without writing. For the create subcommand this
+	 *   validates the new flow without creating it. For the update subcommand
+	 *   it validates every requested change (name, scheduling, agent,
+	 *   set-user-message, handler-config) and prints a "[dry-run] would update
+	 *   ..." preview while making ZERO database writes.
 	 *
 	 * [--pipeline=<id>]
 	 * : Pipeline ID for pause/resume scoping.
@@ -1093,10 +1097,15 @@ class FlowsCommand extends BaseCommand {
 	}
 
 	/**
-	 * Update a flow's name or scheduling.
+	 * Update a flow's name, scheduling, agent, user message, or handler config.
+	 *
+	 * Honors --dry-run on every write sub-path: when set, each requested change
+	 * is validated and previewed ("[dry-run] would update ...") but NO database
+	 * write occurs. Validation (bad JSON, unknown handler, step resolution)
+	 * still runs in dry-run mode, so it is a full validate + preview.
 	 *
 	 * @param int   $flow_id    Flow ID to update.
-	 * @param array $assoc_args Associative arguments (--name, --scheduling).
+	 * @param array $assoc_args Associative arguments (--name, --scheduling, --agent, --set-user-message, --handler-config, --dry-run).
 	 */
 	private function updateFlow( int $flow_id, array $assoc_args ): void {
 		if ( $flow_id <= 0 ) {
@@ -1113,6 +1122,7 @@ class FlowsCommand extends BaseCommand {
 			return;
 		}
 
+		$dry_run      = isset( $assoc_args['dry-run'] );
 		$name         = $assoc_args['name'] ?? null;
 		$scheduling   = $assoc_args['scheduling'] ?? null;
 		$scheduled_at = $assoc_args['scheduled-at'] ?? null;
@@ -1159,15 +1169,19 @@ class FlowsCommand extends BaseCommand {
 				return;
 			}
 
-			$flows_repo = new \DataMachine\Core\Database\Flows\Flows();
-			$success    = $flows_repo->update_flow( $flow_id, array( 'agent_id' => $new_agent_id ) );
+			if ( $dry_run ) {
+				WP_CLI::log( sprintf( '[dry-run] would set flow %d agent to agent_id=%d; no changes written', $flow_id, $new_agent_id ) );
+			} else {
+				$flows_repo = new \DataMachine\Core\Database\Flows\Flows();
+				$success    = $flows_repo->update_flow( $flow_id, array( 'agent_id' => $new_agent_id ) );
 
-			if ( ! $success ) {
-				WP_CLI::error( 'Failed to update flow agent_id.' );
-				return;
+				if ( ! $success ) {
+					WP_CLI::error( 'Failed to update flow agent_id.' );
+					return;
+				}
+
+				WP_CLI::success( sprintf( 'Flow %d agent set to agent_id=%d.', $flow_id, $new_agent_id ) );
 			}
-
-			WP_CLI::success( sprintf( 'Flow %d agent set to agent_id=%d.', $flow_id, $new_agent_id ) );
 		}
 
 		// Validate step resolution BEFORE any writes (atomic: fail fast, change nothing).
@@ -1205,45 +1219,60 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		if ( null !== $name || null !== $scheduling ) {
-			$ability = wp_get_ability( 'datamachine/update-flow' );
-			$result  = $ability->execute( $input );
+			if ( $dry_run ) {
+				$preview = array();
+				if ( null !== $name ) {
+					$preview[] = sprintf( 'flow_name → "%s"', $name );
+				}
+				if ( null !== $scheduling ) {
+					$preview[] = sprintf( 'scheduling → %s', $scheduling );
+				}
+				WP_CLI::log( sprintf( '[dry-run] would update flow %d: %s; no changes written', $flow_id, implode( ', ', $preview ) ) );
+			} else {
+				$ability = wp_get_ability( 'datamachine/update-flow' );
+				$result  = $ability->execute( $input );
 
-			if ( is_wp_error( $result ) ) {
-				WP_CLI::error( $result->get_error_message() );
-			}
+				if ( is_wp_error( $result ) ) {
+					WP_CLI::error( $result->get_error_message() );
+				}
 
-			if ( ! $result['success'] ) {
-				WP_CLI::error( $result['error'] ?? 'Failed to update flow' );
-				return;
-			}
+				if ( ! $result['success'] ) {
+					WP_CLI::error( $result['error'] ?? 'Failed to update flow' );
+					return;
+				}
 
-			WP_CLI::success( sprintf( 'Flow %d updated.', $flow_id ) );
-			WP_CLI::log( sprintf( 'Name: %s', $result['flow_name'] ?? '' ) );
+				WP_CLI::success( sprintf( 'Flow %d updated.', $flow_id ) );
+				WP_CLI::log( sprintf( 'Name: %s', $result['flow_name'] ?? '' ) );
 
-			$sched = $result['flow_data']['scheduling_config'] ?? array();
-			if ( 'cron' === ( $sched['interval'] ?? '' ) && ! empty( $sched['cron_expression'] ) ) {
-				WP_CLI::log( sprintf( 'Scheduling: cron (%s)', $sched['cron_expression'] ) );
-			} elseif ( isset( $sched['interval'] ) ) {
-				WP_CLI::log( sprintf( 'Scheduling: %s', $sched['interval'] ) );
+				$sched = $result['flow_data']['scheduling_config'] ?? array();
+				if ( 'cron' === ( $sched['interval'] ?? '' ) && ! empty( $sched['cron_expression'] ) ) {
+					WP_CLI::log( sprintf( 'Scheduling: cron (%s)', $sched['cron_expression'] ) );
+				} elseif ( isset( $sched['interval'] ) ) {
+					WP_CLI::log( sprintf( 'Scheduling: %s', $sched['interval'] ) );
+				}
 			}
 		}
 
 		// Phase 2: Step-level updates (user_message, handler config).
 		if ( null !== $user_message ) {
-			$step_ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
-			$step_result  = $step_ability->execute(
-				array(
-					'flow_step_id' => $message_step,
-					'user_message' => $user_message,
-				)
-			);
+			if ( $dry_run ) {
+				WP_CLI::log( sprintf( '[dry-run] would update user_message for step %s (%d chars); no changes written', $message_step, mb_strlen( $user_message ) ) );
+			} else {
+				$step_ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
+				$step_result  = $step_ability->execute(
+					array(
+						'flow_step_id' => $message_step,
+						'user_message' => $user_message,
+					)
+				);
 
-			if ( ! $step_result['success'] ) {
-				WP_CLI::error( $step_result['error'] ?? 'Failed to update user_message' );
-				return;
+				if ( ! $step_result['success'] ) {
+					WP_CLI::error( $step_result['error'] ?? 'Failed to update user_message' );
+					return;
+				}
+
+				WP_CLI::success( 'User message updated for step: ' . $message_step );
 			}
-
-			WP_CLI::success( 'User message updated for step: ' . $message_step );
 		}
 
 		if ( $has_handler_config ) {
@@ -1282,16 +1311,21 @@ class FlowsCommand extends BaseCommand {
 				$step_input['handler_slug'] = $handler_slug;
 			}
 
-			$step_ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
-			$step_result  = $step_ability->execute( $step_input );
-
-			if ( ! $step_result['success'] ) {
-				WP_CLI::error( $step_result['error'] ?? 'Failed to update handler config' );
-				return;
-			}
-
 			$updated_keys = implode( ', ', array_keys( $unwrapped_config ) );
-			WP_CLI::success( sprintf( 'Handler config updated for step %s: %s', $handler_step, $updated_keys ) );
+
+			if ( $dry_run ) {
+				WP_CLI::log( sprintf( '[dry-run] would update handler_config for step %s: %s; no changes written', $handler_step, $updated_keys ) );
+			} else {
+				$step_ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
+				$step_result  = $step_ability->execute( $step_input );
+
+				if ( ! $step_result['success'] ) {
+					WP_CLI::error( $step_result['error'] ?? 'Failed to update handler config' );
+					return;
+				}
+
+				WP_CLI::success( sprintf( 'Handler config updated for step %s: %s', $handler_step, $updated_keys ) );
+			}
 		}
 	}
 

--- a/tests/flows-update-dry-run-no-persist-smoke.php
+++ b/tests/flows-update-dry-run-no-persist-smoke.php
@@ -1,0 +1,414 @@
+<?php
+/**
+ * Pure-PHP smoke test for `flows update --dry-run` persistence (#2680).
+ *
+ * Run with: php tests/flows-update-dry-run-no-persist-smoke.php
+ *
+ * #2680 was a SILENT DATA-DESTRUCTION bug: `flows update <id> --handler-config
+ * '...' --dry-run` wrote the change to the database anyway and printed
+ * "Handler config updated" as if it were a no-op preview. It clobbered a live
+ * 16k-char production flow message down to ~11 chars TWICE during verification.
+ *
+ * This test drives the REAL FlowsCommand::updateFlow() private method via
+ * reflection against a SPY persistence layer (UpdateFlowStepAbility), pinning:
+ *
+ *   1. With --dry-run, the persist ability is NEVER executed (zero DB writes),
+ *      so the stored flow config is byte-identical before and after.
+ *   2. With --dry-run, the output reads like a preview ("[dry-run] would
+ *      update ... no changes written"), NOT a "Handler config updated" success.
+ *   3. WITHOUT --dry-run, the SAME command DOES execute the persist ability
+ *      exactly once (the write path is intact — dry-run is the only difference).
+ *   4. The same guarantees hold for --set-user-message.
+ *
+ * The collaborators FlowsCommand touches (WP_CLI, FlowStepConfig, the Flows
+ * repository, UpdateFlowStepAbility, wp_get_ability, etc.) are stubbed below in
+ * their real namespaces BEFORE the command file is required, so PHP resolves
+ * the `new \DataMachine\...` calls to these test doubles.
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+// ─── Test harness ─────────────────────────────────────────────────────
+
+$failures = array();
+$passes   = 0;
+
+function smoke_assert( bool $condition, string $name, string $detail = '' ): void {
+	global $failures, $passes;
+	if ( $condition ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}" . ( '' !== $detail ? " — {$detail}" : '' ) . "\n";
+}
+
+function smoke_assert_equals( $expected, $actual, string $name ): void {
+	global $failures, $passes;
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+// ─── Spy state (module-level so stubs can record into it) ─────────────
+
+$GLOBALS['__smoke_persist_calls']  = array(); // Records every UpdateFlowStepAbility::execute() input.
+$GLOBALS['__smoke_cli_lines']      = array(); // WP_CLI::log / line output.
+$GLOBALS['__smoke_cli_success']    = array(); // WP_CLI::success output.
+$GLOBALS['__smoke_cli_error']      = null;    // First WP_CLI::error message (throws to abort).
+
+/**
+ * The stored flow config the SUT reads from / would write to. Tests snapshot
+ * this before/after a dry-run to assert byte-identity.
+ */
+$GLOBALS['__smoke_stored_flow'] = array(
+	'flow_id'     => 4,
+	'flow_config' => array(
+		'step_abc' => array(
+			'step_type'       => 'system_task',
+			'handler'         => array( 'handler_slug' => '' ),
+			'handler_configs' => array(),
+			'flow_step_settings' => array(
+				'task'   => 'dispatch_message',
+				'params' => array(
+					'channel'   => 'extra-chill',
+					'recipient' => 'chubes',
+					'message'   => str_repeat( 'A', 16104 ), // The 16k-char prod prompt this bug clobbered.
+				),
+			),
+		),
+	),
+);
+
+// ─── WP function stubs ────────────────────────────────────────────────
+
+if ( ! function_exists( 'wp_unslash' ) ) {
+	function wp_unslash( $value ) {
+		if ( is_array( $value ) ) {
+			return array_map( 'wp_unslash', $value );
+		}
+		if ( is_string( $value ) ) {
+			return stripslashes( $value );
+		}
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'wp_kses_post' ) ) {
+	function wp_kses_post( $value ) {
+		return (string) $value;
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = '' ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value, ...$args ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( $name ) {
+		// Only name/scheduling updates reach this in updateFlow(); the tests
+		// here exercise handler-config and user-message paths, which use the
+		// UpdateFlowStepAbility stub directly. Return a permissive double.
+		return new class() {
+			public function execute( $input ) {
+				return array( 'success' => true, 'flow_name' => $input['flow_name'] ?? '', 'flow_data' => array() );
+			}
+		};
+	}
+}
+
+// ─── WP_CLI stub (records output, aborts on error) ────────────────────
+
+class Smoke_WP_CLI_Abort extends \Exception {}
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+	class WP_CLI {
+		public static function log( $msg ) {
+			$GLOBALS['__smoke_cli_lines'][] = (string) $msg;
+		}
+		public static function line( $msg = '' ) {
+			$GLOBALS['__smoke_cli_lines'][] = (string) $msg;
+		}
+		public static function success( $msg ) {
+			$GLOBALS['__smoke_cli_success'][] = (string) $msg;
+		}
+		public static function warning( $msg ) {
+			$GLOBALS['__smoke_cli_lines'][] = 'WARN: ' . (string) $msg;
+		}
+		public static function error( $msg ) {
+			$GLOBALS['__smoke_cli_error'] = (string) $msg;
+			throw new Smoke_WP_CLI_Abort( (string) $msg );
+		}
+		public static function confirm( $msg ) {}
+	}
+}
+
+} // end global namespace (stubs / harness)
+
+// ─── Namespaced collaborator stubs (declared BEFORE the SUT is loaded) ─
+
+namespace DataMachine\Cli {
+	// BaseCommand: FlowsCommand extends this. Minimal empty base.
+	if ( ! class_exists( __NAMESPACE__ . '\\BaseCommand' ) ) {
+		class BaseCommand {}
+	}
+	if ( ! class_exists( __NAMESPACE__ . '\\AgentResolver' ) ) {
+		class AgentResolver {
+			public static function resolve( $args ) { return 1; }
+			public static function buildScopingInput( $args ) { return array(); }
+		}
+	}
+	if ( ! class_exists( __NAMESPACE__ . '\\UserResolver' ) ) {
+		class UserResolver {}
+	}
+}
+
+namespace DataMachine\Cli\Commands {
+	if ( ! class_exists( __NAMESPACE__ . '\\DrainCommand' ) ) {
+		class DrainCommand {
+			const HOOK_BATCH_CHUNK  = 'batch';
+			const HOOK_EXECUTE_STEP = 'exec';
+			public static function drain( $args ) { return array(); }
+		}
+	}
+}
+
+namespace DataMachine\Engine\Debug {
+	if ( ! class_exists( __NAMESPACE__ . '\\SyncRunner' ) ) {
+		class SyncRunner {}
+	}
+}
+
+namespace DataMachine\Core\Steps {
+	if ( ! class_exists( __NAMESPACE__ . '\\FlowStepConfig' ) ) {
+		class FlowStepConfig {
+			public static function usesHandler( $step ) {
+				// system_task / dispatch are handler-free → false, which routes
+				// updateFlow() through normalizeHandlerFreeConfig().
+				$slug = $step['handler']['handler_slug'] ?? '';
+				return ! empty( $slug );
+			}
+			public static function getEffectiveSlug( $step, $fallback = '' ) {
+				return $step['flow_step_settings']['task'] ?? ( $step['handler']['handler_slug'] ?? '' );
+			}
+			public static function getConfiguredHandlerSlugs( $step ) { return array(); }
+			public static function getHandlerConfigs( $step ) { return array(); }
+			public static function getPrimaryHandlerConfig( $step ) { return array(); }
+		}
+	}
+}
+
+namespace DataMachine\Abilities {
+	if ( ! class_exists( __NAMESPACE__ . '\\HandlerAbilities' ) ) {
+		class HandlerAbilities {
+			public function getAllHandlers() { return array(); }
+			public function getConfigFields( $slug ) {
+				// system_task settings schema: task_type + params (json).
+				return array( 'task' => array(), 'params' => array() );
+			}
+		}
+	}
+}
+
+namespace DataMachine\Abilities\FlowStep {
+	// SPY: records every execute() call so the test can assert it is NEVER
+	// invoked during a dry-run and invoked exactly once otherwise.
+	if ( ! class_exists( __NAMESPACE__ . '\\UpdateFlowStepAbility' ) ) {
+		class UpdateFlowStepAbility {
+			public function execute( $input ) {
+				$GLOBALS['__smoke_persist_calls'][] = $input;
+				return array( 'success' => true, 'flow_step_id' => $input['flow_step_id'] ?? '', 'message' => 'ok' );
+			}
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Flows {
+	if ( ! class_exists( __NAMESPACE__ . '\\Flows' ) ) {
+		class Flows {
+			public function get_flow( $flow_id ) {
+				return $GLOBALS['__smoke_stored_flow'];
+			}
+			public function update_flow( $flow_id, $data ) {
+				$GLOBALS['__smoke_persist_calls'][] = array( 'repo_update_flow' => $data );
+				return true;
+			}
+		}
+	}
+}
+
+// ─── Load the real subject under test ─────────────────────────────────
+
+namespace {
+
+	require_once dirname( __DIR__ ) . '/inc/Cli/Commands/Flows/FlowsCommand.php';
+
+	use DataMachine\Cli\Commands\Flows\FlowsCommand;
+
+	/**
+	 * Invoke the real private updateFlow() with the given assoc args and return
+	 * a snapshot of recorded spy state.
+	 */
+	function smoke_run_update( array $assoc_args ): array {
+		$GLOBALS['__smoke_persist_calls'] = array();
+		$GLOBALS['__smoke_cli_lines']     = array();
+		$GLOBALS['__smoke_cli_success']   = array();
+		$GLOBALS['__smoke_cli_error']     = null;
+
+		$command = new FlowsCommand();
+		$ref     = new \ReflectionMethod( FlowsCommand::class, 'updateFlow' );
+		$ref->setAccessible( true );
+
+		try {
+			$ref->invoke( $command, 4, $assoc_args );
+		} catch ( \Smoke_WP_CLI_Abort $e ) {
+			// WP_CLI::error() aborts; surfaced via __smoke_cli_error.
+		}
+
+		return array(
+			'persist_calls' => $GLOBALS['__smoke_persist_calls'],
+			'lines'         => $GLOBALS['__smoke_cli_lines'],
+			'success'       => $GLOBALS['__smoke_cli_success'],
+			'error'         => $GLOBALS['__smoke_cli_error'],
+		);
+	}
+
+	echo "flows update --dry-run no-persist smoke (#2680)\n";
+	echo "------------------------------------------------\n";
+
+	// Snapshot the stored config (serialized) before any run.
+	$before = serialize( $GLOBALS['__smoke_stored_flow'] );
+
+	echo "\n[1] --handler-config --dry-run makes ZERO writes:\n";
+
+	$dry = smoke_run_update(
+		array(
+			'step'           => 'step_abc',
+			'handler-config' => '{"params":{"message":"DRYRUN_SENTINEL_SHOULD_NOT_PERSIST"}}',
+			'dry-run'        => true,
+		)
+	);
+
+	smoke_assert(
+		array() === $dry['persist_calls'],
+		'dry-run handler-config: persist ability NEVER executed',
+		count( $dry['persist_calls'] ) . ' persist call(s) recorded'
+	);
+
+	$after = serialize( $GLOBALS['__smoke_stored_flow'] );
+	smoke_assert(
+		$before === $after,
+		'dry-run handler-config: stored flow config byte-identical (no clobber)'
+	);
+
+	$dry_text = implode( "\n", array_merge( $dry['lines'], $dry['success'] ) );
+	smoke_assert(
+		false !== stripos( $dry_text, 'dry-run' ) && false !== stripos( $dry_text, 'no changes written' ),
+		'dry-run handler-config: emits "[dry-run] ... no changes written" preview',
+		$dry_text
+	);
+	smoke_assert(
+		array() === $dry['success'],
+		'dry-run handler-config: does NOT print a WP_CLI::success "updated" line',
+		implode( ' | ', $dry['success'] )
+	);
+
+	echo "\n[2] --handler-config WITHOUT --dry-run DOES persist (write path intact):\n";
+
+	$wet = smoke_run_update(
+		array(
+			'step'           => 'step_abc',
+			'handler-config' => '{"params":{"message":"REAL_WRITE"}}',
+		)
+	);
+
+	smoke_assert(
+		1 === count( $wet['persist_calls'] ),
+		'non-dry-run handler-config: persist ability executed exactly once',
+		count( $wet['persist_calls'] ) . ' persist call(s) recorded'
+	);
+	smoke_assert(
+		! empty( $wet['success'] ),
+		'non-dry-run handler-config: prints a success line'
+	);
+
+	echo "\n[3] --set-user-message --dry-run makes ZERO writes:\n";
+
+	$dry_msg = smoke_run_update(
+		array(
+			'step'             => 'step_abc',
+			'set-user-message' => 'DRYRUN_MESSAGE_SHOULD_NOT_PERSIST',
+			'dry-run'          => true,
+		)
+	);
+
+	smoke_assert(
+		array() === $dry_msg['persist_calls'],
+		'dry-run set-user-message: persist ability NEVER executed',
+		count( $dry_msg['persist_calls'] ) . ' persist call(s) recorded'
+	);
+	$dry_msg_text = implode( "\n", array_merge( $dry_msg['lines'], $dry_msg['success'] ) );
+	smoke_assert(
+		false !== stripos( $dry_msg_text, 'dry-run' ) && false !== stripos( $dry_msg_text, 'no changes written' ),
+		'dry-run set-user-message: emits "[dry-run] ... no changes written" preview',
+		$dry_msg_text
+	);
+
+	echo "\n[4] --set-user-message WITHOUT --dry-run DOES persist:\n";
+
+	$wet_msg = smoke_run_update(
+		array(
+			'step'             => 'step_abc',
+			'set-user-message' => 'REAL_MESSAGE',
+		)
+	);
+
+	smoke_assert(
+		1 === count( $wet_msg['persist_calls'] ),
+		'non-dry-run set-user-message: persist ability executed exactly once',
+		count( $wet_msg['persist_calls'] ) . ' persist call(s) recorded'
+	);
+
+	echo "\n------------------------------------------------\n";
+	$total = $passes + count( $failures );
+	echo "{$passes} / {$total} passed\n";
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFailures:\n";
+		foreach ( $failures as $failure ) {
+			echo " - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\nAll assertions passed.\n";
+}


### PR DESCRIPTION
## Summary

`wp datamachine flows update <id> --handler-config '...' --dry-run` (and the
`--set-user-message` / `--name` / `--scheduling` / `--agent` variants)
**persisted the change to the database anyway** and printed `Success: Handler
config updated ...` as if it were a no-op preview. `--dry-run` was only honored
on the *create* path. This is a silent data-destruction bug — it clobbered a
live 16k-char production flow message ("EC Agent Progress Ping", flow 4) down to
~11 chars **twice** while it was being used to *avoid* mutating that flow.

Closes #2680.

## Before / after

**Before** (dry-run persisted):
```
$ wp datamachine flows update 4 --step=<id> \
    --handler-config='{"params":{"message":"DRYRUN_SENTINEL"}}' --dry-run
Success: Handler config updated for step <id>: params   # <- WRITTEN to db
$ wp datamachine flows get 4   # message clobbered, sentinel present
```

**After** (dry-run = full validate + preview, zero writes):
```
$ wp datamachine flows update 4 --step=<id> \
    --handler-config='{"params":{"message":"DRYRUN_SENTINEL"}}' --dry-run
[dry-run] would update handler_config for step <id>: params; no changes written
$ wp datamachine flows get 4   # byte-identical, nothing written
```

Removing `--dry-run` runs the identical write path as before.

## What changed

- `inc/Cli/Commands/Flows/FlowsCommand.php` — thread `--dry-run` through
  `updateFlow()` so **every** write sub-path short-circuits BEFORE persist:
  - `--agent` (Flows::update_flow)
  - `--name` / `--scheduling` (datamachine/update-flow ability)
  - `--set-user-message` (UpdateFlowStepAbility)
  - `--handler-config` (UpdateFlowStepAbility)
- Validation and step resolution (bad JSON, unknown handler, AI/handler step
  resolution, shape normalization) STILL run in dry-run mode — it is a full
  validate + preview, just no write. On a dry-run the command emits a
  `[dry-run] would update ...; no changes written` line and never prints the
  misleading "...updated" success language.
- Updated the `--dry-run` and `updateFlow()` docblocks.

## Regression test

`tests/flows-update-dry-run-no-persist-smoke.php` (run directly:
`php tests/flows-update-dry-run-no-persist-smoke.php`) drives the **real**
`FlowsCommand::updateFlow()` via reflection against a spy persistence layer and
asserts:

1. `--handler-config --dry-run`: persist ability is **never** executed and the
   stored flow config (a 16k-char message, mirroring the prod flow) is
   **byte-identical** before/after.
2. The dry-run output is a `[dry-run] ... no changes written` preview, not a
   success "updated" line.
3. The same command **without** `--dry-run` executes the persist exactly once
   (write path intact).
4. Same guarantees for `--set-user-message`.

Verified red-then-green: the test fails 5/9 on the pre-fix code (dry-run paths
persisted) and passes 9/9 with the fix.

`php -l` clean; `phpcs` (WordPress standard) 0/0 on both changed files.

> PR only — not released/deployed.