### PR TITLE
Support typed artifact output assertions

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -544,8 +544,8 @@ class AIStep extends Step {
 			$loop_metadata = datamachine_conversation_metadata( $loop_result );
 
 			if ( $this->job_id > 0 ) {
-				$artifact_engine_data                           = datamachine_get_engine_data( $this->job_id );
-				$artifact_engine_data['tool_execution_summary'] = self::summarizeToolExecutions( $loop_result );
+				$artifact_engine_data                             = datamachine_get_engine_data( $this->job_id );
+				$artifact_engine_data['tool_execution_summary']   = self::summarizeToolExecutions( $loop_result );
 				$artifact_engine_data['tool_resolution_evidence'] = $tool_resolution_evidence;
 				if ( isset( $loop_result['runtime_provenance'] ) && is_array( $loop_result['runtime_provenance'] ) ) {
 					$artifact_engine_data['runtime_provenance'] = $loop_result['runtime_provenance'];
@@ -553,7 +553,7 @@ class AIStep extends Step {
 
 				$typed_artifacts = datamachine_normalize_typed_artifact_outputs( $loop_result );
 				if ( ! empty( $typed_artifacts ) ) {
-					$artifact_engine_data['outputs'] = is_array( $artifact_engine_data['outputs'] ?? null ) ? $artifact_engine_data['outputs'] : array();
+					$artifact_engine_data['outputs']                    = is_array( $artifact_engine_data['outputs'] ?? null ) ? $artifact_engine_data['outputs'] : array();
 					$artifact_engine_data['outputs']['typed_artifacts'] = array_replace_recursive(
 						is_array( $artifact_engine_data['outputs']['typed_artifacts'] ?? null ) ? $artifact_engine_data['outputs']['typed_artifacts'] : array(),
 						$typed_artifacts

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -25,6 +25,7 @@ use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 
 use function DataMachine\Engine\AI\datamachine_run_conversation;
 use function DataMachine\Engine\AI\datamachine_conversation_metadata;
+use function DataMachine\Engine\AI\datamachine_normalize_typed_artifact_outputs;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -550,6 +551,15 @@ class AIStep extends Step {
 					$artifact_engine_data['runtime_provenance'] = $loop_result['runtime_provenance'];
 				}
 
+				$typed_artifacts = datamachine_normalize_typed_artifact_outputs( $loop_result );
+				if ( ! empty( $typed_artifacts ) ) {
+					$artifact_engine_data['outputs'] = is_array( $artifact_engine_data['outputs'] ?? null ) ? $artifact_engine_data['outputs'] : array();
+					$artifact_engine_data['outputs']['typed_artifacts'] = array_replace_recursive(
+						is_array( $artifact_engine_data['outputs']['typed_artifacts'] ?? null ) ? $artifact_engine_data['outputs']['typed_artifacts'] : array(),
+						$typed_artifacts
+					);
+				}
+
 				foreach ( array( 'completion_assertions_required', 'completion_assertions_missing', 'completion_assertions_satisfied' ) as $assertion_key ) {
 					if ( isset( $loop_metadata[ $assertion_key ] ) && array() !== $loop_metadata[ $assertion_key ] ) {
 						$artifact_engine_data[ $assertion_key ] = $loop_metadata[ $assertion_key ];
@@ -707,13 +717,13 @@ class AIStep extends Step {
 	 */
 	private static function mergeCompletionAssertions( array $pipeline_assertions, array $flow_assertions ): array {
 		$merged = array();
-		foreach ( array( 'required_engine_data_keys', 'required_tool_names', 'required_output_packet_types' ) as $key ) {
+		foreach ( array( 'required_engine_data_keys', 'required_tool_names', 'required_output_packet_types', 'required_artifact_outputs' ) as $key ) {
 			$values = array_merge(
-				self::normalizeCompletionAssertionList( $pipeline_assertions[ $key ] ?? array() ),
-				self::normalizeCompletionAssertionList( $flow_assertions[ $key ] ?? array() )
+				self::normalizeCompletionAssertionValues( $pipeline_assertions[ $key ] ?? array() ),
+				self::normalizeCompletionAssertionValues( $flow_assertions[ $key ] ?? array() )
 			);
 			if ( ! empty( $values ) ) {
-				$merged[ $key ] = array_values( array_unique( $values ) );
+				$merged[ $key ] = 'required_artifact_outputs' === $key ? array_values( $values ) : array_values( array_unique( $values ) );
 			}
 		}
 
@@ -780,6 +790,36 @@ class AIStep extends Step {
 
 		$items = array();
 		foreach ( $value as $item ) {
+			$item = trim( (string) $item );
+			if ( '' !== $item ) {
+				$items[] = $item;
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Normalize scalar assertion values while preserving structured assertion entries.
+	 *
+	 * @param mixed $value Raw assertion values.
+	 * @return array<int, mixed>
+	 */
+	private static function normalizeCompletionAssertionValues( $value ): array {
+		if ( is_string( $value ) && '' !== $value ) {
+			$value = array( $value );
+		}
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( $value as $item ) {
+			if ( is_array( $item ) ) {
+				$items[] = $item;
+				continue;
+			}
+
 			$item = trim( (string) $item );
 			if ( '' !== $item ) {
 				$items[] = $item;

--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -26,6 +26,9 @@ class DataMachineCompletionAssertions {
 	/** @var array<int, string> */
 	private array $required_output_packet_types;
 
+	/** @var array<int, array{output_key: string, schema: string, artifact: string}> */
+	private array $required_artifact_outputs;
+
 	/** @var array<int, array{name: string, tools: array<int, array{name: string, required_output: array<int, string>, required_parameters: array<string, mixed>, min_successful_calls: int}>}> */
 	private array $complete_when_any;
 
@@ -46,6 +49,7 @@ class DataMachineCompletionAssertions {
 		$this->required_tool_names            = $this->sanitizeList( $config['required_tool_names'] ?? array() );
 		$this->minimum_successful_tool_counts = $this->sanitizeToolCountMap( $config['minimum_successful_tool_counts'] ?? array() );
 		$this->required_output_packet_types   = $this->sanitizeList( $config['required_output_packet_types'] ?? array() );
+		$this->required_artifact_outputs      = $this->sanitizeRequiredArtifactOutputs( $config['required_artifact_outputs'] ?? array() );
 		$this->complete_when_any              = $this->sanitizeOutcomeAssertions( $config['complete_when_any'] ?? array() );
 	}
 
@@ -59,6 +63,7 @@ class DataMachineCompletionAssertions {
 			|| ! empty( $this->required_tool_names )
 			|| ! empty( $this->minimum_successful_tool_counts )
 			|| ! empty( $this->required_output_packet_types )
+			|| ! empty( $this->required_artifact_outputs )
 			|| ! empty( $this->complete_when_any );
 	}
 
@@ -121,6 +126,7 @@ class DataMachineCompletionAssertions {
 			'tool_names'          => array_values( array_intersect( $this->required_tool_names, array_unique( $this->executed_tool_names ) ) ),
 			'tool_counts'         => $this->satisfiedToolCounts(),
 			'output_packet_types' => array_values( array_intersect( $this->required_output_packet_types, $output_packet_types ) ),
+			'artifact_outputs'    => $this->satisfiedArtifactOutputKeys( $runtime_context ),
 			'complete_when_any'   => $outcome_evaluation['satisfied'],
 		);
 
@@ -130,6 +136,7 @@ class DataMachineCompletionAssertions {
 				'tool_names'          => array_values( array_diff( $this->required_tool_names, $satisfied['tool_names'] ) ),
 				'tool_counts'         => $this->missingToolCounts(),
 				'output_packet_types' => array_values( array_diff( $this->required_output_packet_types, $satisfied['output_packet_types'] ) ),
+				'artifact_outputs'    => array_values( array_diff( $this->requiredArtifactOutputKeys(), $satisfied['artifact_outputs'] ) ),
 				'complete_when_any'   => $outcome_evaluation['missing'],
 			)
 		);
@@ -172,6 +179,7 @@ class DataMachineCompletionAssertions {
 				'tool_names'          => $this->required_tool_names,
 				'tool_counts'         => $this->requiredToolCounts(),
 				'output_packet_types' => $this->required_output_packet_types,
+				'artifact_outputs'    => $this->required_artifact_outputs,
 				'complete_when_any'   => $this->complete_when_any,
 			)
 		);
@@ -567,6 +575,55 @@ class DataMachineCompletionAssertions {
 	}
 
 	/**
+	 * @param mixed $value Raw typed artifact output assertions.
+	 * @return array<int, array{output_key: string, schema: string, artifact: string}>
+	 */
+	private function sanitizeRequiredArtifactOutputs( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$outputs = array();
+		foreach ( $value as $key => $entry ) {
+			if ( is_string( $entry ) ) {
+				$output_key = trim( $entry );
+				$schema     = '';
+				$artifact   = '';
+			} elseif ( is_array( $entry ) ) {
+				$output_key = trim( (string) ( $entry['output_key'] ?? ( is_string( $key ) ? $key : '' ) ) );
+				$schema     = trim( (string) ( $entry['schema'] ?? '' ) );
+				$artifact   = trim( (string) ( $entry['artifact'] ?? '' ) );
+			} else {
+				continue;
+			}
+
+			if ( '' !== $output_key ) {
+				$outputs[] = array(
+					'output_key' => $output_key,
+					'schema'     => $schema,
+					'artifact'   => $artifact,
+				);
+			}
+		}
+
+		return array_values(
+			array_reduce(
+				$outputs,
+				static function ( array $carry, array $output ): array {
+					$carry[ $output['output_key'] ] = $output;
+					return $carry;
+				},
+				array()
+			)
+		);
+	}
+
+	/** @return array<int, string> */
+	private function requiredArtifactOutputKeys(): array {
+		return array_values( array_unique( array_map( static fn( array $output ): string => $output['output_key'], $this->required_artifact_outputs ) ) );
+	}
+
+	/**
 	 * @param array $runtime_context Caller-owned runtime context.
 	 * @return array<int, string>
 	 */
@@ -597,6 +654,48 @@ class DataMachineCompletionAssertions {
 		}
 
 		return array_values( array_unique( $satisfied ) );
+	}
+
+	/**
+	 * @param array $runtime_context Caller-owned runtime context.
+	 * @return array<int, string>
+	 */
+	private function satisfiedArtifactOutputKeys( array $runtime_context ): array {
+		$engine = $runtime_context['engine'] ?? null;
+		$data   = is_array( $runtime_context['engine_data'] ?? null ) ? $runtime_context['engine_data'] : array();
+
+		if ( is_object( $engine ) && method_exists( $engine, 'all' ) ) {
+			$engine_data = $engine->all();
+			if ( is_array( $engine_data ) ) {
+				$data = array_replace_recursive( $data, $engine_data );
+			}
+		}
+
+		$typed_artifacts = is_array( $data['outputs']['typed_artifacts'] ?? null ) ? $data['outputs']['typed_artifacts'] : array();
+		$satisfied       = array();
+		foreach ( $this->required_artifact_outputs as $required_output ) {
+			$output_key = $required_output['output_key'];
+			$output     = is_array( $typed_artifacts[ $output_key ] ?? null ) ? $typed_artifacts[ $output_key ] : array();
+			if ( ! $this->hasOutputPayload( $output ) ) {
+				continue;
+			}
+
+			if ( '' !== $required_output['schema'] && $required_output['schema'] !== (string) ( $output['schema'] ?? '' ) ) {
+				continue;
+			}
+
+			if ( '' !== $required_output['artifact'] && $required_output['artifact'] !== (string) ( $output['artifact'] ?? '' ) ) {
+				continue;
+			}
+
+			$satisfied[] = $output_key;
+		}
+
+		return array_values( array_unique( $satisfied ) );
+	}
+
+	private function hasOutputPayload( array $output ): bool {
+		return array_key_exists( 'payload', $output ) && null !== $output['payload'] && '' !== $output['payload'] && array() !== $output['payload'];
 	}
 
 	/**

--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -680,11 +680,11 @@ class DataMachineCompletionAssertions {
 				continue;
 			}
 
-			if ( '' !== $required_output['schema'] && $required_output['schema'] !== (string) ( $output['schema'] ?? '' ) ) {
+			if ( '' !== $required_output['schema'] && (string) ( $output['schema'] ?? '' ) !== $required_output['schema'] ) {
 				continue;
 			}
 
-			if ( '' !== $required_output['artifact'] && $required_output['artifact'] !== (string) ( $output['artifact'] ?? '' ) ) {
+			if ( '' !== $required_output['artifact'] && (string) ( $output['artifact'] ?? '' ) !== $required_output['artifact'] ) {
 				continue;
 			}
 

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -402,7 +402,19 @@ function datamachine_run_conversation(
 		}
 	}
 	if ( $assertions->hasAssertions() ) {
-		$evaluation = $assertions->evaluate( $loop_payload, $result['final_content'] ?? '' );
+		$evaluation_context = $loop_payload;
+		$typed_artifacts    = datamachine_normalize_typed_artifact_outputs( $result );
+		if ( ! empty( $typed_artifacts ) ) {
+			$evaluation_engine_data            = is_array( $evaluation_context['engine_data'] ?? null ) ? $evaluation_context['engine_data'] : array();
+			$evaluation_engine_data['outputs'] = is_array( $evaluation_engine_data['outputs'] ?? null ) ? $evaluation_engine_data['outputs'] : array();
+			$evaluation_engine_data['outputs']['typed_artifacts'] = array_replace_recursive(
+				is_array( $evaluation_engine_data['outputs']['typed_artifacts'] ?? null ) ? $evaluation_engine_data['outputs']['typed_artifacts'] : array(),
+				$typed_artifacts
+			);
+			$evaluation_context['engine_data']                    = $evaluation_engine_data;
+		}
+
+		$evaluation = $assertions->evaluate( $evaluation_context, $result['final_content'] ?? '' );
 		$datamachine_metadata['completion_assertions_required']  = $assertions->required();
 		$datamachine_metadata['completion_assertions_missing']   = $evaluation['missing'];
 		$datamachine_metadata['completion_assertions_satisfied'] = $evaluation['satisfied'];
@@ -490,6 +502,53 @@ function datamachine_conversation_metadata_top_level_keys(): array {
 function datamachine_conversation_metadata( array $result ): array {
 	$metadata = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
 	return is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
+}
+
+/**
+ * Normalize typed artifact outputs from runtime result shapes into engine-data output shape.
+ *
+ * @param array $result Conversation result.
+ * @return array<string,array<string,mixed>> Typed artifacts keyed by output key.
+ */
+function datamachine_normalize_typed_artifact_outputs( array $result ): array {
+	$sources = array();
+	if ( is_array( $result['outputs']['typed_artifacts'] ?? null ) ) {
+		$sources[] = $result['outputs']['typed_artifacts'];
+	}
+	if ( is_array( $result['typed_artifacts'] ?? null ) ) {
+		$sources[] = $result['typed_artifacts'];
+	}
+
+	$typed_artifacts = array();
+	foreach ( $sources as $source ) {
+		foreach ( $source as $key => $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$output_key = trim( (string) ( $entry['output_key'] ?? $entry['key'] ?? ( is_string( $key ) ? $key : '' ) ) );
+			if ( '' === $output_key ) {
+				continue;
+			}
+
+			$payload = $entry['payload'] ?? $entry['data'] ?? $entry['content'] ?? null;
+			if ( null === $payload || '' === $payload || array() === $payload ) {
+				continue;
+			}
+
+			$normalized = array( 'payload' => $payload );
+			foreach ( array( 'schema', 'artifact' ) as $field ) {
+				$value = trim( (string) ( $entry[ $field ] ?? '' ) );
+				if ( '' !== $value ) {
+					$normalized[ $field ] = $value;
+				}
+			}
+
+			$typed_artifacts[ $output_key ] = $normalized;
+		}
+	}
+
+	return $typed_artifacts;
 }
 
 /**

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -300,7 +300,7 @@ function datamachine_run_conversation(
 
 	// Normalize the substrate result and augment with DM-specific fields.
 	try {
-		$result = WP_Agent_Conversation_Result::normalize( $result );
+		$result                    = WP_Agent_Conversation_Result::normalize( $result );
 		$completion_policy_stopped = false;
 		foreach ( is_array( $result['events'] ?? null ) ? $result['events'] : array() as $event ) {
 			if ( ! is_array( $event ) || ! in_array( (string) ( $event['type'] ?? '' ), array( 'completion_policy_stop', 'completion_policy_continue' ), true ) ) {
@@ -405,8 +405,8 @@ function datamachine_run_conversation(
 		$evaluation_context = $loop_payload;
 		$typed_artifacts    = datamachine_normalize_typed_artifact_outputs( $result );
 		if ( ! empty( $typed_artifacts ) ) {
-			$evaluation_engine_data            = is_array( $evaluation_context['engine_data'] ?? null ) ? $evaluation_context['engine_data'] : array();
-			$evaluation_engine_data['outputs'] = is_array( $evaluation_engine_data['outputs'] ?? null ) ? $evaluation_engine_data['outputs'] : array();
+			$evaluation_engine_data                               = is_array( $evaluation_context['engine_data'] ?? null ) ? $evaluation_context['engine_data'] : array();
+			$evaluation_engine_data['outputs']                    = is_array( $evaluation_engine_data['outputs'] ?? null ) ? $evaluation_engine_data['outputs'] : array();
 			$evaluation_engine_data['outputs']['typed_artifacts'] = array_replace_recursive(
 				is_array( $evaluation_engine_data['outputs']['typed_artifacts'] ?? null ) ? $evaluation_engine_data['outputs']['typed_artifacts'] : array(),
 				$typed_artifacts

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -295,7 +295,7 @@ final class AgentBundleRunner {
 		$engine_data = is_array( $response['engine_data'] ?? null ) ? $response['engine_data'] : array();
 		$mappings    = $this->declared_output_mappings( $input );
 		$required    = $this->required_output_keys( $engine_data, $input );
-		$artifacts   = $this->required_artifact_keys( $input );
+		$artifacts   = $this->required_artifact_keys( $input, $engine_data );
 		$declared    = array_values( array_unique( array_merge( $required, $artifacts, array_keys( $mappings ) ) ) );
 		$outputs     = array();
 
@@ -317,6 +317,14 @@ final class AgentBundleRunner {
 				$key = sanitize_key( (string) $key );
 				if ( '' !== $key && $this->has_output_value( $value ) ) {
 					$outputs[ $key ] = $value;
+				}
+			}
+
+			$typed_artifacts = is_array( $engine_data['outputs']['typed_artifacts'] ?? null ) ? $engine_data['outputs']['typed_artifacts'] : array();
+			foreach ( $typed_artifacts as $key => $artifact_output ) {
+				$key = sanitize_key( (string) $key );
+				if ( '' !== $key && is_array( $artifact_output ) && $this->has_output_value( $artifact_output['payload'] ?? null ) ) {
+					$outputs[ $key ] = $artifact_output['payload'];
 				}
 			}
 		}
@@ -461,8 +469,26 @@ final class AgentBundleRunner {
 	}
 
 	/** @return array<int,string> */
-	private function required_artifact_keys( array $input ): array {
-		return $this->normalize_required_key_list( $input['required_artifacts'] ?? array() );
+	private function required_artifact_keys( array $input, array $engine_data = array() ): array {
+		$keys = $this->normalize_required_key_list( $input['required_artifacts'] ?? array() );
+		$keys = array_merge( $keys, $this->required_artifact_output_keys_from_engine_data( $engine_data ) );
+		return array_values( array_unique( $keys ) );
+	}
+
+	/** @return array<int,string> */
+	private function required_artifact_output_keys_from_engine_data( array $engine_data ): array {
+		$assertions = is_array( $engine_data['completion_assertions_required'] ?? null ) ? $engine_data['completion_assertions_required'] : array();
+		$outputs    = is_array( $assertions['artifact_outputs'] ?? null ) ? $assertions['artifact_outputs'] : array();
+		$keys       = array();
+		foreach ( $outputs as $output ) {
+			if ( is_array( $output ) ) {
+				$keys[] = $output['output_key'] ?? '';
+			} elseif ( is_scalar( $output ) ) {
+				$keys[] = (string) $output;
+			}
+		}
+
+		return $this->normalize_required_key_list( $keys );
 	}
 
 	/** @return array<int,string> */

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -117,7 +117,16 @@ $projected_outputs = $output_projection->invoke(
 	$runner_instance,
 	array(
 		'engine_data' => array(
-			'completion_assertions_required' => array( 'engine_data_keys' => array( 'issue_number', 'issue_url', 'missing_result_url' ) ),
+			'completion_assertions_required' => array(
+				'engine_data_keys' => array( 'issue_number', 'issue_url', 'missing_result_url' ),
+				'artifact_outputs' => array(
+					array(
+						'output_key' => 'concept_packet',
+						'schema'     => 'wp-site-generator/ConceptPacket/v1',
+						'artifact'   => 'ConceptPacket',
+					),
+				),
+			),
 			'issue_number'                   => 123,
 			'issue_url'                      => 'https://github.com/Extra-Chill/data-machine/issues/2519',
 			'result_path'                    => 'artifacts/result.json',
@@ -126,16 +135,26 @@ $projected_outputs = $output_projection->invoke(
 				'issue_number' => 456,
 				'issue_url'    => 'https://github.com/chubes4/wp-site-generator/issues/456',
 			),
-			'outputs'                        => array( 'summary_title' => 'semantic output projection' ),
+			'outputs'                        => array(
+				'summary_title'    => 'semantic output projection',
+				'typed_artifacts'  => array(
+					'concept_packet' => array(
+						'schema'   => 'wp-site-generator/ConceptPacket/v1',
+						'artifact' => 'ConceptPacket',
+						'payload'  => array( 'title' => 'Projected typed artifact' ),
+					),
+				),
+			),
 		),
 	),
 	array(
 		'required_outputs'    => array( 'issue_number', 'issue_url' ),
-		'required_artifacts'   => array( 'concept_packet' ),
+		'required_artifacts'   => array(),
 		'engine_data_outputs' => array(
 			'store_issue_number' => 'metadata.engine_data.store_idea_agent.issue_number',
 			'store_issue_url'    => 'metadata.engine_data.store_idea_agent.issue_url',
 			'missing_store_url'  => 'metadata.engine_data.store_idea_agent.missing_url',
+			'concept_packet'     => 'metadata.engine_data.outputs.typed_artifacts.concept_packet.payload',
 		),
 	)
 );
@@ -145,10 +164,11 @@ datamachine_bundle_runner_assert( 'artifacts/result.json' === ( $projected_outpu
 datamachine_bundle_runner_assert( 'semantic output projection' === ( $projected_outputs['outputs']['summary_title'] ?? null ), 'explicit outputs map is projected', $failures, $passes );
 datamachine_bundle_runner_assert( 456 === ( $projected_outputs['outputs']['store_issue_number'] ?? null ), 'declared nested engine_data output number is projected', $failures, $passes );
 datamachine_bundle_runner_assert( 'https://github.com/chubes4/wp-site-generator/issues/456' === ( $projected_outputs['outputs']['store_issue_url'] ?? null ), 'declared nested engine_data output URL is projected', $failures, $passes );
+datamachine_bundle_runner_assert( array( 'title' => 'Projected typed artifact' ) === ( $projected_outputs['outputs']['concept_packet'] ?? null ), 'declared typed artifact payload path is projected', $failures, $passes );
 datamachine_bundle_runner_assert( ! isset( $projected_outputs['outputs']['agent_id'] ), 'runtime identity fields are not projected as outputs', $failures, $passes );
 datamachine_bundle_runner_assert( array( 'issue_number', 'issue_url', 'missing_result_url' ) === ( $projected_outputs['diagnostics']['required_outputs'] ?? null ), 'required semantic outputs are diagnosed', $failures, $passes );
 datamachine_bundle_runner_assert( array( 'concept_packet' ) === ( $projected_outputs['diagnostics']['required_artifacts'] ?? null ), 'required typed artifacts are diagnosed', $failures, $passes );
-datamachine_bundle_runner_assert( array( 'missing_result_url', 'concept_packet', 'missing_store_url' ) === ( $projected_outputs['diagnostics']['missing_outputs'] ?? null ), 'missing declared outputs are diagnosed semantically', $failures, $passes );
+datamachine_bundle_runner_assert( array( 'missing_result_url', 'missing_store_url' ) === ( $projected_outputs['diagnostics']['missing_outputs'] ?? null ), 'missing declared outputs are diagnosed semantically', $failures, $passes );
 
 echo "\n[3a] Failed terminal status families are not successful\n";
 $success_status = $runner_reflection->getMethod( 'is_success_status' );

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -1204,6 +1204,55 @@ $failed_required_tool_decision = $failed_required_tool_policy->recordNaturalComp
 assert_runtime_policy( ! $failed_required_tool_decision->isComplete(), 'failed required tool does not satisfy completion assertion' );
 assert_runtime_policy( array( 'workspace_edit', 'workspace_git_commit' ) === ( $failed_required_tool_decision->context()['missing']['tool_names'] ?? null ), 'failed required tool remains in missing assertion list' );
 
+$typed_artifact_assertions = new \DataMachine\Engine\AI\DataMachineCompletionAssertions(
+	array(
+		'required_artifact_outputs' => array(
+			array(
+				'output_key' => 'concept_packet',
+				'schema'     => 'wp-site-generator/ConceptPacket/v1',
+				'artifact'   => 'ConceptPacket',
+			),
+		),
+	)
+);
+$typed_artifact_evaluation = $typed_artifact_assertions->evaluate(
+	array(
+		'engine_data' => array(
+			'outputs' => array(
+				'typed_artifacts' => array(
+					'concept_packet' => array(
+						'schema'   => 'wp-site-generator/ConceptPacket/v1',
+						'artifact' => 'ConceptPacket',
+						'payload'  => array( 'title' => 'Test concept' ),
+					),
+				),
+			),
+		),
+	),
+	''
+);
+assert_runtime_policy( $typed_artifact_evaluation['complete'], 'required_artifact_outputs completes from outputs.typed_artifacts.<key>.payload' );
+assert_runtime_policy( array( 'concept_packet' ) === ( $typed_artifact_evaluation['satisfied']['artifact_outputs'] ?? null ), 'required_artifact_outputs reports satisfied output key' );
+
+$missing_typed_artifact_evaluation = $typed_artifact_assertions->evaluate(
+	array(
+		'engine_data' => array(
+			'outputs' => array(
+				'typed_artifacts' => array(
+					'concept_packet' => array(
+						'schema'   => 'wp-site-generator/ConceptPacket/v2',
+						'artifact' => 'ConceptPacket',
+						'payload'  => array( 'title' => 'Wrong schema' ),
+					),
+				),
+			),
+		),
+	),
+	''
+);
+assert_runtime_policy( ! $missing_typed_artifact_evaluation['complete'], 'required_artifact_outputs rejects mismatched typed artifact schema' );
+assert_runtime_policy( array( 'concept_packet' ) === ( $missing_typed_artifact_evaluation['missing']['artifact_outputs'] ?? null ), 'required_artifact_outputs reports missing output key on schema mismatch' );
+
 $outcome_assertions_config = array(
 	'complete_when_any' => array(
 		array(

--- a/tests/typed-artifact-output-contract-smoke.php
+++ b/tests/typed-artifact-output-contract-smoke.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Focused contract test for typed artifact completion/output plumbing.
+ *
+ * Run with: php tests/typed-artifact-output-contract-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$root     = dirname( __DIR__ );
+$failures = array();
+$passes   = 0;
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', $root . '/' );
+
+require_once $root . '/inc/Engine/AI/DataMachineCompletionAssertions.php';
+require_once $root . '/inc/Engine/AI/conversation-loop.php';
+
+function datamachine_typed_artifact_contract_assert( bool $condition, string $label, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "  PASS {$label}\n";
+		return;
+	}
+
+	$failures[] = $label;
+	echo "  FAIL {$label}\n";
+}
+
+echo "typed-artifact-output-contract-smoke\n";
+
+$normalized = \DataMachine\Engine\AI\datamachine_normalize_typed_artifact_outputs(
+	array(
+		'typed_artifacts' => array(
+			array(
+				'output_key' => 'concept_packet',
+				'schema'     => 'wp-site-generator/ConceptPacket/v1',
+				'artifact'   => 'ConceptPacket',
+				'payload'    => array( 'title' => 'Normalized concept' ),
+			),
+		),
+	)
+);
+
+datamachine_typed_artifact_contract_assert(
+	array( 'title' => 'Normalized concept' ) === ( $normalized['concept_packet']['payload'] ?? null ),
+	'loop result typed_artifacts normalize to outputs.typed_artifacts.<key>.payload shape',
+	$failures,
+	$passes
+);
+
+$assertions = new \DataMachine\Engine\AI\DataMachineCompletionAssertions(
+	array(
+		'required_artifact_outputs' => array(
+			array(
+				'output_key' => 'concept_packet',
+				'schema'     => 'wp-site-generator/ConceptPacket/v1',
+				'artifact'   => 'ConceptPacket',
+			),
+		),
+	)
+);
+
+$satisfied = $assertions->evaluate(
+	array(
+		'engine_data' => array(
+			'outputs' => array(
+				'typed_artifacts' => $normalized,
+			),
+		),
+	),
+	''
+);
+
+datamachine_typed_artifact_contract_assert( true === $satisfied['complete'], 'required_artifact_outputs is recognized as a completion assertion target', $failures, $passes );
+datamachine_typed_artifact_contract_assert( array( 'concept_packet' ) === ( $satisfied['satisfied']['artifact_outputs'] ?? null ), 'typed artifact completion reports the satisfied output key', $failures, $passes );
+
+$missing = $assertions->evaluate(
+	array(
+		'engine_data' => array(
+			'outputs' => array(
+				'typed_artifacts' => array(
+					'concept_packet' => array(
+						'schema'   => 'wp-site-generator/ConceptPacket/v1',
+						'artifact' => 'ConceptPacket',
+						'payload'  => array(),
+					),
+				),
+			),
+		),
+	),
+	''
+);
+
+datamachine_typed_artifact_contract_assert( false === $missing['complete'], 'empty typed artifact payload does not satisfy required_artifact_outputs', $failures, $passes );
+datamachine_typed_artifact_contract_assert( array( 'concept_packet' ) === ( $missing['missing']['artifact_outputs'] ?? null ), 'missing typed artifact output reports the required output key', $failures, $passes );
+
+if ( ! empty( $failures ) ) {
+	echo "\nTyped artifact output contract smoke failed (" . count( $failures ) . " failure(s)).\n";
+	exit( 1 );
+}
+
+echo "\nTyped artifact output contract smoke passed ({$passes} assertions).\n";


### PR DESCRIPTION
## Summary
- Add generic `required_artifact_outputs` completion assertions for typed artifact outputs.
- Normalize runtime typed artifact results into `engine_data["outputs"]["typed_artifacts"][<output_key>]["payload"]`.
- Project typed artifact payloads through `AgentBundleRunner` and cover the documented `outputs.typed_artifacts.<key>.payload` mapping path.

## Tests
- `php -l "inc/Engine/AI/DataMachineCompletionAssertions.php" && php -l "inc/Engine/AI/conversation-loop.php" && php -l "inc/Core/Steps/AI/AIStep.php" && php -l "inc/Engine/Bundle/AgentBundleRunner.php"`
- `vendor/bin/phpcs "inc/Engine/AI/DataMachineCompletionAssertions.php" "inc/Engine/AI/conversation-loop.php" "inc/Core/Steps/AI/AIStep.php" "inc/Engine/Bundle/AgentBundleRunner.php" "tests/agent-conversation-runtime-policy-smoke.php" "tests/agent-bundle-runner-contract-smoke.php" "tests/typed-artifact-output-contract-smoke.php"`
- `php tests/typed-artifact-output-contract-smoke.php`
- `php tests/agent-bundle-runner-contract-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented typed artifact completion/output contract support and focused coverage; Chris remains responsible for review and testing.