### PR TITLE
fix: match live-origin bundle flows by rename-proof handler identity in adopt (#2683)

### DIFF
--- a/inc/Engine/Bundle/AgentBundleAbilityService.php
+++ b/inc/Engine/Bundle/AgentBundleAbilityService.php
@@ -760,9 +760,9 @@ final class AgentBundleAbilityService {
 			if ( $new_pipeline_id <= 0 ) {
 				continue;
 			}
-			$flow_slug      = AgentBundleSlugMatcher::bundle_slug( $flow, 'flow_name', 'flow' );
-			$flow_index     = AgentBundleSlugMatcher::index_existing( $existing_flows_by_pipeline[ $new_pipeline_id ] ?? array(), 'flow_name', 'flow' );
-			$existing_flow  = $flow_index['matched'][ $flow_slug ] ?? null;
+			$flow_slug     = AgentBundleSlugMatcher::bundle_slug( $flow, 'flow_name', 'flow' );
+			$flow_index    = AgentBundleSlugMatcher::index_existing( $existing_flows_by_pipeline[ $new_pipeline_id ] ?? array(), 'flow_name', 'flow' );
+			$existing_flow = $flow_index['matched'][ $flow_slug ] ?? null;
 			if ( null === $existing_flow ) {
 				continue;
 			}

--- a/inc/Engine/Bundle/AgentBundleAbilityService.php
+++ b/inc/Engine/Bundle/AgentBundleAbilityService.php
@@ -306,7 +306,10 @@ final class AgentBundleAbilityService {
 		$pipeline_index = AgentBundleSlugMatcher::index_existing( $pipeline_rows, 'pipeline_name', 'pipeline' );
 
 		// Map original bundle pipeline id -> live pipeline id so flows can be
-		// scoped to the right live pipeline.
+		// scoped to the right live pipeline. The in-memory bundle adopt loads
+		// (AgentBundleArrayAdapter::to_array_bundle) synthesizes `original_id` on
+		// every pipeline and `original_pipeline_id` on every flow, so this keys
+		// the scope correctly for live-origin bundles.
 		$pipeline_id_map = array();
 
 		foreach ( $bundle['pipelines'] ?? array() as $bundle_pipeline ) {
@@ -387,15 +390,43 @@ final class AgentBundleAbilityService {
 
 			$live = $flow_index['matched'][ $slug_key ] ?? null;
 
-			// Pipeline-scoped fallback: live-origin flow rows carry no slug, so a
-			// bundle flow keyed on its UNIQUE slug (e.g. "ticketmaster-63") never
-			// meets the live row keyed on its source label ("ticketmaster"). The
-			// global pass above already bounded the candidates to this flow's
-			// matched parent pipeline, where the source label IS unique. So when
-			// the slug key misses, re-key BOTH sides on the normalized source
-			// label within this single pipeline. A unique match there is
-			// unambiguous; the unique bundle slug is still what gets backfilled
-			// onto the row. A genuine in-pipeline name collision stays ambiguous.
+			// Pipeline-scoped handler fallback (primary): the unique-slug pass
+			// above misses for live-origin source flows because the bundle's slug
+			// was deduped at export ("dice-fm-101") and its `name` was renamed to
+			// "<Source> — <City>" (event-bundles#5), while the live row still
+			// carries the bare source label ("Dice.fm"). Neither editable label
+			// can meet the live row. The flow's import HANDLER, however, is
+			// rename-proof: within this already-matched parent pipeline a given
+			// source ("dice_fm", "ticketmaster") appears once — per-venue scrapers
+			// share `universal_web_scraper` but already resolved on the unique
+			// slug pass before reaching here. So re-key BOTH sides on the
+			// normalized handler identity (bundle `steps[]` vs live `flow_config`).
+			// A unique match is unambiguous; a genuine in-pipeline handler
+			// collision stays ambiguous and is never guessed.
+			if ( null === $live ) {
+				$handler_key = AgentBundleSlugMatcher::bundle_handler_key( $bundle_flow, 'flow' );
+				if ( '' !== $handler_key ) {
+					$handler_index = AgentBundleSlugMatcher::index_existing_by_handler( $scoped_rows, 'flow' );
+
+					if ( isset( $handler_index['ambiguous'][ $handler_key ] ) ) {
+						$ambiguous[] = array(
+							'artifact_type' => 'flow',
+							'artifact_id'   => $slug_key,
+							'reason'        => sprintf( '%d live flows on pipeline %d resolve to handler "%s".', count( $handler_index['ambiguous'][ $handler_key ] ), $live_pipeline, $handler_key ),
+						);
+						continue;
+					}
+
+					$live = $handler_index['matched'][ $handler_key ] ?? null;
+				}
+			}
+
+			// Pipeline-scoped name fallback (last resort): when a flow carries no
+			// usable handler signal, fall back to the normalized source label
+			// within this single pipeline. Preserved for flows whose only stable
+			// cross-side identity is the (unrenamed) display name; the unique
+			// bundle slug is still what gets backfilled. A genuine in-pipeline
+			// name collision stays ambiguous.
 			if ( null === $live ) {
 				$name_key   = AgentBundleSlugMatcher::bundle_name_key( $bundle_flow, 'flow_name', 'flow' );
 				$name_index = AgentBundleSlugMatcher::index_existing_by_name( $scoped_rows, 'flow_name', 'flow' );

--- a/inc/Engine/Bundle/AgentBundleSlugMatcher.php
+++ b/inc/Engine/Bundle/AgentBundleSlugMatcher.php
@@ -167,6 +167,212 @@ final class AgentBundleSlugMatcher {
 	}
 
 	/**
+	 * Compute the normalized HANDLER-identity key for a bundle flow.
+	 *
+	 * The display name is mutable: extrachill-event-bundles#5 renamed every
+	 * colliding bundle flow `name` from the bare source label ("Dice.fm") to
+	 * "<Source> — <City>" ("Dice.fm — Austin"), and the export-time global
+	 * dedupe appends a numeric suffix to the slug ("dice-fm-101"). Neither the
+	 * renamed name nor the deduped slug can meet the unchanged live `flow_name`
+	 * ("Dice.fm"). The flow's SOURCE handler, however, is rename-proof: the first
+	 * non-AI/non-output step's handler slug ("dice_fm", "ticketmaster",
+	 * "bandsintown") is the stable per-source identity that survives every UI
+	 * rename. Within a single city pipeline a given import source appears once
+	 * (per-venue scrapers all share `universal_web_scraper`, but those resolve on
+	 * the unique slug pass BEFORE this fallback is reached), so the handler key is
+	 * unambiguous there. This is the bundle-side counterpart to
+	 * {@see self::index_existing_by_handler()}.
+	 *
+	 * A bundle flow carries its steps in one of two equivalent shapes depending
+	 * on how it was loaded: the on-disk document shape exposes an ordered
+	 * `steps[]` list (each entry with `step_type` / `handler_slugs`), while the
+	 * in-memory array-bundle shape produced by
+	 * {@see AgentBundleArrayAdapter::to_array_bundle()} (what `adopt()` actually
+	 * loads) carries the same data as a `flow_config` map keyed by step id. Both
+	 * are scanned identically — the live row uses the very same `flow_config`
+	 * shape — so the bundle and live sides always derive the same handler key.
+	 *
+	 * @param array<string,mixed> $flow     Bundle flow entry.
+	 * @param string              $fallback PortableSlug fallback (flow).
+	 * @return string Normalized handler key, or '' when no handler step exists.
+	 */
+	public static function bundle_handler_key( array $flow, string $fallback ): string {
+		if ( is_array( $flow['steps'] ?? null ) && array() !== $flow['steps'] ) {
+			// On-disk document shape: an ordered steps[] list.
+			return self::handler_key_from_steps( $flow['steps'], $fallback, false );
+		}
+
+		// In-memory array-bundle shape: a flow_config map keyed by step id, the
+		// same shape a live row carries.
+		return self::handler_key_from_steps( self::flow_config_steps( $flow ), $fallback, true );
+	}
+
+	/**
+	 * Index a set of existing flow rows by their normalized HANDLER identity.
+	 *
+	 * The live row keeps its source handler in `flow_config[<step_id>]` — the
+	 * same `handler_slugs` / `handler_configs` shape the bundle flow carries in
+	 * `steps[]`. This keys each row under the first non-AI/non-output step's
+	 * normalized handler slug so a renamed/deduped bundle flow can still meet its
+	 * live row on the rename-proof source identity. Like
+	 * {@see self::index_existing_by_name()}, it must only ever be handed the live
+	 * rows of a SINGLE matched pipeline, and it preserves the genuine-ambiguity
+	 * guarantee: two rows with the same handler in one pipeline surface as
+	 * `ambiguous` and are omitted from `matched`.
+	 *
+	 * @param array<int,array<string,mixed>> $rows     Existing flow rows for ONE pipeline.
+	 * @param string                         $fallback PortableSlug fallback (flow).
+	 * @return array{
+	 *     matched: array<string,array<string,mixed>>,
+	 *     ambiguous: array<string,array<int,array<string,mixed>>>
+	 * }
+	 */
+	public static function index_existing_by_handler( array $rows, string $fallback ): array {
+		$by_handler = array();
+
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$steps = self::flow_config_steps( $row );
+			$key   = self::handler_key_from_steps( $steps, $fallback, true );
+			if ( '' === $key ) {
+				continue;
+			}
+
+			$by_handler[ $key ][] = $row;
+		}
+
+		$matched   = array();
+		$ambiguous = array();
+		foreach ( $by_handler as $key => $candidates ) {
+			if ( 1 === count( $candidates ) ) {
+				$matched[ $key ] = $candidates[0];
+				continue;
+			}
+
+			$ambiguous[ $key ] = $candidates;
+		}
+
+		return array(
+			'matched'   => $matched,
+			'ambiguous' => $ambiguous,
+		);
+	}
+
+	/**
+	 * Resolve a flow's import handler slug from an ordered list of steps.
+	 *
+	 * Both the bundle flow `steps[]` and the live `flow_config` express a step
+	 * the same way: a `step_type`, an ordered position, and either a
+	 * `handler_slugs` list or a `handler_configs` map keyed by handler slug. The
+	 * SOURCE of a flow is its first non-AI / non-output step — the fetch/import
+	 * handler that defines what the flow pulls. AI and output (upsert/publish)
+	 * steps are skipped because they are shared boilerplate across every flow and
+	 * carry no per-source identity.
+	 *
+	 * @param array<int,array<string,mixed>> $steps        Ordered step entries.
+	 * @param string                         $fallback     PortableSlug fallback.
+	 * @param bool                           $sort_by_order Sort steps by execution_order before scanning (live rows are unordered maps).
+	 * @return string Normalized handler slug, or '' when none is present.
+	 */
+	private static function handler_key_from_steps( array $steps, string $fallback, bool $sort_by_order ): string {
+		$steps = array_values(
+			array_filter(
+				$steps,
+				static function ( $step ) {
+					return is_array( $step );
+				}
+			)
+		);
+
+		if ( $sort_by_order ) {
+			usort(
+				$steps,
+				static function ( array $a, array $b ): int {
+					return (int) ( $a['execution_order'] ?? 0 ) <=> (int) ( $b['execution_order'] ?? 0 );
+				}
+			);
+		}
+
+		foreach ( $steps as $step ) {
+			$type = (string) ( $step['step_type'] ?? '' );
+			if ( in_array( $type, array( 'ai', 'upsert', 'publish' ), true ) ) {
+				continue;
+			}
+
+			$slug = self::handler_slug_from_step( $step );
+			if ( '' !== $slug ) {
+				return PortableSlug::normalize( $slug, $fallback );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Extract the handler slug from a single step entry.
+	 *
+	 * Prefers the explicit `handler_slugs` list, falling back to the first key of
+	 * the `handler_configs` map (both sides store the handler config keyed by its
+	 * slug). Returns '' when the step declares no handler.
+	 *
+	 * @param array<string,mixed> $step Step entry.
+	 * @return string Raw handler slug, or '' when absent.
+	 */
+	private static function handler_slug_from_step( array $step ): string {
+		$slugs = $step['handler_slugs'] ?? null;
+		if ( is_array( $slugs ) && array() !== $slugs ) {
+			$first = reset( $slugs );
+			if ( is_string( $first ) && '' !== trim( $first ) ) {
+				return trim( $first );
+			}
+		}
+
+		$configs = $step['handler_configs'] ?? null;
+		if ( is_array( $configs ) && array() !== $configs ) {
+			$keys  = array_keys( $configs );
+			$first = (string) reset( $keys );
+			if ( '' !== trim( $first ) ) {
+				return trim( $first );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Normalize a live flow row's `flow_config` into a list of step arrays.
+	 *
+	 * `flow_config` is a map keyed by `<pipeline>_<uuid>_<flow>` step ids; this
+	 * returns just the step value arrays so {@see self::handler_key_from_steps()}
+	 * can scan them the same way it scans a bundle flow's `steps[]` list.
+	 *
+	 * @param array<string,mixed> $row Existing flow row.
+	 * @return array<int,array<string,mixed>> Step value arrays.
+	 */
+	private static function flow_config_steps( array $row ): array {
+		$config = $row['flow_config'] ?? null;
+		if ( is_string( $config ) ) {
+			$decoded = json_decode( $config, true );
+			$config  = is_array( $decoded ) ? $decoded : array();
+		}
+		if ( ! is_array( $config ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				$config,
+				static function ( $step ) {
+					return is_array( $step );
+				}
+			)
+		);
+	}
+
+	/**
 	 * Compute the effective normalized slug for a single existing row.
 	 *
 	 * The stored `portable_slug` is the row's IDENTITY; the display name is only

--- a/tests/agent-bundle-slug-matcher-smoke.php
+++ b/tests/agent-bundle-slug-matcher-smoke.php
@@ -467,6 +467,174 @@ agent_bundle_slug_matcher_assert(
 	$passes
 );
 
+// ---- 14. Handler-identity fallback: rename-proof in-pipeline match. ---------
+// Reproduces the events-bot live-origin bundle shape that the slug AND name
+// fallbacks both miss (#2683). The in-memory bundle adopt loads carries each
+// flow's steps in `flow_config` (keyed by step id), its `flow_name` RENAMED to
+// "<Source> — <City>" (event-bundles#5) and its `portable_slug` deduped
+// ("dice-fm-101") — so neither the unique-slug pass nor the name fallback can
+// meet the live row, whose `flow_name` is still the bare source label
+// ("Dice.fm"). The import HANDLER is the only rename-proof identity, present on
+// BOTH sides as `flow_config[<step>].handler_slugs[0]`.
+$handler_live_rows = array(
+	// Pipeline 9 (Austin): one Dice.fm source flow + one Ticketmaster source flow.
+	array(
+		'flow_id'       => 26,
+		'pipeline_id'   => 9,
+		'flow_name'     => 'Dice.fm',
+		'portable_slug' => null,
+		'flow_config'   => array(
+			'9_a_26' => array( 'step_type' => 'event_import', 'execution_order' => 0, 'handler_slugs' => array( 'dice_fm' ) ),
+			'9_b_26' => array( 'step_type' => 'ai', 'execution_order' => 1 ),
+			'9_c_26' => array( 'step_type' => 'upsert', 'execution_order' => 2, 'handler_slugs' => array( 'upsert_event' ) ),
+		),
+	),
+	array(
+		'flow_id'       => 27,
+		'pipeline_id'   => 9,
+		'flow_name'     => 'Ticketmaster',
+		'portable_slug' => null,
+		'flow_config'   => array(
+			'9_d_27' => array( 'step_type' => 'event_import', 'execution_order' => 0, 'handler_slugs' => array( 'ticketmaster' ) ),
+			'9_e_27' => array( 'step_type' => 'ai', 'execution_order' => 1 ),
+		),
+	),
+);
+
+// Bundle flow (array-bundle shape): renamed name, deduped slug, no `steps`, the
+// handler lives in `flow_config` exactly like the live row.
+$handler_bundle_flow = array(
+	'original_pipeline_id' => 9,
+	'flow_name'            => 'Dice.fm — Austin',
+	'portable_slug'        => 'dice-fm-101',
+	'flow_config'          => array(
+		'1_bundle_step_0_70' => array( 'step_type' => 'event_import', 'execution_order' => 0, 'handler_slugs' => array( 'dice_fm' ) ),
+		'1_bundle_step_1_70' => array( 'step_type' => 'ai', 'execution_order' => 1 ),
+		'1_bundle_step_2_70' => array( 'step_type' => 'upsert', 'execution_order' => 2, 'handler_slugs' => array( 'upsert_event' ) ),
+	),
+);
+
+$h_slug_key = AgentBundleSlugMatcher::bundle_slug( $handler_bundle_flow, 'flow_name', 'flow' );
+$h_name_key = AgentBundleSlugMatcher::bundle_name_key( $handler_bundle_flow, 'flow_name', 'flow' );
+$h_handler  = AgentBundleSlugMatcher::bundle_handler_key( $handler_bundle_flow, 'flow' );
+
+agent_bundle_slug_matcher_assert(
+	'dice-fm-101' === $h_slug_key && 'dice-fm-austin' === $h_name_key && 'dice-fm' === $h_handler,
+	'events-bot shape: slug=dice-fm-101, name=dice-fm-austin, handler=dice-fm (rename-proof)',
+	$failures,
+	$passes
+);
+
+// Slug pass misses (live row has NULL slug -> keyed on "dice-fm").
+$h_slug_index = AgentBundleSlugMatcher::index_existing( $handler_live_rows, 'flow_name', 'flow' );
+agent_bundle_slug_matcher_assert(
+	! isset( $h_slug_index['matched'][ $h_slug_key ] ),
+	'events-bot shape: deduped slug "dice-fm-101" misses the slug pass (live keyed on "dice-fm")',
+	$failures,
+	$passes
+);
+// Name pass misses (bundle name "dice-fm-austin" vs live "dice-fm").
+$h_name_index = AgentBundleSlugMatcher::index_existing_by_name( $handler_live_rows, 'flow_name', 'flow' );
+agent_bundle_slug_matcher_assert(
+	! isset( $h_name_index['matched'][ $h_name_key ] ),
+	'events-bot shape: renamed name "dice-fm-austin" misses the name pass (live "dice-fm")',
+	$failures,
+	$passes
+);
+// Handler pass matches the correct row, unambiguously.
+$h_index = AgentBundleSlugMatcher::index_existing_by_handler( $handler_live_rows, 'flow' );
+agent_bundle_slug_matcher_assert(
+	isset( $h_index['matched']['dice-fm'] )
+		&& 26 === ( $h_index['matched']['dice-fm']['flow_id'] ?? 0 )
+		&& empty( $h_index['ambiguous'] ),
+	'events-bot shape: handler fallback binds "dice-fm" to its live row (flow_id 26), 0 ambiguous',
+	$failures,
+	$passes
+);
+agent_bundle_slug_matcher_assert(
+	isset( $h_index['matched']['ticketmaster'] ) && 27 === ( $h_index['matched']['ticketmaster']['flow_id'] ?? 0 ),
+	'events-bot shape: the sibling Ticketmaster source flow binds to flow_id 27 by handler',
+	$failures,
+	$passes
+);
+
+// ---- 15. Handler key ignores AI/output steps (source step only). -----------
+// The first non-AI / non-upsert / non-publish step defines the source. An
+// upsert-only or ai-only flow yields no handler key and falls back to name.
+$ai_upsert_only = array(
+	'flow_config' => array(
+		's0' => array( 'step_type' => 'ai', 'execution_order' => 0 ),
+		's1' => array( 'step_type' => 'upsert', 'execution_order' => 1, 'handler_slugs' => array( 'upsert_event' ) ),
+	),
+);
+agent_bundle_slug_matcher_assert(
+	'' === AgentBundleSlugMatcher::bundle_handler_key( $ai_upsert_only, 'flow' ),
+	'handler key is empty when a flow has only ai/upsert steps (no source handler)',
+	$failures,
+	$passes
+);
+
+// ---- 16. Handler key reads BOTH bundle shapes symmetrically. ---------------
+// On-disk document shape (steps[] ordered list) and in-memory array-bundle
+// shape (flow_config map) must derive the SAME key from the same flow.
+$doc_shape = array(
+	'steps' => array(
+		array( 'step_type' => 'event_import', 'step_position' => 0, 'handler_slugs' => array( 'dice_fm' ) ),
+		array( 'step_type' => 'ai', 'step_position' => 1 ),
+	),
+);
+$array_shape = array(
+	'flow_config' => array(
+		'x1' => array( 'step_type' => 'ai', 'execution_order' => 1 ),
+		'x0' => array( 'step_type' => 'event_import', 'execution_order' => 0, 'handler_slugs' => array( 'dice_fm' ) ),
+	),
+);
+agent_bundle_slug_matcher_assert(
+	'dice-fm' === AgentBundleSlugMatcher::bundle_handler_key( $doc_shape, 'flow' )
+		&& 'dice-fm' === AgentBundleSlugMatcher::bundle_handler_key( $array_shape, 'flow' ),
+	'handler key is identical for steps[] (document) and flow_config (array-bundle) shapes',
+	$failures,
+	$passes
+);
+agent_bundle_slug_matcher_assert(
+	'dice-fm' === AgentBundleSlugMatcher::bundle_handler_key(
+		array( 'flow_config' => array( 'x' => array( 'step_type' => 'event_import', 'handler_configs' => array( 'dice_fm' => array() ) ) ) ),
+		'flow'
+	),
+	'handler key falls back to the handler_configs map key when handler_slugs is absent',
+	$failures,
+	$passes
+);
+
+// ---- 17. Handler fallback STILL refuses a genuine in-pipeline source tie. ---
+// Two flows with the SAME source handler in ONE pipeline (e.g. two Dice.fm
+// searches) and no slug/name signal to split them: the handler pass must
+// surface ambiguous and NEVER guess — preserving #2668 at the source-identity
+// scope.
+$handler_tie_rows = array(
+	array(
+		'flow_id'       => 51,
+		'pipeline_id'   => 200,
+		'flow_name'     => 'Dice.fm Rock',
+		'portable_slug' => null,
+		'flow_config'   => array( 's' => array( 'step_type' => 'event_import', 'execution_order' => 0, 'handler_slugs' => array( 'dice_fm' ) ) ),
+	),
+	array(
+		'flow_id'       => 52,
+		'pipeline_id'   => 200,
+		'flow_name'     => 'Dice.fm Jazz',
+		'portable_slug' => null,
+		'flow_config'   => array( 's' => array( 'step_type' => 'event_import', 'execution_order' => 0, 'handler_slugs' => array( 'dice_fm' ) ) ),
+	),
+);
+$tie_handler_index = AgentBundleSlugMatcher::index_existing_by_handler( $handler_tie_rows, 'flow' );
+agent_bundle_slug_matcher_assert(
+	isset( $tie_handler_index['ambiguous']['dice-fm'] ) && ! isset( $tie_handler_index['matched']['dice-fm'] ),
+	'handler fallback: two same-source flows in ONE pipeline stay ambiguous (no guess)',
+	$failures,
+	$passes
+);
+
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " agent bundle slug matcher assertions failed.\n";
 	exit( 1 );


### PR DESCRIPTION
Closes #2683

## What was actually broken

`agent adopt events-bot --dry-run` reported **matched 492 / unmatched 371 / ambiguous 0** on v0.150.3 — the 371 unmatched are exactly the ticketmaster/dice/dice-fm source flows.

While investigating against the **real in-memory bundle adopt loads** (`AgentBundleArrayAdapter::to_array_bundle`), I found the two-bug framing in #2683 was based on the **on-disk document shape** (the bundle *files*), not the shape `adopt()` actually consumes. The findings:

### Bug 1 (pipeline scoping on `original_id`) — NOT a real bug for adopt
The issue claims `original_id` / `original_pipeline_id` are absent (0/671), collapsing the pipeline map to `[0 => last pipeline]`. That's true of the **files**, but `to_array_bundle()` **synthesizes** `original_id` on every pipeline and `original_pipeline_id` on every flow. Simulated against live data, the original `original_id` scoping produces a **192-entry** map, **192/192 pipelines matched** — it was never collapsing. So I **kept** the `original_id`/`original_pipeline_id` scoping (switching to `pipeline_slug`, as the issue proposed, would have *regressed* adopt to 0 matched, because adopt's in-memory flows carry no `pipeline_slug` — only the files do). I added a code comment documenting why the synthesized fields are load-bearing here.

### Bug 2 (name fallback can never match) — REAL, and the whole story
This is the actual cause of all 371 unmatched. The in-memory bundle flow has:
- `flow_name` = `"Dice.fm — Austin"` (renamed by extrachill-event-bundles#5) → normalizes to `dice-fm-austin`
- `portable_slug` = `"dice-fm-101"` (deduped at export)
- the live row's `flow_name` is still `"Dice.fm"` → `dice-fm`

The unique-slug pass misses (`dice-fm-101` ≠ `dice-fm`) and the name fallback misses (`dice-fm-austin` ≠ `dice-fm`). Both editable labels diverged from the live row.

## The fix

A **pipeline-scoped handler-identity fallback**, inserted between the slug pass and the name pass in `adopt()`:

- Derive each flow's import **handler** ("dice_fm", "ticketmaster", "bandsintown") from the first non-AI / non-output (`upsert`/`publish`) step.
- Read it **symmetrically** on both sides: the bundle flow's `steps[]` (on-disk document) **or** `flow_config` map (in-memory array-bundle), and the live row's `flow_config`. Both express the handler the same way (`handler_slugs[0]`, falling back to the `handler_configs` map key).
- The handler is **rename-proof** and **unique within a city pipeline**. Per-venue `universal_web_scraper` flows share a handler, but they resolve on the unique-slug pass **before** reaching this fallback, so they never collide here.
- The **genuine-ambiguity guarantee is preserved**: two same-handler flows in one pipeline surface as `ambiguous` and are never guessed. The name fallback is retained as a last resort for flows with no handler signal.

New helpers in `AgentBundleSlugMatcher`: `bundle_handler_key()`, `index_existing_by_handler()`, plus private `handler_key_from_steps()` / `handler_slug_from_step()` / `flow_config_steps()`. Pure and persistence-free.

## Verification (all required, all run)

### 1. Existing smoke — green
`php tests/agent-bundle-slug-matcher-smoke.php` → **28/28 prior assertions still pass.**

### 2. New smoke reproducing THIS bundle's shape — green
Added 9 assertions (37 total) covering: the in-memory array-bundle shape (renamed `flow_name`, deduped `portable_slug`, handler in `flow_config`, NULL live `portable_slug`); slug pass misses; name pass misses; handler fallback binds the correct row; the sibling source flow binds correctly; AI/upsert-only flows yield no handler key; `steps[]` and `flow_config` shapes derive the same key; `handler_configs`-only fallback; and a genuine in-pipeline same-handler tie staying ambiguous.

### 3. LIVE DRY-RUN PROOF (read-only) — the gate
Ran the worktree matcher methods against the **real** events.extrachill.com pipeline/flow rows (read-only SELECTs) and the **real** in-memory bundle (`to_array_bundle` of `bundles/events-bot`), driving the exact adopt() matching loop (slug → handler → name):

| | BEFORE (v0.150.3) | AFTER (this PR) |
|---|---|---|
| pipelines matched | 192 | **192** |
| pipelines unmatched | 0 | **0** |
| flows matched | 300* | **671** |
| flows unmatched | **371** | **0** |
| flows ambiguous | 0 | **0** |

\* The 492 "matched" in the live dry-run includes pipelines; flow-only matched was 300 via slug. After the fix: 300 via slug + **371 via the handler fallback** + 0 via name = **671/671**, with **0 live rows bound more than once** (1:1).

### 4. Lint — clean
`composer lint` exits **0** (0 errors / 0 warnings) on the changed files (PHP-runtime deprecation noise from the system JsonSchema/Composer libs is unrelated).

### 5. Pre-existing red smokes — independent
`tests/agent-bundle-portable-update-smoke.php` fails identically (5 assertions) on **clean main** via `git stash` — pre-existing, unrelated to this change (it exercises the package CLI / projection, untouched here). `tests/adjacent-handler-tool-policy-smoke.php` passes standalone (its known redeclare failure only surfaces under the wp-codebox harness).

## Import / upgrade projection note

The import-side runtime-drift preview (`runtime_drifts_for_bundle`, ~L690-728) and the upgrade projection (`AgentBundleLifecycleProjection::current_artifacts`, slug-only `index_existing` at ~L99) use the same `original_*` scoping (fine, since `to_array_bundle` synthesizes them) but **lack** the handler/name fallback. For the acceptance criterion ("a real adopt then a subsequent upgrade creates 0 new artifacts") this is **not a problem**: adopt backfills the unique `portable_slug` onto all 671 live rows, after which the upgrade projection's slug pass resolves 1:1 (covered by existing smoke assertion #7). Extending the same handler fallback to the upgrade/import projection (for upgrading an *un-adopted* live-origin agent) is a reasonable follow-up but out of scope for this fix.

## Not done here (operator actions)
No merge, no release, no deploy, no real (non-dry-run) adopt, no live DB writes. The operator runs the real `agent adopt events-bot` after this is merged, released, and deployed.