### PR TITLE
Protect ability tool declaration boundaries

### DIFF
--- a/inc/Core/AbilityResult.php
+++ b/inc/Core/AbilityResult.php
@@ -85,6 +85,37 @@ class AbilityResult {
 	}
 
 	/**
+	 * Put Data Machine handler output into the Agents API result envelope.
+	 *
+	 * @param array  $result    Raw handler result.
+	 * @param string $tool_name Tool name.
+	 * @param array  $metadata  Additional metadata.
+	 * @return array Tool execution result.
+	 */
+	public static function normalize_tool_envelope( array $result, string $tool_name, array $metadata = array() ): array {
+		$result['tool_name'] = is_string( $result['tool_name'] ?? null ) && '' !== $result['tool_name'] ? $result['tool_name'] : $tool_name;
+		if ( ! isset( $result['success'] ) ) {
+			$result['success'] = true;
+		}
+
+		if ( ! empty( $metadata ) ) {
+			$result['metadata'] = array_merge( $metadata, is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array() );
+		}
+
+		if ( ! $result['success'] ) {
+			return $result;
+		}
+
+		if ( ! array_key_exists( 'result', $result ) ) {
+			$payload = $result;
+			unset( $payload['success'], $payload['tool_name'], $payload['metadata'], $payload['runtime'] );
+			$result['result'] = $payload;
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Convert a legacy failed ability result array into WP_Error.
 	 *
 	 * @param mixed  $result          Ability execution result.

--- a/inc/Engine/AI/Tools/Execution/ToolExecutionCore.php
+++ b/inc/Engine/AI/Tools/Execution/ToolExecutionCore.php
@@ -109,7 +109,7 @@ class ToolExecutionCore implements WP_Agent_Tool_Executor {
 			);
 		}
 
-		return $this->normalizeDataMachineResult(
+		return AbilityResult::normalize_tool_envelope(
 			AbilityResult::normalize_tool_result( $ability->execute( $parameters ), $tool_name, $ability_slug ),
 			$tool_name,
 			array( 'ability' => $ability_slug )
@@ -159,37 +159,6 @@ class ToolExecutionCore implements WP_Agent_Tool_Executor {
 		}
 
 		$tool_handler = new $class_name();
-		return $this->normalizeDataMachineResult( $tool_handler->$method( $parameters, $tool_definition ), $tool_name );
-	}
-
-	/**
-	 * Put Data Machine handler output into the Agents API result envelope.
-	 *
-	 * @param array  $result    Raw handler result.
-	 * @param string $tool_name Tool name.
-	 * @param array  $metadata  Additional metadata.
-	 * @return array Tool execution result.
-	 */
-	private function normalizeDataMachineResult( array $result, string $tool_name, array $metadata = array() ): array {
-		$result['tool_name'] = is_string( $result['tool_name'] ?? null ) && '' !== $result['tool_name'] ? $result['tool_name'] : $tool_name;
-		if ( ! isset( $result['success'] ) ) {
-			$result['success'] = true;
-		}
-
-		if ( ! empty( $metadata ) ) {
-			$result['metadata'] = array_merge( $metadata, is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array() );
-		}
-
-		if ( ! $result['success'] ) {
-			return $result;
-		}
-
-		if ( ! array_key_exists( 'result', $result ) ) {
-			$payload = $result;
-			unset( $payload['success'], $payload['tool_name'], $payload['metadata'], $payload['runtime'] );
-			$result['result'] = $payload;
-		}
-
-		return $result;
+		return AbilityResult::normalize_tool_envelope( $tool_handler->$method( $parameters, $tool_definition ), $tool_name );
 	}
 }

--- a/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
+++ b/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
@@ -211,9 +211,6 @@ final class AbilityToolSource {
 		$job_snapshot = is_array( $engine_data['job'] ?? null ) ? $engine_data['job'] : array();
 		$sets[] = $job_snapshot['ability_tools'] ?? null;
 
-		$client_context = is_array( $args['client_context'] ?? null ) ? $args['client_context'] : array();
-		$sets[] = $client_context['ability_tools'] ?? null;
-
 		$declared = array();
 		foreach ( $sets as $set ) {
 			if ( ! is_array( $set ) ) {

--- a/tests/ability-result-wp-error-smoke.php
+++ b/tests/ability-result-wp-error-smoke.php
@@ -122,6 +122,28 @@ $assert( 'tool scalar result is wrapped as success', true === $tool_scalar_resul
 $assert( 'tool scalar result payload uses tool result key', 'ok' === $tool_scalar_result['result'] );
 $assert( 'tool scalar result does not mirror payload into data key', ! array_key_exists( 'data', $tool_scalar_result ) );
 
+$tool_envelope = AbilityResult::normalize_tool_envelope(
+	array(
+		'success' => true,
+		'custom'  => 'value',
+	),
+	'demo_tool',
+	array( 'ability' => 'datamachine/demo' )
+);
+$assert( 'tool envelope fills missing tool name', 'demo_tool' === $tool_envelope['tool_name'] );
+$assert( 'tool envelope stores ability metadata', 'datamachine/demo' === ( $tool_envelope['metadata']['ability'] ?? null ) );
+$assert( 'tool envelope preserves successful payload under result', 'value' === ( $tool_envelope['result']['custom'] ?? null ) );
+
+$failed_tool_envelope = AbilityResult::normalize_tool_envelope(
+	array(
+		'success' => false,
+		'error'   => 'Denied.',
+	),
+	'demo_tool',
+	array( 'ability' => 'datamachine/demo' )
+);
+$assert( 'failed tool envelope does not synthesize result payload', ! array_key_exists( 'result', $failed_tool_envelope ) );
+
 $legacy_error = AbilityResult::legacy_failure_to_wp_error(
 	array(
 		'success' => false,

--- a/tests/ability-tool-source-smoke.php
+++ b/tests/ability-tool-source-smoke.php
@@ -444,6 +444,44 @@ $job_declared = resolve_ability_source_tools(
 );
 assert_ability_tool_source_equals( true, isset( $job_declared['job_summarize_demo'] ), 'job snapshot ability_tools map exposes runtime ability tool', $failures, $passes );
 
+$client_context_override = resolve_ability_source_tools(
+	'pipeline',
+	array(
+		'ability_tools'   => array(
+			'context_boundary_demo' => array(
+				'ability' => 'demo/summarize',
+				'modes'   => array( 'pipeline' ),
+			),
+		),
+		'client_context'  => array(
+			'ability_tools' => array(
+				'context_boundary_demo' => array(
+					'ability'                 => 'demo/missing',
+					'modes'                   => array( 'pipeline' ),
+					'client_context_bindings' => array( 'user_id' ),
+					'parameters'              => array(
+						'type'       => 'object',
+						'required'   => array( 'user_id' ),
+						'properties' => array(
+							'user_id' => array( 'type' => 'integer' ),
+						),
+					),
+				),
+				'client_only_demo' => array(
+					'ability' => 'demo/summarize',
+					'modes'   => array( 'pipeline' ),
+				),
+			),
+		),
+		'allow_only'      => array( 'context_boundary_demo', 'client_only_demo' ),
+	)
+);
+assert_ability_tool_source_equals( true, isset( $client_context_override['context_boundary_demo'] ), 'server ability_tools declaration remains available when client context carries same name', $failures, $passes );
+assert_ability_tool_source_equals( 'demo/summarize', $client_context_override['context_boundary_demo']['execution_ability'] ?? '', 'client context cannot override server ability slug', $failures, $passes );
+assert_ability_tool_source_equals( array( 'message' ), $client_context_override['context_boundary_demo']['parameters']['required'] ?? array(), 'client context cannot override server ability schema', $failures, $passes );
+assert_ability_tool_source_equals( array(), $client_context_override['context_boundary_demo']['client_context_bindings'] ?? array(), 'client context cannot introduce runtime bindings on server ability tool', $failures, $passes );
+assert_ability_tool_source_equals( false, isset( $client_context_override['client_only_demo'] ), 'client context ability_tools cannot introduce new ability tools', $failures, $passes );
+
 echo "\n[4] generated declaration executes through ability-native ToolExecutionCore:\n";
 $result = ToolExecutor::executeTool(
 	'summarize_demo',


### PR DESCRIPTION
## Summary
- Stop reading `client_context.ability_tools` as ability tool declarations so client context cannot introduce or override server/job tool schemas, runtime bindings, modes, or execution metadata.
- Keep trusted resolver args, job snapshots, and server-side projection filters as the ability tool declaration paths.
- Move shared tool result envelope repair into `AbilityResult::normalize_tool_envelope()` and use it from both ability-native and class/method execution paths.

## Tests
- `php -l inc/Engine/AI/Tools/Sources/AbilityToolSource.php && php -l inc/Core/AbilityResult.php && php -l inc/Engine/AI/Tools/Execution/ToolExecutionCore.php && php -l tests/ability-tool-source-smoke.php && php -l tests/ability-result-wp-error-smoke.php`
- `php tests/ability-tool-source-smoke.php`
- `php tests/ability-result-wp-error-smoke.php`
- `php tests/tool-executor-ability-native-smoke.php`
- `./vendor/bin/phpcs inc/Engine/AI/Tools/Sources/AbilityToolSource.php inc/Core/AbilityResult.php inc/Engine/AI/Tools/Execution/ToolExecutionCore.php tests/ability-tool-source-smoke.php tests/ability-result-wp-error-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the boundary cleanup, shared result normalization refactor, and targeted smoke coverage; Chris remains responsible for review and acceptance.
