### PR TITLE
Fix option-backed lease store reuse

### DIFF
--- a/inc/Cli/WorkerLock.php
+++ b/inc/Cli/WorkerLock.php
@@ -7,6 +7,8 @@
 
 namespace DataMachine\Cli;
 
+use DataMachine\Core\OptionLeaseStore;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -47,26 +49,8 @@ class WorkerLock {
 			'lane'       => self::normalizeLane( $lane ),
 		);
 
-		if ( 'stale' === $existing['lock_status'] ) {
-			delete_option( $option_name );
-			if ( add_option( $option_name, $payload, '', false ) ) {
-				return self::formatSnapshot( $payload, $now, 'held', true );
-			}
-
-			$after_delete = self::snapshot( $now, $ttl, $lane );
-			if ( 'held' !== $after_delete['lock_status'] && update_option( $option_name, $payload, false ) ) {
-				$current = get_option( $option_name, array() );
-				if ( is_array( $current ) && hash_equals( $token, (string) ( $current['token'] ?? '' ) ) ) {
-					return self::formatSnapshot( $payload, $now, 'held', true );
-				}
-			}
-
-			$existing             = self::snapshot( $now, $ttl, $lane );
-			$existing['acquired'] = false;
-			return $existing;
-		}
-
-		if ( add_option( $option_name, $payload, '', false ) ) {
+		$result = OptionLeaseStore::acquire( $option_name, $payload, $ttl, $now, null, true );
+		if ( $result['acquired'] ) {
 			return self::formatSnapshot( $payload, $now, 'held', true );
 		}
 
@@ -86,11 +70,7 @@ class WorkerLock {
 			return;
 		}
 
-		$option_name = self::optionName( $lane );
-		$payload     = get_option( $option_name, array() );
-		if ( is_array( $payload ) && hash_equals( (string) ( $payload['token'] ?? '' ), $token ) ) {
-			delete_option( $option_name );
-		}
+		OptionLeaseStore::release( self::optionName( $lane ), $token );
 	}
 
 	/**
@@ -104,7 +84,8 @@ class WorkerLock {
 	public static function snapshot( ?int $now = null, int $ttl = self::DEFAULT_TTL, string $lane = '' ): array {
 		$now     = $now ?? time();
 		$ttl     = max( 60, $ttl );
-		$payload = get_option( self::optionName( $lane ), array() );
+		$snapshot = OptionLeaseStore::snapshot( self::optionName( $lane ), $ttl, $now );
+		$payload  = $snapshot['payload'];
 		$lane    = self::normalizeLane( $lane );
 
 		if ( ! is_array( $payload ) || empty( $payload['started_at'] ) ) {
@@ -119,11 +100,7 @@ class WorkerLock {
 			);
 		}
 
-		$started_at = (int) $payload['started_at'];
-		$expires_at = (int) ( $payload['expires_at'] ?? ( $started_at + $ttl ) );
-		$status     = $expires_at <= $now ? 'stale' : 'held';
-
-		return self::formatSnapshot( $payload, $now, $status, false );
+		return self::formatSnapshot( $payload, $now, $snapshot['status'], false );
 	}
 
 	/**

--- a/inc/Core/OptionLeaseStore.php
+++ b/inc/Core/OptionLeaseStore.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Generic option-backed lease store.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Coordinates tokened option-row leases with TTL cleanup.
+ */
+class OptionLeaseStore {
+
+	/**
+	 * Acquire one option-row lease.
+	 *
+	 * @param string              $option_name               Option name.
+	 * @param array<string,mixed> $payload Lease payload. Must include token and expires_at.
+	 * @param int                 $ttl                       Stale fallback TTL in seconds.
+	 * @param int|null            $now                       Current timestamp.
+	 * @param callable|null       $is_stale                  Optional extra stale predicate.
+	 * @param bool                $replace_stale_with_update Whether to update when stale delete/add races.
+	 * @return array{acquired:bool,status:string,payload:array<string,mixed>,option_name:string}
+	 */
+	public static function acquire(
+		string $option_name,
+		array $payload,
+		int $ttl,
+		?int $now = null,
+		?callable $is_stale = null,
+		bool $replace_stale_with_update = false
+	): array {
+		$now      = $now ?? time();
+		$existing = self::snapshot( $option_name, $ttl, $now, $is_stale );
+
+		if ( 'held' === $existing['status'] ) {
+			return array(
+				'acquired'    => false,
+				'status'      => 'held',
+				'payload'     => $existing['payload'],
+				'option_name' => $option_name,
+			);
+		}
+
+		if ( 'stale' === $existing['status'] ) {
+			delete_option( $option_name );
+		}
+
+		if ( add_option( $option_name, $payload, '', false ) ) {
+			return array(
+				'acquired'    => true,
+				'status'      => 'held',
+				'payload'     => $payload,
+				'option_name' => $option_name,
+			);
+		}
+
+		if ( 'stale' === $existing['status'] && $replace_stale_with_update ) {
+			$after_delete = self::snapshot( $option_name, $ttl, $now, $is_stale );
+			if ( 'held' !== $after_delete['status'] && update_option( $option_name, $payload, false ) ) {
+				$current = get_option( $option_name, array() );
+				if ( is_array( $current ) && hash_equals( (string) ( $payload['token'] ?? '' ), (string) ( $current['token'] ?? '' ) ) ) {
+					return array(
+						'acquired'    => true,
+						'status'      => 'held',
+						'payload'     => $payload,
+						'option_name' => $option_name,
+					);
+				}
+			}
+		}
+
+		$current = self::snapshot( $option_name, $ttl, $now, $is_stale );
+
+		return array(
+			'acquired'    => false,
+			'status'      => $current['status'],
+			'payload'     => $current['payload'],
+			'option_name' => $option_name,
+		);
+	}
+
+	/**
+	 * Acquire the first available numbered slot in a scope.
+	 *
+	 * @param string              $prefix  Option-name prefix.
+	 * @param string              $scope   Lease scope.
+	 * @param int                 $limit   Maximum slots in scope.
+	 * @param array<string,mixed> $payload Lease payload.
+	 * @param int                 $ttl     Stale fallback TTL in seconds.
+	 * @param int|null            $now     Current timestamp.
+	 * @param callable|null       $is_stale Optional extra stale predicate.
+	 * @return array{acquired:bool,limit:int,active:int,option_name?:string}
+	 */
+	public static function acquireSlot(
+		string $prefix,
+		string $scope,
+		int $limit,
+		array $payload,
+		int $ttl,
+		?int $now = null,
+		?callable $is_stale = null
+	): array {
+		$active = 0;
+		$now    = $now ?? time();
+
+		for ( $slot = 1; $slot <= $limit; ++$slot ) {
+			$option_name = self::slotOptionName( $prefix, $scope, $slot );
+			$result      = self::acquire( $option_name, $payload, $ttl, $now, $is_stale );
+
+			if ( $result['acquired'] ) {
+				return array(
+					'acquired'    => true,
+					'limit'       => $limit,
+					'active'      => $active + 1,
+					'option_name' => $option_name,
+				);
+			}
+
+			if ( 'held' === $result['status'] ) {
+				++$active;
+			}
+		}
+
+		return array(
+			'acquired' => false,
+			'limit'    => $limit,
+			'active'   => $active,
+		);
+	}
+
+	/**
+	 * Return a read-only lease snapshot.
+	 *
+	 * @param string        $option_name Option name.
+	 * @param int           $ttl         Stale fallback TTL in seconds.
+	 * @param int|null      $now         Current timestamp.
+	 * @param callable|null $is_stale    Optional extra stale predicate.
+	 * @return array{status:string,payload:array<string,mixed>,option_name:string}
+	 */
+	public static function snapshot(
+		string $option_name,
+		int $ttl,
+		?int $now = null,
+		?callable $is_stale = null
+	): array {
+		$now     = $now ?? time();
+		$payload = get_option( $option_name, array() );
+
+		if ( ! is_array( $payload ) || empty( $payload ) ) {
+			return array(
+				'status'      => 'unlocked',
+				'payload'     => array(),
+				'option_name' => $option_name,
+			);
+		}
+
+		$status = self::isStale( $payload, $ttl, $now, $is_stale ) ? 'stale' : 'held';
+
+		return array(
+			'status'      => $status,
+			'payload'     => $payload,
+			'option_name' => $option_name,
+		);
+	}
+
+	/**
+	 * Delete a lease only when the token still owns it.
+	 */
+	public static function release( string $option_name, string $token ): void {
+		if ( '' === $token ) {
+			return;
+		}
+
+		$payload = get_option( $option_name, array() );
+		if ( is_array( $payload ) && hash_equals( (string) ( $payload['token'] ?? '' ), $token ) ) {
+			delete_option( $option_name );
+		}
+	}
+
+	/**
+	 * Delete a stale lease when present.
+	 */
+	public static function cleanupStale(
+		string $option_name,
+		int $ttl,
+		?int $now = null,
+		?callable $is_stale = null
+	): bool {
+		$snapshot = self::snapshot( $option_name, $ttl, $now, $is_stale );
+		if ( 'stale' !== $snapshot['status'] ) {
+			return false;
+		}
+
+		return delete_option( $option_name );
+	}
+
+	/**
+	 * Build the option name for a numbered scope slot.
+	 */
+	public static function slotOptionName( string $prefix, string $scope, int $slot ): string {
+		return $prefix . md5( $scope ) . '_' . $slot;
+	}
+
+	/**
+	 * Determine whether a stored lease is stale.
+	 *
+	 * @param array<string,mixed> $payload Stored lease payload.
+	 */
+	private static function isStale( array $payload, int $ttl, int $now, ?callable $is_stale ): bool {
+		$started_at = (int) ( $payload['started_at'] ?? $payload['created_at'] ?? 0 );
+		$expires_at = (int) ( $payload['expires_at'] ?? ( $started_at + $ttl ) );
+
+		if ( $expires_at <= $now ) {
+			return true;
+		}
+
+		return null !== $is_stale && (bool) $is_stale( $payload, $now );
+	}
+}

--- a/inc/Engine/AI/PipelineAIConcurrencyLease.php
+++ b/inc/Engine/AI/PipelineAIConcurrencyLease.php
@@ -7,6 +7,8 @@
 
 namespace DataMachine\Engine\AI;
 
+use DataMachine\Core\OptionLeaseStore;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -38,10 +40,7 @@ class PipelineAIConcurrencyLease {
 	 */
 	public function release(): void {
 		foreach ( $this->option_names as $option_name ) {
-			$lease = get_option( $option_name, false );
-			if ( is_array( $lease ) && ( $lease['token'] ?? '' ) === $this->token ) {
-				delete_option( $option_name );
-			}
+			OptionLeaseStore::release( $option_name, $this->token );
 		}
 	}
 }

--- a/inc/Engine/AI/PipelineAIConcurrencyLimiter.php
+++ b/inc/Engine/AI/PipelineAIConcurrencyLimiter.php
@@ -7,6 +7,7 @@
 
 namespace DataMachine\Engine\AI;
 
+use DataMachine\Core\OptionLeaseStore;
 use DataMachine\Core\PluginSettings;
 
 defined( 'ABSPATH' ) || exit;
@@ -19,6 +20,7 @@ class PipelineAIConcurrencyLimiter {
 	private const DEFAULT_LIMIT          = 1;
 	private const DEFAULT_THROTTLE_DELAY = 10;
 	private const DEFAULT_TTL            = 600;
+	private const OPTION_PREFIX          = 'datamachine_pipeline_ai_lease_';
 	private const EXECUTE_STEP_HOOK      = 'datamachine_execute_step';
 	private const ACTION_SCHEDULER_GROUP = 'data-machine';
 
@@ -115,53 +117,25 @@ class PipelineAIConcurrencyLimiter {
 	 * @return array{acquired:bool,limit:int,active:int,option_name?:string}
 	 */
 	private static function acquireScope( string $scope, int $limit, string $token, string $provider, array $context ): array {
-		$active = 0;
-		$now    = time();
+		$now = time();
+		$ttl = self::ttl( $provider, $context );
+		$lease = array(
+			'token'        => $token,
+			'provider'     => $provider,
+			'created_at'   => $now,
+			'expires_at'   => $now + $ttl,
+			'job_id'       => (int) ( $context['job_id'] ?? 0 ),
+			'flow_step_id' => (string) ( $context['flow_step_id'] ?? '' ),
+		);
 
-		for ( $slot = 1; $slot <= $limit; ++$slot ) {
-			$option_name = self::optionName( $scope, $slot );
-			$existing    = get_option( $option_name, false );
-
-			if ( is_array( $existing ) && (int) ( $existing['expires_at'] ?? 0 ) <= $now ) {
-				delete_option( $option_name );
-				$existing = false;
-			}
-
-			if ( is_array( $existing ) && self::isAdvancedOwnerLease( $existing ) ) {
-				delete_option( $option_name );
-				$existing = false;
-			}
-
-			if ( false !== $existing ) {
-				++$active;
-				continue;
-			}
-
-			$lease = array(
-				'token'        => $token,
-				'provider'     => $provider,
-				'created_at'   => $now,
-				'expires_at'   => $now + self::ttl( $provider, $context ),
-				'job_id'       => (int) ( $context['job_id'] ?? 0 ),
-				'flow_step_id' => (string) ( $context['flow_step_id'] ?? '' ),
-			);
-
-			if ( add_option( $option_name, $lease, '', 'no' ) ) {
-				return array(
-					'acquired'    => true,
-					'limit'       => $limit,
-					'active'      => $active + 1,
-					'option_name' => $option_name,
-				);
-			}
-
-			++$active;
-		}
-
-		return array(
-			'acquired' => false,
-			'limit'    => $limit,
-			'active'   => $active,
+		return OptionLeaseStore::acquireSlot(
+			self::OPTION_PREFIX,
+			$scope,
+			$limit,
+			$lease,
+			$ttl,
+			$now,
+			static fn( array $existing ): bool => self::isAdvancedOwnerLease( $existing )
 		);
 	}
 
@@ -193,13 +167,6 @@ class PipelineAIConcurrencyLimiter {
 		 * @param array  $context  Execution context.
 		 */
 		return max( 30, (int) apply_filters( 'datamachine_pipeline_ai_concurrency_lease_ttl', self::DEFAULT_TTL, $provider, $context ) );
-	}
-
-	/**
-	 * Build option name for a slot.
-	 */
-	private static function optionName( string $scope, int $slot ): string {
-		return 'datamachine_pipeline_ai_lease_' . md5( $scope ) . '_' . $slot;
 	}
 
 	/**

--- a/tests/ai-step-backpressure-smoke.php
+++ b/tests/ai-step-backpressure-smoke.php
@@ -111,6 +111,7 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 
 require_once __DIR__ . '/../inc/Core/NetworkSettings.php';
 require_once __DIR__ . '/../inc/Core/PluginSettings.php';
+require_once __DIR__ . '/../inc/Core/OptionLeaseStore.php';
 require_once __DIR__ . '/../inc/Engine/AI/PipelineAIConcurrencyLease.php';
 require_once __DIR__ . '/../inc/Engine/AI/PipelineAIConcurrencyLimiter.php';
 

--- a/tests/worker-lock-smoke.php
+++ b/tests/worker-lock-smoke.php
@@ -70,6 +70,7 @@ if ( ! function_exists( 'sanitize_text_field' ) ) {
     }
 }
 
+require_once __DIR__ . '/../inc/Core/OptionLeaseStore.php';
 require_once __DIR__ . '/../inc/Cli/WorkerLock.php';
 
 use DataMachine\Cli\WorkerLock;


### PR DESCRIPTION
## Summary
- Add a generic OptionLeaseStore for tokened option-row lease acquire/release/snapshot/stale cleanup.
- Rebuild WorkerLock on the shared store while preserving lane output and stale replacement behavior.
- Rebuild pipeline AI concurrency slot leases on the shared store while preserving provider/scope TTL cleanup and advanced-owner stale detection.

## Tests
- php tests/worker-lock-smoke.php
- php tests/ai-step-backpressure-smoke.php
- php -l inc/Core/OptionLeaseStore.php && php -l inc/Cli/WorkerLock.php && php -l inc/Engine/AI/PipelineAIConcurrencyLimiter.php && php -l inc/Engine/AI/PipelineAIConcurrencyLease.php
- vendor/bin/phpcs inc/Core/OptionLeaseStore.php inc/Cli/WorkerLock.php inc/Engine/AI/PipelineAIConcurrencyLimiter.php inc/Engine/AI/PipelineAIConcurrencyLease.php tests/worker-lock-smoke.php tests/ai-step-backpressure-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the shared option lease store refactor, updated the two existing callsites, and ran targeted verification. Chris remains responsible for review and acceptance.