### PR TITLE
Decouple step lifecycle source claims

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -15,7 +15,6 @@
 namespace DataMachine\Abilities\Engine;
 
 use DataMachine\Abilities\StepTypeAbilities;
-use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\EngineData;
 use DataMachine\Core\FilesRepository\FileCleanup;
 use DataMachine\Core\FilesRepository\FileRetrieval;
@@ -442,13 +441,10 @@ class ExecuteStepAbility {
 
 		// Status override: complete with override status and clean up.
 		if ( $status_override ) {
-			// Mark item as processed if the override indicates successful completion
-			// (e.g. agent_skipped is intentional, completed is success).
-			// Failed overrides should NOT mark items as processed.
 			if ( str_starts_with( $status_override, JobStatus::FAILED ) === false ) {
-				$this->markCompletedItemProcessed( $job_id );
+				$this->handleStepLifecycleCompleted( $job_id );
 			} else {
-				$this->releaseInFlightItemClaim( $job_id );
+				$this->handleStepLifecycleFailed( $job_id );
 			}
 			$this->db_jobs->complete_job( $job_id, $status_override );
 
@@ -533,23 +529,7 @@ class ExecuteStepAbility {
 				// producing one packet per event). A single packet is just
 				// the same job continuing to the next step.
 				if ( 'inline' === $transition_route['mode'] || $packet_count <= 1 ) {
-					// For fetch/event_import steps with a single item (inline continuation),
-					// seed dedup context into engine_data so markCompletedItemProcessed()
-					// can find it when the last step completes. For fan-out children this
-					// is handled in PipelineBatchScheduler::createChildJob().
-					if ( in_array( $step_type, array( 'fetch', 'event_import' ), true ) && ! empty( $routed_packets ) ) {
-						$packet_meta = $routed_packets[0]['metadata'] ?? array();
-						$seed_data   = array();
-						if ( ! empty( $packet_meta['item_identifier'] ) ) {
-							$seed_data['item_identifier'] = $packet_meta['item_identifier'];
-						}
-						if ( ! empty( $packet_meta['source_type'] ) ) {
-							$seed_data['source_type'] = $packet_meta['source_type'];
-						}
-						if ( ! empty( $seed_data ) ) {
-							datamachine_merge_engine_data( $job_id, $seed_data );
-						}
-					}
+					$this->handleStepLifecycleInlineContinuation( $job_id, $flow_step_config, $routed_packets );
 
 					do_action(
 						'datamachine_schedule_next_step',
@@ -584,10 +564,8 @@ class ExecuteStepAbility {
 				);
 			}
 
-			// Mark this item as processed now that the full pipeline succeeded.
-			// Deferred from the fetch step to prevent "dropped events" where
-			// an item is marked processed but a downstream step fails.
-			$this->markCompletedItemProcessed( $job_id );
+			// Notify lifecycle handlers after the full pipeline succeeds.
+			$this->handleStepLifecycleCompleted( $job_id );
 
 			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED );
 			$cleanup = new FileCleanup();
@@ -804,105 +782,32 @@ class ExecuteStepAbility {
 	}
 
 	/**
-	 * Mark a completed job's source item as processed.
+	 * Notify step lifecycle handlers that a step is continuing inline.
 	 *
-	 * Called when the LAST step in a pipeline completes successfully.
-	 * Reads the dedup key (item_identifier), source type, and fetch step ID
-	 * from the job's engine_data — these were seeded during fetch and
-	 * propagated through fan-out child creation.
-	 *
-	 * This deferred approach prevents "dropped events" where the fetch
-	 * step marks an item as processed but a downstream step (AI, update)
-	 * fails. Without this, the item would never be retried because the
-	 * dedup filter would skip it on the next fetch run.
-	 *
-	 * @since 0.58.1
-	 * @param int $job_id The completing job ID.
+	 * @param int   $job_id           Job ID.
+	 * @param array $flow_step_config Current flow step configuration.
+	 * @param array $routed_packets   Packets routed to the next step.
 	 */
-	private function markCompletedItemProcessed( int $job_id ): void {
-		$engine_data = datamachine_get_engine_data( $job_id );
-
-		$item_identifier = $engine_data['item_identifier'] ?? null;
-		$source_type     = $engine_data['source_type'] ?? null;
-
-		if ( empty( $item_identifier ) || empty( $source_type ) ) {
-			return;
-		}
-
-		// Find the fetch/event_import step's flow_step_id from flow_config.
-		// The processed items table is keyed by flow_step_id, so we need the
-		// fetch step's ID (not the current step's) for dedup to work correctly.
-		$fetch_flow_step_id = null;
-		$flow_config        = $engine_data['flow_config'] ?? array();
-
-		foreach ( $flow_config as $step_id => $config ) {
-			$step_type = $config['step_type'] ?? '';
-			if ( in_array( $step_type, array( 'fetch', 'event_import' ), true ) ) {
-				$fetch_flow_step_id = $step_id;
-				break;
-			}
-		}
-
-		if ( empty( $fetch_flow_step_id ) ) {
-			return;
-		}
-
-		do_action(
-			'datamachine_mark_item_processed',
-			$fetch_flow_step_id,
-			$source_type,
-			$item_identifier,
-			$job_id
-		);
-
-		do_action(
-			'datamachine_log',
-			'debug',
-			'Deferred mark-as-processed on pipeline completion',
-			array(
-				'job_id'             => $job_id,
-				'item_identifier'    => $item_identifier,
-				'source_type'        => $source_type,
-				'fetch_flow_step_id' => $fetch_flow_step_id,
-			)
-		);
+	private function handleStepLifecycleInlineContinuation( int $job_id, array $flow_step_config, array $routed_packets ): void {
+		do_action( 'datamachine_step_lifecycle_inline_continuation', $job_id, $flow_step_config, $routed_packets );
 	}
 
 	/**
-	 * Release this job's in-flight source claim after a failed status override.
+	 * Notify step lifecycle handlers that a job completed successfully.
 	 *
-	 * Most failures flow through datamachine_fail_job, whose handler releases
-	 * claims centrally. Failed status overrides complete the job directly, so
-	 * they need the same release here.
+	 * @param int $job_id Completed job ID.
+	 */
+	private function handleStepLifecycleCompleted( int $job_id ): void {
+		do_action( 'datamachine_step_lifecycle_completed', $job_id, datamachine_get_engine_data( $job_id ) );
+	}
+
+	/**
+	 * Notify step lifecycle handlers that a job failed outside datamachine_fail_job.
 	 *
 	 * @param int $job_id Failed job ID.
 	 */
-	private function releaseInFlightItemClaim( int $job_id ): void {
-		$engine_data = datamachine_get_engine_data( $job_id );
-
-		$item_identifier = $engine_data['item_identifier'] ?? null;
-		$source_type     = $engine_data['source_type'] ?? null;
-
-		if ( empty( $item_identifier ) || empty( $source_type ) ) {
-			return;
-		}
-
-		$fetch_flow_step_id = null;
-		$flow_config        = $engine_data['flow_config'] ?? array();
-
-		foreach ( $flow_config as $step_id => $config ) {
-			$step_type = $config['step_type'] ?? '';
-			if ( in_array( $step_type, array( 'fetch', 'event_import' ), true ) ) {
-				$fetch_flow_step_id = $step_id;
-				break;
-			}
-		}
-
-		if ( empty( $fetch_flow_step_id ) ) {
-			return;
-		}
-
-		( new ProcessedItems() )->release_claim( $fetch_flow_step_id, (string) $source_type, (string) $item_identifier );
+	private function handleStepLifecycleFailed( int $job_id ): void {
+		do_action( 'datamachine_step_lifecycle_failed', $job_id, datamachine_get_engine_data( $job_id ) );
 	}
 
 	/**

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -52,6 +52,7 @@ use DataMachine\Engine\Actions\Handlers\MarkItemProcessedHandler;
 use DataMachine\Engine\Actions\Handlers\FailJobHandler;
 use DataMachine\Engine\Actions\Handlers\JobCompleteHandler;
 use DataMachine\Engine\Actions\Handlers\LogHandler;
+use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
 use AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision;
 use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action;
 
@@ -66,6 +67,9 @@ function datamachine_register_core_actions() {
 	add_action( 'datamachine_fail_job', array( FailJobHandler::class, 'handle' ), 10, 3 );
 	add_action( 'datamachine_job_complete', array( JobCompleteHandler::class, 'handle' ), 10, 2 );
 	add_action( 'datamachine_log', array( LogHandler::class, 'handle' ), 10, 3 );
+	add_action( 'datamachine_step_lifecycle_inline_continuation', array( StepLifecycleHandler::class, 'handleInlineContinuation' ), 10, 3 );
+	add_action( 'datamachine_step_lifecycle_completed', array( StepLifecycleHandler::class, 'handleCompleted' ), 10, 2 );
+	add_action( 'datamachine_step_lifecycle_failed', array( StepLifecycleHandler::class, 'handleFailed' ), 10, 2 );
 	add_action(
 		'datamachine_pending_action_staged',
 		function ( string $action_id, array $payload ): void {

--- a/inc/Engine/Actions/Handlers/FailJobHandler.php
+++ b/inc/Engine/Actions/Handlers/FailJobHandler.php
@@ -132,7 +132,7 @@ class FailJobHandler {
 		}
 
 		$db_processed_items->delete_processed_items( array( 'job_id' => $job_id ) );
-		self::releaseInFlightSourceClaims( $db_processed_items, $job_id, $engine_data );
+		do_action( 'datamachine_step_lifecycle_failed', $job_id, $engine_data );
 
 		$cleanup_files = \DataMachine\Core\PluginSettings::get( 'cleanup_job_data_on_failure', true );
 		$files_cleaned = false;
@@ -191,58 +191,4 @@ class FailJobHandler {
 		return ! empty( $retry['next_retry_at'] );
 	}
 
-	/**
-	 * Release in-flight source-item claims for failed jobs.
-	 *
-	 * Parent fetch jobs own claims by job_id until their children are scheduled;
-	 * child jobs carry item_identifier/source_type in engine_data. Release both
-	 * shapes so failed downstream work can retry on the next fetch tick.
-	 *
-	 * @param \DataMachine\Core\Database\ProcessedItems\ProcessedItems $db_processed_items Processed items repository.
-	 * @param int                                                        $job_id             Failed job ID.
-	 * @param array                                                      $engine_data        Failed job engine data.
-	 * @return void
-	 */
-	private static function releaseInFlightSourceClaims( \DataMachine\Core\Database\ProcessedItems\ProcessedItems $db_processed_items, int $job_id, array $engine_data ): void {
-		$db_processed_items->release_claims_for_job( $job_id );
-
-		$item_identifier = $engine_data['item_identifier'] ?? null;
-		$source_type     = $engine_data['source_type'] ?? null;
-		if ( empty( $item_identifier ) || empty( $source_type ) ) {
-			return;
-		}
-
-		$fetch_flow_step_id = self::resolveFetchFlowStepId( $engine_data );
-		if ( empty( $fetch_flow_step_id ) ) {
-			return;
-		}
-
-		$db_processed_items->release_claim( $fetch_flow_step_id, (string) $source_type, (string) $item_identifier );
-	}
-
-	/**
-	 * Resolve the fetch/event_import step ID from a job engine snapshot.
-	 *
-	 * @param array $engine_data Job engine data.
-	 * @return string|null Fetch flow step ID, or null when unavailable.
-	 */
-	private static function resolveFetchFlowStepId( array $engine_data ): ?string {
-		$flow_config = $engine_data['flow_config'] ?? array();
-		if ( ! is_array( $flow_config ) ) {
-			return null;
-		}
-
-		foreach ( $flow_config as $step_id => $config ) {
-			if ( ! is_array( $config ) ) {
-				continue;
-			}
-
-			$step_type = $config['step_type'] ?? '';
-			if ( in_array( $step_type, array( 'fetch', 'event_import' ), true ) ) {
-				return (string) $step_id;
-			}
-		}
-
-		return null;
-	}
 }

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Default handlers for generic step lifecycle hooks.
+ *
+ * @package DataMachine\Engine\Actions\Handlers
+ * @since   0.146.2
+ */
+
+namespace DataMachine\Engine\Actions\Handlers;
+
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+
+/**
+ * Keeps source-ingestion processed-item behavior behind lifecycle hooks.
+ */
+class StepLifecycleHandler {
+
+	/**
+	 * Seed lifecycle context before an inline continuation.
+	 *
+	 * @param int   $job_id           Job ID.
+	 * @param array $flow_step_config Current flow step configuration.
+	 * @param array $routed_packets   Packets routed to the next step.
+	 */
+	public static function handleInlineContinuation( int $job_id, array $flow_step_config, array $routed_packets ): void {
+		$step_type = $flow_step_config['step_type'] ?? '';
+		if ( ! self::isSourceIngestionStep( (string) $step_type ) || empty( $routed_packets ) ) {
+			return;
+		}
+
+		$packet_meta = $routed_packets[0]['metadata'] ?? array();
+		$seed_data   = array();
+		if ( ! empty( $packet_meta['item_identifier'] ) ) {
+			$seed_data['item_identifier'] = $packet_meta['item_identifier'];
+		}
+		if ( ! empty( $packet_meta['source_type'] ) ) {
+			$seed_data['source_type'] = $packet_meta['source_type'];
+		}
+		if ( ! empty( $seed_data ) ) {
+			\datamachine_merge_engine_data( $job_id, $seed_data );
+		}
+	}
+
+	/**
+	 * Mark a completed job's source item as processed.
+	 *
+	 * @param int        $job_id      Completed job ID.
+	 * @param array|null $engine_data Optional engine data snapshot.
+	 */
+	public static function handleCompleted( int $job_id, ?array $engine_data = null ): void {
+		$engine_data = is_array( $engine_data ) ? $engine_data : \datamachine_get_engine_data( $job_id );
+
+		$item_identifier = $engine_data['item_identifier'] ?? null;
+		$source_type     = $engine_data['source_type'] ?? null;
+		if ( empty( $item_identifier ) || empty( $source_type ) ) {
+			return;
+		}
+
+		$source_flow_step_id = self::resolveSourceIngestionFlowStepId( $engine_data );
+		if ( empty( $source_flow_step_id ) ) {
+			return;
+		}
+
+		\do_action(
+			'datamachine_mark_item_processed',
+			$source_flow_step_id,
+			$source_type,
+			$item_identifier,
+			$job_id
+		);
+
+		\do_action(
+			'datamachine_log',
+			'debug',
+			'Deferred mark-as-processed on pipeline completion',
+			array(
+				'job_id'             => $job_id,
+				'item_identifier'    => $item_identifier,
+				'source_type'        => $source_type,
+				'fetch_flow_step_id' => $source_flow_step_id,
+			)
+		);
+	}
+
+	/**
+	 * Release source-item claims when a job fails.
+	 *
+	 * @param int        $job_id      Failed job ID.
+	 * @param array|null $engine_data Optional engine data snapshot.
+	 */
+	public static function handleFailed( int $job_id, ?array $engine_data = null ): void {
+		$engine_data        = is_array( $engine_data ) ? $engine_data : \datamachine_get_engine_data( $job_id );
+		$db_processed_items = new ProcessedItems();
+
+		$db_processed_items->release_claims_for_job( $job_id );
+
+		$item_identifier = $engine_data['item_identifier'] ?? null;
+		$source_type     = $engine_data['source_type'] ?? null;
+		if ( empty( $item_identifier ) || empty( $source_type ) ) {
+			return;
+		}
+
+		$source_flow_step_id = self::resolveSourceIngestionFlowStepId( $engine_data );
+		if ( empty( $source_flow_step_id ) ) {
+			return;
+		}
+
+		$db_processed_items->release_claim( $source_flow_step_id, (string) $source_type, (string) $item_identifier );
+	}
+
+	/**
+	 * Resolve the source-ingestion step ID from a job engine snapshot.
+	 *
+	 * @param array $engine_data Job engine data.
+	 * @return string|null Source ingestion flow step ID, or null when unavailable.
+	 */
+	public static function resolveSourceIngestionFlowStepId( array $engine_data ): ?string {
+		$flow_config = $engine_data['flow_config'] ?? array();
+		if ( ! is_array( $flow_config ) ) {
+			return null;
+		}
+
+		foreach ( $flow_config as $step_id => $config ) {
+			if ( ! is_array( $config ) ) {
+				continue;
+			}
+
+			$step_type = $config['step_type'] ?? '';
+			if ( self::isSourceIngestionStep( (string) $step_type ) ) {
+				return (string) $step_id;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Determine whether a step owns source-ingestion dedupe lifecycle behavior.
+	 *
+	 * @param string $step_type Step type.
+	 * @return bool
+	 */
+	private static function isSourceIngestionStep( string $step_type ): bool {
+		return in_array( $step_type, array( 'fetch', 'event_import' ), true );
+	}
+}

--- a/tests/processed-item-claims-smoke.php
+++ b/tests/processed-item-claims-smoke.php
@@ -127,6 +127,7 @@ echo "Case 5: production files expose the claim contract\n";
 $processed_items = file_get_contents( __DIR__ . '/../inc/Core/Database/ProcessedItems/ProcessedItems.php' );
 $fetch_handler   = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/FetchHandler.php' );
 $fail_handler    = file_get_contents( __DIR__ . '/../inc/Engine/Actions/Handlers/FailJobHandler.php' );
+$lifecycle       = file_get_contents( __DIR__ . '/../inc/Engine/Actions/Handlers/StepLifecycleHandler.php' );
 $execute_step    = file_get_contents( __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php' );
 
 assert_claims_smoke( 'repository defines claimed status', (bool) preg_match( "/STATUS_CLAIMED\s*=\s*'claimed'/", $processed_items ) );
@@ -136,8 +137,9 @@ assert_claims_smoke( 'repository has release claim method', str_contains( $proce
 assert_claims_smoke( 'repository ensures claim columns', str_contains( $processed_items, 'function ensure_claim_columns' ) );
 assert_claims_smoke( 'fetch filters active claims', str_contains( $fetch_handler, 'isItemClaimed' ) );
 assert_claims_smoke( 'fetch claims after max_items', strpos( $fetch_handler, 'array_slice' ) < strpos( $fetch_handler, 'claimItems' ) );
-assert_claims_smoke( 'fail handler releases claims', str_contains( $fail_handler, 'releaseInFlightSourceClaims' ) );
-assert_claims_smoke( 'failed status override releases claim', str_contains( $execute_step, 'releaseInFlightItemClaim' ) );
+assert_claims_smoke( 'fail handler delegates failed lifecycle', str_contains( $fail_handler, 'datamachine_step_lifecycle_failed' ) );
+assert_claims_smoke( 'lifecycle handler releases claims for failed work', str_contains( $lifecycle, 'release_claims_for_job' ) && str_contains( $lifecycle, 'release_claim' ) );
+assert_claims_smoke( 'execute step delegates lifecycle hooks', str_contains( $execute_step, 'handleStepLifecycleCompleted' ) && str_contains( $execute_step, 'handleStepLifecycleFailed' ) );
 
 echo "\nProcessed item claims smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary
- Add generic step lifecycle hooks for inline continuation, successful completion, and failed completion.
- Move fetch/event_import processed-item context seeding, processed marking, and claim release behavior into the default lifecycle handler.
- Keep ExecuteStepAbility and FailJobHandler calling generic lifecycle boundaries instead of embedding source-ingestion semantics.

## Testing
- No syntax errors detected in inc/Engine/Actions/Handlers/StepLifecycleHandler.php
No syntax errors detected in inc/Abilities/Engine/ExecuteStepAbility.php
No syntax errors detected in inc/Engine/Actions/Handlers/FailJobHandler.php
No syntax errors detected in inc/Engine/Actions/DataMachineActions.php
Case 1: parallel parents cannot claim the same item
  [PASS] first parent claim succeeds
  [PASS] second parent claim fails while first is active
  [PASS] active claim makes fetch skip item
  [PASS] row is in claimed state before completion
Case 2: failed downstream work releases claim for retry
  [PASS] released claim no longer skips
  [PASS] later parent can reclaim after release
Case 3: successful completion converts claim to processed
  [PASS] row is processed after final completion
  [PASS] processed row makes future fetch skip
  [PASS] processed row cannot be reclaimed
Case 4: stale claims expire
  [PASS] short claim succeeds
  [PASS] expired claim no longer skips
  [PASS] expired claim can be reclaimed
Case 5: production files expose the claim contract
  [PASS] repository defines claimed status
  [PASS] repository defines processed status
  [PASS] repository has atomic claim method
  [PASS] repository has release claim method
  [PASS] repository ensures claim columns
  [PASS] fetch filters active claims
  [PASS] fetch claims after max_items
  [PASS] fail handler delegates failed lifecycle
  [PASS] lifecycle handler releases claims for failed work
  [PASS] execute step delegates lifecycle hooks

Processed item claims smoke complete: 22 assertions, 0 failures.
- 
- Case 1: parallel parents cannot claim the same item
  [PASS] first parent claim succeeds
  [PASS] second parent claim fails while first is active
  [PASS] active claim makes fetch skip item
  [PASS] row is in claimed state before completion
Case 2: failed downstream work releases claim for retry
  [PASS] released claim no longer skips
  [PASS] later parent can reclaim after release
Case 3: successful completion converts claim to processed
  [PASS] row is processed after final completion
  [PASS] processed row makes future fetch skip
  [PASS] processed row cannot be reclaimed
Case 4: stale claims expire
  [PASS] short claim succeeds
  [PASS] expired claim no longer skips
  [PASS] expired claim can be reclaimed
Case 5: production files expose the claim contract
  [PASS] repository defines claimed status
  [PASS] repository defines processed status
  [PASS] repository has atomic claim method
  [PASS] repository has release claim method
  [PASS] repository ensures claim columns
  [PASS] fetch filters active claims
  [PASS] fetch claims after max_items
  [PASS] fail handler delegates failed lifecycle
  [PASS] lifecycle handler releases claims for failed work
  [PASS] execute step delegates lifecycle hooks

Processed item claims smoke complete: 22 assertions, 0 failures.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the lifecycle hook boundary, moved existing processed-item claim behavior into the default handler, updated focused smoke coverage, and ran verification. Chris remains responsible for review and acceptance.