### PR TITLE
Centralize ability boundary helpers

### DIFF
--- a/inc/Abilities/AbilityRegistration.php
+++ b/inc/Abilities/AbilityRegistration.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Shared Abilities API lifecycle helpers.
+ *
+ * @package DataMachine\Abilities
+ */
+
+namespace DataMachine\Abilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Keeps Data Machine ability classes on the public Abilities API lifecycle.
+ */
+class AbilityRegistration {
+
+	/**
+	 * Register now during wp_abilities_api_init, or hook before it fires.
+	 *
+	 * @param callable $register_callback Ability registration callback.
+	 */
+	public static function on_abilities_api_init( callable $register_callback ): void {
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+			return;
+		}
+
+		if ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+}

--- a/inc/Abilities/Flow/CreateFlowAbility.php
+++ b/inc/Abilities/Flow/CreateFlowAbility.php
@@ -10,6 +10,7 @@
 
 namespace DataMachine\Abilities\Flow;
 
+use DataMachine\Abilities\AbilityRegistration;
 use DataMachine\Api\Flows\FlowScheduling;
 
 defined( 'ABSPATH' ) || exit;
@@ -105,11 +106,7 @@ class CreateFlowAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Flow/QueueAbility.php
+++ b/inc/Abilities/Flow/QueueAbility.php
@@ -32,6 +32,7 @@
 
 namespace DataMachine\Abilities\Flow;
 
+use DataMachine\Abilities\AbilityRegistration;
 use DataMachine\Core\Database\Flows\Flows as DB_Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines as DB_Pipelines;
 use DataMachine\Abilities\DuplicateCheck\DuplicateCheckAbility;
@@ -108,11 +109,7 @@ class QueueAbility {
 			$this->registerConfigPatchMove();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Cli/AbilityRunner.php
+++ b/inc/Cli/AbilityRunner.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Shared WP-CLI helper for executing registered abilities.
+ *
+ * @package DataMachine\Cli
+ */
+
+namespace DataMachine\Cli;
+
+use DataMachine\Core\AbilityResult;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Executes abilities through the Abilities API boundary for CLI commands.
+ */
+class AbilityRunner {
+
+	/**
+	 * Execute a registered ability and normalize the result for legacy CLI callers.
+	 *
+	 * @param string $ability_name Ability slug, e.g. datamachine/get-jobs.
+	 * @param array  $input        Ability input.
+	 * @return array Normalized ability result.
+	 */
+	public static function execute( string $ability_name, array $input = array() ): array {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Abilities API is not available.',
+			);
+		}
+
+		$ability = wp_get_ability( $ability_name );
+		if ( ! $ability || ! is_callable( array( $ability, 'execute' ) ) ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Ability not registered: %s', $ability_name ),
+			);
+		}
+
+		return AbilityResult::normalize( $ability->execute( $input ) );
+	}
+}

--- a/inc/Cli/Commands/Flows/WebhookCommand.php
+++ b/inc/Cli/Commands/Flows/WebhookCommand.php
@@ -13,6 +13,7 @@
 namespace DataMachine\Cli\Commands\Flows;
 
 use WP_CLI;
+use DataMachine\Cli\AbilityRunner;
 use DataMachine\Cli\BaseCommand;
 
 defined( 'ABSPATH' ) || exit;
@@ -181,8 +182,7 @@ class WebhookCommand extends BaseCommand {
 			$input['secret_id'] = (string) $assoc_args['secret-id'];
 		}
 
-		$ability = new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
-		$result  = $ability->executeEnable( $input );
+		$result = AbilityRunner::execute( 'datamachine/webhook-trigger-enable', $input );
 
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to enable webhook trigger' );
@@ -316,8 +316,7 @@ class WebhookCommand extends BaseCommand {
 			$input['secret_id'] = (string) $assoc_args['secret-id'];
 		}
 
-		$ability = new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
-		$result  = $ability->executeSetSecret( $input );
+		$result = AbilityRunner::execute( 'datamachine/webhook-trigger-set-secret', $input );
 
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to set webhook secret' );
@@ -360,8 +359,7 @@ class WebhookCommand extends BaseCommand {
 			return;
 		}
 
-		$ability = new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
-		$result  = $ability->executeDisable( array( 'flow_id' => $flow_id ) );
+		$result = AbilityRunner::execute( 'datamachine/webhook-trigger-disable', array( 'flow_id' => $flow_id ) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to disable webhook trigger' );
@@ -401,8 +399,7 @@ class WebhookCommand extends BaseCommand {
 			return;
 		}
 
-		$ability = new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
-		$result  = $ability->executeRegenerate( array( 'flow_id' => $flow_id ) );
+		$result = AbilityRunner::execute( 'datamachine/webhook-trigger-regenerate', array( 'flow_id' => $flow_id ) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to regenerate webhook token' );
@@ -456,8 +453,7 @@ class WebhookCommand extends BaseCommand {
 
 		$format = $assoc_args['format'] ?? 'table';
 
-		$ability = new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
-		$result  = $ability->executeStatus( array( 'flow_id' => $flow_id ) );
+		$result = AbilityRunner::execute( 'datamachine/webhook-trigger-status', array( 'flow_id' => $flow_id ) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to get webhook status' );
@@ -598,8 +594,7 @@ class WebhookCommand extends BaseCommand {
 
 		// If no --max or --window provided, show current config.
 		if ( ! isset( $assoc_args['max'] ) && ! isset( $assoc_args['window'] ) ) {
-			$ability = new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
-			$result  = $ability->executeStatus( array( 'flow_id' => $flow_id ) );
+			$result = AbilityRunner::execute( 'datamachine/webhook-trigger-status', array( 'flow_id' => $flow_id ) );
 
 			if ( ! $result['success'] ) {
 				WP_CLI::error( $result['error'] ?? 'Failed to get webhook status' );
@@ -632,8 +627,7 @@ class WebhookCommand extends BaseCommand {
 			$input['window'] = (int) $assoc_args['window'];
 		}
 
-		$ability = new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
-		$result  = $ability->executeSetRateLimit( $input );
+		$result = AbilityRunner::execute( 'datamachine/webhook-trigger-rate-limit', $input );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to set rate limit' );
@@ -703,8 +697,7 @@ class WebhookCommand extends BaseCommand {
 			$input['previous_ttl_seconds'] = (int) $assoc_args['previous-ttl-seconds'];
 		}
 
-		$ability = new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
-		$result  = $ability->executeRotateSecret( $input );
+		$result = AbilityRunner::execute( 'datamachine/webhook-trigger-rotate-secret', $input );
 
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to rotate secret' );
@@ -762,8 +755,8 @@ class WebhookCommand extends BaseCommand {
 			return;
 		}
 
-		$ability = new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
-		$result  = $ability->executeForgetSecret(
+		$result = AbilityRunner::execute(
+			'datamachine/webhook-trigger-forget-secret',
 			array(
 				'flow_id'   => $flow_id,
 				'secret_id' => $secret_id,

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -13,6 +13,7 @@
 namespace DataMachine\Cli\Commands;
 
 use WP_CLI;
+use DataMachine\Cli\AbilityRunner;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Cli\AgentResolver;
 use DataMachine\Cli\UserResolver;
@@ -110,7 +111,8 @@ class JobsCommand extends BaseCommand {
 		$timeout = isset( $assoc_args['timeout'] ) ? max( 1, (int) $assoc_args['timeout'] ) : 2;
 		$format  = $assoc_args['format'] ?? 'table';
 
-		$result = ( new RecoverStuckJobsAbility() )->execute(
+		$result = AbilityRunner::execute(
+			'datamachine/recover-stuck-jobs',
 			array(
 				'dry_run'       => $dry_run,
 				'flow_id'       => $flow_id,
@@ -1265,7 +1267,7 @@ class JobsCommand extends BaseCommand {
 			$input['fields'] = $this->get_database_fields_for_job_list_fields( $fields );
 		}
 
-		$result = ( new GetJobsAbility() )->execute( $input );
+		$result = AbilityRunner::execute( 'datamachine/get-jobs', $input );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Unknown error occurred' );

--- a/inc/Cli/Commands/TaxonomyCommand.php
+++ b/inc/Cli/Commands/TaxonomyCommand.php
@@ -11,6 +11,7 @@
 namespace DataMachine\Cli\Commands;
 
 use WP_CLI;
+use DataMachine\Cli\AbilityRunner;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Abilities\Taxonomy\CreateTaxonomyTermAbility;
 use DataMachine\Abilities\Taxonomy\DeleteTaxonomyTermAbility;
@@ -117,7 +118,7 @@ class TaxonomyCommand extends BaseCommand {
 			$input['parent'] = (int) $assoc_args['parent'];
 		}
 
-		$result = ( new GetTaxonomyTermsAbility() )->execute( $input );
+		$result = AbilityRunner::execute( 'datamachine/get-taxonomy-terms', $input );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to get taxonomy terms.' );

--- a/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
+++ b/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
@@ -42,6 +42,7 @@ use AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision;
 use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action;
 use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Handler;
 use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Status;
+use DataMachine\Abilities\AbilityRegistration;
 use DataMachine\Abilities\PermissionHelper;
 
 defined( 'ABSPATH' ) || exit;
@@ -135,11 +136,7 @@ class ResolvePendingActionAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register );
-		}
+		AbilityRegistration::on_abilities_api_init( $register );
 	}
 
 	/**

--- a/tests/ability-boundary-helpers-smoke.php
+++ b/tests/ability-boundary-helpers-smoke.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Pure-PHP smoke test for ability registration and CLI runner helpers.
+ *
+ * Run with: php tests/ability-boundary-helpers-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failed = 0;
+$total  = 0;
+
+$datamachine_test_doing_action = false;
+$datamachine_test_did_action   = 0;
+$datamachine_test_actions      = array();
+$datamachine_test_abilities    = array();
+
+function doing_action( $hook = '' ) {
+	global $datamachine_test_doing_action;
+	return 'wp_abilities_api_init' === $hook && $datamachine_test_doing_action;
+}
+
+function did_action( $hook = '' ) {
+	global $datamachine_test_did_action;
+	return 'wp_abilities_api_init' === $hook ? $datamachine_test_did_action : 0;
+}
+
+function add_action( $hook, $callback ) {
+	global $datamachine_test_actions;
+	$datamachine_test_actions[ $hook ][] = $callback;
+}
+
+function wp_get_ability( string $name ) {
+	global $datamachine_test_abilities;
+	return $datamachine_test_abilities[ $name ] ?? null;
+}
+
+function is_wp_error( $value ) {
+	return false;
+}
+
+class Datamachine_Test_Ability {
+	public function execute( $input = null ) {
+		return array(
+			'success' => true,
+			'input'   => $input,
+		);
+	}
+}
+
+require_once __DIR__ . '/../inc/Abilities/AbilityRegistration.php';
+require_once __DIR__ . '/../inc/Core/AbilityResult.php';
+require_once __DIR__ . '/../inc/Cli/AbilityRunner.php';
+
+function assert_ability_boundary( string $name, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$name}\n";
+		return;
+	}
+	echo "  FAIL: {$name}\n";
+	++$failed;
+}
+
+echo "=== Ability Boundary Helpers Smoke ===\n";
+
+$called = 0;
+\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init(
+	function () use ( &$called ) {
+		++$called;
+	}
+);
+assert_ability_boundary( 'registration hooks before wp_abilities_api_init fires', 1 === count( $datamachine_test_actions['wp_abilities_api_init'] ?? array() ) && 0 === $called );
+
+$datamachine_test_doing_action = true;
+\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init(
+	function () use ( &$called ) {
+		++$called;
+	}
+);
+assert_ability_boundary( 'registration executes while wp_abilities_api_init is running', 1 === $called );
+
+$datamachine_test_doing_action = false;
+$datamachine_test_did_action   = 1;
+$before_hook_count             = count( $datamachine_test_actions['wp_abilities_api_init'] ?? array() );
+\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init(
+	function () use ( &$called ) {
+		++$called;
+	}
+);
+assert_ability_boundary( 'registration is a no-op after wp_abilities_api_init has fired', $before_hook_count === count( $datamachine_test_actions['wp_abilities_api_init'] ?? array() ) && 1 === $called );
+
+$datamachine_test_abilities['datamachine/example'] = new Datamachine_Test_Ability();
+$result = \DataMachine\Cli\AbilityRunner::execute( 'datamachine/example', array( 'example' => true ) );
+assert_ability_boundary( 'CLI runner executes registered abilities through wp_get_ability()', ! empty( $result['success'] ) && true === ( $result['input']['example'] ?? false ) );
+
+$missing = \DataMachine\Cli\AbilityRunner::execute( 'datamachine/missing' );
+assert_ability_boundary( 'CLI runner returns normalized failure for missing abilities', empty( $missing['success'] ) && false !== strpos( $missing['error'] ?? '', 'datamachine/missing' ) );
+
+if ( $failed > 0 ) {
+	echo "\nFAILURES: {$failed}/{$total}\n";
+	exit( 1 );
+}
+
+echo "\nAll {$total} checks passed.\n";


### PR DESCRIPTION
## Summary
- Add `AbilityRegistration::on_abilities_api_init()` for the repeated public Abilities API lifecycle guard.
- Add `AbilityRunner::execute()` so WP-CLI commands can execute registered abilities through `wp_get_ability()` instead of directly instantiating ability classes.
- Migrate representative cited sites: create-flow, queue, pending-action resolver registration, jobs list/recover-stuck, taxonomy list, and webhook trigger CLI operations.

## Follow-up
- This intentionally avoids broad churn. Many ability classes still repeat the lifecycle guard and several CLI commands still instantiate ability classes directly. Those can migrate incrementally to the new helpers as touched.

## Testing
- `php -l inc/Abilities/AbilityRegistration.php && php -l inc/Cli/AbilityRunner.php && php -l inc/Abilities/Flow/CreateFlowAbility.php && php -l inc/Abilities/Flow/QueueAbility.php && php -l inc/Engine/AI/Actions/ResolvePendingActionAbility.php && php -l inc/Cli/Commands/JobsCommand.php && php -l inc/Cli/Commands/TaxonomyCommand.php && php -l inc/Cli/Commands/Flows/WebhookCommand.php && php -l tests/ability-boundary-helpers-smoke.php`
- `php tests/ability-boundary-helpers-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the helper implementation, focused migrations, smoke test, and PR description; Chris remains responsible for review and merge.