### PR TITLE
Decouple Agents API boundary hooks

### DIFF
--- a/inc/Engine/AI/Directives/ClientContextDirective.php
+++ b/inc/Engine/AI/Directives/ClientContextDirective.php
@@ -2,10 +2,9 @@
 /**
  * Client Context Directive.
  *
- * Renders client-side context data as a system message so the AI agent
- * knows what the user is currently doing in the application. Context is
- * provided by the frontend via the `client_context` parameter on the
- * chat REST endpoint.
+ * Renders caller-provided client context data as a system message so the AI
+ * agent can consider request-local context. Context is provided via the
+ * `client_context` request parameter.
  *
  * Examples of client context:
  *   - { "tab": "compose", "post_id": 123, "post_title": "My Draft" }
@@ -110,7 +109,11 @@ class ClientContextDirective {
 		$lines[] = '';
 		$lines[] = 'Important: frontend editor context can describe the user\'s current in-browser draft state. Prefer it when answering questions about what is currently open in the editor.';
 
-		return implode( "\n", $lines );
+		$guidance = implode( "\n", $lines );
+
+		return function_exists( 'apply_filters' )
+			? (string) apply_filters( 'datamachine_client_context_editor_guidance', $guidance, $client_context )
+			: $guidance;
 	}
 
 	/**
@@ -139,9 +142,14 @@ class ClientContextDirective {
 			return array();
 		}
 
+		$intro = 'Here is request-local client context supplied by the caller:';
+		if ( function_exists( 'apply_filters' ) ) {
+			$intro = (string) apply_filters( 'datamachine_client_context_directive_intro', $intro, $client_context, $payload );
+		}
+
 		$content = "# Current Client Context\n\n"
-			. 'The user is interacting with you from a frontend interface. '
-			. "Here is their current context:\n\n"
+			. $intro
+			. "\n\n"
 			. implode( "\n", $lines );
 
 		$editor_guidance = self::build_editor_guidance( $client_context );
@@ -149,12 +157,16 @@ class ClientContextDirective {
 			$content .= "\n\n" . $editor_guidance;
 		}
 
-		return array(
+		$outputs = array(
 			array(
 				'type'    => 'system_text',
 				'content' => $content,
 			),
 		);
+
+		return function_exists( 'apply_filters' )
+			? apply_filters( 'datamachine_client_context_directive_outputs', $outputs, $client_context, $payload, $provider_name, $tools, $step_id )
+			: $outputs;
 	}
 }
 
@@ -163,10 +175,15 @@ class ClientContextDirective {
 add_filter(
 	'datamachine_directives',
 	function ( $directives ) {
+		$modes = array( 'chat' );
+		if ( function_exists( 'apply_filters' ) ) {
+			$modes = apply_filters( 'datamachine_client_context_directive_modes', $modes );
+		}
+
 		$directives[] = array(
 			'class'    => ClientContextDirective::class,
 			'priority' => 35,
-			'modes'    => array( 'all' ),
+			'modes'    => is_array( $modes ) ? $modes : array( 'chat' ),
 		);
 		return $directives;
 	}

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -104,7 +104,12 @@ class RequestBuilder {
 			)
 		);
 
-		// 4. Dispatch the request. wp-ai-client is the only runtime provider path.
+		$adapter_result = apply_filters( 'datamachine_ai_request_result', null, $provider_request, $provider, $model, $request, $request_metadata );
+		if ( null !== $adapter_result ) {
+			return self::normalizeAdapterResult( $adapter_result, $provider, $model );
+		}
+
+		// 4. Dispatch the request through Data Machine's default wp-ai-client adapter.
 		$unavailable_reason = self::wpAiClientUnavailableReason( $provider );
 		if ( null !== $unavailable_reason ) {
 			do_action(
@@ -129,20 +134,7 @@ class RequestBuilder {
 
 		$filtered_result = apply_filters( 'datamachine_wp_ai_client_text_result', null, $provider_request, $provider, $model, $request );
 		if ( null !== $filtered_result ) {
-			if ( $filtered_result instanceof \WP_Error || $filtered_result instanceof \WordPress\AiClient\Results\DTO\GenerativeAiResult ) {
-				return $filtered_result;
-			}
-
-			if ( is_array( $filtered_result ) ) {
-				$data = $filtered_result['data'] ?? $filtered_result;
-				if ( is_callable( array( '\WordPress\AiClient\Results\DTO\GenerativeAiResult', 'fromData' ) ) ) {
-					return \WordPress\AiClient\Results\DTO\GenerativeAiResult::fromData( $data );
-				}
-
-				if ( is_callable( array( '\WordPress\AiClient\Results\DTO\GenerativeAiResult', 'fromArray' ) ) ) {
-					return \WordPress\AiClient\Results\DTO\GenerativeAiResult::fromArray( self::wpAiClientResultArray( $data, $provider, $model ) );
-				}
-			}
+			return self::normalizeAdapterResult( $filtered_result, $provider, $model );
 		}
 
 		$result                        = null;
@@ -791,10 +783,14 @@ class RequestBuilder {
 			}
 		}
 
-		return array(
+		$aliases = array(
 			'logical_to_provider' => $logical_to_provider,
 			'provider_to_logical' => $provider_to_logical,
 		);
+
+		return function_exists( 'apply_filters' )
+			? apply_filters( 'datamachine_provider_tool_name_aliases', $aliases, $tools )
+			: $aliases;
 	}
 
 	/**
@@ -805,6 +801,13 @@ class RequestBuilder {
 	 * @return string Provider-safe tool name.
 	 */
 	private static function providerToolName( string $logical_name, array $tool_config ): string {
+		$filtered_name = function_exists( 'apply_filters' )
+			? apply_filters( 'datamachine_provider_tool_name', null, $logical_name, $tool_config )
+			: null;
+		if ( is_string( $filtered_name ) && self::isProviderSafeToolName( $filtered_name ) ) {
+			return $filtered_name;
+		}
+
 		$runtime_tool_id = is_string( $tool_config['runtime_tool_id'] ?? null ) ? trim( (string) $tool_config['runtime_tool_id'] ) : '';
 		if ( self::isProviderSafeToolName( $runtime_tool_id ) ) {
 			return $runtime_tool_id;
@@ -972,6 +975,36 @@ class RequestBuilder {
 		}
 
 		return $payload;
+	}
+
+	/**
+	 * Normalize an adapter/filter result into the wp-ai-client result contract.
+	 *
+	 * Custom dispatch adapters can return a WP_Error, a GenerativeAiResult, or compact
+	 * response data matching the existing test adapter shape.
+	 *
+	 * @param mixed  $result   Adapter result.
+	 * @param string $provider Provider identifier.
+	 * @param string $model    Model identifier.
+	 * @return \WordPress\AiClient\Results\DTO\GenerativeAiResult|\WP_Error|mixed Normalized result when possible.
+	 */
+	private static function normalizeAdapterResult( $result, string $provider, string $model ) {
+		if ( $result instanceof \WP_Error || $result instanceof \WordPress\AiClient\Results\DTO\GenerativeAiResult ) {
+			return $result;
+		}
+
+		if ( is_array( $result ) ) {
+			$data = $result['data'] ?? $result;
+			if ( is_callable( array( '\WordPress\AiClient\Results\DTO\GenerativeAiResult', 'fromData' ) ) ) {
+				return \WordPress\AiClient\Results\DTO\GenerativeAiResult::fromData( $data );
+			}
+
+			if ( is_callable( array( '\WordPress\AiClient\Results\DTO\GenerativeAiResult', 'fromArray' ) ) ) {
+				return \WordPress\AiClient\Results\DTO\GenerativeAiResult::fromArray( self::wpAiClientResultArray( $data, $provider, $model ) );
+			}
+		}
+
+		return $result;
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Sources/RuntimeToolSource.php
+++ b/inc/Engine/AI/Tools/Sources/RuntimeToolSource.php
@@ -59,21 +59,36 @@ final class RuntimeToolSource {
 	}
 
 	/**
-	 * Extract declarations from explicit resolver args and nested client context.
+	 * Extract declarations from explicit resolver args.
+	 *
+	 * Runtime adapters can add transport-specific declaration sets through the
+	 * `datamachine_runtime_tool_declaration_sets` filter. Data Machine core only
+	 * reads explicit resolver arguments and the namespaced `client_context.runtime_tools`
+	 * envelope.
 	 *
 	 * @param array $args Full resolution arguments.
 	 * @return array<int,array{key:string, declaration:mixed}> Runtime declarations.
 	 */
 	private function declarationsFromContext( array $args ): array {
-		$sets = array(
-			$args['runtime_tool_declarations'] ?? null,
-			$args['runtime_tools'] ?? null,
+		$sets = array_filter(
+			array(
+				$args['runtime_tool_declarations'] ?? null,
+				$args['runtime_tools'] ?? null,
+			),
+			'is_array'
 		);
 
 		$client_context = is_array( $args['client_context'] ?? null ) ? $args['client_context'] : array();
-		$sets[]         = $client_context['runtime_tool_declarations'] ?? null;
-		$sets[]         = $client_context['runtime_tools'] ?? null;
-		$sets[]         = $client_context['tool_declarations'] ?? null;
+		$runtime_tools  = is_array( $client_context['runtime_tools'] ?? null ) ? $client_context['runtime_tools'] : array();
+		if ( is_array( $runtime_tools['declarations'] ?? null ) ) {
+			$sets[] = $runtime_tools['declarations'];
+		} elseif ( ! empty( $runtime_tools ) && $this->looksLikeDeclarationSet( $runtime_tools ) ) {
+			$sets[] = $runtime_tools;
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$sets = apply_filters( 'datamachine_runtime_tool_declaration_sets', $sets, $args, $client_context );
+		}
 
 		$declarations = array();
 		foreach ( $sets as $set ) {
@@ -94,6 +109,22 @@ final class RuntimeToolSource {
 		}
 
 		return $declarations;
+	}
+
+	/**
+	 * Heuristically detect the legacy compact map shape under runtime_tools.
+	 *
+	 * @param array<mixed> $set Candidate declaration set.
+	 * @return bool Whether the set appears to contain declarations.
+	 */
+	private function looksLikeDeclarationSet( array $set ): bool {
+		foreach ( $set as $entry ) {
+			if ( is_array( $entry ) && ( isset( $entry['description'] ) || isset( $entry['parameters'] ) || isset( $entry['input_schema'] ) ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/inc/Engine/Agents/PersistedAgentProjector.php
+++ b/inc/Engine/Agents/PersistedAgentProjector.php
@@ -90,7 +90,12 @@ class PersistedAgentProjector {
 	 * @param array<string,mixed> $config Agent config.
 	 */
 	private static function description_from_row( array $row, array $config ): string {
-		foreach ( array( $config, $config['intelligence_wiki_brain'] ?? null ) as $source ) {
+		$sources = array( $config );
+		if ( function_exists( 'apply_filters' ) ) {
+			$sources = apply_filters( 'datamachine_persisted_agent_description_sources', $sources, $row, $config );
+		}
+
+		foreach ( $sources as $source ) {
 			if ( ! is_array( $source ) ) {
 				continue;
 			}
@@ -114,15 +119,63 @@ class PersistedAgentProjector {
 	 * @return array<string,mixed>
 	 */
 	private static function meta_from_row( array $row, array $config ): array {
-		$bundle = is_array( $config['datamachine_bundle'] ?? null ) ? $config['datamachine_bundle'] : array();
-		$brain  = is_array( $config['intelligence_wiki_brain'] ?? null ) ? $config['intelligence_wiki_brain'] : array();
-
 		$meta = array(
 			'source_plugin'        => 'data-machine',
 			'source_type'          => 'persisted-agent',
 			'datamachine_agent_id' => (int) ( $row['agent_id'] ?? 0 ),
 			'datamachine_owner_id' => (int) ( $row['owner_id'] ?? 0 ),
 		);
+
+		foreach ( self::metadata_projectors( $row, $config ) as $projector ) {
+			if ( is_callable( $projector ) ) {
+				$projected = call_user_func( $projector, $row, $config );
+				if ( is_array( $projected ) ) {
+					$meta = array_merge( $meta, $projected );
+				}
+			}
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$meta = apply_filters( 'datamachine_persisted_agent_projection_meta', $meta, $row, $config );
+		}
+
+		return is_array( $meta ) ? $meta : array();
+	}
+
+	/**
+	 * Return metadata projectors for persisted agent rows.
+	 *
+	 * Extensions can register domain-specific projectors without Data Machine core
+	 * knowing their config shape.
+	 *
+	 * @param array<string,mixed> $row    Data Machine agent row.
+	 * @param array<string,mixed> $config Agent config.
+	 * @return array<int,callable>
+	 */
+	private static function metadata_projectors( array $row, array $config ): array {
+		$projectors = array(
+			static fn( array $projector_row, array $projector_config ): array => self::bundle_metadata_from_config( $projector_row, $projector_config ),
+		);
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$projectors = apply_filters( 'datamachine_persisted_agent_metadata_projectors', $projectors, $row, $config );
+		}
+
+		return is_array( $projectors ) ? $projectors : array();
+	}
+
+	/**
+	 * Project generic Data Machine bundle metadata.
+	 *
+	 * @param array<string,mixed> $row    Data Machine agent row.
+	 * @param array<string,mixed> $config Agent config.
+	 * @return array<string,mixed>
+	 */
+	private static function bundle_metadata_from_config( array $row, array $config ): array {
+		unset( $row );
+
+		$bundle = is_array( $config['datamachine_bundle'] ?? null ) ? $config['datamachine_bundle'] : array();
+		$meta   = array();
 
 		foreach ( array( 'bundle_slug', 'bundle_version', 'source_ref', 'source_revision' ) as $key ) {
 			$value = trim( (string) ( $bundle[ $key ] ?? '' ) );
@@ -133,13 +186,6 @@ class PersistedAgentProjector {
 
 		if ( ! empty( $bundle['bundle_slug'] ) ) {
 			$meta['source_package'] = (string) $bundle['bundle_slug'];
-		}
-
-		foreach ( array( 'domain', 'wiki_slug', 'source_slug', 'brain_slug', 'bundle_slug' ) as $key ) {
-			$value = trim( (string) ( $brain[ $key ] ?? '' ) );
-			if ( '' !== $value ) {
-				$meta[ 'intelligence_wiki_brain_' . $key ] = $value;
-			}
 		}
 
 		return $meta;

--- a/tests/agents-api-persisted-agent-registry-smoke.php
+++ b/tests/agents-api-persisted-agent-registry-smoke.php
@@ -22,6 +22,43 @@ $passes   = 0;
 
 echo "agents-api-persisted-agent-registry-smoke\n";
 
+add_filter(
+	'datamachine_persisted_agent_description_sources',
+	static function ( array $sources, array $row, array $config ): array {
+		unset( $row );
+		if ( is_array( $config['intelligence_wiki_brain'] ?? null ) ) {
+			$sources[] = $config['intelligence_wiki_brain'];
+		}
+		return $sources;
+	},
+	10,
+	3
+);
+
+add_filter(
+	'datamachine_persisted_agent_metadata_projectors',
+	static function ( array $projectors ): array {
+		$projectors[] = static function ( array $row, array $config ): array {
+			unset( $row );
+			$brain = is_array( $config['intelligence_wiki_brain'] ?? null ) ? $config['intelligence_wiki_brain'] : array();
+			$meta  = array();
+
+			foreach ( array( 'domain', 'wiki_slug', 'source_slug', 'brain_slug', 'bundle_slug' ) as $key ) {
+				$value = trim( (string) ( $brain[ $key ] ?? '' ) );
+				if ( '' !== $value ) {
+					$meta[ 'intelligence_wiki_brain_' . $key ] = $value;
+				}
+			}
+
+			return $meta;
+		};
+
+		return $projectors;
+	},
+	10,
+	1
+);
+
 class DataMachinePersistedAgentProjectorFakeRepository extends Agents {
 	/** @var array<int,array<string,mixed>> */
 	private array $rows;
@@ -103,12 +140,12 @@ $roadie_agent = wp_get_agent( 'roadie' );
 agents_api_smoke_assert_equals( array( 'wordpress-com-wiki', 'woocommerce-wiki', 'roadie' ), array_keys( $agents ), 'persisted rows are visible through wp_get_agents()', $failures, $passes );
 agents_api_smoke_assert_equals( true, $agent instanceof WP_Agent, 'persisted row resolves through wp_get_agent()', $failures, $passes );
 agents_api_smoke_assert_equals( 'WordPress.com Wiki', $agent ? $agent->get_label() : '', 'row agent_name becomes label', $failures, $passes );
-agents_api_smoke_assert_equals( 'Maintains the WordPress.com wiki brain.', $agent ? $agent->get_description() : '', 'wiki brain description is surfaced', $failures, $passes );
+agents_api_smoke_assert_equals( 'Maintains the WordPress.com wiki brain.', $agent ? $agent->get_description() : '', 'extension description source is surfaced', $failures, $passes );
 agents_api_smoke_assert_equals( '', $roadie_agent ? $roadie_agent->get_description() : 'missing', 'missing config description stays empty instead of synthesizing a runtime-branded fallback', $failures, $passes );
 agents_api_smoke_assert_equals( 7, $agent && is_callable( $agent->get_owner_resolver() ) ? call_user_func( $agent->get_owner_resolver() ) : 0, 'owner_resolver returns persisted owner_id', $failures, $passes );
 agents_api_smoke_assert_equals( 'gpt-5.5', $agent ? $agent->get_default_config()['default_model'] ?? '' : '', 'agent_config becomes default_config', $failures, $passes );
 agents_api_smoke_assert_equals( 'wordpress-com-wiki', $agent ? $agent->get_meta()['source_package'] ?? '' : '', 'bundle slug is exposed as source package', $failures, $passes );
-agents_api_smoke_assert_equals( 'wordpress-com', $agent ? $agent->get_meta()['intelligence_wiki_brain_wiki_slug'] ?? '' : '', 'wiki brain hint is exposed in metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'wordpress-com', $agent ? $agent->get_meta()['intelligence_wiki_brain_wiki_slug'] ?? '' : '', 'extension metadata projector is exposed', $failures, $passes );
 
 echo "\n[2] persisted projection preserves earlier declarative registrations:\n";
 datamachine_persisted_agent_registry_reset();

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -483,6 +483,57 @@ $runtime_tools = resolve_source_tools(
 );
 assert_source_equals( false, isset( $runtime_tools['client/select_block'] ), 'runtime tool is denied by default because it requires allow_only opt-in', $failures, $passes );
 
+$ambient_context_tools = resolve_source_tools(
+	ToolPolicyResolver::MODE_CHAT,
+	new SourcePolicyToolManager(),
+	array(
+		'allow_only'     => array( 'client/ambient_tool' ),
+		'client_context' => array(
+			'tool_declarations' => array(
+				'client/ambient_tool' => array(
+					'description' => 'Ambient runtime declaration that core should not read.',
+					'parameters'  => array( 'type' => 'object' ),
+					'executor'    => 'client',
+				),
+			),
+		),
+	)
+);
+assert_source_equals( false, isset( $ambient_context_tools['client/ambient_tool'] ), 'runtime source ignores arbitrary client_context tool_declarations', $failures, $passes );
+
+add_filter(
+	'datamachine_runtime_tool_declaration_sets',
+	static function ( array $sets, array $args, array $client_context ): array {
+		unset( $args );
+		if ( is_array( $client_context['tool_declarations'] ?? null ) ) {
+			$sets[] = $client_context['tool_declarations'];
+		}
+		return $sets;
+	},
+	10,
+	3
+);
+$adapter_context_tools = resolve_source_tools(
+	ToolPolicyResolver::MODE_CHAT,
+	new SourcePolicyToolManager(),
+	array(
+		'allow_only'     => array( 'client/ambient_tool' ),
+		'client_context' => array(
+			'tool_declarations' => array(
+				'client/ambient_tool' => array(
+					'description' => 'Adapter-owned runtime declaration.',
+					'parameters'  => array( 'type' => 'object' ),
+					'executor'    => 'client',
+					'scope'       => 'run',
+				),
+			),
+		),
+	)
+);
+assert_source_equals( true, isset( $adapter_context_tools['client/ambient_tool'] ), 'runtime declaration filter lets adapters opt in context-specific shapes', $failures, $passes );
+remove_all_filters_for_source_smoke();
+$GLOBALS['__datamachine_log_entries'] = array();
+
 $runtime_policy_tools = resolve_source_tools(
 	ToolPolicyResolver::MODE_CHAT,
 	new SourcePolicyToolManager(),


### PR DESCRIPTION
## Summary
- Replaces hard-coded Intelligence wiki-brain persisted-agent projection with generic description/meta projector filters while keeping Data Machine bundle metadata in core.
- Narrows client-context directive registration to chat by default and exposes filters for mode registration, intro text, editor guidance, and rendered outputs.
- Adds explicit runtime/provider extension seams: runtime tool declaration-set adapters, provider tool-name filters, and a generic AI request dispatch adapter before the default wp-ai-client path.

## Tests
- php -l inc/Engine/Agents/PersistedAgentProjector.php
- php -l inc/Engine/AI/Directives/ClientContextDirective.php
- php -l inc/Engine/AI/Tools/Sources/RuntimeToolSource.php
- php -l inc/Engine/AI/RequestBuilder.php
- php -l tests/agents-api-persisted-agent-registry-smoke.php
- php -l tests/tool-source-registry-smoke.php
- php tests/agents-api-persisted-agent-registry-smoke.php
- php tests/tool-source-registry-smoke.php
- php tests/request-builder-tool-transcript-smoke.php
- composer lint

## Notes / TODO
- This intentionally does not attempt a provider/runtime rewrite.
- Follow-up Agents API/runtime work can consume these extension points for full runtime adapter ownership instead of adding Data Machine-side shims.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the boundary decoupling implementation, updated smoke coverage, ran local verification, and prepared this PR for Chris to review.