### PR TITLE
Fix bundle portable boundary primitives

### DIFF
--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -11,9 +11,9 @@
 
 namespace DataMachine\Engine\Actions;
 
-use DataMachine\Abilities\Flow\QueueAbility;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\FlowStepConfigFactory;
+use DataMachine\Engine\PortableFlowStepFields;
 
 // Prevent direct access
 if ( ! defined( 'WPINC' ) ) {
@@ -509,96 +509,7 @@ class ImportExport {
 	 * Normalize portable flow-step fields for import/export.
 	 */
 	private function normalize_portable_flow_step_settings( array $source ): array {
-		$normalized = array();
-
-		foreach ( array( 'enabled_tools', 'disabled_tools' ) as $field ) {
-			if ( array_key_exists( $field, $source ) ) {
-				$normalized[ $field ] = $this->normalize_string_list_field( $field, $source[ $field ] );
-			}
-		}
-
-		if ( array_key_exists( QueueAbility::SLOT_PROMPT_QUEUE, $source ) ) {
-			$normalized[ QueueAbility::SLOT_PROMPT_QUEUE ] = $this->normalize_prompt_queue_field( $source[ QueueAbility::SLOT_PROMPT_QUEUE ] );
-		}
-
-		if ( array_key_exists( QueueAbility::SLOT_CONFIG_PATCH_QUEUE, $source ) ) {
-			$normalized[ QueueAbility::SLOT_CONFIG_PATCH_QUEUE ] = $this->normalize_config_patch_queue_field( $source[ QueueAbility::SLOT_CONFIG_PATCH_QUEUE ] );
-		}
-
-		if ( isset( $source['queue_mode'] ) && in_array( $source['queue_mode'], array( 'drain', 'loop', 'static' ), true ) ) {
-			$normalized['queue_mode'] = $source['queue_mode'];
-		}
-
-		return $normalized;
-	}
-
-	/**
-	 * Normalize a portable string-list setting.
-	 */
-	private function normalize_string_list_field( string $field, $value ): array {
-		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
-			throw new \InvalidArgumentException( sprintf( '%s must be a list of strings.', esc_html( $field ) ) );
-		}
-
-		$normalized = array();
-		foreach ( $value as $item ) {
-			if ( ! is_string( $item ) ) {
-				throw new \InvalidArgumentException( sprintf( '%s must be a list of strings.', esc_html( $field ) ) );
-			}
-			$normalized[] = $item;
-		}
-
-		return $normalized;
-	}
-
-	/**
-	 * Normalize AI prompt queue entries from portable settings.
-	 */
-	private function normalize_prompt_queue_field( $value ): array {
-		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
-			throw new \InvalidArgumentException( 'prompt_queue must be a list of objects.' );
-		}
-
-		$normalized = array();
-		foreach ( $value as $entry ) {
-			if ( ! is_array( $entry ) ) {
-				throw new \InvalidArgumentException( 'prompt_queue must be a list of objects.' );
-			}
-			if ( ! array_key_exists( QueueAbility::FIELD_PROMPT, $entry ) || ! is_string( $entry[ QueueAbility::FIELD_PROMPT ] ) ) {
-				throw new \InvalidArgumentException( 'prompt_queue entries must include a string prompt.' );
-			}
-			if ( array_key_exists( 'added_at', $entry ) && ! is_string( $entry['added_at'] ) ) {
-				throw new \InvalidArgumentException( 'prompt_queue added_at must be a string when present.' );
-			}
-			$normalized[] = $entry;
-		}
-
-		return $normalized;
-	}
-
-	/**
-	 * Normalize fetch config-patch queue entries from portable settings.
-	 */
-	private function normalize_config_patch_queue_field( $value ): array {
-		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
-			throw new \InvalidArgumentException( 'config_patch_queue must be a list of objects.' );
-		}
-
-		$normalized = array();
-		foreach ( $value as $entry ) {
-			if ( ! is_array( $entry ) ) {
-				throw new \InvalidArgumentException( 'config_patch_queue must be a list of objects.' );
-			}
-			if ( ! array_key_exists( QueueAbility::FIELD_PATCH, $entry ) || ! is_array( $entry[ QueueAbility::FIELD_PATCH ] ) ) {
-				throw new \InvalidArgumentException( 'config_patch_queue entries must include an object patch.' );
-			}
-			if ( array_key_exists( 'added_at', $entry ) && ! is_string( $entry['added_at'] ) ) {
-				throw new \InvalidArgumentException( 'config_patch_queue added_at must be a string when present.' );
-			}
-			$normalized[] = $entry;
-		}
-
-		return $normalized;
+		return PortableFlowStepFields::normalize_settings( $source );
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentBundleFlowFile.php
+++ b/inc/Engine/Bundle/AgentBundleFlowFile.php
@@ -137,6 +137,7 @@ final class AgentBundleFlowFile {
 		try {
 			return PortableFlowStepFields::normalize_field( $field, $value, 'flow file' );
 		} catch ( \InvalidArgumentException $e ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 			throw new BundleValidationException( $e->getMessage() );
 		}
 	}

--- a/inc/Engine/Bundle/AgentBundleFlowFile.php
+++ b/inc/Engine/Bundle/AgentBundleFlowFile.php
@@ -7,6 +7,8 @@
 
 namespace DataMachine\Engine\Bundle;
 
+use DataMachine\Engine\PortableFlowStepFields;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -132,123 +134,10 @@ final class AgentBundleFlowFile {
 	}
 
 	private static function normalize_optional_step_field( string $field, $value ) {
-		if ( 'step_type' === $field ) {
-			return (string) $value;
+		try {
+			return PortableFlowStepFields::normalize_field( $field, $value, 'flow file' );
+		} catch ( \InvalidArgumentException $e ) {
+			throw new BundleValidationException( $e->getMessage() );
 		}
-
-		if ( 'enabled' === $field ) {
-			return (bool) $value;
-		}
-
-		if ( 'flow_step_settings' === $field ) {
-			if ( ! is_array( $value ) ) {
-				throw new BundleValidationException( sprintf( 'flow file %s must be an object.', esc_html( $field ) ) );
-			}
-			return $value;
-		}
-
-		if ( 'completion_assertions' === $field ) {
-			if ( ! is_array( $value ) ) {
-				throw new BundleValidationException( 'flow file completion_assertions must be an object.' );
-			}
-			return $value;
-		}
-
-		if ( 'tool_runtime_rules' === $field ) {
-			if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
-				throw new BundleValidationException( 'flow file tool_runtime_rules must be a list.' );
-			}
-			return $value;
-		}
-
-		if ( in_array( $field, array( 'handler_slugs', 'enabled_tools', 'disabled_tools' ), true ) ) {
-			return self::normalize_string_list( $field, $value );
-		}
-
-		if ( 'prompt_queue' === $field ) {
-			return self::normalize_prompt_queue( $value );
-		}
-
-		if ( 'config_patch_queue' === $field ) {
-			return self::normalize_config_patch_queue( $value );
-		}
-
-		if ( 'queue_mode' === $field ) {
-			if ( ! in_array( $value, array( 'drain', 'loop', 'static' ), true ) ) {
-				throw new BundleValidationException( 'flow file queue_mode must be one of drain, loop, static.' );
-			}
-			return $value;
-		}
-
-		return $value;
-	}
-
-	/**
-	 * Normalize portable string-list fields.
-	 */
-	private static function normalize_string_list( string $field, $value ): array {
-		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
-			throw new BundleValidationException( sprintf( 'flow file %s must be a list of strings.', esc_html( $field ) ) );
-		}
-
-		$normalized = array();
-		foreach ( $value as $item ) {
-			if ( ! is_string( $item ) ) {
-				throw new BundleValidationException( sprintf( 'flow file %s must be a list of strings.', esc_html( $field ) ) );
-			}
-			$normalized[] = $item;
-		}
-
-		return $normalized;
-	}
-
-	/**
-	 * Normalize AI prompt queue seed entries.
-	 */
-	private static function normalize_prompt_queue( $value ): array {
-		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
-			throw new BundleValidationException( 'flow file prompt_queue must be a list of objects.' );
-		}
-
-		$normalized = array();
-		foreach ( $value as $entry ) {
-			if ( ! is_array( $entry ) ) {
-				throw new BundleValidationException( 'flow file prompt_queue must be a list of objects.' );
-			}
-			if ( ! array_key_exists( 'prompt', $entry ) || ! is_string( $entry['prompt'] ) ) {
-				throw new BundleValidationException( 'flow file prompt_queue entries must include a string prompt.' );
-			}
-			if ( array_key_exists( 'added_at', $entry ) && ! is_string( $entry['added_at'] ) ) {
-				throw new BundleValidationException( 'flow file prompt_queue added_at must be a string when present.' );
-			}
-			$normalized[] = $entry;
-		}
-
-		return $normalized;
-	}
-
-	/**
-	 * Normalize fetch config-patch queue seed entries.
-	 */
-	private static function normalize_config_patch_queue( $value ): array {
-		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
-			throw new BundleValidationException( 'flow file config_patch_queue must be a list of objects.' );
-		}
-
-		$normalized = array();
-		foreach ( $value as $entry ) {
-			if ( ! is_array( $entry ) ) {
-				throw new BundleValidationException( 'flow file config_patch_queue must be a list of objects.' );
-			}
-			if ( ! array_key_exists( 'patch', $entry ) || ! is_array( $entry['patch'] ) ) {
-				throw new BundleValidationException( 'flow file config_patch_queue entries must include an object patch.' );
-			}
-			if ( array_key_exists( 'added_at', $entry ) && ! is_string( $entry['added_at'] ) ) {
-				throw new BundleValidationException( 'flow file config_patch_queue added_at must be a string when present.' );
-			}
-			$normalized[] = $entry;
-		}
-
-		return $normalized;
 	}
 }

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -12,6 +12,7 @@ use DataMachine\Abilities\Engine\DrainJobAbility;
 use DataMachine\Core\Agents\AgentBundler;
 use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\JobStatus;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -206,7 +207,10 @@ final class AgentBundleRunner {
 	private function apply_runtime_ability_tools( array &$initial_data, array $input, array $bundle = array() ): void {
 		$ability_tools = is_array( $input['ability_tools'] ?? null ) ? $input['ability_tools'] : array();
 		if ( empty( $ability_tools ) ) {
-			$metadata_tools = $this->path_value( $bundle, 'metadata.codebox.agent_runtime.bundle.ability_tools' );
+			$metadata_tools = $this->path_value( $bundle, 'metadata.agent_runtime.ability_tools' );
+			if ( ! is_array( $metadata_tools ) ) {
+				$metadata_tools = $this->path_value( $bundle, 'metadata.codebox.agent_runtime.bundle.ability_tools' );
+			}
 			$ability_tools  = is_array( $metadata_tools ) ? $metadata_tools : array();
 		}
 		if ( empty( $ability_tools ) ) {
@@ -249,7 +253,15 @@ final class AgentBundleRunner {
 
 	private static function is_success_status( string $status ): bool {
 		$status = trim( $status );
-		foreach ( array( 'failed', 'completed_no_items', 'cancelled', 'timed_out', 'timeout' ) as $failure_status ) {
+		if ( JobStatus::isStatusSuccess( $status ) ) {
+			return true;
+		}
+
+		if ( JobStatus::isStatusFailure( $status ) ) {
+			return false;
+		}
+
+		foreach ( array( 'cancelled', 'timed_out', 'timeout' ) as $failure_status ) {
 			if ( $failure_status === $status || str_starts_with( $status, $failure_status . ' - ' ) ) {
 				return false;
 			}

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -211,7 +211,7 @@ final class AgentBundleRunner {
 			if ( ! is_array( $metadata_tools ) ) {
 				$metadata_tools = $this->path_value( $bundle, 'metadata.codebox.agent_runtime.bundle.ability_tools' );
 			}
-			$ability_tools  = is_array( $metadata_tools ) ? $metadata_tools : array();
+			$ability_tools = is_array( $metadata_tools ) ? $metadata_tools : array();
 		}
 		if ( empty( $ability_tools ) ) {
 			return;

--- a/inc/Engine/PortableFlowStepFields.php
+++ b/inc/Engine/PortableFlowStepFields.php
@@ -67,6 +67,7 @@ final class PortableFlowStepFields {
 
 		if ( in_array( $field, array( 'flow_step_settings', 'completion_assertions' ), true ) ) {
 			if ( ! is_array( $value ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 				throw new \InvalidArgumentException( self::message( sprintf( '%s must be an object.', $field ), $message_prefix ) );
 			}
 			return $value;
@@ -74,6 +75,7 @@ final class PortableFlowStepFields {
 
 		if ( 'tool_runtime_rules' === $field ) {
 			if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 				throw new \InvalidArgumentException( self::message( 'tool_runtime_rules must be a list.', $message_prefix ) );
 			}
 			return $value;
@@ -93,6 +95,7 @@ final class PortableFlowStepFields {
 
 		if ( 'queue_mode' === $field ) {
 			if ( ! in_array( $value, self::QUEUE_MODES, true ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 				throw new \InvalidArgumentException( self::message( 'queue_mode must be one of drain, loop, static.', $message_prefix ) );
 			}
 			return $value;
@@ -103,12 +106,14 @@ final class PortableFlowStepFields {
 
 	private static function normalize_string_list( string $field, $value, string $message_prefix ): array {
 		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 			throw new \InvalidArgumentException( self::message( sprintf( '%s must be a list of strings.', $field ), $message_prefix ) );
 		}
 
 		$normalized = array();
 		foreach ( $value as $item ) {
 			if ( ! is_string( $item ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 				throw new \InvalidArgumentException( self::message( sprintf( '%s must be a list of strings.', $field ), $message_prefix ) );
 			}
 			$normalized[] = $item;
@@ -119,18 +124,22 @@ final class PortableFlowStepFields {
 
 	private static function normalize_prompt_queue( $value, string $message_prefix ): array {
 		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 			throw new \InvalidArgumentException( self::message( 'prompt_queue must be a list of objects.', $message_prefix ) );
 		}
 
 		$normalized = array();
 		foreach ( $value as $entry ) {
 			if ( ! is_array( $entry ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 				throw new \InvalidArgumentException( self::message( 'prompt_queue must be a list of objects.', $message_prefix ) );
 			}
 			if ( ! array_key_exists( self::FIELD_PROMPT, $entry ) || ! is_string( $entry[ self::FIELD_PROMPT ] ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 				throw new \InvalidArgumentException( self::message( 'prompt_queue entries must include a string prompt.', $message_prefix ) );
 			}
 			if ( array_key_exists( 'added_at', $entry ) && ! is_string( $entry['added_at'] ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 				throw new \InvalidArgumentException( self::message( 'prompt_queue added_at must be a string when present.', $message_prefix ) );
 			}
 			$normalized[] = $entry;
@@ -141,18 +150,22 @@ final class PortableFlowStepFields {
 
 	private static function normalize_config_patch_queue( $value, string $message_prefix ): array {
 		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 			throw new \InvalidArgumentException( self::message( 'config_patch_queue must be a list of objects.', $message_prefix ) );
 		}
 
 		$normalized = array();
 		foreach ( $value as $entry ) {
 			if ( ! is_array( $entry ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 				throw new \InvalidArgumentException( self::message( 'config_patch_queue must be a list of objects.', $message_prefix ) );
 			}
 			if ( ! array_key_exists( self::FIELD_PATCH, $entry ) || ! is_array( $entry[ self::FIELD_PATCH ] ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 				throw new \InvalidArgumentException( self::message( 'config_patch_queue entries must include an object patch.', $message_prefix ) );
 			}
 			if ( array_key_exists( 'added_at', $entry ) && ! is_string( $entry['added_at'] ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is not rendered directly.
 				throw new \InvalidArgumentException( self::message( 'config_patch_queue added_at must be a string when present.', $message_prefix ) );
 			}
 			$normalized[] = $entry;

--- a/inc/Engine/PortableFlowStepFields.php
+++ b/inc/Engine/PortableFlowStepFields.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Portable flow-step field normalization primitives.
+ *
+ * @package DataMachine\Engine
+ */
+
+namespace DataMachine\Engine;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Shared normalization for portable flow-step boundary fields.
+ */
+final class PortableFlowStepFields {
+
+	public const PROMPT_QUEUE       = 'prompt_queue';
+	public const CONFIG_PATCH_QUEUE = 'config_patch_queue';
+	public const FIELD_PROMPT       = 'prompt';
+	public const FIELD_PATCH        = 'patch';
+
+	private const STRING_LIST_FIELDS = array( 'handler_slugs', 'enabled_tools', 'disabled_tools' );
+	private const QUEUE_MODES        = array( 'drain', 'loop', 'static' );
+
+	/**
+	 * Normalize optional portable flow-step settings present in a source array.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function normalize_settings( array $source, string $message_prefix = '' ): array {
+		$normalized = array();
+
+		foreach ( self::STRING_LIST_FIELDS as $field ) {
+			if ( array_key_exists( $field, $source ) ) {
+				$normalized[ $field ] = self::normalize_field( $field, $source[ $field ], $message_prefix );
+			}
+		}
+
+		if ( array_key_exists( self::PROMPT_QUEUE, $source ) ) {
+			$normalized[ self::PROMPT_QUEUE ] = self::normalize_field( self::PROMPT_QUEUE, $source[ self::PROMPT_QUEUE ], $message_prefix );
+		}
+
+		if ( array_key_exists( self::CONFIG_PATCH_QUEUE, $source ) ) {
+			$normalized[ self::CONFIG_PATCH_QUEUE ] = self::normalize_field( self::CONFIG_PATCH_QUEUE, $source[ self::CONFIG_PATCH_QUEUE ], $message_prefix );
+		}
+
+		if ( array_key_exists( 'queue_mode', $source ) && in_array( $source['queue_mode'], self::QUEUE_MODES, true ) ) {
+			$normalized['queue_mode'] = $source['queue_mode'];
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize one optional portable flow-step field.
+	 *
+	 * @return mixed
+	 */
+	public static function normalize_field( string $field, $value, string $message_prefix = '' ) {
+		if ( 'step_type' === $field ) {
+			return (string) $value;
+		}
+
+		if ( 'enabled' === $field ) {
+			return (bool) $value;
+		}
+
+		if ( in_array( $field, array( 'flow_step_settings', 'completion_assertions' ), true ) ) {
+			if ( ! is_array( $value ) ) {
+				throw new \InvalidArgumentException( self::message( sprintf( '%s must be an object.', $field ), $message_prefix ) );
+			}
+			return $value;
+		}
+
+		if ( 'tool_runtime_rules' === $field ) {
+			if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+				throw new \InvalidArgumentException( self::message( 'tool_runtime_rules must be a list.', $message_prefix ) );
+			}
+			return $value;
+		}
+
+		if ( in_array( $field, self::STRING_LIST_FIELDS, true ) ) {
+			return self::normalize_string_list( $field, $value, $message_prefix );
+		}
+
+		if ( self::PROMPT_QUEUE === $field ) {
+			return self::normalize_prompt_queue( $value, $message_prefix );
+		}
+
+		if ( self::CONFIG_PATCH_QUEUE === $field ) {
+			return self::normalize_config_patch_queue( $value, $message_prefix );
+		}
+
+		if ( 'queue_mode' === $field ) {
+			if ( ! in_array( $value, self::QUEUE_MODES, true ) ) {
+				throw new \InvalidArgumentException( self::message( 'queue_mode must be one of drain, loop, static.', $message_prefix ) );
+			}
+			return $value;
+		}
+
+		return $value;
+	}
+
+	private static function normalize_string_list( string $field, $value, string $message_prefix ): array {
+		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+			throw new \InvalidArgumentException( self::message( sprintf( '%s must be a list of strings.', $field ), $message_prefix ) );
+		}
+
+		$normalized = array();
+		foreach ( $value as $item ) {
+			if ( ! is_string( $item ) ) {
+				throw new \InvalidArgumentException( self::message( sprintf( '%s must be a list of strings.', $field ), $message_prefix ) );
+			}
+			$normalized[] = $item;
+		}
+
+		return $normalized;
+	}
+
+	private static function normalize_prompt_queue( $value, string $message_prefix ): array {
+		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+			throw new \InvalidArgumentException( self::message( 'prompt_queue must be a list of objects.', $message_prefix ) );
+		}
+
+		$normalized = array();
+		foreach ( $value as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				throw new \InvalidArgumentException( self::message( 'prompt_queue must be a list of objects.', $message_prefix ) );
+			}
+			if ( ! array_key_exists( self::FIELD_PROMPT, $entry ) || ! is_string( $entry[ self::FIELD_PROMPT ] ) ) {
+				throw new \InvalidArgumentException( self::message( 'prompt_queue entries must include a string prompt.', $message_prefix ) );
+			}
+			if ( array_key_exists( 'added_at', $entry ) && ! is_string( $entry['added_at'] ) ) {
+				throw new \InvalidArgumentException( self::message( 'prompt_queue added_at must be a string when present.', $message_prefix ) );
+			}
+			$normalized[] = $entry;
+		}
+
+		return $normalized;
+	}
+
+	private static function normalize_config_patch_queue( $value, string $message_prefix ): array {
+		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+			throw new \InvalidArgumentException( self::message( 'config_patch_queue must be a list of objects.', $message_prefix ) );
+		}
+
+		$normalized = array();
+		foreach ( $value as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				throw new \InvalidArgumentException( self::message( 'config_patch_queue must be a list of objects.', $message_prefix ) );
+			}
+			if ( ! array_key_exists( self::FIELD_PATCH, $entry ) || ! is_array( $entry[ self::FIELD_PATCH ] ) ) {
+				throw new \InvalidArgumentException( self::message( 'config_patch_queue entries must include an object patch.', $message_prefix ) );
+			}
+			if ( array_key_exists( 'added_at', $entry ) && ! is_string( $entry['added_at'] ) ) {
+				throw new \InvalidArgumentException( self::message( 'config_patch_queue added_at must be a string when present.', $message_prefix ) );
+			}
+			$normalized[] = $entry;
+		}
+
+		return $normalized;
+	}
+
+	private static function message( string $message, string $prefix ): string {
+		$prefix = trim( $prefix );
+		return '' === $prefix ? $message : $prefix . ' ' . $message;
+	}
+}

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -104,6 +104,7 @@ datamachine_bundle_runner_contains( $abilities, "'engine_data_outputs'", 'abilit
 datamachine_bundle_runner_contains( $ai_step, "\$payload['tool_recorders']", 'AI step forwards configured tool recorders to the loop', $failures, $passes );
 
 echo "\n[3] Runner exposes semantic outputs without hiding raw engine data\n";
+require_once $root . '/inc/Core/JobStatus.php';
 require_once $root . '/inc/Engine/Bundle/AgentBundleRunner.php';
 require_once $root . '/inc/Abilities/Flow/FlowHelpers.php';
 require_once $root . '/inc/Abilities/Flow/QueueAbility.php';
@@ -175,8 +176,57 @@ $success_status = $runner_reflection->getMethod( 'is_success_status' );
 datamachine_bundle_runner_assert( false === $success_status->invoke( null, 'failed - ai_response_without_tool_result' ), 'failed-prefixed status is terminal failure', $failures, $passes );
 datamachine_bundle_runner_assert( false === $success_status->invoke( null, 'cancelled - operator aborted' ), 'cancelled-prefixed status is terminal failure', $failures, $passes );
 datamachine_bundle_runner_assert( true === $success_status->invoke( null, 'completed' ), 'completed status remains successful', $failures, $passes );
+datamachine_bundle_runner_assert( true === $success_status->invoke( null, 'completed_no_items' ), 'completed_no_items follows JobStatus success semantics', $failures, $passes );
+datamachine_bundle_runner_assert( true === $success_status->invoke( null, 'agent_skipped - no matching source items' ), 'agent_skipped-prefixed status follows JobStatus success semantics', $failures, $passes );
 
-echo "\n[3b] Successful tool results can be recorded into engine data\n";
+echo "\n[3b] Runtime ability tools prefer generic metadata\n";
+$apply_runtime_ability_tools = $runner_reflection->getMethod( 'apply_runtime_ability_tools' );
+$initial_data                = array();
+$apply_runtime_ability_tools->invokeArgs(
+	$runner_instance,
+	array(
+		&$initial_data,
+		array(),
+		array(
+			'metadata' => array(
+				'agent_runtime' => array(
+					'ability_tools' => array( array( 'name' => 'datamachine/generic-tool' ) ),
+				),
+				'codebox'       => array(
+					'agent_runtime' => array(
+						'bundle' => array(
+							'ability_tools' => array( array( 'name' => 'datamachine/codebox-tool' ) ),
+						),
+					),
+				),
+			),
+		)
+	)
+);
+datamachine_bundle_runner_assert( 'datamachine/generic-tool' === ( $initial_data['job']['ability_tools'][0]['name'] ?? null ), 'generic agent_runtime ability tools win over deprecated codebox metadata', $failures, $passes );
+
+$initial_data = array();
+$apply_runtime_ability_tools->invokeArgs(
+	$runner_instance,
+	array(
+		&$initial_data,
+		array(),
+		array(
+			'metadata' => array(
+				'codebox' => array(
+					'agent_runtime' => array(
+						'bundle' => array(
+							'ability_tools' => array( array( 'name' => 'datamachine/codebox-tool' ) ),
+						),
+					),
+				),
+			),
+		)
+	)
+);
+datamachine_bundle_runner_assert( 'datamachine/codebox-tool' === ( $initial_data['job']['ability_tools'][0]['name'] ?? null ), 'deprecated codebox ability tools remain compatible fallback', $failures, $passes );
+
+echo "\n[3c] Successful tool results can be recorded into engine data\n";
 require_once $root . '/inc/Engine/AI/conversation-loop.php';
 $GLOBALS['datamachine_bundle_runner_engine_data_merges'] = array();
 \DataMachine\Engine\AI\datamachine_record_tool_results_to_engine_data(
@@ -323,7 +373,7 @@ $recorded_direct_envelope_merge = $GLOBALS['datamachine_bundle_runner_engine_dat
 datamachine_bundle_runner_assert( 522 === ( $recorded_direct_envelope_merge['data']['design_agent']['issue_number'] ?? null ), 'tool recorder maps issue number from direct result envelope payload', $failures, $passes );
 datamachine_bundle_runner_assert( 'https://github.com/chubes4/wp-site-generator/issues/522' === ( $recorded_direct_envelope_merge['data']['design_agent']['issue_url'] ?? null ), 'tool recorder maps issue URL from direct result envelope payload', $failures, $passes );
 
-echo "\n[3b] Runner applies run-scoped flow step patches\n";
+echo "\n[3d] Runner applies run-scoped flow step patches\n";
 $workflow_from_bundle_flow = $runner_reflection->getMethod( 'workflow_from_bundle_flow' );
 $patched_workflow          = $workflow_from_bundle_flow->invoke(
 	$runner_instance,
@@ -393,7 +443,7 @@ $ephemeral_configs = DataMachine\Core\Steps\WorkflowConfigFactory::buildEphemera
 datamachine_bundle_runner_assert( 'github_pull_request_publish' === ( $ephemeral_configs['flow_config']['ephemeral_step_1']['tool_recorders'][0]['tool'] ?? null ), 'ephemeral flow config preserves AI tool recorders', $failures, $passes );
 datamachine_bundle_runner_assert( 'github_pull_request_publish' === ( $ephemeral_configs['pipeline_config']['ephemeral_pipeline_1']['tool_recorders'][0]['tool'] ?? null ), 'ephemeral pipeline config preserves AI tool recorders', $failures, $passes );
 
-echo "\n[3c] Runner does not treat no-item terminal states as success\n";
+echo "\n[3e] Runner treats no-item terminal states as JobStatus success\n";
 $response_method = $runner_reflection->getMethod( 'response' );
 $no_item_response = $response_method->invoke(
 	$runner_instance,
@@ -404,10 +454,10 @@ $no_item_response = $response_method->invoke(
 	array( 'wait_for_completion' => true )
 );
 datamachine_bundle_runner_assert( 'completed_no_items' === ( $no_item_response['status'] ?? null ), 'no-item terminal status is preserved', $failures, $passes );
-datamachine_bundle_runner_assert( false === ( $no_item_response['success'] ?? null ), 'no-item terminal status is not a successful bundle run', $failures, $passes );
-datamachine_bundle_runner_assert( false === ( $no_item_response['completion_outcome']['success'] ?? null ), 'no-item completion outcome is not successful', $failures, $passes );
+datamachine_bundle_runner_assert( true === ( $no_item_response['success'] ?? null ), 'no-item terminal status is a successful bundle run', $failures, $passes );
+datamachine_bundle_runner_assert( true === ( $no_item_response['completion_outcome']['success'] ?? null ), 'no-item completion outcome is successful', $failures, $passes );
 
-echo "\n[3d] Completed bundle runs enforce required semantic outputs\n";
+echo "\n[3f] Completed bundle runs enforce required semantic outputs\n";
 $missing_artifact_response = $response_method->invoke(
 	$runner_instance,
 	array(


### PR DESCRIPTION
## Summary
- Treat bundle runner success statuses through `JobStatus`, so `completed_no_items` and `agent_skipped` remain successful terminal outcomes.
- Add a shared `PortableFlowStepFields` normalizer and use it from bundle flow files plus import/export portable flow-step settings.
- Prefer generic `metadata.agent_runtime.ability_tools` for bundle runtime tools, with the existing Codebox metadata path retained as deprecated compatibility fallback.

## Tests
- `php -l inc/Engine/PortableFlowStepFields.php && php -l inc/Engine/Bundle/AgentBundleFlowFile.php && php -l inc/Engine/Actions/ImportExport.php && php -l inc/Engine/Bundle/AgentBundleRunner.php && php -l tests/agent-bundle-runner-contract-smoke.php`
- `php tests/agent-bundle-format-smoke.php`
- `php tests/agent-bundle-runner-contract-smoke.php`
- `vendor/bin/phpcs inc/Engine/PortableFlowStepFields.php inc/Engine/Bundle/AgentBundleFlowFile.php inc/Engine/Actions/ImportExport.php inc/Engine/Bundle/AgentBundleRunner.php tests/agent-bundle-runner-contract-smoke.php`
- `git diff --check`

## Known blocker
- `php tests/agent-bundle-portable-update-smoke.php` fails 5 assertions outside this PR's touched behavior: stale flow payload normalization and package CLI PendingActions/apply planning checks.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the scoped code cleanup, updated smoke assertions, and ran local verification. Chris remains responsible for review and testing.
