### PR TITLE
Normalize tool schemas consistently

### DIFF
--- a/inc/Engine/AI/ProviderRequestAssembler.php
+++ b/inc/Engine/AI/ProviderRequestAssembler.php
@@ -92,66 +92,12 @@ class ProviderRequestAssembler {
 			$structured[ $tool_name ] = array(
 				'name'           => $tool_name,
 				'description'    => $tool_config['description'] ?? '',
-				'parameters'     => self::normalizeToolParameters( $tool_config['parameters'] ?? array() ),
+				'parameters'     => ToolSchemaNormalizer::normalize( $tool_config['parameters'] ?? array() ),
 				'handler'        => $tool_config['handler'] ?? null,
 				'handler_config' => $tool_config['handler_config'] ?? array(),
 			);
 		}
 
 		return $structured;
-	}
-
-	/**
-	 * Normalize raw tool parameters to canonical JSON Schema object form.
-	 *
-	 * Tool definitions historically used a flat property map with optional
-	 * property-level `required` flags. Providers expect the canonical root schema.
-	 *
-	 * @param mixed $parameters Raw tool parameters definition.
-	 * @return array<string, mixed>
-	 */
-	private static function normalizeToolParameters( mixed $parameters ): array {
-		if ( ! is_array( $parameters ) || empty( $parameters ) ) {
-			return array(
-				'type'       => 'object',
-				'properties' => (object) array(),
-			);
-		}
-
-		if ( isset( $parameters['type'] ) || isset( $parameters['properties'] ) || isset( $parameters['required'] ) ) {
-			$parameters['type'] = $parameters['type'] ?? 'object';
-			if ( isset( $parameters['properties'] ) && is_array( $parameters['properties'] ) && empty( $parameters['properties'] ) ) {
-				$parameters['properties'] = (object) array();
-			}
-			return $parameters;
-		}
-
-		$properties = array();
-		$required   = array();
-
-		foreach ( $parameters as $name => $schema ) {
-			if ( ! is_string( $name ) || '' === $name ) {
-				continue;
-			}
-
-			$property_schema = is_array( $schema ) ? $schema : array( 'type' => 'string' );
-			if ( ! empty( $property_schema['required'] ) ) {
-				$required[] = $name;
-			}
-			unset( $property_schema['required'] );
-
-			$properties[ $name ] = $property_schema;
-		}
-
-		$normalized = array(
-			'type'       => 'object',
-			'properties' => ! empty( $properties ) ? $properties : (object) array(),
-		);
-
-		if ( ! empty( $required ) ) {
-			$normalized['required'] = $required;
-		}
-
-		return $normalized;
 	}
 }

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -258,7 +258,7 @@ class RequestBuilder {
 				$function_declarations[] = new \WordPress\AiClient\Tools\DTO\FunctionDeclaration(
 					$provider_name,
 					(string) ( $tool_config['description'] ?? '' ),
-					self::normalizeToolSchema( $tool_config['parameters'] ?? array() )
+					ToolSchemaNormalizer::normalize( $tool_config['parameters'] ?? array() )
 				);
 			}
 
@@ -1164,24 +1164,4 @@ class RequestBuilder {
 		}
 	}
 
-	/**
-	 * Return the canonical JSON Schema object for tool parameters.
-	 *
-	 * @param mixed $parameters Raw parameters definition.
-	 * @return array<string, mixed>
-	 */
-	private static function normalizeToolSchema( $parameters ): array {
-		if ( ! is_array( $parameters ) || empty( $parameters ) ) {
-			$parameters = array(
-				'type'       => 'object',
-				'properties' => array(),
-			);
-		}
-
-		if ( isset( $parameters['properties'] ) && is_array( $parameters['properties'] ) && empty( $parameters['properties'] ) ) {
-			$parameters['properties'] = (object) array();
-		}
-
-		return $parameters;
-	}
 }

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -1163,5 +1163,4 @@ class RequestBuilder {
 			return null;
 		}
 	}
-
 }

--- a/inc/Engine/AI/ToolSchemaNormalizer.php
+++ b/inc/Engine/AI/ToolSchemaNormalizer.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Canonical tool schema normalization.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalizes tool parameter declarations to provider-ready JSON Schema objects.
+ */
+class ToolSchemaNormalizer {
+
+	/**
+	 * Normalize raw tool parameters to canonical JSON Schema object form.
+	 *
+	 * Tool definitions historically used flat property maps with optional
+	 * property-level `required` flags. Providers expect a root object schema.
+	 *
+	 * @param mixed $parameters Raw tool parameters definition.
+	 * @return array<string, mixed>
+	 */
+	public static function normalize( mixed $parameters ): array {
+		if ( ! is_array( $parameters ) || empty( $parameters ) ) {
+			return self::canonicalObjectSchema( array() );
+		}
+
+		if ( isset( $parameters['type'] ) || isset( $parameters['properties'] ) || isset( $parameters['required'] ) ) {
+			$parameters['type'] = $parameters['type'] ?? 'object';
+			return self::normalizeRootSchema( $parameters );
+		}
+
+		return self::canonicalObjectSchema( $parameters );
+	}
+
+	/**
+	 * Normalize an existing root object schema.
+	 *
+	 * @param array<string, mixed> $schema Root schema.
+	 * @return array<string, mixed>
+	 */
+	private static function normalizeRootSchema( array $schema ): array {
+		$properties = $schema['properties'] ?? array();
+
+		if ( is_array( $properties ) ) {
+			$normalized_properties = self::normalizeProperties( $properties );
+			$required              = self::requiredNames( $properties );
+
+			$schema['properties'] = ! empty( $normalized_properties ) ? $normalized_properties : (object) array();
+
+			if ( ! empty( $required ) ) {
+				$schema['required'] = self::mergeRequired( $schema['required'] ?? array(), $required );
+			}
+		} elseif ( ! isset( $schema['properties'] ) ) {
+			$schema['properties'] = (object) array();
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Build a canonical object schema from a flat property map.
+	 *
+	 * @param array<mixed> $properties Raw property map.
+	 * @return array<string, mixed>
+	 */
+	private static function canonicalObjectSchema( array $properties ): array {
+		$normalized_properties = self::normalizeProperties( $properties );
+		$required              = self::requiredNames( $properties );
+
+		$schema = array(
+			'type'       => 'object',
+			'properties' => ! empty( $normalized_properties ) ? $normalized_properties : (object) array(),
+		);
+
+		if ( ! empty( $required ) ) {
+			$schema['required'] = $required;
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Normalize property schemas and remove legacy property-level required flags.
+	 *
+	 * @param array<mixed> $properties Raw property map.
+	 * @return array<string, mixed>
+	 */
+	private static function normalizeProperties( array $properties ): array {
+		$normalized = array();
+
+		foreach ( $properties as $name => $property_schema ) {
+			if ( ! is_string( $name ) || '' === $name ) {
+				continue;
+			}
+
+			$property_schema = is_array( $property_schema ) ? $property_schema : array( 'type' => 'string' );
+			unset( $property_schema['required'] );
+
+			$normalized[ $name ] = $property_schema;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Extract required property names from legacy property-level flags.
+	 *
+	 * @param array<mixed> $properties Raw property map.
+	 * @return array<int, string>
+	 */
+	private static function requiredNames( array $properties ): array {
+		$required = array();
+
+		foreach ( $properties as $name => $property_schema ) {
+			if ( ! is_string( $name ) || '' === $name || ! is_array( $property_schema ) ) {
+				continue;
+			}
+
+			if ( ! empty( $property_schema['required'] ) ) {
+				$required[] = $name;
+			}
+		}
+
+		return $required;
+	}
+
+	/**
+	 * Merge existing root required names with extracted legacy required flags.
+	 *
+	 * @param mixed              $existing Existing root required value.
+	 * @param array<int,string> $extracted Extracted required names.
+	 * @return array<int,string>
+	 */
+	private static function mergeRequired( mixed $existing, array $extracted ): array {
+		$required = array();
+
+		if ( is_array( $existing ) ) {
+			foreach ( $existing as $name ) {
+				if ( is_string( $name ) && '' !== $name ) {
+					$required[] = $name;
+				}
+			}
+		}
+
+		foreach ( $extracted as $name ) {
+			$required[] = $name;
+		}
+
+		return array_values( array_unique( $required ) );
+	}
+}

--- a/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
+++ b/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
@@ -12,6 +12,7 @@
 
 namespace DataMachine\Engine\AI\Tools\Sources;
 
+use DataMachine\Engine\AI\ToolSchemaNormalizer;
 use DataMachine\Engine\AI\Tools\ToolManager;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 use DataMachine\Core\PluginSettings;
@@ -274,7 +275,7 @@ final class AbilityToolSource {
 			'description'       => method_exists( $ability, 'get_description' ) ? (string) $ability->get_description() : '',
 			'label'             => method_exists( $ability, 'get_label' ) ? (string) $ability->get_label() : $tool_name,
 			'modes'             => array( ToolPolicyResolver::MODE_CHAT ),
-			'parameters'        => method_exists( $ability, 'get_input_schema' ) ? $ability->get_input_schema() : array(),
+			'parameters'        => ToolSchemaNormalizer::normalize( method_exists( $ability, 'get_input_schema' ) ? $ability->get_input_schema() : array() ),
 		);
 
 		foreach ( self::OVERRIDE_KEYS as $key ) {
@@ -286,6 +287,7 @@ final class AbilityToolSource {
 		if ( ! is_array( $tool['parameters'] ?? null ) ) {
 			$tool['parameters'] = array();
 		}
+		$tool['parameters'] = ToolSchemaNormalizer::normalize( $tool['parameters'] );
 
 		$tool['modes'] = ToolPolicyResolver::normalizeModes( $tool['modes'] ?? array( ToolPolicyResolver::MODE_CHAT ) );
 

--- a/tests/ability-tool-source-smoke.php
+++ b/tests/ability-tool-source-smoke.php
@@ -195,6 +195,7 @@ require_once __DIR__ . '/../inc/Engine/AI/Tools/ability-tool-projections.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineAgentToolPolicyProvider.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineMandatoryToolPolicy.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineToolAccessPolicy.php';
+require_once __DIR__ . '/../inc/Engine/AI/ToolSchemaNormalizer.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/RuntimeToolSource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php';
@@ -272,13 +273,10 @@ $ability  = new Ability_Tool_Source_Smoke_Ability(
 	'Summarize a demo payload.',
 	'demo-category',
 	array(
-		'type'       => 'object',
-		'required'   => array( 'message' ),
-		'properties' => array(
-			'message' => array(
-				'type'        => 'string',
-				'description' => 'Message to summarize.',
-			),
+		'message' => array(
+			'type'        => 'string',
+			'description' => 'Message to summarize.',
+			'required'    => true,
 		),
 	),
 	array(
@@ -388,6 +386,8 @@ assert_ability_tool_source_equals( 'Summarize Demo', $tools['summarize_demo']['l
 assert_ability_tool_source_equals( 'demo-category', $tools['summarize_demo']['ability_category'] ?? '', 'generated tool carries ability category', $failures, $passes );
 assert_ability_tool_source_equals( 'Model-facing summary override.', $tools['summarize_demo']['description'] ?? '', 'definition filter can override model-facing description', $failures, $passes );
 assert_ability_tool_source_equals( array( 'message' ), $tools['summarize_demo']['parameters']['required'] ?? array(), 'generated parameters come from ability input schema', $failures, $passes );
+assert_ability_tool_source_equals( 'object', $tools['summarize_demo']['parameters']['type'] ?? '', 'ability input schema is normalized to root object schema', $failures, $passes );
+assert_ability_tool_source_equals( false, isset( $tools['summarize_demo']['parameters']['properties']['message']['required'] ), 'ability input schema strips property-level required flag', $failures, $passes );
 assert_ability_tool_source_equals( true, $tools['summarize_demo']['annotations']['readonly'] ?? false, 'generated tool carries ability annotations', $failures, $passes );
 
 echo "\n[2] source policy handles opt-in, missing abilities, config, and modes:\n";

--- a/tests/tool-schema-normalizer-smoke.php
+++ b/tests/tool-schema-normalizer-smoke.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Smoke test for canonical AI tool schema normalization.
+ *
+ * Run with: php tests/tool-schema-normalizer-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+require_once __DIR__ . '/bootstrap-unit.php';
+
+use DataMachine\Engine\AI\ProviderRequestAssembler;
+use DataMachine\Engine\AI\ToolSchemaNormalizer;
+
+$failures = array();
+$passes   = 0;
+
+function datamachine_tool_schema_assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+echo "tool-schema-normalizer-smoke\n";
+
+$empty_schema = ToolSchemaNormalizer::normalize( array() );
+datamachine_tool_schema_assert_equals( 'object', $empty_schema['type'] ?? null, 'empty schema becomes an object schema', $failures, $passes );
+datamachine_tool_schema_assert_equals( true, is_object( $empty_schema['properties'] ?? null ), 'empty schema properties are encoded as an object', $failures, $passes );
+
+$canonical = array(
+	'type'       => 'object',
+	'required'   => array( 'message' ),
+	'properties' => array(
+		'message' => array(
+			'type'        => 'string',
+			'description' => 'Message to summarize.',
+		),
+	),
+);
+datamachine_tool_schema_assert_equals( $canonical, ToolSchemaNormalizer::normalize( $canonical ), 'canonical object schema is preserved', $failures, $passes );
+
+$flat = ToolSchemaNormalizer::normalize(
+	array(
+		'message' => array(
+			'type'        => 'string',
+			'description' => 'Message to summarize.',
+		),
+		'count'   => 'integer',
+	)
+);
+datamachine_tool_schema_assert_equals( 'object', $flat['type'] ?? null, 'flat legacy map becomes root object schema', $failures, $passes );
+datamachine_tool_schema_assert_equals(
+	array(
+		'message' => array(
+			'type'        => 'string',
+			'description' => 'Message to summarize.',
+		),
+		'count'   => array( 'type' => 'string' ),
+	),
+	$flat['properties'] ?? null,
+	'flat legacy map becomes properties map',
+	$failures,
+	$passes
+);
+
+$required = ToolSchemaNormalizer::normalize(
+	array(
+		'type'       => 'object',
+		'required'   => array( 'message' ),
+		'properties' => array(
+			'message' => array(
+				'type'     => 'string',
+				'required' => true,
+			),
+			'title'   => array(
+				'type'     => 'string',
+				'required' => true,
+			),
+		),
+	)
+);
+datamachine_tool_schema_assert_equals( array( 'message', 'title' ), $required['required'] ?? null, 'property-level required flags are hoisted and deduped', $failures, $passes );
+datamachine_tool_schema_assert_equals( false, isset( $required['properties']['title']['required'] ), 'property-level required flag is removed from property schema', $failures, $passes );
+
+$structured = ProviderRequestAssembler::restructureTools(
+	array(
+		'summarize' => array(
+			'description' => 'Summarize text.',
+			'parameters'  => array(
+				'message' => array(
+					'type'     => 'string',
+					'required' => true,
+				),
+			),
+		),
+	)
+);
+datamachine_tool_schema_assert_equals( array( 'message' ), $structured['summarize']['parameters']['required'] ?? null, 'ProviderRequestAssembler uses canonical normalizer', $failures, $passes );
+datamachine_tool_schema_assert_equals( false, isset( $structured['summarize']['parameters']['properties']['message']['required'] ), 'ProviderRequestAssembler strips legacy property required flag', $failures, $passes );
+
+echo "\nAssertions: {$passes} passed, " . count( $failures ) . ' failed, ' . ( $passes + count( $failures ) ) . " total\n";
+exit( count( $failures ) );


### PR DESCRIPTION
## Summary
- Add a canonical `ToolSchemaNormalizer` for provider-ready JSON Schema object parameters.
- Use it in provider request assembly, wp-ai-client function declarations, and ability-backed tool generation.
- Cover empty schemas, canonical schemas, legacy flat property maps, property-level required flags, and ability input schema normalization.

## Tests
- `php tests/tool-schema-normalizer-smoke.php`
- `php tests/ability-tool-source-smoke.php`
- `php tests/request-builder-tool-transcript-smoke.php`
- `php -l inc/Engine/AI/ToolSchemaNormalizer.php && php -l inc/Engine/AI/ProviderRequestAssembler.php && php -l inc/Engine/AI/RequestBuilder.php && php -l inc/Engine/AI/Tools/Sources/AbilityToolSource.php && php -l tests/tool-schema-normalizer-smoke.php && php -l tests/ability-tool-source-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/ToolSchemaNormalizer.php inc/Engine/AI/ProviderRequestAssembler.php inc/Engine/AI/RequestBuilder.php inc/Engine/AI/Tools/Sources/AbilityToolSource.php tests/tool-schema-normalizer-smoke.php tests/ability-tool-source-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the shared normalizer, updated call sites, added smoke coverage, and ran verification; Chris remains responsible for review and merge.