### PR TITLE
Centralize consumed queue entry primitives

### DIFF
--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -367,32 +367,13 @@ class RunFlowAbility {
 	 * @return array{flow_step_id:string,queue_mode:string,reason:string}|null
 	 */
 	private function getEmptyDrainQueueSkip( array $flow_config ): ?array {
-		try {
-			$first_flow_step_id = ExecutionPlan::from_flow_config( $flow_config )->first_step_id();
-		} catch ( \InvalidArgumentException $e ) {
-			return null;
-		}
-
-		if ( ! $first_flow_step_id || ! isset( $flow_config[ $first_flow_step_id ] ) || ! is_array( $flow_config[ $first_flow_step_id ] ) ) {
-			return null;
-		}
-
-		$first_step = $flow_config[ $first_flow_step_id ];
-		if ( 'fetch' !== (string) ( $first_step['step_type'] ?? '' ) ) {
-			return null;
-		}
-
-		if ( 'drain' !== (string) ( $first_step['queue_mode'] ?? 'static' ) ) {
-			return null;
-		}
-
-		$queue = $first_step[ QueueAbility::SLOT_CONFIG_PATCH_QUEUE ] ?? array();
-		if ( is_array( $queue ) && ! empty( $queue ) ) {
+		$availability = QueueAbility::firstDrainQueueWorkAvailability( $flow_config );
+		if ( null === $availability || true === $availability['has_work'] ) {
 			return null;
 		}
 
 		return array(
-			'flow_step_id' => (string) $first_flow_step_id,
+			'flow_step_id' => $availability['flow_step_id'],
 			'queue_mode'   => 'drain',
 			'reason'       => 'empty_drain_queue',
 		);

--- a/inc/Abilities/Flow/QueueAbility.php
+++ b/inc/Abilities/Flow/QueueAbility.php
@@ -36,6 +36,7 @@ use DataMachine\Core\Database\Flows\Flows as DB_Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines as DB_Pipelines;
 use DataMachine\Abilities\DuplicateCheck\DuplicateCheckAbility;
 use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Engine\ExecutionPlan;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -1655,6 +1656,203 @@ class QueueAbility {
 				'queue_mode' => $queue_mode,
 			)
 		);
+
+		return null;
+	}
+
+	/**
+	 * Build an engine_data backup for a queue entry consumed from flow config.
+	 *
+	 * Only drain-mode consumes need restoration. Loop mode has already rotated the
+	 * consumed entry back to the tail, and static mode never mutates storage.
+	 *
+	 * @param int    $flow_id      Flow ID.
+	 * @param string $flow_step_id Flow step ID.
+	 * @param string $slot         Queue slot name.
+	 * @param string $queue_mode   Queue consumption mode.
+	 * @param array  $entry        Consumed queue entry.
+	 * @return array|null Backup payload, or null when no restoration is needed.
+	 */
+	public static function createConsumedEntryBackup(
+		int $flow_id,
+		string $flow_step_id,
+		string $slot,
+		string $queue_mode,
+		array $entry
+	): ?array {
+		if ( 'drain' !== $queue_mode ) {
+			return null;
+		}
+
+		$backup = array(
+			'slot'         => $slot,
+			'mode'         => $queue_mode,
+			'flow_id'      => $flow_id,
+			'flow_step_id' => $flow_step_id,
+			'added_at'     => $entry['added_at'] ?? null,
+		);
+
+		if ( self::SLOT_CONFIG_PATCH_QUEUE === $slot && isset( $entry['patch'] ) && is_array( $entry['patch'] ) ) {
+			$backup['patch'] = $entry['patch'];
+		} elseif ( self::SLOT_PROMPT_QUEUE === $slot && isset( $entry['prompt'] ) ) {
+			$backup['prompt'] = $entry['prompt'];
+		} else {
+			return null;
+		}
+
+		return $backup;
+	}
+
+	/**
+	 * Restore a consumed queue-entry backup to a persisted flow config.
+	 *
+	 * @param int           $flow_id  Flow ID.
+	 * @param array         $backup   Backup payload from job engine_data.
+	 * @param DB_Flows|null $db_flows Optional database instance.
+	 * @return bool Whether an entry was restored.
+	 */
+	public static function restoreConsumedEntryBackup(
+		int $flow_id,
+		array $backup,
+		?DB_Flows $db_flows = null
+	): bool {
+		if ( null === $db_flows ) {
+			$db_flows = new DB_Flows();
+		}
+
+		$flow = $db_flows->get_flow( $flow_id );
+		if ( ! $flow || ! isset( $flow['flow_config'] ) || ! is_array( $flow['flow_config'] ) ) {
+			return false;
+		}
+
+		$flow_config = $flow['flow_config'];
+		if ( ! self::restoreConsumedEntryBackupToFlowConfig( $flow_config, $backup ) ) {
+			return false;
+		}
+
+		return (bool) $db_flows->update_flow( $flow_id, array( 'flow_config' => $flow_config ) );
+	}
+
+	/**
+	 * Apply consumed queue-entry backup restoration to an in-memory flow config.
+	 *
+	 * @param array $flow_config Flow config to mutate when restoration is needed.
+	 * @param array $backup      Backup payload from job engine_data.
+	 * @return bool Whether an entry was appended.
+	 */
+	public static function restoreConsumedEntryBackupToFlowConfig(
+		array &$flow_config,
+		array $backup
+	): bool {
+		if ( 'drain' !== ( $backup['mode'] ?? 'drain' ) || empty( $backup['flow_step_id'] ) ) {
+			return false;
+		}
+
+		$step_id = (string) $backup['flow_step_id'];
+		if ( ! isset( $flow_config[ $step_id ] ) || ! is_array( $flow_config[ $step_id ] ) ) {
+			return false;
+		}
+
+		$slot  = $backup['slot'] ?? self::SLOT_PROMPT_QUEUE;
+		$entry = null;
+
+		if ( self::SLOT_CONFIG_PATCH_QUEUE === $slot && isset( $backup['patch'] ) && is_array( $backup['patch'] ) ) {
+			$entry = array(
+				'patch'    => $backup['patch'],
+				'added_at' => $backup['added_at'] ?? gmdate( 'c' ),
+			);
+		} elseif ( isset( $backup['prompt'] ) ) {
+			$slot  = self::SLOT_PROMPT_QUEUE;
+			$entry = array(
+				'prompt'   => $backup['prompt'],
+				'added_at' => $backup['added_at'] ?? gmdate( 'c' ),
+			);
+		}
+
+		if ( null === $entry ) {
+			return false;
+		}
+
+		if ( ! isset( $flow_config[ $step_id ][ $slot ] ) || ! is_array( $flow_config[ $step_id ][ $slot ] ) ) {
+			$flow_config[ $step_id ][ $slot ] = array();
+		}
+
+		$flow_config[ $step_id ][ $slot ][] = $entry;
+
+		return true;
+	}
+
+	/**
+	 * Return first-step drain queue work availability for a flow config.
+	 *
+	 * @param mixed $flow_config_json Raw flow config JSON or decoded array.
+	 * @return array{flow_step_id:string,queue_mode:string,slot:string,has_work:bool,reason:string}|null
+	 */
+	public static function firstDrainQueueWorkAvailability( mixed $flow_config_json ): ?array {
+		$flow_config = is_array( $flow_config_json ) ? $flow_config_json : json_decode( (string) $flow_config_json, true );
+		if ( ! is_array( $flow_config ) ) {
+			return null;
+		}
+
+		try {
+			$first_flow_step_id = ExecutionPlan::from_flow_config( $flow_config )->first_step_id();
+		} catch ( \InvalidArgumentException $e ) {
+			return null;
+		}
+
+		if ( ! $first_flow_step_id || ! isset( $flow_config[ $first_flow_step_id ] ) || ! is_array( $flow_config[ $first_flow_step_id ] ) ) {
+			return null;
+		}
+
+		$first_step = $flow_config[ $first_flow_step_id ];
+		if ( 'drain' !== (string) ( $first_step['queue_mode'] ?? 'static' ) ) {
+			return null;
+		}
+
+		$slot = self::queueSlotForStepConfig( $first_step );
+		if ( null === $slot ) {
+			return null;
+		}
+
+		$queue = $first_step[ $slot ] ?? array();
+		return array(
+			'flow_step_id' => (string) $first_flow_step_id,
+			'queue_mode'   => 'drain',
+			'slot'         => $slot,
+			'has_work'     => is_array( $queue ) && ! empty( $queue ),
+			'reason'       => 'empty_drain_queue',
+		);
+	}
+
+	/**
+	 * Determine whether the first drain-mode queue has queued work now.
+	 *
+	 * @param mixed $flow_config_json Raw flow config JSON or decoded array.
+	 * @return bool True when queued work should bypass suppression.
+	 */
+	public static function firstDrainQueueHasWork( mixed $flow_config_json ): bool {
+		$availability = self::firstDrainQueueWorkAvailability( $flow_config_json );
+		return true === ( $availability['has_work'] ?? false );
+	}
+
+	/**
+	 * Resolve the queue slot a step config consumes from.
+	 *
+	 * @param array $step_config Flow step config.
+	 * @return string|null Queue slot name.
+	 */
+	private static function queueSlotForStepConfig( array $step_config ): ?string {
+		if ( 'fetch' === (string) ( $step_config['step_type'] ?? '' ) ) {
+			return self::SLOT_CONFIG_PATCH_QUEUE;
+		}
+
+		if ( array_key_exists( self::SLOT_PROMPT_QUEUE, $step_config ) ) {
+			return self::SLOT_PROMPT_QUEUE;
+		}
+
+		if ( array_key_exists( self::SLOT_CONFIG_PATCH_QUEUE, $step_config ) ) {
+			return self::SLOT_CONFIG_PATCH_QUEUE;
+		}
 
 		return null;
 	}

--- a/inc/Abilities/Job/JobHelpers.php
+++ b/inc/Abilities/Job/JobHelpers.php
@@ -209,17 +209,7 @@ trait JobHelpers {
 	 * @return bool Whether the backup was restored to the flow config.
 	 */
 	protected function restoreQueuedPromptBackup( int $flow_id, array $backup ): bool {
-		$flow = $this->db_flows->get_flow( $flow_id );
-		if ( ! $flow || ! isset( $flow['flow_config'] ) || ! is_array( $flow['flow_config'] ) ) {
-			return false;
-		}
-
-		$flow_config = $flow['flow_config'];
-		if ( ! $this->restoreQueuedPromptBackupToFlowConfig( $flow_config, $backup ) ) {
-			return false;
-		}
-
-		return (bool) $this->db_flows->update_flow( $flow_id, array( 'flow_config' => $flow_config ) );
+		return QueueAbility::restoreConsumedEntryBackup( $flow_id, $backup, $this->db_flows );
 	}
 
 	/**
@@ -230,43 +220,7 @@ trait JobHelpers {
 	 * @return bool Whether an entry was appended.
 	 */
 	protected function restoreQueuedPromptBackupToFlowConfig( array &$flow_config, array $backup ): bool {
-		$mode = $backup['mode'] ?? 'drain';
-		if ( 'drain' !== $mode || empty( $backup['flow_step_id'] ) ) {
-			return false;
-		}
-
-		$step_id = $backup['flow_step_id'];
-		if ( ! isset( $flow_config[ $step_id ] ) || ! is_array( $flow_config[ $step_id ] ) ) {
-			return false;
-		}
-
-		$slot  = $backup['slot'] ?? QueueAbility::SLOT_PROMPT_QUEUE;
-		$entry = null;
-
-		if ( QueueAbility::SLOT_CONFIG_PATCH_QUEUE === $slot && isset( $backup['patch'] ) && is_array( $backup['patch'] ) ) {
-			$entry = array(
-				'patch'    => $backup['patch'],
-				'added_at' => $backup['added_at'] ?? gmdate( 'c' ),
-			);
-		} elseif ( isset( $backup['prompt'] ) ) {
-			$slot  = QueueAbility::SLOT_PROMPT_QUEUE;
-			$entry = array(
-				'prompt'   => $backup['prompt'],
-				'added_at' => $backup['added_at'] ?? gmdate( 'c' ),
-			);
-		}
-
-		if ( null === $entry ) {
-			return false;
-		}
-
-		if ( ! isset( $flow_config[ $step_id ][ $slot ] ) || ! is_array( $flow_config[ $step_id ][ $slot ] ) ) {
-			$flow_config[ $step_id ][ $slot ] = array();
-		}
-
-		$flow_config[ $step_id ][ $slot ][] = $entry;
-
-		return true;
+		return QueueAbility::restoreConsumedEntryBackupToFlowConfig( $flow_config, $backup );
 	}
 
 	/**

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -4,7 +4,6 @@ namespace DataMachine\Core\Database\Flows;
 
 use DataMachine\Abilities\Flow\QueueAbility;
 use DataMachine\Core\Database\BaseRepository;
-use DataMachine\Engine\ExecutionPlan;
 
 /**
  * Flows Database Class
@@ -1174,32 +1173,7 @@ class Flows extends BaseRepository {
 	 * @return bool True when new queued work should bypass suppression.
 	 */
 	private static function first_drain_queue_has_work( mixed $flow_config_json ): bool {
-		$flow_config = is_array( $flow_config_json ) ? $flow_config_json : json_decode( (string) $flow_config_json, true );
-		if ( ! is_array( $flow_config ) ) {
-			return false;
-		}
-
-		try {
-			$first_flow_step_id = ExecutionPlan::from_flow_config( $flow_config )->first_step_id();
-		} catch ( \InvalidArgumentException $e ) {
-			return false;
-		}
-
-		if ( ! $first_flow_step_id || ! isset( $flow_config[ $first_flow_step_id ] ) || ! is_array( $flow_config[ $first_flow_step_id ] ) ) {
-			return false;
-		}
-
-		$first_step = $flow_config[ $first_flow_step_id ];
-		if ( 'fetch' !== (string) ( $first_step['step_type'] ?? '' ) ) {
-			return false;
-		}
-
-		if ( 'drain' !== (string) ( $first_step['queue_mode'] ?? 'static' ) ) {
-			return false;
-		}
-
-		$queue = $first_step[ QueueAbility::SLOT_CONFIG_PATCH_QUEUE ] ?? array();
-		return is_array( $queue ) && ! empty( $queue );
+		return QueueAbility::firstDrainQueueHasWork( $flow_config_json );
 	}
 
 	/**

--- a/inc/Core/Steps/QueueableTrait.php
+++ b/inc/Core/Steps/QueueableTrait.php
@@ -230,25 +230,18 @@ trait QueueableTrait {
 			)
 		);
 
-		// Store backup of the popped prompt in engine data for retry on
-		// failure. Static mode never mutates so no rollback is needed —
-		// re-running the static tick re-peeks the same entry naturally.
-		if ( 'static' !== $queue_mode
-			&& property_exists( $this, 'job_id' )
-			&& ! empty( $this->job_id )
-		) {
+		// Store backup of drain-mode consumed entries for retry/failure restore.
+		$backup = QueueAbility::createConsumedEntryBackup(
+			(int) $flow_id,
+			$this->flow_step_id,
+			QueueAbility::SLOT_PROMPT_QUEUE,
+			$queue_mode,
+			$entry
+		);
+		if ( null !== $backup && property_exists( $this, 'job_id' ) && ! empty( $this->job_id ) ) {
 			\datamachine_merge_engine_data(
 				$this->job_id,
-				array(
-					'queued_prompt_backup' => array(
-						'slot'         => QueueAbility::SLOT_PROMPT_QUEUE,
-						'mode'         => $queue_mode,
-						'prompt'       => $entry['prompt'],
-						'flow_id'      => (int) $flow_id,
-						'flow_step_id' => $this->flow_step_id,
-						'added_at'     => $entry['added_at'] ?? null,
-					),
-				)
+				array( 'queued_prompt_backup' => $backup )
 			);
 		}
 
@@ -298,22 +291,17 @@ trait QueueableTrait {
 			)
 		);
 
-		if ( 'static' !== $queue_mode
-			&& property_exists( $this, 'job_id' )
-			&& ! empty( $this->job_id )
-		) {
+		$backup = QueueAbility::createConsumedEntryBackup(
+			(int) $flow_id,
+			$this->flow_step_id,
+			QueueAbility::SLOT_CONFIG_PATCH_QUEUE,
+			$queue_mode,
+			$entry
+		);
+		if ( null !== $backup && property_exists( $this, 'job_id' ) && ! empty( $this->job_id ) ) {
 			\datamachine_merge_engine_data(
 				$this->job_id,
-				array(
-					'queued_prompt_backup' => array(
-						'slot'         => QueueAbility::SLOT_CONFIG_PATCH_QUEUE,
-						'mode'         => $queue_mode,
-						'patch'        => $entry['patch'],
-						'flow_id'      => (int) $flow_id,
-						'flow_step_id' => $this->flow_step_id,
-						'added_at'     => $entry['added_at'] ?? null,
-					),
-				)
+				array( 'queued_prompt_backup' => $backup )
 			);
 		}
 

--- a/inc/Engine/Actions/Handlers/FailJobHandler.php
+++ b/inc/Engine/Actions/Handlers/FailJobHandler.php
@@ -8,6 +8,7 @@
 
 namespace DataMachine\Engine\Actions\Handlers;
 
+use DataMachine\Abilities\Flow\QueueAbility;
 use DataMachine\Core\JobRetryPolicy;
 
 /**
@@ -73,45 +74,37 @@ class FailJobHandler {
 
 		$success = $db_jobs->complete_job( $job_id, $status->toString() );
 
-		// Re-queue logic: If a queued prompt was popped but the job failed, add it back.
+		// Restore a drain-mode queue entry if the job failed after consuming it.
 		$engine_data = \datamachine_get_engine_data( $job_id );
 		if ( isset( $engine_data['queued_prompt_backup'] ) && is_array( $engine_data['queued_prompt_backup'] ) ) {
 			$backup = $engine_data['queued_prompt_backup'];
-			if ( ! empty( $backup['prompt'] ) && ! empty( $backup['flow_id'] ) && ! empty( $backup['flow_step_id'] ) ) {
-				$queue_ability = new \DataMachine\Abilities\Flow\QueueAbility();
-				$result        = $queue_ability->executeQueueAdd(
-					array(
-						'flow_id'      => (int) $backup['flow_id'],
-						'flow_step_id' => (string) $backup['flow_step_id'],
-						'prompt'       => $backup['prompt'],
-					)
-				);
+			if ( ! empty( $backup['flow_id'] ) && ! empty( $backup['flow_step_id'] ) ) {
+				$restored = QueueAbility::restoreConsumedEntryBackup( (int) $backup['flow_id'], $backup );
 
-				if ( ! empty( $result['success'] ) ) {
+				if ( $restored ) {
 					unset( $engine_data['queued_prompt_backup'] );
 					\datamachine_set_engine_data( $job_id, $engine_data );
 					do_action(
 						'datamachine_log',
 						'info',
-						'Prompt re-queued to back due to job failure',
+						'Queue entry restored due to job failure',
 						array(
 							'job_id'       => $job_id,
 							'flow_id'      => (int) $backup['flow_id'],
 							'flow_step_id' => (string) $backup['flow_step_id'],
-							'prompt'       => $backup['prompt'],
+							'slot'         => (string) ( $backup['slot'] ?? QueueAbility::SLOT_PROMPT_QUEUE ),
 						)
 					);
 				} else {
 					do_action(
 						'datamachine_log',
 						'error',
-						'Failed to re-queue prompt after job failure - backup retained in engine_data',
+						'Failed to restore queue entry after job failure - backup retained in engine_data',
 						array(
 							'job_id'       => $job_id,
 							'flow_id'      => (int) $backup['flow_id'],
 							'flow_step_id' => (string) $backup['flow_step_id'],
-							'prompt'       => $backup['prompt'],
-							'queue_error'  => $result['error'] ?? 'unknown',
+							'slot'         => (string) ( $backup['slot'] ?? QueueAbility::SLOT_PROMPT_QUEUE ),
 						)
 					);
 				}

--- a/tests/empty-drain-suppression-smoke.php
+++ b/tests/empty-drain-suppression-smoke.php
@@ -7,6 +7,18 @@
  * @package DataMachine\Tests
  */
 
+if ( ! defined( 'WPINC' ) ) {
+	define( 'WPINC', 'wp-includes' );
+}
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', '/tmp/' );
+}
+
+require_once __DIR__ . '/../inc/Engine/ExecutionPlan.php';
+require_once __DIR__ . '/../inc/Abilities/Flow/FlowHelpers.php';
+require_once __DIR__ . '/../inc/Abilities/Flow/QueueAbility.php';
+
 $files = array(
 	'flows'     => __DIR__ . '/../inc/Core/Database/Flows/Flows.php',
 	'formatter' => __DIR__ . '/../inc/Core/Admin/FlowFormatter.php',
@@ -37,8 +49,35 @@ function assert_empty_drain_suppression_contains( string $needle, string $haysta
 assert_empty_drain_suppression_contains( 'datamachine_last_suppressed_run', $sources['flows'], 'flow readiness reads suppression marker' );
 assert_empty_drain_suppression_contains( 'first_drain_queue_has_work', $sources['flows'], 'flow readiness bypasses suppression when new queue work exists' );
 assert_empty_drain_suppression_contains( 'latest_mysql_datetime( $last_run_at, $suppressed_run[\'suppressed_at\'] )', $sources['flows'], 'suppressed tick participates in due-time calculation' );
-assert_empty_drain_suppression_contains( 'QueueAbility::SLOT_CONFIG_PATCH_QUEUE', $sources['flows'], 'flow readiness checks the generic queue slot' );
+assert_empty_drain_suppression_contains( 'QueueAbility::firstDrainQueueHasWork', $sources['flows'], 'flow readiness uses central queue work primitive' );
 assert_empty_drain_suppression_contains( 'last_suppressed_run', $sources['formatter'], 'formatted flow status exposes suppression details' );
 assert_empty_drain_suppression_contains( "\$row['status'] = 'suppressed';", $sources['cycle'], 'cycle command reports suppressed empty-drain flows clearly' );
+
+$availability = DataMachine\Abilities\Flow\QueueAbility::firstDrainQueueWorkAvailability(
+	array(
+		'fetch1' => array(
+			'execution_order'     => 0,
+			'step_type'           => 'fetch',
+			'queue_mode'          => 'drain',
+			'config_patch_queue'  => array(),
+		),
+	)
+);
+assert_empty_drain_suppression_true( is_array( $availability ), 'fetch drain step returns availability' );
+assert_empty_drain_suppression_true( false === $availability['has_work'], 'empty fetch drain step reports no work' );
+assert_empty_drain_suppression_true( DataMachine\Abilities\Flow\QueueAbility::SLOT_CONFIG_PATCH_QUEUE === $availability['slot'], 'fetch drain step resolves config-patch slot' );
+
+$availability = DataMachine\Abilities\Flow\QueueAbility::firstDrainQueueWorkAvailability(
+	array(
+		'ai1' => array(
+			'execution_order' => 0,
+			'step_type'       => 'ai',
+			'queue_mode'      => 'drain',
+			'prompt_queue'    => array( array( 'prompt' => 'work', 'added_at' => 't0' ) ),
+		),
+	)
+);
+assert_empty_drain_suppression_true( true === $availability['has_work'], 'prompt drain step reports queued work' );
+assert_empty_drain_suppression_true( DataMachine\Abilities\Flow\QueueAbility::SLOT_PROMPT_QUEUE === $availability['slot'], 'prompt drain step resolves prompt slot' );
 
 echo "OK ({$assertions} assertions)\n";

--- a/tests/job-queue-backup-restore-smoke.php
+++ b/tests/job-queue-backup-restore-smoke.php
@@ -7,7 +7,18 @@
  * @package DataMachine\Tests
  */
 
-require_once __DIR__ . '/bootstrap-unit.php';
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', '/tmp/' );
+}
+
+if ( ! defined( 'WPINC' ) ) {
+	define( 'WPINC', 'wp-includes' );
+}
+
+require_once __DIR__ . '/../inc/Engine/ExecutionPlan.php';
+require_once __DIR__ . '/../inc/Abilities/Flow/FlowHelpers.php';
+require_once __DIR__ . '/../inc/Abilities/Flow/QueueAbility.php';
+require_once __DIR__ . '/../inc/Abilities/Job/JobHelpers.php';
 
 $failed = 0;
 $total  = 0;
@@ -61,8 +72,11 @@ assert_job_queue_restore_smoke( 'loop config patch queue tail is still the consu
 echo "Case 2: manual retry and recover-stuck use the shared helper\n";
 $retry_src   = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RetryJobAbility.php' ) ?: '';
 $recover_src = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RecoverStuckJobsAbility.php' ) ?: '';
+$fail_src    = file_get_contents( __DIR__ . '/../inc/Engine/Actions/Handlers/FailJobHandler.php' ) ?: '';
 assert_job_queue_restore_smoke( 'manual retry calls restoreQueuedPromptBackup()', str_contains( $retry_src, 'restoreQueuedPromptBackup( $job_flow_id, $backup )' ) );
 assert_job_queue_restore_smoke( 'recover-stuck calls restoreQueuedPromptBackup()', str_contains( $recover_src, 'restoreQueuedPromptBackup( $job_flow_id, $backup )' ) );
+assert_job_queue_restore_smoke( 'fail-job uses slot-aware queue restore primitive', str_contains( $fail_src, 'QueueAbility::restoreConsumedEntryBackup' ) );
+assert_job_queue_restore_smoke( 'fail-job no longer calls prompt-only queue add', ! str_contains( $fail_src, 'executeQueueAdd' ) );
 assert_job_queue_restore_smoke( 'manual retry no longer appends queue backups inline', ! str_contains( $retry_src, '$flow_config[ $step_id ][ $slot ][] = $entry;' ) );
 assert_job_queue_restore_smoke( 'recover-stuck no longer appends queue backups inline', ! str_contains( $recover_src, '$flow_config[ $step_id ][ $slot ][] = $entry;' ) );
 
@@ -139,6 +153,27 @@ $restored    = $helper->apply(
 );
 assert_job_queue_restore_smoke( 'static prompt restore returns false', false === $restored );
 assert_job_queue_restore_smoke( 'static prompt queue is unchanged', 1 === count( $flow_config['step1']['prompt_queue'] ) );
+
+echo "Case 6: backup creation is drain-mode and slot-aware\n";
+$backup = DataMachine\Abilities\Flow\QueueAbility::createConsumedEntryBackup(
+	123,
+	'step1',
+	DataMachine\Abilities\Flow\QueueAbility::SLOT_CONFIG_PATCH_QUEUE,
+	'drain',
+	array( 'patch' => array( 'slug' => 'first' ), 'added_at' => 't0' )
+);
+assert_job_queue_restore_smoke( 'drain config patch backup is created', is_array( $backup ) );
+assert_job_queue_restore_smoke( 'drain config patch backup keeps slot', DataMachine\Abilities\Flow\QueueAbility::SLOT_CONFIG_PATCH_QUEUE === ( $backup['slot'] ?? null ) );
+assert_job_queue_restore_smoke( 'drain config patch backup keeps patch', 'first' === ( $backup['patch']['slug'] ?? null ) );
+
+$backup = DataMachine\Abilities\Flow\QueueAbility::createConsumedEntryBackup(
+	123,
+	'step1',
+	DataMachine\Abilities\Flow\QueueAbility::SLOT_PROMPT_QUEUE,
+	'loop',
+	array( 'prompt' => 'first', 'added_at' => 't0' )
+);
+assert_job_queue_restore_smoke( 'loop prompt backup is not created', null === $backup );
 
 echo "\nJob queue backup restore smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary
- Add central QueueAbility primitives for drain-mode consumed-entry backups/restoration and first-drain queue work availability.
- Use the slot-aware restoration path from fail-job, retry/recovery helpers, and queue consumers.
- Replace duplicated fetch/config-patch-only empty-drain detection with the shared work-availability primitive.

## Verification
- php tests/job-queue-backup-restore-smoke.php
- php tests/empty-drain-suppression-smoke.php
- php -l on touched PHP files

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing the scoped primitive cleanup and verification