### PR TITLE
Add reusable lifecycle state transition helper

### DIFF
--- a/inc/Core/Database/LifecycleStateTransition.php
+++ b/inc/Core/Database/LifecycleStateTransition.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Reusable lifecycle state transition helper.
+ *
+ * @package DataMachine\Core\Database
+ */
+
+namespace DataMachine\Core\Database;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Small compare-and-set primitive for table-backed lifecycle state changes.
+ */
+class LifecycleStateTransition {
+
+	/**
+	 * Update a row only while it is still in the expected state.
+	 *
+	 * The helper keeps store-specific identity columns and payload fields in the
+	 * caller while centralizing the guarded state transition shape used by claims,
+	 * leases, pending decisions, and tracked-item state machines.
+	 *
+	 * @param \wpdb  $wpdb             WordPress database instance.
+	 * @param string $table_name       Fully-qualified table name.
+	 * @param array  $identity         Equality guards that identify the lifecycle row.
+	 * @param string $state_column     Column that stores the lifecycle state.
+	 * @param string $expected_state   State required before the transition.
+	 * @param string $next_state       State to write when guards match.
+	 * @param array  $updates          Additional columns to update with the transition.
+	 * @param array  $identity_formats wpdb formats for identity guards.
+	 * @param array  $update_formats   wpdb formats for additional updates.
+	 * @return int|false Number of rows updated, or false on error.
+	 */
+	public static function compare_and_set(
+		\wpdb $wpdb,
+		string $table_name,
+		array $identity,
+		string $state_column,
+		string $expected_state,
+		string $next_state,
+		array $updates = array(),
+		array $identity_formats = array(),
+		array $update_formats = array()
+	): int|false {
+		$data          = array_merge( $updates, array( $state_column => $next_state ) );
+		$where         = array_merge( $identity, array( $state_column => $expected_state ) );
+		$data_formats  = array_merge( $update_formats, array( '%s' ) );
+		$where_formats = array_merge( $identity_formats, array( '%s' ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->update( $table_name, $data, $where, $data_formats, $where_formats );
+
+		return false === $result ? false : (int) $result;
+	}
+}

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -14,6 +14,7 @@
 namespace DataMachine\Core\Database\ProcessedItems;
 
 use DataMachine\Core\Database\BaseRepository;
+use DataMachine\Core\Database\LifecycleStateTransition;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -347,6 +348,36 @@ class ProcessedItems extends BaseRepository {
 
 		$expires_at = gmdate( 'Y-m-d H:i:s', time() + $ttl_seconds );
 
+		// If the reprocess filter let a completed row through, atomically convert
+		// that processed row into a claim. Active claims remain untouched, so a
+		// parallel fetch still loses the race.
+		$claimed_existing_processed = LifecycleStateTransition::compare_and_set(
+			$this->wpdb,
+			$this->table_name,
+			array(
+				'flow_step_id'    => $flow_step_id,
+				'source_type'     => $source_type,
+				'item_identifier' => $item_identifier,
+			),
+			'status',
+			self::STATUS_PROCESSED,
+			self::STATUS_CLAIMED,
+			array(
+				'job_id'           => $job_id,
+				'claim_expires_at' => $expires_at,
+			),
+			array( '%s', '%s', '%s' ),
+			array( '%d', '%s' )
+		);
+
+		if ( false !== $claimed_existing_processed && $claimed_existing_processed > 0 ) {
+			return true;
+		}
+
+		if ( $this->has_active_claim( $flow_step_id, $source_type, $item_identifier ) ) {
+			return false;
+		}
+
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$result = $this->wpdb->insert(
 			$this->table_name,
@@ -365,27 +396,7 @@ class ProcessedItems extends BaseRepository {
 			return true;
 		}
 
-		// If the reprocess filter let a completed row through, atomically convert
-		// that processed row into a claim. Active claims remain untouched, so a
-		// parallel fetch still loses the race.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with %i table placeholder.
-		$claimed_existing_processed = $this->wpdb->query(
-			$this->wpdb->prepare(
-				'UPDATE %i SET job_id = %d, status = %s, claim_expires_at = %s WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND status = %s',
-				$this->table_name,
-				$job_id,
-				self::STATUS_CLAIMED,
-				$expires_at,
-				$flow_step_id,
-				$source_type,
-				$item_identifier,
-				self::STATUS_PROCESSED
-			)
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
-
-		return false !== $claimed_existing_processed && $claimed_existing_processed > 0;
+		return false;
 	}
 
 	/**

--- a/tests/Unit/Core/Database/ProcessedItemsTest.php
+++ b/tests/Unit/Core/Database/ProcessedItemsTest.php
@@ -249,6 +249,39 @@ class ProcessedItemsTest extends WP_UnitTestCase {
 	}
 
 	// -----------------------------------------------------------------
+	// Claims
+	// -----------------------------------------------------------------
+
+	public function test_claim_item_converts_existing_processed_row_to_claim(): void {
+		global $wpdb;
+
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'claim-existing', 10 );
+
+		$this->assertTrue( $this->db->claim_item( $this->flow_step_id, $this->source_type, 'claim-existing', 11 ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT status, job_id, claim_expires_at FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s',
+				$this->db->get_table_name(),
+				$this->flow_step_id,
+				$this->source_type,
+				'claim-existing'
+			),
+			ARRAY_A
+		);
+
+		$this->assertSame( ProcessedItems::STATUS_CLAIMED, $row['status'] );
+		$this->assertSame( '11', $row['job_id'] );
+		$this->assertNotEmpty( $row['claim_expires_at'] );
+	}
+
+	public function test_claim_item_does_not_steal_active_claim(): void {
+		$this->assertTrue( $this->db->claim_item( $this->flow_step_id, $this->source_type, 'active-claim', 10 ) );
+		$this->assertFalse( $this->db->claim_item( $this->flow_step_id, $this->source_type, 'active-claim', 11 ) );
+	}
+
+	// -----------------------------------------------------------------
 	// Index / schema
 	// -----------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add a small reusable `LifecycleStateTransition::compare_and_set()` helper for guarded table-backed lifecycle state changes.
- Convert the processed-item claim transition from `processed` to `claimed` to use the helper.
- Avoid duplicate insert attempts when an item is already actively claimed, preserving the false return while reducing noisy duplicate-key work.
- Add ProcessedItems claim tests for processed-row conversion and active-claim non-stealing.

## Verification
- `php -l inc/Core/Database/LifecycleStateTransition.php && php -l inc/Core/Database/ProcessedItems/ProcessedItems.php && php -l tests/Unit/Core/Database/ProcessedItemsTest.php`
- `vendor/bin/phpcs inc/Core/Database/LifecycleStateTransition.php inc/Core/Database/ProcessedItems/ProcessedItems.php tests/Unit/Core/Database/ProcessedItemsTest.php`
- `homeboy test --skip-lint -- tests/Unit/Core/Database/ProcessedItemsTest.php` (21 passed, 0 failed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the lifecycle helper, ProcessedItems conversion, targeted tests, and verification workflow; Chris remains responsible for review and acceptance.