### PR TITLE
Centralize agent bundle projection ownership

### DIFF
--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -33,6 +33,7 @@ use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\AgentBundleRuntimeDrift;
 use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
+use DataMachine\Engine\Bundle\AgentConfigArtifactProjector;
 use DataMachine\Engine\Bundle\AgentTemplateMetadata;
 use DataMachine\Engine\Bundle\AgentPackageProjection;
 use DataMachine\Engine\Bundle\BundleSchema;
@@ -683,6 +684,9 @@ class AgentBundler {
 			$config = is_array( $existing['agent_config'] ?? null )
 				? array_merge( $existing['agent_config'], $incoming_config )
 				: $incoming_config;
+			if ( $existing ) {
+				$config = AgentConfigArtifactProjector::preserve_local_paths( $config, is_array( $existing['agent_config'] ?? null ) ? $existing['agent_config'] : array() );
+			}
 
 			$config['datamachine_bundle'] = array_merge(
 				$existing_bundle_state,

--- a/inc/Engine/Bundle/AgentBundleAgentConfig.php
+++ b/inc/Engine/Bundle/AgentBundleAgentConfig.php
@@ -17,16 +17,13 @@ final class AgentBundleAgentConfig {
 	/**
 	 * Return the bundle-owned agent config payload tracked by package upgrades.
 	 *
-	 * Data Machine writes installation bookkeeping under `datamachine_bundle` at
-	 * runtime. That metadata is not authored by bundles, so excluding it keeps
-	 * agent config drift checks focused on operator/bundle-owned settings.
+	 * Projection policy is centralized in AgentConfigArtifactProjector so plugin
+	 * namespaces can opt out of core drift ownership without special cases here.
 	 *
 	 * @param array<string,mixed> $config Agent config.
 	 * @return array<string,mixed>
 	 */
 	public static function tracked_payload( array $config ): array {
-		unset( $config['datamachine_bundle'] );
-		ksort( $config, SORT_STRING );
-		return $config;
+		return AgentConfigArtifactProjector::tracked_payload( $config );
 	}
 }

--- a/inc/Engine/Bundle/AgentBundleArtifactExtensions.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactExtensions.php
@@ -83,6 +83,26 @@ final class AgentBundleArtifactExtensions {
 	}
 
 	/**
+	 * Let artifact owners register package artifact type definitions explicitly.
+	 *
+	 * @param array<string,array<string,mixed>> $definitions Core-owned definitions.
+	 * @return array<string,array<string,mixed>>
+	 */
+	public static function package_artifact_type_definitions( array $definitions ): array {
+		/**
+		 * Filter package artifact type definitions registered by Data Machine.
+		 *
+		 * Plugins that own bundle artifact types should add their package artifact
+		 * type here instead of having core register every known bundle artifact.
+		 *
+		 * @param array<string,array<string,mixed>> $definitions Existing definitions.
+		 */
+		$definitions = self::apply_filter( 'datamachine_agent_package_artifact_type_definitions', $definitions );
+
+		return is_array( $definitions ) ? $definitions : array();
+	}
+
+	/**
 	 * Normalize artifact envelopes and reject unknown plugin artifact types.
 	 *
 	 * @param array<int,array<string,mixed>> $artifacts Raw artifact envelopes.

--- a/inc/Engine/Bundle/AgentBundleArtifactRebase.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactRebase.php
@@ -449,10 +449,11 @@ final class AgentBundleArtifactRebase {
 			return $local;
 		}
 
-		if ( self::is_runtime_local_agent_config_path( $path ) ) {
+		$preserve_policy = AgentConfigArtifactProjector::preserve_local_policy_for_path( $path );
+		if ( null !== $preserve_policy ) {
 			$decisions[ $path ] = array(
 				'source' => 'local',
-				'reason' => 'burn_in_preserve_runtime_agent_config',
+				'reason' => (string) ( $preserve_policy['reason'] ?? 'preserve_runtime_agent_config' ),
 			);
 			return $local_exists ? $local : $base;
 		}
@@ -510,29 +511,6 @@ final class AgentBundleArtifactRebase {
 		}
 
 		return $remote_exists ? $remote : $local;
-	}
-
-	/**
-	 * Whether an agent_config path is runtime-local and should preserve local state.
-	 *
-	 * @param string $path Dot path.
-	 */
-	private static function is_runtime_local_agent_config_path( string $path ): bool {
-		$prefixes = array(
-			'intelligence.context_servers',
-			'intelligence.auth_refs',
-			'allowed_redirect_uris',
-			'model',
-			'provider',
-		);
-
-		foreach ( $prefixes as $prefix ) {
-			if ( $path === $prefix || str_starts_with( $path, $prefix . '.' ) ) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
@@ -109,6 +109,7 @@ final class AgentBundleCoreArtifactApply {
 			return new \WP_Error( 'datamachine_bundle_agent_missing', sprintf( 'Agent ID %d was not found.', $agent_id ) );
 		}
 		$current_config = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
+		$payload        = AgentConfigArtifactProjector::preserve_local_paths( $payload, $current_config );
 		if ( ! empty( $current_config['datamachine_bundle'] ) && ! isset( $payload['datamachine_bundle'] ) ) {
 			$payload['datamachine_bundle'] = $current_config['datamachine_bundle'];
 		}

--- a/inc/Engine/Bundle/AgentConfigArtifactProjector.php
+++ b/inc/Engine/Bundle/AgentConfigArtifactProjector.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Agent config artifact projection policies.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Projects agent_config into bundle-owned artifact payloads.
+ */
+final class AgentConfigArtifactProjector {
+
+	/**
+	 * Return bundle artifact ownership policies keyed by dot path.
+	 *
+	 * Supported policy fields:
+	 * - tracking: include|exclude
+	 * - merge: three_way|preserve_local
+	 * - reason: decision reason for merge output
+	 * - redactor: callable applied to tracked values before hashing/comparison
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	public static function policies(): array {
+		$policies = array(
+			'datamachine_bundle'            => array(
+				'tracking' => 'exclude',
+				'merge'    => 'preserve_local',
+				'reason'   => 'preserve_runtime_bundle_metadata',
+			),
+			'intelligence.context_servers'  => array(
+				'tracking' => 'exclude',
+				'merge'    => 'preserve_local',
+				'reason'   => 'preserve_plugin_owned_agent_config',
+			),
+			'intelligence.auth_refs'        => array(
+				'tracking' => 'exclude',
+				'merge'    => 'preserve_local',
+				'reason'   => 'preserve_plugin_owned_agent_config',
+			),
+			'allowed_redirect_uris'         => array(
+				'merge'  => 'preserve_local',
+				'reason' => 'preserve_runtime_agent_config',
+			),
+			'model'                         => array(
+				'merge'  => 'preserve_local',
+				'reason' => 'preserve_runtime_agent_config',
+			),
+			'provider'                      => array(
+				'merge'  => 'preserve_local',
+				'reason' => 'preserve_runtime_agent_config',
+			),
+		);
+
+		/**
+		 * Filter agent_config artifact projection ownership policies.
+		 *
+		 * Plugins can mark their own agent_config namespaces as runtime-local,
+		 * excluded from core bundle drift checks, or redacted before comparison.
+		 *
+		 * @param array<string,array<string,mixed>> $policies Policy map keyed by dot path.
+		 */
+		$policies = self::apply_filter( 'datamachine_agent_config_artifact_projection_policies', $policies );
+
+		return self::normalize_policies( is_array( $policies ) ? $policies : array() );
+	}
+
+	/**
+	 * Return the bundle-owned config payload tracked by lifecycle planning.
+	 *
+	 * @param array<string,mixed> $config Agent config.
+	 * @return array<string,mixed>
+	 */
+	public static function tracked_payload( array $config ): array {
+		foreach ( self::policies() as $path => $policy ) {
+			if ( 'exclude' === ( $policy['tracking'] ?? '' ) ) {
+				self::unset_path( $config, $path );
+				continue;
+			}
+
+			if ( is_callable( $policy['redactor'] ?? null ) && self::path_exists( $config, $path ) ) {
+				$redactor = $policy['redactor'];
+				self::set_path( $config, $path, $redactor( self::get_path( $config, $path ), $path ) );
+			}
+		}
+
+		self::sort_recursive( $config );
+		return $config;
+	}
+
+	/**
+	 * Return a preserve-local merge policy for a config path, if registered.
+	 *
+	 * @param string $path Dot path.
+	 * @return array<string,mixed>|null
+	 */
+	public static function preserve_local_policy_for_path( string $path ): ?array {
+		foreach ( self::policies() as $prefix => $policy ) {
+			if ( 'preserve_local' !== ( $policy['merge'] ?? '' ) ) {
+				continue;
+			}
+			if ( $path === $prefix || str_starts_with( $path, $prefix . '.' ) ) {
+				return $policy;
+			}
+		}
+
+		return null;
+	}
+
+	/** @param array<string,array<string,mixed>> $policies */
+	private static function normalize_policies( array $policies ): array {
+		$normalized = array();
+		foreach ( $policies as $path => $policy ) {
+			$path = self::normalize_path( (string) $path );
+			if ( '' === $path || ! is_array( $policy ) ) {
+				continue;
+			}
+
+			$tracking = (string) ( $policy['tracking'] ?? 'include' );
+			$merge    = (string) ( $policy['merge'] ?? 'three_way' );
+			$entry    = array(
+				'tracking' => in_array( $tracking, array( 'include', 'exclude' ), true ) ? $tracking : 'include',
+				'merge'    => in_array( $merge, array( 'three_way', 'preserve_local' ), true ) ? $merge : 'three_way',
+				'reason'   => self::sanitize_key( (string) ( $policy['reason'] ?? 'agent_config_projection_policy' ) ),
+			);
+			if ( is_callable( $policy['redactor'] ?? null ) ) {
+				$entry['redactor'] = $policy['redactor'];
+			}
+
+			$normalized[ $path ] = $entry;
+		}
+
+		uksort(
+			$normalized,
+			static fn( string $a, string $b ): int => substr_count( $b, '.' ) <=> substr_count( $a, '.' ) ?: strcmp( $a, $b )
+		);
+		return $normalized;
+	}
+
+	private static function normalize_path( string $path ): string {
+		$path = trim( str_replace( '/', '.', $path ), '.' );
+		$path = preg_replace( '/[^A-Za-z0-9_\.-]+/', '', $path );
+		return trim( is_string( $path ) ? $path : '', '.' );
+	}
+
+	private static function unset_path( array &$config, string $path ): void {
+		self::unset_path_parts( $config, explode( '.', $path ) );
+	}
+
+	/** @param array<int,string> $parts */
+	private static function unset_path_parts( array &$node, array $parts ): bool {
+		$part = array_shift( $parts );
+		if ( null === $part || ! array_key_exists( $part, $node ) ) {
+			return empty( $node );
+		}
+
+		if ( empty( $parts ) ) {
+			unset( $node[ $part ] );
+			return empty( $node );
+		}
+
+		if ( is_array( $node[ $part ] ) && self::unset_path_parts( $node[ $part ], $parts ) ) {
+			unset( $node[ $part ] );
+		}
+
+		return empty( $node );
+	}
+
+	private static function path_exists( array $config, string $path ): bool {
+		$node = $config;
+		foreach ( explode( '.', $path ) as $part ) {
+			if ( ! is_array( $node ) || ! array_key_exists( $part, $node ) ) {
+				return false;
+			}
+			$node = $node[ $part ];
+		}
+		return true;
+	}
+
+	private static function get_path( array $config, string $path ): mixed {
+		$node = $config;
+		foreach ( explode( '.', $path ) as $part ) {
+			$node = is_array( $node ) && array_key_exists( $part, $node ) ? $node[ $part ] : null;
+		}
+		return $node;
+	}
+
+	private static function set_path( array &$config, string $path, mixed $value ): void {
+		$parts = explode( '.', $path );
+		$last  = array_pop( $parts );
+		$node  = &$config;
+		foreach ( $parts as $part ) {
+			if ( ! isset( $node[ $part ] ) || ! is_array( $node[ $part ] ) ) {
+				$node[ $part ] = array();
+			}
+			$node = &$node[ $part ];
+		}
+		if ( null !== $last ) {
+			$node[ $last ] = $value;
+		}
+	}
+
+	private static function sort_recursive( array &$value ): void {
+		foreach ( $value as &$child ) {
+			if ( is_array( $child ) ) {
+				self::sort_recursive( $child );
+			}
+		}
+		ksort( $value, SORT_STRING );
+	}
+
+	private static function apply_filter( string $hook, mixed $value ): mixed {
+		if ( ! \function_exists( 'apply_filters' ) ) {
+			return $value;
+		}
+
+		return \apply_filters( $hook, $value );
+	}
+
+	private static function sanitize_key( string $key ): string {
+		if ( \function_exists( 'sanitize_key' ) ) {
+			return \sanitize_key( $key );
+		}
+
+		$sanitized = preg_replace( '/[^a-zA-Z0-9_\-]/', '', $key );
+		return strtolower( is_string( $sanitized ) ? $sanitized : '' );
+	}
+}

--- a/inc/Engine/Bundle/AgentConfigArtifactProjector.php
+++ b/inc/Engine/Bundle/AgentConfigArtifactProjector.php
@@ -27,30 +27,30 @@ final class AgentConfigArtifactProjector {
 	 */
 	public static function policies(): array {
 		$policies = array(
-			'datamachine_bundle'            => array(
+			'datamachine_bundle'           => array(
 				'tracking' => 'exclude',
 				'merge'    => 'preserve_local',
 				'reason'   => 'preserve_runtime_bundle_metadata',
 			),
-			'intelligence.context_servers'  => array(
+			'intelligence.context_servers' => array(
 				'tracking' => 'exclude',
 				'merge'    => 'preserve_local',
 				'reason'   => 'preserve_plugin_owned_agent_config',
 			),
-			'intelligence.auth_refs'        => array(
+			'intelligence.auth_refs'       => array(
 				'tracking' => 'exclude',
 				'merge'    => 'preserve_local',
 				'reason'   => 'preserve_plugin_owned_agent_config',
 			),
-			'allowed_redirect_uris'         => array(
+			'allowed_redirect_uris'        => array(
 				'merge'  => 'preserve_local',
 				'reason' => 'preserve_runtime_agent_config',
 			),
-			'model'                         => array(
+			'model'                        => array(
 				'merge'  => 'preserve_local',
 				'reason' => 'preserve_runtime_agent_config',
 			),
-			'provider'                      => array(
+			'provider'                     => array(
 				'merge'  => 'preserve_local',
 				'reason' => 'preserve_runtime_agent_config',
 			),
@@ -111,6 +111,24 @@ final class AgentConfigArtifactProjector {
 		return null;
 	}
 
+	/**
+	 * Restore preserve-local config paths before writing a projected payload live.
+	 *
+	 * @param array<string,mixed> $payload        Projected bundle payload.
+	 * @param array<string,mixed> $current_config Current live agent config.
+	 * @return array<string,mixed>
+	 */
+	public static function preserve_local_paths( array $payload, array $current_config ): array {
+		foreach ( self::policies() as $path => $policy ) {
+			if ( 'preserve_local' !== ( $policy['merge'] ?? '' ) || ! self::path_exists( $current_config, $path ) ) {
+				continue;
+			}
+			self::set_path( $payload, $path, self::get_path( $current_config, $path ) );
+		}
+
+		return $payload;
+	}
+
 	/** @param array<string,array<string,mixed>> $policies */
 	private static function normalize_policies( array $policies ): array {
 		$normalized = array();
@@ -136,7 +154,10 @@ final class AgentConfigArtifactProjector {
 
 		uksort(
 			$normalized,
-			static fn( string $a, string $b ): int => substr_count( $b, '.' ) <=> substr_count( $a, '.' ) ?: strcmp( $a, $b )
+			static function ( string $a, string $b ): int {
+				$depth_compare = substr_count( $b, '.' ) <=> substr_count( $a, '.' );
+				return 0 !== $depth_compare ? $depth_compare : strcmp( $a, $b );
+			}
 		);
 		return $normalized;
 	}

--- a/inc/Engine/Bundle/register-agent-package-artifacts.php
+++ b/inc/Engine/Bundle/register-agent-package-artifacts.php
@@ -68,20 +68,7 @@ function datamachine_agent_package_artifact_type_definitions(): array {
 		),
 	);
 
-	foreach ( BundleSchema::artifact_types() as $bundle_artifact_type ) {
-		$package_type = AgentBundleUpgradePlanner::package_artifact_type( $bundle_artifact_type );
-		if ( isset( $definitions[ $package_type ] ) ) {
-			continue;
-		}
-
-		$definitions[ $package_type ] = array(
-			'label'           => $package_type,
-			'description'     => 'Plugin-owned Data Machine bundle artifact.',
-			'import_callback' => $import_callback,
-		);
-	}
-
-	return $definitions;
+	return AgentBundleArtifactExtensions::package_artifact_type_definitions( $definitions );
 }
 
 /**

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -820,7 +820,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_upgrade_preserves_locally_modified_agent_config_and_reports_conflict(): void {
+	public function test_upgrade_preserves_projection_excluded_agent_config_without_conflict(): void {
 		$bundle = $this->fixture_bundle( 'context-agent' );
 		$bundle['agent']['agent_config'] = array(
 			'intelligence' => array(
@@ -869,15 +869,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		);
 
 		$this->assertTrue( (bool) $second['success'], 'Upgrade succeeds so clean artifacts can apply.' );
-		$this->assertSame(
-			array(
-				'artifact_type' => 'agent_config',
-				'artifact_id'   => 'config',
-				'reason'        => 'local_modified',
-			),
-			$second['summary']['conflicts'][0] ?? null,
-			'Locally modified agent config is reported as a conflict.'
-		);
+		$this->assertSame( array(), $second['summary']['conflicts'], 'Projection-excluded agent config does not report a bundle conflict.' );
 
 		$after = $this->agents_repo->get_by_slug( 'context-agent' );
 		$this->assertSame(

--- a/tests/ability-boundary-helpers-smoke.php
+++ b/tests/ability-boundary-helpers-smoke.php
@@ -7,41 +7,65 @@
  * @package DataMachine\Tests
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	define( 'ABSPATH', __DIR__ . '/' );
+namespace DataMachine\Abilities {
+	function doing_action( $hook = '' ) {
+		global $datamachine_test_doing_action;
+		return 'wp_abilities_api_init' === $hook && $datamachine_test_doing_action;
+	}
+
+	function did_action( $hook = '' ) {
+		global $datamachine_test_did_action;
+		return 'wp_abilities_api_init' === $hook ? $datamachine_test_did_action : 0;
+	}
+
+	function add_action( $hook, $callback ) {
+		global $datamachine_test_actions;
+		$datamachine_test_actions[ $hook ][] = $callback;
+	}
 }
 
-$failed = 0;
-$total  = 0;
+namespace DataMachine\Cli {
+	function wp_get_ability( string $name ) {
+		global $datamachine_test_abilities;
+		return $datamachine_test_abilities[ $name ] ?? null;
+	}
 
-$datamachine_test_doing_action = false;
-$datamachine_test_did_action   = 0;
-$datamachine_test_actions      = array();
-$datamachine_test_abilities    = array();
-
-function doing_action( $hook = '' ) {
-	global $datamachine_test_doing_action;
-	return 'wp_abilities_api_init' === $hook && $datamachine_test_doing_action;
+	function is_wp_error( $value ) {
+		return false;
+	}
 }
 
-function did_action( $hook = '' ) {
-	global $datamachine_test_did_action;
-	return 'wp_abilities_api_init' === $hook ? $datamachine_test_did_action : 0;
+namespace DataMachine\Core {
+
+	function is_wp_error( $value ) {
+		return false;
+	}
 }
 
-function add_action( $hook, $callback ) {
-	global $datamachine_test_actions;
-	$datamachine_test_actions[ $hook ][] = $callback;
-}
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
 
-function wp_get_ability( string $name ) {
-	global $datamachine_test_abilities;
-	return $datamachine_test_abilities[ $name ] ?? null;
-}
+	$failed = 0;
+	$total  = 0;
 
-function is_wp_error( $value ) {
-	return false;
-}
+	$datamachine_test_doing_action = false;
+	$datamachine_test_did_action   = 0;
+	$datamachine_test_actions      = array();
+	$datamachine_test_abilities    = array();
+
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		function wp_get_ability( string $name ) {
+			return \DataMachine\Cli\wp_get_ability( $name );
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $value ) {
+			return false;
+		}
+	}
 
 class Datamachine_Test_Ability {
 	public function execute( $input = null ) {
@@ -108,3 +132,4 @@ if ( $failed > 0 ) {
 }
 
 echo "\nAll {$total} checks passed.\n";
+}

--- a/tests/agent-bundle-artifact-rebase-smoke.php
+++ b/tests/agent-bundle-artifact-rebase-smoke.php
@@ -37,10 +37,12 @@ if ( ! class_exists( 'WP_Agent_Package_Artifact_Hasher' ) ) {
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSchema.php';
 require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Packages/class-wp-agent-package-artifact-hasher.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactExtensions.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentConfigArtifactProjector.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactHasher.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactRebase.php';
 
 use DataMachine\Engine\Bundle\AgentBundleArtifactRebase;
+use DataMachine\Engine\Bundle\AgentConfigArtifactProjector;
 
 $failures = 0;
 $total    = 0;
@@ -149,8 +151,11 @@ rebase_assert( 'agent_config rebase is unambiguous for runtime-local plus bundle
 rebase_assert_equals( 'agent_config preserves local context server URL', 'https://local-tunnel.example.test/mcp', $agent_config_result['merged']['intelligence']['context_servers']['a8c']['url'] ?? null );
 rebase_assert_equals( 'agent_config preserves local auth header', 'Bearer local-token', $agent_config_result['merged']['intelligence']['context_servers']['a8c']['headers']['Authorization'] ?? null );
 rebase_assert_equals( 'agent_config takes remote graph alias', array( 'strategy-signal' ), $agent_config_result['merged']['intelligence_wiki_brain']['graph_config']['entity_types']['strategic-signal']['aliases'] ?? null );
-rebase_assert_equals( 'agent_config records runtime-local decision', 'burn_in_preserve_runtime_agent_config', $agent_config_result['decisions']['intelligence.context_servers']['reason'] ?? null );
+rebase_assert_equals( 'agent_config records runtime-local decision', 'preserve_plugin_owned_agent_config', $agent_config_result['decisions']['intelligence.context_servers']['reason'] ?? null );
 rebase_assert_equals( 'agent_config records bundle-owned remote decision', 'local_unchanged_from_base', $agent_config_result['decisions']['intelligence_wiki_brain.graph_config.entity_types.strategic-signal.aliases']['reason'] ?? null );
+$tracked_agent_config = AgentConfigArtifactProjector::tracked_payload( $local_agent_config );
+rebase_assert_equals( 'tracked agent_config excludes Intelligence context servers', false, isset( $tracked_agent_config['intelligence']['context_servers'] ) );
+rebase_assert_equals( 'tracked agent_config keeps bundle-owned Intelligence wiki brain config', 'Strategic signal', $tracked_agent_config['intelligence_wiki_brain']['graph_config']['entity_types']['strategic-signal']['label'] ?? null );
 
 // ---------------------------------------------------------------------------
 // [3] burn-in-safe takes remote source-shape, keeps local throttles.

--- a/tests/agent-bundle-template-upgrade-tracking-smoke.php
+++ b/tests/agent-bundle-template-upgrade-tracking-smoke.php
@@ -49,6 +49,7 @@ require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleValidationException.
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSchema.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/PortableSlug.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactExtensions.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentConfigArtifactProjector.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleAgentConfig.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactHasher.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactStatus.php';

--- a/tests/datamachine-package-artifacts-smoke.php
+++ b/tests/datamachine-package-artifacts-smoke.php
@@ -49,16 +49,6 @@ function datamachine_package_smoke_artifacts_by_type( WP_Agent_Package $package 
 	return $indexed;
 }
 
-echo "\n[1] Data Machine registers package artifact types through the generic registry:\n";
-datamachine_package_smoke_reset_registry();
-$registered_types = wp_get_agent_package_artifact_types();
-$pipeline_type    = $registered_types['datamachine/pipeline'] ?? null;
-agents_api_smoke_assert_equals( true, wp_has_agent_package_artifact_type( 'datamachine/pipeline' ), 'pipeline artifact type is registered', $failures, $passes );
-agents_api_smoke_assert_equals( true, wp_has_agent_package_artifact_type( 'datamachine/flow' ), 'flow artifact type is registered', $failures, $passes );
-agents_api_smoke_assert_equals( true, wp_has_agent_package_artifact_type( 'datamachine/queue-seed' ), 'queue seed artifact type is registered', $failures, $passes );
-agents_api_smoke_assert_equals( 'Data Machine pipeline', $pipeline_type instanceof WP_Agent_Package_Artifact_Type ? $pipeline_type->get_label() : '', 'registered type carries Data Machine metadata outside agents-api', $failures, $passes );
-
-echo "\n[2] Bundle directories project to Core-shaped WP_Agent_Package identity:\n";
 add_filter(
 	'datamachine_agent_bundle_artifact_types',
 	static function ( array $types ): array {
@@ -69,6 +59,35 @@ add_filter(
 	10,
 	1
 );
+add_filter(
+	'datamachine_agent_package_artifact_type_definitions',
+	static function ( array $definitions ): array {
+		$definitions['intelligence/wiki-brain'] = array(
+			'label'           => 'Intelligence wiki brain',
+			'description'     => 'Plugin-owned Intelligence wiki brain artifact.',
+			'import_callback' => 'DataMachine\\Engine\\Bundle\\import_datamachine_agent_package_artifact',
+		);
+		$definitions['datamachine-extension/legacy_plugin_artifact'] = array(
+			'label'           => 'Legacy plugin artifact',
+			'description'     => 'Plugin-owned legacy artifact.',
+			'import_callback' => 'DataMachine\\Engine\\Bundle\\import_datamachine_agent_package_artifact',
+		);
+		return $definitions;
+	},
+	10,
+	1
+);
+
+echo "\n[1] Data Machine registers package artifact types through the generic registry:\n";
+datamachine_package_smoke_reset_registry();
+$registered_types = wp_get_agent_package_artifact_types();
+$pipeline_type    = $registered_types['datamachine/pipeline'] ?? null;
+agents_api_smoke_assert_equals( true, wp_has_agent_package_artifact_type( 'datamachine/pipeline' ), 'pipeline artifact type is registered', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_agent_package_artifact_type( 'datamachine/flow' ), 'flow artifact type is registered', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_agent_package_artifact_type( 'datamachine/queue-seed' ), 'queue seed artifact type is registered', $failures, $passes );
+agents_api_smoke_assert_equals( 'Data Machine pipeline', $pipeline_type instanceof WP_Agent_Package_Artifact_Type ? $pipeline_type->get_label() : '', 'registered type carries Data Machine metadata outside agents-api', $failures, $passes );
+
+echo "\n[2] Bundle directories project to Core-shaped WP_Agent_Package identity:\n";
 $directory = new AgentBundleDirectory(
 	new AgentBundleManifest(
 		'2026-04-30T12:00:00Z',


### PR DESCRIPTION
## Summary
- Add a generic AgentConfigArtifactProjector for agent_config namespace tracking, redaction, and merge ownership policies.
- Route agent_config drift projection and burn-in-safe rebase preservation through the shared projector, including Intelligence runtime config namespaces.
- Replace bulk package artifact registration for every bundle artifact type with an explicit artifact-owner definition filter.

## Verification
- php tests/agent-bundle-artifact-rebase-smoke.php
- php tests/datamachine-package-artifacts-smoke.php
- php -l inc/Engine/Bundle/AgentConfigArtifactProjector.php

## Notes
- Existing bundles keep core Data Machine package artifact registrations.
- Plugin-owned package artifact types can register through datamachine_agent_package_artifact_type_definitions.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5
- **Used for:** Implemented the projection primitive, updated package artifact registration, adjusted focused smoke coverage, and ran targeted verification. Chris remains responsible for review and testing.