### PR TITLE
Centralize REST execution access checks

### DIFF
--- a/inc/Abilities/ExecutionScope.php
+++ b/inc/Abilities/ExecutionScope.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Explicit execution-scope snapshot for Data Machine permission checks.
+ *
+ * @package DataMachine\Abilities
+ */
+
+namespace DataMachine\Abilities;
+
+use AgentsAPI\AI\WP_Agent_Execution_Principal;
+
+/**
+ * Immutable view of the current Data Machine execution scope.
+ *
+ * This intentionally delegates authorization decisions to PermissionHelper so
+ * existing CLI, scheduler, token, and user-session semantics remain unchanged.
+ */
+class ExecutionScope {
+
+	/**
+	 * Action key used for capability checks.
+	 *
+	 * @var string
+	 */
+	private string $action;
+
+	/**
+	 * Whether the scope can perform the configured action.
+	 *
+	 * @var bool
+	 */
+	private bool $can_action;
+
+	/**
+	 * Acting WordPress user ID.
+	 *
+	 * @var int
+	 */
+	private int $acting_user_id;
+
+	/**
+	 * Acting agent ID, when authenticated as an agent.
+	 *
+	 * @var int|null
+	 */
+	private ?int $acting_agent_id;
+
+	/**
+	 * Acting token ID, when authenticated with an agent token.
+	 *
+	 * @var int|null
+	 */
+	private ?int $acting_token_id;
+
+	/**
+	 * Agents API execution principal, when available.
+	 *
+	 * @var WP_Agent_Execution_Principal|null
+	 */
+	private ?WP_Agent_Execution_Principal $principal;
+
+	/**
+	 * Whether this scope is pre-authenticated.
+	 *
+	 * @var bool
+	 */
+	private bool $authenticated_context;
+
+	/**
+	 * Whether this scope is authenticated as an agent.
+	 *
+	 * @var bool
+	 */
+	private bool $agent_context;
+
+	/**
+	 * Create an explicit snapshot of the current permission context.
+	 *
+	 * @param string $action Action key for capability checks.
+	 * @return self
+	 */
+	public static function current( string $action = 'manage_flows' ): self {
+		return new self(
+			$action,
+			PermissionHelper::can( $action ),
+			PermissionHelper::acting_user_id(),
+			PermissionHelper::get_acting_agent_id(),
+			PermissionHelper::get_acting_token_id(),
+			PermissionHelper::get_execution_principal(),
+			PermissionHelper::is_authenticated_context(),
+			PermissionHelper::in_agent_context()
+		);
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string                            $action                Action key.
+	 * @param bool                              $can_action            Whether action is allowed.
+	 * @param int                               $acting_user_id        Acting user ID.
+	 * @param int|null                          $acting_agent_id       Acting agent ID.
+	 * @param int|null                          $acting_token_id       Acting token ID.
+	 * @param WP_Agent_Execution_Principal|null $principal             Execution principal.
+	 * @param bool                              $authenticated_context Pre-authenticated context flag.
+	 * @param bool                              $agent_context         Agent context flag.
+	 */
+	private function __construct( string $action, bool $can_action, int $acting_user_id, ?int $acting_agent_id, ?int $acting_token_id, ?WP_Agent_Execution_Principal $principal, bool $authenticated_context, bool $agent_context ) {
+		$this->action                = $action;
+		$this->can_action            = $can_action;
+		$this->acting_user_id        = $acting_user_id;
+		$this->acting_agent_id       = $acting_agent_id;
+		$this->acting_token_id       = $acting_token_id;
+		$this->principal             = $principal;
+		$this->authenticated_context = $authenticated_context;
+		$this->agent_context         = $agent_context;
+	}
+
+	/**
+	 * Get the scope action key.
+	 *
+	 * @return string
+	 */
+	public function action(): string {
+		return $this->action;
+	}
+
+	/**
+	 * Whether the scope can perform the configured action.
+	 *
+	 * @return bool
+	 */
+	public function can_action(): bool {
+		return $this->can_action;
+	}
+
+	/**
+	 * Get the acting WordPress user ID.
+	 *
+	 * @return int
+	 */
+	public function acting_user_id(): int {
+		return $this->acting_user_id;
+	}
+
+	/**
+	 * Get the acting agent ID.
+	 *
+	 * @return int|null
+	 */
+	public function acting_agent_id(): ?int {
+		return $this->acting_agent_id;
+	}
+
+	/**
+	 * Get the acting token ID.
+	 *
+	 * @return int|null
+	 */
+	public function acting_token_id(): ?int {
+		return $this->acting_token_id;
+	}
+
+	/**
+	 * Get the Agents API execution principal.
+	 *
+	 * @return WP_Agent_Execution_Principal|null
+	 */
+	public function principal(): ?WP_Agent_Execution_Principal {
+		return $this->principal;
+	}
+
+	/**
+	 * Whether the scope is pre-authenticated.
+	 *
+	 * @return bool
+	 */
+	public function is_authenticated_context(): bool {
+		return $this->authenticated_context;
+	}
+
+	/**
+	 * Whether the scope is authenticated as an agent.
+	 *
+	 * @return bool
+	 */
+	public function is_agent_context(): bool {
+		return $this->agent_context;
+	}
+
+	/**
+	 * Check access to an agent-scoped resource under existing PermissionHelper policy.
+	 *
+	 * @param int|null $resource_agent_id Agent ID on the resource record.
+	 * @param int      $resource_user_id  User ID on the resource record.
+	 * @return bool
+	 */
+	public function owns_agent_resource( ?int $resource_agent_id, int $resource_user_id ): bool {
+		return PermissionHelper::owns_agent_resource( $resource_agent_id, $resource_user_id, $this->action );
+	}
+}

--- a/inc/Api/Flows/Flows.php
+++ b/inc/Api/Flows/Flows.php
@@ -10,7 +10,7 @@
 
 namespace DataMachine\Api\Flows;
 
-use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Api\RestAccessGuard;
 use DataMachine\Core\AbilityResult;
 use WP_REST_Server;
 
@@ -346,15 +346,7 @@ class Flows {
 	 */
 	public static function check_permission( $request ) {
 		$request;
-		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
-			return new \WP_Error(
-				'rest_forbidden',
-				__( 'You do not have permission to create flows.', 'data-machine' ),
-				array( 'status' => 403 )
-			);
-		}
-
-		return true;
+		return RestAccessGuard::for_action( 'manage_flows' )->check_permission( __( 'You do not have permission to create flows.', 'data-machine' ) );
 	}
 
 	/**
@@ -369,11 +361,11 @@ class Flows {
 		$input = array(
 			'pipeline_id' => (int) $request->get_param( 'pipeline_id' ),
 			'flow_name'   => $request->get_param( 'flow_name' ) ?? 'Flow',
-			'user_id'     => PermissionHelper::acting_user_id(),
+			'user_id'     => RestAccessGuard::for_action( 'manage_flows' )->acting_user_id(),
 		);
 
 		// Carry agent_id from body params or query string (agent interceptor).
-		$scoped_agent_id = PermissionHelper::resolve_scoped_agent_id( $request );
+		$scoped_agent_id = RestAccessGuard::for_action( 'manage_flows' )->resolve_scoped_agent_id( $request );
 		if ( null !== $scoped_agent_id ) {
 			$input['agent_id'] = $scoped_agent_id;
 		}
@@ -401,12 +393,9 @@ class Flows {
 		$flow     = $db_flows->get_flow( $flow_id );
 
 		$resource_agent_id = isset( $flow['agent_id'] ) ? (int) $flow['agent_id'] : null;
-		if ( $flow && ! PermissionHelper::owns_agent_resource( $resource_agent_id, (int) ( $flow['user_id'] ?? 0 ) ) ) {
-			return new \WP_Error(
-				'rest_forbidden',
-				__( 'You do not have permission to delete this flow.', 'data-machine' ),
-				array( 'status' => 403 )
-			);
+		$access            = RestAccessGuard::for_action( 'manage_flows' )->authorize_agent_resource( $resource_agent_id, (int) ( $flow['user_id'] ?? 0 ), __( 'You do not have permission to delete this flow.', 'data-machine' ) );
+		if ( $flow && is_wp_error( $access ) ) {
+			return $access;
 		}
 
 		$ability = wp_get_ability( 'datamachine/delete-flow' );
@@ -434,12 +423,9 @@ class Flows {
 		$flow     = $db_flows->get_flow( $flow_id );
 
 		$resource_agent_id = isset( $flow['agent_id'] ) ? (int) $flow['agent_id'] : null;
-		if ( $flow && ! PermissionHelper::owns_agent_resource( $resource_agent_id, (int) ( $flow['user_id'] ?? 0 ) ) ) {
-			return new \WP_Error(
-				'rest_forbidden',
-				__( 'You do not have permission to duplicate this flow.', 'data-machine' ),
-				array( 'status' => 403 )
-			);
+		$access            = RestAccessGuard::for_action( 'manage_flows' )->authorize_agent_resource( $resource_agent_id, (int) ( $flow['user_id'] ?? 0 ), __( 'You do not have permission to duplicate this flow.', 'data-machine' ) );
+		if ( $flow && is_wp_error( $access ) ) {
+			return $access;
 		}
 
 		$ability = wp_get_ability( 'datamachine/duplicate-flow' );
@@ -450,7 +436,7 @@ class Flows {
 		$result = $ability->execute(
 			array(
 				'source_flow_id' => $flow_id,
-				'user_id'        => PermissionHelper::acting_user_id(),
+				'user_id'        => RestAccessGuard::for_action( 'manage_flows' )->acting_user_id(),
 			)
 		);
 
@@ -465,8 +451,9 @@ class Flows {
 		$per_page        = $request->get_param( 'per_page' ) ?? 20;
 		$offset          = $request->get_param( 'offset' ) ?? 0;
 		$output_mode     = $request->get_param( 'output_mode' ) ?? 'full';
-		$scoped_user_id  = PermissionHelper::resolve_scoped_user_id( $request );
-		$scoped_agent_id = PermissionHelper::resolve_scoped_agent_id( $request );
+		$access_guard    = RestAccessGuard::for_action( 'manage_flows' );
+		$scoped_user_id  = $access_guard->resolve_scoped_user_id( $request );
+		$scoped_agent_id = $access_guard->resolve_scoped_agent_id( $request );
 
 		$ability = wp_get_ability( 'datamachine/get-flows' );
 		if ( ! $ability ) {
@@ -542,12 +529,9 @@ class Flows {
 		$flow     = $db_flows->get_flow( $flow_id );
 
 		$resource_agent_id = isset( $flow['agent_id'] ) ? (int) $flow['agent_id'] : null;
-		if ( $flow && ! PermissionHelper::owns_agent_resource( $resource_agent_id, (int) ( $flow['user_id'] ?? 0 ) ) ) {
-			return new \WP_Error(
-				'rest_forbidden',
-				__( 'You do not have permission to update this flow.', 'data-machine' ),
-				array( 'status' => 403 )
-			);
+		$access            = RestAccessGuard::for_action( 'manage_flows' )->authorize_agent_resource( $resource_agent_id, (int) ( $flow['user_id'] ?? 0 ), __( 'You do not have permission to update this flow.', 'data-machine' ) );
+		if ( $flow && is_wp_error( $access ) ) {
+			return $access;
 		}
 
 		$ability = wp_get_ability( 'datamachine/update-flow' );
@@ -775,12 +759,9 @@ class Flows {
 		}
 
 		$resource_agent_id = isset( $flow['agent_id'] ) ? (int) $flow['agent_id'] : null;
-		if ( ! PermissionHelper::owns_agent_resource( $resource_agent_id, (int) ( $flow['user_id'] ?? 0 ) ) ) {
-			return new \WP_Error(
-				'rest_forbidden',
-				__( 'You do not have permission to access this flow.', 'data-machine' ),
-				array( 'status' => 403 )
-			);
+		$access            = RestAccessGuard::for_action( 'manage_flows' )->authorize_agent_resource( $resource_agent_id, (int) ( $flow['user_id'] ?? 0 ), __( 'You do not have permission to access this flow.', 'data-machine' ) );
+		if ( is_wp_error( $access ) ) {
+			return $access;
 		}
 
 		$memory_files = $db_flows->get_flow_memory_files( $flow_id );
@@ -824,12 +805,9 @@ class Flows {
 		}
 
 		$resource_agent_id = isset( $flow['agent_id'] ) ? (int) $flow['agent_id'] : null;
-		if ( ! PermissionHelper::owns_agent_resource( $resource_agent_id, (int) ( $flow['user_id'] ?? 0 ) ) ) {
-			return new \WP_Error(
-				'rest_forbidden',
-				__( 'You do not have permission to update this flow.', 'data-machine' ),
-				array( 'status' => 403 )
-			);
+		$access            = RestAccessGuard::for_action( 'manage_flows' )->authorize_agent_resource( $resource_agent_id, (int) ( $flow['user_id'] ?? 0 ), __( 'You do not have permission to update this flow.', 'data-machine' ) );
+		if ( is_wp_error( $access ) ) {
+			return $access;
 		}
 
 		// Sanitize filenames.

--- a/inc/Api/RestAccessGuard.php
+++ b/inc/Api/RestAccessGuard.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * REST access guard for Data Machine resources.
+ *
+ * @package DataMachine\Api
+ */
+
+namespace DataMachine\Api;
+
+use DataMachine\Abilities\ExecutionScope;
+use DataMachine\Abilities\PermissionHelper;
+use WP_Error;
+use WP_REST_Request;
+
+/**
+ * Small REST-facing wrapper around existing Data Machine permission semantics.
+ */
+class RestAccessGuard {
+
+	/**
+	 * Current explicit execution scope.
+	 *
+	 * @var ExecutionScope
+	 */
+	private ExecutionScope $scope;
+
+	/**
+	 * Create a guard for an action key.
+	 *
+	 * @param string $action Action key for capability/resource checks.
+	 * @return self
+	 */
+	public static function for_action( string $action = 'manage_flows' ): self {
+		return new self( ExecutionScope::current( $action ) );
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ExecutionScope $scope Explicit execution scope.
+	 */
+	public function __construct( ExecutionScope $scope ) {
+		$this->scope = $scope;
+	}
+
+	/**
+	 * Get the explicit execution scope used by this guard.
+	 *
+	 * @return ExecutionScope
+	 */
+	public function scope(): ExecutionScope {
+		return $this->scope;
+	}
+
+	/**
+	 * Check the guard action for a REST permission callback.
+	 *
+	 * @param string $message Error message when denied.
+	 * @return true|WP_Error
+	 */
+	public function check_permission( string $message ) {
+		if ( $this->scope->can_action() ) {
+			return true;
+		}
+
+		return $this->forbidden( $message );
+	}
+
+	/**
+	 * Get the acting user ID from the explicit scope.
+	 *
+	 * @return int
+	 */
+	public function acting_user_id(): int {
+		return $this->scope->acting_user_id();
+	}
+
+	/**
+	 * Resolve scoped user ID using the guard action.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return int|null
+	 */
+	public function resolve_scoped_user_id( WP_REST_Request $request ): ?int {
+		return PermissionHelper::resolve_scoped_user_id( $request, $this->scope->action() );
+	}
+
+	/**
+	 * Resolve scoped agent ID using the guard action.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return int|null
+	 */
+	public function resolve_scoped_agent_id( WP_REST_Request $request ): ?int {
+		return PermissionHelper::resolve_scoped_agent_id( $request, $this->scope->action() );
+	}
+
+	/**
+	 * Check access to an agent-scoped resource.
+	 *
+	 * @param int|null $resource_agent_id Agent ID on the resource record.
+	 * @param int      $resource_user_id  User ID on the resource record.
+	 * @param string   $message           Error message when denied.
+	 * @return true|WP_Error
+	 */
+	public function authorize_agent_resource( ?int $resource_agent_id, int $resource_user_id, string $message ) {
+		if ( $this->scope->owns_agent_resource( $resource_agent_id, $resource_user_id ) ) {
+			return true;
+		}
+
+		return $this->forbidden( $message );
+	}
+
+	/**
+	 * Build a standard REST forbidden error.
+	 *
+	 * @param string $message Error message.
+	 * @return WP_Error
+	 */
+	private function forbidden( string $message ): WP_Error {
+		return new WP_Error(
+			'rest_forbidden',
+			$message,
+			array( 'status' => 403 )
+		);
+	}
+}

--- a/tests/Unit/Abilities/PermissionHelperTest.php
+++ b/tests/Unit/Abilities/PermissionHelperTest.php
@@ -14,6 +14,8 @@ namespace DataMachine\Tests\Unit\Abilities;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Abilities\AbilityScopePermissionFilter;
+use DataMachine\Abilities\ExecutionScope;
+use DataMachine\Api\RestAccessGuard;
 use WP_UnitTestCase;
 
 class PermissionHelperTest extends WP_UnitTestCase {
@@ -23,6 +25,7 @@ class PermissionHelperTest extends WP_UnitTestCase {
 	 */
 	public function tear_down(): void {
 		PermissionHelper::clear_agent_context();
+		remove_filter( 'datamachine_cli_bypass_permissions', '__return_false' );
 		wp_set_current_user( 0 );
 
 		// Ensure authenticated context is always reset.
@@ -60,6 +63,38 @@ class PermissionHelperTest extends WP_UnitTestCase {
 		wp_set_current_user( $user_id );
 
 		$this->assertFalse( PermissionHelper::can_manage() );
+	}
+
+	public function test_execution_scope_snapshots_current_permission_context(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$scope = ExecutionScope::current( 'manage_flows' );
+
+		$this->assertSame( 'manage_flows', $scope->action() );
+		$this->assertTrue( $scope->can_action() );
+		$this->assertSame( $user_id, $scope->acting_user_id() );
+		$this->assertNull( $scope->acting_agent_id() );
+	}
+
+	public function test_rest_access_guard_denies_action_with_standard_rest_error(): void {
+		wp_set_current_user( 0 );
+		add_filter( 'datamachine_cli_bypass_permissions', '__return_false' );
+
+		$result = RestAccessGuard::for_action( 'manage_flows' )->check_permission( 'Denied.' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	public function test_rest_access_guard_authorizes_agent_resource_through_permission_helper(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$allowed = RestAccessGuard::for_action( 'manage_flows' )->authorize_agent_resource( null, $user_id + 100, 'Denied.' );
+
+		$this->assertTrue( $allowed );
 	}
 
 	public function test_authenticated_context_not_set_by_default(): void {


### PR DESCRIPTION
## Summary
- add an explicit `ExecutionScope` snapshot that wraps the current `PermissionHelper` context without changing auth semantics
- add `RestAccessGuard` as a small REST-facing wrapper for permission callbacks, scoped user/agent resolution, and agent-resource authorization
- convert representative Flows REST callsites, including duplicate flow ownership guards and memory-file flow access checks

## Verification
- `vendor/bin/phpcs inc/Abilities/ExecutionScope.php inc/Api/RestAccessGuard.php inc/Api/Flows/Flows.php tests/Unit/Abilities/PermissionHelperTest.php`
- `php -l` on changed PHP files
- `composer validate --no-check-publish`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@centralize-execution-access --runner homeboy-lab --skip-lint` (1344 total, 1340 passed, 4 skipped, 0 failed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the shared access primitives, converted representative Flows REST callsites, added focused tests, and ran verification for Chris to review.