### PR TITLE
Centralize REST ability result handling

### DIFF
--- a/inc/Api/Flows/FlowQueue.php
+++ b/inc/Api/Flows/FlowQueue.php
@@ -11,6 +11,8 @@
 namespace DataMachine\Api\Flows;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Api\RestAbilityExecutor;
+use DataMachine\Api\RestResultSpec;
 use WP_REST_Server;
 
 if ( ! defined( 'WPINC' ) ) {
@@ -235,45 +237,27 @@ class FlowQueue {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public static function handle_list_queue( $request ) {
-		$ability = wp_get_ability( 'datamachine/queue-list' );
-		if ( ! $ability ) {
-			return new \WP_Error( 'ability_not_found', 'Ability not found', array( 'status' => 500 ) );
-		}
-
-		$result = $ability->execute(
+		return RestAbilityExecutor::execute(
+			'datamachine/queue-list',
 			array(
 				'flow_id'      => (int) $request->get_param( 'flow_id' ),
 				'flow_step_id' => sanitize_text_field( $request->get_param( 'flow_step_id' ) ),
-			)
-		);
-
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] ) {
-			$status = 400;
-			if ( false !== strpos( $result['error'] ?? '', 'not found' ) ) {
-				$status = 404;
-			}
-
-			return new \WP_Error(
-				'queue_list_failed',
-				$result['error'] ?? __( 'Failed to list queue.', 'data-machine' ),
-				array( 'status' => $status )
-			);
-		}
-
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'data'    => array(
+			),
+			RestResultSpec::item(
+				static function ( array $result ): array {
+					return array(
 					'flow_id'      => $result['flow_id'],
 					'flow_step_id' => $result['flow_step_id'],
 					'queue'        => $result['queue'],
 					'count'        => $result['count'],
 					'queue_mode'   => $result['queue_mode'],
-				),
+					);
+				},
+				null,
+				'queue_list_failed',
+				__( 'Failed to list queue.', 'data-machine' ),
+				400,
+				array( self::class, 'queue_failure_status' )
 			)
 		);
 	}
@@ -352,23 +336,26 @@ class FlowQueue {
 			}
 		}
 
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'data'    => array(
+		return RestResultSpec::item(
+			static function () use ( $flow_id, $flow_step_id, $added_count, $queue_length ): array {
+				return array(
 					'flow_id'      => $flow_id,
 					'flow_step_id' => $flow_step_id,
 					'added_count'  => $added_count,
 					'queue_length' => $queue_length,
-				),
-				'message' => sprintf(
+				);
+			},
+			static function () use ( $added_count, $queue_length ): array {
+				return array(
+					'message' => sprintf(
 					/* translators: %1$d: number of prompts added, %2$d: total queue length */
 					__( 'Added %1$d prompt(s). Queue now has %2$d item(s).', 'data-machine' ),
 					$added_count,
 					$queue_length
-				),
-			)
-		);
+					),
+				);
+			}
+		)->response( array( 'success' => true ) );
 	}
 
 	/**
@@ -380,44 +367,27 @@ class FlowQueue {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public static function handle_clear_queue( $request ) {
-		$ability = wp_get_ability( 'datamachine/queue-clear' );
-		if ( ! $ability ) {
-			return new \WP_Error( 'ability_not_found', 'Ability not found', array( 'status' => 500 ) );
-		}
-
-		$result = $ability->execute(
+		return RestAbilityExecutor::execute(
+			'datamachine/queue-clear',
 			array(
 				'flow_id'      => (int) $request->get_param( 'flow_id' ),
 				'flow_step_id' => sanitize_text_field( $request->get_param( 'flow_step_id' ) ),
-			)
-		);
-
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] ) {
-			$status = 400;
-			if ( false !== strpos( $result['error'] ?? '', 'not found' ) ) {
-				$status = 404;
-			}
-
-			return new \WP_Error(
-				'queue_clear_failed',
-				$result['error'] ?? __( 'Failed to clear queue.', 'data-machine' ),
-				array( 'status' => $status )
-			);
-		}
-
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'data'    => array(
+			),
+			RestResultSpec::item(
+				static function ( array $result ): array {
+					return array(
 					'flow_id'       => $result['flow_id'],
 					'flow_step_id'  => $result['flow_step_id'],
 					'cleared_count' => $result['cleared_count'],
-				),
-				'message' => $result['message'],
+					);
+				},
+				static function ( array $result ): array {
+					return array( 'message' => $result['message'] );
+				},
+				'queue_clear_failed',
+				__( 'Failed to clear queue.', 'data-machine' ),
+				400,
+				array( self::class, 'queue_failure_status' )
 			)
 		);
 	}
@@ -431,46 +401,29 @@ class FlowQueue {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public static function handle_remove_from_queue( $request ) {
-		$ability = wp_get_ability( 'datamachine/queue-remove' );
-		if ( ! $ability ) {
-			return new \WP_Error( 'ability_not_found', 'Ability not found', array( 'status' => 500 ) );
-		}
-
-		$result = $ability->execute(
+		return RestAbilityExecutor::execute(
+			'datamachine/queue-remove',
 			array(
 				'flow_id'      => (int) $request->get_param( 'flow_id' ),
 				'flow_step_id' => sanitize_text_field( $request->get_param( 'flow_step_id' ) ),
 				'index'        => (int) $request->get_param( 'index' ),
-			)
-		);
-
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] ) {
-			$status = 400;
-			if ( false !== strpos( $result['error'] ?? '', 'not found' ) ) {
-				$status = 404;
-			}
-
-			return new \WP_Error(
-				'queue_remove_failed',
-				$result['error'] ?? __( 'Failed to remove from queue.', 'data-machine' ),
-				array( 'status' => $status )
-			);
-		}
-
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'data'    => array(
+			),
+			RestResultSpec::item(
+				static function ( array $result ): array {
+					return array(
 					'flow_id'        => $result['flow_id'],
 					'flow_step_id'   => $result['flow_step_id'],
 					'removed_prompt' => $result['removed_prompt'],
 					'queue_length'   => $result['queue_length'],
-				),
-				'message' => $result['message'],
+					);
+				},
+				static function ( array $result ): array {
+					return array( 'message' => $result['message'] );
+				},
+				'queue_remove_failed',
+				__( 'Failed to remove from queue.', 'data-machine' ),
+				400,
+				array( self::class, 'queue_failure_status' )
 			)
 		);
 	}
@@ -484,47 +437,30 @@ class FlowQueue {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public static function handle_update_queue_item( $request ) {
-		$ability = wp_get_ability( 'datamachine/queue-update' );
-		if ( ! $ability ) {
-			return new \WP_Error( 'ability_not_found', 'Ability not found', array( 'status' => 500 ) );
-		}
-
-		$result = $ability->execute(
+		return RestAbilityExecutor::execute(
+			'datamachine/queue-update',
 			array(
 				'flow_id'      => (int) $request->get_param( 'flow_id' ),
 				'flow_step_id' => sanitize_text_field( $request->get_param( 'flow_step_id' ) ),
 				'index'        => (int) $request->get_param( 'index' ),
 				'prompt'       => $request->get_param( 'prompt' ),
-			)
-		);
-
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] ) {
-			$status = 400;
-			if ( false !== strpos( $result['error'] ?? '', 'not found' ) ) {
-				$status = 404;
-			}
-
-			return new \WP_Error(
-				'queue_update_failed',
-				$result['error'] ?? __( 'Failed to update queue item.', 'data-machine' ),
-				array( 'status' => $status )
-			);
-		}
-
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'data'    => array(
+			),
+			RestResultSpec::item(
+				static function ( array $result ): array {
+					return array(
 					'flow_id'      => $result['flow_id'],
 					'flow_step_id' => $result['flow_step_id'],
 					'index'        => $result['index'],
 					'queue_length' => $result['queue_length'],
-				),
-				'message' => $result['message'],
+					);
+				},
+				static function ( array $result ): array {
+					return array( 'message' => $result['message'] );
+				},
+				'queue_update_failed',
+				__( 'Failed to update queue item.', 'data-machine' ),
+				400,
+				array( self::class, 'queue_failure_status' )
 			)
 		);
 	}
@@ -538,46 +474,36 @@ class FlowQueue {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public static function handle_update_queue_mode( $request ) {
-		$ability = wp_get_ability( 'datamachine/queue-mode' );
-		if ( ! $ability ) {
-			return new \WP_Error( 'ability_not_found', 'Ability not found', array( 'status' => 500 ) );
-		}
-
-		$result = $ability->execute(
+		return RestAbilityExecutor::execute(
+			'datamachine/queue-mode',
 			array(
 				'flow_id'      => (int) $request->get_param( 'flow_id' ),
 				'flow_step_id' => sanitize_text_field( $request->get_param( 'flow_step_id' ) ),
 				'mode'         => sanitize_text_field( $request->get_param( 'mode' ) ),
-			)
-		);
-
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! $result['success'] ) {
-			$status = 400;
-			if ( false !== strpos( $result['error'] ?? '', 'not found' ) ) {
-				$status = 404;
-			}
-
-			return new \WP_Error(
-				'queue_mode_failed',
-				$result['error'] ?? __( 'Failed to update queue mode.', 'data-machine' ),
-				array( 'status' => $status )
-			);
-		}
-
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'data'    => array(
+			),
+			RestResultSpec::item(
+				static function ( array $result ): array {
+					return array(
 					'flow_id'      => $result['flow_id'],
 					'flow_step_id' => $result['flow_step_id'],
 					'queue_mode'   => $result['queue_mode'],
-				),
-				'message' => $result['message'] ?? __( 'Queue mode updated.', 'data-machine' ),
+					);
+				},
+				static function ( array $result ): array {
+					return array( 'message' => $result['message'] ?? __( 'Queue mode updated.', 'data-machine' ) );
+				},
+				'queue_mode_failed',
+				__( 'Failed to update queue mode.', 'data-machine' ),
+				400,
+				array( self::class, 'queue_failure_status' )
 			)
 		);
+	}
+
+	/**
+	 * Preserve queue endpoints' historical not-found status mapping.
+	 */
+	public static function queue_failure_status( array $result ): int {
+		return false !== strpos( $result['error'] ?? '', 'not found' ) ? 404 : 400;
 	}
 }

--- a/inc/Api/Flows/FlowQueue.php
+++ b/inc/Api/Flows/FlowQueue.php
@@ -246,11 +246,11 @@ class FlowQueue {
 			RestResultSpec::item(
 				static function ( array $result ): array {
 					return array(
-					'flow_id'      => $result['flow_id'],
-					'flow_step_id' => $result['flow_step_id'],
-					'queue'        => $result['queue'],
-					'count'        => $result['count'],
-					'queue_mode'   => $result['queue_mode'],
+						'flow_id'      => $result['flow_id'],
+						'flow_step_id' => $result['flow_step_id'],
+						'queue'        => $result['queue'],
+						'count'        => $result['count'],
+						'queue_mode'   => $result['queue_mode'],
 					);
 				},
 				null,
@@ -376,9 +376,9 @@ class FlowQueue {
 			RestResultSpec::item(
 				static function ( array $result ): array {
 					return array(
-					'flow_id'       => $result['flow_id'],
-					'flow_step_id'  => $result['flow_step_id'],
-					'cleared_count' => $result['cleared_count'],
+						'flow_id'       => $result['flow_id'],
+						'flow_step_id'  => $result['flow_step_id'],
+						'cleared_count' => $result['cleared_count'],
 					);
 				},
 				static function ( array $result ): array {
@@ -411,10 +411,10 @@ class FlowQueue {
 			RestResultSpec::item(
 				static function ( array $result ): array {
 					return array(
-					'flow_id'        => $result['flow_id'],
-					'flow_step_id'   => $result['flow_step_id'],
-					'removed_prompt' => $result['removed_prompt'],
-					'queue_length'   => $result['queue_length'],
+						'flow_id'        => $result['flow_id'],
+						'flow_step_id'   => $result['flow_step_id'],
+						'removed_prompt' => $result['removed_prompt'],
+						'queue_length'   => $result['queue_length'],
 					);
 				},
 				static function ( array $result ): array {
@@ -448,10 +448,10 @@ class FlowQueue {
 			RestResultSpec::item(
 				static function ( array $result ): array {
 					return array(
-					'flow_id'      => $result['flow_id'],
-					'flow_step_id' => $result['flow_step_id'],
-					'index'        => $result['index'],
-					'queue_length' => $result['queue_length'],
+						'flow_id'      => $result['flow_id'],
+						'flow_step_id' => $result['flow_step_id'],
+						'index'        => $result['index'],
+						'queue_length' => $result['queue_length'],
 					);
 				},
 				static function ( array $result ): array {
@@ -484,9 +484,9 @@ class FlowQueue {
 			RestResultSpec::item(
 				static function ( array $result ): array {
 					return array(
-					'flow_id'      => $result['flow_id'],
-					'flow_step_id' => $result['flow_step_id'],
-					'queue_mode'   => $result['queue_mode'],
+						'flow_id'      => $result['flow_id'],
+						'flow_step_id' => $result['flow_step_id'],
+						'queue_mode'   => $result['queue_mode'],
 					);
 				},
 				static function ( array $result ): array {

--- a/inc/Api/Flows/FlowSteps.php
+++ b/inc/Api/Flows/FlowSteps.php
@@ -16,6 +16,8 @@ use DataMachine\Abilities\FlowStep\GetFlowStepsAbility;
 use DataMachine\Abilities\FlowStep\UpdateFlowStepAbility;
 use DataMachine\Abilities\HandlerAbilities;
 use DataMachine\Abilities\StepTypeAbilities;
+use DataMachine\Api\RestAbilityExecutor;
+use DataMachine\Api\RestResultSpec;
 
 
 if ( ! defined( 'WPINC' ) ) {
@@ -195,20 +197,18 @@ class FlowSteps {
 			$input['user_message'] = $user_message;
 		}
 
-		$result = ( new UpdateFlowStepAbility() )->execute( $input );
-
-		if ( ! $result['success'] ) {
-			return new \WP_Error(
+		return RestAbilityExecutor::execute(
+			new UpdateFlowStepAbility(),
+			$input,
+			RestResultSpec::item(
+				static function (): array {
+					return array();
+				},
+				static function ( array $result ): array {
+					return array( 'message' => $result['message'] ?? __( 'Flow step updated successfully', 'data-machine' ) );
+				},
 				'update_failed',
-				$result['error'] ?? __( 'Failed to update flow step', 'data-machine' ),
-				array( 'status' => 500 )
-			);
-		}
-
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'message' => $result['message'] ?? __( 'Flow step updated successfully', 'data-machine' ),
+				__( 'Failed to update flow step', 'data-machine' )
 			)
 		);
 	}
@@ -235,29 +235,26 @@ class FlowSteps {
 	public static function handle_get_flow_config( $request ) {
 		$flow_id = (int) $request->get_param( 'flow_id' );
 
-		$result = ( new GetFlowStepsAbility() )->execute( array( 'flow_id' => $flow_id ) );
+		return RestAbilityExecutor::execute(
+			new GetFlowStepsAbility(),
+			array( 'flow_id' => $flow_id ),
+			RestResultSpec::item(
+				static function ( array $result ) use ( $flow_id ): array {
+					$flow_config = array();
+					foreach ( $result['steps'] as $step ) {
+						$flow_step_id                 = $step['flow_step_id'];
+						$flow_config[ $flow_step_id ] = $step;
+					}
 
-		if ( ! $result['success'] ) {
-			return new \WP_Error(
-				'flow_not_found',
-				$result['error'] ?? __( 'Flow not found.', 'data-machine' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		$flow_config = array();
-		foreach ( $result['steps'] as $step ) {
-			$flow_step_id                 = $step['flow_step_id'];
-			$flow_config[ $flow_step_id ] = $step;
-		}
-
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'data'    => array(
+					return array(
 					'flow_id'     => $flow_id,
 					'flow_config' => $flow_config,
-				),
+					);
+				},
+				null,
+				'flow_not_found',
+				__( 'Flow not found.', 'data-machine' ),
+				404
 			)
 		);
 	}
@@ -276,23 +273,20 @@ class FlowSteps {
 			);
 		}
 
-		$result = ( new GetFlowStepsAbility() )->execute( array( 'flow_step_id' => $flow_step_id ) );
-
-		if ( ! $result['success'] ) {
-			return new \WP_Error(
-				'flow_step_not_found',
-				$result['error'] ?? __( 'Flow step configuration not found.', 'data-machine' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'data'    => array(
+		return RestAbilityExecutor::execute(
+			new GetFlowStepsAbility(),
+			array( 'flow_step_id' => $flow_step_id ),
+			RestResultSpec::item(
+				static function ( array $result ) use ( $flow_step_id ): array {
+					return array(
 					'flow_step_id' => $flow_step_id,
 					'step_config'  => $result['steps'][0] ?? array(),
-				),
+					);
+				},
+				null,
+				'flow_step_not_found',
+				__( 'Flow step configuration not found.', 'data-machine' ),
+				404
 			)
 		);
 	}
@@ -424,26 +418,21 @@ class FlowSteps {
 		$flow_step_id = sanitize_text_field( $request->get_param( 'flow_step_id' ) );
 		$user_message = sanitize_textarea_field( $request->get_param( 'user_message' ) );
 
-		$result = ( new UpdateFlowStepAbility() )->execute(
+		return RestAbilityExecutor::execute(
+			new UpdateFlowStepAbility(),
 			array(
 				'flow_step_id' => $flow_step_id,
 				'user_message' => $user_message,
-			)
-		);
-
-		if ( ! $result['success'] ) {
-			return new \WP_Error(
+			),
+			RestResultSpec::item(
+				static function (): array {
+					return array();
+				},
+				static function (): array {
+					return array( 'message' => __( 'User message saved successfully', 'data-machine' ) );
+				},
 				'update_failed',
-				$result['error'] ?? __( 'Failed to update user message.', 'data-machine' ),
-				array( 'status' => 500 )
-			);
-		}
-
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'data'    => array(),
-				'message' => __( 'User message saved successfully', 'data-machine' ),
+				__( 'Failed to update user message.', 'data-machine' )
 			)
 		);
 	}

--- a/inc/Api/Flows/FlowSteps.php
+++ b/inc/Api/Flows/FlowSteps.php
@@ -247,8 +247,8 @@ class FlowSteps {
 					}
 
 					return array(
-					'flow_id'     => $flow_id,
-					'flow_config' => $flow_config,
+						'flow_id'     => $flow_id,
+						'flow_config' => $flow_config,
 					);
 				},
 				null,
@@ -279,8 +279,8 @@ class FlowSteps {
 			RestResultSpec::item(
 				static function ( array $result ) use ( $flow_step_id ): array {
 					return array(
-					'flow_step_id' => $flow_step_id,
-					'step_config'  => $result['steps'][0] ?? array(),
+						'flow_step_id' => $flow_step_id,
+						'step_config'  => $result['steps'][0] ?? array(),
 					);
 				},
 				null,

--- a/inc/Api/Pipelines/Pipelines.php
+++ b/inc/Api/Pipelines/Pipelines.php
@@ -17,6 +17,8 @@ use DataMachine\Abilities\Pipeline\DeletePipelineAbility;
 use DataMachine\Abilities\Pipeline\GetPipelinesAbility;
 use DataMachine\Abilities\Pipeline\ImportExportAbility;
 use DataMachine\Abilities\Pipeline\UpdatePipelineAbility;
+use DataMachine\Api\RestAbilityExecutor;
+use DataMachine\Api\RestResultSpec;
 use DataMachine\Core\Admin\DateFormatter;
 use DataMachine\Core\AbilityResult;
 use WP_REST_Server;
@@ -542,26 +544,24 @@ class Pipelines {
 			);
 		}
 
-		$result = ( new UpdatePipelineAbility() )->execute(
+		return RestAbilityExecutor::execute(
+			new UpdatePipelineAbility(),
 			array(
 				'pipeline_id'   => $pipeline_id,
 				'pipeline_name' => $params['pipeline_name'],
-			)
-		);
-
-		$error = AbilityResult::failure_to_wp_error( $result, 'update_failed', __( 'Failed to save pipeline title', 'data-machine' ) );
-		if ( $error ) {
-			return $error;
-		}
-
-		return rest_ensure_response(
-			array(
-				'success' => true,
-				'data'    => array(
+			),
+			RestResultSpec::item(
+				static function ( array $result ): array {
+					return array(
 					'pipeline_id'   => $result['pipeline_id'],
 					'pipeline_name' => $result['pipeline_name'],
-				),
-				'message' => $result['message'] ?? __( 'Pipeline title saved successfully', 'data-machine' ),
+					);
+				},
+				static function ( array $result ): array {
+					return array( 'message' => $result['message'] ?? __( 'Pipeline title saved successfully', 'data-machine' ) );
+				},
+				'update_failed',
+				__( 'Failed to save pipeline title', 'data-machine' )
 			)
 		);
 	}

--- a/inc/Api/Pipelines/Pipelines.php
+++ b/inc/Api/Pipelines/Pipelines.php
@@ -553,8 +553,8 @@ class Pipelines {
 			RestResultSpec::item(
 				static function ( array $result ): array {
 					return array(
-					'pipeline_id'   => $result['pipeline_id'],
-					'pipeline_name' => $result['pipeline_name'],
+						'pipeline_id'   => $result['pipeline_id'],
+						'pipeline_name' => $result['pipeline_name'],
 					);
 				},
 				static function ( array $result ): array {

--- a/inc/Api/RestAbilityExecutor.php
+++ b/inc/Api/RestAbilityExecutor.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * REST ability execution helper.
+ *
+ * @package DataMachine\Api
+ */
+
+namespace DataMachine\Api;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Executes abilities and applies a REST result spec at controller boundaries.
+ */
+class RestAbilityExecutor {
+
+	/**
+	 * Execute an ability and return the configured REST response.
+	 *
+	 * @param string|object   $ability Ability slug or object with execute().
+	 * @param array           $input   Ability input.
+	 * @param RestResultSpec  $spec    REST result presentation spec.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public static function execute( $ability, array $input, RestResultSpec $spec ) {
+		if ( is_string( $ability ) ) {
+			$ability = wp_get_ability( $ability );
+		}
+
+		if ( ! is_object( $ability ) || ! method_exists( $ability, 'execute' ) ) {
+			return new \WP_Error( 'ability_not_found', __( 'Ability not found', 'data-machine' ), array( 'status' => 500 ) );
+		}
+
+		return $spec->response( $ability->execute( $input ) );
+	}
+}

--- a/inc/Api/RestResultSpec.php
+++ b/inc/Api/RestResultSpec.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * REST ability result presentation spec.
+ *
+ * @package DataMachine\Api
+ */
+
+namespace DataMachine\Api;
+
+use DataMachine\Core\AbilityResult;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Describes how an ability result should be exposed through REST.
+ */
+class RestResultSpec {
+
+	/** @var callable|null */
+	private $data_callback;
+
+	/** @var callable|null */
+	private $extra_callback;
+
+	/** @var callable|null */
+	private $failure_status_callback;
+
+	private string $default_code;
+	private string $default_message;
+	private int $default_status;
+
+	/**
+	 * @param callable|null $data_callback           Maps normalized successful result to response data.
+	 * @param callable|null $extra_callback          Maps normalized successful result to top-level extras.
+	 * @param string        $default_code            Default error code.
+	 * @param string        $default_message         Default error message.
+	 * @param int           $default_status          Default HTTP status for legacy failures.
+	 * @param callable|null $failure_status_callback Maps normalized failed result to HTTP status.
+	 */
+	public function __construct( $data_callback = null, $extra_callback = null, string $default_code = 'ability_failed', string $default_message = 'Ability execution failed.', int $default_status = 500, $failure_status_callback = null ) {
+		$this->data_callback           = $data_callback;
+		$this->extra_callback          = $extra_callback;
+		$this->default_code            = $default_code;
+		$this->default_message         = $default_message;
+		$this->default_status          = $default_status;
+		$this->failure_status_callback = $failure_status_callback;
+	}
+
+	/**
+	 * Create a single-resource REST response spec.
+	 *
+	 * @param callable|null $data_callback           Maps normalized successful result to response data.
+	 * @param callable|null $extra_callback          Maps normalized successful result to top-level extras.
+	 * @param string        $default_code            Default error code.
+	 * @param string        $default_message         Default error message.
+	 * @param int           $default_status          Default HTTP status for legacy failures.
+	 * @param callable|null $failure_status_callback Maps normalized failed result to HTTP status.
+	 * @return self
+	 */
+	public static function item( $data_callback = null, $extra_callback = null, string $default_code = 'ability_failed', string $default_message = 'Ability execution failed.', int $default_status = 500, $failure_status_callback = null ): self {
+		return new self( $data_callback, $extra_callback, $default_code, $default_message, $default_status, $failure_status_callback );
+	}
+
+	/**
+	 * Convert an ability result to a REST response or error.
+	 *
+	 * @param mixed $result Ability execution result.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function response( $result ) {
+		$normalized = AbilityResult::normalize( $result );
+
+		if ( is_array( $normalized ) && isset( $normalized['success'] ) && ! $normalized['success'] && ! isset( $normalized['status'] ) && $this->failure_status_callback ) {
+			$status = call_user_func( $this->failure_status_callback, $normalized );
+			if ( null !== $status ) {
+				$normalized['status'] = (int) $status;
+			}
+		}
+
+		$data = null;
+		if ( is_array( $normalized ) && ( ! isset( $normalized['success'] ) || $normalized['success'] ) && $this->data_callback ) {
+			$data = call_user_func( $this->data_callback, $normalized );
+		}
+
+		$extra = array();
+		if ( is_array( $normalized ) && ( ! isset( $normalized['success'] ) || $normalized['success'] ) && $this->extra_callback ) {
+			$extra = call_user_func( $this->extra_callback, $normalized );
+			if ( ! is_array( $extra ) ) {
+				$extra = array();
+			}
+		}
+
+		return AbilityResult::rest_item_response( $normalized, $data, $extra, $this->default_code, $this->default_message, $this->default_status );
+	}
+}

--- a/tests/ability-result-wp-error-smoke.php
+++ b/tests/ability-result-wp-error-smoke.php
@@ -55,8 +55,25 @@ if ( ! function_exists( 'rest_ensure_response' ) ) {
 	}
 }
 
-require_once __DIR__ . '/../inc/Core/AbilityResult.php';
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = null ) {
+		unset( $domain );
+		return $text;
+	}
+}
 
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $slug ) {
+		return $GLOBALS['datamachine_test_abilities'][ $slug ] ?? null;
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/AbilityResult.php';
+require_once __DIR__ . '/../inc/Api/RestResultSpec.php';
+require_once __DIR__ . '/../inc/Api/RestAbilityExecutor.php';
+
+use DataMachine\Api\RestAbilityExecutor;
+use DataMachine\Api\RestResultSpec;
 use DataMachine\Core\AbilityResult;
 
 $failed = 0;
@@ -241,6 +258,67 @@ $item_rest = AbilityResult::rest_item_response(
 $item_rest = $rest_payload( $item_rest );
 $assert( 'REST item presenter preserves success flag', true === ( $item_rest['success'] ?? null ) );
 $assert( 'REST item presenter wraps mutation fields under data', 3 === ( $item_rest['data']['paused'] ?? null ) );
+
+$rest_spec_response = RestResultSpec::item(
+	static function ( array $result ): array {
+		return array( 'queue_length' => $result['queue_length'] );
+	},
+	static function ( array $result ): array {
+		return array( 'message' => $result['message'] );
+	},
+	'queue_update_failed',
+	'Failed to update queue item.',
+	400
+)->response(
+	array(
+		'success'      => true,
+		'queue_length' => 4,
+		'message'      => 'Queue updated.',
+	)
+);
+$rest_spec_response = $rest_payload( $rest_spec_response );
+$assert( 'REST result spec maps success data', 4 === ( $rest_spec_response['data']['queue_length'] ?? null ) );
+$assert( 'REST result spec maps top-level extras', 'Queue updated.' === ( $rest_spec_response['message'] ?? null ) );
+
+$rest_spec_error = RestResultSpec::item(
+	null,
+	null,
+	'queue_list_failed',
+	'Failed to list queue.',
+	400,
+	static function ( array $result ): int {
+		return false !== strpos( $result['error'] ?? '', 'not found' ) ? 404 : 400;
+	}
+)->response(
+	array(
+		'success' => false,
+		'error'   => 'Flow not found.',
+	)
+);
+$assert( 'REST result spec applies failure status callback', 404 === ( $rest_spec_error->get_error_data()['status'] ?? null ) );
+
+$GLOBALS['datamachine_test_abilities']['datamachine/test-rest'] = new class() {
+	public function execute( array $input ): array {
+		return array(
+			'success' => true,
+			'value'   => $input['value'],
+		);
+	}
+};
+$executor_response = RestAbilityExecutor::execute(
+	'datamachine/test-rest',
+	array( 'value' => 'ok' ),
+	RestResultSpec::item(
+		static function ( array $result ): array {
+			return array( 'value' => $result['value'] );
+		}
+	)
+);
+$executor_response = $rest_payload( $executor_response );
+$assert( 'REST ability executor resolves ability slug and applies spec', 'ok' === ( $executor_response['data']['value'] ?? null ) );
+
+$missing_ability_error = RestAbilityExecutor::execute( 'datamachine/missing', array(), RestResultSpec::item() );
+$assert( 'REST ability executor returns WP_Error for missing abilities', $missing_ability_error instanceof WP_Error );
 
 $cli_rows = array(
 	array(


### PR DESCRIPTION
## Summary
- Add generic REST ability transport helpers: `RestAbilityExecutor` and `RestResultSpec`.
- Convert duplicated REST ability execution/result wrapping in flow queue endpoints.
- Convert representative flow-step and pipeline title endpoints to use the shared REST result spec.
- Extend the existing ability result smoke test to cover REST spec mapping, failure status callbacks, ability lookup, and missing ability errors.

## Verification
- `php -l inc/Api/RestResultSpec.php && php -l inc/Api/RestAbilityExecutor.php && php -l inc/Api/Flows/FlowQueue.php && php -l inc/Api/Flows/FlowSteps.php && php -l inc/Api/Pipelines/Pipelines.php && php -l tests/ability-result-wp-error-smoke.php`
- `php tests/ability-result-wp-error-smoke.php` (46 assertions passed)
- `./vendor/bin/phpcs inc/Api/RestResultSpec.php inc/Api/RestAbilityExecutor.php inc/Api/Flows/FlowQueue.php inc/Api/Flows/FlowSteps.php inc/Api/Pipelines/Pipelines.php tests/ability-result-wp-error-smoke.php`

## Not run
- `homeboy test data-machine --changed-since origin/main` was blocked by Homeboy resource policy because the local machine was warm and this changed-since test selection is currently local-only. I did not force a hot local run.

## Scope note
- Checked PR #2693 before implementation; it is merged and scoped to shared Action Scheduler drain service files. This PR does not touch that drain service work.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the REST ability result helper, converted representative REST controller callsites, added smoke coverage, and ran verification for Chris to review.