### PR TITLE
Decouple bundle source and egress provider vocabulary

### DIFF
--- a/inc/Engine/Bundle/BundleEgressTargetRegistry.php
+++ b/inc/Engine/Bundle/BundleEgressTargetRegistry.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Bundle egress target registry.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registry for bundle run-artifact egress target vocabulary.
+ */
+final class BundleEgressTargetRegistry {
+
+	/** @return string[] */
+	public static function targets(): array {
+		$targets = function_exists( 'apply_filters' )
+			? (array) apply_filters( 'datamachine_bundle_run_artifact_egress_targets', BundleSchema::RUN_ARTIFACT_EGRESS_TARGETS )
+			: BundleSchema::RUN_ARTIFACT_EGRESS_TARGETS;
+
+		$normalized = array();
+		foreach ( $targets as $target ) {
+			if ( ! is_string( $target ) ) {
+				continue;
+			}
+			$target = strtolower( trim( $target ) );
+			$target = preg_replace( '/[^a-z0-9_-]+/', '-', $target );
+			$target = trim( is_string( $target ) ? $target : '', '-' );
+			if ( '' !== $target ) {
+				$normalized[] = $target;
+			}
+		}
+
+		$normalized = array_values( array_unique( $normalized ) );
+		sort( $normalized, SORT_STRING );
+		return $normalized;
+	}
+}

--- a/inc/Engine/Bundle/BundleSchema.php
+++ b/inc/Engine/Bundle/BundleSchema.php
@@ -254,13 +254,14 @@ final class BundleSchema {
 			return array();
 		}
 
-		$normalized = array();
+		$allowed_targets = BundleEgressTargetRegistry::targets();
+		$normalized      = array();
 		foreach ( $targets as $target ) {
 			if ( ! is_string( $target ) ) {
 				continue;
 			}
 			$target = self::sanitize_key( $target );
-			if ( in_array( $target, self::RUN_ARTIFACT_EGRESS_TARGETS, true ) ) {
+			if ( in_array( $target, $allowed_targets, true ) ) {
 				$normalized[] = $target;
 			}
 		}

--- a/inc/Engine/Bundle/BundleSource.php
+++ b/inc/Engine/Bundle/BundleSource.php
@@ -84,9 +84,9 @@ final class BundleSource {
 			return $source;
 		}
 
-		$fetch_url = self::normalize_github_url( $source, $context );
+		$fetch_url = self::normalize_remote_url( $source, $context );
 
-		if ( ! preg_match( '#\.(zip|json)(\?.*)?$#i', $fetch_url ) && ! self::is_github_api_zipball_url( $fetch_url ) ) {
+		if ( ! preg_match( '#\.(zip|json)(\?.*)?$#i', $fetch_url ) && ! self::resolver_accepts_fetch_url( $fetch_url ) ) {
 			return new WP_Error(
 				'datamachine_bundle_source_invalid',
 				sprintf(
@@ -146,8 +146,8 @@ final class BundleSource {
 		// api.github.com/repos/<o>/<r>/zipball/<ref> URLs have no .zip
 		// suffix but always produce a zip archive.
 		$expected_ext = preg_match( '#\.(zip|json)(\?.*)?$#i', $fetch_url, $m ) ? strtolower( $m[1] ) : '';
-		if ( '' === $expected_ext && self::is_github_api_zipball_url( $fetch_url ) ) {
-			$expected_ext = 'zip';
+		if ( '' === $expected_ext ) {
+			$expected_ext = self::resolver_expected_extension( $fetch_url );
 		}
 		if ( '' !== $expected_ext ) {
 			$with_ext = $temp_file . '.' . $expected_ext;
@@ -333,7 +333,7 @@ final class BundleSource {
 		}
 
 		$etag = (string) wp_remote_retrieve_header( $response, 'etag' );
-		$sha  = self::parse_sha_from_etag( $etag );
+		$sha  = self::revision_from_etag( $current_url, $etag );
 
 		return array(
 			'path' => $temp_path,
@@ -507,105 +507,55 @@ final class BundleSource {
 	 * @return string Normalized URL.
 	 */
 	public static function normalize_github_url( string $url, array $context = array() ): string {
+		return ( new GitHubBundleSourceResolver() )->normalize( $url, $context ) ?? trim( $url );
+	}
+
+	/**
+	 * Normalize a remote URL through registered source resolvers.
+	 *
+	 * @param string $url     URL to normalize.
+	 * @param array  $context Resolution context.
+	 * @return string
+	 */
+	public static function normalize_remote_url( string $url, array $context = array() ): string {
 		$url = trim( $url );
-
-		if ( ! preg_match( '#^https?://github\.com/#i', $url ) && ! preg_match( '#^https?://raw\.githubusercontent\.com/#i', $url ) ) {
-			return $url;
-		}
-
-		// Already a raw.githubusercontent.com URL — pass through.
-		if ( preg_match( '#^https?://raw\.githubusercontent\.com/#i', $url ) ) {
-			return $url;
-		}
-
-		// archive/refs/heads/<branch>.zip → API zipball when token configured.
-		if ( preg_match( '#^https?://github\.com/([^/]+)/([^/]+)/archive/refs/heads/(.+)\.zip$#i', $url, $m ) ) {
-			return self::route_github_archive( $m[1], $m[2], $m[3], $url, $context );
-		}
-
-		// archive/<sha>.zip → API zipball when token configured.
-		if ( preg_match( '#^https?://github\.com/([^/]+)/([^/]+)/archive/([0-9a-f]{7,40})\.zip$#i', $url, $m ) ) {
-			return self::route_github_archive( $m[1], $m[2], $m[3], $url, $context );
-		}
-
-		// blob/<ref>/<path> → raw URL.
-		if ( preg_match( '#^https?://github\.com/([^/]+)/([^/]+)/blob/(.+)$#i', $url, $m ) ) {
-			return "https://raw.githubusercontent.com/{$m[1]}/{$m[2]}/{$m[3]}";
-		}
-
-		// raw/<ref>/<path> → raw URL.
-		if ( preg_match( '#^https?://github\.com/([^/]+)/([^/]+)/raw/(.+)$#i', $url, $m ) ) {
-			return "https://raw.githubusercontent.com/{$m[1]}/{$m[2]}/{$m[3]}";
-		}
-
-		// tree/<branch> → API zipball when token configured, else web-host archive.
-		if ( preg_match( '#^https?://github\.com/([^/]+)/([^/]+)/tree/([^/]+)/?$#i', $url, $m ) ) {
-			return self::route_github_archive( $m[1], $m[2], $m[3], $url, $context );
+		foreach ( BundleSourceResolverRegistry::source_resolvers() as $resolver ) {
+			$normalized = $resolver->normalize( $url, $context );
+			if ( is_string( $normalized ) && '' !== $normalized ) {
+				return $normalized;
+			}
 		}
 
 		return $url;
 	}
 
-	/**
-	 * Choose between API and web-host endpoints for a github.com archive.
-	 *
-	 * Returns the API endpoint when a token is available for
-	 * `api.github.com` (CLI/env/constant/option/filter). Falls back to the
-	 * web-host archive URL otherwise so unauthenticated public installs
-	 * keep using the same shape they always have.
-	 *
-	 * @param string $owner       Repo owner (URL segment, not validated).
-	 * @param string $repo        Repo name (URL segment, not validated).
-	 * @param string $ref         Branch name or commit SHA.
-	 * @param string $original    Original web-host URL — returned as the
-	 *                            fallback when no token is available.
-	 * @param array  $context     Resolution context.
-	 * @return string
-	 */
-	private static function route_github_archive( string $owner, string $repo, string $ref, string $original, array $context ): string {
-		// BundleSourceAuth lives in the same namespace and loads via the
-		// PSR-4 autoloader. Use class_exists() to keep the dependency
-		// soft for any consumer that imports BundleSource without the
-		// auth helper (e.g. test harnesses).
-		if ( class_exists( BundleSourceAuth::class ) ) {
-			$token = BundleSourceAuth::token_for( 'https://api.github.com/', $context );
-			if ( null !== $token && '' !== $token ) {
-				return sprintf(
-					'https://api.github.com/repos/%s/%s/zipball/%s',
-					$owner,
-					$repo,
-					$ref
-				);
+	private static function resolver_accepts_fetch_url( string $url ): bool {
+		foreach ( BundleSourceResolverRegistry::source_resolvers() as $resolver ) {
+			if ( $resolver->accepts_fetch_url( $url ) ) {
+				return true;
 			}
 		}
-
-		// Default to the web-host archive shape (works unauthenticated for
-		// public repos, matches the long-standing behavior).
-		if ( preg_match( '#/archive/refs/heads/.+\.zip$#i', $original )
-			|| preg_match( '#/archive/[0-9a-f]{7,40}\.zip$#i', $original )
-		) {
-			return $original;
-		}
-
-		return sprintf(
-			'https://github.com/%s/%s/archive/refs/heads/%s.zip',
-			$owner,
-			$repo,
-			$ref
-		);
+		return false;
 	}
 
-	/**
-	 * Is this URL the api.github.com zipball endpoint?
-	 *
-	 * @param string $url URL to test.
-	 * @return bool
-	 */
-	private static function is_github_api_zipball_url( string $url ): bool {
-		return (bool) preg_match(
-			'#^https?://api\.github\.com/repos/[^/]+/[^/]+/(zipball|tarball)(/|$)#i',
-			$url
-		);
+	private static function resolver_expected_extension( string $url ): string {
+		foreach ( BundleSourceResolverRegistry::source_resolvers() as $resolver ) {
+			$extension = $resolver->expected_extension( $url );
+			if ( '' !== $extension ) {
+				return $extension;
+			}
+		}
+		return '';
+	}
+
+	private static function revision_from_etag( string $url, string $etag ): ?string {
+		foreach ( BundleSourceResolverRegistry::source_resolvers() as $resolver ) {
+			$revision = $resolver->revision_from_etag( $url, $etag );
+			if ( null !== $revision && '' !== $revision ) {
+				return $revision;
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/inc/Engine/Bundle/BundleSourceAuth.php
+++ b/inc/Engine/Bundle/BundleSourceAuth.php
@@ -1,13 +1,10 @@
 <?php
 /**
- * Built-in GitHub.com / GHE auth helper for BundleSource downloads.
+ * BundleSource download auth facade.
  *
- * Hooks into datamachine_bundle_source_download_args to attach an
- * Authorization: Bearer header when:
- *
- *   - The fetch URL host is github.com or raw.githubusercontent.com, OR
- *   - The fetch URL host matches an entry in the
- *     datamachine_bundle_source_ghe_hosts filter map.
+ * Hooks registered auth resolvers into datamachine_bundle_source_download_args.
+ * The built-in resolver preserves GitHub.com / GHE token behavior while other
+ * providers can register resolvers via datamachine_bundle_source_auth_resolvers.
  *
  * Token resolution chain (first hit wins):
  *
@@ -100,12 +97,27 @@ final class BundleSourceAuth {
 		}
 		$registered = true;
 
-		add_filter(
-			'datamachine_bundle_source_download_args',
-			array( self::class, 'inject_github_auth' ),
-			10,
-			3
-		);
+		add_filter( 'datamachine_bundle_source_download_args', array( self::class, 'inject_auth' ), 10, 3 );
+	}
+
+	/**
+	 * Filter callback — apply registered auth resolvers to request args.
+	 *
+	 * @param array  $args      Request args.
+	 * @param string $source    Original source string.
+	 * @param string $fetch_url Normalized URL.
+	 * @return array
+	 */
+	public static function inject_auth( array $args, string $source, string $fetch_url ): array {
+		$context = is_array( $args['datamachine_bundle_source']['context'] ?? null )
+			? (array) $args['datamachine_bundle_source']['context']
+			: array();
+
+		foreach ( BundleSourceResolverRegistry::auth_resolvers() as $resolver ) {
+			$args = $resolver->apply( $args, $source, $fetch_url, $context );
+		}
+
+		return $args;
 	}
 
 	/**
@@ -118,41 +130,10 @@ final class BundleSourceAuth {
 	 * @return array
 	 */
 	public static function inject_github_auth( array $args, string $source, string $fetch_url ): array {
-		unset( $source );
-
-		$host = self::host_for( $fetch_url );
-		if ( '' === $host ) {
-			return $args;
-		}
-
-		// Already-configured Authorization header? Respect it; some
-		// callers manage their own token chain via the filter directly.
-		if ( ! empty( $args['headers']['Authorization'] ) || ! empty( $args['headers']['authorization'] ) ) {
-			return $args;
-		}
-
 		$context   = is_array( $args['datamachine_bundle_source']['context'] ?? null )
 			? (array) $args['datamachine_bundle_source']['context']
 			: array();
-		$is_github = self::is_github_host( $host );
-		$is_ghe    = ! $is_github && array_key_exists( $host, self::ghe_hosts() );
-
-		if ( ! $is_github && ! $is_ghe ) {
-			return $args;
-		}
-
-		$token = self::token_for( $fetch_url, $context );
-		if ( null === $token || '' === $token ) {
-			return $args;
-		}
-
-		if ( ! is_array( $args['headers'] ?? null ) ) {
-			$args['headers'] = array();
-		}
-
-		$args['headers']['Authorization'] = 'Bearer ' . $token;
-
-		return $args;
+		return ( new GitHubBundleSourceAuthResolver() )->apply( $args, $source, $fetch_url, $context );
 	}
 
 	/**
@@ -170,56 +151,11 @@ final class BundleSourceAuth {
 	 * @return string|null
 	 */
 	public static function token_for( string $fetch_url, array $context = array() ): ?string {
-		$host = self::host_for( $fetch_url );
-
-		// 1. CLI-supplied token short-circuits everything.
-		if ( ! empty( $context['cli_token'] ) ) {
-			$cli_token = trim( (string) $context['cli_token'] );
-			if ( '' !== $cli_token ) {
-				return $cli_token;
+		foreach ( BundleSourceResolverRegistry::auth_resolvers() as $resolver ) {
+			$token = $resolver->token_for( $fetch_url, $context );
+			if ( null !== $token && '' !== $token ) {
+				return $token;
 			}
-		}
-
-		$env_var = self::env_var_for_host( $host );
-
-		// 2. Environment variable.
-		if ( '' !== $env_var ) {
-			$from_env = getenv( $env_var );
-			if ( is_string( $from_env ) && '' !== trim( $from_env ) ) {
-				return trim( $from_env );
-			}
-		}
-
-		// 3. PHP constant of the same name.
-		if ( '' !== $env_var && defined( $env_var ) ) {
-			$from_const = constant( $env_var );
-			if ( is_string( $from_const ) && '' !== trim( $from_const ) ) {
-				return trim( $from_const );
-			}
-		}
-
-		// 4. WP option (github.com only).
-		if ( self::is_github_host( $host ) && function_exists( 'get_option' ) ) {
-			$from_option = (string) get_option( self::GITHUB_TOKEN_OPTION, '' );
-			if ( '' !== trim( $from_option ) ) {
-				return trim( $from_option );
-			}
-		}
-
-		/**
-		 * Filter fallback for callers that store secrets elsewhere
-		 * (sigillo, AWS Secrets Manager, etc.).
-		 *
-		 * Return null/empty to leave the resolution unresolved.
-		 *
-		 * @param string|null $token     Current candidate token (always null when this fires).
-		 * @param string      $fetch_url Normalized URL.
-		 * @param string      $host      Lower-cased host.
-		 * @param array       $context   Resolution context.
-		 */
-		$filtered = apply_filters( 'datamachine_bundle_source_token_for_url', null, $fetch_url, $host, $context );
-		if ( is_string( $filtered ) && '' !== trim( $filtered ) ) {
-			return trim( $filtered );
 		}
 
 		return null;
@@ -248,7 +184,7 @@ final class BundleSourceAuth {
 		 *
 		 * @param array<string,string> $hosts Host → env/constant name map.
 		 */
-		$hosts = (array) apply_filters( 'datamachine_bundle_source_ghe_hosts', array() );
+		$hosts = function_exists( 'apply_filters' ) ? (array) apply_filters( 'datamachine_bundle_source_ghe_hosts', array() ) : array();
 
 		$normalized = array();
 		foreach ( $hosts as $host => $env_var ) {
@@ -281,59 +217,5 @@ final class BundleSourceAuth {
 		unset( $args['datamachine_bundle_source'] );
 
 		return $args;
-	}
-
-	/**
-	 * Lower-cased host portion of a URL, or '' on parse failure.
-	 *
-	 * @param string $url URL.
-	 * @return string
-	 */
-	private static function host_for( string $url ): string {
-		$host = wp_parse_url( $url, PHP_URL_HOST );
-		if ( ! is_string( $host ) || '' === $host ) {
-			return '';
-		}
-		return strtolower( $host );
-	}
-
-	/**
-	 * Is the given host one of the built-in github.com hosts?
-	 *
-	 * Includes the API host (`api.github.com`) so the same
-	 * `DATAMACHINE_GITHUB_TOKEN` env/constant/option slot covers all
-	 * three endpoints used by the bundle resolver.
-	 *
-	 * @param string $host Lower-cased host.
-	 * @return bool
-	 */
-	private static function is_github_host( string $host ): bool {
-		return 'github.com' === $host
-			|| 'raw.githubusercontent.com' === $host
-			|| 'api.github.com' === $host;
-	}
-
-	/**
-	 * Resolve the env var / constant name to read for tokens scoped to
-	 * a given host. Returns '' when the host has no configured slot.
-	 *
-	 * @param string $host Lower-cased host.
-	 * @return string
-	 */
-	private static function env_var_for_host( string $host ): string {
-		if ( '' === $host ) {
-			return '';
-		}
-
-		if ( self::is_github_host( $host ) ) {
-			return self::GITHUB_TOKEN_ENV;
-		}
-
-		$ghe_hosts = self::ghe_hosts();
-		if ( array_key_exists( $host, $ghe_hosts ) ) {
-			return $ghe_hosts[ $host ];
-		}
-
-		return '';
 	}
 }

--- a/inc/Engine/Bundle/BundleSourceAuthResolverInterface.php
+++ b/inc/Engine/Bundle/BundleSourceAuthResolverInterface.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Bundle source authentication resolver contract.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Applies provider-specific auth to bundle source downloads.
+ */
+interface BundleSourceAuthResolverInterface {
+
+	/**
+	 * Apply auth headers to request args when this resolver owns the fetch URL.
+	 *
+	 * @param array  $args      Request args.
+	 * @param string $source    Original source URL.
+	 * @param string $fetch_url Normalized fetch URL.
+	 * @param array  $context   Resolution context.
+	 * @return array
+	 */
+	public function apply( array $args, string $source, string $fetch_url, array $context = array() ): array;
+
+	/**
+	 * Resolve a token for the fetch URL, or null when unavailable.
+	 *
+	 * @param string $fetch_url Normalized fetch URL.
+	 * @param array  $context   Resolution context.
+	 * @return string|null
+	 */
+	public function token_for( string $fetch_url, array $context = array() ): ?string;
+}

--- a/inc/Engine/Bundle/BundleSourceResolverInterface.php
+++ b/inc/Engine/Bundle/BundleSourceResolverInterface.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Bundle source resolver contract.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalizes provider-specific bundle source URLs into fetchable URLs.
+ */
+interface BundleSourceResolverInterface {
+
+	/**
+	 * Normalize a remote source URL for download.
+	 *
+	 * Return null when this resolver does not own the source.
+	 *
+	 * @param string $source  Original source URL.
+	 * @param array  $context Resolution context.
+	 * @return string|null Fetch URL or null when unsupported.
+	 */
+	public function normalize( string $source, array $context = array() ): ?string;
+
+	/**
+	 * Whether this resolver accepts a normalized fetch URL without a file suffix.
+	 *
+	 * @param string $fetch_url Normalized fetch URL.
+	 * @return bool
+	 */
+	public function accepts_fetch_url( string $fetch_url ): bool;
+
+	/**
+	 * Expected archive extension for a normalized fetch URL, if provider-specific.
+	 *
+	 * @param string $fetch_url Normalized fetch URL.
+	 * @return string Empty string when the extension should be read from the URL.
+	 */
+	public function expected_extension( string $fetch_url ): string;
+
+	/**
+	 * Parse a source revision from the fetch response.
+	 *
+	 * @param string $fetch_url Normalized fetch URL.
+	 * @param string $etag      Response ETag header.
+	 * @return string|null
+	 */
+	public function revision_from_etag( string $fetch_url, string $etag ): ?string;
+}

--- a/inc/Engine/Bundle/BundleSourceResolverRegistry.php
+++ b/inc/Engine/Bundle/BundleSourceResolverRegistry.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Bundle source resolver registry.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registry for provider-specific bundle source resolvers.
+ */
+final class BundleSourceResolverRegistry {
+
+	/** @var BundleSourceResolverInterface[]|null */
+	private static ?array $source_resolvers = null;
+
+	/** @var BundleSourceAuthResolverInterface[]|null */
+	private static ?array $auth_resolvers = null;
+
+	/** @return BundleSourceResolverInterface[] */
+	public static function source_resolvers(): array {
+		if ( null === self::$source_resolvers ) {
+			self::$source_resolvers = array(
+				new GitHubBundleSourceResolver(),
+			);
+		}
+
+		$resolvers = function_exists( 'apply_filters' )
+			? (array) apply_filters( 'datamachine_bundle_source_resolvers', self::$source_resolvers )
+			: self::$source_resolvers;
+
+		return array_values(
+			array_filter(
+				$resolvers,
+				static fn( $resolver ) => $resolver instanceof BundleSourceResolverInterface
+			)
+		);
+	}
+
+	/** @return BundleSourceAuthResolverInterface[] */
+	public static function auth_resolvers(): array {
+		if ( null === self::$auth_resolvers ) {
+			self::$auth_resolvers = array(
+				new GitHubBundleSourceAuthResolver(),
+			);
+		}
+
+		$resolvers = function_exists( 'apply_filters' )
+			? (array) apply_filters( 'datamachine_bundle_source_auth_resolvers', self::$auth_resolvers )
+			: self::$auth_resolvers;
+
+		return array_values(
+			array_filter(
+				$resolvers,
+				static fn( $resolver ) => $resolver instanceof BundleSourceAuthResolverInterface
+			)
+		);
+	}
+}

--- a/inc/Engine/Bundle/GitHubBundleSourceAuthResolver.php
+++ b/inc/Engine/Bundle/GitHubBundleSourceAuthResolver.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * GitHub bundle source auth resolver.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Token resolution + GitHub/GHE Authorization injection.
+ */
+final class GitHubBundleSourceAuthResolver implements BundleSourceAuthResolverInterface {
+
+	/**
+	 * Apply GitHub/GHE auth headers when applicable.
+	 *
+	 * @param array  $args      Request args.
+	 * @param string $source    Original source URL.
+	 * @param string $fetch_url Normalized fetch URL.
+	 * @param array  $context   Resolution context.
+	 * @return array
+	 */
+	public function apply( array $args, string $source, string $fetch_url, array $context = array() ): array {
+		unset( $source );
+
+		$host = $this->host_for( $fetch_url );
+		if ( '' === $host ) {
+			return $args;
+		}
+
+		if ( ! empty( $args['headers']['Authorization'] ) || ! empty( $args['headers']['authorization'] ) ) {
+			return $args;
+		}
+
+		$is_github = $this->is_github_host( $host );
+		$is_ghe    = ! $is_github && array_key_exists( $host, BundleSourceAuth::ghe_hosts() );
+		if ( ! $is_github && ! $is_ghe ) {
+			return $args;
+		}
+
+		$token = $this->token_for( $fetch_url, $context );
+		if ( null === $token || '' === $token ) {
+			return $args;
+		}
+
+		if ( ! is_array( $args['headers'] ?? null ) ) {
+			$args['headers'] = array();
+		}
+
+		$args['headers']['Authorization'] = 'Bearer ' . $token;
+		return $args;
+	}
+
+	/**
+	 * Resolve a token for a given fetch URL.
+	 *
+	 * @param string $fetch_url Normalized fetch URL.
+	 * @param array  $context   Resolution context.
+	 * @return string|null
+	 */
+	public function token_for( string $fetch_url, array $context = array() ): ?string {
+		$host = $this->host_for( $fetch_url );
+
+		if ( ! empty( $context['cli_token'] ) ) {
+			$cli_token = trim( (string) $context['cli_token'] );
+			if ( '' !== $cli_token ) {
+				return $cli_token;
+			}
+		}
+
+		$env_var = $this->env_var_for_host( $host );
+
+		if ( '' !== $env_var ) {
+			$from_env = getenv( $env_var );
+			if ( is_string( $from_env ) && '' !== trim( $from_env ) ) {
+				return trim( $from_env );
+			}
+		}
+
+		if ( '' !== $env_var && defined( $env_var ) ) {
+			$from_const = constant( $env_var );
+			if ( is_string( $from_const ) && '' !== trim( $from_const ) ) {
+				return trim( $from_const );
+			}
+		}
+
+		if ( $this->is_github_host( $host ) && function_exists( 'get_option' ) ) {
+			$from_option = (string) get_option( BundleSourceAuth::GITHUB_TOKEN_OPTION, '' );
+			if ( '' !== trim( $from_option ) ) {
+				return trim( $from_option );
+			}
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$filtered = apply_filters( 'datamachine_bundle_source_token_for_url', null, $fetch_url, $host, $context );
+			if ( is_string( $filtered ) && '' !== trim( $filtered ) ) {
+				return trim( $filtered );
+			}
+		}
+
+		return null;
+	}
+
+	private function host_for( string $url ): string {
+		$host = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url, PHP_URL_HOST ) : parse_url( $url, PHP_URL_HOST );
+		if ( ! is_string( $host ) || '' === $host ) {
+			return '';
+		}
+		return strtolower( $host );
+	}
+
+	private function is_github_host( string $host ): bool {
+		return 'github.com' === $host
+			|| 'raw.githubusercontent.com' === $host
+			|| 'api.github.com' === $host;
+	}
+
+	private function env_var_for_host( string $host ): string {
+		if ( '' === $host ) {
+			return '';
+		}
+
+		if ( $this->is_github_host( $host ) ) {
+			return BundleSourceAuth::GITHUB_TOKEN_ENV;
+		}
+
+		$ghe_hosts = BundleSourceAuth::ghe_hosts();
+		if ( array_key_exists( $host, $ghe_hosts ) ) {
+			return $ghe_hosts[ $host ];
+		}
+
+		return '';
+	}
+}

--- a/inc/Engine/Bundle/GitHubBundleSourceResolver.php
+++ b/inc/Engine/Bundle/GitHubBundleSourceResolver.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * GitHub bundle source resolver.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalizes GitHub bundle URLs into archive/raw download URLs.
+ */
+final class GitHubBundleSourceResolver implements BundleSourceResolverInterface {
+
+	/**
+	 * Normalize GitHub URL shapes into fetch URLs.
+	 *
+	 * @param string $source  Original source URL.
+	 * @param array  $context Resolution context.
+	 * @return string|null
+	 */
+	public function normalize( string $source, array $context = array() ): ?string {
+		$url = trim( $source );
+
+		if ( ! preg_match( '#^https?://github\.com/#i', $url ) && ! preg_match( '#^https?://raw\.githubusercontent\.com/#i', $url ) ) {
+			return null;
+		}
+
+		if ( preg_match( '#^https?://raw\.githubusercontent\.com/#i', $url ) ) {
+			return $url;
+		}
+
+		if ( preg_match( '#^https?://github\.com/([^/]+)/([^/]+)/archive/refs/heads/(.+)\.zip$#i', $url, $m ) ) {
+			return $this->route_archive( $m[1], $m[2], $m[3], $url, $context );
+		}
+
+		if ( preg_match( '#^https?://github\.com/([^/]+)/([^/]+)/archive/([0-9a-f]{7,40})\.zip$#i', $url, $m ) ) {
+			return $this->route_archive( $m[1], $m[2], $m[3], $url, $context );
+		}
+
+		if ( preg_match( '#^https?://github\.com/([^/]+)/([^/]+)/blob/(.+)$#i', $url, $m ) ) {
+			return "https://raw.githubusercontent.com/{$m[1]}/{$m[2]}/{$m[3]}";
+		}
+
+		if ( preg_match( '#^https?://github\.com/([^/]+)/([^/]+)/raw/(.+)$#i', $url, $m ) ) {
+			return "https://raw.githubusercontent.com/{$m[1]}/{$m[2]}/{$m[3]}";
+		}
+
+		if ( preg_match( '#^https?://github\.com/([^/]+)/([^/]+)/tree/([^/]+)/?$#i', $url, $m ) ) {
+			return $this->route_archive( $m[1], $m[2], $m[3], $url, $context );
+		}
+
+		return $url;
+	}
+
+	public function accepts_fetch_url( string $fetch_url ): bool {
+		return (bool) preg_match(
+			'#^https?://api\.github\.com/repos/[^/]+/[^/]+/(zipball|tarball)(/|$)#i',
+			$fetch_url
+		);
+	}
+
+	public function expected_extension( string $fetch_url ): string {
+		return $this->accepts_fetch_url( $fetch_url ) ? 'zip' : '';
+	}
+
+	public function revision_from_etag( string $fetch_url, string $etag ): ?string {
+		unset( $fetch_url );
+		return BundleSource::parse_sha_from_etag( $etag );
+	}
+
+	private function route_archive( string $owner, string $repo, string $ref, string $original, array $context ): string {
+		$token = BundleSourceAuth::token_for( 'https://api.github.com/', $context );
+		if ( null !== $token && '' !== $token ) {
+			return sprintf(
+				'https://api.github.com/repos/%s/%s/zipball/%s',
+				$owner,
+				$repo,
+				$ref
+			);
+		}
+
+		if ( preg_match( '#/archive/refs/heads/.+\.zip$#i', $original )
+			|| preg_match( '#/archive/[0-9a-f]{7,40}\.zip$#i', $original )
+		) {
+			return $original;
+		}
+
+		return sprintf(
+			'https://github.com/%s/%s/archive/refs/heads/%s.zip',
+			$owner,
+			$repo,
+			$ref
+		);
+	}
+}

--- a/tests/bundle-egress-target-registry-smoke.php
+++ b/tests/bundle-egress-target-registry-smoke.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Behavior smoke test for bundle egress target registry.
+ *
+ * Run with: php tests/bundle-egress-target-registry-smoke.php
+ */
+
+namespace {
+	define( 'ABSPATH', sys_get_temp_dir() . '/datamachine-bundle-egress-test/' );
+	$GLOBALS['datamachine_test_filters'] = array();
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+			unset( $args );
+			$override = $GLOBALS['datamachine_test_filters'][ $hook ] ?? null;
+			if ( is_callable( $override ) ) {
+				return $override( $value );
+			}
+			return $value;
+		}
+	}
+}
+
+namespace DataMachine\Engine\Bundle {
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleValidationException.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleEgressTargetRegistry.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSchema.php';
+}
+
+namespace {
+	use DataMachine\Engine\Bundle\BundleSchema;
+
+	$assertions = 0;
+	$assert     = function ( string $label, bool $condition ) use ( &$assertions ): void {
+		++$assertions;
+		if ( ! $condition ) {
+			fwrite( STDERR, "FAIL: {$label}\n" );
+			exit( 1 );
+		}
+		echo "ok - {$label}\n";
+	};
+
+	echo "=== Bundle Egress Target Registry Smoke ===\n";
+
+	$policy = BundleSchema::normalize_run_artifact_egress_policy(
+		array(
+			'daily_memory' => array(
+				'egress'               => array( 'artifact', 'custom-store' ),
+				'bundle_relative_path' => 'memory/daily.md',
+			),
+		)
+	);
+	$assert( 'unknown egress target is still dropped by default', array( 'artifact' ) === ( $policy['daily_memory']['egress'] ?? array() ) );
+
+	$GLOBALS['datamachine_test_filters']['datamachine_bundle_run_artifact_egress_targets'] = function ( array $targets ): array {
+		$targets[] = 'custom-store';
+		return $targets;
+	};
+
+	$policy = BundleSchema::normalize_run_artifact_egress_policy(
+		array(
+			'daily_memory' => array(
+				'egress'               => array( 'artifact', 'custom-store' ),
+				'bundle_relative_path' => 'memory/daily.md',
+			),
+		)
+	);
+	$assert( 'registered custom egress target is preserved', array( 'artifact', 'custom-store' ) === ( $policy['daily_memory']['egress'] ?? array() ) );
+
+	echo "\nAssertions: {$assertions}\n";
+	echo "PASS\n";
+}

--- a/tests/bundle-source-api-routing-smoke.php
+++ b/tests/bundle-source-api-routing-smoke.php
@@ -195,6 +195,11 @@ namespace {
 }
 
 namespace DataMachine\Engine\Bundle {
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceAuthResolverInterface.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceResolverInterface.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/GitHubBundleSourceAuthResolver.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/GitHubBundleSourceResolver.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceResolverRegistry.php';
 	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceAuth.php';
 	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSource.php';
 }

--- a/tests/bundle-source-auth-smoke.php
+++ b/tests/bundle-source-auth-smoke.php
@@ -56,6 +56,11 @@ namespace {
 }
 
 namespace DataMachine\Engine\Bundle {
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceAuthResolverInterface.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceResolverInterface.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/GitHubBundleSourceAuthResolver.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/GitHubBundleSourceResolver.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceResolverRegistry.php';
 	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceAuth.php';
 }
 
@@ -207,6 +212,31 @@ namespace {
 	$assert(
 		'pre-set Authorization header is preserved',
 		'Bearer manual' === $out['headers']['Authorization']
+	);
+
+	$reset();
+	$GLOBALS['datamachine_test_filters']['datamachine_bundle_source_auth_resolvers'] = function ( array $resolvers ) {
+		$resolvers[] = new class implements \DataMachine\Engine\Bundle\BundleSourceAuthResolverInterface {
+			public function apply( array $args, string $source, string $fetch_url, array $context = array() ): array {
+				unset( $source, $context );
+				if ( 'https://packages.example/private.zip' === $fetch_url ) {
+					$args['headers']['X-Package-Auth'] = 'custom-token';
+				}
+				return $args;
+			}
+
+			public function token_for( string $fetch_url, array $context = array() ): ?string {
+				unset( $context );
+				return 'https://packages.example/private.zip' === $fetch_url ? 'custom-token' : null;
+			}
+		};
+		return $resolvers;
+	};
+	$args = array( 'headers' => array(), 'datamachine_bundle_source' => array( 'context' => array() ) );
+	$out  = BundleSourceAuth::inject_auth( $args, 'https://packages.example/private.zip', 'https://packages.example/private.zip' );
+	$assert(
+		'custom auth resolver can attach provider header',
+		'custom-token' === ( $out['headers']['X-Package-Auth'] ?? '' )
 	);
 
 	// Non-github host with no GHE config → no injection.

--- a/tests/bundle-source-smoke.php
+++ b/tests/bundle-source-smoke.php
@@ -66,6 +66,12 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'wp_parse_url' ) ) {
+		function wp_parse_url( string $url, int $component = -1 ): mixed {
+			return parse_url( $url, $component );
+		}
+	}
+
 	function wp_delete_file( string $path ): void {
 		if ( file_exists( $path ) ) {
 			unlink( $path ); // phpcs:ignore
@@ -117,6 +123,12 @@ namespace {
 }
 
 namespace DataMachine\Engine\Bundle {
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceAuthResolverInterface.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceResolverInterface.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/GitHubBundleSourceAuthResolver.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/GitHubBundleSourceResolver.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceResolverRegistry.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceAuth.php';
 	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSource.php';
 }
 
@@ -212,6 +224,34 @@ namespace {
 	$assert(
 		'bare repo URL is unchanged (caller rejects)',
 		$bare === BundleSource::normalize_github_url( $bare )
+	);
+
+	$reset_stubs();
+	$GLOBALS['datamachine_test_filters']['datamachine_bundle_source_resolvers'] = function ( array $resolvers ) {
+		$resolvers[] = new class implements \DataMachine\Engine\Bundle\BundleSourceResolverInterface {
+			public function normalize( string $source, array $context = array() ): ?string {
+				unset( $context );
+				return 'https://packages.example/agent' === $source ? 'https://packages.example/download/agent' : null;
+			}
+
+			public function accepts_fetch_url( string $fetch_url ): bool {
+				return 'https://packages.example/download/agent' === $fetch_url;
+			}
+
+			public function expected_extension( string $fetch_url ): string {
+				return 'https://packages.example/download/agent' === $fetch_url ? 'zip' : '';
+			}
+
+			public function revision_from_etag( string $fetch_url, string $etag ): ?string {
+				unset( $fetch_url );
+				return '"custom-revision"' === $etag ? 'custom-revision' : null;
+			}
+		};
+		return $resolvers;
+	};
+	$assert(
+		'custom source resolver can normalize provider URL',
+		'https://packages.example/download/agent' === BundleSource::normalize_remote_url( 'https://packages.example/agent' )
 	);
 
 	echo "\n[3] resolve() — local paths\n";

--- a/tests/import-agent-ability-smoke.php
+++ b/tests/import-agent-ability-smoke.php
@@ -201,6 +201,11 @@ namespace {
 }
 
 namespace DataMachine\Engine\Bundle {
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceAuthResolverInterface.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceResolverInterface.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/GitHubBundleSourceAuthResolver.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/GitHubBundleSourceResolver.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceResolverRegistry.php';
 	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceAuth.php';
 	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSource.php';
 }

--- a/tests/run-artifact-egress-policy-smoke.php
+++ b/tests/run-artifact-egress-policy-smoke.php
@@ -27,6 +27,7 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 require_once __DIR__ . '/../inc/Engine/Bundle/BundleValidationException.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/PortableSlug.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleSlugTrait.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/BundleEgressTargetRegistry.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/BundleSchema.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleManifest.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleFlowFile.php';


### PR DESCRIPTION
## Summary
- Add bundle source and auth resolver interfaces plus a registry for provider-specific source normalization and auth injection.
- Move the built-in GitHub/GHE source normalization and token/header behavior behind GitHub resolver classes while preserving existing public facades and behavior.
- Add an egress target registry/filter so run-artifact egress vocabulary can be extended without hard-coding consumer semantics into core.
- Add smoke coverage for custom source/auth resolvers and registered egress targets.

## Verification
- `php -l inc/Engine/Bundle/BundleSourceResolverInterface.php && php -l inc/Engine/Bundle/BundleSourceAuthResolverInterface.php && php -l inc/Engine/Bundle/BundleSourceResolverRegistry.php && php -l inc/Engine/Bundle/BundleEgressTargetRegistry.php && php -l inc/Engine/Bundle/GitHubBundleSourceResolver.php && php -l inc/Engine/Bundle/GitHubBundleSourceAuthResolver.php && php -l inc/Engine/Bundle/BundleSource.php && php -l inc/Engine/Bundle/BundleSourceAuth.php && php -l inc/Engine/Bundle/BundleSchema.php`
- `php tests/bundle-source-auth-smoke.php && php tests/bundle-source-smoke.php && php tests/bundle-source-api-routing-smoke.php && php tests/bundle-egress-target-registry-smoke.php && php tests/run-artifact-egress-policy-smoke.php && php tests/import-agent-ability-smoke.php`
- `./vendor/bin/phpcs inc/Engine/Bundle/BundleSourceResolverInterface.php inc/Engine/Bundle/BundleSourceAuthResolverInterface.php inc/Engine/Bundle/BundleSourceResolverRegistry.php inc/Engine/Bundle/BundleEgressTargetRegistry.php inc/Engine/Bundle/GitHubBundleSourceResolver.php inc/Engine/Bundle/GitHubBundleSourceAuthResolver.php inc/Engine/Bundle/BundleSource.php inc/Engine/Bundle/BundleSourceAuth.php inc/Engine/Bundle/BundleSchema.php tests/bundle-source-auth-smoke.php tests/bundle-source-smoke.php tests/bundle-source-api-routing-smoke.php tests/bundle-egress-target-registry-smoke.php tests/run-artifact-egress-policy-smoke.php tests/import-agent-ability-smoke.php`

## Follow-ups
- Additional source providers can register through the new resolver filters without changing the bundle format.
- Downstream consumers can register egress target vocabulary while keeping target semantics outside Data Machine core.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the resolver/registry refactor, adjusted smoke tests, and ran targeted verification. Chris remains responsible for review and merge.