### PR TITLE
Fix bundle egress smoke under WordPress

### DIFF
--- a/inc/Engine/Bundle/BundleSourceAuth.php
+++ b/inc/Engine/Bundle/BundleSourceAuth.php
@@ -130,7 +130,7 @@ final class BundleSourceAuth {
 	 * @return array
 	 */
 	public static function inject_github_auth( array $args, string $source, string $fetch_url ): array {
-		$context   = is_array( $args['datamachine_bundle_source']['context'] ?? null )
+		$context = is_array( $args['datamachine_bundle_source']['context'] ?? null )
 			? (array) $args['datamachine_bundle_source']['context']
 			: array();
 		return ( new GitHubBundleSourceAuthResolver() )->apply( $args, $source, $fetch_url, $context );

--- a/inc/Engine/Bundle/GitHubBundleSourceAuthResolver.php
+++ b/inc/Engine/Bundle/GitHubBundleSourceAuthResolver.php
@@ -36,7 +36,7 @@ final class GitHubBundleSourceAuthResolver implements BundleSourceAuthResolverIn
 		}
 
 		$is_github = $this->is_github_host( $host );
-		$is_ghe    = ! $is_github && array_key_exists( $host, BundleSourceAuth::ghe_hosts() );
+		$is_ghe = ! $is_github && array_key_exists( $host, BundleSourceAuth::ghe_hosts() );
 		if ( ! $is_github && ! $is_ghe ) {
 			return $args;
 		}

--- a/tests/bundle-egress-target-registry-smoke.php
+++ b/tests/bundle-egress-target-registry-smoke.php
@@ -6,8 +6,15 @@
  */
 
 namespace {
-	define( 'ABSPATH', sys_get_temp_dir() . '/datamachine-bundle-egress-test/' );
+	defined( 'ABSPATH' ) || define( 'ABSPATH', sys_get_temp_dir() . '/datamachine-bundle-egress-test/' );
 	$GLOBALS['datamachine_test_filters'] = array();
+
+	$datamachine_test_stderr = static function ( string $message ): void {
+		$stream = defined( 'STDERR' ) ? STDERR : fopen( 'php://stderr', 'wb' );
+		if ( is_resource( $stream ) ) {
+			fwrite( $stream, $message );
+		}
+	};
 
 	if ( ! function_exists( 'apply_filters' ) ) {
 		function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
@@ -31,10 +38,10 @@ namespace {
 	use DataMachine\Engine\Bundle\BundleSchema;
 
 	$assertions = 0;
-	$assert     = function ( string $label, bool $condition ) use ( &$assertions ): void {
+	$assert     = function ( string $label, bool $condition ) use ( &$assertions, $datamachine_test_stderr ): void {
 		++$assertions;
 		if ( ! $condition ) {
-			fwrite( STDERR, "FAIL: {$label}\n" );
+			$datamachine_test_stderr( "FAIL: {$label}\n" );
 			exit( 1 );
 		}
 		echo "ok - {$label}\n";
@@ -52,10 +59,15 @@ namespace {
 	);
 	$assert( 'unknown egress target is still dropped by default', array( 'artifact' ) === ( $policy['daily_memory']['egress'] ?? array() ) );
 
-	$GLOBALS['datamachine_test_filters']['datamachine_bundle_run_artifact_egress_targets'] = function ( array $targets ): array {
+	$register_custom_store = function ( array $targets ): array {
 		$targets[] = 'custom-store';
 		return $targets;
 	};
+	if ( function_exists( 'add_filter' ) ) {
+		add_filter( 'datamachine_bundle_run_artifact_egress_targets', $register_custom_store );
+	} else {
+		$GLOBALS['datamachine_test_filters']['datamachine_bundle_run_artifact_egress_targets'] = $register_custom_store;
+	}
 
 	$policy = BundleSchema::normalize_run_artifact_egress_policy(
 		array(


### PR DESCRIPTION
## Summary
- Fix PHPCS alignment warnings from the bundle source/auth resolver split.
- Make the bundle egress target smoke safe under both standalone PHP and WP-loaded runtimes.
- Register the custom egress target through WordPress filters when WordPress is loaded.

## Testing
- php -l inc/Engine/Bundle/BundleSourceAuth.php && php -l inc/Engine/Bundle/GitHubBundleSourceAuthResolver.php && php -l tests/bundle-egress-target-registry-smoke.php
- php tests/bundle-egress-target-registry-smoke.php
- ./vendor/bin/phpcs inc/Engine/Bundle/BundleSourceAuth.php inc/Engine/Bundle/GitHubBundleSourceAuthResolver.php tests/bundle-egress-target-registry-smoke.php
- homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-postmerge-bundle-egress-checks --runner homeboy-lab --skip-lint -- tests/bundle-egress-target-registry-smoke.php confirmed the smoke assertions pass, but that direct file path uses PHPUnit mode and reports zero tests after executing the standalone smoke.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5
- **Used for:** Diagnosing the post-merge CI failure and drafting the targeted smoke/lint fix. Chris remains responsible for review and merge.