### PR TITLE
Fix bundle auth resolver lint

### DIFF
--- a/inc/Engine/Bundle/GitHubBundleSourceAuthResolver.php
+++ b/inc/Engine/Bundle/GitHubBundleSourceAuthResolver.php
@@ -36,7 +36,7 @@ final class GitHubBundleSourceAuthResolver implements BundleSourceAuthResolverIn
 		}
 
 		$is_github = $this->is_github_host( $host );
-		$is_ghe = ! $is_github && array_key_exists( $host, BundleSourceAuth::ghe_hosts() );
+		$is_ghe    = ! $is_github && array_key_exists( $host, BundleSourceAuth::ghe_hosts() );
 		if ( ! $is_github && ! $is_ghe ) {
 			return $args;
 		}
@@ -105,6 +105,7 @@ final class GitHubBundleSourceAuthResolver implements BundleSourceAuthResolverIn
 	}
 
 	private function host_for( string $url ): string {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- wp_parse_url() is unavailable in standalone smoke contexts.
 		$host = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url, PHP_URL_HOST ) : parse_url( $url, PHP_URL_HOST );
 		if ( ! is_string( $host ) || '' === $host ) {
 			return '';


### PR DESCRIPTION
## Summary
- Restore PHPCS assignment alignment in the GitHub bundle auth resolver.
- Add a scoped PHPCS ignore for the standalone-safe parse_url fallback when wp_parse_url() is unavailable.

## Testing
- homeboy --force-hot --allow-local-hot lint data-machine --path /Users/chubes/Developer/data-machine@fix-postmerge-bundle-egress-checks --changed-since origin/main

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5
- **Used for:** Diagnosing the follow-up lint failure and drafting the targeted lint fix. Chris remains responsible for review and merge.