### PR TITLE
Centralize ability lifecycle guards

### DIFF
--- a/inc/Abilities/AI/InspectRequestAbility.php
+++ b/inc/Abilities/AI/InspectRequestAbility.php
@@ -54,11 +54,7 @@ class InspectRequestAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/AgentCall/AgentCallAbility.php
+++ b/inc/Abilities/AgentCall/AgentCallAbility.php
@@ -92,11 +92,7 @@ class AgentCallAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/AgentMemoryAbilities.php
+++ b/inc/Abilities/AgentMemoryAbilities.php
@@ -306,11 +306,7 @@ class AgentMemoryAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/AgentRemoteCall/AgentRemoteCallAbility.php
+++ b/inc/Abilities/AgentRemoteCall/AgentRemoteCallAbility.php
@@ -95,11 +95,7 @@ class AgentRemoteCallAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/AgentTokenAbilities.php
+++ b/inc/Abilities/AgentTokenAbilities.php
@@ -36,11 +36,7 @@ class AgentTokenAbilities {
 			$this->registerListTokens();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	private function registerCreateToken(): void {

--- a/inc/Abilities/AuthAbilities.php
+++ b/inc/Abilities/AuthAbilities.php
@@ -185,11 +185,7 @@ class AuthAbilities {
 			$this->registerListProviders();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	private function registerGetAuthStatus(): void {

--- a/inc/Abilities/Chat/CreateChatSessionAbility.php
+++ b/inc/Abilities/Chat/CreateChatSessionAbility.php
@@ -83,11 +83,7 @@ class CreateChatSessionAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Chat/DeleteChatSessionAbility.php
+++ b/inc/Abilities/Chat/DeleteChatSessionAbility.php
@@ -68,11 +68,7 @@ class DeleteChatSessionAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Chat/GetChatSessionAbility.php
+++ b/inc/Abilities/Chat/GetChatSessionAbility.php
@@ -71,11 +71,7 @@ class GetChatSessionAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Chat/ListChatSessionsAbility.php
+++ b/inc/Abilities/Chat/ListChatSessionsAbility.php
@@ -89,11 +89,7 @@ class ListChatSessionsAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Chat/MarkSessionReadAbility.php
+++ b/inc/Abilities/Chat/MarkSessionReadAbility.php
@@ -66,11 +66,7 @@ class MarkSessionReadAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Content/EditPostBlocksAbility.php
+++ b/inc/Abilities/Content/EditPostBlocksAbility.php
@@ -101,11 +101,7 @@ class EditPostBlocksAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	private function registerChatTool(): void {

--- a/inc/Abilities/Content/GetPostBlocksAbility.php
+++ b/inc/Abilities/Content/GetPostBlocksAbility.php
@@ -89,11 +89,7 @@ class GetPostBlocksAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	private function registerChatTool(): void {

--- a/inc/Abilities/Content/InsertContentAbility.php
+++ b/inc/Abilities/Content/InsertContentAbility.php
@@ -86,11 +86,7 @@ class InsertContentAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register );
 	}
 
 	/**

--- a/inc/Abilities/Content/ReplacePostBlocksAbility.php
+++ b/inc/Abilities/Content/ReplacePostBlocksAbility.php
@@ -96,11 +96,7 @@ class ReplacePostBlocksAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	private function registerChatTool(): void {

--- a/inc/Abilities/Content/UpsertPostAbility.php
+++ b/inc/Abilities/Content/UpsertPostAbility.php
@@ -187,11 +187,7 @@ class UpsertPostAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register );
 	}
 
 	/**

--- a/inc/Abilities/DailyMemoryAbilities.php
+++ b/inc/Abilities/DailyMemoryAbilities.php
@@ -291,11 +291,7 @@ class DailyMemoryAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php
+++ b/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php
@@ -45,11 +45,7 @@ class DuplicateCheckAbility {
 			$this->registerTitlesMatch();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	// -----------------------------------------------------------------------

--- a/inc/Abilities/Email/EmailAbilities.php
+++ b/inc/Abilities/Email/EmailAbilities.php
@@ -451,11 +451,7 @@ class EmailAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Engine/DrainJobAbility.php
+++ b/inc/Abilities/Engine/DrainJobAbility.php
@@ -92,11 +92,7 @@ class DrainJobAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -85,11 +85,7 @@ class ExecuteStepAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -89,11 +89,7 @@ class RunFlowAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Engine/ScheduleFlowAbility.php
+++ b/inc/Abilities/Engine/ScheduleFlowAbility.php
@@ -76,11 +76,7 @@ class ScheduleFlowAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -80,11 +80,7 @@ class ScheduleNextStepAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Fetch/FetchEmailAbility.php
+++ b/inc/Abilities/Fetch/FetchEmailAbility.php
@@ -136,11 +136,7 @@ class FetchEmailAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Fetch/FetchFilesAbility.php
+++ b/inc/Abilities/Fetch/FetchFilesAbility.php
@@ -85,11 +85,7 @@ class FetchFilesAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Fetch/FetchRssAbility.php
+++ b/inc/Abilities/Fetch/FetchRssAbility.php
@@ -88,11 +88,7 @@ class FetchRssAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Fetch/FetchWordPressApiAbility.php
+++ b/inc/Abilities/Fetch/FetchWordPressApiAbility.php
@@ -89,11 +89,7 @@ class FetchWordPressApiAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Fetch/FetchWordPressMediaAbility.php
+++ b/inc/Abilities/Fetch/FetchWordPressMediaAbility.php
@@ -91,11 +91,7 @@ class FetchWordPressMediaAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Fetch/GetWordPressPostAbility.php
+++ b/inc/Abilities/Fetch/GetWordPressPostAbility.php
@@ -74,11 +74,7 @@ class GetWordPressPostAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
+++ b/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
@@ -107,11 +107,7 @@ class QueryWordPressPostsAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/File/AgentFileAbilities.php
+++ b/inc/Abilities/File/AgentFileAbilities.php
@@ -47,11 +47,7 @@ class AgentFileAbilities {
 			$this->registerUploadAgentFile();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	// =========================================================================

--- a/inc/Abilities/File/FlowFileAbilities.php
+++ b/inc/Abilities/File/FlowFileAbilities.php
@@ -48,11 +48,7 @@ class FlowFileAbilities {
 			$this->registerCleanupFlowFiles();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	// =========================================================================

--- a/inc/Abilities/File/ScaffoldAbilities.php
+++ b/inc/Abilities/File/ScaffoldAbilities.php
@@ -44,11 +44,7 @@ class ScaffoldAbilities {
 			$this->registerScaffoldMemoryFile();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	private function registerScaffoldMemoryFile(): void {

--- a/inc/Abilities/Flow/DeleteFlowAbility.php
+++ b/inc/Abilities/Flow/DeleteFlowAbility.php
@@ -57,11 +57,7 @@ class DeleteFlowAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Flow/DuplicateFlowAbility.php
+++ b/inc/Abilities/Flow/DuplicateFlowAbility.php
@@ -79,11 +79,7 @@ class DuplicateFlowAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Flow/GetFlowsAbility.php
+++ b/inc/Abilities/Flow/GetFlowsAbility.php
@@ -96,11 +96,7 @@ class GetFlowsAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Flow/PauseFlowAbility.php
+++ b/inc/Abilities/Flow/PauseFlowAbility.php
@@ -73,11 +73,7 @@ class PauseFlowAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Flow/ResumeFlowAbility.php
+++ b/inc/Abilities/Flow/ResumeFlowAbility.php
@@ -73,11 +73,7 @@ class ResumeFlowAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Flow/UpdateFlowAbility.php
+++ b/inc/Abilities/Flow/UpdateFlowAbility.php
@@ -75,11 +75,7 @@ class UpdateFlowAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Flow/WebhookTriggerAbility.php
+++ b/inc/Abilities/Flow/WebhookTriggerAbility.php
@@ -356,11 +356,7 @@ class WebhookTriggerAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
@@ -120,11 +120,7 @@ class ConfigureFlowStepsAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/FlowStep/GetFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/GetFlowStepsAbility.php
@@ -60,11 +60,7 @@ class GetFlowStepsAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
+++ b/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
@@ -90,11 +90,7 @@ class UpdateFlowStepAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
+++ b/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
@@ -81,11 +81,7 @@ class ValidateFlowStepsConfigAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Handler/TestHandlerAbility.php
+++ b/inc/Abilities/Handler/TestHandlerAbility.php
@@ -83,11 +83,7 @@ class TestHandlerAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/HandlerAbilities.php
+++ b/inc/Abilities/HandlerAbilities.php
@@ -81,11 +81,7 @@ class HandlerAbilities {
 			$this->registerGetHandlerSiteDefaultsAbility();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	private function registerGetHandlersAbility(): void {

--- a/inc/Abilities/InjectableMemoryFilesAbility.php
+++ b/inc/Abilities/InjectableMemoryFilesAbility.php
@@ -85,11 +85,7 @@ class InjectableMemoryFilesAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -494,11 +494,7 @@ class InternalLinkingAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Job/DeleteJobsAbility.php
+++ b/inc/Abilities/Job/DeleteJobsAbility.php
@@ -63,11 +63,7 @@ class DeleteJobsAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Job/ExecuteAgentWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteAgentWorkflowAbility.php
@@ -84,11 +84,7 @@ class ExecuteAgentWorkflowAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -85,11 +85,7 @@ class ExecuteWorkflowAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Job/FailJobAbility.php
+++ b/inc/Abilities/Job/FailJobAbility.php
@@ -68,11 +68,7 @@ class FailJobAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Job/FlowHealthAbility.php
+++ b/inc/Abilities/Job/FlowHealthAbility.php
@@ -58,11 +58,7 @@ class FlowHealthAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Job/GetJobsAbility.php
+++ b/inc/Abilities/Job/GetJobsAbility.php
@@ -121,11 +121,7 @@ class GetJobsAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Job/JobsSummaryAbility.php
+++ b/inc/Abilities/Job/JobsSummaryAbility.php
@@ -80,11 +80,7 @@ class JobsSummaryAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Job/ProblemFlowsAbility.php
+++ b/inc/Abilities/Job/ProblemFlowsAbility.php
@@ -72,11 +72,7 @@ class ProblemFlowsAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -88,11 +88,7 @@ class RecoverStuckJobsAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Job/RetryJobAbility.php
+++ b/inc/Abilities/Job/RetryJobAbility.php
@@ -66,11 +66,7 @@ class RetryJobAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Job/RunMetricsAbility.php
+++ b/inc/Abilities/Job/RunMetricsAbility.php
@@ -54,11 +54,7 @@ class RunMetricsAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	public function execute( array $input ): array {

--- a/inc/Abilities/LocalSearchAbilities.php
+++ b/inc/Abilities/LocalSearchAbilities.php
@@ -77,11 +77,7 @@ class LocalSearchAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	public function executeLocalSearch( array $input ): array {

--- a/inc/Abilities/LogAbilities.php
+++ b/inc/Abilities/LogAbilities.php
@@ -248,11 +248,7 @@ class LogAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Media/AltTextAbilities.php
+++ b/inc/Abilities/Media/AltTextAbilities.php
@@ -108,11 +108,7 @@ class AltTextAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Media/ImageGenerationAbilities.php
+++ b/inc/Abilities/Media/ImageGenerationAbilities.php
@@ -139,11 +139,7 @@ class ImageGenerationAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Media/ImageOptimizationAbilities.php
+++ b/inc/Abilities/Media/ImageOptimizationAbilities.php
@@ -141,11 +141,7 @@ class ImageOptimizationAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Media/MediaAbilities.php
+++ b/inc/Abilities/Media/MediaAbilities.php
@@ -47,11 +47,7 @@ class MediaAbilities {
 			$this->registerVideoMetadata();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Pipeline/CreatePipelineAbility.php
+++ b/inc/Abilities/Pipeline/CreatePipelineAbility.php
@@ -97,11 +97,7 @@ class CreatePipelineAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Pipeline/DeletePipelineAbility.php
+++ b/inc/Abilities/Pipeline/DeletePipelineAbility.php
@@ -60,11 +60,7 @@ class DeletePipelineAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Pipeline/DuplicatePipelineAbility.php
+++ b/inc/Abilities/Pipeline/DuplicatePipelineAbility.php
@@ -67,11 +67,7 @@ class DuplicatePipelineAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Pipeline/GetPipelinesAbility.php
+++ b/inc/Abilities/Pipeline/GetPipelinesAbility.php
@@ -97,11 +97,7 @@ class GetPipelinesAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Pipeline/ImportExportAbility.php
+++ b/inc/Abilities/Pipeline/ImportExportAbility.php
@@ -30,11 +30,7 @@ class ImportExportAbility {
 			$this->registerExportAbility();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	private function registerImportAbility(): void {

--- a/inc/Abilities/Pipeline/UpdatePipelineAbility.php
+++ b/inc/Abilities/Pipeline/UpdatePipelineAbility.php
@@ -65,11 +65,7 @@ class UpdatePipelineAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -50,11 +50,7 @@ class PipelineStepAbilities {
 			$this->registerReorderPipelineStepsAbility();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	private function registerGetPipelineStepsAbility(): void {

--- a/inc/Abilities/PostQueryAbilities.php
+++ b/inc/Abilities/PostQueryAbilities.php
@@ -200,11 +200,7 @@ class PostQueryAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	private function registerChatTool(): void {

--- a/inc/Abilities/ProcessedItemsAbilities.php
+++ b/inc/Abilities/ProcessedItemsAbilities.php
@@ -45,11 +45,7 @@ class ProcessedItemsAbilities {
 			$this->registerFindNeverProcessed();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Publish/PublishWordPressAbility.php
+++ b/inc/Abilities/Publish/PublishWordPressAbility.php
@@ -129,11 +129,7 @@ class PublishWordPressAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/SEO/IndexNowAbilities.php
+++ b/inc/Abilities/SEO/IndexNowAbilities.php
@@ -415,11 +415,7 @@ class IndexNowAbilities {
 			$this->registerVerifyKeyAbility();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/SEO/MetaDescriptionAbilities.php
+++ b/inc/Abilities/SEO/MetaDescriptionAbilities.php
@@ -117,11 +117,7 @@ class MetaDescriptionAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -47,11 +47,7 @@ class SettingsAbilities {
 			$this->registerUpdateHandlerDefaults();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	private function registerGetSettings(): void {

--- a/inc/Abilities/SourceAggregateAbility.php
+++ b/inc/Abilities/SourceAggregateAbility.php
@@ -41,11 +41,7 @@ class SourceAggregateAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/SourceInventoryAbility.php
+++ b/inc/Abilities/SourceInventoryAbility.php
@@ -47,11 +47,7 @@ class SourceInventoryAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/StepTypeAbilities.php
+++ b/inc/Abilities/StepTypeAbilities.php
@@ -49,11 +49,7 @@ class StepTypeAbilities {
 			$this->registerValidateStepTypeAbility();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	private function registerGetStepTypesAbility(): void {

--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -48,11 +48,7 @@ class SystemAbilities {
 			$this->registerRunTaskAbility();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	private function registerSessionTitleAbility(): void {

--- a/inc/Abilities/Taxonomy/AbstractTaxonomyAbility.php
+++ b/inc/Abilities/Taxonomy/AbstractTaxonomyAbility.php
@@ -48,11 +48,7 @@ abstract class AbstractTaxonomyAbility {
 			wp_register_ability( $this->getAbilityName(), $this->getAbilityArgs() );
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Taxonomy/MergeTermMetaAbility.php
+++ b/inc/Abilities/Taxonomy/MergeTermMetaAbility.php
@@ -93,11 +93,7 @@ class MergeTermMetaAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Taxonomy/ResolveTermAbility.php
+++ b/inc/Abilities/Taxonomy/ResolveTermAbility.php
@@ -97,11 +97,7 @@ class ResolveTermAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/TrackedItemsAbilities.php
+++ b/inc/Abilities/TrackedItemsAbilities.php
@@ -36,11 +36,7 @@ class TrackedItemsAbilities {
 			$this->registerTrackedItemsSummary();
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	private function registerUpsertTrackedItem(): void {

--- a/inc/Abilities/Update/UpdateWordPressAbility.php
+++ b/inc/Abilities/Update/UpdateWordPressAbility.php
@@ -111,11 +111,7 @@ class UpdateWordPressAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Replace inline `wp_abilities_api_init` lifecycle guards in Data Machine abilities with `DataMachine\Abilities\AbilityRegistration::on_abilities_api_init()`.
- Keep ability schemas, permissions, and execution logic unchanged.
- Leave non-equivalent lifecycle code with late-registration/idempotency state untouched.

## Verification
- `composer lint`
- `git diff --check`
- `composer test` blocked locally: Homeboy extension `wordpress` is linked to missing target `/Users/chubes/Developer/homeboy-extensions@runtime-main-20260617/wordpress`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** ability lifecycle refactor and verification
