### PR TITLE
Centralize retention count primitives

### DIFF
--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -1486,6 +1486,44 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	}
 
 	/**
+	 * Count old sessions based on retention period.
+	 *
+	 * @param int  $retention_days               Days to retain sessions.
+	 * @param bool $exclude_pipeline_transcripts Whether pipeline transcripts are counted separately.
+	 * @return int Number of matching sessions.
+	 */
+	public function count_old_sessions( int $retention_days, bool $exclude_pipeline_transcripts = false ): int {
+		global $wpdb;
+
+		$table_name  = self::get_prefixed_table_name();
+		$cutoff_date = gmdate( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
+
+		if ( $exclude_pipeline_transcripts ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			return (int) $wpdb->get_var(
+				$wpdb->prepare(
+					'SELECT COUNT(*) FROM %i
+					WHERE updated_at < %s
+					AND NOT (mode = %s AND metadata LIKE %s)',
+					$table_name,
+					$cutoff_date,
+					'pipeline',
+					'%"source":"pipeline_transcript"%'
+				)
+			);
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM %i WHERE updated_at < %s',
+				$table_name,
+				$cutoff_date
+			)
+		);
+	}
+
+	/**
 	 * Cleanup old sessions based on retention period
 	 *
 	 * @param int $retention_days Days to retain sessions
@@ -1521,6 +1559,38 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		}
 
 		return (int) $deleted;
+	}
+
+	/**
+	 * Count pipeline transcript sessions older than the retention window.
+	 *
+	 * @since next
+	 * @param int $retention_days Days to retain pipeline transcripts.
+	 * @return int Number of matching transcript sessions.
+	 */
+	public function count_old_pipeline_transcripts( int $retention_days ): int {
+		global $wpdb;
+
+		if ( $retention_days <= 0 ) {
+			return 0;
+		}
+
+		$table_name  = self::get_prefixed_table_name();
+		$cutoff_date = gmdate( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM %i
+				WHERE mode = %s
+				AND metadata LIKE %s
+				AND updated_at < %s',
+				$table_name,
+				'pipeline',
+				'%"source":"pipeline_transcript"%',
+				$cutoff_date
+			)
+		);
 	}
 
 	/**

--- a/inc/Core/Database/Chat/ConversationRetentionInterface.php
+++ b/inc/Core/Database/Chat/ConversationRetentionInterface.php
@@ -24,12 +24,37 @@ interface ConversationRetentionInterface {
 	public function cleanup_expired_sessions(): int;
 
 	/**
+	 * Count sessions older than the retention window.
+	 *
+	 * @param int  $retention_days               Days to retain sessions (by updated_at).
+	 * @param bool $exclude_pipeline_transcripts Whether pipeline transcripts are counted separately.
+	 * @return int Number of matching sessions.
+	 */
+	public function count_old_sessions( int $retention_days, bool $exclude_pipeline_transcripts = false ): int;
+
+	/**
 	 * Delete sessions older than the retention window.
 	 *
 	 * @param int $retention_days Days to retain sessions (by updated_at).
 	 * @return int Number of sessions deleted.
 	 */
 	public function cleanup_old_sessions( int $retention_days ): int;
+
+	/**
+	 * Count pipeline transcript sessions older than the retention window.
+	 *
+	 * @param int $retention_days Days to retain pipeline transcripts.
+	 * @return int Number of matching transcript sessions.
+	 */
+	public function count_old_pipeline_transcripts( int $retention_days ): int;
+
+	/**
+	 * Delete pipeline transcript sessions older than the retention window.
+	 *
+	 * @param int $retention_days Days to retain pipeline transcripts.
+	 * @return int Number of deleted transcript sessions.
+	 */
+	public function cleanup_pipeline_transcripts( int $retention_days ): int;
 
 	/**
 	 * Delete sessions that were created but never received a message.

--- a/inc/Core/FilesRepository/FileCleanup.php
+++ b/inc/Core/FilesRepository/FileCleanup.php
@@ -144,16 +144,30 @@ class FileCleanup {
 	 * @return int Number of files deleted
 	 */
 	public function cleanup_old_files( int $retention_days = 7 ): int {
+		return $this->walk_old_files( $retention_days, true, false );
+	}
+
+	/**
+	 * Count old files and job directories eligible for cleanup.
+	 *
+	 * @param int $retention_days Files older than this many days are eligible.
+	 * @return int Number of eligible files/directories.
+	 */
+	public function count_old_files( int $retention_days = 7 ): int {
+		return $this->walk_old_files( $retention_days, false, true );
+	}
+
+	private function walk_old_files( int $retention_days, bool $delete, bool $count_job_dirs ): int {
 		$upload_dir    = wp_upload_dir();
 		$base          = trailingslashit( $upload_dir['basedir'] ) . self::REPOSITORY_DIR;
 		$cutoff_time   = time() - ( $retention_days * DAY_IN_SECONDS );
-		$deleted_count = 0;
+		$matched_count = 0;
 
 		if ( ! is_dir( $base ) ) {
 			return 0;
 		}
 
-		// Traverse: pipeline → flow → files
+		// Traverse: pipeline -> flow -> files.
 		$pipeline_dirs = glob( "{$base}/pipeline-*", GLOB_ONLYDIR );
 		$pipeline_dirs = is_array( $pipeline_dirs ) ? $pipeline_dirs : array();
 
@@ -170,13 +184,17 @@ class FileCleanup {
 					$files = glob( "{$files_dir}/*" );
 					$files = is_array( $files ) ? $files : array();
 					foreach ( $files as $file ) {
-						if ( is_file( $file ) && filemtime( $file ) < $cutoff_time && wp_delete_file( $file ) ) {
-							++$deleted_count;
+						if ( ! is_file( $file ) || filemtime( $file ) >= $cutoff_time ) {
+							continue;
+						}
+
+						if ( ! $delete || wp_delete_file( $file ) ) {
+							++$matched_count;
 						}
 					}
 
 					// Remove empty files directory
-					if ( empty( glob( "{$files_dir}/*" ) ) ) {
+					if ( $delete && empty( glob( "{$files_dir}/*" ) ) ) {
 						$this->remove_directory( $files_dir );
 					}
 				}
@@ -200,19 +218,25 @@ class FileCleanup {
 						}
 
 						if ( $all_old && ! empty( $files ) ) {
-							$this->remove_directory( $job_dir );
+							if ( $delete ) {
+								$this->remove_directory( $job_dir );
+							}
+
+							if ( $count_job_dirs ) {
+								++$matched_count;
+							}
 						}
 					}
 
 					// Remove empty jobs directory
-					if ( empty( glob( "{$jobs_dir}/*" ) ) ) {
+					if ( $delete && empty( glob( "{$jobs_dir}/*" ) ) ) {
 						$this->remove_directory( $jobs_dir );
 					}
 				}
 			}
 		}
 
-		return $deleted_count;
+		return $matched_count;
 	}
 
 	/**

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -949,75 +949,7 @@ class RetentionCleanup {
 	}
 
 	public static function countOldFiles(): int {
-		$upload_dir  = wp_upload_dir();
-		$base        = trailingslashit( $upload_dir['basedir'] ) . 'datamachine-files';
-		$cutoff_time = time() - ( self::fileRetentionDays() * DAY_IN_SECONDS );
-		$count       = 0;
-
-		if ( ! is_dir( $base ) ) {
-			return 0;
-		}
-
-		$pipeline_dirs = glob( "{$base}/pipeline-*", GLOB_ONLYDIR );
-		if ( false === $pipeline_dirs ) {
-			$pipeline_dirs = array();
-		}
-
-		foreach ( $pipeline_dirs as $pipeline_dir ) {
-			$flow_dirs = glob( "{$pipeline_dir}/flow-*", GLOB_ONLYDIR );
-			if ( false === $flow_dirs ) {
-				$flow_dirs = array();
-			}
-
-			foreach ( $flow_dirs as $flow_dir ) {
-				$flow_id   = basename( $flow_dir );
-				$files_dir = "{$flow_dir}/{$flow_id}-files";
-
-				if ( is_dir( $files_dir ) ) {
-					$files = glob( "{$files_dir}/*" );
-					if ( false === $files ) {
-						$files = array();
-					}
-
-					foreach ( $files as $file ) {
-						if ( is_file( $file ) && filemtime( $file ) < $cutoff_time ) {
-							++$count;
-						}
-					}
-				}
-
-				$jobs_dir = "{$flow_dir}/jobs";
-				$job_dirs = glob( "{$jobs_dir}/job-*", GLOB_ONLYDIR );
-				if ( false === $job_dirs ) {
-					$job_dirs = array();
-				}
-
-				foreach ( $job_dirs as $job_dir ) {
-					$files = glob( "{$job_dir}/*" );
-					if ( false === $files ) {
-						$files = array();
-					}
-
-					if ( empty( $files ) ) {
-						continue;
-					}
-
-					$all_old = true;
-					foreach ( $files as $file ) {
-						if ( is_file( $file ) && filemtime( $file ) >= $cutoff_time ) {
-							$all_old = false;
-							break;
-						}
-					}
-
-					if ( $all_old ) {
-						++$count;
-					}
-				}
-			}
-		}
-
-		return $count;
+		return ( new FileCleanup() )->count_old_files( self::fileRetentionDays() );
 	}
 
 	public static function cleanupOldFiles(): array {
@@ -1067,58 +999,17 @@ class RetentionCleanup {
 	}
 
 	public static function countChatSessions(): int {
-		global $wpdb;
+		$chat_db = ConversationStoreFactory::get();
 
-		if ( ! Chat::table_exists() ) {
+		if ( $chat_db instanceof Chat && ! Chat::table_exists() ) {
 			return 0;
 		}
 
-		$table                     = Chat::get_prefixed_table_name();
 		$retention_days            = self::chatRetentionDays();
 		$transcript_retention_days = self::transcriptRetentionDays();
-		$session_cutoff            = gmdate( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
-		$transcript_count          = 0;
+		$transcript_count          = method_exists( $chat_db, 'count_old_pipeline_transcripts' ) ? $chat_db->count_old_pipeline_transcripts( $transcript_retention_days ) : 0;
 
-		if ( $transcript_retention_days > 0 ) {
-			$transcript_cutoff = gmdate( 'Y-m-d H:i:s', time() - ( $transcript_retention_days * DAY_IN_SECONDS ) );
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$transcript_count = (int) $wpdb->get_var(
-				$wpdb->prepare(
-					'SELECT COUNT(*) FROM %i
-					WHERE mode = %s
-					AND metadata LIKE %s
-					AND updated_at < %s',
-					$table,
-					'pipeline',
-					'%"source":"pipeline_transcript"%',
-					$transcript_cutoff
-				)
-			);
-		}
-
-		if ( $transcript_retention_days > 0 ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$session_count = (int) $wpdb->get_var(
-				$wpdb->prepare(
-					'SELECT COUNT(*) FROM %i
-					WHERE updated_at < %s
-					AND NOT (mode = %s AND metadata LIKE %s)',
-					$table,
-					$session_cutoff,
-					'pipeline',
-					'%"source":"pipeline_transcript"%'
-				)
-			);
-		} else {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$session_count = (int) $wpdb->get_var(
-				$wpdb->prepare(
-					'SELECT COUNT(*) FROM %i WHERE updated_at < %s',
-					$table,
-					$session_cutoff
-				)
-			);
-		}
+		$session_count = $chat_db->count_old_sessions( $retention_days, $transcript_retention_days > 0 );
 
 		return $transcript_count + $session_count;
 	}

--- a/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
+++ b/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
@@ -364,11 +364,57 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 		return $deleted;
 	}
 
+	public function count_old_sessions( int $retention_days, bool $exclude_pipeline_transcripts = false ): int {
+		$cutoff = gmdate( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
+		$count  = 0;
+		foreach ( $this->sessions as $session ) {
+			if ( $exclude_pipeline_transcripts && 'pipeline' === ( $session['mode'] ?? '' ) && 'pipeline_transcript' === ( $session['metadata']['source'] ?? '' ) ) {
+				continue;
+			}
+
+			if ( $session['updated_at'] < $cutoff ) {
+				++$count;
+			}
+		}
+		return $count;
+	}
+
 	public function cleanup_old_sessions( int $retention_days ): int {
 		$cutoff  = gmdate( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
 		$deleted = 0;
 		foreach ( $this->sessions as $id => $session ) {
 			if ( $session['updated_at'] < $cutoff ) {
+				unset( $this->sessions[ $id ] );
+				++$deleted;
+			}
+		}
+		return $deleted;
+	}
+
+	public function count_old_pipeline_transcripts( int $retention_days ): int {
+		if ( $retention_days <= 0 ) {
+			return 0;
+		}
+
+		$cutoff = gmdate( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
+		$count  = 0;
+		foreach ( $this->sessions as $session ) {
+			if ( 'pipeline' === ( $session['mode'] ?? '' ) && 'pipeline_transcript' === ( $session['metadata']['source'] ?? '' ) && $session['updated_at'] < $cutoff ) {
+				++$count;
+			}
+		}
+		return $count;
+	}
+
+	public function cleanup_pipeline_transcripts( int $retention_days ): int {
+		if ( $retention_days <= 0 ) {
+			return 0;
+		}
+
+		$cutoff  = gmdate( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
+		$deleted = 0;
+		foreach ( $this->sessions as $id => $session ) {
+			if ( 'pipeline' === ( $session['mode'] ?? '' ) && 'pipeline_transcript' === ( $session['metadata']['source'] ?? '' ) && $session['updated_at'] < $cutoff ) {
 				unset( $this->sessions[ $id ] );
 				++$deleted;
 			}

--- a/tests/ai-request-metadata-guardrails-smoke.php
+++ b/tests/ai-request-metadata-guardrails-smoke.php
@@ -169,7 +169,10 @@ class RequestMetadataSmokeStore implements ConversationStoreInterface {
 	public function count_unread( array $messages, ?string $last_read_at ): int { return 0; }
 	public function mark_session_read( string $session_id, int $user_id ) { return gmdate( 'Y-m-d H:i:s' ); }
 	public function cleanup_expired_sessions(): int { return 0; }
+	public function count_old_sessions( int $retention_days, bool $exclude_pipeline_transcripts = false ): int { return 0; }
 	public function cleanup_old_sessions( int $retention_days ): int { return 0; }
+	public function count_old_pipeline_transcripts( int $retention_days ): int { return 0; }
+	public function cleanup_pipeline_transcripts( int $retention_days ): int { return 0; }
 	public function cleanup_orphaned_sessions( int $hours = 1 ): int { return 0; }
 	public function list_sessions_for_day( string $date ): array { return array(); }
 	public function get_storage_metrics(): ?array { return array( 'rows' => 0, 'size_mb' => '0.0' ); }

--- a/tests/file-cleanup-count-primitives-smoke.php
+++ b/tests/file-cleanup-count-primitives-smoke.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Smoke tests for FileCleanup retention count primitives.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+	define( 'DAY_IN_SECONDS', 86400 );
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( string $value ): string {
+		return rtrim( $value, '/\\' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'wp_upload_dir' ) ) {
+	function wp_upload_dir(): array {
+		return array( 'basedir' => $GLOBALS['datamachine_file_cleanup_upload_dir'] );
+	}
+}
+
+if ( ! function_exists( 'wp_delete_file' ) ) {
+	function wp_delete_file( string $file ): bool {
+		return is_file( $file ) && unlink( $file );
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		unset( $hook, $args );
+	}
+}
+
+if ( ! class_exists( 'WP_Filesystem_Base' ) ) {
+	class WP_Filesystem_Base {
+		public function delete( string $file ): bool {
+			return is_file( $file ) && unlink( $file );
+		}
+
+		public function rmdir( string $directory ): bool {
+			return is_dir( $directory ) && rmdir( $directory );
+		}
+	}
+}
+
+if ( ! function_exists( 'WP_Filesystem' ) ) {
+	function WP_Filesystem(): bool {
+		$GLOBALS['wp_filesystem'] = new WP_Filesystem_Base();
+		return true;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Core/FilesRepository/DirectoryManager.php';
+require_once dirname( __DIR__ ) . '/inc/Core/FilesRepository/FilesystemHelper.php';
+require_once dirname( __DIR__ ) . '/inc/Core/FilesRepository/FileCleanup.php';
+
+use DataMachine\Core\FilesRepository\FileCleanup;
+
+$failures = array();
+
+$assert_same = static function ( int $expected, int $actual, string $label ) use ( &$failures ): void {
+	if ( $expected === $actual ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	echo "FAIL: {$label} expected {$expected}, got {$actual}\n";
+	$failures[] = $label;
+};
+
+$remove_directory = static function ( string $directory ) use ( &$remove_directory ): void {
+	if ( ! is_dir( $directory ) ) {
+		return;
+	}
+
+	$entries = scandir( $directory );
+	foreach ( false === $entries ? array() : $entries as $entry ) {
+		if ( '.' === $entry || '..' === $entry ) {
+			continue;
+		}
+
+		$path = $directory . DIRECTORY_SEPARATOR . $entry;
+		if ( is_dir( $path ) ) {
+			$remove_directory( $path );
+			continue;
+		}
+
+		unlink( $path );
+	}
+
+	rmdir( $directory );
+};
+
+$upload_dir                                      = sys_get_temp_dir() . '/datamachine-file-cleanup-' . uniqid( '', true );
+$GLOBALS['datamachine_file_cleanup_upload_dir'] = $upload_dir;
+
+$files_dir      = $upload_dir . '/datamachine-files/pipeline-1/flow-2/flow-2-files';
+$jobs_dir       = $upload_dir . '/datamachine-files/pipeline-1/flow-2/jobs';
+$old_file       = $files_dir . '/old.txt';
+$recent_file    = $files_dir . '/recent.txt';
+$old_job_file   = $jobs_dir . '/job-1/payload.json';
+$recent_job_file = $jobs_dir . '/job-2/payload.json';
+
+mkdir( dirname( $old_file ), 0777, true );
+mkdir( dirname( $old_job_file ), 0777, true );
+mkdir( dirname( $recent_job_file ), 0777, true );
+mkdir( $jobs_dir . '/job-3', 0777, true );
+
+file_put_contents( $old_file, 'old' );
+file_put_contents( $recent_file, 'recent' );
+file_put_contents( $old_job_file, 'old job' );
+file_put_contents( $recent_job_file, 'recent job' );
+
+$old_time    = time() - ( 8 * DAY_IN_SECONDS );
+$recent_time = time();
+touch( $old_file, $old_time );
+touch( $old_job_file, $old_time );
+touch( $recent_file, $recent_time );
+touch( $recent_job_file, $recent_time );
+
+$cleanup = new FileCleanup();
+
+$assert_same( 2, $cleanup->count_old_files( 7 ), 'count_old_files counts old flow files and all-old job directories' );
+$assert_same( 1, $cleanup->cleanup_old_files( 7 ), 'cleanup_old_files preserves deleted flow-file return count' );
+$assert_same( 0, $cleanup->count_old_files( 7 ), 'count_old_files reflects cleanup results' );
+
+$remove_directory( $upload_dir );
+
+if ( ! empty( $failures ) ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Move old file retention counting into FileCleanup as a reusable count primitive that shares traversal with cleanup.
- Delegate RetentionCleanup file counts to FileCleanup.
- Add chat retention count methods to the existing conversation retention seam and delegate chat counts through the store.

## Verification
- php -l inc/Core/FilesRepository/FileCleanup.php && php -l inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php && php -l inc/Core/Database/Chat/ConversationRetentionInterface.php && php -l inc/Core/Database/Chat/Chat.php && php -l tests/file-cleanup-count-primitives-smoke.php
- php tests/conversation-store-contracts-smoke.php
- php tests/file-cleanup-count-primitives-smoke.php
- php tests/ai-request-metadata-guardrails-smoke.php
- vendor/bin/phpcs inc/Core/FilesRepository/FileCleanup.php inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php inc/Core/Database/Chat/ConversationRetentionInterface.php inc/Core/Database/Chat/Chat.php tests/file-cleanup-count-primitives-smoke.php tests/Unit/Core/Database/Chat/InMemoryConversationStore.php tests/ai-request-metadata-guardrails-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** retention count primitive refactor and verification