### PR TITLE
Centralize plugin settings writes

### DIFF
--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -653,8 +653,7 @@ class SettingsAbilities {
 		$all_settings = $filtered['settings'] ?? $all_settings;
 		$handled_keys = $filtered['handled_keys'] ?? $handled_keys;
 
-		update_option( 'datamachine_settings', $all_settings );
-		PluginSettings::clearCache();
+		PluginSettings::update( $all_settings );
 
 		// Identify unhandled keys so callers know if something was ignored.
 		$input_keys = array_keys( $input );

--- a/inc/Api/Settings.php
+++ b/inc/Api/Settings.php
@@ -178,13 +178,9 @@ class Settings {
 	 */
 	public static function handle_generate_ping_secret( $request ) {
 		$request;
-		$secret   = wp_generate_password( 32, false );
-		$settings = get_option( 'datamachine_settings', array() );
+		$secret = wp_generate_password( 32, false );
 
-		$settings['chat_ping_secret'] = $secret;
-		update_option( 'datamachine_settings', $settings );
-
-		\DataMachine\Core\PluginSettings::clearCache();
+		\DataMachine\Core\PluginSettings::update( array( 'chat_ping_secret' => $secret ) );
 
 		return rest_ensure_response(
 			array(

--- a/inc/Core/PluginSettings.php
+++ b/inc/Core/PluginSettings.php
@@ -106,6 +106,23 @@ class PluginSettings {
 	}
 
 	/**
+	 * Merge settings into the per-site plugin settings option.
+	 *
+	 * Callers remain responsible for sanitizing values before writing.
+	 *
+	 * @param array<string,mixed> $patch Settings to merge.
+	 * @return bool Whether the option value changed.
+	 */
+	public static function update( array $patch ): bool {
+		$settings = array_merge( self::all(), $patch );
+		$updated  = update_option( 'datamachine_settings', $settings );
+
+		self::clearCache();
+
+		return $updated;
+	}
+
+	/**
 	 * Resolve a setting with network fallback.
 	 *
 	 * Resolution order for network-eligible keys:

--- a/tests/Unit/Core/PluginSettingsTest.php
+++ b/tests/Unit/Core/PluginSettingsTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * PluginSettings Tests
+ *
+ * @package DataMachine\Tests\Unit\Core
+ */
+
+namespace DataMachine\Tests\Unit\Core;
+
+use DataMachine\Core\PluginSettings;
+use WP_UnitTestCase;
+
+class PluginSettingsTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		delete_option( 'datamachine_settings' );
+		PluginSettings::clearCache();
+	}
+
+	public function tear_down(): void {
+		delete_option( 'datamachine_settings' );
+		PluginSettings::clearCache();
+		parent::tear_down();
+	}
+
+	public function test_update_merges_patch_and_clears_cache(): void {
+		update_option( 'datamachine_settings', array( 'default_provider' => 'openai' ) );
+		$this->assertSame( 'openai', PluginSettings::get( 'default_provider' ) );
+
+		$updated = PluginSettings::update( array( 'default_model' => 'gpt-4o' ) );
+
+		$this->assertTrue( $updated );
+		$this->assertSame( 'gpt-4o', PluginSettings::get( 'default_model' ) );
+		$this->assertSame(
+			array(
+				'default_provider' => 'openai',
+				'default_model'    => 'gpt-4o',
+			),
+			get_option( 'datamachine_settings', array() )
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Add PluginSettings::update() as a central per-site settings write primitive.
- Route SettingsAbilities updates and the REST ping-secret write through the primitive.
- Add focused coverage for merge behavior and cache invalidation.

## Verification
- composer lint: passed with no output/errors.
- homeboy test data-machine: blocked by local Homeboy extension config: Extension 'wordpress' is linked but its target is missing at /Users/chubes/Developer/homeboy-extensions@runtime-main-20260617/wordpress.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** settings write primitive refactor and verification