### PR TITLE
Add explicit runtime activation primitive

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -380,6 +380,37 @@ function datamachine_run_datamachine_plugin() {
 }
 
 /**
+ * Request full Data Machine runtime loading for the current request.
+ *
+ * Host runtimes that execute Data Machine abilities from non-standard request
+ * shapes can call this before `plugins_loaded` priority 20 instead of forcing
+ * the generic runtime gate open with a broad filter.
+ *
+ * @param string $reason Optional caller-readable activation reason.
+ * @return void
+ */
+function datamachine_request_full_runtime( string $reason = '' ): void {
+	\DataMachine\Core\Bootstrap\RuntimeEnvironment::request_full_runtime( $reason );
+}
+
+/**
+ * Request and, when possible, activate the full Data Machine runtime now.
+ *
+ * This covers late plugin activation flows where a host activates Data Machine
+ * after the normal `plugins_loaded` bootstrap window has already passed.
+ *
+ * @param string $reason Optional caller-readable activation reason.
+ * @return void
+ */
+function datamachine_activate_full_runtime( string $reason = '' ): void {
+	datamachine_request_full_runtime( $reason );
+
+	if ( did_action( 'plugins_loaded' ) ) {
+		datamachine_run_datamachine_plugin();
+	}
+}
+
+/**
  * Determine whether the full Data Machine runtime is needed for this request.
  *
  * Normal frontend page views do not need the agent, REST, tool, queue, or admin

--- a/inc/Core/Bootstrap/RuntimeEnvironment.php
+++ b/inc/Core/Bootstrap/RuntimeEnvironment.php
@@ -16,6 +16,30 @@ defined( 'ABSPATH' ) || exit;
 class RuntimeEnvironment {
 
 	/**
+	 * Whether a host plugin has explicitly requested the full runtime.
+	 *
+	 * @var bool
+	 */
+	private static bool $full_runtime_requested = false;
+
+	/**
+	 * Request full runtime loading for the current request.
+	 *
+	 * @param string $reason Optional caller-readable reason for diagnostics.
+	 * @return void
+	 */
+	public static function request_full_runtime( string $reason = '' ): void {
+		self::$full_runtime_requested = true;
+
+		/**
+		 * Fires when a host requests the full Data Machine runtime for the request.
+		 *
+		 * @param string $reason Caller-readable activation reason.
+		 */
+		do_action( 'datamachine_full_runtime_requested', $reason );
+	}
+
+	/**
 	 * Determine whether the current request is a WordPress test bootstrap.
 	 *
 	 * @return bool True when the request is running under WordPress tests.
@@ -43,6 +67,10 @@ class RuntimeEnvironment {
 	 * @return bool True when full runtime registration should run.
 	 */
 	public static function should_load_full_runtime(): bool {
+		if ( self::$full_runtime_requested ) {
+			return true;
+		}
+
 		if ( self::is_agent_runtime() ) {
 			return true;
 		}

--- a/tests/bootstrap-runtime-environment-smoke.php
+++ b/tests/bootstrap-runtime-environment-smoke.php
@@ -103,6 +103,12 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( string $hook_name, ...$args ): void {
+			unset( $hook_name, $args );
+		}
+	}
+
 	$_SERVER['REQUEST_URI'] = '/frontend-page/';
 	unset( $_GET['rest_route'] );
 	putenv( 'WP_AGENT_RUNTIME' );
@@ -120,6 +126,12 @@ namespace {
 	);
 
 	putenv( 'WP_AGENT_RUNTIME' );
+	RuntimeEnvironment::request_full_runtime( 'test-host' );
+
+	$assert(
+		'explicit runtime request loads full runtime',
+		RuntimeEnvironment::should_load_full_runtime()
+	);
 
 }
 


### PR DESCRIPTION
## Summary
- Add an explicit Data Machine API for host runtimes to request the full runtime for the current request.
- Add a late activation helper for hosts that activate Data Machine after the normal plugins_loaded bootstrap point.
- Cover the explicit runtime request path in the bootstrap runtime smoke test.

## Tests
- php -l data-machine.php
- php -l inc/Core/Bootstrap/RuntimeEnvironment.php
- php tests/bootstrap-runtime-environment-smoke.php
- php tests/frontend-runtime-gate-smoke.php
- vendor/bin/phpcs data-machine.php inc/Core/Bootstrap/RuntimeEnvironment.php tests/bootstrap-runtime-environment-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the runtime activation primitive, smoke coverage, and PR text for Chris to review and test.