### PR TITLE
Add explicit handler tool declaration primitive

### DIFF
--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -23,6 +23,7 @@ use DataMachine\Core\ExecutionContext;
 use DataMachine\Core\FilesRepository\FileStorage;
 use DataMachine\Core\Steps\Fetch\Tools\FetchItemDispositionTool;
 use DataMachine\Core\Steps\Handlers\HttpRequestHelpers;
+use DataMachine\Engine\AI\Tools\ToolManager;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -422,11 +423,12 @@ abstract class FetchHandler {
 		add_filter(
 			'datamachine_tools',
 			static function ( array $tools ): array {
-				$tools['__handler_tools_fetch_dispositions'] = array(
-					'_handler_callable' => array( self::class, 'resolveFetchDispositionTools' ),
-					'handler_types'     => array( 'fetch', 'event_import' ),
-					'modes'             => array( 'pipeline' ),
-					'access_level'      => 'admin',
+				$tools['__handler_tools_fetch_dispositions'] = ToolManager::handlerToolDeclaration(
+					array( self::class, 'resolveFetchDispositionTools' ),
+					array(
+						'handler_types'           => array( 'fetch', 'event_import' ),
+						'client_context_bindings' => array( 'job_id' ),
+					)
 				);
 				return $tools;
 			}
@@ -469,14 +471,13 @@ abstract class FetchHandler {
 	 */
 	private static function getRejectSourceToolDefinition( string $handler_slug, array $handler_config ): array {
 		return array(
-			'class'                   => FetchItemDispositionTool::class,
-			'client_context_bindings' => array( 'job_id' ),
-			'method'                  => 'handle_tool_call',
-			'handler'                 => $handler_slug,
-			'disposition'             => 'reject_source',
-			'runtime'                 => array( 'completion_signal' => 'terminal' ),
-			'description'             => 'Reject this fetched source item after reasoned content/source evaluation. Use when the source itself is irrelevant, too thin, duplicate, noisy, spammy, or otherwise fails the pipeline quality or relevance criteria. The source item will be marked as processed and will not normally be refetched.',
-			'parameters'              => array(
+			'class'          => FetchItemDispositionTool::class,
+			'method'         => 'handle_tool_call',
+			'handler'        => $handler_slug,
+			'disposition'    => 'reject_source',
+			'runtime'        => array( 'completion_signal' => 'terminal' ),
+			'description'    => 'Reject this fetched source item after reasoned content/source evaluation. Use when the source itself is irrelevant, too thin, duplicate, noisy, spammy, or otherwise fails the pipeline quality or relevance criteria. The source item will be marked as processed and will not normally be refetched.',
+			'parameters'     => array(
 				'type'       => 'object',
 				'properties' => array(
 					'reason' => array(
@@ -486,7 +487,7 @@ abstract class FetchHandler {
 				),
 				'required'   => array( 'reason' ),
 			),
-			'handler_config'          => $handler_config,
+			'handler_config' => $handler_config,
 		);
 	}
 
@@ -500,14 +501,13 @@ abstract class FetchHandler {
 	 */
 	private static function getDeferItemToolDefinition( string $handler_slug, array $handler_config ): array {
 		return array(
-			'class'                   => FetchItemDispositionTool::class,
-			'client_context_bindings' => array( 'job_id' ),
-			'method'                  => 'handle_tool_call',
-			'handler'                 => $handler_slug,
-			'disposition'             => 'defer_item',
-			'runtime'                 => array( 'completion_signal' => 'terminal' ),
-			'description'             => 'Defer this fetched source item when the agent cannot safely complete processing now because of runtime failures, tool errors, missing context, uncertainty, or temporary limitations. The source claim will be released and the item will remain eligible to be fetched and retried later; it will not be marked processed.',
-			'parameters'              => array(
+			'class'          => FetchItemDispositionTool::class,
+			'method'         => 'handle_tool_call',
+			'handler'        => $handler_slug,
+			'disposition'    => 'defer_item',
+			'runtime'        => array( 'completion_signal' => 'terminal' ),
+			'description'    => 'Defer this fetched source item when the agent cannot safely complete processing now because of runtime failures, tool errors, missing context, uncertainty, or temporary limitations. The source claim will be released and the item will remain eligible to be fetched and retried later; it will not be marked processed.',
+			'parameters'     => array(
 				'type'       => 'object',
 				'properties' => array(
 					'reason' => array(
@@ -517,7 +517,7 @@ abstract class FetchHandler {
 				),
 				'required'   => array( 'reason' ),
 			),
-			'handler_config'          => $handler_config,
+			'handler_config' => $handler_config,
 		);
 	}
 }

--- a/inc/Core/Steps/HandlerRegistrationTrait.php
+++ b/inc/Core/Steps/HandlerRegistrationTrait.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Core\Steps;
 
+use DataMachine\Engine\AI\Tools\ToolManager;
+
 if ( ! defined('ABSPATH') ) {
 	exit;
 }
@@ -127,16 +129,12 @@ trait HandlerRegistrationTrait {
 			add_filter(
 				'datamachine_tools',
 				function ( array $tools ) use ( $slug, $aiToolCallback ): array {
-					// Wrapper entry keyed uniquely per handler slug.
-					// ToolPolicyResolver::gatherPipelineTools detects
-					// `_handler_callable` entries and invokes them with
-					// runtime handler context; this registry entry is
-					// intentionally NOT a directly usable tool definition.
-					$tools[ '__handler_tools_' . $slug ] = array(
-						'_handler_callable' => $aiToolCallback,
-						'handler'           => $slug,
-						'modes'             => array( 'pipeline' ),
-						'access_level'      => 'admin',
+					$tools[ '__handler_tools_' . $slug ] = ToolManager::handlerToolDeclaration(
+						$aiToolCallback,
+						array(
+							'handler'                 => $slug,
+							'client_context_bindings' => array( 'job_id' ),
+						)
 					);
 					return $tools;
 				}

--- a/inc/Engine/AI/MemoryFileRegistry.php
+++ b/inc/Engine/AI/MemoryFileRegistry.php
@@ -116,72 +116,15 @@ class MemoryFileRegistry {
 			return;
 		}
 
-		$layer = self::normalize_layer( $args['layer'] ?? self::LAYER_AGENT );
 
-		// Composable files are auto-generated — never hand-editable.
-		$composable = (bool) ( $args['composable'] ?? false );
-
-		// Normalize editable: true (default), false, or a WordPress capability string.
-		// Composable files force editable to false.
-		$editable = $composable ? false : ( $args['editable'] ?? true );
-		if ( ! is_bool( $editable ) && ! is_string( $editable ) ) {
-			$editable = true;
-		}
-
-		// Normalize modes: omitted means registered but not prompt-injected.
-		$modes = $args['modes'] ?? self::MODES_NONE;
-		if ( ! is_array( $modes ) ) {
-			$modes = self::MODES_NONE;
-		}
-		$modes                    = array_values( array_unique( array_map( 'sanitize_key', $modes ) ) );
-		$injection_contexts       = self::normalize_injection_contexts( $args['injection_contexts'] ?? array() );
-		$default_retrieval_policy = self::default_retrieval_policy( empty( $modes ) && empty( $injection_contexts ) );
-
-		// Convention path: relative path from ABSPATH for an additional copy.
-		$convention_path = isset( $args['convention_path'] ) ? ltrim( $args['convention_path'], '/' ) : '';
-
-		$metadata = array(
-			'filename'           => $filename,
-			'priority'           => $priority,
-			'layer'              => $layer,
-			'protected'          => (bool) ( $args['protected'] ?? false ),
-			'editable'           => $editable,
-			'composable'         => $composable,
-			'convention_path'    => $convention_path,
-			'modes'              => $modes,
-			'injection_contexts' => $injection_contexts,
-			'label'              => $args['label'] ?? self::filename_to_label( $filename ),
-			'description'        => $args['description'] ?? '',
-			'retrieval_policy'   => self::normalize_retrieval_policy( $args['retrieval_policy'] ?? $default_retrieval_policy ),
-			'authority_tier'     => $args['authority_tier'] ?? self::default_authority_tier( $layer, $filename ),
-			'provenance'         => is_array( $args['provenance'] ?? null ) ? $args['provenance'] : self::default_provenance( $filename ),
-		);
+		$metadata = self::normalize_file_metadata( $filename, $priority, $args );
 
 		self::$files[ $filename ] = $metadata;
 
 		// Mirror into the Agents API source registry.
 		WP_Agent_Memory_Registry::register(
 			self::source_id_for_filename( $filename ),
-			array(
-				'layer'              => $layer,
-				'priority'           => $priority,
-				'protected'          => $metadata['protected'],
-				'editable'           => $editable,
-				'modes'              => $modes,
-				'injection_contexts' => $injection_contexts,
-				'retrieval_policy'   => $metadata['retrieval_policy'],
-				'composable'         => $composable,
-				'context_slug'       => self::context_slug_for_filename( $filename ),
-				'convention_path'    => $convention_path,
-				'label'              => $metadata['label'],
-				'description'        => $metadata['description'],
-				'meta'               => array(
-					'filename'           => $filename,
-					'authority_tier'     => $metadata['authority_tier'],
-					'provenance'         => $metadata['provenance'],
-					'injection_contexts' => $injection_contexts,
-				),
-			)
+			self::to_agents_api_source( $metadata )
 		);
 	}
 
@@ -633,10 +576,12 @@ class MemoryFileRegistry {
 				continue;
 			}
 
-			$files[ $filename ] = array(
+			$files[ $filename ] = self::normalize_file_metadata(
+				$filename,
+				(int) ( $source['priority'] ?? 50 ),
+				array(
 				'filename'           => $filename,
-				'priority'           => (int) ( $source['priority'] ?? 50 ),
-				'layer'              => self::normalize_layer( $source['layer'] ?? self::LAYER_AGENT ),
+				'layer'              => $source['layer'] ?? self::LAYER_AGENT,
 				'protected'          => (bool) ( $source['protected'] ?? false ),
 				'editable'           => $source['editable'] ?? true,
 				'composable'         => (bool) ( $source['composable'] ?? false ),
@@ -648,10 +593,77 @@ class MemoryFileRegistry {
 				'retrieval_policy'   => is_string( $source['retrieval_policy'] ?? null ) ? $source['retrieval_policy'] : WP_Agent_Context_Injection_Policy::ALWAYS,
 				'authority_tier'     => is_string( $source['meta']['authority_tier'] ?? null ) ? $source['meta']['authority_tier'] : self::default_authority_tier( self::normalize_layer( $source['layer'] ?? self::LAYER_AGENT ), $filename ),
 				'provenance'         => is_array( $source['meta']['provenance'] ?? null ) ? $source['meta']['provenance'] : self::default_provenance( $filename ),
+				)
 			);
 		}
 
 		return $files;
+	}
+
+	/**
+	 * Normalize Data Machine's filename-keyed memory metadata shape.
+	 *
+	 * @param string $filename Filename.
+	 * @param int    $priority Sort priority.
+	 * @param array  $args     Raw registration args.
+	 * @return array<string,mixed> Normalized metadata.
+	 */
+	private static function normalize_file_metadata( string $filename, int $priority, array $args ): array {
+		$layer              = self::normalize_layer( $args['layer'] ?? self::LAYER_AGENT );
+		$composable         = (bool) ( $args['composable'] ?? false );
+		$editable           = $composable ? false : ( $args['editable'] ?? true );
+		$editable           = ( is_bool( $editable ) || is_string( $editable ) ) ? $editable : true;
+		$modes              = is_array( $args['modes'] ?? null ) ? array_values( array_unique( array_map( 'sanitize_key', $args['modes'] ) ) ) : self::MODES_NONE;
+		$injection_contexts = self::normalize_injection_contexts( $args['injection_contexts'] ?? array() );
+		$retrieval_policy   = $args['retrieval_policy'] ?? self::default_retrieval_policy( empty( $modes ) && empty( $injection_contexts ) );
+
+		return array(
+			'filename'           => $filename,
+			'priority'           => $priority,
+			'layer'              => $layer,
+			'protected'          => (bool) ( $args['protected'] ?? false ),
+			'editable'           => $editable,
+			'composable'         => $composable,
+			'convention_path'    => isset( $args['convention_path'] ) ? ltrim( (string) $args['convention_path'], '/' ) : '',
+			'modes'              => $modes,
+			'injection_contexts' => $injection_contexts,
+			'label'              => $args['label'] ?? self::filename_to_label( $filename ),
+			'description'        => $args['description'] ?? '',
+			'retrieval_policy'   => self::normalize_retrieval_policy( (string) $retrieval_policy ),
+			'authority_tier'     => $args['authority_tier'] ?? self::default_authority_tier( $layer, $filename ),
+			'provenance'         => is_array( $args['provenance'] ?? null ) ? $args['provenance'] : self::default_provenance( $filename ),
+		);
+	}
+
+	/**
+	 * Project normalized Data Machine memory metadata into Agents API source shape.
+	 *
+	 * @param array $metadata Normalized file metadata.
+	 * @return array<string,mixed> Agents API memory source metadata.
+	 */
+	private static function to_agents_api_source( array $metadata ): array {
+		$filename = (string) $metadata['filename'];
+
+		return array(
+			'layer'              => $metadata['layer'],
+			'priority'           => $metadata['priority'],
+			'protected'          => $metadata['protected'],
+			'editable'           => $metadata['editable'],
+			'modes'              => $metadata['modes'],
+			'injection_contexts' => $metadata['injection_contexts'],
+			'retrieval_policy'   => $metadata['retrieval_policy'],
+			'composable'         => $metadata['composable'],
+			'context_slug'       => self::context_slug_for_filename( $filename ),
+			'convention_path'    => $metadata['convention_path'],
+			'label'              => $metadata['label'],
+			'description'        => $metadata['description'],
+			'meta'               => array(
+				'filename'           => $filename,
+				'authority_tier'     => $metadata['authority_tier'],
+				'provenance'         => $metadata['provenance'],
+				'injection_contexts' => $metadata['injection_contexts'],
+			),
+		);
 	}
 
 	private static function source_id_for_filename( string $filename ): string {

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -208,6 +208,52 @@ class ToolManager {
 	}
 
 	/**
+	 * Build a normalized handler-tool declaration for the `datamachine_tools` registry.
+	 *
+	 * Handler declarations are not directly exposed to models. They describe which
+	 * adjacent handler(s) can lazily produce tools and which runtime context values
+	 * should be bound onto each produced tool definition.
+	 *
+	 * Existing `_handler_callable` arrays remain supported; this helper is the
+	 * first-class shape new handler registrations should use.
+	 *
+	 * @param callable $handler_callable Callback that returns tools for a handler.
+	 * @param array    $args             Declaration args: handler, handler_types, modes,
+	 *                                   access_level, ability, client_context_bindings.
+	 * @return array<string,mixed> Handler-tool declaration.
+	 */
+	public static function handlerToolDeclaration( callable $handler_callable, array $args = array() ): array {
+		$args['_handler_callable'] = $handler_callable;
+		return self::normalizeHandlerToolDeclaration( $args );
+	}
+
+	/**
+	 * Normalize legacy and first-class handler-tool declarations.
+	 *
+	 * @param array $definition Raw declaration.
+	 * @return array<string,mixed> Normalized declaration.
+	 */
+	public static function normalizeHandlerToolDeclaration( array $definition ): array {
+		if ( ! isset( $definition['modes'] ) ) {
+			$definition['modes'] = array( ToolPolicyResolver::MODE_PIPELINE );
+		}
+		if ( ! isset( $definition['access_level'] ) && ! isset( $definition['ability'] ) ) {
+			$definition['access_level'] = 'admin';
+		}
+
+		if ( isset( $definition['context_bindings'] ) && ! isset( $definition['client_context_bindings'] ) ) {
+			$definition['client_context_bindings'] = $definition['context_bindings'];
+		}
+		unset( $definition['context_bindings'] );
+
+		if ( isset( $definition['handler_types'] ) && is_string( $definition['handler_types'] ) ) {
+			$definition['handler_types'] = array( $definition['handler_types'] );
+		}
+
+		return $definition;
+	}
+
+	/**
 	 * Resolve handler tools for a specific adjacent-step handler.
 	 *
 	 * Iterates the unified `datamachine_tools` registry and resolves every
@@ -255,6 +301,7 @@ class ToolManager {
 			if ( ! is_array( $definition ) ) {
 				continue;
 			}
+			$definition = self::normalizeHandlerToolDeclaration( $definition );
 			if ( ! isset( $definition['_handler_callable'] ) || ! is_callable( $definition['_handler_callable'] ) ) {
 				continue;
 			}
@@ -318,36 +365,7 @@ class ToolManager {
 					continue;
 				}
 
-				// Ensure a handler link is set so downstream filters (handler
-				// context, permission resolution) know which handler owns
-				// the tool.
-				if ( ! isset( $tool_def['handler'] ) ) {
-					$tool_def['handler'] = $handler_slug;
-				}
-				if ( ! isset( $tool_def['handler_config'] ) ) {
-					$tool_def['handler_config'] = $handler_config;
-				}
-
-				// Auto-attach the job_id context binding for handler-class
-				// tools. Handler tools route through the *Handler base classes
-				// (Upsert/Publish/Fetch) via handle_tool_call(), all of which
-				// require the run's job_id to load engine_data — and after the
-				// explicit-context-bindings migration, job_id only reaches a
-				// tool when it is named in client_context_bindings. Defaulting
-				// the binding here means satellite plugins (events, socials,
-				// business, third parties) no longer have to declare it
-				// per-tool-def and cannot silently regress into rejecting
-				// every tool call. Tools that explicitly declare their own
-				// bindings keep them untouched.
-				if ( 'handle_tool_call' === ( $tool_def['method'] ?? '' ) ) {
-					$existing = is_array( $tool_def['client_context_bindings'] ?? null )
-						? $tool_def['client_context_bindings']
-						: array();
-					if ( ! in_array( 'job_id', $existing, true ) && ! array_key_exists( 'job_id', $existing ) ) {
-						$existing[]                          = 'job_id';
-						$tool_def['client_context_bindings'] = $existing;
-					}
-				}
+				$tool_def = $this->withHandlerToolContext( $tool_def, $definition, $handler_slug, $handler_config );
 
 				// Apply registry-level meta unless the resolved tool
 				// explicitly overrides.
@@ -370,6 +388,65 @@ class ToolManager {
 		}
 
 		return $resolved;
+	}
+
+	/**
+	 * Apply handler ownership and declaration-level context bindings to a tool.
+	 *
+	 * @param array  $tool_def       Tool definition returned by the handler callback.
+	 * @param array  $declaration    Normalized handler-tool declaration.
+	 * @param string $handler_slug   Adjacent step handler slug.
+	 * @param array  $handler_config Handler configuration from flow step.
+	 * @return array<string,mixed> Tool definition with handler context.
+	 */
+	private function withHandlerToolContext( array $tool_def, array $declaration, string $handler_slug, array $handler_config ): array {
+		if ( ! isset( $tool_def['handler'] ) ) {
+			$tool_def['handler'] = $handler_slug;
+		}
+		if ( ! isset( $tool_def['handler_config'] ) ) {
+			$tool_def['handler_config'] = $handler_config;
+		}
+
+		$declared_bindings = is_array( $declaration['client_context_bindings'] ?? null )
+			? $declaration['client_context_bindings']
+			: array();
+		if ( ! empty( $declared_bindings ) ) {
+			$tool_def['client_context_bindings'] = self::mergeContextBindings( $tool_def['client_context_bindings'] ?? array(), $declared_bindings );
+		}
+
+		// Compatibility fallback for existing third-party handler declarations.
+		// New registrations should declare context bindings on the handler-tool
+		// declaration so ownership is visible before the callback is invoked.
+		if ( 'handle_tool_call' === ( $tool_def['method'] ?? '' ) ) {
+			$tool_def['client_context_bindings'] = self::mergeContextBindings( $tool_def['client_context_bindings'] ?? array(), array( 'job_id' ) );
+		}
+
+		return $tool_def;
+	}
+
+	/**
+	 * Merge context-binding lists/maps without changing existing mappings.
+	 *
+	 * @param mixed $existing Existing tool-level binding declaration.
+	 * @param array $defaults Default bindings from the handler declaration.
+	 * @return array<int|string,string> Merged bindings.
+	 */
+	private static function mergeContextBindings( mixed $existing, array $defaults ): array {
+		$merged = is_array( $existing ) ? $existing : array();
+		foreach ( $defaults as $parameter => $context_key ) {
+			if ( is_int( $parameter ) ) {
+				if ( is_string( $context_key ) && '' !== $context_key && ! in_array( $context_key, $merged, true ) && ! array_key_exists( $context_key, $merged ) ) {
+					$merged[] = $context_key;
+				}
+				continue;
+			}
+
+			if ( is_string( $parameter ) && '' !== $parameter && is_string( $context_key ) && '' !== $context_key && ! array_key_exists( $parameter, $merged ) ) {
+				$merged[ $parameter ] = $context_key;
+			}
+		}
+
+		return $merged;
 	}
 
 	/**

--- a/tests/agents-api-memory-contract-adoption-smoke.php
+++ b/tests/agents-api-memory-contract-adoption-smoke.php
@@ -114,6 +114,8 @@ $datamachine_file = MemoryFileRegistry::get( 'SITE.md' );
 $agents_source    = WP_Agent_Memory_Registry::get( 'datamachine/site.md' );
 datamachine_contract_adoption_assert( null !== $agents_source, 'Data Machine registration creates an Agents API memory source' );
 datamachine_contract_adoption_assert( 'SITE.md' === ( $agents_source['meta']['filename'] ?? null ), 'Agents API source retains Data Machine filename adapter metadata' );
+datamachine_contract_adoption_assert( $datamachine_file['retrieval_policy'] === ( $agents_source['retrieval_policy'] ?? null ), 'Data Machine and Agents API memory registries share normalized retrieval policy' );
+datamachine_contract_adoption_assert( empty( $datamachine_file['injection_contexts'] ) && empty( $agents_source['injection_contexts'] ?? array() ), 'Data Machine and Agents API memory registries share normalized injection contexts' );
 datamachine_contract_adoption_assert( WP_Agent_Context_Authority_Tier::WORKSPACE_SHARED === $datamachine_file['authority_tier'], 'shared memory file receives workspace authority tier' );
 datamachine_contract_adoption_assert( false === $datamachine_file['editable'], 'composable files remain non-editable through the adapter' );
 

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -322,20 +322,22 @@ remove_all_filters_for_source_smoke();
 add_filter(
 	'datamachine_tools',
 	static function ( array $tools ): array {
-		$tools['__handler_tools_context_smoke'] = array(
-			'_handler_callable' => static function (): array {
+		$tools['__handler_tools_context_smoke'] = ToolManager::handlerToolDeclaration(
+			static function (): array {
 				return array(
-					'unbound_handler_tool' => array(
+					'declaration_bound_handler_tool' => array(
 						'description' => 'Handler tool without runtime context.',
 					),
-					'bound_handler_tool'   => array(
+					'tool_bound_handler_tool'        => array(
 						'description'             => 'Handler tool with explicit job context.',
-						'client_context_bindings' => array( 'job_id' ),
+						'client_context_bindings' => array( 'query' => 'search_query' ),
 					),
 				);
 			},
-			'handler'           => 'context_smoke',
-			'modes'             => array( 'pipeline' ),
+			array(
+				'handler'                 => 'context_smoke',
+				'client_context_bindings' => array( 'job_id' ),
+			)
 		);
 		return $tools;
 	}
@@ -346,8 +348,8 @@ $handler_context_tools = ( new ToolManager() )->resolveHandlerTools(
 	array( 'job_id' => 99 ),
 	'context_scope'
 );
-assert_source_equals( false, isset( $handler_context_tools['unbound_handler_tool']['client_context_bindings'] ), 'handler tools do not receive implicit job_id bindings', $failures, $passes );
-assert_source_equals( array( 'job_id' ), $handler_context_tools['bound_handler_tool']['client_context_bindings'] ?? null, 'handler tools keep explicit job_id bindings', $failures, $passes );
+assert_source_equals( array( 'job_id' ), $handler_context_tools['declaration_bound_handler_tool']['client_context_bindings'] ?? null, 'handler declaration binds job_id onto produced tools', $failures, $passes );
+assert_source_equals( array( 'query' => 'search_query', 'job_id' ), $handler_context_tools['tool_bound_handler_tool']['client_context_bindings'] ?? null, 'handler declaration bindings merge without replacing tool-level bindings', $failures, $passes );
 
 echo "\n[3] filters can add a source without disturbing default order:\n";
 remove_all_filters_for_source_smoke();
@@ -731,19 +733,35 @@ assert_source_equals(
 	$passes
 );
 
-echo "\n[9] handler-class tools auto-bind job_id context:\n";
+echo "\n[9] handler declarations expose first-class context bindings:\n";
 $tool_manager_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php' );
+$handler_trait_source = (string) file_get_contents( __DIR__ . '/../inc/Core/Steps/HandlerRegistrationTrait.php' );
+$fetch_handler_source = (string) file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/FetchHandler.php' );
 assert_source_equals(
 	true,
-	false !== strpos( $tool_manager_source, "'handle_tool_call' === ( \$tool_def['method'] ?? '' )" ),
-	'ToolManager auto-binds job_id for handler-class tools (handle_tool_call method)',
+	false !== strpos( $tool_manager_source, 'handlerToolDeclaration' ),
+	'ToolManager exposes a first-class handler-tool declaration helper',
 	$failures,
 	$passes
 );
 assert_source_equals(
 	true,
-	false !== strpos( $tool_manager_source, "\$tool_def['client_context_bindings'] = \$existing" ),
-	'ToolManager writes the resolved client_context_bindings back onto handler tool defs',
+	false !== strpos( $tool_manager_source, 'normalizeHandlerToolDeclaration' ),
+	'ToolManager normalizes legacy and first-class handler declarations',
+	$failures,
+	$passes
+);
+assert_source_equals(
+	true,
+	false !== strpos( $handler_trait_source, 'ToolManager::handlerToolDeclaration' ) && false !== strpos( $handler_trait_source, "'client_context_bindings' => array( 'job_id' )" ),
+	'core handler registration declares job_id binding at wrapper level',
+	$failures,
+	$passes
+);
+assert_source_equals(
+	true,
+	false !== strpos( $fetch_handler_source, 'ToolManager::handlerToolDeclaration' ) && false !== strpos( $fetch_handler_source, "'client_context_bindings' => array( 'job_id' )" ),
+	'cross-cutting fetch handler tools declare job_id binding at wrapper level',
 	$failures,
 	$passes
 );


### PR DESCRIPTION
## Summary
- Add a first-class `ToolManager::handlerToolDeclaration()` primitive for handler-owned tool declarations and declaration-level context bindings.
- Migrate core handler wrapper registrations and fetch disposition tools to declare `job_id` binding at the wrapper level instead of repeating it in every produced tool definition.
- Centralize Data Machine memory-file normalization and Agents API memory-source projection through one adapter path, reducing duplicated registry-shape mapping while preserving existing contracts.

## Notes
- Existing `_handler_callable` arrays remain supported, and the legacy `handle_tool_call` `job_id` fallback remains in place for third-party handler tools that have not adopted the explicit primitive yet.
- Full Data Machine / Agents API memory registry convergence still needs an Agents API-owned canonical memory-source primitive. This PR intentionally only adds the Data Machine upstream-clean primitive and adapter consolidation rather than introducing a workaround.

## Tests
- `php -l inc/Engine/AI/Tools/ToolManager.php && php -l inc/Core/Steps/HandlerRegistrationTrait.php && php -l inc/Core/Steps/Fetch/Handlers/FetchHandler.php && php -l inc/Engine/AI/MemoryFileRegistry.php`
- `php tests/tool-source-registry-smoke.php`
- `php tests/agents-api-memory-contract-adoption-smoke.php`
- `composer lint`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, and PR text. Chris remains responsible for review and acceptance.
