### PR TITLE
Normalize agent config and bundle path handling

### DIFF
--- a/inc/Core/Agents/AgentConfigFactory.php
+++ b/inc/Core/Agents/AgentConfigFactory.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Agent configuration normalization helpers.
+ *
+ * @package DataMachine\Core\Agents
+ */
+
+namespace DataMachine\Core\Agents;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Builds canonical persisted agent_config payloads.
+ */
+final class AgentConfigFactory {
+
+	/**
+	 * Normalize persisted agent_config into the canonical model shape.
+	 *
+	 * Canonical model defaults live at default_provider/default_model. Legacy
+	 * scalar provider/model aliases are accepted as input but not persisted back.
+	 *
+	 * @param array<string,mixed> $config Raw agent config.
+	 * @return array<string,mixed>
+	 */
+	public static function normalize( array $config ): array {
+		$config = self::normalize_model_defaults( $config );
+		$config = self::normalize_mode_models( $config );
+
+		return $config;
+	}
+
+	/** @param array<string,mixed> $config */
+	private static function normalize_model_defaults( array $config ): array {
+		$legacy_provider = is_scalar( $config['provider'] ?? null ) ? trim( (string) $config['provider'] ) : '';
+		$legacy_model    = is_scalar( $config['model'] ?? null ) ? trim( (string) $config['model'] ) : '';
+
+		if ( '' === trim( (string) ( $config['default_provider'] ?? '' ) ) && '' !== $legacy_provider ) {
+			$config['default_provider'] = $legacy_provider;
+		}
+
+		if ( '' === trim( (string) ( $config['default_model'] ?? '' ) ) && '' !== $legacy_model ) {
+			$config['default_model'] = $legacy_model;
+		}
+
+		if ( is_scalar( $config['provider'] ?? null ) ) {
+			unset( $config['provider'] );
+		}
+		if ( is_scalar( $config['model'] ?? null ) ) {
+			unset( $config['model'] );
+		}
+
+		return $config;
+	}
+
+	/** @param array<string,mixed> $config */
+	private static function normalize_mode_models( array $config ): array {
+		if ( ! is_array( $config['mode_models'] ?? null ) ) {
+			return $config;
+		}
+
+		$mode_models = array();
+		foreach ( $config['mode_models'] as $mode => $mode_config ) {
+			if ( ! is_scalar( $mode ) || ! is_array( $mode_config ) ) {
+				continue;
+			}
+
+			$mode = self::sanitize_key( (string) $mode );
+			if ( '' === $mode ) {
+				continue;
+			}
+
+			$provider = is_scalar( $mode_config['provider'] ?? null ) ? trim( (string) $mode_config['provider'] ) : '';
+			$model    = is_scalar( $mode_config['model'] ?? null ) ? trim( (string) $mode_config['model'] ) : '';
+			if ( '' === $provider && '' === $model ) {
+				continue;
+			}
+
+			$mode_models[ $mode ] = array_filter(
+				array(
+					'provider' => $provider,
+					'model'    => $model,
+				),
+				static fn( string $value ): bool => '' !== $value
+			);
+		}
+
+		if ( empty( $mode_models ) ) {
+			unset( $config['mode_models'] );
+		} else {
+			ksort( $mode_models, SORT_STRING );
+			$config['mode_models'] = $mode_models;
+		}
+
+		return $config;
+	}
+
+	private static function sanitize_key( string $key ): string {
+		if ( \function_exists( 'sanitize_key' ) ) {
+			return \sanitize_key( $key );
+		}
+
+		$sanitized = preg_replace( '/[^a-zA-Z0-9_\-]/', '', $key );
+		return strtolower( is_string( $sanitized ) ? $sanitized : '' );
+	}
+}

--- a/inc/Core/Database/Agents/Agents.php
+++ b/inc/Core/Database/Agents/Agents.php
@@ -11,6 +11,7 @@
 
 namespace DataMachine\Core\Database\Agents;
 
+use DataMachine\Core\Agents\AgentConfigFactory;
 use DataMachine\Core\Database\BaseRepository;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -111,9 +112,7 @@ class Agents extends BaseRepository {
 			return null;
 		}
 
-		if ( ! empty( $row['agent_config'] ) ) {
-			$row['agent_config'] = json_decode( $row['agent_config'], true ) ? json_decode( $row['agent_config'], true ) : array();
-		}
+		$row['agent_config'] = self::decode_agent_config( $row['agent_config'] ?? null );
 
 		return $row;
 	}
@@ -143,9 +142,7 @@ class Agents extends BaseRepository {
 			return null;
 		}
 
-		if ( ! empty( $row['agent_config'] ) ) {
-			$row['agent_config'] = json_decode( $row['agent_config'], true ) ? json_decode( $row['agent_config'], true ) : array();
-		}
+		$row['agent_config'] = self::decode_agent_config( $row['agent_config'] ?? null );
 
 		return $row;
 	}
@@ -183,10 +180,7 @@ class Agents extends BaseRepository {
 		}
 
 		foreach ( $rows as &$row ) {
-			if ( ! empty( $row['agent_config'] ) ) {
-				$decoded             = json_decode( $row['agent_config'], true );
-				$row['agent_config'] = is_array( $decoded ) ? $decoded : array();
-			}
+			$row['agent_config'] = self::decode_agent_config( $row['agent_config'] ?? null );
 		}
 
 		return $rows;
@@ -236,10 +230,7 @@ class Agents extends BaseRepository {
 		}
 
 		foreach ( $rows as &$row ) {
-			if ( ! empty( $row['agent_config'] ) ) {
-				$decoded             = json_decode( $row['agent_config'], true );
-				$row['agent_config'] = is_array( $decoded ) ? $decoded : array();
-			}
+			$row['agent_config'] = self::decode_agent_config( $row['agent_config'] ?? null );
 		}
 
 		return $rows;
@@ -267,9 +258,7 @@ class Agents extends BaseRepository {
 			return null;
 		}
 
-		if ( ! empty( $row['agent_config'] ) ) {
-			$row['agent_config'] = json_decode( $row['agent_config'], true ) ? json_decode( $row['agent_config'], true ) : array();
-		}
+		$row['agent_config'] = self::decode_agent_config( $row['agent_config'] ?? null );
 
 		return $row;
 	}
@@ -319,7 +308,7 @@ class Agents extends BaseRepository {
 			}
 
 			if ( 'agent_config' === $field ) {
-				$update[ $field ] = is_array( $data[ $field ] ) ? wp_json_encode( $data[ $field ] ) : (string) $data[ $field ];
+				$update[ $field ] = is_array( $data[ $field ] ) ? wp_json_encode( AgentConfigFactory::normalize( $data[ $field ] ) ) : (string) $data[ $field ];
 				$formats[]        = '%s';
 			} else {
 				$update[ $field ] = (string) $data[ $field ];
@@ -408,10 +397,7 @@ class Agents extends BaseRepository {
 		}
 
 		foreach ( $rows as &$row ) {
-			if ( ! empty( $row['agent_config'] ) ) {
-				$decoded             = json_decode( $row['agent_config'], true );
-				$row['agent_config'] = is_array( $decoded ) ? $decoded : array();
-			}
+			$row['agent_config'] = self::decode_agent_config( $row['agent_config'] ?? null );
 		}
 
 		return $rows;
@@ -440,11 +426,20 @@ class Agents extends BaseRepository {
 				'agent_slug'   => $agent_slug,
 				'agent_name'   => $agent_name,
 				'owner_id'     => $owner_id,
-				'agent_config' => wp_json_encode( $agent_config ),
+				'agent_config' => wp_json_encode( AgentConfigFactory::normalize( $agent_config ) ),
 			),
 			array( '%s', '%s', '%d', '%s' )
 		);
 
 		return (int) $this->wpdb->insert_id;
+	}
+
+	private static function decode_agent_config( mixed $value ): array {
+		if ( is_array( $value ) ) {
+			return AgentConfigFactory::normalize( $value );
+		}
+
+		$decoded = is_string( $value ) && '' !== $value ? json_decode( $value, true ) : array();
+		return AgentConfigFactory::normalize( is_array( $decoded ) ? $decoded : array() );
 	}
 }

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -43,6 +43,7 @@ class ToolPolicyResolver {
 	private DataMachineToolAccessPolicy $tool_access_policy;
 	private \WP_Agent_Tool_Policy $tool_policy;
 	private \WP_Agent_Tool_Policy_Filter $policy_filter;
+	private ?array $last_source_trace = null;
 
 	public function __construct(
 		?ToolManager $tool_manager = null,
@@ -89,6 +90,7 @@ class ToolPolicyResolver {
 	 * @return array Resolved tools array keyed by tool name.
 	 */
 	public function resolve( array $args ): array {
+		$this->last_source_trace = null;
 		$modes    = self::normalizeModes( $args['modes'] ?? ( array_key_exists( 'mode', $args ) ? array( $args['mode'] ) : array( self::MODE_PIPELINE ) ) );
 		$agent_id = isset( $args['agent_id'] ) ? (int) $args['agent_id'] : 0;
 
@@ -103,7 +105,13 @@ class ToolPolicyResolver {
 
 		// 1. Gather tools from Data Machine-owned sources.
 		$args['modes'] = $modes;
-		$tools         = $this->gatherByModes( $modes, $args );
+		$source_trace  = null;
+		if ( ! empty( $args['capture_trace'] ) ) {
+			$source_trace = $this->tool_source_registry->gatherTrace( $modes, $args );
+			$tools        = $source_trace['tools'];
+		} else {
+			$tools = $this->gatherByModes( $modes, $args );
+		}
 		$tools        = $this->filterRuntimeToolsByPolicyOptIn( $tools, $args, $agent_policy );
 
 		// 2. Delegate generic mode/allow/deny/category policy resolution to Agents API.
@@ -128,6 +136,9 @@ class ToolPolicyResolver {
 		}
 
 		$tools = $this->tool_policy->resolve( $tools, $policy_context );
+		if ( is_array( $source_trace ) ) {
+			$this->last_source_trace = $source_trace;
+		}
 
 		// An explicitly-empty allow_only means "no optional tools." The generic
 		// substrate only applies a non-empty allow_only, so it would otherwise
@@ -157,7 +168,14 @@ class ToolPolicyResolver {
 	 * @return array{tools: array<string,array<string,mixed>>, evidence: array<string,mixed>}
 	 */
 	public function resolveWithEvidence( array $args, array $required_tool_names = array(), array $requested_tool_names = array() ): array {
+		$args['capture_trace']                    = true;
+		$args['include_unavailable']              = true;
+		$args['include_source_rejection_metadata'] = true;
+		$args['diagnostic_tool_names']             = array_values( array_unique( array_merge( $required_tool_names, $requested_tool_names ) ) );
 		$tools    = $this->resolve( $args );
+		if ( is_array( $this->last_source_trace ) ) {
+			$args['source_trace'] = $this->last_source_trace;
+		}
 		$evidence = $this->buildResolutionEvidence( $args, $tools, $required_tool_names, $requested_tool_names );
 
 		return array(
@@ -184,7 +202,7 @@ class ToolPolicyResolver {
 		$required_tool_names = $this->policy_filter->string_list( $required_tool_names );
 		$resolved_tool_names = array_keys( $resolved_tools );
 
-		$source_snapshot = $this->tool_source_registry->gatherWithMetadata(
+		$source_snapshot = is_array( $args['source_trace'] ?? null ) ? $args['source_trace'] : $this->tool_source_registry->gatherTrace(
 			$modes,
 			array_merge(
 				$args,

--- a/inc/Engine/AI/Tools/ToolSourceRegistry.php
+++ b/inc/Engine/AI/Tools/ToolSourceRegistry.php
@@ -42,6 +42,11 @@ class ToolSourceRegistry {
 	 * @return array Tools keyed by tool name.
 	 */
 	public function gather( array $modes, array $args ): array {
+		if ( ! empty( $args['capture_trace'] ) ) {
+			$trace = $this->gatherTrace( $modes, $args );
+			return $trace['tools'];
+		}
+
 		$callback = array( $this, 'orderSourcesForContext' );
 		if ( function_exists( 'add_filter' ) ) {
 			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical Agents API tool-source compatibility hook.
@@ -74,6 +79,17 @@ class ToolSourceRegistry {
 	 * @return array{tools: array<string,array<string,mixed>>, sources: array<int,array<string,mixed>>}
 	 */
 	public function gatherWithMetadata( array $modes, array $args ): array {
+		return $this->gatherTrace( $modes, $args );
+	}
+
+	/**
+	 * Gather tools and source trace metadata through the same source path.
+	 *
+	 * @param array $modes Agent mode slugs.
+	 * @param array $args Full resolution arguments.
+	 * @return array{tools: array<string,array<string,mixed>>, sources: array<int,array<string,mixed>>}
+	 */
+	public function gatherTrace( array $modes, array $args ): array {
 		$context  = array_merge(
 			$args,
 			array(

--- a/inc/Engine/Agents/PersistedAgentProjector.php
+++ b/inc/Engine/Agents/PersistedAgentProjector.php
@@ -35,16 +35,19 @@ class PersistedAgentProjector {
 
 		$agents_repository = $agents_repository ?? new Agents();
 		$registered        = array();
+		$existing_agents   = wp_get_agents();
 
 		foreach ( $agents_repository->get_all() as $row ) {
 			$slug = sanitize_title( (string) ( $row['agent_slug'] ?? '' ) );
-			if ( '' === $slug || wp_has_agent( $slug ) ) {
+			if ( '' === $slug || isset( $existing_agents[ $slug ] ) || wp_has_agent( $slug ) ) {
 				continue;
 			}
 
 			$agent = wp_register_agent( $slug, self::definition_from_row( $row ) );
 			if ( $agent instanceof \WP_Agent ) {
-				$registered[] = $agent->get_slug();
+				$registered_slug                     = $agent->get_slug();
+				$registered[]                        = $registered_slug;
+				$existing_agents[ $registered_slug ] = $agent;
 			}
 		}
 

--- a/inc/Engine/Agents/PersistedAgentProjector.php
+++ b/inc/Engine/Agents/PersistedAgentProjector.php
@@ -8,6 +8,7 @@
 
 namespace DataMachine\Engine\Agents;
 
+use DataMachine\Core\Agents\AgentConfigFactory;
 use DataMachine\Core\Database\Agents\Agents;
 
 defined( 'ABSPATH' ) || exit;
@@ -57,7 +58,7 @@ class PersistedAgentProjector {
 	 * @return array<string,mixed>
 	 */
 	public static function definition_from_row( array $row ): array {
-		$config   = is_array( $row['agent_config'] ?? null ) ? $row['agent_config'] : array();
+		$config   = AgentConfigFactory::normalize( is_array( $row['agent_config'] ?? null ) ? $row['agent_config'] : array() );
 		$owner_id = (int) ( $row['owner_id'] ?? 0 );
 
 		return array(

--- a/inc/Engine/Bundle/AgentBundleAgentConfig.php
+++ b/inc/Engine/Bundle/AgentBundleAgentConfig.php
@@ -7,6 +7,8 @@
 
 namespace DataMachine\Engine\Bundle;
 
+use DataMachine\Core\Agents\AgentConfigFactory;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -24,6 +26,6 @@ final class AgentBundleAgentConfig {
 	 * @return array<string,mixed>
 	 */
 	public static function tracked_payload( array $config ): array {
-		return AgentConfigArtifactProjector::tracked_payload( $config );
+		return AgentConfigArtifactProjector::tracked_payload( AgentConfigFactory::normalize( $config ) );
 	}
 }

--- a/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
+++ b/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
@@ -198,13 +198,7 @@ final class AgentBundleInstalledArtifact {
 	}
 
 	private static function normalize_source_path( string $path ): string {
-		$path = str_replace( '\\', '/', self::non_empty_string( $path, 'source_path' ) );
-		$path = ltrim( $path, '/' );
-		if ( str_contains( $path, '..' ) ) {
-			throw new BundleValidationException( 'installed bundle artifact source_path must be bundle-local.' );
-		}
-
-		return $path;
+		return BundlePath::normalize_relative( $path, 'source_path', 'installed bundle artifact' );
 	}
 
 	private static function build_package_artifact( string $bundle_slug, string $bundle_version, string $artifact_type, string $artifact_id, string $source_path, ?string $installed_hash, ?string $current_hash, string $installed_at, string $updated_at, mixed $installed_payload ): object {

--- a/inc/Engine/Bundle/BundlePath.php
+++ b/inc/Engine/Bundle/BundlePath.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Bundle-relative path normalization.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalizes paths that must remain inside a portable bundle.
+ */
+final class BundlePath {
+
+	public static function normalize_relative( string $path, string $field, string $label ): string {
+		$path = str_replace( '\\', '/', trim( $path ) );
+		$path = preg_replace( '#/+#', '/', $path );
+		$path = ltrim( is_string( $path ) ? $path : '', '/' );
+
+		if ( '' === $path ) {
+			throw new BundleValidationException( sprintf( '%s %s must be a non-empty string.', esc_html( $label ), esc_html( $field ) ) );
+		}
+
+		$parts = explode( '/', $path );
+		foreach ( $parts as $part ) {
+			if ( '' === $part || '.' === $part || '..' === $part ) {
+				throw new BundleValidationException( sprintf( '%s %s must be bundle-local.', esc_html( $label ), esc_html( $field ) ) );
+			}
+		}
+
+		return $path;
+	}
+}

--- a/inc/Engine/Bundle/PromptArtifact.php
+++ b/inc/Engine/Bundle/PromptArtifact.php
@@ -142,13 +142,7 @@ final class PromptArtifact {
 	}
 
 	private static function normalize_source_path( string $path ): string {
-		$path = str_replace( '\\', '/', self::non_empty_string( $path, 'source_path' ) );
-		$path = ltrim( $path, '/' );
-		if ( str_contains( $path, '..' ) ) {
-			throw new BundleValidationException( 'prompt artifact source_path must be bundle-local.' );
-		}
-
-		return $path;
+		return BundlePath::normalize_relative( $path, 'source_path', 'prompt artifact' );
 	}
 
 	private static function normalize_metadata( array $metadata ): array {

--- a/tests/agent-bundle-artifact-rebase-smoke.php
+++ b/tests/agent-bundle-artifact-rebase-smoke.php
@@ -36,6 +36,7 @@ if ( ! class_exists( 'WP_Agent_Package_Artifact_Hasher' ) ) {
 // vendor packages that need a full WordPress environment to bootstrap.
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSchema.php';
 require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Packages/class-wp-agent-package-artifact-hasher.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Agents/AgentConfigFactory.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactExtensions.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentConfigArtifactProjector.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactHasher.php';

--- a/tests/agent-bundle-installed-artifact-smoke.php
+++ b/tests/agent-bundle-installed-artifact-smoke.php
@@ -184,6 +184,9 @@ $round_trip = AgentBundleInstalledArtifact::from_array( $modified )->to_array();
 assert_installed_artifact_equals( 'round-trip recomputes modified status', AgentBundleArtifactStatus::MODIFIED, $round_trip['status'] );
 assert_installed_artifact_equals( 'round-trip preserves updated timestamp', '2026-04-28T01:00:00Z', $round_trip['updated_at'] );
 
+$dot_name = AgentBundleInstalledArtifact::from_array( array_merge( $installed_array, array( 'source_path' => 'prompts/version..notes.md' ) ) )->to_array();
+assert_installed_artifact_equals( 'bundle path normalizer allows dot sequences inside a filename', 'prompts/version..notes.md', $dot_name['source_path'] );
+
 $threw = false;
 try {
 	AgentBundleInstalledArtifact::from_array( array_merge( $installed_array, array( 'artifact_type' => 'secret' ) ) );

--- a/tests/agent-bundle-installed-payload-snapshot-smoke.php
+++ b/tests/agent-bundle-installed-payload-snapshot-smoke.php
@@ -53,6 +53,7 @@ require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Packages/cla
 require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Packages/class-wp-agent-package-artifact-hasher.php';
 require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Packages/class-wp-agent-package-artifact-status.php';
 require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Packages/class-wp-agent-package-installed-artifact.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundlePath.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactDefinitions.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactExtensions.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactHasher.php';

--- a/tests/agent-bundle-template-upgrade-tracking-smoke.php
+++ b/tests/agent-bundle-template-upgrade-tracking-smoke.php
@@ -48,6 +48,9 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleValidationException.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSchema.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/PortableSlug.php';
+require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Packages/class-wp-agent-package-artifact-hasher.php';
+require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Packages/class-wp-agent-package-artifact-status.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Agents/AgentConfigFactory.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactExtensions.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentConfigArtifactProjector.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleAgentConfig.php';
@@ -60,6 +63,7 @@ require_once dirname( __DIR__ ) . '/inc/Cli/Commands/AgentBundleCommand.php';
 use DataMachine\Cli\Commands\AgentBundleCommand;
 use DataMachine\Engine\Bundle\AgentBundleAgentConfig;
 use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
+use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
 use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
 use DataMachine\Engine\Bundle\AgentTemplateMetadata;
 
@@ -89,7 +93,34 @@ final class TemplateTrackingCommand extends AgentBundleCommand {
 	}
 
 	public function expose_status( array $agent ): array {
-		return $this->installed_status( $agent );
+		$bundle    = $agent['agent_config']['datamachine_bundle'] ?? array();
+		$installed = is_array( $bundle['artifacts'] ?? null ) ? array_values( $bundle['artifacts'] ) : array();
+		$current   = array();
+		foreach ( $this->current as $artifact ) {
+			$key             = AgentBundleArtifactExtensions::artifact_key( (string) ( $artifact['artifact_type'] ?? '' ), (string) ( $artifact['artifact_id'] ?? '' ) );
+			$current[ $key ] = $artifact;
+		}
+		$artifacts = array();
+		foreach ( $installed as $record ) {
+			$key                    = AgentBundleArtifactExtensions::artifact_key( (string) ( $record['artifact_type'] ?? '' ), (string) ( $record['artifact_id'] ?? '' ) );
+			$current_hash           = isset( $current[ $key ] ) ? AgentBundleArtifactHasher::hash( $current[ $key ]['payload'] ?? null ) : null;
+			$record['current_hash'] = $current_hash;
+			$record['status']       = AgentBundleArtifactStatus::classify( (string) ( $record['installed_hash'] ?? '' ), $current_hash );
+			$artifacts[]            = $record;
+		}
+
+		return array(
+			'agent_id'         => (int) $agent['agent_id'],
+			'agent_slug'       => (string) $agent['agent_slug'],
+			'template_slug'    => (string) ( $bundle['template_slug'] ?? $bundle['bundle_slug'] ?? '' ),
+			'template_version' => (string) ( $bundle['template_version'] ?? $bundle['bundle_version'] ?? '' ),
+			'bundle_slug'      => (string) ( $bundle['bundle_slug'] ?? '' ),
+			'bundle_version'   => (string) ( $bundle['bundle_version'] ?? '' ),
+			'source_ref'       => (string) ( $bundle['source_ref'] ?? '' ),
+			'source_revision'  => (string) ( $bundle['source_revision'] ?? '' ),
+			'artifact_count'   => count( $artifacts ),
+			'artifacts'        => $artifacts,
+		);
 	}
 
 	protected function current_artifacts( array $agent, array $installed ): array {
@@ -118,7 +149,7 @@ template_tracking_assert_equals( 'bundle version remains distinct', '1.2.3', $me
 template_tracking_assert_equals( 'source revision is preserved', 'etag-abc123', $metadata['source_revision'] );
 
 echo "\n[2] Installed status reports source/version and live local modification state\n";
-$installed_agent_config = array( 'model' => 'openai/gpt-5.5' );
+$installed_agent_config = array( 'default_model' => 'openai/gpt-5.5' );
 $installed_pipeline     = array(
 	'portable_slug'   => 'daily-sync',
 	'pipeline_name'   => 'Daily Sync',
@@ -134,7 +165,7 @@ $agent = array(
 	'agent_id'     => 123,
 	'agent_slug'   => 'wordpress-com-brain',
 	'agent_config' => array(
-		'model'              => 'openai/gpt-5.5',
+		'default_model'      => 'openai/gpt-5.5',
 		'datamachine_bundle' => array(
 			'template_slug'    => 'domain-wiki-template',
 			'template_version' => '4.5.6',

--- a/tests/agents-api-persisted-agent-registry-smoke.php
+++ b/tests/agents-api-persisted-agent-registry-smoke.php
@@ -80,6 +80,9 @@ class DataMachinePersistedAgentProjectorFakeRepository extends Agents {
 
 function datamachine_persisted_agent_registry_reset(): void {
 	WP_Agents_Registry::reset_for_tests();
+	if ( function_exists( 'remove_all_actions' ) ) {
+		remove_all_actions( 'wp_agents_api_init' );
+	}
 	$GLOBALS['__agents_api_smoke_actions'] = array();
 	$GLOBALS['__agents_api_smoke_wrong']   = array();
 	$GLOBALS['__agents_api_smoke_current'] = array();

--- a/tests/agents-api-persisted-agent-registry-smoke.php
+++ b/tests/agents-api-persisted-agent-registry-smoke.php
@@ -11,9 +11,11 @@ require_once __DIR__ . '/agents-api-smoke-helpers.php';
 agents_api_smoke_require_module();
 
 require_once dirname( __DIR__ ) . '/inc/Core/Database/BaseRepository.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Agents/AgentConfigFactory.php';
 require_once dirname( __DIR__ ) . '/inc/Core/Database/Agents/Agents.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Agents/PersistedAgentProjector.php';
 
+use DataMachine\Core\Agents\AgentConfigFactory;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Engine\Agents\PersistedAgentProjector;
 
@@ -146,6 +148,25 @@ agents_api_smoke_assert_equals( 7, $agent && is_callable( $agent->get_owner_reso
 agents_api_smoke_assert_equals( 'gpt-5.5', $agent ? $agent->get_default_config()['default_model'] ?? '' : '', 'agent_config becomes default_config', $failures, $passes );
 agents_api_smoke_assert_equals( 'wordpress-com-wiki', $agent ? $agent->get_meta()['source_package'] ?? '' : '', 'bundle slug is exposed as source package', $failures, $passes );
 agents_api_smoke_assert_equals( 'wordpress-com', $agent ? $agent->get_meta()['intelligence_wiki_brain_wiki_slug'] ?? '' : '', 'extension metadata projector is exposed', $failures, $passes );
+
+echo "\n[1b] persisted agent config normalizes legacy model aliases:\n";
+$legacy_config = AgentConfigFactory::normalize(
+	array(
+		'provider'    => 'openai',
+		'model'       => 'gpt-5.5',
+		'mode_models' => array(
+			'chat' => array(
+				'provider' => 'openai',
+				'model'    => 'gpt-5.5-chat',
+			),
+		),
+	)
+);
+agents_api_smoke_assert_equals( 'openai', $legacy_config['default_provider'] ?? '', 'legacy provider becomes default_provider', $failures, $passes );
+agents_api_smoke_assert_equals( 'gpt-5.5', $legacy_config['default_model'] ?? '', 'legacy model becomes default_model', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'provider', $legacy_config ), 'legacy provider alias is not persisted', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'model', $legacy_config ), 'legacy model alias is not persisted', $failures, $passes );
+agents_api_smoke_assert_equals( 'gpt-5.5-chat', $legacy_config['mode_models']['chat']['model'] ?? '', 'mode_models remain canonical mode overrides', $failures, $passes );
 
 echo "\n[2] persisted projection preserves earlier declarative registrations:\n";
 datamachine_persisted_agent_registry_reset();

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -352,6 +352,11 @@ assert_policy_equals( array(), $resolution['evidence']['unavailable_required_too
 assert_policy_equals( 'resolved', $resolution['evidence']['required_tool_resolution'][0]['status'] ?? null, 'resolved evidence marks required tool resolved', $failures, $passes );
 assert_policy_equals( 'alpha_tool', $resolution['evidence']['required_tool_resolution'][0]['resolved_name'] ?? null, 'resolved evidence preserves resolved logical name', $failures, $passes );
 
+echo "\n[10] required-tool evidence reuses captured source trace:\n";
+$resolver_source = file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php' ) ?: '';
+assert_policy_equals( 0, substr_count( $resolver_source, 'gatherWithMetadata(' ), 'evidence no longer manually replays metadata-only source gathering', $failures, $passes );
+assert_policy_equals( true, str_contains( $resolver_source, '$args[\'source_trace\'] = $this->last_source_trace' ), 'evidence builder receives captured trace metadata', $failures, $passes );
+
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " pipeline policy assertions failed.\n";
 	exit( 1 );


### PR DESCRIPTION
## Summary
- Normalize persisted agent config through a canonical AgentConfigFactory so legacy scalar provider/model inputs become default_provider/default_model before storage or Agents API projection.
- Centralize bundle-local source path validation in BundlePath and reuse it for prompt and installed artifact paths.
- Reuse captured tool source trace metadata for required-tool diagnostics instead of manually replaying source metadata gathering.

## Tests
- php tests/agents-api-persisted-agent-registry-smoke.php
- php tests/agent-bundle-installed-artifact-smoke.php
- php tests/pipeline-tool-policy-snapshot-smoke.php
- php tests/agent-bundle-template-upgrade-tracking-smoke.php
- php tests/agent-bundle-installed-payload-snapshot-smoke.php
- php tests/agent-bundle-artifact-rebase-smoke.php
- php -l on changed PHP source and smoke test files
- vendor/bin/phpcs on changed PHP source and smoke test files
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, and PR description; Chris remains responsible for review and merge.