### PR TITLE
Remove implicit image provider default hook

### DIFF
--- a/inc/Abilities/Media/ImageGenerationAbilities.php
+++ b/inc/Abilities/Media/ImageGenerationAbilities.php
@@ -148,10 +148,9 @@ class ImageGenerationAbilities {
 			);
 		}
 
-		$config = self::get_config();
-		$defaults = self::resolve_capability_defaults( $config );
-		$provider = ! empty( $input['provider'] ) ? sanitize_text_field( $input['provider'] ) : ( $config['default_provider'] ?? $defaults['provider'] );
-		$model    = ! empty( $input['model'] ) ? sanitize_text_field( $input['model'] ) : ( $config['default_model'] ?? $defaults['model'] );
+		$config   = self::get_config();
+		$provider = ! empty( $input['provider'] ) ? sanitize_text_field( $input['provider'] ) : ( $config['default_provider'] ?? '' );
+		$model    = ! empty( $input['model'] ) ? sanitize_text_field( $input['model'] ) : ( $config['default_model'] ?? '' );
 
 		if ( empty( $provider ) || empty( $model ) ) {
 			return array(
@@ -465,45 +464,11 @@ class ImageGenerationAbilities {
 	 * @return bool
 	 */
 	public static function is_configured(): bool {
-		$config = self::get_config();
-		$defaults = self::resolve_capability_defaults( $config );
-
-		$provider = $config['default_provider'] ?? $defaults['provider'];
-		$model    = $config['default_model'] ?? $defaults['model'];
+		$config   = self::get_config();
+		$provider = $config['default_provider'] ?? '';
+		$model    = $config['default_model'] ?? '';
 
 		return ! empty( $provider ) && ! empty( $model ) && null === RequestBuilder::wpAiClientUnavailableReason( (string) $provider );
-	}
-
-	/**
-	 * Resolve provider-neutral defaults for the image generation capability.
-	 *
-	 * Data Machine core intentionally supplies no provider/model defaults here.
-	 * Provider integrations may opt in through the generic capability contract.
-	 *
-	 * @param array $config Stored image generation config.
-	 * @return array{provider:string,model:string}
-	 */
-	public static function resolve_capability_defaults( array $config ): array {
-		$defaults = apply_filters(
-			'datamachine_ai_capability_defaults',
-			array(
-				'provider' => '',
-				'model'    => '',
-			),
-			'image_generation',
-			array(
-				'config' => $config,
-			)
-		);
-
-		if ( ! is_array( $defaults ) ) {
-			$defaults = array();
-		}
-
-		return array(
-			'provider' => sanitize_text_field( (string) ( $defaults['provider'] ?? '' ) ),
-			'model'    => sanitize_text_field( (string) ( $defaults['model'] ?? '' ) ),
-		);
 	}
 
 	/**

--- a/inc/Cli/Commands/ImageCommand.php
+++ b/inc/Cli/Commands/ImageCommand.php
@@ -355,9 +355,8 @@ class ImageCommand extends BaseCommand {
 		$configured    = ImageGenerationAbilities::is_configured();
 		$refinement    = ImageGenerationAbilities::is_refinement_enabled();
 		$config        = ImageGenerationAbilities::get_config();
-		$defaults      = ImageGenerationAbilities::resolve_capability_defaults( $config );
-		$provider      = $config['default_provider'] ?? $defaults['provider'];
-		$default_model = $config['default_model'] ?? $defaults['model'];
+		$provider      = $config['default_provider'] ?? '';
+		$default_model = $config['default_model'] ?? '';
 		$default_ratio = $config['default_aspect_ratio'] ?? ImageGenerationAbilities::DEFAULT_ASPECT_RATIO;
 
 		$items = array(

--- a/inc/Engine/AI/Tools/Global/ImageGeneration.php
+++ b/inc/Engine/AI/Tools/Global/ImageGeneration.php
@@ -234,14 +234,14 @@ class ImageGeneration extends BaseTool {
 				'label'       => __( 'Default Provider', 'data-machine' ),
 				'placeholder' => __( 'Provider id', 'data-machine' ),
 				'required'    => false,
-				'description' => __( 'wp-ai-client provider identifier. Leave empty only when a provider integration supplies an image-generation default.', 'data-machine' ),
+				'description' => __( 'wp-ai-client provider identifier used when an image-generation request does not provide one.', 'data-machine' ),
 			),
 			'default_model'             => array(
 				'type'        => 'text',
 				'label'       => __( 'Default Model', 'data-machine' ),
 				'placeholder' => __( 'Model id', 'data-machine' ),
 				'required'    => false,
-				'description' => __( 'wp-ai-client image model identifier. Leave empty only when a provider integration supplies an image-generation default. AI agents can override per-call.', 'data-machine' ),
+				'description' => __( 'wp-ai-client image model identifier used when an image-generation request does not provide one.', 'data-machine' ),
 			),
 			'default_aspect_ratio'      => array(
 				'type'        => 'select',

--- a/tests/Unit/Abilities/Media/ImageGenerationAbilitiesTest.php
+++ b/tests/Unit/Abilities/Media/ImageGenerationAbilitiesTest.php
@@ -17,9 +17,6 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 
 	private ImageGenerationAbilities $abilities;
 
-	/** @var callable|null */
-	private $defaults_filter = null;
-
 	public function set_up(): void {
 		parent::set_up();
 
@@ -35,10 +32,6 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 
 	public function tear_down(): void {
 		delete_site_option( 'datamachine_image_generation_config' );
-		if ( null !== $this->defaults_filter ) {
-			remove_filter( 'datamachine_ai_capability_defaults', $this->defaults_filter, 10 );
-			$this->defaults_filter = null;
-		}
 		WpAiClientTestDouble::reset();
 		parent::tear_down();
 	}
@@ -82,41 +75,15 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'not configured', $result['error'] );
 	}
 
-	public function test_generate_image_uses_generic_capability_defaults_when_no_config(): void {
-		$this->defaults_filter = function ( array $defaults, string $capability ): array {
-			if ( 'image_generation' !== $capability ) {
-				return $defaults;
-			}
-
-			return array(
-				'provider' => 'openai',
-				'model'    => 'gpt-image-1',
-			);
-		};
-		add_filter( 'datamachine_ai_capability_defaults', $this->defaults_filter, 10, 2 );
-
-		$captured_request = null;
-		WpAiClientTestDouble::set_response_callback( function ( array $request ) use ( &$captured_request ): array {
-			$captured_request = $request;
-			return array(
-				'success' => true,
-				'data'    => array( 'image_url' => 'https://example.com/generated.png' ),
-			);
-		} );
-
+	public function test_generate_image_missing_config_requires_explicit_provider_and_model(): void {
 		$result = ImageGenerationAbilities::generateImage( array( 'prompt' => 'Test prompt' ) );
 
-		$this->assertTrue( $result['success'] );
-		$this->assertSame( 'openai', $captured_request['provider'] ?? '' );
-		$this->assertSame( 'gpt-image-1', $captured_request['model'] ?? '' );
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'not configured', $result['error'] );
 	}
 
-	public function test_generate_image_explicit_config_overrides_capability_defaults(): void {
+	public function test_generate_image_uses_explicit_config(): void {
 		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'configured-model' ) );
-		$this->defaults_filter = fn( array $defaults, string $capability ): array => 'image_generation' === $capability
-			? array( 'provider' => 'openai', 'model' => 'filtered-model' )
-			: $defaults;
-		add_filter( 'datamachine_ai_capability_defaults', $this->defaults_filter, 10, 2 );
 
 		$captured_request = null;
 		WpAiClientTestDouble::set_response_callback( function ( array $request ) use ( &$captured_request ): array {
@@ -131,6 +98,28 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( 'configured-model', $captured_request['model'] ?? '' );
+	}
+
+	public function test_generate_image_input_provider_and_model_override_config(): void {
+		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'configured-model' ) );
+
+		$captured_request = null;
+		WpAiClientTestDouble::set_response_callback( function ( array $request ) use ( &$captured_request ): array {
+			$captured_request = $request;
+			return array(
+				'success' => true,
+				'data'    => array( 'image_url' => 'https://example.com/generated.png' ),
+			);
+		} );
+
+		$result = ImageGenerationAbilities::generateImage( array(
+			'prompt'   => 'Test prompt',
+			'provider' => 'openai',
+			'model'    => 'request-model',
+		) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'request-model', $captured_request['model'] ?? '' );
 	}
 
 	public function test_generate_image_unregistered_provider(): void {
@@ -199,13 +188,8 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 		$this->assertFalse( ImageGenerationAbilities::is_configured() );
 	}
 
-	public function test_is_configured_true_when_capability_defaults_available(): void {
-		$this->defaults_filter = fn( array $defaults, string $capability ): array => 'image_generation' === $capability
-			? array( 'provider' => 'openai', 'model' => 'gpt-image-1' )
-			: $defaults;
-		add_filter( 'datamachine_ai_capability_defaults', $this->defaults_filter, 10, 2 );
-
-		$this->assertTrue( ImageGenerationAbilities::is_configured() );
+	public function test_is_configured_false_without_explicit_config(): void {
+		$this->assertFalse( ImageGenerationAbilities::is_configured() );
 	}
 
 	public function test_is_configured_true_when_provider_and_model_available(): void {

--- a/tests/image-generation-wp-ai-client-boundary-smoke.php
+++ b/tests/image-generation-wp-ai-client-boundary-smoke.php
@@ -48,7 +48,7 @@ $assert( str_contains( $task, 'image_data_uri' ), 'system task consumes inline g
 $assert( ! str_contains( $task, 'HttpClient::get' ), 'system task no longer polls direct provider HTTP status' );
 $assert( ! str_contains( $task, 'api.replicate.com' ), 'system task has no Replicate API endpoint' );
 $assert( str_contains( $tool, 'default_provider' ), 'tool settings collect provider id instead of provider API key' );
-$assert( str_contains( $ability, 'datamachine_ai_capability_defaults' ), 'image ability resolves provider defaults through generic capability contract' );
+$assert( ! str_contains( $ability, 'datamachine_ai_capability_defaults' ), 'image ability has no Data Machine provider-default hook contract' );
 $assert( ! str_contains( $ability, 'DEFAULT_PROVIDER' ), 'image ability has no provider-specific default constant' );
 $assert( ! str_contains( $ability, 'DEFAULT_MODEL' ), 'image ability has no model-specific default constant' );
 $assert( ! str_contains( $ability, 'gpt-image-1' ), 'image ability has no OpenAI image model default' );


### PR DESCRIPTION
## Summary
- Remove the `datamachine_ai_capability_defaults` image-generation default hook introduced in #2714.
- Resolve image-generation provider/model only from explicit request input or explicit Data Machine image-generation settings.
- Update settings copy and tests so provider plugins are not expected to know Data Machine filter names.

## Design correction
Data Machine core remains provider/model-agnostic by shipping no image-generation provider/model default and no provider-default hook contract for provider plugins.

Image generation now resolves provider/model in this order:
1. Per-call `provider` and `model` input.
2. Data Machine image-generation settings: `default_provider` and `default_model`.
3. No implicit default; the request returns a configuration error.

wp-ai-client remains responsible for provider registration, model resolution, authentication, and image-generation support checks once explicit provider/model values are supplied.

## Tests
- `php tests/image-generation-wp-ai-client-boundary-smoke.php`
- `php -l inc/Abilities/Media/ImageGenerationAbilities.php`
- `php -l inc/Engine/AI/Tools/Global/ImageGeneration.php`
- `php -l inc/Cli/Commands/ImageCommand.php`
- `php -l tests/Unit/Abilities/Media/ImageGenerationAbilitiesTest.php`
- `php -l tests/image-generation-wp-ai-client-boundary-smoke.php`
- `vendor/bin/phpcs inc/Abilities/Media/ImageGenerationAbilities.php inc/Engine/AI/Tools/Global/ImageGeneration.php inc/Cli/Commands/ImageCommand.php tests/Unit/Abilities/Media/ImageGenerationAbilitiesTest.php tests/image-generation-wp-ai-client-boundary-smoke.php`

## Blockers / not run
- `vendor/bin/phpunit tests/Unit/Abilities/Media/ImageGenerationAbilitiesTest.php tests/Unit/Engine/AI/Tools/Global/ImageGenerationTest.php` could not run because this checkout has no `vendor/bin/phpunit`.
- #2714 was already merged, so this is a corrective follow-up PR rather than an update to that PR branch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the corrective implementation, tests, verification commands, and PR description for Chris to review.