### PR TITLE
Respect host-owned tool policy in agent runs

### DIFF
--- a/inc/Engine/AI/Tools/HostToolPolicy.php
+++ b/inc/Engine/AI/Tools/HostToolPolicy.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Host-owned tool execution policy.
+ *
+ * @package DataMachine\Engine\AI\Tools
+ */
+
+namespace DataMachine\Engine\AI\Tools;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolves whether a tool source declaration is locally runnable in this host.
+ */
+final class HostToolPolicy {
+
+	private const ENV_POLICY_JSON = 'DATAMACHINE_HOST_TOOL_POLICY_JSON';
+
+	/** @var array<string,mixed> */
+	private array $policy;
+
+	/**
+	 * @param array<string,mixed> $policy Normalized policy document.
+	 */
+	private function __construct( array $policy ) {
+		$this->policy = $policy;
+	}
+
+	/**
+	 * Build the active host tool policy for a resolver context.
+	 *
+	 * Hosts can provide policy directly in resolver args, via the generic
+	 * environment variable, or through the filter for deeper integrations.
+	 *
+	 * @param array<string,mixed> $context Resolver context.
+	 */
+	public static function fromContext( array $context ): ?self {
+		$policy = null;
+		foreach ( array( 'host_tool_policy', 'external_tool_ownership_policy' ) as $key ) {
+			if ( is_array( $context[ $key ] ?? null ) ) {
+				$policy = $context[ $key ];
+				break;
+			}
+		}
+
+		if ( null === $policy ) {
+			$policy = self::policyFromEnvironment();
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$policy = apply_filters( 'datamachine_host_tool_policy', $policy, $context );
+		}
+
+		$policy = self::normalizePolicy( $policy );
+		return null !== $policy ? new self( $policy ) : null;
+	}
+
+	/**
+	 * Return the execution location assigned to a tool by host policy.
+	 */
+	public function executionLocation( string $tool_name ): string {
+		$tools = is_array( $this->policy['tools'] ?? null ) ? $this->policy['tools'] : array();
+		$rule  = is_array( $tools[ $tool_name ] ?? null ) ? $tools[ $tool_name ] : array();
+
+		$value = is_string( $rule['execution_location'] ?? null )
+			? $rule['execution_location']
+			: $this->defaultExecutionLocation();
+
+		$value = strtolower( trim( $value ) );
+		return '' !== $value ? $value : 'disabled';
+	}
+
+	/**
+	 * Whether host policy allows the current PHP runner to execute a tool locally.
+	 */
+	public function isLocallyRunnable( string $tool_name ): bool {
+		return 'runner' === $this->executionLocation( $tool_name );
+	}
+
+	private function defaultExecutionLocation(): string {
+		foreach ( array( 'default_execution_location', 'default_location', 'execution_location' ) as $key ) {
+			if ( is_string( $this->policy[ $key ] ?? null ) && '' !== trim( $this->policy[ $key ] ) ) {
+				return (string) $this->policy[ $key ];
+			}
+		}
+
+		return 'disabled';
+	}
+
+	/**
+	 * @return array<string,mixed>|null
+	 */
+	private static function policyFromEnvironment(): ?array {
+		$json = getenv( self::ENV_POLICY_JSON );
+		if ( ! is_string( $json ) || '' === trim( $json ) ) {
+			return null;
+		}
+
+		$policy = json_decode( $json, true );
+		return is_array( $policy ) ? $policy : null;
+	}
+
+	/**
+	 * @param mixed $policy Raw policy candidate.
+	 * @return array<string,mixed>|null
+	 */
+	private static function normalizePolicy( $policy ): ?array {
+		if ( ! is_array( $policy ) ) {
+			return null;
+		}
+
+		$tools = is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array();
+		foreach ( $tools as $tool_name => $rule ) {
+			if ( ! is_string( $tool_name ) || '' === $tool_name || ! is_array( $rule ) ) {
+				unset( $tools[ $tool_name ] );
+				continue;
+			}
+			if ( isset( $rule['execution_location'] ) && ! is_string( $rule['execution_location'] ) ) {
+				unset( $rule['execution_location'] );
+			}
+			$tools[ $tool_name ] = $rule;
+		}
+		$policy['tools'] = $tools;
+
+		$has_default = false;
+		foreach ( array( 'default_execution_location', 'default_location', 'execution_location' ) as $key ) {
+			if ( is_string( $policy[ $key ] ?? null ) && '' !== trim( $policy[ $key ] ) ) {
+				$has_default = true;
+				break;
+			}
+		}
+
+		return $has_default || ! empty( $tools ) ? $policy : null;
+	}
+}

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -255,7 +255,7 @@ class ToolPolicyResolver {
 				'reason'    => $reason,
 				'source'    => $source,
 			);
-			foreach ( array( 'ability', 'tool_modes', 'active_modes' ) as $key ) {
+			foreach ( array( 'ability', 'tool_modes', 'active_modes', 'execution_location' ) as $key ) {
 				if ( array_key_exists( $key, $rejection_by_tool[ $tool_name ] ?? array() ) ) {
 					$evidence[ $key ] = $rejection_by_tool[ $tool_name ][ $key ];
 				}

--- a/inc/Engine/AI/Tools/ToolSourceRegistry.php
+++ b/inc/Engine/AI/Tools/ToolSourceRegistry.php
@@ -42,10 +42,13 @@ class ToolSourceRegistry {
 	 * @return array Tools keyed by tool name.
 	 */
 	public function gather( array $modes, array $args ): array {
-		$callback = array( $this, 'orderSourcesForContext' );
+		$order_callback       = array( $this, 'orderSourcesForContext' );
+		$host_policy_callback = array( $this, 'filterSourceToolsForHostPolicy' );
 		if ( function_exists( 'add_filter' ) ) {
 			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical Agents API tool-source compatibility hook.
-			add_filter( 'agents_api_tool_source_order', $callback, 5, 3 );
+			add_filter( 'agents_api_tool_source_order', $order_callback, 5, 3 );
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical Agents API tool-source compatibility hook.
+			add_filter( 'agents_api_tool_source_tools', $host_policy_callback, PHP_INT_MAX, 4 );
 		}
 
 		try {
@@ -61,7 +64,9 @@ class ToolSourceRegistry {
 		} finally {
 			if ( function_exists( 'remove_filter' ) ) {
 				// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical Agents API tool-source compatibility hook.
-				remove_filter( 'agents_api_tool_source_order', $callback, 5 );
+				remove_filter( 'agents_api_tool_source_order', $order_callback, 5 );
+				// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical Agents API tool-source compatibility hook.
+				remove_filter( 'agents_api_tool_source_tools', $host_policy_callback, PHP_INT_MAX );
 			}
 		}
 	}
@@ -106,6 +111,7 @@ class ToolSourceRegistry {
 				}
 
 				$source_tools      = is_array( $source_tools ) ? $source_tools : array();
+				$source_tools      = $this->applyHostToolPolicy( $source_tools, $source_slug, $context );
 				$source_rejections = array();
 				if ( isset( $source_tools[ AbilityToolSource::REJECTION_METADATA_KEY ] ) && is_array( $source_tools[ AbilityToolSource::REJECTION_METADATA_KEY ] ) ) {
 					$source_rejections = $source_tools[ AbilityToolSource::REJECTION_METADATA_KEY ];
@@ -160,9 +166,9 @@ class ToolSourceRegistry {
 
 		$this->registry->registerSource(
 			self::SOURCE_RUNTIME_TOOLS,
-			static function ( array $context ) use ( $runtime_source ): array {
+			function ( array $context ) use ( $runtime_source ): array {
 				$modes = ToolPolicyResolver::normalizeModes( $context['modes'] ?? array() );
-				return $runtime_source( $modes, $context );
+				return $this->applyHostToolPolicy( $runtime_source( $modes, $context ), self::SOURCE_RUNTIME_TOOLS, $context );
 			}
 		);
 
@@ -170,25 +176,88 @@ class ToolSourceRegistry {
 			self::SOURCE_ADJACENT_HANDLERS,
 			function ( array $context ) use ( $handler_source ): array {
 				$modes = ToolPolicyResolver::normalizeModes( $context['modes'] ?? array() );
-				return $handler_source( $modes, $context, $this->tool_manager );
+				return $this->applyHostToolPolicy( $handler_source( $modes, $context, $this->tool_manager ), self::SOURCE_ADJACENT_HANDLERS, $context );
 			}
 		);
 
 		$this->registry->registerSource(
 			self::SOURCE_STATIC_REGISTRY,
-			static function ( array $context ) use ( $static_source ): array {
+			function ( array $context ) use ( $static_source ): array {
 				$modes = ToolPolicyResolver::normalizeModes( $context['modes'] ?? array() );
-				return $static_source( $modes, $context );
+				return $this->applyHostToolPolicy( $static_source( $modes, $context ), self::SOURCE_STATIC_REGISTRY, $context );
 			}
 		);
 
 		$this->registry->registerSource(
 			self::SOURCE_ABILITY_TOOLS,
-			static function ( array $context ) use ( $ability_source ): array {
+			function ( array $context ) use ( $ability_source ): array {
 				$modes = ToolPolicyResolver::normalizeModes( $context['modes'] ?? array() );
-				return $ability_source( $modes, $context );
+				return $this->applyHostToolPolicy( $ability_source( $modes, $context ), self::SOURCE_ABILITY_TOOLS, $context );
 			}
 		);
+	}
+
+	/**
+	 * Apply host-owned execution policy to one source's locally runnable tools.
+	 *
+	 * @param array<string,mixed> $source_tools Tools keyed by name, optionally with source rejections.
+	 * @param string              $source_slug  Source slug.
+	 * @param array<string,mixed> $context      Resolver context.
+	 * @return array<string,mixed> Filtered tools with source-level rejection metadata.
+	 */
+	private function applyHostToolPolicy( array $source_tools, string $source_slug, array $context ): array {
+		$policy = HostToolPolicy::fromContext( $context );
+		if ( null === $policy ) {
+			return $source_tools;
+		}
+
+		$rejections = array();
+		if ( isset( $source_tools[ AbilityToolSource::REJECTION_METADATA_KEY ] ) && is_array( $source_tools[ AbilityToolSource::REJECTION_METADATA_KEY ] ) ) {
+			$rejections = $source_tools[ AbilityToolSource::REJECTION_METADATA_KEY ];
+		}
+
+		foreach ( $source_tools as $tool_name => $tool_definition ) {
+			if ( AbilityToolSource::REJECTION_METADATA_KEY === $tool_name || ! is_string( $tool_name ) || ! is_array( $tool_definition ) ) {
+				continue;
+			}
+
+			if ( $policy->isLocallyRunnable( $tool_name ) ) {
+				continue;
+			}
+
+			$rejections[ $tool_name ] = array(
+				'tool_name'           => $tool_name,
+				'reason'              => 'host_tool_policy',
+				'execution_location'  => $policy->executionLocation( $tool_name ),
+				'source'              => $source_slug,
+			);
+			unset( $source_tools[ $tool_name ] );
+		}
+
+		if ( ! empty( $context['include_source_rejection_metadata'] ) && ! empty( $rejections ) ) {
+			$source_tools[ AbilityToolSource::REJECTION_METADATA_KEY ] = $rejections;
+		} else {
+			unset( $source_tools[ AbilityToolSource::REJECTION_METADATA_KEY ] );
+		}
+
+		return $source_tools;
+	}
+
+	/**
+	 * Agents API source-tools filter that enforces host policy after source filters.
+	 *
+	 * @param mixed                         $source_tools Source tool declarations.
+	 * @param string                        $source_slug  Source slug.
+	 * @param array<string,mixed>           $context      Resolver context.
+	 * @param WP_Agent_Tool_Source_Registry $registry     Source registry instance.
+	 * @return mixed Filtered source tools.
+	 */
+	public function filterSourceToolsForHostPolicy( $source_tools, string $source_slug, array $context, WP_Agent_Tool_Source_Registry $registry ) {
+		if ( $registry !== $this->registry || ! is_array( $source_tools ) ) {
+			return $source_tools;
+		}
+
+		return $this->applyHostToolPolicy( $source_tools, $source_slug, $context );
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -66,8 +66,14 @@ final class AgentBundleRunner {
 			return $this->response( $selection, $input, $runtime_imports );
 		}
 
-		$workflow     = $this->workflow_from_bundle_flow( $selection['flow'], $selection['pipeline'], $input );
-		$initial_data = is_array( $input['initial_data'] ?? null ) ? $input['initial_data'] : array();
+		$workflow_override = $this->workflow_override_from_input( $input );
+		if ( empty( $workflow_override['success'] ) ) {
+			return $this->response( $workflow_override, $input, $runtime_imports, $selection );
+		}
+
+		$workflow     = is_array( $workflow_override['workflow'] ?? null ) ? $workflow_override['workflow'] : $this->workflow_from_bundle_flow( $selection['flow'], $selection['pipeline'], $input );
+		$initial_data = is_array( $workflow_override['initial_data'] ?? null ) ? $workflow_override['initial_data'] : array();
+		$initial_data = array_merge( $initial_data, is_array( $input['initial_data'] ?? null ) ? $input['initial_data'] : array() );
 		$manifest     = $directory->manifest()->to_array();
 
 		$initial_data['agent_bundle'] = array(
@@ -801,6 +807,60 @@ final class AgentBundleRunner {
 			'success'         => true,
 			'bundle'          => $bundle,
 			'source_revision' => $revision,
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private function workflow_override_from_input( array $input ): array {
+		$workflow = null;
+		if ( isset( $input['execute_workflow'] ) ) {
+			$workflow = $input['execute_workflow'];
+		} elseif ( isset( $input['execute_workflow_path'] ) ) {
+			$path = trim( (string) $input['execute_workflow_path'] );
+			if ( '' === $path || ! is_file( $path ) ) {
+				return array(
+					'success' => false,
+					'error'   => sprintf( 'Workflow override path not found: %s', $path ),
+				);
+			}
+
+			$raw = file_get_contents( $path );
+			if ( false === $raw ) {
+				return array(
+					'success' => false,
+					'error'   => sprintf( 'Workflow override path is not readable: %s', $path ),
+				);
+			}
+
+			$workflow = json_decode( $raw, true );
+			if ( ! is_array( $workflow ) ) {
+				return array(
+					'success' => false,
+					'error'   => sprintf( 'Workflow override path does not contain valid JSON: %s', $path ),
+				);
+			}
+		}
+
+		if ( null === $workflow ) {
+			return array( 'success' => true );
+		}
+
+		$initial_data = is_array( $workflow['initial_data'] ?? null ) ? $workflow['initial_data'] : array();
+		if ( is_array( $workflow['workflow'] ?? null ) ) {
+			$workflow = $workflow['workflow'];
+		}
+
+		if ( ! is_array( $workflow ) || ! is_array( $workflow['steps'] ?? null ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Workflow override must contain a workflow steps array.',
+			);
+		}
+
+		return array(
+			'success'      => true,
+			'workflow'     => $workflow,
+			'initial_data' => $initial_data,
 		);
 	}
 

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -824,7 +824,7 @@ final class AgentBundleRunner {
 				);
 			}
 
-			$raw = file_get_contents( $path );
+			$raw = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			if ( false === $raw ) {
 				return array(
 					'success' => false,

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -72,6 +72,8 @@ foreach ( array(
 	'AgentBundleArrayAdapter::from_array_bundle' => 'runner consumes portable bundle documents',
 	'BundleSourceAuth::build_resolve_context'    => 'runner shares bundle token resolution with import/install surfaces',
 	'workflow_from_bundle_flow'                  => 'runner converts selected bundle flow to workflow steps',
+	'workflow_override_from_input'               => 'runner supports caller-supplied workflow overrides',
+	'execute_workflow_path'                      => 'runner accepts file-backed workflow overrides',
 	'ExecuteWorkflowAbility'                     => 'runner reuses existing headless workflow executor',
 	'DrainJobAbility'                            => 'runner can drain jobs for final result callers',
 	'wp_agent_import_runtime_bundles'            => 'runner uses generic runtime bundle import helper when available',
@@ -114,6 +116,50 @@ require_once $root . '/inc/Core/Steps/FlowStepConfigFactory.php';
 require_once $root . '/inc/Core/Steps/WorkflowConfigFactory.php';
 $runner_reflection = new ReflectionClass( DataMachine\Engine\Bundle\AgentBundleRunner::class );
 $runner_instance   = $runner_reflection->newInstanceWithoutConstructor();
+
+echo "\n[2a] Runner accepts direct workflow overrides\n";
+$workflow_override = $runner_reflection->getMethod( 'workflow_override_from_input' );
+$inline_override   = $workflow_override->invoke(
+	$runner_instance,
+	array(
+		'execute_workflow' => array(
+			'workflow'     => array(
+				'steps' => array(
+					array(
+						'step_type' => 'ai',
+						'label'     => 'Inline override',
+					),
+				),
+			),
+			'initial_data' => array( 'job_source' => 'inline_override' ),
+		),
+	)
+);
+datamachine_bundle_runner_assert( true === ( $inline_override['success'] ?? false ), 'inline workflow override resolves', $failures, $passes );
+datamachine_bundle_runner_assert( 'Inline override' === ( $inline_override['workflow']['steps'][0]['label'] ?? null ), 'inline workflow override unwraps workflow payload', $failures, $passes );
+datamachine_bundle_runner_assert( 'inline_override' === ( $inline_override['initial_data']['job_source'] ?? null ), 'inline workflow override preserves initial_data', $failures, $passes );
+
+$workflow_path = sys_get_temp_dir() . '/datamachine-agent-bundle-workflow-override-' . uniqid( '', true ) . '.json';
+file_put_contents(
+	$workflow_path,
+	json_encode(
+		array(
+			'workflow' => array(
+				'steps' => array(
+					array(
+						'step_type' => 'ai',
+						'label'     => 'Path override',
+					),
+				),
+			),
+		)
+	)
+);
+$path_override = $workflow_override->invoke( $runner_instance, array( 'execute_workflow_path' => $workflow_path ) );
+@unlink( $workflow_path );
+datamachine_bundle_runner_assert( true === ( $path_override['success'] ?? false ), 'file workflow override resolves', $failures, $passes );
+datamachine_bundle_runner_assert( 'Path override' === ( $path_override['workflow']['steps'][0]['label'] ?? null ), 'file workflow override unwraps workflow payload', $failures, $passes );
+
 $output_projection = $runner_reflection->getMethod( 'output_projection' );
 $projected_outputs = $output_projection->invoke(
 	$runner_instance,

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -16,6 +16,16 @@ namespace DataMachine\Abilities\Flow {
 	}
 }
 
+namespace DataMachine\Core {
+	if ( ! class_exists( PluginSettings::class, false ) ) {
+		class PluginSettings {
+			public static function get( string $key, $default = null ) {
+				return $default;
+			}
+		}
+	}
+}
+
 namespace {
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -57,6 +67,46 @@ if ( ! function_exists( 'wp_generate_uuid4' ) ) {
 	}
 }
 
+if ( ! class_exists( 'SnapshotPolicyAbility', false ) ) {
+	class SnapshotPolicyAbility {
+		public function get_meta(): array {
+			return array( 'annotations' => array() );
+		}
+
+		public function get_category(): string {
+			return 'test';
+		}
+
+		public function get_description(): string {
+			return 'Snapshot policy test ability';
+		}
+
+		public function get_label(): string {
+			return 'Snapshot policy test ability';
+		}
+
+		public function get_input_schema(): array {
+			return array( 'type' => 'object', 'properties' => array() );
+		}
+	}
+}
+
+if ( ! class_exists( 'WP_Abilities_Registry', false ) ) {
+	class WP_Abilities_Registry {
+		public static function get_instance(): self {
+			return new self();
+		}
+
+		public function is_registered( string $ability_slug ): bool {
+			return in_array( $ability_slug, array( 'test/control-plane', 'test/runner' ), true );
+		}
+
+		public function get_registered( string $ability_slug ): ?SnapshotPolicyAbility {
+			return $this->is_registered( $ability_slug ) ? new SnapshotPolicyAbility() : null;
+		}
+	}
+}
+
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
 require_once __DIR__ . '/../inc/Core/Steps/WorkflowConfigFactory.php';
@@ -66,10 +116,13 @@ require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-policy-filter.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-policy.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-source-registry.php';
+require_once __DIR__ . '/../inc/Engine/AI/ToolSchemaNormalizer.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/AbilityToolAdapter.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineAgentToolPolicyProvider.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineMandatoryToolPolicy.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineToolAccessPolicy.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/HostToolPolicy.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/RuntimeToolSource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php';
@@ -351,6 +404,63 @@ assert_policy_equals( array( 'alpha_tool' ), array_keys( $resolution['tools'] ),
 assert_policy_equals( array(), $resolution['evidence']['unavailable_required_tool_names'] ?? null, 'resolved evidence has no unavailable required tools', $failures, $passes );
 assert_policy_equals( 'resolved', $resolution['evidence']['required_tool_resolution'][0]['status'] ?? null, 'resolved evidence marks required tool resolved', $failures, $passes );
 assert_policy_equals( 'alpha_tool', $resolution['evidence']['required_tool_resolution'][0]['resolved_name'] ?? null, 'resolved evidence preserves resolved logical name', $failures, $passes );
+
+echo "\n[10] host tool policy excludes non-runner local tools from every source:\n";
+$previous_policy_env = getenv( 'DATAMACHINE_HOST_TOOL_POLICY_JSON' );
+putenv(
+	'DATAMACHINE_HOST_TOOL_POLICY_JSON=' . json_encode(
+		array(
+			'schema'                     => 'datamachine/host-tool-policy/v1',
+			'default_execution_location' => 'disabled',
+			'tools'            => array(
+				'alpha_tool'            => array( 'execution_location' => 'control_plane' ),
+				'beta_tool'             => array( 'execution_location' => 'runner' ),
+				'client/control_plane_runtime' => array( 'execution_location' => 'control_plane' ),
+				'client/runner_runtime'        => array( 'execution_location' => 'runner' ),
+				'control_plane_ability' => array( 'execution_location' => 'control_plane' ),
+				'runner_ability'        => array( 'execution_location' => 'runner' ),
+			),
+		)
+	)
+);
+$resolver   = new ToolPolicyResolver( new SnapshotPolicyToolManager() );
+$resolution = $resolver->resolveWithEvidence(
+	array(
+		'mode'                      => ToolPolicyResolver::MODE_PIPELINE,
+		'agent_id'                  => 0,
+		'previous_step_config'      => null,
+		'next_step_config'          => null,
+		'pipeline_step_id'          => 'ephemeral_pipeline_0',
+		'engine_data'               => array(),
+		'categories'                => array(),
+		'allow_only_explicit'       => true,
+		'allow_only'                => array( 'alpha_tool', 'beta_tool', 'client/control_plane_runtime', 'client/runner_runtime', 'control_plane_ability', 'runner_ability' ),
+		'runtime_tool_declarations' => array(
+			'client/control_plane_runtime' => array( 'description' => 'Control-plane runtime tool', 'parameters' => array( 'type' => 'object', 'properties' => array() ), 'executor' => 'client', 'scope' => 'run' ),
+			'client/runner_runtime'        => array( 'description' => 'Runner runtime tool', 'parameters' => array( 'type' => 'object', 'properties' => array() ), 'executor' => 'client', 'scope' => 'run' ),
+		),
+		'ability_tools'             => array(
+			'control_plane_ability' => array( 'ability' => 'test/control-plane', 'modes' => array( ToolPolicyResolver::MODE_PIPELINE ) ),
+			'runner_ability'        => array( 'ability' => 'test/runner', 'modes' => array( ToolPolicyResolver::MODE_PIPELINE ) ),
+		),
+	),
+	array( 'alpha_tool', 'client/control_plane_runtime', 'control_plane_ability' ),
+	array( 'alpha_tool', 'beta_tool', 'client/control_plane_runtime', 'client/runner_runtime', 'control_plane_ability', 'runner_ability' )
+);
+if ( false === $previous_policy_env ) {
+	putenv( 'DATAMACHINE_HOST_TOOL_POLICY_JSON' );
+} else {
+	putenv( 'DATAMACHINE_HOST_TOOL_POLICY_JSON=' . $previous_policy_env );
+}
+assert_policy_equals( array( 'client/runner_runtime', 'beta_tool', 'runner_ability' ), array_keys( $resolution['tools'] ), 'host policy keeps only runner-owned tools across local sources', $failures, $passes );
+assert_policy_equals( array( 'alpha_tool', 'client/control_plane_runtime', 'control_plane_ability' ), $resolution['evidence']['unavailable_required_tool_names'] ?? null, 'host policy reports control-plane required tools unavailable', $failures, $passes );
+assert_policy_equals( 'host_tool_policy', $resolution['evidence']['required_tool_resolution'][0]['reason'] ?? null, 'host policy records source-level rejection reason', $failures, $passes );
+assert_policy_equals( 'control_plane', $resolution['evidence']['required_tool_resolution'][0]['execution_location'] ?? null, 'host policy records rejected execution location', $failures, $passes );
+assert_policy_equals( 'runtime_tools', $resolution['evidence']['required_tool_resolution'][1]['source'] ?? null, 'host policy records rejected runtime tool source', $failures, $passes );
+assert_policy_equals( 'ability_tools', $resolution['evidence']['required_tool_resolution'][2]['source'] ?? null, 'host policy records rejected ability tool source', $failures, $passes );
+assert_policy_equals( array( 'client/runner_runtime' ), $resolution['evidence']['available_tool_sources'][0]['accepted_tool_names'] ?? null, 'runtime source excludes control-plane tool from accepted names', $failures, $passes );
+assert_policy_equals( array( 'beta_tool' ), $resolution['evidence']['available_tool_sources'][2]['accepted_tool_names'] ?? null, 'static registry evidence excludes control-plane tool from accepted names', $failures, $passes );
+assert_policy_equals( array( 'runner_ability' ), $resolution['evidence']['available_tool_sources'][3]['accepted_tool_names'] ?? null, 'ability source excludes control-plane tool from accepted names', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " pipeline policy assertions failed.\n";


### PR DESCRIPTION
## Summary
- Add a generic HostToolPolicy resolver for host-owned tool execution-location policy.
- Apply host policy across local tool sources before tools are accepted as runnable: runtime tools, adjacent handlers, static registry, and ability tools.
- Preserve source-level rejection evidence with reason, execution location, and source.
- Keep direct execute_workflow / execute_workflow_path support for agent bundle runs.

## Testing
- php tests/pipeline-tool-policy-snapshot-smoke.php
- php tests/agent-bundle-runner-contract-smoke.php
- php -l inc/Engine/AI/Tools/HostToolPolicy.php && php -l inc/Engine/AI/Tools/ToolSourceRegistry.php && php -l inc/Engine/AI/Tools/ToolPolicyResolver.php && php -l inc/Engine/Bundle/AgentBundleRunner.php && php -l tests/pipeline-tool-policy-snapshot-smoke.php && php -l tests/agent-bundle-runner-contract-smoke.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the generic host tool policy implementation, source-registry integration, and smoke-test updates for Chris to review and validate.
