### PR TITLE
Delegate host-owned tools through runtime path

### DIFF
--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -105,14 +105,9 @@ class ToolPolicyResolver {
 
 		// 1. Gather tools from Data Machine-owned sources.
 		$args['modes'] = $modes;
-		$source_trace  = null;
-		if ( ! empty( $args['capture_trace'] ) ) {
-			$source_trace = $this->tool_source_registry->gatherTrace( $modes, $args );
-			$tools        = $source_trace['tools'];
-		} else {
-			$tools = $this->gatherByModes( $modes, $args );
-		}
-		$tools        = $this->filterRuntimeToolsByPolicyOptIn( $tools, $args, $agent_policy );
+		$source_trace  = $this->tool_source_registry->gatherTrace( $modes, $args );
+		$tools         = $this->filterRuntimeToolsByPolicyOptIn( $source_trace['tools'], $args, $agent_policy );
+		$gathered_tools = $tools;
 
 		// 2. Delegate generic mode/allow/deny/category policy resolution to Agents API.
 		$policy_context = array_merge(
@@ -136,9 +131,8 @@ class ToolPolicyResolver {
 		}
 
 		$tools = $this->tool_policy->resolve( $tools, $policy_context );
-		if ( is_array( $source_trace ) ) {
-			$this->last_source_trace = $source_trace;
-		}
+		$tools = $this->restoreExplicitDelegatedRuntimeTools( $tools, $gathered_tools, $args, $agent_policy );
+		$this->last_source_trace = $source_trace;
 
 		// An explicitly-empty allow_only means "no optional tools." The generic
 		// substrate only applies a non-empty allow_only, so it would otherwise
@@ -392,6 +386,42 @@ class ToolPolicyResolver {
 		foreach ( $runtime_tool_names as $name ) {
 			if ( ! isset( $allowed[ $name ] ) ) {
 				unset( $tools[ $name ] );
+			}
+		}
+
+		return $tools;
+	}
+
+	/**
+	 * Restore explicit host-delegated runtime tools after generic policy filtering.
+	 *
+	 * The generic policy layer may drop minimal client-executed declarations that do
+	 * not look like local PHP tools. Host-delegated tools are still safe to expose
+	 * when the caller explicitly opted into them; execution is mediated by the
+	 * runtime-tool path rather than local PHP handlers.
+	 *
+	 * @param array      $tools          Resolved tools after generic policy filtering.
+	 * @param array      $gathered_tools Tools gathered before generic policy filtering.
+	 * @param array      $args           Resolver args.
+	 * @param array|null $agent_policy   Optional persisted agent policy.
+	 * @return array Resolved tools with explicit delegated runtime tools restored.
+	 */
+	private function restoreExplicitDelegatedRuntimeTools( array $tools, array $gathered_tools, array $args, ?array $agent_policy ): array {
+		$allowed = $this->policy_filter->string_list( $args['allow_only'] ?? array() );
+		foreach ( array( $agent_policy, $args['tool_policy'] ?? null ) as $policy ) {
+			if ( is_array( $policy ) && \WP_Agent_Tool_Policy::MODE_ALLOW === ( $policy['mode'] ?? \WP_Agent_Tool_Policy::MODE_DENY ) ) {
+				$allowed = array_merge( $allowed, $this->policy_filter->string_list( $policy['tools'] ?? array() ) );
+			}
+		}
+
+		foreach ( array_values( array_unique( $allowed ) ) as $tool_name ) {
+			if ( isset( $tools[ $tool_name ] ) || ! is_array( $gathered_tools[ $tool_name ] ?? null ) ) {
+				continue;
+			}
+
+			$tool = $gathered_tools[ $tool_name ];
+			if ( ! empty( $tool['runtime_tool'] ) && 'client' === (string) ( $tool['executor'] ?? '' ) && 'control_plane' === (string) ( $tool['runtime']['execution_location'] ?? '' ) ) {
+				$tools[ $tool_name ] = $tool;
 			}
 		}
 

--- a/inc/Engine/AI/Tools/ToolSourceRegistry.php
+++ b/inc/Engine/AI/Tools/ToolSourceRegistry.php
@@ -42,38 +42,8 @@ class ToolSourceRegistry {
 	 * @return array Tools keyed by tool name.
 	 */
 	public function gather( array $modes, array $args ): array {
-		if ( ! empty( $args['capture_trace'] ) ) {
-			$trace = $this->gatherTrace( $modes, $args );
-			return $trace['tools'];
-		}
-
-		$order_callback       = array( $this, 'orderSourcesForContext' );
-		$host_policy_callback = array( $this, 'filterSourceToolsForHostPolicy' );
-		if ( function_exists( 'add_filter' ) ) {
-			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical Agents API tool-source compatibility hook.
-			add_filter( 'agents_api_tool_source_order', $order_callback, 5, 3 );
-			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical Agents API tool-source compatibility hook.
-			add_filter( 'agents_api_tool_source_tools', $host_policy_callback, PHP_INT_MAX, 4 );
-		}
-
-		try {
-			return $this->registry->gather(
-				array_merge(
-					$args,
-					array(
-						'modes'        => $modes,
-						'tool_manager' => $this->tool_manager,
-					)
-				)
-			);
-		} finally {
-			if ( function_exists( 'remove_filter' ) ) {
-				// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical Agents API tool-source compatibility hook.
-				remove_filter( 'agents_api_tool_source_order', $order_callback, 5 );
-				// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical Agents API tool-source compatibility hook.
-				remove_filter( 'agents_api_tool_source_tools', $host_policy_callback, PHP_INT_MAX );
-			}
-		}
+		$trace = $this->gatherTrace( $modes, $args );
+		return $trace['tools'];
 	}
 
 	/**
@@ -184,7 +154,7 @@ class ToolSourceRegistry {
 			self::SOURCE_RUNTIME_TOOLS,
 			function ( array $context ) use ( $runtime_source ): array {
 				$modes = ToolPolicyResolver::normalizeModes( $context['modes'] ?? array() );
-				return $this->applyHostToolPolicy( $runtime_source( $modes, $context ), self::SOURCE_RUNTIME_TOOLS, $context );
+				return $runtime_source( $modes, $context );
 			}
 		);
 
@@ -192,7 +162,7 @@ class ToolSourceRegistry {
 			self::SOURCE_ADJACENT_HANDLERS,
 			function ( array $context ) use ( $handler_source ): array {
 				$modes = ToolPolicyResolver::normalizeModes( $context['modes'] ?? array() );
-				return $this->applyHostToolPolicy( $handler_source( $modes, $context, $this->tool_manager ), self::SOURCE_ADJACENT_HANDLERS, $context );
+				return $handler_source( $modes, $context, $this->tool_manager );
 			}
 		);
 
@@ -200,7 +170,7 @@ class ToolSourceRegistry {
 			self::SOURCE_STATIC_REGISTRY,
 			function ( array $context ) use ( $static_source ): array {
 				$modes = ToolPolicyResolver::normalizeModes( $context['modes'] ?? array() );
-				return $this->applyHostToolPolicy( $static_source( $modes, $context ), self::SOURCE_STATIC_REGISTRY, $context );
+				return $static_source( $modes, $context );
 			}
 		);
 
@@ -208,7 +178,7 @@ class ToolSourceRegistry {
 			self::SOURCE_ABILITY_TOOLS,
 			function ( array $context ) use ( $ability_source ): array {
 				$modes = ToolPolicyResolver::normalizeModes( $context['modes'] ?? array() );
-				return $this->applyHostToolPolicy( $ability_source( $modes, $context ), self::SOURCE_ABILITY_TOOLS, $context );
+				return $ability_source( $modes, $context );
 			}
 		);
 	}
@@ -237,14 +207,20 @@ class ToolSourceRegistry {
 				continue;
 			}
 
-			if ( $policy->isLocallyRunnable( $tool_name ) ) {
+			$execution_location = $policy->executionLocation( $tool_name );
+			if ( 'runner' === $execution_location ) {
+				continue;
+			}
+
+			if ( 'control_plane' === $execution_location ) {
+				$source_tools[ $tool_name ] = $this->delegateHostToolToControlPlane( $tool_definition, $tool_name, $source_slug );
 				continue;
 			}
 
 			$rejections[ $tool_name ] = array(
 				'tool_name'           => $tool_name,
 				'reason'              => 'host_tool_policy',
-				'execution_location'  => $policy->executionLocation( $tool_name ),
+				'execution_location'  => $execution_location,
 				'source'              => $source_slug,
 			);
 			unset( $source_tools[ $tool_name ] );
@@ -257,6 +233,34 @@ class ToolSourceRegistry {
 		}
 
 		return $source_tools;
+	}
+
+	/**
+	 * Convert a host-owned tool into a delegated runtime tool declaration.
+	 *
+	 * @param array<string,mixed> $tool_definition Original source tool definition.
+	 * @param string              $tool_name       Tool name.
+	 * @param string              $source_slug     Source slug.
+	 * @return array<string,mixed>
+	 */
+	private function delegateHostToolToControlPlane( array $tool_definition, string $tool_name, string $source_slug ): array {
+		$runtime = is_array( $tool_definition['runtime'] ?? null ) ? $tool_definition['runtime'] : array();
+
+		$tool_definition['name']              = is_string( $tool_definition['name'] ?? null ) && '' !== trim( (string) $tool_definition['name'] ) ? (string) $tool_definition['name'] : $tool_name;
+		$tool_definition['executor']          = 'client';
+		$tool_definition['external_executor'] = true;
+		$tool_definition['runtime_tool']      = true;
+		$tool_definition['runtime']           = array_merge(
+			$runtime,
+			array(
+				'environment'        => 'control_plane',
+				'capability_scope'   => 'control_plane',
+				'execution_location' => 'control_plane',
+				'source'             => $source_slug,
+			)
+		);
+
+		return $tool_definition;
 	}
 
 	/**

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -156,12 +156,15 @@ require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
 require_once __DIR__ . '/../inc/Core/Steps/WorkflowConfigFactory.php';
 require_once __DIR__ . '/../inc/Core/Steps/AI/ToolPolicy/PipelineToolPolicyArgs.php';
+require_once __DIR__ . '/../inc/Core/DataPath.php';
+require_once __DIR__ . '/../inc/Core/OutputContract.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-access-policy.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-declaration.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-policy-filter.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-policy.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-source-registry.php';
 require_once __DIR__ . '/../inc/Engine/AI/ToolSchemaNormalizer.php';
+require_once __DIR__ . '/../inc/Engine/AI/DataMachineCompletionAssertions.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/AbilityToolAdapter.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Policy/DataMachineAgentToolPolicyProvider.php';
@@ -455,7 +458,7 @@ $resolver_source = file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/ToolPol
 assert_policy_equals( 0, substr_count( $resolver_source, 'gatherWithMetadata(' ), 'evidence no longer manually replays metadata-only source gathering', $failures, $passes );
 assert_policy_equals( true, str_contains( $resolver_source, '$args[\'source_trace\'] = $this->last_source_trace' ), 'evidence builder receives captured trace metadata', $failures, $passes );
 
-echo "\n[11] host tool policy excludes non-runner local tools from every source:\n";
+echo "\n[11] host tool policy delegates control-plane tools from every source:\n";
 $previous_policy_env = getenv( 'DATAMACHINE_HOST_TOOL_POLICY_JSON' );
 putenv(
 	'DATAMACHINE_HOST_TOOL_POLICY_JSON=' . json_encode(
@@ -502,15 +505,34 @@ if ( false === $previous_policy_env ) {
 } else {
 	putenv( 'DATAMACHINE_HOST_TOOL_POLICY_JSON=' . $previous_policy_env );
 }
-assert_policy_equals( array( 'client/runner_runtime', 'beta_tool', 'runner_ability' ), array_keys( $resolution['tools'] ), 'host policy keeps only runner-owned tools across local sources', $failures, $passes );
-assert_policy_equals( array( 'alpha_tool', 'client/control_plane_runtime', 'control_plane_ability' ), $resolution['evidence']['unavailable_required_tool_names'] ?? null, 'host policy reports control-plane required tools unavailable', $failures, $passes );
-assert_policy_equals( 'host_tool_policy', $resolution['evidence']['required_tool_resolution'][0]['reason'] ?? null, 'host policy records source-level rejection reason', $failures, $passes );
-assert_policy_equals( 'control_plane', $resolution['evidence']['required_tool_resolution'][0]['execution_location'] ?? null, 'host policy records rejected execution location', $failures, $passes );
-assert_policy_equals( 'runtime_tools', $resolution['evidence']['required_tool_resolution'][1]['source'] ?? null, 'host policy records rejected runtime tool source', $failures, $passes );
-assert_policy_equals( 'ability_tools', $resolution['evidence']['required_tool_resolution'][2]['source'] ?? null, 'host policy records rejected ability tool source', $failures, $passes );
-assert_policy_equals( array( 'client/runner_runtime' ), $resolution['evidence']['available_tool_sources'][0]['accepted_tool_names'] ?? null, 'runtime source excludes control-plane tool from accepted names', $failures, $passes );
-assert_policy_equals( array( 'beta_tool' ), $resolution['evidence']['available_tool_sources'][2]['accepted_tool_names'] ?? null, 'static registry evidence excludes control-plane tool from accepted names', $failures, $passes );
-assert_policy_equals( array( 'runner_ability' ), $resolution['evidence']['available_tool_sources'][3]['accepted_tool_names'] ?? null, 'ability source excludes control-plane tool from accepted names', $failures, $passes );
+assert_policy_equals( array( 'client/control_plane_runtime', 'client/runner_runtime', 'alpha_tool', 'beta_tool', 'control_plane_ability', 'runner_ability' ), array_keys( $resolution['tools'] ), 'host policy keeps runner tools and delegated control-plane tools across local sources', $failures, $passes );
+assert_policy_equals( array(), $resolution['evidence']['unavailable_required_tool_names'] ?? null, 'host policy resolves control-plane required tools as delegated tools', $failures, $passes );
+assert_policy_equals( 'resolved', $resolution['evidence']['required_tool_resolution'][0]['status'] ?? null, 'host policy reports delegated static tool as resolved', $failures, $passes );
+assert_policy_equals( 'resolved', $resolution['evidence']['required_tool_resolution'][1]['status'] ?? null, 'host policy reports delegated runtime tool as resolved', $failures, $passes );
+assert_policy_equals( 'resolved', $resolution['evidence']['required_tool_resolution'][2]['status'] ?? null, 'host policy reports delegated ability tool as resolved', $failures, $passes );
+assert_policy_equals( 'client', $resolution['tools']['alpha_tool']['executor'] ?? null, 'control-plane static tool uses delegated client executor', $failures, $passes );
+assert_policy_equals( 'control_plane', $resolution['tools']['alpha_tool']['runtime']['execution_location'] ?? null, 'control-plane static tool records execution location', $failures, $passes );
+assert_policy_equals( 'client', $resolution['tools']['client/control_plane_runtime']['executor'] ?? null, 'control-plane runtime tool uses delegated client executor', $failures, $passes );
+assert_policy_equals( 'client', $resolution['tools']['control_plane_ability']['executor'] ?? null, 'control-plane ability tool uses delegated client executor', $failures, $passes );
+assert_policy_equals( array( 'client/control_plane_runtime', 'client/runner_runtime' ), $resolution['evidence']['available_tool_sources'][0]['accepted_tool_names'] ?? null, 'runtime source accepts delegated control-plane tool', $failures, $passes );
+assert_policy_equals( array( 'alpha_tool', 'beta_tool' ), $resolution['evidence']['available_tool_sources'][2]['accepted_tool_names'] ?? null, 'static registry evidence accepts delegated control-plane tool', $failures, $passes );
+assert_policy_equals( array( 'control_plane_ability', 'runner_ability' ), $resolution['evidence']['available_tool_sources'][3]['accepted_tool_names'] ?? null, 'ability source accepts delegated control-plane tool', $failures, $passes );
+
+$completion_assertions = new \DataMachine\Engine\AI\DataMachineCompletionAssertions(
+	array(
+		'complete_when_any' => array(
+			array(
+				'name'  => 'control_plane_path',
+				'tools' => array(
+					array( 'name' => 'alpha_tool' ),
+					array( 'name' => 'control_plane_ability' ),
+				),
+			),
+		),
+	)
+);
+assert_policy_equals( array(), $completion_assertions->unavailableRequiredToolNames( $resolution['tools'] ), 'complete_when_any treats delegated control-plane path as available', $failures, $passes );
+assert_policy_equals( array( 'alpha_tool', 'control_plane_ability' ), $completion_assertions->unavailableRequiredToolNames( array() ), 'complete_when_any still reports missing tools without a delegated path', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " pipeline policy assertions failed.\n";


### PR DESCRIPTION
## Summary
- route control-plane host-owned tools through Data Machine's generic client/runtime-tool path instead of removing them from model-visible tools
- make `ToolSourceRegistry::gather()` and `gatherWithMetadata()` share one source-composition path
- preserve disabled host-policy tools as unavailable while allowing explicitly enabled delegated control-plane tools to satisfy completion preflight

## Testing
- php -l inc/Engine/AI/Tools/ToolSourceRegistry.php
- php -l inc/Engine/AI/Tools/ToolPolicyResolver.php
- php tests/pipeline-tool-policy-snapshot-smoke.php
- php tests/agent-bundle-runner-contract-smoke.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the host-owned delegated tool path refactor and focused smoke coverage; Chris remains responsible for review and validation.
