### PR TITLE
Add deterministic job lifecycle transitions

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -120,7 +120,17 @@ class ExecuteStepAbility {
 		// RunFlowAbility). For batch child jobs this is the real transition from
 		// 'pending' → 'processing', ensuring recover-stuck only catches jobs
 		// that genuinely started but never finished.
-		$this->db_jobs->start_job( $job_id );
+		if ( ! $this->db_jobs->start_job( $job_id ) ) {
+			$job_after_start       = $this->db_jobs->get_job( $job_id );
+			$current_status        = is_array( $job_after_start ) ? (string) ( $job_after_start['status'] ?? '' ) : '';
+			$terminal_after_start = JobStatus::isStatusFinal( $current_status );
+
+			return array(
+				'success'        => false,
+				'error'          => $terminal_after_start ? sprintf( 'Job %d has terminal status "%s"; step execution skipped.', $job_id, $current_status ) : sprintf( 'Job %d could not be started from status "%s".', $job_id, $current_status ),
+				'terminal_state' => $terminal_after_start ? $current_status : null,
+			);
+		}
 
 		try {
 			$engine_snapshot = datamachine_get_engine_data( $job_id );
@@ -437,12 +447,18 @@ class ExecuteStepAbility {
 
 		// Status override: complete with override status and clean up.
 		if ( $status_override ) {
-			if ( str_starts_with( $status_override, JobStatus::FAILED ) === false ) {
-				$this->handleStepLifecycleCompleted( $job_id );
-			} else {
-				$this->handleStepLifecycleFailed( $job_id );
+			$transition = $this->db_jobs->transition_job_status_result( $job_id, $status_override, true );
+			if ( $transition['changed'] ) {
+				if ( str_starts_with( $status_override, JobStatus::FAILED ) === false ) {
+					$this->handleStepLifecycleCompleted( $job_id );
+				} else {
+					$this->handleStepLifecycleFailed( $job_id );
+				}
+
+				$cleanup = new FileCleanup();
+				$context = datamachine_get_file_context( $flow_id );
+				$cleanup->cleanup_job_data_packets( $job_id, $context );
 			}
-			$this->db_jobs->complete_job( $job_id, $status_override );
 
 			do_action(
 				'datamachine_log',
@@ -453,10 +469,6 @@ class ExecuteStepAbility {
 					'status' => $status_override,
 				)
 			);
-
-			$cleanup = new FileCleanup();
-			$context = datamachine_get_file_context( $flow_id );
-			$cleanup->cleanup_job_data_packets( $job_id, $context );
 
 			do_action(
 				'datamachine_log',
@@ -560,13 +572,15 @@ class ExecuteStepAbility {
 				);
 			}
 
-			// Notify lifecycle handlers after the full pipeline succeeds.
-			$this->handleStepLifecycleCompleted( $job_id );
+			$transition = $this->db_jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
+			if ( $transition['changed'] ) {
+				// Notify lifecycle handlers after the full pipeline succeeds.
+				$this->handleStepLifecycleCompleted( $job_id );
 
-			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED );
-			$cleanup = new FileCleanup();
-			$context = datamachine_get_file_context( $flow_id );
-			$cleanup->cleanup_job_data_packets( $job_id, $context );
+				$cleanup = new FileCleanup();
+				$context = datamachine_get_file_context( $flow_id );
+				$cleanup->cleanup_job_data_packets( $job_id, $context );
+			}
 
 			do_action(
 				'datamachine_log',

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -17,6 +17,7 @@
 namespace DataMachine\Core\Database\Jobs;
 
 use DataMachine\Core\Database\BaseRepository;
+use DataMachine\Core\Database\LifecycleStateTransition;
 use DataMachine\Core\ExecutionQuery;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\RunMetrics;
@@ -1253,25 +1254,13 @@ class Jobs extends BaseRepository {
 	 * @return bool True on success, false on failure.
 	 */
 	public function start_job( int $job_id, string $status = 'processing' ): bool {
-		if ( empty( $job_id ) ) {
-			return false;
-		}
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$updated = $this->wpdb->update(
-			$this->table_name,
-			array(
-				'status' => $status,
-			),
-			array( 'job_id' => $job_id ),
-			array( '%s' ), // Format for data
-			array( '%d' )  // Format for WHERE
-		);
+		$result = $this->transition_job_status_result( $job_id, $status );
 
-		if ( false !== $updated ) {
+		if ( $result['changed'] ) {
 			RunMetrics::start( $job_id, array( 'status' => $status ) );
 		}
 
-		return false !== $updated;
+		return $result['success'];
 	}
 
 	/**
@@ -1310,14 +1299,42 @@ class Jobs extends BaseRepository {
 	 * @return bool True on success, false on failure.
 	 */
 	public function transition_job_status( int $job_id, string $status, bool $require_final = false ): bool {
+		$result = $this->transition_job_status_result( $job_id, $status, $require_final );
+
+		return $result['success'];
+	}
+
+	/**
+	 * Transition a job status with compare-and-set/idempotent lifecycle details.
+	 *
+	 * Non-terminal jobs may move to another non-terminal state or to a terminal
+	 * state. Terminal jobs are immutable; repeating the same terminal state is an
+	 * idempotent success and does not run terminal side effects again.
+	 *
+	 * @param int    $job_id        The job ID.
+	 * @param string $status        The new status.
+	 * @param bool   $require_final Whether to reject non-final statuses.
+	 * @return array{success: bool, changed: bool, current_status: ?string, status: string}
+	 */
+	public function transition_job_status_result( int $job_id, string $status, bool $require_final = false ): array {
 
 		if ( empty( $job_id ) ) {
-			return false;
+			return array(
+				'success'        => false,
+				'changed'        => false,
+				'current_status' => null,
+				'status'         => $status,
+			);
 		}
 
 		$is_final = JobStatus::isStatusFinal( $status );
 		if ( $require_final && ! $is_final ) {
-			return false;
+			return array(
+				'success'        => false,
+				'changed'        => false,
+				'current_status' => null,
+				'status'         => $status,
+			);
 		}
 
 		// Truncate to fit varchar(255) column.
@@ -1325,28 +1342,87 @@ class Jobs extends BaseRepository {
 			$status = substr( $status, 0, 252 ) . '...';
 		}
 
-		$update_data = array( 'status' => $status );
-		$format      = array( '%s' );
+		$job = $this->get_job( $job_id );
+		if ( ! is_array( $job ) ) {
+			return array(
+				'success'        => false,
+				'changed'        => false,
+				'current_status' => null,
+				'status'         => $status,
+			);
+		}
+
+		$current_status = is_string( $job['status'] ?? null ) ? $job['status'] : '';
+		if ( $current_status === $status ) {
+			return array(
+				'success'        => true,
+				'changed'        => false,
+				'current_status' => $current_status,
+				'status'         => $status,
+			);
+		}
+
+		if ( JobStatus::isStatusFinal( $current_status ) ) {
+			return array(
+				'success'        => false,
+				'changed'        => false,
+				'current_status' => $current_status,
+				'status'         => $status,
+			);
+		}
+
+		$update_data = array();
+		$format      = array();
 		if ( $is_final ) {
 			$update_data['completed_at'] = current_time( 'mysql', true );
 			$format[]                    = '%s';
 		}
 
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$updated = $this->wpdb->update(
+		$updated = LifecycleStateTransition::compare_and_set(
+			$this->wpdb,
 			$this->table_name,
-			$update_data,
 			array( 'job_id' => $job_id ),
-			$format,
-			array( '%d' )
+			'status',
+			$current_status,
+			$status,
+			$update_data,
+			array( '%d' ),
+			$format
 		);
 
-		if ( false !== $updated && $is_final ) {
+		if ( false === $updated ) {
+			return array(
+				'success'        => false,
+				'changed'        => false,
+				'current_status' => $current_status,
+				'status'         => $status,
+			);
+		}
+
+		if ( 0 === $updated ) {
+			$job_after      = $this->get_job( $job_id );
+			$status_after   = is_array( $job_after ) && is_string( $job_after['status'] ?? null ) ? $job_after['status'] : null;
+			$race_was_no_op = $status_after === $status;
+
+			return array(
+				'success'        => $race_was_no_op,
+				'changed'        => false,
+				'current_status' => $status_after,
+				'status'         => $status,
+			);
+		}
+
+		if ( $is_final ) {
 			RunMetrics::complete( $job_id, $status );
 			do_action( 'datamachine_job_complete', $job_id, $status );
 		}
 
-		return false !== $updated;
+		return array(
+			'success'        => true,
+			'changed'        => true,
+			'current_status' => $current_status,
+			'status'         => $status,
+		);
 	}
 
 	// ---------------------------------------------------------------------

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Tests for job lifecycle status transitions.
+ *
+ * @package DataMachine\Tests\Unit\Core\Database
+ */
+
+namespace DataMachine\Tests\Unit\Core\Database;
+
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\JobStatus;
+use WP_UnitTestCase;
+
+class JobLifecycleTransitionTest extends WP_UnitTestCase {
+
+	private Jobs $db_jobs;
+
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+
+		if ( function_exists( 'datamachine_activate_for_site' ) ) {
+			datamachine_activate_for_site();
+		}
+	}
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->db_jobs = new Jobs();
+	}
+
+	public function test_terminal_status_cannot_be_overwritten_by_start_job(): void {
+		$job_id = $this->db_jobs->create_job( array( 'label' => 'Terminal immutability' ) );
+		$this->assertIsInt( $job_id );
+
+		$this->assertTrue( $this->db_jobs->complete_job( $job_id, JobStatus::FAILED ) );
+		$this->assertFalse( $this->db_jobs->start_job( $job_id, JobStatus::PROCESSING ) );
+
+		$job = $this->db_jobs->get_job( $job_id );
+		$this->assertSame( JobStatus::FAILED, $job['status'] );
+	}
+
+	public function test_terminal_transition_hook_only_fires_when_status_changes(): void {
+		$job_id = $this->db_jobs->create_job( array( 'label' => 'Terminal hook idempotency' ) );
+		$this->assertIsInt( $job_id );
+
+		$completed = array();
+		$listener  = static function ( int $completed_job_id, string $status ) use ( &$completed ): void {
+			$completed[] = array( $completed_job_id, $status );
+		};
+
+		add_action( 'datamachine_job_complete', $listener, 10, 2 );
+		try {
+			$first = $this->db_jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
+			$again = $this->db_jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
+
+			$this->assertTrue( $first['success'] );
+			$this->assertTrue( $first['changed'] );
+			$this->assertTrue( $again['success'] );
+			$this->assertFalse( $again['changed'] );
+			$this->assertSame( array( array( $job_id, JobStatus::COMPLETED ) ), $completed );
+		} finally {
+			remove_action( 'datamachine_job_complete', $listener, 10 );
+		}
+	}
+
+	public function test_terminal_status_can_move_from_active_once(): void {
+		$job_id = $this->db_jobs->create_job( array( 'label' => 'Active to terminal' ) );
+		$this->assertIsInt( $job_id );
+
+		$this->assertTrue( $this->db_jobs->start_job( $job_id, JobStatus::PROCESSING ) );
+
+		$completed = $this->db_jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED_NO_ITEMS, true );
+		$failed    = $this->db_jobs->transition_job_status_result( $job_id, JobStatus::FAILED, true );
+
+		$this->assertTrue( $completed['success'] );
+		$this->assertTrue( $completed['changed'] );
+		$this->assertFalse( $failed['success'] );
+		$this->assertFalse( $failed['changed'] );
+
+		$job = $this->db_jobs->get_job( $job_id );
+		$this->assertSame( JobStatus::COMPLETED_NO_ITEMS, $job['status'] );
+	}
+}


### PR DESCRIPTION
## Summary
- Centralizes job status transitions through a compare-and-set/idempotent lifecycle primitive backed by LifecycleStateTransition.
- Preserves terminal job immutability so active loops cannot overwrite completed/failed jobs.
- Runs terminal accounting, hooks, step lifecycle callbacks, and cleanup only when the stored job status actually changes.
- Adds focused unit coverage for terminal immutability and idempotent terminal transitions.

## Tests
- `php -l inc/Core/Database/Jobs/Jobs.php`
- `php -l inc/Abilities/Engine/ExecuteStepAbility.php`
- `php -l tests/Unit/Core/Database/JobLifecycleTransitionTest.php`
- `homeboy test --skip-lint --changed-since=origin/main`
- `./vendor/bin/phpcs inc/Core/Database/Jobs/Jobs.php inc/Abilities/Engine/ExecuteStepAbility.php tests/Unit/Core/Database/JobLifecycleTransitionTest.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the lifecycle transition implementation, targeted tests, and verification commands for Chris to review.