### PR TITLE
Add versioned engine state ledger

### DIFF
--- a/inc/Core/EngineData.php
+++ b/inc/Core/EngineData.php
@@ -121,13 +121,13 @@ class EngineData {
 	}
 
 	/**
-	 * Append a versioned state event and persist its patch as the current snapshot projection.
+	 * Append a compact state event trace and persist its patch as the current snapshot projection.
 	 *
 	 * @param int    $job_id   Job ID.
 	 * @param string $type     Generic event type.
 	 * @param array  $patch    Engine data patch to project onto the snapshot.
 	 * @param array  $metadata Optional event metadata.
-	 * @return array|null Appended ledger entry on success, null on failure.
+	 * @return array|null Appended trace entry on success, null on failure.
 	 */
 	public static function appendStateEvent( int $job_id, string $type, array $patch, array $metadata = array() ): ?array {
 		if ( $job_id <= 0 || '' === trim( $type ) ) {
@@ -141,7 +141,8 @@ class EngineData {
 			'version'     => $version,
 			'type'        => sanitize_key( $type ),
 			'recorded_at' => gmdate( 'c' ),
-			'patch'       => $patch,
+			'patch_keys'  => array_keys( $patch ),
+			'patch_hash'  => self::stableHash( $patch ),
 		);
 
 		if ( ! empty( $metadata ) ) {
@@ -170,6 +171,46 @@ class EngineData {
 		}
 
 		return $version + 1;
+	}
+
+	/**
+	 * Build a stable hash for a projected state patch.
+	 *
+	 * @param array $patch Engine data patch.
+	 * @return string sha256 hash prefixed for readability.
+	 */
+	private static function stableHash( array $patch ): string {
+		$normalized = self::sortRecursively( $patch );
+		$json       = wp_json_encode( $normalized );
+
+		if ( ! is_string( $json ) ) {
+			$json = serialize( $normalized );
+		}
+
+		return 'sha256:' . hash( 'sha256', $json );
+	}
+
+	/**
+	 * Recursively sort associative array keys for deterministic hashing.
+	 *
+	 * @param mixed $value Value to sort.
+	 * @return mixed Sorted value.
+	 */
+	private static function sortRecursively( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$sorted = array();
+		foreach ( $value as $key => $item ) {
+			$sorted[ $key ] = self::sortRecursively( $item );
+		}
+
+		if ( array_keys( $sorted ) !== range( 0, count( $sorted ) - 1 ) ) {
+			ksort( $sorted );
+		}
+
+		return $sorted;
 	}
 
 	/**

--- a/inc/Core/EngineData.php
+++ b/inc/Core/EngineData.php
@@ -149,8 +149,8 @@ class EngineData {
 			$entry['metadata'] = $metadata;
 		}
 
-		$ledger[]                         = $entry;
-		$projected                        = array_replace_recursive( $current, $patch );
+		$ledger[]                          = $entry;
+		$projected                         = array_replace_recursive( $current, $patch );
 		$projected['_engine_state_ledger'] = $ledger;
 
 		return self::persist( $job_id, $projected ) ? $entry : null;
@@ -181,10 +181,10 @@ class EngineData {
 	 */
 	private static function stableHash( array $patch ): string {
 		$normalized = self::sortRecursively( $patch );
-		$json       = wp_json_encode( $normalized );
+		$json       = wp_json_encode( $normalized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PARTIAL_OUTPUT_ON_ERROR );
 
 		if ( ! is_string( $json ) ) {
-			$json = serialize( $normalized );
+			$json = 'null';
 		}
 
 		return 'sha256:' . hash( 'sha256', $json );

--- a/inc/Core/EngineData.php
+++ b/inc/Core/EngineData.php
@@ -121,6 +121,58 @@ class EngineData {
 	}
 
 	/**
+	 * Append a versioned state event and persist its patch as the current snapshot projection.
+	 *
+	 * @param int    $job_id   Job ID.
+	 * @param string $type     Generic event type.
+	 * @param array  $patch    Engine data patch to project onto the snapshot.
+	 * @param array  $metadata Optional event metadata.
+	 * @return array|null Appended ledger entry on success, null on failure.
+	 */
+	public static function appendStateEvent( int $job_id, string $type, array $patch, array $metadata = array() ): ?array {
+		if ( $job_id <= 0 || '' === trim( $type ) ) {
+			return null;
+		}
+
+		$current = self::retrieve( $job_id );
+		$ledger  = is_array( $current['_engine_state_ledger'] ?? null ) ? $current['_engine_state_ledger'] : array();
+		$version = self::nextLedgerVersion( $ledger );
+		$entry   = array(
+			'version'     => $version,
+			'type'        => sanitize_key( $type ),
+			'recorded_at' => gmdate( 'c' ),
+			'patch'       => $patch,
+		);
+
+		if ( ! empty( $metadata ) ) {
+			$entry['metadata'] = $metadata;
+		}
+
+		$ledger[]                         = $entry;
+		$projected                        = array_replace_recursive( $current, $patch );
+		$projected['_engine_state_ledger'] = $ledger;
+
+		return self::persist( $job_id, $projected ) ? $entry : null;
+	}
+
+	/**
+	 * Resolve the next monotonically increasing ledger version.
+	 *
+	 * @param array $ledger Existing ledger entries.
+	 * @return int Next version number.
+	 */
+	private static function nextLedgerVersion( array $ledger ): int {
+		$version = 0;
+		foreach ( $ledger as $entry ) {
+			if ( is_array( $entry ) && isset( $entry['version'] ) ) {
+				$version = max( $version, (int) $entry['version'] );
+			}
+		}
+
+		return $version + 1;
+	}
+
+	/**
 	 * Set a value in the engine data and persist it.
 	 *
 	 * @param string $key   Data key.

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -2012,7 +2012,8 @@ function datamachine_persist_inflight_tool_summary( array $loop_payload, array $
 function datamachine_record_tool_results_to_engine_data( array $loop_payload, array $tool_execution_results ): void {
 	$job_id    = (int) ( $loop_payload['job_id'] ?? 0 );
 	$recorders = is_array( $loop_payload['tool_recorders'] ?? null ) ? $loop_payload['tool_recorders'] : array();
-	if ( $job_id <= 0 || empty( $recorders ) || ! function_exists( '\datamachine_merge_engine_data' ) ) {
+	$can_record = function_exists( '\datamachine_append_engine_state_event' ) || function_exists( '\datamachine_merge_engine_data' );
+	if ( $job_id <= 0 || empty( $recorders ) || ! $can_record ) {
 		return;
 	}
 
@@ -2045,6 +2046,16 @@ function datamachine_record_tool_results_to_engine_data( array $loop_payload, ar
 				$engine_data[ $key ] = array_merge( is_array( $engine_data[ $key ] ?? null ) ? $engine_data[ $key ] : array(), $values );
 			}
 		}
+	}
+
+	if ( ! empty( $engine_data ) && function_exists( '\datamachine_append_engine_state_event' ) ) {
+		\datamachine_append_engine_state_event(
+			$job_id,
+			'tool_result_recorded',
+			$engine_data,
+			array( 'source' => 'conversation_loop' )
+		);
+		return;
 	}
 
 	if ( ! empty( $engine_data ) ) {

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -2010,8 +2010,8 @@ function datamachine_persist_inflight_tool_summary( array $loop_payload, array $
  * @param array<int,array<string,mixed>> $tool_execution_results Tool execution results accumulated by the loop.
  */
 function datamachine_record_tool_results_to_engine_data( array $loop_payload, array $tool_execution_results ): void {
-	$job_id    = (int) ( $loop_payload['job_id'] ?? 0 );
-	$recorders = is_array( $loop_payload['tool_recorders'] ?? null ) ? $loop_payload['tool_recorders'] : array();
+	$job_id     = (int) ( $loop_payload['job_id'] ?? 0 );
+	$recorders  = is_array( $loop_payload['tool_recorders'] ?? null ) ? $loop_payload['tool_recorders'] : array();
 	$can_record = function_exists( '\datamachine_append_engine_state_event' ) || function_exists( '\datamachine_merge_engine_data' );
 	if ( $job_id <= 0 || empty( $recorders ) || ! $can_record ) {
 		return;

--- a/inc/Engine/Filters/EngineData.php
+++ b/inc/Engine/Filters/EngineData.php
@@ -50,7 +50,7 @@ function datamachine_merge_engine_data( int $job_id, array $data ): bool {
 }
 
 /**
- * Append a versioned engine state event and persist its patch as the current snapshot projection.
+ * Append a compact engine state event trace and persist its patch as the current snapshot projection.
  *
  * @param int    $job_id   Job ID.
  * @param string $type     Generic event type.

--- a/inc/Engine/Filters/EngineData.php
+++ b/inc/Engine/Filters/EngineData.php
@@ -50,6 +50,27 @@ function datamachine_merge_engine_data( int $job_id, array $data ): bool {
 }
 
 /**
+ * Append a versioned engine state event and persist its patch as the current snapshot projection.
+ *
+ * @param int    $job_id   Job ID.
+ * @param string $type     Generic event type.
+ * @param array  $patch    Engine data patch to project onto the snapshot.
+ * @param array  $metadata Optional event metadata.
+ * @return array|null Appended ledger entry on success, null on failure.
+ */
+function datamachine_append_engine_state_event( int $job_id, string $type, array $patch, array $metadata = array() ): ?array {
+	$entry = \DataMachine\Core\EngineData::appendStateEvent( $job_id, $type, $patch, $metadata );
+	if ( is_array( $entry ) ) {
+		$snapshot = \DataMachine\Core\EngineData::retrieve( $job_id );
+		if ( datamachine_engine_data_should_write_artifact_files( $snapshot ) ) {
+			datamachine_write_engine_data_artifact_files( $job_id );
+		}
+	}
+
+	return $entry;
+}
+
+/**
  * Determine whether an engine data snapshot has enough runtime artifact data to
  * emit first-class transcript/tool-trace files.
  *

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -29,6 +29,18 @@ if ( ! function_exists( 'datamachine_merge_engine_data' ) ) {
 	}
 }
 
+if ( ! function_exists( 'datamachine_append_engine_state_event' ) ) {
+	function datamachine_append_engine_state_event( int $job_id, string $type, array $patch, array $metadata = array() ): ?array {
+		$GLOBALS['datamachine_bundle_runner_engine_data_merges'][] = array(
+			'job_id'   => $job_id,
+			'type'     => $type,
+			'data'     => $patch,
+			'metadata' => $metadata,
+		);
+		return array( 'version' => count( $GLOBALS['datamachine_bundle_runner_engine_data_merges'] ) );
+	}
+}
+
 function datamachine_bundle_runner_assert( bool $condition, string $label, array &$failures, int &$passes ): void {
 	if ( $condition ) {
 		++$passes;
@@ -311,6 +323,7 @@ $GLOBALS['datamachine_bundle_runner_engine_data_merges'] = array();
 );
 $recorded_merge = $GLOBALS['datamachine_bundle_runner_engine_data_merges'][0] ?? array();
 datamachine_bundle_runner_assert( 77 === ( $recorded_merge['job_id'] ?? null ), 'tool recorder writes to the owning job', $failures, $passes );
+datamachine_bundle_runner_assert( 'tool_result_recorded' === ( $recorded_merge['type'] ?? null ), 'tool recorder uses versioned append path when available', $failures, $passes );
 datamachine_bundle_runner_assert( 'static/issue-460-design-direction' === ( $recorded_merge['data']['static_site_agent']['branch'] ?? null ), 'tool recorder maps branch from result data', $failures, $passes );
 datamachine_bundle_runner_assert( 'https://github.com/chubes4/wp-site-generator/pull/461' === ( $recorded_merge['data']['static_site_agent']['pr_url'] ?? null ), 'tool recorder maps PR URL from result data', $failures, $passes );
 datamachine_bundle_runner_assert( 'issue-460-design-direction' === ( $recorded_merge['data']['static_site_agent']['slug'] ?? null ), 'tool recorder applies strip_prefix transforms', $failures, $passes );

--- a/tests/engine-state-ledger-smoke.php
+++ b/tests/engine-state-ledger-smoke.php
@@ -99,7 +99,9 @@ namespace {
 	datamachine_engine_state_ledger_assert( 'snapshot-value' === ( $snapshot['existing'] ?? null ), 'snapshot compatibility preserves existing keys', $failures, $passes );
 	datamachine_engine_state_ledger_assert( 'alpha' === ( $snapshot['tool_outputs']['first'] ?? null ), 'snapshot projection includes appended patch data', $failures, $passes );
 	datamachine_engine_state_ledger_assert( true === ( $snapshot['nested']['before'] ?? null ) && true === ( $snapshot['nested']['after'] ?? null ), 'snapshot projection recursively merges patches', $failures, $passes );
-	datamachine_engine_state_ledger_assert( 'trace.json' === ( $ledger[1]['patch']['artifact_files']['trace'] ?? null ), 'ledger retains append-only patch evidence', $failures, $passes );
+	datamachine_engine_state_ledger_assert( in_array( 'artifact_files', $ledger[1]['patch_keys'] ?? array(), true ), 'ledger records compact patch keys', $failures, $passes );
+	datamachine_engine_state_ledger_assert( is_string( $ledger[1]['patch_hash'] ?? null ) && 0 === strpos( $ledger[1]['patch_hash'], 'sha256:' ), 'ledger records deterministic patch hash', $failures, $passes );
+	datamachine_engine_state_ledger_assert( ! array_key_exists( 'patch', $ledger[1] ?? array() ), 'ledger omits full patch payload by default', $failures, $passes );
 
 	if ( ! empty( $failures ) ) {
 		echo "\nFailures:\n";

--- a/tests/engine-state-ledger-smoke.php
+++ b/tests/engine-state-ledger-smoke.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Smoke test for versioned engine state ledger behavior.
+ *
+ * Run with: php tests/engine-state-ledger-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core\Database\Jobs {
+	class Jobs {
+		public static array $engine_data = array();
+
+		public function retrieve_engine_data( int $job_id ): array {
+			return self::$engine_data[ $job_id ] ?? array();
+		}
+
+		public function store_engine_data( int $job_id, array $data ): bool {
+			self::$engine_data[ $job_id ] = $data;
+			return true;
+		}
+	}
+}
+
+namespace {
+	$root     = dirname( __DIR__ );
+	$failures = array();
+	$passes   = 0;
+
+	defined( 'ABSPATH' ) || define( 'ABSPATH', $root . '/' );
+
+	function datamachine_engine_state_ledger_assert( bool $condition, string $label, array &$failures, int &$passes ): void {
+		if ( $condition ) {
+			++$passes;
+			echo "  PASS {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "  FAIL {$label}\n";
+	}
+
+	if ( ! function_exists( 'wp_cache_get' ) ) {
+		function wp_cache_get( $key, $group = '' ) {
+			return $GLOBALS['datamachine_engine_state_ledger_cache'][ $group ][ $key ] ?? false;
+		}
+	}
+
+	if ( ! function_exists( 'wp_cache_set' ) ) {
+		function wp_cache_set( $key, $data, $group = '' ): bool {
+			$GLOBALS['datamachine_engine_state_ledger_cache'][ $group ][ $key ] = $data;
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( string $key ): string {
+			return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $key ) ) ?? '';
+		}
+	}
+
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $value ) {
+			return json_encode( $value );
+		}
+	}
+
+	require_once $root . '/inc/Core/EngineData.php';
+	require_once $root . '/inc/Engine/Filters/EngineData.php';
+
+	\datamachine_set_engine_data(
+		101,
+		array(
+			'existing' => 'snapshot-value',
+			'nested'   => array( 'before' => true ),
+		)
+	);
+
+	$first = \datamachine_append_engine_state_event(
+		101,
+		'tool_result_recorded',
+		array(
+			'tool_outputs' => array( 'first' => 'alpha' ),
+			'nested'       => array( 'after' => true ),
+		)
+	);
+	$second = \datamachine_append_engine_state_event(
+		101,
+		'artifact_recorded',
+		array( 'artifact_files' => array( 'trace' => 'trace.json' ) )
+	);
+
+	$snapshot = \datamachine_get_engine_data( 101 );
+	$ledger   = $snapshot['_engine_state_ledger'] ?? array();
+
+	datamachine_engine_state_ledger_assert( 1 === ( $first['version'] ?? null ), 'first append starts at version 1', $failures, $passes );
+	datamachine_engine_state_ledger_assert( 2 === ( $second['version'] ?? null ), 'second append increments version monotonically', $failures, $passes );
+	datamachine_engine_state_ledger_assert( 2 === count( $ledger ), 'append path preserves both ledger entries', $failures, $passes );
+	datamachine_engine_state_ledger_assert( 'snapshot-value' === ( $snapshot['existing'] ?? null ), 'snapshot compatibility preserves existing keys', $failures, $passes );
+	datamachine_engine_state_ledger_assert( 'alpha' === ( $snapshot['tool_outputs']['first'] ?? null ), 'snapshot projection includes appended patch data', $failures, $passes );
+	datamachine_engine_state_ledger_assert( true === ( $snapshot['nested']['before'] ?? null ) && true === ( $snapshot['nested']['after'] ?? null ), 'snapshot projection recursively merges patches', $failures, $passes );
+	datamachine_engine_state_ledger_assert( 'trace.json' === ( $ledger[1]['patch']['artifact_files']['trace'] ?? null ), 'ledger retains append-only patch evidence', $failures, $passes );
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFailures:\n";
+		foreach ( $failures as $failure ) {
+			echo " - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\nEngine state ledger smoke passed ({$passes} assertions).\n";
+}


### PR DESCRIPTION
## Summary
- Add a minimal versioned engine-state append primitive that records generic events under `_engine_state_ledger` while projecting patches into the existing engine data snapshot.
- Expose `datamachine_append_engine_state_event()` alongside the existing snapshot helpers.
- Migrate tool result recorder writes to use the append path when available, preserving the existing snapshot projection/fallback behavior.

## Tests
- `php tests/engine-state-ledger-smoke.php`
- `php tests/agent-bundle-runner-contract-smoke.php`
- `php -l inc/Core/EngineData.php && php -l inc/Engine/Filters/EngineData.php && php -l inc/Engine/AI/conversation-loop.php && php -l tests/engine-state-ledger-smoke.php`
- `./vendor/bin/phpcs inc/Core/EngineData.php inc/Engine/Filters/EngineData.php inc/Engine/AI/conversation-loop.php tests/engine-state-ledger-smoke.php tests/agent-bundle-runner-contract-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the minimal implementation, focused smoke coverage, and verification commands for Chris to review.