### PR TITLE
Add runtime tool run state store

### DIFF
--- a/inc/Engine/AI/RuntimeToolRunStateStore.php
+++ b/inc/Engine/AI/RuntimeToolRunStateStore.php
@@ -158,11 +158,11 @@ class RuntimeToolRunStateStore {
 			return $state;
 		}
 
-		$timestamp                              = $this->timestamp();
-		$state['status']                        = $status;
-		$state[ $payload_key ]                  = $payload;
-		$state[ $timestamp_key ]                = $timestamp;
-		$state['updated_at']                    = $timestamp;
+		$timestamp                             = $this->timestamp();
+		$state['status']                       = $status;
+		$state[ $payload_key ]                 = $payload;
+		$state[ $timestamp_key ]               = $timestamp;
+		$state['updated_at']                   = $timestamp;
 		$engine_data['runtime_tool_run_state'] = $state;
 
 		$this->jobs->store_engine_data( $job_id, $engine_data );
@@ -204,7 +204,7 @@ class RuntimeToolRunStateStore {
 	private function required_string( array $state, string $key ): string {
 		$value = trim( (string) ( $state[ $key ] ?? '' ) );
 		if ( '' === $value ) {
-			throw new \InvalidArgumentException( "Runtime tool run state requires {$key}." );
+			throw new \InvalidArgumentException( sprintf( 'Runtime tool run state requires %s.', esc_html( $key ) ) );
 		}
 
 		return $value;

--- a/inc/Engine/AI/RuntimeToolRunStateStore.php
+++ b/inc/Engine/AI/RuntimeToolRunStateStore.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Durable runtime-tool run state storage.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+use DataMachine\Core\Database\Jobs\Jobs;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Stores deterministic runtime-tool pause/resume state on the request job.
+ */
+class RuntimeToolRunStateStore {
+
+	public const STATUS_PENDING   = 'pending';
+	public const STATUS_FINALIZED = 'finalized';
+	public const STATUS_RESUMED   = 'resumed';
+	public const STATUS_TIMED_OUT = 'timed_out';
+
+	/**
+	 * Jobs repository.
+	 *
+	 * @var object
+	 */
+	private object $jobs;
+
+	/**
+	 * @param object|null $jobs Jobs-like repository with retrieve_engine_data() and store_engine_data().
+	 */
+	public function __construct( ?object $jobs = null ) {
+		$this->jobs = $jobs ?? new Jobs();
+	}
+
+	/**
+	 * Create pending runtime-tool run state for a request job.
+	 *
+	 * @param int                  $job_id Request job ID.
+	 * @param array<string,mixed>  $state  Initial state fields.
+	 * @return array<string,mixed>
+	 */
+	public function create( int $job_id, array $state ): array {
+		$this->assert_job_id( $job_id );
+
+		$engine_data = $this->engine_data( $job_id );
+		$existing    = $this->normalize_existing( $engine_data['runtime_tool_run_state'] ?? null );
+		if ( ! empty( $existing ) ) {
+			return $existing;
+		}
+
+		$created_at = $this->timestamp();
+		$run_state  = array(
+			'parent_job_id'           => max( 0, (int) ( $state['parent_job_id'] ?? 0 ) ),
+			'runtime_tool_request_id' => $this->required_string( $state, 'runtime_tool_request_id' ),
+			'tool_name'               => $this->required_string( $state, 'tool_name' ),
+			'status'                  => self::STATUS_PENDING,
+			'timeout_seconds'         => max( 0, (int) ( $state['timeout_seconds'] ?? 0 ) ),
+			'deadline_at'             => (string) ( $state['deadline_at'] ?? '' ),
+			'resume_payload'          => null,
+			'finalize_payload'        => null,
+			'created_at'              => $created_at,
+			'updated_at'              => $created_at,
+			'finalized_at'            => null,
+			'resumed_at'              => null,
+		);
+
+		$engine_data['runtime_tool_run_state'] = $run_state;
+		$this->jobs->store_engine_data( $job_id, $engine_data );
+
+		return $run_state;
+	}
+
+	/**
+	 * Create pending state from a canonical Agents API runtime-tool request.
+	 *
+	 * @param array<string,mixed> $request Canonical runtime-tool request.
+	 * @return array<string,mixed>|null
+	 */
+	public function create_from_request( array $request ): ?array {
+		$metadata = is_array( $request['metadata']['datamachine'] ?? null ) ? $request['metadata']['datamachine'] : array();
+		$job_id   = max( 0, (int) ( $metadata['job_id'] ?? 0 ) );
+		if ( $job_id <= 0 ) {
+			return null;
+		}
+
+		return $this->create(
+			$job_id,
+			array(
+				'parent_job_id'           => max( 0, (int) ( $metadata['parent_job_id'] ?? 0 ) ),
+				'runtime_tool_request_id' => (string) ( $request['request_id'] ?? '' ),
+				'tool_name'               => (string) ( $request['tool_name'] ?? '' ),
+				'timeout_seconds'         => max( 0, (int) ( $metadata['timeout_seconds'] ?? 0 ) ),
+				'deadline_at'             => (string) ( $request['timeout_at'] ?? $metadata['expires_at'] ?? '' ),
+			)
+		);
+	}
+
+	/**
+	 * Read runtime-tool run state from a request job.
+	 *
+	 * @param int $job_id Request job ID.
+	 * @return array<string,mixed>|null
+	 */
+	public function get( int $job_id ): ?array {
+		$this->assert_job_id( $job_id );
+
+		$state = $this->normalize_existing( $this->engine_data( $job_id )['runtime_tool_run_state'] ?? null );
+
+		return empty( $state ) ? null : $state;
+	}
+
+	/**
+	 * Persist a deterministic finalize payload once.
+	 *
+	 * @param int                 $job_id  Request job ID.
+	 * @param array<string,mixed> $payload Finalize payload.
+	 * @param string              $status  Finalized status.
+	 * @return array<string,mixed>|null
+	 */
+	public function finalize( int $job_id, array $payload, string $status = self::STATUS_FINALIZED ): ?array {
+		return $this->transition_once( $job_id, 'finalized_at', 'finalize_payload', $payload, $status );
+	}
+
+	/**
+	 * Persist a deterministic resume payload once.
+	 *
+	 * @param int                 $job_id  Request job ID.
+	 * @param array<string,mixed> $payload Resume payload.
+	 * @return array<string,mixed>|null
+	 */
+	public function resume( int $job_id, array $payload ): ?array {
+		return $this->transition_once( $job_id, 'resumed_at', 'resume_payload', $payload, self::STATUS_RESUMED );
+	}
+
+	/**
+	 * Apply a one-time state transition.
+	 *
+	 * @param int                 $job_id      Request job ID.
+	 * @param string              $timestamp_key Timestamp field name.
+	 * @param string              $payload_key Payload field name.
+	 * @param array<string,mixed> $payload     Payload to persist.
+	 * @param string              $status      New status.
+	 * @return array<string,mixed>|null
+	 */
+	private function transition_once( int $job_id, string $timestamp_key, string $payload_key, array $payload, string $status ): ?array {
+		$this->assert_job_id( $job_id );
+
+		$engine_data = $this->engine_data( $job_id );
+		$state       = $this->normalize_existing( $engine_data['runtime_tool_run_state'] ?? null );
+		if ( empty( $state ) ) {
+			return null;
+		}
+
+		if ( ! empty( $state[ $timestamp_key ] ) ) {
+			return $state;
+		}
+
+		$timestamp                              = $this->timestamp();
+		$state['status']                        = $status;
+		$state[ $payload_key ]                  = $payload;
+		$state[ $timestamp_key ]                = $timestamp;
+		$state['updated_at']                    = $timestamp;
+		$engine_data['runtime_tool_run_state'] = $state;
+
+		$this->jobs->store_engine_data( $job_id, $engine_data );
+
+		return $state;
+	}
+
+	/**
+	 * @param int $job_id Request job ID.
+	 * @return array<string,mixed>
+	 */
+	private function engine_data( int $job_id ): array {
+		$engine_data = $this->jobs->retrieve_engine_data( $job_id );
+
+		return is_array( $engine_data ) ? $engine_data : array();
+	}
+
+	/**
+	 * @param mixed $state Raw state.
+	 * @return array<string,mixed>
+	 */
+	private function normalize_existing( $state ): array {
+		return is_array( $state ) ? $state : array();
+	}
+
+	/**
+	 * @param int $job_id Request job ID.
+	 */
+	private function assert_job_id( int $job_id ): void {
+		if ( $job_id <= 0 ) {
+			throw new \InvalidArgumentException( 'Runtime tool run state requires a positive job id.' );
+		}
+	}
+
+	/**
+	 * @param array<string,mixed> $state Initial state fields.
+	 * @param string              $key Required key.
+	 */
+	private function required_string( array $state, string $key ): string {
+		$value = trim( (string) ( $state[ $key ] ?? '' ) );
+		if ( '' === $value ) {
+			throw new \InvalidArgumentException( "Runtime tool run state requires {$key}." );
+		}
+
+		return $value;
+	}
+
+	private function timestamp(): string {
+		return gmdate( 'c' );
+	}
+}

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1344,6 +1344,7 @@ function datamachine_prepare_runtime_tool_request( array $request, array $payloa
 			'metadata'     => array(
 				'datamachine' => array(
 					'job_id'             => (int) $job_id,
+					'parent_job_id'      => max( 0, (int) ( $payload['job_id'] ?? $request['job_id'] ?? 0 ) ),
 					'persistence_status' => 'pending',
 					'session_id'         => (string) ( $request['session_id'] ?? '' ),
 					'user_id'            => (int) ( $payload['user_id'] ?? 0 ),
@@ -1422,8 +1423,9 @@ function datamachine_runtime_tool_request_store(): WP_Agent_Runtime_Tool_Request
 				$jobs_db->store_engine_data(
 					$job_id,
 					array(
-						'task_type'            => 'runtime_tool_request',
-						'runtime_tool_request' => $request,
+						'task_type'              => 'runtime_tool_request',
+						'runtime_tool_request'   => $request,
+						'runtime_tool_run_state' => ( new RuntimeToolRunStateStore( $jobs_db ) )->create_from_request( $request ),
 					)
 				);
 				datamachine_store_runtime_tool_request_on_session( $request );
@@ -1467,6 +1469,13 @@ function datamachine_runtime_tool_request_store(): WP_Agent_Runtime_Tool_Request
 				$datamachine_metadata['result']             = $result;
 				$request['metadata']['datamachine']         = $datamachine_metadata;
 				$engine_data['runtime_tool_request']        = $request;
+				$engine_data['runtime_tool_run_state']      = ( new RuntimeToolRunStateStore( $jobs_db ) )->finalize(
+					$job_id,
+					array( 'result' => $result ),
+					! empty( $result['metadata']['datamachine']['code'] ) && WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT === (string) $result['metadata']['datamachine']['code']
+						? RuntimeToolRunStateStore::STATUS_TIMED_OUT
+						: RuntimeToolRunStateStore::STATUS_FINALIZED
+				);
 
 				$jobs_db->store_engine_data( $job_id, $engine_data );
 				$jobs_db->complete_job( $job_id, ! empty( $result['success'] ) ? 'completed' : 'failed' );
@@ -1687,6 +1696,17 @@ function datamachine_resume_runtime_tool_request( string $request_id ): void {
 	$datamachine_metadata = datamachine_runtime_tool_datamachine_metadata( $request );
 	if ( 'pending' === (string) ( $datamachine_metadata['persistence_status'] ?? '' ) ) {
 		return;
+	}
+
+	$job_id = datamachine_runtime_tool_job_id_from_request_id( $request_id );
+	if ( $job_id > 0 ) {
+		( new RuntimeToolRunStateStore() )->resume(
+			$job_id,
+			array(
+				'session_id' => (string) ( $datamachine_metadata['session_id'] ?? '' ),
+				'user_id'    => (int) ( $datamachine_metadata['user_id'] ?? 0 ),
+			)
+		);
 	}
 
 	\DataMachine\Api\Chat\ChatOrchestrator::processContinue(

--- a/tests/Unit/Engine/AI/RuntimeToolRunStateStoreTest.php
+++ b/tests/Unit/Engine/AI/RuntimeToolRunStateStoreTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Tests for durable runtime-tool run state storage.
+ *
+ * @package DataMachine\Tests\Unit\Engine\AI
+ */
+
+namespace DataMachine\Tests\Unit\Engine\AI;
+
+use DataMachine\Engine\AI\RuntimeToolRunStateStore;
+use PHPUnit\Framework\TestCase;
+
+class RuntimeToolRunStateStoreTest extends TestCase {
+
+	public function test_create_persists_runtime_tool_run_state_fields(): void {
+		$jobs  = new RuntimeToolRunStateJobsDouble();
+		$store = new RuntimeToolRunStateStore( $jobs );
+
+		$state = $store->create(
+			42,
+			array(
+				'parent_job_id'           => 7,
+				'runtime_tool_request_id' => 'runtime_tool_42',
+				'tool_name'               => 'client.inspect',
+				'timeout_seconds'         => 120,
+				'deadline_at'             => '2026-06-18T00:02:00+00:00',
+			)
+		);
+
+		$this->assertSame( 7, $state['parent_job_id'] );
+		$this->assertSame( 'runtime_tool_42', $state['runtime_tool_request_id'] );
+		$this->assertSame( 'client.inspect', $state['tool_name'] );
+		$this->assertSame( RuntimeToolRunStateStore::STATUS_PENDING, $state['status'] );
+		$this->assertSame( 120, $state['timeout_seconds'] );
+		$this->assertSame( '2026-06-18T00:02:00+00:00', $state['deadline_at'] );
+		$this->assertNull( $state['resume_payload'] );
+		$this->assertNull( $state['finalize_payload'] );
+		$this->assertArrayHasKey( 'runtime_tool_run_state', $jobs->data[42] );
+	}
+
+	public function test_finalize_is_idempotent(): void {
+		$jobs  = new RuntimeToolRunStateJobsDouble();
+		$store = new RuntimeToolRunStateStore( $jobs );
+
+		$store->create(
+			42,
+			array(
+				'runtime_tool_request_id' => 'runtime_tool_42',
+				'tool_name'               => 'client.inspect',
+			)
+		);
+
+		$first  = $store->finalize( 42, array( 'result' => array( 'value' => 'first' ) ) );
+		$second = $store->finalize( 42, array( 'result' => array( 'value' => 'second' ) ) );
+
+		$this->assertSame( $first, $second );
+		$this->assertSame( 'first', $second['finalize_payload']['result']['value'] );
+		$this->assertSame( RuntimeToolRunStateStore::STATUS_FINALIZED, $second['status'] );
+	}
+
+	public function test_resume_is_idempotent(): void {
+		$jobs  = new RuntimeToolRunStateJobsDouble();
+		$store = new RuntimeToolRunStateStore( $jobs );
+
+		$store->create(
+			42,
+			array(
+				'runtime_tool_request_id' => 'runtime_tool_42',
+				'tool_name'               => 'client.inspect',
+			)
+		);
+
+		$first  = $store->resume( 42, array( 'session_id' => 'session-a' ) );
+		$second = $store->resume( 42, array( 'session_id' => 'session-b' ) );
+
+		$this->assertSame( $first, $second );
+		$this->assertSame( 'session-a', $second['resume_payload']['session_id'] );
+		$this->assertSame( RuntimeToolRunStateStore::STATUS_RESUMED, $second['status'] );
+	}
+
+	public function test_create_from_request_maps_timeout_and_deadline_fields(): void {
+		$jobs  = new RuntimeToolRunStateJobsDouble();
+		$store = new RuntimeToolRunStateStore( $jobs );
+
+		$state = $store->create_from_request(
+			array(
+				'request_id' => 'runtime_tool_42',
+				'tool_name'  => 'client.inspect',
+				'timeout_at' => '2026-06-18T00:02:00+00:00',
+				'metadata'   => array(
+					'datamachine' => array(
+						'job_id'          => 42,
+						'parent_job_id'   => 7,
+						'timeout_seconds' => 120,
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 7, $state['parent_job_id'] );
+		$this->assertSame( 120, $state['timeout_seconds'] );
+		$this->assertSame( '2026-06-18T00:02:00+00:00', $state['deadline_at'] );
+	}
+}
+
+class RuntimeToolRunStateJobsDouble {
+
+	/** @var array<int,array<string,mixed>> */
+	public array $data = array();
+
+	/**
+	 * @param int $job_id Job ID.
+	 * @return array<string,mixed>
+	 */
+	public function retrieve_engine_data( int $job_id ): array {
+		return $this->data[ $job_id ] ?? array();
+	}
+
+	/**
+	 * @param int                 $job_id Job ID.
+	 * @param array<string,mixed> $data   Engine data.
+	 */
+	public function store_engine_data( int $job_id, array $data ): bool {
+		$this->data[ $job_id ] = $data;
+
+		return true;
+	}
+}


### PR DESCRIPTION
## Summary
- Add a generic metadata-backed runtime-tool run-state store on the runtime-tool request job engine data.
- Track parent job id, runtime tool request id, tool name, status, timeout/deadline fields, resume/finalize payloads, and timestamps.
- Wire the existing runtime-tool defer/complete/timeout/resume path to create, finalize, and resume state without broad provider-specific migration.
- Add targeted unit coverage for create, finalize/resume idempotency, and timeout/deadline mapping.

## Tests
- `php -l inc/Engine/AI/RuntimeToolRunStateStore.php && php -l inc/Engine/AI/conversation-loop.php && php -l tests/Unit/Engine/AI/RuntimeToolRunStateStoreTest.php`
- `git diff --check`
- Blocked: `homeboy test data-machine --path . --changed-since origin/main --json-summary` failed before tests ran with WP Codebox `ERR_FS_CP_EINVAL` while copying `/var/folders/.../T` into its own subdirectory. Result: 0 tests executed.
- Blocked: direct PHPUnit invocation is unavailable because this worktree has no `vendor/bin/phpunit`.
- Not run: PHPCS, because this worktree has no `vendor/bin/phpcs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, targeted tests, and verification notes for Chris to review.