### PR TITLE
feat: forward-surface candidate sourcing for internal linking (#2725)

### DIFF
--- a/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
+++ b/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
@@ -305,8 +305,11 @@ class InternalLinkingTask extends SystemTask {
 			fn( $word ) => strlen( $word ) >= 3
 		);
 
-		$related_tags = wp_get_post_tags( $related_post['id'], array( 'fields' => 'names' ) );
-		$related_tags = is_array( $related_tags ) ? array_map( 'strtolower', $related_tags ) : array();
+		// Off-site / filter-injected candidates carry id 0 and have no local
+		// tags to read; fall back to title-word matching only.
+		$related_post_id = absint( $related_post['id'] ?? 0 );
+		$related_tags    = $related_post_id > 0 ? wp_get_post_tags( $related_post_id, array( 'fields' => 'names' ) ) : array();
+		$related_tags    = is_array( $related_tags ) ? array_map( 'strtolower', $related_tags ) : array();
 
 		$best_block = null;
 		$best_score = 0;
@@ -449,7 +452,94 @@ class InternalLinkingTask extends SystemTask {
 			);
 		}
 
-		return $related;
+		/**
+		 * Filter the ranked list of internal-linking candidates for a post.
+		 *
+		 * Core discovers candidates from same-site posts that share categories
+		 * or tags with the source post. This filter lets a platform layer
+		 * inject additional candidates — for example, relevant targets on
+		 * sibling sites of a multisite network (events, community, news) — so
+		 * traffic can be routed toward forward surfaces rather than deepening a
+		 * single-site silo. Returned candidates are re-sorted by `score` and
+		 * capped at `$limit`.
+		 *
+		 * Each candidate is an associative array with:
+		 *   - url     (string, required) Absolute URL to link to.
+		 *   - title   (string, required) Human title of the target.
+		 *   - score   (float,  optional) Relevance score; higher ranks higher.
+		 *   - id      (int,    optional) Local post ID; 0 for off-site targets.
+		 *   - excerpt (string, optional) Short summary for prompt context.
+		 *
+		 * Core stays network-agnostic: it never names specific sites. Any
+		 * cross-site / forward-surface knowledge lives in the platform plugin
+		 * that hooks this filter.
+		 *
+		 * @since 0.74.0
+		 *
+		 * @param array  $related      Ranked candidates discovered by core.
+		 * @param int    $post_id      Source post being linked from.
+		 * @param string $source_title Title of the source post.
+		 * @param array  $categories   Source post category term IDs.
+		 * @param array  $tags         Source post tag term IDs.
+		 * @param int    $limit        Maximum candidates to return.
+		 */
+		$related = apply_filters(
+			'datamachine_internal_linking_candidates',
+			$related,
+			$post_id,
+			$source_title,
+			$categories,
+			$tags,
+			$limit
+		);
+
+		return $this->normalizeCandidates( $related, $limit );
+	}
+
+	/**
+	 * Normalize and re-rank the candidate list after filtering.
+	 *
+	 * Keeps only well-formed candidates (a non-empty url + title), backfills
+	 * optional keys so downstream consumers never hit undefined indices,
+	 * re-sorts by score descending, and caps to the requested limit.
+	 *
+	 * @param mixed $candidates Filtered candidate list (untrusted shape).
+	 * @param int   $limit      Maximum candidates to return.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function normalizeCandidates( $candidates, int $limit ): array {
+		if ( ! is_array( $candidates ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $candidates as $candidate ) {
+			if ( ! is_array( $candidate ) ) {
+				continue;
+			}
+
+			$url   = isset( $candidate['url'] ) ? esc_url_raw( (string) $candidate['url'] ) : '';
+			$title = isset( $candidate['title'] ) ? trim( (string) $candidate['title'] ) : '';
+
+			if ( '' === $url || '' === $title ) {
+				continue;
+			}
+
+			$normalized[] = array(
+				'id'      => isset( $candidate['id'] ) ? absint( $candidate['id'] ) : 0,
+				'url'     => $url,
+				'title'   => $title,
+				'excerpt' => isset( $candidate['excerpt'] ) ? (string) $candidate['excerpt'] : '',
+				'score'   => isset( $candidate['score'] ) ? (float) $candidate['score'] : 0.0,
+			);
+		}
+
+		usort(
+			$normalized,
+			static fn( array $a, array $b ): int => $b['score'] <=> $a['score']
+		);
+
+		return array_slice( $normalized, 0, max( 0, $limit ) );
 	}
 
 	private function computeWordIDF( array $candidate_titles ): array {

--- a/tests/internal-linking-candidates-smoke.php
+++ b/tests/internal-linking-candidates-smoke.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Smoke tests for internal-linking candidate normalization and the
+ * datamachine_internal_linking_candidates filter contract.
+ *
+ * Runs via:
+ *
+ *   php tests/internal-linking-candidates-smoke.php
+ *
+ * Verifies that filter-injected (including off-site, id=0) candidates are
+ * accepted, malformed candidates are dropped, the list is re-sorted by score
+ * descending, and the limit is enforced — the behavior that lets a platform
+ * layer route internal links toward forward surfaces without core knowing
+ * about any specific site.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+// Minimal WP shims used by normalizeCandidates().
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $url ) {
+		$url = trim( (string) $url );
+		// Accept http(s) absolute URLs; reject obviously invalid ones.
+		return preg_match( '#^https?://#i', $url ) ? $url : '';
+	}
+}
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $maybeint ) {
+		return abs( (int) $maybeint );
+	}
+}
+
+require_once __DIR__ . '/../inc/Engine/AI/System/Tasks/SystemTask.php';
+require_once __DIR__ . '/../inc/Engine/AI/System/Tasks/InternalLinkingTask.php';
+
+$failures = 0;
+$assert   = static function ( string $label, bool $cond ) use ( &$failures ): void {
+	if ( $cond ) {
+		echo "  PASS  {$label}\n";
+		return;
+	}
+	echo "  FAIL  {$label}\n";
+	++$failures;
+};
+
+// Use reflection to reach the private normalizeCandidates() without booting WP.
+$task   = ( new ReflectionClass( \DataMachine\Engine\AI\System\Tasks\InternalLinkingTask::class ) )
+	->newInstanceWithoutConstructor();
+$method = new ReflectionMethod( $task, 'normalizeCandidates' );
+$method->setAccessible( true );
+
+$call = static fn( $candidates, int $limit ) => $method->invoke( $task, $candidates, $limit );
+
+// 1. Off-site candidate (id=0) with a valid url+title is kept.
+$result = $call(
+	array(
+		array( 'id' => 0, 'url' => 'https://events.example.com/show', 'title' => 'A Relevant Show', 'score' => 9.0 ),
+	),
+	3
+);
+$assert( 'off-site id=0 candidate is accepted', count( $result ) === 1 && 0 === $result[0]['id'] );
+$assert( 'off-site candidate keeps url', 'https://events.example.com/show' === $result[0]['url'] );
+
+// 2. Re-sorts by score descending regardless of input order.
+$result = $call(
+	array(
+		array( 'id' => 5, 'url' => 'https://a.example.com/1', 'title' => 'Low', 'score' => 1.0 ),
+		array( 'id' => 0, 'url' => 'https://b.example.com/2', 'title' => 'High', 'score' => 99.0 ),
+		array( 'id' => 7, 'url' => 'https://c.example.com/3', 'title' => 'Mid', 'score' => 50.0 ),
+	),
+	10
+);
+$assert(
+	'sorted by score desc',
+	array( 'High', 'Mid', 'Low' ) === array_column( $result, 'title' )
+);
+
+// 3. Limit is enforced after re-sorting.
+$result = $call(
+	array(
+		array( 'url' => 'https://a/1', 'title' => 'One', 'score' => 5 ),
+		array( 'url' => 'https://a/2', 'title' => 'Two', 'score' => 4 ),
+		array( 'url' => 'https://a/3', 'title' => 'Three', 'score' => 3 ),
+	),
+	2
+);
+$assert( 'limit caps result count', count( $result ) === 2 );
+$assert( 'limit keeps highest scores', array( 'One', 'Two' ) === array_column( $result, 'title' ) );
+
+// 4. Malformed candidates are dropped (missing url, missing title, bad url, non-array).
+$result = $call(
+	array(
+		array( 'title' => 'No URL', 'score' => 9 ),
+		array( 'url' => 'https://ok/1', 'score' => 8 ),            // missing title
+		array( 'url' => 'not-a-url', 'title' => 'Bad URL' ),       // rejected by esc_url_raw
+		'garbage',                                                  // non-array
+		array( 'url' => 'https://ok/2', 'title' => 'Good', 'score' => 7 ),
+	),
+	10
+);
+$assert( 'malformed candidates dropped, valid kept', count( $result ) === 1 && 'Good' === $result[0]['title'] );
+
+// 5. Non-array input is handled safely.
+$assert( 'non-array input yields empty list', $call( null, 3 ) === array() );
+
+// 6. Optional keys are backfilled so downstream never hits undefined indices.
+$result = $call( array( array( 'url' => 'https://x/1', 'title' => 'Bare' ) ), 3 );
+$assert(
+	'optional keys backfilled',
+	0 === $result[0]['id'] && '' === $result[0]['excerpt'] && 0.0 === $result[0]['score']
+);
+
+echo "\n";
+if ( $failures > 0 ) {
+	echo "FAILED: {$failures} assertion(s) failed\n";
+	exit( 1 );
+}
+echo "OK: all internal-linking candidate assertions passed\n";


### PR DESCRIPTION
## Summary

Closes the blocker from #2725. Internal linking (`datamachine links crosslink` → `InternalLinkingTask`) previously discovered link targets **only** from same-site posts sharing a category or tag with the source post. On a single-site residual silo (the Extra Chill song-meaning catalog being the motivating case), that can only deepen the silo it's meant to break — there was no way to route captive traffic toward sibling-site forward surfaces (events, community, news).

This adds a single extension point so a platform layer can inject and re-weight candidates, while **core stays network-agnostic and never names a specific site**.

## What changed

- **New filter `datamachine_internal_linking_candidates`** in `InternalLinkingTask::findRelatedPosts()`. Core still discovers same-site shared-taxonomy candidates and passes them through the filter with `$post_id`, `$source_title`, `$categories`, `$tags`, `$limit`. A platform plugin can append candidates (including off-site targets) and re-rank.
- **New `normalizeCandidates()`** hardens the post-filter list: keeps only well-formed entries (non-empty `url` + `title`), backfills optional keys (`id`, `excerpt`, `score`), re-sorts by `score` desc, and caps to the link limit. Untrusted/malformed shapes are dropped safely.
- **Off-site safety in `findCandidateParagraph()`**: reads local tags only when a real post `id` is present, so filter-injected off-site candidates (id `0`) match on title words alone instead of breaking on `wp_get_post_tags( 0 )`.

Candidate shape (documented on the filter):
```
url     (string, required)  absolute URL
title   (string, required)  human title
score   (float,  optional)  relevance; higher ranks higher
id      (int,    optional)  local post ID; 0 for off-site targets
excerpt (string, optional)  short summary for prompt context
```

## Layer purity

Core ships no cross-site/forward-surface knowledge — no site names, no `switch_to_blog`, no enumerated surfaces. All of that lives in the platform plugin that hooks the filter (separate EC PR, not in this change). Default behavior with no hook is identical to today.

## Testing

- `php tests/internal-linking-candidates-smoke.php` — new smoke test, 8/8 assertions pass (off-site id=0 acceptance, score re-sort, limit enforcement, malformed-candidate rejection, non-array safety, optional-key backfill).
- `php -l` clean on both files.
- `phpcs --standard=phpcs.xml.dist` → 0 errors / 0 warnings on both changed files.

## Notes

- No changelog or version edits (homeboy owns those).
- This is the tooling half. The EC platform hook that actually injects events/community candidates with a forward-surface weight is a follow-up in the platform repo; once it lands, re-run the #15 ops pass.

Refs #2725