### PR TITLE
feat: make get-post-blocks read prefer in-flight user autosave

### DIFF
--- a/inc/Abilities/Content/BlogContext.php
+++ b/inc/Abilities/Content/BlogContext.php
@@ -219,4 +219,56 @@ class BlogContext {
 			switch_to_blog( $target );
 		}
 	}
+
+	/**
+	 * Resolve the freshest authored content for a post, preferring the calling
+	 * user's in-flight autosave revision over the stored parent post.
+	 *
+	 * Editors that autosave (e.g. an iframe compose surface posting to
+	 * `/wp/v2/posts/<id>/autosaves` every few seconds) deliberately leave the
+	 * parent post untouched until an explicit Save/Submit. Reading
+	 * `$post->post_content` therefore surfaces stale — or, for a brand-new
+	 * draft, empty — content versus what the author is actively typing.
+	 *
+	 * WordPress core stores one autosave revision per user (`wp_get_post_autosave`
+	 * keyed on the user id), so the lookup is inherently scoped to the current
+	 * user — another user's in-flight draft is never returned. When that
+	 * autosave exists and is newer than the parent post, its `post_content` is
+	 * the freshest authored content and is returned in place of the parent's.
+	 *
+	 * This is a READ-only preference: it changes only which content is parsed
+	 * and shown to a caller proofreading/diffing a draft. It does not alter
+	 * where edits are written — write paths continue to target the parent post
+	 * through the normal pending-action/apply flow.
+	 *
+	 * Must be called inside the post's blog context (after BlogContext::enter()
+	 * on multisite) so the autosave lookup runs against the correct site.
+	 *
+	 * @param \WP_Post $post           The stored parent post.
+	 * @param bool     $prefer_autosave Whether to prefer a newer user autosave.
+	 *                                  Defaults to true (freshest-authored).
+	 * @return string The post_content to parse (autosave's when newer, else parent's).
+	 */
+	public static function freshest_authored_content( \WP_Post $post, bool $prefer_autosave = true ): string {
+		if ( ! $prefer_autosave ) {
+			return (string) $post->post_content;
+		}
+
+		$user_id = get_current_user_id();
+		if ( $user_id <= 0 ) {
+			return (string) $post->post_content;
+		}
+
+		$autosave = wp_get_post_autosave( $post->ID, $user_id );
+		if ( ! $autosave instanceof \WP_Post ) {
+			return (string) $post->post_content;
+		}
+
+		// Only prefer the autosave when it is strictly newer than the parent.
+		if ( strtotime( (string) $autosave->post_modified_gmt ) <= strtotime( (string) $post->post_modified_gmt ) ) {
+			return (string) $post->post_content;
+		}
+
+		return (string) $autosave->post_content;
+	}
 }

--- a/inc/Abilities/Content/GetPostBlocksAbility.php
+++ b/inc/Abilities/Content/GetPostBlocksAbility.php
@@ -60,6 +60,10 @@ class GetPostBlocksAbility {
 								'type'        => 'string',
 								'description' => __( 'Filter to blocks containing this text (case-insensitive)', 'data-machine' ),
 							),
+							'prefer_autosave' => array(
+								'type'        => 'boolean',
+								'description' => __( 'When true (default), read the calling user\'s latest autosave revision if it is newer than the saved post — so an in-flight draft is proofread, not the stale saved version. Set false to always read the saved post.', 'data-machine' ),
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -138,6 +142,11 @@ class GetPostBlocksAbility {
 					'required'    => false,
 					'description' => 'Filter to blocks containing this text (case-insensitive)',
 				),
+				'prefer_autosave' => array(
+					'type'        => 'boolean',
+					'required'    => false,
+					'description' => 'When true (default), read the caller\'s latest autosave revision if newer than the saved post, so an in-flight draft is proofread instead of the stale saved version.',
+				),
 			),
 		);
 	}
@@ -167,9 +176,11 @@ class GetPostBlocksAbility {
 	 * @return array
 	 */
 	public static function execute( array $input ): array {
-		$post_id     = absint( $input['post_id'] ?? 0 );
-		$block_types = $input['block_types'] ?? array();
-		$search      = $input['search'] ?? '';
+		$post_id         = absint( $input['post_id'] ?? 0 );
+		$block_types     = $input['block_types'] ?? array();
+		$search          = $input['search'] ?? '';
+		// Default true: proofread the freshest authored content (in-flight autosave).
+		$prefer_autosave = ! array_key_exists( 'prefer_autosave', $input ) || ! empty( $input['prefer_autosave'] );
 
 		if ( $post_id <= 0 ) {
 			return array(
@@ -197,7 +208,12 @@ class GetPostBlocksAbility {
 				);
 			}
 
-			$block_content = ContentFormat::storedToBlocks( (string) $post->post_content, (string) $post->post_type );
+			// Prefer the calling user's in-flight autosave when it is newer than
+			// the saved post — so a draft being actively typed is proofread, not
+			// the stale saved version. Runs inside the post's blog context above.
+			$source_content = BlogContext::freshest_authored_content( $post, $prefer_autosave );
+
+			$block_content = ContentFormat::storedToBlocks( $source_content, (string) $post->post_type );
 			if ( is_wp_error( $block_content ) ) {
 				return array(
 					'success' => false,

--- a/inc/Abilities/Content/GetPostBlocksAbility.php
+++ b/inc/Abilities/Content/GetPostBlocksAbility.php
@@ -43,20 +43,20 @@ class GetPostBlocksAbility {
 						'type'       => 'object',
 						'required'   => array( 'post_id' ),
 						'properties' => array(
-							'post_id'     => array(
+							'post_id'         => array(
 								'type'        => 'integer',
 								'description' => __( 'Post ID to parse', 'data-machine' ),
 							),
-							'blog_id'     => array(
+							'blog_id'         => array(
 								'type'        => 'integer',
 								'description' => __( 'Optional. Multisite blog ID the post lives on. Omit to use the current site. The read runs in that blog\'s context.', 'data-machine' ),
 							),
-							'block_types' => array(
+							'block_types'     => array(
 								'type'        => 'array',
 								'items'       => array( 'type' => 'string' ),
 								'description' => __( 'Filter to specific block types (e.g. ["core/paragraph", "core/heading"]). Empty = all blocks.', 'data-machine' ),
 							),
-							'search'      => array(
+							'search'          => array(
 								'type'        => 'string',
 								'description' => __( 'Filter to blocks containing this text (case-insensitive)', 'data-machine' ),
 							),
@@ -121,23 +121,23 @@ class GetPostBlocksAbility {
 			'method'      => 'handleChatToolCall',
 			'description' => 'Parse a WordPress post into its Gutenberg blocks. Optionally filter by block type or text content. Returns block index, type, and innerHTML for each matching block.',
 			'parameters'  => array(
-				'post_id'     => array(
+				'post_id'         => array(
 					'type'        => 'integer',
 					'required'    => true,
 					'description' => 'Post ID to parse',
 				),
-				'blog_id'     => array(
+				'blog_id'         => array(
 					'type'        => 'integer',
 					'required'    => false,
 					'description' => 'Optional multisite blog ID the post lives on. Omit for the current site.',
 				),
-				'block_types' => array(
+				'block_types'     => array(
 					'type'        => 'array',
 					'items'       => array( 'type' => 'string' ),
 					'required'    => false,
 					'description' => 'Filter to specific block types (e.g. ["core/paragraph"])',
 				),
-				'search'      => array(
+				'search'          => array(
 					'type'        => 'string',
 					'required'    => false,
 					'description' => 'Filter to blocks containing this text (case-insensitive)',
@@ -176,10 +176,10 @@ class GetPostBlocksAbility {
 	 * @return array
 	 */
 	public static function execute( array $input ): array {
+		// prefer_autosave defaults true: proofread the freshest authored content (in-flight autosave).
 		$post_id         = absint( $input['post_id'] ?? 0 );
 		$block_types     = $input['block_types'] ?? array();
 		$search          = $input['search'] ?? '';
-		// Default true: proofread the freshest authored content (in-flight autosave).
 		$prefer_autosave = ! array_key_exists( 'prefer_autosave', $input ) || ! empty( $input['prefer_autosave'] );
 
 		if ( $post_id <= 0 ) {


### PR DESCRIPTION
## Summary

Makes the block READ path autosave-aware so the chat proofreads the **live in-flight draft** the user is actively typing, not the stale saved parent post.

Editors that autosave (posting to `/wp/v2/posts/<id>/autosaves` every few seconds) deliberately leave the parent post untouched until an explicit Save Draft / Submit. So `GetPostBlocksAbility::execute()` reading `$post->post_content` surfaced content that was minutes/keystrokes stale — and for a brand-new draft where only autosaves had fired, near-empty.

Closes #2728.

## What changed

**`inc/Abilities/Content/BlogContext.php`** (+52)
- New generic helper `BlogContext::freshest_authored_content( \WP_Post $post, bool $prefer_autosave = true ): string`.
- Looks up `wp_get_post_autosave( $post->ID, get_current_user_id() )` (core stores **one autosave per user**). When that autosave exists and its `post_modified_gmt` is **strictly newer** than the parent's, returns the autosave's `post_content`; otherwise returns the parent's.
- Logged-out (user id 0) → parent. No autosave → parent. Equal timestamp → parent.
- Documented as READ-only; must run inside the post's blog context (which `BlogContext::enter()` already establishes), so multisite lookups hit the correct site.

**`inc/Abilities/Content/GetPostBlocksAbility.php`** (+24/-4)
- `execute()` now parses `BlogContext::freshest_authored_content( $post, $prefer_autosave )` instead of `$post->post_content`. The autosave lookup runs after `BlogContext::enter()`, inside the switched blog context.
- New optional `prefer_autosave` input (boolean, default **true**) on both the ability `input_schema` and the chat-tool parameters, so callers can opt out and force reading the saved post.

## Read vs. write distinction (deliberate)

This change is **READ-only** — it only affects *what content is shown* to an agent proofreading/diffing a draft.

The sibling write abilities (`EditPostBlocksAbility`, `ReplacePostBlocksAbility`, `InsertContentAbility`) read `post_content` only to compute and then **apply** changes back to the parent post via the normal `wp_update_post` / pending-action / diff flow. Making their read autosave-aware would implicitly change the **write target** (autosave-derived content written onto the parent), which the spec explicitly forbids. They are intentionally left reading the parent post.

## Layer purity

Helper is fully generic — `grep -iE 'studio|roadie|extrachill'` over the diff is clean. It's a generic "read the freshest authored content including in-flight autosave" improvement.

## Verification

- `php -l` clean on both changed files.
- `vendor/bin/phpcbf` then `vendor/bin/phpcs --standard=WordPress` → **exit 0, 0 errors / 0 warnings** on both files. (PSR-4 class-file-name findings are repo-wide house-style baseline; none surfaced here.)
- Logic harness (6 cases, all PASS): no autosave → base; autosave newer → autosave; autosave older → base; equal timestamp → base; `prefer_autosave=false` → base; logged-out → base. Per-user scoping is structural via `wp_get_post_autosave($id, $user_id)` — another user's autosave is never surfaced.

### Known harness debt
If CI shows red **Test** but green **Lint/Audit**, and the failures are the pre-existing real-WordPress smoke fatals on `main` (`do_action` redeclare / legacy `handler_slug`), those are unrelated to this change and non-blocking per repo convention (main is also red on those).