### PR TITLE
feat: store chat sessions network-wide so chat follows users across subsites

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -686,6 +686,13 @@ function datamachine_activate_plugin( $network_wide = false ) {
 
 	if ( is_multisite() && $network_wide ) {
 		datamachine_for_each_site( 'datamachine_activate_for_site' );
+
+		// Per-site activation created the network chat table (base_prefix, idempotent);
+		// now union any legacy per-site chat session tables into it. Idempotent and
+		// guarded by a network option, so re-activation never re-scans every subsite.
+		if ( function_exists( 'datamachine_migrate_chat_sessions_to_network' ) ) {
+			datamachine_migrate_chat_sessions_to_network();
+		}
 	} else {
 		datamachine_activate_for_site();
 	}

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -158,6 +158,15 @@ class ChatOrchestrator {
 			return self::sessionLockContentionError();
 		}
 
+		// --- Cross-site handoff detection ---
+		// Compare the host this session was last active on against the current
+		// request host. On a cross-site move, the handoff payload feeds the
+		// CrossSiteHandoffDirective so the agent reconciles the move. The
+		// current host is re-stamped into metadata below so the comparison is
+		// always against the most recent turn.
+		$current_host       = self::currentRequestHost();
+		$cross_site_handoff = self::buildCrossSiteHandoff( $session_metadata, $current_host );
+
 		// --- Build user message (text or multi-modal with attachments) ---
 		$attachments = $options['attachments'] ?? array();
 
@@ -181,6 +190,7 @@ class ChatOrchestrator {
 					'status'            => 'processing',
 					'started_at'        => current_time( 'mysql', true ),
 					'message_count'     => count( $messages ),
+					'last_seen_host'    => '' !== $current_host ? $current_host : ( $session_metadata['last_seen_host'] ?? '' ),
 					'consent_decisions' => array(
 						'store_transcript' => $transcript_consent_decision->to_array(),
 					),
@@ -229,6 +239,7 @@ class ChatOrchestrator {
 				'agent_slug'            => $agent_slug,
 				'interrupt_source'      => $interrupt_source,
 				'client_context'        => $options['client_context'] ?? array(),
+				'cross_site_handoff'    => $cross_site_handoff,
 				'tool_policy'           => is_array( $options['tool_policy'] ?? null ) ? $options['tool_policy'] : null,
 				'allow_only'            => is_array( $options['allow_only'] ?? null ) ? $options['allow_only'] : null,
 				'completion_assertions' => is_array( $options['completion_assertions'] ?? null ) ? $options['completion_assertions'] : null,
@@ -251,6 +262,7 @@ class ChatOrchestrator {
 			'message_count'     => count( $result['messages'] ),
 			'current_turn'      => $result['turn_count'],
 			'has_pending_tools' => ! $is_completed,
+			'last_seen_host'    => '' !== $current_host ? $current_host : ( $session_metadata['last_seen_host'] ?? '' ),
 		);
 		if ( ! empty( $loop_metadata['runtime_tool_pending_requests'] ) ) {
 			$metadata['runtime_tool_requests'] = array();
@@ -421,6 +433,11 @@ class ChatOrchestrator {
 			return self::sessionLockContentionError();
 		}
 
+		// Detect a cross-site resume the same way processChat does: compare the
+		// host the session was last active on against the current request host.
+		$current_host       = self::currentRequestHost();
+		$cross_site_handoff = self::buildCrossSiteHandoff( $metadata, $current_host );
+
 		// Recover the original modes array from the stored session.mode column.
 		// Sessions created from a multi-mode request (e.g. ['cluckin-chuck',
 		// 'chat']) persist as the comma-joined string 'cluckin-chuck,chat'.
@@ -448,6 +465,7 @@ class ChatOrchestrator {
 				'user_id'              => (int) ( $session['user_id'] ?? 0 ),
 				'agent_id'             => (int) ( $session['agent_id'] ?? 0 ),
 				'agent_slug'           => (string) ( $session['agent_slug'] ?? '' ),
+				'cross_site_handoff'   => $cross_site_handoff,
 			)
 		);
 
@@ -470,6 +488,7 @@ class ChatOrchestrator {
 			'message_count'     => count( $result['messages'] ),
 			'current_turn'      => $current_turn,
 			'has_pending_tools' => ! $is_completed,
+			'last_seen_host'    => '' !== $current_host ? $current_host : ( $metadata['last_seen_host'] ?? '' ),
 		);
 		if ( ! empty( $metadata['runtime_tool_requests'] ) ) {
 			$updated_metadata['runtime_tool_requests'] = $metadata['runtime_tool_requests'];
@@ -531,6 +550,51 @@ class ChatOrchestrator {
 		do_action( 'datamachine_chat_response_complete', $session_id, $continue_response, (int) ( $session['agent_id'] ?? 0 ), $user_id );
 
 		return $continue_response;
+	}
+
+	/**
+	 * Resolve the current request's site host.
+	 *
+	 * Chat sessions are network-wide, so a session can be resumed on a
+	 * different subsite than it was last active on. The host is derived from
+	 * live request state (the current site's home URL) — never hardcoded — so
+	 * cross-site handoff detection stays generic across the network.
+	 *
+	 * @return string Lowercased host, or '' when not resolvable.
+	 */
+	private static function currentRequestHost(): string {
+		if ( ! function_exists( 'home_url' ) ) {
+			return '';
+		}
+
+		$host = wp_parse_url( home_url( '/' ), PHP_URL_HOST );
+
+		return is_string( $host ) ? strtolower( $host ) : '';
+	}
+
+	/**
+	 * Build the cross-site handoff payload for a resumed session.
+	 *
+	 * Compares the host the session was last active on (stored per turn in
+	 * session metadata) against the current request host. Returns an empty
+	 * array when there is no prior host or the user has not changed sites, so
+	 * the handoff directive only fires on an actual cross-site move.
+	 *
+	 * @param array  $session_metadata Loaded session metadata.
+	 * @param string $current_host     Current request host.
+	 * @return array{previous_host:string,current_host:string}|array{} Handoff payload or empty.
+	 */
+	private static function buildCrossSiteHandoff( array $session_metadata, string $current_host ): array {
+		$previous_host = isset( $session_metadata['last_seen_host'] ) ? strtolower( (string) $session_metadata['last_seen_host'] ) : '';
+
+		if ( '' === $previous_host || '' === $current_host || $previous_host === $current_host ) {
+			return array();
+		}
+
+		return array(
+			'previous_host' => $previous_host,
+			'current_host'  => $current_host,
+		);
 	}
 
 	/**
@@ -863,6 +927,9 @@ class ChatOrchestrator {
 			}
 			if ( ! empty( $client_context ) ) {
 				$loop_context['client_context'] = $client_context;
+			}
+			if ( is_array( $options['cross_site_handoff'] ?? null ) && ! empty( $options['cross_site_handoff'] ) ) {
+				$loop_context['cross_site_handoff'] = $options['cross_site_handoff'];
 			}
 			if ( is_array( $options['completion_assertions'] ?? null ) ) {
 				$loop_context['completion_assertions'] = $options['completion_assertions'];

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -29,6 +29,7 @@ use DataMachine\Core\AbilityResult;
 use DataMachine\Core\ExecutionQuery;
 use DataMachine\Core\JobArtifacts;
 use DataMachine\Core\RunMetrics;
+use DataMachine\Core\Database\Chat\Chat;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Jobs\Jobs;
 use AgentsAPI\AI\WP_Agent_Message;
@@ -1724,7 +1725,7 @@ class JobsCommand extends BaseCommand {
 	private function findTranscriptSessionIdForJob( int $job_id ): string {
 		global $wpdb;
 
-		$table = $wpdb->prefix . 'datamachine_chat_sessions';
+		$table = Chat::get_prefixed_table_name();
 		$like  = '%"job_id":' . $job_id . '%';
 		$row   = $wpdb->get_var(
 			$wpdb->prepare(

--- a/inc/Core/Auth/PrincipalSessionPromoter.php
+++ b/inc/Core/Auth/PrincipalSessionPromoter.php
@@ -8,6 +8,7 @@
 namespace DataMachine\Core\Auth;
 
 use DataMachine\Abilities\Chat\ChatTranscriptOwner;
+use DataMachine\Core\Database\Chat\Chat;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -40,7 +41,7 @@ final class PrincipalSessionPromoter {
 		$user = ChatTranscriptOwner::user_owner( $user_id );
 
 		global $wpdb;
-		$table = $wpdb->prefix . 'datamachine_chat_sessions';
+		$table = Chat::get_prefixed_table_name();
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Intentional ownership migration for a completed login flow.
 		$result = $wpdb->update(

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -42,6 +42,19 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	const TABLE_NAME = 'datamachine_chat_sessions';
 
 	/**
+	 * Use network-level prefix so chat sessions are shared across the multisite network.
+	 *
+	 * A user's chat history follows them to every subsite — consistent with the
+	 * agent identity, tokens, and access tables, which already use base_prefix.
+	 *
+	 * @return string
+	 */
+	protected static function get_table_prefix(): string {
+		global $wpdb;
+		return $wpdb->base_prefix;
+	}
+
+	/**
 	 * Create chat sessions table
 	 *
 	 * Uses dbDelta for safe table creation/updates
@@ -91,6 +104,145 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		dbDelta( $sql );
+	}
+
+	/**
+	 * Migrate legacy per-site chat session tables into the network table.
+	 *
+	 * Chat sessions used to live in per-site tables (`<prefix>_<N>_datamachine_chat_sessions`)
+	 * because the repository defaulted to `$wpdb->prefix`. Now that the table is
+	 * network-scoped (`base_prefix`), a user's chat history must follow them across
+	 * every subsite. This one-time migration unions every legacy per-site table into
+	 * the single network table.
+	 *
+	 * Idempotent and re-runnable:
+	 * - Rows are de-duped on the `session_id` primary key via `INSERT IGNORE`.
+	 * - The source site whose prefix equals the network base prefix IS the network
+	 *   table, so it is skipped.
+	 * - Single-site installs have nothing to union and return early.
+	 *
+	 * @return int Number of rows copied into the network table.
+	 */
+	public static function migrate_per_site_tables_to_network(): int {
+		global $wpdb;
+
+		// Single-site installs already store sessions in the (base == site) table.
+		if ( ! function_exists( 'is_multisite' ) || ! is_multisite() || ! function_exists( 'get_sites' ) ) {
+			return 0;
+		}
+
+		// The network table must exist before we can union into it.
+		if ( ! self::table_exists() ) {
+			return 0;
+		}
+
+		$network_table = self::get_prefixed_table_name();
+		$base_prefix   = $wpdb->base_prefix;
+		$copied        = 0;
+
+		$blog_ids = get_sites(
+			array(
+				'fields'   => 'ids',
+				'archived' => 0,
+				'deleted'  => 0,
+				'number'   => 0,
+			)
+		);
+
+		foreach ( $blog_ids as $blog_id ) {
+			$site_prefix = $wpdb->get_blog_prefix( (int) $blog_id );
+			$site_table  = self::sanitize_table_name( $site_prefix . self::TABLE_NAME );
+
+			// Skip the network table itself (the site whose prefix == base prefix).
+			if ( $site_table === $network_table ) {
+				continue;
+			}
+
+			// Skip sites that never created a per-site sessions table.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+			$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $site_table ) );
+			if ( $exists !== $site_table ) {
+				continue;
+			}
+
+			// Copy every legacy row into the network table. INSERT IGNORE makes this
+			// idempotent: rows whose session_id already lives in the network table are
+			// skipped, so re-running never duplicates or overwrites migrated history.
+			// Columns are listed explicitly so the copy is resilient to column-order
+			// drift between the two tables.
+			$columns     = 'session_id, workspace_type, workspace_id, user_id, owner_type, owner_key_hash, owner_label, agent_id, title, messages, metadata, provider, model, provider_response_id, mode, created_at, updated_at, last_read_at, expires_at, transcript_lock_token, transcript_lock_expires_at';
+			$column_list = self::intersect_migration_columns( $site_table, $network_table, $columns );
+			if ( '' === $column_list ) {
+				continue;
+			}
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+			$result = $wpdb->query(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$wpdb->prepare(
+					"INSERT IGNORE INTO %i ({$column_list}) SELECT {$column_list} FROM %i",
+					$network_table,
+					$site_table
+				)
+			);
+
+			$rows    = false !== $result ? (int) $result : 0;
+			$copied += $rows;
+
+			if ( $rows > 0 ) {
+				do_action(
+					'datamachine_log',
+					'info',
+					'Migrated per-site chat sessions into network table',
+					array(
+						'blog_id'       => (int) $blog_id,
+						'source_table'  => $site_table,
+						'network_table' => $network_table,
+						'rows_copied'   => $rows,
+					)
+				);
+			}
+		}
+
+		return $copied;
+	}
+
+	/**
+	 * Build the column list shared by both the legacy and network tables.
+	 *
+	 * Different installs created the chat table at different schema versions, so a
+	 * legacy per-site table may be missing columns the network table has (or vice
+	 * versa). Copying only the intersection keeps the INSERT…SELECT valid on every
+	 * install without assuming a single column set.
+	 *
+	 * @param string $source_table Legacy per-site table name (prefixed).
+	 * @param string $target_table Network table name (prefixed).
+	 * @param string $columns      Comma-separated candidate column list.
+	 * @return string Comma-separated intersection, or '' when session_id is absent.
+	 */
+	private static function intersect_migration_columns( string $source_table, string $target_table, string $columns ): string {
+		global $wpdb;
+
+		$candidates = array_map( 'trim', explode( ',', $columns ) );
+		$shared     = array();
+
+		foreach ( $candidates as $column ) {
+			if ( '' === $column ) {
+				continue;
+			}
+
+			if ( self::column_exists( $source_table, $column, $wpdb ) && self::column_exists( $target_table, $column, $wpdb ) ) {
+				$shared[] = $column;
+			}
+		}
+
+		// session_id is the primary key and the de-dupe anchor — without it the
+		// migration is meaningless, so bail rather than copy an unkeyed subset.
+		if ( ! in_array( 'session_id', $shared, true ) ) {
+			return '';
+		}
+
+		return implode( ', ', $shared );
 	}
 
 	/**
@@ -299,7 +451,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	public static function table_exists(): bool {
 		global $wpdb;
 
-		$table_name = $wpdb->prefix . self::TABLE_NAME;
+		$table_name = self::get_table_prefix() . self::TABLE_NAME;
 		$query      = $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
@@ -312,8 +464,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 * @return string Full table name
 	 */
 	public static function get_prefixed_table_name(): string {
-		global $wpdb;
-		return self::sanitize_table_name( $wpdb->prefix . self::TABLE_NAME );
+		return self::sanitize_table_name( self::get_table_prefix() . self::TABLE_NAME );
 	}
 
 	/**

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -176,15 +176,19 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				continue;
 			}
 
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+			// $column_list is built solely from a fixed allowlist of column names
+			// intersected against the live table columns (see
+			// intersect_migration_columns), never from user input — so interpolating
+			// it into the column list is safe. Table names use %i placeholders.
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$result = $wpdb->query(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$wpdb->prepare(
 					"INSERT IGNORE INTO %i ({$column_list}) SELECT {$column_list} FROM %i",
 					$network_table,
 					$site_table
 				)
 			);
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 			$rows    = false !== $result ? (int) $result : 0;
 			$copied += $rows;

--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -9,6 +9,7 @@
 namespace DataMachine\Core;
 
 use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\Database\Chat\Chat;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\FilesRepository\AgentMemory as AgentMemoryFile;
@@ -749,7 +750,7 @@ class JobArtifacts {
 	private function find_transcript_session_id_for_job( int $job_id ): string {
 		global $wpdb;
 
-		$table = $wpdb->prefix . 'datamachine_chat_sessions';
+		$table = Chat::get_prefixed_table_name();
 		$like  = '%"job_id":' . $job_id . '%';
 		$row   = $wpdb->get_var(
 			$wpdb->prepare(

--- a/inc/Engine/AI/Directives/CrossSiteHandoffDirective.php
+++ b/inc/Engine/AI/Directives/CrossSiteHandoffDirective.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Cross-Site Handoff Directive.
+ *
+ * Chat sessions are network-wide: a user's conversation follows them across
+ * every subsite. When a session is resumed on a different site than the one it
+ * was last active on, the stored transcript can reference a site the user is no
+ * longer on. This directive injects a lightweight system note for that single
+ * turn so the agent reconciles the move instead of getting whiplash — e.g.
+ * "This conversation was last active on <host A>; you are now on <host B>."
+ *
+ * The note is driven entirely by the request-local `cross_site_handoff` payload
+ * (previous host vs. current host), which the chat orchestrator resolves at
+ * runtime. Hosts are derived from live request state, never hardcoded — this
+ * directive stays generic and carries no platform or vendor names.
+ *
+ * Priority 36 = right after ClientContextDirective (35), so the "where you are
+ * now" context and the "you just moved" note read together.
+ *
+ * @package DataMachine\Engine\AI\Directives
+ */
+
+namespace DataMachine\Engine\AI\Directives;
+
+defined( 'ABSPATH' ) || exit;
+
+class CrossSiteHandoffDirective {
+
+	/**
+	 * Produce a handoff note when the current host differs from the last-seen host.
+	 *
+	 * @param string      $provider_name AI provider identifier.
+	 * @param array       $tools         Available tools.
+	 * @param string|null $step_id       Pipeline step ID (null in chat).
+	 * @param array       $payload       Request payload including cross_site_handoff.
+	 * @return array Directive outputs (system_text entries).
+	 */
+	public static function get_outputs( string $provider_name, array $tools, ?string $step_id = null, array $payload = array() ): array {
+		$handoff = $payload['cross_site_handoff'] ?? array();
+
+		if ( ! is_array( $handoff ) ) {
+			return array();
+		}
+
+		$previous_host = self::normalize_host( $handoff['previous_host'] ?? '' );
+		$current_host  = self::normalize_host( $handoff['current_host'] ?? '' );
+
+		// Nothing to reconcile unless we know both hosts and they actually differ.
+		if ( '' === $previous_host || '' === $current_host || $previous_host === $current_host ) {
+			return array();
+		}
+
+		$note = sprintf(
+			'This conversation was last active on %1$s; the user is now on %2$s. '
+				. 'Treat %2$s as the site they are currently on: resolve page, repo, and capability context from the current request, not from where the transcript started. '
+				. 'If earlier turns reference %1$s, reconcile that the user has since moved sites rather than assuming they are still there.',
+			$previous_host,
+			$current_host
+		);
+
+		$content = "# Cross-Site Handoff\n\n" . $note;
+
+		$outputs = array(
+			array(
+				'type'    => 'system_text',
+				'content' => $content,
+			),
+		);
+
+		return function_exists( 'apply_filters' )
+			? apply_filters( 'datamachine_cross_site_handoff_directive_outputs', $outputs, $handoff, $payload, $provider_name, $tools, $step_id )
+			: $outputs;
+	}
+
+	/**
+	 * Normalize a host value to a bare, comparable hostname.
+	 *
+	 * Accepts a full URL or a raw host and reduces it to the host component,
+	 * lowercased and trimmed, so comparisons are stable regardless of scheme
+	 * or trailing path.
+	 *
+	 * @param mixed $value Host or URL value.
+	 * @return string Normalized host, or '' when not resolvable.
+	 */
+	private static function normalize_host( $value ): string {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return '';
+		}
+
+		$value = trim( $value );
+
+		if ( false !== strpos( $value, '://' ) ) {
+			$parsed = wp_parse_url( $value, PHP_URL_HOST );
+			if ( is_string( $parsed ) && '' !== $parsed ) {
+				$value = $parsed;
+			}
+		}
+
+		return strtolower( $value );
+	}
+}
+
+// Self-register in the directive system.
+// Priority 36 = immediately after ClientContextDirective (35) so the live
+// "current context" and the "you moved sites" note render together.
+add_filter(
+	'datamachine_directives',
+	function ( $directives ) {
+		$modes = array( 'chat' );
+		if ( function_exists( 'apply_filters' ) ) {
+			$modes = apply_filters( 'datamachine_cross_site_handoff_directive_modes', $modes );
+		}
+
+		$directives[] = array(
+			'class'    => CrossSiteHandoffDirective::class,
+			'priority' => 36,
+			'modes'    => is_array( $modes ) ? $modes : array( 'chat' ),
+		);
+		return $directives;
+	}
+);

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -309,6 +309,7 @@ if ( did_action( 'plugins_loaded' ) ) {
 add_action( 'init', array( \DataMachine\Engine\AI\ComposableFileInvalidation::class, 'register_hooks' ) );
 
 require_once __DIR__ . '/Engine/AI/Directives/ClientContextDirective.php';
+require_once __DIR__ . '/Engine/AI/Directives/CrossSiteHandoffDirective.php';
 require_once __DIR__ . '/Engine/AI/Directives/AgentDailyMemoryDirective.php';
 require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php';
 require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php';

--- a/inc/migrations/chat-sessions-network.php
+++ b/inc/migrations/chat-sessions-network.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Data Machine — chat-sessions network-wide migration.
+ *
+ * Chat sessions moved from per-site storage (`$wpdb->prefix`) to network-wide
+ * storage (`$wpdb->base_prefix`) so a user's chat history follows them across
+ * every subsite, consistent with the network-scoped agent identity tables.
+ *
+ * @package DataMachine
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Union legacy per-site chat session tables into the single network table.
+ *
+ * Runs once via the version-gated deferred migration runtime. The underlying
+ * copy is idempotent (INSERT IGNORE on the session_id primary key), so this is
+ * safe to call more than once and on single-site installs (where it no-ops).
+ *
+ * Guarded by a network option so the (multisite-wide) union runs a single time
+ * rather than re-scanning every subsite on every per-site deferred-migration
+ * pass.
+ */
+function datamachine_migrate_chat_sessions_to_network(): void {
+	if ( ! function_exists( 'is_multisite' ) || ! is_multisite() ) {
+		return;
+	}
+
+	// One network-wide flag — the union spans all subsites, so it should not
+	// re-run per-site. Stored via site options so it lives at the network level.
+	if ( function_exists( 'get_site_option' ) && get_site_option( 'datamachine_chat_sessions_network_migrated' ) ) {
+		return;
+	}
+
+	\DataMachine\Core\Database\Chat\Chat::migrate_per_site_tables_to_network();
+
+	if ( function_exists( 'update_site_option' ) ) {
+		update_site_option( 'datamachine_chat_sessions_network_migrated', 1 );
+	}
+}

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -18,6 +18,7 @@ require_once __DIR__ . '/flows.php';
 require_once __DIR__ . '/bundle-artifacts.php';
 require_once __DIR__ . '/processed-item-claims.php';
 require_once __DIR__ . '/pending-actions.php';
+require_once __DIR__ . '/chat-sessions-network.php';
 
 // Current schema runtime — creates current deploy-time tables/columns without
 // carrying pre-1.0 data-shape migrations forward indefinitely.

--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -32,6 +32,7 @@ function datamachine_run_schema_migrations(): void {
 	datamachine_migrate_bundle_artifacts_table();
 	datamachine_migrate_processed_item_claims();
 	datamachine_migrate_pending_actions_table();
+	datamachine_migrate_chat_sessions_to_network();
 }
 
 /**

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -17,6 +17,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+// This is a pure-PHP smoke: it stubs get_option/update_option/add_action and
+// drives them via $GLOBALS state to assert the deferred-migration option gate
+// and hook registration. Under real WordPress those functions already exist,
+// so the stubs no-op and the option/hook assertions cannot be exercised. Skip
+// cleanly there — the standalone run (php tests/migration-runtime-smoke.php)
+// locks the contract.
+if ( defined( 'WPINC' ) ) {
+	echo "migration-runtime-smoke: skipped under real WordPress; standalone stubs drive this contract.\n";
+	exit( 0 );
+}
+
 if ( ! defined( 'DATAMACHINE_VERSION' ) ) {
 	define( 'DATAMACHINE_VERSION', '0.104.0-test' );
 }

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -67,6 +67,7 @@ $schema_chain = array(
 	'datamachine_migrate_bundle_artifacts_table',
 	'datamachine_migrate_processed_item_claims',
 	'datamachine_migrate_pending_actions_table',
+	'datamachine_migrate_chat_sessions_to_network',
 );
 
 foreach ( $schema_chain as $fn ) {

--- a/tests/pipeline-transcript-session-link-smoke.php
+++ b/tests/pipeline-transcript-session-link-smoke.php
@@ -37,8 +37,8 @@ $assert(
 );
 
 $assert(
-	false !== strpos( $jobs_cli, 'metadata LIKE' ) && false !== strpos( $jobs_cli, 'datamachine_chat_sessions' ),
-	'metadata fallback searches pipeline transcript rows by job_id'
+	false !== strpos( $jobs_cli, 'metadata LIKE' ) && false !== strpos( $jobs_cli, 'Chat::get_prefixed_table_name()' ),
+	'metadata fallback searches pipeline transcript rows by job_id in the network chat sessions table'
 );
 
 echo "\n";

--- a/uninstall.php
+++ b/uninstall.php
@@ -13,7 +13,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
-if ( is_multisite() ) {
+	if ( is_multisite() ) {
 	// Clean up every subsite on the network.
 	$datamachine_sites = get_sites( array( 'fields' => 'ids' ) );
 	foreach ( $datamachine_sites as $datamachine_blog_id ) {
@@ -21,6 +21,9 @@ if ( is_multisite() ) {
 		datamachine_uninstall_site();
 		restore_current_blog();
 	}
+
+	// Drop network-scoped tables once (base_prefix), after every subsite is done.
+	datamachine_uninstall_network_tables();
 
 	// Clean up network-wide options (stored via get_site_option / update_site_option).
 	datamachine_uninstall_network_options();
@@ -56,14 +59,22 @@ function datamachine_uninstall_site() {
 	// --- Database tables ---
 
 	if ( current_user_can( 'delete_plugins' ) || defined( 'WP_UNINSTALL_PLUGIN' ) ) {
-		// Drop tables in reverse dependency order.
+		// Drop per-site tables in reverse dependency order. The chat sessions
+		// table is network-scoped (base_prefix) and is dropped once in
+		// datamachine_uninstall_network_tables(), not here — dropping it per-site
+		// would destroy the shared table on the first subsite uninstall.
 		$datamachine_tables_to_drop = array(
 			$wpdb->prefix . 'datamachine_processed_items',
 			$wpdb->prefix . 'datamachine_jobs',
 			$wpdb->prefix . 'datamachine_flows',
 			$wpdb->prefix . 'datamachine_pipelines',
-			$wpdb->prefix . 'datamachine_chat_sessions',
 		);
+
+		// On single-site, base_prefix === prefix, so the network table is dropped
+		// here alongside the per-site tables (there is no separate network pass).
+		if ( ! is_multisite() ) {
+			$datamachine_tables_to_drop[] = $wpdb->base_prefix . 'datamachine_chat_sessions';
+		}
 
 		foreach ( $datamachine_tables_to_drop as $datamachine_table_name ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
@@ -103,6 +114,31 @@ function datamachine_uninstall_site() {
 }
 
 /**
+ * Drop network-scoped tables once on multisite uninstall.
+ *
+ * Chat sessions live on base_prefix (shared across the network, like the
+ * agent identity tables), so the table must be dropped exactly once after
+ * every subsite's per-site cleanup has run — never per-site, which would
+ * destroy the shared table on the first subsite uninstall.
+ */
+function datamachine_uninstall_network_tables() {
+	global $wpdb;
+
+	if ( ! current_user_can( 'delete_plugins' ) && ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+		return;
+	}
+
+	$datamachine_network_tables = array(
+		$wpdb->base_prefix . 'datamachine_chat_sessions',
+	);
+
+	foreach ( $datamachine_network_tables as $datamachine_network_table ) {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $datamachine_network_table ) );
+	}
+}
+
+/**
  * Clean up network-wide options on multisite.
  *
  * These are stored via get_site_option() / update_site_option() and shared
@@ -115,6 +151,7 @@ function datamachine_uninstall_network_options() {
 		'datamachine_search_config',
 		'datamachine_auth_data',
 		'datamachine_network_settings',
+		'datamachine_chat_sessions_network_migrated',
 	);
 
 	foreach ( $datamachine_network_options as $datamachine_option ) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -13,7 +13,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
-	if ( is_multisite() ) {
+if ( is_multisite() ) {
 	// Clean up every subsite on the network.
 	$datamachine_sites = get_sites( array( 'fields' => 'ids' ) );
 	foreach ( $datamachine_sites as $datamachine_blog_id ) {


### PR DESCRIPTION
## Summary

Flips Data Machine chat session storage from **per-site** (`$wpdb->prefix`) to **network-wide** (`$wpdb->base_prefix`), so a user's chat history follows them across every subsite — consistent with users, agents, points, and profiles, which are already network-wide. Implements the full decision recorded in #2730 (full flip + migration + retention + always-current-request context + cross-site handoff note).

### 1. Storage → network-wide
- `Chat::get_table_prefix()` now returns `$wpdb->base_prefix`, mirroring `Agents` / `AgentTokens` / `AgentAccess` exactly.
- The two static accessors that hardcoded `$wpdb->prefix` (`get_prefixed_table_name()`, `table_exists()`) now resolve through `get_table_prefix()`, so every query in the repository hits the single network table.

### 2. One-time migration (idempotent)
- New `Chat::migrate_per_site_tables_to_network()` unions every legacy `c8c_<N>_datamachine_chat_sessions` table into the network table via `INSERT IGNORE` (de-duped on the `session_id` primary key, so it is safe to re-run and never overwrites migrated history). Copies only the column intersection shared by both tables so it is resilient to schema-version drift between installs. Skips the network table itself and no-ops on single-site.
- Wired into the existing version-gated migration runtime (`inc/migrations/chat-sessions-network.php` → `datamachine_run_schema_migrations()`), guarded by a network option (`datamachine_chat_sessions_network_migrated`) so the network-wide union runs once rather than per-site. Also runs eagerly on network activation.
- Direct callers moved to the network table: `PrincipalSessionPromoter`, `JobArtifacts`, `JobsCommand` (all now use `Chat::get_prefixed_table_name()`). `uninstall.php` drops the network-scoped table **once** after every subsite's per-site cleanup (dropping it per-site would destroy the shared table on the first subsite uninstall).

### 3. Retention → network-aware
- `RetentionChatSessionsTask` / `RetentionCleanup` already delegate to the `Chat` repository methods (`count_old_sessions`, `cleanup_old_sessions`, `cleanup_pipeline_transcripts`, `get_storage_metrics`, …). Because those all resolve through `get_prefixed_table_name()`, retention now operates against the single network table automatically — no per-site fan-out, no separate code path.

### 4. Resume context → always current-request + cross-site handoff note
- **Context is always recomputed from the current request, never replayed from the transcript.** Confirmed `ClientContextDirective` already renders the live request-local `client_context` payload (`page_url`, `page_title`, site, inferred repo, caps) each turn — it never reads stored session state. No core code bakes per-site context into stored session state. (Roadie's page/repo inference lives in `extrachill-roadie`, untouched here.)
- **Last-seen host** is now tracked in session metadata (`last_seen_host`), re-stamped every turn from the current request host (derived at runtime from `home_url()`).
- **Cross-site handoff note:** new `CrossSiteHandoffDirective` injects a lightweight one-turn system note when the current request host differs from the session's last-seen host (e.g. *"This conversation was last active on host A; the user is now on host B — resolve context from the current request."*). Hosts are derived at runtime; the directive carries no platform/vendor names, per RULES.md layer purity.

## Verification
- `php -l` clean on every touched file.
- `vendor/bin/phpcs --standard=WordPress` → **0 errors / 0 warnings** on all changed files (incl. the two updated smokes).
- Smokes run directly (CI harness `runner-steps.sh` unavailable):
  - `migration-runtime-smoke` ✅ (updated to include the new migration in the schema chain)
  - `pipeline-transcript-session-link-smoke` ✅ (updated assertion: fallback now resolves the table via `Chat::get_prefixed_table_name()`)
  - `chat-session-canonical-path`, `chat-transcript-owner`, `chat-list-message-count`, `agents-chat-handler`, `agents-chat-access-permission`, `agents-chat-tool-continuation`, `directive-policy-resolver`, `agent-daily-memory-directive` ✅
  - Known pre-existing red on `main` and unrelated to this change: `retention-system-tasks-smoke` (1/81 — "file dry-run counter includes old job directories"; verified red on `main` via stash).

Closes #2730