### PR TITLE
Fix deterministic job lifecycle states

### DIFF
--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -16,6 +16,7 @@ namespace DataMachine\Abilities\Engine;
 
 use DataMachine\Abilities\Flow\QueueAbility;
 use DataMachine\Core\Agents\AgentIdentityResolver;
+use DataMachine\Core\JobStatus;
 use DataMachine\Engine\ExecutionPlan;
 
 defined( 'ABSPATH' ) || exit;
@@ -214,9 +215,6 @@ class RunFlowAbility {
 			);
 		}
 
-		// Transition job from pending to processing.
-		$this->db_jobs->start_job( $job_id );
-
 		$scheduling_config   = $flow['scheduling_config'] ?? array();
 		$run_artifact_policy = \DataMachine\Engine\Bundle\BundleSchema::normalize_run_artifact_egress_policy( $scheduling_config['run_artifacts'] ?? array() );
 
@@ -301,6 +299,8 @@ class RunFlowAbility {
 		try {
 			$first_flow_step_id = ExecutionPlan::from_flow_config( $flow_config )->first_step_id();
 		} catch ( \InvalidArgumentException $e ) {
+			$this->db_jobs->complete_job( $job_id, JobStatus::failed( 'invalid_execution_plan' )->toString() );
+
 			do_action(
 				'datamachine_log',
 				'error',
@@ -314,11 +314,15 @@ class RunFlowAbility {
 			);
 			return array(
 				'success' => false,
+				'job_id'  => $job_id,
+				'reason'  => 'invalid_execution_plan',
 				'error'   => $e->getMessage(),
 			);
 		}
 
 		if ( ! $first_flow_step_id ) {
+			$this->db_jobs->complete_job( $job_id, JobStatus::failed( 'no_first_step' )->toString() );
+
 			do_action(
 				'datamachine_log',
 				'error',
@@ -331,9 +335,14 @@ class RunFlowAbility {
 			);
 			return array(
 				'success' => false,
+				'job_id'  => $job_id,
+				'reason'  => 'no_first_step',
 				'error'   => 'Flow execution failed - no first step found.',
 			);
 		}
+
+		// Transition job from pending to processing only after a first step is known.
+		$this->db_jobs->start_job( $job_id );
 
 		do_action( 'datamachine_schedule_next_step', $job_id, $first_flow_step_id, array() );
 

--- a/inc/Core/JobRetryPolicy.php
+++ b/inc/Core/JobRetryPolicy.php
@@ -92,9 +92,6 @@ class JobRetryPolicy {
 			);
 		}
 
-		self::recordRetry( $job_id, $reason, $context_data, $engine_data, $attempt, $max_attempts, $delay_seconds, $timestamp, $policy );
-		$db_jobs->update_job_status( $job_id, 'pending' );
-
 		$action_id = as_schedule_single_action(
 			$timestamp,
 			'datamachine_execute_step',
@@ -106,7 +103,6 @@ class JobRetryPolicy {
 		);
 
 		if ( false === $action_id ) {
-			$db_jobs->update_job_status( $job_id, 'processing' );
 			return array(
 				'retried'      => false,
 				'exhausted'    => false,
@@ -115,6 +111,9 @@ class JobRetryPolicy {
 				'reason'       => 'retry_schedule_failed',
 			);
 		}
+
+		self::recordRetry( $job_id, $reason, $context_data, $engine_data, $attempt, $max_attempts, $delay_seconds, $timestamp, $policy );
+		$db_jobs->update_job_status( $job_id, 'pending' );
 
 		do_action(
 			'datamachine_log',

--- a/inc/Engine/Actions/Handlers/FailJobHandler.php
+++ b/inc/Engine/Actions/Handlers/FailJobHandler.php
@@ -132,12 +132,9 @@ class FailJobHandler {
 		$retry_pending = self::hasPendingRetry( $engine_data );
 
 		// Skip cleanup whenever a retry is already scheduled for this job.
-		// JobRetryPolicy::recordRetry writes the next_retry_at timestamp before
-		// rescheduling the next Action Scheduler attempt; deleting the packet
-		// file before that retry runs would orphan the next attempt with no
-		// input data. This is defense-in-depth on top of the duplicate-fail-job
-		// guard in ExecuteStepAbility — even if a future caller fires fail-job
-		// during a pending retry, the data file survives until retry exhausts.
+		// JobRetryPolicy::recordRetry writes next_retry_at only after Action
+		// Scheduler accepts the retry action. A non-empty value means the next
+		// attempt has ownership of the packet file until retry exhausts.
 		if ( $cleanup_files && ! $retry_pending ) {
 			$job = $db_jobs->get_job( $job_id );
 			if ( $job && function_exists( 'datamachine_get_file_context' ) && ! empty( $job['flow_id'] ) ) {
@@ -171,10 +168,8 @@ class FailJobHandler {
 	 * Detect whether the engine snapshot already reflects a scheduled retry.
 	 *
 	 * `JobRetryPolicy::recordRetry` stamps `engine_data['retry']['next_retry_at']`
-	 * before rescheduling the next attempt. Any non-empty value means the policy
-	 * has taken ownership of the failure path — finalizing the failure here would
-	 * race ahead of that retry and (when cleanup is enabled) orphan the rescheduled
-	 * attempt with no input data.
+	 * only after Action Scheduler accepts the next attempt. Any non-empty value
+	 * means the policy has taken ownership of the failure path.
 	 *
 	 * @param array $engine_data Engine snapshot read prior to fail finalization.
 	 * @return bool

--- a/inc/Engine/Actions/Handlers/FailJobHandler.php
+++ b/inc/Engine/Actions/Handlers/FailJobHandler.php
@@ -178,5 +178,4 @@ class FailJobHandler {
 		$retry = is_array( $engine_data['retry'] ?? null ) ? $engine_data['retry'] : array();
 		return ! empty( $retry['next_retry_at'] );
 	}
-
 }

--- a/tests/Unit/Abilities/Engine/RunFlowAbilityLifecycleTest.php
+++ b/tests/Unit/Abilities/Engine/RunFlowAbilityLifecycleTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Tests for run-flow lifecycle transitions on invalid plans.
+ *
+ * @package DataMachine\Tests\Unit\Abilities\Engine
+ */
+
+namespace DataMachine\Tests\Unit\Abilities\Engine;
+
+use DataMachine\Abilities\Engine\RunFlowAbility;
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Core\JobStatus;
+use WP_UnitTestCase;
+
+class RunFlowAbilityLifecycleTest extends WP_UnitTestCase {
+
+	private $schedule_capture;
+	private array $scheduled_steps = array();
+
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+
+		if ( function_exists( 'datamachine_activate_for_site' ) ) {
+			datamachine_activate_for_site();
+		}
+	}
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$this->scheduled_steps  = array();
+		$this->schedule_capture = function ( $job_id, $flow_step_id, $data_packets = array() ): void {
+			$this->scheduled_steps[] = compact( 'job_id', 'flow_step_id', 'data_packets' );
+		};
+		add_action( 'datamachine_schedule_next_step', $this->schedule_capture, 1, 3 );
+	}
+
+	public function tear_down(): void {
+		remove_action( 'datamachine_schedule_next_step', $this->schedule_capture, 1 );
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
+	}
+
+	public function test_no_first_step_marks_created_job_failed(): void {
+		$pipeline_id = ( new Pipelines() )->create_pipeline(
+			array(
+				'pipeline_name'   => 'No First Step Pipeline',
+				'pipeline_config' => array(),
+				'user_id'         => get_current_user_id(),
+			)
+		);
+		$this->assertIsInt( $pipeline_id );
+
+		$flow_id = ( new Flows() )->create_flow(
+			array(
+				'pipeline_id'       => $pipeline_id,
+				'flow_name'         => 'No First Step Flow',
+				'flow_config'       => array(),
+				'scheduling_config' => array( 'enabled' => true ),
+				'user_id'           => get_current_user_id(),
+			)
+		);
+		$this->assertIsInt( $flow_id );
+
+		$result = ( new RunFlowAbility() )->execute( array( 'flow_id' => $flow_id ) );
+
+		$this->assertFalse( $result['success'] ?? true );
+		$this->assertSame( 'no_first_step', $result['reason'] ?? '' );
+		$this->assertIsInt( $result['job_id'] ?? null );
+		$this->assertSame( array(), $this->scheduled_steps );
+
+		$job = ( new Jobs() )->get_job( (int) $result['job_id'] );
+		$this->assertNotEmpty( $job );
+		$this->assertSame( JobStatus::failed( 'no_first_step' )->toString(), $job['status'] ?? '' );
+	}
+}

--- a/tests/retry-schedule-lifecycle-smoke.php
+++ b/tests/retry-schedule-lifecycle-smoke.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Pure-PHP smoke test for retry lifecycle state determinism.
+ *
+ * Run with: php tests/retry-schedule-lifecycle-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core\Database\Jobs {
+	class Jobs {
+		public string $status = 'processing';
+
+		public function get_job( int $job_id ): array {
+			$job_id;
+			return array( 'status' => $this->status );
+		}
+
+		public function update_job_status( int $job_id, string $status ): bool {
+			$job_id;
+			$this->status = $status;
+			return true;
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ );
+
+	$failed = 0;
+	$total  = 0;
+
+	function assert_retry_schedule_lifecycle( string $name, bool $condition, string $detail = '' ): void {
+		global $failed, $total;
+		++$total;
+		if ( $condition ) {
+			echo "  [PASS] $name\n";
+			return;
+		}
+
+		echo "  [FAIL] $name" . ( $detail ? " - $detail" : '' ) . "\n";
+		++$failed;
+	}
+
+	function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+		$hook;
+		$args;
+		return $value;
+	}
+
+	function do_action( string $hook, mixed ...$args ): void {
+		$hook;
+		$args;
+	}
+
+	function wp_rand( int $min, int $max ): int {
+		$max;
+		return $min;
+	}
+
+	function as_schedule_single_action( int $timestamp, string $hook, array $args = array(), string $group = '' ): int|false {
+		$GLOBALS['scheduled_retry'] = compact( 'timestamp', 'hook', 'args', 'group' );
+		return $GLOBALS['schedule_retry_result'];
+	}
+
+	function datamachine_get_engine_data( int $job_id ): array {
+		$job_id;
+		return $GLOBALS['engine_data'] ?? array();
+	}
+
+	function datamachine_merge_engine_data( int $job_id, array $data ): void {
+		$job_id;
+		$GLOBALS['merged_engine_data'] = $data;
+	}
+
+	require_once __DIR__ . '/../inc/Core/JobRetryPolicy.php';
+
+	echo "Case 1: scheduler failure leaves no pending retry metadata\n";
+	$GLOBALS['engine_data']           = array();
+	$GLOBALS['merged_engine_data']    = array();
+	$GLOBALS['schedule_retry_result'] = false;
+	$GLOBALS['scheduled_retry']       = null;
+	$jobs                             = new \DataMachine\Core\Database\Jobs\Jobs();
+	$result                           = \DataMachine\Core\JobRetryPolicy::maybeRetry(
+		123,
+		'transient_failure',
+		array(
+			'flow_step_id' => 'step-1',
+			'retryable'    => true,
+		),
+		$jobs
+	);
+
+	assert_retry_schedule_lifecycle( 'schedule failure is not reported as retried', false === $result['retried'] );
+	assert_retry_schedule_lifecycle( 'schedule failure reports structured reason', 'retry_schedule_failed' === ( $result['reason'] ?? '' ) );
+	assert_retry_schedule_lifecycle( 'job status remains processing when no retry action exists', 'processing' === $jobs->status );
+	assert_retry_schedule_lifecycle( 'next_retry_at is not exposed in result', ! isset( $result['next_retry_at'] ) );
+	assert_retry_schedule_lifecycle( 'next_retry_at is not persisted without action', ! isset( $GLOBALS['merged_engine_data']['retry']['next_retry_at'] ) );
+
+	echo "Case 2: scheduler success publishes pending retry metadata\n";
+	$GLOBALS['engine_data']           = array();
+	$GLOBALS['merged_engine_data']    = array();
+	$GLOBALS['schedule_retry_result'] = 456;
+	$GLOBALS['scheduled_retry']       = null;
+	$jobs                             = new \DataMachine\Core\Database\Jobs\Jobs();
+	$result                           = \DataMachine\Core\JobRetryPolicy::maybeRetry(
+		123,
+		'transient_failure',
+		array(
+			'flow_step_id' => 'step-1',
+			'retryable'    => true,
+		),
+		$jobs
+	);
+
+	assert_retry_schedule_lifecycle( 'schedule success is reported as retried', true === $result['retried'] );
+	assert_retry_schedule_lifecycle( 'job moves pending after retry action exists', 'pending' === $jobs->status );
+	assert_retry_schedule_lifecycle( 'next_retry_at is exposed in result', isset( $result['next_retry_at'] ) );
+	assert_retry_schedule_lifecycle( 'next_retry_at is persisted after action exists', isset( $GLOBALS['merged_engine_data']['retry']['next_retry_at'] ) );
+
+	echo "\nRetry schedule lifecycle smoke complete: {$total} assertions, {$failed} failures.\n";
+	if ( $failed > 0 ) {
+		exit( 1 );
+	}
+}


### PR DESCRIPTION
## Summary
- Record retry metadata only after Action Scheduler accepts the retry action, so failed scheduling does not expose stale pending retry state.
- Keep RunFlow jobs pending until a first step is known, and mark invalid/no-first-step jobs terminal failed with structured reasons.
- Add focused retry lifecycle smoke coverage and RunFlow no-first-step lifecycle coverage.

## Testing
- php tests/retry-schedule-lifecycle-smoke.php
- php tests/job-retry-policy-smoke.php
- php -l inc/Core/JobRetryPolicy.php && php -l inc/Abilities/Engine/RunFlowAbility.php && php -l inc/Engine/Actions/Handlers/FailJobHandler.php && php -l tests/retry-schedule-lifecycle-smoke.php && php -l tests/Unit/Abilities/Engine/RunFlowAbilityLifecycleTest.php
- vendor/bin/phpcs --standard=phpcs.xml.dist inc/Core/JobRetryPolicy.php inc/Abilities/Engine/RunFlowAbility.php inc/Engine/Actions/Handlers/FailJobHandler.php tests/retry-schedule-lifecycle-smoke.php tests/Unit/Abilities/Engine/RunFlowAbilityLifecycleTest.php

## Caveats
- vendor/bin/phpunit is not installed in this worktree.
- homeboy test data-machine is blocked locally before repo tests run because the linked Homeboy wordpress extension target is missing: /Users/chubes/Developer/homeboy-extensions@fix-persist-codex-refresh/wordpress.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested deterministic job lifecycle fixes.