### PR TITLE
Add portable step result envelopes

### DIFF
--- a/inc/Core/RunResult.php
+++ b/inc/Core/RunResult.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Portable run result envelope.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Builds the canonical result envelope for a deterministic run.
+ */
+class RunResult {
+
+	public const SCHEMA_VERSION = 'datamachine.run_result.v1';
+
+	/**
+	 * Build a run envelope from step result envelopes.
+	 *
+	 * @param array<int,array<string,mixed>> $step_results StepResult envelopes.
+	 * @param array<string,mixed>            $context      Optional outputs/artifact refs/replay context.
+	 * @return array<string,mixed>
+	 */
+	public static function fromStepResults( array $step_results, array $context = array() ): array {
+		$steps         = array_values( array_filter( $step_results, fn( $step_result ) => is_array( $step_result ) ) );
+		$status        = self::deriveStatus( $steps, $context['status'] ?? null );
+		$outputs       = is_array( $context['outputs'] ?? null ) ? $context['outputs'] : array();
+		$artifact_refs = self::mergeRefs( $steps, 'artifact_refs', $context['artifact_refs'] ?? ( $context['artifacts'] ?? array() ) );
+		$packet_refs   = self::mergeRefs( $steps, 'packet_refs', $context['packet_refs'] ?? array() );
+		$diagnostics   = is_array( $context['diagnostics'] ?? null ) ? $context['diagnostics'] : array();
+
+		return array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'status'         => $status,
+			'outputs'        => $outputs,
+			'artifact_refs'  => $artifact_refs,
+			'packet_refs'    => $packet_refs,
+			'diagnostics'    => $diagnostics,
+			'replay'         => self::buildReplayMetadata( $steps, $outputs, $artifact_refs, $packet_refs, is_array( $context['replay'] ?? null ) ? $context['replay'] : array() ),
+			'steps'          => $steps,
+		);
+	}
+
+	/**
+	 * Derive an aggregate run status from step envelopes.
+	 *
+	 * @param array<int,array<string,mixed>> $steps           Step envelopes.
+	 * @param mixed                          $explicit_status Caller-provided status.
+	 * @return string Run status.
+	 */
+	private static function deriveStatus( array $steps, $explicit_status ): string {
+		if ( is_scalar( $explicit_status ) && '' !== trim( (string) $explicit_status ) ) {
+			return trim( (string) $explicit_status );
+		}
+
+		foreach ( $steps as $step ) {
+			if ( 'failed' === ( $step['status'] ?? '' ) || 'blocked' === ( $step['status'] ?? '' ) ) {
+				return (string) $step['status'];
+			}
+		}
+
+		return array() === $steps ? 'completed_no_items' : 'succeeded';
+	}
+
+	/**
+	 * Merge caller refs with refs from every step envelope.
+	 *
+	 * @param array<int,array<string,mixed>> $steps Step envelopes.
+	 * @param string                         $key   Envelope ref key.
+	 * @param mixed                          $refs  Caller refs.
+	 * @return array<int,mixed>
+	 */
+	private static function mergeRefs( array $steps, string $key, $refs ): array {
+		$merged = is_array( $refs ) ? array_values( $refs ) : array();
+
+		foreach ( $steps as $step ) {
+			if ( is_array( $step[ $key ] ?? null ) ) {
+				$merged = array_merge( $merged, array_values( $step[ $key ] ) );
+			}
+		}
+
+		return $merged;
+	}
+
+	/**
+	 * Build replay metadata with deterministic content hashes.
+	 *
+	 * @param array<int,array<string,mixed>> $steps         Step envelopes.
+	 * @param array<string,mixed>            $outputs       Run outputs.
+	 * @param array<int,mixed>               $artifact_refs Artifact refs.
+	 * @param array<int,mixed>               $packet_refs   Packet refs.
+	 * @param array<string,mixed>            $replay        Replay metadata.
+	 * @return array<string,mixed>
+	 */
+	private static function buildReplayMetadata( array $steps, array $outputs, array $artifact_refs, array $packet_refs, array $replay ): array {
+		$content_hashes = is_array( $replay['content_hashes'] ?? null ) ? $replay['content_hashes'] : array();
+		$content_hashes += array(
+			'steps'         => self::contentHash( $steps ),
+			'outputs'       => self::contentHash( $outputs ),
+			'artifact_refs' => self::contentHash( $artifact_refs ),
+			'packet_refs'   => self::contentHash( $packet_refs ),
+		);
+
+		$replay['content_hashes'] = $content_hashes;
+
+		return $replay;
+	}
+
+	/**
+	 * Compute a stable SHA-256 hash for JSON-serializable content.
+	 *
+	 * @param mixed $value Value to hash.
+	 * @return string Content hash.
+	 */
+	private static function contentHash( $value ): string {
+		$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( self::sortKeysRecursive( $value ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : json_encode( self::sortKeysRecursive( $value ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+
+		if ( ! is_string( $encoded ) ) {
+			$encoded = '';
+		}
+
+		return 'sha256:' . hash( 'sha256', $encoded );
+	}
+
+	/**
+	 * Sort associative array keys recursively for stable hashes.
+	 *
+	 * @param mixed $value Value to normalize.
+	 * @return mixed Normalized value.
+	 */
+	private static function sortKeysRecursive( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$is_list = array_keys( $value ) === range( 0, count( $value ) - 1 );
+		if ( ! $is_list ) {
+			ksort( $value );
+		}
+
+		foreach ( $value as $key => $item ) {
+			$value[ $key ] = self::sortKeysRecursive( $item );
+		}
+
+		return $value;
+	}
+}

--- a/inc/Core/RunResult.php
+++ b/inc/Core/RunResult.php
@@ -95,7 +95,7 @@ class RunResult {
 	 * @return array<string,mixed>
 	 */
 	private static function buildReplayMetadata( array $steps, array $outputs, array $artifact_refs, array $packet_refs, array $replay ): array {
-		$content_hashes = is_array( $replay['content_hashes'] ?? null ) ? $replay['content_hashes'] : array();
+		$content_hashes  = is_array( $replay['content_hashes'] ?? null ) ? $replay['content_hashes'] : array();
 		$content_hashes += array(
 			'steps'         => self::contentHash( $steps ),
 			'outputs'       => self::contentHash( $outputs ),
@@ -115,7 +115,7 @@ class RunResult {
 	 * @return string Content hash.
 	 */
 	private static function contentHash( $value ): string {
-		$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( self::sortKeysRecursive( $value ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : json_encode( self::sortKeysRecursive( $value ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		$encoded = wp_json_encode( self::sortKeysRecursive( $value ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 
 		if ( ! is_string( $encoded ) ) {
 			$encoded = '';

--- a/inc/Core/StepExecutionResult.php
+++ b/inc/Core/StepExecutionResult.php
@@ -9,6 +9,10 @@ namespace DataMachine\Core;
 
 defined( 'ABSPATH' ) || exit;
 
+if ( ! class_exists( StepResult::class ) ) {
+	require_once __DIR__ . '/StepResult.php';
+}
+
 /**
  * Normalizes step execution status separately from DataPacket transport.
  */
@@ -40,7 +44,7 @@ class StepExecutionResult {
 	 *
 	 * @param mixed  $step_output Step return value.
 	 * @param string $step_type   Step type identifier.
-	 * @return array{status: string, packets: array, reason: string, error: ?string, diagnostics: array, terminal_status: ?string, success: bool, packet_count: int}
+	 * @return array{status: string, packets: array, reason: string, error: ?string, diagnostics: array, terminal_status: ?string, success: bool, packet_count: int, step_result: array}
 	 */
 	public static function fromStepOutput( $step_output, string $step_type = '' ): array {
 		if ( self::isExplicitResult( $step_output ) ) {
@@ -48,6 +52,7 @@ class StepExecutionResult {
 			$status  = self::normalizeStatus( $step_output['status'] ?? '' );
 			$reason  = is_scalar( $step_output['reason'] ?? null ) ? self::sanitizeReason( $step_output['reason'] ) : '';
 			$error   = self::normalizeError( $step_output['error'] ?? ( $step_output['error_message'] ?? null ) );
+			$context = self::envelopeContextFromOutput( $step_output );
 
 			if ( '' === $status ) {
 				$classified = self::classify( $packets, $step_type );
@@ -62,7 +67,7 @@ class StepExecutionResult {
 			$terminal_status = $step_output['terminal_status'] ?? null;
 			$terminal_status = is_scalar( $terminal_status ) && '' !== trim( (string) $terminal_status ) ? trim( (string) $terminal_status ) : null;
 
-			return self::buildResult( $status, $packets, $reason, $terminal_status, $error );
+			return self::buildResult( $status, $packets, $reason, $terminal_status, $error, array(), $context );
 		}
 
 		return self::classify( self::normalizePackets( $step_output ), $step_type );
@@ -73,7 +78,7 @@ class StepExecutionResult {
 	 *
 	 * @param array  $data_packets Returned data packets.
 	 * @param string $step_type    Step type identifier.
-	 * @return array{status: string, packets: array, reason: string, error: ?string, diagnostics: array, terminal_status: ?string, success: bool, packet_count: int}
+	 * @return array{status: string, packets: array, reason: string, error: ?string, diagnostics: array, terminal_status: ?string, success: bool, packet_count: int, step_result: array}
 	 */
 	public static function classify( array $data_packets, string $step_type = '' ): array {
 		$data_packets = self::normalizePackets( $data_packets );
@@ -141,13 +146,13 @@ class StepExecutionResult {
 		);
 	}
 
-	private static function buildResult( string $status, array $packets, string $reason, ?string $terminal_status, ?string $error = null, array $diagnostics = array() ): array {
+	private static function buildResult( string $status, array $packets, string $reason, ?string $terminal_status, ?string $error = null, array $diagnostics = array(), array $envelope_context = array() ): array {
 		$status = self::normalizeStatus( $status );
 		if ( '' === $status ) {
 			$status = self::STATUS_FAILED;
 		}
 
-		return array(
+		$result = array(
 			'status'          => $status,
 			'packets'         => $packets,
 			'reason'          => self::sanitizeReason( $reason ),
@@ -156,6 +161,22 @@ class StepExecutionResult {
 			'terminal_status' => $terminal_status,
 			'success'         => self::STATUS_SUCCEEDED === $status,
 			'packet_count'    => count( $packets ),
+		);
+
+		$result['step_result'] = StepResult::fromExecutionResult( $result, $envelope_context );
+
+		return $result;
+	}
+
+	private static function envelopeContextFromOutput( array $step_output ): array {
+		return array_filter(
+			array(
+				'outputs'       => is_array( $step_output['outputs'] ?? null ) ? $step_output['outputs'] : null,
+				'artifact_refs' => is_array( $step_output['artifact_refs'] ?? null ) ? $step_output['artifact_refs'] : ( is_array( $step_output['artifacts'] ?? null ) ? $step_output['artifacts'] : null ),
+				'packet_refs'   => is_array( $step_output['packet_refs'] ?? null ) ? $step_output['packet_refs'] : null,
+				'replay'        => is_array( $step_output['replay'] ?? null ) ? $step_output['replay'] : null,
+			),
+			fn( $value ) => null !== $value
 		);
 	}
 

--- a/inc/Core/StepResult.php
+++ b/inc/Core/StepResult.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Portable step result envelope.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Builds the canonical, packet-neutral result envelope for a single step.
+ */
+class StepResult {
+
+	public const SCHEMA_VERSION = 'datamachine.step_result.v1';
+
+	/**
+	 * Build a portable step result envelope from the legacy execution result.
+	 *
+	 * @param array<string,mixed> $execution_result Legacy StepExecutionResult array.
+	 * @param array<string,mixed> $context          Optional outputs/artifact refs/replay context.
+	 * @return array<string,mixed>
+	 */
+	public static function fromExecutionResult( array $execution_result, array $context = array() ): array {
+		$outputs       = self::normalizeAssociativeArray( $context['outputs'] ?? array() );
+		$artifact_refs = self::normalizeList( $context['artifact_refs'] ?? ( $context['artifacts'] ?? array() ) );
+		$packet_refs   = array_merge(
+			self::packetRefsFromPackets( is_array( $execution_result['packets'] ?? null ) ? $execution_result['packets'] : array() ),
+			self::normalizeList( $context['packet_refs'] ?? array() )
+		);
+		$diagnostics   = self::normalizeAssociativeArray( $execution_result['diagnostics'] ?? array() );
+
+		if ( ! isset( $diagnostics['reason'] ) && is_scalar( $execution_result['reason'] ?? null ) ) {
+			$diagnostics['reason'] = (string) $execution_result['reason'];
+		}
+
+		if ( ! isset( $diagnostics['error'] ) && is_scalar( $execution_result['error'] ?? null ) ) {
+			$diagnostics['error'] = (string) $execution_result['error'];
+		}
+
+		if ( ! array_key_exists( 'packet_count', $outputs ) ) {
+			$outputs['packet_count'] = count( is_array( $execution_result['packets'] ?? null ) ? $execution_result['packets'] : array() );
+		}
+
+		return array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'status'         => is_scalar( $execution_result['status'] ?? null ) ? (string) $execution_result['status'] : 'failed',
+			'outputs'        => $outputs,
+			'artifact_refs'  => $artifact_refs,
+			'packet_refs'    => $packet_refs,
+			'diagnostics'    => $diagnostics,
+			'replay'         => self::buildReplayMetadata( $outputs, $artifact_refs, $packet_refs, self::normalizeAssociativeArray( $context['replay'] ?? array() ) ),
+		);
+	}
+
+	/**
+	 * Build deterministic packet references without embedding transport packets.
+	 *
+	 * @param array<int,mixed> $packets Step output packets.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function packetRefsFromPackets( array $packets ): array {
+		$refs = array();
+
+		foreach ( array_values( $packets ) as $index => $packet ) {
+			if ( ! is_array( $packet ) ) {
+				continue;
+			}
+
+			$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+			$ref      = array(
+				'index'        => $index,
+				'type'         => is_scalar( $packet['type'] ?? null ) ? (string) $packet['type'] : '',
+				'content_hash' => self::contentHash( $packet ),
+			);
+
+			foreach ( array( 'source_type', 'source_id', 'source_item_id', 'job_id', 'flow_step_id' ) as $key ) {
+				if ( is_scalar( $metadata[ $key ] ?? null ) ) {
+					$ref[ $key ] = (string) $metadata[ $key ];
+				}
+			}
+
+			if ( is_scalar( $packet['timestamp'] ?? null ) ) {
+				$ref['timestamp'] = (string) $packet['timestamp'];
+			}
+
+			$refs[] = $ref;
+		}
+
+		return $refs;
+	}
+
+	/**
+	 * Build replay metadata with deterministic content hashes where available.
+	 *
+	 * @param array<string,mixed>     $outputs       Normalized outputs.
+	 * @param array<int,mixed>        $artifact_refs Artifact references.
+	 * @param array<int,mixed>        $packet_refs   Packet references.
+	 * @param array<string,mixed>     $replay        Caller-provided replay metadata.
+	 * @return array<string,mixed>
+	 */
+	private static function buildReplayMetadata( array $outputs, array $artifact_refs, array $packet_refs, array $replay ): array {
+		$content_hashes = self::normalizeAssociativeArray( $replay['content_hashes'] ?? array() );
+
+		$content_hashes += array(
+			'outputs'       => self::contentHash( $outputs ),
+			'artifact_refs' => self::contentHash( $artifact_refs ),
+			'packet_refs'   => self::contentHash( $packet_refs ),
+		);
+
+		$replay['content_hashes'] = $content_hashes;
+
+		return $replay;
+	}
+
+	/**
+	 * Compute a stable SHA-256 hash for JSON-serializable content.
+	 *
+	 * @param mixed $value Value to hash.
+	 * @return string Content hash.
+	 */
+	private static function contentHash( $value ): string {
+		$normalized = self::sortKeysRecursive( $value );
+		$encoded    = function_exists( 'wp_json_encode' ) ? wp_json_encode( $normalized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : json_encode( $normalized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+
+		if ( ! is_string( $encoded ) ) {
+			$encoded = '';
+		}
+
+		return 'sha256:' . hash( 'sha256', $encoded );
+	}
+
+	/**
+	 * Sort associative array keys recursively for stable hashes.
+	 *
+	 * @param mixed $value Value to normalize.
+	 * @return mixed Normalized value.
+	 */
+	private static function sortKeysRecursive( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$is_list = array_keys( $value ) === range( 0, count( $value ) - 1 );
+		if ( ! $is_list ) {
+			ksort( $value );
+		}
+
+		foreach ( $value as $key => $item ) {
+			$value[ $key ] = self::sortKeysRecursive( $item );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Normalize associative array input.
+	 *
+	 * @param mixed $value Input value.
+	 * @return array<string,mixed>
+	 */
+	private static function normalizeAssociativeArray( $value ): array {
+		return is_array( $value ) ? $value : array();
+	}
+
+	/**
+	 * Normalize list-like input.
+	 *
+	 * @param mixed $value Input value.
+	 * @return array<int,mixed>
+	 */
+	private static function normalizeList( $value ): array {
+		return is_array( $value ) ? array_values( $value ) : array();
+	}
+}

--- a/inc/Core/StepResult.php
+++ b/inc/Core/StepResult.php
@@ -123,7 +123,7 @@ class StepResult {
 	 */
 	private static function contentHash( $value ): string {
 		$normalized = self::sortKeysRecursive( $value );
-		$encoded    = function_exists( 'wp_json_encode' ) ? wp_json_encode( $normalized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : json_encode( $normalized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		$encoded    = wp_json_encode( $normalized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 
 		if ( ! is_string( $encoded ) ) {
 			$encoded = '';

--- a/tests/step-execution-result-contract-smoke.php
+++ b/tests/step-execution-result-contract-smoke.php
@@ -19,10 +19,14 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 }
 
 require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/StepResult.php';
+require_once __DIR__ . '/../inc/Core/RunResult.php';
 require_once __DIR__ . '/../inc/Core/StepExecutionResult.php';
 
 use DataMachine\Core\JobStatus;
+use DataMachine\Core\RunResult;
 use DataMachine\Core\StepExecutionResult;
+use DataMachine\Core\StepResult;
 
 $failures = 0;
 $total    = 0;
@@ -155,6 +159,46 @@ $result = StepExecutionResult::classify(
 $assert( 'recovered failed runtime tool does not fail final step', 'succeeded' === $result['status'] );
 $assert( 'recovered failed runtime tool packet remains in audit packets', false === ( $result['packets'][0]['metadata']['tool_success'] ?? null ) );
 $assert( 'recovered failed runtime tool diagnostics remain in packet history', 'file_too_large' === ( $result['packets'][0]['metadata']['tool_result_envelope']['code'] ?? '' ) );
+
+echo "\n[7] step result envelope carries portable deterministic refs\n";
+$result = StepExecutionResult::fromStepOutput(
+	array(
+		'status'        => 'succeeded',
+		'outputs'       => array( 'post_id' => 123 ),
+		'artifact_refs' => array(
+			array(
+				'type' => 'file',
+				'uri'  => 'artifact://job/123/output.json',
+			),
+		),
+		'packets'       => array(
+			array(
+				'type'     => 'source_item',
+				'data'     => array( 'body' => 'ok' ),
+				'metadata' => array(
+					'source_type' => 'test',
+					'source_id'   => 'abc',
+				),
+			),
+		),
+	),
+	'publish'
+);
+
+$step_result = $result['step_result'];
+$assert( 'step envelope schema version is canonical', StepResult::SCHEMA_VERSION === ( $step_result['schema_version'] ?? '' ) );
+$assert( 'step envelope preserves non-packet outputs', 123 === ( $step_result['outputs']['post_id'] ?? null ) );
+$assert( 'step envelope includes artifact refs', 'artifact://job/123/output.json' === ( $step_result['artifact_refs'][0]['uri'] ?? '' ) );
+$assert( 'step envelope references packets by content hash', str_starts_with( (string) ( $step_result['packet_refs'][0]['content_hash'] ?? '' ), 'sha256:' ) );
+$assert( 'step envelope records replay content hashes', str_starts_with( (string) ( $step_result['replay']['content_hashes']['packet_refs'] ?? '' ), 'sha256:' ) );
+
+echo "\n[8] run result envelope aggregates step envelopes\n";
+$run_result = RunResult::fromStepResults( array( $step_result ) );
+
+$assert( 'run envelope schema version is canonical', RunResult::SCHEMA_VERSION === ( $run_result['schema_version'] ?? '' ) );
+$assert( 'run envelope derives success from step envelopes', 'succeeded' === ( $run_result['status'] ?? '' ) );
+$assert( 'run envelope aggregates packet refs', str_starts_with( (string) ( $run_result['packet_refs'][0]['content_hash'] ?? '' ), 'sha256:' ) );
+$assert( 'run envelope records step replay hash', str_starts_with( (string) ( $run_result['replay']['content_hashes']['steps'] ?? '' ), 'sha256:' ) );
 
 if ( $failures > 0 ) {
 	echo "\n=== step-execution-result-contract-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";

--- a/tests/step-execution-result-contract-smoke.php
+++ b/tests/step-execution-result-contract-smoke.php
@@ -18,6 +18,13 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $options = 0 ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Pure-PHP smoke test fallback outside WordPress.
+		return json_encode( $data, $options );
+	}
+}
+
 require_once __DIR__ . '/../inc/Core/JobStatus.php';
 require_once __DIR__ . '/../inc/Core/StepResult.php';
 require_once __DIR__ . '/../inc/Core/RunResult.php';


### PR DESCRIPTION
## Summary
- Add canonical `StepResult` and `RunResult` envelopes with schema versions, status, outputs, artifact refs, packet refs, diagnostics, and replay content hashes.
- Attach a `step_result` envelope to existing `StepExecutionResult` arrays without changing legacy packet/status fields.
- Extend the StepExecutionResult contract smoke test for deterministic envelope refs and run aggregation.

## Tests
- `php tests/step-execution-result-contract-smoke.php`
- `php tests/step-base-explicit-result-smoke.php`
- `php tests/job-status-accounting-smoke.php`
- `php -l inc/Core/StepResult.php && php -l inc/Core/RunResult.php && php -l inc/Core/StepExecutionResult.php && php -l tests/step-execution-result-contract-smoke.php`
- `vendor/bin/phpcs inc/Core/StepResult.php inc/Core/RunResult.php inc/Core/StepExecutionResult.php tests/step-execution-result-contract-smoke.php`

## Caveats
- `homeboy test data-machine` is blocked locally by Homeboy extension `wordpress` linking to missing target `/Users/chubes/Developer/homeboy-extensions@fix-persist-codex-refresh/wordpress`.
- `php tests/step-exception-failure-contract-smoke.php` remains failing because it expects `Step::execute()` to return a raw packet list and then hits an uninitialized `ExecuteStepAbility::$db_jobs` test double; left unchanged as unrelated to this additive envelope.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested deterministic step result envelope.