### PR TITLE
Add replayable engine state ledger

### DIFF
--- a/inc/Core/EngineData.php
+++ b/inc/Core/EngineData.php
@@ -121,7 +121,7 @@ class EngineData {
 	}
 
 	/**
-	 * Append a compact state event trace and persist its patch as the current snapshot projection.
+	 * Append a replayable state event and persist its patch as the current snapshot projection.
 	 *
 	 * @param int    $job_id   Job ID.
 	 * @param string $type     Generic event type.
@@ -134,83 +134,33 @@ class EngineData {
 			return null;
 		}
 
-		$current = self::retrieve( $job_id );
-		$ledger  = is_array( $current['_engine_state_ledger'] ?? null ) ? $current['_engine_state_ledger'] : array();
-		$version = self::nextLedgerVersion( $ledger );
-		$entry   = array(
-			'version'     => $version,
-			'type'        => sanitize_key( $type ),
-			'recorded_at' => gmdate( 'c' ),
-			'patch_keys'  => array_keys( $patch ),
-			'patch_hash'  => self::stableHash( $patch ),
-		);
-
-		if ( ! empty( $metadata ) ) {
-			$entry['metadata'] = $metadata;
+		$projection = EngineStateLedger::append( self::retrieve( $job_id ), $type, $patch, $metadata );
+		if ( null === $projection ) {
+			return null;
 		}
 
-		$ledger[]                          = $entry;
-		$projected                         = array_replace_recursive( $current, $patch );
-		$projected['_engine_state_ledger'] = $ledger;
-
-		return self::persist( $job_id, $projected ) ? $entry : null;
+		return self::persist( $job_id, $projection['snapshot'] ) ? $projection['event'] : null;
 	}
 
 	/**
-	 * Resolve the next monotonically increasing ledger version.
+	 * Return replayable state ledger events from a snapshot.
 	 *
-	 * @param array $ledger Existing ledger entries.
-	 * @return int Next version number.
+	 * @param array $snapshot Engine data snapshot.
+	 * @return array Ledger events.
 	 */
-	private static function nextLedgerVersion( array $ledger ): int {
-		$version = 0;
-		foreach ( $ledger as $entry ) {
-			if ( is_array( $entry ) && isset( $entry['version'] ) ) {
-				$version = max( $version, (int) $entry['version'] );
-			}
-		}
-
-		return $version + 1;
+	public static function stateLedger( array $snapshot ): array {
+		return EngineStateLedger::fromSnapshot( $snapshot );
 	}
 
 	/**
-	 * Build a stable hash for a projected state patch.
+	 * Replay state ledger events onto a base snapshot.
 	 *
-	 * @param array $patch Engine data patch.
-	 * @return string sha256 hash prefixed for readability.
+	 * @param array $events        Ledger events.
+	 * @param array $base_snapshot Optional base snapshot.
+	 * @return array Replayed engine data snapshot without ledger metadata.
 	 */
-	private static function stableHash( array $patch ): string {
-		$normalized = self::sortRecursively( $patch );
-		$json       = wp_json_encode( $normalized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PARTIAL_OUTPUT_ON_ERROR );
-
-		if ( ! is_string( $json ) ) {
-			$json = 'null';
-		}
-
-		return 'sha256:' . hash( 'sha256', $json );
-	}
-
-	/**
-	 * Recursively sort associative array keys for deterministic hashing.
-	 *
-	 * @param mixed $value Value to sort.
-	 * @return mixed Sorted value.
-	 */
-	private static function sortRecursively( $value ) {
-		if ( ! is_array( $value ) ) {
-			return $value;
-		}
-
-		$sorted = array();
-		foreach ( $value as $key => $item ) {
-			$sorted[ $key ] = self::sortRecursively( $item );
-		}
-
-		if ( array_keys( $sorted ) !== range( 0, count( $sorted ) - 1 ) ) {
-			ksort( $sorted );
-		}
-
-		return $sorted;
+	public static function replayStateLedger( array $events, array $base_snapshot = array() ): array {
+		return EngineStateLedger::replay( $events, $base_snapshot );
 	}
 
 	/**

--- a/inc/Core/EngineStateLedger.php
+++ b/inc/Core/EngineStateLedger.php
@@ -61,7 +61,7 @@ class EngineStateLedger {
 			$event['metadata'] = $metadata;
 		}
 
-		$ledger[]                         = $event;
+		$ledger[]                        = $event;
 		$projected[ self::SNAPSHOT_KEY ] = $ledger;
 
 		return array(

--- a/inc/Core/EngineStateLedger.php
+++ b/inc/Core/EngineStateLedger.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Replayable engine state ledger primitive.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Builds and replays append-only engine state events.
+ */
+class EngineStateLedger {
+
+	/** Current ledger event schema version. */
+	public const SCHEMA_VERSION = 1;
+
+	/** Engine snapshot key used to store ledger events. */
+	public const SNAPSHOT_KEY = '_engine_state_ledger';
+
+	/**
+	 * Append a replayable event to a snapshot and return the projected snapshot.
+	 *
+	 * @param array  $snapshot Current engine data snapshot.
+	 * @param string $type     Event type.
+	 * @param array  $patch    Engine data patch.
+	 * @param array  $metadata Optional event metadata.
+	 * @return array{snapshot: array, event: array}|null Projected snapshot and appended event.
+	 */
+	public static function append( array $snapshot, string $type, array $patch, array $metadata = array() ): ?array {
+		$type = sanitize_key( $type );
+		if ( '' === $type ) {
+			return null;
+		}
+
+		$ledger        = self::fromSnapshot( $snapshot );
+		$pre_snapshot  = self::snapshotForHashing( $snapshot );
+		$projected     = array_replace_recursive( $snapshot, $patch );
+		$post_snapshot = self::snapshotForHashing( $projected );
+		$event         = array(
+			'schema_version'     => self::SCHEMA_VERSION,
+			'version'            => self::nextVersion( $ledger ),
+			'type'               => $type,
+			'event_type'         => $type,
+			'op_id'              => self::resolveOpId( $metadata ),
+			'actor'              => self::resolveStringMetadata( $metadata, 'actor' ),
+			'source'             => self::resolveStringMetadata( $metadata, 'source' ),
+			'recorded_at'        => gmdate( 'c' ),
+			'patch'              => $patch,
+			'patch_keys'         => array_keys( $patch ),
+			'patch_hash'         => self::stableHash( $patch ),
+			'pre_snapshot_hash'  => self::stableHash( $pre_snapshot ),
+			'post_snapshot_hash' => self::stableHash( $post_snapshot ),
+		);
+
+		if ( ! empty( $metadata ) ) {
+			$event['metadata'] = $metadata;
+		}
+
+		$ledger[]                         = $event;
+		$projected[ self::SNAPSHOT_KEY ] = $ledger;
+
+		return array(
+			'snapshot' => $projected,
+			'event'    => $event,
+		);
+	}
+
+	/**
+	 * Return ledger events from a snapshot.
+	 *
+	 * @param array $snapshot Engine data snapshot.
+	 * @return array Ledger events.
+	 */
+	public static function fromSnapshot( array $snapshot ): array {
+		return is_array( $snapshot[ self::SNAPSHOT_KEY ] ?? null ) ? $snapshot[ self::SNAPSHOT_KEY ] : array();
+	}
+
+	/**
+	 * Replay event patches onto a base snapshot.
+	 *
+	 * @param array $events        Ledger events.
+	 * @param array $base_snapshot Optional base snapshot.
+	 * @return array Replayed engine data snapshot without ledger metadata.
+	 */
+	public static function replay( array $events, array $base_snapshot = array() ): array {
+		$projection = self::snapshotForHashing( $base_snapshot );
+
+		foreach ( $events as $event ) {
+			if ( ! is_array( $event ) || ! is_array( $event['patch'] ?? null ) ) {
+				continue;
+			}
+
+			$projection = array_replace_recursive( $projection, $event['patch'] );
+		}
+
+		return $projection;
+	}
+
+	/**
+	 * Replay a snapshot's ledger onto an optional base snapshot.
+	 *
+	 * @param array $snapshot      Engine data snapshot containing ledger events.
+	 * @param array $base_snapshot Optional base snapshot.
+	 * @return array Replayed engine data snapshot without ledger metadata.
+	 */
+	public static function replaySnapshotLedger( array $snapshot, array $base_snapshot = array() ): array {
+		return self::replay( self::fromSnapshot( $snapshot ), $base_snapshot );
+	}
+
+	/**
+	 * Build a stable hash for a value.
+	 *
+	 * @param mixed $value Value to hash.
+	 * @return string sha256 hash prefixed for readability.
+	 */
+	public static function stableHash( $value ): string {
+		$normalized = self::sortRecursively( $value );
+		$json       = wp_json_encode( $normalized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PARTIAL_OUTPUT_ON_ERROR );
+
+		if ( ! is_string( $json ) ) {
+			$json = 'null';
+		}
+
+		return 'sha256:' . hash( 'sha256', $json );
+	}
+
+	/**
+	 * Remove ledger metadata from a snapshot before hashing or replay comparison.
+	 *
+	 * @param array $snapshot Engine data snapshot.
+	 * @return array Snapshot without ledger metadata.
+	 */
+	public static function snapshotForHashing( array $snapshot ): array {
+		unset( $snapshot[ self::SNAPSHOT_KEY ] );
+		return $snapshot;
+	}
+
+	/**
+	 * Resolve the next monotonically increasing ledger version.
+	 *
+	 * @param array $ledger Existing ledger entries.
+	 * @return int Next version number.
+	 */
+	private static function nextVersion( array $ledger ): int {
+		$version = 0;
+		foreach ( $ledger as $entry ) {
+			if ( is_array( $entry ) && isset( $entry['version'] ) ) {
+				$version = max( $version, (int) $entry['version'] );
+			}
+		}
+
+		return $version + 1;
+	}
+
+	/**
+	 * Resolve operation id from metadata or create a deterministic-shape fallback.
+	 *
+	 * @param array $metadata Event metadata.
+	 * @return string Operation id.
+	 */
+	private static function resolveOpId( array $metadata ): string {
+		$op_id = self::resolveStringMetadata( $metadata, 'op_id' );
+		return '' !== $op_id ? $op_id : wp_generate_uuid4();
+	}
+
+	/**
+	 * Resolve a string metadata field.
+	 *
+	 * @param array  $metadata Event metadata.
+	 * @param string $key      Metadata key.
+	 * @return string Metadata string or empty string.
+	 */
+	private static function resolveStringMetadata( array $metadata, string $key ): string {
+		$value = $metadata[ $key ] ?? '';
+		return is_scalar( $value ) ? (string) $value : '';
+	}
+
+	/**
+	 * Recursively sort associative array keys for deterministic hashing.
+	 *
+	 * @param mixed $value Value to sort.
+	 * @return mixed Sorted value.
+	 */
+	private static function sortRecursively( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$sorted = array();
+		foreach ( $value as $key => $item ) {
+			$sorted[ $key ] = self::sortRecursively( $item );
+		}
+
+		if ( array_keys( $sorted ) !== range( 0, count( $sorted ) - 1 ) ) {
+			ksort( $sorted );
+		}
+
+		return $sorted;
+	}
+}

--- a/inc/Engine/Filters/EngineData.php
+++ b/inc/Engine/Filters/EngineData.php
@@ -50,7 +50,7 @@ function datamachine_merge_engine_data( int $job_id, array $data ): bool {
 }
 
 /**
- * Append a compact engine state event trace and persist its patch as the current snapshot projection.
+ * Append a replayable engine state event and persist its patch as the current snapshot projection.
  *
  * @param int    $job_id   Job ID.
  * @param string $type     Generic event type.

--- a/tests/engine-state-ledger-smoke.php
+++ b/tests/engine-state-ledger-smoke.php
@@ -65,6 +65,13 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+		function wp_generate_uuid4(): string {
+			return '00000000-0000-4000-8000-000000000000';
+		}
+	}
+
+	require_once $root . '/inc/Core/EngineStateLedger.php';
 	require_once $root . '/inc/Core/EngineData.php';
 	require_once $root . '/inc/Engine/Filters/EngineData.php';
 
@@ -82,16 +89,28 @@ namespace {
 		array(
 			'tool_outputs' => array( 'first' => 'alpha' ),
 			'nested'       => array( 'after' => true ),
+		),
+		array(
+			'op_id'  => 'op-001',
+			'actor'  => 'test-runner',
+			'source' => 'engine-state-ledger-smoke',
 		)
 	);
 	$second = \datamachine_append_engine_state_event(
 		101,
 		'artifact_recorded',
-		array( 'artifact_files' => array( 'trace' => 'trace.json' ) )
+		array( 'artifact_files' => array( 'trace' => 'trace.json' ) ),
+		array(
+			'op_id'  => 'op-002',
+			'actor'  => 'test-runner',
+			'source' => 'artifact-writer',
+		)
 	);
 
-	$snapshot = \datamachine_get_engine_data( 101 );
-	$ledger   = $snapshot['_engine_state_ledger'] ?? array();
+	$snapshot        = \datamachine_get_engine_data( 101 );
+	$ledger          = \DataMachine\Core\EngineStateLedger::fromSnapshot( $snapshot );
+	$replayed        = \DataMachine\Core\EngineStateLedger::replaySnapshotLedger( $snapshot, array( 'existing' => 'snapshot-value', 'nested' => array( 'before' => true ) ) );
+	$replay_expected = \DataMachine\Core\EngineStateLedger::snapshotForHashing( $snapshot );
 
 	datamachine_engine_state_ledger_assert( 1 === ( $first['version'] ?? null ), 'first append starts at version 1', $failures, $passes );
 	datamachine_engine_state_ledger_assert( 2 === ( $second['version'] ?? null ), 'second append increments version monotonically', $failures, $passes );
@@ -99,9 +118,17 @@ namespace {
 	datamachine_engine_state_ledger_assert( 'snapshot-value' === ( $snapshot['existing'] ?? null ), 'snapshot compatibility preserves existing keys', $failures, $passes );
 	datamachine_engine_state_ledger_assert( 'alpha' === ( $snapshot['tool_outputs']['first'] ?? null ), 'snapshot projection includes appended patch data', $failures, $passes );
 	datamachine_engine_state_ledger_assert( true === ( $snapshot['nested']['before'] ?? null ) && true === ( $snapshot['nested']['after'] ?? null ), 'snapshot projection recursively merges patches', $failures, $passes );
+	datamachine_engine_state_ledger_assert( 1 === ( $ledger[0]['schema_version'] ?? null ), 'ledger records schema version', $failures, $passes );
+	datamachine_engine_state_ledger_assert( 'tool_result_recorded' === ( $ledger[0]['event_type'] ?? null ), 'ledger records event type alias', $failures, $passes );
+	datamachine_engine_state_ledger_assert( 'op-001' === ( $ledger[0]['op_id'] ?? null ), 'ledger records operation id', $failures, $passes );
+	datamachine_engine_state_ledger_assert( 'test-runner' === ( $ledger[0]['actor'] ?? null ), 'ledger records actor', $failures, $passes );
+	datamachine_engine_state_ledger_assert( 'engine-state-ledger-smoke' === ( $ledger[0]['source'] ?? null ), 'ledger records source', $failures, $passes );
+	datamachine_engine_state_ledger_assert( array( 'tool_outputs' => array( 'first' => 'alpha' ), 'nested' => array( 'after' => true ) ) === ( $ledger[0]['patch'] ?? null ), 'ledger stores replayable patch body', $failures, $passes );
 	datamachine_engine_state_ledger_assert( in_array( 'artifact_files', $ledger[1]['patch_keys'] ?? array(), true ), 'ledger records compact patch keys', $failures, $passes );
 	datamachine_engine_state_ledger_assert( is_string( $ledger[1]['patch_hash'] ?? null ) && 0 === strpos( $ledger[1]['patch_hash'], 'sha256:' ), 'ledger records deterministic patch hash', $failures, $passes );
-	datamachine_engine_state_ledger_assert( ! array_key_exists( 'patch', $ledger[1] ?? array() ), 'ledger omits full patch payload by default', $failures, $passes );
+	datamachine_engine_state_ledger_assert( is_string( $ledger[1]['pre_snapshot_hash'] ?? null ) && 0 === strpos( $ledger[1]['pre_snapshot_hash'], 'sha256:' ), 'ledger records pre snapshot hash', $failures, $passes );
+	datamachine_engine_state_ledger_assert( is_string( $ledger[1]['post_snapshot_hash'] ?? null ) && 0 === strpos( $ledger[1]['post_snapshot_hash'], 'sha256:' ), 'ledger records post snapshot hash', $failures, $passes );
+	datamachine_engine_state_ledger_assert( $replay_expected === $replayed, 'ledger events replay to snapshot projection', $failures, $passes );
 
 	if ( ! empty( $failures ) ) {
 		echo "\nFailures:\n";


### PR DESCRIPTION
## Summary
- Add a first-class EngineStateLedger primitive for append-only replayable engine state events.
- Persist event schema_version, op_id, actor/source, patch body, patch keys/hash, pre/post snapshot hashes, recorded_at, and event type.
- Delegate EngineData::appendStateEvent() to the ledger primitive and expose state ledger replay helpers while preserving snapshot projection behavior.
- Merge latest main CAS mutation behavior with the replayable ledger helper so concurrent writes remain protected.
- Expand ledger smoke coverage to prove patch bodies/hashes are recorded and events replay to the projected snapshot.

## Tests
- vendor/bin/phpcs inc/Core/EngineStateLedger.php
- vendor/bin/phpcs inc/Core/EngineData.php inc/Core/EngineStateLedger.php
- homeboy --force-hot --allow-local-hot lint data-machine --path /Users/chubes/Developer/data-machine@feat-replayable-engine-state-ledger --changed-since 89993160b87aefaece4057c61cd62ead73036de7
- homeboy --force-hot --allow-local-hot test data-machine --path /Users/chubes/Developer/data-machine@feat-replayable-engine-state-ledger --changed-since 89993160b87aefaece4057c61cd62ead73036de7
- homeboy --force-hot --allow-local-hot lint data-machine --path /Users/chubes/Developer/data-machine@feat-replayable-engine-state-ledger --changed-since origin/main
- homeboy --force-hot --allow-local-hot test data-machine --path /Users/chubes/Developer/data-machine@feat-replayable-engine-state-ledger --changed-since origin/main
- GitHub Homeboy CI: Audit, Lint, and Test passed on run 27762393340

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested replayable engine state ledger primitive; resolved merge conflict and lint failure.