### PR TITLE
Add CAS-backed engine data mutations

### DIFF
--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -1147,27 +1147,10 @@ class Jobs extends BaseRepository {
 			return false;
 		}
 
-		// Encode data as JSON for database storage.
-		$encoded     = wp_json_encode( $data );
-		$update_data = array( 'engine_data' => $encoded );
-		$format      = array( '%s' );
-
-		// Promote task_type to its own indexed column for fast lookups.
-		if ( isset( $data['task_type'] ) && is_string( $data['task_type'] ) ) {
-			$update_data['task_type'] = sanitize_key( $data['task_type'] );
-			$format[]                 = '%s';
-		}
-
-		// Promote the first handler_slug to its own column so handler
-		// summaries / filtering survive engine_data being shed from terminal
-		// jobs by retention (see RetentionCleanup::cleanupEngineData()).
-		// Extracted from the encoded blob so the column matches exactly what
-		// the legacy REGEXP_SUBSTR( engine_data, ... ) aggregation produced.
-		$handler_slug = self::extract_handler_slug( is_string( $encoded ) ? $encoded : '' );
-		if ( '' !== $handler_slug ) {
-			$update_data['handler_slug'] = $handler_slug;
-			$format[]                    = '%s';
-		}
+		$encoded          = wp_json_encode( $data );
+		$storage_envelope = $this->engine_data_storage_envelope( $data, is_string( $encoded ) ? $encoded : '' );
+		$update_data      = $storage_envelope['data'];
+		$format           = $storage_envelope['format'];
 
 		$result = $this->wpdb->update(
 			$this->table_name,
@@ -1206,6 +1189,81 @@ class Jobs extends BaseRepository {
 	}
 
 	/**
+	 * Store engine data only when the persisted snapshot still matches the caller's baseline.
+	 *
+	 * @param int   $job_id        Job ID.
+	 * @param array $expected_data Engine data snapshot read before mutation.
+	 * @param array $new_data      Engine data snapshot to persist.
+	 * @return array{updated:bool,conflict:bool,error:string|null}
+	 */
+	public function compare_and_swap_engine_data( int $job_id, array $expected_data, array $new_data ): array {
+		if ( $job_id <= 0 ) {
+			do_action( 'datamachine_log', 'error', 'Invalid job ID for engine_data compare-and-swap', array( 'job_id' => $job_id ) );
+			return array(
+				'updated'  => false,
+				'conflict' => false,
+				'error'    => 'invalid_job_id',
+			);
+		}
+
+		$expected_encoded = wp_json_encode( $expected_data );
+		$new_encoded      = wp_json_encode( $new_data );
+		if ( ! is_string( $expected_encoded ) || ! is_string( $new_encoded ) ) {
+			return array(
+				'updated'  => false,
+				'conflict' => false,
+				'error'    => 'json_encode_failed',
+			);
+		}
+
+		$storage_envelope = $this->engine_data_storage_envelope( $new_data, $new_encoded );
+		$result           = $this->wpdb->update(
+			$this->table_name,
+			$storage_envelope['data'],
+			array(
+				'job_id'      => $job_id,
+				'engine_data' => $expected_encoded,
+			),
+			$storage_envelope['format'],
+			array( '%d', '%s' )
+		);
+
+		if ( false === $result ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Failed to compare-and-swap engine_data',
+				array(
+					'job_id'   => $job_id,
+					'db_error' => $this->wpdb->last_error,
+				)
+			);
+
+			return array(
+				'updated'  => false,
+				'conflict' => false,
+				'error'    => 'db_error',
+			);
+		}
+
+		if ( 0 === (int) $result ) {
+			return array(
+				'updated'  => false,
+				'conflict' => true,
+				'error'    => null,
+			);
+		}
+
+		wp_cache_set( $job_id, $new_data, 'datamachine_engine_data' );
+
+		return array(
+			'updated'  => true,
+			'conflict' => false,
+			'error'    => null,
+		);
+	}
+
+	/**
 	 * Retrieve stored engine data for datamachine_engine_data filter access.
 	 */
 	public function retrieve_engine_data( int $job_id ): array {
@@ -1216,6 +1274,40 @@ class Jobs extends BaseRepository {
 		}
 
 		return array();
+	}
+
+	/**
+	 * Build column updates that mirror store_engine_data() promotion behavior.
+	 *
+	 * @param array  $data    Engine data snapshot.
+	 * @param string $encoded JSON-encoded engine_data.
+	 * @return array{data:array<string,mixed>,format:array<int,string>}
+	 */
+	private function engine_data_storage_envelope( array $data, string $encoded ): array {
+		$update_data = array( 'engine_data' => $encoded );
+		$format      = array( '%s' );
+
+		// Promote task_type to its own indexed column for fast lookups.
+		if ( isset( $data['task_type'] ) && is_string( $data['task_type'] ) ) {
+			$update_data['task_type'] = sanitize_key( $data['task_type'] );
+			$format[]                 = '%s';
+		}
+
+		// Promote the first handler_slug to its own column so handler
+		// summaries / filtering survive engine_data being shed from terminal
+		// jobs by retention (see RetentionCleanup::cleanupEngineData()).
+		// Extracted from the encoded blob so the column matches exactly what
+		// the legacy REGEXP_SUBSTR( engine_data, ... ) aggregation produced.
+		$handler_slug = self::extract_handler_slug( $encoded );
+		if ( '' !== $handler_slug ) {
+			$update_data['handler_slug'] = $handler_slug;
+			$format[]                    = '%s';
+		}
+
+		return array(
+			'data'   => $update_data,
+			'format' => $format,
+		);
 	}
 
 	/**

--- a/inc/Core/EngineData.php
+++ b/inc/Core/EngineData.php
@@ -114,10 +114,115 @@ class EngineData {
 			return false;
 		}
 
-		$current = self::retrieve( $job_id );
-		$merged  = array_replace_recursive( $current, $data );
+		$result = self::mutate(
+			$job_id,
+			static fn( array $current ): array => array_replace_recursive( $current, $data ),
+			'merge'
+		);
 
-		return self::persist( $job_id, $merged );
+		return ! empty( $result['success'] );
+	}
+
+	/**
+	 * Mutate engine data with compare-and-swap retries to preserve concurrent writes.
+	 *
+	 * @param int      $job_id       Job ID.
+	 * @param callable $callback     Receives the latest snapshot and returns the next snapshot, or null to abort.
+	 * @param string   $event_type   Mutation event type for diagnostics.
+	 * @param int      $max_attempts Maximum CAS attempts.
+	 * @return array{success:bool,conflict:bool,attempts:int,snapshot:array,error:string|null}
+	 */
+	public static function mutate( int $job_id, callable $callback, string $event_type = 'mutation', int $max_attempts = 3 ): array {
+		if ( $job_id <= 0 ) {
+			return array(
+				'success'  => false,
+				'conflict' => false,
+				'attempts' => 0,
+				'snapshot' => array(),
+				'error'    => 'invalid_job_id',
+			);
+		}
+
+		$db_jobs      = new Jobs();
+		$max_attempts = max( 1, $max_attempts );
+		$event_type   = sanitize_key( $event_type );
+
+		for ( $attempt = 1; $attempt <= $max_attempts; $attempt++ ) {
+			$current = $db_jobs->retrieve_engine_data( $job_id );
+			$current = is_array( $current ) ? $current : array();
+			$next    = $callback( $current );
+
+			if ( null === $next ) {
+				return array(
+					'success'  => false,
+					'conflict' => false,
+					'attempts' => $attempt,
+					'snapshot' => $current,
+					'error'    => 'mutation_aborted',
+				);
+			}
+
+			if ( ! is_array( $next ) ) {
+				return array(
+					'success'  => false,
+					'conflict' => false,
+					'attempts' => $attempt,
+					'snapshot' => $current,
+					'error'    => 'invalid_mutation_result',
+				);
+			}
+
+			if ( $next === $current ) {
+				return array(
+					'success'  => true,
+					'conflict' => false,
+					'attempts' => $attempt,
+					'snapshot' => $current,
+					'error'    => null,
+				);
+			}
+
+			$result = $db_jobs->compare_and_swap_engine_data( $job_id, $current, $next );
+			if ( ! empty( $result['updated'] ) ) {
+				wp_cache_set( $job_id, $next, 'datamachine_engine_data' );
+				return array(
+					'success'  => true,
+					'conflict' => false,
+					'attempts' => $attempt,
+					'snapshot' => $next,
+					'error'    => null,
+				);
+			}
+
+			if ( empty( $result['conflict'] ) ) {
+				return array(
+					'success'  => false,
+					'conflict' => false,
+					'attempts' => $attempt,
+					'snapshot' => $current,
+					'error'    => (string) ( $result['error'] ?? 'persist_failed' ),
+				);
+			}
+
+			do_action(
+				'datamachine_log',
+				'warning',
+				'EngineData mutation conflict, retrying latest snapshot',
+				array(
+					'job_id'     => $job_id,
+					'event_type' => $event_type,
+					'attempt'    => $attempt,
+				)
+			);
+		}
+
+		return array(
+			'success'  => false,
+			'conflict' => true,
+			'attempts' => $max_attempts,
+			'snapshot' => self::retrieve( $job_id ),
+			'error'    => 'conflict_exhausted',
+		);
 	}
 
 	/**
@@ -134,26 +239,33 @@ class EngineData {
 			return null;
 		}
 
-		$current = self::retrieve( $job_id );
-		$ledger  = is_array( $current['_engine_state_ledger'] ?? null ) ? $current['_engine_state_ledger'] : array();
-		$version = self::nextLedgerVersion( $ledger );
-		$entry   = array(
-			'version'     => $version,
-			'type'        => sanitize_key( $type ),
-			'recorded_at' => gmdate( 'c' ),
-			'patch_keys'  => array_keys( $patch ),
-			'patch_hash'  => self::stableHash( $patch ),
+		$entry  = null;
+		$result = self::mutate(
+			$job_id,
+			static function ( array $current ) use ( $type, $patch, $metadata, &$entry ): array {
+				$ledger = is_array( $current['_engine_state_ledger'] ?? null ) ? $current['_engine_state_ledger'] : array();
+				$entry  = array(
+					'version'     => self::nextLedgerVersion( $ledger ),
+					'type'        => sanitize_key( $type ),
+					'recorded_at' => gmdate( 'c' ),
+					'patch_keys'  => array_keys( $patch ),
+					'patch_hash'  => self::stableHash( $patch ),
+				);
+
+				if ( ! empty( $metadata ) ) {
+					$entry['metadata'] = $metadata;
+				}
+
+				$ledger[]                          = $entry;
+				$projected                         = array_replace_recursive( $current, $patch );
+				$projected['_engine_state_ledger'] = $ledger;
+
+				return $projected;
+			},
+			$type
 		);
 
-		if ( ! empty( $metadata ) ) {
-			$entry['metadata'] = $metadata;
-		}
-
-		$ledger[]                          = $entry;
-		$projected                         = array_replace_recursive( $current, $patch );
-		$projected['_engine_state_ledger'] = $ledger;
-
-		return self::persist( $job_id, $projected ) ? $entry : null;
+		return ! empty( $result['success'] ) ? $entry : null;
 	}
 
 	/**

--- a/inc/Engine/AI/RuntimeToolRunStateStore.php
+++ b/inc/Engine/AI/RuntimeToolRunStateStore.php
@@ -7,6 +7,7 @@
 
 namespace DataMachine\Engine\AI;
 
+use DataMachine\Core\EngineData;
 use DataMachine\Core\Database\Jobs\Jobs;
 
 defined( 'ABSPATH' ) || exit;
@@ -45,30 +46,38 @@ class RuntimeToolRunStateStore {
 	public function create( int $job_id, array $state ): array {
 		$this->assert_job_id( $job_id );
 
-		$engine_data = $this->engine_data( $job_id );
-		$existing    = $this->normalize_existing( $engine_data['runtime_tool_run_state'] ?? null );
-		if ( ! empty( $existing ) ) {
-			return $existing;
-		}
+		$run_state = array();
+		$this->mutate_engine_data(
+			$job_id,
+			function ( array $engine_data ) use ( $state, &$run_state ): array {
+				$existing = $this->normalize_existing( $engine_data['runtime_tool_run_state'] ?? null );
+				if ( ! empty( $existing ) ) {
+					$run_state = $existing;
+					return $engine_data;
+				}
 
-		$created_at = $this->timestamp();
-		$run_state  = array(
-			'parent_job_id'           => max( 0, (int) ( $state['parent_job_id'] ?? 0 ) ),
-			'runtime_tool_request_id' => $this->required_string( $state, 'runtime_tool_request_id' ),
-			'tool_name'               => $this->required_string( $state, 'tool_name' ),
-			'status'                  => self::STATUS_PENDING,
-			'timeout_seconds'         => max( 0, (int) ( $state['timeout_seconds'] ?? 0 ) ),
-			'deadline_at'             => (string) ( $state['deadline_at'] ?? '' ),
-			'resume_payload'          => null,
-			'finalize_payload'        => null,
-			'created_at'              => $created_at,
-			'updated_at'              => $created_at,
-			'finalized_at'            => null,
-			'resumed_at'              => null,
+				$created_at = $this->timestamp();
+				$run_state  = array(
+					'parent_job_id'           => max( 0, (int) ( $state['parent_job_id'] ?? 0 ) ),
+					'runtime_tool_request_id' => $this->required_string( $state, 'runtime_tool_request_id' ),
+					'tool_name'               => $this->required_string( $state, 'tool_name' ),
+					'status'                  => self::STATUS_PENDING,
+					'timeout_seconds'         => max( 0, (int) ( $state['timeout_seconds'] ?? 0 ) ),
+					'deadline_at'             => (string) ( $state['deadline_at'] ?? '' ),
+					'resume_payload'          => null,
+					'finalize_payload'        => null,
+					'created_at'              => $created_at,
+					'updated_at'              => $created_at,
+					'finalized_at'            => null,
+					'resumed_at'              => null,
+				);
+
+				$engine_data['runtime_tool_run_state'] = $run_state;
+
+				return $engine_data;
+			},
+			'runtime_tool_run_state_create'
 		);
-
-		$engine_data['runtime_tool_run_state'] = $run_state;
-		$this->jobs->store_engine_data( $job_id, $engine_data );
 
 		return $run_state;
 	}
@@ -148,26 +157,71 @@ class RuntimeToolRunStateStore {
 	private function transition_once( int $job_id, string $timestamp_key, string $payload_key, array $payload, string $status ): ?array {
 		$this->assert_job_id( $job_id );
 
-		$engine_data = $this->engine_data( $job_id );
-		$state       = $this->normalize_existing( $engine_data['runtime_tool_run_state'] ?? null );
-		if ( empty( $state ) ) {
-			return null;
-		}
+		$state = null;
+		$this->mutate_engine_data(
+			$job_id,
+			function ( array $engine_data ) use ( $timestamp_key, $payload_key, $payload, $status, &$state ): array {
+				$state = $this->normalize_existing( $engine_data['runtime_tool_run_state'] ?? null );
+				if ( empty( $state ) || ! empty( $state[ $timestamp_key ] ) ) {
+					return $engine_data;
+				}
 
-		if ( ! empty( $state[ $timestamp_key ] ) ) {
-			return $state;
-		}
+				$timestamp                             = $this->timestamp();
+				$state['status']                       = $status;
+				$state[ $payload_key ]                 = $payload;
+				$state[ $timestamp_key ]               = $timestamp;
+				$state['updated_at']                   = $timestamp;
+				$engine_data['runtime_tool_run_state'] = $state;
 
-		$timestamp                             = $this->timestamp();
-		$state['status']                       = $status;
-		$state[ $payload_key ]                 = $payload;
-		$state[ $timestamp_key ]               = $timestamp;
-		$state['updated_at']                   = $timestamp;
-		$engine_data['runtime_tool_run_state'] = $state;
-
-		$this->jobs->store_engine_data( $job_id, $engine_data );
+				return $engine_data;
+			},
+			'runtime_tool_run_state_transition'
+		);
 
 		return $state;
+	}
+
+	/**
+	 * @param int      $job_id Request job ID.
+	 * @param callable $callback Receives current engine data and returns next engine data.
+	 * @param string   $event_type Mutation event type.
+	 * @return bool
+	 */
+	private function mutate_engine_data( int $job_id, callable $callback, string $event_type ): bool {
+		if ( $this->jobs instanceof Jobs ) {
+			$result = EngineData::mutate( $job_id, $callback, $event_type );
+
+			return ! empty( $result['success'] );
+		}
+
+		for ( $attempt = 1; $attempt <= 3; $attempt++ ) {
+			$current = $this->engine_data( $job_id );
+			$next    = $callback( $current );
+			if ( ! is_array( $next ) ) {
+				return false;
+			}
+
+			if ( $next === $current ) {
+				return true;
+			}
+
+			if ( method_exists( $this->jobs, 'compare_and_swap_engine_data' ) ) {
+				$result = $this->jobs->compare_and_swap_engine_data( $job_id, $current, $next );
+				if ( ! empty( $result['updated'] ) ) {
+					return true;
+				}
+
+				if ( empty( $result['conflict'] ) ) {
+					return false;
+				}
+
+				continue;
+			}
+
+			return (bool) $this->jobs->store_engine_data( $job_id, $next );
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/Unit/Engine/AI/RuntimeToolRunStateStoreTest.php
+++ b/tests/Unit/Engine/AI/RuntimeToolRunStateStoreTest.php
@@ -78,6 +78,50 @@ class RuntimeToolRunStateStoreTest extends TestCase {
 		$this->assertSame( RuntimeToolRunStateStore::STATUS_RESUMED, $second['status'] );
 	}
 
+	public function test_finalize_retries_conflicting_engine_data_write(): void {
+		$jobs  = new RuntimeToolRunStateJobsDouble();
+		$store = new RuntimeToolRunStateStore( $jobs );
+
+		$store->create(
+			42,
+			array(
+				'runtime_tool_request_id' => 'runtime_tool_42',
+				'tool_name'               => 'client.inspect',
+			)
+		);
+
+		$jobs->conflict_once_with = array( 'concurrent_metric' => array( 'count' => 1 ) );
+		$jobs->cas_attempts      = 0;
+
+		$state = $store->finalize( 42, array( 'result' => array( 'value' => 'final' ) ) );
+
+		$this->assertSame( RuntimeToolRunStateStore::STATUS_FINALIZED, $state['status'] );
+		$this->assertSame( 'final', $state['finalize_payload']['result']['value'] );
+		$this->assertSame( 1, $jobs->data[42]['concurrent_metric']['count'] );
+		$this->assertSame( 2, $jobs->cas_attempts );
+	}
+
+	public function test_create_retries_conflicting_engine_data_write(): void {
+		$jobs                         = new RuntimeToolRunStateJobsDouble();
+		$jobs->data[42]               = array( 'existing_key' => 'before' );
+		$jobs->conflict_once_with     = array( 'concurrent_metric' => array( 'count' => 1 ) );
+		$store                        = new RuntimeToolRunStateStore( $jobs );
+
+		$state = $store->create(
+			42,
+			array(
+				'runtime_tool_request_id' => 'runtime_tool_42',
+				'tool_name'               => 'client.inspect',
+			)
+		);
+
+		$this->assertSame( RuntimeToolRunStateStore::STATUS_PENDING, $state['status'] );
+		$this->assertSame( 'before', $jobs->data[42]['existing_key'] );
+		$this->assertSame( 1, $jobs->data[42]['concurrent_metric']['count'] );
+		$this->assertArrayHasKey( 'runtime_tool_run_state', $jobs->data[42] );
+		$this->assertSame( 2, $jobs->cas_attempts );
+	}
+
 	public function test_create_from_request_maps_timeout_and_deadline_fields(): void {
 		$jobs  = new RuntimeToolRunStateJobsDouble();
 		$store = new RuntimeToolRunStateStore( $jobs );
@@ -108,6 +152,11 @@ class RuntimeToolRunStateJobsDouble {
 	/** @var array<int,array<string,mixed>> */
 	public array $data = array();
 
+	/** @var array<string,mixed>|null */
+	public ?array $conflict_once_with = null;
+
+	public int $cas_attempts = 0;
+
 	/**
 	 * @param int $job_id Job ID.
 	 * @return array<string,mixed>
@@ -124,5 +173,43 @@ class RuntimeToolRunStateJobsDouble {
 		$this->data[ $job_id ] = $data;
 
 		return true;
+	}
+
+	/**
+	 * @param int                 $job_id        Job ID.
+	 * @param array<string,mixed> $expected_data Expected engine data.
+	 * @param array<string,mixed> $new_data      New engine data.
+	 * @return array{updated:bool,conflict:bool,error:string|null}
+	 */
+	public function compare_and_swap_engine_data( int $job_id, array $expected_data, array $new_data ): array {
+		$this->cas_attempts++;
+		$current = $this->data[ $job_id ] ?? array();
+
+		if ( null !== $this->conflict_once_with ) {
+			$this->data[ $job_id ]      = array_replace_recursive( $current, $this->conflict_once_with );
+			$this->conflict_once_with = null;
+
+			return array(
+				'updated'  => false,
+				'conflict' => true,
+				'error'    => null,
+			);
+		}
+
+		if ( $current !== $expected_data ) {
+			return array(
+				'updated'  => false,
+				'conflict' => true,
+				'error'    => null,
+			);
+		}
+
+		$this->data[ $job_id ] = $new_data;
+
+		return array(
+			'updated'  => true,
+			'conflict' => false,
+			'error'    => null,
+		);
 	}
 }


### PR DESCRIPTION
## Summary
- Add a Jobs compare-and-swap helper for engine_data snapshots.
- Add EngineData::mutate() with retry-on-conflict and route EngineData::merge()/state ledger writes through it.
- Use CAS-backed mutation for RuntimeToolRunStateStore create/finalize/resume writes.
- Add unit coverage that simulates conflicting engine_data writes and verifies deterministic runtime-tool state survives alongside concurrent data.

## Testing
- php -l inc/Core/Database/Jobs/Jobs.php && php -l inc/Core/EngineData.php && php -l inc/Engine/AI/RuntimeToolRunStateStore.php && php -l tests/Unit/Engine/AI/RuntimeToolRunStateStoreTest.php
- homeboy --force-hot --allow-local-hot lint data-machine --changed-only
- homeboy --force-hot --allow-local-hot test data-machine --skip-lint --changed-since origin/main (968 tests: 964 passed, 4 skipped)

## Caveats
- Full `composer test` / `homeboy test data-machine` initially failed before test execution because the local Homeboy `wordpress` extension metadata has no source URL. The PR-scoped Homeboy test path ran successfully after using the local resource-policy override.
- Full `homeboy lint data-machine` reports existing baseline-wide findings outside this change; changed-only lint passes with no baseline drift.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested CAS-backed engine data mutations.