### PR TITLE
fix: stop chat migration phpcs:disable block from unmasking ignored queries

### DIFF
--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -180,15 +180,15 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			// intersected against the live table columns (see
 			// intersect_migration_columns), never from user input — so interpolating
 			// it into the column list is safe. Table names use %i placeholders.
-			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$result = $wpdb->query(
-				$wpdb->prepare(
-					"INSERT IGNORE INTO %i ({$column_list}) SELECT {$column_list} FROM %i",
-					$network_table,
-					$site_table
-				)
+			$migration_sql = $wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"INSERT IGNORE INTO %i ({$column_list}) SELECT {$column_list} FROM %i",
+				$network_table,
+				$site_table
 			);
-			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+			$result = $wpdb->query( $migration_sql );
 
 			$rows    = false !== $result ? (int) $result : 0;
 			$copied += $rows;


### PR DESCRIPTION
## Summary

Follow-up to #2731 (already merged). That PR landed with a `phpcs:disable/enable WordPress.DB.PreparedSQL.NotPrepared` block around the network chat-session migration `INSERT…SELECT`. The `phpcs:enable` re-armed that sniff for the **rest of `Chat.php`**, which unmasked four pre-existing `phpcs:ignore`'d `$wpdb->prepare` queries (`table_exists`, `list_sessions`, `get_recent_pending_session`, `get_user_session_count`) and left `homeboy / Lint` red on `main`.

The Lint fix was authored on the #2731 branch but landed **after** that PR was squash-merged, so it never reached `main` — hence this small follow-up.

## Change
- Replace the `phpcs:disable/enable` block with the file's established **single-line `phpcs:ignore`** convention:
  - one `phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared` for the interpolated column list inside `prepare()` (the list is a fixed allowlist intersected against live table columns via `intersect_migration_columns()` — never user input),
  - one `phpcs:ignore` for the direct `$wpdb->query()`.
- No directive now changes file-wide sniff state, so the four downstream `phpcs:ignore`'d queries stay suppressed as before.

Migration behavior is byte-for-byte unchanged (same prepared SQL, same args).

## Verification
- `php -l` clean.
- `tests/migration-runtime-smoke.php` → 16/16 pass.
- (Local phpcs standards registration is broken in this environment — `phpcs -i` returns empty — so final lint confirmation is delegated to CI, which is the authority that reported the original 4 errors.)