### PR TITLE
Persist step result envelopes with CAS metrics

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -272,7 +272,7 @@ class ExecuteStepAbility {
 					'status'       => $recorded_status,
 					'reason'       => $result['reason'] ?? ( $execution_result['reason'] ?? ( $result['error'] ?? null ) ),
 					'error'        => $result['error'] ?? ( $execution_result['error'] ?? null ),
-					'step_result'  => $execution_result['step_result'] ?? array(),
+					'step_result'  => is_array( $execution_result['step_result'] ?? null ) ? $execution_result['step_result'] : array(),
 				)
 			);
 

--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -59,51 +59,58 @@ class RunMetrics {
 			return false;
 		}
 
-		$engine       = EngineData::retrieve( $job_id );
-		$step_results = is_array( $engine[ self::STEP_RESULTS_KEY ] ?? null ) ? $engine[ self::STEP_RESULTS_KEY ] : array();
-		$existing     = is_array( $step_results[ $flow_step_id ] ?? null ) ? $step_results[ $flow_step_id ] : array();
 		$clean_result = self::sanitizeResult( $result );
+		$result       = EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $flow_step_id, $clean_result ): array {
+				$step_results = is_array( $engine[ self::STEP_RESULTS_KEY ] ?? null ) ? $engine[ self::STEP_RESULTS_KEY ] : array();
+				$existing     = is_array( $step_results[ $flow_step_id ] ?? null ) ? $step_results[ $flow_step_id ] : array();
 
-		$step_results[ $flow_step_id ] = array_replace_recursive(
-			$existing,
-			array_merge(
-				array(
-					'flow_step_id' => $flow_step_id,
-					'recorded_at'  => self::now(),
-				),
-				$clean_result
-			)
+				$step_results[ $flow_step_id ] = array_replace_recursive(
+					$existing,
+					array_merge(
+						array(
+							'flow_step_id' => $flow_step_id,
+							'recorded_at'  => self::now(),
+						),
+						$clean_result
+					)
+				);
+
+				$engine[ self::STEP_RESULTS_KEY ] = $step_results;
+				if ( is_array( $clean_result['step_result'] ?? null ) ) {
+					$step_result_envelopes                     = is_array( $engine[ self::STEP_RESULT_ENVELOPES_KEY ] ?? null ) ? $engine[ self::STEP_RESULT_ENVELOPES_KEY ] : array();
+					$step_result_envelope                      = $clean_result['step_result'];
+					$step_result_envelope['flow_step_id']    ??= $flow_step_id;
+					$step_result_envelopes[ $flow_step_id ]    = $step_result_envelope;
+					$engine[ self::STEP_RESULT_ENVELOPES_KEY ] = $step_result_envelopes;
+				}
+
+				$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
+				if ( isset( $clean_result['packet_count'] ) && 'fetch' === ( $clean_result['step_type'] ?? '' ) ) {
+					$metrics['counts']['fetch_packets'] = max( (int) $metrics['counts']['fetch_packets'], (int) $clean_result['packet_count'] );
+				}
+				if ( in_array( $clean_result['result'] ?? '', array( 'no_content', 'completed_no_items' ), true ) ) {
+					$metrics['counts']['no_content'] = max( 1, (int) $metrics['counts']['no_content'] );
+				}
+				if ( 'source_rejected' === ( $clean_result['result'] ?? '' ) || ! empty( $clean_result['source_rejection_reason'] ) ) {
+					$metrics['counts']['source_rejected'] = max( 1, (int) $metrics['counts']['source_rejected'] );
+				}
+				foreach ( self::classesFromStepResult( $clean_result, (string) ( $clean_result['status'] ?? '' ) ) as $class ) {
+					if ( ! isset( $metrics['counts'][ $class ] ) ) {
+						$metrics['counts'][ $class ] = 0;
+					}
+					$metrics['counts'][ $class ] = max( 1, (int) $metrics['counts'][ $class ] );
+				}
+				$metrics['last_activity_at'] = self::now();
+				$engine[ self::KEY ]         = $metrics;
+
+				return $engine;
+			},
+			'record_step_result'
 		);
 
-		$engine[ self::STEP_RESULTS_KEY ] = $step_results;
-		if ( is_array( $clean_result['step_result'] ?? null ) ) {
-			$step_result_envelopes                     = is_array( $engine[ self::STEP_RESULT_ENVELOPES_KEY ] ?? null ) ? $engine[ self::STEP_RESULT_ENVELOPES_KEY ] : array();
-			$step_result_envelope                      = $clean_result['step_result'];
-			$step_result_envelope['flow_step_id']    ??= $flow_step_id;
-			$step_result_envelopes[ $flow_step_id ]    = $step_result_envelope;
-			$engine[ self::STEP_RESULT_ENVELOPES_KEY ] = $step_result_envelopes;
-		}
-
-		$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
-		if ( isset( $clean_result['packet_count'] ) && 'fetch' === ( $clean_result['step_type'] ?? '' ) ) {
-			$metrics['counts']['fetch_packets'] = max( (int) $metrics['counts']['fetch_packets'], (int) $clean_result['packet_count'] );
-		}
-		if ( in_array( $clean_result['result'] ?? '', array( 'no_content', 'completed_no_items' ), true ) ) {
-			$metrics['counts']['no_content'] = max( 1, (int) $metrics['counts']['no_content'] );
-		}
-		if ( 'source_rejected' === ( $clean_result['result'] ?? '' ) || ! empty( $clean_result['source_rejection_reason'] ) ) {
-			$metrics['counts']['source_rejected'] = max( 1, (int) $metrics['counts']['source_rejected'] );
-		}
-		foreach ( self::classesFromStepResult( $clean_result, (string) ( $clean_result['status'] ?? '' ) ) as $class ) {
-			if ( ! isset( $metrics['counts'][ $class ] ) ) {
-				$metrics['counts'][ $class ] = 0;
-			}
-			$metrics['counts'][ $class ] = max( 1, (int) $metrics['counts'][ $class ] );
-		}
-		$metrics['last_activity_at'] = self::now();
-		$engine[ self::KEY ]         = $metrics;
-
-		return EngineData::persist( $job_id, $engine );
+		return ! empty( $result['success'] );
 	}
 
 	public static function start( int $job_id, array $context = array() ): bool {
@@ -217,6 +224,7 @@ class RunMetrics {
 			'duration_seconds' => self::durationSeconds( $started_at, $duration_end ),
 			'outcome'          => self::outcomeDetails( $job, $engine, $counts, $outcome_classes ),
 			'step_results'     => self::stepResults( $engine ),
+			'run_result'       => self::runResult( $engine, $status ),
 			'context'          => $metrics['context'],
 			'token_usage'      => self::tokenUsage( $engine ),
 			'cost'             => self::cost( $engine ),
@@ -466,6 +474,22 @@ class RunMetrics {
 	private static function stepResults( array $engine ): array {
 		$step_results = is_array( $engine[ self::STEP_RESULTS_KEY ] ?? null ) ? $engine[ self::STEP_RESULTS_KEY ] : array();
 		return array_values( array_filter( $step_results, 'is_array' ) );
+	}
+
+	private static function runResult( array $engine, string $status ): array {
+		$step_results = array();
+		foreach ( self::stepResults( $engine ) as $result ) {
+			if ( is_array( $result['step_result'] ?? null ) ) {
+				$step_results[] = $result['step_result'];
+			}
+		}
+
+		return RunResult::fromStepResults(
+			$step_results,
+			array(
+				'status' => $status,
+			)
+		);
 	}
 
 	private static function firstStepField( array $engine, string $field ) {

--- a/tests/run-metrics-smoke.php
+++ b/tests/run-metrics-smoke.php
@@ -11,7 +11,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $flags = 0, $depth = 512 ) {
+		return json_encode( $data, $flags, $depth );
+	}
+}
+
 require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/RunResult.php';
 require_once __DIR__ . '/../inc/Core/RunMetrics.php';
 
 use DataMachine\Core\RunMetrics;

--- a/tests/run-metrics-smoke.php
+++ b/tests/run-metrics-smoke.php
@@ -18,6 +18,8 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 }
 
 require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/JobArtifactSurfaces.php';
+require_once __DIR__ . '/../inc/Core/StepResult.php';
 require_once __DIR__ . '/../inc/Core/RunResult.php';
 require_once __DIR__ . '/../inc/Core/RunMetrics.php';
 

--- a/tests/step-result-persistence-cas-smoke.php
+++ b/tests/step-result-persistence-cas-smoke.php
@@ -104,6 +104,8 @@ namespace {
 	}
 
 	require_once __DIR__ . '/../inc/Core/JobStatus.php';
+	require_once __DIR__ . '/../inc/Core/JobArtifactSurfaces.php';
+	require_once __DIR__ . '/../inc/Core/StepResult.php';
 	require_once __DIR__ . '/../inc/Core/RunResult.php';
 	require_once __DIR__ . '/../inc/Core/EngineData.php';
 	require_once __DIR__ . '/../inc/Core/RunMetrics.php';
@@ -198,7 +200,7 @@ namespace {
 	);
 
 	datamachine_step_result_persistence_assert( RunResult::SCHEMA_VERSION === ( $metrics['run_result']['schema_version'] ?? null ), 'RunMetrics exposes canonical RunResult summary' );
-	datamachine_step_result_persistence_assert( 'datamachine.step_result.v1' === ( $metrics['run_result']['steps'][0]['schema_version'] ?? null ), 'RunResult summary includes persisted StepResult envelope' );
+	datamachine_step_result_persistence_assert( 'datamachine.step_result.v1' === ( $metrics['run_result']['step_results'][0]['schema_version'] ?? null ), 'RunResult summary includes persisted StepResult envelope' );
 
 	echo "\n=== step-result-persistence-cas-smoke: ALL PASS ===\n";
 }

--- a/tests/step-result-persistence-cas-smoke.php
+++ b/tests/step-result-persistence-cas-smoke.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Pure-PHP smoke test for canonical step result persistence and CAS retry.
+ *
+ * Run with: php tests/step-result-persistence-cas-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core\Database\Jobs {
+
+	class Jobs {
+
+		public static array $snapshots = array();
+
+		public static bool $inject_conflict = false;
+
+		public static int $compare_and_swap_calls = 0;
+
+		public function retrieve_engine_data( int $job_id ): array {
+			return self::$snapshots[ $job_id ] ?? array();
+		}
+
+		public function store_engine_data( int $job_id, array $snapshot ): bool {
+			self::$snapshots[ $job_id ] = $snapshot;
+			return true;
+		}
+
+		public function compare_and_swap_engine_data( int $job_id, array $expected_data, array $new_data ): array {
+			self::$compare_and_swap_calls++;
+
+			if ( self::$inject_conflict ) {
+				self::$inject_conflict             = false;
+				$current                          = self::$snapshots[ $job_id ] ?? array();
+				$current['concurrent_writer_kept'] = true;
+				self::$snapshots[ $job_id ]        = $current;
+
+				return array(
+					'updated'  => false,
+					'conflict' => true,
+					'error'    => null,
+				);
+			}
+
+			if ( ( self::$snapshots[ $job_id ] ?? array() ) !== $expected_data ) {
+				return array(
+					'updated'  => false,
+					'conflict' => true,
+					'error'    => null,
+				);
+			}
+
+			self::$snapshots[ $job_id ] = $new_data;
+
+			return array(
+				'updated'  => true,
+				'conflict' => false,
+				'error'    => null,
+			);
+		}
+	}
+}
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( $key ) {
+			return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+		}
+	}
+
+	if ( ! function_exists( 'current_time' ) ) {
+		function current_time( $type, $gmt = false ) {
+			return '2026-06-18 14:30:00';
+		}
+	}
+
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $data, $flags = 0, $depth = 512 ) {
+			return json_encode( $data, $flags, $depth );
+		}
+	}
+
+	if ( ! function_exists( 'wp_cache_get' ) ) {
+		function wp_cache_get( $key, $group = '' ) {
+			return false;
+		}
+	}
+
+	if ( ! function_exists( 'wp_cache_set' ) ) {
+		function wp_cache_set( $key, $data, $group = '', $expire = 0 ) {
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( $hook_name, ...$arg ) {
+			return null;
+		}
+	}
+
+	require_once __DIR__ . '/../inc/Core/JobStatus.php';
+	require_once __DIR__ . '/../inc/Core/RunResult.php';
+	require_once __DIR__ . '/../inc/Core/EngineData.php';
+	require_once __DIR__ . '/../inc/Core/RunMetrics.php';
+
+	use DataMachine\Core\Database\Jobs\Jobs;
+	use DataMachine\Core\RunMetrics;
+	use DataMachine\Core\RunResult;
+
+	function datamachine_step_result_persistence_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	echo "=== step-result-persistence-cas-smoke ===\n";
+
+	$job_id                   = 991;
+	Jobs::$snapshots[ $job_id ] = array(
+		'existing' => array(
+			'value' => 'preserved',
+		),
+	);
+	Jobs::$inject_conflict      = true;
+
+	$step_result = array(
+		'schema_version' => 'datamachine.step_result.v1',
+		'status'         => 'succeeded',
+		'outputs'        => array(
+			'packet_count' => 2,
+			'nested'       => array(
+				'value' => 'kept',
+			),
+		),
+		'artifact_refs'  => array(
+			array(
+				'id'   => 'artifact-1',
+				'hash' => 'sha256:abc',
+			),
+		),
+		'packet_refs'    => array(
+			array(
+				'index'        => 0,
+				'content_hash' => 'sha256:def',
+			),
+		),
+		'diagnostics'    => array(
+			'reason' => 'completed',
+		),
+		'replay'         => array(
+			'content_hashes' => array(
+				'outputs' => 'sha256:123',
+			),
+		),
+	);
+
+	$recorded = RunMetrics::recordStepResult(
+		$job_id,
+		'fetch_sources',
+		array(
+			'step_type'    => 'fetch',
+			'result'       => 'completed',
+			'step_success' => true,
+			'packet_count' => 2,
+			'status'       => 'completed',
+			'reason'       => 'completed',
+			'step_result'  => $step_result,
+		)
+	);
+
+	$snapshot = Jobs::$snapshots[ $job_id ];
+
+	datamachine_step_result_persistence_assert( $recorded, 'recordStepResult reports success after retry' );
+	datamachine_step_result_persistence_assert( 2 === Jobs::$compare_and_swap_calls, 'CAS conflict is retried against the latest snapshot' );
+	datamachine_step_result_persistence_assert( true === ( $snapshot['concurrent_writer_kept'] ?? false ), 'concurrent engine_data write is preserved' );
+	datamachine_step_result_persistence_assert( 'preserved' === ( $snapshot['existing']['value'] ?? null ), 'pre-existing engine_data remains intact' );
+	datamachine_step_result_persistence_assert( 'datamachine.step_result.v1' === ( $snapshot['step_results']['fetch_sources']['step_result']['schema_version'] ?? null ), 'canonical StepResult envelope is persisted' );
+	datamachine_step_result_persistence_assert( 'kept' === ( $snapshot['step_results']['fetch_sources']['step_result']['outputs']['nested']['value'] ?? null ), 'nested envelope data survives sanitization' );
+	datamachine_step_result_persistence_assert( 2 === ( $snapshot['run_metrics']['counts']['fetch_packets'] ?? 0 ), 'fetch packet count is recorded in run metrics' );
+
+	$metrics = RunMetrics::fromJob(
+		array(
+			'job_id'      => $job_id,
+			'source'      => 'pipeline',
+			'status'      => 'completed',
+			'created_at'  => '2026-06-18 14:00:00',
+			'engine_data' => $snapshot,
+		)
+	);
+
+	datamachine_step_result_persistence_assert( RunResult::SCHEMA_VERSION === ( $metrics['run_result']['schema_version'] ?? null ), 'RunMetrics exposes canonical RunResult summary' );
+	datamachine_step_result_persistence_assert( 'datamachine.step_result.v1' === ( $metrics['run_result']['steps'][0]['schema_version'] ?? null ), 'RunResult summary includes persisted StepResult envelope' );
+
+	echo "\n=== step-result-persistence-cas-smoke: ALL PASS ===\n";
+}


### PR DESCRIPTION
## Summary
- Persist canonical StepResult envelopes from ExecuteStepAbility into step_results engine data.
- Update RunMetrics::recordStepResult() to use EngineData::mutate() so concurrent engine_data writes are preserved by CAS retries.
- Expose a canonical RunResult summary from persisted step result envelopes in RunMetrics::fromJob().
- Add a focused pure-PHP smoke for canonical envelope persistence and CAS conflict retry behavior.

## Verification
- php tests/run-metrics-smoke.php
- php tests/step-result-persistence-cas-smoke.php
- php -l inc/Core/RunMetrics.php
- php -l inc/Abilities/Engine/ExecuteStepAbility.php
- php -l tests/step-result-persistence-cas-smoke.php
- git diff --check
- composer lint -- --standard=phpcs.xml.dist inc/Core/RunMetrics.php inc/Abilities/Engine/ExecuteStepAbility.php tests/step-result-persistence-cas-smoke.php tests/run-metrics-smoke.php

## Blockers
- composer test did not reach the test suite because the Homeboy lab runner rejected the installed wordpress extension metadata: Extension 'wordpress' has no sourceUrl or .source-url metadata.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the CAS-safe RunMetrics persistence change, canonical StepResult/RunResult wiring, and focused smoke coverage; Chris remains responsible for review and merge.