### PR TITLE
Harden batch cancellation lifecycle and chunk fanout

### DIFF
--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -119,9 +119,10 @@ class PipelineBatchScheduler {
 	 * Action Scheduler callback — delegates to BatchScheduler::processChunk
 	 * with a pipeline-specific child-creation callback.
 	 *
-	 * @param int $parent_job_id The parent job ID.
+	 * @param int      $parent_job_id  The parent job ID.
+	 * @param int|null $expected_offset Offset key carried by the scheduler action.
 	 */
-	public function processChunk( int $parent_job_id ): void {
+	public function processChunk( int $parent_job_id, ?int $expected_offset = null ): void {
 		$parent_job = $this->db_jobs->get_job( $parent_job_id );
 		if ( ! $parent_job || JobStatus::PROCESSING !== ( $parent_job['status'] ?? '' ) ) {
 			do_action(
@@ -138,8 +139,13 @@ class PipelineBatchScheduler {
 
 		$result = BatchScheduler::processChunk(
 			$parent_job_id,
-			array( $this, 'createChildJobFromBatch' )
+			array( $this, 'createChildJobFromBatch' ),
+			$expected_offset
 		);
+
+		if ( ! empty( $result['duplicate'] ) ) {
+			return;
+		}
 
 		if ( $result['missing'] ) {
 			$this->failParentIfStillProcessing( $parent_job_id, 'batch_state_missing' );
@@ -155,7 +161,7 @@ class PipelineBatchScheduler {
 		if ( $result['cancelled'] ) {
 			$this->db_jobs->complete_job(
 				$parent_job_id,
-				JobStatus::failed( 'batch cancelled' )->toString()
+				JobStatus::CANCELLED
 			);
 			return;
 		}

--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -308,9 +308,9 @@ class BatchScheduler {
 						return null;
 					}
 
-					$current_state['claims']      = $claims;
+					$current_state['claims']                              = $claims;
 					$current_state['claims'][ (string) $expected_offset ] = current_time( 'mysql' );
-					$current['batch_state']       = $current_state;
+					$current['batch_state']                               = $current_state;
 
 					return $current;
 				},

--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -36,6 +36,7 @@ namespace DataMachine\Core\ActionScheduler;
 
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\DataPacketStore;
+use DataMachine\Core\EngineData;
 use DataMachine\Core\PluginSettings;
 
 defined( 'ABSPATH' ) || exit;
@@ -190,7 +191,10 @@ class BatchScheduler {
 		as_schedule_single_action(
 			time(),
 			$hook,
-			array( 'parent_job_id' => $parent_job_id ),
+			array(
+				'parent_job_id' => $parent_job_id,
+				'offset'        => 0,
+			),
 			'data-machine'
 		);
 
@@ -215,22 +219,39 @@ class BatchScheduler {
 	 * that as a fatal protocol error and complete the parent as failed).
 	 *
 	 * @param int      $parent_job_id Parent job ID.
-	 * @param callable $createItem    fn(array $item, array $extra, int $parent_job_id): mixed
+	 * @param callable $createItem      fn(array $item, array $extra, int $parent_job_id): mixed
+	 * @param int|null $expected_offset Offset key carried by the scheduler action.
 	 * @return array{
 	 *     scheduled:int,
 	 *     offset:int,
 	 *     total:int,
 	 *     more:bool,
 	 *     cancelled:bool,
-	 *     missing:bool
+	 *     missing:bool,
+	 *     duplicate:bool
 	 * } Chunk result. `missing` is true only when the batch_state key
 	 *   has been lost; consumer must fail the parent in that case.
 	 */
-	public static function processChunk( int $parent_job_id, callable $createItem ): array {
+	public static function processChunk( int $parent_job_id, callable $createItem, ?int $expected_offset = null ): array {
 		$parent_engine = datamachine_get_engine_data( $parent_job_id );
 		$batch_state   = $parent_engine['batch_state'] ?? null;
 
 		if ( ! is_array( $batch_state ) ) {
+			if ( null !== $expected_offset && ! empty( $parent_engine['batch'] ) ) {
+				$total  = (int) ( $parent_engine['batch_total'] ?? 0 );
+				$offset = (int) ( $parent_engine['batch_offset'] ?? $total );
+
+				return array(
+					'scheduled' => 0,
+					'offset'    => $offset,
+					'total'     => $total,
+					'more'      => false,
+					'cancelled' => ! empty( $parent_engine['cancelled'] ),
+					'missing'   => false,
+					'duplicate' => true,
+				);
+			}
+
 			return array(
 				'scheduled' => 0,
 				'offset'    => 0,
@@ -238,6 +259,7 @@ class BatchScheduler {
 				'more'      => false,
 				'cancelled' => false,
 				'missing'   => true,
+				'duplicate' => false,
 			);
 		}
 
@@ -254,7 +276,64 @@ class BatchScheduler {
 				'more'      => false,
 				'cancelled' => true,
 				'missing'   => false,
+				'duplicate' => false,
 			);
+		}
+
+		if ( null !== $expected_offset ) {
+			$claim_error = null;
+			$claim       = EngineData::mutate(
+				$parent_job_id,
+				static function ( array $current ) use ( $expected_offset, &$claim_error ): ?array {
+					$current_state = $current['batch_state'] ?? null;
+					if ( ! is_array( $current_state ) ) {
+						$claim_error = 'missing';
+						return null;
+					}
+
+					if ( ! empty( $current['cancelled'] ) ) {
+						$claim_error = 'cancelled';
+						return null;
+					}
+
+					$current_offset = (int) ( $current_state['offset'] ?? 0 );
+					if ( $current_offset !== $expected_offset ) {
+						$claim_error = 'stale_offset';
+						return null;
+					}
+
+					$claims = is_array( $current_state['claims'] ?? null ) ? $current_state['claims'] : array();
+					if ( isset( $claims[ (string) $expected_offset ] ) ) {
+						$claim_error = 'already_claimed';
+						return null;
+					}
+
+					$current_state['claims']      = $claims;
+					$current_state['claims'][ (string) $expected_offset ] = current_time( 'mysql' );
+					$current['batch_state']       = $current_state;
+
+					return $current;
+				},
+				'batch_chunk_claim'
+			);
+
+			if ( empty( $claim['success'] ) ) {
+				$latest       = is_array( $claim['snapshot'] ?? null ) ? $claim['snapshot'] : datamachine_get_engine_data( $parent_job_id );
+				$latest_state = is_array( $latest['batch_state'] ?? null ) ? $latest['batch_state'] : array();
+
+				return array(
+					'scheduled' => 0,
+					'offset'    => (int) ( $latest_state['offset'] ?? ( $latest['batch_offset'] ?? 0 ) ),
+					'total'     => (int) ( $latest_state['total'] ?? ( $latest['batch_total'] ?? 0 ) ),
+					'more'      => ! empty( $latest['batch_state'] ),
+					'cancelled' => 'cancelled' === $claim_error || ! empty( $latest['cancelled'] ),
+					'missing'   => 'missing' === $claim_error && empty( $latest['batch'] ),
+					'duplicate' => in_array( $claim_error, array( 'already_claimed', 'stale_offset', 'missing' ), true ),
+				);
+			}
+
+			$parent_engine = $claim['snapshot'];
+			$batch_state   = is_array( $parent_engine['batch_state'] ?? null ) ? $parent_engine['batch_state'] : $batch_state;
 		}
 
 		$context    = $parent_engine['batch_context'] ?? '';
@@ -280,30 +359,41 @@ class BatchScheduler {
 
 		$new_offset = $offset + $chunk_size;
 
-		// Re-read engine_data — caller's createItem callback may have
-		// merged its own keys (child links, deferred state, etc.).
-		$parent_engine                    = datamachine_get_engine_data( $parent_job_id );
-		$parent_engine['batch_scheduled'] = ( $parent_engine['batch_scheduled'] ?? 0 ) + $scheduled;
-		$parent_engine['batch_offset']    = min( $new_offset, $total );
-
 		$more = $new_offset < $total;
 
+		EngineData::mutate(
+			$parent_job_id,
+			static function ( array $current ) use ( $scheduled, $new_offset, $total, $more, $expected_offset ): array {
+				$current['batch_scheduled'] = ( $current['batch_scheduled'] ?? 0 ) + $scheduled;
+				$current['batch_offset']    = min( $new_offset, $total );
+
+				if ( $more ) {
+					if ( is_array( $current['batch_state'] ?? null ) ) {
+						$current['batch_state']['offset'] = $new_offset;
+						if ( null !== $expected_offset && isset( $current['batch_state']['claims'][ (string) $expected_offset ] ) ) {
+							unset( $current['batch_state']['claims'][ (string) $expected_offset ] );
+						}
+					}
+				} else {
+					unset( $current['batch_state'] );
+				}
+
+				return $current;
+			},
+			'batch_chunk_advance'
+		);
+
 		if ( $more ) {
-			$parent_engine['batch_state']['offset'] = $new_offset;
-			datamachine_set_engine_data( $parent_job_id, $parent_engine );
 
 			as_schedule_single_action(
 				time() + $delay,
 				$hook,
-				array( 'parent_job_id' => $parent_job_id ),
+				array(
+					'parent_job_id' => $parent_job_id,
+					'offset'        => $new_offset,
+				),
 				'data-machine'
 			);
-		} else {
-			// Last chunk — drop batch_state to free row space. Top-level
-			// batch_total / batch_scheduled / batch_offset stay so the
-			// parent's status aggregation has what it needs.
-			unset( $parent_engine['batch_state'] );
-			datamachine_set_engine_data( $parent_job_id, $parent_engine );
 		}
 
 		return array(
@@ -313,6 +403,7 @@ class BatchScheduler {
 			'more'      => $more,
 			'cancelled' => false,
 			'missing'   => false,
+			'duplicate' => false,
 		);
 	}
 

--- a/inc/Core/JobStatus.php
+++ b/inc/Core/JobStatus.php
@@ -24,6 +24,7 @@ class JobStatus {
 	public const WAITING            = 'waiting';
 	public const COMPLETED          = 'completed';
 	public const FAILED             = 'failed';
+	public const CANCELLED          = 'cancelled';
 	public const COMPLETED_NO_ITEMS = 'completed_no_items';
 	public const AGENT_SKIPPED      = 'agent_skipped';
 
@@ -33,6 +34,7 @@ class JobStatus {
 	public const FINAL_STATUSES = array(
 		self::COMPLETED,
 		self::FAILED,
+		self::CANCELLED,
 		self::COMPLETED_NO_ITEMS,
 		self::AGENT_SKIPPED,
 	);

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -291,7 +291,7 @@ class SystemAgentServiceProvider {
 	 * @since 0.72.0
 	 */
 	private function registerActionSchedulerHooks(): void {
-		add_action( 'datamachine_task_process_batch', array( $this, 'handleBatchChunk' ) );
+		add_action( 'datamachine_task_process_batch', array( $this, 'handleBatchChunk' ), 10, 2 );
 		add_action( 'datamachine_task_retry', array( $this, 'handleTaskRetry' ) );
 		add_action(
 			'datamachine_system_agent_set_featured_image',
@@ -465,10 +465,11 @@ class SystemAgentServiceProvider {
 	 *
 	 * @since 0.32.0
 	 *
-	 * @param string $batchId Batch identifier.
+	 * @param string   $batchId Batch identifier.
+	 * @param int|null $offset  Offset key carried by the scheduler action.
 	 */
-	public function handleBatchChunk( string $batchId ): void {
-		TaskScheduler::processBatchChunk( $batchId );
+	public function handleBatchChunk( string $batchId, ?int $offset = null ): void {
+		TaskScheduler::processBatchChunk( $batchId, $offset );
 	}
 
 	/**

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -106,12 +106,12 @@ function datamachine_register_core_actions() {
 	// Pipeline batch fan-out: process chunks and track child completion.
 	add_action(
 		PipelineBatchScheduler::BATCH_HOOK,
-		function ( $parent_job_id ) {
+		function ( $parent_job_id, $offset = null ) {
 			$scheduler = new PipelineBatchScheduler();
-			$scheduler->processChunk( (int) $parent_job_id );
+			$scheduler->processChunk( (int) $parent_job_id, null === $offset ? null : (int) $offset );
 		},
 		10,
-		1
+		2
 	);
 	add_action( 'datamachine_job_complete', array( PipelineBatchScheduler::class, 'onChildComplete' ), 20, 2 );
 

--- a/inc/Engine/Tasks/TaskScheduler.php
+++ b/inc/Engine/Tasks/TaskScheduler.php
@@ -458,7 +458,7 @@ class TaskScheduler {
 	 * @param int|string $parentJobIdOrBatchId Parent job ID. Numeric strings
 	 *                                         from Action Scheduler are coerced.
 	 */
-	public static function processBatchChunk( int|string $parentJobIdOrBatchId ): void {
+	public static function processBatchChunk( int|string $parentJobIdOrBatchId, ?int $expected_offset = null ): void {
 		$parent_job_id = self::resolveParentJobId( $parentJobIdOrBatchId );
 
 		if ( $parent_job_id <= 0 ) {
@@ -492,7 +492,8 @@ class TaskScheduler {
 				$child_parent_id      = $caller_parent_job_id > 0 ? $caller_parent_job_id : $parent_id;
 
 				return self::schedule( $task_type, $params, $context, $child_parent_id );
-			}
+			},
+			$expected_offset
 		);
 
 		$jobs_db       = new Jobs();
@@ -514,6 +515,10 @@ class TaskScheduler {
 				$parent_job_id,
 				JobStatus::failed( 'batch_state_missing' )->toString()
 			);
+			return;
+		}
+
+		if ( ! empty( $result['duplicate'] ) ) {
 			return;
 		}
 

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -230,10 +230,36 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 
 		$this->assertEquals( 0, $count );
 
-		// Parent should be failed with cancellation reason.
+		// Parent should terminalize through the generic cancellation status.
 		$parent_job = $this->jobs_db->get_job( $parent_id );
-		$this->assertStringContainsString( 'failed', $parent_job['status'] );
-		$this->assertStringContainsString( 'batch cancelled', $parent_job['status'] );
+		$this->assertSame( JobStatus::CANCELLED, $parent_job['status'] );
+	}
+
+	public function test_duplicate_chunk_delivery_for_same_offset_does_not_create_duplicate_children(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+		$packets   = array(
+			$this->make_data_packet( 'Event A' ),
+			$this->make_data_packet( 'Event B' ),
+		);
+
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->fanOut( $parent_id, 'step_abc_123', $packets, $engine );
+
+		$scheduler->processChunk( $parent_id, 0 );
+		$scheduler->processChunk( $parent_id, 0 );
+
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_jobs';
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE parent_job_id = %d", $parent_id )
+		);
+
+		$this->assertSame( 2, $count );
+
+		$parent_engine = datamachine_get_engine_data( $parent_id );
+		$this->assertSame( 2, (int) $parent_engine['batch_scheduled'] );
+		$this->assertArrayNotHasKey( 'batch_state', $parent_engine );
 	}
 
 	public function test_process_chunk_marks_parent_failed_when_batch_state_is_missing(): void {

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -80,4 +80,22 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 		$job = $this->db_jobs->get_job( $job_id );
 		$this->assertSame( JobStatus::COMPLETED_NO_ITEMS, $job['status'] );
 	}
+
+	public function test_cancelled_is_generic_terminal_status(): void {
+		$job_id = $this->db_jobs->create_job( array( 'label' => 'Cancelled terminal lifecycle' ) );
+		$this->assertIsInt( $job_id );
+
+		$this->assertTrue( $this->db_jobs->start_job( $job_id, JobStatus::PROCESSING ) );
+
+		$cancelled = $this->db_jobs->transition_job_status_result( $job_id, JobStatus::CANCELLED, true );
+		$restart   = $this->db_jobs->start_job( $job_id, JobStatus::PROCESSING );
+
+		$this->assertTrue( $cancelled['success'] );
+		$this->assertTrue( $cancelled['changed'] );
+		$this->assertFalse( $restart );
+		$this->assertTrue( JobStatus::isStatusFinal( JobStatus::CANCELLED ) );
+
+		$job = $this->db_jobs->get_job( $job_id );
+		$this->assertSame( JobStatus::CANCELLED, $job['status'] );
+	}
 }


### PR DESCRIPTION
## Summary
- Make `cancelled` a first-class generic terminal `JobStatus` so batch cancellation terminalizes through the shared lifecycle contract.
- Carry chunk offset keys in batch Action Scheduler payloads and claim offsets through CAS-backed engine-data mutation before creating child work.
- Treat duplicate/stale chunk deliveries as no-ops and keep pipeline/task batch consumers wired to the shared contract.
- Add focused unit coverage for cancelled lifecycle terminalization and duplicate pipeline chunk delivery.

## Verification
- `php -l inc/Core/JobStatus.php inc/Core/ActionScheduler/BatchScheduler.php inc/Abilities/Engine/PipelineBatchScheduler.php inc/Engine/Tasks/TaskScheduler.php inc/Engine/Actions/DataMachineActions.php inc/Engine/AI/System/SystemAgentServiceProvider.php tests/Unit/Core/Database/JobLifecycleTransitionTest.php tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php`
- `vendor/bin/phpcs inc/Core/JobStatus.php inc/Core/ActionScheduler/BatchScheduler.php inc/Abilities/Engine/PipelineBatchScheduler.php inc/Engine/Tasks/TaskScheduler.php inc/Engine/Actions/DataMachineActions.php inc/Engine/AI/System/SystemAgentServiceProvider.php tests/Unit/Core/Database/JobLifecycleTransitionTest.php tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php`

## Test runner blockers
- `homeboy test data-machine --path . --changed-since origin/main` failed before running tests with WP Codebox `ERR_FS_CP_EINVAL` while copying `/var/folders/.../T` into its own subdirectory.
- `homeboy test data-machine --changed-since origin/main` did not start because Homeboy resource policy refused local execution on a warm machine.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the lifecycle/fanout hardening implementation and focused tests; Chris remains responsible for review and merge.