### PR TITLE
Add content-addressed DataPacket refs

### DIFF
--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -35,6 +35,7 @@
 namespace DataMachine\Core\ActionScheduler;
 
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\DataPacketStore;
 use DataMachine\Core\PluginSettings;
 
 defined( 'ABSPATH' ) || exit;
@@ -153,6 +154,7 @@ class BatchScheduler {
 		string $context = '',
 		string $completion_strategy = ''
 	): array {
+		$items      = array_map( array( DataPacketStore::class, 'reference_packet_collections_in_value' ), $items );
 		$total      = count( $items );
 		$chunk_size = self::chunkSize( $context );
 
@@ -269,6 +271,7 @@ class BatchScheduler {
 		$scheduled = 0;
 
 		foreach ( $chunk as $item ) {
+			$item   = DataPacketStore::hydrate_packet_collections_in_value( $item );
 			$result = $createItem( $item, $extra, $parent_job_id );
 			if ( $result ) {
 				++$scheduled;

--- a/inc/Core/DataPacketStore.php
+++ b/inc/Core/DataPacketStore.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Content-addressed DataPacket storage and hydration.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Core\FilesRepository\FilesystemHelper;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class DataPacketStore {
+
+	public const SCHEMA_VERSION = 1;
+	public const HASH_ALGORITHM = 'sha256';
+
+	/**
+	 * Store a packet and return its hydration reference.
+	 *
+	 * @param array $packet Packet payload.
+	 * @return array|false Packet ref on success.
+	 */
+	public static function store( array $packet ): array|false {
+		$canonical = self::canonicalize_packet( $packet );
+		$json      = self::encode_canonical_json( $canonical );
+
+		if ( false === $json ) {
+			return false;
+		}
+
+		$hash      = hash( self::HASH_ALGORITHM, $json );
+		$directory = ( new DirectoryManager() )->get_data_packet_store_directory( self::SCHEMA_VERSION, $hash );
+
+		if ( ! ( new DirectoryManager() )->ensure_directory_exists( $directory ) ) {
+			return false;
+		}
+
+		$file_path = $directory . '/' . $hash . '.json';
+		$fs        = FilesystemHelper::get();
+
+		if ( ! $fs ) {
+			return false;
+		}
+
+		if ( ! file_exists( $file_path ) ) {
+			$envelope = array(
+				'schema_version' => self::SCHEMA_VERSION,
+				'hash_algorithm' => self::HASH_ALGORITHM,
+				'content_hash'   => $hash,
+				'packet'         => $canonical,
+			);
+			$stored_json = wp_json_encode( $envelope, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+			if ( false === $stored_json || ! $fs->put_contents( $file_path, $stored_json ) ) {
+				return false;
+			}
+		}
+
+		return self::ref( $hash, $file_path );
+	}
+
+	/**
+	 * Store many packets.
+	 *
+	 * @param array $packets Packet list.
+	 * @return array|false Ref list on success.
+	 */
+	public static function store_many( array $packets ): array|false {
+		$refs = array();
+		foreach ( $packets as $packet ) {
+			if ( ! is_array( $packet ) ) {
+				$refs[] = $packet;
+				continue;
+			}
+
+			if ( self::is_ref( $packet ) ) {
+				$refs[] = $packet;
+				continue;
+			}
+
+			$ref = self::store( $packet );
+			if ( false === $ref ) {
+				return false;
+			}
+			$refs[] = $ref;
+		}
+
+		return $refs;
+	}
+
+	/**
+	 * Hydrate a packet ref or return the given packet unchanged.
+	 *
+	 * @param array $packet_or_ref Packet payload or ref.
+	 * @return array|null Hydrated packet, original packet, or null on failure.
+	 */
+	public static function hydrate( array $packet_or_ref ): ?array {
+		if ( ! self::is_ref( $packet_or_ref ) ) {
+			return $packet_or_ref;
+		}
+
+		$file_path = self::file_path_from_ref( $packet_or_ref );
+		if ( '' === $file_path || ! file_exists( $file_path ) ) {
+			return null;
+		}
+
+		$fs   = FilesystemHelper::get();
+		$json = $fs ? $fs->get_contents( $file_path ) : false;
+		if ( false === $json ) {
+			return null;
+		}
+
+		$envelope = json_decode( $json, true );
+		if ( ! is_array( $envelope ) || ! is_array( $envelope['packet'] ?? null ) ) {
+			return null;
+		}
+
+		$packet = $envelope['packet'];
+		$hash   = self::content_hash( $packet );
+		if ( ! is_string( $hash ) || $hash !== (string) ( $packet_or_ref['content_hash'] ?? '' ) ) {
+			return null;
+		}
+
+		return $packet;
+	}
+
+	/**
+	 * Hydrate a packet list containing packets and/or refs.
+	 *
+	 * @param array $packets Packet/ref list.
+	 * @return array Hydrated packets. Failed refs are omitted.
+	 */
+	public static function hydrate_many( array $packets ): array {
+		$hydrated = array();
+		foreach ( $packets as $packet ) {
+			if ( ! is_array( $packet ) ) {
+				$hydrated[] = $packet;
+				continue;
+			}
+
+			$value = self::hydrate( $packet );
+			if ( null !== $value ) {
+				$hydrated[] = $value;
+			}
+		}
+
+		return $hydrated;
+	}
+
+	/**
+	 * Replace known packet collections in a value with refs.
+	 *
+	 * @param mixed $value Arbitrary value.
+	 * @return mixed Value with packet collections referenced where possible.
+	 */
+	public static function reference_packet_collections_in_value( mixed $value ): mixed {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		foreach ( array( 'data_packets', 'packets' ) as $key ) {
+			if ( isset( $value[ $key ] ) && is_array( $value[ $key ] ) ) {
+				$refs = self::store_many( $value[ $key ] );
+				if ( false !== $refs ) {
+					$value[ $key ] = $refs;
+				}
+			}
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Hydrate known packet collections in a value.
+	 *
+	 * @param mixed $value Arbitrary value.
+	 * @return mixed Value with packet collections hydrated.
+	 */
+	public static function hydrate_packet_collections_in_value( mixed $value ): mixed {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		foreach ( array( 'data_packets', 'packets' ) as $key ) {
+			if ( isset( $value[ $key ] ) && is_array( $value[ $key ] ) ) {
+				$value[ $key ] = self::hydrate_many( $value[ $key ] );
+			}
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Determine whether an array is a packet ref.
+	 *
+	 * @param array $value Candidate value.
+	 * @return bool Whether the value is a ref.
+	 */
+	public static function is_ref( array $value ): bool {
+		return ! empty( $value['is_data_packet_ref'] )
+			&& self::SCHEMA_VERSION === (int) ( $value['schema_version'] ?? 0 )
+			&& self::HASH_ALGORITHM === (string) ( $value['hash_algorithm'] ?? '' )
+			&& is_string( $value['content_hash'] ?? null )
+			&& 64 === strlen( (string) $value['content_hash'] );
+	}
+
+	/**
+	 * Compute the stable content hash for a packet.
+	 *
+	 * @param array $packet Packet payload.
+	 * @return string|false Hash on success.
+	 */
+	public static function content_hash( array $packet ): string|false {
+		$json = self::encode_canonical_json( self::canonicalize_packet( $packet ) );
+		return false === $json ? false : hash( self::HASH_ALGORITHM, $json );
+	}
+
+	/**
+	 * Create a ref array.
+	 *
+	 * @param string $hash Content hash.
+	 * @param string $file_path Storage path.
+	 * @return array Ref.
+	 */
+	private static function ref( string $hash, string $file_path ): array {
+		return array(
+			'is_data_packet_ref' => true,
+			'schema_version'     => self::SCHEMA_VERSION,
+			'hash_algorithm'     => self::HASH_ALGORITHM,
+			'content_hash'       => $hash,
+			'file_path'          => $file_path,
+		);
+	}
+
+	/**
+	 * Resolve a ref to an on-disk path.
+	 *
+	 * @param array $ref Packet ref.
+	 * @return string File path.
+	 */
+	private static function file_path_from_ref( array $ref ): string {
+		$file_path = (string) ( $ref['file_path'] ?? '' );
+		if ( '' !== $file_path ) {
+			return $file_path;
+		}
+
+		$hash = (string) ( $ref['content_hash'] ?? '' );
+		if ( '' === $hash ) {
+			return '';
+		}
+
+		$directory = ( new DirectoryManager() )->get_data_packet_store_directory( self::SCHEMA_VERSION, $hash );
+		return $directory . '/' . $hash . '.json';
+	}
+
+	/**
+	 * Normalize packet content before hashing/storing.
+	 *
+	 * The legacy DataPacket value object injects a top-level runtime timestamp;
+	 * content addressing excludes it so identical packet content hashes the same.
+	 *
+	 * @param array $packet Packet payload.
+	 * @return array Canonical packet.
+	 */
+	private static function canonicalize_packet( array $packet ): array {
+		unset( $packet['timestamp'] );
+		self::ksort_recursive( $packet );
+		return $packet;
+	}
+
+	/**
+	 * Recursively sort associative keys for stable JSON hashing.
+	 *
+	 * @param mixed $value Value to sort.
+	 * @return void
+	 */
+	private static function ksort_recursive( mixed &$value ): void {
+		if ( ! is_array( $value ) ) {
+			return;
+		}
+
+		foreach ( $value as &$child ) {
+			self::ksort_recursive( $child );
+		}
+		unset( $child );
+
+		if ( array_keys( $value ) !== range( 0, count( $value ) - 1 ) ) {
+			ksort( $value );
+		}
+	}
+
+	/**
+	 * Encode canonical JSON for hashing.
+	 *
+	 * @param array $value Canonical value.
+	 * @return string|false JSON string.
+	 */
+	private static function encode_canonical_json( array $value ): string|false {
+		return wp_json_encode( $value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+	}
+}

--- a/inc/Core/DataPacketStore.php
+++ b/inc/Core/DataPacketStore.php
@@ -48,7 +48,7 @@ class DataPacketStore {
 		}
 
 		if ( ! file_exists( $file_path ) ) {
-			$envelope = array(
+			$envelope    = array(
 				'schema_version' => self::SCHEMA_VERSION,
 				'hash_algorithm' => self::HASH_ALGORITHM,
 				'content_hash'   => $hash,
@@ -121,7 +121,7 @@ class DataPacketStore {
 
 		$packet = $envelope['packet'];
 		$hash   = self::content_hash( $packet );
-		if ( ! is_string( $hash ) || $hash !== (string) ( $packet_or_ref['content_hash'] ?? '' ) ) {
+		if ( ! is_string( $hash ) || (string) ( $packet_or_ref['content_hash'] ?? '' ) !== $hash ) {
 			return null;
 		}
 

--- a/inc/Core/FilesRepository/DirectoryManager.php
+++ b/inc/Core/FilesRepository/DirectoryManager.php
@@ -395,8 +395,6 @@ class DirectoryManager {
 		if ( null !== $default_id ) {
 			return $default_id;
 		}
-
-
 		// Activation can run before the users table exists in WP-PHPUnit/Playground bootstraps.
 		try {
 			$admins = get_users( array(

--- a/inc/Core/FilesRepository/DirectoryManager.php
+++ b/inc/Core/FilesRepository/DirectoryManager.php
@@ -104,6 +104,21 @@ class DirectoryManager {
 	}
 
 	/**
+	 * Get the content-addressed DataPacket directory for a hash.
+	 *
+	 * @param int    $schema_version Packet store schema version.
+	 * @param string $content_hash Content hash.
+	 * @return string Full path to packet directory.
+	 */
+	public function get_data_packet_store_directory( int $schema_version, string $content_hash ): string {
+		$upload_dir = wp_upload_dir();
+		$base       = trailingslashit( $upload_dir['basedir'] ) . self::REPOSITORY_DIR;
+		$prefix     = substr( $content_hash, 0, 2 );
+
+		return "{$base}/data-packets/v{$schema_version}/{$prefix}";
+	}
+
+	/**
 	 * Get flow files directory path
 	 *
 	 * @param int|string $pipeline_id Pipeline ID or 'direct' for direct execution

--- a/inc/Core/FilesRepository/FileRetrieval.php
+++ b/inc/Core/FilesRepository/FileRetrieval.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Core\FilesRepository;
 
+use DataMachine\Core\DataPacketStore;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -50,6 +52,6 @@ class FileRetrieval {
 		}
 
 		$data = json_decode( $json_data, true );
-		return is_array( $data ) ? $data : array();
+		return is_array( $data ) ? DataPacketStore::hydrate_many( $data ) : array();
 	}
 }

--- a/inc/Core/FilesRepository/FileStorage.php
+++ b/inc/Core/FilesRepository/FileStorage.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Core\FilesRepository;
 
+use DataMachine\Core\DataPacketStore;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -204,9 +206,22 @@ class FileStorage {
 			}
 		}
 
-		// Merge new data (newest first)
+		$packet_refs = DataPacketStore::store_many( $data );
+		if ( false === $packet_refs ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'FileStorage: Failed to store content-addressed data packets.',
+				array(
+					'job_id' => $job_id,
+				)
+			);
+			return false;
+		}
+
+		// Merge new data (newest first). New writes store refs; retrieval hydrates them.
 		if ( ! empty( $data ) ) {
-			$accumulated_data = array_merge( $data, $accumulated_data );
+			$accumulated_data = array_merge( $packet_refs, $accumulated_data );
 		}
 
 		// Serialize and write
@@ -240,7 +255,7 @@ class FileStorage {
 			'is_data_reference' => true,
 			'job_id'            => $job_id,
 			'file_path'         => $file_path,
-			'stored_at'         => time(),
+			'packet_refs'       => $packet_refs,
 		);
 	}
 
@@ -296,6 +311,6 @@ class FileStorage {
 			return null;
 		}
 
-		return $data;
+		return is_array( $data ) ? DataPacketStore::hydrate_many( $data ) : $data;
 	}
 }

--- a/inc/Engine/Tasks/TaskScheduler.php
+++ b/inc/Engine/Tasks/TaskScheduler.php
@@ -26,6 +26,7 @@ use DataMachine\Core\ActionScheduler\BatchScheduler;
 use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\AbilityResult;
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\DataPacketStore;
 use DataMachine\Core\JobStatus;
 use DataMachine\Engine\AI\System\Tasks\SystemTask;
 
@@ -90,6 +91,7 @@ class TaskScheduler {
 	 */
 	public static function schedule( string $taskType, array $params, array $context = array(), int $parentJobId = 0 ): int|false {
 		self::$last_schedule_error = null;
+		$params                    = DataPacketStore::hydrate_packet_collections_in_value( $params );
 
 		if ( ! TaskRegistry::isRegistered( $taskType ) ) {
 			$message = "TaskScheduler: Unknown task type '{$taskType}'";

--- a/tests/content-addressed-data-packets-smoke.php
+++ b/tests/content-addressed-data-packets-smoke.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Smoke coverage for content-addressed DataPacket refs.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', sys_get_temp_dir() . '/datamachine-packet-smoke/' );
+}
+
+if ( ! class_exists( 'WP_Filesystem_Base' ) ) {
+	class WP_Filesystem_Base {
+		public function put_contents( $file, $contents ) {
+			return false !== file_put_contents( $file, $contents );
+		}
+
+		public function get_contents( $file ) {
+			return file_get_contents( $file );
+		}
+
+		public function copy( $source, $destination, $overwrite = false ) {
+			if ( ! $overwrite && file_exists( $destination ) ) {
+				return false;
+			}
+			return copy( $source, $destination );
+		}
+	}
+}
+
+if ( ! function_exists( 'WP_Filesystem' ) ) {
+	function WP_Filesystem(): bool {
+		global $wp_filesystem;
+		$wp_filesystem = new WP_Filesystem_Base();
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_upload_dir' ) ) {
+	function wp_upload_dir(): array {
+		$base = sys_get_temp_dir() . '/datamachine-packet-smoke/uploads';
+		return array(
+			'basedir' => $base,
+			'baseurl' => 'http://example.test/uploads',
+		);
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( string $value ): string {
+		return rtrim( $value, '/\\' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'wp_mkdir_p' ) ) {
+	function wp_mkdir_p( string $path ): bool {
+		return is_dir( $path ) || mkdir( $path, 0777, true );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, int $flags = 0 ) {
+		return json_encode( $value, $flags );
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( ...$args ): void {}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook = '' ): int {
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook = '' ): bool {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ): void {}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( ...$args ): void {}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'current_time' ) ) {
+	function current_time( string $type, $gmt = 0 ): string {
+		return '2026-01-01 00:00:00';
+	}
+}
+
+if ( ! function_exists( 'as_schedule_single_action' ) ) {
+	function as_schedule_single_action( ...$args ): int {
+		return 1;
+	}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $name, $default = false ) {
+		if ( 'datamachine_settings' === $name ) {
+			return array( 'queue_tuning' => array( 'chunk_size' => 10, 'chunk_delay' => 0 ) );
+		}
+		return $default;
+	}
+}
+
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ): int {
+		return abs( (int) $value );
+	}
+}
+
+if ( ! class_exists( 'DataMachine\\Core\\RunMetrics' ) ) {
+	eval( 'namespace DataMachine\\Core { class RunMetrics { public static function start( int $job_id, array $context = array() ): bool { return true; } } }' );
+}
+
+$engine_snapshots = array();
+
+if ( ! function_exists( 'datamachine_merge_engine_data' ) ) {
+	function datamachine_merge_engine_data( int $job_id, array $data ): bool {
+		global $engine_snapshots;
+		$engine_snapshots[ $job_id ] = array_replace_recursive( $engine_snapshots[ $job_id ] ?? array(), $data );
+		return true;
+	}
+}
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use DataMachine\Core\ActionScheduler\BatchScheduler;
+use DataMachine\Core\DataPacketStore;
+use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Core\FilesRepository\FileRetrieval;
+use DataMachine\Core\FilesRepository\FileStorage;
+
+function datamachine_packet_smoke_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+function datamachine_packet_smoke_rm_tree( string $path ): void {
+	if ( ! file_exists( $path ) ) {
+		return;
+	}
+	$items = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $path, FilesystemIterator::SKIP_DOTS ),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+	foreach ( $items as $item ) {
+		$item->isDir() ? rmdir( $item->getPathname() ) : unlink( $item->getPathname() );
+	}
+	rmdir( $path );
+}
+
+$upload_dir = wp_upload_dir();
+datamachine_packet_smoke_rm_tree( $upload_dir['basedir'] );
+
+$packet_a = array(
+	'type'      => 'fetch',
+	'timestamp' => 111,
+	'data'      => array(
+		'title' => 'Packet title',
+		'body'  => 'Packet body',
+	),
+	'metadata'  => array(
+		'source_type' => 'smoke',
+	),
+);
+$packet_b               = $packet_a;
+$packet_b['timestamp'] = 999;
+
+$ref_a = DataPacketStore::store( $packet_a );
+$ref_b = DataPacketStore::store( $packet_b );
+
+datamachine_packet_smoke_assert( is_array( $ref_a ) && DataPacketStore::is_ref( $ref_a ), 'store returns packet ref' );
+datamachine_packet_smoke_assert( $ref_a['content_hash'] === $ref_b['content_hash'], 'runtime timestamp excluded from content hash' );
+
+$hydrated = DataPacketStore::hydrate( $ref_a );
+datamachine_packet_smoke_assert( is_array( $hydrated ), 'ref hydrates' );
+datamachine_packet_smoke_assert( ! isset( $hydrated['timestamp'] ), 'hydrated packet is canonical without runtime timestamp' );
+datamachine_packet_smoke_assert( $hydrated['data']['title'] === 'Packet title', 'hydrated packet preserves content' );
+
+$context = array(
+	'pipeline_id' => 7,
+	'flow_id'     => 8,
+);
+$stored = ( new FileStorage() )->store_data_packet( array( $packet_a ), 42, $context );
+datamachine_packet_smoke_assert( is_array( $stored ) && isset( $stored['packet_refs'][0] ), 'job data storage returns packet refs' );
+
+$retrieved = ( new FileRetrieval() )->retrieve_data_by_job_id( 42, $context );
+datamachine_packet_smoke_assert( count( $retrieved ) === 1, 'job data retrieval hydrates one packet' );
+datamachine_packet_smoke_assert( $retrieved[0]['data']['body'] === 'Packet body', 'legacy data.json read hydrates refs transparently' );
+
+$legacy_job_dir = ( new DirectoryManager() )->get_job_directory( $context['pipeline_id'], $context['flow_id'], 43 );
+wp_mkdir_p( $legacy_job_dir );
+file_put_contents( $legacy_job_dir . '/data.json', wp_json_encode( array( $packet_a ), JSON_UNESCAPED_SLASHES ) );
+$legacy_retrieved = ( new FileRetrieval() )->retrieve_data_by_job_id( 43, $context );
+datamachine_packet_smoke_assert( isset( $legacy_retrieved[0]['timestamp'] ), 'legacy raw data.json packet remains readable' );
+
+$batch_result = BatchScheduler::start(
+	101,
+	'datamachine_packet_smoke_batch',
+	array(
+		array( 'data_packets' => array( $packet_a ) ),
+	),
+	array(),
+	'packet-smoke',
+	BatchScheduler::COMPLETION_STRATEGY_CHUNKS_SCHEDULED
+);
+
+global $engine_snapshots;
+$batch_item = $engine_snapshots[101]['batch_state']['items'][0] ?? array();
+datamachine_packet_smoke_assert( ! empty( $batch_result['parent_job_id'] ), 'batch scheduler starts' );
+datamachine_packet_smoke_assert( DataPacketStore::is_ref( $batch_item['data_packets'][0] ?? array() ), 'child batch item stores packet by ref' );
+
+$child_params = DataPacketStore::hydrate_packet_collections_in_value( $batch_item );
+datamachine_packet_smoke_assert( $child_params['data_packets'][0]['data']['title'] === 'Packet title', 'child packet ref hydrates deterministically' );
+
+datamachine_packet_smoke_rm_tree( $upload_dir['basedir'] );
+fwrite( STDOUT, "content-addressed-data-packets-smoke: ok\n" );


### PR DESCRIPTION
## Summary
- Add a generic content-addressed DataPacket store with schema version, SHA-256 content hashes, canonical JSON, and top-level runtime timestamp exclusion from the stored/hashable packet.
- Store new job data.json entries as packet hydration refs while keeping legacy raw data.json packet reads transparent.
- Store batch child item packet collections by ref and hydrate them before child creation/task workflow scheduling.

## Tests
- php tests/content-addressed-data-packets-smoke.php
- php tests/batch-completion-strategy-smoke.php
- php tests/direct-request-inspector-packets-smoke.php
- php tests/ai-packet-projection-smoke.php
- vendor/bin/phpcs inc/Core/DataPacketStore.php inc/Core/FilesRepository/DirectoryManager.php inc/Core/FilesRepository/FileStorage.php inc/Core/FilesRepository/FileRetrieval.php inc/Core/ActionScheduler/BatchScheduler.php inc/Engine/Tasks/TaskScheduler.php tests/content-addressed-data-packets-smoke.php
- composer lint

## Caveats / blockers
- composer test is blocked before the suite runs by Homeboy lab extension metadata: Extension 'wordpress' has no sourceUrl or .source-url metadata.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested content-addressed DataPacket refs.