### PR TITLE
Hydrate job artifact content refs

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -262,6 +262,7 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\FlowStep\ConfigureFlowStepsAbility();
 	new \DataMachine\Abilities\FlowStep\ValidateFlowStepsConfigAbility();
 	new \DataMachine\Abilities\Job\GetJobsAbility();
+	new \DataMachine\Abilities\Job\HydrateJobArtifactAbility();
 	new \DataMachine\Abilities\Job\DeleteJobsAbility();
 	new \DataMachine\Abilities\Job\ExecuteWorkflowAbility();
 	new \DataMachine\Abilities\Job\ExecuteAgentWorkflowAbility();

--- a/inc/Abilities/Job/HydrateJobArtifactAbility.php
+++ b/inc/Abilities/Job/HydrateJobArtifactAbility.php
@@ -83,7 +83,7 @@ class HydrateJobArtifactAbility {
 
 		$content = (string) ( $result['content'] ?? '' );
 		unset( $result['content'] );
-		$result['content_base64'] = base64_encode( $content );
+		$result['content_base64'] = base64_encode( $content ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encodes verified artifact bytes for JSON-safe transport.
 		$result['encoding']       = 'base64';
 
 		return $result;

--- a/inc/Abilities/Job/HydrateJobArtifactAbility.php
+++ b/inc/Abilities/Job/HydrateJobArtifactAbility.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Hydrate Job Artifact Ability.
+ *
+ * @package DataMachine\Abilities\Job
+ */
+
+namespace DataMachine\Abilities\Job;
+
+use DataMachine\Core\JobArtifacts;
+
+defined( 'ABSPATH' ) || exit;
+
+class HydrateJobArtifactAbility {
+
+	use JobHelpers;
+
+	public function __construct() {
+		$this->initDatabases();
+		$this->registerAbility();
+	}
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/hydrate-job-artifact',
+				array(
+					'label'               => __( 'Hydrate Job Artifact', 'data-machine' ),
+					'description'         => __( 'Resolve a portable job artifact_ref to verified artifact content. The response omits local_debug metadata and returns content as base64 for JSON-safe transport.', 'data-machine' ),
+					'category'            => 'datamachine-jobs',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'artifact_ref' ),
+						'properties' => array(
+							'artifact_ref' => array(
+								'type'        => 'string',
+								'description' => __( 'Portable artifact ref, for example datamachine://jobs/123/artifacts/tool-trace.', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'        => array( 'type' => 'boolean' ),
+							'artifact'       => array( 'type' => 'object' ),
+							'content_base64' => array( 'type' => 'string' ),
+							'encoding'       => array( 'type' => 'string' ),
+							'bytes'          => array( 'type' => 'integer' ),
+							'sha256'         => array( 'type' => 'string' ),
+							'verified'       => array( 'type' => 'boolean' ),
+							'error'          => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
+	}
+
+	/**
+	 * Execute artifact hydration.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input ): array {
+		$artifact_ref = trim( (string) ( $input['artifact_ref'] ?? '' ) );
+		if ( '' === $artifact_ref ) {
+			return array(
+				'success' => false,
+				'error'   => 'artifact_ref is required.',
+			);
+		}
+
+		$result = ( new JobArtifacts() )->hydrate_artifact_ref( $artifact_ref );
+		if ( empty( $result['success'] ) ) {
+			return $result;
+		}
+
+		$content = (string) ( $result['content'] ?? '' );
+		unset( $result['content'] );
+		$result['content_base64'] = base64_encode( $content );
+		$result['encoding']       = 'base64';
+
+		return $result;
+	}
+}

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -1768,7 +1768,7 @@ class JobsCommand extends BaseCommand {
 
 		$content = (string) ( $result['content'] ?? '' );
 		unset( $result['content'] );
-		$result['content_base64'] = base64_encode( $content );
+		$result['content_base64'] = base64_encode( $content ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encodes verified artifact bytes for JSON-safe transport.
 		$result['encoding']       = 'base64';
 
 		WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -1716,6 +1716,65 @@ class JobsCommand extends BaseCommand {
 	}
 
 	/**
+	 * Hydrate verified artifact content by portable artifact ref.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <artifact_ref>
+	 * : The portable artifact ref to hydrate.
+	 *
+	 * [--format=<format>]
+	 * : Output format. `raw` streams the verified content bytes.
+	 * ---
+	 * default: json
+	 * options:
+	 *   - json
+	 *   - raw
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine jobs artifact-content datamachine://jobs/844/artifacts/tool-trace --format=raw
+	 *
+	 * @subcommand artifact-content
+	 */
+	public function artifact_content( array $args, array $assoc_args ): void {
+		$artifact_ref = isset( $args[0] ) ? (string) $args[0] : '';
+		if ( '' === trim( $artifact_ref ) ) {
+			WP_CLI::error( 'artifact_ref is required.' );
+			return;
+		}
+
+		$format    = (string) ( $assoc_args['format'] ?? 'json' );
+		$artifacts = new JobArtifacts();
+		if ( 'raw' === $format ) {
+			$result = $artifacts->stream_artifact_ref(
+				$artifact_ref,
+				static function ( string $content ): void {
+					fwrite( STDOUT, $content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+				}
+			);
+			if ( empty( $result['success'] ) ) {
+				WP_CLI::error( $result['error'] ?? 'Failed to hydrate artifact content.' );
+			}
+			return;
+		}
+
+		$result = $artifacts->hydrate_artifact_ref( $artifact_ref );
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to hydrate artifact content.' );
+			return;
+		}
+
+		$content = (string) ( $result['content'] ?? '' );
+		unset( $result['content'] );
+		$result['content_base64'] = base64_encode( $content );
+		$result['encoding']       = 'base64';
+
+		WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+	}
+
+	/**
 	 * Locate a pipeline transcript by metadata for jobs created before engine_data
 	 * stored transcript_session_id.
 	 *

--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -83,6 +83,99 @@ class JobArtifacts {
 	}
 
 	/**
+	 * Hydrate a portable job artifact ref into verified artifact content.
+	 *
+	 * Public consumers should use artifact_ref plus this resolver instead of
+	 * relying on local_debug paths, absolute filesystem paths, or URLs.
+	 *
+	 * @param string $artifact_ref Portable artifact ref.
+	 * @param array  $engine_data  Optional engine_data snapshot containing artifact_files.
+	 * @return array{success: bool, artifact?: array<string,mixed>, content?: string, bytes?: int, sha256?: string, verified?: bool, error?: string}
+	 */
+	public function hydrate_artifact_ref( string $artifact_ref, array $engine_data = array() ): array {
+		$resolved = $this->resolve_artifact_ref( $artifact_ref, $engine_data );
+		if ( empty( $resolved['success'] ) || ! is_array( $resolved['artifact'] ?? null ) ) {
+			return array(
+				'success' => false,
+				'error'   => (string) ( $resolved['error'] ?? 'Artifact metadata was not found.' ),
+			);
+		}
+
+		$artifact      = $resolved['artifact'];
+		$content       = null;
+		$resolver_args = array(
+			'artifact_ref' => $artifact_ref,
+			'artifact'     => $artifact,
+			'engine_data'  => $engine_data,
+		);
+
+		$filtered = apply_filters( 'datamachine_job_artifact_ref_content', null, $resolver_args );
+		if ( is_string( $filtered ) ) {
+			$content = $filtered;
+		} elseif ( is_array( $filtered ) && isset( $filtered['content'] ) && is_string( $filtered['content'] ) ) {
+			$content = $filtered['content'];
+		}
+
+		if ( null === $content ) {
+			$path = $this->artifact_storage_path( $artifact );
+			if ( '' !== $path ) {
+				$read = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				if ( false !== $read ) {
+					$content = $read;
+				}
+			}
+		}
+
+		if ( null === $content ) {
+			return array(
+				'success' => false,
+				'error'   => 'Artifact content is unavailable from configured artifact storage.',
+			);
+		}
+
+		$bytes  = strlen( $content );
+		$sha256 = hash( 'sha256', $content );
+		$verify = $this->verify_artifact_content( $artifact, $bytes, $sha256 );
+		if ( empty( $verify['success'] ) ) {
+			return array(
+				'success'  => false,
+				'artifact' => $this->public_artifact_metadata( $artifact ),
+				'bytes'    => $bytes,
+				'sha256'   => $sha256,
+				'error'    => (string) ( $verify['error'] ?? 'Artifact content failed integrity verification.' ),
+			);
+		}
+
+		return array(
+			'success'  => true,
+			'artifact' => $this->public_artifact_metadata( $artifact ),
+			'content'  => $content,
+			'bytes'    => $bytes,
+			'sha256'   => $sha256,
+			'verified' => true,
+		);
+	}
+
+	/**
+	 * Stream verified artifact content to a caller-provided writer.
+	 *
+	 * @param string   $artifact_ref Portable artifact ref.
+	 * @param callable $writer       Receives the content string once verified.
+	 * @param array    $engine_data  Optional engine_data snapshot containing artifact_files.
+	 * @return array{success: bool, artifact?: array<string,mixed>, bytes?: int, sha256?: string, verified?: bool, error?: string}
+	 */
+	public function stream_artifact_ref( string $artifact_ref, callable $writer, array $engine_data = array() ): array {
+		$hydrated = $this->hydrate_artifact_ref( $artifact_ref, $engine_data );
+		if ( empty( $hydrated['success'] ) || ! is_string( $hydrated['content'] ?? null ) ) {
+			return $hydrated;
+		}
+
+		$writer( $hydrated['content'] );
+		unset( $hydrated['content'] );
+		return $hydrated;
+	}
+
+	/**
 	 * Build a deterministic artifact payload for a job.
 	 *
 	 * @param int   $job_id                    Job ID.
@@ -530,6 +623,60 @@ class JobArtifacts {
 		}
 
 		return (int) $matches[1];
+	}
+
+	private function artifact_storage_path( array $artifact ): string {
+		$relative_path = trim( (string) ( $artifact['relative_path'] ?? '' ) );
+		if ( '' === $relative_path || str_contains( $relative_path, "\0" ) || str_starts_with( $relative_path, '/' ) || preg_match( '#^[A-Za-z]:[\\/]#', $relative_path ) ) {
+			return '';
+		}
+
+		$upload_dir = wp_upload_dir();
+		$base_root  = (string) ( $upload_dir['basedir'] ?? '' );
+		if ( '' === trim( $base_root ) ) {
+			return '';
+		}
+
+		$base_dir = realpath( $base_root );
+		if ( false === $base_dir ) {
+			return '';
+		}
+
+		$candidate = trailingslashit( $base_dir ) . ltrim( str_replace( '\\', '/', $relative_path ), '/' );
+		$real_path = realpath( $candidate );
+		if ( false === $real_path || ! is_file( $real_path ) ) {
+			return '';
+		}
+
+		$base_prefix = trailingslashit( $base_dir );
+		return str_starts_with( $real_path, $base_prefix ) ? $real_path : '';
+	}
+
+	/** @return array{success: bool, error?: string} */
+	private function verify_artifact_content( array $artifact, int $bytes, string $sha256 ): array {
+		$expected_bytes = isset( $artifact['bytes'] ) ? (int) $artifact['bytes'] : null;
+		if ( null !== $expected_bytes && $expected_bytes !== $bytes ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Artifact byte count mismatch: expected %d, got %d.', $expected_bytes, $bytes ),
+			);
+		}
+
+		$expected_sha256 = strtolower( trim( (string) ( $artifact['sha256'] ?? '' ) ) );
+		if ( '' !== $expected_sha256 && ! hash_equals( $expected_sha256, $sha256 ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Artifact sha256 mismatch.',
+			);
+		}
+
+		return array( 'success' => true );
+	}
+
+	/** @return array<string,mixed> */
+	private function public_artifact_metadata( array $artifact ): array {
+		unset( $artifact['local_debug'] );
+		return $artifact;
 	}
 
 	/** @return array<string,mixed> */

--- a/tests/cleanup-cluster-smoke.php
+++ b/tests/cleanup-cluster-smoke.php
@@ -113,6 +113,7 @@ foreach ( array(
 	'FlowStep\\ConfigureFlowStepsAbility',
 	'FlowStep\\ValidateFlowStepsConfigAbility',
 	'Job\\GetJobsAbility',
+	'Job\\HydrateJobArtifactAbility',
 	'Job\\DeleteJobsAbility',
 	'Job\\ExecuteWorkflowAbility',
 	'Job\\FlowHealthAbility',

--- a/tests/job-artifact-content-resolver-smoke.php
+++ b/tests/job-artifact-content-resolver-smoke.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Smoke tests for verified job artifact content hydration.
+ *
+ * Run with: php tests/job-artifact-content-resolver-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$filters = $GLOBALS['datamachine_test_filters'][ $hook ] ?? array();
+		foreach ( $filters as $filter ) {
+			$value = $filter( $value, ...$args );
+		}
+		return $value;
+	}
+}
+
+require_once __DIR__ . '/bootstrap-unit.php';
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $flags = 0, int $depth = 512 ) {
+		return json_encode( $data, $flags, $depth );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ): string {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $value ): string {
+		return trim( wp_strip_all_tags( (string) $value ) );
+	}
+}
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $value ): string {
+		return (string) $value;
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( $value ): string {
+		return rtrim( (string) $value, '/\\' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $value ): string {
+		return strip_tags( (string) $value );
+	}
+}
+
+if ( ! function_exists( 'wp_upload_dir' ) ) {
+	function wp_upload_dir(): array {
+		$base = sys_get_temp_dir() . '/datamachine-job-artifact-content-resolver-smoke';
+		return array(
+			'basedir' => $base,
+			'baseurl' => 'https://example.test/uploads',
+		);
+	}
+}
+
+use DataMachine\Core\JobArtifacts;
+
+$failures = array();
+$passes   = 0;
+
+$assert_true = static function ( bool $condition, string $label ) use ( &$failures, &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		return;
+	}
+
+	$failures[] = $label;
+};
+
+$upload_dir = wp_upload_dir();
+$base_dir   = (string) $upload_dir['basedir'];
+$artifact_dir = trailingslashit( $base_dir ) . 'datamachine-artifacts/jobs/77';
+if ( ! is_dir( $artifact_dir ) ) {
+	mkdir( $artifact_dir, 0775, true );
+}
+
+$content       = "{\"ok\":true}\n";
+$relative_path = 'datamachine-artifacts/jobs/77/result.json';
+$file_path     = trailingslashit( $base_dir ) . $relative_path;
+file_put_contents( $file_path, $content );
+
+$artifact_ref = 'datamachine://jobs/77/artifacts/result';
+$engine_data  = array(
+	'artifact_files' => array(
+		'result' => array(
+			'artifact_ref'  => $artifact_ref,
+			'type'          => 'result',
+			'sha256'        => hash( 'sha256', $content ),
+			'bytes'         => strlen( $content ),
+			'relative_path' => $relative_path,
+			'local_debug'   => array(
+				'path' => '/private/internal/path/result.json',
+				'url'  => 'https://internal.test/result.json',
+			),
+		),
+	),
+);
+
+$artifacts = new JobArtifacts();
+$hydrated  = $artifacts->hydrate_artifact_ref( $artifact_ref, $engine_data );
+
+$assert_true( true === ( $hydrated['success'] ?? false ), 'hydrates artifact content from uploads-relative storage' );
+$assert_true( $content === ( $hydrated['content'] ?? null ), 'returns exact content bytes' );
+$assert_true( strlen( $content ) === ( $hydrated['bytes'] ?? null ), 'returns verified byte count' );
+$assert_true( hash( 'sha256', $content ) === ( $hydrated['sha256'] ?? null ), 'returns verified sha256' );
+$assert_true( true === ( $hydrated['verified'] ?? false ), 'marks content as verified' );
+$assert_true( ! isset( $hydrated['artifact']['local_debug'] ), 'does not expose local_debug metadata' );
+
+$streamed = '';
+$stream_result = $artifacts->stream_artifact_ref(
+	$artifact_ref,
+	static function ( string $chunk ) use ( &$streamed ): void {
+		$streamed .= $chunk;
+	},
+	$engine_data
+);
+$assert_true( true === ( $stream_result['success'] ?? false ) && $content === $streamed, 'streams verified content through callback' );
+$assert_true( ! isset( $stream_result['content'] ), 'stream result omits hydrated content copy' );
+
+$bad_hash = $engine_data;
+$bad_hash['artifact_files']['result']['sha256'] = str_repeat( '0', 64 );
+$hash_result = $artifacts->hydrate_artifact_ref( $artifact_ref, $bad_hash );
+$assert_true( false === ( $hash_result['success'] ?? true ) && str_contains( (string) ( $hash_result['error'] ?? '' ), 'sha256' ), 'rejects sha256 mismatches' );
+
+$bad_bytes = $engine_data;
+$bad_bytes['artifact_files']['result']['bytes'] = strlen( $content ) + 1;
+$bytes_result = $artifacts->hydrate_artifact_ref( $artifact_ref, $bad_bytes );
+$assert_true( false === ( $bytes_result['success'] ?? true ) && str_contains( (string) ( $bytes_result['error'] ?? '' ), 'byte count' ), 'rejects byte count mismatches' );
+
+$without_storage = $engine_data;
+$without_storage['artifact_files']['result']['relative_path'] = '../outside.json';
+$missing_result = $artifacts->hydrate_artifact_ref( $artifact_ref, $without_storage );
+$assert_true( false === ( $missing_result['success'] ?? true ), 'rejects traversal-shaped storage paths' );
+
+$filtered_content = "filter-storage\n";
+$GLOBALS['datamachine_test_filters']['datamachine_job_artifact_ref_content'] = array(
+	static function ( $value, array $args ) use ( $artifact_ref, $filtered_content ) {
+		return $artifact_ref === ( $args['artifact_ref'] ?? '' ) ? $filtered_content : $value;
+	},
+);
+$filter_engine_data = array(
+	'artifact_files' => array(
+		'filtered' => array(
+			'artifact_ref' => $artifact_ref,
+			'type'         => 'filtered',
+			'sha256'       => hash( 'sha256', $filtered_content ),
+			'bytes'        => strlen( $filtered_content ),
+		),
+	),
+);
+$filter_result = $artifacts->hydrate_artifact_ref( $artifact_ref, $filter_engine_data );
+$assert_true( true === ( $filter_result['success'] ?? false ) && $filtered_content === ( $filter_result['content'] ?? null ), 'filter-backed storage can hydrate without paths or URLs' );
+
+$ability_source = file_get_contents( __DIR__ . '/../inc/Abilities/Job/HydrateJobArtifactAbility.php' ) ?: '';
+$cli_source     = file_get_contents( __DIR__ . '/../inc/Cli/Commands/JobsCommand.php' ) ?: '';
+$bootstrap      = file_get_contents( __DIR__ . '/../data-machine.php' ) ?: '';
+$assert_true( str_contains( $ability_source, "wp_register_ability(\n\t\t\t\t'datamachine/hydrate-job-artifact'" ), 'registers public hydrate-job-artifact ability' );
+$assert_true( str_contains( $ability_source, 'content_base64' ), 'ability returns JSON-safe content payloads' );
+$assert_true( str_contains( $bootstrap, 'new \\DataMachine\\Abilities\\Job\\HydrateJobArtifactAbility();' ), 'plugin bootstrap registers hydrate job artifact ability' );
+$assert_true( str_contains( $cli_source, '@subcommand artifact-content' ), 'jobs CLI exposes artifact-content command' );
+
+if ( $failures ) {
+	echo "=== job-artifact-content-resolver-smoke: " . count( $failures ) . " FAILURE(S) ===\n";
+	foreach ( $failures as $failure ) {
+		echo "  [FAIL] {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "=== job-artifact-content-resolver-smoke: ALL PASS ({$passes} assertions) ===\n";

--- a/tests/job-artifact-content-resolver-smoke.php
+++ b/tests/job-artifact-content-resolver-smoke.php
@@ -145,11 +145,13 @@ $missing_result = $artifacts->hydrate_artifact_ref( $artifact_ref, $without_stor
 $assert_true( false === ( $missing_result['success'] ?? true ), 'rejects traversal-shaped storage paths' );
 
 $filtered_content = "filter-storage\n";
-$GLOBALS['datamachine_test_filters']['datamachine_job_artifact_ref_content'] = array(
-	static function ( $value, array $args ) use ( $artifact_ref, $filtered_content ) {
-		return $artifact_ref === ( $args['artifact_ref'] ?? '' ) ? $filtered_content : $value;
-	},
-);
+$filter_callback = static function ( $value, array $args ) use ( $artifact_ref, $filtered_content ) {
+	return $artifact_ref === ( $args['artifact_ref'] ?? '' ) ? $filtered_content : $value;
+};
+$GLOBALS['datamachine_test_filters']['datamachine_job_artifact_ref_content'] = array( $filter_callback );
+if ( function_exists( 'add_filter' ) ) {
+	add_filter( 'datamachine_job_artifact_ref_content', $filter_callback, 10, 2 );
+}
 $filter_engine_data = array(
 	'artifact_files' => array(
 		'filtered' => array(


### PR DESCRIPTION
## Summary
- Add verified job artifact content hydration by portable artifact_ref.
- Resolve content from uploads-relative artifact storage without requiring absolute local paths or URLs, with a generic filter seam for alternate storage backends.
- Keep local_debug metadata out of public hydration responses.
- Expose hydration through datamachine/hydrate-job-artifact and wp datamachine jobs artifact-content.

## Tests
- php tests/job-artifact-content-resolver-smoke.php
- php tests/job-artifact-surfaces-smoke.php
- php tests/cleanup-cluster-smoke.php
- php -l inc/Core/JobArtifacts.php && php -l inc/Cli/Commands/JobsCommand.php && php -l inc/Abilities/Job/HydrateJobArtifactAbility.php && php -l data-machine.php && php -l tests/job-artifact-content-resolver-smoke.php && php -l tests/cleanup-cluster-smoke.php
- vendor/bin/phpcs inc/Core/JobArtifacts.php inc/Cli/Commands/JobsCommand.php inc/Abilities/Job/HydrateJobArtifactAbility.php data-machine.php tests/job-artifact-content-resolver-smoke.php tests/cleanup-cluster-smoke.php
- composer lint

## Caveats
- composer test currently fails before running Data Machine tests because the local Homeboy lab offload preflight reports: Extension 'wordpress' has no sourceUrl or .source-url metadata, so Homeboy cannot determine where to update it from.
- A related existing smoke, php tests/job-artifact-hashable-smoke.php, fails because it expects write_artifact_file() to return a top-level file.path while current artifact metadata stores paths under local_debug; this PR leaves that unrelated contract unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested Data Machine artifact content resolver.