### PR TITLE
Persist durable run result envelopes

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -121,8 +121,8 @@ class ExecuteStepAbility {
 		// 'pending' → 'processing', ensuring recover-stuck only catches jobs
 		// that genuinely started but never finished.
 		if ( ! $this->db_jobs->start_job( $job_id ) ) {
-			$job_after_start       = $this->db_jobs->get_job( $job_id );
-			$current_status        = is_array( $job_after_start ) ? (string) ( $job_after_start['status'] ?? '' ) : '';
+			$job_after_start      = $this->db_jobs->get_job( $job_id );
+			$current_status       = is_array( $job_after_start ) ? (string) ( $job_after_start['status'] ?? '' ) : '';
 			$terminal_after_start = JobStatus::isStatusFinal( $current_status );
 
 			return array(

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -213,6 +213,20 @@ class ExecuteStepAbility {
 
 			$payload['data'] = $dataPackets;
 			$this->logStepExecutionResult( $execution_result, $job_id, $flow_step_id, $step_type );
+			RunMetrics::recordStepResult(
+				$job_id,
+				$flow_step_id,
+				array(
+					'step_type'    => $step_type,
+					'result'       => $execution_result['status'] ?? ( $step_success ? 'completed' : 'failed' ),
+					'step_success' => $step_success,
+					'packet_count' => $execution_result['packet_count'],
+					'status'       => $execution_result['status'] ?? null,
+					'reason'       => $execution_result['reason'] ?? null,
+					'error'        => $execution_result['error'] ?? null,
+					'step_result'  => $execution_result['step_result'] ?? array(),
+				)
+			);
 
 			// Refresh engine data to capture changes made during step execution.
 			$refreshed_engine_data = datamachine_get_engine_data( $job_id );
@@ -258,6 +272,7 @@ class ExecuteStepAbility {
 					'status'       => $recorded_status,
 					'reason'       => $result['reason'] ?? ( $execution_result['reason'] ?? ( $result['error'] ?? null ) ),
 					'error'        => $result['error'] ?? ( $execution_result['error'] ?? null ),
+					'step_result'  => $execution_result['step_result'] ?? array(),
 				)
 			);
 
@@ -272,6 +287,15 @@ class ExecuteStepAbility {
 					'packet_count' => 0,
 					'reason'       => 'throwable_exception_in_step_execution',
 					'error'        => $e->getMessage(),
+					'step_result'  => \DataMachine\Core\StepResult::fromExecutionResult(
+						array(
+							'status'      => 'failed',
+							'packets'     => array(),
+							'reason'      => 'throwable_exception_in_step_execution',
+							'error'       => $e->getMessage(),
+							'diagnostics' => array( 'flow_step_id' => $flow_step_id ),
+						)
+					),
 				)
 			);
 			do_action(

--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -14,6 +14,10 @@ namespace DataMachine\Core;
 
 defined( 'ABSPATH' ) || exit;
 
+if ( ! class_exists( RunResult::class ) ) {
+	require_once __DIR__ . '/RunResult.php';
+}
+
 class RunMetrics {
 
 	private const KEY = 'run_metrics';
@@ -46,6 +50,10 @@ class RunMetrics {
 
 	private const STEP_RESULTS_KEY = 'step_results';
 
+	private const STEP_RESULT_ENVELOPES_KEY = 'step_result';
+
+	private const RUN_RESULT_KEY = 'run_result';
+
 	public static function recordStepResult( int $job_id, string $flow_step_id, array $result ): bool {
 		if ( $job_id <= 0 || '' === $flow_step_id ) {
 			return false;
@@ -68,6 +76,13 @@ class RunMetrics {
 		);
 
 		$engine[ self::STEP_RESULTS_KEY ] = $step_results;
+		if ( is_array( $clean_result['step_result'] ?? null ) ) {
+			$step_result_envelopes                  = is_array( $engine[ self::STEP_RESULT_ENVELOPES_KEY ] ?? null ) ? $engine[ self::STEP_RESULT_ENVELOPES_KEY ] : array();
+			$step_result_envelope                   = $clean_result['step_result'];
+			$step_result_envelope['flow_step_id'] ??= $flow_step_id;
+			$step_result_envelopes[ $flow_step_id ] = $step_result_envelope;
+			$engine[ self::STEP_RESULT_ENVELOPES_KEY ] = $step_result_envelopes;
+		}
 
 		$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
 		if ( isset( $clean_result['packet_count'] ) && 'fetch' === ( $clean_result['step_type'] ?? '' ) ) {
@@ -113,7 +128,7 @@ class RunMetrics {
 		}
 
 		$engine[ self::KEY ] = $metrics;
-		return EngineData::persist( $job_id, $engine );
+		return EngineData::persist( $job_id, self::withRunResult( $job_id, $engine ) );
 	}
 
 	public static function increment( int $job_id, string $key, int $amount = 1 ): bool {
@@ -162,7 +177,7 @@ class RunMetrics {
 		}
 
 		$engine[ self::KEY ] = $metrics;
-		return EngineData::persist( $job_id, $engine );
+		return EngineData::persist( $job_id, self::withRunResult( $job_id, $engine, $status ) );
 	}
 
 	public static function fromJob( array $job ): array {
@@ -182,7 +197,7 @@ class RunMetrics {
 
 		$outcome_classes = self::outcomeClasses( $job, $engine, $counts );
 
-		return array(
+		$summary = array(
 			'job_id'           => (int) ( $job['job_id'] ?? 0 ),
 			'source'           => $job['source'] ?? null,
 			'label'            => $job['label'] ?? ( $job['display_label'] ?? null ),
@@ -206,6 +221,10 @@ class RunMetrics {
 			'token_usage'      => self::tokenUsage( $engine ),
 			'cost'             => self::cost( $engine ),
 		);
+
+		$summary['run_result'] = is_array( $engine[ self::RUN_RESULT_KEY ] ?? null ) ? $engine[ self::RUN_RESULT_KEY ] : RunResult::fromJobSummary( $job, $summary );
+
+		return $summary;
 	}
 
 	public static function normalize( $metrics ): array {
@@ -492,9 +511,55 @@ class RunMetrics {
 		foreach ( $values as $key => $value ) {
 			if ( is_scalar( $value ) || null === $value ) {
 				$clean[ is_int( $key ) ? $key : (string) $key ] = $value;
+			} elseif ( is_array( $value ) ) {
+				$clean[ is_int( $key ) ? $key : (string) $key ] = self::sanitizeList( $value );
 			}
 		}
 		return $clean;
+	}
+
+	private static function withRunResult( int $job_id, array $engine, ?string $status_override = null ): array {
+		$job = self::jobForEnvelope( $job_id, $engine, $status_override );
+		if ( null === $job ) {
+			return $engine;
+		}
+
+		unset( $engine[ self::RUN_RESULT_KEY ] );
+		$job['engine_data']              = $engine;
+		$summary                         = self::fromJob( $job );
+		$engine[ self::RUN_RESULT_KEY ] = RunResult::fromJobSummary( $job, $summary );
+
+		return $engine;
+	}
+
+	private static function jobForEnvelope( int $job_id, array $engine, ?string $status_override = null ): ?array {
+		global $wpdb;
+		if ( $job_id <= 0 || ! is_object( $wpdb ) ) {
+			return null;
+		}
+
+		$table = $wpdb->prefix . 'datamachine_jobs';
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQLPlaceholders, WordPress.DB.PreparedSQL -- Data Machine owns the jobs table and needs fresh job state for durable result envelopes.
+		$job = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM {$table} WHERE job_id = %d LIMIT 1",
+				$job_id
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQLPlaceholders, WordPress.DB.PreparedSQL
+
+		if ( ! is_array( $job ) ) {
+			$job = is_array( $engine['job'] ?? null ) ? $engine['job'] : array( 'job_id' => $job_id );
+		}
+
+		if ( null !== $status_override ) {
+			$job['status'] = $status_override;
+		}
+
+		$job['engine_data'] = $engine;
+
+		return $job;
 	}
 
 	private static function childTotals( int $job_id ): array {

--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -77,10 +77,10 @@ class RunMetrics {
 
 		$engine[ self::STEP_RESULTS_KEY ] = $step_results;
 		if ( is_array( $clean_result['step_result'] ?? null ) ) {
-			$step_result_envelopes                  = is_array( $engine[ self::STEP_RESULT_ENVELOPES_KEY ] ?? null ) ? $engine[ self::STEP_RESULT_ENVELOPES_KEY ] : array();
-			$step_result_envelope                   = $clean_result['step_result'];
-			$step_result_envelope['flow_step_id'] ??= $flow_step_id;
-			$step_result_envelopes[ $flow_step_id ] = $step_result_envelope;
+			$step_result_envelopes                     = is_array( $engine[ self::STEP_RESULT_ENVELOPES_KEY ] ?? null ) ? $engine[ self::STEP_RESULT_ENVELOPES_KEY ] : array();
+			$step_result_envelope                      = $clean_result['step_result'];
+			$step_result_envelope['flow_step_id']    ??= $flow_step_id;
+			$step_result_envelopes[ $flow_step_id ]    = $step_result_envelope;
 			$engine[ self::STEP_RESULT_ENVELOPES_KEY ] = $step_result_envelopes;
 		}
 
@@ -525,8 +525,8 @@ class RunMetrics {
 		}
 
 		unset( $engine[ self::RUN_RESULT_KEY ] );
-		$job['engine_data']              = $engine;
-		$summary                         = self::fromJob( $job );
+		$job['engine_data']             = $engine;
+		$summary                        = self::fromJob( $job );
 		$engine[ self::RUN_RESULT_KEY ] = RunResult::fromJobSummary( $job, $summary );
 
 		return $engine;

--- a/inc/Core/RunResult.php
+++ b/inc/Core/RunResult.php
@@ -7,10 +7,12 @@
 
 namespace DataMachine\Core;
 
+use DataMachine\Core\Database\Jobs\Jobs;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Builds the canonical result envelope for a deterministic run.
+ * Builds the canonical result envelope for a job/run.
  */
 class RunResult {
 
@@ -40,6 +42,226 @@ class RunResult {
 			'diagnostics'    => $diagnostics,
 			'replay'         => self::buildReplayMetadata( $steps, $outputs, $artifact_refs, $packet_refs, is_array( $context['replay'] ?? null ) ? $context['replay'] : array() ),
 			'steps'          => $steps,
+		);
+	}
+
+	/**
+	 * Build a portable run result envelope from a job row and its metrics summary.
+	 *
+	 * @param array<string,mixed> $job     Job row.
+	 * @param array<string,mixed> $summary RunMetrics::fromJob() summary.
+	 * @return array<string,mixed>
+	 */
+	public static function fromJobSummary( array $job, array $summary ): array {
+		$engine       = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$step_results = self::stepResultEnvelopes( $summary['step_results'] ?? array(), $engine );
+
+		return self::filterNull(
+			array(
+				'schema_version'      => self::SCHEMA_VERSION,
+				'job'                 => self::jobRef( $job, $summary ),
+				'status'              => (string) ( $summary['status'] ?? ( $job['status'] ?? '' ) ),
+				'outputs'             => self::outputs( $summary ),
+				'artifact_refs'       => array_values( JobArtifactSurfaces::artifactRefs( $engine ) ),
+				'packet_refs'         => self::packetRefs( $step_results ),
+				'step_results'        => $step_results,
+				'child_job_refs'      => self::childJobRefs( (int) ( $job['job_id'] ?? 0 ) ),
+				'child_job_envelopes' => self::childJobEnvelopes( (int) ( $job['job_id'] ?? 0 ) ),
+				'diagnostics'         => self::diagnostics( $summary ),
+				'replay'              => array(
+					'content_hashes' => array(
+						'outputs'       => self::contentHash( self::outputs( $summary ) ),
+						'artifact_refs' => self::contentHash( array_values( JobArtifactSurfaces::artifactRefs( $engine ) ) ),
+						'packet_refs'   => self::contentHash( self::packetRefs( $step_results ) ),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $job
+	 * @param array<string,mixed> $summary
+	 * @return array<string,mixed>
+	 */
+	private static function jobRef( array $job, array $summary ): array {
+		return self::filterNull(
+			array(
+				'job_id'        => (int) ( $summary['job_id'] ?? ( $job['job_id'] ?? 0 ) ),
+				'source'        => $summary['source'] ?? ( $job['source'] ?? null ),
+				'label'         => $summary['label'] ?? ( $job['label'] ?? null ),
+				'flow_id'       => $summary['flow_id'] ?? ( $job['flow_id'] ?? null ),
+				'pipeline_id'   => $summary['pipeline_id'] ?? ( $job['pipeline_id'] ?? null ),
+				'parent_job_id' => (int) ( $summary['parent_job_id'] ?? ( $job['parent_job_id'] ?? 0 ) ),
+			)
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $summary
+	 * @return array<string,mixed>
+	 */
+	private static function outputs( array $summary ): array {
+		return self::filterNull(
+			array(
+				'counts'           => is_array( $summary['counts'] ?? null ) ? $summary['counts'] : array(),
+				'outcome'          => is_array( $summary['outcome'] ?? null ) ? $summary['outcome'] : array(),
+				'outcome_classes'  => is_array( $summary['outcome_classes'] ?? null ) ? array_values( $summary['outcome_classes'] ) : array(),
+				'child_jobs'       => is_array( $summary['child_jobs'] ?? null ) ? $summary['child_jobs'] : array(),
+				'token_usage'      => is_array( $summary['token_usage'] ?? null ) ? $summary['token_usage'] : array(),
+				'cost'             => is_array( $summary['cost'] ?? null ) ? $summary['cost'] : array(),
+				'duration_seconds' => $summary['duration_seconds'] ?? null,
+				'timestamps'       => is_array( $summary['timestamps'] ?? null ) ? $summary['timestamps'] : array(),
+			)
+		);
+	}
+
+	/**
+	 * @param mixed               $step_results Legacy step result rows.
+	 * @param array<string,mixed> $engine       Engine data.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function stepResultEnvelopes( $step_results, array $engine ): array {
+		$envelopes = array();
+		$canonical = is_array( $engine['step_result'] ?? null ) ? $engine['step_result'] : array();
+
+		foreach ( is_array( $step_results ) ? $step_results : array() as $step_result ) {
+			if ( ! is_array( $step_result ) ) {
+				continue;
+			}
+
+			$envelope = is_array( $step_result['step_result'] ?? null ) ? $step_result['step_result'] : array();
+			$step_id  = is_scalar( $step_result['flow_step_id'] ?? null ) ? (string) $step_result['flow_step_id'] : '';
+			if ( array() === $envelope && '' !== $step_id && is_array( $canonical[ $step_id ] ?? null ) ) {
+				$envelope = $canonical[ $step_id ];
+			}
+			if ( array() === $envelope ) {
+				$envelope = StepResult::fromExecutionResult(
+					array(
+						'status'      => is_scalar( $step_result['result'] ?? null ) ? (string) $step_result['result'] : (string) ( $step_result['status'] ?? 'failed' ),
+						'packets'     => array(),
+						'reason'      => is_scalar( $step_result['reason'] ?? null ) ? (string) $step_result['reason'] : '',
+						'error'       => is_scalar( $step_result['error'] ?? null ) ? (string) $step_result['error'] : null,
+						'diagnostics' => array(
+							'flow_step_id' => $step_id,
+							'step_type'    => is_scalar( $step_result['step_type'] ?? null ) ? (string) $step_result['step_type'] : '',
+						),
+					),
+					array(
+						'outputs' => array(
+							'packet_count' => (int) ( $step_result['packet_count'] ?? 0 ),
+						),
+					)
+				);
+			}
+
+			if ( array() !== $envelope ) {
+				if ( '' !== $step_id && ! isset( $envelope['flow_step_id'] ) ) {
+					$envelope['flow_step_id'] = $step_id;
+				}
+				$envelopes[] = $envelope;
+			}
+		}
+
+		return $envelopes;
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $step_results Step result envelopes.
+	 * @return array<int,mixed>
+	 */
+	private static function packetRefs( array $step_results ): array {
+		$refs = array();
+		foreach ( $step_results as $step_result ) {
+			foreach ( is_array( $step_result['packet_refs'] ?? null ) ? $step_result['packet_refs'] : array() as $packet_ref ) {
+				$refs[] = $packet_ref;
+			}
+		}
+
+		return $refs;
+	}
+
+	/**
+	 * @param int $job_id Parent job ID.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function childJobRefs( int $job_id ): array {
+		$refs = array();
+		foreach ( self::childJobs( $job_id ) as $child ) {
+			$refs[] = self::filterNull(
+				array(
+					'job_id' => (int) ( $child['job_id'] ?? 0 ),
+					'status' => $child['status'] ?? null,
+					'label'  => $child['label'] ?? null,
+				)
+			);
+		}
+
+		return $refs;
+	}
+
+	/**
+	 * @param int $job_id Parent job ID.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function childJobEnvelopes( int $job_id ): array {
+		$envelopes = array();
+		foreach ( self::childJobs( $job_id ) as $child ) {
+			$engine = is_array( $child['engine_data'] ?? null ) ? $child['engine_data'] : array();
+			if ( is_array( $engine['run_result'] ?? null ) ) {
+				$envelopes[] = $engine['run_result'];
+			}
+		}
+
+		return $envelopes;
+	}
+
+	/**
+	 * @param int $job_id Parent job ID.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function childJobs( int $job_id ): array {
+		if ( $job_id <= 0 ) {
+			return array();
+		}
+
+		global $wpdb;
+		if ( ! is_object( $wpdb ) ) {
+			return array();
+		}
+
+		$table = $wpdb->prefix . 'datamachine_jobs';
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQLPlaceholders, WordPress.DB.PreparedSQL -- Data Machine owns the jobs table and needs fresh child state for terminal envelopes.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT job_id FROM {$table} WHERE parent_job_id = %d ORDER BY job_id ASC",
+				$job_id
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQLPlaceholders, WordPress.DB.PreparedSQL
+
+		$jobs = new Jobs();
+		$out  = array();
+		foreach ( is_array( $rows ) ? $rows : array() as $row ) {
+			$child = $jobs->get_job( (int) ( $row['job_id'] ?? 0 ) );
+			if ( is_array( $child ) ) {
+				$out[] = $child;
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * @param array<string,mixed> $summary Run summary.
+	 * @return array<string,mixed>
+	 */
+	private static function diagnostics( array $summary ): array {
+		return self::filterNull(
+			array(
+				'context' => is_array( $summary['context'] ?? null ) ? $summary['context'] : array(),
+			)
 		);
 	}
 
@@ -109,26 +331,17 @@ class RunResult {
 	}
 
 	/**
-	 * Compute a stable SHA-256 hash for JSON-serializable content.
-	 *
 	 * @param mixed $value Value to hash.
-	 * @return string Content hash.
+	 * @return string
 	 */
 	private static function contentHash( $value ): string {
 		$encoded = wp_json_encode( self::sortKeysRecursive( $value ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-
-		if ( ! is_string( $encoded ) ) {
-			$encoded = '';
-		}
-
-		return 'sha256:' . hash( 'sha256', $encoded );
+		return 'sha256:' . hash( 'sha256', is_string( $encoded ) ? $encoded : '' );
 	}
 
 	/**
-	 * Sort associative array keys recursively for stable hashes.
-	 *
 	 * @param mixed $value Value to normalize.
-	 * @return mixed Normalized value.
+	 * @return mixed
 	 */
 	private static function sortKeysRecursive( $value ) {
 		if ( ! is_array( $value ) ) {
@@ -145,5 +358,16 @@ class RunResult {
 		}
 
 		return $value;
+	}
+
+	/**
+	 * @param array<string,mixed> $values Values to filter.
+	 * @return array<string,mixed>
+	 */
+	private static function filterNull( array $values ): array {
+		return array_filter(
+			$values,
+			static fn( $value ) => null !== $value
+		);
 	}
 }

--- a/tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php
@@ -250,6 +250,20 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
         $this->assertSame('inline_continuation', $fetch_result['outcome'] ?? '');
         $this->assertSame('flow_ai', $this->_latestScheduledStep()['flow_step_id'] ?? '');
 
+		$engine_after_fetch = datamachine_get_engine_data($job_id);
+		$this->assertSame(
+			'datamachine.step_result.v1',
+			$engine_after_fetch['step_result']['flow_fetch']['schema_version'] ?? ''
+		);
+		$this->assertSame(
+			'datamachine.step_result.v1',
+			$engine_after_fetch['step_results']['flow_fetch']['step_result']['schema_version'] ?? ''
+		);
+		$this->assertSame(
+			'datamachine.run_result.v1',
+			$engine_after_fetch['run_result']['schema_version'] ?? ''
+		);
+
         $ai_result = $executor->execute(
             array(
                 'job_id'       => $job_id,
@@ -297,6 +311,11 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
             $engine_after_ai['token_usage'] ?? array()
         );
         $this->assertSame('preserved', $engine_after_ai['fake_handler_written_key'] ?? '');
+		$this->assertSame(
+			'datamachine.step_result.v1',
+			$engine_after_ai['step_result']['flow_ai']['schema_version'] ?? ''
+		);
+		$this->assertNotEmpty($engine_after_ai['step_result']['flow_ai']['packet_refs'] ?? array());
 
         $publish_result = $executor->execute(
             array(
@@ -314,6 +333,15 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
 
         $job = (new Jobs())->get_job($job_id);
         $this->assertSame(JobStatus::COMPLETED, $job['status'] ?? '');
+
+		$completed_engine = datamachine_get_engine_data($job_id);
+		$this->assertSame(
+			'datamachine.run_result.v1',
+			$completed_engine['run_result']['schema_version'] ?? ''
+		);
+		$this->assertSame(JobStatus::COMPLETED, $completed_engine['run_result']['status'] ?? '');
+		$this->assertCount(3, $completed_engine['run_result']['step_results'] ?? array());
+		$this->assertNotEmpty($completed_engine['run_result']['packet_refs'] ?? array());
     }
 
     /**

--- a/tests/Unit/Abilities/Engine/RunFlowAbilityLifecycleTest.php
+++ b/tests/Unit/Abilities/Engine/RunFlowAbilityLifecycleTest.php
@@ -79,4 +79,56 @@ class RunFlowAbilityLifecycleTest extends WP_UnitTestCase {
 		$this->assertNotEmpty( $job );
 		$this->assertSame( JobStatus::failed( 'no_first_step' )->toString(), $job['status'] ?? '' );
 	}
+
+	public function test_completed_parent_run_result_includes_available_child_envelopes(): void {
+		$jobs = new Jobs();
+
+		$parent_job_id = $jobs->create_job(
+			array(
+				'source' => 'pipeline',
+				'label'  => 'Parent run result envelope test',
+			)
+		);
+		$this->assertIsInt( $parent_job_id );
+
+		$child_job_id = $jobs->create_job(
+			array(
+				'source'        => 'pipeline',
+				'label'         => 'Child run result envelope test',
+				'parent_job_id' => $parent_job_id,
+			)
+		);
+		$this->assertIsInt( $child_job_id );
+
+		datamachine_set_engine_data(
+			$child_job_id,
+			array(
+				'job'        => array( 'job_id' => $child_job_id ),
+				'run_result' => array(
+					'schema_version' => 'datamachine.run_result.v1',
+					'job'            => array( 'job_id' => $child_job_id ),
+					'status'         => JobStatus::COMPLETED,
+				),
+			)
+		);
+
+		datamachine_set_engine_data(
+			$parent_job_id,
+			array(
+				'job'           => array( 'job_id' => $parent_job_id ),
+				'batch_results' => array(
+					'completed' => 1,
+					'failed'    => 0,
+					'skipped'   => 0,
+					'total'     => 1,
+				),
+			)
+		);
+
+		$this->assertTrue( $jobs->complete_job( $parent_job_id, JobStatus::COMPLETED ) );
+
+		$parent_engine = datamachine_get_engine_data( $parent_job_id );
+		$this->assertSame( 'datamachine.run_result.v1', $parent_engine['run_result']['schema_version'] ?? '' );
+		$this->assertSame( $child_job_id, $parent_engine['run_result']['child_job_envelopes'][0]['job']['job_id'] ?? 0 );
+	}
 }


### PR DESCRIPTION
## Summary
- Persist canonical `step_result` envelopes in engine data alongside legacy `step_results` metrics.
- Persist canonical `run_result` envelopes for in-progress and terminal job summaries, including packet refs, artifact refs, and available child job run envelopes.
- Preserve legacy metrics/status fields and the existing `RunResult::fromStepResults()` API.

## Testing
- `php -l inc/Core/RunResult.php && php -l inc/Core/RunMetrics.php && php -l inc/Abilities/Engine/ExecuteStepAbility.php`
- `composer test`
- `composer lint`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested durable Data Machine result envelopes.
