### PR TITLE
Remove runtime-specific bundle metadata fallback

### DIFF
--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -215,10 +215,7 @@ final class AgentBundleRunner {
 		$ability_tools = is_array( $input['ability_tools'] ?? null ) ? $input['ability_tools'] : array();
 		if ( empty( $ability_tools ) ) {
 			$metadata_tools = DataPath::value( $bundle, 'metadata.agent_runtime.ability_tools' );
-			if ( ! is_array( $metadata_tools ) ) {
-				$metadata_tools = DataPath::value( $bundle, 'metadata.codebox.agent_runtime.bundle.ability_tools' );
-			}
-			$ability_tools = is_array( $metadata_tools ) ? $metadata_tools : array();
+			$ability_tools  = is_array( $metadata_tools ) ? $metadata_tools : array();
 		}
 		if ( empty( $ability_tools ) ) {
 			return;
@@ -590,7 +587,18 @@ final class AgentBundleRunner {
 			$import_input
 		);
 
-		$imports = wp_agent_import_runtime_bundles( $bundle_specs, $import_input );
+		if ( ! function_exists( '\wp_agent_import_runtime_bundles' ) ) {
+			return array(
+				'required' => true,
+				'success'  => false,
+				'status'   => 'unavailable',
+				'imports'  => array(),
+				'failed'   => array(),
+				'error'    => 'The generic runtime bundle importer is unavailable.',
+			);
+		}
+
+		$imports = \wp_agent_import_runtime_bundles( $bundle_specs, $import_input );
 
 		$failed = array_values(
 			array_filter(

--- a/tests/Unit/AI/Tools/SandboxOptInToolResolutionTest.php
+++ b/tests/Unit/AI/Tools/SandboxOptInToolResolutionTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Tests that an opt-in ability-projected tool (the shape DMC uses for
- * workspace_write) resolves for a Codebox sandbox run when the runtime
+ * workspace_write) resolves for a sandbox run when the runtime
  * declares it via allow_only / an allow-mode tool policy.
  *
  * Data Machine has no sandbox-specific knowledge: 'sandbox' is just an unknown
@@ -45,7 +45,7 @@ class SandboxOptInToolResolutionTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The argument shape a Codebox sandbox run passes through ChatOrchestrator.
+	 * The argument shape a sandbox run passes through ChatOrchestrator.
 	 */
 	private function sandboxArgs(): array {
 		return array(

--- a/tests/Unit/Abilities/Media/MediaAbilitiesTest.php
+++ b/tests/Unit/Abilities/Media/MediaAbilitiesTest.php
@@ -164,13 +164,13 @@ class MediaAbilitiesTest extends WP_UnitTestCase {
 	 */
 	public function test_video_metadata_returns_structure(): void {
 		// Write the fixture with the PHP filesystem primitive rather than the
-		// $wp_filesystem global: the WP Codebox / Playground test runner does not
+		// $wp_filesystem global: the headless test runner does not
 		// initialize $wp_filesystem, so $wp_filesystem->put_contents() is a call
 		// on null there (see #2506). VideoMetadata::extract() reads the real bytes
 		// off disk regardless of how they were written, so this fixture is
 		// equivalent while being environment-agnostic.
 		$temp_file = tempnam( sys_get_temp_dir(), 'dm-video-test-' );
-		file_put_contents( $temp_file, str_repeat( 'x', 100 ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture on the local temp dir; $wp_filesystem is unavailable in the Codebox/Playground runner (#2506).
+		file_put_contents( $temp_file, str_repeat( 'x', 100 ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture on the local temp dir; $wp_filesystem is unavailable in the headless runner (#2506).
 
 		$result = $this->abilities->executeVideoMetadata( array(
 			'path' => $temp_file,

--- a/tests/Unit/Engine/AI/RequestBuilderMultimodalTest.php
+++ b/tests/Unit/Engine/AI/RequestBuilderMultimodalTest.php
@@ -318,7 +318,7 @@ class RequestBuilderMultimodalTest extends TestCase {
 
 		// The slashed logical tool name is not provider-safe (OpenAI/Responses
 		// require ^[a-zA-Z0-9_-]+$). The provider declares it with a safe name
-		// (e.g. wp-codebox normalises `client/filesystem-write` → `filesystem_write`),
+		// (e.g. some runtimes normalize `client/filesystem-write` to `filesystem_write`),
 		// and RequestBuilder carries that mapping via the alias table built from
 		// the structured tool declarations. The transcript converter must rewrite
 		// the logical name to the provider-safe alias so replayed function call /

--- a/tests/abilities-categories-load-order-smoke.php
+++ b/tests/abilities-categories-load-order-smoke.php
@@ -113,7 +113,7 @@ $assert(
 // add_action/wp_register_ability_category) to drive AbilityCategories through
 // its three timing states. Those stubs are only installed when the real
 // functions are absent (`if ( ! function_exists() )`), so under a real
-// WordPress runtime — e.g. the wp-codebox host-smoke harness — they are inert:
+// WordPress runtime they are inert:
 // `doing_action( 'wp_abilities_api_categories_init' )` reflects the live
 // dispatch state (false during the test) and the simulation can't control it,
 // which made state 1 fail spuriously. The source-string assertions above
@@ -181,7 +181,7 @@ if ( ! function_exists( 'wp_register_ability_category' ) ) {
 }
 
 // Minimal fake of the category registry so the late-registration path
-// (headless / WP Codebox sandbox load order — plugin included AFTER the
+// (headless sandbox load order — plugin included AFTER the
 // one-shot `wp_abilities_api_categories_init` fired) can be exercised. Mirrors
 // core: `WP_Ability_Categories_Registry::register()` has NO lifecycle guard —
 // only the `wp_register_ability_category()` wrapper does.
@@ -249,7 +249,7 @@ $assert(
 		&& empty( $state->registered )
 );
 
-// --- State 3: post-action (headless / WP Codebox sandbox load order).
+// --- State 3: post-action (headless sandbox load order).
 // The one-shot `wp_abilities_api_categories_init` already fired during
 // `wp-load.php` before `run-php` included the plugin file. Categories must
 // register late via the registry instance so category-bound abilities (e.g.

--- a/tests/abilities-image-template-load-order-smoke.php
+++ b/tests/abilities-image-template-load-order-smoke.php
@@ -112,7 +112,7 @@ $assert(
 //
 // The stubs below (doing_action/did_action/add_action/wp_register_ability) are
 // only installed when the real functions are absent, so under a real WordPress
-// runtime — e.g. the wp-codebox host-smoke harness — they are inert and the
+// runtime they are inert and the
 // simulation cannot control `doing_action()`, making state 1 fail spuriously.
 // The source-string assertions above lock the real contract in every backend
 // and the behavioral path is covered in the pure-PHP / PHPUnit context, so skip

--- a/tests/abilities-send-email-load-order-smoke.php
+++ b/tests/abilities-send-email-load-order-smoke.php
@@ -85,7 +85,7 @@ foreach ( array( 'send-email' => $send_source, 'send-email-queued' => $queue_sou
 
 // The behavioral simulation below stubs WordPress lifecycle functions, which
 // are only installed when the real ones are absent. Under a real WordPress
-// runtime — e.g. the wp-codebox host-smoke harness — those stubs are inert and
+// runtime those stubs are inert and
 // the simulation cannot control `doing_action()`, making state 1 fail
 // spuriously. The source-string assertions above lock the real contract in
 // every backend and the behavioral path is covered in the pure-PHP / PHPUnit

--- a/tests/agent-abilities-late-registration-smoke.php
+++ b/tests/agent-abilities-late-registration-smoke.php
@@ -5,8 +5,8 @@
  * Run with: php tests/agent-abilities-late-registration-smoke.php
  *
  * Runs in two modes:
- *  - Real WordPress runtime (e.g. the wp-codebox host-smoke-wp backend, which
- *    boots WordPress and includes the plugin): assert the canonical
+ *  - Real WordPress runtime (which boots WordPress and includes the plugin):
+ *    assert the canonical
  *    `datamachine/run-agent-bundle` ability is registered. This is the headless
  *    sandbox load order (`run-php` boots WP, then includes the plugin file) that
  *    must resolve the ability — see Extra-Chill/data-machine#2629.
@@ -19,13 +19,13 @@ namespace {
 	// exist, so the pure-PHP stubs below must NOT be declared (they would fatal
 	// with "Cannot redeclare"). Assert the real registration outcome and return.
 	if ( function_exists( 'wp_get_ability' ) ) {
-		// Real WordPress runtime (e.g. the wp-codebox host-smoke-wp backend).
+		// Real WordPress runtime.
 		// The harness boots a bare WordPress with the plugin DIRECTORY mounted
 		// but NOT activated, so load the agent ability registration the same
 		// unconditional way data-machine.php does at file scope, then assert the
 		// ability resolves through `wp_get_ability()` (which lazily fires
 		// `wp_abilities_api_init`). This exercises the real registration code
-		// path the WP Codebox sandbox depends on for `datamachine/run-agent-bundle`.
+		// path headless sandbox runs depend on for `datamachine/run-agent-bundle`.
 		if ( ! class_exists( '\DataMachine\Abilities\AgentAbilities' ) ) {
 			require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 			require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityCategories.php';
@@ -91,7 +91,7 @@ namespace {
 	}
 
 	// Minimal fake of the abilities registry so the late-registration path
-	// (headless / WP Codebox sandbox load order, where the plugin file is
+	// (headless sandbox load order, where the plugin file is
 	// included AFTER `wp_abilities_api_init` has already fired) can be
 	// exercised. Mirrors core: `WP_Abilities_Registry::register()` has NO
 	// lifecycle guard — only the `wp_register_ability()` wrapper does.
@@ -178,7 +178,7 @@ namespace {
 	$registered = array_keys( $GLOBALS['datamachine_test_state']->registered );
 	$assert( 'normal bootstrap registers agent bundle/import abilities during wp_abilities_api_init', in_array( 'datamachine/import-agent', $registered, true ) && in_array( 'datamachine/run-agent-bundle', $registered, true ) );
 
-	// Headless / WP Codebox sandbox load order: `run-php` boots WordPress
+	// Headless sandbox load order: `run-php` boots WordPress
 	// through `wp-load.php` (firing the one-shot `wp_abilities_api_init`) and
 	// only THEN includes the plugin file. The constructor must register
 	// immediately through the registry instance — NOT silently no-op, which was

--- a/tests/agent-abilities-registration-smoke.php
+++ b/tests/agent-abilities-registration-smoke.php
@@ -13,12 +13,12 @@ namespace {
 	}
 
 	if ( function_exists( 'wp_get_ability' ) ) {
-		// Real WordPress runtime (e.g. the wp-codebox host-smoke-wp backend).
+		// Real WordPress runtime.
 		// The harness boots a bare WordPress with the plugin DIRECTORY mounted
 		// but NOT activated, so Data Machine's normal `plugins_loaded`
-		// registration never runs. This mirrors the WP Codebox sandbox case the
-		// fix targets: a runtime task that needs `datamachine/run-agent-bundle`
-		// must be able to register it on demand, regardless of request shape.
+		// registration never runs. This mirrors headless sandbox tasks that need
+		// `datamachine/run-agent-bundle` to register on demand, regardless of
+		// request shape.
 		//
 		// Load the agent ability registration the same unconditional way
 		// data-machine.php does at file scope, then assert the ability resolves.
@@ -53,7 +53,7 @@ namespace {
 	$GLOBALS['agent_abilities_registered_abilities'] = array();
 
 	// Minimal fake of the WordPress abilities registry so the late-registration
-	// path (used in headless / WP Codebox sandbox load order, where the plugin
+	// path (used in headless sandbox load order, where the plugin
 	// is included AFTER `wp_abilities_api_init` has already fired) can be
 	// exercised without a full WordPress runtime. Mirrors how
 	// `WP_Abilities_Registry::register()` has NO lifecycle guard — only the
@@ -173,7 +173,7 @@ namespace {
 	$GLOBALS['agent_abilities_doing_action'] = false;
 	agent_abilities_assert( isset( $GLOBALS['agent_abilities_registered_abilities']['datamachine/run-agent-bundle'] ), 'run-agent-bundle registers during wp_abilities_api_init' );
 
-	// Headless / WP Codebox sandbox load order: `run-php` boots WordPress
+	// Headless sandbox load order: `run-php` boots WordPress
 	// through `wp-load.php` (firing the one-shot `wp_abilities_api_init`) and
 	// only THEN includes the plugin file. The constructor sees the action has
 	// already completed and must register immediately through the registry

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -238,7 +238,7 @@ datamachine_bundle_runner_assert( true === $success_status->invoke( null, 'compl
 datamachine_bundle_runner_assert( true === $success_status->invoke( null, 'completed_no_items' ), 'completed_no_items follows JobStatus success semantics', $failures, $passes );
 datamachine_bundle_runner_assert( true === $success_status->invoke( null, 'agent_skipped - no matching source items' ), 'agent_skipped-prefixed status follows JobStatus success semantics', $failures, $passes );
 
-echo "\n[3b] Runtime ability tools prefer generic metadata\n";
+echo "\n[3b] Runtime ability tools consume generic metadata only\n";
 $apply_runtime_ability_tools = $runner_reflection->getMethod( 'apply_runtime_ability_tools' );
 $initial_data                = array();
 $apply_runtime_ability_tools->invokeArgs(
@@ -251,18 +251,11 @@ $apply_runtime_ability_tools->invokeArgs(
 				'agent_runtime' => array(
 					'ability_tools' => array( array( 'name' => 'datamachine/generic-tool' ) ),
 				),
-				'codebox'       => array(
-					'agent_runtime' => array(
-						'bundle' => array(
-							'ability_tools' => array( array( 'name' => 'datamachine/codebox-tool' ) ),
-						),
-					),
-				),
 			),
 		)
 	)
 );
-datamachine_bundle_runner_assert( 'datamachine/generic-tool' === ( $initial_data['job']['ability_tools'][0]['name'] ?? null ), 'generic agent_runtime ability tools win over deprecated codebox metadata', $failures, $passes );
+datamachine_bundle_runner_assert( 'datamachine/generic-tool' === ( $initial_data['job']['ability_tools'][0]['name'] ?? null ), 'generic agent_runtime ability tools are consumed from bundle metadata', $failures, $passes );
 
 $initial_data = array();
 $apply_runtime_ability_tools->invokeArgs(
@@ -272,18 +265,16 @@ $apply_runtime_ability_tools->invokeArgs(
 		array(),
 		array(
 			'metadata' => array(
-				'codebox' => array(
+				'runtime' => array(
 					'agent_runtime' => array(
-						'bundle' => array(
-							'ability_tools' => array( array( 'name' => 'datamachine/codebox-tool' ) ),
-						),
+						'ability_tools' => array( array( 'name' => 'datamachine/runtime-specific-tool' ) ),
 					),
 				),
 			),
 		)
 	)
 );
-datamachine_bundle_runner_assert( 'datamachine/codebox-tool' === ( $initial_data['job']['ability_tools'][0]['name'] ?? null ), 'deprecated codebox ability tools remain compatible fallback', $failures, $passes );
+datamachine_bundle_runner_assert( empty( $initial_data['job']['ability_tools'] ?? array() ), 'runtime-specific metadata namespaces are ignored by the generic runner', $failures, $passes );
 
 echo "\n[3c] Successful tool results can be recorded into engine data\n";
 require_once $root . '/inc/Engine/AI/conversation-loop.php';
@@ -586,7 +577,6 @@ foreach ( array(
 	"'ability_tools'       => array("                                           => 'run-agent-bundle schema accepts runtime ability tools',
 	'apply_runtime_model_config'                                              => 'runner projects provider/model into initial data',
 	'apply_runtime_ability_tools'                                             => 'runner projects ability tools into initial data',
-	'metadata.codebox.agent_runtime.bundle.ability_tools'                     => 'runner consumes bundle metadata ability tools fallback',
 	"\$job_snapshot['ability_tools']"                                         => 'runner stamps job-scoped ability tool declarations',
 	"\$job_snapshot['default_provider']"                                      => 'runner stamps job-scoped default provider',
 	"\$job_snapshot['default_model']"                                         => 'runner stamps job-scoped default model',
@@ -599,7 +589,7 @@ foreach ( array(
 }
 
 echo "\n[6] Boundary stays generic\n";
-foreach ( array( 'homeboy', 'wp-codebox' ) as $forbidden ) {
+foreach ( array( 'homeboy' ) as $forbidden ) {
 	datamachine_bundle_runner_assert( false === stripos( $runner, $forbidden ), "runner does not mention {$forbidden}", $failures, $passes );
 }
 foreach ( array( 'DataMachine\\Core\\Database\\Agents', 'DataMachine\\Core\\Database\\Flows', 'DataMachine\\Core\\Database\\Pipelines' ) as $forbidden ) {

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -49,7 +49,7 @@ if ( ! function_exists( 'datamachine_merge_engine_data' ) ) {
 	}
 }
 
-// Under a real WordPress runtime (e.g. the wp-codebox smoke harness) the
+// Under a real WordPress runtime the
 // do_action stub above is never defined, so bridge the hooks this test
 // observes into the same capture buffer via real add_action.
 if ( defined( 'WPINC' ) ) {

--- a/tests/agents-chat-access-permission-smoke.php
+++ b/tests/agents-chat-access-permission-smoke.php
@@ -130,7 +130,7 @@ namespace {
 
 	$GLOBALS['datamachine_agents_chat_access_grants'] = array( 'wiki-brain' => false );
 	$assert_same( true, $handler->checkPermission( true, array( 'agent' => 'wiki-brain' ) ), 'explicit upstream admin/operator override can chat with the agent' );
-	$assert_same( true, $handler->checkPermission( true, array( 'agent' => 'wp-codebox-sandbox' ) ), 'explicit upstream runtime-principal override is preserved for runtime agent slugs' );
+	$assert_same( true, $handler->checkPermission( true, array( 'agent' => 'headless-runtime-sandbox' ) ), 'explicit upstream runtime-principal override is preserved for runtime agent slugs' );
 
 	$GLOBALS['datamachine_agents_chat_access_broad_chat'] = true;
 	$GLOBALS['datamachine_agents_chat_access_grants']     = array( 'wiki-brain' => false );

--- a/tests/bfb-substrate-bundle-smoke.php
+++ b/tests/bfb-substrate-bundle-smoke.php
@@ -218,7 +218,7 @@ $bfb_ability_names = array(
  *    that capture registrations into `$GLOBALS` arrays. We fire the bundle's
  *    registration callbacks by hand and assert against those recorders.
  *
- *  - Real WordPress (wp-codebox CI harness): WP core defines the abilities API and
+ *  - Real WordPress CI harness: WP core defines the abilities API and
  *    fires `wp_abilities_api_*_init` during normal init, so the BFB bundle has
  *    already registered into WP's real registry before this smoke runs. The
  *    pure-PHP recorders are never populated (registrations go through core), so we

--- a/tests/chat-session-canonical-path-smoke.php
+++ b/tests/chat-session-canonical-path-smoke.php
@@ -52,11 +52,6 @@ $assert(
 );
 
 $assert(
-	false === strpos( $bootstrap, 'wp_codebox_' ) && false === strpos( $agent_abilities, 'wp_codebox_' ),
-	'Data Machine does not reference WP Codebox-specific runtime hooks'
-);
-
-$assert(
 	false !== strpos( $chat_orchestrator, "'session_creation_ability_unavailable'" ),
 	'ChatOrchestrator reports missing ability dependencies as an explicit error'
 );

--- a/tests/fetch-item-dispositions-smoke.php
+++ b/tests/fetch-item-dispositions-smoke.php
@@ -37,7 +37,7 @@ namespace {
 		}
 	}
 
-	// Under a real WordPress runtime (e.g. the wp-codebox smoke harness) the
+	// Under a real WordPress runtime the
 	// do_action stub above never installs, so bridge the observed hook into the
 	// same capture buffer via real add_action.
 	if ( defined( 'WPINC' ) ) {


### PR DESCRIPTION
## Summary
- Remove the deprecated runtime-specific bundle metadata fallback from AgentBundleRunner.
- Keep metadata.agent_runtime.ability_tools as the single generic bundle metadata contract.
- Update tests and comments to describe headless/runtime behavior generically instead of naming a specific sandbox provider.

## Verification
- php tests/agent-bundle-runner-contract-smoke.php
- php tests/chat-session-canonical-path-smoke.php
- php -l inc/Engine/Bundle/AgentBundleRunner.php
- homeboy --force-hot --allow-local-hot lint data-machine --path /Users/chubes/Developer/data-machine@cook-remove-codebox-coupling --changed-since origin/main
- homeboy --force-hot --allow-local-hot test data-machine --path /Users/chubes/Developer/data-machine@cook-remove-codebox-coupling --changed-since origin/main --skip-lint

## Boundary
Data Machine should consume generic runtime contracts only. Provider-specific bundle metadata belongs in the provider/runtime layer before it calls Data Machine.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing Codebox coupling, drafting the runtime-generic cleanup, and running verification; Chris remains responsible for review and merge.