### PR TITLE
Remove runtime-specific boundary names

### DIFF
--- a/bench/fixtures/README.md
+++ b/bench/fixtures/README.md
@@ -1,10 +1,10 @@
 # Data Machine Benchmark Fixtures
 
-Benchmark fixtures are repository-owned setup helpers for profiling rigs. They are not plugin runtime APIs and are not registered as WP-CLI commands.
+Benchmark fixtures are repository-owned setup helpers for profiling environments. They are not plugin runtime APIs and are not registered as WP-CLI commands.
 
 ## Admin Scale
 
-`admin-scale.php` creates bounded Data Machine pipelines, flows, and step configs for admin profiling rigs.
+`admin-scale.php` creates bounded Data Machine pipelines, flows, and step configs for admin profiling environments.
 
 Run setup through `wp eval-file` from a WordPress install with Data Machine active:
 
@@ -23,4 +23,4 @@ Run cleanup with the same seed:
 wp eval-file /path/to/data-machine/bench/fixtures/admin-scale.php -- cleanup --seed-slug=profile-run
 ```
 
-The fixture deletes existing records for the seed before setup, then recreates them through Data Machine repository APIs. Downstream Homeboy Rigs should call this file from bench setup instead of constructing Data Machine database classes or writing `datamachine_*` tables directly.
+The fixture defines the benchmark setup and cleanup contract. Callers should invoke this file from benchmark setup and cleanup phases instead of constructing Data Machine database classes or writing `datamachine_*` tables directly. Setup deletes existing records for the seed, then recreates them through Data Machine repository APIs; cleanup deletes records for that same seed.

--- a/docs/core-system/abilities-api.md
+++ b/docs/core-system/abilities-api.md
@@ -126,10 +126,10 @@ public function register(): void {
 
 ## Testing
 
-Ability coverage lives in focused smoke tests under `tests/` rather than a separate `tests/Unit/Abilities/` tree. The ability-related smoke tests cover registration, schema contracts, permission contexts, chat/tool integration, source inventory, queue behavior, taxonomy cleanup, auth scoping, and wp-ai-client runtime boundaries. Run them through Homeboy or directly through the repository's PHP smoke harness:
+Ability coverage lives in focused smoke tests under `tests/` rather than a separate `tests/Unit/Abilities/` tree. The ability-related smoke tests cover registration, schema contracts, permission contexts, chat/tool integration, source inventory, queue behavior, taxonomy cleanup, auth scoping, and wp-ai-client runtime boundaries. Run them through the repository's configured test command or directly through the PHP smoke harness:
 
 ```bash
-homeboy test data-machine
+php tests/lightweight-ability-manifest-smoke.php
 ```
 
 ## WP-CLI Integration

--- a/docs/core-system/daily-memory-system.md
+++ b/docs/core-system/daily-memory-system.md
@@ -233,9 +233,9 @@ wp_execute_ability('datamachine/daily-memory-write', [
     'mode'    => 'append',
 ]);
 
-// Search for mentions of "homeboy"
+// Search for mentions of "project"
 wp_execute_ability('datamachine/search-daily-memory', [
-    'query' => 'homeboy',
+    'query' => 'project',
     'from'  => '2026-03-01',
     'to'    => '2026-03-31',
 ]);

--- a/inc/Abilities/AbilityCategories.php
+++ b/inc/Abilities/AbilityCategories.php
@@ -67,7 +67,7 @@ class AbilityCategories {
 		foreach ( self::get_category_definitions() as $slug => $args ) {
 			if ( $late ) {
 				// Late path: the categories-init action has already completed
-				// (headless / WP Codebox sandbox load order — see
+				// (headless runtime load order — see
 				// ensure_registered()). The public helper would
 				// `_doing_it_wrong()`, so register through the registry
 				// instance directly, which core permits any time after `init`.
@@ -94,12 +94,12 @@ class AbilityCategories {
 	 *      land in this same dispatch pass.
 	 *   2. `! did_action( wp_abilities_api_categories_init )` — the action
 	 *      has not fired yet. Attach a hook for the lazy fire.
-	 *   3. otherwise — the action has already fired and completed. This happens
-	 *      in headless runtimes (WP Codebox sandbox / WordPress Playground)
-	 *      where `run-php` boots WordPress through `wp-load.php` — firing the
-	 *      one-shot `wp_abilities_api_categories_init` — and only THEN includes
-	 *      the plugin file. Register through the registry instance directly via
-	 *      `register()`'s late path so category-bound abilities (e.g.
+	 *   3. otherwise — the action has already fired and completed. This can
+	 *      happen in headless runtimes where WordPress boots before including
+	 *      the plugin file, firing the one-shot
+	 *      `wp_abilities_api_categories_init` action first. Register through the
+	 *      registry instance directly via `register()`'s late path so
+	 *      category-bound abilities (e.g.
 	 *      `datamachine/run-agent-bundle`) are not silently dropped. Core only
 	 *      enforces the lifecycle in the `wp_register_ability_category()`
 	 *      wrapper, not in `WP_Ability_Categories_Registry::register()`.

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -40,15 +40,14 @@ class AgentAbilities {
 	 * requests, where this class hooks `registerAbilities()` onto the action
 	 * before it fires.
 	 *
-	 * WP Codebox sandbox runs (WordPress Playground) load Data Machine in a
-	 * fundamentally different order: `run-php` boots WordPress through
-	 * `wp-load.php` — which fires `init` and lazily initializes the abilities
-	 * registry, completing the one-shot `wp_abilities_api_init` action — and
-	 * only THEN `require_once`s the plugin file. By the time this class is
+	 * Some headless runtimes load Data Machine after WordPress has already
+	 * booted through `wp-load.php` — which fires `init` and lazily initializes
+	 * the abilities registry, completing the one-shot `wp_abilities_api_init`
+	 * action — and only THEN include the plugin file. By the time this class is
 	 * instantiated, the public registration window has already closed, so
 	 * `wp_register_ability()` would `_doing_it_wrong()` and return null,
-	 * leaving `datamachine/run-agent-bundle` unregistered for the very sandbox
-	 * runs that need it.
+	 * leaving `datamachine/run-agent-bundle` unregistered for the runs that
+	 * need it.
 	 *
 	 * WordPress core only enforces the lifecycle in the `wp_register_ability()`
 	 * wrapper; `WP_Abilities_Registry::register()` itself has no such guard and
@@ -96,7 +95,7 @@ class AgentAbilities {
 			add_action( 'wp_abilities_api_init', array( $this, 'registerAbilities' ) );
 			self::$registered = true;
 		} else {
-			// Post-lifecycle (headless / WP Codebox sandbox load order): the
+			// Post-lifecycle (headless runtime load order): the
 			// init action has already fired before this plugin file was
 			// included, so neither the in-lifecycle nor the hook path will run.
 			// Register immediately via the late path in registerAbility().

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -442,7 +442,7 @@ class MemoryCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # Search MEMORY.md (default)
-	 *     wp datamachine memory search "homeboy"
+	 *     wp datamachine memory search "project"
 	 *
 	 *     # Search SOUL.md
 	 *     wp datamachine memory search "identity" --file=SOUL.md
@@ -539,7 +539,7 @@ class MemoryCommand extends BaseCommand {
 	 *     wp datamachine memory daily delete 2026-02-24
 	 *
 	 *     # Search daily memory
-	 *     wp datamachine memory daily search "homeboy"
+	 *     wp datamachine memory daily search "project"
 	 *
 	 *     # Search with date range
 	 *     wp datamachine memory daily search "deploy" --from=2026-02-01 --to=2026-02-28

--- a/tests/admin-scale-benchmark-fixture-smoke.php
+++ b/tests/admin-scale-benchmark-fixture-smoke.php
@@ -28,7 +28,7 @@ $assert( 'fixture avoids direct table writes', ! str_contains( $fixture, '$wpdb-
 $assert( 'fixture is not a registered WP-CLI command', ! str_contains( $fixture, 'WP_CLI::add_command' ) );
 $assert( 'fixture supports setup', str_contains( $fixture, "'setup'" ) );
 $assert( 'fixture supports cleanup', str_contains( $fixture, "'cleanup'" ) );
-$assert( 'fixture documents Homeboy Rigs usage', str_contains( $readme, 'Homeboy Rigs' ) );
+$assert( 'fixture documents generic setup and cleanup contract', str_contains( $readme, 'benchmark setup and cleanup contract' ) );
 
 if ( ! empty( $failures ) ) {
 	echo "\nFAILED: " . count( $failures ) . " admin scale benchmark fixture assertions failed.\n";

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -589,9 +589,6 @@ foreach ( array(
 }
 
 echo "\n[6] Boundary stays generic\n";
-foreach ( array( 'homeboy' ) as $forbidden ) {
-	datamachine_bundle_runner_assert( false === stripos( $runner, $forbidden ), "runner does not mention {$forbidden}", $failures, $passes );
-}
 foreach ( array( 'DataMachine\\Core\\Database\\Agents', 'DataMachine\\Core\\Database\\Flows', 'DataMachine\\Core\\Database\\Pipelines' ) as $forbidden ) {
 	datamachine_bundle_runner_assert( false === strpos( $runner, $forbidden ), "runtime runner does not require caller-facing {$forbidden}", $failures, $passes );
 }


### PR DESCRIPTION
## Summary
- Reword ability lifecycle comments to describe generic headless runtime timing instead of named sandbox runtimes.
- Replace benchmark fixture docs/tests with generic setup and cleanup contract language.
- Neutralize feature-doc and WP-CLI memory examples that used runtime/tooling-specific sample terms.

## Tests
- php tests/admin-scale-benchmark-fixture-smoke.php
- php tests/agent-bundle-runner-contract-smoke.php
- php tests/lightweight-ability-manifest-smoke.php
- composer run lint
- composer run test: 1364 total, 1360 passed, 4 skipped

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** removed runtime boundary names from Data Machine