### PR TITLE
Use generic WordPress runtime version config

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -24,7 +24,7 @@
       "mysql_password": "",
       "release_latest_branch": "release-latest",
       "settings": {
-        "wp_codebox_wordpress_version": "7.0"
+        "runtime_wordpress_version": "7.0"
       }
     }
   },

--- a/tests/boundary-forbidden-names-smoke.php
+++ b/tests/boundary-forbidden-names-smoke.php
@@ -59,7 +59,6 @@ function datamachine_boundary_is_allowed_file( string $relative_path ): bool {
 		// Developer/release harness config. Runtime code must remain generic.
 		'.buildignore',
 		'composer.json',
-		'homeboy.json',
 	);
 
 	if ( in_array( $relative_path, $allowed_files, true ) ) {


### PR DESCRIPTION
## Summary
- Switch Data Machine's WordPress harness settings from the WP Codebox-specific `wp_codebox_wordpress_version` key to the generic `runtime_wordpress_version` key now present in Homeboy Extensions.
- Remove `homeboy.json` from the boundary smoke allowlist so downstream runtime names in harness config are caught going forward.

## Verification
- `php tests/boundary-forbidden-names-smoke.php` passed.
- `composer lint` passed.
- `composer test` passed via Homeboy lab offload: 1364 tests, 1360 passed, 4 skipped.
- `homeboy --force-hot --allow-local-hot lint data-machine --changed-only` passed with no findings.
- `homeboy lint data-machine` currently fails on 71 unrelated pre-existing PHPCS findings in files untouched by this PR, mostly `inc/Core/Database/ProcessedItems/ProcessedItems.php` and `inc/Engine/AI/MemoryFileRegistry.php`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected the upstream Homeboy Extensions key, updated the Data Machine harness config and boundary smoke allowlist, ran verification, and drafted this PR body.