### PR TITLE
fix: preserve network-wide agent scope through bundle round-trip + first-class site_scope on create

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -355,6 +355,10 @@ class AgentAbilities {
 								'type'        => 'object',
 								'description' => 'Agent configuration object.',
 							),
+							'site_scope' => array(
+								'type'        => array( 'integer', 'null' ),
+								'description' => 'Site scope for the agent. Omit or null for network-wide (resolves on every site); a blog ID scopes the agent to that single site. Default network-wide.',
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -366,6 +370,7 @@ class AgentAbilities {
 							'agent_name' => array( 'type' => 'string' ),
 							'owner_id'   => array( 'type' => 'integer' ),
 							'agent_dir'  => array( 'type' => 'string' ),
+							'site_scope' => array( 'type' => array( 'integer', 'null' ) ),
 							'message'    => array( 'type' => 'string' ),
 							'error'      => array( 'type' => 'string' ),
 						),
@@ -1913,6 +1918,21 @@ class AgentAbilities {
 		$owner_id = (int) ( $input['owner_id'] ?? 0 );
 		$config   = $input['config'] ?? array();
 
+		// Scope is first-class on create. Default (key absent) is network-wide
+		// via the DB column default. An explicit null also means network-wide;
+		// a positive integer scopes the agent to that single blog.
+		$site_scope = false;
+		if ( array_key_exists( 'site_scope', $input ) ) {
+			$scope_input = $input['site_scope'];
+			if ( null === $scope_input || '' === $scope_input ) {
+				$site_scope = null;
+			} elseif ( is_numeric( $scope_input ) && (int) $scope_input > 0 ) {
+				$site_scope = (int) $scope_input;
+			} else {
+				$site_scope = null;
+			}
+		}
+
 		if ( empty( $slug ) ) {
 			return array(
 				'success' => false,
@@ -2006,7 +2026,7 @@ class AgentAbilities {
 			);
 		}
 
-		$agent_id = $agents_repo->create_if_missing( $slug, $name, $owner_id, $config );
+		$agent_id = $agents_repo->create_if_missing( $slug, $name, $owner_id, $config, $site_scope );
 
 		if ( ! $agent_id ) {
 			return array(
@@ -2052,6 +2072,7 @@ class AgentAbilities {
 			'agent_name' => $name,
 			'owner_id'   => $owner_id,
 			'agent_dir'  => $agent_dir,
+			'site_scope' => ( false === $site_scope ) ? null : $site_scope,
 			'message'    => sprintf( 'Agent "%s" created (ID: %d).', $slug, $agent_id ),
 		);
 	}

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -1075,17 +1075,11 @@ class AgentsCommand extends AgentBundleCommand {
 				$raw_value = substr( $pair, $eq_pos + 1 );
 
 				// Handle site_scope as a special case — it's a column, not agent_config.
+				// Changing scope is an explicit operation; route it through the
+				// repository so the nullable-column write stays in one place.
 				if ( 'site_scope' === $key ) {
 					$scope_value = ( 'null' === strtolower( $raw_value ) || '' === $raw_value ) ? null : (int) $raw_value;
-					global $wpdb;
-					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-					$wpdb->update(
-						$wpdb->base_prefix . 'datamachine_agents',
-						array( 'site_scope' => $scope_value ),
-						array( 'agent_id' => $agent_id ),
-						array( null === $scope_value ? null : '%d' ),
-						array( '%d' )
-					);
+					$agents_repo->update_agent( $agent_id, array( 'site_scope' => $scope_value ) );
 					$site_scope_changed = true;
 					WP_CLI::log( sprintf( '  site_scope → %s', null === $scope_value ? 'NULL (network-wide)' : $scope_value ) );
 					continue;

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -99,10 +99,8 @@ class AgentBundler {
 			);
 		}
 
-		$agent                         = is_array( $result['agent'] ?? null ) ? $result['agent'] : array();
-		$bundle                        = AgentBundleArrayAdapter::to_array_bundle( $directory );
-		$bundle['abilities_manifest']  = $this->collect_abilities_manifest();
-		$bundle['agent']['site_scope'] = (string) ( $agent['site_scope'] ?? 'site' );
+		$bundle                       = AgentBundleArrayAdapter::to_array_bundle( $directory );
+		$bundle['abilities_manifest'] = $this->collect_abilities_manifest();
 
 		return array(
 			'success' => true,
@@ -245,6 +243,10 @@ class AgentBundler {
 				'label'        => $agent['agent_name'],
 				'description'  => '',
 				'agent_config' => is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array(),
+				// Preserve the agent's actual scope through the bundle round-trip:
+				// null = network-wide, positive int = a specific blog. The manifest
+				// drops legacy/unknown values so import never re-pins to a blog.
+				'site_scope'   => self::normalize_export_site_scope( $agent['site_scope'] ?? null ),
 			),
 			array(
 				'memory'       => array_keys( $memory_files ),
@@ -489,6 +491,25 @@ class AgentBundler {
 		return $manifest;
 	}
 
+	/**
+	 * Normalize a stored agent `site_scope` for export into a manifest.
+	 *
+	 * The DB column is `NULL` for network-wide or a blog ID otherwise. We map
+	 * `NULL` to a first-class `null` (network-wide) and a numeric value to its
+	 * integer blog ID. Anything else collapses to the unspecified sentinel,
+	 * which the manifest validator drops so it can't re-pin an agent on import.
+	 *
+	 * @param mixed $stored_scope Raw site_scope value from the agent row.
+	 * @return int|null|string
+	 */
+	private static function normalize_export_site_scope( mixed $stored_scope ): int|null|string {
+		if ( null === $stored_scope ) {
+			return null;
+		}
+
+		return \DataMachine\Engine\Bundle\BundleSchema::normalize_agent_site_scope( $stored_scope );
+	}
+
 	private static function strip_secret_like_values( array $value ): array {
 		$secret_keys = array( 'access_token', 'refresh_token', 'token', 'secret', 'client_secret', 'password', 'api_key', 'apikey', 'key' );
 		foreach ( $value as $key => $child ) {
@@ -708,11 +729,21 @@ class AgentBundler {
 					throw new \RuntimeException( 'Failed to update existing agent record.' );
 				}
 			} else {
+				// Honor the bundle's portable scope on CREATE only. `null` is
+				// first-class network-wide; a positive int scopes to that blog.
+				// An unspecified/legacy scope falls to the column default (NULL).
+				// Read with array_key_exists so an explicit null is not swallowed
+				// by `??` and collapsed into the unspecified sentinel.
+				$raw_site_scope    = array_key_exists( 'site_scope', $agent_data ) ? $agent_data['site_scope'] : BundleSchema::SITE_SCOPE_UNSPECIFIED;
+				$bundle_site_scope = BundleSchema::normalize_agent_site_scope( $raw_site_scope );
+				$create_site_scope = ( BundleSchema::SITE_SCOPE_UNSPECIFIED === $bundle_site_scope ) ? false : $bundle_site_scope;
+
 				$agent_id = $this->agents_repo->create_if_missing(
 					$slug,
 					$agent_data['agent_name'] ?? $slug,
 					$owner_id,
-					$config
+					$config,
+					$create_site_scope
 				);
 				if ( ! $agent_id ) {
 					throw new \RuntimeException( 'Failed to create agent record.' );

--- a/inc/Core/Database/Agents/Agents.php
+++ b/inc/Core/Database/Agents/Agents.php
@@ -290,9 +290,15 @@ class Agents extends BaseRepository {
 	 * Update an agent's mutable fields.
 	 *
 	 * Only updates fields that are present in the $data array.
-	 * Allowed fields: agent_name, agent_config.
+	 * Allowed fields: agent_name, agent_config, site_scope.
+	 *
+	 * Changing `site_scope` is an explicit, intentional operation: callers must
+	 * pass the `site_scope` key to move an agent between network-wide (`null`)
+	 * and site-specific (positive int). It is never mutated as a side effect of
+	 * an agent_name/agent_config update.
 	 *
 	 * @since 0.43.0
+	 * @since 0.57.0 Added explicit site_scope support.
 	 * @param int   $agent_id Agent ID.
 	 * @param array $data     Associative array of fields to update.
 	 * @return bool True on success, false on DB failure or no valid fields.
@@ -314,6 +320,14 @@ class Agents extends BaseRepository {
 				$update[ $field ] = (string) $data[ $field ];
 				$formats[]        = '%s';
 			}
+		}
+
+		// site_scope is a nullable column, handled outside the string-cast loop
+		// so `null` (network-wide) round-trips correctly instead of becoming "".
+		if ( array_key_exists( 'site_scope', $data ) ) {
+			$scope              = $data['site_scope'];
+			$update['site_scope'] = ( null === $scope ) ? null : (int) $scope;
+			$formats[]            = ( null === $scope ) ? null : '%d';
 		}
 
 		if ( empty( $update ) ) {
@@ -406,29 +420,49 @@ class Agents extends BaseRepository {
 	/**
 	 * Create an agent if slug does not exist.
 	 *
-	 * @param string $agent_slug Agent slug.
-	 * @param string $agent_name Display name.
-	 * @param int    $owner_id Owner user ID.
-	 * @param array  $agent_config Agent configuration.
+	 * Network-wide scope is first-class and the default: when `$site_scope` is
+	 * omitted (the `false` sentinel) the `site_scope` column is left unset and
+	 * falls to its DB default of `NULL` (network-wide). Pass an explicit `null`
+	 * to force network-wide, or a positive integer to scope to a single blog.
+	 *
+	 * @since 0.57.0 Added explicit $site_scope parameter.
+	 *
+	 * @param string        $agent_slug   Agent slug.
+	 * @param string        $agent_name   Display name.
+	 * @param int           $owner_id     Owner user ID.
+	 * @param array         $agent_config Agent configuration.
+	 * @param int|null|false $site_scope  Scope to set on create. `null` = network-wide,
+	 *                                    positive int = a specific blog, `false` = use
+	 *                                    the column default (network-wide). Default false.
 	 * @return int Agent ID.
 	 */
-	public function create_if_missing( string $agent_slug, string $agent_name, int $owner_id, array $agent_config = array() ): int {
+	public function create_if_missing( string $agent_slug, string $agent_name, int $owner_id, array $agent_config = array(), int|null|false $site_scope = false ): int {
 		$existing = $this->get_by_slug( $agent_slug );
 
 		if ( $existing ) {
 			return (int) $existing['agent_id'];
 		}
 
+		$data    = array(
+			'agent_slug'   => $agent_slug,
+			'agent_name'   => $agent_name,
+			'owner_id'     => $owner_id,
+			'agent_config' => wp_json_encode( AgentConfigFactory::normalize( $agent_config ) ),
+		);
+		$formats = array( '%s', '%s', '%d', '%s' );
+
+		// Only write site_scope when the caller is intentional about it. The
+		// `false` sentinel leaves the column to its DB default (NULL = network-wide).
+		if ( false !== $site_scope ) {
+			$data['site_scope'] = ( null === $site_scope ) ? null : (int) $site_scope;
+			$formats[]          = ( null === $site_scope ) ? null : '%d';
+		}
+
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$this->wpdb->insert(
 			$this->table_name,
-			array(
-				'agent_slug'   => $agent_slug,
-				'agent_name'   => $agent_name,
-				'owner_id'     => $owner_id,
-				'agent_config' => wp_json_encode( AgentConfigFactory::normalize( $agent_config ) ),
-			),
-			array( '%s', '%s', '%d', '%s' )
+			$data,
+			$formats
 		);
 
 		return (int) $this->wpdb->insert_id;

--- a/inc/Engine/Bundle/AgentBundleArrayAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleArrayAdapter.php
@@ -34,12 +34,7 @@ final class AgentBundleArrayAdapter {
 			(string) ( $bundle['bundle_version'] ?? '1' ),
 			(string) ( $bundle['source_ref'] ?? '' ),
 			(string) ( $bundle['source_revision'] ?? '' ),
-			array(
-				'slug'         => $bundle['agent']['agent_slug'] ?? 'agent',
-				'label'        => $bundle['agent']['agent_name'] ?? ( $bundle['agent']['agent_slug'] ?? 'Agent' ),
-				'description'  => (string) ( $bundle['agent']['description'] ?? '' ),
-				'agent_config' => is_array( $bundle['agent']['agent_config'] ?? null ) ? $bundle['agent']['agent_config'] : array(),
-			),
+			self::manifest_agent_block( $bundle['agent'] ?? array() ),
 			array(
 				'memory'       => self::memory_paths_from_array_bundle( $bundle, $pipeline_slugs, $flow_slugs ),
 				'pipelines'    => array_values( $pipeline_slugs ),
@@ -145,12 +140,7 @@ final class AgentBundleArrayAdapter {
 			'source_revision'       => $manifest['source_revision'] ?? '',
 			'bundle_schema_version' => BundleSchema::VERSION,
 			'exported_at'           => $manifest['exported_at'],
-			'agent'                 => array(
-				'agent_slug'   => $manifest['agent']['slug'],
-				'agent_name'   => $manifest['agent']['label'],
-				'agent_config' => $manifest['agent']['agent_config'],
-				'site_scope'   => 'site',
-			),
+			'agent'                 => self::bundle_agent_block( $manifest['agent'] ?? array() ),
 			'files'                 => self::strip_memory_prefix( $memory_files, 'agent/' ),
 			'user_template'         => $memory_files['USER.md'] ?? '',
 			'pipelines'             => $pipelines,
@@ -229,6 +219,63 @@ final class AgentBundleArrayAdapter {
 			$slugs[ $index ] = $slug;
 		}
 		return $slugs;
+	}
+
+	/**
+	 * Build the manifest agent block from a raw bundle agent array.
+	 *
+	 * Preserves the agent's actual `site_scope` through the round-trip: `null`
+	 * for network-wide, a positive integer for a specific blog. Legacy/unknown
+	 * values (`'site'`, empty string, absent) are omitted so the importer never
+	 * re-pins a network agent to the installing blog.
+	 *
+	 * @param array<string,mixed> $agent Raw bundle agent array.
+	 * @return array<string,mixed>
+	 */
+	private static function manifest_agent_block( array $agent ): array {
+		$block = array(
+			'slug'         => $agent['agent_slug'] ?? 'agent',
+			'label'        => $agent['agent_name'] ?? ( $agent['agent_slug'] ?? 'Agent' ),
+			'description'  => (string) ( $agent['description'] ?? '' ),
+			'agent_config' => is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array(),
+		);
+
+		if ( array_key_exists( 'site_scope', $agent ) ) {
+			$scope = BundleSchema::normalize_agent_site_scope( $agent['site_scope'] );
+			if ( BundleSchema::SITE_SCOPE_UNSPECIFIED !== $scope ) {
+				$block['site_scope'] = $scope;
+			}
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Build the bundle agent block from a validated manifest agent array.
+	 *
+	 * Emits the real `site_scope` carried by the manifest (`null` network-wide
+	 * or a positive integer). When the manifest carries no scope, the key is
+	 * omitted entirely — the importer treats an absent scope as "do not
+	 * re-pin", never as "scope to the current blog".
+	 *
+	 * @param array<string,mixed> $agent Validated manifest agent array.
+	 * @return array<string,mixed>
+	 */
+	private static function bundle_agent_block( array $agent ): array {
+		$block = array(
+			'agent_slug'   => $agent['slug'] ?? 'agent',
+			'agent_name'   => $agent['label'] ?? ( $agent['slug'] ?? 'Agent' ),
+			'agent_config' => is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array(),
+		);
+
+		if ( array_key_exists( 'site_scope', $agent ) ) {
+			$scope = BundleSchema::normalize_agent_site_scope( $agent['site_scope'] );
+			if ( BundleSchema::SITE_SCOPE_UNSPECIFIED !== $scope ) {
+				$block['site_scope'] = $scope;
+			}
+		}
+
+		return $block;
 	}
 
 	private static function exported_by(): string {

--- a/inc/Engine/Bundle/AgentBundleManifest.php
+++ b/inc/Engine/Bundle/AgentBundleManifest.php
@@ -150,12 +150,25 @@ final class AgentBundleManifest {
 			throw new BundleValidationException( 'manifest.json agent.agent_config must be an object.' );
 		}
 
-		return array(
+		$validated = array(
 			'slug'         => $agent['slug'],
 			'label'        => $agent['label'],
 			'description'  => $agent['description'],
 			'agent_config' => $agent['agent_config'],
 		);
+
+		// Carry the agent's site scope through the round-trip. `null` means
+		// network-wide; a positive integer means a specific blog. Anything else
+		// (legacy `'site'`, empty string, absent key) is "unspecified" and is
+		// omitted so the importer never re-pins the agent to the installing blog.
+		if ( array_key_exists( 'site_scope', $agent ) ) {
+			$scope = BundleSchema::normalize_agent_site_scope( $agent['site_scope'] );
+			if ( BundleSchema::SITE_SCOPE_UNSPECIFIED !== $scope ) {
+				$validated['site_scope'] = $scope;
+			}
+		}
+
+		return $validated;
 	}
 
 	private static function validate_included( array $included ): array {

--- a/inc/Engine/Bundle/BundleSchema.php
+++ b/inc/Engine/Bundle/BundleSchema.php
@@ -16,6 +16,15 @@ final class BundleSchema {
 
 	public const VERSION = 1;
 
+	/**
+	 * Sentinel returned by {@see self::normalize_agent_site_scope()} when a bundle
+	 * carries no usable scope value (absent key, empty string, or the legacy
+	 * `'site'` literal). Distinct from `null`, which is the first-class
+	 * "network-wide" scope. Callers must not write a `site_scope` column for the
+	 * unspecified sentinel so existing scope is preserved.
+	 */
+	public const SITE_SCOPE_UNSPECIFIED = '__unspecified__';
+
 	public const MANIFEST_FILE = 'manifest.json';
 
 	public const MEMORY_DIR = 'memory';
@@ -146,6 +155,46 @@ final class BundleSchema {
 		sort( $normalized, SORT_STRING );
 
 		return $normalized;
+	}
+
+	/**
+	 * Normalize a bundle agent's `site_scope` to a first-class scope value.
+	 *
+	 * Network-wide scope is a durable, intentional concept: it is `null`, never
+	 * the installing blog. A specific blog is a positive integer. The legacy
+	 * hardcoded `'site'` literal and the empty string carry no portable meaning
+	 * (they cannot identify a blog across installs), so both resolve to the
+	 * {@see self::SITE_SCOPE_UNSPECIFIED} sentinel and the importer leaves the
+	 * existing scope untouched rather than re-pinning to the current blog.
+	 *
+	 * @param mixed $value Raw site_scope value from a bundle/manifest.
+	 * @return int|null|string `null` for network-wide, positive int for a blog,
+	 *                          or the SITE_SCOPE_UNSPECIFIED sentinel.
+	 */
+	public static function normalize_agent_site_scope( mixed $value ): int|null|string {
+		if ( null === $value ) {
+			return null;
+		}
+
+		if ( is_int( $value ) ) {
+			return $value > 0 ? $value : self::SITE_SCOPE_UNSPECIFIED;
+		}
+
+		if ( is_string( $value ) ) {
+			$trimmed = trim( $value );
+			if ( '' === $trimmed || 'site' === strtolower( $trimmed ) ) {
+				return self::SITE_SCOPE_UNSPECIFIED;
+			}
+			if ( 'null' === strtolower( $trimmed ) ) {
+				return null;
+			}
+			if ( ctype_digit( $trimmed ) ) {
+				$int = (int) $trimmed;
+				return $int > 0 ? $int : self::SITE_SCOPE_UNSPECIFIED;
+			}
+		}
+
+		return self::SITE_SCOPE_UNSPECIFIED;
 	}
 
 	private static function apply_filter( string $hook, array $value ): mixed {

--- a/tests/agent-bundle-site-scope-roundtrip-smoke.php
+++ b/tests/agent-bundle-site-scope-roundtrip-smoke.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Pure-PHP smoke test for network-wide agent scope preservation through the
+ * bundle export -> import/adopt round-trip (#2749).
+ *
+ * Run with: php tests/agent-bundle-site-scope-roundtrip-smoke.php
+ *
+ * This is the exact path that broke the network-wide platform agent in
+ * production: the bundle adapter hardcoded `site_scope = 'site'` on export,
+ * which the canonical round-trip then resolved to the installing blog. A
+ * network-wide (NULL) agent bundled from one subsite came back pinned to that
+ * subsite and was dead everywhere else.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook = '' ) {
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook = '' ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		// no-op
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( ...$args ) {
+		// no-op stub for standalone smoke runs.
+	}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value = null, ...$args ) {
+		return $value;
+	}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( ...$args ) {
+		// no-op stub for standalone smoke runs.
+	}
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
+use DataMachine\Engine\Bundle\BundleSchema;
+
+$failures = array();
+$passes   = 0;
+
+function assert_scope( string $label, bool $condition ): void {
+	global $failures, $passes;
+	if ( $condition ) {
+		++$passes;
+		echo "  PASS: {$label}\n";
+		return;
+	}
+	$failures[] = $label;
+	echo "  FAIL: {$label}\n";
+}
+
+function assert_scope_equals( string $label, $expected, $actual ): void {
+	assert_scope( $label, $expected === $actual );
+}
+
+/**
+ * Build a minimal bundle array carrying a given agent scope value.
+ *
+ * @param mixed $site_scope Value (or sentinel-absent) for the agent block.
+ * @param bool  $include    Whether to include the site_scope key at all.
+ * @return array<string,mixed>
+ */
+function scope_bundle( $site_scope, bool $include = true ): array {
+	$agent = array(
+		'agent_slug'   => 'platform-agent',
+		'agent_name'   => 'Platform Agent',
+		'agent_config' => array( 'model' => 'gpt-5.5' ),
+	);
+	if ( $include ) {
+		$agent['site_scope'] = $site_scope;
+	}
+
+	return array(
+		'bundle_version' => 1,
+		'exported_at'    => '2026-06-18T12:00:00Z',
+		'agent'          => $agent,
+		'files'          => array( 'SOUL.md' => "# Soul\n" ),
+		'pipelines'      => array(),
+		'flows'          => array(),
+	);
+}
+
+/**
+ * Run a bundle array through the canonical round-trip the importer uses
+ * (from_array_bundle -> to_array_bundle), returning the resulting agent block.
+ *
+ * @param array<string,mixed> $bundle Bundle array.
+ * @return array<string,mixed>
+ */
+function round_trip_agent( array $bundle ): array {
+	$directory = AgentBundleArrayAdapter::from_array_bundle( $bundle );
+	$result    = AgentBundleArrayAdapter::to_array_bundle( $directory );
+	return is_array( $result['agent'] ?? null ) ? $result['agent'] : array();
+}
+
+echo "=== Agent Bundle Site-Scope Round-Trip Smoke (#2749) ===\n";
+
+echo "\n[1] BundleSchema::normalize_agent_site_scope classifies scope values\n";
+assert_scope_equals( 'explicit null is first-class network-wide', null, BundleSchema::normalize_agent_site_scope( null ) );
+assert_scope_equals( 'positive int is a specific blog', 12, BundleSchema::normalize_agent_site_scope( 12 ) );
+assert_scope_equals( 'numeric string is a specific blog', 7, BundleSchema::normalize_agent_site_scope( '7' ) );
+assert_scope_equals( 'string "null" is network-wide', null, BundleSchema::normalize_agent_site_scope( 'null' ) );
+assert_scope_equals( 'legacy "site" literal is unspecified', BundleSchema::SITE_SCOPE_UNSPECIFIED, BundleSchema::normalize_agent_site_scope( 'site' ) );
+assert_scope_equals( 'empty string is unspecified', BundleSchema::SITE_SCOPE_UNSPECIFIED, BundleSchema::normalize_agent_site_scope( '' ) );
+assert_scope_equals( 'zero collapses to unspecified', BundleSchema::SITE_SCOPE_UNSPECIFIED, BundleSchema::normalize_agent_site_scope( 0 ) );
+assert_scope( 'unspecified sentinel is distinct from null', null !== BundleSchema::SITE_SCOPE_UNSPECIFIED );
+
+echo "\n[2] Network-wide (NULL) scope survives the round-trip — the roadie regression\n";
+$agent = round_trip_agent( scope_bundle( null ) );
+assert_scope( 'network-wide agent carries a site_scope key', array_key_exists( 'site_scope', $agent ) );
+assert_scope( 'network-wide agent round-trips to NULL, not the installing blog', array_key_exists( 'site_scope', $agent ) && null === $agent['site_scope'] );
+assert_scope( 'round-trip never re-stamps the legacy "site" literal', 'site' !== ( $agent['site_scope'] ?? null ) );
+
+echo "\n[3] Site-specific scope survives the round-trip\n";
+$agent = round_trip_agent( scope_bundle( 12 ) );
+assert_scope_equals( 'site-specific agent round-trips to its blog ID', 12, $agent['site_scope'] ?? 'MISSING' );
+
+echo "\n[4] Legacy/unknown scope is dropped (no silent re-pin to current blog)\n";
+$agent = round_trip_agent( scope_bundle( 'site' ) );
+assert_scope( 'legacy "site" literal is omitted from the round-tripped agent', ! array_key_exists( 'site_scope', $agent ) );
+$agent = round_trip_agent( scope_bundle( null, false ) );
+assert_scope( 'absent scope stays absent through the round-trip', ! array_key_exists( 'site_scope', $agent ) );
+
+echo "\n[5] Importer create-scope resolution honors the round-tripped value\n";
+// Mirror AgentBundler::import()'s create-branch resolution: unspecified -> false
+// (use DB default NULL = network-wide); null/int -> explicit scope on create.
+$resolve = static function ( $bundle_agent ) {
+	$raw   = array_key_exists( 'site_scope', $bundle_agent ) ? $bundle_agent['site_scope'] : BundleSchema::SITE_SCOPE_UNSPECIFIED;
+	$scope = BundleSchema::normalize_agent_site_scope( $raw );
+	return ( BundleSchema::SITE_SCOPE_UNSPECIFIED === $scope ) ? false : $scope;
+};
+assert_scope_equals( 'network-wide bundle creates with explicit NULL scope', null, $resolve( round_trip_agent( scope_bundle( null ) ) ) );
+assert_scope_equals( 'site-specific bundle creates scoped to its blog', 12, $resolve( round_trip_agent( scope_bundle( 12 ) ) ) );
+assert_scope_equals( 'legacy bundle falls to the column default (network-wide)', false, $resolve( round_trip_agent( scope_bundle( 'site' ) ) ) );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAILED: " . count( $failures ) . " site-scope round-trip assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} site-scope round-trip assertions passed.\n";


### PR DESCRIPTION
## Summary

First-class network-wide agent support so the agent bundle round-trip stops silently re-pinning network agents to the installing blog.

**Root cause:** `AgentBundleArrayAdapter` hardcoded `site_scope = 'site'` on bundle export. A network-wide (`NULL`) agent bundled from one subsite came back resolving `'site'` → the installing blog, so it was dead on every other site. This is exactly what broke the platform's cross-site agent in production (resolved on only one subsite, `UPDATE ... SET site_scope=NULL` hotfix applied, which this PR makes durable).

### 1. Bundle round-trip preserves real scope (the fix)
- `AgentBundleManifest` and `AgentBundleArrayAdapter` now carry the agent's **actual** `site_scope` through `from_array_bundle → manifest → to_array_bundle`: `null` = network-wide, positive int = a specific blog.
- New `BundleSchema::normalize_agent_site_scope()` + `BundleSchema::SITE_SCOPE_UNSPECIFIED` sentinel. The legacy `'site'` literal, empty string, and absent keys collapse to the sentinel and are **dropped** from the bundle — so import never re-pins to the current blog. Explicit `null` is honored as first-class network-wide, distinct from "unspecified".
- `AgentBundler::export()` no longer string-casts scope (`(string) ... ?? 'site'`, which turned `NULL` into `""`); it threads the real value into the manifest agent block.

### 2. First-class scope on create
- `Agents::create_if_missing()` takes a new `int|null|false $site_scope` param: `false` = column default (network-wide), explicit `null` = network-wide, positive int = a blog. Direct-create default stays network-wide.
- `createAgent()` ability + input/output schema gain a `site_scope` param. Default network-wide.
- `AgentBundler::import()` honors the bundled scope on **CREATE only** (read via `array_key_exists`, not `??`, so an explicit `null` isn't swallowed).

### 3. Idempotent re-scope protection
- The import **upgrade/update** branch only passes `agent_name` + `agent_config` to `update_agent()` — it never touches `site_scope`. Re-importing/upgrading an existing agent preserves its current scope regardless of which blog ran the command.
- `update_agent()` now allows `site_scope` as an explicit, intentional change (nullable-column handling outside the string-cast loop). The CLI `agents config --set site_scope=...` now routes through the repository instead of a raw `$wpdb->update` (layer purity — the column write lives in one place).

### Regression test
- `tests/agent-bundle-site-scope-roundtrip-smoke.php` covers the exact path that broke the network agent: export a network-wide (`NULL`) agent → bundle → round-trip → still `NULL`; site-specific int survives; legacy `'site'`/empty/absent are dropped (no silent re-pin); and the importer's create-scope resolution honors each case. 17/17 assertions pass.

## Layer purity
Generic core behavior only — no platform/agent-name special-casing. `git diff | grep -iE 'roadie|extrachill|studio|...'` is clean.

## Verification
- `php -l` clean on all 7 changed files.
- `vendor/bin/phpcs --standard=WordPress` → 0 errors, 0 warnings on every changed file + the new test.
- New regression smoke: all 17 assertions pass.
- Existing bundle smokes (`agent-bundler-directory-adapter`, `agent-bundle-format`, `export-agent-ability`, `import-agent-ability`) pass. The 1 failure in `agent-bundle-package-portability-smoke` and 5 in `agent-bundle-portable-update-smoke` are **pre-existing on the clean base** (confirmed by `git stash` comparison) and unrelated to this change.

Part 4 (warn before narrowing an existing network-wide agent's scope on import) was deferred — it would require surfacing a warning through the import summary/CLI and isn't needed for correctness of the round-trip. The re-scope protection in part 3 already prevents the silent narrowing; an explicit advisory warning can be a small follow-up.

Closes #2749