### PR TITLE
Snapshot host tool policy for bundle runs

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -382,7 +382,7 @@ class AIStep extends Step {
 					'pipeline_step_id'     => $pipeline_step_id,
 					'engine_data'          => $engine_data,
 					'ability_tools'        => is_array( $job_snapshot['ability_tools'] ?? null ) ? $job_snapshot['ability_tools'] : array(),
-					'host_tool_policy'    => is_array( $job_snapshot['host_tool_policy'] ?? null ) ? $job_snapshot['host_tool_policy'] : array(),
+					'host_tool_policy'     => is_array( $job_snapshot['host_tool_policy'] ?? null ) ? $job_snapshot['host_tool_policy'] : array(),
 					'categories'           => $tool_categories,
 				),
 				PipelineToolPolicyArgs::fromConfigs( $this->flow_step_config, $pipeline_step_config )

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -382,6 +382,7 @@ class AIStep extends Step {
 					'pipeline_step_id'     => $pipeline_step_id,
 					'engine_data'          => $engine_data,
 					'ability_tools'        => is_array( $job_snapshot['ability_tools'] ?? null ) ? $job_snapshot['ability_tools'] : array(),
+					'host_tool_policy'    => is_array( $job_snapshot['host_tool_policy'] ?? null ) ? $job_snapshot['host_tool_policy'] : array(),
 					'categories'           => $tool_categories,
 				),
 				PipelineToolPolicyArgs::fromConfigs( $this->flow_step_config, $pipeline_step_config )

--- a/inc/Engine/AI/Tools/HostToolPolicy.php
+++ b/inc/Engine/AI/Tools/HostToolPolicy.php
@@ -121,6 +121,18 @@ final class HostToolPolicy {
 			return null;
 		}
 
+		$unwrapped = self::unwrapPolicyDocument( $policy );
+		if ( $unwrapped !== $policy ) {
+			return self::normalizePolicy( $unwrapped );
+		}
+
+		if ( self::isSandboxPolicyDocument( $policy ) ) {
+			$policy = self::normalizeSandboxPolicyDocument( $policy );
+			if ( null === $policy ) {
+				return null;
+			}
+		}
+
 		$tools = is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array();
 		foreach ( $tools as $tool_name => $rule ) {
 			if ( ! is_string( $tool_name ) || '' === $tool_name || ! is_array( $rule ) ) {
@@ -143,5 +155,105 @@ final class HostToolPolicy {
 		}
 
 		return $has_default || ! empty( $tools ) ? $policy : null;
+	}
+
+	/**
+	 * Unwrap host policy documents embedded in broader runtime/sandbox payloads.
+	 *
+	 * @param array<string,mixed> $policy Policy candidate.
+	 * @return array<string,mixed>
+	 */
+	private static function unwrapPolicyDocument( array $policy ): array {
+		if ( is_array( $policy['policy'] ?? null ) ) {
+			return $policy['policy'];
+		}
+
+		if ( is_array( $policy['host_tool_policy'] ?? null ) ) {
+			return $policy['host_tool_policy'];
+		}
+
+		if ( is_array( $policy['external_tool_ownership_policy'] ?? null ) ) {
+			return $policy['external_tool_ownership_policy'];
+		}
+
+		if ( is_array( $policy['sandbox_tool_policy'] ?? null ) ) {
+			return $policy['sandbox_tool_policy'];
+		}
+
+		$tools = is_array( $policy['tools'] ?? null ) ? $policy['tools'] : null;
+		if ( is_array( $tools ) && is_array( $tools['tools'] ?? null ) ) {
+			foreach ( array( 'schema', 'default_location', 'default_execution_location', 'execution_location' ) as $key ) {
+				if ( isset( $tools[ $key ] ) ) {
+					return $tools;
+				}
+			}
+		}
+
+		return $policy;
+	}
+
+	/**
+	 * @param array<string,mixed> $policy Policy candidate.
+	 */
+	private static function isSandboxPolicyDocument( array $policy ): bool {
+		if ( 'wp-codebox/sandbox-tool-policy/v1' === (string) ( $policy['schema'] ?? '' ) ) {
+			return true;
+		}
+
+		$tools = is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array();
+		if ( empty( $tools ) ) {
+			return false;
+		}
+
+		return array_is_list( $tools ) && is_array( $tools[0] ?? null ) && ( isset( $tools[0]['id'] ) || isset( $tools[0]['runtime_tool_id'] ) );
+	}
+
+	/**
+	 * Convert a sandbox transport policy list into the generic host policy shape.
+	 *
+	 * @param array<string,mixed> $policy Sandbox policy document.
+	 * @return array<string,mixed>|null
+	 */
+	private static function normalizeSandboxPolicyDocument( array $policy ): ?array {
+		$entries = is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array();
+		if ( empty( $entries ) ) {
+			return null;
+		}
+
+		$tools = array();
+
+		foreach ( $entries as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$tool_name = is_string( $entry['id'] ?? null ) && '' !== trim( (string) $entry['id'] )
+				? trim( (string) $entry['id'] )
+				: ( is_string( $entry['runtime_tool_id'] ?? null ) ? trim( (string) $entry['runtime_tool_id'] ) : '' );
+			if ( '' === $tool_name ) {
+				continue;
+			}
+
+			$location = self::sandboxExecutionLocationToHostLocation( (string) ( $entry['execution_location'] ?? '' ) );
+
+			$tools[ $tool_name ] = array( 'execution_location' => $location );
+		}
+
+		return array(
+			'default_location' => 'disabled',
+			'tools'            => $tools,
+		);
+	}
+
+	private static function sandboxExecutionLocationToHostLocation( string $location ): string {
+		$location = strtolower( trim( $location ) );
+		if ( in_array( $location, array( 'sandbox', 'runner', 'runtime_local' ), true ) ) {
+			return 'runner';
+		}
+		if ( in_array( $location, array( 'parent', 'control_plane' ), true ) ) {
+			return 'control_plane';
+		}
+
+		return 'disabled';
 	}
 }

--- a/inc/Engine/AI/Tools/HostToolPolicy.php
+++ b/inc/Engine/AI/Tools/HostToolPolicy.php
@@ -56,6 +56,18 @@ final class HostToolPolicy {
 	}
 
 	/**
+	 * Return a normalized policy snapshot from the process environment.
+	 *
+	 * This lets durable job runners capture host ownership while the launching
+	 * process still has the host-provided environment available.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	public static function environmentSnapshot(): ?array {
+		return self::normalizePolicy( self::policyFromEnvironment() );
+	}
+
+	/**
 	 * Return the execution location assigned to a tool by host policy.
 	 */
 	public function executionLocation( string $tool_name ): string {

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -14,6 +14,7 @@ use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\DataPath;
 use DataMachine\Core\JobStatus;
+use DataMachine\Engine\AI\Tools\HostToolPolicy;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -88,6 +89,7 @@ final class AgentBundleRunner {
 		$initial_data['job_source']   = (string) ( $input['job_source'] ?? 'agent_bundle' );
 		$initial_data['job_label']    = (string) ( $input['job_label'] ?? ( $selection['flow_name'] ?? 'Agent Bundle Workflow' ) );
 		$this->apply_runtime_ability_tools( $initial_data, $input, $bundle );
+		$this->apply_runtime_host_tool_policy( $initial_data, $input );
 		$this->apply_runtime_model_config( $initial_data, $input );
 
 		if ( ! empty( $input['dry_run'] ) ) {
@@ -224,6 +226,37 @@ final class AgentBundleRunner {
 		$job_snapshot                  = is_array( $initial_data['job'] ?? null ) ? $initial_data['job'] : array();
 		$job_snapshot['ability_tools'] = $ability_tools;
 		$initial_data['job']           = $job_snapshot;
+	}
+
+	/**
+	 * Project the active host tool policy into the durable job snapshot.
+	 *
+	 * Agent bundle runs can outlive the launching PHP process, so environment-only
+	 * host policy must be captured before queued AI steps resolve tools.
+	 *
+	 * @param array<string,mixed> $initial_data Initial workflow engine data.
+	 * @param array<string,mixed> $input Bundle run input.
+	 */
+	private function apply_runtime_host_tool_policy( array &$initial_data, array $input ): void {
+		$policy = null;
+		foreach ( array( 'host_tool_policy', 'external_tool_ownership_policy' ) as $key ) {
+			if ( is_array( $input[ $key ] ?? null ) ) {
+				$policy = $input[ $key ];
+				break;
+			}
+		}
+
+		if ( null === $policy ) {
+			$policy = HostToolPolicy::environmentSnapshot();
+		}
+
+		if ( empty( $policy ) || ! is_array( $policy ) ) {
+			return;
+		}
+
+		$job_snapshot                     = is_array( $initial_data['job'] ?? null ) ? $initial_data['job'] : array();
+		$job_snapshot['host_tool_policy'] = $policy;
+		$initial_data['job']              = $job_snapshot;
 	}
 
 	private function status_from_response( array $response ): string {

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -626,7 +626,7 @@ foreach ( array(
 	"\$job_snapshot['default_model']"                                         => 'runner stamps job-scoped default model',
 	"\$mode_models['pipeline']"                                               => 'runner stamps pipeline mode model config',
 	"'ability_tools'        => is_array( \$job_snapshot['ability_tools'] ?? null )" => 'AI step passes job-scoped ability tools to resolver',
-	"'host_tool_policy'    => is_array( \$job_snapshot['host_tool_policy'] ?? null )" => 'AI step passes job-scoped host tool policy to resolver',
+	"'host_tool_policy'     => is_array( \$job_snapshot['host_tool_policy'] ?? null )" => 'AI step passes job-scoped host tool policy to resolver',
 	'resolveModelFromJobSnapshot'                                             => 'AI step reads run-scoped model config',
 	'resolveModelForExecutionModes( $agent_id, $execution_modes, $job_snapshot )' => 'AI validation uses job-scoped model config',
 ) as $needle => $label ) {

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -120,6 +120,7 @@ datamachine_bundle_runner_contains( $ai_step, "\$payload['tool_recorders']", 'AI
 echo "\n[3] Runner exposes semantic outputs without hiding raw engine data\n";
 require_once $root . '/inc/Core/JobStatus.php';
 require_once $root . '/inc/Core/DataPath.php';
+require_once $root . '/inc/Engine/AI/Tools/HostToolPolicy.php';
 require_once $root . '/inc/Engine/Bundle/AgentBundleRunner.php';
 require_once $root . '/inc/Abilities/Flow/FlowHelpers.php';
 require_once $root . '/inc/Abilities/Flow/QueueAbility.php';
@@ -276,7 +277,48 @@ $apply_runtime_ability_tools->invokeArgs(
 );
 datamachine_bundle_runner_assert( empty( $initial_data['job']['ability_tools'] ?? array() ), 'runtime-specific metadata namespaces are ignored by the generic runner', $failures, $passes );
 
-echo "\n[3c] Successful tool results can be recorded into engine data\n";
+echo "\n[3c] Host tool policy is captured into durable job snapshots\n";
+$apply_runtime_host_tool_policy = $runner_reflection->getMethod( 'apply_runtime_host_tool_policy' );
+$initial_data                   = array();
+$apply_runtime_host_tool_policy->invokeArgs(
+	$runner_instance,
+	array(
+		&$initial_data,
+		array(
+			'host_tool_policy' => array(
+				'schema'           => 'datamachine/host-tool-policy/v1',
+				'default_location' => 'runner',
+				'tools'            => array(
+					'workspace_read' => array( 'execution_location' => 'control_plane' ),
+				),
+			),
+		),
+	)
+);
+datamachine_bundle_runner_assert( 'control_plane' === ( $initial_data['job']['host_tool_policy']['tools']['workspace_read']['execution_location'] ?? null ), 'explicit host tool policy is projected into job snapshot', $failures, $passes );
+
+$previous_host_policy = getenv( 'DATAMACHINE_HOST_TOOL_POLICY_JSON' );
+putenv(
+	'DATAMACHINE_HOST_TOOL_POLICY_JSON=' . json_encode(
+		array(
+			'schema'           => 'homeboy/agent-tool-policy/v1',
+			'default_location' => 'runner',
+			'tools'            => array(
+				'workspace_grep' => array( 'execution_location' => 'control_plane' ),
+			),
+		)
+	)
+);
+$initial_data = array();
+$apply_runtime_host_tool_policy->invokeArgs( $runner_instance, array( &$initial_data, array() ) );
+if ( false === $previous_host_policy ) {
+	putenv( 'DATAMACHINE_HOST_TOOL_POLICY_JSON' );
+} else {
+	putenv( 'DATAMACHINE_HOST_TOOL_POLICY_JSON=' . $previous_host_policy );
+}
+datamachine_bundle_runner_assert( 'control_plane' === ( $initial_data['job']['host_tool_policy']['tools']['workspace_grep']['execution_location'] ?? null ), 'environment host tool policy is snapshotted for queued bundle jobs', $failures, $passes );
+
+echo "\n[3d] Successful tool results can be recorded into engine data\n";
 require_once $root . '/inc/Engine/AI/conversation-loop.php';
 $GLOBALS['datamachine_bundle_runner_engine_data_merges'] = array();
 \DataMachine\Engine\AI\datamachine_record_tool_results_to_engine_data(
@@ -577,11 +619,14 @@ foreach ( array(
 	"'ability_tools'       => array("                                           => 'run-agent-bundle schema accepts runtime ability tools',
 	'apply_runtime_model_config'                                              => 'runner projects provider/model into initial data',
 	'apply_runtime_ability_tools'                                             => 'runner projects ability tools into initial data',
+	'apply_runtime_host_tool_policy'                                         => 'runner projects host tool policy into initial data',
 	"\$job_snapshot['ability_tools']"                                         => 'runner stamps job-scoped ability tool declarations',
+	"\$job_snapshot['host_tool_policy']"                                     => 'runner stamps job-scoped host tool policy',
 	"\$job_snapshot['default_provider']"                                      => 'runner stamps job-scoped default provider',
 	"\$job_snapshot['default_model']"                                         => 'runner stamps job-scoped default model',
 	"\$mode_models['pipeline']"                                               => 'runner stamps pipeline mode model config',
 	"'ability_tools'        => is_array( \$job_snapshot['ability_tools'] ?? null )" => 'AI step passes job-scoped ability tools to resolver',
+	"'host_tool_policy'    => is_array( \$job_snapshot['host_tool_policy'] ?? null )" => 'AI step passes job-scoped host tool policy to resolver',
 	'resolveModelFromJobSnapshot'                                             => 'AI step reads run-scoped model config',
 	'resolveModelForExecutionModes( $agent_id, $execution_modes, $job_snapshot )' => 'AI validation uses job-scoped model config',
 ) as $needle => $label ) {

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -534,6 +534,29 @@ $completion_assertions = new \DataMachine\Engine\AI\DataMachineCompletionAsserti
 assert_policy_equals( array(), $completion_assertions->unavailableRequiredToolNames( $resolution['tools'] ), 'complete_when_any treats delegated control-plane path as available', $failures, $passes );
 assert_policy_equals( array( 'alpha_tool', 'control_plane_ability' ), $completion_assertions->unavailableRequiredToolNames( array() ), 'complete_when_any still reports missing tools without a delegated path', $failures, $passes );
 
+echo "\n[12] host tool policy accepts default_location policy payloads:\n";
+$resolution = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->resolveWithEvidence(
+	array(
+		'mode'                => ToolPolicyResolver::MODE_PIPELINE,
+		'pipeline_step_id'    => 'ephemeral_pipeline_0',
+		'engine_data'         => array(),
+		'categories'          => array(),
+		'allow_only_explicit' => true,
+		'allow_only'          => array( 'alpha_tool', 'beta_tool' ),
+		'host_tool_policy'    => array(
+			'schema'           => 'homeboy/agent-tool-policy/v1',
+			'default_location' => 'runner',
+			'tools'            => array(
+				'alpha_tool' => array( 'execution_location' => 'control_plane' ),
+			),
+		),
+	),
+	array( 'alpha_tool' ),
+	array( 'alpha_tool', 'beta_tool' )
+);
+assert_policy_equals( 'client', $resolution['tools']['alpha_tool']['executor'] ?? null, 'default_location host policy delegates explicit control-plane tool', $failures, $passes );
+assert_policy_equals( null, $resolution['tools']['beta_tool']['executor'] ?? null, 'default_location host policy leaves runner-default tool local', $failures, $passes );
+
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " pipeline policy assertions failed.\n";
 	exit( 1 );

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -557,6 +557,64 @@ $resolution = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->res
 assert_policy_equals( 'client', $resolution['tools']['alpha_tool']['executor'] ?? null, 'default_location host policy delegates explicit control-plane tool', $failures, $passes );
 assert_policy_equals( null, $resolution['tools']['beta_tool']['executor'] ?? null, 'default_location host policy leaves runner-default tool local', $failures, $passes );
 
+echo "\n[13] host tool policy accepts wrapped runtime policy payloads:\n";
+$wrapped_policy = array(
+	'apply' => 'propose_only',
+	'read'  => 'workspace',
+	'tools' => array(
+		'schema'           => 'homeboy/agent-tool-policy/v1',
+		'default_location' => 'runner',
+		'tools'            => array(
+			'alpha_tool' => array( 'execution_location' => 'control_plane' ),
+		),
+	),
+	'write' => 'artifacts_only',
+);
+$resolution     = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->resolve(
+	array(
+		'mode'                => ToolPolicyResolver::MODE_PIPELINE,
+		'pipeline_step_id'    => 'ephemeral_pipeline_0',
+		'engine_data'         => array(),
+		'categories'          => array(),
+		'allow_only_explicit' => true,
+		'allow_only'          => array( 'alpha_tool', 'beta_tool' ),
+		'host_tool_policy'    => $wrapped_policy,
+	)
+);
+assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'wrapped policy delegates explicit control-plane tool', $failures, $passes );
+assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'wrapped policy leaves runner-default tool local', $failures, $passes );
+
+echo "\n[14] host tool policy accepts sandbox transport policy payloads:\n";
+$sandbox_policy = array(
+	'schema'   => 'wp-codebox/sandbox-tool-policy/v1',
+	'version'  => 1,
+	'tools'    => array(
+		array(
+			'id'                 => 'alpha_tool',
+			'runtime_tool_id'    => 'alpha_tool',
+			'execution_location' => 'parent',
+		),
+		array(
+			'id'                 => 'beta_tool',
+			'runtime_tool_id'    => 'beta_tool',
+			'execution_location' => 'sandbox',
+		),
+	),
+);
+$resolution     = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->resolve(
+	array(
+		'mode'                => ToolPolicyResolver::MODE_PIPELINE,
+		'pipeline_step_id'    => 'ephemeral_pipeline_0',
+		'engine_data'         => array(),
+		'categories'          => array(),
+		'allow_only_explicit' => true,
+		'allow_only'          => array( 'alpha_tool', 'beta_tool' ),
+		'host_tool_policy'    => $sandbox_policy,
+	)
+);
+assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'sandbox policy delegates parent-visible tool', $failures, $passes );
+assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'sandbox policy leaves sandbox-local tool local', $failures, $passes );
+
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " pipeline policy assertions failed.\n";
 	exit( 1 );


### PR DESCRIPTION
## Summary
- snapshot active host tool policy into agent bundle job data before queued execution
- pass the durable host policy snapshot into AI tool resolution
- normalize wrapped runtime/sandbox policy payloads into Data Machine host tool policy shape
- cover explicit/env host policy snapshotting, default_location policy payloads, and wrapped/sandbox payloads

## Verification
- php tests/agent-bundle-runner-contract-smoke.php
- php tests/pipeline-tool-policy-snapshot-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the host policy snapshot/normalization implementation and focused smoke coverage; Chris reviewed direction and constraints during iteration.
