### PR TITLE
Add append-once engine state ledger writes

### DIFF
--- a/inc/Core/EngineData.php
+++ b/inc/Core/EngineData.php
@@ -259,6 +259,50 @@ class EngineData {
 	}
 
 	/**
+	 * Append a replayable state event once per deterministic operation id.
+	 *
+	 * Duplicate operation ids return the existing ledger event without reapplying the patch.
+	 *
+	 * @param int    $job_id   Job ID.
+	 * @param string $op_id    Deterministic operation id.
+	 * @param string $type     Generic event type.
+	 * @param array  $patch    Engine data patch to project onto the snapshot.
+	 * @param array  $metadata Optional event metadata.
+	 * @return array|null Appended or existing trace entry on success, null on failure.
+	 */
+	public static function appendStateEventOnce( int $job_id, string $op_id, string $type, array $patch, array $metadata = array() ): ?array {
+		$op_id = trim( $op_id );
+		if ( $job_id <= 0 || '' === $op_id || '' === trim( $type ) ) {
+			return null;
+		}
+
+		$metadata['op_id'] = $op_id;
+		$event             = null;
+		$result            = self::mutate(
+			$job_id,
+			static function ( array $current ) use ( $op_id, $type, $patch, $metadata, &$event ): ?array {
+				$existing = EngineStateLedger::findByOpId( $current, $op_id );
+				if ( null !== $existing ) {
+					$event = $existing;
+					return $current;
+				}
+
+				$projection = EngineStateLedger::append( $current, $type, $patch, $metadata );
+				if ( null === $projection ) {
+					return null;
+				}
+
+				$event = $projection['event'];
+
+				return $projection['snapshot'];
+			},
+			$type
+		);
+
+		return ! empty( $result['success'] ) ? $event : null;
+	}
+
+	/**
 	 * Return replayable state ledger events from a snapshot.
 	 *
 	 * @param array $snapshot Engine data snapshot.

--- a/inc/Core/EngineStateLedger.php
+++ b/inc/Core/EngineStateLedger.php
@@ -71,6 +71,20 @@ class EngineStateLedger {
 	}
 
 	/**
+	 * Append a replayable event to a persisted job snapshot once per operation id.
+	 *
+	 * @param int    $job_id   Job ID.
+	 * @param string $op_id    Deterministic operation id.
+	 * @param string $type     Event type.
+	 * @param array  $patch    Engine data patch.
+	 * @param array  $metadata Optional event metadata.
+	 * @return array|null Appended event, existing event for duplicate op_id, or null on failure.
+	 */
+	public static function appendOnce( int $job_id, string $op_id, string $type, array $patch, array $metadata = array() ): ?array {
+		return EngineData::appendStateEventOnce( $job_id, $op_id, $type, $patch, $metadata );
+	}
+
+	/**
 	 * Return ledger events from a snapshot.
 	 *
 	 * @param array $snapshot Engine data snapshot.
@@ -78,6 +92,28 @@ class EngineStateLedger {
 	 */
 	public static function fromSnapshot( array $snapshot ): array {
 		return is_array( $snapshot[ self::SNAPSHOT_KEY ] ?? null ) ? $snapshot[ self::SNAPSHOT_KEY ] : array();
+	}
+
+	/**
+	 * Return the first ledger event matching an operation id.
+	 *
+	 * @param array  $snapshot Engine data snapshot.
+	 * @param string $op_id    Operation id.
+	 * @return array|null Matching ledger event, or null when absent.
+	 */
+	public static function findByOpId( array $snapshot, string $op_id ): ?array {
+		$op_id = trim( $op_id );
+		if ( '' === $op_id ) {
+			return null;
+		}
+
+		foreach ( self::fromSnapshot( $snapshot ) as $event ) {
+			if ( is_array( $event ) && $op_id === (string) ( $event['op_id'] ?? '' ) ) {
+				return $event;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/inc/Core/EngineStateLedger.php
+++ b/inc/Core/EngineStateLedger.php
@@ -108,7 +108,7 @@ class EngineStateLedger {
 		}
 
 		foreach ( self::fromSnapshot( $snapshot ) as $event ) {
-			if ( is_array( $event ) && $op_id === (string) ( $event['op_id'] ?? '' ) ) {
+			if ( is_array( $event ) && (string) ( $event['op_id'] ?? '' ) === $op_id ) {
 				return $event;
 			}
 		}

--- a/inc/Engine/Filters/EngineData.php
+++ b/inc/Engine/Filters/EngineData.php
@@ -71,6 +71,33 @@ function datamachine_append_engine_state_event( int $job_id, string $type, array
 }
 
 /**
+ * Append a replayable engine state event once per deterministic operation id.
+ *
+ * @param int    $job_id   Job ID.
+ * @param string $op_id    Deterministic operation id.
+ * @param string $type     Generic event type.
+ * @param array  $patch    Engine data patch to project onto the snapshot.
+ * @param array  $metadata Optional event metadata.
+ * @return array|null Appended ledger entry, existing entry for duplicate op_id, or null on failure.
+ */
+function datamachine_append_engine_state_event_once( int $job_id, string $op_id, string $type, array $patch, array $metadata = array() ): ?array {
+	$existing = \DataMachine\Core\EngineStateLedger::findByOpId( \DataMachine\Core\EngineData::retrieve( $job_id ), $op_id );
+	if ( null !== $existing ) {
+		return $existing;
+	}
+
+	$entry = \DataMachine\Core\EngineData::appendStateEventOnce( $job_id, $op_id, $type, $patch, $metadata );
+	if ( is_array( $entry ) ) {
+		$snapshot = \DataMachine\Core\EngineData::retrieve( $job_id );
+		if ( datamachine_engine_data_should_write_artifact_files( $snapshot ) ) {
+			datamachine_write_engine_data_artifact_files( $job_id );
+		}
+	}
+
+	return $entry;
+}
+
+/**
  * Determine whether an engine data snapshot has enough runtime artifact data to
  * emit first-class transcript/tool-trace files.
  *

--- a/tests/engine-state-ledger-smoke.php
+++ b/tests/engine-state-ledger-smoke.php
@@ -19,6 +19,25 @@ namespace DataMachine\Core\Database\Jobs {
 			self::$engine_data[ $job_id ] = $data;
 			return true;
 		}
+
+		public function compare_and_swap_engine_data( int $job_id, array $expected_data, array $new_data ): array {
+			$current = self::$engine_data[ $job_id ] ?? array();
+			if ( $current !== $expected_data ) {
+				return array(
+					'updated'  => false,
+					'conflict' => true,
+					'error'    => null,
+				);
+			}
+
+			self::$engine_data[ $job_id ] = $new_data;
+
+			return array(
+				'updated'  => true,
+				'conflict' => false,
+				'error'    => null,
+			);
+		}
 	}
 }
 
@@ -106,17 +125,48 @@ namespace {
 			'source' => 'artifact-writer',
 		)
 	);
+	$once_first = \datamachine_append_engine_state_event_once(
+		101,
+		'op-once-001',
+		'runtime_state_patch',
+		array( 'append_once' => array( 'first' => 'kept' ) ),
+		array(
+			'actor'  => 'test-runner',
+			'source' => 'append-once-path',
+		)
+	);
+	$once_duplicate = \DataMachine\Core\EngineStateLedger::appendOnce(
+		101,
+		'op-once-001',
+		'runtime_state_patch',
+		array( 'append_once' => array( 'first' => 'duplicate-applied' ) ),
+		array(
+			'actor'  => 'test-runner',
+			'source' => 'append-once-path',
+		)
+	);
+	$once_missing_op = \datamachine_append_engine_state_event_once(
+		101,
+		'',
+		'runtime_state_patch',
+		array( 'append_once' => array( 'invalid' => true ) )
+	);
 
 	$snapshot        = \datamachine_get_engine_data( 101 );
 	$ledger          = \DataMachine\Core\EngineStateLedger::fromSnapshot( $snapshot );
+	$once_event      = \DataMachine\Core\EngineStateLedger::findByOpId( $snapshot, 'op-once-001' );
 	$replayed        = \DataMachine\Core\EngineStateLedger::replaySnapshotLedger( $snapshot, array( 'existing' => 'snapshot-value', 'nested' => array( 'before' => true ) ) );
 	$replay_expected = \DataMachine\Core\EngineStateLedger::snapshotForHashing( $snapshot );
 
 	datamachine_engine_state_ledger_assert( 1 === ( $first['version'] ?? null ), 'first append starts at version 1', $failures, $passes );
 	datamachine_engine_state_ledger_assert( 2 === ( $second['version'] ?? null ), 'second append increments version monotonically', $failures, $passes );
-	datamachine_engine_state_ledger_assert( 2 === count( $ledger ), 'append path preserves both ledger entries', $failures, $passes );
+	datamachine_engine_state_ledger_assert( 3 === ( $once_first['version'] ?? null ), 'append-once append increments version once', $failures, $passes );
+	datamachine_engine_state_ledger_assert( $once_first === $once_duplicate, 'append-once duplicate returns existing ledger event', $failures, $passes );
+	datamachine_engine_state_ledger_assert( null === $once_missing_op, 'append-once rejects empty operation id', $failures, $passes );
+	datamachine_engine_state_ledger_assert( 3 === count( $ledger ), 'append-once suppresses duplicate ledger entries', $failures, $passes );
 	datamachine_engine_state_ledger_assert( 'snapshot-value' === ( $snapshot['existing'] ?? null ), 'snapshot compatibility preserves existing keys', $failures, $passes );
 	datamachine_engine_state_ledger_assert( 'alpha' === ( $snapshot['tool_outputs']['first'] ?? null ), 'snapshot projection includes appended patch data', $failures, $passes );
+	datamachine_engine_state_ledger_assert( 'kept' === ( $snapshot['append_once']['first'] ?? null ), 'append-once duplicate does not reapply patch data', $failures, $passes );
 	datamachine_engine_state_ledger_assert( true === ( $snapshot['nested']['before'] ?? null ) && true === ( $snapshot['nested']['after'] ?? null ), 'snapshot projection recursively merges patches', $failures, $passes );
 	datamachine_engine_state_ledger_assert( 1 === ( $ledger[0]['schema_version'] ?? null ), 'ledger records schema version', $failures, $passes );
 	datamachine_engine_state_ledger_assert( 'tool_result_recorded' === ( $ledger[0]['event_type'] ?? null ), 'ledger records event type alias', $failures, $passes );
@@ -128,6 +178,7 @@ namespace {
 	datamachine_engine_state_ledger_assert( is_string( $ledger[1]['patch_hash'] ?? null ) && 0 === strpos( $ledger[1]['patch_hash'], 'sha256:' ), 'ledger records deterministic patch hash', $failures, $passes );
 	datamachine_engine_state_ledger_assert( is_string( $ledger[1]['pre_snapshot_hash'] ?? null ) && 0 === strpos( $ledger[1]['pre_snapshot_hash'], 'sha256:' ), 'ledger records pre snapshot hash', $failures, $passes );
 	datamachine_engine_state_ledger_assert( is_string( $ledger[1]['post_snapshot_hash'] ?? null ) && 0 === strpos( $ledger[1]['post_snapshot_hash'], 'sha256:' ), 'ledger records post snapshot hash', $failures, $passes );
+	datamachine_engine_state_ledger_assert( $once_first === $once_event, 'ledger can query by operation id', $failures, $passes );
 	datamachine_engine_state_ledger_assert( $replay_expected === $replayed, 'ledger events replay to snapshot projection', $failures, $passes );
 
 	if ( ! empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- Add append-once engine state ledger writes keyed by deterministic operation id.
- Return existing ledger entries for duplicate op ids without reapplying patches.
- Add an operation-id lookup helper and focused smoke coverage for append-once behavior.

## Tests
-   PASS first append starts at version 1
  PASS second append increments version monotonically
  PASS append-once append increments version once
  PASS append-once duplicate returns existing ledger event
  PASS append-once rejects empty operation id
  PASS append-once suppresses duplicate ledger entries
  PASS snapshot compatibility preserves existing keys
  PASS snapshot projection includes appended patch data
  PASS append-once duplicate does not reapply patch data
  PASS snapshot projection recursively merges patches
  PASS ledger records schema version
  PASS ledger records event type alias
  PASS ledger records operation id
  PASS ledger records actor
  PASS ledger records source
  PASS ledger stores replayable patch body
  PASS ledger records compact patch keys
  PASS ledger records deterministic patch hash
  PASS ledger records pre snapshot hash
  PASS ledger records post snapshot hash
  PASS ledger can query by operation id
  PASS ledger events replay to snapshot projection

Engine state ledger smoke passed (22 assertions).
- 
- 

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the narrow append-once ledger API and focused smoke coverage; Chris to review and validate before merge.