### PR TITLE
Add indexed run metadata and artifact manifests

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -788,6 +788,7 @@ function datamachine_ensure_all_tables() {
 	$db_identity_index->create_table();
 
 	\DataMachine\Core\Database\BundleArtifacts\InstalledBundleArtifacts::create_table();
+	\DataMachine\Core\Database\RunMetadata\RunMetadata::create_table();
 
 	\DataMachine\Core\Database\Chat\Chat::create_table();
 	\DataMachine\Core\Database\Chat\Chat::ensure_owner_columns();

--- a/inc/Core/ArtifactManifest.php
+++ b/inc/Core/ArtifactManifest.php
@@ -64,7 +64,7 @@ class ArtifactManifest {
 		}
 
 		foreach ( $manifests as $manifest ) {
-			if ( is_array( $manifest ) && $artifact_ref === (string) ( $manifest['artifact_ref'] ?? '' ) ) {
+			if ( is_array( $manifest ) && (string) ( $manifest['artifact_ref'] ?? '' ) === $artifact_ref ) {
 				return array(
 					'success'  => true,
 					'artifact' => self::public_metadata( $manifest ),

--- a/inc/Core/ArtifactManifest.php
+++ b/inc/Core/ArtifactManifest.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Generic artifact manifest helpers.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+class ArtifactManifest {
+
+	public const SCHEMA_VERSION = 1;
+
+	/**
+	 * Build portable manifest metadata for stored artifact content.
+	 *
+	 * @param array<string,mixed> $args Manifest arguments.
+	 * @return array<string,mixed>
+	 */
+	public static function create( array $args ): array {
+		$content = isset( $args['content'] ) && is_string( $args['content'] ) ? $args['content'] : '';
+		$ref     = self::text( $args['artifact_ref'] ?? '' );
+		$type    = self::key( $args['artifact_type'] ?? ( $args['type'] ?? '' ) );
+
+		if ( '' === $ref || '' === $type ) {
+			return array();
+		}
+
+		$manifest = array(
+			'artifact_ref'    => $ref,
+			'artifact_type'   => $type,
+			'type'            => $type,
+			'schema_version'  => self::SCHEMA_VERSION,
+			'sha256'          => hash( 'sha256', $content ),
+			'bytes'           => strlen( $content ),
+			'relative_path'   => self::text( $args['relative_path'] ?? '' ),
+			'export_url'      => self::url( $args['export_url'] ?? '' ),
+			'signed_url'      => self::url( $args['signed_url'] ?? '' ),
+			'retention_scope' => self::key( $args['retention_scope'] ?? '' ),
+			'payload_sha256'  => self::text( $args['payload_sha256'] ?? '' ),
+			'written_at'      => self::text( $args['written_at'] ?? gmdate( 'c' ) ),
+			'local_debug'     => is_array( $args['local_debug'] ?? null ) ? self::filter_present( $args['local_debug'] ) : null,
+		);
+
+		return self::filter_present( $manifest );
+	}
+
+	/**
+	 * Resolve an artifact ref from a manifest list.
+	 *
+	 * @param string              $artifact_ref Portable artifact ref.
+	 * @param array<string,mixed> $manifests    Manifest list keyed by artifact key.
+	 * @return array{success:bool,artifact?:array<string,mixed>,error?:string}
+	 */
+	public static function resolve( string $artifact_ref, array $manifests ): array {
+		$artifact_ref = self::text( $artifact_ref );
+		if ( '' === $artifact_ref ) {
+			return array(
+				'success' => false,
+				'error'   => 'artifact_ref must be a non-empty string.',
+			);
+		}
+
+		foreach ( $manifests as $manifest ) {
+			if ( is_array( $manifest ) && $artifact_ref === (string) ( $manifest['artifact_ref'] ?? '' ) ) {
+				return array(
+					'success'  => true,
+					'artifact' => self::public_metadata( $manifest ),
+				);
+			}
+		}
+
+		return array(
+			'success' => false,
+			'error'   => sprintf( 'Artifact ref %s was not found.', $artifact_ref ),
+		);
+	}
+
+	/**
+	 * Hydrate and verify artifact content from a caller-provided content resolver.
+	 *
+	 * @param string   $artifact_ref Portable artifact ref.
+	 * @param array    $manifests    Manifest list keyed by artifact key.
+	 * @param callable $resolver     Receives public manifest metadata and returns content string or null.
+	 * @return array{success:bool,artifact?:array<string,mixed>,content?:string,bytes?:int,sha256?:string,verified?:bool,error?:string}
+	 */
+	public static function hydrate( string $artifact_ref, array $manifests, callable $resolver ): array {
+		$resolved = self::resolve( $artifact_ref, $manifests );
+		if ( empty( $resolved['success'] ) || ! is_array( $resolved['artifact'] ?? null ) ) {
+			return array(
+				'success' => false,
+				'error'   => (string) ( $resolved['error'] ?? 'Artifact metadata was not found.' ),
+			);
+		}
+
+		$artifact = $resolved['artifact'];
+		$content  = $resolver( $artifact );
+		if ( ! is_string( $content ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Artifact content is unavailable from configured artifact storage.',
+			);
+		}
+
+		$bytes  = strlen( $content );
+		$sha256 = hash( 'sha256', $content );
+		$verify = self::verify( $artifact, $bytes, $sha256 );
+		if ( empty( $verify['success'] ) ) {
+			return array(
+				'success'  => false,
+				'artifact' => $artifact,
+				'bytes'    => $bytes,
+				'sha256'   => $sha256,
+				'error'    => (string) ( $verify['error'] ?? 'Artifact content failed integrity verification.' ),
+			);
+		}
+
+		return array(
+			'success'  => true,
+			'artifact' => $artifact,
+			'content'  => $content,
+			'bytes'    => $bytes,
+			'sha256'   => $sha256,
+			'verified' => true,
+		);
+	}
+
+	/**
+	 * Verify artifact bytes and sha256 against manifest metadata.
+	 *
+	 * @param array<string,mixed> $artifact Artifact metadata.
+	 * @param int                 $bytes    Observed byte count.
+	 * @param string              $sha256   Observed sha256.
+	 * @return array{success:bool,error?:string}
+	 */
+	public static function verify( array $artifact, int $bytes, string $sha256 ): array {
+		$expected_bytes = isset( $artifact['bytes'] ) ? (int) $artifact['bytes'] : null;
+		if ( null !== $expected_bytes && $expected_bytes !== $bytes ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Artifact byte count mismatch: expected %d, got %d.', $expected_bytes, $bytes ),
+			);
+		}
+
+		$expected_sha256 = strtolower( trim( (string) ( $artifact['sha256'] ?? '' ) ) );
+		if ( '' !== $expected_sha256 && ! hash_equals( $expected_sha256, $sha256 ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Artifact sha256 mismatch.',
+			);
+		}
+
+		return array( 'success' => true );
+	}
+
+	/**
+	 * @param array<string,mixed> $artifact Artifact metadata.
+	 * @return array<string,mixed>
+	 */
+	public static function public_metadata( array $artifact ): array {
+		unset( $artifact['local_debug'] );
+		return $artifact;
+	}
+
+	/**
+	 * @param array<string,mixed> $value Raw metadata.
+	 * @return array<string,mixed>
+	 */
+	private static function filter_present( array $value ): array {
+		if ( class_exists( DataPath::class ) ) {
+			return DataPath::filterPresent( $value );
+		}
+
+		return array_filter(
+			$value,
+			static fn( $item ): bool => null !== $item && '' !== $item && array() !== $item
+		);
+	}
+
+	private static function key( mixed $value ): string {
+		return sanitize_key( (string) $value );
+	}
+
+	private static function text( mixed $value ): string {
+		return sanitize_text_field( (string) $value );
+	}
+
+	private static function url( mixed $value ): string {
+		$value = trim( (string) $value );
+		return '' === $value ? '' : esc_url_raw( $value );
+	}
+}

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -926,7 +926,7 @@ class Jobs extends BaseRepository {
 			);
 		}
 
-		$scan_limit       = max( $per_page + $offset, min( 5000, (int) ( $args['metadata_scan_limit'] ?? 1000 ) ) );
+		$scan_limit = max( $per_page + $offset, min( 5000, (int) ( $args['metadata_scan_limit'] ?? 1000 ) ) );
 
 		$query_args                         = $args;
 		$query_args['per_page']             = $scan_limit;

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -18,6 +18,7 @@ namespace DataMachine\Core\Database\Jobs;
 
 use DataMachine\Core\Database\BaseRepository;
 use DataMachine\Core\Database\LifecycleStateTransition;
+use DataMachine\Core\Database\RunMetadata\RunMetadata;
 use DataMachine\Core\ExecutionQuery;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\RunMetrics;
@@ -739,6 +740,12 @@ class Jobs extends BaseRepository {
 			$where_values[]  = sanitize_text_field( $args['source'] );
 		}
 
+		$job_id_filter = array_values( array_filter( array_map( 'absint', (array) ( $args['job_ids'] ?? array() ) ) ) );
+		if ( ! empty( $job_id_filter ) ) {
+			$where_clauses[] = 'j.job_id IN (' . implode( ',', array_fill( 0, count( $job_id_filter ), '%d' ) ) . ')';
+			$where_values    = array_merge( $where_values, $job_id_filter );
+		}
+
 		if ( ! empty( $args['handler'] ) ) {
 			$handler = sanitize_key( (string) $args['handler'] );
 			if ( '' !== $handler ) {
@@ -888,6 +895,37 @@ class Jobs extends BaseRepository {
 		$metadata_filters = ExecutionQuery::normalize_metadata_filters( $args['metadata'] ?? array() );
 		$per_page         = max( 1, min( 500, (int) ( $args['per_page'] ?? 50 ) ) );
 		$offset           = max( 0, (int) ( $args['offset'] ?? 0 ) );
+		$run_metadata     = new RunMetadata();
+		$matching_job_ids = $run_metadata->query_job_ids( $metadata_filters, $per_page, $offset );
+		$total            = $run_metadata->count_jobs( $metadata_filters );
+		if ( ! empty( $matching_job_ids ) || $total > 0 ) {
+			if ( empty( $matching_job_ids ) ) {
+				return array(
+					'jobs'       => array(),
+					'total'      => $total,
+					'scanned'    => 0,
+					'scan_limit' => $per_page,
+					'filters'    => $metadata_filters,
+					'indexed'    => true,
+				);
+			}
+
+			$query_args             = $args;
+			$query_args['job_ids']  = $matching_job_ids;
+			$query_args['per_page'] = $per_page;
+			$query_args['offset']   = 0;
+			unset( $query_args['metadata'], $query_args['metadata_scan_limit'], $query_args['engine_data_contains'] );
+
+			return array(
+				'jobs'       => $this->get_jobs_for_list_table( $query_args ),
+				'total'      => $total,
+				'scanned'    => count( $matching_job_ids ),
+				'scan_limit' => $per_page,
+				'filters'    => $metadata_filters,
+				'indexed'    => true,
+			);
+		}
+
 		$scan_limit       = max( $per_page + $offset, min( 5000, (int) ( $args['metadata_scan_limit'] ?? 1000 ) ) );
 
 		$query_args                         = $args;
@@ -929,6 +967,7 @@ class Jobs extends BaseRepository {
 			'scanned'    => count( $candidates ),
 			'scan_limit' => $scan_limit,
 			'filters'    => $metadata_filters,
+			'indexed'    => false,
 		);
 	}
 
@@ -1317,6 +1356,7 @@ class Jobs extends BaseRepository {
 		}
 
 		wp_cache_set( $job_id, $data, 'datamachine_engine_data' );
+		( new RunMetadata() )->replace_for_engine_data( $job_id, $data );
 
 		do_action(
 			'datamachine_log',
@@ -1398,6 +1438,7 @@ class Jobs extends BaseRepository {
 		}
 
 		wp_cache_set( $job_id, $new_data, 'datamachine_engine_data' );
+		( new RunMetadata() )->replace_for_engine_data( $job_id, $new_data );
 
 		return array(
 			'updated'  => true,

--- a/inc/Core/Database/RunMetadata/RunMetadata.php
+++ b/inc/Core/Database/RunMetadata/RunMetadata.php
@@ -1,0 +1,275 @@
+<?php
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Data Machine owns this custom operational index table.
+/**
+ * Indexed run metadata repository.
+ *
+ * @package DataMachine\Core\Database\RunMetadata
+ */
+
+namespace DataMachine\Core\Database\RunMetadata;
+
+use DataMachine\Core\Database\BaseRepository;
+use DataMachine\Core\ExecutionQuery;
+
+defined( 'ABSPATH' ) || exit;
+
+final class RunMetadata extends BaseRepository {
+
+	public const TABLE_NAME = 'datamachine_run_metadata';
+
+	private const MAX_PATH_LENGTH  = 191;
+	private const MAX_VALUE_LENGTH = 191;
+
+	/**
+	 * Create indexed run metadata table.
+	 *
+	 * @return void
+	 */
+	public static function create_table(): void {
+		global $wpdb;
+
+		$table_name      = $wpdb->prefix . self::TABLE_NAME;
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE {$table_name} (
+			metadata_id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+			job_id BIGINT(20) UNSIGNED NOT NULL,
+			metadata_path VARCHAR(191) NOT NULL,
+			metadata_value VARCHAR(191) NOT NULL,
+			value_type VARCHAR(20) NOT NULL DEFAULT 'string',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			PRIMARY KEY (metadata_id),
+			UNIQUE KEY job_path (job_id, metadata_path),
+			KEY path_value (metadata_path, metadata_value),
+			KEY job_id (job_id)
+		) {$charset_collate};";
+
+		if ( ! function_exists( 'dbDelta' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		}
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Replace indexed metadata for a job.
+	 *
+	 * @param int                 $job_id   Job ID.
+	 * @param array<string,mixed> $metadata Metadata keyed by dot-path.
+	 * @return bool
+	 */
+	public function replace_for_job( int $job_id, array $metadata ): bool {
+		if ( $job_id <= 0 ) {
+			return false;
+		}
+
+		$rows = $this->normalize_rows( $job_id, $metadata );
+		$this->wpdb->delete( $this->table_name, array( 'job_id' => $job_id ), array( '%d' ) );
+		if ( empty( $rows ) ) {
+			return true;
+		}
+
+		foreach ( $rows as $row ) {
+			$result = $this->wpdb->replace(
+				$this->table_name,
+				$row,
+				array( '%d', '%s', '%s', '%s', '%s', '%s' )
+			);
+			if ( false === $result ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Index configured metadata paths from an engine snapshot.
+	 *
+	 * @param int                 $job_id      Job ID.
+	 * @param array<string,mixed> $engine_data Engine data snapshot.
+	 * @return bool
+	 */
+	public function replace_for_engine_data( int $job_id, array $engine_data ): bool {
+		$paths = apply_filters( 'datamachine_run_metadata_index_paths', array(), $job_id, $engine_data );
+		if ( ! is_array( $paths ) ) {
+			$paths = array();
+		}
+		$paths = array_values( array_filter( array_map( 'strval', $paths ) ) );
+		if ( empty( $paths ) ) {
+			return true;
+		}
+
+		$metadata = array();
+		foreach ( $paths as $path ) {
+			$path = sanitize_text_field( (string) $path );
+			if ( '' === $path ) {
+				continue;
+			}
+
+			$value = ExecutionQuery::get_path_value( $engine_data, $path );
+			if ( null !== $value && is_scalar( $value ) ) {
+				$metadata[ $path ] = $value;
+			}
+		}
+
+		return $this->replace_for_job( $job_id, $metadata );
+	}
+
+	/**
+	 * Query job IDs that match every exact metadata filter.
+	 *
+	 * @param array<string,mixed> $metadata_filters Metadata filters keyed by dot-path.
+	 * @param int                 $limit            Max rows.
+	 * @param int                 $offset           Offset.
+	 * @return array<int,int>
+	 */
+	public function query_job_ids( array $metadata_filters, int $limit = 50, int $offset = 0 ): array {
+		$filters = ExecutionQuery::normalize_metadata_filters( $metadata_filters );
+		if ( empty( $filters ) ) {
+			return array();
+		}
+
+		$limit        = max( 1, min( 500, $limit ) );
+		$offset       = max( 0, $offset );
+		$where_parts  = array();
+		$where_values = array();
+		foreach ( $filters as $path => $value ) {
+			$normalized = $this->normalize_value( $value );
+			if ( null === $normalized ) {
+				return array();
+			}
+
+			$where_parts[]  = '(metadata_path = %s AND metadata_value = %s)';
+			$where_values[] = $this->bounded_path( $path );
+			$where_values[] = $normalized['metadata_value'];
+		}
+
+		$where_sql = implode( ' OR ', $where_parts );
+		$needed    = count( $filters );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+		$query = $this->wpdb->prepare(
+			"SELECT job_id
+			 FROM {$this->table_name}
+			 WHERE {$where_sql}
+			 GROUP BY job_id
+			 HAVING COUNT(DISTINCT metadata_path) = %d
+			 ORDER BY job_id DESC
+			 LIMIT %d OFFSET %d",
+			array_merge( $where_values, array( $needed, $limit, $offset ) )
+		);
+		$rows  = $this->wpdb->get_col( $query );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+
+		return array_map( 'intval', is_array( $rows ) ? $rows : array() );
+	}
+
+	/**
+	 * Count jobs that match every exact metadata filter.
+	 *
+	 * @param array<string,mixed> $metadata_filters Metadata filters keyed by dot-path.
+	 * @return int
+	 */
+	public function count_jobs( array $metadata_filters ): int {
+		$filters = ExecutionQuery::normalize_metadata_filters( $metadata_filters );
+		if ( empty( $filters ) ) {
+			return 0;
+		}
+
+		$where_parts  = array();
+		$where_values = array();
+		foreach ( $filters as $path => $value ) {
+			$normalized = $this->normalize_value( $value );
+			if ( null === $normalized ) {
+				return 0;
+			}
+
+			$where_parts[]  = '(metadata_path = %s AND metadata_value = %s)';
+			$where_values[] = $this->bounded_path( $path );
+			$where_values[] = $normalized['metadata_value'];
+		}
+
+		$where_sql = implode( ' OR ', $where_parts );
+		$needed    = count( $filters );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+		$query = $this->wpdb->prepare(
+			"SELECT COUNT(*) FROM (
+				SELECT job_id
+				FROM {$this->table_name}
+				WHERE {$where_sql}
+				GROUP BY job_id
+				HAVING COUNT(DISTINCT metadata_path) = %d
+			) matches",
+			array_merge( $where_values, array( $needed ) )
+		);
+		$count = $this->wpdb->get_var( $query );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+
+		return (int) $count;
+	}
+
+	/**
+	 * @param array<string,mixed> $metadata Metadata keyed by dot-path.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function normalize_rows( int $job_id, array $metadata ): array {
+		$rows = array();
+		$now  = gmdate( 'Y-m-d H:i:s' );
+		foreach ( ExecutionQuery::normalize_metadata_filters( $metadata ) as $path => $value ) {
+			$normalized = $this->normalize_value( $value );
+			if ( null === $normalized ) {
+				continue;
+			}
+
+			$rows[] = array(
+				'job_id'         => $job_id,
+				'metadata_path'  => $this->bounded_path( $path ),
+				'metadata_value' => $normalized['metadata_value'],
+				'value_type'     => $normalized['value_type'],
+				'created_at'     => $now,
+				'updated_at'     => $now,
+			);
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * @return array{metadata_value:string,value_type:string}|null
+	 */
+	private function normalize_value( mixed $value ): ?array {
+		if ( is_bool( $value ) ) {
+			return array(
+				'metadata_value' => $value ? 'true' : 'false',
+				'value_type'     => 'bool',
+			);
+		}
+
+		if ( is_int( $value ) || is_float( $value ) ) {
+			return array(
+				'metadata_value' => substr( (string) $value, 0, self::MAX_VALUE_LENGTH ),
+				'value_type'     => is_int( $value ) ? 'int' : 'float',
+			);
+		}
+
+		if ( is_string( $value ) ) {
+			$value = sanitize_text_field( $value );
+			if ( '' === $value ) {
+				return null;
+			}
+
+			return array(
+				'metadata_value' => substr( $value, 0, self::MAX_VALUE_LENGTH ),
+				'value_type'     => 'string',
+			);
+		}
+
+		return null;
+	}
+
+	private function bounded_path( string $path ): string {
+		return substr( sanitize_text_field( $path ), 0, self::MAX_PATH_LENGTH );
+	}
+}

--- a/inc/Core/Database/RunMetadata/RunMetadata.php
+++ b/inc/Core/Database/RunMetadata/RunMetadata.php
@@ -148,7 +148,7 @@ final class RunMetadata extends BaseRepository {
 		$where_sql = implode( ' OR ', $where_parts );
 		$needed    = count( $filters );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		$query = $this->wpdb->prepare(
 			"SELECT job_id
 			 FROM {$this->table_name}
@@ -160,7 +160,7 @@ final class RunMetadata extends BaseRepository {
 			array_merge( $where_values, array( $needed, $limit, $offset ) )
 		);
 		$rows  = $this->wpdb->get_col( $query );
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
 		return array_map( 'intval', is_array( $rows ) ? $rows : array() );
 	}

--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -654,29 +654,12 @@ class JobArtifacts {
 
 	/** @return array{success: bool, error?: string} */
 	private function verify_artifact_content( array $artifact, int $bytes, string $sha256 ): array {
-		$expected_bytes = isset( $artifact['bytes'] ) ? (int) $artifact['bytes'] : null;
-		if ( null !== $expected_bytes && $expected_bytes !== $bytes ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Artifact byte count mismatch: expected %d, got %d.', $expected_bytes, $bytes ),
-			);
-		}
-
-		$expected_sha256 = strtolower( trim( (string) ( $artifact['sha256'] ?? '' ) ) );
-		if ( '' !== $expected_sha256 && ! hash_equals( $expected_sha256, $sha256 ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Artifact sha256 mismatch.',
-			);
-		}
-
-		return array( 'success' => true );
+		return ArtifactManifest::verify( $artifact, $bytes, $sha256 );
 	}
 
 	/** @return array<string,mixed> */
 	private function public_artifact_metadata( array $artifact ): array {
-		unset( $artifact['local_debug'] );
-		return $artifact;
+		return ArtifactManifest::public_metadata( $artifact );
 	}
 
 	/** @return array<string,mixed> */
@@ -774,28 +757,26 @@ class JobArtifacts {
 			)
 		);
 
+		$manifest = ArtifactManifest::create(
+			array(
+				'artifact_ref'   => $artifact_ref,
+				'artifact_type'  => $type,
+				'content'        => $json,
+				'relative_path'  => $relative_path,
+				'export_url'     => is_string( $export_url ) ? $export_url : '',
+				'signed_url'     => is_string( $signed_url ) ? $signed_url : '',
+				'payload_sha256' => (string) ( $artifact_payload['sha256'] ?? '' ),
+				'written_at'     => gmdate( 'c' ),
+				'local_debug'    => array(
+					'path' => $file_path,
+					'url'  => '' !== $base_url ? trailingslashit( $base_url ) . $file_name : null,
+				),
+			)
+		);
+
 		return array(
 			'success' => true,
-			'file'    => $this->filter_empty(
-				array(
-					'artifact_ref'   => $artifact_ref,
-					'type'           => $type,
-					'schema_version' => self::ARTIFACT_REF_SCHEMA_VERSION,
-					'sha256'         => hash( 'sha256', $json ),
-					'bytes'          => strlen( $json ),
-					'relative_path'  => $relative_path,
-					'export_url'     => is_string( $export_url ) && '' !== $export_url ? $export_url : null,
-					'signed_url'     => is_string( $signed_url ) && '' !== $signed_url ? $signed_url : null,
-					'payload_sha256' => (string) ( $artifact_payload['sha256'] ?? '' ),
-					'written_at'     => gmdate( 'c' ),
-					'local_debug'    => $this->filter_empty(
-						array(
-							'path' => $file_path,
-							'url'  => '' !== $base_url ? trailingslashit( $base_url ) . $file_name : null,
-						)
-					),
-				)
-			),
+			'file'    => $manifest,
 		);
 	}
 

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -16,6 +16,7 @@ require_once __DIR__ . '/site-md.php';
 require_once __DIR__ . '/agents-md.php';
 require_once __DIR__ . '/flows.php';
 require_once __DIR__ . '/bundle-artifacts.php';
+require_once __DIR__ . '/run-metadata.php';
 require_once __DIR__ . '/processed-item-claims.php';
 require_once __DIR__ . '/pending-actions.php';
 require_once __DIR__ . '/chat-sessions-network.php';

--- a/inc/migrations/run-metadata.php
+++ b/inc/migrations/run-metadata.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Data Machine — indexed run metadata table migration.
+ *
+ * @package DataMachine
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Ensure the indexed run metadata table exists on upgraded installs.
+ *
+ * @return void
+ */
+function datamachine_migrate_run_metadata_table(): void {
+	\DataMachine\Core\Database\RunMetadata\RunMetadata::create_table();
+}

--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -30,6 +30,7 @@ function datamachine_run_schema_migrations(): void {
 	}
 
 	datamachine_migrate_bundle_artifacts_table();
+	datamachine_migrate_run_metadata_table();
 	datamachine_migrate_processed_item_claims();
 	datamachine_migrate_pending_actions_table();
 	datamachine_migrate_chat_sessions_to_network();

--- a/tests/artifact-manifest-smoke.php
+++ b/tests/artifact-manifest-smoke.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Smoke tests for generic artifact manifest primitives.
+ *
+ * Run with: php tests/artifact-manifest-smoke.php
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ );
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ): string {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $value ): string {
+		return is_scalar( $value ) ? trim( (string) $value ) : '';
+	}
+}
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $value ): string {
+		return (string) $value;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Core/ArtifactManifest.php';
+
+use DataMachine\Core\ArtifactManifest;
+
+$failures = 0;
+$passes   = 0;
+
+$assert = static function ( string $label, bool $condition ) use ( &$failures, &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		return;
+	}
+
+	++$failures;
+	fwrite( STDERR, "FAIL: {$label}\n" );
+};
+
+$content  = "{\"ok\":true}\n";
+$manifest = ArtifactManifest::create(
+	array(
+		'artifact_ref'  => 'datamachine://runs/123/artifacts/result',
+		'artifact_type' => 'result_json',
+		'content'       => $content,
+		'relative_path' => 'datamachine-artifacts/runs/123/result.json',
+		'local_debug'   => array(
+			'path' => '/private/tmp/result.json',
+		),
+	)
+);
+
+$assert( 'manifest carries portable ref', 'datamachine://runs/123/artifacts/result' === ( $manifest['artifact_ref'] ?? '' ) );
+$assert( 'manifest stores content sha256', hash( 'sha256', $content ) === ( $manifest['sha256'] ?? '' ) );
+$assert( 'manifest stores byte count', strlen( $content ) === ( $manifest['bytes'] ?? null ) );
+
+$resolved = ArtifactManifest::resolve( 'datamachine://runs/123/artifacts/result', array( 'result' => $manifest ) );
+$assert( 'resolve finds manifest by ref', true === ( $resolved['success'] ?? false ) );
+$assert( 'resolve omits local debug metadata', ! isset( $resolved['artifact']['local_debug'] ) );
+
+$hydrated = ArtifactManifest::hydrate(
+	'datamachine://runs/123/artifacts/result',
+	array( 'result' => $manifest ),
+	static fn() => $content
+);
+$assert( 'hydrate returns verified content', true === ( $hydrated['success'] ?? false ) && true === ( $hydrated['verified'] ?? false ) );
+$assert( 'hydrate preserves exact bytes', $content === ( $hydrated['content'] ?? null ) );
+
+$bad = ArtifactManifest::hydrate(
+	'datamachine://runs/123/artifacts/result',
+	array( 'result' => array_merge( $manifest, array( 'sha256' => str_repeat( '0', 64 ) ) ) ),
+	static fn() => $content
+);
+$assert( 'hydrate rejects sha256 mismatch', false === ( $bad['success'] ?? true ) && str_contains( (string) ( $bad['error'] ?? '' ), 'sha256' ) );
+
+$job_artifacts_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/JobArtifacts.php' ) ?: '';
+$assert( 'existing job artifact writer uses generic manifest primitive', str_contains( $job_artifacts_source, 'ArtifactManifest::create' ) );
+$assert( 'job artifact verification delegates to generic primitive', str_contains( $job_artifacts_source, 'ArtifactManifest::verify' ) );
+
+if ( $failures > 0 ) {
+	fwrite( STDERR, "artifact-manifest-smoke: {$failures} failure(s), {$passes} pass(es).\n" );
+	exit( 1 );
+}
+
+echo "artifact-manifest-smoke: ALL PASS ({$passes} assertions)\n";

--- a/tests/execution-metadata-query-smoke.php
+++ b/tests/execution-metadata-query-smoke.php
@@ -50,12 +50,18 @@ $assert( 'matching metadata requires every filter', ExecutionQuery::matches_meta
 $assert( 'metadata matching is exact', ! ExecutionQuery::matches_metadata_filters( $engine_data, array( 'task_type' => 'weekly' ) ) );
 
 $jobs_db_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Jobs/Jobs.php' ) ?: '';
+$run_metadata_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/RunMetadata/RunMetadata.php' ) ?: '';
+$bootstrap_source = file_get_contents( dirname( __DIR__ ) . '/data-machine.php' ) ?: '';
 $ability_source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/Job/GetJobsAbility.php' ) ?: '';
 $cli_source     = file_get_contents( dirname( __DIR__ ) . '/inc/Cli/Commands/JobsCommand.php' ) ?: '';
 $rest_source    = file_get_contents( dirname( __DIR__ ) . '/inc/Api/Jobs.php' ) ?: '';
 
 $assert( 'Jobs repository exposes read-only metadata query primitive', str_contains( $jobs_db_source, 'function query_executions_by_metadata' ) );
-$assert( 'get-jobs ability accepts metadata filters', str_contains( $ability_source, "'metadata'    => array(" ) );
+$assert( 'run metadata table has indexed exact path/value lookup', str_contains( $run_metadata_source, 'KEY path_value (metadata_path, metadata_value)' ) );
+$assert( 'schema creation includes run metadata table', str_contains( $bootstrap_source, 'Database\\RunMetadata\\RunMetadata::create_table' ) );
+$assert( 'Jobs metadata query uses indexed run metadata first', str_contains( $jobs_db_source, 'new RunMetadata()' ) && str_contains( $jobs_db_source, "'indexed'    => true" ) );
+$assert( 'engine data persistence updates run metadata index', str_contains( $jobs_db_source, 'replace_for_engine_data' ) );
+$assert( 'get-jobs ability accepts metadata filters', str_contains( $ability_source, "'metadata'" ) && str_contains( $ability_source, 'query_executions_by_metadata' ) );
 $assert( 'jobs CLI exposes metadata filter option', str_contains( $cli_source, '[--metadata=<filters>]' ) );
 $assert( 'REST jobs endpoint exposes metadata query diagnostics', str_contains( $rest_source, "'metadata_query'" ) );
 


### PR DESCRIPTION
## Summary
- Add an indexed run metadata table/repository for exact path/value execution metadata lookup.
- Wire job engine_data persistence to maintain the metadata index via configured generic paths, and use the index before falling back to legacy JSON scanning.
- Add a generic ArtifactManifest helper for portable refs, hydration, public metadata, and verification, and migrate job artifact file writing to use it.

## Tests
- php -l inc/Core/ArtifactManifest.php
- php -l inc/Core/Database/RunMetadata/RunMetadata.php
- php -l inc/Core/Database/Jobs/Jobs.php
- php -l inc/Core/JobArtifacts.php
- php tests/artifact-manifest-smoke.php
- php tests/execution-metadata-query-smoke.php
- php tests/job-artifact-content-resolver-smoke.php
- ./vendor/bin/phpcs inc/Core/ArtifactManifest.php inc/Core/Database/RunMetadata/RunMetadata.php inc/Core/Database/Jobs/Jobs.php inc/Core/JobArtifacts.php tests/artifact-manifest-smoke.php tests/execution-metadata-query-smoke.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation and focused tests; Chris remains responsible for review and validation.