### PR TITLE
Add generic run lifecycle store

### DIFF
--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -21,6 +21,7 @@ use DataMachine\Core\Database\LifecycleStateTransition;
 use DataMachine\Core\ExecutionQuery;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\RunMetrics;
+use DataMachine\Core\RunLifecycleStore;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -88,7 +89,16 @@ class Jobs extends BaseRepository {
 			return false;
 		}
 
-		return $this->wpdb->insert_id;
+		$job_id = (int) $this->wpdb->insert_id;
+		( new RunLifecycleStore( $this ) )->mark_job_created(
+			$job_id,
+			array(
+				'run_type' => $prepared['data']['source'] ?? 'job',
+				'status'   => $prepared['data']['status'] ?? JobStatus::PENDING,
+			)
+		);
+
+		return $job_id;
 	}
 
 	/**
@@ -110,6 +120,14 @@ class Jobs extends BaseRepository {
 
 		$existing = $this->get_job_by_idempotency_key( $idempotency_key );
 		if ( null !== $existing ) {
+			( new RunLifecycleStore( $this ) )->mark_job_created(
+				(int) $existing['job_id'],
+				array(
+					'run_type' => $existing['source'] ?? 'job',
+					'status'   => $existing['status'] ?? JobStatus::PENDING,
+				)
+			);
+
 			return array(
 				'job_id'         => (int) $existing['job_id'],
 				'created'        => false,
@@ -128,6 +146,14 @@ class Jobs extends BaseRepository {
 		if ( false === $inserted ) {
 			$existing = $this->get_job_by_idempotency_key( $idempotency_key );
 			if ( null !== $existing ) {
+				( new RunLifecycleStore( $this ) )->mark_job_created(
+					(int) $existing['job_id'],
+					array(
+						'run_type' => $existing['source'] ?? 'job',
+						'status'   => $existing['status'] ?? JobStatus::PENDING,
+					)
+				);
+
 				return array(
 					'job_id'         => (int) $existing['job_id'],
 					'created'        => false,
@@ -151,6 +177,13 @@ class Jobs extends BaseRepository {
 		}
 
 		$job_id = (int) $this->wpdb->insert_id;
+		( new RunLifecycleStore( $this ) )->mark_job_created(
+			$job_id,
+			array(
+				'run_type' => $prepared['data']['source'] ?? 'job',
+				'status'   => $prepared['data']['status'] ?? JobStatus::PENDING,
+			)
+		);
 
 		return array(
 			'job_id'         => $job_id,
@@ -1390,6 +1423,31 @@ class Jobs extends BaseRepository {
 		}
 
 		if ( 0 === (int) $result ) {
+			if ( array() === $expected_data ) {
+				$job = $this->get_job( $job_id );
+				if ( is_array( $job ) && ( ! array_key_exists( 'engine_data', $job ) || null === $job['engine_data'] || '' === $job['engine_data'] ) ) {
+					$result = $this->wpdb->update(
+						$this->table_name,
+						$storage_envelope['data'],
+						array(
+							'job_id'      => $job_id,
+							'engine_data' => null,
+						),
+						$storage_envelope['format'],
+						array( '%d', null )
+					);
+
+					if ( false !== $result && (int) $result > 0 ) {
+						wp_cache_set( $job_id, $new_data, 'datamachine_engine_data' );
+						return array(
+							'updated'  => true,
+							'conflict' => false,
+							'error'    => null,
+						);
+					}
+				}
+			}
+
 			return array(
 				'updated'  => false,
 				'conflict' => true,
@@ -1651,6 +1709,8 @@ class Jobs extends BaseRepository {
 			RunMetrics::complete( $job_id, $status );
 			do_action( 'datamachine_job_complete', $job_id, $status );
 		}
+
+		( new RunLifecycleStore( $this ) )->mark_job_status( $job_id, $status );
 
 		return array(
 			'success'        => true,

--- a/inc/Core/RunLifecycleStore.php
+++ b/inc/Core/RunLifecycleStore.php
@@ -168,8 +168,8 @@ class RunLifecycleStore {
 		return $this->mutate_run(
 			$run_id,
 			function ( array $meta ) use ( $event_type, $payload ): array {
-				$events   = is_array( $meta['replay_events'] ?? null ) ? $meta['replay_events'] : array();
-				$events[] = array(
+				$events                = is_array( $meta['replay_events'] ?? null ) ? $meta['replay_events'] : array();
+				$events[]              = array(
 					'type'       => $event_type,
 					'payload'    => $payload,
 					'created_at' => $this->now(),
@@ -205,7 +205,14 @@ class RunLifecycleStore {
 					$metadata
 				);
 
-				return array_merge( $created, $meta, array( 'run_id' => $this->run_id_for_job( $job_id ), 'job_id' => $job_id ) );
+				return array_merge(
+					$created,
+					$meta,
+					array(
+						'run_id' => $this->run_id_for_job( $job_id ),
+						'job_id' => $job_id,
+					)
+				);
 			}
 		);
 
@@ -235,13 +242,13 @@ class RunLifecycleStore {
 		return false !== $result;
 	}
 
-	private function transition_run( int|string $run_id, string $status, string $timestamp_key, array $context = array(), bool $final = false ): array|false {
+	private function transition_run( int|string $run_id, string $status, string $timestamp_key, array $context = array(), bool $is_final = false ): array|false {
 		$job_id = $this->job_id_from_run_id( $run_id );
 		if ( $job_id <= 0 ) {
 			return false;
 		}
 
-		$transition = $this->jobs->transition_job_status_result( $job_id, $status, $final );
+		$transition = $this->jobs->transition_job_status_result( $job_id, $status, $is_final );
 		if ( empty( $transition['success'] ) ) {
 			return false;
 		}
@@ -271,15 +278,15 @@ class RunLifecycleStore {
 		$result = EngineData::mutate(
 			$job_id,
 			function ( array $snapshot ) use ( $job_id, $callback ): array {
-				$meta                  = is_array( $snapshot[ self::META_KEY ] ?? null ) ? $snapshot[ self::META_KEY ] : array();
-				$meta['run_id']        = (string) ( $meta['run_id'] ?? $this->run_id_for_job( $job_id ) );
-				$meta['job_id']        = $job_id;
-				$meta['attempt']       = max( 1, (int) ( $meta['attempt'] ?? 1 ) );
-				$meta['replay_events'] = is_array( $meta['replay_events'] ?? null ) ? array_values( $meta['replay_events'] ) : array();
-				$meta['artifact_refs'] = is_array( $meta['artifact_refs'] ?? null ) ? array_values( $meta['artifact_refs'] ) : array();
-				$next                  = $callback( $meta );
-				$next['run_id']        = $this->run_id_for_job( $job_id );
-				$next['job_id']        = $job_id;
+				$meta                       = is_array( $snapshot[ self::META_KEY ] ?? null ) ? $snapshot[ self::META_KEY ] : array();
+				$meta['run_id']             = (string) ( $meta['run_id'] ?? $this->run_id_for_job( $job_id ) );
+				$meta['job_id']             = $job_id;
+				$meta['attempt']            = max( 1, (int) ( $meta['attempt'] ?? 1 ) );
+				$meta['replay_events']      = is_array( $meta['replay_events'] ?? null ) ? array_values( $meta['replay_events'] ) : array();
+				$meta['artifact_refs']      = is_array( $meta['artifact_refs'] ?? null ) ? array_values( $meta['artifact_refs'] ) : array();
+				$next                       = $callback( $meta );
+				$next['run_id']             = $this->run_id_for_job( $job_id );
+				$next['job_id']             = $job_id;
 				$snapshot[ self::META_KEY ] = $next;
 				return $snapshot;
 			},

--- a/inc/Core/RunLifecycleStore.php
+++ b/inc/Core/RunLifecycleStore.php
@@ -1,0 +1,316 @@
+<?php
+/**
+ * Generic run lifecycle store.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+use DataMachine\Core\Database\Jobs\Jobs;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Small run lifecycle facade backed by existing job storage.
+ *
+ * The first implementation intentionally maps a run to a job so deterministic
+ * loops can share lifecycle semantics before a dedicated run table is needed.
+ */
+class RunLifecycleStore {
+
+	private const META_KEY = 'run_lifecycle';
+
+	private Jobs $jobs;
+
+	public function __construct( ?Jobs $jobs = null ) {
+		$this->jobs = $jobs ?? new Jobs();
+	}
+
+	/**
+	 * Create a run and return its normalized lifecycle snapshot.
+	 *
+	 * @param string $run_type Generic run type.
+	 * @param array  $args Optional job/lifecycle data.
+	 * @return array|false Lifecycle snapshot, or false on failure.
+	 */
+	public function create_run( string $run_type, array $args = array() ): array|false {
+		$run_type = $this->normalize_run_type( $run_type );
+		if ( '' === $run_type ) {
+			return false;
+		}
+
+		$job_data = is_array( $args['job_data'] ?? null ) ? $args['job_data'] : array();
+		$job_data = array_merge(
+			array(
+				'pipeline_id' => null,
+				'flow_id'     => null,
+				'source'      => $run_type,
+				'label'       => $args['label'] ?? null,
+			),
+			$job_data
+		);
+
+		$job_result = ! empty( $job_data['idempotency_key'] )
+			? $this->jobs->create_or_get_job( $job_data )
+			: $this->jobs->create_job( $job_data );
+
+		$job_id = is_array( $job_result ) ? (int) ( $job_result['job_id'] ?? 0 ) : (int) $job_result;
+		if ( $job_id <= 0 ) {
+			return false;
+		}
+
+		$seed = array(
+			'run_type'      => $run_type,
+			'status'        => JobStatus::PENDING,
+			'attempt'       => max( 1, (int) ( $args['attempt'] ?? 1 ) ),
+			'replay_events' => is_array( $args['replay_events'] ?? null ) ? array_values( $args['replay_events'] ) : array(),
+			'artifact_refs' => is_array( $args['artifact_refs'] ?? null ) ? array_values( $args['artifact_refs'] ) : array(),
+		);
+
+		$this->mark_job_created( $job_id, $seed );
+
+		return $this->get_run( $this->run_id_for_job( $job_id ) );
+	}
+
+	/**
+	 * Get a run by run_id. Numeric IDs are accepted as job IDs for adapters.
+	 */
+	public function get_run( int|string $run_id ): ?array {
+		$job_id = $this->job_id_from_run_id( $run_id );
+		if ( $job_id <= 0 ) {
+			return null;
+		}
+
+		$job = $this->jobs->get_job( $job_id );
+		if ( ! is_array( $job ) ) {
+			return null;
+		}
+
+		$engine_data = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$meta        = is_array( $engine_data[ self::META_KEY ] ?? null ) ? $engine_data[ self::META_KEY ] : array();
+		$run_id      = (string) ( $meta['run_id'] ?? $this->run_id_for_job( $job_id ) );
+
+		return array_merge(
+			array(
+				'run_id'        => $run_id,
+				'job_id'        => $job_id,
+				'run_type'      => $this->normalize_run_type( $meta['run_type'] ?? ( $job['source'] ?? 'job' ) ),
+				'status'        => (string) ( $job['status'] ?? ( $meta['status'] ?? JobStatus::PENDING ) ),
+				'attempt'       => max( 1, (int) ( $meta['attempt'] ?? 1 ) ),
+				'replay_events' => is_array( $meta['replay_events'] ?? null ) ? array_values( $meta['replay_events'] ) : array(),
+				'artifact_refs' => is_array( $meta['artifact_refs'] ?? null ) ? array_values( $meta['artifact_refs'] ) : array(),
+				'created_at'    => (string) ( $job['created_at'] ?? ( $meta['created_at'] ?? '' ) ),
+				'completed_at'  => (string) ( $job['completed_at'] ?? ( $meta['completed_at'] ?? '' ) ),
+			),
+			$meta,
+			array(
+				'run_id' => $run_id,
+				'job_id' => $job_id,
+			)
+		);
+	}
+
+	public function start_run( int|string $run_id, array $context = array() ): array|false {
+		return $this->transition_run( $run_id, JobStatus::PROCESSING, 'started_at', $context );
+	}
+
+	public function wait_run( int|string $run_id, array $context = array() ): array|false {
+		return $this->transition_run( $run_id, JobStatus::WAITING, 'waiting_at', $context );
+	}
+
+	public function resume_run( int|string $run_id, array $context = array() ): array|false {
+		$context['attempt_delta'] = (int) ( $context['attempt_delta'] ?? 1 );
+		return $this->transition_run( $run_id, JobStatus::PROCESSING, 'resumed_at', $context );
+	}
+
+	public function complete_run( int|string $run_id, array $context = array() ): array|false {
+		return $this->transition_run( $run_id, JobStatus::COMPLETED, 'completed_at', $context, true );
+	}
+
+	public function fail_run( int|string $run_id, string $reason = '', array $context = array() ): array|false {
+		$status = '' === trim( $reason ) ? JobStatus::FAILED : JobStatus::failed( $reason )->toString();
+		return $this->transition_run( $run_id, $status, 'failed_at', $context, true );
+	}
+
+	public function cancel_run( int|string $run_id, array $context = array() ): array|false {
+		return $this->transition_run( $run_id, JobStatus::CANCELLED, 'cancelled_at', $context, true );
+	}
+
+	public function add_artifact_ref( int|string $run_id, string $artifact_ref, array $metadata = array() ): array|false {
+		$artifact_ref = sanitize_text_field( $artifact_ref );
+		if ( '' === $artifact_ref ) {
+			return false;
+		}
+
+		return $this->mutate_run(
+			$run_id,
+			static function ( array $meta ) use ( $artifact_ref, $metadata ): array {
+				$refs = is_array( $meta['artifact_refs'] ?? null ) ? $meta['artifact_refs'] : array();
+				if ( ! in_array( $artifact_ref, $refs, true ) ) {
+					$refs[] = $artifact_ref;
+				}
+				$meta['artifact_refs'] = array_values( $refs );
+				if ( ! empty( $metadata ) ) {
+					$meta['artifact_ref_metadata'][ $artifact_ref ] = $metadata;
+				}
+				return $meta;
+			}
+		);
+	}
+
+	public function append_replay_event( int|string $run_id, string $event_type, array $payload = array() ): array|false {
+		$event_type = sanitize_key( $event_type );
+		if ( '' === $event_type ) {
+			return false;
+		}
+
+		return $this->mutate_run(
+			$run_id,
+			function ( array $meta ) use ( $event_type, $payload ): array {
+				$events   = is_array( $meta['replay_events'] ?? null ) ? $meta['replay_events'] : array();
+				$events[] = array(
+					'type'       => $event_type,
+					'payload'    => $payload,
+					'created_at' => $this->now(),
+				);
+				$meta['replay_events'] = $events;
+				return $meta;
+			}
+		);
+	}
+
+	/**
+	 * Attach lifecycle metadata to an existing job without changing job behavior.
+	 */
+	public function mark_job_created( int $job_id, array $metadata = array() ): bool {
+		if ( $job_id <= 0 ) {
+			return false;
+		}
+
+		$result = $this->mutate_run(
+			$job_id,
+			function ( array $meta ) use ( $job_id, $metadata ): array {
+				$created = array_merge(
+					array(
+						'run_id'        => $this->run_id_for_job( $job_id ),
+						'job_id'        => $job_id,
+						'run_type'      => $this->normalize_run_type( $metadata['run_type'] ?? 'job' ),
+						'status'        => JobStatus::PENDING,
+						'attempt'       => 1,
+						'replay_events' => array(),
+						'artifact_refs' => array(),
+						'created_at'    => $this->now(),
+					),
+					$metadata
+				);
+
+				return array_merge( $created, $meta, array( 'run_id' => $this->run_id_for_job( $job_id ), 'job_id' => $job_id ) );
+			}
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Mirror an existing job status transition into generic run metadata.
+	 */
+	public function mark_job_status( int $job_id, string $status ): bool {
+		if ( $job_id <= 0 || '' === $status ) {
+			return false;
+		}
+
+		$result = $this->mutate_run(
+			$job_id,
+			function ( array $meta ) use ( $status ): array {
+				$meta['status']     = $status;
+				$meta['updated_at'] = $this->now();
+				if ( JobStatus::isStatusFinal( $status ) ) {
+					$meta['completed_at'] = $meta['completed_at'] ?? $meta['updated_at'];
+				}
+				return $meta;
+			}
+		);
+
+		return false !== $result;
+	}
+
+	private function transition_run( int|string $run_id, string $status, string $timestamp_key, array $context = array(), bool $final = false ): array|false {
+		$job_id = $this->job_id_from_run_id( $run_id );
+		if ( $job_id <= 0 ) {
+			return false;
+		}
+
+		$transition = $this->jobs->transition_job_status_result( $job_id, $status, $final );
+		if ( empty( $transition['success'] ) ) {
+			return false;
+		}
+
+		return $this->mutate_run(
+			$job_id,
+			function ( array $meta ) use ( $status, $timestamp_key, $context ): array {
+				$meta['status']          = $status;
+				$meta[ $timestamp_key ]  = $meta[ $timestamp_key ] ?? $this->now();
+				$meta['updated_at']      = $this->now();
+				$meta['attempt']         = max( 1, (int) ( $meta['attempt'] ?? 1 ) + (int) ( $context['attempt_delta'] ?? 0 ) );
+				$meta['last_transition'] = array(
+					'status'  => $status,
+					'context' => $context,
+				);
+				return $meta;
+			}
+		);
+	}
+
+	private function mutate_run( int|string $run_id, callable $callback ): array|false {
+		$job_id = $this->job_id_from_run_id( $run_id );
+		if ( $job_id <= 0 ) {
+			return false;
+		}
+
+		$result = EngineData::mutate(
+			$job_id,
+			function ( array $snapshot ) use ( $job_id, $callback ): array {
+				$meta                  = is_array( $snapshot[ self::META_KEY ] ?? null ) ? $snapshot[ self::META_KEY ] : array();
+				$meta['run_id']        = (string) ( $meta['run_id'] ?? $this->run_id_for_job( $job_id ) );
+				$meta['job_id']        = $job_id;
+				$meta['attempt']       = max( 1, (int) ( $meta['attempt'] ?? 1 ) );
+				$meta['replay_events'] = is_array( $meta['replay_events'] ?? null ) ? array_values( $meta['replay_events'] ) : array();
+				$meta['artifact_refs'] = is_array( $meta['artifact_refs'] ?? null ) ? array_values( $meta['artifact_refs'] ) : array();
+				$next                  = $callback( $meta );
+				$next['run_id']        = $this->run_id_for_job( $job_id );
+				$next['job_id']        = $job_id;
+				$snapshot[ self::META_KEY ] = $next;
+				return $snapshot;
+			},
+			'run_lifecycle'
+		);
+
+		return empty( $result['success'] ) ? false : $this->get_run( $job_id );
+	}
+
+	private function run_id_for_job( int $job_id ): string {
+		return 'job:' . $job_id;
+	}
+
+	private function job_id_from_run_id( int|string $run_id ): int {
+		if ( is_int( $run_id ) || ctype_digit( (string) $run_id ) ) {
+			return absint( $run_id );
+		}
+
+		$run_id = trim( (string) $run_id );
+		if ( str_starts_with( $run_id, 'job:' ) ) {
+			return absint( substr( $run_id, 4 ) );
+		}
+
+		return 0;
+	}
+
+	private function normalize_run_type( mixed $run_type ): string {
+		return sanitize_key( (string) $run_type );
+	}
+
+	private function now(): string {
+		return function_exists( 'current_time' ) ? current_time( 'mysql', true ) : gmdate( 'Y-m-d H:i:s' );
+	}
+}

--- a/tests/job-status-transition-smoke.php
+++ b/tests/job-status-transition-smoke.php
@@ -26,6 +26,9 @@ namespace {
 	if ( ! defined( 'ARRAY_A' ) ) {
 		define( 'ARRAY_A', 'ARRAY_A' );
 	}
+	if ( ! defined( 'OBJECT' ) ) {
+		define( 'OBJECT', 'OBJECT' );
+	}
 
 	if ( ! function_exists( 'absint' ) ) {
 		function absint( $value ): int {
@@ -95,8 +98,16 @@ namespace {
 		);
 	}
 
-	class wpdb {
-		public string $prefix = 'wp_';
+	if ( ! class_exists( 'wpdb' ) ) {
+		class wpdb {
+			public $prefix;
+		}
+	}
+
+	class Datamachine_Transition_Smoke_Wpdb extends wpdb {
+		public function __construct() {
+			$this->prefix = 'wp_';
+		}
 
 		/** @var array<int,array<string,mixed>> */
 		public array $updates = array();
@@ -108,7 +119,7 @@ namespace {
 			12 => array( 'job_id' => 12, 'status' => 'pending', 'engine_data' => null ),
 		);
 
-		public function update( string $table, array $data, array $where, array $format, array $where_format ) {
+		public function update( $table, $data, $where, $format = null, $where_format = null ) {
 			$this->updates[] = compact( 'table', 'data', 'where', 'format', 'where_format' );
 			$job_id          = (int) ( $where['job_id'] ?? 0 );
 			if ( isset( $this->rows[ $job_id ] ) ) {
@@ -117,11 +128,11 @@ namespace {
 			return 1;
 		}
 
-		public function prepare( string $query, ...$args ): array {
+		public function prepare( $query, ...$args ) {
 			return array( $query, $args );
 		}
 
-		public function get_row( $query, string $output = ARRAY_A ) {
+		public function get_row( $query = null, $output = OBJECT, $y = 0 ) {
 			$args   = is_array( $query ) ? ( $query[1] ?? array() ) : array();
 			$job_id = (int) end( $args );
 			$row    = $this->rows[ $job_id ] ?? null;
@@ -135,7 +146,7 @@ namespace {
 		}
 	}
 
-	$wpdb = new wpdb();
+	$wpdb = new Datamachine_Transition_Smoke_Wpdb();
 
 	require_once __DIR__ . '/../inc/Core/JobStatus.php';
 	require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';

--- a/tests/job-status-transition-smoke.php
+++ b/tests/job-status-transition-smoke.php
@@ -23,6 +23,46 @@ namespace {
 	if ( ! defined( 'ABSPATH' ) ) {
 		define( 'ABSPATH', __DIR__ . '/' );
 	}
+	if ( ! defined( 'ARRAY_A' ) ) {
+		define( 'ARRAY_A', 'ARRAY_A' );
+	}
+
+	if ( ! function_exists( 'absint' ) ) {
+		function absint( $value ): int {
+			return abs( (int) $value );
+		}
+	}
+
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( $key ): string {
+			return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+		}
+	}
+
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $value ): string {
+			return trim( strip_tags( (string) $value ) );
+		}
+	}
+
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $data, int $flags = 0, int $depth = 512 ) {
+			return json_encode( $data, $flags, $depth );
+		}
+	}
+
+	if ( ! function_exists( 'wp_cache_get' ) ) {
+		function wp_cache_get( $key, string $group = '' ) {
+			return $GLOBALS['datamachine_transition_cache'][ $group ][ $key ] ?? false;
+		}
+	}
+
+	if ( ! function_exists( 'wp_cache_set' ) ) {
+		function wp_cache_set( $key, $value, string $group = '' ): bool {
+			$GLOBALS['datamachine_transition_cache'][ $group ][ $key ] = $value;
+			return true;
+		}
+	}
 
 	$datamachine_transition_hooks = array();
 
@@ -55,22 +95,53 @@ namespace {
 		);
 	}
 
-	class DataMachineTransitionWpdbStub {
+	class wpdb {
 		public string $prefix = 'wp_';
 
 		/** @var array<int,array<string,mixed>> */
 		public array $updates = array();
 
+		/** @var array<int,array<string,mixed>> */
+		public array $rows = array(
+			10 => array( 'job_id' => 10, 'status' => 'pending', 'engine_data' => null ),
+			11 => array( 'job_id' => 11, 'status' => 'pending', 'engine_data' => null ),
+			12 => array( 'job_id' => 12, 'status' => 'pending', 'engine_data' => null ),
+		);
+
 		public function update( string $table, array $data, array $where, array $format, array $where_format ) {
 			$this->updates[] = compact( 'table', 'data', 'where', 'format', 'where_format' );
+			$job_id          = (int) ( $where['job_id'] ?? 0 );
+			if ( isset( $this->rows[ $job_id ] ) ) {
+				$this->rows[ $job_id ] = array_merge( $this->rows[ $job_id ], $data );
+			}
 			return 1;
+		}
+
+		public function prepare( string $query, ...$args ): array {
+			return array( $query, $args );
+		}
+
+		public function get_row( $query, string $output = ARRAY_A ) {
+			$args   = is_array( $query ) ? ( $query[1] ?? array() ) : array();
+			$job_id = (int) end( $args );
+			$row    = $this->rows[ $job_id ] ?? null;
+			if ( $row && isset( $row['engine_data'] ) && is_string( $row['engine_data'] ) ) {
+				$decoded = json_decode( $row['engine_data'], true );
+				if ( JSON_ERROR_NONE === json_last_error() ) {
+					$row['engine_data'] = $decoded;
+				}
+			}
+			return $row ?: null;
 		}
 	}
 
-	$wpdb = new DataMachineTransitionWpdbStub();
+	$wpdb = new wpdb();
 
 	require_once __DIR__ . '/../inc/Core/JobStatus.php';
 	require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+	require_once __DIR__ . '/../inc/Core/Database/LifecycleStateTransition.php';
+	require_once __DIR__ . '/../inc/Core/EngineData.php';
+	require_once __DIR__ . '/../inc/Core/RunLifecycleStore.php';
 	require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
 
 	use DataMachine\Core\Database\Jobs\Jobs;
@@ -93,21 +164,29 @@ namespace {
 	echo "=== job-status-transition-smoke ===\n";
 
 	$jobs = new Jobs();
+	$status_updates = static function () use ( $wpdb ): array {
+		return array_values(
+			array_filter(
+				$wpdb->updates,
+				static fn( array $update ): bool => array_key_exists( 'status', $update['data'] ?? array() )
+			)
+		);
+	};
 
 	$assert( 'non-final update succeeds', $jobs->update_job_status( 10, 'processing' ) );
-	$non_terminal = $wpdb->updates[0]['data'] ?? array();
+	$non_terminal = $status_updates()[0]['data'] ?? array();
 	$assert( 'non-final update writes status only', array( 'status' ) === array_keys( $non_terminal ) );
 	$assert( 'non-final update does not fire completion hook', 0 === count( $datamachine_transition_hooks ) );
 
 	$assert( 'terminal update succeeds through update_job_status', $jobs->update_job_status( 11, 'completed' ) );
-	$terminal = $wpdb->updates[1]['data'] ?? array();
+	$terminal = $status_updates()[1]['data'] ?? array();
 	$assert( 'terminal update writes completed_at', isset( $terminal['completed_at'] ) && is_string( $terminal['completed_at'] ) && '' !== $terminal['completed_at'] );
 	$assert( 'terminal update records run metrics', 'completed' === ( RunMetrics::$completed[11] ?? '' ) );
 	$assert( 'terminal update fires completion hook once', 1 === count( $datamachine_transition_hooks ) );
 	$assert( 'completion hook receives terminal status', 'completed' === ( $datamachine_transition_hooks[0]['args'][1] ?? '' ) );
 
 	$assert( 'complete_job rejects non-final statuses', false === $jobs->complete_job( 12, 'processing' ) );
-	$assert( 'rejected complete_job does not write', 2 === count( $wpdb->updates ) );
+	$assert( 'rejected complete_job does not write', 2 === count( $status_updates() ) );
 
 	if ( $failures > 0 ) {
 		echo "\n=== job-status-transition-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";

--- a/tests/run-lifecycle-store-smoke.php
+++ b/tests/run-lifecycle-store-smoke.php
@@ -27,6 +27,9 @@ namespace {
 	if ( ! defined( 'ARRAY_A' ) ) {
 		define( 'ARRAY_A', 'ARRAY_A' );
 	}
+	if ( ! defined( 'OBJECT' ) ) {
+		define( 'OBJECT', 'OBJECT' );
+	}
 
 	if ( ! function_exists( 'absint' ) ) {
 		function absint( $value ): int {
@@ -75,15 +78,25 @@ namespace {
 		}
 	}
 
-	class wpdb {
-		public string $prefix = 'wp_';
-		public int $insert_id = 0;
-		public string $last_error = '';
+	if ( ! class_exists( 'wpdb' ) ) {
+		class wpdb {
+			public $prefix;
+			public $insert_id;
+			public $last_error;
+		}
+	}
+
+	class Datamachine_Run_Lifecycle_Smoke_Wpdb extends wpdb {
+		public function __construct() {
+			$this->prefix     = 'wp_';
+			$this->insert_id  = 0;
+			$this->last_error = '';
+		}
 
 		/** @var array<int,array<string,mixed>> */
 		public array $rows = array();
 
-		public function insert( string $table, array $data, array $format ) {
+		public function insert( $table, $data, $format = null ) {
 			++$this->insert_id;
 			$this->rows[ $this->insert_id ] = array_merge(
 				array(
@@ -97,7 +110,7 @@ namespace {
 			return 1;
 		}
 
-		public function update( string $table, array $data, array $where, array $format, array $where_format ) {
+		public function update( $table, $data, $where, $format = null, $where_format = null ) {
 			$job_id = (int) ( $where['job_id'] ?? 0 );
 			if ( ! isset( $this->rows[ $job_id ] ) ) {
 				return 0;
@@ -125,11 +138,11 @@ namespace {
 			return 1;
 		}
 
-		public function prepare( string $query, ...$args ): array {
+		public function prepare( $query, ...$args ) {
 			return array( $query, $args );
 		}
 
-		public function get_row( $query, string $output = ARRAY_A ) {
+		public function get_row( $query = null, $output = OBJECT, $y = 0 ) {
 			$args   = is_array( $query ) ? ( $query[1] ?? array() ) : array();
 			$job_id = (int) end( $args );
 			$row    = $this->rows[ $job_id ] ?? null;
@@ -137,7 +150,7 @@ namespace {
 		}
 	}
 
-	$wpdb = new wpdb();
+	$wpdb = new Datamachine_Run_Lifecycle_Smoke_Wpdb();
 
 	require_once __DIR__ . '/../inc/Core/JobStatus.php';
 	require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';

--- a/tests/run-lifecycle-store-smoke.php
+++ b/tests/run-lifecycle-store-smoke.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Smoke test for generic run lifecycle storage.
+ *
+ * Run with: php tests/run-lifecycle-store-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core {
+	class RunMetrics {
+		public static function start( int $job_id, array $metadata = array() ): bool {
+			return true;
+		}
+
+		public static function complete( int $job_id, string $status ): bool {
+			return true;
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! defined( 'ARRAY_A' ) ) {
+		define( 'ARRAY_A', 'ARRAY_A' );
+	}
+
+	if ( ! function_exists( 'absint' ) ) {
+		function absint( $value ): int {
+			return abs( (int) $value );
+		}
+	}
+
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( $key ): string {
+			return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+		}
+	}
+
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $value ): string {
+			return trim( strip_tags( (string) $value ) );
+		}
+	}
+
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $data, int $flags = 0, int $depth = 512 ) {
+			return json_encode( $data, $flags, $depth );
+		}
+	}
+
+	if ( ! function_exists( 'current_time' ) ) {
+		function current_time( string $type, bool $gmt = false ): string {
+			return '2026-06-19 12:00:00';
+		}
+	}
+
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( string $hook, ...$args ): void {}
+	}
+
+	if ( ! function_exists( 'wp_cache_get' ) ) {
+		function wp_cache_get( $key, string $group = '' ) {
+			return $GLOBALS['datamachine_run_lifecycle_cache'][ $group ][ $key ] ?? false;
+		}
+	}
+
+	if ( ! function_exists( 'wp_cache_set' ) ) {
+		function wp_cache_set( $key, $value, string $group = '' ): bool {
+			$GLOBALS['datamachine_run_lifecycle_cache'][ $group ][ $key ] = $value;
+			return true;
+		}
+	}
+
+	class wpdb {
+		public string $prefix = 'wp_';
+		public int $insert_id = 0;
+		public string $last_error = '';
+
+		/** @var array<int,array<string,mixed>> */
+		public array $rows = array();
+
+		public function insert( string $table, array $data, array $format ) {
+			++$this->insert_id;
+			$this->rows[ $this->insert_id ] = array_merge(
+				array(
+					'job_id'       => $this->insert_id,
+					'engine_data'  => null,
+					'created_at'   => '2026-06-19 11:59:00',
+					'completed_at' => null,
+				),
+				$data
+			);
+			return 1;
+		}
+
+		public function update( string $table, array $data, array $where, array $format, array $where_format ) {
+			$job_id = (int) ( $where['job_id'] ?? 0 );
+			if ( ! isset( $this->rows[ $job_id ] ) ) {
+				return 0;
+			}
+
+			foreach ( $where as $column => $expected ) {
+				if ( 'job_id' === $column ) {
+					continue;
+				}
+
+				$current = $this->rows[ $job_id ][ $column ] ?? null;
+				if ( null === $expected ) {
+					if ( null !== $current ) {
+						return 0;
+					}
+					continue;
+				}
+
+				if ( (string) $current !== (string) $expected ) {
+					return 0;
+				}
+			}
+
+			$this->rows[ $job_id ] = array_merge( $this->rows[ $job_id ], $data );
+			return 1;
+		}
+
+		public function prepare( string $query, ...$args ): array {
+			return array( $query, $args );
+		}
+
+		public function get_row( $query, string $output = ARRAY_A ) {
+			$args   = is_array( $query ) ? ( $query[1] ?? array() ) : array();
+			$job_id = (int) end( $args );
+			$row    = $this->rows[ $job_id ] ?? null;
+			return $row ?: null;
+		}
+	}
+
+	$wpdb = new wpdb();
+
+	require_once __DIR__ . '/../inc/Core/JobStatus.php';
+	require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+	require_once __DIR__ . '/../inc/Core/Database/LifecycleStateTransition.php';
+	require_once __DIR__ . '/../inc/Core/EngineData.php';
+	require_once __DIR__ . '/../inc/Core/RunLifecycleStore.php';
+	require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
+
+	use DataMachine\Core\RunLifecycleStore;
+
+	$failures = array();
+	$passes   = 0;
+
+	$assert = static function ( bool $condition, string $label ) use ( &$failures, &$passes ): void {
+		if ( $condition ) {
+			++$passes;
+			return;
+		}
+
+		$failures[] = $label;
+	};
+
+	$store = new RunLifecycleStore();
+	$run   = $store->create_run( 'deterministic_loop', array( 'label' => 'Generic lifecycle proof' ) );
+
+	$assert( is_array( $run ) && 'job:1' === ( $run['run_id'] ?? '' ), 'create_run returns stable job-backed run_id' );
+	$assert( 'deterministic_loop' === ( $run['run_type'] ?? '' ), 'create_run records generic run_type' );
+	$assert( 'pending' === ( $run['status'] ?? '' ), 'create_run records pending status' );
+	$assert( 1 === ( $run['attempt'] ?? 0 ), 'create_run initializes attempt' );
+
+	$started = $store->start_run( 'job:1' );
+	$assert( 'processing' === ( $started['status'] ?? '' ), 'start_run transitions to processing' );
+
+	$waiting = $store->wait_run( 'job:1', array( 'gate' => 'manual' ) );
+	$assert( 'waiting' === ( $waiting['status'] ?? '' ), 'wait_run transitions to waiting' );
+
+	$resumed = $store->resume_run( 'job:1' );
+	$assert( 'processing' === ( $resumed['status'] ?? '' ) && 2 === ( $resumed['attempt'] ?? 0 ), 'resume_run transitions to processing and increments attempt' );
+
+	$with_replay = $store->append_replay_event( 'job:1', 'step_completed', array( 'step' => 'fetch' ) );
+	$assert( 1 === count( $with_replay['replay_events'] ?? array() ), 'append_replay_event stores replay ledger entries' );
+
+	$with_artifact = $store->add_artifact_ref( 'job:1', 'datamachine://jobs/1/artifacts/result' );
+	$assert( array( 'datamachine://jobs/1/artifacts/result' ) === ( $with_artifact['artifact_refs'] ?? array() ), 'add_artifact_ref stores portable artifact refs' );
+
+	$completed = $store->complete_run( 'job:1' );
+	$assert( 'completed' === ( $completed['status'] ?? '' ), 'complete_run transitions to completed' );
+
+	$failed_after_final = $store->fail_run( 'job:1', 'too late' );
+	$assert( false === $failed_after_final, 'terminal runs are immutable through fail_run' );
+
+	$cancel_candidate = $store->create_run( 'deterministic_loop' );
+	$cancelled        = $store->cancel_run( $cancel_candidate['run_id'] ?? '' );
+	$assert( 'cancelled' === ( $cancelled['status'] ?? '' ), 'cancel_run transitions to cancelled' );
+
+	if ( $failures ) {
+		echo '=== run-lifecycle-store-smoke: ' . count( $failures ) . " FAILURE(S) ===\n";
+		foreach ( $failures as $failure ) {
+			echo "  [FAIL] {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "=== run-lifecycle-store-smoke: ALL PASS ({$passes} assertions) ===\n";
+}


### PR DESCRIPTION
## Summary
- Add a generic job-backed RunLifecycleStore with create/start/wait/resume/complete/fail/cancel lifecycle methods.
- Record run_id, run_type, status, attempt, replay events, and artifact refs in existing job engine_data without introducing a dedicated run table.
- Adapt job create/idempotent-create/status transitions to seed and mirror generic run lifecycle metadata while leaving existing job callers in place.
- Fix first engine-data compare-and-swap initialization when existing job engine_data is NULL.

## Tests
- php tests/run-lifecycle-store-smoke.php
- php tests/job-status-transition-smoke.php
- php -l inc/Core/RunLifecycleStore.php
- php -l inc/Core/Database/Jobs/Jobs.php
- php -l tests/run-lifecycle-store-smoke.php
- php -l tests/job-status-transition-smoke.php
- vendor/bin/phpcs inc/Core/RunLifecycleStore.php inc/Core/Database/Jobs/Jobs.php tests/run-lifecycle-store-smoke.php tests/job-status-transition-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the generic run lifecycle substrate, job adapter changes, and focused PHP smoke tests; Chris remains responsible for review and validation.