### PR TITLE
fix: make FilesystemHelper group-writable chmod best-effort (stop EPERM warnings)

### DIFF
--- a/inc/Core/FilesRepository/FilesystemHelper.php
+++ b/inc/Core/FilesRepository/FilesystemHelper.php
@@ -114,7 +114,7 @@ class FilesystemHelper {
 		// files it fails with EPERM, so skip it rather than emit a Warning.
 		if ( function_exists( 'posix_getuid' ) ) {
 			$owner = fileowner( $filepath );
-			if ( false !== $owner && $owner !== posix_getuid() ) {
+			if ( false !== $owner && posix_getuid() !== $owner ) {
 				return false;
 			}
 		}

--- a/inc/Core/FilesRepository/FilesystemHelper.php
+++ b/inc/Core/FilesRepository/FilesystemHelper.php
@@ -85,16 +85,43 @@ class FilesystemHelper {
 	 * both the web server user (www-data) and the coding agent user
 	 * (e.g. opencode) can read and write the file.
 	 *
+	 * Best-effort: the group-writable bit is a convenience, not a correctness
+	 * requirement. On multisite installs the target file is frequently owned by
+	 * www-data while the CLI runs as a different user in the www-data group, so
+	 * an unconditional chmod() on a non-owned file fails with EPERM and PHP
+	 * raises a Warning — even though setgid directories usually mean the file is
+	 * already group-writable. We therefore skip the chmod when the bit is
+	 * already set or when the process does not own the file, and suppress any
+	 * residual warning so a failed chmod never surfaces in CLI stderr or the
+	 * production error log.
+	 *
 	 * @since 0.32.0
 	 * @param string $filepath Absolute path to the file.
-	 * @return bool True if permissions were set, false on failure.
+	 * @return bool True if the file is (or was made) group-writable, false otherwise.
 	 */
 	public static function make_group_writable( string $filepath ): bool {
 		if ( ! file_exists( $filepath ) ) {
 			return false;
 		}
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
-		return chmod( $filepath, self::AGENT_FILE_PERMISSIONS );
+
+		// Already group-writable (commonly via setgid dirs) — nothing to do.
+		$perms = fileperms( $filepath );
+		if ( false !== $perms && ( $perms & 0020 ) === 0020 ) {
+			return true;
+		}
+
+		// chmod() only succeeds for the file owner (or root). On non-owned
+		// files it fails with EPERM, so skip it rather than emit a Warning.
+		if ( function_exists( 'posix_getuid' ) ) {
+			$owner = fileowner( $filepath );
+			if ( false !== $owner && $owner !== posix_getuid() ) {
+				return false;
+			}
+		}
+
+		// Suppress any residual warning — a failed chmod is non-fatal here.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod, WordPress.PHP.NoSilencedErrors.Discouraged
+		return @chmod( $filepath, self::AGENT_FILE_PERMISSIONS );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`FilesystemHelper::make_group_writable()` called `chmod()` **unconditionally** whenever the target file existed (`inc/Core/FilesRepository/FilesystemHelper.php`). On multisite installs the target files are frequently owned by `www-data` while the CLI runs as a *different* user that is merely a member of the `www-data` group. `chmod()` only succeeds for the file owner (or root), so on a non-owned file it fails with **EPERM** and PHP raises a `Warning: chmod(): Operation not permitted`.

Because the agent directories are setgid, the file is usually **already group-writable** — so the failing `chmod()` was both raising a warning *and* unnecessary. It surfaced in CLI stderr on every memory/worktree write and as a chronic production error-log signature (~200–1500 / 7d).

## Root cause

Unconditional `chmod()` on files the process does not own.

## The fix (best-effort, silent)

The group-writable bit is a convenience, not a correctness requirement, so the chmod is now best-effort:

1. **Short-circuit** `true` when the bit is already set: `( fileperms($filepath) & 0020 ) === 0020`.
2. **Skip** the chmod when the process is not the file owner — guarded by `function_exists('posix_getuid')` and comparing `fileowner()` vs `posix_getuid()`.
3. **Error-suppress** the residual `chmod()` so a failed call never emits a PHP Warning.

The `bool` return contract and the existing `phpcs:ignore` for the WP filesystem sniff are preserved.

## Caller safety

All four callers discard the return value (best-effort already):
- `inc/Engine/AI/ComposableFileGenerator.php:208`
- `inc/Core/FilesRepository/DiskAgentMemoryStore.php:109`
- `inc/Abilities/File/ScaffoldAbilities.php:438,444`

None rely on the method throwing or on a hard-`true` return.

## Verification

- `php -l` clean on the changed file.
- `vendor/bin/phpcs --standard=WordPress` on the changed file: **0 findings**.
- Standalone harness replicating the new logic confirms: owned-0644 file → chmods to 0664 + returns true; already-0664 file → short-circuit true; non-existent → false; **no PHP warnings emitted** in any case (an `set_error_handler` that `exit(1)`s on any warning passed).

Closes #2755