### PR TITLE
fix: emit real flow config in structured output instead of the table display placeholder

### DIFF
--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -469,15 +469,25 @@ class FlowsCommand extends BaseCommand {
 			return;
 		}
 
+		// Apply the human empty-cell placeholder ("—") ONLY for the table
+		// display. Structured formats (json/csv/yaml/ids/count) must carry the
+		// real value (an empty string when there's no config summary) — a
+		// display dash in structured output is a silent data-integrity bug: it
+		// reads as "this flow has config '—'" when the flow simply has none
+		// (#2754).
+		$is_table = 'table' === $format;
+
 		// Transform flows to flat row format.
 		$items = array_map(
-			function ( $flow ) {
+			function ( $flow ) use ( $is_table ) {
+				$config_summary = $this->extractConfigSummary( $flow );
+
 				return array(
 					'id'          => $flow['flow_id'],
 					'name'        => $flow['flow_name'],
 					'pipeline_id' => $flow['pipeline_id'],
 					'handlers'    => $this->extractHandlers( $flow ),
-					'config'      => $this->extractConfigSummary( $flow ),
+					'config'      => ( $is_table && '' === $config_summary ) ? '—' : $config_summary,
 					'schedule'    => $this->extractSchedule( $flow ),
 					'max_items'   => $this->extractMaxItems( $flow ),
 					'prompt'      => $this->extractPrompt( $flow ),
@@ -1578,8 +1588,13 @@ class FlowsCommand extends BaseCommand {
 	 * specific taxonomy, handler, or post type. Surfaces distinguishing
 	 * values like coordinates, city names, URLs, and taxonomy selections.
 	 *
+	 * Returns the honest summary string — an EMPTY string when the flow has
+	 * no distinguishing config — so the value is safe for every output format
+	 * (json/csv/yaml). The human "—" empty-cell placeholder is a table-display
+	 * concern and is applied only when building table rows, never here (#2754).
+	 *
 	 * @param array $flow Flow data.
-	 * @return string Config summary (max ~60 chars).
+	 * @return string Config summary (max ~60 chars), or '' when empty.
 	 */
 	private function extractConfigSummary( array $flow ): string {
 		$flow_config = $flow['flow_config'] ?? array();
@@ -1637,7 +1652,7 @@ class FlowsCommand extends BaseCommand {
 			$summary = mb_substr( $summary, 0, 57 ) . '...';
 		}
 
-		return '' !== $summary ? $summary : '—';
+		return $summary;
 	}
 
 	/**

--- a/inc/Cli/Commands/PipelinesCommand.php
+++ b/inc/Cli/Commands/PipelinesCommand.php
@@ -360,18 +360,26 @@ class PipelinesCommand extends BaseCommand {
 				return;
 			}
 
+			// Apply the human empty-cell placeholder ("—") ONLY for the table
+			// display. Structured formats (json/csv/yaml/ids/count) must carry
+			// the real value (empty string when there's no summary) — mirrors
+			// the flows-list fix; a display dash in structured output is a
+			// silent data-integrity bug (#2754).
+			$is_table = 'table' === $format;
+
 			// Transform pipelines to flat row format.
 			$items = array_map(
-				function ( $pipeline ) {
-					$config = $pipeline['pipeline_config'] ?? array();
-					$flows  = $pipeline['flows'] ?? array();
+				function ( $pipeline ) use ( $is_table ) {
+					$config   = $pipeline['pipeline_config'] ?? array();
+					$flows    = $pipeline['flows'] ?? array();
+					$location = $this->extractPipelineLocation( $flows );
 					return array(
 						'id'         => $pipeline['pipeline_id'],
 						'name'       => $pipeline['pipeline_name'],
 						'steps'      => count( $config ),
 						'step_types' => $this->extractStepTypes( $config ),
 						'flows'      => count( $flows ),
-						'location'   => $this->extractPipelineLocation( $flows ),
+						'location'   => ( $is_table && '' === $location ) ? '—' : $location,
 						'updated'    => $pipeline['updated_at_display'] ?? $pipeline['updated_at'] ?? 'N/A',
 					);
 				},
@@ -493,8 +501,13 @@ class PipelinesCommand extends BaseCommand {
 	 * city names, URLs, taxonomy term IDs. Domain-agnostic: reads raw
 	 * config keys without assuming any specific taxonomy or handler.
 	 *
+	 * Returns the honest summary string — an EMPTY string when no
+	 * distinguishing config is found — so the value is safe for every output
+	 * format. The "—" empty-cell placeholder is applied only when building
+	 * table rows, never here (#2754).
+	 *
 	 * @param array $flows Pipeline's flows array.
-	 * @return string Config summary or "—".
+	 * @return string Config summary, or '' when empty.
 	 */
 	private function extractPipelineLocation( array $flows ): string {
 		$parts = array();
@@ -537,7 +550,7 @@ class PipelinesCommand extends BaseCommand {
 		}
 
 		$summary = implode( ' | ', array_unique( $parts ) );
-		return '' !== $summary ? $summary : '—';
+		return $summary;
 	}
 
 	/**

--- a/tests/flows-list-config-placeholder-smoke.php
+++ b/tests/flows-list-config-placeholder-smoke.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Smoke test for the flows/pipelines list "config" placeholder fix (#2754).
+ *
+ * The bug: `wp datamachine flows --format=json` emitted the `config` field as
+ * the literal table display placeholder "—" (em-dash) when a flow had no
+ * distinguishing config summary. A display dash in structured (json/csv/yaml)
+ * output is a silent data-integrity bug — it reads as "this flow has config
+ * '—'" when the flow simply has none. `flows get <id> --format=json` already
+ * returned the real flow_config, so only the LIST view JSON lied.
+ *
+ * The fix: the summary extractors return the honest value (an EMPTY string
+ * when there is nothing to summarize). The "—" empty-cell placeholder is a
+ * table-display concern and is applied ONLY when building table rows.
+ *
+ * This test asserts the placeholder decision the row builders make:
+ *   - table  + empty summary  → "—"   (human empty-cell)
+ *   - table  + real summary   → summary verbatim
+ *   - json/csv/yaml/ids/count + empty summary → ""   (honest, never a dash)
+ *   - json/csv/yaml + real summary → summary verbatim
+ *
+ * Run with: php tests/flows-list-config-placeholder-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare( strict_types=1 );
+
+$failures = 0;
+
+/**
+ * Assert helper.
+ *
+ * @param bool   $cond   Condition.
+ * @param string $label  Test label.
+ * @param string $detail Optional detail.
+ */
+function dm_assert( bool $cond, string $label, string $detail = '' ): void {
+	global $failures;
+	if ( $cond ) {
+		echo "  [PASS] {$label}\n";
+		return;
+	}
+	++$failures;
+	echo "  [FAIL] {$label}" . ( '' !== $detail ? " — {$detail}" : '' ) . "\n";
+}
+
+/**
+ * Mirror of the production row-builder placeholder decision.
+ *
+ * Both FlowsCommand::__invoke (config column) and PipelinesCommand::__invoke
+ * (location column) compute the cell as:
+ *   ( $is_table && '' === $summary ) ? '—' : $summary
+ *
+ * @param string $summary  Honest summary string from the extractor.
+ * @param string $format   Output format.
+ * @return string Cell value.
+ */
+function dm_list_cell( string $summary, string $format ): string {
+	$is_table = 'table' === $format;
+	return ( $is_table && '' === $summary ) ? '—' : $summary;
+}
+
+echo "\n[1] table + empty summary → em-dash placeholder (human display)\n";
+dm_assert( '—' === dm_list_cell( '', 'table' ), 'empty config in table shows "—"' );
+
+echo "\n[2] structured formats + empty summary → honest empty string (no dash)\n";
+foreach ( array( 'json', 'csv', 'yaml', 'ids', 'count' ) as $fmt ) {
+	dm_assert(
+		'' === dm_list_cell( '', $fmt ),
+		"empty config in {$fmt} is '' not '—'",
+		"got: '" . dm_list_cell( '', $fmt ) . "'"
+	);
+}
+
+echo "\n[3] real summary passes through verbatim in every format\n";
+$real = 'city=Charleston | r=50';
+foreach ( array( 'table', 'json', 'csv', 'yaml' ) as $fmt ) {
+	dm_assert(
+		$real === dm_list_cell( $real, $fmt ),
+		"real config preserved in {$fmt}"
+	);
+}
+
+echo "\n[4] the literal em-dash never appears in structured output for an empty cell\n";
+$json_cell = dm_list_cell( '', 'json' );
+dm_assert(
+	false === strpos( $json_cell, '—' ),
+	'json cell contains no em-dash',
+	"got: '{$json_cell}'"
+);
+
+echo "\n[5] source guard: extractors no longer hardcode the '—' fallback\n";
+$flows_src     = (string) file_get_contents( __DIR__ . '/../inc/Cli/Commands/Flows/FlowsCommand.php' );
+$pipelines_src = (string) file_get_contents( __DIR__ . '/../inc/Cli/Commands/PipelinesCommand.php' );
+dm_assert(
+	false === strpos( $flows_src, "? \$summary : '—'" ),
+	'FlowsCommand::extractConfigSummary dropped the inline "—" fallback'
+);
+dm_assert(
+	false === strpos( $pipelines_src, "? \$summary : '—'" ),
+	'PipelinesCommand::extractPipelineLocation dropped the inline "—" fallback'
+);
+dm_assert(
+	false !== strpos( $flows_src, "( \$is_table && '' === \$config_summary ) ? '—'" ),
+	'FlowsCommand applies the "—" placeholder only for table format'
+);
+dm_assert(
+	false !== strpos( $pipelines_src, "( \$is_table && '' === \$location ) ? '—'" ),
+	'PipelinesCommand applies the "—" placeholder only for table format'
+);
+
+echo "\n";
+if ( $failures > 0 ) {
+	echo "FAILED: {$failures} assertion(s) failed.\n";
+	exit( 1 );
+}
+echo "OK: all assertions passed.\n";
+exit( 0 );


### PR DESCRIPTION
## Root cause

`wp datamachine flows --format=json` returned the `config` field as the literal table empty-cell placeholder `—` (em-dash) for any flow with no distinguishing config summary.

The list-view row builder calls `FlowsCommand::extractConfigSummary()`, which ended with:

```php
return '' !== $summary ? $summary : '—';
```

That `—` is a **human table empty-cell** marker, but it was baked into the extractor's return value, so it leaked into **every** output format — json, csv, yaml. A display dash in structured output is a silent data-integrity bug: a consumer parsing the JSON reads it as "this flow has config `—`" when the flow simply has no config summary.

The detail view (`wp datamachine flows get <id> --format=json`) already returned the full real `flow_config`, so the data exists — only the **list-view JSON lied**.

`PipelinesCommand::extractPipelineLocation()` (the `location` column on `wp datamachine pipelines`) had the identical bug, so it's fixed in the same pass.

## Fix (option a — make list-JSON honest)

- `extractConfigSummary()` / `extractPipelineLocation()` now return the **honest** value: the real summary string, or an **empty string** when there's nothing to summarize. No display formatting baked into the extractor.
- The `—` placeholder is applied **only when building table rows**, gated on `$format === 'table'`:
  ```php
  'config' => ( $is_table && '' === $config_summary ) ? '—' : $config_summary,
  ```
- Result:
  - `--format=table` → still shows `—` for genuinely-empty cells (unchanged human UX).
  - `--format=json` / `csv` / `yaml` / `ids` / `count` → carry the real value (empty string when empty), never a display dash.

Chose (a) over (b) — the config summary is short (capped ~60 chars) and genuinely useful in a list row, so omitting the column entirely would lose information. Making list-JSON honest is the minimal, correct fix.

## Verification

- `php -l` clean on both changed files.
- `phpcs --standard=WordPress` exit 0 (no errors, no warnings) on all changed files — the data-machine Lint gate fails on warnings, so this matters.
- New smoke `tests/flows-list-config-placeholder-smoke.php` asserts the placeholder decision (table+empty → `—`; structured+empty → `''`; real summary verbatim in every format) plus source guards that the inline `—` fallback is gone and the table-only gate is present. All assertions pass: `php tests/flows-list-config-placeholder-smoke.php`.

## Scope note

Applied the parallel fix to `pipelines` list `location` column since it shared the exact anti-pattern. No other list columns emit a display placeholder (`handlers`, `max_items`, `prompt` already return `''` when empty; `schedule`/`status`/`next_run` carry real labels).

Closes #2754