### PR TITLE
Pin Blocks Engine transformer trunk commit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
 				"source": {
 					"type": "git",
 					"url": "https://github.com/Automattic/blocks-engine.git",
-					"reference": "trunk"
+					"reference": "f8259ed02cf9f815e945dced6c8e5458cda96212"
 				},
 				"autoload": {
 					"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "684b1cea1db6afde16fa2e019140b230",
+    "content-hash": "3e50926fcfadbf3595b27e6fa6ea0452",
     "packages": [
         {
             "name": "automattic/blocks-engine-php-transformer",
@@ -12,7 +12,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "trunk"
+                "reference": "f8259ed02cf9f815e945dced6c8e5458cda96212"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- Pin the Composer package source reference for automattic/blocks-engine-php-transformer to Blocks Engine trunk f8259ed02cf9f815e945dced6c8e5458cda96212.
- Refresh composer.lock so installs materialize the post-merge transformer instead of a stale cached trunk checkout.

## Verification
- git ls-remote https://github.com/Automattic/blocks-engine.git refs/heads/trunk -> f8259ed02cf9f815e945dced6c8e5458cda96212
- composer install
- composer update automattic/blocks-engine-php-transformer --with-dependencies
- git rev-parse HEAD in vendor/automattic/blocks-engine-php-transformer -> f8259ed02cf9f815e945dced6c8e5458cda96212
- composer validate (passes with existing version-field warning)
- composer lint
- php tests/content-format-blocks-engine-smoke.php
- php tests/content-format-blocks-engine-class-smoke.php
- php tests/content-format-abilities-smoke.php
- php tests/content-format-convert-filter-smoke.php
- php tests/content-format-helper-smoke.php
- php tests/wordpress-publish-content-format-smoke.php
- vendor/autoload.php transformer probe with minimal WordPress hook stubs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Dependency verification, Composer metadata update, test execution, and PR drafting.