### PR TITLE
fix: make RunMetrics engine_data writes compare-and-swap safe

### DIFF
--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -118,24 +118,34 @@ class RunMetrics {
 			return false;
 		}
 
-		$engine  = EngineData::retrieve( $job_id );
-		$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
-		$now     = self::now();
+		// Compare-and-swap mutate so a concurrent writer's keys (e.g. a
+		// fan-out batch_state merge happening in the same tight window)
+		// are never clobbered by a blind full-snapshot overwrite. See #2762.
+		$result = EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $context, $job_id ): array {
+				$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
+				$now     = self::now();
 
-		if ( empty( $metrics['started_at'] ) ) {
-			$metrics['started_at'] = $now;
-		}
-		$metrics['last_activity_at'] = $now;
+				if ( empty( $metrics['started_at'] ) ) {
+					$metrics['started_at'] = $now;
+				}
+				$metrics['last_activity_at'] = $now;
 
-		if ( ! empty( $context ) ) {
-			$metrics['context'] = array_replace_recursive(
-				is_array( $metrics['context'] ?? null ) ? $metrics['context'] : array(),
-				self::sanitizeContext( $context )
-			);
-		}
+				if ( ! empty( $context ) ) {
+					$metrics['context'] = array_replace_recursive(
+						is_array( $metrics['context'] ?? null ) ? $metrics['context'] : array(),
+						self::sanitizeContext( $context )
+					);
+				}
 
-		$engine[ self::KEY ] = $metrics;
-		return EngineData::persist( $job_id, self::withRunResult( $job_id, $engine ) );
+				$engine[ self::KEY ] = $metrics;
+				return self::withRunResult( $job_id, $engine );
+			},
+			'run_metrics_start'
+		);
+
+		return ! empty( $result['success'] );
 	}
 
 	public static function increment( int $job_id, string $key, int $amount = 1 ): bool {
@@ -143,18 +153,27 @@ class RunMetrics {
 			return false;
 		}
 
-		$engine  = EngineData::retrieve( $job_id );
-		$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
+		// Compare-and-swap mutate so concurrent writers cannot lose the
+		// incremented counter or clobber unrelated keys. See #2762.
+		$result = EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $key, $amount ): array {
+				$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
 
-		if ( ! isset( $metrics['counts'][ $key ] ) ) {
-			$metrics['counts'][ $key ] = 0;
-		}
+				if ( ! isset( $metrics['counts'][ $key ] ) ) {
+					$metrics['counts'][ $key ] = 0;
+				}
 
-		$metrics['counts'][ $key ]   = max( 0, (int) $metrics['counts'][ $key ] + $amount );
-		$metrics['last_activity_at'] = self::now();
+				$metrics['counts'][ $key ]   = max( 0, (int) $metrics['counts'][ $key ] + $amount );
+				$metrics['last_activity_at'] = self::now();
 
-		$engine[ self::KEY ] = $metrics;
-		return EngineData::persist( $job_id, $engine );
+				$engine[ self::KEY ] = $metrics;
+				return $engine;
+			},
+			'run_metrics_increment'
+		);
+
+		return ! empty( $result['success'] );
 	}
 
 	public static function complete( int $job_id, string $status ): bool {
@@ -162,29 +181,39 @@ class RunMetrics {
 			return false;
 		}
 
-		$engine  = EngineData::retrieve( $job_id );
-		$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
-		$now     = self::now();
+		// Compare-and-swap mutate so completing a parent job cannot blindly
+		// overwrite a concurrent fan-out batch_state write with a stale
+		// snapshot — the lost-update race behind batch_state_missing. See #2762.
+		$result = EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $status, $job_id ): array {
+				$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
+				$now     = self::now();
 
-		if ( empty( $metrics['started_at'] ) ) {
-			$metrics['started_at'] = $engine['started_at'] ?? ( $engine['job']['created_at'] ?? $now );
-		}
+				if ( empty( $metrics['started_at'] ) ) {
+					$metrics['started_at'] = $engine['started_at'] ?? ( $engine['job']['created_at'] ?? $now );
+				}
 
-		$metrics['completed_at']     = $now;
-		$metrics['last_activity_at'] = $now;
-		$metrics['duration_seconds'] = self::durationSeconds( $metrics['started_at'], $now );
-		$metrics['terminal_status']  = $status;
+				$metrics['completed_at']     = $now;
+				$metrics['last_activity_at'] = $now;
+				$metrics['duration_seconds'] = self::durationSeconds( $metrics['started_at'], $now );
+				$metrics['terminal_status']  = $status;
 
-		if ( JobStatus::isStatusFailure( $status ) ) {
-			$metrics['counts']['failed'] = max( 1, (int) ( $metrics['counts']['failed'] ?? 0 ) );
-		} elseif ( str_starts_with( $status, JobStatus::AGENT_SKIPPED ) || str_starts_with( $status, JobStatus::COMPLETED_NO_ITEMS ) ) {
-			$metrics['counts']['skipped'] = max( 1, (int) ( $metrics['counts']['skipped'] ?? 0 ) );
-		} elseif ( JobStatus::COMPLETED === $status ) {
-			$metrics['counts']['processed'] = max( 1, (int) ( $metrics['counts']['processed'] ?? 0 ) );
-		}
+				if ( JobStatus::isStatusFailure( $status ) ) {
+					$metrics['counts']['failed'] = max( 1, (int) ( $metrics['counts']['failed'] ?? 0 ) );
+				} elseif ( str_starts_with( $status, JobStatus::AGENT_SKIPPED ) || str_starts_with( $status, JobStatus::COMPLETED_NO_ITEMS ) ) {
+					$metrics['counts']['skipped'] = max( 1, (int) ( $metrics['counts']['skipped'] ?? 0 ) );
+				} elseif ( JobStatus::COMPLETED === $status ) {
+					$metrics['counts']['processed'] = max( 1, (int) ( $metrics['counts']['processed'] ?? 0 ) );
+				}
 
-		$engine[ self::KEY ] = $metrics;
-		return EngineData::persist( $job_id, self::withRunResult( $job_id, $engine, $status ) );
+				$engine[ self::KEY ] = $metrics;
+				return self::withRunResult( $job_id, $engine, $status );
+			},
+			'run_metrics_complete'
+		);
+
+		return ! empty( $result['success'] );
 	}
 
 	public static function fromJob( array $job ): array {

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -168,6 +168,61 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$this->assertFalse( get_transient( 'dm_pipeline_batch_' . $parent_id ) );
 	}
 
+	/**
+	 * Regression for #2762: a concurrent RunMetrics write must not clobber
+	 * batch_state written by fan-out.
+	 *
+	 * Reproduces the lost-update race where the Ticketmaster fan-out flow
+	 * fails children with batch_state_missing: fan-out writes batch_state, but
+	 * a RunMetrics persist that started from a pre-fan-out baseline overwrites
+	 * the whole engine_data column with a snapshot that has no batch key. The
+	 * stale object-cache entry below stands in for that baseline. With the
+	 * compare-and-swap path, RunMetrics re-reads the live snapshot and the
+	 * batch key survives.
+	 */
+	public function test_runmetrics_write_does_not_clobber_batch_state(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+
+		// Snapshot the parent BEFORE fan-out — this is the stale baseline a
+		// concurrent RunMetrics writer would have read.
+		$stale_baseline = datamachine_get_engine_data( $parent_id );
+		$this->assertArrayNotHasKey( 'batch', $stale_baseline );
+
+		$packets = array(
+			$this->make_data_packet( 'Event A' ),
+			$this->make_data_packet( 'Event B' ),
+		);
+
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->fanOut( $parent_id, 'step_abc_123', $packets, $engine );
+
+		// Parent now carries the batch state on disk.
+		$after_fanout = datamachine_get_engine_data( $parent_id );
+		$this->assertTrue( $after_fanout['batch'] );
+		$this->assertArrayHasKey( 'batch_state', $after_fanout );
+
+		// Re-prime the object cache with the stale pre-fan-out baseline to
+		// simulate a concurrent runner that read engine_data before fan-out
+		// committed. A blind read-modify-write persist would push this stale
+		// snapshot back and drop batch / batch_state.
+		wp_cache_set( $parent_id, $stale_baseline, 'datamachine_engine_data' );
+
+		\DataMachine\Core\RunMetrics::increment( $parent_id, 'processed' );
+
+		$preserved = datamachine_get_engine_data( $parent_id );
+		$this->assertTrue( $preserved['batch'] ?? false, 'batch flag survives concurrent RunMetrics write' );
+		$this->assertArrayHasKey( 'batch_state', $preserved, 'batch_state survives concurrent RunMetrics write' );
+		$this->assertSame( 2, (int) $preserved['batch_state']['total'] );
+		$this->assertSame( 1, (int) $preserved['run_metrics']['counts']['processed'] );
+
+		// And the chunk that runs next still finds its state — no
+		// batch_state_missing failure.
+		$scheduler->processChunk( $parent_id );
+		$parent_job = $this->jobs_db->get_job( $parent_id );
+		$this->assertStringNotContainsString( 'batch_state_missing', (string) $parent_job['status'] );
+	}
+
 	public function test_process_chunk_creates_child_jobs(): void {
 		$parent_id = $this->create_parent_job();
 		$engine    = $this->make_engine_snapshot( $parent_id );

--- a/tests/run-metrics-smoke.php
+++ b/tests/run-metrics-smoke.php
@@ -119,4 +119,23 @@ $failed = RunMetrics::fromJob(
 dm_assert( 1 === $skipped['counts']['skipped'], 'completed_no_items increments skipped' );
 dm_assert( 1 === $failed['counts']['failed'], 'failed status increments failed' );
 
+echo "\n[4] engine_data writers use compare-and-swap, not blind overwrite (regression: #2762)\n";
+// The lost-update race behind batch_state_missing came from start(), increment(),
+// and complete() doing a non-atomic retrieve()+persist() read-modify-write that
+// could overwrite a concurrent fan-out batch_state merge with a stale snapshot.
+// All three must route through the compare-and-swap EngineData::mutate() path so
+// they can never clobber another writer's keys.
+$run_metrics_source = file_get_contents( __DIR__ . '/../inc/Core/RunMetrics.php' );
+dm_assert( false !== $run_metrics_source, 'RunMetrics source readable' );
+
+foreach ( array( 'start', 'increment', 'complete' ) as $method ) {
+	if ( ! preg_match( '/public static function ' . $method . '\([^)]*\)[^{]*\{(.*?)\n\t\}/s', $run_metrics_source, $m ) ) {
+		echo "  [FAIL] could not locate {$method}() body\n";
+		exit( 1 );
+	}
+	$body = $m[1];
+	dm_assert( str_contains( $body, 'EngineData::mutate' ), "{$method}() persists via EngineData::mutate (CAS)" );
+	dm_assert( ! str_contains( $body, 'EngineData::persist' ), "{$method}() does not blind-overwrite via EngineData::persist" );
+}
+
 echo "\n=== run-metrics-smoke: ALL PASS ===\n";


### PR DESCRIPTION
## Summary

Fixes the recurring `batch_state_missing` failures on the events.extrachill.com Ticketmaster fan-out flow (5-17 failed child jobs/day). Root cause is a lost-update race in `RunMetrics`, not in the batch engine itself.

Closes #2762.

## Confirmed root cause (which read/write path)

`RunMetrics::start()`, `increment()`, and `complete()` (`inc/Core/RunMetrics.php`) persisted engine_data with a **non-atomic read-modify-write**:

```php
$engine = EngineData::retrieve( $job_id );   // baseline read (object-cache first)
$engine['run_metrics'] = ...;
return EngineData::persist( $job_id, $engine ); // BLIND full-column overwrite
```

`EngineData::persist()` overwrites the entire `engine_data` column. Every *other* engine_data writer in the codebase was migrated to the compare-and-swap `EngineData::mutate()` path (that's what `Jobs::compare_and_swap_engine_data()` exists for) — these three RunMetrics writers were the lone holdouts still doing blind overwrites.

The race that produces `batch_state_missing`:

1. A fetch flow job (Ticketmaster, large result set) runs its fetch step and calls `PipelineBatchScheduler::fanOut()` → `BatchScheduler::start()`, which **CAS-merges `batch=true` + `batch_state`** into the parent's engine_data and immediately schedules the first chunk (`as_schedule_single_action(time(), …)`).
2. Concurrently (Action Scheduler runs multiple queue runners; the first chunk is queued for *now*), a `RunMetrics` write fires for that **same parent job** from a baseline snapshot read **before** `batch_state` was committed. Its blind `persist()` writes the whole stale snapshot back, **dropping `batch` and `batch_state`**.
3. The chunk action runs `BatchScheduler::processChunk()`, finds no `batch_state` **and** no `batch` flag → returns `missing: true` → `PipelineBatchScheduler` fails the parent with `batch_state_missing`.

### Why this matches every piece of the evidence
- **`batch` *and* `batch_state` both absent** from the failed parent (job 649798): a full-snapshot clobber. The normal last-chunk cleanup only `unset()`s `batch_state` and *leaves* the `batch` flag, so it can't explain both being gone.
- **`run_result` present**: it was written by the very RunMetrics call that clobbered (`withRunResult()` is only invoked by `start()`/`complete()`).
- **Jobs cluster at the exact same second**: fan-out + immediate first chunk + concurrent metrics writes all land in one tight window.
- **Correlates with large Ticketmaster payloads**: more packets ⇒ more concurrent child/metric writes ⇒ wider race window.

**Hypothesis supported by the evidence: (a) a regression / incomplete migration of #699.** #699 moved batch state from a transient into engine_data, but never converted the RunMetrics writers to the CAS path that makes engine_data writes safe under concurrency. The size angle (b) and partial-API-failure angle (c) are contributing pressure (they widen the window) but are not the mechanism — the mechanism is the non-atomic overwrite.

## Fix

Route `start()`, `increment()`, and `complete()` through the existing compare-and-swap `EngineData::mutate()` path. On a concurrent-write conflict, `mutate()` re-reads the live snapshot and re-applies the metrics mutation, so a metrics write can never overwrite another writer's keys (`batch_state` or anything else). `withRunResult()` already operates purely on the in-callback snapshot (plus a read-only job-row lookup), so it is safe inside the mutate callback.

## Why it is handler-agnostic (layer purity)

The change is entirely in the generic `RunMetrics` core. There are **no** `Ticketmaster`/`events`/handler-name literals — Ticketmaster is just the flow whose large payloads exposed the generic race. Any fan-out on any handler benefits identically.

## Verification

- `php -l inc/Core/RunMetrics.php` — clean.
- `vendor/bin/phpcs` on all touched files — **0 errors / 0 warnings, exit 0** (the data-machine Lint gate fails on warnings; this is clean).
- `php tests/run-metrics-smoke.php` — PASS. Extended with a source-guard (section [4]) asserting all three writers use `EngineData::mutate` and never `EngineData::persist`, to catch re-regression.
- `php tests/batch-completion-strategy-smoke.php`, `pipeline-batch-terminal-parent-guard-smoke.php`, `task-scheduler-batch-parent-link-smoke.php` — PASS.
- Added `PipelineBatchSchedulerTest::test_runmetrics_write_does_not_clobber_batch_state` (PHPUnit / `WP_UnitTestCase`, runs in CI via `homeboy test`): reproduces the race by priming the object cache with a stale pre-fan-out baseline, then calling `RunMetrics::increment()` on the parent, and asserts `batch` + `batch_state` survive and the next `processChunk()` does **not** fail with `batch_state_missing`. (The DB-backed PHPUnit suite needs `install-wp-tests.sh`, which isn't provisioned in this worktree; it lints clean and runs in CI.)

### Known pre-existing red (not caused by this change)
`tests/job-outcome-metrics-smoke.php` fatals on `undefined function ...wp_json_encode()` from `RunResult.php` — its bootstrap lacks the stub. Confirmed identical failure on clean `main` (verified via `git stash`). Out of scope here.