### PR TITLE
Refresh Blocks Engine transformer pin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
 				"source": {
 					"type": "git",
 					"url": "https://github.com/Automattic/blocks-engine.git",
-					"reference": "f8259ed02cf9f815e945dced6c8e5458cda96212"
+					"reference": "726f1320ff64cd740ca3bda8a82161e2833979c0"
 				},
 				"autoload": {
 					"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e50926fcfadbf3595b27e6fa6ea0452",
+    "content-hash": "eaa37b38d214a56afdca257ef3d2c0a5",
     "packages": [
         {
             "name": "automattic/blocks-engine-php-transformer",
@@ -12,7 +12,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "f8259ed02cf9f815e945dced6c8e5458cda96212"
+                "reference": "726f1320ff64cd740ca3bda8a82161e2833979c0"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- refresh the Composer package pin for `automattic/blocks-engine-php-transformer` to Blocks Engine trunk `726f1320ff64cd740ca3bda8a82161e2833979c0`
- update `composer.lock` so Data Machine installs the current canonical transformer package

## Testing
- `composer update automattic/blocks-engine-php-transformer --no-interaction`
- `composer validate --strict`
- `composer test`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Updating the Composer pin, running verification, and preparing the PR.
