### PR TITLE
Use tagged Blocks Engine transformer release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=8.2",
 		"wordpress/agents-api": "dev-main",
 		"woocommerce/action-scheduler": "^3.9",
-		"automattic/blocks-engine-php-transformer": "dev-trunk"
+		"automattic/blocks-engine-php-transformer": "0.1.0"
 	},
 	"require-dev": {
 		"php-stubs/wordpress-stubs": "^6.9",
@@ -48,12 +48,12 @@
 			"type": "package",
 			"package": {
 				"name": "automattic/blocks-engine-php-transformer",
-				"version": "dev-trunk",
+				"version": "0.1.0",
 				"type": "library",
 				"source": {
 					"type": "git",
 					"url": "https://github.com/Automattic/blocks-engine.git",
-					"reference": "ecb99000c6f04288837adaffb20c33035c4f41a0"
+					"reference": "php-transformer-v0.1.0"
 				},
 				"autoload": {
 					"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,15 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c91bc219f45e2285070f0c093d2f660",
+    "content-hash": "9636364c8090b9d2a60860bcb1c4bcde",
     "packages": [
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "dev-trunk",
+            "version": "0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "ecb99000c6f04288837adaffb20c33035c4f41a0"
+                "reference": "php-transformer-v0.1.0"
             },
             "require": {
                 "league/commonmark": "^2.5",
@@ -1607,7 +1607,6 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "automattic/blocks-engine-php-transformer": 20,
         "wordpress/agents-api": 20
     },
     "prefer-stable": false,


### PR DESCRIPTION
## Summary
- Pin the Blocks Engine PHP transformer dependency to the tagged `0.1.0` release.
- Resolve the inline Composer package from `php-transformer-v0.1.0` instead of a trunk commit.
- Regenerate `composer.lock` so installs prove the tagged release path.

## Verification
- `composer update automattic/blocks-engine-php-transformer --no-interaction --prefer-dist`
- `composer show automattic/blocks-engine-php-transformer --all` reported `versions : * 0.1.0` and `source : [git] https://github.com/Automattic/blocks-engine.git php-transformer-v0.1.0`
- `php tests/content-format-blocks-engine-class-smoke.php && php tests/content-format-blocks-engine-smoke.php && php tests/content-format-helper-smoke.php && php tests/content-format-abilities-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Dependency pin update, Composer lock regeneration, and verification run orchestration.
