### PR TITLE
fix: remove Codebox-specific tool policy parsing

### DIFF
--- a/inc/Engine/AI/Tools/HostToolPolicy.php
+++ b/inc/Engine/AI/Tools/HostToolPolicy.php
@@ -126,13 +126,6 @@ final class HostToolPolicy {
 			return self::normalizePolicy( $unwrapped );
 		}
 
-		if ( self::isSandboxPolicyDocument( $policy ) ) {
-			$policy = self::normalizeSandboxPolicyDocument( $policy );
-			if ( null === $policy ) {
-				return null;
-			}
-		}
-
 		$tools = is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array();
 		foreach ( $tools as $tool_name => $rule ) {
 			if ( ! is_string( $tool_name ) || '' === $tool_name || ! is_array( $rule ) ) {
@@ -176,10 +169,6 @@ final class HostToolPolicy {
 			return $policy['external_tool_ownership_policy'];
 		}
 
-		if ( is_array( $policy['sandbox_tool_policy'] ?? null ) ) {
-			return $policy['sandbox_tool_policy'];
-		}
-
 		$tools = is_array( $policy['tools'] ?? null ) ? $policy['tools'] : null;
 		if ( is_array( $tools ) && is_array( $tools['tools'] ?? null ) ) {
 			foreach ( array( 'schema', 'default_location', 'default_execution_location', 'execution_location' ) as $key ) {
@@ -190,70 +179,5 @@ final class HostToolPolicy {
 		}
 
 		return $policy;
-	}
-
-	/**
-	 * @param array<string,mixed> $policy Policy candidate.
-	 */
-	private static function isSandboxPolicyDocument( array $policy ): bool {
-		if ( 'wp-codebox/sandbox-tool-policy/v1' === (string) ( $policy['schema'] ?? '' ) ) {
-			return true;
-		}
-
-		$tools = is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array();
-		if ( empty( $tools ) ) {
-			return false;
-		}
-
-		return array_is_list( $tools ) && is_array( $tools[0] ?? null ) && ( isset( $tools[0]['id'] ) || isset( $tools[0]['runtime_tool_id'] ) );
-	}
-
-	/**
-	 * Convert a sandbox transport policy list into the generic host policy shape.
-	 *
-	 * @param array<string,mixed> $policy Sandbox policy document.
-	 * @return array<string,mixed>|null
-	 */
-	private static function normalizeSandboxPolicyDocument( array $policy ): ?array {
-		$entries = is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array();
-		if ( empty( $entries ) ) {
-			return null;
-		}
-
-		$tools = array();
-
-		foreach ( $entries as $entry ) {
-			if ( ! is_array( $entry ) ) {
-				continue;
-			}
-
-			$tool_name = is_string( $entry['id'] ?? null ) && '' !== trim( (string) $entry['id'] )
-				? trim( (string) $entry['id'] )
-				: ( is_string( $entry['runtime_tool_id'] ?? null ) ? trim( (string) $entry['runtime_tool_id'] ) : '' );
-			if ( '' === $tool_name ) {
-				continue;
-			}
-
-			$location = self::sandboxExecutionLocationToHostLocation( (string) ( $entry['execution_location'] ?? '' ) );
-
-			$tools[ $tool_name ] = array( 'execution_location' => $location );
-		}
-
-		return array(
-			'default_location' => 'disabled',
-			'tools'            => $tools,
-		);
-	}
-
-	private static function sandboxExecutionLocationToHostLocation( string $location ): string {
-		$location = strtolower( trim( $location ) );
-		if ( in_array( $location, array( 'sandbox', 'runner', 'runtime_local' ), true ) ) {
-			return 'runner';
-		}
-		if ( in_array( $location, array( 'parent', 'control_plane' ), true ) ) {
-			return 'control_plane';
-		}
-
-		return 'disabled';
 	}
 }

--- a/tests/boundary-forbidden-names-smoke.php
+++ b/tests/boundary-forbidden-names-smoke.php
@@ -51,6 +51,10 @@ function datamachine_boundary_is_excluded_dir( string $relative_path ): bool {
 }
 
 function datamachine_boundary_is_allowed_file( string $relative_path ): bool {
+	if ( '.git' === $relative_path ) {
+		return true;
+	}
+
 	$allowed_files = array(
 		// Generated local agent guidance; not part of plugin runtime behavior.
 		'AGENTS.md',
@@ -65,8 +69,8 @@ function datamachine_boundary_is_allowed_file( string $relative_path ): bool {
 		return true;
 	}
 
-	// CI workflow files are source-control harness config, not runtime logic.
-	return str_starts_with( $relative_path, '.github/workflows/' );
+	// CI workflow files and tests are source-control harness config, not runtime logic.
+	return str_starts_with( $relative_path, '.github/workflows/' ) || str_starts_with( $relative_path, 'tests/' );
 }
 
 $forbidden_patterns = array(

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -584,24 +584,17 @@ $resolution     = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )-
 assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'wrapped policy delegates explicit control-plane tool', $failures, $passes );
 assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'wrapped policy leaves runner-default tool local', $failures, $passes );
 
-echo "\n[14] host tool policy accepts sandbox transport policy payloads:\n";
-$sandbox_policy = array(
-	'schema'   => 'wp-codebox/sandbox-tool-policy/v1',
-	'version'  => 1,
-	'tools'    => array(
+echo "\n[14] host tool policy ignores list-shaped transport payloads:\n";
+$transport_policy = array(
+	'schema' => 'vendor/tool-policy/v1',
+	'tools'  => array(
 		array(
 			'id'                 => 'alpha_tool',
-			'runtime_tool_id'    => 'alpha_tool',
-			'execution_location' => 'parent',
-		),
-		array(
-			'id'                 => 'beta_tool',
-			'runtime_tool_id'    => 'beta_tool',
-			'execution_location' => 'sandbox',
+			'execution_location' => 'control_plane',
 		),
 	),
 );
-$resolution     = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->resolve(
+$resolution       = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->resolve(
 	array(
 		'mode'                => ToolPolicyResolver::MODE_PIPELINE,
 		'pipeline_step_id'    => 'ephemeral_pipeline_0',
@@ -609,11 +602,11 @@ $resolution     = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )-
 		'categories'          => array(),
 		'allow_only_explicit' => true,
 		'allow_only'          => array( 'alpha_tool', 'beta_tool' ),
-		'host_tool_policy'    => $sandbox_policy,
+		'host_tool_policy'    => $transport_policy,
 	)
 );
-assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'sandbox policy delegates parent-visible tool', $failures, $passes );
-assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'sandbox policy leaves sandbox-local tool local', $failures, $passes );
+assert_policy_equals( null, $resolution['alpha_tool']['executor'] ?? null, 'list-shaped transport policy is not converted into host policy', $failures, $passes );
+assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'list-shaped transport policy does not affect unrelated tools', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " pipeline policy assertions failed.\n";


### PR DESCRIPTION
## Summary
- Remove direct `wp-codebox/sandbox-tool-policy/v1` parsing and sandbox execution-location translation from generic host tool policy handling.
- Keep host/runtime tool ownership generic through `host_tool_policy`, `external_tool_ownership_policy`, environment snapshots, and the `datamachine_host_tool_policy` filter.
- Update policy smoke coverage to prove list-shaped runtime transport payloads are not implicitly converted by Data Machine core.
- Scope the boundary vocabulary smoke test to runtime/source files so it guards generic core code without scanning VCS metadata or test fixtures.

## Verification
- `php tests/pipeline-tool-policy-snapshot-smoke.php`
- `php tests/boundary-forbidden-names-smoke.php`
- `php tests/agent-bundle-runner-contract-smoke.php`
- `grep` search for `wp-codebox|wp_codebox|codebox|sandbox-tool-policy` found only the boundary guard pattern, worktree `.git` pointer, and vendored Agents API tests.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the existing worktree, removing generic-core runtime coupling, updating tests, running verification, and drafting this PR description.
