### PR TITLE
Add generic runtime tool policy schema

### DIFF
--- a/inc/Engine/AI/Tools/HostToolPolicy.php
+++ b/inc/Engine/AI/Tools/HostToolPolicy.php
@@ -15,6 +15,9 @@ defined( 'ABSPATH' ) || exit;
 final class HostToolPolicy {
 
 	private const ENV_POLICY_JSON = 'DATAMACHINE_HOST_TOOL_POLICY_JSON';
+	private const SCHEMA_RUNTIME_TOOL_POLICY = 'datamachine/runtime-tool-policy/v1';
+	// Deprecated transport alias retained for older sandbox hosts.
+	private const SCHEMA_LEGACY_SANDBOX_TOOL_POLICY = 'wp-codebox/sandbox-tool-policy/v1';
 
 	/** @var array<string,mixed> */
 	private array $policy;
@@ -126,6 +129,11 @@ final class HostToolPolicy {
 			return self::normalizePolicy( $unwrapped );
 		}
 
+		$transport_policy = self::normalizeTransportPolicy( $policy );
+		if ( $transport_policy !== $policy ) {
+			return self::normalizePolicy( $transport_policy );
+		}
+
 		$tools = is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array();
 		foreach ( $tools as $tool_name => $rule ) {
 			if ( ! is_string( $tool_name ) || '' === $tool_name || ! is_array( $rule ) ) {
@@ -148,6 +156,53 @@ final class HostToolPolicy {
 		}
 
 		return $has_default || ! empty( $tools ) ? $policy : null;
+	}
+
+	/**
+	 * Normalize runtime transport schemas into the host policy document shape.
+	 *
+	 * @param array<string,mixed> $policy Policy candidate.
+	 * @return array<string,mixed>
+	 */
+	private static function normalizeTransportPolicy( array $policy ): array {
+		$schema = is_string( $policy['schema'] ?? null ) ? (string) $policy['schema'] : '';
+		$supported_schemas = array(
+			self::SCHEMA_RUNTIME_TOOL_POLICY,
+			self::SCHEMA_LEGACY_SANDBOX_TOOL_POLICY,
+		);
+		if ( ! in_array( $schema, $supported_schemas, true ) ) {
+			return $policy;
+		}
+
+		$tools = is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array();
+		if ( empty( $tools ) || ! array_is_list( $tools ) ) {
+			return $policy;
+		}
+
+		$normalized_tools = array();
+		foreach ( $tools as $tool ) {
+			if ( ! is_array( $tool ) ) {
+				continue;
+			}
+
+			$tool_name = is_string( $tool['name'] ?? null )
+				? (string) $tool['name']
+				: ( is_string( $tool['id'] ?? null ) ? (string) $tool['id'] : '' );
+			$tool_name = trim( $tool_name );
+			if ( '' === $tool_name ) {
+				continue;
+			}
+
+			$rule = array();
+			if ( is_string( $tool['execution_location'] ?? null ) ) {
+				$rule['execution_location'] = (string) $tool['execution_location'];
+			}
+
+			$normalized_tools[ $tool_name ] = $rule;
+		}
+
+		$policy['tools'] = $normalized_tools;
+		return $policy;
 	}
 
 	/**

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -584,7 +584,57 @@ $resolution     = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )-
 assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'wrapped policy delegates explicit control-plane tool', $failures, $passes );
 assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'wrapped policy leaves runner-default tool local', $failures, $passes );
 
-echo "\n[14] host tool policy ignores list-shaped transport payloads:\n";
+echo "\n[14] host tool policy accepts generic list-shaped runtime policy payloads:\n";
+$transport_policy = array(
+	'schema'           => 'datamachine/runtime-tool-policy/v1',
+	'default_location' => 'runner',
+	'tools'            => array(
+		array(
+			'name'               => 'alpha_tool',
+			'execution_location' => 'control_plane',
+		),
+	),
+);
+$resolution       = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->resolve(
+	array(
+		'mode'                => ToolPolicyResolver::MODE_PIPELINE,
+		'pipeline_step_id'    => 'ephemeral_pipeline_0',
+		'engine_data'         => array(),
+		'categories'          => array(),
+		'allow_only_explicit' => true,
+		'allow_only'          => array( 'alpha_tool', 'beta_tool' ),
+		'host_tool_policy'    => $transport_policy,
+	)
+);
+assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'generic runtime policy delegates explicit control-plane tool', $failures, $passes );
+assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'generic runtime policy leaves runner-default tool local', $failures, $passes );
+
+echo "\n[15] host tool policy accepts legacy sandbox runtime policy payloads:\n";
+$legacy_transport_policy = array(
+	'schema'           => 'wp-codebox/sandbox-tool-policy/v1',
+	'default_location' => 'runner',
+	'tools'            => array(
+		array(
+			'id'                 => 'alpha_tool',
+			'execution_location' => 'control_plane',
+		),
+	),
+);
+$resolution              = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->resolve(
+	array(
+		'mode'                => ToolPolicyResolver::MODE_PIPELINE,
+		'pipeline_step_id'    => 'ephemeral_pipeline_0',
+		'engine_data'         => array(),
+		'categories'          => array(),
+		'allow_only_explicit' => true,
+		'allow_only'          => array( 'alpha_tool', 'beta_tool' ),
+		'host_tool_policy'    => $legacy_transport_policy,
+	)
+);
+assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'legacy sandbox policy delegates explicit control-plane tool', $failures, $passes );
+assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'legacy sandbox policy leaves runner-default tool local', $failures, $passes );
+
+echo "\n[16] host tool policy ignores unrecognized list-shaped transport payloads:\n";
 $transport_policy = array(
 	'schema' => 'vendor/tool-policy/v1',
 	'tools'  => array(


### PR DESCRIPTION
## Summary
- Add `datamachine/runtime-tool-policy/v1` as the generic list-shaped runtime tool policy schema.
- Normalize generic runtime policy payloads into the host policy shape before resolver filtering.
- Preserve `wp-codebox/sandbox-tool-policy/v1` as a deprecated legacy transport alias so existing WP Codebox consumers continue to work.

## Tests
- `php tests/pipeline-tool-policy-snapshot-smoke.php`
- `homeboy test data-machine --skip-lint -- tests/Unit/Engine/AI/Tools/ToolPolicyResolverTest.php`
- `php -l inc/Engine/AI/Tools/HostToolPolicy.php`
- `php -l tests/pipeline-tool-policy-snapshot-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Implementation, targeted test updates, verification, and PR preparation.