### PR TITLE
Remove Codebox host tool policy leakage

### DIFF
--- a/inc/Engine/AI/Tools/HostToolPolicy.php
+++ b/inc/Engine/AI/Tools/HostToolPolicy.php
@@ -15,9 +15,7 @@ defined( 'ABSPATH' ) || exit;
 final class HostToolPolicy {
 
 	private const ENV_POLICY_JSON = 'DATAMACHINE_HOST_TOOL_POLICY_JSON';
-	private const SCHEMA_RUNTIME_TOOL_POLICY = 'datamachine/runtime-tool-policy/v1';
-	// Deprecated transport alias retained for older sandbox hosts.
-	private const SCHEMA_LEGACY_SANDBOX_TOOL_POLICY = 'wp-codebox/sandbox-tool-policy/v1';
+	private const SCHEMA_RUNTIME_TOOL_POLICY = 'agents-api/runtime-tool-policy/v1';
 
 	/** @var array<string,mixed> */
 	private array $policy;
@@ -166,11 +164,7 @@ final class HostToolPolicy {
 	 */
 	private static function normalizeTransportPolicy( array $policy ): array {
 		$schema = is_string( $policy['schema'] ?? null ) ? (string) $policy['schema'] : '';
-		$supported_schemas = array(
-			self::SCHEMA_RUNTIME_TOOL_POLICY,
-			self::SCHEMA_LEGACY_SANDBOX_TOOL_POLICY,
-		);
-		if ( ! in_array( $schema, $supported_schemas, true ) ) {
+		if ( self::SCHEMA_RUNTIME_TOOL_POLICY !== $schema ) {
 			return $policy;
 		}
 

--- a/tests/boundary-forbidden-names-smoke.php
+++ b/tests/boundary-forbidden-names-smoke.php
@@ -80,8 +80,9 @@ $forbidden_patterns = array(
 	'homeboy'           => '/homeboy/i',
 );
 
-$violations = array();
-$iterator   = new RecursiveIteratorIterator(
+$violations                = array();
+$production_inc_violations = array();
+$iterator                  = new RecursiveIteratorIterator(
 	new RecursiveCallbackFilterIterator(
 		new RecursiveDirectoryIterator( $root, FilesystemIterator::SKIP_DOTS ),
 		function ( SplFileInfo $file ) use ( $root ): bool {
@@ -111,11 +112,22 @@ foreach ( $iterator as $file ) {
 	foreach ( $forbidden_patterns as $label => $pattern ) {
 		if ( preg_match( $pattern, $contents ) ) {
 			$violations[] = "{$relative_path} contains {$label}";
+			if ( 'codebox' === $label && str_starts_with( $relative_path, 'inc/' ) ) {
+				$production_inc_violations[] = "{$relative_path} contains {$label}";
+			}
 		}
 	}
 }
 
+datamachine_boundary_assert( array() === $production_inc_violations, 'production inc files have no Codebox vocabulary', $failures, $passes );
 datamachine_boundary_assert( array() === $violations, 'first-party source has no downstream runtime names outside explicit harness/generated allowlists', $failures, $passes );
+
+if ( ! empty( $production_inc_violations ) ) {
+	echo "\nProduction inc boundary mentions:\n";
+	foreach ( $production_inc_violations as $violation ) {
+		echo "  - {$violation}\n";
+	}
+}
 
 if ( ! empty( $violations ) ) {
 	echo "\nForbidden boundary mentions:\n";

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -586,7 +586,7 @@ assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'wrapp
 
 echo "\n[14] host tool policy accepts generic list-shaped runtime policy payloads:\n";
 $transport_policy = array(
-	'schema'           => 'datamachine/runtime-tool-policy/v1',
+	'schema'           => 'agents-api/runtime-tool-policy/v1',
 	'default_location' => 'runner',
 	'tools'            => array(
 		array(
@@ -609,18 +609,15 @@ $resolution       = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) 
 assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'generic runtime policy delegates explicit control-plane tool', $failures, $passes );
 assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'generic runtime policy leaves runner-default tool local', $failures, $passes );
 
-echo "\n[15] host tool policy accepts legacy sandbox runtime policy payloads:\n";
-$legacy_transport_policy = array(
-	'schema'           => 'wp-codebox/sandbox-tool-policy/v1',
+echo "\n[15] host tool policy accepts neutral host policy payloads:\n";
+$host_policy = array(
+	'schema'           => 'datamachine/host-tool-policy/v1',
 	'default_location' => 'runner',
 	'tools'            => array(
-		array(
-			'id'                 => 'alpha_tool',
-			'execution_location' => 'control_plane',
-		),
+		'alpha_tool' => array( 'execution_location' => 'control_plane' ),
 	),
 );
-$resolution              = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->resolve(
+$resolution  = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->resolve(
 	array(
 		'mode'                => ToolPolicyResolver::MODE_PIPELINE,
 		'pipeline_step_id'    => 'ephemeral_pipeline_0',
@@ -628,11 +625,11 @@ $resolution              = ( new ToolPolicyResolver( new SnapshotPolicyToolManag
 		'categories'          => array(),
 		'allow_only_explicit' => true,
 		'allow_only'          => array( 'alpha_tool', 'beta_tool' ),
-		'host_tool_policy'    => $legacy_transport_policy,
+		'host_tool_policy'    => $host_policy,
 	)
 );
-assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'legacy sandbox policy delegates explicit control-plane tool', $failures, $passes );
-assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'legacy sandbox policy leaves runner-default tool local', $failures, $passes );
+assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'neutral host policy delegates explicit control-plane tool', $failures, $passes );
+assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'neutral host policy leaves runner-default tool local', $failures, $passes );
 
 echo "\n[16] host tool policy ignores unrecognized list-shaped transport payloads:\n";
 $transport_policy = array(


### PR DESCRIPTION
## Summary
- Replace the host tool policy transport schema recognition with the product-neutral Agents API runtime policy schema.
- Remove the legacy wp-codebox sandbox policy fixture in favor of the neutral Data Machine host policy shape.
- Add an explicit boundary smoke assertion that production inc files contain no Codebox vocabulary.

## Tests
- php tests/pipeline-tool-policy-snapshot-smoke.php
- php tests/boundary-forbidden-names-smoke.php
- php tests/agent-bundle-runner-contract-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the policy boundary cleanup, updating smoke fixtures, running targeted verification, and drafting this PR description.