### PR TITLE
Use neutral host tool policy fixtures

### DIFF
--- a/inc/Engine/AI/Tools/HostToolPolicy.php
+++ b/inc/Engine/AI/Tools/HostToolPolicy.php
@@ -200,7 +200,7 @@ final class HostToolPolicy {
 	}
 
 	/**
-	 * Unwrap host policy documents embedded in broader runtime/sandbox payloads.
+	 * Unwrap host policy documents embedded in broader runtime payloads.
 	 *
 	 * @param array<string,mixed> $policy Policy candidate.
 	 * @return array<string,mixed>

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -117,7 +117,7 @@ datamachine_bundle_runner_contains( $abilities, "'required_artifacts'", 'ability
 datamachine_bundle_runner_contains( $abilities, "'engine_data_outputs'", 'ability input schema accepts semantic output mappings', $failures, $passes );
 datamachine_bundle_runner_contains( $ai_step, "\$payload['tool_recorders']", 'AI step forwards configured tool recorders to the loop', $failures, $passes );
 
-echo "\n[3] Runner exposes semantic outputs without hiding raw engine data\n";
+echo "\n[3] Runner exposes semantic outputs while preserving raw engine data\n";
 require_once $root . '/inc/Core/JobStatus.php';
 require_once $root . '/inc/Core/DataPath.php';
 require_once $root . '/inc/Engine/AI/Tools/HostToolPolicy.php';
@@ -601,7 +601,7 @@ $scheduled_required_response = $response_method->invoke(
 datamachine_bundle_runner_assert( true === ( $scheduled_required_response['success'] ?? null ), 'required outputs do not fail an async scheduled run before completion', $failures, $passes );
 datamachine_bundle_runner_assert( array( 'future_result_url' ) === ( $scheduled_required_response['output_diagnostics']['missing_outputs'] ?? null ), 'async scheduled run still exposes missing output diagnostics', $failures, $passes );
 
-echo "\n[4] WP-CLI wraps the same ability instead of duplicating runner internals\n";
+echo "\n[4] WP-CLI wraps the same ability through the shared runner path\n";
 foreach ( array(
 	'@subcommand run-bundle'       => 'run-bundle subcommand declared',
 	'AgentAbilities::runAgentBundle' => 'CLI calls ability callback',
@@ -633,9 +633,9 @@ foreach ( array(
 	datamachine_bundle_runner_contains( $abilities . $runner . $ai_step, $needle, $label, $failures, $passes );
 }
 
-echo "\n[6] Boundary stays generic\n";
-foreach ( array( 'DataMachine\\Core\\Database\\Agents', 'DataMachine\\Core\\Database\\Flows', 'DataMachine\\Core\\Database\\Pipelines' ) as $forbidden ) {
-	datamachine_bundle_runner_assert( false === strpos( $runner, $forbidden ), "runtime runner does not require caller-facing {$forbidden}", $failures, $passes );
+echo "\n[6] Runner stays host-neutral\n";
+foreach ( array( 'DataMachine\\Core\\Database\\Agents', 'DataMachine\\Core\\Database\\Flows', 'DataMachine\\Core\\Database\\Pipelines' ) as $runner_dependency ) {
+	datamachine_bundle_runner_assert( false === strpos( $runner, $runner_dependency ), "runtime runner uses shared ability access instead of {$runner_dependency}", $failures, $passes );
 }
 
 if ( $failures ) {

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -301,7 +301,7 @@ $previous_host_policy = getenv( 'DATAMACHINE_HOST_TOOL_POLICY_JSON' );
 putenv(
 	'DATAMACHINE_HOST_TOOL_POLICY_JSON=' . json_encode(
 		array(
-			'schema'           => 'homeboy/agent-tool-policy/v1',
+			'schema'           => 'generic/host-tool-policy/v1',
 			'default_location' => 'runner',
 			'tools'            => array(
 				'workspace_grep' => array( 'execution_location' => 'control_plane' ),

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -544,7 +544,7 @@ $resolution = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->res
 		'allow_only_explicit' => true,
 		'allow_only'          => array( 'alpha_tool', 'beta_tool' ),
 		'host_tool_policy'    => array(
-			'schema'           => 'homeboy/agent-tool-policy/v1',
+			'schema'           => 'generic/host-tool-policy/v1',
 			'default_location' => 'runner',
 			'tools'            => array(
 				'alpha_tool' => array( 'execution_location' => 'control_plane' ),
@@ -562,7 +562,7 @@ $wrapped_policy = array(
 	'apply' => 'propose_only',
 	'read'  => 'workspace',
 	'tools' => array(
-		'schema'           => 'homeboy/agent-tool-policy/v1',
+		'schema'           => 'generic/host-tool-policy/v1',
 		'default_location' => 'runner',
 		'tools'            => array(
 			'alpha_tool' => array( 'execution_location' => 'control_plane' ),

--- a/tests/runtime-vocabulary-smoke.php
+++ b/tests/runtime-vocabulary-smoke.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Smoke test for Data Machine boundary vocabulary.
+ * Smoke test for host-neutral runtime vocabulary.
  *
- * Run with: php tests/boundary-forbidden-names-smoke.php
+ * Run with: php tests/runtime-vocabulary-smoke.php
  *
  * @package DataMachine\Tests
  */
@@ -11,9 +11,9 @@ $root     = dirname( __DIR__ );
 $failures = array();
 $passes   = 0;
 
-echo "boundary-forbidden-names-smoke\n";
+echo "runtime-vocabulary-smoke\n";
 
-function datamachine_boundary_assert( bool $condition, string $label, array &$failures, int &$passes ): void {
+function datamachine_runtime_vocab_assert( bool $condition, string $label, array &$failures, int &$passes ): void {
 	if ( $condition ) {
 		++$passes;
 		echo "  PASS {$label}\n";
@@ -24,12 +24,12 @@ function datamachine_boundary_assert( bool $condition, string $label, array &$fa
 	echo "  FAIL {$label}\n";
 }
 
-function datamachine_boundary_relative_path( string $root, string $path ): string {
+function datamachine_runtime_vocab_relative_path( string $root, string $path ): string {
 	$relative = substr( $path, strlen( $root ) + 1 );
 	return str_replace( DIRECTORY_SEPARATOR, '/', false === $relative ? $path : $relative );
 }
 
-function datamachine_boundary_is_excluded_dir( string $relative_path ): bool {
+function datamachine_runtime_vocab_is_excluded_dir( string $relative_path ): bool {
 	$excluded_roots = array(
 		'.git',
 		'.datamachine',
@@ -50,7 +50,7 @@ function datamachine_boundary_is_excluded_dir( string $relative_path ): bool {
 	return false;
 }
 
-function datamachine_boundary_is_allowed_file( string $relative_path ): bool {
+function datamachine_runtime_vocab_is_allowed_file( string $relative_path ): bool {
 	if ( '.git' === $relative_path ) {
 		return true;
 	}
@@ -73,7 +73,7 @@ function datamachine_boundary_is_allowed_file( string $relative_path ): bool {
 	return str_starts_with( $relative_path, '.github/workflows/' ) || str_starts_with( $relative_path, 'tests/' );
 }
 
-$forbidden_patterns = array(
+$host_specific_patterns = array(
 	'wp-site-generator' => '/wp-site-generator/i',
 	'wpsg'              => '/\bwpsg\b/i',
 	'codebox'           => '/(?:wp[-_ ]?)?codebox/i',
@@ -81,13 +81,13 @@ $forbidden_patterns = array(
 );
 
 $violations                = array();
-$production_inc_violations = array();
+$runtime_source_violations = array();
 $iterator                  = new RecursiveIteratorIterator(
 	new RecursiveCallbackFilterIterator(
 		new RecursiveDirectoryIterator( $root, FilesystemIterator::SKIP_DOTS ),
 		function ( SplFileInfo $file ) use ( $root ): bool {
-			$relative_path = datamachine_boundary_relative_path( $root, $file->getPathname() );
-			return ! $file->isDir() || ! datamachine_boundary_is_excluded_dir( $relative_path );
+			$relative_path = datamachine_runtime_vocab_relative_path( $root, $file->getPathname() );
+			return ! $file->isDir() || ! datamachine_runtime_vocab_is_excluded_dir( $relative_path );
 		}
 	)
 );
@@ -98,9 +98,9 @@ foreach ( $iterator as $file ) {
 	}
 
 	$path          = $file->getPathname();
-	$relative_path = datamachine_boundary_relative_path( $root, $path );
+	$relative_path = datamachine_runtime_vocab_relative_path( $root, $path );
 
-	if ( __FILE__ === $path || datamachine_boundary_is_allowed_file( $relative_path ) ) {
+	if ( __FILE__ === $path || datamachine_runtime_vocab_is_allowed_file( $relative_path ) ) {
 		continue;
 	}
 
@@ -109,36 +109,36 @@ foreach ( $iterator as $file ) {
 		continue;
 	}
 
-	foreach ( $forbidden_patterns as $label => $pattern ) {
+	foreach ( $host_specific_patterns as $label => $pattern ) {
 		if ( preg_match( $pattern, $contents ) ) {
 			$violations[] = "{$relative_path} contains {$label}";
 			if ( 'codebox' === $label && str_starts_with( $relative_path, 'inc/' ) ) {
-				$production_inc_violations[] = "{$relative_path} contains {$label}";
+				$runtime_source_violations[] = "{$relative_path} contains {$label}";
 			}
 		}
 	}
 }
 
-datamachine_boundary_assert( array() === $production_inc_violations, 'production inc files have no Codebox vocabulary', $failures, $passes );
-datamachine_boundary_assert( array() === $violations, 'first-party source has no downstream runtime names outside explicit harness/generated allowlists', $failures, $passes );
+datamachine_runtime_vocab_assert( array() === $runtime_source_violations, 'runtime source uses host-neutral vocabulary', $failures, $passes );
+datamachine_runtime_vocab_assert( array() === $violations, 'first-party source uses host-neutral vocabulary outside explicit harness/generated allowlists', $failures, $passes );
 
-if ( ! empty( $production_inc_violations ) ) {
-	echo "\nProduction inc boundary mentions:\n";
-	foreach ( $production_inc_violations as $violation ) {
+if ( ! empty( $runtime_source_violations ) ) {
+	echo "\nRuntime source host-specific mentions:\n";
+	foreach ( $runtime_source_violations as $violation ) {
 		echo "  - {$violation}\n";
 	}
 }
 
 if ( ! empty( $violations ) ) {
-	echo "\nForbidden boundary mentions:\n";
+	echo "\nHost-specific mentions:\n";
 	foreach ( $violations as $violation ) {
 		echo "  - {$violation}\n";
 	}
 }
 
 if ( ! empty( $failures ) ) {
-	echo "\nBoundary forbidden names smoke failed (" . count( $failures ) . " failure(s)).\n";
+	echo "\nRuntime vocabulary smoke failed (" . count( $failures ) . " failure(s)).\n";
 	exit( 1 );
 }
 
-echo "\nBoundary forbidden names smoke passed ({$passes} assertions).\n";
+echo "\nRuntime vocabulary smoke passed ({$passes} assertions).\n";


### PR DESCRIPTION
## Summary
- Replace downstream product-specific host tool policy fixture schemas with neutral generic schemas.
- Keep the runtime host policy documentation generic while preserving generic runtime/host policy support.
- Preserve boundary coverage that rejects downstream runtime product names from production code.

## Tests
- php tests/pipeline-tool-policy-snapshot-smoke.php
- php tests/boundary-forbidden-names-smoke.php
- php tests/agent-bundle-runner-contract-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code inspection, fixture cleanup, focused test execution, commit and PR preparation.