### PR TITLE
Add neutral sandbox tool policy contract

### DIFF
--- a/inc/Engine/AI/Tools/HostToolPolicy.php
+++ b/inc/Engine/AI/Tools/HostToolPolicy.php
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
 final class HostToolPolicy {
 
 	private const ENV_POLICY_JSON = 'DATAMACHINE_HOST_TOOL_POLICY_JSON';
+	private const SCHEMA_SANDBOX_TOOL_POLICY = 'datamachine/sandbox-tool-policy/v1';
 	private const SCHEMA_RUNTIME_TOOL_POLICY = 'agents-api/runtime-tool-policy/v1';
 
 	/** @var array<string,mixed> */
@@ -163,8 +164,8 @@ final class HostToolPolicy {
 	 * @return array<string,mixed>
 	 */
 	private static function normalizeTransportPolicy( array $policy ): array {
-		$schema = is_string( $policy['schema'] ?? null ) ? (string) $policy['schema'] : '';
-		if ( self::SCHEMA_RUNTIME_TOOL_POLICY !== $schema ) {
+		$schema = is_string( $policy['schema'] ?? null ) ? trim( (string) $policy['schema'] ) : '';
+		if ( '' === $schema || ! in_array( $schema, self::transportPolicySchemas(), true ) ) {
 			return $policy;
 		}
 
@@ -197,6 +198,35 @@ final class HostToolPolicy {
 
 		$policy['tools'] = $normalized_tools;
 		return $policy;
+	}
+
+	/**
+	 * Return list-shaped transport schemas that can be normalized into host policy.
+	 *
+	 * @return array<int,string>
+	 */
+	private static function transportPolicySchemas(): array {
+		$schemas = array(
+			self::SCHEMA_SANDBOX_TOOL_POLICY,
+			self::SCHEMA_RUNTIME_TOOL_POLICY,
+		);
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$schemas = apply_filters( 'datamachine_host_tool_policy_transport_schemas', $schemas );
+		}
+
+		if ( ! is_array( $schemas ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $schemas as $schema ) {
+			if ( is_string( $schema ) && '' !== trim( $schema ) ) {
+				$normalized[] = trim( $schema );
+			}
+		}
+
+		return array_values( array_unique( $normalized ) );
 	}
 
 	/**

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -34,6 +34,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! function_exists( 'apply_filters' ) ) {
 	function apply_filters( string $hook, $value, ...$args ) {
+		global $datamachine_pipeline_policy_filters;
+		if ( is_array( $datamachine_pipeline_policy_filters[ $hook ] ?? null ) ) {
+			foreach ( $datamachine_pipeline_policy_filters[ $hook ] as $callback ) {
+				$value = $callback( $value, ...$args );
+			}
+			return $value;
+		}
+
 		if ( 'datamachine_step_types' === $hook ) {
 			return array(
 				'ai'      => array( 'uses_handler' => false, 'multi_handler' => false ),
@@ -584,7 +592,32 @@ $resolution     = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )-
 assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'wrapped policy delegates explicit control-plane tool', $failures, $passes );
 assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'wrapped policy leaves runner-default tool local', $failures, $passes );
 
-echo "\n[14] host tool policy accepts generic list-shaped runtime policy payloads:\n";
+echo "\n[14] host tool policy accepts neutral list-shaped sandbox policy payloads:\n";
+$transport_policy = array(
+	'schema'           => 'datamachine/sandbox-tool-policy/v1',
+	'default_location' => 'runner',
+	'tools'            => array(
+		array(
+			'name'               => 'alpha_tool',
+			'execution_location' => 'control_plane',
+		),
+	),
+);
+$resolution       = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->resolve(
+	array(
+		'mode'                => ToolPolicyResolver::MODE_PIPELINE,
+		'pipeline_step_id'    => 'ephemeral_pipeline_0',
+		'engine_data'         => array(),
+		'categories'          => array(),
+		'allow_only_explicit' => true,
+		'allow_only'          => array( 'alpha_tool', 'beta_tool' ),
+		'host_tool_policy'    => $transport_policy,
+	)
+);
+assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'neutral sandbox policy delegates explicit control-plane tool', $failures, $passes );
+assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'neutral sandbox policy leaves runner-default tool local', $failures, $passes );
+
+echo "\n[14b] host tool policy accepts generic list-shaped runtime policy payloads:\n";
 $transport_policy = array(
 	'schema'           => 'agents-api/runtime-tool-policy/v1',
 	'default_location' => 'runner',
@@ -631,7 +664,38 @@ $resolution  = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->re
 assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'neutral host policy delegates explicit control-plane tool', $failures, $passes );
 assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'neutral host policy leaves runner-default tool local', $failures, $passes );
 
-echo "\n[16] host tool policy ignores unrecognized list-shaped transport payloads:\n";
+echo "\n[16] host tool policy accepts filter-registered list-shaped transport payloads:\n";
+$datamachine_pipeline_policy_filters['datamachine_host_tool_policy_transport_schemas'] = array(
+	static function ( array $schemas ): array {
+		$schemas[] = 'vendor/tool-policy/v1';
+		return $schemas;
+	},
+);
+$transport_policy = array(
+	'schema' => 'vendor/tool-policy/v1',
+	'tools'  => array(
+		array(
+			'id'                 => 'alpha_tool',
+			'execution_location' => 'control_plane',
+		),
+	),
+);
+$resolution       = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->resolve(
+	array(
+		'mode'                => ToolPolicyResolver::MODE_PIPELINE,
+		'pipeline_step_id'    => 'ephemeral_pipeline_0',
+		'engine_data'         => array(),
+		'categories'          => array(),
+		'allow_only_explicit' => true,
+		'allow_only'          => array( 'alpha_tool', 'beta_tool' ),
+		'host_tool_policy'    => $transport_policy,
+	)
+);
+unset( $datamachine_pipeline_policy_filters['datamachine_host_tool_policy_transport_schemas'] );
+assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'filter-registered transport policy delegates explicit control-plane tool', $failures, $passes );
+assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'filter-registered transport policy does not affect unrelated tools', $failures, $passes );
+
+echo "\n[17] host tool policy ignores unrecognized list-shaped transport payloads:\n";
 $transport_policy = array(
 	'schema' => 'vendor/tool-policy/v1',
 	'tools'  => array(
@@ -654,6 +718,10 @@ $resolution       = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) 
 );
 assert_policy_equals( null, $resolution['alpha_tool']['executor'] ?? null, 'list-shaped transport policy is not converted into host policy', $failures, $passes );
 assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'list-shaped transport policy does not affect unrelated tools', $failures, $passes );
+
+echo "\n[18] production host policy code has no Codebox sandbox schema special-case:\n";
+$host_policy_source = file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/HostToolPolicy.php' ) ?: '';
+assert_policy_equals( false, str_contains( $host_policy_source, 'wp-codebox/sandbox-tool-policy/v1' ), 'HostToolPolicy does not name the Codebox sandbox schema', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " pipeline policy assertions failed.\n";

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -55,6 +55,32 @@ if ( ! function_exists( 'apply_filters' ) ) {
 	}
 }
 
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback ): bool {
+		global $datamachine_pipeline_policy_filters;
+		$datamachine_pipeline_policy_filters[ $hook ][] = $callback;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'remove_filter' ) ) {
+	function remove_filter( string $hook, callable $callback ): bool {
+		global $datamachine_pipeline_policy_filters;
+		if ( ! is_array( $datamachine_pipeline_policy_filters[ $hook ] ?? null ) ) {
+			return false;
+		}
+
+		foreach ( $datamachine_pipeline_policy_filters[ $hook ] as $index => $registered_callback ) {
+			if ( $registered_callback === $callback ) {
+				unset( $datamachine_pipeline_policy_filters[ $hook ][ $index ] );
+				return true;
+			}
+		}
+
+		return false;
+	}
+}
+
 if ( ! function_exists( 'do_action' ) ) {
 	function do_action( string $hook, ...$args ): void {
 		// no-op for tests.
@@ -665,12 +691,11 @@ assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, '
 assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'neutral host policy leaves runner-default tool local', $failures, $passes );
 
 echo "\n[16] host tool policy accepts filter-registered list-shaped transport payloads:\n";
-$datamachine_pipeline_policy_filters['datamachine_host_tool_policy_transport_schemas'] = array(
-	static function ( array $schemas ): array {
-		$schemas[] = 'vendor/tool-policy/v1';
-		return $schemas;
-	},
-);
+$transport_schema_filter = static function ( array $schemas ): array {
+	$schemas[] = 'vendor/tool-policy/v1';
+	return $schemas;
+};
+add_filter( 'datamachine_host_tool_policy_transport_schemas', $transport_schema_filter );
 $transport_policy = array(
 	'schema' => 'vendor/tool-policy/v1',
 	'tools'  => array(
@@ -691,7 +716,7 @@ $resolution       = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) 
 		'host_tool_policy'    => $transport_policy,
 	)
 );
-unset( $datamachine_pipeline_policy_filters['datamachine_host_tool_policy_transport_schemas'] );
+remove_filter( 'datamachine_host_tool_policy_transport_schemas', $transport_schema_filter );
 assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'filter-registered transport policy delegates explicit control-plane tool', $failures, $passes );
 assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'filter-registered transport policy does not affect unrelated tools', $failures, $passes );
 


### PR DESCRIPTION
## Summary
- Add a neutral datamachine/sandbox-tool-policy/v1 list-shaped transport contract for host tool policies.
- Add datamachine_host_tool_policy_transport_schemas so external hosts can register compatible transport schemas without Data Machine core naming product-specific schemas.
- Update the pipeline policy smoke test to cover neutral sandbox policy, filter-registered transports, generic runtime compatibility, and absence of the old Codebox sandbox schema in production policy code.

## Tests
- php tests/pipeline-tool-policy-snapshot-smoke.php
- php tests/runtime-vocabulary-smoke.php
- php tests/agent-bundle-runner-contract-smoke.php
- php -l inc/Engine/AI/Tools/HostToolPolicy.php && php -l tests/pipeline-tool-policy-snapshot-smoke.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Scoped implementation, targeted test updates, local verification, and PR drafting.