### PR TITLE
Neutralize Agents API runtime fixture vocabulary

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -794,12 +794,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "995e94571dc26ffd3d0fe3eda95ddf25ff1fe215"
+                "reference": "7be8fc3e2c6736c553d61c0578f295b4fe565cf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/995e94571dc26ffd3d0fe3eda95ddf25ff1fe215",
-                "reference": "995e94571dc26ffd3d0fe3eda95ddf25ff1fe215",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/7be8fc3e2c6736c553d61c0578f295b4fe565cf1",
+                "reference": "7be8fc3e2c6736c553d61c0578f295b4fe565cf1",
                 "shasum": ""
             },
             "require": {
@@ -918,7 +918,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-06-08T03:16:09+00:00"
+            "time": "2026-06-21T22:54:32+00:00"
         }
     ],
     "packages-dev": [

--- a/tests/runtime-vocabulary-smoke.php
+++ b/tests/runtime-vocabulary-smoke.php
@@ -30,6 +30,10 @@ function datamachine_runtime_vocab_relative_path( string $root, string $path ): 
 }
 
 function datamachine_runtime_vocab_is_excluded_dir( string $relative_path ): bool {
+	if ( 'vendor/wordpress/agents-api/tests' === $relative_path || str_starts_with( $relative_path, 'vendor/wordpress/agents-api/tests/' ) ) {
+		return false;
+	}
+
 	$excluded_roots = array(
 		'.git',
 		'.datamachine',
@@ -69,8 +73,8 @@ function datamachine_runtime_vocab_is_allowed_file( string $relative_path ): boo
 		return true;
 	}
 
-	// CI workflow files and tests are source-control harness config, not runtime logic.
-	return str_starts_with( $relative_path, '.github/workflows/' ) || str_starts_with( $relative_path, 'tests/' );
+	// CI workflow files are source-control harness config, not runtime logic.
+	return str_starts_with( $relative_path, '.github/workflows/' );
 }
 
 $host_specific_patterns = array(


### PR DESCRIPTION
## Summary
- Pin the vendored Agents API dependency to the upstream commit that replaces product-bound runtime fixture examples with neutral runtime names.
- Tighten the runtime vocabulary smoke so first-party tests and vendored Agents API test fixtures are covered instead of broadly allowlisting tests.

## Tests
- `php tests/runtime-vocabulary-smoke.php`
- `php vendor/wordpress/agents-api/tests/agents-chat-ability-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Updating dependency/test vocabulary guardrails, running focused smoke tests, drafting this PR.