### PR TITLE
fix(daily-memory): let an over-budget MEMORY.md make compaction progress instead of failing every day

### DIFF
--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -621,19 +621,68 @@ class DailyMemoryTask extends SystemTask {
 
 			$persistent_size = strlen( (string) $parsed['persistent'] );
 			$original_size   = strlen( $original_content );
-			if ( $original_size > AgentMemory::MAX_FILE_SIZE && $persistent_size > AgentMemory::MAX_FILE_SIZE ) {
+
+			// Overflow-aware acceptance target for the persistent section.
+			//
+			// When MEMORY.md is already far over MAX_FILE_SIZE, demanding the
+			// persistent section drop to MAX_FILE_SIZE in a single bounded
+			// conversation (default 3 turns) is frequently unsatisfiable: the
+			// model can rarely thread a clean, non-duplicating, conservation-
+			// passing partition that also lands under budget in one pass, so
+			// the loop exhausts its turns and the job fails every day, freezing
+			// the agent's memory (issue #2775).
+			//
+			// Instead of failing closed forever, accept a split that makes
+			// meaningful FORWARD PROGRESS toward budget. The acceptance ceiling
+			// scales with how far over budget the file is, mirroring the
+			// deterministic-overflow `oversize_factor` precedent below: a file
+			// that is N* over budget need only shrink to a fraction of its
+			// original size this pass, and subsequent daily runs compound the
+			// progress until it converges on MAX_FILE_SIZE. Near-budget files
+			// keep the strict MAX_FILE_SIZE target, so their fail-closed
+			// protection is unchanged.
+			$max_size            = AgentMemory::MAX_FILE_SIZE;
+			$oversize_factor     = $original_size / max( $max_size, 1 );
+			$acceptable_max_size = $max_size;
+			if ( $oversize_factor > 1 ) {
+				// Require the persistent section to drop to at most this
+				// fraction of the original size this pass. The fraction
+				// tightens as the file approaches budget (it can never exceed
+				// the strict target once within ~1x), guaranteeing strict
+				// per-run progress while remaining reachable for a far-over
+				// file. Floored at MAX_FILE_SIZE so the target never relaxes
+				// below budget.
+				$progress_ratio = (float) apply_filters(
+					'datamachine_daily_memory_overflow_progress_ratio',
+					0.75,
+					array(
+						'date'            => $date,
+						'job_id'          => $jobId,
+						'original_size'   => $original_size,
+						'persistent_size' => $persistent_size,
+						'oversize_factor' => $oversize_factor,
+						'max_size'        => $max_size,
+					)
+				);
+				$progress_ratio      = min( 1.0, max( 0.0, $progress_ratio ) );
+				$acceptable_max_size = max( $max_size, (int) floor( $original_size * $progress_ratio ) );
+			}
+
+			if ( $persistent_size > $acceptable_max_size ) {
 				return WP_Agent_Conversation_Completion_Decision::incomplete(
 					'Daily memory completion policy: persistent memory remains oversized.',
 					array(
 						'turn_count'           => $turn_count,
 						'original_size'        => $original_size,
 						'persistent_size'      => $persistent_size,
-						'max_size'             => AgentMemory::MAX_FILE_SIZE,
+						'max_size'             => $max_size,
+						'acceptable_max_size'  => $acceptable_max_size,
 						'continuation_message' => sprintf(
-							'The `===PERSISTENT===` section is still %s, above the target %s. Return a corrected full split. Keep durable facts, archive session-specific detail, condense overlapping entries, and ensure `===PERSISTENT===` is at or below %s without discarding information.',
+							'The `===PERSISTENT===` section is still %s. For this pass it must be at or below %s (the file is far over the %s budget, so it should shrink toward budget now and converge over subsequent runs). Return a corrected full split. Keep durable facts, archive session-specific detail, condense overlapping entries, and shrink `===PERSISTENT===` to at or below %s without discarding information.',
 							size_format( $persistent_size ),
-							size_format( AgentMemory::MAX_FILE_SIZE ),
-							size_format( AgentMemory::MAX_FILE_SIZE )
+							size_format( $acceptable_max_size ),
+							size_format( $max_size ),
+							size_format( $acceptable_max_size )
 						),
 					)
 				);


### PR DESCRIPTION
Fixes #2775

## Which gate actually fires (confirmed from job data)

Per the issue's code-read-correction comment, I investigated **which** of two gates fires before touching anything.

**Confirmed: gate #1 — the AI-conversation completion policy** (`DailyMemoryTask.php` line 198, `failJob(... 'Daily memory completion policy was not satisfied. MEMORY.md unchanged.')`).

Evidence from prod `c8c_datamachine_jobs` (read-only query):

| job_id | created_at | status |
|--------|-----------|--------|
| 4921 | 2026-06-22 | `failed: Daily memory completion policy was not satisfied. MEMORY.md unchanged.` |
| 4911 | 2026-06-22 | `failed: Daily memory completion policy was not satisfied. MEMORY.md unchanged.` |
| 4807, 4799, 4797 | 2026-06-21 | same |
| 4687, 4679, 4677 | 2026-06-20 | same |
| ... 06-17 → 06-22 | | same string every day |
| 4232, 3817, 3767, 3717, 3665 | 2026-06-09 → 06-16 | `failed: Conservation check failed -- AI emitted a lossy split.` (gate #2, the **earlier** mode) |

So the failure migrated from gate #2 (conservation) to gate #1 (completion policy) around 06-17, and gate #1 is the one freezing memory now. `engine_data` for job 4921 records the terminal status but not the raw AI output (not persisted), so the gate identity comes from the failure string, which maps unambiguously to line 198.

`maybeHandleDeterministicOverflow()` does NOT catch this case: its threshold is `MAX_FILE_SIZE * 4 = 32,768` bytes. extra-chill-bot's MEMORY.md is **27,735 bytes (3.4×, just under 4×)**, so it falls through to the AI-completion path and deadlocks — exactly the "over budget but no escape hatch" gap the issue describes.

## Root cause of gate #1

The completion-policy validator (`buildCleanupCompletionPolicy`, line ~575) returns `complete` only if, in the bounded conversation (default 3 turns), the model produces a split where ALL hold:
1. persistent section parses,
2. `planMemoryCompaction` passes (conservation ≥ 85% **and** combined ≤ 115%, i.e. no duplication),
3. **`persistent_size <= MAX_FILE_SIZE` (8,192)** when the original is oversized (old line 624).

For a 27,735-byte file, requirement #3 demands a one-shot drop to ≤8 KB while requirement #2 forbids dropping content or duplicating it. The model can't reliably thread that needle in 3 turns, every turn returns `incomplete`, the loop exhausts its turns, `metadata.completed` stays false, and the job fails — **every day, forever**.

## The fix (smallest correct one)

Make gate #1's persistent-size acceptance **overflow-aware**, mirroring the existing `oversize_factor` precedent at line ~246. Instead of requiring `persistent ≤ MAX_FILE_SIZE` in a single pass, require **forward progress toward budget**: the acceptance ceiling scales with how far over budget the file is, then tightens each run until it converges on `MAX_FILE_SIZE`.

- `acceptable_max_size = max(MAX_FILE_SIZE, floor(original_size * progress_ratio))`, `progress_ratio` default **0.75**, filterable via `datamachine_daily_memory_overflow_progress_ratio`.
- For a file ≤ `MAX_FILE_SIZE` (near-budget), `oversize_factor <= 1`, so the strict `MAX_FILE_SIZE` target is unchanged — **near-budget files still fail closed**.
- The conservation gate (#2, ≥85% / ≤115%) is untouched, so genuinely lossy or duplicating splits are still rejected.

## On-paper acceptance trace (27,735-byte file, 8,192 target)

Per-run acceptable persistent ceiling = `max(8192, floor(size * 0.75))`:

| run | start size | acceptable ceiling | result |
|-----|-----------|--------------------|--------|
| 1 | 27,735 | 20,801 | shrinks toward budget |
| 2 | 20,801 | 15,600 | progress |
| 3 | 15,600 | 11,700 | progress |
| 4 | 11,700 | 8,775 | progress |
| 5 | 8,775 | 8,192 (floor) | converged to budget |

So a 3.4× file makes strict forward progress every run and converges on budget in ~5 daily runs instead of failing forever. At run 1 with persistent ≈ 20,801 and original 27,735, the conservation window for `archived` is `[2,774, 11,094]` (≥85% / ≤115%) — satisfiable, so gates #1 and #2 do not collide.

**Near-budget fail-closed preserved:** for `original_size = 8,000` (under `MAX_FILE_SIZE`), `oversize_factor <= 1`, the relaxation branch is skipped, and `acceptable_max_size = MAX_FILE_SIZE`. A lossy split still trips the conservation gate; an oversized persistent still trips the strict cap. Behavior unchanged for the case the gate was designed to protect.

## Verification

- `php -l` clean.
- `vendor/bin/phpcs inc/Engine/AI/System/Tasks/DailyMemoryTask.php` → **0 findings, exit 0** (the data-machine lint gate fails on warnings too; verified zero).
- Reasoned acceptance on paper (above) for the 27.7 KB case + near-budget fail-closed confirmation.

## Operational note

As the issue states, extra-chill-bot's MEMORY.md still needs a one-time manual compaction to get back under budget faster than the ~5-run convergence — but with this fix it now makes progress every day instead of being frozen.