### PR TITLE
style(daily-memory): fix assignment alignment warning from #2776

### DIFF
--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -652,7 +652,7 @@ class DailyMemoryTask extends SystemTask {
 				// per-run progress while remaining reachable for a far-over
 				// file. Floored at MAX_FILE_SIZE so the target never relaxes
 				// below budget.
-				$progress_ratio = (float) apply_filters(
+				$progress_ratio      = (float) apply_filters(
 					'datamachine_daily_memory_overflow_progress_ratio',
 					0.75,
 					array(


### PR DESCRIPTION
One-line phpcbf alignment fix on the overflow progress-ratio filter added in #2776. data-machine's lint gate fails on warnings, so this clears it. No behavior change.