### PR TITLE
Fix tracked items table bootstrap on SQLite

### DIFF
--- a/inc/Core/Database/Agents/AgentAccess.php
+++ b/inc/Core/Database/Agents/AgentAccess.php
@@ -74,7 +74,9 @@ class AgentAccess extends BaseRepository {
 		) {$charset_collate};";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-		dbDelta( $sql );
+		if ( ! self::is_sqlite() || ! self::database_table_exists( $table_name, $wpdb ) ) {
+			dbDelta( $sql );
+		}
 
 		$principal_table_name = $wpdb->base_prefix . self::PRINCIPAL_TABLE_NAME;
 		$principal_sql        = "CREATE TABLE {$principal_table_name} (
@@ -91,7 +93,9 @@ class AgentAccess extends BaseRepository {
 			KEY role (role)
 		) {$charset_collate};";
 
-		dbDelta( $principal_sql );
+		if ( ! self::is_sqlite() || ! self::database_table_exists( $principal_table_name, $wpdb ) ) {
+			dbDelta( $principal_sql );
+		}
 	}
 
 	/**

--- a/inc/Core/Database/Agents/AgentTokens.php
+++ b/inc/Core/Database/Agents/AgentTokens.php
@@ -54,6 +54,10 @@ class AgentTokens extends BaseRepository implements \WP_Agent_Token_Store {
 		$table_name      = $wpdb->base_prefix . self::TABLE_NAME;
 		$charset_collate = $wpdb->get_charset_collate();
 
+		if ( self::is_sqlite() && self::database_table_exists( $table_name, $wpdb ) ) {
+			return;
+		}
+
 		$sql = "CREATE TABLE {$table_name} (
 			token_id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
 			agent_id BIGINT(20) UNSIGNED NOT NULL,

--- a/inc/Core/Database/Agents/Agents.php
+++ b/inc/Core/Database/Agents/Agents.php
@@ -46,6 +46,10 @@ class Agents extends BaseRepository {
 		$table_name      = $wpdb->base_prefix . self::TABLE_NAME;
 		$charset_collate = $wpdb->get_charset_collate();
 
+		if ( self::is_sqlite() && self::database_table_exists( $table_name, $wpdb ) ) {
+			return;
+		}
+
 		$sql = "CREATE TABLE {$table_name} (
 			agent_id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
 			agent_slug VARCHAR(200) NOT NULL,

--- a/inc/Core/Database/BaseRepository.php
+++ b/inc/Core/Database/BaseRepository.php
@@ -176,6 +176,39 @@ abstract class BaseRepository {
 	}
 
 	/**
+	 * Check whether a table exists.
+	 *
+	 * Uses SQLite's native schema table on Studio/SQLite and SHOW TABLES on MySQL.
+	 *
+	 * @since 0.149.1
+	 *
+	 * @param string     $table_name Fully-qualified table name.
+	 * @param \wpdb|null $wpdb       Optional wpdb instance (defaults to global).
+	 * @return bool
+	 */
+	public static function table_exists( string $table_name, ?\wpdb $wpdb = null ): bool {
+		if ( null === $wpdb ) {
+			global $wpdb;
+		}
+
+		if ( self::is_sqlite() ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result = $wpdb->get_var(
+				$wpdb->prepare( "SELECT name FROM sqlite_master WHERE type = 'table' AND name = %s", $table_name )
+			);
+
+			return $table_name === $result;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->get_var(
+			$wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name )
+		);
+
+		return $table_name === $result;
+	}
+
+	/**
 	 * Get column metadata from information_schema (MySQL only).
 	 *
 	 * Returns an object-keyed result set with DATA_TYPE,

--- a/inc/Core/Database/BaseRepository.php
+++ b/inc/Core/Database/BaseRepository.php
@@ -186,7 +186,7 @@ abstract class BaseRepository {
 	 * @param \wpdb|null $wpdb       Optional wpdb instance (defaults to global).
 	 * @return bool
 	 */
-	public static function table_exists( string $table_name, ?\wpdb $wpdb = null ): bool {
+	public static function database_table_exists( string $table_name, ?\wpdb $wpdb = null ): bool {
 		if ( null === $wpdb ) {
 			global $wpdb;
 		}

--- a/inc/Core/Database/TrackedItems/TrackedItems.php
+++ b/inc/Core/Database/TrackedItems/TrackedItems.php
@@ -163,7 +163,7 @@ class TrackedItems extends BaseRepository {
 	 * Create or update the tracked items table.
 	 */
 	public function create_table(): void {
-		if ( self::is_sqlite() && self::table_exists( $this->table_name, $this->wpdb ) ) {
+		if ( self::is_sqlite() && self::database_table_exists( $this->table_name, $this->wpdb ) ) {
 			return;
 		}
 

--- a/inc/Core/Database/TrackedItems/TrackedItems.php
+++ b/inc/Core/Database/TrackedItems/TrackedItems.php
@@ -163,6 +163,10 @@ class TrackedItems extends BaseRepository {
 	 * Create or update the tracked items table.
 	 */
 	public function create_table(): void {
+		if ( self::is_sqlite() && self::table_exists( $this->table_name, $this->wpdb ) ) {
+			return;
+		}
+
 		$charset_collate = $this->wpdb->get_charset_collate();
 		$sql             = "CREATE TABLE {$this->table_name} (
 			id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
## Summary
- Add a reusable table-existence helper that uses SQLite's native schema table on SQLite and SHOW TABLES on MySQL.
- Skip tracked-items dbDelta on SQLite when the table already exists.
- Prevent repeated noisy table-already-exists errors during normal bootstrap on Studio/SQLite installs.

## Testing
- php -l inc/Core/Database/BaseRepository.php
- php -l inc/Core/Database/TrackedItems/TrackedItems.php
- Verified the active Studio SQLite table lookup returns wp_datamachine_tracked_items via sqlite_master.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the SQLite bootstrap error, drafting the table-existence guard, and preparing the PR.