### PR TITLE
Keep runtime tool policy host neutral

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -162,7 +162,7 @@ function datamachine_run_datamachine_plugin() {
 	// Register ability categories first — must happen before any ability registration.
 	// Categories are also registered unconditionally at file include time (see bottom
 	// of this file); this call is the defensive in-runtime path for late `plugins_loaded`
-	// inclusion (`plugin_sandbox_scrape()` during activation, etc.). The static guard in
+	// inclusion during activation or runtime inspection. The static guard in
 	// `AbilityCategories::register()` makes it idempotent.
 	require_once __DIR__ . '/inc/Abilities/AbilityCategories.php';
 	\DataMachine\Abilities\AbilityCategories::ensure_registered();
@@ -485,7 +485,7 @@ if ( did_action( 'plugins_loaded' ) ) {
  * `ensure_registered()` here attaches the `wp_abilities_api_categories_init`
  * hook before `init` fires (the action cannot fire before `init`, so any
  * later `plugins_loaded` priority works too — but earlier is safer for any
- * site that includes our plugin file via `plugin_sandbox_scrape()` or
+ * site that includes our plugin file through late runtime inspection or
  * similar late-load paths).
  */
 require_once __DIR__ . '/inc/Abilities/AbilityCategories.php';
@@ -497,7 +497,7 @@ require_once __DIR__ . '/inc/Abilities/AbilityManifest.php';
 /**
  * Declare Data Machine abilities whose schemas are cheap enough for lite requests.
  *
- * These abilities have frontend, sandbox, or helper consumers that can resolve
+ * These abilities have frontend, headless runtime, or helper consumers that can resolve
  * them before the full runtime gate opens. The declarations load only schema and
  * callback owners; execution callbacks lazily activate the full runtime.
  *
@@ -730,7 +730,7 @@ function datamachine_activate_for_site() {
 
 	// Ensure default agent memory files exist.
 	// During activation the Abilities API is unavailable (init already fired before
-	// the plugin was included via plugin_sandbox_scrape, so our init callback that
+	// the plugin was included for activation inspection, so our init callback that
 	// registers abilities never ran). Set a transient so the scaffold runs on the
 	// first normal request where the full hook sequence fires in order.
 	if ( ! datamachine_ensure_default_memory_files() ) {

--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -283,7 +283,7 @@ Agent package operations live under `wp datamachine agent`:
 
 Every read/preview command supports `--format=json` for automation.
 
-`run-bundle` returns `datamachine/agent-bundle-run/v1`. By default it is a job-start envelope with `job_id`, `execution_type`, and bundle metadata. Pass `--wait` to drain the created job in the current request and include terminal `job_status`, `wait_result`, and final `engine_data`. `--step-budget` and `--time-budget-ms` bound synchronous drains for one-shot CI or sandbox runtimes.
+`run-bundle` returns `datamachine/agent-bundle-run/v1`. By default it is a job-start envelope with `job_id`, `execution_type`, and bundle metadata. Pass `--wait` to drain the created job in the current request and include terminal `job_status`, `wait_result`, and final `engine_data`. `--step-budget` and `--time-budget-ms` bound synchronous drains for one-shot CI or headless runtimes.
 
 `install`, `import`, `upgrade`, and `diff` accept `--token=<token>` and `--token-env=<varname>` for one-off authenticated downloads — see [Authenticated Bundle Sources](#authenticated-bundle-sources).
 

--- a/inc/Abilities/AbilityCategories.php
+++ b/inc/Abilities/AbilityCategories.php
@@ -67,7 +67,7 @@ class AbilityCategories {
 		foreach ( self::get_category_definitions() as $slug => $args ) {
 			if ( $late ) {
 				// Late path: the categories-init action has already completed
-				// (headless runtime load order — see
+				// (headless runtime load order; see
 				// ensure_registered()). The public helper would
 				// `_doing_it_wrong()`, so register through the registry
 				// instance directly, which core permits any time after `init`.

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -66,7 +66,7 @@ class AgentAbilities {
 			return \wp_register_ability( $name, $args );
 		}
 
-		// Late path: the init action has already fired (headless / sandbox
+		// Late path: the init action has already fired (headless runtime
 		// load order). Register through the registry instance directly, which
 		// WordPress core permits any time after `init`.
 		if ( ! did_action( 'wp_abilities_api_init' ) || ! class_exists( '\WP_Abilities_Registry' ) ) {
@@ -1558,7 +1558,7 @@ class AgentAbilities {
 	 *
 	 * @param mixed $result         Previous runner result, or null when unhandled.
 	 * @param array $task_config    Generic task/bundle execution config.
-	 * @param array $runtime_config Generic runtime config supplied by the sandbox owner.
+	 * @param array $runtime_config Generic runtime config supplied by the runtime host.
 	 * @param int   $index          Bundle/task index in the runtime request.
 	 * @return mixed Runtime bundle run result.
 	 */
@@ -1742,7 +1742,7 @@ class AgentAbilities {
 				),
 				'agent_bundles'       => array(
 					'type'        => 'array',
-					'description' => 'Alias for runtime_bundles used by sandbox task payloads.',
+					'description' => 'Alias for runtime_bundles used by runtime host task payloads.',
 					'items'       => array( 'type' => 'object' ),
 				),
 				'runtime_import'      => array(

--- a/inc/Engine/AI/Tools/HostToolPolicy.php
+++ b/inc/Engine/AI/Tools/HostToolPolicy.php
@@ -15,7 +15,6 @@ defined( 'ABSPATH' ) || exit;
 final class HostToolPolicy {
 
 	private const ENV_POLICY_JSON = 'DATAMACHINE_HOST_TOOL_POLICY_JSON';
-	private const SCHEMA_SANDBOX_TOOL_POLICY = 'datamachine/sandbox-tool-policy/v1';
 	private const SCHEMA_RUNTIME_TOOL_POLICY = 'agents-api/runtime-tool-policy/v1';
 
 	/** @var array<string,mixed> */
@@ -207,7 +206,6 @@ final class HostToolPolicy {
 	 */
 	private static function transportPolicySchemas(): array {
 		$schemas = array(
-			self::SCHEMA_SANDBOX_TOOL_POLICY,
 			self::SCHEMA_RUNTIME_TOOL_POLICY,
 		);
 

--- a/tests/abilities-categories-load-order-smoke.php
+++ b/tests/abilities-categories-load-order-smoke.php
@@ -96,8 +96,8 @@ $assert(
 );
 
 $assert(
-	'ensure_registered() documents the headless / sandbox late-registration path',
-	str_contains( $categories, 'sandbox' )
+	'ensure_registered() documents the headless runtime late-registration path',
+	str_contains( $categories, 'headless runtime' )
 );
 
 $assert(
@@ -181,7 +181,7 @@ if ( ! function_exists( 'wp_register_ability_category' ) ) {
 }
 
 // Minimal fake of the category registry so the late-registration path
-// (headless sandbox load order — plugin included AFTER the
+// (headless runtime load order: plugin included AFTER the
 // one-shot `wp_abilities_api_categories_init` fired) can be exercised. Mirrors
 // core: `WP_Ability_Categories_Registry::register()` has NO lifecycle guard —
 // only the `wp_register_ability_category()` wrapper does.
@@ -249,7 +249,7 @@ $assert(
 		&& empty( $state->registered )
 );
 
-// --- State 3: post-action (headless sandbox load order).
+// --- State 3: post-action (headless runtime load order).
 // The one-shot `wp_abilities_api_categories_init` already fired during
 // `wp-load.php` before `run-php` included the plugin file. Categories must
 // register late via the registry instance so category-bound abilities (e.g.

--- a/tests/agent-abilities-late-registration-smoke.php
+++ b/tests/agent-abilities-late-registration-smoke.php
@@ -8,7 +8,7 @@
  *  - Real WordPress runtime (which boots WordPress and includes the plugin):
  *    assert the canonical
  *    `datamachine/run-agent-bundle` ability is registered. This is the headless
- *    sandbox load order (`run-php` boots WP, then includes the plugin file) that
+ *    runtime-host load order (WordPress boots, then includes the plugin file) that
  *    must resolve the ability — see Extra-Chill/data-machine#2629.
  *  - Standalone pure-PHP (`php tests/...`): drive the three registration timing
  *    states with stubbed WordPress lifecycle functions.
@@ -25,7 +25,7 @@ namespace {
 		// unconditional way data-machine.php does at file scope, then assert the
 		// ability resolves through `wp_get_ability()` (which lazily fires
 		// `wp_abilities_api_init`). This exercises the real registration code
-		// path headless sandbox runs depend on for `datamachine/run-agent-bundle`.
+		// path headless runtime runs depend on for `datamachine/run-agent-bundle`.
 		if ( ! class_exists( '\DataMachine\Abilities\AgentAbilities' ) ) {
 			require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 			require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityCategories.php';
@@ -91,7 +91,7 @@ namespace {
 	}
 
 	// Minimal fake of the abilities registry so the late-registration path
-	// (headless sandbox load order, where the plugin file is
+	// (headless runtime load order, where the plugin file is
 	// included AFTER `wp_abilities_api_init` has already fired) can be
 	// exercised. Mirrors core: `WP_Abilities_Registry::register()` has NO
 	// lifecycle guard — only the `wp_register_ability()` wrapper does.
@@ -125,6 +125,7 @@ namespace DataMachine\Engine\Bundle {
 }
 
 namespace DataMachine\Abilities {
+	require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityRegistration.php';
 	require_once dirname( __DIR__ ) . '/inc/Abilities/AgentAbilities.php';
 }
 
@@ -161,7 +162,7 @@ namespace {
 	$source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/AgentAbilities.php' ) ?: '';
 	$assert( 'agent abilities support a late registry-backed registration path for headless runtimes', str_contains( $source, 'WP_Abilities_Registry::get_instance()' ) );
 	$assert( 'late path is guarded by is_registered() for idempotency', str_contains( $source, 'is_registered' ) );
-	$assert( 'agent abilities document the headless / sandbox load order', str_contains( $source, 'sandbox' ) );
+	$assert( 'agent abilities document the headless runtime load order', str_contains( $source, 'headless runtime' ) );
 
 	$reset_state();
 	new AgentAbilities();
@@ -178,17 +179,17 @@ namespace {
 	$registered = array_keys( $GLOBALS['datamachine_test_state']->registered );
 	$assert( 'normal bootstrap registers agent bundle/import abilities during wp_abilities_api_init', in_array( 'datamachine/import-agent', $registered, true ) && in_array( 'datamachine/run-agent-bundle', $registered, true ) );
 
-	// Headless sandbox load order: `run-php` boots WordPress
+	// Headless runtime load order: the host boots WordPress
 	// through `wp-load.php` (firing the one-shot `wp_abilities_api_init`) and
 	// only THEN includes the plugin file. The constructor must register
 	// immediately through the registry instance — NOT silently no-op, which was
 	// the original bug that left `datamachine/run-agent-bundle` unregistered for
-	// sandbox runs (Extra-Chill/data-machine#2629).
+	// headless runtime runs (Extra-Chill/data-machine#2629).
 	$reset_state();
 	$GLOBALS['datamachine_test_state']->did = 1;
 	new AgentAbilities();
 	$post_registered = array_keys( $GLOBALS['datamachine_test_state']->registered );
-	$assert( 'post-action constructor registers run-agent-bundle via the registry (headless sandbox load order)', in_array( 'datamachine/run-agent-bundle', $post_registered, true ) );
+	$assert( 'post-action constructor registers run-agent-bundle via the registry (headless runtime load order)', in_array( 'datamachine/run-agent-bundle', $post_registered, true ) );
 	$assert( 'post-action constructor registers import-agent via the registry', in_array( 'datamachine/import-agent', $post_registered, true ) );
 	$assert( 'post-action constructor does not defer to an already-fired action', array() === $GLOBALS['datamachine_test_state']->added_actions );
 

--- a/tests/agent-abilities-registration-smoke.php
+++ b/tests/agent-abilities-registration-smoke.php
@@ -16,7 +16,7 @@ namespace {
 		// Real WordPress runtime.
 		// The harness boots a bare WordPress with the plugin DIRECTORY mounted
 		// but NOT activated, so Data Machine's normal `plugins_loaded`
-		// registration never runs. This mirrors headless sandbox tasks that need
+		// registration never runs. This mirrors headless runtime tasks that need
 		// `datamachine/run-agent-bundle` to register on demand, regardless of
 		// request shape.
 		//
@@ -53,7 +53,7 @@ namespace {
 	$GLOBALS['agent_abilities_registered_abilities'] = array();
 
 	// Minimal fake of the WordPress abilities registry so the late-registration
-	// path (used in headless sandbox load order, where the plugin
+	// path (used in headless runtime load order, where the plugin
 	// is included AFTER `wp_abilities_api_init` has already fired) can be
 	// exercised without a full WordPress runtime. Mirrors how
 	// `WP_Abilities_Registry::register()` has NO lifecycle guard — only the
@@ -173,12 +173,12 @@ namespace {
 	$GLOBALS['agent_abilities_doing_action'] = false;
 	agent_abilities_assert( isset( $GLOBALS['agent_abilities_registered_abilities']['datamachine/run-agent-bundle'] ), 'run-agent-bundle registers during wp_abilities_api_init' );
 
-	// Headless sandbox load order: `run-php` boots WordPress
+	// Headless runtime load order: the host boots WordPress
 	// through `wp-load.php` (firing the one-shot `wp_abilities_api_init`) and
 	// only THEN includes the plugin file. The constructor sees the action has
 	// already completed and must register immediately through the registry
 	// instance, NOT silently no-op (the original bug that left
-	// `datamachine/run-agent-bundle` unregistered for sandbox runs).
+	// `datamachine/run-agent-bundle` unregistered for headless runtime runs).
 	$GLOBALS['agent_abilities_actions']              = array();
 	$GLOBALS['agent_abilities_registered_abilities'] = array();
 	$GLOBALS['agent_abilities_doing_action']         = false;
@@ -188,7 +188,7 @@ namespace {
 	new \DataMachine\Abilities\AgentAbilities();
 	agent_abilities_assert(
 		isset( $GLOBALS['agent_abilities_registered_abilities']['datamachine/run-agent-bundle'] ),
-		'late construction (post-init, headless sandbox load order) registers run-agent-bundle via the registry'
+		'late construction (post-init, headless runtime load order) registers run-agent-bundle via the registry'
 	);
 
 	// Re-constructing after a successful late registration must remain

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -619,32 +619,7 @@ $resolution     = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )-
 assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'wrapped policy delegates explicit control-plane tool', $failures, $passes );
 assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'wrapped policy leaves runner-default tool local', $failures, $passes );
 
-echo "\n[14] host tool policy accepts neutral list-shaped sandbox policy payloads:\n";
-$transport_policy = array(
-	'schema'           => 'datamachine/sandbox-tool-policy/v1',
-	'default_location' => 'runner',
-	'tools'            => array(
-		array(
-			'name'               => 'alpha_tool',
-			'execution_location' => 'control_plane',
-		),
-	),
-);
-$resolution       = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->resolve(
-	array(
-		'mode'                => ToolPolicyResolver::MODE_PIPELINE,
-		'pipeline_step_id'    => 'ephemeral_pipeline_0',
-		'engine_data'         => array(),
-		'categories'          => array(),
-		'allow_only_explicit' => true,
-		'allow_only'          => array( 'alpha_tool', 'beta_tool' ),
-		'host_tool_policy'    => $transport_policy,
-	)
-);
-assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'neutral sandbox policy delegates explicit control-plane tool', $failures, $passes );
-assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'neutral sandbox policy leaves runner-default tool local', $failures, $passes );
-
-echo "\n[14b] host tool policy accepts generic list-shaped runtime policy payloads:\n";
+echo "\n[14] host tool policy accepts generic list-shaped runtime policy payloads:\n";
 $transport_policy = array(
 	'schema'           => 'agents-api/runtime-tool-policy/v1',
 	'default_location' => 'runner',
@@ -668,6 +643,52 @@ $resolution       = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) 
 );
 assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'generic runtime policy delegates explicit control-plane tool', $failures, $passes );
 assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'generic runtime policy leaves runner-default tool local', $failures, $passes );
+
+echo "\n[14b] host tool policy ignores deprecated sandbox-shaped policy payloads unless a runtime host registers them:\n";
+$transport_policy = array(
+	'schema'           => 'datamachine/sandbox-tool-policy/v1',
+	'default_location' => 'runner',
+	'tools'            => array(
+		array(
+			'name'               => 'alpha_tool',
+			'execution_location' => 'control_plane',
+		),
+	),
+);
+$resolution       = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->resolve(
+	array(
+		'mode'                => ToolPolicyResolver::MODE_PIPELINE,
+		'pipeline_step_id'    => 'ephemeral_pipeline_0',
+		'engine_data'         => array(),
+		'categories'          => array(),
+		'allow_only_explicit' => true,
+		'allow_only'          => array( 'alpha_tool', 'beta_tool' ),
+		'host_tool_policy'    => $transport_policy,
+	)
+);
+assert_policy_equals( null, $resolution['alpha_tool']['executor'] ?? null, 'deprecated sandbox-shaped policy is not built into Data Machine core', $failures, $passes );
+assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'deprecated sandbox-shaped policy does not affect unrelated tools', $failures, $passes );
+
+echo "\n[14c] host tool policy accepts externally registered deprecated transport payloads:\n";
+$deprecated_transport_schema_filter = static function ( array $schemas ): array {
+	$schemas[] = 'datamachine/sandbox-tool-policy/v1';
+	return $schemas;
+};
+add_filter( 'datamachine_host_tool_policy_transport_schemas', $deprecated_transport_schema_filter );
+$resolution = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) )->resolve(
+	array(
+		'mode'                => ToolPolicyResolver::MODE_PIPELINE,
+		'pipeline_step_id'    => 'ephemeral_pipeline_0',
+		'engine_data'         => array(),
+		'categories'          => array(),
+		'allow_only_explicit' => true,
+		'allow_only'          => array( 'alpha_tool', 'beta_tool' ),
+		'host_tool_policy'    => $transport_policy,
+	)
+);
+remove_filter( 'datamachine_host_tool_policy_transport_schemas', $deprecated_transport_schema_filter );
+assert_policy_equals( 'client', $resolution['alpha_tool']['executor'] ?? null, 'runtime hosts can externally register deprecated transport schemas', $failures, $passes );
+assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'externally registered deprecated transport schema leaves runner-default tool local', $failures, $passes );
 
 echo "\n[15] host tool policy accepts neutral host policy payloads:\n";
 $host_policy = array(
@@ -745,9 +766,9 @@ $resolution       = ( new ToolPolicyResolver( new SnapshotPolicyToolManager() ) 
 assert_policy_equals( null, $resolution['alpha_tool']['executor'] ?? null, 'list-shaped transport policy is not converted into host policy', $failures, $passes );
 assert_policy_equals( null, $resolution['beta_tool']['executor'] ?? null, 'list-shaped transport policy does not affect unrelated tools', $failures, $passes );
 
-echo "\n[18] production host policy code has no unregistered vendor sandbox schema special-case:\n";
+echo "\n[18] production host policy code has no sandbox transport schema special-case:\n";
 $host_policy_source = file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/HostToolPolicy.php' ) ?: '';
-assert_policy_equals( false, str_contains( $host_policy_source, 'acme-runner/sandbox-tool-policy/v1' ), 'HostToolPolicy does not name an unregistered vendor sandbox schema', $failures, $passes );
+assert_policy_equals( false, str_contains( $host_policy_source, 'sandbox-tool-policy/v1' ), 'HostToolPolicy does not name sandbox transport schemas', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " pipeline policy assertions failed.\n";


### PR DESCRIPTION
## Summary
- Standardizes built-in list-shaped runtime tool policy handling on `agents-api/runtime-tool-policy/v1`.
- Removes Data Machine core recognition of `datamachine/sandbox-tool-policy/v1`; runtime hosts can still opt into deprecated/vendor schemas through `datamachine_host_tool_policy_transport_schemas`.
- Replaces sandbox-shaped wording in core ability docs/tests with headless runtime/runtime host language.

## Tests
- `php -l` on touched PHP files
- `./vendor/bin/phpcs` on touched PHP files
- `php tests/pipeline-tool-policy-snapshot-smoke.php`
- `php tests/agent-abilities-late-registration-smoke.php`
- `php tests/abilities-categories-load-order-smoke.php`
- `php tests/agent-abilities-registration-smoke.php`

## Compatibility / follow-up
- Any runtime host still emitting `datamachine/sandbox-tool-policy/v1` must register that deprecated schema externally via `datamachine_host_tool_policy_transport_schemas` or migrate to `agents-api/runtime-tool-policy/v1`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code changes, test updates, and PR drafting.