### PR TITLE
fix: treat daily-memory no-op as success instead of hard failure

### DIFF
--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -182,6 +182,60 @@ class DailyMemoryTask extends SystemTask {
 
 		$datamachine_metadata = is_array( $response['metadata']['datamachine'] ?? null ) ? $response['metadata']['datamachine'] : array();
 		if ( empty( $datamachine_metadata['completed'] ) ) {
+			$response_error = is_string( $response['error'] ?? null ) ? trim( $response['error'] ) : '';
+
+			// Distinguish a genuine execution failure from a legitimate
+			// "nothing worth changing today" no-op.
+			//
+			// The conversation loop sets completed=false both when the
+			// request actually failed (provider error, runtime exception,
+			// malformed loop result, interruption) AND when the model simply
+			// ran out of turns without producing a split the completion
+			// policy would accept. The latter is the common path for small,
+			// already-healthy MEMORY.md files: the agent reviewed the day's
+			// activity and never emitted an acceptable PERSISTENT/ARCHIVED
+			// partition because there was nothing memory-worthy to fold in.
+			//
+			// At this point nothing has been written to MEMORY.md yet (the
+			// replace_all() call happens later in this method), so the file
+			// is genuinely untouched. A no-op should therefore complete the
+			// job successfully and log at info, not fail loudly and pollute
+			// error-rate metrics / the wake briefing (issue #2783).
+			//
+			// A genuine fault is identified by an explicit error signal:
+			// a non-empty error string, an error_code, or a hard failure /
+			// interrupted status from the loop. Those still fail the job.
+			$genuine_failure = '' !== $response_error
+				|| ! empty( $response['error_code'] )
+				|| in_array( (string) ( $response['status'] ?? '' ), array( 'error', 'failed', 'interrupted' ), true );
+
+			if ( ! $genuine_failure ) {
+				do_action(
+					'datamachine_log',
+					'info',
+					'Daily memory no-op: completion policy not satisfied, MEMORY.md left unchanged.',
+					array(
+						'date'        => $date,
+						'job_id'      => $jobId,
+						'status'      => $response['status'] ?? '',
+						'turn_count'  => $response['turn_count'] ?? 0,
+						'datamachine' => $datamachine_metadata,
+					)
+				);
+
+				$this->completeJob(
+					$jobId,
+					array(
+						'skipped'       => true,
+						'no_change'     => true,
+						'reason'        => 'Completion policy not satisfied within turn budget; MEMORY.md left unchanged (no memory-worthy change this run).',
+						'original_size' => $original_size,
+						'turn_count'    => $response['turn_count'] ?? 0,
+					)
+				);
+				return;
+			}
+
 			do_action(
 				'datamachine_log',
 				'warning',
@@ -195,7 +249,7 @@ class DailyMemoryTask extends SystemTask {
 					'error'       => $response['error'] ?? null,
 				)
 			);
-			$this->failJob( $jobId, $response['error'] ?? 'Daily memory completion policy was not satisfied. MEMORY.md unchanged.' );
+			$this->failJob( $jobId, $response_error !== '' ? $response_error : 'Daily memory completion policy was not satisfied. MEMORY.md unchanged.' );
 			return;
 		}
 

--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -249,7 +249,7 @@ class DailyMemoryTask extends SystemTask {
 					'error'       => $response['error'] ?? null,
 				)
 			);
-			$this->failJob( $jobId, $response_error !== '' ? $response_error : 'Daily memory completion policy was not satisfied. MEMORY.md unchanged.' );
+			$this->failJob( $jobId, '' !== $response_error ? $response_error : 'Daily memory completion policy was not satisfied. MEMORY.md unchanged.' );
 			return;
 		}
 


### PR DESCRIPTION
Closes #2783

## Problem

`DailyMemoryTask` logged a legitimate "MEMORY.md unchanged" outcome as an **ERROR-level hard job failure**, generating recurring false-positive noise that polluted error-rate metrics and the wake briefing.

Real log evidence from `extrachill.com` (and `wire.extrachill.com`), repeating ~3×/day across multiple agents and every day:

```
Task failed (job #5151): Daily memory completion policy was not satisfied. MEMORY.md unchanged.
```
```json
{"job_id":5151,"task_type":"daily_memory_generation","error":"Daily memory completion policy was not satisfied. MEMORY.md unchanged."}
```

## Root cause (investigated, not assumed)

Inspecting live failing jobs confirmed the mechanism:

- The job that "failed" (e.g. job #5151, agent_id 17) runs for ~5s with **empty `token_usage`** and the error is the exact *fallback* string — meaning `$response['error']` was empty.
- That fallback only fires when the conversation loop returns `completed=false` **with no genuine error** — i.e. the completion policy never returned `complete()` within the turn budget.
- The affected agent's `MEMORY.md` is **144 bytes** (MAX is 8192), so the file is small and already healthy. The task didn't skip at the size-threshold guard only because there was some activity context that day. The model reviewed the day, found nothing memory-worthy, and never emitted an acceptable `===PERSISTENT===` / `===ARCHIVED===` partition. Nothing is written to disk on this path, so `MEMORY.md` is genuinely **unchanged** — a successful no-op, not a fault.

The conversation loop (`datamachine_run_conversation`) sets `completed=false` for **both** genuine faults (provider error, runtime exception, malformed result, `budget_exceeded`/`interrupted`/`failed` status) **and** this benign "ran out of turns without an acceptable changed split" case. The old code blindly `failJob`'d both.

## Fix

At the `completed=false` branch in `DailyMemoryTask::executeTask()`, distinguish the two by **explicit error signal**:

```php
$genuine_failure = '' !== $response_error
    || ! empty( $response['error_code'] )
    || in_array( (string) ( $response['status'] ?? '' ), array( 'error', 'failed', 'interrupted' ), true );
```

- **Genuine failure** (any of the above) → unchanged behavior: log at `error` and `failJob`.
- **No-op** (no error signal; the model simply produced no acceptable changed split) → `completeJob` with `skipped`/`no_change` markers and log at `info`. Safe because `replace_all()` happens *later* in the method, so `MEMORY.md` is untouched at this point.

### How legitimate no-op is distinguished from genuine failure

| Outcome | Signal | Behavior |
|---|---|---|
| Provider/runtime error | non-empty `error` / `error_code` | `failJob` (error) |
| Hard loop failure / interruption | `status` ∈ {error, failed, interrupted} | `failJob` (error) |
| Empty model output | later `empty($ai_output)` guard | `failJob` (error) — unchanged |
| Lossy/duplicative split | `planMemoryCompaction` conservation checks | `failJob` (error) — unchanged |
| Policy unsatisfied, file untouched, **no error** | none of the above | `completeJob` no-op (info) ✅ |

All genuine-failure paths downstream (empty response, parse failure, conservation/expansion failures in `planMemoryCompaction`) are reached only when `completed=true` and remain loud — they represent a model that *produced bad output*, which the issue explicitly says must still fail.

## Fork decisions / out of scope

- **Chose to gate on the loop's existing error signals** rather than add a new "no-op" state to the Agents API completion-decision substrate. The substrate decision is intentionally binary (`complete()`/`incomplete()`); the no-op semantics are a Data-Machine-task concern (the file being untouched at this call site), so the distinction belongs in the task, not the generic loop. This keeps layer purity intact.
- Did **not** change the prompt/completion-policy contract to let the model emit an explicit "no change" sentinel. That would be a larger behavioral change; the minimal, evidence-backed fix is to stop treating the existing untouched-file outcome as an error. A future enhancement could add a first-class "decline" signal, but it's not needed to resolve the noise.

## Verification

- `php -l` clean.
- `phpcs --standard=WordPress` clean (exit 0, no warnings — covers the array-arrow/assignment-alignment gate).
- `phpcbf` made no changes.