### PR TITLE
fix: retry engine_data CAS on InnoDB deadlocks instead of dropping writes

### DIFF
--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -1439,7 +1439,7 @@ class Jobs extends BaseRepository {
 	 * @param int   $job_id        Job ID.
 	 * @param array $expected_data Engine data snapshot read before mutation.
 	 * @param array $new_data      Engine data snapshot to persist.
-	 * @return array{updated:bool,conflict:bool,error:string|null}
+	 * @return array{updated:bool,conflict:bool,retryable?:bool,error:string|null}
 	 */
 	public function compare_and_swap_engine_data( int $job_id, array $expected_data, array $new_data ): array {
 		if ( $job_id <= 0 ) {
@@ -1474,20 +1474,27 @@ class Jobs extends BaseRepository {
 		);
 
 		if ( false === $result ) {
+			$db_error  = (string) $this->wpdb->last_error;
+			$retryable = $this->is_retryable_db_error( $db_error );
+
 			do_action(
 				'datamachine_log',
-				'error',
-				'Failed to compare-and-swap engine_data',
+				$retryable ? 'warning' : 'error',
+				$retryable
+					? 'Transient DB lock contention during engine_data compare-and-swap, retrying'
+					: 'Failed to compare-and-swap engine_data',
 				array(
-					'job_id'   => $job_id,
-					'db_error' => $this->wpdb->last_error,
+					'job_id'    => $job_id,
+					'db_error'  => $db_error,
+					'retryable' => $retryable,
 				)
 			);
 
 			return array(
-				'updated'  => false,
-				'conflict' => false,
-				'error'    => 'db_error',
+				'updated'   => false,
+				'conflict'  => false,
+				'retryable' => $retryable,
+				'error'     => $retryable ? 'deadlock' : 'db_error',
 			);
 		}
 
@@ -1532,6 +1539,38 @@ class Jobs extends BaseRepository {
 			'conflict' => false,
 			'error'    => null,
 		);
+	}
+
+	/**
+	 * Determine whether a DB error string represents a transient lock condition
+	 * that should be retried by re-reading the latest snapshot.
+	 *
+	 * Covers InnoDB deadlocks (MySQL 1213) and lock-wait timeouts (MySQL 1205),
+	 * both of which MySQL explicitly recommends resolving by restarting the
+	 * transaction rather than treating as a fatal failure.
+	 *
+	 * @param string $db_error Raw $wpdb->last_error message.
+	 * @return bool True when the error is transient and retryable.
+	 */
+	private function is_retryable_db_error( string $db_error ): bool {
+		if ( '' === $db_error ) {
+			return false;
+		}
+
+		$needles = array(
+			'deadlock found',
+			'try restarting transaction',
+			'lock wait timeout exceeded',
+		);
+
+		$haystack = strtolower( $db_error );
+		foreach ( $needles as $needle ) {
+			if ( false !== strpos( $haystack, $needle ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/inc/Core/EngineData.php
+++ b/inc/Core/EngineData.php
@@ -194,7 +194,9 @@ class EngineData {
 				);
 			}
 
-			if ( empty( $result['conflict'] ) ) {
+			$is_retryable = ! empty( $result['conflict'] ) || ! empty( $result['retryable'] );
+
+			if ( ! $is_retryable ) {
 				return array(
 					'success'  => false,
 					'conflict' => false,
@@ -207,13 +209,21 @@ class EngineData {
 			do_action(
 				'datamachine_log',
 				'warning',
-				'EngineData mutation conflict, retrying latest snapshot',
+				'EngineData mutation contention, retrying latest snapshot',
 				array(
 					'job_id'     => $job_id,
 					'event_type' => $event_type,
 					'attempt'    => $attempt,
+					'reason'     => ! empty( $result['retryable'] ) ? 'deadlock' : 'conflict',
 				)
 			);
+
+			// On a transient DB lock (deadlock / lock-wait), the row may still be
+			// locked momentarily; a small randomized backoff lets the winning
+			// transaction commit before we re-read and retry.
+			if ( ! empty( $result['retryable'] ) && $attempt < $max_attempts ) {
+				usleep( wp_rand( 5000, 25000 ) );
+			}
 		}
 
 		return array(

--- a/inc/Engine/AI/RuntimeToolRunStateStore.php
+++ b/inc/Engine/AI/RuntimeToolRunStateStore.php
@@ -211,8 +211,15 @@ class RuntimeToolRunStateStore {
 					return true;
 				}
 
-				if ( empty( $result['conflict'] ) ) {
+				// Retry on both logical conflicts and transient DB lock
+				// contention (deadlock / lock-wait timeout); bail only on a
+				// genuinely fatal persist failure.
+				if ( empty( $result['conflict'] ) && empty( $result['retryable'] ) ) {
 					return false;
+				}
+
+				if ( ! empty( $result['retryable'] ) && $attempt < 3 ) {
+					usleep( wp_rand( 5000, 25000 ) );
 				}
 
 				continue;


### PR DESCRIPTION
## Summary

Fixes #2785. InnoDB deadlocks (and lock-wait timeouts) during the engine_data compare-and-swap were returned as a generic `db_error` and treated as **non-retryable**, so the optimistic-concurrency loop bailed and **silently dropped the write**. This is exactly the case MySQL recommends retrying ("try restarting transaction").

Observed in production on events.extrachill.com — parallel scraper/Ticketmaster ingestion flows CAS the same engine_data rows at the same scheduled tick (~15:02–15:03 UTC) and step on each other's locks, dropping tool-run-state / step-progress writes.

## Changes

- **`Jobs::compare_and_swap_engine_data()`** — on `$wpdb->update` failure, classify `$wpdb->last_error` via a new `is_retryable_db_error()` helper (matches deadlock 1213 / lock-wait timeout 1205). Return a `retryable` flag and `error: 'deadlock'`, and log at `warning` (not `error`) when transient.
- **`EngineData::mutate()`** — treat `retryable` like a logical `conflict`: re-read the latest snapshot and retry within the existing `max_attempts` budget, with a small randomized backoff (`5–25ms`) to let the winning transaction commit. Genuinely fatal DB errors still fail fast.
- **`RuntimeToolRunStateStore::mutate_engine_data()`** — mirror the same classification in the fallback CAS loop.

## Behavior

- A deadlock on the CAS write is now retried instead of dropping the write.
- Non-retryable DB errors still fail fast (no infinite loop — bounded by `max_attempts`).
- Logging distinguishes transient contention (`warning`, with `reason: deadlock|conflict`) from fatal failure (`error`).

## Verification

- `php -l` clean on all three files.
- `phpcs` clean (no warnings/errors) on all three files.
