### PR TITLE
fix: retry lifecycle state transitions on transient DB deadlocks

### DIFF
--- a/inc/Core/Database/LifecycleStateTransition.php
+++ b/inc/Core/Database/LifecycleStateTransition.php
@@ -17,11 +17,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 class LifecycleStateTransition {
 
 	/**
+	 * Maximum number of attempts when a transition hits a transient deadlock.
+	 *
+	 * @var int
+	 */
+	private const MAX_DEADLOCK_ATTEMPTS = 5;
+
+	/**
+	 * Base backoff in microseconds between deadlock retries (grows linearly).
+	 *
+	 * @var int
+	 */
+	private const DEADLOCK_BACKOFF_BASE_US = 20000;
+
+	/**
 	 * Update a row only while it is still in the expected state.
 	 *
 	 * The helper keeps store-specific identity columns and payload fields in the
 	 * caller while centralizing the guarded state transition shape used by claims,
 	 * leases, pending decisions, and tracked-item state machines.
+	 *
+	 * Lifecycle transitions are the hottest concurrent writes in the system: many
+	 * Action Scheduler runners can race to update the same status rows at once,
+	 * which surfaces transient InnoDB deadlocks (MySQL error 1213) and lock-wait
+	 * timeouts (1205). MySQL explicitly instructs callers to "try restarting
+	 * transaction" in this case, so the failed statement is retried a bounded
+	 * number of times with linear backoff before giving up. Non-deadlock errors
+	 * are returned immediately without retry.
 	 *
 	 * @param \wpdb  $wpdb             WordPress database instance.
 	 * @param string $table_name       Fully-qualified table name.
@@ -50,9 +72,53 @@ class LifecycleStateTransition {
 		$data_formats  = array_merge( $update_formats, array( '%s' ) );
 		$where_formats = array_merge( $identity_formats, array( '%s' ) );
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$result = $wpdb->update( $table_name, $data, $where, $data_formats, $where_formats );
+		for ( $attempt = 1; $attempt <= self::MAX_DEADLOCK_ATTEMPTS; $attempt++ ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result = $wpdb->update( $table_name, $data, $where, $data_formats, $where_formats );
 
-		return false === $result ? false : (int) $result;
+			if ( false !== $result ) {
+				return (int) $result;
+			}
+
+			if ( ! self::is_deadlock_error( $wpdb->last_error ) || $attempt >= self::MAX_DEADLOCK_ATTEMPTS ) {
+				break;
+			}
+
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Lifecycle transition deadlock; retrying',
+				array(
+					'table'          => $table_name,
+					'state_column'   => $state_column,
+					'expected_state' => $expected_state,
+					'next_state'     => $next_state,
+					'attempt'        => $attempt,
+					'max_attempts'   => self::MAX_DEADLOCK_ATTEMPTS,
+					'db_error'       => $wpdb->last_error,
+				)
+			);
+
+			// Linear backoff with a little jitter to desynchronize racing runners.
+			usleep( self::DEADLOCK_BACKOFF_BASE_US * $attempt + random_int( 0, self::DEADLOCK_BACKOFF_BASE_US ) );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determine whether a wpdb error string represents a transient, retryable
+	 * locking failure (InnoDB deadlock or lock-wait timeout).
+	 *
+	 * @param string $error The wpdb last_error string.
+	 * @return bool True when the error is a deadlock or lock-wait timeout.
+	 */
+	private static function is_deadlock_error( string $error ): bool {
+		if ( '' === $error ) {
+			return false;
+		}
+
+		return false !== stripos( $error, 'Deadlock found' )
+			|| false !== stripos( $error, 'Lock wait timeout exceeded' );
 	}
 }


### PR DESCRIPTION
## Summary

Makes all Data Machine lifecycle status transitions resilient to transient MySQL deadlocks, fixing the uncaught `RuntimeException` fatals observed on the live network (events.extrachill.com / blog 7).

Fixes #2787.

## Root cause

All status transitions — `start_job()`, `complete_job()`, `update_job_status()`, plus the tracked-item, lease, and pending-decision state machines — funnel through a single chokepoint: `LifecycleStateTransition::compare_and_set()`, which performs a guarded `$wpdb->update()`.

Under load, many Action Scheduler queue runners race to update the same status rows simultaneously. This produces transient InnoDB **deadlocks (MySQL error 1213)** and lock-wait timeouts (1205). On the live log over ~12 days this surfaced as:

- **80** deadlocks on `c8c_7_datamachine_jobs` during `Jobs->start_job()` (swallowed/retried by luck, no fatal)
- **25** deadlocks on the Action Scheduler claim query, **8 of which became fatal** `RuntimeException`s

Previously `compare_and_set()` returned `false` on deadlock with **no retry**, so a transient, recoverable condition propagated as a hard failure. MySQL's own guidance for error 1213 is *"try restarting transaction."*

## Fix

Wrap the guarded `UPDATE` in a bounded retry loop inside `compare_and_set()` — the single point every lifecycle transition already passes through, so every consumer (jobs, tracked-items, leases, pending decisions) benefits with no caller changes:

- **5 attempts max**, linear backoff (~20ms × attempt) **+ jitter** to desynchronize racing runners
- Retries **only** on deadlock / lock-wait-timeout errors (matched on `$wpdb->last_error`); any other failure returns `false` immediately as before
- Each retry logs a `warning` via `datamachine_log` with table, states, attempt count, and the DB error for observability
- Behavior on success and on non-deadlock failure is unchanged (returns `(int) $rows` or `false`)

## Why here and not in vendored Action Scheduler

AS itself is current (3.9.3, with `SKIP LOCKED`) and behaving as designed — it throws on a failed claim so the runner retries next tick. The fatals are a symptom of DM's own concurrent write contention, and the durable fix belongs in DM's own state-transition primitive, not in a Composer dependency.

## Notes / follow-ups (out of scope for this PR)

- A second, complementary lever is reducing AS queue concurrency / staggering dispatch so fewer runners contend at once — tracked in #2787 as a separate consideration.
- Worth confirming AS table retention (`wp datamachine retention run`) is trimming `actionscheduler_actions`, since a bloated actions table worsens claim-query lock contention.

## Testing

- `php -l` clean
- `phpcs` clean on the changed file