### PR TITLE
fix: retry Action Scheduler claim on transient deadlock instead of fataling

### DIFF
--- a/inc/Core/ActionScheduler/QueueTuning.php
+++ b/inc/Core/ActionScheduler/QueueTuning.php
@@ -61,8 +61,88 @@ add_action(
 		} );
 
 		datamachine_enable_cron_async_dispatch();
+		datamachine_install_deadlock_resilient_runner();
 	}
 );
+
+/**
+ * Make the Action Scheduler queue runner resilient to transient claim deadlocks.
+ *
+ * DM runs the queue runner with concurrent batches enabled (default 3) and also
+ * drops Action Scheduler's is_admin() gate on the async dispatch chain (see
+ * datamachine_enable_cron_async_dispatch()), so multiple runner processes can
+ * call ActionScheduler_DBStore::claim_actions() at the same time. That method
+ * issues an `UPDATE ... JOIN` against the actions table; when several of those
+ * run concurrently against the same hot rows, MariaDB/MySQL can return a
+ * deadlock ("Deadlock found when trying to get lock; try restarting transaction").
+ *
+ * Action Scheduler treats that as fatal: claim_actions() throws an uncaught
+ * RuntimeException from ActionScheduler_DBStore.php, which bubbles out of
+ * ActionScheduler_QueueRunner::run() and crashes the request with a PHP fatal.
+ *
+ * A deadlock is transient and retryable by design — the database itself tells us
+ * to restart the transaction. So instead of letting it become a fatal, we replace
+ * the default queue-runner callback with one that retries run() a few times with a
+ * short jittered backoff when the failure is a transient deadlock, and re-throws
+ * anything else unchanged. We cannot patch the vendored Action Scheduler library,
+ * so this guard lives in DM where it owns the runner wiring (mirroring how
+ * datamachine_enable_cron_async_dispatch() already swaps an AS shutdown callback).
+ *
+ * @since 0.153.6
+ */
+function datamachine_install_deadlock_resilient_runner(): void {
+	$runner = \ActionScheduler::runner();
+
+	// Swap AS's default `run` callback for a deadlock-resilient wrapper.
+	remove_action( 'action_scheduler_run_queue', array( $runner, 'run' ) );
+
+	add_action(
+		'action_scheduler_run_queue',
+		function ( $context = '' ) use ( $runner ) {
+			$max_attempts = 3;
+			$attempt      = 0;
+
+			while ( true ) {
+				$attempt++;
+
+				try {
+					return $runner->run( $context );
+				} catch ( \RuntimeException $e ) {
+					if ( ! datamachine_is_transient_deadlock( $e ) || $attempt >= $max_attempts ) {
+						// Not retryable, or we're out of attempts — let it surface.
+						throw $e;
+					}
+
+					// Transient deadlock: back off briefly with jitter, then retry.
+					// 50ms, 100ms (+ up to 50ms jitter) keeps us well inside the
+					// batch time limit while giving the competing transaction time
+					// to commit and release its locks.
+					$backoff_us = ( 50000 * $attempt ) + random_int( 0, 50000 );
+					usleep( $backoff_us );
+				}
+			}
+		},
+		10,
+		1
+	);
+}
+
+/**
+ * Determine whether an exception represents a transient, retryable DB deadlock.
+ *
+ * Action Scheduler surfaces the raw database error inside the RuntimeException
+ * message (see ActionScheduler_DBStore::claim_actions()), so we match on the
+ * deadlock / lock-wait signatures the database emits.
+ *
+ * @param \Throwable $e Exception thrown while claiming actions.
+ * @return bool True when the failure is a transient deadlock or lock-wait timeout.
+ */
+function datamachine_is_transient_deadlock( \Throwable $e ): bool {
+	$message = $e->getMessage();
+
+	return false !== stripos( $message, 'Deadlock found when trying to get lock' )
+		|| false !== stripos( $message, 'Lock wait timeout exceeded' );
+}
 
 /**
  * Enable async request dispatch from WP-Cron and CLI contexts.


### PR DESCRIPTION
## Summary

Fixes a live PHP fatal firing ~60/hr across the network:

```
PHP Fatal error: Uncaught RuntimeException: Unable to claim actions.
Database error: Deadlock found when trying to get lock; try restarting transaction.
in .../data-machine/vendor/woocommerce/action-scheduler/classes/data-stores/ActionScheduler_DBStore.php:1019
```

## Root cause

The fatal originates in the Action Scheduler copy **bundled inside Data Machine** (`data-machine/vendor/woocommerce/action-scheduler/`), confirmed by the full stack trace (`admin-ajax.php` → `WP_Async_Request->maybe_handle()` → `AsyncRequest_QueueRunner->handle()` → `QueueRunner->run()` → `do_batch()` → `stake_claim()` → `claim_actions()`), not the WooCommerce copy.

DM amplifies AS concurrency in `inc/Core/ActionScheduler/QueueTuning.php`:
- sets `action_scheduler_queue_runner_concurrent_batches` to **3** (AS default is 1), and
- `datamachine_enable_cron_async_dispatch()` removes AS's `is_admin()` gate so the async runner chain fires from cron/frontend shutdown too.

Result: multiple runner processes call `ActionScheduler_DBStore::claim_actions()` simultaneously. That method runs an `UPDATE ... JOIN` against the hot `actionscheduler_actions` table; concurrent UPDATEs deadlock. AS throws the deadlock as an **uncaught** `RuntimeException`, which bubbles out of `QueueRunner::run()` (hooked to `action_scheduler_run_queue`) with no handler → PHP fatal.

A deadlock is **transient and retryable** — the DB error literally says "try restarting transaction." DM increased the concurrency that causes the deadlock but never added resilience to it.

## Fix

`QueueTuning.php` now replaces the default `action_scheduler_run_queue` runner callback with a wrapper that:
- calls `$runner->run()` inside a try/catch,
- on a **transient deadlock / lock-wait timeout**, retries up to 3 times with short jittered backoff (50ms, 100ms + jitter — well inside the batch time limit),
- re-throws any non-deadlock exception unchanged.

The vendored AS library can't be patched (composer overwrites it), so the guard lives in DM, which already owns the runner wiring — this mirrors the existing `datamachine_enable_cron_async_dispatch()` that swaps an AS shutdown callback in the same `action_scheduler_init` hook.

## Verification
- Confirmed the fatal is the DM-bundled AS copy via debug.log stack trace.
- Confirmed the AS queue is ~100% `datamachine_*` workload (zero WooCommerce AS traffic).
- Confirmed `concurrent_batches=3` default in `PluginSettings::getDefaultQueueTuning()`.
- Confirmed runner `init()` registers the default `run` callback before `action_scheduler_init` fires in both web and CLI contexts, so `remove_action()` reliably removes it.
- `php -l` passes.

## Notes
- No release/deploy. No CHANGELOG edits. No version bump (homeboy owns those).