### PR TITLE
feat: throttle flow-job admission to cap Action Scheduler queue growth

### DIFF
--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -25,6 +25,19 @@ class RunFlowAbility {
 
 	use EngineHelpers;
 
+	/**
+	 * Default ceiling on in-flight (pending + processing) jobs before new
+	 * scheduler-triggered runs are deferred. Tunable via the queue_tuning
+	 * setting `max_active_jobs` or the `datamachine_max_active_jobs` filter.
+	 */
+	public const DEFAULT_MAX_ACTIVE_JOBS = 500;
+
+	/**
+	 * Default backoff (seconds) before a backpressured flow is retried.
+	 * Tunable via the `datamachine_backpressure_defer_seconds` filter.
+	 */
+	public const DEFAULT_BACKPRESSURE_DEFER_SECONDS = 60;
+
 	public function __construct() {
 		$this->initDatabases();
 
@@ -174,6 +187,20 @@ class RunFlowAbility {
 
 		// Use provided job_id or create new one (for scheduled/recurring flows).
 		if ( ! $job_id ) {
+			// Admission throttle for scheduler-triggered runs. When the queue
+			// already holds at least $max_active in-flight (pending/processing)
+			// jobs, defer this run instead of admitting another job. Each job
+			// fans out into a chain of execute_step actions, so unbounded
+			// admission is what bloats the Action Scheduler tables and starves
+			// the claim query into deadlocks. Manual/API runs (respect_paused
+			// === false, or a pre-created job_id) are never throttled.
+			if ( $respect_paused ) {
+				$defer = $this->maybeDeferForBackpressure( $flow_id );
+				if ( null !== $defer ) {
+					return $defer;
+				}
+			}
+
 			$job_data = array(
 				'pipeline_id' => $pipeline_id,
 				'flow_id'     => $flow_id,
@@ -363,6 +390,121 @@ class RunFlowAbility {
 			'job_id'     => $job_id,
 			'first_step' => $first_flow_step_id,
 		);
+	}
+
+	/**
+	 * Defer a scheduler-triggered run when the queue is already saturated.
+	 *
+	 * Reads the in-flight (pending + processing) job count and compares it to
+	 * the configured ceiling. When at or over the ceiling, reschedules
+	 * `datamachine_run_flow_now` for this flow a short, jittered delay later
+	 * and returns a skip result so no new job is admitted. Below the ceiling
+	 * (or when throttling is disabled with a ceiling <= 0) returns null and the
+	 * caller proceeds to admit the job normally.
+	 *
+	 * The jittered backoff prevents a thundering-herd re-stampede where every
+	 * deferred flow wakes at the same instant and saturates the queue again.
+	 *
+	 * @param int $flow_id Flow being scheduled.
+	 * @return array{success:bool,flow_id:int,job_id:null,skipped:bool,reason:string}|null
+	 *               Skip result when deferred, or null to proceed.
+	 */
+	private function maybeDeferForBackpressure( int $flow_id ): ?array {
+		$max_active = self::maxActiveJobs();
+		if ( $max_active <= 0 ) {
+			return null;
+		}
+
+		$active = $this->db_jobs->count_active_jobs();
+		if ( $active < $max_active ) {
+			return null;
+		}
+
+		$delay = self::backpressureDeferSeconds( $flow_id );
+
+		if ( function_exists( 'as_schedule_single_action' ) ) {
+			// Only enqueue a deferral tick if one is not already pending for
+			// this flow, so repeated saturated cycles don't pile up duplicate
+			// wake-ups for the same flow.
+			$already_pending = function_exists( 'as_next_scheduled_action' )
+				&& false !== as_next_scheduled_action( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
+
+			if ( ! $already_pending ) {
+				as_schedule_single_action(
+					time() + $delay,
+					'datamachine_run_flow_now',
+					array( $flow_id ),
+					'data-machine'
+				);
+			}
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Flow execution deferred - queue backpressure',
+			array(
+				'flow_id'       => $flow_id,
+				'active_jobs'   => $active,
+				'max_active'    => $max_active,
+				'defer_seconds' => $delay,
+				'reason'        => 'queue_backpressure',
+			)
+		);
+
+		return array(
+			'success' => true,
+			'flow_id' => $flow_id,
+			'job_id'  => null,
+			'skipped' => true,
+			'reason'  => 'queue_backpressure',
+		);
+	}
+
+	/**
+	 * Resolve the maximum number of in-flight jobs before new scheduler-
+	 * triggered runs are deferred.
+	 *
+	 * Reads queue_tuning.max_active_jobs and runs it through the
+	 * `datamachine_max_active_jobs` filter. A value of 0 (or less) disables
+	 * admission throttling entirely (the prior unbounded behavior).
+	 *
+	 * @return int Ceiling on in-flight jobs (0 disables throttling).
+	 */
+	private static function maxActiveJobs(): int {
+		$tuning  = \DataMachine\Core\PluginSettings::get( 'queue_tuning', array() );
+		$default = ( is_array( $tuning ) && isset( $tuning['max_active_jobs'] ) )
+			? (int) $tuning['max_active_jobs']
+			: self::DEFAULT_MAX_ACTIVE_JOBS;
+
+		/**
+		 * Filter the in-flight job ceiling used for scheduler admission control.
+		 *
+		 * @param int $default The resolved ceiling. 0 (or less) disables throttling.
+		 */
+		$max = (int) apply_filters( 'datamachine_max_active_jobs', $default );
+
+		return $max > 0 ? $max : 0;
+	}
+
+	/**
+	 * Resolve the deferral backoff (seconds) for a backpressured flow, with
+	 * deterministic per-flow jitter to avoid a synchronized re-stampede.
+	 *
+	 * @param int $flow_id Flow being deferred (used as the jitter seed).
+	 * @return int Delay in seconds (always >= 1).
+	 */
+	private static function backpressureDeferSeconds( int $flow_id ): int {
+		$base = (int) apply_filters( 'datamachine_backpressure_defer_seconds', self::DEFAULT_BACKPRESSURE_DEFER_SECONDS );
+		if ( $base < 1 ) {
+			$base = self::DEFAULT_BACKPRESSURE_DEFER_SECONDS;
+		}
+
+		// Deterministic jitter in [0, base) spreads deferred flows across the
+		// window instead of waking them all at base seconds.
+		$jitter = absint( crc32( 'dm_backpressure_' . $flow_id ) ) % $base;
+
+		return $base + $jitter;
 	}
 
 	/**

--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -132,8 +132,9 @@ class SettingsAbilities {
 						'ai_provider_keys'               => array( 'type' => 'object' ),
 						'queue_tuning'                   => array(
 							'type'        => 'object',
-							'description' => 'Queue tuning — producer side (chunk_size/chunk_delay control how DM creates child jobs) and consumer side (concurrent_batches/batch_size/time_limit control how Action Scheduler drains them).',
+							'description' => 'Queue tuning — admission side (max_active_jobs caps how many in-flight jobs DM admits before deferring new scheduler runs), producer side (chunk_size/chunk_delay control how DM creates child jobs) and consumer side (concurrent_batches/batch_size/time_limit control how Action Scheduler drains them).',
 							'properties'  => array(
+								'max_active_jobs'    => array( 'type' => 'integer' ),
 								'concurrent_batches' => array( 'type' => 'integer' ),
 								'batch_size'         => array( 'type' => 'integer' ),
 								'time_limit'         => array( 'type' => 'integer' ),
@@ -559,6 +560,12 @@ class SettingsAbilities {
 		// Queue tuning settings for Action Scheduler
 		if ( isset( $input['queue_tuning'] ) && is_array( $input['queue_tuning'] ) ) {
 			$tuning = wp_parse_args( $all_settings['queue_tuning'] ?? array(), PluginSettings::getDefaultQueueTuning() );
+
+			if ( isset( $input['queue_tuning']['max_active_jobs'] ) ) {
+				// 0 disables admission throttling; otherwise clamp to a sane ceiling.
+				$max_active                = absint( $input['queue_tuning']['max_active_jobs'] );
+				$tuning['max_active_jobs'] = min( PluginSettings::MAX_QUEUE_MAX_ACTIVE_JOBS, $max_active );
+			}
 
 			if ( isset( $input['queue_tuning']['concurrent_batches'] ) ) {
 				$batches                      = absint( $input['queue_tuning']['concurrent_batches'] );

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -439,6 +439,33 @@ class Jobs extends BaseRepository {
 	}
 
 	/**
+	 * Count in-flight (non-terminal) jobs.
+	 *
+	 * "In-flight" means a job that Action Scheduler is still fanning out work
+	 * for: pending (admitted, first step not yet scheduled) or processing
+	 * (executing steps). This is the load the scheduler must throttle against
+	 * — every in-flight job spawns a chain of `datamachine_execute_step`
+	 * actions, so admitting an unbounded number of them is what bloats the
+	 * Action Scheduler tables and deadlocks the claim query.
+	 *
+	 * Deliberately a single cheap COUNT over an indexed status column — it
+	 * never hydrates or decodes the heavy engine_data blob.
+	 *
+	 * @return int Number of pending + processing jobs.
+	 */
+	public function count_active_jobs(): int {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return (int) $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				'SELECT COUNT(job_id) FROM %i WHERE status IN (%s, %s)',
+				$this->table_name,
+				'pending',
+				'processing'
+			)
+		);
+	}
+
+	/**
 	 * Get memory-safe aggregate job summary counts.
 	 *
 	 * Uses grouped SQL queries so operator dashboards can inspect large job

--- a/inc/Core/PluginSettings.php
+++ b/inc/Core/PluginSettings.php
@@ -30,6 +30,7 @@ class PluginSettings {
 	public const MAX_QUEUE_TIME_LIMIT                  = 300;
 	public const MAX_QUEUE_CHUNK_SIZE                  = 500;
 	public const MAX_QUEUE_CHUNK_DELAY                 = 300;
+	public const MAX_QUEUE_MAX_ACTIVE_JOBS             = 100000;
 	public const DEFAULT_WP_AI_CLIENT_CONNECT_TIMEOUT  = 15.0;
 	public const DEFAULT_WP_AI_CLIENT_REQUEST_TIMEOUT  = 300.0;
 	public const MAX_WP_AI_CLIENT_CONNECT_TIMEOUT      = 300.0;
@@ -41,7 +42,12 @@ class PluginSettings {
 	/**
 	 * Get default queue tuning values.
 	 *
-	 * Five knobs across two layers:
+	 * Six knobs across three layers:
+	 *
+	 *   Admission side (RunFlowAbility — whether DM admits a new flow job):
+	 *     - max_active_jobs: ceiling on in-flight (pending + processing) jobs
+	 *                        before scheduler-triggered runs are deferred.
+	 *                        0 disables admission throttling.
 	 *
 	 *   Producer side (BatchScheduler — how DM creates child jobs):
 	 *     - chunk_size:  child jobs created per scheduling cycle
@@ -52,10 +58,11 @@ class PluginSettings {
 	 *     - batch_size:         actions claimed per AS batch
 	 *     - time_limit:         seconds per AS batch
 	 *
-	 * @return array{concurrent_batches:int,batch_size:int,time_limit:int,chunk_size:int,chunk_delay:int}
+	 * @return array{max_active_jobs:int,concurrent_batches:int,batch_size:int,time_limit:int,chunk_size:int,chunk_delay:int}
 	 */
 	public static function getDefaultQueueTuning(): array {
 		return array(
+			'max_active_jobs'    => \DataMachine\Abilities\Engine\RunFlowAbility::DEFAULT_MAX_ACTIVE_JOBS,
 			'concurrent_batches' => 3,
 			'batch_size'         => 25,
 			'time_limit'         => 60,

--- a/tests/Unit/Abilities/Engine/RunFlowAbilityLifecycleTest.php
+++ b/tests/Unit/Abilities/Engine/RunFlowAbilityLifecycleTest.php
@@ -80,6 +80,98 @@ class RunFlowAbilityLifecycleTest extends WP_UnitTestCase {
 		$this->assertSame( JobStatus::failed( 'no_first_step' )->toString(), $job['status'] ?? '' );
 	}
 
+	public function test_scheduler_run_is_deferred_when_active_jobs_exceed_ceiling(): void {
+		$jobs = new Jobs();
+
+		// Saturate the queue with in-flight (pending) jobs.
+		$jobs->create_job( array( 'source' => 'pipeline', 'label' => 'inflight 1' ) );
+		$jobs->create_job( array( 'source' => 'pipeline', 'label' => 'inflight 2' ) );
+
+		$pipeline_id = ( new Pipelines() )->create_pipeline(
+			array(
+				'pipeline_name'   => 'Backpressure Pipeline',
+				'pipeline_config' => array(),
+				'user_id'         => get_current_user_id(),
+			)
+		);
+		$flow_id = ( new Flows() )->create_flow(
+			array(
+				'pipeline_id'       => $pipeline_id,
+				'flow_name'         => 'Backpressure Flow',
+				'flow_config'       => array(),
+				'scheduling_config' => array( 'enabled' => true ),
+				'user_id'           => get_current_user_id(),
+			)
+		);
+		$this->assertIsInt( $flow_id );
+
+		$jobs_before = $jobs->count_active_jobs();
+
+		// Force the ceiling below the current in-flight count so the next
+		// scheduler-triggered run must defer.
+		$cap = static fn() => 1;
+		add_filter( 'datamachine_max_active_jobs', $cap );
+
+		$result = ( new RunFlowAbility() )->execute(
+			array(
+				'flow_id'        => $flow_id,
+				'respect_paused' => true,
+			)
+		);
+
+		remove_filter( 'datamachine_max_active_jobs', $cap );
+
+		$this->assertTrue( $result['success'] ?? false );
+		$this->assertTrue( $result['skipped'] ?? false );
+		$this->assertSame( 'queue_backpressure', $result['reason'] ?? '' );
+		$this->assertNull( $result['job_id'] ?? 'unset' );
+
+		// No new job was admitted.
+		$this->assertSame( $jobs_before, $jobs->count_active_jobs() );
+		$this->assertSame( array(), $this->scheduled_steps );
+	}
+
+	public function test_throttling_disabled_when_ceiling_is_zero(): void {
+		$jobs = new Jobs();
+		$jobs->create_job( array( 'source' => 'pipeline', 'label' => 'inflight a' ) );
+		$jobs->create_job( array( 'source' => 'pipeline', 'label' => 'inflight b' ) );
+
+		$pipeline_id = ( new Pipelines() )->create_pipeline(
+			array(
+				'pipeline_name'   => 'No Throttle Pipeline',
+				'pipeline_config' => array(),
+				'user_id'         => get_current_user_id(),
+			)
+		);
+		$flow_id = ( new Flows() )->create_flow(
+			array(
+				'pipeline_id'       => $pipeline_id,
+				'flow_name'         => 'No Throttle Flow',
+				'flow_config'       => array(),
+				'scheduling_config' => array( 'enabled' => true ),
+				'user_id'           => get_current_user_id(),
+			)
+		);
+
+		// 0 disables admission throttling — the run proceeds and admits a job
+		// (it will fail later on no_first_step, but a job_id is created, proving
+		// admission was not deferred).
+		$cap = static fn() => 0;
+		add_filter( 'datamachine_max_active_jobs', $cap );
+
+		$result = ( new RunFlowAbility() )->execute(
+			array(
+				'flow_id'        => $flow_id,
+				'respect_paused' => true,
+			)
+		);
+
+		remove_filter( 'datamachine_max_active_jobs', $cap );
+
+		$this->assertNotSame( 'queue_backpressure', $result['reason'] ?? '' );
+		$this->assertIsInt( $result['job_id'] ?? null );
+	}
+
 	public function test_completed_parent_run_result_includes_available_child_envelopes(): void {
 		$jobs = new Jobs();
 

--- a/tests/Unit/Abilities/Engine/RunFlowAbilityLifecycleTest.php
+++ b/tests/Unit/Abilities/Engine/RunFlowAbilityLifecycleTest.php
@@ -124,7 +124,12 @@ class RunFlowAbilityLifecycleTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['success'] ?? false );
 		$this->assertTrue( $result['skipped'] ?? false );
 		$this->assertSame( 'queue_backpressure', $result['reason'] ?? '' );
-		$this->assertNull( $result['job_id'] ?? 'unset' );
+		// On a backpressure defer the result carries an explicit null job_id
+		// (no job admitted). Assert the key exists and is null directly — the
+		// `?? 'unset'` idiom would coerce a legitimate null into the default
+		// and make assertNull() impossible to satisfy.
+		$this->assertArrayHasKey( 'job_id', $result );
+		$this->assertNull( $result['job_id'] );
 
 		// No new job was admitted.
 		$this->assertSame( $jobs_before, $jobs->count_active_jobs() );


### PR DESCRIPTION
## Summary

Caps how many flow jobs Data Machine admits at once so a site with many due flows can't stampede the Action Scheduler queue. This is the **root-cause fix** for the runaway `actionscheduler_actions` bloat behind the live `claim_actions` deadlock fatals on events.extrachill.com.

## Why

A live investigation found `c8c_7_actionscheduler_actions` at **25.2M rows / 21.6 GB** (plus `actionscheduler_logs` at 76.4M rows / 9 GB) on a single subsite, with `datamachine_execute_step` completing at **~90/sec** sustained. All `complete` rows were <8 days old — the table grew ~3M rows/day.

Root cause chain:
- The scheduler fires `datamachine_run_flow_now` per due flow; with **670 venue-scraper flows**, many come due in clusters.
- `RunFlowAbility` admitted a **new job for every due flow unconditionally** — no admission control.
- Each job fans out into a chain of `datamachine_execute_step` actions, so unbounded admission balloons the AS tables faster than retention can prune them.
- Retention's batched deletes then contend with `claim_actions`' `UPDATE ... JOIN` on the 21GB table → InnoDB deadlock. (The deadlock→fatal handling itself was already fixed separately in #2789 / `datamachine_install_deadlock_resilient_runner`; this PR attacks the *generation* side that makes the table huge in the first place.)

## What changed

- **`Jobs::count_active_jobs()`** — cheap indexed `COUNT` of `pending` + `processing` jobs. Never hydrates/decodes `engine_data`.
- **`RunFlowAbility`** — before creating a **new scheduler-triggered job** (`respect_paused === true`, no pre-created `job_id`), compare in-flight jobs against a configurable ceiling. When saturated, **defer** by rescheduling `datamachine_run_flow_now` with a deterministic jittered backoff (and a dedup guard so saturated cycles don't pile up duplicate wake-ups) instead of admitting another job. Manual/API runs are never throttled.
- **Config surface:** new `queue_tuning.max_active_jobs` setting (default **500**; `0` disables throttling) wired through `PluginSettings` defaults + `SettingsAbilities` schema/save with a clamp. Two filters: `datamachine_max_active_jobs` and `datamachine_backpressure_defer_seconds`.
- **Tests:** added coverage for defer-on-saturation and disabled-when-zero to `RunFlowAbilityLifecycleTest`.

## Behavior

- **Steady state unaffected** when in-flight jobs stay under the ceiling — zero added overhead beyond one cheap COUNT per scheduler-triggered admission.
- **Under load**, excess flows defer and retry on a jittered backoff instead of flooding the queue. The AS table can then be drained/pruned faster than it grows.
- **Opt-out**: set `max_active_jobs` to `0` to restore prior unbounded behavior.

## Verification

- `php -l` clean on all changed files.
- `phpcs` clean (exit 0) on all changed files.
- Full PHPUnit suite deferred to CI — the local box was too warm to run `homeboy test` (the very AS churn this PR addresses pushed load to ~8.8).

## Notes

- The 30GB of already-accumulated rows on the affected subsite is an operational cleanup (queue drain + retention/OPTIMIZE), separate from this code fix.