### PR TITLE
fix: make AS deadlock-resilient runner idempotent and widen retry budget

### DIFF
--- a/inc/Core/ActionScheduler/QueueTuning.php
+++ b/inc/Core/ActionScheduler/QueueTuning.php
@@ -82,15 +82,40 @@ add_action(
  *
  * A deadlock is transient and retryable by design — the database itself tells us
  * to restart the transaction. So instead of letting it become a fatal, we replace
- * the default queue-runner callback with one that retries run() a few times with a
- * short jittered backoff when the failure is a transient deadlock, and re-throws
- * anything else unchanged. We cannot patch the vendored Action Scheduler library,
- * so this guard lives in DM where it owns the runner wiring (mirroring how
+ * the default queue-runner callback with one that retries run() with an
+ * exponential, jittered backoff when the failure is a transient deadlock, and
+ * re-throws anything else unchanged. We cannot patch the vendored Action Scheduler
+ * library, so this guard lives in DM where it owns the runner wiring (mirroring how
  * datamachine_enable_cron_async_dispatch() already swaps an AS shutdown callback).
+ *
+ * Two correctness details this function has to get right:
+ *
+ *  1. Idempotency. `action_scheduler_init` can fire more than once in a request
+ *     (notably on multisite, where AS may initialize across switch_to_blog()
+ *     contexts). Without a guard, each fire would stack another wrapper closure on
+ *     `action_scheduler_run_queue` — the queue would then run two-plus times per
+ *     dispatch, multiplying the concurrent claim_actions() pressure that causes the
+ *     deadlock in the first place. A static guard makes the swap happen once per
+ *     request.
+ *
+ *  2. Sufficient retry budget. Under concurrent batches (default 3) the same hot
+ *     rows can deadlock several times in quick succession, so a 3-attempt /
+ *     ~150ms-ceiling budget can still exhaust and surface the fatal. We widen the
+ *     budget to 5 attempts with exponential backoff (up to ~800ms + jitter), which
+ *     stays well inside the batch time limit while giving competing transactions
+ *     room to commit and release their locks.
  *
  * @since 0.153.6
  */
 function datamachine_install_deadlock_resilient_runner(): void {
+	static $installed = false;
+
+	// `action_scheduler_init` can fire multiple times per request; only swap once.
+	if ( $installed ) {
+		return;
+	}
+	$installed = true;
+
 	$runner = \ActionScheduler::runner();
 
 	// Swap AS's default `run` callback for a deadlock-resilient wrapper.
@@ -99,7 +124,7 @@ function datamachine_install_deadlock_resilient_runner(): void {
 	add_action(
 		'action_scheduler_run_queue',
 		function ( $context = '' ) use ( $runner ) {
-			$max_attempts = 3;
+			$max_attempts = 5;
 			$attempt      = 0;
 
 			while ( true ) {
@@ -113,11 +138,12 @@ function datamachine_install_deadlock_resilient_runner(): void {
 						throw $e;
 					}
 
-					// Transient deadlock: back off briefly with jitter, then retry.
-					// 50ms, 100ms (+ up to 50ms jitter) keeps us well inside the
-					// batch time limit while giving the competing transaction time
-					// to commit and release its locks.
-					$backoff_us = ( 50000 * $attempt ) + random_int( 0, 50000 );
+					// Transient deadlock: back off with exponential, jittered delay,
+					// then retry. 50/100/200/400ms (+ up to 50ms jitter) caps total
+					// backoff under ~1s — comfortably inside the batch time limit —
+					// while giving the competing transaction time to commit and
+					// release its locks.
+					$backoff_us = ( 50000 * ( 2 ** ( $attempt - 1 ) ) ) + random_int( 0, 50000 );
 					usleep( $backoff_us );
 				}
 			}


### PR DESCRIPTION
## Summary

PHP fatals from `ActionScheduler_DBStore::claim_actions()` — `Uncaught RuntimeException: Unable to claim actions. Database error: Deadlock found when trying to get lock; try restarting transaction` (`ActionScheduler_DBStore.php:1019`) — were **still firing on the live network** after the first deadlock-resilience pass (#2789, shipped in 0.153.8 and deployed ~04:14 UTC). Confirmed actively firing post-deploy (05:45, 06:19, 07:20, 08:31, 09:47, **10:09 UTC**), ~1–3/hr.

Live diagnosis on the deployed install found two reasons #2789's wrapper wasn't fully holding:

1. **The runner swap was not idempotent.** Inspecting `$wp_filter['action_scheduler_run_queue']` on the live site showed **two** wrapper closures registered, not one. `action_scheduler_init` can fire more than once per request (multisite, across `switch_to_blog()` contexts), and each fire stacked another wrapper. Two wrappers ⇒ the queue runner runs twice per dispatch ⇒ **doubled** concurrent `claim_actions()` pressure — directly feeding the deadlock the wrapper is meant to absorb.

2. **The retry budget was too small.** Under concurrent batches (default 3), the same hot rows can deadlock several times in quick succession. The original 3-attempt / ~150ms-ceiling budget could exhaust and re-throw, surfacing the fatal. (The exception trace points at the original `claim_actions` throw site after the final re-throw, which is why it looks like the raw callback — it's actually the wrapper exhausting its budget.)

## Fix

- **Idempotency:** per-process `static` guard so the AS `run` → resilient-wrapper swap happens exactly once per request, regardless of how many times `action_scheduler_init` fires.
- **Retry budget:** widen to **5 attempts** with **exponential, jittered backoff** (50/100/200/400ms + jitter, total capped under ~1s — comfortably inside the batch time limit), giving competing transactions room to commit and release locks.

Both changes live entirely in `inc/Core/ActionScheduler/QueueTuning.php` (DM owns the runner wiring; the vendored AS library is not patched). Non-deadlock `RuntimeException`s still surface immediately; the deadlock-only retry path is unchanged in spirit, just made correct and sufficient.

## Verification

A standalone hook/runner harness (mirroring WP's `add_action`/`remove_action`/`do_action` and a fake AS runner) confirms:

- double `action_scheduler_init` → **exactly 1** callback on `action_scheduler_run_queue` (reproduces and fixes the live double-registration)
- 4 consecutive deadlocks → recovers across 5 attempts, **no fatal**
- 5 consecutive deadlocks → budget exhausts and surfaces (no infinite loop)
- non-deadlock `RuntimeException` → surfaces immediately (no inappropriate retry)

`php -l` clean.

## Notes

- Diagnosed live: `concurrent_batches=3` is active; fatal rate dropped after #2789 (8→6/hr pre-deploy vs 1–3/hr post-deploy) but did not reach zero — consistent with "wrapper installed but doubled + under-budgeted."
- Builds on #2789 (already merged); this is the follow-up that closes the remaining fatals.