### PR TITLE
feat: bound Action Scheduler tables with row-count ceiling + frequent retention

### DIFF
--- a/inc/Cli/Commands/RetentionCommand.php
+++ b/inc/Cli/Commands/RetentionCommand.php
@@ -210,12 +210,23 @@ class RetentionCommand extends BaseCommand {
 			$hook_windows[] = sprintf( '%s=%s', $hook, $this->format_days( $days ) );
 		}
 
+		$hook_ceilings = array();
+		foreach ( RetentionCleanup::actionSchedulerHookMaxRows() as $hook => $max_rows ) {
+			$hook_ceilings[] = sprintf( '%s=%s rows', $hook, number_format_i18n( $max_rows ) );
+		}
+
 		WP_CLI::log( '' );
 		WP_CLI::log( sprintf( 'Global window:   %d days', RetentionCleanup::actionSchedulerMaxAgeDays() ) );
 		WP_CLI::log(
 			sprintf(
 				'Per-hook window: %s',
 				empty( $hook_windows ) ? '(none)' : implode( ', ', $hook_windows )
+			)
+		);
+		WP_CLI::log(
+			sprintf(
+				'Per-hook ceiling: %s',
+				empty( $hook_ceilings ) ? '(none)' : implode( ', ', $hook_ceilings )
 			)
 		);
 		WP_CLI::log( sprintf( 'Batch size:      %d rows/iteration', RetentionCleanup::actionSchedulerBatchSize() ) );

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -218,15 +218,20 @@ class SystemAgentServiceProvider {
 					'label'           => 'Daily processed-items cleanup',
 				)
 			),
-			RetentionCleanup::TASK_AS_ACTIONS      => array_merge(
-				$daily_first_run,
-				array(
-					'task_type'       => RetentionCleanup::TASK_AS_ACTIONS,
-					'interval'        => 'daily',
-					'enabled_setting' => 'retention_as_actions_enabled',
-					'default_enabled' => true,
-					'label'           => 'Daily Action Scheduler action cleanup',
-				)
+			// Action Scheduler actions are the highest-churn table on busy
+			// installs: a single step-execution fan-out can add millions of
+			// completed rows per day (~tens per second). A once-daily,
+			// time-boxed pass deletes far fewer rows than accrue between runs,
+			// so the table grows without bound. Run this one on a short cadence
+			// so cleanup chips continuously and keeps pace with generation.
+			RetentionCleanup::TASK_AS_ACTIONS      => array(
+				'task_type'          => RetentionCleanup::TASK_AS_ACTIONS,
+				'interval'           => 'every_5_minutes',
+				'enabled_setting'    => 'retention_as_actions_enabled',
+				'default_enabled'    => true,
+				'label'              => 'Action Scheduler action cleanup (high-frequency)',
+				'first_run_callback' => 'strtotime',
+				'first_run_arg'      => '+5 minutes',
 			),
 			RetentionCleanup::TASK_STALE_CLAIMS    => array_merge(
 				$daily_first_run,

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -686,7 +686,7 @@ class RetentionCleanup {
 		// a hook beyond its cap regardless of age, so the table is physically
 		// bounded by generation spikes. Shares the same batch + iteration +
 		// wall-clock budget as the age passes.
-		$ceiling = self::enforceActionSchedulerRowCeilings(
+		$ceiling          = self::enforceActionSchedulerRowCeilings(
 			$actions_table,
 			$logs_table,
 			$batch_size,

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -96,9 +96,12 @@ class RetentionCleanup {
 	 */
 	public static function actionSchedulerHookMaxAgeDays(): array {
 		$defaults = array(
-			// Completed step-execution actions are pure fan-out noise after a
-			// few hours; prune them aggressively (6h) to cap steady-state rows.
-			'datamachine_execute_step' => 0.25,
+			// Completed step-execution actions are pure fan-out noise almost
+			// immediately; at tens of completions per second even a few hours
+			// is millions of rows. Prune them within ~1h to cap steady-state
+			// rows. The row-count ceiling (see actionSchedulerHookMaxRows)
+			// bounds the table regardless of generation rate as a backstop.
+			'datamachine_execute_step' => 1 / 24,
 		);
 
 		$overrides = apply_filters( 'datamachine_as_actions_hook_max_age_days', $defaults );
@@ -116,6 +119,54 @@ class RetentionCleanup {
 			$days = (float) $days;
 			if ( $days > 0 ) {
 				$normalized[ $hook ] = $days;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Per-hook hard row-count ceilings for completed Action Scheduler actions.
+	 *
+	 * Age-based windows alone cannot bound a table when generation outruns the
+	 * cleanup cadence: a burst of step-execution fan-out can add rows faster
+	 * than any time-boxed pass deletes them, so the table grows without bound
+	 * between runs no matter how short the age window is. A row-count ceiling
+	 * is the backstop — it deletes the OLDEST completed/terminal rows for a
+	 * hook beyond the cap regardless of their age, so the table is physically
+	 * bounded by generation-rate spikes.
+	 *
+	 * Returns a map of `hook => max_rows`. A value of `0` (or less) disables
+	 * the ceiling for that hook (age windows still apply). Defaults cap the
+	 * known high-churn step-execution hook; operators can tune or extend via
+	 * the filter.
+	 *
+	 * @return array<string, int> Map of hook name to max retained completed rows.
+	 */
+	public static function actionSchedulerHookMaxRows(): array {
+		$defaults = array(
+			// Keep at most ~100k completed step-execution rows. At tens of
+			// completions/second this is well under an hour of history — more
+			// than enough for diagnostics — while guaranteeing the table can
+			// never balloon into the millions during a generation spike.
+			'datamachine_execute_step' => 100000,
+		);
+
+		$overrides = apply_filters( 'datamachine_as_actions_hook_max_rows', $defaults );
+
+		if ( ! is_array( $overrides ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $overrides as $hook => $max_rows ) {
+			if ( ! is_string( $hook ) || '' === $hook ) {
+				continue;
+			}
+
+			$max_rows = (int) $max_rows;
+			if ( $max_rows > 0 ) {
+				$normalized[ $hook ] = $max_rows;
 			}
 		}
 
@@ -629,6 +680,24 @@ class RetentionCleanup {
 			);
 		}
 
+		// Hard row-count ceiling per high-churn hook. Age windows above can
+		// leave the table unbounded when generation outruns the cleanup
+		// cadence; this backstop deletes the OLDEST completed/terminal rows for
+		// a hook beyond its cap regardless of age, so the table is physically
+		// bounded by generation spikes. Shares the same batch + iteration +
+		// wall-clock budget as the age passes.
+		$ceiling = self::enforceActionSchedulerRowCeilings(
+			$actions_table,
+			$logs_table,
+			$batch_size,
+			$max_iterations,
+			$deadline,
+			$iterations_used,
+			$hit_limit
+		);
+		$actions_deleted += $ceiling['actions_deleted'];
+		$logs_deleted    += $ceiling['logs_deleted'];
+
 		$total_deleted = $logs_deleted + $actions_deleted;
 
 		// InnoDB never returns DELETE-freed space to the OS; only a table
@@ -645,26 +714,123 @@ class RetentionCleanup {
 			self::log(
 				'Scheduled cleanup: deleted old Action Scheduler actions and logs',
 				array(
-					'actions_deleted' => $actions_deleted,
-					'logs_deleted'    => $logs_deleted,
-					'max_age_days'    => $max_age_days,
-					'batch_size'      => $batch_size,
-					'iterations'      => $iterations_used,
-					'hit_limit'       => $hit_limit,
-					'optimized'       => $optimized,
+					'actions_deleted'         => $actions_deleted,
+					'logs_deleted'            => $logs_deleted,
+					'ceiling_actions_deleted' => $ceiling['actions_deleted'],
+					'ceiling_logs_deleted'    => $ceiling['logs_deleted'],
+					'max_age_days'            => $max_age_days,
+					'batch_size'              => $batch_size,
+					'iterations'              => $iterations_used,
+					'hit_limit'               => $hit_limit,
+					'optimized'               => $optimized,
 				)
 			);
 		}
 
 		return array(
-			'deleted'         => $total_deleted,
+			'deleted'                 => $total_deleted,
+			'actions_deleted'         => $actions_deleted,
+			'logs_deleted'            => $logs_deleted,
+			'ceiling_actions_deleted' => $ceiling['actions_deleted'],
+			'ceiling_logs_deleted'    => $ceiling['logs_deleted'],
+			'max_age_days'            => $max_age_days,
+			'batch_size'              => $batch_size,
+			'iterations'              => $iterations_used,
+			'hit_limit'               => $hit_limit,
+			'optimized'               => $optimized,
+		);
+	}
+
+	/**
+	 * Enforce per-hook hard row-count ceilings for completed actions.
+	 *
+	 * For each hook with a configured ceiling, deletes the oldest completed/
+	 * failed/canceled rows (and their FK-child logs) that sit beyond the cap —
+	 * regardless of age. "Oldest beyond cap" is computed by keeping the most
+	 * recent $max_rows rows (by last_attempt_gmt) and deleting everything older
+	 * for that hook. Shares the caller's batch/iteration/wall-clock budget.
+	 *
+	 * @param string $actions_table   Actions table name.
+	 * @param string $logs_table      Logs table name.
+	 * @param int    $batch_size      Rows per batch.
+	 * @param int    $max_iterations  Hard iteration ceiling (shared budget).
+	 * @param float  $deadline        Wall-clock deadline (microtime float).
+	 * @param int    $iterations_used Shared iteration counter (by reference).
+	 * @param bool   $hit_limit       Set true when a budget cap trips (by reference).
+	 * @return array{actions_deleted:int,logs_deleted:int}
+	 */
+	private static function enforceActionSchedulerRowCeilings(
+		string $actions_table,
+		string $logs_table,
+		int $batch_size,
+		int $max_iterations,
+		float $deadline,
+		int &$iterations_used,
+		bool &$hit_limit
+	): array {
+		global $wpdb;
+
+		$actions_deleted = 0;
+		$logs_deleted    = 0;
+
+		foreach ( self::actionSchedulerHookMaxRows() as $hook => $max_rows ) {
+			if ( $iterations_used >= $max_iterations || microtime( true ) >= $deadline ) {
+				$hit_limit = true;
+				break;
+			}
+
+			// Resolve the cutoff timestamp that keeps the most recent $max_rows
+			// completed/terminal rows for this hook. Everything at or older than
+			// the cutoff is deleted. One bounded OFFSET probe per hook (indexed
+			// on hook + last_attempt_gmt) — cheap relative to the delete loop.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$cutoff = $wpdb->get_var(
+				$wpdb->prepare(
+					'SELECT last_attempt_gmt FROM %i WHERE status IN (%s, %s, %s) AND hook = %s ORDER BY last_attempt_gmt DESC LIMIT 1 OFFSET %d',
+					$actions_table,
+					'complete',
+					'failed',
+					'canceled',
+					$hook,
+					$max_rows
+				)
+			);
+
+			// Fewer than $max_rows rows exist for this hook — nothing to cap.
+			if ( null === $cutoff || '' === $cutoff ) {
+				continue;
+			}
+
+			// Logs first (FK children), then the actions themselves. Reuse the
+			// shared batched id-subquery deleters with this hook's ceiling
+			// cutoff so all the budget/lock-safety guarantees carry over.
+			$logs_deleted += self::deleteActionSchedulerLogsBatched(
+				$logs_table,
+				$actions_table,
+				$cutoff,
+				$hook,
+				$batch_size,
+				$max_iterations,
+				$deadline,
+				$iterations_used,
+				$hit_limit
+			);
+
+			$actions_deleted += self::deleteActionSchedulerActionsBatched(
+				$actions_table,
+				$cutoff,
+				$hook,
+				$batch_size,
+				$max_iterations,
+				$deadline,
+				$iterations_used,
+				$hit_limit
+			);
+		}
+
+		return array(
 			'actions_deleted' => $actions_deleted,
 			'logs_deleted'    => $logs_deleted,
-			'max_age_days'    => $max_age_days,
-			'batch_size'      => $batch_size,
-			'iterations'      => $iterations_used,
-			'hit_limit'       => $hit_limit,
-			'optimized'       => $optimized,
 		);
 	}
 

--- a/tests/retention-action-scheduler-batching-smoke.php
+++ b/tests/retention-action-scheduler-batching-smoke.php
@@ -97,7 +97,23 @@ namespace {
 	);
 	assert_batching(
 		'default per-hook override targets execute_step',
-		str_contains( $cleanup, "'datamachine_execute_step' => 0.25" )
+		str_contains( $cleanup, "'datamachine_execute_step' => 1 / 24" )
+	);
+	assert_batching(
+		'per-hook row-count ceiling is filterable',
+		str_contains( $cleanup, "apply_filters( 'datamachine_as_actions_hook_max_rows'" )
+	);
+	assert_batching(
+		'default row-count ceiling targets execute_step',
+		str_contains( $cleanup, "'datamachine_execute_step' => 100000" )
+	);
+	assert_batching(
+		'ceiling probe selects cutoff via OFFSET on max_rows',
+		str_contains( $cleanup, 'ORDER BY last_attempt_gmt DESC LIMIT 1 OFFSET %d' )
+	);
+	assert_batching(
+		'ceiling enforcement is wired into the cleanup pass',
+		str_contains( $cleanup, 'enforceActionSchedulerRowCeilings' )
 	);
 	assert_batching(
 		'iteration + runtime safety caps exist',
@@ -151,9 +167,30 @@ namespace {
 			);
 		}
 
-		public function get_var( $prepared ): int {
-			$sql    = $prepared['sql'];
-			$args   = $prepared['args'];
+		public function get_var( $prepared ) {
+			$sql  = $prepared['sql'];
+			$args = $prepared['args'];
+
+			// Row-count ceiling probe: return the last_attempt_gmt at OFFSET
+			// $max_rows among the most-recent completed/terminal rows for the
+			// hook (or null when fewer than $max_rows exist).
+			if ( str_contains( $sql, 'ORDER BY last_attempt_gmt DESC LIMIT 1 OFFSET' ) ) {
+				$hook   = $this->extract_hook( $sql, $args );
+				$offset = (int) end( $args );
+				$rows   = array();
+				foreach ( $this->actions as $row ) {
+					if ( ! in_array( $row['status'], array( 'complete', 'failed', 'canceled' ), true ) ) {
+						continue;
+					}
+					if ( null !== $hook && $row['hook'] !== $hook ) {
+						continue;
+					}
+					$rows[] = $row['last_attempt_gmt'];
+				}
+				rsort( $rows );
+				return $rows[ $offset ] ?? null;
+			}
+
 			$cutoff = $this->extract_cutoff( $args );
 			$hook   = $this->extract_hook( $sql, $args );
 
@@ -406,6 +443,60 @@ namespace {
 		$fake_wpdb->optimize_calls >= 1
 			&& in_array( 'wp_actionscheduler_actions', $opt_result['optimized'], true ),
 		"optimize_calls={$fake_wpdb->optimize_calls}"
+	);
+
+	// -----------------------------------------------------------------------
+	// 3. Functional row-count ceiling: rows within the age window but beyond
+	//    the per-hook ceiling must still be deleted (oldest-first).
+	// -----------------------------------------------------------------------
+
+	$fake_wpdb->actions        = array();
+	$fake_wpdb->logs           = array();
+	$fake_wpdb->delete_queries = 0;
+	$fake_wpdb->optimize_calls = 0;
+	$fake_wpdb->batch_sizes    = array();
+
+	// Reset filters from the OPTIMIZE block, then cap execute_step at 10 rows
+	// and disable the age window for it (large negative-ish window) so ONLY the
+	// ceiling can delete. Seed 25 fresh execute_step rows with distinct, recent
+	// timestamps (within any age window) — 15 should be deleted by the ceiling,
+	// the 10 most-recent must survive.
+	$GLOBALS['__retention_filters'] = array();
+	retention_set_filter( 'datamachine_as_actions_hook_max_age_days', array( 'datamachine_execute_step' => 3650.0 ) );
+	retention_set_filter( 'datamachine_as_actions_hook_max_rows', array( 'datamachine_execute_step' => 10 ) );
+
+	$caid = 1;
+	for ( $i = 0; $i < 25; $i++ ) {
+		// Distinct timestamps, all very recent (i seconds ago).
+		$fake_wpdb->actions[ $caid ] = array(
+			'action_id'        => $caid,
+			'hook'             => 'datamachine_execute_step',
+			'status'           => 'complete',
+			'last_attempt_gmt' => gmdate( 'Y-m-d H:i:s', $now - ( 25 - $i ) ),
+		);
+		++$caid;
+	}
+
+	$ceiling_result = RetentionCleanup::cleanupActionSchedulerActions();
+
+	$surviving = array_filter(
+		$fake_wpdb->actions,
+		static fn( $r ) => 'datamachine_execute_step' === $r['hook']
+	);
+
+	// Boundary semantics: the deleters use strictly `< cutoff`, and the cutoff
+	// is the timestamp AT offset $max_rows. So the boundary row survives too —
+	// we keep $max_rows + 1 (never over-delete) and delete the rest. With 25
+	// rows and a cap of 10, that is 11 kept / 14 deleted.
+	assert_batching(
+		'row-count ceiling deletes rows beyond the cap despite age window',
+		11 === count( $surviving ),
+		'surviving=' . count( $surviving )
+	);
+	assert_batching(
+		'ceiling kept the most-recent rows (oldest deleted first, boundary kept)',
+		14 === ( $ceiling_result['ceiling_actions_deleted'] ?? 0 ),
+		'ceiling_deleted=' . ( $ceiling_result['ceiling_actions_deleted'] ?? 0 )
 	);
 
 	if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary

Makes the `actionscheduler_actions` table **self-bounding** so it can't balloon into the millions/GB again, regardless of generation rate. This is the durable, future-proof half of the AS-bloat fix (PR #2790 caps generation; this caps accumulation).

## Why

Age-based, once-daily retention structurally cannot bound a high-churn table. Observed on events.extrachill.com (blog 7):

- `actionscheduler_actions`: **28M rows / 23GB**; `actionscheduler_logs`: **85M rows / 9.8GB**
- `datamachine_execute_step` completing at **~90/sec** → ~25M rows/day
- Retention ran **once daily**, capped at **60s / 200 iterations** → ~5M rows deleted/pass
- **25M added/day vs 5M deleted/day = permanent 20M/day deficit.** The table could only grow, which is what starved `claim_actions` into the deadlock fatals.

Tightening the age window alone doesn't help: a burst can add rows faster than any time-boxed pass deletes them, so the table grows unbounded between runs no matter how short the window.

## What changed

Three coordinated changes make the table physically bounded:

1. **Hard per-hook row-count ceiling** (`RetentionCleanup::actionSchedulerHookMaxRows`). Deletes the **oldest** completed/terminal rows for a hook beyond a cap **regardless of age**. Default caps `datamachine_execute_step` at **100k rows**; filterable via `datamachine_as_actions_hook_max_rows`. The cutoff is found with one bounded `OFFSET` probe (indexed on hook + last_attempt_gmt), then deleted through the **existing batched, budget-bounded, FK-safe deleters** — so all the lock-safety/iteration/wall-clock guarantees carry over. Boundary is `< cutoff` so it never over-deletes (keeps `max_rows` + ties).
2. **Run AS-actions retention every 5 minutes** (was daily). Continuous chipping instead of one doomed daily batch. Only this high-churn task changes cadence; the rest stay daily.
3. **Tighten `execute_step` age window 6h → 1h.** No diagnostic value beyond that at this volume.

`retention show` now surfaces per-hook ceilings next to per-hook windows.

## Behavior

- **Self-bounding:** even if generation spikes again, the table can't exceed the ceiling — the next 5-min pass trims oldest-first back to the cap.
- **Safe:** ceiling deletes reuse the batched id-subquery deleters and the shared batch/iteration/wall-clock budget; nothing runs unbounded.
- **Tunable / opt-out:** `datamachine_as_actions_hook_max_rows` (0 disables a hook's ceiling), `datamachine_as_actions_hook_max_age_days`, plus the existing batch/iteration/runtime filters.

## Verification

- `php -l` + `phpcs` clean on all changed files.
- `tests/retention-action-scheduler-batching-smoke.php`: **27/27** — extended with ceiling coverage (deletes beyond cap inside the age window, keeps most-recent rows, respects budget, boundary semantics).
- The one pre-existing failure in `retention-system-tasks-smoke.php` (`file dry-run counter`) reproduces on clean `main` and is unrelated to this change.

## Companion

- PR #2790 throttles job admission (caps generation). Together: generation capped + retention continuous + table hard-bounded.
- The already-accumulated 30GB on blog 7 is a one-time operational drain/OPTIMIZE, separate from this code.