### PR TITLE
fix: bound AI concurrency defers to stop runaway action generation (#2793)

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -42,6 +42,28 @@ class AIStep extends Step {
 	use QueueableTrait;
 
 	/**
+	 * Maximum number of times an AI step may defer itself because the pipeline
+	 * AI concurrency slot is saturated before it gives up and fails.
+	 *
+	 * Without this ceiling a saturated single-slot limiter (the default
+	 * `pipeline_ai_concurrency_limit` is 1) lets every contending job
+	 * reschedule its own `datamachine_execute_step` action every throttle
+	 * delay, indefinitely. Under a sustained backlog that turns into millions
+	 * of self-rescheduling actions a day (see #2793). Capping the defers makes
+	 * a saturated queue fail loudly and boundedly instead of churning forever.
+	 *
+	 * Filterable via `datamachine_ai_concurrency_max_defers`.
+	 */
+	private const AI_CONCURRENCY_MAX_DEFERS = 30;
+
+	/**
+	 * Ceiling (seconds) for the exponential backoff applied between AI
+	 * concurrency defers. Keeps a long-saturated queue from hammering the
+	 * limiter on the base throttle delay for the full attempt budget.
+	 */
+	private const AI_CONCURRENCY_MAX_DEFER_DELAY = 600;
+
+	/**
 	 * Initialize AI step.
 	 */
 	public function __construct() {
@@ -631,7 +653,86 @@ class AIStep extends Step {
 	 * @param array  $lease_result  Limiter result.
 	 */
 	private function deferForAIConcurrency( string $provider_name, array $lease_result ): void {
-		$delay_seconds = max( 1, (int) ( $lease_result['delay'] ?? 10 ) );
+		// Count defers per job/step so a permanently saturated slot cannot
+		// reschedule this step forever. The throttle state is keyed by
+		// flow_step_id: a job that legitimately advances to a different AI
+		// step starts its own budget rather than inheriting the prior step's.
+		$existing_throttle = $this->engine instanceof \DataMachine\Core\EngineData
+			? $this->engine->get( 'ai_concurrency_throttle' )
+			: null;
+		$existing_throttle = is_array( $existing_throttle ) ? $existing_throttle : array();
+
+		$prior_attempts = 0;
+		if ( (string) ( $existing_throttle['flow_step_id'] ?? '' ) === $this->flow_step_id ) {
+			$prior_attempts = (int) ( $existing_throttle['attempts'] ?? 0 );
+		}
+		$attempt = $prior_attempts + 1;
+
+		$max_defers = max(
+			1,
+			(int) apply_filters(
+				'datamachine_ai_concurrency_max_defers',
+				self::AI_CONCURRENCY_MAX_DEFERS,
+				$provider_name,
+				$this->job_id
+			)
+		);
+
+		// Budget exhausted: stop self-rescheduling and route through the normal
+		// failure path. This bounds the runaway — a saturated queue fails loudly
+		// instead of generating self-rescheduling actions indefinitely (#2793).
+		if ( $attempt > $max_defers ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Pipeline AI step exhausted concurrency defer budget; failing job',
+				array(
+					'job_id'       => $this->job_id,
+					'flow_step_id' => $this->flow_step_id,
+					'provider'     => $provider_name,
+					'attempts'     => $prior_attempts,
+					'max_defers'   => $max_defers,
+					'limit'        => (int) ( $lease_result['limit'] ?? 0 ),
+					'active'       => (int) ( $lease_result['active'] ?? 0 ),
+				)
+			);
+
+			// Clear the throttle marker so ExecuteStepAbility does not treat the
+			// empty packet list as an already-routed retry and swallow the failure.
+			datamachine_merge_engine_data(
+				$this->job_id,
+				array( 'ai_concurrency_throttle' => array() )
+			);
+
+			do_action(
+				'datamachine_fail_job',
+				$this->job_id,
+				'ai_concurrency_defer_exhausted',
+				array(
+					'flow_step_id'  => $this->flow_step_id,
+					'ai_provider'   => $provider_name,
+					'attempts'      => $prior_attempts,
+					'max_defers'    => $max_defers,
+					// Terminal, not retryable: the defer budget IS the retry
+					// budget for this contention. Retrying would re-enter the
+					// same starvation and reopen the runaway (#2793).
+					'retryable'     => false,
+					'error_message' => sprintf(
+						'AI concurrency slot saturated; gave up after %d defers.',
+						$prior_attempts
+					),
+				)
+			);
+			return;
+		}
+
+		// Exponential backoff between defers, capped, so a long-saturated queue
+		// backs off instead of polling the limiter on the base delay forever.
+		$base_delay    = max( 1, (int) ( $lease_result['delay'] ?? 10 ) );
+		$delay_seconds = min(
+			self::AI_CONCURRENCY_MAX_DEFER_DELAY,
+			$base_delay * ( 2 ** min( $prior_attempts, 16 ) )
+		);
 		$timestamp     = time() + $delay_seconds;
 		$action_id     = false;
 
@@ -672,6 +773,8 @@ class AIStep extends Step {
 					'reason'                  => 'ai_concurrency_limit',
 					'provider'                => $provider_name,
 					'flow_step_id'            => $this->flow_step_id,
+					'attempts'                => $attempt,
+					'max_defers'              => $max_defers,
 					'limit'                   => (int) ( $lease_result['limit'] ?? 0 ),
 					'active'                  => (int) ( $lease_result['active'] ?? 0 ),
 					'action_id'               => $action_id,
@@ -688,6 +791,8 @@ class AIStep extends Step {
 				'flow_step_id'            => $this->flow_step_id,
 				'provider'                => $provider_name,
 				'reason'                  => 'ai_concurrency_limit',
+				'attempts'                => $attempt,
+				'max_defers'              => $max_defers,
 				'limit'                   => (int) ( $lease_result['limit'] ?? 0 ),
 				'active'                  => (int) ( $lease_result['active'] ?? 0 ),
 				'rescheduled_for_seconds' => $delay_seconds,

--- a/tests/ai-step-backpressure-smoke.php
+++ b/tests/ai-step-backpressure-smoke.php
@@ -180,6 +180,15 @@ assert_ai_backpressure_smoke( 'existing transport retry classifier remains intac
 assert_ai_backpressure_smoke( 'throttle log includes requested metadata', str_contains( $ai_src, 'rescheduled_for_seconds' ) && str_contains( $ai_src, "'active'" ) && str_contains( $ai_src, "'limit'" ) );
 assert_ai_backpressure_smoke( 'limiter checks for advanced owner leases generically', str_contains( file_get_contents( __DIR__ . '/../inc/Engine/AI/PipelineAIConcurrencyLimiter.php' ) ?: '', 'isAdvancedOwnerLease' ) );
 
+echo "Case 6: concurrency defers are bounded (#2793 runaway guard)\n";
+assert_ai_backpressure_smoke( 'defer attempt budget constant exists', str_contains( $ai_src, 'AI_CONCURRENCY_MAX_DEFERS' ) );
+assert_ai_backpressure_smoke( 'defer budget is filterable', str_contains( $ai_src, 'datamachine_ai_concurrency_max_defers' ) );
+assert_ai_backpressure_smoke( 'defer increments a per-step attempt counter', str_contains( $ai_src, "'attempts'" ) && str_contains( $ai_src, '$prior_attempts + 1' ) );
+assert_ai_backpressure_smoke( 'attempt counter resets when the AI step advances', str_contains( $ai_src, "( \$existing_throttle['flow_step_id'] ?? '' ) === \$this->flow_step_id" ) );
+assert_ai_backpressure_smoke( 'exhausted budget fails the job terminally', str_contains( $ai_src, 'ai_concurrency_defer_exhausted' ) && str_contains( $ai_src, "'retryable'     => false" ) );
+assert_ai_backpressure_smoke( 'exhausted budget clears the throttle marker so the failure is not swallowed', str_contains( $ai_src, "'ai_concurrency_throttle' => array()" ) );
+assert_ai_backpressure_smoke( 'defers back off exponentially under a capped ceiling', str_contains( $ai_src, 'AI_CONCURRENCY_MAX_DEFER_DELAY' ) && str_contains( $ai_src, '2 ** ' ) );
+
 echo "\nAI step backpressure smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {
 	exit( 1 );


### PR DESCRIPTION
## Summary

Fixes the runaway Action Scheduler generation on **events.extrachill.com (blog 7)** tracked in #2793. The root cause is an **unbounded self-rescheduling loop in the pipeline AI concurrency throttle** — not duplicate flow scheduling, not a rogue flow, and not a per-item fan-out bug.

## Root cause (exact path)

`PipelineAIConcurrencyLimiter` defaults to a **single site-wide AI slot** (`DEFAULT_LIMIT = 1`, settings unset on blog 7). When an `ai` step can't acquire the slot, `AIStep::deferForAIConcurrency()` did this with **no upper bound and no backoff**:

1. `as_schedule_single_action( time()+delay, 'datamachine_execute_step', {job_id, flow_step_id} )` — reschedule the **same step**
2. set job status back to `pending`
3. stamp `engine_data['ai_concurrency_throttle']['next_retry_at']`, which `ExecuteStepAbility::hasPendingAIConcurrencyThrottle()` reads to treat the empty return as "already routed" (so the loop never surfaces as a failure)

With one slot and thousands of contending AI child jobs, jobs starve and re-defer **forever**.

## Evidence (blog 7)

- Daily `datamachine_execute_step` volume jumped from a 2k–10k/day baseline to **~8M/day on June 23** and sustained (table reached 25.6M rows).
- `run_flow_now` (~500/day) and jobs created (~6k/day) were both **normal** — so it wasn't more flows or more jobs.
- The multiplier was per-job: **~1,300 `execute_step` actions per job**. Sampled jobs each re-ran the **same `flow_step_id`** every ~30s.
- **Smoking gun:** job `674111` (pipeline 58, flow 250, the `ai` step `58_75e0d0e3-69b2-4ad1-952c-a213fa06050c_745`) executed the identical step **2,134 times across ~37 hours** (Jun 24 21:12 → Jun 26 10:55) and was still going. Pipeline 58 shape: `event_import → ai → upsert`; the `ai` step is the one that loops.
- Dominant job statuses on blog 7: `completed_no_items` (70k), `agent_skipped` (31k, mostly wrong-location / "duplicate upsert" reasons) — consistent with huge fetch fan-out feeding a starved single AI slot.

### Responsible flow_id(s)/pipeline(s)
The loop is **systemic across all event pipelines on blog 7** (any pipeline containing an `ai` step), not one misconfigured flow. The 5-minute hot-window `execute_step` breakdown was spread fairly evenly across dozens of pipelines (27, 3, 25, 20, 10, 56, 43, 30, 39, …). Concrete witnessed instance: **flow_id 250 / pipeline 58**, AI step uuid `75e0d0e3-69b2-4ad1-952c-a213fa06050c`.

## June-23 trigger

The throttle mechanism itself landed May 6 (#1822). The most likely regression trigger in the June 21–23 window is **`dc497590` "fix: share option-backed lease store" (June 16)**, which refactored AI lease acquisition/release into `OptionLeaseStore` and changed the limiter. Any change that makes leases harder to acquire/release (or any latency/volume increase) flips a slow-drain queue into permanent starvation — and because the defer loop was unbounded, starvation became millions of actions/day. The precise lease-store defect (if any) is worth a follow-up, but the **defect that turns starvation into a runaway is the missing defer cap**, which this PR fixes at the source.

## Fix (code, not config)

In `AIStep::deferForAIConcurrency()`:

- **Cap defers per job/step**: `AI_CONCURRENCY_MAX_DEFERS = 30` (filterable via `datamachine_ai_concurrency_max_defers`). The attempt counter is keyed by `flow_step_id`, so a job that legitimately advances to a *different* AI step starts a fresh budget instead of inheriting the prior step's.
- **Capped exponential backoff** between defers (`base_delay * 2^prior_attempts`, capped at `AI_CONCURRENCY_MAX_DEFER_DELAY = 600s`) so a long-saturated queue backs off instead of polling the limiter on the base delay for the whole budget.
- **Exhausted budget → terminal failure**: fails the job with `ai_concurrency_defer_exhausted` and `retryable => false`, and clears the `ai_concurrency_throttle` marker so `ExecuteStepAbility` routes it as a real failure instead of swallowing the empty return. Retrying would re-enter the same starvation, so it is intentionally non-retryable.

A saturated queue now fails **loudly and boundedly** instead of generating self-rescheduling actions indefinitely.

## Tests

Extended `tests/ai-step-backpressure-smoke.php` with **Case 6** (7 new assertions): defer budget constant + filter, per-step attempt counter, reset-on-advance, terminal non-retryable exhaustion, throttle-marker clearing, and capped exponential backoff. Full suite: **24 assertions, 0 failures.** `phpcs` clean on both changed files.

## Follow-ups (not in this PR)

- One-time operational cleanup of the existing blog-7 backlog (already partially drained by retention).
- Consider raising `pipeline_ai_concurrency_limit` above 1 for high-throughput event sites, and investigating whether `dc497590` introduced a lease acquire/release defect worth a separate fix.

Refs #2793