### PR TITLE
feat: Action Scheduler bloat guardrail + retention catch-up (#2792)

### DIFF
--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -311,6 +311,9 @@ class SystemAbilities {
 				'oldest_due_gmt'   => $due['oldest_gmt'],
 				'next_pending_gmt' => $pending['oldest_gmt'],
 				'last_attempt_gmt' => $complete['last_attempt_gmt'],
+				'table_sizes'      => function_exists( 'as_get_scheduled_actions' ) && class_exists( '\\ActionScheduler' )
+					? \DataMachine\Engine\AI\System\Tasks\Retention\RetentionCleanup::actionSchedulerTableSizes()
+					: null,
 			),
 			'wp_cron'                 => array(
 				'action_scheduler_run_queue_next_gmt' => is_int( $wp_cron_next ) ? gmdate( 'Y-m-d H:i:s', $wp_cron_next ) : null,

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionActionSchedulerTask.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionActionSchedulerTask.php
@@ -4,6 +4,8 @@ namespace DataMachine\Engine\AI\System\Tasks\Retention;
 
 defined( 'ABSPATH' ) || exit;
 
+use DataMachine\Engine\Tasks\TaskScheduler;
+
 class RetentionActionSchedulerTask extends RetentionTask {
 
 	public function getTaskType(): string {
@@ -21,6 +23,68 @@ class RetentionActionSchedulerTask extends RetentionTask {
 	}
 
 	protected function runRetentionCleanup(): array {
-		return RetentionCleanup::cleanupActionSchedulerActions();
+		$result = RetentionCleanup::cleanupActionSchedulerActions();
+
+		$this->maybeScheduleCatchUp( $result );
+
+		return $result;
+	}
+
+	/**
+	 * Enqueue an immediate catch-up pass when a single run could not drain the
+	 * backlog.
+	 *
+	 * A single retention pass is bounded by iteration + wall-clock budgets, so
+	 * on installs where a producer floods Action Scheduler faster than one
+	 * daily 60s pass can prune (the blog-7 30GB scenario), the daily cadence
+	 * never catches up and the tables grow without bound. When a pass both
+	 * made progress (deleted rows) AND hit its budget cap, we enqueue an async
+	 * follow-up so the backlog drains over minutes instead of weeks.
+	 *
+	 * Guards against a hot loop: we only reschedule when the pass actually
+	 * deleted rows. A pass that deleted nothing but still reports `hit_limit`
+	 * (e.g. deletes blocked) does not trigger a follow-up — the next regular
+	 * daily tick will retry.
+	 *
+	 * @param array $result Result from RetentionCleanup::cleanupActionSchedulerActions().
+	 */
+	private function maybeScheduleCatchUp( array $result ): void {
+		$hit_limit = ! empty( $result['hit_limit'] );
+		$deleted   = (int) ( $result['deleted'] ?? 0 );
+
+		/**
+		 * Filter whether an oversized table alone (no budget cap hit) should
+		 * trigger a catch-up pass. Default false — only a budget-capped pass
+		 * that made progress reschedules.
+		 *
+		 * @param bool  $on     Whether to chase a breached guardrail.
+		 * @param array $result Cleanup result.
+		 */
+		$chase_breach = (bool) apply_filters( 'datamachine_as_retention_chase_breach', false, $result );
+		$breached     = ! empty( $result['table_sizes']['breached'] );
+
+		$should_catch_up = ( $hit_limit && $deleted > 0 ) || ( $chase_breach && $breached && $deleted > 0 );
+
+		if ( ! $should_catch_up ) {
+			return;
+		}
+
+		if ( ! class_exists( TaskScheduler::class ) ) {
+			return;
+		}
+
+		$scheduled = TaskScheduler::schedule( RetentionCleanup::TASK_AS_ACTIONS, array() );
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Action Scheduler retention: enqueued catch-up pass (backlog not drained in one run)',
+			array(
+				'deleted'    => $deleted,
+				'hit_limit'  => $hit_limit,
+				'breached'   => $breached,
+				'scheduled'  => false !== $scheduled,
+			)
+		);
 	}
 }

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -250,6 +250,132 @@ class RetentionCleanup {
 		return $threshold > 0 ? $threshold : 100000;
 	}
 
+	/**
+	 * Row-count threshold above which an Action Scheduler table is flagged.
+	 *
+	 * A bloat guardrail: when either `actionscheduler_actions` or
+	 * `actionscheduler_logs` exceeds this many rows after a cleanup pass, a
+	 * `warning` is logged so an operator (or the system health surface) notices
+	 * before the tables silently grow to tens of GB again — which is exactly
+	 * how blog 7 reached a 30GB / 25M-row actions table while daily retention
+	 * was running but could not keep up with a runaway producer.
+	 *
+	 * Default is 1,000,000 rows. A value of `0` (or less) disables the check.
+	 *
+	 * @return int Row-count threshold (>= 0; 0 disables the guardrail).
+	 */
+	public static function actionSchedulerTableSizeThreshold(): int {
+		$threshold = (int) apply_filters( 'datamachine_as_table_size_threshold', 1000000 );
+		return $threshold > 0 ? $threshold : 0;
+	}
+
+	/**
+	 * Read-only row counts for the Action Scheduler tables.
+	 *
+	 * Pure read with no side effects — safe for health/diagnostic surfaces.
+	 * Returns the per-table counts plus a `breached` flag against the configured
+	 * threshold. When the threshold is disabled (`<= 0`) `breached` is always
+	 * false but the live counts are still returned for reporting.
+	 *
+	 * NOTE: `SELECT COUNT(*)` on InnoDB is a full index scan. On the very
+	 * installs this guardrail targets (multi-million-row tables) that is not
+	 * free, so callers should treat it as a periodic check, not a hot path.
+	 *
+	 * @return array{enabled: bool, threshold: int, actions: int, logs: int, breached: bool}
+	 */
+	public static function actionSchedulerTableSizes(): array {
+		global $wpdb;
+
+		$threshold     = self::actionSchedulerTableSizeThreshold();
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$logs_table    = $wpdb->prefix . 'actionscheduler_logs';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$actions_rows = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $actions_table ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$logs_rows = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $logs_table ) );
+
+		$breached = $threshold > 0 && ( $actions_rows > $threshold || $logs_rows > $threshold );
+
+		return array(
+			'enabled'   => $threshold > 0,
+			'threshold' => $threshold,
+			'actions'   => $actions_rows,
+			'logs'      => $logs_rows,
+			'breached'  => $breached,
+		);
+	}
+
+	/**
+	 * Emit a guardrail warning when an Action Scheduler table is oversized.
+	 *
+	 * Counts rows in the actions and logs tables and logs a `warning` for each
+	 * one over `actionSchedulerTableSizeThreshold()`. Returns the per-table
+	 * counts and a `breached` flag so callers (the AS retention task) can react
+	 * — e.g. enqueue an immediate catch-up pass. Skipped entirely when the
+	 * threshold is disabled.
+	 *
+	 * @return array{enabled: bool, threshold: int, actions: int, logs: int, breached: bool}
+	 */
+	public static function checkActionSchedulerTableSizes(): array {
+		$threshold = self::actionSchedulerTableSizeThreshold();
+		if ( $threshold <= 0 ) {
+			return array(
+				'enabled'   => false,
+				'threshold' => 0,
+				'actions'   => 0,
+				'logs'      => 0,
+				'breached'  => false,
+			);
+		}
+
+		$sizes        = self::actionSchedulerTableSizes();
+		$actions_rows = $sizes['actions'];
+		$logs_rows    = $sizes['logs'];
+
+		global $wpdb;
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$logs_table    = $wpdb->prefix . 'actionscheduler_logs';
+
+		$breached = false;
+
+		if ( $actions_rows > $threshold ) {
+			$breached = true;
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Action Scheduler bloat guardrail: actions table over threshold',
+				array(
+					'table'     => $actions_table,
+					'rows'      => $actions_rows,
+					'threshold' => $threshold,
+				)
+			);
+		}
+
+		if ( $logs_rows > $threshold ) {
+			$breached = true;
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Action Scheduler bloat guardrail: logs table over threshold',
+				array(
+					'table'     => $logs_table,
+					'rows'      => $logs_rows,
+					'threshold' => $threshold,
+				)
+			);
+		}
+
+		return array(
+			'enabled'   => true,
+			'threshold' => $threshold,
+			'actions'   => $actions_rows,
+			'logs'      => $logs_rows,
+			'breached'  => $breached,
+		);
+	}
+
 	public static function staleClaimMaxAgeSeconds(): int {
 		$seconds = absint( apply_filters( 'datamachine_stale_claim_max_age', DAY_IN_SECONDS ) );
 		return $seconds > 0 ? $seconds : DAY_IN_SECONDS;
@@ -727,6 +853,12 @@ class RetentionCleanup {
 			);
 		}
 
+		// Bloat guardrail: after every pass, check the live table sizes and
+		// warn if either is still oversized. This is the safety net that was
+		// missing when blog 7 silently grew to 30GB — daily retention ran but
+		// nothing ever flagged that it was falling behind.
+		$table_sizes = self::checkActionSchedulerTableSizes();
+
 		return array(
 			'deleted'                 => $total_deleted,
 			'actions_deleted'         => $actions_deleted,
@@ -738,6 +870,7 @@ class RetentionCleanup {
 			'iterations'              => $iterations_used,
 			'hit_limit'               => $hit_limit,
 			'optimized'               => $optimized,
+			'table_sizes'             => $table_sizes,
 		);
 	}
 

--- a/tests/retention-action-scheduler-batching-smoke.php
+++ b/tests/retention-action-scheduler-batching-smoke.php
@@ -499,6 +499,60 @@ namespace {
 		'ceiling_deleted=' . ( $ceiling_result['ceiling_actions_deleted'] ?? 0 )
 	);
 
+	// -----------------------------------------------------------------------
+	// 4. Bloat guardrail + catch-up reschedule (#2792).
+	// -----------------------------------------------------------------------
+
+	$task = file_get_contents( $root . '/inc/Engine/AI/System/Tasks/Retention/RetentionActionSchedulerTask.php' ) ?: '';
+
+	assert_batching(
+		'guardrail threshold is filterable',
+		str_contains( $cleanup, "apply_filters( 'datamachine_as_table_size_threshold'" )
+	);
+	assert_batching(
+		'guardrail logs a warning when a table is over threshold',
+		str_contains( $cleanup, "'warning'," )
+			&& str_contains( $cleanup, 'Action Scheduler bloat guardrail' )
+	);
+	assert_batching(
+		'cleanup attaches live table sizes to its result',
+		(bool) preg_match( "/'table_sizes'\\s+=>\\s+\\\$table_sizes/", $cleanup )
+			&& str_contains( $cleanup, 'checkActionSchedulerTableSizes()' )
+	);
+	assert_batching(
+		'read-only table-size method exists for health surfaces',
+		str_contains( $cleanup, 'public static function actionSchedulerTableSizes()' )
+	);
+	assert_batching(
+		'AS retention task enqueues a catch-up pass when a run hits its limit',
+		str_contains( $task, 'maybeScheduleCatchUp' )
+			&& str_contains( $task, 'TaskScheduler::schedule( RetentionCleanup::TASK_AS_ACTIONS' )
+	);
+	assert_batching(
+		'catch-up only fires when the pass made progress (guards hot loop)',
+		str_contains( $task, '$hit_limit && $deleted > 0' )
+	);
+
+	// Functional: threshold filter clamps to 0 (disabled) and back.
+	retention_set_filter( 'datamachine_as_table_size_threshold', 0 );
+	assert_batching(
+		'threshold of 0 disables the guardrail',
+		0 === RetentionCleanup::actionSchedulerTableSizeThreshold()
+	);
+	retention_set_filter( 'datamachine_as_table_size_threshold', 5000 );
+	assert_batching(
+		'threshold is read from the filter',
+		5000 === RetentionCleanup::actionSchedulerTableSizeThreshold()
+	);
+
+	// Functional: a disabled guardrail short-circuits without counting.
+	retention_set_filter( 'datamachine_as_table_size_threshold', 0 );
+	$disabled = RetentionCleanup::checkActionSchedulerTableSizes();
+	assert_batching(
+		'disabled guardrail returns enabled=false and breached=false',
+		false === $disabled['enabled'] && false === $disabled['breached']
+	);
+
 	if ( $failed > 0 ) {
 		echo "\nretention-action-scheduler-batching-smoke failed: {$failed}/{$total} assertions failed.\n";
 		exit( 1 );


### PR DESCRIPTION
Fixes the Action Scheduler retention/bloat problem on blog 7 (events.extrachill.com) from #2792.

## What was actually wrong (the issue's premise was off)

The issue assumed `action_scheduler_retention_period` resolves to **0** and that AS-native cleanup was disabled. **That is not what's happening on this install:**

- `apply_filters('action_scheduler_retention_period', MONTH_IN_SECONDS)` resolves to **2592000 (30 days)** on blog 7 — AS-native cleanup is enabled, nothing forces it to 0. No code in data-machine or the live plugin tree adds a filter on that hook.
- DM already owns a comprehensive, batched AS retention task (`RetentionCleanup::cleanupActionSchedulerActions()`): 7-day global window (`datamachine_as_actions_max_age_days`), an aggressive **6h** per-hook window for `datamachine_execute_step`, FK-safe batched deletes (logs before actions), iteration + wall-clock caps, opt-in OPTIMIZE.
- `datamachine_recurring_retention_as_actions` **is scheduled and was running** (2 complete passes on 24th/25th, next pending) — and **logs are already covered** by the same task (it prunes `actionscheduler_logs` as FK-children of the actions it deletes).

**So why did blog 7 reach 25M rows / 30GB?** A single retention pass is bounded to ~`200 iterations × 25k batch = ~5M rows` and `60s` wall-clock. The runaway producer in #2793 generated **8M+ rows/day** — faster than one daily 60s pass could prune. Retention ran correctly but **couldn't catch up**, and **nothing ever flagged that it was falling behind**. Both of those gaps are what this PR closes.

## What was setting retention to 0 and how it's fixed

Nothing was — retention was never 0 here; that part of the issue was a misdiagnosis (confirmed by `apply_filters` returning 2592000 live). The real fix is the **catch-up + guardrail** below, not restoring a retention period.

## Changes

1. **Bloat guardrail (issue item 4 — the genuinely missing piece).** New `actionSchedulerTableSizeThreshold()` (filter `datamachine_as_table_size_threshold`, default **1,000,000** rows, `0` disables) + `checkActionSchedulerTableSizes()` which logs a `warning` when the actions or logs table exceeds the threshold. Called at the end of every `cleanupActionSchedulerActions()` pass, and attached to its result as `table_sizes`.
2. **Health surface.** A read-only `actionSchedulerTableSizes()` is exposed on the system health ability (`action_scheduler.table_sizes`) so oversized tables surface proactively, not only after a cleanup pass.
3. **Catch-up reschedule.** When a pass both **made progress** (deleted rows) **and** hit its budget cap (`hit_limit`), `RetentionActionSchedulerTask` enqueues an immediate async follow-up via `TaskScheduler::schedule(TASK_AS_ACTIONS)` so a backlog drains in minutes instead of a full day per pass. Guarded against a hot loop (only reschedules when rows were actually deleted); an optional breach-chasing path is opt-in via `datamachine_as_retention_chase_breach`.

## Confirmation logs are covered

Yes — `cleanupActionSchedulerActions()` already prunes `actionscheduler_logs` as FK-children (logs deleted before their parent actions, both batched). The new guardrail additionally counts and threshold-checks the **logs** table independently, so log bloat is flagged even if actions stay small.

## Guardrail added

`datamachine_as_table_size_threshold` (default 1M rows) → `warning` log per oversized table + `table_sizes` on the health ability. See above.

## Live purge (blog 7) — summary

Done out-of-band and reported in detail in a separate comment on #2792. Headline: per-row DELETE was unusable (~50 rows/sec; 500MB buffer pool vs 18GB tables), so I used a **swap-table rebuild** (build keep-set table → atomic `RENAME` → `DROP` old), which reclaimed disk to the OS instantly via `innodb_file_per_table`.

- `c8c_7_actionscheduler_actions`: 8.3GB / 15.4M rows → **1.2GB / 1.44M rows**
- `c8c_7_actionscheduler_logs`: 9.8GB / 86M rows → **930MB / 5.1M rows**
- Kept: all pending/failed/in-progress actions + completed rows from the last ~6h (preserves recent evidence for #2793). All recurring retention schedules intact.

## Free disk before/after

**9.8GB free → 43GB free** (~33GB reclaimed).

## OPTIMIZE run or deferred?

**Neither needed.** The swap-table approach `DROP`s the old tablespaces, which returns space to the OS immediately — no `OPTIMIZE TABLE` (and its long lock on a huge table) required.

## Tests

`tests/retention-action-scheduler-batching-smoke.php` extended with 9 new assertions (threshold filter, warning emission, result wiring, read-only size method, catch-up conditions). Full suite: **30/30 pass**. `phpcs` clean on all changed files. (One pre-existing, unrelated failure in `retention-system-tasks-smoke.php` — "file dry-run counter includes old job directories" — fails identically on `main` without these changes.)

Refs #2792, complementary to #2793 (the runaway producer).