### PR TITLE
fix: satisfy strict phpcs NotPrepared sniff in count_active_jobs

### DIFF
--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -454,15 +454,17 @@ class Jobs extends BaseRepository {
 	 * @return int Number of pending + processing jobs.
 	 */
 	public function count_active_jobs(): int {
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		return (int) $this->wpdb->get_var(
-			$this->wpdb->prepare(
-				'SELECT COUNT(job_id) FROM %i WHERE status IN (%s, %s)',
-				$this->table_name,
-				'pending',
-				'processing'
-			)
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$query = $this->wpdb->prepare(
+			'SELECT COUNT(job_id) FROM %i WHERE status IN (%s, %s)',
+			$this->table_name,
+			'pending',
+			'processing'
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Query is prepared above.
+		return (int) $this->wpdb->get_var( $query );
 	}
 
 	/**


### PR DESCRIPTION
Release preflight lint (stricter phpcs config than local) flagged the nested get_var( wpdb->prepare(...) ) in count_active_jobs() (added in #2790). Refactor to the codebase's established split pattern — prepare() into a $query var with the InterpolatedNotPrepared disable/enable block, then get_var($query) with the NotPrepared ignore — matching the adjacent get_jobs_count(). Behavior unchanged; query was already fully prepared with placeholders.