### PR TITLE
feat: surface PHP fatals, disk pressure, and Action Scheduler bloat in wake briefing

### DIFF
--- a/inc/Engine/AI/System/Tasks/WakeBriefingTask.php
+++ b/inc/Engine/AI/System/Tasks/WakeBriefingTask.php
@@ -59,6 +59,39 @@ class WakeBriefingTask extends SystemTask {
 	private const REPEATED_FAILURE_THRESHOLD = 3;
 
 	/**
+	 * Default disk-pressure thresholds. Surface a disk line when free space
+	 * crosses EITHER bar (whichever triggers first): below this fraction of
+	 * total, or below this many free bytes. Both are independently filterable.
+	 */
+	private const DISK_MIN_FREE_PCT   = 0.15;          // 15% free.
+	private const DISK_MIN_FREE_BYTES = 20000000000;   // 20 GB free.
+
+	/**
+	 * Default Action Scheduler bloat ceilings. Surface a line when either the
+	 * `actionscheduler_actions` or `actionscheduler_logs` table crosses EITHER
+	 * the row ceiling or the byte ceiling. Both are filterable.
+	 */
+	private const AS_MAX_ROWS  = 1000000;     // 1M rows.
+	private const AS_MAX_BYTES = 2000000000;  // 2 GB.
+
+	/**
+	 * Max bytes of the debug.log tail to scan for PHP fatals. Bounds the read
+	 * so a runaway multi-GB log never blows the task up. 5 MiB of tail is far
+	 * more than a rolling window of fatals would ever occupy.
+	 */
+	private const FATAL_TAIL_BYTES = 5242880; // 5 MiB.
+
+	/**
+	 * Tracks whether the disk-pressure line has already been emitted in the
+	 * current run. Disk is a host-global signal, but gatherSiteSignals() runs
+	 * once per blog under the network switch_to_blog loop — without this guard
+	 * the same disk warning would repeat on every site. Emit it once.
+	 *
+	 * @var bool
+	 */
+	private bool $disk_emitted = false;
+
+	/**
 	 * This is pure site-scoped maintenance reading operational tables and
 	 * writing a file. It does not act as an agent or invoke agent-scoped
 	 * abilities, so it opts out of the agent-context gate (see
@@ -198,6 +231,25 @@ class WakeBriefingTask extends SystemTask {
 		$errors = $this->getGroupedErrors( $since );
 		if ( ! empty( $errors ) ) {
 			$signals[] = $errors;
+		}
+
+		$fatals = $this->getPhpFatals( $since );
+		if ( ! empty( $fatals ) ) {
+			$signals[] = $fatals;
+		}
+
+		// Disk is host-global; emit it once per run, not once per blog.
+		if ( ! $this->disk_emitted ) {
+			$disk = $this->getDiskPressure();
+			if ( ! empty( $disk ) ) {
+				$signals[]          = $disk;
+				$this->disk_emitted = true;
+			}
+		}
+
+		$as_bloat = $this->getActionSchedulerBloat();
+		if ( ! empty( $as_bloat ) ) {
+			$signals[] = $as_bloat;
 		}
 
 		return $signals;
@@ -397,6 +449,358 @@ class WakeBriefingTask extends SystemTask {
 			(int) $top['n'],
 			$signature
 		);
+	}
+
+	/**
+	 * New PHP fatals from the live debug.log tail, grouped by normalized
+	 * signature. The single highest-value infra signal: a `claim_actions`
+	 * fatal storm leaves ZERO rows in datamachine_logs — it lives only in
+	 * debug.log — so getGroupedErrors() is structurally blind to it.
+	 *
+	 * This reads only the tail of the current debug.log (bounded to
+	 * FATAL_TAIL_BYTES), folds multi-line stack traces into one entry, filters
+	 * to the rolling window by parsed timestamp, normalizes each fatal to a
+	 * stable signature (severity + file + numeric-stripped message), and emits
+	 * a single grouped line with the total count and the top signature.
+	 *
+	 * Fail-soft: any unreadable/absent log, or any error, returns ''. Never
+	 * throws — the briefing must compose even when the log is missing.
+	 *
+	 * @param string $since Window start (UTC `Y-m-d H:i:s`).
+	 * @return string Single grouped line, or '' when no fatals in-window.
+	 */
+	private function getPhpFatals( string $since ): string {
+		$path = $this->resolveDebugLogPath();
+		if ( '' === $path || ! is_file( $path ) || ! is_readable( $path ) ) {
+			return '';
+		}
+
+		$since_ts = strtotime( $since . ' UTC' );
+		if ( false === $since_ts ) {
+			$since_ts = 0;
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		$handle = @fopen( $path, 'rb' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		if ( false === $handle ) {
+			return '';
+		}
+
+		$size = (int) filesize( $path );
+		if ( $size > self::FATAL_TAIL_BYTES ) {
+			fseek( $handle, $size - self::FATAL_TAIL_BYTES );
+			fgets( $handle ); // Discard the partial first line after the seek.
+		}
+
+		$groups  = array(); // signature => [ 'count' => int, 'sample' => string ].
+		$total   = 0;
+		$current = null;
+
+		$flush = function () use ( &$current, &$groups, &$total, $since_ts ) {
+			if ( null === $current ) {
+				return;
+			}
+			$entry   = $current;
+			$current = null;
+
+			if ( null !== $entry['ts'] && $entry['ts'] < $since_ts ) {
+				return;
+			}
+
+			$norm = $this->normalizeFatal( $entry['raw'] );
+			if ( null === $norm ) {
+				return;
+			}
+
+			++$total;
+			if ( ! isset( $groups[ $norm['signature'] ] ) ) {
+				$groups[ $norm['signature'] ] = array(
+					'count'  => 0,
+					'sample' => $norm['sample'],
+				);
+			}
+			++$groups[ $norm['signature'] ]['count'];
+		};
+
+		for ( $line = fgets( $handle ); false !== $line; $line = fgets( $handle ) ) {
+			$ts = $this->parseLogTimestamp( $line );
+			if ( null !== $ts || '' !== $line && '[' === $line[0] ) {
+				$flush();
+				$current = array(
+					'ts'  => $ts,
+					'raw' => rtrim( $line, "\r\n" ),
+				);
+				continue;
+			}
+			if ( null !== $current ) {
+				$current['raw'] .= "\n" . rtrim( $line, "\r\n" );
+			}
+		}
+		$flush();
+		fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+
+		if ( 0 === $total || empty( $groups ) ) {
+			return '';
+		}
+
+		uasort(
+			$groups,
+			static fn( $a, $b ) => $b['count'] <=> $a['count']
+		);
+		$top = reset( $groups );
+
+		return sprintf(
+			'⚠ %d PHP fatal(s) in debug.log, top: "%s" ×%d.',
+			$total,
+			$this->truncate( (string) $top['sample'], 80 ),
+			(int) $top['count']
+		);
+	}
+
+	/**
+	 * Resolve the active PHP error log path robustly.
+	 *
+	 * WP_DEBUG_LOG may be a bool (true => canonical wp-content/debug.log) or an
+	 * explicit path string. We also honor a real-file `error_log` ini target.
+	 * Always falls back to WP_CONTENT_DIR/debug.log so a sane default exists.
+	 *
+	 * @return string Absolute path (may not exist), or '' when undeterminable.
+	 */
+	private function resolveDebugLogPath(): string {
+		if ( defined( 'WP_DEBUG_LOG' ) && is_string( WP_DEBUG_LOG ) && '' !== WP_DEBUG_LOG ) {
+			return WP_DEBUG_LOG;
+		}
+
+		$ini_path = ini_get( 'error_log' );
+		if ( is_string( $ini_path ) && '' !== $ini_path && 'syslog' !== $ini_path && false === strpos( $ini_path, '://' ) ) {
+			return $ini_path;
+		}
+
+		if ( defined( 'WP_CONTENT_DIR' ) && is_string( WP_CONTENT_DIR ) && '' !== WP_CONTENT_DIR ) {
+			return rtrim( WP_CONTENT_DIR, '/\\' ) . '/debug.log';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Extract a Unix timestamp from a debug.log line prefix.
+	 *
+	 * Matches the WordPress/PHP default format: [DD-Mon-YYYY HH:MM:SS UTC].
+	 *
+	 * @param string $line Raw log line.
+	 * @return int|null Unix timestamp, or null when the line has no prefix.
+	 */
+	private function parseLogTimestamp( string $line ): ?int {
+		if ( ! preg_match( '/^\[(\d{2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2}:\d{2}(?: [A-Za-z]+)?)\]/', $line, $m ) ) {
+			return null;
+		}
+		$ts = strtotime( $m[1] );
+		return false === $ts ? null : $ts;
+	}
+
+	/**
+	 * Normalize a raw (possibly multi-line) log entry to a stable FATAL
+	 * signature. Returns null for non-fatal severities (warnings, notices,
+	 * deprecations) so WAKE only surfaces the reddest signal.
+	 *
+	 * @param string $raw Raw log entry.
+	 * @return array{signature:string, sample:string}|null
+	 */
+	private function normalizeFatal( string $raw ): ?array {
+		$first_line = strtok( $raw, "\n" );
+		if ( false === $first_line ) {
+			$first_line = $raw;
+		}
+
+		$body = (string) preg_replace( '/^\[[^\]]*\]\s*/', '', $first_line );
+
+		// Fatals and parse errors only — the highest-signal, lowest-noise band.
+		if ( ! preg_match( '/\bPHP (Parse error|Fatal error|Recoverable fatal error)\b:?/i', $body ) ) {
+			return null;
+		}
+
+		$message = trim( (string) preg_replace( '/^.*?\bPHP [^:]+:\s*/i', '', $body ) );
+		$message = trim( (string) preg_replace( '/\s+/', ' ', $message ) );
+
+		$file = '';
+		if ( preg_match( '/thrown in (.+?) on line (\d+)/', $raw, $tm ) ) {
+			$file = basename( $tm[1] );
+		} elseif ( preg_match( '/ in (.+?) on line (\d+)/', $first_line, $fm ) ) {
+			$file = basename( $fm[1] );
+		}
+
+		// Build the signature off the numeric-stripped message + file basename
+		// so request-specific ids/addresses collapse into one group.
+		$norm = (string) preg_replace( '/ in .+? on line \d+.*$/', '', $message );
+		$norm = (string) preg_replace( '/0x[0-9a-fA-F]+/', '0xADDR', $norm );
+		$norm = (string) preg_replace( '/\d+/', 'N', $norm );
+		$norm = trim( (string) preg_replace( '/\s+/', ' ', $norm ) );
+
+		$signature = substr( md5( $file . '|' . $norm ), 0, 12 );
+
+		$sample = '' !== $file ? $file . ': ' . $norm : $norm;
+
+		return array(
+			'signature' => $signature,
+			'sample'    => $sample,
+		);
+	}
+
+	/**
+	 * Disk pressure on the filesystem holding WordPress. One line when free
+	 * space crosses EITHER the percent floor or the byte floor. Both bars are
+	 * filterable. Fail-soft: returns '' if the filesystem can't be probed.
+	 *
+	 * @return string Single line, or '' when disk is healthy.
+	 */
+	private function getDiskPressure(): string {
+		$root = defined( 'ABSPATH' ) ? ABSPATH : ( defined( 'WP_CONTENT_DIR' ) ? WP_CONTENT_DIR : '/' );
+
+		$free  = @disk_free_space( $root );  // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		$total = @disk_total_space( $root ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+
+		if ( ! is_numeric( $free ) || ! is_numeric( $total ) || $total <= 0 ) {
+			return '';
+		}
+
+		$free  = (float) $free;
+		$total = (float) $total;
+
+		/**
+		 * Filter the disk-pressure minimum-free-fraction threshold.
+		 *
+		 * @param float $pct Default 0.15 (15%).
+		 */
+		$min_pct = (float) apply_filters( 'datamachine_wake_briefing_disk_min_free_pct', self::DISK_MIN_FREE_PCT );
+
+		/**
+		 * Filter the disk-pressure minimum-free-bytes threshold.
+		 *
+		 * @param float $bytes Default 20000000000 (20 GB).
+		 */
+		$min_bytes = (float) apply_filters( 'datamachine_wake_briefing_disk_min_free_bytes', (float) self::DISK_MIN_FREE_BYTES );
+
+		$free_fraction = $free / $total;
+
+		if ( $free_fraction >= $min_pct && $free >= $min_bytes ) {
+			return '';
+		}
+
+		$used_pct = (int) round( ( 1 - $free_fraction ) * 100 );
+
+		return sprintf(
+			'⚠ Disk %d%% full (%s free).',
+			$used_pct,
+			$this->formatBytes( $free )
+		);
+	}
+
+	/**
+	 * Action Scheduler table bloat for the current blog. One line when either
+	 * `actionscheduler_actions` or `actionscheduler_logs` crosses EITHER the
+	 * row ceiling or the byte ceiling. Reads information_schema.TABLES (cheap;
+	 * row counts are approximate but plenty for a "this is runaway" alarm).
+	 * Both ceilings are filterable. Fail-soft: returns '' on any error.
+	 *
+	 * @return string Single line, or '' when both tables are within bounds.
+	 */
+	private function getActionSchedulerBloat(): string {
+		global $wpdb;
+
+		/**
+		 * Filter the Action Scheduler row-count ceiling.
+		 *
+		 * @param int $rows Default 1,000,000.
+		 */
+		$max_rows = (int) apply_filters( 'datamachine_wake_briefing_as_max_rows', self::AS_MAX_ROWS );
+
+		/**
+		 * Filter the Action Scheduler byte (data + index) ceiling.
+		 *
+		 * @param int $bytes Default 2,000,000,000 (2 GB).
+		 */
+		$max_bytes = (int) apply_filters( 'datamachine_wake_briefing_as_max_bytes', self::AS_MAX_BYTES );
+
+		$tables = array(
+			$wpdb->prefix . 'actionscheduler_actions',
+			$wpdb->prefix . 'actionscheduler_logs',
+		);
+
+		$offenders = array();
+
+		foreach ( $tables as $table ) {
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+			$query = $wpdb->prepare(
+				'SELECT table_rows AS n, (data_length + index_length) AS bytes
+				 FROM information_schema.TABLES
+				 WHERE table_schema = DATABASE() AND table_name = %s',
+				$table
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Query is prepared above.
+			$row = $wpdb->get_row( $query, ARRAY_A );
+
+			if ( empty( $row ) ) {
+				continue;
+			}
+
+			$rows  = (int) $row['n'];
+			$bytes = (int) $row['bytes'];
+
+			if ( $rows <= $max_rows && $bytes <= $max_bytes ) {
+				continue;
+			}
+
+			$offenders[] = sprintf(
+				'%s %s rows / %s',
+				$table,
+				$this->formatCount( $rows ),
+				$this->formatBytes( (float) $bytes )
+			);
+		}
+
+		if ( empty( $offenders ) ) {
+			return '';
+		}
+
+		return '⚠ Action Scheduler bloat: ' . implode( ', ', $offenders ) . '.';
+	}
+
+	/**
+	 * Format a byte count into a compact human-readable string (GB/MB/etc).
+	 *
+	 * @param float $bytes Byte count.
+	 * @return string
+	 */
+	private function formatBytes( float $bytes ): string {
+		$units = array( 'B', 'KB', 'MB', 'GB', 'TB', 'PB' );
+		$i     = 0;
+		while ( $bytes >= 1000 && $i < count( $units ) - 1 ) {
+			$bytes /= 1000;
+			++$i;
+		}
+		// Whole numbers for raw bytes/KB/MB; one decimal from GB up so a
+		// multi-GB runaway reads precisely (e.g. "23.9GB", not "24GB").
+		$precision = $i >= 3 ? 1 : 0;
+		return number_format( $bytes, $precision ) . $units[ $i ];
+	}
+
+	/**
+	 * Format a large integer into a compact human-readable string (e.g. 28.1M).
+	 *
+	 * @param int $n Count.
+	 * @return string
+	 */
+	private function formatCount( int $n ): string {
+		if ( $n >= 1000000 ) {
+			return number_format( $n / 1000000, 1 ) . 'M';
+		}
+		if ( $n >= 1000 ) {
+			return number_format( $n / 1000, 1 ) . 'K';
+		}
+		return (string) $n;
 	}
 
 	/**

--- a/tests/wake-briefing-infra-signals-smoke.php
+++ b/tests/wake-briefing-infra-signals-smoke.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Smoke coverage for the WakeBriefing infrastructure-layer signal gatherers
+ * (#2799): PHP fatals (debug.log), disk pressure, and Action Scheduler bloat.
+ *
+ * Run with: php tests/wake-briefing-infra-signals-smoke.php
+ *
+ * Each gatherer obeys the same ruthless-terseness contract as the existing
+ * three: ONE grouped markdown line when over its threshold, '' otherwise. This
+ * test drives all three private gatherers via reflection against a fake $wpdb,
+ * a real temp debug.log, and filterable disk thresholds — asserting each emits
+ * a line when over the bar and empty when under, and that all three fail soft.
+ *
+ * Dependency-free like the other smoke tests: a tiny in-memory filter registry,
+ * stubbed WP constants/functions, and a hand-rolled fake $wpdb.
+ *
+ * @package DataMachine\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {
+
+	use DataMachine\Engine\AI\System\Tasks\WakeBriefingTask;
+
+	$root = dirname( __DIR__ );
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', $root . '/' );
+	}
+	if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+		define( 'WP_CONTENT_DIR', sys_get_temp_dir() );
+	}
+	if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+		define( 'HOUR_IN_SECONDS', 3600 );
+	}
+	if ( ! defined( 'ARRAY_A' ) ) {
+		define( 'ARRAY_A', 'ARRAY_A' );
+	}
+
+	// In-memory filter registry so apply_filters() returns overrides.
+	$GLOBALS['__wake_filters'] = array();
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, $value, ...$rest ) {
+			if ( array_key_exists( $hook, $GLOBALS['__wake_filters'] ) ) {
+				return $GLOBALS['__wake_filters'][ $hook ];
+			}
+			return $value;
+		}
+	}
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( ...$args ) {}
+	}
+
+	function wake_set_filter( string $hook, $value ): void {
+		$GLOBALS['__wake_filters'][ $hook ] = $value;
+	}
+	function wake_clear_filters(): void {
+		$GLOBALS['__wake_filters'] = array();
+	}
+
+	$failed = 0;
+	$total  = 0;
+
+	function wake_assert( string $name, bool $condition, string $detail = '' ): void {
+		global $failed, $total;
+		++$total;
+		if ( $condition ) {
+			echo "  [PASS] {$name}\n";
+			return;
+		}
+		++$failed;
+		echo "  [FAIL] {$name}" . ( $detail ? " — {$detail}" : '' ) . "\n";
+	}
+
+	echo "=== wake-briefing-infra-signals-smoke ===\n";
+
+	// SystemTask is the abstract parent; load it then the task itself.
+	require_once $root . '/inc/Engine/AI/System/Tasks/SystemTask.php';
+	require_once $root . '/inc/Engine/AI/System/Tasks/WakeBriefingTask.php';
+
+	// WakeBriefingTask's constructor may need dependencies; we only exercise
+	// private methods via reflection on a bare instance, so instantiate without
+	// invoking the constructor.
+	$ref  = new ReflectionClass( WakeBriefingTask::class );
+	$task = $ref->newInstanceWithoutConstructor();
+
+	$invoke = function ( string $method, array $args = array() ) use ( $ref, $task ) {
+		$m = $ref->getMethod( $method );
+		$m->setAccessible( true );
+		return $m->invoke( $task, ...$args );
+	};
+
+	// -----------------------------------------------------------------------
+	// 1. PHP fatals from debug.log.
+	// -----------------------------------------------------------------------
+
+	$log = tempnam( sys_get_temp_dir(), 'wake-debug-' );
+
+	$now    = time();
+	$recent = gmdate( 'd-M-Y H:i:s', $now - 600 ) . ' UTC';
+	$old    = gmdate( 'd-M-Y H:i:s', $now - ( 72 * 3600 ) ) . ' UTC';
+	$since  = gmdate( 'Y-m-d H:i:s', $now - ( 24 * 3600 ) );
+
+	// Two in-window fatals sharing one signature, one with a distinct signature,
+	// a multi-line trace folded into one, an out-of-window fatal (ignored), and
+	// a warning (ignored — fatals only).
+	$lines = array(
+		"[{$recent}] PHP Fatal error:  Uncaught Error: Call to a member function claim_actions() on null in /var/www/wp-content/plugins/x/foo.php on line 42",
+		'Stack trace:',
+		'#0 /var/www/wp-content/plugins/x/foo.php(99): bar()',
+		"[{$recent}] PHP Fatal error:  Uncaught Error: Call to a member function claim_actions() on null in /var/www/wp-content/plugins/x/foo.php on line 42",
+		"[{$recent}] PHP Parse error:  syntax error, unexpected token in /var/www/wp-content/plugins/y/baz.php on line 7",
+		"[{$old}] PHP Fatal error:  Old out-of-window fatal in /var/www/old.php on line 1",
+		"[{$recent}] PHP Warning:  Undefined variable in /var/www/warn.php on line 5",
+	);
+	file_put_contents( $log, implode( "\n", $lines ) . "\n" );
+
+	// WP_DEBUG_LOG is undefined in this harness, so resolveDebugLogPath() falls
+	// back to the `error_log` ini target — point it at our temp log.
+	$prev_error_log = ini_get( 'error_log' );
+	ini_set( 'error_log', $log );
+
+	$fatal_line = $invoke( 'getPhpFatals', array( $since ) );
+	wake_assert(
+		'fatals: emits a grouped line counting only in-window fatals (3)',
+		is_string( $fatal_line ) && str_contains( $fatal_line, '3 PHP fatal(s)' ),
+		"got: {$fatal_line}"
+	);
+	wake_assert(
+		'fatals: top signature is the ×2 claim_actions group',
+		str_contains( $fatal_line, '×2' ) && str_contains( $fatal_line, 'claim_actions' ),
+		"got: {$fatal_line}"
+	);
+	wake_assert(
+		'fatals: ignores warnings (no Undefined variable in output)',
+		! str_contains( $fatal_line, 'Undefined variable' ),
+		"got: {$fatal_line}"
+	);
+
+	// Under threshold: window starts AFTER all entries => empty.
+	$future_since = gmdate( 'Y-m-d H:i:s', $now + 3600 );
+	$fatal_empty  = $invoke( 'getPhpFatals', array( $future_since ) );
+	wake_assert(
+		'fatals: empty when no fatals fall inside the window',
+		'' === $fatal_empty,
+		"got: {$fatal_empty}"
+	);
+
+	// Fail-soft: unreadable/absent log => ''.
+	ini_set( 'error_log', '/nonexistent/definitely/not/here.log' );
+	$fatal_missing = $invoke( 'getPhpFatals', array( $since ) );
+	wake_assert(
+		'fatals: fail-soft empty string when debug.log is absent',
+		'' === $fatal_missing
+	);
+	ini_set( 'error_log', false === $prev_error_log ? '' : $prev_error_log );
+	@unlink( $log );
+
+	// -----------------------------------------------------------------------
+	// 2. Disk pressure (real filesystem, filter-driven thresholds).
+	// -----------------------------------------------------------------------
+
+	wake_clear_filters();
+
+	// Force a trigger: demand 100% free (impossible) => always over the bar.
+	wake_set_filter( 'datamachine_wake_briefing_disk_min_free_pct', 1.0 );
+	wake_set_filter( 'datamachine_wake_briefing_disk_min_free_bytes', 0.0 );
+	$disk_line = $invoke( 'getDiskPressure' );
+	wake_assert(
+		'disk: emits a "% full" line when free space is under the pct bar',
+		is_string( $disk_line ) && str_contains( $disk_line, 'Disk ' ) && str_contains( $disk_line, 'full' ),
+		"got: {$disk_line}"
+	);
+
+	// Force healthy: demand 0% free and 0 free bytes => never over the bar.
+	wake_clear_filters();
+	wake_set_filter( 'datamachine_wake_briefing_disk_min_free_pct', 0.0 );
+	wake_set_filter( 'datamachine_wake_briefing_disk_min_free_bytes', 0.0 );
+	$disk_empty = $invoke( 'getDiskPressure' );
+	wake_assert(
+		'disk: empty when free space clears both thresholds',
+		'' === $disk_empty,
+		"got: {$disk_empty}"
+	);
+
+	// -----------------------------------------------------------------------
+	// 3. Action Scheduler bloat (fake $wpdb information_schema read).
+	// -----------------------------------------------------------------------
+
+	wake_clear_filters();
+
+	$fake_wpdb = new class() {
+		public string $prefix = 'wp_';
+
+		/** @var array<string, array{n:int, bytes:int}> table_name => stats */
+		public array $stats = array();
+
+		public function prepare( string $query, ...$args ): array {
+			if ( 1 === count( $args ) && is_array( $args[0] ) ) {
+				$args = $args[0];
+			}
+			return array(
+				'sql'  => $query,
+				'args' => $args,
+			);
+		}
+
+		public function get_row( $prepared, $output = ARRAY_A ) {
+			$table = (string) end( $prepared['args'] );
+			if ( ! isset( $this->stats[ $table ] ) ) {
+				return null;
+			}
+			return array(
+				'n'     => $this->stats[ $table ]['n'],
+				'bytes' => $this->stats[ $table ]['bytes'],
+			);
+		}
+	};
+	$GLOBALS['wpdb'] = $fake_wpdb;
+
+	// Over-threshold: actions table is a 28.1M-row / 23.9GB runaway.
+	$fake_wpdb->stats = array(
+		'wp_actionscheduler_actions' => array(
+			'n'     => 28100000,
+			'bytes' => 23900000000,
+		),
+		'wp_actionscheduler_logs'    => array(
+			'n'     => 5000,
+			'bytes' => 1000000,
+		),
+	);
+	$as_line = $invoke( 'getActionSchedulerBloat' );
+	wake_assert(
+		'AS bloat: emits a line naming the offending actions table',
+		is_string( $as_line ) && str_contains( $as_line, 'Action Scheduler bloat' )
+			&& str_contains( $as_line, 'wp_actionscheduler_actions' ),
+		"got: {$as_line}"
+	);
+	wake_assert(
+		'AS bloat: humanizes counts/bytes (28.1M rows / 23.9GB)',
+		str_contains( $as_line, '28.1M rows' ) && str_contains( $as_line, '23.9GB' ),
+		"got: {$as_line}"
+	);
+	wake_assert(
+		'AS bloat: does NOT name the within-bounds logs table',
+		! str_contains( $as_line, 'actionscheduler_logs' ),
+		"got: {$as_line}"
+	);
+
+	// Under-threshold: both tables small => empty.
+	$fake_wpdb->stats = array(
+		'wp_actionscheduler_actions' => array(
+			'n'     => 1000,
+			'bytes' => 500000,
+		),
+		'wp_actionscheduler_logs'    => array(
+			'n'     => 2000,
+			'bytes' => 700000,
+		),
+	);
+	$as_empty = $invoke( 'getActionSchedulerBloat' );
+	wake_assert(
+		'AS bloat: empty when both tables are within bounds',
+		'' === $as_empty,
+		"got: {$as_empty}"
+	);
+
+	// Row ceiling alone (rows over, bytes under) still triggers via filter.
+	wake_set_filter( 'datamachine_wake_briefing_as_max_rows', 500 );
+	$as_rowtrip = $invoke( 'getActionSchedulerBloat' );
+	wake_assert(
+		'AS bloat: row ceiling is filterable and trips independently of bytes',
+		is_string( $as_rowtrip ) && str_contains( $as_rowtrip, 'Action Scheduler bloat' ),
+		"got: {$as_rowtrip}"
+	);
+
+	// Fail-soft: missing table rows => empty.
+	wake_clear_filters();
+	$fake_wpdb->stats = array();
+	$as_missing       = $invoke( 'getActionSchedulerBloat' );
+	wake_assert(
+		'AS bloat: fail-soft empty string when information_schema returns nothing',
+		'' === $as_missing
+	);
+
+	// -----------------------------------------------------------------------
+
+	if ( $failed > 0 ) {
+		echo "\nwake-briefing-infra-signals-smoke failed: {$failed}/{$total} assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nwake-briefing-infra-signals-smoke passed: {$total} assertions.\n";
+}


### PR DESCRIPTION
## Summary

`WakeBriefingTask` only scanned three DM-database sources — failed `datamachine_jobs`, processing `datamachine_jobs`, and `datamachine_logs` at `level = ERROR`. That made it structurally blind to the three infrastructure-layer signals that mattered most in the recent events.extrachill.com incident: a `claim_actions` **PHP fatal storm** (fatals never land in `datamachine_logs`), a **94%-full disk**, and a **28M-row / 23GB `actionscheduler_actions` runaway**. The operator caught it via an external fatal alarm, not WAKE.

This wires three new threshold-gated gatherers into `gatherSiteSignals()` alongside the existing three. Each keeps the ruthless-terseness contract: ONE grouped markdown line, only when it crosses a bar, `''` otherwise — exactly like `getStuckJobs()` / `getGroupedErrors()`.

## Signals added

1. **PHP fatals from `debug.log`** (`getPhpFatals()`) — the highest-value add. Reads a bounded tail (5 MiB) of the live `debug.log`, folds multi-line stack traces into one entry, filters to the rolling window by parsed `[DD-Mon-YYYY HH:MM:SS UTC]` timestamp, normalizes each **fatal/parse-error** (warnings/notices excluded) to a stable signature (file basename + numeric-stripped message), groups, and emits e.g. `⚠ 3 PHP fatal(s) in debug.log, top: "foo.php: Uncaught Error: Call to a member function claim_actions() on null" ×2.` This mirrors the rotation-safe reading approach behind `wp extrachill analytics errors --severity=fatal` (`extrachill-analytics/inc/core/php-error-log.php`) — reimplemented self-contained inside the task rather than reaching across a plugin boundary, so data-machine keeps no dependency on extrachill-analytics.

2. **Disk pressure** (`getDiskPressure()`) — `disk_free_space()` / `disk_total_space()` on `ABSPATH` (falls back to `WP_CONTENT_DIR`, then `/`). Surfaces when **< 15% free OR < 20GB free** (whichever triggers). Example: `⚠ Disk 94% full (7.9GB free).`

3. **Action Scheduler bloat** (`getActionSchedulerBloat()`) — one `information_schema.TABLES` read of `table_rows` + `(data_length + index_length)` for `{$wpdb->prefix}actionscheduler_actions` and `…_logs`. Surfaces when **> 1,000,000 rows OR > 2GB** on either table. Example: `⚠ Action Scheduler bloat: wp_actionscheduler_actions 28.1M rows / 23.9GB.`

## debug.log path resolution

`resolveDebugLogPath()` is robust to `WP_DEBUG_LOG` being a **bool or a path string**: if it's a non-empty string, use it; else honor a real-file `error_log` ini target (skipping `syslog`/stream wrappers); else fall back to `WP_CONTENT_DIR/debug.log`. If the resolved log is unreadable/absent, `getPhpFatals()` returns `''` — never fatals the task.

## Thresholds & filters

| Signal | Default | Filters |
| --- | --- | --- |
| Disk | < 15% free **OR** < 20GB free | `datamachine_wake_briefing_disk_min_free_pct`, `datamachine_wake_briefing_disk_min_free_bytes` |
| AS bloat | > 1,000,000 rows **OR** > 2GB (per table) | `datamachine_wake_briefing_as_max_rows`, `datamachine_wake_briefing_as_max_bytes` |
| Fatal tail scan | 5 MiB tail | (constant `FATAL_TAIL_BYTES`) |

All gatherers are fail-soft: any unreadable log, unprobable filesystem, or empty `information_schema` read returns `''` and never throws.

## Per-site vs network disk handling

`gatherSiteSignals()` runs **once per blog** under the `switch_to_blog` loop in `gatherNetworkSignals()`. AS bloat and fatals are genuinely per-site (per-prefix tables, per-site `debug.log` semantics) and repeat correctly. **Disk is host-global**, so a naive per-blog emit would repeat the same warning on every site. I added a `$disk_emitted` instance guard so the disk line is emitted **once per run** (on the first site that crosses the bar) rather than deduping it into a separate network-only line — this keeps `gatherSiteSignals()` self-contained and correct in both `site` and `network` scope without special-casing the network path.

## Tests

New dependency-free smoke test `tests/wake-briefing-infra-signals-smoke.php` (same convention as `retention-action-scheduler-batching-smoke.php`) drives all three private gatherers via reflection:

- **Fatals**: real temp `debug.log` with in-window grouped fatals, an out-of-window fatal, a multi-line trace, and a warning — asserts grouped count (3), top signature (`×2` claim_actions), warning excluded, empty when window excludes all, and fail-soft empty when the log is absent.
- **Disk**: filter-driven thresholds against the real filesystem — asserts a line when forced over the bar and empty when forced healthy.
- **AS bloat**: fake `$wpdb` `information_schema` read — asserts the 28.1M/23.9GB actions table is named, the within-bounds logs table is not, humanized formatting, empty when both within bounds, the row ceiling trips independently of bytes via filter, and fail-soft empty on a missing table.

## Verification

- `php -l` on both changed files — no syntax errors.
- `php -d error_reporting=0 vendor/bin/phpcs inc/Engine/AI/System/Tasks/WakeBriefingTask.php tests/wake-briefing-infra-signals-smoke.php` — **exit 0**.
- `php tests/wake-briefing-infra-signals-smoke.php` — **13/13 assertions pass**.
- `php tests/retention-action-scheduler-batching-smoke.php` — still passes (no regression).

Closes #2799