### PR TITLE
Expose runtime package inputs to bundle runs

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -549,6 +549,7 @@ function datamachine_load_handlers() {
 	// Publish Handlers (core only - social handlers moved to data-machine-socials plugin)
 	new \DataMachine\Core\Steps\Publish\Handlers\WordPress\WordPress();
 	new \DataMachine\Core\Steps\Publish\Handlers\Email\Email();
+	new \DataMachine\Core\Steps\Publish\Handlers\TypedArtifact\TypedArtifact();
 
 	// Fetch Handlers
 	new \DataMachine\Core\Steps\Fetch\Handlers\WordPress\WordPress();

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -1601,6 +1601,9 @@ class AgentAbilities {
 			$workflow = method_exists( $request, 'get_workflow' ) ? $request->get_workflow() : array();
 			$input    = method_exists( $request, 'get_input' ) ? $request->get_input() : array();
 			$options  = method_exists( $request, 'get_options' ) ? $request->get_options() : array();
+			if ( is_array( $raw_input['options'] ?? null ) ) {
+				$options = array_replace( $raw_input['options'], is_array( $options ) ? $options : array() );
+			}
 			$metadata = method_exists( $request, 'get_metadata' ) ? $request->get_metadata() : array();
 			$replay   = method_exists( $request, 'get_replay' ) ? $request->get_replay() : array();
 
@@ -1626,6 +1629,8 @@ class AgentAbilities {
 			foreach ( array( 'provider', 'model', 'wait_for_completion', 'wait', 'step_budget', 'time_budget_ms', 'required_outputs', 'required_artifacts', 'engine_data_outputs', 'runtime_tools', 'ability_tools', 'tools', 'disable_directives' ) as $key ) {
 				if ( array_key_exists( $key, $options ) ) {
 					$bundle_input[ $key ] = $options[ $key ];
+				} elseif ( array_key_exists( $key, $input ) ) {
+					$bundle_input[ $key ] = $input[ $key ];
 				}
 			}
 

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -273,10 +273,11 @@ class AIStep extends Step {
 				'pipeline_step_id' => $pipeline_step_id,
 			);
 
-			$messages = array();
+			$messages            = array();
+			$prompt_data_packets = $this->runtimeInputPacketsForPrompt( $this->dataPackets );
 
-			if ( ! empty( $this->dataPackets ) ) {
-				$data_packet_content = wp_json_encode( array( 'data_packets' => DataPacketPromptProjector::project( $this->dataPackets, $packet_projection_context ) ), JSON_UNESCAPED_UNICODE );
+			if ( ! empty( $prompt_data_packets ) ) {
+				$data_packet_content = wp_json_encode( array( 'data_packets' => DataPacketPromptProjector::project( $prompt_data_packets, $packet_projection_context ) ), JSON_UNESCAPED_UNICODE );
 				$messages[]          = ConversationManager::buildConversationMessage(
 					'user',
 					false === $data_packet_content ? '' : $data_packet_content
@@ -707,6 +708,44 @@ class AIStep extends Step {
 	 */
 	public static function sanitizeDataPacketsForAi( array $data_packets ): array {
 		return DataPacketPromptProjector::project( $data_packets );
+	}
+
+	/**
+	 * Add runtime-package caller input to the AI-visible packet list.
+	 *
+	 * Runtime-package workflows can start with caller-provided artifacts without a
+	 * preceding fetch step. Those values live in engine_data for deterministic
+	 * handlers, but AI prompt construction reads data packets. Expose the runtime
+	 * input as a prompt-only packet so agents can consume upstream artifacts while
+	 * leaving canonical pipeline packets unchanged.
+	 *
+	 * @param array $data_packets Canonical data packets.
+	 * @return array Prompt-facing data packets.
+	 */
+	private function runtimeInputPacketsForPrompt( array $data_packets ): array {
+		$runtime_input = array();
+		foreach ( array( 'artifacts', 'concept_packet', 'design_packet', 'static_site_candidate', 'import_validation_result', 'visual_parity_artifact', 'finding_packet_set' ) as $key ) {
+			if ( array_key_exists( $key, $this->engine_data ) ) {
+				$runtime_input[ $key ] = $this->engine_data[ $key ];
+			}
+		}
+
+		if ( empty( $runtime_input ) ) {
+			return $data_packets;
+		}
+
+		$packet = new DataPacket(
+			array(
+				'runtime_input' => $runtime_input,
+			),
+			array(
+				'source_type'  => 'runtime_package_input',
+				'source_label' => 'Runtime package input',
+			),
+			'runtime_input'
+		);
+
+		return $packet->addTo( $data_packets );
 	}
 
 	/**

--- a/inc/Core/Steps/Publish/Handlers/TypedArtifact/TypedArtifact.php
+++ b/inc/Core/Steps/Publish/Handlers/TypedArtifact/TypedArtifact.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Typed artifact publish handler.
+ *
+ * @package DataMachine\Core\Steps\Publish\Handlers\TypedArtifact
+ */
+
+namespace DataMachine\Core\Steps\Publish\Handlers\TypedArtifact;
+
+use DataMachine\Core\EngineData;
+use DataMachine\Core\Steps\HandlerRegistrationTrait;
+use DataMachine\Core\Steps\Publish\Handlers\PublishHandler;
+
+defined( 'ABSPATH' ) || exit;
+
+class TypedArtifact extends PublishHandler {
+	use HandlerRegistrationTrait;
+
+	public function __construct() {
+		parent::__construct( 'typed_artifact' );
+
+		self::registerHandler(
+			'typed_artifact',
+			'publish',
+			self::class,
+			'Typed Artifact',
+			'Emit a typed artifact output and canonical Data Machine packet for downstream workflow handoff.',
+			false,
+			null,
+			null,
+			array( self::class, 'registerAITool' )
+		);
+	}
+
+	/**
+	 * Register the model-facing typed artifact emitter tool.
+	 *
+	 * @param array  $tools          Existing tools.
+	 * @param string $handler_slug   Handler slug.
+	 * @param array  $handler_config Handler config.
+	 * @return array<string,array<string,mixed>>
+	 */
+	public static function registerAITool( array $tools, string $handler_slug, array $handler_config ): array {
+		if ( 'typed_artifact' !== $handler_slug ) {
+			return $tools;
+		}
+
+		$output_key = self::nonEmptyConfigString( $handler_config, 'output_key' );
+		$schema     = self::nonEmptyConfigString( $handler_config, 'schema' );
+		$artifact   = self::nonEmptyConfigString( $handler_config, 'artifact' );
+
+		$tools['emit_typed_artifact'] = array(
+			'class'                   => self::class,
+			'client_context_bindings' => array( 'job_id' ),
+			'method'                  => 'handle_tool_call',
+			'handler'                 => 'typed_artifact',
+			'description'             => sprintf(
+				'Emit the required %s typed artifact. Call this exactly once when the payload is complete; the payload must match %s.',
+				'' !== $artifact ? $artifact : 'workflow',
+				'' !== $schema ? $schema : 'the configured artifact schema'
+			),
+			'parameters'              => array(
+				'type'       => 'object',
+				'properties' => array(
+					'payload' => array(
+						'type'        => 'object',
+						'description' => sprintf( 'The %s payload object.', '' !== $artifact ? $artifact : 'typed artifact' ),
+					),
+				),
+				'required'   => array( 'payload' ),
+			),
+			'handler_config'          => $handler_config,
+		);
+
+		if ( '' !== $output_key ) {
+			$tools['emit_typed_artifact']['output_key'] = $output_key;
+		}
+		if ( '' !== $schema ) {
+			$tools['emit_typed_artifact']['artifact_schema'] = $schema;
+		}
+		if ( '' !== $artifact ) {
+			$tools['emit_typed_artifact']['artifact'] = $artifact;
+		}
+
+		return $tools;
+	}
+
+	/**
+	 * Emit a typed artifact from model-provided payload.
+	 *
+	 * @param array $parameters     Tool parameters.
+	 * @param array $handler_config Handler config.
+	 * @return array<string,mixed>
+	 */
+	protected function executePublish( array $parameters, array $handler_config ): array {
+		$payload = $parameters['payload'] ?? null;
+		if ( ! is_array( $payload ) ) {
+			return $this->errorResponse( 'payload must be an object for typed artifact output.' );
+		}
+
+		$output_key = self::nonEmptyConfigString( $handler_config, 'output_key' );
+		$schema     = self::nonEmptyConfigString( $handler_config, 'schema' );
+		$artifact   = self::nonEmptyConfigString( $handler_config, 'artifact' );
+		if ( '' === $output_key || '' === $schema || '' === $artifact ) {
+			return $this->errorResponse( 'typed_artifact handler requires output_key, schema, and artifact configuration.' );
+		}
+
+		$typed_artifact = array(
+			'output_key' => $output_key,
+			'schema'     => $schema,
+			'artifact'   => $artifact,
+			'payload'    => $payload,
+		);
+
+		$job_id = (int) ( $parameters['job_id'] ?? 0 );
+		$engine = $parameters['engine'] ?? null;
+		if ( $job_id > 0 ) {
+			$outputs                                     = $engine instanceof EngineData ? $engine->get( 'outputs', array() ) : array();
+			$outputs                                     = is_array( $outputs ) ? $outputs : array();
+			$outputs['typed_artifacts']                  = is_array( $outputs['typed_artifacts'] ?? null ) ? $outputs['typed_artifacts'] : array();
+			$outputs['typed_artifacts'][ $output_key ] = $typed_artifact;
+
+			if ( $engine instanceof EngineData ) {
+				$engine->set( 'outputs', $outputs );
+			} else {
+				EngineData::merge( $job_id, array( 'outputs' => $outputs ) );
+			}
+		}
+
+		return $this->successResponse(
+			array(
+				'output_key'      => $output_key,
+				'schema'          => $schema,
+				'artifact'        => $artifact,
+				'typed_artifacts' => array(
+					$output_key => $typed_artifact,
+				),
+				'packet'          => array(
+					'type'     => 'typed_artifact',
+					'data'     => array(
+						'output_key' => $output_key,
+						'schema'     => $schema,
+						'artifact'   => $artifact,
+						'payload'    => $payload,
+					),
+					'metadata' => array(
+						'source_type'       => 'typed_artifact_handler',
+						'handler_tool'      => 'typed_artifact',
+						'tool_success'      => true,
+						'output_key'        => $output_key,
+						'artifact_schema'   => $schema,
+						'artifact'          => $artifact,
+					),
+				),
+			)
+		);
+	}
+
+	private static function nonEmptyConfigString( array $config, string $key ): string {
+		$value = $config[ $key ] ?? '';
+		return is_scalar( $value ) ? trim( (string) $value ) : '';
+	}
+}

--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -603,7 +603,20 @@ class DataMachineCompletionAssertions {
 		}
 
 		$typed_artifacts = is_array( $data['outputs']['typed_artifacts'] ?? null ) ? $data['outputs']['typed_artifacts'] : array();
-		$satisfied       = array();
+		foreach ( $this->successful_tool_results as $tool_results ) {
+			foreach ( is_array( $tool_results ) ? $tool_results : array() as $tool_result ) {
+				if ( ! is_array( $tool_result ) ) {
+					continue;
+				}
+
+				foreach ( array( $tool_result['typed_artifacts'] ?? null, $tool_result['data']['typed_artifacts'] ?? null, $tool_result['result']['typed_artifacts'] ?? null ) as $artifact_outputs ) {
+					if ( is_array( $artifact_outputs ) ) {
+						$typed_artifacts = array_replace_recursive( $typed_artifacts, $artifact_outputs );
+					}
+				}
+			}
+		}
+		$satisfied = array();
 		foreach ( $this->required_artifact_outputs as $required_output ) {
 			if ( ! OutputContract::artifactOutputSatisfied( $required_output, $typed_artifacts ) ) {
 				continue;

--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -614,7 +614,7 @@ class DataMachineCompletionAssertions {
 					continue;
 				}
 
-				foreach ( array( $tool_result['typed_artifacts'] ?? null, $tool_result['data']['typed_artifacts'] ?? null, $tool_result['result']['typed_artifacts'] ?? null ) as $artifact_outputs ) {
+				foreach ( array( $tool_result['typed_artifacts'] ?? null, $tool_result['outputs']['typed_artifacts'] ?? null, $tool_result['data']['typed_artifacts'] ?? null, $tool_result['result']['typed_artifacts'] ?? null ) as $artifact_outputs ) {
 					if ( is_array( $artifact_outputs ) ) {
 						$typed_artifacts = array_replace_recursive( $typed_artifacts, $artifact_outputs );
 					}

--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -602,7 +602,12 @@ class DataMachineCompletionAssertions {
 			}
 		}
 
-		$typed_artifacts = is_array( $data['outputs']['typed_artifacts'] ?? null ) ? $data['outputs']['typed_artifacts'] : array();
+		$typed_artifacts = array();
+		foreach ( array( $data['outputs']['typed_artifacts'] ?? null, $runtime_context['outputs']['typed_artifacts'] ?? null ) as $artifact_outputs ) {
+			if ( is_array( $artifact_outputs ) ) {
+				$typed_artifacts = array_replace_recursive( $typed_artifacts, $artifact_outputs );
+			}
+		}
 		foreach ( $this->successful_tool_results as $tool_results ) {
 			foreach ( is_array( $tool_results ) ? $tool_results : array() as $tool_result ) {
 				if ( ! is_array( $tool_result ) ) {

--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -79,7 +79,7 @@ class DataMachineCompletionAssertions {
 	 * @param array      $tool_parameters Tool parameters.
 	 */
 	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, array $tool_parameters = array() ): void {
-		$tool_succeeded = true === ( $tool_result['success'] ?? false );
+		$tool_succeeded = true === ( $tool_result['success'] ?? false ) || in_array( (string) ( $tool_result['status'] ?? '' ), array( 'success', 'succeeded', 'completed' ), true );
 
 		if ( '' !== $tool_name && $tool_succeeded ) {
 			$tool_result['_parameters']                    = $tool_parameters;
@@ -614,7 +614,7 @@ class DataMachineCompletionAssertions {
 					continue;
 				}
 
-				foreach ( array( $tool_result['typed_artifacts'] ?? null, $tool_result['outputs']['typed_artifacts'] ?? null, $tool_result['data']['typed_artifacts'] ?? null, $tool_result['result']['typed_artifacts'] ?? null ) as $artifact_outputs ) {
+				foreach ( array( $tool_result['typed_artifacts'] ?? null, $tool_result['outputs']['typed_artifacts'] ?? null, $tool_result['data']['typed_artifacts'] ?? null, $tool_result['result']['typed_artifacts'] ?? null, $tool_result['result']['data']['typed_artifacts'] ?? null ) as $artifact_outputs ) {
 					if ( is_array( $artifact_outputs ) ) {
 						$typed_artifacts = array_replace_recursive( $typed_artifacts, $artifact_outputs );
 					}

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -518,6 +518,21 @@ function datamachine_normalize_typed_artifact_outputs( array $result ): array {
 	if ( is_array( $result['typed_artifacts'] ?? null ) ) {
 		$sources[] = $result['typed_artifacts'];
 	}
+	foreach ( is_array( $result['tool_execution_results'] ?? null ) ? $result['tool_execution_results'] : array() as $tool_result ) {
+		if ( ! is_array( $tool_result ) ) {
+			continue;
+		}
+
+		if ( is_array( $tool_result['typed_artifacts'] ?? null ) ) {
+			$sources[] = $tool_result['typed_artifacts'];
+		}
+		if ( is_array( $tool_result['data']['typed_artifacts'] ?? null ) ) {
+			$sources[] = $tool_result['data']['typed_artifacts'];
+		}
+		if ( is_array( $tool_result['result']['typed_artifacts'] ?? null ) ) {
+			$sources[] = $tool_result['result']['typed_artifacts'];
+		}
+	}
 
 	$typed_artifacts = array();
 	foreach ( $sources as $source ) {

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -535,6 +535,9 @@ function datamachine_normalize_typed_artifact_outputs( array $result ): array {
 		if ( is_array( $tool_result['result']['typed_artifacts'] ?? null ) ) {
 			$sources[] = $tool_result['result']['typed_artifacts'];
 		}
+		if ( is_array( $tool_result['result']['data']['typed_artifacts'] ?? null ) ) {
+			$sources[] = $tool_result['result']['data']['typed_artifacts'];
+		}
 	}
 
 	$typed_artifacts = array();

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -526,6 +526,9 @@ function datamachine_normalize_typed_artifact_outputs( array $result ): array {
 		if ( is_array( $tool_result['typed_artifacts'] ?? null ) ) {
 			$sources[] = $tool_result['typed_artifacts'];
 		}
+		if ( is_array( $tool_result['outputs']['typed_artifacts'] ?? null ) ) {
+			$sources[] = $tool_result['outputs']['typed_artifacts'];
+		}
 		if ( is_array( $tool_result['data']['typed_artifacts'] ?? null ) ) {
 			$sources[] = $tool_result['data']['typed_artifacts'];
 		}

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -148,6 +148,7 @@ final class AgentBundleRunner {
 	/** @return array<string,mixed> */
 	private function response( array $response, array $input, array $runtime_imports = array(), array $selection = array() ): array {
 		$response['schema'] ??= 'datamachine/agent-bundle-run/v1';
+		$response           = $this->apply_wait_result_status( $response );
 
 		if ( ! empty( $runtime_imports ) ) {
 			$response['runtime_imports'] = $runtime_imports;
@@ -174,6 +175,26 @@ final class AgentBundleRunner {
 		$response['status']             = $this->status_from_response( $response );
 		$response['success']            = ! empty( $response['success'] ) && self::is_success_status( $response['status'] );
 		$response['completion_outcome'] = $this->completion_outcome( $response );
+
+		return $response;
+	}
+
+	/** @return array<string,mixed> */
+	private function apply_wait_result_status( array $response ): array {
+		if ( empty( $response['wait_for_completion'] ) || ! is_array( $response['wait_result'] ?? null ) ) {
+			return $response;
+		}
+
+		$wait_result = $response['wait_result'];
+		if ( ! empty( $wait_result['success'] ) ) {
+			return $response;
+		}
+
+		$response['success'] = false;
+		$response['error'] ??= (string) ( $wait_result['error'] ?? 'Agent bundle run did not reach a terminal job state before the wait budget was exhausted.' );
+		if ( empty( $response['error_type'] ) ) {
+			$response['error_type'] = (string) ( $wait_result['error_type'] ?? 'wait_incomplete' );
+		}
 
 		return $response;
 	}

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -74,6 +74,7 @@ final class AgentBundleRunner {
 
 		$workflow     = is_array( $workflow_override['workflow'] ?? null ) ? $workflow_override['workflow'] : $this->workflow_from_bundle_flow( $selection['flow'], $selection['pipeline'], $input );
 		$initial_data = is_array( $workflow_override['initial_data'] ?? null ) ? $workflow_override['initial_data'] : array();
+		$initial_data = array_merge( $initial_data, $this->initial_data_from_workflow_input( $input ) );
 		$initial_data = array_merge( $initial_data, is_array( $input['initial_data'] ?? null ) ? $input['initial_data'] : array() );
 		$manifest     = $directory->manifest()->to_array();
 
@@ -143,6 +144,21 @@ final class AgentBundleRunner {
 		);
 
 		return $this->response( $response, $input, $runtime_imports, $selection );
+	}
+
+	/**
+	 * Promote caller workflow input into workflow state for runtime-package runs.
+	 *
+	 * @param array<string,mixed> $input Bundle run input.
+	 * @return array<string,mixed>
+	 */
+	private function initial_data_from_workflow_input( array $input ): array {
+		$workflow_input = is_array( $input['input'] ?? null ) ? $input['input'] : array();
+		foreach ( array( 'wait_for_completion', 'wait', 'step_budget', 'time_budget_ms', 'required_outputs', 'required_artifacts', 'engine_data_outputs', 'runtime_tools', 'ability_tools', 'tools', 'disable_directives' ) as $control_field ) {
+			unset( $workflow_input[ $control_field ] );
+		}
+
+		return $workflow_input;
 	}
 
 	/** @return array<string,mixed> */

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -552,6 +552,24 @@ datamachine_bundle_runner_assert( 'completed_no_items' === ( $no_item_response['
 datamachine_bundle_runner_assert( true === ( $no_item_response['success'] ?? null ), 'no-item terminal status is a successful bundle run', $failures, $passes );
 datamachine_bundle_runner_assert( true === ( $no_item_response['completion_outcome']['success'] ?? null ), 'no-item completion outcome is successful', $failures, $passes );
 
+$incomplete_wait_response = $response_method->invoke(
+	$runner_instance,
+	array(
+		'success'             => true,
+		'wait_for_completion' => true,
+		'wait_result'         => array(
+			'success'           => false,
+			'terminal_state'    => null,
+			'remaining_actions' => 1,
+		),
+		'job_status'          => 'processing',
+	),
+	array( 'wait_for_completion' => true )
+);
+datamachine_bundle_runner_assert( false === ( $incomplete_wait_response['success'] ?? null ), 'non-terminal wait result fails the bundle run', $failures, $passes );
+datamachine_bundle_runner_assert( 'failed' === ( $incomplete_wait_response['status'] ?? null ), 'non-terminal wait result exposes failed status', $failures, $passes );
+datamachine_bundle_runner_assert( 'wait_incomplete' === ( $incomplete_wait_response['error_type'] ?? null ), 'non-terminal wait result exposes typed error', $failures, $passes );
+
 echo "\n[3f] Completed bundle runs enforce required semantic outputs\n";
 $missing_artifact_response = $response_method->invoke(
 	$runner_instance,

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -80,6 +80,8 @@ foreach ( array(
 datamachine_bundle_runner_contains( $bootstrap, "add_filter( 'wp_agent_runtime_import_bundle', array( AgentAbilities::class, 'importRuntimeAgentBundle' ), 5, 4 )", 'Data Machine importer runs before generic runtime bundle fallback', $failures, $passes );
 datamachine_bundle_runner_contains( $bootstrap, "add_filter( 'wp_agent_runtime_run_bundle'", 'Data Machine registers generic runtime run seam', $failures, $passes );
 datamachine_bundle_runner_contains( $bootstrap, "add_filter( 'wp_agent_runtime_package_run_handler', array( AgentAbilities::class, 'runtimePackageRunHandler' ), 10, 3 )", 'Data Machine registers Agents API runtime-package handler', $failures, $passes );
+datamachine_bundle_runner_contains( $abilities, 'array_key_exists( $key, $input )', 'runtime-package handler lifts control fields from package input', $failures, $passes );
+datamachine_bundle_runner_contains( $abilities, 'array_replace( $raw_input[\'options\']', 'runtime-package handler falls back to raw package options', $failures, $passes );
 
 echo "\n[2] Runner projects bundles to ephemeral workflows\n";
 foreach ( array(
@@ -174,6 +176,27 @@ $path_override = $workflow_override->invoke( $runner_instance, array( 'execute_w
 @unlink( $workflow_path );
 datamachine_bundle_runner_assert( true === ( $path_override['success'] ?? false ), 'file workflow override resolves', $failures, $passes );
 datamachine_bundle_runner_assert( 'Path override' === ( $path_override['workflow']['steps'][0]['label'] ?? null ), 'file workflow override unwraps workflow payload', $failures, $passes );
+
+$initial_data_from_workflow_input = $runner_reflection->getMethod( 'initial_data_from_workflow_input' );
+$runtime_initial_data             = $initial_data_from_workflow_input->invoke(
+	$runner_instance,
+	array(
+		'input' => array(
+			'wait_for_completion' => true,
+			'site_kind'           => 'store',
+			'artifacts'           => array(
+				'concept_packet' => array(
+					'payload' => array( 'title' => 'Kiln Shelf Supply' ),
+				),
+			),
+			'concept_packet'     => array( 'title' => 'Kiln Shelf Supply' ),
+		),
+	)
+);
+datamachine_bundle_runner_assert( 'store' === ( $runtime_initial_data['site_kind'] ?? null ), 'runtime workflow input scalar is promoted to initial_data', $failures, $passes );
+datamachine_bundle_runner_assert( 'Kiln Shelf Supply' === ( $runtime_initial_data['concept_packet']['title'] ?? null ), 'runtime workflow artifact alias is promoted to initial_data', $failures, $passes );
+datamachine_bundle_runner_assert( 'Kiln Shelf Supply' === ( $runtime_initial_data['artifacts']['concept_packet']['payload']['title'] ?? null ), 'runtime workflow artifacts map is promoted to initial_data', $failures, $passes );
+datamachine_bundle_runner_assert( ! isset( $runtime_initial_data['wait_for_completion'] ), 'runtime workflow control field is not promoted to initial_data', $failures, $passes );
 
 $output_projection = $runner_reflection->getMethod( 'output_projection' );
 $projected_outputs = $output_projection->invoke(

--- a/tests/ai-completion-assertion-packet-smoke.php
+++ b/tests/ai-completion-assertion-packet-smoke.php
@@ -104,6 +104,7 @@ echo "-------------------------------------\n\n";
 
 $method = new ReflectionMethod( AIStep::class, 'processLoopResults' );
 $missing_method = new ReflectionMethod( AIStep::class, 'missingCompletionAssertionsFailure' );
+$runtime_input_method = new ReflectionMethod( AIStep::class, 'runtimeInputPacketsForPrompt' );
 
 $result = $method->invoke(
 	null,
@@ -161,6 +162,26 @@ $complete_failure = $missing_method->invoke(
 );
 
 assert_completion_packet( null === $complete_failure, 'satisfied assertions do not build failure payload', $failures, $passes );
+
+$ai_step_reflection = new ReflectionClass( AIStep::class );
+$ai_step            = $ai_step_reflection->newInstanceWithoutConstructor();
+$engine_data_prop   = $ai_step_reflection->getParentClass()->getProperty( 'engine_data' );
+$engine_data_prop->setValue(
+	$ai_step,
+	array(
+		'artifacts'      => array(
+			'concept_packet' => array(
+				'payload' => array( 'title' => 'Runtime concept' ),
+			),
+		),
+		'concept_packet' => array( 'title' => 'Runtime concept' ),
+	)
+);
+$runtime_packets = $runtime_input_method->invoke( $ai_step, array() );
+assert_completion_packet( 1 === count( $runtime_packets ), 'runtime input prompt packet is added when runtime artifacts exist', $failures, $passes );
+assert_completion_packet( 'runtime_input' === ( $runtime_packets[0]['type'] ?? null ), 'runtime input packet uses runtime_input type', $failures, $passes );
+assert_completion_packet( 'Runtime concept' === ( $runtime_packets[0]['data']['runtime_input']['concept_packet']['title'] ?? null ), 'runtime concept packet is prompt-visible', $failures, $passes );
+assert_completion_packet( 'Runtime concept' === ( $runtime_packets[0]['data']['runtime_input']['artifacts']['concept_packet']['payload']['title'] ?? null ), 'runtime artifact map is prompt-visible', $failures, $passes );
 
 echo "\n-------------------------------------\n";
 echo sprintf( "%d / %d passed\n", $passes, $passes + count( $failures ) );

--- a/tests/typed-artifact-handler-smoke.php
+++ b/tests/typed-artifact-handler-smoke.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Focused contract test for the typed_artifact publish handler.
+ *
+ * Run with: php tests/typed-artifact-handler-smoke.php
+ */
+
+$root = dirname( __DIR__ );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', $root . '/' );
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter() {}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action() {}
+}
+require_once $root . '/inc/Core/Steps/Handlers/HttpRequestHelpers.php';
+require_once $root . '/inc/Core/Steps/Publish/Handlers/PublishHandler.php';
+require_once $root . '/inc/Core/Steps/HandlerRegistrationTrait.php';
+require_once $root . '/inc/Core/Steps/Publish/Handlers/TypedArtifact/TypedArtifact.php';
+
+$failures = 0;
+$passes   = 0;
+
+function typed_artifact_handler_assert( bool $condition, string $message, int &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	++$failures;
+	echo "FAIL: {$message}\n";
+}
+
+$tools = \DataMachine\Core\Steps\Publish\Handlers\TypedArtifact\TypedArtifact::registerAITool(
+	array(),
+	'typed_artifact',
+	array(
+		'output_key' => 'concept_packet',
+		'schema'     => 'wp-site-generator/ConceptPacket/v1',
+		'artifact'   => 'ConceptPacket',
+	)
+);
+
+typed_artifact_handler_assert( isset( $tools['emit_typed_artifact'] ), 'typed_artifact exposes emit_typed_artifact tool', $failures, $passes );
+typed_artifact_handler_assert( array( 'payload' ) === ( $tools['emit_typed_artifact']['parameters']['required'] ?? null ), 'tool requires payload object', $failures, $passes );
+typed_artifact_handler_assert( 'concept_packet' === ( $tools['emit_typed_artifact']['output_key'] ?? null ), 'tool carries output key metadata', $failures, $passes );
+typed_artifact_handler_assert( 'wp-site-generator/ConceptPacket/v1' === ( $tools['emit_typed_artifact']['artifact_schema'] ?? null ), 'tool carries artifact schema metadata', $failures, $passes );
+
+if ( 0 !== $failures ) {
+	echo "typed-artifact-handler-smoke failed: {$failures} failure(s), {$passes} pass(es).\n";
+	exit( 1 );
+}
+
+echo "typed-artifact-handler-smoke passed: {$passes} assertion(s).\n";

--- a/tests/typed-artifact-output-contract-smoke.php
+++ b/tests/typed-artifact-output-contract-smoke.php
@@ -143,6 +143,38 @@ $tool_result_assertions->recordToolResult(
 $tool_result_satisfied = $tool_result_assertions->evaluate( array(), '' );
 datamachine_typed_artifact_contract_assert( true === $tool_result_satisfied['complete'], 'required_artifact_outputs can be satisfied by a handler tool result', $failures, $passes );
 
+$wrapped_tool_result_assertions = new \DataMachine\Engine\AI\DataMachineCompletionAssertions(
+	array(
+		'required_artifact_outputs' => array(
+			array(
+				'output_key' => 'concept_packet',
+				'schema'     => 'example-agent/ConceptPacket/v1',
+				'artifact'   => 'ConceptPacket',
+			),
+		),
+	)
+);
+$wrapped_tool_result_assertions->recordToolResult(
+	'emit_typed_artifact',
+	array( 'handler' => 'typed_artifact' ),
+	array(
+		'status' => 'success',
+		'result' => array(
+			'data' => array(
+				'typed_artifacts' => array(
+					'concept_packet' => array(
+						'schema'   => 'example-agent/ConceptPacket/v1',
+						'artifact' => 'ConceptPacket',
+						'payload'  => array( 'title' => 'Wrapped Tool Result Concept' ),
+					),
+				),
+			),
+		),
+	)
+);
+$wrapped_tool_result_satisfied = $wrapped_tool_result_assertions->evaluate( array(), '' );
+datamachine_typed_artifact_contract_assert( true === $wrapped_tool_result_satisfied['complete'], 'required_artifact_outputs can be satisfied by wrapped handler tool result data', $failures, $passes );
+
 $missing = $assertions->evaluate(
 	array(
 		'engine_data' => array(

--- a/tests/typed-artifact-output-contract-smoke.php
+++ b/tests/typed-artifact-output-contract-smoke.php
@@ -129,7 +129,7 @@ $tool_result_assertions->recordToolResult(
 	array( 'handler' => 'typed_artifact' ),
 	array(
 		'success' => true,
-		'data'    => array(
+		'outputs' => array(
 			'typed_artifacts' => array(
 				'concept_packet' => array(
 					'schema'   => 'example-agent/ConceptPacket/v1',

--- a/tests/typed-artifact-output-contract-smoke.php
+++ b/tests/typed-artifact-output-contract-smoke.php
@@ -56,7 +56,7 @@ $tool_result_normalized = \DataMachine\Engine\AI\datamachine_normalize_typed_art
 		'tool_execution_results' => array(
 			array(
 				'success' => true,
-				'data'    => array(
+				'outputs' => array(
 					'typed_artifacts' => array(
 						'concept_packet' => array(
 							'schema'   => 'example-agent/ConceptPacket/v1',
@@ -72,7 +72,7 @@ $tool_result_normalized = \DataMachine\Engine\AI\datamachine_normalize_typed_art
 
 datamachine_typed_artifact_contract_assert(
 	array( 'title' => 'Tool Result Concept' ) === ( $tool_result_normalized['concept_packet']['payload'] ?? null ),
-	'typed artifact output normalizes from tool result data',
+	'typed artifact output normalizes from tool result outputs',
 	$failures,
 	$passes
 );

--- a/tests/typed-artifact-output-contract-smoke.php
+++ b/tests/typed-artifact-output-contract-smoke.php
@@ -103,6 +103,16 @@ $satisfied = $assertions->evaluate(
 datamachine_typed_artifact_contract_assert( true === $satisfied['complete'], 'required_artifact_outputs is recognized as a completion assertion target', $failures, $passes );
 datamachine_typed_artifact_contract_assert( array( 'concept_packet' ) === ( $satisfied['satisfied']['artifact_outputs'] ?? null ), 'typed artifact completion reports the satisfied output key', $failures, $passes );
 
+$top_level_satisfied = $assertions->evaluate(
+	array(
+		'outputs' => array(
+			'typed_artifacts' => $normalized,
+		),
+	),
+	''
+);
+datamachine_typed_artifact_contract_assert( true === $top_level_satisfied['complete'], 'required_artifact_outputs is recognized from top-level outputs.typed_artifacts', $failures, $passes );
+
 $tool_result_assertions = new \DataMachine\Engine\AI\DataMachineCompletionAssertions(
 	array(
 		'required_artifact_outputs' => array(

--- a/tests/typed-artifact-output-contract-smoke.php
+++ b/tests/typed-artifact-output-contract-smoke.php
@@ -51,6 +51,32 @@ datamachine_typed_artifact_contract_assert(
 	$passes
 );
 
+$tool_result_normalized = \DataMachine\Engine\AI\datamachine_normalize_typed_artifact_outputs(
+	array(
+		'tool_execution_results' => array(
+			array(
+				'success' => true,
+				'data'    => array(
+					'typed_artifacts' => array(
+						'concept_packet' => array(
+							'schema'   => 'example-agent/ConceptPacket/v1',
+							'artifact' => 'ConceptPacket',
+							'payload'  => array( 'title' => 'Tool Result Concept' ),
+						),
+					),
+				),
+			),
+		),
+	)
+);
+
+datamachine_typed_artifact_contract_assert(
+	array( 'title' => 'Tool Result Concept' ) === ( $tool_result_normalized['concept_packet']['payload'] ?? null ),
+	'typed artifact output normalizes from tool result data',
+	$failures,
+	$passes
+);
+
 $assertions = new \DataMachine\Engine\AI\DataMachineCompletionAssertions(
 	array(
 		'required_artifact_outputs' => array(
@@ -76,6 +102,36 @@ $satisfied = $assertions->evaluate(
 
 datamachine_typed_artifact_contract_assert( true === $satisfied['complete'], 'required_artifact_outputs is recognized as a completion assertion target', $failures, $passes );
 datamachine_typed_artifact_contract_assert( array( 'concept_packet' ) === ( $satisfied['satisfied']['artifact_outputs'] ?? null ), 'typed artifact completion reports the satisfied output key', $failures, $passes );
+
+$tool_result_assertions = new \DataMachine\Engine\AI\DataMachineCompletionAssertions(
+	array(
+		'required_artifact_outputs' => array(
+			array(
+				'output_key' => 'concept_packet',
+				'schema'     => 'example-agent/ConceptPacket/v1',
+				'artifact'   => 'ConceptPacket',
+			),
+		),
+	)
+);
+$tool_result_assertions->recordToolResult(
+	'emit_typed_artifact',
+	array( 'handler' => 'typed_artifact' ),
+	array(
+		'success' => true,
+		'data'    => array(
+			'typed_artifacts' => array(
+				'concept_packet' => array(
+					'schema'   => 'example-agent/ConceptPacket/v1',
+					'artifact' => 'ConceptPacket',
+					'payload'  => array( 'title' => 'Tool Result Concept' ),
+				),
+			),
+		),
+	)
+);
+$tool_result_satisfied = $tool_result_assertions->evaluate( array(), '' );
+datamachine_typed_artifact_contract_assert( true === $tool_result_satisfied['complete'], 'required_artifact_outputs can be satisfied by a handler tool result', $failures, $passes );
 
 $missing = $assertions->evaluate(
 	array(


### PR DESCRIPTION
## Summary
- Promote runtime-package caller input and artifacts into bundle workflow initial data.
- Add a prompt-visible `runtime_input` packet so AI steps can consume hydrated runtime artifacts.
- Lift runtime-package control fields and raw options fallbacks so wait controls survive the runtime-package boundary.

## Validation
- `php tests/agent-bundle-runner-contract-smoke.php`
- `php tests/ai-completion-assertion-packet-smoke.php`
- `php -l inc/Abilities/AgentAbilities.php`
- `php -l inc/Core/Steps/AI/AIStep.php`
- `php -l inc/Engine/Bundle/AgentBundleRunner.php`

## Notes
- This fixes the confirmed Data Machine runtime-package input visibility and control-field propagation gaps found during the Homeboy lab loop.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing runtime-package input/control propagation, implementing the upstream fix, and adding contract coverage.