### PR TITLE
Improve bundle source import diagnostics

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -1317,8 +1317,9 @@ class AgentAbilities {
 		$source            = trim( (string) ( $input['source'] ?? '' ) );
 		if ( ! $has_inline_bundle && '' === $source ) {
 			return array(
-				'success' => false,
-				'error'   => 'Bundle source or inline bundle is required.',
+				'success'     => false,
+				'error'       => 'Bundle source or inline bundle is required.',
+				'diagnostics' => self::bundle_source_import_diagnostics( $source ),
 			);
 		}
 
@@ -1330,8 +1331,9 @@ class AgentAbilities {
 			$resolved = BundleSource::resolve( $source, $context );
 			if ( is_wp_error( $resolved ) ) {
 				return array(
-					'success' => false,
-					'error'   => $resolved->get_error_message(),
+					'success'     => false,
+					'error'       => $resolved->get_error_message(),
+					'diagnostics' => self::bundle_source_import_diagnostics( $source ),
 				);
 			}
 
@@ -1374,8 +1376,9 @@ class AgentAbilities {
 
 		if ( ! is_array( $bundle ) ) {
 			return array(
-				'success' => false,
-				'error'   => 'Failed to parse bundle. Use a bundle directory, .json file, or .zip archive.',
+				'success'     => false,
+				'error'       => 'Failed to parse bundle. Use a bundle directory, .json file, or .zip archive.',
+				'diagnostics' => $has_inline_bundle ? array() : self::bundle_source_import_diagnostics( $source ),
 			);
 		}
 
@@ -1876,6 +1879,27 @@ class AgentAbilities {
 		return BundleSourceAuth::build_resolve_context(
 			isset( $input['token'] ) ? (string) $input['token'] : null,
 			isset( $input['token_env'] ) ? (string) $input['token_env'] : null
+		);
+	}
+
+	/**
+	 * Build source import diagnostics for runtime/package callers.
+	 *
+	 * @param string $source Attempted source path or URL.
+	 * @return array<string,mixed>
+	 */
+	private static function bundle_source_import_diagnostics( string $source ): array {
+		$context = 'empty';
+		if ( '' !== $source ) {
+			$context = BundleSource::is_remote( $source ) ? 'remote_url' : 'local_path';
+		}
+		$cwd = getcwd();
+
+		return array(
+			'source'         => $source,
+			'cwd'            => false === $cwd ? '' : $cwd,
+			'context'        => $context,
+			'expected_shape' => 'Readable local directory, .zip, or JSON file, or remote .zip/.json URL containing a Data Machine agent bundle.',
 		);
 	}
 

--- a/tests/Unit/Abilities/SettingsAbilitiesTest.php
+++ b/tests/Unit/Abilities/SettingsAbilitiesTest.php
@@ -174,6 +174,7 @@ class SettingsAbilitiesTest extends WP_UnitTestCase {
 		$updated_settings = get_option( 'datamachine_settings', array() );
 		$this->assertSame(
 			array(
+				'max_active_jobs'    => 500,
 				'concurrent_batches' => 50,
 				'batch_size'         => 500,
 				'time_limit'         => 300,
@@ -202,6 +203,7 @@ class SettingsAbilitiesTest extends WP_UnitTestCase {
 		$updated_settings = get_option( 'datamachine_settings', array() );
 		$this->assertSame(
 			array(
+				'max_active_jobs'    => 500,
 				'concurrent_batches' => 50,
 				'batch_size'         => 500,
 				'time_limit'         => 300,

--- a/tests/import-agent-ability-smoke.php
+++ b/tests/import-agent-ability-smoke.php
@@ -287,6 +287,7 @@ namespace {
 	$agent_abilities_source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/AgentAbilities.php' );
 	$assert( 'import-agent execution validates source-or-bundle requirement', false !== strpos( $agent_abilities_source, 'Bundle source or inline bundle is required.' ) && false === strpos( $agent_abilities_source, "array( 'required' => array( 'bundle' ) )" ) );
 	$assert( 'import-agent schema exposes inline bundle input', false !== strpos( $agent_abilities_source, "'bundle'      => array(" ) && false !== strpos( $agent_abilities_source, 'Already-parsed portable Data Machine agent bundle array' ) );
+	$assert( 'import-agent schema keeps source as canonical path field', false !== strpos( $agent_abilities_source, "'source'            => array(" ) && false === strpos( $agent_abilities_source, "'source_path'" ) );
 	$assert( 'runtime importer does not stage bundles through temp files', false === strpos( $agent_abilities_source, 'tempnam' ) && false === strpos( $agent_abilities_source, 'wp_tempnam' ) );
 
 	echo "=== Import Agent Ability Behavior Smoke (#1306) ===\n";
@@ -359,6 +360,26 @@ namespace {
 	$assert( 'owner_id passes through to bundler import', 99 === AgentBundler::$last_import['owner_id'] );
 	// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 	$assert( 'ability lets bundler use rewritten bundle slug, not new_slug', null === AgentBundler::$last_import['new_slug'] );
+
+	$reset();
+	$missing_source = sys_get_temp_dir() . '/datamachine-missing-runtime-bundle-' . uniqid() . '.json';
+	$result         = AgentAbilities::importAgent( array( 'source' => $missing_source ) );
+	$assert( 'missing source import fails', false === $result['success'] );
+	$assert( 'missing source diagnostic reports attempted source', $missing_source === ( $result['diagnostics']['source'] ?? '' ) );
+	$assert( 'missing source diagnostic reports cwd', isset( $result['diagnostics']['cwd'] ) && is_string( $result['diagnostics']['cwd'] ) );
+	$assert( 'missing source diagnostic reports context', 'local_path' === ( $result['diagnostics']['context'] ?? '' ) );
+	$assert( 'missing source diagnostic reports expected shape', 'Readable local directory, .zip, or JSON file, or remote .zip/.json URL containing a Data Machine agent bundle.' === ( $result['diagnostics']['expected_shape'] ?? '' ) );
+
+	$reset();
+	$invalid_json_temp = tempnam( sys_get_temp_dir(), 'datamachine-invalid-runtime-bundle-' );
+	$invalid_json_path = $invalid_json_temp . '.json';
+	rename( $invalid_json_temp, $invalid_json_path );
+	file_put_contents( $invalid_json_path, '{not valid json' );
+	$result = AgentAbilities::importAgent( array( 'source' => $invalid_json_path ) );
+	$assert( 'invalid source import fails', false === $result['success'] );
+	$assert( 'invalid source diagnostic reports attempted source', $invalid_json_path === ( $result['diagnostics']['source'] ?? '' ) );
+	$assert( 'invalid source diagnostic reports expected shape', 'Readable local directory, .zip, or JSON file, or remote .zip/.json URL containing a Data Machine agent bundle.' === ( $result['diagnostics']['expected_shape'] ?? '' ) );
+	@unlink( $invalid_json_path );
 
 	echo "\n[3] Inline bundle import path\n";
 	$reset();


### PR DESCRIPTION
## Summary
- Keep `source` as the canonical Data Machine import-agent/bundle lifecycle source field.
- Remove the proposed broad `source_path` alias from this PR.
- Add generic diagnostics for missing, unreadable, and unparsable canonical `source` imports: attempted source, cwd, source context, and expected shape.
- Add smoke coverage that schemas match the canonical `source` implementation.
- Update queue tuning unit expectations for the existing `max_active_jobs` field returned by runtime defaults.

## Tests
- `php tests/import-agent-ability-smoke.php`
- `php tests/agent-bundle-runner-contract-smoke.php`
- `php -l inc/Abilities/AgentAbilities.php && php -l tests/import-agent-ability-smoke.php && php -l tests/Unit/Abilities/SettingsAbilitiesTest.php`
- `vendor/bin/phpcs inc/Abilities/AgentAbilities.php tests/import-agent-ability-smoke.php tests/Unit/Abilities/SettingsAbilitiesTest.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, test updates, verification, and PR drafting.