### PR TITLE
refactor: stage default provider-turn adapter adoption seam (partial #2803)

### DIFF
--- a/inc/Engine/AI/DataMachineProviderTurnState.php
+++ b/inc/Engine/AI/DataMachineProviderTurnState.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Mutable per-turn state for the Data Machine conversation loop.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Mutable per-turn state surfaced to the caller for the pre-substrate error path.
+ *
+ * The upstream conversation loop surfaces turn_count, final_content, usage, and
+ * request_metadata on the FINAL result (agents-api#136). DM only needs to carry
+ * these by reference for the case where the provider-turn adapter throws a
+ * RuntimeException BEFORE the substrate can return its accumulated result — see
+ * the catch block in datamachine_run_conversation(), which reconstructs a
+ * best-effort error result from the last completed turn. Consolidating the
+ * three previously-separate by-ref params (latest_messages, latest_turn_count,
+ * last_request_metadata) into one accumulator shrinks the provider-turn
+ * adapter's parameter surface toward the #2803 decomposition target without
+ * changing behavior.
+ */
+final class DataMachineProviderTurnState {
+
+	/** @var array Messages handed to the latest dispatched turn. */
+	public array $latest_messages;
+
+	/** @var int Turn number of the latest dispatched turn. */
+	public int $latest_turn_count = 0;
+
+	/** @var array Request metadata captured on the latest dispatched turn. */
+	public array $last_request_metadata = array();
+
+	/**
+	 * @param array $initial_messages Initial conversation messages.
+	 */
+	public function __construct( array $initial_messages ) {
+		$this->latest_messages = $initial_messages;
+	}
+}

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -858,39 +858,6 @@ function datamachine_enrich_mediated_tool_results( array $tool_results, array $t
 }
 
 /**
- * Mutable per-turn state surfaced to the caller for the pre-substrate error path.
- *
- * The upstream conversation loop surfaces turn_count, final_content, usage, and
- * request_metadata on the FINAL result (agents-api#136). DM only needs to carry
- * these by reference for the case where the provider-turn adapter throws a
- * RuntimeException BEFORE the substrate can return its accumulated result — see
- * the catch block in datamachine_run_conversation(), which reconstructs a
- * best-effort error result from the last completed turn. Consolidating the
- * three previously-separate by-ref params (latest_messages, latest_turn_count,
- * last_request_metadata) into one accumulator shrinks the provider-turn
- * adapter's parameter surface toward the #2803 decomposition target without
- * changing behavior.
- */
-final class DataMachineProviderTurnState {
-
-	/** @var array Messages handed to the latest dispatched turn. */
-	public array $latest_messages;
-
-	/** @var int Turn number of the latest dispatched turn. */
-	public int $latest_turn_count = 0;
-
-	/** @var array Request metadata captured on the latest dispatched turn. */
-	public array $last_request_metadata = array();
-
-	/**
-	 * @param array $initial_messages Initial conversation messages.
-	 */
-	public function __construct( array $initial_messages ) {
-		$this->latest_messages = $initial_messages;
-	}
-}
-
-/**
  * Dispatch one DM provider turn and normalize the wp-ai-client result.
  *
  * Owns the genuinely DM-specific half of a provider turn:
@@ -954,6 +921,7 @@ function datamachine_dispatch_provider_turn(
 		$loop_payload,
 		$request_metadata
 	);
+
 	$turn_state->last_request_metadata = $request_metadata;
 
 	// Handle AI request failure — throw so the upstream loop catches and the
@@ -1079,9 +1047,9 @@ function datamachine_build_provider_turn_adapter(
 		}
 
 		// The upstream loop provides the turn number via turn_context.
-		$turn_count                     = (int) ( $turn_context['turn'] ?? 1 );
-		$turn_state->latest_turn_count  = $turn_count;
-		$turn_state->latest_messages    = $messages;
+		$turn_count                    = (int) ( $turn_context['turn'] ?? 1 );
+		$turn_state->latest_turn_count = $turn_count;
+		$turn_state->latest_messages   = $messages;
 
 		// Dispatch one DM provider turn: prompt assembly + authenticated
 		// wp-ai-client dispatch + provider-safe tool-name aliasing + per-turn

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -90,9 +90,7 @@ function datamachine_run_conversation(
 	$all_tool_calls         = array();
 	$tool_execution_results = array();
 	$completion_nudges      = array();
-	$last_request_metadata  = array();
-	$latest_messages        = $messages;
-	$latest_turn_count      = 0;
+	$turn_state             = new DataMachineProviderTurnState( $messages );
 	$runtime_tool_pending   = false;
 	$runtime_tool_requests  = array();
 
@@ -190,9 +188,7 @@ function datamachine_run_conversation(
 		$base_log_context,
 		$last_tool_calls,
 		$all_tool_calls,
-		$last_request_metadata,
-		$latest_messages,
-		$latest_turn_count,
+		$turn_state,
 		$completion_policy,
 		$completion_nudges
 	);
@@ -273,13 +269,13 @@ function datamachine_run_conversation(
 		// known state from completed turns so failed job artifacts still explain
 		// where the conversation stopped.
 		$error_result          = array(
-			'messages'               => $latest_messages,
+			'messages'               => $turn_state->latest_messages,
 			'final_content'          => '',
-			'turn_count'             => $latest_turn_count,
+			'turn_count'             => $turn_state->latest_turn_count,
 			'tool_execution_results' => $tool_execution_results,
 			'error'                  => $e->getMessage(),
 			'usage'                  => array(),
-			'request_metadata'       => $last_request_metadata,
+			'request_metadata'       => $turn_state->last_request_metadata,
 			'status'                 => 'error',
 		);
 		$error_result          = datamachine_with_conversation_metadata(
@@ -290,7 +286,7 @@ function datamachine_run_conversation(
 				'tool_calls'      => $all_tool_calls,
 			)
 		);
-		$transcript_session_id = $transcript_persister->persist( $latest_messages, $conversation_request, $error_result );
+		$transcript_session_id = $transcript_persister->persist( $turn_state->latest_messages, $conversation_request, $error_result );
 		if ( '' !== $transcript_session_id ) {
 			$error_result['transcript_session_id'] = $transcript_session_id;
 		}
@@ -437,7 +433,7 @@ function datamachine_run_conversation(
 	$result                       = datamachine_with_conversation_metadata( $result, $datamachine_metadata );
 	$result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $result, $loop_payload, $provider, $model, $modes );
 	if ( 'failed' === (string) ( $result['status'] ?? '' ) || isset( $result['error'] ) ) {
-		$transcript_session_id = $transcript_persister->persist( is_array( $result['messages'] ?? null ) ? $result['messages'] : $latest_messages, $conversation_request, $result );
+		$transcript_session_id = $transcript_persister->persist( is_array( $result['messages'] ?? null ) ? $result['messages'] : $turn_state->latest_messages, $conversation_request, $result );
 		if ( '' !== $transcript_session_id ) {
 			$result['transcript_session_id'] = $transcript_session_id;
 		}
@@ -862,6 +858,156 @@ function datamachine_enrich_mediated_tool_results( array $tool_results, array $t
 }
 
 /**
+ * Mutable per-turn state surfaced to the caller for the pre-substrate error path.
+ *
+ * The upstream conversation loop surfaces turn_count, final_content, usage, and
+ * request_metadata on the FINAL result (agents-api#136). DM only needs to carry
+ * these by reference for the case where the provider-turn adapter throws a
+ * RuntimeException BEFORE the substrate can return its accumulated result — see
+ * the catch block in datamachine_run_conversation(), which reconstructs a
+ * best-effort error result from the last completed turn. Consolidating the
+ * three previously-separate by-ref params (latest_messages, latest_turn_count,
+ * last_request_metadata) into one accumulator shrinks the provider-turn
+ * adapter's parameter surface toward the #2803 decomposition target without
+ * changing behavior.
+ */
+final class DataMachineProviderTurnState {
+
+	/** @var array Messages handed to the latest dispatched turn. */
+	public array $latest_messages;
+
+	/** @var int Turn number of the latest dispatched turn. */
+	public int $latest_turn_count = 0;
+
+	/** @var array Request metadata captured on the latest dispatched turn. */
+	public array $last_request_metadata = array();
+
+	/**
+	 * @param array $initial_messages Initial conversation messages.
+	 */
+	public function __construct( array $initial_messages ) {
+		$this->latest_messages = $initial_messages;
+	}
+}
+
+/**
+ * Dispatch one DM provider turn and normalize the wp-ai-client result.
+ *
+ * Owns the genuinely DM-specific half of a provider turn:
+ *  - DM prompt assembly + authenticated dispatch via RequestBuilder::build()
+ *    (per-provider API-key auth, transport timeouts, response caching,
+ *    model-config, multimodal/vision parts, oversized-request guarding).
+ *  - provider-safe tool-name aliasing of the extracted tool calls.
+ *  - per-turn token-usage and finish-reason capture.
+ *
+ * #2803 / agents-api#370: the upstream WP_Agent_Default_Provider_Turn_Adapter
+ * now owns the GENERIC half of this work (message→builder mapping, dispatch via
+ * wp_ai_client_prompt(), tool-call extraction, usage/result normalization), and
+ * exposes a prompt-input seam (set_prompt_input_provider) for consumer prompt
+ * assembly. DM cannot adopt that adapter's run_turn() yet: it dispatches through
+ * a BARE wp_ai_client_prompt() builder with no seam for DM's authenticated,
+ * transport-tuned, cached, model-config-aware, vision-capable dispatch, so
+ * routing DM through it would drop provider auth and break parity. That gap is
+ * tracked in agents-api#371. When that seam lands, this helper is the single
+ * swap point: construct the default adapter, inject DM prompt assembly through
+ * set_prompt_input_provider, and inject DM dispatch through the new dispatch
+ * seam — leaving aliasing/events/nudges in the caller untouched.
+ *
+ * @param array  $messages         Messages for this turn.
+ * @param array  $tools            Available tools keyed by name.
+ * @param string $provider         AI provider identifier.
+ * @param string $model            AI model identifier.
+ * @param array  $modes            Execution mode slugs.
+ * @param array  $loop_payload     Cleaned loop payload.
+ * @param DataMachineProviderTurnState $turn_state Per-turn state; updated with the
+ *                                     dispatched turn's request metadata even when
+ *                                     dispatch fails, preserving the failure-path
+ *                                     diagnostics the caller's error result reports.
+ * @return array{content:string,tool_calls:array,usage:array,request_metadata:array,request_metadata_pre_finish:array,finish_reason:?string}
+ *               `request_metadata_pre_finish` is the metadata snapshot taken
+ *               before the finish reason is appended, used for the
+ *               `request_built` event to preserve the legacy event payload shape.
+ * @throws \RuntimeException When the wp-ai-client request fails (caught by the upstream loop).
+ */
+function datamachine_dispatch_provider_turn(
+	array $messages,
+	array $tools,
+	string $provider,
+	string $model,
+	array $modes,
+	array $loop_payload,
+	DataMachineProviderTurnState $turn_state
+): array {
+	// Build and dispatch the AI request through DM's centralized RequestBuilder.
+	// RequestBuilder owns directive-ordered prompt assembly (PromptBuilder) AND
+	// authenticated wp-ai-client dispatch; the two are fused today, which is why
+	// the agents-api#370 prompt-input seam alone cannot replace this path.
+	// RequestBuilder populates $request_metadata even on failure, so capture it
+	// into turn state before any throw to preserve failure-path diagnostics.
+	$request_metadata = array();
+	$ai_response      = RequestBuilder::build(
+		$messages,
+		$provider,
+		$model,
+		$tools,
+		$modes,
+		$loop_payload,
+		$request_metadata
+	);
+	$turn_state->last_request_metadata = $request_metadata;
+
+	// Handle AI request failure — throw so the upstream loop catches and the
+	// caller reconstructs a best-effort error result from the last turn state.
+	if ( $ai_response instanceof \WP_Error ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message is caught by upstream loop and returned as structured array, never rendered as HTML.
+		throw new \RuntimeException( $ai_response->get_error_message() );
+	}
+
+	/** @var \WordPress\AiClient\Results\DTO\GenerativeAiResult $ai_result */
+	$ai_result = $ai_response;
+
+	// Provider-safe tool-name aliasing: map provider-emitted names back to DM's
+	// logical tool names. Generic extraction is delegated to Agents API; the
+	// alias map is DM-specific request metadata and stays here.
+	$tool_calls = datamachine_apply_provider_tool_name_aliases(
+		datamachine_extract_tool_calls( $ai_result ),
+		$request_metadata
+	);
+	$ai_content = RequestBuilder::resultText( $ai_result );
+
+	// Snapshot the metadata as returned by RequestBuilder (before the finish
+	// reason is appended) so the `request_built` event payload matches the
+	// legacy behavior, which emitted the event prior to enrichment.
+	$request_metadata_pre_finish = $request_metadata;
+
+	// Per-turn token usage. The substrate accumulates this across turns and
+	// exposes the running total on the final loop result.
+	$token_usage   = $ai_result->getTokenUsage();
+	$turn_usage    = array(
+		'prompt_tokens'     => $token_usage->getPromptTokens(),
+		'completion_tokens' => $token_usage->getCompletionTokens(),
+		'total_tokens'      => $token_usage->getTotalTokens(),
+	);
+	$finish_reason = datamachine_ai_result_finish_reason( $ai_result );
+	if ( null !== $finish_reason ) {
+		$request_metadata['response']['finish_reason'] = $finish_reason;
+		// Mirror the legacy behavior of re-capturing metadata once the finish
+		// reason is appended, so the failure-path/error-result diagnostics carry
+		// the same enriched metadata as the returned turn.
+		$turn_state->last_request_metadata = $request_metadata;
+	}
+
+	return array(
+		'content'                     => $ai_content,
+		'tool_calls'                  => $tool_calls,
+		'usage'                       => $turn_usage,
+		'request_metadata'            => $request_metadata,
+		'request_metadata_pre_finish' => $request_metadata_pre_finish,
+		'finish_reason'               => $finish_reason,
+	);
+}
+
+/**
  * Build the DM-specific provider-turn adapter callable.
  *
  * The adapter handles one provider turn: build request → dispatch via
@@ -884,9 +1030,7 @@ function datamachine_enrich_mediated_tool_results( array $tool_results, array $t
  * @param array                                     $base_log_context   Base log context.
  * @param array                                     &$last_tool_calls    Mutable last turn's tool calls (DM-flavored shape).
  * @param array                                     &$all_tool_calls     Mutable all tool calls made during the run.
- * @param array                                     &$last_request_metadata Mutable last request metadata.
- * @param array                                     &$latest_messages    Mutable latest messages.
- * @param int                                       &$latest_turn_count  Mutable latest turn count.
+ * @param DataMachineProviderTurnState              $turn_state         Mutable per-turn state for the pre-substrate error path.
  * @param WP_Agent_Conversation_Completion_Policy   $completion_policy  Completion policy for natural completions.
  * @param array                                     &$completion_nudges  Mutable nudge diagnostics (DM-only).
  * @return callable Provider-turn adapter callable.
@@ -902,9 +1046,7 @@ function datamachine_build_provider_turn_adapter(
 	array $base_log_context,
 	array &$last_tool_calls,
 	array &$all_tool_calls,
-	array &$last_request_metadata,
-	array &$latest_messages,
-	int &$latest_turn_count,
+	DataMachineProviderTurnState $turn_state,
 	WP_Agent_Conversation_Completion_Policy $completion_policy,
 	array &$completion_nudges
 ): callable {
@@ -918,11 +1060,9 @@ function datamachine_build_provider_turn_adapter(
 		$event_sink,
 		$base_log_context,
 		$completion_policy,
+		$turn_state,
 		&$last_tool_calls,
 		&$all_tool_calls,
-		&$last_request_metadata,
-		&$latest_messages,
-		&$latest_turn_count,
 		&$completion_nudges
 	): array {
 		$messages = is_array( $provider_turn_request ) ? $provider_turn_request : array();
@@ -939,25 +1079,66 @@ function datamachine_build_provider_turn_adapter(
 		}
 
 		// The upstream loop provides the turn number via turn_context.
-		$turn_count        = (int) ( $turn_context['turn'] ?? 1 );
-		$latest_turn_count = $turn_count;
-		$latest_messages   = $messages;
+		$turn_count                     = (int) ( $turn_context['turn'] ?? 1 );
+		$turn_state->latest_turn_count  = $turn_count;
+		$turn_state->latest_messages    = $messages;
 
-		// Build and dispatch AI request using centralized RequestBuilder.
-		// Per-turn request metadata is captured locally and returned in the
-		// turn result so the substrate can surface the latest one on the
-		// final loop result.
-		$request_metadata      = array();
-		$ai_response           = RequestBuilder::build(
-			$messages,
-			$provider,
-			$model,
-			$tools,
-			$modes,
-			$loop_payload,
-			$request_metadata
-		);
-		$last_request_metadata = $request_metadata;
+		// Dispatch one DM provider turn: prompt assembly + authenticated
+		// wp-ai-client dispatch + provider-safe tool-name aliasing + per-turn
+		// usage. Throws RuntimeException on failure (caught by the upstream loop);
+		// the dispatched-turn state captured above lets the caller rebuild a
+		// best-effort error result. See datamachine_dispatch_provider_turn() for
+		// the agents-api#370/#371 default-adapter adoption boundary.
+		try {
+			$turn = datamachine_dispatch_provider_turn(
+				$messages,
+				$tools,
+				$provider,
+				$model,
+				$modes,
+				$loop_payload,
+				$turn_state
+			);
+		} catch ( \RuntimeException $e ) {
+			datamachine_emit_loop_event(
+				$event_sink,
+				'request_built',
+				array_merge(
+					$base_log_context,
+					array(
+						'turn_count'       => $turn_count,
+						'provider'         => $provider,
+						'model'            => $model,
+						'success'          => false,
+						'request_metadata' => $turn_state->last_request_metadata,
+					)
+				)
+			);
+
+			do_action(
+				'datamachine_log',
+				'error',
+				'datamachine_run_conversation: AI request failed',
+				array_merge(
+					$base_log_context,
+					array(
+						'turn_count' => $turn_count,
+						'error'      => $e->getMessage(),
+						'provider'   => $provider,
+					)
+				)
+			);
+
+			throw $e;
+		}
+
+		// On success the helper has already recorded request metadata (including
+		// the resolved finish_reason) into turn state.
+		$request_metadata = $turn['request_metadata'];
+		$tool_calls       = $turn['tool_calls'];
+		$ai_content       = $turn['content'];
+		$turn_usage       = $turn['usage'];
+		$finish_reason    = $turn['finish_reason'];
 
 		datamachine_emit_loop_event(
 			$event_sink,
@@ -968,53 +1149,15 @@ function datamachine_build_provider_turn_adapter(
 					'turn_count'       => $turn_count,
 					'provider'         => $provider,
 					'model'            => $model,
-					'success'          => ! is_wp_error( $ai_response ),
-					'request_metadata' => $request_metadata,
+					'success'          => true,
+					'request_metadata' => $turn['request_metadata_pre_finish'],
 				)
 			)
 		);
 
-		// Handle AI request failure — throw so the upstream loop catches.
-		if ( $ai_response instanceof \WP_Error ) {
-			do_action(
-				'datamachine_log',
-				'error',
-				'datamachine_run_conversation: AI request failed',
-				array_merge(
-					$base_log_context,
-					array(
-						'turn_count' => $turn_count,
-						'error'      => $ai_response->get_error_message(),
-						'provider'   => $provider,
-					)
-				)
-			);
-
-			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message is caught by upstream loop and returned as structured array, never rendered as HTML.
-			throw new \RuntimeException( $ai_response->get_error_message() );
-		}
-
-		/** @var \WordPress\AiClient\Results\DTO\GenerativeAiResult $ai_result */
-		$ai_result       = $ai_response;
-		$tool_calls      = datamachine_apply_provider_tool_name_aliases( datamachine_extract_tool_calls( $ai_result ), $request_metadata );
-		$ai_content      = RequestBuilder::resultText( $ai_result );
 		$last_tool_calls = $tool_calls;
 		foreach ( $tool_calls as $tool_call ) {
 			$all_tool_calls[] = $tool_call;
-		}
-
-		// Per-turn token usage. Substrate accumulates this across turns and
-		// exposes the running total on the final loop result.
-		$token_usage   = $ai_result->getTokenUsage();
-		$turn_usage    = array(
-			'prompt_tokens'     => $token_usage->getPromptTokens(),
-			'completion_tokens' => $token_usage->getCompletionTokens(),
-			'total_tokens'      => $token_usage->getTotalTokens(),
-		);
-		$finish_reason = datamachine_ai_result_finish_reason( $ai_result );
-		if ( null !== $finish_reason ) {
-			$request_metadata['response']['finish_reason'] = $finish_reason;
-			$last_request_metadata                         = $request_metadata;
 		}
 
 		$messages_with_response = $messages;


### PR DESCRIPTION
## Summary

First, scoped slice of #2803 — the **provider-turn-adapter** portion — now that the upstream primitive merged in **agents-api#370** (`WP_Agent_Default_Provider_Turn_Adapter` + the `set_prompt_input_provider` seam).

The slice as originally framed was "swap DM's bespoke dispatch for the default adapter via the prompt-input seam." Investigation showed that the headline swap **cannot be done today without breaking parity**, because of a real upstream gap (filed as **agents-api#371**). So this PR ships the part that is cleanly safe and **stages the swap point**, and documents the blocker — rather than forcing a parity-breaking adoption. This is a substrate-adoption *refactor*: **no external behavior changes.**

## What was removed/replaced (line delta: +210 / −76, net structural, one file)

`inc/Engine/AI/conversation-loop.php`:

- **Extracted** the per-turn dispatch body out of the 226-line closure in `datamachine_build_provider_turn_adapter()` into a named function `datamachine_dispatch_provider_turn()`. It owns the genuinely DM-specific half of a turn: DM prompt assembly + authenticated dispatch (`RequestBuilder::build()`), provider-safe tool-name aliasing, and per-turn usage/finish-reason capture.
- **Collapsed** the three error-path-only by-ref params — `&$last_request_metadata`, `&$latest_messages`, `&$latest_turn_count` — into a single `DataMachineProviderTurnState` accumulator object, shrinking `datamachine_build_provider_turn_adapter()`'s 15-param/6-by-ref surface (the exact smell #2803 calls out) toward the decomposition target. (`&$last_tool_calls`, `&$all_tool_calls`, `&$completion_nudges` remain — they carry DM-flavored, aliased, cross-turn state the substrate does not surface.)

## How DM prompt assembly relates to `set_prompt_input_provider`

DM's prompt assembly (directive-ordered, mode-aware composition via `PromptBuilder`/`ProviderRequestAssembler`) is **fused with dispatch** inside `RequestBuilder::build()` — a single call both composes the directive-ordered prompt *and* dispatches it. The new `datamachine_dispatch_provider_turn()` is the single, documented place where, once the upstream dispatch seam exists, DM will: construct `WP_Agent_Default_Provider_Turn_Adapter`, inject DM prompt assembly through `set_prompt_input_provider`, and inject DM dispatch through the (not-yet-existing) dispatch seam — leaving aliasing/events/nudges in the caller untouched.

## Why the full adapter swap is blocked (agents-api#371)

`WP_Agent_Default_Provider_Turn_Adapter::run_turn()` dispatches through a **bare** `wp_ai_client_prompt()` builder. Its only seam is **prompt input**; all dispatch internals are `private`, and `$options` accept only `temperature`/`max_tokens`/`prompt_input_provider`. DM's `RequestBuilder::build()` dispatch carries, and **every item is load-bearing for parity**:

1. **Per-provider API-key auth** (`setProviderRequestAuthentication`) — DM has **no ambient auth binding**, so the bare builder would dispatch **unauthenticated** and fail.
2. **Resolved model *instance*** (not a model-id string) + `setRequestOptions`.
3. **`using_model_config()`** (product/model config).
4. **Transport profile** — request/connect timeouts, `RequestOptions`, `DefaultOptionsHttpTransporter`, `http_api_curl` hooks.
5. **Response caching** (`WpAiClientCache::install()`).
6. **Filter override seams** (`datamachine_ai_request_result`, `datamachine_wp_ai_client_text_result`).
7. **Multimodal/vision MessageParts** (file/image blocks).
8. Provider-safe tool-name aliasing in function declarations + oversized-request guarding.

Routing DM through `run_turn()` would drop all of the above. Per repo rules ("don't implement workarounds for things that should be fixed upstream" / "don't fork the adapter"), the gap is filed as **agents-api#371** and the swap is deferred until a dispatch seam (or publicly reusable result-normalization primitives) lands.

## DM-specific concerns explicitly preserved

- **Prompt assembly** — still flows through DM's directive `PromptBuilder`/`ProviderRequestAssembler` via `RequestBuilder::build()` (directives applied in the same order).
- **Provider-safe tool-name aliasing** — `datamachine_apply_provider_tool_name_aliases()` still applied after extraction.
- **Event-sink emissions** — `request_built` still emitted once per turn; success-path payload still uses the **pre-finish-reason** metadata snapshot (exact legacy shape), failure-path still emits `success=false` with the current turn's metadata, then logs, then throws — same order, same payloads.
- **Completion-nudge continuation** and **by-ref accumulators** the substrate doesn't surface — untouched.

## Behavior-parity confirmation + test results

- `php -l inc/Engine/AI/conversation-loop.php` — clean.
- `phpcs inc/Engine/AI/conversation-loop.php` — clean (exit 0).
- Full `tests/*-smoke.php` suite (295 files) — exit codes **byte-identical to baseline** (`diff` of pre-change vs post-change run shows zero differences). Conversation-loop-relevant tests pass: `provider-turn-tool-extraction-contract`, `request-builder-tool-transcript`, `wp-ai-client-request-timeout`, `ai-loop-event-sink`, `agent-conversation-result`, `ai-request-metadata-guardrails`, `pipeline-system-prompt-queue`, `direct-request-inspector-packets`.

## Relationship to #2803 (do NOT close)

Partial step toward #2803. Remaining decomposition still owned by #2803:

- **The actual adapter swap** in `datamachine_dispatch_provider_turn()` — blocked on **agents-api#371**.
- **Completion-policy / result-normalizer untangling** — the `datamachine_run_conversation()` post-hoc status surgery (the scattered `$result['status']` switches, the `ConversationStatus` enum / `ConversationResultNormalizer` proposal).
- **RuntimeToolFulfillment** extraction (the L1218-1900 runtime-tool subsystem).
- Decoupling DM's `RequestBuilder` prompt-assembly from dispatch so the `set_prompt_input_provider` seam can be fed exactly once (prerequisite for the swap).

Consumes agents-api#370. References #2803, agents-api#371.