### PR TITLE
refactor: route DM provider turn through default adapter dispatch seam (#2803)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -793,13 +793,13 @@
             "version": "dev-main",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "7be8fc3e2c6736c553d61c0578f295b4fe565cf1"
+                "url": "https://github.com/Automattic/agents-api",
+                "reference": "ab9686c1e854bda3aea46657454c06aaaf820bd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/7be8fc3e2c6736c553d61c0578f295b4fe565cf1",
-                "reference": "7be8fc3e2c6736c553d61c0578f295b4fe565cf1",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/ab9686c1e854bda3aea46657454c06aaaf820bd3",
+                "reference": "ab9686c1e854bda3aea46657454c06aaaf820bd3",
                 "shasum": ""
             },
             "require": {
@@ -846,6 +846,7 @@
                     "php tests/tool-policy-contracts-smoke.php",
                     "php tests/tool-source-registry-smoke.php",
                     "php tests/runtime-tool-policy-smoke.php",
+                    "php tests/runtime-tool-lifecycle-abilities-smoke.php",
                     "php tests/tool-tier-resolver-smoke.php",
                     "php tests/action-policy-resolver-smoke.php",
                     "php tests/ability-meta-abilities-smoke.php",
@@ -877,19 +878,29 @@
                     "php tests/context-registry-smoke.php",
                     "php tests/conversation-loop-smoke.php",
                     "php tests/provider-turn-adapter-smoke.php",
+                    "php tests/default-provider-turn-adapter-smoke.php",
+                    "php tests/ability-tool-executor-smoke.php",
+                    "php tests/tool-mediation-runner-smoke.php",
                     "php tests/conversation-loop-tool-execution-smoke.php",
                     "php tests/conversation-loop-completion-policy-smoke.php",
                     "php tests/conversation-loop-transcript-persister-smoke.php",
                     "php tests/conversation-loop-events-smoke.php",
                     "php tests/tool-declaration-rejection-smoke.php",
                     "php tests/conversation-loop-interrupt-source-smoke.php",
+                    "php tests/run-outcome-status-smoke.php",
+                    "php tests/run-result-envelope-smoke.php",
                     "php tests/iteration-budget-smoke.php",
                     "php tests/conversation-loop-budgets-smoke.php",
+                    "php tests/runtime-package-run-contract-smoke.php",
+                    "php tests/run-control-normalization-smoke.php",
+                    "php tests/canonical-run-lifecycle-smoke.php",
                     "php tests/channels-smoke.php",
                     "php tests/chat-run-control-smoke.php",
+                    "php tests/external-chat-run-bridge-fixture-smoke.php",
                     "php tests/task-execution-smoke.php",
                     "php tests/frontend-chat-rest-smoke.php",
                     "php tests/agents-chat-jsonrpc-route-smoke.php",
+                    "php tests/response-and-input-primitives-smoke.php",
                     "php tests/agents-dispatch-message-ability-smoke.php",
                     "php tests/webhook-safety-smoke.php",
                     "php tests/remote-bridge-smoke.php",
@@ -918,7 +929,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-06-21T22:54:32+00:00"
+            "time": "2026-06-27T22:02:33+00:00"
         }
     ],
     "packages-dev": [
@@ -1614,6 +1625,6 @@
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
 }

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -17,9 +17,11 @@ namespace DataMachine\Engine\AI;
 use AgentsAPI\AI\WP_Agent_Conversation_Completion_Policy;
 use AgentsAPI\AI\WP_Agent_Conversation_Loop;
 use AgentsAPI\AI\WP_Agent_Conversation_Result;
+use AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter;
 use AgentsAPI\AI\WP_Agent_Transcript_Persister;
 use AgentsAPI\AI\WP_Agent_Message;
 use AgentsAPI\AI\WP_Agent_Null_Transcript_Persister;
+use AgentsAPI\AI\WP_Agent_Provider_Turn_Request;
 use AgentsAPI\AI\WP_Agent_Provider_Turn_Result;
 use AgentsAPI\AI\WP_Agent_Runtime_Tool_Request;
 use AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Store;
@@ -858,27 +860,26 @@ function datamachine_enrich_mediated_tool_results( array $tool_results, array $t
 }
 
 /**
- * Dispatch one DM provider turn and normalize the wp-ai-client result.
+ * Dispatch one DM provider turn through the Agents API default adapter.
  *
- * Owns the genuinely DM-specific half of a provider turn:
- *  - DM prompt assembly + authenticated dispatch via RequestBuilder::build()
- *    (per-provider API-key auth, transport timeouts, response caching,
- *    model-config, multimodal/vision parts, oversized-request guarding).
- *  - provider-safe tool-name aliasing of the extracted tool calls.
- *  - per-turn token-usage and finish-reason capture.
+ * agents-api#370 shipped WP_Agent_Default_Provider_Turn_Adapter and agents-api#371
+ * (PR #373) added its dispatch-provider seam, so DM now delegates the GENERIC
+ * half of a provider turn to the substrate and keeps only the DM-specific half:
  *
- * #2803 / agents-api#370: the upstream WP_Agent_Default_Provider_Turn_Adapter
- * now owns the GENERIC half of this work (message→builder mapping, dispatch via
- * wp_ai_client_prompt(), tool-call extraction, usage/result normalization), and
- * exposes a prompt-input seam (set_prompt_input_provider) for consumer prompt
- * assembly. DM cannot adopt that adapter's run_turn() yet: it dispatches through
- * a BARE wp_ai_client_prompt() builder with no seam for DM's authenticated,
- * transport-tuned, cached, model-config-aware, vision-capable dispatch, so
- * routing DM through it would drop provider auth and break parity. That gap is
- * tracked in agents-api#371. When that seam lands, this helper is the single
- * swap point: construct the default adapter, inject DM prompt assembly through
- * set_prompt_input_provider, and inject DM dispatch through the new dispatch
- * seam — leaving aliasing/events/nudges in the caller untouched.
+ *  - GENERIC (owned by the default adapter): map the request into builder inputs,
+ *    run the turn, then extract tool calls, assistant text, and token usage via
+ *    the now-public WP_Agent_Provider_Turn_Result::{extract_tool_calls, result_text,
+ *    result_usage} and assemble the normalized { content, tool_calls, usage,
+ *    request_metadata } result. DM no longer re-implements any of this.
+ *  - DM-SPECIFIC dispatch (injected via set_dispatch_provider): RequestBuilder::build()
+ *    performs directive-ordered prompt assembly AND authenticated wp-ai-client
+ *    dispatch (per-provider API-key auth, transport timeouts, response caching,
+ *    model-config, multimodal/vision parts, oversized-request guarding). It returns
+ *    the wp-ai-client GenerativeAiResult; the adapter owns the tail from there.
+ *  - DM-SPECIFIC enrichments re-applied on the adapter's normalized output:
+ *    provider-safe tool-name aliasing of the extracted tool calls, DM's full
+ *    request metadata (the adapter only surfaces provider_id/model_id), and the
+ *    response finish reason.
  *
  * @param array  $messages         Messages for this turn.
  * @param array  $tools            Available tools keyed by name.
@@ -905,58 +906,80 @@ function datamachine_dispatch_provider_turn(
 	array $loop_payload,
 	DataMachineProviderTurnState $turn_state
 ): array {
-	// Build and dispatch the AI request through DM's centralized RequestBuilder.
-	// RequestBuilder owns directive-ordered prompt assembly (PromptBuilder) AND
-	// authenticated wp-ai-client dispatch; the two are fused today, which is why
-	// the agents-api#370 prompt-input seam alone cannot replace this path.
-	// RequestBuilder populates $request_metadata even on failure, so capture it
-	// into turn state before any throw to preserve failure-path diagnostics.
+	// DM's full request metadata + the raw wp-ai-client result, captured out of
+	// RequestBuilder::build() (by ref) inside the dispatch provider so they
+	// survive back here for enrichment. The adapter's own request_metadata only
+	// carries provider_id/model_id, and the finish reason is read off the raw
+	// result DM produced.
 	$request_metadata = array();
-	$ai_response      = RequestBuilder::build(
+	$ai_result        = null;
+
+	// Inject DM's authenticated dispatch into the substrate's default adapter.
+	// The adapter owns the generic mapping and the generic tail (extract/text/
+	// usage/normalize); the dispatch provider owns only request construction and
+	// dispatch, returning a wp-ai-client GenerativeAiResult. RequestBuilder
+	// populates $request_metadata even on failure, so capture it before any throw
+	// to preserve failure-path diagnostics.
+	$dispatch_provider = static function ( array $payload ) use (
 		$messages,
+		$tools,
 		$provider,
 		$model,
-		$tools,
 		$modes,
 		$loop_payload,
-		$request_metadata
-	);
+		$turn_state,
+		&$request_metadata,
+		&$ai_result
+	) {
+		unset( $payload ); // DM builds its own authenticated request from the loop inputs.
 
-	$turn_state->last_request_metadata = $request_metadata;
+		$response                          = RequestBuilder::build(
+			$messages,
+			$provider,
+			$model,
+			$tools,
+			$modes,
+			$loop_payload,
+			$request_metadata
+		);
+		$turn_state->last_request_metadata = $request_metadata;
 
-	// Handle AI request failure — throw so the upstream loop catches and the
-	// caller reconstructs a best-effort error result from the last turn state.
-	if ( $ai_response instanceof \WP_Error ) {
-		// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message is caught by upstream loop and returned as structured array, never rendered as HTML.
-		throw new \RuntimeException( $ai_response->get_error_message() );
-	}
+		// Keep the raw result for DM's finish-reason read after the adapter tail.
+		if ( ! ( $response instanceof \WP_Error ) ) {
+			$ai_result = $response;
+		}
 
-	/** @var \WordPress\AiClient\Results\DTO\GenerativeAiResult $ai_result */
-	$ai_result = $ai_response;
+		// Returning the WP_Error lets the adapter throw the RuntimeException the
+		// upstream loop catches (identical to the bare-builder failure path).
+		return $response;
+	};
 
-	// Provider-safe tool-name aliasing: map provider-emitted names back to DM's
-	// logical tool names. Generic extraction is delegated to Agents API; the
-	// alias map is DM-specific request metadata and stays here.
+	$adapter = new WP_Agent_Default_Provider_Turn_Adapter( $provider, $model );
+	$adapter->set_dispatch_provider( $dispatch_provider );
+
+	// run_turn() resolves provider/model from the request first, so pass an empty
+	// model map and let it fall back to the constructor provider/model above.
+	$request = new WP_Agent_Provider_Turn_Request( $messages, $tools );
+
+	// The adapter owns extract/text/usage/normalize; it returns
+	// { content, tool_calls, usage, request_metadata{provider_id,model_id} }.
+	$result = $adapter->run_turn( $request );
+
+	// Re-apply the two DM-specific enrichments the generic tail does not cover:
+	// provider-safe tool-name aliasing and DM's full request metadata.
 	$tool_calls = datamachine_apply_provider_tool_name_aliases(
-		datamachine_extract_tool_calls( $ai_result ),
+		is_array( $result['tool_calls'] ?? null ) ? $result['tool_calls'] : array(),
 		$request_metadata
 	);
-	$ai_content = RequestBuilder::resultText( $ai_result );
+	$ai_content = is_string( $result['content'] ?? null ) ? $result['content'] : '';
+	$turn_usage = is_array( $result['usage'] ?? null ) ? $result['usage'] : array();
 
-	// Snapshot the metadata as returned by RequestBuilder (before the finish
+	// Snapshot DM's metadata as returned by RequestBuilder (before the finish
 	// reason is appended) so the `request_built` event payload matches the
 	// legacy behavior, which emitted the event prior to enrichment.
 	$request_metadata_pre_finish = $request_metadata;
 
-	// Per-turn token usage. The substrate accumulates this across turns and
-	// exposes the running total on the final loop result.
-	$token_usage   = $ai_result->getTokenUsage();
-	$turn_usage    = array(
-		'prompt_tokens'     => $token_usage->getPromptTokens(),
-		'completion_tokens' => $token_usage->getCompletionTokens(),
-		'total_tokens'      => $token_usage->getTotalTokens(),
-	);
-	$finish_reason = datamachine_ai_result_finish_reason( $ai_result );
+	$finish_reason = null !== $ai_result ? datamachine_ai_result_finish_reason( $ai_result ) : null;
 	if ( null !== $finish_reason ) {
 		$request_metadata['response']['finish_reason'] = $finish_reason;
 		// Mirror the legacy behavior of re-capturing metadata once the finish
@@ -2377,16 +2400,6 @@ function datamachine_completion_nudge_diagnostic( array $decision_context, int $
 		'completion_assertions_satisfied' => is_array( $decision_context['satisfied'] ?? null ) ? $decision_context['satisfied'] : array(),
 		'completion_nudge_turn'           => $turn_count,
 	);
-}
-
-/**
- * Extract tool calls from a wp-ai-client GenerativeAiResult.
- *
- * @param \WordPress\AiClient\Results\DTO\GenerativeAiResult $result wp-ai-client result.
- * @return array<int, array{name:string,parameters:array,id:mixed}>
- */
-function datamachine_extract_tool_calls( $result ): array {
-	return \AgentsAPI\AI\WP_Agent_Provider_Turn_Result::extract_tool_calls( $result );
 }
 
 /**

--- a/tests/provider-turn-tool-extraction-contract-smoke.php
+++ b/tests/provider-turn-tool-extraction-contract-smoke.php
@@ -27,8 +27,20 @@ $assert = static function ( bool $condition, string $message ) use ( &$failures,
 
 $assert( false !== $loop_source, 'conversation loop source is readable' );
 $assert(
-	false !== strpos( (string) $loop_source, 'WP_Agent_Provider_Turn_Result::extract_tool_calls( $result )' ),
-	'Data Machine delegates provider-turn tool extraction to Agents API'
+	false !== strpos( (string) $loop_source, 'new WP_Agent_Default_Provider_Turn_Adapter(' ),
+	'Data Machine routes the provider turn through the Agents API default adapter'
+);
+$assert(
+	false !== strpos( (string) $loop_source, '$adapter->set_dispatch_provider(' ),
+	'Data Machine injects its authenticated dispatch through the adapter dispatch seam'
+);
+$assert(
+	false !== strpos( (string) $loop_source, '$adapter->run_turn(' ),
+	'Data Machine delegates provider-turn extraction/text/usage normalization to the adapter run_turn() tail'
+);
+$assert(
+	false === strpos( (string) $loop_source, 'function datamachine_extract_tool_calls(' ),
+	'Data Machine no longer wraps Agents API tool extraction with its own helper'
 );
 $assert(
 	false === strpos( (string) $loop_source, 'class_exists( \'\\AgentsAPI\\AI\\WP_Agent_Provider_Turn_Result\'' ),


### PR DESCRIPTION
## Summary

Follow-up to **#2805** (already merged), which staged the swap point but couldn't adopt the default adapter because it lacked a dispatch seam. **agents-api#371 (PR #373) merged** and added that seam, so this PR delivers the actual payoff: DM now delegates the generic half of a provider turn to the substrate and deletes its re-implemented dispatch tail.

This is the provider-turn-adapter slice of **#2803**.

## What landed upstream (now consumed here)

- `WP_Agent_Default_Provider_Turn_Adapter::set_dispatch_provider( ?callable )` — when set, `run_turn()` calls DM's dispatcher (receiving the mapped builder inputs as a single payload array) instead of the bare `wp_ai_client_prompt()` builder, and still owns the generic tail.
- `WP_Agent_Provider_Turn_Result::{result_text, result_usage, extract_tool_calls, normalize}` are now **public static**.

## What changed in DM

`inc/Engine/AI/conversation-loop.php` — `datamachine_dispatch_provider_turn()`:

- **Constructs `WP_Agent_Default_Provider_Turn_Adapter($provider, $model)`** and injects DM's authenticated dispatch via **`set_dispatch_provider()`**. The injected dispatcher runs `RequestBuilder::build()` (directive-ordered prompt assembly + authenticated wp-ai-client dispatch: per-provider API-key auth, transport timeouts, response caching, model-config, multimodal/vision parts, oversized-request guarding) and returns the `GenerativeAiResult` (or `WP_Error` → adapter throws the same `RuntimeException` the loop already catches).
- **Calls `$adapter->run_turn($request)`** — the adapter now owns tool-call extraction, assistant-text and token-usage normalization, and result-shape assembly via the public `WP_Agent_Provider_Turn_Result` helpers.
- **Deletes `datamachine_extract_tool_calls()`** and DM's manual `getTokenUsage()` usage-dict construction and the loop's `RequestBuilder::resultText()` call. DM no longer re-implements extract/text/usage.
- **Re-applies only the two DM-specific enrichments** the generic tail doesn't cover: provider-safe tool-name aliasing (`datamachine_apply_provider_tool_name_aliases`) and DM's full request metadata (the adapter surfaces only `provider_id`/`model_id`), plus the response finish reason read off the raw result DM produced.

Net: **−74 lines of duplicated dispatch/extract/usage glue**, replaced by adapter delegation.

## DM-specific concerns preserved (parity)

- **Authenticated dispatch** — unchanged; still flows through `RequestBuilder::build()` (now injected as the adapter's dispatch provider).
- **Tool-name aliasing** — still applied to the adapter's extracted tool calls.
- **Full request metadata** — captured by-ref out of `RequestBuilder` and re-applied over the adapter's minimal metadata.
- **Events / nudges / accumulators** — untouched in the caller; `request_built` still emits once per turn with the pre-finish-reason metadata snapshot on success and the current-turn metadata on failure.
- **Failure path** — dispatcher returns `WP_Error`; the adapter throws a `RuntimeException` (now prefixed `wp-ai-client request failed: ` but still carrying the original message), which the loop catches exactly as before. The `ai-loop-event-sink` smoke confirms the original error text is preserved (`str_contains` assertions pass).

## Dependency bump

`composer.lock` bumped `wordpress/agents-api` `dev-main` → **ab9686c** (the seam-bearing main) so `set_dispatch_provider()` and the public result helpers are present. Required for this code to load.

## Tests

- Updated `tests/provider-turn-tool-extraction-contract-smoke.php` to assert the new contract: adapter construction + `set_dispatch_provider()` + `run_turn()`, and absence of the deleted `datamachine_extract_tool_calls()` wrapper.
- `php -l` + `phpcs` (homeboy ruleset) clean on touched files.
- Full `tests/*-smoke.php` suite is **byte-identical to baseline** when both are run against the seam-bearing agents-api (verified via stash/diff). Conversation-loop tests pass: extraction-contract, event-sink, conversation-result, request-builder-tool-transcript, request-metadata-guardrails, pipeline-system-prompt-queue, direct-request-inspector-packets.

## Relationship to #2803 (do NOT close)

Completes the provider-turn-adapter portion. Remaining #2803 scope: completion-policy / result-normalizer untangling (`ConversationStatus` enum + `ConversationResultNormalizer`), `RuntimeToolFulfillment` extraction, and decoupling `RequestBuilder`'s prompt-assembly from dispatch so the `set_prompt_input_provider` seam can also be fed (DM currently rebuilds its own request inside the dispatcher rather than mapping the adapter's payload).

Consumes agents-api#370 and #371. Continues the work merged in #2805.