### PR TITLE
Conform Data Machine to the canonical flat approval envelope

### DIFF
--- a/inc/Engine/AI/Actions/PendingActionHelper.php
+++ b/inc/Engine/AI/Actions/PendingActionHelper.php
@@ -5,8 +5,8 @@
  *
  * Tools that opt into WP_Agent_Action_Policy should never hand-roll the store/envelope
  * shape. Call PendingActionHelper::stage() from the 'preview' branch of the
- * tool handler and return its result directly. The AI sees the Agents API
- * approval-required envelope: read pending_action.action_id and call
+ * tool handler and return its result directly. The AI sees the canonical Agents
+ * API approval_required envelope: read payload.action_id and call
  * `resolve_pending_action` with `accepted` or `rejected` once the user
  * decides.
  *
@@ -26,10 +26,11 @@ class PendingActionHelper {
 	/**
 	 * Stage a tool invocation for user approval.
 	 *
-	 * The returned value is an Agents API approval_required envelope. The
-	 * envelope payload carries a `pending_action` value object plus the
-	 * `resolve_with` / `resolve_params` directives the AI uses to confirm
-	 * or reject the invocation.
+	 * The returned value is the canonical Agents API approval_required envelope.
+	 * The envelope payload carries the full canonical pending-action shape
+	 * (action_id, kind, summary, preview, status, expires_at, …) plus the
+	 * standardized `instruction` and `grants` slots the AI uses to confirm or
+	 * reject the invocation.
 	 *
 	 * @param array $args {
 	 *     Staging arguments.
@@ -165,18 +166,9 @@ class PendingActionHelper {
 			'expires_at'      => null !== $expires_at ? gmdate( 'c', $expires_at ) : null,
 		);
 
-		if ( class_exists( WP_Agent_Pending_Action::class ) ) {
-			$pending_action = WP_Agent_Pending_Action::from_array( $pending_action )->to_array();
-		}
-
-		$envelope_payload = array(
-			'pending_action' => $pending_action,
-			'resolve_with'   => 'resolve_pending_action',
-			'resolve_params' => array(
-				'action_id' => $action_id,
-				'decision'  => '<accepted|rejected>',
-			),
-			'instruction'    => 'Show this preview to the user and wait for their confirmation. Do not call resolve_pending_action until they explicitly approve or reject. If the user asks to modify, call the original tool again with updated parameters instead of resolving this action.',
+		$instruction = sprintf(
+			'Show this preview to the user and wait for their confirmation. Do not resolve until they explicitly approve or reject. To resolve, call resolve_pending_action with action_id "%s" and decision "accepted" or "rejected". If the user asks to modify, call the original tool again with updated parameters instead of resolving this action.',
+			$action_id
 		);
 
 		$envelope_metadata = array(
@@ -187,24 +179,34 @@ class PendingActionHelper {
 			),
 		);
 
-		$envelope = method_exists( WP_Agent_Message::class, 'approvalRequired' )
-			? WP_Agent_Message::approvalRequired( $payload['summary'], $envelope_payload, $envelope_metadata )
-			: array(
-				'schema'   => WP_Agent_Message::SCHEMA,
-				'version'  => WP_Agent_Message::VERSION,
-				'type'     => WP_Agent_Message::TYPE_APPROVAL_REQUIRED,
-				'role'     => 'tool',
-				'content'  => $payload['summary'],
-				'payload'  => $envelope_payload,
-				'metadata' => $envelope_metadata,
-			);
+		// Emit the canonical flat approval_required envelope. The payload carries
+		// the full canonical pending-action shape (action_id, kind, summary,
+		// preview, status, expires_at, …) plus the standardized `instruction`
+		// and `grants` slots, so every producer emits and every consumer reads
+		// one shape. See Agents API WP_Agent_Pending_Action::to_approval_envelope().
+		$pending = WP_Agent_Pending_Action::from_array( $pending_action );
+
+		if ( method_exists( $pending, 'to_approval_envelope' ) ) {
+			$envelope = $pending->to_approval_envelope( $instruction, $grants, $envelope_metadata );
+		} else {
+			// Transitional path for an Agents API build that predates
+			// to_approval_envelope(): build the identical canonical flat payload
+			// inline so the emitted shape is the same either way.
+			$flat_payload                = $pending->to_array();
+			$flat_payload['instruction'] = $instruction;
+			$grant_list                  = array_values( array_filter( $grants, 'is_array' ) );
+			if ( array() !== $grant_list ) {
+				$flat_payload['grants'] = $grant_list;
+			}
+			$envelope = WP_Agent_Message::approvalRequired( $payload['summary'], $flat_payload, $envelope_metadata );
+		}
 
 		// Surface staged + action_id at the top level so internal callers
 		// (content abilities, ToolExecutor, bundle/memory pending actions)
 		// can detect success and reference the new pending action without
-		// digging into the envelope payload. Everything else — kind,
-		// summary, preview, resolve_with, instruction, timestamps — lives
-		// inside the Agents API envelope payload (envelope.payload.pending_action).
+		// digging into the envelope payload. Everything else — kind, summary,
+		// preview, status, instruction, grants, timestamps — lives inside the
+		// canonical Agents API envelope payload (envelope.payload).
 		return array_merge(
 			$envelope,
 			array(

--- a/tests/agent-bundle-upgrade-planner-smoke.php
+++ b/tests/agent-bundle-upgrade-planner-smoke.php
@@ -468,6 +468,17 @@ if ( is_object( $wpdb ) && method_exists( $wpdb, 'get_charset_collate' ) && file
 add_filter( 'wp_agent_pending_action_store', static fn() => \DataMachine\Engine\AI\Actions\PendingActionStore::adapter() );
 add_filter( 'wp_agent_pending_action_resolver', static fn() => ResolvePendingActionAbility::adapter() );
 
+// On the real-WP host-smoke backend the runner is unauthenticated, so resolution
+// authorization fails. Act as an administrator (the pure-PHP stubs simulate this
+// with current_user_can => true) so staging and resolution share an authorized
+// operator identity.
+if ( function_exists( 'wp_set_current_user' ) && function_exists( 'get_users' ) ) {
+	$smoke_admins = get_users( array( 'role' => 'administrator', 'number' => 1, 'fields' => 'ID' ) );
+	if ( ! empty( $smoke_admins ) ) {
+		wp_set_current_user( (int) $smoke_admins[0] );
+	}
+}
+
 $staged = AgentBundleUpgradePendingAction::stage(
 	$plan,
 	array(

--- a/tests/agent-bundle-upgrade-planner-smoke.php
+++ b/tests/agent-bundle-upgrade-planner-smoke.php
@@ -452,6 +452,16 @@ assert_upgrade_plan_equals( 'scheduled seed is visible in after diff', 'hourly',
 assert_upgrade_plan_equals( 'burn-in max_items seed drift remains visible', 50, $runtime_update['diff']['after']['runtime_overlays']['steps']['1_fetch_1']['handler_configs']['mcp']['max_items'] ?? null );
 
 echo "\n[3] PendingAction stages bundle-upgrade previews\n";
+
+// The host-smoke backend provides a real $wpdb but does not run the plugin's
+// deferred migrations, so the durable pending-actions table is absent while
+// has_database() still reports true. Create the table when a real database is
+// present; pure-PHP runs (no real $wpdb) keep using the transient fallback.
+global $wpdb;
+if ( is_object( $wpdb ) && method_exists( $wpdb, 'get_charset_collate' ) && file_exists( ABSPATH . 'wp-admin/includes/upgrade.php' ) ) {
+	\DataMachine\Engine\AI\Actions\PendingActionStore::create_table();
+}
+
 $staged = AgentBundleUpgradePendingAction::stage(
 	$plan,
 	array(

--- a/tests/agent-bundle-upgrade-planner-smoke.php
+++ b/tests/agent-bundle-upgrade-planner-smoke.php
@@ -462,7 +462,7 @@ $staged = AgentBundleUpgradePendingAction::stage(
 	)
 );
 assert_upgrade_plan( 'pending action staged', true === ( $staged['staged'] ?? false ) );
-$staged_pending = $staged['payload']['pending_action'] ?? $staged;
+$staged_pending = $staged['payload'] ?? $staged;
 assert_upgrade_plan_equals( 'pending action kind is bundle_upgrade', 'bundle_upgrade', $staged_pending['kind'] ?? null );
 assert_upgrade_plan_equals( 'preview carries approval count', 1, $staged_pending['preview']['counts']['needs_approval'] ?? null );
 

--- a/tests/agent-bundle-upgrade-planner-smoke.php
+++ b/tests/agent-bundle-upgrade-planner-smoke.php
@@ -462,6 +462,12 @@ if ( is_object( $wpdb ) && method_exists( $wpdb, 'get_charset_collate' ) && file
 	\DataMachine\Engine\AI\Actions\PendingActionStore::create_table();
 }
 
+// Register the canonical store + resolver adapters so resolution dispatches
+// through the generic agents/resolve-pending-action surface. In a fully booted
+// plugin these are wired at bootstrap; the standalone smoke wires them itself.
+add_filter( 'wp_agent_pending_action_store', static fn() => \DataMachine\Engine\AI\Actions\PendingActionStore::adapter() );
+add_filter( 'wp_agent_pending_action_resolver', static fn() => ResolvePendingActionAbility::adapter() );
+
 $staged = AgentBundleUpgradePendingAction::stage(
 	$plan,
 	array(
@@ -469,6 +475,10 @@ $staged = AgentBundleUpgradePendingAction::stage(
 		'bundle'             => array( 'bundle_slug' => 'woocommerce-brain', 'target_version' => '1.1.0' ),
 		'target_artifacts'   => $target_artifacts,
 		'approved_artifacts' => array( 'pipeline:collector' ),
+		// Stage as the resolving user so the action's creator matches the
+		// resolution scope (pure-PHP stub returns 1; real WP returns the current
+		// user). Without this the resolver denies on owner mismatch.
+		'user_id'            => get_current_user_id(),
 	)
 );
 assert_upgrade_plan( 'pending action staged', true === ( $staged['staged'] ?? false ) );

--- a/tests/memory-bundle-policy-smoke.php
+++ b/tests/memory-bundle-policy-smoke.php
@@ -403,7 +403,7 @@ $staged = SelfMemoryWritePolicy::execute(
 );
 memory_policy_assert( true === $staged['staged'], 'bundle-owned overwrite is staged instead of applied' );
 memory_policy_assert( ! str_contains( $store->files[ $scope_key ], 'super-secret-value' ), 'staged overwrite does not mutate memory immediately' );
-$staged_preview = $staged['payload']['pending_action']['preview'] ?? array();
+$staged_preview = $staged['payload']['preview'] ?? array();
 memory_policy_assert( str_contains( $staged_preview['diff'] ?? '', '[redacted]' ), 'preview diff redacts secret-like values' );
 memory_policy_assert( ! str_contains( $staged_preview['diff'] ?? '', 'super-secret-value' ), 'preview diff does not expose secret-like value' );
 

--- a/tests/memory-bundle-policy-smoke.php
+++ b/tests/memory-bundle-policy-smoke.php
@@ -19,6 +19,13 @@ if ( ! defined( 'DATAMACHINE_PENDING_ACTION_TRANSIENT_FALLBACK' ) ) {
 	define( 'DATAMACHINE_PENDING_ACTION_TRANSIENT_FALLBACK', true );
 }
 
+// The host-smoke backend runs under WordPress Playground (PHP WASM), which does
+// not define the STDERR stream constant. Define it so the assert helper can
+// report failures instead of crashing on an undefined constant.
+if ( ! defined( 'STDERR' ) ) {
+	define( 'STDERR', fopen( 'php://stderr', 'w' ) );
+}
+
 $GLOBALS['datamachine_memory_policy_filters']    = array();
 $GLOBALS['datamachine_memory_policy_actions']    = array();
 $GLOBALS['datamachine_memory_policy_transients'] = array();

--- a/tests/memory-bundle-policy-smoke.php
+++ b/tests/memory-bundle-policy-smoke.php
@@ -399,6 +399,17 @@ if ( is_object( $wpdb ) && method_exists( $wpdb, 'get_charset_collate' ) && file
 	PendingActionStore::create_table();
 }
 
+// On the real-WP host-smoke backend the runner is unauthenticated, so resolution
+// authorization fails. Act as an administrator (the pure-PHP stubs simulate this
+// with current_user_can => true) so staging and resolution share an authorized
+// operator identity.
+if ( function_exists( 'wp_set_current_user' ) && function_exists( 'get_users' ) ) {
+	$smoke_admins = get_users( array( 'role' => 'administrator', 'number' => 1, 'fields' => 'ID' ) );
+	if ( ! empty( $smoke_admins ) ) {
+		wp_set_current_user( (int) $smoke_admins[0] );
+	}
+}
+
 add_filter(
 	'datamachine_memory_section_artifact',
 	static function ( $_artifact, array $context ) use ( $artifact ) {

--- a/tests/memory-bundle-policy-smoke.php
+++ b/tests/memory-bundle-policy-smoke.php
@@ -382,6 +382,16 @@ $durable_fact = SelfMemoryWritePolicy::execute(
 memory_policy_assert( false === $durable_fact['success'] && 'durable_fact_denied' === $durable_fact['error_code'], 'durable fact writes are rejected' );
 
 echo "\n[3] Bundle-owned section overwrites are staged with redacted PendingAction preview\n";
+
+// The host-smoke backend provides a real $wpdb but does not run the plugin's
+// deferred migrations, so the durable pending-actions table is absent while
+// has_database() still reports true. Create the table when a real database is
+// present; pure-PHP runs (no real $wpdb) keep using the transient fallback.
+global $wpdb;
+if ( is_object( $wpdb ) && method_exists( $wpdb, 'get_charset_collate' ) && file_exists( ABSPATH . 'wp-admin/includes/upgrade.php' ) ) {
+	PendingActionStore::create_table();
+}
+
 add_filter(
 	'datamachine_memory_section_artifact',
 	static function ( $_artifact, array $context ) use ( $artifact ) {

--- a/tests/pending-action-helper-approval-envelope-smoke.php
+++ b/tests/pending-action-helper-approval-envelope-smoke.php
@@ -90,6 +90,15 @@ function datamachine_pending_action_helper_assert( bool $condition, string $mess
 
 $GLOBALS['datamachine_pending_action_helper_transients'] = array();
 
+// The host-smoke backend provides a real $wpdb but does not run the plugin's
+// deferred migrations, so the durable pending-actions table is absent while
+// has_database() still reports true. Create the table when a real database is
+// present; pure-PHP runs (no real $wpdb) keep using the transient fallback.
+global $wpdb;
+if ( is_object( $wpdb ) && method_exists( $wpdb, 'get_charset_collate' ) && file_exists( ABSPATH . 'wp-admin/includes/upgrade.php' ) ) {
+	PendingActionStore::create_table();
+}
+
 $result = PendingActionHelper::stage(
 	array(
 		'kind'         => 'wiki_upsert',

--- a/tests/pending-action-helper-approval-envelope-smoke.php
+++ b/tests/pending-action-helper-approval-envelope-smoke.php
@@ -5,14 +5,22 @@
  * Run with: php tests/pending-action-helper-approval-envelope-smoke.php
  *
  * Contract:
- *   - Successful stage() returns the Agents API approval_required envelope
- *     plus two top-level convenience fields: staged=true and action_id.
- *   - Every other detail (kind, summary, preview, resolve_with, etc.) lives
- *     inside envelope.payload / envelope.payload.pending_action.
+ *   - Successful stage() returns the canonical Agents API approval_required
+ *     envelope plus two top-level convenience fields: staged=true and action_id.
+ *   - The envelope payload is the canonical flat pending-action shape (action_id,
+ *     kind, summary, preview, status, expires_at, …) plus the standardized
+ *     `instruction` and `grants` slots — no nested pending_action/resolve_with
+ *     wrapper.
  *   - Failure stage() returns array( 'staged' => false, 'error' => ... ).
  *
  * @package DataMachine\Tests
  */
+
+// Pure-PHP smoke runs without a $wpdb, so let PendingActionStore fall back to
+// the transient store (matches the sibling pending-action smokes).
+if ( ! defined( 'DATAMACHINE_PENDING_ACTION_TRANSIENT_FALLBACK' ) ) {
+	define( 'DATAMACHINE_PENDING_ACTION_TRANSIENT_FALLBACK', true );
+}
 
 require_once __DIR__ . '/bootstrap-unit.php';
 
@@ -117,23 +125,32 @@ datamachine_pending_action_helper_assert( ! isset( $result['resolve_params'] ), 
 datamachine_pending_action_helper_assert( ! isset( $result['instruction'] ), 'Top level no longer mirrors instruction.' );
 datamachine_pending_action_helper_assert( ! isset( $result['expires_at'] ), 'Top level no longer mirrors expires_at.' );
 
+// Canonical flat payload: the pending-action fields live directly on the
+// payload, not under a nested `pending_action` key. There is no longer a
+// `pending_action`, `resolve_with`, or `resolve_params` wrapper.
 $payload = $result['payload'];
-datamachine_pending_action_helper_assert( 'resolve_pending_action' === $payload['resolve_with'], 'Envelope payload carries resolve_with.' );
-datamachine_pending_action_helper_assert( $result['action_id'] === $payload['resolve_params']['action_id'], 'Envelope payload resolve_params carries the action_id.' );
-datamachine_pending_action_helper_assert( '<accepted|rejected>' === $payload['resolve_params']['decision'], 'Envelope payload resolve_params describes the decision shape.' );
-datamachine_pending_action_helper_assert( is_string( $payload['instruction'] ?? null ) && '' !== $payload['instruction'], 'Envelope payload carries the operator instruction.' );
+datamachine_pending_action_helper_assert( ! array_key_exists( 'pending_action', $payload ), 'Payload no longer nests a pending_action wrapper.' );
+datamachine_pending_action_helper_assert( ! array_key_exists( 'resolve_with', $payload ), 'Payload no longer carries a resolve_with directive.' );
+datamachine_pending_action_helper_assert( ! array_key_exists( 'resolve_params', $payload ), 'Payload no longer carries a resolve_params directive.' );
 
-$pending_action = $payload['pending_action'];
-datamachine_pending_action_helper_assert( $result['action_id'] === $pending_action['action_id'], 'pending_action carries the staged action_id.' );
-datamachine_pending_action_helper_assert( 'wiki_upsert' === $pending_action['kind'], 'pending_action carries the product handler kind.' );
-datamachine_pending_action_helper_assert( 'Update Wiki Page' === $pending_action['summary'], 'pending_action carries the sanitized summary.' );
-datamachine_pending_action_helper_assert( array( 'diff' => "- old\n+ new" ) === $pending_action['preview'], 'pending_action carries preview data.' );
-datamachine_pending_action_helper_assert( 'user:123' === $pending_action['creator'], 'pending_action records creator identity.' );
-datamachine_pending_action_helper_assert( 'agent:456' === $pending_action['agent'], 'pending_action records agent identity.' );
-datamachine_pending_action_helper_assert( 123 === $pending_action['metadata']['datamachine']['created_by'], 'Data Machine created_by audit field is retained in pending_action metadata.' );
-datamachine_pending_action_helper_assert( 456 === $pending_action['metadata']['datamachine']['agent_id'], 'Data Machine agent_id audit field is retained in pending_action metadata.' );
-datamachine_pending_action_helper_assert( isset( $pending_action['created_at'] ) && is_string( $pending_action['created_at'] ), 'pending_action carries an ISO creation timestamp.' );
-datamachine_pending_action_helper_assert( isset( $pending_action['expires_at'] ) && is_string( $pending_action['expires_at'] ), 'pending_action carries an ISO expiration timestamp.' );
+datamachine_pending_action_helper_assert( $result['action_id'] === $payload['action_id'], 'Payload carries the staged action_id at the top level.' );
+datamachine_pending_action_helper_assert( 'wiki_upsert' === $payload['kind'], 'Payload carries the product handler kind.' );
+datamachine_pending_action_helper_assert( 'Update Wiki Page' === $payload['summary'], 'Payload carries the sanitized summary.' );
+datamachine_pending_action_helper_assert( array( 'diff' => "- old\n+ new" ) === $payload['preview'], 'Payload carries preview data.' );
+datamachine_pending_action_helper_assert( array( 'title' => 'Demo', 'content' => 'Updated content.' ) === $payload['apply_input'], 'Payload carries apply_input.' );
+datamachine_pending_action_helper_assert( 'pending' === $payload['status'], 'Payload carries the canonical pending status.' );
+datamachine_pending_action_helper_assert( 'user:123' === $payload['creator'], 'Payload records creator identity.' );
+datamachine_pending_action_helper_assert( 'agent:456' === $payload['agent'], 'Payload records agent identity.' );
+datamachine_pending_action_helper_assert( 123 === $payload['metadata']['datamachine']['created_by'], 'Data Machine created_by audit field is retained in payload metadata.' );
+datamachine_pending_action_helper_assert( 456 === $payload['metadata']['datamachine']['agent_id'], 'Data Machine agent_id audit field is retained in payload metadata.' );
+datamachine_pending_action_helper_assert( isset( $payload['created_at'] ) && is_string( $payload['created_at'] ), 'Payload carries an ISO creation timestamp.' );
+datamachine_pending_action_helper_assert( array_key_exists( 'expires_at', $payload ), 'Payload carries an expires_at field.' );
+
+// Standardized orchestration slots: instruction is always present; grants is
+// omitted when the caller staged no resolver grants.
+datamachine_pending_action_helper_assert( is_string( $payload['instruction'] ?? null ) && '' !== $payload['instruction'], 'Payload carries the operator instruction slot.' );
+datamachine_pending_action_helper_assert( str_contains( $payload['instruction'], $result['action_id'] ), 'Instruction references the action_id to resolve.' );
+datamachine_pending_action_helper_assert( ! array_key_exists( 'grants', $payload ), 'Grants slot is omitted when no resolver grants were staged.' );
 
 datamachine_pending_action_helper_assert( 'data-machine' === $result['metadata']['adapter'], 'Data Machine is identified as adapter metadata.' );
 datamachine_pending_action_helper_assert( 'wiki_upsert' === $result['metadata']['datamachine']['kind'], 'Data Machine handler kind lives in adapter metadata.' );
@@ -148,6 +165,23 @@ datamachine_pending_action_helper_assert( ! array_key_exists( 'preview', $stored
 $normalized = WP_Agent_Message::normalize( $result );
 datamachine_pending_action_helper_assert( WP_Agent_Message::TYPE_APPROVAL_REQUIRED === $normalized['type'], 'Result normalizes as an approval_required envelope.' );
 datamachine_pending_action_helper_assert( $result['payload'] === $normalized['payload'], 'Envelope payload survives normalization.' );
+
+// Resolver grants flow into the canonical `grants` slot.
+$granted = PendingActionHelper::stage(
+	array(
+		'kind'            => 'wiki_upsert',
+		'summary'         => 'Grant-carrying stage.',
+		'apply_input'     => array( 'title' => 'Demo' ),
+		'resolver_grants' => array(
+			array( 'resolver' => 'service:publisher', 'scope' => 'publish' ),
+		),
+	)
+);
+datamachine_pending_action_helper_assert( true === $granted['staged'], 'Grant-carrying stage succeeds.' );
+datamachine_pending_action_helper_assert(
+	array( array( 'resolver' => 'service:publisher', 'scope' => 'publish' ) ) === $granted['payload']['grants'],
+	'Resolver grants flow into the canonical payload grants slot.'
+);
 
 // Failure shape: missing kind/apply_input still returns staged=false.
 $failure = PendingActionHelper::stage( array() );

--- a/tests/pending-action-helper-approval-envelope-smoke.php
+++ b/tests/pending-action-helper-approval-envelope-smoke.php
@@ -111,6 +111,10 @@ $result = PendingActionHelper::stage(
 			'diff' => '- old' . "\n" . '+ new',
 		),
 		'agent_id'     => 456,
+		// Pass user_id explicitly so creator is deterministic regardless of the
+		// runtime. The pure-PHP stub returns 123, but real WP (host-smoke
+		// backend) overrides get_current_user_id() with the unauthenticated 0.
+		'user_id'      => 123,
 		'context'      => array(
 			'tool_name'  => 'wiki_upsert',
 			'session_id' => 'session_123',


### PR DESCRIPTION
## What

Converge Data Machine onto the **single canonical** `approval_required` envelope shape so producers emit consistently and consumers read one shape.

`PendingActionHelper::stage()` previously emitted a custom **nested** payload:

```
{ pending_action: { …canonical… }, resolve_with, resolve_params, instruction }
```

It now emits the canonical **flat** envelope via the Agents API pending-action value object. The payload is the full canonical pending-action shape (`action_id`, `kind`, `summary`, `preview`, `status`, `expires_at`, `apply_input`, audit fields, …) plus the standardized `instruction` and `grants` slots.

## Why

There were two divergent approval-envelope shapes: Agents API's flat `approval_required` (from the ability lifecycle bridge) and Data Machine's nested wrapper. Agents API's flat shape is canonical; this PR makes Data Machine conform. As a bonus, the Agents API conversation loop reads `payload.action_id` from the flat shape, so the `approval_required` runtime event now carries a real `action_id` for Data Machine-staged actions instead of `null`.

## Behavior preserved

All Data Machine behavior is intact — verified against the code, not assumed:
- **Resolver grants** now ride the canonical `grants` slot (still also persisted in store metadata).
- **Durable `datamachine_pending_actions` table**, `datamachine_pending_action_handlers` dispatch, multisite `blog_id` re-entry, and the generic `agents/resolve-pending-action` resolution are untouched — the resolver reads the **store**, never the envelope.
- Top-level `staged` / `action_id` convenience fields are unchanged, so internal callers (content abilities, `ToolExecutor`, bundle/memory pending actions) and the frontend diff card keep working.
- `PendingActionInspectionAbility::normalize_action_row()` already rebuilds `resolve_with`/`resolve_params` from store metadata, so the CLI/frontend inspection rows are unaffected.

## Blast radius (verified)

No production code anywhere reads the old nested `payload.pending_action` wrapper. Checked Data Machine, frontend-agent-chat (reads the top-level `action_id` and the generic resolve route — handles both shapes), `data-machine-events` (uses `action_id` as a tool input, reads the store), and searched `Automattic/wpcom` (GitHub Enterprise) plus the Extra-Chill org — no nested-shape consumers. Big Sky / Odie and other Agents API consumers read the flat shape and are unaffected.

## Dependency / sequencing

Depends on the Agents API canonical builder (`WP_Agent_Pending_Action::to_approval_envelope()`): https://github.com/Automattic/agents-api/pull/375. Data Machine pins `wordpress/agents-api: dev-main`. `stage()` uses the canonical builder when present and otherwise builds the **identical** flat payload inline, so this PR is green now against the currently-vendored Agents API and adopts the canonical path automatically after #375 lands and `composer update wordpress/agents-api` runs. The inline path is version-transition only — it emits the same canonical flat shape, not the old nested one.

## Tests

- Rewrote `pending-action-helper-approval-envelope-smoke` to assert the flat shape (no nested `pending_action`/`resolve_with`/`resolve_params`), plus the `instruction` and `grants` slots. Verified passing on **both** the canonical builder path and the inline transition path.
- Repointed two sibling smokes (`memory-bundle-policy`, `agent-bundle-upgrade-planner`) that read `payload.pending_action` to the flat payload.
- Added the `DATAMACHINE_PENDING_ACTION_TRANSIENT_FALLBACK` guard to the envelope smoke so it runs in pure PHP like its siblings (it previously relied on an ambient `$wpdb`).
- Remaining local failures in resolution-apply smokes are pre-existing (need a real `$wpdb`) and identical on `main`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Cross-repo blast-radius analysis, implementing the `stage()` change, fixing affected test reads, and verifying both dependency paths. Chris reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)