### PR TITLE
fix(retry): make direct/system tasks retryable through JobRetryPolicy

### DIFF
--- a/inc/Core/JobRetryPolicy.php
+++ b/inc/Core/JobRetryPolicy.php
@@ -82,6 +82,18 @@ class JobRetryPolicy {
 		$timestamp     = time() + $delay_seconds;
 		$flow_step_id  = (string) ( $context_data['flow_step_id'] ?? '' );
 
+		// Direct/system tasks (e.g. daily_memory_generation) run through an
+		// ephemeral single-step workflow with flow_id=pipeline_id='direct'.
+		// They fail without a flow_step_id in $context_data, but their engine
+		// snapshot still carries the ephemeral step definition under
+		// flow_config — and datamachine_execute_step re-runs a step purely by
+		// its flow_step_id against that snapshot. Resolve it so a transient
+		// provider failure on a direct task is retryable through the same path
+		// as a pipeline step, rather than dead-ending on missing_flow_step_id.
+		if ( '' === $flow_step_id ) {
+			$flow_step_id = self::resolveEphemeralFlowStepId( $engine_data );
+		}
+
 		if ( '' === $flow_step_id ) {
 			return array(
 				'retried'      => false,
@@ -404,6 +416,39 @@ class JobRetryPolicy {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Resolve the flow_step_id of a direct/system task's ephemeral step.
+	 *
+	 * Direct tasks (scheduled via TaskScheduler → execute-workflow) store a
+	 * single ephemeral step under engine_data['flow_config']. Its key (and its
+	 * own `flow_step_id`) is what datamachine_execute_step needs to re-run the
+	 * task against the same job. Returns '' when the snapshot has no single
+	 * resumable system_task step (multi-step ephemeral workflows are not
+	 * blindly resumed here).
+	 *
+	 * @param array $engine_data Job engine data.
+	 * @return string Ephemeral flow_step_id, or '' when not resolvable.
+	 */
+	private static function resolveEphemeralFlowStepId( array $engine_data ): string {
+		$flow_config = is_array( $engine_data['flow_config'] ?? null ) ? $engine_data['flow_config'] : array();
+		if ( 1 !== count( $flow_config ) ) {
+			return '';
+		}
+
+		$step = reset( $flow_config );
+		if ( ! is_array( $step ) ) {
+			return '';
+		}
+
+		$flow_step_id = (string) ( $step['flow_step_id'] ?? '' );
+		if ( '' === $flow_step_id ) {
+			$key          = array_key_first( $flow_config );
+			$flow_step_id = is_string( $key ) ? $key : '';
+		}
+
+		return $flow_step_id;
 	}
 
 	/**

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -348,10 +348,40 @@ abstract class SystemTask {
 	/**
 	 * Mark a job as failed with an error message.
 	 *
+	 * Routes through the canonical `datamachine_fail_job` action so system
+	 * tasks share the same failure path as pipeline steps: JobRetryPolicy gets
+	 * a chance to reschedule transient provider/transport failures (e.g. an AI
+	 * request timeout on daily_memory_generation), structured error context is
+	 * persisted to engine_data, and the failure is logged consistently. When a
+	 * retry is scheduled the job is left pending and is NOT finalized here.
+	 *
+	 * The real error message is forwarded in $context_data so the retry
+	 * classifier can recognize timeout / rate-limit / overload signatures. Falls
+	 * back to direct finalization only if the action is somehow unavailable, so
+	 * a task never hangs un-finalized.
+	 *
 	 * @param int    $jobId   Job ID.
 	 * @param string $message Error message.
 	 */
 	protected function failJob( int $jobId, string $message ): void {
+		if ( has_action( 'datamachine_fail_job' ) ) {
+			do_action(
+				'datamachine_fail_job',
+				$jobId,
+				$message,
+				array(
+					'reason'        => $message,
+					'error_message' => $message,
+					'ai_error'      => $message,
+					'task_type'     => $this->getTaskType(),
+					'context'       => 'system',
+				)
+			);
+			return;
+		}
+
+		// Defensive fallback: finalize directly if the central handler is not
+		// registered (should not happen on a booted install).
 		$jobs_db              = new Jobs();
 		$engine_data          = $jobs_db->retrieve_engine_data( $jobId );
 		$engine_data['error'] = $message;

--- a/tests/job-retry-policy-smoke.php
+++ b/tests/job-retry-policy-smoke.php
@@ -62,6 +62,7 @@ $resolve_delay       = $reflection->getMethod( 'resolveDelay' );
 $classify_failure    = $reflection->getMethod( 'classifyFailure' );
 $resolve_policy      = $reflection->getMethod( 'resolvePolicy' );
 $record_poison_item  = $reflection->getMethod( 'recordPoisonItem' );
+$resolve_ephemeral   = $reflection->getMethod( 'resolveEphemeralFlowStepId' );
 
 echo "Case 1: Retry-After values are normalized\n";
 assert_retry_policy_smoke( 'numeric Retry-After is seconds', 90 === $extract_retry_after->invoke( null, array( 'retry_after' => '90' ) ) );
@@ -146,6 +147,53 @@ assert_retry_policy_smoke( 'policy records poison item isolation metadata', str_
 assert_retry_policy_smoke( 'fail handler tries retry before final failure', strpos( $fail_src, 'maybeRetry' ) < strpos( $fail_src, 'complete_job' ) );
 assert_retry_policy_smoke( 'fail handler persists structured diagnostics', str_contains( $fail_src, "'error_diagnostics'" ) && str_contains( $fail_src, "\$context_data['diagnostics']" ) );
 assert_retry_policy_smoke( 'AI failures pass retry and transport context', str_contains( $ai_src, "'retry_after'" ) && str_contains( $ai_src, "'headers'" ) && str_contains( $ai_src, "'transport_profile'" ) );
+
+echo "Case 7: Direct/system tasks resolve an ephemeral flow_step_id so they are retryable\n";
+// A direct task (e.g. daily_memory_generation) runs through a single ephemeral
+// step under engine_data['flow_config']; its flow_step_id is what
+// datamachine_execute_step needs to re-run the same job on retry.
+$direct_engine_data = array(
+	'flow_config' => array(
+		'ephemeral_step_0' => array(
+			'flow_step_id' => 'ephemeral_step_0',
+			'step_type'    => 'system_task',
+		),
+	),
+);
+assert_retry_policy_smoke(
+	'ephemeral single-step workflow resolves its flow_step_id',
+	'ephemeral_step_0' === $resolve_ephemeral->invoke( null, $direct_engine_data )
+);
+
+// Falls back to the array key when the step omits an explicit flow_step_id.
+$keyed_engine_data = array(
+	'flow_config' => array(
+		'ephemeral_step_0' => array( 'step_type' => 'system_task' ),
+	),
+);
+assert_retry_policy_smoke(
+	'ephemeral step without explicit id falls back to its config key',
+	'ephemeral_step_0' === $resolve_ephemeral->invoke( null, $keyed_engine_data )
+);
+
+// Multi-step ephemeral workflows are not blindly resumed.
+$multi_engine_data = array(
+	'flow_config' => array(
+		'ephemeral_step_0' => array( 'flow_step_id' => 'ephemeral_step_0' ),
+		'ephemeral_step_1' => array( 'flow_step_id' => 'ephemeral_step_1' ),
+	),
+);
+assert_retry_policy_smoke(
+	'multi-step ephemeral workflow does not resolve a single step',
+	'' === $resolve_ephemeral->invoke( null, $multi_engine_data )
+);
+
+// No flow_config (e.g. a genuine pipeline job) yields empty so the normal
+// $context_data['flow_step_id'] path is used instead.
+assert_retry_policy_smoke(
+	'absent flow_config yields empty (defers to context flow_step_id)',
+	'' === $resolve_ephemeral->invoke( null, array() )
+);
 
 echo "\nJob retry policy smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary

Closes the substrate gap behind #2576: `daily_memory_generation` (and every other direct system task) could never use the existing generic retry policy, so transient provider timeouts failed the job outright instead of being retried.

**No new retry path** — this wires direct tasks into the `JobRetryPolicy` substrate that already exists and already classifies the failure (cURL 28 timeout → `transport_connect_timeout` → retryable).

## Root cause

Direct system tasks run as an ephemeral single-step workflow with `flow_id=pipeline_id='direct'`. Two gaps:

1. `SystemTask::failJob()` finalized the job directly (`'failed: <msg>'`), **bypassing** the canonical `datamachine_fail_job` action — so `FailJobHandler` → `JobRetryPolicy::maybeRetry()` never ran.
2. Even if reached, `maybeRetry()` dead-ended on `missing_flow_step_id`: it only read `flow_step_id` from `$context_data`, which direct tasks don't populate. (Their ephemeral step id lives in `engine_data['flow_config']`.)

Reproduced: 3 agents failing nightly at ~00:09–00:10 on transient 300s OpenAI timeouts; manual reruns all succeed (idempotent → retry-safe). Verified on a live direct job that the new resolver returns its real `ephemeral_step_0` id.

## Fix

- **`SystemTask::failJob()`** routes through the `datamachine_fail_job` action, forwarding the real error (`error_message`/`ai_error`) so the classifier can detect timeout/rate-limit/overload. Retried failures leave the job `pending` (not finalized). Defensive fallback to direct finalization only if the handler is unregistered.
- **`JobRetryPolicy`** resolves the ephemeral step's `flow_step_id` from `engine_data['flow_config']` when `$context_data` omits one, so `datamachine_execute_step` re-runs the same direct-task job — the identical mechanism used for pipeline steps. Multi-step ephemeral workflows are not blindly resumed.

## Safety / blast radius

- **Image polling tasks unaffected:** their terminal messages (`Missing attachment_id`, etc.) match none of the transient retry signatures → classify non-retryable → finalize exactly as before.
- **No double-finalize:** `FailJobHandler` calls `maybeRetry()` first and returns early if retried; otherwise it finalizes once. `failJob()` no longer finalizes itself when delegating.
- **Format change (intentional):** direct-task non-retryable failures now read `failed - <reason>` (engine canonical, dash) instead of `failed: <reason>` (colon), aligning system tasks with pipeline-step failure formatting.

## Tests

- `tests/job-retry-policy-smoke.php`: **32 assertions, 0 failures** (added Case 7 — `resolveEphemeralFlowStepId`: single-step resolve, key fallback, multi-step guard, absent-config defer).
- `tests/retry-schedule-lifecycle-smoke.php`: 9/9 pass.
- PHPCS + PHPStan clean on all 3 changed files.

refs #2576