### PR TITLE
feat(retry): resume-from-checkpoint retry for multi-step ephemeral workflows

### DIFF
--- a/inc/Core/JobRetryPolicy.php
+++ b/inc/Core/JobRetryPolicy.php
@@ -419,33 +419,138 @@ class JobRetryPolicy {
 	}
 
 	/**
-	 * Resolve the flow_step_id of a direct/system task's ephemeral step.
+	 * Resolve the flow_step_id a direct/system task should re-run on retry.
 	 *
-	 * Direct tasks (scheduled via TaskScheduler → execute-workflow) store a
-	 * single ephemeral step under engine_data['flow_config']. Its key (and its
-	 * own `flow_step_id`) is what datamachine_execute_step needs to re-run the
-	 * task against the same job. Returns '' when the snapshot has no single
-	 * resumable system_task step (multi-step ephemeral workflows are not
-	 * blindly resumed here).
+	 * Direct tasks (scheduled via TaskScheduler → execute-workflow) store their
+	 * ephemeral steps under engine_data['flow_config'], keyed by flow_step_id.
+	 * datamachine_execute_step re-runs a step purely by its flow_step_id against
+	 * the engine snapshot, so resolving the right id is all that's needed to make
+	 * a direct task retryable.
+	 *
+	 * Resolution is scoped by step count:
+	 *
+	 *   - Single-step ephemeral workflow (the default getWorkflow() for all 13
+	 *     current system tasks): the step IS the whole task and is idempotent, so
+	 *     re-running it is the retry. Returns that step's id.
+	 *
+	 *   - Multi-step ephemeral workflow: only resumed when the task opted in via
+	 *     SystemTask::isResumable() (surfaced as engine_data['resumable'] = true).
+	 *     For a resumable workflow the resume point is the FIRST INCOMPLETE step
+	 *     in execution order — steps that already completed (recorded in
+	 *     engine_data['step_results']) are skipped, so their already-applied
+	 *     effects (engine_data['effects']) are never re-applied. A non-resumable
+	 *     multi-step workflow returns '' and continues to fail fast, never
+	 *     blindly re-running a step of a partially-executed flow.
+	 *
+	 *   - No flow_config (a genuine pipeline/flow job): returns '' so the normal
+	 *     $context_data['flow_step_id'] path is used instead.
 	 *
 	 * @param array $engine_data Job engine data.
-	 * @return string Ephemeral flow_step_id, or '' when not resolvable.
+	 * @return string Resume flow_step_id, or '' when not resolvable.
 	 */
 	private static function resolveEphemeralFlowStepId( array $engine_data ): string {
 		$flow_config = is_array( $engine_data['flow_config'] ?? null ) ? $engine_data['flow_config'] : array();
-		if ( 1 !== count( $flow_config ) ) {
+		$step_count  = count( $flow_config );
+
+		if ( 0 === $step_count ) {
 			return '';
 		}
 
-		$step = reset( $flow_config );
-		if ( ! is_array( $step ) ) {
+		if ( 1 === $step_count ) {
+			return self::flowStepIdFor( $flow_config, (string) ( array_key_first( $flow_config ) ?? '' ) );
+		}
+
+		// Multi-step ephemeral workflow: only resumable workflows resolve a
+		// resume point. Everything else fails fast (unchanged behavior).
+		if ( empty( $engine_data['resumable'] ) ) {
 			return '';
 		}
 
-		$flow_step_id = (string) ( $step['flow_step_id'] ?? '' );
-		if ( '' === $flow_step_id ) {
-			$key          = array_key_first( $flow_config );
-			$flow_step_id = is_string( $key ) ? $key : '';
+		return self::resolveResumeStepId( $flow_config, $engine_data );
+	}
+
+	/**
+	 * Resolve the first incomplete step id of a resumable multi-step workflow.
+	 *
+	 * Walks the flow_config in execution order and returns the first step that
+	 * does not have a successful completion recorded in
+	 * engine_data['step_results']. Completed steps are skipped so the retry never
+	 * re-runs already-applied work. Returns '' when the order cannot be resolved
+	 * (invalid execution_order) or when every step already completed (nothing to
+	 * resume — the failure is not a resumable partial-execution case).
+	 *
+	 * @param array $flow_config Ephemeral flow config keyed by flow_step_id.
+	 * @param array $engine_data Job engine data.
+	 * @return string First incomplete flow_step_id, or '' when not resolvable.
+	 */
+	private static function resolveResumeStepId( array $flow_config, array $engine_data ): string {
+		try {
+			$plan = \DataMachine\Engine\ExecutionPlan::from_flow_config( $flow_config );
+		} catch ( \InvalidArgumentException $e ) {
+			// A workflow without a valid execution order cannot be safely
+			// resumed; fall back to fail-fast rather than guess an order.
+			return '';
+		}
+
+		$ordered      = $plan->ordered_step_ids();
+		$step_results = is_array( $engine_data['step_results'] ?? null ) ? $engine_data['step_results'] : array();
+
+		foreach ( $ordered as $flow_step_id ) {
+			if ( ! self::stepCompletedSuccessfully( $step_results[ $flow_step_id ] ?? null ) ) {
+				return self::flowStepIdFor( $flow_config, (string) $flow_step_id );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Whether a recorded step result represents a successful completion.
+	 *
+	 * RunMetrics::recordStepResult stamps engine_data['step_results'][id] with a
+	 * step_success boolean and a result/status string as each step runs. A step
+	 * counts as completed (and must NOT be re-run on resume) when it reported
+	 * step_success or a terminal-success result. Any other shape — failed,
+	 * never-run (null), or empty — is an incomplete step to resume from.
+	 *
+	 * @param mixed $step_result Recorded step result entry, or null when absent.
+	 * @return bool True when the step completed successfully.
+	 */
+	private static function stepCompletedSuccessfully( $step_result ): bool {
+		if ( ! is_array( $step_result ) ) {
+			return false;
+		}
+
+		if ( array_key_exists( 'step_success', $step_result ) ) {
+			return (bool) $step_result['step_success'];
+		}
+
+		$outcome = (string) ( $step_result['result'] ?? ( $step_result['status'] ?? '' ) );
+
+		return in_array(
+			$outcome,
+			array( 'completed', 'completed_override', 'inline_continuation', 'batch_scheduled', 'completed_no_items', 'waiting' ),
+			true
+		);
+	}
+
+	/**
+	 * Resolve the canonical flow_step_id for an ephemeral flow_config entry.
+	 *
+	 * Prefers the entry's own `flow_step_id` field, falling back to its config
+	 * key (the engine keys flow_config by flow_step_id).
+	 *
+	 * @param array  $flow_config  Ephemeral flow config keyed by flow_step_id.
+	 * @param string $flow_step_id Candidate/key flow step id.
+	 * @return string Resolved flow_step_id, or '' when not resolvable.
+	 */
+	private static function flowStepIdFor( array $flow_config, string $flow_step_id ): string {
+		$step = is_array( $flow_config[ $flow_step_id ] ?? null ) ? $flow_config[ $flow_step_id ] : null;
+		if ( is_array( $step ) ) {
+			$explicit = (string) ( $step['flow_step_id'] ?? '' );
+			if ( '' !== $explicit ) {
+				return $explicit;
+			}
 		}
 
 		return $flow_step_id;

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -93,6 +93,35 @@ abstract class SystemTask {
 	}
 
 	/**
+	 * Whether a transient failure in this task's workflow may be retried from
+	 * the first incomplete step (resume-from-checkpoint) instead of failing fast.
+	 *
+	 * Single-step tasks (the default getWorkflow()) are always retryable through
+	 * JobRetryPolicy — the one step *is* the whole task, and re-running it is the
+	 * idempotent retry. This flag only matters for tasks that override
+	 * getWorkflow() to emit a MULTI-step ephemeral workflow: on retry the engine
+	 * must not blindly re-run a step of a partially-executed flow, because steps
+	 * 0..K-1 may have already applied side effects (writes, sent messages,
+	 * created posts).
+	 *
+	 * When this returns true, JobRetryPolicy resolves the resume point as the
+	 * first step whose engine_data['step_results'] entry did not complete
+	 * successfully, so completed steps (and their already-recorded effects) are
+	 * never re-applied. When false (the safe default), a multi-step workflow
+	 * fails fast on a transient error rather than risk partial re-execution.
+	 *
+	 * Only override this to true when every step in the workflow is either
+	 * idempotent or records its effects under engine_data['effects'] so the
+	 * resume contract can skip already-applied work.
+	 *
+	 * @return bool True when the workflow may resume from its first incomplete step.
+	 * @since 0.156.2
+	 */
+	public function isResumable(): bool {
+		return false;
+	}
+
+	/**
 	 * Execute the task's imperative business logic.
 	 *
 	 * Called by SystemTaskStep when running as a pipeline/workflow step.

--- a/inc/Engine/ExecutionPlan.php
+++ b/inc/Engine/ExecutionPlan.php
@@ -76,6 +76,15 @@ class ExecutionPlan {
 	}
 
 	/**
+	 * Get all flow step IDs in execution order.
+	 *
+	 * @return string[] Flow step IDs sorted by execution_order.
+	 */
+	public function ordered_step_ids(): array {
+		return $this->step_ids;
+	}
+
+	/**
 	 * Get the next flow step ID after the current step.
 	 *
 	 * @param string $flow_step_id Current flow step ID.

--- a/inc/Engine/Tasks/TaskScheduler.php
+++ b/inc/Engine/Tasks/TaskScheduler.php
@@ -245,21 +245,31 @@ class TaskScheduler {
 			? $task_meta['label']
 			: ucfirst( str_replace( '_', ' ', $taskType ) );
 
+		$initial_data = array(
+			'task_type'     => $taskType,
+			'task_params'   => $params,
+			'task_context'  => $context,
+			'job_source'    => 'system',
+			'job_label'     => $job_label,
+			'parent_job_id' => $parentJobId,
+			'user_id'       => $context_user_id,
+			'agent_id'      => $context_agent_id,
+			'agent_slug'    => $context_agent_slug,
+			'job'           => $job_snapshot,
+		);
+
+		// Multi-step resumable tasks opt into resume-from-checkpoint retry so a
+		// transient failure restarts from the first incomplete step rather than
+		// failing fast. Only stamp the flag when opted in — the 13 single-step
+		// tasks keep an unchanged engine snapshot and the existing retry path.
+		if ( $handler->isResumable() ) {
+			$initial_data['resumable'] = true;
+		}
+
 		$result = AbilityResult::normalize( $ability->execute( array(
 			'workflow'     => $workflow,
 			'timestamp'    => $params['scheduled_at'] ?? null,
-			'initial_data' => array(
-				'task_type'     => $taskType,
-				'task_params'   => $params,
-				'task_context'  => $context,
-				'job_source'    => 'system',
-				'job_label'     => $job_label,
-				'parent_job_id' => $parentJobId,
-				'user_id'       => $context_user_id,
-				'agent_id'      => $context_agent_id,
-				'agent_slug'    => $context_agent_slug,
-				'job'           => $job_snapshot,
-			),
+			'initial_data' => $initial_data,
 		) ) );
 
 		if ( empty( $result['success'] ) ) {

--- a/tests/job-retry-policy-smoke.php
+++ b/tests/job-retry-policy-smoke.php
@@ -8,6 +8,7 @@
  */
 
 define( 'ABSPATH', __DIR__ );
+define( 'WPINC', 'wp-includes' );
 
 $failed = 0;
 $total  = 0;
@@ -52,6 +53,7 @@ function datamachine_merge_engine_data( int $job_id, array $data ): void {
 	$merged_engine_data = $data;
 }
 
+require_once __DIR__ . '/../inc/Engine/ExecutionPlan.php';
 require_once __DIR__ . '/../inc/Core/JobRetryPolicy.php';
 
 $reflection          = new ReflectionClass( DataMachine\Core\JobRetryPolicy::class );
@@ -63,6 +65,8 @@ $classify_failure    = $reflection->getMethod( 'classifyFailure' );
 $resolve_policy      = $reflection->getMethod( 'resolvePolicy' );
 $record_poison_item  = $reflection->getMethod( 'recordPoisonItem' );
 $resolve_ephemeral   = $reflection->getMethod( 'resolveEphemeralFlowStepId' );
+$resolve_resume      = $reflection->getMethod( 'resolveResumeStepId' );
+$step_completed      = $reflection->getMethod( 'stepCompletedSuccessfully' );
 
 echo "Case 1: Retry-After values are normalized\n";
 assert_retry_policy_smoke( 'numeric Retry-After is seconds', 90 === $extract_retry_after->invoke( null, array( 'retry_after' => '90' ) ) );
@@ -176,15 +180,16 @@ assert_retry_policy_smoke(
 	'ephemeral_step_0' === $resolve_ephemeral->invoke( null, $keyed_engine_data )
 );
 
-// Multi-step ephemeral workflows are not blindly resumed.
+// Non-resumable multi-step ephemeral workflows are not blindly resumed (the
+// current #2810 fail-fast guard — unchanged).
 $multi_engine_data = array(
 	'flow_config' => array(
-		'ephemeral_step_0' => array( 'flow_step_id' => 'ephemeral_step_0' ),
-		'ephemeral_step_1' => array( 'flow_step_id' => 'ephemeral_step_1' ),
+		'ephemeral_step_0' => array( 'flow_step_id' => 'ephemeral_step_0', 'execution_order' => 0 ),
+		'ephemeral_step_1' => array( 'flow_step_id' => 'ephemeral_step_1', 'execution_order' => 1 ),
 	),
 );
 assert_retry_policy_smoke(
-	'multi-step ephemeral workflow does not resolve a single step',
+	'non-resumable multi-step ephemeral workflow does not resolve a single step',
 	'' === $resolve_ephemeral->invoke( null, $multi_engine_data )
 );
 
@@ -193,6 +198,131 @@ assert_retry_policy_smoke(
 assert_retry_policy_smoke(
 	'absent flow_config yields empty (defers to context flow_step_id)',
 	'' === $resolve_ephemeral->invoke( null, array() )
+);
+
+echo "Case 8: Resumable multi-step ephemeral workflows resume from the first incomplete step (#2811)\n";
+
+// A resumable multi-step workflow where step 0 completed but step 1 has not:
+// the resume point is step 1, so step 0's already-applied effects are skipped.
+$resumable_partial = array(
+	'resumable'    => true,
+	'flow_config'  => array(
+		'ephemeral_step_0' => array( 'flow_step_id' => 'ephemeral_step_0', 'execution_order' => 0 ),
+		'ephemeral_step_1' => array( 'flow_step_id' => 'ephemeral_step_1', 'execution_order' => 1 ),
+		'ephemeral_step_2' => array( 'flow_step_id' => 'ephemeral_step_2', 'execution_order' => 2 ),
+	),
+	'step_results' => array(
+		'ephemeral_step_0' => array( 'flow_step_id' => 'ephemeral_step_0', 'step_success' => true, 'result' => 'inline_continuation' ),
+	),
+);
+assert_retry_policy_smoke(
+	'resumable workflow resumes at the first step without a completed result',
+	'ephemeral_step_1' === $resolve_ephemeral->invoke( null, $resumable_partial )
+);
+assert_retry_policy_smoke(
+	'resolveResumeStepId returns the first incomplete step directly',
+	'ephemeral_step_1' === $resolve_resume->invoke( null, $resumable_partial['flow_config'], $resumable_partial )
+);
+
+// execution_order — not array insertion order — drives the resume point.
+$resumable_reordered = array(
+	'resumable'    => true,
+	'flow_config'  => array(
+		'ephemeral_step_1' => array( 'flow_step_id' => 'ephemeral_step_1', 'execution_order' => 1 ),
+		'ephemeral_step_0' => array( 'flow_step_id' => 'ephemeral_step_0', 'execution_order' => 0 ),
+	),
+	'step_results' => array(
+		'ephemeral_step_0' => array( 'flow_step_id' => 'ephemeral_step_0', 'step_success' => true ),
+	),
+);
+assert_retry_policy_smoke(
+	'resume point follows execution_order, not array order',
+	'ephemeral_step_1' === $resolve_ephemeral->invoke( null, $resumable_reordered )
+);
+
+// A failed mid-flow step is the resume point even when a later step somehow
+// recorded success — the first incomplete step in order wins.
+$resumable_failed_mid = array(
+	'resumable'    => true,
+	'flow_config'  => array(
+		'ephemeral_step_0' => array( 'flow_step_id' => 'ephemeral_step_0', 'execution_order' => 0 ),
+		'ephemeral_step_1' => array( 'flow_step_id' => 'ephemeral_step_1', 'execution_order' => 1 ),
+	),
+	'step_results' => array(
+		'ephemeral_step_0' => array( 'flow_step_id' => 'ephemeral_step_0', 'step_success' => false, 'result' => 'failed' ),
+		'ephemeral_step_1' => array( 'flow_step_id' => 'ephemeral_step_1', 'step_success' => true ),
+	),
+);
+assert_retry_policy_smoke(
+	'a failed step is the resume point even with later success recorded',
+	'ephemeral_step_0' === $resolve_ephemeral->invoke( null, $resumable_failed_mid )
+);
+
+// Every step already completed: nothing to resume (not a partial-execution
+// case) so resolution is empty and the workflow fails normally.
+$resumable_all_done = array(
+	'resumable'    => true,
+	'flow_config'  => array(
+		'ephemeral_step_0' => array( 'flow_step_id' => 'ephemeral_step_0', 'execution_order' => 0 ),
+		'ephemeral_step_1' => array( 'flow_step_id' => 'ephemeral_step_1', 'execution_order' => 1 ),
+	),
+	'step_results' => array(
+		'ephemeral_step_0' => array( 'flow_step_id' => 'ephemeral_step_0', 'step_success' => true ),
+		'ephemeral_step_1' => array( 'flow_step_id' => 'ephemeral_step_1', 'step_success' => true ),
+	),
+);
+assert_retry_policy_smoke(
+	'fully-completed resumable workflow resolves no resume step',
+	'' === $resolve_ephemeral->invoke( null, $resumable_all_done )
+);
+
+// Opt-in gate: the SAME partial multi-step snapshot WITHOUT the resumable flag
+// still fails fast (no resume) — proving the default is non-resumable.
+$non_resumable_partial            = $resumable_partial;
+$non_resumable_partial['resumable'] = false;
+assert_retry_policy_smoke(
+	'partial multi-step workflow without resumable flag still fails fast',
+	'' === $resolve_ephemeral->invoke( null, $non_resumable_partial )
+);
+unset( $non_resumable_partial['resumable'] );
+assert_retry_policy_smoke(
+	'partial multi-step workflow with absent resumable flag still fails fast',
+	'' === $resolve_ephemeral->invoke( null, $non_resumable_partial )
+);
+
+// The single-step path from #2810 is unchanged regardless of the resumable
+// flag — a single step is always its own resume point.
+$single_with_flag = array(
+	'resumable'   => true,
+	'flow_config' => array(
+		'ephemeral_step_0' => array( 'flow_step_id' => 'ephemeral_step_0', 'execution_order' => 0 ),
+	),
+);
+assert_retry_policy_smoke(
+	'single-step path is unchanged even when resumable flag is set',
+	'ephemeral_step_0' === $resolve_ephemeral->invoke( null, $single_with_flag )
+);
+
+// step completion classification: step_success boolean is authoritative;
+// terminal-success result strings count as completed; failed/absent do not.
+assert_retry_policy_smoke( 'step_success=true counts as completed', true === $step_completed->invoke( null, array( 'step_success' => true ) ) );
+assert_retry_policy_smoke( 'step_success=false counts as incomplete', false === $step_completed->invoke( null, array( 'step_success' => false, 'result' => 'failed' ) ) );
+assert_retry_policy_smoke( 'completed result string counts as completed', true === $step_completed->invoke( null, array( 'result' => 'completed' ) ) );
+assert_retry_policy_smoke( 'inline_continuation result counts as completed', true === $step_completed->invoke( null, array( 'result' => 'inline_continuation' ) ) );
+assert_retry_policy_smoke( 'absent step result counts as incomplete', false === $step_completed->invoke( null, null ) );
+
+// An invalid execution order (missing execution_order) cannot be safely
+// resumed — fall back to fail-fast rather than guess.
+$resumable_bad_order = array(
+	'resumable'   => true,
+	'flow_config' => array(
+		'ephemeral_step_0' => array( 'flow_step_id' => 'ephemeral_step_0' ),
+		'ephemeral_step_1' => array( 'flow_step_id' => 'ephemeral_step_1' ),
+	),
+);
+assert_retry_policy_smoke(
+	'resumable workflow with invalid execution order fails fast',
+	'' === $resolve_ephemeral->invoke( null, $resumable_bad_order )
 );
 
 echo "\nJob retry policy smoke complete: {$total} assertions, {$failed} failures.\n";


### PR DESCRIPTION
## Summary

Follow-up to #2810. That PR made **single-step** direct/system tasks retryable through the generic `JobRetryPolicy` by resolving the ephemeral `flow_step_id` from `engine_data['flow_config']`. It deliberately left **multi-step** ephemeral workflows to fail fast (`resolveEphemeralFlowStepId()` returned `''` for >1 step), because blindly re-running one step of a partially-executed flow could double-apply side effects.

This PR closes that latent gap: a multi-step ephemeral workflow that **opts in as resumable** now retries a transient failure from its **first incomplete step**, skipping completed steps so their already-applied effects are never re-applied.

There are **zero** multi-step ephemeral system tasks today (all 13 use the default single-step `getWorkflow()`), so this is mechanism + opt-in + smoke coverage validated against synthetic `engine_data` fixtures — exactly the latent/low-priority scope #2811 describes. No new infrastructure was invented; the design reuses the existing `step_results` / `flow_config`/`ExecutionPlan` / `effects` substrates.

`Closes #2811`

## Checkpoint source (existing engine_data records — no parallel store)

- **Resume point:** `engine_data['step_results']` — written per step by `RunMetrics::recordStepResult()` from `ExecuteStepAbility`, keyed by `flow_step_id`, carrying `step_success` + a `result`/`status` string. A step counts as completed when `step_success === true` (authoritative) or its `result`/`status` is a terminal-success outcome (`completed`, `completed_override`, `inline_continuation`, `batch_scheduled`, `completed_no_items`, `waiting`).
- **Order:** `engine_data['flow_config']` + `ExecutionPlan::from_flow_config()` — the same positional plan the engine uses to walk steps (`StepNavigator`). Added `ExecutionPlan::ordered_step_ids()` so the policy can iterate the full order. Resume point = first step in execution order **without** a successful `step_results` entry.
- **Re-dispatch:** unchanged — the resolved `flow_step_id` is scheduled on `datamachine_execute_step`, which re-runs exactly that step against the engine snapshot.

## How completed-step effects are skipped

Resume re-dispatches **only the first incomplete step**. Steps `0..K-1` that already completed are never re-run, so their effects recorded under `engine_data['effects']` (the same substrate `SystemTask::undoEffects()` reverses) are never re-applied. The `step_results` completion record **is** the idempotency gate — there is no separate "skip these effects" bookkeeping to keep in sync.

## Opt-in mechanism and default

- **`SystemTask::isResumable(): bool`** — new method, **defaults `false`**. Only a task that overrides `getWorkflow()` to emit a multi-step workflow AND knows every step is idempotent-or-effect-recording should return `true`.
- **`TaskScheduler::schedule()`** stamps `initial_data['resumable'] = true` **only when** `isResumable()` is true, so it lands in `engine_data['resumable']`. The 13 existing single-step tasks get an **unchanged** engine snapshot (no `resumable` key).
- A method on `SystemTask` (rather than a registration-level declaration) is the right opt-in here: resumability is a property of the workflow shape the task emits, which is exactly what `getWorkflow()`/the task class already own. Registration metadata (`getTaskMeta()`) is for UI/manual-run safety, not execution semantics.

### Decision scope

`resolveEphemeralFlowStepId()` is now structured by step count:
- **1 step →** returns that step's id (the #2810 path, **untouched**).
- **>1 step + `resumable` truthy →** first incomplete step via `ExecutionPlan` order.
- **>1 step + not resumable →** `''` (fail-fast, **unchanged** #2810 guard behavior).
- **invalid `execution_order` →** `''` (fail-fast — never guess an order).
- **fully completed →** `''` (nothing to resume; not a partial-execution case).
- **no `flow_config` →** `''` (genuine pipeline job defers to `$context_data['flow_step_id']`).

## Blast radius

- **Single-step path (#2810) is untouched** — confirmed by smoke (`single-step path is unchanged even when resumable flag is set`) and by the count-scoped branch that returns the lone step before any resumable logic runs.
- **Non-resumable multi-step still fails fast** — the existing Case 7 assertion is preserved (now labeled `non-resumable multi-step ... does not resolve a single step`) and reinforced by the opt-in-gate assertions.
- No engine_data shape changes for existing tasks; `resumable` is additive and absent by default.

## Test results

- `php tests/job-retry-policy-smoke.php` → **46 assertions, 0 failures.** New Case 8 covers: resume at first incomplete step, `execution_order` (not array order) drives the point, failed-mid-flow resume, fully-completed → no resume, opt-in gate (absent/false flag → fail fast), single-step unchanged with flag set, step-completion classification, and invalid-order fail-fast.
- `homeboy lint data-machine --changed-since origin/main` → **PHPCS, PHPStan (level 7), ESLint all passed, 0 findings** on changed files.
- `php -l` clean on all changed files.

## Files

- `inc/Core/JobRetryPolicy.php` — count-scoped `resolveEphemeralFlowStepId()`; new `resolveResumeStepId()`, `stepCompletedSuccessfully()`, `flowStepIdFor()`.
- `inc/Engine/AI/System/Tasks/SystemTask.php` — `isResumable()` opt-in (default false).
- `inc/Engine/Tasks/TaskScheduler.php` — stamp `engine_data['resumable']` when opted in.
- `inc/Engine/ExecutionPlan.php` — `ordered_step_ids()` accessor.
- `tests/job-retry-policy-smoke.php` — Case 8 + ExecutionPlan wiring.