### PR TITLE
fix(bundle): require canonical typed artifact outputs

### DIFF
--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -614,10 +614,9 @@ class DataMachineCompletionAssertions {
 					continue;
 				}
 
-				foreach ( array( $tool_result['typed_artifacts'] ?? null, $tool_result['outputs']['typed_artifacts'] ?? null, $tool_result['data']['typed_artifacts'] ?? null, $tool_result['result']['typed_artifacts'] ?? null, $tool_result['result']['data']['typed_artifacts'] ?? null ) as $artifact_outputs ) {
-					if ( is_array( $artifact_outputs ) ) {
-						$typed_artifacts = array_replace_recursive( $typed_artifacts, $artifact_outputs );
-					}
+				$artifact_outputs = $tool_result['outputs']['typed_artifacts'] ?? null;
+				if ( is_array( $artifact_outputs ) ) {
+					$typed_artifacts = array_replace_recursive( $typed_artifacts, $artifact_outputs );
 				}
 			}
 		}

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -486,28 +486,13 @@ function datamachine_normalize_typed_artifact_outputs( array $result ): array {
 	if ( is_array( $result['outputs']['typed_artifacts'] ?? null ) ) {
 		$sources[] = $result['outputs']['typed_artifacts'];
 	}
-	if ( is_array( $result['typed_artifacts'] ?? null ) ) {
-		$sources[] = $result['typed_artifacts'];
-	}
 	foreach ( is_array( $result['tool_execution_results'] ?? null ) ? $result['tool_execution_results'] : array() as $tool_result ) {
 		if ( ! is_array( $tool_result ) ) {
 			continue;
 		}
 
-		if ( is_array( $tool_result['typed_artifacts'] ?? null ) ) {
-			$sources[] = $tool_result['typed_artifacts'];
-		}
 		if ( is_array( $tool_result['outputs']['typed_artifacts'] ?? null ) ) {
 			$sources[] = $tool_result['outputs']['typed_artifacts'];
-		}
-		if ( is_array( $tool_result['data']['typed_artifacts'] ?? null ) ) {
-			$sources[] = $tool_result['data']['typed_artifacts'];
-		}
-		if ( is_array( $tool_result['result']['typed_artifacts'] ?? null ) ) {
-			$sources[] = $tool_result['result']['typed_artifacts'];
-		}
-		if ( is_array( $tool_result['result']['data']['typed_artifacts'] ?? null ) ) {
-			$sources[] = $tool_result['result']['data']['typed_artifacts'];
 		}
 	}
 

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -164,7 +164,7 @@ final class AgentBundleRunner {
 	/** @return array<string,mixed> */
 	private function response( array $response, array $input, array $runtime_imports = array(), array $selection = array() ): array {
 		$response['schema'] ??= 'datamachine/agent-bundle-run/v1';
-		$response           = $this->apply_wait_result_status( $response );
+		$response             = $this->apply_wait_result_status( $response );
 
 		if ( ! empty( $runtime_imports ) ) {
 			$response['runtime_imports'] = $runtime_imports;
@@ -402,7 +402,6 @@ final class AgentBundleRunner {
 					$outputs[ $key ] = $value;
 				}
 			}
-
 		}
 
 		foreach ( $engine_data as $key => $value ) {
@@ -412,8 +411,8 @@ final class AgentBundleRunner {
 			}
 		}
 
-		$present = array_keys( $outputs );
-		$missing = array_values( array_diff( array_values( array_unique( array_merge( $required, array_keys( $mappings ) ) ) ), $present ) );
+		$present           = array_keys( $outputs );
+		$missing           = array_values( array_diff( array_values( array_unique( array_merge( $required, array_keys( $mappings ) ) ) ), $present ) );
 		$missing_artifacts = array_values(
 			array_filter(
 				$artifacts,
@@ -441,16 +440,16 @@ final class AgentBundleRunner {
 
 	/** @return array<string,mixed> */
 	private function enforce_required_outputs( array $response, array $input ): array {
-		$diagnostics = is_array( $response['output_diagnostics'] ?? null ) ? $response['output_diagnostics'] : array();
+		$diagnostics        = is_array( $response['output_diagnostics'] ?? null ) ? $response['output_diagnostics'] : array();
 		$required_outputs   = is_array( $diagnostics['required_outputs'] ?? null ) ? $diagnostics['required_outputs'] : array();
 		$required_artifacts = is_array( $diagnostics['required_artifacts'] ?? null ) ? $diagnostics['required_artifacts'] : array();
 		if ( ( empty( $required_outputs ) && empty( $required_artifacts ) ) || empty( $response['success'] ) || ! $this->can_enforce_required_outputs( $response, $input ) ) {
 			return $response;
 		}
 
-		$outputs         = is_array( $response['outputs'] ?? null ) ? $response['outputs'] : array();
-		$typed_artifacts = is_array( $outputs['typed_artifacts'] ?? null ) ? $outputs['typed_artifacts'] : array();
-		$missing_outputs = array_values(
+		$outputs           = is_array( $response['outputs'] ?? null ) ? $response['outputs'] : array();
+		$typed_artifacts   = is_array( $outputs['typed_artifacts'] ?? null ) ? $outputs['typed_artifacts'] : array();
+		$missing_outputs   = array_values(
 			array_filter(
 				$required_outputs,
 				function ( string $key ) use ( $outputs ): bool {
@@ -466,7 +465,7 @@ final class AgentBundleRunner {
 				}
 			)
 		);
-		$missing = array_values( array_unique( array_merge( $missing_outputs, $missing_artifacts ) ) );
+		$missing           = array_values( array_unique( array_merge( $missing_outputs, $missing_artifacts ) ) );
 		if ( empty( $missing ) ) {
 			return $response;
 		}

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -403,13 +403,6 @@ final class AgentBundleRunner {
 				}
 			}
 
-			$typed_artifacts = is_array( $engine_data['outputs']['typed_artifacts'] ?? null ) ? $engine_data['outputs']['typed_artifacts'] : array();
-			foreach ( $typed_artifacts as $key => $artifact_output ) {
-				$key = sanitize_key( (string) $key );
-				if ( '' !== $key && is_array( $artifact_output ) && DataPath::hasValue( $artifact_output['payload'] ?? null ) ) {
-					$outputs[ $key ] = $artifact_output['payload'];
-				}
-			}
 		}
 
 		foreach ( $engine_data as $key => $value ) {
@@ -420,7 +413,16 @@ final class AgentBundleRunner {
 		}
 
 		$present = array_keys( $outputs );
-		$missing = array_values( array_diff( $declared, $present ) );
+		$missing = array_values( array_diff( array_values( array_unique( array_merge( $required, array_keys( $mappings ) ) ) ), $present ) );
+		$missing_artifacts = array_values(
+			array_filter(
+				$artifacts,
+				function ( string $key ) use ( $outputs ): bool {
+					$typed_artifacts = is_array( $outputs['typed_artifacts'] ?? null ) ? $outputs['typed_artifacts'] : array();
+					return ! is_array( $typed_artifacts[ $key ] ?? null ) || ! DataPath::hasValue( $typed_artifacts[ $key ]['payload'] ?? null );
+				}
+			)
+		);
 
 		return array(
 			'outputs'     => $outputs,
@@ -431,6 +433,7 @@ final class AgentBundleRunner {
 					'required_artifacts' => $artifacts,
 					'present_outputs'    => $present,
 					'missing_outputs'    => $missing,
+					'missing_artifacts'  => $missing_artifacts,
 				)
 			),
 		);
@@ -439,27 +442,31 @@ final class AgentBundleRunner {
 	/** @return array<string,mixed> */
 	private function enforce_required_outputs( array $response, array $input ): array {
 		$diagnostics = is_array( $response['output_diagnostics'] ?? null ) ? $response['output_diagnostics'] : array();
-		$required    = array_values(
-			array_unique(
-				array_merge(
-					is_array( $diagnostics['required_outputs'] ?? null ) ? $diagnostics['required_outputs'] : array(),
-					is_array( $diagnostics['required_artifacts'] ?? null ) ? $diagnostics['required_artifacts'] : array()
-				)
-			)
-		);
-		if ( empty( $required ) || empty( $response['success'] ) || ! $this->can_enforce_required_outputs( $response, $input ) ) {
+		$required_outputs   = is_array( $diagnostics['required_outputs'] ?? null ) ? $diagnostics['required_outputs'] : array();
+		$required_artifacts = is_array( $diagnostics['required_artifacts'] ?? null ) ? $diagnostics['required_artifacts'] : array();
+		if ( ( empty( $required_outputs ) && empty( $required_artifacts ) ) || empty( $response['success'] ) || ! $this->can_enforce_required_outputs( $response, $input ) ) {
 			return $response;
 		}
 
-		$outputs = is_array( $response['outputs'] ?? null ) ? $response['outputs'] : array();
-		$missing = array_values(
+		$outputs         = is_array( $response['outputs'] ?? null ) ? $response['outputs'] : array();
+		$typed_artifacts = is_array( $outputs['typed_artifacts'] ?? null ) ? $outputs['typed_artifacts'] : array();
+		$missing_outputs = array_values(
 			array_filter(
-				$required,
+				$required_outputs,
 				function ( string $key ) use ( $outputs ): bool {
 					return ! array_key_exists( $key, $outputs ) || ! DataPath::hasValue( $outputs[ $key ] );
 				}
 			)
 		);
+		$missing_artifacts = array_values(
+			array_filter(
+				$required_artifacts,
+				function ( string $key ) use ( $typed_artifacts ): bool {
+					return ! is_array( $typed_artifacts[ $key ] ?? null ) || ! DataPath::hasValue( $typed_artifacts[ $key ]['payload'] ?? null );
+				}
+			)
+		);
+		$missing = array_values( array_unique( array_merge( $missing_outputs, $missing_artifacts ) ) );
 		if ( empty( $missing ) ) {
 			return $response;
 		}

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -184,18 +184,21 @@ $runtime_initial_data             = $initial_data_from_workflow_input->invoke(
 		'input' => array(
 			'wait_for_completion' => true,
 			'site_kind'           => 'store',
-			'artifacts'           => array(
-				'concept_packet' => array(
-					'payload' => array( 'title' => 'Kiln Shelf Supply' ),
+			'outputs'             => array(
+				'typed_artifacts' => array(
+					'concept_packet' => array(
+						'schema'   => 'example-agent/ConceptPacket/v1',
+						'artifact' => 'ConceptPacket',
+						'payload'  => array( 'title' => 'Kiln Shelf Supply' ),
+					),
 				),
 			),
-			'concept_packet'     => array( 'title' => 'Kiln Shelf Supply' ),
 		),
 	)
 );
 datamachine_bundle_runner_assert( 'store' === ( $runtime_initial_data['site_kind'] ?? null ), 'runtime workflow input scalar is promoted to initial_data', $failures, $passes );
-datamachine_bundle_runner_assert( 'Kiln Shelf Supply' === ( $runtime_initial_data['concept_packet']['title'] ?? null ), 'runtime workflow artifact alias is promoted to initial_data', $failures, $passes );
-datamachine_bundle_runner_assert( 'Kiln Shelf Supply' === ( $runtime_initial_data['artifacts']['concept_packet']['payload']['title'] ?? null ), 'runtime workflow artifacts map is promoted to initial_data', $failures, $passes );
+datamachine_bundle_runner_assert( ! isset( $runtime_initial_data['concept_packet'] ), 'runtime workflow artifact alias is not promoted to initial_data', $failures, $passes );
+datamachine_bundle_runner_assert( 'Kiln Shelf Supply' === ( $runtime_initial_data['outputs']['typed_artifacts']['concept_packet']['payload']['title'] ?? null ), 'runtime workflow typed artifact envelope is promoted to initial_data', $failures, $passes );
 datamachine_bundle_runner_assert( ! isset( $runtime_initial_data['wait_for_completion'] ), 'runtime workflow control field is not promoted to initial_data', $failures, $passes );
 
 $output_projection = $runner_reflection->getMethod( 'output_projection' );
@@ -240,7 +243,6 @@ $projected_outputs = $output_projection->invoke(
 			'store_issue_number' => 'metadata.engine_data.store_idea_agent.issue_number',
 			'store_issue_url'    => 'metadata.engine_data.store_idea_agent.issue_url',
 			'missing_store_url'  => 'metadata.engine_data.store_idea_agent.missing_url',
-			'concept_packet'     => 'metadata.engine_data.outputs.typed_artifacts.concept_packet.payload',
 		),
 	)
 );
@@ -250,7 +252,8 @@ datamachine_bundle_runner_assert( 'artifacts/result.json' === ( $projected_outpu
 datamachine_bundle_runner_assert( 'semantic output projection' === ( $projected_outputs['outputs']['summary_title'] ?? null ), 'explicit outputs map is projected', $failures, $passes );
 datamachine_bundle_runner_assert( 456 === ( $projected_outputs['outputs']['store_issue_number'] ?? null ), 'declared nested engine_data output number is projected', $failures, $passes );
 datamachine_bundle_runner_assert( 'https://github.com/Extra-Chill/example-agent/issues/456' === ( $projected_outputs['outputs']['store_issue_url'] ?? null ), 'declared nested engine_data output URL is projected', $failures, $passes );
-datamachine_bundle_runner_assert( array( 'title' => 'Projected typed artifact' ) === ( $projected_outputs['outputs']['concept_packet'] ?? null ), 'declared typed artifact payload path is projected', $failures, $passes );
+datamachine_bundle_runner_assert( array( 'title' => 'Projected typed artifact' ) === ( $projected_outputs['outputs']['typed_artifacts']['concept_packet']['payload'] ?? null ), 'declared typed artifact envelope is projected', $failures, $passes );
+datamachine_bundle_runner_assert( ! isset( $projected_outputs['outputs']['concept_packet'] ), 'typed artifact payload is not projected through legacy output alias', $failures, $passes );
 datamachine_bundle_runner_assert( ! isset( $projected_outputs['outputs']['agent_id'] ), 'runtime identity fields are not projected as outputs', $failures, $passes );
 datamachine_bundle_runner_assert( array( 'issue_number', 'issue_url', 'missing_result_url' ) === ( $projected_outputs['diagnostics']['required_outputs'] ?? null ), 'required semantic outputs are diagnosed', $failures, $passes );
 datamachine_bundle_runner_assert( array( 'concept_packet' ) === ( $projected_outputs['diagnostics']['required_artifacts'] ?? null ), 'required typed artifacts are diagnosed', $failures, $passes );
@@ -601,7 +604,13 @@ $missing_artifact_response = $response_method->invoke(
 		'job_status'  => 'completed',
 		'engine_data' => array(
 			'outputs' => array(
-				'concept_packet' => array(),
+				'typed_artifacts' => array(
+					'concept_packet' => array(
+						'schema'   => 'example-agent/ConceptPacket/v1',
+						'artifact' => 'ConceptPacket',
+						'payload'  => array(),
+					),
+				),
 			),
 		),
 	),
@@ -621,7 +630,13 @@ $present_artifact_response = $response_method->invoke(
 		'job_status'  => 'completed',
 		'engine_data' => array(
 			'outputs' => array(
-				'concept_packet' => array( 'title' => 'Concept Packet' ),
+				'typed_artifacts' => array(
+					'concept_packet' => array(
+						'schema'   => 'example-agent/ConceptPacket/v1',
+						'artifact' => 'ConceptPacket',
+						'payload'  => array( 'title' => 'Concept Packet' ),
+					),
+				),
 			),
 		),
 	),

--- a/tests/typed-artifact-output-contract-smoke.php
+++ b/tests/typed-artifact-output-contract-smoke.php
@@ -33,12 +33,13 @@ echo "typed-artifact-output-contract-smoke\n";
 
 $normalized = \DataMachine\Engine\AI\datamachine_normalize_typed_artifact_outputs(
 	array(
-		'typed_artifacts' => array(
-			array(
-				'output_key' => 'concept_packet',
-				'schema'     => 'example-agent/ConceptPacket/v1',
-				'artifact'   => 'ConceptPacket',
-				'payload'    => array( 'title' => 'Normalized concept' ),
+		'outputs' => array(
+			'typed_artifacts' => array(
+				'concept_packet' => array(
+					'schema'   => 'example-agent/ConceptPacket/v1',
+					'artifact' => 'ConceptPacket',
+					'payload'  => array( 'title' => 'Normalized concept' ),
+				),
 			),
 		),
 	)
@@ -47,6 +48,25 @@ $normalized = \DataMachine\Engine\AI\datamachine_normalize_typed_artifact_output
 datamachine_typed_artifact_contract_assert(
 	array( 'title' => 'Normalized concept' ) === ( $normalized['concept_packet']['payload'] ?? null ),
 	'loop result typed_artifacts normalize to outputs.typed_artifacts.<key>.payload shape',
+	$failures,
+	$passes
+);
+
+$legacy_normalized = \DataMachine\Engine\AI\datamachine_normalize_typed_artifact_outputs(
+	array(
+		'typed_artifacts' => array(
+			'concept_packet' => array(
+				'schema'   => 'example-agent/ConceptPacket/v1',
+				'artifact' => 'ConceptPacket',
+				'payload'  => array( 'title' => 'Legacy concept' ),
+			),
+		),
+	)
+);
+
+datamachine_typed_artifact_contract_assert(
+	array() === $legacy_normalized,
+	'legacy top-level typed_artifacts alias is ignored',
 	$failures,
 	$passes
 );
@@ -143,7 +163,7 @@ $tool_result_assertions->recordToolResult(
 $tool_result_satisfied = $tool_result_assertions->evaluate( array(), '' );
 datamachine_typed_artifact_contract_assert( true === $tool_result_satisfied['complete'], 'required_artifact_outputs can be satisfied by a handler tool result', $failures, $passes );
 
-$wrapped_tool_result_assertions = new \DataMachine\Engine\AI\DataMachineCompletionAssertions(
+$legacy_tool_result_assertions = new \DataMachine\Engine\AI\DataMachineCompletionAssertions(
 	array(
 		'required_artifact_outputs' => array(
 			array(
@@ -154,7 +174,7 @@ $wrapped_tool_result_assertions = new \DataMachine\Engine\AI\DataMachineCompleti
 		),
 	)
 );
-$wrapped_tool_result_assertions->recordToolResult(
+$legacy_tool_result_assertions->recordToolResult(
 	'emit_typed_artifact',
 	array( 'handler' => 'typed_artifact' ),
 	array(
@@ -172,8 +192,8 @@ $wrapped_tool_result_assertions->recordToolResult(
 		),
 	)
 );
-$wrapped_tool_result_satisfied = $wrapped_tool_result_assertions->evaluate( array(), '' );
-datamachine_typed_artifact_contract_assert( true === $wrapped_tool_result_satisfied['complete'], 'required_artifact_outputs can be satisfied by wrapped handler tool result data', $failures, $passes );
+$legacy_tool_result_satisfied = $legacy_tool_result_assertions->evaluate( array(), '' );
+datamachine_typed_artifact_contract_assert( false === $legacy_tool_result_satisfied['complete'], 'legacy wrapped handler tool result data does not satisfy required_artifact_outputs', $failures, $passes );
 
 $missing = $assertions->evaluate(
 	array(


### PR DESCRIPTION
## Summary
- make runtime-package/bundle execution expose typed artifacts only through `outputs.typed_artifacts.<key>` envelopes
- remove legacy/fallback typed-artifact aliases from completion assertion satisfaction
- require `required_artifact_outputs` to validate canonical typed artifact payloads
- add smoke coverage for `concept_packet` required typed artifact behavior

## Verification
- `php tests/typed-artifact-output-contract-smoke.php`
- `php tests/agent-bundle-runner-contract-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** tracing runtime-package typed artifact projection, drafting code/tests, running verification, and preparing this PR description.
