### PR TITLE
refactor: extract conversation-result normalizer with named status constants (#2803 slice 2)

### DIFF
--- a/inc/Engine/AI/ConversationResultNormalization.php
+++ b/inc/Engine/AI/ConversationResultNormalization.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Value object holding the output of ConversationResultNormalizer.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Immutable carrier for normalized conversation-result diagnostics.
+ *
+ * Holds the derived metadata.datamachine payload and the conversation status.
+ * The status is exposed alongside a flag indicating whether the normalizer
+ * overrode it (the runtime-tool-pending path is the only one that does). The
+ * caller writes the status back onto the result ONLY when it was overridden, so
+ * status-less results are not given a spurious empty `status` key — preserving
+ * byte-for-byte parity with the prior inline logic.
+ */
+final class ConversationResultNormalization {
+
+	/** @var array<string,mixed> Derived metadata.datamachine diagnostics. */
+	public array $metadata;
+
+	/** @var string The conversation status the normalizer reasoned about. */
+	public string $status;
+
+	/** @var bool Whether the normalizer overrode the result status. */
+	public bool $status_overridden;
+
+	/**
+	 * @param array<string,mixed> $metadata          Derived diagnostics.
+	 * @param string              $status            Final status (possibly overridden).
+	 * @param bool                $status_overridden Whether the status was overridden.
+	 */
+	public function __construct( array $metadata, string $status, bool $status_overridden = false ) {
+		$this->metadata          = $metadata;
+		$this->status            = $status;
+		$this->status_overridden = $status_overridden;
+	}
+}

--- a/inc/Engine/AI/ConversationResultNormalizer.php
+++ b/inc/Engine/AI/ConversationResultNormalizer.php
@@ -87,8 +87,9 @@ final class ConversationResultNormalizer {
 			$datamachine_metadata['completed']                     = false;
 			$datamachine_metadata['runtime_tool_pending']          = true;
 			$datamachine_metadata['runtime_tool_pending_requests'] = $runtime_tool_requests;
-			$status                                                = DataMachineConversationStatus::RUNTIME_TOOL_PENDING;
-			$status_overridden                                     = true;
+
+			$status            = DataMachineConversationStatus::RUNTIME_TOOL_PENDING;
+			$status_overridden = true;
 		}
 		if ( ! empty( $completion_nudges ) ) {
 			$latest_nudge                                   = $completion_nudges[ count( $completion_nudges ) - 1 ];

--- a/inc/Engine/AI/ConversationResultNormalizer.php
+++ b/inc/Engine/AI/ConversationResultNormalizer.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Normalizes a finished conversation-loop result into Data Machine diagnostics.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Derives the metadata.datamachine diagnostics from a finished loop result.
+ *
+ * The Agents API substrate returns a normalized conversation result carrying a
+ * `status` string. Data Machine layers its own diagnostics on top — completed,
+ * max_turns_reached, runtime_tool_pending, interrupted, completion-assertion
+ * evaluation, and a human-readable warning. Historically that derivation was a
+ * sequence of ~8 scattered if-blocks inside datamachine_run_conversation() that
+ * re-read $result['status'] against bare string literals and computed the
+ * `completed` flag in four different places.
+ *
+ * This class collapses that "result surgery" into a single decision path keyed
+ * off DataMachineConversationStatus constants. It is a pure transform: given the
+ * loop result plus the surrounding turn context, it returns the normalized
+ * metadata and the (possibly overridden) status string. It does not mutate the
+ * result in place and does not emit events — the caller owns those concerns.
+ *
+ * Behavior parity: the derived metadata and status are byte-for-byte identical
+ * to the prior inline logic for every status path. This is a structure refactor,
+ * not a behavior change.
+ */
+final class ConversationResultNormalizer {
+
+	/**
+	 * Normalize a finished loop result into Data Machine diagnostics.
+	 *
+	 * @param array                        $result                   Substrate-normalized conversation result.
+	 * @param array                        $last_tool_calls          Tool calls from the latest turn.
+	 * @param array                        $all_tool_calls           Tool calls accumulated across all turns.
+	 * @param array                        $tool_execution_results   Enriched mediated tool-execution results.
+	 * @param array                        $completion_nudges        Completion nudges recorded during the loop.
+	 * @param bool                         $completion_policy_stopped Whether a completion_policy_stop event fired.
+	 * @param int                          $turn_ceiling             Max-turn ceiling from the turn budget.
+	 * @param DataMachineCompletionAssertions $assertions            Completion assertions for this run.
+	 * @param array                        $loop_payload             Cleaned loop payload (assertion evaluation context).
+	 * @return ConversationResultNormalization Normalized metadata and final status.
+	 */
+	public static function normalize(
+		array $result,
+		array $last_tool_calls,
+		array $all_tool_calls,
+		array $tool_execution_results,
+		array $completion_nudges,
+		bool $completion_policy_stopped,
+		int $turn_ceiling,
+		DataMachineCompletionAssertions $assertions,
+		array $loop_payload
+	): ConversationResultNormalization {
+		$status            = (string) ( $result['status'] ?? '' );
+		$status_overridden = false;
+
+		$datamachine_metadata = array(
+			'completed'       => ! isset( $result['error'] ) && ! in_array( $status, DataMachineConversationStatus::incompleteStatuses(), true ),
+			'last_tool_calls' => $last_tool_calls,
+			'tool_calls'      => $all_tool_calls,
+		);
+		if ( ! empty( $tool_execution_results ) ) {
+			$datamachine_metadata['tool_execution_summary'] = datamachine_summarize_tool_execution_results( $tool_execution_results, false );
+		}
+		if ( DataMachineConversationStatus::INTERRUPTED === $status && isset( $result['interrupted'] ) ) {
+			$datamachine_metadata['interrupted'] = $result['interrupted'];
+		}
+		$silent_max_turns_reached = ! empty( $last_tool_calls )
+			&& (int) ( $result['turn_count'] ?? 0 ) >= $turn_ceiling
+			&& DataMachineConversationStatus::BUDGET_EXCEEDED !== $status;
+		if ( $silent_max_turns_reached ) {
+			$datamachine_metadata['completed']         = false;
+			$datamachine_metadata['max_turns_reached'] = true;
+			$datamachine_metadata['warning']           = sprintf(
+				'Maximum conversation turns (%d) reached. Response may be incomplete.',
+				$turn_ceiling
+			);
+		}
+		if ( DataMachineConversationStatus::RUNTIME_TOOL_PENDING === $status || ! empty( $result['runtime_tool_pending'] ) ) {
+			$runtime_tool_requests                                 = is_array( $result['runtime_tool_pending'] ?? null ) ? array( $result['runtime_tool_pending'] ) : array();
+			$datamachine_metadata['completed']                     = false;
+			$datamachine_metadata['runtime_tool_pending']          = true;
+			$datamachine_metadata['runtime_tool_pending_requests'] = $runtime_tool_requests;
+			$status                                                = DataMachineConversationStatus::RUNTIME_TOOL_PENDING;
+			$status_overridden                                     = true;
+		}
+		if ( ! empty( $completion_nudges ) ) {
+			$latest_nudge                                   = $completion_nudges[ count( $completion_nudges ) - 1 ];
+			$datamachine_metadata['completion_nudge_count'] = count( $completion_nudges );
+			$datamachine_metadata['completion_nudge']       = $latest_nudge['completion_nudge'] ?? '';
+			$datamachine_metadata['completion_assertions_required']  = $latest_nudge['completion_assertions_required'] ?? array();
+			$datamachine_metadata['completion_assertions_missing']   = $latest_nudge['completion_assertions_missing'] ?? array();
+			$datamachine_metadata['completion_assertions_satisfied'] = $latest_nudge['completion_assertions_satisfied'] ?? array();
+			if ( ! $completion_policy_stopped && (int) ( $result['turn_count'] ?? 0 ) >= $turn_ceiling ) {
+				$datamachine_metadata['completed']         = false;
+				$datamachine_metadata['max_turns_reached'] = true;
+				$datamachine_metadata['warning']           = sprintf(
+					'Maximum conversation turns (%d) reached before completion policy was satisfied.',
+					$turn_ceiling
+				);
+			}
+		}
+		if ( $assertions->hasAssertions() ) {
+			$evaluation_context = $loop_payload;
+			$typed_artifacts    = datamachine_normalize_typed_artifact_outputs( $result );
+			if ( ! empty( $typed_artifacts ) ) {
+				$evaluation_engine_data                               = is_array( $evaluation_context['engine_data'] ?? null ) ? $evaluation_context['engine_data'] : array();
+				$evaluation_engine_data['outputs']                    = is_array( $evaluation_engine_data['outputs'] ?? null ) ? $evaluation_engine_data['outputs'] : array();
+				$evaluation_engine_data['outputs']['typed_artifacts'] = array_replace_recursive(
+					is_array( $evaluation_engine_data['outputs']['typed_artifacts'] ?? null ) ? $evaluation_engine_data['outputs']['typed_artifacts'] : array(),
+					$typed_artifacts
+				);
+				$evaluation_context['engine_data']                    = $evaluation_engine_data;
+			}
+
+			$evaluation = $assertions->evaluate( $evaluation_context, $result['final_content'] ?? '' );
+			$datamachine_metadata['completion_assertions_required']  = $assertions->required();
+			$datamachine_metadata['completion_assertions_missing']   = $evaluation['missing'];
+			$datamachine_metadata['completion_assertions_satisfied'] = $evaluation['satisfied'];
+			$datamachine_metadata['completion_assertions_complete']  = ! empty( $evaluation['complete'] );
+			if ( ! empty( $evaluation['complete'] ) && DataMachineConversationStatus::BUDGET_EXCEEDED !== $status ) {
+				$datamachine_metadata['completed'] = true;
+			}
+		}
+		// Map upstream budget_exceeded status to DM's max-turn diagnostics for chat
+		// response shaping without adding legacy aliases to the canonical result.
+		if ( DataMachineConversationStatus::BUDGET_EXCEEDED === $status && in_array( $result['budget'] ?? '', array( 'conversation_turns', 'turns' ), true ) ) {
+			$datamachine_metadata['max_turns_reached'] = true;
+			$datamachine_metadata['completed']         = false;
+			$datamachine_metadata['warning']           = sprintf(
+				'Maximum conversation turns (%d) reached. Response may be incomplete.',
+				$turn_ceiling
+			);
+		}
+
+		return new ConversationResultNormalization( $datamachine_metadata, $status, $status_overridden );
+	}
+}

--- a/inc/Engine/AI/DataMachineConversationStatus.php
+++ b/inc/Engine/AI/DataMachineConversationStatus.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Conversation-result status vocabulary for the Data Machine conversation loop.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Named constants for the conversation-result status strings.
+ *
+ * The Agents API substrate surfaces a `status` string on the normalized
+ * conversation result, and emits `completion_policy_*` loop events. Data Machine
+ * reads those raw strings in several places to derive its own diagnostics
+ * (completed / max_turns_reached / runtime_tool_pending / interrupted /
+ * warning). Historically those reads compared against bare string literals
+ * scattered across datamachine_run_conversation(), with no single source of
+ * truth.
+ *
+ * These constants name the same wire strings without changing them: every
+ * value here is byte-for-byte identical to the literal it replaces, so the
+ * status format on the wire (consumed by chat response shaping, job artifacts,
+ * and pipeline steps) is unchanged. This class is the single source of truth
+ * for the status/finish vocabulary the loop reasons about.
+ */
+final class DataMachineConversationStatus {
+
+	/**
+	 * Turn budget (max turns) was exceeded — the substrate stopped the loop.
+	 */
+	public const BUDGET_EXCEEDED = 'budget_exceeded';
+
+	/**
+	 * A runtime tool call is awaiting asynchronous fulfillment; the loop paused.
+	 */
+	public const RUNTIME_TOOL_PENDING = 'runtime_tool_pending';
+
+	/**
+	 * The conversation completed normally.
+	 */
+	public const COMPLETED = 'completed';
+
+	/**
+	 * The conversation failed (provider/transport error or fatal condition).
+	 */
+	public const FAILED = 'failed';
+
+	/**
+	 * The conversation was interrupted by an external interrupt source.
+	 */
+	public const INTERRUPTED = 'interrupted';
+
+	/**
+	 * DM diagnostic: the max-turn ceiling was reached before completion.
+	 *
+	 * Not an upstream substrate status — derived by the normalizer and surfaced
+	 * under metadata.datamachine — but kept here so the full status/finish
+	 * vocabulary lives in one place.
+	 */
+	public const MAX_TURNS_REACHED = 'max_turns_reached';
+
+	/**
+	 * Loop-event type: the completion policy decided to stop the conversation.
+	 */
+	public const COMPLETION_POLICY_STOP = 'completion_policy_stop';
+
+	/**
+	 * Loop-event type: the completion policy decided to continue the conversation.
+	 */
+	public const COMPLETION_POLICY_CONTINUE = 'completion_policy_continue';
+
+	/**
+	 * Finish reason / error code for a provider-side request failure.
+	 */
+	public const PROVIDER_ERROR = 'provider_error';
+
+	/**
+	 * Statuses that mean the conversation did NOT complete successfully.
+	 *
+	 * Mirrors the historical inline check
+	 * `! in_array( $status, array( 'budget_exceeded', 'interrupted', 'failed' ), true )`
+	 * used to seed the `completed` diagnostic.
+	 *
+	 * @return string[]
+	 */
+	public static function incompleteStatuses(): array {
+		return array(
+			self::BUDGET_EXCEEDED,
+			self::INTERRUPTED,
+			self::FAILED,
+		);
+	}
+}

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -93,8 +93,6 @@ function datamachine_run_conversation(
 	$tool_execution_results = array();
 	$completion_nudges      = array();
 	$turn_state             = new DataMachineProviderTurnState( $messages );
-	$runtime_tool_pending   = false;
-	$runtime_tool_requests  = array();
 
 	// Base log context for consistent logging.
 	$base_log_context = array_filter(
@@ -301,11 +299,11 @@ function datamachine_run_conversation(
 		$result                    = WP_Agent_Conversation_Result::normalize( $result );
 		$completion_policy_stopped = false;
 		foreach ( is_array( $result['events'] ?? null ) ? $result['events'] : array() as $event ) {
-			if ( ! is_array( $event ) || ! in_array( (string) ( $event['type'] ?? '' ), array( 'completion_policy_stop', 'completion_policy_continue' ), true ) ) {
+			if ( ! is_array( $event ) || ! in_array( (string) ( $event['type'] ?? '' ), array( DataMachineConversationStatus::COMPLETION_POLICY_STOP, DataMachineConversationStatus::COMPLETION_POLICY_CONTINUE ), true ) ) {
 				continue;
 			}
 
-			if ( 'completion_policy_stop' === (string) ( $event['type'] ?? '' ) ) {
+			if ( DataMachineConversationStatus::COMPLETION_POLICY_STOP === (string) ( $event['type'] ?? '' ) ) {
 				$completion_policy_stopped = true;
 			}
 
@@ -316,8 +314,8 @@ function datamachine_run_conversation(
 		}
 		if ( isset( $result['failure'] ) && is_array( $result['failure'] ) && ! isset( $result['error'] ) ) {
 			$result['error']         = (string) ( $result['failure']['message'] ?? 'Provider request failed.' );
-			$result['error_code']    = (string) ( $result['failure']['code'] ?? 'provider_error' );
-			$result['finish_reason'] = 'provider_error';
+			$result['error_code']    = (string) ( $result['failure']['code'] ?? DataMachineConversationStatus::PROVIDER_ERROR );
+			$result['finish_reason'] = DataMachineConversationStatus::PROVIDER_ERROR;
 		}
 		$tool_execution_results = datamachine_enrich_mediated_tool_results(
 			is_array( $result['tool_execution_results'] ?? null ) ? $result['tool_execution_results'] : array(),
@@ -351,90 +349,30 @@ function datamachine_run_conversation(
 	}
 
 	// Substrate now surfaces turn_count, final_content, usage, and
-	// request_metadata directly on the result (agents-api#136). Keep DM-only
-	// diagnostics namespaced so the top level remains the Agents API result.
-	$datamachine_metadata = array(
-		'completed'       => ! isset( $result['error'] ) && ! in_array( (string) ( $result['status'] ?? '' ), array( 'budget_exceeded', 'interrupted', 'failed' ), true ),
-		'last_tool_calls' => $last_tool_calls,
-		'tool_calls'      => $all_tool_calls,
+	// request_metadata directly on the result (agents-api#136). Derive the
+	// DM-only diagnostics (completed / max_turns_reached / runtime_tool_pending
+	// / interrupted / completion-assertion evaluation / warning) through a
+	// single normalizer pass keyed off DataMachineConversationStatus constants,
+	// instead of re-reading $result['status'] across scattered if-blocks. Keep
+	// the diagnostics namespaced so the top level remains the Agents API result.
+	$normalization = ConversationResultNormalizer::normalize(
+		$result,
+		$last_tool_calls,
+		$all_tool_calls,
+		$tool_execution_results,
+		$completion_nudges,
+		$completion_policy_stopped,
+		$turn_budget->ceiling(),
+		$assertions,
+		$loop_payload
 	);
-	if ( ! empty( $tool_execution_results ) ) {
-		$datamachine_metadata['tool_execution_summary'] = datamachine_summarize_tool_execution_results( $tool_execution_results, false );
-	}
-	if ( 'interrupted' === ( $result['status'] ?? '' ) && isset( $result['interrupted'] ) ) {
-		$datamachine_metadata['interrupted'] = $result['interrupted'];
-	}
-	$silent_max_turns_reached = ! empty( $last_tool_calls )
-		&& (int) ( $result['turn_count'] ?? 0 ) >= $turn_budget->ceiling()
-		&& 'budget_exceeded' !== ( $result['status'] ?? '' );
-	if ( $silent_max_turns_reached ) {
-		$datamachine_metadata['completed']         = false;
-		$datamachine_metadata['max_turns_reached'] = true;
-		$datamachine_metadata['warning']           = sprintf(
-			'Maximum conversation turns (%d) reached. Response may be incomplete.',
-			$turn_budget->ceiling()
-		);
-	}
-	if ( 'runtime_tool_pending' === (string) ( $result['status'] ?? '' ) || ! empty( $result['runtime_tool_pending'] ) ) {
-		$runtime_tool_pending                                  = true;
-		$runtime_tool_requests                                 = is_array( $result['runtime_tool_pending'] ?? null ) ? array( $result['runtime_tool_pending'] ) : $runtime_tool_requests;
-		$datamachine_metadata['completed']                     = false;
-		$datamachine_metadata['runtime_tool_pending']          = true;
-		$datamachine_metadata['runtime_tool_pending_requests'] = $runtime_tool_requests;
-		$result['status']                                      = 'runtime_tool_pending';
-	}
-	if ( ! empty( $completion_nudges ) ) {
-		$latest_nudge                                   = $completion_nudges[ count( $completion_nudges ) - 1 ];
-		$datamachine_metadata['completion_nudge_count'] = count( $completion_nudges );
-		$datamachine_metadata['completion_nudge']       = $latest_nudge['completion_nudge'] ?? '';
-		$datamachine_metadata['completion_assertions_required']  = $latest_nudge['completion_assertions_required'] ?? array();
-		$datamachine_metadata['completion_assertions_missing']   = $latest_nudge['completion_assertions_missing'] ?? array();
-		$datamachine_metadata['completion_assertions_satisfied'] = $latest_nudge['completion_assertions_satisfied'] ?? array();
-		if ( ! $completion_policy_stopped && (int) ( $result['turn_count'] ?? 0 ) >= $turn_budget->ceiling() ) {
-			$datamachine_metadata['completed']         = false;
-			$datamachine_metadata['max_turns_reached'] = true;
-			$datamachine_metadata['warning']           = sprintf(
-				'Maximum conversation turns (%d) reached before completion policy was satisfied.',
-				$turn_budget->ceiling()
-			);
-		}
-	}
-	if ( $assertions->hasAssertions() ) {
-		$evaluation_context = $loop_payload;
-		$typed_artifacts    = datamachine_normalize_typed_artifact_outputs( $result );
-		if ( ! empty( $typed_artifacts ) ) {
-			$evaluation_engine_data                               = is_array( $evaluation_context['engine_data'] ?? null ) ? $evaluation_context['engine_data'] : array();
-			$evaluation_engine_data['outputs']                    = is_array( $evaluation_engine_data['outputs'] ?? null ) ? $evaluation_engine_data['outputs'] : array();
-			$evaluation_engine_data['outputs']['typed_artifacts'] = array_replace_recursive(
-				is_array( $evaluation_engine_data['outputs']['typed_artifacts'] ?? null ) ? $evaluation_engine_data['outputs']['typed_artifacts'] : array(),
-				$typed_artifacts
-			);
-			$evaluation_context['engine_data']                    = $evaluation_engine_data;
-		}
-
-		$evaluation = $assertions->evaluate( $evaluation_context, $result['final_content'] ?? '' );
-		$datamachine_metadata['completion_assertions_required']  = $assertions->required();
-		$datamachine_metadata['completion_assertions_missing']   = $evaluation['missing'];
-		$datamachine_metadata['completion_assertions_satisfied'] = $evaluation['satisfied'];
-		$datamachine_metadata['completion_assertions_complete']  = ! empty( $evaluation['complete'] );
-		if ( ! empty( $evaluation['complete'] ) && 'budget_exceeded' !== ( $result['status'] ?? '' ) ) {
-			$datamachine_metadata['completed'] = true;
-		}
-	}
-	// Map upstream budget_exceeded status to DM's max-turn diagnostics for chat
-	// response shaping without adding legacy aliases to the canonical result.
-	if ( 'budget_exceeded' === ( $result['status'] ?? '' ) && in_array( $result['budget'] ?? '', array( 'conversation_turns', 'turns' ), true ) ) {
-		$datamachine_metadata['max_turns_reached'] = true;
-		$datamachine_metadata['completed']         = false;
-		$datamachine_metadata['warning']           = sprintf(
-			'Maximum conversation turns (%d) reached. Response may be incomplete.',
-			$turn_budget->ceiling()
-		);
+	if ( $normalization->status_overridden ) {
+		$result['status'] = $normalization->status;
 	}
 
-	$result                       = datamachine_with_conversation_metadata( $result, $datamachine_metadata );
+	$result                       = datamachine_with_conversation_metadata( $result, $normalization->metadata );
 	$result['runtime_provenance'] = RuntimeProvenance::fromConversationResult( $result, $loop_payload, $provider, $model, $modes );
-	if ( 'failed' === (string) ( $result['status'] ?? '' ) || isset( $result['error'] ) ) {
+	if ( DataMachineConversationStatus::FAILED === (string) ( $result['status'] ?? '' ) || isset( $result['error'] ) ) {
 		$transcript_session_id = $transcript_persister->persist( is_array( $result['messages'] ?? null ) ? $result['messages'] : $turn_state->latest_messages, $conversation_request, $result );
 		if ( '' !== $transcript_session_id ) {
 			$result['transcript_session_id'] = $transcript_session_id;
@@ -759,8 +697,8 @@ function datamachine_build_pre_tool_mediator( array $tools, array $loop_payload,
 				$tool_result['result'] = $runtime_result_payload;
 			}
 			if ( ! empty( $tool_result['pending'] ) ) {
-				$tool_result['status']             = 'runtime_tool_pending';
-				$tool_result['metadata']['status'] = 'runtime_tool_pending';
+				$tool_result['status']             = DataMachineConversationStatus::RUNTIME_TOOL_PENDING;
+				$tool_result['metadata']['status'] = DataMachineConversationStatus::RUNTIME_TOOL_PENDING;
 			}
 
 			return array(


### PR DESCRIPTION
## Summary

Second scoped slice of #2803. Decomposes the post-loop **conversation-result "status surgery"** out of `datamachine_run_conversation()` (in `inc/Engine/AI/conversation-loop.php`) into a cohesive normalizer with named status constants and a single decision path. The first slice (provider-turn adapter / `DataMachineProviderTurnState`) merged as #2808.

This is a **readability/structure refactor, NOT a behavior change** — the status strings on the wire are unchanged and the normalized result is byte-for-byte identical for every status path.

## Status constants introduced

New `final class DataMachineConversationStatus` (`inc/Engine/AI/DataMachineConversationStatus.php`) — the single source of truth for the conversation status/finish vocabulary. Each constant holds the **same string value** as the literal it replaces (so the wire format is unchanged):

| Constant | Value |
|---|---|
| `BUDGET_EXCEEDED` | `budget_exceeded` |
| `RUNTIME_TOOL_PENDING` | `runtime_tool_pending` |
| `COMPLETED` | `completed` |
| `FAILED` | `failed` |
| `INTERRUPTED` | `interrupted` |
| `MAX_TURNS_REACHED` | `max_turns_reached` |
| `COMPLETION_POLICY_STOP` | `completion_policy_stop` |
| `COMPLETION_POLICY_CONTINUE` | `completion_policy_continue` |
| `PROVIDER_ERROR` | `provider_error` |

Plus `incompleteStatuses()` mirroring the inline `array( 'budget_exceeded', 'interrupted', 'failed' )` used to seed the `completed` flag.

All bare conversation-status **value** literals in `conversation-loop.php` now route through these constants. (Metadata array **keys** like `'completed' => false`, and the distinct job/persistence/tool-result vocabularies — `complete_job('completed'/'failed')`, `persistence_status`, `'success'/'failed'` — are intentionally left alone; they belong to other layers and converting them would conflate domains.)

## Normalizer extracted

- `ConversationResultNormalizer::normalize()` (`inc/Engine/AI/ConversationResultNormalizer.php`) — a pure transform that takes the substrate-normalized loop result + surrounding turn context and **returns** the derived `metadata.datamachine` diagnostics (`completed` / `max_turns_reached` / `runtime_tool_pending` / `interrupted` / completion-nudge + completion-assertion evaluation / `warning`). It collapses the ~8 scattered `if`-blocks — which each re-read `$result['status']` and recomputed `completed` in **four** different places — into one decision path keyed off the constants.
- `ConversationResultNormalization` (`inc/Engine/AI/ConversationResultNormalization.php`) — small immutable value object carrying `metadata`, `status`, and a `status_overridden` flag. The caller writes the status back onto the result **only when overridden** (the `runtime_tool_pending` path is the only one that overrides), so status-less results don't gain a spurious empty `status` key — preserving byte-for-byte parity.

`datamachine_run_conversation()` now: run the loop → hand the result to the normalizer → apply the (only-when-overridden) status → attach metadata → return.

## Line count

`datamachine_run_conversation()`: **~392 → 330 lines** (the result-surgery block shrank from ~88 lines of scattered if-blocks to a single ~20-line normalizer call). Two now-dead outer accumulator vars (`$runtime_tool_pending`, `$runtime_tool_requests`) removed.

## Wire-string parity

Confirmed unchanged: every constant value equals the prior literal byte-for-byte. The only status mutation (`$result['status'] = 'runtime_tool_pending'`) is reproduced exactly via the `status_overridden` flag.

## Per-status parity confirmation

Verified each path produces identical diagnostics (standalone harness + smoke tests):

- **completed** → `completed=true`, status unchanged
- **budget_exceeded (max turns)** → `completed=false, max_turns_reached=true`, warning, status unchanged
- **interrupted** → `completed=false, interrupted=<payload>`, status unchanged
- **failed / provider_error** → `completed=false`, status unchanged (transcript persist still triggers via the `FAILED` check)
- **runtime_tool_pending** → `completed=false, runtime_tool_pending=true, runtime_tool_pending_requests=[...]`, status **overridden** to `runtime_tool_pending`
- **completion_policy_stop** → suppresses the policy-not-satisfied max-turn warning exactly as before
- **silent max-turns-reached** (tool calls present, turn_count ≥ ceiling, status ≠ budget_exceeded) → `completed=false, max_turns_reached=true`, warning, status unchanged

## Test results

- `php -l` clean on all four touched files.
- `homeboy lint data-machine` / `phpcs`: **clean (exit 0)** on all four files, including the equals-alignment sniff (`Generic.Formatting.MultipleStatementAlignment`). phpstan: 0 findings. (The repo's eslint findings are pre-existing JS — no JS touched in this slice.)
- Relevant smoke tests pass: `agent-conversation-result`, `agents-chat-tool-continuation`, `ai-loop-event-sink`, `ai-completion-assertion-packet`, `runtime-tool-delegated-result`, `runtime-tool-async-broker`, `provider-turn-tool-extraction-contract`, `typed-artifact-output-contract`, `ai-enabled-tools`, `tool-result-consumer-contract`.
- Note: `ai-error-status-propagation-smoke` and `runtime-tool-contract-store-smoke` fail identically on clean `main` when run via standalone `php` (missing WP stubs: `wp_json_encode`, `EngineData`) — pre-existing/environmental, unrelated to this slice and outside the result normalizer.

## Remaining #2803 scope (do NOT close)

This slice covers **only** the result-status normalization. Still open under #2803:
- The 15-param / 6-by-ref `datamachine_build_provider_turn_adapter()` closure — the by-ref accumulator / turn-state smuggling (partially started by `DataMachineProviderTurnState` in #2808).
- The broader god-file split: the L1200–1900 runtime-tool fulfillment subsystem (`RuntimeToolFulfillment`) and the overall 64-free-function file decomposition.

Refs #2803.