### PR TITLE
fix: scrub Extra Chill bucket-A layer-purity violation from core

### DIFF
--- a/inc/Cli/Commands/ExternalCommand.php
+++ b/inc/Cli/Commands/ExternalCommand.php
@@ -205,7 +205,7 @@ class ExternalCommand extends BaseCommand {
 		$key = $args[0] ?? '';
 
 		if ( empty( $key ) ) {
-			WP_CLI::error( 'Connection key is required (e.g., "extrachill.com/sarai").' );
+			WP_CLI::error( 'Connection key is required (e.g., "example.com/agent-slug").' );
 			return;
 		}
 


### PR DESCRIPTION
## Summary

Scrubs the single **bucket-A** layer-purity violation enumerated in Extra-Chill/data-machine#2816. Per the platform rule, no plugin in the Data Machine suite may know Extra Chill exists — it is generic, distributable substrate.

The issue triage confirmed core is "overwhelmingly clean": exactly one executable EC literal existed.

## Violation fixed

**`inc/Cli/Commands/ExternalCommand.php:208`** — runtime CLI error string for `external remove` baked `extrachill.com/sarai` into the operator-facing error message every install prints.

```diff
- WP_CLI::error( 'Connection key is required (e.g., "extrachill.com/sarai").' );
+ WP_CLI::error( 'Connection key is required (e.g., "example.com/agent-slug").' );
```

Replaced with a neutral `example.com/agent-slug` placeholder matching the format-illustration style used elsewhere. No filter seam needed — this is prose-in-code with no behavior coupling (the data-machine-business#54/#55 `apply_filters` precedent applies to behavior-affecting defaults, which this is not).

## Out of scope (per issue)

- **`AgentAuthorize.php:438`** (`*.extrachill.com` same-network check) — verified NON-violation; domain resolves at runtime from `network_home_url()`, EC appears only in a comment. Not touched.
- **Bucket B** (docblocks, `## EXAMPLES`, `@param` blocks, author/contributor tags) — tracked lower-priority prose noise, left as-is.
- **Bucket C** (`@extrachill/chat` npm dep references) — legitimate external dependency, excluded.
- Did **not** touch `inc/Engine/AI/` (reserved by another branch).

## Verification

- `php -l inc/Cli/Commands/ExternalCommand.php` — no syntax errors.
- `vendor/bin/phpcs inc/Cli/Commands/ExternalCommand.php` — exit 0, clean (no equals-alignment or other findings on the touched file).
- Acceptance grep: no executable EC literals remain; all surviving `extrachill.com/sarai` matches are docblocks/`@param`/`## EXAMPLES` (bucket B).
- Behavior unchanged — single error-string literal swap.

Closes Extra-Chill/data-machine#2816 (bucket-B prose remains as tracked lower-priority cleanup).