### PR TITLE
refactor: fold tool-call and nudge accumulators into turn state (#2803 slice 3)

### DIFF
--- a/inc/Engine/AI/DataMachineProviderTurnState.php
+++ b/inc/Engine/AI/DataMachineProviderTurnState.php
@@ -18,10 +18,13 @@ defined( 'ABSPATH' ) || exit;
  * RuntimeException BEFORE the substrate can return its accumulated result — see
  * the catch block in datamachine_run_conversation(), which reconstructs a
  * best-effort error result from the last completed turn. Consolidating the
- * three previously-separate by-ref params (latest_messages, latest_turn_count,
- * last_request_metadata) into one accumulator shrinks the provider-turn
- * adapter's parameter surface toward the #2803 decomposition target without
- * changing behavior.
+ * previously-separate by-ref params (latest_messages, latest_turn_count,
+ * last_request_metadata, last_tool_calls, all_tool_calls, completion_nudges)
+ * into one accumulator shrinks the provider-turn adapter's parameter surface
+ * toward the #2803 decomposition target without changing behavior. The
+ * tool-call and nudge accumulators are read after the loop by the result
+ * normalizer and the failure-path error result; routing them through this
+ * object makes that data flow local and traceable instead of reference-smuggled.
  */
 final class DataMachineProviderTurnState {
 
@@ -33,6 +36,15 @@ final class DataMachineProviderTurnState {
 
 	/** @var array Request metadata captured on the latest dispatched turn. */
 	public array $last_request_metadata = array();
+
+	/** @var array Tool calls from the latest dispatched turn (DM-flavored shape). */
+	public array $last_tool_calls = array();
+
+	/** @var array All tool calls accumulated across the run. */
+	public array $all_tool_calls = array();
+
+	/** @var array Completion nudge diagnostics accumulated across the run (DM-only). */
+	public array $completion_nudges = array();
 
 	/**
 	 * @param array $initial_messages Initial conversation messages.

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -86,12 +86,11 @@ function datamachine_run_conversation(
 
 	// DM-flavored mutable state accumulated by the turn runner. The substrate
 	// surfaces turn_count, final_content, usage, and request_metadata on the
-	// final result directly (see agents-api#136), so we only carry by-reference
-	// the things substrate doesn't track for us.
-	$last_tool_calls        = array();
-	$all_tool_calls         = array();
+	// final result directly (see agents-api#136), so we only carry the things
+	// substrate doesn't track for us. The per-turn mutable accumulators
+	// (last_tool_calls, all_tool_calls, completion_nudges) now live on
+	// $turn_state so they flow through one object instead of by-reference params.
 	$tool_execution_results = array();
-	$completion_nudges      = array();
 	$turn_state             = new DataMachineProviderTurnState( $messages );
 
 	// Base log context for consistent logging.
@@ -186,11 +185,8 @@ function datamachine_run_conversation(
 		$loop_payload,
 		$event_sink,
 		$base_log_context,
-		$last_tool_calls,
-		$all_tool_calls,
 		$turn_state,
-		$completion_policy,
-		$completion_nudges
+		$completion_policy
 	);
 
 	$tool_executor     = datamachine_build_loop_tool_executor( $tools, $loop_payload, $mode, $modes, $event_sink, $base_log_context );
@@ -282,8 +278,8 @@ function datamachine_run_conversation(
 			$error_result,
 			array(
 				'completed'       => false,
-				'last_tool_calls' => $last_tool_calls,
-				'tool_calls'      => $all_tool_calls,
+				'last_tool_calls' => $turn_state->last_tool_calls,
+				'tool_calls'      => $turn_state->all_tool_calls,
 			)
 		);
 		$transcript_session_id = $transcript_persister->persist( $turn_state->latest_messages, $conversation_request, $error_result );
@@ -357,10 +353,10 @@ function datamachine_run_conversation(
 	// the diagnostics namespaced so the top level remains the Agents API result.
 	$normalization = ConversationResultNormalizer::normalize(
 		$result,
-		$last_tool_calls,
-		$all_tool_calls,
+		$turn_state->last_tool_calls,
+		$turn_state->all_tool_calls,
 		$tool_execution_results,
-		$completion_nudges,
+		$turn_state->completion_nudges,
 		$completion_policy_stopped,
 		$turn_budget->ceiling(),
 		$assertions,
@@ -957,11 +953,10 @@ function datamachine_dispatch_provider_turn(
  * @param array                                     $loop_payload       Cleaned payload.
  * @param LoopEventSinkInterface                    $event_sink         DM event sink.
  * @param array                                     $base_log_context   Base log context.
- * @param array                                     &$last_tool_calls    Mutable last turn's tool calls (DM-flavored shape).
- * @param array                                     &$all_tool_calls     Mutable all tool calls made during the run.
- * @param DataMachineProviderTurnState              $turn_state         Mutable per-turn state for the pre-substrate error path.
+ * @param DataMachineProviderTurnState              $turn_state         Mutable per-turn state: carries the pre-substrate
+ *                                                                      error-path snapshot plus the tool-call and nudge
+ *                                                                      accumulators read after the loop.
  * @param WP_Agent_Conversation_Completion_Policy   $completion_policy  Completion policy for natural completions.
- * @param array                                     &$completion_nudges  Mutable nudge diagnostics (DM-only).
  * @return callable Provider-turn adapter callable.
  */
 function datamachine_build_provider_turn_adapter(
@@ -973,11 +968,8 @@ function datamachine_build_provider_turn_adapter(
 	array $loop_payload,
 	LoopEventSinkInterface $event_sink,
 	array $base_log_context,
-	array &$last_tool_calls,
-	array &$all_tool_calls,
 	DataMachineProviderTurnState $turn_state,
-	WP_Agent_Conversation_Completion_Policy $completion_policy,
-	array &$completion_nudges
+	WP_Agent_Conversation_Completion_Policy $completion_policy
 ): callable {
 	return static function ( $provider_turn_request, array $turn_context = array() ) use (
 		$tools,
@@ -989,10 +981,7 @@ function datamachine_build_provider_turn_adapter(
 		$event_sink,
 		$base_log_context,
 		$completion_policy,
-		$turn_state,
-		&$last_tool_calls,
-		&$all_tool_calls,
-		&$completion_nudges
+		$turn_state
 	): array {
 		$messages = is_array( $provider_turn_request ) ? $provider_turn_request : array();
 		if ( is_object( $provider_turn_request ) ) {
@@ -1084,9 +1073,9 @@ function datamachine_build_provider_turn_adapter(
 			)
 		);
 
-		$last_tool_calls = $tool_calls;
+		$turn_state->last_tool_calls = $tool_calls;
 		foreach ( $tool_calls as $tool_call ) {
-			$all_tool_calls[] = $tool_call;
+			$turn_state->all_tool_calls[] = $tool_call;
 		}
 
 		$messages_with_response = $messages;
@@ -1174,7 +1163,7 @@ function datamachine_build_provider_turn_adapter(
 				if ( '' !== $completion_nudge ) {
 					$continuation_messages[] = ConversationManager::buildConversationMessage( 'user', $completion_nudge );
 					datamachine_record_completion_nudge(
-						$completion_nudges,
+						$turn_state->completion_nudges,
 						$event_sink,
 						$base_log_context,
 						$mode,


### PR DESCRIPTION
## Summary

Third scoped slice of #2803. Eliminates the remaining by-reference parameter smuggling in `conversation-loop.php` by folding the per-turn mutable accumulators onto the existing `DataMachineProviderTurnState` object. This is a **state-plumbing refactor only** — behavior is byte-for-byte identical across every conversation path.

Slices 1+2 (merged via #2808 and #2815) introduced `DataMachineProviderTurnState` and absorbed `latest_messages`, `latest_turn_count`, and `last_request_metadata`. This slice absorbs the last three.

## Fields added to `DataMachineProviderTurnState`

- `public array $last_tool_calls = array();` — tool calls from the latest dispatched turn (DM-flavored shape)
- `public array $all_tool_calls = array();` — all tool calls accumulated across the run
- `public array $completion_nudges = array();` — completion nudge diagnostics accumulated across the run (DM-only)

Declared as public typed properties with array init, matching the existing field style on the object.

## By-ref params removed

`datamachine_build_provider_turn_adapter()` signature, before → after:

- **Before:** 12 params, **3 by-ref** (`&$last_tool_calls`, `&$all_tool_calls`, `&$completion_nudges`) — on top of the 3 by-ref already removed in slices 1+2, this is the **6 → 0 by-ref** target from the issue.
- **After:** 10 params, **0 by-ref**. All per-turn mutable state now flows through the single `$turn_state` object.

Dropped from both the function signature and the returned closure's `use(...)` list.

## Call sites updated

1. **Factory call** (`datamachine_run_conversation`, ~L180) — removed the 3 by-ref args.
2. **Closure writes** (~L1073) — `$last_tool_calls = $tool_calls` → `$turn_state->last_tool_calls = $tool_calls`; `$all_tool_calls[] = ...` → `$turn_state->all_tool_calls[] = ...`.
3. **Nudge recorder call** (~L1163) — `datamachine_record_completion_nudge( $turn_state->completion_nudges, ... )`. The helper keeps its own by-ref param and now mutates the object property directly (valid PHP — public array property passed by reference).
4. **Failure-path error result** (catch block, ~L278) — reads `$turn_state->last_tool_calls` / `$turn_state->all_tool_calls`.
5. **Result normalizer call** (~L353) — reads `$turn_state->last_tool_calls`, `$turn_state->all_tool_calls`, `$turn_state->completion_nudges`.
6. **Init block** (~L86) — removed the three local `array()` initializers (now object-owned).

## Per-path parity

Every former by-ref read now reads the **same value from `$turn_state` at the same point** in execution:

- **completed / completion_policy_stop** — normalizer reads accumulators after the loop returns; values populated by the closure during the loop, unchanged ordering.
- **budget_exceeded / runtime_tool_pending / interrupted** — same normalizer read path.
- **failed (pre-substrate RuntimeException)** — catch block reads `last_tool_calls`/`all_tool_calls` from `$turn_state`, populated by the closure up to the point of failure, identical to the prior by-ref snapshot.
- **nudge diagnostics** — appended via the recorder mutating `$turn_state->completion_nudges`, read by the normalizer at the same point with the same accumulated sequence.

## Verification

- `php -l` clean on both touched files.
- `vendor/bin/phpcbf` + `vendor/bin/phpcs` — **fully green** on both files, including the `Generic.Formatting.MultipleStatementAlignment` equals-alignment sniff.
- Relevant smoke tests pass individually: `agent-conversation-runner-request`, `agent-conversation-result`, `agent-conversation-runtime-policy`, `ai-message-envelope`, `ai-loop-event-sink`, `provider-turn-tool-extraction-contract`.
- Full smoke suite: **PASS=233 FAIL=62 — identical to baseline** (changes stashed). The 62 failures are pre-existing environmental issues when the suite is run as a batch loop (missing WP test bootstrap/autoload), unrelated to this change and present on `main`. Zero regressions introduced.
- `grep` confirms `&$last_tool_calls`, `&$all_tool_calls`, `&$completion_nudges` are **gone** from the adapter; the only remaining occurrence is the receiving by-ref param inside the `datamachine_record_completion_nudge` helper (which now receives `$turn_state->completion_nudges`).

## Scope

Slice 3 of #2803 — references #2803, does **not** close it. Remaining: the broader 64-function file split into cohesive modules.