### PR TITLE
feat: express packet fan-out as the generic parallel-map step contract

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -577,14 +577,53 @@ class ExecuteStepAbility {
 					);
 				}
 
+				// Adaptive fan-out gate. This packet fan-out is Data Machine's
+				// concurrent backend for the generic Agents API `parallel`-map
+				// step contract, so route the decision through the same
+				// `wp_agent_workflow_should_fanout` filter the substrate uses.
+				// A false return collapses to inline continuation: the routed
+				// packets continue on this job instead of spawning children.
+				$parallel_step = array(
+					'id'    => $next_flow_step_id,
+					'type'  => ParallelMapFanoutAdapter::STEP_TYPE,
+					'items' => $routed_packets,
+					'steps' => array( array( 'flow_step_id' => $next_flow_step_id ) ),
+				);
+
+				if ( ! ParallelMapFanoutAdapter::shouldFanOut(
+					$parallel_step,
+					array(
+						'job_id'            => $job_id,
+						'next_flow_step_id' => $next_flow_step_id,
+						'item_count'        => $packet_count,
+					)
+				) ) {
+					$this->handleStepLifecycleInlineContinuation( $job_id, $flow_step_config, $routed_packets );
+
+					do_action(
+						'datamachine_schedule_next_step',
+						$job_id,
+						$next_flow_step_id,
+						$routed_packets
+					);
+
+					return array(
+						'success'      => true,
+						'step_success' => true,
+						'outcome'      => 'fanout_gated_inline',
+					);
+				}
+
 				// Fan out: each routed DataPacket becomes its own child job
-				// continuing through the remaining pipeline steps.
+				// continuing through the remaining pipeline steps. The adapter
+				// expresses this as the generic `parallel`-map step contract,
+				// backed by the Action-Scheduler PipelineBatchScheduler.
 				$engine_snapshot = datamachine_get_engine_data( $job_id );
-				$batch_scheduler = new PipelineBatchScheduler();
-				$batch_result    = $batch_scheduler->fanOut(
+				$adapter         = new ParallelMapFanoutAdapter();
+				$parallel_result = $adapter->dispatch(
+					$parallel_step,
 					$job_id,
 					$next_flow_step_id,
-					$routed_packets,
 					$engine_snapshot
 				);
 
@@ -592,7 +631,8 @@ class ExecuteStepAbility {
 					'success'      => true,
 					'step_success' => true,
 					'outcome'      => 'batch_scheduled',
-					'batch'        => $batch_result,
+					'batch'        => $parallel_result['batch'] ?? array(),
+					'parallel'     => $parallel_result,
 				);
 			}
 

--- a/inc/Abilities/Engine/ParallelMapFanoutAdapter.php
+++ b/inc/Abilities/Engine/ParallelMapFanoutAdapter.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Parallel-map fan-out adapter.
+ *
+ * Expresses Data Machine's packet fan-out *in terms of* the generic
+ * `parallel` workflow step contract introduced by Agents API
+ * ({@link https://github.com/Automattic/agents-api/pull/389}, the
+ * parallel-MAP shape). It lets a workflow spec authored against the
+ * Agents API `parallel` step be satisfied by Data Machine's
+ * Action-Scheduler-backed {@see PipelineBatchScheduler} executor.
+ *
+ * Architectural boundary (complementary, not duplicative):
+ *
+ *   - Agents API owns the `parallel` step CONTRACT and its synchronous
+ *     reference dispatch (run the same nested steps over N items in one
+ *     request, returning `{ shape:'map', count, branches:[...] }`).
+ *   - Data Machine provides a CONCURRENT executor backend for the map
+ *     shape: each item becomes an independent child pipeline job drained
+ *     through Action Scheduler with real concurrency budgets, chunk
+ *     sizing, and parent/child status rollup. DM does not replace the
+ *     contract; it is one real backend behind it.
+ *
+ * Generic `parallel`-map step shape this adapter accepts (PR #389):
+ *
+ *   array(
+ *       'id'       => 'fan',
+ *       'type'     => 'parallel',
+ *       'items'    => array( ...N items... ),  // array binding, resolved by caller
+ *       'as'       => 'item',                  // optional item var name
+ *       'index_as' => 'index',                 // optional index var name
+ *       'steps'    => array( ...nested steps run per item... ),
+ *   )
+ *
+ * Mapping onto Data Machine packet jobs:
+ *
+ *   - `items`  → the N DataPackets fanned into N child pipeline jobs.
+ *   - `steps`  → the remaining pipeline steps each child runs; the caller
+ *                supplies the concrete `next_flow_step_id` entry point.
+ *   - output  → the `{ shape:'map', count, branches:[...] }` contract
+ *                envelope, where each branch describes the dispatched
+ *                child (index, item, the nested steps it will run, and a
+ *                `scheduled` output marker — DM dispatch is asynchronous,
+ *                so branch outputs are scheduling receipts, not final
+ *                synchronous results).
+ *
+ * Adaptive gate: honors the `wp_agent_workflow_should_fanout` filter
+ * (default true) so the decision to fan out is consistent across every
+ * consumer of the generic contract. When the gate returns false the
+ * adapter reports `shape:'inline'` and performs no fan-out.
+ *
+ * This adapter has no hard dependency on Agents API code being present.
+ * It models the contract shape directly so Data Machine's existing
+ * behavior keeps working before PR #389 merges; once that substrate is
+ * installed, DM composes the same primitive instead of re-deriving it.
+ *
+ * @package DataMachine\Abilities\Engine
+ * @since 0.159.0
+ */
+
+namespace DataMachine\Abilities\Engine;
+
+defined( 'ABSPATH' ) || exit;
+
+class ParallelMapFanoutAdapter {
+
+	/**
+	 * Contract step type owned by the Agents API `parallel` step.
+	 */
+	public const STEP_TYPE = 'parallel';
+
+	/**
+	 * Map shape identifier from the generic `parallel` contract output.
+	 */
+	public const SHAPE_MAP = 'map';
+
+	/**
+	 * Inline shape reported when the adaptive gate suppresses fan-out.
+	 */
+	public const SHAPE_INLINE = 'inline';
+
+	/**
+	 * @var PipelineBatchScheduler
+	 */
+	private PipelineBatchScheduler $batch_scheduler;
+
+	/**
+	 * @param PipelineBatchScheduler|null $batch_scheduler Injectable executor backend.
+	 */
+	public function __construct( ?PipelineBatchScheduler $batch_scheduler = null ) {
+		$this->batch_scheduler = $batch_scheduler ?? new PipelineBatchScheduler();
+	}
+
+	/**
+	 * Validate that a step spec is the generic `parallel`-MAP shape.
+	 *
+	 * The parallel-roles+aggregate shape (the other shape PR #389 expresses)
+	 * is not a DM packet fan-out and is intentionally rejected here: it has
+	 * no `items` binding and DM has no concurrent backend for it.
+	 *
+	 * @param array $step Generic workflow step spec.
+	 * @return bool True when the step is a parallel-map step.
+	 */
+	public static function isParallelMapStep( array $step ): bool {
+		if ( self::STEP_TYPE !== ( $step['type'] ?? '' ) ) {
+			return false;
+		}
+
+		// The map shape is identified by an `items` array binding plus
+		// nested `steps`. Roles-style parallel steps carry `branches`/
+		// `roles` instead and are not mappable onto packet fan-out.
+		return array_key_exists( 'items', $step ) && isset( $step['steps'] ) && is_array( $step['steps'] );
+	}
+
+	/**
+	 * Resolve the adaptive fan-out gate for a `parallel`-map step.
+	 *
+	 * Mirrors the Agents API `wp_agent_workflow_should_fanout` filter
+	 * (default true) so a single ecosystem-wide policy decides whether the
+	 * map shape fans out or collapses inline. Data Machine routes its
+	 * packet fan-out through the same gate so behavior is consistent
+	 * whether the parallel step runs on the Agents API reference dispatch
+	 * or on DM's concurrent backend.
+	 *
+	 * @param array $step    The `parallel`-map step spec.
+	 * @param array $context Caller context (job_id, next_flow_step_id, item count, ...).
+	 * @return bool Whether to fan out. Defaults to true.
+	 */
+	public static function shouldFanOut( array $step, array $context = array() ): bool {
+		/**
+		 * Filter whether a generic `parallel`-map step should fan out.
+		 *
+		 * Compatible with the Agents API `wp_agent_workflow_should_fanout`
+		 * contract (PR #389). Returning false collapses the map shape to an
+		 * inline (single-branch) pass so no child jobs are scheduled.
+		 *
+		 * @param bool  $should  Whether to fan out. Default true.
+		 * @param array $step    The `parallel`-map step spec.
+		 * @param array $context Caller context.
+		 */
+		return (bool) apply_filters( 'wp_agent_workflow_should_fanout', true, $step, $context );
+	}
+
+	/**
+	 * Map a generic `parallel`-map step onto Data Machine packet fan-out.
+	 *
+	 * Given a parallel-map step whose resolved `items` are DataPacket
+	 * arrays, fan them into N independent child pipeline jobs via the
+	 * Action-Scheduler-backed executor, and return the generic contract
+	 * output envelope describing the dispatch.
+	 *
+	 * @param array  $step              Generic `parallel`-map step spec.
+	 * @param int    $parent_job_id     Parent job that owns the fan-out.
+	 * @param string $next_flow_step_id Concrete entry step each child runs (the per-item `steps`).
+	 * @param array  $engine_snapshot   Parent engine_data cloned to each child.
+	 * @return array {
+	 *     Generic `parallel` contract output.
+	 *
+	 *     @type string $shape    'map' on fan-out, 'inline' when gated off.
+	 *     @type int    $count    Number of items / branches.
+	 *     @type array  $branches Per-item branch descriptors.
+	 *     @type array  $batch    DM batch summary (parent_job_id, total, chunk_size) on fan-out.
+	 *     @type bool   $gated    True when the adaptive gate suppressed fan-out.
+	 * }
+	 */
+	public function dispatch(
+		array $step,
+		int $parent_job_id,
+		string $next_flow_step_id,
+		array $engine_snapshot
+	): array {
+		$items = is_array( $step['items'] ?? null ) ? array_values( $step['items'] ) : array();
+		$count = count( $items );
+
+		$context = array(
+			'job_id'            => $parent_job_id,
+			'next_flow_step_id' => $next_flow_step_id,
+			'item_count'        => $count,
+			'step_id'           => (string) ( $step['id'] ?? '' ),
+		);
+
+		if ( ! self::shouldFanOut( $step, $context ) ) {
+			return array(
+				'shape'    => self::SHAPE_INLINE,
+				'count'    => $count,
+				'branches' => $this->buildBranches( $step, $items, 'gated' ),
+				'gated'    => true,
+			);
+		}
+
+		$batch = $this->batch_scheduler->fanOut(
+			$parent_job_id,
+			$next_flow_step_id,
+			$items,
+			$engine_snapshot
+		);
+
+		return array(
+			'shape'    => self::SHAPE_MAP,
+			'count'    => $count,
+			'branches' => $this->buildBranches( $step, $items, 'scheduled' ),
+			'batch'    => $batch,
+			'gated'    => false,
+		);
+	}
+
+	/**
+	 * Build the per-item branch descriptors for the contract envelope.
+	 *
+	 * Each branch mirrors the generic `parallel`-map branch shape:
+	 * `{ index, item, steps, output }`. Because Data Machine dispatch is
+	 * asynchronous (children drain through Action Scheduler later), the
+	 * branch `output` is a scheduling receipt rather than the final
+	 * synchronous step result. The item var name (`as`) and index var
+	 * name (`index_as`) from the step spec are surfaced so callers can map
+	 * branch context back onto `${vars.item.*}` bindings.
+	 *
+	 * @param array  $step  The `parallel`-map step spec.
+	 * @param array  $items Resolved item bindings (DataPacket arrays).
+	 * @param string $state Dispatch state marker: 'scheduled' or 'gated'.
+	 * @return array<int,array<string,mixed>> Branch descriptors.
+	 */
+	private function buildBranches( array $step, array $items, string $state ): array {
+		$nested_steps = is_array( $step['steps'] ?? null ) ? $step['steps'] : array();
+		$item_var     = is_string( $step['as'] ?? null ) && '' !== $step['as'] ? $step['as'] : 'item';
+		$index_var    = is_string( $step['index_as'] ?? null ) && '' !== $step['index_as'] ? $step['index_as'] : 'index';
+
+		$branches = array();
+		foreach ( $items as $index => $item ) {
+			$branches[] = array(
+				'index'     => $index,
+				'item'      => $item,
+				'item_var'  => $item_var,
+				'index_var' => $index_var,
+				'steps'     => $nested_steps,
+				'output'    => array( 'state' => $state ),
+			);
+		}
+
+		return $branches;
+	}
+}

--- a/tests/parallel-map-fanout-adapter-smoke.php
+++ b/tests/parallel-map-fanout-adapter-smoke.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Pure-PHP smoke test for the parallel-map fan-out adapter.
+ *
+ * Proves Data Machine's packet fan-out can be expressed as the generic
+ * Agents API `parallel`-MAP step contract (PR #389): a `parallel`-map step
+ * spec `{ items, steps }` maps onto DM's PipelineBatchScheduler executor,
+ * and the `wp_agent_workflow_should_fanout` adaptive gate is honored.
+ *
+ * Run with: php tests/parallel-map-fanout-adapter-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Abilities\Engine {
+
+	// Test double for the Action-Scheduler executor backend. Captures the
+	// fanOut() call so the adapter's mapping can be asserted without a DB
+	// or WordPress runtime.
+	class PipelineBatchScheduler {
+		/** @var array<int,array<string,mixed>> */
+		public array $calls = array();
+
+		public function fanOut( int $parent_job_id, string $next_flow_step_id, array $dataPackets, array $engine_snapshot ): array {
+			$this->calls[] = array(
+				'parent_job_id'     => $parent_job_id,
+				'next_flow_step_id' => $next_flow_step_id,
+				'dataPackets'       => $dataPackets,
+				'engine_snapshot'   => $engine_snapshot,
+			);
+
+			return array(
+				'parent_job_id' => $parent_job_id,
+				'total'         => count( $dataPackets ),
+				'chunk_size'    => 10,
+			);
+		}
+	}
+}
+
+namespace {
+
+	defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+	// Filter shim: a single registered callback for wp_agent_workflow_should_fanout.
+	$GLOBALS['__should_fanout_filter'] = null;
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, $value, ...$args ) {
+			if ( 'wp_agent_workflow_should_fanout' === $hook && is_callable( $GLOBALS['__should_fanout_filter'] ) ) {
+				return ( $GLOBALS['__should_fanout_filter'] )( $value, ...$args );
+			}
+			return $value;
+		}
+	}
+
+	require_once __DIR__ . '/../inc/Abilities/Engine/ParallelMapFanoutAdapter.php';
+
+	use DataMachine\Abilities\Engine\ParallelMapFanoutAdapter;
+	use DataMachine\Abilities\Engine\PipelineBatchScheduler;
+
+	$failures = array();
+	$passes   = 0;
+
+	function parallel_map_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+		if ( $expected === $actual ) {
+			++$passes;
+			echo "  PASS {$name}\n";
+			return;
+		}
+
+		$failures[] = $name;
+		echo "  FAIL {$name}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	}
+
+	echo "parallel-map-fanout-adapter-smoke\n";
+
+	// A DataPacket-shaped item (the array form a fetch step emits).
+	function parallel_map_packet( string $title ): array {
+		return array(
+			'type'      => 'fetch',
+			'timestamp' => 0,
+			'data'      => array( 'title' => $title ),
+			'metadata'  => array( 'item_identifier' => $title ),
+		);
+	}
+
+	$items = array(
+		parallel_map_packet( 'one' ),
+		parallel_map_packet( 'two' ),
+		parallel_map_packet( 'three' ),
+	);
+
+	// Generic `parallel`-MAP step spec, exactly the PR #389 shape.
+	$parallel_step = array(
+		'id'       => 'fan',
+		'type'     => 'parallel',
+		'items'    => $items,
+		'as'       => 'packet',
+		'index_as' => 'i',
+		'steps'    => array(
+			array( 'id' => 'process', 'type' => 'ability', 'ability' => 'datamachine/execute-step' ),
+		),
+	);
+
+	// --- Shape detection ---
+	parallel_map_assert( true, ParallelMapFanoutAdapter::isParallelMapStep( $parallel_step ), 'parallel-map step is recognized', $failures, $passes );
+	parallel_map_assert( false, ParallelMapFanoutAdapter::isParallelMapStep( array( 'type' => 'ability' ) ), 'non-parallel step is rejected', $failures, $passes );
+	parallel_map_assert( false, ParallelMapFanoutAdapter::isParallelMapStep( array( 'type' => 'parallel', 'roles' => array() ) ), 'roles-shape parallel step is rejected (no items map)', $failures, $passes );
+
+	// --- Fan-out path: maps onto PipelineBatchScheduler ---
+	$GLOBALS['__should_fanout_filter'] = null; // default true
+	$backend = new PipelineBatchScheduler();
+	$adapter = new ParallelMapFanoutAdapter( $backend );
+
+	$engine_snapshot = array( 'job' => array( 'pipeline_id' => 5, 'flow_id' => 9 ) );
+	$result          = $adapter->dispatch( $parallel_step, 42, 'flow_step_next', $engine_snapshot );
+
+	parallel_map_assert( 'map', $result['shape'], 'dispatch reports map shape on fan-out', $failures, $passes );
+	parallel_map_assert( 3, $result['count'], 'dispatch count equals item count', $failures, $passes );
+	parallel_map_assert( false, $result['gated'], 'fan-out not gated by default', $failures, $passes );
+	parallel_map_assert( 1, count( $backend->calls ), 'executor backend fanOut called once', $failures, $passes );
+	parallel_map_assert( 42, $backend->calls[0]['parent_job_id'], 'items map onto parent job id', $failures, $passes );
+	parallel_map_assert( 'flow_step_next', $backend->calls[0]['next_flow_step_id'], 'nested steps map onto next_flow_step_id entry point', $failures, $passes );
+	parallel_map_assert( $items, $backend->calls[0]['dataPackets'], 'items map onto fanned DataPackets verbatim', $failures, $passes );
+	parallel_map_assert( $engine_snapshot, $backend->calls[0]['engine_snapshot'], 'engine snapshot forwarded to executor', $failures, $passes );
+	parallel_map_assert( 3, $result['batch']['total'], 'batch summary surfaced from executor', $failures, $passes );
+
+	// --- Contract output envelope: branches ---
+	parallel_map_assert( 3, count( $result['branches'] ), 'one branch per item', $failures, $passes );
+	parallel_map_assert( 0, $result['branches'][0]['index'], 'branch carries item index', $failures, $passes );
+	parallel_map_assert( $items[1], $result['branches'][1]['item'], 'branch carries the item binding', $failures, $passes );
+	parallel_map_assert( 'packet', $result['branches'][0]['item_var'], 'branch surfaces the `as` item var name', $failures, $passes );
+	parallel_map_assert( 'i', $result['branches'][0]['index_var'], 'branch surfaces the `index_as` index var name', $failures, $passes );
+	parallel_map_assert( $parallel_step['steps'], $result['branches'][0]['steps'], 'branch carries the nested per-item steps', $failures, $passes );
+	parallel_map_assert( array( 'state' => 'scheduled' ), $result['branches'][0]['output'], 'branch output is an async scheduling receipt', $failures, $passes );
+
+	// --- Adaptive gate: filter returning false suppresses fan-out ---
+	$GLOBALS['__should_fanout_filter'] = static function ( bool $should, array $step, array $context ): bool {
+		// Assert the contract args reach the filter.
+		if ( 'parallel' !== ( $step['type'] ?? '' ) || 42 !== ( $context['job_id'] ?? 0 ) ) {
+			return $should;
+		}
+		return false;
+	};
+
+	$backend_gated = new PipelineBatchScheduler();
+	$adapter_gated = new ParallelMapFanoutAdapter( $backend_gated );
+	$gated_result  = $adapter_gated->dispatch( $parallel_step, 42, 'flow_step_next', $engine_snapshot );
+
+	parallel_map_assert( 'inline', $gated_result['shape'], 'gate=false reports inline shape', $failures, $passes );
+	parallel_map_assert( true, $gated_result['gated'], 'gate=false marks result gated', $failures, $passes );
+	parallel_map_assert( 0, count( $backend_gated->calls ), 'gate=false performs no fan-out', $failures, $passes );
+	parallel_map_assert( 3, $gated_result['count'], 'gated result still reports item count', $failures, $passes );
+
+	// --- shouldFanOut() honors the same filter directly ---
+	parallel_map_assert( false, ParallelMapFanoutAdapter::shouldFanOut( $parallel_step, array( 'job_id' => 42 ) ), 'shouldFanOut honors filter', $failures, $passes );
+
+	$GLOBALS['__should_fanout_filter'] = null;
+	parallel_map_assert( true, ParallelMapFanoutAdapter::shouldFanOut( $parallel_step, array( 'job_id' => 42 ) ), 'shouldFanOut defaults to true', $failures, $passes );
+
+	if ( $failures ) {
+		echo "\nFAILED: " . count( $failures ) . " parallel-map fan-out adapter assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$passes} parallel-map fan-out adapter assertions passed.\n";
+}


### PR DESCRIPTION
## Summary

Expresses Data Machine's packet fan-out **in terms of** the generic `parallel` workflow step contract (parallel-MAP shape) from `Automattic/agents-api#389`, so DM becomes a **concurrent executor backend** behind that contract rather than a competing standalone primitive.

DM's `BatchScheduler` map fan-out is arguably a *reference* implementation of the parallel-MAP shape: it is Action-Scheduler-backed, with real concurrency budgets, chunk sizing/delay, and parent/child status rollup. So this does **not** replace DM's executor with Agents API's synchronous orchestration. Instead it adds a thin adapter + clean seam.

## What changed

- **`inc/Abilities/Engine/ParallelMapFanoutAdapter.php`** (new) — maps a generic `parallel`-map step spec `{ id, type:'parallel', items, as?, index_as?, steps }` onto `PipelineBatchScheduler::fanOut()`, returning the contract output envelope `{ shape:'map', count, branches:[ {index, item, steps, output} ] }`. Each item → one child pipeline job; the nested `steps` map onto the concrete `next_flow_step_id` entry point each child runs. Because DM dispatch is asynchronous (children drain through Action Scheduler), branch `output` is a scheduling receipt, not a synchronous result. Also recognizes/rejects the non-map (`roles`) parallel shape, which DM has no concurrent backend for.
- **`inc/Abilities/Engine/ExecuteStepAbility.php`** — routes the existing fan-out decision through the adaptive `wp_agent_workflow_should_fanout` filter (default true) before fanning out, consistent with the substrate. A false return collapses to inline continuation (the routed packets continue on the same job; no child jobs spawned) and returns `outcome: 'fanout_gated_inline'`. The fan-out path now goes through the adapter.
- **`tests/parallel-map-fanout-adapter-smoke.php`** (new) — pure-PHP smoke test (25 assertions) proving the generic `parallel`-map spec maps onto DM packet fan-out, the contract envelope/branches are correct, and the gate filter is honored (default true; false suppresses fan-out and reports `shape:'inline'`).

## How the gate filter is wired

`ParallelMapFanoutAdapter::shouldFanOut($step, $context)` applies `wp_agent_workflow_should_fanout` (default `true`). Both the adapter's `dispatch()` and the live `ExecuteStepAbility` fan-out decision call it, so a single ecosystem-wide policy decides whether the map shape fans out — whether the `parallel` step runs on the Agents API reference dispatch or on DM's concurrent backend.

## Complementary, not duplicative

Agents API owns the `parallel` step **contract** and its **synchronous reference dispatch** (run the same nested steps over N items in one request). Data Machine provides a **concurrent executor backend** for the map shape: each item becomes an independent child pipeline job drained through Action Scheduler with real concurrency budgets, chunk sizing, and parent/child status rollup. DM does not replace the contract; it is one real backend behind it. The substrate declares the contract; DM is one durable, async concurrency implementation of it.

## Ordering / dependency note

`Automattic/agents-api#389` is **OPEN, not merged**. This PR composes against its *interface contract* only — the adapter models the `parallel`-map shape directly and has **no hard dependency on Agents API code being present at runtime**. DM's existing `BatchScheduler` fan-out is untouched and keeps working before #389 merges. Once the substrate is installed, DM composes the same primitive instead of re-deriving it. No runtime green here requires the unmerged upstream code.

## Test output

`php tests/parallel-map-fanout-adapter-smoke.php` — all 25 assertions pass:

```
All 25 parallel-map fan-out adapter assertions passed.
```

Existing `php tests/transition-fanout-policy-smoke.php` still passes (11 assertions). `php -l` clean on all changed files. The full suite runs via `homeboy test data-machine` (needs a MySQL/WP bootstrap not available in this clean checkout); the adapter is covered by the runnable pure-PHP unit-shaped smoke test above.

Refs #388
Depends on Automattic/agents-api#389

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** Adapter design, gate-filter wiring into the existing fan-out decision, and the smoke test.
