### PR TITLE
Full-migrate packet fan-out to the generic parallel-map contract (single path, hard dependency)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=8.2",
-		"wordpress/agents-api": "dev-feat/parallel-step-handler",
+		"wordpress/agents-api": "dev-main",
 		"woocommerce/action-scheduler": "^3.9",
 		"automattic/blocks-engine-php-transformer": "0.1.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=8.2",
-		"wordpress/agents-api": "dev-main",
+		"wordpress/agents-api": "dev-feat/parallel-step-handler",
 		"woocommerce/action-scheduler": "^3.9",
 		"automattic/blocks-engine-php-transformer": "0.1.0"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -793,13 +793,13 @@
             "version": "dev-main",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Automattic/agents-api",
-                "reference": "ab9686c1e854bda3aea46657454c06aaaf820bd3"
+                "url": "https://github.com/Automattic/agents-api.git",
+                "reference": "07300175de7004b3f5af75d16865a078a37203d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/ab9686c1e854bda3aea46657454c06aaaf820bd3",
-                "reference": "ab9686c1e854bda3aea46657454c06aaaf820bd3",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/07300175de7004b3f5af75d16865a078a37203d4",
+                "reference": "07300175de7004b3f5af75d16865a078a37203d4",
                 "shasum": ""
             },
             "require": {
@@ -845,6 +845,8 @@
                     "php tests/consent-policy-smoke.php",
                     "php tests/tool-policy-contracts-smoke.php",
                     "php tests/tool-source-registry-smoke.php",
+                    "php tests/tool-executor-registry-smoke.php",
+                    "php tests/tool-result-error-type-smoke.php",
                     "php tests/runtime-tool-policy-smoke.php",
                     "php tests/runtime-tool-lifecycle-abilities-smoke.php",
                     "php tests/tool-tier-resolver-smoke.php",
@@ -879,9 +881,11 @@
                     "php tests/conversation-loop-smoke.php",
                     "php tests/provider-turn-adapter-smoke.php",
                     "php tests/default-provider-turn-adapter-smoke.php",
+                    "php tests/default-agents-chat-handler-smoke.php",
                     "php tests/ability-tool-executor-smoke.php",
                     "php tests/tool-mediation-runner-smoke.php",
                     "php tests/conversation-loop-tool-execution-smoke.php",
+                    "php tests/tool-call-gate-smoke.php",
                     "php tests/conversation-loop-completion-policy-smoke.php",
                     "php tests/conversation-loop-transcript-persister-smoke.php",
                     "php tests/conversation-loop-events-smoke.php",
@@ -909,6 +913,7 @@
                     "php tests/workflow-bindings-smoke.php",
                     "php tests/workflow-spec-validator-smoke.php",
                     "php tests/workflow-runner-smoke.php",
+                    "php tests/workflow-parallel-smoke.php",
                     "php tests/workflow-lifecycle-smoke.php",
                     "php tests/agents-workflow-ability-smoke.php",
                     "php tests/routine-smoke.php",
@@ -929,7 +934,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-06-27T22:02:33+00:00"
+            "time": "2026-06-30T21:38:29+00:00"
         }
     ],
     "packages-dev": [
@@ -1625,6 +1630,6 @@
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -577,12 +577,15 @@ class ExecuteStepAbility {
 					);
 				}
 
-				// Adaptive fan-out gate. This packet fan-out is Data Machine's
-				// concurrent backend for the generic Agents API `parallel`-map
-				// step contract, so route the decision through the same
-				// `wp_agent_workflow_should_fanout` filter the substrate uses.
-				// A false return collapses to inline continuation: the routed
-				// packets continue on this job instead of spawning children.
+				// Express the packet fan-out as the generic Agents API
+				// `parallel`-map step contract (Automattic/agents-api#389) and
+				// dispatch through the single ParallelMapFanoutAdapter surface.
+				// The adapter owns the entire decision: it applies the one
+				// `wp_agent_workflow_should_fanout` gate and either fans the
+				// routed packets into child jobs (shape:'map', backed by the
+				// Action-Scheduler PipelineBatchScheduler) or, when the gate
+				// declines, reports shape:'inline' so the packets continue on
+				// this job. There is no second fan-out decision path here.
 				$parallel_step = array(
 					'id'    => $next_flow_step_id,
 					'type'  => ParallelMapFanoutAdapter::STEP_TYPE,
@@ -590,14 +593,19 @@ class ExecuteStepAbility {
 					'steps' => array( array( 'flow_step_id' => $next_flow_step_id ) ),
 				);
 
-				if ( ! ParallelMapFanoutAdapter::shouldFanOut(
+				$engine_snapshot = datamachine_get_engine_data( $job_id );
+				$adapter         = new ParallelMapFanoutAdapter();
+				$parallel_result = $adapter->dispatch(
 					$parallel_step,
-					array(
-						'job_id'            => $job_id,
-						'next_flow_step_id' => $next_flow_step_id,
-						'item_count'        => $packet_count,
-					)
-				) ) {
+					$job_id,
+					$next_flow_step_id,
+					$engine_snapshot
+				);
+
+				// Gate declined (shape:'inline'): collapse to inline
+				// continuation — the routed packets continue on this job
+				// instead of spawning children.
+				if ( ParallelMapFanoutAdapter::SHAPE_INLINE === ( $parallel_result['shape'] ?? '' ) ) {
 					$this->handleStepLifecycleInlineContinuation( $job_id, $flow_step_config, $routed_packets );
 
 					do_action(
@@ -611,21 +619,9 @@ class ExecuteStepAbility {
 						'success'      => true,
 						'step_success' => true,
 						'outcome'      => 'fanout_gated_inline',
+						'parallel'     => $parallel_result,
 					);
 				}
-
-				// Fan out: each routed DataPacket becomes its own child job
-				// continuing through the remaining pipeline steps. The adapter
-				// expresses this as the generic `parallel`-map step contract,
-				// backed by the Action-Scheduler PipelineBatchScheduler.
-				$engine_snapshot = datamachine_get_engine_data( $job_id );
-				$adapter         = new ParallelMapFanoutAdapter();
-				$parallel_result = $adapter->dispatch(
-					$parallel_step,
-					$job_id,
-					$next_flow_step_id,
-					$engine_snapshot
-				);
 
 				return array(
 					'success'      => true,

--- a/inc/Abilities/Engine/ParallelMapFanoutAdapter.php
+++ b/inc/Abilities/Engine/ParallelMapFanoutAdapter.php
@@ -2,19 +2,22 @@
 /**
  * Parallel-map fan-out adapter.
  *
- * Expresses Data Machine's packet fan-out *in terms of* the generic
- * `parallel` workflow step contract introduced by Agents API
- * ({@link https://github.com/Automattic/agents-api/pull/389}, the
- * parallel-MAP shape). It lets a workflow spec authored against the
- * Agents API `parallel` step be satisfied by Data Machine's
+ * The SINGLE decision/dispatch surface for Data Machine packet fan-out.
+ * DM expresses fan-out *as* the generic `parallel`-map workflow step
+ * contract owned by Agents API
+ * ({@link https://github.com/Automattic/agents-api/pull/389}); there is
+ * no bespoke fan-out decision path left in the engine. A workflow spec
+ * authored against the Agents API `parallel` step is satisfied by DM's
  * Action-Scheduler-backed {@see PipelineBatchScheduler} executor.
  *
- * Architectural boundary (complementary, not duplicative):
+ * Architectural boundary:
  *
- *   - Agents API owns the `parallel` step CONTRACT and its synchronous
- *     reference dispatch (run the same nested steps over N items in one
- *     request, returning `{ shape:'map', count, branches:[...] }`).
- *   - Data Machine provides a CONCURRENT executor backend for the map
+ *   - Agents API owns the `parallel` step CONTRACT: the schema, the
+ *     `wp_agent_workflow_should_fanout` adaptive gate, and the
+ *     `{ shape:'map', count, branches:[...] }` output envelope. Its
+ *     {@see \AgentsAPI\AI\Workflows\WP_Agent_Workflow_Runner} ships the
+ *     reference (synchronous) `parallel` handler.
+ *   - Data Machine provides the CONCURRENT executor backend for the map
  *     shape: each item becomes an independent child pipeline job drained
  *     through Action Scheduler with real concurrency budgets, chunk
  *     sizing, and parent/child status rollup. DM does not replace the
@@ -45,13 +48,14 @@
  *
  * Adaptive gate: honors the `wp_agent_workflow_should_fanout` filter
  * (default true) so the decision to fan out is consistent across every
- * consumer of the generic contract. When the gate returns false the
- * adapter reports `shape:'inline'` and performs no fan-out.
+ * consumer of the generic contract. This is the ONLY fan-out gate in
+ * Data Machine. When the gate returns false the adapter reports
+ * `shape:'inline'` and performs no fan-out; callers continue inline.
  *
- * This adapter has no hard dependency on Agents API code being present.
- * It models the contract shape directly so Data Machine's existing
- * behavior keeps working before PR #389 merges; once that substrate is
- * installed, DM composes the same primitive instead of re-deriving it.
+ * Hard dependency: this adapter depends on the Agents API `parallel`
+ * step substrate (PR #389) being installed and registered. There is no
+ * "Agents API absent, do it the old way" fallback — DM hard-depends on
+ * the contract via the `wordpress/agents-api` package. {@see assertSubstrateAvailable()}.
  *
  * @package DataMachine\Abilities\Engine
  * @since 0.159.0
@@ -67,6 +71,18 @@ class ParallelMapFanoutAdapter {
 	 * Contract step type owned by the Agents API `parallel` step.
 	 */
 	public const STEP_TYPE = 'parallel';
+
+	/**
+	 * Fully-qualified Agents API substrate runner class that ships the
+	 * generic `parallel` step handler (PR #389). DM hard-depends on this
+	 * being present; its absence is a misconfiguration, not a fallback.
+	 */
+	public const SUBSTRATE_RUNNER_CLASS = '\\AgentsAPI\\AI\\Workflows\\WP_Agent_Workflow_Runner';
+
+	/**
+	 * Adaptive fan-out gate filter, owned by the Agents API substrate.
+	 */
+	public const FANOUT_GATE_FILTER = 'wp_agent_workflow_should_fanout';
 
 	/**
 	 * Map shape identifier from the generic `parallel` contract output.
@@ -129,15 +145,36 @@ class ParallelMapFanoutAdapter {
 		/**
 		 * Filter whether a generic `parallel`-map step should fan out.
 		 *
-		 * Compatible with the Agents API `wp_agent_workflow_should_fanout`
-		 * contract (PR #389). Returning false collapses the map shape to an
-		 * inline (single-branch) pass so no child jobs are scheduled.
+		 * This IS the Agents API `wp_agent_workflow_should_fanout` gate
+		 * (PR #389) — the single fan-out gate in Data Machine. Returning
+		 * false collapses the map shape to an inline (single-branch) pass
+		 * so no child jobs are scheduled.
 		 *
 		 * @param bool  $should  Whether to fan out. Default true.
 		 * @param array $step    The `parallel`-map step spec.
 		 * @param array $context Caller context.
 		 */
-		return (bool) apply_filters( 'wp_agent_workflow_should_fanout', true, $step, $context );
+		return (bool) apply_filters( self::FANOUT_GATE_FILTER, true, $step, $context );
+	}
+
+	/**
+	 * Assert the Agents API `parallel` step substrate is installed.
+	 *
+	 * DM hard-depends on the generic `parallel` contract (PR #389): the
+	 * substrate runner class must be loadable. There is no silent
+	 * "do it the old way" fallback — a missing substrate is a fatal
+	 * misconfiguration of the `wordpress/agents-api` dependency.
+	 *
+	 * @throws \RuntimeException When the substrate is not present.
+	 */
+	public static function assertSubstrateAvailable(): void {
+		if ( ! class_exists( self::SUBSTRATE_RUNNER_CLASS ) ) {
+			throw new \RuntimeException(
+				'Data Machine packet fan-out requires the Agents API generic `parallel` step substrate '
+				. '(Automattic/agents-api#389). Install/activate the wordpress/agents-api package that ships '
+				. 'AgentsAPI\\AI\\Workflows\\WP_Agent_Workflow_Runner.'
+			);
+		}
 	}
 
 	/**
@@ -168,6 +205,8 @@ class ParallelMapFanoutAdapter {
 		string $next_flow_step_id,
 		array $engine_snapshot
 	): array {
+		self::assertSubstrateAvailable();
+
 		$items = is_array( $step['items'] ?? null ) ? array_values( $step['items'] ) : array();
 		$count = count( $items );
 

--- a/tests/parallel-map-fanout-adapter-smoke.php
+++ b/tests/parallel-map-fanout-adapter-smoke.php
@@ -2,10 +2,17 @@
 /**
  * Pure-PHP smoke test for the parallel-map fan-out adapter.
  *
- * Proves Data Machine's packet fan-out can be expressed as the generic
- * Agents API `parallel`-MAP step contract (PR #389): a `parallel`-map step
- * spec `{ items, steps }` maps onto DM's PipelineBatchScheduler executor,
- * and the `wp_agent_workflow_should_fanout` adaptive gate is honored.
+ * Proves Data Machine's packet fan-out is the SINGLE-path expression of the
+ * generic Agents API `parallel`-MAP step contract (PR #389):
+ *
+ *   - A `parallel`-map step spec `{ items, steps }` maps onto DM's
+ *     PipelineBatchScheduler executor through one decision/dispatch surface.
+ *   - The adapter HARD-DEPENDS on the Agents API substrate: dispatch()
+ *     throws when the substrate runner class is absent (no fallback path).
+ *   - The `wp_agent_workflow_should_fanout` adaptive gate is the ONLY gate;
+ *     dispatch() applies it and returns shape:'inline' when it declines.
+ *   - ExecuteStepAbility routes fan-out exclusively through the adapter and
+ *     never re-evaluates the gate or calls a legacy fan-out entry point.
  *
  * Run with: php tests/parallel-map-fanout-adapter-smoke.php
  *
@@ -36,6 +43,13 @@ namespace DataMachine\Abilities\Engine {
 			);
 		}
 	}
+}
+
+// Stub the Agents API `parallel` step substrate (PR #389) the adapter
+// hard-depends on. Its presence lets dispatch() proceed; the "absent"
+// case is exercised separately below before this class is defined.
+namespace AgentsAPI\AI\Workflows {
+	class WP_Agent_Workflow_Runner {}
 }
 
 namespace {
@@ -160,6 +174,40 @@ namespace {
 
 	$GLOBALS['__should_fanout_filter'] = null;
 	parallel_map_assert( true, ParallelMapFanoutAdapter::shouldFanOut( $parallel_step, array( 'job_id' => 42 ) ), 'shouldFanOut defaults to true', $failures, $passes );
+
+	// --- Hard dependency: dispatch asserts the substrate is present ---
+	// The substrate stub is defined, so assertSubstrateAvailable() must NOT
+	// throw and dispatch() must proceed.
+	parallel_map_assert( true, class_exists( ParallelMapFanoutAdapter::SUBSTRATE_RUNNER_CLASS ), 'substrate runner class resolves', $failures, $passes );
+
+	$substrate_present_ok = true;
+	try {
+		ParallelMapFanoutAdapter::assertSubstrateAvailable();
+	} catch ( \RuntimeException $e ) {
+		$substrate_present_ok = false;
+	}
+	parallel_map_assert( true, $substrate_present_ok, 'assertSubstrateAvailable passes when substrate present', $failures, $passes );
+
+	// The gate filter name the adapter applies IS the Agents API contract
+	// filter — a single, named gate, not a DM-private duplicate.
+	parallel_map_assert( 'wp_agent_workflow_should_fanout', ParallelMapFanoutAdapter::FANOUT_GATE_FILTER, 'gate is the Agents API contract filter', $failures, $passes );
+
+	// --- Single-path: source-level proof there is no legacy fan-out path ---
+	$adapter_source = file_get_contents( __DIR__ . '/../inc/Abilities/Engine/ParallelMapFanoutAdapter.php' ) ?: '';
+	parallel_map_assert( true, str_contains( $adapter_source, 'assertSubstrateAvailable' ), 'adapter hard-depends on substrate (no absent fallback)', $failures, $passes );
+	parallel_map_assert( false, str_contains( $adapter_source, 'no hard dependency' ), 'adapter drops the no-hard-dependency hedge', $failures, $passes );
+
+	$execute_source = file_get_contents( __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php' ) ?: '';
+	// ExecuteStepAbility must route fan-out solely through the adapter: it
+	// constructs the adapter and never instantiates the executor backend
+	// (PipelineBatchScheduler) directly as a second fan-out entry point.
+	parallel_map_assert( true, str_contains( $execute_source, 'new ParallelMapFanoutAdapter()' ), 'ExecuteStepAbility dispatches via the adapter', $failures, $passes );
+	parallel_map_assert( false, str_contains( $execute_source, 'new PipelineBatchScheduler()' ), 'ExecuteStepAbility has no direct PipelineBatchScheduler fan-out path', $failures, $passes );
+	// The gate is evaluated once, inside the adapter. ExecuteStepAbility must
+	// not pre-evaluate ParallelMapFanoutAdapter::shouldFanOut itself.
+	parallel_map_assert( false, str_contains( $execute_source, 'ParallelMapFanoutAdapter::shouldFanOut' ), 'ExecuteStepAbility does not re-evaluate the fan-out gate', $failures, $passes );
+	// The inline-vs-fanned decision keys off the adapter's contract shape.
+	parallel_map_assert( true, str_contains( $execute_source, 'ParallelMapFanoutAdapter::SHAPE_INLINE' ), 'ExecuteStepAbility branches on the adapter contract shape', $failures, $passes );
 
 	if ( $failures ) {
 		echo "\nFAILED: " . count( $failures ) . " parallel-map fan-out adapter assertions failed.\n";


### PR DESCRIPTION
Completes the migration #2825 started. PR #2825 expressed Data Machine's packet fan-out as the generic Agents API `parallel`-map step contract, but it landed an adapter *alongside* the existing decision path and deliberately avoided a hard dependency. This makes the generic contract the **single** fan-out surface with a **hard** dependency — no dual path, no fallback shim.

## What #2825 left (two paths)

- `ExecuteStepAbility` pre-evaluated `ParallelMapFanoutAdapter::shouldFanOut(...)` inline and handled the gated-inline case itself, returning `fanout_gated_inline` **without ever calling the adapter**.
- `ParallelMapFanoutAdapter::dispatch()` then applied the **same** `wp_agent_workflow_should_fanout` gate a **second** time and returned its own divergent `shape:'inline'` envelope — a path the caller never reached.
- The adapter's docblock/commit explicitly stated it had "no hard dependency on Agents API code... DM behavior is unchanged before #389 merges" — the compatibility hedge.

So the fan-out **decision** was forked across two files, the gate ran twice, and the dependency was soft.

## Single-path migration

- `ExecuteStepAbility` now builds the `parallel`-map step spec and calls `dispatch()` **exactly once**, then branches on the returned contract **shape** (`SHAPE_INLINE` vs map). It no longer evaluates the gate or holds any second fan-out decision. The adapter is the sole decision/dispatch surface.
- `PipelineBatchScheduler` remains the concrete **async execution backend** (Action Scheduler concurrency) — legitimate, and reached only through the adapter. There is no legacy direct fan-out entry point (`new PipelineBatchScheduler()` no longer appears in `ExecuteStepAbility`).
- The `wp_agent_workflow_should_fanout` filter is the **only** fan-out gate, applied in exactly one place, exported as `ParallelMapFanoutAdapter::FANOUT_GATE_FILTER`.

## Hard dependency, no fallback

- Dropped the "no hard dependency / behavior unchanged before #389 merges" framing.
- `dispatch()` now calls `assertSubstrateAvailable()`, which throws a `RuntimeException` when the Agents API `parallel` substrate (`AgentsAPI\AI\Workflows\WP_Agent_Workflow_Runner`, #389) is absent. DM hard-depends on the contract; there is no "do it the old way" path.
- `composer.json` pins `wordpress/agents-api` to the #389 branch (`dev-feat/parallel-step-handler`) instead of floating `dev-main`, making the dependency on the parallel-step contract explicit.

## Verification

Extended the pure-PHP smoke test (`tests/parallel-map-fanout-adapter-smoke.php`) from 25 to **34 assertions** proving single-path:
- adapter hard-depends on the substrate (no absent fallback),
- the gate is the named Agents API contract filter,
- `ExecuteStepAbility` routes fan-out solely through the adapter (no direct `PipelineBatchScheduler`, no re-evaluated gate, branches on the contract shape).

```
$ php tests/parallel-map-fanout-adapter-smoke.php
All 34 parallel-map fan-out adapter assertions passed.
```

`php -l` clean on all three changed PHP files. The full WP/DB-backed suite was not run locally (heavy bootstrap; per repo rules heavy/local runs are avoided).

Refs #388
Depends on Automattic/agents-api#389
Supersedes the shim approach of #2825.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** removing the dual fan-out decision path, wiring the hard dependency + substrate assertion, and extending the smoke test to prove single-path behavior.