### PR TITLE
fix: harden daily-memory no-op classification and make quiet days observable

### DIFF
--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -27,6 +27,7 @@ use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Core\FilesRepository\AgentMemory;
 use DataMachine\Core\FilesRepository\DailyMemory;
+use DataMachine\Engine\AI\DataMachineConversationStatus;
 use DataMachine\Engine\AI\NaturalCompletionPolicyInterface;
 use AgentsAPI\AI\WP_Agent_Compaction_Conservation;
 use AgentsAPI\AI\WP_Agent_Conversation_Completion_Decision;
@@ -205,15 +206,36 @@ class DailyMemoryTask extends SystemTask {
 			// A genuine fault is identified by an explicit error signal:
 			// a non-empty error string, an error_code, or a hard failure /
 			// interrupted status from the loop. Those still fail the job.
-			$genuine_failure = '' !== $response_error
-				|| ! empty( $response['error_code'] )
-				|| in_array( (string) ( $response['status'] ?? '' ), array( 'error', 'failed', 'interrupted' ), true );
+			//
+			// The complement — the legitimate no-op — is the far more common
+			// path for small, already-healthy MEMORY.md files: the model
+			// reviewed the day and never emitted an acceptable split, so the
+			// completion policy kept declining until the turn budget was
+			// exhausted. The substrate reports that budget exhaustion as
+			// `budget_exceeded` (see DataMachineConversationStatus), which is
+			// deliberately NOT a hard-failure status here. Classification is
+			// centralized in self::isGenuineFailureResponse() so the no-op vs
+			// failure decision has a single, testable source of truth rather
+			// than an implicit "absent from a denylist" read.
+			$genuine_failure = self::isGenuineFailureResponse( $response, $response_error );
 
 			if ( ! $genuine_failure ) {
+				// A quiet no-op is an expected, healthy outcome of a recurring
+				// maintenance task — not an error and not a warning. But at the
+				// default production log level (`error`) an info log is silently
+				// discarded, so a quiet day leaves no trace in the log store and
+				// looks indistinguishable from "the task never ran" (issue
+				// #2827). The durable, level-independent signal is the job's own
+				// completed status plus the structured `no_change` marker written
+				// to engine_data by completeJob() below: `wp datamachine jobs
+				// show <id>` and the run-outcome metrics both surface it
+				// regardless of log filtering. The info log stays for verbose
+				// installs; the structured completion is the observability
+				// contract.
 				do_action(
 					'datamachine_log',
 					'info',
-					'Daily memory no-op: completion policy not satisfied, MEMORY.md left unchanged.',
+					'Daily memory no-op: completion policy not satisfied within turn budget, MEMORY.md left unchanged (expected on a quiet day).',
 					array(
 						'date'        => $date,
 						'job_id'      => $jobId,
@@ -228,9 +250,11 @@ class DailyMemoryTask extends SystemTask {
 					array(
 						'skipped'       => true,
 						'no_change'     => true,
+						'outcome'       => 'no_op',
 						'reason'        => 'Completion policy not satisfied within turn budget; MEMORY.md left unchanged (no memory-worthy change this run).',
 						'original_size' => $original_size,
 						'turn_count'    => $response['turn_count'] ?? 0,
+						'status'        => (string) ( $response['status'] ?? '' ),
 					)
 				);
 				return;
@@ -388,6 +412,59 @@ class DailyMemoryTask extends SystemTask {
 				'compaction'        => $plan['metadata'],
 				'compaction_events' => $plan['events'],
 			)
+		);
+	}
+
+	/**
+	 * Decide whether an incomplete conversation result is a genuine failure.
+	 *
+	 * When the daily-memory conversation ends without the completion policy
+	 * being satisfied (`metadata.datamachine.completed` is falsey), the run is
+	 * either a real fault or a legitimate no-op. This is the single source of
+	 * truth for that classification, extracted so it can be regression-tested
+	 * in isolation (see tests/daily-memory-noop-classification-smoke.php) and
+	 * so both the guard and its intent live in one place instead of an
+	 * implicit "not present in a denylist" read.
+	 *
+	 * A GENUINE FAILURE is signalled by any of:
+	 *   - a non-empty error string on the result,
+	 *   - a non-empty `error_code`, or
+	 *   - a hard-failure conversation status: `error`, `failed`, or
+	 *     `interrupted` (an external interruption, distinct from turn-budget
+	 *     exhaustion).
+	 *
+	 * Everything else is a NO-OP, including the common turn-budget-exhaustion
+	 * status `budget_exceeded` and an empty/absent status. Turn-budget
+	 * exhaustion is expected on a quiet day: the model reviewed the day's
+	 * activity and never produced an acceptable PERSISTENT/ARCHIVED split
+	 * because there was nothing memory-worthy to fold in. MEMORY.md is left
+	 * untouched (nothing is written until later in executeTask()), so the job
+	 * should complete cleanly rather than fail and pollute error-rate metrics
+	 * and the wake briefing (issues #2783, #2827).
+	 *
+	 * @param array  $response       Normalized conversation result.
+	 * @param string $response_error Pre-trimmed error string from the result.
+	 * @return bool True when the result is a genuine failure, false for a no-op.
+	 */
+	public static function isGenuineFailureResponse( array $response, string $response_error ): bool {
+		if ( '' !== $response_error ) {
+			return true;
+		}
+
+		if ( ! empty( $response['error_code'] ) ) {
+			return true;
+		}
+
+		$status = (string) ( $response['status'] ?? '' );
+
+		return in_array(
+			$status,
+			array(
+				DataMachineConversationStatus::FAILED,
+				DataMachineConversationStatus::INTERRUPTED,
+				'error',
+			),
+			true
 		);
 	}
 

--- a/tests/daily-memory-noop-classification-smoke.php
+++ b/tests/daily-memory-noop-classification-smoke.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Pure-PHP smoke test for DailyMemoryTask no-op vs genuine-failure
+ * classification.
+ *
+ * Run with: php tests/daily-memory-noop-classification-smoke.php
+ *
+ * Covers DailyMemoryTask::isGenuineFailureResponse() — the single source of
+ * truth for deciding, when a daily-memory conversation ends WITHOUT the
+ * completion policy being satisfied, whether that is a real fault or a
+ * legitimate "nothing memory-worthy this run" no-op.
+ *
+ * Background (issues #2783, #2827):
+ *
+ *   The conversation loop reports `metadata.datamachine.completed = false`
+ *   both when the request actually failed (provider error, runtime exception,
+ *   external interruption) AND when the model simply ran out of turns without
+ *   producing a split the completion policy would accept. The latter is the
+ *   common path for small, already-healthy MEMORY.md files. Pre-#2783 the task
+ *   routed BOTH to failJob(), which:
+ *
+ *     1. Failed the `system` "Daily Memory" job every quiet day.
+ *     2. Cascaded through the paired `pipeline_system_task` leg as
+ *        `packet_failure` ("Step execution failed - empty data packet"),
+ *        because the failed child job produced a failure result packet that
+ *        StepExecutionResult::classify() rejected.
+ *     3. Polluted error-rate metrics and the wake briefing (which counts jobs
+ *        with status LIKE 'failed%' grouped by task_type).
+ *
+ *   #2783 added the guard so a no-op completeJob()s with skipped/no_change and
+ *   only genuine faults still fail. Because the no-op sets skipped=true,
+ *   SystemTaskStep marks success and emits a success result packet, so BOTH
+ *   legs now complete. This test locks in the exact classification so a
+ *   regression (e.g. a new substrate status accidentally treated as a
+ *   failure, or the budget-exhaustion no-op accidentally treated as a fault)
+ *   surfaces here.
+ *
+ * The classifier is pure and static, so we exercise the real production method
+ * directly rather than mirroring its logic inline.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+// Minimal WP shims so the class file (and its imports) can load without a
+// full WordPress bootstrap. The classifier under test has no WP dependencies.
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( ...$args ): void {
+		unset( $args );
+	}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value ) {
+		unset( $hook );
+		return $value;
+	}
+}
+if ( ! function_exists( 'size_format' ) ) {
+	function size_format( $bytes ): string {
+		return $bytes . ' B';
+	}
+}
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = 'default' ) {
+		unset( $domain );
+		return $text;
+	}
+}
+
+// Only the status vocabulary and the task class are needed. Load the status
+// constants and the task file directly; SystemTask (the parent) and the
+// Agents API compaction classes are not touched by the pure classifier, but
+// the class declaration must be loadable, so stub the parent minimally when
+// the real one is unavailable.
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/DataMachineConversationStatus.php';
+
+if ( ! class_exists( '\DataMachine\Engine\AI\System\Tasks\SystemTask' ) ) {
+	// Declare a lightweight parent so DailyMemoryTask can be declared without
+	// pulling the full engine. The classifier under test is static and never
+	// touches parent behavior.
+	eval(
+		'namespace DataMachine\\Engine\\AI\\System\\Tasks; abstract class SystemTask {}'
+	);
+}
+if ( ! interface_exists( '\DataMachine\Engine\AI\NaturalCompletionPolicyInterface' ) ) {
+	eval(
+		'namespace DataMachine\\Engine\\AI; interface NaturalCompletionPolicyInterface {}'
+	);
+}
+
+// The task file `use`s several Agents API + Core classes at namespace scope.
+// PHP resolves `use` lazily (only on actual reference), so unresolved imports
+// do not fatal at include time as long as the referenced symbols are never
+// used by the code path we exercise. isGenuineFailureResponse() references
+// only DataMachineConversationStatus, already loaded above.
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/System/Tasks/DailyMemoryTask.php';
+
+use DataMachine\Engine\AI\System\Tasks\DailyMemoryTask;
+use DataMachine\Engine\AI\DataMachineConversationStatus;
+
+$failures = array();
+$passes   = 0;
+
+function assert_bool( bool $expected, bool $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		$passes++;
+		echo "  \xE2\x9C\x93 {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  \xE2\x9C\x97 {$name}\n";
+	echo '    expected: ' . ( $expected ? 'true' : 'false' ) . "\n";
+	echo '    actual:   ' . ( $actual ? 'true' : 'false' ) . "\n";
+}
+
+echo "daily memory no-op classification smoke\n";
+echo "---------------------------------------\n";
+
+// ── NO-OP cases (must NOT fail the job) ───────────────────────────────────
+
+echo "\n[no-op] budget exhausted, no error (the common quiet-day path):\n";
+assert_bool(
+	false,
+	DailyMemoryTask::isGenuineFailureResponse(
+		array( 'status' => DataMachineConversationStatus::BUDGET_EXCEEDED, 'turn_count' => 3 ),
+		''
+	),
+	'budget_exceeded with no error is a no-op',
+	$failures,
+	$passes
+);
+
+echo "\n[no-op] empty/absent status, no error:\n";
+assert_bool(
+	false,
+	DailyMemoryTask::isGenuineFailureResponse( array( 'turn_count' => 3 ), '' ),
+	'absent status is a no-op',
+	$failures,
+	$passes
+);
+assert_bool(
+	false,
+	DailyMemoryTask::isGenuineFailureResponse( array( 'status' => '' ), '' ),
+	'empty status string is a no-op',
+	$failures,
+	$passes
+);
+
+echo "\n[no-op] max_turns_reached diagnostic status, no error:\n";
+assert_bool(
+	false,
+	DailyMemoryTask::isGenuineFailureResponse(
+		array( 'status' => DataMachineConversationStatus::MAX_TURNS_REACHED ),
+		''
+	),
+	'max_turns_reached with no error is a no-op',
+	$failures,
+	$passes
+);
+
+echo "\n[no-op] runtime_tool_pending status, no error:\n";
+assert_bool(
+	false,
+	DailyMemoryTask::isGenuineFailureResponse(
+		array( 'status' => DataMachineConversationStatus::RUNTIME_TOOL_PENDING ),
+		''
+	),
+	'runtime_tool_pending with no error is a no-op',
+	$failures,
+	$passes
+);
+
+// ── GENUINE FAILURE cases (must fail the job) ─────────────────────────────
+
+echo "\n[fail] non-empty error string:\n";
+assert_bool(
+	true,
+	DailyMemoryTask::isGenuineFailureResponse(
+		array( 'status' => DataMachineConversationStatus::BUDGET_EXCEEDED ),
+		'provider request timed out'
+	),
+	'non-empty error string fails even with budget_exceeded status',
+	$failures,
+	$passes
+);
+
+echo "\n[fail] error_code present:\n";
+assert_bool(
+	true,
+	DailyMemoryTask::isGenuineFailureResponse(
+		array( 'status' => '', 'error_code' => 'provider_error' ),
+		''
+	),
+	'error_code fails the job',
+	$failures,
+	$passes
+);
+
+echo "\n[fail] hard failure status: failed:\n";
+assert_bool(
+	true,
+	DailyMemoryTask::isGenuineFailureResponse(
+		array( 'status' => DataMachineConversationStatus::FAILED ),
+		''
+	),
+	'failed status is a genuine failure',
+	$failures,
+	$passes
+);
+
+echo "\n[fail] hard failure status: interrupted (external interrupt, not budget):\n";
+assert_bool(
+	true,
+	DailyMemoryTask::isGenuineFailureResponse(
+		array( 'status' => DataMachineConversationStatus::INTERRUPTED ),
+		''
+	),
+	'interrupted status is a genuine failure',
+	$failures,
+	$passes
+);
+
+echo "\n[fail] legacy 'error' status literal:\n";
+assert_bool(
+	true,
+	DailyMemoryTask::isGenuineFailureResponse( array( 'status' => 'error' ), '' ),
+	"'error' status is a genuine failure",
+	$failures,
+	$passes
+);
+
+// ── Invariant: budget_exceeded is the divider ─────────────────────────────
+// The distinction that makes the whole fix correct: turn-budget exhaustion is
+// a no-op, external interruption is a failure. If a future refactor collapses
+// these two the daily-memory job starts failing every quiet day again.
+echo "\n[invariant] budget_exceeded != interrupted:\n";
+$budget_is_failure      = DailyMemoryTask::isGenuineFailureResponse( array( 'status' => DataMachineConversationStatus::BUDGET_EXCEEDED ), '' );
+$interrupted_is_failure = DailyMemoryTask::isGenuineFailureResponse( array( 'status' => DataMachineConversationStatus::INTERRUPTED ), '' );
+assert_bool(
+	true,
+	( false === $budget_is_failure ) && ( true === $interrupted_is_failure ),
+	'budget_exceeded is a no-op while interrupted is a failure',
+	$failures,
+	$passes
+);
+
+echo "\n---------------------------------------\n";
+$total = $passes + count( $failures );
+echo "{$passes} / {$total} passed\n";
+
+if ( ! empty( $failures ) ) {
+	echo "Failures:\n";
+	foreach ( $failures as $name ) {
+		echo "  - {$name}\n";
+	}
+	exit( 1 );
+}
+
+echo "All checks passed.\n";
+exit( 0 );


### PR DESCRIPTION
Fixes #2827

## Two-leg trace finding

A daily-memory run produces two jobs:

- a `system` **Daily Memory** job (`DailyMemoryTask::executeTask()` via the task processor), and
- a paired `pipeline_system_task` **Flow direct** job spawned by `SystemTaskStep::executeStep()` as a child of the pipeline job.

The relationship: `SystemTaskStep` creates the child `pipeline_system_task` job, runs the task body synchronously, then reads the child's `engine_data`/status back. If the child job's status is a failure (or the result packet carries `success=false`), the step emits a failure `system_task_result` packet, which `StepExecutionResult::classify()` turns into `packet_failure` → `ExecuteStepAbility` fires "Step execution failed - empty data packet". That is exactly the cascade in the issue's Jun 23–26 evidence: the **pre-#2783** `failJob()` failed the task leg, and the failed child then propagated `packet_failure` up the pipeline leg.

## Which leg was actually failing — and is it still?

**Neither, since the #2783 fix deployed (~Jun 27).** Verified on production (extrachill.com):

- Daily Memory `system` jobs today (9050–9054) all `completed`; their paired `pipeline_system_task` children all `completed`.
- `jobs list --status=failed --since=2026-06-27` shows **zero** `daily_memory_generation` failures (the only post-fix failures are unrelated "EC Agent Progress Ping" / kimaki-dispatch sudoers noise).

The #2783 guard fixes **both** legs: a no-op sets `skipped=true`, so `SystemTaskStep` marks `$success=true` and emits a **success** result packet, which `classify()` accepts — the pipeline leg completes instead of failing on an empty/failed packet.

The WAKE.md `daily_memory_generation ×6` warning is **stale rolling-window data** from the pre-fix Jun 25–26 failures (the wake briefing counts `status LIKE 'failed%'` grouped by `task_type` within its window), not new failures.

## The remaining real gap: observability + implicit classification

1. **A quiet no-op was silent.** The no-op success path logs at `info` (Logger gates on `datamachine_log_level`). Production runs `datamachine_log_level = error`, so info/warning logs are discarded by design — the log store holds **only** ERROR rows. That's why no "Daily memory no-op…" log ever appeared; it's a log-level config choice, not a swallowed log or a broken schedule.
2. **The guard classified by absence-from-a-denylist.** The `budget_exceeded` no-op worked only because that status happened not to be in the failure list — fragile and undocumented.

## The fix

- Extract the no-op vs genuine-failure decision into a single pure static `DailyMemoryTask::isGenuineFailureResponse()` (byte-identical behavior to the previous inline check: `failed`/`interrupted`/`error` + error string + `error_code`), with a docblock stating that turn-budget exhaustion (`budget_exceeded`) is a no-op while an external `interrupted` is a failure.
- Record an explicit `outcome => 'no_op'` and the resolved `status` on the completed no-op job. This is the durable, **level-independent** observability contract: a quiet day is visible via `wp datamachine jobs show <id>` and run-outcome metrics regardless of `datamachine_log_level`. The `info` log stays for verbose installs.
- Verify concern #3: turn-budget exhaustion returns `budget_exceeded` (not `interrupted`), so a legitimate no-op is never mis-failed. `interrupted` originates only from an external interrupt signal and is correctly treated as a failure.

No workaround at a higher layer — the change lives in `DailyMemoryTask` where the policy lives. No CHANGELOG or version-string edits.

## Test / lint output

New regression smoke `tests/daily-memory-noop-classification-smoke.php` (mirrors the repo's pure-PHP smoke pattern):

```
11 / 11 passed
All checks passed.
```

Existing daily-memory + system-task smokes still green:

```
daily-memory-unconfigured-model-skip-smoke   10 / 10 passed
daily-memory-conservation-smoke              31 / 31 passed
daily-memory-overflow-split-smoke            18 passed, 0 failed
daily-memory-store-seam-smoke                ok (24)
system-task-contract-smoke                   8 passed
system-task-output-packets-smoke             15 passed
systemtask-passthrough-smoke                 29 passed
corpus-system-tasks-smoke                    16 passed
```

phpcs on both changed files: clean (no output). `php -l`: no syntax errors.