### PR TITLE
fix: carry tool_call/tool_result parts through live agents/chat reply

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -424,10 +424,10 @@ class AgentsChatHandler {
 		}
 
 		$canonical = array(
-			'role'     => (string) $message['role'],
-			'content'  => $content,
-			'type'     => $type,
-			'payload'  => $payload,
+			'role'    => (string) $message['role'],
+			'content' => $content,
+			'type'    => $type,
+			'payload' => $payload,
 		);
 
 		if ( ! empty( $metadata ) ) {

--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -353,10 +353,18 @@ class AgentsChatHandler {
 	}
 
 	/**
-	 * Project Data Machine envelopes to the simple canonical message list.
+	 * Project Data Machine envelopes to the canonical message list.
+	 *
+	 * Text messages project to the plain `{role, content}` contract. Interactive
+	 * tool parts (`tool_call`/`tool_result` — e.g. a `present_question` choice
+	 * card or a confirmation/DiffCard button) are carried through with their
+	 * `type`, `payload`, and `metadata` preserved, matching the shape the
+	 * persisted transcript and the frontend renderer already consume on session
+	 * reload. This makes the live-turn projection equivalent to a reload so the
+	 * card renders on the turn it is produced instead of only after a reload.
 	 *
 	 * @param array $conversation Conversation messages.
-	 * @return array<int,array{role:string,content:string}>
+	 * @return array<int,array<string,mixed>>
 	 */
 	private function toCanonicalMessages( array $conversation ): array {
 		$messages = array();
@@ -366,7 +374,13 @@ class AgentsChatHandler {
 				continue;
 			}
 
-			if ( in_array( (string) ( $message['type'] ?? '' ), array( 'tool_call', 'tool_result' ), true ) ) {
+			$type = (string) ( $message['type'] ?? '' );
+
+			if ( in_array( $type, array( 'tool_call', 'tool_result' ), true ) ) {
+				$tool_message = $this->toCanonicalToolMessage( $message, $type );
+				if ( null !== $tool_message ) {
+					$messages[] = $tool_message;
+				}
 				continue;
 			}
 
@@ -381,5 +395,45 @@ class AgentsChatHandler {
 		}
 
 		return $messages;
+	}
+
+	/**
+	 * Project a tool_call/tool_result envelope into the canonical message shape.
+	 *
+	 * Preserves the interactive payload (tool_name, parameters, model-facing
+	 * tool_data, success) so the frontend can render the clickable card on the
+	 * live turn. Mirrors the persisted-transcript / session-reload projection so
+	 * both paths feed the renderer an identical envelope.
+	 *
+	 * @param array  $message Tool envelope from the conversation transcript.
+	 * @param string $type    Envelope type: `tool_call` or `tool_result`.
+	 * @return array<string,mixed>|null Canonical tool message, or null when unrenderable.
+	 */
+	private function toCanonicalToolMessage( array $message, string $type ): ?array {
+		$payload  = is_array( $message['payload'] ?? null ) ? $message['payload'] : array();
+		$metadata = is_array( $message['metadata'] ?? null ) ? $message['metadata'] : array();
+
+		$tool_name = (string) ( $payload['tool_name'] ?? $metadata['tool_name'] ?? '' );
+		if ( '' === $tool_name ) {
+			return null;
+		}
+
+		$content = $message['content'];
+		if ( ! is_string( $content ) && ! is_array( $content ) ) {
+			return null;
+		}
+
+		$canonical = array(
+			'role'     => (string) $message['role'],
+			'content'  => $content,
+			'type'     => $type,
+			'payload'  => $payload,
+		);
+
+		if ( ! empty( $metadata ) ) {
+			$canonical['metadata'] = $metadata;
+		}
+
+		return $canonical;
 	}
 }

--- a/tests/agents-chat-tool-continuation-smoke.php
+++ b/tests/agents-chat-tool-continuation-smoke.php
@@ -103,7 +103,101 @@ datamachine_agents_chat_tool_continuation_assert(
 			'content' => 'Here is the answer.',
 		),
 	) === $messages,
-	'Canonical Agents API chat output should omit internal tool call/result messages.'
+	'Canonical Agents API chat output should omit tool envelopes that carry no renderable tool_name.'
+);
+++ $assertions;
+
+// Interactive tool parts that carry a tool_name (e.g. present_question choice
+// cards, confirmation/DiffCard buttons) must be projected through to the
+// canonical messages[] on the live turn — preserving type, payload, and
+// metadata — so the frontend renders the clickable card on the sending turn
+// instead of only after a session reload. This is the fix for the dead-loop
+// where the model references a card the client never received.
+$interactive_messages = $method->invoke(
+	$handler,
+	array(
+		array(
+			'role'    => 'user',
+			'type'    => 'text',
+			'content' => 'Should I proceed?',
+		),
+		array(
+			'role'     => 'assistant',
+			'type'     => 'tool_call',
+			'content'  => 'AI ACTION (Turn 1): Executing Present Question.',
+			'payload'  => array(
+				'tool_name'  => 'present_question',
+				'parameters' => array(
+					'question' => 'Which surface?',
+				),
+				'turn'       => 1,
+			),
+			'metadata' => array(
+				'timestamp' => '2026-07-03T00:00:00+00:00',
+			),
+		),
+		array(
+			'role'    => 'user',
+			'type'    => 'tool_result',
+			'content' => 'TOOL RESPONSE (Turn 1): SUCCESS.',
+			'payload' => array(
+				'tool_name' => 'present_question',
+				'success'   => true,
+				'tool_data' => array(
+					'question' => 'Which surface?',
+					'choices'  => array(
+						array(
+							'label'   => 'Platform',
+							'message' => 'Platform',
+						),
+						array(
+							'label'   => 'UX',
+							'message' => 'UX',
+						),
+					),
+				),
+			),
+		),
+		array(
+			'role'    => 'assistant',
+			'type'    => 'text',
+			'content' => 'Click a choice on the card above.',
+		),
+	)
+);
+
+datamachine_agents_chat_tool_continuation_assert(
+	4 === count( $interactive_messages ),
+	'Interactive tool parts with a tool_name must be carried through into canonical messages[] on the live turn.'
+);
+++ $assertions;
+
+datamachine_agents_chat_tool_continuation_assert(
+	'tool_call' === ( $interactive_messages[1]['type'] ?? null )
+		&& 'present_question' === ( $interactive_messages[1]['payload']['tool_name'] ?? null )
+		&& 'assistant' === ( $interactive_messages[1]['role'] ?? null ),
+	'Live-turn tool_call projection preserves type, role, and tool_name for the frontend renderer.'
+);
+++ $assertions;
+
+datamachine_agents_chat_tool_continuation_assert(
+	'tool_result' === ( $interactive_messages[2]['type'] ?? null )
+		&& true === ( $interactive_messages[2]['payload']['success'] ?? null )
+		&& 2 === count( $interactive_messages[2]['payload']['tool_data']['choices'] ?? array() ),
+	'Live-turn tool_result projection preserves the interactive tool_data payload (question/choices).'
+);
+++ $assertions;
+
+datamachine_agents_chat_tool_continuation_assert(
+	array( 'timestamp' => '2026-07-03T00:00:00+00:00' ) === ( $interactive_messages[1]['metadata'] ?? null ),
+	'Live-turn tool projection preserves envelope metadata when present.'
+);
+++ $assertions;
+
+datamachine_agents_chat_tool_continuation_assert(
+	'Click a choice on the card above.' === ( $interactive_messages[3]['content'] ?? null )
+		&& ! isset( $interactive_messages[3]['type'] ),
+	'Plain text messages retain the {role, content} contract unchanged alongside tool parts.'
 );
 ++ $assertions;
 

--- a/tests/agents-chat-tool-continuation-smoke.php
+++ b/tests/agents-chat-tool-continuation-smoke.php
@@ -107,12 +107,14 @@ datamachine_agents_chat_tool_continuation_assert(
 );
 ++ $assertions;
 
-// Interactive tool parts that carry a tool_name (e.g. present_question choice
-// cards, confirmation/DiffCard buttons) must be projected through to the
-// canonical messages[] on the live turn — preserving type, payload, and
-// metadata — so the frontend renders the clickable card on the sending turn
-// instead of only after a session reload. This is the fix for the dead-loop
-// where the model references a card the client never received.
+/*
+ * Interactive tool parts that carry a tool_name (e.g. present_question choice
+ * cards, confirmation/DiffCard buttons) must be projected through to the
+ * canonical messages[] on the live turn — preserving type, payload, and
+ * metadata — so the frontend renders the clickable card on the sending turn
+ * instead of only after a session reload. This is the fix for the dead-loop
+ * where the model references a card the client never received.
+ */
 $interactive_messages = $method->invoke(
 	$handler,
 	array(


### PR DESCRIPTION
## Summary

The synchronous `agents/chat` reply projection stripped every `tool_call` and `tool_result` message before returning canonical `messages[]` to the client. As a result, interactive tool parts (`present_question` choice cards, confirmation/DiffCard buttons) never reached the frontend on the turn they were produced. The model would reference a card the client never received, the agent waited for a click that could never happen, and the conversation dead-looped.

**Fixes #2830.**

## Root cause

**File:** `inc/Abilities/Chat/AgentsChatHandler.php`
**Method:** `toCanonicalMessages()` (was ~lines 361–384)

```php
if ( in_array( (string) ( $message['type'] ?? '' ), array( 'tool_call', 'tool_result' ), true ) ) {
    continue;   // <-- dropped the interactive tool part (e.g. present_question card)
}
```

`toCanonicalOutput()` (~line 270) calls it to build `messages[]` for the `agents/chat` ability response, so the projected messages were text-only. The interactive payload (question + choices) lives only inside the dropped `tool_result` envelope, so the frontend never received it on the live turn.

## The reload-vs-live asymmetry that proves the fix

The transcript **store** already persists the tool_result correctly: `ConversationManager::formatToolResultMessage()` (`inc/Engine/AI/ConversationManager.php` ~line 158) builds a full `tool_result` envelope via `WP_Agent_Message::toolResult()` — `{ type, role, content, payload: { tool_name, tool_data, success, ... }, metadata }` — with the model-facing `question`/`choices` payload from `modelFacingToolData()`.

On **session reload**, `frontend-agent-chat` `inc/rest.php` `frontend_agent_chat_session_messages()` (~line 1017) detects `type` = `tool_call`/`tool_result` and routes each through `frontend_agent_chat_tool_message()` (~line 1265), which reads `message['type']`, `message['payload']` (`tool_name`, `parameters`, `tool_data`, `success`) and `message['metadata']` to render the clickable card.

So the store and renderer already speak the full-envelope shape — **only** the synchronous live-reply projection in `toCanonicalMessages()` was lossy. Reload rendered the card; the live turn did not. That asymmetry is the proof the fix belongs exactly here.

## What changed

- `toCanonicalMessages()` no longer discards `tool_call`/`tool_result` messages. Text messages keep the plain `{role, content}` contract unchanged (additive/parallel handling).
- New private `toCanonicalToolMessage()` projects a tool envelope into the canonical shape, preserving `role`, `content`, `type`, `payload` (with `tool_name`, `parameters`, `tool_data`, `success`), and `metadata` when present — matching the persisted-transcript / session-reload shape the frontend renderer already consumes. The live turn is now projection-equivalent to a reload.
- Tool envelopes with no renderable `tool_name` are still omitted (nothing for the client to render).

No layer boundaries crossed: agents-api already models these as first-class parts, and frontend-agent-chat already renders them — this only stops Data Machine's live projection from dropping them.

## Tests / lint

- `tests/agents-chat-tool-continuation-smoke.php` — updated the obsolete "omit tool messages" assertion and added coverage that interactive tool parts with a `tool_name` are carried through on the live turn with `type`, `role`, `tool_name`, `tool_data` (question/choices), and `metadata` preserved, while plain text keeps the `{role, content}` contract. **17 assertions pass.**
- `php tests/agents-chat-handler-smoke.php` — 22 passed, 0 failed.
- `agents-chat-access-permission-smoke`, `chat-session-canonical-path-smoke`, `chat-list-message-count-smoke` — all pass.
- `vendor/bin/phpcs` on both changed files — clean (exit 0).
- `php -l` on both changed files — no syntax errors.

Note: `homeboy test data-machine` could not run in this environment — it aborts during harness setup with `wp-codebox was found, but no candidate passed 'wp-codebox --version'` (a stale host wrapper), so no tests executed under it. The repo's PHP smoke suite was run directly instead and passes.