### PR TITLE
ci: stop broken upstream wp-codebox from blocking PRs (#2840)

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -20,9 +20,37 @@ jobs:
   homeboy:
     if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'release:') }}
     uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2
+    # TEMPORARY (2026-07-03): `test` is dropped from the pull_request command set
+    # because CI's WP Codebox runtime is broken upstream. CI builds the WP Codebox
+    # CLI from `Automattic/wp-codebox@main` on every run (the release artifact is not
+    # published, so setup falls back to a source install — see homeboy-extensions
+    # wordpress/scripts/build/setup.sh: `ref="${HOMEBOY_WP_CODEBOX_REF:-main}"`).
+    # An upstream regression (wp-codebox PR #1698 "canonical-input-mount-paths",
+    # commit 242e36f8, merged ~2026-07-03 00:34 UTC) breaks composer autoloading of
+    # mounted plugin classes inside the Playground runtime, so phpunit crashes at
+    # collection with `Class "DataMachine\Core\OAuth\BaseAuthProvider" not found`.
+    # This is NOT a data-machine bug — an untouched-main canary reproduces it
+    # (see #2840). The known-good WP Codebox ref is tag `v0.12.0` (commit 536fc6fd,
+    # 2026-07-02 19:37 UTC), which predates the breaking merge and matches the last
+    # green data-machine run (1370 tests passing, 2026-07-02).
+    #
+    # We cannot pin the ref from this repo: `HOMEBOY_WP_CODEBOX_REF` is a process env
+    # var consumed inside the homeboy-action reusable workflow's job, and a reusable
+    # workflow invoked via `uses:` does not inherit the caller's `env:`. Neither the
+    # reusable workflow (ci.yml@v2) nor the composite action expose a codebox-ref
+    # input, and no homeboy.json `--setting` feeds it. The only repo-controllable
+    # lever is which command legs run — so `test` is removed from `pull_request` to
+    # stop the phantom red Test check from blocking PRs, while `audit` + `lint`
+    # continue to gate. `push`/`workflow_dispatch` still run `test` so the upstream
+    # breakage stays visible on main/manual runs without blocking contributors.
+    #
+    # REVERT once the upstream wp-codebox fix lands (or a pinned release artifact is
+    # published): restore `test` to the pull_request command set below (i.e. change
+    # the pull_request branch back to 'audit,lint,test' for both `commands` and
+    # `expected-commands`).
     with:
-      commands: ${{ github.event_name == 'pull_request' && 'audit,lint,test' || github.event_name == 'workflow_dispatch' && 'audit,lint,test' || 'test' }}
-      expected-commands: ${{ github.event_name == 'pull_request' && 'audit,lint,test' || github.event_name == 'workflow_dispatch' && 'audit,lint,test' || 'test' }}
+      commands: ${{ github.event_name == 'pull_request' && 'audit,lint' || github.event_name == 'workflow_dispatch' && 'audit,lint,test' || 'test' }}
+      expected-commands: ${{ github.event_name == 'pull_request' && 'audit,lint' || github.event_name == 'workflow_dispatch' && 'audit,lint,test' || 'test' }}
       autofix: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
       autofix-commands: 'lint --fix'
     secrets: inherit


### PR DESCRIPTION
## Summary

Makes data-machine's `homeboy / Test` CI check trustworthy again after an upstream WP Codebox regression started crashing it on **every** PR (see #2840). This is a **TEMPORARY stopgap** to be reverted once the upstream fix lands.

## What was pinned / changed, and where

The intended fix — pinning the WP Codebox source install to a known-good ref — **cannot be done from this repo.** The controlling knob is a process env var, `HOMEBOY_WP_CODEBOX_REF`, consumed inside `homeboy-extensions/wordpress/scripts/build/setup.sh`:

```sh
source="${HOMEBOY_WP_CODEBOX_SOURCE:-https://github.com/Automattic/wp-codebox.git}"
ref="${HOMEBOY_WP_CODEBOX_REF:-main}"
...
git -C "${repo_dir}" fetch --quiet origin "${ref}"
git -C "${repo_dir}" checkout --quiet FETCH_HEAD
```

That `setup.sh` runs **inside the `Extra-Chill/homeboy-action` reusable workflow's job** (`.github/workflows/homeboy.yml` calls `Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2`). A reusable workflow invoked via `uses:` does **not** inherit the caller workflow's `env:`, and:

- the reusable workflow (`ci.yml@v2`) exposes **no** codebox-ref input,
- the composite `action.yml` exposes **no** codebox-ref input,
- no `homeboy.json` setting or `homeboy test --setting` key feeds `HOMEBOY_WP_CODEBOX_REF`.

So there is no repo-local surface through which data-machine can inject the pin. A real ref-pin has to happen upstream (in homeboy-extensions/homeboy-action config or by publishing a pinned release artifact), not here.

**The change this repo *can* make** — and does, in `.github/workflows/homeboy.yml` — is to drop the `test` leg from the `pull_request` command set so the phantom red **Test** check stops blocking PRs, while `audit` + `lint` keep gating. `push` and `workflow_dispatch` still run `test`, so the upstream breakage stays visible on main / manual runs without blocking contributors. A loud `TEMPORARY` comment at the change site documents the root cause, the known-good ref, and the exact revert.

## Known-good ref (for the eventual upstream pin / revert)

- **wp-codebox `v0.12.0` = commit `536fc6fd`** (2026-07-02 19:37 UTC).
- Predates the breaking merge `242e36f8` (wp-codebox PR #1698 "canonical-input-mount-paths", ~2026-07-03 00:34 UTC).
- Postdates the last green data-machine run (1370 tests passing, 2026-07-02).

## Root cause (not a data-machine bug)

CI's WP Codebox release artifact is unpublished, so setup falls back to a **source install of `Automattic/wp-codebox@main` rebuilt from tip every run**. The #1698 regression breaks composer autoloading of mounted plugin classes inside the Playground runtime, so phpunit crashes during **collection**:

```
Class "DataMachine\Core\OAuth\BaseAuthProvider" not found
```

An untouched-`main` canary reproduces this (#2840), proving it is infra, not repo code. A separate PR is being filed upstream against `Automattic/wp-codebox` to fix the mount-path autoload regression at the root.

## Resulting Test CI status

With `test` removed from the `pull_request` set, this PR's checks are `audit` + `lint` only — the crashing `Test` leg no longer runs on PRs, so it can no longer show a phantom red. This is the honest limitation: the repo cannot pin the ref, only stop the broken leg from blocking PRs.

## Revert plan

Once the upstream wp-codebox fix lands (or a pinned release artifact is published), restore `test` to the `pull_request` branch of both `commands` and `expected-commands` in `.github/workflows/homeboy.yml` (back to `audit,lint,test`). Refs #2840, wp-codebox #1698.