### PR TITLE
fix: attach default agent owner to system-triggered media/SEO task enqueues

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -848,6 +848,49 @@ function datamachine_resolve_or_create_agent_id( int $user_id ): int {
 }
 
 /**
+ * Resolve the acting agent identity for a system/ability-triggered operation.
+ *
+ * Media, SEO, and linking abilities enqueue agent-owned queued tasks (alt text,
+ * meta descriptions, image optimization, internal linking). Those tasks require
+ * a real agent owner in TaskScheduler — a queued task with agent_id/user_id 0 is
+ * rejected by the agent-context gate before it ever runs.
+ *
+ * The historical pattern resolved identity solely from get_current_user_id(),
+ * which returns 0 whenever the ability runs outside an authenticated web request
+ * — WP-Cron, WP-CLI without --user, or a system pipeline step. That produced a
+ * zeroed context and a flood of "queued task requires agent context" rejections,
+ * one per batched item. This helper closes that gap by falling back to the
+ * install's default agent user (DirectoryManager::get_default_agent_user_id())
+ * when no user is present in the request, mirroring how the rest of the
+ * single-agent surface resolves an owner.
+ *
+ * @since 0.72.0
+ *
+ * @return array{user_id:int,agent_id:int} Acting user id and its agent id. Both
+ *                                          may be 0 only when the install has no
+ *                                          resolvable owner at all.
+ */
+function datamachine_resolve_system_agent_context(): array {
+	$user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
+
+	// No authenticated user (cron / CLI / system pipeline): fall back to the
+	// install's default agent owner so agent-owned queued tasks carry a real
+	// identity into TaskScheduler instead of a zeroed, gate-rejected context.
+	if ( $user_id <= 0 && class_exists( \DataMachine\Core\FilesRepository\DirectoryManager::class ) ) {
+		$user_id = (int) \DataMachine\Core\FilesRepository\DirectoryManager::get_default_agent_user_id();
+	}
+
+	$agent_id = ( $user_id > 0 && function_exists( 'datamachine_resolve_or_create_agent_id' ) )
+		? datamachine_resolve_or_create_agent_id( $user_id )
+		: 0;
+
+	return array(
+		'user_id'  => $user_id,
+		'agent_id' => $agent_id,
+	);
+}
+
+/**
  * Run a callback for every site on the network.
  *
  * Switches to each site, runs the callback, then restores. Used by

--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -510,8 +510,9 @@ class InternalLinkingAbilities {
 		$dry_run        = ! empty( $input['dry_run'] );
 		$force          = ! empty( $input['force'] );
 
-		$user_id         = get_current_user_id();
-		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
+		$acting          = datamachine_resolve_system_agent_context();
+		$user_id         = $acting['user_id'];
+		$agent_id        = $acting['agent_id'];
 		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];

--- a/inc/Abilities/Media/AltTextAbilities.php
+++ b/inc/Abilities/Media/AltTextAbilities.php
@@ -137,8 +137,9 @@ class AltTextAbilities {
 		$post_id       = absint( $input['post_id'] ?? 0 );
 		$force         = ! empty( $input['force'] );
 
-		$user_id         = get_current_user_id();
-		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
+		$acting          = datamachine_resolve_system_agent_context();
+		$user_id         = $acting['user_id'];
+		$agent_id        = $acting['agent_id'];
 		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
@@ -353,8 +354,9 @@ class AltTextAbilities {
 			return;
 		}
 
-		$user_id         = get_current_user_id();
-		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
+		$acting          = datamachine_resolve_system_agent_context();
+		$user_id         = $acting['user_id'];
+		$agent_id        = $acting['agent_id'];
 		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];

--- a/inc/Abilities/Media/ImageGenerationAbilities.php
+++ b/inc/Abilities/Media/ImageGenerationAbilities.php
@@ -325,8 +325,9 @@ class ImageGenerationAbilities {
 	 * @return string|null Refined prompt on success, null on failure.
 	 */
 	public static function refine_prompt( string $raw_prompt, string $post_context = '', array $config = array() ): ?string {
-		$user_id         = get_current_user_id();
-		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
+		$acting          = datamachine_resolve_system_agent_context();
+		$user_id         = $acting['user_id'];
+		$agent_id        = $acting['agent_id'];
 		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
@@ -423,8 +424,8 @@ class ImageGenerationAbilities {
 		}
 
 		// Must have a DM AI provider configured.
-		$user_id         = get_current_user_id();
-		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
+		$acting          = datamachine_resolve_system_agent_context();
+		$agent_id        = $acting['agent_id'];
 		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 
 		return ! empty( $system_defaults['provider'] ) && ! empty( $system_defaults['model'] );

--- a/inc/Abilities/Media/ImageOptimizationAbilities.php
+++ b/inc/Abilities/Media/ImageOptimizationAbilities.php
@@ -340,8 +340,9 @@ class ImageOptimizationAbilities {
 			);
 		}
 
-		$user_id  = get_current_user_id();
-		$agent_id = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
+		$acting   = datamachine_resolve_system_agent_context();
+		$user_id  = $acting['user_id'];
+		$agent_id = $acting['agent_id'];
 
 		$batch = TaskScheduler::scheduleBatch(
 			'image_optimization',

--- a/inc/Abilities/SEO/MetaDescriptionAbilities.php
+++ b/inc/Abilities/SEO/MetaDescriptionAbilities.php
@@ -134,8 +134,9 @@ class MetaDescriptionAbilities {
 		$limit     = absint( $input['limit'] ?? 50 );
 		$force     = ! empty( $input['force'] );
 
-		$user_id         = get_current_user_id();
-		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
+		$acting          = datamachine_resolve_system_agent_context();
+		$user_id         = $acting['user_id'];
+		$agent_id        = $acting['agent_id'];
 		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];

--- a/tests/system-agent-context-resolution-smoke.php
+++ b/tests/system-agent-context-resolution-smoke.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Pure-PHP smoke test for datamachine_resolve_system_agent_context().
+ *
+ * Run with: php tests/system-agent-context-resolution-smoke.php
+ *
+ * Regression coverage for the "queued task requires agent context" flood
+ * produced when media/SEO/linking abilities enqueued agent-owned batch tasks
+ * (alt_text_generation, image_optimization, meta_description_generation,
+ * internal_linking) from a context with no authenticated user — WP-Cron,
+ * WP-CLI without --user, or a system pipeline step.
+ *
+ * The old resolution resolved identity solely from get_current_user_id(),
+ * which returns 0 outside a web request. That zeroed the enqueue context, so
+ * every batched item hit TaskScheduler's agent-context gate and was rejected
+ * (one ERROR log line per item). The fix teaches the enqueue path to fall back
+ * to the install's default agent owner via
+ * DirectoryManager::get_default_agent_user_id().
+ *
+ * This test verifies the resolver's decision table without a WP bootstrap by
+ * mirroring its production logic byte-for-byte in a harness whose two inputs
+ * (current-user id, default-agent user id → agent id) are injectable.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+// ─── Harness mirroring datamachine_resolve_system_agent_context() ────
+//
+// Mirrors data-machine.php:datamachine_resolve_system_agent_context().
+// The two collaborators the real function calls — get_current_user_id() and
+// DirectoryManager::get_default_agent_user_id() — are supplied as inputs, and
+// the user_id → agent_id resolution (datamachine_resolve_or_create_agent_id)
+// is supplied as a closure so the branch logic is exercised in isolation.
+//
+// @param int      $current_user_id  What get_current_user_id() would return.
+// @param int      $default_user_id  What DirectoryManager::get_default_agent_user_id() would return.
+// @param callable $resolve_agent_id user_id => agent_id (0 for unresolvable users).
+function resolve_system_agent_context_for_test( int $current_user_id, int $default_user_id, callable $resolve_agent_id ): array {
+	$user_id = $current_user_id;
+
+	// No authenticated user: fall back to the install's default agent owner.
+	if ( $user_id <= 0 ) {
+		$user_id = $default_user_id;
+	}
+
+	$agent_id = $user_id > 0 ? (int) $resolve_agent_id( $user_id ) : 0;
+
+	return array(
+		'user_id'  => $user_id,
+		'agent_id' => $agent_id,
+	);
+}
+
+/**
+ * Mirror of TaskScheduler's agent-context gate for a task that
+ * requiresAgentContext() === true: reject when neither agent_id nor
+ * agent_slug is present in the enqueue context.
+ */
+function task_scheduler_gate_for_test( array $context ): bool {
+	return ! empty( $context['agent_slug'] ) || ! empty( $context['agent_id'] );
+}
+
+// ─── Tiny assertion helpers ─────────────────────────────────────────
+
+$failures = 0;
+$total    = 0;
+
+$assert = function ( string $label, bool $cond ) use ( &$failures, &$total ): void {
+	$total++;
+	if ( $cond ) {
+		echo "  [PASS] {$label}\n";
+	} else {
+		$failures++;
+		echo "  [FAIL] {$label}\n";
+	}
+};
+
+// Single-agent install: default owner is user 1 → agent 1.
+$resolve = static function ( int $user_id ): int {
+	$map = array( 1 => 1, 7 => 25 ); // owner_id => agent_id
+	return $map[ $user_id ] ?? 0;
+};
+
+// ─── Test cases ─────────────────────────────────────────────────────
+
+echo "\n[1] Authenticated web request resolves the current user's agent\n";
+$ctx = resolve_system_agent_context_for_test( 7, 1, $resolve );
+$assert( 'user_id is the current user', 7 === $ctx['user_id'] );
+$assert( 'agent_id resolved for current user', 25 === $ctx['agent_id'] );
+$assert( 'enqueue context passes the agent-context gate', task_scheduler_gate_for_test( $ctx ) );
+
+echo "\n[2] Cron/CLI/system context (no current user) falls back to default agent owner\n";
+$ctx = resolve_system_agent_context_for_test( 0, 1, $resolve );
+$assert( 'user_id falls back to default agent user', 1 === $ctx['user_id'] );
+$assert( 'agent_id resolved from default owner', 1 === $ctx['agent_id'] );
+$assert(
+	'REGRESSION: fallback context is NOT gate-rejected (was agent_id 0 before fix)',
+	task_scheduler_gate_for_test( $ctx )
+);
+
+echo "\n[3] Old behaviour would have produced a zeroed, gate-rejected context\n";
+// Before the fix, a no-user context resolved to user_id 0 / agent_id 0.
+$old_ctx = array( 'user_id' => 0, 'agent_id' => 0 );
+$assert(
+	'old zeroed context is exactly what the gate rejected',
+	false === task_scheduler_gate_for_test( $old_ctx )
+);
+
+echo "\n[4] Install with no resolvable owner at all still returns zeros (no fatal)\n";
+$ctx = resolve_system_agent_context_for_test( 0, 0, $resolve );
+$assert( 'user_id is 0 when no default owner exists', 0 === $ctx['user_id'] );
+$assert( 'agent_id is 0 when no default owner exists', 0 === $ctx['agent_id'] );
+
+echo "\n[5] Production sources use the shared resolver, not raw get_current_user_id()\n";
+$root    = dirname( __DIR__ );
+$sources = array(
+	'AltTextAbilities'          => $root . '/inc/Abilities/Media/AltTextAbilities.php',
+	'ImageOptimizationAbilities' => $root . '/inc/Abilities/Media/ImageOptimizationAbilities.php',
+	'ImageGenerationAbilities'  => $root . '/inc/Abilities/Media/ImageGenerationAbilities.php',
+	'MetaDescriptionAbilities'  => $root . '/inc/Abilities/SEO/MetaDescriptionAbilities.php',
+	'InternalLinkingAbilities'  => $root . '/inc/Abilities/InternalLinkingAbilities.php',
+);
+foreach ( $sources as $name => $path ) {
+	$src = (string) file_get_contents( $path );
+	$assert( "{$name} calls datamachine_resolve_system_agent_context()", str_contains( $src, 'datamachine_resolve_system_agent_context()' ) );
+	$assert(
+		"{$name} no longer resolves system-task agent id from a user-gated ternary",
+		! str_contains( $src, 'datamachine_resolve_or_create_agent_id( $user_id ) : 0' )
+	);
+}
+
+echo "\n[6] The resolver is defined and documents the cron/CLI fallback\n";
+$plugin_src = (string) file_get_contents( $root . '/data-machine.php' );
+$assert( 'datamachine_resolve_system_agent_context() defined', str_contains( $plugin_src, 'function datamachine_resolve_system_agent_context(): array' ) );
+$assert( 'resolver falls back to the default agent user', str_contains( $plugin_src, 'get_default_agent_user_id()' ) );
+
+echo "\n";
+if ( $failures > 0 ) {
+	echo "=== system-agent-context-resolution-smoke: {$failures}/{$total} FAILED ===\n";
+	exit( 1 );
+}
+echo "=== system-agent-context-resolution-smoke: ALL PASS ({$total} assertions) ===\n";


### PR DESCRIPTION
## Summary

Fixes the recurring **\"TaskScheduler: queued task requires agent context\"** ERROR flood on production (87 rejections in a single tick, 2026-07-03 00:44–00:45). The scoped brief pointed at `daily_memory_generation`, but production evidence shows the live, ongoing failure is actually **`alt_text_generation`** (and its media/SEO/linking siblings). The daily-memory piece was a red herring already fixed on `main` — details below.

## The exact enqueue path that was missing agent identity

`inc/Abilities/Media/AltTextAbilities.php` (and five sibling call sites) resolved the acting identity like this:

```php
$user_id  = get_current_user_id();
$agent_id = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0
    ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
// ...
TaskScheduler::scheduleBatch( 'alt_text_generation', $item_params, array(
    'user_id' => $user_id, 'agent_id' => $agent_id,
) );
```

The affected enqueue sites:

- `inc/Abilities/Media/AltTextAbilities.php` — `generateAltText()` (batch) + `queueAttachmentAltText()`
- `inc/Abilities/Media/ImageOptimizationAbilities.php` — `optimizeImages()` (batch)
- `inc/Abilities/Media/ImageGenerationAbilities.php` — `refine_prompt()` + provider preflight
- `inc/Abilities/SEO/MetaDescriptionAbilities.php` — `generateMetaDescriptions()` (batch)
- `inc/Abilities/InternalLinkingAbilities.php` — `crosslink` generation (batch)

## Why it was missing (root cause)

`get_current_user_id()` returns `0` whenever the ability runs **outside an authenticated web request** — WP-Cron, WP-CLI without `--user`, or a system pipeline step. With `$user_id === 0` the ternary short-circuits `$agent_id` to `0`, so the whole batch is scheduled with `user_id: 0, agent_id: 0`. `TaskScheduler::scheduleBatch()` persists that context in the batch parent's `engine_data` and re-schedules it for **every chunk item**. Each item then reaches `TaskScheduler::schedule()`, whose agent-context gate (`inc/Engine/Tasks/TaskScheduler.php:210`) correctly rejects an ownerless queued task — logging `error_code: task_scheduler_agent_context_required` once per item. A single bulk alt-text run produced the 87-line burst.

## The fix and why it lives at this layer

Added `datamachine_resolve_system_agent_context()` (in `data-machine.php`, next to the existing `datamachine_resolve_or_create_agent_id()`), which resolves the acting user from `get_current_user_id()` and, when that is `0`, **falls back to the install's default agent owner** via `DirectoryManager::get_default_agent_user_id()` before resolving the agent id. All six call sites now route through it.

The defect is in the **enqueue path**, so that is where the fix lives. The agent-context gate in `TaskScheduler` is *correct* to reject a genuinely ownerless queued task (the docblock at `TaskScheduler.php:179-182` is explicit that queued work must have a real agent owner) — papering over it there, or flipping `requiresAgentContext()` to `false` for these tasks, would silently strip ownership from real content-mutating work. Teaching the enqueue path to resolve the single-agent owner mirrors how the per-agent recurring fan-out (`SystemAgentServiceProvider`) already supplies identity.

## Is the `daily_memory` \"completion policy not satisfied / MEMORY.md unchanged\" (job 5381) the same root cause? — **Distinct, and already fixed.**

Verified against production:

- The `daily_memory_generation` \"completion policy was not satisfied\" failures (jobs 5371/5373/5381) are from **June 25–26** and are a **different** signature from the agent-context gate.
- They were already resolved on `main` by `bdd9e132` (\"treat daily-memory no-op as success instead of hard failure\", 2026-06-25) and hardened by `a52a7d10` (\"harden daily-memory no-op classification\", 2026-07-02) — both present in HEAD. Daily memory has run cleanly since (last attempt 2026-07-03 00:12, no failed job).
- The per-agent daily-memory fan-out already attaches a valid `agent_id`/`user_id` for all 22 active agents, so daily memory does **not** hit the agent-context gate.
- Note: the Wake Briefing's \"`daily_memory_generation` ×6\" flag is counting those **stale June failures** as if in the 24h window — a wake-briefing counting-window question, tracked separately, not fixed here.

## Test coverage added

`tests/system-agent-context-resolution-smoke.php` (pure-PHP, no WP bootstrap; matches `system-task-agent-context-smoke.php` conventions) — 21 assertions covering:

- Authenticated request → current user's agent; passes the gate.
- **Regression:** no-user (cron/CLI/system) context → falls back to default agent owner and now **passes** the gate (previously `agent_id: 0` → rejected).
- The old zeroed context is exactly what the gate rejects.
- No-owner install still returns zeros without fataling.
- All five production call sites use the shared resolver and no longer use the user-gated ternary.

Verification:
- \`php tests/system-agent-context-resolution-smoke.php\` → ALL PASS (21).
- \`php tests/system-task-agent-context-smoke.php\` → ALL PASS (47, no regression).
- \`php -l\` clean on all six edited files.