### PR TITLE
ci: use review quality commands

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -21,8 +21,8 @@ jobs:
     if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'release:') }}
     uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2
     with:
-      commands: ${{ github.event_name == 'pull_request' && 'audit,lint,test' || github.event_name == 'workflow_dispatch' && 'audit,lint,test' || 'test' }}
-      expected-commands: ${{ github.event_name == 'pull_request' && 'audit,lint,test' || github.event_name == 'workflow_dispatch' && 'audit,lint,test' || 'test' }}
+      commands: ${{ github.event_name == 'pull_request' && 'review audit,review lint,review test' || github.event_name == 'workflow_dispatch' && 'review audit,review lint,review test' || 'review test' }}
+      expected-commands: ${{ github.event_name == 'pull_request' && 'review audit,review lint,review test' || github.event_name == 'workflow_dispatch' && 'review audit,review lint,review test' || 'review test' }}
       autofix: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
-      autofix-commands: 'lint --fix'
+      autofix-commands: 'review lint --fix'
     secrets: inherit


### PR DESCRIPTION
Part of the review-pillar vocabulary cut (Extra-Chill/homeboy#7456, homeboy#7590).

Updates Homeboy workflow command inputs and autofix commands to the review-nested vocabulary accepted by homeboy-action v2.8.6.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Applied the workflow vocabulary update and prepared this PR.