### PR TITLE
fix: make generic content-publishing tools opt-in for pipeline AI steps

### DIFF
--- a/inc/Abilities/Content/InsertContentAbility.php
+++ b/inc/Abilities/Content/InsertContentAbility.php
@@ -97,9 +97,14 @@ class InsertContentAbility {
 			'datamachine_tools',
 			function ( $tools ) {
 				$tools['insert_content'] = array(
-					'_callable' => array( self::class, 'getChatTool' ),
-					'modes'     => array( 'chat', 'pipeline', 'system', 'editor' ),
-					'ability'   => 'datamachine/insert-content',
+					'_callable'                => array( self::class, 'getChatTool' ),
+					'modes'                    => array( 'chat', 'pipeline', 'system', 'editor' ),
+					'ability'                  => 'datamachine/insert-content',
+					// Generic content-writing tools are opt-in for pipeline AI
+					// steps so a model cannot improvise arbitrary publishes that
+					// bypass the flow's declared handler. Chat/system/editor
+					// unaffected. See data-machine#2852.
+					'requires_pipeline_opt_in' => true,
 				);
 				return $tools;
 			}

--- a/inc/Abilities/Content/UpsertPostAbility.php
+++ b/inc/Abilities/Content/UpsertPostAbility.php
@@ -198,9 +198,14 @@ class UpsertPostAbility {
 			'datamachine_tools',
 			function ( array $tools ): array {
 				$tools['upsert_post'] = array(
-					'_callable' => array( self::class, 'getChatTool' ),
-					'modes'     => array( 'chat', 'pipeline', 'system' ),
-					'ability'   => self::ABILITY_NAME,
+					'_callable'                => array( self::class, 'getChatTool' ),
+					'modes'                    => array( 'chat', 'pipeline', 'system' ),
+					'ability'                  => self::ABILITY_NAME,
+					// Generic content-writing tools are opt-in for pipeline AI
+					// steps so a model cannot improvise arbitrary publishes that
+					// bypass the flow's declared handler. Chat/system unaffected.
+					// See https://github.com/Extra-Chill/data-machine/issues/2852.
+					'requires_pipeline_opt_in' => true,
 				);
 				return $tools;
 			}

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -150,7 +150,7 @@ class ToolManager {
 		if ( ! empty( $modes ) ) {
 			$resolved['modes'] = $modes;
 		}
-		foreach ( array( 'ability', 'abilities', 'access_level', 'requires_opt_in' ) as $key ) {
+		foreach ( array( 'ability', 'abilities', 'access_level', 'requires_opt_in', 'requires_pipeline_opt_in' ) as $key ) {
 			if ( isset( $meta[ $key ] ) ) {
 				$resolved[ $key ] = $meta[ $key ];
 			}

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -11,9 +11,10 @@
  * 2. Per-agent tool policy (deny/allow mode from agent_config, supports categories)
  * 3. Ability category filter (narrows tools by their linked ability's category)
  * 4. Context-level allow_only (narrows to explicit subset)
- * 5. Context preset (pipeline/chat/system)
- * 6. Global enablement settings
- * 7. Tool configuration requirements
+ * 5. Pipeline content-writing opt-in (generic write tools excluded by default)
+ * 6. Context preset (pipeline/chat/system)
+ * 7. Global enablement settings
+ * 8. Tool configuration requirements
  *
  * @package DataMachine\Engine\AI\Tools
  * @since 0.39.0
@@ -35,6 +36,26 @@ class ToolPolicyResolver {
 	public const MODE_PIPELINE = 'pipeline';
 	public const MODE_CHAT     = 'chat';
 	public const MODE_SYSTEM   = 'system';
+
+	/**
+	 * Tool declaration flag that gates a generic content-writing tool behind
+	 * explicit opt-in for pipeline AI steps. Tools marked with this flag are
+	 * excluded from the default pipeline preset; a step must list them in
+	 * enabled_tools (or an allow-mode tool policy) to use them.
+	 *
+	 * See https://github.com/Extra-Chill/data-machine/issues/2852.
+	 */
+	public const PIPELINE_OPT_IN_FLAG = 'requires_pipeline_opt_in';
+
+	/**
+	 * Ability categories whose projected tools are content-writing surface and
+	 * therefore gated behind explicit opt-in for pipeline AI steps. The
+	 * canonical category slugs are owned by AbilityCategories; they are
+	 * inlined here as strings so the generic policy layer has no upward
+	 * dependency on the Abilities namespace (matches the established pattern
+	 * in AgentAuthorize).
+	 */
+	private const PIPELINE_OPT_IN_CATEGORIES = array( 'datamachine-publishing' );
 
 	private ToolManager $tool_manager;
 	private ToolSourceRegistry $tool_source_registry;
@@ -133,6 +154,18 @@ class ToolPolicyResolver {
 		$tools = $this->tool_policy->resolve( $tools, $policy_context );
 		$tools = $this->restoreExplicitDelegatedRuntimeTools( $tools, $gathered_tools, $args, $agent_policy );
 		$this->last_source_trace = $source_trace;
+
+		// Generic content-writing abilities are opt-in for pipeline AI steps.
+		// By default a pipeline step receives only its adjacent-handler tools,
+		// research/read tools, and disposition tools. Generic publish/write-any
+		// tools (publish-wordpress, upsert-post, insert-content, ...) leak
+		// otherwise: a model can improvise arbitrary publishes that bypass the
+		// flow's declared handler and its guards. Adjacent-handler plumbing is
+		// mandatory and therefore exempt. Chat/system modes are unaffected.
+		// See https://github.com/Extra-Chill/data-machine/issues/2852.
+		if ( in_array( self::MODE_PIPELINE, $modes, true ) ) {
+			$tools = $this->filterPipelineWriteOptInTools( $tools, $args );
+		}
 
 		// An explicitly-empty allow_only means "no optional tools." The generic
 		// substrate only applies a non-empty allow_only, so it would otherwise
@@ -566,5 +599,69 @@ class ToolPolicyResolver {
 		}
 
 		return in_array( $tool_name, $allowed, true );
+	}
+
+	/**
+	 * Whether a tool is a generic content-writing surface gated behind
+	 * explicit opt-in for pipeline AI steps.
+	 *
+	 * A tool is gated when it declares the {@see PIPELINE_OPT_IN_FLAG} flag at
+	 * its registration site, or when it is projected from one of the canonical
+	 * content-writing ability categories ({@see PIPELINE_OPT_IN_CATEGORIES}).
+	 * Adjacent-handler tools do not carry the flag and are not projected from
+	 * those categories, so flow plumbing is never gated.
+	 *
+	 * @param array $tool Tool definition.
+	 * @return bool True when the tool requires explicit opt-in in pipeline mode.
+	 */
+	private function isPipelineWriteOptInTool( array $tool ): bool {
+		if ( ! empty( $tool[ self::PIPELINE_OPT_IN_FLAG ] ) ) {
+			return true;
+		}
+
+		$category = isset( $tool['ability_category'] ) && is_string( $tool['ability_category'] ) ? $tool['ability_category'] : '';
+		if ( '' !== $category && in_array( $category, self::PIPELINE_OPT_IN_CATEGORIES, true ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Drop pipeline-gated content-writing tools that were not explicitly opted
+	 * into by the step. Adjacent-handler plumbing (mandatory tools) and tools
+	 * named in an allow path (enabled_tools / allow-mode tool policy) survive.
+	 *
+	 * @param array<string,array<string,mixed>> $tools Resolved tools keyed by name.
+	 * @param array                             $args  Resolver args.
+	 * @return array<string,array<string,mixed>> Filtered tools.
+	 */
+	private function filterPipelineWriteOptInTools( array $tools, array $args ): array {
+		$allowed = $this->policy_filter->string_list( $args['allow_only'] ?? array() );
+		$policy  = is_array( $args['tool_policy'] ?? null ) ? $args['tool_policy'] : null;
+		if ( is_array( $policy ) && \WP_Agent_Tool_Policy::MODE_ALLOW === ( $policy['mode'] ?? '' ) ) {
+			$allowed = array_merge( $allowed, $this->policy_filter->string_list( $policy['tools'] ?? array() ) );
+		}
+		$allowed = array_flip( $allowed );
+
+		foreach ( $tools as $name => $tool ) {
+			if ( ! is_array( $tool ) || ! $this->isPipelineWriteOptInTool( $tool ) ) {
+				continue;
+			}
+
+			// Flow plumbing (adjacent-handler tools) is mandatory and survives.
+			if ( $this->mandatory_tool_policy->isMandatory( $tool ) ) {
+				continue;
+			}
+
+			// A step that explicitly opts in (enabled_tools / allow policy) keeps it.
+			if ( isset( $allowed[ $name ] ) ) {
+				continue;
+			}
+
+			unset( $tools[ $name ] );
+		}
+
+		return $tools;
 	}
 }

--- a/tests/Unit/Engine/AI/Tools/PipelinePublishOptInTest.php
+++ b/tests/Unit/Engine/AI/Tools/PipelinePublishOptInTest.php
@@ -1,0 +1,403 @@
+<?php
+
+namespace DataMachine\Tests\Unit\Engine\AI\Tools;
+
+use DataMachine\Engine\AI\Tools\ToolManager;
+use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
+use WP_UnitTestCase;
+
+/**
+ * Verifies that generic content-publishing abilities are opt-in for pipeline
+ * AI steps (data-machine#2852).
+ *
+ * The default pipeline preset must not surface free-form publish/write tools.
+ * A step receives its adjacent-handler tools, research/read tools, and
+ * disposition tools by default; generic publish/write tools only appear when
+ * the step explicitly lists them in enabled_tools (or an allow-mode policy).
+ */
+class PipelinePublishOptInTest extends WP_UnitTestCase {
+
+	private ToolPolicyResolver $resolver;
+
+	/**
+	 * Track filter callbacks registered per-test so tear_down can remove them.
+	 *
+	 * @var array<int, array{hook:string, callback:callable, priority:int}>
+	 */
+	private array $filter_callbacks = array();
+
+	public function set_up(): void {
+		parent::set_up();
+
+		datamachine_register_capabilities();
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		ToolManager::clearCache();
+		$this->resolver = new ToolPolicyResolver();
+	}
+
+	public function tear_down(): void {
+		foreach ( $this->filter_callbacks as $entry ) {
+			remove_filter( $entry['hook'], $entry['callback'], $entry['priority'] );
+		}
+		$this->filter_callbacks = array();
+
+		ToolManager::clearCache();
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Register a datamachine_tools filter callback and track it for cleanup.
+	 */
+	private function registerToolsFilter( callable $callback ): void {
+		add_filter( 'datamachine_tools', $callback );
+		$this->filter_callbacks[] = array(
+			'hook'     => 'datamachine_tools',
+			'callback' => $callback,
+			'priority' => 10,
+		);
+	}
+
+	/**
+	 * Register a datamachine_handlers filter callback and track it for cleanup.
+	 */
+	private function registerHandlersFilter( callable $callback ): void {
+		add_filter( 'datamachine_handlers', $callback );
+		$this->filter_callbacks[] = array(
+			'hook'     => 'datamachine_handlers',
+			'callback' => $callback,
+			'priority' => 10,
+		);
+	}
+
+	// ============================================
+	// REQUIREMENT 1: generic write tools excluded by default
+	// ============================================
+
+	public function test_pipeline_excludes_flagged_content_writing_tool_by_default(): void {
+		$this->registerToolsFilter(
+			function ( array $tools ): array {
+				$tools['test_gated_publish'] = array(
+					'label'                    => 'Test Gated Publish',
+					'description'              => 'Mirrors upsert_post / insert_content declarations.',
+					'class'                    => 'NonExistentClass',
+					'method'                   => 'handle_tool_call',
+					'parameters'               => array(),
+					'modes'                    => array( 'pipeline', 'chat' ),
+					'requires_pipeline_opt_in' => true,
+				);
+				$tools['test_read_tool'] = array(
+					'label'       => 'Test Read Tool',
+					'description' => 'A read-only research tool that must remain available.',
+					'class'       => 'NonExistentClass',
+					'method'      => 'handle_tool_call',
+					'parameters'  => array(),
+					'modes'       => array( 'pipeline' ),
+				);
+				return $tools;
+			}
+		);
+
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_PIPELINE,
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'test_gated_publish', $tools, 'Flagged content-writing tool is excluded by default.' );
+		$this->assertArrayHasKey( 'test_read_tool', $tools, 'Non-gated research tool remains available.' );
+	}
+
+	public function test_pipeline_excludes_publishing_category_tool_by_default(): void {
+		$this->registerToolsFilter(
+			function ( array $tools ): array {
+				$tools['test_publishing_ability_tool'] = array(
+					'label'            => 'Test Publishing Ability Tool',
+					'description'      => 'Mirrors a datamachine-publishing category projection.',
+					'class'            => 'NonExistentClass',
+					'method'           => 'handle_tool_call',
+					'parameters'       => array(),
+					'modes'            => array( 'pipeline' ),
+					'ability'          => 'datamachine/test-publish',
+					'ability_category' => 'datamachine-publishing',
+				);
+				return $tools;
+			}
+		);
+
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_PIPELINE,
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'test_publishing_ability_tool', $tools, 'datamachine-publishing category tool is excluded by default.' );
+	}
+
+	public function test_pipeline_excludes_write_tools_but_keeps_adjacent_and_disposition_tools(): void {
+		// Adjacent upsert handler (next step) — produces the upsert_event tool.
+		$this->registerToolsFilter(
+			function ( array $tools ): array {
+				$tools['__handler_tools_test_upsert_event'] = array(
+					'_handler_callable' => static function () {
+						return array(
+							'upsert_event' => array(
+								'description' => 'Upsert event handler tool.',
+								'handler'     => 'upsert_event',
+								'parameters'  => array(),
+							),
+						);
+					},
+					'handler'           => 'upsert_event',
+					'modes'             => array( 'pipeline' ),
+				);
+
+				// Cross-cutting fetch disposition tools (previous step), matched by handler type.
+				$tools['__handler_tools_test_fetch_dispositions'] = array(
+					'_handler_callable' => static function () {
+						return array(
+							'reject_source' => array(
+								'description'  => 'Reject fetched source item.',
+								'handler'      => 'test_fetch',
+								'disposition'  => 'reject_source',
+								'parameters'   => array(),
+							),
+							'defer_item'    => array(
+								'description'  => 'Defer fetched source item.',
+								'handler'      => 'test_fetch',
+								'disposition'  => 'defer_item',
+								'parameters'   => array(),
+							),
+						);
+					},
+					'handler_types'     => array( 'fetch' ),
+					'modes'             => array( 'pipeline' ),
+				);
+
+				// Generic content-writing tool that must NOT leak into the step.
+				$tools['test_generic_publish'] = array(
+					'label'                    => 'Generic Publish',
+					'description'              => 'Free-form publish tool.',
+					'class'                    => 'NonExistentClass',
+					'method'                   => 'handle_tool_call',
+					'parameters'               => array(),
+					'modes'                    => array( 'pipeline' ),
+					'requires_pipeline_opt_in' => true,
+				);
+				return $tools;
+			}
+		);
+
+		$this->registerHandlersFilter(
+			static function () {
+				return array( 'test_fetch' => array( 'type' => 'fetch' ) );
+			}
+		);
+
+		$tools = $this->resolver->resolve(
+			array(
+				'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
+				'previous_step_config' => array(
+					'flow_step_id'    => 'flow_fetch_1',
+					'step_type'       => 'fetch',
+					'handler_slugs'   => array( 'test_fetch' ),
+					'handler_configs' => array( 'test_fetch' => array() ),
+				),
+				'next_step_config'     => array(
+					'flow_step_id'    => 'flow_upsert_1',
+					'step_type'       => 'upsert',
+					'handler_slugs'   => array( 'upsert_event' ),
+					'handler_configs' => array( 'upsert_event' => array() ),
+				),
+			)
+		);
+
+		// Generic publish tool excluded.
+		$this->assertArrayNotHasKey( 'test_generic_publish', $tools, 'Generic content-writing tool is excluded.' );
+
+		// Adjacent upsert handler tool preserved (flow plumbing).
+		$this->assertArrayHasKey( 'upsert_event', $tools, 'Adjacent upsert_event handler tool is preserved.' );
+
+		// Fetch disposition tools preserved (flow plumbing).
+		$this->assertArrayHasKey( 'reject_source', $tools, 'reject_source disposition tool is preserved.' );
+		$this->assertArrayHasKey( 'defer_item', $tools, 'defer_item disposition tool is preserved.' );
+	}
+
+	// ============================================
+	// REQUIREMENT 2: adjacent publish handler preserved (no regression)
+	// ============================================
+
+	public function test_pipeline_keeps_adjacent_publish_handler_tool(): void {
+		$this->registerToolsFilter(
+			function ( array $tools ): array {
+				// Mirrors the real wordpress_publish handler-tool registration
+				// (Core/Steps/Publish/Handlers/WordPress/WordPress.php), which
+				// uses the identical _handler_callable path.
+				$tools['__handler_tools_test_wp_publish'] = array(
+					'_handler_callable' => static function () {
+						return array(
+							'test_wp_publish' => array(
+								'class'                   => 'NonExistentClass',
+								'method'                  => 'handle_tool_call',
+								'client_context_bindings' => array( 'job_id' ),
+								'handler'                 => 'test_wp_publish',
+								'description'             => 'Create WordPress posts.',
+								'parameters'              => array(),
+							),
+						);
+					},
+					'handler'           => 'test_wp_publish',
+					'modes'             => array( 'pipeline' ),
+				);
+
+				// A gated generic tool that must remain excluded even when a real
+				// publish handler is adjacent.
+				$tools['test_generic_publish'] = array(
+					'label'                    => 'Generic Publish',
+					'description'              => 'Free-form publish tool.',
+					'class'                    => 'NonExistentClass',
+					'method'                   => 'handle_tool_call',
+					'parameters'               => array(),
+					'modes'                    => array( 'pipeline' ),
+					'requires_pipeline_opt_in' => true,
+				);
+				return $tools;
+			}
+		);
+
+		$tools = $this->resolver->resolve(
+			array(
+				'mode'             => ToolPolicyResolver::MODE_PIPELINE,
+				'next_step_config' => array(
+					'flow_step_id'    => 'flow_publish_1',
+					'step_type'       => 'publish',
+					'handler_slugs'   => array( 'test_wp_publish' ),
+					'handler_configs' => array( 'test_wp_publish' => array() ),
+				),
+			)
+		);
+
+		$this->assertArrayHasKey( 'test_wp_publish', $tools, 'Adjacent publish handler tool is preserved (flow plumbing).' );
+		$this->assertArrayNotHasKey( 'test_generic_publish', $tools, 'Generic publish tool still excluded when a publish handler is adjacent.' );
+	}
+
+	// ============================================
+	// REQUIREMENT 3: explicit opt-in restores gated tools
+	// ============================================
+
+	public function test_pipeline_explicit_allow_restores_flagged_tool(): void {
+		$this->registerToolsFilter(
+			function ( array $tools ): array {
+				$tools['test_gated_publish'] = array(
+					'label'                    => 'Test Gated Publish',
+					'description'              => 'Opt-in publish tool.',
+					'class'                    => 'NonExistentClass',
+					'method'                   => 'handle_tool_call',
+					'parameters'               => array(),
+					'modes'                    => array( 'pipeline' ),
+					'requires_pipeline_opt_in' => true,
+				);
+				return $tools;
+			}
+		);
+
+		$tools = $this->resolver->resolve(
+			array(
+				'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
+				'allow_only'           => array( 'test_gated_publish' ),
+				'allow_only_explicit'  => true,
+			)
+		);
+
+		$this->assertArrayHasKey( 'test_gated_publish', $tools, 'Explicit enabled_tools restores the gated tool.' );
+	}
+
+	public function test_pipeline_explicit_allow_restores_category_tool(): void {
+		$this->registerToolsFilter(
+			function ( array $tools ): array {
+				$tools['test_publishing_ability_tool'] = array(
+					'label'            => 'Test Publishing Ability Tool',
+					'description'      => 'Opt-in publishing tool.',
+					'class'            => 'NonExistentClass',
+					'method'           => 'handle_tool_call',
+					'parameters'       => array(),
+					'modes'            => array( 'pipeline' ),
+					'ability'          => 'datamachine/test-publish',
+					'ability_category' => 'datamachine-publishing',
+				);
+				return $tools;
+			}
+		);
+
+		$tools = $this->resolver->resolve(
+			array(
+				'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
+				'allow_only'           => array( 'test_publishing_ability_tool' ),
+				'allow_only_explicit'  => true,
+			)
+		);
+
+		$this->assertArrayHasKey( 'test_publishing_ability_tool', $tools, 'Explicit enabled_tools restores the publishing-category tool.' );
+	}
+
+	public function test_pipeline_allow_mode_tool_policy_restores_flagged_tool(): void {
+		$this->registerToolsFilter(
+			function ( array $tools ): array {
+				$tools['test_gated_publish'] = array(
+					'label'                    => 'Test Gated Publish',
+					'description'              => 'Opt-in publish tool.',
+					'class'                    => 'NonExistentClass',
+					'method'                   => 'handle_tool_call',
+					'parameters'               => array(),
+					'modes'                    => array( 'pipeline' ),
+					'requires_pipeline_opt_in' => true,
+				);
+				return $tools;
+			}
+		);
+
+		$tools = $this->resolver->resolve(
+			array(
+				'mode'        => ToolPolicyResolver::MODE_PIPELINE,
+				'tool_policy' => array(
+					'mode'  => 'allow',
+					'tools' => array( 'test_gated_publish' ),
+				),
+			)
+		);
+
+		$this->assertArrayHasKey( 'test_gated_publish', $tools, 'Allow-mode tool_policy restores the gated tool.' );
+	}
+
+	// ============================================
+	// NON-REGRESSION: chat/system modes unaffected
+	// ============================================
+
+	public function test_chat_mode_not_gated(): void {
+		$this->registerToolsFilter(
+			function ( array $tools ): array {
+				$tools['test_gated_publish'] = array(
+					'label'                    => 'Test Gated Publish',
+					'description'              => 'Available in chat.',
+					'class'                    => 'NonExistentClass',
+					'method'                   => 'handle_tool_call',
+					'parameters'               => array(),
+					'modes'                    => array( 'chat' ),
+					'requires_pipeline_opt_in' => true,
+				);
+				return $tools;
+			}
+		);
+
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
+
+		$this->assertArrayHasKey( 'test_gated_publish', $tools, 'Pipeline opt-in flag does not affect chat mode.' );
+	}
+}


### PR DESCRIPTION
Fixes Extra-Chill/data-machine#2852

## Root cause

Pipeline AI steps were offered generic content-publishing ability tools (`publish-wordpress`, `upsert-post`, `insert-content`) **by default, with no allow-list required**. A model could create arbitrary post types with `post_status=publish` even when the flow's declared handler was something else (e.g. `upsert_event`), bypassing the handler's guards entirely. On the events site this leaked 224 junk `post`-type items (AI-improvised "rejection reports"/"admin logs") that bypassed the intended `upsert_event` handler and its junk-title guard.

The default posture was **opt-out, not opt-in**, via four compounding code paths in `inc/`:
1. `PublishWordPressAbility` / `UpsertPostAbility` / `InsertContentAbility` register generic content-writing abilities (free-form `post_type`, `post_status: publish`) exposed to pipeline mode.
2. `AbilityToolSource::matchesModes()` (~L259) and `DataMachineToolRegistrySource` expose ANY tool whose declared `modes` include `pipeline` to EVERY pipeline AI step, regardless of the flow's adjacent handler.
3. `ToolManager` defaults a mode-less tool to `MODE_PIPELINE` (~L238, L373).
4. `ToolPolicyResolver::resolve()` only enforced an allow-list when one was explicitly set (`allow_only_explicit`, ~L137). A step with no `enabled_tools` fell through to the full preset.

Net: generic publish was ambient availability for every pipeline step.

## What changed and why

Made generic content-writing abilities **opt-in for pipeline AI steps**. A step now receives by default only:
- its **adjacent-handler tools** (the flow's declared publish/upsert handler, e.g. `wordpress_publish` / `upsert_event`),
- **research/read** tools (search, post-read, link audit, etc.),
- **disposition** tools (`reject_source`, `defer_item`).

Generic publish/write tools appear only when the step explicitly lists them in `enabled_tools` (or an allow-mode `tool_policy`).

### Mechanism (principled and layer-pure — not a slug blocklist)
- A new **declared tool flag** `requires_pipeline_opt_in`, set at each writing tool's own registration site (`UpsertPostAbility`, `InsertContentAbility`), exactly mirroring how `requires_opt_in` / `requires_config` / `modes` are declared. `ToolManager::resolveToolDefinition()` now propagates this flag from the `_callable` wrapper into the resolved definition.
- Ability tools projected from the canonical **`datamachine-publishing` category** are auto-gated (`ToolPolicyResolver::isPipelineWriteOptInTool()`). `ability_category` is already stamped onto ability-projection tools by `AbilityToolAdapter`. This covers `publish-wordpress` / `update-wordpress` / send-email defensively if they are ever projected as tools.
- `ToolPolicyResolver` enforces the gate in **pipeline mode only**, after the generic policy pass, preserving mandatory adjacent-handler plumbing and honoring explicit opt-in. Chat / system / editor modes are unaffected.

This was chosen over (a) a category-only rule, because `datamachine-content` mixes read + write tools and gating it wholesale would regress read tools; and (b) a slug blocklist in the policy layer, which would violate layer purity and the "add a new vendor/tool = config change, not a code change in the generic layer" rule. The generic policy layer reads a *declared* posture; each writing tool owns its own flag.

## Adjacent-handler publishing is preserved (no regression)

A flow whose next step **IS** a WordPress publish step still gets its `wordpress_publish` handler tool — that is mandatory flow plumbing (`DataMachineMandatoryToolPolicy::isMandatory()`: has `handler`, no `ability`), produced by `AdjacentHandlerToolSource` via the `_handler_callable` path in `WordPress.php`. The gate exempts mandatory tools.

Proven by `tests/Unit/Engine/AI/Tools/PipelinePublishOptInTest.php` (see `test_pipeline_keeps_adjacent_publish_handler_tool` and `test_pipeline_excludes_write_tools_but_keeps_adjacent_and_disposition_tools`).

## Exact behavior change

| Surface | Before | After |
|---|---|---|
| Pipeline AI step, no `enabled_tools` | generic publish/write tools ambient | only adjacent-handler + read + disposition tools |
| Pipeline AI step, `enabled_tools: ['upsert_post']` | upsert_post available | upsert_post available (opt-in works) |
| Pipeline AI step whose next step IS a `wordpress_publish` publish step | `wordpress_publish` tool available | `wordpress_publish` tool still available (flow plumbing) |
| Chat / system / editor | generic tools available | unchanged |

**Excluded by default in pipeline mode:** `upsert-post`, `insert-content`, and any `datamachine-publishing`-category ability projection (e.g. a future `publish-wordpress` projection).
**Still available by default:** adjacent-handler tools (`wordpress_publish`, `upsert_event`, …), disposition tools (`reject_source`, `defer_item`), research/read tools (`web_fetch`, search, post readers, link audit).
**How to opt back in:** list the tool in the step's `enabled_tools`, or use an allow-mode agent/step `tool_policy`.

## Tests

Added `tests/Unit/Engine/AI/Tools/PipelinePublishOptInTest.php` covering:
1. Pipeline step with adjacent `upsert_event` + fetch disposition tools → **excludes** the flagged/category write tools, **includes** `upsert_event`, `reject_source`, `defer_item` (requirement 1).
2. Pipeline step whose next step is a publish handler → the adjacent publish handler tool is preserved; generic publish still excluded (requirement 2).
3. Pipeline step that explicitly opts in via `enabled_tools` / allow-mode `tool_policy` → gated tool is restored (requirement 3).
4. Category-based gating (`datamachine-publishing`) excluded by default, restored on opt-in.
5. Chat mode is not gated (non-regression).

The new gate logic was also exercised end-to-end against the real `ToolPolicyResolver` class via reflection (standalone harness), confirming all 18 identification/filtering cases pass.

> Note: `composer test` runs through `homeboy test`, which provisions the PHPUnit/wp-phpunit sandbox via wp-codebox; in this shell the wp-codebox binary-detection was broken so the full suite could not be executed locally. The new tests follow the exact patterns of the existing `ToolPolicyResolverTest` / `HandlerToolResolutionTest` and will run in CI.

## Related

The events-layer mitigation (the junk-title guard and the leaked-items cleanup for the events site) is tracked in **Extra-Chill/data-machine-events#412**, a separate parallel PR. This core PR is the durable fix.