### PR TITLE
Fix review audit and lint findings

### DIFF
--- a/inc/Api/AgentBundles.php
+++ b/inc/Api/AgentBundles.php
@@ -51,7 +51,14 @@ add_action(
 				$route,
 				array(
 					'methods'             => 'POST',
-					'callback'            => static fn( \WP_REST_Request $request ): array => call_user_func( $callback, $request->get_json_params() ? $request->get_json_params() : array() ),
+					'callback'            => static function ( \WP_REST_Request $request ) use ( $callback ): array {
+						$params = $request->get_json_params();
+						if ( ! is_array( $params ) ) {
+							$params = array();
+						}
+
+						return call_user_func( $callback, $params );
+					},
 					'permission_callback' => static fn(): bool => PermissionHelper::can_manage(),
 				)
 			);

--- a/inc/Core/Database/Pipelines/Pipelines.php
+++ b/inc/Core/Database/Pipelines/Pipelines.php
@@ -973,17 +973,21 @@ class Pipelines extends BaseRepository {
 		$limit  = max( 1, min( 100, $limit ) );
 		$offset = max( 0, $offset );
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
+		$orphaned_pipelines_sql = $this->wpdb->prepare(
+			'SELECT pipeline_id, pipeline_name, user_id, portable_slug, created_at, updated_at FROM %i WHERE agent_id IS NULL ORDER BY updated_at DESC LIMIT %d OFFSET %d',
+			$this->table_name,
+			$limit,
+			$offset
+		);
+
+		// phpcs:disable WordPress.DB.PreparedSQL -- query is prepared above with %i/%d placeholders.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$results = $this->wpdb->get_results(
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
-			$this->wpdb->prepare(
-				'SELECT pipeline_id, pipeline_name, user_id, portable_slug, created_at, updated_at FROM %i WHERE agent_id IS NULL ORDER BY updated_at DESC LIMIT %d OFFSET %d',
-				$this->table_name,
-				$limit,
-				$offset
-			),
+			$orphaned_pipelines_sql,
 			ARRAY_A
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		return is_array( $results ) ? $results : array();
 	}

--- a/inc/Core/Database/Pipelines/Pipelines.php
+++ b/inc/Core/Database/Pipelines/Pipelines.php
@@ -510,8 +510,9 @@ class Pipelines extends BaseRepository {
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
 		$pipeline_config_sql = $this->wpdb->prepare( 'SELECT pipeline_config FROM %i WHERE pipeline_id = %d', $this->table_name, $pipeline_id );
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- query is prepared above with %i/%d placeholders.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- query is prepared above with %i/%d placeholders.
 		$pipeline_config_json = $this->wpdb->get_var( $pipeline_config_sql );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( empty( $pipeline_config_json ) ) {
 			return array();
@@ -980,11 +981,13 @@ class Pipelines extends BaseRepository {
 			$offset
 		);
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- query is prepared above with %i/%d placeholders.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- query is prepared above with %i/%d placeholders.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$results = $this->wpdb->get_results(
 			$orphaned_pipelines_sql,
 			ARRAY_A
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		return is_array( $results ) ? $results : array();
 	}

--- a/inc/Core/Database/Pipelines/Pipelines.php
+++ b/inc/Core/Database/Pipelines/Pipelines.php
@@ -981,13 +981,12 @@ class Pipelines extends BaseRepository {
 			$offset
 		);
 
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- query is prepared above with %i/%d placeholders.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$results = $this->wpdb->get_results(
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- query is prepared above with %i/%d placeholders.
 			$orphaned_pipelines_sql,
 			ARRAY_A
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		return is_array( $results ) ? $results : array();
 	}

--- a/inc/Core/Database/Pipelines/Pipelines.php
+++ b/inc/Core/Database/Pipelines/Pipelines.php
@@ -508,9 +508,10 @@ class Pipelines extends BaseRepository {
 			return array();
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
-		$pipeline_config_json = $this->wpdb->get_var( $this->wpdb->prepare( 'SELECT pipeline_config FROM %i WHERE pipeline_id = %d', $this->table_name, $pipeline_id ) );
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
+		$pipeline_config_sql = $this->wpdb->prepare( 'SELECT pipeline_config FROM %i WHERE pipeline_id = %d', $this->table_name, $pipeline_id );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- query is prepared above with %i/%d placeholders.
+		$pipeline_config_json = $this->wpdb->get_var( $pipeline_config_sql );
 
 		if ( empty( $pipeline_config_json ) ) {
 			return array();
@@ -971,18 +972,19 @@ class Pipelines extends BaseRepository {
 		$limit  = max( 1, min( 100, $limit ) );
 		$offset = max( 0, $offset );
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		// phpcs:disable WordPress.DB.PreparedSQL -- Table name uses %i and limit/offset are prepared integers.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
+		$orphaned_pipelines_sql = $this->wpdb->prepare(
+			'SELECT pipeline_id, pipeline_name, user_id, portable_slug, created_at, updated_at FROM %i WHERE agent_id IS NULL ORDER BY updated_at DESC LIMIT %d OFFSET %d',
+			$this->table_name,
+			$limit,
+			$offset
+		);
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- query is prepared above with %i/%d placeholders.
 		$results = $this->wpdb->get_results(
-			$this->wpdb->prepare(
-				'SELECT pipeline_id, pipeline_name, user_id, portable_slug, created_at, updated_at FROM %i WHERE agent_id IS NULL ORDER BY updated_at DESC LIMIT %d OFFSET %d',
-				$this->table_name,
-				$limit,
-				$offset
-			),
+			$orphaned_pipelines_sql,
 			ARRAY_A
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL
 
 		return is_array( $results ) ? $results : array();
 	}

--- a/inc/Core/Database/Pipelines/Pipelines.php
+++ b/inc/Core/Database/Pipelines/Pipelines.php
@@ -973,18 +973,15 @@ class Pipelines extends BaseRepository {
 		$limit  = max( 1, min( 100, $limit ) );
 		$offset = max( 0, $offset );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
-		$orphaned_pipelines_sql = $this->wpdb->prepare(
-			'SELECT pipeline_id, pipeline_name, user_id, portable_slug, created_at, updated_at FROM %i WHERE agent_id IS NULL ORDER BY updated_at DESC LIMIT %d OFFSET %d',
-			$this->table_name,
-			$limit,
-			$offset
-		);
-
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$results = $this->wpdb->get_results(
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- query is prepared above with %i/%d placeholders.
-			$orphaned_pipelines_sql,
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
+			$this->wpdb->prepare(
+				'SELECT pipeline_id, pipeline_name, user_id, portable_slug, created_at, updated_at FROM %i WHERE agent_id IS NULL ORDER BY updated_at DESC LIMIT %d OFFSET %d',
+				$this->table_name,
+				$limit,
+				$offset
+			),
 			ARRAY_A
 		);
 

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -789,11 +789,13 @@ class ProcessedItems extends BaseRepository {
 			return;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange
 		$wpdb->query(
 			"ALTER TABLE {$table_name}
 			 ADD KEY `flow_source_ts` (flow_step_id, source_type, processed_timestamp)"
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		do_action(
 			'datamachine_log',
@@ -811,25 +813,31 @@ class ProcessedItems extends BaseRepository {
 	public static function ensure_claim_columns( string $table_name ): void {
 		global $wpdb;
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
 		$status_column = $wpdb->get_var( "SHOW COLUMNS FROM {$table_name} LIKE 'status'" );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( ! $status_column ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
 			$wpdb->query( "ALTER TABLE {$table_name} ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'processed'" );
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
 		$claim_column = $wpdb->get_var( "SHOW COLUMNS FROM {$table_name} LIKE 'claim_expires_at'" );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( ! $claim_column ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
 			$wpdb->query( "ALTER TABLE {$table_name} ADD COLUMN claim_expires_at DATETIME NULL" );
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
 		$index = $wpdb->get_row( "SHOW INDEX FROM {$table_name} WHERE Key_name = 'status_claim_expires'" );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( ! $index ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
 			$wpdb->query( "ALTER TABLE {$table_name} ADD KEY `status_claim_expires` (status, claim_expires_at)" );
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 	}
 }

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -789,13 +789,11 @@ class ProcessedItems extends BaseRepository {
 			return;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
 		$wpdb->query(
 			"ALTER TABLE {$table_name}
 			 ADD KEY `flow_source_ts` (flow_step_id, source_type, processed_timestamp)"
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL
 
 		do_action(
 			'datamachine_log',
@@ -813,31 +811,25 @@ class ProcessedItems extends BaseRepository {
 	public static function ensure_claim_columns( string $table_name ): void {
 		global $wpdb;
 
-		// phpcs:disable WordPress.DB.PreparedSQL -- table name is code-defined ($wpdb->prefix), not user input.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
 		$status_column = $wpdb->get_var( "SHOW COLUMNS FROM {$table_name} LIKE 'status'" );
-		// phpcs:enable WordPress.DB.PreparedSQL
 		if ( ! $status_column ) {
-			// phpcs:disable WordPress.DB.PreparedSQL -- table name is code-defined ($wpdb->prefix), not user input.
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
 			$wpdb->query( "ALTER TABLE {$table_name} ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'processed'" );
-			// phpcs:enable WordPress.DB.PreparedSQL
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL -- table name is code-defined ($wpdb->prefix), not user input.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
 		$claim_column = $wpdb->get_var( "SHOW COLUMNS FROM {$table_name} LIKE 'claim_expires_at'" );
-		// phpcs:enable WordPress.DB.PreparedSQL
 		if ( ! $claim_column ) {
-			// phpcs:disable WordPress.DB.PreparedSQL -- table name is code-defined ($wpdb->prefix), not user input.
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
 			$wpdb->query( "ALTER TABLE {$table_name} ADD COLUMN claim_expires_at DATETIME NULL" );
-			// phpcs:enable WordPress.DB.PreparedSQL
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL -- table name is code-defined ($wpdb->prefix), not user input.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
 		$index = $wpdb->get_row( "SHOW INDEX FROM {$table_name} WHERE Key_name = 'status_claim_expires'" );
-		// phpcs:enable WordPress.DB.PreparedSQL
 		if ( ! $index ) {
-			// phpcs:disable WordPress.DB.PreparedSQL -- table name is code-defined ($wpdb->prefix), not user input.
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
 			$wpdb->query( "ALTER TABLE {$table_name} ADD KEY `status_claim_expires` (status, claim_expires_at)" );
-			// phpcs:enable WordPress.DB.PreparedSQL
 		}
 	}
 }

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -789,13 +789,14 @@ class ProcessedItems extends BaseRepository {
 			return;
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange
 		$wpdb->query(
-			"ALTER TABLE {$table_name}
-			 ADD KEY `flow_source_ts` (flow_step_id, source_type, processed_timestamp)"
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
+			$wpdb->prepare(
+				'ALTER TABLE %i ADD KEY `flow_source_ts` (flow_step_id, source_type, processed_timestamp)',
+				$table_name
+			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		do_action(
 			'datamachine_log',
@@ -813,31 +814,37 @@ class ProcessedItems extends BaseRepository {
 	public static function ensure_claim_columns( string $table_name ): void {
 		global $wpdb;
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
-		$status_column = $wpdb->get_var( "SHOW COLUMNS FROM {$table_name} LIKE 'status'" );
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$status_column = $wpdb->get_var(
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
+			$wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $table_name, 'status' )
+		);
 		if ( ! $status_column ) {
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
-			$wpdb->query( "ALTER TABLE {$table_name} ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'processed'" );
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->query(
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
+				$wpdb->prepare( "ALTER TABLE %i ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'processed'", $table_name )
+			);
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
-		$claim_column = $wpdb->get_var( "SHOW COLUMNS FROM {$table_name} LIKE 'claim_expires_at'" );
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$claim_column = $wpdb->get_var(
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
+			$wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $table_name, 'claim_expires_at' )
+		);
 		if ( ! $claim_column ) {
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
-			$wpdb->query( "ALTER TABLE {$table_name} ADD COLUMN claim_expires_at DATETIME NULL" );
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->query(
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
+				$wpdb->prepare( 'ALTER TABLE %i ADD COLUMN claim_expires_at DATETIME NULL', $table_name )
+			);
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
-		$index = $wpdb->get_row( "SHOW INDEX FROM {$table_name} WHERE Key_name = 'status_claim_expires'" );
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$index = $wpdb->get_row(
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
+			$wpdb->prepare( 'SHOW INDEX FROM %i WHERE Key_name = %s', $table_name, 'status_claim_expires' )
+		);
 		if ( ! $index ) {
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is code-defined ($wpdb->prefix), not user input.
-			$wpdb->query( "ALTER TABLE {$table_name} ADD KEY `status_claim_expires` (status, claim_expires_at)" );
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->query(
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
+				$wpdb->prepare( 'ALTER TABLE %i ADD KEY `status_claim_expires` (status, claim_expires_at)', $table_name )
+			);
 		}
 	}
 }

--- a/tests/Unit/AI/Tools/ImageGenerationToolCallTest.php
+++ b/tests/Unit/AI/Tools/ImageGenerationToolCallTest.php
@@ -10,6 +10,7 @@
 
 namespace DataMachine\Tests\Unit\AI\Tools;
 
+use DataMachine\Abilities\Media\ImageGenerationAbilities;
 use DataMachine\Engine\AI\Tools\Global\ImageGeneration;
 use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 use WP_UnitTestCase;
@@ -32,7 +33,7 @@ class ImageGenerationToolCallTest extends WP_UnitTestCase {
 	}
 
 	public function tear_down(): void {
-		delete_site_option( 'datamachine_image_generation_config' );
+		delete_site_option( ImageGenerationAbilities::CONFIG_OPTION );
 		WpAiClientTestDouble::reset();
 		parent::tear_down();
 	}
@@ -52,7 +53,7 @@ class ImageGenerationToolCallTest extends WP_UnitTestCase {
 			return array( 'success' => false, 'error' => 'Provider connection failed' );
 		} );
 
-		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
 
 		$result = $this->tool->handle_tool_call( array( 'prompt' => 'A beautiful sunset' ) );
 
@@ -65,7 +66,7 @@ class ImageGenerationToolCallTest extends WP_UnitTestCase {
 	 * Test handle_tool_call handles error from ability result.
 	 */
 	public function test_handle_tool_call_ability_error(): void {
-		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'missing-provider', 'default_model' => 'gpt-image-1' ) );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array( 'default_provider' => 'missing-provider', 'default_model' => 'gpt-image-1' ) );
 
 		$result = $this->tool->handle_tool_call( array( 'prompt' => 'A beautiful sunset' ) );
 
@@ -78,7 +79,7 @@ class ImageGenerationToolCallTest extends WP_UnitTestCase {
 	 * Test handle_tool_call delegates to ability successfully.
 	 */
 	public function test_handle_tool_call_success_basic(): void {
-		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
 
 		$result = $this->tool->handle_tool_call( array( 'prompt' => 'A beautiful sunset' ) );
 
@@ -93,7 +94,7 @@ class ImageGenerationToolCallTest extends WP_UnitTestCase {
 	 * Test handle_tool_call passes parameters through.
 	 */
 	public function test_handle_tool_call_with_parameters(): void {
-		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
 
 		$result = $this->tool->handle_tool_call( array(
 			'prompt'       => 'A serene mountain landscape',
@@ -114,7 +115,7 @@ class ImageGenerationToolCallTest extends WP_UnitTestCase {
 	 * Test handle_tool_call always returns tool_name.
 	 */
 	public function test_handle_tool_call_returns_tool_name(): void {
-		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
 
 		$result = $this->tool->handle_tool_call( array( 'prompt' => 'Test image' ) );
 

--- a/tests/Unit/Abilities/ImageGenerationPromptRefinementTest.php
+++ b/tests/Unit/Abilities/ImageGenerationPromptRefinementTest.php
@@ -27,7 +27,7 @@ class ImageGenerationPromptRefinementTest extends WP_UnitTestCase {
 	}
 
 	public function tear_down(): void {
-		delete_site_option( 'datamachine_image_generation_config' );
+		delete_site_option( ImageGenerationAbilities::CONFIG_OPTION );
 		delete_option( 'datamachine_settings' );
 		PluginSettings::clearCache();
 		WpAiClientTestDouble::reset();
@@ -254,7 +254,7 @@ class ImageGenerationPromptRefinementTest extends WP_UnitTestCase {
 	}
 
 	public function test_generate_image_applies_refinement_when_enabled(): void {
-		update_site_option( 'datamachine_image_generation_config', array(
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array(
 			'default_provider'          => 'openai',
 			'default_model'             => 'gpt-image-1',
 			'prompt_refinement_enabled' => true,
@@ -282,7 +282,7 @@ class ImageGenerationPromptRefinementTest extends WP_UnitTestCase {
 	}
 
 	public function test_generate_image_skips_refinement_when_disabled(): void {
-		update_site_option( 'datamachine_image_generation_config', array(
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array(
 			'default_provider'          => 'openai',
 			'default_model'             => 'gpt-image-1',
 			'prompt_refinement_enabled' => false,

--- a/tests/Unit/Abilities/Media/ImageGenerationAbilitiesTest.php
+++ b/tests/Unit/Abilities/Media/ImageGenerationAbilitiesTest.php
@@ -31,7 +31,7 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function tear_down(): void {
-		delete_site_option( 'datamachine_image_generation_config' );
+		delete_site_option( ImageGenerationAbilities::CONFIG_OPTION );
 		WpAiClientTestDouble::reset();
 		parent::tear_down();
 	}
@@ -67,7 +67,7 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_generate_image_missing_provider(): void {
-		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => '', 'default_model' => 'gpt-image-1' ) );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array( 'default_provider' => '', 'default_model' => 'gpt-image-1' ) );
 
 		$result = ImageGenerationAbilities::generateImage( array( 'prompt' => 'Test prompt' ) );
 
@@ -83,7 +83,7 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_generate_image_uses_explicit_config(): void {
-		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'configured-model' ) );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array( 'default_provider' => 'openai', 'default_model' => 'configured-model' ) );
 
 		$captured_request = null;
 		WpAiClientTestDouble::set_response_callback( function ( array $request ) use ( &$captured_request ): array {
@@ -101,7 +101,7 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_generate_image_input_provider_and_model_override_config(): void {
-		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'configured-model' ) );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array( 'default_provider' => 'openai', 'default_model' => 'configured-model' ) );
 
 		$captured_request = null;
 		WpAiClientTestDouble::set_response_callback( function ( array $request ) use ( &$captured_request ): array {
@@ -123,7 +123,7 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_generate_image_unregistered_provider(): void {
-		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'missing-provider', 'default_model' => 'image-model' ) );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array( 'default_provider' => 'missing-provider', 'default_model' => 'image-model' ) );
 
 		$result = ImageGenerationAbilities::generateImage( array( 'prompt' => 'Test prompt' ) );
 
@@ -132,7 +132,7 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_generate_image_support_check_failure(): void {
-		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'text-only-model' ) );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array( 'default_provider' => 'openai', 'default_model' => 'text-only-model' ) );
 		WpAiClientTestDouble::set_response_callback( function (): array {
 			return array( 'success' => true, 'supported' => false );
 		} );
@@ -144,7 +144,7 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_generate_image_provider_error(): void {
-		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
 		WpAiClientTestDouble::set_response_callback( function (): array {
 			return array( 'success' => false, 'error' => 'Provider unavailable' );
 		} );
@@ -157,7 +157,7 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_generate_image_success_schedules_job(): void {
-		update_site_option( 'datamachine_image_generation_config', array(
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array(
 			'default_provider'     => 'openai',
 			'default_model'        => 'gpt-image-1',
 			'default_aspect_ratio' => '3:4',
@@ -184,7 +184,7 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_is_configured_false_when_provider_unavailable(): void {
-		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'missing-provider', 'default_model' => 'gpt-image-1' ) );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array( 'default_provider' => 'missing-provider', 'default_model' => 'gpt-image-1' ) );
 		$this->assertFalse( ImageGenerationAbilities::is_configured() );
 	}
 
@@ -193,18 +193,18 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_is_configured_true_when_provider_and_model_available(): void {
-		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
 		$this->assertTrue( ImageGenerationAbilities::is_configured() );
 	}
 
 	public function test_get_config_empty(): void {
-		delete_site_option( 'datamachine_image_generation_config' );
+		delete_site_option( ImageGenerationAbilities::CONFIG_OPTION );
 		$this->assertSame( array(), ImageGenerationAbilities::get_config() );
 	}
 
 	public function test_get_config_returns_stored(): void {
 		$config = array( 'default_provider' => 'openai', 'default_model' => 'custom-model' );
-		update_site_option( 'datamachine_image_generation_config', $config );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, $config );
 		$this->assertSame( $config, ImageGenerationAbilities::get_config() );
 	}
 }

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -29,6 +29,7 @@ use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Store_Capabilities;
 use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Write_Result;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Agents\AgentBundler;
+use DataMachine\Core\ActionScheduler\GroupRegistrar;
 use DataMachine\Core\Database\Agents\Agents as AgentsRepository;
 use DataMachine\Core\Database\BundleArtifacts\InstalledBundleArtifacts;
 use DataMachine\Core\Database\Flows\Flows as FlowsRepository;
@@ -579,8 +580,8 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$flow     = $this->flows_repo->get_by_portable_slug( (int) $pipeline['pipeline_id'], 'static-site-flow' );
 		$flow_id  = (int) $flow['flow_id'];
 
-		as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
-		$this->assertFalse( as_next_scheduled_action( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' ), 'Test setup removes the scheduled action while preserving flow row scheduling.' );
+		as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), GroupRegistrar::GROUP );
+		$this->assertFalse( as_next_scheduled_action( 'datamachine_run_flow_now', array( $flow_id ), GroupRegistrar::GROUP ), 'Test setup removes the scheduled action while preserving flow row scheduling.' );
 
 		$second = $this->bundler->import(
 			$bundle,
@@ -591,7 +592,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		);
 
 		$this->assertTrue( (bool) $second['success'], 'Upgrade import succeeds when only the scheduled action is missing.' );
-		$this->assertNotFalse( as_next_scheduled_action( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' ), 'Importer re-creates the missing scheduled action for an enabled non-manual flow.' );
+		$this->assertNotFalse( as_next_scheduled_action( 'datamachine_run_flow_now', array( $flow_id ), GroupRegistrar::GROUP ), 'Importer re-creates the missing scheduled action for an enabled non-manual flow.' );
 	}
 
 	public function test_reconcile_runtime_replaces_local_modified_flow_queue_and_schedule(): void {

--- a/tests/Unit/Engine/AI/System/Tasks/ImageGenerationTaskTest.php
+++ b/tests/Unit/Engine/AI/System/Tasks/ImageGenerationTaskTest.php
@@ -8,6 +8,7 @@
 
 namespace DataMachine\Tests\Unit\Engine\AI\System\Tasks;
 
+use DataMachine\Abilities\Media\ImageGenerationAbilities;
 use DataMachine\Engine\AI\System\Tasks\ImageGenerationTask;
 use WP_UnitTestCase;
 
@@ -45,7 +46,7 @@ class ImageGenerationTaskTest extends WP_UnitTestCase {
 	}
 
 	public function tear_down(): void {
-		delete_site_option( 'datamachine_image_generation_config' );
+		delete_site_option( ImageGenerationAbilities::CONFIG_OPTION );
 		parent::tear_down();
 	}
 

--- a/tests/Unit/Engine/AI/Tools/Global/ImageGenerationTest.php
+++ b/tests/Unit/Engine/AI/Tools/Global/ImageGenerationTest.php
@@ -31,29 +31,29 @@ class ImageGenerationTest extends WP_UnitTestCase {
 	}
 
 	public function tear_down(): void {
-		delete_site_option( 'datamachine_image_generation_config' );
+		delete_site_option( ImageGenerationAbilities::CONFIG_OPTION );
 		WpAiClientTestDouble::reset();
 		parent::tear_down();
 	}
 
 	public function test_is_configured_returns_false_when_no_config(): void {
-		delete_site_option( 'datamachine_image_generation_config' );
+		delete_site_option( ImageGenerationAbilities::CONFIG_OPTION );
 		$this->assertFalse( ImageGeneration::is_configured() );
 	}
 
 	public function test_is_configured_returns_true_when_provider_and_model_set(): void {
-		update_site_option( 'datamachine_image_generation_config', [ 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ] );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, [ 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ] );
 		$this->assertTrue( ImageGeneration::is_configured() );
 	}
 
 	public function test_get_config_returns_empty_array_by_default(): void {
-		delete_site_option( 'datamachine_image_generation_config' );
+		delete_site_option( ImageGenerationAbilities::CONFIG_OPTION );
 		$this->assertSame( [], ImageGeneration::get_config() );
 	}
 
 	public function test_get_config_returns_stored_config(): void {
 		$config = [ 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ];
-		update_site_option( 'datamachine_image_generation_config', $config );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, $config );
 		$this->assertSame( $config, ImageGeneration::get_config() );
 	}
 
@@ -63,10 +63,10 @@ class ImageGenerationTest extends WP_UnitTestCase {
 	}
 
 	public function test_check_configuration_returns_status_for_image_generation(): void {
-		delete_site_option( 'datamachine_image_generation_config' );
+		delete_site_option( ImageGenerationAbilities::CONFIG_OPTION );
 		$this->assertFalse( $this->tool->check_configuration( true, 'image_generation' ) );
 
-		update_site_option( 'datamachine_image_generation_config', [ 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ] );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, [ 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ] );
 		$this->assertTrue( $this->tool->check_configuration( false, 'image_generation' ) );
 	}
 
@@ -77,7 +77,7 @@ class ImageGenerationTest extends WP_UnitTestCase {
 
 	public function test_get_configuration_returns_config_for_image_generation(): void {
 		$config = [ 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ];
-		update_site_option( 'datamachine_image_generation_config', $config );
+		update_site_option( ImageGenerationAbilities::CONFIG_OPTION, $config );
 		$this->assertSame( $config, $this->tool->get_configuration( [], 'image_generation' ) );
 	}
 
@@ -114,7 +114,7 @@ class ImageGenerationTest extends WP_UnitTestCase {
 	}
 
 	public function test_handle_tool_call_error_when_not_configured(): void {
-		delete_site_option( 'datamachine_image_generation_config' );
+		delete_site_option( ImageGenerationAbilities::CONFIG_OPTION );
 		$result = $this->tool->handle_tool_call( [ 'prompt' => 'A sunset' ] );
 		$this->assertFalse( $result['success'] );
 		$this->assertStringContainsString( 'not configured', $result['error'] );
@@ -128,6 +128,8 @@ class ImageGenerationTest extends WP_UnitTestCase {
 	}
 
 	public function test_config_option_key(): void {
-		$this->assertSame( 'datamachine_image_generation_config', ImageGenerationAbilities::CONFIG_OPTION );
+		$method = new \ReflectionMethod( ImageGeneration::class, 'get_config_option_name' );
+
+		$this->assertSame( ImageGenerationAbilities::CONFIG_OPTION, $method->invoke( $this->tool ) );
 	}
 }

--- a/tests/action-scheduler-group-registration-smoke.php
+++ b/tests/action-scheduler-group-registration-smoke.php
@@ -104,7 +104,7 @@ assert_action_scheduler_group_contains( 'action_scheduler_init', $plugin_src, 'p
 assert_action_scheduler_group_contains( 'GroupRegistrar::class', $plugin_src, 'plugin hooks the Data Machine group registrar' );
 assert_action_scheduler_group_contains( 'ensureDataMachineGroup', $plugin_src, 'plugin ensures Data Machine group during AS init' );
 
-assert_action_scheduler_group_contains( "public const GROUP = 'data-machine'", $group_src, 'group registrar owns the Data Machine group slug' );
+assert_action_scheduler_group_contains( "public const GROUP = '" . \DataMachine\Core\ActionScheduler\GroupRegistrar::GROUP . "'", $group_src, 'group registrar owns the Data Machine group slug' );
 assert_action_scheduler_group_contains( 'ensureCustomTableGroup( self::GROUP )', $group_src, 'group registrar ensures custom-table group storage' );
 assert_action_scheduler_group_contains( 'ensurePostStoreGroup( self::GROUP )', $group_src, 'group registrar ensures legacy post-store taxonomy storage' );
 assert_action_scheduler_group_contains( 'actionscheduler_groups', $group_src, 'custom-table group storage targets Action Scheduler groups table' );
@@ -120,11 +120,11 @@ assert_action_scheduler_group_true( $ensure_pos < $claim_pos, 'drain ensures gro
 \DataMachine\Core\ActionScheduler\GroupRegistrar::ensureDataMachineGroup();
 
 assert_action_scheduler_group_true(
-	array( 'table' => 'wp_actionscheduler_groups', 'data' => array( 'slug' => 'data-machine' ) ) === $GLOBALS['wpdb']->inserted[0],
+	array( 'table' => 'wp_actionscheduler_groups', 'data' => array( 'slug' => \DataMachine\Core\ActionScheduler\GroupRegistrar::GROUP ) ) === $GLOBALS['wpdb']->inserted[0],
 	'group registrar creates the custom-table group row when missing'
 );
 assert_action_scheduler_group_true(
-	in_array( 'data-machine', $GLOBALS['action_scheduler_group_terms'], true ),
+	in_array( \DataMachine\Core\ActionScheduler\GroupRegistrar::GROUP, $GLOBALS['action_scheduler_group_terms'], true ),
 	'group registrar creates the legacy action-group taxonomy term when missing'
 );
 

--- a/tests/ai-step-backpressure-smoke.php
+++ b/tests/ai-step-backpressure-smoke.php
@@ -112,9 +112,11 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 require_once __DIR__ . '/../inc/Core/NetworkSettings.php';
 require_once __DIR__ . '/../inc/Core/PluginSettings.php';
 require_once __DIR__ . '/../inc/Core/OptionLeaseStore.php';
+require_once __DIR__ . '/../inc/Core/ActionScheduler/GroupRegistrar.php';
 require_once __DIR__ . '/../inc/Engine/AI/PipelineAIConcurrencyLease.php';
 require_once __DIR__ . '/../inc/Engine/AI/PipelineAIConcurrencyLimiter.php';
 
+use DataMachine\Core\ActionScheduler\GroupRegistrar;
 use DataMachine\Engine\AI\PipelineAIConcurrencyLease;
 use DataMachine\Engine\AI\PipelineAIConcurrencyLimiter;
 
@@ -149,7 +151,7 @@ assert_ai_backpressure_smoke( 'stale owner initially acquires slot', true === $s
 $GLOBALS['datamachine_ai_backpressure_actions'][] = new DataMachineAIBackpressureSmokeAction(
 	array(
 		'hook'   => 'datamachine_execute_step',
-		'group'  => 'data-machine',
+		'group'  => GroupRegistrar::GROUP,
 		'status' => 'pending',
 		'job_id' => 201,
 		'args'   => array(

--- a/uninstall.php
+++ b/uninstall.php
@@ -13,6 +13,11 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
+require_once __DIR__ . '/inc/Abilities/Media/ImageGenerationAbilities.php';
+require_once __DIR__ . '/inc/Abilities/SettingsAbilities.php';
+require_once __DIR__ . '/inc/Core/ActionScheduler/GroupRegistrar.php';
+require_once __DIR__ . '/inc/Core/NetworkSettings.php';
+
 if ( is_multisite() ) {
 	// Clean up every subsite on the network.
 	$datamachine_sites = get_sites( array( 'fields' => 'ids' ) );
@@ -39,11 +44,11 @@ if ( is_multisite() ) {
 function datamachine_uninstall_site() {
 	global $wpdb;
 
-	// --- Options ---
+	// --- Site options ---
 
 	// Core plugin settings.
 	delete_option( 'datamachine_settings' );
-	delete_option( 'datamachine_handler_defaults' );
+	delete_option( \DataMachine\Abilities\SettingsAbilities::HANDLER_DEFAULTS_OPTION );
 	delete_option( 'datamachine_agent_ping_callback_token' );
 	delete_option( 'datamachine_page_hook_suffixes' );
 
@@ -101,7 +106,7 @@ function datamachine_uninstall_site() {
 	// --- Scheduled actions ---
 
 	if ( function_exists( 'as_unschedule_all_actions' ) ) {
-		as_unschedule_all_actions( '', array(), 'data-machine' );
+		as_unschedule_all_actions( '', array(), \DataMachine\Core\ActionScheduler\GroupRegistrar::GROUP );
 	}
 
 	// --- Transients ---
@@ -146,11 +151,11 @@ function datamachine_uninstall_network_tables() {
  */
 function datamachine_uninstall_network_options() {
 	$datamachine_network_options = array(
-		'datamachine_image_generation_config',
+		\DataMachine\Abilities\Media\ImageGenerationAbilities::CONFIG_OPTION,
 		'datamachine_gsc_config',
 		'datamachine_search_config',
 		'datamachine_auth_data',
-		'datamachine_network_settings',
+		\DataMachine\Core\NetworkSettings::OPTION_NAME,
 		'datamachine_chat_sessions_network_migrated',
 	);
 


### PR DESCRIPTION
## Summary
- Fixes PHPCS findings surfaced by homeboy CI probe run 28747327863, including short ternary expansion and narrow prepared-SQL handling for code-defined identifiers.
- Replaces audit-reported option/group slug literals with backing constants where safe.
- Updates tests to use existing option/group constants instead of duplicating backing values.

## Verification
- `homeboy review lint data-machine --path /Users/chubes/Developer/data-machine@fix-review-findings --changed-since origin/main --lab-only --runner homeboy-lab` passed with no findings on run 9cfea0a4-945f-4518-9cef-4a50f06893dd.
- `homeboy review audit data-machine --path /Users/chubes/Developer/data-machine@fix-review-findings --only constant_backed_slug_literal --lab-only --runner homeboy-lab` still reports whole-tree findings because `audit --changed-since` is not Lab-portable in the current Homeboy runner.
- `homeboy review test data-machine --lab-only --runner homeboy-lab` fails on existing broader runner/runtime failures: missing `InMemoryConversationStore` test class and `CliCommandIntrospectorTest` failures.

Surfaced by run 28747327863.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Fixed audit/lint findings surfaced by the homeboy review CI probe; Chris reviews and owns the change.
