### PR TITLE
Fix Composer test script for Homeboy review

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 		}
 	},
 	"scripts": {
-		"test": "homeboy test data-machine",
+		"test": "homeboy review test data-machine",
 		"lint": "phpcs",
 		"lint-fix": "phpcbf"
 	},


### PR DESCRIPTION
## Summary
- Updated `composer.json` `test` from `homeboy test data-machine` to `homeboy review test data-machine`.
- Searched the full repo for stale bare `homeboy test`, `homeboy lint`, `homeboy audit`, `homeboy build`, and `homeboy ci` invocations; no other actionable CLI invocations were found.
- Left historical docs changelog prose untouched.

Closes #2855

## Verification
- `homeboy review test --help` resolves successfully with Homeboy 0.281.13.
- `composer run test` now reaches PHPUnit via `homeboy review test data-machine`; it no longer fails with the removed `homeboy test` subcommand.
- `composer run test` currently exposes separate PHPUnit failures in `CliCommandIntrospectorTest`; filed as #2856.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Updated stale bare homeboy quality commands to review-nested vocabulary; Chris reviews and owns the change.