### PR TITLE
feat: agent bundle manifest reconciliation — slug-based diff, status drift, upgrade (#2860)

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -1527,6 +1527,16 @@ class AgentAbilities {
 	}
 
 	/**
+	 * Reconcile every installed bundle-backed agent against its on-disk manifest.
+	 *
+	 * @param array $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public static function reconcileAllAgentBundles( array $input ): array {
+		return self::bundleLifecycleService()->reconcile_all( $input );
+	}
+
+	/**
 	 * Bind an already-live agent to a bundle (one-time, idempotent adopt).
 	 *
 	 * @param array $input Ability input.

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -248,8 +248,8 @@ class AgentBundleCommand extends BaseCommand {
 			WP_CLI::log( 'Run `wp datamachine agent diff <slug>` for the full upgrade plan.' );
 		}
 
-		$row            = $status;
-		$row['drift']   = $has_drift ? 'Yes' : 'No';
+		$row          = $status;
+		$row['drift'] = $has_drift ? 'Yes' : 'No';
 		$this->format_items( array( $row ), array( 'agent_id', 'agent_slug', 'template_slug', 'template_version', 'bundle_slug', 'bundle_version', 'artifact_count', 'drift' ), array( 'format' => 'table' ) );
 	}
 

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -187,6 +187,10 @@ class AgentBundleCommand extends BaseCommand {
 	/**
 	 * Show installed package status for an agent or package slug.
 	 *
+	 * Includes manifest drift detection when the on-disk bundle directory
+	 * is discoverable: reports whether a deployed manifest change has not
+	 * yet reached the live agent row (#2860).
+	 *
 	 * ## OPTIONS
 	 *
 	 * <slug>
@@ -208,16 +212,54 @@ class AgentBundleCommand extends BaseCommand {
 			return;
 		}
 
-		$this->output( $status, $assoc_args, array( 'agent_id', 'agent_slug', 'template_slug', 'template_version', 'bundle_slug', 'bundle_version', 'artifact_count' ) );
+		$has_drift = ! empty( $status['has_manifest_drift'] );
+
+		if ( 'json' === ( $assoc_args['format'] ?? 'table' ) ) {
+			WP_CLI::line( (string) wp_json_encode( $status, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		if ( $has_drift ) {
+			$manifest      = $status['manifest'] ?? array();
+			$config_drift  = is_array( $manifest['config_drift'] ?? null ) ? $manifest['config_drift'] : array();
+			$version_drift = is_array( $manifest['bundle_version'] ?? null ) ? (bool) ( $manifest['bundle_version']['drift'] ?? false ) : false;
+
+			if ( $version_drift ) {
+				WP_CLI::warning( sprintf(
+					'Bundle version drift: installed %s, manifest %s.',
+					(string) ( $manifest['bundle_version']['installed'] ?? '' ),
+					(string) ( $manifest['bundle_version']['manifest'] ?? '' )
+				) );
+			}
+
+			foreach ( $config_drift as $field ) {
+				$key = (string) ( $field['key'] ?? '' );
+				if ( '' === $key ) {
+					continue;
+				}
+				WP_CLI::warning( sprintf(
+					'Config drift: %s (installed: %s, manifest: %s)',
+					$key,
+					wp_json_encode( $field['installed'] ?? null ),
+					wp_json_encode( $field['manifest'] ?? null )
+				) );
+			}
+
+			WP_CLI::log( 'Run `wp datamachine agent diff <slug>` for the full upgrade plan.' );
+		}
+
+		$row            = $status;
+		$row['drift']   = $has_drift ? 'Yes' : 'No';
+		$this->format_items( array( $row ), array( 'agent_id', 'agent_slug', 'template_slug', 'template_version', 'bundle_slug', 'bundle_version', 'artifact_count', 'drift' ), array( 'format' => 'table' ) );
 	}
 
 	/**
-	 * Inspect an agent package from a local file, directory, or URL without writing.
+	 * Inspect an agent package from a slug, local file, directory, or URL.
 	 *
 	 * ## OPTIONS
 	 *
-	 * <path>
-	 * : Package path (.zip, .json, or directory) or remote URL.
+	 * <slug-or-path>
+	 * : Installed agent/bundle slug, or package path (.zip, .json, or directory) or remote URL.
 	 *
 	 * [--slug=<slug>]
 	 * : Override target agent slug for summary output.
@@ -286,12 +328,17 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	/**
-	 * Show an upgrade diff for a package path.
+	 * Show an upgrade diff for a package path or installed agent slug.
+	 *
+	 * When given a slug (not a file path or URL), resolves the on-disk
+	 * bundle directory registered by the integration plugin via the
+	 * `datamachine_agent_bundle_directories` filter and diffs that
+	 * manifest against the installed agent row.
 	 *
 	 * ## OPTIONS
 	 *
-	 * <path>
-	 * : Package path (.zip, .json, or directory).
+	 * <slug-or-path>
+	 * : Installed agent/bundle slug, or package path (.zip, .json, or directory).
 	 *
 	 * [--slug=<slug>]
 	 * : Override target agent slug.
@@ -324,13 +371,21 @@ class AgentBundleCommand extends BaseCommand {
 	/**
 	 * Upgrade an installed agent package.
 	 *
+	 * Accepts either a filesystem path or an installed agent/bundle slug.
+	 * When given a slug, resolves the on-disk bundle directory registered
+	 * by the integration plugin via `datamachine_agent_bundle_directories`.
+	 *
 	 * Clean artifacts are applied through the importer. Approval-required changes
 	 * are staged as PendingActions.
 	 *
 	 * ## OPTIONS
 	 *
-	 * <path>
-	 * : Package path (.zip, .json, or directory).
+	 * [<slug-or-path>]
+	 * : Installed agent/bundle slug, or package path (.zip, .json, or directory).
+	 *   Required unless --all is used.
+	 *
+	 * [--all]
+	 * : Reconcile every installed bundle-backed agent against its on-disk manifest.
 	 *
 	 * [--slug=<slug>]
 	 * : Override target agent slug.
@@ -375,6 +430,48 @@ class AgentBundleCommand extends BaseCommand {
 	 * ---
 	 */
 	public function upgrade( array $args, array $assoc_args ): void {
+		$all = \WP_CLI\Utils\get_flag_value( $assoc_args, 'all', false );
+
+		if ( $all ) {
+			$dry_run  = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+			$response = AgentAbilities::reconcileAllAgentBundles( array( 'dry_run' => $dry_run ) );
+			if ( empty( $response['success'] ) ) {
+				WP_CLI::error( (string) ( $response['error'] ?? 'Bundle reconcile-all failed.' ) );
+				return;
+			}
+
+			if ( 'json' === ( $assoc_args['format'] ?? 'table' ) ) {
+				WP_CLI::line( (string) wp_json_encode( $response, JSON_PRETTY_PRINT ) );
+				return;
+			}
+
+			WP_CLI::log( sprintf( 'Reconciled %d agent(s).', (int) ( $response['count'] ?? 0 ) ) );
+
+			$rows = array();
+			foreach ( is_array( $response['reconciled'] ?? null ) ? $response['reconciled'] : array() as $entry ) {
+				$rows[] = array(
+					'agent_slug'  => (string) ( $entry['agent_slug'] ?? '' ),
+					'bundle_slug' => (string) ( $entry['bundle_slug'] ?? '' ),
+					'success'     => ! empty( $entry['success'] ) ? 'Yes' : 'No',
+					'skipped'     => ! empty( $entry['skipped'] ) ? 'Yes' : 'No',
+					'error'       => (string) ( $entry['error'] ?? '' ),
+				);
+			}
+
+			if ( $rows ) {
+				$this->format_items( $rows, array( 'agent_slug', 'bundle_slug', 'success', 'skipped', 'error' ), array( 'format' => 'table' ) );
+			}
+
+			return;
+		}
+
+		$source = (string) ( $args[0] ?? '' );
+		if ( '' === $source ) {
+			WP_CLI::error( 'Slug or path is required. Use --all to reconcile every installed bundle-backed agent.' );
+			return;
+		}
+
+		$args             = array( $source );
 		$dry_run          = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
 		$input            = $this->bundle_ability_input( $args, $assoc_args );
 		$input['dry_run'] = $dry_run;

--- a/inc/Engine/Bundle/AgentBundleAbilityService.php
+++ b/inc/Engine/Bundle/AgentBundleAbilityService.php
@@ -72,7 +72,18 @@ final class AgentBundleAbilityService {
 			);
 		}
 
-		return array_merge( array( 'success' => true ), $this->installed_status( $agent ) );
+		$status = array_merge( array( 'success' => true ), $this->installed_status( $agent ) );
+
+		// Manifest drift detection (#2860): compare the on-disk bundle
+		// manifest against the installed row so operators can see when a
+		// deployed manifest change has not yet reached the live agent.
+		$drift = $this->manifest_drift( $agent );
+		if ( null !== $drift ) {
+			$status['manifest']            = $drift;
+			$status['has_manifest_drift']  = ! empty( $drift['has_drift'] );
+		}
+
+		return $status;
 	}
 
 	/** @return array<string,mixed> */
@@ -579,6 +590,18 @@ final class AgentBundleAbilityService {
 			);
 		}
 
+		// Slug resolution (#2860): when the source is neither a remote URL
+		// nor an existing local path, treat it as a bundle/agent slug and
+		// try to resolve the on-disk bundle directory registered by the
+		// integration plugin. This lets operators run `agent diff <slug>`
+		// / `agent upgrade <slug>` without knowing the filesystem path.
+		if ( ! BundleSource::is_remote( $source ) && ! file_exists( $source ) ) {
+			$resolved_dir = $this->resolve_bundle_directory_for_slug( $source );
+			if ( null !== $resolved_dir ) {
+				$source = $resolved_dir;
+			}
+		}
+
 		$context  = BundleSourceAuth::build_resolve_context(
 			isset( $input['token'] ) ? (string) $input['token'] : null,
 			isset( $input['token_env'] ) ? (string) $input['token_env'] : null
@@ -893,6 +916,30 @@ final class AgentBundleAbilityService {
 		return null;
 	}
 
+	/**
+	 * Resolve a slug to a registered on-disk bundle directory.
+	 *
+	 * Tries a direct bundle-slug match against registered directories
+	 * first, then falls back to resolving through an installed agent's
+	 * stored bundle_slug.
+	 *
+	 * @param string $slug Agent slug or bundle slug.
+	 * @return string|null Absolute directory path, or null when unresolved.
+	 */
+	private function resolve_bundle_directory_for_slug( string $slug ): ?string {
+		$dir = AgentBundleDirectoryRegistry::resolve_for_bundle_slug( $slug );
+		if ( null !== $dir ) {
+			return $dir;
+		}
+
+		$agent = $this->resolve_installed_agent( $slug );
+		if ( $agent ) {
+			return AgentBundleDirectoryRegistry::resolve_for_agent( $agent );
+		}
+
+		return null;
+	}
+
 	private function installed_status( array $agent ): array {
 		$bundle    = $agent['agent_config']['datamachine_bundle'] ?? array();
 		$artifacts = AgentBundleArtifactState::installed_for_agent( $agent );
@@ -908,6 +955,156 @@ final class AgentBundleAbilityService {
 			'source_revision'  => (string) ( $bundle['source_revision'] ?? '' ),
 			'artifact_count'   => count( $artifacts ),
 			'artifacts'        => $artifacts,
+		);
+	}
+
+	/**
+	 * Compare the on-disk bundle manifest against the installed agent row.
+	 *
+	 * Returns null when no registered bundle directory is available.
+	 * Otherwise returns a drift report comparing bundle_version and the
+	 * bundle-owned agent_config payload (via the same projection the
+	 * upgrade planner uses).
+	 *
+	 * @param array<string,mixed> $agent Installed agent row.
+	 * @return array<string,mixed>|null Drift report or null.
+	 */
+	private function manifest_drift( array $agent ): ?array {
+		$dir = AgentBundleDirectoryRegistry::resolve_for_agent( $agent );
+		if ( null === $dir ) {
+			return null;
+		}
+
+		try {
+			$directory = AgentBundleDirectory::read( $dir );
+		} catch ( BundleValidationException $e ) {
+			return array(
+				'path'      => $dir,
+				'available' => false,
+				'error'     => $e->getMessage(),
+				'has_drift' => false,
+			);
+		}
+
+		$manifest         = $directory->manifest();
+		$manifest_data    = $manifest->to_array();
+		$installed_bundle = $agent['agent_config']['datamachine_bundle'] ?? array();
+
+		$installed_version = (string) ( $installed_bundle['bundle_version'] ?? '' );
+		$manifest_version  = $manifest->bundle_version();
+		$version_drift     = $installed_version !== $manifest_version;
+
+		$installed_config_payload = AgentBundleAgentConfig::tracked_payload(
+			is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array()
+		);
+		$manifest_config_payload = AgentBundleAgentConfig::tracked_payload(
+			is_array( $manifest_data['agent']['agent_config'] ?? null ) ? $manifest_data['agent']['agent_config'] : array()
+		);
+
+		$config_drift = self::config_drift_fields( $installed_config_payload, $manifest_config_payload );
+
+		return array(
+			'path'           => $dir,
+			'available'      => true,
+			'bundle_version' => array(
+				'installed' => $installed_version,
+				'manifest'  => $manifest_version,
+				'drift'     => $version_drift,
+			),
+			'config_drift'   => $config_drift,
+			'has_drift'      => $version_drift || ! empty( $config_drift ),
+		);
+	}
+
+	/**
+	 * Report top-level config fields that differ between two tracked payloads.
+	 *
+	 * @param array<string,mixed> $installed Tracked installed config.
+	 * @param array<string,mixed> $manifest  Tracked manifest config.
+	 * @return array<int,array<string,mixed>> List of {key, installed, manifest} entries.
+	 */
+	public static function config_drift_fields( array $installed, array $manifest ): array {
+		$drift = array();
+		$keys  = array_unique( array_merge( array_keys( $installed ), array_keys( $manifest ) ) );
+		sort( $keys );
+
+		foreach ( $keys as $key ) {
+			$installed_value = array_key_exists( $key, $installed ) ? $installed[ $key ] : null;
+			$manifest_value  = array_key_exists( $key, $manifest ) ? $manifest[ $key ] : null;
+
+			if ( AgentBundleArtifactHasher::hash( $installed_value ) === AgentBundleArtifactHasher::hash( $manifest_value ) ) {
+				continue;
+			}
+
+			$drift[] = array(
+				'key'       => (string) $key,
+				'installed' => $installed_value,
+				'manifest'  => $manifest_value,
+			);
+		}
+
+		return $drift;
+	}
+
+	/**
+	 * Reconcile every installed bundle-backed agent against its on-disk manifest.
+	 *
+	 * Iterates all agents with a stored bundle_slug, resolves each one's
+	 * registered bundle directory, and runs the standard upgrade path.
+	 * Agents without a registered directory are reported as skipped.
+	 *
+	 * @param array<string,mixed> $input { dry_run?: bool }.
+	 * @return array<string,mixed>
+	 */
+	public function reconcile_all( array $input ): array {
+		$dry_run = ! empty( $input['dry_run'] );
+		$results = array();
+
+		foreach ( $this->agents->get_all() as $agent ) {
+			if ( ! is_array( $agent ) ) {
+				continue;
+			}
+
+			$bundle = $agent['agent_config']['datamachine_bundle'] ?? array();
+			if ( empty( $bundle['bundle_slug'] ) ) {
+				continue;
+			}
+
+			$slug   = (string) $agent['agent_slug'];
+			$dir    = AgentBundleDirectoryRegistry::resolve_for_agent( $agent );
+
+			if ( null === $dir ) {
+				$results[] = array(
+					'agent_slug'  => $slug,
+					'bundle_slug' => (string) $bundle['bundle_slug'],
+					'success'     => false,
+					'skipped'     => true,
+					'error'       => 'No registered bundle directory for this agent.',
+				);
+				continue;
+			}
+
+			$result = $this->upgrade(
+				array(
+					'source'  => $dir,
+					'slug'    => $slug,
+					'dry_run' => $dry_run,
+				)
+			);
+
+			$results[] = array_merge(
+				$result,
+				array(
+					'agent_slug'  => $slug,
+					'bundle_slug' => (string) $bundle['bundle_slug'],
+				)
+			);
+		}
+
+		return array(
+			'success'    => true,
+			'reconciled' => $results,
+			'count'      => count( $results ),
 		);
 	}
 

--- a/inc/Engine/Bundle/AgentBundleAbilityService.php
+++ b/inc/Engine/Bundle/AgentBundleAbilityService.php
@@ -79,8 +79,8 @@ final class AgentBundleAbilityService {
 		// deployed manifest change has not yet reached the live agent.
 		$drift = $this->manifest_drift( $agent );
 		if ( null !== $drift ) {
-			$status['manifest']            = $drift;
-			$status['has_manifest_drift']  = ! empty( $drift['has_drift'] );
+			$status['manifest']           = $drift;
+			$status['has_manifest_drift'] = ! empty( $drift['has_drift'] );
 		}
 
 		return $status;
@@ -997,7 +997,7 @@ final class AgentBundleAbilityService {
 		$installed_config_payload = AgentBundleAgentConfig::tracked_payload(
 			is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array()
 		);
-		$manifest_config_payload = AgentBundleAgentConfig::tracked_payload(
+		$manifest_config_payload  = AgentBundleAgentConfig::tracked_payload(
 			is_array( $manifest_data['agent']['agent_config'] ?? null ) ? $manifest_data['agent']['agent_config'] : array()
 		);
 
@@ -1070,8 +1070,8 @@ final class AgentBundleAbilityService {
 				continue;
 			}
 
-			$slug   = (string) $agent['agent_slug'];
-			$dir    = AgentBundleDirectoryRegistry::resolve_for_agent( $agent );
+			$slug = (string) $agent['agent_slug'];
+			$dir  = AgentBundleDirectoryRegistry::resolve_for_agent( $agent );
 
 			if ( null === $dir ) {
 				$results[] = array(

--- a/inc/Engine/Bundle/AgentBundleDirectoryRegistry.php
+++ b/inc/Engine/Bundle/AgentBundleDirectoryRegistry.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Agent bundle directory discovery registry.
+ *
+ * Resolves on-disk bundle directories shipped by integration plugins.
+ * Plugins register their bundle directories through the
+ * `datamachine_agent_bundle_directories` filter so that `agent diff`,
+ * `agent status`, and `agent upgrade` can resolve a slug to its source
+ * bundle without requiring an explicit filesystem path (#2860).
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Discover registered agent bundle directories by bundle slug.
+ */
+final class AgentBundleDirectoryRegistry {
+
+	/**
+	 * Collect registered bundle directories keyed by bundle slug.
+	 *
+	 * Integration plugins hook `datamachine_agent_bundle_directories` to
+	 * declare where their shipped bundle directories live:
+	 *
+	 *   add_filter( 'datamachine_agent_bundle_directories', function ( $dirs ) {
+	 *       $dirs['roadie'] = __DIR__ . '/bundles/roadie';
+	 *       return $dirs;
+	 *   } );
+	 *
+	 * Directories that do not exist on disk are silently dropped so a
+	 * stale registration never surfaces as a false-positive resolve.
+	 *
+	 * @return array<string,string> Normalized bundle_slug => absolute directory path.
+	 */
+	public static function directories(): array {
+		$registered = array();
+
+		if ( function_exists( 'apply_filters' ) ) {
+			/** @var mixed $filtered */
+			$filtered = apply_filters( 'datamachine_agent_bundle_directories', array() );
+			if ( is_array( $filtered ) ) {
+				$registered = $filtered;
+			}
+		}
+
+		$validated = array();
+		foreach ( $registered as $slug => $path ) {
+			$slug = PortableSlug::normalize( (string) $slug, 'bundle' );
+			$path = rtrim( (string) $path, '/\\' );
+
+			if ( '' === $slug || '' === $path || ! is_dir( $path ) ) {
+				continue;
+			}
+
+			$validated[ $slug ] = $path;
+		}
+
+		return $validated;
+	}
+
+	/**
+	 * Resolve a bundle directory path for a bundle slug.
+	 *
+	 * @param string $bundle_slug Bundle slug (will be normalized).
+	 * @return string|null Absolute directory path, or null when unregistered.
+	 */
+	public static function resolve_for_bundle_slug( string $bundle_slug ): ?string {
+		$slug = PortableSlug::normalize( $bundle_slug, 'bundle' );
+		if ( '' === $slug ) {
+			return null;
+		}
+
+		$dirs = self::directories();
+
+		return $dirs[ $slug ] ?? null;
+	}
+
+	/**
+	 * Resolve a bundle directory path for an installed agent row.
+	 *
+	 * Reads the agent's stored `datamachine_bundle.bundle_slug` and looks
+	 * up the registered directory for that slug.
+	 *
+	 * @param array<string,mixed> $agent Agent row with agent_config.
+	 * @return string|null Absolute directory path, or null when unregistered.
+	 */
+	public static function resolve_for_agent( array $agent ): ?string {
+		$bundle_slug = (string) ( $agent['agent_config']['datamachine_bundle']['bundle_slug'] ?? '' );
+		if ( '' === $bundle_slug ) {
+			return null;
+		}
+
+		return self::resolve_for_bundle_slug( $bundle_slug );
+	}
+}

--- a/tests/agent-bundle-manifest-reconcile-smoke.php
+++ b/tests/agent-bundle-manifest-reconcile-smoke.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * Smoke checks for agent bundle manifest reconciliation (#2860).
+ *
+ * Tests bundle directory discovery, manifest-vs-row drift detection,
+ * and operator-override survival through the projection policies that
+ * the reconcile path relies on.
+ *
+ * Run with: php tests/agent-bundle-manifest-reconcile-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failures = array();
+$passes   = 0;
+
+echo "agent-bundle-manifest-reconcile-smoke (#2860)\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+agents_api_smoke_require_module();
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/register-agent-package-artifacts.php';
+
+use DataMachine\Engine\Bundle\AgentBundleAbilityService;
+use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
+use DataMachine\Engine\Bundle\AgentBundleDirectoryRegistry;
+use DataMachine\Engine\Bundle\AgentConfigArtifactProjector;
+use DataMachine\Engine\Bundle\AgentBundleAgentConfig;
+
+// ---------------------------------------------------------------------------
+// Helper: create a temporary bundle directory with a manifest.json.
+// ---------------------------------------------------------------------------
+function reconcile_smoke_make_bundle_dir( string $slug, string $version, array $agent_config ): string {
+	$dir = sys_get_temp_dir() . '/dm-reconcile-' . $slug . '-' . uniqid();
+	if ( ! is_dir( $dir ) ) {
+		mkdir( $dir, 0755, true );
+	}
+
+	$manifest = array(
+		'schema_version'  => 1,
+		'bundle_slug'     => $slug,
+		'bundle_version'  => $version,
+		'exported_at'     => '2026-07-08T00:00:00Z',
+		'exported_by'     => 'data-machine/test',
+		'source_ref'      => '',
+		'source_revision' => '',
+		'agent'           => array(
+			'slug'         => $slug,
+			'label'        => ucfirst( $slug ),
+			'description'  => 'Test agent.',
+			'agent_config' => $agent_config,
+		),
+		'included'        => array(
+			'memory'        => array(),
+			'pipelines'     => array(),
+			'flows'         => array(),
+			'prompts'       => array(),
+			'rubrics'       => array(),
+			'tool_policies' => array(),
+			'auth_refs'     => array(),
+			'seed_queues'   => array(),
+			'extensions'    => array(),
+			'handler_auth'  => 'refs',
+		),
+	);
+
+	file_put_contents( $dir . '/manifest.json', wp_json_encode( $manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+
+	return $dir;
+}
+
+// ===========================================================================
+// [1] AgentBundleDirectoryRegistry resolves registered directories
+// ===========================================================================
+echo "\n[1] AgentBundleDirectoryRegistry resolves registered directories\n";
+
+$bundle_dir = reconcile_smoke_make_bundle_dir( 'test-agent', '1', array( 'default_model' => 'gpt-5.5' ) );
+
+add_filter(
+	'datamachine_agent_bundle_directories',
+	static function ( array $dirs ) use ( $bundle_dir ): array {
+		$dirs['test-agent'] = $bundle_dir;
+		return $dirs;
+	},
+	10,
+	1
+);
+
+$dirs = AgentBundleDirectoryRegistry::directories();
+agents_api_smoke_assert_equals( $bundle_dir, $dirs['test-agent'] ?? null, 'registered directory is collected', $failures, $passes );
+
+$resolved = AgentBundleDirectoryRegistry::resolve_for_bundle_slug( 'test-agent' );
+agents_api_smoke_assert_equals( $bundle_dir, $resolved, 'resolve_for_bundle_slug returns the path', $failures, $passes );
+
+$resolved_normalized = AgentBundleDirectoryRegistry::resolve_for_bundle_slug( 'Test Agent' );
+agents_api_smoke_assert_equals( $bundle_dir, $resolved_normalized, 'slug is normalized before lookup', $failures, $passes );
+
+// Resolve via agent row (simulated).
+$fake_agent = array(
+	'agent_config' => array(
+		'datamachine_bundle' => array(
+			'bundle_slug' => 'test-agent',
+		),
+	),
+);
+$resolved_via_agent = AgentBundleDirectoryRegistry::resolve_for_agent( $fake_agent );
+agents_api_smoke_assert_equals( $bundle_dir, $resolved_via_agent, 'resolve_for_agent returns the path from agent row', $failures, $passes );
+
+// Unregistered slug returns null.
+agents_api_smoke_assert_equals( null, AgentBundleDirectoryRegistry::resolve_for_bundle_slug( 'nonexistent' ), 'unregistered slug returns null', $failures, $passes );
+
+// Agent without bundle_slug returns null.
+agents_api_smoke_assert_equals( null, AgentBundleDirectoryRegistry::resolve_for_agent( array( 'agent_config' => array() ) ), 'agent without bundle_slug returns null', $failures, $passes );
+
+// ===========================================================================
+// [2] Registry drops stale (non-existent) directories
+// ===========================================================================
+echo "\n[2] Registry drops stale directories\n";
+
+add_filter(
+	'datamachine_agent_bundle_directories',
+	static function ( array $dirs ): array {
+		$dirs['stale-bundle'] = '/nonexistent/path/that/does/not/exist';
+		return $dirs;
+	},
+	20,
+	1
+);
+
+$dirs_after = AgentBundleDirectoryRegistry::directories();
+agents_api_smoke_assert_equals( false, array_key_exists( 'stale-bundle', $dirs_after ), 'non-existent directory is dropped', $failures, $passes );
+agents_api_smoke_assert_equals( $bundle_dir, $dirs_after['test-agent'] ?? null, 'valid directory survives alongside stale entry', $failures, $passes );
+
+// ===========================================================================
+// [3] config_drift_fields detects manifest-vs-row divergence
+// ===========================================================================
+echo "\n[3] config_drift_fields detects manifest-vs-row divergence\n";
+
+$installed_config = array(
+	'default_model'    => 'gpt-5.4-nano',
+	'default_provider' => 'openai',
+	'description'      => 'Test agent.',
+);
+
+$manifest_config = array(
+	'default_model'    => 'gpt-5.5',
+	'default_provider' => 'openai',
+	'description'      => 'Test agent.',
+);
+
+$drift = AgentBundleAbilityService::config_drift_fields( $installed_config, $manifest_config );
+agents_api_smoke_assert_equals( 1, count( $drift ), 'only the changed key (default_model) is reported as drift', $failures, $passes );
+agents_api_smoke_assert_equals( 'default_model', $drift[0]['key'] ?? '', 'drift key is default_model', $failures, $passes );
+agents_api_smoke_assert_equals( 'gpt-5.4-nano', $drift[0]['installed'] ?? null, 'installed value is the old model', $failures, $passes );
+agents_api_smoke_assert_equals( 'gpt-5.5', $drift[0]['manifest'] ?? null, 'manifest value is the new model', $failures, $passes );
+
+// ===========================================================================
+// [4] config_drift_fields returns empty when configs match
+// ===========================================================================
+echo "\n[4] config_drift_fields returns empty when configs match\n";
+
+$matching_drift = AgentBundleAbilityService::config_drift_fields( $installed_config, $installed_config );
+agents_api_smoke_assert_equals( array(), $matching_drift, 'identical configs produce no drift', $failures, $passes );
+
+// Key order difference does not cause false drift.
+$reordered = array( 'description' => 'Test agent.', 'default_provider' => 'openai', 'default_model' => 'gpt-5.4-nano' );
+$reordered_drift = AgentBundleAbilityService::config_drift_fields( $installed_config, $reordered );
+agents_api_smoke_assert_equals( array(), $reordered_drift, 'key order difference does not cause drift', $failures, $passes );
+
+// ===========================================================================
+// [5] config_drift_fields detects added and removed keys
+// ===========================================================================
+echo "\n[5] config_drift_fields detects added and removed keys\n";
+
+$config_with_extra = array_merge( $installed_config, array( 'tool_policy' => array( 'mode' => 'deny' ) ) );
+$added_drift = AgentBundleAbilityService::config_drift_fields( $installed_config, $config_with_extra );
+agents_api_smoke_assert_equals( 1, count( $added_drift ), 'added key is reported as drift', $failures, $passes );
+agents_api_smoke_assert_equals( 'tool_policy', $added_drift[0]['key'] ?? '', 'added key name is tool_policy', $failures, $passes );
+agents_api_smoke_assert_equals( true, array_key_exists( 'installed', $added_drift[0] ) && null === $added_drift[0]['installed'], 'added key has null installed value', $failures, $passes );
+
+$removed_drift = AgentBundleAbilityService::config_drift_fields( $config_with_extra, $installed_config );
+agents_api_smoke_assert_equals( 1, count( $removed_drift ), 'removed key is reported as drift', $failures, $passes );
+agents_api_smoke_assert_equals( 'tool_policy', $removed_drift[0]['key'] ?? '', 'removed key name is tool_policy', $failures, $passes );
+agents_api_smoke_assert_equals( true, array_key_exists( 'manifest', $removed_drift[0] ) && null === $removed_drift[0]['manifest'], 'removed key has null manifest value', $failures, $passes );
+
+// ===========================================================================
+// [6] tracked_payload excludes datamachine_bundle (not bundle-owned)
+// ===========================================================================
+echo "\n[6] tracked_payload excludes datamachine_bundle from drift comparison\n";
+
+$config_with_bundle_header = array(
+	'default_model'         => 'gpt-5.5',
+	'datamachine_bundle'    => array(
+		'bundle_slug'    => 'test-agent',
+		'bundle_version' => '2',
+	),
+);
+
+$config_without_bundle_header = array(
+	'default_model' => 'gpt-5.5',
+);
+
+$tracked_a = AgentBundleAgentConfig::tracked_payload( $config_with_bundle_header );
+$tracked_b = AgentBundleAgentConfig::tracked_payload( $config_without_bundle_header );
+$bundle_header_drift = AgentBundleAbilityService::config_drift_fields( $tracked_a, $tracked_b );
+agents_api_smoke_assert_equals( array(), $bundle_header_drift, 'datamachine_bundle key does not cause drift (excluded from tracked payload)', $failures, $passes );
+
+// ===========================================================================
+// [7] Operator override survives upgrade via preserve_local_paths
+// ===========================================================================
+echo "\n[7] Operator override survives upgrade via preserve_local_paths\n";
+
+// Simulate: manifest ships model=4o, operator overrode to 5.5 locally.
+// The 'model' key has preserve_local merge policy, so the operator's
+// value must survive even when the manifest payload is applied.
+$operator_config = array(
+	'model' => 'gpt-5.5',
+);
+
+$manifest_payload = array(
+	'model' => 'gpt-4o',
+);
+
+$preserved = AgentConfigArtifactProjector::preserve_local_paths( $manifest_payload, $operator_config );
+agents_api_smoke_assert_equals( 'gpt-5.5', $preserved['model'] ?? null, 'operator model override survives preserve_local_paths', $failures, $passes );
+
+// Keys WITHOUT a preserve_local policy are NOT restored (manifest wins on merge).
+$operator_config_no_policy = array(
+	'default_model' => 'gpt-5.5',
+);
+$manifest_payload_no_policy = array(
+	'default_model' => 'gpt-4o',
+);
+$not_preserved = AgentConfigArtifactProjector::preserve_local_paths( $manifest_payload_no_policy, $operator_config_no_policy );
+agents_api_smoke_assert_equals( 'gpt-4o', $not_preserved['default_model'] ?? null, 'non-preserve_local key is not restored (three_way merge applies)', $failures, $passes );
+
+// ===========================================================================
+// [8] Hash comparison is order-independent for drift detection
+// ===========================================================================
+echo "\n[8] Hash comparison is order-independent for drift detection\n";
+
+$nested_a = array( 'b' => 2, 'a' => 1, 'steps' => array( 'fetch', 'ai' ) );
+$nested_b = array( 'steps' => array( 'fetch', 'ai' ), 'a' => 1, 'b' => 2 );
+agents_api_smoke_assert_equals(
+	AgentBundleArtifactHasher::hash( $nested_a ),
+	AgentBundleArtifactHasher::hash( $nested_b ),
+	'associative key order does not affect hash (drift is not a false positive)',
+	$failures,
+	$passes
+);
+
+// List order DOES matter (different content = drift).
+$nested_c = array( 'a' => 1, 'b' => 2, 'steps' => array( 'ai', 'fetch' ) );
+$hash_differs = AgentBundleArtifactHasher::hash( $nested_a ) !== AgentBundleArtifactHasher::hash( $nested_c );
+agents_api_smoke_assert_equals( true, $hash_differs, 'list order difference is detected as drift', $failures, $passes );
+
+// ===========================================================================
+// [9] CLI and ability surfaces reference the new reconcile entry points
+// ===========================================================================
+echo "\n[9] CLI and ability surfaces reference reconcile entry points\n";
+
+$ability_source = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/AgentAbilities.php' );
+$cli_source     = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Cli/Commands/AgentBundleCommand.php' );
+$service_source = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleAbilityService.php' );
+$registry_file  = dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleDirectoryRegistry.php';
+
+agents_api_smoke_assert_equals( true, str_contains( $ability_source, 'reconcileAllAgentBundles' ), 'reconcileAllAgentBundles ability method exists', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $cli_source, "'all'" ) || str_contains( $cli_source, '--all' ), 'CLI upgrade --all flag is present', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $service_source, 'resolve_bundle_directory_for_slug' ), 'service has slug resolution method', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $service_source, 'manifest_drift' ), 'service has manifest_drift method', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $service_source, 'config_drift_fields' ), 'service has config_drift_fields method', $failures, $passes );
+agents_api_smoke_assert_equals( true, file_exists( $registry_file ), 'AgentBundleDirectoryRegistry file exists', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( (string) file_get_contents( $registry_file ), 'datamachine_agent_bundle_directories' ), 'registry uses datamachine_agent_bundle_directories filter', $failures, $passes );
+
+// ===========================================================================
+// [10] Precedence rule: three_way keys apply manifest when operator hasn't diverged
+// ===========================================================================
+echo "\n[10] Precedence rule: manifest applies to untouched keys\n";
+
+// When the installed (base) == current (operator didn't touch), the manifest
+// change should be detectable as drift and applyable. We verify this through
+// the drift comparison: if base == current and manifest differs, drift is
+// reported — which is the signal that `agent upgrade` would auto-apply.
+$base_config    = array( 'default_model' => 'gpt-5.4-nano' );
+$current_config = array( 'default_model' => 'gpt-5.4-nano' ); // operator didn't touch
+$target_config  = array( 'default_model' => 'gpt-5.5' );     // manifest changed
+
+$drift_base_to_target = AgentBundleAbilityService::config_drift_fields( $current_config, $target_config );
+agents_api_smoke_assert_equals( 1, count( $drift_base_to_target ), 'manifest change is detected as drift when operator has not diverged', $failures, $passes );
+
+// When operator already fixed it to the same value as the manifest — no drift.
+$operator_fixed = array( 'default_model' => 'gpt-5.5' );
+$drift_after_fix = AgentBundleAbilityService::config_drift_fields( $operator_fixed, $target_config );
+agents_api_smoke_assert_equals( array(), $drift_after_fix, 'no drift when operator already set the same value as the manifest', $failures, $passes );
+
+// Cleanup temp directory.
+if ( is_dir( $bundle_dir ) ) {
+	unlink( $bundle_dir . '/manifest.json' );
+	rmdir( $bundle_dir );
+}
+
+agents_api_smoke_finish( 'agent bundle manifest reconcile', $failures, $passes );


### PR DESCRIPTION
## Summary

Fixes #2860

Agent bundle manifests shipped by integration plugins were only applied to the live agent DB row at install/adopt time. Subsequent manifest changes deployed with the plugin but never reconciled into the row, causing silent drift. Production case: a `default_model` bump (`gpt-5.4-nano` → `gpt-5.5`) shipped in the roadie repo on June 30 but the live agent row kept nano for 8+ days, causing real session failures.

Compounding factor: `wp datamachine agent diff <slug>` and `agent upgrade <slug>` errored with "Bundle path not found: \<slug\>" because those commands required an explicit filesystem path — operators only knew the agent slug.

## Investigation findings

### Why "Bundle path not found" happens

`agent diff`, `agent upgrade`, `agent inspect`, `agent validate`, `agent adopt`, and `agent rebase` all take a `<path>` positional argument. The source string flows through `BundleSource::resolve()` (`inc/Engine/Bundle/BundleSource.php:64`), which treats any non-remote string as a local path and checks `file_exists($source)`. When the operator passes a slug like `roadie`, `file_exists("roadie")` is false → WP_Error "Bundle path not found: roadie".

### Why there was no bundle discovery mechanism

There was **no filter or registry** for integration plugins to declare where their on-disk bundle directories live. The `datamachine_agent_bundle_directories` filter did not exist. Integration plugins (e.g. extrachill-roadie) ship bundles at `bundles/<slug>/manifest.json` but had no way to tell Data Machine where they were — installation was a manual `wp datamachine agent install <path>` invocation with no automated discovery or reconcile-on-activate path.

### Why `source_ref`/`source_revision` didn't help

The stored `datamachine_bundle.source_ref`/`source_revision` fields on the agent row are provenance metadata (URL / git SHA for remote sources), not resolvable local paths. They are empty for locally-installed bundles and were never designed to be read back as a filesystem path for diff/upgrade.

### The existing precedence system was correct but unreachable

The 3-way artifact ledger (`installed_hash` / `current_hash` / target hash) already implements the right precedence:
- **Clean artifacts** (current == installed, target differs) → auto-apply.
- **Locally modified artifacts** where target also differs → staged as conflict for approval (don't clobber).
- **Locally modified artifacts** where target matches current → no conflict, no-op (operator already fixed it).
- **`preserve_local` paths** (`model`, `provider`, `allowed_redirect_uris`) → operator values always survive via `AgentConfigArtifactProjector::preserve_local_paths()`.

The problem was purely that this system was unreachable without slug-based discovery — nobody could run `agent upgrade <slug>` to trigger it.

## What changed

### 1. Bundle directory discovery — `AgentBundleDirectoryRegistry`

New class (`inc/Engine/Bundle/AgentBundleDirectoryRegistry.php`) with a `datamachine_agent_bundle_directories` filter. Integration plugins register their bundle directories:

```php
add_filter( 'datamachine_agent_bundle_directories', function ( $dirs ) {
    $dirs['roadie'] = __DIR__ . '/bundles/roadie';
    return $dirs;
} );
```

Stale/non-existent directories are silently dropped. The registry resolves by bundle slug, by agent row, or by raw slug (tries direct match, then falls back to resolving through an installed agent's stored `bundle_slug`).

### 2. Slug resolution in `load_bundle_from_input`

`AgentBundleAbilityService::load_bundle_from_input()` now checks: if the source is neither a remote URL nor an existing local path, treat it as a slug and resolve it through the registry. This makes **all** path-based commands (`diff`, `upgrade`, `inspect`, `validate`, `adopt`, `rebase`) accept slugs:

```
wp datamachine agent diff roadie       # was: "Bundle path not found: roadie"
wp datamachine agent upgrade roadie    # now works
wp datamachine agent inspect roadie    # now works
```

### 3. Manifest drift detection in `status`

`agent status <slug>` now loads the on-disk manifest (when discoverable) and compares `bundle_version` + the tracked `agent_config` payload against the installed row. Returns:
- `has_manifest_drift` (bool) — quick signal
- `manifest.bundle_version.drift` — version mismatch
- `manifest.config_drift` — per-field `{key, installed, manifest}` entries

Table output shows a `drift` column and prints warnings for each drifted field.

### 4. Reconcile verb — `agent upgrade <slug>` and `--all`

`agent upgrade` now accepts either a slug or a path. When given a slug, it resolves the on-disk bundle directory and runs the existing upgrade machinery (3-way merge via the artifact ledger). The `--all` flag iterates every installed bundle-backed agent and reconciles each one against its registered on-disk manifest.

### 5. Tests

New smoke test (`tests/agent-bundle-manifest-reconcile-smoke.php`, 34 assertions):
- Registry resolves registered directories, normalizes slugs, drops stale paths
- `config_drift_fields` detects changed/added/removed keys, ignores key order
- `tracked_payload` excludes `datamachine_bundle` from drift comparison
- Operator override survives via `preserve_local_paths` (model key)
- Non-preserve_local keys are not restored (three_way merge applies)
- Hash comparison is order-independent (no false drift)
- No drift when operator already set the same value as the manifest
- CLI/ability surfaces reference the new entry points

## Precedence rule (existing, documented here for clarity)

The reconcile path uses the **existing** 3-way artifact ledger. No new precedence system was built:

| Scenario | installed (base) | current (live) | target (manifest) | Behavior |
|---|---|---|---|---|
| Operator didn't touch | A | A | B | **Auto-apply** (clean → target wins) |
| Operator touched, manifest didn't | A | B | A | **No-op** (target == installed, no drift) |
| Operator touched, manifest changed same way | A | B | B | **No conflict** (target == current, no-op) |
| Operator touched, manifest changed differently | A | B | C | **Conflict** (staged for approval, don't clobber) |
| `preserve_local` key (model, provider) | A | B | C | **Operator wins** (always preserved) |

This is the correct shape: operator overrides survive unless explicitly reset, manifest changes reach the row when the operator hasn't diverged, and genuine conflicts are surfaced for human review rather than silently clobbered.

## Integration plugin follow-up

Integration plugins (extrachill-roadie, extrachill-event-bundles, etc.) need to hook `datamachine_agent_bundle_directories` to register their bundle directories. This is a one-line change per plugin — out of scope for this Data Machine PR.