### PR TITLE
feat: bridge wp_agent_can_access_agent into datamachine_can_access_agent

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -794,12 +794,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "59d1e6b473f22498e40e279130bbb4f9bcde3b73"
+                "reference": "c1183c44f7d6ef21e162b5ac42532c27f8ff7d22"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/59d1e6b473f22498e40e279130bbb4f9bcde3b73",
-                "reference": "59d1e6b473f22498e40e279130bbb4f9bcde3b73",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/c1183c44f7d6ef21e162b5ac42532c27f8ff7d22",
+                "reference": "c1183c44f7d6ef21e162b5ac42532c27f8ff7d22",
                 "shasum": ""
             },
             "require": {
@@ -836,8 +836,10 @@
                     "php tests/package-adoption-orchestration-smoke.php",
                     "php tests/execution-principal-smoke.php",
                     "php tests/effective-agent-resolver-smoke.php",
+                    "php tests/runtime-profile-smoke.php",
                     "php tests/caller-context-smoke.php",
                     "php tests/authorization-smoke.php",
+                    "php tests/autonomous-capability-ceiling-smoke.php",
                     "php tests/agents-access-ability-smoke.php",
                     "php tests/agents-conversation-session-abilities-smoke.php",
                     "php tests/conversation-session-store-contract-smoke.php",
@@ -848,6 +850,7 @@
                     "php tests/tool-executor-registry-smoke.php",
                     "php tests/tool-result-error-type-smoke.php",
                     "php tests/runtime-tool-policy-smoke.php",
+                    "php tests/write-capable-default-smoke.php",
                     "php tests/runtime-tool-lifecycle-abilities-smoke.php",
                     "php tests/tool-tier-resolver-smoke.php",
                     "php tests/action-policy-resolver-smoke.php",
@@ -883,6 +886,7 @@
                     "php tests/default-provider-turn-adapter-smoke.php",
                     "php tests/default-agents-chat-handler-smoke.php",
                     "php tests/ability-tool-executor-smoke.php",
+                    "php tests/ability-tool-ceiling-smoke.php",
                     "php tests/tool-mediation-runner-smoke.php",
                     "php tests/conversation-loop-tool-execution-smoke.php",
                     "php tests/tool-call-gate-smoke.php",
@@ -917,6 +921,7 @@
                     "php tests/workflow-parallel-async-smoke.php",
                     "php tests/workflow-as-branch-smoke.php",
                     "php tests/workflow-branch-concurrency-gate-smoke.php",
+                    "php tests/workflow-scoped-drain-smoke.php",
                     "php tests/workflow-async-branch-payload-smoke.php",
                     "php tests/workflow-async-loopback-target-smoke.php",
                     "php tests/workflow-reconcile-race-smoke.php",
@@ -925,6 +930,7 @@
                     "php tests/routine-smoke.php",
                     "php tests/event-trigger-smoke.php",
                     "php tests/subagents-smoke.php",
+                    "php tests/access-decision-filter-smoke.php",
                     "php tests/no-product-imports-smoke.php"
                 ],
                 "test": [
@@ -940,7 +946,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-07-03T14:34:26+00:00"
+            "time": "2026-07-08T14:21:40+00:00"
         }
     ],
     "packages-dev": [
@@ -1636,6 +1642,6 @@
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
 }

--- a/inc/Core/Auth/AgentAccessFilterBridge.php
+++ b/inc/Core/Auth/AgentAccessFilterBridge.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Bridges the Agents API `wp_agent_can_access_agent` substrate filter into
+ * Data Machine's existing `datamachine_can_access_agent` host filter.
+ *
+ * @package DataMachine\Core\Auth
+ * @since   0.159.12
+ */
+
+namespace DataMachine\Core\Auth;
+
+use DataMachine\Core\Database\Agents\Agents;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Converges Data Machine's two agent-access resolution paths.
+ *
+ * Without this bridge, the agents-api ability path (`agents/can-access-agent`
+ * and `agents/list-accessible-agents`) resolves access exclusively through the
+ * access-store contract, while Data Machine's internal path applies the
+ * `datamachine_can_access_agent` filter. The two paths silently disagree:
+ * host plugins that widen access via the filter are invisible to every
+ * ability-driven consumer (chat widgets, MCP, REST).
+ *
+ * The bridge forwards the substrate's final store-derived decision — which
+ * already includes the effective-agent short-circuit — into Data Machine's
+ * filter so both tighten and widen semantics are honored, then returns
+ * whatever the filter produces.
+ */
+class AgentAccessFilterBridge {
+
+	/**
+	 * Agent identity repository used to map Agents API slugs to numeric IDs.
+	 *
+	 * @var Agents
+	 */
+	private Agents $agents_repository;
+
+	/**
+	 * @param Agents|null $agents_repository Optional repository for tests.
+	 */
+	public function __construct( ?Agents $agents_repository = null ) {
+		$this->agents_repository = $agents_repository ?? new Agents();
+	}
+
+	/**
+	 * Register the substrate access-filter bridge.
+	 */
+	public static function register(): void {
+		static $bridge = null;
+
+		if ( null === $bridge ) {
+			$bridge = new self();
+		}
+
+		add_filter( 'wp_agent_can_access_agent', array( $bridge, 'bridge_access_decision' ), 10, 5 );
+	}
+
+	/**
+	 * Forward the substrate access decision into Data Machine's host filter.
+	 *
+	 * Only user principals (`acting_user_id > 0`) are forwarded: Data Machine's
+	 * filter is user-centric, so audience/anonymous principals pass through with
+	 * the substrate's store-derived decision unchanged. The substrate's current
+	 * `$allowed` value is seeded into the host filter so hooks can tighten as
+	 * well as widen the decision (including the effective-agent short-circuit).
+	 *
+	 * @param bool                                       $allowed      Store-derived decision.
+	 * @param \AgentsAPI\AI\WP_Agent_Execution_Principal $principal    Execution principal.
+	 * @param string                                     $agent_id     Agents API agent identifier (slug or numeric).
+	 * @param string                                     $minimum_role Minimum access role.
+	 * @param array<string,mixed>                        $context      Host-owned authorization context.
+	 * @return bool
+	 */
+	public function bridge_access_decision( $allowed, $principal, $agent_id, $minimum_role, $context = array() ) {
+		unset( $context );
+
+		if ( ! $principal instanceof \AgentsAPI\AI\WP_Agent_Execution_Principal ) {
+			return $allowed;
+		}
+
+		if ( $principal->acting_user_id <= 0 ) {
+			return $allowed;
+		}
+
+		$numeric_agent_id = $this->resolve_numeric_agent_id( (string) $agent_id );
+		if ( null === $numeric_agent_id ) {
+			return $allowed;
+		}
+
+		/**
+		 * Filters whether a user can access an agent.
+		 *
+		 * Host plugins (e.g. team-membership bridges) hook this to widen or
+		 * tighten access based on live state (capabilities, roles, memberships)
+		 * without materializing grant rows. The substrate decision is seeded as
+		 * the initial value so hooks can both grant and revoke.
+		 *
+		 * @since 0.62.0
+		 *
+		 * @param bool   $can_access   Whether the user can access the agent.
+		 * @param int    $agent_id     Agent ID.
+		 * @param int    $user_id      User ID.
+		 * @param string $minimum_role Minimum role required.
+		 */
+		return (bool) apply_filters( 'datamachine_can_access_agent', (bool) $allowed, $numeric_agent_id, $principal->acting_user_id, (string) $minimum_role );
+	}
+
+	/**
+	 * Resolve an Agents API agent identifier to Data Machine's numeric ID.
+	 *
+	 * Numeric identifiers are returned verbatim; slugs are resolved through the
+	 * agent identity repository. Unresolvable slugs yield null so the caller
+	 * can pass the substrate decision through unchanged.
+	 */
+	private function resolve_numeric_agent_id( string $agent_id ): ?int {
+		if ( is_numeric( $agent_id ) ) {
+			return (int) $agent_id;
+		}
+
+		$row = $this->agents_repository->get_by_slug( $agent_id );
+		if ( $row && ! empty( $row['agent_id'] ) ) {
+			return (int) $row['agent_id'];
+		}
+
+		return null;
+	}
+}

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -77,6 +77,7 @@ use DataMachine\Abilities\AbilityScopePermissionFilter;
 use DataMachine\Abilities\AgentAbilities;
 use DataMachine\Core\Content\ContentFormat;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
+use DataMachine\Core\Auth\AgentAccessFilterBridge;
 use DataMachine\Core\Auth\AgentAccessStoreAdapter;
 use DataMachine\Core\Identity\AgentIdentityStoreAdapter;
 use DataMachine\Core\OAuth\HttpBasicAuthProvider;
@@ -112,6 +113,7 @@ add_filter(
 );
 
 AgentAccessStoreAdapter::register();
+AgentAccessFilterBridge::register();
 AgentIdentityStoreAdapter::register();
 
 add_filter(

--- a/tests/agents-api-access-filter-bridge-smoke.php
+++ b/tests/agents-api-access-filter-bridge-smoke.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Pure-PHP smoke test for the wp_agent_can_access_agent bridge.
+ *
+ * Verifies that Data Machine's `datamachine_can_access_agent` host filter is
+ * applied on the Agents API ability path, with tighten + widen semantics,
+ * a user-principal guard, and slug↔numeric ID translation.
+ *
+ * Run with: php tests/agents-api-access-filter-bridge-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+require_once dirname( __DIR__ ) . '/inc/Core/Database/BaseRepository.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Database/Agents/Agents.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Auth/AgentAccessFilterBridge.php';
+
+use DataMachine\Core\Auth\AgentAccessFilterBridge;
+use DataMachine\Core\Database\Agents\Agents;
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		$key = strtolower( (string) $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+$GLOBALS['wpdb'] = (object) array(
+	'base_prefix' => 'wp_',
+	'prefix'      => 'wp_',
+);
+
+$failures = array();
+$passes   = 0;
+
+/**
+ * Fake agent identity repository for slug→ID resolution.
+ */
+class AgentAccessFilterBridgeFakeAgentsRepository extends Agents {
+
+	/** @var array<int,array<string,mixed>> */
+	private array $rows;
+
+	/**
+	 * @param array<int,array<string,mixed>> $rows Agent rows keyed by ID.
+	 */
+	public function __construct( array $rows ) {
+		$this->rows = $rows;
+	}
+
+	public function get_by_slug( string $agent_slug ): ?array {
+		foreach ( $this->rows as $row ) {
+			if ( ( $row['agent_slug'] ?? '' ) === $agent_slug ) {
+				return $row;
+			}
+		}
+
+		return null;
+	}
+}
+
+/**
+ * Clear any hooked datamachine_can_access_agent callbacks between scenarios.
+ */
+function agent_access_filter_bridge_clear_hooks(): void {
+	unset( $GLOBALS['__agents_api_smoke_filters']['datamachine_can_access_agent'] );
+}
+
+echo "agents-api-access-filter-bridge-smoke\n";
+
+$agents = new AgentAccessFilterBridgeFakeAgentsRepository(
+	array(
+		42 => array(
+			'agent_id'   => 42,
+			'agent_slug' => 'wiki-brain',
+		),
+		77 => array(
+			'agent_id'   => 77,
+			'agent_slug' => 'summarizer',
+		),
+	)
+);
+
+$bridge = new AgentAccessFilterBridge( $agents );
+
+$user_principal    = \AgentsAPI\AI\WP_Agent_Execution_Principal::user_session( 7, '__wordpress_user__' );
+$audience_principal = \AgentsAPI\AI\WP_Agent_Execution_Principal::audience( 'audience:public', '__wordpress_user__' );
+
+// ---- 1. Grant hook widens access with no store row (seed false → true) ----
+agent_access_filter_bridge_clear_hooks();
+add_filter(
+	'datamachine_can_access_agent',
+	static function ( $can_access, $agent_id, $user_id, $minimum_role ) {
+		return 42 === (int) $agent_id && 7 === (int) $user_id;
+	},
+	10,
+	4
+);
+
+agents_api_smoke_assert_equals( true, $bridge->bridge_access_decision( false, $user_principal, 'wiki-brain', \WP_Agent_Access_Grant::ROLE_VIEWER, array() ), 'grant hook widens denied store decision to true', $failures, $passes );
+
+$last_hook_args = null;
+agent_access_filter_bridge_clear_hooks();
+add_filter(
+	'datamachine_can_access_agent',
+	static function ( $can_access, $agent_id, $user_id, $minimum_role ) use ( &$last_hook_args ) {
+		$last_hook_args = array( $can_access, (int) $agent_id, (int) $user_id, (string) $minimum_role );
+		return $can_access;
+	},
+	10,
+	4
+);
+$bridge->bridge_access_decision( false, $user_principal, 'wiki-brain', \WP_Agent_Access_Grant::ROLE_VIEWER, array() );
+agents_api_smoke_assert_equals( array( false, 42, 7, \WP_Agent_Access_Grant::ROLE_VIEWER ), $last_hook_args, 'hook receives numeric agent ID, user ID, and seed decision', $failures, $passes );
+
+// ---- 2. Deny hook tightens access despite a store grant (seed true → false) ----
+agent_access_filter_bridge_clear_hooks();
+add_filter(
+	'datamachine_can_access_agent',
+	static function ( $can_access, $agent_id, $user_id, $minimum_role ) {
+		return false;
+	},
+	10,
+	4
+);
+
+agents_api_smoke_assert_equals( false, $bridge->bridge_access_decision( true, $user_principal, 'wiki-brain', \WP_Agent_Access_Grant::ROLE_VIEWER, array() ), 'deny hook tightens granted store decision to false', $failures, $passes );
+
+// ---- 3. No hook = unchanged store behavior (both directions) ----
+agent_access_filter_bridge_clear_hooks();
+
+agents_api_smoke_assert_equals( true, $bridge->bridge_access_decision( true, $user_principal, 'wiki-brain', \WP_Agent_Access_Grant::ROLE_VIEWER, array() ), 'no hook passes granted store decision through unchanged', $failures, $passes );
+agents_api_smoke_assert_equals( false, $bridge->bridge_access_decision( false, $user_principal, 'wiki-brain', \WP_Agent_Access_Grant::ROLE_VIEWER, array() ), 'no hook passes denied store decision through unchanged', $failures, $passes );
+
+// ---- 4. Audience principals unaffected (hook must not run) ----
+$audience_hook_ran = false;
+agent_access_filter_bridge_clear_hooks();
+add_filter(
+	'datamachine_can_access_agent',
+	static function ( $can_access ) use ( &$audience_hook_ran ) {
+		$audience_hook_ran = true;
+		return false;
+	},
+	10,
+	4
+);
+
+agents_api_smoke_assert_equals( true, $bridge->bridge_access_decision( true, $audience_principal, 'wiki-brain', \WP_Agent_Access_Grant::ROLE_VIEWER, array() ), 'audience principal passes granted decision through unchanged', $failures, $passes );
+agents_api_smoke_assert_equals( false, $audience_hook_ran, 'datamachine_can_access_agent hook is not invoked for audience principals', $failures, $passes );
+
+// ---- 5. Unresolvable slug passes through unchanged (hook must not run) ----
+$unresolved_hook_ran = false;
+agent_access_filter_bridge_clear_hooks();
+add_filter(
+	'datamachine_can_access_agent',
+	static function ( $can_access ) use ( &$unresolved_hook_ran ) {
+		$unresolved_hook_ran = true;
+		return true;
+	},
+	10,
+	4
+);
+
+agents_api_smoke_assert_equals( false, $bridge->bridge_access_decision( false, $user_principal, 'ghost-agent', \WP_Agent_Access_Grant::ROLE_VIEWER, array() ), 'unresolvable slug passes denied decision through unchanged', $failures, $passes );
+agents_api_smoke_assert_equals( false, $unresolved_hook_ran, 'hook is not invoked when slug cannot be resolved to a numeric ID', $failures, $passes );
+
+// ---- 6. Numeric agent identifier bypasses slug resolution ----
+agent_access_filter_bridge_clear_hooks();
+add_filter(
+	'datamachine_can_access_agent',
+	static function ( $can_access, $agent_id, $user_id, $minimum_role ) {
+		return 77 === (int) $agent_id && 7 === (int) $user_id;
+	},
+	10,
+	4
+);
+
+agents_api_smoke_assert_equals( true, $bridge->bridge_access_decision( false, $user_principal, '77', \WP_Agent_Access_Grant::ROLE_VIEWER, array() ), 'numeric agent identifier is forwarded to hook without slug resolution', $failures, $passes );
+
+// ---- 7. Register wires the bridge into the substrate filter ----
+$GLOBALS['__agents_api_smoke_filters'] = array();
+AgentAccessFilterBridge::register();
+$registered = $GLOBALS['__agents_api_smoke_filters']['wp_agent_can_access_agent'][10] ?? array();
+agents_api_smoke_assert_equals( true, ! empty( $registered ), 'register() hooks wp_agent_can_access_agent', $failures, $passes );
+
+// ---- 8. Non-principal value passes through unchanged ----
+agent_access_filter_bridge_clear_hooks();
+add_filter(
+	'datamachine_can_access_agent',
+	static function () {
+		return true;
+	},
+	10,
+	4
+);
+
+agents_api_smoke_assert_equals( true, $bridge->bridge_access_decision( true, null, 'wiki-brain', \WP_Agent_Access_Grant::ROLE_VIEWER, array() ), 'non-principal value passes through unchanged', $failures, $passes );
+
+agents_api_smoke_finish( 'access-filter bridge smoke', $failures, $passes );

--- a/tests/agents-api-access-filter-bridge-smoke.php
+++ b/tests/agents-api-access-filter-bridge-smoke.php
@@ -64,8 +64,15 @@ class AgentAccessFilterBridgeFakeAgentsRepository extends Agents {
 
 /**
  * Clear any hooked datamachine_can_access_agent callbacks between scenarios.
+ *
+ * Uses the real WordPress hook API when available (CI host-smoke-wp backend)
+ * and falls back to the pure-PHP stub harness's filter global otherwise.
  */
 function agent_access_filter_bridge_clear_hooks(): void {
+	if ( function_exists( 'remove_all_filters' ) ) {
+		remove_all_filters( 'datamachine_can_access_agent' );
+	}
+
 	unset( $GLOBALS['__agents_api_smoke_filters']['datamachine_can_access_agent'] );
 }
 
@@ -181,10 +188,17 @@ add_filter(
 agents_api_smoke_assert_equals( true, $bridge->bridge_access_decision( false, $user_principal, '77', \WP_Agent_Access_Grant::ROLE_VIEWER, array() ), 'numeric agent identifier is forwarded to hook without slug resolution', $failures, $passes );
 
 // ---- 7. Register wires the bridge into the substrate filter ----
-$GLOBALS['__agents_api_smoke_filters'] = array();
+if ( function_exists( 'remove_all_filters' ) ) {
+	remove_all_filters( 'wp_agent_can_access_agent' );
+}
+unset( $GLOBALS['__agents_api_smoke_filters']['wp_agent_can_access_agent'] );
 AgentAccessFilterBridge::register();
-$registered = $GLOBALS['__agents_api_smoke_filters']['wp_agent_can_access_agent'][10] ?? array();
-agents_api_smoke_assert_equals( true, ! empty( $registered ), 'register() hooks wp_agent_can_access_agent', $failures, $passes );
+if ( function_exists( 'has_filter' ) ) {
+	$registered = false !== has_filter( 'wp_agent_can_access_agent' );
+} else {
+	$registered = ! empty( $GLOBALS['__agents_api_smoke_filters']['wp_agent_can_access_agent'][10] ?? array() );
+}
+agents_api_smoke_assert_equals( true, $registered, 'register() hooks wp_agent_can_access_agent', $failures, $passes );
 
 // ---- 8. Non-principal value passes through unchanged ----
 agent_access_filter_bridge_clear_hooks();


### PR DESCRIPTION
## Problem

Data Machine has two agent-access resolution paths that silently disagree:

1. **DM-internal path** — `PermissionHelper::can_access_agent()` and `AgentAbilities::user_can_access_agent_row()` apply the `datamachine_can_access_agent` filter after the grant-store check. Host plugins hook this filter to widen (or tighten) access based on live state (capabilities, roles, memberships).
2. **agents-api ability path** — `agents/can-access-agent` and `agents/list-accessible-agents` resolve through `WP_Agent_Access` → `WP_Agent_WordPress_Authorization_Policy` → DM's `AgentAccessStoreAdapter`. Store rows only; the host filter never runs.

Any consumer of the abilities (Frontend Agent Chat, MCP, REST) gets path 2 and never sees filter-granted access. On a live site this left ~47 team members who should see an agent invisible to the chat widget — only the 3 with explicit grant rows appeared — for weeks, because both paths *exist* and both *look* authoritative.

Fixes #2859.

## Upstream dependency (resolved)

The upstream blocker was **Automattic/agents-api#417**. It landed as [Automattic/agents-api#418](https://github.com/Automattic/agents-api/pull/418), which added the `wp_agent_can_access_agent` filter wrapping the **final** authorization decision (including the effective-agent short-circuit) so hosts can tighten as well as widen. The list path (`list_accessible_agents_for_principal`) was rewritten to iterate every registered agent through the **same** `can_access_agent()` decision — so list/check symmetry is guaranteed **by construction**. There is only one filter; no separate list-path seam exists to wire.

## Bridge design

New `inc/Core/Auth/AgentAccessFilterBridge.php` hooks `wp_agent_can_access_agent` and forwards into DM's existing `datamachine_can_access_agent` filter so both access paths converge.

- **Slug ↔ numeric ID translation.** The substrate deals in agent slugs; DM's filter takes a numeric `agent_id`. The bridge owns the translation via `Agents::get_by_slug()`, with a numeric-identifier passthrough (mirrors `AgentAccessStoreAdapter::storage_agent_id()`). Unresolvable slugs pass the substrate decision through unchanged — the host filter can't be invoked without a numeric ID.
- **User-principal guard.** Only user principals (`acting_user_id > 0`) are forwarded; audience/anonymous principals pass through with the substrate's store-derived decision unchanged. DM's filter is user-centric, so non-user principals have nothing to translate.
- **Tighten + widen semantics.** The substrate's current `$allowed` decision (which already includes the store lookup **and** the effective-agent short-circuit) is seeded as the initial `$can_access` value into `datamachine_can_access_agent`, and whatever the filter returns is returned. A host hook can therefore grant access with no store row *and* revoke access despite a store grant — including denying the effective-agent short-circuit.
- **No behavior change when unhooked.** With no `datamachine_can_access_agent` callbacks, `apply_filters` returns the seeded value unchanged, so the store-derived decision is preserved exactly.

### Registration

`AgentAccessFilterBridge::register()` is wired in `inc/bootstrap.php` immediately after `AgentAccessStoreAdapter::register()`, following the same cached-default-instance + `add_filter` pattern the adapter uses. The class takes an optional `Agents` repository in its constructor for direct-injection testing (mirrors the adapter's testability shape).

### Layer purity

DM stays generic. The bridge forwards to DM's existing filter and contains zero site-, platform-, or vendor-specific knowledge. Platform policy stays in integration plugins that already hook `datamachine_can_access_agent`.

## composer.lock bump

`composer.json` requires `wordpress/agents-api: dev-main`, but `composer.lock` pinned a commit (`59d1e6b`) predating #418. `composer update wordpress/agents-api` bumps the lock to `c1183c4`, which contains the `wp_agent_can_access_agent` seam. Committed as its own commit (`chore: bump agents-api to pick up wp_agent_can_access_agent seam`).

## Tests

New `tests/agents-api-access-filter-bridge-smoke.php` (12 assertions) follows the existing pure-PHP smoke harness:

- Grant hook widens a denied store decision to true (no store row).
- Hook receives the **numeric** agent ID, user ID, and the seeded decision.
- Deny hook tightens a granted store decision to false.
- No hook = unchanged store behavior (both true and false seeds).
- Audience principals pass through unchanged; the hook is **not** invoked.
- Unresolvable slug passes through unchanged; the hook is not invoked.
- Numeric agent identifier is forwarded without slug resolution.
- `register()` hooks `wp_agent_can_access_agent`.
- Non-principal value passes through unchanged.

## Verification

- `php tests/agents-api-access-filter-bridge-smoke.php` — 12/12 pass.
- `php tests/agents-api-access-store-adapter-smoke.php` — 19/19 pass (no regression).
- Related access-path smokes (`agents-chat-access-permission`, `agents-api-registration`, `auth-principal-scoped`) — all pass.
- `phpcs` (WordPress standard) on changed files — clean.
- `homeboy review audit` — passed (alignment 0.82, no new findings).
- `homeboy review lint` — passed (phpcs + phpstan level 7, 0 errors).
- `homeboy review test` — failed due to the WP Codebox CLI infrastructure issue (missing Node module on this host), not a code issue. This is the same infra limitation noted in Automattic/agents-api#418. GitHub Actions CI is the real gate.