### PR TITLE
fix: stop system tasks from minting per-user agent rows; add agent prune

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -950,38 +950,44 @@ function datamachine_resolve_or_create_agent_id( int $user_id ): int {
  * a real agent owner in TaskScheduler — a queued task with agent_id/user_id 0 is
  * rejected by the agent-context gate before it ever runs.
  *
- * The historical pattern resolved identity solely from get_current_user_id(),
- * which returns 0 whenever the ability runs outside an authenticated web request
- * — WP-Cron, WP-CLI without --user, or a system pipeline step. That produced a
- * zeroed context and a flood of "queued task requires agent context" rejections,
- * one per batched item. This helper closes that gap by falling back to the
- * install's default agent user (DirectoryManager::get_default_agent_user_id())
- * when no user is present in the request, mirroring how the rest of the
- * single-agent surface resolves an owner.
+ * System tasks should attribute to the install's default agent rather than the
+ * human who triggered the action. A user uploading an image is not "operating an
+ * agent"; minting a persistent agent row for them silts the agents table with
+ * stray identities. The triggering user is preserved separately in
+ * `triggering_user_id` so callers can carry it as task-context metadata for
+ * audit without conflating attribution with agent identity.
  *
  * @since 0.72.0
+ * @since 0.160.0 Always resolves to the install default agent; never auto-provisions
+ *               a per-human agent row for system tasks. ChatOrchestrator remains
+ *               the legitimate caller of datamachine_resolve_or_create_agent_id().
  *
- * @return array{user_id:int,agent_id:int} Acting user id and its agent id. Both
- *                                          may be 0 only when the install has no
- *                                          resolvable owner at all.
+ * @return array{user_id:int,agent_id:int,triggering_user_id:int} Acting user id
+ *         (the default agent owner), its agent id, and the original triggering
+ *         user id. user_id and agent_id may be 0 only when the install has no
+ *         resolvable default owner at all.
  */
 function datamachine_resolve_system_agent_context(): array {
-	$user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
+	$triggering_user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
+	$user_id            = 0;
 
-	// No authenticated user (cron / CLI / system pipeline): fall back to the
-	// install's default agent owner so agent-owned queued tasks carry a real
-	// identity into TaskScheduler instead of a zeroed, gate-rejected context.
-	if ( $user_id <= 0 && class_exists( \DataMachine\Core\FilesRepository\DirectoryManager::class ) ) {
+	// Always attribute system-task work to the install's default agent owner.
+	// This prevents every authenticated user who triggers a media/SEO/linking
+	// ability from getting a full agent row minted from their login.
+	if ( class_exists( \DataMachine\Core\FilesRepository\DirectoryManager::class ) ) {
 		$user_id = (int) \DataMachine\Core\FilesRepository\DirectoryManager::get_default_agent_user_id();
 	}
 
+	// Resolve (or create) the agent row for the *default owner* only. System
+	// tasks never auto-provision an agent for the triggering human.
 	$agent_id = ( $user_id > 0 && function_exists( 'datamachine_resolve_or_create_agent_id' ) )
 		? datamachine_resolve_or_create_agent_id( $user_id )
 		: 0;
 
 	return array(
-		'user_id'  => $user_id,
-		'agent_id' => $agent_id,
+		'user_id'            => $user_id,
+		'agent_id'           => $agent_id,
+		'triggering_user_id' => $triggering_user_id,
 	);
 }
 

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -801,7 +801,7 @@ class AgentAbilities {
 					),
 					'execute_callback'    => array( self::class, 'pruneAgents' ),
 					'permission_callback' => fn() => PermissionHelper::can_manage(),
-				'meta'                => array( 'show_in_rest' => true ),
+					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
 

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -772,6 +772,40 @@ class AgentAbilities {
 			);
 
 			self::registerAbility(
+				'datamachine/prune-agents',
+				array(
+					'label'               => 'Prune Agents',
+					'description'         => 'List or remove agent rows with zero references (no sessions, jobs, grants, files, or bundle config).',
+					'category'            => 'datamachine-agent',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'dry_run' => array(
+								'type'        => 'boolean',
+								'description' => 'When true (default), list candidates without deleting.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'       => array( 'type' => 'boolean' ),
+							'dry_run'       => array( 'type' => 'boolean' ),
+							'total'         => array( 'type' => 'integer' ),
+							'count'         => array( 'type' => 'integer' ),
+							'deleted_count' => array( 'type' => 'integer' ),
+							'candidates'    => array( 'type' => 'array' ),
+							'deleted'       => array( 'type' => 'array' ),
+							'error'         => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'pruneAgents' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+				'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			self::registerAbility(
 				'datamachine/grant-agent-audience-access',
 				array(
 					'label'               => 'Grant Agent Audience Access',
@@ -2620,6 +2654,175 @@ class AgentAbilities {
 			}
 		}
 		rmdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+	}
+
+	/**
+	 * Find agent rows with no external references.
+	 *
+	 * Candidates are agents that own nothing: no chat sessions, no jobs, no
+	 * access grants, no on-disk agent directory, no bundle install metadata, and
+	 * they are not the install's default agent. The default agent and any agent
+	 * with files, grants, sessions, jobs, or bundle config is always spared.
+	 *
+	 * @param array $input {
+	 *     Optional. Input arguments.
+	 *
+	 *     @type bool $dry_run Default true. When true, return candidates without deleting.
+	 * }
+	 * @return array Result with candidates and counts.
+	 */
+	public static function pruneAgents( array $input ): array {
+		$dry_run = $input['dry_run'] ?? true;
+
+		$agents_repo = new Agents();
+		$agents      = $agents_repo->get_all();
+
+		$default_user_id = class_exists( DirectoryManager::class )
+			? (int) DirectoryManager::get_default_agent_user_id()
+			: 0;
+
+		$referenced_ids = self::collect_referenced_agent_ids( $agents, $default_user_id );
+
+		$candidates = array();
+		foreach ( $agents as $agent ) {
+			$agent_id = (int) $agent['agent_id'];
+			if ( isset( $referenced_ids[ $agent_id ] ) ) {
+				continue;
+			}
+
+			$candidates[] = array(
+				'agent_id'   => $agent_id,
+				'agent_slug' => (string) $agent['agent_slug'],
+				'agent_name' => (string) $agent['agent_name'],
+				'owner_id'   => (int) $agent['owner_id'],
+			);
+		}
+
+		$deleted = array();
+		if ( ! $dry_run ) {
+			foreach ( $candidates as $candidate ) {
+				$result = self::deleteAgent( array( 'agent_id' => $candidate['agent_id'] ) );
+				if ( ! empty( $result['success'] ) ) {
+					$deleted[] = $candidate;
+				}
+			}
+		}
+
+		return array(
+			'success'       => true,
+			'dry_run'       => $dry_run,
+			'total'         => count( $agents ),
+			'candidates'    => $candidates,
+			'count'         => count( $candidates ),
+			'deleted'       => $deleted,
+			'deleted_count' => count( $deleted ),
+		);
+	}
+
+	/**
+	 * Collect agent IDs that have any reference preventing prune.
+	 *
+	 * References checked: chat sessions, jobs, access grants, on-disk directory,
+	 * bundle install config, and the install default agent.
+	 *
+	 * @param array $agents          List of agent rows.
+	 * @param int   $default_user_id Install default agent owner user ID.
+	 * @return array<int,true> Referenced agent IDs.
+	 */
+	private static function collect_referenced_agent_ids( array $agents, int $default_user_id ): array {
+		$referenced = array();
+
+		// Default agent owner is always referenced.
+		if ( $default_user_id > 0 ) {
+			foreach ( $agents as $agent ) {
+				if ( (int) $agent['owner_id'] === $default_user_id ) {
+					$referenced[ (int) $agent['agent_id'] ] = true;
+				}
+			}
+		}
+
+		// Bundle-installed agents are real.
+		foreach ( $agents as $agent ) {
+			$config = $agent['agent_config'] ?? array();
+			if ( is_array( $config ) && ! empty( $config['datamachine_bundle'] ) ) {
+				$referenced[ (int) $agent['agent_id'] ] = true;
+			}
+		}
+
+		// On-disk agent directories.
+		$directory_manager = new DirectoryManager();
+		foreach ( $agents as $agent ) {
+			$agent_dir = $directory_manager->get_agent_identity_directory( (string) $agent['agent_slug'] );
+			if ( is_dir( $agent_dir ) ) {
+				$referenced[ (int) $agent['agent_id'] ] = true;
+			}
+		}
+
+		global $wpdb;
+
+		// Chat sessions: network-wide table (current) plus legacy per-site tables.
+		if ( class_exists( \DataMachine\Core\Database\Chat\Chat::class ) ) {
+			$chat_table = $wpdb->base_prefix . \DataMachine\Core\Database\Chat\Chat::TABLE_NAME;
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+			$chat_agent_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT DISTINCT agent_id FROM %i WHERE agent_id IS NOT NULL AND agent_id > 0', $chat_table ) );
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+			foreach ( $chat_agent_ids as $id ) {
+				$referenced[ (int) $id ] = true;
+			}
+
+			// Legacy per-site tables (pre-network migration).
+			if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_sites' ) ) {
+				$blog_ids = get_sites(
+					array(
+						'fields' => 'ids',
+						'number' => 0,
+					)
+				);
+				foreach ( $blog_ids as $blog_id ) {
+					$site_prefix = $wpdb->get_blog_prefix( (int) $blog_id );
+					$site_table  = $site_prefix . \DataMachine\Core\Database\Chat\Chat::TABLE_NAME;
+					if ( $site_table === $chat_table ) {
+						continue;
+					}
+					// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+					$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $site_table ) );
+					// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+					if ( $exists !== $site_table ) {
+						continue;
+					}
+					// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+					$site_agent_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT DISTINCT agent_id FROM %i WHERE agent_id IS NOT NULL AND agent_id > 0', $site_table ) );
+					// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+					foreach ( $site_agent_ids as $id ) {
+						$referenced[ (int) $id ] = true;
+					}
+				}
+			}
+		}
+
+		// Jobs (agent_id column).
+		$jobs_repo  = new \DataMachine\Core\Database\Jobs\Jobs();
+		$jobs_table = $jobs_repo->get_table_name();
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$job_agent_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT DISTINCT agent_id FROM %i WHERE agent_id IS NOT NULL AND agent_id > 0', $jobs_table ) );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		foreach ( $job_agent_ids as $id ) {
+			$referenced[ (int) $id ] = true;
+		}
+
+		// Access grants (user + principal).
+		$access_repo     = new AgentAccess();
+		$access_table    = $wpdb->base_prefix . AgentAccess::TABLE_NAME;
+		$principal_table = $wpdb->base_prefix . AgentAccess::PRINCIPAL_TABLE_NAME;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$grant_agent_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT DISTINCT agent_id FROM %i', $access_table ) );
+		$principal_ids   = $wpdb->get_col( $wpdb->prepare( 'SELECT DISTINCT agent_id FROM %i', $principal_table ) );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		foreach ( array_merge( $grant_agent_ids, $principal_ids ) as $id ) {
+			$referenced[ (int) $id ] = true;
+		}
+
+		return $referenced;
 	}
 
 	/**

--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -510,12 +510,13 @@ class InternalLinkingAbilities {
 		$dry_run        = ! empty( $input['dry_run'] );
 		$force          = ! empty( $input['force'] );
 
-		$acting          = datamachine_resolve_system_agent_context();
-		$user_id         = $acting['user_id'];
-		$agent_id        = $acting['agent_id'];
-		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
-		$provider        = $system_defaults['provider'];
-		$model           = $system_defaults['model'];
+		$acting             = datamachine_resolve_system_agent_context();
+		$user_id            = $acting['user_id'];
+		$agent_id           = $acting['agent_id'];
+		$triggering_user_id = $acting['triggering_user_id'];
+		$system_defaults    = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
+		$provider           = $system_defaults['provider'];
+		$model              = $system_defaults['model'];
 
 		if ( empty( $provider ) || empty( $model ) ) {
 			return array(
@@ -607,8 +608,9 @@ class InternalLinkingAbilities {
 			'internal_linking',
 			$item_params,
 			array(
-				'user_id'  => $user_id,
-				'agent_id' => $agent_id,
+				'user_id'            => $user_id,
+				'agent_id'           => $agent_id,
+				'triggering_user_id' => $triggering_user_id,
 			)
 		);
 

--- a/inc/Abilities/Media/AltTextAbilities.php
+++ b/inc/Abilities/Media/AltTextAbilities.php
@@ -137,12 +137,13 @@ class AltTextAbilities {
 		$post_id       = absint( $input['post_id'] ?? 0 );
 		$force         = ! empty( $input['force'] );
 
-		$acting          = datamachine_resolve_system_agent_context();
-		$user_id         = $acting['user_id'];
-		$agent_id        = $acting['agent_id'];
-		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
-		$provider        = $system_defaults['provider'];
-		$model           = $system_defaults['model'];
+		$acting             = datamachine_resolve_system_agent_context();
+		$user_id            = $acting['user_id'];
+		$agent_id           = $acting['agent_id'];
+		$triggering_user_id = $acting['triggering_user_id'];
+		$system_defaults    = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
+		$provider           = $system_defaults['provider'];
+		$model              = $system_defaults['model'];
 
 		if ( empty( $provider ) || empty( $model ) ) {
 			return array(
@@ -241,8 +242,9 @@ class AltTextAbilities {
 			'alt_text_generation',
 			$item_params,
 			array(
-				'user_id'  => $user_id,
-				'agent_id' => $agent_id,
+				'user_id'            => $user_id,
+				'agent_id'           => $agent_id,
+				'triggering_user_id' => $triggering_user_id,
 			)
 		);
 
@@ -354,12 +356,13 @@ class AltTextAbilities {
 			return;
 		}
 
-		$acting          = datamachine_resolve_system_agent_context();
-		$user_id         = $acting['user_id'];
-		$agent_id        = $acting['agent_id'];
-		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
-		$provider        = $system_defaults['provider'];
-		$model           = $system_defaults['model'];
+		$acting             = datamachine_resolve_system_agent_context();
+		$user_id            = $acting['user_id'];
+		$agent_id           = $acting['agent_id'];
+		$triggering_user_id = $acting['triggering_user_id'];
+		$system_defaults    = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
+		$provider           = $system_defaults['provider'];
+		$model              = $system_defaults['model'];
 
 		if ( empty( $provider ) || empty( $model ) ) {
 			return;
@@ -381,8 +384,9 @@ class AltTextAbilities {
 				'source'        => 'add_attachment',
 			),
 			array(
-				'user_id'  => $user_id,
-				'agent_id' => $agent_id,
+				'user_id'            => $user_id,
+				'agent_id'           => $agent_id,
+				'triggering_user_id' => $triggering_user_id,
 			)
 		);
 	}

--- a/inc/Abilities/Media/ImageOptimizationAbilities.php
+++ b/inc/Abilities/Media/ImageOptimizationAbilities.php
@@ -340,16 +340,18 @@ class ImageOptimizationAbilities {
 			);
 		}
 
-		$acting   = datamachine_resolve_system_agent_context();
-		$user_id  = $acting['user_id'];
-		$agent_id = $acting['agent_id'];
+		$acting             = datamachine_resolve_system_agent_context();
+		$user_id            = $acting['user_id'];
+		$agent_id           = $acting['agent_id'];
+		$triggering_user_id = $acting['triggering_user_id'];
 
 		$batch = TaskScheduler::scheduleBatch(
 			'image_optimization',
 			$item_params,
 			array(
-				'user_id'  => $user_id,
-				'agent_id' => $agent_id,
+				'user_id'            => $user_id,
+				'agent_id'           => $agent_id,
+				'triggering_user_id' => $triggering_user_id,
 			)
 		);
 

--- a/inc/Abilities/SEO/MetaDescriptionAbilities.php
+++ b/inc/Abilities/SEO/MetaDescriptionAbilities.php
@@ -134,12 +134,13 @@ class MetaDescriptionAbilities {
 		$limit     = absint( $input['limit'] ?? 50 );
 		$force     = ! empty( $input['force'] );
 
-		$acting          = datamachine_resolve_system_agent_context();
-		$user_id         = $acting['user_id'];
-		$agent_id        = $acting['agent_id'];
-		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
-		$provider        = $system_defaults['provider'];
-		$model           = $system_defaults['model'];
+		$acting             = datamachine_resolve_system_agent_context();
+		$user_id            = $acting['user_id'];
+		$agent_id           = $acting['agent_id'];
+		$triggering_user_id = $acting['triggering_user_id'];
+		$system_defaults    = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
+		$provider           = $system_defaults['provider'];
+		$model              = $system_defaults['model'];
 
 		if ( empty( $provider ) || empty( $model ) ) {
 			return array(
@@ -206,8 +207,9 @@ class MetaDescriptionAbilities {
 			'meta_description_generation',
 			$item_params,
 			array(
-				'user_id'  => $user_id,
-				'agent_id' => $agent_id,
+				'user_id'            => $user_id,
+				'agent_id'           => $agent_id,
+				'triggering_user_id' => $triggering_user_id,
 			)
 		);
 

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -518,6 +518,86 @@ class AgentsCommand extends AgentBundleCommand {
 	}
 
 	/**
+	 * Prune agent rows with zero references.
+	 *
+	 * Lists candidates by default. Use --yes to actually delete. A candidate
+	 * is an agent row with no chat sessions, no jobs, no access grants, no
+	 * on-disk directory, no bundle install config, and is not the install's
+	 * default agent.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--yes]
+	 * : Skip the dry-run preview and delete candidates.
+	 *
+	 * [--format=<format>]
+	 * : Output format for the candidate list.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 *   - ids
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Preview candidates (default)
+	 *     wp datamachine agent prune
+	 *
+	 *     # Delete candidates
+	 *     wp datamachine agent prune --yes
+	 *
+	 * @subcommand prune
+	 */
+	public function prune( array $args, array $assoc_args ): void {
+		$apply = isset( $assoc_args['yes'] );
+
+		$result = AgentAbilities::pruneAgents(
+			array(
+				'dry_run' => ! $apply,
+			)
+		);
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to prune agents.' );
+			return;
+		}
+
+		$candidates = $result['candidates'] ?? array();
+
+		if ( empty( $candidates ) ) {
+			WP_CLI::success( 'No pruneable agents found — all rows have references.' );
+			return;
+		}
+
+		$items = array();
+		foreach ( $candidates as $agent ) {
+			$owner_id = (int) $agent['owner_id'];
+			$user     = $owner_id > 0 ? get_user_by( 'id', $owner_id ) : false;
+			$items[]  = array(
+				'agent_id'    => (int) $agent['agent_id'],
+				'agent_slug'  => (string) $agent['agent_slug'],
+				'agent_name'  => (string) $agent['agent_name'],
+				'owner_id'    => $owner_id,
+				'owner_login' => $user ? $user->user_login : '(deleted)',
+			);
+		}
+
+		$fields = array( 'agent_id', 'agent_slug', 'agent_name', 'owner_id', 'owner_login' );
+		$this->format_items( $items, $fields, $assoc_args, 'agent_id' );
+
+		if ( ! $apply ) {
+			WP_CLI::log( sprintf( 'Found %d pruneable agent(s). Re-run with --yes to delete.', count( $items ) ) );
+			return;
+		}
+
+		WP_CLI::success( sprintf( 'Deleted %d pruneable agent(s).', (int) $result['deleted_count'] ) );
+	}
+
+	/**
 	 * Manage agent access grants.
 	 *
 	 * ## OPTIONS

--- a/tests/agent-prune-smoke.php
+++ b/tests/agent-prune-smoke.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Pure-PHP smoke test for agent prune semantics.
+ *
+ * Run with: php tests/agent-prune-smoke.php
+ *
+ * Covers the prune ability and CLI without requiring a live WordPress install
+ * by mirroring the production reference-checking algorithm from
+ * AgentAbilities::pruneAgents() / collect_referenced_agent_ids() in a
+ * dependency-injected harness.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+// ─── Harness mirroring AgentAbilities prune logic ───────────────────
+
+/**
+ * Determine which agents are referenced and therefore ineligible for prune.
+ *
+ * Mirrors AgentAbilities::collect_referenced_agent_ids().
+ *
+ * @param array $agents          List of agent rows.
+ * @param int   $default_user_id Install default agent owner user ID.
+ * @param array $refs            Reference sets: 'sessions', 'jobs', 'grants',
+ *                               'directories', 'bundles' as arrays of agent_ids.
+ * @return array<int,true> Referenced agent IDs.
+ */
+function collect_referenced_agent_ids_for_test( array $agents, int $default_user_id, array $refs ): array {
+	$referenced = array();
+
+	// Default agent owner is always referenced.
+	if ( $default_user_id > 0 ) {
+		foreach ( $agents as $agent ) {
+			if ( (int) $agent['owner_id'] === $default_user_id ) {
+				$referenced[ (int) $agent['agent_id'] ] = true;
+			}
+		}
+	}
+
+	// Bundle-installed agents.
+	foreach ( $agents as $agent ) {
+		if ( in_array( (int) $agent['agent_id'], $refs['bundles'] ?? array(), true ) ) {
+			$referenced[ (int) $agent['agent_id'] ] = true;
+		}
+	}
+
+	// On-disk directories.
+	foreach ( $agents as $agent ) {
+		if ( in_array( (int) $agent['agent_id'], $refs['directories'] ?? array(), true ) ) {
+			$referenced[ (int) $agent['agent_id'] ] = true;
+		}
+	}
+
+	// Chat sessions, jobs, access grants.
+	foreach ( array( 'sessions', 'jobs', 'grants' ) as $key ) {
+		foreach ( $refs[ $key ] ?? array() as $id ) {
+			$referenced[ (int) $id ] = true;
+		}
+	}
+
+	return $referenced;
+}
+
+/**
+ * Compute prune candidates.
+ *
+ * Mirrors AgentAbilities::pruneAgents() dry-run path.
+ *
+ * @param array $agents          List of agent rows.
+ * @param int   $default_user_id Install default agent owner user ID.
+ * @param array $refs            Reference sets.
+ * @return array Candidate agent rows.
+ */
+function prune_candidates_for_test( array $agents, int $default_user_id, array $refs ): array {
+	$referenced = collect_referenced_agent_ids_for_test( $agents, $default_user_id, $refs );
+
+	$candidates = array();
+	foreach ( $agents as $agent ) {
+		$agent_id = (int) $agent['agent_id'];
+		if ( isset( $referenced[ $agent_id ] ) ) {
+			continue;
+		}
+		$candidates[] = $agent;
+	}
+
+	return $candidates;
+}
+
+// ─── Tiny assertion helpers ─────────────────────────────────────────
+
+$failures = 0;
+$total    = 0;
+
+$assert = function ( string $label, bool $cond ) use ( &$failures, &$total ): void {
+	$total++;
+	if ( $cond ) {
+		echo "  [PASS] {$label}\n";
+	} else {
+		$failures++;
+		echo "  [FAIL] {$label}\n";
+	}
+};
+
+$assert_same_set = function ( string $label, array $expected, array $actual ) use ( $assert ): void {
+	$e = array_values( array_unique( $expected ) );
+	$a = array_values( array_unique( $actual ) );
+	sort( $e );
+	sort( $a );
+	$assert( $label, $e === $a );
+};
+
+// ─── Shared fixture builders ────────────────────────────────────────
+
+function make_agent( int $agent_id, int $owner_id, string $slug ): array {
+	return array(
+		'agent_id'   => $agent_id,
+		'agent_slug' => $slug,
+		'agent_name' => $slug,
+		'owner_id'   => $owner_id,
+	);
+}
+
+$default_user_id = 1;
+
+// ─── Test cases ─────────────────────────────────────────────────────
+
+echo "\n[1] Prune identifies only zero-reference rows\n";
+$agents = array(
+	make_agent( 1, $default_user_id, 'default-bot' ),
+	make_agent( 2, 5, 'stray-uploader' ),
+	make_agent( 3, 6, 'stray-commenter' ),
+);
+$candidates = prune_candidates_for_test( $agents, $default_user_id, array() );
+$assert_same_set(
+	'only zero-reference agents are candidates',
+	array( 2, 3 ),
+	array_column( $candidates, 'agent_id' )
+);
+
+echo "\n[2] Prune spares the install default agent\n";
+$agents = array(
+	make_agent( 1, $default_user_id, 'default-bot' ),
+	make_agent( 2, 5, 'stray-uploader' ),
+);
+$candidates = prune_candidates_for_test( $agents, $default_user_id, array() );
+$assert( 'default agent (1) is not a candidate', ! in_array( 1, array_column( $candidates, 'agent_id' ), true ) );
+$assert( 'stray agent (2) is a candidate', in_array( 2, array_column( $candidates, 'agent_id' ), true ) );
+
+echo "\n[3] Prune spares rows with a chat session reference\n";
+$agents = array(
+	make_agent( 1, $default_user_id, 'default-bot' ),
+	make_agent( 2, 5, 'stray-uploader' ),
+	make_agent( 4, 7, 'session-bot' ),
+);
+$candidates = prune_candidates_for_test( $agents, $default_user_id, array( 'sessions' => array( 4 ) ) );
+$ids = array_column( $candidates, 'agent_id' );
+$assert( 'session-bot (4) is spared', ! in_array( 4, $ids, true ) );
+$assert( 'stray agent (2) remains a candidate', in_array( 2, $ids, true ) );
+
+echo "\n[4] Prune spares rows with a job reference\n";
+$agents = array(
+	make_agent( 1, $default_user_id, 'default-bot' ),
+	make_agent( 2, 5, 'stray-uploader' ),
+	make_agent( 5, 8, 'job-bot' ),
+);
+$candidates = prune_candidates_for_test( $agents, $default_user_id, array( 'jobs' => array( 5 ) ) );
+$ids = array_column( $candidates, 'agent_id' );
+$assert( 'job-bot (5) is spared', ! in_array( 5, $ids, true ) );
+$assert( 'stray agent (2) remains a candidate', in_array( 2, $ids, true ) );
+
+echo "\n[5] Prune spares rows with an access grant reference\n";
+$agents = array(
+	make_agent( 1, $default_user_id, 'default-bot' ),
+	make_agent( 2, 5, 'stray-uploader' ),
+	make_agent( 6, 9, 'grant-bot' ),
+);
+$candidates = prune_candidates_for_test( $agents, $default_user_id, array( 'grants' => array( 6 ) ) );
+$ids = array_column( $candidates, 'agent_id' );
+$assert( 'grant-bot (6) is spared', ! in_array( 6, $ids, true ) );
+$assert( 'stray agent (2) remains a candidate', in_array( 2, $ids, true ) );
+
+echo "\n[6] Prune spares rows with an on-disk directory\n";
+$agents = array(
+	make_agent( 1, $default_user_id, 'default-bot' ),
+	make_agent( 2, 5, 'stray-uploader' ),
+	make_agent( 7, 10, 'file-bot' ),
+);
+$candidates = prune_candidates_for_test( $agents, $default_user_id, array( 'directories' => array( 7 ) ) );
+$ids = array_column( $candidates, 'agent_id' );
+$assert( 'file-bot (7) is spared', ! in_array( 7, $ids, true ) );
+$assert( 'stray agent (2) remains a candidate', in_array( 2, $ids, true ) );
+
+echo "\n[7] Prune spares bundle-installed agents\n";
+$agents = array(
+	make_agent( 1, $default_user_id, 'default-bot' ),
+	make_agent( 2, 5, 'stray-uploader' ),
+	make_agent( 8, 11, 'bundle-bot' ),
+);
+$candidates = prune_candidates_for_test( $agents, $default_user_id, array( 'bundles' => array( 8 ) ) );
+$ids = array_column( $candidates, 'agent_id' );
+$assert( 'bundle-bot (8) is spared', ! in_array( 8, $ids, true ) );
+$assert( 'stray agent (2) remains a candidate', in_array( 2, $ids, true ) );
+
+echo "\n[8] Multiple references do not create duplicate candidates\n";
+$agents = array(
+	make_agent( 1, $default_user_id, 'default-bot' ),
+	make_agent( 2, 5, 'stray-uploader' ),
+	make_agent( 3, 6, 'stray-commenter' ),
+	make_agent( 4, 7, 'session-bot' ),
+	make_agent( 5, 8, 'job-bot' ),
+	make_agent( 6, 9, 'grant-bot' ),
+	make_agent( 7, 10, 'file-bot' ),
+	make_agent( 8, 11, 'bundle-bot' ),
+);
+$refs = array(
+	'sessions'    => array( 4 ),
+	'jobs'        => array( 5 ),
+	'grants'      => array( 6 ),
+	'directories' => array( 7 ),
+	'bundles'     => array( 8 ),
+);
+$candidates = prune_candidates_for_test( $agents, $default_user_id, $refs );
+$assert_same_set(
+	'only zero-reference rows are candidates when every reference type is present',
+	array( 2, 3 ),
+	array_column( $candidates, 'agent_id' )
+);
+
+echo "\n[9] Production prune ability and CLI exist\n";
+$root        = dirname( __DIR__ );
+$ability_src = (string) file_get_contents( $root . '/inc/Abilities/AgentAbilities.php' );
+$cli_src     = (string) file_get_contents( $root . '/inc/Cli/Commands/AgentsCommand.php' );
+
+$assert( 'AgentAbilities::pruneAgents() is defined', str_contains( $ability_src, 'public static function pruneAgents' ) );
+$assert( 'datamachine/prune-agents ability is registered', str_contains( $ability_src, "'datamachine/prune-agents'" ) );
+$assert( 'collect_referenced_agent_ids() helper exists', str_contains( $ability_src, 'private static function collect_referenced_agent_ids' ) );
+$assert( 'AgentsCommand::prune() subcommand exists', str_contains( $cli_src, 'public function prune' ) );
+$assert( 'CLI default is dry-run (requires --yes to delete)', str_contains( $cli_src, "\$apply = isset( \$assoc_args['yes'] )" ) );
+
+// ─── Summary ────────────────────────────────────────────────────────
+
+echo "\n";
+if ( $failures > 0 ) {
+	echo "=== agent-prune-smoke: {$failures}/{$total} FAILED ===\n";
+	exit( 1 );
+}
+echo "=== agent-prune-smoke: ALL PASS ({$total} assertions) ===\n";

--- a/tests/system-agent-context-resolution-smoke.php
+++ b/tests/system-agent-context-resolution-smoke.php
@@ -4,22 +4,15 @@
  *
  * Run with: php tests/system-agent-context-resolution-smoke.php
  *
- * Regression coverage for the "queued task requires agent context" flood
- * produced when media/SEO/linking abilities enqueued agent-owned batch tasks
- * (alt_text_generation, image_optimization, meta_description_generation,
- * internal_linking) from a context with no authenticated user — WP-Cron,
- * WP-CLI without --user, or a system pipeline step.
+ * Regression coverage for the stray-agent provisioning leak tracked in
+ * Extra-Chill/data-machine #2864. Media/SEO/linking abilities enqueue
+ * agent-owned queued tasks; historically they resolved identity from
+ * get_current_user_id(), which caused every authenticated user who triggered
+ * a system task to get a persistent agent row minted from their login.
  *
- * The old resolution resolved identity solely from get_current_user_id(),
- * which returns 0 outside a web request. That zeroed the enqueue context, so
- * every batched item hit TaskScheduler's agent-context gate and was rejected
- * (one ERROR log line per item). The fix teaches the enqueue path to fall back
- * to the install's default agent owner via
- * DirectoryManager::get_default_agent_user_id().
- *
- * This test verifies the resolver's decision table without a WP bootstrap by
- * mirroring its production logic byte-for-byte in a harness whose two inputs
- * (current-user id, default-agent user id → agent id) are injectable.
+ * The resolver now always attributes system tasks to the install's default
+ * agent owner and returns the original triggering user separately so callers
+ * can carry it as task-context metadata for audit.
  *
  * @package DataMachine\Tests
  */
@@ -31,27 +24,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 // ─── Harness mirroring datamachine_resolve_system_agent_context() ────
 //
 // Mirrors data-machine.php:datamachine_resolve_system_agent_context().
-// The two collaborators the real function calls — get_current_user_id() and
-// DirectoryManager::get_default_agent_user_id() — are supplied as inputs, and
-// the user_id → agent_id resolution (datamachine_resolve_or_create_agent_id)
-// is supplied as a closure so the branch logic is exercised in isolation.
+// The collaborators the real function calls are supplied as inputs/closure so
+// the branch logic is exercised in isolation without a WP bootstrap.
 //
 // @param int      $current_user_id  What get_current_user_id() would return.
 // @param int      $default_user_id  What DirectoryManager::get_default_agent_user_id() would return.
 // @param callable $resolve_agent_id user_id => agent_id (0 for unresolvable users).
 function resolve_system_agent_context_for_test( int $current_user_id, int $default_user_id, callable $resolve_agent_id ): array {
-	$user_id = $current_user_id;
-
-	// No authenticated user: fall back to the install's default agent owner.
-	if ( $user_id <= 0 ) {
-		$user_id = $default_user_id;
-	}
+	$triggering_user_id = $current_user_id;
+	$user_id            = $default_user_id;
 
 	$agent_id = $user_id > 0 ? (int) $resolve_agent_id( $user_id ) : 0;
 
 	return array(
-		'user_id'  => $user_id,
-		'agent_id' => $agent_id,
+		'user_id'            => $user_id,
+		'agent_id'           => $agent_id,
+		'triggering_user_id' => $triggering_user_id,
 	);
 }
 
@@ -87,16 +75,18 @@ $resolve = static function ( int $user_id ): int {
 
 // ─── Test cases ─────────────────────────────────────────────────────
 
-echo "\n[1] Authenticated web request resolves the current user's agent\n";
+echo "\n[1] Authenticated web request attributes to the default agent, not the triggering user\n";
 $ctx = resolve_system_agent_context_for_test( 7, 1, $resolve );
-$assert( 'user_id is the current user', 7 === $ctx['user_id'] );
-$assert( 'agent_id resolved for current user', 25 === $ctx['agent_id'] );
+$assert( 'user_id is the default agent owner', 1 === $ctx['user_id'] );
+$assert( 'agent_id resolved for default owner', 1 === $ctx['agent_id'] );
+$assert( 'triggering_user_id preserves the human', 7 === $ctx['triggering_user_id'] );
 $assert( 'enqueue context passes the agent-context gate', task_scheduler_gate_for_test( $ctx ) );
 
-echo "\n[2] Cron/CLI/system context (no current user) falls back to default agent owner\n";
+echo "\n[2] Cron/CLI/system context (no current user) still resolves to default agent owner\n";
 $ctx = resolve_system_agent_context_for_test( 0, 1, $resolve );
-$assert( 'user_id falls back to default agent user', 1 === $ctx['user_id'] );
+$assert( 'user_id is the default agent user', 1 === $ctx['user_id'] );
 $assert( 'agent_id resolved from default owner', 1 === $ctx['agent_id'] );
+$assert( 'triggering_user_id is 0 when no human triggered the work', 0 === $ctx['triggering_user_id'] );
 $assert(
 	'REGRESSION: fallback context is NOT gate-rejected (was agent_id 0 before fix)',
 	task_scheduler_gate_for_test( $ctx )
@@ -114,13 +104,13 @@ echo "\n[4] Install with no resolvable owner at all still returns zeros (no fata
 $ctx = resolve_system_agent_context_for_test( 0, 0, $resolve );
 $assert( 'user_id is 0 when no default owner exists', 0 === $ctx['user_id'] );
 $assert( 'agent_id is 0 when no default owner exists', 0 === $ctx['agent_id'] );
+$assert( 'triggering_user_id is still reported', 0 === $ctx['triggering_user_id'] );
 
-echo "\n[5] Production sources use the shared resolver, not raw get_current_user_id()\n";
+echo "\n[5] Production sources use the shared resolver and carry triggering_user_id\n";
 $root    = dirname( __DIR__ );
 $sources = array(
 	'AltTextAbilities'          => $root . '/inc/Abilities/Media/AltTextAbilities.php',
 	'ImageOptimizationAbilities' => $root . '/inc/Abilities/Media/ImageOptimizationAbilities.php',
-	'ImageGenerationAbilities'  => $root . '/inc/Abilities/Media/ImageGenerationAbilities.php',
 	'MetaDescriptionAbilities'  => $root . '/inc/Abilities/SEO/MetaDescriptionAbilities.php',
 	'InternalLinkingAbilities'  => $root . '/inc/Abilities/InternalLinkingAbilities.php',
 );
@@ -128,15 +118,23 @@ foreach ( $sources as $name => $path ) {
 	$src = (string) file_get_contents( $path );
 	$assert( "{$name} calls datamachine_resolve_system_agent_context()", str_contains( $src, 'datamachine_resolve_system_agent_context()' ) );
 	$assert(
-		"{$name} no longer resolves system-task agent id from a user-gated ternary",
-		! str_contains( $src, 'datamachine_resolve_or_create_agent_id( $user_id ) : 0' )
+		"{$name} carries triggering_user_id into TaskScheduler context",
+		str_contains( $src, "'triggering_user_id' => \$triggering_user_id" )
 	);
 }
 
-echo "\n[6] The resolver is defined and documents the cron/CLI fallback\n";
+echo "\n[6] Chat path is untouched — it still auto-provisions via resolve_or_create_agent_id\n";
+$chat_src = (string) file_get_contents( $root . '/inc/Api/Chat/ChatOrchestrator.php' );
+$assert(
+	'ChatOrchestrator calls datamachine_resolve_or_create_agent_id()',
+	str_contains( $chat_src, 'datamachine_resolve_or_create_agent_id' )
+);
+
+echo "\n[7] The resolver documents the attribution-vs-identity distinction\n";
 $plugin_src = (string) file_get_contents( $root . '/data-machine.php' );
 $assert( 'datamachine_resolve_system_agent_context() defined', str_contains( $plugin_src, 'function datamachine_resolve_system_agent_context(): array' ) );
-$assert( 'resolver falls back to the default agent user', str_contains( $plugin_src, 'get_default_agent_user_id()' ) );
+$assert( 'resolver always falls back to default agent user', str_contains( $plugin_src, '$user_id = (int) \\DataMachine\\Core\\FilesRepository\\DirectoryManager::get_default_agent_user_id();' ) );
+$assert( 'resolver returns triggering_user_id', str_contains( $plugin_src, "'triggering_user_id' =>" ) );
 
 echo "\n";
 if ( $failures > 0 ) {


### PR DESCRIPTION
Closes #2864.

## Problem

`datamachine_resolve_system_agent_context()` conflated attribution (which human triggered the work) with agent identity (a persistent row in the agents table). Any authenticated user who triggered a system-owned queued task — uploading an image, generating alt text, meta descriptions, image optimization, internal linking — got a full agent identity minted from their login. ChatOrchestrator is the only legitimate auto-provision surface.

## Fix: attribution vs. identity

- `datamachine_resolve_system_agent_context()` now **always** resolves to the install's default agent owner (`DirectoryManager::get_default_agent_user_id()` → its agent id). It only calls `datamachine_resolve_or_create_agent_id()` for that default owner, never for the triggering human.
- The original triggering user is returned separately as `triggering_user_id`.
- Media/SEO/linking callers pass `triggering_user_id` into the `TaskScheduler` context so it is preserved in `engine_data['task_context']` for audit, without minting a row.
- `ChatOrchestrator` keeps `datamachine_resolve_or_create_agent_id()` — opening chat is still operating an agent.

## Cleanup: `wp datamachine agent prune`

- New `datamachine/prune-agents` ability and matching `wp datamachine agent prune` subcommand.
- Default is dry-run listing; `--yes` applies deletion.
- A candidate is an agent row with **zero references**:
  - no chat sessions (network-wide table + legacy per-site tables)
  - no jobs (`agent_id`)
  - no access grants (user or principal)
  - no on-disk agent directory
  - no `datamachine_bundle` config block
  - not the install's default agent
- Uses the existing `deleteAgent` path so grants are cleaned up; directories are never auto-deleted.

## Tests

- Updated `tests/system-agent-context-resolution-smoke.php` for the new resolver behavior.
- Added `tests/agent-prune-smoke.php` covering zero-reference detection, default-agent protection, and session/job/grant/directory/bundle spares.

## Verification

- Local `phpcs` clean.
- `homeboy review data-machine --changed-since origin/main --summary`: lint passed; test stage failed before running tests due to a missing `wp-codebox` CLI binary in this environment (infrastructure, not code).
- Manual smoke-test runs pass.

Fixes #2864