### PR TITLE
fix: prevent pruned agent rows from resurrecting with fresh owner grants

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -1226,6 +1226,11 @@ class AgentAbilities {
 	/**
 	 * Resolve active agent row from persisted preference or safe fallback.
 	 *
+	 * A persisted slug that no longer resolves to an accessible agent is treated
+	 * as "no active agent": the stale pointer is cleared so that later read paths
+	 * (and any external resolver that reads this meta) cannot re-materialize a
+	 * pruned agent identity.
+	 *
 	 * @param int        $user_id               User ID.
 	 * @param array|null $candidates            Optional accessible agent rows.
 	 * @param bool       $allow_single_fallback Whether a single candidate should become active by default.
@@ -1236,14 +1241,20 @@ class AgentAbilities {
 		$stored     = self::get_active_agent_slug_for_user( $user_id );
 
 		if ( '' !== $stored ) {
+			$matched = false;
 			foreach ( $candidates as $row ) {
 				if ( (string) ( $row['agent_slug'] ?? '' ) === $stored && self::user_can_access_agent_row( $user_id, $row ) ) {
+					$matched = true;
 					return array(
 						'agent'        => $row,
 						'source'       => 'preference',
 						'needs_choice' => false,
 					);
 				}
+			}
+
+			if ( ! $matched ) {
+				self::clear_active_agent_slug_for_user( $user_id );
 			}
 		}
 
@@ -1263,14 +1274,40 @@ class AgentAbilities {
 	}
 
 	/**
-	 * Read persisted active agent slug for a user.
+	 * Read persisted active agent slug for a user, validating it still exists.
+	 *
+	 * If the stored slug no longer resolves to a real agent row, the stale meta
+	 * entry is deleted and an empty string is returned.
 	 *
 	 * @param int $user_id User ID.
 	 * @return string
 	 */
 	private static function get_active_agent_slug_for_user( int $user_id ): string {
 		$stored = get_user_meta( $user_id, self::ACTIVE_AGENT_META_KEY, true );
-		return is_string( $stored ) ? sanitize_title( $stored ) : '';
+		$slug   = is_string( $stored ) ? sanitize_title( $stored ) : '';
+		if ( '' === $slug ) {
+			return '';
+		}
+
+		$agents_repo = new Agents();
+		if ( ! $agents_repo->get_by_slug( $slug ) ) {
+			self::clear_active_agent_slug_for_user( $user_id );
+			return '';
+		}
+
+		return $slug;
+	}
+
+	/**
+	 * Clear a user's persisted active agent preference.
+	 *
+	 * @param int $user_id User ID.
+	 * @return void
+	 */
+	private static function clear_active_agent_slug_for_user( int $user_id ): void {
+		if ( $user_id > 0 ) {
+			delete_user_meta( $user_id, self::ACTIVE_AGENT_META_KEY );
+		}
 	}
 
 	/**
@@ -2713,6 +2750,7 @@ class AgentAbilities {
 			foreach ( $candidates as $candidate ) {
 				$result = self::deleteAgent( array( 'agent_id' => $candidate['agent_id'] ) );
 				if ( ! empty( $result['success'] ) ) {
+					self::clear_active_agent_meta_for_owner( (int) $candidate['owner_id'] );
 					$deleted[] = $candidate;
 				}
 			}
@@ -2727,6 +2765,44 @@ class AgentAbilities {
 			'deleted'       => $deleted,
 			'deleted_count' => count( $deleted ),
 		);
+	}
+
+	/**
+	 * Clear the active-agent user-meta pointer for a pruned agent's owner.
+	 *
+	 * User meta is per-site on multisite, so this deletes the key from every
+	 * site where it might have been set.
+	 *
+	 * @param int $owner_id Owner user ID.
+	 * @return void
+	 */
+	private static function clear_active_agent_meta_for_owner( int $owner_id ): void {
+		if ( $owner_id <= 0 ) {
+			return;
+		}
+
+		if ( ! function_exists( 'delete_user_meta' ) ) {
+			return;
+		}
+
+		if ( ! is_multisite() || ! function_exists( 'get_sites' ) || ! function_exists( 'switch_to_blog' ) ) {
+			delete_user_meta( $owner_id, self::ACTIVE_AGENT_META_KEY );
+			return;
+		}
+
+		$blog_ids = get_sites(
+			array(
+				'fields' => 'ids',
+				'number' => 0,
+			)
+		);
+
+		$original_blog_id = get_current_blog_id();
+		foreach ( $blog_ids as $blog_id ) {
+			switch_to_blog( (int) $blog_id );
+			delete_user_meta( $owner_id, self::ACTIVE_AGENT_META_KEY );
+		}
+		switch_to_blog( $original_blog_id );
 	}
 
 	/**

--- a/inc/Core/Database/Agents/AgentAccess.php
+++ b/inc/Core/Database/Agents/AgentAccess.php
@@ -277,6 +277,11 @@ class AgentAccess extends BaseRepository {
 		$agent_id = (int) $grant->agent_id;
 		$user_id  = $grant->user_id;
 		$role     = $grant->role;
+
+		if ( $agent_id <= 0 ) {
+			throw new \InvalidArgumentException( 'invalid_datamachine_agent_access_grant_agent_id' );
+		}
+
 		$existing = $this->get_access( $grant->agent_id, $user_id, $grant->workspace_id );
 
 		if ( $existing ) {
@@ -453,6 +458,10 @@ class AgentAccess extends BaseRepository {
 	 * @return bool True on success.
 	 */
 	public function bootstrap_owner_access( int $agent_id, int $owner_id ): bool {
+		if ( $agent_id <= 0 || $owner_id <= 0 ) {
+			return false;
+		}
+
 		try {
 			$this->grant_access( new \WP_Agent_Access_Grant( (string) $agent_id, $owner_id, \WP_Agent_Access_Grant::ROLE_ADMIN ) );
 			return true;

--- a/inc/Core/Identity/AgentIdentityStoreAdapter.php
+++ b/inc/Core/Identity/AgentIdentityStoreAdapter.php
@@ -74,12 +74,27 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 			return $this->identity_from_row( $existing, $scope );
 		}
 
+		// Only materialize identities that correspond to a registered agent
+		// definition. A stale scope (e.g., from pruned user-meta or a cached
+		// pointer) must not resurrect a phantom agent row.
+		if ( function_exists( 'wp_has_agent' ) && ! wp_has_agent( $scope->agent_slug ) ) {
+			throw new \InvalidArgumentException(
+				sprintf( 'Cannot materialize unregistered agent "%s".', esc_html( $scope->agent_slug ) )
+			);
+		}
+
 		$agent_id = $this->agents_repository->create_if_missing(
 			$scope->agent_slug,
 			$this->label_from_meta( $meta, $scope->agent_slug ),
 			$scope->owner_user_id,
 			$default_config
 		);
+
+		if ( $agent_id <= 0 ) {
+			throw new \RuntimeException(
+				sprintf( 'Failed to create agent row for "%s".', esc_html( $scope->agent_slug ) )
+			);
+		}
 
 		$row = $this->agents_repository->get_agent( $agent_id );
 		if ( ! is_array( $row ) ) {

--- a/tests/Unit/Abilities/AgentPruneResurrectionTest.php
+++ b/tests/Unit/Abilities/AgentPruneResurrectionTest.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Agent prune resurrection regression tests.
+ *
+ * Covers the fixes for Extra-Chill/data-machine#2866:
+ *   1. Stale active-agent user meta is cleared when the agent no longer exists.
+ *   2. pruneAgents clears each pruned owner's active-agent meta.
+ *   3. AgentIdentityStoreAdapter::materialize refuses unregistered scopes.
+ *   4. AgentAccess rejects grants for agent_id <= 0.
+ *
+ * @package DataMachine\Tests\Unit\Abilities
+ * @since   0.161.1
+ */
+
+namespace DataMachine\Tests\Unit\Abilities;
+
+use DataMachine\Abilities\AgentAbilities;
+use DataMachine\Core\Database\Agents\AgentAccess;
+use DataMachine\Core\Identity\AgentIdentityStoreAdapter;
+use WP_UnitTestCase;
+
+class AgentPruneResurrectionTest extends WP_UnitTestCase {
+
+	private const ACTIVE_AGENT_META_KEY = 'datamachine_active_agent_slug';
+
+	/**
+	 * Admin user ID for tests.
+	 */
+	private int $admin_id;
+
+	/**
+	 * Second user ID used as a stray owner.
+	 */
+	private int $owner_id;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->owner_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $this->admin_id );
+	}
+
+	public function tear_down(): void {
+		// Clean up any user meta we touched so later tests do not see stale state.
+		delete_user_meta( $this->owner_id, self::ACTIVE_AGENT_META_KEY );
+		delete_user_meta( $this->admin_id, self::ACTIVE_AGENT_META_KEY );
+
+		// The Agents API registry is in-memory; reset it between tests to avoid
+		// state bleed from registrations made inside test cases.
+		if ( class_exists( 'WP_Agents_Registry' ) && method_exists( 'WP_Agents_Registry', 'reset_for_tests' ) ) {
+			\WP_Agents_Registry::reset_for_tests();
+		}
+
+		parent::tear_down();
+	}
+
+	public function test_getActiveAgent_clears_stale_meta_and_does_not_resurrect(): void {
+		$created = AgentAbilities::createAgent(
+			array(
+				'agent_slug' => 'stale-meta-bot',
+				'owner_id'   => $this->owner_id,
+			)
+		);
+		$this->assertTrue( $created['success'] );
+
+		// Owner selects the agent as their active preference.
+		AgentAbilities::setActiveAgent(
+			array(
+				'user_id' => $this->owner_id,
+				'agent'   => $created['agent_slug'],
+			)
+		);
+		$this->assertSame( 'stale-meta-bot', get_user_meta( $this->owner_id, self::ACTIVE_AGENT_META_KEY, true ) );
+
+		// Simulate prune by deleting the agent row directly.
+		$deleted = AgentAbilities::deleteAgent( array( 'agent_id' => $created['agent_id'] ) );
+		$this->assertTrue( $deleted['success'] );
+
+		// Reading the active agent should now clear the stale meta and report none.
+		$result = AgentAbilities::getActiveAgent( array( 'user_id' => $this->owner_id ) );
+		$this->assertTrue( $result['success'] );
+		$this->assertNull( $result['agent'] );
+		$this->assertSame( 'invalid_preference', $result['source'] );
+		$this->assertSame( '', get_user_meta( $this->owner_id, self::ACTIVE_AGENT_META_KEY, true ) );
+
+		// The agent row must stay deleted.
+		$lookup = AgentAbilities::getAgent( array( 'agent_slug' => 'stale-meta-bot' ) );
+		$this->assertFalse( $lookup['success'] );
+	}
+
+	public function test_pruneAgents_clears_owner_active_agent_meta(): void {
+		$created = AgentAbilities::createAgent(
+			array(
+				'agent_slug' => 'prune-me-bot',
+				'owner_id'   => $this->owner_id,
+			)
+		);
+		$this->assertTrue( $created['success'] );
+
+		AgentAbilities::setActiveAgent(
+			array(
+				'user_id' => $this->owner_id,
+				'agent'   => $created['agent_slug'],
+			)
+		);
+
+		// No references => prune candidate.
+		$pruned = AgentAbilities::pruneAgents( array( 'dry_run' => false ) );
+		$this->assertTrue( $pruned['success'] );
+
+		$deleted_ids = array_column( $pruned['deleted'], 'agent_id' );
+		$this->assertContains( $created['agent_id'], $deleted_ids );
+
+		// The owner's active-agent pointer must have been deleted network-wide.
+		$this->assertSame( '', get_user_meta( $this->owner_id, self::ACTIVE_AGENT_META_KEY, true ) );
+	}
+
+	public function test_materialize_throws_for_unregistered_stale_scope(): void {
+		$store = new AgentIdentityStoreAdapter();
+		$scope = new \AgentsAPI\Core\Identity\WP_Agent_Identity_Scope( 'pruned-stale-bot', $this->owner_id );
+
+		$this->expectException( \InvalidArgumentException::class );
+		$store->materialize( $scope, array( 'model' => array( 'default' => 'openai/gpt-4o' ) ) );
+	}
+
+	public function test_materialize_creates_registered_definition(): void {
+		$scope = new \AgentsAPI\Core\Identity\WP_Agent_Identity_Scope( 'registered-bot', $this->owner_id );
+
+		$registry = \WP_Agents_Registry::get_instance();
+		$registry->register(
+			'registered-bot',
+			array(
+				'label'          => 'Registered Bot',
+				'owner_resolver' => function () {
+					return $this->owner_id;
+				},
+			)
+		);
+
+		try {
+			$store    = new AgentIdentityStoreAdapter();
+			$identity = $store->materialize( $scope );
+
+			$this->assertGreaterThan( 0, $identity->id );
+			$this->assertSame( 'registered-bot', $identity->scope->normalize()->agent_slug );
+
+			$access_repo = new AgentAccess();
+			$this->assertTrue( $access_repo->user_can_access( $identity->id, $this->owner_id, 'admin' ) );
+		} finally {
+			$registry->unregister( 'registered-bot' );
+		}
+	}
+
+	public function test_grant_access_rejects_agent_id_zero(): void {
+		$access_repo = new AgentAccess();
+		$grant       = new \WP_Agent_Access_Grant( '0', $this->owner_id, \WP_Agent_Access_Grant::ROLE_ADMIN );
+
+		$this->expectException( \InvalidArgumentException::class );
+		$access_repo->grant_access( $grant );
+	}
+
+	public function test_bootstrap_owner_access_rejects_agent_id_zero(): void {
+		$access_repo = new AgentAccess();
+		$this->assertFalse( $access_repo->bootstrap_owner_access( 0, $this->owner_id ) );
+		$this->assertFalse( $access_repo->bootstrap_owner_access( -1, $this->owner_id ) );
+	}
+}

--- a/tests/agent-prune-resurrection-smoke.php
+++ b/tests/agent-prune-resurrection-smoke.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Regression smoke test for agent prune resurrection (Extra-Chill/data-machine#2866).
+ *
+ * Run with: php tests/agent-prune-resurrection-smoke.php
+ *
+ * When executed inside a WordPress runtime, this exercises the actual ability
+ * paths that caused pruned per-user agents to resurrect. In a pure-PHP harness
+ * it falls back to source-level assertions verifying the four fixes are in
+ * place.
+ *
+ * @package DataMachine\Tests
+ * @since   0.161.1
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = 0;
+$total    = 0;
+
+$assert = function ( string $label, bool $cond ) use ( &$failures, &$total ): void {
+	$total++;
+	if ( $cond ) {
+		echo "  [PASS] {$label}\n";
+	} else {
+		$failures++;
+		echo "  [FAIL] {$label}\n";
+	}
+};
+
+$root        = dirname( __DIR__ );
+$ability_src = (string) file_get_contents( $root . '/inc/Abilities/AgentAbilities.php' );
+$access_src  = (string) file_get_contents( $root . '/inc/Core/Database/Agents/AgentAccess.php' );
+$adapter_src = (string) file_get_contents( $root . '/inc/Core/Identity/AgentIdentityStoreAdapter.php' );
+
+// ─── Source-level guards ────────────────────────────────────────────
+
+echo "\n[1] Source-level fixes for #2866 are present\n";
+
+$assert(
+	'AgentAbilities::get_active_agent_slug_for_user validates slug existence and clears stale meta',
+	str_contains( $ability_src, 'get_by_slug( $slug )' )
+	&& str_contains( $ability_src, 'clear_active_agent_slug_for_user( $user_id )' )
+	&& str_contains( $ability_src, "delete_user_meta( \$user_id, self::ACTIVE_AGENT_META_KEY )" )
+);
+
+$assert(
+	'AgentAbilities::pruneAgents clears owner active-agent meta after deletion',
+	str_contains( $ability_src, 'clear_active_agent_meta_for_owner( (int) $candidate[\'owner_id\'] )' )
+);
+
+$assert(
+	'AgentIdentityStoreAdapter::materialize guards unregistered scopes',
+	str_contains( $adapter_src, "function_exists( 'wp_has_agent' )" )
+	&& str_contains( $adapter_src, '! wp_has_agent( $scope->agent_slug )' )
+	&& str_contains( $adapter_src, 'Cannot materialize unregistered agent' )
+);
+
+$assert(
+	'AgentAccess::grant_access rejects agent_id <= 0',
+	str_contains( $access_src, 'if ( $agent_id <= 0 )' )
+	&& str_contains( $access_src, 'throw new \\InvalidArgumentException' )
+);
+
+$assert(
+	'AgentAccess::bootstrap_owner_access rejects agent_id <= 0',
+	str_contains( $access_src, 'if ( $agent_id <= 0 || $owner_id <= 0 )' )
+);
+
+// ─── Real WordPress runtime regression ──────────────────────────────
+
+if ( function_exists( 'wp_get_ability' ) ) {
+	echo "\n[2] WordPress runtime regression: prune + active-agent read\n";
+
+	require_once $root . '/vendor/autoload.php';
+
+	$owner_id = wp_insert_user(
+		array(
+			'user_login' => 'prune-resurrection-owner-' . wp_rand(),
+			'user_pass'  => wp_generate_password(),
+			'role'       => 'author',
+		)
+	);
+	if ( is_wp_error( $owner_id ) ) {
+		echo "  [SKIP] Could not create test user: {$owner_id->get_error_message()}\n";
+	} else {
+		$meta_key = 'datamachine_active_agent_slug';
+
+		$created = \DataMachine\Abilities\AgentAbilities::createAgent(
+			array(
+				'agent_slug' => 'resurrection-test-bot',
+				'owner_id'   => $owner_id,
+			)
+		);
+		$assert( 'test agent created', ! empty( $created['success'] ) );
+
+		if ( ! empty( $created['success'] ) ) {
+			\DataMachine\Abilities\AgentAbilities::setActiveAgent(
+				array(
+					'user_id' => $owner_id,
+					'agent'   => $created['agent_slug'],
+				)
+			);
+			$assert( 'active-agent meta persisted', get_user_meta( $owner_id, $meta_key, true ) === $created['agent_slug'] );
+
+			$deleted = \DataMachine\Abilities\AgentAbilities::deleteAgent( array( 'agent_id' => $created['agent_id'] ) );
+			$assert( 'test agent deleted', ! empty( $deleted['success'] ) );
+
+			// The read path must clear stale meta and must not recreate the row.
+			$active = \DataMachine\Abilities\AgentAbilities::getActiveAgent( array( 'user_id' => $owner_id ) );
+			$assert( 'getActiveAgent returns null for stale preference', null === $active['agent'] );
+			$assert( 'stale active-agent meta is cleared', '' === get_user_meta( $owner_id, $meta_key, true ) );
+
+			$lookup = \DataMachine\Abilities\AgentAbilities::getAgent( array( 'agent_slug' => $created['agent_slug'] ) );
+			$assert( 'pruned agent row stays deleted', empty( $lookup['success'] ) );
+
+			$access_repo = new \DataMachine\Core\Database\Agents\AgentAccess();
+			$grants      = $access_repo->get_users_for_agent( (string) $created['agent_id'] );
+			$assert( 'no grants exist for pruned agent ID', empty( $grants ) );
+		}
+
+		// Cleanup.
+		delete_user_meta( $owner_id, $meta_key );
+		if ( is_numeric( $owner_id ) ) {
+			wp_delete_user( (int) $owner_id );
+		}
+	}
+
+	echo "\n[3] WordPress runtime regression: identity-store materialize guard\n";
+
+	$adapter = new \DataMachine\Core\Identity\AgentIdentityStoreAdapter();
+	$scope   = new \AgentsAPI\Core\Identity\WP_Agent_Identity_Scope( 'unregistered-pruned-bot', 1 );
+
+	try {
+		$adapter->materialize( $scope );
+		$assert( 'materialize rejects unregistered stale scope', false );
+	} catch ( \InvalidArgumentException $e ) {
+		$assert( 'materialize rejects unregistered stale scope', true );
+	}
+}
+
+// ─── Summary ────────────────────────────────────────────────────────
+
+echo "\n";
+if ( $failures > 0 ) {
+	echo "=== agent-prune-resurrection-smoke: {$failures}/{$total} FAILED ===\n";
+	exit( 1 );
+}
+echo "=== agent-prune-resurrection-smoke: ALL PASS ({$total} assertions) ===\n";


### PR DESCRIPTION
Fixes #2866.

## Identified resurrector

The recreated rows matched the `bootstrap_owner_access()` signature (owner admin grant), not the bare `create_if_missing()` shape. The path that produced them is the **Agents API identity-store materialization path** reading stale `datamachine_active_agent_slug` user meta:

1. An external resolver or chat path reads `datamachine_active_agent_slug` for a user whose agent was just pruned.
2. It constructs a `WP_Agent_Identity_Scope( $stale_slug, $owner_id )` and calls the filtered identity store.
3. `AgentIdentityStoreAdapter::materialize()` did not verify that the slug corresponded to a registered definition; when the row was missing it simply created it via `create_if_missing()`.
4. `after_created()` then called `AgentAccess::bootstrap_owner_access()`, minting the fresh admin grant that made the row un-pruneable.

The production SQL cleanup deleted the rows and their grants but left the per-user meta pointer intact, so a subsequent request that resolved the active agent re-ran the chain. Manual cleanup of the rows+grants happened to sever the pointer, which is why the table stabilized.

## Fixes

1. **Stop recreation-on-read** (`AgentAbilities::get_active_agent_slug_for_user` / `resolve_active_agent_for_user`): a persisted active-agent slug that no longer resolves to an existing agent row is now treated as "no active agent" and the stale `datamachine_active_agent_slug` meta is deleted.
2. **Prune deletes pointers** (`AgentAbilities::pruneAgents`): after a candidate is deleted, each pruned owner's `datamachine_active_agent_slug` user meta is cleared across all network sites.
3. **Identity-store guard** (`AgentIdentityStoreAdapter::materialize`): creation is now allowed only when the slug is registered in the Agents API registry (`wp_has_agent`). A stale scope therefore throws instead of resurrecting a phantom row. Failed inserts (`agent_id <= 0`) also throw before `after_created()` can run.
4. **Grants guard** (`AgentAccess::grant_access` / `bootstrap_owner_access`): reject `agent_id <= 0` at the repository layer, preventing corrupted `agent_id=0` grant rows like the one observed in production.

## Tests

- Added `tests/agent-prune-resurrection-smoke.php` (source-level + real-WordPress regression assertions).
- Added `tests/Unit/Abilities/AgentPruneResurrectionTest.php` covering stale-meta clearing, prune pointer cleanup, the materialize guard, and the grants guard.

## Verification

- `php tests/agent-prune-resurrection-smoke.php` ✅
- `php tests/agent-prune-smoke.php` ✅
- `php tests/agent-registry-materializer-smoke.php` ✅
- `vendor/bin/phpcs` on all changed files ✅

The homeboy/Test CI stage has a known intermittent infra failure (warm-machine resource-policy refusal, tracked in Extra-Chill/homeboy#7735). If the Test check fails, please inspect the job log: resource-policy refusal is the known flake; any other failure is real and should be fixed.