### PR TITLE
fix(wake-briefing): add freshness stamp, staleness guard, honest hourly wording

### DIFF
--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -92,7 +92,7 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 				continue;
 			}
 
-			$content = self::normalize_for_injection( $read->content, $read->bytes, $filename );
+			$content = self::normalize_for_injection( $read->content, $read->bytes, $filename, $read->updated_at );
 			if ( null === $content ) {
 				continue;
 			}
@@ -207,9 +207,10 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 	 * @param string $content  Raw file content (already loaded by caller).
 	 * @param int    $bytes    Content length in bytes (already known by caller).
 	 * @param string $filename Filename for logs and the content filter.
+	 * @param int|null $updated_at File mtime (Unix timestamp) or null when unknown.
 	 * @return string|null
 	 */
-	private static function normalize_for_injection( string $content, int $bytes, string $filename ): ?string {
+	private static function normalize_for_injection( string $content, int $bytes, string $filename, ?int $updated_at = null ): ?string {
 		if ( $bytes > AgentMemory::MAX_FILE_SIZE ) {
 			do_action(
 				'datamachine_log',
@@ -242,16 +243,19 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 		 * file read, not just composable ones.
 		 *
 		 * @since 0.66.0
+		 * @since next  Added $updated_at (file mtime) as 4th param.
 		 *
-		 * @param string     $content  File content.
-		 * @param string     $filename Filename (e.g. 'SOUL.md', 'MEMORY.md').
-		 * @param array|null $meta     Registry metadata, or null if unregistered.
+		 * @param string     $content    File content.
+		 * @param string     $filename   Filename (e.g. 'SOUL.md', 'MEMORY.md').
+		 * @param array|null $meta       Registry metadata, or null if unregistered.
+		 * @param int|null   $updated_at File mtime (Unix timestamp) or null.
 		 */
 		$content = apply_filters(
 			'datamachine_memory_file_content',
 			$content,
 			$filename,
-			MemoryFileRegistry::get( $filename )
+			MemoryFileRegistry::get( $filename ),
+			$updated_at
 		);
 
 		if ( empty( trim( $content ) ) ) {

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -60,6 +60,7 @@ class SystemAgentServiceProvider {
 		$this->initializeRegistry();
 		$this->registerActionSchedulerHooks();
 		add_action( 'action_scheduler_init', array( $this, 'manageRecurringTaskSchedules' ) );
+		WakeBriefingTask::registerStalenessGuard();
 	}
 
 	/**

--- a/inc/Engine/AI/System/Tasks/WakeBriefingTask.php
+++ b/inc/Engine/AI/System/Tasks/WakeBriefingTask.php
@@ -15,8 +15,10 @@
  * sessions. A single mutable "last_wake" timestamp would be a race: whichever
  * session composed first would reset the clock and blind every concurrent
  * session. So this task keeps NO state. The digest is always "what changed in
- * the last N hours", recomputed from the current time on every run. There is
- * nothing to race because there is nothing to reset.
+ * the last N hours", recomputed hourly via Action Scheduler (see
+ * SystemAgentServiceProvider, schedule interval=hourly) — not per session.
+ * There is nothing to race because there is nothing to reset; the "hourly"
+ * cadence means a freshly composed file is at most ~1 cycle old.
  *
  * ## Signal discipline is the feature
  *
@@ -316,14 +318,22 @@ class WakeBriefingTask extends SystemTask {
 	 * Render the digest. Ruthless terseness: one grouped line per signal,
 	 * a single quiet line when nothing crosses the bar.
 	 *
+	 * The rendered header includes a machine+human-readable `generated_at`
+	 * (UTC) stamp so any reader can see the digest age. The injection-time
+	 * staleness guard (see {@see self::applyStalenessGuard()}) layers a
+	 * visible warning on top when the on-disk file is older than the
+	 * rolling window.
+	 *
 	 * @param string[] $signals      Threshold-crossing signal lines.
 	 * @param int      $window_hours Window size in hours.
 	 * @return string Markdown content.
 	 */
 	private function render( array $signals, int $window_hours, string $scope = 'site' ): string {
-		$reach   = 'network' === $scope ? 'across the network' : 'on this site';
-		$header  = "# Wake Briefing\n\n";
-		$header .= sprintf( "_What changed in the last %dh %s (recomputed each session; not personal to one session)._\n\n", $window_hours, $reach );
+		$reach        = 'network' === $scope ? 'across the network' : 'on this site';
+		$generated_at = gmdate( 'Y-m-d H:i T' );
+		$header       = "# Wake Briefing\n\n";
+		$header      .= sprintf( "_What changed in the last %dh %s (recomposed hourly; a rolling %dh window; not personal to one session)._\n\n", $window_hours, $reach, $window_hours );
+		$header      .= sprintf( "_Generated at %s._\n\n", $generated_at );
 
 		if ( empty( $signals ) ) {
 			$where = 'network' === $scope ? 'across the network' : 'here';
@@ -824,6 +834,58 @@ class WakeBriefingTask extends SystemTask {
 	 */
 	public function getTaskType(): string {
 		return 'wake_briefing';
+	}
+
+	/**
+	 * Register the injection-time staleness guard for WAKE.md.
+	 *
+	 * Hooks into datamachine_memory_file_content to prepend a visible
+	 * warning when the on-disk WAKE.md is older than the rolling window
+	 * — i.e. when hourly recomposition has stalled (feature disabled,
+	 * cron wedged, etc.). Without this guard every consumer silently
+	 * trusts fossil data.
+	 *
+	 * Called once from SystemAgentServiceProvider at construction time.
+	 */
+	public static function registerStalenessGuard(): void {
+		add_filter( 'datamachine_memory_file_content', array( self::class, 'applyStalenessGuard' ), 10, 4 );
+	}
+
+	/**
+	 * Staleness guard callback for datamachine_memory_file_content.
+	 *
+	 * If WAKE.md hasn't been refreshed within the rolling window, prepend
+	 * a visible warning so consumers don't silently trust stale data. The
+	 * generated_at stamp baked into the file by render() already shows the
+	 * composition time; this guard adds a machine-computed age warning at
+	 * injection time based on the file's actual mtime.
+	 *
+	 * @param string     $content    File content.
+	 * @param string     $filename   Filename.
+	 * @param array|null $meta       Registry metadata (unused).
+	 * @param int|null   $updated_at File mtime (Unix timestamp), or null.
+	 * @return string
+	 */
+	public static function applyStalenessGuard( string $content, string $filename, ?array $meta, ?int $updated_at ): string {
+		if ( self::BRIEFING_FILENAME !== $filename || null === $updated_at ) {
+			return $content;
+		}
+
+		$window_hours = (int) apply_filters( 'datamachine_wake_briefing_window_hours', self::DEFAULT_WINDOW_HOURS, array() );
+		$age          = time() - $updated_at;
+		$max_age      = $window_hours * HOUR_IN_SECONDS;
+
+		if ( $age <= $max_age ) {
+			return $content;
+		}
+
+		$hours_old = (int) round( $age / HOUR_IN_SECONDS );
+
+		return sprintf(
+			"⚠ **This briefing is %d hours old — recomposition may be stalled.** The data below may be out of date.\n\n%s",
+			$hours_old,
+			$content
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes two WAKE.md freshness bugs in one PR — both edit `WakeBriefingTask.php`, so they must land together.

Closes #2868, closes #2869.

## Issue #2868 — no freshness stamp / no self-staleness guard

**Problem:** WAKE.md is injected into every agent session as "what changed in the last 24h" but carried NO composed-at timestamp and no self-staleness guard. When recomposition halted (feature disabled, cron wedged), every consumer silently trusted fossil data. In production the file froze for 15 days while still claiming "last 24h", causing a false alarm about a healthy task.

**What changed:**

- **`generated_at` stamp in `render()`:** The rendered WAKE.md header now includes a machine+human-readable `_Generated at YYYY-MM-DD HH:MM UTC._` line. Any reader can see the digest age at a glance. This stamp is baked into the file at composition time.

- **Self-staleness guard at injection time:** If the on-disk WAKE.md is older than the rolling window (mtime > `window_hours` ago), a leading warning is prepended:
  > ⚠ **This briefing is N hours old — recomposition may be stalled.** The data below may be out of date.

  The guard is implemented as a `datamachine_memory_file_content` filter callback (`WakeBriefingTask::applyStalenessGuard()`), registered from `WakeBriefingTask::registerStalenessGuard()` called in `SystemAgentServiceProvider::__construct()`. It targets only `WAKE.md` by filename — zero impact on other memory files.

- **Filter plumbing (`CoreMemoryFilesDirective.php`):** The file's `updated_at` (mtime, already populated by the store from `filemtime()`) is now threaded through `normalize_for_injection()` as a backward-compatible 4th argument to the `datamachine_memory_file_content` filter. This is the only change to the generic directive layer — purely additive, existing 3-arg callbacks are unaffected.

## Issue #2869 — docblock + header claim "recomputed each session" but only hourly cron triggers it

**Decision:** OPTION B (honest hourly wording). No session-start hook wired.

**What changed:**

- **Class docblock (L12-19):** Was "recomputed from the current time on every run." Now: "recomputed hourly via Action Scheduler (see SystemAgentServiceProvider, schedule interval=hourly) — not per session." The stateless-rolling-window rationale is kept intact.

- **Rendered header (`render()` ~L335):** Was:
  > _What changed in the last 24h across the network (recomputed each session; not personal to one session)._

  Now:
  > _What changed in the last 24h across the network (recomposed hourly; a rolling 24h window; not personal to one session)._

  Dropped "recomputed each session." Kept the accurate "not personal to one session" and the rolling-window claim. Matches the actual `window_hours` value that `render()` already receives.

## Files changed

| File | Change |
|------|--------|
| `inc/Engine/AI/System/Tasks/WakeBriefingTask.php` | Docblock honesty (#2869); `generated_at` stamp + staleness guard methods (#2868) |
| `inc/Engine/AI/Directives/CoreMemoryFilesDirective.php` | Thread `updated_at` into `datamachine_memory_file_content` filter (#2868) |
| `inc/Engine/AI/System/SystemAgentServiceProvider.php` | Register staleness guard (#2868) |

## Verification

- **PHPCS:** passed
- **PHPStan (level 7):** passed
- **ESLint:** 1 pre-existing warning in `inc/Core/Admin/shared/utils/api.js` (not touched by this PR)
- **Tests:** could not run — WP Codebox recipe builder unavailable on this host (infrastructure, not code)

## Layer purity

The staleness guard logic lives on `WakeBriefingTask` (the class that owns WAKE.md semantics), not in the generic directive. The generic layer change is limited to threading an already-available `updated_at` value through an existing filter — no WAKE-specific knowledge in `CoreMemoryFilesDirective`.