### PR TITLE
fix: guard null source_url in WordPress publish dedup path

### DIFF
--- a/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php
+++ b/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php
@@ -93,8 +93,8 @@ class DuplicateCheckAbility {
 							'description' => __( 'Jaccard similarity threshold for queue checks (default: 0.65)', 'data-machine' ),
 						),
 						'source_url'    => array(
-							'type'        => 'string',
-							'description' => __( 'Canonical source URL to check for exact-match duplicates before title similarity.', 'data-machine' ),
+							'type'        => array( 'string', 'null' ),
+							'description' => __( 'Canonical source URL to check for exact-match duplicates before title similarity. Optional; when absent or null, dedup falls back to title matching.', 'data-machine' ),
 						),
 						'context'       => array(
 							'type'        => 'object',

--- a/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php
+++ b/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php
@@ -142,15 +142,18 @@ class WordPress extends PublishHandler {
 				$existing_id     = null;
 
 				if ( $duplicate_check ) {
-					$duplicate_result = $duplicate_check->execute(
-						array(
-							'title'         => $title,
-							'post_type'     => $post_type,
-							'lookback_days' => $lookback_days,
-							'scope'         => 'published',
-							'source_url'    => $source_url,
-						)
+					$args = array(
+						'title'         => $title,
+						'post_type'     => $post_type,
+						'lookback_days' => $lookback_days,
+						'scope'         => 'published',
 					);
+
+					if ( is_string( $source_url ) && '' !== $source_url ) {
+						$args['source_url'] = $source_url;
+					}
+
+					$duplicate_result = $duplicate_check->execute( $args );
 
 					if ( is_wp_error( $duplicate_result ) ) {
 						$this->log( 'warning', 'Duplicate check failed: ' . $duplicate_result->get_error_message() );

--- a/tests/Unit/Abilities/DuplicateCheckAbilityTest.php
+++ b/tests/Unit/Abilities/DuplicateCheckAbilityTest.php
@@ -177,6 +177,48 @@ class DuplicateCheckAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( $post_id, $result['match']['post_id'] );
 	}
 
+	/**
+	 * Dedup must still work when source_url is absent/null — it falls back
+	 * to title matching. Regression guard for #2870.
+	 */
+	public function test_check_duplicate_falls_back_to_title_when_source_url_absent(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Bonnaroo 2026 Lineup Announced',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		update_post_meta( $post_id, PostTracking::SOURCE_URL_META_KEY, 'https://www.reddit.com/r/bonnaroo/comments/zzz/original/' );
+
+		$ability = wp_get_ability( 'datamachine/check-duplicate' );
+
+		$result_without = $ability->execute(
+			array(
+				'title'     => 'Bonnaroo 2026 Lineup Announced',
+				'post_type' => 'post',
+				'scope'     => 'published',
+			)
+		);
+
+		$this->assertSame( 'duplicate', $result_without['verdict'] );
+		$this->assertSame( 'published_post', $result_without['source'] );
+		$this->assertSame( $post_id, $result_without['match']['post_id'] );
+
+		$result_null = $ability->execute(
+			array(
+				'title'      => 'Bonnaroo 2026 Lineup Announced',
+				'post_type'  => 'post',
+				'scope'      => 'published',
+				'source_url' => null,
+			)
+		);
+
+		$this->assertSame( 'duplicate', $result_null['verdict'] );
+		$this->assertSame( 'published_post', $result_null['source'] );
+	}
+
 	// -----------------------------------------------------------------------
 	// Strategy registry
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a silent dedup-skip bug in the WordPress publish handler. Closes #2870.

## Root cause

`inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php` called `$engine->getSourceUrl()` (which legitimately returns `?string` — `EngineData::getSourceUrl(): ?string`, and `PublishHandler::getSourceUrl()` defaults to `null`) and passed it straight into the `datamachine/check-duplicate` ability as `source_url => $source_url`. That ability's input schema declared `source_url` as a **non-nullable** `string` (`inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php`), so input validation failed with:

> Duplicate check failed: ... input[source_url] is not of type string.

The handler logged that at `warning` level and **swallowed** it (`$duplicate_result = array()`), so dedup was silently skipped on every publish whose source was null. Observed 12x in 48h on the wire.extrachill.com Festival Wire pipeline (Reddit→AI→WordPress), where each miss means the wire can republish a story it already covered.

## The fix — both sides

**1. Handler side** (`WordPress.php`): only include `source_url` in the `execute()` payload when it is a non-empty string; omit the key entirely otherwise.

```php
$args = array(
    'title'         => $title,
    'post_type'     => $post_type,
    'lookback_days' => $lookback_days,
    'scope'         => 'published',
);
if ( is_string( $source_url ) && '' !== $source_url ) {
    $args['source_url'] = $source_url;
}
$duplicate_result = $duplicate_check->execute( $args );
```

**2. Ability side** (`DuplicateCheckAbility.php`): make `source_url` nullable in the input schema — `'type' => array( 'string', 'null' )`. Title + post_type + lookback is already a valid dedup key without it.

## Other handlers checked

Grepped `inc/Core/Steps/Publish/Handlers/` for `check-duplicate` / `source_url`. Only the **WordPress** handler invokes the check-duplicate ability. `Email` and `TypedArtifact` handlers do not call it. No other handlers needed the guard.

## How dedup still works without source_url

Confirmed by reading `executeCheckDuplicate()`:
- L139: `$source_url = ! empty( $input['source_url'] ) ? esc_url_raw( $input['source_url'] ) : '';` — an absent/null source_url coalesces to `''`.
- L182: `checkPublishedPostsBySourceUrl( '', ... )` returns `null` immediately (empty-string guard at the top of the method).
- L187: `checkPublishedPosts( $title, ... )` then runs — **title-based matching is the fallback**, so dedup still fires. The present (source_url-present) case is unchanged.

## Test

Added `test_check_duplicate_falls_back_to_title_when_source_url_absent` to `tests/Unit/Abilities/DuplicateCheckAbilityTest.php`. It creates a published post (with a source_url meta) and asserts a `duplicate` verdict via `published_post` (title match) for **both** an omitted `source_url` and an explicitly `null` one.

## Verification

- `php -l` — no syntax errors on all 3 changed files.
- `homeboy review data-machine lint` — clean; the only remaining finding is a **pre-existing** `eslint.no-console` warning in `inc/Core/Admin/shared/utils/api.js` (untouched by this PR).
- `homeboy review data-machine test` — **could not run**: the WP Codebox PHPUnit backend fails to start in this environment with `WP Codebox recipe builder export buildWordPressPhpunitRecipe is unavailable` (missing `@automattic/wp-codebox-core/recipe-builders` module). This is an infra/tooling issue, not a test failure — no tests executed. Please run the suite in a working sandbox on review.

Do not release / deploy — PR only.