### PR TITLE
fix: downgrade empty-fetch log from ERROR to INFO (#2873)

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -401,22 +401,35 @@ class ExecuteStepAbility {
 	private function logStepExecutionResult( array $execution_result, int $job_id, string $flow_step_id, string $step_type = '' ): void {
 		$success = (bool) ( $execution_result['success'] ?? false );
 
-		if ( ! $success ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				'Step execution did not produce a successful result',
-				array(
-					'job_id'       => $job_id,
-					'flow_step_id' => $flow_step_id,
-					'step_type'    => $step_type,
-					'status'       => $execution_result['status'] ?? 'failed',
-					'reason'       => $execution_result['reason'] ?? 'step_execution_failed',
-					'packet_count' => $execution_result['packet_count'] ?? 0,
-					'diagnostics'  => is_array( $execution_result['diagnostics'] ?? null ) ? $execution_result['diagnostics'] : array(),
-				)
-			);
+		if ( $success ) {
+			return;
 		}
+
+		$status = $execution_result['status'] ?? 'failed';
+
+		// completed_no_items is a success-family terminal status (an empty fetch
+		// window, not a failure) — it already gets its own INFO log downstream
+		// ("Step completed with no new items to process"). Warning here on top
+		// of that INFO and the step's own info-level "no content" log would be
+		// triple noise for one routine event. See #2873.
+		if ( 'completed_no_items' === $status ) {
+			return;
+		}
+
+		do_action(
+			'datamachine_log',
+			'warning',
+			'Step execution did not produce a successful result',
+			array(
+				'job_id'       => $job_id,
+				'flow_step_id' => $flow_step_id,
+				'step_type'    => $step_type,
+				'status'       => $status,
+				'reason'       => $execution_result['reason'] ?? 'step_execution_failed',
+				'packet_count' => $execution_result['packet_count'] ?? 0,
+				'diagnostics'  => is_array( $execution_result['diagnostics'] ?? null ) ? $execution_result['diagnostics'] : array(),
+			)
+		);
 	}
 
 	/**

--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -253,7 +253,13 @@ class FetchStep extends Step {
 		}
 
 		if ( empty( $packets ) ) {
-			$this->log( 'error', 'Fetch handler returned no content' );
+			// Empty fetch is routine, expected behavior (filtered sources, quiet
+			// windows, small subreddits with no qualifying items) — not a handler
+			// failure. The job proceeds to the success-family `completed_no_items`
+			// terminal status, and RunMetrics already records `result: no_content`
+			// below. Reserve `error` for the is_wp_error() branch above, which is
+			// an actual handler failure. See #2873.
+			$this->log( 'info', 'Fetch handler returned no content' );
 			RunMetrics::recordStepResult(
 				$this->job_id,
 				$this->flow_step_id,

--- a/tests/fetch-no-content-log-severity-smoke.php
+++ b/tests/fetch-no-content-log-severity-smoke.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Pure-PHP smoke test for empty-fetch log severity (#2873).
+ *
+ * Empty fetch results are routine, expected outcomes (filtered sources,
+ * quiet windows) that terminate in the success-family `completed_no_items`
+ * status. They must not log at `error`, and the paired
+ * "Step execution did not produce a successful result" WARNING must not
+ * fire for that status either — both would be noise for a successful
+ * empty window.
+ *
+ * Run with: php tests/fetch-no-content-log-severity-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$datamachine_no_content_severity_logs = array();
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['datamachine_no_content_severity_logs'][] = array(
+			'hook' => $hook,
+			'args' => $args,
+		);
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		$key = strtolower( $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/StepExecutionResult.php';
+require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
+require_once __DIR__ . '/../inc/Abilities/Engine/EngineHelpers.php';
+require_once __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php';
+
+use DataMachine\Abilities\Engine\ExecuteStepAbility;
+use DataMachine\Core\StepExecutionResult;
+
+$failures = 0;
+$total    = 0;
+
+$assert = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$label}\n";
+		return;
+	}
+
+	++$failures;
+	echo "  [FAIL] {$label}\n";
+};
+
+echo "=== fetch-no-content-log-severity-smoke ===\n";
+
+echo "\n[1] FetchStep logs empty results at info, not error\n";
+$fetch_step = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/FetchStep.php' ) ?: '';
+
+$assert(
+	'FetchStep no-content branch logs at info level',
+	str_contains( $fetch_step, "\$this->log( 'info', 'Fetch handler returned no content' );" )
+);
+$assert(
+	'FetchStep no longer logs no-content at error level',
+	! str_contains( $fetch_step, "\$this->log( 'error', 'Fetch handler returned no content' );" )
+);
+$assert(
+	'FetchStep still logs actual handler failures at error level',
+	str_contains( $fetch_step, "\$this->log( 'error', 'Fetch handler failed: ' . \$packets->get_error_message() );" )
+);
+$assert(
+	'FetchStep still records no_content in RunMetrics unchanged',
+	str_contains( $fetch_step, "'result'       => 'no_content'," )
+);
+
+echo "\n[2] logStepExecutionResult skips the paired WARNING for completed_no_items\n";
+
+$run_log = function ( array $execution_result ): array {
+	$GLOBALS['datamachine_no_content_severity_logs'] = array();
+
+	$reflection = new ReflectionClass( ExecuteStepAbility::class );
+	$ability    = $reflection->newInstanceWithoutConstructor();
+	$method     = $reflection->getMethod( 'logStepExecutionResult' );
+	$method->invoke( $ability, $execution_result, 123, 'fetch_1', 'fetch' );
+
+	return $GLOBALS['datamachine_no_content_severity_logs'];
+};
+
+// Real classification path: an empty-packet fetch step classifies to
+// completed_no_items via StepExecutionResult::classify(), exactly like
+// FetchStep's empty-return path does.
+$classified = StepExecutionResult::classify( array(), 'fetch' );
+$assert( 'classify() marks empty fetch packets as completed_no_items', 'completed_no_items' === $classified['status'] );
+
+$logs = $run_log( $classified );
+$assert( 'no WARNING is fired for completed_no_items status', 0 === count( $logs ) );
+
+// A genuine failure (e.g. empty packets on a non-fetch step) must still warn.
+$failed_classified = StepExecutionResult::classify( array(), 'ai' );
+$assert( 'classify() marks empty non-fetch packets as failed', 'failed' === $failed_classified['status'] );
+
+$failed_logs = $run_log( $failed_classified );
+$assert( 'WARNING still fires for genuine failed status', 1 === count( $failed_logs ) );
+$assert(
+	'WARNING message is unchanged for genuine failures',
+	isset( $failed_logs[0]['args'][1] ) && 'Step execution did not produce a successful result' === $failed_logs[0]['args'][1]
+);
+
+if ( $failures > 0 ) {
+	echo "\n=== fetch-no-content-log-severity-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";
+	exit( 1 );
+}
+
+echo "\n=== fetch-no-content-log-severity-smoke: ALL PASS ({$total} assertions) ===\n";


### PR DESCRIPTION
## Summary

Fixes #2873. `FetchStep::execute()` logged `'Fetch handler returned no content'` at **ERROR** level for every empty fetch result — a routine, expected outcome (filtered sources, quiet windows, small subreddits with no qualifying items today), not a handler failure. On wire.extrachill.com's ~27 daily reddit flows this produced ~16 ERROR rows/day of pure noise, diluting the error channel and triggering false-positive investigation via the agent wake briefing.

## Severity rationale

- The job already proceeds to the success-family terminal status `completed_no_items`.
- `RunMetrics::recordStepResult()` already records `result: no_content` — the machine-readable outcome was never wrong, only the log severity.
- The `is_wp_error( $packets )` branch immediately above (`'Fetch handler failed: ...'`) is the actual handler-failure path and correctly stays at `error` — untouched by this PR.
- Downgraded to `info` (not `debug`) because it's a meaningful per-flow-run event worth keeping visible in normal log output, just not error-worthy. The existing downstream `'Step completed with no new items to process'` INFO log already covers the human-readable summary; this is the step-level detail one layer below it.

## Paired WARNING decision

The issue also flagged the paired `'Step execution did not produce a successful result'` WARNING fired from `ExecuteStepAbility::logStepExecutionResult()`. I traced this to a single call site that already receives the classified `$execution_result['status']` (via `StepExecutionResult::classify()`/`fromStepOutput()`). Gating on `'completed_no_items' === $status` there is a clean, one-line, well-bounded change — it is **not** tangled into generic step-failure handling, since `completed_no_items` is already a distinct, explicitly-modeled status value (not inferred from packet count at that call site). Skipped it for that one case; every other non-success status (`failed`, `blocked`, etc.) still warns exactly as before.

Net effect for a routine empty-fetch day: one INFO log from FetchStep + one INFO log from the engine ("no new items to process"). Previously it was ERROR + WARNING + INFO for the same event.

## Changes

- `inc/Core/Steps/Fetch/FetchStep.php` — empty-packets branch logs at `info` instead of `error`; `is_wp_error()` failure branch unchanged.
- `inc/Abilities/Engine/ExecuteStepAbility.php` — `logStepExecutionResult()` early-returns (skips the WARNING) when `$execution_result['status'] === 'completed_no_items'`.
- `tests/fetch-no-content-log-severity-smoke.php` — new pure-PHP smoke test (follows the existing `tests/*-smoke.php` convention) asserting: FetchStep logs at info not error, the handler-failure error log is untouched, RunMetrics `no_content` recording is untouched, the paired WARNING is skipped for `completed_no_items`, and the WARNING still fires for genuine `failed` classifications.

## Verification

- `homeboy review data-machine --changed-since origin/main` — audit: 0 findings/passed, lint: 0 findings/passed. The `test` stage failed in this environment due to a WP Codebox PHPUnit recipe-builder module being unavailable (`buildWordPressPhpunitRecipe` missing) — a sandbox/harness infra gap, not a code failure; confirmed by running the repo's actual portable test pattern directly instead:
- Ran the new smoke test plus all directly-related existing smoke tests (`fetch-handler-failure-status-smoke.php`, `job-status-accounting-smoke.php`, `job-outcome-metrics-smoke.php`, `step-execution-result-contract-smoke.php`, `fetch-item-dispositions-smoke.php`, `run-metrics-smoke.php`) via `php tests/<name>.php`. New test: 9/9 pass. Pre-existing failures in `job-status-accounting-smoke.php`, `job-outcome-metrics-smoke.php`, and `fetch-item-dispositions-smoke.php` (missing `wp_json_encode()` stub for a newer `StepResult`/`RunResult` codepath, and an unrelated `normal completion still marks processed` assertion) reproduce identically on `origin/main` before this change — confirmed via `git stash`. Not introduced by this PR.

Not released, not deployed — PR only per task constraints.