### PR TITLE
fix: use ability existence predicate in bundles

### DIFF
--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -1747,13 +1747,13 @@ class AgentBundler {
 	 * @return array Missing ability slugs.
 	 */
 	private function check_abilities_manifest( array $manifest ): array {
-		if ( empty( $manifest ) || ! function_exists( 'wp_get_ability' ) ) {
+		if ( empty( $manifest ) || ! function_exists( 'wp_has_ability' ) ) {
 			return array();
 		}
 
 		$missing = array();
 		foreach ( $manifest as $slug ) {
-			if ( ! wp_get_ability( $slug ) ) {
+			if ( ! wp_has_ability( $slug ) ) {
 				$missing[] = $slug;
 			}
 		}

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -357,11 +357,12 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$this->assertNotEmpty( $flow, 'Flow imports from a schema-versioned array that omits source install IDs.' );
 	}
 
-	public function test_schema_versioned_array_import_preserves_abilities_manifest_for_dry_run_checks(): void {
+	public function test_schema_versioned_array_import_reports_only_missing_manifest_abilities(): void {
 		$bundle                       = AgentBundleArrayAdapter::to_array_bundle( AgentBundleArrayAdapter::from_array_bundle( $this->fixture_bundle( 'schema-abilities-agent' ) ) );
-		$bundle['abilities_manifest'] = array( 'datamachine/test-missing-ability' );
+		$bundle['abilities_manifest'] = array( 'datamachine/run-flow', 'datamachine/test-missing-ability' );
 
-		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
+		$this->assertTrue( wp_has_ability( 'datamachine/run-flow' ), 'Present manifest fixture ability is registered.' );
+		$this->assertFalse( wp_has_ability( 'datamachine/test-missing-ability' ), 'Missing manifest fixture ability is not registered.' );
 		$result = $this->bundler->import( $bundle, null, $this->owner_id, true );
 
 		$this->assertTrue( (bool) $result['success'], 'Schema-versioned dry run succeeds.' );


### PR DESCRIPTION
## Summary
- use WordPress 6.9's `wp_has_ability()` API when checking bundle manifest ability existence
- preserve missing-ability reporting while avoiding incorrect-usage notices from absent ability retrieval
- cover both registered and missing abilities in the focused dry-run import test

## Verification
- `vendor/bin/phpcs inc/Core/Agents/AgentBundler.php tests/Unit/Core/Agents/AgentBundlerImportTest.php`
- `php -l inc/Core/Agents/AgentBundler.php`
- `php -l tests/Unit/Core/Agents/AgentBundlerImportTest.php`
- `git diff --check`
- `homeboy review test data-machine --path /var/lib/datamachine/workspace/data-machine@fix-2875-ability-predicate -- --filter AgentBundlerImportTest` *(blocked before PHPUnit: installed Homeboy runtime cannot resolve a WP Codebox recipe-builder module)*

Closes #2875