### PR TITLE
fix: preserve engine data during inline continuation

### DIFF
--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -26,6 +26,7 @@
 
 namespace DataMachine\Abilities\Engine;
 
+use DataMachine\Core\PacketEngineData;
 use DataMachine\Core\ActionScheduler\BatchScheduler;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\JobStatus;
@@ -327,7 +328,7 @@ class PipelineBatchScheduler {
 		// item's data overwriting all previous items).
 		$item_engine_data = $single_packet['metadata']['_engine_data'] ?? array();
 		if ( ! empty( $item_engine_data ) && is_array( $item_engine_data ) ) {
-			$item_engine_data = $this->removeReservedEngineDataKeys( $item_engine_data, $parent_job_id );
+			$item_engine_data = PacketEngineData::sanitize( $item_engine_data, $parent_job_id );
 			$child_engine     = array_merge( $child_engine, $item_engine_data );
 		}
 
@@ -393,65 +394,6 @@ class PipelineBatchScheduler {
 		$engine_snapshot['flow_config'] = $flow_config;
 
 		return $engine_snapshot;
-	}
-
-	/**
-	 * Remove packet-provided keys that belong to the canonical engine snapshot.
-	 *
-	 * Packet metadata may provide per-item context, but it must not overwrite
-	 * job/flow/pipeline/batch state cloned from the parent execution.
-	 *
-	 * @param array $engine_data   Packet-provided engine data.
-	 * @param int   $parent_job_id Parent job ID for logging context.
-	 * @return array Sanitized per-item engine data.
-	 */
-	private function removeReservedEngineDataKeys( array $engine_data, int $parent_job_id ): array {
-		$reserved = array();
-
-		foreach ( array_keys( $engine_data ) as $key ) {
-			if ( $this->isReservedEngineDataKey( (string) $key ) ) {
-				$reserved[] = (string) $key;
-				unset( $engine_data[ $key ] );
-			}
-		}
-
-		if ( $reserved ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				'Pipeline batch: dropped packet engine_data keys reserved for child job context',
-				array(
-					'parent_job_id' => $parent_job_id,
-					'keys'          => $reserved,
-				)
-			);
-		}
-
-		return $engine_data;
-	}
-
-	/**
-	 * Check whether a packet-provided engine_data key is reserved.
-	 *
-	 * @param string $key Engine data key.
-	 * @return bool
-	 */
-	private function isReservedEngineDataKey( string $key ): bool {
-		if ( str_starts_with( $key, 'batch' ) ) {
-			return true;
-		}
-
-		return in_array(
-			$key,
-			array(
-				'job',
-				'flow',
-				'pipeline',
-				'flow_config',
-				'pipeline_config',
-			),
-			true
-		);
 	}
 
 	/**

--- a/inc/Core/PacketEngineData.php
+++ b/inc/Core/PacketEngineData.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Per-item engine data carried by DataPacket metadata.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+class PacketEngineData {
+
+	/**
+	 * Remove keys reserved for canonical job runtime context.
+	 *
+	 * @param array $engine_data Packet-provided engine data.
+	 * @param int   $job_id      Job ID for logging context.
+	 * @return array Sanitized per-item engine data.
+	 */
+	public static function sanitize( array $engine_data, int $job_id ): array {
+		$reserved = array();
+
+		foreach ( array_keys( $engine_data ) as $key ) {
+			if ( self::isReservedKey( (string) $key ) ) {
+				$reserved[] = (string) $key;
+				unset( $engine_data[ $key ] );
+			}
+		}
+
+		if ( $reserved ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Dropped packet engine_data keys reserved for job runtime context',
+				array(
+					'job_id' => $job_id,
+					'keys'   => $reserved,
+				)
+			);
+		}
+
+		return $engine_data;
+	}
+
+	/**
+	 * Check whether a packet-provided engine data key is reserved.
+	 *
+	 * @param string $key Engine data key.
+	 * @return bool
+	 */
+	private static function isReservedKey( string $key ): bool {
+		if ( str_starts_with( $key, 'batch' ) ) {
+			return true;
+		}
+
+		return in_array(
+			$key,
+			array( 'job', 'flow', 'pipeline', 'flow_config', 'pipeline_config' ),
+			true
+		);
+	}
+}

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -8,6 +8,7 @@
 
 namespace DataMachine\Engine\Actions\Handlers;
 
+use DataMachine\Core\PacketEngineData;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 
 /**
@@ -29,7 +30,9 @@ class StepLifecycleHandler {
 		}
 
 		$packet_meta = $routed_packets[0]['metadata'] ?? array();
-		$seed_data   = array();
+		$seed_data   = is_array( $packet_meta['_engine_data'] ?? null )
+			? PacketEngineData::sanitize( $packet_meta['_engine_data'], $job_id )
+			: array();
 		if ( ! empty( $packet_meta['item_identifier'] ) ) {
 			$seed_data['item_identifier'] = $packet_meta['item_identifier'];
 		}

--- a/tests/packet-engine-data-smoke.php
+++ b/tests/packet-engine-data-smoke.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Smoke test for packet-provided engine data sanitation.
+ *
+ * @package DataMachine
+ */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+function do_action() {}
+
+require_once dirname( __DIR__ ) . '/inc/Core/PacketEngineData.php';
+
+use DataMachine\Core\PacketEngineData;
+
+$result = PacketEngineData::sanitize(
+	array(
+		'source_url'      => 'https://example.com/source',
+		'image_file_path' => '/tmp/image.jpg',
+		'job'             => array( 'job_id' => 999 ),
+		'flow_config'     => array( 'unsafe' => true ),
+		'batch_id'        => 'unsafe',
+	),
+	42
+);
+
+$expected = array(
+	'source_url'      => 'https://example.com/source',
+	'image_file_path' => '/tmp/image.jpg',
+);
+
+if ( $expected !== $result ) {
+	fwrite( STDERR, "Packet engine data sanitation failed.\n" );
+	exit( 1 );
+}
+
+echo "Packet engine data smoke test passed.\n";

--- a/tests/packet-engine-data-smoke.php
+++ b/tests/packet-engine-data-smoke.php
@@ -7,7 +7,9 @@
 
 define( 'ABSPATH', __DIR__ . '/' );
 
-function do_action() {}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action() {}
+}
 
 require_once dirname( __DIR__ ) . '/inc/Core/PacketEngineData.php';
 


### PR DESCRIPTION
## Summary

- promote sanitized per-item `_engine_data` when a single packet continues on its existing job
- centralize reserved runtime-key filtering and use it for both inline continuation and batch child jobs
- add native smoke coverage proving valid source/image context survives while job, flow-config, and batch keys are rejected

Fixes #2882.

## Production evidence

After deploying v0.161.4, Wire job 14866 created post 7931 with restored handler/flow metadata but no `_datamachine_source_url`. The Reddit handler correctly put the canonical URL in `packet.metadata._engine_data.source_url`; only the one-packet inline route dropped it. Multi-packet fan-out already preserved the same seed.

## Verification

- `php tests/packet-engine-data-smoke.php`
- PHP syntax checks for all changed PHP files
- `git diff --check`
- changed-file PHPCS passes through Homeboy with no findings or baseline drift

Local PHPStan remains unavailable because the installed PHAR has an oversized manifest; this is existing tooling state, not a code finding.