### PR TITLE
fix: decode encoded upload paths once in broken image audit

### DIFF
--- a/inc/Abilities/Media/BrokenImageReferenceAbilities.php
+++ b/inc/Abilities/Media/BrokenImageReferenceAbilities.php
@@ -630,7 +630,13 @@ class BrokenImageReferenceAbilities {
 	 * for cross-site references. URLs whose host never matches a network site are
 	 * classified `external`. Pure given the maps.
 	 *
+	 * The URL remainder below the matched upload base is URL-decoded exactly once
+	 * (the URL-to-filename boundary) before joining to the uploads base directory.
+	 * See {@see build_contained_upload_path()} for the decode boundary and
+	 * containment rules.
+	 *
 	 * @since 0.161.6
+	 * @since 0.162.1 Decode encoded upload paths once and contain them under basedir.
 	 *
 	 * @param string                                                        $url              Absolute URL.
 	 * @param array<int, array{baseurl: string, basedir: string}>           $blog_uploads     Blog upload maps.
@@ -694,16 +700,88 @@ class BrokenImageReferenceAbilities {
 
 		$basedir  = $blog_uploads[ $best_blog_id ]['basedir'] ?? '';
 		$relative = substr( $url, strlen( $best_baseurl ) );
-		$fs_path  = $basedir . $relative;
+		$fs_path  = self::build_contained_upload_path( $basedir, $relative );
 
-		// Normalize directory separators for the platform.
-		$fs_path = str_replace( '/', DIRECTORY_SEPARATOR, $fs_path );
+		if ( null === $fs_path ) {
+			// Empty remainder or a decoded traversal/separator escape attempt.
+			return array(
+				'kind'    => 'unresolvable',
+				'path'    => null,
+				'blog_id' => null,
+			);
+		}
 
 		return array(
 			'kind'    => 'local',
 			'path'    => $fs_path,
 			'blog_id' => $best_blog_id,
 		);
+	}
+
+	/**
+	 * Build a contained filesystem path for the URL remainder below an upload base.
+	 *
+	 * The remainder (the raw URL substring after the matched upload base URL) is
+	 * URL-decoded exactly once before being joined to the uploads base directory.
+	 * `rawurldecode()` is the correct path-component decoder: it maps `%20` to a
+	 * space, `%2B` to a literal `+`, and — for Blogger migration URLs — `%2528`
+	 * to the literal filename fragment `%28`. The result is never decoded again,
+	 * so a double-encoded sequence like `%252e%252e%252f` stays an inert literal
+	 * filename (`%2e%2e%2f`) rather than a traversal.
+	 *
+	 * Containment is enforced lexically: `realpath()` is unusable here because
+	 * this diagnostic verifies files that are expected to be *missing*. Any path
+	 * segment equal to `..` is rejected outright, which also catches decoded
+	 * separator escapes (e.g. `%2f..%2f` decodes to `/../`). Query strings and
+	 * fragments are dropped before lookup since they are not part of the filename.
+	 *
+	 * @since 0.162.1
+	 *
+	 * @param string $basedir   Absolute uploads base directory (no trailing slash expected).
+	 * @param string $remainder Raw URL remainder after the upload base URL (starts with `/`, `?`, or empty).
+	 * @return string|null Contained filesystem path under basedir, or null when the
+	 *                     remainder is empty or attempts to escape the base.
+	 */
+	private static function build_contained_upload_path( string $basedir, string $remainder ): ?string {
+		if ( '' === $basedir ) {
+			return null;
+		}
+
+		// Query strings and fragments are not part of the filesystem name.
+		$split     = preg_split( '/[?#]/', $remainder, 2 );
+		$path_part = is_array( $split ) ? (string) $split[0] : $remainder;
+
+		// Decode exactly once: URL representation -> literal filesystem name.
+		// A single pass maps `%2528` to `%28`; further decoding is intentionally
+		// avoided so double-encoded traversal stays an inert literal.
+		$decoded = rawurldecode( $path_part );
+
+		$segments = explode( '/', $decoded );
+		$clean    = array();
+		foreach ( $segments as $segment ) {
+			if ( '' === $segment || '.' === $segment ) {
+				// Collapse empty (leading/duplicate separators) and current-dir segments.
+				continue;
+			}
+
+			if ( '..' === $segment || false !== strpos( $segment, "\0" ) ) {
+				// Reject decoded traversal (`..`, including `%2e%2e` variants) and
+				// null-byte injection outright; a contained upload never needs them.
+				return null;
+			}
+
+			$clean[] = $segment;
+		}
+
+		if ( empty( $clean ) ) {
+			// The URL pointed at the upload root itself (or carried only a query).
+			return null;
+		}
+
+		$fs_path = $basedir . '/' . implode( '/', $clean );
+
+		// Normalize directory separators for the platform.
+		return str_replace( '/', DIRECTORY_SEPARATOR, $fs_path );
 	}
 
 	/**

--- a/tests/image-broken-reference-multisite-smoke.php
+++ b/tests/image-broken-reference-multisite-smoke.php
@@ -275,6 +275,63 @@ $assert( null === $rext['path'], 'external has no path' );
 $r_prefix = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads-other/x.jpg', $blog_uploads, 1, 'https://extrachill.com' );
 $assert( 'external' === $r_prefix['kind'] || 'unresolvable' === $r_prefix['kind'], 'shared-prefix sibling directory does not falsely match upload base' );
 
+// --- Encoded upload path resolution (issue #2887) ----------------------------
+
+echo "\nresolve_url_to_local (encoded upload paths):\n";
+$sep = DIRECTORY_SEPARATOR;
+
+// %20 decodes once to a literal space.
+$r_space = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/2024/01/my%20file.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'local' === $r_space['kind'], '%20 url resolves as local' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/2024/01/my file.jpg' ) === $r_space['path'], '%20 decodes once to a literal space in the path' );
+
+// %2B decodes once to a literal '+'. rawurldecode keeps a literal '+' intact.
+$r_plus = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/2024/01/a%2Bb.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'local' === $r_plus['kind'], '%2B url resolves as local' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/2024/01/a+b.jpg' ) === $r_plus['path'], '%2B decodes once to a literal plus sign' );
+
+// A literal '+' in the URL path must NOT become a space (path semantics, not query).
+$r_lit_plus = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/2024/01/a+b.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/2024/01/a+b.jpg' ) === $r_lit_plus['path'], 'literal plus in path stays a plus (rawurldecode, not urldecode)' );
+
+// The Blogger migration case: %2528 -> %28 (decoded exactly once, not re-decoded).
+$r_blogger = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/blogger/s1600/Abstract-ECF%25281%2529.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'local' === $r_blogger['kind'], 'Blogger-encoded %2528 url resolves as local' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/blogger/s1600/Abstract-ECF%281%29.jpg' ) === $r_blogger['path'], '%2528 decodes once to the literal %28 filename on disk' );
+
+// Unicode filename (UTF-8 bytes percent-encoded) decodes once to the multibyte name.
+$r_uni = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/2024/01/caf%C3%A9.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'local' === $r_uni['kind'], 'unicode-encoded url resolves as local' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/2024/01/caf' . "\xc3\xa9" . '.jpg' ) === $r_uni['path'], 'unicode %C3%A9 decodes once to the UTF-8 filename' );
+
+// Decoded traversal must be rejected (never produce a local path above basedir).
+$r_trav = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/2024/01/../../etc/passwd', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'unresolvable' === $r_trav['kind'], 'decoded ../ traversal is rejected as unresolvable' );
+$assert( null === $r_trav['path'], 'decoded traversal yields no filesystem path' );
+
+// Encoded separator escape (%2f..%2f) decodes to /../ and must be rejected.
+$r_enc_trav = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/2024/01/foo%2f..%2f..%2fsecret', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'unresolvable' === $r_enc_trav['kind'], 'encoded separator traversal (%2f..%2f) is rejected' );
+
+// Single-encoded %2e%2e traversal must also be rejected.
+$r_dot_enc = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/%2e%2e/%2e%2e/etc', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'unresolvable' === $r_dot_enc['kind'], 'encoded %2e%2e traversal is rejected' );
+
+// Double-encoded traversal decodes once to a literal (inert) name and stays contained.
+$r_double = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/%252e%252e%252flogo.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'local' === $r_double['kind'], 'double-encoded traversal stays local (single decode only)' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/%2e%2e%2flogo.jpg' ) === $r_double['path'], 'double-encoded sequence is not re-decoded, stays a literal filename' );
+
+// Query strings and fragments must be stripped before filesystem lookup.
+$r_query = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/2024/01/cache.jpg?v=123', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/2024/01/cache.jpg' ) === $r_query['path'], 'query string is stripped from the filesystem path' );
+
+// Cross-site encoded path still resolves against the owning site's base.
+$r_cross_enc = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://community.extrachill.com/wp-content/uploads/sites/2/2024/02/cross%20shot.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'local' === $r_cross_enc['kind'], 'cross-site encoded url resolves as local' );
+$assert( 2 === $r_cross_enc['blog_id'], 'cross-site encoded url attributes to owning blog 2' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/sites/2/2024/02/cross shot.jpg' ) === $r_cross_enc['path'], 'cross-site encoded path uses blog 2 basedir with decoded name' );
+
 // --- Full orchestration: diagnoseBrokenImageReferences -----------------------
 
 echo "\ndiagnoseBrokenImageReferences (full scan):\n";
@@ -296,6 +353,11 @@ $GLOBALS['__dm_broken_image_rows'] = array(
 			'post_title'   => 'Post with present cross-site',
 			'post_content' => '<img src="https://community.extrachill.com/wp-content/uploads/sites/2/2024/02/cross_present.jpg">',
 		),
+		(object) array(
+			'ID'           => 12,
+			'post_title'   => 'Post with present Blogger-encoded image',
+			'post_content' => '<img src="https://extrachill.com/wp-content/uploads/blogger/s1600/Abstract-ECF%25281%2529.jpg">',
+		),
 	),
 	2 => array(),
 );
@@ -304,6 +366,7 @@ $GLOBALS['__dm_broken_image_rows'] = array(
 $present = array(
 	'/var/www/uploads/2024/01/present.jpg',
 	'/var/www/uploads/sites/2/2024/02/cross_present.jpg',
+	'/var/www/uploads/blogger/s1600/Abstract-ECF%281%29.jpg',
 );
 $sep        = DIRECTORY_SEPARATOR;
 $present_n  = array_map( static fn( $p ) => str_replace( '/', $sep, $p ), $present );
@@ -320,7 +383,7 @@ $result = BrokenImageReferenceAbilities::diagnoseBrokenImageReferences(
 );
 
 $assert( true === $result['success'], 'network scan returns success' );
-$assert( 2 === $result['posts_scanned'], 'two posts scanned (blog 2 has no posts)' );
+$assert( 3 === $result['posts_scanned'], 'three posts scanned (blog 2 has no posts)' );
 
 $broken = $result['broken_references'];
 $urls   = array();
@@ -336,6 +399,11 @@ $assert( in_array( $missing_main, $urls, true ), 'missing main-site file reporte
 $assert( in_array( $cross_missing, $urls, true ), 'missing cross-site (blog 2) file reported from a blog 1 post' );
 $assert( in_array( $root_missing, $urls, true ), 'root-relative missing file reported' );
 $assert( ! in_array( 'https://cdn.example.com/external.jpg', $urls, true ), 'external url is not reported as missing local' );
+
+// The Blogger-encoded image whose decoded filename exists on disk must NOT be
+// reported as broken — the concrete production false-positive from issue #2887.
+$blogger_present_url = 'https://extrachill.com/wp-content/uploads/blogger/s1600/Abstract-ECF%25281%2529.jpg';
+$assert( ! in_array( $blogger_present_url, $urls, true ), 'present Blogger-encoded (%2528 -> %28) image is not a false positive' );
 
 // Dedup: missing.jpg appears in src AND srcset but must be reported once.
 $duplicate_count = 0;
@@ -377,7 +445,7 @@ $single = BrokenImageReferenceAbilities::diagnoseBrokenImageReferences(
 );
 
 $assert( true === $single['success'], 'single-site scan returns success' );
-$assert( 2 === $single['posts_scanned'], 'single-site scan reads the current blog posts' );
+$assert( 3 === $single['posts_scanned'], 'single-site scan reads the current blog posts' );
 
 // --- single post_id scope ----------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes the broken image reference audit (`wp datamachine image broken`) reporting URL-encoded Blogger migration files as missing when the file exists on disk. Closes #2887.

**Root cause:** `BrokenImageReferenceAbilities::resolve_url_to_local()` joined the raw, still-URL-encoded URL remainder directly to the uploads base directory without decoding. Blogger migration URLs like `.../s1600/Abstract-ECF%25281%2529.jpg` never matched the on-disk file `Abstract-ECF%281%29.jpg`. Production reported 171 missing images; 152 of those under `/wp-content/uploads/blogger/` were false positives (~19 genuinely missing remain).

## Fix

The URL remainder below the matched upload base is now decoded **exactly once** with `rawurldecode()` — the correct path-component decoder — via a new `build_contained_upload_path()` helper:

- `%20` → space, `%2B` → literal `+`, `%2528` → literal `%28` (the Blogger case)
- A literal `+` in the path stays `+` (path semantics, not query/form-data semantics — `rawurldecode` is used instead of `urldecode`)
- The result is **never re-decoded**, so double-encoded traversal (`%252e%252e%252f`) stays an inert literal filename (`%2e%2e%2f`) rather than escaping

**Containment** is enforced lexically (`realpath()` is unusable here because this diagnostic verifies files expected to be *missing*):
- Any `..` path segment is rejected, which also catches decoded separator escapes (`%2f..%2f` → `/../`) and single-encoded `%2e%2e` traversal
- Null-byte injection is rejected
- Query strings and fragments are stripped before lookup (not part of the filename)
- An escape attempt is classified `unresolvable` rather than producing a path outside the uploads base

Multisite host/base resolution and cross-site references are preserved unchanged (read-only behavior and existing output schema intact).

I checked WordPress core path/URL helpers before writing new logic: `rawurldecode` is the right single-pass path decoder (mirrors the decoding boundary the web server applies to a request path), and lexical containment is required because `realpath()`/`path_join()` can't validate a file that doesn't exist yet.

## Verification

- ✅ `php tests/image-broken-reference-multisite-smoke.php` — **72 assertions, 0 failures** (added focused regression cases: `%20`, `%2B`, literal `+`, `%2528`→`%28`, Unicode `%C3%A9`, decoded `../` traversal, `%2f..%2f` separator escape, `%2e%2e`, double-encoded `%252e%252e`, query-string stripping, cross-site encoded path, and a production-shaped orchestration assertion that the concrete Blogger image is no longer a false positive)
- ✅ `php tests/image-broken-reference-ability-registration-smoke.php` — 3 assertions, 0 failures
- ✅ `php -l` on changed file — no syntax errors
- ✅ `homeboy review data-machine lint --changed-only` — **passed** (PHPStan level 7 + ESLint, 0 findings)
- ⚠️ `homeboy review data-machine test` — **blocked by environment infrastructure**, not by this change: the PHPUnit bootstrap failed because the WP Codebox recipe-builder module (`@automattic/wp-codebox-core/recipe-builders`) is not installed in this agent runtime (`Error: WP Codebox recipe builder export buildWordPressPhpunitRecipe is unavailable`). No tests ran. The standalone smoke tests above are the repository-supported verification path for this logic.

The concrete Blogger example now resolves correctly: URL `.../Abstract-ECF%25281%2529.jpg` → `/var/www/uploads/blogger/s1600/Abstract-ECF%281%29.jpg` (matches disk).

## Notes

- PR only. Not merging, releasing, or deploying.
- No `CHANGELOG.md` / version edits (Homeboy owns both).
- Conventional commit used: `fix:`.