### PR TITLE
fix: store credential auth config fields byte-exact

### DIFF
--- a/inc/Abilities/AuthAbilities.php
+++ b/inc/Abilities/AuthAbilities.php
@@ -778,7 +778,7 @@ class AuthAbilities {
 		}
 
 		foreach ( $config_fields as $field_name => $field_config ) {
-			$value = sanitize_text_field( $config_input[ $field_name ] ?? '' );
+			$value = self::sanitizeConfigValue( $config_input[ $field_name ] ?? '', $field_config );
 
 			if ( ( $field_config['required'] ?? false ) && empty( $value ) && empty( $existing_config[ $field_name ] ?? '' ) ) {
 				return array(
@@ -953,11 +953,11 @@ class AuthAbilities {
 			);
 		}
 
-		// Sanitize string values in account data.
+		// Account data can contain opaque credentials, including percent-encoded cookies.
 		$sanitized = array();
 		foreach ( $account_data as $key => $value ) {
 			if ( is_string( $value ) ) {
-				$sanitized[ $key ] = sanitize_text_field( $value );
+				$sanitized[ $key ] = self::sanitizeOpaqueCredentialValue( $value );
 			} elseif ( is_int( $value ) || is_float( $value ) || is_bool( $value ) || is_null( $value ) ) {
 				$sanitized[ $key ] = $value;
 			} elseif ( is_array( $value ) ) {
@@ -1107,5 +1107,40 @@ class AuthAbilities {
 		}
 
 		return array_filter( $context );
+	}
+
+	/**
+	 * Sanitize an auth config value according to its provider-declared field type.
+	 *
+	 * Password and textarea fields can carry opaque credentials, so they must not
+	 * pass through sanitize_text_field(), which removes percent-encoded octets.
+	 *
+	 * @param mixed $value        Submitted field value.
+	 * @param array $field_config Provider field declaration.
+	 * @return string Sanitized value.
+	 */
+	private static function sanitizeConfigValue( $value, array $field_config ): string {
+		if ( ! is_scalar( $value ) ) {
+			return '';
+		}
+
+		$value = (string) $value;
+		$type  = $field_config['type'] ?? 'text';
+
+		if ( in_array( $type, array( 'password', 'textarea' ), true ) ) {
+			return self::sanitizeOpaqueCredentialValue( $value );
+		}
+
+		return sanitize_text_field( $value );
+	}
+
+	/**
+	 * Preserve opaque credential payloads while rejecting control characters.
+	 *
+	 * @param string $value Submitted credential value.
+	 * @return string Credential-safe value.
+	 */
+	private static function sanitizeOpaqueCredentialValue( string $value ): string {
+		return trim( preg_replace( '/[\x00-\x1F\x7F]/', '', $value ) );
 	}
 }

--- a/inc/Cli/Commands/AuthCommand.php
+++ b/inc/Cli/Commands/AuthCommand.php
@@ -829,7 +829,7 @@ class AuthCommand extends BaseCommand {
 				$missing[] = sprintf( '--%s', $cli_key );
 			}
 
-			$config_data[ $field_name ] = sanitize_text_field( $value );
+			$config_data[ $field_name ] = $value;
 		}
 
 		if ( ! empty( $missing ) ) {

--- a/tests/Unit/Abilities/AuthAbilitiesTest.php
+++ b/tests/Unit/Abilities/AuthAbilitiesTest.php
@@ -25,6 +25,31 @@ class AuthAbilitiesAccountScopeProvider extends BaseAuthProvider {
 	}
 }
 
+class AuthAbilitiesConfigProvider extends BaseAuthProvider {
+
+	public function get_config_fields(): array {
+		return array(
+			'session_cookie' => array(
+				'label'    => 'Session Cookie',
+				'type'     => 'password',
+				'required' => true,
+			),
+			'cookie_jar'     => array(
+				'label' => 'Cookie Jar',
+				'type'  => 'textarea',
+			),
+			'label'          => array(
+				'label' => 'Label',
+				'type'  => 'text',
+			),
+		);
+	}
+
+	public function is_authenticated(): bool {
+		return false;
+	}
+}
+
 class AuthAbilitiesTest extends WP_UnitTestCase {
 
 	private AuthAbilities $auth_abilities;
@@ -135,6 +160,61 @@ class AuthAbilitiesTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'error', $result );
 	}
 
+	public function test_save_auth_config_preserves_opaque_credential_fields(): void {
+		$provider = new AuthAbilitiesConfigProvider( 'config_provider' );
+		$this->registerConfigProvider( $provider );
+		$cookie = 'tk_or=%22https%3A%2F%2Fwww.google.com%2F%22;wporg_sec=abc%7Cdef$o3$g0';
+
+		$result = $this->auth_abilities->executeSaveAuthConfig(
+			array(
+				'handler_slug' => 'config_handler',
+				'config'       => array(
+					'session_cookie' => $cookie,
+					'cookie_jar'     => $cookie,
+				),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $cookie, $provider->get_config()['session_cookie'] );
+		$this->assertSame( $cookie, $provider->get_config()['cookie_jar'] );
+	}
+
+	public function test_save_auth_config_sanitizes_text_fields(): void {
+		$provider = new AuthAbilitiesConfigProvider( 'config_provider' );
+		$this->registerConfigProvider( $provider );
+		$value = " <strong>Example</strong>\n";
+
+		$result = $this->auth_abilities->executeSaveAuthConfig(
+			array(
+				'handler_slug' => 'config_handler',
+				'config'       => array(
+					'session_cookie' => 'required-cookie',
+					'label'          => $value,
+				),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( sanitize_text_field( $value ), $provider->get_config()['label'] );
+	}
+
+	public function test_set_auth_token_preserves_opaque_token_value(): void {
+		$provider = new AuthAbilitiesAccountScopeProvider( 'scope_provider' );
+		$this->registerAccountScopeProvider( $provider );
+		$token = 'tk_or=%22https%3A%2F%2Fwww.google.com%2F%22%7C$o3$g0';
+
+		$result = $this->auth_abilities->executeSetAuthToken(
+			array(
+				'handler_slug' => 'scope_handler',
+				'account_data' => array( 'access_token' => $token ),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $token, $provider->get_site_account()['access_token'] );
+	}
+
 	public function test_set_auth_token_saves_user_account_without_site_fallback(): void {
 		$provider = new AuthAbilitiesAccountScopeProvider( 'scope_provider' );
 		$this->registerAccountScopeProvider( $provider );
@@ -187,6 +267,30 @@ class AuthAbilitiesTest extends WP_UnitTestCase {
 					'slug'              => 'scope_handler',
 					'requires_auth'     => true,
 					'auth_provider_key' => 'scope_provider',
+				);
+				return $handlers;
+			}
+		);
+
+		AuthAbilities::clearCache();
+		HandlerAbilities::clearCache();
+	}
+
+	private function registerConfigProvider( AuthAbilitiesConfigProvider $provider ): void {
+		add_filter(
+			'datamachine_auth_providers',
+			function ( array $providers ) use ( $provider ): array {
+				$providers['config_provider'] = $provider;
+				return $providers;
+			}
+		);
+		add_filter(
+			'datamachine_handlers',
+			function ( array $handlers ): array {
+				$handlers['config_handler'] = array(
+					'slug'              => 'config_handler',
+					'requires_auth'     => true,
+					'auth_provider_key' => 'config_provider',
 				);
 				return $handlers;
 			}


### PR DESCRIPTION
## Summary
- Store provider-declared `password` and `textarea` auth config values as opaque credentials after trimming and removing control characters, preserving percent-encoded octets and `$` payload segments.
- Keep `text` field sanitization unchanged.
- Preserve opaque values in the `set-token` account-data path as well.

## Root cause and impact
`sanitize_text_field()` was applied to every auth config field in both the CLI direct-connect path and the shared `executeSaveAuthConfig()` ability path. WordPress.org session cookies are opaque credential payloads, not text input: the live `wporg_trac` cookie was reduced from 832 to 772 bytes, with percent-encoded octets stripped (`tk_or=%22https%3A%2F%2Fwww.google.com%2F%22` became `tk_or=httpswww.google.com`) and `%7C` segments in `wporg_sec`/`wporg_logged_in` corrupted. The original cookie returned curl 200; the stored corrupted cookie returned Trac 403.

## Approach
The provider field declaration from `get_config_fields()` is now the sanitization contract:
- `password` and `textarea`: preserve the payload byte-for-byte except boundary trimming and control-character removal.
- `text` and unknown field types: retain `sanitize_text_field()` behavior.

The regression coverage saves and reads a password/textarea value containing `%22`, `%3A`, `%2F`, `%7C`, and `$o3$g0` byte-identically; it also proves text fields remain sanitized and `set-token` preserves opaque token data.

## Test evidence
- `php -l inc/Abilities/AuthAbilities.php`
- `php -l inc/Cli/Commands/AuthCommand.php`
- `php -l tests/Unit/Abilities/AuthAbilitiesTest.php`
- `composer lint -- inc/Abilities/AuthAbilities.php inc/Cli/Commands/AuthCommand.php tests/Unit/Abilities/AuthAbilitiesTest.php`

The checkout has no PHPUnit executable, PHPUnit configuration, or Composer test script, so the WordPress unit suite is not runnable from this repository state.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.6-terra), orchestrated by Franklin
- **Used for:** Root-caused and fixed credential-destroying sanitization in the auth config save path with regression tests, under Chris Huber direction.