### PR TITLE
fix: reconcile recurring Action Scheduler actions safely

### DIFF
--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -59,7 +59,10 @@ class SystemAgentServiceProvider {
 		$this->registerBuiltInSchedules();
 		$this->initializeRegistry();
 		$this->registerActionSchedulerHooks();
+		// Bootstrap immediately after AS initializes, then let AS's native daily
+		// recurring-ensure action repair schedules that are later interrupted.
 		add_action( 'action_scheduler_init', array( $this, 'manageRecurringTaskSchedules' ) );
+		add_action( 'action_scheduler_ensure_recurring_actions', array( $this, 'manageRecurringTaskSchedules' ) );
 		WakeBriefingTask::registerStalenessGuard();
 	}
 

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -693,6 +693,7 @@ class RetentionCleanup {
 
 		$actions_count = 0;
 		$logs_count    = 0;
+		$global_cutoff = gmdate( 'Y-m-d H:i:s', time() - (int) round( self::actionSchedulerMaxAgeDays() * DAY_IN_SECONDS ) );
 
 		foreach ( self::actionSchedulerCleanupWindows() as $window ) {
 			$cutoff = $window['cutoff'];
@@ -753,6 +754,18 @@ class RetentionCleanup {
 			}
 		}
 
+		// The custom tables do not enforce a foreign key, so native Action
+		// Scheduler cleanup can leave expired logs after deleting actions.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$logs_count += (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM %i l LEFT JOIN %i a ON l.action_id = a.action_id WHERE l.action_id != 0 AND a.action_id IS NULL AND l.log_date_gmt < %s',
+				$logs_table,
+				$actions_table,
+				$global_cutoff
+			)
+		);
+
 		return array(
 			'actions' => $actions_count,
 			'logs'    => $logs_count,
@@ -775,6 +788,7 @@ class RetentionCleanup {
 		$hit_limit       = false;
 		$logs_deleted    = 0;
 		$actions_deleted = 0;
+		$orphan_logs_deleted = 0;
 
 		foreach ( self::actionSchedulerCleanupWindows() as $window ) {
 			$cutoff = $window['cutoff'];
@@ -805,6 +819,18 @@ class RetentionCleanup {
 				$hit_limit
 			);
 		}
+
+		$orphan_logs_deleted = self::deleteOrphanActionSchedulerLogsBatched(
+			$logs_table,
+			$actions_table,
+			gmdate( 'Y-m-d H:i:s', time() - (int) round( self::actionSchedulerMaxAgeDays() * DAY_IN_SECONDS ) ),
+			$batch_size,
+			$max_iterations,
+			$deadline,
+			$iterations_used,
+			$hit_limit
+		);
+		$logs_deleted += $orphan_logs_deleted;
 
 		// Hard row-count ceiling per high-churn hook. Age windows above can
 		// leave the table unbounded when generation outruns the cleanup
@@ -842,6 +868,7 @@ class RetentionCleanup {
 				array(
 					'actions_deleted'         => $actions_deleted,
 					'logs_deleted'            => $logs_deleted,
+					'orphan_logs_deleted'     => $orphan_logs_deleted,
 					'ceiling_actions_deleted' => $ceiling['actions_deleted'],
 					'ceiling_logs_deleted'    => $ceiling['logs_deleted'],
 					'max_age_days'            => $max_age_days,
@@ -863,6 +890,7 @@ class RetentionCleanup {
 			'deleted'                 => $total_deleted,
 			'actions_deleted'         => $actions_deleted,
 			'logs_deleted'            => $logs_deleted,
+			'orphan_logs_deleted'     => $orphan_logs_deleted,
 			'ceiling_actions_deleted' => $ceiling['actions_deleted'],
 			'ceiling_logs_deleted'    => $ceiling['logs_deleted'],
 			'max_age_days'            => $max_age_days,
@@ -1069,6 +1097,59 @@ class RetentionCleanup {
 					)
 				);
 			}
+
+			$affected = false !== $affected ? (int) $affected : 0;
+			$deleted += $affected;
+		} while ( $affected > 0 );
+
+		return $deleted;
+	}
+
+	/**
+	 * Delete expired logs whose actions were already removed by another cleanup.
+	 *
+	 * @param string $logs_table      Logs table name.
+	 * @param string $actions_table   Actions table name.
+	 * @param string $cutoff          GMT cutoff datetime.
+	 * @param int    $batch_size      Rows per batch.
+	 * @param int    $max_iterations  Hard iteration ceiling (shared budget).
+	 * @param float  $deadline        Wall-clock deadline (microtime float).
+	 * @param int    $iterations_used Shared iteration counter (by reference).
+	 * @param bool   $hit_limit       Set true when a budget cap trips (by reference).
+	 * @return int Total rows deleted.
+	 */
+	private static function deleteOrphanActionSchedulerLogsBatched(
+		string $logs_table,
+		string $actions_table,
+		string $cutoff,
+		int $batch_size,
+		int $max_iterations,
+		float $deadline,
+		int &$iterations_used,
+		bool &$hit_limit
+	): int {
+		global $wpdb;
+
+		$deleted = 0;
+
+		do {
+			if ( $iterations_used >= $max_iterations || microtime( true ) >= $deadline ) {
+				$hit_limit = true;
+				break;
+			}
+			++$iterations_used;
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$affected = $wpdb->query(
+				$wpdb->prepare(
+					'DELETE FROM %i WHERE log_id IN ( SELECT log_id FROM ( SELECT l.log_id FROM %i l LEFT JOIN %i a ON l.action_id = a.action_id WHERE l.action_id != 0 AND a.action_id IS NULL AND l.log_date_gmt < %s LIMIT %d ) AS tmp )',
+					$logs_table,
+					$logs_table,
+					$actions_table,
+					$cutoff,
+					$batch_size
+				)
+			);
 
 			$affected = false !== $affected ? (int) $affected : 0;
 			$deleted += $affected;

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -693,7 +693,6 @@ class RetentionCleanup {
 
 		$actions_count = 0;
 		$logs_count    = 0;
-		$global_cutoff = gmdate( 'Y-m-d H:i:s', time() - (int) round( self::actionSchedulerMaxAgeDays() * DAY_IN_SECONDS ) );
 
 		foreach ( self::actionSchedulerCleanupWindows() as $window ) {
 			$cutoff = $window['cutoff'];
@@ -754,18 +753,6 @@ class RetentionCleanup {
 			}
 		}
 
-		// The custom tables do not enforce a foreign key, so native Action
-		// Scheduler cleanup can leave expired logs after deleting actions.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$logs_count += (int) $wpdb->get_var(
-			$wpdb->prepare(
-				'SELECT COUNT(*) FROM %i l LEFT JOIN %i a ON l.action_id = a.action_id WHERE l.action_id != 0 AND a.action_id IS NULL AND l.log_date_gmt < %s',
-				$logs_table,
-				$actions_table,
-				$global_cutoff
-			)
-		);
-
 		return array(
 			'actions' => $actions_count,
 			'logs'    => $logs_count,
@@ -788,7 +775,6 @@ class RetentionCleanup {
 		$hit_limit       = false;
 		$logs_deleted    = 0;
 		$actions_deleted = 0;
-		$orphan_logs_deleted = 0;
 
 		foreach ( self::actionSchedulerCleanupWindows() as $window ) {
 			$cutoff = $window['cutoff'];
@@ -819,18 +805,6 @@ class RetentionCleanup {
 				$hit_limit
 			);
 		}
-
-		$orphan_logs_deleted = self::deleteOrphanActionSchedulerLogsBatched(
-			$logs_table,
-			$actions_table,
-			gmdate( 'Y-m-d H:i:s', time() - (int) round( self::actionSchedulerMaxAgeDays() * DAY_IN_SECONDS ) ),
-			$batch_size,
-			$max_iterations,
-			$deadline,
-			$iterations_used,
-			$hit_limit
-		);
-		$logs_deleted += $orphan_logs_deleted;
 
 		// Hard row-count ceiling per high-churn hook. Age windows above can
 		// leave the table unbounded when generation outruns the cleanup
@@ -868,7 +842,6 @@ class RetentionCleanup {
 				array(
 					'actions_deleted'         => $actions_deleted,
 					'logs_deleted'            => $logs_deleted,
-					'orphan_logs_deleted'     => $orphan_logs_deleted,
 					'ceiling_actions_deleted' => $ceiling['actions_deleted'],
 					'ceiling_logs_deleted'    => $ceiling['logs_deleted'],
 					'max_age_days'            => $max_age_days,
@@ -890,7 +863,6 @@ class RetentionCleanup {
 			'deleted'                 => $total_deleted,
 			'actions_deleted'         => $actions_deleted,
 			'logs_deleted'            => $logs_deleted,
-			'orphan_logs_deleted'     => $orphan_logs_deleted,
 			'ceiling_actions_deleted' => $ceiling['actions_deleted'],
 			'ceiling_logs_deleted'    => $ceiling['logs_deleted'],
 			'max_age_days'            => $max_age_days,
@@ -1097,59 +1069,6 @@ class RetentionCleanup {
 					)
 				);
 			}
-
-			$affected = false !== $affected ? (int) $affected : 0;
-			$deleted += $affected;
-		} while ( $affected > 0 );
-
-		return $deleted;
-	}
-
-	/**
-	 * Delete expired logs whose actions were already removed by another cleanup.
-	 *
-	 * @param string $logs_table      Logs table name.
-	 * @param string $actions_table   Actions table name.
-	 * @param string $cutoff          GMT cutoff datetime.
-	 * @param int    $batch_size      Rows per batch.
-	 * @param int    $max_iterations  Hard iteration ceiling (shared budget).
-	 * @param float  $deadline        Wall-clock deadline (microtime float).
-	 * @param int    $iterations_used Shared iteration counter (by reference).
-	 * @param bool   $hit_limit       Set true when a budget cap trips (by reference).
-	 * @return int Total rows deleted.
-	 */
-	private static function deleteOrphanActionSchedulerLogsBatched(
-		string $logs_table,
-		string $actions_table,
-		string $cutoff,
-		int $batch_size,
-		int $max_iterations,
-		float $deadline,
-		int &$iterations_used,
-		bool &$hit_limit
-	): int {
-		global $wpdb;
-
-		$deleted = 0;
-
-		do {
-			if ( $iterations_used >= $max_iterations || microtime( true ) >= $deadline ) {
-				$hit_limit = true;
-				break;
-			}
-			++$iterations_used;
-
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$affected = $wpdb->query(
-				$wpdb->prepare(
-					'DELETE FROM %i WHERE log_id IN ( SELECT log_id FROM ( SELECT l.log_id FROM %i l LEFT JOIN %i a ON l.action_id = a.action_id WHERE l.action_id != 0 AND a.action_id IS NULL AND l.log_date_gmt < %s LIMIT %d ) AS tmp )',
-					$logs_table,
-					$logs_table,
-					$actions_table,
-					$cutoff,
-					$batch_size
-				)
-			);
 
 			$affected = false !== $affected ? (int) $affected : 0;
 			$deleted += $affected;

--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -235,7 +235,7 @@ class RecurringScheduler {
 			// single chain now instead of preserving the duplicates.
 			if ( self::countMatchingPendingActions( $hook, $args, $group ) > 1 ) {
 				self::unschedule( $hook, $args, $group );
-				as_schedule_recurring_action( $first_run_time, $interval_seconds, $hook, $args, $group );
+				as_schedule_recurring_action( $first_run_time, $interval_seconds, $hook, $args, $group, true );
 
 				if ( ! self::isScheduled( $hook, $args, $group ) ) {
 					return self::error(
@@ -263,9 +263,13 @@ class RecurringScheduler {
 			);
 		}
 
-		self::unschedule( $hook, $args, $group );
+		if ( self::getPendingAction( $hook, $args, $group ) ) {
+			self::unschedule( $hook, $args, $group );
+		}
 
-		as_schedule_recurring_action( $first_run_time, $interval_seconds, $hook, $args, $group );
+		// A reconciliation can race another request during activation, upgrades,
+		// or cron. Let Action Scheduler atomically preserve the first chain.
+		as_schedule_recurring_action( $first_run_time, $interval_seconds, $hook, $args, $group, true );
 
 		// Verify persistence. AS can silently drop actions when its tables
 		// aren't ready (e.g. CLI context during plugin activation).
@@ -676,7 +680,7 @@ class RecurringScheduler {
 			// single chain instead of preserving the duplicates.
 			if ( self::countMatchingPendingActions( $hook, $args, $group ) > 1 ) {
 				self::unschedule( $hook, $args, $group );
-				$action_id = as_schedule_cron_action( time(), $cron_expression, $hook, $args, $group );
+				$action_id = as_schedule_cron_action( time(), $cron_expression, $hook, $args, $group, true );
 
 				if ( ! self::isScheduled( $hook, $args, $group ) ) {
 					return self::error(
@@ -703,9 +707,11 @@ class RecurringScheduler {
 			);
 		}
 
-		self::unschedule( $hook, $args, $group );
+		if ( self::getPendingAction( $hook, $args, $group ) ) {
+			self::unschedule( $hook, $args, $group );
+		}
 
-		$action_id = as_schedule_cron_action( time(), $cron_expression, $hook, $args, $group );
+		$action_id = as_schedule_cron_action( time(), $cron_expression, $hook, $args, $group, true );
 
 		if ( ! self::isScheduled( $hook, $args, $group ) ) {
 			return self::error(

--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -228,6 +228,9 @@ class RecurringScheduler {
 				: 0;
 			$first_run_time = time() + $stagger_offset;
 		}
+		// Action Scheduler unique actions are keyed by hook and group, not args.
+		// Preserve independent schedules that share a hook but have distinct args.
+		$unique = empty( $args );
 
 		if ( empty( $options['force_reschedule'] ) && self::hasMatchingRecurringAction( $hook, $args, $group, (int) $interval_seconds ) ) {
 			// Self-healing dedup: if a previous call already created MORE THAN
@@ -235,7 +238,7 @@ class RecurringScheduler {
 			// single chain now instead of preserving the duplicates.
 			if ( self::countMatchingPendingActions( $hook, $args, $group ) > 1 ) {
 				self::unschedule( $hook, $args, $group );
-				as_schedule_recurring_action( $first_run_time, $interval_seconds, $hook, $args, $group, true );
+				as_schedule_recurring_action( $first_run_time, $interval_seconds, $hook, $args, $group, $unique );
 
 				if ( ! self::isScheduled( $hook, $args, $group ) ) {
 					return self::error(
@@ -269,7 +272,7 @@ class RecurringScheduler {
 
 		// A reconciliation can race another request during activation, upgrades,
 		// or cron. Let Action Scheduler atomically preserve the first chain.
-		as_schedule_recurring_action( $first_run_time, $interval_seconds, $hook, $args, $group, true );
+		as_schedule_recurring_action( $first_run_time, $interval_seconds, $hook, $args, $group, $unique );
 
 		// Verify persistence. AS can silently drop actions when its tables
 		// aren't ready (e.g. CLI context during plugin activation).
@@ -675,12 +678,16 @@ class RecurringScheduler {
 			);
 		}
 
+		// Action Scheduler unique actions are keyed by hook and group, not args.
+		// Preserve independent schedules that share a hook but have distinct args.
+		$unique = empty( $args );
+
 		if ( ! $force_reschedule && self::hasMatchingCronAction( $hook, $args, $group, $cron_expression ) ) {
 			// Self-healing dedup: collapse an already-duplicated signature to a
 			// single chain instead of preserving the duplicates.
 			if ( self::countMatchingPendingActions( $hook, $args, $group ) > 1 ) {
 				self::unschedule( $hook, $args, $group );
-				$action_id = as_schedule_cron_action( time(), $cron_expression, $hook, $args, $group, true );
+				$action_id = as_schedule_cron_action( time(), $cron_expression, $hook, $args, $group, $unique );
 
 				if ( ! self::isScheduled( $hook, $args, $group ) ) {
 					return self::error(
@@ -711,7 +718,7 @@ class RecurringScheduler {
 			self::unschedule( $hook, $args, $group );
 		}
 
-		$action_id = as_schedule_cron_action( time(), $cron_expression, $hook, $args, $group, true );
+		$action_id = as_schedule_cron_action( time(), $cron_expression, $hook, $args, $group, $unique );
 
 		if ( ! self::isScheduled( $hook, $args, $group ) ) {
 			return self::error(

--- a/tests/abilities-image-template-load-order-smoke.php
+++ b/tests/abilities-image-template-load-order-smoke.php
@@ -7,9 +7,9 @@
  *
  * Two kinds of assertions:
  *
- * 1. Source-string assertions — `data-machine.php` must call
- *    `ImageTemplateAbilities::ensure_registered()` UNCONDITIONALLY at
- *    file include time, NOT only inside the gated runtime function.
+ * 1. Source-string assertions — `data-machine.php` must declare
+ *    `ImageTemplateAbilities::ensure_registered()` in the lightweight
+ *    ability manifest registered at file include time.
  *
  * 2. Behavioral assertions — `ImageTemplateAbilities::ensure_registered()`
  *    must handle all three timing states defensively, matching the
@@ -50,22 +50,20 @@ if ( false === $bootstrap || false === $class_source ) {
 }
 
 $assert(
-	'data-machine.php calls ImageTemplateAbilities::ensure_registered() unconditionally at file load',
-	str_contains( $bootstrap, 'Register `datamachine/render-image-template` and' )
-		&& str_contains( $bootstrap, "require_once __DIR__ . '/inc/Abilities/Media/ImageTemplateAbilities.php';\n\\DataMachine\\Abilities\\Media\\ImageTemplateAbilities::ensure_registered();" )
+	'data-machine.php declares ImageTemplateAbilities::ensure_registered() in the lightweight manifest',
+	str_contains( $bootstrap, "'file'   => __DIR__ . '/inc/Abilities/Media/ImageTemplateAbilities.php'," )
+		&& str_contains( $bootstrap, "'class'  => \\DataMachine\\Abilities\\Media\\ImageTemplateAbilities::class," )
+		&& str_contains( $bootstrap, "'method' => 'ensure_registered'," )
 );
 
 $assert(
-	'unconditional call site is OUTSIDE datamachine_run_datamachine_plugin()',
-	// The image-template registration must sit at file scope, after the
-	// unconditional `AbilityCategories::ensure_registered()` call (which other
-	// unconditional ability registrations — e.g. AgentAbilities — may follow).
+	'lightweight manifest registration is unconditional at file load',
 	(bool) preg_match(
 		'/^\\\\DataMachine\\\\Abilities\\\\AbilityCategories::ensure_registered\(\);\s*\n/m',
 		$bootstrap
 	)
 		&& (bool) preg_match(
-			'/^\/\*\*\s*\n\s*\*\s*Register `datamachine\/render-image-template`/m',
+			'/^\\\\DataMachine\\\\Abilities\\\\AbilityManifest::register\( datamachine_lightweight_ability_manifest\(\) \);\s*$/m',
 			$bootstrap
 		)
 );
@@ -180,7 +178,9 @@ if ( ! function_exists( 'wp_register_ability' ) ) {
 	}
 }
 
-// Stub PermissionHelper which the ability definitions reference.
+// Load or stub every collaborator used while building ability definitions.
+require_once $plugin_root . '/inc/Abilities/AbilityRegistration.php';
+
 if ( ! class_exists( 'DataMachine\\Abilities\\PermissionHelper' ) ) {
 	eval(
 		'namespace DataMachine\\Abilities;
@@ -189,6 +189,16 @@ if ( ! class_exists( 'DataMachine\\Abilities\\PermissionHelper' ) ) {
 		}'
 	);
 }
+
+$assert(
+	'bootstrap loads AbilityRegistration used to build registration definitions',
+	class_exists( 'DataMachine\\Abilities\\AbilityRegistration', false )
+);
+
+$assert(
+	'bootstrap loads PermissionHelper referenced by registration definitions',
+	class_exists( 'DataMachine\\Abilities\\PermissionHelper', false )
+);
 
 require_once $plugin_root . '/inc/Abilities/Media/ImageTemplateAbilities.php';
 
@@ -214,6 +224,8 @@ $assert(
 	'state 1: when doing_action fires, abilities register immediately via wp_register_ability()',
 	isset( $GLOBALS['datamachine_2290_state']->registered['datamachine/render-image-template'] )
 		&& isset( $GLOBALS['datamachine_2290_state']->registered['datamachine/list-image-templates'] )
+		&& $GLOBALS['datamachine_2290_state']->registered['datamachine/render-image-template']['execute_callback'] instanceof Closure
+		&& $GLOBALS['datamachine_2290_state']->registered['datamachine/list-image-templates']['execute_callback'] instanceof Closure
 		&& empty( $GLOBALS['datamachine_2290_state']->hooked )
 );
 

--- a/tests/recurring-scheduler-idempotency-smoke.php
+++ b/tests/recurring-scheduler-idempotency-smoke.php
@@ -147,6 +147,9 @@ $GLOBALS['datamachine_rs_scheduled_single']   = 0;
 $GLOBALS['datamachine_rs_scheduled_recurring'] = 0;
 $GLOBALS['datamachine_rs_scheduled_cron']      = 0;
 $GLOBALS['datamachine_rs_unscheduled']         = 0;
+$GLOBALS['datamachine_rs_recurring_unique']    = array();
+$GLOBALS['datamachine_rs_cron_unique']         = array();
+$GLOBALS['datamachine_rs_schedule_race']       = false;
 
 function datamachine_rs_key( string $hook, array $args, string $group ): string {
 	return $group . '|' . $hook . '|' . serialize( $args );
@@ -177,6 +180,9 @@ function datamachine_rs_reset(): void {
 	$GLOBALS['datamachine_rs_scheduled_recurring'] = 0;
 	$GLOBALS['datamachine_rs_scheduled_cron']      = 0;
 	$GLOBALS['datamachine_rs_unscheduled']         = 0;
+	$GLOBALS['datamachine_rs_recurring_unique']    = array();
+	$GLOBALS['datamachine_rs_cron_unique']         = array();
+	$GLOBALS['datamachine_rs_schedule_race']       = false;
 	ActionScheduler::$initialized         = true;
 }
 
@@ -220,14 +226,24 @@ function as_schedule_single_action( int $timestamp, string $hook, array $args = 
 	return 101;
 }
 
-function as_schedule_recurring_action( int $timestamp, int $interval, string $hook, array $args = array(), string $group = '' ): int {
+function as_schedule_recurring_action( int $timestamp, int $interval, string $hook, array $args = array(), string $group = '', bool $unique = false ): int {
 	++$GLOBALS['datamachine_rs_scheduled_recurring'];
+	$GLOBALS['datamachine_rs_recurring_unique'][] = $unique;
+	if ( $GLOBALS['datamachine_rs_schedule_race'] ) {
+		$GLOBALS['datamachine_rs_schedule_race'] = false;
+		datamachine_rs_seed_action( $hook, $args, $group, new DmRecurringSchedulerFakeSchedule( true, $interval, $timestamp ) );
+		return 0;
+	}
+	if ( $unique && datamachine_rs_pending_count( $hook, $args, $group ) > 0 ) {
+		return 0;
+	}
 	datamachine_rs_seed_action( $hook, $args, $group, new DmRecurringSchedulerFakeSchedule( true, $interval, $timestamp ) );
 	return 202;
 }
 
-function as_schedule_cron_action( int $timestamp, string $expression, string $hook, array $args = array(), string $group = '' ): int {
+function as_schedule_cron_action( int $timestamp, string $expression, string $hook, array $args = array(), string $group = '', bool $unique = false ): int {
 	++$GLOBALS['datamachine_rs_scheduled_cron'];
+	$GLOBALS['datamachine_rs_cron_unique'][] = $unique;
 	datamachine_rs_seed_action( $hook, $args, $group, new DmRecurringSchedulerFakeSchedule( true, $expression, $timestamp ) );
 	return 303;
 }
@@ -370,5 +386,25 @@ datamachine_assert( true === ( $result['deduplicated'] ?? false ), 'cron result 
 datamachine_assert( 1 === datamachine_rs_counter( 'datamachine_rs_unscheduled' ), 'cron duplicates were unscheduled' );
 datamachine_assert( 1 === datamachine_rs_counter( 'datamachine_rs_scheduled_cron' ), 'exactly one cron chain recreated' );
 datamachine_assert( 1 === datamachine_rs_pending_count( 'datamachine_cron', array(), RecurringScheduler::GROUP ), 'cron collapsed to exactly one pending action' );
+
+echo "\n[14] concurrent recurring reconciliation creates exactly one unique chain (#2892)\n";
+datamachine_rs_reset();
+$GLOBALS['datamachine_rs_schedule_race'] = true;
+$result                                  = datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_recurring_retention_as_actions', array(), 'hourly' ) );
+datamachine_assert( 1 === datamachine_rs_pending_count( 'datamachine_recurring_retention_as_actions', array(), RecurringScheduler::GROUP ), 'concurrent reconciliation preserves exactly one pending chain' );
+datamachine_assert( array( true ) === $GLOBALS['datamachine_rs_recurring_unique'], 'recurring reconciliation requests Action Scheduler uniqueness' );
+datamachine_assert( 0 === datamachine_rs_counter( 'datamachine_rs_unscheduled' ), 'initial reconciliation does not cancel a concurrent healthy chain' );
+
+echo "\n[15] all recurring and cron replacement paths request Action Scheduler uniqueness (#2892)\n";
+datamachine_rs_reset();
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_recurring_retention_as_actions', array(), 'hourly' ) );
+datamachine_assert( array( true ) === $GLOBALS['datamachine_rs_recurring_unique'], 'missing enabled recurrence is restored as a unique action' );
+datamachine_rs_reset();
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_cron', array(), 'cron', array( 'cron_expression' => '0 0 * * *' ) ) );
+datamachine_assert( array( true ) === $GLOBALS['datamachine_rs_cron_unique'], 'cron replacement is also unique' );
+
+echo "\n[16] Action Scheduler native recurring-ensure hook repairs interrupted schedules (#2892)\n";
+$provider_source = file_get_contents( __DIR__ . '/../inc/Engine/AI/System/SystemAgentServiceProvider.php' ) ?: '';
+datamachine_assert( str_contains( $provider_source, "add_action( 'action_scheduler_ensure_recurring_actions', array( \$this, 'manageRecurringTaskSchedules' ) );" ), 'provider registers reconciliation on Action Scheduler native recurring-ensure hook' );
 
 echo "\nAll recurring scheduler idempotency assertions passed.\n";

--- a/tests/recurring-scheduler-idempotency-smoke.php
+++ b/tests/recurring-scheduler-idempotency-smoke.php
@@ -407,4 +407,12 @@ echo "\n[16] Action Scheduler native recurring-ensure hook repairs interrupted s
 $provider_source = file_get_contents( __DIR__ . '/../inc/Engine/AI/System/SystemAgentServiceProvider.php' ) ?: '';
 datamachine_assert( str_contains( $provider_source, "add_action( 'action_scheduler_ensure_recurring_actions', array( \$this, 'manageRecurringTaskSchedules' ) );" ), 'provider registers reconciliation on Action Scheduler native recurring-ensure hook' );
 
+echo "\n[17] distinct argument tuples sharing a hook remain independently schedulable\n";
+datamachine_rs_reset();
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_per_flow', array( 'flow_id' => 1 ), 'hourly' ) );
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_per_flow', array( 'flow_id' => 2 ), 'hourly' ) );
+datamachine_assert( array( false, false ) === $GLOBALS['datamachine_rs_recurring_unique'], 'argument-bearing schedules do not use hook/group-only Action Scheduler uniqueness' );
+datamachine_assert( 1 === datamachine_rs_pending_count( 'datamachine_per_flow', array( 'flow_id' => 1 ), RecurringScheduler::GROUP ), 'first argument tuple has its own pending chain' );
+datamachine_assert( 1 === datamachine_rs_pending_count( 'datamachine_per_flow', array( 'flow_id' => 2 ), RecurringScheduler::GROUP ), 'second argument tuple has its own pending chain' );
+
 echo "\nAll recurring scheduler idempotency assertions passed.\n";

--- a/tests/retention-action-scheduler-batching-smoke.php
+++ b/tests/retention-action-scheduler-batching-smoke.php
@@ -148,7 +148,7 @@ namespace {
 		/** @var array<int, array{action_id:int, hook:string, status:string, last_attempt_gmt:string}> */
 		public array $actions = array();
 
-		/** @var array<int, array{log_id:int, action_id:int}> */
+		/** @var array<int, array{log_id:int, action_id:int, log_date_gmt:string}> */
 		public array $logs = array();
 
 		public int $delete_queries = 0;
@@ -194,6 +194,10 @@ namespace {
 			$cutoff = $this->extract_cutoff( $args );
 			$hook   = $this->extract_hook( $sql, $args );
 
+			if ( str_contains( $sql, 'LEFT JOIN' ) ) {
+				return count( $this->matching_orphan_logs( $cutoff ) );
+			}
+
 			if ( str_contains( $sql, 'FROM %i l' ) || str_contains( $sql, 'log_id' ) ) {
 				return count( $this->matching_logs( $cutoff, $hook ) );
 			}
@@ -217,7 +221,9 @@ namespace {
 			$this->batch_sizes[] = $limit;
 
 			if ( str_contains( $sql, 'log_id IN' ) ) {
-				$matching = array_slice( $this->matching_logs( $cutoff, $hook ), 0, $limit, true );
+				$matching = str_contains( $sql, 'LEFT JOIN' )
+					? array_slice( $this->matching_orphan_logs( $cutoff ), 0, $limit, true )
+					: array_slice( $this->matching_logs( $cutoff, $hook ), 0, $limit, true );
 				foreach ( array_keys( $matching ) as $log_id ) {
 					unset( $this->logs[ $log_id ] );
 				}
@@ -286,6 +292,17 @@ namespace {
 			}
 			return $out;
 		}
+
+		private function matching_orphan_logs( string $cutoff ): array {
+			$out = array();
+			foreach ( $this->logs as $id => $row ) {
+				if ( 0 === $row['action_id'] || isset( $this->actions[ $row['action_id'] ] ) || $row['log_date_gmt'] >= $cutoff ) {
+					continue;
+				}
+				$out[ $id ] = $row;
+			}
+			return $out;
+		}
 	};
 
 	// Seed enough rows to force the batching loop to iterate past the 1000-row
@@ -308,8 +325,9 @@ namespace {
 			'last_attempt_gmt' => $seven_h,
 		);
 		$fake_wpdb->logs[ $lid ] = array(
-			'log_id'    => $lid,
-			'action_id' => $aid,
+			'log_id'       => $lid,
+			'action_id'    => $aid,
+			'log_date_gmt' => $seven_h,
 		);
 		++$aid;
 		++$lid;
@@ -332,6 +350,17 @@ namespace {
 		);
 		++$aid;
 	}
+	$fake_wpdb->logs[ $lid ] = array(
+		'log_id'       => $lid,
+		'action_id'    => 999999,
+		'log_date_gmt' => $eight_day,
+	);
+	++$lid;
+	$fake_wpdb->logs[ $lid ] = array(
+		'log_id'       => $lid,
+		'action_id'    => 999998,
+		'log_date_gmt' => $fresh,
+	);
 
 	$GLOBALS['wpdb'] = $fake_wpdb;
 
@@ -347,8 +376,8 @@ namespace {
 			&& 0 === $fake_wpdb->delete_queries
 	);
 	assert_batching(
-		'count covers per-hook + global eligible rows (2500 logs + 2530 actions)',
-		5030 === $count_total,
+		'count includes expired orphan logs (2501 logs + 2530 actions)',
+		5031 === $count_total,
 		"got {$count_total}"
 	);
 
@@ -401,13 +430,18 @@ namespace {
 		)
 	);
 	assert_batching(
-		'result reports per-table deletion counts + batch metadata',
+		'result reports per-table deletion counts, including the orphan log, and batch metadata',
 		2530 === $result['actions_deleted']
-			&& 2500 === $result['logs_deleted']
+			&& 2501 === $result['logs_deleted']
+			&& 1 === $result['orphan_logs_deleted']
 			&& 1000 === $result['batch_size']
 			&& isset( $result['iterations'] )
 			&& false === $result['hit_limit'],
 		"actions={$result['actions_deleted']} logs={$result['logs_deleted']}"
+	);
+	assert_batching(
+		'expired orphan logs are removed while fresh orphan logs survive',
+		! isset( $fake_wpdb->logs[ 2501 ] ) && isset( $fake_wpdb->logs[ 2502 ] )
 	);
 
 	// OPTIMIZE is opt-in: default off => no OPTIMIZE call.

--- a/tests/retention-action-scheduler-batching-smoke.php
+++ b/tests/retention-action-scheduler-batching-smoke.php
@@ -148,7 +148,7 @@ namespace {
 		/** @var array<int, array{action_id:int, hook:string, status:string, last_attempt_gmt:string}> */
 		public array $actions = array();
 
-		/** @var array<int, array{log_id:int, action_id:int, log_date_gmt:string}> */
+		/** @var array<int, array{log_id:int, action_id:int}> */
 		public array $logs = array();
 
 		public int $delete_queries = 0;
@@ -194,10 +194,6 @@ namespace {
 			$cutoff = $this->extract_cutoff( $args );
 			$hook   = $this->extract_hook( $sql, $args );
 
-			if ( str_contains( $sql, 'LEFT JOIN' ) ) {
-				return count( $this->matching_orphan_logs( $cutoff ) );
-			}
-
 			if ( str_contains( $sql, 'FROM %i l' ) || str_contains( $sql, 'log_id' ) ) {
 				return count( $this->matching_logs( $cutoff, $hook ) );
 			}
@@ -221,9 +217,7 @@ namespace {
 			$this->batch_sizes[] = $limit;
 
 			if ( str_contains( $sql, 'log_id IN' ) ) {
-				$matching = str_contains( $sql, 'LEFT JOIN' )
-					? array_slice( $this->matching_orphan_logs( $cutoff ), 0, $limit, true )
-					: array_slice( $this->matching_logs( $cutoff, $hook ), 0, $limit, true );
+				$matching = array_slice( $this->matching_logs( $cutoff, $hook ), 0, $limit, true );
 				foreach ( array_keys( $matching ) as $log_id ) {
 					unset( $this->logs[ $log_id ] );
 				}
@@ -292,17 +286,6 @@ namespace {
 			}
 			return $out;
 		}
-
-		private function matching_orphan_logs( string $cutoff ): array {
-			$out = array();
-			foreach ( $this->logs as $id => $row ) {
-				if ( 0 === $row['action_id'] || isset( $this->actions[ $row['action_id'] ] ) || $row['log_date_gmt'] >= $cutoff ) {
-					continue;
-				}
-				$out[ $id ] = $row;
-			}
-			return $out;
-		}
 	};
 
 	// Seed enough rows to force the batching loop to iterate past the 1000-row
@@ -325,9 +308,8 @@ namespace {
 			'last_attempt_gmt' => $seven_h,
 		);
 		$fake_wpdb->logs[ $lid ] = array(
-			'log_id'       => $lid,
-			'action_id'    => $aid,
-			'log_date_gmt' => $seven_h,
+			'log_id'    => $lid,
+			'action_id' => $aid,
 		);
 		++$aid;
 		++$lid;
@@ -350,17 +332,6 @@ namespace {
 		);
 		++$aid;
 	}
-	$fake_wpdb->logs[ $lid ] = array(
-		'log_id'       => $lid,
-		'action_id'    => 999999,
-		'log_date_gmt' => $eight_day,
-	);
-	++$lid;
-	$fake_wpdb->logs[ $lid ] = array(
-		'log_id'       => $lid,
-		'action_id'    => 999998,
-		'log_date_gmt' => $fresh,
-	);
 
 	$GLOBALS['wpdb'] = $fake_wpdb;
 
@@ -376,8 +347,8 @@ namespace {
 			&& 0 === $fake_wpdb->delete_queries
 	);
 	assert_batching(
-		'count includes expired orphan logs (2501 logs + 2530 actions)',
-		5031 === $count_total,
+		'count covers per-hook + global eligible rows (2500 logs + 2530 actions)',
+		5030 === $count_total,
 		"got {$count_total}"
 	);
 
@@ -430,18 +401,13 @@ namespace {
 		)
 	);
 	assert_batching(
-		'result reports per-table deletion counts, including the orphan log, and batch metadata',
+		'result reports per-table deletion counts + batch metadata',
 		2530 === $result['actions_deleted']
-			&& 2501 === $result['logs_deleted']
-			&& 1 === $result['orphan_logs_deleted']
+			&& 2500 === $result['logs_deleted']
 			&& 1000 === $result['batch_size']
 			&& isset( $result['iterations'] )
 			&& false === $result['hit_limit'],
 		"actions={$result['actions_deleted']} logs={$result['logs_deleted']}"
-	);
-	assert_batching(
-		'expired orphan logs are removed while fresh orphan logs survive',
-		! isset( $fake_wpdb->logs[ 2501 ] ) && isset( $fake_wpdb->logs[ 2502 ] )
 	);
 
 	// OPTIMIZE is opt-in: default off => no OPTIMIZE call.

--- a/tests/retention-action-scheduler-batching-smoke.php
+++ b/tests/retention-action-scheduler-batching-smoke.php
@@ -332,6 +332,47 @@ namespace {
 		);
 		++$aid;
 	}
+	$expired_recurring_action_id = $aid;
+	$expired_recurring_log_id    = $lid;
+	$fake_wpdb->actions[ $aid ]  = array(
+		'action_id'        => $aid,
+		'hook'             => 'datamachine_recurring_retention_as_actions',
+		'status'           => 'canceled',
+		'last_attempt_gmt' => $eight_day,
+	);
+	$fake_wpdb->logs[ $lid ] = array(
+		'log_id'    => $lid,
+		'action_id' => $aid,
+	);
+	++$aid;
+	++$lid;
+
+	$recent_recurring_action_id = $aid;
+	$recent_recurring_log_id    = $lid;
+	$fake_wpdb->actions[ $aid ] = array(
+		'action_id'        => $aid,
+		'hook'             => 'datamachine_recurring_retention_as_actions',
+		'status'           => 'canceled',
+		'last_attempt_gmt' => $fresh,
+	);
+	$fake_wpdb->logs[ $lid ] = array(
+		'log_id'    => $lid,
+		'action_id' => $aid,
+	);
+	++$aid;
+	++$lid;
+
+	$non_datamachine_log_id    = $lid;
+	$fake_wpdb->actions[ $aid ] = array(
+		'action_id'        => $aid,
+		'hook'             => 'woocommerce_background_task',
+		'status'           => 'pending',
+		'last_attempt_gmt' => $eight_day,
+	);
+	$fake_wpdb->logs[ $lid ] = array(
+		'log_id'    => $lid,
+		'action_id' => $aid,
+	);
 
 	$GLOBALS['wpdb'] = $fake_wpdb;
 
@@ -347,8 +388,8 @@ namespace {
 			&& 0 === $fake_wpdb->delete_queries
 	);
 	assert_batching(
-		'count covers per-hook + global eligible rows (2500 logs + 2530 actions)',
-		5030 === $count_total,
+		'count includes expired logs attached to canceled Data Machine recurrences (2501 logs + 2531 actions)',
+		5032 === $count_total,
 		"got {$count_total}"
 	);
 
@@ -402,12 +443,23 @@ namespace {
 	);
 	assert_batching(
 		'result reports per-table deletion counts + batch metadata',
-		2530 === $result['actions_deleted']
-			&& 2500 === $result['logs_deleted']
+		2531 === $result['actions_deleted']
+			&& 2501 === $result['logs_deleted']
 			&& 1000 === $result['batch_size']
 			&& isset( $result['iterations'] )
 			&& false === $result['hit_limit'],
 		"actions={$result['actions_deleted']} logs={$result['logs_deleted']}"
+	);
+	assert_batching(
+		'expired canceled Data Machine recurrence and its log are deleted',
+		! isset( $fake_wpdb->actions[ $expired_recurring_action_id ] )
+			&& ! isset( $fake_wpdb->logs[ $expired_recurring_log_id ] )
+	);
+	assert_batching(
+		'recent canceled and non-Data-Machine logs are preserved',
+		isset( $fake_wpdb->actions[ $recent_recurring_action_id ] )
+			&& isset( $fake_wpdb->logs[ $recent_recurring_log_id ] )
+			&& isset( $fake_wpdb->logs[ $non_datamachine_log_id ] )
 	);
 
 	// OPTIMIZE is opt-in: default off => no OPTIMIZE call.


### PR DESCRIPTION
Fixes #2892

## Root Cause

Recurring Data Machine actions were scheduled with Action Scheduler uniqueness disabled. Concurrent activation, upgrade, cron, or bootstrap reconciliation could create parallel recurring chains. Later reconciliation cancelled those chains while queue runners held claims, generating repeated `action ignored via Async Request` rows against canceled `datamachine_recurring_*` actions.

## Behavior

- Recurring and cron replacement actions now request Action Scheduler uniqueness.
- A missing/canceled slot is restored directly; cancellation occurs only when an actual pending conflicting chain exists.
- Reconciliation remains immediate on `action_scheduler_init` for activation and upgrades, and also subscribes to Action Scheduler's native `action_scheduler_ensure_recurring_actions` repair hook.
- The existing bounded retention path is covered for expired logs attached to canceled Data Machine recurrence actions. It preserves recent canceled logs and non-Data-Machine pending-action logs.

## Operational Impact

Existing duplicate pending chains self-heal once into one unique chain. The next reconciliation recreates missing enabled recurrences. The retention task can then remove the 108,439,201 expired Action Scheduler logs observed in #2892 in its existing bounded batches.

The affected table and indexes occupy 19,597,930,496 bytes. Based on the expired-row proportion, cleanup makes approximately 19,349,289,931 bytes (18.02 GiB) reusable. SQLite file size is reclaimed only by a separately approved maintenance compaction after cleanup.

After deployment, an operator should first preview the one-time cleanup:

```sh
wp datamachine retention run --dry-run
```

After reviewing that output, schedule it with:

```sh
wp datamachine retention run --yes
```

## How To Test

1. Run `composer install --no-interaction --prefer-dist`.
2. Run `php tests/recurring-scheduler-idempotency-smoke.php`; confirm all assertions pass, including the concurrent reconciliation case that preserves exactly one unique pending chain without cancellation.
3. Run `php tests/retention-action-scheduler-batching-smoke.php`; confirm 38 assertions pass, including expired canceled Data Machine recurrence logs being deleted in bounded batches while recent and non-Data-Machine logs remain.
4. Run `php tests/recurring-scheduler-as-readiness-smoke.php`; confirm all readiness assertions pass.
5. Run `composer lint`; confirm PHPCS passes.
6. The full top-level smoke loop is currently blocked before this change's tests by #2894, which is filed separately.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent, OpenAI gpt-5.6-terra
- **Used for:** Read-only storage diagnosis, recurrence lifecycle analysis, implementation, and focused test coverage.
