### PR TITLE
feat(media): add brand-agnostic flow_diagram core template

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Data Machine will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Core `flow_diagram` image template — a brand-agnostic, spec-driven flow diagram (nodes + edges) rendered server-side via GDRenderer. Composable through the existing `datamachine/render-image-template` ability surface (CLI, REST, MCP, PHP): `wp datamachine image render --template_id=flow_diagram --data='{"nodes":[...],"edges":[...]}'`. Core ships only generic structural templates; domain templates remain downstream.
+
+### Fixed
+- `GDRenderer::draw_rounded_rect()` no longer fatals on PHP 8.0–8.3. It called `imagefilledroundedrectangle()` unconditionally, but that builtin is PHP 8.4+; added a manual rounded-rect fallback so rounded nodes render on all supported PHP versions.
+
 ## [0.162.3] - 2026-07-13
 
 ### Fixed

--- a/inc/Abilities/Media/GDRenderer.php
+++ b/inc/Abilities/Media/GDRenderer.php
@@ -717,8 +717,33 @@ class GDRenderer {
 			return $this;
 		}
 
-		// Draw filled rectangle with rounded corners using arc.
-		imagefilledroundedrectangle( $this->image, $x, $y, $x + $width, $y + $height, $radius, $color );
+		$x2 = $x + $width;
+		$y2 = $y + $height;
+
+		// imagefilledroundedrectangle() is PHP 8.4+. Fall back to a manual
+		// composition (rects + corner arcs) so rounded nodes render on 8.0–8.3.
+		if ( function_exists( 'imagefilledroundedrectangle' ) ) {
+			imagefilledroundedrectangle( $this->image, $x, $y, $x2, $y2, $radius, $color );
+			return $this;
+		}
+
+		$radius = max( 0, min( $radius, intdiv( $width, 2 ), intdiv( $height, 2 ) ) );
+
+		if ( 0 === $radius ) {
+			imagefilledrectangle( $this->image, $x, $y, $x2, $y2, $color );
+			return $this;
+		}
+
+		// Center cross of the rounded rect.
+		imagefilledrectangle( $this->image, $x + $radius, $y, $x2 - $radius, $y2, $color );
+		imagefilledrectangle( $this->image, $x, $y + $radius, $x2, $y2 - $radius, $color );
+
+		$d = $radius * 2;
+		// Four corner quarter-circles.
+		imagefilledellipse( $this->image, $x + $radius, $y + $radius, $d, $d, $color );
+		imagefilledellipse( $this->image, $x2 - $radius, $y + $radius, $d, $d, $color );
+		imagefilledellipse( $this->image, $x + $radius, $y2 - $radius, $d, $d, $color );
+		imagefilledellipse( $this->image, $x2 - $radius, $y2 - $radius, $d, $d, $color );
 
 		return $this;
 	}

--- a/inc/Abilities/Media/Templates/FlowDiagramTemplate.php
+++ b/inc/Abilities/Media/Templates/FlowDiagramTemplate.php
@@ -45,19 +45,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class FlowDiagramTemplate implements TemplateInterface {
 
-	private const DEFAULT_BG        = '#0f1117';
-	private const DEFAULT_SURFACE   = '#1b1f2a';
-	private const DEFAULT_NODE      = '#2d6cdf';
-	private const DEFAULT_EDGE      = '#8a93a6';
-	private const DEFAULT_TEXT      = '#ffffff';
-	private const DEFAULT_TITLE     = '#ffffff';
-	private const DEFAULT_MUTED     = '#8a93a6';
+	private const DEFAULT_BG      = '#0f1117';
+	private const DEFAULT_SURFACE = '#1b1f2a';
+	private const DEFAULT_NODE    = '#2d6cdf';
+	private const DEFAULT_EDGE    = '#8a93a6';
+	private const DEFAULT_TEXT    = '#ffffff';
+	private const DEFAULT_TITLE   = '#ffffff';
+	private const DEFAULT_MUTED   = '#8a93a6';
 
-	private const NODE_WIDTH        = 260;
-	private const NODE_HEIGHT       = 120;
-	private const GAP               = 90;
-	private const MARGIN            = 60;
-	private const TITLE_BAND        = 96;
+	private const NODE_WIDTH  = 260;
+	private const NODE_HEIGHT = 120;
+	private const GAP         = 90;
+	private const MARGIN      = 60;
+	private const TITLE_BAND  = 96;
 
 	public function get_id(): string {
 		return 'flow_diagram';
@@ -216,12 +216,12 @@ class FlowDiagramTemplate implements TemplateInterface {
 
 			$label = isset( $edge['label'] ) ? (string) $edge['label'] : '';
 			if ( '' !== $label ) {
-				$mid_x   = intdiv( $x1 + $x2, 2 );
-				$mid_y   = intdiv( $y1 + $y2, 2 );
-				$fs      = 14;
-				$lw      = $renderer->measure_text_width( $label, $fs, 'label' );
-				$pad     = 8;
-				$chip_h  = $fs + $pad;
+				$mid_x  = intdiv( $x1 + $x2, 2 );
+				$mid_y  = intdiv( $y1 + $y2, 2 );
+				$fs     = 14;
+				$lw     = $renderer->measure_text_width( $label, $fs, 'label' );
+				$pad    = 8;
+				$chip_h = $fs + $pad;
 				// Chip sits above the connector so it never overlaps node fills.
 				$chip_x1 = $mid_x - intdiv( $lw, 2 ) - $pad;
 				$chip_y1 = $mid_y - $chip_h - 6;
@@ -235,10 +235,10 @@ class FlowDiagramTemplate implements TemplateInterface {
 			$id  = isset( $node['id'] ) ? (string) $node['id'] : (string) $i;
 			$pos = $positions[ $id ];
 
-			$shape     = $node['shape'] ?? 'box';
-			$fill      = isset( $node['color'] ) ? $renderer->color_hex( 'node_' . $id, (string) $node['color'] ) : $node_c;
-			$label     = isset( $node['label'] ) ? (string) $node['label'] : '';
-			$label     = str_replace( '\n', "\n", $label );
+			$shape = $node['shape'] ?? 'box';
+			$fill  = isset( $node['color'] ) ? $renderer->color_hex( 'node_' . $id, (string) $node['color'] ) : $node_c;
+			$label = isset( $node['label'] ) ? (string) $node['label'] : '';
+			$label = str_replace( '\n', "\n", $label );
 
 			switch ( $shape ) {
 				case 'diamond':
@@ -297,9 +297,9 @@ class FlowDiagramTemplate implements TemplateInterface {
 			}
 		}
 
-		$line_h      = (int) ( $font_size * 1.35 );
-		$block_h     = count( $lines ) * $line_h;
-		$start_y     = $pos['cy'] - intdiv( $block_h, 2 );
+		$line_h  = (int) ( $font_size * 1.35 );
+		$block_h = count( $lines ) * $line_h;
+		$start_y = $pos['cy'] - intdiv( $block_h, 2 );
 
 		foreach ( $lines as $n => $line ) {
 			$lw = $renderer->measure_text_width( $line, $font_size, 'label' );

--- a/inc/Abilities/Media/Templates/FlowDiagramTemplate.php
+++ b/inc/Abilities/Media/Templates/FlowDiagramTemplate.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Flow Diagram Template
+ *
+ * A brand-agnostic, spec-driven flow diagram. Renders a set of labelled
+ * nodes connected by directional arrows from a declarative JSON payload —
+ * no domain logic, no external services, pure GDRenderer.
+ *
+ * Unlike domain templates (event cards, quote cards), this is a generic
+ * structural primitive: describe a graph as data and get a deterministic
+ * PNG/JPEG back. Any consumer of the `datamachine/render-image-template`
+ * ability — CLI, REST, MCP, or PHP — can generate flow diagrams for free.
+ *
+ * Data spec:
+ *   {
+ *     "title":     "Optional heading",
+ *     "direction": "horizontal" | "vertical",   // default: horizontal
+ *     "nodes": [
+ *       { "id": "a", "label": "First step",  "shape": "box",   "color": "#2d6cdf" },
+ *       { "id": "b", "label": "Decision?",   "shape": "diamond" },
+ *       { "id": "c", "label": "Done",        "shape": "oval" }
+ *     ],
+ *     "edges": [
+ *       { "from": "a", "to": "b", "label": "next" },
+ *       { "from": "b", "to": "c" }
+ *     ]
+ *   }
+ *
+ * `label` supports "\n" for manual line breaks; long labels also wrap to the
+ * node width automatically. `shape` is one of box (default), diamond, oval.
+ * Per-node `color` (hex) overrides the default node fill.
+ *
+ * @package DataMachine\Abilities\Media\Templates
+ * @since 0.163.0
+ */
+
+namespace DataMachine\Abilities\Media\Templates;
+
+use DataMachine\Abilities\Media\GDRenderer;
+use DataMachine\Abilities\Media\TemplateInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class FlowDiagramTemplate implements TemplateInterface {
+
+	private const DEFAULT_BG        = '#0f1117';
+	private const DEFAULT_SURFACE   = '#1b1f2a';
+	private const DEFAULT_NODE      = '#2d6cdf';
+	private const DEFAULT_EDGE      = '#8a93a6';
+	private const DEFAULT_TEXT      = '#ffffff';
+	private const DEFAULT_TITLE     = '#ffffff';
+	private const DEFAULT_MUTED     = '#8a93a6';
+
+	private const NODE_WIDTH        = 260;
+	private const NODE_HEIGHT       = 120;
+	private const GAP               = 90;
+	private const MARGIN            = 60;
+	private const TITLE_BAND        = 96;
+
+	public function get_id(): string {
+		return 'flow_diagram';
+	}
+
+	public function get_name(): string {
+		return 'Flow Diagram';
+	}
+
+	public function get_description(): string {
+		return 'Brand-agnostic flow diagram. Renders labelled nodes (box, diamond, oval) connected by directional arrows from a declarative nodes/edges spec. Composable via CLI, REST, MCP, or PHP.';
+	}
+
+	public function get_fields(): array {
+		return array(
+			'title'     => array(
+				'label'    => 'Title',
+				'type'     => 'string',
+				'required' => false,
+			),
+			'direction' => array(
+				'label'    => 'Layout Direction',
+				'type'     => 'string',
+				'required' => false,
+			),
+			'nodes'     => array(
+				'label'    => 'Nodes',
+				'type'     => 'array',
+				'required' => true,
+			),
+			'edges'     => array(
+				'label'    => 'Edges',
+				'type'     => 'array',
+				'required' => false,
+			),
+		);
+	}
+
+	public function get_default_preset(): string {
+		return 'open_graph';
+	}
+
+	/**
+	 * @param array      $data     Diagram spec (title, direction, nodes, edges).
+	 * @param GDRenderer $renderer Shared GD renderer.
+	 * @param array      $options  preset, format, context, colors overrides.
+	 * @return string[] Rendered file paths.
+	 */
+	public function render( array $data, GDRenderer $renderer, array $options = array() ): array {
+		$nodes = isset( $data['nodes'] ) && is_array( $data['nodes'] ) ? array_values( $data['nodes'] ) : array();
+		if ( empty( $nodes ) ) {
+			do_action( 'datamachine_log', 'error', 'FlowDiagramTemplate: no nodes provided' );
+			return array();
+		}
+
+		$edges     = isset( $data['edges'] ) && is_array( $data['edges'] ) ? $data['edges'] : array();
+		$title     = isset( $data['title'] ) ? (string) $data['title'] : '';
+		$direction = ( ( $data['direction'] ?? 'horizontal' ) === 'vertical' ) ? 'vertical' : 'horizontal';
+		$colors    = isset( $options['colors'] ) && is_array( $options['colors'] ) ? $options['colors'] : array();
+		$format    = $options['format'] ?? 'png';
+
+		$count      = count( $nodes );
+		$title_band = '' !== $title ? self::TITLE_BAND : 0;
+
+		// Widen the inter-node gap when any edge carries a label so the label
+		// chip has room to sit clear of both node fills.
+		$has_edge_labels = false;
+		foreach ( $edges as $edge ) {
+			if ( ! empty( $edge['label'] ) ) {
+				$has_edge_labels = true;
+				break;
+			}
+		}
+		$gap = $has_edge_labels ? self::GAP + 90 : self::GAP;
+
+		// Compute canvas from the node grid (ignore preset; diagrams size to content).
+		if ( 'vertical' === $direction ) {
+			$width  = self::MARGIN * 2 + self::NODE_WIDTH;
+			$height = self::MARGIN * 2 + $title_band + $count * self::NODE_HEIGHT + ( $count - 1 ) * $gap;
+		} else {
+			$width  = self::MARGIN * 2 + $count * self::NODE_WIDTH + ( $count - 1 ) * $gap;
+			$height = self::MARGIN * 2 + $title_band + self::NODE_HEIGHT;
+		}
+
+		$renderer->create_canvas( $width, $height );
+
+		// Fonts: theme fonts if present, DejaVu fallback otherwise (handled by register_font).
+		$renderer->register_font( 'title', 'Inter-Bold.ttf' );
+		$renderer->register_font( 'label', 'Inter-Regular.ttf' );
+
+		$bg      = $renderer->color_hex( 'bg', $colors['background'] ?? self::DEFAULT_BG );
+		$surface = $renderer->color_hex( 'surface', $colors['surface'] ?? self::DEFAULT_SURFACE );
+		$node_c  = $renderer->color_hex( 'node', $colors['node'] ?? self::DEFAULT_NODE );
+		$edge_c  = $renderer->color_hex( 'edge', $colors['edge'] ?? self::DEFAULT_EDGE );
+		$text_c  = $renderer->color_hex( 'text', $colors['text'] ?? self::DEFAULT_TEXT );
+		$title_c = $renderer->color_hex( 'title', $colors['title'] ?? self::DEFAULT_TITLE );
+		$muted_c = $renderer->color_hex( 'muted', $colors['muted'] ?? self::DEFAULT_MUTED );
+
+		$renderer->fill( $bg );
+
+		if ( '' !== $title ) {
+			$renderer->filled_rect( 0, 0, $width, $title_band, $surface );
+			$renderer->draw_text_centered( $title, 30, self::MARGIN + 6, $title_c, 'title' );
+		}
+
+		// Position nodes on a single row/column and index by id for edge routing.
+		$positions = array();
+		$top0      = self::MARGIN + $title_band;
+
+		foreach ( $nodes as $i => $node ) {
+			if ( 'vertical' === $direction ) {
+				$x = self::MARGIN;
+				$y = $top0 + $i * ( self::NODE_HEIGHT + $gap );
+			} else {
+				$x = self::MARGIN + $i * ( self::NODE_WIDTH + $gap );
+				$y = $top0;
+			}
+
+			$id = isset( $node['id'] ) ? (string) $node['id'] : (string) $i;
+
+			$positions[ $id ] = array(
+				'x'      => $x,
+				'y'      => $y,
+				'cx'     => $x + intdiv( self::NODE_WIDTH, 2 ),
+				'cy'     => $y + intdiv( self::NODE_HEIGHT, 2 ),
+				'right'  => $x + self::NODE_WIDTH,
+				'bottom' => $y + self::NODE_HEIGHT,
+			);
+		}
+
+		// Draw edges first so arrows sit behind node fills.
+		foreach ( $edges as $edge ) {
+			$from = isset( $edge['from'] ) ? (string) $edge['from'] : '';
+			$to   = isset( $edge['to'] ) ? (string) $edge['to'] : '';
+
+			if ( ! isset( $positions[ $from ], $positions[ $to ] ) ) {
+				continue;
+			}
+
+			$a = $positions[ $from ];
+			$b = $positions[ $to ];
+
+			if ( 'vertical' === $direction ) {
+				$x1 = $a['cx'];
+				$y1 = $a['bottom'];
+				$x2 = $b['cx'];
+				$y2 = $b['y'];
+			} else {
+				$x1 = $a['right'];
+				$y1 = $a['cy'];
+				$x2 = $b['x'];
+				$y2 = $b['cy'];
+			}
+
+			$renderer->draw_arrow( $x1, $y1, $x2, $y2, $edge_c, 3 );
+
+			$label = isset( $edge['label'] ) ? (string) $edge['label'] : '';
+			if ( '' !== $label ) {
+				$mid_x   = intdiv( $x1 + $x2, 2 );
+				$mid_y   = intdiv( $y1 + $y2, 2 );
+				$fs      = 14;
+				$lw      = $renderer->measure_text_width( $label, $fs, 'label' );
+				$pad     = 8;
+				$chip_h  = $fs + $pad;
+				// Chip sits above the connector so it never overlaps node fills.
+				$chip_x1 = $mid_x - intdiv( $lw, 2 ) - $pad;
+				$chip_y1 = $mid_y - $chip_h - 6;
+				$renderer->draw_rounded_rect( $chip_x1, $chip_y1, $lw + $pad * 2, $chip_h, $surface, 6 );
+				$renderer->draw_text( $label, $fs, $mid_x - intdiv( $lw, 2 ), $chip_y1 + $fs + intdiv( $pad, 2 ) - 2, $muted_c, 'label' );
+			}
+		}
+
+		// Draw nodes.
+		foreach ( $nodes as $i => $node ) {
+			$id  = isset( $node['id'] ) ? (string) $node['id'] : (string) $i;
+			$pos = $positions[ $id ];
+
+			$shape     = $node['shape'] ?? 'box';
+			$fill      = isset( $node['color'] ) ? $renderer->color_hex( 'node_' . $id, (string) $node['color'] ) : $node_c;
+			$label     = isset( $node['label'] ) ? (string) $node['label'] : '';
+			$label     = str_replace( '\n', "\n", $label );
+
+			switch ( $shape ) {
+				case 'diamond':
+					$renderer->draw_diamond( $pos['cx'], $pos['cy'], self::NODE_WIDTH, self::NODE_HEIGHT, $fill, true );
+					break;
+				case 'oval':
+					$renderer->draw_oval( $pos['cx'], $pos['cy'], self::NODE_WIDTH, self::NODE_HEIGHT, $fill, true );
+					break;
+				default:
+					$renderer->draw_rounded_rect( $pos['x'], $pos['y'], self::NODE_WIDTH, self::NODE_HEIGHT, $fill, 16 );
+					break;
+			}
+
+			$this->draw_node_label( $renderer, $label, $pos, $text_c );
+		}
+
+		$path = $renderer->save_temp( $format );
+
+		return $path ? array( $path ) : array();
+	}
+
+	/**
+	 * Draw a node's (possibly multi-line, possibly wrapped) label centered in the node box.
+	 *
+	 * @param GDRenderer          $renderer Renderer.
+	 * @param string              $label    Label text (may contain "\n").
+	 * @param array<string, int>  $pos      Node position record.
+	 * @param int                 $color    Text color id.
+	 */
+	private function draw_node_label( GDRenderer $renderer, string $label, array $pos, int $color ): void {
+		if ( '' === $label ) {
+			return;
+		}
+
+		$inner = self::NODE_WIDTH - 40;
+
+		// Auto-shrink the font until the longest single token fits the node
+		// width. Handles long unbroken strings (e.g. "ai-provider-for-claude-code")
+		// that word-wrapping alone can't break.
+		$font_size = 20;
+		$longest   = '';
+		foreach ( preg_split( '/\s+/', str_replace( "\n", ' ', $label ) ) as $token ) {
+			if ( strlen( $token ) > strlen( $longest ) ) {
+				$longest = $token;
+			}
+		}
+		while ( $font_size > 11 && $renderer->measure_text_width( $longest, $font_size, 'label' ) > $inner ) {
+			--$font_size;
+		}
+
+		// Expand manual line breaks, then wrap each to the inner width.
+		$lines = array();
+		foreach ( explode( "\n", $label ) as $segment ) {
+			foreach ( $renderer->wrap_text( $segment, $font_size, 'label', $inner ) as $wrapped ) {
+				$lines[] = $wrapped;
+			}
+		}
+
+		$line_h      = (int) ( $font_size * 1.35 );
+		$block_h     = count( $lines ) * $line_h;
+		$start_y     = $pos['cy'] - intdiv( $block_h, 2 );
+
+		foreach ( $lines as $n => $line ) {
+			$lw = $renderer->measure_text_width( $line, $font_size, 'label' );
+			$lx = $pos['cx'] - intdiv( $lw, 2 );
+			$ly = $start_y + $n * $line_h + $font_size;
+			$renderer->draw_text( $line, $font_size, $lx, $ly, $color, 'label' );
+		}
+	}
+}

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -146,6 +146,22 @@ add_filter(
 
 /*
 |--------------------------------------------------------------------------
+| Core image templates
+|--------------------------------------------------------------------------
+| Core ships only brand-agnostic, structural templates (generic primitives).
+| Domain-specific templates (event cards, quote cards) belong downstream.
+*/
+add_filter(
+	// phpcs:ignore WordPress.NamingConventions.ValidHookName -- Intentional slash-separated hook namespace.
+	'datamachine/image_generation/templates',
+	static function ( array $templates ): array {
+		$templates['flow_diagram'] ??= \DataMachine\Abilities\Media\Templates\FlowDiagramTemplate::class;
+		return $templates;
+	}
+);
+
+/*
+|--------------------------------------------------------------------------
 | Iteration budget registrations
 |--------------------------------------------------------------------------
 | Named bounded-iteration budgets shared across the engine. Each budget

--- a/tests/flow-diagram-template-smoke.php
+++ b/tests/flow-diagram-template-smoke.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Smoke test for the core FlowDiagramTemplate.
+ *
+ * Asserts:
+ *  - implements TemplateInterface and reports the expected contract
+ *  - renders a nodes/edges spec to a valid PNG file
+ *  - handles box/diamond/oval shapes and edge labels
+ *  - GDRenderer::draw_rounded_rect() works without imagefilledroundedrectangle()
+ *    (the PHP 8.4+ builtin) so nodes render on PHP 8.0–8.3
+ *  - registered on the core datamachine/image_generation/templates filter
+ *
+ * Run with: php tests/flow-diagram-template-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare( strict_types = 1 );
+
+$failed = 0;
+$total  = 0;
+
+$assert = static function ( string $name, bool $condition ) use ( &$failed, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$name}\n";
+		return;
+	}
+	echo "  FAIL: {$name}\n";
+	++$failed;
+};
+
+$plugin_root = dirname( __DIR__ );
+
+// -------------------------------------------------------------------------
+// Source-string assertions (hold in every backend, incl. real WordPress).
+// -------------------------------------------------------------------------
+
+$bootstrap     = (string) file_get_contents( $plugin_root . '/inc/bootstrap.php' );
+$gd_source     = (string) file_get_contents( $plugin_root . '/inc/Abilities/Media/GDRenderer.php' );
+$tmpl_source   = (string) file_get_contents( $plugin_root . '/inc/Abilities/Media/Templates/FlowDiagramTemplate.php' );
+
+$assert(
+	'bootstrap registers flow_diagram on the core template filter',
+	str_contains( $bootstrap, "'datamachine/image_generation/templates'" )
+		&& str_contains( $bootstrap, 'FlowDiagramTemplate::class' )
+);
+
+$assert(
+	'draw_rounded_rect guards imagefilledroundedrectangle for PHP < 8.4',
+	str_contains( $gd_source, "function_exists( 'imagefilledroundedrectangle' )" )
+);
+
+$assert(
+	'FlowDiagramTemplate implements TemplateInterface',
+	str_contains( $tmpl_source, 'implements TemplateInterface' )
+);
+
+// -------------------------------------------------------------------------
+// Behavioral: render a real diagram (skipped if GD/freetype unavailable).
+// -------------------------------------------------------------------------
+
+if ( ! function_exists( 'imagecreatetruecolor' ) || ! function_exists( 'imagettftext' ) ) {
+	echo "\nGD/freetype unavailable — behavioral render assertions skipped.\n";
+	if ( $failed > 0 ) {
+		fwrite( fopen( 'php://stderr', 'w' ), "\nflow-diagram-template-smoke: {$failed}/{$total} assertions failed\n" );
+		exit( 1 );
+	}
+	echo "All {$total} flow-diagram-template source assertions passed.\n";
+	return;
+}
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', '/tmp/' );
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( ...$args ) {}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $tag, $value, ...$rest ) {
+		return $value;
+	}
+}
+if ( ! function_exists( 'wp_delete_file' ) ) {
+	function wp_delete_file( $file ) {
+		if ( is_string( $file ) && file_exists( $file ) ) {
+			@unlink( $file ); // phpcs:ignore
+		}
+	}
+}
+if ( ! function_exists( 'get_template_directory' ) ) {
+	function get_template_directory() {
+		return '/tmp/datamachine-no-theme';
+	}
+}
+
+require_once $plugin_root . '/inc/Abilities/Media/PlatformPresets.php';
+require_once $plugin_root . '/inc/Abilities/Media/TemplateInterface.php';
+require_once $plugin_root . '/inc/Abilities/Media/GDRenderer.php';
+require_once $plugin_root . '/inc/Abilities/Media/Templates/FlowDiagramTemplate.php';
+
+use DataMachine\Abilities\Media\GDRenderer;
+use DataMachine\Abilities\Media\TemplateInterface;
+use DataMachine\Abilities\Media\Templates\FlowDiagramTemplate;
+
+$template = new FlowDiagramTemplate();
+
+$assert( 'instance is a TemplateInterface', $template instanceof TemplateInterface );
+$assert( 'get_id() returns flow_diagram', $template->get_id() === 'flow_diagram' );
+$assert( 'nodes field is required', ! empty( $template->get_fields()['nodes']['required'] ) );
+$assert( 'default preset declared', $template->get_default_preset() !== '' );
+
+$spec = array(
+	'title'     => 'Smoke Test Flow',
+	'direction' => 'horizontal',
+	'nodes'     => array(
+		array( 'id' => 'a', 'label' => 'Start',           'shape' => 'oval' ),
+		array( 'id' => 'b', 'label' => 'Decision?',        'shape' => 'diamond' ),
+		array( 'id' => 'c', 'label' => 'a-very-long-single-token-node-label', 'shape' => 'box', 'color' => '#16a34a' ),
+	),
+	'edges'     => array(
+		array( 'from' => 'a', 'to' => 'b', 'label' => 'go' ),
+		array( 'from' => 'b', 'to' => 'c' ),
+	),
+);
+
+$paths = $template->render( $spec, new GDRenderer(), array( 'format' => 'png' ) );
+
+$assert( 'render returns a non-empty array of paths', is_array( $paths ) && count( $paths ) === 1 );
+
+$path = $paths[0] ?? '';
+$assert( 'rendered file exists', $path && file_exists( $path ) );
+
+if ( $path && file_exists( $path ) ) {
+	$info = getimagesize( $path );
+	$assert( 'output is a valid PNG', is_array( $info ) && $info['mime'] === 'image/png' );
+	$assert( 'output has sane dimensions', is_array( $info ) && $info[0] > 100 && $info[1] > 100 );
+	wp_delete_file( $path );
+}
+
+// Empty nodes must fail gracefully (no fatal, empty result).
+$empty = $template->render( array( 'nodes' => array() ), new GDRenderer() );
+$assert( 'empty nodes returns empty array without fatal', is_array( $empty ) && count( $empty ) === 0 );
+
+// Rounded-rect polyfill path: draw a box node and confirm a canvas was produced
+// even on runtimes lacking imagefilledroundedrectangle (8.0–8.3).
+$renderer = new GDRenderer();
+$renderer->create_canvas( 200, 100 );
+$fill = $renderer->color_hex( 'x', '#2d6cdf' );
+$renderer->draw_rounded_rect( 10, 10, 180, 80, $fill, 16 );
+$assert( 'draw_rounded_rect produced an image on this PHP', $renderer->get_image() instanceof \GdImage );
+
+if ( $failed > 0 ) {
+	fwrite( fopen( 'php://stderr', 'w' ), "\nflow-diagram-template-smoke: {$failed}/{$total} assertions failed\n" );
+	exit( 1 );
+}
+
+echo "\nAll {$total} flow-diagram-template assertions passed.\n";


### PR DESCRIPTION
## Summary

Adds a generic, **spec-driven flow diagram** template to core, rendered server-side via the existing `GDRenderer`. Describe a graph as `{ nodes, edges }` and get a deterministic PNG/JPEG back — no external services, no AI, no per-token cost.

It registers on the core `datamachine/image_generation/templates` filter, so it's **composable for free** through the existing `datamachine/render-image-template` ability across every surface:

```bash
wp datamachine image render --template_id=flow_diagram \
  --data='{"title":"...","nodes":[{"id":"a","label":"A"},{"id":"b","label":"B"}],"edges":[{"from":"a","to":"b","label":"next"}]}'
```

Any consumer of Data Machine (CLI, REST, MCP, PHP) now gets programmatic PHP diagram generation with zero extra wiring.

### Design: generic templates in core, domain templates downstream

The GD engine (`GDRenderer` + `TemplateInterface` + `TemplateRegistry`) has always lived in core, but core shipped **zero** templates by the original "core provides the engine, downstream brings the templates" rule (PR #449). That rule was written for *domain-specific* graphics (event cards, quote cards). A `flow_diagram` is different: it's a **domain-agnostic structural primitive**, same abstraction level as `PlatformPresets`, `BrandTokens`, and `GDRenderer::get_chart_palette()` that core already ships. So it belongs in core; domain templates still stay downstream.

## Features

- Node shapes: `box` (default), `diamond`, `oval`
- Per-node `color` (hex) override; auto-shrink + wrap for long/unbreakable labels
- Directional arrows with optional labelled chips
- `horizontal` (default) or `vertical` layout
- Canvas sizes to content

## Bonus fix

`GDRenderer::draw_rounded_rect()` called `imagefilledroundedrectangle()` unconditionally — but that builtin is **PHP 8.4+**, while the plugin requires PHP 8.0. Rounded nodes fataled on 8.0–8.3. Added a manual rounded-rect fallback (rects + corner ellipses).

## Test plan

- New self-contained smoke test `tests/flow-diagram-template-smoke.php` — renders a spec, asserts a valid PNG, exercises box/diamond/oval + edge labels + empty-nodes guard + the rounded-rect polyfill path. All 13 assertions pass locally on PHP 8.3.6.
- Verified visually: rendered a real 4-node OAuth-flow diagram (attached in the PR discussion).

## Notes

- `render()` returns `string[]` per the `TemplateInterface` contract.
- No breaking changes; purely additive plus one latent-bug fix.