### PR TITLE
fix: remove stray empty tracked .eslintrc.js from Pipelines assets

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Data Machine will be documented in this file.
 
 ### Fixed
 - `GDRenderer::draw_rounded_rect()` no longer fatals on PHP 8.0–8.3. It called `imagefilledroundedrectangle()` unconditionally, but that builtin is PHP 8.4+; added a manual rounded-rect fallback so rounded nodes render on all supported PHP versions.
+- Remove a stray empty tracked `.eslintrc.js` under the Pipelines React assets. It was dev-only cruft with no runtime purpose, excluded from the production build, which caused the release packager's tracked-file parity check to fail.
 
 ## [0.162.3] - 2026-07-13
 


### PR DESCRIPTION
## Summary
- Removes an empty, dev-only `.eslintrc.js` tracked under `inc/Core/Admin/Pages/Pipelines/assets/react/`.
- The production build strips dotfiles, so the file never ships — but homeboy 0.283.1's release packager enforces tracked-file parity and fails with "Release package is missing 1 tracked runtime file(s): ...eslintrc.js". This blocks all releases from environments running the newer packager.
- The file is 0 bytes and has no runtime purpose.

## Why now
Releases under the older homeboy (0.245.0) didn't run this parity check, so v0.162.3 shipped fine. The upgraded packager surfaced this pre-existing hygiene issue.

## Test plan
- `homeboy release data-machine` package preflight no longer reports the missing tracked file.