### PR TITLE
fix: reconcile missing recurring flow schedules

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -351,6 +351,7 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\Flow\DuplicateFlowAbility();
 	new \DataMachine\Abilities\Flow\PauseFlowAbility();
 	new \DataMachine\Abilities\Flow\ResumeFlowAbility();
+	new \DataMachine\Abilities\Flow\ReconcileFlowSchedulesAbility();
 	new \DataMachine\Abilities\Flow\QueueAbility();
 	new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
 	new \DataMachine\Abilities\FlowStep\GetFlowStepsAbility();
@@ -843,8 +844,9 @@ function datamachine_activate_for_site() {
 	// every deploy.
 	\DataMachine\Engine\AI\ComposableFileGenerator::regenerate_all();
 
-	// Re-schedule any flows with non-manual scheduling
-	datamachine_activate_scheduled_flows();
+	// Action Scheduler may not be initialized during activation. Mark this site
+	// for reconciliation on the next initialized scheduler request.
+	datamachine_mark_flow_schedule_reconciliation();
 
 	// Track DB schema version so deploy-time migrations auto-run.
 	update_option( 'datamachine_db_version', DATAMACHINE_VERSION, true );

--- a/inc/Abilities/Flow/ReconcileFlowSchedulesAbility.php
+++ b/inc/Abilities/Flow/ReconcileFlowSchedulesAbility.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Reconcile Flow Schedules Ability.
+ *
+ * @package DataMachine\Abilities\Flow
+ */
+
+namespace DataMachine\Abilities\Flow;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Api\Flows\FlowScheduleReconciler;
+
+defined( 'ABSPATH' ) || exit;
+
+class ReconcileFlowSchedulesAbility {
+
+	public function __construct() {
+		$this->registerAbility();
+	}
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/reconcile-flow-schedules',
+				array(
+					'label'               => __( 'Reconcile Flow Schedules', 'data-machine' ),
+					'description'         => __( 'Audit recurring flow schedule coverage and optionally restore missing Action Scheduler actions.', 'data-machine' ),
+					'category'            => 'datamachine-flow',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'apply'        => array(
+								'type'        => 'boolean',
+								'default'     => false,
+								'description' => __( 'Restore missing schedules. Defaults to dry-run.', 'data-machine' ),
+							),
+							'spread_hours' => array(
+								'type'        => array( 'integer', 'null' ),
+								'minimum'     => 1,
+								'maximum'     => 24,
+								'description' => __( 'Explicit fleet distribution window in hours (1-24).', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'           => array( 'type' => 'boolean' ),
+							'transient'         => array( 'type' => 'boolean' ),
+							'code'              => array( 'type' => 'string' ),
+							'applied'           => array( 'type' => 'boolean' ),
+							'eligible'          => array( 'type' => 'integer' ),
+							'covered'           => array( 'type' => 'integer' ),
+							'missing'           => array( 'type' => 'integer' ),
+							'blocked'           => array( 'type' => 'integer' ),
+							'repaired'          => array( 'type' => 'integer' ),
+							'failed'            => array( 'type' => 'integer' ),
+							'remaining_missing' => array( 'type' => 'integer' ),
+							'invalid'           => array( 'type' => 'integer' ),
+							'details'           => array( 'type' => 'array' ),
+							'error'             => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
+	}
+
+	/**
+	 * Execute schedule reconciliation.
+	 *
+	 * @param array $input Ability input.
+	 * @return array Reconciliation report.
+	 */
+	public function execute( array $input ): array {
+		$spread_hours = isset( $input['spread_hours'] ) ? (int) $input['spread_hours'] : null;
+		return ( new FlowScheduleReconciler() )->reconcile( ! empty( $input['apply'] ), $spread_hours );
+	}
+}

--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -19,6 +19,7 @@ use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\PluginSettings;
+use DataMachine\Api\Flows\FlowScheduleReconciler;
 use DataMachine\Engine\Tasks\RecurringRejectionTracker;
 use DataMachine\Engine\Tasks\RecurringScheduler;
 use DataMachine\Engine\Tasks\TaskScheduler;
@@ -249,6 +250,21 @@ class SystemAbilities {
 		$complete        = $this->getActionSchedulerGroupStats( 'complete' );
 		$due             = $this->getActionSchedulerGroupStats( 'pending', true );
 		$daily_memory    = $this->getActionSchedulerHookStats( 'datamachine_recurring_daily_memory_generation' );
+		$flow_coverage   = array(
+			'success'           => false,
+			'eligible'          => 0,
+			'covered'           => 0,
+			'remaining_missing' => 0,
+			'blocked'           => 0,
+			'invalid'           => 0,
+		);
+		if ( function_exists( 'as_get_scheduled_actions' ) && RecurringScheduler::isReady() ) {
+			$flow_coverage = ( new FlowScheduleReconciler() )->reconcile();
+		}
+		$missing_flow_schedules = (int) ( $flow_coverage['remaining_missing'] ?? 0 );
+		$invalid_flow_schedules = (int) ( $flow_coverage['invalid'] ?? 0 );
+		$blocked_flow_schedules = (int) ( $flow_coverage['blocked'] ?? 0 );
+		$coverage_failed        = empty( $flow_coverage['success'] ) && 0 === $blocked_flow_schedules;
 
 		// Recurring bindings rejected by TaskScheduler::schedule() on every
 		// tick are a silent, permanent failure: the task never runs and the
@@ -262,13 +278,46 @@ class SystemAbilities {
 			$status = 'unavailable';
 		} elseif ( ! empty( $rejected_schedules ) ) {
 			$status = 'failing';
+		} elseif ( $blocked_flow_schedules > 0 || $coverage_failed ) {
+			$status = 'failing';
+		} elseif ( $missing_flow_schedules > 0 || $invalid_flow_schedules > 0 ) {
+			$status = 'failing';
 		} elseif ( $due['count'] > 0 || ( null !== $wp_cron_overdue && $wp_cron_overdue > $stale_threshold ) ) {
 			$status = 'stale';
 		}
 
 		$message = match ( $status ) {
 			'ok'          => __( 'scheduler current', 'data-machine' ),
-			'failing'     => sprintf(
+			'failing'     => $blocked_flow_schedules > 0 ? sprintf(
+				/* translators: %d: number of flows blocked by in-progress Action Scheduler ownership. */
+				_n(
+					'%d recurring flow is blocked by in-progress Action Scheduler ownership',
+					'%d recurring flows are blocked by in-progress Action Scheduler ownership',
+					$blocked_flow_schedules,
+					'data-machine'
+				),
+				$blocked_flow_schedules
+			) : ( $missing_flow_schedules > 0 ? sprintf(
+				/* translators: %d: number of enabled recurring flows missing scheduler coverage. */
+				_n(
+					'%d enabled recurring flow is missing Action Scheduler coverage',
+					'%d enabled recurring flows are missing Action Scheduler coverage',
+					$missing_flow_schedules,
+					'data-machine'
+				),
+				$missing_flow_schedules
+			) : ( $invalid_flow_schedules > 0 ? sprintf(
+				/* translators: %d: number of malformed recurring flow definitions. */
+				_n(
+					'%d recurring flow has an invalid schedule definition',
+					'%d recurring flows have invalid schedule definitions',
+					$invalid_flow_schedules,
+					'data-machine'
+				),
+				$invalid_flow_schedules
+			) : ( $coverage_failed
+				? __( 'flow schedule coverage audit failed', 'data-machine' )
+				: sprintf(
 				/* translators: %d: number of recurring schedules rejected on every tick. */
 				_n(
 					'%d recurring schedule rejected on every tick and never running',
@@ -277,7 +326,7 @@ class SystemAbilities {
 					'data-machine'
 				),
 				count( $rejected_schedules )
-			),
+			) ) ) ),
 			'stale'       => __( 'scheduler has overdue work; invoke WordPress cron, run wp datamachine drain, or run a specific task with wp datamachine system run <task_type> --wait', 'data-machine' ),
 			'unavailable' => __( 'Action Scheduler is unavailable', 'data-machine' ),
 			default       => __( 'scheduler status unknown', 'data-machine' ),
@@ -323,8 +372,17 @@ class SystemAbilities {
 				'next_pending_gmt' => $daily_memory['pending']['oldest_gmt'],
 				'last_attempt_gmt' => $daily_memory['complete']['last_attempt_gmt'],
 			),
+			'flow_schedule_coverage'  => $flow_coverage,
 			'recommendation'          => match ( $status ) {
-				'failing' => __( 'One or more recurring schedules are rejected on every tick and never run. Inspect them with wp datamachine logs (filter error_code recurring_schedule_persistently_rejected) and fix the binding or its prerequisites (agent ownership, task registration, ability availability).', 'data-machine' ),
+				'failing' => $blocked_flow_schedules > 0
+					? __( 'Recover stale or uncertain in-progress jobs/actions first, then rerun wp datamachine flows reconcile-schedules. Reconciliation will not schedule around active ownership.', 'data-machine' )
+					: ( $missing_flow_schedules > 0
+					? __( 'Run wp datamachine flows reconcile-schedules to inspect missing coverage, then rerun with --apply. Large repairs automatically spread first runs across 24 hours.', 'data-machine' )
+					: ( $invalid_flow_schedules > 0
+						? __( 'Inspect invalid definitions with wp datamachine flows reconcile-schedules and correct each flow schedule before applying repairs.', 'data-machine' )
+						: ( $coverage_failed
+							? __( 'Run wp datamachine flows reconcile-schedules --format=json to inspect the coverage query failure before applying repairs.', 'data-machine' )
+							: __( 'One or more recurring schedules are rejected on every tick and never run. Inspect them with wp datamachine logs (filter error_code recurring_schedule_persistently_rejected) and fix the binding or its prerequisites (agent ownership, task registration, ability availability).', 'data-machine' ) ) ) ),
 				'stale'   => __( 'For local or low-traffic installs, schedule an external wake-up such as wp cron event run --due-now. To remediate only daily memory for an affected agent, run wp datamachine system run daily_memory_generation --param=agent_slug=<slug> --wait; for all overdue work, run wp datamachine drain.', 'data-machine' ),
 				default   => null,
 			},

--- a/inc/Api/Flows/FlowScheduleReconciler.php
+++ b/inc/Api/Flows/FlowScheduleReconciler.php
@@ -1,0 +1,513 @@
+<?php
+/**
+ * Flow schedule coverage reconciliation.
+ *
+ * @package DataMachine\Api\Flows
+ */
+
+namespace DataMachine\Api\Flows;
+
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Engine\Tasks\RecurringScheduler;
+
+defined( 'ABSPATH' ) || exit;
+
+class FlowScheduleReconciler {
+
+	private const LARGE_FLEET_THRESHOLD = 25;
+	private const MAX_DETAILS           = 100;
+	private const MAX_COVERAGE_ROWS     = 5000;
+	private const RUNNING_STALE_AFTER   = 7200;
+
+	private Flows $flows;
+
+	public function __construct( ?Flows $flows = null ) {
+		$this->flows = $flows ?? new Flows();
+	}
+
+	/**
+	 * Audit and optionally restore recurring flow schedule coverage.
+	 *
+	 * @param bool     $apply        Whether to repair missing schedules.
+	 * @param int|null $spread_hours Optional explicit fleet spread (1-24 hours).
+	 * @return array Reconciliation report.
+	 */
+	public function reconcile( bool $apply = false, ?int $spread_hours = null ): array {
+		if ( ! RecurringScheduler::isReady() ) {
+			return $this->failure( 'Action Scheduler is not initialized.', true );
+		}
+
+		if ( null !== $spread_hours && ( $spread_hours < 1 || $spread_hours > 24 ) ) {
+			return $this->failure( 'spread_hours must be between 1 and 24.' );
+		}
+
+		$lock_token = null;
+		if ( $apply ) {
+			$lock_token = FlowScheduleReconciliationLock::acquire();
+			if ( is_wp_error( $lock_token ) ) {
+				return $this->failure( $lock_token->get_error_message(), true, $lock_token->get_error_code() );
+			}
+		}
+
+		try {
+			return $this->reconcileUnlocked( $apply, $spread_hours, $lock_token );
+		} finally {
+			if ( null !== $lock_token ) {
+				FlowScheduleReconciliationLock::release( $lock_token );
+			}
+		}
+	}
+
+	/**
+	 * Reconcile after the apply lock has been acquired.
+	 *
+	 * @param bool     $apply        Whether to repair missing schedules.
+	 * @param int|null $spread_hours Optional explicit fleet spread.
+	 * @param string|null $lock_token Apply lock token.
+	 * @return array Reconciliation report.
+	 */
+	private function reconcileUnlocked( bool $apply, ?int $spread_hours, ?string $lock_token ): array {
+		$eligible       = array();
+		$invalid        = array();
+		$excluded_count = 0;
+
+		foreach ( $this->flows->get_flow_schedules() as $flow ) {
+			$scheduling = $flow['scheduling_config'] ?? array();
+			$interval   = $scheduling['interval'] ?? null;
+
+			if ( ! Flows::is_flow_enabled( $scheduling ) || empty( $interval ) || in_array( $interval, array( 'manual', 'one_time' ), true ) ) {
+				++$excluded_count;
+				continue;
+			}
+
+			$expected = $this->expectedRecurrence( $scheduling );
+			if ( is_wp_error( $expected ) ) {
+				$flow['definition_error'] = $expected->get_error_message();
+				$invalid[]                = $flow;
+				continue;
+			}
+
+			$flow['expected_recurrence'] = $expected;
+			$eligible[]                  = $flow;
+		}
+
+		$coverage_rows = $this->getCoverageRows();
+		if ( is_wp_error( $coverage_rows ) ) {
+			return $this->failure( $coverage_rows->get_error_message(), true, $coverage_rows->get_error_code() );
+		}
+
+		$coverage = $this->classifyCoverageRows( $coverage_rows, $eligible );
+		$missing  = array();
+		$blocked  = array();
+		foreach ( $eligible as $flow ) {
+			$flow_id = (int) $flow['flow_id'];
+			if ( isset( $coverage['blocked'][ $flow_id ] ) ) {
+				$flow['blocked_reason'] = $coverage['blocked'][ $flow_id ];
+				$blocked[]              = $flow;
+			} elseif ( ! isset( $coverage['covered'][ $flow_id ] ) ) {
+				$missing[] = $flow;
+			}
+		}
+
+		$missing_count = count( $missing );
+		$window_hours  = $spread_hours;
+		if ( null === $window_hours && $missing_count >= self::LARGE_FLEET_THRESHOLD ) {
+			$window_hours = 24;
+		}
+
+		$repaired = 0;
+		$failed   = 0;
+		$details  = array();
+		foreach ( $invalid as $flow ) {
+			$this->appendDetail(
+				$details,
+				$flow,
+				'invalid',
+				(string) $flow['definition_error']
+			);
+		}
+		foreach ( $blocked as $flow ) {
+			$this->appendDetail( $details, $flow, 'blocked', (string) $flow['blocked_reason'] );
+		}
+
+		foreach ( $missing as $index => $flow ) {
+			$flow_id    = (int) $flow['flow_id'];
+			$scheduling = $flow['scheduling_config'];
+			$status     = 'missing';
+			$error      = '';
+
+			if ( $apply ) {
+				if ( 0 === $index % 10 && ( null === $lock_token || ! FlowScheduleReconciliationLock::refresh( $lock_token ) ) ) {
+					return $this->failure( 'Flow schedule reconciliation lost its apply lock.', true, 'flow_schedule_reconciliation_lock_lost' );
+				}
+
+				$options = array( 'stagger_seed' => $flow_id );
+				if ( null !== $window_hours ) {
+					$options['distribution_window_seconds'] = $window_hours * HOUR_IN_SECONDS;
+				}
+				if ( 'cron' === $scheduling['interval'] ) {
+					$options['cron_expression'] = $scheduling['cron_expression'];
+				}
+
+				$result = RecurringScheduler::ensureSchedule(
+					FlowScheduling::FLOW_HOOK,
+					array( $flow_id ),
+					(string) $scheduling['interval'],
+					$options
+				);
+
+				if ( is_wp_error( $result ) ) {
+					++$failed;
+					$status = 'error';
+					$error  = $result->get_error_message();
+				} else {
+					++$repaired;
+					$status = 'repaired';
+				}
+			}
+
+			$this->appendDetail( $details, $flow, $status, $error );
+		}
+
+		return array(
+			'success'                   => 0 === $failed && empty( $blocked ),
+			'transient'                 => $failed > 0 || ! empty( $blocked ),
+			'applied'                   => $apply,
+			'total'                     => count( $eligible ) + count( $invalid ) + $excluded_count,
+			'eligible'                  => count( $eligible ),
+			'covered'                   => count( $coverage['covered'] ),
+			'missing'                   => $missing_count,
+			'blocked'                   => count( $blocked ),
+			'repaired'                  => $repaired,
+			'failed'                    => $failed,
+			'remaining_missing'         => ( $apply ? $failed : $missing_count ) + count( $blocked ),
+			'invalid'                   => count( $invalid ),
+			'excluded'                  => $excluded_count,
+			'distribution_window_hours' => $window_hours ?? 1,
+			'details'                   => $details,
+			'details_truncated'         => count( $invalid ) + count( $blocked ) + $missing_count > self::MAX_DETAILS,
+		);
+	}
+
+	/**
+	 * Resolve and validate the persisted recurrence semantics.
+	 *
+	 * @param array $scheduling Persisted scheduling configuration.
+	 * @return int|string|\WP_Error Expected interval seconds or cron expression.
+	 */
+	private function expectedRecurrence( array $scheduling ) {
+		$interval = (string) ( $scheduling['interval'] ?? '' );
+		if ( 'cron' === $interval ) {
+			$expression = (string) ( $scheduling['cron_expression'] ?? '' );
+			if ( '' === $expression || ! RecurringScheduler::isValidCronExpression( $expression ) ) {
+				return new \WP_Error( 'invalid_cron_definition', 'Cron schedule is missing a valid cron_expression.' );
+			}
+			return $expression;
+		}
+
+		if ( RecurringScheduler::looksLikeCronExpression( $interval ) ) {
+			return RecurringScheduler::isValidCronExpression( $interval )
+				? $interval
+				: new \WP_Error( 'invalid_cron_definition', 'Flow schedule contains an invalid cron expression.' );
+		}
+
+		$resolved  = RecurringScheduler::resolveIntervalAlias( $interval );
+		$intervals = apply_filters( 'datamachine_scheduler_intervals', array() );
+		$seconds   = (int) ( $intervals[ $resolved ]['seconds'] ?? 0 );
+		if ( $seconds <= 0 ) {
+			return new \WP_Error( 'unknown_interval_definition', sprintf( 'Unknown recurring interval: %s.', $interval ) );
+		}
+
+		return $seconds;
+	}
+
+	/**
+	 * Read lightweight coverage rows, preferring a direct bounded table query.
+	 *
+	 * @return array|\WP_Error Coverage rows or a transient query error.
+	 */
+	private function getCoverageRows() {
+		$rows = $this->getDirectCoverageRows();
+		if ( null === $rows ) {
+			$rows = $this->getApiCoverageRows();
+		}
+
+		if ( ! is_array( $rows ) ) {
+			return new \WP_Error( 'flow_schedule_coverage_unavailable', 'Unable to query Action Scheduler flow coverage.' );
+		}
+
+		if ( count( $rows ) > self::MAX_COVERAGE_ROWS ) {
+			return new \WP_Error( 'flow_schedule_coverage_too_large', 'Flow schedule coverage exceeded the bounded audit row limit; clean duplicate Action Scheduler rows before retrying.' );
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Query Action Scheduler's owned tables without hydrating action objects.
+	 *
+	 * @return array|null Rows, or null when direct querying is unavailable.
+	 */
+	private function getDirectCoverageRows(): ?array {
+		global $wpdb;
+		if ( ! class_exists( '\ActionScheduler' ) || ! class_exists( '\ActionScheduler_DBStore' ) ) {
+			return null;
+		}
+
+		$store = \ActionScheduler::store();
+		if ( ! is_object( $store ) || 'ActionScheduler_DBStore' !== get_class( $store ) ) {
+			return null;
+		}
+
+		if ( empty( $wpdb->actionscheduler_actions ) || empty( $wpdb->actionscheduler_groups ) || empty( $wpdb->actionscheduler_claims ) ) {
+			return null;
+		}
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Read-only bounded diagnostics against Action Scheduler-owned tables.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT a.action_id, a.status, a.args, a.extended_args, a.schedule, a.last_attempt_gmt, c.date_created_gmt AS claim_created_gmt
+				FROM %i a
+				INNER JOIN %i g ON g.group_id = a.group_id
+				LEFT JOIN %i c ON c.claim_id = a.claim_id
+				WHERE a.hook = %s AND g.slug = %s AND a.status IN (%s, %s)
+				ORDER BY a.action_id DESC LIMIT %d',
+				$wpdb->actionscheduler_actions,
+				$wpdb->actionscheduler_groups,
+				$wpdb->actionscheduler_claims,
+				FlowScheduling::FLOW_HOOK,
+				RecurringScheduler::GROUP,
+				'pending',
+				'in-progress',
+				self::MAX_COVERAGE_ROWS + 1
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		if ( is_array( $rows ) ) {
+			foreach ( $rows as &$row ) {
+				$row['timing_authoritative'] = true;
+			}
+		}
+
+		return is_array( $rows ) ? $rows : null;
+	}
+
+	/**
+	 * Portable bounded fallback through Action Scheduler's public query API.
+	 *
+	 * @return array|null Coverage rows, or null on failure.
+	 */
+	private function getApiCoverageRows(): ?array {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) || ! class_exists( '\ActionScheduler' ) ) {
+			return null;
+		}
+
+		$store = \ActionScheduler::store();
+		if ( ! is_object( $store ) || ! method_exists( $store, 'fetch_action' ) ) {
+			return null;
+		}
+
+		$rows = array();
+		foreach ( array( 'pending', 'in-progress' ) as $status ) {
+			$action_ids = as_get_scheduled_actions(
+				array(
+					'hook'     => FlowScheduling::FLOW_HOOK,
+					'group'    => RecurringScheduler::GROUP,
+					'status'   => $status,
+					'per_page' => self::MAX_COVERAGE_ROWS + 1 - count( $rows ),
+				),
+				'ids'
+			);
+			if ( ! is_array( $action_ids ) ) {
+				return null;
+			}
+
+			foreach ( $action_ids as $action_id ) {
+				try {
+					$action = $store->fetch_action( $action_id );
+				} catch ( \Throwable $throwable ) {
+					unset( $throwable );
+					return null;
+				}
+				if ( ! is_object( $action ) || ! method_exists( $action, 'get_args' ) || ! method_exists( $action, 'get_schedule' ) ) {
+					return null;
+				}
+
+				$rows[] = array(
+					'status'               => $status,
+					'action_args'          => $action->get_args(),
+					'schedule_object'      => $action->get_schedule(),
+					'timing_authoritative' => false,
+				);
+			}
+			if ( count( $rows ) > self::MAX_COVERAGE_ROWS ) {
+				break;
+			}
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Classify flow coverage by action ownership, freshness, and recurrence.
+	 *
+	 * @param array $rows Coverage rows.
+	 * @param array $eligible Eligible flow definitions.
+	 * @return array{covered:array<int,true>,blocked:array<int,string>} Coverage classification.
+	 */
+	private function classifyCoverageRows( array $rows, array $eligible ): array {
+		$expected = array();
+		foreach ( $eligible as $flow ) {
+			$expected[ (int) $flow['flow_id'] ] = $flow['expected_recurrence'];
+		}
+
+		$coverage = array();
+		foreach ( $rows as $row ) {
+			$args    = $row['action_args'] ?? $this->decodeActionArgs( $row );
+			$flow_id = is_array( $args ) && 1 === count( $args ) ? (int) reset( $args ) : 0;
+			if ( $flow_id <= 0 || ! array_key_exists( $flow_id, $expected ) ) {
+				continue;
+			}
+			if ( ! isset( $coverage[ $flow_id ] ) ) {
+				$coverage[ $flow_id ] = array(
+					'total'       => 0,
+					'valid'       => 0,
+					'in_progress' => 0,
+				);
+			}
+			++$coverage[ $flow_id ]['total'];
+
+			if ( 'in-progress' === ( $row['status'] ?? '' ) ) {
+				++$coverage[ $flow_id ]['in_progress'];
+				if ( $this->isStaleInProgress( $row ) ) {
+					$coverage[ $flow_id ]['blocked'] = empty( $row['timing_authoritative'] )
+						? 'In-progress Action Scheduler ownership timing is unavailable; recover the action before reconciling schedules.'
+						: 'A stale in-progress Action Scheduler action still owns this flow; recover the action before reconciling schedules.';
+					continue;
+				}
+			}
+
+			$schedule = $row['schedule_object'] ?? maybe_unserialize( $row['schedule'] ?? null );
+			if ( $this->scheduleMatches( $schedule, $expected[ $flow_id ] ) ) {
+				++$coverage[ $flow_id ]['valid'];
+			}
+		}
+
+		$covered = array();
+		$blocked = array();
+		foreach ( $coverage as $flow_id => $counts ) {
+			if ( ! empty( $counts['blocked'] ) ) {
+				$blocked[ $flow_id ] = $counts['blocked'];
+			} elseif ( $counts['in_progress'] > 0 && ( 1 !== $counts['total'] || 1 !== $counts['in_progress'] || 1 !== $counts['valid'] ) ) {
+				$blocked[ $flow_id ] = 'In-progress Action Scheduler ownership is mixed or does not match the persisted schedule; recover the action before reconciling schedules.';
+			} elseif ( 1 === $counts['total'] && 1 === $counts['valid'] ) {
+				$covered[ $flow_id ] = true;
+			}
+		}
+
+		return array(
+			'covered' => $covered,
+			'blocked' => $blocked,
+		);
+	}
+
+	/**
+	 * Decode Action Scheduler's compact or extended JSON args.
+	 *
+	 * @param array $row Action row.
+	 * @return array|null Decoded args.
+	 */
+	private function decodeActionArgs( array $row ): ?array {
+		$json = ! empty( $row['extended_args'] ) ? $row['extended_args'] : ( $row['args'] ?? '' );
+		$args = json_decode( (string) $json, true );
+		return is_array( $args ) ? $args : null;
+	}
+
+	/**
+	 * Determine whether an in-progress action is older than two hours.
+	 *
+	 * Missing timing is treated as stale so a custom-store action cannot suppress
+	 * repair forever when authoritative timing is unavailable.
+	 *
+	 * @param array $row Action row.
+	 * @return bool True when available timing proves the action is stale.
+	 */
+	private function isStaleInProgress( array $row ): bool {
+		if ( empty( $row['timing_authoritative'] ) ) {
+			return true;
+		}
+
+		$timestamps = array_filter(
+			array(
+				(int) ( $row['last_attempt_timestamp'] ?? 0 ),
+				strtotime( (string) ( $row['last_attempt_gmt'] ?? '' ) ),
+				strtotime( (string) ( $row['claim_created_gmt'] ?? '' ) ),
+			)
+		);
+		if ( empty( $timestamps ) ) {
+			return true;
+		}
+
+		return max( $timestamps ) < time() - self::RUNNING_STALE_AFTER;
+	}
+
+	/**
+	 * Compare a stored Action Scheduler schedule with persisted semantics.
+	 *
+	 * @param mixed      $schedule Stored Action Scheduler schedule object.
+	 * @param int|string $expected Expected seconds or cron expression.
+	 * @return bool True when recurrence semantics match.
+	 */
+	private function scheduleMatches( $schedule, $expected ): bool {
+		if ( ! is_object( $schedule ) || ! method_exists( $schedule, 'is_recurring' ) || ! $schedule->is_recurring() || ! method_exists( $schedule, 'get_recurrence' ) ) {
+			return false;
+		}
+
+		$recurrence = $schedule->get_recurrence();
+		return is_int( $expected )
+			? (int) $recurrence === $expected
+			: (string) $recurrence === $expected;
+	}
+
+	/**
+	 * Append one bounded detail row.
+	 *
+	 * @param array  $details Detail accumulator.
+	 * @param array  $flow Flow row.
+	 * @param string $status Detail status.
+	 * @param string $error Optional error.
+	 * @return void
+	 */
+	private function appendDetail( array &$details, array $flow, string $status, string $error = '' ): void {
+		if ( count( $details ) >= self::MAX_DETAILS ) {
+			return;
+		}
+
+		$details[] = array(
+			'flow_id'   => (int) $flow['flow_id'],
+			'flow_name' => (string) ( $flow['flow_name'] ?? '' ),
+			'interval'  => (string) ( $flow['scheduling_config']['interval'] ?? '' ),
+			'status'    => $status,
+			'error'     => $error,
+		);
+	}
+
+	/**
+	 * Build a consistent failure response.
+	 *
+	 * @param string $error     Failure message.
+	 * @param bool   $transient Whether deferred reconciliation should retry.
+	 * @param string $code      Machine-readable failure code.
+	 * @return array Failure report.
+	 */
+	private function failure( string $error, bool $transient = false, string $code = 'invalid_request' ): array {
+		return array(
+			'success'   => false,
+			'transient' => $transient,
+			'code'      => $code,
+			'error'     => $error,
+			'details'   => array(),
+		);
+	}
+}

--- a/inc/Api/Flows/FlowScheduleReconciliationLock.php
+++ b/inc/Api/Flows/FlowScheduleReconciliationLock.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Atomic per-site flow schedule reconciliation lock.
+ *
+ * @package DataMachine\Api\Flows
+ */
+
+namespace DataMachine\Api\Flows;
+
+defined( 'ABSPATH' ) || exit;
+
+class FlowScheduleReconciliationLock {
+
+	private const OPTION_NAME = 'datamachine_flow_schedule_reconciliation_lock';
+	private const STALE_AFTER = 1800;
+
+	/**
+	 * Acquire the apply lock, atomically replacing a stale owner when needed.
+	 *
+	 * @return string|\WP_Error Lock token or an error when another apply is active.
+	 */
+	public static function acquire() {
+		$token   = function_exists( 'wp_generate_uuid4' ) ? wp_generate_uuid4() : uniqid( 'dm-flow-reconcile-', true );
+		$payload = array(
+			'token'       => $token,
+			'acquired_at' => time(),
+		);
+
+		if ( add_option( self::OPTION_NAME, $payload, '', false ) ) {
+			return $token;
+		}
+
+		$current = get_option( self::OPTION_NAME, array() );
+		if ( is_array( $current ) && (int) ( $current['acquired_at'] ?? 0 ) > time() - self::STALE_AFTER ) {
+			return new \WP_Error( 'flow_schedule_reconciliation_locked', 'Another flow schedule reconciliation apply is already running.' );
+		}
+
+		if ( self::compareAndSwap( $current, $payload ) ) {
+			return $token;
+		}
+
+		return new \WP_Error( 'flow_schedule_reconciliation_locked', 'Another flow schedule reconciliation apply acquired the stale lock first.' );
+	}
+
+	/**
+	 * Release only the lock owned by the supplied token.
+	 *
+	 * @param string $token Lock token returned by acquire().
+	 * @return bool True when this owner released the lock.
+	 */
+	public static function release( string $token ): bool {
+		$current = get_option( self::OPTION_NAME, array() );
+		if ( ! is_array( $current ) || ! hash_equals( (string) ( $current['token'] ?? '' ), $token ) ) {
+			return false;
+		}
+
+		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Conditional delete provides token-safe lock release.
+		$deleted = $wpdb->query(
+			$wpdb->prepare(
+				'DELETE FROM %i WHERE option_name = %s AND option_value = %s',
+				$wpdb->options,
+				self::OPTION_NAME,
+				maybe_serialize( $current )
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( 1 === $deleted ) {
+			wp_cache_delete( self::OPTION_NAME, 'options' );
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Atomically refresh a lock lease owned by the supplied token.
+	 *
+	 * @param string $token Active lock token.
+	 * @return bool True when the exact owned lease was refreshed.
+	 */
+	public static function refresh( string $token ): bool {
+		$current = get_option( self::OPTION_NAME, array() );
+		if ( ! is_array( $current ) || ! hash_equals( (string) ( $current['token'] ?? '' ), $token ) ) {
+			return false;
+		}
+
+		$replacement                = $current;
+		$replacement['acquired_at'] = max( time(), (int) ( $current['acquired_at'] ?? 0 ) + 1 );
+		return self::compareAndSwap( $current, $replacement );
+	}
+
+	/**
+	 * Atomically replace the exact stale payload.
+	 *
+	 * @param mixed $expected Current stale lock payload.
+	 * @param array $replacement New lock payload.
+	 * @return bool True when the stale owner was replaced.
+	 */
+	private static function compareAndSwap( $expected, array $replacement ): bool {
+		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Conditional update provides atomic stale-lock takeover.
+		$updated = $wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i SET option_value = %s WHERE option_name = %s AND option_value = %s',
+				$wpdb->options,
+				maybe_serialize( $replacement ),
+				self::OPTION_NAME,
+				maybe_serialize( $expected )
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( 1 === $updated ) {
+			wp_cache_delete( self::OPTION_NAME, 'options' );
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/inc/Api/Flows/FlowScheduling.php
+++ b/inc/Api/Flows/FlowScheduling.php
@@ -75,7 +75,7 @@ class FlowScheduling {
 		}
 
 		// Verify AS action is actually pending.
-		if ( $flow_id > 0 && ! RecurringScheduler::isScheduled( self::FLOW_HOOK, array( $flow_id ) ) ) {
+		if ( $flow_id > 0 && ! RecurringScheduler::hasCoverage( self::FLOW_HOOK, array( $flow_id ) ) ) {
 			return false;
 		}
 

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -42,7 +42,7 @@ class FlowsCommand extends BaseCommand {
 	 * ## OPTIONS
 	 *
 	 * [<args>...]
-	 * : Subcommand and arguments. Accepts: list [pipeline_id], get <flow_id>, run <flow_id>, create, delete <flow_id>, update <flow_id>.
+	 * : Subcommand and arguments. Accepts: list [pipeline_id], get <flow_id>, run <flow_id>, create, delete <flow_id>, update <flow_id>, reconcile-schedules.
 	 *
 	 * [--handler=<slug>]
 	 * : Filter flows using this handler slug (any step that uses this handler).
@@ -161,6 +161,12 @@ class FlowsCommand extends BaseCommand {
 	 *   set-user-message, handler-config) and prints a "[dry-run] would update
 	 *   ..." preview while making ZERO database writes.
 	 *
+	 * [--apply]
+	 * : Repair missing schedules for reconcile-schedules. Without this flag the command is a dry-run.
+	 *
+	 * [--spread-hours=<hours>]
+	 * : Explicit first-run distribution window for reconcile-schedules (1-24).
+	 *
 	 * [--pipeline=<id>]
 	 * : Pipeline ID for pause/resume scoping.
 	 *
@@ -269,12 +275,21 @@ class FlowsCommand extends BaseCommand {
  *     wp datamachine flows reassign --from-agent=1 --to-agent=events-bot
  *
  *     # Dry-run reassign
- *     wp datamachine flows reassign --where-null --to-agent=events-bot --dry-run
+	 *     wp datamachine flows reassign --where-null --to-agent=events-bot --dry-run
+	 *
+	 *     # Audit or repair recurring schedule coverage
+	 *     wp datamachine flows reconcile-schedules --format=json
+	 *     wp datamachine flows reconcile-schedules --apply --spread-hours=24
  *
 	 */
 	public function __invoke( array $args, array $assoc_args ): void {
 		$flow_id     = null;
 		$pipeline_id = null;
+
+		if ( ! empty( $args ) && 'reconcile-schedules' === $args[0] ) {
+			$this->reconcileSchedules( $assoc_args );
+			return;
+		}
 
 		// Handle 'create' subcommand: `flows create --pipeline_id=3 --name="Test"`.
 		if ( ! empty( $args ) && 'create' === $args[0] ) {
@@ -501,6 +516,74 @@ class FlowsCommand extends BaseCommand {
 		$this->format_items( $items, $this->default_fields, $assoc_args, 'id' );
 		$this->output_pagination( $offset, count( $flows ), $total, $format, 'flows' );
 		$this->outputFilters( $result['filters_applied'] ?? array(), $format );
+	}
+
+	/**
+	 * Audit and optionally repair recurring flow schedule coverage.
+	 *
+	 * @param array $assoc_args WP-CLI arguments.
+	 * @return void
+	 */
+	private function reconcileSchedules( array $assoc_args ): void {
+		$format = (string) ( $assoc_args['format'] ?? 'table' );
+		if ( ! in_array( $format, array( 'table', 'json' ), true ) ) {
+			WP_CLI::error( 'reconcile-schedules supports --format=table or --format=json.' );
+			return;
+		}
+
+		$spread_hours = isset( $assoc_args['spread-hours'] ) ? (int) $assoc_args['spread-hours'] : null;
+		if ( null !== $spread_hours && ( $spread_hours < 1 || $spread_hours > 24 ) ) {
+			WP_CLI::error( '--spread-hours must be between 1 and 24.' );
+			return;
+		}
+
+		$ability = wp_get_ability( 'datamachine/reconcile-flow-schedules' );
+		$result  = $ability->execute(
+			array(
+				'apply'        => isset( $assoc_args['apply'] ),
+				'spread_hours' => $spread_hours,
+			)
+		);
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( (string) wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			if ( empty( $result['success'] ) || (int) ( $result['invalid'] ?? 0 ) > 0 ) {
+				WP_CLI::halt( 1 );
+			}
+			return;
+		}
+
+		if ( empty( $result['success'] ) && isset( $result['error'] ) ) {
+			WP_CLI::error( (string) $result['error'], false );
+			WP_CLI::halt( 1 );
+			return;
+		}
+
+		WP_CLI::log( ! empty( $result['applied'] ) ? 'Mode: apply' : 'Mode: dry-run' );
+		WP_CLI::log(
+			sprintf(
+				'Eligible: %d | Covered: %d | Missing: %d | Blocked: %d | Invalid: %d | Repaired: %d | Failed: %d | Spread: %dh',
+				(int) ( $result['eligible'] ?? 0 ),
+				(int) ( $result['covered'] ?? 0 ),
+				(int) ( $result['missing'] ?? 0 ),
+				(int) ( $result['blocked'] ?? 0 ),
+				(int) ( $result['invalid'] ?? 0 ),
+				(int) ( $result['repaired'] ?? 0 ),
+				(int) ( $result['failed'] ?? 0 ),
+				(int) ( $result['distribution_window_hours'] ?? 1 )
+			)
+		);
+
+		$details = $result['details'] ?? array();
+		if ( ! empty( $details ) ) {
+			WP_CLI\Utils\format_items( 'table', $details, array( 'flow_id', 'flow_name', 'interval', 'status', 'error' ) );
+		}
+		if ( ! empty( $result['details_truncated'] ) ) {
+			WP_CLI::warning( 'Detail output was truncated; use summary counts to assess the full fleet.' );
+		}
+		if ( empty( $result['success'] ) || (int) ( $result['failed'] ?? 0 ) > 0 || (int) ( $result['invalid'] ?? 0 ) > 0 ) {
+			WP_CLI::halt( 1 );
+		}
 	}
 
 	/**

--- a/inc/Cli/Commands/SystemCommand.php
+++ b/inc/Cli/Commands/SystemCommand.php
@@ -132,6 +132,18 @@ class SystemCommand extends BaseCommand {
 					WP_CLI::log( sprintf( '  Daily memory:   last attempted %s GMT', $daily_memory['last_attempt_gmt'] ) );
 				}
 			}
+			if ( isset( $check_result['flow_schedule_coverage'] ) && is_array( $check_result['flow_schedule_coverage'] ) ) {
+				$coverage = $check_result['flow_schedule_coverage'];
+				WP_CLI::log(
+					sprintf(
+						'  Flow schedules: %d covered, %d missing, %d blocked, %d invalid',
+						(int) ( $coverage['covered'] ?? 0 ),
+						(int) ( $coverage['remaining_missing'] ?? 0 ),
+						(int) ( $coverage['blocked'] ?? 0 ),
+						(int) ( $coverage['invalid'] ?? 0 )
+					)
+				);
+			}
 			if ( ! empty( $check_result['rejected_schedules'] ) && is_array( $check_result['rejected_schedules'] ) ) {
 				WP_CLI::log( sprintf( '  Rejected schedules: %d (rejected every tick, never running)', count( $check_result['rejected_schedules'] ) ) );
 				foreach ( $check_result['rejected_schedules'] as $rejected ) {

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -437,6 +437,33 @@ class Flows extends BaseRepository {
 	}
 
 	/**
+	 * Get the minimal persisted fields needed to audit schedule coverage.
+	 *
+	 * @return array Flow schedule definitions ordered by flow ID.
+	 */
+	public function get_flow_schedules(): array {
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Fresh operational coverage must be read from Data Machine's owned table.
+		$flows = $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				'SELECT flow_id, flow_name, scheduling_config FROM %i ORDER BY flow_id ASC',
+				$this->table_name
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( ! is_array( $flows ) ) {
+			return array();
+		}
+
+		foreach ( $flows as &$flow ) {
+			$flow['scheduling_config'] = json_decode( $flow['scheduling_config'], true ) ?? array();
+		}
+
+		return $flows;
+	}
+
+	/**
 	 * Get paginated flows for a pipeline
 	 *
 	 * @param int $pipeline_id Pipeline ID

--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -46,6 +46,11 @@ class RecurringScheduler {
 	public const MAX_STAGGER_SECONDS = 3600;
 
 	/**
+	 * Maximum explicit fleet distribution window in seconds.
+	 */
+	public const MAX_DISTRIBUTION_WINDOW_SECONDS = 86400;
+
+	/**
 	 * Ensure an Action Scheduler schedule matches the requested configuration.
 	 *
 	 * This is the single entry point for all recurring/cron/one-time scheduling
@@ -83,6 +88,10 @@ class RecurringScheduler {
 	 *                                            takes precedence over stagger.
 	 *                                            Default: time() + stagger offset.
 	 *     @type string      $group               AS group. Default self::GROUP.
+	 *     @type int|null    $distribution_window_seconds Explicit first-run distribution
+	 *                                            window for fleet recovery. Capped at
+	 *                                            24 hours. Ordinary scheduling ignores
+	 *                                            this and retains the one-hour stagger.
 	 *     @type bool        $force_reschedule    When true, replace existing matching
 	 *                                            pending actions. Default false.
 	 * }
@@ -175,12 +184,12 @@ class RecurringScheduler {
 					array( 'status' => 400 )
 				);
 			}
-			return self::scheduleCron( $hook, $args, $cron_expression, $group, ! empty( $options['force_reschedule'] ) );
+			return self::scheduleCron( $hook, $args, $cron_expression, $group, $options );
 		}
 
 		// Auto-detect cron expression passed as the interval value.
 		if ( self::looksLikeCronExpression( $interval ) ) {
-			return self::scheduleCron( $hook, $args, $interval, $group );
+			return self::scheduleCron( $hook, $args, $interval, $group, $options );
 		}
 
 		// Recurring by interval key (with alias resolution).
@@ -222,10 +231,18 @@ class RecurringScheduler {
 		if ( isset( $options['first_run_timestamp'] ) ) {
 			$first_run_time = (int) $options['first_run_timestamp'];
 		} else {
-			$stagger_seed   = (int) ( $options['stagger_seed'] ?? 0 );
-			$stagger_offset = $stagger_seed > 0
-				? self::calculateStaggerOffset( $stagger_seed, (int) $interval_seconds )
-				: 0;
+			$stagger_seed        = (int) ( $options['stagger_seed'] ?? 0 );
+			$distribution_window = min(
+				self::MAX_DISTRIBUTION_WINDOW_SECONDS,
+				max( 0, (int) ( $options['distribution_window_seconds'] ?? 0 ) )
+			);
+			if ( $stagger_seed > 0 && $distribution_window > 0 ) {
+				$stagger_offset = self::calculateDistributionOffset( $stagger_seed, $distribution_window );
+			} else {
+				$stagger_offset = $stagger_seed > 0
+					? self::calculateStaggerOffset( $stagger_seed, (int) $interval_seconds )
+					: 0;
+			}
 			$first_run_time = time() + $stagger_offset;
 		}
 		// Action Scheduler unique actions are keyed by hook and group, not args.
@@ -324,6 +341,48 @@ class RecurringScheduler {
 		}
 
 		return false !== as_next_scheduled_action( $hook, $args, $group );
+	}
+
+	/**
+	 * Check whether a pending or in-progress action covers a schedule slot.
+	 *
+	 * @param string $hook  Hook name.
+	 * @param array  $args  Action args (signature).
+	 * @param string $group AS group.
+	 * @return bool True when matching work is pending or currently running.
+	 */
+	public static function hasCoverage( string $hook, array $args, string $group = self::GROUP ): bool {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) || ! self::isReady() ) {
+			return false;
+		}
+
+		foreach ( array( 'pending', 'in-progress' ) as $status ) {
+			$actions = as_get_scheduled_actions(
+				array(
+					'hook'     => $hook,
+					'args'     => $args,
+					'group'    => $group,
+					'status'   => $status,
+					'per_page' => 1,
+				),
+				'ids'
+			);
+
+			if ( ! empty( $actions ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check whether Action Scheduler can safely answer datastore queries.
+	 *
+	 * @return bool True when Action Scheduler is initialized.
+	 */
+	public static function isReady(): bool {
+		return self::isActionSchedulerDataStoreReady();
 	}
 
 	/**
@@ -538,6 +597,25 @@ class RecurringScheduler {
 	}
 
 	/**
+	 * Calculate an offset inside an explicit fleet distribution window.
+	 *
+	 * Unlike ordinary staggering, this is not bounded by recurrence interval;
+	 * callers opt into it only when recovering a fleet of missing schedules.
+	 *
+	 * @param int $seed           Stable schedule seed.
+	 * @param int $window_seconds Requested distribution window in seconds.
+	 * @return int Offset from zero up to the capped window.
+	 */
+	public static function calculateDistributionOffset( int $seed, int $window_seconds ): int {
+		$window_seconds = min( self::MAX_DISTRIBUTION_WINDOW_SECONDS, max( 0, $window_seconds ) );
+		if ( $window_seconds <= 0 ) {
+			return 0;
+		}
+
+		return absint( crc32( 'datamachine_distribution_' . $seed ) ) % $window_seconds;
+	}
+
+	/**
 	 * Validate a cron expression string.
 	 *
 	 * Uses Action Scheduler's bundled CronExpression library — no external
@@ -648,9 +726,11 @@ class RecurringScheduler {
 	 * @param array  $args            Action args.
 	 * @param string $cron_expression Cron expression.
 	 * @param string $group           AS group.
+	 * @param array  $options         Scheduling options.
 	 * @return array{interval:'cron',scheduled:true,cron_expression:string,first_run?:string|null,action_id?:int,preserved?:bool}|\WP_Error
 	 */
-	private static function scheduleCron( string $hook, array $args, string $cron_expression, string $group, bool $force_reschedule = false ) {
+	private static function scheduleCron( string $hook, array $args, string $cron_expression, string $group, array $options = array() ) {
+		$force_reschedule = ! empty( $options['force_reschedule'] );
 		if ( ! self::isValidCronExpression( $cron_expression ) ) {
 			return self::error(
 				'invalid_cron_expression',
@@ -687,7 +767,7 @@ class RecurringScheduler {
 			// single chain instead of preserving the duplicates.
 			if ( self::countMatchingPendingActions( $hook, $args, $group ) > 1 ) {
 				self::unschedule( $hook, $args, $group );
-				$action_id = as_schedule_cron_action( time(), $cron_expression, $hook, $args, $group, $unique );
+				$action_id = as_schedule_cron_action( self::cronStartTimestamp( $options ), $cron_expression, $hook, $args, $group, $unique );
 
 				if ( ! self::isScheduled( $hook, $args, $group ) ) {
 					return self::error(
@@ -718,7 +798,7 @@ class RecurringScheduler {
 			self::unschedule( $hook, $args, $group );
 		}
 
-		$action_id = as_schedule_cron_action( time(), $cron_expression, $hook, $args, $group, $unique );
+		$action_id = as_schedule_cron_action( self::cronStartTimestamp( $options ), $cron_expression, $hook, $args, $group, $unique );
 
 		if ( ! self::isScheduled( $hook, $args, $group ) ) {
 			return self::error(
@@ -744,5 +824,25 @@ class RecurringScheduler {
 			'first_run'       => $next_run,
 			'action_id'       => $action_id,
 		);
+	}
+
+	/**
+	 * Resolve a cron chain's initial timing without changing ordinary behavior.
+	 *
+	 * @param array $options Scheduling options.
+	 * @return int Cron schedule start timestamp.
+	 */
+	private static function cronStartTimestamp( array $options ): int {
+		if ( isset( $options['first_run_timestamp'] ) ) {
+			return (int) $options['first_run_timestamp'];
+		}
+
+		$seed   = (int) ( $options['stagger_seed'] ?? 0 );
+		$window = (int) ( $options['distribution_window_seconds'] ?? 0 );
+		if ( $seed > 0 && $window > 0 ) {
+			return time() + self::calculateDistributionOffset( $seed, $window );
+		}
+
+		return time();
 	}
 }

--- a/inc/migrations/flows.php
+++ b/inc/migrations/flows.php
@@ -1,77 +1,79 @@
 <?php
-// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Data Machine owns custom operational tables and these paths require fresh runtime state or one-time schema mutation.
 /**
- * Data Machine — Flow activation helpers.
+ * Data Machine flow schedule repair lifecycle.
  *
- * Re-schedules flows with non-manual scheduling on plugin activation.
+ * Activation and deploy-time migrations only mark the current site. The repair
+ * runs after Action Scheduler initializes so datastore reads and writes are safe.
  *
  * @package DataMachine
- * @since 0.60.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Re-schedule all flows with non-manual scheduling on plugin activation.
+ * Persist a per-site marker requesting flow schedule reconciliation.
  *
- * Ensures scheduled flows resume after plugin reactivation.
+ * @return void
  */
-function datamachine_activate_scheduled_flows() {
-	if ( ! function_exists( 'as_schedule_recurring_action' ) ) {
+function datamachine_mark_flow_schedule_reconciliation(): void {
+	update_option(
+		'datamachine_flow_schedule_reconciliation_pending',
+		array(
+			'marked_at' => time(),
+			'reason'    => 'activation_or_deploy',
+		),
+		false
+	);
+}
+
+/**
+ * Repair marked flow schedules once Action Scheduler is ready.
+ *
+ * The marker is retained after transient failures so a later request can retry.
+ * Paused, manual, one-time, and malformed schedule definitions are not repaired;
+ * malformed definitions are reported without making the marker permanent.
+ *
+ * @return void
+ */
+function datamachine_reconcile_marked_flow_schedules(): void {
+	if ( ! get_option( 'datamachine_flow_schedule_reconciliation_pending', false ) ) {
 		return;
 	}
 
-	global $wpdb;
-	$table_name = $wpdb->prefix . 'datamachine_flows';
-
-	// Check if table exists (fresh install won't have flows yet)
-	if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) !== $table_name ) {
+	if ( ! \DataMachine\Engine\Tasks\RecurringScheduler::isReady() ) {
 		return;
 	}
 
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-	$flows = $wpdb->get_results( $wpdb->prepare( 'SELECT flow_id, scheduling_config FROM %i', $table_name ), ARRAY_A );
-
-	if ( empty( $flows ) ) {
-		return;
-	}
-
-	$scheduled_count = 0;
-
-	foreach ( $flows as $flow ) {
-		$flow_id           = (int) $flow['flow_id'];
-		$scheduling_config = json_decode( $flow['scheduling_config'], true );
-
-		if ( empty( $scheduling_config ) || empty( $scheduling_config['interval'] ) ) {
-			continue;
-		}
-
-		$interval = $scheduling_config['interval'];
-
-		if ( 'manual' === $interval ) {
-			continue;
-		}
-
-		// Delegate to FlowScheduling — single source of truth for scheduling
-		// logic including stagger offsets, interval validation, and AS registration.
-		$result = \DataMachine\Api\Flows\FlowScheduling::handle_scheduling_update(
-			$flow_id,
-			$scheduling_config
-		);
-
-		if ( ! is_wp_error( $result ) ) {
-			++$scheduled_count;
-		}
-	}
-
-	if ( $scheduled_count > 0 ) {
+	$result = ( new \DataMachine\Api\Flows\FlowScheduleReconciler() )->reconcile( true );
+	if ( empty( $result['success'] ) && ! empty( $result['transient'] ) ) {
 		do_action(
 			'datamachine_log',
-			'info',
-			'Flows re-scheduled on plugin activation',
-			array(
-				'scheduled_count' => $scheduled_count,
-			)
+			'error',
+			'Deferred flow schedule reconciliation failed; marker retained',
+			array( 'result' => $result )
 		);
+		return;
 	}
+
+	delete_option( 'datamachine_flow_schedule_reconciliation_pending' );
+	if ( empty( $result['success'] ) ) {
+		do_action(
+			'datamachine_log',
+			'error',
+			'Deferred flow schedule reconciliation failed permanently; marker cleared',
+			array( 'result' => $result )
+		);
+		return;
+	}
+	do_action(
+		'datamachine_log',
+		'info',
+		'Deferred flow schedule reconciliation completed',
+		array(
+			'eligible' => (int) ( $result['eligible'] ?? 0 ),
+			'repaired' => (int) ( $result['repaired'] ?? 0 ),
+		)
+	);
 }
+
+add_action( 'action_scheduler_init', 'datamachine_reconcile_marked_flow_schedules', 20 );

--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -76,6 +76,9 @@ function datamachine_maybe_run_deferred_migrations(): void {
 
 	// Mismatch: a deploy bumped the constant past the persisted option.
 	datamachine_run_schema_migrations();
+	if ( function_exists( 'datamachine_mark_flow_schedule_reconciliation' ) ) {
+		datamachine_mark_flow_schedule_reconciliation();
+	}
 	update_option( 'datamachine_db_version', DATAMACHINE_VERSION, true );
 }
 

--- a/tests/Unit/Abilities/AllAbilitiesRegisteredTest.php
+++ b/tests/Unit/Abilities/AllAbilitiesRegisteredTest.php
@@ -24,12 +24,13 @@ class AllAbilitiesRegisteredTest extends WP_UnitTestCase {
 	 */
 	public function test_all_data_machine_abilities_registered(): void {
 		$expected = array(
-			// Flow abilities (5)
+			// Flow abilities (6)
 			'datamachine/get-flows',
 			'datamachine/create-flow',
 			'datamachine/delete-flow',
 			'datamachine/update-flow',
 			'datamachine/duplicate-flow',
+			'datamachine/reconcile-flow-schedules',
 			// AuthAbilities (3)
 			'datamachine/get-auth-status',
 			'datamachine/disconnect-auth',

--- a/tests/Unit/Api/Flows/FlowScheduleReconcilerTest.php
+++ b/tests/Unit/Api/Flows/FlowScheduleReconcilerTest.php
@@ -1,0 +1,342 @@
+<?php
+/**
+ * Flow schedule reconciliation tests.
+ *
+ * @package DataMachine\Tests\Unit\Api\Flows
+ */
+
+namespace DataMachine\Tests\Unit\Api\Flows;
+
+use DataMachine\Api\Flows\FlowScheduleReconciler;
+use DataMachine\Api\Flows\FlowScheduleReconciliationLock;
+use DataMachine\Api\Flows\FlowScheduling;
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Engine\Tasks\RecurringScheduler;
+use WP_UnitTestCase;
+
+class FlowScheduleReconcilerTest extends WP_UnitTestCase {
+
+	private int $pipeline_id;
+	private Flows $flows;
+	private array $flow_ids = array();
+
+	public function set_up(): void {
+		parent::set_up();
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$pipeline         = wp_get_ability( 'datamachine/create-pipeline' )->execute( array( 'pipeline_name' => 'Schedule reconciliation' ) );
+		$this->pipeline_id = (int) $pipeline['pipeline_id'];
+		$this->flows       = new Flows();
+	}
+
+	public function tear_down(): void {
+		foreach ( $this->flow_ids as $flow_id ) {
+			RecurringScheduler::unschedule( FlowScheduling::FLOW_HOOK, array( $flow_id ) );
+		}
+		delete_option( 'datamachine_flow_schedule_reconciliation_lock' );
+
+		parent::tear_down();
+	}
+
+	public function test_dry_run_excludes_non_recurring_and_paused_flows(): void {
+		$hourly = $this->create_flow( 'Hourly', array( 'interval' => 'hourly' ) );
+		$cron   = $this->create_flow(
+			'Cron',
+			array(
+				'interval'        => 'cron',
+				'cron_expression' => '0 * * * *',
+			)
+		);
+		$this->create_flow( 'Manual', array( 'interval' => 'manual' ) );
+		$this->create_flow( 'Missing', array() );
+		$this->create_flow( 'One time', array( 'interval' => 'one_time', 'timestamp' => time() + HOUR_IN_SECONDS ) );
+		$this->create_flow( 'Paused', array( 'interval' => 'daily', 'enabled' => false ) );
+
+		$result = ( new FlowScheduleReconciler( $this->flows ) )->reconcile();
+
+		$this->assertTrue( $result['success'] );
+		$this->assertFalse( $result['applied'] );
+		$this->assertSame( 2, $result['eligible'] );
+		$this->assertSame( 2, $result['missing'] );
+		$this->assertSame( 4, $result['excluded'] );
+		$this->assertFalse( RecurringScheduler::hasCoverage( FlowScheduling::FLOW_HOOK, array( $hourly ) ) );
+		$this->assertFalse( RecurringScheduler::hasCoverage( FlowScheduling::FLOW_HOOK, array( $cron ) ) );
+	}
+
+	public function test_apply_repairs_missing_schedules_idempotently(): void {
+		$hourly = $this->create_flow( 'Hourly', array( 'interval' => 'hourly' ) );
+		$cron   = $this->create_flow(
+			'Cron',
+			array(
+				'interval'        => 'cron',
+				'cron_expression' => '15 * * * *',
+			)
+		);
+
+		$first = ( new FlowScheduleReconciler( $this->flows ) )->reconcile( true, 12 );
+
+		$this->assertTrue( $first['success'] );
+		$this->assertSame( 2, $first['repaired'] );
+		$this->assertSame( 0, $first['remaining_missing'] );
+		$this->assertSame( 12, $first['distribution_window_hours'] );
+		$this->assertTrue( RecurringScheduler::hasCoverage( FlowScheduling::FLOW_HOOK, array( $hourly ) ) );
+		$this->assertTrue( RecurringScheduler::hasCoverage( FlowScheduling::FLOW_HOOK, array( $cron ) ) );
+
+		$second = ( new FlowScheduleReconciler( $this->flows ) )->reconcile( true );
+		$this->assertTrue( $second['success'] );
+		$this->assertSame( 0, $second['missing'] );
+		$this->assertSame( 0, $second['repaired'] );
+		$this->assertSame( 2, $second['covered'] );
+	}
+
+	public function test_in_progress_action_counts_as_coverage(): void {
+		global $wpdb;
+
+		$flow_id   = $this->create_flow( 'Running', array( 'interval' => 'hourly' ) );
+		$action_id = as_schedule_recurring_action(
+			time() + 60,
+			HOUR_IN_SECONDS,
+			FlowScheduling::FLOW_HOOK,
+			array( $flow_id ),
+			RecurringScheduler::GROUP,
+			false
+		);
+
+		$wpdb->update(
+			$wpdb->actionscheduler_actions,
+			array(
+				'status'           => 'in-progress',
+				'last_attempt_gmt' => gmdate( 'Y-m-d H:i:s' ),
+			),
+			array( 'action_id' => $action_id ),
+			array( '%s', '%s' ),
+			array( '%d' )
+		);
+
+		$result = ( new FlowScheduleReconciler( $this->flows ) )->reconcile();
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 1, $result['covered'] );
+		$this->assertSame( 0, $result['missing'] );
+	}
+
+	public function test_stale_in_progress_action_does_not_cover_schedule(): void {
+		global $wpdb;
+
+		$flow_id   = $this->create_flow( 'Stale running', array( 'interval' => 'hourly' ) );
+		$action_id = as_schedule_recurring_action(
+			time() + 60,
+			HOUR_IN_SECONDS,
+			FlowScheduling::FLOW_HOOK,
+			array( $flow_id ),
+			RecurringScheduler::GROUP,
+			false
+		);
+
+		$wpdb->update(
+			$wpdb->actionscheduler_actions,
+			array(
+				'status'           => 'in-progress',
+				'last_attempt_gmt' => gmdate( 'Y-m-d H:i:s', time() - 3 * HOUR_IN_SECONDS ),
+			),
+			array( 'action_id' => $action_id ),
+			array( '%s', '%s' ),
+			array( '%d' )
+		);
+
+		$result = ( new FlowScheduleReconciler( $this->flows ) )->reconcile();
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 0, $result['covered'] );
+		$this->assertSame( 1, $result['blocked'] );
+
+		$applied = ( new FlowScheduleReconciler( $this->flows ) )->reconcile( true );
+		$this->assertFalse( $applied['success'] );
+		$this->assertTrue( $applied['transient'] );
+		$this->assertSame( 1, $applied['blocked'] );
+		$this->assertSame( 0, $applied['repaired'] );
+		$this->assertFalse( RecurringScheduler::isScheduled( FlowScheduling::FLOW_HOOK, array( $flow_id ) ) );
+
+		$second = ( new FlowScheduleReconciler( $this->flows ) )->reconcile();
+		$this->assertSame( 1, $second['blocked'] );
+	}
+
+	public function test_fresh_mismatched_in_progress_action_blocks_apply_without_successor(): void {
+		global $wpdb;
+
+		$flow_id   = $this->create_flow( 'Fresh mismatched owner', array( 'interval' => 'daily' ) );
+		$action_id = as_schedule_recurring_action( time() + 60, HOUR_IN_SECONDS, FlowScheduling::FLOW_HOOK, array( $flow_id ), RecurringScheduler::GROUP, false );
+		$wpdb->update(
+			$wpdb->actionscheduler_actions,
+			array(
+				'status'           => 'in-progress',
+				'last_attempt_gmt' => gmdate( 'Y-m-d H:i:s' ),
+			),
+			array( 'action_id' => $action_id ),
+			array( '%s', '%s' ),
+			array( '%d' )
+		);
+
+		$result = ( new FlowScheduleReconciler( $this->flows ) )->reconcile( true );
+		$this->assertFalse( $result['success'] );
+		$this->assertTrue( $result['transient'] );
+		$this->assertSame( 1, $result['blocked'] );
+		$this->assertSame( 0, $result['repaired'] );
+		$this->assertFalse( RecurringScheduler::isScheduled( FlowScheduling::FLOW_HOOK, array( $flow_id ) ) );
+	}
+
+	public function test_fresh_in_progress_plus_pending_action_blocks_apply_without_changes(): void {
+		global $wpdb;
+
+		$flow_id = $this->create_flow( 'Fresh mixed owner', array( 'interval' => 'hourly' ) );
+		$running = as_schedule_recurring_action( time() + 60, HOUR_IN_SECONDS, FlowScheduling::FLOW_HOOK, array( $flow_id ), RecurringScheduler::GROUP, false );
+		as_schedule_recurring_action( time() + 120, HOUR_IN_SECONDS, FlowScheduling::FLOW_HOOK, array( $flow_id ), RecurringScheduler::GROUP, false );
+		$wpdb->update(
+			$wpdb->actionscheduler_actions,
+			array(
+				'status'           => 'in-progress',
+				'last_attempt_gmt' => gmdate( 'Y-m-d H:i:s' ),
+			),
+			array( 'action_id' => $running ),
+			array( '%s', '%s' ),
+			array( '%d' )
+		);
+
+		$before = as_get_scheduled_actions(
+			array(
+				'hook'     => FlowScheduling::FLOW_HOOK,
+				'args'     => array( $flow_id ),
+				'group'    => RecurringScheduler::GROUP,
+				'status'   => array( 'pending', 'in-progress' ),
+				'per_page' => 10,
+			),
+			'ids'
+		);
+		$result = ( new FlowScheduleReconciler( $this->flows ) )->reconcile( true );
+		$after  = as_get_scheduled_actions(
+			array(
+				'hook'     => FlowScheduling::FLOW_HOOK,
+				'args'     => array( $flow_id ),
+				'group'    => RecurringScheduler::GROUP,
+				'status'   => array( 'pending', 'in-progress' ),
+				'per_page' => 10,
+			),
+			'ids'
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertTrue( $result['transient'] );
+		$this->assertSame( 1, $result['blocked'] );
+		$this->assertSame( 0, $result['repaired'] );
+		$this->assertSame( $before, $after );
+	}
+
+	public function test_pending_action_with_wrong_interval_is_missing_and_repaired(): void {
+		$flow_id = $this->create_flow( 'Changed interval', array( 'interval' => 'daily' ) );
+		as_schedule_recurring_action(
+			time() + 60,
+			HOUR_IN_SECONDS,
+			FlowScheduling::FLOW_HOOK,
+			array( $flow_id ),
+			RecurringScheduler::GROUP,
+			false
+		);
+
+		$dry_run = ( new FlowScheduleReconciler( $this->flows ) )->reconcile();
+		$this->assertSame( 1, $dry_run['missing'] );
+
+		$applied = ( new FlowScheduleReconciler( $this->flows ) )->reconcile( true );
+		$this->assertTrue( $applied['success'] );
+		$this->assertSame( 1, $applied['repaired'] );
+
+		$verified = ( new FlowScheduleReconciler( $this->flows ) )->reconcile();
+		$this->assertSame( 1, $verified['covered'] );
+		$this->assertSame( 0, $verified['missing'] );
+	}
+
+	public function test_pending_cron_action_with_wrong_expression_is_missing(): void {
+		$flow_id = $this->create_flow(
+			'Changed cron',
+			array(
+				'interval'        => 'cron',
+				'cron_expression' => '15 * * * *',
+			)
+		);
+		as_schedule_cron_action(
+			time(),
+			'0 * * * *',
+			FlowScheduling::FLOW_HOOK,
+			array( $flow_id ),
+			RecurringScheduler::GROUP,
+			false
+		);
+
+		$result = ( new FlowScheduleReconciler( $this->flows ) )->reconcile();
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 1, $result['missing'] );
+		$this->assertSame( 0, $result['covered'] );
+	}
+
+	public function test_duplicate_pending_actions_are_missing_and_apply_collapses_them(): void {
+		$flow_id = $this->create_flow( 'Duplicate actions', array( 'interval' => 'hourly' ) );
+		as_schedule_recurring_action( time() + 60, HOUR_IN_SECONDS, FlowScheduling::FLOW_HOOK, array( $flow_id ), RecurringScheduler::GROUP, false );
+		as_schedule_recurring_action( time() + 120, HOUR_IN_SECONDS, FlowScheduling::FLOW_HOOK, array( $flow_id ), RecurringScheduler::GROUP, false );
+
+		$dry_run = ( new FlowScheduleReconciler( $this->flows ) )->reconcile();
+		$this->assertSame( 1, $dry_run['missing'] );
+
+		$applied = ( new FlowScheduleReconciler( $this->flows ) )->reconcile( true );
+		$this->assertTrue( $applied['success'] );
+		$this->assertSame( 1, $applied['repaired'] );
+		$action_ids = as_get_scheduled_actions(
+			array(
+				'hook'     => FlowScheduling::FLOW_HOOK,
+				'args'     => array( $flow_id ),
+				'group'    => RecurringScheduler::GROUP,
+				'status'   => 'pending',
+				'per_page' => 10,
+			),
+			'ids'
+		);
+		$this->assertCount( 1, $action_ids );
+	}
+
+	public function test_invalid_definitions_are_reported_without_failing_apply(): void {
+		$this->create_flow( 'Broken cron', array( 'interval' => 'cron' ) );
+		$this->create_flow( 'Unknown interval', array( 'interval' => 'sometimes' ) );
+
+		$result = ( new FlowScheduleReconciler( $this->flows ) )->reconcile( true );
+		$this->assertTrue( $result['success'] );
+		$this->assertFalse( $result['transient'] );
+		$this->assertSame( 2, $result['invalid'] );
+		$this->assertSame( 0, $result['eligible'] );
+		$this->assertSame( 0, $result['repaired'] );
+	}
+
+	public function test_apply_returns_transient_failure_while_lock_is_held(): void {
+		$this->create_flow( 'Locked', array( 'interval' => 'hourly' ) );
+		$token = FlowScheduleReconciliationLock::acquire();
+		$this->assertIsString( $token );
+
+		$result = ( new FlowScheduleReconciler( $this->flows ) )->reconcile( true );
+		$this->assertFalse( $result['success'] );
+		$this->assertTrue( $result['transient'] );
+		$this->assertSame( 'flow_schedule_reconciliation_locked', $result['code'] );
+
+		$this->assertTrue( FlowScheduleReconciliationLock::release( $token ) );
+	}
+
+	private function create_flow( string $name, array $scheduling ): int {
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute(
+			array(
+				'pipeline_id'      => $this->pipeline_id,
+				'flow_name'        => $name,
+				'scheduling_config' => array( 'interval' => 'manual' ),
+			)
+		);
+
+		$flow_id = (int) $result['flow_id'];
+		$this->flows->update_flow_scheduling( $flow_id, $scheduling );
+		$this->flow_ids[] = $flow_id;
+
+		return $flow_id;
+	}
+}

--- a/tests/Unit/Api/Flows/FlowScheduleReconciliationLockTest.php
+++ b/tests/Unit/Api/Flows/FlowScheduleReconciliationLockTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Flow schedule reconciliation lock tests.
+ *
+ * @package DataMachine\Tests\Unit\Api\Flows
+ */
+
+namespace DataMachine\Tests\Unit\Api\Flows;
+
+use DataMachine\Api\Flows\FlowScheduleReconciliationLock;
+use WP_UnitTestCase;
+
+class FlowScheduleReconciliationLockTest extends WP_UnitTestCase {
+
+	private const OPTION_NAME = 'datamachine_flow_schedule_reconciliation_lock';
+
+	public function tear_down(): void {
+		delete_option( self::OPTION_NAME );
+		parent::tear_down();
+	}
+
+	public function test_concurrent_acquire_is_rejected_and_owner_can_release(): void {
+		$token = FlowScheduleReconciliationLock::acquire();
+		$this->assertIsString( $token );
+
+		$second = FlowScheduleReconciliationLock::acquire();
+		$this->assertWPError( $second );
+		$this->assertSame( 'flow_schedule_reconciliation_locked', $second->get_error_code() );
+		$this->assertTrue( FlowScheduleReconciliationLock::release( $token ) );
+		$this->assertFalse( get_option( self::OPTION_NAME, false ) );
+	}
+
+	public function test_stale_lock_takeover_is_atomic_and_release_is_token_safe(): void {
+		$old_token = FlowScheduleReconciliationLock::acquire();
+		$this->assertIsString( $old_token );
+
+		$stale                = get_option( self::OPTION_NAME );
+		$stale['acquired_at'] = time() - HOUR_IN_SECONDS;
+		update_option( self::OPTION_NAME, $stale, false );
+
+		$new_token = FlowScheduleReconciliationLock::acquire();
+		$this->assertIsString( $new_token );
+		$this->assertNotSame( $old_token, $new_token );
+		$this->assertFalse( FlowScheduleReconciliationLock::release( $old_token ) );
+		$this->assertTrue( FlowScheduleReconciliationLock::release( $new_token ) );
+	}
+
+	public function test_refresh_extends_only_the_owned_lease(): void {
+		$token = FlowScheduleReconciliationLock::acquire();
+		$this->assertIsString( $token );
+
+		$stale                = get_option( self::OPTION_NAME );
+		$stale['acquired_at'] = time() - HOUR_IN_SECONDS;
+		update_option( self::OPTION_NAME, $stale, false );
+
+		$this->assertFalse( FlowScheduleReconciliationLock::refresh( 'wrong-token' ) );
+		$this->assertTrue( FlowScheduleReconciliationLock::refresh( $token ) );
+		$refreshed = get_option( self::OPTION_NAME );
+		$this->assertSame( $token, $refreshed['token'] );
+		$this->assertGreaterThan( time() - 5, (int) $refreshed['acquired_at'] );
+		$this->assertTrue( FlowScheduleReconciliationLock::release( $token ) );
+	}
+}

--- a/tests/Unit/Engine/RecurringSchedulerStaggerTest.php
+++ b/tests/Unit/Engine/RecurringSchedulerStaggerTest.php
@@ -77,4 +77,28 @@ class RecurringSchedulerStaggerTest extends WP_UnitTestCase {
 		$this->assertGreaterThanOrEqual( 0, $offset );
 		$this->assertLessThan( 60, $offset );
 	}
+
+	/**
+	 * Explicit fleet distribution can exceed the ordinary one-hour cap.
+	 */
+	public function test_distribution_window_is_distinct_from_ordinary_stagger(): void {
+		$offsets = array();
+		for ( $seed = 1; $seed <= 100; $seed++ ) {
+			$offsets[] = RecurringScheduler::calculateDistributionOffset( $seed, 24 * HOUR_IN_SECONDS );
+		}
+
+		$this->assertGreaterThan( RecurringScheduler::MAX_STAGGER_SECONDS, max( $offsets ) );
+		$this->assertLessThan( RecurringScheduler::MAX_DISTRIBUTION_WINDOW_SECONDS, max( $offsets ) );
+	}
+
+	/**
+	 * Explicit windows are capped at 24 hours.
+	 */
+	public function test_distribution_window_is_capped_at_24_hours(): void {
+		for ( $seed = 1; $seed <= 100; $seed++ ) {
+			$offset = RecurringScheduler::calculateDistributionOffset( $seed, 7 * DAY_IN_SECONDS );
+			$this->assertGreaterThanOrEqual( 0, $offset );
+			$this->assertLessThan( RecurringScheduler::MAX_DISTRIBUTION_WINDOW_SECONDS, $offset );
+		}
+	}
 }

--- a/tests/flow-abilities-proxy-removal-smoke.php
+++ b/tests/flow-abilities-proxy-removal-smoke.php
@@ -151,6 +151,7 @@ $expected_classes = array(
 	'DuplicateFlowAbility',
 	'PauseFlowAbility',
 	'ResumeFlowAbility',
+	'ReconcileFlowSchedulesAbility',
 	'QueueAbility',
 	'WebhookTriggerAbility',
 );

--- a/tests/flow-schedule-reconciler-smoke.php
+++ b/tests/flow-schedule-reconciler-smoke.php
@@ -1,0 +1,442 @@
+<?php
+/**
+ * Pure-PHP behavioral smoke tests for FlowScheduleReconciler.
+ *
+ * Run with: php tests/flow-schedule-reconciler-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core\Database\Flows {
+	class Flows {
+		public array $schedules = array();
+
+		public function get_flow_schedules(): array {
+			return $this->schedules;
+		}
+
+		public static function is_flow_enabled( array $scheduling ): bool {
+			return ! isset( $scheduling['enabled'] ) || false !== $scheduling['enabled'];
+		}
+	}
+}
+
+namespace DataMachine\Api\Flows {
+	class FlowScheduling {
+		public const FLOW_HOOK = 'datamachine_run_flow_now';
+	}
+
+	class FlowScheduleReconciliationLock {
+		public static int $refresh_count = 0;
+
+		public static function acquire(): string {
+			return 'test-lock';
+		}
+
+		public static function release( string $token ): bool {
+			return 'test-lock' === $token;
+		}
+
+		public static function refresh( string $token ): bool {
+			++self::$refresh_count;
+			return 'test-lock' === $token;
+		}
+	}
+}
+
+namespace DataMachine\Engine\Tasks {
+	class RecurringScheduler {
+		public const GROUP = 'data-machine';
+
+		public static bool $ready = true;
+		public static array $covered = array();
+		public static array $recurrences = array();
+		public static array $calls = array();
+		public static array $fail_ids = array();
+		public static array $statuses = array();
+		public static array $last_attempts = array();
+		public static array $duplicates = array();
+
+		public static function isReady(): bool {
+			return self::$ready;
+		}
+
+		public static function hasCoverage( string $hook, array $args ): bool {
+			unset( $hook );
+			return ! empty( self::$covered[ (int) $args[0] ] );
+		}
+
+		public static function isValidCronExpression( string $expression ): bool {
+			return str_contains( $expression, ' ' );
+		}
+
+		public static function looksLikeCronExpression( string $value ): bool {
+			return substr_count( trim( $value ), ' ' ) >= 4;
+		}
+
+		public static function resolveIntervalAlias( string $interval ): string {
+			return $interval;
+		}
+
+		public static function ensureSchedule( string $hook, array $args, ?string $interval, array $options = array() ) {
+			$flow_id            = (int) $args[0];
+			if ( ! empty( self::$fail_ids[ $flow_id ] ) ) {
+				return new \WP_Error( 'schedule_failed', 'Synthetic schedule failure.' );
+			}
+			self::$covered[ $flow_id ] = true;
+			self::$recurrences[ $flow_id ] = 'cron' === $interval
+				? (string) ( $options['cron_expression'] ?? '' )
+				: 3600;
+			self::$statuses[ $flow_id ] = 'pending';
+			self::$duplicates[ $flow_id ] = array();
+			self::$calls[]      = compact( 'hook', 'args', 'interval', 'options' );
+			return array(
+				'interval'  => $interval,
+				'scheduled' => true,
+			);
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ );
+	define( 'HOUR_IN_SECONDS', 3600 );
+	define( 'ARRAY_A', 'ARRAY_A' );
+
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '' ) {}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+
+	function apply_filters( string $hook, array $value ): array {
+		if ( 'datamachine_scheduler_intervals' === $hook ) {
+			return array(
+				'hourly' => array( 'seconds' => 3600 ),
+				'daily'  => array( 'seconds' => 86400 ),
+			);
+		}
+		return $value;
+	}
+
+	function maybe_unserialize( $value ) {
+		if ( ! is_string( $value ) ) {
+			return $value;
+		}
+		$decoded = @unserialize( $value );
+		return false === $decoded ? $value : $decoded;
+	}
+
+	class DatamachineFakeSchedule {
+		public function __construct( private int|string $recurrence ) {}
+
+		public function is_recurring(): bool {
+			return true;
+		}
+
+		public function get_recurrence(): int|string {
+			return $this->recurrence;
+		}
+	}
+
+	class DatamachineFakeAction {
+		public function __construct( private int $flow_id, private int|string $recurrence ) {}
+
+		public function get_args(): array {
+			return array( $this->flow_id );
+		}
+
+		public function get_schedule(): DatamachineFakeSchedule {
+			return new DatamachineFakeSchedule( $this->recurrence );
+		}
+	}
+
+	class DatamachineCoverageWpdb {
+		public string $actionscheduler_actions = 'wp_actionscheduler_actions';
+		public string $actionscheduler_groups  = 'wp_actionscheduler_groups';
+		public string $actionscheduler_claims  = 'wp_actionscheduler_claims';
+
+		public function prepare( string $query, ...$args ): array {
+			return array( $query, $args );
+		}
+
+		public function get_results( array $prepared, string $format ): array {
+			unset( $prepared, $format );
+			$rows = array();
+			foreach ( \DataMachine\Engine\Tasks\RecurringScheduler::$covered as $flow_id => $covered ) {
+				if ( ! $covered ) {
+					continue;
+				}
+				$rows[] = array(
+					'action_id'        => $flow_id,
+					'status'           => \DataMachine\Engine\Tasks\RecurringScheduler::$statuses[ $flow_id ] ?? 'pending',
+					'args'             => json_encode( array( $flow_id ) ),
+					'extended_args'    => null,
+					'schedule'         => serialize( new DatamachineFakeSchedule( \DataMachine\Engine\Tasks\RecurringScheduler::$recurrences[ $flow_id ] ?? 3600 ) ),
+					'last_attempt_gmt' => \DataMachine\Engine\Tasks\RecurringScheduler::$last_attempts[ $flow_id ] ?? null,
+					'claim_created_gmt' => null,
+				);
+				foreach ( \DataMachine\Engine\Tasks\RecurringScheduler::$duplicates[ $flow_id ] ?? array() as $duplicate ) {
+					$rows[] = array(
+						'action_id'         => $flow_id + count( $rows ) + 1000,
+						'status'            => $duplicate['status'] ?? 'pending',
+						'args'              => json_encode( array( $flow_id ) ),
+						'extended_args'     => null,
+						'schedule'          => serialize( new DatamachineFakeSchedule( $duplicate['recurrence'] ?? 3600 ) ),
+						'last_attempt_gmt'  => $duplicate['last_attempt_gmt'] ?? null,
+						'claim_created_gmt' => null,
+					);
+				}
+			}
+			return $rows;
+		}
+	}
+
+	class ActionScheduler_DBStore {
+		public function fetch_action( int $action_id ): DatamachineFakeAction {
+			return new DatamachineFakeAction(
+				$action_id,
+				\DataMachine\Engine\Tasks\RecurringScheduler::$recurrences[ $action_id ] ?? 3600
+			);
+		}
+
+		public function get_date( int $action_id ): ?DateTimeInterface {
+			$date = \DataMachine\Engine\Tasks\RecurringScheduler::$last_attempts[ $action_id ] ?? null;
+			return $date ? new DateTimeImmutable( $date, new DateTimeZone( 'UTC' ) ) : null;
+		}
+	}
+
+	class DatamachineFallbackStore extends ActionScheduler_DBStore {}
+
+	class ActionScheduler {
+		public static object $store;
+
+		public static function store(): object {
+			return self::$store;
+		}
+	}
+
+	$wpdb = new DatamachineCoverageWpdb();
+	ActionScheduler::$store = new ActionScheduler_DBStore();
+
+	function as_get_scheduled_actions( array $query, string $return_format ): array {
+		$actions = array();
+		foreach ( \DataMachine\Engine\Tasks\RecurringScheduler::$covered as $flow_id => $covered ) {
+			if ( $covered && ( $query['status'] ?? '' ) === ( \DataMachine\Engine\Tasks\RecurringScheduler::$statuses[ $flow_id ] ?? 'pending' ) ) {
+				$actions[] = 'ids' === $return_format
+					? (int) $flow_id
+					: new DatamachineFakeAction(
+					(int) $flow_id,
+					\DataMachine\Engine\Tasks\RecurringScheduler::$recurrences[ $flow_id ] ?? 3600
+				);
+			}
+		}
+		return $actions;
+	}
+
+	require_once __DIR__ . '/../inc/Api/Flows/FlowScheduleReconciler.php';
+
+	use DataMachine\Api\Flows\FlowScheduleReconciler;
+	use DataMachine\Core\Database\Flows\Flows;
+	use DataMachine\Engine\Tasks\RecurringScheduler;
+
+	function datamachine_reconciler_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	function datamachine_reconciler_flow( int $id, array $scheduling ): array {
+		return array(
+			'flow_id'           => $id,
+			'flow_name'         => 'Flow ' . $id,
+			'scheduling_config' => $scheduling,
+		);
+	}
+
+	echo "=== flow-schedule-reconciler-smoke ===\n";
+
+	$flows = new Flows();
+	for ( $id = 1; $id <= 30; $id++ ) {
+		$flows->schedules[] = datamachine_reconciler_flow( $id, array( 'interval' => 'hourly' ) );
+	}
+	$flows->schedules[] = datamachine_reconciler_flow( 31, array( 'interval' => 'manual' ) );
+	$flows->schedules[] = datamachine_reconciler_flow( 32, array( 'interval' => 'daily', 'enabled' => false ) );
+	$flows->schedules[] = datamachine_reconciler_flow( 33, array( 'interval' => 'one_time' ) );
+	$flows->schedules[] = datamachine_reconciler_flow( 34, array() );
+	RecurringScheduler::$covered[1] = true; // Models pending or in-progress matching coverage.
+	RecurringScheduler::$recurrences[1] = 3600;
+	RecurringScheduler::$statuses[1] = 'pending';
+
+	$reconciler = new FlowScheduleReconciler( $flows );
+	$dry_run    = $reconciler->reconcile();
+	datamachine_reconciler_assert( 30 === $dry_run['eligible'], 'only recurring and cron definitions are eligible' );
+	datamachine_reconciler_assert( 4 === $dry_run['excluded'], 'manual, paused, one-time, and missing schedules are excluded' );
+	datamachine_reconciler_assert( 1 === $dry_run['covered'] && 29 === $dry_run['missing'], 'existing matching work counts as coverage' );
+	datamachine_reconciler_assert( 24 === $dry_run['distribution_window_hours'], 'large automatic reconciliation selects 24-hour spread' );
+	datamachine_reconciler_assert( empty( RecurringScheduler::$calls ), 'dry-run does not schedule actions' );
+
+	$applied = $reconciler->reconcile( true );
+	datamachine_reconciler_assert( 29 === $applied['repaired'] && 0 === $applied['remaining_missing'], 'apply repairs every missing schedule' );
+	datamachine_reconciler_assert( 29 === count( RecurringScheduler::$calls ), 'apply schedules each missing definition exactly once' );
+	datamachine_reconciler_assert( 3 === \DataMachine\Api\Flows\FlowScheduleReconciliationLock::$refresh_count, 'large apply refreshes its lock lease throughout the loop' );
+	datamachine_reconciler_assert(
+		86400 === RecurringScheduler::$calls[0]['options']['distribution_window_seconds'],
+		'large repair passes an explicit 24-hour fleet window'
+	);
+
+	$second = $reconciler->reconcile( true );
+	datamachine_reconciler_assert( 0 === $second['missing'] && 0 === $second['repaired'], 'second apply is idempotent' );
+	datamachine_reconciler_assert( 29 === count( RecurringScheduler::$calls ), 'idempotent apply creates no duplicate actions' );
+
+	$small             = new Flows();
+	$small->schedules  = array( datamachine_reconciler_flow( 100, array( 'interval' => 'daily' ) ) );
+	$small_reconciler  = new FlowScheduleReconciler( $small );
+	$small_result      = $small_reconciler->reconcile( true );
+	$small_call        = RecurringScheduler::$calls[ count( RecurringScheduler::$calls ) - 1 ];
+	datamachine_reconciler_assert( 1 === $small_result['distribution_window_hours'], 'small repair reports ordinary one-hour staggering' );
+	datamachine_reconciler_assert( ! isset( $small_call['options']['distribution_window_seconds'] ), 'small repair leaves ordinary scheduler behavior untouched' );
+
+	$invalid = $small_reconciler->reconcile( false, 25 );
+	datamachine_reconciler_assert( false === $invalid['success'], 'explicit spread is bounded to 24 hours' );
+
+	$malformed            = new Flows();
+	$malformed->schedules = array(
+		datamachine_reconciler_flow( 200, array( 'interval' => 'cron' ) ),
+		datamachine_reconciler_flow( 201, array( 'interval' => 'sometimes' ) ),
+	);
+	$malformed_result = ( new FlowScheduleReconciler( $malformed ) )->reconcile( true );
+	datamachine_reconciler_assert( true === $malformed_result['success'], 'malformed definitions do not create a permanent apply failure' );
+	datamachine_reconciler_assert( 2 === $malformed_result['invalid'] && 0 === $malformed_result['eligible'], 'malformed definitions are reported separately' );
+
+	$partial            = new Flows();
+	$partial->schedules = array(
+		datamachine_reconciler_flow( 300, array( 'interval' => 'hourly' ) ),
+		datamachine_reconciler_flow( 301, array( 'interval' => 'hourly' ) ),
+	);
+	RecurringScheduler::$fail_ids[300] = true;
+	$partial_result = ( new FlowScheduleReconciler( $partial ) )->reconcile( true );
+	datamachine_reconciler_assert( false === $partial_result['success'], 'partial schedule failure marks reconciliation unsuccessful' );
+	datamachine_reconciler_assert( 1 === $partial_result['failed'] && 1 === $partial_result['repaired'], 'partial failure preserves exact repair counts' );
+	datamachine_reconciler_assert( true === $partial_result['transient'], 'partial schedule failure remains retryable for deferred repair' );
+
+	$fresh_running            = new Flows();
+	$fresh_running->schedules = array( datamachine_reconciler_flow( 400, array( 'interval' => 'hourly' ) ) );
+	RecurringScheduler::$covered[400]      = true;
+	RecurringScheduler::$recurrences[400]  = 3600;
+	RecurringScheduler::$statuses[400]     = 'in-progress';
+	RecurringScheduler::$last_attempts[400] = gmdate( 'Y-m-d H:i:s' );
+	$fresh_result = ( new FlowScheduleReconciler( $fresh_running ) )->reconcile();
+	datamachine_reconciler_assert( 1 === $fresh_result['covered'], 'fresh in-progress action covers its matching schedule' );
+
+	RecurringScheduler::$last_attempts[400] = gmdate( 'Y-m-d H:i:s', time() - 3 * HOUR_IN_SECONDS );
+	$stale_result = ( new FlowScheduleReconciler( $fresh_running ) )->reconcile();
+	datamachine_reconciler_assert( 1 === $stale_result['blocked'] && false === $stale_result['success'], 'stale DBStore in-progress action blocks reconciliation' );
+	$calls_before_blocked_apply = count( RecurringScheduler::$calls );
+	$stale_apply = ( new FlowScheduleReconciler( $fresh_running ) )->reconcile( true );
+	datamachine_reconciler_assert( 1 === $stale_apply['blocked'] && true === $stale_apply['transient'], 'blocked apply remains a transient failure' );
+	datamachine_reconciler_assert( 1 === $stale_apply['remaining_missing'] && 0 === $stale_apply['repaired'], 'blocked apply cannot report complete repair' );
+	datamachine_reconciler_assert( $calls_before_blocked_apply === count( RecurringScheduler::$calls ), 'blocked apply does not schedule a successor' );
+	$stale_second = ( new FlowScheduleReconciler( $fresh_running ) )->reconcile();
+	datamachine_reconciler_assert( 1 === $stale_second['blocked'], 'second audit remains blocked while ownership persists' );
+
+	$mismatch            = new Flows();
+	$mismatch->schedules = array( datamachine_reconciler_flow( 401, array( 'interval' => 'daily' ) ) );
+	RecurringScheduler::$covered[401]     = true;
+	RecurringScheduler::$recurrences[401] = 3600;
+	RecurringScheduler::$statuses[401]    = 'pending';
+	$mismatch_result = ( new FlowScheduleReconciler( $mismatch ) )->reconcile();
+	datamachine_reconciler_assert( 1 === $mismatch_result['missing'], 'pending action with mismatched recurrence is not coverage' );
+
+	$duplicate            = new Flows();
+	$duplicate->schedules = array( datamachine_reconciler_flow( 402, array( 'interval' => 'hourly' ) ) );
+	RecurringScheduler::$covered[402]     = true;
+	RecurringScheduler::$recurrences[402] = 3600;
+	RecurringScheduler::$statuses[402]    = 'pending';
+	RecurringScheduler::$duplicates[402]  = array( array( 'recurrence' => 3600 ) );
+	$duplicate_result = ( new FlowScheduleReconciler( $duplicate ) )->reconcile();
+	datamachine_reconciler_assert( 1 === $duplicate_result['missing'], 'duplicate matching actions are unhealthy coverage' );
+	$duplicate_apply = ( new FlowScheduleReconciler( $duplicate ) )->reconcile( true );
+	datamachine_reconciler_assert( 1 === $duplicate_apply['repaired'] && empty( RecurringScheduler::$duplicates[402] ), 'apply delegates duplicate collapse to ensureSchedule' );
+	$duplicate_verified = ( new FlowScheduleReconciler( $duplicate ) )->reconcile();
+	datamachine_reconciler_assert( 1 === $duplicate_verified['covered'], 'deduplicated pending schedule becomes healthy coverage' );
+
+	$mixed            = new Flows();
+	$mixed->schedules = array( datamachine_reconciler_flow( 405, array( 'interval' => 'hourly' ) ) );
+	RecurringScheduler::$covered[405]     = true;
+	RecurringScheduler::$recurrences[405] = 3600;
+	RecurringScheduler::$statuses[405]    = 'pending';
+	RecurringScheduler::$duplicates[405]  = array(
+		array(
+			'recurrence'      => 3600,
+			'status'          => 'in-progress',
+			'last_attempt_gmt' => gmdate( 'Y-m-d H:i:s', time() - 3 * HOUR_IN_SECONDS ),
+		),
+	);
+	$mixed_result = ( new FlowScheduleReconciler( $mixed ) )->reconcile( true );
+	datamachine_reconciler_assert( 1 === $mixed_result['blocked'] && 0 === $mixed_result['repaired'], 'mixed rows with stale in-progress ownership are blocked' );
+
+	ActionScheduler::$store = new DatamachineFallbackStore();
+	$fallback            = new Flows();
+	$fallback->schedules = array( datamachine_reconciler_flow( 403, array( 'interval' => 'hourly' ) ) );
+	RecurringScheduler::$covered[403]       = true;
+	RecurringScheduler::$recurrences[403]   = 3600;
+	RecurringScheduler::$statuses[403]      = 'in-progress';
+	RecurringScheduler::$last_attempts[403] = gmdate( 'Y-m-d H:i:s' );
+	$fallback_fresh = ( new FlowScheduleReconciler( $fallback ) )->reconcile();
+	datamachine_reconciler_assert( 1 === $fallback_fresh['blocked'], 'fallback in-progress action is blocked regardless of scheduled date' );
+	RecurringScheduler::$last_attempts[403] = gmdate( 'Y-m-d H:i:s', time() - 3 * HOUR_IN_SECONDS );
+	$fallback_stale = ( new FlowScheduleReconciler( $fallback ) )->reconcile();
+	datamachine_reconciler_assert( 1 === $fallback_stale['blocked'], 'fallback in-progress remains blocked for stale-looking dates' );
+	RecurringScheduler::$last_attempts[403] = null;
+	$fallback_unknown = ( new FlowScheduleReconciler( $fallback ) )->reconcile();
+	datamachine_reconciler_assert( 1 === $fallback_unknown['blocked'], 'fallback in-progress remains blocked when timing is unavailable' );
+
+	$fallback_pending            = new Flows();
+	$fallback_pending->schedules = array( datamachine_reconciler_flow( 404, array( 'interval' => 'hourly' ) ) );
+	RecurringScheduler::$covered[404]     = true;
+	RecurringScheduler::$recurrences[404] = 3600;
+	RecurringScheduler::$statuses[404]    = 'pending';
+	$fallback_pending_result = ( new FlowScheduleReconciler( $fallback_pending ) )->reconcile();
+	datamachine_reconciler_assert( 1 === $fallback_pending_result['covered'], 'pending fallback action still provides semantic coverage' );
+
+	ActionScheduler::$store = new ActionScheduler_DBStore();
+	$fresh_mismatch            = new Flows();
+	$fresh_mismatch->schedules = array( datamachine_reconciler_flow( 406, array( 'interval' => 'daily' ) ) );
+	RecurringScheduler::$covered[406]       = true;
+	RecurringScheduler::$recurrences[406]   = 3600;
+	RecurringScheduler::$statuses[406]      = 'in-progress';
+	RecurringScheduler::$last_attempts[406] = gmdate( 'Y-m-d H:i:s' );
+	$calls_before_fresh_mismatch = count( RecurringScheduler::$calls );
+	$fresh_mismatch_result = ( new FlowScheduleReconciler( $fresh_mismatch ) )->reconcile( true );
+	datamachine_reconciler_assert( 1 === $fresh_mismatch_result['blocked'] && true === $fresh_mismatch_result['transient'], 'fresh mismatched in-progress ownership blocks apply' );
+	datamachine_reconciler_assert( $calls_before_fresh_mismatch === count( RecurringScheduler::$calls ), 'fresh mismatched in-progress apply schedules nothing' );
+
+	$fresh_mixed            = new Flows();
+	$fresh_mixed->schedules = array( datamachine_reconciler_flow( 407, array( 'interval' => 'hourly' ) ) );
+	RecurringScheduler::$covered[407]       = true;
+	RecurringScheduler::$recurrences[407]   = 3600;
+	RecurringScheduler::$statuses[407]      = 'in-progress';
+	RecurringScheduler::$last_attempts[407] = gmdate( 'Y-m-d H:i:s' );
+	RecurringScheduler::$duplicates[407]    = array( array( 'recurrence' => 3600, 'status' => 'pending' ) );
+	$calls_before_fresh_mixed = count( RecurringScheduler::$calls );
+	$fresh_mixed_result = ( new FlowScheduleReconciler( $fresh_mixed ) )->reconcile( true );
+	datamachine_reconciler_assert( 1 === $fresh_mixed_result['blocked'] && true === $fresh_mixed_result['transient'], 'fresh in-progress plus pending mixed ownership blocks apply' );
+	datamachine_reconciler_assert( $calls_before_fresh_mixed === count( RecurringScheduler::$calls ), 'mixed fresh in-progress apply schedules nothing' );
+
+	echo "\nAll flow schedule reconciler assertions passed.\n";
+}

--- a/tests/flow-schedule-reconciliation-deferred-smoke.php
+++ b/tests/flow-schedule-reconciliation-deferred-smoke.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Pure-PHP deferred reconciliation marker smoke.
+ *
+ * Run with: php tests/flow-schedule-reconciliation-deferred-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Engine\Tasks {
+	class RecurringScheduler {
+		public static function isReady(): bool {
+			return true;
+		}
+	}
+}
+
+namespace DataMachine\Api\Flows {
+	class FlowScheduleReconciler {
+		public static array $result = array();
+
+		public function reconcile( bool $apply = false ): array {
+			unset( $apply );
+			return self::$result;
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ );
+
+	$GLOBALS['datamachine_deferred_options'] = array();
+
+	function get_option( string $name, $default = false ) {
+		return $GLOBALS['datamachine_deferred_options'][ $name ] ?? $default;
+	}
+
+	function update_option( string $name, $value, bool $autoload = true ): bool {
+		unset( $autoload );
+		$GLOBALS['datamachine_deferred_options'][ $name ] = $value;
+		return true;
+	}
+
+	function delete_option( string $name ): bool {
+		unset( $GLOBALS['datamachine_deferred_options'][ $name ] );
+		return true;
+	}
+
+	function add_action( string $hook, $callback, int $priority = 10 ): void {
+		unset( $hook, $callback, $priority );
+	}
+
+	function do_action( string $hook, ...$args ): void {
+		unset( $hook, $args );
+	}
+
+	require_once __DIR__ . '/../inc/migrations/flows.php';
+
+	use DataMachine\Api\Flows\FlowScheduleReconciler;
+
+	function datamachine_deferred_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	echo "=== flow-schedule-reconciliation-deferred-smoke ===\n";
+
+	$marker = 'datamachine_flow_schedule_reconciliation_pending';
+	update_option( $marker, array( 'marked_at' => time() ), false );
+	FlowScheduleReconciler::$result = array(
+		'success'   => false,
+		'transient' => true,
+		'blocked'   => 1,
+	);
+	datamachine_reconcile_marked_flow_schedules();
+	datamachine_deferred_assert( false !== get_option( $marker, false ), 'blocked transient result retains deferred marker' );
+
+	FlowScheduleReconciler::$result = array(
+		'success'  => true,
+		'transient' => false,
+		'invalid'  => 1,
+	);
+	datamachine_reconcile_marked_flow_schedules();
+	datamachine_deferred_assert( false === get_option( $marker, false ), 'permanent invalid definitions do not retain deferred marker' );
+
+	echo "\nAll deferred reconciliation marker assertions passed.\n";
+}

--- a/tests/flow-schedule-reconciliation-lock-smoke.php
+++ b/tests/flow-schedule-reconciliation-lock-smoke.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Pure-PHP behavioral smoke for the reconciliation option lock.
+ *
+ * Run with: php tests/flow-schedule-reconciliation-lock-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+$GLOBALS['datamachine_lock_options'] = array();
+
+class WP_Error {
+	public function __construct( private string $code, private string $message ) {}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+}
+
+class DatamachineLockWpdb {
+	public string $options = 'wp_options';
+
+	public function prepare( string $query, ...$args ): array {
+		return array( $query, $args );
+	}
+
+	public function query( array $prepared ): int {
+		list( $query, $args ) = $prepared;
+		if ( str_starts_with( $query, 'UPDATE' ) ) {
+			list( , $replacement, $option_name, $expected ) = $args;
+			$current = $GLOBALS['datamachine_lock_options'][ $option_name ] ?? null;
+			if ( maybe_serialize( $current ) !== $expected ) {
+				return 0;
+			}
+			$GLOBALS['datamachine_lock_options'][ $option_name ] = unserialize( $replacement );
+			return 1;
+		}
+
+		if ( str_starts_with( $query, 'DELETE' ) ) {
+			list( , $option_name, $expected ) = $args;
+			$current = $GLOBALS['datamachine_lock_options'][ $option_name ] ?? null;
+			if ( maybe_serialize( $current ) !== $expected ) {
+				return 0;
+			}
+			unset( $GLOBALS['datamachine_lock_options'][ $option_name ] );
+			return 1;
+		}
+
+		return 0;
+	}
+}
+
+$wpdb = new DatamachineLockWpdb();
+
+function wp_generate_uuid4(): string {
+	static $counter = 0;
+	return 'test-token-' . ++$counter;
+}
+
+function add_option( string $name, $value, string $deprecated = '', bool $autoload = true ): bool {
+	unset( $deprecated, $autoload );
+	if ( array_key_exists( $name, $GLOBALS['datamachine_lock_options'] ) ) {
+		return false;
+	}
+	$GLOBALS['datamachine_lock_options'][ $name ] = $value;
+	return true;
+}
+
+function get_option( string $name, $default = false ) {
+	return $GLOBALS['datamachine_lock_options'][ $name ] ?? $default;
+}
+
+function maybe_serialize( $value ): string {
+	return is_array( $value ) || is_object( $value ) ? serialize( $value ) : (string) $value;
+}
+
+function wp_cache_delete( string $key, string $group ): bool {
+	unset( $key, $group );
+	return true;
+}
+
+require_once __DIR__ . '/../inc/Api/Flows/FlowScheduleReconciliationLock.php';
+
+use DataMachine\Api\Flows\FlowScheduleReconciliationLock;
+
+function datamachine_lock_assert( bool $condition, string $message ): void {
+	if ( $condition ) {
+		echo "  [PASS] {$message}\n";
+		return;
+	}
+
+	echo "  [FAIL] {$message}\n";
+	exit( 1 );
+}
+
+echo "=== flow-schedule-reconciliation-lock-smoke ===\n";
+
+$first = FlowScheduleReconciliationLock::acquire();
+datamachine_lock_assert( is_string( $first ), 'first owner atomically acquires the lock' );
+
+$blocked = FlowScheduleReconciliationLock::acquire();
+datamachine_lock_assert( $blocked instanceof WP_Error, 'concurrent owner is rejected' );
+datamachine_lock_assert( 'flow_schedule_reconciliation_locked' === $blocked->get_error_code(), 'lock rejection is machine-readable' );
+datamachine_lock_assert( FlowScheduleReconciliationLock::refresh( $first ), 'same-second heartbeat advances the lease monotonically' );
+datamachine_lock_assert( ! FlowScheduleReconciliationLock::refresh( 'wrong-token' ), 'non-owner cannot refresh the lease' );
+$GLOBALS['datamachine_lock_options']['datamachine_flow_schedule_reconciliation_lock']['acquired_at'] = time() - 1200;
+datamachine_lock_assert( FlowScheduleReconciliationLock::refresh( $first ), 'owner atomically refreshes the lease' );
+datamachine_lock_assert(
+	(int) $GLOBALS['datamachine_lock_options']['datamachine_flow_schedule_reconciliation_lock']['acquired_at'] > time() - 5,
+	'refreshed lease receives current timing'
+);
+
+$option_name = 'datamachine_flow_schedule_reconciliation_lock';
+$GLOBALS['datamachine_lock_options'][ $option_name ]['acquired_at'] = time() - 3600;
+$replacement = FlowScheduleReconciliationLock::acquire();
+datamachine_lock_assert( is_string( $replacement ) && $replacement !== $first, 'stale owner is replaced with a new token' );
+datamachine_lock_assert( ! FlowScheduleReconciliationLock::release( $first ), 'stale owner cannot release replacement lock' );
+datamachine_lock_assert( FlowScheduleReconciliationLock::release( $replacement ), 'replacement owner releases its lock' );
+datamachine_lock_assert( ! array_key_exists( $option_name, $GLOBALS['datamachine_lock_options'] ), 'successful release deletes the lock option' );
+
+$GLOBALS['datamachine_lock_options'][ $option_name ] = 'malformed-stale-lock';
+$recovered = FlowScheduleReconciliationLock::acquire();
+datamachine_lock_assert( is_string( $recovered ), 'malformed stale lock is recovered atomically' );
+datamachine_lock_assert( FlowScheduleReconciliationLock::release( $recovered ), 'recovered lock remains token-safe' );
+
+echo "\nAll reconciliation lock assertions passed.\n";

--- a/tests/flow-schedule-reconciliation-wiring-smoke.php
+++ b/tests/flow-schedule-reconciliation-wiring-smoke.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Pure-PHP smoke assertions for flow schedule reconciliation wiring.
+ *
+ * Run with: php tests/flow-schedule-reconciliation-wiring-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$root = dirname( __DIR__ );
+
+function datamachine_flow_reconcile_assert_contains( string $needle, string $haystack, string $message ): void {
+	if ( str_contains( $haystack, $needle ) ) {
+		echo "  [PASS] {$message}\n";
+		return;
+	}
+
+	echo "  [FAIL] {$message}\n";
+	exit( 1 );
+}
+
+echo "=== flow-schedule-reconciliation-wiring-smoke ===\n";
+
+$plugin     = file_get_contents( $root . '/data-machine.php' );
+$migration  = file_get_contents( $root . '/inc/migrations/flows.php' );
+$runtime    = file_get_contents( $root . '/inc/migrations/runtime.php' );
+$command    = file_get_contents( $root . '/inc/Cli/Commands/Flows/FlowsCommand.php' );
+$reconciler = file_get_contents( $root . '/inc/Api/Flows/FlowScheduleReconciler.php' );
+$scheduler  = file_get_contents( $root . '/inc/Engine/Tasks/RecurringScheduler.php' );
+$lock       = file_get_contents( $root . '/inc/Api/Flows/FlowScheduleReconciliationLock.php' );
+
+foreach ( array( $plugin, $migration, $runtime, $command, $reconciler, $scheduler, $lock ) as $source ) {
+	if ( false === $source ) {
+		echo "  [FAIL] Unable to read reconciliation source files\n";
+		exit( 1 );
+	}
+}
+
+datamachine_flow_reconcile_assert_contains( 'ReconcileFlowSchedulesAbility', $plugin, 'ability is registered with the full runtime' );
+datamachine_flow_reconcile_assert_contains( 'datamachine_mark_flow_schedule_reconciliation', $runtime, 'deploy migrations mark schedule repair' );
+datamachine_flow_reconcile_assert_contains( "add_action( 'action_scheduler_init'", $migration, 'repair waits for Action Scheduler initialization' );
+datamachine_flow_reconcile_assert_contains( "delete_option( 'datamachine_flow_schedule_reconciliation_pending' )", $migration, 'successful repair clears the marker' );
+datamachine_flow_reconcile_assert_contains( 'Flows::is_flow_enabled', $reconciler, 'reconciler excludes disabled persisted flows' );
+datamachine_flow_reconcile_assert_contains( "array( 'manual', 'one_time' )", $reconciler, 'manual and one-time definitions are excluded' );
+datamachine_flow_reconcile_assert_contains( "array( 'pending', 'in-progress' )", $scheduler, 'pending and in-progress actions count as coverage' );
+datamachine_flow_reconcile_assert_contains( 'last_attempt_gmt', $reconciler, 'in-progress freshness uses last-attempt timing' );
+datamachine_flow_reconcile_assert_contains( 'claim_created_gmt', $reconciler, 'in-progress freshness uses claim timing' );
+datamachine_flow_reconcile_assert_contains( 'RUNNING_STALE_AFTER   = 7200', $reconciler, 'stale in-progress threshold is two hours' );
+datamachine_flow_reconcile_assert_contains( 'scheduleMatches', $reconciler, 'coverage verifies recurrence semantics' );
+datamachine_flow_reconcile_assert_contains( 'LIMIT %d', $reconciler, 'direct Action Scheduler coverage query is bounded' );
+datamachine_flow_reconcile_assert_contains( 'MAX_COVERAGE_ROWS     = 5000', $reconciler, 'large fleet health query has an explicit ceiling' );
+datamachine_flow_reconcile_assert_contains( "'ActionScheduler_DBStore' !== get_class( \$store )", $reconciler, 'direct SQL requires the authoritative DB store' );
+datamachine_flow_reconcile_assert_contains( "'timing_authoritative' => false", $reconciler, 'fallback in-progress ownership is explicitly uncertain' );
+datamachine_flow_reconcile_assert_contains( "'blocked'", $reconciler, 'stale or uncertain ownership is reported as blocked' );
+datamachine_flow_reconcile_assert_contains( 'FlowScheduleReconciliationLock::acquire', $reconciler, 'all apply paths acquire the shared lock' );
+datamachine_flow_reconcile_assert_contains( 'FlowScheduleReconciliationLock::refresh', $reconciler, 'large apply loops refresh the lock lease' );
+datamachine_flow_reconcile_assert_contains( 'add_option( self::OPTION_NAME', $lock, 'first lock acquisition is atomic' );
+datamachine_flow_reconcile_assert_contains( 'option_value = %s', $lock, 'stale takeover and release compare exact lock payloads' );
+datamachine_flow_reconcile_assert_contains( "'reconcile-schedules'", $command, 'flows CLI dispatches reconcile-schedules' );
+datamachine_flow_reconcile_assert_contains( "isset( \$assoc_args['apply'] )", $command, 'CLI remains dry-run unless --apply is present' );
+datamachine_flow_reconcile_assert_contains( 'WP_CLI::error( (string) $result[\'error\'], false )', $command, 'table failures print before exiting non-zero' );
+datamachine_flow_reconcile_assert_contains( 'WP_CLI::halt( 1 )', $command, 'JSON and table failures return non-zero' );
+datamachine_flow_reconcile_assert_contains( "(int) ( \$result['invalid'] ?? 0 ) > 0", $command, 'invalid definitions return non-zero without changing ability success' );
+datamachine_flow_reconcile_assert_contains( 'Blocked: %d', $command, 'CLI summary surfaces blocked flows' );
+datamachine_flow_reconcile_assert_contains( "! empty( \$result['transient'] )", $migration, 'deferred marker persists only for transient failures' );
+
+echo "\nAll flow schedule reconciliation wiring assertions passed.\n";

--- a/tests/system-health-scheduler-smoke.php
+++ b/tests/system-health-scheduler-smoke.php
@@ -32,10 +32,15 @@ if ( false === $system_abilities || false === $system_command ) {
 datamachine_scheduler_health_assert_contains( "'scheduler' => array", $system_abilities, 'scheduler check is registered' );
 datamachine_scheduler_health_assert_contains( "wp_next_scheduled( 'action_scheduler_run_queue' )", $system_abilities, 'WP-Cron runner lag is inspected' );
 datamachine_scheduler_health_assert_contains( 'RecurringScheduler::GROUP', $system_abilities, 'diagnostics scope to Data Machine actions' );
+datamachine_scheduler_health_assert_contains( 'FlowScheduleReconciler', $system_abilities, 'flow schedule coverage is audited' );
+datamachine_scheduler_health_assert_contains( 'flows reconcile-schedules', $system_abilities, 'missing coverage includes operator repair guidance' );
+datamachine_scheduler_health_assert_contains( 'blocked by in-progress Action Scheduler ownership', $system_abilities, 'blocked ownership makes scheduler health fail' );
+datamachine_scheduler_health_assert_contains( 'Recover stale or uncertain in-progress jobs/actions first', $system_abilities, 'blocked health recommends ownership recovery first' );
 datamachine_scheduler_health_assert_contains( 'wp datamachine drain', $system_abilities, 'stale scheduler output recommends an explicit drain' );
 datamachine_scheduler_health_assert_contains( 'wp datamachine system run daily_memory_generation --param=agent_slug=<slug> --wait', $system_abilities, 'stale scheduler output recommends scoped daily memory remediation' );
 datamachine_scheduler_health_assert_contains( 'Due now:', $system_command, 'CLI table output shows due Action Scheduler work' );
 datamachine_scheduler_health_assert_contains( 'Daily memory:', $system_command, 'CLI table output shows daily memory schedule state' );
+datamachine_scheduler_health_assert_contains( 'Flow schedules:', $system_command, 'CLI table output shows flow schedule coverage' );
 datamachine_scheduler_health_assert_contains( '[--wait]', $system_command, 'system run exposes a job-scoped wait option' );
 datamachine_scheduler_health_assert_contains( 'DrainJobAbility', $system_command, 'system run drains only the created job when waiting' );
 


### PR DESCRIPTION
## Summary
- audit persisted recurring flow definitions against authoritative Action Scheduler coverage and expose a dry-run/apply reconciliation ability plus CLI
- defer activation/deploy repairs until Action Scheduler is ready, lock concurrent repairs, and spread large fleet recovery over 24 hours
- surface missing, invalid, duplicate, and blocked schedule ownership in system health without scheduling around active in-progress work

## Testing
- `composer lint`
- scheduler reconciliation smoke suites
- recurring scheduler idempotency smoke suite
- PHP syntax checks for changed files
- `git diff --check`
- independent final code review found no blocking correctness issues

## Operational Evidence
Production recovery restored 659 recurring Events schedules after 670 flows lost their next run. The initial one-hour repair window would have concentrated 627 starts; this change adds fleet-aware distribution and routine coverage diagnostics so that drift is detected and repaired safely.

Full `homeboy review data-machine` was not run locally because Homeboy's resource policy rejected the hot 8-CPU host at load 132.2 and no Lab runner was available. Focused Homeboy changed-file lint passed during implementation.

Closes #2902