### PR TITLE
refactor(fetch): extract duplicate keyword filters into shared traits

### DIFF
--- a/inc/Abilities/Fetch/FetchRssAbility.php
+++ b/inc/Abilities/Fetch/FetchRssAbility.php
@@ -11,12 +11,16 @@
 namespace DataMachine\Abilities\Fetch;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Abilities\Fetch\Traits\HasApplyKeywordSearch;
+use DataMachine\Abilities\Fetch\Traits\HasApplyKeywordExclusion;
 
 defined( 'ABSPATH' ) || exit;
 
 class FetchRssAbility {
 
 	use FetchHttpGetTrait;
+	use HasApplyKeywordSearch;
+	use HasApplyKeywordExclusion;
 
 	private static bool $registered = false;
 
@@ -526,51 +530,4 @@ class FetchRssAbility {
 		return $item_timestamp >= $cutoff;
 	}
 
-	/**
-	 * Apply keyword search filter.
-	 */
-	private function applyKeywordSearch( string $text, string $search_term ): bool {
-		if ( empty( $search_term ) ) {
-			return true;
-		}
-
-		$terms      = array_map( 'trim', explode( ',', $search_term ) );
-		$text_lower = strtolower( $text );
-
-		foreach ( $terms as $term ) {
-			if ( empty( $term ) ) {
-				continue;
-			}
-			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Apply keyword exclusion filter.
-	 *
-	 * Returns true when any of the comma-separated terms in $exclude_keywords
-	 * is present in $text. Inverse of applyKeywordSearch — callers should skip
-	 * items for which this returns true. An empty exclusion list never matches.
-	 */
-	private function applyKeywordExclusion( string $text, string $exclude_keywords ): bool {
-		$exclude_keywords = trim( $exclude_keywords );
-		if ( '' === $exclude_keywords ) {
-			return false;
-		}
-
-		$terms      = array_filter( array_map( 'trim', explode( ',', $exclude_keywords ) ) );
-		$text_lower = strtolower( $text );
-
-		foreach ( $terms as $term ) {
-			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
 }

--- a/inc/Abilities/Fetch/FetchWordPressApiAbility.php
+++ b/inc/Abilities/Fetch/FetchWordPressApiAbility.php
@@ -12,12 +12,16 @@
 namespace DataMachine\Abilities\Fetch;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Abilities\Fetch\Traits\HasApplyKeywordSearch;
+use DataMachine\Abilities\Fetch\Traits\HasApplyKeywordExclusion;
 
 defined( 'ABSPATH' ) || exit;
 
 class FetchWordPressApiAbility {
 
 	use FetchHttpGetTrait;
+	use HasApplyKeywordSearch;
+	use HasApplyKeywordExclusion;
 
 	private static bool $registered = false;
 
@@ -599,51 +603,4 @@ class FetchWordPressApiAbility {
 		return $item_timestamp >= $cutoff;
 	}
 
-	/**
-	 * Apply keyword search filter.
-	 */
-	private function applyKeywordSearch( string $text, string $search_term ): bool {
-		if ( empty( $search_term ) ) {
-			return true;
-		}
-
-		$terms      = array_map( 'trim', explode( ',', $search_term ) );
-		$text_lower = strtolower( $text );
-
-		foreach ( $terms as $term ) {
-			if ( empty( $term ) ) {
-				continue;
-			}
-			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Apply keyword exclusion filter.
-	 *
-	 * Returns true when any of the comma-separated terms in $exclude_keywords
-	 * is present in $text. Inverse of applyKeywordSearch — callers should skip
-	 * items for which this returns true. An empty exclusion list never matches.
-	 */
-	private function applyKeywordExclusion( string $text, string $exclude_keywords ): bool {
-		$exclude_keywords = trim( $exclude_keywords );
-		if ( '' === $exclude_keywords ) {
-			return false;
-		}
-
-		$terms      = array_filter( array_map( 'trim', explode( ',', $exclude_keywords ) ) );
-		$text_lower = strtolower( $text );
-
-		foreach ( $terms as $term ) {
-			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
 }

--- a/inc/Abilities/Fetch/FetchWordPressMediaAbility.php
+++ b/inc/Abilities/Fetch/FetchWordPressMediaAbility.php
@@ -11,10 +11,14 @@
 namespace DataMachine\Abilities\Fetch;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Abilities\Fetch\Traits\HasApplyKeywordSearch;
+use DataMachine\Abilities\Fetch\Traits\HasApplyKeywordExclusion;
 
 defined( 'ABSPATH' ) || exit;
 
 class FetchWordPressMediaAbility {
+	use HasApplyKeywordSearch;
+	use HasApplyKeywordExclusion;
 
 	private static bool $registered = false;
 
@@ -370,51 +374,4 @@ class FetchWordPressMediaAbility {
 		return $mime_patterns;
 	}
 
-	/**
-	 * Apply keyword search filter.
-	 */
-	private function applyKeywordSearch( string $text, string $search_term ): bool {
-		if ( empty( $search_term ) ) {
-			return true;
-		}
-
-		$terms      = array_map( 'trim', explode( ',', $search_term ) );
-		$text_lower = strtolower( $text );
-
-		foreach ( $terms as $term ) {
-			if ( empty( $term ) ) {
-				continue;
-			}
-			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Apply keyword exclusion filter.
-	 *
-	 * Returns true when any of the comma-separated terms in $exclude_keywords
-	 * is present in $text. Inverse of applyKeywordSearch — callers should skip
-	 * items for which this returns true. An empty exclusion list never matches.
-	 */
-	private function applyKeywordExclusion( string $text, string $exclude_keywords ): bool {
-		$exclude_keywords = trim( $exclude_keywords );
-		if ( '' === $exclude_keywords ) {
-			return false;
-		}
-
-		$terms      = array_filter( array_map( 'trim', explode( ',', $exclude_keywords ) ) );
-		$text_lower = strtolower( $text );
-
-		foreach ( $terms as $term ) {
-			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
 }

--- a/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
+++ b/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
@@ -11,10 +11,14 @@
 namespace DataMachine\Abilities\Fetch;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Abilities\Fetch\Traits\HasApplyKeywordSearch;
+use DataMachine\Abilities\Fetch\Traits\HasApplyKeywordExclusion;
 
 defined( 'ABSPATH' ) || exit;
 
 class QueryWordPressPostsAbility {
+	use HasApplyKeywordSearch;
+	use HasApplyKeywordExclusion;
 
 	private static bool $registered = false;
 
@@ -339,51 +343,4 @@ class QueryWordPressPostsAbility {
 		return array_merge( $defaults, $input );
 	}
 
-	/**
-	 * Apply keyword search filter.
-	 */
-	private function applyKeywordSearch( string $text, string $search_term ): bool {
-		if ( empty( $search_term ) ) {
-			return true;
-		}
-
-		$terms      = array_map( 'trim', explode( ',', $search_term ) );
-		$text_lower = strtolower( $text );
-
-		foreach ( $terms as $term ) {
-			if ( empty( $term ) ) {
-				continue;
-			}
-			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Apply keyword exclusion filter.
-	 *
-	 * Returns true when any of the comma-separated terms in $exclude_keywords
-	 * is present in $text. Inverse of applyKeywordSearch — callers should skip
-	 * items for which this returns true. An empty exclusion list never matches.
-	 */
-	private function applyKeywordExclusion( string $text, string $exclude_keywords ): bool {
-		$exclude_keywords = trim( $exclude_keywords );
-		if ( '' === $exclude_keywords ) {
-			return false;
-		}
-
-		$terms      = array_filter( array_map( 'trim', explode( ',', $exclude_keywords ) ) );
-		$text_lower = strtolower( $text );
-
-		foreach ( $terms as $term ) {
-			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
 }

--- a/inc/Abilities/Fetch/Traits/HasApplyKeywordExclusion.php
+++ b/inc/Abilities/Fetch/Traits/HasApplyKeywordExclusion.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace DataMachine\Abilities\Fetch\Traits;
+
+/**
+ * Shared trait for the `applyKeywordExclusion` method.
+ *
+ * Extracted from duplicate implementations across the Fetch ability handlers.
+ */
+trait HasApplyKeywordExclusion {
+	/**
+	 * Apply keyword exclusion filter.
+	 *
+	 * Returns true when any of the comma-separated terms in $exclude_keywords
+	 * is present in $text. Inverse of applyKeywordSearch — callers should skip
+	 * items for which this returns true. An empty exclusion list never matches.
+	 */
+	private function applyKeywordExclusion( string $text, string $exclude_keywords ): bool {
+		$exclude_keywords = trim( $exclude_keywords );
+		if ( '' === $exclude_keywords ) {
+			return false;
+		}
+
+		$terms      = array_filter( array_map( 'trim', explode( ',', $exclude_keywords ) ) );
+		$text_lower = strtolower( $text );
+
+		foreach ( $terms as $term ) {
+			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/inc/Abilities/Fetch/Traits/HasApplyKeywordSearch.php
+++ b/inc/Abilities/Fetch/Traits/HasApplyKeywordSearch.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DataMachine\Abilities\Fetch\Traits;
+
+/**
+ * Shared trait for the `applyKeywordSearch` method.
+ *
+ * Extracted from duplicate implementations across the Fetch ability handlers.
+ */
+trait HasApplyKeywordSearch {
+	/**
+	 * Apply keyword search filter.
+	 */
+	private function applyKeywordSearch( string $text, string $search_term ): bool {
+		if ( empty( $search_term ) ) {
+			return true;
+		}
+
+		$terms      = array_map( 'trim', explode( ',', $search_term ) );
+		$text_lower = strtolower( $text );
+
+		foreach ( $terms as $term ) {
+			if ( empty( $term ) ) {
+				continue;
+			}
+			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary
The four Fetch ability handlers each carried **byte-identical** copies of `applyKeywordSearch` and `applyKeywordExclusion` (a comma-separated keyword matcher + its negation). This hoists both into shared traits and composes them into each handler.

- **New traits** under `DataMachine\Abilities\Fetch\Traits`: `HasApplyKeywordSearch`, `HasApplyKeywordExclusion`.
- Each of the 4 handlers (`FetchRssAbility`, `FetchWordPressApiAbility`, `FetchWordPressMediaAbility`, `QueryWordPressPostsAbility`) drops the two duplicated methods and adds the two trait `use`s.
- **Net −104 lines** (188 removed, 84 added) across 6 files. Call sites (`$this->applyKeyword*`, 8 of them) are unchanged — traits provide the methods identically.

## How it was generated
Produced by **homeboy's refactor `extract_shared`** (the WordPress refactor extension), which verifies method-body equality before hoisting and resolves the PSR-4 trait path from `composer.json`. This is the WordPress-idiomatic analog of the Rust struct-dedup refactors — the same "kill duplication" engine, pointed at PHP.

## Verification
- `php -l` clean on all 6 touched files.
- PSR-4 autoload confirmed: `DataMachine\Abilities\ → inc/Abilities/`, so the new traits autoload from `inc/Abilities/Fetch/Traits/`.
- **Runtime smoke test**: composing both traits into a class and calling the methods reproduces the original behavior (present term → true, absent → false, empty search → true).

## Context
First dogfood of homeboy's refactor engine against a PHP/WordPress codebase (Data Machine). A codebase-wide scan found **55 byte-identical duplicated methods**; this PR takes the cleanest, most cohesive cluster. Follow-ups could target `get_table_prefix` (×4 DB classes), `normalizeModes` (×6 AI directives), and others.