### PR TITLE
fix(chat): propagate acting caller to tool policy

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -105,6 +105,7 @@ class AgentsChatHandler {
 		}
 		$agent_id = $identity ? $identity->agent_id : 0;
 
+		$calling_user_id = $this->resolveCallingUserId( $input );
 		$user_id = $this->resolveRuntimeUserId( $identity, (string) ( $input['agent'] ?? '' ), $input );
 		if ( $user_id <= 0 ) {
 			return new WP_Error( 'no_user', __( 'No user context available.', 'data-machine' ), array( 'status' => 400 ) );
@@ -145,6 +146,7 @@ class AgentsChatHandler {
 				'modes'                 => $modes,
 				'agent_id'              => $agent_id,
 				'agent_slug'            => $identity ? $identity->agent_slug : '',
+				'calling_user_id'        => $calling_user_id,
 				'attachments'           => $input['attachments'] ?? array(),
 				'client_context'        => $client_context,
 				'tool_policy'           => is_array( $input['tool_policy'] ?? null ) ? $input['tool_policy'] : null,
@@ -162,6 +164,26 @@ class AgentsChatHandler {
 
 		$output = $this->toCanonicalOutput( $result );
 		return $this->withInputControlDiagnostics( $output, $input );
+	}
+
+	/**
+	 * Resolve the authenticated user on whose behalf the chat executes.
+	 *
+	 * The runtime and transcript may be owned by an agent owner even when no
+	 * human is acting. An execution principal therefore takes precedence over
+	 * WordPress request state, including when it explicitly identifies a
+	 * system/runtime context with acting_user_id 0.
+	 *
+	 * @param array $input Canonical chat input.
+	 * @return int Acting WordPress user ID, or 0 when no human is acting.
+	 */
+	private function resolveCallingUserId( array $input ): int {
+		$principal = $this->resolveCallerPrincipal( $input ) ?? PermissionHelper::get_execution_principal();
+		if ( $principal instanceof \AgentsAPI\AI\WP_Agent_Execution_Principal ) {
+			return max( 0, $principal->acting_user_id );
+		}
+
+		return max( 0, get_current_user_id() );
 	}
 
 	/**

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -74,6 +74,7 @@ class ChatOrchestrator {
 		$interrupt_source     = is_callable( $options['interrupt_source'] ?? null ) ? $options['interrupt_source'] : null;
 		$agent_id             = (int) ( $options['agent_id'] ?? 0 );
 		$agent_slug           = (string) ( $options['agent_slug'] ?? '' );
+		$calling_user_id      = array_key_exists( 'calling_user_id', $options ) ? max( 0, (int) $options['calling_user_id'] ) : $user_id;
 		$modes                = ToolPolicyResolver::normalizeModes( ! empty( $options['modes'] ) ? $options['modes'] : array( $options['mode'] ?? ToolPolicyResolver::MODE_CHAT ) );
 		$mode                 = implode( ',', $modes );
 		$transcript_owner     = ChatTranscriptOwner::resolve_for_request( $options, $user_id );
@@ -191,6 +192,7 @@ class ChatOrchestrator {
 					'status'            => 'processing',
 					'started_at'        => current_time( 'mysql', true ),
 					'message_count'     => count( $messages ),
+					'calling_user_id'   => $calling_user_id,
 					'last_seen_host'    => '' !== $current_host ? $current_host : ( $session_metadata['last_seen_host'] ?? '' ),
 					'consent_decisions' => array(
 						'store_transcript' => $transcript_consent_decision->to_array(),
@@ -236,7 +238,7 @@ class ChatOrchestrator {
 				'modes'                 => $modes,
 				'mode'                  => $mode,
 				'user_id'               => $user_id,
-				'calling_user_id'       => isset( $options['calling_user_id'] ) ? max( 0, (int) $options['calling_user_id'] ) : $user_id,
+				'calling_user_id'       => $calling_user_id,
 				'agent_id'              => $agent_id,
 				'agent_slug'            => $agent_slug,
 				'interrupt_source'      => $interrupt_source,
@@ -264,6 +266,7 @@ class ChatOrchestrator {
 			'message_count'     => count( $result['messages'] ),
 			'current_turn'      => $result['turn_count'],
 			'has_pending_tools' => ! $is_completed,
+			'calling_user_id'   => $calling_user_id,
 			'last_seen_host'    => '' !== $current_host ? $current_host : ( $session_metadata['last_seen_host'] ?? '' ),
 		);
 		if ( ! empty( $loop_metadata['runtime_tool_pending_requests'] ) ) {
@@ -384,9 +387,10 @@ class ChatOrchestrator {
 	 *
 	 * @param string $session_id Session ID to continue.
 	 * @param int    $user_id    Current user ID for ownership check.
+	 * @param int|null $calling_user_id Original authenticated acting user. Null restores session context.
 	 * @return array|WP_Error Response data array or WP_Error on failure.
 	 */
-	public static function processContinue( string $session_id, int $user_id ): array|WP_Error {
+	public static function processContinue( string $session_id, int $user_id, ?int $calling_user_id = null ): array|WP_Error {
 		$max_turns = PluginSettings::get( 'max_turns', PluginSettings::DEFAULT_MAX_TURNS );
 
 		$chat_db = ConversationStoreFactory::get();
@@ -409,6 +413,9 @@ class ChatOrchestrator {
 		}
 
 		$metadata = $session['metadata'] ?? array();
+		$calling_user_id = null !== $calling_user_id
+			? max( 0, $calling_user_id )
+			: ( array_key_exists( 'calling_user_id', $metadata ) ? max( 0, (int) $metadata['calling_user_id'] ) : $user_id );
 
 		// Short-circuit if session is already completed.
 		if ( isset( $metadata['status'] ) && 'completed' === $metadata['status'] && empty( $metadata['has_pending_tools'] ) ) {
@@ -465,6 +472,7 @@ class ChatOrchestrator {
 				'modes'                => $modes,
 				'mode'                 => $stored_mode,
 				'user_id'              => (int) ( $session['user_id'] ?? 0 ),
+				'calling_user_id'      => $calling_user_id,
 				'agent_id'             => (int) ( $session['agent_id'] ?? 0 ),
 				'agent_slug'           => (string) ( $session['agent_slug'] ?? '' ),
 				'cross_site_handoff'   => $cross_site_handoff,
@@ -490,6 +498,7 @@ class ChatOrchestrator {
 			'message_count'     => count( $result['messages'] ),
 			'current_turn'      => $current_turn,
 			'has_pending_tools' => ! $is_completed,
+			'calling_user_id'   => $calling_user_id,
 			'last_seen_host'    => '' !== $current_host ? $current_host : ( $metadata['last_seen_host'] ?? '' ),
 		);
 		if ( ! empty( $metadata['runtime_tool_requests'] ) ) {

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -55,6 +55,7 @@ class ChatOrchestrator {
 	 *     @type int    $selected_pipeline_id Currently selected pipeline ID.
 	 *     @type int    $max_turns            Maximum turns allowed.
 	 *     @type string $request_id           Idempotency request ID.
+	 *     @type int    $calling_user_id      Authenticated acting user. 0 means no human caller.
 	 *     @type callable|null $interrupt_source Optional cooperative interrupt source.
 	 * }
 	 * @return array|WP_Error Response data array or WP_Error on failure.
@@ -235,6 +236,7 @@ class ChatOrchestrator {
 				'modes'                 => $modes,
 				'mode'                  => $mode,
 				'user_id'               => $user_id,
+				'calling_user_id'       => isset( $options['calling_user_id'] ) ? max( 0, (int) $options['calling_user_id'] ) : $user_id,
 				'agent_id'              => $agent_id,
 				'agent_slug'            => $agent_slug,
 				'interrupt_source'      => $interrupt_source,
@@ -320,7 +322,7 @@ class ChatOrchestrator {
 		}
 
 		// --- Build response data ---
-		$response_metadata = is_array( $loop_result['metadata'] ?? null ) ? $loop_result['metadata'] : array();
+		$response_metadata = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
 		if ( empty( $response_metadata ) ) {
 			$response_metadata = $metadata;
 		} else {
@@ -849,6 +851,7 @@ class ChatOrchestrator {
 	 *     @type int    $max_turns             Maximum turns allowed (default 25).
 	 *     @type int    $selected_pipeline_id  Currently selected pipeline ID.
 	 *     @type string $mode                  Agent mode (default 'chat').
+	 *     @type int    $calling_user_id       Authenticated acting user. 0 means no human caller.
 	 *     @type callable|null $interrupt_source Optional cooperative interrupt source.
 	 * }
 	 * @return array|WP_Error Result array with messages, final_content, completed, turn_count,
@@ -884,6 +887,13 @@ class ChatOrchestrator {
 				$agent_slug = ConversationStoreFactory::resolve_agent_slug_for_transcript( $agent_id );
 			}
 
+			// Keep the authenticated acting user separate from runtime/session
+			// ownership. An explicit 0 denotes a system or delegated runtime with
+			// no human caller and must not fall back to the transcript owner.
+			$calling_user_id = isset( $options['calling_user_id'] )
+				? max( 0, (int) $options['calling_user_id'] )
+				: $user_id;
+
 			$resolver       = new ToolPolicyResolver();
 			$client_context = $options['client_context'] ?? array();
 			$all_tools      = $resolver->resolve(
@@ -892,25 +902,13 @@ class ChatOrchestrator {
 					'agent_id'       => $agent_id,
 					'agent_slug'     => $agent_slug,
 					'user_id'        => $user_id,
+					'calling_user_id' => $calling_user_id,
 					'interactive'    => true,
 					'client_context' => is_array( $client_context ) ? $client_context : array(),
 					'tool_policy'    => is_array( $options['tool_policy'] ?? null ) ? $options['tool_policy'] : null,
 					'allow_only'     => is_array( $options['allow_only'] ?? null ) ? $options['allow_only'] : array(),
 				)
 			);
-
-			// `calling_user_id` is the human user on whose behalf this AI invocation
-			// is running. In a chat session that's the chat caller. Tools that resolve
-			// per-user OAuth credentials read this field — distinct from `agent_id`
-			// (the acting agent identity) and from pipeline `user_id` (job owner).
-			//
-			// Callers can override via `$options['calling_user_id']` to express
-			// "this is a system-level invocation borrowing an admin session_id for
-			// storage but has no real human caller" (e.g. processPing). When the
-			// override is absent, the chat user is the calling user.
-			$calling_user_id = isset( $options['calling_user_id'] )
-				? max( 0, (int) $options['calling_user_id'] )
-				: $user_id;
 
 			$loop_context = array(
 				'session_id'      => $session_id,

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1488,6 +1488,7 @@ function datamachine_prepare_runtime_tool_request( array $request, array $payloa
 					'persistence_status' => 'pending',
 					'session_id'         => (string) ( $request['session_id'] ?? '' ),
 					'user_id'            => (int) ( $payload['user_id'] ?? 0 ),
+					'calling_user_id'    => array_key_exists( 'calling_user_id', $payload ) ? max( 0, (int) $payload['calling_user_id'] ) : (int) ( $payload['user_id'] ?? 0 ),
 					'agent_id'           => (int) ( $payload['agent_id'] ?? 0 ),
 					'mode'               => (string) ( $request['mode'] ?? '' ),
 					'modes'              => is_array( $request['modes'] ?? null ) ? $request['modes'] : array(),
@@ -1843,15 +1844,17 @@ function datamachine_resume_runtime_tool_request( string $request_id ): void {
 		( new RuntimeToolRunStateStore() )->resume(
 			$job_id,
 			array(
-				'session_id' => (string) ( $datamachine_metadata['session_id'] ?? '' ),
-				'user_id'    => (int) ( $datamachine_metadata['user_id'] ?? 0 ),
+				'session_id'      => (string) ( $datamachine_metadata['session_id'] ?? '' ),
+				'user_id'         => (int) ( $datamachine_metadata['user_id'] ?? 0 ),
+				'calling_user_id' => array_key_exists( 'calling_user_id', $datamachine_metadata ) ? max( 0, (int) $datamachine_metadata['calling_user_id'] ) : (int) ( $datamachine_metadata['user_id'] ?? 0 ),
 			)
 		);
 	}
 
 	\DataMachine\Api\Chat\ChatOrchestrator::processContinue(
 		(string) ( $datamachine_metadata['session_id'] ?? '' ),
-		(int) ( $datamachine_metadata['user_id'] ?? 0 )
+		(int) ( $datamachine_metadata['user_id'] ?? 0 ),
+		array_key_exists( 'calling_user_id', $datamachine_metadata ) ? max( 0, (int) $datamachine_metadata['calling_user_id'] ) : null
 	);
 }
 

--- a/tests/agents-chat-handler-smoke.php
+++ b/tests/agents-chat-handler-smoke.php
@@ -93,7 +93,9 @@ $assert( str_contains( $handler_source, "'completion_assertions'" ) && str_conta
 $assert( str_contains( $handler_source, "'interrupted'" ) && str_contains( $handler_source, "$" . "result['interrupted'] ?? null" ), 'AgentsChatHandler returns interrupted diagnostics in canonical metadata' );
 $assert( str_contains( $handler_source, "'tool_execution_summary'" ), 'AgentsChatHandler returns bounded tool execution diagnostics in canonical metadata' );
 $assert( str_contains( $orchestrator, "'tool_execution_summary'" ) && str_contains( $orchestrator, 'datamachine_summarize_tool_execution_results' ), 'ChatOrchestrator forwards bounded tool execution diagnostics to chat adapters' );
-$assert( str_contains( $orchestrator, '$response_metadata = is_array( $loop_result[\'metadata\'] ?? null )' ), 'ChatOrchestrator exposes loop metadata in chat adapter responses' );
+$assert( str_contains( $handler_source, "'calling_user_id'        => $" . "calling_user_id" ), 'AgentsChatHandler forwards the authenticated acting user separately from runtime ownership' );
+$assert( str_contains( $orchestrator, "'calling_user_id' => $" . "calling_user_id" ), 'ChatOrchestrator passes caller identity to tool resolution and the conversation loop' );
+$assert( str_contains( $orchestrator, '$response_metadata = is_array( $result[\'metadata\'] ?? null )' ), 'ChatOrchestrator exposes loop metadata from the actual turn result' );
 $assert( ! file_exists( $root . '/inc/Abilities/Chat/SendMessageAbility.php' ), 'datamachine/send-message facade class is removed' );
 $assert( ! str_contains( $chat_abilities, 'SendMessageAbility' ), 'ChatAbilities no longer registers datamachine/send-message' );
 $assert( str_contains( $chat_api, "wp_get_ability( 'agents/chat' )" ), 'REST chat endpoint dispatches directly through canonical agents/chat' );

--- a/tests/chat-caller-context-smoke.php
+++ b/tests/chat-caller-context-smoke.php
@@ -69,6 +69,14 @@ namespace DataMachine\Core {
 			unset( $key );
 			return $default;
 		}
+
+		public static function resolveModelForAgentMode( int $agent_id, string $mode ): array {
+			unset( $agent_id, $mode );
+			return array(
+				'provider' => 'test-provider',
+				'model'    => 'test-model',
+			);
+		}
 	}
 }
 
@@ -78,8 +86,12 @@ namespace DataMachine\Core\Database\Chat {
 			'session_id' => 'caller-context-session',
 			'user_id'    => 700,
 			'agent_id'   => 9,
+			'agent_slug' => 'agent-9',
 			'messages'   => array(),
 			'metadata'   => array(),
+			'mode'       => 'chat',
+			'provider'   => 'test-provider',
+			'model'      => 'test-model',
 			'title'      => 'Existing title',
 		);
 
@@ -229,6 +241,10 @@ namespace {
 		return $value instanceof WP_Error;
 	}
 
+	function sanitize_key( string $key ): string {
+		return strtolower( preg_replace( '/[^a-z0-9_-]/', '', $key ) ?? '' );
+	}
+
 	function current_time( string $type, bool $gmt = false ): string {
 		unset( $type, $gmt );
 		return '2026-07-20 00:00:00';
@@ -331,6 +347,23 @@ namespace {
 		)
 	);
 	$assert_same( 'preserved', $response['metadata']['datamachine']['response_marker'] ?? null, 'loop response metadata survives final response assembly' );
+
+	$store = \DataMachine\Core\Database\Chat\ConversationStoreFactory::get();
+	$store->session['metadata']['status']          = 'processing';
+	$store->session['metadata']['has_pending_tools'] = true;
+	$store->session['metadata']['calling_user_id'] = 52;
+	\DataMachine\Api\Chat\ChatOrchestrator::processContinue( 'caller-context-session', 700 );
+	$assert_same( 52, $GLOBALS['datamachine_chat_caller_resolver_args'][4]['calling_user_id'], 'processContinue restores the delegated caller from session metadata' );
+	$assert_same( 52, $GLOBALS['datamachine_chat_caller_loop_tools'][4]['caller_tool']['caller'], 'delegated caller-sensitive tool remains visible after continuation' );
+
+	$store->session['metadata']['status']          = 'processing';
+	$store->session['metadata']['has_pending_tools'] = true;
+	$store->session['metadata']['calling_user_id'] = 52;
+	\DataMachine\Api\Chat\ChatOrchestrator::processContinue( 'caller-context-session', 700, 0 );
+	$assert_same( 0, $GLOBALS['datamachine_chat_caller_resolver_args'][5]['calling_user_id'], 'processContinue preserves an explicit no-human override' );
+	$assert_same( array(), $GLOBALS['datamachine_chat_caller_loop_tools'][5], 'owner-scoped tools do not appear after no-human continuation' );
+	$assert_same( 700, $GLOBALS['datamachine_chat_caller_loop_context'][5]['user_id'], 'continued no-human context retains separate runtime ownership' );
+	$assert_same( 0, $GLOBALS['datamachine_chat_caller_loop_context'][5]['calling_user_id'], 'continued no-human context does not inherit the runtime owner' );
 
 	if ( $failures ) {
 		echo "\nFAILED: " . count( $failures ) . " assertion(s)\n";

--- a/tests/chat-caller-context-smoke.php
+++ b/tests/chat-caller-context-smoke.php
@@ -1,0 +1,341 @@
+<?php
+/**
+ * Pure-PHP regression coverage for chat caller identity propagation.
+ *
+ * Run with: php tests/chat-caller-context-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+namespace AgentsAPI\AI {
+	final class WP_Agent_Execution_Principal {
+		public function __construct( public readonly int $acting_user_id ) {}
+	}
+}
+
+namespace AgentsAPI\AI\Channels {
+	function register_chat_handler( callable $handler ): void {
+		$GLOBALS['datamachine_chat_caller_handler'] = $handler;
+	}
+}
+
+namespace DataMachine\Abilities {
+	class PermissionHelper {
+		public static ?\AgentsAPI\AI\WP_Agent_Execution_Principal $principal = null;
+
+		public static function get_execution_principal(): ?\AgentsAPI\AI\WP_Agent_Execution_Principal {
+			return self::$principal;
+		}
+
+		public static function can( string $action ): bool {
+			unset( $action );
+			return true;
+		}
+
+		public static function acting_user_id(): int {
+			return 700;
+		}
+
+		public static function get_acting_token_id(): ?int {
+			return null;
+		}
+	}
+}
+
+namespace DataMachine\Abilities\Chat {
+	class ChatTranscriptOwner {
+		public static function resolve_for_request( array $options, int $user_id ): array {
+			unset( $options );
+			return array(
+				'type' => 'user',
+				'key'  => (string) $user_id,
+			);
+		}
+	}
+}
+
+namespace DataMachine\Core\Agents {
+	class AgentIdentity {}
+	class AgentIdentityResolver {}
+}
+
+namespace DataMachine\Core {
+	class PluginSettings {
+		public const DEFAULT_MAX_TURNS = 25;
+
+		public static function get( string $key, mixed $default = null ): mixed {
+			unset( $key );
+			return $default;
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Chat {
+	class CallerContextStore {
+		public array $session = array(
+			'session_id' => 'caller-context-session',
+			'user_id'    => 700,
+			'agent_id'   => 9,
+			'messages'   => array(),
+			'metadata'   => array(),
+			'title'      => 'Existing title',
+		);
+
+		public function get_session( string $session_id ): array {
+			unset( $session_id );
+			return $this->session;
+		}
+
+		public function session_matches_owner( array $session, array $owner ): bool {
+			unset( $session, $owner );
+			return true;
+		}
+
+		public function acquire_session_lock( string $session_id ): string {
+			unset( $session_id );
+			return 'lock';
+		}
+
+		public function release_session_lock( string $session_id, string $lock ): void {
+			unset( $session_id, $lock );
+		}
+
+		public function update_session( string $session_id, array $messages, array $metadata, string $provider, string $model ): bool {
+			unset( $session_id, $provider, $model );
+			$this->session['messages'] = $messages;
+			$this->session['metadata'] = $metadata;
+			return true;
+		}
+	}
+
+	class ConversationStoreFactory {
+		private static ?CallerContextStore $store = null;
+
+		public static function get(): CallerContextStore {
+			self::$store ??= new CallerContextStore();
+			return self::$store;
+		}
+
+		public static function resolve_agent_slug_for_transcript( int $agent_id ): string {
+			return 'agent-' . $agent_id;
+		}
+	}
+}
+
+namespace DataMachine\Core\Workspace {
+	class WordPressWorkspaceScope {
+		public static function current(): string {
+			return 'site:test';
+		}
+	}
+}
+
+namespace DataMachine\Engine\AI\Tools {
+	class ToolManager {}
+
+	class ToolPolicyResolver {
+		public const MODE_CHAT = 'chat';
+
+		public static function normalizeModes( mixed $modes ): array {
+			return array_values( array_filter( array_map( 'strval', (array) $modes ) ) );
+		}
+
+		public function resolve( array $args ): array {
+			$GLOBALS['datamachine_chat_caller_resolver_args'][] = $args;
+			$calling_user_id = (int) ( $args['calling_user_id'] ?? 0 );
+			return $calling_user_id > 0
+				? array( 'caller_tool' => array( 'caller' => $calling_user_id ) )
+				: array();
+		}
+	}
+}
+
+namespace DataMachine\Engine\AI {
+	class ConversationManager {
+		public static function buildConversationMessage( string $role, mixed $content, array $metadata ): array {
+			return compact( 'role', 'content', 'metadata' );
+		}
+
+		public static function buildMultiModalContent( string $message, array $attachments ): array {
+			return compact( 'message', 'attachments' );
+		}
+	}
+
+	class DataMachineAgentConsentPolicy {
+		public static function get(): self {
+			return new self();
+		}
+
+		public function can_store_transcript( array $context ): object {
+			unset( $context );
+			return new class() {
+				public function to_array(): array {
+					return array( 'allowed' => true );
+				}
+			};
+		}
+	}
+
+	function datamachine_run_conversation( array $messages, array $tools, string $provider, string $model, array $modes, array $context, int $max_turns, bool $single_turn ): array {
+		unset( $provider, $model, $modes, $max_turns, $single_turn );
+		$GLOBALS['datamachine_chat_caller_loop_tools'][]   = $tools;
+		$GLOBALS['datamachine_chat_caller_loop_context'][] = $context;
+		$messages[] = array( 'role' => 'assistant', 'content' => 'ok' );
+		return array(
+			'messages'      => $messages,
+			'final_content' => 'ok',
+			'turn_count'    => 1,
+			'usage'         => array(),
+			'metadata'      => array(
+				'completed'        => true,
+				'response_marker'  => 'preserved',
+			),
+		);
+	}
+
+	function datamachine_conversation_metadata( array $result ): array {
+		if ( is_array( $result['metadata']['datamachine'] ?? null ) ) {
+			return $result['metadata']['datamachine'];
+		}
+
+		return is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
+	}
+
+	function datamachine_summarize_tool_execution_results( array $results, bool $include_results ): array {
+		unset( $results, $include_results );
+		return array();
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	class WP_Error {}
+
+	function add_filter( ...$args ): bool {
+		unset( $args );
+		return true;
+	}
+
+	function get_current_user_id(): int {
+		return (int) ( $GLOBALS['datamachine_chat_caller_current_user'] ?? 0 );
+	}
+
+	function is_wp_error( mixed $value ): bool {
+		return $value instanceof WP_Error;
+	}
+
+	function current_time( string $type, bool $gmt = false ): string {
+		unset( $type, $gmt );
+		return '2026-07-20 00:00:00';
+	}
+
+	function home_url( string $path = '' ): string {
+		unset( $path );
+		return 'https://example.test/';
+	}
+
+	function wp_parse_url( string $url, int $component = -1 ): mixed {
+		return parse_url( $url, $component );
+	}
+
+	function set_transient( string $key, mixed $value, int $expiration ): bool {
+		unset( $key, $value, $expiration );
+		return true;
+	}
+
+	function wp_get_ability( string $name ): null {
+		unset( $name );
+		return null;
+	}
+
+	function do_action( ...$args ): void {
+		unset( $args );
+	}
+
+	function __( string $text, string $domain = 'default' ): string {
+		unset( $domain );
+		return $text;
+	}
+
+	require_once dirname( __DIR__ ) . '/inc/Abilities/Chat/AgentsChatHandler.php';
+	require_once dirname( __DIR__ ) . '/inc/Api/Chat/ChatOrchestrator.php';
+
+	$failures = array();
+	$assert_same = static function ( mixed $expected, mixed $actual, string $label ) use ( &$failures ): void {
+		if ( $expected === $actual ) {
+			echo "PASS: {$label}\n";
+			return;
+		}
+
+		$failures[] = $label;
+		echo "FAIL: {$label}\n";
+		echo '  expected: ' . var_export( $expected, true ) . "\n";
+		echo '  actual:   ' . var_export( $actual, true ) . "\n";
+	};
+
+	$handler = new \DataMachine\Abilities\Chat\AgentsChatHandler();
+	$method  = new ReflectionMethod( $handler, 'resolveCallingUserId' );
+
+	$GLOBALS['datamachine_chat_caller_current_user'] = 41;
+	$assert_same( 41, $method->invoke( $handler, array() ), 'browser caller uses the authenticated WordPress user' );
+
+	\DataMachine\Abilities\PermissionHelper::$principal = new \AgentsAPI\AI\WP_Agent_Execution_Principal( 52 );
+	$assert_same( 52, $method->invoke( $handler, array() ), 'delegated execution principal preserves its acting user' );
+
+	\DataMachine\Abilities\PermissionHelper::$principal = new \AgentsAPI\AI\WP_Agent_Execution_Principal( 0 );
+	$assert_same( 0, $method->invoke( $handler, array() ), 'system execution principal does not inherit the browser or runtime owner' );
+	\DataMachine\Abilities\PermissionHelper::$principal = null;
+
+	$run_turn = static function ( int $calling_user_id ): array {
+		return \DataMachine\Api\Chat\ChatOrchestrator::executeConversationTurn(
+			'caller-context-session',
+			array(),
+			'test-provider',
+			'test-model',
+			array(
+				'user_id'         => 700,
+				'calling_user_id' => $calling_user_id,
+				'agent_id'        => 9,
+				'modes'           => array( 'chat' ),
+			)
+		);
+	};
+
+	$run_turn( 41 );
+	$assert_same( 41, $GLOBALS['datamachine_chat_caller_resolver_args'][0]['calling_user_id'], 'browser caller reaches tool resolution' );
+	$assert_same( 41, $GLOBALS['datamachine_chat_caller_loop_tools'][0]['caller_tool']['caller'], 'browser caller-sensitive tool is visible' );
+
+	$run_turn( 52 );
+	$assert_same( 52, $GLOBALS['datamachine_chat_caller_resolver_args'][1]['calling_user_id'], 'delegated acting user reaches tool resolution' );
+	$assert_same( 52, $GLOBALS['datamachine_chat_caller_loop_context'][1]['calling_user_id'], 'delegated acting user reaches the conversation turn' );
+
+	$run_turn( 0 );
+	$assert_same( array(), $GLOBALS['datamachine_chat_caller_loop_tools'][2], 'system context does not receive caller-sensitive tools' );
+	$assert_same( 700, $GLOBALS['datamachine_chat_caller_loop_context'][2]['user_id'], 'system context retains separate runtime ownership' );
+	$assert_same( 0, $GLOBALS['datamachine_chat_caller_loop_context'][2]['calling_user_id'], 'system context retains an explicit no-human caller' );
+
+	$response = \DataMachine\Api\Chat\ChatOrchestrator::processChat(
+		'hello',
+		'test-provider',
+		'test-model',
+		700,
+		array(
+			'session_id'      => 'caller-context-session',
+			'agent_id'        => 9,
+			'calling_user_id' => 52,
+		)
+	);
+	$assert_same( 'preserved', $response['metadata']['datamachine']['response_marker'] ?? null, 'loop response metadata survives final response assembly' );
+
+	if ( $failures ) {
+		echo "\nFAILED: " . count( $failures ) . " assertion(s)\n";
+		exit( 1 );
+	}
+
+	echo "\nOK: chat caller context regression assertions passed.\n";
+}

--- a/tests/runtime-tool-contract-store-smoke.php
+++ b/tests/runtime-tool-contract-store-smoke.php
@@ -13,6 +13,33 @@ namespace DataMachine\Core {
 	class PluginSettings {
 		public const DEFAULT_MAX_TURNS = 8;
 	}
+
+	class EngineData {
+		public static function mutate( int $job_id, callable $callback, string $event_type ): array {
+			unset( $event_type );
+			$current = \DataMachine\Core\Database\Jobs\Jobs::$engine_data[ $job_id ] ?? array();
+			\DataMachine\Core\Database\Jobs\Jobs::$engine_data[ $job_id ] = $callback( $current );
+
+			return array( 'success' => true );
+		}
+	}
+}
+
+namespace DataMachine\Api\Chat {
+	class ChatOrchestrator {
+		public static array $calls = array();
+
+		public static function processContinue( string $session_id, int $user_id, ?int $calling_user_id = null ): array {
+			self::$calls[] = array(
+				'session_id'      => $session_id,
+				'user_id'         => $user_id,
+				'calling_user_id' => $calling_user_id,
+				'tools'           => null !== $calling_user_id && $calling_user_id > 0 ? array( 'owner_tool' ) : array(),
+			);
+
+			return array();
+		}
+	}
 }
 
 namespace DataMachine\Core\Database\Jobs {
@@ -104,6 +131,7 @@ namespace {
 	use DataMachine\Core\Database\Jobs\Jobs;
 	use function DataMachine\Engine\AI\datamachine_defer_runtime_tool_call;
 	use function DataMachine\Engine\AI\datamachine_runtime_tool_request_store;
+	use function DataMachine\Engine\AI\datamachine_resume_runtime_tool_request;
 	use function DataMachine\Engine\AI\datamachine_session_has_pending_runtime_tools;
 	use function DataMachine\Engine\AI\datamachine_submit_runtime_tool_result;
 	use function DataMachine\Engine\AI\datamachine_timeout_runtime_tool_request;
@@ -201,9 +229,10 @@ namespace {
 			'modes'      => array( 'chat' ),
 		),
 		array(
-			'user_id'        => 7,
-			'agent_id'       => 11,
-			'client_context' => array( 'runtime_tool_timeout' => 30 ),
+			'user_id'         => 7,
+			'calling_user_id' => 52,
+			'agent_id'        => 11,
+			'client_context'  => array( 'runtime_tool_timeout' => 30 ),
 		)
 	);
 
@@ -212,6 +241,7 @@ namespace {
 	$assert( WP_Agent_Runtime_Tool_Request::STATUS_PENDING === ( $request['status'] ?? '' ), 'deferred request uses canonical pending status' );
 	$assert( 'call-1' === ( $request['tool_call_id'] ?? '' ), 'deferred request carries canonical tool_call_id' );
 	$assert( 'pending' === ( $request['metadata']['datamachine']['persistence_status'] ?? '' ), 'deferred request keeps Data Machine persistence status namespaced' );
+	$assert( 52 === ( $request['metadata']['datamachine']['calling_user_id'] ?? null ), 'deferred request persists the delegated acting caller separately from runtime ownership' );
 	$assert( isset( Jobs::$engine_data[1]['runtime_tool_request'] ), 'store adapter persists request in job engine data' );
 	$assert( isset( $chat_db->sessions['session-1']['metadata']['runtime_tool_requests'][ $request_id ] ), 'store adapter mirrors request into session metadata' );
 	$assert( 'datamachine_runtime_tool_timeout' === ( $GLOBALS['datamachine_runtime_tool_scheduled'][0]['hook'] ?? '' ), 'deferred request schedules timeout action' );
@@ -226,6 +256,12 @@ namespace {
 	$assert( 1 === count( $chat_db->sessions['session-1']['messages'] ), 'submitted result appends a transcript tool message' );
 	$assert( false === ( $chat_db->sessions['session-1']['metadata']['has_pending_tools'] ?? true ), 'submitted result clears pending session state' );
 	$assert( 'datamachine_runtime_tool_resume' === ( $GLOBALS['datamachine_runtime_tool_enqueued'][0]['hook'] ?? '' ), 'submitted result enqueues resume action' );
+	datamachine_resume_runtime_tool_request( $request_id );
+	$delegated_resume = \DataMachine\Api\Chat\ChatOrchestrator::$calls[0] ?? array();
+	$assert( 7 === ( $delegated_resume['user_id'] ?? null ), 'async delegated resume retains runtime/session ownership' );
+	$assert( 52 === ( $delegated_resume['calling_user_id'] ?? null ), 'async delegated resume restores the original acting caller' );
+	$assert( array( 'owner_tool' ) === ( $delegated_resume['tools'] ?? null ), 'delegated caller-scoped tools remain visible after async resume' );
+	$assert( 52 === ( Jobs::$engine_data[1]['runtime_tool_run_state']['resume_payload']['calling_user_id'] ?? null ), 'runtime run-state records the delegated caller in its resume payload' );
 
 	$timeout_pending = datamachine_defer_runtime_tool_call(
 		array(
@@ -242,6 +278,34 @@ namespace {
 	$assert( 'failed' === ( $timeout_stored['metadata']['datamachine']['persistence_status'] ?? '' ), 'timeout marks namespaced Data Machine status failed' );
 	$assert( 'runtime_tool_timeout' === ( $timeout_stored['metadata']['datamachine']['result']['metadata']['datamachine']['code'] ?? '' ), 'timeout stores canonical error result metadata' );
 	$assert( 'failed' === ( Jobs::$jobs[2]['status'] ?? '' ), 'timeout fails the Data Machine job' );
+
+	$chat_db->sessions['session-system'] = array( 'messages' => array(), 'metadata' => array(), 'provider' => 'openai', 'model' => 'gpt' );
+	$system_pending = datamachine_defer_runtime_tool_call(
+		array(
+			'tool_name'  => 'client/select_block',
+			'call_id'    => 'call-system',
+			'parameters' => array(),
+			'turn_count' => 2,
+			'session_id' => 'session-system',
+			'mode'       => 'chat',
+			'modes'      => array( 'chat' ),
+		),
+		array(
+			'user_id'         => 7,
+			'calling_user_id' => 0,
+			'agent_id'        => 11,
+		)
+	);
+	$system_request    = $system_pending['runtime_tool_request'] ?? array();
+	$system_request_id = (string) ( $system_request['request_id'] ?? '' );
+	$assert( 0 === ( $system_request['metadata']['datamachine']['calling_user_id'] ?? null ), 'deferred request preserves an explicit no-human caller' );
+	datamachine_submit_runtime_tool_result( $system_request_id, array( 'selected_id' => 'block-2' ) );
+	datamachine_resume_runtime_tool_request( $system_request_id );
+	$system_resume = \DataMachine\Api\Chat\ChatOrchestrator::$calls[1] ?? array();
+	$assert( 7 === ( $system_resume['user_id'] ?? null ), 'async no-human resume retains runtime/session ownership' );
+	$assert( 0 === ( $system_resume['calling_user_id'] ?? null ), 'async no-human resume restores explicit zero without owner fallback' );
+	$assert( array() === ( $system_resume['tools'] ?? null ), 'owner-scoped tools do not appear after async no-human resume' );
+	$assert( 0 === ( Jobs::$engine_data[3]['runtime_tool_run_state']['resume_payload']['calling_user_id'] ?? null ), 'runtime run-state records explicit zero in its resume payload' );
 
 	$assert( array() === datamachine_runtime_tool_request_store()->recent_pending(), 'store adapter implements the Agents API recent-pending contract' );
 


### PR DESCRIPTION
## Summary
- resolve the authenticated acting caller before chat tool policy resolution
- keep `calling_user_id` separate from runtime, agent, and transcript ownership across initial and continued turns
- persist caller identity through session metadata and async runtime-tool request/run state, including explicit zero
- preserve loop response metadata from the actual turn result

## Identity Flow
Before this change, chat tools resolved with the runtime/session `user_id` only. `calling_user_id` was derived afterward, so caller-sensitive filters saw an anonymous caller. Continuations then rebuilt context from session ownership, and async runtime-tool requests persisted no caller identity, allowing an explicit no-human `0` to become the runtime owner after resume.

After this change, `AgentsChatHandler` derives the acting caller from the execution principal when one exists, including an explicit `0` for no-human system/runtime contexts, and otherwise uses the authenticated browser user. `ChatOrchestrator` persists that resolved value in session metadata and supplies it to both `ToolPolicyResolver` and the conversation turn. `processContinue()` restores the stored caller or accepts the async request's explicit override. Runtime-tool request metadata and durable resume state carry the same value, preserving zero without fallback.

Runtime user, agent identity/owner, transcript owner, and acting caller remain distinct across initial turns, direct continuation, submitted runtime-tool resume, and timeout resume.

## Compatibility
- Existing direct `processChat()` callers retain the previous fallback where runtime `user_id` is also the caller unless they pass `calling_user_id` explicitly.
- Legacy sessions and runtime-tool requests without caller metadata retain the runtime/session-owner fallback.
- Existing explicit `calling_user_id => 0` system paths remain no-human contexts through continuation and async resume.
- `processContinue()` adds an optional third argument; existing two-argument callers remain compatible.
- No product-specific logic or parallel identity field was added.

## Test Evidence
- `php tests/chat-caller-context-smoke.php` validates browser, delegated, and no-human initial turns; direct `processContinue()` restoration; explicit-zero override; and absence of owner-scoped tools after no-human continuation.
- `php tests/runtime-tool-contract-store-smoke.php` validates delegated and zero caller persistence in canonical requests, session mirrors, durable resume payloads, and async `processContinue()` dispatch; owner-scoped tools remain absent after zero-caller resume.
- `php tests/runtime-tool-async-broker-smoke.php`
- `php tests/agents-chat-handler-smoke.php`
- `php tests/agents-chat-access-permission-smoke.php`
- `php tests/agents-chat-tool-continuation-smoke.php`
- `php tests/calling-user-id-payload-smoke.php`
- `php tests/pipeline-tool-policy-snapshot-smoke.php` (57 assertions)
- PHP syntax checks for all changed production and regression files
- PHPCS for all changed production and regression files
- `git diff --check`

Fixes #2905