### PR TITLE
feat: expose invocation input to action policies

### DIFF
--- a/inc/Engine/AI/Actions/ActionPolicyResolver.php
+++ b/inc/Engine/AI/Actions/ActionPolicyResolver.php
@@ -78,6 +78,7 @@ class ActionPolicyResolver {
 	 *     @type string     $tool_name      Required. The tool being invoked.
 	 *     @type string     $mode           Required. Agent mode (chat/pipeline/system).
 	 *     @type array      $tool_def       Optional. Tool definition (to read `action_policy` default).
+	 *     @type array      $input          Optional. Normalized invocation input.
 	 *     @type int|null   $agent_id       Optional. Acting agent ID for per-agent overrides.
 	 *     @type array      $client_context Optional. Client-supplied runtime context.
 	 *     @type string[]   $deny           Optional. Tools to forcibly forbid in this call.
@@ -85,6 +86,7 @@ class ActionPolicyResolver {
 	 * @return string One of the POLICY_* constants.
 	 */
 	public function resolveForTool( array $context ): string {
+		$context['input'] = is_array( $context['input'] ?? null ) ? $context['input'] : array();
 		$context = $this->withAgentConfig( $context );
 		$policy  = $this->resolver->resolve_for_tool( $context );
 

--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -95,6 +95,7 @@ class ToolExecutor {
 					'tool_name' => $tool_name,
 					'tool_def'  => $tool_def,
 					'mode'      => $mode,
+					'input'     => $complete_parameters,
 				)
 			)
 		);

--- a/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
+++ b/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
@@ -9,6 +9,7 @@ namespace DataMachine\Tests\Unit\AI\Tools;
 
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+use DataMachine\Engine\AI\Actions\PendingActionStore;
 use DataMachine\Engine\AI\Tools\ToolExecutor;
 use DataMachine\Engine\AI\Tools\ToolManager;
 use WP_UnitTestCase;
@@ -453,6 +454,76 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 		$this->assertTrue( $allowed['success'] );
 		$this->assertFalse( $forbidden['success'] );
 		$this->assertSame( 'forbidden', $forbidden['action_policy'] );
+	}
+
+	public function test_execute_tool_policy_provider_receives_complete_input_across_direct_and_staged_paths(): void {
+		add_filter(
+			'agents_api_action_policy_providers',
+			static function ( $providers ) {
+				$providers[] = new class() implements \WP_Agent_Action_Policy_Provider {
+					public function get_action_policy( array $context ): ?string {
+						return 'read' === ( $context['input']['operation'] ?? '' ) ? 'direct' : 'preview';
+					}
+				};
+
+				return $providers;
+			},
+			10,
+			1
+		);
+
+		$tools = array(
+			'input_sensitive_tool' => array(
+				'class'                   => TestToolHandler::class,
+				'method'                  => 'handle_tool_call',
+				'action_kind'             => 'input_sensitive_action',
+				'parameters'              => array(
+					'operation' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+					'target'    => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+				),
+				'client_context_bindings' => array( 'target' => 'bound_target' ),
+			),
+		);
+
+		$read = ToolExecutor::executeTool(
+			'input_sensitive_tool',
+			array( 'operation' => 'read' ),
+			$tools,
+			array(),
+			'chat',
+			0,
+			array( 'bound_target' => 'record-1' )
+		);
+		$write = ToolExecutor::executeTool(
+			'input_sensitive_tool',
+			array( 'operation' => 'write' ),
+			$tools,
+			array(),
+			'chat',
+			0,
+			array( 'bound_target' => 'record-2' )
+		);
+
+		$this->assertTrue( $read['success'] );
+		$this->assertSame( 'record-1', $read['result']['data']['target'] ?? null );
+		$this->assertTrue( $write['staged'] );
+		$this->assertSame( 'preview', $write['action_policy'] );
+
+		$pending_action = PendingActionStore::get( $write['action_id'] );
+		$this->assertSame(
+			array(
+				'operation' => 'write',
+				'target'    => 'record-2',
+			),
+			$pending_action['apply_input'] ?? null
+		);
+		PendingActionStore::delete( $write['action_id'] );
 	}
 
 	public function test_resolve_tools_invokes_callables(): void {

--- a/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
+++ b/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
@@ -456,13 +456,28 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 		$this->assertSame( 'forbidden', $forbidden['action_policy'] );
 	}
 
-	public function test_execute_tool_policy_provider_receives_complete_input_across_direct_and_staged_paths(): void {
+	public function test_execute_tool_policy_provider_receives_complete_input_across_all_policy_outcomes(): void {
+		$seen_contexts = array();
 		add_filter(
 			'agents_api_action_policy_providers',
-			static function ( $providers ) {
-				$providers[] = new class() implements \WP_Agent_Action_Policy_Provider {
+			static function ( $providers ) use ( &$seen_contexts ) {
+				$providers[] = new class( $seen_contexts ) implements \WP_Agent_Action_Policy_Provider {
+					/** @var array<int,array<string,mixed>> */
+					private array $seen_contexts;
+
+					public function __construct( array &$seen_contexts ) {
+						$this->seen_contexts =& $seen_contexts;
+					}
+
 					public function get_action_policy( array $context ): ?string {
-						return 'read' === ( $context['input']['operation'] ?? '' ) ? 'direct' : 'preview';
+						$this->seen_contexts[] = $context;
+
+						return match ( $context['input']['operation'] ?? '' ) {
+							'read'  => 'direct',
+							'write' => 'preview',
+							'delete' => 'forbidden',
+							default => null,
+						};
 					}
 				};
 
@@ -482,12 +497,17 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 						'type'     => 'string',
 						'required' => true,
 					),
-					'target'    => array(
+					'query'     => array(
 						'type'     => 'string',
 						'required' => true,
 					),
+					'scope'     => array(
+						'type'     => 'string',
+						'required' => false,
+					),
 				),
-				'client_context_bindings' => array( 'target' => 'bound_target' ),
+				'client_context_bindings' => array( 'query' => 'bound_query' ),
+				'parameter_defaults'      => array( 'scope' => 'all' ),
 			),
 		);
 
@@ -498,7 +518,7 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 			array(),
 			'chat',
 			0,
-			array( 'bound_target' => 'record-1' )
+			array( 'bound_query' => 'record-1' )
 		);
 		$write = ToolExecutor::executeTool(
 			'input_sensitive_tool',
@@ -507,19 +527,57 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 			array(),
 			'chat',
 			0,
-			array( 'bound_target' => 'record-2' )
+			array( 'bound_query' => 'record-2' )
+		);
+		$forbidden = ToolExecutor::executeTool(
+			'input_sensitive_tool',
+			array( 'operation' => 'delete' ),
+			$tools,
+			array(),
+			'chat',
+			0,
+			array( 'bound_query' => 'record-3' )
 		);
 
 		$this->assertTrue( $read['success'] );
-		$this->assertSame( 'record-1', $read['result']['data']['target'] ?? null );
+		$this->assertSame( 'record-1', $read['result']['data']['query'] ?? null );
 		$this->assertTrue( $write['staged'] );
 		$this->assertSame( 'preview', $write['action_policy'] );
+		$this->assertFalse( $forbidden['success'] );
+		$this->assertSame( 'forbidden', $forbidden['action_policy'] );
+
+		$this->assertCount( 3, $seen_contexts );
+		$this->assertSame(
+			array(
+				'scope'     => 'all',
+				'query'     => 'record-1',
+				'operation' => 'read',
+			),
+			$seen_contexts[0]['input'] ?? null
+		);
+		$this->assertSame(
+			array(
+				'scope'     => 'all',
+				'query'     => 'record-2',
+				'operation' => 'write',
+			),
+			$seen_contexts[1]['input'] ?? null
+		);
+		$this->assertSame(
+			array(
+				'scope'     => 'all',
+				'query'     => 'record-3',
+				'operation' => 'delete',
+			),
+			$seen_contexts[2]['input'] ?? null
+		);
 
 		$pending_action = PendingActionStore::get( $write['action_id'] );
 		$this->assertSame(
 			array(
+				'scope'     => 'all',
+				'query'     => 'record-2',
 				'operation' => 'write',
-				'target'    => 'record-2',
 			),
 			$pending_action['apply_input'] ?? null
 		);

--- a/tests/Unit/Engine/AI/Actions/ActionPolicyResolverTest.php
+++ b/tests/Unit/Engine/AI/Actions/ActionPolicyResolverTest.php
@@ -193,6 +193,64 @@ class ActionPolicyResolverTest extends WP_UnitTestCase {
 		$this->assertSame( ActionPolicyResolver::POLICY_FORBIDDEN, $policy );
 	}
 
+	public function test_filter_can_resolve_policy_from_normalized_input(): void {
+		add_filter(
+			'datamachine_tool_action_policy',
+			static function ( $policy, $tool_name, $mode, $context ) {
+				return 'read' === ( $context['input']['operation'] ?? '' ) ? 'direct' : 'preview';
+			},
+			10,
+			4
+		);
+
+		$read_policy = $this->resolver->resolveForTool(
+			array(
+				'tool_name' => 'records',
+				'mode'      => ActionPolicyResolver::MODE_CHAT,
+				'input'     => array( 'operation' => 'read' ),
+			)
+		);
+		$write_policy = $this->resolver->resolveForTool(
+			array(
+				'tool_name' => 'records',
+				'mode'      => ActionPolicyResolver::MODE_CHAT,
+				'input'     => array( 'operation' => 'write' ),
+			)
+		);
+
+		$this->assertSame( ActionPolicyResolver::POLICY_DIRECT, $read_policy );
+		$this->assertSame( ActionPolicyResolver::POLICY_PREVIEW, $write_policy );
+	}
+
+	public function test_absent_and_invalid_input_are_normalized_to_empty_array(): void {
+		$seen_inputs = array();
+		add_filter(
+			'datamachine_tool_action_policy',
+			static function ( $policy, $tool_name, $mode, $context ) use ( &$seen_inputs ) {
+				$seen_inputs[] = $context['input'] ?? null;
+				return $policy;
+			},
+			10,
+			4
+		);
+
+		$this->resolver->resolveForTool(
+			array(
+				'tool_name' => 'records',
+				'mode'      => ActionPolicyResolver::MODE_CHAT,
+			)
+		);
+		$this->resolver->resolveForTool(
+			array(
+				'tool_name' => 'records',
+				'mode'      => ActionPolicyResolver::MODE_CHAT,
+				'input'     => 'invalid',
+			)
+		);
+
+		$this->assertSame( array( array(), array() ), $seen_inputs );
+	}
+
 	public function test_filter_garbage_return_is_ignored(): void {
 		add_filter(
 			'datamachine_tool_action_policy',


### PR DESCRIPTION
## Summary
- expose normalized, complete invocation input as `context['input']` throughout the existing action-policy resolver contract
- let generic policy providers and filters distinguish read-like and write-like operations without introducing another policy system
- verify direct, forbidden, and staged pending-action paths receive the same complete input

## API and compatibility
- `ActionPolicyResolver::resolveForTool()` now guarantees `context['input']` is an array; absent or invalid values normalize to `array()`
- `ToolExecutor` supplies the complete parameters returned by Agents API preparation, including declared context bindings and parameter defaults
- existing static tool, mode, agent, and category policies retain their precedence and behavior
- existing WordPress filter callbacks with fewer accepted arguments remain compatible through native callback arity; no wrappers or alternate callback contracts were added

## Call-site audit
- `ToolExecutor::executeTool()` is the sole production caller of `resolveForTool()` and now passes complete normalized input before direct execution, refusal, or preview staging
- chat and pipeline callers both route through `ToolExecutor`, so they receive the same contract
- pending-action resolution does not re-resolve action policy; its async boundary consumes the `apply_input` staged by `ToolExecutor`, tested to equal the complete policy input

## Test coverage
- provider contexts are captured for `direct`, `preview`, and `forbidden` outcomes
- each captured input must contain raw invocation data, a context-bound parameter, and a declaration-defaulted parameter, so the test fails if raw parameters are passed instead of prepared complete parameters
- the direct path asserts the existing test handler's actual `query` result
- the staged path asserts persisted `apply_input` exactly matches the complete provider input
- existing static policy and reduced-arity callback tests remain unchanged

## Test evidence
- `composer lint` passes
- modified-file PHP syntax and PHPCS checks pass
- direct Agents API parameter-preparation assertion passes for raw, bound, and defaulted values
- `php tests/pending-actions-agents-api-contract-smoke.php` passes 93 assertions
- focused and full `homeboy review test` runs were attempted after the test correction; both remain blocked before PHPUnit discovery because Codebox mounts an incomplete Composer autoloader (`Composer\\Autoload\\ClassLoader` missing), tracked in Extra-Chill/homeboy#9257
- broader tool-source standalone smoke loading remains tracked in Extra-Chill/data-machine#2908

Fixes #2906