### PR TITLE
fix: preserve direct job ownership and idempotency

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -60,6 +60,11 @@ class ExecuteStepAbility {
 								'type'        => 'string',
 								'description' => __( 'Flow step ID to execute.', 'data-machine' ),
 							),
+							'operation_generation' => array(
+								'type'        => 'integer',
+								'minimum'     => 0,
+								'description' => __( 'Direct workflow execution generation.', 'data-machine' ),
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -68,6 +73,7 @@ class ExecuteStepAbility {
 							'success'      => array( 'type' => 'boolean' ),
 							'step_success' => array( 'type' => 'boolean' ),
 							'outcome'      => array( 'type' => 'string' ),
+							'stale_generation' => array( 'type' => 'boolean' ),
 							'error'        => array( 'type' => 'string' ),
 						),
 					),
@@ -97,12 +103,21 @@ class ExecuteStepAbility {
 	public function execute( array $input ): array {
 		$job_id       = (int) ( $input['job_id'] ?? 0 );
 		$flow_step_id = (string) ( $input['flow_step_id'] ?? '' );
+		$operation_generation = max( 0, (int) ( $input['operation_generation'] ?? 0 ) );
 		$job          = $this->db_jobs->get_job( $job_id );
 
 		if ( ! $job ) {
 			return array(
 				'success' => false,
 				'error'   => sprintf( 'Job %d not found.', $job_id ),
+			);
+		}
+
+		if ( $operation_generation > 0 && $operation_generation !== (int) ( $job['operation_generation'] ?? 0 ) ) {
+			return array(
+				'success'          => false,
+				'error'            => sprintf( 'Job %d execution generation %d is stale.', $job_id, $operation_generation ),
+				'stale_generation' => true,
 			);
 		}
 
@@ -207,6 +222,16 @@ class ExecuteStepAbility {
 			);
 
 			$step_output      = $flow_step->execute( $payload );
+			if ( $operation_generation > 0 ) {
+				$job_after_execution = $this->db_jobs->get_job( $job_id );
+				if ( ! is_array( $job_after_execution ) || $operation_generation !== (int) ( $job_after_execution['operation_generation'] ?? 0 ) ) {
+					return array(
+						'success'          => false,
+						'error'            => sprintf( 'Job %d execution generation %d was superseded.', $job_id, $operation_generation ),
+						'stale_generation' => true,
+					);
+				}
+			}
 			$execution_result = StepExecutionResult::fromStepOutput( $step_output, $step_type );
 			$dataPackets      = $execution_result['packets'];
 			$step_success     = (bool) $execution_result['success'];
@@ -245,6 +270,17 @@ class ExecuteStepAbility {
 				)
 			);
 
+			if ( $operation_generation > 0 ) {
+				$job_before_routing = $this->db_jobs->get_job( $job_id );
+				if ( ! is_array( $job_before_routing ) || $operation_generation !== (int) ( $job_before_routing['operation_generation'] ?? 0 ) ) {
+					return array(
+						'success'          => false,
+						'error'            => sprintf( 'Job %d execution generation %d was superseded before routing.', $job_id, $operation_generation ),
+						'stale_generation' => true,
+					);
+				}
+			}
+
 			$result = $this->routeAfterExecution(
 				$job_id,
 				$flow_step_id,
@@ -278,6 +314,16 @@ class ExecuteStepAbility {
 
 			return $result;
 		} catch ( \Throwable $e ) {
+			if ( $operation_generation > 0 ) {
+				$job_after_exception = $this->db_jobs->get_job( $job_id );
+				if ( ! is_array( $job_after_exception ) || $operation_generation !== (int) ( $job_after_exception['operation_generation'] ?? 0 ) ) {
+					return array(
+						'success'          => false,
+						'error'            => sprintf( 'Job %d execution generation %d threw after being superseded.', $job_id, $operation_generation ),
+						'stale_generation' => true,
+					);
+				}
+			}
 			RunMetrics::recordStepResult(
 				$job_id,
 				$flow_step_id,

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -65,6 +65,10 @@ class ExecuteStepAbility {
 								'minimum'     => 0,
 								'description' => __( 'Direct workflow execution generation.', 'data-machine' ),
 							),
+							'operation_claim_token' => array(
+								'type'        => 'string',
+								'description' => __( 'Direct workflow enqueue ownership token.', 'data-machine' ),
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -74,6 +78,8 @@ class ExecuteStepAbility {
 							'step_success' => array( 'type' => 'boolean' ),
 							'outcome'      => array( 'type' => 'string' ),
 							'stale_generation' => array( 'type' => 'boolean' ),
+							'deferred'         => array( 'type' => 'boolean' ),
+							'retryable'        => array( 'type' => 'boolean' ),
 							'error'        => array( 'type' => 'string' ),
 						),
 					),
@@ -104,6 +110,7 @@ class ExecuteStepAbility {
 		$job_id       = (int) ( $input['job_id'] ?? 0 );
 		$flow_step_id = (string) ( $input['flow_step_id'] ?? '' );
 		$operation_generation = max( 0, (int) ( $input['operation_generation'] ?? 0 ) );
+		$operation_claim_token = (string) ( $input['operation_claim_token'] ?? '' );
 		$job          = $this->db_jobs->get_job( $job_id );
 
 		if ( ! $job ) {
@@ -113,12 +120,14 @@ class ExecuteStepAbility {
 			);
 		}
 
-		if ( $operation_generation > 0 && $operation_generation !== (int) ( $job['operation_generation'] ?? 0 ) ) {
-			return array(
-				'success'          => false,
-				'error'            => sprintf( 'Job %d execution generation %d is stale.', $job_id, $operation_generation ),
-				'stale_generation' => true,
-			);
+		if ( $operation_generation > 0 ) {
+			$admission = $this->operationGenerationAdmission( $job, $operation_generation, $operation_claim_token );
+			if ( 'pending_commit' === $admission ) {
+				return $this->deferOperationGeneration( $job_id, $flow_step_id, $operation_generation, $operation_claim_token );
+			}
+			if ( 'committed' !== $admission ) {
+				return $this->staleOperationGeneration( $job_id, $operation_generation, 'is stale or was not durably committed' );
+			}
 		}
 
 		$current_status = (string) ( $job['status'] ?? '' );
@@ -145,6 +154,13 @@ class ExecuteStepAbility {
 				'error'          => $terminal_after_start ? sprintf( 'Job %d has terminal status "%s"; step execution skipped.', $job_id, $current_status ) : sprintf( 'Job %d could not be started from status "%s".', $job_id, $current_status ),
 				'terminal_state' => $terminal_after_start ? $current_status : null,
 			);
+		}
+
+		if ( $operation_generation > 0 ) {
+			$job_before_side_effect = $this->db_jobs->get_job( $job_id );
+			if ( ! is_array( $job_before_side_effect ) || 'committed' !== $this->operationGenerationAdmission( $job_before_side_effect, $operation_generation, $operation_claim_token ) ) {
+				return $this->staleOperationGeneration( $job_id, $operation_generation, 'lost durable ownership before execution' );
+			}
 		}
 
 		try {
@@ -224,12 +240,8 @@ class ExecuteStepAbility {
 			$step_output      = $flow_step->execute( $payload );
 			if ( $operation_generation > 0 ) {
 				$job_after_execution = $this->db_jobs->get_job( $job_id );
-				if ( ! is_array( $job_after_execution ) || $operation_generation !== (int) ( $job_after_execution['operation_generation'] ?? 0 ) ) {
-					return array(
-						'success'          => false,
-						'error'            => sprintf( 'Job %d execution generation %d was superseded.', $job_id, $operation_generation ),
-						'stale_generation' => true,
-					);
+				if ( ! is_array( $job_after_execution ) || 'committed' !== $this->operationGenerationAdmission( $job_after_execution, $operation_generation, $operation_claim_token ) ) {
+					return $this->staleOperationGeneration( $job_id, $operation_generation, 'was superseded during execution' );
 				}
 			}
 			$execution_result = StepExecutionResult::fromStepOutput( $step_output, $step_type );
@@ -272,12 +284,8 @@ class ExecuteStepAbility {
 
 			if ( $operation_generation > 0 ) {
 				$job_before_routing = $this->db_jobs->get_job( $job_id );
-				if ( ! is_array( $job_before_routing ) || $operation_generation !== (int) ( $job_before_routing['operation_generation'] ?? 0 ) ) {
-					return array(
-						'success'          => false,
-						'error'            => sprintf( 'Job %d execution generation %d was superseded before routing.', $job_id, $operation_generation ),
-						'stale_generation' => true,
-					);
+				if ( ! is_array( $job_before_routing ) || 'committed' !== $this->operationGenerationAdmission( $job_before_routing, $operation_generation, $operation_claim_token ) ) {
+					return $this->staleOperationGeneration( $job_id, $operation_generation, 'was superseded before routing' );
 				}
 			}
 
@@ -316,12 +324,8 @@ class ExecuteStepAbility {
 		} catch ( \Throwable $e ) {
 			if ( $operation_generation > 0 ) {
 				$job_after_exception = $this->db_jobs->get_job( $job_id );
-				if ( ! is_array( $job_after_exception ) || $operation_generation !== (int) ( $job_after_exception['operation_generation'] ?? 0 ) ) {
-					return array(
-						'success'          => false,
-						'error'            => sprintf( 'Job %d execution generation %d threw after being superseded.', $job_id, $operation_generation ),
-						'stale_generation' => true,
-					);
+				if ( ! is_array( $job_after_exception ) || 'committed' !== $this->operationGenerationAdmission( $job_after_exception, $operation_generation, $operation_claim_token ) ) {
+					return $this->staleOperationGeneration( $job_id, $operation_generation, 'threw after being superseded' );
 				}
 			}
 			RunMetrics::recordStepResult(
@@ -360,6 +364,51 @@ class ExecuteStepAbility {
 				'error'   => $e->getMessage(),
 			);
 		}
+	}
+
+	private function operationGenerationAdmission( array $job, int $generation, string $token ): string {
+		if ( $generation <= 0 ) {
+			return 'committed';
+		}
+		if ( '' === $token || $generation !== (int) ( $job['operation_generation'] ?? 0 ) || ! hash_equals( $token, (string) ( $job['operation_claim_token'] ?? '' ) ) ) {
+			return 'stale';
+		}
+		if ( 'enqueued' === ( $job['operation_state'] ?? '' ) && (int) ( $job['operation_action_id'] ?? 0 ) > 0 ) {
+			return 'committed';
+		}
+
+		return 'enqueuing' === ( $job['operation_state'] ?? '' ) ? 'pending_commit' : 'stale';
+	}
+
+	private function deferOperationGeneration( int $job_id, string $flow_step_id, int $generation, string $token ): array {
+		$action_id = function_exists( 'as_schedule_single_action' )
+			? as_schedule_single_action(
+				time() + 1,
+				'datamachine_execute_step',
+				array(
+					'job_id'               => $job_id,
+					'flow_step_id'         => $flow_step_id,
+					'operation_generation' => $generation,
+					'operation_claim_token' => $token,
+				),
+				'data-machine'
+			)
+			: 0;
+
+		return array(
+			'success'   => false,
+			'deferred'  => true,
+			'retryable' => true,
+			'error'     => $action_id > 0 ? 'Execution deferred until enqueue generation is durably committed.' : 'Execution generation is not durably committed and could not be deferred.',
+		);
+	}
+
+	private function staleOperationGeneration( int $job_id, int $generation, string $reason ): array {
+		return array(
+			'success'          => false,
+			'error'            => sprintf( 'Job %d execution generation %d %s.', $job_id, $generation, $reason ),
+			'stale_generation' => true,
+		);
 	}
 
 	/**

--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -158,13 +158,19 @@ class ScheduleNextStepAbility {
 		}
 
 		// Action Scheduler only receives IDs.
+		$action_args = array(
+			'job_id'       => $job_id,
+			'flow_step_id' => $flow_step_id,
+		);
+		$job = $this->db_jobs->get_job( $job_id );
+		if ( 'direct' === (string) ( $job['flow_id'] ?? '' ) && (int) ( $job['operation_generation'] ?? 0 ) > 0 ) {
+			$action_args['operation_generation'] = (int) $job['operation_generation'];
+		}
+
 		$action_id = as_schedule_single_action(
 			time(),
 			'datamachine_execute_step',
-			array(
-				'job_id'       => $job_id,
-				'flow_step_id' => $flow_step_id,
-			),
+			$action_args,
 			'data-machine'
 		);
 

--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -165,6 +165,7 @@ class ScheduleNextStepAbility {
 		$job = $this->db_jobs->get_job( $job_id );
 		if ( 'direct' === (string) ( $job['flow_id'] ?? '' ) && (int) ( $job['operation_generation'] ?? 0 ) > 0 ) {
 			$action_args['operation_generation'] = (int) $job['operation_generation'];
+			$action_args['operation_claim_token'] = (string) ( $job['operation_claim_token'] ?? '' );
 		}
 
 		$action_id = as_schedule_single_action(

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Abilities\Job;
 
+use DataMachine\Abilities\ExecutionScope;
+use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\Steps\WorkflowConfigFactory;
 use DataMachine\Core\Steps\WorkflowSpecValidator;
@@ -63,6 +65,11 @@ class ExecuteWorkflowAbility {
 								'default'     => false,
 								'description' => __( 'Preview execution without creating posts. Returns preview data instead of publishing.', 'data-machine' ),
 							),
+							'operation_key' => array(
+								'type'        => 'string',
+								'maxLength'   => 191,
+								'description' => __( 'Optional caller-stable key for idempotent workflow submission.', 'data-machine' ),
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -74,6 +81,7 @@ class ExecuteWorkflowAbility {
 							'job_id'         => array( 'type' => 'integer' ),
 							'step_count'     => array( 'type' => 'integer' ),
 							'dry_run'        => array( 'type' => 'boolean' ),
+							'replayed'       => array( 'type' => 'boolean' ),
 							'message'        => array( 'type' => 'string' ),
 							'error'          => array( 'type' => 'string' ),
 						),
@@ -95,9 +103,11 @@ class ExecuteWorkflowAbility {
 	 * @return array Result with job_id and execution info.
 	 */
 	public function execute( array $input ): array {
-		$workflow     = $input['workflow'] ?? null;
-		$timestamp    = $input['timestamp'] ?? null;
-		$initial_data = is_array( $input['initial_data'] ?? null ) ? $input['initial_data'] : array();
+		$workflow       = $input['workflow'] ?? null;
+		$timestamp      = $input['timestamp'] ?? null;
+		$initial_data   = is_array( $input['initial_data'] ?? null ) ? $input['initial_data'] : array();
+		$operation_key  = is_string( $input['operation_key'] ?? null ) ? trim( $input['operation_key'] ) : '';
+		$system_context = ! empty( $input['system_context'] );
 
 		// Validate workflow structure
 		$validation = WorkflowSpecValidator::validate( $workflow );
@@ -110,6 +120,14 @@ class ExecuteWorkflowAbility {
 
 		// Build configs from workflow
 		$configs = WorkflowConfigFactory::buildEphemeralConfigs( $workflow );
+
+		$ownership = $this->resolveOwnership( $initial_data, $system_context );
+		if ( isset( $ownership['error'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => $ownership['error'],
+			);
+		}
 
 		// Create job record for direct execution. Honor parent_job_id
 		// from initial_data so callers (e.g. TaskScheduler scheduling
@@ -130,60 +148,35 @@ class ExecuteWorkflowAbility {
 			'flow_id'     => 'direct',
 			'source'      => $job_source,
 			'label'       => $job_label,
+			'user_id'     => $ownership['user_id'],
 		);
+		if ( $ownership['agent_id'] > 0 ) {
+			$create_args['agent_id'] = $ownership['agent_id'];
+		}
 
 		$initial_parent_job_id = (int) ( $initial_data['parent_job_id'] ?? 0 );
 		if ( $initial_parent_job_id > 0 ) {
 			$create_args['parent_job_id'] = $initial_parent_job_id;
 		}
 
-		$job_id = $this->db_jobs->create_job( $create_args );
-
-		if ( ! $job_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to create job record',
-			);
-		}
-
 		// Build engine data with caller data underneath engine-owned configs.
 		$engine_data                    = $initial_data;
 		$engine_data['flow_config']     = $configs['flow_config'];
 		$engine_data['pipeline_config'] = $configs['pipeline_config'];
+		$engine_data['user_id']         = $ownership['user_id'];
+		$engine_data['calling_user_id'] = $ownership['calling_user_id'];
 
 		// Mirror RunFlowAbility's engine_data['job'] shape so downstream
-		// step types (AIStep, SystemTaskStep) can read job + agent
-		// identity from the engine snapshot the same way they do for
-		// flow jobs. Callers (e.g. TaskScheduler) may provide a partial
-		// 'job' snapshot in initial_data with agent_id/user_id; this
-		// layers our authoritative job_id on top of any caller-provided
-		// snapshot.
-		$caller_snapshot  = is_array( $engine_data['job'] ?? null ) ? $engine_data['job'] : array();
-		$job_snapshot     = array_merge(
-			array( 'user_id' => (int) ( $initial_data['user_id'] ?? 0 ) ),
-			$caller_snapshot,
-			array( 'job_id' => $job_id )
-		);
-		$identity_context = array_filter(
-			array(
-				'agent_slug' => $job_snapshot['agent_slug'] ?? ( $initial_data['agent_slug'] ?? null ),
-				'agent_id'   => $job_snapshot['agent_id'] ?? ( $initial_data['agent_id'] ?? null ),
-			),
-			fn( $value ) => null !== $value && '' !== $value && 0 !== $value
-		);
-		if ( ! empty( $identity_context ) ) {
-			try {
-				$identity                   = ( new AgentIdentityResolver() )->resolve_agent_identity( $identity_context );
-				$job_snapshot['agent_id']   = $identity->agent_id;
-				$job_snapshot['agent_slug'] = $identity->agent_slug;
-			} catch ( \InvalidArgumentException $e ) {
-				if ( ! empty( $initial_data['agent_id'] ) && empty( $job_snapshot['agent_id'] ) ) {
-					$job_snapshot['agent_id'] = (int) $initial_data['agent_id'];
-				}
-				if ( ! empty( $initial_data['agent_slug'] ) && empty( $job_snapshot['agent_slug'] ) ) {
-					$job_snapshot['agent_slug'] = sanitize_title( (string) $initial_data['agent_slug'] );
-				}
-			}
+		// step types can restore authoritative job and agent identity from
+		// the engine snapshot during worker execution and deferred resume.
+		$caller_snapshot         = is_array( $engine_data['job'] ?? null ) ? $engine_data['job'] : array();
+		$job_snapshot            = $caller_snapshot;
+		$job_snapshot['user_id'] = $ownership['user_id'];
+		if ( $ownership['agent_id'] > 0 ) {
+			$job_snapshot['agent_id']   = $ownership['agent_id'];
+			$job_snapshot['agent_slug'] = $ownership['agent_slug'];
+		} else {
+			unset( $job_snapshot['agent_id'], $job_snapshot['agent_slug'] );
 		}
 		$engine_data['job'] = $job_snapshot;
 
@@ -192,7 +185,52 @@ class ExecuteWorkflowAbility {
 			$engine_data['dry_run_mode'] = true;
 		}
 
-		$this->db_jobs->store_engine_data( $job_id, $engine_data );
+		$request_fingerprint = $this->requestFingerprint( $engine_data, $timestamp );
+		if ( '' !== $operation_key ) {
+			$create_args['idempotency_key'] = 'direct:' . hash( 'sha256', $ownership['user_id'] . ':' . $ownership['agent_id'] . ':' . $operation_key );
+			$engine_data['direct_request']   = array(
+				'operation_key' => $operation_key,
+				'fingerprint'   => $request_fingerprint,
+				'execution_type' => $timestamp && is_numeric( $timestamp ) && (int) $timestamp > time() ? 'delayed' : 'immediate',
+				'timestamp'      => is_numeric( $timestamp ) ? (int) $timestamp : null,
+				'dry_run'        => ! empty( $input['dry_run'] ),
+			);
+		}
+
+		$create_args['engine_data'] = $engine_data;
+		$creation                   = '' !== $operation_key
+			? $this->db_jobs->create_or_get_job( $create_args )
+			: $this->db_jobs->create_job( $create_args );
+		$job_id                     = is_array( $creation ) ? (int) ( $creation['job_id'] ?? 0 ) : (int) $creation;
+
+		if ( $job_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to create job record',
+			);
+		}
+
+		if ( is_array( $creation ) && ! empty( $creation['already_exists'] ) ) {
+			$existing_engine_data = is_array( $creation['job']['engine_data'] ?? null ) ? $creation['job']['engine_data'] : array();
+			$existing_fingerprint = (string) ( $existing_engine_data['direct_request']['fingerprint'] ?? '' );
+			if ( '' === $existing_fingerprint || ! hash_equals( $existing_fingerprint, $request_fingerprint ) ) {
+				return array(
+					'success' => false,
+					'error'   => 'operation_key has already been used with different workflow input.',
+				);
+			}
+
+			return $this->executionResponse( $job_id, $workflow, $existing_engine_data['direct_request'], true );
+		}
+
+		$engine_data['job']['job_id'] = $job_id;
+
+		if ( ! $this->db_jobs->store_engine_data( $job_id, $engine_data ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to persist job execution data',
+			);
+		}
 
 		try {
 			$first_step_id = ExecutionPlan::from_flow_config( $configs['flow_config'] )->first_step_id();
@@ -300,5 +338,135 @@ class ExecuteWorkflowAbility {
 			'scheduled_time' => wp_date( 'c', $timestamp ),
 			'message'        => 'Ephemeral workflow scheduled for one-time execution at ' . wp_date( 'M j, Y g:i A', $timestamp ),
 		);
+	}
+
+	/**
+	 * Resolve authoritative ownership for a direct asynchronous job.
+	 *
+	 * @param array $initial_data   Caller-provided engine data.
+	 * @param bool  $system_context Whether an internal scheduler initiated the job.
+	 * @return array{user_id:int,calling_user_id:int,agent_id:int,agent_slug:string}|array{error:string}
+	 */
+	private function resolveOwnership( array $initial_data, bool $system_context ): array {
+		$scope           = ExecutionScope::current( 'manage_flows' );
+		$principal       = $scope->principal();
+		$user_id         = $principal ? max( 0, (int) $principal->acting_user_id ) : max( 0, $scope->acting_user_id() );
+		$calling_user_id = $user_id;
+		$agent_id        = max( 0, (int) ( $scope->acting_agent_id() ?? 0 ) );
+		$agent_slug      = '';
+
+		$caller_snapshot = is_array( $initial_data['job'] ?? null ) ? $initial_data['job'] : array();
+		$identity_context = array_filter(
+			$agent_id > 0
+				? array( 'agent_id' => $agent_id )
+				: array(
+					'agent_id'   => $caller_snapshot['agent_id'] ?? ( $initial_data['agent_id'] ?? null ),
+					'agent_slug' => $caller_snapshot['agent_slug'] ?? ( $initial_data['agent_slug'] ?? null ),
+				),
+			static fn( $value ) => null !== $value && '' !== $value && 0 !== $value
+		);
+
+		if ( ! empty( $identity_context ) ) {
+			try {
+				$identity = ( new AgentIdentityResolver() )->resolve_agent_identity( $identity_context );
+			} catch ( \InvalidArgumentException $e ) {
+				return array( 'error' => $e->getMessage() );
+			}
+
+			if ( $agent_id <= 0 && ! $system_context && ! PermissionHelper::can_access_agent( $identity->agent_id ) ) {
+				return array( 'error' => 'You do not have permission to execute work for this agent.' );
+			}
+
+			$agent_id   = $identity->agent_id;
+			$agent_slug = $identity->agent_slug;
+			if ( $system_context && $user_id <= 0 ) {
+				$user_id = $identity->owner_id;
+			}
+		}
+
+		if ( ! $system_context && $user_id <= 0 && $agent_id <= 0 ) {
+			return array( 'error' => 'An authenticated acting caller is required for user-scoped workflow execution.' );
+		}
+
+		return array(
+			'user_id'         => $user_id,
+			'calling_user_id' => $calling_user_id,
+			'agent_id'        => $agent_id,
+			'agent_slug'      => $agent_slug,
+		);
+	}
+
+	/**
+	 * Hash the effective request input stored on an idempotent job.
+	 *
+	 * @param array $engine_data Effective engine data before request metadata.
+	 * @param mixed $timestamp   Requested execution timestamp.
+	 * @return string
+	 */
+	private function requestFingerprint( array $engine_data, $timestamp ): string {
+		$payload = $this->canonicalize(
+			array(
+				'engine_data' => $engine_data,
+				'timestamp'   => is_numeric( $timestamp ) ? (int) $timestamp : null,
+			)
+		);
+
+		return hash( 'sha256', (string) wp_json_encode( $payload ) );
+	}
+
+	/**
+	 * Sort object keys recursively while retaining list order.
+	 *
+	 * @param mixed $value Value to normalize.
+	 * @return mixed
+	 */
+	private function canonicalize( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		if ( ! array_is_list( $value ) ) {
+			ksort( $value, SORT_STRING );
+		}
+
+		foreach ( $value as $key => $item ) {
+			$value[ $key ] = $this->canonicalize( $item );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Recreate the original submission response without scheduling duplicate work.
+	 *
+	 * @param int   $job_id        Existing job ID.
+	 * @param array $workflow      Validated workflow input.
+	 * @param array $request_meta  Persisted direct request metadata.
+	 * @param bool  $replayed      Whether this is an idempotent replay.
+	 * @return array
+	 */
+	private function executionResponse( int $job_id, array $workflow, array $request_meta, bool $replayed ): array {
+		$execution_type = 'delayed' === ( $request_meta['execution_type'] ?? '' ) ? 'delayed' : 'immediate';
+		$is_dry_run     = ! empty( $request_meta['dry_run'] );
+		$response       = array(
+			'success'        => true,
+			'execution_mode' => 'direct',
+			'execution_type' => $execution_type,
+			'job_id'         => $job_id,
+			'step_count'     => count( $workflow['steps'] ?? array() ),
+			'replayed'       => $replayed,
+			'message'        => 'Existing workflow execution returned for operation_key.',
+		);
+
+		if ( $is_dry_run ) {
+			$response['dry_run'] = true;
+		}
+
+		if ( 'delayed' === $execution_type && ! empty( $request_meta['timestamp'] ) ) {
+			$response['timestamp']      = (int) $request_meta['timestamp'];
+			$response['scheduled_time'] = wp_date( 'c', (int) $request_meta['timestamp'] );
+		}
+
+		return $response;
 	}
 }

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -14,6 +14,8 @@ namespace DataMachine\Abilities\Job;
 use DataMachine\Abilities\ExecutionScope;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Agents\AgentIdentityResolver;
+use DataMachine\Core\DirectJobEnqueuer;
+use DataMachine\Core\JobStatus;
 use DataMachine\Core\Steps\WorkflowConfigFactory;
 use DataMachine\Core\Steps\WorkflowSpecValidator;
 use DataMachine\Engine\ExecutionPlan;
@@ -24,10 +26,12 @@ class ExecuteWorkflowAbility {
 
 	use JobHelpers;
 
-	public function __construct() {
+	public function __construct( bool $register = true ) {
 		$this->initDatabases();
 
-		$this->registerAbility();
+		if ( $register ) {
+			$this->registerAbility();
+		}
 	}
 
 	private function registerAbility(): void {
@@ -103,11 +107,31 @@ class ExecuteWorkflowAbility {
 	 * @return array Result with job_id and execution info.
 	 */
 	public function execute( array $input ): array {
+		return $this->executeWithAuthority( $input, false );
+	}
+
+	/**
+	 * Execute trusted internal system work without accepting public authority flags.
+	 *
+	 * @param array $input Workflow input.
+	 * @return array
+	 */
+	public function executeInternal( array $input ): array {
+		return $this->executeWithAuthority( $input, true );
+	}
+
+	/**
+	 * Execute an ephemeral workflow under an explicit trusted authority boundary.
+	 *
+	 * @param array $input          Workflow input.
+	 * @param bool  $system_context Trusted internal system execution.
+	 * @return array
+	 */
+	private function executeWithAuthority( array $input, bool $system_context ): array {
 		$workflow       = $input['workflow'] ?? null;
 		$timestamp      = $input['timestamp'] ?? null;
 		$initial_data   = is_array( $input['initial_data'] ?? null ) ? $input['initial_data'] : array();
 		$operation_key  = is_string( $input['operation_key'] ?? null ) ? trim( $input['operation_key'] ) : '';
-		$system_context = ! empty( $input['system_context'] );
 
 		// Validate workflow structure
 		$validation = WorkflowSpecValidator::validate( $workflow );
@@ -118,8 +142,23 @@ class ExecuteWorkflowAbility {
 			);
 		}
 
-		// Build configs from workflow
+		// Validate the complete execution plan before claiming an operation key.
 		$configs = WorkflowConfigFactory::buildEphemeralConfigs( $workflow );
+		try {
+			$first_step_id = ExecutionPlan::from_flow_config( $configs['flow_config'] )->first_step_id();
+		} catch ( \InvalidArgumentException $e ) {
+			return array(
+				'success' => false,
+				'error'   => $e->getMessage(),
+			);
+		}
+
+		if ( ! $first_step_id ) {
+			return array(
+				'success' => false,
+				'error'   => 'Could not determine first step in workflow',
+			);
+		}
 
 		$ownership = $this->resolveOwnership( $initial_data, $system_context );
 		if ( isset( $ownership['error'] ) ) {
@@ -144,11 +183,13 @@ class ExecuteWorkflowAbility {
 			: 'Chat Workflow';
 
 		$create_args = array(
-			'pipeline_id' => 'direct',
-			'flow_id'     => 'direct',
-			'source'      => $job_source,
-			'label'       => $job_label,
-			'user_id'     => $ownership['user_id'],
+			'pipeline_id'      => 'direct',
+			'flow_id'          => 'direct',
+			'source'           => $job_source,
+			'label'            => $job_label,
+			'user_id'          => $ownership['user_id'],
+			'operation_state'  => 'preparing',
+			'operation_step_id' => $first_step_id,
 		);
 		if ( $ownership['agent_id'] > 0 ) {
 			$create_args['agent_id'] = $ownership['agent_id'];
@@ -186,15 +227,16 @@ class ExecuteWorkflowAbility {
 		}
 
 		$request_fingerprint = $this->requestFingerprint( $engine_data, $timestamp );
+		$create_args['request_fingerprint'] = $request_fingerprint;
+		$engine_data['direct_request']       = array(
+			'operation_key'  => $operation_key,
+			'fingerprint'    => $request_fingerprint,
+			'execution_type' => $timestamp && is_numeric( $timestamp ) && (int) $timestamp > time() ? 'delayed' : 'immediate',
+			'timestamp'      => is_numeric( $timestamp ) ? (int) $timestamp : null,
+			'dry_run'        => ! empty( $input['dry_run'] ),
+		);
 		if ( '' !== $operation_key ) {
 			$create_args['idempotency_key'] = 'direct:' . hash( 'sha256', $ownership['user_id'] . ':' . $ownership['agent_id'] . ':' . $operation_key );
-			$engine_data['direct_request']   = array(
-				'operation_key' => $operation_key,
-				'fingerprint'   => $request_fingerprint,
-				'execution_type' => $timestamp && is_numeric( $timestamp ) && (int) $timestamp > time() ? 'delayed' : 'immediate',
-				'timestamp'      => is_numeric( $timestamp ) ? (int) $timestamp : null,
-				'dry_run'        => ! empty( $input['dry_run'] ),
-			);
 		}
 
 		$create_args['engine_data'] = $engine_data;
@@ -211,133 +253,52 @@ class ExecuteWorkflowAbility {
 		}
 
 		if ( is_array( $creation ) && ! empty( $creation['already_exists'] ) ) {
-			$existing_engine_data = is_array( $creation['job']['engine_data'] ?? null ) ? $creation['job']['engine_data'] : array();
-			$existing_fingerprint = (string) ( $existing_engine_data['direct_request']['fingerprint'] ?? '' );
+			$existing_fingerprint = (string) ( $creation['job']['request_fingerprint'] ?? '' );
 			if ( '' === $existing_fingerprint || ! hash_equals( $existing_fingerprint, $request_fingerprint ) ) {
 				return array(
 					'success' => false,
 					'error'   => 'operation_key has already been used with different workflow input.',
 				);
 			}
-
-			return $this->executionResponse( $job_id, $workflow, $existing_engine_data['direct_request'], true );
 		}
 
-		$engine_data['job']['job_id'] = $job_id;
-
-		if ( ! $this->db_jobs->store_engine_data( $job_id, $engine_data ) ) {
+		$job = $this->db_jobs->get_job( $job_id );
+		if ( ! is_array( $job ) ) {
 			return array(
 				'success' => false,
-				'error'   => 'Failed to persist job execution data',
+				'error'   => 'Failed to load job record after creation',
 			);
 		}
 
-		try {
-			$first_step_id = ExecutionPlan::from_flow_config( $configs['flow_config'] )->first_step_id();
-		} catch ( \InvalidArgumentException $e ) {
-			do_action(
-				'datamachine_log',
-				'error',
-				'Workflow execution failed - invalid execution plan',
-				array(
-					'job_id' => $job_id,
-					'error'  => $e->getMessage(),
-				)
-			);
+		$existing_engine_data = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$request_meta         = is_array( $existing_engine_data['direct_request'] ?? null ) ? $existing_engine_data['direct_request'] : array();
+		if ( JobStatus::isStatusFinal( (string) ( $job['status'] ?? '' ) ) ) {
+			return $this->executionResponse( $job_id, $workflow, $request_meta, true );
+		}
 
+		$existing_engine_data['job']           = is_array( $existing_engine_data['job'] ?? null ) ? $existing_engine_data['job'] : array();
+		$existing_engine_data['job']['job_id'] = $job_id;
+		if ( ! $this->db_jobs->store_engine_data( $job_id, $existing_engine_data ) ) {
+			$this->db_jobs->finish_operation_enqueue( $job_id, 'enqueue_failed' );
 			return array(
 				'success' => false,
-				'error'   => $e->getMessage(),
+				'error'   => 'Failed to persist job execution data; replay may retry the operation.',
 			);
 		}
 
-		if ( ! $first_step_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'Could not determine first step in workflow',
-			);
-		}
-
-		$step_count = count( $workflow['steps'] ?? array() );
-		$is_dry_run = ! empty( $input['dry_run'] );
-
-		// Immediate execution
-		if ( ! $timestamp || ! is_numeric( $timestamp ) || (int) $timestamp <= time() ) {
-			do_action( 'datamachine_schedule_next_step', $job_id, $first_step_id, array() );
-
-			do_action(
-				'datamachine_log',
-				'info',
-				'Workflow executed via ability (direct mode)',
-				array(
-					'execution_mode' => 'direct',
-					'execution_type' => 'immediate',
-					'job_id'         => $job_id,
-					'step_count'     => $step_count,
-					'dry_run'        => $is_dry_run,
-				)
-			);
-
-			$message = $is_dry_run
-				? 'Ephemeral workflow dry-run started. No posts will be created - preview data will be returned.'
-				: 'Ephemeral workflow execution started';
-
-			$response = array(
-				'success'        => true,
-				'execution_mode' => 'direct',
-				'execution_type' => 'immediate',
-				'job_id'         => $job_id,
-				'step_count'     => $step_count,
-				'message'        => $message,
-			);
-
-			if ( $is_dry_run ) {
-				$response['dry_run'] = true;
-			}
-
-			return $response;
-		}
-
-		// Delayed execution
-		$timestamp = (int) $timestamp;
-
-		$action_id = as_schedule_single_action(
-			$timestamp,
-			'datamachine_schedule_next_step',
-			array( $job_id, $first_step_id, array() ),
-			'data-machine'
+		$enqueue = ( new DirectJobEnqueuer( $this->db_jobs ) )->enqueue(
+			$job_id,
+			$first_step_id,
+			is_numeric( $timestamp ) ? (int) $timestamp : null
 		);
-
-		if ( false === $action_id ) {
+		if ( empty( $enqueue['success'] ) ) {
 			return array(
 				'success' => false,
-				'error'   => 'Failed to schedule workflow execution',
+				'error'   => 'Failed to durably enqueue workflow execution; replay may retry the operation.',
 			);
 		}
 
-		do_action(
-			'datamachine_log',
-			'info',
-			'Workflow scheduled via ability (direct mode)',
-			array(
-				'execution_mode' => 'direct',
-				'execution_type' => 'delayed',
-				'job_id'         => $job_id,
-				'step_count'     => $step_count,
-				'timestamp'      => $timestamp,
-			)
-		);
-
-		return array(
-			'success'        => true,
-			'execution_mode' => 'direct',
-			'execution_type' => 'delayed',
-			'job_id'         => $job_id,
-			'step_count'     => $step_count,
-			'timestamp'      => $timestamp,
-			'scheduled_time' => wp_date( 'c', $timestamp ),
-			'message'        => 'Ephemeral workflow scheduled for one-time execution at ' . wp_date( 'M j, Y g:i A', $timestamp ),
-		);
+		return $this->executionResponse( $job_id, $workflow, $request_meta, is_array( $creation ) && ! empty( $creation['already_exists'] ) );
 	}
 
 	/**

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -86,6 +86,8 @@ class ExecuteWorkflowAbility {
 							'step_count'     => array( 'type' => 'integer' ),
 							'dry_run'        => array( 'type' => 'boolean' ),
 							'replayed'       => array( 'type' => 'boolean' ),
+							'retryable'      => array( 'type' => 'boolean' ),
+							'enqueue_state'  => array( 'type' => 'string' ),
 							'message'        => array( 'type' => 'string' ),
 							'error'          => array( 'type' => 'string' ),
 						),
@@ -279,7 +281,6 @@ class ExecuteWorkflowAbility {
 		$existing_engine_data['job']           = is_array( $existing_engine_data['job'] ?? null ) ? $existing_engine_data['job'] : array();
 		$existing_engine_data['job']['job_id'] = $job_id;
 		if ( ! $this->db_jobs->store_engine_data( $job_id, $existing_engine_data ) ) {
-			$this->db_jobs->finish_operation_enqueue( $job_id, 'enqueue_failed' );
 			return array(
 				'success' => false,
 				'error'   => 'Failed to persist job execution data; replay may retry the operation.',
@@ -293,8 +294,10 @@ class ExecuteWorkflowAbility {
 		);
 		if ( empty( $enqueue['success'] ) ) {
 			return array(
-				'success' => false,
-				'error'   => 'Failed to durably enqueue workflow execution; replay may retry the operation.',
+				'success'    => false,
+				'error'      => (string) ( $enqueue['error'] ?? 'enqueue_failed' ),
+				'retryable'  => ! empty( $enqueue['retryable'] ),
+				'enqueue_state' => (string) ( $enqueue['state'] ?? 'enqueue_failed' ),
 			);
 		}
 

--- a/inc/Abilities/Job/FailJobAbility.php
+++ b/inc/Abilities/Job/FailJobAbility.php
@@ -99,6 +99,10 @@ class FailJobAbility {
 			);
 		}
 
+		if ( ! $this->canAccessJob( $job ) ) {
+			return $this->jobAccessDenied();
+		}
+
 		$previous_status = $job['status'] ?? '';
 
 		// Already failed — nothing to do.

--- a/inc/Abilities/Job/GetJobsAbility.php
+++ b/inc/Abilities/Job/GetJobsAbility.php
@@ -157,6 +157,18 @@ class GetJobsAbility {
 		$order       = $input['order'] ?? 'DESC';
 		$fields      = $input['fields'] ?? null;
 		$metadata    = \DataMachine\Core\ExecutionQuery::normalize_metadata_filters( $input['metadata'] ?? array() );
+		$ownership_scope = $this->jobCollectionScope(
+			null !== $user_id ? (int) $user_id : null,
+			null !== $agent_id ? (int) $agent_id : null
+		);
+		if ( isset( $ownership_scope['error'] ) ) {
+			return array(
+				'success'    => false,
+				'error_code' => 'job_access_denied',
+				'error'      => $ownership_scope['error'],
+				'status'     => 403,
+			);
+		}
 
 		// Direct job lookup by ID - bypasses pagination and filters.
 		if ( $job_id ) {
@@ -235,11 +247,11 @@ class GetJobsAbility {
 			$filters_applied['handler'] = $args['handler'];
 		}
 
-		if ( null !== $agent_id ) {
-			$args['agent_id']            = (int) $agent_id;
+		if ( isset( $ownership_scope['agent_id'] ) ) {
+			$args['agent_id']            = $ownership_scope['agent_id'];
 			$filters_applied['agent_id'] = $args['agent_id'];
-		} elseif ( null !== $user_id ) {
-			$args['user_id']            = (int) $user_id;
+		} elseif ( isset( $ownership_scope['user_id'] ) ) {
+			$args['user_id']            = $ownership_scope['user_id'];
 			$filters_applied['user_id'] = $args['user_id'];
 		}
 

--- a/inc/Abilities/Job/GetJobsAbility.php
+++ b/inc/Abilities/Job/GetJobsAbility.php
@@ -180,6 +180,10 @@ class GetJobsAbility {
 				);
 			}
 
+			if ( ! $this->canAccessJob( $job ) ) {
+				return $this->jobAccessDenied();
+			}
+
 			$jobs_enriched = $this->enrichJobNames( array( $job ) );
 			$job           = $this->addDisplayFields( $jobs_enriched[0] );
 

--- a/inc/Abilities/Job/HydrateJobArtifactAbility.php
+++ b/inc/Abilities/Job/HydrateJobArtifactAbility.php
@@ -76,7 +76,21 @@ class HydrateJobArtifactAbility {
 			);
 		}
 
-		$result = ( new JobArtifacts() )->hydrate_artifact_ref( $artifact_ref );
+		$artifacts = new JobArtifacts();
+		$job_id    = $artifacts->job_id_from_artifact_ref( $artifact_ref );
+		$job       = $job_id > 0 ? $this->db_jobs->get_job( $job_id ) : null;
+		if ( ! is_array( $job ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'artifact_ref is not associated with an existing job.',
+			);
+		}
+
+		if ( ! $this->canAccessJob( $job ) ) {
+			return $this->jobAccessDenied();
+		}
+
+		$result = $artifacts->hydrate_artifact_ref( $artifact_ref, is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array() );
 		if ( empty( $result['success'] ) ) {
 			return $result;
 		}

--- a/inc/Abilities/Job/JobHelpers.php
+++ b/inc/Abilities/Job/JobHelpers.php
@@ -11,8 +11,9 @@
 
 namespace DataMachine\Abilities\Job;
 
-use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Abilities\Flow\QueueAbility;
+use DataMachine\Abilities\ExecutionScope;
+use DataMachine\Abilities\PermissionHelper;
 
 use DataMachine\Core\Admin\DateFormatter;
 use DataMachine\Core\JobArtifactSurfaces;
@@ -44,6 +45,42 @@ trait JobHelpers {
 	 */
 	public function checkPermission(): bool {
 		return PermissionHelper::can_manage();
+	}
+
+	/**
+	 * Check row ownership while preserving capability-gated access to legacy jobs.
+	 *
+	 * Jobs created before ownership was persisted have user_id=0 and agent_id=NULL.
+	 * Those rows retain the shipped manage-jobs behavior; owned rows require the
+	 * matching user/agent or privileged operational access.
+	 *
+	 * @param array $job Job row.
+	 * @return bool
+	 */
+	protected function canAccessJob( array $job ): bool {
+		$scope    = ExecutionScope::current( 'manage_flows' );
+		$user_id  = max( 0, (int) ( $job['user_id'] ?? 0 ) );
+		$agent_id = isset( $job['agent_id'] ) && (int) $job['agent_id'] > 0 ? (int) $job['agent_id'] : null;
+
+		if ( 0 === $user_id && null === $agent_id ) {
+			return $scope->can_action();
+		}
+
+		return $scope->owns_agent_resource( $agent_id, $user_id );
+	}
+
+	/**
+	 * Standard failed result for an inaccessible job row.
+	 *
+	 * @return array
+	 */
+	protected function jobAccessDenied(): array {
+		return array(
+			'success'    => false,
+			'error_code' => 'job_access_denied',
+			'error'      => 'You do not have permission to access this job.',
+			'status'     => 403,
+		);
 	}
 
 	/**

--- a/inc/Abilities/Job/JobHelpers.php
+++ b/inc/Abilities/Job/JobHelpers.php
@@ -63,7 +63,10 @@ trait JobHelpers {
 		$agent_id = isset( $job['agent_id'] ) && (int) $job['agent_id'] > 0 ? (int) $job['agent_id'] : null;
 
 		if ( 0 === $user_id && null === $agent_id ) {
-			return $scope->can_action();
+			$legacy_unowned = empty( $job['request_fingerprint'] ) && empty( $job['operation_state'] );
+			return $legacy_unowned
+				? $scope->can_action()
+				: PermissionHelper::has_privileged_resource_access( 'manage_flows' );
 		}
 
 		return $scope->owns_agent_resource( $agent_id, $user_id );
@@ -81,6 +84,44 @@ trait JobHelpers {
 			'error'      => 'You do not have permission to access this job.',
 			'status'     => 403,
 		);
+	}
+
+	/**
+	 * Apply authoritative ownership constraints to a job collection query.
+	 *
+	 * @param int|null $requested_user_id  Caller-selected user filter.
+	 * @param int|null $requested_agent_id Caller-selected agent filter.
+	 * @return array{user_id?:int,agent_id?:int}|array{error:string}
+	 */
+	protected function jobCollectionScope( ?int $requested_user_id, ?int $requested_agent_id ): array {
+		if ( PermissionHelper::has_privileged_resource_access( 'manage_flows' ) ) {
+			if ( null !== $requested_agent_id ) {
+				return array( 'agent_id' => $requested_agent_id );
+			}
+			return null !== $requested_user_id ? array( 'user_id' => $requested_user_id ) : array();
+		}
+
+		$acting_user_id = PermissionHelper::acting_user_id();
+		if ( null !== $requested_agent_id ) {
+			return PermissionHelper::can_access_agent( $requested_agent_id )
+				? array( 'agent_id' => $requested_agent_id )
+				: array( 'error' => 'You do not have permission to access jobs for this agent.' );
+		}
+
+		$acting_agent_id = PermissionHelper::get_acting_agent_id();
+		if ( null !== $acting_agent_id ) {
+			return array( 'agent_id' => $acting_agent_id );
+		}
+
+		if ( null !== $requested_user_id && $requested_user_id !== $acting_user_id ) {
+			return array( 'error' => 'You do not have permission to access jobs for this user.' );
+		}
+
+		if ( $acting_user_id <= 0 ) {
+			return array( 'error' => 'An authenticated acting caller is required to list owned jobs.' );
+		}
+
+		return array( 'user_id' => $acting_user_id );
 	}
 
 	/**

--- a/inc/Abilities/Job/JobsSummaryAbility.php
+++ b/inc/Abilities/Job/JobsSummaryAbility.php
@@ -93,12 +93,26 @@ class JobsSummaryAbility {
 	 * @return array Result with summary counts.
 	 */
 	public function execute( array $input ): array {
+		$ownership_scope = $this->jobCollectionScope(
+			isset( $input['user_id'] ) ? (int) $input['user_id'] : null,
+			isset( $input['agent_id'] ) ? (int) $input['agent_id'] : null
+		);
+		if ( isset( $ownership_scope['error'] ) ) {
+			return array(
+				'success'    => false,
+				'error_code' => 'job_access_denied',
+				'error'      => $ownership_scope['error'],
+				'status'     => 403,
+			);
+		}
+
 		$filters = array();
-		foreach ( array( 'flow_id', 'pipeline_id', 'handler', 'status', 'source', 'since', 'user_id', 'agent_id' ) as $key ) {
+		foreach ( array( 'flow_id', 'pipeline_id', 'handler', 'status', 'source', 'since' ) as $key ) {
 			if ( isset( $input[ $key ] ) && '' !== $input[ $key ] ) {
 				$filters[ $key ] = $input[ $key ];
 			}
 		}
+		$filters = array_merge( $filters, $ownership_scope );
 
 		$summary = empty( $input['compact'] ) ? $this->db_jobs->get_jobs_summary( $filters ) : $this->getCompactSummary( $filters );
 

--- a/inc/Abilities/Job/RetryJobAbility.php
+++ b/inc/Abilities/Job/RetryJobAbility.php
@@ -97,6 +97,10 @@ class RetryJobAbility {
 			);
 		}
 
+		if ( ! $this->canAccessJob( $job ) ) {
+			return $this->jobAccessDenied();
+		}
+
 		$previous_status = $job['status'] ?? '';
 
 		// Unless forced, only allow retrying failed or processing jobs.

--- a/inc/Abilities/Job/RetryJobAbility.php
+++ b/inc/Abilities/Job/RetryJobAbility.php
@@ -59,6 +59,8 @@ class RetryJobAbility {
 							'previous_status' => array( 'type' => 'string' ),
 							'prompt_requeued' => array( 'type' => 'boolean' ),
 							'direct_requeued' => array( 'type' => 'boolean' ),
+							'retryable'       => array( 'type' => 'boolean' ),
+							'error_code'      => array( 'type' => 'string' ),
 							'message'         => array( 'type' => 'string' ),
 							'error'           => array( 'type' => 'string' ),
 						),
@@ -135,6 +137,18 @@ class RetryJobAbility {
 			}
 
 			if ( 'processing' === $previous_status ) {
+				$generation = (int) ( $job['operation_generation'] ?? 0 );
+				$token      = (string) ( $job['operation_claim_token'] ?? '' );
+				if ( $generation > 0 && '' !== $token && ( new DirectJobEnqueuer( $this->db_jobs ) )->hasLiveAction( $job_id, $flow_step_id, $generation, $token ) ) {
+					return array(
+						'success'         => false,
+						'job_id'          => $job_id,
+						'previous_status' => $previous_status,
+						'retryable'       => true,
+						'error_code'      => 'job_execution_in_progress',
+						'error'           => sprintf( 'Job %d still has live execution for generation %d; retry after it exits or is recovered.', $job_id, $generation ),
+					);
+				}
 				$this->db_jobs->complete_job( $job_id, 'failed - manual_retry' );
 			}
 			if ( ! $this->db_jobs->reopen_failed_job( $job_id ) ) {

--- a/inc/Abilities/Job/RetryJobAbility.php
+++ b/inc/Abilities/Job/RetryJobAbility.php
@@ -10,6 +10,9 @@
 
 namespace DataMachine\Abilities\Job;
 
+use DataMachine\Core\DirectJobEnqueuer;
+use DataMachine\Core\JobRetryPolicy;
+
 defined( 'ABSPATH' ) || exit;
 
 class RetryJobAbility {
@@ -55,6 +58,7 @@ class RetryJobAbility {
 							'job_id'          => array( 'type' => 'integer' ),
 							'previous_status' => array( 'type' => 'string' ),
 							'prompt_requeued' => array( 'type' => 'boolean' ),
+							'direct_requeued' => array( 'type' => 'boolean' ),
 							'message'         => array( 'type' => 'string' ),
 							'error'           => array( 'type' => 'string' ),
 						),
@@ -113,6 +117,52 @@ class RetryJobAbility {
 
 		// Retrieve engine data for prompt backup before marking failed.
 		$engine_data = $this->db_jobs->retrieve_engine_data( $job_id );
+
+		if ( 'direct' === (string) ( $job['flow_id'] ?? '' ) ) {
+			if ( empty( $engine_data['flow_config'] ) ) {
+				return array(
+					'success' => false,
+					'error'   => 'Direct workflow execution data is no longer available for retry.',
+				);
+			}
+
+			$flow_step_id = JobRetryPolicy::resolveDirectResumeStepId( $engine_data );
+			if ( '' === $flow_step_id ) {
+				return array(
+					'success' => false,
+					'error'   => 'Direct workflow has no safe resume step.',
+				);
+			}
+
+			if ( 'processing' === $previous_status ) {
+				$this->db_jobs->complete_job( $job_id, 'failed - manual_retry' );
+			}
+			if ( ! $this->db_jobs->reopen_failed_job( $job_id ) ) {
+				return array(
+					'success' => false,
+					'error'   => sprintf( 'Job %d could not be reopened for retry.', $job_id ),
+				);
+			}
+
+			$enqueue = ( new DirectJobEnqueuer( $this->db_jobs ) )->enqueue( $job_id, $flow_step_id );
+			if ( empty( $enqueue['success'] ) ) {
+				$this->db_jobs->complete_job( $job_id, 'failed - retry_enqueue_failed' );
+				return array(
+					'success' => false,
+					'error'   => sprintf( 'Job %d retry could not be enqueued.', $job_id ),
+				);
+			}
+
+			\DataMachine\Core\RunMetrics::increment( $job_id, 'retried' );
+			return array(
+				'success'         => true,
+				'job_id'          => $job_id,
+				'previous_status' => $previous_status,
+				'prompt_requeued' => false,
+				'direct_requeued' => true,
+				'message'         => sprintf( 'Job %d direct workflow retry enqueued.', $job_id ),
+			);
+		}
 
 		// Mark as failed for retry.
 		\DataMachine\Core\RunMetrics::increment( $job_id, 'retried' );

--- a/inc/Abilities/Job/RetryJobAbility.php
+++ b/inc/Abilities/Job/RetryJobAbility.php
@@ -139,7 +139,7 @@ class RetryJobAbility {
 			if ( 'processing' === $previous_status ) {
 				$generation = (int) ( $job['operation_generation'] ?? 0 );
 				$token      = (string) ( $job['operation_claim_token'] ?? '' );
-				if ( $generation > 0 && '' !== $token && ( new DirectJobEnqueuer( $this->db_jobs ) )->hasLiveAction( $job_id, $flow_step_id, $generation, $token ) ) {
+				if ( $generation > 0 && '' !== $token && ( new DirectJobEnqueuer( $this->db_jobs ) )->hasLiveGenerationAction( $job_id, $generation, $token ) ) {
 					return array(
 						'success'         => false,
 						'job_id'          => $job_id,

--- a/inc/Abilities/Job/RunMetricsAbility.php
+++ b/inc/Abilities/Job/RunMetricsAbility.php
@@ -74,6 +74,10 @@ class RunMetricsAbility {
 			);
 		}
 
+		if ( ! $this->canAccessJob( $job ) ) {
+			return $this->jobAccessDenied();
+		}
+
 		$jobs = $this->enrichJobNames( array( $job ) );
 		$job  = $this->addDisplayFields( $jobs[0] );
 

--- a/inc/Abilities/PermissionHelper.php
+++ b/inc/Abilities/PermissionHelper.php
@@ -578,12 +578,22 @@ class PermissionHelper {
 		}
 
 		// Admins can access any resource.
-		if ( self::can( $action ) && ( self::is_authenticated_context() || current_user_can( 'manage_options' ) ) ) {
+		if ( self::has_privileged_resource_access( $action ) ) {
 			return true;
 		}
 
 		// Owner check.
 		return self::acting_user_id() === $resource_user_id;
+	}
+
+	/**
+	 * Whether the current scope may operate across resource owners.
+	 *
+	 * @param string $action Data Machine action key.
+	 * @return bool
+	 */
+	public static function has_privileged_resource_access( string $action = 'manage_flows' ): bool {
+		return self::can( $action ) && ( self::is_authenticated_context() || current_user_can( 'manage_options' ) );
 	}
 
 	/**

--- a/inc/Api/Execute.php
+++ b/inc/Api/Execute.php
@@ -71,6 +71,12 @@ class Execute {
 						'default'     => false,
 						'description' => 'Preview execution without creating posts (ephemeral workflows only)',
 					),
+					'operation_key' => array(
+						'type'        => 'string',
+						'required'    => false,
+						'maxLength'   => 191,
+						'description' => 'Caller-stable key for idempotent ephemeral workflow submission',
+					),
 				),
 			)
 		);
@@ -230,6 +236,7 @@ class Execute {
 		$timestamp    = $request->get_param( 'timestamp' );
 		$initial_data = $request->get_param( 'initial_data' );
 		$dry_run      = $request->get_param( 'dry_run' );
+		$operation_key = $request->get_param( 'operation_key' );
 
 		$ability = wp_get_ability( 'datamachine/execute-workflow' );
 		if ( ! $ability ) {
@@ -248,6 +255,10 @@ class Execute {
 
 		if ( $dry_run ) {
 			$input['dry_run'] = true;
+		}
+
+		if ( is_string( $operation_key ) && '' !== trim( $operation_key ) ) {
+			$input['operation_key'] = trim( $operation_key );
 		}
 
 		$result = $ability->execute( $input );
@@ -289,6 +300,10 @@ class Execute {
 		if ( isset( $result['timestamp'] ) ) {
 			$response_data['timestamp']      = $result['timestamp'];
 			$response_data['scheduled_time'] = $result['scheduled_time'] ?? wp_date( 'c', $result['timestamp'] );
+		}
+
+		if ( isset( $result['replayed'] ) ) {
+			$response_data['replayed'] = (bool) $result['replayed'];
 		}
 
 		return rest_ensure_response(

--- a/inc/Api/Execute.php
+++ b/inc/Api/Execute.php
@@ -270,14 +270,20 @@ class Execute {
 		if ( ! ( $result['success'] ?? false ) ) {
 			$status = 400;
 			$error  = $result['error'] ?? __( 'Execution failed', 'data-machine' );
+			$error_data = array( 'status' => $status );
 
 			if ( false !== strpos( $error, 'not found' ) ) {
 				$status = 404;
 			} elseif ( false !== strpos( $error, 'Failed to create' ) || false !== strpos( $error, 'not available' ) ) {
 				$status = 500;
+			} elseif ( ! empty( $result['retryable'] ) ) {
+				$status = 409;
+				$error_data['retryable']     = true;
+				$error_data['enqueue_state'] = (string) ( $result['enqueue_state'] ?? 'enqueuing' );
 			}
+			$error_data['status'] = $status;
 
-			return new \WP_Error( 'execute_failed', $error, array( 'status' => $status ) );
+			return new \WP_Error( 'execute_failed', $error, $error_data );
 		}
 
 		$response_data = array(

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -307,6 +307,16 @@ class Jobs extends BaseRepository {
 			$format[]                = '%s';
 		}
 
+		if ( isset( $job_data['engine_data'] ) && is_array( $job_data['engine_data'] ) ) {
+			$encoded_engine_data = wp_json_encode( $job_data['engine_data'] );
+			if ( false === $encoded_engine_data ) {
+				return false;
+			}
+
+			$data['engine_data'] = $encoded_engine_data;
+			$format[]            = '%s';
+		}
+
 		return array(
 			'data'        => $data,
 			'format'      => $format,

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -317,12 +317,118 @@ class Jobs extends BaseRepository {
 			$format[]            = '%s';
 		}
 
+		foreach ( array( 'request_fingerprint', 'operation_state', 'operation_step_id' ) as $operation_field ) {
+			if ( isset( $job_data[ $operation_field ] ) && is_scalar( $job_data[ $operation_field ] ) ) {
+				$data[ $operation_field ] = sanitize_text_field( (string) $job_data[ $operation_field ] );
+				$format[]                 = '%s';
+			}
+		}
+
 		return array(
 			'data'        => $data,
 			'format'      => $format,
 			'pipeline_id' => $pipeline_id,
 			'flow_id'     => $flow_id,
 		);
+	}
+
+	/**
+	 * Claim responsibility for durably enqueueing a job operation.
+	 *
+	 * Failed/preparing operations are immediately reclaimable. An enqueuing
+	 * claim becomes reclaimable after the lease to recover a crashed submitter.
+	 *
+	 * @param int $job_id        Job ID.
+	 * @param int $lease_seconds Claim lease in seconds.
+	 * @return bool Whether this caller acquired the claim.
+	 */
+	public function claim_operation_enqueue( int $job_id, int $lease_seconds = 30 ): bool {
+		if ( $job_id <= 0 ) {
+			return false;
+		}
+
+		$lease_cutoff = gmdate( 'Y-m-d H:i:s', time() - max( 1, $lease_seconds ) );
+		$claimed_at   = gmdate( 'Y-m-d H:i:s' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $this->wpdb->query(
+			$this->wpdb->prepare(
+				"UPDATE %i SET operation_state = 'enqueuing', operation_claimed_at = %s WHERE job_id = %d AND (operation_state IN ('preparing', 'enqueue_failed') OR (operation_state = 'enqueuing' AND (operation_claimed_at IS NULL OR operation_claimed_at < %s)))",
+				$this->table_name,
+				$claimed_at,
+				$job_id,
+				$lease_cutoff
+			)
+		);
+
+		return 1 === (int) $updated;
+	}
+
+	/**
+	 * Make an enqueued-but-unowned pending operation reclaimable.
+	 *
+	 * @param int $job_id Job ID.
+	 * @return bool Whether the operation was reset.
+	 */
+	public function reclaim_missing_operation_action( int $job_id ): bool {
+		if ( $job_id <= 0 ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $this->wpdb->query(
+			$this->wpdb->prepare(
+				"UPDATE %i SET operation_state = 'enqueue_failed', operation_action_id = NULL WHERE job_id = %d AND status = 'pending' AND operation_state = 'enqueued'",
+				$this->table_name,
+				$job_id
+			)
+		);
+
+		return 1 === (int) $updated;
+	}
+
+	/**
+	 * Record the durable enqueue outcome for an operation.
+	 *
+	 * @param int    $job_id   Job ID.
+	 * @param string $state    enqueued or enqueue_failed.
+	 * @param int    $action_id Action Scheduler action ID when available.
+	 * @return bool
+	 */
+	public function finish_operation_enqueue( int $job_id, string $state, int $action_id = 0 ): bool {
+		if ( $job_id <= 0 || ! in_array( $state, array( 'enqueued', 'enqueue_failed' ), true ) ) {
+			return false;
+		}
+
+		$data = array(
+			'operation_state'      => $state,
+			'operation_claimed_at' => null,
+			'operation_action_id'  => $action_id > 0 ? $action_id : null,
+		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return false !== $this->wpdb->update( $this->table_name, $data, array( 'job_id' => $job_id ), array( '%s', null, '%d' ), array( '%d' ) );
+	}
+
+	/**
+	 * Reopen a failed job for an explicit retry.
+	 *
+	 * @param int $job_id Job ID.
+	 * @return bool Whether the failed row was reopened.
+	 */
+	public function reopen_failed_job( int $job_id ): bool {
+		if ( $job_id <= 0 ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $this->wpdb->query(
+			$this->wpdb->prepare(
+				"UPDATE %i SET status = 'pending', completed_at = NULL, operation_state = 'preparing', operation_claimed_at = NULL, operation_action_id = NULL WHERE job_id = %d AND status LIKE 'failed%'",
+				$this->table_name,
+				$job_id
+			)
+		);
+
+		return 1 === (int) $updated;
 	}
 
 	/**
@@ -976,7 +1082,8 @@ class Jobs extends BaseRepository {
 		$run_metadata     = new RunMetadata();
 		$matching_job_ids = $run_metadata->query_job_ids( $metadata_filters, $per_page, $offset );
 		$total            = $run_metadata->count_jobs( $metadata_filters );
-		if ( ! empty( $matching_job_ids ) || $total > 0 ) {
+		$has_ownership_scope = isset( $args['user_id'] ) || isset( $args['agent_id'] );
+		if ( ! $has_ownership_scope && ( ! empty( $matching_job_ids ) || $total > 0 ) ) {
 			if ( empty( $matching_job_ids ) ) {
 				return array(
 					'jobs'       => array(),
@@ -2053,6 +2160,11 @@ class Jobs extends BaseRepository {
             engine_data longtext NULL,
             handler_slug varchar(100) NULL DEFAULT NULL,
             idempotency_key varchar(191) NULL DEFAULT NULL,
+			request_fingerprint char(64) NULL DEFAULT NULL,
+			operation_state varchar(32) NULL DEFAULT NULL,
+			operation_step_id varchar(191) NULL DEFAULT NULL,
+			operation_claimed_at datetime NULL DEFAULT NULL,
+			operation_action_id bigint(20) unsigned NULL DEFAULT NULL,
             created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
             completed_at datetime NULL DEFAULT NULL,
             PRIMARY KEY  (job_id),
@@ -2075,6 +2187,7 @@ class Jobs extends BaseRepository {
 		self::migrate_task_type_column( $table_name );
 		self::migrate_handler_slug_column( $table_name );
 		self::migrate_idempotency_key_column( $table_name );
+		self::migrate_operation_columns( $table_name );
 		self::migrate_indexes( $table_name );
 
 		do_action(
@@ -2495,6 +2608,32 @@ class Jobs extends BaseRepository {
 		}
 
 		self::ensure_jobs_index( $table_name, 'idx_idempotency_key', 'UNIQUE INDEX', '(idempotency_key)' );
+	}
+
+	/**
+	 * Add retention-safe operation metadata used by idempotent job submission.
+	 *
+	 * @param string $table_name Fully qualified jobs table name.
+	 */
+	private static function migrate_operation_columns( string $table_name ): void {
+		global $wpdb;
+
+		$columns = array(
+			'request_fingerprint'  => 'char(64) NULL DEFAULT NULL',
+			'operation_state'      => 'varchar(32) NULL DEFAULT NULL',
+			'operation_step_id'    => 'varchar(191) NULL DEFAULT NULL',
+			'operation_claimed_at' => 'datetime NULL DEFAULT NULL',
+			'operation_action_id'  => 'bigint(20) unsigned NULL DEFAULT NULL',
+		);
+
+		foreach ( $columns as $column => $definition ) {
+			if ( BaseRepository::column_exists( $table_name, $column, $wpdb ) ) {
+				continue;
+			}
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Fixed schema identifiers and definitions.
+			$wpdb->query( "ALTER TABLE {$table_name} ADD COLUMN {$column} {$definition}" );
+		}
 	}
 
 	/**

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -431,7 +431,7 @@ class Jobs extends BaseRepository {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->query(
 			$this->wpdb->prepare(
-				'UPDATE %i SET operation_state = %s, operation_claimed_at = NULL, operation_claim_token = NULL, operation_action_id = %d WHERE job_id = %d AND operation_state = %s AND operation_generation = %d AND operation_claim_token = %s',
+				'UPDATE %i SET operation_state = %s, operation_claimed_at = NULL, operation_action_id = %d WHERE job_id = %d AND operation_state = %s AND operation_generation = %d AND operation_claim_token = %s',
 				$this->table_name,
 				$state,
 				max( 0, $action_id ),

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -340,27 +340,54 @@ class Jobs extends BaseRepository {
 	 *
 	 * @param int $job_id        Job ID.
 	 * @param int $lease_seconds Claim lease in seconds.
-	 * @return bool Whether this caller acquired the claim.
+	 * @return array{token:string,generation:int}|false Claim details, or false when another generation owns it.
 	 */
-	public function claim_operation_enqueue( int $job_id, int $lease_seconds = 30 ): bool {
+	public function claim_operation_enqueue( int $job_id, int $lease_seconds = 30 ): array|false {
 		if ( $job_id <= 0 ) {
 			return false;
 		}
 
 		$lease_cutoff = gmdate( 'Y-m-d H:i:s', time() - max( 1, $lease_seconds ) );
 		$claimed_at   = gmdate( 'Y-m-d H:i:s' );
+		$claim_token  = bin2hex( random_bytes( 16 ) );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->query(
 			$this->wpdb->prepare(
-				"UPDATE %i SET operation_state = 'enqueuing', operation_claimed_at = %s WHERE job_id = %d AND (operation_state IN ('preparing', 'enqueue_failed') OR (operation_state = 'enqueuing' AND (operation_claimed_at IS NULL OR operation_claimed_at < %s)))",
+				"UPDATE %i SET operation_state = 'enqueuing', operation_claimed_at = %s, operation_claim_token = %s, operation_generation = COALESCE(operation_generation, 0) + 1 WHERE job_id = %d AND (operation_state IN ('preparing', 'enqueue_failed') OR (operation_state = 'enqueuing' AND (operation_claimed_at IS NULL OR operation_claimed_at < %s)))",
 				$this->table_name,
 				$claimed_at,
+				$claim_token,
 				$job_id,
 				$lease_cutoff
 			)
 		);
 
-		return 1 === (int) $updated;
+		if ( 1 !== (int) $updated ) {
+			return false;
+		}
+
+		$job = $this->get_job( $job_id );
+		if ( ! is_array( $job ) || ! hash_equals( $claim_token, (string) ( $job['operation_claim_token'] ?? '' ) ) ) {
+			return false;
+		}
+
+		return array(
+			'token'      => $claim_token,
+			'generation' => (int) ( $job['operation_generation'] ?? 0 ),
+		);
+	}
+
+	/**
+	 * Check whether an enqueue claim still owns the active generation.
+	 */
+	public function owns_operation_enqueue_claim( int $job_id, string $token, int $generation ): bool {
+		$job = $this->get_job( $job_id );
+
+		return is_array( $job )
+			&& 'enqueuing' === ( $job['operation_state'] ?? '' )
+			&& $generation === (int) ( $job['operation_generation'] ?? 0 )
+			&& '' !== $token
+			&& hash_equals( $token, (string) ( $job['operation_claim_token'] ?? '' ) );
 	}
 
 	/**
@@ -391,21 +418,31 @@ class Jobs extends BaseRepository {
 	 *
 	 * @param int    $job_id   Job ID.
 	 * @param string $state    enqueued or enqueue_failed.
-	 * @param int    $action_id Action Scheduler action ID when available.
+	 * @param int    $action_id  Action Scheduler action ID when available.
+	 * @param string $token      Active claim token.
+	 * @param int    $generation Active claim generation.
 	 * @return bool
 	 */
-	public function finish_operation_enqueue( int $job_id, string $state, int $action_id = 0 ): bool {
-		if ( $job_id <= 0 || ! in_array( $state, array( 'enqueued', 'enqueue_failed' ), true ) ) {
+	public function finish_operation_enqueue( int $job_id, string $state, int $action_id, string $token, int $generation ): bool {
+		if ( $job_id <= 0 || '' === $token || $generation <= 0 || ! in_array( $state, array( 'enqueued', 'enqueue_failed' ), true ) ) {
 			return false;
 		}
 
-		$data = array(
-			'operation_state'      => $state,
-			'operation_claimed_at' => null,
-			'operation_action_id'  => $action_id > 0 ? $action_id : null,
-		);
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		return false !== $this->wpdb->update( $this->table_name, $data, array( 'job_id' => $job_id ), array( '%s', null, '%d' ), array( '%d' ) );
+		$updated = $this->wpdb->query(
+			$this->wpdb->prepare(
+				'UPDATE %i SET operation_state = %s, operation_claimed_at = NULL, operation_claim_token = NULL, operation_action_id = %d WHERE job_id = %d AND operation_state = %s AND operation_generation = %d AND operation_claim_token = %s',
+				$this->table_name,
+				$state,
+				max( 0, $action_id ),
+				$job_id,
+				'enqueuing',
+				$generation,
+				$token
+			)
+		);
+
+		return 1 === (int) $updated;
 	}
 
 	/**
@@ -422,7 +459,7 @@ class Jobs extends BaseRepository {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->query(
 			$this->wpdb->prepare(
-				"UPDATE %i SET status = 'pending', completed_at = NULL, operation_state = 'preparing', operation_claimed_at = NULL, operation_action_id = NULL WHERE job_id = %d AND status LIKE 'failed%'",
+				"UPDATE %i SET status = 'pending', completed_at = NULL, operation_state = 'preparing', operation_claimed_at = NULL, operation_claim_token = NULL, operation_action_id = NULL WHERE job_id = %d AND status LIKE 'failed%'",
 				$this->table_name,
 				$job_id
 			)
@@ -2164,6 +2201,8 @@ class Jobs extends BaseRepository {
 			operation_state varchar(32) NULL DEFAULT NULL,
 			operation_step_id varchar(191) NULL DEFAULT NULL,
 			operation_claimed_at datetime NULL DEFAULT NULL,
+			operation_claim_token varchar(64) NULL DEFAULT NULL,
+			operation_generation bigint(20) unsigned NOT NULL DEFAULT 0,
 			operation_action_id bigint(20) unsigned NULL DEFAULT NULL,
             created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
             completed_at datetime NULL DEFAULT NULL,
@@ -2623,6 +2662,8 @@ class Jobs extends BaseRepository {
 			'operation_state'      => 'varchar(32) NULL DEFAULT NULL',
 			'operation_step_id'    => 'varchar(191) NULL DEFAULT NULL',
 			'operation_claimed_at' => 'datetime NULL DEFAULT NULL',
+			'operation_claim_token' => 'varchar(64) NULL DEFAULT NULL',
+			'operation_generation' => 'bigint(20) unsigned NOT NULL DEFAULT 0',
 			'operation_action_id'  => 'bigint(20) unsigned NULL DEFAULT NULL',
 		);
 

--- a/inc/Core/DirectJobEnqueuer.php
+++ b/inc/Core/DirectJobEnqueuer.php
@@ -45,7 +45,8 @@ class DirectJobEnqueuer {
 
 		$job        = $this->jobs->get_job( $job_id );
 		$generation = max( 0, (int) ( $job['operation_generation'] ?? 0 ) );
-		$args       = $this->actionArgs( $job_id, $flow_step_id, $generation );
+		$token      = (string) ( $job['operation_claim_token'] ?? '' );
+		$args       = $this->actionArgs( $job_id, $flow_step_id, $generation, $token );
 		$scheduled_action_id = in_array( (string) ( $job['operation_state'] ?? '' ), array( 'enqueued', 'enqueuing' ), true )
 			? $this->scheduledActionId( $args )
 			: 0;
@@ -61,7 +62,8 @@ class DirectJobEnqueuer {
 		if ( false === $claim ) {
 			$job                 = $this->jobs->get_job( $job_id );
 			$current_generation  = max( 0, (int) ( $job['operation_generation'] ?? 0 ) );
-			$current_action_args = $this->actionArgs( $job_id, $flow_step_id, $current_generation );
+			$current_token       = (string) ( $job['operation_claim_token'] ?? '' );
+			$current_action_args = $this->actionArgs( $job_id, $flow_step_id, $current_generation, $current_token );
 			$current_action_id   = $this->scheduledActionId( $current_action_args );
 			if ( $current_action_id > 0 ) {
 				return $this->success( $current_action_id, $current_generation );
@@ -72,7 +74,7 @@ class DirectJobEnqueuer {
 
 		$token      = $claim['token'];
 		$generation = $claim['generation'];
-		$args       = $this->actionArgs( $job_id, $flow_step_id, $generation );
+		$args       = $this->actionArgs( $job_id, $flow_step_id, $generation, $token );
 
 		// A previous submitter may have crashed after scheduling but before it
 		// recorded success. Reconcile that action before creating another one.
@@ -102,11 +104,16 @@ class DirectJobEnqueuer {
 		return $this->success( $action_id, $generation );
 	}
 
-	private function actionArgs( int $job_id, string $flow_step_id, int $generation ): array {
+	public function hasLiveAction( int $job_id, string $flow_step_id, int $generation, string $token ): bool {
+		return $this->scheduledActionId( $this->actionArgs( $job_id, $flow_step_id, $generation, $token ) ) > 0;
+	}
+
+	private function actionArgs( int $job_id, string $flow_step_id, int $generation, string $token ): array {
 		return array(
 			'job_id'               => $job_id,
 			'flow_step_id'         => $flow_step_id,
 			'operation_generation' => $generation,
+			'operation_claim_token' => $token,
 		);
 	}
 

--- a/inc/Core/DirectJobEnqueuer.php
+++ b/inc/Core/DirectJobEnqueuer.php
@@ -51,7 +51,7 @@ class DirectJobEnqueuer {
 			? $this->scheduledActionId( $args )
 			: 0;
 		if ( $scheduled_action_id > 0 ) {
-			return $this->success( $scheduled_action_id, $generation );
+			return $this->reconcileScheduledAction( $job_id, $job, $scheduled_action_id, $generation, $token );
 		}
 
 		if ( 'enqueued' === ( $job['operation_state'] ?? '' ) && 'pending' === ( $job['status'] ?? '' ) ) {
@@ -66,7 +66,7 @@ class DirectJobEnqueuer {
 			$current_action_args = $this->actionArgs( $job_id, $flow_step_id, $current_generation, $current_token );
 			$current_action_id   = $this->scheduledActionId( $current_action_args );
 			if ( $current_action_id > 0 ) {
-				return $this->success( $current_action_id, $current_generation );
+				return $this->reconcileScheduledAction( $job_id, $job, $current_action_id, $current_generation, $current_token );
 			}
 
 			return $this->inProgress( $current_generation );
@@ -80,10 +80,7 @@ class DirectJobEnqueuer {
 		// recorded success. Reconcile that action before creating another one.
 		$scheduled_action_id = $this->scheduledActionId( $args );
 		if ( $scheduled_action_id > 0 ) {
-			if ( ! $this->jobs->finish_operation_enqueue( $job_id, 'enqueued', $scheduled_action_id, $token, $generation ) ) {
-				return $this->failure( 'enqueue_claim_fenced', $generation, true, 'enqueuing' );
-			}
-			return $this->success( $scheduled_action_id, $generation );
+			return $this->reconcileScheduledAction( $job_id, $this->jobs->get_job( $job_id ), $scheduled_action_id, $generation, $token );
 		}
 
 		if ( ! $this->jobs->owns_operation_enqueue_claim( $job_id, $token, $generation ) ) {
@@ -106,6 +103,33 @@ class DirectJobEnqueuer {
 
 	public function hasLiveAction( int $job_id, string $flow_step_id, int $generation, string $token ): bool {
 		return $this->scheduledActionId( $this->actionArgs( $job_id, $flow_step_id, $generation, $token ) ) > 0;
+	}
+
+	/**
+	 * Check for any pending/in-progress step in an operation generation.
+	 */
+	public function hasLiveGenerationAction( int $job_id, int $generation, string $token ): bool {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) || $job_id <= 0 || $generation <= 0 || '' === $token ) {
+			return false;
+		}
+
+		$action_ids = as_get_scheduled_actions(
+			array(
+				'hook'                  => self::HOOK,
+				'group'                 => self::GROUP,
+				'args'                  => array(
+					'job_id'               => $job_id,
+					'operation_generation' => $generation,
+					'operation_claim_token' => $token,
+				),
+				'partial_args_matching' => 'like',
+				'status'                => array( 'pending', 'in-progress' ),
+				'per_page'              => 1,
+			),
+			'ids'
+		);
+
+		return ! empty( $action_ids );
 	}
 
 	private function actionArgs( int $job_id, string $flow_step_id, int $generation, string $token ): array {
@@ -155,6 +179,33 @@ class DirectJobEnqueuer {
 		}
 
 		return 0;
+	}
+
+	private function reconcileScheduledAction( int $job_id, ?array $job, int $action_id, int $generation, string $token ): array {
+		if ( ! is_array( $job ) || $generation <= 0 || '' === $token ) {
+			return $this->inProgress( $generation );
+		}
+
+		if ( 'enqueued' === ( $job['operation_state'] ?? '' )
+			&& $generation === (int) ( $job['operation_generation'] ?? 0 )
+			&& hash_equals( $token, (string) ( $job['operation_claim_token'] ?? '' ) ) ) {
+			return $this->success( $action_id, $generation );
+		}
+
+		if ( 'enqueuing' === ( $job['operation_state'] ?? '' )
+			&& $this->jobs->finish_operation_enqueue( $job_id, 'enqueued', $action_id, $token, $generation ) ) {
+			return $this->success( $action_id, $generation );
+		}
+
+		$reloaded = $this->jobs->get_job( $job_id );
+		if ( is_array( $reloaded )
+			&& 'enqueued' === ( $reloaded['operation_state'] ?? '' )
+			&& $generation === (int) ( $reloaded['operation_generation'] ?? 0 )
+			&& hash_equals( $token, (string) ( $reloaded['operation_claim_token'] ?? '' ) ) ) {
+			return $this->success( $action_id, $generation );
+		}
+
+		return $this->inProgress( max( $generation, (int) ( $reloaded['operation_generation'] ?? 0 ) ) );
 	}
 
 	private function success( int $action_id, int $generation ): array {

--- a/inc/Core/DirectJobEnqueuer.php
+++ b/inc/Core/DirectJobEnqueuer.php
@@ -36,61 +36,78 @@ class DirectJobEnqueuer {
 	 * @param int      $job_id       Job ID.
 	 * @param string   $flow_step_id Flow step ID.
 	 * @param int|null $timestamp    Optional future Unix timestamp.
-	 * @return array{success:bool,action_id:int,state:string,error?:string}
+	 * @return array{success:bool,action_id:int,state:string,generation:int,retryable?:bool,error?:string}
 	 */
 	public function enqueue( int $job_id, string $flow_step_id, ?int $timestamp = null ): array {
 		if ( $job_id <= 0 || '' === $flow_step_id ) {
 			return $this->failure( 'invalid_enqueue_target' );
 		}
 
-		$args = array(
-			'job_id'       => $job_id,
-			'flow_step_id' => $flow_step_id,
-		);
-		$scheduled_action_id = $this->scheduledActionId( $args );
+		$job        = $this->jobs->get_job( $job_id );
+		$generation = max( 0, (int) ( $job['operation_generation'] ?? 0 ) );
+		$args       = $this->actionArgs( $job_id, $flow_step_id, $generation );
+		$scheduled_action_id = in_array( (string) ( $job['operation_state'] ?? '' ), array( 'enqueued', 'enqueuing' ), true )
+			? $this->scheduledActionId( $args )
+			: 0;
 		if ( $scheduled_action_id > 0 ) {
-			$this->jobs->finish_operation_enqueue( $job_id, 'enqueued', $scheduled_action_id );
-			return $this->success( $scheduled_action_id );
+			return $this->success( $scheduled_action_id, $generation );
 		}
 
-		$job = $this->jobs->get_job( $job_id );
 		if ( 'enqueued' === ( $job['operation_state'] ?? '' ) && 'pending' === ( $job['status'] ?? '' ) ) {
 			$this->jobs->reclaim_missing_operation_action( $job_id );
 		}
 
-		if ( ! $this->jobs->claim_operation_enqueue( $job_id ) ) {
-			$job = $this->jobs->get_job( $job_id );
-			if ( 'enqueued' === ( $job['operation_state'] ?? '' ) ) {
-				return $this->success( (int) ( $job['operation_action_id'] ?? 0 ) );
+		$claim = $this->jobs->claim_operation_enqueue( $job_id );
+		if ( false === $claim ) {
+			$job                 = $this->jobs->get_job( $job_id );
+			$current_generation  = max( 0, (int) ( $job['operation_generation'] ?? 0 ) );
+			$current_action_args = $this->actionArgs( $job_id, $flow_step_id, $current_generation );
+			$current_action_id   = $this->scheduledActionId( $current_action_args );
+			if ( $current_action_id > 0 ) {
+				return $this->success( $current_action_id, $current_generation );
 			}
 
-			return array(
-				'success'   => true,
-				'action_id' => 0,
-				'state'     => 'enqueuing',
-			);
+			return $this->inProgress( $current_generation );
 		}
+
+		$token      = $claim['token'];
+		$generation = $claim['generation'];
+		$args       = $this->actionArgs( $job_id, $flow_step_id, $generation );
 
 		// A previous submitter may have crashed after scheduling but before it
 		// recorded success. Reconcile that action before creating another one.
 		$scheduled_action_id = $this->scheduledActionId( $args );
 		if ( $scheduled_action_id > 0 ) {
-			$this->jobs->finish_operation_enqueue( $job_id, 'enqueued', $scheduled_action_id );
-			return $this->success( $scheduled_action_id );
+			if ( ! $this->jobs->finish_operation_enqueue( $job_id, 'enqueued', $scheduled_action_id, $token, $generation ) ) {
+				return $this->failure( 'enqueue_claim_fenced', $generation, true, 'enqueuing' );
+			}
+			return $this->success( $scheduled_action_id, $generation );
+		}
+
+		if ( ! $this->jobs->owns_operation_enqueue_claim( $job_id, $token, $generation ) ) {
+			return $this->failure( 'enqueue_claim_fenced', $generation, true, 'enqueuing' );
 		}
 
 		$run_at    = null !== $timestamp && $timestamp > time() ? $timestamp : time();
 		$action_id = ( $this->scheduler )( $run_at, self::HOOK, $args, self::GROUP );
 		if ( ! is_int( $action_id ) || $action_id <= 0 ) {
-			$this->jobs->finish_operation_enqueue( $job_id, 'enqueue_failed' );
-			return $this->failure( 'action_schedule_failed' );
+			$this->jobs->finish_operation_enqueue( $job_id, 'enqueue_failed', 0, $token, $generation );
+			return $this->failure( 'action_schedule_failed', $generation, true );
 		}
 
-		if ( ! $this->jobs->finish_operation_enqueue( $job_id, 'enqueued', $action_id ) ) {
-			return $this->failure( 'enqueue_state_persist_failed' );
+		if ( ! $this->jobs->finish_operation_enqueue( $job_id, 'enqueued', $action_id, $token, $generation ) ) {
+			return $this->failure( 'enqueue_claim_fenced', $generation, true, 'enqueuing' );
 		}
 
-		return $this->success( $action_id );
+		return $this->success( $action_id, $generation );
+	}
+
+	private function actionArgs( int $job_id, string $flow_step_id, int $generation ): array {
+		return array(
+			'job_id'               => $job_id,
+			'flow_step_id'         => $flow_step_id,
+			'operation_generation' => $generation,
+		);
 	}
 
 	/**
@@ -133,20 +150,38 @@ class DirectJobEnqueuer {
 		return 0;
 	}
 
-	private function success( int $action_id ): array {
+	private function success( int $action_id, int $generation ): array {
 		return array(
-			'success'   => true,
-			'action_id' => $action_id,
-			'state'     => 'enqueued',
+			'success'    => true,
+			'action_id'  => $action_id,
+			'state'      => 'enqueued',
+			'generation' => $generation,
 		);
 	}
 
-	private function failure( string $error ): array {
+	private function inProgress( int $generation ): array {
 		return array(
-			'success'   => false,
-			'action_id' => 0,
-			'state'     => 'enqueue_failed',
-			'error'     => $error,
+			'success'    => false,
+			'action_id'  => 0,
+			'state'      => 'enqueuing',
+			'generation' => $generation,
+			'retryable'  => true,
+			'error'      => 'enqueue_in_progress',
 		);
+	}
+
+	private function failure( string $error, int $generation = 0, bool $retryable = false, string $state = 'enqueue_failed' ): array {
+		$result = array(
+			'success'    => false,
+			'action_id'  => 0,
+			'state'      => $state,
+			'generation' => $generation,
+			'error'      => $error,
+		);
+		if ( $retryable ) {
+			$result['retryable'] = true;
+		}
+
+		return $result;
 	}
 }

--- a/inc/Core/DirectJobEnqueuer.php
+++ b/inc/Core/DirectJobEnqueuer.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Durable enqueue coordinator for direct workflow jobs.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+use DataMachine\Core\Database\Jobs\Jobs;
+
+defined( 'ABSPATH' ) || exit;
+
+class DirectJobEnqueuer {
+
+	private const HOOK  = 'datamachine_execute_step';
+	private const GROUP = 'data-machine';
+
+	private Jobs $jobs;
+	private \Closure $scheduler;
+	private \Closure $action_finder;
+
+	public function __construct( ?Jobs $jobs = null, ?callable $scheduler = null, ?callable $action_finder = null ) {
+		$this->jobs          = $jobs ?? new Jobs();
+		$this->scheduler     = null !== $scheduler
+			? \Closure::fromCallable( $scheduler )
+			: static fn( int $run_at, string $hook, array $args, string $group ) => as_schedule_single_action( $run_at, $hook, $args, $group );
+		$this->action_finder = null !== $action_finder
+			? \Closure::fromCallable( $action_finder )
+			: fn( array $args ): int => $this->findScheduledActionId( $args );
+	}
+
+	/**
+	 * Durably enqueue one direct workflow step with crash recovery.
+	 *
+	 * @param int      $job_id       Job ID.
+	 * @param string   $flow_step_id Flow step ID.
+	 * @param int|null $timestamp    Optional future Unix timestamp.
+	 * @return array{success:bool,action_id:int,state:string,error?:string}
+	 */
+	public function enqueue( int $job_id, string $flow_step_id, ?int $timestamp = null ): array {
+		if ( $job_id <= 0 || '' === $flow_step_id ) {
+			return $this->failure( 'invalid_enqueue_target' );
+		}
+
+		$args = array(
+			'job_id'       => $job_id,
+			'flow_step_id' => $flow_step_id,
+		);
+		$scheduled_action_id = $this->scheduledActionId( $args );
+		if ( $scheduled_action_id > 0 ) {
+			$this->jobs->finish_operation_enqueue( $job_id, 'enqueued', $scheduled_action_id );
+			return $this->success( $scheduled_action_id );
+		}
+
+		$job = $this->jobs->get_job( $job_id );
+		if ( 'enqueued' === ( $job['operation_state'] ?? '' ) && 'pending' === ( $job['status'] ?? '' ) ) {
+			$this->jobs->reclaim_missing_operation_action( $job_id );
+		}
+
+		if ( ! $this->jobs->claim_operation_enqueue( $job_id ) ) {
+			$job = $this->jobs->get_job( $job_id );
+			if ( 'enqueued' === ( $job['operation_state'] ?? '' ) ) {
+				return $this->success( (int) ( $job['operation_action_id'] ?? 0 ) );
+			}
+
+			return array(
+				'success'   => true,
+				'action_id' => 0,
+				'state'     => 'enqueuing',
+			);
+		}
+
+		// A previous submitter may have crashed after scheduling but before it
+		// recorded success. Reconcile that action before creating another one.
+		$scheduled_action_id = $this->scheduledActionId( $args );
+		if ( $scheduled_action_id > 0 ) {
+			$this->jobs->finish_operation_enqueue( $job_id, 'enqueued', $scheduled_action_id );
+			return $this->success( $scheduled_action_id );
+		}
+
+		$run_at    = null !== $timestamp && $timestamp > time() ? $timestamp : time();
+		$action_id = ( $this->scheduler )( $run_at, self::HOOK, $args, self::GROUP );
+		if ( ! is_int( $action_id ) || $action_id <= 0 ) {
+			$this->jobs->finish_operation_enqueue( $job_id, 'enqueue_failed' );
+			return $this->failure( 'action_schedule_failed' );
+		}
+
+		if ( ! $this->jobs->finish_operation_enqueue( $job_id, 'enqueued', $action_id ) ) {
+			return $this->failure( 'enqueue_state_persist_failed' );
+		}
+
+		return $this->success( $action_id );
+	}
+
+	/**
+	 * Find an existing pending/in-progress action for this exact job step.
+	 *
+	 * @param array $args Action arguments.
+	 * @return int Action ID, or 0 when none exists.
+	 */
+	private function scheduledActionId( array $args ): int {
+		return max( 0, (int) ( $this->action_finder )( $args ) );
+	}
+
+	/**
+	 * Query Action Scheduler for an exact pending/in-progress action.
+	 *
+	 * @param array $args Action arguments.
+	 * @return int
+	 */
+	private function findScheduledActionId( array $args ): int {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+			return 0;
+		}
+
+		foreach ( array( 'pending', 'in-progress' ) as $status ) {
+			$action_ids = as_get_scheduled_actions(
+				array(
+					'hook'     => self::HOOK,
+					'group'    => self::GROUP,
+					'args'     => $args,
+					'status'   => $status,
+					'per_page' => 1,
+				),
+				'ids'
+			);
+			if ( ! empty( $action_ids ) ) {
+				return (int) reset( $action_ids );
+			}
+		}
+
+		return 0;
+	}
+
+	private function success( int $action_id ): array {
+		return array(
+			'success'   => true,
+			'action_id' => $action_id,
+			'state'     => 'enqueued',
+		);
+	}
+
+	private function failure( string $error ): array {
+		return array(
+			'success'   => false,
+			'action_id' => 0,
+			'state'     => 'enqueue_failed',
+			'error'     => $error,
+		);
+	}
+}

--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -617,7 +617,7 @@ class JobArtifacts {
 		return $ref;
 	}
 
-	private function job_id_from_artifact_ref( string $artifact_ref ): int {
+	public function job_id_from_artifact_ref( string $artifact_ref ): int {
 		if ( ! preg_match( '#^datamachine://jobs/(\d+)/artifacts/#', $artifact_ref, $matches ) ) {
 			return 0;
 		}

--- a/inc/Core/JobRetryPolicy.php
+++ b/inc/Core/JobRetryPolicy.php
@@ -470,6 +470,16 @@ class JobRetryPolicy {
 	}
 
 	/**
+	 * Resolve the safe resume step for an explicit direct-workflow retry.
+	 *
+	 * @param array $engine_data Job engine data.
+	 * @return string Resume step ID, or empty string when retry is unsafe.
+	 */
+	public static function resolveDirectResumeStepId( array $engine_data ): string {
+		return self::resolveEphemeralFlowStepId( $engine_data );
+	}
+
+	/**
 	 * Resolve the first incomplete step id of a resumable multi-step workflow.
 	 *
 	 * Walks the flow_config in execution order and returns the first step that

--- a/inc/Core/JobRetryPolicy.php
+++ b/inc/Core/JobRetryPolicy.php
@@ -104,13 +104,18 @@ class JobRetryPolicy {
 			);
 		}
 
+		$action_args = array(
+			'job_id'       => $job_id,
+			'flow_step_id' => $flow_step_id,
+		);
+		if ( 'direct' === (string) ( $job['flow_id'] ?? '' ) && (int) ( $job['operation_generation'] ?? 0 ) > 0 ) {
+			$action_args['operation_generation'] = (int) $job['operation_generation'];
+		}
+
 		$action_id = as_schedule_single_action(
 			$timestamp,
 			'datamachine_execute_step',
-			array(
-				'job_id'       => $job_id,
-				'flow_step_id' => $flow_step_id,
-			),
+			$action_args,
 			'data-machine'
 		);
 

--- a/inc/Core/JobRetryPolicy.php
+++ b/inc/Core/JobRetryPolicy.php
@@ -110,6 +110,7 @@ class JobRetryPolicy {
 		);
 		if ( 'direct' === (string) ( $job['flow_id'] ?? '' ) && (int) ( $job['operation_generation'] ?? 0 ) > 0 ) {
 			$action_args['operation_generation'] = (int) $job['operation_generation'];
+			$action_args['operation_claim_token'] = (string) ( $job['operation_claim_token'] ?? '' );
 		}
 
 		$action_id = as_schedule_single_action(

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -736,15 +736,20 @@ class AIStep extends Step {
 		);
 		$timestamp     = time() + $delay_seconds;
 		$action_id     = false;
+		$action_args   = array(
+			'job_id'       => $this->job_id,
+			'flow_step_id' => $this->flow_step_id,
+		);
+		$job = ( new \DataMachine\Core\Database\Jobs\Jobs() )->get_job( $this->job_id );
+		if ( 'direct' === (string) ( $job['flow_id'] ?? '' ) && (int) ( $job['operation_generation'] ?? 0 ) > 0 ) {
+			$action_args['operation_generation'] = (int) $job['operation_generation'];
+		}
 
 		if ( function_exists( 'as_schedule_single_action' ) ) {
 			$action_id = as_schedule_single_action(
 				$timestamp,
 				'datamachine_execute_step',
-				array(
-					'job_id'       => $this->job_id,
-					'flow_step_id' => $this->flow_step_id,
-				),
+				$action_args,
 				'data-machine'
 			);
 		}

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -743,6 +743,7 @@ class AIStep extends Step {
 		$job = ( new \DataMachine\Core\Database\Jobs\Jobs() )->get_job( $this->job_id );
 		if ( 'direct' === (string) ( $job['flow_id'] ?? '' ) && (int) ( $job['operation_generation'] ?? 0 ) > 0 ) {
 			$action_args['operation_generation'] = (int) $job['operation_generation'];
+			$action_args['operation_claim_token'] = (string) ( $job['operation_claim_token'] ?? '' );
 		}
 
 		if ( function_exists( 'as_schedule_single_action' ) ) {

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -522,8 +522,9 @@ class RetentionCleanup {
 	 *
 	 * Sets `engine_data = NULL` on jobs that have been terminal for longer than
 	 * engineDataTerminalMaxAgeDays(), KEEPING the row. The heavy working-state
-	 * blob is the only thing dropped; status, timing, counts and the promoted
-	 * handler_slug column survive for stats/history/dedup. Whole-row deletion
+	 * blob is the only thing dropped; status, timing, counts, handler_slug, and
+	 * retention-safe request_fingerprint/operation columns survive for
+	 * stats/history/idempotent replay. Whole-row deletion
 	 * (cleanupCompletedJobs/cleanupFailedJobs) handles the longer window.
 	 *
 	 * The UPDATE is batched by id (bounded LIMIT per pass, shared iteration +

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -111,7 +111,7 @@ function datamachine_register_execution_engine() {
 	 */
 	add_action(
 		'datamachine_execute_step',
-		function ( $job_id, string $flow_step_id, $operation_generation = 0 ) {
+		function ( $job_id, string $flow_step_id, $operation_generation = 0, $operation_claim_token = '' ) {
 			$ability = wp_get_ability( 'datamachine/execute-step' );
 			if ( $ability ) {
 				$ability->execute(
@@ -119,12 +119,13 @@ function datamachine_register_execution_engine() {
 						'job_id'               => (int) $job_id,
 						'flow_step_id'          => $flow_step_id,
 						'operation_generation' => is_numeric( $operation_generation ) ? (int) $operation_generation : 0,
+						'operation_claim_token' => is_string( $operation_claim_token ) ? $operation_claim_token : '',
 					)
 				);
 			}
 		},
 		10,
-		3
+		4
 	);
 
 	/**

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -111,14 +111,14 @@ function datamachine_register_execution_engine() {
 	 */
 	add_action(
 		'datamachine_execute_step',
-		function ( $job_id, string $flow_step_id, ?array $dataPackets = null ) {
-			$dataPackets;
+		function ( $job_id, string $flow_step_id, $operation_generation = 0 ) {
 			$ability = wp_get_ability( 'datamachine/execute-step' );
 			if ( $ability ) {
 				$ability->execute(
 					array(
-						'job_id'       => (int) $job_id,
-						'flow_step_id' => $flow_step_id,
+						'job_id'               => (int) $job_id,
+						'flow_step_id'          => $flow_step_id,
+						'operation_generation' => is_numeric( $operation_generation ) ? (int) $operation_generation : 0,
 					)
 				);
 			}

--- a/inc/Engine/Tasks/TaskScheduler.php
+++ b/inc/Engine/Tasks/TaskScheduler.php
@@ -22,6 +22,7 @@ namespace DataMachine\Engine\Tasks;
 
 defined( 'ABSPATH' ) || exit;
 
+use DataMachine\Abilities\Job\ExecuteWorkflowAbility;
 use DataMachine\Core\ActionScheduler\BatchScheduler;
 use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\AbilityResult;
@@ -161,21 +162,6 @@ class TaskScheduler {
 			return false;
 		}
 
-		// Delegate to the execute-workflow ability.
-		$ability = wp_get_ability( 'datamachine/execute-workflow' );
-
-		if ( ! $ability ) {
-			$message = 'TaskScheduler: datamachine/execute-workflow ability not available';
-			do_action(
-				'datamachine_log',
-				'error',
-				$message,
-				array( 'task_type' => $taskType )
-			);
-			self::recordScheduleError( $message, 'task_scheduler_execute_workflow_unavailable' );
-			return false;
-		}
-
 		// Resolve agent identity from the context when present. Tasks that can
 		// safely run as explicit system maintenance may opt out via
 		// SystemTask::requiresAgentContext(); all other queued task work must have
@@ -266,12 +252,15 @@ class TaskScheduler {
 			$initial_data['resumable'] = true;
 		}
 
-		$result = AbilityResult::normalize( $ability->execute( array(
-			'workflow'       => $workflow,
-			'timestamp'      => $params['scheduled_at'] ?? null,
-			'initial_data'   => $initial_data,
-			'system_context' => true,
-		) ) );
+		$result = AbilityResult::normalize(
+			( new ExecuteWorkflowAbility( false ) )->executeInternal(
+				array(
+					'workflow'     => $workflow,
+					'timestamp'    => $params['scheduled_at'] ?? null,
+					'initial_data' => $initial_data,
+				)
+			)
+		);
 
 		if ( empty( $result['success'] ) ) {
 			$message    = 'TaskScheduler: Workflow execution failed for ' . $taskType . ': ' . ( $result['error'] ?? 'Unknown error' );

--- a/inc/Engine/Tasks/TaskScheduler.php
+++ b/inc/Engine/Tasks/TaskScheduler.php
@@ -267,9 +267,10 @@ class TaskScheduler {
 		}
 
 		$result = AbilityResult::normalize( $ability->execute( array(
-			'workflow'     => $workflow,
-			'timestamp'    => $params['scheduled_at'] ?? null,
-			'initial_data' => $initial_data,
+			'workflow'       => $workflow,
+			'timestamp'      => $params['scheduled_at'] ?? null,
+			'initial_data'   => $initial_data,
+			'system_context' => true,
 		) ) );
 
 		if ( empty( $result['success'] ) ) {

--- a/tests/Unit/Abilities/AgentPruneResurrectionTest.php
+++ b/tests/Unit/Abilities/AgentPruneResurrectionTest.php
@@ -56,6 +56,8 @@ class AgentPruneResurrectionTest extends WP_UnitTestCase {
 	}
 
 	public function test_getActiveAgent_clears_stale_meta_and_does_not_resurrect(): void {
+		global $wpdb;
+
 		$created = AgentAbilities::createAgent(
 			array(
 				'agent_slug' => 'stale-meta-bot',
@@ -73,9 +75,10 @@ class AgentPruneResurrectionTest extends WP_UnitTestCase {
 		);
 		$this->assertSame( 'stale-meta-bot', get_user_meta( $this->owner_id, self::ACTIVE_AGENT_META_KEY, true ) );
 
-		// Simulate prune by deleting the agent row directly.
-		$deleted = AgentAbilities::deleteAgent( array( 'agent_id' => $created['agent_id'] ) );
-		$this->assertTrue( $deleted['success'] );
+		// Bypass deleteAgent(), whose deletion hook correctly clears this meta,
+		// to reproduce a genuinely stale historical row.
+		$deleted = $wpdb->delete( $wpdb->base_prefix . 'datamachine_agents', array( 'agent_id' => $created['agent_id'] ) );
+		$this->assertSame( 1, $deleted );
 
 		// Reading the active agent should now clear the stale meta and report none.
 		$result = AgentAbilities::getActiveAgent( array( 'user_id' => $this->owner_id ) );
@@ -90,9 +93,10 @@ class AgentPruneResurrectionTest extends WP_UnitTestCase {
 	}
 
 	public function test_pruneAgents_clears_owner_active_agent_meta(): void {
+		$agent_slug = 'prune-me-' . wp_generate_uuid4();
 		$created = AgentAbilities::createAgent(
 			array(
-				'agent_slug' => 'prune-me-bot',
+				'agent_slug' => $agent_slug,
 				'owner_id'   => $this->owner_id,
 			)
 		);

--- a/tests/Unit/Abilities/AuthAbilitiesTest.php
+++ b/tests/Unit/Abilities/AuthAbilitiesTest.php
@@ -212,7 +212,7 @@ class AuthAbilitiesTest extends WP_UnitTestCase {
 		);
 
 		$this->assertTrue( $result['success'] );
-		$this->assertSame( $token, $provider->get_site_account()['access_token'] );
+		$this->assertSame( $token, $provider->get_account_for_user( get_current_user_id() )['access_token'] );
 	}
 
 	public function test_set_auth_token_saves_user_account_without_site_fallback(): void {

--- a/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
+++ b/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Direct asynchronous job ownership and idempotency coverage.
+ *
+ * @package DataMachine\Tests\Unit\Abilities\Job
+ */
+
+namespace DataMachine\Tests\Unit\Abilities\Job;
+
+use AgentsAPI\AI\WP_Agent_Execution_Principal;
+use DataMachine\Abilities\Job\ExecuteWorkflowAbility;
+use DataMachine\Abilities\Job\FailJobAbility;
+use DataMachine\Abilities\Job\GetJobsAbility;
+use DataMachine\Abilities\Job\RetryJobAbility;
+use DataMachine\Abilities\Job\RunMetricsAbility;
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\JobRetryPolicy;
+use WP_UnitTestCase;
+
+class DirectJobOwnershipTest extends WP_UnitTestCase {
+
+	private int $owner_id;
+	private int $other_user_id;
+	private int $admin_id;
+	private int $agent_id;
+	private int $scheduled_count = 0;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		datamachine_register_capabilities();
+		$this->owner_id      = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->other_user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->admin_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		get_user_by( 'id', $this->owner_id )->add_cap( 'datamachine_manage_flows' );
+		get_user_by( 'id', $this->other_user_id )->add_cap( 'datamachine_manage_flows' );
+		$this->agent_id = ( new Agents() )->create_if_missing( 'direct-job-owner', 'Direct Job Owner', $this->owner_id );
+
+		add_action( 'datamachine_schedule_next_step', array( $this, 'captureSchedule' ), 1 );
+	}
+
+	public function tear_down(): void {
+		remove_action( 'datamachine_schedule_next_step', array( $this, 'captureSchedule' ), 1 );
+		PermissionHelper::clear_agent_context();
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function captureSchedule(): void {
+		++$this->scheduled_count;
+	}
+
+	public function test_authenticated_caller_owns_direct_job_and_identity_survives_engine_snapshot(): void {
+		wp_set_current_user( $this->owner_id );
+
+		$result = $this->execute( 'authenticated-caller' );
+		$job    = ( new Jobs() )->get_job( (int) $result['job_id'] );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $this->owner_id, (int) $job['user_id'] );
+		$this->assertNull( $job['agent_id'] );
+		$this->assertSame( $this->owner_id, (int) $job['engine_data']['job']['user_id'] );
+		$this->assertSame( (int) $job['job_id'], (int) $job['engine_data']['job']['job_id'] );
+	}
+
+	public function test_delegated_principal_and_effective_agent_are_persisted(): void {
+		wp_set_current_user( $this->owner_id );
+		PermissionHelper::set_agent_context( $this->agent_id, $this->owner_id );
+		PermissionHelper::set_execution_principal(
+			WP_Agent_Execution_Principal::user_session(
+				$this->other_user_id,
+				(string) $this->agent_id,
+				WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST
+			)
+		);
+
+		$result = $this->execute( 'delegated-caller' );
+		$job    = ( new Jobs() )->get_job( (int) $result['job_id'] );
+
+		$this->assertSame( $this->other_user_id, (int) $job['user_id'] );
+		$this->assertSame( $this->agent_id, (int) $job['agent_id'] );
+		$this->assertSame( $this->other_user_id, (int) $job['engine_data']['job']['user_id'] );
+		$this->assertSame( $this->agent_id, (int) $job['engine_data']['job']['agent_id'] );
+		$this->assertSame( $this->other_user_id, (int) $job['engine_data']['calling_user_id'] );
+	}
+
+	public function test_absent_caller_fails_closed_for_user_scoped_execution(): void {
+		wp_set_current_user( 0 );
+
+		$result = $this->execute( 'missing-caller' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'authenticated acting caller', $result['error'] );
+	}
+
+	public function test_ownership_survives_deferred_worker_resume(): void {
+		wp_set_current_user( $this->owner_id );
+		$created = $this->execute( 'deferred-resume' );
+		$jobs    = new Jobs();
+
+		$retry = JobRetryPolicy::maybeRetry(
+			(int) $created['job_id'],
+			'ai_step_failed',
+			array(
+				'retryable'   => true,
+				'flow_step_id' => 'ephemeral_step_0',
+			),
+			$jobs
+		);
+		$job = $jobs->get_job( (int) $created['job_id'] );
+
+		$this->assertTrue( $retry['retried'] );
+		$this->assertSame( $this->owner_id, (int) $job['user_id'] );
+		$this->assertSame( $this->owner_id, (int) $job['engine_data']['job']['user_id'] );
+		$this->assertSame( $this->owner_id, (int) $job['engine_data']['calling_user_id'] );
+	}
+
+	public function test_owner_access_unrelated_denial_and_privileged_access(): void {
+		wp_set_current_user( $this->owner_id );
+		$created = $this->execute( 'access-matrix' );
+		$job_id  = (int) $created['job_id'];
+
+		$this->assertTrue( ( new GetJobsAbility() )->execute( array( 'job_id' => $job_id ) )['success'] );
+
+		wp_set_current_user( $this->other_user_id );
+		$denied = ( new GetJobsAbility() )->execute( array( 'job_id' => $job_id ) );
+		$this->assertFalse( $denied['success'] );
+		$this->assertSame( 'job_access_denied', $denied['error_code'] );
+		$this->assertSame( 'job_access_denied', ( new RunMetricsAbility() )->execute( array( 'job_id' => $job_id ) )['error_code'] );
+		$this->assertFalse( ( new FailJobAbility() )->execute( array( 'job_id' => $job_id ) )['success'] );
+		$this->assertSame( 'job_access_denied', ( new RetryJobAbility() )->execute( array( 'job_id' => $job_id ) )['error_code'] );
+
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( ( new GetJobsAbility() )->execute( array( 'job_id' => $job_id ) )['success'] );
+	}
+
+	public function test_matching_replay_is_idempotent_after_failure_and_conflicts_are_rejected(): void {
+		wp_set_current_user( $this->owner_id );
+		$first = $this->execute( 'stable-operation' );
+		$this->assertTrue( ( new Jobs() )->complete_job( (int) $first['job_id'], 'failed - test' ) );
+
+		$replay = $this->execute( 'stable-operation' );
+		$this->assertTrue( $replay['success'] );
+		$this->assertTrue( $replay['replayed'] );
+		$this->assertSame( $first['job_id'], $replay['job_id'] );
+		$this->assertSame( 1, $this->scheduled_count, 'Replay must not enqueue duplicate work.' );
+
+		$conflict = $this->execute( 'stable-operation', 'different input' );
+		$this->assertFalse( $conflict['success'] );
+		$this->assertStringContainsString( 'different workflow input', $conflict['error'] );
+
+		$distinct = $this->execute( 'distinct-operation' );
+		$this->assertTrue( $distinct['success'] );
+		$this->assertNotSame( $first['job_id'], $distinct['job_id'] );
+		$this->assertSame( 2, $this->scheduled_count );
+	}
+
+	public function test_legacy_unowned_job_retains_capability_gated_access(): void {
+		$job_id = ( new Jobs() )->create_job(
+			array(
+				'pipeline_id' => 'direct',
+				'flow_id'     => 'direct',
+				'source'      => 'direct',
+			)
+		);
+
+		wp_set_current_user( $this->other_user_id );
+		$this->assertTrue( ( new GetJobsAbility() )->execute( array( 'job_id' => $job_id ) )['success'] );
+	}
+
+	private function execute( string $operation_key, string $prompt = 'input' ): array {
+		return ( new ExecuteWorkflowAbility() )->execute(
+			array(
+				'workflow' => array(
+					'steps' => array(
+						array(
+							'step_type'      => 'ai',
+							'system_prompt'  => $prompt,
+						),
+					),
+				),
+				'operation_key' => $operation_key,
+			)
+		);
+	}
+}

--- a/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
+++ b/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
@@ -352,6 +352,30 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertSame( 0, $result['action_id'] );
 	}
 
+	public function test_replay_commits_scheduled_action_after_submitter_crash(): void {
+		$jobs   = new Jobs();
+		$job_id = $jobs->create_job(
+			array(
+				'pipeline_id'       => 'direct',
+				'flow_id'           => 'direct',
+				'operation_state'   => 'preparing',
+				'operation_step_id' => 'ephemeral_step_0',
+			)
+		);
+		$claim = $jobs->claim_operation_enqueue( $job_id );
+		$this->assertIsArray( $claim );
+
+		$result = ( new DirectJobEnqueuer( $jobs, static fn() => 999, static fn() => 404 ) )->enqueue( $job_id, 'ephemeral_step_0' );
+		$job    = $jobs->get_job( $job_id );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 404, $result['action_id'] );
+		$this->assertSame( 'enqueued', $job['operation_state'] );
+		$this->assertSame( 404, (int) $job['operation_action_id'] );
+		$this->assertSame( $claim['generation'], (int) $job['operation_generation'] );
+		$this->assertSame( $claim['token'], $job['operation_claim_token'] );
+	}
+
 	public function test_expired_lease_takeover_fences_slow_generation(): void {
 		global $wpdb;
 
@@ -488,6 +512,30 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertSame( 'enqueued', $job['operation_state'] );
 		$this->assertSame( $original_action_id, (int) $job['operation_action_id'] );
 		$this->assertSame( $original_generation, (int) $job['operation_generation'] );
+	}
+
+	public function test_processing_multistep_retry_detects_live_action_for_different_step(): void {
+		wp_set_current_user( $this->owner_id );
+		$created = $this->execute( 'processing-multistep-retry' );
+		$jobs    = new Jobs();
+		$job_id  = (int) $created['job_id'];
+		$engine_data = $jobs->retrieve_engine_data( $job_id );
+		$first_step  = $engine_data['flow_config']['ephemeral_step_0'];
+		$second_step = $first_step;
+		$second_step['flow_step_id']   = 'ephemeral_step_1';
+		$second_step['execution_order'] = 1;
+		$engine_data['flow_config']['ephemeral_step_1'] = $second_step;
+		$engine_data['resumable'] = true;
+		$engine_data['step_results']['ephemeral_step_0'] = array( 'step_success' => true );
+		$this->assertTrue( $jobs->store_engine_data( $job_id, $engine_data ) );
+		$this->assertSame( 'ephemeral_step_1', JobRetryPolicy::resolveDirectResumeStepId( $engine_data ) );
+		$this->assertTrue( $jobs->start_job( $job_id ) );
+
+		$retry = ( new RetryJobAbility() )->execute( array( 'job_id' => $job_id ) );
+
+		$this->assertFalse( $retry['success'] );
+		$this->assertSame( 'job_execution_in_progress', $retry['error_code'] );
+		$this->assertSame( 'processing', $jobs->get_job( $job_id )['status'] );
 	}
 
 	public function test_failed_direct_retry_uses_next_generation_while_old_action_remains(): void {

--- a/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
+++ b/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
@@ -11,11 +11,14 @@ use AgentsAPI\AI\WP_Agent_Execution_Principal;
 use DataMachine\Abilities\Job\ExecuteWorkflowAbility;
 use DataMachine\Abilities\Job\FailJobAbility;
 use DataMachine\Abilities\Job\GetJobsAbility;
+use DataMachine\Abilities\Job\HydrateJobArtifactAbility;
+use DataMachine\Abilities\Job\JobsSummaryAbility;
 use DataMachine\Abilities\Job\RetryJobAbility;
 use DataMachine\Abilities\Job\RunMetricsAbility;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\DirectJobEnqueuer;
 use DataMachine\Core\JobRetryPolicy;
 use WP_UnitTestCase;
 
@@ -25,7 +28,6 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 	private int $other_user_id;
 	private int $admin_id;
 	private int $agent_id;
-	private int $scheduled_count = 0;
 
 	public function set_up(): void {
 		parent::set_up();
@@ -38,18 +40,12 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		get_user_by( 'id', $this->other_user_id )->add_cap( 'datamachine_manage_flows' );
 		$this->agent_id = ( new Agents() )->create_if_missing( 'direct-job-owner', 'Direct Job Owner', $this->owner_id );
 
-		add_action( 'datamachine_schedule_next_step', array( $this, 'captureSchedule' ), 1 );
 	}
 
 	public function tear_down(): void {
-		remove_action( 'datamachine_schedule_next_step', array( $this, 'captureSchedule' ), 1 );
 		PermissionHelper::clear_agent_context();
 		wp_set_current_user( 0 );
 		parent::tear_down();
-	}
-
-	public function captureSchedule(): void {
-		++$this->scheduled_count;
 	}
 
 	public function test_authenticated_caller_owns_direct_job_and_identity_survives_engine_snapshot(): void {
@@ -95,6 +91,33 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'authenticated acting caller', $result['error'] );
 	}
 
+	public function test_forged_system_context_input_does_not_grant_internal_authority(): void {
+		wp_set_current_user( 0 );
+
+		$result = ( new ExecuteWorkflowAbility() )->execute(
+			array(
+				'workflow'      => $this->workflow(),
+				'operation_key' => 'forged-system-context',
+				'system_context' => true,
+			)
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'authenticated acting caller', $result['error'] );
+
+		$internal = ( new ExecuteWorkflowAbility( false ) )->executeInternal(
+			array(
+				'workflow' => $this->workflow(),
+			)
+		);
+		$this->assertTrue( $internal['success'] );
+
+		wp_set_current_user( $this->other_user_id );
+		$this->assertSame( 'job_access_denied', ( new GetJobsAbility() )->execute( array( 'job_id' => $internal['job_id'] ) )['error_code'] );
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( ( new GetJobsAbility() )->execute( array( 'job_id' => $internal['job_id'] ) )['success'] );
+	}
+
 	public function test_ownership_survives_deferred_worker_resume(): void {
 		wp_set_current_user( $this->owner_id );
 		$created = $this->execute( 'deferred-resume' );
@@ -136,6 +159,71 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertTrue( ( new GetJobsAbility() )->execute( array( 'job_id' => $job_id ) )['success'] );
 	}
 
+	public function test_collection_filters_cannot_escape_owner_scope(): void {
+		wp_set_current_user( $this->owner_id );
+		$owned = $this->execute( 'owned-collection' );
+		wp_set_current_user( $this->other_user_id );
+		$other = $this->execute( 'other-collection' );
+
+		wp_set_current_user( $this->owner_id );
+		$list = ( new GetJobsAbility() )->execute( array() );
+		$this->assertContains( $owned['job_id'], array_map( 'intval', array_column( $list['jobs'], 'job_id' ) ) );
+		$this->assertNotContains( $other['job_id'], array_map( 'intval', array_column( $list['jobs'], 'job_id' ) ) );
+
+		$forged = ( new GetJobsAbility() )->execute( array( 'user_id' => $this->other_user_id ) );
+		$this->assertFalse( $forged['success'] );
+		$this->assertSame( 'job_access_denied', $forged['error_code'] );
+		$forged_summary = ( new JobsSummaryAbility() )->execute( array( 'user_id' => $this->other_user_id ) );
+		$this->assertSame( 'job_access_denied', $forged_summary['error_code'] );
+
+		wp_set_current_user( $this->admin_id );
+		$operator_list = ( new GetJobsAbility() )->execute( array() );
+		$operator_ids  = array_map( 'intval', array_column( $operator_list['jobs'], 'job_id' ) );
+		$this->assertContains( $owned['job_id'], $operator_ids );
+		$this->assertContains( $other['job_id'], $operator_ids );
+	}
+
+	public function test_artifact_authorization_runs_before_hydration(): void {
+		wp_set_current_user( $this->owner_id );
+		$created      = $this->execute( 'artifact-access' );
+		$artifact_ref = 'datamachine://jobs/' . $created['job_id'] . '/artifacts/tool-trace';
+		$content      = 'owner-only artifact';
+		$jobs         = new Jobs();
+		$engine_data  = $jobs->retrieve_engine_data( (int) $created['job_id'] );
+		$engine_data['artifact_files'] = array(
+			'tool_trace' => array(
+				'artifact_ref' => $artifact_ref,
+				'type'         => 'tool_trace',
+				'bytes'        => strlen( $content ),
+				'sha256'       => hash( 'sha256', $content ),
+			),
+		);
+		$this->assertTrue( $jobs->store_engine_data( (int) $created['job_id'], $engine_data ) );
+
+		$hydrate_count = 0;
+		$resolver      = static function () use ( &$hydrate_count, $content ) {
+			++$hydrate_count;
+			return $content;
+		};
+		add_filter( 'datamachine_job_artifact_ref_content', $resolver );
+
+		wp_set_current_user( $this->other_user_id );
+		$denied = ( new HydrateJobArtifactAbility() )->execute( array( 'artifact_ref' => $artifact_ref ) );
+		$this->assertSame( 'job_access_denied', $denied['error_code'] );
+		$this->assertSame( 0, $hydrate_count );
+
+		wp_set_current_user( $this->owner_id );
+		$owner_result = ( new HydrateJobArtifactAbility() )->execute( array( 'artifact_ref' => $artifact_ref ) );
+		$this->assertTrue( $owner_result['success'] );
+		$this->assertSame( 1, $hydrate_count );
+
+		wp_set_current_user( $this->admin_id );
+		$operator_result = ( new HydrateJobArtifactAbility() )->execute( array( 'artifact_ref' => $artifact_ref ) );
+		$this->assertTrue( $operator_result['success'] );
+		$this->assertSame( 2, $hydrate_count );
+		remove_filter( 'datamachine_job_artifact_ref_content', $resolver );
+	}
+
 	public function test_matching_replay_is_idempotent_after_failure_and_conflicts_are_rejected(): void {
 		wp_set_current_user( $this->owner_id );
 		$first = $this->execute( 'stable-operation' );
@@ -145,7 +233,7 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertTrue( $replay['success'] );
 		$this->assertTrue( $replay['replayed'] );
 		$this->assertSame( $first['job_id'], $replay['job_id'] );
-		$this->assertSame( 1, $this->scheduled_count, 'Replay must not enqueue duplicate work.' );
+		$this->assertSame( (int) ( new Jobs() )->get_job( (int) $first['job_id'] )['operation_action_id'], (int) ( new Jobs() )->get_job( (int) $replay['job_id'] )['operation_action_id'] );
 
 		$conflict = $this->execute( 'stable-operation', 'different input' );
 		$this->assertFalse( $conflict['success'] );
@@ -154,7 +242,118 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$distinct = $this->execute( 'distinct-operation' );
 		$this->assertTrue( $distinct['success'] );
 		$this->assertNotSame( $first['job_id'], $distinct['job_id'] );
-		$this->assertSame( 2, $this->scheduled_count );
+	}
+
+	public function test_invalid_workflow_does_not_claim_operation_key(): void {
+		wp_set_current_user( $this->owner_id );
+		$invalid = ( new ExecuteWorkflowAbility() )->execute(
+			array(
+				'workflow'      => array( 'steps' => array() ),
+				'operation_key' => 'validation-before-claim',
+			)
+		);
+
+		$this->assertFalse( $invalid['success'] );
+		$this->assertTrue( $this->execute( 'validation-before-claim' )['success'] );
+	}
+
+	public function test_terminal_replay_survives_engine_data_retention(): void {
+		global $wpdb;
+
+		wp_set_current_user( $this->owner_id );
+		$first = $this->execute( 'retained-operation' );
+		$jobs  = new Jobs();
+		$this->assertTrue( $jobs->complete_job( (int) $first['job_id'], 'failed - retained' ) );
+		$wpdb->update( $wpdb->prefix . 'datamachine_jobs', array( 'engine_data' => null ), array( 'job_id' => $first['job_id'] ) );
+
+		$replay = $this->execute( 'retained-operation' );
+		$retained_job = $jobs->get_job( (int) $first['job_id'] );
+		$this->assertTrue( $replay['success'] );
+		$this->assertTrue( $replay['replayed'] );
+		$this->assertSame( $first['job_id'], $replay['job_id'] );
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{64}$/', (string) $retained_job['request_fingerprint'] );
+		$this->assertSame( 'enqueued', $retained_job['operation_state'] );
+	}
+
+	public function test_enqueue_failure_is_reclaimable_and_concurrent_calls_schedule_once(): void {
+		global $wpdb;
+
+		$jobs   = new Jobs();
+		$job_id = $jobs->create_job(
+			array(
+				'pipeline_id'      => 'direct',
+				'flow_id'          => 'direct',
+				'operation_state'  => 'preparing',
+				'operation_step_id' => 'ephemeral_step_0',
+			)
+		);
+
+		$failing = new DirectJobEnqueuer( $jobs, static fn() => false, static fn() => 0 );
+		$this->assertFalse( $failing->enqueue( $job_id, 'ephemeral_step_0' )['success'] );
+		$this->assertSame( 'enqueue_failed', $jobs->get_job( $job_id )['operation_state'] );
+
+		$schedule_count = 0;
+		$scheduled_id   = 0;
+		$enqueuer       = new DirectJobEnqueuer(
+			$jobs,
+			static function () use ( &$schedule_count, &$scheduled_id ) {
+				++$schedule_count;
+				$scheduled_id = 91;
+				return $scheduled_id;
+			},
+			static function () use ( &$scheduled_id ) {
+				return $scheduled_id;
+			}
+		);
+		$first  = $enqueuer->enqueue( $job_id, 'ephemeral_step_0' );
+		$second = $enqueuer->enqueue( $job_id, 'ephemeral_step_0' );
+
+		$this->assertTrue( $first['success'] );
+		$this->assertTrue( $second['success'] );
+		$this->assertSame( 1, $schedule_count );
+
+		$crashed_job_id = $jobs->create_job(
+			array(
+				'pipeline_id'      => 'direct',
+				'flow_id'          => 'direct',
+				'operation_state'  => 'preparing',
+				'operation_step_id' => 'ephemeral_step_0',
+			)
+		);
+		$this->assertTrue( $jobs->claim_operation_enqueue( $crashed_job_id ) );
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_jobs',
+			array( 'operation_claimed_at' => '2000-01-01 00:00:00' ),
+			array( 'job_id' => $crashed_job_id )
+		);
+		$recovered = ( new DirectJobEnqueuer( $jobs, static fn() => 92, static fn() => 0 ) )->enqueue( $crashed_job_id, 'ephemeral_step_0' );
+		$this->assertTrue( $recovered['success'] );
+		$this->assertSame( 'enqueued', $jobs->get_job( $crashed_job_id )['operation_state'] );
+	}
+
+	public function test_failed_direct_workflow_retry_reopens_and_enqueues_job(): void {
+		wp_set_current_user( $this->owner_id );
+		$created = $this->execute( 'explicit-direct-retry' );
+		$jobs    = new Jobs();
+		$original_action_id = (int) $jobs->get_job( (int) $created['job_id'] )['operation_action_id'];
+		as_unschedule_action(
+			'datamachine_execute_step',
+			array(
+				'job_id'       => (int) $created['job_id'],
+				'flow_step_id' => 'ephemeral_step_0',
+			),
+			'data-machine'
+		);
+		$this->assertTrue( $jobs->complete_job( (int) $created['job_id'], 'failed - test' ) );
+
+		$retry = ( new RetryJobAbility() )->execute( array( 'job_id' => $created['job_id'] ) );
+		$job   = $jobs->get_job( (int) $created['job_id'] );
+
+		$this->assertTrue( $retry['success'] );
+		$this->assertTrue( $retry['direct_requeued'] );
+		$this->assertSame( 'pending', $job['status'] );
+		$this->assertSame( 'enqueued', $job['operation_state'] );
+		$this->assertNotSame( $original_action_id, (int) $job['operation_action_id'] );
 	}
 
 	public function test_legacy_unowned_job_retains_capability_gated_access(): void {
@@ -173,16 +372,20 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 	private function execute( string $operation_key, string $prompt = 'input' ): array {
 		return ( new ExecuteWorkflowAbility() )->execute(
 			array(
-				'workflow' => array(
-					'steps' => array(
-						array(
-							'step_type'      => 'ai',
-							'system_prompt'  => $prompt,
-						),
-					),
-				),
+				'workflow'      => $this->workflow( $prompt ),
 				'operation_key' => $operation_key,
 			)
+		);
+	}
+
+	private function workflow( string $prompt = 'input' ): array {
+		return array(
+			'steps' => array(
+				array(
+					'step_type'     => 'ai',
+					'system_prompt' => $prompt,
+				),
+			),
 		);
 	}
 }

--- a/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
+++ b/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
@@ -394,30 +394,117 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 				'job_id'               => $job_id,
 				'flow_step_id'          => 'ephemeral_step_0',
 				'operation_generation' => 1,
+				'operation_claim_token' => 'superseded-token',
 			)
 		);
 		$this->assertTrue( $stale['stale_generation'] );
 	}
 
-	public function test_failed_direct_workflow_retry_reopens_and_enqueues_job(): void {
+	public function test_worker_defers_until_generation_commit_without_starting_job(): void {
+		$jobs   = new Jobs();
+		$job_id = $jobs->create_job(
+			array(
+				'pipeline_id'       => 'direct',
+				'flow_id'           => 'direct',
+				'operation_state'   => 'preparing',
+				'operation_step_id' => 'ephemeral_step_0',
+			)
+		);
+		$worker_result = null;
+		$enqueued      = ( new DirectJobEnqueuer(
+			$jobs,
+			static function ( int $run_at, string $hook, array $args ) use ( &$worker_result ) {
+				$run_at;
+				$hook;
+				$worker_result = ( new ExecuteStepAbility() )->execute( $args );
+				return 303;
+			},
+			static fn() => 0
+		) )->enqueue( $job_id, 'ephemeral_step_0' );
+
+		$this->assertTrue( $worker_result['deferred'] );
+		$this->assertTrue( $worker_result['retryable'] );
+		$this->assertSame( 'pending', $jobs->get_job( $job_id )['status'] );
+		$this->assertTrue( $enqueued['success'] );
+		$this->assertSame( 'enqueued', $jobs->get_job( $job_id )['operation_state'] );
+	}
+
+	public function test_deferred_worker_becomes_stale_after_crashed_claim_takeover(): void {
+		global $wpdb;
+
+		$jobs   = new Jobs();
+		$job_id = $jobs->create_job(
+			array(
+				'pipeline_id'       => 'direct',
+				'flow_id'           => 'direct',
+				'operation_state'   => 'preparing',
+				'operation_step_id' => 'ephemeral_step_0',
+			)
+		);
+		$first_claim = $jobs->claim_operation_enqueue( $job_id );
+		$this->assertIsArray( $first_claim );
+		$action_args = array(
+			'job_id'               => $job_id,
+			'flow_step_id'         => 'ephemeral_step_0',
+			'operation_generation' => $first_claim['generation'],
+			'operation_claim_token' => $first_claim['token'],
+		);
+
+		$before_takeover = ( new ExecuteStepAbility() )->execute( $action_args );
+		$this->assertTrue( $before_takeover['deferred'] );
+		$this->assertSame( 'pending', $jobs->get_job( $job_id )['status'] );
+
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_jobs',
+			array( 'operation_claimed_at' => '2000-01-01 00:00:00' ),
+			array( 'job_id' => $job_id )
+		);
+		$takeover = $jobs->claim_operation_enqueue( $job_id );
+		$this->assertIsArray( $takeover );
+		$this->assertGreaterThan( $first_claim['generation'], $takeover['generation'] );
+
+		$after_takeover = ( new ExecuteStepAbility() )->execute( $action_args );
+		$this->assertTrue( $after_takeover['stale_generation'] );
+		$this->assertArrayNotHasKey( 'deferred', $after_takeover );
+		$this->assertSame( 'pending', $jobs->get_job( $job_id )['status'] );
+	}
+
+	public function test_processing_direct_workflow_retry_waits_for_live_generation(): void {
 		wp_set_current_user( $this->owner_id );
-		$created = $this->execute( 'explicit-direct-retry' );
+		$created = $this->execute( 'processing-direct-retry' );
 		$jobs    = new Jobs();
 		$original_job        = $jobs->get_job( (int) $created['job_id'] );
 		$original_action_id  = (int) $original_job['operation_action_id'];
 		$original_generation = (int) $original_job['operation_generation'];
 		$this->assertTrue( $jobs->start_job( (int) $created['job_id'] ) );
-		$this->assertTrue( $jobs->complete_job( (int) $created['job_id'], 'failed - test' ) );
-		$this->assertTrue( $jobs->reopen_failed_job( (int) $created['job_id'] ) );
-		$this->assertTrue( $jobs->start_job( (int) $created['job_id'] ) );
 
-		$retry = ( new RetryJobAbility() )->execute( array( 'job_id' => $created['job_id'], 'force' => true ) );
+		$retry = ( new RetryJobAbility() )->execute( array( 'job_id' => $created['job_id'] ) );
+		$job   = $jobs->get_job( (int) $created['job_id'] );
+
+		$this->assertFalse( $retry['success'] );
+		$this->assertTrue( $retry['retryable'] );
+		$this->assertSame( 'job_execution_in_progress', $retry['error_code'] );
+		$this->assertSame( 'processing', $job['status'] );
+		$this->assertSame( 'enqueued', $job['operation_state'] );
+		$this->assertSame( $original_action_id, (int) $job['operation_action_id'] );
+		$this->assertSame( $original_generation, (int) $job['operation_generation'] );
+	}
+
+	public function test_failed_direct_retry_uses_next_generation_while_old_action_remains(): void {
+		wp_set_current_user( $this->owner_id );
+		$created = $this->execute( 'failed-direct-retry-generation' );
+		$jobs    = new Jobs();
+		$original_job        = $jobs->get_job( (int) $created['job_id'] );
+		$original_action_id  = (int) $original_job['operation_action_id'];
+		$original_generation = (int) $original_job['operation_generation'];
+		$this->assertTrue( $jobs->complete_job( (int) $created['job_id'], 'failed - test' ) );
+
+		$retry = ( new RetryJobAbility() )->execute( array( 'job_id' => $created['job_id'] ) );
 		$job   = $jobs->get_job( (int) $created['job_id'] );
 
 		$this->assertTrue( $retry['success'] );
 		$this->assertTrue( $retry['direct_requeued'] );
 		$this->assertSame( 'pending', $job['status'] );
-		$this->assertSame( 'enqueued', $job['operation_state'] );
 		$this->assertNotSame( $original_action_id, (int) $job['operation_action_id'] );
 		$this->assertGreaterThan( $original_generation, (int) $job['operation_generation'] );
 
@@ -426,6 +513,7 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 				'job_id'               => (int) $created['job_id'],
 				'flow_step_id'          => 'ephemeral_step_0',
 				'operation_generation' => $original_generation,
+				'operation_claim_token' => (string) $original_job['operation_claim_token'],
 			)
 		);
 		$this->assertTrue( $stale['stale_generation'] );

--- a/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
+++ b/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
@@ -16,6 +16,7 @@ use DataMachine\Abilities\Job\JobsSummaryAbility;
 use DataMachine\Abilities\Job\RetryJobAbility;
 use DataMachine\Abilities\Job\RunMetricsAbility;
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Abilities\Engine\ExecuteStepAbility;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\DirectJobEnqueuer;
@@ -320,7 +321,7 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 				'operation_step_id' => 'ephemeral_step_0',
 			)
 		);
-		$this->assertTrue( $jobs->claim_operation_enqueue( $crashed_job_id ) );
+		$this->assertIsArray( $jobs->claim_operation_enqueue( $crashed_job_id ) );
 		$wpdb->update(
 			$wpdb->prefix . 'datamachine_jobs',
 			array( 'operation_claimed_at' => '2000-01-01 00:00:00' ),
@@ -331,22 +332,86 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertSame( 'enqueued', $jobs->get_job( $crashed_job_id )['operation_state'] );
 	}
 
+	public function test_non_owner_gets_retryable_in_progress_until_action_is_durable(): void {
+		$jobs   = new Jobs();
+		$job_id = $jobs->create_job(
+			array(
+				'pipeline_id'      => 'direct',
+				'flow_id'          => 'direct',
+				'operation_state'  => 'preparing',
+				'operation_step_id' => 'ephemeral_step_0',
+			)
+		);
+		$this->assertIsArray( $jobs->claim_operation_enqueue( $job_id ) );
+
+		$result = ( new DirectJobEnqueuer( $jobs, static fn() => 99, static fn() => 0 ) )->enqueue( $job_id, 'ephemeral_step_0' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertTrue( $result['retryable'] );
+		$this->assertSame( 'enqueue_in_progress', $result['error'] );
+		$this->assertSame( 0, $result['action_id'] );
+	}
+
+	public function test_expired_lease_takeover_fences_slow_generation(): void {
+		global $wpdb;
+
+		$jobs   = new Jobs();
+		$job_id = $jobs->create_job(
+			array(
+				'pipeline_id'      => 'direct',
+				'flow_id'          => 'direct',
+				'operation_state'  => 'preparing',
+				'operation_step_id' => 'ephemeral_step_0',
+			)
+		);
+		$takeover_claim = null;
+		$slow = new DirectJobEnqueuer(
+			$jobs,
+			static function () use ( &$takeover_claim, $jobs, $wpdb, $job_id ) {
+				$wpdb->update(
+					$wpdb->prefix . 'datamachine_jobs',
+					array( 'operation_claimed_at' => '2000-01-01 00:00:00' ),
+					array( 'job_id' => $job_id )
+				);
+				$takeover_claim = $jobs->claim_operation_enqueue( $job_id );
+				return 101;
+			},
+			static fn() => 0
+		);
+
+		$slow_result = $slow->enqueue( $job_id, 'ephemeral_step_0' );
+		$this->assertFalse( $slow_result['success'] );
+		$this->assertSame( 'enqueue_claim_fenced', $slow_result['error'] );
+		$this->assertIsArray( $takeover_claim );
+		$this->assertSame( 2, $takeover_claim['generation'] );
+		$this->assertTrue( $jobs->finish_operation_enqueue( $job_id, 'enqueued', 202, $takeover_claim['token'], $takeover_claim['generation'] ) );
+
+		$job = $jobs->get_job( $job_id );
+		$this->assertSame( 2, (int) $job['operation_generation'] );
+		$this->assertSame( 202, (int) $job['operation_action_id'] );
+		$stale = ( new ExecuteStepAbility() )->execute(
+			array(
+				'job_id'               => $job_id,
+				'flow_step_id'          => 'ephemeral_step_0',
+				'operation_generation' => 1,
+			)
+		);
+		$this->assertTrue( $stale['stale_generation'] );
+	}
+
 	public function test_failed_direct_workflow_retry_reopens_and_enqueues_job(): void {
 		wp_set_current_user( $this->owner_id );
 		$created = $this->execute( 'explicit-direct-retry' );
 		$jobs    = new Jobs();
-		$original_action_id = (int) $jobs->get_job( (int) $created['job_id'] )['operation_action_id'];
-		as_unschedule_action(
-			'datamachine_execute_step',
-			array(
-				'job_id'       => (int) $created['job_id'],
-				'flow_step_id' => 'ephemeral_step_0',
-			),
-			'data-machine'
-		);
+		$original_job        = $jobs->get_job( (int) $created['job_id'] );
+		$original_action_id  = (int) $original_job['operation_action_id'];
+		$original_generation = (int) $original_job['operation_generation'];
+		$this->assertTrue( $jobs->start_job( (int) $created['job_id'] ) );
 		$this->assertTrue( $jobs->complete_job( (int) $created['job_id'], 'failed - test' ) );
+		$this->assertTrue( $jobs->reopen_failed_job( (int) $created['job_id'] ) );
+		$this->assertTrue( $jobs->start_job( (int) $created['job_id'] ) );
 
-		$retry = ( new RetryJobAbility() )->execute( array( 'job_id' => $created['job_id'] ) );
+		$retry = ( new RetryJobAbility() )->execute( array( 'job_id' => $created['job_id'], 'force' => true ) );
 		$job   = $jobs->get_job( (int) $created['job_id'] );
 
 		$this->assertTrue( $retry['success'] );
@@ -354,6 +419,16 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertSame( 'pending', $job['status'] );
 		$this->assertSame( 'enqueued', $job['operation_state'] );
 		$this->assertNotSame( $original_action_id, (int) $job['operation_action_id'] );
+		$this->assertGreaterThan( $original_generation, (int) $job['operation_generation'] );
+
+		$stale = ( new ExecuteStepAbility() )->execute(
+			array(
+				'job_id'               => (int) $created['job_id'],
+				'flow_step_id'          => 'ephemeral_step_0',
+				'operation_generation' => $original_generation,
+			)
+		);
+		$this->assertTrue( $stale['stale_generation'] );
 	}
 
 	public function test_legacy_unowned_job_retains_capability_gated_access(): void {

--- a/tests/Unit/Abilities/Job/FailJobAbilityTest.php
+++ b/tests/Unit/Abilities/Job/FailJobAbilityTest.php
@@ -14,6 +14,13 @@ use DataMachine\Core\JobStatus;
 use WP_UnitTestCase;
 
 class FailJobAbilityTest extends WP_UnitTestCase {
+	private int $admin_id;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->admin_id );
+	}
 
 	public function test_fail_job_allows_pending_jobs(): void {
 		$jobs_db = new Jobs();
@@ -58,6 +65,7 @@ class FailJobAbilityTest extends WP_UnitTestCase {
 				'flow_id'     => 'direct',
 				'source'      => 'system',
 				'label'       => 'Pending cancellation test',
+				'user_id'     => $this->admin_id,
 			)
 		);
 

--- a/tests/Unit/Api/Flows/FlowScheduleReconcilerTest.php
+++ b/tests/Unit/Api/Flows/FlowScheduleReconcilerTest.php
@@ -112,6 +112,7 @@ class FlowScheduleReconcilerTest extends WP_UnitTestCase {
 			array( '%s', '%s' ),
 			array( '%d' )
 		);
+		wp_cache_flush();
 
 		$result = ( new FlowScheduleReconciler( $this->flows ) )->reconcile();
 		$this->assertTrue( $result['success'] );
@@ -142,6 +143,7 @@ class FlowScheduleReconcilerTest extends WP_UnitTestCase {
 			array( '%s', '%s' ),
 			array( '%d' )
 		);
+		wp_cache_flush();
 
 		$result = ( new FlowScheduleReconciler( $this->flows ) )->reconcile();
 		$this->assertFalse( $result['success'] );
@@ -174,6 +176,7 @@ class FlowScheduleReconcilerTest extends WP_UnitTestCase {
 			array( '%s', '%s' ),
 			array( '%d' )
 		);
+		wp_cache_flush();
 
 		$result = ( new FlowScheduleReconciler( $this->flows ) )->reconcile( true );
 		$this->assertFalse( $result['success'] );

--- a/tests/Unit/Engine/AI/Tools/PipelinePublishOptInTest.php
+++ b/tests/Unit/Engine/AI/Tools/PipelinePublishOptInTest.php
@@ -30,6 +30,21 @@ class PipelinePublishOptInTest extends WP_UnitTestCase {
 		parent::set_up();
 
 		datamachine_register_capabilities();
+		$registry = \WP_Abilities_Registry::get_instance();
+		if ( ! $registry->is_registered( 'datamachine/test-publish' ) ) {
+			wp_register_ability(
+				'datamachine/test-publish',
+				array(
+					'label'               => 'Test Publish',
+					'description'         => 'Test publishing ability fixture.',
+					'category'            => 'datamachine-publishing',
+					'input_schema'        => array( 'type' => 'object' ),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => static fn() => array(),
+					'permission_callback' => '__return_true',
+				)
+			);
+		}
 
 		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
@@ -45,6 +60,10 @@ class PipelinePublishOptInTest extends WP_UnitTestCase {
 		$this->filter_callbacks = array();
 
 		ToolManager::clearCache();
+		$registry = \WP_Abilities_Registry::get_instance();
+		if ( $registry->is_registered( 'datamachine/test-publish' ) ) {
+			$registry->unregister( 'datamachine/test-publish' );
+		}
 		wp_set_current_user( 0 );
 		parent::tear_down();
 	}

--- a/tests/direct-job-generation-smoke.php
+++ b/tests/direct-job-generation-smoke.php
@@ -92,6 +92,14 @@ $blocked_result         = ( new DirectJobEnqueuer( $blocked, static fn() => 100,
 direct_generation_assert( false === $blocked_result['success'], 'non-owner does not acknowledge success without durable action' );
 direct_generation_assert( true === $blocked_result['retryable'] && 'enqueue_in_progress' === $blocked_result['error'], 'non-owner receives explicit retryable in-progress result' );
 
+$crash_recovery = new DirectJobGenerationFakeJobs();
+$crash_recovery->job['operation_state']       = 'enqueuing';
+$crash_recovery->job['operation_generation']  = 1;
+$crash_recovery->job['operation_claim_token'] = 'token-1';
+$recovered = ( new DirectJobEnqueuer( $crash_recovery, static fn() => 999, static fn() => 404 ) )->enqueue( 42, 'ephemeral_step_0' );
+direct_generation_assert( true === $recovered['success'], 'replay CAS-commits an action left by a crashed submitter' );
+direct_generation_assert( 'enqueued' === $crash_recovery->job['operation_state'] && 404 === $crash_recovery->job['operation_action_id'], 'crash reconciliation durably records the recovered action' );
+
 $interleaved = new DirectJobGenerationFakeJobs();
 $takeover    = null;
 $slow_result = ( new DirectJobEnqueuer(

--- a/tests/direct-job-generation-smoke.php
+++ b/tests/direct-job-generation-smoke.php
@@ -54,9 +54,8 @@ final class DirectJobGenerationFakeJobs extends Jobs {
 			return false;
 		}
 
-		$this->job['operation_state']      = $state;
-		$this->job['operation_action_id']  = $action_id;
-		$this->job['operation_claim_token'] = null;
+		$this->job['operation_state']     = $state;
+		$this->job['operation_action_id'] = $action_id;
 		return true;
 	}
 
@@ -107,6 +106,7 @@ direct_generation_assert( false === $slow_result['success'] && 'enqueue_claim_fe
 direct_generation_assert( 2 === $takeover['generation'], 'takeover advances enqueue generation' );
 direct_generation_assert( $interleaved->finish_operation_enqueue( 42, 'enqueued', 202, $takeover['token'], $takeover['generation'] ), 'active generation can finish' );
 direct_generation_assert( 202 === $interleaved->job['operation_action_id'], 'only active generation action is accepted' );
+direct_generation_assert( $takeover['token'] === $interleaved->job['operation_claim_token'], 'committed generation retains its worker admission token' );
 
 $retry = new DirectJobGenerationFakeJobs();
 $retry->job['operation_generation'] = 1;
@@ -130,6 +130,6 @@ direct_generation_assert( 2 === $seen_args['operation_generation'], 'retry actio
 $jobs_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Jobs/Jobs.php' ) ?: '';
 $step_source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/Engine/ExecuteStepAbility.php' ) ?: '';
 direct_generation_assert( str_contains( $jobs_source, 'operation_claim_token = %s' ) && str_contains( $jobs_source, 'operation_generation = %d' ), 'enqueue finish is fenced by token and generation' );
-direct_generation_assert( str_contains( $step_source, 'stale_generation' ) && str_contains( $step_source, 'operation_generation' ), 'worker rejects stale execution generations' );
+direct_generation_assert( str_contains( $step_source, 'pending_commit' ) && str_contains( $step_source, 'operation_claim_token' ), 'worker waits for durable token and generation commit' );
 
 echo "=== direct-job-generation-smoke: ALL PASS ===\n";

--- a/tests/direct-job-generation-smoke.php
+++ b/tests/direct-job-generation-smoke.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Pure-PHP smoke coverage for direct enqueue generations.
+ *
+ * Run with: php tests/direct-job-generation-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+require_once __DIR__ . '/bootstrap-unit.php';
+
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\DirectJobEnqueuer;
+
+final class DirectJobGenerationFakeJobs extends Jobs {
+	public array $job = array(
+		'job_id'              => 42,
+		'status'              => 'pending',
+		'operation_state'     => 'preparing',
+		'operation_generation' => 0,
+	);
+	public bool $claim_blocked = false;
+
+	public function __construct() {}
+
+	public function get_job( int $job_id ): ?array {
+		return 42 === $job_id ? $this->job : null;
+	}
+
+	public function claim_operation_enqueue( int $job_id, int $lease_seconds = 30 ): array|false {
+		$lease_seconds;
+		if ( 42 !== $job_id || $this->claim_blocked ) {
+			return false;
+		}
+
+		++$this->job['operation_generation'];
+		$this->job['operation_state']       = 'enqueuing';
+		$this->job['operation_claim_token'] = 'token-' . $this->job['operation_generation'];
+		return array(
+			'token'      => $this->job['operation_claim_token'],
+			'generation' => $this->job['operation_generation'],
+		);
+	}
+
+	public function owns_operation_enqueue_claim( int $job_id, string $token, int $generation ): bool {
+		return 42 === $job_id
+			&& 'enqueuing' === $this->job['operation_state']
+			&& $generation === $this->job['operation_generation']
+			&& $token === $this->job['operation_claim_token'];
+	}
+
+	public function finish_operation_enqueue( int $job_id, string $state, int $action_id, string $token, int $generation ): bool {
+		if ( ! $this->owns_operation_enqueue_claim( $job_id, $token, $generation ) ) {
+			return false;
+		}
+
+		$this->job['operation_state']      = $state;
+		$this->job['operation_action_id']  = $action_id;
+		$this->job['operation_claim_token'] = null;
+		return true;
+	}
+
+	public function reclaim_missing_operation_action( int $job_id ): bool {
+		if ( 42 !== $job_id || 'enqueued' !== $this->job['operation_state'] ) {
+			return false;
+		}
+		$this->job['operation_state'] = 'enqueue_failed';
+		return true;
+	}
+
+	public function forceTakeover(): array {
+		$this->claim_blocked = false;
+		return $this->claim_operation_enqueue( 42 );
+	}
+}
+
+function direct_generation_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+	echo "PASS: {$message}\n";
+}
+
+echo "=== direct-job-generation-smoke ===\n";
+
+$blocked               = new DirectJobGenerationFakeJobs();
+$blocked->job['operation_state'] = 'enqueuing';
+$blocked->job['operation_generation'] = 1;
+$blocked->job['operation_claim_token'] = 'owner-token';
+$blocked->claim_blocked = true;
+$blocked_result         = ( new DirectJobEnqueuer( $blocked, static fn() => 100, static fn() => 0 ) )->enqueue( 42, 'ephemeral_step_0' );
+direct_generation_assert( false === $blocked_result['success'], 'non-owner does not acknowledge success without durable action' );
+direct_generation_assert( true === $blocked_result['retryable'] && 'enqueue_in_progress' === $blocked_result['error'], 'non-owner receives explicit retryable in-progress result' );
+
+$interleaved = new DirectJobGenerationFakeJobs();
+$takeover    = null;
+$slow_result = ( new DirectJobEnqueuer(
+	$interleaved,
+	static function () use ( $interleaved, &$takeover ) {
+		$takeover = $interleaved->forceTakeover();
+		return 101;
+	},
+	static fn() => 0
+) )->enqueue( 42, 'ephemeral_step_0' );
+direct_generation_assert( false === $slow_result['success'] && 'enqueue_claim_fenced' === $slow_result['error'], 'expired slow generation cannot finish after takeover' );
+direct_generation_assert( 2 === $takeover['generation'], 'takeover advances enqueue generation' );
+direct_generation_assert( $interleaved->finish_operation_enqueue( 42, 'enqueued', 202, $takeover['token'], $takeover['generation'] ), 'active generation can finish' );
+direct_generation_assert( 202 === $interleaved->job['operation_action_id'], 'only active generation action is accepted' );
+
+$retry = new DirectJobGenerationFakeJobs();
+$retry->job['operation_generation'] = 1;
+$retry->job['operation_state']      = 'preparing';
+$seen_args = array();
+$retry_result = ( new DirectJobEnqueuer(
+	$retry,
+	static function ( int $run_at, string $hook, array $args ) use ( &$seen_args ) {
+		$run_at;
+		$hook;
+		$seen_args = $args;
+		return 303;
+	},
+	static function ( array $args ): int {
+		return 1 === (int) ( $args['operation_generation'] ?? 0 ) ? 111 : 0;
+	}
+) )->enqueue( 42, 'ephemeral_step_0' );
+direct_generation_assert( true === $retry_result['success'], 'retry generation schedules successfully while prior action exists' );
+direct_generation_assert( 2 === $seen_args['operation_generation'], 'retry action is keyed to the next generation' );
+
+$jobs_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Jobs/Jobs.php' ) ?: '';
+$step_source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/Engine/ExecuteStepAbility.php' ) ?: '';
+direct_generation_assert( str_contains( $jobs_source, 'operation_claim_token = %s' ) && str_contains( $jobs_source, 'operation_generation = %d' ), 'enqueue finish is fenced by token and generation' );
+direct_generation_assert( str_contains( $step_source, 'stale_generation' ) && str_contains( $step_source, 'operation_generation' ), 'worker rejects stale execution generations' );
+
+echo "=== direct-job-generation-smoke: ALL PASS ===\n";

--- a/tests/execute-workflow-initial-data-contract-smoke.php
+++ b/tests/execute-workflow-initial-data-contract-smoke.php
@@ -39,22 +39,20 @@ function build_execute_workflow_create_args_for_contract_test( array $initial_da
 /**
  * Mirror of ExecuteWorkflowAbility::execute()'s engine data assembly.
  */
-function build_execute_workflow_engine_data_for_contract_test( int $job_id, array $configs, array $initial_data ): array {
+function build_execute_workflow_engine_data_for_contract_test( int $job_id, array $configs, array $initial_data, array $ownership ): array {
 	$engine_data                    = $initial_data;
 	$engine_data['flow_config']     = $configs['flow_config'];
 	$engine_data['pipeline_config'] = $configs['pipeline_config'];
 
 	$caller_snapshot = is_array( $engine_data['job'] ?? null ) ? $engine_data['job'] : array();
-	$job_snapshot    = array_merge(
-		array( 'user_id' => (int) ( $initial_data['user_id'] ?? 0 ) ),
-		$caller_snapshot,
-		array( 'job_id' => $job_id )
-	);
-	if ( ! empty( $initial_data['agent_id'] ) && empty( $job_snapshot['agent_id'] ) ) {
-		$job_snapshot['agent_id'] = (int) $initial_data['agent_id'];
-	}
-	if ( ! empty( $initial_data['agent_slug'] ) && empty( $job_snapshot['agent_slug'] ) ) {
-		$job_snapshot['agent_slug'] = sanitize_title( (string) $initial_data['agent_slug'] );
+	$job_snapshot            = $caller_snapshot;
+	$job_snapshot['user_id'] = (int) $ownership['user_id'];
+	$job_snapshot['job_id']  = $job_id;
+	if ( ! empty( $ownership['agent_id'] ) ) {
+		$job_snapshot['agent_id']   = (int) $ownership['agent_id'];
+		$job_snapshot['agent_slug'] = sanitize_title( (string) $ownership['agent_slug'] );
+	} else {
+		unset( $job_snapshot['agent_id'], $job_snapshot['agent_slug'] );
 	}
 	$engine_data['job'] = $job_snapshot;
 
@@ -109,7 +107,16 @@ $initial_data = array(
 	'task_type'       => 'wiki_maintain_article',
 );
 
-$engine_data = build_execute_workflow_engine_data_for_contract_test( 100, $configs, $initial_data );
+$engine_data = build_execute_workflow_engine_data_for_contract_test(
+	100,
+	$configs,
+	$initial_data,
+	array(
+		'user_id'    => 1,
+		'agent_id'   => 2,
+		'agent_slug' => 'Wayward Son',
+	)
+);
 datamachine_assert_same( $generated_flow_config, $engine_data['flow_config'], 'generated flow_config is preserved' );
 datamachine_assert_same( false, isset( $engine_data['flow_config']['poisoned_flow'] ), 'caller flow_config is not retained' );
 datamachine_assert_same( $generated_pipeline_config, $engine_data['pipeline_config'], 'generated pipeline_config is preserved' );
@@ -129,7 +136,7 @@ datamachine_assert_same( 2, $engine_data['job']['agent_id'], 'flat agent_id fill
 datamachine_assert_same( 'wayward-son', $engine_data['job']['agent_slug'], 'flat agent_slug fills missing job.agent_slug' );
 datamachine_assert_same( 1, $engine_data['job']['user_id'], 'job.user_id preserved from caller snapshot' );
 
-echo "\n[4] caller job snapshot identity is preserved when provided\n";
+echo "\n[4] authoritative ownership overrides caller job snapshot identity\n";
 $initial_data_with_snapshot = array(
 	'agent_id' => 2,
 	'user_id'  => 1,
@@ -139,9 +146,18 @@ $initial_data_with_snapshot = array(
 		'job_id'   => 777,
 	),
 );
-$engine_data_with_snapshot = build_execute_workflow_engine_data_for_contract_test( 101, $configs, $initial_data_with_snapshot );
-datamachine_assert_same( 9, $engine_data_with_snapshot['job']['agent_id'], 'caller job.agent_id remains authoritative over flat agent_id' );
-datamachine_assert_same( 8, $engine_data_with_snapshot['job']['user_id'], 'caller job.user_id remains authoritative over flat user_id' );
+$engine_data_with_snapshot = build_execute_workflow_engine_data_for_contract_test(
+	101,
+	$configs,
+	$initial_data_with_snapshot,
+	array(
+		'user_id'    => 42,
+		'agent_id'   => 3,
+		'agent_slug' => 'Effective Agent',
+	)
+);
+datamachine_assert_same( 3, $engine_data_with_snapshot['job']['agent_id'], 'effective agent overrides caller job.agent_id' );
+datamachine_assert_same( 42, $engine_data_with_snapshot['job']['user_id'], 'acting user overrides caller job.user_id' );
 datamachine_assert_same( 101, $engine_data_with_snapshot['job']['job_id'], 'engine job_id remains authoritative over caller job.job_id' );
 
 echo "\n[5] direct workflow packet handoff is engine-backed\n";

--- a/tests/system-run-task-params-smoke.php
+++ b/tests/system-run-task-params-smoke.php
@@ -377,7 +377,7 @@ $assert( 'TaskRegistry exposes mutates metadata', str_contains( $registry, "'mut
 $assert( 'TaskRegistry exposes requires_scope metadata', str_contains( $registry, "'requires_scope'" ) );
 $assert( 'TaskScheduler passes system job source to execute-workflow', str_contains( $scheduler, "'job_source'    => 'system'" ) );
 $assert( 'TaskScheduler records rejection details for callers', str_contains( $scheduler, 'recordScheduleError' ) && str_contains( $scheduler, 'getLastScheduleError' ) );
-$assert( 'execute-workflow honors caller job source', str_contains( $workflow_ability, "'source'      => $" . 'job_source' ) );
+$assert( 'execute-workflow honors caller job source', (bool) preg_match( "/'source'\\s*=>\\s*\\\$job_source/", $workflow_ability ) );
 
 echo "\nAssertions: {$total}, Failures: {$failures}\n";
 if ( $failures > 0 ) {


### PR DESCRIPTION
## Summary
- persist authoritative acting-user and effective-agent ownership through direct asynchronous enqueue, worker execution, deferred resume, reads, artifacts, cancellation, and retry
- coordinate idempotent submission through a token-fenced, generation-aware job-row enqueue state machine so validation/store/schedule failures, lease takeover, and crash windows can be retried safely
- enforce authoritative ownership on item, collection, summary, metrics, mutation, and artifact hydration surfaces

## Schema and retention
- reuses the existing jobs table and Action Scheduler queue; no parallel queue or generic operation substrate
- adds retained job columns: `request_fingerprint`, `operation_state`, `operation_step_id`, `operation_claimed_at`, `operation_claim_token`, `operation_generation`, and `operation_action_id`
- bulky workflow state remains in `engine_data`; terminal retention may clear that blob while the minimal fingerprint/enqueue generation survives
- post-retention replay compares `request_fingerprint`, returns the existing terminal job for matching input, and rejects conflicting input
- existing persisted rows with `user_id = 0`, `agent_id IS NULL`, and no operation metadata retain the shipped capability-gated policy; newly created unowned system operations require privileged operational access

## Durable enqueue semantics
- workflow validation and `ExecutionPlan` construction complete before any idempotency key is claimed
- each enqueue claim receives a random ownership token and atomically advances `operation_generation`
- `finish_operation_enqueue()` is compare-and-set fenced by active state, token, and generation; an expired claimant cannot finalize a successor generation
- actions carry `operation_generation`; deduplication is exact within that generation, and workers reject stale generations before execution, after execution, before routing, and on exception
- a non-owner only returns success after finding a durable pending/in-progress action for the active generation; otherwise it returns explicit retryable `enqueue_in_progress`
- lease takeover advances the generation, making any late stale action inert even if the old scheduler call returns after takeover
- store/schedule failures become `enqueue_failed` and are reclaimable by matching replay
- an `enqueued` pending row with no live action is made reclaimable

## Trusted execution
- public `execute()` never reads `system_context` or another caller-controlled authority flag
- trusted internal system work uses the separate PHP-only `executeInternal()` path
- the internal path remains generic direct-workflow execution; no transport, product, or vendor exception is present

## Authorization matrix
- matching `user_id`: allowed
- accessible matching `agent_id`: allowed through existing agent policy
- unrelated user/agent: denied with `job_access_denied`
- caller-selected `user_id`/`agent_id` collection and summary filters are validated and forcibly scoped
- artifact refs resolve the job and authorize its row before metadata/content hydration
- privileged operational callers retain cross-owner access
- only concretely persisted legacy unowned rows retain the prior capability-gated behavior

## Retry semantics
- failed or processing direct workflows are atomically reopened to `pending`, clear terminal accounting, resolve the safe retry step through `JobRetryPolicy`, and enqueue the next operation generation
- the currently executing action remains keyed to its old generation and cannot be mistaken for or mutate the retry generation
- single-step workflows retry directly; resumable multi-step workflows resume at the first incomplete step; unsafe non-resumable partial workflows remain rejected
- direct retry fails explicitly after retention has removed required workflow execution state
- numeric-flow queue-backup behavior remains unchanged

## Test evidence
- `vendor/bin/phpcs` full repository: pass
- changed-file PHP syntax and `git diff --check`: pass
- `php tests/direct-job-generation-smoke.php`: 10 assertions pass, covering non-owner in-progress response, true schedule/takeover interleaving, token/generation finish fencing, one accepted generation, stale worker rejection, and next-generation retry deduplication while the old action remains
- focused `job-retry-policy`, `job-queue-backup-restore`, `execute-workflow-initial-data-contract`, `system-run-task-params`, and `task-scheduler-batch-parent-link` smokes: pass
- `DirectJobOwnershipTest` adds persisted-row coverage for concurrent non-owner acknowledgement, expired-lease takeover, stale worker rejection, and processing-job retry without unscheduling the original action
- prior focused ownership, retention replay, forged authority, collection/artifact confidentiality, trusted-system-call, and operator access coverage remains intact

Fixes #2907
