### PR TITLE
ci: fix Homeboy workflow startup_failure from undeclared autofix inputs

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -21,8 +21,9 @@ jobs:
     if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'release:') }}
     uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2
     with:
-      commands: ${{ github.event_name == 'pull_request' && 'review audit,review lint,review test' || github.event_name == 'workflow_dispatch' && 'review audit,review lint,review test' || 'review test' }}
+      # Autofix on PRs is expressed by adding `refactor lint` to the commands
+      # list — ci.yml@v2 has no `autofix`/`autofix-commands` inputs, and passing
+      # undeclared inputs to a reusable workflow is a hard startup_failure.
+      commands: ${{ github.event_name == 'pull_request' && 'review audit,review lint,review test,refactor lint' || github.event_name == 'workflow_dispatch' && 'review audit,review lint,review test' || 'review test' }}
       expected-commands: ${{ github.event_name == 'pull_request' && 'review audit,review lint,review test' || github.event_name == 'workflow_dispatch' && 'review audit,review lint,review test' || 'review test' }}
-      autofix: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
-      autofix-commands: 'review lint --fix'
     secrets: inherit


### PR DESCRIPTION
## Summary
Fixes the `startup_failure` that has blocked **every** run of `.github/workflows/homeboy.yml` — no CI has run and no `homeboy-ci` tracking issues have been filed since the drift.

Closes #2918.

## Root cause
`homeboy.yml` calls the reusable workflow `Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2` with two inputs it doesn't declare:

```yaml
autofix: ${{ ... }}
autofix-commands: 'review lint --fix'
```

`ci.yml@v2` has no `autofix`/`autofix-commands` inputs. GitHub validates reusable-workflow inputs at **compile time**, so passing an undeclared input rejects the whole run before any job starts → `startup_failure` with zero jobs. (The composite-action path only *warns* on undeclared inputs, which is why homeboy's own `ci.yml` gets away with `autofix: 'false'`; the reusable-workflow path is strict.)

## Fix
- Remove the undeclared `autofix` / `autofix-commands` inputs.
- Preserve the autofix-on-PR intent via the supported surface: add `refactor lint` to the PR `commands` list. `ci.yml@v2` canonicalizes and runs `refactor` commands (`commands/lib.sh` → `homeboy refactor <component> lint`).
- Non-PR events unchanged.

## Verification
- YAML validated.
- Only `with:` keys now are `commands` and `expected-commands` — both declared inputs of `ci.yml@v2`.

## Context
This is the last piece of the fleet-wide auto-issue-filing repair. The categorizer/reconcile fixes are already merged and live on `homeboy-action@v2.8.19` (#288/#289), and homeboy #9269 fixed its audit config. Once this merges and CI can start, data-machine's audit/lint/test tracking-issue filing resumes — the same pipeline that just filed 25 audit issues on homeboy's first working sweep.