### PR TITLE
fix: avoid duplicate artifact registration during inspection

### DIFF
--- a/inc/Engine/Bundle/AgentBundleAbilityService.php
+++ b/inc/Engine/Bundle/AgentBundleAbilityService.php
@@ -670,11 +670,6 @@ final class AgentBundleAbilityService {
 	}
 
 	public static function capability_report( \WP_Agent_Package $package ): \WP_Agent_Package_Capability_Report {
-		if ( 0 === did_action( 'wp_agent_package_artifacts_init' ) ) {
-			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Canonical wp-agent package artifact registry hook.
-			do_action( 'wp_agent_package_artifacts_init' );
-		}
-
 		return \WP_Agent_Package_Capability_Checker::check( $package, self::host_capabilities() );
 	}
 

--- a/tests/bundle-validate-inspect-smoke.php
+++ b/tests/bundle-validate-inspect-smoke.php
@@ -28,7 +28,14 @@ use DataMachine\Engine\Bundle\BundleSchema;
 function datamachine_bundle_validate_smoke_reset_registry(): void {
 	do_action( 'init' );
 	WP_Agent_Package_Artifacts_Registry::reset_for_tests();
-	do_action( 'wp_agent_package_artifacts_init' );
+	$GLOBALS['__agents_api_smoke_wrong'] = array();
+}
+
+function datamachine_bundle_validate_smoke_artifact_definitions(): array {
+	return array_map(
+		static fn( WP_Agent_Package_Artifact_Type $type ): array => $type->to_array(),
+		wp_get_agent_package_artifact_types()
+	);
 }
 
 echo "\n[1] Valid Data Machine bundle projects and passes host capability checks:\n";
@@ -98,11 +105,17 @@ $directory = new AgentBundleDirectory(
 	)
 );
 
-$package = AgentPackageProjection::from_directory( $directory );
-$report  = AgentBundleAbilityService::capability_report( $package )->to_array();
+$package           = AgentPackageProjection::from_directory( $directory );
+$report            = AgentBundleAbilityService::capability_report( $package )->to_array();
+$artifact_types    = datamachine_bundle_validate_smoke_artifact_definitions();
+$repeated_report   = AgentBundleAbilityService::capability_report( $package )->to_array();
+$repeated_artifacts = datamachine_bundle_validate_smoke_artifact_definitions();
 agents_api_smoke_assert_equals( true, $report['compatible'] ?? false, 'valid bundle is compatible with Data Machine host capabilities', $failures, $passes );
 agents_api_smoke_assert_equals( array(), $report['unsupported_capabilities'] ?? null, 'valid bundle has no unsupported package capabilities', $failures, $passes );
 agents_api_smoke_assert_equals( array(), $report['unsupported_artifacts'] ?? null, 'valid bundle has no unsupported artifacts', $failures, $passes );
+agents_api_smoke_assert_equals( $report, $repeated_report, 'repeated inspection returns the same compatibility report', $failures, $passes );
+agents_api_smoke_assert_equals( $artifact_types, $repeated_artifacts, 'repeated inspection preserves registered artifact definitions', $failures, $passes );
+agents_api_smoke_assert_equals( array(), $GLOBALS['__agents_api_smoke_wrong'], 'repeated inspection emits no incorrect-usage notices', $failures, $passes );
 
 echo "\n[2] Projected extension artifact requirements are reported as unsupported:\n";
 add_filter(


### PR DESCRIPTION
## Summary
- remove Data Machine's manual dispatch of the generic package artifact initialization hook during compatibility inspection
- rely on the Agents API capability checker to initialize its owning singleton registry through the public artifact lookup API
- cover repeated inspection in one request, asserting identical compatibility output, unchanged artifact definitions, and no incorrect-usage notices

## Ownership and hook ordering
This is a Data Machine lifecycle bug, not missing idempotency in Agents API. `AgentBundleAbilityService::capability_report()` manually dispatched `wp_agent_package_artifacts_init` before calling `WP_Agent_Package_Capability_Checker::check()`. During that outer dispatch, each registration callback calls `wp_register_agent_package_artifact_type()`, which asks `WP_Agent_Package_Artifacts_Registry::get_instance()` for the registry. Creating that singleton dispatches the registry-owned `wp_agent_package_artifacts_init` hook again, so all callbacks register once in the nested dispatch and then attempt to register again as the outer dispatch resumes.

The capability checker already calls `wp_get_agent_package_artifact_types()`, which initializes the singleton and its hook exactly once at the correct generic boundary. Removing Data Machine's redundant dispatch preserves layer purity and leaves duplicate-registration rejection in the generic registry unchanged.

## Machine-readable output
With only the registry-owned initialization path, package types including `agent-runtime/workspace-preload` and Data Machine's artifact types are registered once. Repeated compatibility inspection returns the same report and definitions without `_doing_it_wrong` notices, so WP-CLI JSON output is no longer prefixed by registration diagnostics.

## Tests
- `php tests/bundle-validate-inspect-smoke.php`
- `php tests/datamachine-package-artifacts-smoke.php`
- `composer lint`

Fixes #2915