### PR TITLE
fix: exclude runtime metadata from agent exports

### DIFF
--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -243,7 +243,7 @@ class AgentBundler {
 				'slug'         => $agent['agent_slug'],
 				'label'        => $agent['agent_name'],
 				'description'  => '',
-				'agent_config' => is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array(),
+				'agent_config' => AgentBundleAgentConfig::tracked_payload( is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array() ),
 				// Preserve the agent's actual scope through the bundle round-trip:
 				// null = network-wide, positive int = a specific blog. The manifest
 				// drops legacy/unknown values so import never re-pins to a blog.

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -243,7 +243,10 @@ class AgentBundler {
 				'slug'         => $agent['agent_slug'],
 				'label'        => $agent['agent_name'],
 				'description'  => '',
-				'agent_config' => AgentBundleAgentConfig::tracked_payload( is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array() ),
+				'agent_config' => AgentBundleAgentConfig::export_payload(
+					is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array(),
+					(string) ( $context['profile'] ?? 'share' )
+				),
 				// Preserve the agent's actual scope through the bundle round-trip:
 				// null = network-wide, positive int = a specific blog. The manifest
 				// drops legacy/unknown values so import never re-pins to a blog.

--- a/inc/Engine/Bundle/AgentBundleAgentConfig.php
+++ b/inc/Engine/Bundle/AgentBundleAgentConfig.php
@@ -28,4 +28,19 @@ final class AgentBundleAgentConfig {
 	public static function tracked_payload( array $config ): array {
 		return AgentConfigArtifactProjector::tracked_payload( AgentConfigFactory::normalize( $config ) );
 	}
+
+	/**
+	 * Return agent config for an export profile.
+	 *
+	 * @param array<string,mixed> $config  Agent config.
+	 * @param string              $profile Export profile.
+	 * @return array<string,mixed>
+	 */
+	public static function export_payload( array $config, string $profile ): array {
+		$config = AgentConfigFactory::normalize( $config );
+
+		return 'backup' === $profile
+			? AgentConfigArtifactProjector::backup_payload( $config )
+			: AgentConfigArtifactProjector::tracked_payload( $config );
+	}
 }

--- a/inc/Engine/Bundle/AgentConfigArtifactProjector.php
+++ b/inc/Engine/Bundle/AgentConfigArtifactProjector.php
@@ -19,18 +19,21 @@ final class AgentConfigArtifactProjector {
 	 *
 	 * Supported policy fields:
 	 * - tracking: include|exclude
+	 * - backup_egress: include|exclude
 	 * - merge: three_way|preserve_local
 	 * - reason: decision reason for merge output
 	 * - redactor: callable applied to tracked values before hashing/comparison
+	 * - backup_redactor: callable applied to backup values before export
 	 *
 	 * @return array<string,array<string,mixed>>
 	 */
 	public static function policies(): array {
 		$policies = array(
 			'datamachine_bundle'           => array(
-				'tracking' => 'exclude',
-				'merge'    => 'preserve_local',
-				'reason'   => 'preserve_runtime_bundle_metadata',
+				'tracking'      => 'exclude',
+				'backup_egress' => 'exclude',
+				'merge'         => 'preserve_local',
+				'reason'        => 'preserve_runtime_bundle_metadata',
 			),
 			'intelligence.context_servers' => array(
 				'tracking' => 'exclude',
@@ -60,7 +63,8 @@ final class AgentConfigArtifactProjector {
 		 * Filter agent_config artifact projection ownership policies.
 		 *
 		 * Plugins can mark their own agent_config namespaces as runtime-local,
-		 * excluded from core bundle drift checks, or redacted before comparison.
+		 * excluded from core bundle drift checks, redacted before comparison, or
+		 * explicitly excluded/redacted during restorable backup egress.
 		 *
 		 * @param array<string,array<string,mixed>> $policies Policy map keyed by dot path.
 		 */
@@ -84,6 +88,33 @@ final class AgentConfigArtifactProjector {
 
 			if ( is_callable( $policy['redactor'] ?? null ) && self::path_exists( $config, $path ) ) {
 				$redactor = $policy['redactor'];
+				self::set_path( $config, $path, $redactor( self::get_path( $config, $path ), $path ) );
+			}
+		}
+
+		self::sort_recursive( $config );
+		return $config;
+	}
+
+	/**
+	 * Return restorable config for backup egress.
+	 *
+	 * Tracking exclusions do not apply because a fresh restore has no local
+	 * config to preserve. Paths are removed or redacted only when their policy
+	 * explicitly opts out of backup egress.
+	 *
+	 * @param array<string,mixed> $config Agent config.
+	 * @return array<string,mixed>
+	 */
+	public static function backup_payload( array $config ): array {
+		foreach ( self::policies() as $path => $policy ) {
+			if ( 'exclude' === ( $policy['backup_egress'] ?? '' ) ) {
+				self::unset_path( $config, $path );
+				continue;
+			}
+
+			if ( is_callable( $policy['backup_redactor'] ?? null ) && self::path_exists( $config, $path ) ) {
+				$redactor = $policy['backup_redactor'];
 				self::set_path( $config, $path, $redactor( self::get_path( $config, $path ), $path ) );
 			}
 		}
@@ -138,15 +169,20 @@ final class AgentConfigArtifactProjector {
 				continue;
 			}
 
-			$tracking = (string) ( $policy['tracking'] ?? 'include' );
-			$merge    = (string) ( $policy['merge'] ?? 'three_way' );
+			$tracking      = (string) ( $policy['tracking'] ?? 'include' );
+			$backup_egress = (string) ( $policy['backup_egress'] ?? 'include' );
+			$merge         = (string) ( $policy['merge'] ?? 'three_way' );
 			$entry    = array(
-				'tracking' => in_array( $tracking, array( 'include', 'exclude' ), true ) ? $tracking : 'include',
-				'merge'    => in_array( $merge, array( 'three_way', 'preserve_local' ), true ) ? $merge : 'three_way',
-				'reason'   => self::sanitize_key( (string) ( $policy['reason'] ?? 'agent_config_projection_policy' ) ),
+				'tracking'      => in_array( $tracking, array( 'include', 'exclude' ), true ) ? $tracking : 'include',
+				'backup_egress' => in_array( $backup_egress, array( 'include', 'exclude' ), true ) ? $backup_egress : 'include',
+				'merge'         => in_array( $merge, array( 'three_way', 'preserve_local' ), true ) ? $merge : 'three_way',
+				'reason'        => self::sanitize_key( (string) ( $policy['reason'] ?? 'agent_config_projection_policy' ) ),
 			);
 			if ( is_callable( $policy['redactor'] ?? null ) ) {
 				$entry['redactor'] = $policy['redactor'];
+			}
+			if ( is_callable( $policy['backup_redactor'] ?? null ) ) {
+				$entry['backup_redactor'] = $policy['backup_redactor'];
 			}
 
 			$normalized[ $path ] = $entry;

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -39,6 +39,7 @@ use DataMachine\Abilities\Engine\RunFlowAbility;
 use DataMachine\Engine\AI\Tools\Global\AgentDailyMemory;
 use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
 use DataMachine\Engine\Bundle\AgentBundleArtifactState;
+use DataMachine\Engine\Bundle\AgentBundleDirectory;
 use DataMachine\Engine\Bundle\AgentBundleInstalledArtifact;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\BundleSchema;
@@ -119,6 +120,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 	private FlowsRepository $flows_repo;
 	private int $owner_id;
 	private $memory_store_filter = null;
+	private $agent_config_projection_filter = null;
 
 	public function set_up(): void {
 		parent::set_up();
@@ -154,6 +156,10 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		if ( null !== $this->memory_store_filter ) {
 			remove_filter( 'wp_agent_memory_store', $this->memory_store_filter, 10 );
 			$this->memory_store_filter = null;
+		}
+		if ( null !== $this->agent_config_projection_filter ) {
+			remove_filter( 'datamachine_agent_config_artifact_projection_policies', $this->agent_config_projection_filter, 10 );
+			$this->agent_config_projection_filter = null;
 		}
 		PermissionHelper::clear_agent_context();
 
@@ -946,6 +952,83 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 			$after['agent_config']['intelligence']['context_servers']['wporg'],
 			'Bundle context server args do not overwrite local runtime config without approval.'
 		);
+	}
+
+	public function test_backup_export_restores_tracking_excluded_agent_config_to_fresh_agent(): void {
+		$this->agent_config_projection_filter = static function ( array $policies ): array {
+			$policies['plugin_runtime'] = array(
+				'tracking' => 'exclude',
+				'merge'    => 'preserve_local',
+				'reason'   => 'preserve_plugin_runtime_config',
+			);
+			$policies['backup_private'] = array(
+				'tracking'      => 'exclude',
+				'backup_egress' => 'exclude',
+				'merge'         => 'preserve_local',
+				'reason'        => 'exclude_private_backup_config',
+			);
+			return $policies;
+		};
+		add_filter( 'datamachine_agent_config_artifact_projection_policies', $this->agent_config_projection_filter, 10, 1 );
+
+		$source_config = array(
+			'default_provider'        => 'openai',
+			'default_model'           => 'gpt-5.5',
+			'tool_policy'             => array( 'allow' => array( 'datamachine/search' ) ),
+			'intelligence_wiki_brain' => array( 'graph' => array( 'enabled' => true ) ),
+			'intelligence'            => array(
+				'context_servers' => array( 'events' => array( 'url' => 'https://runtime.example.test' ) ),
+				'auth_refs'       => array( 'events' => 'runtime:events' ),
+			),
+			'plugin_runtime'          => array( 'endpoint' => 'https://plugin-runtime.example.test' ),
+			'backup_private'          => array( 'token' => 'do-not-export' ),
+			'datamachine_bundle'      => array(
+				'adopted'          => true,
+				'bundle_slug'      => 'backup-source',
+				'bundle_version'   => '1.2.3',
+				'source_revision'  => 'source-only-revision',
+			),
+		);
+		$source_id = $this->agents_repo->create_if_missing( 'backup-source', 'Backup Source', $this->owner_id, $source_config, 7 );
+		$this->assertIsInt( $source_id );
+
+		$exports = array();
+		foreach ( array( 'share', 'backup', 'fork' ) as $profile ) {
+			$result = $this->bundler->export_directory_object( 'backup-source', array( 'profile' => $profile ) );
+			$this->assertTrue( (bool) $result['success'], "{$profile} export succeeds." );
+			$this->assertInstanceOf( AgentBundleDirectory::class, $result['directory'] ?? null );
+			$exports[ $profile ] = AgentBundleArrayAdapter::to_array_bundle( $result['directory'] );
+		}
+
+		$share_config  = $exports['share']['agent']['agent_config'];
+		$backup_config = $exports['backup']['agent']['agent_config'];
+		$fork_config   = $exports['fork']['agent']['agent_config'];
+
+		$this->assertArrayNotHasKey( 'datamachine_bundle', $share_config );
+		$this->assertArrayNotHasKey( 'datamachine_bundle', $backup_config );
+		$this->assertArrayNotHasKey( 'datamachine_bundle', $fork_config );
+		$this->assertArrayNotHasKey( 'plugin_runtime', $share_config, 'Share follows lifecycle tracking exclusions.' );
+		$this->assertArrayNotHasKey( 'plugin_runtime', $fork_config, 'Fork follows lifecycle tracking exclusions.' );
+		$this->assertSame( 'https://plugin-runtime.example.test', $backup_config['plugin_runtime']['endpoint'] ?? null, 'Backup preserves tracking-excluded restorable config.' );
+		$this->assertSame( 'https://runtime.example.test', $backup_config['intelligence']['context_servers']['events']['url'] ?? null );
+		$this->assertSame( 'runtime:events', $backup_config['intelligence']['auth_refs']['events'] ?? null );
+		$this->assertArrayNotHasKey( 'backup_private', $backup_config, 'Backup honors explicit backup egress exclusion.' );
+
+		$restore = $this->bundler->import( $exports['backup'], 'backup-restored', $this->owner_id );
+		$this->assertTrue( (bool) $restore['success'], 'Backup imports into a fresh agent.' );
+
+		$restored        = $this->agents_repo->get_by_slug( 'backup-restored' );
+		$restored_config = $restored['agent_config'] ?? array();
+		$this->assertSame( 7, (int) ( $restored['site_scope'] ?? 0 ), 'Fresh restore preserves site scope.' );
+		$this->assertSame( 'openai', $restored_config['default_provider'] ?? null );
+		$this->assertSame( 'gpt-5.5', $restored_config['default_model'] ?? null );
+		$this->assertSame( array( 'datamachine/search' ), $restored_config['tool_policy']['allow'] ?? null );
+		$this->assertTrue( $restored_config['intelligence_wiki_brain']['graph']['enabled'] ?? false );
+		$this->assertSame( 'https://runtime.example.test', $restored_config['intelligence']['context_servers']['events']['url'] ?? null );
+		$this->assertSame( 'runtime:events', $restored_config['intelligence']['auth_refs']['events'] ?? null );
+		$this->assertSame( 'https://plugin-runtime.example.test', $restored_config['plugin_runtime']['endpoint'] ?? null );
+		$this->assertArrayNotHasKey( 'backup_private', $restored_config );
+		$this->assertNotSame( 'source-only-revision', $restored_config['datamachine_bundle']['source_revision'] ?? null, 'Source install metadata does not survive the restore.' );
 	}
 
 	/**

--- a/tests/agent-bundle-export-config-projection-smoke.php
+++ b/tests/agent-bundle-export-config-projection-smoke.php
@@ -246,41 +246,6 @@ foreach ( array( 'share', 'backup', 'fork' ) as $profile ) {
 	export_config_assert_equals( "{$profile} keeps site scope", 7, $round_trip['agent']['site_scope'] ?? null );
 }
 
-if ( isset( $GLOBALS['wpdb'] ) && function_exists( 'get_current_user_id' ) ) {
-	echo "\n[restore] Real WordPress export imports into a fresh agent\n";
-	$source_slug   = 'events-bot-source-' . getmypid();
-	$restored_slug = 'events-bot-restored-' . getmypid();
-	$owner_id      = max( 1, get_current_user_id() );
-	$repository    = new Agents();
-	$source_id     = $repository->create_if_missing( $source_slug, 'Events Bot Source', $owner_id, $agent['agent_config'], 7 );
-	export_config_assert( 'real source agent is created', false !== $source_id && $source_id > 0 );
-
-	if ( false !== $source_id && $source_id > 0 ) {
-		$export          = ( new AgentBundler() )->export_directory_object( $source_slug, array( 'profile' => 'backup' ) );
-		$backup          = isset( $export['directory'] ) ? AgentBundleArrayAdapter::to_array_bundle( $export['directory'] ) : array();
-		$backup_config   = $backup['agent']['agent_config'] ?? array();
-		$restore         = ( new AgentBundler() )->import( $backup, $restored_slug, $owner_id );
-		$restored_agent  = $repository->get_by_slug( $restored_slug );
-		$restored_config = $restored_agent['agent_config'] ?? array();
-
-		export_config_assert( 'real backup omits source package metadata', ! isset( $backup_config['datamachine_bundle'] ) );
-		export_config_assert( 'fresh restore succeeds', ! empty( $restore['success'] ) );
-		export_config_assert_equals( 'fresh restore keeps plugin runtime context', 'https://runtime.example.test', $restored_config['intelligence']['context_servers']['events']['url'] ?? null );
-		export_config_assert_equals( 'fresh restore keeps plugin auth refs', 'runtime:events', $restored_config['intelligence']['auth_refs']['events'] ?? null );
-		export_config_assert_equals( 'fresh restore keeps tracking-excluded plugin config', 'https://plugin-runtime.example.test', $restored_config['plugin_runtime']['endpoint'] ?? null );
-		export_config_assert( 'fresh restore honors explicit backup-private exclusion', ! isset( $restored_config['backup_private'] ) );
-		export_config_assert_equals( 'fresh restore keeps normalized provider', 'openai', $restored_config['default_provider'] ?? null );
-		export_config_assert_equals( 'fresh restore keeps normalized model', 'gpt-5.5', $restored_config['default_model'] ?? null );
-		export_config_assert_equals( 'fresh restore keeps site scope', 7, $restored_agent['site_scope'] ?? null );
-
-		$table = $GLOBALS['wpdb']->base_prefix . Agents::TABLE_NAME;
-		$GLOBALS['wpdb']->delete( $table, array( 'agent_id' => (int) $source_id ), array( '%d' ) );
-		if ( is_array( $restored_agent ) ) {
-			$GLOBALS['wpdb']->delete( $table, array( 'agent_id' => (int) $restored_agent['agent_id'] ), array( '%d' ) );
-		}
-	}
-}
-
 if ( ! empty( $failures ) ) {
 	echo "\nFAILED: " . count( $failures ) . " export config projection assertions failed.\n";
 	exit( 1 );

--- a/tests/agent-bundle-export-config-projection-smoke.php
+++ b/tests/agent-bundle-export-config-projection-smoke.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Round-trip coverage for portable agent config export projection (#2913).
+ *
+ * Run with: php tests/agent-bundle-export-config-projection-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $title ) {
+		$title = strtolower( (string) $title );
+		$title = preg_replace( '/[^a-z0-9]+/', '-', $title );
+		return trim( (string) $title, '-' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		return strtolower( (string) preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $key ) );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) {
+		return $value instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value, ...$args ) {
+		unset( $hook, $args );
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( ...$args ) {
+		unset( $args );
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( ...$args ) {
+		unset( $args );
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		unset( $args );
+	}
+}
+
+class WP_Error {
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use DataMachine\Core\Agents\AgentBundler;
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
+
+final class ExportConfigAgentsRepository extends Agents {
+	public function __construct( private array $agent ) {
+	}
+
+	public function get_by_slug( string $agent_slug ): ?array {
+		return $agent_slug === $this->agent['agent_slug'] ? $this->agent : null;
+	}
+}
+
+final class ExportConfigPipelinesRepository extends Pipelines {
+	public function __construct() {
+	}
+
+	public function get_all_pipelines( ?int $user_id = null, ?int $agent_id = null, ?string $search = null, ?int $per_page = null, int $offset = 0 ): array {
+		unset( $user_id, $agent_id, $search, $per_page, $offset );
+		return array();
+	}
+}
+
+final class ExportConfigFlowsRepository extends Flows {
+	public function __construct() {
+	}
+
+	public function get_all_flows( ?int $user_id = null, ?int $agent_id = null ): array {
+		unset( $user_id, $agent_id );
+		return array();
+	}
+}
+
+final class ExportConfigDirectoryManager extends DirectoryManager {
+	public function get_agent_identity_directory( string $agent_slug ): string {
+		return sys_get_temp_dir() . '/missing-agent-' . $agent_slug;
+	}
+
+	public function get_user_directory( int $user_id ): string {
+		return sys_get_temp_dir() . '/missing-user-' . $user_id;
+	}
+}
+
+$failures = array();
+$passes   = 0;
+
+function export_config_assert( string $label, bool $condition ): void {
+	global $failures, $passes;
+	if ( $condition ) {
+		++$passes;
+		echo "  PASS: {$label}\n";
+		return;
+	}
+
+	$failures[] = $label;
+	echo "  FAIL: {$label}\n";
+}
+
+function export_config_assert_equals( string $label, $expected, $actual ): void {
+	export_config_assert( $label, $expected === $actual );
+}
+
+function export_config_bundler( array $agent ): AgentBundler {
+	$reflection = new ReflectionClass( AgentBundler::class );
+	$bundler    = $reflection->newInstanceWithoutConstructor();
+	$properties = array(
+		'agents_repo'       => new ExportConfigAgentsRepository( $agent ),
+		'pipelines_repo'    => new ExportConfigPipelinesRepository(),
+		'flows_repo'        => new ExportConfigFlowsRepository(),
+		'directory_manager' => new ExportConfigDirectoryManager(),
+	);
+
+	foreach ( $properties as $name => $value ) {
+		$property = $reflection->getProperty( $name );
+		$property->setValue( $bundler, $value );
+	}
+
+	return $bundler;
+}
+
+$agent = array(
+	'agent_id'     => 2913,
+	'agent_slug'   => 'events-bot',
+	'agent_name'   => 'Events Bot',
+	'owner_id'     => 1,
+	'site_scope'   => 7,
+	'agent_config' => array(
+		'provider'                => 'openai',
+		'model'                   => 'gpt-5.5',
+		'tool_policy'             => array( 'allow' => array( 'datamachine/search' ) ),
+		'intelligence_wiki_brain' => array( 'graph' => array( 'enabled' => true ) ),
+		'intelligence'            => array(
+			'context_servers' => array( 'events' => array( 'url' => 'https://runtime.example.test' ) ),
+			'auth_refs'       => array( 'events' => 'runtime:events' ),
+		),
+		'datamachine_bundle'      => array(
+			'adopted'          => true,
+			'bundle_slug'      => 'events-bot',
+			'bundle_version'   => '1.2.3',
+			'template_slug'    => 'events-template',
+			'template_version' => '4.5.6',
+			'source_ref'       => 'refs/heads/main',
+			'source_revision'  => 'abc123',
+		),
+	),
+);
+
+echo "=== Agent Bundle Export Config Projection Smoke (#2913) ===\n";
+
+foreach ( array( 'share', 'backup', 'fork' ) as $profile ) {
+	echo "\n[{$profile}] Adopted agent export remains portable\n";
+	$result    = export_config_bundler( $agent )->export_directory_object( 'events-bot', array( 'profile' => $profile ) );
+	$directory = $result['directory'] ?? null;
+	export_config_assert( "{$profile} export succeeds", ! empty( $result['success'] ) && null !== $directory );
+	if ( null === $directory ) {
+		continue;
+	}
+
+	$round_trip = AgentBundleArrayAdapter::to_array_bundle( $directory );
+	$config     = $round_trip['agent']['agent_config'] ?? array();
+	export_config_assert( "{$profile} omits runtime bundle metadata", ! array_key_exists( 'datamachine_bundle', $config ) );
+	export_config_assert( "{$profile} omits plugin runtime context", ! isset( $config['intelligence']['context_servers'] ) );
+	export_config_assert( "{$profile} omits plugin runtime auth refs", ! isset( $config['intelligence']['auth_refs'] ) );
+	export_config_assert_equals( "{$profile} keeps normalized provider", 'openai', $config['default_provider'] ?? null );
+	export_config_assert_equals( "{$profile} keeps normalized model", 'gpt-5.5', $config['default_model'] ?? null );
+	export_config_assert_equals( "{$profile} keeps tool policy", array( 'datamachine/search' ), $config['tool_policy']['allow'] ?? null );
+	export_config_assert_equals( "{$profile} keeps plugin bundle-owned policy", true, $config['intelligence_wiki_brain']['graph']['enabled'] ?? null );
+	export_config_assert_equals( "{$profile} keeps site scope", 7, $round_trip['agent']['site_scope'] ?? null );
+}
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAILED: " . count( $failures ) . " export config projection assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} export config projection assertions passed.\n";

--- a/tests/agent-bundle-export-config-projection-smoke.php
+++ b/tests/agent-bundle-export-config-projection-smoke.php
@@ -43,16 +43,26 @@ if ( ! function_exists( 'is_wp_error' ) ) {
 	}
 }
 
-if ( ! function_exists( 'apply_filters' ) ) {
-	function apply_filters( $hook, $value, ...$args ) {
-		unset( $hook, $args );
-		return $value;
+if ( ! function_exists( 'add_filter' ) ) {
+	$GLOBALS['export_config_filters'] = array();
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['export_config_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
 	}
 }
 
-if ( ! function_exists( 'add_filter' ) ) {
-	function add_filter( ...$args ) {
-		unset( $args );
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value, ...$args ) {
+		if ( empty( $GLOBALS['export_config_filters'][ $hook ] ) ) {
+			return $value;
+		}
+
+		ksort( $GLOBALS['export_config_filters'][ $hook ], SORT_NUMERIC );
+		foreach ( $GLOBALS['export_config_filters'][ $hook ] as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				$value = $callback[0]( ...array_slice( array_merge( array( $value ), $args ), 0, $callback[1] ) );
+			}
+		}
+		return $value;
 	}
 }
 
@@ -68,7 +78,9 @@ if ( ! function_exists( 'add_action' ) ) {
 	}
 }
 
-class WP_Error {
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+	}
 }
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
@@ -171,6 +183,8 @@ $agent = array(
 			'context_servers' => array( 'events' => array( 'url' => 'https://runtime.example.test' ) ),
 			'auth_refs'       => array( 'events' => 'runtime:events' ),
 		),
+		'plugin_runtime'          => array( 'endpoint' => 'https://plugin-runtime.example.test' ),
+		'backup_private'          => array( 'token' => 'do-not-export' ),
 		'datamachine_bundle'      => array(
 			'adopted'          => true,
 			'bundle_slug'      => 'events-bot',
@@ -181,6 +195,24 @@ $agent = array(
 			'source_revision'  => 'abc123',
 		),
 	),
+);
+
+add_filter(
+	'datamachine_agent_config_artifact_projection_policies',
+	static function ( array $policies ): array {
+		$policies['plugin_runtime'] = array(
+			'tracking' => 'exclude',
+			'merge'    => 'preserve_local',
+			'reason'   => 'preserve_plugin_runtime_config',
+		);
+		$policies['backup_private'] = array(
+			'tracking'      => 'exclude',
+			'backup_egress' => 'exclude',
+			'merge'         => 'preserve_local',
+			'reason'        => 'exclude_private_backup_config',
+		);
+		return $policies;
+	}
 );
 
 echo "=== Agent Bundle Export Config Projection Smoke (#2913) ===\n";
@@ -197,13 +229,56 @@ foreach ( array( 'share', 'backup', 'fork' ) as $profile ) {
 	$round_trip = AgentBundleArrayAdapter::to_array_bundle( $directory );
 	$config     = $round_trip['agent']['agent_config'] ?? array();
 	export_config_assert( "{$profile} omits runtime bundle metadata", ! array_key_exists( 'datamachine_bundle', $config ) );
-	export_config_assert( "{$profile} omits plugin runtime context", ! isset( $config['intelligence']['context_servers'] ) );
-	export_config_assert( "{$profile} omits plugin runtime auth refs", ! isset( $config['intelligence']['auth_refs'] ) );
+	if ( 'backup' === $profile ) {
+		export_config_assert_equals( 'backup keeps restorable plugin runtime context', 'https://runtime.example.test', $config['intelligence']['context_servers']['events']['url'] ?? null );
+		export_config_assert_equals( 'backup keeps restorable plugin auth refs', 'runtime:events', $config['intelligence']['auth_refs']['events'] ?? null );
+		export_config_assert_equals( 'backup keeps tracking-excluded plugin config', 'https://plugin-runtime.example.test', $config['plugin_runtime']['endpoint'] ?? null );
+	} else {
+		export_config_assert( "{$profile} omits plugin runtime context", ! isset( $config['intelligence']['context_servers'] ) );
+		export_config_assert( "{$profile} omits plugin runtime auth refs", ! isset( $config['intelligence']['auth_refs'] ) );
+		export_config_assert( "{$profile} omits tracking-excluded plugin config", ! isset( $config['plugin_runtime'] ) );
+	}
+	export_config_assert( "{$profile} honors explicit backup-private exclusion", ! isset( $config['backup_private'] ) );
 	export_config_assert_equals( "{$profile} keeps normalized provider", 'openai', $config['default_provider'] ?? null );
 	export_config_assert_equals( "{$profile} keeps normalized model", 'gpt-5.5', $config['default_model'] ?? null );
 	export_config_assert_equals( "{$profile} keeps tool policy", array( 'datamachine/search' ), $config['tool_policy']['allow'] ?? null );
 	export_config_assert_equals( "{$profile} keeps plugin bundle-owned policy", true, $config['intelligence_wiki_brain']['graph']['enabled'] ?? null );
 	export_config_assert_equals( "{$profile} keeps site scope", 7, $round_trip['agent']['site_scope'] ?? null );
+}
+
+if ( isset( $GLOBALS['wpdb'] ) && function_exists( 'get_current_user_id' ) ) {
+	echo "\n[restore] Real WordPress export imports into a fresh agent\n";
+	$source_slug   = 'events-bot-source-' . getmypid();
+	$restored_slug = 'events-bot-restored-' . getmypid();
+	$owner_id      = max( 1, get_current_user_id() );
+	$repository    = new Agents();
+	$source_id     = $repository->create_if_missing( $source_slug, 'Events Bot Source', $owner_id, $agent['agent_config'], 7 );
+	export_config_assert( 'real source agent is created', false !== $source_id && $source_id > 0 );
+
+	if ( false !== $source_id && $source_id > 0 ) {
+		$export          = ( new AgentBundler() )->export_directory_object( $source_slug, array( 'profile' => 'backup' ) );
+		$backup          = isset( $export['directory'] ) ? AgentBundleArrayAdapter::to_array_bundle( $export['directory'] ) : array();
+		$backup_config   = $backup['agent']['agent_config'] ?? array();
+		$restore         = ( new AgentBundler() )->import( $backup, $restored_slug, $owner_id );
+		$restored_agent  = $repository->get_by_slug( $restored_slug );
+		$restored_config = $restored_agent['agent_config'] ?? array();
+
+		export_config_assert( 'real backup omits source package metadata', ! isset( $backup_config['datamachine_bundle'] ) );
+		export_config_assert( 'fresh restore succeeds', ! empty( $restore['success'] ) );
+		export_config_assert_equals( 'fresh restore keeps plugin runtime context', 'https://runtime.example.test', $restored_config['intelligence']['context_servers']['events']['url'] ?? null );
+		export_config_assert_equals( 'fresh restore keeps plugin auth refs', 'runtime:events', $restored_config['intelligence']['auth_refs']['events'] ?? null );
+		export_config_assert_equals( 'fresh restore keeps tracking-excluded plugin config', 'https://plugin-runtime.example.test', $restored_config['plugin_runtime']['endpoint'] ?? null );
+		export_config_assert( 'fresh restore honors explicit backup-private exclusion', ! isset( $restored_config['backup_private'] ) );
+		export_config_assert_equals( 'fresh restore keeps normalized provider', 'openai', $restored_config['default_provider'] ?? null );
+		export_config_assert_equals( 'fresh restore keeps normalized model', 'gpt-5.5', $restored_config['default_model'] ?? null );
+		export_config_assert_equals( 'fresh restore keeps site scope', 7, $restored_agent['site_scope'] ?? null );
+
+		$table = $GLOBALS['wpdb']->base_prefix . Agents::TABLE_NAME;
+		$GLOBALS['wpdb']->delete( $table, array( 'agent_id' => (int) $source_id ), array( '%d' ) );
+		if ( is_array( $restored_agent ) ) {
+			$GLOBALS['wpdb']->delete( $table, array( 'agent_id' => (int) $restored_agent['agent_id'] ), array( '%d' ) );
+		}
+	}
 }
 
 if ( ! empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- remove runtime-local `datamachine_bundle` package metadata from every exported manifest
- keep lifecycle ownership projection for portable share/fork exports without applying those tracking exclusions to restorable backups
- add explicit `backup_egress` and `backup_redactor` policy controls for plugin-owned config that must not leave through backups
- cover adopted-agent exports across all profiles and a discovered `WP_UnitTestCase` export-to-fresh-import restore path

## Root cause
`AgentBundler::export_directory_object()` originally copied raw persisted `agent_config` into `manifest.json`, which leaked adopted package lifecycle state from `datamachine_bundle`.

The first fix reused `tracked_payload()` for every profile. That was correct for portable share/fork ownership but wrong for backup: tracking-excluded paths such as `intelligence.context_servers`, `intelligence.auth_refs`, and plugin-owned runtime config are preserved locally during upgrades, but a fresh restore has no local state to preserve.

## Export semantics
`AgentBundleAgentConfig::export_payload()` now selects projection by profile:

- `share` and `fork` use lifecycle `tracked_payload()` semantics, excluding paths whose owners mark them `tracking=exclude`.
- `backup` uses `backup_payload()`, retaining full normalized restorable config by default.
- `datamachine_bundle` is explicitly `backup_egress=exclude`, so source install/package metadata is never serialized.
- plugins can explicitly set `backup_egress=exclude` or provide `backup_redactor` without changing lifecycle tracking/merge ownership.

Backup remains intentionally fuller than share/fork for memory, user data, daily memory, handler auth, and restorable agent config. Site scope remains a separate manifest field and survives fresh import.

## Compatibility
Lifecycle drift, three-way merge, and `preserve_local` behavior are unchanged. Existing `tracking`, `merge`, and `redactor` policies retain their prior meaning. The new backup fields default to inclusion/no redaction, preserving historical backup restoration behavior except for explicitly excluded runtime package metadata.

Legacy scalar `provider` and `model` values still normalize to `default_provider` and `default_model` in every profile.

## Tests
`AgentBundlerImportTest::test_backup_export_restores_tracking_excluded_agent_config_to_fresh_agent()` is a discovered `WP_UnitTestCase`. It creates a persisted adopted agent, registers plugin projection policies, exports share/backup/fork, imports the backup under a fresh slug, and inspects the restored database row for runtime config/auth refs, bundle-owned config, explicit backup exclusions, package metadata replacement, and site scope.

Passing locally:
- `php tests/agent-bundle-export-config-projection-smoke.php` (33 assertions)
- `php tests/export-agent-ability-smoke.php`
- `php tests/agent-bundle-site-scope-roundtrip-smoke.php`
- `php tests/agent-bundle-artifact-rebase-smoke.php`
- `php tests/agent-bundle-template-upgrade-tracking-smoke.php`
- PHPCS for all changed production and test files
- PHP syntax checks for all changed files
- `git diff --check`

Exact real-WordPress command attempted:

`homeboy review test data-machine --path /var/lib/datamachine/workspace/data-machine@fix-bundle-export-runtime-metadata-2913 --placement local -- --filter=test_backup_export_restores_tracking_excluded_agent_config_to_fresh_agent`

Homeboy provisioned WordPress 7.0 and ran exactly one test. The test reached 27 assertions before the sandbox PHPUnit dependency bundle failed while handling results because `SebastianBergmann\\Comparator\\ExceptionComparator` was absent. Evidence run: `a7b500e1-debb-4790-a524-1cfffebbb6db`. GitHub Homeboy run `29790635213` is queued awaiting a runner and will provide the authoritative CI result.

Closes #2913