### PR TITLE
fix: make flow creation validation atomic

### DIFF
--- a/inc/Abilities/Flow/CreateFlowAbility.php
+++ b/inc/Abilities/Flow/CreateFlowAbility.php
@@ -164,6 +164,37 @@ class CreateFlowAbility {
 		$agent_id          = isset( $input['agent_id'] ) ? (int) $input['agent_id'] : null;
 		$scheduling_config = $input['scheduling_config'] ?? array( 'interval' => 'manual' );
 		$flow_config       = $input['flow_config'] ?? array();
+		$step_configs      = $input['step_configs'] ?? array();
+		$validate_only     = ! empty( $input['validate_only'] );
+
+		if ( ! is_array( $scheduling_config ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'scheduling_config must be an object',
+			);
+		}
+
+		if ( ! is_array( $flow_config ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'flow_config must be an object',
+			);
+		}
+
+		if ( ! is_array( $step_configs ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'step_configs must be an object',
+			);
+		}
+
+		$step_config_validation = $this->validateCreateStepConfigs( $step_configs );
+		if ( true !== $step_config_validation ) {
+			return array(
+				'success' => false,
+				'error'   => $step_config_validation,
+			);
+		}
 
 		// Resolve the owning agent when the caller did not supply one. Agent-first
 		// scoping (#735) makes agent-scoped reads filter `WHERE agent_id = %d`, so a
@@ -210,8 +241,21 @@ class CreateFlowAbility {
 			$flow_data['agent_id'] = $agent_id;
 		}
 
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$transaction_started = false !== $wpdb->query( 'START TRANSACTION' );
+		if ( ! $transaction_started ) {
+			return array(
+				'success' => false,
+				'error'   => 'Unable to start flow creation transaction',
+			);
+		}
+
 		$flow_id = $this->db_flows->create_flow( $flow_data );
 		if ( ! $flow_id ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( 'ROLLBACK' );
 			do_action(
 				'datamachine_log',
 				'error',
@@ -232,7 +276,9 @@ class CreateFlowAbility {
 
 		if ( ! empty( $pipeline_config ) ) {
 			$pipeline_steps = is_array( $pipeline_config ) ? array_values( $pipeline_config ) : array();
-			$this->syncStepsToFlow( $flow_id, $pipeline_id, $pipeline_steps, $pipeline_config );
+			if ( ! $this->syncStepsToFlow( $flow_id, $pipeline_id, $pipeline_steps, $pipeline_config ) ) {
+				return $this->rollbackCreation( $flow_id, 'Failed to sync pipeline steps to flow' );
+			}
 			$synced_steps = count( $pipeline_config );
 		}
 
@@ -242,26 +288,28 @@ class CreateFlowAbility {
 				do_action(
 					'datamachine_log',
 					'error',
-					'Failed to schedule flow — reverting to manual',
+					'Failed to schedule flow during creation',
 					array(
 						'flow_id' => $flow_id,
 						'error'   => $scheduling_result->get_error_message(),
 					)
 				);
 
-				// Revert to manual so the DB doesn't claim a schedule that
-				// has no backing AS action.
-				$this->db_flows->update_flow_scheduling( $flow_id, array( 'interval' => 'manual' ) );
+				return $this->rollbackCreation( $flow_id, $scheduling_result->get_error_message() );
 			}
 		}
 
-		$step_configs   = $input['step_configs'] ?? array();
 		$config_results = array(
 			'applied' => array(),
 			'errors'  => array(),
 		);
 		if ( ! empty( $step_configs ) ) {
 			$config_results = $this->applyStepConfigsToFlow( $flow_id, $step_configs );
+			if ( ! empty( $config_results['errors'] ) ) {
+				$first_error = $config_results['errors'][0];
+				$message     = is_array( $first_error ) ? ( $first_error['error'] ?? 'Failed to configure flow step' ) : (string) $first_error;
+				return $this->rollbackCreation( $flow_id, $message, $config_results['errors'] );
+			}
 		}
 
 		$configured_step_types = array_keys( $step_configs );
@@ -272,6 +320,35 @@ class CreateFlowAbility {
 		}
 
 		$flow = $this->db_flows->get_flow( $flow_id );
+		if ( ! $flow ) {
+			return $this->rollbackCreation( $flow_id, 'Failed to load created flow' );
+		}
+
+		if ( $validate_only ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( 'ROLLBACK' );
+
+			return array(
+				'success'      => true,
+				'valid'        => true,
+				'mode'         => 'validate_only',
+				'would_create' => array(
+					array(
+						'pipeline_id'        => $pipeline_id,
+						'pipeline_name'      => $pipeline['pipeline_name'] ?? '',
+						'flow_name'          => $flow_name,
+						'scheduling'         => $scheduling_config['interval'] ?? 'manual',
+						'step_configs_count' => count( $step_configs ),
+					),
+				),
+				'message'      => 'Validation passed. Would create 1 flow.',
+			);
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		if ( false === $wpdb->query( 'COMMIT' ) ) {
+			return $this->rollbackCreation( $flow_id, 'Failed to commit flow creation transaction' );
+		}
 
 		do_action(
 			'datamachine_log',
@@ -298,8 +375,34 @@ class CreateFlowAbility {
 			$result['configured_steps'] = $config_results['applied'];
 		}
 
-		if ( ! empty( $config_results['errors'] ) ) {
-			$result['configuration_errors'] = $config_results['errors'];
+		return $result;
+	}
+
+	/**
+	 * Roll back all writes made while creating a flow.
+	 *
+	 * @param int    $flow_id Flow ID allocated in the transaction.
+	 * @param string $error Error message.
+	 * @param array  $configuration_errors Optional structured configuration errors.
+	 * @return array Failure result.
+	 */
+	private function rollbackCreation( int $flow_id, string $error, array $configuration_errors = array() ): array {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( 'ROLLBACK' );
+
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
+		}
+
+		$result = array(
+			'success' => false,
+			'error'   => $error,
+		);
+
+		if ( ! empty( $configuration_errors ) ) {
+			$result['configuration_errors'] = $configuration_errors;
 		}
 
 		return $result;
@@ -316,10 +419,25 @@ class CreateFlowAbility {
 		$shared_step_config = $input['shared_step_config'] ?? array();
 		$validate_only      = ! empty( $input['validate_only'] );
 
+		if ( ! is_array( $shared_step_config ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'shared_step_config must be an object',
+			);
+		}
+
 		$validation_errors = array();
 		$pipeline_cache    = array();
 
 		foreach ( $flows as $index => $flow_config ) {
+			if ( ! is_array( $flow_config ) ) {
+				$validation_errors[] = array(
+					'index' => $index,
+					'error' => 'Each flows entry must be an object',
+				);
+				continue;
+			}
+
 			$pipeline_id = $flow_config['pipeline_id'] ?? null;
 			$flow_name   = $flow_config['flow_name'] ?? null;
 
@@ -365,25 +483,45 @@ class CreateFlowAbility {
 			);
 		}
 
-		if ( $validate_only ) {
-			$preview = array();
-			foreach ( $flows as $index => $flow_config ) {
-				$pipeline_id       = (int) $flow_config['pipeline_id'];
-				$flow_name         = $flow_config['flow_name'];
-				$scheduling_config = $flow_config['scheduling_config'] ?? array( 'interval' => 'manual' );
-				$step_configs      = $flow_config['step_configs'] ?? array();
-
-				$merged_step_configs = array_merge( $shared_step_config, $step_configs );
-
-				$preview[] = array(
-					'pipeline_id'        => $pipeline_id,
-					'pipeline_name'      => $pipeline_cache[ $pipeline_id ]['pipeline_name'] ?? '',
-					'flow_name'          => $flow_name,
-					'scheduling'         => $scheduling_config['interval'] ?? 'manual',
-					'step_configs_count' => count( $merged_step_configs ),
+		$preview = array();
+		foreach ( $flows as $index => $flow_config ) {
+			$pipeline_id       = (int) $flow_config['pipeline_id'];
+			$flow_name         = $flow_config['flow_name'];
+			$scheduling_config = $flow_config['scheduling_config'] ?? array( 'interval' => 'manual' );
+			$step_configs      = $flow_config['step_configs'] ?? array();
+			if ( ! is_array( $step_configs ) ) {
+				return array(
+					'success' => false,
+					'error'   => sprintf( 'Validation failed for flow %d: step_configs must be an object', $index ),
 				);
 			}
 
+			$single_input = array(
+				'pipeline_id'       => $pipeline_id,
+				'flow_name'         => $flow_name,
+				'scheduling_config' => $scheduling_config,
+				'step_configs'      => array_merge( $shared_step_config, $step_configs ),
+				'validate_only'     => true,
+			);
+			if ( isset( $flow_config['agent_id'] ) ) {
+				$single_input['agent_id'] = $flow_config['agent_id'];
+			} elseif ( isset( $input['agent_id'] ) ) {
+				$single_input['agent_id'] = $input['agent_id'];
+			}
+
+			$single_result = $this->executeSingle( $single_input );
+			if ( ! $single_result['success'] ) {
+				return array(
+					'success' => false,
+					'error'   => sprintf( 'Validation failed for flow %d: %s', $index, $single_result['error'] ?? 'unknown error' ),
+					'errors'  => $single_result['configuration_errors'] ?? array(),
+				);
+			}
+
+			$preview[] = $single_result['would_create'][0];
+		}
+
+		if ( $validate_only ) {
 			return array(
 				'success'      => true,
 				'valid'        => true,
@@ -407,11 +545,15 @@ class CreateFlowAbility {
 			$merged_step_configs = array_merge( $shared_step_config, $step_configs );
 
 			$single_result = $this->executeSingle(
-				array(
-					'pipeline_id'       => $pipeline_id,
-					'flow_name'         => $flow_name,
-					'scheduling_config' => $scheduling_config,
-					'step_configs'      => $merged_step_configs,
+				array_filter(
+					array(
+						'pipeline_id'       => $pipeline_id,
+						'flow_name'         => $flow_name,
+						'scheduling_config' => $scheduling_config,
+						'step_configs'      => $merged_step_configs,
+						'agent_id'          => $flow_config['agent_id'] ?? ( $input['agent_id'] ?? null ),
+					),
+					static fn( $value ) => null !== $value
 				)
 			);
 
@@ -441,10 +583,6 @@ class CreateFlowAbility {
 
 			if ( ! empty( $single_result['configured_steps'] ) ) {
 				$created_entry['configured_steps'] = $single_result['configured_steps'];
-			}
-
-			if ( ! empty( $single_result['configuration_errors'] ) ) {
-				$created_entry['configuration_errors'] = $single_result['configuration_errors'];
 			}
 
 			$created[] = $created_entry;

--- a/inc/Abilities/Flow/CreateFlowAbility.php
+++ b/inc/Abilities/Flow/CreateFlowAbility.php
@@ -12,6 +12,8 @@ namespace DataMachine\Abilities\Flow;
 
 use DataMachine\Abilities\AbilityRegistration;
 use DataMachine\Api\Flows\FlowScheduling;
+use DataMachine\Core\Database\BaseRepository;
+use DataMachine\Engine\Tasks\RecurringScheduler;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -241,11 +243,8 @@ class CreateFlowAbility {
 			$flow_data['agent_id'] = $agent_id;
 		}
 
-		global $wpdb;
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
-		$transaction_started = false !== $wpdb->query( 'START TRANSACTION' );
-		if ( ! $transaction_started ) {
+		$transaction_scope = $this->beginCreationTransactionScope();
+		if ( null === $transaction_scope ) {
 			return array(
 				'success' => false,
 				'error'   => 'Unable to start flow creation transaction',
@@ -254,8 +253,7 @@ class CreateFlowAbility {
 
 		$flow_id = $this->db_flows->create_flow( $flow_data );
 		if ( ! $flow_id ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
-			$wpdb->query( 'ROLLBACK' );
+			$this->rollbackCreationTransactionScope( $transaction_scope );
 			do_action(
 				'datamachine_log',
 				'error',
@@ -277,7 +275,7 @@ class CreateFlowAbility {
 		if ( ! empty( $pipeline_config ) ) {
 			$pipeline_steps = is_array( $pipeline_config ) ? array_values( $pipeline_config ) : array();
 			if ( ! $this->syncStepsToFlow( $flow_id, $pipeline_id, $pipeline_steps, $pipeline_config ) ) {
-				return $this->rollbackCreation( $flow_id, 'Failed to sync pipeline steps to flow' );
+				return $this->rollbackCreation( $transaction_scope, $flow_id, 'Failed to sync pipeline steps to flow' );
 			}
 			$synced_steps = count( $pipeline_config );
 		}
@@ -295,7 +293,7 @@ class CreateFlowAbility {
 					)
 				);
 
-				return $this->rollbackCreation( $flow_id, $scheduling_result->get_error_message() );
+				return $this->rollbackCreation( $transaction_scope, $flow_id, $scheduling_result->get_error_message() );
 			}
 		}
 
@@ -308,7 +306,7 @@ class CreateFlowAbility {
 			if ( ! empty( $config_results['errors'] ) ) {
 				$first_error = $config_results['errors'][0];
 				$message     = is_array( $first_error ) ? ( $first_error['error'] ?? 'Failed to configure flow step' ) : (string) $first_error;
-				return $this->rollbackCreation( $flow_id, $message, $config_results['errors'] );
+				return $this->rollbackCreation( $transaction_scope, $flow_id, $message, $config_results['errors'] );
 			}
 		}
 
@@ -318,15 +316,24 @@ class CreateFlowAbility {
 		if ( ! empty( $defaults_results['applied'] ) ) {
 			$config_results['applied'] = array_merge( $config_results['applied'], $defaults_results['applied'] );
 		}
+		if ( ! empty( $defaults_results['errors'] ) ) {
+			$first_error = $defaults_results['errors'][0];
+			return $this->rollbackCreation(
+				$transaction_scope,
+				$flow_id,
+				$first_error['error'] ?? 'Failed to apply site default configuration',
+				$defaults_results['errors']
+			);
+		}
 
 		$flow = $this->db_flows->get_flow( $flow_id );
 		if ( ! $flow ) {
-			return $this->rollbackCreation( $flow_id, 'Failed to load created flow' );
+			return $this->rollbackCreation( $transaction_scope, $flow_id, 'Failed to load created flow' );
 		}
 
 		if ( $validate_only ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
-			$wpdb->query( 'ROLLBACK' );
+			$this->compensateFlowSchedule( $flow_id );
+			$this->rollbackCreationTransactionScope( $transaction_scope );
 
 			return array(
 				'success'      => true,
@@ -345,9 +352,8 @@ class CreateFlowAbility {
 			);
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
-		if ( false === $wpdb->query( 'COMMIT' ) ) {
-			return $this->rollbackCreation( $flow_id, 'Failed to commit flow creation transaction' );
+		if ( ! $this->commitCreationTransactionScope( $transaction_scope ) ) {
+			return $this->rollbackCreation( $transaction_scope, $flow_id, 'Failed to commit flow creation transaction' );
 		}
 
 		do_action(
@@ -381,20 +387,15 @@ class CreateFlowAbility {
 	/**
 	 * Roll back all writes made while creating a flow.
 	 *
+	 * @param array  $transaction_scope Transaction or savepoint owned by this call.
 	 * @param int    $flow_id Flow ID allocated in the transaction.
 	 * @param string $error Error message.
 	 * @param array  $configuration_errors Optional structured configuration errors.
 	 * @return array Failure result.
 	 */
-	private function rollbackCreation( int $flow_id, string $error, array $configuration_errors = array() ): array {
-		global $wpdb;
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
-		$wpdb->query( 'ROLLBACK' );
-
-		if ( function_exists( 'as_unschedule_all_actions' ) ) {
-			as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
-		}
+	private function rollbackCreation( array $transaction_scope, int $flow_id, string $error, array $configuration_errors = array() ): array {
+		$this->compensateFlowSchedule( $flow_id );
+		$this->rollbackCreationTransactionScope( $transaction_scope );
 
 		$result = array(
 			'success' => false,
@@ -406,6 +407,92 @@ class CreateFlowAbility {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Begin an owned transaction scope without committing a caller transaction.
+	 *
+	 * @return array{type:string,name?:string}|null Scope metadata, or null on failure.
+	 */
+	private function beginCreationTransactionScope(): ?array {
+		global $wpdb;
+
+		static $savepoint_sequence = 0;
+
+		$in_transaction = false;
+		if ( ! BaseRepository::is_sqlite() ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+			$in_transaction = 1 === (int) $wpdb->get_var( 'SELECT @@in_transaction' );
+		}
+
+		if ( $in_transaction || BaseRepository::is_sqlite() ) {
+			++$savepoint_sequence;
+			$name = 'datamachine_create_flow_' . $savepoint_sequence;
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			if ( false === $wpdb->query( "SAVEPOINT {$name}" ) ) {
+				return null;
+			}
+
+			return array(
+				'type' => 'savepoint',
+				'name' => $name,
+			);
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) {
+			return null;
+		}
+
+		return array( 'type' => 'transaction' );
+	}
+
+	/**
+	 * Commit only the transaction scope opened by this ability call.
+	 *
+	 * @param array{type:string,name?:string} $scope Transaction scope metadata.
+	 */
+	private function commitCreationTransactionScope( array $scope ): bool {
+		global $wpdb;
+
+		if ( 'savepoint' === $scope['type'] ) {
+			$name = $scope['name'];
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			return false !== $wpdb->query( "RELEASE SAVEPOINT {$name}" );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		return false !== $wpdb->query( 'COMMIT' );
+	}
+
+	/**
+	 * Roll back only the transaction scope opened by this ability call.
+	 *
+	 * @param array{type:string,name?:string} $scope Transaction scope metadata.
+	 */
+	private function rollbackCreationTransactionScope( array $scope ): void {
+		global $wpdb;
+
+		if ( 'savepoint' === $scope['type'] ) {
+			$name = $scope['name'];
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->query( "ROLLBACK TO SAVEPOINT {$name}" );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->query( "RELEASE SAVEPOINT {$name}" );
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( 'ROLLBACK' );
+	}
+
+	/**
+	 * Remove any Action Scheduler side effect created for a rolled-back flow.
+	 *
+	 * @param int $flow_id Flow ID allocated in this scope.
+	 */
+	private function compensateFlowSchedule( int $flow_id ): void {
+		RecurringScheduler::unschedule( FlowScheduling::FLOW_HOOK, array( $flow_id ), RecurringScheduler::GROUP );
 	}
 
 	/**

--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -510,37 +510,8 @@ trait FlowHelpers {
 			$flow_step_id = $target['flow_step_id'];
 			$step_type    = $target['step_type'] ?? (string) $step_key;
 
-			$normalized_handler_config = FlowStepConfigFactory::withHandlerFields(
-				array( 'step_type' => $step_type ),
-				$config
-			);
-
-			$handler_slugs   = $config['handler_slugs'] ?? array();
-			$handler_configs = FlowStepConfig::getHandlerConfigs( $normalized_handler_config );
-			$single_slug     = $config['handler_slug'] ?? '';
-			$single_config   = $config['handler_config'] ?? array();
-
-			// When handler_slugs is provided, add each handler with its config from handler_configs.
-			if ( ! empty( $handler_slugs ) ) {
-				foreach ( $handler_slugs as $slug ) {
-					$slug_config = $handler_configs[ $slug ] ?? array();
-					$add_result  = $update_flow_step_ability->execute(
-						array(
-							'flow_step_id'       => $flow_step_id,
-							'add_handler'        => $slug,
-							'add_handler_config' => $slug_config,
-						)
-					);
-					if ( ! $add_result['success'] ) {
-						$errors[] = array(
-							'step_type'    => $step_type,
-							'flow_step_id' => $flow_step_id,
-							'handler'      => $slug,
-							'error'        => $add_result['error'] ?? 'Failed to add handler',
-						);
-					}
-				}
-			}
+			$single_slug   = $config['handler_slug'] ?? '';
+			$single_config = $config['handler_config'] ?? array();
 
 			// Build the base update input for singular handler_slug / handler_config / user_message.
 			$update_input = array( 'flow_step_id' => $flow_step_id );
@@ -553,13 +524,6 @@ trait FlowHelpers {
 			}
 			if ( ! empty( $config['user_message'] ) ) {
 				$update_input['user_message'] = $config['user_message'];
-			}
-
-			// Only call update if there's something beyond the flow_step_id to apply.
-			if ( count( $update_input ) <= 1 && ! empty( $handler_slugs ) ) {
-				// Already handled via add_handler above — mark as applied.
-				$applied[] = $flow_step_id;
-				continue;
 			}
 
 			$result = $update_flow_step_ability->execute( $update_input );
@@ -579,6 +543,54 @@ trait FlowHelpers {
 			'applied' => $applied,
 			'errors'  => $errors,
 		);
+	}
+
+	/**
+	 * Validate the public flow-create step configuration shape.
+	 *
+	 * @param array $step_configs Configs keyed by step target.
+	 * @return true|string True when valid, otherwise an error message.
+	 */
+	protected function validateCreateStepConfigs( array $step_configs ): true|string {
+		$allowed_fields = array( 'handler_slug', 'handler_config', 'user_message', 'flow_step_id', 'pipeline_step_id', 'execution_order' );
+		$handlers       = new HandlerAbilities();
+
+		foreach ( $step_configs as $step_key => $config ) {
+			if ( ! is_array( $config ) ) {
+				return sprintf( 'step_configs.%s must be an object', $step_key );
+			}
+
+			$unknown_fields = array_diff( array_keys( $config ), $allowed_fields );
+			if ( ! empty( $unknown_fields ) ) {
+				return sprintf(
+					'Unknown fields in step_configs.%s: %s. Valid configuration fields: handler_slug, handler_config, user_message',
+					$step_key,
+					implode( ', ', $unknown_fields )
+				);
+			}
+
+			if ( isset( $config['handler_slug'] ) && ( ! is_string( $config['handler_slug'] ) || '' === trim( $config['handler_slug'] ) ) ) {
+				return sprintf( 'step_configs.%s.handler_slug must be a non-empty string', $step_key );
+			}
+
+			if ( isset( $config['handler_slug'] ) && ! $handlers->handlerExists( $config['handler_slug'] ) ) {
+				return sprintf( "Handler '%s' not found", $config['handler_slug'] );
+			}
+
+			if ( isset( $config['handler_config'] ) && ! is_array( $config['handler_config'] ) ) {
+				return sprintf( 'step_configs.%s.handler_config must be an object', $step_key );
+			}
+
+			if ( isset( $config['user_message'] ) && ! is_string( $config['user_message'] ) ) {
+				return sprintf( 'step_configs.%s.user_message must be a string', $step_key );
+			}
+
+			if ( ! array_key_exists( 'handler_slug', $config ) && ! array_key_exists( 'handler_config', $config ) && ! array_key_exists( 'user_message', $config ) ) {
+				return sprintf( 'step_configs.%s must include handler_slug, handler_config, or user_message', $step_key );
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -522,7 +522,7 @@ trait FlowHelpers {
 			if ( ! empty( $single_config ) ) {
 				$update_input['handler_config'] = $single_config;
 			}
-			if ( ! empty( $config['user_message'] ) ) {
+			if ( array_key_exists( 'user_message', $config ) ) {
 				$update_input['user_message'] = $config['user_message'];
 			}
 
@@ -601,11 +601,12 @@ trait FlowHelpers {
 	 *
 	 * @param int   $flow_id Flow ID.
 	 * @param array $configured_step_types Step types that were explicitly configured.
-	 * @return array{applied: array, skipped: array}
+	 * @return array{applied: array, skipped: array, errors: array}
 	 */
 	protected function applySiteDefaultsToUnconfiguredSteps( int $flow_id, array $configured_step_types ): array {
 		$applied = array();
 		$skipped = array();
+		$errors  = array();
 
 		$flow        = $this->db_flows->get_flow( $flow_id );
 		$flow_config = $flow['flow_config'] ?? array();
@@ -617,6 +618,7 @@ trait FlowHelpers {
 			return array(
 				'applied' => $applied,
 				'skipped' => array_keys( $flow_config ),
+				'errors'  => $errors,
 			);
 		}
 
@@ -668,13 +670,19 @@ trait FlowHelpers {
 			if ( $result['success'] ) {
 				$applied[] = $flow_step_id;
 			} else {
-				$skipped[] = $flow_step_id;
+				$errors[] = array(
+					'flow_step_id' => $flow_step_id,
+					'step_type'    => $step_type,
+					'handler'      => $default_handler_slug,
+					'error'        => $result['error'] ?? 'Failed to apply site default configuration',
+				);
 			}
 		}
 
 		return array(
 			'applied' => $applied,
 			'skipped' => $skipped,
+			'errors'  => $errors,
 		);
 	}
 }

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -171,7 +171,7 @@ class FlowsCommand extends BaseCommand {
 	 * : Pipeline ID for pause/resume scoping.
 	 *
  * [--agent=<slug_or_id>]
- * : Agent slug or ID. For update: set the flow's agent_id.
+ * : Agent slug or ID. For create/update: set the flow's agent_id.
  *   For pause/resume/list: scope by agent.
  *   For reassign: see --from-agent / --to-agent instead.
  *
@@ -928,6 +928,7 @@ class FlowsCommand extends BaseCommand {
 		$scheduled_at = $assoc_args['scheduled-at'] ?? null;
 		$dry_run      = isset( $assoc_args['dry-run'] );
 		$format       = $assoc_args['format'] ?? 'table';
+		$agent_id     = null;
 
 		if ( ! $pipeline_id ) {
 			WP_CLI::error( 'Required: --pipeline_id=<id>' );
@@ -937,6 +938,14 @@ class FlowsCommand extends BaseCommand {
 		if ( ! $flow_name ) {
 			WP_CLI::error( 'Required: --name=<name>' );
 			return;
+		}
+
+		if ( isset( $assoc_args['agent'] ) ) {
+			$agent_id = AgentResolver::resolve( $assoc_args );
+			if ( null === $agent_id ) {
+				WP_CLI::error( 'Could not resolve --agent to a valid agent.' );
+				return;
+			}
 		}
 
 		$step_configs = array();
@@ -993,17 +1002,12 @@ class FlowsCommand extends BaseCommand {
 			'scheduling_config' => $scheduling_config,
 			'step_configs'      => $step_configs,
 		);
+		if ( null !== $agent_id ) {
+			$input['agent_id'] = $agent_id;
+		}
 
 		if ( $dry_run ) {
 			$input['validate_only'] = true;
-			$input['flows']         = array(
-				array(
-					'pipeline_id'       => $pipeline_id,
-					'flow_name'         => $flow_name,
-					'scheduling_config' => $scheduling_config,
-					'step_configs'      => $step_configs,
-				),
-			);
 		}
 
 		$ability = wp_get_ability( 'datamachine/create-flow' );
@@ -1040,13 +1044,6 @@ class FlowsCommand extends BaseCommand {
 
 		if ( ! empty( $result['configured_steps'] ) ) {
 			WP_CLI::log( sprintf( 'Configured steps: %s', implode( ', ', $result['configured_steps'] ) ) );
-		}
-
-		if ( ! empty( $result['configuration_errors'] ) ) {
-			WP_CLI::warning( 'Some step configurations failed:' );
-			foreach ( $result['configuration_errors'] as $error ) {
-				WP_CLI::log( sprintf( '  - %s: %s', $error['step_type'] ?? 'unknown', $error['error'] ?? 'unknown error' ) );
-			}
 		}
 
 		if ( 'json' === $format && isset( $result['flow_data'] ) ) {

--- a/inc/Cli/Commands/PipelinesCommand.php
+++ b/inc/Cli/Commands/PipelinesCommand.php
@@ -91,7 +91,7 @@ class PipelinesCommand extends BaseCommand {
 	 *   Use --step to target a specific step when multiple exist.
 	 *
  * [--agent=<slug_or_id>]
- * : Agent slug or ID. For update: set the pipeline's agent_id.
+ * : Agent slug or ID. For create/update: set the pipeline's agent_id.
  *   For reassign: see --from-agent / --to-agent instead.
  *   For list: filter by agent.
  *
@@ -578,10 +578,19 @@ class PipelinesCommand extends BaseCommand {
 		$pipeline_name = $assoc_args['name'] ?? null;
 		$dry_run       = isset( $assoc_args['dry-run'] );
 		$format        = $assoc_args['format'] ?? 'table';
+		$agent_id      = null;
 
 		if ( ! $pipeline_name ) {
 			WP_CLI::error( 'Required: --name=<name>' );
 			return;
+		}
+
+		if ( isset( $assoc_args['agent'] ) ) {
+			$agent_id = AgentResolver::resolve( $assoc_args );
+			if ( null === $agent_id ) {
+				WP_CLI::error( 'Could not resolve --agent to a valid agent.' );
+				return;
+			}
 		}
 
 		$steps = array();
@@ -602,6 +611,9 @@ class PipelinesCommand extends BaseCommand {
 			'pipeline_name' => $pipeline_name,
 			'steps'         => $steps,
 		);
+		if ( null !== $agent_id ) {
+			$input['agent_id'] = $agent_id;
+		}
 
 		if ( $dry_run ) {
 			$input['validate_only'] = true;

--- a/tests/Unit/Abilities/FlowCreationAtomicityTest.php
+++ b/tests/Unit/Abilities/FlowCreationAtomicityTest.php
@@ -8,11 +8,17 @@
 namespace DataMachine\Tests\Unit\Abilities;
 
 use DataMachine\Abilities\AgentAbilities;
+use DataMachine\Abilities\Flow\QueueAbility;
 use DataMachine\Abilities\HandlerAbilities;
+use DataMachine\Api\Flows\FlowScheduling;
+use DataMachine\Cli\Commands\Flows\FlowsCommand;
+use DataMachine\Cli\Commands\PipelinesCommand;
 use DataMachine\Core\Agents\AgentBundler;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\Steps\Settings\SettingsHandler;
+use DataMachine\Engine\Tasks\RecurringScheduler;
+use ReflectionMethod;
 use WP_UnitTestCase;
 
 class AtomicEventImportSettings extends SettingsHandler {
@@ -31,6 +37,16 @@ class AtomicUpsertSettings extends SettingsHandler {
 		return array(
 			'post_type' => array(
 				'type' => 'text',
+			),
+		);
+	}
+}
+
+class AtomicFetchSettings extends SettingsHandler {
+	public static function get_fields(): array {
+		return array(
+			'url' => array(
+				'type' => 'url',
 			),
 		);
 	}
@@ -55,6 +71,18 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 					'label' => 'Ticketmaster',
 				);
 			}
+			if ( null === $step_type || 'upsert' === $step_type ) {
+				$handlers['upsert_event'] = array(
+					'type'  => 'upsert',
+					'label' => 'Upsert Event',
+				);
+			}
+			if ( null === $step_type || 'fetch' === $step_type ) {
+				$handlers['atomic_fetch'] = array(
+					'type'  => 'fetch',
+					'label' => 'Atomic Fetch',
+				);
+			}
 
 			return $handlers;
 		};
@@ -68,8 +96,11 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 			if ( null === $handler_slug || 'ticketmaster' === $handler_slug ) {
 				$settings['ticketmaster'] = new AtomicEventImportSettings();
 			}
-			if ( null === $handler_slug || 'upsert' === $handler_slug ) {
-				$settings['upsert'] = new AtomicUpsertSettings();
+			if ( null === $handler_slug || 'upsert_event' === $handler_slug ) {
+				$settings['upsert_event'] = new AtomicUpsertSettings();
+			}
+			if ( null === $handler_slug || 'atomic_fetch' === $handler_slug ) {
+				$settings['atomic_fetch'] = new AtomicFetchSettings();
 			}
 
 			return $settings;
@@ -91,7 +122,7 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 		);
 
 		$pipeline_config = array();
-		foreach ( array( 'event_import', 'ai', 'upsert' ) as $order => $step_type ) {
+		foreach ( array( 'event_import', 'ai', 'upsert', 'fetch' ) as $order => $step_type ) {
 			$pipeline_step_id                     = $this->pipeline_id . '_' . $step_type;
 			$pipeline_config[ $pipeline_step_id ] = array(
 				'pipeline_step_id' => $pipeline_step_id,
@@ -107,6 +138,7 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 		remove_filter( 'datamachine_handlers', $this->handlers_filter, 10 );
 		remove_filter( 'datamachine_handler_settings', $this->settings_filter, 10 );
 		HandlerAbilities::clearCache();
+		delete_option( 'datamachine_handler_defaults' );
 
 		parent::tear_down();
 	}
@@ -121,8 +153,9 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 		$step_types = array_column( $flow['flow_config'], null, 'step_type' );
 		$this->assertSame( array( 'ticketmaster' ), $step_types['event_import']['handler_slugs'] );
 		$this->assertSame( 'ticketmaster', $step_types['event_import']['handler_configs']['ticketmaster']['source'] );
-		$this->assertSame( array( 'Import upcoming events.' ), $step_types['ai']['prompt_queue'] );
-		$this->assertSame( 'event', $step_types['upsert']['flow_step_settings']['post_type'] );
+		$this->assertSame( array( 'Import upcoming events.' ), $step_types['ai'][ QueueAbility::SLOT_PROMPT_QUEUE ] );
+		$this->assertSame( array( 'upsert_event' ), $step_types['upsert']['handler_slugs'] );
+		$this->assertSame( 'event', $step_types['upsert']['handler_configs']['upsert_event']['post_type'] );
 	}
 
 	public function test_dry_run_executes_deep_validation_without_persisting(): void {
@@ -161,7 +194,7 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 		return array(
 			'plural handler slugs'   => array( 'handler_slugs' ),
 			'plural handler configs' => array( 'handler_configs' ),
-			'stored prompt queue'     => array( 'prompt_queue' ),
+			'stored prompt queue'     => array( QueueAbility::SLOT_PROMPT_QUEUE ),
 		);
 	}
 
@@ -174,6 +207,97 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 
 		$this->assertFalse( $result['success'] );
 		$this->assertStringContainsString( 'Unknown handler_config fields', $result['error'] );
+		$this->assertSame( $before, $this->flowCount() );
+	}
+
+	public function test_empty_user_message_clears_prompt_queue(): void {
+		$input = $this->validInput( 'Empty Message Flow' );
+		$input['step_configs']['ai']['user_message'] = '';
+
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute( $input );
+
+		$this->assertTrue( $result['success'] );
+		$flow       = ( new Flows() )->get_flow( (int) $result['flow_id'] );
+		$step_types = array_column( $flow['flow_config'], null, 'step_type' );
+		$this->assertSame( array(), $step_types['ai'][ QueueAbility::SLOT_PROMPT_QUEUE ] );
+	}
+
+	public function test_nested_creation_preserves_caller_transaction(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( 'SAVEPOINT datamachine_test_caller' );
+
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute( $this->validInput( 'Nested Transaction Flow' ) );
+
+		$this->assertTrue( $result['success'] );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$this->assertNotFalse( $wpdb->query( 'ROLLBACK TO SAVEPOINT datamachine_test_caller' ) );
+		$this->assertNull( ( new Flows() )->get_flow( (int) $result['flow_id'] ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( 'RELEASE SAVEPOINT datamachine_test_caller' );
+	}
+
+	public function test_scheduled_dry_run_rolls_back_action_side_effects(): void {
+		$input = $this->validInput( 'Scheduled Dry Run Flow' );
+		$input['scheduling_config'] = array( 'interval' => 'hourly' );
+		$input['validate_only'] = true;
+		$before = $this->scheduledFlowActionCount();
+
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute( $input );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $before, $this->scheduledFlowActionCount() );
+	}
+
+	public function test_invalid_config_rolls_back_scheduled_action(): void {
+		$input = $this->validInput( 'Scheduled Rollback Flow' );
+		$input['scheduling_config'] = array( 'interval' => 'hourly' );
+		$input['step_configs']['upsert']['handler_config'] = array( 'unknown_field' => 'event' );
+		$before = $this->scheduledFlowActionCount();
+
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute( $input );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( $before, $this->scheduledFlowActionCount() );
+	}
+
+	public function test_scheduling_failure_rolls_back_flow_and_actions(): void {
+		$input = $this->validInput( 'Scheduling Failure Flow' );
+		$input['scheduling_config'] = array( 'interval' => 'one_time' );
+		$flow_count   = $this->flowCount();
+		$action_count = $this->scheduledFlowActionCount();
+
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute( $input );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'Timestamp required', $result['error'] );
+		$this->assertSame( $flow_count, $this->flowCount() );
+		$this->assertSame( $action_count, $this->scheduledFlowActionCount() );
+	}
+
+	public function test_site_default_failure_rolls_back_flow(): void {
+		update_option(
+			'datamachine_handler_defaults',
+			array( 'atomic_fetch' => array( 'url' => 'https://example.com/events' ) )
+		);
+		HandlerAbilities::clearSiteDefaultsCache();
+		$reject_default = static function ( $flow_config ) {
+			foreach ( $flow_config as $step_config ) {
+				if ( in_array( 'atomic_fetch', $step_config['handler_slugs'] ?? array(), true ) ) {
+					return new \WP_Error( 'default_write_failed', 'Forced site-default write failure' );
+				}
+			}
+			return $flow_config;
+		};
+		add_filter( 'datamachine_flow_config_pre_save', $reject_default );
+		$before = $this->flowCount();
+
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute( $this->validInput( 'Default Failure Flow' ) );
+
+		remove_filter( 'datamachine_flow_config_pre_save', $reject_default );
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'Failed to update handler configuration', $result['error'] );
 		$this->assertSame( $before, $this->flowCount() );
 	}
 
@@ -227,6 +351,47 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 		$this->assertContains( 'Owned Export Flow', array_column( $export['bundle']['flows'], 'flow_name' ) );
 	}
 
+	public function test_cli_create_commands_persist_explicit_agent_ownership(): void {
+		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$agent    = AgentAbilities::createAgent(
+			array(
+				'agent_slug' => 'cli-create-owner',
+				'agent_name' => 'CLI Create Owner',
+				'owner_id'   => $owner_id,
+			)
+		);
+		$agent_id = (int) $agent['agent_id'];
+
+		$pipeline_method = new ReflectionMethod( PipelinesCommand::class, 'createPipeline' );
+		$pipeline_method->setAccessible( true );
+		$pipeline_method->invoke(
+			new PipelinesCommand(),
+			array(
+				'name'  => 'CLI Owned Pipeline',
+				'agent' => 'cli-create-owner',
+			)
+		);
+
+		$owned_pipelines = ( new Pipelines() )->get_all_pipelines( null, $agent_id );
+		$this->assertContains( 'CLI Owned Pipeline', array_column( $owned_pipelines, 'pipeline_name' ) );
+		$pipeline_ids = array_column( $owned_pipelines, 'pipeline_id', 'pipeline_name' );
+		$pipeline_id  = (int) $pipeline_ids['CLI Owned Pipeline'];
+
+		$flow_method = new ReflectionMethod( FlowsCommand::class, 'createFlow' );
+		$flow_method->setAccessible( true );
+		$flow_method->invoke(
+			new FlowsCommand(),
+			array(
+				'pipeline_id' => $pipeline_id,
+				'name'        => 'CLI Owned Flow',
+				'agent'       => 'cli-create-owner',
+			)
+		);
+
+		$owned_flows = ( new Flows() )->get_all_flows( null, $agent_id );
+		$this->assertContains( 'CLI Owned Flow', array_column( $owned_flows, 'flow_name' ) );
+	}
+
 	private function validInput( string $flow_name ): array {
 		return array(
 			'pipeline_id'  => $this->pipeline_id,
@@ -240,6 +405,7 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 					'user_message' => 'Import upcoming events.',
 				),
 				'upsert'       => array(
+					'handler_slug'   => 'upsert_event',
 					'handler_config' => array( 'post_type' => 'event' ),
 				),
 			),
@@ -248,5 +414,22 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 
 	private function flowCount(): int {
 		return count( ( new Flows() )->get_flows_for_pipeline( $this->pipeline_id ) );
+	}
+
+	private function scheduledFlowActionCount(): int {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+			return 0;
+		}
+
+		return count(
+			as_get_scheduled_actions(
+				array(
+					'hook'   => FlowScheduling::FLOW_HOOK,
+					'group'  => RecurringScheduler::GROUP,
+					'status' => \ActionScheduler_Store::STATUS_PENDING,
+				),
+				'ids'
+			)
+		);
 	}
 }

--- a/tests/Unit/Abilities/FlowCreationAtomicityTest.php
+++ b/tests/Unit/Abilities/FlowCreationAtomicityTest.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * Flow creation validation and atomicity tests.
+ *
+ * @package DataMachine\Tests\Unit\Abilities
+ */
+
+namespace DataMachine\Tests\Unit\Abilities;
+
+use DataMachine\Abilities\AgentAbilities;
+use DataMachine\Abilities\HandlerAbilities;
+use DataMachine\Core\Agents\AgentBundler;
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Core\Steps\Settings\SettingsHandler;
+use WP_UnitTestCase;
+
+class AtomicEventImportSettings extends SettingsHandler {
+	public static function get_fields(): array {
+		return array(
+			'source' => array(
+				'type'     => 'text',
+				'required' => true,
+			),
+		);
+	}
+}
+
+class AtomicUpsertSettings extends SettingsHandler {
+	public static function get_fields(): array {
+		return array(
+			'post_type' => array(
+				'type' => 'text',
+			),
+		);
+	}
+}
+
+class FlowCreationAtomicityTest extends WP_UnitTestCase {
+
+	private int $pipeline_id;
+	private \Closure $handlers_filter;
+	private \Closure $settings_filter;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$this->handlers_filter = static function ( array $handlers, ?string $step_type ): array {
+			if ( null === $step_type || 'event_import' === $step_type ) {
+				$handlers['ticketmaster'] = array(
+					'type'  => 'event_import',
+					'label' => 'Ticketmaster',
+				);
+			}
+
+			return $handlers;
+		};
+		add_filter(
+			'datamachine_handlers',
+			$this->handlers_filter,
+			10,
+			2
+		);
+		$this->settings_filter = static function ( array $settings, ?string $handler_slug ): array {
+			if ( null === $handler_slug || 'ticketmaster' === $handler_slug ) {
+				$settings['ticketmaster'] = new AtomicEventImportSettings();
+			}
+			if ( null === $handler_slug || 'upsert' === $handler_slug ) {
+				$settings['upsert'] = new AtomicUpsertSettings();
+			}
+
+			return $settings;
+		};
+		add_filter(
+			'datamachine_handler_settings',
+			$this->settings_filter,
+			10,
+			2
+		);
+		HandlerAbilities::clearCache();
+
+		$pipelines         = new Pipelines();
+		$this->pipeline_id = (int) $pipelines->create_pipeline(
+			array(
+				'pipeline_name'   => 'Atomic Flow Creation',
+				'pipeline_config' => array(),
+			)
+		);
+
+		$pipeline_config = array();
+		foreach ( array( 'event_import', 'ai', 'upsert' ) as $order => $step_type ) {
+			$pipeline_step_id                     = $this->pipeline_id . '_' . $step_type;
+			$pipeline_config[ $pipeline_step_id ] = array(
+				'pipeline_step_id' => $pipeline_step_id,
+				'step_type'        => $step_type,
+				'execution_order'  => $order,
+				'label'            => $step_type,
+			);
+		}
+		$pipelines->update_pipeline( $this->pipeline_id, array( 'pipeline_config' => $pipeline_config ) );
+	}
+
+	public function tear_down(): void {
+		remove_filter( 'datamachine_handlers', $this->handlers_filter, 10 );
+		remove_filter( 'datamachine_handler_settings', $this->settings_filter, 10 );
+		HandlerAbilities::clearCache();
+
+		parent::tear_down();
+	}
+
+	public function test_valid_handler_ai_and_upsert_config_is_applied(): void {
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute( $this->validInput( 'Configured Flow' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 3, $result['configured_steps'] );
+
+		$flow       = ( new Flows() )->get_flow( (int) $result['flow_id'] );
+		$step_types = array_column( $flow['flow_config'], null, 'step_type' );
+		$this->assertSame( array( 'ticketmaster' ), $step_types['event_import']['handler_slugs'] );
+		$this->assertSame( 'ticketmaster', $step_types['event_import']['handler_configs']['ticketmaster']['source'] );
+		$this->assertSame( array( 'Import upcoming events.' ), $step_types['ai']['prompt_queue'] );
+		$this->assertSame( 'event', $step_types['upsert']['flow_step_settings']['post_type'] );
+	}
+
+	public function test_dry_run_executes_deep_validation_without_persisting(): void {
+		$before = $this->flowCount();
+		$input  = $this->validInput( 'Dry Run Flow' );
+		$input['validate_only'] = true;
+
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute( $input );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'validate_only', $result['mode'] );
+		$this->assertSame( $before, $this->flowCount() );
+	}
+
+	/**
+	 * @dataProvider malformedAliasProvider
+	 */
+	public function test_malformed_aliases_fail_in_dry_run_and_write_mode( string $alias ): void {
+		foreach ( array( false, true ) as $validate_only ) {
+			$input = $this->validInput( 'Malformed Alias Flow' );
+			$input['step_configs']['event_import'] = array(
+				$alias => array( 'ticketmaster' ),
+			);
+			$input['validate_only'] = $validate_only;
+			$before = $this->flowCount();
+
+			$result = wp_get_ability( 'datamachine/create-flow' )->execute( $input );
+
+			$this->assertFalse( $result['success'] );
+			$this->assertStringContainsString( $alias, $result['error'] );
+			$this->assertSame( $before, $this->flowCount() );
+		}
+	}
+
+	public static function malformedAliasProvider(): array {
+		return array(
+			'plural handler slugs'   => array( 'handler_slugs' ),
+			'plural handler configs' => array( 'handler_configs' ),
+			'stored prompt queue'     => array( 'prompt_queue' ),
+		);
+	}
+
+	public function test_invalid_late_step_rolls_back_the_entire_flow(): void {
+		$input = $this->validInput( 'Rollback Flow' );
+		$input['step_configs']['upsert']['handler_config'] = array( 'unknown_field' => 'event' );
+		$before = $this->flowCount();
+
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute( $input );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'Unknown handler_config fields', $result['error'] );
+		$this->assertSame( $before, $this->flowCount() );
+	}
+
+	public function test_bulk_validation_rejects_invalid_config_before_creating_any_flow(): void {
+		$valid                                             = $this->validInput( 'Valid Bulk Flow' );
+		$invalid                                           = $this->validInput( 'Invalid Bulk Flow' );
+		$invalid['step_configs']['upsert']['handler_config'] = array( 'unknown_field' => 'event' );
+		$before                                            = $this->flowCount();
+
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute(
+			array(
+				'flows' => array( $valid, $invalid ),
+			)
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( $before, $this->flowCount() );
+	}
+
+	public function test_owned_parent_and_child_are_visible_in_agent_export(): void {
+		$agent = AgentAbilities::createAgent(
+			array(
+				'agent_slug' => 'atomic-export-agent',
+				'agent_name' => 'Atomic Export Agent',
+				'owner_id'   => get_current_user_id(),
+			)
+		);
+		$agent_id = (int) $agent['agent_id'];
+
+		$pipeline = wp_get_ability( 'datamachine/create-pipeline' )->execute(
+			array(
+				'pipeline_name' => 'Owned Export Pipeline',
+				'agent_id'      => $agent_id,
+				'steps'         => array( array( 'step_type' => 'ai' ) ),
+			)
+		);
+		$flow = wp_get_ability( 'datamachine/create-flow' )->execute(
+			array(
+				'pipeline_id' => $pipeline['pipeline_id'],
+				'flow_name'   => 'Owned Export Flow',
+				'agent_id'    => $agent_id,
+			)
+		);
+
+		$this->assertTrue( $pipeline['success'] );
+		$this->assertTrue( $flow['success'] );
+
+		$export = ( new AgentBundler() )->export( 'atomic-export-agent' );
+		$this->assertTrue( $export['success'] );
+		$this->assertContains( 'Owned Export Pipeline', array_column( $export['bundle']['pipelines'], 'pipeline_name' ) );
+		$this->assertContains( 'Owned Export Flow', array_column( $export['bundle']['flows'], 'flow_name' ) );
+	}
+
+	private function validInput( string $flow_name ): array {
+		return array(
+			'pipeline_id'  => $this->pipeline_id,
+			'flow_name'    => $flow_name,
+			'step_configs' => array(
+				'event_import' => array(
+					'handler_slug'   => 'ticketmaster',
+					'handler_config' => array( 'source' => 'ticketmaster' ),
+				),
+				'ai'           => array(
+					'user_message' => 'Import upcoming events.',
+				),
+				'upsert'       => array(
+					'handler_config' => array( 'post_type' => 'event' ),
+				),
+			),
+		);
+	}
+
+	private function flowCount(): int {
+		return count( ( new Flows() )->get_flows_for_pipeline( $this->pipeline_id ) );
+	}
+}

--- a/tests/flow-pipeline-create-cli-agent-smoke.php
+++ b/tests/flow-pipeline-create-cli-agent-smoke.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Flow and pipeline create CLI ownership wiring regression test.
+ *
+ * Run with: php tests/flow-pipeline-create-cli-agent-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$root           = dirname( __DIR__ );
+$flows_source   = file_get_contents( $root . '/inc/Cli/Commands/Flows/FlowsCommand.php' );
+$pipeline_source = file_get_contents( $root . '/inc/Cli/Commands/PipelinesCommand.php' );
+$failures       = array();
+
+$assert = static function ( bool $condition, string $message ) use ( &$failures ): void {
+	if ( ! $condition ) {
+		$failures[] = $message;
+	}
+};
+
+$assert( str_contains( $flows_source, "if ( isset( \$assoc_args['agent'] ) )" ), 'flow create checks --agent' );
+$assert( str_contains( $flows_source, 'AgentResolver::resolve( $assoc_args )' ), 'flow create resolves --agent' );
+$assert( str_contains( $flows_source, '$input[\'agent_id\'] = $agent_id;' ), 'flow create passes agent_id to the ability' );
+$assert( str_contains( $pipeline_source, "if ( isset( \$assoc_args['agent'] ) )" ), 'pipeline create checks --agent' );
+$assert( str_contains( $pipeline_source, 'AgentResolver::resolve( $assoc_args )' ), 'pipeline create resolves --agent' );
+$assert( str_contains( $pipeline_source, '$input[\'agent_id\'] = $agent_id;' ), 'pipeline create passes agent_id to the ability' );
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, implode( PHP_EOL, $failures ) . PHP_EOL );
+	exit( 1 );
+}
+
+echo "Flow and pipeline create CLI ownership smoke passed.\n";


### PR DESCRIPTION
## Summary
- run dry-run and write flow creation through the same normalized, deep configuration path
- wrap row creation, step sync/configuration, prompts, scheduling, defaults, and ownership in a transaction that rolls back on any failure
- resolve and persist `--agent` for both flow and pipeline CLI creation

## Root cause
`flows create --dry-run` forced the request through bulk mode, whose validation only checked names and pipeline IDs. Write mode inserted the flow before applying step configuration and returned success even when the existing update-flow-step validation rejected handlers, AI messages, or config fields. The flow and pipeline CLI adapters also never resolved their create-time `--agent` flags, despite the abilities already accepting `agent_id`.

## Design
Single creation now validates the public singular config shape, starts a database transaction, and uses the existing step sync, `UpdateFlowStepAbility`, handler schema validation, prompt queue, site-default, and scheduling paths. Any sync, schedule, or requested configuration error rolls back the complete creation. `validate_only` executes that same path and always rolls back instead of maintaining a parallel shallow validator.

Bulk creation preflights every entry through that same transactional dry-run path before writing any entry. Each subsequent write remains individually transactional. Explicit per-flow and shared ownership continue to propagate.

## Compatibility
The documented create contract is enforced: `handler_slug`, `handler_config`, and `user_message` are accepted along with target selectors. Stored/internal aliases such as `handler_slugs`, `handler_configs`, and `prompt_queue` are now rejected rather than silently producing partial configuration. Existing handler-backed, handler-free, scheduling, defaults, and agent-context behavior continues through the existing abilities.

## CLI behavior
Both `flows create --agent=<slug-or-id>` and `pipelines create --agent=<slug-or-id>` now resolve the agent with `AgentResolver`, fail on an unknown agent, and pass the resolved `agent_id` into creation. A failed flow configuration reaches `WP_CLI::error`; the old post-success configuration warning path is removed.

## Tests
- added integration coverage for handler-backed `event_import`, AI `user_message`, handler-free upsert settings, dry-run non-persistence, malformed aliases in both modes, late-step rollback, bulk preflight, and owned parent/child bundle export visibility
- added focused CLI ownership wiring smoke coverage for flow and pipeline creation
- `php tests/flow-pipeline-create-cli-agent-smoke.php`
- `php tests/create-flow-resolves-owning-agent-smoke.php`
- PHP syntax checks for all changed files
- `git diff --check`

Full PHPUnit and PHPCS were attempted through Homeboy, but the shared Homeboy/WP Codebox Composer artifact failed during bootstrap before loading this plugin: `Class Composer\\Autoload\\ClassLoader not found`. No test assertion or lint finding was produced.

Closes #2917