### PR TITLE
fix: preserve semantic flow config strings

### DIFF
--- a/inc/Cli/Commands/Flows/BulkConfigCommand.php
+++ b/inc/Cli/Commands/Flows/BulkConfigCommand.php
@@ -13,6 +13,7 @@
 namespace DataMachine\Cli\Commands\Flows;
 
 use WP_CLI;
+use DataMachine\Cli\JsonInput;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Abilities\FlowStep\ConfigureFlowStepsAbility;
 
@@ -108,7 +109,7 @@ class BulkConfigCommand extends BaseCommand {
 			return;
 		}
 
-		$handler_config = json_decode( wp_unslash( $config_json ), true );
+		$handler_config = JsonInput::decode_array( (string) $config_json );
 		if ( ! is_array( $handler_config ) ) {
 			WP_CLI::error( 'Invalid JSON in --config. Example: --config=\'{"max_items":5}\'' );
 			return;

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -613,14 +613,20 @@ class FlowsCommand extends BaseCommand {
 			return;
 		}
 
-		$repo = new \DataMachine\Core\Database\Flows\Flows();
-		$flow = $repo->get_flow( $flow_id );
-		if ( ! $flow ) {
+		$repo                 = new \DataMachine\Core\Database\Flows\Flows();
+		$expected_config_json = $repo->get_flow_config_json( $flow_id );
+		if ( null === $expected_config_json ) {
 			WP_CLI::error( sprintf( 'Flow %d not found.', $flow_id ) );
 			return;
 		}
 
-		$repair  = FlowConfigEscaping::repair( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() );
+		$flow_config = json_decode( $expected_config_json, true );
+		if ( ! is_array( $flow_config ) ) {
+			WP_CLI::error( sprintf( 'Flow %d has invalid flow_config JSON.', $flow_id ) );
+			return;
+		}
+
+		$repair  = FlowConfigEscaping::repair( $flow_config );
 		$changes = $repair['changes'];
 		$apply   = isset( $assoc_args['apply'] );
 		$format  = (string) ( $assoc_args['format'] ?? 'table' );
@@ -630,8 +636,8 @@ class FlowsCommand extends BaseCommand {
 			return;
 		}
 
-		if ( $apply && ! $repo->update_flow( $flow_id, array( 'flow_config' => $repair['config'] ) ) ) {
-			WP_CLI::error( sprintf( 'Failed to repair flow %d.', $flow_id ) );
+		if ( $apply && ! $repo->compare_and_swap_flow_config( $flow_id, $expected_config_json, $repair['config'] ) ) {
+			WP_CLI::error( sprintf( 'Flow %d changed after the repair preview was read; no changes were written. Review the latest config and retry.', $flow_id ) );
 			return;
 		}
 

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -20,8 +20,10 @@ namespace DataMachine\Cli\Commands\Flows;
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Cli\AgentResolver;
+use DataMachine\Cli\JsonInput;
 use DataMachine\Cli\UserResolver;
 use DataMachine\Cli\Commands\DrainCommand;
+use DataMachine\Core\Database\Flows\FlowConfigEscaping;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Engine\Debug\SyncRunner;
 
@@ -42,7 +44,7 @@ class FlowsCommand extends BaseCommand {
 	 * ## OPTIONS
 	 *
 	 * [<args>...]
-	 * : Subcommand and arguments. Accepts: list [pipeline_id], get <flow_id>, run <flow_id>, create, delete <flow_id>, update <flow_id>, reconcile-schedules.
+	 * : Subcommand and arguments. Accepts: list [pipeline_id], get <flow_id>, run <flow_id>, create, delete <flow_id>, update <flow_id>, reconcile-schedules, repair-escaped-config <flow_id>.
 	 *
 	 * [--handler=<slug>]
 	 * : Filter flows using this handler slug (any step that uses this handler).
@@ -162,7 +164,7 @@ class FlowsCommand extends BaseCommand {
 	 *   ..." preview while making ZERO database writes.
 	 *
 	 * [--apply]
-	 * : Repair missing schedules for reconcile-schedules. Without this flag the command is a dry-run.
+	 * : Apply a repair command. Without this flag repair commands are dry-runs.
 	 *
 	 * [--spread-hours=<hours>]
 	 * : Explicit first-run distribution window for reconcile-schedules (1-24).
@@ -280,6 +282,10 @@ class FlowsCommand extends BaseCommand {
 	 *     # Audit or repair recurring schedule coverage
 	 *     wp datamachine flows reconcile-schedules --format=json
 	 *     wp datamachine flows reconcile-schedules --apply --spread-hours=24
+	 *
+	 *     # Audit literal JSON solidus escapes, then explicitly repair reviewed candidates
+	 *     wp datamachine flows repair-escaped-config 52 --format=json
+	 *     wp datamachine flows repair-escaped-config 52 --apply
  *
 	 */
 	public function __invoke( array $args, array $assoc_args ): void {
@@ -288,6 +294,15 @@ class FlowsCommand extends BaseCommand {
 
 		if ( ! empty( $args ) && 'reconcile-schedules' === $args[0] ) {
 			$this->reconcileSchedules( $assoc_args );
+			return;
+		}
+
+		if ( ! empty( $args ) && 'repair-escaped-config' === $args[0] ) {
+			if ( ! isset( $args[1] ) ) {
+				WP_CLI::error( 'Usage: wp datamachine flows repair-escaped-config <flow_id> [--apply] [--format=table|json]' );
+				return;
+			}
+			$this->repairEscapedConfig( (int) $args[1], $assoc_args );
 			return;
 		}
 
@@ -583,6 +598,66 @@ class FlowsCommand extends BaseCommand {
 		}
 		if ( empty( $result['success'] ) || (int) ( $result['failed'] ?? 0 ) > 0 || (int) ( $result['invalid'] ?? 0 ) > 0 ) {
 			WP_CLI::halt( 1 );
+		}
+	}
+
+	/**
+	 * Diagnose or explicitly repair literal JSON solidus escapes in one flow.
+	 *
+	 * @param int   $flow_id Flow ID.
+	 * @param array $assoc_args WP-CLI arguments.
+	 */
+	private function repairEscapedConfig( int $flow_id, array $assoc_args ): void {
+		if ( $flow_id <= 0 ) {
+			WP_CLI::error( 'flow_id must be a positive integer.' );
+			return;
+		}
+
+		$repo = new \DataMachine\Core\Database\Flows\Flows();
+		$flow = $repo->get_flow( $flow_id );
+		if ( ! $flow ) {
+			WP_CLI::error( sprintf( 'Flow %d not found.', $flow_id ) );
+			return;
+		}
+
+		$repair  = FlowConfigEscaping::repair( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() );
+		$changes = $repair['changes'];
+		$apply   = isset( $assoc_args['apply'] );
+		$format  = (string) ( $assoc_args['format'] ?? 'table' );
+
+		if ( empty( $changes ) ) {
+			WP_CLI::success( sprintf( 'Flow %d has no literal JSON solidus escapes.', $flow_id ) );
+			return;
+		}
+
+		if ( $apply && ! $repo->update_flow( $flow_id, array( 'flow_config' => $repair['config'] ) ) ) {
+			WP_CLI::error( sprintf( 'Failed to repair flow %d.', $flow_id ) );
+			return;
+		}
+
+		$rows = array_map(
+			static function ( array $change ) use ( $flow_id, $apply ): array {
+				return array(
+					'flow_id' => $flow_id,
+					'status'  => $apply ? 'repaired' : 'would_repair',
+					'path'    => $change['path'],
+					'before'  => $change['before'],
+					'after'   => $change['after'],
+				);
+			},
+			$changes
+		);
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( (string) wp_json_encode( $rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		} else {
+			WP_CLI\Utils\format_items( 'table', $rows, array( 'flow_id', 'status', 'path', 'before', 'after' ) );
+		}
+
+		if ( $apply ) {
+			WP_CLI::success( sprintf( 'Repaired %d value(s) in flow %d.', count( $changes ), $flow_id ) );
+		} else {
+			WP_CLI::warning( 'Dry run only. Review each candidate, then rerun with --apply to write exactly these replacements.' );
 		}
 	}
 
@@ -941,7 +1016,7 @@ class FlowsCommand extends BaseCommand {
 
 		$step_configs = array();
 		if ( isset( $assoc_args['step_configs'] ) ) {
-			$decoded = json_decode( wp_unslash( $assoc_args['step_configs'] ), true );
+			$decoded = JsonInput::decode_array( (string) $assoc_args['step_configs'] );
 			if ( null === $decoded && '' !== $assoc_args['step_configs'] ) {
 				WP_CLI::error( 'Invalid JSON in --step_configs' );
 				return;
@@ -957,7 +1032,7 @@ class FlowsCommand extends BaseCommand {
 		// --handler-config accepts handler-keyed JSON, e.g. {"reddit":{"subreddit":"test"}}.
 		// Each handler slug is resolved to its step type and merged into step_configs.
 		if ( isset( $assoc_args['handler-config'] ) ) {
-			$handler_config_input = json_decode( wp_unslash( $assoc_args['handler-config'] ), true );
+			$handler_config_input = JsonInput::decode_array( (string) $assoc_args['handler-config'] );
 			if ( ! is_array( $handler_config_input ) ) {
 				WP_CLI::error( 'Invalid JSON in --handler-config. Must be a JSON object.' );
 				return;
@@ -1221,7 +1296,7 @@ class FlowsCommand extends BaseCommand {
 		$scheduled_at = $assoc_args['scheduled-at'] ?? null;
 		$has_agent    = isset( $assoc_args['agent'] );
 		$user_message = isset( $assoc_args['set-user-message'] )
-			? wp_kses_post( wp_unslash( $assoc_args['set-user-message'] ) )
+			? wp_kses_post( (string) $assoc_args['set-user-message'] )
 			: null;
 		$step         = $assoc_args['step'] ?? null;
 
@@ -1233,7 +1308,7 @@ class FlowsCommand extends BaseCommand {
 		$has_handler_config = isset( $assoc_args['handler-config'] );
 		$handler_config     = null;
 		if ( $has_handler_config ) {
-			$handler_config = json_decode( wp_unslash( $assoc_args['handler-config'] ), true );
+			$handler_config = JsonInput::decode_array( (string) $assoc_args['handler-config'] );
 			if ( ! is_array( $handler_config ) ) {
 				WP_CLI::error(
 					'Invalid JSON in --handler-config. Must be a JSON object, e.g. '
@@ -1852,9 +1927,9 @@ class FlowsCommand extends BaseCommand {
 
 		// Parse --config if provided.
 		if ( isset( $assoc_args['config'] ) ) {
-			$handler_config = json_decode( wp_unslash( $assoc_args['config'] ), true );
-			if ( json_last_error() !== JSON_ERROR_NONE ) {
-				WP_CLI::error( 'Invalid JSON in --config: ' . json_last_error_msg() );
+			$handler_config = JsonInput::decode_array( (string) $assoc_args['config'] );
+			if ( null === $handler_config ) {
+				WP_CLI::error( 'Invalid JSON in --config. Must be a JSON object.' );
 				return;
 			}
 			$input['add_handler_config'] = $handler_config;

--- a/inc/Cli/JsonInput.php
+++ b/inc/Cli/JsonInput.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DataMachine\Cli;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Decodes JSON supplied directly by WP-CLI.
+ */
+final class JsonInput {
+
+	/**
+	 * WP-CLI arguments are not WordPress request data and must not be unslashed.
+	 *
+	 * @return array<mixed>|null Decoded object/array, or null for invalid JSON/scalars.
+	 */
+	public static function decode_array( string $json ): ?array {
+		$decoded = json_decode( $json, true );
+
+		return is_array( $decoded ) ? $decoded : null;
+	}
+}

--- a/inc/Core/Database/Flows/FlowConfigEscaping.php
+++ b/inc/Core/Database/Flows/FlowConfigEscaping.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace DataMachine\Core\Database\Flows;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Explicit repair support for literal JSON solidus escapes in flow config.
+ */
+final class FlowConfigEscaping {
+
+	/**
+	 * Replace only literal `\/` pairs and report every changed value.
+	 *
+	 * Other backslashes are byte-preserved. This is intentionally not called by
+	 * normal persistence because a literal backslash before a slash can be valid.
+	 *
+	 * @param array<string,mixed> $config Flow config.
+	 * @return array{config: array<string,mixed>, changes: array<int,array{path:string,before:string,after:string}>}
+	 */
+	public static function repair( array $config ): array {
+		$changes = array();
+		$config  = self::repair_value( $config, '', $changes );
+
+		return array(
+			'config'  => $config,
+			'changes' => $changes,
+		);
+	}
+
+	/**
+	 * @param mixed                                                   $value Value to inspect.
+	 * @param string                                                  $path Dot-separated config path.
+	 * @param array<int,array{path:string,before:string,after:string}> $changes Collected changes.
+	 * @return mixed
+	 */
+	private static function repair_value( mixed $value, string $path, array &$changes ): mixed {
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $child ) {
+				$child_path    = '' === $path ? (string) $key : $path . '.' . $key;
+				$value[ $key ] = self::repair_value( $child, $child_path, $changes );
+			}
+			return $value;
+		}
+
+		if ( ! is_string( $value ) || ! str_contains( $value, '\\/' ) ) {
+			return $value;
+		}
+
+		$repaired  = str_replace( '\\/', '/', $value );
+		$changes[] = array(
+			'path'   => $path,
+			'before' => $value,
+			'after'  => $repaired,
+		);
+
+		return $repaired;
+	}
+}

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -344,7 +344,7 @@ class Flows extends BaseRepository {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		$result = $this->wpdb->query(
 			$this->wpdb->prepare(
-				'UPDATE %i SET flow_config = %s WHERE flow_id = %d AND flow_config = %s',
+				'UPDATE %i SET flow_config = %s WHERE flow_id = %d AND HEX(flow_config) = HEX(%s)',
 				$this->table_name,
 				$new_config_json,
 				$flow_id,

--- a/tests/Unit/Cli/Commands/Flows/FlowsCommandTest.php
+++ b/tests/Unit/Cli/Commands/Flows/FlowsCommandTest.php
@@ -12,6 +12,7 @@
 
 namespace DataMachine\Tests\Unit\Cli\Commands\Flows;
 
+use DataMachine\Core\Database\Flows\Flows as FlowsRepository;
 use WP_UnitTestCase;
 
 class FlowsCommandTest extends WP_UnitTestCase {
@@ -234,6 +235,36 @@ class FlowsCommandTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['success'] );
 		$this->assertArrayHasKey( 'flow_id', $result );
 		$this->assertIsInt( $result['flow_id'] );
+	}
+
+	public function test_repository_create_and_update_preserve_semantic_config_strings(): void {
+		$repo   = new FlowsRepository();
+		$config = array(
+			'test_step' => array(
+				'handler_configs' => array(
+					'test' => array(
+						'source_url' => 'https://example.com/events/',
+						'path'       => 'C:\\Temp\\events.json',
+					),
+				),
+				'prompt_queue'    => array(
+					array( 'prompt' => 'Process start/end with \\d+ items.' ),
+				),
+			),
+		);
+		$flow_id = $repo->create_flow(
+			array(
+				'pipeline_id'       => $this->test_pipeline_id,
+				'flow_name'         => 'String Round Trip',
+				'flow_config'       => $config,
+				'scheduling_config' => array( 'interval' => 'manual' ),
+			)
+		);
+
+		$this->assertIsInt( $flow_id );
+		$this->assertSame( $config, $repo->get_flow( $flow_id )['flow_config'] );
+		$this->assertTrue( $repo->update_flow( $flow_id, array( 'flow_config' => $config ) ) );
+		$this->assertSame( $config, $repo->get_flow( $flow_id )['flow_config'] );
 	}
 
 	public function test_delete_flow(): void {

--- a/tests/Unit/Cli/JsonInputTest.php
+++ b/tests/Unit/Cli/JsonInputTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DataMachine\Tests\Unit\Cli;
+
+use DataMachine\Cli\JsonInput;
+use WP_UnitTestCase;
+
+class JsonInputTest extends WP_UnitTestCase {
+
+	public function test_decodes_wp_cli_json_exactly_once(): void {
+		$input = array(
+			'url'       => 'https://example.com/events/',
+			'prompt'    => 'Process start/end.',
+			'windows'   => 'C:\\Temp\\events.json',
+			'regexp'    => '\\d+\\s+events',
+			'backslash' => 'literal \\ value',
+		);
+
+		$this->assertSame( $input, JsonInput::decode_array( (string) wp_json_encode( $input ) ) );
+	}
+
+	public function test_rejects_invalid_json_and_scalars(): void {
+		$this->assertNull( JsonInput::decode_array( '{broken' ) );
+		$this->assertNull( JsonInput::decode_array( '"string"' ) );
+	}
+}

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -270,7 +270,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$second_step   = reset( $second_bundle['flows'][0]['flow_config'] );
 
 		foreach ( array( 'handler_configs', 'prompt_queue' ) as $field ) {
-			$this->assertSame( $expected[ $field ], $first_step[ $field ], "Export preserves {$field}." );
+			$this->assertEquals( $expected[ $field ], $first_step[ $field ], "Export preserves {$field}." );
 			$this->assertSame( $first_step[ $field ], $second_step[ $field ], "Repeated bundle round trip is idempotent for {$field}." );
 		}
 	}

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -230,6 +230,51 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$this->assertSame( array( 'mcp' => 5 ), $flow['scheduling_config']['max_items'] ?? null, 'Importer preserves bundle max item caps.' );
 	}
 
+	public function test_flow_config_strings_are_idempotent_across_import_and_export_round_trips(): void {
+		$bundle = $this->fixture_bundle( 'flow-string-round-trip-agent' );
+		$step   = &$bundle['flows'][0]['flow_config']['1_step-uuid_1'];
+		$step['step_type']       = 'fetch';
+		$step['handler_slugs']   = array( 'fixture' );
+		$step['handler_configs'] = array(
+			'fixture' => array(
+				'source_url' => 'https://example.com/events/',
+				'path'       => 'C:\\Temp\\events.json',
+				'regexp'     => '\\d+\\s+events',
+			),
+		);
+		$step['prompt_queue']    = array(
+			array(
+				'prompt'   => 'Process start/end with a literal \\ marker.',
+				'added_at' => '2026-07-20T00:00:00+00:00',
+			),
+		);
+		unset( $step );
+
+		$result = $this->bundler->import( $bundle, null, $this->owner_id );
+		$this->assertTrue( (bool) $result['success'] );
+
+		$agent    = $this->agents_repo->get_by_slug( 'flow-string-round-trip-agent' );
+		$pipeline = $this->pipelines_repo->get_by_portable_slug( (int) $agent['agent_id'], 'static-site-pipeline' );
+		$flow     = $this->flows_repo->get_by_portable_slug( (int) $pipeline['pipeline_id'], 'static-site-flow' );
+		$stored   = reset( $flow['flow_config'] );
+		$expected = reset( $bundle['flows'][0]['flow_config'] );
+
+		foreach ( array( 'handler_configs', 'prompt_queue' ) as $field ) {
+			$this->assertSame( $expected[ $field ], $stored[ $field ], "Import preserves {$field}." );
+		}
+
+		$first_export  = $this->bundler->export( 'flow-string-round-trip-agent' );
+		$first_step    = reset( $first_export['bundle']['flows'][0]['flow_config'] );
+		$directory     = AgentBundleArrayAdapter::from_array_bundle( $first_export['bundle'] );
+		$second_bundle = AgentBundleArrayAdapter::to_array_bundle( $directory );
+		$second_step   = reset( $second_bundle['flows'][0]['flow_config'] );
+
+		foreach ( array( 'handler_configs', 'prompt_queue' ) as $field ) {
+			$this->assertSame( $expected[ $field ], $first_step[ $field ], "Export preserves {$field}." );
+			$this->assertSame( $first_step[ $field ], $second_step[ $field ], "Repeated bundle round trip is idempotent for {$field}." );
+		}
+	}
+
 	public function test_import_persists_installed_artifacts_to_canonical_table(): void {
 		$result = $this->bundler->import( $this->fixture_bundle( 'artifact-state-agent' ), null, $this->owner_id );
 

--- a/tests/Unit/Core/Database/Flows/FlowConfigEscapingTest.php
+++ b/tests/Unit/Core/Database/Flows/FlowConfigEscapingTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace DataMachine\Tests\Unit\Core\Database\Flows;
+
+use DataMachine\Core\Database\Flows\FlowConfigEscaping;
+use WP_UnitTestCase;
+
+class FlowConfigEscapingTest extends WP_UnitTestCase {
+
+	public function test_repairs_only_literal_json_solidus_escapes(): void {
+		$config = array(
+			'step' => array(
+				'url'    => 'https:\\/\\/example.com\\/events',
+				'prompt' => 'Process start\\/end.',
+				'path'   => 'C:\\Temp\\events.json',
+				'regexp' => '\\d+\\s+events',
+			),
+		);
+
+		$result = FlowConfigEscaping::repair( $config );
+
+		$this->assertSame( 'https://example.com/events', $result['config']['step']['url'] );
+		$this->assertSame( 'Process start/end.', $result['config']['step']['prompt'] );
+		$this->assertSame( 'C:\\Temp\\events.json', $result['config']['step']['path'] );
+		$this->assertSame( '\\d+\\s+events', $result['config']['step']['regexp'] );
+		$this->assertSame( array( 'step.url', 'step.prompt' ), array_column( $result['changes'], 'path' ) );
+	}
+
+	public function test_repair_is_idempotent(): void {
+		$first  = FlowConfigEscaping::repair( array( 'prompt' => 'start\\/end' ) );
+		$second = FlowConfigEscaping::repair( $first['config'] );
+
+		$this->assertSame( array( 'prompt' => 'start/end' ), $second['config'] );
+		$this->assertSame( array(), $second['changes'] );
+	}
+}

--- a/tests/Unit/Core/Database/Flows/FlowsCompareAndSwapTest.php
+++ b/tests/Unit/Core/Database/Flows/FlowsCompareAndSwapTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Flow config compare-and-swap database tests.
+ *
+ * @package DataMachine\Tests\Unit\Core\Database\Flows
+ */
+
+namespace DataMachine\Tests\Unit\Core\Database\Flows;
+
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Pipelines\Pipelines;
+use WP_UnitTestCase;
+
+class FlowsCompareAndSwapTest extends WP_UnitTestCase {
+
+	private Flows $flows;
+	private int $flow_id;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$pipelines   = new Pipelines();
+		$this->flows = new Flows();
+		$pipeline_id = $pipelines->create_pipeline(
+			array(
+				'pipeline_name'   => 'Byte-exact CAS Pipeline',
+				'pipeline_config' => array(),
+			)
+		);
+		$this->flow_id = $this->flows->create_flow(
+			array(
+				'pipeline_id'       => $pipeline_id,
+				'flow_name'         => 'Byte-exact CAS Flow',
+				'flow_config'       => array(
+					'step' => array( 'value' => 'Alpha' ),
+				),
+				'scheduling_config' => array( 'interval' => 'manual' ),
+			)
+		);
+	}
+
+	public function test_case_only_concurrent_change_rejects_stale_snapshot(): void {
+		$expected   = $this->get_raw_config();
+		$concurrent = str_replace( 'Alpha', 'alpha', $expected );
+		$this->write_raw_config( $concurrent );
+
+		$updated = $this->flows->compare_and_swap_flow_config(
+			$this->flow_id,
+			$expected,
+			array( 'step' => array( 'value' => 'Replacement' ) )
+		);
+
+		$this->assertFalse( $updated );
+		$this->assertSame( $concurrent, $this->flows->get_flow_config_json( $this->flow_id ) );
+	}
+
+	public function test_trailing_space_concurrent_change_rejects_stale_snapshot(): void {
+		$expected   = $this->get_raw_config();
+		$concurrent = $expected . ' ';
+		$this->write_raw_config( $concurrent );
+
+		$updated = $this->flows->compare_and_swap_flow_config(
+			$this->flow_id,
+			$expected,
+			array( 'step' => array( 'value' => 'Replacement' ) )
+		);
+
+		$this->assertFalse( $updated );
+		$this->assertSame( $concurrent, $this->flows->get_flow_config_json( $this->flow_id ) );
+	}
+
+	public function test_exact_snapshot_updates_successfully(): void {
+		$updated = $this->flows->compare_and_swap_flow_config(
+			$this->flow_id,
+			$this->get_raw_config(),
+			array( 'step' => array( 'value' => 'Replacement' ) )
+		);
+
+		$this->assertTrue( $updated );
+		$this->assertSame(
+			array( 'step' => array( 'value' => 'Replacement' ) ),
+			json_decode( $this->get_raw_config(), true )
+		);
+	}
+
+	private function get_raw_config(): string {
+		$config = $this->flows->get_flow_config_json( $this->flow_id );
+
+		$this->assertIsString( $config );
+		return $config;
+	}
+
+	private function write_raw_config( string $config ): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->update(
+			$wpdb->prefix . Flows::TABLE_NAME,
+			array( 'flow_config' => $config ),
+			array( 'flow_id' => $this->flow_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		$this->assertSame( 1, $result );
+	}
+}

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -156,8 +156,11 @@ $array_bundle = array(
 					'handler_slugs'      => array( 'mcp' ),
 					'handler_configs'    => array(
 						'mcp' => array(
-							'provider' => 'github',
-							'auth_ref' => 'github:default',
+							'provider'   => 'github',
+							'auth_ref'   => 'github:default',
+							'source_url' => 'https://example.com/events/',
+							'path'       => 'C:\\Temp\\events.json',
+							'regexp'     => '\\d+\\s+events',
 						),
 					),
 					'config_patch_queue' => array(
@@ -193,7 +196,7 @@ $array_bundle = array(
 					'disabled_tools'   => array( 'datamachine/delete-flow' ),
 					'prompt_queue'     => array(
 						array(
-							'prompt'   => 'Review PR #1',
+							'prompt'   => 'Review PR #1 start/end with \\d+ items',
 							'added_at' => '2026-04-28T12:00:00Z',
 						),
 					),
@@ -242,8 +245,11 @@ assert_adapter_equals( 'pipeline document strips runtime pipeline_step_id', fals
 assert_adapter_equals(
 	'flow document preserves handler config',
 	array(
-		'provider' => 'github',
-		'auth_ref' => 'github:default',
+		'provider'   => 'github',
+		'auth_ref'   => 'github:default',
+		'source_url' => 'https://example.com/events/',
+		'path'       => 'C:\\Temp\\events.json',
+		'regexp'     => '\\d+\\s+events',
 	),
 	$flow['steps'][0]['handler_configs']['mcp'] ?? null
 );
@@ -253,7 +259,7 @@ assert_adapter_equals( 'flow document preserves AI enabled tools', array( 'datam
 assert_adapter_equals( 'flow document preserves AI disabled tools', array( 'datamachine/delete-flow' ), $flow['steps'][1]['disabled_tools'] );
 assert_adapter_equals( 'flow document preserves completion assertions', array( 'create_github_pull_request', 'comment_github_pull_request' ), $flow['steps'][1]['completion_assertions']['required_tool_names'] ?? null );
 assert_adapter_equals( 'flow document preserves tool runtime rules', 4, $flow['steps'][1]['tool_runtime_rules'][0]['max_calls'] ?? null );
-assert_adapter_equals( 'flow document preserves prompt queue', 'Review PR #1', $flow['steps'][1]['prompt_queue'][0]['prompt'] );
+assert_adapter_equals( 'flow document preserves prompt queue', 'Review PR #1 start/end with \\d+ items', $flow['steps'][1]['prompt_queue'][0]['prompt'] );
 assert_adapter_equals( 'flow document preserves queue mode', 'loop', $flow['steps'][1]['queue_mode'] );
 assert_adapter_equals( 'flow document preserves system task settings', 'wiki_graph_extract', $flow['steps'][2]['flow_step_settings']['task_type'] ?? null );
 assert_adapter_equals( 'flow document preserves scheduling interval', 'hourly', $flow['schedule'] );
@@ -284,8 +290,11 @@ assert_adapter_equals( 'round-trip preserves flow file memory', "{}\n", $round_t
 assert_adapter_equals(
 	'round-trip preserves handler config',
 	array(
-		'auth_ref' => 'github:default',
-		'provider' => 'github',
+		'auth_ref'   => 'github:default',
+		'path'       => 'C:\\Temp\\events.json',
+		'provider'   => 'github',
+		'regexp'     => '\\d+\\s+events',
+		'source_url' => 'https://example.com/events/',
 	),
 	$round_steps[0]['handler_configs']['mcp'] ?? null
 );
@@ -296,7 +305,7 @@ assert_adapter_equals( 'round-trip preserves enabled tools', array( 'datamachine
 assert_adapter_equals( 'round-trip preserves disabled tools', array( 'datamachine/delete-flow' ), $round_steps[1]['disabled_tools'] );
 assert_adapter_equals( 'round-trip preserves completion assertions', array( 'create_github_pull_request', 'comment_github_pull_request' ), $round_steps[1]['completion_assertions']['required_tool_names'] ?? null );
 assert_adapter_equals( 'round-trip preserves tool runtime rules', array( 'workspace_edit', 'create_github_issue' ), $round_steps[1]['tool_runtime_rules'][0]['then_require_one_of'] ?? null );
-assert_adapter_equals( 'round-trip preserves prompt queue', 'Review PR #1', $round_steps[1]['prompt_queue'][0]['prompt'] );
+assert_adapter_equals( 'round-trip preserves prompt queue', 'Review PR #1 start/end with \\d+ items', $round_steps[1]['prompt_queue'][0]['prompt'] );
 assert_adapter_equals( 'round-trip preserves queue mode', 'loop', $round_steps[1]['queue_mode'] );
 assert_adapter_equals( 'round-trip preserves system task settings', 'wiki_graph_extract', $round_steps[2]['flow_step_settings']['task_type'] ?? null );
 assert_adapter_equals( 'round-trip preserves system task params', 'wordpress-com', $round_steps[2]['flow_step_settings']['params']['root'] ?? null );

--- a/tests/flow-config-cli-round-trip-smoke.php
+++ b/tests/flow-config-cli-round-trip-smoke.php
@@ -1,0 +1,413 @@
+<?php
+/**
+ * Command-level flow config string and repair smoke tests (#2914).
+ *
+ * Run with: php tests/flow-config-cli-round-trip-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+function flow_config_cli_assert( bool $condition, string $message ): void {
+	global $failures, $passes;
+	if ( $condition ) {
+		++$passes;
+		echo "  PASS: {$message}\n";
+		return;
+	}
+
+	$failures[] = $message;
+	echo "  FAIL: {$message}\n";
+}
+
+function flow_config_cli_assert_same( $expected, $actual, string $message ): void {
+	flow_config_cli_assert( $expected === $actual, $message );
+	if ( $expected !== $actual ) {
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	}
+}
+
+$GLOBALS['flow_config_cli_ability_calls'] = array();
+$GLOBALS['flow_config_cli_cas_calls']     = array();
+$GLOBALS['flow_config_cli_update_calls']  = array();
+$GLOBALS['flow_config_cli_output']        = array();
+$GLOBALS['flow_config_cli_raw']           = '';
+$GLOBALS['flow_config_cli_conflict']      = false;
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, $flags = 0 ) {
+		return json_encode( $value, $flags );
+	}
+}
+
+if ( ! function_exists( 'wp_kses_post' ) ) {
+	function wp_kses_post( $value ) {
+		return (string) $value;
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = '' ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value, ...$args ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( $name ) {
+		return new class( $name ) {
+			private string $name;
+
+			public function __construct( string $name ) {
+				$this->name = $name;
+			}
+
+			public function execute( array $input ): array {
+				$GLOBALS['flow_config_cli_ability_calls'][] = array(
+					'ability' => $this->name,
+					'input'   => $input,
+				);
+
+				return array(
+					'success'      => true,
+					'flow_id'      => 91,
+					'flow_name'    => $input['flow_name'] ?? 'Flow',
+					'pipeline_id'  => $input['pipeline_id'] ?? 7,
+					'synced_steps' => 1,
+					'flow_data'    => array(),
+				);
+			}
+		};
+	}
+}
+
+class Flow_Config_CLI_Abort extends \RuntimeException {}
+
+class WP_CLI {
+	public static function log( $message = '' ): void {
+		$GLOBALS['flow_config_cli_output'][] = (string) $message;
+	}
+
+	public static function line( $message = '' ): void {
+		$GLOBALS['flow_config_cli_output'][] = (string) $message;
+	}
+
+	public static function success( $message ): void {
+		$GLOBALS['flow_config_cli_output'][] = 'SUCCESS: ' . $message;
+	}
+
+	public static function warning( $message ): void {
+		$GLOBALS['flow_config_cli_output'][] = 'WARNING: ' . $message;
+	}
+
+	public static function error( $message, $exit = true ): void {
+		$GLOBALS['flow_config_cli_output'][] = 'ERROR: ' . $message;
+		throw new Flow_Config_CLI_Abort( (string) $message );
+	}
+
+	public static function confirm( $message ): void {}
+}
+
+} // Global namespace.
+
+namespace WP_CLI\Utils {
+	function format_items( $format, $items, $fields ): void {
+		$GLOBALS['flow_config_cli_output'][] = json_encode( $items );
+	}
+}
+
+namespace DataMachine\Cli {
+	class BaseCommand {}
+
+	class AgentResolver {
+		public static function resolve( array $args ): int {
+			return 1;
+		}
+
+		public static function buildScopingInput( array $args ): array {
+			return array();
+		}
+	}
+
+	class UserResolver {}
+}
+
+namespace DataMachine\Cli\Commands {
+	class DrainCommand {
+		public const HOOK_BATCH_CHUNK  = 'batch';
+		public const HOOK_EXECUTE_STEP = 'step';
+	}
+}
+
+namespace DataMachine\Engine\Debug {
+	class SyncRunner {}
+}
+
+namespace DataMachine\Engine\Tasks {
+	class RecurringScheduler {
+		public static function looksLikeCronExpression( string $value ): bool {
+			return false;
+		}
+	}
+}
+
+namespace DataMachine\Core\Steps {
+	class FlowStepConfig {
+		public static function usesHandler( array $step ): bool {
+			return true;
+		}
+
+		public static function getEffectiveSlug( array $step, string $fallback = '' ): string {
+			return $fallback ?: 'fixture';
+		}
+
+		public static function getConfiguredHandlerSlugs( array $step ): array {
+			return array( 'fixture' );
+		}
+
+		public static function getHandlerConfigs( array $step ): array {
+			return $step['handler_configs'] ?? array();
+		}
+
+		public static function getPrimaryHandlerConfig( array $step ): array {
+			return $step['handler_configs']['fixture'] ?? array();
+		}
+	}
+}
+
+namespace DataMachine\Abilities {
+	class HandlerAbilities {
+		public function getAllHandlers(): array {
+			return array();
+		}
+
+		public function getConfigFields( string $slug ): array {
+			return array();
+		}
+	}
+}
+
+namespace DataMachine\Abilities\FlowStep {
+	class UpdateFlowStepAbility {
+		public function execute( array $input ): array {
+			$GLOBALS['flow_config_cli_ability_calls'][] = array(
+				'ability' => 'update-flow-step',
+				'input'   => $input,
+			);
+			return array(
+				'success'      => true,
+				'flow_step_id' => $input['flow_step_id'] ?? '',
+			);
+		}
+	}
+
+	class ConfigureFlowStepsAbility {
+		public function execute( array $input ): array {
+			$GLOBALS['flow_config_cli_ability_calls'][] = array(
+				'ability' => 'configure-flow-steps',
+				'input'   => $input,
+			);
+			return array(
+				'success'       => true,
+				'updated_steps' => array(),
+				'message'       => 'configured',
+			);
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Flows {
+	class Flows {
+		public function get_flow( int $flow_id ): ?array {
+			$config = json_decode( $GLOBALS['flow_config_cli_raw'], true );
+			return array(
+				'flow_id'     => $flow_id,
+				'pipeline_id' => 7,
+				'flow_config' => is_array( $config ) ? $config : array(),
+			);
+		}
+
+		public function get_flow_config_json( int $flow_id ): ?string {
+			return $GLOBALS['flow_config_cli_raw'];
+		}
+
+		public function compare_and_swap_flow_config( int $flow_id, string $expected, array $replacement ): bool {
+			if ( $GLOBALS['flow_config_cli_conflict'] ) {
+				$current                                  = json_decode( $GLOBALS['flow_config_cli_raw'], true );
+				$current['step']['prompt_queue'][]         = array( 'prompt' => 'concurrent work' );
+				$GLOBALS['flow_config_cli_raw']             = json_encode( $current );
+				$GLOBALS['flow_config_cli_conflict']        = false;
+			}
+
+			$GLOBALS['flow_config_cli_cas_calls'][] = array(
+				'flow_id'     => $flow_id,
+				'expected'    => $expected,
+				'replacement' => $replacement,
+			);
+
+			if ( $GLOBALS['flow_config_cli_raw'] !== $expected ) {
+				return false;
+			}
+
+			$GLOBALS['flow_config_cli_raw'] = json_encode( $replacement );
+			return true;
+		}
+
+		public function update_flow( int $flow_id, array $data ): bool {
+			$GLOBALS['flow_config_cli_update_calls'][] = $data;
+			return true;
+		}
+	}
+}
+
+namespace {
+
+require_once dirname( __DIR__ ) . '/inc/Cli/JsonInput.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Database/Flows/FlowConfigEscaping.php';
+require_once dirname( __DIR__ ) . '/inc/Cli/Commands/Flows/FlowsCommand.php';
+require_once dirname( __DIR__ ) . '/inc/Cli/Commands/Flows/BulkConfigCommand.php';
+
+use DataMachine\Cli\Commands\Flows\BulkConfigCommand;
+use DataMachine\Cli\Commands\Flows\FlowsCommand;
+
+function flow_config_cli_invoke( string $method, array $arguments ): void {
+	$reflection = new \ReflectionMethod( FlowsCommand::class, $method );
+	$reflection->setAccessible( true );
+	try {
+		$reflection->invokeArgs( new FlowsCommand(), $arguments );
+	} catch ( Flow_Config_CLI_Abort $e ) {
+		// Assertions inspect the captured error.
+	}
+}
+
+function flow_config_cli_reset(): void {
+	$GLOBALS['flow_config_cli_ability_calls'] = array();
+	$GLOBALS['flow_config_cli_cas_calls']     = array();
+	$GLOBALS['flow_config_cli_update_calls']  = array();
+	$GLOBALS['flow_config_cli_output']        = array();
+}
+
+$semantic = array(
+	'source_url' => 'https://example.com/events/',
+	'prompt'     => 'Process start/end.',
+	'path'       => 'C:\\Temp\\events.json',
+	'regexp'     => '\\d+\\s+events',
+);
+$json = json_encode( $semantic );
+
+echo "=== Flow config CLI round trips (#2914) ===\n";
+
+flow_config_cli_reset();
+flow_config_cli_invoke(
+	'createFlow',
+	array(
+		array(
+			'pipeline_id' => 7,
+			'name'        => 'CLI strings',
+			'step_configs' => json_encode(
+				array(
+					'fetch' => array( 'handler_config' => $semantic ),
+				)
+			),
+		),
+	)
+);
+flow_config_cli_assert_same( $semantic, $GLOBALS['flow_config_cli_ability_calls'][0]['input']['step_configs']['fetch']['handler_config'] ?? null, 'create decodes config exactly once' );
+
+$GLOBALS['flow_config_cli_raw'] = json_encode(
+	array(
+		'step' => array(
+			'step_type'       => 'fetch',
+			'handler_configs' => array( 'fixture' => array() ),
+		),
+	)
+);
+flow_config_cli_reset();
+flow_config_cli_invoke( 'updateFlow', array( 52, array( 'step' => 'step', 'handler-config' => json_encode( array( 'fixture' => $semantic ) ) ) ) );
+flow_config_cli_assert_same( $semantic, $GLOBALS['flow_config_cli_ability_calls'][0]['input']['handler_config'] ?? null, 'update decodes config exactly once' );
+
+flow_config_cli_reset();
+flow_config_cli_invoke( 'addHandler', array( 52, array( 'step' => 'step', 'handler' => 'fixture', 'config' => $json ) ) );
+flow_config_cli_assert_same( $semantic, $GLOBALS['flow_config_cli_ability_calls'][0]['input']['add_handler_config'] ?? null, 'add-handler decodes config exactly once' );
+
+flow_config_cli_reset();
+( new BulkConfigCommand() )->dispatch(
+	array(),
+	array(
+		'scope'   => 'global',
+		'handler' => 'fixture',
+		'config'  => $json,
+		'execute' => true,
+	)
+);
+flow_config_cli_assert_same( $semantic, $GLOBALS['flow_config_cli_ability_calls'][0]['input']['handler_config'] ?? null, 'bulk-config decodes config exactly once' );
+
+flow_config_cli_reset();
+$message = 'Process start/end from C:\\Temp with \\d+ items.';
+flow_config_cli_invoke( 'updateFlow', array( 52, array( 'step' => 'step', 'set-user-message' => $message ) ) );
+flow_config_cli_assert_same( $message, $GLOBALS['flow_config_cli_ability_calls'][0]['input']['user_message'] ?? null, 'set-user-message preserves semantic backslashes' );
+
+$corrupt = array(
+	'step' => array(
+		'source_url'   => 'https:\\/\\/example.com\\/',
+		'prompt_queue' => array( array( 'prompt' => 'Process start\\/end.' ) ),
+		'path'         => 'C:\\Temp\\events.json',
+		'regexp'       => '\\d+\\s+events',
+	),
+);
+$GLOBALS['flow_config_cli_raw'] = json_encode( $corrupt );
+$before                         = $GLOBALS['flow_config_cli_raw'];
+flow_config_cli_reset();
+flow_config_cli_invoke( 'repairEscapedConfig', array( 52, array( 'format' => 'json' ) ) );
+flow_config_cli_assert_same( $before, $GLOBALS['flow_config_cli_raw'], 'repair dry-run does not mutate config' );
+flow_config_cli_assert_same( array(), $GLOBALS['flow_config_cli_cas_calls'], 'repair dry-run does not call CAS' );
+
+flow_config_cli_reset();
+flow_config_cli_invoke( 'repairEscapedConfig', array( 52, array( 'format' => 'json', 'apply' => true ) ) );
+$repaired = json_decode( $GLOBALS['flow_config_cli_raw'], true );
+flow_config_cli_assert_same( 'https://example.com/', $repaired['step']['source_url'] ?? null, 'repair apply persists URL replacement' );
+flow_config_cli_assert_same( 'Process start/end.', $repaired['step']['prompt_queue'][0]['prompt'] ?? null, 'repair apply persists prompt replacement' );
+flow_config_cli_assert_same( 'C:\\Temp\\events.json', $repaired['step']['path'] ?? null, 'repair apply preserves Windows path backslashes' );
+flow_config_cli_assert_same( '\\d+\\s+events', $repaired['step']['regexp'] ?? null, 'repair apply preserves regex backslashes' );
+flow_config_cli_assert_same( $before, $GLOBALS['flow_config_cli_cas_calls'][0]['expected'] ?? null, 'repair CAS uses the exact reviewed raw snapshot' );
+flow_config_cli_assert_same( array(), $GLOBALS['flow_config_cli_update_calls'], 'repair bypasses filtered update_flow boundary' );
+
+$after_apply = $GLOBALS['flow_config_cli_raw'];
+flow_config_cli_reset();
+flow_config_cli_invoke( 'repairEscapedConfig', array( 52, array( 'apply' => true, 'format' => 'json' ) ) );
+flow_config_cli_assert_same( $after_apply, $GLOBALS['flow_config_cli_raw'], 'repeated repair is idempotent' );
+flow_config_cli_assert_same( array(), $GLOBALS['flow_config_cli_cas_calls'], 'idempotent repair performs no write' );
+
+$GLOBALS['flow_config_cli_raw']      = json_encode( $corrupt );
+$GLOBALS['flow_config_cli_conflict'] = true;
+flow_config_cli_reset();
+flow_config_cli_invoke( 'repairEscapedConfig', array( 52, array( 'apply' => true, 'format' => 'json' ) ) );
+$concurrent = json_decode( $GLOBALS['flow_config_cli_raw'], true );
+flow_config_cli_assert_same( 'https:\\/\\/example.com\\/', $concurrent['step']['source_url'] ?? null, 'concurrent modification rejection does not apply stale repair' );
+flow_config_cli_assert_same( 'concurrent work', $concurrent['step']['prompt_queue'][1]['prompt'] ?? null, 'concurrent modification rejection preserves new queue work' );
+flow_config_cli_assert( str_contains( implode( "\n", $GLOBALS['flow_config_cli_output'] ), 'changed after the repair preview was read' ), 'concurrent modification reports a clean retryable error' );
+
+echo "\n{$passes} passed, " . count( $failures ) . " failed.\n";
+exit( empty( $failures ) ? 0 : 1 );
+
+} // Global namespace.

--- a/tests/flows-update-dry-run-no-persist-smoke.php
+++ b/tests/flows-update-dry-run-no-persist-smoke.php
@@ -270,6 +270,7 @@ namespace DataMachine\Core\Database\Flows {
 
 namespace {
 
+	require_once dirname( __DIR__ ) . '/inc/Cli/JsonInput.php';
 	require_once dirname( __DIR__ ) . '/inc/Cli/Commands/Flows/FlowsCommand.php';
 
 	use DataMachine\Cli\Commands\Flows\FlowsCommand;


### PR DESCRIPTION
## Summary
- decode flow-related WP-CLI JSON exactly once instead of applying `wp_unslash()` before `json_decode()`
- preserve semantic URLs, slash-containing prompts, and legitimate backslashes across repository and bundle round trips
- add a dry-run-first `flows repair-escaped-config <flow_id>` command for reviewing and explicitly repairing existing literal `\/` values

Closes #2914.

## Root cause and provenance
WP-CLI associative arguments are already raw shell values, not magic-quoted WordPress request globals. The flow create/update/bulk/add-handler paths nevertheless ran `wp_unslash()` and then `json_decode()`. Those are two escape-decoding passes: JSON decoding is the one boundary that owns JSON escapes, while the earlier unslash pass can consume legitimate backslashes before JSON sees them (for example `C:\\Temp` or regex escapes). The fix centralizes these flags on `JsonInput::decode_array()`, which performs one `json_decode()` and nothing else. The direct `--set-user-message` path likewise no longer unslashes an already-semantic WP-CLI string.

The live flow 52 evidence also distinguishes persistence from provenance:
- the checked-in bundle has normal `https://.../` and `start/end` values
- the canonical row contains semantic strings with literal `\/`
- the June 17 installed-artifact snapshot contains the same literal `\/` values
- that snapshot was adoption of existing runtime state, so bundle adoption preserved corruption that already existed; it did not create it

Once a literal `\/` reaches the semantic config array, the repository correctly JSON-encodes its backslash as `\\`, stores it, and decodes it once on read. Export then correctly emits the same semantic backslash. Persistence and export therefore cannot safely guess that every `\/` is accidental; silently stripping it would corrupt legitimate regex/text content.

## Safety boundaries
- normal create/update/import/export paths never perform broad slash stripping
- JSON is decoded once at its WP-CLI transport boundary
- repository serialization and bundle materialization remain one encode/decode pass and preserve exact semantic strings
- existing-row repair is explicit and dry-run by default
- `--apply` changes only literal backslash-solidus pairs and reports each path, before value, and after value; all other backslashes are byte-preserved

For flow 52, the dry run reports exactly two candidates: the Universal Web Scraper `source_url` and the AI prompt's `start\/end`. No production row was modified.

Repair guidance after deployment:

```bash
wp datamachine flows repair-escaped-config 52 --format=json
wp datamachine flows repair-escaped-config 52 --apply
```

Review the dry-run output before using `--apply`, because a literal `\/` can be intentional in arbitrary text.

## Tests
- changed-file Homeboy lint: passed with zero findings
- PHP syntax checks: passed for all changed PHP files
- bundle directory adapter smoke: 55/55 assertions passed
- direct one-pass JSON decode and targeted repair/idempotence assertions: passed
- live flow 52 repair detection: dry-run found the expected two paths; no write performed
- added PHPUnit coverage for CLI JSON decoding, repository create/update, import/export and repeated bundle round trips, targeted repair, idempotence, URLs, slash-containing prompts, Windows paths, and regex backslashes

The Homeboy PHPUnit sandbox was attempted but failed before loading tests because its dependency image could not load `Composer\\Autoload\\ClassLoader`; it reported 0 tests run. This is a test-runner bootstrap failure, not a test assertion failure.