### PR TITLE
fix: consume authoritative tool bindings

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -794,16 +794,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "c1183c44f7d6ef21e162b5ac42532c27f8ff7d22"
+                "reference": "a4765649ca3cd2dda78aeec35c72b696e2480fa9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/c1183c44f7d6ef21e162b5ac42532c27f8ff7d22",
-                "reference": "c1183c44f7d6ef21e162b5ac42532c27f8ff7d22",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/a4765649ca3cd2dda78aeec35c72b696e2480fa9",
+                "reference": "a4765649ca3cd2dda78aeec35c72b696e2480fa9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
+            },
+            "replace": {
+                "automattic/agents-api": "self.version"
             },
             "require-dev": {
                 "phpstan/phpstan": "^2.0",
@@ -824,6 +827,8 @@
                     "phpstan analyse --no-progress --memory-limit=2G"
                 ],
                 "smoke": [
+                    "php tests/composer-autoload-smoke.php",
+                    "php tests/bootstrap-version-skew-smoke.php",
                     "php tests/bootstrap-smoke.php",
                     "php tests/message-envelope-smoke.php",
                     "php tests/message-coalesce-smoke.php",
@@ -884,9 +889,12 @@
                     "php tests/conversation-loop-smoke.php",
                     "php tests/provider-turn-adapter-smoke.php",
                     "php tests/default-provider-turn-adapter-smoke.php",
+                    "php tests/agents-chat-ability-smoke.php",
                     "php tests/default-agents-chat-handler-smoke.php",
+                    "php tests/tool-observability-smoke.php",
                     "php tests/ability-tool-executor-smoke.php",
                     "php tests/ability-tool-ceiling-smoke.php",
+                    "php tests/ability-tool-capability-denied-event-smoke.php",
                     "php tests/tool-mediation-runner-smoke.php",
                     "php tests/conversation-loop-tool-execution-smoke.php",
                     "php tests/tool-call-gate-smoke.php",
@@ -922,8 +930,10 @@
                     "php tests/workflow-as-branch-smoke.php",
                     "php tests/workflow-branch-concurrency-gate-smoke.php",
                     "php tests/workflow-scoped-drain-smoke.php",
+                    "php tests/workflow-run-awaiter-smoke.php",
                     "php tests/workflow-async-branch-payload-smoke.php",
                     "php tests/workflow-async-loopback-target-smoke.php",
+                    "php tests/workflow-async-runner-dispatch-result-smoke.php",
                     "php tests/workflow-reconcile-race-smoke.php",
                     "php tests/workflow-lifecycle-smoke.php",
                     "php tests/agents-workflow-ability-smoke.php",
@@ -946,7 +956,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-07-08T14:21:40+00:00"
+            "time": "2026-07-20T23:17:53+00:00"
         }
     ],
     "packages-dev": [

--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -61,12 +61,14 @@ class ToolExecutor {
 		int $agent_id = 0,
 		array $client_context = array()
 	): array {
-		$core           = new WP_Agent_Tool_Execution_Core();
-		$execution      = new ToolExecutionCore();
+		$core                             = new WP_Agent_Tool_Execution_Core();
+		$execution                        = new ToolExecutionCore();
+		$caller_context                   = $payload;
+		unset( $caller_context['client_context'] );
 		$tool_context                   = array_merge( $client_context, $payload );
 		$tool_context['client_context'] = $client_context;
-		$tool_context['caller_context'] = $payload;
-		$prepared       = $core->prepareWP_Agent_Tool_Call( $tool_name, $tool_parameters, $available_tools, $tool_context );
+		$tool_context['caller_context'] = $caller_context;
+		$prepared                         = $core->prepareWP_Agent_Tool_Call( $tool_name, $tool_parameters, $available_tools, $tool_context );
 		if ( empty( $prepared['ready'] ) ) {
 			unset( $prepared['ready'] );
 			return $prepared;

--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -63,7 +63,9 @@ class ToolExecutor {
 	): array {
 		$core           = new WP_Agent_Tool_Execution_Core();
 		$execution      = new ToolExecutionCore();
-		$tool_context   = array_merge( $client_context, $payload );
+		$tool_context                   = array_merge( $client_context, $payload );
+		$tool_context['client_context'] = $client_context;
+		$tool_context['caller_context'] = $payload;
 		$prepared       = $core->prepareWP_Agent_Tool_Call( $tool_name, $tool_parameters, $available_tools, $tool_context );
 		if ( empty( $prepared['ready'] ) ) {
 			unset( $prepared['ready'] );

--- a/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
+++ b/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
@@ -306,6 +306,49 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 		$this->assertSame( array( 'calling_user_id' ), $result['metadata']['missing_parameters'] ?? array() );
 	}
 
+	public function test_caller_context_excludes_frontend_controlled_client_context(): void {
+		$tools = array(
+			'context_boundary_tool' => array(
+				'class'              => TestToolHandler::class,
+				'method'             => 'handle_tool_call',
+				'parameters'         => array(
+					'type'       => 'object',
+					'required'   => array( 'frontend_user_id' ),
+					'properties' => array(
+						'trusted_user_id'  => array( 'type' => 'integer' ),
+						'frontend_user_id' => array( 'type' => 'integer' ),
+					),
+				),
+				'parameter_bindings' => array(
+					'trusted_user_id'  => array(
+						'source'        => 'caller_context',
+						'path'          => 'client_context.calling_user_id',
+						'authoritative' => true,
+					),
+					'frontend_user_id' => array(
+						'source' => 'client_context',
+						'path'   => 'calling_user_id',
+					),
+				),
+			),
+		);
+		$client_context = array( 'calling_user_id' => 999 );
+
+		$result = ToolExecutor::executeTool(
+			'context_boundary_tool',
+			array( 'trusted_user_id' => 777 ),
+			$tools,
+			array( 'client_context' => $client_context ),
+			'chat',
+			0,
+			$client_context
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertArrayNotHasKey( 'trusted_user_id', $result['result']['data'] ?? array() );
+		$this->assertSame( 999, $result['result']['data']['frontend_user_id'] ?? null );
+	}
+
 	public function test_provider_schema_excludes_authoritative_caller_context_parameters(): void {
 		$request = new WP_Agent_Provider_Turn_Request(
 			array( array( 'role' => 'user', 'content' => 'Inspect context.' ) ),

--- a/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
+++ b/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
@@ -8,6 +8,7 @@
 namespace DataMachine\Tests\Unit\AI\Tools;
 
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters;
+use AgentsAPI\AI\WP_Agent_Provider_Turn_Request;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 use DataMachine\Engine\AI\Tools\ToolExecutor;
@@ -236,6 +237,85 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( 42, $result['result']['data']['query'] ?? null );
+	}
+
+	public function test_execute_tool_applies_authoritative_caller_context_bindings(): void {
+		$tools = $this->authoritativeCallerContextTools();
+
+		$injected = ToolExecutor::executeTool(
+			'caller_context_tool',
+			array( 'query' => 'model query' ),
+			$tools,
+			array(
+				'calling_user_id' => 42,
+				'bound_query'     => 'context query',
+			)
+		);
+		$override_attempt = ToolExecutor::executeTool(
+			'caller_context_tool',
+			array(
+				'calling_user_id' => 999,
+				'query'           => 'model query',
+			),
+			$tools,
+			array(
+				'calling_user_id' => 42,
+				'bound_query'     => 'context query',
+			)
+		);
+
+		$this->assertTrue( $injected['success'] );
+		$this->assertSame( 42, $injected['result']['data']['calling_user_id'] ?? null );
+		$this->assertSame( 'model query', $injected['result']['data']['query'] ?? null );
+		$this->assertTrue( $override_attempt['success'] );
+		$this->assertSame( 42, $override_attempt['result']['data']['calling_user_id'] ?? null );
+		$this->assertSame( 'model query', $override_attempt['result']['data']['query'] ?? null );
+	}
+
+	public function test_execute_tool_preserves_authoritative_caller_context_zero(): void {
+		$result = ToolExecutor::executeTool(
+			'caller_context_tool',
+			array(
+				'calling_user_id' => 999,
+				'query'           => 'model query',
+			),
+			$this->authoritativeCallerContextTools(),
+			array(
+				'calling_user_id' => 0,
+				'bound_query'     => 'context query',
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 0, $result['result']['data']['calling_user_id'] ?? null );
+	}
+
+	public function test_execute_tool_fails_closed_without_authoritative_caller_context(): void {
+		$result = ToolExecutor::executeTool(
+			'caller_context_tool',
+			array(
+				'calling_user_id' => 999,
+				'query'           => 'model query',
+			),
+			$this->authoritativeCallerContextTools(),
+			array( 'bound_query' => 'context query' )
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'missing_required_parameters', $result['metadata']['error_type'] ?? null );
+		$this->assertSame( array( 'calling_user_id' ), $result['metadata']['missing_parameters'] ?? array() );
+	}
+
+	public function test_provider_schema_excludes_authoritative_caller_context_parameters(): void {
+		$request = new WP_Agent_Provider_Turn_Request(
+			array( array( 'role' => 'user', 'content' => 'Inspect context.' ) ),
+			$this->authoritativeCallerContextTools()
+		);
+		$schema = $request->toolDeclarations()['caller_context_tool']['parameters'] ?? array();
+
+		$this->assertArrayNotHasKey( 'calling_user_id', $schema['properties'] ?? array() );
+		$this->assertArrayHasKey( 'query', $schema['properties'] ?? array() );
+		$this->assertSame( array( 'query' ), $schema['required'] ?? array() );
 	}
 
 	public function test_execute_tool_does_not_satisfy_required_params_from_ambient_context_keys(): void {
@@ -639,6 +719,36 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 		);
 	}
 
+	private function authoritativeCallerContextTools(): array {
+		return array(
+			'caller_context_tool' => array(
+				'name'               => 'caller_context_tool',
+				'class'              => TestToolHandler::class,
+				'method'             => 'handle_tool_call',
+				'description'        => 'Inspect caller context.',
+				'parameters'         => array(
+					'type'       => 'object',
+					'required'   => array( 'calling_user_id', 'query' ),
+					'properties' => array(
+						'calling_user_id' => array( 'type' => 'integer' ),
+						'query'           => array( 'type' => 'string' ),
+					),
+				),
+				'parameter_bindings' => array(
+					'calling_user_id' => array(
+						'source'        => 'caller_context',
+						'path'          => 'calling_user_id',
+						'authoritative' => true,
+					),
+					'query'           => array(
+						'source' => 'caller_context',
+						'path'   => 'bound_query',
+					),
+				),
+			),
+		);
+	}
+
 	private function invokeValidateMethod( array $tool_parameters, array $tool_def ): array {
 		return WP_Agent_Tool_Parameters::validateRequiredParameters( $tool_parameters, $tool_def );
 	}
@@ -649,7 +759,7 @@ class TestToolHandler {
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
 		return array(
 			'success'   => true,
-			'data'      => array( 'query' => $parameters['query'] ?? '' ),
+			'data'      => $parameters,
 			'tool_name' => 'test_tool',
 		);
 	}

--- a/tests/tool-executor-ability-native-smoke.php
+++ b/tests/tool-executor-ability-native-smoke.php
@@ -165,6 +165,7 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 	require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Runtime/class-wp-agent-citation-metadata.php';
 	require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-result.php';
 	require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-executor.php';
+	require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-executor-registry.php';
 	require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-execution-core.php';
 	require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Tools/class-wp-agent-action-policy.php';
 	require_once dirname( __DIR__ ) . '/vendor/wordpress/agents-api/src/Workspace/class-wp-agent-workspace-scope.php';


### PR DESCRIPTION
## Summary
- update `wordpress/agents-api` from `c1183c44` to merged authoritative binding contract `a4765649`
- expose trusted Data Machine payload as the generic `caller_context` binding root while preserving legacy flat and namespaced client context behavior
- cover authoritative caller injection, model override rejection, explicit zero, missing-context fail-closed behavior, ordinary caller-wins bindings, and provider schema filtering
- update the standalone ToolExecutor smoke bootstrap for the dependency's executor registry

## Compatibility
Ordinary parameter bindings retain model/caller-wins precedence. Existing legacy flat context bindings remain available, while new structured `caller_context` bindings resolve only from the trusted loop payload and `client_context` remains separately namespaced. No product-specific vocabulary or behavior is introduced.

## Dependency
- `wordpress/agents-api`: `c1183c44f7d6ef21e162b5ac42532c27f8ff7d22` -> `a4765649ca3cd2dda78aeec35c72b696e2480fa9`
- includes Automattic/agents-api#447

## Test Evidence
- `vendor/bin/phpcs` passes for the full repository
- `composer validate --strict` passes with the repository's existing version-field warning
- `composer install --dry-run` passes
- `php tests/tool-executor-ability-native-smoke.php` passes: 46 assertions
- `php tests/calling-user-id-payload-smoke.php` passes: 11 assertions
- `php tests/chat-caller-context-smoke.php` passes
- Agents API `tool-runtime-smoke.php` passes: 114 assertions
- Agents API `provider-turn-adapter-smoke.php` passes: 52 assertions
- Agents API `default-provider-turn-adapter-smoke.php` passes: 92 assertions
- focused and full Homeboy PHPUnit attempts are blocked before test bootstrap by Extra-Chill/homeboy-extensions#2322: `Composer\\Autoload\\ClassLoader` is missing in the Codebox runtime

Fixes #2925