### PR TITLE
fix: preserve transcript and approval origins

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -12,7 +12,9 @@ use DataMachine\Api\Chat\ChatOrchestrator;
 use DataMachine\Core\Agents\AgentIdentity;
 use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\PluginSettings;
+use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
 use WP_Error;
 
 defined( 'ABSPATH' ) || exit;
@@ -132,6 +134,11 @@ class AgentsChatHandler {
 			return new WP_Error( 'model_required', __( 'AI model is required. Set a default in Data Machine settings.', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
+		$workspace = $this->resolveTranscriptWorkspace( $input );
+		if ( is_wp_error( $workspace ) ) {
+			return $workspace;
+		}
+
 		$result = ChatOrchestrator::processChat(
 			$message,
 			sanitize_text_field( $provider ),
@@ -155,6 +162,7 @@ class AgentsChatHandler {
 				'event_sink'            => $input['event_sink'] ?? null,
 				'session_owner'         => is_array( $input['session_owner'] ?? null ) ? $input['session_owner'] : null,
 				'transcript_owner'      => is_array( $input['transcript_owner'] ?? null ) ? $input['transcript_owner'] : null,
+				'workspace'             => $workspace,
 			)
 		);
 
@@ -241,6 +249,35 @@ class AgentsChatHandler {
 		}
 
 		return $identity->owner_id;
+	}
+
+	/**
+	 * Resolve the canonical transcript workspace from trusted runtime input.
+	 *
+	 * Opaque client context is intentionally ignored. Transport adapters that
+	 * select a workspace must place the canonical value at the top-level input.
+	 *
+	 * @param array $input Canonical agents/chat input.
+	 * @return WP_Agent_Workspace_Scope|WP_Error
+	 */
+	private function resolveTranscriptWorkspace( array $input ): WP_Agent_Workspace_Scope|WP_Error {
+		if ( ! array_key_exists( 'workspace', $input ) ) {
+			return WordPressWorkspaceScope::current();
+		}
+
+		if ( $input['workspace'] instanceof WP_Agent_Workspace_Scope ) {
+			return $input['workspace'];
+		}
+
+		if ( ! is_array( $input['workspace'] ) ) {
+			return new WP_Error( 'invalid_transcript_workspace', __( 'Transcript workspace must be a canonical workspace object.', 'data-machine' ), array( 'status' => 400 ) );
+		}
+
+		try {
+			return WP_Agent_Workspace_Scope::from_array( $input['workspace'] );
+		} catch ( \InvalidArgumentException $exception ) {
+			return new WP_Error( 'invalid_transcript_workspace', $exception->getMessage(), array( 'status' => 400 ) );
+		}
 	}
 
 	/**

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -17,6 +17,7 @@
 namespace DataMachine\Api\Chat;
 
 use AgentsAPI\AI\WP_Agent_Execution_Principal;
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
 use DataMachine\Abilities\Chat\ChatTranscriptOwner;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
@@ -77,6 +78,10 @@ class ChatOrchestrator {
 		$calling_user_id      = array_key_exists( 'calling_user_id', $options ) ? max( 0, (int) $options['calling_user_id'] ) : $user_id;
 		$modes                = ToolPolicyResolver::normalizeModes( ! empty( $options['modes'] ) ? $options['modes'] : array( $options['mode'] ?? ToolPolicyResolver::MODE_CHAT ) );
 		$mode                 = implode( ',', $modes );
+		$workspace            = $options['workspace'] ?? WordPressWorkspaceScope::current();
+		if ( ! $workspace instanceof WP_Agent_Workspace_Scope ) {
+			return new WP_Error( 'invalid_transcript_workspace', __( 'A canonical transcript workspace is required.', 'data-machine' ), array( 'status' => 400 ) );
+		}
 		$transcript_owner     = ChatTranscriptOwner::resolve_for_request( $options, $user_id );
 		if ( is_wp_error( $transcript_owner ) ) {
 			return $transcript_owner;
@@ -118,6 +123,14 @@ class ChatOrchestrator {
 				);
 			}
 
+			if ( (string) ( $session['workspace_type'] ?? '' ) !== $workspace->workspace_type || (string) ( $session['workspace_id'] ?? '' ) !== $workspace->workspace_id ) {
+				return new WP_Error(
+					'session_not_found',
+					__( 'Session not found', 'data-machine' ),
+					array( 'status' => 404 )
+				);
+			}
+
 			$messages         = $session['messages'];
 			$session_metadata = $session['metadata'] ?? array();
 			if ( empty( $options['mode'] ) && ! empty( $session['mode'] ) ) {
@@ -125,7 +138,7 @@ class ChatOrchestrator {
 			}
 		} else {
 			// Check for recent pending session to prevent duplicates from timeout retries.
-			$pending_session = $chat_db->get_recent_pending_session( WordPressWorkspaceScope::current(), $user_id, 600, $mode, $acting_token_id, $transcript_owner );
+			$pending_session = $chat_db->get_recent_pending_session( $workspace, $user_id, 600, $mode, $acting_token_id, $transcript_owner );
 
 			if ( $pending_session ) {
 				$session_id       = $pending_session['session_id'];
@@ -144,7 +157,7 @@ class ChatOrchestrator {
 					)
 				);
 			} else {
-				$create_result = self::createSession( $user_id, '', $agent_id, $mode, $transcript_owner );
+				$create_result = self::createSession( $user_id, '', $agent_id, $mode, $transcript_owner, $workspace );
 
 				if ( is_wp_error( $create_result ) ) {
 					return $create_result;
@@ -750,7 +763,7 @@ class ChatOrchestrator {
 	 * @param string $source  Optional source identifier.
 	 * @return string|WP_Error Session ID on success, WP_Error on failure.
 	 */
-	private static function createSession( int $user_id, string $source = '', int $agent_id = 0, string $mode = ToolPolicyResolver::MODE_CHAT, ?array $transcript_owner = null ): string|WP_Error {
+	private static function createSession( int $user_id, string $source = '', int $agent_id = 0, string $mode = ToolPolicyResolver::MODE_CHAT, ?array $transcript_owner = null, ?WP_Agent_Workspace_Scope $workspace = null ): string|WP_Error {
 		// Comma-joined multi-mode strings ('cluckin-chuck,chat') survive intact
 		// here so processContinue can later parse them back into a modes array.
 		// Single-mode strings still get sanitize_key'd for the usual safety.
@@ -794,8 +807,9 @@ class ChatOrchestrator {
 		}
 
 		$agent_slug = ConversationStoreFactory::resolve_agent_slug_for_transcript( $agent_id );
+		$workspace  = $workspace ?? WordPressWorkspaceScope::current();
 		$input      = array(
-			'workspace' => WordPressWorkspaceScope::current()->to_array(),
+			'workspace' => $workspace->to_array(),
 			'agent'     => $agent_slug,
 			'context'   => $mode,
 			'principal' => WP_Agent_Execution_Principal::user_session(
@@ -803,7 +817,7 @@ class ChatOrchestrator {
 				$agent_slug,
 				WP_Agent_Execution_Principal::REQUEST_CONTEXT_CHAT,
 				array(),
-				WordPressWorkspaceScope::current()->key()
+				$workspace->key()
 			),
 			'metadata'  => array(
 				'started_at'    => current_time( 'mysql', true ),

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -594,15 +594,13 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 * @return string Session ID (UUID), or empty string on failure.
 	 */
 	public function create_session_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, string $agent_slug = '', array $metadata = array(), string $context = 'chat' ): string {
-		unset( $workspace );
-
 		$transcript_owner = self::principal_owner_to_transcript_owner( $owner );
 		if ( null === $transcript_owner ) {
 			return '';
 		}
 
 		$metadata['transcript_owner'] = $transcript_owner;
-		return $this->create_session( WordPressWorkspaceScope::current(), (int) $transcript_owner['user_id'], $agent_slug, $metadata, $context );
+		return $this->create_session( $workspace, (int) $transcript_owner['user_id'], $agent_slug, $metadata, $context );
 	}
 
 	/**
@@ -898,8 +896,6 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 * @return array<int,array<string,mixed>> Session rows.
 	 */
 	public function list_sessions_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, array $args = array() ): array {
-		unset( $workspace );
-
 		$transcript_owner = self::principal_owner_to_transcript_owner( $owner );
 		if ( null === $transcript_owner ) {
 			return array();
@@ -907,7 +903,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 
 		$args['transcript_owner'] = $transcript_owner;
 		$args['owner_only']       = true;
-		return $this->list_sessions( WordPressWorkspaceScope::current(), (int) $transcript_owner['user_id'], $args );
+		return $this->list_sessions( $workspace, (int) $transcript_owner['user_id'], $args );
 	}
 
 	/**
@@ -919,15 +915,16 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 * @return array<string,mixed>|null Session row, or null when missing/not owned.
 	 */
 	public function get_session_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, string $session_id ): ?array {
-		unset( $workspace );
-
 		$transcript_owner = self::principal_owner_to_transcript_owner( $owner );
 		if ( null === $transcript_owner ) {
 			return null;
 		}
 
 		$session = $this->get_session( $session_id );
-		if ( ! is_array( $session ) || ! self::session_matches_owner( $session, $transcript_owner ) ) {
+		if ( ! is_array( $session )
+			|| (string) ( $session['workspace_type'] ?? '' ) !== $workspace->workspace_type
+			|| (string) ( $session['workspace_id'] ?? '' ) !== $workspace->workspace_id
+			|| ! self::session_matches_owner( $session, $transcript_owner ) ) {
 			return null;
 		}
 

--- a/inc/Engine/AI/Actions/PendingActionHelper.php
+++ b/inc/Engine/AI/Actions/PendingActionHelper.php
@@ -161,7 +161,8 @@ class PendingActionHelper {
 			'resolver_grants' => $grants,
 			'creator'         => $payload['creator'],
 			'agent'           => $payload['agent'],
-			'metadata'        => $payload['metadata'],
+			'workspace'       => $stored_payload['workspace'] ?? null,
+			'metadata'        => $stored_payload['metadata'] ?? $payload['metadata'],
 			'created_at'      => gmdate( 'c', $created_at ),
 			'expires_at'      => null !== $expires_at ? gmdate( 'c', $expires_at ) : null,
 		);

--- a/inc/Engine/AI/Actions/PendingActionStore.php
+++ b/inc/Engine/AI/Actions/PendingActionStore.php
@@ -201,6 +201,12 @@ class PendingActionStore {
 		$context              = is_array( $payload['context'] ?? null ) ? $payload['context'] : array();
 		$context['wordpress'] = $context['wordpress'] ?? WordPressWorkspaceScope::metadata();
 		$payload['context']   = $context;
+		$metadata             = is_array( $payload['metadata'] ?? null ) ? $payload['metadata'] : array();
+		$datamachine          = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
+		$datamachine_context  = is_array( $datamachine['context'] ?? null ) ? $datamachine['context'] : array();
+		$datamachine['context'] = array_replace_recursive( $datamachine_context, $context );
+		$metadata['datamachine'] = $datamachine;
+		$payload['metadata']     = $metadata;
 
 		if ( ! self::has_database() ) {
 			if ( ! self::allows_transient_fallback() ) {

--- a/inc/Engine/AI/Actions/PendingActionStore.php
+++ b/inc/Engine/AI/Actions/PendingActionStore.php
@@ -199,7 +199,7 @@ class PendingActionStore {
 			: WordPressWorkspaceScope::current();
 		$payload['workspace'] = $workspace->to_array();
 		$context              = is_array( $payload['context'] ?? null ) ? $payload['context'] : array();
-		$context['wordpress'] = $context['wordpress'] ?? WordPressWorkspaceScope::metadata();
+		$context['wordpress'] = WordPressWorkspaceScope::metadata();
 		$payload['context']   = $context;
 		$metadata             = is_array( $payload['metadata'] ?? null ) ? $payload['metadata'] : array();
 		$datamachine          = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();

--- a/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
+++ b/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
@@ -258,6 +258,12 @@ class ResolvePendingActionAbility {
 			);
 		}
 
+		$origin_blog_id = self::originBlogIdFromInput( $input );
+		$current_blog_id = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+		if ( empty( $input['_origin_routed'] ) && $origin_blog_id > 0 && $origin_blog_id !== $current_blog_id ) {
+			return self::resolveAtOrigin( $input, $origin_blog_id );
+		}
+
 		$decision = self::approvalDecisionFromValue( $decision_value );
 		if ( null === $decision ) {
 			return array(
@@ -273,6 +279,14 @@ class ResolvePendingActionAbility {
 			return array(
 				'success'   => false,
 				'error'     => 'Pending action not found or expired.',
+				'action_id' => $action_id,
+			);
+		}
+
+		if ( $origin_blog_id > 0 && ! self::payloadMatchesOrigin( $payload, $origin_blog_id ) ) {
+			return array(
+				'success'   => false,
+				'error'     => 'Pending action origin could not be verified.',
 				'action_id' => $action_id,
 			);
 		}
@@ -428,6 +442,66 @@ class ResolvePendingActionAbility {
 			'kind'      => $kind,
 			'result'    => is_array( $result ) ? $result : array( 'value' => $result ),
 		);
+	}
+
+	/**
+	 * Resolve in the site-local store identified by an untrusted routing hint.
+	 *
+	 * The switched store remains authoritative: the loaded action must repeat the
+	 * same stamped blog ID before authorization, handler execution, or audit.
+	 *
+	 * @param array $input          Resolver input.
+	 * @param int   $origin_blog_id Claimed originating blog ID.
+	 * @return array
+	 */
+	private static function resolveAtOrigin( array $input, int $origin_blog_id ): array {
+		$action_id = isset( $input['action_id'] ) ? sanitize_text_field( $input['action_id'] ) : '';
+		if ( ! function_exists( 'switch_to_blog' ) || ! function_exists( 'restore_current_blog' )
+			|| ( function_exists( 'get_site' ) && ! get_site( $origin_blog_id ) ) ) {
+			return array(
+				'success'   => false,
+				'error'     => 'Pending action origin could not be verified.',
+				'action_id' => $action_id,
+			);
+		}
+
+		if ( ! switch_to_blog( $origin_blog_id ) ) {
+			return array(
+				'success'   => false,
+				'error'     => 'Pending action origin could not be verified.',
+				'action_id' => $action_id,
+			);
+		}
+
+		try {
+			$input['_origin_routed'] = true;
+			return self::resolve_with_datamachine_handlers( $input );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	/**
+	 * Read the WordPress origin supplied with the canonical pending action.
+	 *
+	 * @param array $input Resolver input.
+	 */
+	private static function originBlogIdFromInput( array $input ): int {
+		$context   = is_array( $input['context'] ?? null ) ? $input['context'] : array();
+		$wordpress = is_array( $context['wordpress'] ?? null ) ? $context['wordpress'] : array();
+		return isset( $wordpress['blog_id'] ) ? absint( $wordpress['blog_id'] ) : 0;
+	}
+
+	/**
+	 * Verify a routing hint against canonical metadata loaded from the store.
+	 *
+	 * @param array $payload        Stored pending action.
+	 * @param int   $origin_blog_id Claimed originating blog ID.
+	 */
+	private static function payloadMatchesOrigin( array $payload, int $origin_blog_id ): bool {
+		$context   = is_array( $payload['context'] ?? null ) ? $payload['context'] : array();
+		$wordpress = is_array( $context['wordpress'] ?? null ) ? $context['wordpress'] : array();
+		return $origin_blog_id === absint( $wordpress['blog_id'] ?? 0 );
 	}
 
 	/**

--- a/tests/agents-chat-handler-smoke.php
+++ b/tests/agents-chat-handler-smoke.php
@@ -94,6 +94,9 @@ $assert( str_contains( $handler_source, "'interrupted'" ) && str_contains( $hand
 $assert( str_contains( $handler_source, "'tool_execution_summary'" ), 'AgentsChatHandler returns bounded tool execution diagnostics in canonical metadata' );
 $assert( str_contains( $orchestrator, "'tool_execution_summary'" ) && str_contains( $orchestrator, 'datamachine_summarize_tool_execution_results' ), 'ChatOrchestrator forwards bounded tool execution diagnostics to chat adapters' );
 $assert( str_contains( $handler_source, "'calling_user_id'        => $" . "calling_user_id" ), 'AgentsChatHandler forwards the authenticated acting user separately from runtime ownership' );
+$assert( str_contains( $handler_source, "'workspace'             => $" . "workspace" ), 'AgentsChatHandler forwards the explicit canonical transcript workspace' );
+$assert( str_contains( $orchestrator, 'get_recent_pending_session( $workspace' ), 'ChatOrchestrator scopes pending-session deduplication to the explicit workspace' );
+$assert( str_contains( $orchestrator, "'workspace' => $" . "workspace->to_array()" ), 'ChatOrchestrator creates canonical sessions in the explicit workspace' );
 $assert( str_contains( $orchestrator, "'calling_user_id' => $" . "calling_user_id" ), 'ChatOrchestrator passes caller identity to tool resolution and the conversation loop' );
 $assert( str_contains( $orchestrator, '$response_metadata = is_array( $result[\'metadata\'] ?? null )' ), 'ChatOrchestrator exposes loop metadata from the actual turn result' );
 $assert( ! file_exists( $root . '/inc/Abilities/Chat/SendMessageAbility.php' ), 'datamachine/send-message facade class is removed' );

--- a/tests/chat-explicit-workspace-smoke.php
+++ b/tests/chat-explicit-workspace-smoke.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Pure-PHP integration coverage for principal-owned explicit workspaces.
+ *
+ * Run with: php tests/chat-explicit-workspace-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $value ): string {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $value ) );
+	}
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( string $value ): string {
+		return trim( $value );
+	}
+}
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ): int {
+		return abs( (int) $value );
+	}
+}
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return 0;
+	}
+}
+if ( ! function_exists( 'is_user_logged_in' ) ) {
+	function is_user_logged_in(): bool {
+		return false;
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+}
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( public string $code = '' ) {}
+	}
+}
+
+require_once __DIR__ . '/agents-api-loader.php';
+datamachine_tests_require_agents_api();
+require_once dirname( __DIR__ ) . '/inc/Abilities/Chat/ChatTranscriptOwner.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Database/BaseRepository.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Database/Chat/ConversationSessionIndexInterface.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Database/Chat/ConversationReadStateInterface.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Database/Chat/ConversationRetentionInterface.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Database/Chat/ConversationReportingInterface.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Database/Chat/ConversationStoreInterface.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Database/Chat/Chat.php';
+require_once dirname( __DIR__ ) . '/inc/Core/Database/Chat/PrincipalChat.php';
+
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+use DataMachine\Abilities\Chat\ChatTranscriptOwner;
+use DataMachine\Core\Database\Chat\PrincipalChat;
+
+final class ExplicitWorkspaceChatStore extends PrincipalChat {
+	/** @var array<string,array<string,mixed>> */
+	private array $sessions = array();
+
+	public function __construct() {}
+
+	public function create_session( ...$args ): string {
+		$workspace = $args[0];
+		$metadata  = $args[3];
+		$owner     = $metadata['transcript_owner'];
+		$id        = 'explicit-workspace-session';
+
+		$this->sessions[ $id ] = array(
+			'session_id'     => $id,
+			'workspace_type' => $workspace->workspace_type,
+			'workspace_id'   => $workspace->workspace_id,
+			'user_id'        => (int) $args[1],
+			'owner_type'     => $owner['owner_type'],
+			'owner_key_hash' => $owner['owner_key_hash'],
+			'messages'       => array(),
+			'metadata'       => $metadata,
+		);
+
+		return $id;
+	}
+
+	public function list_sessions( WP_Agent_Workspace_Scope $workspace, int $user_id, array $args = array() ): array {
+		unset( $user_id );
+		$owner = $args['transcript_owner'] ?? array();
+		return array_values(
+			array_filter(
+				$this->sessions,
+				static fn( array $session ): bool => $session['workspace_type'] === $workspace->workspace_type
+					&& $session['workspace_id'] === $workspace->workspace_id
+					&& $session['owner_type'] === ( $owner['owner_type'] ?? '' )
+					&& $session['owner_key_hash'] === ( $owner['owner_key_hash'] ?? '' )
+			)
+		);
+	}
+
+	public function get_session( string $session_id ): ?array {
+		return $this->sessions[ $session_id ] ?? null;
+	}
+}
+
+$failures = array();
+$passes   = 0;
+$assert   = static function ( bool $condition, string $label ) use ( &$failures, &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	$failures[] = $label;
+	echo "FAIL: {$label}\n";
+};
+
+$store             = new ExplicitWorkspaceChatStore();
+$network_workspace = WP_Agent_Workspace_Scope::from_parts( 'network', 'network:4' );
+$site_workspace    = WP_Agent_Workspace_Scope::from_parts( 'site', 'https://other.example' );
+$owner             = array( 'type' => 'audience', 'key' => 'principal-123' );
+$session_id        = $store->create_session_for_owner( $network_workspace, $owner );
+
+$sessions = $store->list_sessions_for_owner( $network_workspace, $owner );
+$assert( 1 === count( $sessions ), 'explicit workspace create is visible through the same workspace list' );
+$assert( 'network' === $sessions[0]['workspace_type'] && 'network:4' === $sessions[0]['workspace_id'], 'create preserves the supplied workspace tuple' );
+$assert( array() === $store->list_sessions_for_owner( $site_workspace, $owner ), 'ambient or different workspaces cannot list the session' );
+$assert( null !== $store->get_session_for_owner( $network_workspace, $owner, $session_id ), 'same owner and workspace can read the session' );
+$assert( null === $store->get_session_for_owner( $site_workspace, $owner, $session_id ), 'single-session reads verify workspace ownership' );
+$assert( null === $store->get_session_for_owner( $network_workspace, array( 'type' => 'audience', 'key' => 'forged' ), $session_id ), 'single-session reads preserve principal owner isolation' );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " explicit workspace assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} explicit workspace assertions passed.\n";

--- a/tests/pending-action-helper-approval-envelope-smoke.php
+++ b/tests/pending-action-helper-approval-envelope-smoke.php
@@ -47,6 +47,12 @@ if ( ! function_exists( 'get_current_user_id' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_current_blog_id' ) ) {
+	function get_current_blog_id(): int {
+		return 7;
+	}
+}
+
 if ( ! function_exists( 'apply_filters' ) ) {
 	function apply_filters( string $_hook, $value, ...$_args ) {
 		return $value;
@@ -154,8 +160,10 @@ datamachine_pending_action_helper_assert( array( 'title' => 'Demo', 'content' =>
 datamachine_pending_action_helper_assert( 'pending' === $payload['status'], 'Payload carries the canonical pending status.' );
 datamachine_pending_action_helper_assert( 'user:123' === $payload['creator'], 'Payload records creator identity.' );
 datamachine_pending_action_helper_assert( 'agent:456' === $payload['agent'], 'Payload records agent identity.' );
+datamachine_pending_action_helper_assert( is_array( $payload['workspace'] ?? null ), 'Payload carries the canonical originating workspace.' );
 datamachine_pending_action_helper_assert( 123 === $payload['metadata']['datamachine']['created_by'], 'Data Machine created_by audit field is retained in payload metadata.' );
 datamachine_pending_action_helper_assert( 456 === $payload['metadata']['datamachine']['agent_id'], 'Data Machine agent_id audit field is retained in payload metadata.' );
+datamachine_pending_action_helper_assert( 7 === $payload['metadata']['datamachine']['context']['wordpress']['blog_id'], 'Payload exposes the stamped WordPress origin for canonical resolution routing.' );
 datamachine_pending_action_helper_assert( isset( $payload['created_at'] ) && is_string( $payload['created_at'] ), 'Payload carries an ISO creation timestamp.' );
 datamachine_pending_action_helper_assert( array_key_exists( 'expires_at', $payload ), 'Payload carries an expires_at field.' );
 

--- a/tests/pending-action-resolver-contract-smoke.php
+++ b/tests/pending-action-resolver-contract-smoke.php
@@ -166,6 +166,7 @@ require_once dirname( __DIR__ ) . '/inc/Core/Workspace/WordPressWorkspaceScope.p
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionObservers.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/WordPressActionDispatchObserver.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionStore.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionHelper.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionScope.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionResolverAdapter.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/ResolvePendingActionAbility.php';
@@ -176,6 +177,7 @@ use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Handler;
 use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Observer;
 use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Resolver;
 use DataMachine\Engine\AI\Actions\PendingActionObservers;
+use DataMachine\Engine\AI\Actions\PendingActionHelper;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
 
@@ -605,21 +607,30 @@ add_filter(
 );
 
 switch_to_blog( 7 );
-PendingActionStore::store(
-	'act_origin_accept',
+$origin_envelope = PendingActionHelper::stage(
 	array(
+		'action_id'   => 'act_00000000-0000-4000-8000-000000000007',
 		'kind'        => 'origin_kind',
 		'summary'     => 'Resolve at origin.',
 		'apply_input' => array( 'target' => 'origin' ),
-		'created_by'  => 123,
-		'creator'     => 'user:123',
+		'user_id'     => 123,
+		'context'     => array(
+			'wordpress' => array( 'blog_id' => 1 ),
+			'trace_id'  => 'caller-context-preserved',
+		),
 	)
 );
+$origin_action_id = $origin_envelope['action_id'] ?? '';
+$origin_stored    = PendingActionStore::get( $origin_action_id );
 restore_current_blog();
 $GLOBALS['__resolver_current_blog'] = 2;
 
+resolver_smoke_assert( 7 === ( $origin_stored['context']['wordpress']['blog_id'] ?? null ), 'store overwrites forged WordPress origin with the actual staging blog', $failures, $passes );
+resolver_smoke_assert( 'caller-context-preserved' === ( $origin_stored['context']['trace_id'] ?? null ), 'store preserves non-reserved caller context', $failures, $passes );
+resolver_smoke_assert( 7 === ( $origin_envelope['payload']['metadata']['datamachine']['context']['wordpress']['blog_id'] ?? null ), 'approval envelope exposes the actual server-owned origin', $failures, $passes );
+
 $origin_result = $adapter->resolve_pending_action(
-	'act_origin_accept',
+	$origin_action_id,
 	WP_Agent_Approval_Decision::accepted(),
 	'user:123',
 	array(),

--- a/tests/pending-action-resolver-contract-smoke.php
+++ b/tests/pending-action-resolver-contract-smoke.php
@@ -15,8 +15,11 @@ if ( ! defined( 'DATAMACHINE_PENDING_ACTION_TRANSIENT_FALLBACK' ) ) {
 	define( 'DATAMACHINE_PENDING_ACTION_TRANSIENT_FALLBACK', true );
 }
 
-$GLOBALS['__resolver_filters']    = array();
-$GLOBALS['__resolver_transients'] = array();
+$GLOBALS['__resolver_filters']     = array();
+$GLOBALS['__resolver_transients']  = array();
+$GLOBALS['__resolver_current_blog'] = 1;
+$GLOBALS['__resolver_blog_stack']   = array();
+$GLOBALS['__resolver_switches']     = array();
 
 if ( ! function_exists( 'sanitize_text_field' ) ) {
 	function sanitize_text_field( $value ) {
@@ -41,6 +44,38 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 if ( ! function_exists( 'get_current_user_id' ) ) {
 	function get_current_user_id() {
 		return 123;
+	}
+}
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ) {
+		return abs( (int) $value );
+	}
+}
+if ( ! function_exists( 'get_current_blog_id' ) ) {
+	function get_current_blog_id() {
+		return $GLOBALS['__resolver_current_blog'];
+	}
+}
+if ( ! function_exists( 'get_site' ) ) {
+	function get_site( int $blog_id ) {
+		return in_array( $blog_id, array( 1, 2, 7 ), true ) ? (object) array( 'blog_id' => $blog_id ) : null;
+	}
+}
+if ( ! function_exists( 'switch_to_blog' ) ) {
+	function switch_to_blog( int $blog_id ): bool {
+		$GLOBALS['__resolver_blog_stack'][] = $GLOBALS['__resolver_current_blog'];
+		$GLOBALS['__resolver_current_blog'] = $blog_id;
+		$GLOBALS['__resolver_switches'][]   = $blog_id;
+		return true;
+	}
+}
+if ( ! function_exists( 'restore_current_blog' ) ) {
+	function restore_current_blog(): bool {
+		if ( empty( $GLOBALS['__resolver_blog_stack'] ) ) {
+			return false;
+		}
+		$GLOBALS['__resolver_current_blog'] = array_pop( $GLOBALS['__resolver_blog_stack'] );
+		return true;
 	}
 }
 if ( ! function_exists( 'did_action' ) ) {
@@ -90,18 +125,18 @@ if ( ! function_exists( 'do_action' ) ) {
 if ( ! function_exists( 'set_transient' ) ) {
 	function set_transient( $key, $value, $expiration = 0 ) {
 		unset( $expiration );
-		$GLOBALS['__resolver_transients'][ $key ] = $value;
+		$GLOBALS['__resolver_transients'][ get_current_blog_id() ][ $key ] = $value;
 		return true;
 	}
 }
 if ( ! function_exists( 'get_transient' ) ) {
 	function get_transient( $key ) {
-		return $GLOBALS['__resolver_transients'][ $key ] ?? false;
+		return $GLOBALS['__resolver_transients'][ get_current_blog_id() ][ $key ] ?? false;
 	}
 }
 if ( ! function_exists( 'delete_transient' ) ) {
 	function delete_transient( $key ) {
-		unset( $GLOBALS['__resolver_transients'][ $key ] );
+		unset( $GLOBALS['__resolver_transients'][ get_current_blog_id() ][ $key ] );
 		return true;
 	}
 }
@@ -138,7 +173,9 @@ require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/ResolvePendingActionAb
 use AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision;
 use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action;
 use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Handler;
+use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Observer;
 use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Resolver;
+use DataMachine\Engine\AI\Actions\PendingActionObservers;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
 
@@ -535,6 +572,74 @@ $scoped_out = ResolvePendingActionAbility::execute(
 );
 resolver_smoke_assert( false === ( $scoped_out['success'] ?? true ), 'resolver rejects actions outside caller owner scope', $failures, $passes );
 resolver_smoke_assert( 0 === $scoped_out_apply_calls, 'scope denial happens before handler execution', $failures, $passes );
+
+$origin_handler_blogs = array();
+$origin_audit_blogs   = array();
+$origin_observer      = new class( $origin_audit_blogs ) implements WP_Agent_Pending_Action_Observer {
+	public function __construct( private array &$origin_audit_blogs ) {}
+	public function on_stored( WP_Agent_Pending_Action $action ): void {
+		unset( $action );
+	}
+	public function on_resolved( WP_Agent_Pending_Action $action, WP_Agent_Approval_Decision $decision, string $resolver ): void {
+		unset( $action, $decision, $resolver );
+		$this->origin_audit_blogs[] = get_current_blog_id();
+	}
+	public function on_expired( WP_Agent_Pending_Action $action ): void {
+		unset( $action );
+	}
+};
+PendingActionObservers::register( $origin_observer );
+add_filter(
+	'datamachine_pending_action_handlers',
+	static function ( array $handlers ) use ( &$origin_handler_blogs ) {
+		$handlers['origin_kind'] = array(
+			'apply' => static function () use ( &$origin_handler_blogs ) {
+				$origin_handler_blogs[] = get_current_blog_id();
+				return array( 'success' => true );
+			},
+		);
+		return $handlers;
+	},
+	50,
+	1
+);
+
+switch_to_blog( 7 );
+PendingActionStore::store(
+	'act_origin_accept',
+	array(
+		'kind'        => 'origin_kind',
+		'summary'     => 'Resolve at origin.',
+		'apply_input' => array( 'target' => 'origin' ),
+		'created_by'  => 123,
+		'creator'     => 'user:123',
+	)
+);
+restore_current_blog();
+$GLOBALS['__resolver_current_blog'] = 2;
+
+$origin_result = $adapter->resolve_pending_action(
+	'act_origin_accept',
+	WP_Agent_Approval_Decision::accepted(),
+	'user:123',
+	array(),
+	array( 'wordpress' => array( 'blog_id' => 7 ) )
+);
+resolver_smoke_assert( true === ( $origin_result['success'] ?? false ), 'cross-site resolution succeeds against the originating store', $failures, $passes );
+resolver_smoke_assert( array( 7 ) === $origin_handler_blogs, 'approval handler executes in the originating blog context', $failures, $passes );
+resolver_smoke_assert( 2 === get_current_blog_id(), 'origin routing restores the caller blog after resolution', $failures, $passes );
+resolver_smoke_assert( array( 7 ) === $origin_audit_blogs, 'resolution audit lifecycle runs in the originating blog context', $failures, $passes );
+
+$forged_result = $adapter->resolve_pending_action(
+	'act_origin_accept',
+	WP_Agent_Approval_Decision::accepted(),
+	'user:123',
+	array(),
+	array( 'wordpress' => array( 'blog_id' => 1 ) )
+);
+resolver_smoke_assert( false === ( $forged_result['success'] ?? true ), 'forged origin metadata is denied', $failures, $passes );
+resolver_smoke_assert( array( 7 ) === $origin_handler_blogs, 'forged origin does not execute the handler', $failures, $passes );
+resolver_smoke_assert( 2 === get_current_blog_id(), 'forged origin denial also restores the caller blog', $failures, $passes );
 
 if ( ! empty( $failures ) ) {
 	echo "\nFailures:\n";


### PR DESCRIPTION
## Summary
- honor explicit canonical transcript workspaces through chat deduplication, creation, principal list/read operations, and continuation checks
- expose stored pending-action origin metadata and resolve against the verified originating multisite store while preserving authorization and restoring blog context
- cover explicit workspace isolation, cross-site handler/audit routing, forged-origin denial, and context restoration

## Testing
- `php tests/chat-explicit-workspace-smoke.php`
- `php tests/agents-chat-handler-smoke.php`
- `php tests/chat-session-canonical-path-smoke.php`
- `php tests/pending-action-helper-approval-envelope-smoke.php`
- `php tests/pending-action-resolver-contract-smoke.php`
- `php tests/pending-action-scope-smoke.php`
- `vendor/bin/phpcs` on all changed PHP files
- `homeboy review --placement local --changed-since origin/main --summary` (audit and lint passed; Codebox PHPUnit could not execute because its runtime lacks `SebastianBergmann\Comparator\ExceptionComparator`, tracked in Extra-Chill/homeboy#9338)

Fixes #2927