### PR TITLE
fix: make cross-flow claims owner safe

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -52,7 +52,7 @@ class ExecuteStepAbility {
 						'type'       => 'object',
 						'required'   => array( 'job_id', 'flow_step_id' ),
 						'properties' => array(
-							'job_id'               => array(
+							'job_id'                => array(
 								'type'        => 'integer',
 								'description' => __( 'Job ID for the execution.', 'data-machine' ),
 							),
@@ -387,9 +387,9 @@ class ExecuteStepAbility {
 				'datamachine_execute_step',
 				array(
 					'job_id'                => $job_id,
-					'flow_step_id'           => $flow_step_id,
-					'operation_generation'   => $generation,
-					'operation_claim_token'  => $token,
+					'flow_step_id'          => $flow_step_id,
+					'operation_generation'  => $generation,
+					'operation_claim_token' => $token,
 				),
 				'data-machine'
 			)

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -581,12 +581,6 @@ class ExecuteStepAbility {
 		if ( $status_override ) {
 			$transition = $this->db_jobs->transition_job_status_result( $job_id, $status_override, true );
 			if ( $transition['changed'] ) {
-				if ( str_starts_with( $status_override, JobStatus::FAILED ) === false ) {
-					$this->handleStepLifecycleCompleted( $job_id );
-				} else {
-					$this->handleStepLifecycleFailed( $job_id );
-				}
-
 				$cleanup = new FileCleanup();
 				$context = datamachine_get_file_context( $flow_id );
 				$cleanup->cleanup_job_data_packets( $job_id, $context );
@@ -742,9 +736,6 @@ class ExecuteStepAbility {
 
 			$transition = $this->db_jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
 			if ( $transition['changed'] ) {
-				// Notify lifecycle handlers after the full pipeline succeeds.
-				$this->handleStepLifecycleCompleted( $job_id );
-
 				$cleanup = new FileCleanup();
 				$context = datamachine_get_file_context( $flow_id );
 				$cleanup->cleanup_job_data_packets( $job_id, $context );
@@ -968,24 +959,6 @@ class ExecuteStepAbility {
 	 */
 	private function handleStepLifecycleInlineContinuation( int $job_id, array $flow_step_config, array $routed_packets ): void {
 		do_action( 'datamachine_step_lifecycle_inline_continuation', $job_id, $flow_step_config, $routed_packets );
-	}
-
-	/**
-	 * Notify step lifecycle handlers that a job completed successfully.
-	 *
-	 * @param int $job_id Completed job ID.
-	 */
-	private function handleStepLifecycleCompleted( int $job_id ): void {
-		do_action( 'datamachine_step_lifecycle_completed', $job_id, datamachine_get_engine_data( $job_id ) );
-	}
-
-	/**
-	 * Notify step lifecycle handlers that a job failed outside datamachine_fail_job.
-	 *
-	 * @param int $job_id Failed job ID.
-	 */
-	private function handleStepLifecycleFailed( int $job_id ): void {
-		do_action( 'datamachine_step_lifecycle_failed', $job_id, datamachine_get_engine_data( $job_id ) );
 	}
 
 	/**

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -52,15 +52,15 @@ class ExecuteStepAbility {
 						'type'       => 'object',
 						'required'   => array( 'job_id', 'flow_step_id' ),
 						'properties' => array(
-							'job_id'       => array(
+							'job_id'               => array(
 								'type'        => 'integer',
 								'description' => __( 'Job ID for the execution.', 'data-machine' ),
 							),
-							'flow_step_id' => array(
+							'flow_step_id'          => array(
 								'type'        => 'string',
 								'description' => __( 'Flow step ID to execute.', 'data-machine' ),
 							),
-							'operation_generation' => array(
+							'operation_generation'  => array(
 								'type'        => 'integer',
 								'minimum'     => 0,
 								'description' => __( 'Direct workflow execution generation.', 'data-machine' ),
@@ -74,13 +74,13 @@ class ExecuteStepAbility {
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success'      => array( 'type' => 'boolean' ),
-							'step_success' => array( 'type' => 'boolean' ),
-							'outcome'      => array( 'type' => 'string' ),
+							'success'          => array( 'type' => 'boolean' ),
+							'step_success'     => array( 'type' => 'boolean' ),
+							'outcome'          => array( 'type' => 'string' ),
 							'stale_generation' => array( 'type' => 'boolean' ),
 							'deferred'         => array( 'type' => 'boolean' ),
 							'retryable'        => array( 'type' => 'boolean' ),
-							'error'        => array( 'type' => 'string' ),
+							'error'            => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( $this, 'execute' ),
@@ -107,11 +107,11 @@ class ExecuteStepAbility {
 	 * @return array Result with step execution outcome.
 	 */
 	public function execute( array $input ): array {
-		$job_id       = (int) ( $input['job_id'] ?? 0 );
-		$flow_step_id = (string) ( $input['flow_step_id'] ?? '' );
-		$operation_generation = max( 0, (int) ( $input['operation_generation'] ?? 0 ) );
+		$job_id                = (int) ( $input['job_id'] ?? 0 );
+		$flow_step_id          = (string) ( $input['flow_step_id'] ?? '' );
+		$operation_generation  = max( 0, (int) ( $input['operation_generation'] ?? 0 ) );
 		$operation_claim_token = (string) ( $input['operation_claim_token'] ?? '' );
-		$job          = $this->db_jobs->get_job( $job_id );
+		$job                   = $this->db_jobs->get_job( $job_id );
 
 		if ( ! $job ) {
 			return array(
@@ -237,7 +237,7 @@ class ExecuteStepAbility {
 				'engine'       => $engine,
 			);
 
-			$step_output      = $flow_step->execute( $payload );
+			$step_output = $flow_step->execute( $payload );
 			if ( $operation_generation > 0 ) {
 				$job_after_execution = $this->db_jobs->get_job( $job_id );
 				if ( ! is_array( $job_after_execution ) || 'committed' !== $this->operationGenerationAdmission( $job_after_execution, $operation_generation, $operation_claim_token ) ) {
@@ -370,7 +370,7 @@ class ExecuteStepAbility {
 		if ( $generation <= 0 ) {
 			return 'committed';
 		}
-		if ( '' === $token || $generation !== (int) ( $job['operation_generation'] ?? 0 ) || ! hash_equals( $token, (string) ( $job['operation_claim_token'] ?? '' ) ) ) {
+		if ( '' === $token || (int) ( $job['operation_generation'] ?? 0 ) !== $generation || ! hash_equals( $token, (string) ( $job['operation_claim_token'] ?? '' ) ) ) {
 			return 'stale';
 		}
 		if ( 'enqueued' === ( $job['operation_state'] ?? '' ) && (int) ( $job['operation_action_id'] ?? 0 ) > 0 ) {
@@ -386,10 +386,10 @@ class ExecuteStepAbility {
 				time() + 1,
 				'datamachine_execute_step',
 				array(
-					'job_id'               => $job_id,
-					'flow_step_id'         => $flow_step_id,
-					'operation_generation' => $generation,
-					'operation_claim_token' => $token,
+					'job_id'                => $job_id,
+					'flow_step_id'           => $flow_step_id,
+					'operation_generation'   => $generation,
+					'operation_claim_token'  => $token,
 				),
 				'data-machine'
 			)

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -585,6 +585,15 @@ class ExecuteStepAbility {
 				$context = datamachine_get_file_context( $flow_id );
 				$cleanup->cleanup_job_data_packets( $job_id, $context );
 			}
+			if ( JobStatus::isStatusSuccess( $status_override ) && ! JobStatus::isStatusSuccess( $transition['status'] ) ) {
+				return array(
+					'success'      => false,
+					'step_success' => false,
+					'outcome'      => 'claim_completion_failed',
+					'reason'       => 'item_claim_completion_failed',
+					'status'       => $transition['status'],
+				);
+			}
 
 			do_action(
 				'datamachine_log',
@@ -739,6 +748,15 @@ class ExecuteStepAbility {
 				$cleanup = new FileCleanup();
 				$context = datamachine_get_file_context( $flow_id );
 				$cleanup->cleanup_job_data_packets( $job_id, $context );
+			}
+			if ( ! JobStatus::isStatusSuccess( $transition['status'] ) ) {
+				return array(
+					'success'      => false,
+					'step_success' => false,
+					'outcome'      => 'claim_completion_failed',
+					'reason'       => 'item_claim_completion_failed',
+					'status'       => $transition['status'],
+				);
 			}
 
 			do_action(

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -585,7 +585,7 @@ class ExecuteStepAbility {
 				$context = datamachine_get_file_context( $flow_id );
 				$cleanup->cleanup_job_data_packets( $job_id, $context );
 			}
-			if ( JobStatus::isStatusSuccess( $status_override ) && ! JobStatus::isStatusSuccess( $transition['status'] ) ) {
+			if ( JobStatus::isStatusSuccess( $status_override ) && ( ! $transition['success'] || ! JobStatus::isStatusSuccess( $transition['status'] ) ) ) {
 				return array(
 					'success'      => false,
 					'step_success' => false,
@@ -749,7 +749,7 @@ class ExecuteStepAbility {
 				$context = datamachine_get_file_context( $flow_id );
 				$cleanup->cleanup_job_data_packets( $job_id, $context );
 			}
-			if ( ! JobStatus::isStatusSuccess( $transition['status'] ) ) {
+			if ( ! $transition['success'] || ! JobStatus::isStatusSuccess( $transition['status'] ) ) {
 				return array(
 					'success'      => false,
 					'step_success' => false,
@@ -809,7 +809,16 @@ class ExecuteStepAbility {
 		// Fetch/event_import legacy empty outputs classify this way, and explicit
 		// result-shaped step returns can also choose it without emitting packets.
 		if ( 'completed_no_items' === ( $execution_result['status'] ?? '' ) ) {
-			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED_NO_ITEMS );
+			$transition = $this->db_jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED_NO_ITEMS, true );
+			if ( ! $transition['success'] || ! JobStatus::isStatusSuccess( $transition['status'] ) ) {
+				return array(
+					'success'      => false,
+					'step_success' => false,
+					'outcome'      => 'claim_completion_failed',
+					'reason'       => 'item_claim_completion_failed',
+					'status'       => $transition['status'],
+				);
+			}
 			do_action(
 				'datamachine_log',
 				'info',

--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -29,6 +29,7 @@ namespace DataMachine\Abilities\Engine;
 use DataMachine\Core\PacketEngineData;
 use DataMachine\Core\ActionScheduler\BatchScheduler;
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\JobStatus;
 
 defined( 'ABSPATH' ) || exit;
@@ -89,6 +90,10 @@ class PipelineBatchScheduler {
 			self::BATCH_CONTEXT,
 			BatchScheduler::COMPLETION_STRATEGY_CHILDREN_COMPLETE
 		);
+
+		if ( empty( $result['scheduled'] ) ) {
+			$this->db_jobs->complete_job( $parent_job_id, JobStatus::failed( 'batch_schedule_failed' )->toString() );
+		}
 
 		// Surface next_flow_step_id at the top level for legacy consumers
 		// that read it without descending into batch_state. Parity with
@@ -209,12 +214,14 @@ class PipelineBatchScheduler {
 				return;
 			}
 
-			do_action(
-				'datamachine_log',
-				'info',
-				sprintf( 'Pipeline batch: all %d items scheduled', $result['total'] ),
-				array( 'parent_job_id' => $parent_job_id )
-			);
+			if ( empty( $result['schedule_failed'] ) ) {
+				do_action(
+					'datamachine_log',
+					'info',
+					sprintf( 'Pipeline batch: all %d items scheduled', $result['total'] ),
+					array( 'parent_job_id' => $parent_job_id )
+				);
+			}
 
 			self::maybeCompleteParent( $parent_job_id );
 		}
@@ -339,11 +346,15 @@ class PipelineBatchScheduler {
 		// parent, but now the fetch step no longer marks items eagerly.
 		$item_identifier = $single_packet['metadata']['item_identifier'] ?? null;
 		$source_type     = $single_packet['metadata']['source_type'] ?? null;
+		$item_claim      = $single_packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] ?? null;
 		if ( ! empty( $item_identifier ) ) {
 			$child_engine['item_identifier'] = $item_identifier;
 		}
 		if ( ! empty( $source_type ) ) {
 			$child_engine['source_type'] = $source_type;
+		}
+		if ( is_array( $item_claim ) ) {
+			$child_engine[ ProcessedItems::CLAIM_METADATA_KEY ] = $item_claim;
 		}
 
 		datamachine_set_engine_data( $child_job_id, $child_engine );
@@ -482,10 +493,11 @@ class PipelineBatchScheduler {
 
 		$total_children = (int) $counts['total'];
 		$active         = (int) $counts['active'];
-		$batch_total    = (int) ( $parent_engine['batch_total'] ?? $total_children );
+		$batch_scheduled = (int) ( $parent_engine['batch_scheduled'] ?? $total_children );
+		$batch_pending   = isset( $parent_engine['batch_state'] );
 
 		// Still have active children or not all scheduled yet.
-		if ( $active > 0 || $total_children < $batch_total ) {
+		if ( $active > 0 || $batch_pending || $total_children < $batch_scheduled ) {
 			return;
 		}
 
@@ -494,7 +506,9 @@ class PipelineBatchScheduler {
 		$failed    = (int) $counts['failed'];
 		$skipped   = (int) $counts['skipped'];
 
-		if ( $completed > 0 ) {
+		if ( ! empty( $parent_engine['batch_schedule_failed'] ) ) {
+			$parent_status = JobStatus::failed( 'batch_schedule_failed' )->toString();
+		} elseif ( $completed > 0 ) {
 			$parent_status = JobStatus::COMPLETED;
 		} elseif ( $failed === $total_children ) {
 			$parent_status = JobStatus::failed(

--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -491,8 +491,8 @@ class PipelineBatchScheduler {
 			return;
 		}
 
-		$total_children = (int) $counts['total'];
-		$active         = (int) $counts['active'];
+		$total_children  = (int) $counts['total'];
+		$active          = (int) $counts['active'];
 		$batch_scheduled = (int) ( $parent_engine['batch_scheduled'] ?? $total_children );
 		$batch_pending   = isset( $parent_engine['batch_state'] );
 

--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -155,6 +155,10 @@ class BatchScheduler {
 		string $context = '',
 		string $completion_strategy = ''
 	): array {
+		$cleanup_contexts = array_map(
+			static fn( mixed $item ): array => (array) apply_filters( 'datamachine_batch_item_cleanup_context', array(), $item ),
+			$items
+		);
 		$items      = array_map( array( DataPacketStore::class, 'reference_packet_collections_in_value' ), $items );
 		$total      = count( $items );
 		$chunk_size = self::chunkSize( $context );
@@ -170,11 +174,12 @@ class BatchScheduler {
 				'batch_completion_strategy' => $completion_strategy,
 				'started_at'                => current_time( 'mysql' ),
 				'batch_state'               => array(
-					'offset' => 0,
-					'total'  => $total,
-					'items'  => $items,
-					'extra'  => $extra,
-					'hook'   => $hook,
+					'offset'           => 0,
+					'total'            => $total,
+					'items'            => $items,
+					'cleanup_contexts' => $cleanup_contexts,
+					'extra'            => $extra,
+					'hook'             => $hook,
 				),
 			)
 		);
@@ -212,7 +217,7 @@ class BatchScheduler {
 		}
 
 		if ( ! $action_id ) {
-			do_action( 'datamachine_batch_items_discarded', $items, $parent_job_id, $context );
+			do_action( 'datamachine_batch_items_discarded', $items, $parent_job_id, $context, $cleanup_contexts );
 			$engine = datamachine_get_engine_data( $parent_job_id );
 			unset( $engine['batch_state'] );
 			$engine['batch_schedule_failed'] = true;
@@ -290,12 +295,16 @@ class BatchScheduler {
 		// Cancellation flag set on the parent's engine_data short-circuits
 		// any further child creation.
 		if ( ! empty( $parent_engine['cancelled'] ) ) {
-			$remaining = array_slice(
+			$remaining         = array_slice(
 				is_array( $batch_state['items'] ?? null ) ? $batch_state['items'] : array(),
 				(int) ( $batch_state['offset'] ?? 0 )
 			);
+			$remaining_cleanup = array_slice(
+				is_array( $batch_state['cleanup_contexts'] ?? null ) ? $batch_state['cleanup_contexts'] : array(),
+				(int) ( $batch_state['offset'] ?? 0 )
+			);
 			if ( $remaining ) {
-				do_action( 'datamachine_batch_items_discarded', $remaining, $parent_job_id, (string) ( $parent_engine['batch_context'] ?? '' ) );
+				do_action( 'datamachine_batch_items_discarded', $remaining, $parent_job_id, (string) ( $parent_engine['batch_context'] ?? '' ), $remaining_cleanup );
 			}
 			unset( $parent_engine['batch_state'] );
 			datamachine_set_engine_data( $parent_job_id, $parent_engine );
@@ -371,23 +380,30 @@ class BatchScheduler {
 		$chunk_size = self::chunkSize( $context );
 		$delay      = self::chunkDelay( $context );
 
-		$total  = (int) ( $batch_state['total'] ?? 0 );
-		$offset = (int) ( $batch_state['offset'] ?? 0 );
-		$items  = is_array( $batch_state['items'] ?? null ) ? $batch_state['items'] : array();
-		$extra  = is_array( $batch_state['extra'] ?? null ) ? $batch_state['extra'] : array();
-		$hook   = (string) ( $batch_state['hook'] ?? '' );
+		$total            = (int) ( $batch_state['total'] ?? 0 );
+		$offset           = (int) ( $batch_state['offset'] ?? 0 );
+		$items            = is_array( $batch_state['items'] ?? null ) ? $batch_state['items'] : array();
+		$cleanup_contexts = is_array( $batch_state['cleanup_contexts'] ?? null ) ? $batch_state['cleanup_contexts'] : array();
+		$extra            = is_array( $batch_state['extra'] ?? null ) ? $batch_state['extra'] : array();
+		$hook             = (string) ( $batch_state['hook'] ?? '' );
 
 		$chunk           = array_slice( $items, $offset, $chunk_size );
 		$scheduled       = 0;
 		$schedule_failed = false;
 
-		foreach ( $chunk as $item ) {
-			$item   = DataPacketStore::hydrate_packet_collections_in_value( $item );
+		foreach ( $chunk as $index => $item ) {
+			$cleanup_context = $cleanup_contexts[ $offset + $index ] ?? array();
+			$hydration       = DataPacketStore::hydrate_packet_collections_with_status( $item );
+			$item            = $hydration['value'];
+			if ( empty( $hydration['success'] ) ) {
+				do_action( 'datamachine_batch_items_discarded', array( $item ), $parent_job_id, (string) $context, array( $cleanup_context ) );
+				continue;
+			}
 			$result = $createItem( $item, $extra, $parent_job_id );
 			if ( $result ) {
 				++$scheduled;
 			} else {
-				do_action( 'datamachine_batch_items_discarded', array( $item ), $parent_job_id, (string) $context );
+				do_action( 'datamachine_batch_items_discarded', array( $item ), $parent_job_id, (string) $context, array( $cleanup_context ) );
 			}
 		}
 
@@ -443,9 +459,10 @@ class BatchScheduler {
 			}
 
 			if ( ! $action_id ) {
-				$remaining = array_slice( $items, $new_offset );
+				$remaining         = array_slice( $items, $new_offset );
+				$remaining_cleanup = array_slice( $cleanup_contexts, $new_offset );
 				if ( $remaining ) {
-					do_action( 'datamachine_batch_items_discarded', $remaining, $parent_job_id, (string) $context );
+					do_action( 'datamachine_batch_items_discarded', $remaining, $parent_job_id, (string) $context, $remaining_cleanup );
 				}
 				EngineData::mutate(
 					$parent_job_id,
@@ -496,10 +513,14 @@ class BatchScheduler {
 			is_array( $batch_state['items'] ?? null ) ? $batch_state['items'] : array(),
 			(int) ( $batch_state['offset'] ?? 0 )
 		);
+		$remaining_cleanup             = array_slice(
+			is_array( $batch_state['cleanup_contexts'] ?? null ) ? $batch_state['cleanup_contexts'] : array(),
+			(int) ( $batch_state['offset'] ?? 0 )
+		);
 		datamachine_set_engine_data( $parent_job_id, $parent_engine );
 
 		if ( $remaining ) {
-			do_action( 'datamachine_batch_items_discarded', $remaining, $parent_job_id, (string) ( $parent_engine['batch_context'] ?? '' ) );
+			do_action( 'datamachine_batch_items_discarded', $remaining, $parent_job_id, (string) ( $parent_engine['batch_context'] ?? '' ), $remaining_cleanup );
 		}
 
 		return true;

--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -159,9 +159,9 @@ class BatchScheduler {
 			static fn( mixed $item ): array => (array) apply_filters( 'datamachine_batch_item_cleanup_context', array(), $item ),
 			$items
 		);
-		$items      = array_map( array( DataPacketStore::class, 'reference_packet_collections_in_value' ), $items );
-		$total      = count( $items );
-		$chunk_size = self::chunkSize( $context );
+		$items            = array_map( array( DataPacketStore::class, 'reference_packet_collections_in_value' ), $items );
+		$total            = count( $items );
+		$chunk_size       = self::chunkSize( $context );
 
 		datamachine_merge_engine_data(
 			$parent_job_id,
@@ -292,22 +292,44 @@ class BatchScheduler {
 			);
 		}
 
-		// Cancellation flag set on the parent's engine_data short-circuits
-		// any further child creation.
+		$context    = $parent_engine['batch_context'] ?? '';
+		$chunk_size = self::chunkSize( $context );
+		$delay      = self::chunkDelay( $context );
+
+		// Cancellation without an in-flight owner may discard from the durable
+		// offset. An in-flight owner is responsible for its own chunk boundary.
 		if ( ! empty( $parent_engine['cancelled'] ) ) {
-			$remaining         = array_slice(
-				is_array( $batch_state['items'] ?? null ) ? $batch_state['items'] : array(),
-				(int) ( $batch_state['offset'] ?? 0 )
-			);
-			$remaining_cleanup = array_slice(
-				is_array( $batch_state['cleanup_contexts'] ?? null ) ? $batch_state['cleanup_contexts'] : array(),
-				(int) ( $batch_state['offset'] ?? 0 )
-			);
-			if ( $remaining ) {
-				do_action( 'datamachine_batch_items_discarded', $remaining, $parent_job_id, (string) ( $parent_engine['batch_context'] ?? '' ), $remaining_cleanup );
+			if ( is_array( $batch_state['in_flight'] ?? null ) ) {
+				return array(
+					'scheduled' => 0,
+					'offset'    => (int) ( $batch_state['offset'] ?? 0 ),
+					'total'     => (int) ( $batch_state['total'] ?? 0 ),
+					'more'      => false,
+					'cancelled' => true,
+					'missing'   => false,
+					'duplicate' => true,
+				);
 			}
-			unset( $parent_engine['batch_state'] );
-			datamachine_set_engine_data( $parent_job_id, $parent_engine );
+
+			if ( ! isset( $batch_state['discarded_from'] ) ) {
+				$discard_from      = (int) ( $batch_state['offset'] ?? 0 );
+				$remaining         = array_slice( is_array( $batch_state['items'] ?? null ) ? $batch_state['items'] : array(), $discard_from );
+				$remaining_cleanup = array_slice( is_array( $batch_state['cleanup_contexts'] ?? null ) ? $batch_state['cleanup_contexts'] : array(), $discard_from );
+				if ( $remaining ) {
+					do_action( 'datamachine_batch_items_discarded', $remaining, $parent_job_id, (string) $context, $remaining_cleanup );
+				}
+			}
+
+			EngineData::mutate(
+				$parent_job_id,
+				static function ( array $current ): array {
+					if ( ! is_array( $current['batch_state']['in_flight'] ?? null ) ) {
+						unset( $current['batch_state'] );
+					}
+					return $current;
+				},
+				'batch_cancelled_cleanup'
+			);
 
 			return array(
 				'scheduled' => 0,
@@ -324,7 +346,7 @@ class BatchScheduler {
 			$claim_error = null;
 			$claim       = EngineData::mutate(
 				$parent_job_id,
-				static function ( array $current ) use ( $expected_offset, &$claim_error ): ?array {
+				static function ( array $current ) use ( $expected_offset, $chunk_size, &$claim_error ): ?array {
 					$current_state = $current['batch_state'] ?? null;
 					if ( ! is_array( $current_state ) ) {
 						$claim_error = 'missing';
@@ -350,6 +372,10 @@ class BatchScheduler {
 
 					$current_state['claims']                              = $claims;
 					$current_state['claims'][ (string) $expected_offset ] = current_time( 'mysql' );
+					$current_state['in_flight']                           = array(
+						'offset' => $expected_offset,
+						'end'    => min( $expected_offset + $chunk_size, (int) ( $current_state['total'] ?? 0 ) ),
+					);
 					$current['batch_state']                               = $current_state;
 
 					return $current;
@@ -376,10 +402,6 @@ class BatchScheduler {
 			$batch_state   = is_array( $parent_engine['batch_state'] ?? null ) ? $parent_engine['batch_state'] : $batch_state;
 		}
 
-		$context    = $parent_engine['batch_context'] ?? '';
-		$chunk_size = self::chunkSize( $context );
-		$delay      = self::chunkDelay( $context );
-
 		$total            = (int) ( $batch_state['total'] ?? 0 );
 		$offset           = (int) ( $batch_state['offset'] ?? 0 );
 		$items            = is_array( $batch_state['items'] ?? null ) ? $batch_state['items'] : array();
@@ -389,14 +411,28 @@ class BatchScheduler {
 
 		$chunk           = array_slice( $items, $offset, $chunk_size );
 		$scheduled       = 0;
+		$processed       = 0;
+		$cancelled       = false;
 		$schedule_failed = false;
 
 		foreach ( $chunk as $index => $item ) {
+			$latest = EngineData::retrieve( $parent_job_id );
+			if ( ! empty( $latest['cancelled'] ) ) {
+				$cancelled        = true;
+				$remaining        = array_slice( $chunk, $index );
+				$remaining_cleanup = array_slice( $cleanup_contexts, $offset + $index, count( $remaining ) );
+				if ( $remaining ) {
+					do_action( 'datamachine_batch_items_discarded', $remaining, $parent_job_id, (string) $context, $remaining_cleanup );
+				}
+				break;
+			}
+
 			$cleanup_context = $cleanup_contexts[ $offset + $index ] ?? array();
 			$hydration       = DataPacketStore::hydrate_packet_collections_with_status( $item );
 			$item            = $hydration['value'];
 			if ( empty( $hydration['success'] ) ) {
 				do_action( 'datamachine_batch_items_discarded', array( $item ), $parent_job_id, (string) $context, array( $cleanup_context ) );
+				++$processed;
 				continue;
 			}
 			$result = $createItem( $item, $extra, $parent_job_id );
@@ -405,21 +441,26 @@ class BatchScheduler {
 			} else {
 				do_action( 'datamachine_batch_items_discarded', array( $item ), $parent_job_id, (string) $context, array( $cleanup_context ) );
 			}
+			++$processed;
 		}
 
-		$new_offset = $offset + $chunk_size;
+		$new_offset = $cancelled ? $offset + $processed : $offset + count( $chunk );
 
-		$more = $new_offset < $total;
+		$more = ! $cancelled && $new_offset < $total;
 
 		EngineData::mutate(
 			$parent_job_id,
-			static function ( array $current ) use ( $scheduled, $new_offset, $total, $more, $expected_offset ): array {
+			static function ( array $current ) use ( $scheduled, $new_offset, $total, $more, $expected_offset, &$cancelled ): array {
 				$current['batch_scheduled'] = ( $current['batch_scheduled'] ?? 0 ) + $scheduled;
 				$current['batch_offset']    = min( $new_offset, $total );
 
-				if ( $more ) {
+				if ( ! empty( $current['cancelled'] ) ) {
+					$cancelled = true;
+					unset( $current['batch_state'] );
+				} elseif ( $more ) {
 					if ( is_array( $current['batch_state'] ?? null ) ) {
 						$current['batch_state']['offset'] = $new_offset;
+						unset( $current['batch_state']['in_flight'] );
 						if ( null !== $expected_offset && isset( $current['batch_state']['claims'][ (string) $expected_offset ] ) ) {
 							unset( $current['batch_state']['claims'][ (string) $expected_offset ] );
 						}
@@ -432,6 +473,9 @@ class BatchScheduler {
 			},
 			'batch_chunk_advance'
 		);
+		if ( $cancelled ) {
+			$more = false;
+		}
 
 		if ( $more ) {
 			try {
@@ -483,7 +527,7 @@ class BatchScheduler {
 			'offset'          => min( $new_offset, $total ),
 			'total'           => $total,
 			'more'            => $more,
-			'cancelled'       => false,
+			'cancelled'       => $cancelled,
 			'missing'         => false,
 			'duplicate'       => false,
 			'schedule_failed' => $schedule_failed,
@@ -500,27 +544,44 @@ class BatchScheduler {
 	 * @return bool True when the parent was a batch parent and the flag was set.
 	 */
 	public static function cancel( int $parent_job_id ): bool {
-		$parent_engine = datamachine_get_engine_data( $parent_job_id );
+		$remaining         = array();
+		$remaining_cleanup = array();
+		$context           = '';
+		$mutation          = EngineData::mutate(
+			$parent_job_id,
+			static function ( array $current ) use ( &$remaining, &$remaining_cleanup, &$context ): ?array {
+				$remaining         = array();
+				$remaining_cleanup = array();
+				if ( empty( $current['batch'] ) ) {
+					return null;
+				}
 
-		if ( empty( $parent_engine['batch'] ) ) {
+				$current['cancelled']    = true;
+				$current['cancelled_at'] = current_time( 'mysql' );
+				$context                 = (string) ( $current['batch_context'] ?? '' );
+				$state                   = is_array( $current['batch_state'] ?? null ) ? $current['batch_state'] : array();
+				if ( $state && ! isset( $state['discarded_from'] ) ) {
+					$in_flight    = is_array( $state['in_flight'] ?? null ) ? $state['in_flight'] : array();
+					$discard_from = $in_flight
+						? (int) ( $in_flight['end'] ?? $state['offset'] ?? 0 )
+						: (int) ( $state['offset'] ?? 0 );
+					$remaining                 = array_slice( is_array( $state['items'] ?? null ) ? $state['items'] : array(), $discard_from );
+					$remaining_cleanup         = array_slice( is_array( $state['cleanup_contexts'] ?? null ) ? $state['cleanup_contexts'] : array(), $discard_from );
+					$state['discarded_from']   = $discard_from;
+					$current['batch_state']     = $state;
+				}
+
+				return $current;
+			},
+			'batch_cancel'
+		);
+
+		if ( empty( $mutation['success'] ) ) {
 			return false;
 		}
 
-		$parent_engine['cancelled']    = true;
-		$parent_engine['cancelled_at'] = current_time( 'mysql' );
-		$batch_state                   = is_array( $parent_engine['batch_state'] ?? null ) ? $parent_engine['batch_state'] : array();
-		$remaining                     = array_slice(
-			is_array( $batch_state['items'] ?? null ) ? $batch_state['items'] : array(),
-			(int) ( $batch_state['offset'] ?? 0 )
-		);
-		$remaining_cleanup             = array_slice(
-			is_array( $batch_state['cleanup_contexts'] ?? null ) ? $batch_state['cleanup_contexts'] : array(),
-			(int) ( $batch_state['offset'] ?? 0 )
-		);
-		datamachine_set_engine_data( $parent_job_id, $parent_engine );
-
 		if ( $remaining ) {
-			do_action( 'datamachine_batch_items_discarded', $remaining, $parent_job_id, (string) ( $parent_engine['batch_context'] ?? '' ), $remaining_cleanup );
+			do_action( 'datamachine_batch_items_discarded', $remaining, $parent_job_id, $context, $remaining_cleanup );
 		}
 
 		return true;

--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -145,7 +145,7 @@ class BatchScheduler {
 	 * @param array  $extra         Arbitrary per-batch state cloned to chunks (engine_snapshot, task_type, ...).
 	 * @param string $context       Consumer context, used for chunk-size/delay filter dispatch.
 	 * @param string $completion_strategy Declared parent-completion strategy.
-	 * @return array{parent_job_id:int,total:int,chunk_size:int} Batch summary.
+	 * @return array{parent_job_id:int,total:int,chunk_size:int,action_id:int,scheduled:bool} Batch summary.
 	 */
 	public static function start(
 		int $parent_job_id,
@@ -188,20 +188,43 @@ class BatchScheduler {
 			)
 		);
 
-		as_schedule_single_action(
-			time(),
-			$hook,
-			array(
-				'parent_job_id' => $parent_job_id,
-				'offset'        => 0,
-			),
-			'data-machine'
-		);
+		try {
+			$action_id = as_schedule_single_action(
+				time(),
+				$hook,
+				array(
+					'parent_job_id' => $parent_job_id,
+					'offset'        => 0,
+				),
+				'data-machine'
+			);
+		} catch ( \Throwable $exception ) {
+			$action_id = 0;
+			do_action(
+				'datamachine_log',
+				'error',
+				'Batch scheduler failed to schedule initial chunk',
+				array(
+					'parent_job_id' => $parent_job_id,
+					'exception'     => $exception->getMessage(),
+				)
+			);
+		}
+
+		if ( ! $action_id ) {
+			do_action( 'datamachine_batch_items_discarded', $items, $parent_job_id, $context );
+			$engine = datamachine_get_engine_data( $parent_job_id );
+			unset( $engine['batch_state'] );
+			$engine['batch_schedule_failed'] = true;
+			datamachine_set_engine_data( $parent_job_id, $engine );
+		}
 
 		return array(
 			'parent_job_id' => $parent_job_id,
 			'total'         => $total,
 			'chunk_size'    => $chunk_size,
+			'action_id'     => (int) $action_id,
+			'scheduled'     => (bool) $action_id,
 		);
 	}
 
@@ -228,7 +251,8 @@ class BatchScheduler {
 	 *     more:bool,
 	 *     cancelled:bool,
 	 *     missing:bool,
-	 *     duplicate:bool
+	 *     duplicate:bool,
+	 *     schedule_failed?:bool
 	 * } Chunk result. `missing` is true only when the batch_state key
 	 *   has been lost; consumer must fail the parent in that case.
 	 */
@@ -266,6 +290,13 @@ class BatchScheduler {
 		// Cancellation flag set on the parent's engine_data short-circuits
 		// any further child creation.
 		if ( ! empty( $parent_engine['cancelled'] ) ) {
+			$remaining = array_slice(
+				is_array( $batch_state['items'] ?? null ) ? $batch_state['items'] : array(),
+				(int) ( $batch_state['offset'] ?? 0 )
+			);
+			if ( $remaining ) {
+				do_action( 'datamachine_batch_items_discarded', $remaining, $parent_job_id, (string) ( $parent_engine['batch_context'] ?? '' ) );
+			}
 			unset( $parent_engine['batch_state'] );
 			datamachine_set_engine_data( $parent_job_id, $parent_engine );
 
@@ -346,14 +377,17 @@ class BatchScheduler {
 		$extra  = is_array( $batch_state['extra'] ?? null ) ? $batch_state['extra'] : array();
 		$hook   = (string) ( $batch_state['hook'] ?? '' );
 
-		$chunk     = array_slice( $items, $offset, $chunk_size );
-		$scheduled = 0;
+		$chunk           = array_slice( $items, $offset, $chunk_size );
+		$scheduled       = 0;
+		$schedule_failed = false;
 
 		foreach ( $chunk as $item ) {
 			$item   = DataPacketStore::hydrate_packet_collections_in_value( $item );
 			$result = $createItem( $item, $extra, $parent_job_id );
 			if ( $result ) {
 				++$scheduled;
+			} else {
+				do_action( 'datamachine_batch_items_discarded', array( $item ), $parent_job_id, (string) $context );
 			}
 		}
 
@@ -384,26 +418,58 @@ class BatchScheduler {
 		);
 
 		if ( $more ) {
+			try {
+				$action_id = as_schedule_single_action(
+					time() + $delay,
+					$hook,
+					array(
+						'parent_job_id' => $parent_job_id,
+						'offset'        => $new_offset,
+					),
+					'data-machine'
+				);
+			} catch ( \Throwable $exception ) {
+				$action_id = 0;
+				do_action(
+					'datamachine_log',
+					'error',
+					'Batch scheduler failed to schedule next chunk',
+					array(
+						'parent_job_id' => $parent_job_id,
+						'offset'        => $new_offset,
+						'exception'     => $exception->getMessage(),
+					)
+				);
+			}
 
-			as_schedule_single_action(
-				time() + $delay,
-				$hook,
-				array(
-					'parent_job_id' => $parent_job_id,
-					'offset'        => $new_offset,
-				),
-				'data-machine'
-			);
+			if ( ! $action_id ) {
+				$remaining = array_slice( $items, $new_offset );
+				if ( $remaining ) {
+					do_action( 'datamachine_batch_items_discarded', $remaining, $parent_job_id, (string) $context );
+				}
+				EngineData::mutate(
+					$parent_job_id,
+					static function ( array $current ): array {
+						unset( $current['batch_state'] );
+						$current['batch_schedule_failed'] = true;
+						return $current;
+					},
+					'batch_chunk_schedule_failure'
+				);
+				$more            = false;
+				$schedule_failed = true;
+			}
 		}
 
 		return array(
-			'scheduled' => $scheduled,
-			'offset'    => min( $new_offset, $total ),
-			'total'     => $total,
-			'more'      => $more,
-			'cancelled' => false,
-			'missing'   => false,
-			'duplicate' => false,
+			'scheduled'       => $scheduled,
+			'offset'          => min( $new_offset, $total ),
+			'total'           => $total,
+			'more'            => $more,
+			'cancelled'       => false,
+			'missing'         => false,
+			'duplicate'       => false,
+			'schedule_failed' => $schedule_failed,
 		);
 	}
 
@@ -425,7 +491,16 @@ class BatchScheduler {
 
 		$parent_engine['cancelled']    = true;
 		$parent_engine['cancelled_at'] = current_time( 'mysql' );
+		$batch_state                   = is_array( $parent_engine['batch_state'] ?? null ) ? $parent_engine['batch_state'] : array();
+		$remaining                     = array_slice(
+			is_array( $batch_state['items'] ?? null ) ? $batch_state['items'] : array(),
+			(int) ( $batch_state['offset'] ?? 0 )
+		);
 		datamachine_set_engine_data( $parent_job_id, $parent_engine );
+
+		if ( $remaining ) {
+			do_action( 'datamachine_batch_items_discarded', $remaining, $parent_job_id, (string) ( $parent_engine['batch_context'] ?? '' ) );
+		}
 
 		return true;
 	}

--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -299,19 +299,8 @@ class BatchScheduler {
 		// Cancellation without an in-flight owner may discard from the durable
 		// offset. An in-flight owner is responsible for its own chunk boundary.
 		if ( ! empty( $parent_engine['cancelled'] ) ) {
-			if ( is_array( $batch_state['in_flight'] ?? null ) ) {
-				return array(
-					'scheduled' => 0,
-					'offset'    => (int) ( $batch_state['offset'] ?? 0 ),
-					'total'     => (int) ( $batch_state['total'] ?? 0 ),
-					'more'      => false,
-					'cancelled' => true,
-					'missing'   => false,
-					'duplicate' => true,
-				);
-			}
-
-			if ( ! isset( $batch_state['discarded_from'] ) ) {
+			$duplicate = is_array( $batch_state['in_flight'] ?? null );
+			if ( ! $duplicate && ! isset( $batch_state['discarded_from'] ) ) {
 				$discard_from      = (int) ( $batch_state['offset'] ?? 0 );
 				$remaining         = array_slice( is_array( $batch_state['items'] ?? null ) ? $batch_state['items'] : array(), $discard_from );
 				$remaining_cleanup = array_slice( is_array( $batch_state['cleanup_contexts'] ?? null ) ? $batch_state['cleanup_contexts'] : array(), $discard_from );
@@ -320,16 +309,18 @@ class BatchScheduler {
 				}
 			}
 
-			EngineData::mutate(
-				$parent_job_id,
-				static function ( array $current ): array {
-					if ( ! is_array( $current['batch_state']['in_flight'] ?? null ) ) {
-						unset( $current['batch_state'] );
-					}
-					return $current;
-				},
-				'batch_cancelled_cleanup'
-			);
+			if ( ! $duplicate ) {
+				EngineData::mutate(
+					$parent_job_id,
+					static function ( array $current ): array {
+						if ( ! is_array( $current['batch_state']['in_flight'] ?? null ) ) {
+							unset( $current['batch_state'] );
+						}
+						return $current;
+					},
+					'batch_cancelled_cleanup'
+				);
+			}
 
 			return array(
 				'scheduled' => 0,
@@ -338,7 +329,7 @@ class BatchScheduler {
 				'more'      => false,
 				'cancelled' => true,
 				'missing'   => false,
-				'duplicate' => false,
+				'duplicate' => $duplicate,
 			);
 		}
 
@@ -486,7 +477,7 @@ class BatchScheduler {
 						'parent_job_id' => $parent_job_id,
 						'offset'        => $new_offset,
 					),
-					'data-machine'
+					GroupRegistrar::GROUP
 				);
 			} catch ( \Throwable $exception ) {
 				$action_id = 0;

--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -418,8 +418,8 @@ class BatchScheduler {
 		foreach ( $chunk as $index => $item ) {
 			$latest = EngineData::retrieve( $parent_job_id );
 			if ( ! empty( $latest['cancelled'] ) ) {
-				$cancelled        = true;
-				$remaining        = array_slice( $chunk, $index );
+				$cancelled         = true;
+				$remaining         = array_slice( $chunk, $index );
 				$remaining_cleanup = array_slice( $cleanup_contexts, $offset + $index, count( $remaining ) );
 				if ( $remaining ) {
 					do_action( 'datamachine_batch_items_discarded', $remaining, $parent_job_id, (string) $context, $remaining_cleanup );
@@ -561,14 +561,14 @@ class BatchScheduler {
 				$context                 = (string) ( $current['batch_context'] ?? '' );
 				$state                   = is_array( $current['batch_state'] ?? null ) ? $current['batch_state'] : array();
 				if ( $state && ! isset( $state['discarded_from'] ) ) {
-					$in_flight    = is_array( $state['in_flight'] ?? null ) ? $state['in_flight'] : array();
-					$discard_from = $in_flight
+					$in_flight               = is_array( $state['in_flight'] ?? null ) ? $state['in_flight'] : array();
+					$discard_from            = $in_flight
 						? (int) ( $in_flight['end'] ?? $state['offset'] ?? 0 )
 						: (int) ( $state['offset'] ?? 0 );
-					$remaining                 = array_slice( is_array( $state['items'] ?? null ) ? $state['items'] : array(), $discard_from );
-					$remaining_cleanup         = array_slice( is_array( $state['cleanup_contexts'] ?? null ) ? $state['cleanup_contexts'] : array(), $discard_from );
-					$state['discarded_from']   = $discard_from;
-					$current['batch_state']     = $state;
+					$remaining               = array_slice( is_array( $state['items'] ?? null ) ? $state['items'] : array(), $discard_from );
+					$remaining_cleanup       = array_slice( is_array( $state['cleanup_contexts'] ?? null ) ? $state['cleanup_contexts'] : array(), $discard_from );
+					$state['discarded_from'] = $discard_from;
+					$current['batch_state']  = $state;
 				}
 
 				return $current;

--- a/inc/Core/DataPacketStore.php
+++ b/inc/Core/DataPacketStore.php
@@ -181,17 +181,52 @@ class DataPacketStore {
 	 * @return mixed Value with packet collections hydrated.
 	 */
 	public static function hydrate_packet_collections_in_value( mixed $value ): mixed {
+		return self::hydrate_packet_collections_with_status( $value )['value'];
+	}
+
+	/**
+	 * Hydrate known packet collections and report missing/corrupt references.
+	 *
+	 * @param mixed $value Arbitrary value.
+	 * @return array{value:mixed,success:bool} Hydrated value and aggregate status.
+	 */
+	public static function hydrate_packet_collections_with_status( mixed $value ): array {
 		if ( ! is_array( $value ) ) {
-			return $value;
+			return array(
+				'value'   => $value,
+				'success' => true,
+			);
 		}
 
+		$success = true;
 		foreach ( array( 'data_packets', 'packets' ) as $key ) {
 			if ( isset( $value[ $key ] ) && is_array( $value[ $key ] ) ) {
-				$value[ $key ] = self::hydrate_many( $value[ $key ] );
+				$hydrated = array();
+				foreach ( $value[ $key ] as $packet ) {
+					if ( ! is_array( $packet ) ) {
+						$hydrated[] = $packet;
+						continue;
+					}
+					if ( ! empty( $packet['is_data_packet_ref'] ) && ! self::is_ref( $packet ) ) {
+						$success = false;
+						continue;
+					}
+
+					$packet_value = self::hydrate( $packet );
+					if ( null === $packet_value ) {
+						$success = false;
+						continue;
+					}
+					$hydrated[] = $packet_value;
+				}
+				$value[ $key ] = $hydrated;
 			}
 		}
 
-		return $value;
+		return array(
+			'value'   => $value,
+			'success' => $success,
+		);
 	}
 
 	/**

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -2127,11 +2127,13 @@ class Jobs extends BaseRepository {
 	private function get_job_for_update( int $job_id ): ?array {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; value uses a typed placeholder.
 		$query = $this->wpdb->prepare( 'SELECT * FROM %i WHERE job_id = %d FOR UPDATE', $this->table_name, $job_id );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Dynamic identifier is prepared with %i; job ID uses %d.
 		$job = $this->wpdb->get_row(
 			$query,
 			ARRAY_A
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		if ( is_array( $job ) && isset( $job['engine_data'] ) && is_string( $job['engine_data'] ) ) {
 			$decoded = json_decode( $job['engine_data'], true );
 			if ( JSON_ERROR_NONE === json_last_error() ) {

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -32,6 +32,9 @@ class Jobs extends BaseRepository {
 
 	const TABLE_NAME = 'datamachine_jobs';
 
+	/** Job currently owning the connection-wide terminal transaction. */
+	private static ?int $terminalizing_job = null;
+
 	/**
 	 * Known compound status suffixes for exact-match queries.
 	 *
@@ -1902,6 +1905,9 @@ class Jobs extends BaseRepository {
 				'status'         => $status,
 			);
 		}
+		if ( $is_final ) {
+			return $this->transition_terminal_job_status_result( $job_id, $status );
+		}
 
 		$job = $this->get_job( $job_id );
 		if ( ! is_array( $job ) ) {
@@ -1932,36 +1938,9 @@ class Jobs extends BaseRepository {
 			);
 		}
 
-		if ( $is_final ) {
-			/**
-			 * Filter a terminal status before its irreversible database transition.
-			 *
-			 * @param string $status Current terminal status.
-			 * @param int    $job_id Job ID.
-			 * @param array  $job Current job row.
-			 */
-			$status   = (string) apply_filters( 'datamachine_job_terminal_status', $status, $job_id, $job );
-			$is_final = JobStatus::isStatusFinal( $status );
-			if ( ! $is_final ) {
-				return array(
-					'success'        => false,
-					'changed'        => false,
-					'current_status' => $current_status,
-					'status'         => $status,
-				);
-			}
-		}
-
 		// Truncate to fit varchar(255) column.
 		if ( strlen( $status ) > 255 ) {
 			$status = substr( $status, 0, 252 ) . '...';
-		}
-
-		$update_data = array();
-		$format      = array();
-		if ( $is_final ) {
-			$update_data['completed_at'] = current_time( 'mysql', true );
-			$format[]                    = '%s';
 		}
 
 		$updated = LifecycleStateTransition::compare_and_set(
@@ -1971,9 +1950,9 @@ class Jobs extends BaseRepository {
 			'status',
 			$current_status,
 			$status,
-			$update_data,
+			array(),
 			array( '%d' ),
-			$format
+			array()
 		);
 
 		if ( false === $updated ) {
@@ -1998,16 +1977,178 @@ class Jobs extends BaseRepository {
 			);
 		}
 
-		if ( $is_final ) {
-			RunMetrics::complete( $job_id, $status );
-			do_action( 'datamachine_job_complete', $job_id, $status );
-		}
-
 		( new RunLifecycleStore( $this ) )->mark_job_status( $job_id, $status );
 
 		return array(
 			'success'        => true,
 			'changed'        => true,
+			'current_status' => $current_status,
+			'status'         => $status,
+		);
+	}
+
+	/**
+	 * Atomically prepare claim side effects and persist one terminal winner.
+	 *
+	 * @param int    $job_id Job ID.
+	 * @param string $requested_status Requested final status.
+	 * @return array{success: bool, changed: bool, current_status: ?string, status: string}
+	 */
+	private function transition_terminal_job_status_result( int $job_id, string $requested_status ): array {
+		if ( null !== self::$terminalizing_job ) {
+			return $this->status_transition_result( false, false, null, $requested_status );
+		}
+
+		self::$terminalizing_job = $job_id;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		if ( false === $this->wpdb->query( 'START TRANSACTION' ) ) {
+			self::$terminalizing_job = null;
+			return $this->status_transition_result( false, false, null, $requested_status );
+		}
+
+		$job = $this->get_job_for_update( $job_id );
+		if ( ! is_array( $job ) ) {
+			$this->rollback_terminal_transition( $job_id );
+			return $this->status_transition_result( false, false, null, $requested_status );
+		}
+
+		$current_status = is_string( $job['status'] ?? null ) ? $job['status'] : '';
+		if ( $current_status === $requested_status ) {
+			$this->rollback_terminal_transition( $job_id );
+			return $this->status_transition_result( true, false, $current_status, $current_status );
+		}
+		if ( JobStatus::isStatusFinal( $current_status ) ) {
+			$this->rollback_terminal_transition( $job_id );
+			return $this->status_transition_result( false, false, $current_status, $current_status );
+		}
+
+		$status = $requested_status;
+		if ( JobStatus::isStatusSuccess( $status ) ) {
+			try {
+				/**
+				 * Prepare a successful terminal transition inside the locked job transaction.
+				 *
+				 * Return WP_Error to roll back all preparation and persist its failure status.
+				 *
+				 * @param string $status Current terminal status.
+				 * @param int    $job_id Job ID.
+				 * @param array  $job Locked job row.
+				 */
+				$prepared_status = apply_filters( 'datamachine_job_terminal_status', $status, $job_id, $job );
+			} catch ( \Throwable $exception ) {
+				$prepared_status = new \WP_Error(
+					'terminal_preparation_exception',
+					$exception->getMessage(),
+					array( 'status' => JobStatus::failed( 'terminal_preparation_exception' )->toString() )
+				);
+			}
+
+			if ( is_wp_error( $prepared_status ) ) {
+				$this->rollback_terminal_transition( $job_id );
+				$failure_data   = $prepared_status->get_error_data();
+				$failure_status = is_array( $failure_data ) && is_string( $failure_data['status'] ?? null )
+					? $failure_data['status']
+					: JobStatus::failed( 'terminal_preparation_failed' )->toString();
+				return $this->transition_job_status_result( $job_id, $failure_status, true );
+			}
+			$status = is_string( $prepared_status ) ? $prepared_status : '';
+			if ( ! JobStatus::isStatusSuccess( $status ) ) {
+				$this->rollback_terminal_transition( $job_id );
+				$failure_status = JobStatus::isStatusFinal( $status )
+					? $status
+					: JobStatus::failed( 'terminal_preparation_failed' )->toString();
+				return $this->transition_job_status_result( $job_id, $failure_status, true );
+			}
+		}
+
+		if ( ! JobStatus::isStatusFinal( $status ) ) {
+			$this->rollback_terminal_transition( $job_id );
+			return $this->status_transition_result( false, false, $current_status, $current_status );
+		}
+		if ( strlen( $status ) > 255 ) {
+			$status = substr( $status, 0, 252 ) . '...';
+		}
+
+		// The locked row makes this a non-retrying ownership CAS. Any failure rolls
+		// back the whole callback/claim/job unit instead of retrying one statement.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $this->wpdb->update(
+			$this->table_name,
+			array(
+				'status'       => $status,
+				'completed_at' => current_time( 'mysql', true ),
+			),
+			array(
+				'job_id' => $job_id,
+				'status' => $current_status,
+			),
+			array( '%s', '%s' ),
+			array( '%d', '%s' )
+		);
+		if ( 1 !== $updated ) {
+			$this->rollback_terminal_transition( $job_id );
+			$winner = $this->get_job( $job_id );
+			$winner_status = is_array( $winner ) && is_string( $winner['status'] ?? null ) ? $winner['status'] : $current_status;
+			return $this->status_transition_result( false, false, $winner_status, $winner_status );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$committed = false !== $this->wpdb->query( 'COMMIT' );
+		self::$terminalizing_job = null;
+		if ( ! $committed ) {
+			$this->rollback_terminal_transition( $job_id );
+			$winner = $this->get_job( $job_id );
+			$winner_status = is_array( $winner ) && is_string( $winner['status'] ?? null ) ? $winner['status'] : $current_status;
+			return $this->status_transition_result( $status === $winner_status, false, $winner_status, $winner_status );
+		}
+
+		do_action( 'datamachine_job_terminal_committed', $job_id, $status );
+		RunMetrics::complete( $job_id, $status );
+		do_action( 'datamachine_job_complete', $job_id, $status );
+		( new RunLifecycleStore( $this ) )->mark_job_status( $job_id, $status );
+
+		return $this->status_transition_result( true, true, $current_status, $status );
+	}
+
+	/**
+	 * Read and decode one job while holding its row lock.
+	 *
+	 * @param int $job_id Job ID.
+	 * @return array|null Locked job row.
+	 */
+	private function get_job_for_update( int $job_id ): ?array {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$job = $this->wpdb->get_row(
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; value uses a typed placeholder.
+			$this->wpdb->prepare( 'SELECT * FROM %i WHERE job_id = %d FOR UPDATE', $this->table_name, $job_id ),
+			ARRAY_A
+		);
+		if ( is_array( $job ) && isset( $job['engine_data'] ) && is_string( $job['engine_data'] ) ) {
+			$decoded = json_decode( $job['engine_data'], true );
+			if ( JSON_ERROR_NONE === json_last_error() ) {
+				$job['engine_data'] = $decoded;
+			}
+		}
+
+		return is_array( $job ) ? $job : null;
+	}
+
+	/** Roll back a terminal ownership boundary and clear request-shared state. */
+	private function rollback_terminal_transition( int $job_id ): void {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$this->wpdb->query( 'ROLLBACK' );
+		wp_cache_delete( $job_id, 'datamachine_engine_data' );
+		self::$terminalizing_job = null;
+		do_action( 'datamachine_job_terminal_rolled_back', $job_id );
+	}
+
+	/**
+	 * Build the canonical status transition result envelope.
+	 */
+	private function status_transition_result( bool $success, bool $changed, ?string $current_status, string $status ): array {
+		return array(
+			'success'        => $success,
+			'changed'        => $changed,
 			'current_status' => $current_status,
 			'status'         => $status,
 		);

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -2127,12 +2127,8 @@ class Jobs extends BaseRepository {
 	private function get_job_for_update( int $job_id ): ?array {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; value uses a typed placeholder.
 		$query = $this->wpdb->prepare( 'SELECT * FROM %i WHERE job_id = %d FOR UPDATE', $this->table_name, $job_id );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$job = $this->wpdb->get_row(
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above; dynamic identifier uses %i and job ID uses %d.
-			$query,
-			ARRAY_A
-		);
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- $query is fully prepared above; %i binds the table and %d binds the job ID.
+		$job = $this->wpdb->get_row( $query, ARRAY_A );
 		if ( is_array( $job ) && isset( $job['engine_data'] ) && is_string( $job['engine_data'] ) ) {
 			$decoded = json_decode( $job['engine_data'], true );
 			if ( JSON_ERROR_NONE === json_last_error() ) {

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -2127,7 +2127,7 @@ class Jobs extends BaseRepository {
 	private function get_job_for_update( int $job_id ): ?array {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; value uses a typed placeholder.
 		$query = $this->wpdb->prepare( 'SELECT * FROM %i WHERE job_id = %d FOR UPDATE', $this->table_name, $job_id );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
 		$job = $this->wpdb->get_row(
 			$query,
 			ARRAY_A

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -2022,43 +2022,50 @@ class Jobs extends BaseRepository {
 			return $this->status_transition_result( false, false, $current_status, $current_status );
 		}
 
-		$status = $requested_status;
-		if ( JobStatus::isStatusSuccess( $status ) ) {
-			try {
-				/**
-				 * Prepare a successful terminal transition inside the locked job transaction.
-				 *
-				 * Return WP_Error to roll back all preparation and persist its failure status.
-				 *
-				 * @param string $status Current terminal status.
-				 * @param int    $job_id Job ID.
-				 * @param array  $job Locked job row.
-				 */
-				$prepared_status = apply_filters( 'datamachine_job_terminal_status', $status, $job_id, $job );
-			} catch ( \Throwable $exception ) {
-				$prepared_status = new \WP_Error(
-					'terminal_preparation_exception',
-					$exception->getMessage(),
-					array( 'status' => JobStatus::failed( 'terminal_preparation_exception' )->toString() )
-				);
-			}
+		$status            = $requested_status;
+		$requested_success = JobStatus::isStatusSuccess( $requested_status );
+		try {
+			/**
+			 * Prepare required claim transitions inside the locked job transaction.
+			 *
+			 * Return WP_Error to roll back all claim and callback changes.
+			 *
+			 * @param string $status Current terminal status.
+			 * @param int    $job_id Job ID.
+			 * @param array  $job Locked job row.
+			 */
+			$prepared_status = apply_filters( 'datamachine_job_terminal_status', $status, $job_id, $job );
+		} catch ( \Throwable $exception ) {
+			$prepared_status = new \WP_Error(
+				'terminal_preparation_exception',
+				$exception->getMessage(),
+				array( 'status' => JobStatus::failed( 'terminal_preparation_exception' )->toString() )
+			);
+		}
 
-			if ( is_wp_error( $prepared_status ) ) {
-				$this->rollback_terminal_transition( $job_id );
-				$failure_data   = $prepared_status->get_error_data();
-				$failure_status = is_array( $failure_data ) && is_string( $failure_data['status'] ?? null )
-					? $failure_data['status']
-					: JobStatus::failed( 'terminal_preparation_failed' )->toString();
-				return $this->transition_job_status_result( $job_id, $failure_status, true );
+		if ( is_wp_error( $prepared_status ) ) {
+			$this->rollback_terminal_transition( $job_id );
+			if ( ! $requested_success ) {
+				return $this->status_transition_result( false, false, $current_status, $current_status );
 			}
-			$status = is_string( $prepared_status ) ? $prepared_status : '';
-			if ( ! JobStatus::isStatusSuccess( $status ) ) {
-				$this->rollback_terminal_transition( $job_id );
-				$failure_status = JobStatus::isStatusFinal( $status )
-					? $status
-					: JobStatus::failed( 'terminal_preparation_failed' )->toString();
-				return $this->transition_job_status_result( $job_id, $failure_status, true );
-			}
+			$failure_data   = $prepared_status->get_error_data();
+			$failure_status = is_array( $failure_data ) && is_string( $failure_data['status'] ?? null )
+				? $failure_data['status']
+				: JobStatus::failed( 'terminal_preparation_failed' )->toString();
+			return $this->transition_job_status_result( $job_id, $failure_status, true );
+		}
+
+		$status = is_string( $prepared_status ) ? $prepared_status : '';
+		if ( $requested_success && ! JobStatus::isStatusSuccess( $status ) ) {
+			$this->rollback_terminal_transition( $job_id );
+			$failure_status = JobStatus::isStatusFinal( $status )
+				? $status
+				: JobStatus::failed( 'terminal_preparation_failed' )->toString();
+			return $this->transition_job_status_result( $job_id, $failure_status, true );
+		}
+		if ( ! $requested_success && JobStatus::isStatusSuccess( $status ) ) {
+			$this->rollback_terminal_transition( $job_id );
+			return $this->status_transition_result( false, false, $current_status, $current_status );
 		}
 
 		if ( ! JobStatus::isStatusFinal( $status ) ) {

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -2094,17 +2094,18 @@ class Jobs extends BaseRepository {
 		);
 		if ( 1 !== $updated ) {
 			$this->rollback_terminal_transition( $job_id );
-			$winner = $this->get_job( $job_id );
+			$winner        = $this->get_job( $job_id );
 			$winner_status = is_array( $winner ) && is_string( $winner['status'] ?? null ) ? $winner['status'] : $current_status;
 			return $this->status_transition_result( false, false, $winner_status, $winner_status );
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$committed = false !== $this->wpdb->query( 'COMMIT' );
+
 		self::$terminalizing_job = null;
 		if ( ! $committed ) {
 			$this->rollback_terminal_transition( $job_id );
-			$winner = $this->get_job( $job_id );
+			$winner        = $this->get_job( $job_id );
 			$winner_status = is_array( $winner ) && is_string( $winner['status'] ?? null ) ? $winner['status'] : $current_status;
 			return $this->status_transition_result( $status === $winner_status, false, $winner_status, $winner_status );
 		}
@@ -2124,10 +2125,11 @@ class Jobs extends BaseRepository {
 	 * @return array|null Locked job row.
 	 */
 	private function get_job_for_update( int $job_id ): ?array {
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; value uses a typed placeholder.
+		$query = $this->wpdb->prepare( 'SELECT * FROM %i WHERE job_id = %d FOR UPDATE', $this->table_name, $job_id );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$job = $this->wpdb->get_row(
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; value uses a typed placeholder.
-			$this->wpdb->prepare( 'SELECT * FROM %i WHERE job_id = %d FOR UPDATE', $this->table_name, $job_id ),
+			$query,
 			ARRAY_A
 		);
 		if ( is_array( $job ) && isset( $job['engine_data'] ) && is_string( $job['engine_data'] ) ) {

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -2128,12 +2128,11 @@ class Jobs extends BaseRepository {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; value uses a typed placeholder.
 		$query = $this->wpdb->prepare( 'SELECT * FROM %i WHERE job_id = %d FOR UPDATE', $this->table_name, $job_id );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Dynamic identifier is prepared with %i; job ID uses %d.
 		$job = $this->wpdb->get_row(
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above; dynamic identifier uses %i and job ID uses %d.
 			$query,
 			ARRAY_A
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		if ( is_array( $job ) && isset( $job['engine_data'] ) && is_string( $job['engine_data'] ) ) {
 			$decoded = json_decode( $job['engine_data'], true );
 			if ( JSON_ERROR_NONE === json_last_error() ) {

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -1903,11 +1903,6 @@ class Jobs extends BaseRepository {
 			);
 		}
 
-		// Truncate to fit varchar(255) column.
-		if ( strlen( $status ) > 255 ) {
-			$status = substr( $status, 0, 252 ) . '...';
-		}
-
 		$job = $this->get_job( $job_id );
 		if ( ! is_array( $job ) ) {
 			return array(
@@ -1935,6 +1930,31 @@ class Jobs extends BaseRepository {
 				'current_status' => $current_status,
 				'status'         => $status,
 			);
+		}
+
+		if ( $is_final ) {
+			/**
+			 * Filter a terminal status before its irreversible database transition.
+			 *
+			 * @param string $status Current terminal status.
+			 * @param int    $job_id Job ID.
+			 * @param array  $job Current job row.
+			 */
+			$status   = (string) apply_filters( 'datamachine_job_terminal_status', $status, $job_id, $job );
+			$is_final = JobStatus::isStatusFinal( $status );
+			if ( ! $is_final ) {
+				return array(
+					'success'        => false,
+					'changed'        => false,
+					'current_status' => $current_status,
+					'status'         => $status,
+				);
+			}
+		}
+
+		// Truncate to fit varchar(255) column.
+		if ( strlen( $status ) > 255 ) {
+			$status = substr( $status, 0, 252 ) . '...';
 		}
 
 		$update_data = array();

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -464,16 +464,16 @@ class ProcessedItems extends BaseRepository {
 	 * @param string $source_type     Source type.
 	 * @param string $item_identifier Unique item identifier.
 	 * @param int    $job_id          Completing legacy job ID.
-	 * @return bool Whether the job completed its current claim.
+	 * @return int|false Number of completed claims, or false on error.
 	 */
-	public function complete_claim_for_job( string $flow_step_id, string $source_type, string $item_identifier, int $job_id ): bool {
+	public function complete_claim_for_job( string $flow_step_id, string $source_type, string $item_identifier, int $job_id ): int|false {
 		if ( 1 > $job_id ) {
 			return false;
 		}
 
 		$now = current_time( 'mysql', true );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$updated = $this->wpdb->query(
+		return $this->wpdb->query(
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
 			$this->wpdb->prepare(
 				'UPDATE %i SET status = %s, processed_timestamp = %s, claim_expires_at = NULL, claim_token = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND job_id = %d AND status = %s',
@@ -487,8 +487,6 @@ class ProcessedItems extends BaseRepository {
 				self::STATUS_CLAIMED
 			)
 		);
-
-		return false !== $updated && 0 < $updated;
 	}
 
 	/**

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -14,7 +14,6 @@
 namespace DataMachine\Core\Database\ProcessedItems;
 
 use DataMachine\Core\Database\BaseRepository;
-use DataMachine\Core\Database\LifecycleStateTransition;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -27,6 +26,7 @@ class ProcessedItems extends BaseRepository {
 	const STATUS_PROCESSED          = 'processed';
 	const DEFAULT_CLAIM_TTL_SECONDS = 3600;
 	const CLAIM_METADATA_KEY        = '_datamachine_item_claim';
+	const CLAIMS_METADATA_KEY       = '_datamachine_item_claims';
 
 
 	/**
@@ -363,91 +363,100 @@ class ProcessedItems extends BaseRepository {
 			$ttl_seconds = self::DEFAULT_CLAIM_TTL_SECONDS;
 		}
 
-		$this->delete_expired_claims();
-
-		$expires_at = gmdate( 'Y-m-d H:i:s', time() + $ttl_seconds );
+		$now         = current_time( 'mysql', true );
+		$expires_at  = gmdate( 'Y-m-d H:i:s', time() + $ttl_seconds );
 		$claim_token = bin2hex( random_bytes( 16 ) );
 
-		// If the reprocess filter let a completed row through, atomically convert
-		// that processed row into a claim. Active claims remain untouched, so a
-		// parallel fetch still loses the race.
-		$claimed_existing_processed = LifecycleStateTransition::compare_and_set(
-			$this->wpdb,
-			$this->table_name,
-			array(
-				'flow_step_id'    => $identity_scope,
-				'source_type'     => $source_type,
-				'item_identifier' => $item_identifier,
-			),
-			'status',
-			self::STATUS_PROCESSED,
-			self::STATUS_CLAIMED,
-			array(
-				'job_id'           => $job_id,
-				'claim_expires_at' => $expires_at,
-				'claim_token'      => $claim_token,
-			),
-			array( '%s', '%s', '%s' ),
-			array( '%d', '%s', '%s' )
-		);
-
-		if ( false !== $claimed_existing_processed && $claimed_existing_processed > 0 ) {
-			return $claim_token;
-		}
-
-		if ( $this->has_active_claim( $identity_scope, $source_type, $item_identifier ) ) {
-			return false;
-		}
-
+		// One upsert handles absent-row races, processed-row reprocessing, and
+		// expired-claim takeover without surfacing duplicate-key errors. Assignment
+		// order is intentional: status is changed last so every condition observes
+		// the row state that existed when this statement acquired its lock.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with a %i table placeholder.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$result = $this->wpdb->insert(
-			$this->table_name,
-			array(
-				'flow_step_id'     => $identity_scope,
-				'source_type'      => $source_type,
-				'item_identifier'  => $item_identifier,
-				'job_id'           => $job_id,
-				'status'           => self::STATUS_CLAIMED,
-				'claim_expires_at' => $expires_at,
-				'claim_token'      => $claim_token,
-			),
-			array( '%s', '%s', '%s', '%d', '%s', '%s', '%s' )
+		$this->wpdb->query(
+			$this->wpdb->prepare(
+				'INSERT INTO %i (flow_step_id, source_type, item_identifier, job_id, status, claim_expires_at, claim_token)
+				VALUES (%s, %s, %s, %d, %s, %s, %s)
+				ON DUPLICATE KEY UPDATE
+				claim_token = IF(item_identifier = VALUES(item_identifier) AND (status = %s OR (status = %s AND claim_expires_at IS NOT NULL AND claim_expires_at <= %s)), VALUES(claim_token), claim_token),
+				job_id = IF(item_identifier = VALUES(item_identifier) AND (status = %s OR (status = %s AND claim_expires_at IS NOT NULL AND claim_expires_at <= %s)), VALUES(job_id), job_id),
+				claim_expires_at = IF(item_identifier = VALUES(item_identifier) AND (status = %s OR (status = %s AND claim_expires_at IS NOT NULL AND claim_expires_at <= %s)), VALUES(claim_expires_at), claim_expires_at),
+				status = IF(item_identifier = VALUES(item_identifier) AND (status = %s OR (status = %s AND claim_expires_at IS NOT NULL AND claim_expires_at <= %s)), VALUES(status), status)',
+				$this->table_name,
+				$identity_scope,
+				$source_type,
+				$item_identifier,
+				$job_id,
+				self::STATUS_CLAIMED,
+				$expires_at,
+				$claim_token,
+				self::STATUS_PROCESSED,
+				self::STATUS_CLAIMED,
+				$now,
+				self::STATUS_PROCESSED,
+				self::STATUS_CLAIMED,
+				$now,
+				self::STATUS_PROCESSED,
+				self::STATUS_CLAIMED,
+				$now,
+				self::STATUS_PROCESSED,
+				self::STATUS_CLAIMED,
+				$now
+			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
-		if ( false !== $result ) {
-			return $claim_token;
-		}
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with a %i table placeholder.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$owned_token = $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				'SELECT claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND status = %s',
+				$this->table_name,
+				$identity_scope,
+				$source_type,
+				$item_identifier,
+				self::STATUS_CLAIMED
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
-		return false;
+		return is_string( $owned_token ) && hash_equals( $claim_token, $owned_token ) ? $claim_token : false;
 	}
 
 	/**
-	 * Complete a claim only while the supplied token owns it.
+	 * Atomically run completion work and transition an owned claim.
 	 *
-	 * Processed rows retain the token until optional completion state is safely
-	 * persisted and an ephemeral claim row is removed.
+	 * The callback runs after an ownership-locking SELECT and before the claim
+	 * transition in the same transaction. Returning false or a failed transition
+	 * rolls back both the callback's database writes and the claim mutation.
 	 *
 	 * @param string $identity_scope  Claim identity scope.
 	 * @param string $source_type     Source type.
 	 * @param string $item_identifier Unique item identifier.
 	 * @param string $claim_token     Opaque ownership token.
 	 * @param int    $job_id          Completing job ID.
+	 * @param callable|null $completion Optional callback returning true on success.
+	 * @param bool   $retain_processed Whether to retain a processed row after completion.
 	 * @return bool Whether the token completed its owned claim.
 	 */
-	public function complete_owned_claim( string $identity_scope, string $source_type, string $item_identifier, string $claim_token, int $job_id ): bool {
+	public function complete_owned_claim( string $identity_scope, string $source_type, string $item_identifier, string $claim_token, int $job_id, ?callable $completion = null, bool $retain_processed = true ): bool {
 		if ( '' === $claim_token ) {
 			return false;
 		}
 
 		$now = current_time( 'mysql', true );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$updated = $this->wpdb->query(
+		$transaction_started = $this->wpdb->query( 'START TRANSACTION' );
+		if ( false === $transaction_started ) {
+			return false;
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with a %i table placeholder.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$owned = $this->wpdb->get_var(
 			$this->wpdb->prepare(
-				'UPDATE %i SET status = %s, job_id = %d, processed_timestamp = %s, claim_expires_at = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s AND claim_expires_at > %s',
+				'SELECT claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s AND claim_expires_at > %s FOR UPDATE',
 				$this->table_name,
-				self::STATUS_PROCESSED,
-				$job_id,
-				$now,
 				$identity_scope,
 				$source_type,
 				$item_identifier,
@@ -456,8 +465,69 @@ class ProcessedItems extends BaseRepository {
 				$now
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
-		return false !== $updated && $updated > 0;
+		if ( ! is_string( $owned ) || ! hash_equals( $claim_token, $owned ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$this->wpdb->query( 'ROLLBACK' );
+			return false;
+		}
+
+		try {
+			if ( null !== $completion && true !== $completion() ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$this->wpdb->query( 'ROLLBACK' );
+				return false;
+			}
+		} catch ( \Throwable $exception ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$this->wpdb->query( 'ROLLBACK' );
+			do_action( 'datamachine_log', 'error', 'Item claim completion callback failed.', array( 'exception' => $exception->getMessage() ) );
+			return false;
+		}
+
+		if ( $retain_processed ) {
+			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with a %i table placeholder.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$transitioned = $this->wpdb->query(
+				$this->wpdb->prepare(
+					'UPDATE %i SET status = %s, job_id = %d, processed_timestamp = %s, claim_expires_at = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s AND claim_expires_at > %s',
+					$this->table_name,
+					self::STATUS_PROCESSED,
+					$job_id,
+					$now,
+					$identity_scope,
+					$source_type,
+					$item_identifier,
+					$claim_token,
+					self::STATUS_CLAIMED,
+					$now
+				)
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		} else {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$transitioned = $this->wpdb->delete(
+				$this->table_name,
+				array(
+					'flow_step_id'    => $identity_scope,
+					'source_type'     => $source_type,
+					'item_identifier' => $item_identifier,
+					'claim_token'     => $claim_token,
+					'status'          => self::STATUS_CLAIMED,
+				),
+				array( '%s', '%s', '%s', '%s', '%s' )
+			);
+		}
+
+		if ( false === $transitioned || $transitioned < 1 ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$this->wpdb->query( 'ROLLBACK' );
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return false !== $this->wpdb->query( 'COMMIT' );
 	}
 
 	/**

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -376,7 +376,7 @@ class ProcessedItems extends BaseRepository {
 			return false;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Nested query is prepared with typed placeholders.
 		$upserted = $this->wpdb->query(
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
 			$this->wpdb->prepare(
@@ -399,7 +399,7 @@ class ProcessedItems extends BaseRepository {
 			return false;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Nested query is prepared with typed placeholders.
 		$row = $this->wpdb->get_row(
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
 			$this->wpdb->prepare(
@@ -475,7 +475,7 @@ class ProcessedItems extends BaseRepository {
 		}
 
 		$now = current_time( 'mysql', true );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Nested query is prepared with typed placeholders.
 		return $this->wpdb->query(
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
 			$this->wpdb->prepare(
@@ -514,9 +514,9 @@ class ProcessedItems extends BaseRepository {
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$nested = 1 === (int) $this->wpdb->get_var( 'SELECT @@in_transaction' );
-		$savepoint = 'datamachine_claim_completion_' . ++self::$savepoint_sequence;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Savepoint is a code-owned identifier.
+		$nested   = 1 === (int) $this->wpdb->get_var( 'SELECT @@in_transaction' );
+		$savepoint = 'datamachine_claim_completion_' . ( ++self::$savepoint_sequence );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Savepoint is a code-owned identifier.
 		$transaction_started = $this->wpdb->query( $nested ? "SAVEPOINT {$savepoint}" : 'START TRANSACTION' );
 		if ( false === $transaction_started ) {
 			return false;
@@ -531,22 +531,22 @@ class ProcessedItems extends BaseRepository {
 			$retain_processed
 		);
 		if ( ! $completed ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Savepoint is a code-owned identifier.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Savepoint is a code-owned identifier.
 			$this->wpdb->query( $nested ? "ROLLBACK TO SAVEPOINT {$savepoint}" : 'ROLLBACK' );
 			if ( $nested ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Savepoint is a code-owned identifier.
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Savepoint is a code-owned identifier.
 				$this->wpdb->query( "RELEASE SAVEPOINT {$savepoint}" );
 			}
 			return false;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Savepoint is a code-owned identifier.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Savepoint is a code-owned identifier.
 		$committed = false !== $this->wpdb->query( $nested ? "RELEASE SAVEPOINT {$savepoint}" : 'COMMIT' );
 		if ( ! $committed ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Savepoint is a code-owned identifier.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Savepoint is a code-owned identifier.
 			$this->wpdb->query( $nested ? "ROLLBACK TO SAVEPOINT {$savepoint}" : 'ROLLBACK' );
 			if ( $nested ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Savepoint is a code-owned identifier.
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Savepoint is a code-owned identifier.
 				$this->wpdb->query( "RELEASE SAVEPOINT {$savepoint}" );
 			}
 		}
@@ -578,7 +578,7 @@ class ProcessedItems extends BaseRepository {
 		}
 
 		$now = current_time( 'mysql', true );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Nested query is prepared with typed placeholders.
 		$owned = $this->wpdb->get_var(
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
 			$this->wpdb->prepare(
@@ -606,7 +606,7 @@ class ProcessedItems extends BaseRepository {
 		}
 
 		if ( $retain_processed ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Nested query is prepared with typed placeholders.
 			$transitioned = $this->wpdb->query(
 				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
 				$this->wpdb->prepare(

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -21,9 +21,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class ProcessedItems extends BaseRepository {
 
-	/** Monotonic suffix for connection-local nested claim savepoints. */
-	private static int $savepoint_sequence = 0;
-
 	const TABLE_NAME                = 'datamachine_processed_items';
 	const STATUS_CLAIMED            = 'claimed';
 	const STATUS_PROCESSED          = 'processed';
@@ -376,41 +373,38 @@ class ProcessedItems extends BaseRepository {
 			return false;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Nested query is prepared with typed placeholders.
-		$upserted = $this->wpdb->query(
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
-			$this->wpdb->prepare(
-				'INSERT INTO %i (flow_step_id, source_type, item_identifier, job_id, status, claim_expires_at, claim_token)
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
+		$upsert_query = $this->wpdb->prepare(
+			'INSERT INTO %i (flow_step_id, source_type, item_identifier, job_id, status, claim_expires_at, claim_token)
 				VALUES (%s, %s, %s, %d, %s, %s, %s)
 				ON DUPLICATE KEY UPDATE id = id',
-				$this->table_name,
-				$identity_scope,
-				$source_type,
-				$item_identifier,
-				$job_id,
-				self::STATUS_CLAIMED,
-				$expires_at,
-				$claim_token
-			)
+			$this->table_name,
+			$identity_scope,
+			$source_type,
+			$item_identifier,
+			$job_id,
+			self::STATUS_CLAIMED,
+			$expires_at,
+			$claim_token
 		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
+		$upserted = $this->wpdb->query( $upsert_query );
 		if ( false === $upserted ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$this->wpdb->query( 'ROLLBACK' );
 			return false;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Nested query is prepared with typed placeholders.
-		$row = $this->wpdb->get_row(
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
-			$this->wpdb->prepare(
-				'SELECT id, status, claim_expires_at, claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s FOR UPDATE',
-				$this->table_name,
-				$identity_scope,
-				$source_type,
-				$item_identifier
-			),
-			ARRAY_A
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
+		$lock_query = $this->wpdb->prepare(
+			'SELECT id, status, claim_expires_at, claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s FOR UPDATE',
+			$this->table_name,
+			$identity_scope,
+			$source_type,
+			$item_identifier
 		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
+		$row = $this->wpdb->get_row( $lock_query, ARRAY_A );
 
 		if ( ! is_array( $row ) ) {
 			// A different full identifier may share the 191-character unique-key prefix.
@@ -475,21 +469,20 @@ class ProcessedItems extends BaseRepository {
 		}
 
 		$now = current_time( 'mysql', true );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Nested query is prepared with typed placeholders.
-		return $this->wpdb->query(
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
-			$this->wpdb->prepare(
-				'UPDATE %i SET status = %s, processed_timestamp = %s, claim_expires_at = NULL, claim_token = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND job_id = %d AND status = %s',
-				$this->table_name,
-				self::STATUS_PROCESSED,
-				$now,
-				$flow_step_id,
-				$source_type,
-				$item_identifier,
-				$job_id,
-				self::STATUS_CLAIMED
-			)
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
+		$query = $this->wpdb->prepare(
+			'UPDATE %i SET status = %s, processed_timestamp = %s, claim_expires_at = NULL, claim_token = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND job_id = %d AND status = %s',
+			$this->table_name,
+			self::STATUS_PROCESSED,
+			$now,
+			$flow_step_id,
+			$source_type,
+			$item_identifier,
+			$job_id,
+			self::STATUS_CLAIMED
 		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
+		return $this->wpdb->query( $query );
 	}
 
 	/**
@@ -514,10 +507,7 @@ class ProcessedItems extends BaseRepository {
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$nested   = 1 === (int) $this->wpdb->get_var( 'SELECT @@in_transaction' );
-		$savepoint = 'datamachine_claim_completion_' . ( ++self::$savepoint_sequence );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Savepoint is a code-owned identifier.
-		$transaction_started = $this->wpdb->query( $nested ? "SAVEPOINT {$savepoint}" : 'START TRANSACTION' );
+		$transaction_started = $this->wpdb->query( 'START TRANSACTION' );
 		if ( false === $transaction_started ) {
 			return false;
 		}
@@ -531,24 +521,16 @@ class ProcessedItems extends BaseRepository {
 			$retain_processed
 		);
 		if ( ! $completed ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Savepoint is a code-owned identifier.
-			$this->wpdb->query( $nested ? "ROLLBACK TO SAVEPOINT {$savepoint}" : 'ROLLBACK' );
-			if ( $nested ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Savepoint is a code-owned identifier.
-				$this->wpdb->query( "RELEASE SAVEPOINT {$savepoint}" );
-			}
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$this->wpdb->query( 'ROLLBACK' );
 			return false;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Savepoint is a code-owned identifier.
-		$committed = false !== $this->wpdb->query( $nested ? "RELEASE SAVEPOINT {$savepoint}" : 'COMMIT' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$committed = false !== $this->wpdb->query( 'COMMIT' );
 		if ( ! $committed ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Savepoint is a code-owned identifier.
-			$this->wpdb->query( $nested ? "ROLLBACK TO SAVEPOINT {$savepoint}" : 'ROLLBACK' );
-			if ( $nested ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Savepoint is a code-owned identifier.
-				$this->wpdb->query( "RELEASE SAVEPOINT {$savepoint}" );
-			}
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$this->wpdb->query( 'ROLLBACK' );
 		}
 		return $committed;
 	}
@@ -572,25 +554,19 @@ class ProcessedItems extends BaseRepository {
 		if ( '' === $claim_token ) {
 			return false;
 		}
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		if ( 1 !== (int) $this->wpdb->get_var( 'SELECT @@in_transaction' ) ) {
-			return false;
-		}
-
 		$now = current_time( 'mysql', true );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Nested query is prepared with typed placeholders.
-		$owned = $this->wpdb->get_var(
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
-			$this->wpdb->prepare(
-				'SELECT claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s FOR UPDATE',
-				$this->table_name,
-				$identity_scope,
-				$source_type,
-				$item_identifier,
-				$claim_token,
-				self::STATUS_CLAIMED
-			)
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
+		$ownership_query = $this->wpdb->prepare(
+			'SELECT claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s FOR UPDATE',
+			$this->table_name,
+			$identity_scope,
+			$source_type,
+			$item_identifier,
+			$claim_token,
+			self::STATUS_CLAIMED
 		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
+		$owned = $this->wpdb->get_var( $ownership_query );
 
 		if ( ! is_string( $owned ) || ! hash_equals( $claim_token, $owned ) ) {
 			return false;
@@ -606,22 +582,21 @@ class ProcessedItems extends BaseRepository {
 		}
 
 		if ( $retain_processed ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Nested query is prepared with typed placeholders.
-			$transitioned = $this->wpdb->query(
-				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
-				$this->wpdb->prepare(
-					'UPDATE %i SET status = %s, job_id = %d, processed_timestamp = %s, claim_expires_at = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s',
-					$this->table_name,
-					self::STATUS_PROCESSED,
-					$job_id,
-					$now,
-					$identity_scope,
-					$source_type,
-					$item_identifier,
-					$claim_token,
-					self::STATUS_CLAIMED
-				)
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
+			$transition_query = $this->wpdb->prepare(
+				'UPDATE %i SET status = %s, job_id = %d, processed_timestamp = %s, claim_expires_at = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s',
+				$this->table_name,
+				self::STATUS_PROCESSED,
+				$job_id,
+				$now,
+				$identity_scope,
+				$source_type,
+				$item_identifier,
+				$claim_token,
+				self::STATUS_CLAIMED
 			);
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
+			$transitioned = $this->wpdb->query( $transition_query );
 		} else {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$transitioned = $this->wpdb->delete(

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -21,6 +21,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class ProcessedItems extends BaseRepository {
 
+	/** Monotonic suffix for connection-local nested claim savepoints. */
+	private static int $savepoint_sequence = 0;
+
 	const TABLE_NAME                = 'datamachine_processed_items';
 	const STATUS_CLAIMED            = 'claimed';
 	const STATUS_PROCESSED          = 'processed';
@@ -510,13 +513,71 @@ class ProcessedItems extends BaseRepository {
 			return false;
 		}
 
-		$now = current_time( 'mysql', true );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$transaction_started = $this->wpdb->query( 'START TRANSACTION' );
+		$nested = 1 === (int) $this->wpdb->get_var( 'SELECT @@in_transaction' );
+		$savepoint = 'datamachine_claim_completion_' . ++self::$savepoint_sequence;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Savepoint is a code-owned identifier.
+		$transaction_started = $this->wpdb->query( $nested ? "SAVEPOINT {$savepoint}" : 'START TRANSACTION' );
 		if ( false === $transaction_started ) {
 			return false;
 		}
+		$completed = $this->complete_owned_claim_in_transaction(
+			$identity_scope,
+			$source_type,
+			$item_identifier,
+			$claim_token,
+			$job_id,
+			$completion,
+			$retain_processed
+		);
+		if ( ! $completed ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Savepoint is a code-owned identifier.
+			$this->wpdb->query( $nested ? "ROLLBACK TO SAVEPOINT {$savepoint}" : 'ROLLBACK' );
+			if ( $nested ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Savepoint is a code-owned identifier.
+				$this->wpdb->query( "RELEASE SAVEPOINT {$savepoint}" );
+			}
+			return false;
+		}
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Savepoint is a code-owned identifier.
+		$committed = false !== $this->wpdb->query( $nested ? "RELEASE SAVEPOINT {$savepoint}" : 'COMMIT' );
+		if ( ! $committed ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Savepoint is a code-owned identifier.
+			$this->wpdb->query( $nested ? "ROLLBACK TO SAVEPOINT {$savepoint}" : 'ROLLBACK' );
+			if ( $nested ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Savepoint is a code-owned identifier.
+				$this->wpdb->query( "RELEASE SAVEPOINT {$savepoint}" );
+			}
+		}
+		return $committed;
+	}
+
+	/**
+	 * Complete an owned claim inside a caller-managed transaction.
+	 *
+	 * This method never starts, commits, or rolls back a transaction, allowing
+	 * every claim callback and transition to share the job terminal boundary.
+	 *
+	 * @param string $identity_scope  Claim identity scope.
+	 * @param string $source_type     Source type.
+	 * @param string $item_identifier Unique item identifier.
+	 * @param string $claim_token     Opaque ownership token.
+	 * @param int    $job_id          Completing job ID.
+	 * @param callable|null $completion Optional callback returning true on success.
+	 * @param bool   $retain_processed Whether to retain a processed row after completion.
+	 * @return bool Whether the token completed its owned claim.
+	 */
+	public function complete_owned_claim_in_transaction( string $identity_scope, string $source_type, string $item_identifier, string $claim_token, int $job_id, ?callable $completion = null, bool $retain_processed = true ): bool {
+		if ( '' === $claim_token ) {
+			return false;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		if ( 1 !== (int) $this->wpdb->get_var( 'SELECT @@in_transaction' ) ) {
+			return false;
+		}
+
+		$now = current_time( 'mysql', true );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$owned = $this->wpdb->get_var(
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
@@ -532,20 +593,14 @@ class ProcessedItems extends BaseRepository {
 		);
 
 		if ( ! is_string( $owned ) || ! hash_equals( $claim_token, $owned ) ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$this->wpdb->query( 'ROLLBACK' );
 			return false;
 		}
 
 		try {
 			if ( null !== $completion && true !== $completion() ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-				$this->wpdb->query( 'ROLLBACK' );
 				return false;
 			}
 		} catch ( \Throwable $exception ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$this->wpdb->query( 'ROLLBACK' );
 			do_action( 'datamachine_log', 'error', 'Item claim completion callback failed.', array( 'exception' => $exception->getMessage() ) );
 			return false;
 		}
@@ -583,13 +638,10 @@ class ProcessedItems extends BaseRepository {
 		}
 
 		if ( false === $transitioned || 1 > $transitioned ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$this->wpdb->query( 'ROLLBACK' );
 			return false;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		return false !== $this->wpdb->query( 'COMMIT' );
+		return true;
 	}
 
 	/**

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -387,8 +387,10 @@ class ProcessedItems extends BaseRepository {
 			$expires_at,
 			$claim_token
 		);
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Dynamic identifier is prepared with %i; every value uses a typed placeholder.
 		$upserted = $this->wpdb->query( $upsert_query );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		if ( false === $upserted ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$this->wpdb->query( 'ROLLBACK' );
@@ -403,8 +405,10 @@ class ProcessedItems extends BaseRepository {
 			$source_type,
 			$item_identifier
 		);
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Dynamic identifier is prepared with %i; every value uses a typed placeholder.
 		$row = $this->wpdb->get_row( $lock_query, ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( ! is_array( $row ) ) {
 			// A different full identifier may share the 191-character unique-key prefix.
@@ -481,8 +485,11 @@ class ProcessedItems extends BaseRepository {
 			$job_id,
 			self::STATUS_CLAIMED
 		);
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
-		return $this->wpdb->query( $query );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Dynamic identifier is prepared with %i; every value uses a typed placeholder.
+		$result = $this->wpdb->query( $query );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		return $result;
 	}
 
 	/**
@@ -565,8 +572,10 @@ class ProcessedItems extends BaseRepository {
 			$claim_token,
 			self::STATUS_CLAIMED
 		);
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Dynamic identifier is prepared with %i; every value uses a typed placeholder.
 		$owned = $this->wpdb->get_var( $ownership_query );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( ! is_string( $owned ) || ! hash_equals( $claim_token, $owned ) ) {
 			return false;
@@ -595,8 +604,10 @@ class ProcessedItems extends BaseRepository {
 				$claim_token,
 				self::STATUS_CLAIMED
 			);
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared immediately above.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Dynamic identifier is prepared with %i; every value uses a typed placeholder.
 			$transitioned = $this->wpdb->query( $transition_query );
+			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		} else {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$transitioned = $this->wpdb->delete(

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -357,7 +357,7 @@ class ProcessedItems extends BaseRepository {
 	 * @return string|false Opaque ownership token, or false when unavailable.
 	 */
 	public function claim_item_owned( string $identity_scope, string $source_type, string $item_identifier, int $job_id, int $ttl_seconds = self::DEFAULT_CLAIM_TTL_SECONDS ): string|false {
-		if ( $ttl_seconds < 1 ) {
+		if ( 1 > $ttl_seconds ) {
 			$ttl_seconds = self::DEFAULT_CLAIM_TTL_SECONDS;
 		}
 
@@ -373,9 +373,9 @@ class ProcessedItems extends BaseRepository {
 			return false;
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with a %i table placeholder.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$upserted = $this->wpdb->query(
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
 			$this->wpdb->prepare(
 				'INSERT INTO %i (flow_step_id, source_type, item_identifier, job_id, status, claim_expires_at, claim_token)
 				VALUES (%s, %s, %s, %d, %s, %s, %s)
@@ -390,16 +390,15 @@ class ProcessedItems extends BaseRepository {
 				$claim_token
 			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		if ( false === $upserted ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$this->wpdb->query( 'ROLLBACK' );
 			return false;
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with a %i table placeholder.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$row = $this->wpdb->get_row(
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
 			$this->wpdb->prepare(
 				'SELECT id, status, claim_expires_at, claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s FOR UPDATE',
 				$this->table_name,
@@ -409,7 +408,6 @@ class ProcessedItems extends BaseRepository {
 			),
 			ARRAY_A
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( ! is_array( $row ) ) {
 			// A different full identifier may share the 191-character unique-key prefix.
@@ -422,7 +420,7 @@ class ProcessedItems extends BaseRepository {
 		$inserted    = hash_equals( $claim_token, $owned_token );
 		$expired     = self::STATUS_CLAIMED === ( $row['status'] ?? '' )
 			&& ! empty( $row['claim_expires_at'] )
-			&& $row['claim_expires_at'] <= $now;
+			&& $now >= $row['claim_expires_at'];
 		$available   = self::STATUS_PROCESSED === ( $row['status'] ?? '' ) || $expired;
 
 		if ( ! $inserted && ! $available ) {
@@ -445,7 +443,7 @@ class ProcessedItems extends BaseRepository {
 				array( '%d', '%s', '%s', '%s' ),
 				array( '%d' )
 			);
-			if ( false === $updated || $updated < 1 ) {
+			if ( false === $updated || 1 > $updated ) {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 				$this->wpdb->query( 'ROLLBACK' );
 				return false;
@@ -469,14 +467,14 @@ class ProcessedItems extends BaseRepository {
 	 * @return bool Whether the job completed its current claim.
 	 */
 	public function complete_claim_for_job( string $flow_step_id, string $source_type, string $item_identifier, int $job_id ): bool {
-		if ( $job_id < 1 ) {
+		if ( 1 > $job_id ) {
 			return false;
 		}
 
 		$now = current_time( 'mysql', true );
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with a %i table placeholder.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->query(
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
 			$this->wpdb->prepare(
 				'UPDATE %i SET status = %s, processed_timestamp = %s, claim_expires_at = NULL, claim_token = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND job_id = %d AND status = %s',
 				$this->table_name,
@@ -489,9 +487,8 @@ class ProcessedItems extends BaseRepository {
 				self::STATUS_CLAIMED
 			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
-		return false !== $updated && $updated > 0;
+		return false !== $updated && 0 < $updated;
 	}
 
 	/**
@@ -522,9 +519,9 @@ class ProcessedItems extends BaseRepository {
 			return false;
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with a %i table placeholder.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$owned = $this->wpdb->get_var(
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
 			$this->wpdb->prepare(
 				'SELECT claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s FOR UPDATE',
 				$this->table_name,
@@ -535,7 +532,6 @@ class ProcessedItems extends BaseRepository {
 				self::STATUS_CLAIMED
 			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( ! is_string( $owned ) || ! hash_equals( $claim_token, $owned ) ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -557,9 +553,9 @@ class ProcessedItems extends BaseRepository {
 		}
 
 		if ( $retain_processed ) {
-			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with a %i table placeholder.
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$transitioned = $this->wpdb->query(
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
 				$this->wpdb->prepare(
 					'UPDATE %i SET status = %s, job_id = %d, processed_timestamp = %s, claim_expires_at = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s',
 					$this->table_name,
@@ -573,7 +569,6 @@ class ProcessedItems extends BaseRepository {
 					self::STATUS_CLAIMED
 				)
 			);
-			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		} else {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$transitioned = $this->wpdb->delete(
@@ -589,7 +584,7 @@ class ProcessedItems extends BaseRepository {
 			);
 		}
 
-		if ( false === $transitioned || $transitioned < 1 ) {
+		if ( false === $transitioned || 1 > $transitioned ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$this->wpdb->query( 'ROLLBACK' );
 			return false;

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -419,11 +419,11 @@ class ProcessedItems extends BaseRepository {
 		}
 
 		$owned_token = is_string( $row['claim_token'] ?? null ) ? $row['claim_token'] : '';
-		$inserted     = hash_equals( $claim_token, $owned_token );
-		$expired      = self::STATUS_CLAIMED === ( $row['status'] ?? '' )
+		$inserted    = hash_equals( $claim_token, $owned_token );
+		$expired     = self::STATUS_CLAIMED === ( $row['status'] ?? '' )
 			&& ! empty( $row['claim_expires_at'] )
 			&& $row['claim_expires_at'] <= $now;
-		$available    = self::STATUS_PROCESSED === ( $row['status'] ?? '' ) || $expired;
+		$available   = self::STATUS_PROCESSED === ( $row['status'] ?? '' ) || $expired;
 
 		if ( ! $inserted && ! $available ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -436,8 +436,8 @@ class ProcessedItems extends BaseRepository {
 			$updated = $this->wpdb->update(
 				$this->table_name,
 				array(
-					'job_id'          => $job_id,
-					'status'          => self::STATUS_CLAIMED,
+					'job_id'           => $job_id,
+					'status'           => self::STATUS_CLAIMED,
 					'claim_expires_at' => $expires_at,
 					'claim_token'      => $claim_token,
 				),
@@ -454,6 +454,44 @@ class ProcessedItems extends BaseRepository {
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		return false !== $this->wpdb->query( 'COMMIT' ) ? $claim_token : false;
+	}
+
+	/**
+	 * Complete a descriptor-less claim while the completing job still owns it.
+	 *
+	 * Reacquisition replaces job_id, so a stale legacy completion cannot mutate
+	 * a token-owned replacement generation.
+	 *
+	 * @param string $flow_step_id    Flow step identity scope.
+	 * @param string $source_type     Source type.
+	 * @param string $item_identifier Unique item identifier.
+	 * @param int    $job_id          Completing legacy job ID.
+	 * @return bool Whether the job completed its current claim.
+	 */
+	public function complete_claim_for_job( string $flow_step_id, string $source_type, string $item_identifier, int $job_id ): bool {
+		if ( $job_id < 1 ) {
+			return false;
+		}
+
+		$now = current_time( 'mysql', true );
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with a %i table placeholder.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $this->wpdb->query(
+			$this->wpdb->prepare(
+				'UPDATE %i SET status = %s, processed_timestamp = %s, claim_expires_at = NULL, claim_token = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND job_id = %d AND status = %s',
+				$this->table_name,
+				self::STATUS_PROCESSED,
+				$now,
+				$flow_step_id,
+				$source_type,
+				$item_identifier,
+				$job_id,
+				self::STATUS_CLAIMED
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		return false !== $updated && $updated > 0;
 	}
 
 	/**

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -26,6 +26,7 @@ class ProcessedItems extends BaseRepository {
 	const STATUS_CLAIMED            = 'claimed';
 	const STATUS_PROCESSED          = 'processed';
 	const DEFAULT_CLAIM_TTL_SECONDS = 3600;
+	const CLAIM_METADATA_KEY        = '_datamachine_item_claim';
 
 
 	/**
@@ -296,9 +297,9 @@ class ProcessedItems extends BaseRepository {
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with %i table placeholder.
 		$result = $this->wpdb->query(
 			$this->wpdb->prepare(
-				'INSERT INTO %i (flow_step_id, source_type, item_identifier, job_id, status, processed_timestamp, claim_expires_at)
-				VALUES (%s, %s, %s, %d, %s, %s, NULL)
-				ON DUPLICATE KEY UPDATE job_id = VALUES(job_id), status = VALUES(status), processed_timestamp = VALUES(processed_timestamp), claim_expires_at = NULL',
+				'INSERT INTO %i (flow_step_id, source_type, item_identifier, job_id, status, processed_timestamp, claim_expires_at, claim_token)
+				VALUES (%s, %s, %s, %d, %s, %s, NULL, NULL)
+				ON DUPLICATE KEY UPDATE job_id = VALUES(job_id), status = VALUES(status), processed_timestamp = VALUES(processed_timestamp), claim_expires_at = NULL, claim_token = NULL',
 				$this->table_name,
 				$flow_step_id,
 				$source_type,
@@ -341,6 +342,23 @@ class ProcessedItems extends BaseRepository {
 	 * @return bool True when this caller owns the claim; false when already processed or actively claimed.
 	 */
 	public function claim_item( string $flow_step_id, string $source_type, string $item_identifier, int $job_id, int $ttl_seconds = self::DEFAULT_CLAIM_TTL_SECONDS ): bool {
+		return false !== $this->claim_item_owned( $flow_step_id, $source_type, $item_identifier, $job_id, $ttl_seconds );
+	}
+
+	/**
+	 * Atomically claim a source identity and return its ownership token.
+	 *
+	 * The first argument is an identity scope. Existing callers use their flow
+	 * step ID; cross-flow consumers may provide a stable shared scope.
+	 *
+	 * @param string $identity_scope  Caller-provided identity scope.
+	 * @param string $source_type     Source type.
+	 * @param string $item_identifier Unique item identifier.
+	 * @param int    $job_id          Job creating the claim.
+	 * @param int    $ttl_seconds     Claim TTL in seconds.
+	 * @return string|false Opaque ownership token, or false when unavailable.
+	 */
+	public function claim_item_owned( string $identity_scope, string $source_type, string $item_identifier, int $job_id, int $ttl_seconds = self::DEFAULT_CLAIM_TTL_SECONDS ): string|false {
 		if ( $ttl_seconds < 1 ) {
 			$ttl_seconds = self::DEFAULT_CLAIM_TTL_SECONDS;
 		}
@@ -348,6 +366,7 @@ class ProcessedItems extends BaseRepository {
 		$this->delete_expired_claims();
 
 		$expires_at = gmdate( 'Y-m-d H:i:s', time() + $ttl_seconds );
+		$claim_token = bin2hex( random_bytes( 16 ) );
 
 		// If the reprocess filter let a completed row through, atomically convert
 		// that processed row into a claim. Active claims remain untouched, so a
@@ -356,7 +375,7 @@ class ProcessedItems extends BaseRepository {
 			$this->wpdb,
 			$this->table_name,
 			array(
-				'flow_step_id'    => $flow_step_id,
+				'flow_step_id'    => $identity_scope,
 				'source_type'     => $source_type,
 				'item_identifier' => $item_identifier,
 			),
@@ -366,16 +385,17 @@ class ProcessedItems extends BaseRepository {
 			array(
 				'job_id'           => $job_id,
 				'claim_expires_at' => $expires_at,
+				'claim_token'      => $claim_token,
 			),
 			array( '%s', '%s', '%s' ),
-			array( '%d', '%s' )
+			array( '%d', '%s', '%s' )
 		);
 
 		if ( false !== $claimed_existing_processed && $claimed_existing_processed > 0 ) {
-			return true;
+			return $claim_token;
 		}
 
-		if ( $this->has_active_claim( $flow_step_id, $source_type, $item_identifier ) ) {
+		if ( $this->has_active_claim( $identity_scope, $source_type, $item_identifier ) ) {
 			return false;
 		}
 
@@ -383,21 +403,90 @@ class ProcessedItems extends BaseRepository {
 		$result = $this->wpdb->insert(
 			$this->table_name,
 			array(
-				'flow_step_id'     => $flow_step_id,
+				'flow_step_id'     => $identity_scope,
 				'source_type'      => $source_type,
 				'item_identifier'  => $item_identifier,
 				'job_id'           => $job_id,
 				'status'           => self::STATUS_CLAIMED,
 				'claim_expires_at' => $expires_at,
+				'claim_token'      => $claim_token,
 			),
-			array( '%s', '%s', '%s', '%d', '%s', '%s' )
+			array( '%s', '%s', '%s', '%d', '%s', '%s', '%s' )
 		);
 
 		if ( false !== $result ) {
-			return true;
+			return $claim_token;
 		}
 
 		return false;
+	}
+
+	/**
+	 * Complete a claim only while the supplied token owns it.
+	 *
+	 * Processed rows retain the token until optional completion state is safely
+	 * persisted and an ephemeral claim row is removed.
+	 *
+	 * @param string $identity_scope  Claim identity scope.
+	 * @param string $source_type     Source type.
+	 * @param string $item_identifier Unique item identifier.
+	 * @param string $claim_token     Opaque ownership token.
+	 * @param int    $job_id          Completing job ID.
+	 * @return bool Whether the token completed its owned claim.
+	 */
+	public function complete_owned_claim( string $identity_scope, string $source_type, string $item_identifier, string $claim_token, int $job_id ): bool {
+		if ( '' === $claim_token ) {
+			return false;
+		}
+
+		$now = current_time( 'mysql', true );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $this->wpdb->query(
+			$this->wpdb->prepare(
+				'UPDATE %i SET status = %s, job_id = %d, processed_timestamp = %s, claim_expires_at = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s AND claim_expires_at > %s',
+				$this->table_name,
+				self::STATUS_PROCESSED,
+				$job_id,
+				$now,
+				$identity_scope,
+				$source_type,
+				$item_identifier,
+				$claim_token,
+				self::STATUS_CLAIMED,
+				$now
+			)
+		);
+
+		return false !== $updated && $updated > 0;
+	}
+
+	/**
+	 * Release a claim only while the supplied token owns it.
+	 *
+	 * @param string $identity_scope  Claim identity scope.
+	 * @param string $source_type     Source type.
+	 * @param string $item_identifier Unique item identifier.
+	 * @param string $claim_token     Opaque ownership token.
+	 * @param bool   $completed       Whether to remove an owned processed row.
+	 * @return int|false Number of rows released, or false on error.
+	 */
+	public function release_owned_claim( string $identity_scope, string $source_type, string $item_identifier, string $claim_token, bool $completed = false ): int|false {
+		if ( '' === $claim_token ) {
+			return 0;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $this->wpdb->delete(
+			$this->table_name,
+			array(
+				'flow_step_id'    => $identity_scope,
+				'source_type'     => $source_type,
+				'item_identifier' => $item_identifier,
+				'claim_token'     => $claim_token,
+				'status'          => $completed ? self::STATUS_PROCESSED : self::STATUS_CLAIMED,
+			),
+			array( '%s', '%s', '%s', '%s', '%s' )
+		);
 	}
 
 	/**
@@ -670,6 +759,7 @@ class ProcessedItems extends BaseRepository {
             job_id BIGINT(20) UNSIGNED NOT NULL,
 			status VARCHAR(20) NOT NULL DEFAULT 'processed',
 			claim_expires_at DATETIME NULL,
+			claim_token VARCHAR(64) NULL,
             processed_timestamp DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
             PRIMARY KEY  (id),
             UNIQUE KEY `flow_source_item` (flow_step_id, source_type, item_identifier(191)),
@@ -833,6 +923,17 @@ class ProcessedItems extends BaseRepository {
 			$wpdb->query(
 				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
 				$wpdb->prepare( 'ALTER TABLE %i ADD COLUMN claim_expires_at DATETIME NULL', $table_name )
+			);
+		}
+
+		$token_column = $wpdb->get_var(
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
+			$wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $table_name, 'claim_token' )
+		);
+		if ( ! $token_column ) {
+			$wpdb->query(
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses %i identifier placeholder; WPCS does not recognize %i (false positive).
+				$wpdb->prepare( 'ALTER TABLE %i ADD COLUMN claim_token VARCHAR(64) NULL', $table_name )
 			);
 		}
 

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -55,8 +55,6 @@ class ProcessedItems extends BaseRepository {
 	 * @return bool True when an active claim exists.
 	 */
 	public function has_active_claim( string $flow_step_id, string $source_type, string $item_identifier ): bool {
-		$this->delete_expired_claims();
-
 		$now = current_time( 'mysql', true );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with %i table placeholder.
@@ -367,21 +365,21 @@ class ProcessedItems extends BaseRepository {
 		$expires_at  = gmdate( 'Y-m-d H:i:s', time() + $ttl_seconds );
 		$claim_token = bin2hex( random_bytes( 16 ) );
 
-		// One upsert handles absent-row races, processed-row reprocessing, and
-		// expired-claim takeover without surfacing duplicate-key errors. Assignment
-		// order is intentional: status is changed last so every condition observes
-		// the row state that existed when this statement acquired its lock.
+		// Insert-or-lock avoids duplicate-key errors under contention. The no-op
+		// duplicate update acquires the existing row lock on both MySQL and MariaDB;
+		// the locked read below then decides whether this generation may take over.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		if ( false === $this->wpdb->query( 'START TRANSACTION' ) ) {
+			return false;
+		}
+
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with a %i table placeholder.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$this->wpdb->query(
+		$upserted = $this->wpdb->query(
 			$this->wpdb->prepare(
 				'INSERT INTO %i (flow_step_id, source_type, item_identifier, job_id, status, claim_expires_at, claim_token)
 				VALUES (%s, %s, %s, %d, %s, %s, %s)
-				ON DUPLICATE KEY UPDATE
-				claim_token = IF(item_identifier = VALUES(item_identifier) AND (status = %s OR (status = %s AND claim_expires_at IS NOT NULL AND claim_expires_at <= %s)), VALUES(claim_token), claim_token),
-				job_id = IF(item_identifier = VALUES(item_identifier) AND (status = %s OR (status = %s AND claim_expires_at IS NOT NULL AND claim_expires_at <= %s)), VALUES(job_id), job_id),
-				claim_expires_at = IF(item_identifier = VALUES(item_identifier) AND (status = %s OR (status = %s AND claim_expires_at IS NOT NULL AND claim_expires_at <= %s)), VALUES(claim_expires_at), claim_expires_at),
-				status = IF(item_identifier = VALUES(item_identifier) AND (status = %s OR (status = %s AND claim_expires_at IS NOT NULL AND claim_expires_at <= %s)), VALUES(status), status)',
+				ON DUPLICATE KEY UPDATE id = id',
 				$this->table_name,
 				$identity_scope,
 				$source_type,
@@ -389,38 +387,73 @@ class ProcessedItems extends BaseRepository {
 				$job_id,
 				self::STATUS_CLAIMED,
 				$expires_at,
-				$claim_token,
-				self::STATUS_PROCESSED,
-				self::STATUS_CLAIMED,
-				$now,
-				self::STATUS_PROCESSED,
-				self::STATUS_CLAIMED,
-				$now,
-				self::STATUS_PROCESSED,
-				self::STATUS_CLAIMED,
-				$now,
-				self::STATUS_PROCESSED,
-				self::STATUS_CLAIMED,
-				$now
+				$claim_token
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		if ( false === $upserted ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$this->wpdb->query( 'ROLLBACK' );
+			return false;
+		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with a %i table placeholder.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$owned_token = $this->wpdb->get_var(
+		$row = $this->wpdb->get_row(
 			$this->wpdb->prepare(
-				'SELECT claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND status = %s',
+				'SELECT id, status, claim_expires_at, claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s FOR UPDATE',
 				$this->table_name,
 				$identity_scope,
 				$source_type,
-				$item_identifier,
-				self::STATUS_CLAIMED
-			)
+				$item_identifier
+			),
+			ARRAY_A
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
-		return is_string( $owned_token ) && hash_equals( $claim_token, $owned_token ) ? $claim_token : false;
+		if ( ! is_array( $row ) ) {
+			// A different full identifier may share the 191-character unique-key prefix.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$this->wpdb->query( 'ROLLBACK' );
+			return false;
+		}
+
+		$owned_token = is_string( $row['claim_token'] ?? null ) ? $row['claim_token'] : '';
+		$inserted     = hash_equals( $claim_token, $owned_token );
+		$expired      = self::STATUS_CLAIMED === ( $row['status'] ?? '' )
+			&& ! empty( $row['claim_expires_at'] )
+			&& $row['claim_expires_at'] <= $now;
+		$available    = self::STATUS_PROCESSED === ( $row['status'] ?? '' ) || $expired;
+
+		if ( ! $inserted && ! $available ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$this->wpdb->query( 'ROLLBACK' );
+			return false;
+		}
+
+		if ( ! $inserted ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$updated = $this->wpdb->update(
+				$this->table_name,
+				array(
+					'job_id'          => $job_id,
+					'status'          => self::STATUS_CLAIMED,
+					'claim_expires_at' => $expires_at,
+					'claim_token'      => $claim_token,
+				),
+				array( 'id' => (int) $row['id'] ),
+				array( '%d', '%s', '%s', '%s' ),
+				array( '%d' )
+			);
+			if ( false === $updated || $updated < 1 ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$this->wpdb->query( 'ROLLBACK' );
+				return false;
+			}
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return false !== $this->wpdb->query( 'COMMIT' ) ? $claim_token : false;
 	}
 
 	/**
@@ -455,14 +488,13 @@ class ProcessedItems extends BaseRepository {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$owned = $this->wpdb->get_var(
 			$this->wpdb->prepare(
-				'SELECT claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s AND claim_expires_at > %s FOR UPDATE',
+				'SELECT claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s FOR UPDATE',
 				$this->table_name,
 				$identity_scope,
 				$source_type,
 				$item_identifier,
 				$claim_token,
-				self::STATUS_CLAIMED,
-				$now
+				self::STATUS_CLAIMED
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
@@ -491,7 +523,7 @@ class ProcessedItems extends BaseRepository {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$transitioned = $this->wpdb->query(
 				$this->wpdb->prepare(
-					'UPDATE %i SET status = %s, job_id = %d, processed_timestamp = %s, claim_expires_at = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s AND claim_expires_at > %s',
+					'UPDATE %i SET status = %s, job_id = %d, processed_timestamp = %s, claim_expires_at = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s',
 					$this->table_name,
 					self::STATUS_PROCESSED,
 					$job_id,
@@ -500,8 +532,7 @@ class ProcessedItems extends BaseRepository {
 					$source_type,
 					$item_identifier,
 					$claim_token,
-					self::STATUS_CLAIMED,
-					$now
+					self::STATUS_CLAIMED
 				)
 			);
 			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
@@ -600,7 +631,10 @@ class ProcessedItems extends BaseRepository {
 	}
 
 	/**
-	 * Delete expired in-flight claims.
+	 * Delete expired legacy claims that have no ownership generation.
+	 *
+	 * Token-owned rows remain available for either completion by the current
+	 * generation or atomic takeover by a replacement generation.
 	 *
 	 * @return int|false Number of rows deleted, or false on error.
 	 */
@@ -611,7 +645,7 @@ class ProcessedItems extends BaseRepository {
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with %i table placeholder.
 		$result = $this->wpdb->query(
 			$this->wpdb->prepare(
-				'DELETE FROM %i WHERE status = %s AND claim_expires_at IS NOT NULL AND claim_expires_at <= %s',
+				'DELETE FROM %i WHERE status = %s AND claim_token IS NULL AND claim_expires_at IS NOT NULL AND claim_expires_at <= %s',
 				$this->table_name,
 				self::STATUS_CLAIMED,
 				$now

--- a/inc/Core/Database/TrackedItems/TrackedItems.php
+++ b/inc/Core/Database/TrackedItems/TrackedItems.php
@@ -8,8 +8,6 @@
 namespace DataMachine\Core\Database\TrackedItems;
 
 use DataMachine\Core\Database\BaseRepository;
-use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
-
 defined( 'ABSPATH' ) || exit;
 
 class TrackedItems extends BaseRepository {
@@ -87,70 +85,31 @@ class TrackedItems extends BaseRepository {
 	}
 
 	/**
-	 * Upsert a tracked item only while an in-flight token owns its claim.
+	 * Register tracked-item completion with the generic claim lifecycle.
 	 *
-	 * The INSERT ... SELECT performs ownership validation and the ledger write
-	 * in one SQL statement. A claim deleted or replaced after TTL expiry cannot
-	 * satisfy the SELECT and therefore cannot overwrite a newer revision.
-	 *
-	 * @param array<string,mixed> $item  Tracked item payload.
-	 * @param array<string,mixed> $claim Claim lifecycle descriptor.
-	 * @return array<string,mixed>|null Stored row, or null without ownership/on failure.
+	 * @param array<string,callable> $handlers Registered completion handlers.
+	 * @return array<string,callable> Registered completion handlers.
 	 */
-	public function upsert_owned( array $item, array $claim ): ?array {
-		$normalized = $this->normalize_item( $item );
-		$scope      = (string) ( $claim['identity_scope'] ?? '' );
-		$source     = (string) ( $claim['source_type'] ?? '' );
-		$item_id    = (string) ( $claim['item_identifier'] ?? '' );
-		$token      = (string) ( $claim['ownership_token'] ?? '' );
-		if ( '' === $normalized['namespace'] || '' === $normalized['item_id'] || '' === $scope || '' === $source || '' === $item_id || '' === $token ) {
-			return null;
+	public static function registerClaimCompletionHandler( array $handlers ): array {
+		$handlers['tracked_item'] = array( self::class, 'completeClaim' );
+		return $handlers;
+	}
+
+	/**
+	 * Persist a tracked item inside the owning claim transaction.
+	 *
+	 * @param array<string,mixed> $payload Completion payload.
+	 * @param int                 $job_id Completing job ID.
+	 * @return bool Whether the tracked item was persisted.
+	 */
+	public static function completeClaim( array $payload, int $job_id ): bool {
+		$item = is_array( $payload['item'] ?? null ) ? $payload['item'] : array();
+		if ( empty( $item ) ) {
+			return false;
 		}
 
-		$now          = current_time( 'mysql', true );
-		$last_seen_at = '' !== $normalized['last_seen_at'] ? $normalized['last_seen_at'] : $now;
-		$first_seen_at = '' !== $normalized['first_seen_at'] ? $normalized['first_seen_at'] : $now;
-		$processed     = new ProcessedItems();
-
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with %i table placeholders.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$result = $this->wpdb->query(
-			$this->wpdb->prepare(
-				'INSERT INTO %i (namespace, item_id, item_type, state, source_ref, source_revision, source_path, source_line, output_ref, metadata_json, first_seen_at, last_seen_at, last_job_id, updated_at)
-				SELECT %s, %s, %s, %s, %s, %s, %s, %d, %s, %s, %s, %s, %d, %s FROM %i
-				WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND status = %s AND claim_token = %s AND claim_expires_at > %s
-				ON DUPLICATE KEY UPDATE item_type = VALUES(item_type), state = VALUES(state), source_ref = VALUES(source_ref), source_revision = VALUES(source_revision), source_path = VALUES(source_path), source_line = VALUES(source_line), output_ref = VALUES(output_ref), metadata_json = VALUES(metadata_json), last_seen_at = VALUES(last_seen_at), last_job_id = VALUES(last_job_id), updated_at = VALUES(updated_at)',
-				$this->table_name,
-				$normalized['namespace'],
-				$normalized['item_id'],
-				$normalized['item_type'],
-				$normalized['state'],
-				$normalized['source_ref'],
-				$normalized['source_revision'],
-				$normalized['source_path'],
-				$normalized['source_line'],
-				$normalized['output_ref'],
-				wp_json_encode( $normalized['metadata'], JSON_UNESCAPED_SLASHES ),
-				$first_seen_at,
-				$last_seen_at,
-				$normalized['last_job_id'],
-				$now,
-				$processed->get_table_name(),
-				$scope,
-				$source,
-				$item_id,
-				ProcessedItems::STATUS_CLAIMED,
-				$token,
-				$now
-			)
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
-
-		if ( false === $result || 0 === $result ) {
-			return null;
-		}
-
-		return $this->get( $normalized['namespace'], $normalized['item_id'] );
+		$item['last_job_id'] = $job_id;
+		return null !== ( new self() )->upsert( $item );
 	}
 
 	/**

--- a/inc/Core/Database/TrackedItems/TrackedItems.php
+++ b/inc/Core/Database/TrackedItems/TrackedItems.php
@@ -63,11 +63,13 @@ class TrackedItems extends BaseRepository {
 				$formats,
 				array( '%d' )
 			);
+			$stored = array_merge( $existing, $row );
 		} else {
 			$row['first_seen_at'] = '' !== $normalized['first_seen_at'] ? $normalized['first_seen_at'] : $now;
 			$formats[]            = '%s';
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$result = $this->wpdb->insert( $this->table_name, $row, $formats );
+			$stored = array_merge( array( 'id' => (int) $this->wpdb->insert_id ), $row );
 		}
 
 		if ( false === $result ) {
@@ -81,7 +83,7 @@ class TrackedItems extends BaseRepository {
 			return null;
 		}
 
-		return $this->get( $normalized['namespace'], $normalized['item_id'] );
+		return self::normalize_row( $stored );
 	}
 
 	/**

--- a/inc/Core/Database/TrackedItems/TrackedItems.php
+++ b/inc/Core/Database/TrackedItems/TrackedItems.php
@@ -8,6 +8,7 @@
 namespace DataMachine\Core\Database\TrackedItems;
 
 use DataMachine\Core\Database\BaseRepository;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -79,6 +80,73 @@ class TrackedItems extends BaseRepository {
 					'item_id'   => $normalized['item_id'],
 				)
 			);
+			return null;
+		}
+
+		return $this->get( $normalized['namespace'], $normalized['item_id'] );
+	}
+
+	/**
+	 * Upsert a tracked item only while an in-flight token owns its claim.
+	 *
+	 * The INSERT ... SELECT performs ownership validation and the ledger write
+	 * in one SQL statement. A claim deleted or replaced after TTL expiry cannot
+	 * satisfy the SELECT and therefore cannot overwrite a newer revision.
+	 *
+	 * @param array<string,mixed> $item  Tracked item payload.
+	 * @param array<string,mixed> $claim Claim lifecycle descriptor.
+	 * @return array<string,mixed>|null Stored row, or null without ownership/on failure.
+	 */
+	public function upsert_owned( array $item, array $claim ): ?array {
+		$normalized = $this->normalize_item( $item );
+		$scope      = (string) ( $claim['identity_scope'] ?? '' );
+		$source     = (string) ( $claim['source_type'] ?? '' );
+		$item_id    = (string) ( $claim['item_identifier'] ?? '' );
+		$token      = (string) ( $claim['ownership_token'] ?? '' );
+		if ( '' === $normalized['namespace'] || '' === $normalized['item_id'] || '' === $scope || '' === $source || '' === $item_id || '' === $token ) {
+			return null;
+		}
+
+		$now          = current_time( 'mysql', true );
+		$last_seen_at = '' !== $normalized['last_seen_at'] ? $normalized['last_seen_at'] : $now;
+		$first_seen_at = '' !== $normalized['first_seen_at'] ? $normalized['first_seen_at'] : $now;
+		$processed     = new ProcessedItems();
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with %i table placeholders.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $this->wpdb->query(
+			$this->wpdb->prepare(
+				'INSERT INTO %i (namespace, item_id, item_type, state, source_ref, source_revision, source_path, source_line, output_ref, metadata_json, first_seen_at, last_seen_at, last_job_id, updated_at)
+				SELECT %s, %s, %s, %s, %s, %s, %s, %d, %s, %s, %s, %s, %d, %s FROM %i
+				WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND status = %s AND claim_token = %s AND claim_expires_at > %s
+				ON DUPLICATE KEY UPDATE item_type = VALUES(item_type), state = VALUES(state), source_ref = VALUES(source_ref), source_revision = VALUES(source_revision), source_path = VALUES(source_path), source_line = VALUES(source_line), output_ref = VALUES(output_ref), metadata_json = VALUES(metadata_json), last_seen_at = VALUES(last_seen_at), last_job_id = VALUES(last_job_id), updated_at = VALUES(updated_at)',
+				$this->table_name,
+				$normalized['namespace'],
+				$normalized['item_id'],
+				$normalized['item_type'],
+				$normalized['state'],
+				$normalized['source_ref'],
+				$normalized['source_revision'],
+				$normalized['source_path'],
+				$normalized['source_line'],
+				$normalized['output_ref'],
+				wp_json_encode( $normalized['metadata'], JSON_UNESCAPED_SLASHES ),
+				$first_seen_at,
+				$last_seen_at,
+				$normalized['last_job_id'],
+				$now,
+				$processed->get_table_name(),
+				$scope,
+				$source,
+				$item_id,
+				ProcessedItems::STATUS_CLAIMED,
+				$token,
+				$now
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( false === $result || 0 === $result ) {
 			return null;
 		}
 

--- a/inc/Core/ExecutionContext.php
+++ b/inc/Core/ExecutionContext.php
@@ -260,18 +260,39 @@ class ExecutionContext {
 		 *     @type int    $job_id          Current job ID (0 if unavailable).
 		 * }
 		 */
-		$skip = (bool) apply_filters(
+		return $this->shouldSkipItem( $skip, $item_identifier );
+	}
+
+	/**
+	 * Apply the public reprocess policy with the actual flow-step context.
+	 *
+	 * Consumers with their own revision ledger can supply its skip decision and
+	 * additional context without substituting a synthetic identity scope for the
+	 * flow step that is actually executing.
+	 *
+	 * @param bool   $skip               Consumer's default skip decision.
+	 * @param string $item_identifier    Item identifier being evaluated.
+	 * @param array  $additional_context Additional public filter context.
+	 * @return bool Filtered skip decision.
+	 */
+	public function shouldSkipItem( bool $skip, string $item_identifier, array $additional_context = array() ): bool {
+		if ( $this->isDirect() || $this->isStandalone() || ! $this->flow_step_id ) {
+			return $skip;
+		}
+
+		return (bool) apply_filters(
 			'datamachine_should_reprocess_item',
 			$skip,
-			array(
-				'flow_step_id'    => $this->flow_step_id,
-				'source_type'     => $this->handler_type,
-				'item_identifier' => $item_identifier,
-				'job_id'          => (int) $this->job_id,
+			array_merge(
+				$additional_context,
+				array(
+					'flow_step_id'    => $this->flow_step_id,
+					'source_type'     => $this->handler_type,
+					'item_identifier' => $item_identifier,
+					'job_id'          => (int) $this->job_id,
+				)
 			)
 		);
-
-		return $skip;
 	}
 
 	/**
@@ -311,16 +332,55 @@ class ExecutionContext {
 			return true;
 		}
 
-		if ( empty( $this->job_id ) ) {
+		$claim = $this->claimItemOwnership( $this->flow_step_id, $item_identifier );
+		if ( false === $claim ) {
 			return false;
 		}
 
-		$db_processed_items = new ProcessedItems();
-		return $db_processed_items->claim_item(
-			$this->flow_step_id,
+		$this->storeEngineData( array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
+		return true;
+	}
+
+	/**
+	 * Claim an item under a caller-provided identity scope.
+	 *
+	 * Attach the returned descriptor to DataPacket metadata under
+	 * ProcessedItems::CLAIM_METADATA_KEY. Data Machine propagates it to child
+	 * work and owns terminal completion/release. The optional completion payload
+	 * may contain a `tracked_item` array and `keep_processed` boolean.
+	 *
+	 * @param string $identity_scope  Caller-provided stable identity scope.
+	 * @param string $item_identifier Stable item identifier within the scope.
+	 * @param int    $ttl_seconds     Claim lifetime in seconds.
+	 * @param array  $completion      Optional successful-completion behavior.
+	 * @return array<string,mixed>|false Opaque lifecycle descriptor, or false on contention.
+	 */
+	public function claimItemOwnership( string $identity_scope, string $item_identifier, int $ttl_seconds = ProcessedItems::DEFAULT_CLAIM_TTL_SECONDS, array $completion = array() ): array|false {
+		if ( $this->isDirect() || $this->isStandalone() ) {
+			return array( 'persisted' => false );
+		}
+
+		if ( '' === trim( $identity_scope ) || '' === $item_identifier || empty( $this->job_id ) ) {
+			return false;
+		}
+
+		$token = ( new ProcessedItems() )->claim_item_owned(
+			$identity_scope,
 			$this->handler_type,
 			$item_identifier,
-			(int) $this->job_id
+			(int) $this->job_id,
+			$ttl_seconds
+		);
+		if ( false === $token ) {
+			return false;
+		}
+
+		return array(
+			'identity_scope'  => $identity_scope,
+			'source_type'     => $this->handler_type,
+			'item_identifier' => $item_identifier,
+			'ownership_token' => $token,
+			'completion'      => $completion,
 		);
 	}
 

--- a/inc/Core/ExecutionContext.php
+++ b/inc/Core/ExecutionContext.php
@@ -346,8 +346,9 @@ class ExecutionContext {
 	 *
 	 * Attach the returned descriptor to DataPacket metadata under
 	 * ProcessedItems::CLAIM_METADATA_KEY. Data Machine propagates it to child
-	 * work and owns terminal completion/release. The optional completion payload
-	 * may contain a `tracked_item` array and `keep_processed` boolean.
+	 * work and owns terminal completion/release. Completion behavior is selected
+	 * through a registered handler ID plus opaque payload; `retain_processed`
+	 * controls whether successful completion retains the dedupe row.
 	 *
 	 * @param string $identity_scope  Caller-provided stable identity scope.
 	 * @param string $item_identifier Stable item identifier within the scope.

--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -19,6 +19,7 @@ namespace DataMachine\Core\Steps\Fetch\Handlers;
 
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Core\DataPacket;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\ExecutionContext;
 use DataMachine\Core\FilesRepository\FileStorage;
 use DataMachine\Core\Steps\Fetch\Tools\FetchItemDispositionTool;
@@ -184,9 +185,12 @@ abstract class FetchHandler {
 				continue;
 			}
 
-			if ( ! $context->claimItemForProcessing( (string) $item_identifier ) ) {
+			$claim = $context->claimItemOwnership( (string) $context->getFlowStepId(), (string) $item_identifier );
+			if ( false === $claim ) {
 				continue;
 			}
+
+			$item['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] = $claim;
 
 			$result[] = $item;
 		}

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -70,6 +70,8 @@ function datamachine_register_core_actions() {
 	add_action( 'datamachine_step_lifecycle_inline_continuation', array( StepLifecycleHandler::class, 'handleInlineContinuation' ), 10, 3 );
 	add_action( 'datamachine_step_lifecycle_completed', array( StepLifecycleHandler::class, 'handleCompleted' ), 10, 2 );
 	add_action( 'datamachine_step_lifecycle_failed', array( StepLifecycleHandler::class, 'handleFailed' ), 10, 2 );
+	add_action( 'datamachine_job_complete', array( StepLifecycleHandler::class, 'handleTerminal' ), 5, 2 );
+	add_action( 'datamachine_batch_items_discarded', array( StepLifecycleHandler::class, 'handleDiscardedPackets' ), 10, 3 );
 	add_action(
 		'datamachine_pending_action_staged',
 		function ( string $action_id, array $payload ): void {

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -73,6 +73,8 @@ function datamachine_register_core_actions() {
 	add_action( 'datamachine_step_lifecycle_failed', array( StepLifecycleHandler::class, 'handleFailed' ), 10, 2 );
 	add_action( 'datamachine_job_complete', array( StepLifecycleHandler::class, 'handleTerminal' ), 5, 2 );
 	add_filter( 'datamachine_job_terminal_status', array( StepLifecycleHandler::class, 'filterTerminalStatus' ), 10, 3 );
+	add_action( 'datamachine_job_terminal_rolled_back', array( StepLifecycleHandler::class, 'handleTerminalRollback' ) );
+	add_action( 'datamachine_job_terminal_committed', array( StepLifecycleHandler::class, 'handleTerminalCommit' ), 10, 2 );
 	add_action( 'datamachine_batch_items_discarded', array( StepLifecycleHandler::class, 'handleDiscardedPackets' ), 10, 4 );
 	add_filter( 'datamachine_batch_item_cleanup_context', array( StepLifecycleHandler::class, 'captureBatchItemCleanupContext' ), 10, 2 );
 	add_filter( 'datamachine_item_claim_completion_handlers', array( TrackedItems::class, 'registerClaimCompletionHandler' ) );

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -53,6 +53,7 @@ use DataMachine\Engine\Actions\Handlers\FailJobHandler;
 use DataMachine\Engine\Actions\Handlers\JobCompleteHandler;
 use DataMachine\Engine\Actions\Handlers\LogHandler;
 use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
+use DataMachine\Core\Database\TrackedItems\TrackedItems;
 use AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision;
 use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action;
 
@@ -71,7 +72,9 @@ function datamachine_register_core_actions() {
 	add_action( 'datamachine_step_lifecycle_completed', array( StepLifecycleHandler::class, 'handleCompleted' ), 10, 2 );
 	add_action( 'datamachine_step_lifecycle_failed', array( StepLifecycleHandler::class, 'handleFailed' ), 10, 2 );
 	add_action( 'datamachine_job_complete', array( StepLifecycleHandler::class, 'handleTerminal' ), 5, 2 );
-	add_action( 'datamachine_batch_items_discarded', array( StepLifecycleHandler::class, 'handleDiscardedPackets' ), 10, 3 );
+	add_action( 'datamachine_batch_items_discarded', array( StepLifecycleHandler::class, 'handleDiscardedPackets' ), 10, 4 );
+	add_filter( 'datamachine_batch_item_cleanup_context', array( StepLifecycleHandler::class, 'captureBatchItemCleanupContext' ), 10, 2 );
+	add_filter( 'datamachine_item_claim_completion_handlers', array( TrackedItems::class, 'registerClaimCompletionHandler' ) );
 	add_action(
 		'datamachine_pending_action_staged',
 		function ( string $action_id, array $payload ): void {

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -72,6 +72,7 @@ function datamachine_register_core_actions() {
 	add_action( 'datamachine_step_lifecycle_completed', array( StepLifecycleHandler::class, 'handleCompleted' ), 10, 2 );
 	add_action( 'datamachine_step_lifecycle_failed', array( StepLifecycleHandler::class, 'handleFailed' ), 10, 2 );
 	add_action( 'datamachine_job_complete', array( StepLifecycleHandler::class, 'handleTerminal' ), 5, 2 );
+	add_filter( 'datamachine_job_terminal_status', array( StepLifecycleHandler::class, 'filterTerminalStatus' ), 10, 3 );
 	add_action( 'datamachine_batch_items_discarded', array( StepLifecycleHandler::class, 'handleDiscardedPackets' ), 10, 4 );
 	add_filter( 'datamachine_batch_item_cleanup_context', array( StepLifecycleHandler::class, 'captureBatchItemCleanupContext' ), 10, 2 );
 	add_filter( 'datamachine_item_claim_completion_handlers', array( TrackedItems::class, 'registerClaimCompletionHandler' ) );

--- a/inc/Engine/Actions/Handlers/FailJobHandler.php
+++ b/inc/Engine/Actions/Handlers/FailJobHandler.php
@@ -125,7 +125,6 @@ class FailJobHandler {
 		}
 
 		$db_processed_items->delete_processed_items( array( 'job_id' => $job_id ) );
-		do_action( 'datamachine_step_lifecycle_failed', $job_id, $engine_data );
 
 		$cleanup_files = \DataMachine\Core\PluginSettings::get( 'cleanup_job_data_on_failure', true );
 		$files_cleaned = false;

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -9,7 +9,6 @@
 namespace DataMachine\Engine\Actions\Handlers;
 
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
-use DataMachine\Core\Database\TrackedItems\TrackedItems;
 use DataMachine\Core\DataPacketStore;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\PacketEngineData;
@@ -33,18 +32,24 @@ class StepLifecycleHandler {
 			return;
 		}
 
-		$packet_meta = $routed_packets[0]['metadata'] ?? array();
-		$seed_data   = is_array( $packet_meta['_engine_data'] ?? null )
-			? PacketEngineData::sanitize( $packet_meta['_engine_data'], $job_id )
-			: array();
-		if ( ! empty( $packet_meta['item_identifier'] ) ) {
-			$seed_data['item_identifier'] = $packet_meta['item_identifier'];
+		$seed_data = array();
+		$claims    = self::claimsFromEngine( \datamachine_get_engine_data( $job_id ) );
+		foreach ( $routed_packets as $packet ) {
+			$packet_meta = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+			if ( empty( $seed_data ) && is_array( $packet_meta['_engine_data'] ?? null ) ) {
+				$seed_data = PacketEngineData::sanitize( $packet_meta['_engine_data'], $job_id );
+			}
+			if ( ! isset( $seed_data['item_identifier'] ) && ! empty( $packet_meta['item_identifier'] ) ) {
+				$seed_data['item_identifier'] = $packet_meta['item_identifier'];
+			}
+			if ( ! isset( $seed_data['source_type'] ) && ! empty( $packet_meta['source_type'] ) ) {
+				$seed_data['source_type'] = $packet_meta['source_type'];
+			}
+			$claims = array_merge( $claims, self::normalizeClaims( $packet_meta ) );
 		}
-		if ( ! empty( $packet_meta['source_type'] ) ) {
-			$seed_data['source_type'] = $packet_meta['source_type'];
-		}
-		if ( is_array( $packet_meta[ ProcessedItems::CLAIM_METADATA_KEY ] ?? null ) ) {
-			$seed_data[ ProcessedItems::CLAIM_METADATA_KEY ] = $packet_meta[ ProcessedItems::CLAIM_METADATA_KEY ];
+		if ( ! empty( $claims ) ) {
+			$seed_data[ ProcessedItems::CLAIMS_METADATA_KEY ] = self::uniqueClaims( $claims );
+			unset( $seed_data[ ProcessedItems::CLAIM_METADATA_KEY ] );
 		}
 		if ( ! empty( $seed_data ) ) {
 			\datamachine_merge_engine_data( $job_id, $seed_data );
@@ -59,9 +64,11 @@ class StepLifecycleHandler {
 	 */
 	public static function handleCompleted( int $job_id, ?array $engine_data = null ): void {
 		$engine_data = is_array( $engine_data ) ? $engine_data : \datamachine_get_engine_data( $job_id );
-		$claim       = self::claimFromEngine( $engine_data );
-		if ( null !== $claim ) {
-			self::completeClaim( $claim, $job_id );
+		$claims      = self::claimsFromEngine( $engine_data );
+		if ( ! empty( $claims ) ) {
+			foreach ( $claims as $claim ) {
+				self::completeClaim( $claim, $job_id );
+			}
 			return;
 		}
 
@@ -105,10 +112,16 @@ class StepLifecycleHandler {
 	 */
 	public static function handleFailed( int $job_id, ?array $engine_data = null ): void {
 		$engine_data = is_array( $engine_data ) ? $engine_data : \datamachine_get_engine_data( $job_id );
-		$claim       = self::claimFromEngine( $engine_data );
-		if ( null !== $claim ) {
-			self::releaseClaim( $claim );
+		$claims      = self::claimsFromEngine( $engine_data );
+		if ( ! empty( $claims ) ) {
+			foreach ( $claims as $claim ) {
+				self::releaseClaim( $claim );
+			}
 		}
+
+		// Pre-descriptor and partially migrated jobs still own claims by job_id.
+		// Reacquisition replaces job_id, so this cannot release a newer worker's row.
+		( new ProcessedItems() )->release_claims_for_job( $job_id );
 	}
 
 	/**
@@ -133,38 +146,56 @@ class StepLifecycleHandler {
 	 * @param array  $items         Discarded batch items.
 	 * @param int    $parent_job_id Parent job ID.
 	 * @param string $context       Batch consumer context.
+	 * @param array  $cleanup_contexts Sidecar cleanup contexts captured before storage.
 	 */
-	public static function handleDiscardedPackets( array $items, int $parent_job_id, string $context ): void {
+	public static function handleDiscardedPackets( array $items, int $parent_job_id, string $context, array $cleanup_contexts = array() ): void {
 		unset( $parent_job_id, $context );
-		foreach ( $items as $item ) {
-			$item     = DataPacketStore::hydrate_packet_collections_in_value( $item );
-			$metadata = is_array( $item['metadata'] ?? null ) ? $item['metadata'] : array();
-			$claim    = self::normalizeClaim( $metadata[ ProcessedItems::CLAIM_METADATA_KEY ] ?? null );
-			if ( null !== $claim ) {
+		foreach ( $items as $index => $item ) {
+			$item   = DataPacketStore::hydrate_packet_collections_in_value( $item );
+			$claims = array_merge(
+				self::collectClaimsInValue( $item ),
+				self::collectClaimsInValue( $cleanup_contexts[ $index ] ?? array() )
+			);
+			foreach ( $claims as $claim ) {
 				self::releaseClaim( $claim );
 			}
 		}
 	}
 
 	/**
-	 * Apply optional tracked-item state and complete an owned claim.
+	 * Capture claim descriptors before batch content-addressing.
 	 *
-	 * TrackedItems validates ownership in the same SQL statement as its upsert.
-	 * A stale worker therefore cannot update a replacement owner's revision.
+	 * @param array $context Existing cleanup context.
+	 * @param mixed $item    Batch item before storage.
+	 * @return array Cleanup context.
+	 */
+	public static function captureBatchItemCleanupContext( array $context, mixed $item ): array {
+		$context[ ProcessedItems::CLAIMS_METADATA_KEY ] = self::collectClaimsInValue( $item );
+		return $context;
+	}
+
+	/**
+	 * Run an optional registered completion handler and transition the claim.
 	 *
 	 * @param array $claim  Validated claim descriptor.
 	 * @param int   $job_id Completing job ID.
 	 */
 	private static function completeClaim( array $claim, int $job_id ): void {
-		$processed    = new ProcessedItems();
-		$completion   = is_array( $claim['completion'] ?? null ) ? $claim['completion'] : array();
-		$tracked_item = is_array( $completion['tracked_item'] ?? null ) ? $completion['tracked_item'] : null;
-		if ( null !== $tracked_item ) {
-			$tracked_item['last_job_id'] = $job_id;
-			if ( null === ( new TrackedItems() )->upsert_owned( $tracked_item, $claim ) ) {
-				$processed->release_owned_claim( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'], $claim['ownership_token'] );
+		$processed  = new ProcessedItems();
+		$completion = is_array( $claim['completion'] ?? null ) ? $claim['completion'] : array();
+		$handler_id = is_string( $completion['handler'] ?? null ) ? $completion['handler'] : '';
+		$payload    = is_array( $completion['payload'] ?? null ) ? $completion['payload'] : array();
+		$callback   = null;
+
+		if ( '' !== $handler_id ) {
+			$handlers = apply_filters( 'datamachine_item_claim_completion_handlers', array() );
+			$handler  = $handlers[ $handler_id ] ?? null;
+			if ( ! is_callable( $handler ) ) {
+				self::releaseClaim( $claim );
 				return;
 			}
+
+			$callback = static fn(): bool => true === call_user_func( $handler, $payload, $job_id, $claim );
 		}
 
 		$owned = $processed->complete_owned_claim(
@@ -172,16 +203,15 @@ class StepLifecycleHandler {
 			$claim['source_type'],
 			$claim['item_identifier'],
 			$claim['ownership_token'],
-			$job_id
+			$job_id,
+			$callback,
+			false !== ( $completion['retain_processed'] ?? true )
 		);
 		if ( ! $owned ) {
+			self::releaseClaim( $claim );
 			return;
 		}
 		RunMetrics::increment( $job_id, 'processed' );
-
-		if ( isset( $completion['keep_processed'] ) && false === $completion['keep_processed'] ) {
-			$processed->release_owned_claim( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'], $claim['ownership_token'], true );
-		}
 	}
 
 	/**
@@ -199,13 +229,73 @@ class StepLifecycleHandler {
 	}
 
 	/**
-	 * Read a claim descriptor from engine data.
+	 * Read claim descriptors from engine data.
 	 *
 	 * @param array $engine_data Job engine snapshot.
-	 * @return array|null Validated descriptor, or null.
+	 * @return array<int,array<string,mixed>> Validated descriptors.
 	 */
-	private static function claimFromEngine( array $engine_data ): ?array {
-		return self::normalizeClaim( $engine_data[ ProcessedItems::CLAIM_METADATA_KEY ] ?? null );
+	private static function claimsFromEngine( array $engine_data ): array {
+		return self::normalizeClaims( $engine_data );
+	}
+
+	/**
+	 * Read singular and collection claim metadata from one container.
+	 *
+	 * @param array $container Engine data or packet metadata.
+	 * @return array<int,array<string,mixed>> Validated descriptors.
+	 */
+	private static function normalizeClaims( array $container ): array {
+		$claims = array();
+		$single = self::normalizeClaim( $container[ ProcessedItems::CLAIM_METADATA_KEY ] ?? null );
+		if ( null !== $single ) {
+			$claims[] = $single;
+		}
+
+		$collection = is_array( $container[ ProcessedItems::CLAIMS_METADATA_KEY ] ?? null )
+			? $container[ ProcessedItems::CLAIMS_METADATA_KEY ]
+			: array();
+		foreach ( $collection as $candidate ) {
+			$claim = self::normalizeClaim( $candidate );
+			if ( null !== $claim ) {
+				$claims[] = $claim;
+			}
+		}
+
+		return self::uniqueClaims( $claims );
+	}
+
+	/**
+	 * Deduplicate descriptors by ownership token.
+	 *
+	 * @param array<int,array<string,mixed>> $claims Claim descriptors.
+	 * @return array<int,array<string,mixed>> Unique descriptors.
+	 */
+	private static function uniqueClaims( array $claims ): array {
+		$unique = array();
+		foreach ( $claims as $claim ) {
+			$unique[ $claim['ownership_token'] ] = $claim;
+		}
+		return array_values( $unique );
+	}
+
+	/**
+	 * Recursively collect claim metadata from packets or sidecar context.
+	 *
+	 * @param mixed $value Candidate value.
+	 * @return array<int,array<string,mixed>> Validated descriptors.
+	 */
+	private static function collectClaimsInValue( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$claims = self::normalizeClaims( $value );
+		foreach ( $value as $child ) {
+			if ( is_array( $child ) ) {
+				$claims = array_merge( $claims, self::collectClaimsInValue( $child ) );
+			}
+		}
+		return self::uniqueClaims( $claims );
 	}
 
 	/**

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -208,7 +208,7 @@ class StepLifecycleHandler {
 			$claim['ownership_token'],
 			$job_id,
 			$callback,
-			( $completion['retain_processed'] ?? true ) !== false
+			false !== ( $completion['retain_processed'] ?? true )
 		);
 		if ( ! $owned ) {
 			self::releaseClaim( $claim );

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -83,13 +83,16 @@ class StepLifecycleHandler {
 			return;
 		}
 
-		\do_action(
-			'datamachine_mark_item_processed',
+		$completed = ( new ProcessedItems() )->complete_claim_for_job(
 			$source_flow_step_id,
-			$source_type,
-			$item_identifier,
+			(string) $source_type,
+			(string) $item_identifier,
 			$job_id
 		);
+		if ( ! $completed ) {
+			return;
+		}
+		RunMetrics::increment( $job_id, 'processed' );
 
 		\do_action(
 			'datamachine_log',

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -19,6 +19,9 @@ use DataMachine\Core\RunMetrics;
  */
 class StepLifecycleHandler {
 
+	/** @var array<int,int> Processed metrics deferred until terminal commit. */
+	private static array $pending_processed_metrics = array();
+
 	/**
 	 * Seed lifecycle context before an inline continuation.
 	 *
@@ -61,28 +64,32 @@ class StepLifecycleHandler {
 	 *
 	 * @param int        $job_id      Completed job ID.
 	 * @param array|null $engine_data Optional engine data snapshot.
+	 * @param bool       $within_transaction Whether the caller owns the terminal transaction.
 	 * @return bool Whether all owned descriptor and legacy claims completed.
 	 */
-	public static function handleCompleted( int $job_id, ?array $engine_data = null ): bool {
+	public static function handleCompleted( int $job_id, ?array $engine_data = null, bool $within_transaction = false ): bool {
 		$engine_data = is_array( $engine_data ) ? $engine_data : \datamachine_get_engine_data( $job_id );
 		$claims      = self::claimsFromEngine( $engine_data );
+		$completed   = 0;
 		if ( ! empty( $claims ) ) {
 			foreach ( $claims as $claim ) {
-				if ( ! self::completeClaim( $claim, $job_id ) ) {
+				if ( ! self::completeClaim( $claim, $job_id, $within_transaction ) ) {
+					unset( self::$pending_processed_metrics[ $job_id ] );
 					return false;
 				}
+				++$completed;
 			}
 		}
 
 		$item_identifier = $engine_data['item_identifier'] ?? null;
 		$source_type     = $engine_data['source_type'] ?? null;
 		if ( empty( $item_identifier ) || empty( $source_type ) ) {
-			return true;
+			return self::recordCompletedMetrics( $job_id, $completed, $within_transaction );
 		}
 
 		$source_flow_step_id = self::resolveSourceIngestionFlowStepId( $engine_data );
 		if ( empty( $source_flow_step_id ) ) {
-			return true;
+			return self::recordCompletedMetrics( $job_id, $completed, $within_transaction );
 		}
 
 		$legacy_completed = ( new ProcessedItems() )->complete_claim_for_job(
@@ -92,13 +99,12 @@ class StepLifecycleHandler {
 			$job_id
 		);
 		if ( false === $legacy_completed ) {
+			unset( self::$pending_processed_metrics[ $job_id ] );
 			return false;
 		}
-		if ( 0 < $legacy_completed ) {
-			RunMetrics::increment( $job_id, 'processed' );
-		}
+		$completed += $legacy_completed;
 
-		return true;
+		return self::recordCompletedMetrics( $job_id, $completed, $within_transaction );
 	}
 
 	/**
@@ -132,7 +138,22 @@ class StepLifecycleHandler {
 			return;
 		}
 
+		unset( self::$pending_processed_metrics[ $job_id ] );
 		\do_action( 'datamachine_step_lifecycle_failed', $job_id, \datamachine_get_engine_data( $job_id ) );
+	}
+
+	/** Clear request-local completion state after a database rollback. */
+	public static function handleTerminalRollback( int $job_id ): void {
+		unset( self::$pending_processed_metrics[ $job_id ] );
+	}
+
+	/** Flush deferred metrics after commit and before final metric aggregation. */
+	public static function handleTerminalCommit( int $job_id, string $status ): void {
+		$completed = self::$pending_processed_metrics[ $job_id ] ?? 0;
+		unset( self::$pending_processed_metrics[ $job_id ] );
+		if ( JobStatus::isStatusSuccess( $status ) && 0 < $completed ) {
+			RunMetrics::increment( $job_id, 'processed', $completed );
+		}
 	}
 
 	/**
@@ -141,19 +162,23 @@ class StepLifecycleHandler {
 	 * @param string $status Requested terminal status.
 	 * @param int    $job_id Job ID.
 	 * @param array  $job    Current job row.
-	 * @return string Original success status or an observable failure status.
+	 * @return string|\WP_Error Original status or a rollback signal.
 	 */
-	public static function filterTerminalStatus( string $status, int $job_id, array $job ): string {
-		unset( $job );
+	public static function filterTerminalStatus( string $status, int $job_id, array $job ): string|\WP_Error {
 		if ( ! JobStatus::isStatusSuccess( $status ) ) {
 			return $status;
 		}
 
-		if ( self::handleCompleted( $job_id ) ) {
+		$engine_data = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		if ( self::handleCompleted( $job_id, $engine_data, true ) ) {
 			return $status;
 		}
 
-		return JobStatus::failed( 'item_claim_completion_failed' )->toString();
+		return new \WP_Error(
+			'item_claim_completion_failed',
+			'Item claim completion failed inside terminal ownership boundary.',
+			array( 'status' => JobStatus::failed( 'item_claim_completion_failed' )->toString() )
+		);
 	}
 
 	/**
@@ -195,9 +220,10 @@ class StepLifecycleHandler {
 	 *
 	 * @param array $claim  Validated claim descriptor.
 	 * @param int   $job_id Completing job ID.
+	 * @param bool  $within_transaction Whether the caller owns the terminal transaction.
 	 * @return bool Whether the descriptor claim and its callback completed.
 	 */
-	private static function completeClaim( array $claim, int $job_id ): bool {
+	private static function completeClaim( array $claim, int $job_id, bool $within_transaction = false ): bool {
 		$processed  = new ProcessedItems();
 		$completion = is_array( $claim['completion'] ?? null ) ? $claim['completion'] : array();
 		$handler_id = is_string( $completion['handler'] ?? null ) ? $completion['handler'] : '';
@@ -214,7 +240,8 @@ class StepLifecycleHandler {
 			$callback = static fn(): bool => true === call_user_func( $handler, $payload, $job_id, $claim );
 		}
 
-		$owned = $processed->complete_owned_claim(
+		$method = $within_transaction ? 'complete_owned_claim_in_transaction' : 'complete_owned_claim';
+		$owned  = $processed->{$method}(
 			$claim['identity_scope'],
 			$claim['source_type'],
 			$claim['item_identifier'],
@@ -226,7 +253,19 @@ class StepLifecycleHandler {
 		if ( ! $owned ) {
 			return false;
 		}
-		RunMetrics::increment( $job_id, 'processed' );
+		return true;
+	}
+
+	/**
+	 * Persist metrics now or defer them until the outer transaction commits.
+	 */
+	private static function recordCompletedMetrics( int $job_id, int $completed, bool $within_transaction ): bool {
+		if ( $within_transaction ) {
+			self::$pending_processed_metrics[ $job_id ] = $completed;
+		} elseif ( 0 < $completed ) {
+			RunMetrics::increment( $job_id, 'processed', $completed );
+		}
+
 		return true;
 	}
 

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -61,50 +61,44 @@ class StepLifecycleHandler {
 	 *
 	 * @param int        $job_id      Completed job ID.
 	 * @param array|null $engine_data Optional engine data snapshot.
+	 * @return bool Whether all owned descriptor and legacy claims completed.
 	 */
-	public static function handleCompleted( int $job_id, ?array $engine_data = null ): void {
+	public static function handleCompleted( int $job_id, ?array $engine_data = null ): bool {
 		$engine_data = is_array( $engine_data ) ? $engine_data : \datamachine_get_engine_data( $job_id );
 		$claims      = self::claimsFromEngine( $engine_data );
 		if ( ! empty( $claims ) ) {
 			foreach ( $claims as $claim ) {
-				self::completeClaim( $claim, $job_id );
+				if ( ! self::completeClaim( $claim, $job_id ) ) {
+					return false;
+				}
 			}
-			return;
 		}
 
 		$item_identifier = $engine_data['item_identifier'] ?? null;
 		$source_type     = $engine_data['source_type'] ?? null;
 		if ( empty( $item_identifier ) || empty( $source_type ) ) {
-			return;
+			return true;
 		}
 
 		$source_flow_step_id = self::resolveSourceIngestionFlowStepId( $engine_data );
 		if ( empty( $source_flow_step_id ) ) {
-			return;
+			return true;
 		}
 
-		$completed = ( new ProcessedItems() )->complete_claim_for_job(
+		$legacy_completed = ( new ProcessedItems() )->complete_claim_for_job(
 			$source_flow_step_id,
 			(string) $source_type,
 			(string) $item_identifier,
 			$job_id
 		);
-		if ( ! $completed ) {
-			return;
+		if ( false === $legacy_completed ) {
+			return false;
 		}
-		RunMetrics::increment( $job_id, 'processed' );
+		if ( 0 < $legacy_completed ) {
+			RunMetrics::increment( $job_id, 'processed' );
+		}
 
-		\do_action(
-			'datamachine_log',
-			'debug',
-			'Deferred mark-as-processed on pipeline completion',
-			array(
-				'job_id'             => $job_id,
-				'item_identifier'    => $item_identifier,
-				'source_type'        => $source_type,
-				'fetch_flow_step_id' => $source_flow_step_id,
-			)
-		);
+		return true;
 	}
 
 	/**
@@ -134,13 +128,32 @@ class StepLifecycleHandler {
 	 * @param string $status Final job status.
 	 */
 	public static function handleTerminal( int $job_id, string $status ): void {
-		$engine_data = \datamachine_get_engine_data( $job_id );
 		if ( JobStatus::isStatusSuccess( $status ) ) {
-			\do_action( 'datamachine_step_lifecycle_completed', $job_id, $engine_data );
 			return;
 		}
 
-		\do_action( 'datamachine_step_lifecycle_failed', $job_id, $engine_data );
+		\do_action( 'datamachine_step_lifecycle_failed', $job_id, \datamachine_get_engine_data( $job_id ) );
+	}
+
+	/**
+	 * Complete owned claims before a successful terminal status is persisted.
+	 *
+	 * @param string $status Requested terminal status.
+	 * @param int    $job_id Job ID.
+	 * @param array  $job    Current job row.
+	 * @return string Original success status or an observable failure status.
+	 */
+	public static function filterTerminalStatus( string $status, int $job_id, array $job ): string {
+		unset( $job );
+		if ( ! JobStatus::isStatusSuccess( $status ) ) {
+			return $status;
+		}
+
+		if ( self::handleCompleted( $job_id ) ) {
+			return $status;
+		}
+
+		return JobStatus::failed( 'item_claim_completion_failed' )->toString();
 	}
 
 	/**
@@ -182,8 +195,9 @@ class StepLifecycleHandler {
 	 *
 	 * @param array $claim  Validated claim descriptor.
 	 * @param int   $job_id Completing job ID.
+	 * @return bool Whether the descriptor claim and its callback completed.
 	 */
-	private static function completeClaim( array $claim, int $job_id ): void {
+	private static function completeClaim( array $claim, int $job_id ): bool {
 		$processed  = new ProcessedItems();
 		$completion = is_array( $claim['completion'] ?? null ) ? $claim['completion'] : array();
 		$handler_id = is_string( $completion['handler'] ?? null ) ? $completion['handler'] : '';
@@ -194,8 +208,7 @@ class StepLifecycleHandler {
 			$handlers = apply_filters( 'datamachine_item_claim_completion_handlers', array() );
 			$handler  = $handlers[ $handler_id ] ?? null;
 			if ( ! is_callable( $handler ) ) {
-				self::releaseClaim( $claim );
-				return;
+				return false;
 			}
 
 			$callback = static fn(): bool => true === call_user_func( $handler, $payload, $job_id, $claim );
@@ -211,10 +224,10 @@ class StepLifecycleHandler {
 			false !== ( $completion['retain_processed'] ?? true )
 		);
 		if ( ! $owned ) {
-			self::releaseClaim( $claim );
-			return;
+			return false;
 		}
 		RunMetrics::increment( $job_id, 'processed' );
+		return true;
 	}
 
 	/**

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -242,6 +242,10 @@ class StepLifecycleHandler {
 			$callback = static fn(): bool => true === call_user_func( $handler, $payload, $job_id, $claim );
 		}
 
+		$retain_processed = true;
+		if ( isset( $completion['retain_processed'] ) && false === $completion['retain_processed'] ) {
+			$retain_processed = false;
+		}
 		$method = $within_transaction ? 'complete_owned_claim_in_transaction' : 'complete_owned_claim';
 		$owned  = $processed->{$method}(
 			$claim['identity_scope'],
@@ -250,7 +254,7 @@ class StepLifecycleHandler {
 			$claim['ownership_token'],
 			$job_id,
 			$callback,
-			false !== ( $completion['retain_processed'] ?? true )
+			$retain_processed
 		);
 		if ( ! $owned ) {
 			return false;

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -205,7 +205,7 @@ class StepLifecycleHandler {
 			$claim['ownership_token'],
 			$job_id,
 			$callback,
-			false !== ( $completion['retain_processed'] ?? true )
+			( $completion['retain_processed'] ?? true ) !== false
 		);
 		if ( ! $owned ) {
 			self::releaseClaim( $claim );

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -8,8 +8,12 @@
 
 namespace DataMachine\Engine\Actions\Handlers;
 
-use DataMachine\Core\PacketEngineData;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\Database\TrackedItems\TrackedItems;
+use DataMachine\Core\DataPacketStore;
+use DataMachine\Core\JobStatus;
+use DataMachine\Core\PacketEngineData;
+use DataMachine\Core\RunMetrics;
 
 /**
  * Keeps source-ingestion processed-item behavior behind lifecycle hooks.
@@ -39,6 +43,9 @@ class StepLifecycleHandler {
 		if ( ! empty( $packet_meta['source_type'] ) ) {
 			$seed_data['source_type'] = $packet_meta['source_type'];
 		}
+		if ( is_array( $packet_meta[ ProcessedItems::CLAIM_METADATA_KEY ] ?? null ) ) {
+			$seed_data[ ProcessedItems::CLAIM_METADATA_KEY ] = $packet_meta[ ProcessedItems::CLAIM_METADATA_KEY ];
+		}
 		if ( ! empty( $seed_data ) ) {
 			\datamachine_merge_engine_data( $job_id, $seed_data );
 		}
@@ -52,6 +59,11 @@ class StepLifecycleHandler {
 	 */
 	public static function handleCompleted( int $job_id, ?array $engine_data = null ): void {
 		$engine_data = is_array( $engine_data ) ? $engine_data : \datamachine_get_engine_data( $job_id );
+		$claim       = self::claimFromEngine( $engine_data );
+		if ( null !== $claim ) {
+			self::completeClaim( $claim, $job_id );
+			return;
+		}
 
 		$item_identifier = $engine_data['item_identifier'] ?? null;
 		$source_type     = $engine_data['source_type'] ?? null;
@@ -92,23 +104,128 @@ class StepLifecycleHandler {
 	 * @param array|null $engine_data Optional engine data snapshot.
 	 */
 	public static function handleFailed( int $job_id, ?array $engine_data = null ): void {
-		$engine_data        = is_array( $engine_data ) ? $engine_data : \datamachine_get_engine_data( $job_id );
-		$db_processed_items = new ProcessedItems();
+		$engine_data = is_array( $engine_data ) ? $engine_data : \datamachine_get_engine_data( $job_id );
+		$claim       = self::claimFromEngine( $engine_data );
+		if ( null !== $claim ) {
+			self::releaseClaim( $claim );
+		}
+	}
 
-		$db_processed_items->release_claims_for_job( $job_id );
-
-		$item_identifier = $engine_data['item_identifier'] ?? null;
-		$source_type     = $engine_data['source_type'] ?? null;
-		if ( empty( $item_identifier ) || empty( $source_type ) ) {
+	/**
+	 * Apply claim lifecycle for every terminal job transition.
+	 *
+	 * @param int    $job_id Terminal job ID.
+	 * @param string $status Final job status.
+	 */
+	public static function handleTerminal( int $job_id, string $status ): void {
+		$engine_data = \datamachine_get_engine_data( $job_id );
+		if ( JobStatus::isStatusSuccess( $status ) ) {
+			\do_action( 'datamachine_step_lifecycle_completed', $job_id, $engine_data );
 			return;
 		}
 
-		$source_flow_step_id = self::resolveSourceIngestionFlowStepId( $engine_data );
-		if ( empty( $source_flow_step_id ) ) {
-			return;
+		\do_action( 'datamachine_step_lifecycle_failed', $job_id, $engine_data );
+	}
+
+	/**
+	 * Release claims attached to batch items that will not be scheduled.
+	 *
+	 * @param array  $items         Discarded batch items.
+	 * @param int    $parent_job_id Parent job ID.
+	 * @param string $context       Batch consumer context.
+	 */
+	public static function handleDiscardedPackets( array $items, int $parent_job_id, string $context ): void {
+		unset( $parent_job_id, $context );
+		foreach ( $items as $item ) {
+			$item     = DataPacketStore::hydrate_packet_collections_in_value( $item );
+			$metadata = is_array( $item['metadata'] ?? null ) ? $item['metadata'] : array();
+			$claim    = self::normalizeClaim( $metadata[ ProcessedItems::CLAIM_METADATA_KEY ] ?? null );
+			if ( null !== $claim ) {
+				self::releaseClaim( $claim );
+			}
+		}
+	}
+
+	/**
+	 * Apply optional tracked-item state and complete an owned claim.
+	 *
+	 * TrackedItems validates ownership in the same SQL statement as its upsert.
+	 * A stale worker therefore cannot update a replacement owner's revision.
+	 *
+	 * @param array $claim  Validated claim descriptor.
+	 * @param int   $job_id Completing job ID.
+	 */
+	private static function completeClaim( array $claim, int $job_id ): void {
+		$processed    = new ProcessedItems();
+		$completion   = is_array( $claim['completion'] ?? null ) ? $claim['completion'] : array();
+		$tracked_item = is_array( $completion['tracked_item'] ?? null ) ? $completion['tracked_item'] : null;
+		if ( null !== $tracked_item ) {
+			$tracked_item['last_job_id'] = $job_id;
+			if ( null === ( new TrackedItems() )->upsert_owned( $tracked_item, $claim ) ) {
+				$processed->release_owned_claim( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'], $claim['ownership_token'] );
+				return;
+			}
 		}
 
-		$db_processed_items->release_claim( $source_flow_step_id, (string) $source_type, (string) $item_identifier );
+		$owned = $processed->complete_owned_claim(
+			$claim['identity_scope'],
+			$claim['source_type'],
+			$claim['item_identifier'],
+			$claim['ownership_token'],
+			$job_id
+		);
+		if ( ! $owned ) {
+			return;
+		}
+		RunMetrics::increment( $job_id, 'processed' );
+
+		if ( isset( $completion['keep_processed'] ) && false === $completion['keep_processed'] ) {
+			$processed->release_owned_claim( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'], $claim['ownership_token'], true );
+		}
+	}
+
+	/**
+	 * Release one validated claim descriptor.
+	 *
+	 * @param array $claim Validated claim descriptor.
+	 */
+	private static function releaseClaim( array $claim ): void {
+		( new ProcessedItems() )->release_owned_claim(
+			$claim['identity_scope'],
+			$claim['source_type'],
+			$claim['item_identifier'],
+			$claim['ownership_token']
+		);
+	}
+
+	/**
+	 * Read a claim descriptor from engine data.
+	 *
+	 * @param array $engine_data Job engine snapshot.
+	 * @return array|null Validated descriptor, or null.
+	 */
+	private static function claimFromEngine( array $engine_data ): ?array {
+		return self::normalizeClaim( $engine_data[ ProcessedItems::CLAIM_METADATA_KEY ] ?? null );
+	}
+
+	/**
+	 * Validate a claim lifecycle descriptor.
+	 *
+	 * @param mixed $claim Candidate descriptor.
+	 * @return array|null Validated descriptor, or null.
+	 */
+	private static function normalizeClaim( mixed $claim ): ?array {
+		if ( ! is_array( $claim ) || false === ( $claim['persisted'] ?? true ) ) {
+			return null;
+		}
+
+		foreach ( array( 'identity_scope', 'source_type', 'item_identifier', 'ownership_token' ) as $key ) {
+			if ( ! is_string( $claim[ $key ] ?? null ) || '' === $claim[ $key ] ) {
+				return null;
+			}
+		}
+
+		return $claim;
 	}
 
 	/**

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -112,19 +112,23 @@ class StepLifecycleHandler {
 	 *
 	 * @param int        $job_id      Failed job ID.
 	 * @param array|null $engine_data Optional engine data snapshot.
+	 * @return bool Whether every descriptor and legacy claim was released.
 	 */
-	public static function handleFailed( int $job_id, ?array $engine_data = null ): void {
+	public static function handleFailed( int $job_id, ?array $engine_data = null ): bool {
 		$engine_data = is_array( $engine_data ) ? $engine_data : \datamachine_get_engine_data( $job_id );
 		$claims      = self::claimsFromEngine( $engine_data );
+		$processed   = new ProcessedItems();
 		if ( ! empty( $claims ) ) {
 			foreach ( $claims as $claim ) {
-				self::releaseClaim( $claim );
+				if ( false === self::releaseClaim( $claim, $processed ) ) {
+					return false;
+				}
 			}
 		}
 
 		// Pre-descriptor and partially migrated jobs still own claims by job_id.
 		// Reacquisition replaces job_id, so this cannot release a newer worker's row.
-		( new ProcessedItems() )->release_claims_for_job( $job_id );
+		return false !== $processed->release_claims_for_job( $job_id );
 	}
 
 	/**
@@ -134,12 +138,8 @@ class StepLifecycleHandler {
 	 * @param string $status Final job status.
 	 */
 	public static function handleTerminal( int $job_id, string $status ): void {
-		if ( JobStatus::isStatusSuccess( $status ) ) {
-			return;
-		}
-
+		unset( $status );
 		unset( self::$pending_processed_metrics[ $job_id ] );
-		\do_action( 'datamachine_step_lifecycle_failed', $job_id, \datamachine_get_engine_data( $job_id ) );
 	}
 
 	/** Clear request-local completion state after a database rollback. */
@@ -165,19 +165,21 @@ class StepLifecycleHandler {
 	 * @return string|\WP_Error Original status or a rollback signal.
 	 */
 	public static function filterTerminalStatus( string $status, int $job_id, array $job ): string|\WP_Error {
-		if ( ! JobStatus::isStatusSuccess( $status ) ) {
-			return $status;
-		}
-
 		$engine_data = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
-		if ( self::handleCompleted( $job_id, $engine_data, true ) ) {
+		$prepared    = JobStatus::isStatusSuccess( $status )
+			? self::handleCompleted( $job_id, $engine_data, true )
+			: self::handleFailed( $job_id, $engine_data );
+		if ( $prepared ) {
 			return $status;
 		}
 
+		$reason = JobStatus::isStatusSuccess( $status )
+			? 'item_claim_completion_failed'
+			: 'item_claim_release_failed';
 		return new \WP_Error(
-			'item_claim_completion_failed',
-			'Item claim completion failed inside terminal ownership boundary.',
-			array( 'status' => JobStatus::failed( 'item_claim_completion_failed' )->toString() )
+			$reason,
+			'Item claim transition failed inside terminal ownership boundary.',
+			array( 'status' => JobStatus::failed( $reason )->toString() )
 		);
 	}
 
@@ -272,10 +274,13 @@ class StepLifecycleHandler {
 	/**
 	 * Release one validated claim descriptor.
 	 *
-	 * @param array $claim Validated claim descriptor.
+	 * @param array               $claim     Validated claim descriptor.
+	 * @param ProcessedItems|null $processed Shared repository instance.
+	 * @return int|false Number of released rows, or false on error.
 	 */
-	private static function releaseClaim( array $claim ): void {
-		( new ProcessedItems() )->release_owned_claim(
+	private static function releaseClaim( array $claim, ?ProcessedItems $processed = null ): int|false {
+		$processed = $processed ?? new ProcessedItems();
+		return $processed->release_owned_claim(
 			$claim['identity_scope'],
 			$claim['source_type'],
 			$claim['item_identifier'],

--- a/inc/Engine/Tasks/TaskScheduler.php
+++ b/inc/Engine/Tasks/TaskScheduler.php
@@ -411,6 +411,10 @@ class TaskScheduler {
 			self::BATCH_CONTEXT,
 			BatchScheduler::COMPLETION_STRATEGY_CHUNKS_SCHEDULED
 		);
+		if ( empty( $result['scheduled'] ) ) {
+			$jobs_db->complete_job( (int) $batch_job_id, JobStatus::failed( 'batch_schedule_failed' )->toString() );
+			return false;
+		}
 
 		// Surface task-specific identifiers alongside the BatchScheduler
 		// metadata so getBatchStatus() and CLI consumers see the same
@@ -538,6 +542,11 @@ class TaskScheduler {
 					'total'        => $result['total'],
 				)
 			);
+			return;
+		}
+
+		if ( ! empty( $result['schedule_failed'] ) ) {
+			$jobs_db->complete_job( $parent_job_id, JobStatus::failed( 'batch_schedule_failed' )->toString() );
 			return;
 		}
 

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -10,6 +10,7 @@ namespace DataMachine\Tests\Unit\Abilities\Engine;
 
 use DataMachine\Abilities\Engine\PipelineBatchScheduler;
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\JobStatus;
 use WP_UnitTestCase;
 
@@ -257,6 +258,29 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		// Check parent progress was updated.
 		$parent_engine = datamachine_get_engine_data( $parent_id );
 		$this->assertEquals( 2, $parent_engine['batch_scheduled'] );
+	}
+
+	public function test_process_chunk_propagates_claim_ownership_to_children(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+		$claim     = array(
+			'identity_scope'  => 'shared:source',
+			'source_type'     => 'source',
+			'item_identifier' => 'item-1',
+			'ownership_token' => 'opaque-token',
+			'completion'      => array(),
+		);
+		$packet = $this->make_data_packet( 'Claimed Event' );
+		$packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] = $claim;
+
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->fanOut( $parent_id, 'step_abc_123', array( $packet ), $engine );
+		$scheduler->processChunk( $parent_id );
+
+		global $wpdb;
+		$child_id    = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT job_id FROM %i WHERE parent_job_id = %d', $wpdb->prefix . 'datamachine_jobs', $parent_id ) );
+		$child_engine = datamachine_get_engine_data( $child_id );
+		$this->assertSame( $claim, $child_engine[ ProcessedItems::CLAIM_METADATA_KEY ] );
 	}
 
 	public function test_process_chunk_respects_cancellation(): void {

--- a/tests/Unit/Core/ExecutionContextReprocessFilterTest.php
+++ b/tests/Unit/Core/ExecutionContextReprocessFilterTest.php
@@ -124,6 +124,25 @@ class ExecutionContextReprocessFilterTest extends WP_UnitTestCase {
 		$this->assertSame( 7, $captured['job_id'] );
 	}
 
+	public function test_custom_revision_policy_preserves_actual_flow_step_context(): void {
+		$captured = null;
+		add_filter(
+			'datamachine_should_reprocess_item',
+			static function ( bool $skip, array $context ) use ( &$captured ): bool {
+				$captured = $context;
+				return $skip;
+			},
+			10,
+			2
+		);
+
+		$ctx = ExecutionContext::fromFlow( $this->pipeline_id, $this->flow_id, $this->flow_step_id, '9', $this->handler_type );
+		$ctx->shouldSkipItem( true, $this->item_identifier, array( 'identity_scope' => 'shared:source' ) );
+
+		$this->assertSame( $this->flow_step_id, $captured['flow_step_id'] );
+		$this->assertSame( 'shared:source', $captured['identity_scope'] );
+	}
+
 	public function test_filter_not_invoked_in_direct_mode(): void {
 		$invoked = false;
 

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -42,6 +42,7 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->jobs      = new Jobs();
 		$this->processed->create_table();
 		$this->tracked->create_table();
+		add_filter( 'datamachine_item_claim_completion_handlers', array( TrackedItems::class, 'registerClaimCompletionHandler' ) );
 		$this->admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $this->admin_id );
 		$this->deleteTestRows();
@@ -57,6 +58,7 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		if ( null !== $this->completion_handler_filter ) {
 			remove_filter( 'datamachine_item_claim_completion_handlers', $this->completion_handler_filter );
 		}
+		remove_filter( 'datamachine_item_claim_completion_handlers', array( TrackedItems::class, 'registerClaimCompletionHandler' ) );
 		$this->deleteTestRows();
 		parent::tear_down();
 	}
@@ -199,10 +201,15 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		add_filter( 'datamachine_job_terminal_status', $crash, 20 );
 
 		try {
-			$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
+			$this->assertFalse( $this->jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
 		} finally {
 			remove_filter( 'datamachine_job_terminal_status', $crash, 20 );
 		}
+
+		$this->assertSame( 'processing', $this->jobs->get_job( $job_id )['status'] );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'crash-boundary-id' ) );
+		$this->assertTrue( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'crash-boundary-id' ) );
+		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::failed( 'terminal_preparation_exception' )->toString() ) );
 
 		$job = $this->jobs->get_job( $job_id );
 		$this->assertIsArray( $job );

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -309,9 +309,7 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 
 	public function test_interleaved_status_write_before_terminal_cas_rolls_back_and_recovers(): void {
 		global $wpdb;
-		$job_id = $this->createJobWithClaim( array(), true );
-		$claim  = $this->claim( 'process-death-id', $job_id, 'recovered-revision' );
-		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
+		$job_id     = $this->createProcessingJobWithTrackedClaim( 'process-death-id', 'recovered-revision' );
 		$interleave = static function ( string $status, int $filtered_job_id ) use ( $wpdb ): string {
 			$wpdb->update(
 				( new Jobs() )->get_table_name(),
@@ -338,9 +336,7 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 	}
 
 	public function test_interruption_after_failure_commit_preserves_cleanup_for_replay(): void {
-		$job_id = $this->createJobWithClaim( array(), true );
-		$claim  = $this->claim( 'failed-commit-crash-id', $job_id, 'must-not-persist' );
-		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
+		$job_id                 = $this->createProcessingJobWithTrackedClaim( 'failed-commit-crash-id', 'must-not-persist' );
 		$interrupt_after_commit = static function ( int $committed_job_id, string $status ) use ( $job_id ): void {
 			if ( $job_id !== $committed_job_id || JobStatus::isStatusSuccess( $status ) ) {
 				return;
@@ -426,7 +422,7 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
 		$this->assertSame( 'success-revision', $this->tracked->get( self::NAMESPACE, 'success-id' )['source_revision'] );
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'success-id' ) );
-		$this->assertSame( 1, datamachine_get_engine_data( $job_id )[ RunMetrics::KEY ]['counts']['processed'] );
+		$this->assertSame( 1, RunMetrics::fromJob( $this->jobs->get_job( $job_id ) )['counts']['processed'] );
 	}
 
 	public function test_ordinary_terminal_failure_releases_claim(): void {
@@ -673,7 +669,7 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertSame( 'mixed-success-revision', $this->tracked->get( self::NAMESPACE, 'mixed-success-owned' )['source_revision'] );
 		$this->assertTrue( $this->processed->has_item_been_processed( self::SCOPE, self::SOURCE, 'mixed-success-legacy' ) );
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'mixed-success-owned' ) );
-		$this->assertSame( 2, datamachine_get_engine_data( $job_id )[ RunMetrics::KEY ]['counts']['processed'] );
+		$this->assertSame( 2, RunMetrics::fromJob( $this->jobs->get_job( $job_id ) )['counts']['processed'] );
 	}
 
 	public function test_malformed_content_addressed_ref_releases_sidecar_claim(): void {
@@ -772,6 +768,13 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 			$this->jobs->start_job( $job_id );
 		}
 		datamachine_set_engine_data( $job_id, $claim ? array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) : array() );
+		return $job_id;
+	}
+
+	private function createProcessingJobWithTrackedClaim( string $item_id, string $revision ): int {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$claim  = $this->claim( $item_id, $job_id, $revision );
+		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
 		return $job_id;
 	}
 

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -378,6 +378,76 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertSame( 'recovered-revision', $this->tracked->get( self::NAMESPACE, 'process-death-id' )['source_revision'] );
 	}
 
+	public function test_process_death_after_failure_commit_preserves_cleanup_for_replay(): void {
+		if ( ! function_exists( 'pcntl_fork' ) || ! function_exists( 'stream_socket_pair' ) ) {
+			$this->markTestSkipped( 'pcntl and socket pairs are required for crash-boundary coverage.' );
+		}
+
+		global $wpdb;
+		$sockets = stream_socket_pair( STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP );
+		$this->assertIsArray( $sockets );
+		stream_set_timeout( $sockets[0], 5 );
+		stream_set_timeout( $sockets[1], 5 );
+		$job_id = $this->createJobWithClaim( array(), true );
+		$claim  = $this->claim( 'failed-commit-crash-id', $job_id, 'must-not-persist' );
+		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
+		$kill_after_commit = static function ( int $committed_job_id, string $status ) use ( $job_id, $sockets ): void {
+			if ( $job_id !== $committed_job_id || JobStatus::isStatusSuccess( $status ) ) {
+				return;
+			}
+			fwrite( $sockets[1], "committed\n" );
+			if ( function_exists( 'posix_kill' ) ) {
+				posix_kill( getmypid(), SIGKILL );
+			}
+			exit( 99 );
+		};
+		add_action( 'datamachine_job_terminal_committed', $kill_after_commit, 20, 2 );
+		$pid = pcntl_fork();
+		$this->assertNotSame( -1, $pid );
+
+		if ( 0 === $pid ) {
+			fclose( $sockets[0] );
+			$child_db = new \wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+			$child_db->set_prefix( $wpdb->prefix );
+			$GLOBALS['wpdb'] = $child_db;
+			( new Jobs() )->transition_job_status_result( $job_id, JobStatus::failed( 'crash-after-commit' )->toString(), true );
+			exit( 98 );
+		}
+
+		fclose( $sockets[1] );
+		$this->assertSame( "committed\n", fgets( $sockets[0] ) );
+		fclose( $sockets[0] );
+		pcntl_waitpid( $pid, $child_status );
+		remove_action( 'datamachine_job_terminal_committed', $kill_after_commit, 20 );
+
+		$persisted_status = (string) $this->jobs->get_job( $job_id )['status'];
+		$this->assertStringContainsString( 'crash-after-commit', $persisted_status );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'failed-commit-crash-id' ) );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'failed-commit-crash-id' ) );
+		$this->assertTrue( $this->jobs->complete_job( $job_id, $persisted_status ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'failed-commit-crash-id' ) );
+	}
+
+	public function test_cancellation_atomically_releases_mixed_descriptor_and_legacy_claims(): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$claim  = $this->claim( 'cancel-mixed-owned', $job_id, 'must-not-persist' );
+		$this->assertTrue( $this->processed->claim_item( self::SCOPE, self::SOURCE, 'cancel-mixed-legacy', $job_id ) );
+		datamachine_set_engine_data(
+			$job_id,
+			array_merge(
+				$this->legacyEngineData( 'cancel-mixed-legacy' ),
+				array( ProcessedItems::CLAIM_METADATA_KEY => $claim )
+			)
+		);
+
+		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::CANCELLED ) );
+
+		$this->assertSame( JobStatus::CANCELLED, $this->jobs->get_job( $job_id )['status'] );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'cancel-mixed-owned' ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'cancel-mixed-legacy' ) );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'cancel-mixed-owned' ) );
+	}
+
 	public function test_gated_inline_continuation_completes_every_claim(): void {
 		$first  = $this->claim( 'inline-success-a', 211, 'revision-a' );
 		$second = $this->claim( 'inline-success-b', 211, 'revision-b' );

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -32,6 +32,7 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 	private Jobs $jobs;
 	private int $admin_id;
 	private ?Closure $schedule_failure_filter = null;
+	private ?Closure $chunk_size_filter       = null;
 
 	public function set_up(): void {
 		parent::set_up();
@@ -49,26 +50,29 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		if ( null !== $this->schedule_failure_filter ) {
 			remove_filter( 'pre_as_schedule_single_action', $this->schedule_failure_filter );
 		}
+		if ( null !== $this->chunk_size_filter ) {
+			remove_filter( 'datamachine_batch_chunk_size', $this->chunk_size_filter );
+		}
 		$this->deleteTestRows();
 		parent::tear_down();
 	}
 
 	public function test_two_flow_steps_race_one_shared_identity(): void {
-		$first = $this->context( 'flow-step-a', 101 )->claimItemOwnership( self::SCOPE, 'shared-id' );
+		global $wpdb;
+		$first  = $this->context( 'flow-step-a', 101 )->claimItemOwnership( self::SCOPE, 'shared-id' );
 		$second = $this->context( 'flow-step-b', 102 )->claimItemOwnership( self::SCOPE, 'shared-id' );
 
 		$this->assertIsArray( $first );
 		$this->assertFalse( $second );
+		$this->assertSame( '', $wpdb->last_error );
 	}
 
 	public function test_expired_owner_cannot_complete_or_release_replacement(): void {
 		$old = $this->claim( 'expiry-id', 201, 'old-revision' );
 		$this->expireClaim( 'expiry-id' );
-		StepLifecycleHandler::handleCompleted( 201, array( ProcessedItems::CLAIM_METADATA_KEY => $old ) );
-		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'expiry-id' ) );
-
 		$new = $this->claim( 'expiry-id', 202, 'new-revision' );
 
+		// The old worker resumes only after expiry and replacement ownership.
 		StepLifecycleHandler::handleCompleted( 201, array( ProcessedItems::CLAIM_METADATA_KEY => $old ) );
 		StepLifecycleHandler::handleFailed( 201, array( ProcessedItems::CLAIM_METADATA_KEY => $old ) );
 
@@ -80,8 +84,67 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'expiry-id' ) );
 	}
 
+	public function test_completion_callback_failure_rolls_back_side_effect(): void {
+		$claim  = $this->claim( 'rollback-id', 203, 'rolled-back-revision' );
+		$result = $this->processed->complete_owned_claim(
+			$claim['identity_scope'],
+			$claim['source_type'],
+			$claim['item_identifier'],
+			$claim['ownership_token'],
+			203,
+			function (): bool {
+				$this->tracked->upsert(
+					array(
+						'namespace'       => self::NAMESPACE,
+						'item_id'         => 'rollback-id',
+						'source_revision' => 'rolled-back-revision',
+					)
+				);
+				return false;
+			}
+		);
+
+		$this->assertFalse( $result );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'rollback-id' ) );
+		$this->assertTrue( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'rollback-id' ) );
+	}
+
+	public function test_gated_inline_continuation_completes_every_claim(): void {
+		$first  = $this->claim( 'inline-success-a', 211, 'revision-a' );
+		$second = $this->claim( 'inline-success-b', 211, 'revision-b' );
+		$job_id = $this->createJobWithClaim( array(), true );
+
+		StepLifecycleHandler::handleInlineContinuation(
+			$job_id,
+			array( 'step_type' => 'fetch' ),
+			array( $this->packet( $first ), $this->packet( $second ) )
+		);
+		$engine = datamachine_get_engine_data( $job_id );
+		$this->assertCount( 2, $engine[ ProcessedItems::CLAIMS_METADATA_KEY ] );
+
+		StepLifecycleHandler::handleCompleted( $job_id, $engine );
+		$this->assertSame( 'revision-a', $this->tracked->get( self::NAMESPACE, 'inline-success-a' )['source_revision'] );
+		$this->assertSame( 'revision-b', $this->tracked->get( self::NAMESPACE, 'inline-success-b' )['source_revision'] );
+	}
+
+	public function test_gated_inline_continuation_failure_releases_every_claim(): void {
+		$first  = $this->claim( 'inline-failure-a', 212, 'revision-a' );
+		$second = $this->claim( 'inline-failure-b', 212, 'revision-b' );
+		$job_id = $this->createJobWithClaim( array(), true );
+
+		StepLifecycleHandler::handleInlineContinuation(
+			$job_id,
+			array( 'step_type' => 'fetch' ),
+			array( $this->packet( $first ), $this->packet( $second ) )
+		);
+		StepLifecycleHandler::handleFailed( $job_id );
+
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'inline-failure-a' ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'inline-failure-b' ) );
+	}
+
 	public function test_successful_terminal_completion_persists_tracked_revision(): void {
-		$claim = $this->claim( 'success-id', 301, 'success-revision' );
+		$claim  = $this->claim( 'success-id', 301, 'success-revision' );
 		$job_id = $this->createJobWithClaim( $claim, true );
 
 		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
@@ -142,8 +205,8 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 	}
 
 	public function test_initial_batch_scheduling_failure_releases_all_claims(): void {
-		$claim = $this->claim( 'schedule-id', 701, 'schedule-revision' );
-		$parent_id = $this->createJobWithClaim( array(), true );
+		$claim                         = $this->claim( 'schedule-id', 701, 'schedule-revision' );
+		$parent_id                     = $this->createJobWithClaim( array(), true );
 		$this->schedule_failure_filter = static fn() => 0;
 		add_filter( 'pre_as_schedule_single_action', $this->schedule_failure_filter );
 
@@ -154,9 +217,10 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 	}
 
 	public function test_child_creation_failure_releases_item_claim(): void {
-		$claim = $this->claim( 'child-id', 801, 'child-revision' );
+		$claim     = $this->claim( 'child-id', 801, 'child-revision' );
 		$parent_id = $this->createJobWithClaim( array(), true );
 		BatchScheduler::start( $parent_id, 'test_batch_hook', array( $this->packet( $claim ) ), array(), 'pipeline' );
+		$this->unscheduleTestBatch( $parent_id );
 
 		BatchScheduler::processChunk( $parent_id, static fn() => false );
 
@@ -164,12 +228,111 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 	}
 
 	public function test_batch_cancellation_releases_unscheduled_claims(): void {
-		$claim = $this->claim( 'cancel-id', 901, 'cancel-revision' );
+		$claim     = $this->claim( 'cancel-id', 901, 'cancel-revision' );
 		$parent_id = $this->createJobWithClaim( array(), true );
 		BatchScheduler::start( $parent_id, 'test_batch_hook', array( $this->packet( $claim ) ), array(), 'pipeline' );
+		$this->unscheduleTestBatch( $parent_id );
 
 		$this->assertTrue( BatchScheduler::cancel( $parent_id ) );
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'cancel-id' ) );
+	}
+
+	public function test_later_chunk_scheduling_failure_releases_remaining_claims(): void {
+		$first     = $this->claim( 'later-a', 902, 'revision-a' );
+		$second    = $this->claim( 'later-b', 902, 'revision-b' );
+		$parent_id = $this->createJobWithClaim( array(), true );
+		$calls     = 0;
+		$this->chunk_size_filter       = static fn() => 1;
+		$this->schedule_failure_filter = static function ( $pre ) use ( &$calls ) {
+			++$calls;
+			return $calls > 1 ? 0 : $pre;
+		};
+		add_filter( 'datamachine_batch_chunk_size', $this->chunk_size_filter );
+		add_filter( 'pre_as_schedule_single_action', $this->schedule_failure_filter );
+
+		BatchScheduler::start( $parent_id, 'test_batch_hook', array( $this->packet( $first ), $this->packet( $second ) ), array(), 'pipeline' );
+		$this->unscheduleTestBatch( $parent_id );
+		$result = BatchScheduler::processChunk( $parent_id, static fn() => true );
+
+		$this->assertTrue( $result['schedule_failed'] );
+		$this->assertTrue( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'later-a' ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'later-b' ) );
+		StepLifecycleHandler::handleFailed( 902, array( ProcessedItems::CLAIM_METADATA_KEY => $first ) );
+	}
+
+	public function test_content_addressed_hydration_failure_releases_sidecar_claim(): void {
+		$claim     = $this->claim( 'hydrate-id', 903, 'hydrate-revision' );
+		$parent_id = $this->createJobWithClaim( array(), true );
+		$item      = array( 'data_packets' => array( $this->packet( $claim ) ) );
+		BatchScheduler::start( $parent_id, 'test_batch_hook', array( $item ), array(), 'task' );
+		$this->unscheduleTestBatch( $parent_id );
+
+		$engine = datamachine_get_engine_data( $parent_id );
+		$engine['batch_state']['items'][0]['data_packets'][0]['file_path'] = '/missing/data-packet.json';
+		datamachine_set_engine_data( $parent_id, $engine );
+		$called = false;
+		BatchScheduler::processChunk(
+			$parent_id,
+			static function () use ( &$called ): bool {
+				$called = true;
+				return true;
+			}
+		);
+
+		$this->assertFalse( $called );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'hydrate-id' ) );
+	}
+
+	/**
+	 * @dataProvider legacy_terminal_status_provider
+	 */
+	public function test_predeployment_job_without_descriptor_releases_legacy_claim( string $status ): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$this->assertTrue( $this->processed->claim_item( self::SCOPE, self::SOURCE, 'legacy-' . $status, $job_id ) );
+
+		$this->assertTrue( $this->jobs->complete_job( $job_id, $status ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'legacy-' . $status ) );
+	}
+
+	public function legacy_terminal_status_provider(): array {
+		return array(
+			'failure'      => array( JobStatus::failed( 'legacy' )->toString() ),
+			'cancellation' => array( JobStatus::CANCELLED ),
+		);
+	}
+
+	public function test_predeployment_stale_recovery_releases_legacy_claim(): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$this->assertTrue( $this->processed->claim_item( self::SCOPE, self::SOURCE, 'legacy-recovery', $job_id ) );
+		datamachine_merge_engine_data( $job_id, array( 'job_status' => JobStatus::failed( 'stale' )->toString() ) );
+
+		( new RecoverStuckJobsAbility() )->execute( array( 'dry_run' => false ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'legacy-recovery' ) );
+	}
+
+	public function test_mixed_descriptor_and_legacy_claims_are_both_released(): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$claim  = $this->claim( 'mixed-owned', $job_id, 'mixed-revision' );
+		$this->assertTrue( $this->processed->claim_item( self::SCOPE, self::SOURCE, 'mixed-legacy', $job_id ) );
+
+		StepLifecycleHandler::handleFailed( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'mixed-owned' ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'mixed-legacy' ) );
+	}
+
+	public function test_malformed_content_addressed_ref_releases_sidecar_claim(): void {
+		$claim     = $this->claim( 'malformed-ref', 904, 'malformed-revision' );
+		$parent_id = $this->createJobWithClaim( array(), true );
+		$item      = array( 'data_packets' => array( $this->packet( $claim ) ) );
+		BatchScheduler::start( $parent_id, 'test_batch_hook', array( $item ), array(), 'task' );
+		$this->unscheduleTestBatch( $parent_id );
+
+		$engine = datamachine_get_engine_data( $parent_id );
+		$engine['batch_state']['items'][0]['data_packets'][0]['schema_version'] = 999;
+		datamachine_set_engine_data( $parent_id, $engine );
+		BatchScheduler::processChunk( $parent_id, static fn() => true );
+
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'malformed-ref' ) );
 	}
 
 	private function context( string $flow_step_id, int $job_id ): ExecutionContext {
@@ -182,13 +345,16 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 			$item_id,
 			ProcessedItems::DEFAULT_CLAIM_TTL_SECONDS,
 			array(
-				'keep_processed' => false,
-				'tracked_item'   => array(
-					'namespace'       => self::NAMESPACE,
-					'item_id'         => $item_id,
-					'item_type'       => 'source',
-					'state'           => TrackedItems::STATE_GENERATED,
-					'source_revision' => $revision,
+				'handler'          => 'tracked_item',
+				'retain_processed' => false,
+				'payload'          => array(
+					'item' => array(
+						'namespace'       => self::NAMESPACE,
+						'item_id'         => $item_id,
+						'item_type'       => 'source',
+						'state'           => TrackedItems::STATE_GENERATED,
+						'source_revision' => $revision,
+					),
 				),
 			)
 		);
@@ -202,6 +368,19 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 			'data'     => array( 'title' => 'Claimed item', 'body' => 'body' ),
 			'metadata' => array( ProcessedItems::CLAIM_METADATA_KEY => $claim ),
 		);
+	}
+
+	private function unscheduleTestBatch( int $parent_id ): void {
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions(
+				'test_batch_hook',
+				array(
+					'parent_job_id' => $parent_id,
+					'offset'        => 0,
+				),
+				'data-machine'
+			);
+		}
 	}
 
 	private function createJobWithClaim( array $claim, bool $processing = false ): int {

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -268,15 +268,6 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 	}
 
 	public function test_concurrent_terminal_callers_share_one_persisted_success(): void {
-		if ( ! function_exists( 'pcntl_fork' ) || ! function_exists( 'stream_socket_pair' ) ) {
-			$this->markTestSkipped( 'pcntl and socket pairs are required for DB concurrency coverage.' );
-		}
-
-		global $wpdb;
-		$sockets = stream_socket_pair( STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP );
-		$this->assertIsArray( $sockets );
-		stream_set_timeout( $sockets[0], 5 );
-		stream_set_timeout( $sockets[1], 5 );
 		$job_id = $this->createJobWithClaim( array(), true );
 		$claim  = $this->claimWithCompletion(
 			'concurrent-terminal-id',
@@ -287,103 +278,58 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 			)
 		);
 		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
-		$this->completion_handler_filter = static function ( array $handlers ): array {
-			$handlers['counting_test'] = static function ( array $payload, int $callback_job_id ): bool {
-				unset( $payload );
-				global $wpdb;
-				return false !== $wpdb->query(
-					// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
-					$wpdb->prepare(
-						'UPDATE %i SET label = CONCAT(label, %s) WHERE job_id = %d',
-						( new Jobs() )->get_table_name(),
-						'|callback',
-						$callback_job_id
-					)
-				);
+		$callback_count                  = 0;
+		$this->completion_handler_filter = static function ( array $handlers ) use ( &$callback_count ): array {
+			$handlers['counting_test'] = static function () use ( &$callback_count ): bool {
+				++$callback_count;
+				return true;
 			};
 			return $handlers;
 		};
 		add_filter( 'datamachine_item_claim_completion_handlers', $this->completion_handler_filter );
-		$pause_owner = static function ( string $status ) use ( $sockets ): string {
-			fwrite( $sockets[0], "locked\n" );
-			fgets( $sockets[0] );
-			usleep( 200000 );
+		$contender_result = null;
+		$interleave       = function ( string $status ) use ( $job_id, &$contender_result ): string {
+			$contender_result = ( new Jobs() )->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
 			return $status;
 		};
-		add_filter( 'datamachine_job_terminal_status', $pause_owner, 20 );
-		$pid = pcntl_fork();
-		$this->assertNotSame( -1, $pid );
-
-		if ( 0 === $pid ) {
-			fclose( $sockets[0] );
-			$child_db = new \wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
-			$child_db->set_prefix( $wpdb->prefix );
-			$GLOBALS['wpdb'] = $child_db;
-			fwrite( $sockets[1], "ready\n" );
-			fgets( $sockets[1] );
-			fwrite( $sockets[1], "attempting\n" );
-			$result = ( new Jobs() )->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
-			fwrite( $sockets[1], wp_json_encode( $result ) . "\n" );
-			fclose( $sockets[1] );
-			exit( 0 );
+		add_filter( 'datamachine_job_terminal_status', $interleave, 20 );
+		try {
+			$owner_result = $this->jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
+		} finally {
+			remove_filter( 'datamachine_job_terminal_status', $interleave, 20 );
 		}
 
-		fclose( $sockets[1] );
-		$this->assertSame( "ready\n", fgets( $sockets[0] ) );
-		$owner_result = $this->jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
-		$child_result = json_decode( (string) fgets( $sockets[0] ), true );
-		fclose( $sockets[0] );
-		pcntl_waitpid( $pid, $child_status );
-		remove_filter( 'datamachine_job_terminal_status', $pause_owner, 20 );
-
-		$this->assertSame( 0, pcntl_wexitstatus( $child_status ) );
 		$this->assertTrue( $owner_result['success'] );
-		$this->assertTrue( $child_result['success'] );
+		$this->assertIsArray( $contender_result );
+		$this->assertFalse( $contender_result['success'] );
 		$this->assertSame( JobStatus::COMPLETED, $owner_result['status'] );
-		$this->assertSame( JobStatus::COMPLETED, $child_result['status'] );
-		$this->assertSame( 1, substr_count( (string) $this->jobs->get_job( $job_id )['label'], '|callback' ) );
+		$this->assertSame( 1, $callback_count );
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'concurrent-terminal-id' ) );
 	}
 
-	public function test_process_death_before_terminal_cas_rolls_back_and_recovers(): void {
-		if ( ! function_exists( 'pcntl_fork' ) || ! function_exists( 'stream_socket_pair' ) ) {
-			$this->markTestSkipped( 'pcntl and socket pairs are required for crash-boundary coverage.' );
-		}
-
+	public function test_interleaved_status_write_before_terminal_cas_rolls_back_and_recovers(): void {
 		global $wpdb;
-		$sockets = stream_socket_pair( STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP );
-		$this->assertIsArray( $sockets );
-		stream_set_timeout( $sockets[0], 5 );
-		stream_set_timeout( $sockets[1], 5 );
 		$job_id = $this->createJobWithClaim( array(), true );
 		$claim  = $this->claim( 'process-death-id', $job_id, 'recovered-revision' );
 		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
-		$kill_before_cas = static function ( string $status ) use ( $sockets ): string {
-			fwrite( $sockets[1], "prepared\n" );
-			if ( function_exists( 'posix_kill' ) ) {
-				posix_kill( getmypid(), SIGKILL );
-			}
-			exit( 99 );
+		$interleave = static function ( string $status, int $filtered_job_id ) use ( $wpdb ): string {
+			$wpdb->update(
+				( new Jobs() )->get_table_name(),
+				array( 'status' => 'processing-interleaver' ),
+				array( 'job_id' => $filtered_job_id ),
+				array( '%s' ),
+				array( '%d' )
+			);
+			return $status;
 		};
-		add_filter( 'datamachine_job_terminal_status', $kill_before_cas, 20 );
-		$pid = pcntl_fork();
-		$this->assertNotSame( -1, $pid );
-
-		if ( 0 === $pid ) {
-			fclose( $sockets[0] );
-			$child_db = new \wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
-			$child_db->set_prefix( $wpdb->prefix );
-			$GLOBALS['wpdb'] = $child_db;
-			( new Jobs() )->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
-			exit( 98 );
+		add_filter( 'datamachine_job_terminal_status', $interleave, 20, 2 );
+		try {
+			$result = $this->jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
+		} finally {
+			remove_filter( 'datamachine_job_terminal_status', $interleave, 20 );
 		}
 
-		fclose( $sockets[1] );
-		$this->assertSame( "prepared\n", fgets( $sockets[0] ) );
-		fclose( $sockets[0] );
-		pcntl_waitpid( $pid, $child_status );
-		remove_filter( 'datamachine_job_terminal_status', $kill_before_cas, 20 );
-
+		$this->assertFalse( $result['success'] );
 		$this->assertSame( 'processing', $this->jobs->get_job( $job_id )['status'] );
 		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'process-death-id' ) );
 		$this->assertTrue( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'process-death-id' ) );
@@ -391,47 +337,25 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertSame( 'recovered-revision', $this->tracked->get( self::NAMESPACE, 'process-death-id' )['source_revision'] );
 	}
 
-	public function test_process_death_after_failure_commit_preserves_cleanup_for_replay(): void {
-		if ( ! function_exists( 'pcntl_fork' ) || ! function_exists( 'stream_socket_pair' ) ) {
-			$this->markTestSkipped( 'pcntl and socket pairs are required for crash-boundary coverage.' );
-		}
-
-		global $wpdb;
-		$sockets = stream_socket_pair( STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP );
-		$this->assertIsArray( $sockets );
-		stream_set_timeout( $sockets[0], 5 );
-		stream_set_timeout( $sockets[1], 5 );
+	public function test_interruption_after_failure_commit_preserves_cleanup_for_replay(): void {
 		$job_id = $this->createJobWithClaim( array(), true );
 		$claim  = $this->claim( 'failed-commit-crash-id', $job_id, 'must-not-persist' );
 		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
-		$kill_after_commit = static function ( int $committed_job_id, string $status ) use ( $job_id, $sockets ): void {
+		$interrupt_after_commit = static function ( int $committed_job_id, string $status ) use ( $job_id ): void {
 			if ( $job_id !== $committed_job_id || JobStatus::isStatusSuccess( $status ) ) {
 				return;
 			}
-			fwrite( $sockets[1], "committed\n" );
-			if ( function_exists( 'posix_kill' ) ) {
-				posix_kill( getmypid(), SIGKILL );
-			}
-			exit( 99 );
+			throw new \RuntimeException( 'simulated interruption after commit' );
 		};
-		add_action( 'datamachine_job_terminal_committed', $kill_after_commit, 20, 2 );
-		$pid = pcntl_fork();
-		$this->assertNotSame( -1, $pid );
-
-		if ( 0 === $pid ) {
-			fclose( $sockets[0] );
-			$child_db = new \wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
-			$child_db->set_prefix( $wpdb->prefix );
-			$GLOBALS['wpdb'] = $child_db;
-			( new Jobs() )->transition_job_status_result( $job_id, JobStatus::failed( 'crash-after-commit' )->toString(), true );
-			exit( 98 );
+		add_action( 'datamachine_job_terminal_committed', $interrupt_after_commit, 20, 2 );
+		try {
+			$this->jobs->transition_job_status_result( $job_id, JobStatus::failed( 'crash-after-commit' )->toString(), true );
+			$this->fail( 'Expected the post-commit interruption.' );
+		} catch ( \RuntimeException $exception ) {
+			$this->assertSame( 'simulated interruption after commit', $exception->getMessage() );
+		} finally {
+			remove_action( 'datamachine_job_terminal_committed', $interrupt_after_commit, 20 );
 		}
-
-		fclose( $sockets[1] );
-		$this->assertSame( "committed\n", fgets( $sockets[0] ) );
-		fclose( $sockets[0] );
-		pcntl_waitpid( $pid, $child_status );
-		remove_action( 'datamachine_job_terminal_committed', $kill_after_commit, 20 );
 
 		$persisted_status = (string) $this->jobs->get_job( $job_id )['status'];
 		$this->assertStringContainsString( 'crash-after-commit', $persisted_status );

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -161,6 +161,223 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertIsArray( $this->context( 'retry-flow-step', $job_id + 1000 )->claimItemOwnership( self::SCOPE, 'terminal-rollback-id' ) );
 	}
 
+	public function test_later_claim_failure_rolls_back_every_claim_and_callback(): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$first  = $this->claim( 'multi-rollback-first', $job_id, 'must-rollback' );
+		$second = $this->claimWithCompletion(
+			'multi-rollback-second',
+			$job_id,
+			array(
+				'handler'          => 'failing_test',
+				'retain_processed' => false,
+			)
+		);
+		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIMS_METADATA_KEY => array( $first, $second ) ) );
+		$this->completion_handler_filter = static function ( array $handlers ): array {
+			$handlers['failing_test'] = static fn(): bool => false;
+			return $handlers;
+		};
+		add_filter( 'datamachine_item_claim_completion_handlers', $this->completion_handler_filter );
+
+		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
+
+		$job = $this->jobs->get_job( $job_id );
+		$this->assertIsArray( $job );
+		$this->assertStringContainsString( 'item_claim_completion_failed', (string) $job['status'] );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'multi-rollback-first' ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'multi-rollback-first' ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'multi-rollback-second' ) );
+	}
+
+	public function test_terminal_exception_rolls_back_callbacks_before_failure_recovery(): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$claim  = $this->claim( 'crash-boundary-id', $job_id, 'must-rollback' );
+		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
+		$crash = static function (): never {
+			throw new \RuntimeException( 'simulated crash before terminal CAS' );
+		};
+		add_filter( 'datamachine_job_terminal_status', $crash, 20 );
+
+		try {
+			$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
+		} finally {
+			remove_filter( 'datamachine_job_terminal_status', $crash, 20 );
+		}
+
+		$job = $this->jobs->get_job( $job_id );
+		$this->assertIsArray( $job );
+		$this->assertStringContainsString( 'terminal_preparation_exception', (string) $job['status'] );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'crash-boundary-id' ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'crash-boundary-id' ) );
+		$this->assertIsArray( $this->context( 'crash-retry-step', $job_id + 2000 )->claimItemOwnership( self::SCOPE, 'crash-boundary-id' ) );
+	}
+
+	public function test_forced_terminal_cas_failure_rolls_back_claim_side_effects(): void {
+		global $wpdb;
+		$job_id = $this->createJobWithClaim( array(), true );
+		$claim  = $this->claim( 'cas-loser-id', $job_id, 'must-rollback' );
+		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
+		$force_cas_loss = static function ( string $status, int $filtered_job_id ) use ( $wpdb ): string {
+			$wpdb->update(
+				( new Jobs() )->get_table_name(),
+				array( 'status' => 'processing-race-winner' ),
+				array( 'job_id' => $filtered_job_id ),
+				array( '%s' ),
+				array( '%d' )
+			);
+			return $status;
+		};
+		add_filter( 'datamachine_job_terminal_status', $force_cas_loss, 20, 2 );
+
+		try {
+			$result = $this->jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
+		} finally {
+			remove_filter( 'datamachine_job_terminal_status', $force_cas_loss, 20 );
+		}
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'processing', $result['status'] );
+		$this->assertSame( 'processing', $this->jobs->get_job( $job_id )['status'] );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'cas-loser-id' ) );
+		$this->assertTrue( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'cas-loser-id' ) );
+		StepLifecycleHandler::handleFailed( $job_id );
+	}
+
+	public function test_terminal_cas_loser_reports_persisted_winner(): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::CANCELLED ) );
+
+		$result = $this->jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( JobStatus::CANCELLED, $result['status'] );
+		$this->assertSame( JobStatus::CANCELLED, $result['current_status'] );
+	}
+
+	public function test_concurrent_terminal_callers_share_one_persisted_success(): void {
+		if ( ! function_exists( 'pcntl_fork' ) || ! function_exists( 'stream_socket_pair' ) ) {
+			$this->markTestSkipped( 'pcntl and socket pairs are required for DB concurrency coverage.' );
+		}
+
+		global $wpdb;
+		$sockets = stream_socket_pair( STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP );
+		$this->assertIsArray( $sockets );
+		stream_set_timeout( $sockets[0], 5 );
+		stream_set_timeout( $sockets[1], 5 );
+		$job_id = $this->createJobWithClaim( array(), true );
+		$claim  = $this->claimWithCompletion(
+			'concurrent-terminal-id',
+			$job_id,
+			array(
+				'handler'          => 'counting_test',
+				'retain_processed' => false,
+			)
+		);
+		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
+		$this->completion_handler_filter = static function ( array $handlers ): array {
+			$handlers['counting_test'] = static function ( array $payload, int $callback_job_id ): bool {
+				unset( $payload );
+				global $wpdb;
+				return false !== $wpdb->query(
+					// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
+					$wpdb->prepare(
+						'UPDATE %i SET label = CONCAT(label, %s) WHERE job_id = %d',
+						( new Jobs() )->get_table_name(),
+						'|callback',
+						$callback_job_id
+					)
+				);
+			};
+			return $handlers;
+		};
+		add_filter( 'datamachine_item_claim_completion_handlers', $this->completion_handler_filter );
+		$pause_owner = static function ( string $status ) use ( $sockets ): string {
+			fwrite( $sockets[0], "locked\n" );
+			fgets( $sockets[0] );
+			usleep( 200000 );
+			return $status;
+		};
+		add_filter( 'datamachine_job_terminal_status', $pause_owner, 20 );
+		$pid = pcntl_fork();
+		$this->assertNotSame( -1, $pid );
+
+		if ( 0 === $pid ) {
+			fclose( $sockets[0] );
+			$child_db = new \wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+			$child_db->set_prefix( $wpdb->prefix );
+			$GLOBALS['wpdb'] = $child_db;
+			fwrite( $sockets[1], "ready\n" );
+			fgets( $sockets[1] );
+			fwrite( $sockets[1], "attempting\n" );
+			$result = ( new Jobs() )->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
+			fwrite( $sockets[1], wp_json_encode( $result ) . "\n" );
+			fclose( $sockets[1] );
+			exit( 0 );
+		}
+
+		fclose( $sockets[1] );
+		$this->assertSame( "ready\n", fgets( $sockets[0] ) );
+		$owner_result = $this->jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
+		$child_result = json_decode( (string) fgets( $sockets[0] ), true );
+		fclose( $sockets[0] );
+		pcntl_waitpid( $pid, $child_status );
+		remove_filter( 'datamachine_job_terminal_status', $pause_owner, 20 );
+
+		$this->assertSame( 0, pcntl_wexitstatus( $child_status ) );
+		$this->assertTrue( $owner_result['success'] );
+		$this->assertTrue( $child_result['success'] );
+		$this->assertSame( JobStatus::COMPLETED, $owner_result['status'] );
+		$this->assertSame( JobStatus::COMPLETED, $child_result['status'] );
+		$this->assertSame( 1, substr_count( (string) $this->jobs->get_job( $job_id )['label'], '|callback' ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'concurrent-terminal-id' ) );
+	}
+
+	public function test_process_death_before_terminal_cas_rolls_back_and_recovers(): void {
+		if ( ! function_exists( 'pcntl_fork' ) || ! function_exists( 'stream_socket_pair' ) ) {
+			$this->markTestSkipped( 'pcntl and socket pairs are required for crash-boundary coverage.' );
+		}
+
+		global $wpdb;
+		$sockets = stream_socket_pair( STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP );
+		$this->assertIsArray( $sockets );
+		stream_set_timeout( $sockets[0], 5 );
+		stream_set_timeout( $sockets[1], 5 );
+		$job_id = $this->createJobWithClaim( array(), true );
+		$claim  = $this->claim( 'process-death-id', $job_id, 'recovered-revision' );
+		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
+		$kill_before_cas = static function ( string $status ) use ( $sockets ): string {
+			fwrite( $sockets[1], "prepared\n" );
+			if ( function_exists( 'posix_kill' ) ) {
+				posix_kill( getmypid(), SIGKILL );
+			}
+			exit( 99 );
+		};
+		add_filter( 'datamachine_job_terminal_status', $kill_before_cas, 20 );
+		$pid = pcntl_fork();
+		$this->assertNotSame( -1, $pid );
+
+		if ( 0 === $pid ) {
+			fclose( $sockets[0] );
+			$child_db = new \wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+			$child_db->set_prefix( $wpdb->prefix );
+			$GLOBALS['wpdb'] = $child_db;
+			( new Jobs() )->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
+			exit( 98 );
+		}
+
+		fclose( $sockets[1] );
+		$this->assertSame( "prepared\n", fgets( $sockets[0] ) );
+		fclose( $sockets[0] );
+		pcntl_waitpid( $pid, $child_status );
+		remove_filter( 'datamachine_job_terminal_status', $kill_before_cas, 20 );
+
+		$this->assertSame( 'processing', $this->jobs->get_job( $job_id )['status'] );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'process-death-id' ) );
+		$this->assertTrue( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'process-death-id' ) );
+		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
+		$this->assertSame( 'recovered-revision', $this->tracked->get( self::NAMESPACE, 'process-death-id' )['source_revision'] );
+	}
+
 	public function test_gated_inline_continuation_completes_every_claim(): void {
 		$first  = $this->claim( 'inline-success-a', 211, 'revision-a' );
 		$second = $this->claim( 'inline-success-b', 211, 'revision-b' );
@@ -202,6 +419,7 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
 		$this->assertSame( 'success-revision', $this->tracked->get( self::NAMESPACE, 'success-id' )['source_revision'] );
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'success-id' ) );
+		$this->assertSame( 1, datamachine_get_engine_data( $job_id )['run_metrics']['counts']['processed'] );
 	}
 
 	public function test_ordinary_terminal_failure_releases_claim(): void {
@@ -448,6 +666,7 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertSame( 'mixed-success-revision', $this->tracked->get( self::NAMESPACE, 'mixed-success-owned' )['source_revision'] );
 		$this->assertTrue( $this->processed->has_item_been_processed( self::SCOPE, self::SOURCE, 'mixed-success-legacy' ) );
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'mixed-success-owned' ) );
+		$this->assertSame( 2, datamachine_get_engine_data( $job_id )['run_metrics']['counts']['processed'] );
 	}
 
 	public function test_malformed_content_addressed_ref_releases_sidecar_claim(): void {

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -84,6 +84,16 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'expiry-id' ) );
 	}
 
+	public function test_expired_current_owner_can_complete_without_replacement(): void {
+		$claim = $this->claim( 'long-running-id', 2021, 'long-running-revision' );
+		$this->expireClaim( 'long-running-id' );
+
+		StepLifecycleHandler::handleCompleted( 2021, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
+
+		$this->assertSame( 'long-running-revision', $this->tracked->get( self::NAMESPACE, 'long-running-id' )['source_revision'] );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'long-running-id' ) );
+	}
+
 	public function test_completion_callback_failure_rolls_back_side_effect(): void {
 		$claim  = $this->claim( 'rollback-id', 203, 'rolled-back-revision' );
 		$result = $this->processed->complete_owned_claim(
@@ -235,6 +245,43 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 
 		$this->assertTrue( BatchScheduler::cancel( $parent_id ) );
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'cancel-id' ) );
+	}
+
+	public function test_batch_cancellation_during_active_chunk_preserves_created_child_claim(): void {
+		$first     = $this->claim( 'cancel-race-a', 9011, 'revision-a' );
+		$second    = $this->claim( 'cancel-race-b', 9011, 'revision-b' );
+		$third     = $this->claim( 'cancel-race-c', 9011, 'revision-c' );
+		$fourth    = $this->claim( 'cancel-race-d', 9011, 'revision-d' );
+		$parent_id = $this->createJobWithClaim( array(), true );
+		$this->chunk_size_filter = static fn() => 2;
+		add_filter( 'datamachine_batch_chunk_size', $this->chunk_size_filter );
+		BatchScheduler::start(
+			$parent_id,
+			'test_batch_hook',
+			array( $this->packet( $first ), $this->packet( $second ), $this->packet( $third ), $this->packet( $fourth ) ),
+			array(),
+			'pipeline'
+		);
+		$this->unscheduleTestBatch( $parent_id );
+		$created = 0;
+
+		$result = BatchScheduler::processChunk(
+			$parent_id,
+			static function () use ( $parent_id, &$created ): bool {
+				++$created;
+				BatchScheduler::cancel( $parent_id );
+				return true;
+			},
+			0
+		);
+
+		$this->assertTrue( $result['cancelled'] );
+		$this->assertSame( 1, $created );
+		$this->assertTrue( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'cancel-race-a' ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'cancel-race-b' ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'cancel-race-c' ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'cancel-race-d' ) );
+		StepLifecycleHandler::handleFailed( 9011, array( ProcessedItems::CLAIM_METADATA_KEY => $first ) );
 	}
 
 	public function test_later_chunk_scheduling_failure_releases_remaining_claims(): void {

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -341,6 +341,28 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'legacy-' . $status ) );
 	}
 
+	public function test_descriptorless_success_completes_job_owned_claim(): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$this->assertTrue( $this->processed->claim_item( self::SCOPE, self::SOURCE, 'legacy-success', $job_id ) );
+
+		StepLifecycleHandler::handleCompleted( $job_id, $this->legacyEngineData( 'legacy-success' ) );
+
+		$this->assertTrue( $this->processed->has_item_been_processed( self::SCOPE, self::SOURCE, 'legacy-success' ) );
+	}
+
+	public function test_stale_descriptorless_success_cannot_overwrite_replacement_owner(): void {
+		$legacy_job_id = $this->createJobWithClaim( array(), true );
+		$this->assertTrue( $this->processed->claim_item( self::SCOPE, self::SOURCE, 'legacy-replaced', $legacy_job_id ) );
+		$this->expireClaim( 'legacy-replaced' );
+		$replacement = $this->claim( 'legacy-replaced', 905, 'replacement-revision' );
+
+		StepLifecycleHandler::handleCompleted( $legacy_job_id, $this->legacyEngineData( 'legacy-replaced' ) );
+
+		$this->assertTrue( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'legacy-replaced' ) );
+		StepLifecycleHandler::handleCompleted( 905, array( ProcessedItems::CLAIM_METADATA_KEY => $replacement ) );
+		$this->assertSame( 'replacement-revision', $this->tracked->get( self::NAMESPACE, 'legacy-replaced' )['source_revision'] );
+	}
+
 	public function legacy_terminal_status_provider(): array {
 		return array(
 			'failure'      => array( JobStatus::failed( 'legacy' )->toString() ),
@@ -414,6 +436,16 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 			'type'     => 'fetch',
 			'data'     => array( 'title' => 'Claimed item', 'body' => 'body' ),
 			'metadata' => array( ProcessedItems::CLAIM_METADATA_KEY => $claim ),
+		);
+	}
+
+	private function legacyEngineData( string $item_id ): array {
+		return array(
+			'item_identifier' => $item_id,
+			'source_type'     => self::SOURCE,
+			'flow_config'     => array(
+				self::SCOPE => array( 'step_type' => 'fetch' ),
+			),
 		);
 	}
 

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -31,8 +31,9 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 	private TrackedItems $tracked;
 	private Jobs $jobs;
 	private int $admin_id;
-	private ?Closure $schedule_failure_filter = null;
-	private ?Closure $chunk_size_filter       = null;
+	private ?Closure $schedule_failure_filter   = null;
+	private ?Closure $chunk_size_filter         = null;
+	private ?Closure $completion_handler_filter = null;
 
 	public function set_up(): void {
 		parent::set_up();
@@ -52,6 +53,9 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		}
 		if ( null !== $this->chunk_size_filter ) {
 			remove_filter( 'datamachine_batch_chunk_size', $this->chunk_size_filter );
+		}
+		if ( null !== $this->completion_handler_filter ) {
+			remove_filter( 'datamachine_item_claim_completion_handlers', $this->completion_handler_filter );
 		}
 		$this->deleteTestRows();
 		parent::tear_down();
@@ -117,6 +121,44 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertFalse( $result );
 		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'rollback-id' ) );
 		$this->assertTrue( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'rollback-id' ) );
+	}
+
+	public function test_terminal_completion_callback_failure_fails_job_and_releases_for_retry(): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$claim  = $this->claimWithCompletion(
+			'terminal-rollback-id',
+			$job_id,
+			array(
+				'handler'          => 'failing_test',
+				'retain_processed' => false,
+			)
+		);
+		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
+		$this->completion_handler_filter = function ( array $handlers ): array {
+			$handlers['failing_test'] = function ( array $payload, int $job_id, array $claim ): bool {
+				unset( $payload, $job_id, $claim );
+				$this->tracked->upsert(
+					array(
+						'namespace'       => self::NAMESPACE,
+						'item_id'         => 'terminal-rollback-id',
+						'source_revision' => 'must-rollback',
+					)
+				);
+				return false;
+			};
+			return $handlers;
+		};
+		add_filter( 'datamachine_item_claim_completion_handlers', $this->completion_handler_filter );
+
+		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
+
+		$job = $this->jobs->get_job( $job_id );
+		$this->assertIsArray( $job );
+		$this->assertFalse( JobStatus::isStatusSuccess( (string) $job['status'] ) );
+		$this->assertStringContainsString( 'item_claim_completion_failed', (string) $job['status'] );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'terminal-rollback-id' ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'terminal-rollback-id' ) );
+		$this->assertIsArray( $this->context( 'retry-flow-step', $job_id + 1000 )->claimItemOwnership( self::SCOPE, 'terminal-rollback-id' ) );
 	}
 
 	public function test_gated_inline_continuation_completes_every_claim(): void {
@@ -389,6 +431,25 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'mixed-legacy' ) );
 	}
 
+	public function test_mixed_descriptor_and_legacy_claims_are_both_completed(): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$claim  = $this->claim( 'mixed-success-owned', $job_id, 'mixed-success-revision' );
+		$this->assertTrue( $this->processed->claim_item( self::SCOPE, self::SOURCE, 'mixed-success-legacy', $job_id ) );
+		datamachine_set_engine_data(
+			$job_id,
+			array_merge(
+				$this->legacyEngineData( 'mixed-success-legacy' ),
+				array( ProcessedItems::CLAIM_METADATA_KEY => $claim )
+			)
+		);
+
+		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
+
+		$this->assertSame( 'mixed-success-revision', $this->tracked->get( self::NAMESPACE, 'mixed-success-owned' )['source_revision'] );
+		$this->assertTrue( $this->processed->has_item_been_processed( self::SCOPE, self::SOURCE, 'mixed-success-legacy' ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'mixed-success-owned' ) );
+	}
+
 	public function test_malformed_content_addressed_ref_releases_sidecar_claim(): void {
 		$claim     = $this->claim( 'malformed-ref', 904, 'malformed-revision' );
 		$parent_id = $this->createJobWithClaim( array(), true );
@@ -409,10 +470,9 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 	}
 
 	private function claim( string $item_id, int $job_id, string $revision ): array {
-		$claim = $this->context( 'actual-flow-step', $job_id )->claimItemOwnership(
-			self::SCOPE,
+		return $this->claimWithCompletion(
 			$item_id,
-			ProcessedItems::DEFAULT_CLAIM_TTL_SECONDS,
+			$job_id,
 			array(
 				'handler'          => 'tracked_item',
 				'retain_processed' => false,
@@ -426,6 +486,15 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 					),
 				),
 			)
+		);
+	}
+
+	private function claimWithCompletion( string $item_id, int $job_id, array $completion ): array {
+		$claim = $this->context( 'actual-flow-step', $job_id )->claimItemOwnership(
+			self::SCOPE,
+			$item_id,
+			ProcessedItems::DEFAULT_CLAIM_TTL_SECONDS,
+			$completion
 		);
 		$this->assertIsArray( $claim );
 		return $claim;

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -1,0 +1,244 @@
+<?php
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Integration coverage verifies Data Machine-owned claim and tracking tables.
+/**
+ * Owner-safe source identity claim lifecycle coverage.
+ *
+ * @package DataMachine\Tests\Unit\Core
+ */
+
+namespace DataMachine\Tests\Unit\Core;
+
+use DataMachine\Abilities\Job\FailJobAbility;
+use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
+use DataMachine\Core\ActionScheduler\BatchScheduler;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\Database\TrackedItems\TrackedItems;
+use DataMachine\Core\ExecutionContext;
+use DataMachine\Core\JobStatus;
+use DataMachine\Engine\Actions\Handlers\FailJobHandler;
+use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
+use Closure;
+use WP_UnitTestCase;
+
+class ItemClaimLifecycleTest extends WP_UnitTestCase {
+
+	private const SCOPE     = 'shared:test-source';
+	private const SOURCE    = 'test_source';
+	private const NAMESPACE = 'claim-lifecycle-test';
+
+	private ProcessedItems $processed;
+	private TrackedItems $tracked;
+	private Jobs $jobs;
+	private int $admin_id;
+	private ?Closure $schedule_failure_filter = null;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->processed = new ProcessedItems();
+		$this->tracked   = new TrackedItems();
+		$this->jobs      = new Jobs();
+		$this->processed->create_table();
+		$this->tracked->create_table();
+		$this->admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->admin_id );
+		$this->deleteTestRows();
+	}
+
+	public function tear_down(): void {
+		if ( null !== $this->schedule_failure_filter ) {
+			remove_filter( 'pre_as_schedule_single_action', $this->schedule_failure_filter );
+		}
+		$this->deleteTestRows();
+		parent::tear_down();
+	}
+
+	public function test_two_flow_steps_race_one_shared_identity(): void {
+		$first = $this->context( 'flow-step-a', 101 )->claimItemOwnership( self::SCOPE, 'shared-id' );
+		$second = $this->context( 'flow-step-b', 102 )->claimItemOwnership( self::SCOPE, 'shared-id' );
+
+		$this->assertIsArray( $first );
+		$this->assertFalse( $second );
+	}
+
+	public function test_expired_owner_cannot_complete_or_release_replacement(): void {
+		$old = $this->claim( 'expiry-id', 201, 'old-revision' );
+		$this->expireClaim( 'expiry-id' );
+		StepLifecycleHandler::handleCompleted( 201, array( ProcessedItems::CLAIM_METADATA_KEY => $old ) );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'expiry-id' ) );
+
+		$new = $this->claim( 'expiry-id', 202, 'new-revision' );
+
+		StepLifecycleHandler::handleCompleted( 201, array( ProcessedItems::CLAIM_METADATA_KEY => $old ) );
+		StepLifecycleHandler::handleFailed( 201, array( ProcessedItems::CLAIM_METADATA_KEY => $old ) );
+
+		$this->assertTrue( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'expiry-id' ) );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'expiry-id' ) );
+
+		StepLifecycleHandler::handleCompleted( 202, array( ProcessedItems::CLAIM_METADATA_KEY => $new ) );
+		$this->assertSame( 'new-revision', $this->tracked->get( self::NAMESPACE, 'expiry-id' )['source_revision'] );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'expiry-id' ) );
+	}
+
+	public function test_successful_terminal_completion_persists_tracked_revision(): void {
+		$claim = $this->claim( 'success-id', 301, 'success-revision' );
+		$job_id = $this->createJobWithClaim( $claim, true );
+
+		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
+		$this->assertSame( 'success-revision', $this->tracked->get( self::NAMESPACE, 'success-id' )['source_revision'] );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'success-id' ) );
+	}
+
+	public function test_ordinary_terminal_failure_releases_claim(): void {
+		$claim  = $this->claim( 'retry-id', 401, 'retry-revision' );
+		$job_id = $this->createJobWithClaim( $claim, true );
+
+		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::failed( 'retry-exhausted' )->toString() ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'retry-id' ) );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'retry-id' ) );
+	}
+
+	public function test_retry_exhaustion_releases_claim(): void {
+		$claim  = $this->claim( 'exhausted-id', 402, 'exhausted-revision' );
+		$job_id = $this->createJobWithClaim( $claim, true );
+		$retryable = static fn() => true;
+		$policy    = static function ( array $resolved ): array {
+			$resolved['max_attempts'] = 1;
+			return $resolved;
+		};
+		add_filter( 'datamachine_job_error_retryable', $retryable );
+		add_filter( 'datamachine_job_retry_policy', $policy );
+
+		try {
+			$this->assertTrue( FailJobHandler::handle( $job_id, 'retryable-test', array( 'flow_step_id' => 'step-1' ) ) );
+		} finally {
+			remove_filter( 'datamachine_job_error_retryable', $retryable );
+			remove_filter( 'datamachine_job_retry_policy', $policy );
+		}
+
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'exhausted-id' ) );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'exhausted-id' ) );
+	}
+
+	public function test_manual_fail_releases_claim(): void {
+		$claim  = $this->claim( 'manual-id', 501, 'manual-revision' );
+		$job_id = $this->createJobWithClaim( $claim );
+
+		$result = ( new FailJobAbility() )->execute( array( 'job_id' => $job_id, 'reason' => 'manual test' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'manual-id' ) );
+	}
+
+	public function test_stale_recovery_releases_claim(): void {
+		$claim  = $this->claim( 'stale-id', 601, 'stale-revision' );
+		$job_id = $this->createJobWithClaim( $claim, true );
+		datamachine_merge_engine_data( $job_id, array( 'job_status' => JobStatus::failed( 'stale' )->toString() ) );
+
+		$result = ( new RecoverStuckJobsAbility() )->execute( array( 'dry_run' => false ) );
+
+		$this->assertGreaterThanOrEqual( 1, $result['recovered'] );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'stale-id' ) );
+	}
+
+	public function test_initial_batch_scheduling_failure_releases_all_claims(): void {
+		$claim = $this->claim( 'schedule-id', 701, 'schedule-revision' );
+		$parent_id = $this->createJobWithClaim( array(), true );
+		$this->schedule_failure_filter = static fn() => 0;
+		add_filter( 'pre_as_schedule_single_action', $this->schedule_failure_filter );
+
+		$result = BatchScheduler::start( $parent_id, 'test_batch_hook', array( $this->packet( $claim ) ), array(), 'pipeline' );
+
+		$this->assertFalse( $result['scheduled'] );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'schedule-id' ) );
+	}
+
+	public function test_child_creation_failure_releases_item_claim(): void {
+		$claim = $this->claim( 'child-id', 801, 'child-revision' );
+		$parent_id = $this->createJobWithClaim( array(), true );
+		BatchScheduler::start( $parent_id, 'test_batch_hook', array( $this->packet( $claim ) ), array(), 'pipeline' );
+
+		BatchScheduler::processChunk( $parent_id, static fn() => false );
+
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'child-id' ) );
+	}
+
+	public function test_batch_cancellation_releases_unscheduled_claims(): void {
+		$claim = $this->claim( 'cancel-id', 901, 'cancel-revision' );
+		$parent_id = $this->createJobWithClaim( array(), true );
+		BatchScheduler::start( $parent_id, 'test_batch_hook', array( $this->packet( $claim ) ), array(), 'pipeline' );
+
+		$this->assertTrue( BatchScheduler::cancel( $parent_id ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'cancel-id' ) );
+	}
+
+	private function context( string $flow_step_id, int $job_id ): ExecutionContext {
+		return ExecutionContext::fromFlow( 1, 1, $flow_step_id, (string) $job_id, self::SOURCE );
+	}
+
+	private function claim( string $item_id, int $job_id, string $revision ): array {
+		$claim = $this->context( 'actual-flow-step', $job_id )->claimItemOwnership(
+			self::SCOPE,
+			$item_id,
+			ProcessedItems::DEFAULT_CLAIM_TTL_SECONDS,
+			array(
+				'keep_processed' => false,
+				'tracked_item'   => array(
+					'namespace'       => self::NAMESPACE,
+					'item_id'         => $item_id,
+					'item_type'       => 'source',
+					'state'           => TrackedItems::STATE_GENERATED,
+					'source_revision' => $revision,
+				),
+			)
+		);
+		$this->assertIsArray( $claim );
+		return $claim;
+	}
+
+	private function packet( array $claim ): array {
+		return array(
+			'type'     => 'fetch',
+			'data'     => array( 'title' => 'Claimed item', 'body' => 'body' ),
+			'metadata' => array( ProcessedItems::CLAIM_METADATA_KEY => $claim ),
+		);
+	}
+
+	private function createJobWithClaim( array $claim, bool $processing = false ): int {
+		$job_id = $this->jobs->create_job(
+			array(
+				'pipeline_id' => 'direct',
+				'flow_id'     => 'direct',
+				'source'      => 'system',
+				'label'       => 'Claim lifecycle test',
+				'user_id'     => $this->admin_id,
+			)
+		);
+		$this->assertIsInt( $job_id );
+		if ( $processing ) {
+			$this->jobs->start_job( $job_id );
+		}
+		datamachine_set_engine_data( $job_id, $claim ? array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) : array() );
+		return $job_id;
+	}
+
+	private function expireClaim( string $item_id ): void {
+		global $wpdb;
+		$wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i SET claim_expires_at = %s WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s',
+				$this->processed->get_table_name(),
+				'2000-01-01 00:00:00',
+				self::SCOPE,
+				self::SOURCE,
+				$item_id
+			)
+		);
+	}
+
+	private function deleteTestRows(): void {
+		global $wpdb;
+		$wpdb->delete( $this->processed->get_table_name(), array( 'flow_step_id' => self::SCOPE ), array( '%s' ) );
+		$wpdb->delete( $this->tracked->get_table_name(), array( 'namespace' => self::NAMESPACE ), array( '%s' ) );
+	}
+}

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -11,11 +11,13 @@ namespace DataMachine\Tests\Unit\Core;
 use DataMachine\Abilities\Job\FailJobAbility;
 use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Core\ActionScheduler\BatchScheduler;
+use DataMachine\Core\ActionScheduler\GroupRegistrar;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\Database\TrackedItems\TrackedItems;
 use DataMachine\Core\ExecutionContext;
 use DataMachine\Core\JobStatus;
+use DataMachine\Core\RunMetrics;
 use DataMachine\Engine\Actions\Handlers\FailJobHandler;
 use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
 use Closure;
@@ -33,6 +35,7 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 	private int $admin_id;
 	private ?Closure $schedule_failure_filter   = null;
 	private ?Closure $chunk_size_filter         = null;
+	private ?Closure $tracked_handler_filter    = null;
 	private ?Closure $completion_handler_filter = null;
 
 	public function set_up(): void {
@@ -42,7 +45,8 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->jobs      = new Jobs();
 		$this->processed->create_table();
 		$this->tracked->create_table();
-		add_filter( 'datamachine_item_claim_completion_handlers', array( TrackedItems::class, 'registerClaimCompletionHandler' ) );
+		$this->tracked_handler_filter = static fn( array $handlers ): array => TrackedItems::registerClaimCompletionHandler( $handlers );
+		add_filter( 'datamachine_item_claim_completion_handlers', $this->tracked_handler_filter );
 		$this->admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $this->admin_id );
 		$this->deleteTestRows();
@@ -58,7 +62,9 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		if ( null !== $this->completion_handler_filter ) {
 			remove_filter( 'datamachine_item_claim_completion_handlers', $this->completion_handler_filter );
 		}
-		remove_filter( 'datamachine_item_claim_completion_handlers', array( TrackedItems::class, 'registerClaimCompletionHandler' ) );
+		if ( null !== $this->tracked_handler_filter ) {
+			remove_filter( 'datamachine_item_claim_completion_handlers', $this->tracked_handler_filter );
+		}
 		$this->deleteTestRows();
 		parent::tear_down();
 	}
@@ -496,7 +502,7 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
 		$this->assertSame( 'success-revision', $this->tracked->get( self::NAMESPACE, 'success-id' )['source_revision'] );
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'success-id' ) );
-		$this->assertSame( 1, datamachine_get_engine_data( $job_id )['run_metrics']['counts']['processed'] );
+		$this->assertSame( 1, datamachine_get_engine_data( $job_id )[ RunMetrics::KEY ]['counts']['processed'] );
 	}
 
 	public function test_ordinary_terminal_failure_releases_claim(): void {
@@ -743,7 +749,7 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertSame( 'mixed-success-revision', $this->tracked->get( self::NAMESPACE, 'mixed-success-owned' )['source_revision'] );
 		$this->assertTrue( $this->processed->has_item_been_processed( self::SCOPE, self::SOURCE, 'mixed-success-legacy' ) );
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'mixed-success-owned' ) );
-		$this->assertSame( 2, datamachine_get_engine_data( $job_id )['run_metrics']['counts']['processed'] );
+		$this->assertSame( 2, datamachine_get_engine_data( $job_id )[ RunMetrics::KEY ]['counts']['processed'] );
 	}
 
 	public function test_malformed_content_addressed_ref_releases_sidecar_claim(): void {
@@ -822,7 +828,7 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 					'parent_job_id' => $parent_id,
 					'offset'        => 0,
 				),
-				'data-machine'
+				GroupRegistrar::GROUP
 			);
 		}
 	}

--- a/tests/batch-completion-strategy-smoke.php
+++ b/tests/batch-completion-strategy-smoke.php
@@ -97,7 +97,7 @@ datamachine_strategy_assert(
 	'pipeline completion still lives in onChildComplete()'
 );
 datamachine_strategy_assert(
-	str_contains( $pipeline_batch, '$active > 0 || $total_children < $batch_total' ),
+	str_contains( $pipeline_batch, '$active > 0 || $batch_pending || $total_children < $batch_scheduled' ),
 	'pipeline parent still waits for children to finish and all children to be scheduled'
 );
 datamachine_strategy_assert(

--- a/tests/processed-item-claims-smoke.php
+++ b/tests/processed-item-claims-smoke.php
@@ -128,6 +128,8 @@ $processed_items = file_get_contents( __DIR__ . '/../inc/Core/Database/Processed
 $fetch_handler   = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/FetchHandler.php' );
 $lifecycle       = file_get_contents( __DIR__ . '/../inc/Engine/Actions/Handlers/StepLifecycleHandler.php' );
 $actions         = file_get_contents( __DIR__ . '/../inc/Engine/Actions/DataMachineActions.php' );
+$batch_scheduler = file_get_contents( __DIR__ . '/../inc/Core/ActionScheduler/BatchScheduler.php' );
+$packet_store    = file_get_contents( __DIR__ . '/../inc/Core/DataPacketStore.php' );
 
 assert_claims_smoke( 'repository defines claimed status', (bool) preg_match( "/STATUS_CLAIMED\s*=\s*'claimed'/", $processed_items ) );
 assert_claims_smoke( 'repository defines processed status', (bool) preg_match( "/STATUS_PROCESSED\s*=\s*'processed'/", $processed_items ) );
@@ -135,12 +137,18 @@ assert_claims_smoke( 'repository has atomic claim method', str_contains( $proces
 assert_claims_smoke( 'repository returns ownership tokens', str_contains( $processed_items, 'function claim_item_owned' ) && str_contains( $processed_items, 'claim_token' ) );
 assert_claims_smoke( 'repository conditionally completes owned claims', str_contains( $processed_items, 'function complete_owned_claim' ) );
 assert_claims_smoke( 'repository conditionally releases owned claims', str_contains( $processed_items, 'function release_owned_claim' ) );
+assert_claims_smoke( 'completion side effects share the claim transaction', str_contains( $processed_items, "'START TRANSACTION'" ) && str_contains( $processed_items, "'COMMIT'" ) && str_contains( $processed_items, "'ROLLBACK'" ) );
+assert_claims_smoke( 'claim acquisition handles duplicate contention without bare insert', str_contains( $processed_items, 'ON DUPLICATE KEY UPDATE' ) );
 assert_claims_smoke( 'repository ensures claim columns', str_contains( $processed_items, 'function ensure_claim_columns' ) );
 assert_claims_smoke( 'fetch filters active claims', str_contains( $fetch_handler, 'isItemClaimed' ) );
 assert_claims_smoke( 'fetch claims after max_items', strpos( $fetch_handler, 'array_slice' ) < strpos( $fetch_handler, 'claimItems' ) );
 assert_claims_smoke( 'all terminal statuses use one lifecycle hook', str_contains( $actions, "add_action( 'datamachine_job_complete', array( StepLifecycleHandler::class, 'handleTerminal' )" ) );
 assert_claims_smoke( 'lifecycle uses owner-conditional completion and release', str_contains( $lifecycle, 'complete_owned_claim' ) && str_contains( $lifecycle, 'release_owned_claim' ) );
+assert_claims_smoke( 'lifecycle preserves multiple inline claims', str_contains( $lifecycle, 'CLAIMS_METADATA_KEY' ) && str_contains( $lifecycle, 'uniqueClaims' ) );
+assert_claims_smoke( 'completion consumers register outside generic lifecycle', str_contains( $actions, 'datamachine_item_claim_completion_handlers' ) && ! str_contains( $lifecycle, 'TrackedItems' ) );
+assert_claims_smoke( 'legacy jobs retain terminal job-id cleanup', str_contains( $lifecycle, 'release_claims_for_job' ) );
 assert_claims_smoke( 'discarded batch packets release ownership', str_contains( $actions, "add_action( 'datamachine_batch_items_discarded'" ) );
+assert_claims_smoke( 'batch cleanup survives packet hydration failure', str_contains( $batch_scheduler, 'cleanup_contexts' ) && str_contains( $packet_store, 'hydrate_packet_collections_with_status' ) );
 
 echo "\nProcessed item claims smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {

--- a/tests/processed-item-claims-smoke.php
+++ b/tests/processed-item-claims-smoke.php
@@ -126,20 +126,21 @@ assert_claims_smoke( 'expired claim can be reclaimed', $ledger->claim( $flow, $s
 echo "Case 5: production files expose the claim contract\n";
 $processed_items = file_get_contents( __DIR__ . '/../inc/Core/Database/ProcessedItems/ProcessedItems.php' );
 $fetch_handler   = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/FetchHandler.php' );
-$fail_handler    = file_get_contents( __DIR__ . '/../inc/Engine/Actions/Handlers/FailJobHandler.php' );
 $lifecycle       = file_get_contents( __DIR__ . '/../inc/Engine/Actions/Handlers/StepLifecycleHandler.php' );
-$execute_step    = file_get_contents( __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php' );
+$actions         = file_get_contents( __DIR__ . '/../inc/Engine/Actions/DataMachineActions.php' );
 
 assert_claims_smoke( 'repository defines claimed status', (bool) preg_match( "/STATUS_CLAIMED\s*=\s*'claimed'/", $processed_items ) );
 assert_claims_smoke( 'repository defines processed status', (bool) preg_match( "/STATUS_PROCESSED\s*=\s*'processed'/", $processed_items ) );
 assert_claims_smoke( 'repository has atomic claim method', str_contains( $processed_items, 'function claim_item' ) );
-assert_claims_smoke( 'repository has release claim method', str_contains( $processed_items, 'function release_claim' ) );
+assert_claims_smoke( 'repository returns ownership tokens', str_contains( $processed_items, 'function claim_item_owned' ) && str_contains( $processed_items, 'claim_token' ) );
+assert_claims_smoke( 'repository conditionally completes owned claims', str_contains( $processed_items, 'function complete_owned_claim' ) );
+assert_claims_smoke( 'repository conditionally releases owned claims', str_contains( $processed_items, 'function release_owned_claim' ) );
 assert_claims_smoke( 'repository ensures claim columns', str_contains( $processed_items, 'function ensure_claim_columns' ) );
 assert_claims_smoke( 'fetch filters active claims', str_contains( $fetch_handler, 'isItemClaimed' ) );
 assert_claims_smoke( 'fetch claims after max_items', strpos( $fetch_handler, 'array_slice' ) < strpos( $fetch_handler, 'claimItems' ) );
-assert_claims_smoke( 'fail handler delegates failed lifecycle', str_contains( $fail_handler, 'datamachine_step_lifecycle_failed' ) );
-assert_claims_smoke( 'lifecycle handler releases claims for failed work', str_contains( $lifecycle, 'release_claims_for_job' ) && str_contains( $lifecycle, 'release_claim' ) );
-assert_claims_smoke( 'execute step delegates lifecycle hooks', str_contains( $execute_step, 'handleStepLifecycleCompleted' ) && str_contains( $execute_step, 'handleStepLifecycleFailed' ) );
+assert_claims_smoke( 'all terminal statuses use one lifecycle hook', str_contains( $actions, "add_action( 'datamachine_job_complete', array( StepLifecycleHandler::class, 'handleTerminal' )" ) );
+assert_claims_smoke( 'lifecycle uses owner-conditional completion and release', str_contains( $lifecycle, 'complete_owned_claim' ) && str_contains( $lifecycle, 'release_owned_claim' ) );
+assert_claims_smoke( 'discarded batch packets release ownership', str_contains( $actions, "add_action( 'datamachine_batch_items_discarded'" ) );
 
 echo "\nProcessed item claims smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary
- add token-owned `ProcessedItems` claims for caller-provided identity scopes while preserving the existing boolean claim API
- make completion-handler side effects and the token-owned claim transition one database transaction
- carry every opaque claim descriptor through multi-packet inline continuation, fan-out children, and content-addressed batch cleanup sidecars
- preserve job-ID cleanup for pre-deployment and partially migrated jobs without allowing stale tokens to release replacement ownership
- release unscheduled claims on initial/later chunk enqueue failure, hydration failure, child creation failure, and cancellation
- route success, ordinary failure, manual fail, retry exhaustion, stale recovery, and cancellation through the same terminal lifecycle hooks
- preserve the actual executing `flow_step_id` in `datamachine_should_reprocess_item` context

Fixes #2936

## Generic Contract

`ExecutionContext::claimItemOwnership()` accepts a caller-provided identity scope and item ID and returns an opaque lifecycle descriptor. Consumers attach descriptors under `ProcessedItems::CLAIM_METADATA_KEY`; Data Machine propagates them and owns terminal cleanup. Inline continuation stores a deduplicated collection under `ProcessedItems::CLAIMS_METADATA_KEY` so gated multi-item fallback cannot lose ownership metadata.

Completion configuration contains only a registered handler ID, opaque payload, and generic `retain_processed` transition choice. Handlers register through `datamachine_item_claim_completion_handlers`; generic `ExecutionContext` and `StepLifecycleHandler` contain no completion-ledger knowledge. The `TrackedItems` repository registers its own handler.

`ProcessedItems::complete_owned_claim()` starts a transaction, locks the active unexpired token with `SELECT ... FOR UPDATE`, executes the registered callback, transitions or deletes the claim, and commits. Callback failure, transition failure, or an exception rolls back both side effects and ownership. A stale worker therefore cannot persist a revision without completing its ownership transition.

Acquisition uses `INSERT ... ON DUPLICATE KEY UPDATE` for absent-row contention, processed-row reprocessing, and expired takeover. Active contention returns `false` without a duplicate-key error, and full-identifier equality prevents truncated-index prefix collisions from mutating a different row.

The existing `claim_item()` and `ExecutionContext::claimItemForProcessing()` boolean APIs remain available. Terminal failure also releases remaining `job_id` claims for descriptorless and partially migrated in-flight jobs; takeover replaces `job_id`, so this cannot release a replacement worker's claim.

## Lifecycle

- `datamachine_job_complete` bridges every final status into completed/failed lifecycle hooks.
- Success executes registered completion work and the claim transition atomically.
- Failure, manual fail, stale recovery, retry exhaustion, and cancellation release token-owned and legacy job-owned claims.
- Batch cleanup contexts are captured before content-addressing, allowing missing or malformed references to release ownership.
- Initial and later chunk scheduling failures discard all unscheduled ownership and terminalize batch parents.

## Tests

Added MySQL/WordPress integration coverage for:

- two flow steps contending for one shared identity without a database error
- exact TTL expiry/reacquisition followed by stale completion and stale failure
- rollback of completion side effects when ownership transition cannot commit
- multiple claimed packets through gated inline continuation success and failure
- initial and later chunk scheduling failure
- child creation failure and batch cancellation
- missing and malformed content-addressed packet hydration
- ordinary terminal failure, retry exhaustion, manual fail, and stale recovery
- successful terminal completion
- descriptorless and mixed descriptor/legacy pre-deployment jobs
- packet-to-child ownership propagation
- actual flow-step reprocess callback context

Passed locally on corrected head:

- PHP syntax for all 17 changed PHP files
- `git diff --check`
- `tests/processed-item-claims-smoke.php` (30 assertions)
- `tests/content-addressed-data-packets-smoke.php`
- `tests/batch-completion-strategy-smoke.php`
- `tests/packet-engine-data-smoke.php`
- `tests/parallel-map-fanout-adapter-smoke.php` (34 assertions)
- `tests/recover-stuck-terminal-actions-smoke.php`
- `tests/pipeline-batch-terminal-parent-guard-smoke.php`
- Homeboy PR audit `0084d00e-73fd-4bc8-875a-7868cfa38120`: no introduced findings

The first CI head exposed 37 PHPCS findings and 14 PHPUnit failures. All 37 branch lint findings were inspected and corrected. The 14 PHPUnit failures were inspected individually: two agent preference tests, one already-merged flow-creation expectation, three flow-schedule reconciliation tests, and eight WordPress 6.9 ability-registration notice failures; none executed changed claim lifecycle code. Corrected-head CI is the authoritative discovered PHPUnit/WPCS rerun.

Local Homeboy project-mode PHPUnit remains blocked before discovery because its sandbox does not load `PHPUnit\\Framework\\TestSuite` (`6b6b89d1-3458-4a41-b7ec-b1deb17cab2c`). Local Homeboy PHPCS also has a corrupted extension install, while corrected-head GitHub CI provisions its own working harness.