### PR TITLE
Require signed pending-action authorization receipts

### DIFF
--- a/docs/core-system/pending-actions.md
+++ b/docs/core-system/pending-actions.md
@@ -4,6 +4,8 @@ Data Machine implements the Agents API pending-action approval storage contract 
 
 Pending actions are approval and audit records. Normal runtime requires the durable `datamachine_pending_actions` table; if database access is unavailable, store/resolution operations fail closed and emit `datamachine_pending_action_store_unavailable`. The transient store path is reserved for pure-PHP smoke tests or explicit pre-table boot by defining `DATAMACHINE_PENDING_ACTION_TRANSIENT_FALLBACK`.
 
+Resolution atomically claims a row as `pending -> applying -> accepted|rejected|failed`. Accepted handlers receive an `authorization_receipt` in resolver context (or as the third argument for callable compatibility handlers). Mutators can call `PendingActionAuthorizationReceipt::validate( $receipt, $kind, $operation, $target, $input, $subject, $workspace )`; validation binds the receipt to the pending action, kind, operation, target, input, subject, workspace, resolver, expiry, and one-time claim nonce.
+
 ## Boundary
 
 - Agents API owns generic approval vocabulary, contracts, and the canonical pending-action abilities.

--- a/inc/Cli/Commands/PendingActionsCommand.php
+++ b/inc/Cli/Commands/PendingActionsCommand.php
@@ -19,6 +19,31 @@ defined( 'ABSPATH' ) || exit;
  */
 class PendingActionsCommand extends BaseCommand {
 
+	/** Resolve a pending action through the canonical resolver. */
+	public function accept( array $args, array $assoc_args ): void {
+		$this->resolve( $args, $assoc_args, 'accepted' );
+	}
+
+	/** Resolve a pending action through the canonical resolver. */
+	public function reject( array $args, array $assoc_args ): void {
+		$this->resolve( $args, $assoc_args, 'rejected' );
+	}
+
+	private function resolve( array $args, array $assoc_args, string $decision ): void {
+		$action_id = isset( $args[0] ) ? (string) $args[0] : '';
+		if ( '' === $action_id ) {
+			WP_CLI::error( 'action_id is required.' );
+		}
+		$result = \DataMachine\Engine\AI\Actions\ResolvePendingActionAbility::execute( array( 'action_id' => $action_id, 'decision' => $decision, 'resolver' => 'cli:' . get_current_user_id(), 'context' => array( 'resolution_transport' => 'cli' ) ) );
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( (string) ( $result['error'] ?? 'Pending action could not be resolved.' ) );
+		}
+		WP_CLI::success( sprintf( 'Pending action %s.', $decision ) );
+		if ( 'json' === ( $assoc_args['format'] ?? '' ) ) {
+			WP_CLI::line( wp_json_encode( $result ) );
+		}
+	}
+
 	/**
 	 * List pending actions.
 	 *

--- a/inc/Engine/AI/Actions/PendingActionAuthorizationReceipt.php
+++ b/inc/Engine/AI/Actions/PendingActionAuthorizationReceipt.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Generic, handler-facing authorization receipt for an applying pending action.
+ *
+ * @package DataMachine\Engine\AI\Actions
+ */
+
+namespace DataMachine\Engine\AI\Actions;
+
+defined( 'ABSPATH' ) || exit;
+
+final class PendingActionAuthorizationReceipt {
+
+	private const OPTION_SECRET = 'datamachine_pending_action_receipt_secret';
+	private static ?string $transient_secret = null;
+
+	/** Issue a signed receipt from an atomically claimed action payload. */
+	public static function issue( array $action, string $resolver ): array {
+		$authorization = self::authorization( $action );
+		$claims        = array(
+			'action_id'    => (string) $action['action_id'],
+			'kind'         => (string) $action['kind'],
+			'operation'    => $authorization['operation'],
+			'target_digest'=> self::digest( $authorization['target'] ),
+			'input_digest' => self::digest( $action['apply_input'] ?? array() ),
+			'subject'      => (string) ( $action['agent'] ?? $action['creator'] ?? '' ),
+			'workspace'    => $action['workspace'] ?? null,
+			'resolver'     => $resolver,
+			'issued_at'    => time(),
+			'expires_at'   => (int) ( $action['expires_at'] ?? 0 ),
+			'nonce'        => (string) ( $action['receipt_nonce'] ?? '' ),
+		);
+
+		$encoded = self::base64url_encode( wp_json_encode( $claims ) );
+		return array( 'token' => $encoded . '.' . self::base64url_encode( hash_hmac( 'sha256', $encoded, self::secret(), true ) ), 'claims' => $claims );
+	}
+
+	/**
+	 * Validate that a receipt still authorizes this exact handler operation.
+	 * A claimed action is the single-use boundary; terminal actions invalidate it.
+	 *
+	 * @return true|\WP_Error
+	 */
+	public static function validate( $receipt, string $kind, string $operation, $target, array $input, string $subject, array $workspace ): true|\WP_Error {
+		$token = is_array( $receipt ) ? (string) ( $receipt['token'] ?? '' ) : (string) $receipt;
+		$parts = explode( '.', $token, 2 );
+		if ( 2 !== count( $parts ) || ! hash_equals( self::base64url_encode( hash_hmac( 'sha256', $parts[0], self::secret(), true ) ), $parts[1] ) ) {
+			return new \WP_Error( 'invalid_authorization_receipt', 'Authorization receipt is invalid.' );
+		}
+
+		$claims = json_decode( self::base64url_decode( $parts[0] ), true );
+		if ( ! is_array( $claims ) || (int) ( $claims['expires_at'] ?? 0 ) <= time() ) {
+			return new \WP_Error( 'authorization_receipt_expired', 'Authorization receipt has expired.' );
+		}
+		if ( (string) ( $claims['kind'] ?? '' ) !== $kind || (string) ( $claims['operation'] ?? '' ) !== $operation || (string) ( $claims['target_digest'] ?? '' ) !== self::digest( $target ) || (string) ( $claims['input_digest'] ?? '' ) !== self::digest( $input ) || (string) ( $claims['subject'] ?? '' ) !== $subject || self::digest( $claims['workspace'] ?? null ) !== self::digest( $workspace ) ) {
+			return new \WP_Error( 'authorization_receipt_mismatch', 'Authorization receipt does not match this kind, operation, target, input, subject, or workspace.' );
+		}
+
+		$action = PendingActionStore::inspect( (string) ( $claims['action_id'] ?? '' ) );
+		if ( null === $action || 'applying' !== (string) ( $action['status'] ?? '' ) || ! hash_equals( (string) ( $action['receipt_nonce'] ?? '' ), (string) ( $claims['nonce'] ?? '' ) ) || (string) ( $action['kind'] ?? '' ) !== (string) ( $claims['kind'] ?? '' ) || (string) ( $action['resolver'] ?? '' ) !== (string) ( $claims['resolver'] ?? '' ) || self::digest( $action['workspace'] ?? null ) !== self::digest( $claims['workspace'] ?? null ) || (string) ( $action['agent'] ?? $action['creator'] ?? '' ) !== (string) ( $claims['subject'] ?? '' ) ) {
+			return new \WP_Error( 'authorization_receipt_consumed', 'Authorization receipt has been consumed or is no longer valid.' );
+		}
+
+		return true;
+	}
+
+	/** Normalize the generic authorization binding, including legacy rows. */
+	public static function authorization( array $action ): array {
+		$metadata      = is_array( $action['metadata'] ?? null ) ? $action['metadata'] : array();
+		$authorization = is_array( $metadata['datamachine']['authorization'] ?? null ) ? $metadata['datamachine']['authorization'] : array();
+		return array(
+			'operation' => (string) ( $authorization['operation'] ?? $action['kind'] ?? '' ),
+			'target'    => $authorization['target'] ?? ( $action['apply_input'] ?? array() ),
+		);
+	}
+
+	public static function digest( $value ): string {
+		return hash( 'sha256', wp_json_encode( self::sort_value( $value ) ) );
+	}
+
+	private static function sort_value( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+		foreach ( $value as $key => $item ) {
+			$value[ $key ] = self::sort_value( $item );
+		}
+		if ( array_keys( $value ) !== range( 0, count( $value ) - 1 ) ) {
+			ksort( $value );
+		}
+		return $value;
+	}
+
+	private static function secret(): string {
+		if ( ! function_exists( 'get_option' ) || ! function_exists( 'update_option' ) ) {
+			self::$transient_secret ??= bin2hex( random_bytes( 32 ) );
+			return self::$transient_secret;
+		}
+		$secret = get_option( self::OPTION_SECRET, '' );
+		if ( is_string( $secret ) && '' !== $secret ) {
+			return $secret;
+		}
+		$secret = bin2hex( random_bytes( 32 ) );
+		update_option( self::OPTION_SECRET, $secret, false );
+		return $secret;
+	}
+
+	private static function base64url_encode( string $value ): string { return rtrim( strtr( base64_encode( $value ), '+/', '-_' ), '=' ); }
+	private static function base64url_decode( string $value ): string { return (string) base64_decode( strtr( $value, '-_', '+/' ) ); }
+}

--- a/inc/Engine/AI/Actions/PendingActionHelper.php
+++ b/inc/Engine/AI/Actions/PendingActionHelper.php
@@ -104,6 +104,11 @@ class PendingActionHelper {
 				'resolve_with'    => 'resolve_pending_action',
 			)
 		);
+		$authorization = isset( $args['authorization'] ) && is_array( $args['authorization'] ) ? $args['authorization'] : array();
+		$metadata['datamachine']['authorization'] = array(
+			'operation' => (string) ( $authorization['operation'] ?? $kind ),
+			'target'    => $authorization['target'] ?? $apply_input,
+		);
 
 		$payload = array(
 			'kind'            => $kind,

--- a/inc/Engine/AI/Actions/PendingActionStore.php
+++ b/inc/Engine/AI/Actions/PendingActionStore.php
@@ -107,6 +107,7 @@ class PendingActionStore {
 			resolution_result longtext NULL,
 			resolution_error text NULL,
 			resolution_metadata longtext NULL,
+			receipt_nonce varchar(64) NULL,
 			PRIMARY KEY  (action_id),
 			KEY workspace (workspace_type, workspace_id),
 			KEY status (status),
@@ -147,6 +148,11 @@ class PendingActionStore {
 		if ( ! self::column_exists( $table_name, 'workspace_id' ) ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
 			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN workspace_id varchar(191) NULL', $table_name ) );
+		}
+
+		if ( ! self::column_exists( $table_name, 'receipt_nonce' ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN receipt_nonce varchar(64) NULL', $table_name ) );
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
@@ -260,9 +266,10 @@ class PendingActionStore {
 			'resolution_result'   => null,
 			'resolution_error'    => null,
 			'resolution_metadata' => null,
+			'receipt_nonce'       => null,
 		);
 
-		$formats = array( '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%s' );
+		$formats = array( '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s' );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$stored = $wpdb->replace( self::get_table_name(), $row, $formats );
@@ -287,7 +294,10 @@ class PendingActionStore {
 			}
 
 			$data = get_transient( self::TRANSIENT_PREFIX . $action_id );
-			return is_array( $data ) ? $data : null;
+			if ( ! is_array( $data ) || ( ! $include_resolved && WP_Agent_Pending_Action_Status::PENDING !== ( $data['status'] ?? null ) ) ) {
+				return null;
+			}
+			return $data;
 		}
 
 		$row = self::get_row( $action_id );
@@ -398,6 +408,71 @@ class PendingActionStore {
 		}
 
 		return false !== $updated;
+	}
+
+	/**
+	 * Atomically claim a pending action before a handler can apply it.
+	 *
+	 * @return array|null Claimed payload, or null when another resolver won.
+	 */
+	public static function claim_for_resolution( string $action_id, ?string $resolver = null ): ?array {
+		$nonce = bin2hex( random_bytes( 24 ) );
+		if ( ! self::has_database() ) {
+			if ( ! self::allows_transient_fallback() ) {
+				self::warn_database_unavailable( 'claim_for_resolution' );
+				return null;
+			}
+			$payload = get_transient( self::TRANSIENT_PREFIX . $action_id );
+			if ( ! is_array( $payload ) || WP_Agent_Pending_Action_Status::PENDING !== ( $payload['status'] ?? null ) || (int) ( $payload['expires_at'] ?? 0 ) <= time() ) {
+				return null;
+			}
+			$payload['status']        = 'applying';
+			$payload['receipt_nonce'] = $nonce;
+			$payload['resolver']      = self::nullable_string( $resolver ?? self::current_resolver() );
+			set_transient( self::TRANSIENT_PREFIX . $action_id, $payload, self::resolve_ttl( $payload ) );
+			return $payload;
+		}
+
+		global $wpdb;
+		// A status predicate makes this a cross-process compare-and-swap claim.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+		$updated = $wpdb->query( $wpdb->prepare( 'UPDATE %i SET status = %s, receipt_nonce = %s, resolver = %s WHERE action_id = %s AND status = %s AND ( expires_at IS NULL OR expires_at > UTC_TIMESTAMP() )', self::get_table_name(), 'applying', $nonce, self::nullable_string( $resolver ?? self::current_resolver() ), $action_id, WP_Agent_Pending_Action_Status::PENDING ) );
+		if ( 1 !== $updated ) {
+			return null;
+		}
+		return self::get( $action_id, true );
+	}
+
+	/** Complete a claim only when its receipt nonce still owns the applying row. */
+	public static function complete_claim( string $action_id, string $nonce, string $status, $result = null, ?string $error = null, ?string $resolver = null, array $metadata = array() ): bool {
+		if ( ! in_array( $status, array( WP_Agent_Pending_Action_Status::ACCEPTED, WP_Agent_Pending_Action_Status::REJECTED, 'failed' ), true ) ) {
+			return false;
+		}
+		if ( ! self::has_database() ) {
+			$payload = get_transient( self::TRANSIENT_PREFIX . $action_id );
+			if ( ! is_array( $payload ) || 'applying' !== ( $payload['status'] ?? null ) || ! hash_equals( (string) ( $payload['receipt_nonce'] ?? '' ), $nonce ) ) {
+				return false;
+			}
+			$payload['status'] = $status;
+			$completed = set_transient( self::TRANSIENT_PREFIX . $action_id, $payload, self::resolve_ttl( $payload ) );
+			if ( $completed && in_array( $status, array( WP_Agent_Pending_Action_Status::ACCEPTED, WP_Agent_Pending_Action_Status::REJECTED ), true ) ) {
+				$action = self::action_from_payload( $payload );
+				if ( null !== $action ) {
+					self::dispatch_resolution( $action, $status, $resolver ?? self::current_resolver() );
+				}
+			}
+			return $completed;
+		}
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+		$updated = $wpdb->update( self::get_table_name(), array( 'status' => $status, 'resolved_at' => current_time( 'mysql', true ), 'resolved_by' => get_current_user_id(), 'resolver' => self::nullable_string( $resolver ?? self::current_resolver() ), 'resolution_result' => self::encode_json( $result ), 'resolution_error' => $error, 'resolution_metadata' => self::encode_json( $metadata ) ), array( 'action_id' => $action_id, 'status' => 'applying', 'receipt_nonce' => $nonce ), array( '%s', '%s', '%d', '%s', '%s', '%s', '%s' ), array( '%s', '%s', '%s' ) );
+		if ( 1 === $updated && in_array( $status, array( WP_Agent_Pending_Action_Status::ACCEPTED, WP_Agent_Pending_Action_Status::REJECTED ), true ) ) {
+			$action = self::get_action( $action_id, true );
+			if ( null !== $action ) {
+				self::dispatch_resolution( $action, $status, $resolver ?? self::current_resolver() );
+			}
+		}
+		return 1 === $updated;
 	}
 
 	/**
@@ -779,6 +854,7 @@ class PendingActionStore {
 			'resolution_result'   => self::decode_json( $row['resolution_result'] ?? null ),
 			'resolution_error'    => isset( $row['resolution_error'] ) ? (string) $row['resolution_error'] : null,
 			'resolution_metadata' => self::decode_json( $row['resolution_metadata'] ?? null ),
+			'receipt_nonce'       => isset( $row['receipt_nonce'] ) ? (string) $row['receipt_nonce'] : '',
 		);
 	}
 

--- a/inc/Engine/AI/Actions/PendingActionStore.php
+++ b/inc/Engine/AI/Actions/PendingActionStore.php
@@ -453,7 +453,15 @@ class PendingActionStore {
 			if ( ! is_array( $payload ) || 'applying' !== ( $payload['status'] ?? null ) || ! hash_equals( (string) ( $payload['receipt_nonce'] ?? '' ), $nonce ) ) {
 				return false;
 			}
-			$payload['status'] = $status;
+			$resolved_at                    = time();
+			$payload['status']              = $status;
+			$payload['resolved_at']         = $resolved_at;
+			$payload['resolved_at_iso']     = gmdate( 'c', $resolved_at );
+			$payload['resolved_by']         = get_current_user_id();
+			$payload['resolver']            = self::nullable_string( $resolver ?? self::current_resolver() );
+			$payload['resolution_result']   = $result;
+			$payload['resolution_error']    = $error;
+			$payload['resolution_metadata'] = $metadata;
 			$completed = set_transient( self::TRANSIENT_PREFIX . $action_id, $payload, self::resolve_ttl( $payload ) );
 			if ( $completed && in_array( $status, array( WP_Agent_Pending_Action_Status::ACCEPTED, WP_Agent_Pending_Action_Status::REJECTED ), true ) ) {
 				$action = self::action_from_payload( $payload );

--- a/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
+++ b/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
@@ -341,7 +341,11 @@ class ResolvePendingActionAbility {
 		if ( ! is_array( $handler ) || empty( $handler['apply'] ) || ! self::isApplyHandler( $handler['apply'] ) ) {
 			// No handler registered — can't apply, but reject is still safe.
 			if ( $decision->is_rejected() ) {
-				PendingActionStore::record_resolution( $action_id, WP_Agent_Pending_Action_Status::REJECTED, null, null, $resolver, array( 'reason' => 'no_handler_rejected' ) );
+				$claimed = PendingActionStore::claim_for_resolution( $action_id, $resolver );
+				if ( null === $claimed ) {
+					return self::claimed_elsewhere_response( $action_id, $kind );
+				}
+				PendingActionStore::complete_claim( $action_id, (string) $claimed['receipt_nonce'], WP_Agent_Pending_Action_Status::REJECTED, null, null, $resolver, array( 'reason' => 'no_handler_rejected' ) );
 				return array(
 					'success'   => true,
 					'decision'  => 'rejected',
@@ -398,7 +402,11 @@ class ResolvePendingActionAbility {
 		}
 
 		if ( $decision->is_rejected() ) {
-			PendingActionStore::record_resolution( $action_id, WP_Agent_Pending_Action_Status::REJECTED, null, null, $resolver );
+			$claimed = PendingActionStore::claim_for_resolution( $action_id, $resolver );
+			if ( null === $claimed ) {
+				return self::claimed_elsewhere_response( $action_id, $kind );
+			}
+			PendingActionStore::complete_claim( $action_id, (string) $claimed['receipt_nonce'], WP_Agent_Pending_Action_Status::REJECTED, null, null, $resolver );
 			return array(
 				'success'   => true,
 				'decision'  => 'rejected',
@@ -407,11 +415,18 @@ class ResolvePendingActionAbility {
 			);
 		}
 
+		$claimed = PendingActionStore::claim_for_resolution( $action_id, $resolver );
+		if ( null === $claimed ) {
+			return self::claimed_elsewhere_response( $action_id, $kind );
+		}
+		$receipt          = PendingActionAuthorizationReceipt::issue( $claimed, $resolver );
+		$resolver_context = array_merge( $resolver_context, array( 'authorization_receipt' => $receipt, 'pending_action' => $claimed ) );
+
 		// Accepted: invoke the apply handler with the stored input.
-		$result = self::applyHandler( $handler, $decision, $apply_input, $payload, $resolver_payload, $resolver_context, $pending_action );
+		$result = self::applyHandler( $handler, $decision, $apply_input, $payload, $resolver_payload, $resolver_context, $pending_action, $receipt );
 
 		if ( is_wp_error( $result ) ) {
-			PendingActionStore::record_resolution( $action_id, WP_Agent_Pending_Action_Status::ACCEPTED, null, $result->get_error_message(), $resolver );
+			PendingActionStore::complete_claim( $action_id, (string) $claimed['receipt_nonce'], 'failed', null, $result->get_error_message(), $resolver );
 			return array(
 				'success'   => false,
 				'decision'  => 'accepted',
@@ -422,7 +437,7 @@ class ResolvePendingActionAbility {
 		}
 
 		if ( is_array( $result ) && array_key_exists( 'success', $result ) && false === $result['success'] ) {
-			PendingActionStore::record_resolution( $action_id, WP_Agent_Pending_Action_Status::ACCEPTED, $result, $result['error'] ?? 'Apply handler reported failure.', $resolver );
+			PendingActionStore::complete_claim( $action_id, (string) $claimed['receipt_nonce'], 'failed', $result, $result['error'] ?? 'Apply handler reported failure.', $resolver );
 			return array(
 				'success'   => false,
 				'decision'  => 'accepted',
@@ -433,7 +448,7 @@ class ResolvePendingActionAbility {
 			);
 		}
 
-		PendingActionStore::record_resolution( $action_id, WP_Agent_Pending_Action_Status::ACCEPTED, $result, null, $resolver );
+		PendingActionStore::complete_claim( $action_id, (string) $claimed['receipt_nonce'], WP_Agent_Pending_Action_Status::ACCEPTED, $result, null, $resolver );
 
 		return array(
 			'success'   => true,
@@ -544,7 +559,7 @@ class ResolvePendingActionAbility {
 	 * @param array            $resolver_context Optional resolver context.
 	 * @return mixed
 	 */
-	private static function applyHandler( array $handler, WP_Agent_Approval_Decision $decision, array $apply_input, array $payload, array $resolver_payload = array(), array $resolver_context = array(), ?WP_Agent_Pending_Action $pending_action = null ) {
+	private static function applyHandler( array $handler, WP_Agent_Approval_Decision $decision, array $apply_input, array $payload, array $resolver_payload = array(), array $resolver_context = array(), ?WP_Agent_Pending_Action $pending_action = null, array $receipt = array() ) {
 		$apply = $handler['apply'];
 		if ( $apply instanceof WP_Agent_Pending_Action_Handler ) {
 			if ( null === $pending_action ) {
@@ -554,7 +569,12 @@ class ResolvePendingActionAbility {
 			return $apply->handle_pending_action( $pending_action, $decision, $resolver_payload, $resolver_context );
 		}
 
-		return call_user_func( $apply, $apply_input, $payload );
+		// The third argument is additive: legacy two-argument handlers remain valid.
+		return call_user_func( $apply, $apply_input, $payload, $receipt );
+	}
+
+	private static function claimed_elsewhere_response( string $action_id, string $kind ): array {
+		return array( 'success' => false, 'error' => 'Pending action has already been claimed or resolved.', 'action_id' => $action_id, 'kind' => $kind );
 	}
 
 	/**

--- a/tests/pending-action-resolver-contract-smoke.php
+++ b/tests/pending-action-resolver-contract-smoke.php
@@ -167,6 +167,7 @@ require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionObservers
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/WordPressActionDispatchObserver.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionStore.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionHelper.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionAuthorizationReceipt.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionScope.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionResolverAdapter.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/ResolvePendingActionAbility.php';

--- a/tests/pending-actions-agents-api-contract-smoke.php
+++ b/tests/pending-actions-agents-api-contract-smoke.php
@@ -114,8 +114,8 @@ datamachine_pending_actions_assert( str_contains( $store_source, 'datamachine_pe
 datamachine_pending_actions_assert( str_contains( $store_source, 'public static function get( string $action_id, bool $include_resolved = false )' ), 'legacy get defaults to live-pending rows only', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $store_source, 'public static function inspect( string $action_id ): ?array' ), 'inspect surface can fetch resolved audit rows', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $store_source, 'WP_Agent_Pending_Action_Status::normalize' ), 'lifecycle vocabulary is delegated to Agents API WP_Agent_Pending_Action_Status', $failures, $passes );
-datamachine_pending_actions_assert( str_contains( $resolver_source, 'record_resolution( $action_id, WP_Agent_Pending_Action_Status::ACCEPTED' ), 'accepted resolutions are retained instead of transient-deleted', $failures, $passes );
-datamachine_pending_actions_assert( str_contains( $resolver_source, 'record_resolution( $action_id, WP_Agent_Pending_Action_Status::REJECTED' ), 'rejected resolutions are retained instead of transient-deleted', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $resolver_source, 'complete_claim( $action_id, (string) $claimed[\'receipt_nonce\'], WP_Agent_Pending_Action_Status::ACCEPTED' ), 'accepted claims are retained as audited terminal rows', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $resolver_source, 'complete_claim( $action_id, (string) $claimed[\'receipt_nonce\'], WP_Agent_Pending_Action_Status::REJECTED' ), 'rejected claims are retained as audited terminal rows', $failures, $passes );
 
 echo "\n[3] List/get/summary surfaces are registered for agents and operators:\n";
 foreach ( array( 'datamachine/list-pending-actions', 'datamachine/get-pending-action', 'datamachine/summarize-pending-actions' ) as $ability ) {

--- a/tests/signed-pending-action-resolution-smoke.php
+++ b/tests/signed-pending-action-resolution-smoke.php
@@ -172,9 +172,13 @@ require_once dirname( __DIR__ ) . '/inc/Abilities/PermissionHelper.php';
 require_once dirname( __DIR__ ) . '/inc/Core/Workspace/WordPressWorkspaceScope.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionObservers.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionStore.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionAuthorizationReceipt.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionScope.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionResolverAdapter.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/ResolvePendingActionAbility.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/SignPendingActionResolutionAbility.php';
+
+add_filter( 'wp_agent_pending_action_resolver', static fn() => \DataMachine\Engine\AI\Actions\ResolvePendingActionAbility::adapter() );
 
 $failures = array();
 $passes   = 0;
@@ -182,6 +186,8 @@ $passes   = 0;
 echo "signed-pending-action-resolution-smoke\n";
 
 $action_id = 'act_signed_smoke';
+$GLOBALS['__signed_applies'] = 0;
+$GLOBALS['__signed_receipt'] = array();
 \DataMachine\Engine\AI\Actions\PendingActionStore::store(
 	$action_id,
 	array(
@@ -192,6 +198,7 @@ $action_id = 'act_signed_smoke';
 		'created_by'   => 0,
 		'agent_id'     => 0,
 		'context'      => array(),
+		'metadata'     => array( 'datamachine' => array( 'authorization' => array( 'operation' => 'signed_smoke', 'target' => array( 'action' => 'signed' ) ) ) ),
 	)
 );
 
@@ -199,10 +206,30 @@ add_filter(
 	'datamachine_pending_action_handlers',
 	static function ( array $handlers ): array {
 		$handlers['signed_smoke'] = array(
-			'apply' => static function ( array $apply_input ): array {
+			'apply' => static function ( array $apply_input, array $payload, array $receipt ): array {
+				++$GLOBALS['__signed_applies'];
+				$GLOBALS['__signed_receipt'] = $receipt;
+				$subject = (string) ( $payload['agent'] ?? $payload['creator'] ?? '' );
+				$workspace = $payload['workspace'] ?? array();
+				$valid = \DataMachine\Engine\AI\Actions\PendingActionAuthorizationReceipt::validate( $receipt, 'signed_smoke', 'signed_smoke', array( 'action' => 'signed' ), $apply_input, $subject, $workspace );
+				if ( is_wp_error( $valid ) ) {
+					return array( 'success' => false, 'error' => $valid->get_error_message() );
+				}
+				$wrong_kind = \DataMachine\Engine\AI\Actions\PendingActionAuthorizationReceipt::validate( $receipt, 'other_kind', 'signed_smoke', array( 'action' => 'signed' ), $apply_input, $subject, $workspace );
+				$wrong_target = \DataMachine\Engine\AI\Actions\PendingActionAuthorizationReceipt::validate( $receipt, 'signed_smoke', 'signed_smoke', array( 'action' => 'other' ), $apply_input, $subject, $workspace );
+				$wrong_operation = \DataMachine\Engine\AI\Actions\PendingActionAuthorizationReceipt::validate( $receipt, 'signed_smoke', 'other_operation', array( 'action' => 'signed' ), $apply_input, $subject, $workspace );
+				$wrong_input = \DataMachine\Engine\AI\Actions\PendingActionAuthorizationReceipt::validate( $receipt, 'signed_smoke', 'signed_smoke', array( 'action' => 'signed' ), array( 'value' => 0 ), $subject, $workspace );
+				$wrong_subject = \DataMachine\Engine\AI\Actions\PendingActionAuthorizationReceipt::validate( $receipt, 'signed_smoke', 'signed_smoke', array( 'action' => 'signed' ), $apply_input, 'other-subject', $workspace );
+				$wrong_workspace = \DataMachine\Engine\AI\Actions\PendingActionAuthorizationReceipt::validate( $receipt, 'signed_smoke', 'signed_smoke', array( 'action' => 'signed' ), $apply_input, $subject, array( 'workspace_id' => 'other' ) );
 				return array(
 					'success' => true,
 					'value'   => $apply_input['value'] ?? null,
+					'wrong_kind_rejected' => is_wp_error( $wrong_kind ),
+					'mismatch_rejected' => is_wp_error( $wrong_target ),
+					'wrong_operation_rejected' => is_wp_error( $wrong_operation ),
+					'wrong_input_rejected' => is_wp_error( $wrong_input ),
+					'wrong_subject_rejected' => is_wp_error( $wrong_subject ),
+					'wrong_workspace_rejected' => is_wp_error( $wrong_workspace ),
 				);
 			},
 		);
@@ -231,7 +258,39 @@ $resolved = \DataMachine\Engine\AI\Actions\SignPendingActionResolutionAbility::r
 datamachine_signed_assert( true === ( $resolved['success'] ?? false ), 'valid approve token resolves action', $failures, $passes );
 datamachine_signed_assert( 'accepted' === ( $resolved['decision'] ?? null ), 'approve token records accepted decision', $failures, $passes );
 datamachine_signed_assert( 'signed_smoke' === ( $resolved['kind'] ?? null ), 'resolution keeps pending action kind', $failures, $passes );
-datamachine_signed_assert( null === \DataMachine\Engine\AI\Actions\PendingActionStore::get( $action_id ), 'resolved transient action is no longer pending', $failures, $passes );
+datamachine_signed_assert( true === ( $resolved['result']['wrong_kind_rejected'] ?? false ), 'receipt rejects a mismatched kind', $failures, $passes );
+datamachine_signed_assert( true === ( $resolved['result']['mismatch_rejected'] ?? false ), 'receipt rejects a mismatched target', $failures, $passes );
+datamachine_signed_assert( true === ( $resolved['result']['wrong_operation_rejected'] ?? false ), 'receipt rejects a mismatched operation', $failures, $passes );
+datamachine_signed_assert( true === ( $resolved['result']['wrong_input_rejected'] ?? false ), 'receipt rejects mismatched input', $failures, $passes );
+datamachine_signed_assert( true === ( $resolved['result']['wrong_subject_rejected'] ?? false ), 'receipt rejects a mismatched subject', $failures, $passes );
+datamachine_signed_assert( true === ( $resolved['result']['wrong_workspace_rejected'] ?? false ), 'receipt rejects a mismatched workspace', $failures, $passes );
+datamachine_signed_assert( 1 === $GLOBALS['__signed_applies'], 'accepted action applies exactly once', $failures, $passes );
+
+$second = \DataMachine\Engine\AI\Actions\ResolvePendingActionAbility::execute( array( 'action_id' => $action_id, 'decision' => 'accepted', 'resolver' => 'email_approval' ) );
+datamachine_signed_assert( false === ( $second['success'] ?? true ), 'a second acceptance cannot claim the action', $failures, $passes );
+datamachine_signed_assert( null === \DataMachine\Engine\AI\Actions\PendingActionStore::get( $action_id ) && 'accepted' === ( \DataMachine\Engine\AI\Actions\PendingActionStore::inspect( $action_id )['status'] ?? null ), 'resolved action is retained as an accepted audit row', $failures, $passes );
+datamachine_signed_assert( is_wp_error( \DataMachine\Engine\AI\Actions\PendingActionAuthorizationReceipt::validate( $GLOBALS['__signed_receipt'], 'signed_smoke', 'signed_smoke', array( 'action' => 'signed' ), array( 'value' => 42 ), '', $GLOBALS['__signed_receipt']['claims']['workspace'] ) ), 'consumed receipt cannot be reused', $failures, $passes );
+
+$rejected_action_id = 'act_rejected_smoke';
+\DataMachine\Engine\AI\Actions\PendingActionStore::store(
+	$rejected_action_id,
+	array(
+		'kind'        => 'signed_smoke',
+		'summary'     => 'Rejected receipt smoke action',
+		'apply_input' => array( 'value' => 42 ),
+		'metadata'    => array( 'datamachine' => array( 'authorization' => array( 'operation' => 'signed_smoke', 'target' => array( 'action' => 'signed' ) ) ) ),
+	)
+);
+$rejected_claim = \DataMachine\Engine\AI\Actions\PendingActionStore::claim_for_resolution( $rejected_action_id, 'email_approval' );
+$rejected_receipt = \DataMachine\Engine\AI\Actions\PendingActionAuthorizationReceipt::issue( $rejected_claim, 'email_approval' );
+\DataMachine\Engine\AI\Actions\PendingActionStore::complete_claim( $rejected_action_id, (string) $rejected_claim['receipt_nonce'], 'rejected', null, null, 'email_approval' );
+datamachine_signed_assert( is_wp_error( \DataMachine\Engine\AI\Actions\PendingActionAuthorizationReceipt::validate( $rejected_receipt, 'signed_smoke', 'signed_smoke', array( 'action' => 'signed' ), array( 'value' => 42 ), '', $rejected_receipt['claims']['workspace'] ) ), 'rejected receipt cannot be used', $failures, $passes );
+
+$expired_claims = $GLOBALS['__signed_receipt']['claims'];
+$expired_claims['expires_at'] = time() - 1;
+$expired_encoded = rtrim( strtr( base64_encode( wp_json_encode( $expired_claims ) ), '+/', '-_' ), '=' );
+$expired_receipt = array( 'token' => $expired_encoded . '.' . rtrim( strtr( base64_encode( hash_hmac( 'sha256', $expired_encoded, $GLOBALS['__signed_options']['datamachine_pending_action_receipt_secret'], true ) ), '+/', '-_' ), '=' ) );
+datamachine_signed_assert( is_wp_error( \DataMachine\Engine\AI\Actions\PendingActionAuthorizationReceipt::validate( $expired_receipt, 'signed_smoke', 'signed_smoke', array( 'action' => 'signed' ), array( 'value' => 42 ), '', $expired_claims['workspace'] ) ), 'expired receipt is rejected before use', $failures, $passes );
 
 \DataMachine\Engine\AI\Actions\SignPendingActionResolutionAbility::rotate_secret();
 $after_rotation = \DataMachine\Engine\AI\Actions\SignPendingActionResolutionAbility::resolve_token( (string) ( $query['t'] ?? '' ) );


### PR DESCRIPTION
## Summary

- atomically claim pending actions before handler execution
- issue signed, expiring receipts bound to kind, operation, target, input, subject, workspace, resolver, and nonce
- reject wrong-kind, expired, consumed, rejected, or mismatched receipts
- retain durable and transient resolution audit fields after receipt consumption

## Compatibility

Legacy handlers remain callable and receive the receipt as an additive third argument. Existing resolver response shapes remain unchanged.

## How to test

1. Run `php tests/signed-pending-action-resolution-smoke.php`.
2. Run `php tests/pending-action-resolver-contract-smoke.php`.
3. Run `php tests/pending-actions-agents-api-contract-smoke.php`.
4. Run `php tests/pending-action-store-durable-required-smoke.php`.

Closes #2934