### PR TITLE
feat: expose bounded raw test handler output

### DIFF
--- a/inc/Abilities/Handler/TestHandlerAbility.php
+++ b/inc/Abilities/Handler/TestHandlerAbility.php
@@ -755,7 +755,7 @@ class TestHandlerAbility {
 			return false;
 		}
 
-		$sensitive_segments = array( 'authorization', 'bearer', 'cookie', 'credential', 'credentials', 'nonce', 'password', 'secret', 'signature', 'token' );
+		$sensitive_segments = array( 'authorization', 'bearer', 'cookie', 'cookies', 'credential', 'credentials', 'nonce', 'password', 'secret', 'signature', 'token' );
 		if ( array_intersect( $segments, $sensitive_segments ) ) {
 			return true;
 		}

--- a/inc/Abilities/Handler/TestHandlerAbility.php
+++ b/inc/Abilities/Handler/TestHandlerAbility.php
@@ -26,6 +26,7 @@ class TestHandlerAbility {
 	private const MAX_RAW_PACKET_LIMIT   = 100;
 	private const MAX_REPORT_PATHS       = 8;
 	private const MAX_SANITIZE_DEPTH     = 32;
+	private const TRANSPORT_ENTRY_BUDGET = 132;
 
 	private static bool $registered = false;
 
@@ -83,7 +84,22 @@ class TestHandlerAbility {
 							),
 						),
 					),
-					'output_schema'       => array(
+					'output_schema'       => self::getOutputSchema(),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
+	}
+
+	/**
+	 * Return the registered output schema for runtime and validation tests.
+	 */
+	public static function getOutputSchema(): array {
+		return array(
 						'type'                 => 'object',
 						'additionalProperties' => false,
 						'properties'           => array(
@@ -156,27 +172,22 @@ class TestHandlerAbility {
 						),
 						'oneOf'      => array(
 							array(
+								'type'       => 'object',
 								'required'   => array( 'success', 'error' ),
-								'properties' => array( 'success' => array( 'enum' => array( false ) ) ),
+								'properties' => array( 'success' => array( 'type' => 'boolean', 'enum' => array( false ) ) ),
 							),
 							array(
+								'type'       => 'object',
 								'required'   => array( 'success', 'output_mode', 'packets', 'packet_count', 'warnings', 'execution_time_ms' ),
-								'properties' => array( 'success' => array( 'enum' => array( true ) ), 'output_mode' => array( 'enum' => array( 'compact' ) ) ),
+								'properties' => array( 'success' => array( 'type' => 'boolean', 'enum' => array( true ) ), 'output_mode' => array( 'type' => 'string', 'enum' => array( 'compact' ) ) ),
 							),
 							array(
+								'type'       => 'object',
 								'required'   => array( 'success', 'output_mode', 'packets', 'packet_count', 'warnings', 'execution_time_ms', 'limits', 'truncation' ),
-								'properties' => array( 'success' => array( 'enum' => array( true ) ), 'output_mode' => array( 'enum' => array( 'raw' ) ) ),
+								'properties' => array( 'success' => array( 'type' => 'boolean', 'enum' => array( true ) ), 'output_mode' => array( 'type' => 'string', 'enum' => array( 'raw' ) ) ),
 							),
 						),
-					),
-					'execute_callback'    => array( $this, 'execute' ),
-					'permission_callback' => array( $this, 'checkPermission' ),
-					'meta'                => array( 'show_in_rest' => true ),
-				)
-			);
-		};
-
-		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
+					);
 	}
 
 	/**
@@ -442,7 +453,7 @@ class TestHandlerAbility {
 		$base['handler_label'] = $this->boundOutputString( (string) ( $base['handler_label'] ?? '' ), 256 );
 
 		$empty_response = $this->composeRawResponse( $base, array(), $total_count, $packet_limit, $byte_limit, $report, $materialization_limited );
-		$envelope_bytes = $this->serializedSize( $empty_response );
+		$envelope_bytes = $this->transportSize( $empty_response, true );
 		$packet_budget  = max( 0, $byte_limit - $envelope_bytes - 1024 );
 
 		foreach ( $packets as $index => $packet ) {
@@ -606,7 +617,7 @@ class TestHandlerAbility {
 				$this->recordOmission( $report, $path, 'json_encode_failure' );
 				return 'omit';
 			}
-			$bytes = strlen( $encoded );
+			$bytes = $this->transportSize( $value, false );
 			if ( $bytes > $remaining ) {
 				return 'limit';
 			}
@@ -625,10 +636,10 @@ class TestHandlerAbility {
 		$first      = true;
 
 		foreach ( $value as $key => $child ) {
-			if ( $remaining < 1 ) {
+			if ( $remaining < self::TRANSPORT_ENTRY_BUDGET ) {
 				return 'limit';
 			}
-			--$remaining;
+			$remaining -= self::TRANSPORT_ENTRY_BUDGET;
 
 			$key_bytes  = 0;
 			$child_path = $path;
@@ -740,19 +751,25 @@ class TestHandlerAbility {
 		return mb_strcut( $value, 0, max( 0, $max_bytes - 3 ), 'UTF-8' ) . '...';
 	}
 
-	private function serializedSize( array $value ): int {
-		$encoded = wp_json_encode( $value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
-		return false === $encoded ? PHP_INT_MAX : strlen( $encoded );
+	private function transportSize( $value, bool $complete_response ): int {
+		$rest = wp_json_encode( $value );
+		$cli  = wp_json_encode( $value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		if ( false === $rest || false === $cli ) {
+			return PHP_INT_MAX;
+		}
+
+		$cli_bytes = strlen( $cli ) + ( $complete_response ? 1 : 0 );
+		return max( strlen( $rest ), $cli_bytes );
 	}
 
 	private function stabilizeReturnedBytes( array &$response ): int {
 		for ( $iteration = 0; $iteration < 4; ++$iteration ) {
-			$bytes = $this->serializedSize( $response );
+			$bytes = $this->transportSize( $response, true );
 			if ( $response['truncation']['returned_bytes'] === $bytes ) {
 				return $bytes;
 			}
 			$response['truncation']['returned_bytes'] = $bytes;
 		}
-		return $this->serializedSize( $response );
+		return $this->transportSize( $response, true );
 	}
 }

--- a/inc/Abilities/Handler/TestHandlerAbility.php
+++ b/inc/Abilities/Handler/TestHandlerAbility.php
@@ -100,94 +100,143 @@ class TestHandlerAbility {
 	 */
 	public static function getOutputSchema(): array {
 		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => array(
+				'success'           => array( 'type' => 'boolean' ),
+				'handler_slug'      => array( 'type' => 'string' ),
+				'handler_label'     => array( 'type' => 'string' ),
+				'config_used'       => array(
+					'type'                 => 'object',
+					'additionalProperties' => true,
+				),
+				'packets'           => array(
+					'type'        => 'array',
+					'description' => __( 'Compact packet summaries, or raw packet envelopes containing type, timestamp, data, and metadata.', 'data-machine' ),
+					'items'       => array(
 						'type'                 => 'object',
-						'additionalProperties' => false,
+						'additionalProperties' => true,
 						'properties'           => array(
-							'success'           => array( 'type' => 'boolean' ),
-							'handler_slug'      => array( 'type' => 'string' ),
-							'handler_label'     => array( 'type' => 'string' ),
-							'config_used'       => array( 'type' => 'object', 'additionalProperties' => true ),
-							'packets'           => array(
-								'type'        => 'array',
-								'description' => __( 'Compact packet summaries, or raw packet envelopes containing type, timestamp, data, and metadata.', 'data-machine' ),
-								'items'       => array(
-									'type'                 => 'object',
-									'additionalProperties' => true,
-									'properties'           => array(
-										'title'           => array( 'type' => 'string' ),
-										'content_preview' => array( 'type' => 'string' ),
-										'source_url'      => array( 'type' => 'string' ),
-										'type'            => array( 'type' => 'string' ),
-										'timestamp'       => array( 'type' => 'integer' ),
-										'data'            => array( 'type' => 'object' ),
-										'metadata'        => array( 'type' => 'object' ),
-									),
-								),
-							),
-							'packet_count'      => array( 'type' => 'integer' ),
-							'warnings'          => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
-							'execution_time_ms' => array( 'type' => 'number' ),
-							'error'             => array( 'type' => 'string' ),
-							'output_mode'       => array(
+							'title'           => array( 'type' => 'string' ),
+							'content_preview' => array( 'type' => 'string' ),
+							'source_url'      => array( 'type' => 'string' ),
+							'type'            => array( 'type' => 'string' ),
+							'timestamp'       => array( 'type' => 'integer' ),
+							'data'            => array( 'type' => 'object' ),
+							'metadata'        => array( 'type' => 'object' ),
+						),
+					),
+				),
+				'packet_count'      => array( 'type' => 'integer' ),
+				'warnings'          => array(
+					'type'  => 'array',
+					'items' => array( 'type' => 'string' ),
+				),
+				'execution_time_ms' => array( 'type' => 'number' ),
+				'error'             => array( 'type' => 'string' ),
+				'output_mode'       => array(
+					'type' => 'string',
+					'enum' => array( 'compact', 'raw' ),
+				),
+				'limits'            => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'required'             => array( 'packet_count', 'bytes' ),
+					'properties'           => array(
+						'packet_count' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'maximum' => self::MAX_RAW_PACKET_LIMIT,
+						),
+						'bytes'        => array(
+							'type'    => 'integer',
+							'minimum' => self::MIN_RAW_BYTE_LIMIT,
+							'maximum' => self::MAX_RAW_BYTE_LIMIT,
+						),
+					),
+				),
+				'truncation'        => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'required'             => array( 'truncated', 'reasons', 'materialized_packet_count', 'returned_packet_count', 'omitted_packet_count', 'returned_bytes', 'materialization_limited', 'redacted_fields', 'binary_fields', 'omitted_fields', 'omitted_field_count' ),
+					'properties'           => array(
+						'truncated'                 => array( 'type' => 'boolean' ),
+						'reasons'                   => array(
+							'type'  => 'array',
+							'items' => array(
 								'type' => 'string',
-								'enum' => array( 'compact', 'raw' ),
+								'enum' => array( 'packet_limit', 'byte_limit', 'response_limit', 'config_limit', 'binary_content', 'invalid_utf8', 'unsupported_type', 'json_encode_failure' ),
 							),
-							'limits'            => array(
-								'type'                 => 'object',
-								'additionalProperties' => false,
-								'required'             => array( 'packet_count', 'bytes' ),
-								'properties'           => array(
-									'packet_count' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => self::MAX_RAW_PACKET_LIMIT ),
-									'bytes'        => array( 'type' => 'integer', 'minimum' => self::MIN_RAW_BYTE_LIMIT, 'maximum' => self::MAX_RAW_BYTE_LIMIT ),
-								),
-							),
-							'truncation'        => array(
-								'type'                 => 'object',
-								'additionalProperties' => false,
-								'required'             => array( 'truncated', 'reasons', 'materialized_packet_count', 'returned_packet_count', 'omitted_packet_count', 'returned_bytes', 'materialization_limited', 'redacted_fields', 'binary_fields', 'omitted_fields', 'omitted_field_count' ),
-								'properties'           => array(
-									'truncated'             => array( 'type' => 'boolean' ),
-									'reasons'               => array( 'type' => 'array', 'items' => array( 'type' => 'string', 'enum' => array( 'packet_limit', 'byte_limit', 'response_limit', 'config_limit', 'binary_content', 'invalid_utf8', 'unsupported_type', 'json_encode_failure' ) ) ),
-									'materialized_packet_count' => array( 'type' => 'integer' ),
-									'returned_packet_count' => array( 'type' => 'integer' ),
-									'omitted_packet_count'  => array( 'type' => 'integer' ),
-									'returned_bytes'        => array( 'type' => 'integer' ),
-									'materialization_limited' => array( 'type' => 'boolean' ),
-									'redacted_fields'       => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
-									'binary_fields'         => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
-									'omitted_fields'        => array(
-										'type'  => 'array',
-										'items' => array(
-											'type'       => 'object',
-											'required'   => array( 'path', 'reason' ),
-											'properties' => array(
-												'path'   => array( 'type' => 'string' ),
-												'reason' => array( 'type' => 'string' ),
-											),
-										),
-									),
-									'omitted_field_count'   => array( 'type' => 'integer' ),
+						),
+						'materialized_packet_count' => array( 'type' => 'integer' ),
+						'returned_packet_count'     => array( 'type' => 'integer' ),
+						'omitted_packet_count'      => array( 'type' => 'integer' ),
+						'returned_bytes'            => array( 'type' => 'integer' ),
+						'materialization_limited'   => array( 'type' => 'boolean' ),
+						'redacted_fields'           => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+						'binary_fields'             => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+						'omitted_fields'            => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'required'   => array( 'path', 'reason' ),
+								'properties' => array(
+									'path'   => array( 'type' => 'string' ),
+									'reason' => array( 'type' => 'string' ),
 								),
 							),
 						),
-						'oneOf'      => array(
-							array(
-								'type'       => 'object',
-								'required'   => array( 'success', 'error' ),
-								'properties' => array( 'success' => array( 'type' => 'boolean', 'enum' => array( false ) ) ),
-							),
-							array(
-								'type'       => 'object',
-								'required'   => array( 'success', 'output_mode', 'packets', 'packet_count', 'warnings', 'execution_time_ms' ),
-								'properties' => array( 'success' => array( 'type' => 'boolean', 'enum' => array( true ) ), 'output_mode' => array( 'type' => 'string', 'enum' => array( 'compact' ) ) ),
-							),
-							array(
-								'type'       => 'object',
-								'required'   => array( 'success', 'output_mode', 'packets', 'packet_count', 'warnings', 'execution_time_ms', 'limits', 'truncation' ),
-								'properties' => array( 'success' => array( 'type' => 'boolean', 'enum' => array( true ) ), 'output_mode' => array( 'type' => 'string', 'enum' => array( 'raw' ) ) ),
-							),
+						'omitted_field_count'       => array( 'type' => 'integer' ),
+					),
+				),
+			),
+			'oneOf'                => array(
+				array(
+					'type'       => 'object',
+					'required'   => array( 'success', 'error' ),
+					'properties' => array(
+						'success' => array(
+							'type' => 'boolean',
+							'enum' => array( false ),
 						),
-					);
+					),
+				),
+				array(
+					'type'       => 'object',
+					'required'   => array( 'success', 'output_mode', 'packets', 'packet_count', 'warnings', 'execution_time_ms' ),
+					'properties' => array(
+						'success'     => array(
+							'type' => 'boolean',
+							'enum' => array( true ),
+						),
+						'output_mode' => array(
+							'type' => 'string',
+							'enum' => array( 'compact' ),
+						),
+					),
+				),
+				array(
+					'type'       => 'object',
+					'required'   => array( 'success', 'output_mode', 'packets', 'packet_count', 'warnings', 'execution_time_ms', 'limits', 'truncation' ),
+					'properties' => array(
+						'success'     => array(
+							'type' => 'boolean',
+							'enum' => array( true ),
+						),
+						'output_mode' => array(
+							'type' => 'string',
+							'enum' => array( 'raw' ),
+						),
+					),
+				),
+			),
+		);
 	}
 
 	/**
@@ -530,7 +579,10 @@ class TestHandlerAbility {
 				'warnings'          => array( 'Raw response metadata exceeded byte_limit; all optional output was omitted.' ),
 				'execution_time_ms' => $base['execution_time_ms'] ?? 0,
 				'output_mode'       => 'raw',
-				'limits'            => array( 'packet_count' => $packet_limit, 'bytes' => $byte_limit ),
+				'limits'            => array(
+					'packet_count' => $packet_limit,
+					'bytes'        => $byte_limit,
+				),
 				'truncation'        => array(
 					'truncated'                 => true,
 					'reasons'                   => array( 'response_limit' ),
@@ -554,7 +606,7 @@ class TestHandlerAbility {
 	 * Compose the complete response from bounded, JSON-safe values.
 	 */
 	private function composeRawResponse( array $base, array $packets, int $total_count, int $packet_limit, int $byte_limit, array $report, bool $materialization_limited ): array {
-		$reasons = array_values( array_unique( $report['reasons'] ) );
+		$reasons  = array_values( array_unique( $report['reasons'] ) );
 		$response = $base;
 
 		$response['packets']      = $packets;
@@ -630,7 +682,7 @@ class TestHandlerAbility {
 			return 'limit';
 		}
 
-		$is_list   = array_is_list( $value );
+		$is_list    = array_is_list( $value );
 		$remaining -= 2;
 		$output     = array();
 		$first      = true;
@@ -672,7 +724,7 @@ class TestHandlerAbility {
 				$this->recordPath( $report['redacted_fields'], $child_path );
 			}
 
-			$remaining -= $prefix_bytes;
+			$remaining   -= $prefix_bytes;
 			$child_output = null;
 			$status       = $this->sanitizeBoundedValue( $child, $child_path, $remaining, $report, $child_output, $depth + 1 );
 			if ( 'limit' === $status ) {
@@ -695,12 +747,21 @@ class TestHandlerAbility {
 	}
 
 	private function isSensitiveKey( string $key ): bool {
-		$key = strtolower( str_replace( '-', '_', $key ) );
-		return in_array(
-			$key,
-			array( 'api_key', 'apikey', 'authorization', 'auth_token', 'access_token', 'refresh_token', 'bearer', 'cookie', 'credential', 'credentials', 'nonce', 'password', 'secret', 'client_secret', 'signature', 'token' ),
-			true
-		);
+		$normalized = preg_replace( '/([a-z0-9])([A-Z])/', '$1_$2', $key );
+		$normalized = strtolower( is_string( $normalized ) ? $normalized : $key );
+		$segments   = preg_split( '/[^a-z0-9]+/', $normalized, -1, PREG_SPLIT_NO_EMPTY );
+
+		if ( false === $segments ) {
+			return false;
+		}
+
+		$sensitive_segments = array( 'authorization', 'bearer', 'cookie', 'credential', 'credentials', 'nonce', 'password', 'secret', 'signature', 'token' );
+		if ( array_intersect( $segments, $sensitive_segments ) ) {
+			return true;
+		}
+
+		$joined = implode( '_', $segments );
+		return in_array( $joined, array( 'api_key', 'apikey', 'private_key' ), true );
 	}
 
 	private function newSanitizationReport(): array {

--- a/inc/Abilities/Handler/TestHandlerAbility.php
+++ b/inc/Abilities/Handler/TestHandlerAbility.php
@@ -22,7 +22,10 @@ defined( 'ABSPATH' ) || exit;
 class TestHandlerAbility {
 	private const DEFAULT_RAW_BYTE_LIMIT = 1048576;
 	private const MAX_RAW_BYTE_LIMIT     = 5242880;
+	private const MIN_RAW_BYTE_LIMIT     = 4096;
 	private const MAX_RAW_PACKET_LIMIT   = 100;
+	private const MAX_REPORT_PATHS       = 8;
+	private const MAX_SANITIZE_DEPTH     = 32;
 
 	private static bool $registered = false;
 
@@ -44,9 +47,8 @@ class TestHandlerAbility {
 					'description'         => __( 'Dry-run any fetch handler with a config and return compact summaries or bounded raw packets.', 'data-machine' ),
 					'category'            => 'datamachine-pipeline',
 					'input_schema'        => array(
-						'type'                 => 'object',
-						'additionalProperties' => false,
-						'properties'           => array(
+						'type'       => 'object',
+						'properties' => array(
 							'handler_slug' => array(
 								'type'        => 'string',
 								'description' => __( 'Handler slug to test (required unless flow_id provided)', 'data-machine' ),
@@ -74,9 +76,9 @@ class TestHandlerAbility {
 							),
 							'byte_limit'   => array(
 								'type'        => 'integer',
-								'description' => __( 'Maximum serialized packet bytes returned in raw mode (default 1048576, maximum 5242880). Whole packets are omitted rather than partially truncated.', 'data-machine' ),
+								'description' => __( 'Maximum serialized bytes for the complete raw response (default 1048576, range 4096-5242880). Whole packets are omitted rather than partially truncated.', 'data-machine' ),
 								'default'     => self::DEFAULT_RAW_BYTE_LIMIT,
-								'minimum'     => 1,
+								'minimum'     => self::MIN_RAW_BYTE_LIMIT,
 								'maximum'     => self::MAX_RAW_BYTE_LIMIT,
 							),
 						),
@@ -112,7 +114,7 @@ class TestHandlerAbility {
 							'error'             => array( 'type' => 'string' ),
 							'output_mode'       => array(
 								'type' => 'string',
-								'enum' => array( 'raw' ),
+								'enum' => array( 'compact', 'raw' ),
 							),
 							'limits'            => array(
 								'type'                 => 'object',
@@ -120,23 +122,50 @@ class TestHandlerAbility {
 								'required'             => array( 'packet_count', 'bytes' ),
 								'properties'           => array(
 									'packet_count' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => self::MAX_RAW_PACKET_LIMIT ),
-									'bytes'        => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => self::MAX_RAW_BYTE_LIMIT ),
+									'bytes'        => array( 'type' => 'integer', 'minimum' => self::MIN_RAW_BYTE_LIMIT, 'maximum' => self::MAX_RAW_BYTE_LIMIT ),
 								),
 							),
 							'truncation'        => array(
 								'type'                 => 'object',
 								'additionalProperties' => false,
-								'required'             => array( 'truncated', 'reasons', 'original_packet_count', 'returned_packet_count', 'omitted_packet_count', 'returned_bytes', 'redacted_fields', 'binary_fields' ),
+								'required'             => array( 'truncated', 'reasons', 'materialized_packet_count', 'returned_packet_count', 'omitted_packet_count', 'returned_bytes', 'materialization_limited', 'redacted_fields', 'binary_fields', 'omitted_fields', 'omitted_field_count' ),
 								'properties'           => array(
 									'truncated'             => array( 'type' => 'boolean' ),
-									'reasons'               => array( 'type' => 'array', 'items' => array( 'type' => 'string', 'enum' => array( 'packet_limit', 'byte_limit', 'binary_content' ) ) ),
-									'original_packet_count' => array( 'type' => 'integer' ),
+									'reasons'               => array( 'type' => 'array', 'items' => array( 'type' => 'string', 'enum' => array( 'packet_limit', 'byte_limit', 'response_limit', 'config_limit', 'binary_content', 'invalid_utf8', 'unsupported_type', 'json_encode_failure' ) ) ),
+									'materialized_packet_count' => array( 'type' => 'integer' ),
 									'returned_packet_count' => array( 'type' => 'integer' ),
 									'omitted_packet_count'  => array( 'type' => 'integer' ),
 									'returned_bytes'        => array( 'type' => 'integer' ),
+									'materialization_limited' => array( 'type' => 'boolean' ),
 									'redacted_fields'       => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
 									'binary_fields'         => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+									'omitted_fields'        => array(
+										'type'  => 'array',
+										'items' => array(
+											'type'       => 'object',
+											'required'   => array( 'path', 'reason' ),
+											'properties' => array(
+												'path'   => array( 'type' => 'string' ),
+												'reason' => array( 'type' => 'string' ),
+											),
+										),
+									),
+									'omitted_field_count'   => array( 'type' => 'integer' ),
 								),
+							),
+						),
+						'oneOf'      => array(
+							array(
+								'required'   => array( 'success', 'error' ),
+								'properties' => array( 'success' => array( 'enum' => array( false ) ) ),
+							),
+							array(
+								'required'   => array( 'success', 'output_mode', 'packets', 'packet_count', 'warnings', 'execution_time_ms' ),
+								'properties' => array( 'success' => array( 'enum' => array( true ) ), 'output_mode' => array( 'enum' => array( 'compact' ) ) ),
+							),
+							array(
+								'required'   => array( 'success', 'output_mode', 'packets', 'packet_count', 'warnings', 'execution_time_ms', 'limits', 'truncation' ),
+								'properties' => array( 'success' => array( 'enum' => array( true ) ), 'output_mode' => array( 'enum' => array( 'raw' ) ) ),
 							),
 						),
 					),
@@ -173,6 +202,8 @@ class TestHandlerAbility {
 		$output_mode  = 'raw' === ( $input['output_mode'] ?? 'compact' ) ? 'raw' : 'compact';
 		$byte_limit   = (int) ( $input['byte_limit'] ?? self::DEFAULT_RAW_BYTE_LIMIT );
 		$warnings     = array();
+		$packet_limit = max( 1, min( self::MAX_RAW_PACKET_LIMIT, $limit > 0 ? $limit : 5 ) );
+		$byte_limit   = max( self::MIN_RAW_BYTE_LIMIT, min( self::MAX_RAW_BYTE_LIMIT, $byte_limit ) );
 
 		// Resolve from flow if flow_id provided.
 		if ( $flow_id ) {
@@ -226,18 +257,36 @@ class TestHandlerAbility {
 			$config['flow_id'] = 'direct';
 		}
 
-		$handler  = new $handler_class();
+		$materialization_limited = false;
+		if ( 'raw' === $output_mode ) {
+			$configured_max = (int) ( $config['max_items'] ?? 0 );
+			if ( $configured_max <= 0 || $configured_max > $packet_limit ) {
+				$config['max_items'] = $packet_limit;
+			}
+			$materialization_limited = true;
+		}
+
+		$config_report = $this->newSanitizationReport();
+		$config_budget = 'raw' === $output_mode ? min( 65536, max( 512, intdiv( $byte_limit, 4 ) ) ) : 65536;
+		$config_used   = null;
+		$config_status = $this->sanitizeBoundedValue( $config, 'config', $config_budget, $config_report, $config_used );
+		if ( 'ok' !== $config_status ) {
+			$config_used = array( '_omitted' => 'byte_limit' );
+			$this->recordOmission( $config_report, 'config', 'config_limit' );
+		}
+
 		$start_ms = microtime( true );
 
 		try {
+			$handler = new $handler_class();
 			$packets = $handler->get_fetch_data( 'direct', $config, null );
 		} catch ( \Throwable $e ) {
 			return array(
 				'success'           => false,
-				'handler_slug'      => $handler_slug,
-				'handler_label'     => $handler_label,
-				'config_used'       => $config,
-				'error'             => $e->getMessage(),
+				'handler_slug'      => $this->boundOutputString( (string) $handler_slug, 256 ),
+				'handler_label'     => $this->boundOutputString( (string) $handler_label, 256 ),
+				'config_used'       => $config_used,
+				'error'             => 'Handler execution failed.',
 				'execution_time_ms' => round( ( microtime( true ) - $start_ms ) * 1000, 1 ),
 			);
 		}
@@ -251,44 +300,16 @@ class TestHandlerAbility {
 		$total_count = count( $packets );
 
 		if ( 'raw' === $output_mode ) {
-			$packet_limit = max( 1, min( self::MAX_RAW_PACKET_LIMIT, $limit > 0 ? $limit : 5 ) );
-			$byte_limit   = max( 1, min( self::MAX_RAW_BYTE_LIMIT, $byte_limit ) );
-			$raw_output   = $this->formatRawPackets( $packets, $packet_limit, $byte_limit );
-			$config_used  = $this->sanitizeRawValue( $config, 'config', $raw_output['redacted_fields'], $raw_output['binary_fields'] );
-
-			$raw_output['truncation']['redacted_fields'] = $raw_output['redacted_fields'];
-			$raw_output['truncation']['binary_fields']   = $raw_output['binary_fields'];
-			if ( ! empty( $raw_output['binary_fields'] ) && ! in_array( 'binary_content', $raw_output['truncation']['reasons'], true ) ) {
-				$raw_output['truncation']['reasons'][] = 'binary_content';
-				$raw_output['truncation']['truncated'] = true;
-			}
-
-			if ( $raw_output['truncation']['truncated'] ) {
-				$warnings[] = sprintf(
-					'Raw packet output truncated: returned %d of %d packets (%d of %d byte limit).',
-					$raw_output['truncation']['returned_packet_count'],
-					$total_count,
-					$raw_output['truncation']['returned_bytes'],
-					$byte_limit
-				);
-			}
-
-			return array(
+			$base = array(
 				'success'           => true,
 				'handler_slug'      => $handler_slug,
 				'handler_label'     => $handler_label,
 				'config_used'       => $config_used,
-				'packets'           => $raw_output['packets'],
-				'packet_count'      => $total_count,
-				'warnings'          => $warnings,
 				'execution_time_ms' => $elapsed_ms,
 				'output_mode'       => 'raw',
-				'limits'            => array(
-					'packet_count' => $packet_limit,
-					'bytes'        => $byte_limit,
-				),
-				'truncation'        => $raw_output['truncation'],
 			);
+
+			return $this->buildRawResponse( $packets, $packet_limit, $byte_limit, $base, $config_report, $materialization_limited );
 		}
 
 		if ( $limit > 0 && $total_count > $limit ) {
@@ -306,11 +327,12 @@ class TestHandlerAbility {
 			'success'           => true,
 			'handler_slug'      => $handler_slug,
 			'handler_label'     => $handler_label,
-			'config_used'       => $config,
+			'config_used'       => $config_used,
 			'packets'           => $packet_summaries,
 			'packet_count'      => $total_count,
 			'warnings'          => $warnings,
 			'execution_time_ms' => $elapsed_ms,
+			'output_mode'       => 'compact',
 		);
 	}
 
@@ -402,117 +424,335 @@ class TestHandlerAbility {
 	}
 
 	/**
-	 * Serialize complete text packets without cutting through a packet body.
+	 * Build a raw response while keeping every intermediate representation bounded.
 	 *
-	 * @param array $packets      DataPacket instances.
-	 * @param int   $packet_limit Maximum packets to return.
-	 * @param int   $byte_limit   Maximum serialized packet bytes to return.
-	 * @return array Raw packets and explicit truncation metadata.
+	 * @param array $packets                 Materialized DataPacket instances.
+	 * @param int   $packet_limit            Maximum packets to return.
+	 * @param int   $byte_limit              Maximum complete response bytes.
+	 * @param array $base                    Already-sanitized response fields.
+	 * @param array $report                  Config sanitization report.
+	 * @param bool  $materialization_limited Whether max_items bounded handler execution.
+	 * @return array JSON-safe raw response.
 	 */
-	private function formatRawPackets( array $packets, int $packet_limit, int $byte_limit ): array {
-		$returned        = array();
-		$returned_bytes  = 0;
-		$reasons         = array();
-		$redacted_fields = array();
-		$binary_fields   = array();
-		$total_count     = count( $packets );
+	private function buildRawResponse( array $packets, int $packet_limit, int $byte_limit, array $base, array $report, bool $materialization_limited ): array {
+		$total_count = count( $packets );
+		$returned    = array();
 
-		foreach ( array_slice( $packets, 0, $packet_limit ) as $index => $packet ) {
-			$serialized = $packet->addTo( array() );
-			$entry      = $serialized[0] ?? array();
-			$entry      = $this->sanitizeRawValue( $entry, 'packets.' . $index, $redacted_fields, $binary_fields );
-			$encoded    = wp_json_encode( $entry, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
-			$bytes      = strlen( (string) $encoded );
+		$base['handler_slug']  = $this->boundOutputString( (string) ( $base['handler_slug'] ?? '' ), 256 );
+		$base['handler_label'] = $this->boundOutputString( (string) ( $base['handler_label'] ?? '' ), 256 );
 
-			if ( $returned_bytes + $bytes > $byte_limit ) {
-				$reasons[] = 'byte_limit';
+		$empty_response = $this->composeRawResponse( $base, array(), $total_count, $packet_limit, $byte_limit, $report, $materialization_limited );
+		$envelope_bytes = $this->serializedSize( $empty_response );
+		$packet_budget  = max( 0, $byte_limit - $envelope_bytes - 1024 );
+
+		foreach ( $packets as $index => $packet ) {
+			if ( $index >= $packet_limit ) {
+				$this->addReason( $report, 'packet_limit' );
 				break;
 			}
 
-			$returned[]      = $entry;
-			$returned_bytes += $bytes;
+			try {
+				$serialized = $packet->addTo( array() );
+				$entry      = $serialized[0] ?? null;
+			} catch ( \Throwable $e ) {
+				$this->recordOmission( $report, 'packets.' . $index, 'unsupported_type' );
+				continue;
+			}
+
+			$packet_output = null;
+			$status        = $this->sanitizeBoundedValue( $entry, 'packets.' . $index, $packet_budget, $report, $packet_output );
+			if ( 'limit' === $status ) {
+				$this->addReason( $report, 'byte_limit' );
+				break;
+			}
+			if ( 'ok' !== $status ) {
+				$this->recordOmission( $report, 'packets.' . $index, 'unsupported_type' );
+				continue;
+			}
+
+			$returned[] = $packet_output;
 		}
 
-		if ( $total_count > $packet_limit ) {
-			$reasons[] = 'packet_limit';
-		}
-		if ( ! empty( $binary_fields ) ) {
-			$reasons[] = 'binary_content';
+		if ( $materialization_limited && $total_count >= $packet_limit ) {
+			$this->addReason( $report, 'packet_limit' );
 		}
 
-		$reasons        = array_values( array_unique( $reasons ) );
-		$returned_count = count( $returned );
+		$config_collapsed = false;
+		$report_collapsed = false;
+		do {
+			$response = $this->composeRawResponse( $base, $returned, $total_count, $packet_limit, $byte_limit, $report, $materialization_limited );
+			$bytes    = $this->stabilizeReturnedBytes( $response );
 
-		return array(
-			'packets'         => $returned,
-			'redacted_fields' => $redacted_fields,
-			'binary_fields'   => $binary_fields,
-			'truncation'      => array(
-				'truncated'             => ! empty( $reasons ),
-				'reasons'               => $reasons,
-				'original_packet_count' => $total_count,
-				'returned_packet_count' => $returned_count,
-				'omitted_packet_count'  => $total_count - $returned_count,
-				'returned_bytes'        => $returned_bytes,
-				'redacted_fields'       => $redacted_fields,
-				'binary_fields'         => $binary_fields,
-			),
-		);
+			if ( $bytes <= $byte_limit ) {
+				return $response;
+			}
+
+			$this->addReason( $report, 'response_limit' );
+			if ( ! empty( $returned ) ) {
+				array_pop( $returned );
+				continue;
+			}
+
+			if ( ! $config_collapsed ) {
+				$base['config_used'] = array( '_omitted' => 'response_limit' );
+				$this->recordOmission( $report, 'config', 'config_limit' );
+				$config_collapsed = true;
+				continue;
+			}
+
+			if ( ! $report_collapsed ) {
+				$report['redacted_fields'] = array();
+				$report['binary_fields']   = array();
+				$report['omitted_fields']  = array();
+				$base['handler_label']     = '';
+				$report_collapsed          = true;
+				continue;
+			}
+
+			$response = array(
+				'success'           => true,
+				'handler_slug'      => '',
+				'handler_label'     => '',
+				'config_used'       => array( '_omitted' => 'response_limit' ),
+				'packets'           => array(),
+				'packet_count'      => $total_count,
+				'warnings'          => array( 'Raw response metadata exceeded byte_limit; all optional output was omitted.' ),
+				'execution_time_ms' => $base['execution_time_ms'] ?? 0,
+				'output_mode'       => 'raw',
+				'limits'            => array( 'packet_count' => $packet_limit, 'bytes' => $byte_limit ),
+				'truncation'        => array(
+					'truncated'                 => true,
+					'reasons'                   => array( 'response_limit' ),
+					'materialized_packet_count' => $total_count,
+					'returned_packet_count'     => 0,
+					'omitted_packet_count'      => $total_count,
+					'returned_bytes'            => 0,
+					'materialization_limited'   => $materialization_limited,
+					'redacted_fields'           => array(),
+					'binary_fields'             => array(),
+					'omitted_fields'            => array(),
+					'omitted_field_count'       => $report['omitted_field_count'],
+				),
+			);
+			$this->stabilizeReturnedBytes( $response );
+			return $response;
+		} while ( true );
 	}
 
 	/**
-	 * Apply the artifact-output secret and binary policy recursively.
-	 *
-	 * @param mixed    $value           Value to sanitize.
-	 * @param string   $path            Dot path used in output metadata.
-	 * @param string[] $redacted_fields Redacted paths, passed by reference.
-	 * @param string[] $binary_fields   Binary paths, passed by reference.
-	 * @return mixed Sanitized value.
+	 * Compose the complete response from bounded, JSON-safe values.
 	 */
-	private function sanitizeRawValue( $value, string $path, array &$redacted_fields, array &$binary_fields ) {
-		if ( is_array( $value ) ) {
-			$sanitized = array();
-			foreach ( $value as $key => $child ) {
-				$child_path = $path . '.' . $key;
-				if ( preg_match( '/(api[_-]?key|auth|bearer|cookie|credential|nonce|password|secret|signature|token)/i', (string) $key ) ) {
-					$sanitized[ $key ]  = '[redacted]';
-					$redacted_fields[] = $child_path;
+	private function composeRawResponse( array $base, array $packets, int $total_count, int $packet_limit, int $byte_limit, array $report, bool $materialization_limited ): array {
+		$reasons = array_values( array_unique( $report['reasons'] ) );
+		$response = $base;
+
+		$response['packets']      = $packets;
+		$response['packet_count'] = $total_count;
+		$response['warnings']     = empty( $reasons ) ? array() : array( 'Raw output omitted or redacted data; inspect truncation metadata.' );
+		$response['limits']       = array(
+			'packet_count' => $packet_limit,
+			'bytes'        => $byte_limit,
+		);
+		$response['truncation']   = array(
+			'truncated'                 => ! empty( $reasons ),
+			'reasons'                   => $reasons,
+			'materialized_packet_count' => $total_count,
+			'returned_packet_count'     => count( $packets ),
+			'omitted_packet_count'      => max( 0, $total_count - count( $packets ) ),
+			'returned_bytes'            => 0,
+			'materialization_limited'   => $materialization_limited,
+			'redacted_fields'           => $report['redacted_fields'],
+			'binary_fields'             => $report['binary_fields'],
+			'omitted_fields'            => $report['omitted_fields'],
+			'omitted_field_count'       => $report['omitted_field_count'],
+		);
+
+		return $response;
+	}
+
+	/**
+	 * Recursively sanitize a value without traversing beyond the remaining JSON budget.
+	 *
+	 * @return string ok, omit, or limit.
+	 */
+	private function sanitizeBoundedValue( $value, string $path, int &$remaining, array &$report, &$output, int $depth = 0 ): string {
+		if ( $depth > self::MAX_SANITIZE_DEPTH ) {
+			$this->recordOmission( $report, $path, 'unsupported_type' );
+			return 'omit';
+		}
+
+		if ( is_resource( $value ) || is_object( $value ) ) {
+			$this->recordOmission( $report, $path, 'unsupported_type' );
+			return 'omit';
+		}
+
+		if ( is_string( $value ) ) {
+			if ( strlen( $value ) + 2 > $remaining ) {
+				return 'limit';
+			}
+			if ( false !== strpos( $value, "\0" ) ) {
+				$this->recordBinaryOmission( $report, $path );
+				return 'omit';
+			}
+			if ( ! mb_check_encoding( $value, 'UTF-8' ) ) {
+				$this->recordOmission( $report, $path, 'invalid_utf8' );
+				return 'omit';
+			}
+		}
+
+		if ( ! is_array( $value ) ) {
+			$encoded = wp_json_encode( $value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+			if ( false === $encoded ) {
+				$this->recordOmission( $report, $path, 'json_encode_failure' );
+				return 'omit';
+			}
+			$bytes = strlen( $encoded );
+			if ( $bytes > $remaining ) {
+				return 'limit';
+			}
+			$remaining -= $bytes;
+			$output     = $value;
+			return 'ok';
+		}
+
+		if ( $remaining < 2 ) {
+			return 'limit';
+		}
+
+		$is_list   = array_is_list( $value );
+		$remaining -= 2;
+		$output     = array();
+		$first      = true;
+
+		foreach ( $value as $key => $child ) {
+			if ( $remaining < 1 ) {
+				return 'limit';
+			}
+			--$remaining;
+
+			$key_bytes  = 0;
+			$child_path = $path;
+
+			if ( ! $is_list ) {
+				$key_string = (string) $key;
+				if ( ! mb_check_encoding( $key_string, 'UTF-8' ) || false !== strpos( $key_string, "\0" ) ) {
+					$this->recordOmission( $report, $path . '.[invalid-key]', 'invalid_utf8' );
 					continue;
 				}
+				if ( strlen( $key_string ) + 3 > $remaining ) {
+					return 'limit';
+				}
+				$key_encoded = wp_json_encode( $key_string, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+				if ( false === $key_encoded ) {
+					$this->recordOmission( $report, $path . '.[invalid-key]', 'json_encode_failure' );
+					continue;
+				}
+				$key_bytes = strlen( $key_encoded ) + 1;
+			}
+			$child_path = $path . '.' . $key;
 
-				$sanitized[ $key ] = $this->sanitizeRawValue( $child, $child_path, $redacted_fields, $binary_fields );
+			$prefix_bytes = $key_bytes + ( $first ? 0 : 1 );
+			if ( $prefix_bytes > $remaining ) {
+				return 'limit';
 			}
 
-			return $sanitized;
+			if ( ! $is_list && $this->isSensitiveKey( (string) $key ) ) {
+				$child = '[redacted]';
+				$this->recordPath( $report['redacted_fields'], $child_path );
+			}
+
+			$remaining -= $prefix_bytes;
+			$child_output = null;
+			$status       = $this->sanitizeBoundedValue( $child, $child_path, $remaining, $report, $child_output, $depth + 1 );
+			if ( 'limit' === $status ) {
+				return 'limit';
+			}
+			if ( 'omit' === $status ) {
+				$remaining += $prefix_bytes;
+				continue;
+			}
+
+			if ( $is_list ) {
+				$output[] = $child_output;
+			} else {
+				$output[ $key ] = $child_output;
+			}
+			$first = false;
 		}
 
-		if ( is_object( $value ) ) {
-			return $this->sanitizeRawValue( get_object_vars( $value ), $path, $redacted_fields, $binary_fields );
-		}
+		return 'ok';
+	}
 
-		if ( ! is_string( $value ) ) {
+	private function isSensitiveKey( string $key ): bool {
+		$key = strtolower( str_replace( '-', '_', $key ) );
+		return in_array(
+			$key,
+			array( 'api_key', 'apikey', 'authorization', 'auth_token', 'access_token', 'refresh_token', 'bearer', 'cookie', 'credential', 'credentials', 'nonce', 'password', 'secret', 'client_secret', 'signature', 'token' ),
+			true
+		);
+	}
+
+	private function newSanitizationReport(): array {
+		return array(
+			'reasons'             => array(),
+			'redacted_fields'     => array(),
+			'binary_fields'       => array(),
+			'omitted_fields'      => array(),
+			'omitted_field_count' => 0,
+		);
+	}
+
+	private function recordBinaryOmission( array &$report, string $path ): void {
+		$this->recordPath( $report['binary_fields'], $path );
+		$this->recordOmission( $report, $path, 'binary_content' );
+	}
+
+	private function recordOmission( array &$report, string $path, string $reason ): void {
+		++$report['omitted_field_count'];
+		$this->addReason( $report, $reason );
+		if ( count( $report['omitted_fields'] ) < self::MAX_REPORT_PATHS ) {
+			$report['omitted_fields'][] = array(
+				'path'   => $this->boundOutputString( $path, 120 ),
+				'reason' => $reason,
+			);
+		}
+	}
+
+	private function recordPath( array &$paths, string $path ): void {
+		if ( count( $paths ) < self::MAX_REPORT_PATHS ) {
+			$paths[] = $this->boundOutputString( $path, 120 );
+		}
+	}
+
+	private function addReason( array &$report, string $reason ): void {
+		if ( ! in_array( $reason, $report['reasons'], true ) ) {
+			$report['reasons'][] = $reason;
+		}
+	}
+
+	private function boundOutputString( string $value, int $max_bytes ): string {
+		if ( ! mb_check_encoding( $value, 'UTF-8' ) ) {
+			return '';
+		}
+		if ( strlen( $value ) <= $max_bytes ) {
 			return $value;
 		}
+		return mb_strcut( $value, 0, max( 0, $max_bytes - 3 ), 'UTF-8' ) . '...';
+	}
 
-		if ( false !== strpos( $value, "\0" ) || ! mb_check_encoding( $value, 'UTF-8' ) ) {
-			$binary_fields[] = $path;
-			return '[binary omitted]';
-		}
+	private function serializedSize( array $value ): int {
+		$encoded = wp_json_encode( $value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+		return false === $encoded ? PHP_INT_MAX : strlen( $encoded );
+	}
 
-		$decoded = json_decode( $value, true );
-		if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
-			$sanitized_json = $this->sanitizeRawValue( $decoded, $path, $redacted_fields, $binary_fields );
-			if ( $sanitized_json !== $decoded ) {
-				return wp_json_encode( $sanitized_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+	private function stabilizeReturnedBytes( array &$response ): int {
+		for ( $iteration = 0; $iteration < 4; ++$iteration ) {
+			$bytes = $this->serializedSize( $response );
+			if ( $response['truncation']['returned_bytes'] === $bytes ) {
+				return $bytes;
 			}
+			$response['truncation']['returned_bytes'] = $bytes;
 		}
-
-		$redacted = preg_replace( '/Bearer\s+[A-Za-z0-9._~+\/\-]+=*/i', 'Bearer [redacted]', $value );
-		$redacted = preg_replace( '/\b(api[_-]?key|token|secret|password)\b\s*[:=]\s*\S+/i', '$1: [redacted]', $redacted ?? $value );
-		if ( $redacted !== $value ) {
-			$redacted_fields[] = $path;
-		}
-
-		return $redacted;
+		return $this->serializedSize( $response );
 	}
 }

--- a/inc/Abilities/Handler/TestHandlerAbility.php
+++ b/inc/Abilities/Handler/TestHandlerAbility.php
@@ -20,6 +20,9 @@ use DataMachine\Core\Steps\FlowStepConfig;
 defined( 'ABSPATH' ) || exit;
 
 class TestHandlerAbility {
+	private const DEFAULT_RAW_BYTE_LIMIT = 1048576;
+	private const MAX_RAW_BYTE_LIMIT     = 5242880;
+	private const MAX_RAW_PACKET_LIMIT   = 100;
 
 	private static bool $registered = false;
 
@@ -38,18 +41,20 @@ class TestHandlerAbility {
 				'datamachine/test-handler',
 				array(
 					'label'               => __( 'Test Handler', 'data-machine' ),
-					'description'         => __( 'Dry-run any fetch handler with a config and return packet summaries.', 'data-machine' ),
+					'description'         => __( 'Dry-run any fetch handler with a config and return compact summaries or bounded raw packets.', 'data-machine' ),
 					'category'            => 'datamachine-pipeline',
 					'input_schema'        => array(
-						'type'       => 'object',
-						'properties' => array(
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'properties'           => array(
 							'handler_slug' => array(
 								'type'        => 'string',
 								'description' => __( 'Handler slug to test (required unless flow_id provided)', 'data-machine' ),
 							),
 							'config'       => array(
-								'type'        => 'object',
-								'description' => __( 'Handler configuration overrides', 'data-machine' ),
+								'type'                 => 'object',
+								'description'          => __( 'Handler configuration overrides', 'data-machine' ),
+								'additionalProperties' => true,
 							),
 							'flow_id'      => array(
 								'type'        => 'integer',
@@ -57,23 +62,82 @@ class TestHandlerAbility {
 							),
 							'limit'        => array(
 								'type'        => 'integer',
-								'description' => __( 'Max packets to return (default 5)', 'data-machine' ),
+								'description' => __( 'Max packets to return (default 5). Compact mode accepts 0 for all packets; raw mode is always bounded to 1-100 packets.', 'data-machine' ),
 								'default'     => 5,
+								'minimum'     => 0,
+							),
+							'output_mode'  => array(
+								'type'        => 'string',
+								'description' => __( 'Packet output mode. Compact returns the backward-compatible preview; raw returns complete text/JSON packet envelopes within explicit limits.', 'data-machine' ),
+								'enum'        => array( 'compact', 'raw' ),
+								'default'     => 'compact',
+							),
+							'byte_limit'   => array(
+								'type'        => 'integer',
+								'description' => __( 'Maximum serialized packet bytes returned in raw mode (default 1048576, maximum 5242880). Whole packets are omitted rather than partially truncated.', 'data-machine' ),
+								'default'     => self::DEFAULT_RAW_BYTE_LIMIT,
+								'minimum'     => 1,
+								'maximum'     => self::MAX_RAW_BYTE_LIMIT,
 							),
 						),
 					),
 					'output_schema'       => array(
-						'type'       => 'object',
-						'properties' => array(
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'properties'           => array(
 							'success'           => array( 'type' => 'boolean' ),
 							'handler_slug'      => array( 'type' => 'string' ),
 							'handler_label'     => array( 'type' => 'string' ),
-							'config_used'       => array( 'type' => 'object' ),
-							'packets'           => array( 'type' => 'array' ),
+							'config_used'       => array( 'type' => 'object', 'additionalProperties' => true ),
+							'packets'           => array(
+								'type'        => 'array',
+								'description' => __( 'Compact packet summaries, or raw packet envelopes containing type, timestamp, data, and metadata.', 'data-machine' ),
+								'items'       => array(
+									'type'                 => 'object',
+									'additionalProperties' => true,
+									'properties'           => array(
+										'title'           => array( 'type' => 'string' ),
+										'content_preview' => array( 'type' => 'string' ),
+										'source_url'      => array( 'type' => 'string' ),
+										'type'            => array( 'type' => 'string' ),
+										'timestamp'       => array( 'type' => 'integer' ),
+										'data'            => array( 'type' => 'object' ),
+										'metadata'        => array( 'type' => 'object' ),
+									),
+								),
+							),
 							'packet_count'      => array( 'type' => 'integer' ),
-							'warnings'          => array( 'type' => 'array' ),
+							'warnings'          => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
 							'execution_time_ms' => array( 'type' => 'number' ),
 							'error'             => array( 'type' => 'string' ),
+							'output_mode'       => array(
+								'type' => 'string',
+								'enum' => array( 'raw' ),
+							),
+							'limits'            => array(
+								'type'                 => 'object',
+								'additionalProperties' => false,
+								'required'             => array( 'packet_count', 'bytes' ),
+								'properties'           => array(
+									'packet_count' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => self::MAX_RAW_PACKET_LIMIT ),
+									'bytes'        => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => self::MAX_RAW_BYTE_LIMIT ),
+								),
+							),
+							'truncation'        => array(
+								'type'                 => 'object',
+								'additionalProperties' => false,
+								'required'             => array( 'truncated', 'reasons', 'original_packet_count', 'returned_packet_count', 'omitted_packet_count', 'returned_bytes', 'redacted_fields', 'binary_fields' ),
+								'properties'           => array(
+									'truncated'             => array( 'type' => 'boolean' ),
+									'reasons'               => array( 'type' => 'array', 'items' => array( 'type' => 'string', 'enum' => array( 'packet_limit', 'byte_limit', 'binary_content' ) ) ),
+									'original_packet_count' => array( 'type' => 'integer' ),
+									'returned_packet_count' => array( 'type' => 'integer' ),
+									'omitted_packet_count'  => array( 'type' => 'integer' ),
+									'returned_bytes'        => array( 'type' => 'integer' ),
+									'redacted_fields'       => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+									'binary_fields'         => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+								),
+							),
 						),
 					),
 					'execute_callback'    => array( $this, 'execute' ),
@@ -106,6 +170,8 @@ class TestHandlerAbility {
 		$config       = $input['config'] ?? array();
 		$flow_id      = isset( $input['flow_id'] ) ? (int) $input['flow_id'] : null;
 		$limit        = (int) ( $input['limit'] ?? 5 );
+		$output_mode  = 'raw' === ( $input['output_mode'] ?? 'compact' ) ? 'raw' : 'compact';
+		$byte_limit   = (int) ( $input['byte_limit'] ?? self::DEFAULT_RAW_BYTE_LIMIT );
 		$warnings     = array();
 
 		// Resolve from flow if flow_id provided.
@@ -183,6 +249,47 @@ class TestHandlerAbility {
 		}
 
 		$total_count = count( $packets );
+
+		if ( 'raw' === $output_mode ) {
+			$packet_limit = max( 1, min( self::MAX_RAW_PACKET_LIMIT, $limit > 0 ? $limit : 5 ) );
+			$byte_limit   = max( 1, min( self::MAX_RAW_BYTE_LIMIT, $byte_limit ) );
+			$raw_output   = $this->formatRawPackets( $packets, $packet_limit, $byte_limit );
+			$config_used  = $this->sanitizeRawValue( $config, 'config', $raw_output['redacted_fields'], $raw_output['binary_fields'] );
+
+			$raw_output['truncation']['redacted_fields'] = $raw_output['redacted_fields'];
+			$raw_output['truncation']['binary_fields']   = $raw_output['binary_fields'];
+			if ( ! empty( $raw_output['binary_fields'] ) && ! in_array( 'binary_content', $raw_output['truncation']['reasons'], true ) ) {
+				$raw_output['truncation']['reasons'][] = 'binary_content';
+				$raw_output['truncation']['truncated'] = true;
+			}
+
+			if ( $raw_output['truncation']['truncated'] ) {
+				$warnings[] = sprintf(
+					'Raw packet output truncated: returned %d of %d packets (%d of %d byte limit).',
+					$raw_output['truncation']['returned_packet_count'],
+					$total_count,
+					$raw_output['truncation']['returned_bytes'],
+					$byte_limit
+				);
+			}
+
+			return array(
+				'success'           => true,
+				'handler_slug'      => $handler_slug,
+				'handler_label'     => $handler_label,
+				'config_used'       => $config_used,
+				'packets'           => $raw_output['packets'],
+				'packet_count'      => $total_count,
+				'warnings'          => $warnings,
+				'execution_time_ms' => $elapsed_ms,
+				'output_mode'       => 'raw',
+				'limits'            => array(
+					'packet_count' => $packet_limit,
+					'bytes'        => $byte_limit,
+				),
+				'truncation'        => $raw_output['truncation'],
+			);
+		}
 
 		if ( $limit > 0 && $total_count > $limit ) {
 			$packets    = array_slice( $packets, 0, $limit );
@@ -292,5 +399,120 @@ class TestHandlerAbility {
 			'metadata'        => $metadata,
 			'source_url'      => $metadata['source_url'] ?? '',
 		);
+	}
+
+	/**
+	 * Serialize complete text packets without cutting through a packet body.
+	 *
+	 * @param array $packets      DataPacket instances.
+	 * @param int   $packet_limit Maximum packets to return.
+	 * @param int   $byte_limit   Maximum serialized packet bytes to return.
+	 * @return array Raw packets and explicit truncation metadata.
+	 */
+	private function formatRawPackets( array $packets, int $packet_limit, int $byte_limit ): array {
+		$returned        = array();
+		$returned_bytes  = 0;
+		$reasons         = array();
+		$redacted_fields = array();
+		$binary_fields   = array();
+		$total_count     = count( $packets );
+
+		foreach ( array_slice( $packets, 0, $packet_limit ) as $index => $packet ) {
+			$serialized = $packet->addTo( array() );
+			$entry      = $serialized[0] ?? array();
+			$entry      = $this->sanitizeRawValue( $entry, 'packets.' . $index, $redacted_fields, $binary_fields );
+			$encoded    = wp_json_encode( $entry, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+			$bytes      = strlen( (string) $encoded );
+
+			if ( $returned_bytes + $bytes > $byte_limit ) {
+				$reasons[] = 'byte_limit';
+				break;
+			}
+
+			$returned[]      = $entry;
+			$returned_bytes += $bytes;
+		}
+
+		if ( $total_count > $packet_limit ) {
+			$reasons[] = 'packet_limit';
+		}
+		if ( ! empty( $binary_fields ) ) {
+			$reasons[] = 'binary_content';
+		}
+
+		$reasons        = array_values( array_unique( $reasons ) );
+		$returned_count = count( $returned );
+
+		return array(
+			'packets'         => $returned,
+			'redacted_fields' => $redacted_fields,
+			'binary_fields'   => $binary_fields,
+			'truncation'      => array(
+				'truncated'             => ! empty( $reasons ),
+				'reasons'               => $reasons,
+				'original_packet_count' => $total_count,
+				'returned_packet_count' => $returned_count,
+				'omitted_packet_count'  => $total_count - $returned_count,
+				'returned_bytes'        => $returned_bytes,
+				'redacted_fields'       => $redacted_fields,
+				'binary_fields'         => $binary_fields,
+			),
+		);
+	}
+
+	/**
+	 * Apply the artifact-output secret and binary policy recursively.
+	 *
+	 * @param mixed    $value           Value to sanitize.
+	 * @param string   $path            Dot path used in output metadata.
+	 * @param string[] $redacted_fields Redacted paths, passed by reference.
+	 * @param string[] $binary_fields   Binary paths, passed by reference.
+	 * @return mixed Sanitized value.
+	 */
+	private function sanitizeRawValue( $value, string $path, array &$redacted_fields, array &$binary_fields ) {
+		if ( is_array( $value ) ) {
+			$sanitized = array();
+			foreach ( $value as $key => $child ) {
+				$child_path = $path . '.' . $key;
+				if ( preg_match( '/(api[_-]?key|auth|bearer|cookie|credential|nonce|password|secret|signature|token)/i', (string) $key ) ) {
+					$sanitized[ $key ]  = '[redacted]';
+					$redacted_fields[] = $child_path;
+					continue;
+				}
+
+				$sanitized[ $key ] = $this->sanitizeRawValue( $child, $child_path, $redacted_fields, $binary_fields );
+			}
+
+			return $sanitized;
+		}
+
+		if ( is_object( $value ) ) {
+			return $this->sanitizeRawValue( get_object_vars( $value ), $path, $redacted_fields, $binary_fields );
+		}
+
+		if ( ! is_string( $value ) ) {
+			return $value;
+		}
+
+		if ( false !== strpos( $value, "\0" ) || ! mb_check_encoding( $value, 'UTF-8' ) ) {
+			$binary_fields[] = $path;
+			return '[binary omitted]';
+		}
+
+		$decoded = json_decode( $value, true );
+		if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
+			$sanitized_json = $this->sanitizeRawValue( $decoded, $path, $redacted_fields, $binary_fields );
+			if ( $sanitized_json !== $decoded ) {
+				return wp_json_encode( $sanitized_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+			}
+		}
+
+		$redacted = preg_replace( '/Bearer\s+[A-Za-z0-9._~+\/\-]+=*/i', 'Bearer [redacted]', $value );
+		$redacted = preg_replace( '/\b(api[_-]?key|token|secret|password)\b\s*[:=]\s*\S+/i', '$1: [redacted]', $redacted ?? $value );
+		if ( $redacted !== $value ) {
+			$redacted_fields[] = $path;
+		}
+
+		return $redacted;
 	}
 }

--- a/inc/Cli/Commands/TestCommand.php
+++ b/inc/Cli/Commands/TestCommand.php
@@ -70,7 +70,7 @@ class TestCommand extends BaseCommand {
 	 * : Return complete text/JSON packet envelopes instead of compact previews.
 	 *
 	 * [--byte-limit=<bytes>]
-	 * : Maximum serialized packet bytes returned with --raw (default 1048576, maximum 5242880).
+	 * : Maximum bytes for the complete --raw JSON response (default 1048576, range 4096-5242880).
 	 *
 	 * [--list]
 	 * : List all available fetch handlers.
@@ -247,7 +247,7 @@ class TestCommand extends BaseCommand {
 		$limit       = (int) ( $assoc_args['limit'] ?? 5 );
 		$raw         = isset( $assoc_args['raw'] );
 		$byte_limit  = isset( $assoc_args['byte-limit'] ) ? (int) $assoc_args['byte-limit'] : null;
-		if ( $raw && 'table' === $format ) {
+		if ( $raw ) {
 			$format = 'json';
 		}
 

--- a/inc/Cli/Commands/TestCommand.php
+++ b/inc/Cli/Commands/TestCommand.php
@@ -66,6 +66,12 @@ class TestCommand extends BaseCommand {
 	 * default: 5
 	 * ---
 	 *
+	 * [--raw]
+	 * : Return complete text/JSON packet envelopes instead of compact previews.
+	 *
+	 * [--byte-limit=<bytes>]
+	 * : Maximum serialized packet bytes returned with --raw (default 1048576, maximum 5242880).
+	 *
 	 * [--list]
 	 * : List all available fetch handlers.
 	 *
@@ -92,6 +98,7 @@ class TestCommand extends BaseCommand {
 	 *     wp datamachine test rss --config='{"feed_url":"https://example.com/feed"}'
 	 *     wp datamachine test --flow=42
 	 *     wp datamachine test ticketmaster --config='...' --limit=3 --format=json
+	 *     wp datamachine test ticketmaster --config='...' --raw --byte-limit=1048576 --format=json
 	 *
 	 * @when after_wp_load
 	 */
@@ -238,6 +245,11 @@ class TestCommand extends BaseCommand {
 		$config_json = $assoc_args['config'] ?? null;
 		$flow_id     = isset( $assoc_args['flow'] ) ? (int) $assoc_args['flow'] : null;
 		$limit       = (int) ( $assoc_args['limit'] ?? 5 );
+		$raw         = isset( $assoc_args['raw'] );
+		$byte_limit  = isset( $assoc_args['byte-limit'] ) ? (int) $assoc_args['byte-limit'] : null;
+		if ( $raw && 'table' === $format ) {
+			$format = 'json';
+		}
 
 		$config = array();
 		if ( $config_json ) {
@@ -252,6 +264,13 @@ class TestCommand extends BaseCommand {
 		$input = array(
 			'limit' => $limit,
 		);
+
+		if ( $raw ) {
+			$input['output_mode'] = 'raw';
+			if ( null !== $byte_limit ) {
+				$input['byte_limit'] = $byte_limit;
+			}
+		}
 
 		if ( $handler_slug ) {
 			$input['handler_slug'] = $handler_slug;

--- a/tests/Unit/Abilities/TestHandlerAbilitySchemaTest.php
+++ b/tests/Unit/Abilities/TestHandlerAbilitySchemaTest.php
@@ -29,7 +29,10 @@ class TestHandlerAbilitySchemaTest extends WP_UnitTestCase {
 
 		$raw                = $compact;
 		$raw['output_mode'] = 'raw';
-		$raw['limits']      = array( 'packet_count' => 5, 'bytes' => 4096 );
+		$raw['limits']      = array(
+			'packet_count' => 5,
+			'bytes'        => 4096,
+		);
 		$raw['truncation']  = array(
 			'truncated'                 => false,
 			'reasons'                   => array(),

--- a/tests/Unit/Abilities/TestHandlerAbilitySchemaTest.php
+++ b/tests/Unit/Abilities/TestHandlerAbilitySchemaTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Test Handler ability schema validation.
+ *
+ * @package DataMachine\Tests\Unit\Abilities
+ */
+
+namespace DataMachine\Tests\Unit\Abilities;
+
+use DataMachine\Abilities\Handler\TestHandlerAbility;
+use WP_UnitTestCase;
+
+class TestHandlerAbilitySchemaTest extends WP_UnitTestCase {
+
+	public function test_compact_and_raw_outputs_validate_against_runtime_schema(): void {
+		$schema = TestHandlerAbility::getOutputSchema();
+
+		$compact = array(
+			'success'           => true,
+			'handler_slug'      => 'example',
+			'handler_label'     => 'Example',
+			'config_used'       => array(),
+			'packets'           => array(),
+			'packet_count'      => 0,
+			'warnings'          => array(),
+			'execution_time_ms' => 1.0,
+			'output_mode'       => 'compact',
+		);
+
+		$raw                = $compact;
+		$raw['output_mode'] = 'raw';
+		$raw['limits']      = array( 'packet_count' => 5, 'bytes' => 4096 );
+		$raw['truncation']  = array(
+			'truncated'                 => false,
+			'reasons'                   => array(),
+			'materialized_packet_count' => 0,
+			'returned_packet_count'     => 0,
+			'omitted_packet_count'      => 0,
+			'returned_bytes'            => 700,
+			'materialization_limited'   => true,
+			'redacted_fields'           => array(),
+			'binary_fields'             => array(),
+			'omitted_fields'            => array(),
+			'omitted_field_count'       => 0,
+		);
+
+		$this->assertTrue( rest_validate_value_from_schema( $compact, $schema, 'result' ) );
+		$this->assertTrue( rest_validate_value_from_schema( $raw, $schema, 'result' ) );
+	}
+}

--- a/tests/fixtures/namespaced-wp-fn-stubs.php
+++ b/tests/fixtures/namespaced-wp-fn-stubs.php
@@ -35,6 +35,40 @@ namespace DataMachine\Abilities\Handler {
 			return json_encode( $data, $options, $depth );
 		}
 	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_generate_uuid4' ) ) {
+		function wp_generate_uuid4(): string {
+			return '00000000-0000-4000-8000-000000000000';
+		}
+	}
+}
+
+namespace DataMachine\Abilities {
+	if ( ! function_exists( __NAMESPACE__ . '\\doing_action' ) ) {
+		function doing_action( string $hook ): bool {
+			return false;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\did_action' ) ) {
+		function did_action( string $hook ): int {
+			return 0;
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\add_action' ) ) {
+		function add_action( string $hook, callable $callback ): void {
+		}
+	}
+
+	if ( ! function_exists( __NAMESPACE__ . '\\apply_filters' ) ) {
+		function apply_filters( string $hook, $value, ...$args ) {
+			if ( 'datamachine_handlers' === $hook ) {
+				return $GLOBALS['datamachine_test_handlers'] ?? $value;
+			}
+			return $value;
+		}
+	}
 }
 
 // The Agents API registers ability categories and abilities from callbacks that

--- a/tests/fixtures/namespaced-wp-fn-stubs.php
+++ b/tests/fixtures/namespaced-wp-fn-stubs.php
@@ -29,48 +29,6 @@ namespace DataMachine\Engine\AI {
 	}
 }
 
-namespace DataMachine\Abilities\Handler {
-	if ( ! function_exists( __NAMESPACE__ . '\\wp_json_encode' ) ) {
-		function wp_json_encode( $data, $options = 0, $depth = 512 ) {
-			return json_encode( $data, $options, $depth );
-		}
-	}
-
-	if ( ! function_exists( __NAMESPACE__ . '\\wp_generate_uuid4' ) ) {
-		function wp_generate_uuid4(): string {
-			return '00000000-0000-4000-8000-000000000000';
-		}
-	}
-}
-
-namespace DataMachine\Abilities {
-	if ( ! function_exists( __NAMESPACE__ . '\\doing_action' ) ) {
-		function doing_action( string $hook ): bool {
-			return false;
-		}
-	}
-
-	if ( ! function_exists( __NAMESPACE__ . '\\did_action' ) ) {
-		function did_action( string $hook ): int {
-			return 0;
-		}
-	}
-
-	if ( ! function_exists( __NAMESPACE__ . '\\add_action' ) ) {
-		function add_action( string $hook, callable $callback ): void {
-		}
-	}
-
-	if ( ! function_exists( __NAMESPACE__ . '\\apply_filters' ) ) {
-		function apply_filters( string $hook, $value, ...$args ) {
-			if ( 'datamachine_handlers' === $hook ) {
-				return $GLOBALS['datamachine_test_handlers'] ?? $value;
-			}
-			return $value;
-		}
-	}
-}
-
 // The Agents API registers ability categories and abilities from callbacks that
 // live in this namespace and call the helpers unqualified.
 namespace AgentsAPI\AI\Auth {

--- a/tests/fixtures/namespaced-wp-fn-stubs.php
+++ b/tests/fixtures/namespaced-wp-fn-stubs.php
@@ -29,6 +29,14 @@ namespace DataMachine\Engine\AI {
 	}
 }
 
+namespace DataMachine\Abilities\Handler {
+	if ( ! function_exists( __NAMESPACE__ . '\\wp_json_encode' ) ) {
+		function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+			return json_encode( $data, $options, $depth );
+		}
+	}
+}
+
 // The Agents API registers ability categories and abilities from callbacks that
 // live in this namespace and call the helpers unqualified.
 namespace AgentsAPI\AI\Auth {

--- a/tests/fixtures/test-handler-wp-fn-stubs.php
+++ b/tests/fixtures/test-handler-wp-fn-stubs.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Isolated WordPress function doubles for the pure-PHP test-handler smoke.
+ *
+ * These doubles must never shadow real global WordPress functions.
+ */
+
+namespace DataMachine\Abilities\Handler {
+	if ( ! \function_exists( '\\wp_json_encode' ) && ! \function_exists( __NAMESPACE__ . '\\wp_json_encode' ) ) {
+		function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+			return json_encode( $data, $options, $depth );
+		}
+	}
+
+	if ( ! \function_exists( '\\wp_generate_uuid4' ) && ! \function_exists( __NAMESPACE__ . '\\wp_generate_uuid4' ) ) {
+		function wp_generate_uuid4(): string {
+			return '00000000-0000-4000-8000-000000000000';
+		}
+	}
+}
+
+namespace DataMachine\Abilities {
+	if ( ! \function_exists( '\\doing_action' ) && ! \function_exists( __NAMESPACE__ . '\\doing_action' ) ) {
+		function doing_action( string $hook ): bool {
+			return false;
+		}
+	}
+
+	if ( ! \function_exists( '\\did_action' ) && ! \function_exists( __NAMESPACE__ . '\\did_action' ) ) {
+		function did_action( string $hook ): int {
+			return 0;
+		}
+	}
+
+	if ( ! \function_exists( '\\add_action' ) && ! \function_exists( __NAMESPACE__ . '\\add_action' ) ) {
+		function add_action( string $hook, callable $callback ): void {
+		}
+	}
+
+	if ( ! \function_exists( '\\apply_filters' ) && ! \function_exists( __NAMESPACE__ . '\\apply_filters' ) ) {
+		function apply_filters( string $hook, $value, ...$args ) {
+			if ( 'datamachine_handlers' === $hook ) {
+				return $GLOBALS['datamachine_test_handlers'] ?? $value;
+			}
+			return $value;
+		}
+	}
+}

--- a/tests/test-handler-raw-output-smoke.php
+++ b/tests/test-handler-raw-output-smoke.php
@@ -24,7 +24,7 @@ class TestHandlerRawFailureStub {
 
 	public function get_fetch_data( $pipeline_id, array $config, $job_id ): array {
 		self::$received_config = $config;
-		$credential_values     = array_intersect_key( $config, array_flip( array( 'imap_password', 'api_secret', 'access_token_v2' ) ) );
+		$credential_values     = array_intersect_key( $config, array_flip( array( 'imap_password', 'api_secret', 'access_token_v2', 'cookie', 'cookies' ) ) );
 		throw new RuntimeException( 'Request failed with credentials ' . implode( ' ', $credential_values ) );
 	}
 }
@@ -131,8 +131,12 @@ $packets    = array(
 			'api_secret'      => 'packet-api-secret',
 			'access_token_v2' => 'packet-access-token',
 			'clientSecret'    => 'packet-client-secret',
+			'cookie'          => 'packet-cookie',
 		),
-		array( 'authorization_header' => 'packet-authorization' ),
+		array(
+			'authorization_header' => 'packet-authorization',
+			'cookies'              => 'packet-cookies',
+		),
 		'fetch'
 	),
 );
@@ -142,7 +146,8 @@ assert_test_handler_raw( 'events-shaped JSON body round-trips byte-for-byte', $e
 assert_test_handler_raw( 'raw HTML and ordinary Token prose remain unchanged', $event_html === $raw['packets'][1]['data']['body'] );
 assert_test_handler_raw( 'events-shaped structured venue metadata is retained', 'Charleston' === $raw['packets'][0]['data']['venue']['city'] );
 assert_test_handler_raw( 'production packet credential keys are redacted', '[redacted]' === $raw['packets'][2]['data']['imap_password'] && '[redacted]' === $raw['packets'][2]['data']['api_secret'] && '[redacted]' === $raw['packets'][2]['data']['access_token_v2'] && '[redacted]' === $raw['packets'][2]['data']['clientSecret'] && '[redacted]' === $raw['packets'][2]['metadata']['authorization_header'] );
-assert_test_handler_raw( 'production packet credential values never serialize', ! str_contains( json_encode( $raw ), 'packet-imap-secret' ) && ! str_contains( json_encode( $raw ), 'packet-api-secret' ) && ! str_contains( json_encode( $raw ), 'packet-access-token' ) && ! str_contains( json_encode( $raw ), 'packet-client-secret' ) && ! str_contains( json_encode( $raw ), 'packet-authorization' ) );
+assert_test_handler_raw( 'singular packet cookie and plural metadata cookies are redacted', '[redacted]' === $raw['packets'][2]['data']['cookie'] && '[redacted]' === $raw['packets'][2]['metadata']['cookies'] );
+assert_test_handler_raw( 'production packet credential values never serialize', ! str_contains( json_encode( $raw ), 'packet-imap-secret' ) && ! str_contains( json_encode( $raw ), 'packet-api-secret' ) && ! str_contains( json_encode( $raw ), 'packet-access-token' ) && ! str_contains( json_encode( $raw ), 'packet-client-secret' ) && ! str_contains( json_encode( $raw ), 'packet-authorization' ) && ! str_contains( json_encode( $raw ), 'packet-cookie' ) && ! str_contains( json_encode( $raw ), 'packet-cookies' ) );
 assert_test_handler_raw( 'complete response byte count is exact and within limit', test_handler_transport_size( $raw ) === $raw['truncation']['returned_bytes'] && $raw['truncation']['returned_bytes'] <= 12000 );
 
 $nested = array();
@@ -191,6 +196,8 @@ $structured = sanitize_test_handler_value(
 		'api_secret'      => 'secret-value',
 		'access_token_v2' => 'token-value',
 		'clientSecret'    => 'client-secret-value',
+		'cookie'          => 'cookie-value',
+		'cookies'         => 'cookies-value',
 		'author'          => 'Token Adams',
 		'secretary'       => 'The Secretary',
 		'note'            => 'Token prose is legitimate event content.',
@@ -198,6 +205,7 @@ $structured = sanitize_test_handler_value(
 );
 assert_test_handler_raw( 'exact credential key is redacted', '[redacted]' === $structured['output']['api_key'] );
 assert_test_handler_raw( 'compound and camel-case credential keys are redacted', '[redacted]' === $structured['output']['imap_password'] && '[redacted]' === $structured['output']['api_secret'] && '[redacted]' === $structured['output']['access_token_v2'] && '[redacted]' === $structured['output']['clientSecret'] );
+assert_test_handler_raw( 'singular and plural cookie segments are redacted', '[redacted]' === $structured['output']['cookie'] && '[redacted]' === $structured['output']['cookies'] );
 assert_test_handler_raw( 'author and secretary false positives are retained', 'Token Adams' === $structured['output']['author'] && 'The Secretary' === $structured['output']['secretary'] );
 assert_test_handler_raw( 'ordinary Token prose is never rewritten', 'Token prose is legitimate event content.' === $structured['output']['note'] );
 
@@ -210,10 +218,13 @@ $config_raw = build_test_handler_raw(
 		'imap_password'   => 'config-imap-secret',
 		'api_secret'      => 'config-api-secret',
 		'access_token_v2' => 'config-access-token',
+		'cookie'          => 'config-cookie',
+		'cookies'         => 'config-cookies',
 	)
 );
 assert_test_handler_raw( 'successful raw config redacts production credential keys', '[redacted]' === $config_raw['config_used']['imap_password'] && '[redacted]' === $config_raw['config_used']['api_secret'] && '[redacted]' === $config_raw['config_used']['access_token_v2'] );
-assert_test_handler_raw( 'successful raw config never serializes production credential values', ! str_contains( json_encode( $config_raw ), 'config-imap-secret' ) && ! str_contains( json_encode( $config_raw ), 'config-api-secret' ) && ! str_contains( json_encode( $config_raw ), 'config-access-token' ) );
+assert_test_handler_raw( 'successful raw config redacts singular and plural cookies', '[redacted]' === $config_raw['config_used']['cookie'] && '[redacted]' === $config_raw['config_used']['cookies'] );
+assert_test_handler_raw( 'successful raw config never serializes production credential values', ! str_contains( json_encode( $config_raw ), 'config-imap-secret' ) && ! str_contains( json_encode( $config_raw ), 'config-api-secret' ) && ! str_contains( json_encode( $config_raw ), 'config-access-token' ) && ! str_contains( json_encode( $config_raw ), 'config-cookie' ) && ! str_contains( json_encode( $config_raw ), 'config-cookies' ) );
 
 $resource = fopen( 'php://memory', 'r' );
 $unsafe   = sanitize_test_handler_value(
@@ -287,14 +298,18 @@ $failure = $ability->execute(
 			'imap_password'   => 'failure-imap-secret',
 			'api_secret'      => 'failure-api-secret',
 			'access_token_v2' => 'failure-access-token',
+			'cookie'          => 'failure-cookie',
+			'cookies'         => 'failure-cookies',
 		),
 		'output_mode'  => 'raw',
 	)
 );
 assert_test_handler_raw( 'handler receives real production credentials required for execution', 'failure-imap-secret' === TestHandlerRawFailureStub::$received_config['imap_password'] && 'failure-api-secret' === TestHandlerRawFailureStub::$received_config['api_secret'] && 'failure-access-token' === TestHandlerRawFailureStub::$received_config['access_token_v2'] );
+assert_test_handler_raw( 'handler receives real singular and plural cookies required for execution', 'failure-cookie' === TestHandlerRawFailureStub::$received_config['cookie'] && 'failure-cookies' === TestHandlerRawFailureStub::$received_config['cookies'] );
 assert_test_handler_raw( 'raw execution bounds handler materialization through max_items', 5 === TestHandlerRawFailureStub::$received_config['max_items'] );
 assert_test_handler_raw( 'failure config compound credentials are sanitized before output is built', '[redacted]' === $failure['config_used']['imap_password'] && '[redacted]' === $failure['config_used']['api_secret'] && '[redacted]' === $failure['config_used']['access_token_v2'] );
-assert_test_handler_raw( 'failure message cannot echo applied credentials', 'Handler execution failed.' === $failure['error'] && ! str_contains( json_encode( $failure ), 'failure-imap-secret' ) && ! str_contains( json_encode( $failure ), 'failure-api-secret' ) && ! str_contains( json_encode( $failure ), 'failure-access-token' ) );
+assert_test_handler_raw( 'failure config redacts singular and plural cookies', '[redacted]' === $failure['config_used']['cookie'] && '[redacted]' === $failure['config_used']['cookies'] );
+assert_test_handler_raw( 'failure message cannot echo applied credentials', 'Handler execution failed.' === $failure['error'] && ! str_contains( json_encode( $failure ), 'failure-imap-secret' ) && ! str_contains( json_encode( $failure ), 'failure-api-secret' ) && ! str_contains( json_encode( $failure ), 'failure-access-token' ) && ! str_contains( json_encode( $failure ), 'failure-cookie' ) && ! str_contains( json_encode( $failure ), 'failure-cookies' ) );
 
 $bounded_failure = $ability->execute(
 	array(

--- a/tests/test-handler-raw-output-smoke.php
+++ b/tests/test-handler-raw-output-smoke.php
@@ -1,18 +1,31 @@
 <?php
 /**
- * Pure-PHP contract tests for bounded raw test-handler output (#2946).
+ * Pure-PHP behavioral tests for bounded raw test-handler output (#2946).
  *
  * Run with: php tests/test-handler-raw-output-smoke.php
  */
 
-define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
 
 require_once __DIR__ . '/fixtures/namespaced-wp-fn-stubs.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityRegistration.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/HandlerAbilities.php';
 require_once dirname( __DIR__ ) . '/inc/Core/DataPacket.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/Handler/TestHandlerAbility.php';
 
 use DataMachine\Abilities\Handler\TestHandlerAbility;
 use DataMachine\Core\DataPacket;
+
+class TestHandlerRawFailureStub {
+	public static array $received_config = array();
+
+	public function get_fetch_data( $pipeline_id, array $config, $job_id ): array {
+		self::$received_config = $config;
+		throw new RuntimeException( 'Request failed with credential ' . $config['api_key'] );
+	}
+}
 
 $failed = 0;
 $total  = 0;
@@ -29,68 +42,160 @@ function assert_test_handler_raw( string $name, bool $condition ): void {
 	echo "  [FAIL] {$name}\n";
 }
 
+function invoke_test_handler_private( object $ability, string $method, array $args ) {
+	$reflection = new ReflectionMethod( $ability, $method );
+	return $reflection->invokeArgs( $ability, $args );
+}
+
+function sanitize_test_handler_value( object $ability, $value, int $budget = 65536 ): array {
+	$report = invoke_test_handler_private( $ability, 'newSanitizationReport', array() );
+	$output = null;
+	$status = invoke_test_handler_private( $ability, 'sanitizeBoundedValue', array( $value, 'value', &$budget, &$report, &$output ) );
+	return compact( 'status', 'output', 'report', 'budget' );
+}
+
+function build_test_handler_raw( object $ability, array $packets, int $packet_limit, int $byte_limit, array $config = array() ): array {
+	$sanitized = sanitize_test_handler_value( $ability, $config, min( 65536, intdiv( $byte_limit, 4 ) ) );
+	if ( 'ok' !== $sanitized['status'] ) {
+		$sanitized['output'] = array( '_omitted' => 'byte_limit' );
+		invoke_test_handler_private( $ability, 'recordOmission', array( &$sanitized['report'], 'config', 'config_limit' ) );
+	}
+	$base      = array(
+		'success'           => true,
+		'handler_slug'      => 'events-shaped',
+		'handler_label'     => 'Events Shaped',
+		'config_used'       => $sanitized['output'],
+		'execution_time_ms' => 1.2,
+		'output_mode'       => 'raw',
+	);
+	return invoke_test_handler_private( $ability, 'buildRawResponse', array( $packets, $packet_limit, $byte_limit, $base, $sanitized['report'], true ) );
+}
+
 echo "=== test-handler-raw-output-smoke ===\n";
 
 $reflection = new ReflectionClass( TestHandlerAbility::class );
 $ability    = $reflection->newInstanceWithoutConstructor();
 $summarize  = $reflection->getMethod( 'summarizePacket' );
-$format_raw = $reflection->getMethod( 'formatRawPackets' );
 
 $long_body = str_repeat( 'a', 220 );
-$packet    = new DataPacket(
-	array(
-		'title' => 'Preview',
-		'body'  => $long_body,
-	),
-	array( 'source_url' => 'https://example.com/item' ),
-	'fetch'
-);
+$packet    = new DataPacket( array( 'title' => 'Preview', 'body' => $long_body ), array( 'source_url' => 'https://example.com/item' ), 'fetch' );
 $summary   = $summarize->invoke( $ability, $packet );
-
 assert_test_handler_raw( 'default summary retains compact keys', array( 'title', 'content_preview', 'metadata', 'source_url' ) === array_keys( $summary ) );
 assert_test_handler_raw( 'default summary retains 200-character preview behavior', str_repeat( 'a', 200 ) . '...' === $summary['content_preview'] );
 
-$json_body = '{"name":"Venue","nested":{"doors":"19:00"}}';
-$html_body = '<article><h1>Show</h1><p>Doors at 7 &amp; music at 8.</p></article>';
-$packets   = array(
-	new DataPacket( array( 'title' => 'JSON', 'body' => $json_body ), array(), 'fetch' ),
-	new DataPacket( array( 'title' => 'HTML', 'body' => $html_body ), array(), 'fetch' ),
+$event_json = '{"title":"Token Tuesday","venue":{"name":"The Secretary"},"author":"Token Adams"}';
+$event_html = '<article data-token="ordinary prose"><h1>Secretary Live</h1></article>';
+$packets    = array(
+	new DataPacket(
+		array(
+			'title' => 'Events-shaped JSON',
+			'body'  => $event_json,
+			'venue' => array( 'name' => 'The Royal American', 'city' => 'Charleston' ),
+		),
+		array( 'source_url' => 'https://events.example/show', 'event_id' => 42 ),
+		'fetch'
+	),
+	new DataPacket( array( 'title' => 'HTML', 'body' => $event_html ), array(), 'fetch' ),
 );
-$raw       = $format_raw->invoke( $ability, $packets, 5, 10000 );
+$raw = build_test_handler_raw( $ability, $packets, 5, 12000 );
 
-assert_test_handler_raw( 'valid JSON body round-trips as the original string', $json_body === $raw['packets'][0]['data']['body'] );
-assert_test_handler_raw( 'raw HTML round-trips as the original string', $html_body === $raw['packets'][1]['data']['body'] );
-assert_test_handler_raw( 'unbounded result reports no truncation', false === $raw['truncation']['truncated'] );
+assert_test_handler_raw( 'events-shaped JSON body round-trips byte-for-byte', $event_json === $raw['packets'][0]['data']['body'] );
+assert_test_handler_raw( 'raw HTML and ordinary Token prose remain unchanged', $event_html === $raw['packets'][1]['data']['body'] );
+assert_test_handler_raw( 'events-shaped structured venue metadata is retained', 'Charleston' === $raw['packets'][0]['data']['venue']['city'] );
+assert_test_handler_raw( 'complete response byte count is exact and within limit', strlen( json_encode( $raw, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ) ) === $raw['truncation']['returned_bytes'] && $raw['truncation']['returned_bytes'] <= 12000 );
 
-$binary = new DataPacket( array( 'body' => "image\0bytes" ), array( 'api_token' => 'secret-value' ), 'fetch' );
-$raw    = $format_raw->invoke( $ability, array( $binary ), 5, 10000 );
+$structured = sanitize_test_handler_value(
+	$ability,
+	array(
+		'api_key'   => 'credential-value',
+		'author'    => 'Token Adams',
+		'secretary' => 'The Secretary',
+		'note'      => 'Token prose is legitimate event content.',
+	)
+);
+assert_test_handler_raw( 'exact credential key is redacted', '[redacted]' === $structured['output']['api_key'] );
+assert_test_handler_raw( 'author and secretary false positives are retained', 'Token Adams' === $structured['output']['author'] && 'The Secretary' === $structured['output']['secretary'] );
+assert_test_handler_raw( 'ordinary Token prose is never rewritten', 'Token prose is legitimate event content.' === $structured['output']['note'] );
 
-assert_test_handler_raw( 'binary content follows omission policy', '[binary omitted]' === $raw['packets'][0]['data']['body'] );
-assert_test_handler_raw( 'secret-bearing fields are redacted', '[redacted]' === $raw['packets'][0]['metadata']['api_token'] );
-assert_test_handler_raw( 'binary and redacted paths are declared', ! empty( $raw['truncation']['binary_fields'] ) && ! empty( $raw['truncation']['redacted_fields'] ) );
+$resource = fopen( 'php://memory', 'r' );
+$unsafe   = sanitize_test_handler_value(
+	$ability,
+	array(
+		'binary'      => "image\0bytes",
+		'invalid'     => "bad\xB1utf8",
+		'resource'    => $resource,
+		'object'      => new stdClass(),
+		'not_a_number' => INF,
+		"bad\xB1key" => 'value',
+	)
+);
+fclose( $resource );
+assert_test_handler_raw( 'binary, invalid UTF-8, resources, and objects are omitted', ! isset( $unsafe['output']['binary'], $unsafe['output']['invalid'], $unsafe['output']['resource'], $unsafe['output']['object'] ) );
+assert_test_handler_raw( 'invalid keys and json_encode failures are omitted', ! isset( $unsafe['output']['not_a_number'] ) && 0 === count( array_filter( array_keys( $unsafe['output'] ), static fn ( $key ) => ! mb_check_encoding( (string) $key, 'UTF-8' ) ) ) );
+assert_test_handler_raw( 'all unsafe omissions are explicitly reported', $unsafe['report']['omitted_field_count'] >= 6 && in_array( 'binary_content', $unsafe['report']['reasons'], true ) && in_array( 'invalid_utf8', $unsafe['report']['reasons'], true ) && in_array( 'unsupported_type', $unsafe['report']['reasons'], true ) && in_array( 'json_encode_failure', $unsafe['report']['reasons'], true ) );
+assert_test_handler_raw( 'sanitized unsafe output always serializes', false !== json_encode( $unsafe['output'] ) );
 
-$secret_json = new DataPacket( array( 'body' => '{"event":"Show","api_token":"secret-value"}' ), array(), 'fetch' );
-$raw         = $format_raw->invoke( $ability, array( $secret_json ), 5, 10000 );
-$decoded     = json_decode( $raw['packets'][0]['data']['body'], true );
-assert_test_handler_raw( 'redacted JSON remains complete valid JSON', 'Show' === $decoded['event'] && '[redacted]' === $decoded['api_token'] );
+$multibyte = new DataPacket( array( 'title' => 'Emoji', 'body' => str_repeat( '🥶', 900 ) ), array(), 'fetch' );
+$raw       = build_test_handler_raw( $ability, array( $multibyte ), 5, 4096 );
+assert_test_handler_raw( 'multibyte packet is omitted whole at the boundary', array() === $raw['packets'] && in_array( 'byte_limit', $raw['truncation']['reasons'], true ) );
+assert_test_handler_raw( 'multibyte truncation response remains valid UTF-8 JSON under the complete-response cap', false !== json_encode( $raw, JSON_UNESCAPED_UNICODE ) && strlen( json_encode( $raw, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ) ) <= 4096 );
 
-$oversized = new DataPacket( array( 'body' => str_repeat( 'x', 500 ) ), array(), 'fetch' );
-$raw       = $format_raw->invoke( $ability, array( $oversized ), 5, 100 );
+$oversized = new DataPacket( array( 'body' => str_repeat( 'x', 20000 ) ), array(), 'fetch' );
+$raw       = build_test_handler_raw( $ability, array( $oversized ), 5, 4096, array( 'description' => str_repeat( 'c', 5000 ) ) );
+assert_test_handler_raw( 'oversized packet and config are omitted rather than partially copied', array() === $raw['packets'] && isset( $raw['config_used']['_omitted'] ) );
+assert_test_handler_raw( 'full response cap reports config and packet omissions', in_array( 'config_limit', $raw['truncation']['reasons'], true ) && in_array( 'byte_limit', $raw['truncation']['reasons'], true ) );
 
-assert_test_handler_raw( 'oversized packet is omitted rather than cut', array() === $raw['packets'] );
-assert_test_handler_raw( 'byte cap reports explicit truncation', in_array( 'byte_limit', $raw['truncation']['reasons'], true ) && 1 === $raw['truncation']['omitted_packet_count'] );
+$huge_body = str_repeat( 'z', 8 * 1024 * 1024 );
+$huge      = new DataPacket( array( 'body' => $huge_body ), array(), 'fetch' );
+if ( function_exists( 'memory_reset_peak_usage' ) ) {
+	memory_reset_peak_usage();
+}
+$memory_before = memory_get_usage( true );
+$raw           = build_test_handler_raw( $ability, array( $huge ), 5, 4096 );
+$peak_delta    = memory_get_peak_usage( true ) - $memory_before;
+assert_test_handler_raw( 'oversized body is rejected before full encoding or copying', array() === $raw['packets'] && $peak_delta < 4 * 1024 * 1024 );
+unset( $huge_body, $huge );
 
-$raw = $format_raw->invoke( $ability, $packets, 1, 10000 );
+$raw = build_test_handler_raw( $ability, $packets, 1, 12000 );
 assert_test_handler_raw( 'packet cap returns only complete packets', 1 === count( $raw['packets'] ) );
-assert_test_handler_raw( 'packet cap reports explicit truncation', in_array( 'packet_limit', $raw['truncation']['reasons'], true ) && 1 === $raw['truncation']['omitted_packet_count'] );
+assert_test_handler_raw( 'packet cap and materialization bound are explicit', in_array( 'packet_limit', $raw['truncation']['reasons'], true ) && true === $raw['truncation']['materialization_limited'] );
+
+$GLOBALS['datamachine_test_handlers'] = array(
+	'failure-stub' => array(
+		'label' => 'Failure Stub',
+		'class' => TestHandlerRawFailureStub::class,
+	),
+);
+$failure = $ability->execute(
+	array(
+		'handler_slug' => 'failure-stub',
+		'config'       => array( 'api_key' => 'credential-value' ),
+		'output_mode'  => 'raw',
+	)
+);
+assert_test_handler_raw( 'handler receives the real credential required for execution', 'credential-value' === TestHandlerRawFailureStub::$received_config['api_key'] );
+assert_test_handler_raw( 'raw execution bounds handler materialization through max_items', 5 === TestHandlerRawFailureStub::$received_config['max_items'] );
+assert_test_handler_raw( 'failure config is sanitized before execution output is built', '[redacted]' === $failure['config_used']['api_key'] );
+assert_test_handler_raw( 'failure message cannot echo applied credentials', 'Handler execution failed.' === $failure['error'] );
+
+$bounded_failure = $ability->execute(
+	array(
+		'handler_slug' => 'failure-stub',
+		'config'       => array( 'description' => str_repeat( 'x', 5000 ), 'api_key' => 'later-credential' ),
+		'output_mode'  => 'raw',
+		'byte_limit'   => 4096,
+	)
+);
+assert_test_handler_raw( 'oversized failure config is replaced before handler execution returns', 'byte_limit' === $bounded_failure['config_used']['_omitted'] );
+assert_test_handler_raw( 'failure stays credential-safe when a secret follows oversized config', 'Handler execution failed.' === $bounded_failure['error'] && ! str_contains( json_encode( $bounded_failure ), 'later-credential' ) );
 
 $command = file_get_contents( dirname( __DIR__ ) . '/inc/Cli/Commands/TestCommand.php' ) ?: '';
-assert_test_handler_raw( 'CLI adapter maps --raw to output_mode', str_contains( $command, "\$input['output_mode'] = 'raw';" ) );
-assert_test_handler_raw( 'CLI adapter forwards --byte-limit', str_contains( $command, "\$input['byte_limit'] = \$byte_limit;" ) );
-assert_test_handler_raw( 'CLI adapter renders raw mode as JSON', str_contains( $command, "\$raw && 'table' === \$format" ) );
+assert_test_handler_raw( 'CLI adapter maps --raw and --byte-limit', str_contains( $command, "\$input['output_mode'] = 'raw';" ) && str_contains( $command, "\$input['byte_limit'] = \$byte_limit;" ) );
+assert_test_handler_raw( 'every explicit raw CLI format emits JSON', str_contains( $command, "if ( \$raw ) {\n\t\t\t\$format = 'json';" ) );
 
 $ability_source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/Handler/TestHandlerAbility.php' ) ?: '';
-assert_test_handler_raw( 'ability schema declares raw mode and truncation contract', str_contains( $ability_source, "'output_mode'" ) && str_contains( $ability_source, "'truncation'" ) && str_contains( $ability_source, "'byte_limit'" ) );
+assert_test_handler_raw( 'schema discriminates failure, compact, and raw output', str_contains( $ability_source, "'oneOf'" ) && str_contains( $ability_source, "array( 'compact' )" ) && str_contains( $ability_source, "array( 'raw' )" ) );
+assert_test_handler_raw( 'input schema remains extensible', ! str_contains( substr( $ability_source, strpos( $ability_source, "'input_schema'" ), 500 ), "'additionalProperties' => false" ) );
 assert_test_handler_raw( 'direct execution remains lifecycle-read-only', str_contains( $ability_source, "get_fetch_data( 'direct', \$config, null )" ) );
 
 if ( $failed > 0 ) {

--- a/tests/test-handler-raw-output-smoke.php
+++ b/tests/test-handler-raw-output-smoke.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
 }
 
-require_once __DIR__ . '/fixtures/namespaced-wp-fn-stubs.php';
+require_once __DIR__ . '/fixtures/test-handler-wp-fn-stubs.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityRegistration.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/HandlerAbilities.php';
 require_once dirname( __DIR__ ) . '/inc/Core/DataPacket.php';
@@ -71,6 +71,12 @@ function build_test_handler_raw( object $ability, array $packets, int $packet_li
 	return invoke_test_handler_private( $ability, 'buildRawResponse', array( $packets, $packet_limit, $byte_limit, $base, $sanitized['report'], true ) );
 }
 
+function test_handler_transport_size( array $response ): int {
+	$rest = json_encode( $response );
+	$cli  = json_encode( $response, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+	return max( strlen( $rest ), strlen( $cli ) + 1 );
+}
+
 echo "=== test-handler-raw-output-smoke ===\n";
 
 $reflection = new ReflectionClass( TestHandlerAbility::class );
@@ -102,7 +108,27 @@ $raw = build_test_handler_raw( $ability, $packets, 5, 12000 );
 assert_test_handler_raw( 'events-shaped JSON body round-trips byte-for-byte', $event_json === $raw['packets'][0]['data']['body'] );
 assert_test_handler_raw( 'raw HTML and ordinary Token prose remain unchanged', $event_html === $raw['packets'][1]['data']['body'] );
 assert_test_handler_raw( 'events-shaped structured venue metadata is retained', 'Charleston' === $raw['packets'][0]['data']['venue']['city'] );
-assert_test_handler_raw( 'complete response byte count is exact and within limit', strlen( json_encode( $raw, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ) ) === $raw['truncation']['returned_bytes'] && $raw['truncation']['returned_bytes'] <= 12000 );
+assert_test_handler_raw( 'complete response byte count is exact and within limit', test_handler_transport_size( $raw ) === $raw['truncation']['returned_bytes'] && $raw['truncation']['returned_bytes'] <= 12000 );
+
+$nested = array();
+for ( $index = 0; $index < 35; ++$index ) {
+	$nested[ 'item_' . $index ] = array( 'venue' => 'Royal American', 'city' => 'Charleston', 'date' => '2026-08-01' );
+}
+$nested_packet = new DataPacket( array( 'title' => 'Nested expansion', 'body' => $nested ), array(), 'fetch' );
+$nested_probe  = build_test_handler_raw( $ability, array( $nested_packet ), 5, 65536 );
+$nested_min    = strlen( json_encode( $nested_probe, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ) );
+$nested_pretty = strlen( json_encode( $nested_probe, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ) + 1;
+assert_test_handler_raw( 'nested probe reproduces minified-under/pretty-over transport expansion', $nested_min < 4096 && $nested_pretty > 4096 );
+$nested_bounded = build_test_handler_raw( $ability, array( $nested_packet ), 5, 4096 );
+assert_test_handler_raw( 'nested probe emitted response fits both actual transports', test_handler_transport_size( $nested_bounded ) <= 4096 && array() === $nested_bounded['packets'] );
+
+$emoji_packet = new DataPacket( array( 'title' => 'Emoji expansion', 'body' => str_repeat( '🥶', 300 ) ), array(), 'fetch' );
+$emoji_probe  = build_test_handler_raw( $ability, array( $emoji_packet ), 5, 12000 );
+$emoji_min    = strlen( json_encode( $emoji_probe, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ) );
+$emoji_rest   = strlen( json_encode( $emoji_probe ) );
+assert_test_handler_raw( '300-emoji probe reproduces canonical-under/REST-over expansion', $emoji_min < 4096 && $emoji_rest > 4096 );
+$emoji_bounded = build_test_handler_raw( $ability, array( $emoji_packet ), 5, 4096 );
+assert_test_handler_raw( '300-emoji probe emitted response fits REST and CLI transports', test_handler_transport_size( $emoji_bounded ) <= 4096 && array() === $emoji_bounded['packets'] );
 
 $structured = sanitize_test_handler_value(
 	$ability,
@@ -138,7 +164,7 @@ assert_test_handler_raw( 'sanitized unsafe output always serializes', false !== 
 $multibyte = new DataPacket( array( 'title' => 'Emoji', 'body' => str_repeat( '🥶', 900 ) ), array(), 'fetch' );
 $raw       = build_test_handler_raw( $ability, array( $multibyte ), 5, 4096 );
 assert_test_handler_raw( 'multibyte packet is omitted whole at the boundary', array() === $raw['packets'] && in_array( 'byte_limit', $raw['truncation']['reasons'], true ) );
-assert_test_handler_raw( 'multibyte truncation response remains valid UTF-8 JSON under the complete-response cap', false !== json_encode( $raw, JSON_UNESCAPED_UNICODE ) && strlen( json_encode( $raw, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ) ) <= 4096 );
+assert_test_handler_raw( 'multibyte truncation response remains valid UTF-8 JSON under the complete-response cap', false !== json_encode( $raw, JSON_UNESCAPED_UNICODE ) && test_handler_transport_size( $raw ) <= 4096 );
 
 $oversized = new DataPacket( array( 'body' => str_repeat( 'x', 20000 ) ), array(), 'fetch' );
 $raw       = build_test_handler_raw( $ability, array( $oversized ), 5, 4096, array( 'description' => str_repeat( 'c', 5000 ) ) );

--- a/tests/test-handler-raw-output-smoke.php
+++ b/tests/test-handler-raw-output-smoke.php
@@ -16,6 +16,7 @@ require_once dirname( __DIR__ ) . '/inc/Core/DataPacket.php';
 require_once dirname( __DIR__ ) . '/inc/Abilities/Handler/TestHandlerAbility.php';
 
 use DataMachine\Abilities\Handler\TestHandlerAbility;
+use DataMachine\Abilities\HandlerAbilities;
 use DataMachine\Core\DataPacket;
 
 class TestHandlerRawFailureStub {
@@ -23,7 +24,8 @@ class TestHandlerRawFailureStub {
 
 	public function get_fetch_data( $pipeline_id, array $config, $job_id ): array {
 		self::$received_config = $config;
-		throw new RuntimeException( 'Request failed with credential ' . $config['api_key'] );
+		$credential_values     = array_intersect_key( $config, array_flip( array( 'imap_password', 'api_secret', 'access_token_v2' ) ) );
+		throw new RuntimeException( 'Request failed with credentials ' . implode( ' ', $credential_values ) );
 	}
 }
 
@@ -60,7 +62,7 @@ function build_test_handler_raw( object $ability, array $packets, int $packet_li
 		$sanitized['output'] = array( '_omitted' => 'byte_limit' );
 		invoke_test_handler_private( $ability, 'recordOmission', array( &$sanitized['report'], 'config', 'config_limit' ) );
 	}
-	$base      = array(
+	$base = array(
 		'success'           => true,
 		'handler_slug'      => 'events-shaped',
 		'handler_label'     => 'Events Shaped',
@@ -84,7 +86,14 @@ $ability    = $reflection->newInstanceWithoutConstructor();
 $summarize  = $reflection->getMethod( 'summarizePacket' );
 
 $long_body = str_repeat( 'a', 220 );
-$packet    = new DataPacket( array( 'title' => 'Preview', 'body' => $long_body ), array( 'source_url' => 'https://example.com/item' ), 'fetch' );
+$packet    = new DataPacket(
+	array(
+		'title' => 'Preview',
+		'body'  => $long_body,
+	),
+	array( 'source_url' => 'https://example.com/item' ),
+	'fetch'
+);
 $summary   = $summarize->invoke( $ability, $packet );
 assert_test_handler_raw( 'default summary retains compact keys', array( 'title', 'content_preview', 'metadata', 'source_url' ) === array_keys( $summary ) );
 assert_test_handler_raw( 'default summary retains 200-character preview behavior', str_repeat( 'a', 200 ) . '...' === $summary['content_preview'] );
@@ -96,25 +105,62 @@ $packets    = array(
 		array(
 			'title' => 'Events-shaped JSON',
 			'body'  => $event_json,
-			'venue' => array( 'name' => 'The Royal American', 'city' => 'Charleston' ),
+			'venue' => array(
+				'name' => 'The Royal American',
+				'city' => 'Charleston',
+			),
 		),
-		array( 'source_url' => 'https://events.example/show', 'event_id' => 42 ),
+		array(
+			'source_url' => 'https://events.example/show',
+			'event_id'   => 42,
+		),
 		'fetch'
 	),
-	new DataPacket( array( 'title' => 'HTML', 'body' => $event_html ), array(), 'fetch' ),
+	new DataPacket(
+		array(
+			'title' => 'HTML',
+			'body'  => $event_html,
+		),
+		array(),
+		'fetch'
+	),
+	new DataPacket(
+		array(
+			'title'           => 'Production credentials',
+			'imap_password'   => 'packet-imap-secret',
+			'api_secret'      => 'packet-api-secret',
+			'access_token_v2' => 'packet-access-token',
+			'clientSecret'    => 'packet-client-secret',
+		),
+		array( 'authorization_header' => 'packet-authorization' ),
+		'fetch'
+	),
 );
-$raw = build_test_handler_raw( $ability, $packets, 5, 12000 );
+$raw        = build_test_handler_raw( $ability, $packets, 5, 12000 );
 
 assert_test_handler_raw( 'events-shaped JSON body round-trips byte-for-byte', $event_json === $raw['packets'][0]['data']['body'] );
 assert_test_handler_raw( 'raw HTML and ordinary Token prose remain unchanged', $event_html === $raw['packets'][1]['data']['body'] );
 assert_test_handler_raw( 'events-shaped structured venue metadata is retained', 'Charleston' === $raw['packets'][0]['data']['venue']['city'] );
+assert_test_handler_raw( 'production packet credential keys are redacted', '[redacted]' === $raw['packets'][2]['data']['imap_password'] && '[redacted]' === $raw['packets'][2]['data']['api_secret'] && '[redacted]' === $raw['packets'][2]['data']['access_token_v2'] && '[redacted]' === $raw['packets'][2]['data']['clientSecret'] && '[redacted]' === $raw['packets'][2]['metadata']['authorization_header'] );
+assert_test_handler_raw( 'production packet credential values never serialize', ! str_contains( json_encode( $raw ), 'packet-imap-secret' ) && ! str_contains( json_encode( $raw ), 'packet-api-secret' ) && ! str_contains( json_encode( $raw ), 'packet-access-token' ) && ! str_contains( json_encode( $raw ), 'packet-client-secret' ) && ! str_contains( json_encode( $raw ), 'packet-authorization' ) );
 assert_test_handler_raw( 'complete response byte count is exact and within limit', test_handler_transport_size( $raw ) === $raw['truncation']['returned_bytes'] && $raw['truncation']['returned_bytes'] <= 12000 );
 
 $nested = array();
 for ( $index = 0; $index < 35; ++$index ) {
-	$nested[ 'item_' . $index ] = array( 'venue' => 'Royal American', 'city' => 'Charleston', 'date' => '2026-08-01' );
+	$nested[ 'item_' . $index ] = array(
+		'venue' => 'Royal American',
+		'city'  => 'Charleston',
+		'date'  => '2026-08-01',
+	);
 }
-$nested_packet = new DataPacket( array( 'title' => 'Nested expansion', 'body' => $nested ), array(), 'fetch' );
+$nested_packet = new DataPacket(
+	array(
+		'title' => 'Nested expansion',
+		'body'  => $nested,
+	),
+	array(),
+	'fetch'
+);
 $nested_probe  = build_test_handler_raw( $ability, array( $nested_packet ), 5, 65536 );
 $nested_min    = strlen( json_encode( $nested_probe, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ) );
 $nested_pretty = strlen( json_encode( $nested_probe, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ) + 1;
@@ -122,7 +168,14 @@ assert_test_handler_raw( 'nested probe reproduces minified-under/pretty-over tra
 $nested_bounded = build_test_handler_raw( $ability, array( $nested_packet ), 5, 4096 );
 assert_test_handler_raw( 'nested probe emitted response fits both actual transports', test_handler_transport_size( $nested_bounded ) <= 4096 && array() === $nested_bounded['packets'] );
 
-$emoji_packet = new DataPacket( array( 'title' => 'Emoji expansion', 'body' => str_repeat( '🥶', 300 ) ), array(), 'fetch' );
+$emoji_packet = new DataPacket(
+	array(
+		'title' => 'Emoji expansion',
+		'body'  => str_repeat( '🥶', 300 ),
+	),
+	array(),
+	'fetch'
+);
 $emoji_probe  = build_test_handler_raw( $ability, array( $emoji_packet ), 5, 12000 );
 $emoji_min    = strlen( json_encode( $emoji_probe, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ) );
 $emoji_rest   = strlen( json_encode( $emoji_probe ) );
@@ -133,26 +186,45 @@ assert_test_handler_raw( '300-emoji probe emitted response fits REST and CLI tra
 $structured = sanitize_test_handler_value(
 	$ability,
 	array(
-		'api_key'   => 'credential-value',
-		'author'    => 'Token Adams',
-		'secretary' => 'The Secretary',
-		'note'      => 'Token prose is legitimate event content.',
+		'api_key'         => 'credential-value',
+		'imap_password'   => 'imap-value',
+		'api_secret'      => 'secret-value',
+		'access_token_v2' => 'token-value',
+		'clientSecret'    => 'client-secret-value',
+		'author'          => 'Token Adams',
+		'secretary'       => 'The Secretary',
+		'note'            => 'Token prose is legitimate event content.',
 	)
 );
 assert_test_handler_raw( 'exact credential key is redacted', '[redacted]' === $structured['output']['api_key'] );
+assert_test_handler_raw( 'compound and camel-case credential keys are redacted', '[redacted]' === $structured['output']['imap_password'] && '[redacted]' === $structured['output']['api_secret'] && '[redacted]' === $structured['output']['access_token_v2'] && '[redacted]' === $structured['output']['clientSecret'] );
 assert_test_handler_raw( 'author and secretary false positives are retained', 'Token Adams' === $structured['output']['author'] && 'The Secretary' === $structured['output']['secretary'] );
 assert_test_handler_raw( 'ordinary Token prose is never rewritten', 'Token prose is legitimate event content.' === $structured['output']['note'] );
+
+$config_raw = build_test_handler_raw(
+	$ability,
+	array(),
+	5,
+	12000,
+	array(
+		'imap_password'   => 'config-imap-secret',
+		'api_secret'      => 'config-api-secret',
+		'access_token_v2' => 'config-access-token',
+	)
+);
+assert_test_handler_raw( 'successful raw config redacts production credential keys', '[redacted]' === $config_raw['config_used']['imap_password'] && '[redacted]' === $config_raw['config_used']['api_secret'] && '[redacted]' === $config_raw['config_used']['access_token_v2'] );
+assert_test_handler_raw( 'successful raw config never serializes production credential values', ! str_contains( json_encode( $config_raw ), 'config-imap-secret' ) && ! str_contains( json_encode( $config_raw ), 'config-api-secret' ) && ! str_contains( json_encode( $config_raw ), 'config-access-token' ) );
 
 $resource = fopen( 'php://memory', 'r' );
 $unsafe   = sanitize_test_handler_value(
 	$ability,
 	array(
-		'binary'      => "image\0bytes",
-		'invalid'     => "bad\xB1utf8",
-		'resource'    => $resource,
-		'object'      => new stdClass(),
+		'binary'       => "image\0bytes",
+		'invalid'      => "bad\xB1utf8",
+		'resource'     => $resource,
+		'object'       => new stdClass(),
 		'not_a_number' => INF,
-		"bad\xB1key" => 'value',
+		"bad\xB1key"   => 'value',
 	)
 );
 fclose( $resource );
@@ -161,7 +233,14 @@ assert_test_handler_raw( 'invalid keys and json_encode failures are omitted', ! 
 assert_test_handler_raw( 'all unsafe omissions are explicitly reported', $unsafe['report']['omitted_field_count'] >= 6 && in_array( 'binary_content', $unsafe['report']['reasons'], true ) && in_array( 'invalid_utf8', $unsafe['report']['reasons'], true ) && in_array( 'unsupported_type', $unsafe['report']['reasons'], true ) && in_array( 'json_encode_failure', $unsafe['report']['reasons'], true ) );
 assert_test_handler_raw( 'sanitized unsafe output always serializes', false !== json_encode( $unsafe['output'] ) );
 
-$multibyte = new DataPacket( array( 'title' => 'Emoji', 'body' => str_repeat( '🥶', 900 ) ), array(), 'fetch' );
+$multibyte = new DataPacket(
+	array(
+		'title' => 'Emoji',
+		'body'  => str_repeat( '🥶', 900 ),
+	),
+	array(),
+	'fetch'
+);
 $raw       = build_test_handler_raw( $ability, array( $multibyte ), 5, 4096 );
 assert_test_handler_raw( 'multibyte packet is omitted whole at the boundary', array() === $raw['packets'] && in_array( 'byte_limit', $raw['truncation']['reasons'], true ) );
 assert_test_handler_raw( 'multibyte truncation response remains valid UTF-8 JSON under the complete-response cap', false !== json_encode( $raw, JSON_UNESCAPED_UNICODE ) && test_handler_transport_size( $raw ) <= 4096 );
@@ -186,34 +265,55 @@ $raw = build_test_handler_raw( $ability, $packets, 1, 12000 );
 assert_test_handler_raw( 'packet cap returns only complete packets', 1 === count( $raw['packets'] ) );
 assert_test_handler_raw( 'packet cap and materialization bound are explicit', in_array( 'packet_limit', $raw['truncation']['reasons'], true ) && true === $raw['truncation']['materialization_limited'] );
 
-$GLOBALS['datamachine_test_handlers'] = array(
+$failure_handlers       = array(
 	'failure-stub' => array(
 		'label' => 'Failure Stub',
 		'class' => TestHandlerRawFailureStub::class,
 	),
 );
+$failure_handler_filter = static function ( array $handlers ) use ( $failure_handlers ): array {
+	return array_merge( $handlers, $failure_handlers );
+};
+if ( function_exists( 'add_filter' ) ) {
+	add_filter( 'datamachine_handlers', $failure_handler_filter, 10, 2 );
+	HandlerAbilities::clearCache();
+} else {
+	$GLOBALS['datamachine_test_handlers'] = $failure_handlers;
+}
 $failure = $ability->execute(
 	array(
 		'handler_slug' => 'failure-stub',
-		'config'       => array( 'api_key' => 'credential-value' ),
+		'config'       => array(
+			'imap_password'   => 'failure-imap-secret',
+			'api_secret'      => 'failure-api-secret',
+			'access_token_v2' => 'failure-access-token',
+		),
 		'output_mode'  => 'raw',
 	)
 );
-assert_test_handler_raw( 'handler receives the real credential required for execution', 'credential-value' === TestHandlerRawFailureStub::$received_config['api_key'] );
+assert_test_handler_raw( 'handler receives real production credentials required for execution', 'failure-imap-secret' === TestHandlerRawFailureStub::$received_config['imap_password'] && 'failure-api-secret' === TestHandlerRawFailureStub::$received_config['api_secret'] && 'failure-access-token' === TestHandlerRawFailureStub::$received_config['access_token_v2'] );
 assert_test_handler_raw( 'raw execution bounds handler materialization through max_items', 5 === TestHandlerRawFailureStub::$received_config['max_items'] );
-assert_test_handler_raw( 'failure config is sanitized before execution output is built', '[redacted]' === $failure['config_used']['api_key'] );
-assert_test_handler_raw( 'failure message cannot echo applied credentials', 'Handler execution failed.' === $failure['error'] );
+assert_test_handler_raw( 'failure config compound credentials are sanitized before output is built', '[redacted]' === $failure['config_used']['imap_password'] && '[redacted]' === $failure['config_used']['api_secret'] && '[redacted]' === $failure['config_used']['access_token_v2'] );
+assert_test_handler_raw( 'failure message cannot echo applied credentials', 'Handler execution failed.' === $failure['error'] && ! str_contains( json_encode( $failure ), 'failure-imap-secret' ) && ! str_contains( json_encode( $failure ), 'failure-api-secret' ) && ! str_contains( json_encode( $failure ), 'failure-access-token' ) );
 
 $bounded_failure = $ability->execute(
 	array(
 		'handler_slug' => 'failure-stub',
-		'config'       => array( 'description' => str_repeat( 'x', 5000 ), 'api_key' => 'later-credential' ),
+		'config'       => array(
+			'description' => str_repeat( 'x', 5000 ),
+			'api_key'     => 'later-credential',
+		),
 		'output_mode'  => 'raw',
 		'byte_limit'   => 4096,
 	)
 );
 assert_test_handler_raw( 'oversized failure config is replaced before handler execution returns', 'byte_limit' === $bounded_failure['config_used']['_omitted'] );
 assert_test_handler_raw( 'failure stays credential-safe when a secret follows oversized config', 'Handler execution failed.' === $bounded_failure['error'] && ! str_contains( json_encode( $bounded_failure ), 'later-credential' ) );
+
+if ( function_exists( 'remove_filter' ) ) {
+	remove_filter( 'datamachine_handlers', $failure_handler_filter, 10 );
+	HandlerAbilities::clearCache();
+}
 
 $command = file_get_contents( dirname( __DIR__ ) . '/inc/Cli/Commands/TestCommand.php' ) ?: '';
 assert_test_handler_raw( 'CLI adapter maps --raw and --byte-limit', str_contains( $command, "\$input['output_mode'] = 'raw';" ) && str_contains( $command, "\$input['byte_limit'] = \$byte_limit;" ) );

--- a/tests/test-handler-raw-output-smoke.php
+++ b/tests/test-handler-raw-output-smoke.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Pure-PHP contract tests for bounded raw test-handler output (#2946).
+ *
+ * Run with: php tests/test-handler-raw-output-smoke.php
+ */
+
+define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+
+require_once __DIR__ . '/fixtures/namespaced-wp-fn-stubs.php';
+require_once dirname( __DIR__ ) . '/inc/Core/DataPacket.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/Handler/TestHandlerAbility.php';
+
+use DataMachine\Abilities\Handler\TestHandlerAbility;
+use DataMachine\Core\DataPacket;
+
+$failed = 0;
+$total  = 0;
+
+function assert_test_handler_raw( string $name, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+
+	++$failed;
+	echo "  [FAIL] {$name}\n";
+}
+
+echo "=== test-handler-raw-output-smoke ===\n";
+
+$reflection = new ReflectionClass( TestHandlerAbility::class );
+$ability    = $reflection->newInstanceWithoutConstructor();
+$summarize  = $reflection->getMethod( 'summarizePacket' );
+$format_raw = $reflection->getMethod( 'formatRawPackets' );
+
+$long_body = str_repeat( 'a', 220 );
+$packet    = new DataPacket(
+	array(
+		'title' => 'Preview',
+		'body'  => $long_body,
+	),
+	array( 'source_url' => 'https://example.com/item' ),
+	'fetch'
+);
+$summary   = $summarize->invoke( $ability, $packet );
+
+assert_test_handler_raw( 'default summary retains compact keys', array( 'title', 'content_preview', 'metadata', 'source_url' ) === array_keys( $summary ) );
+assert_test_handler_raw( 'default summary retains 200-character preview behavior', str_repeat( 'a', 200 ) . '...' === $summary['content_preview'] );
+
+$json_body = '{"name":"Venue","nested":{"doors":"19:00"}}';
+$html_body = '<article><h1>Show</h1><p>Doors at 7 &amp; music at 8.</p></article>';
+$packets   = array(
+	new DataPacket( array( 'title' => 'JSON', 'body' => $json_body ), array(), 'fetch' ),
+	new DataPacket( array( 'title' => 'HTML', 'body' => $html_body ), array(), 'fetch' ),
+);
+$raw       = $format_raw->invoke( $ability, $packets, 5, 10000 );
+
+assert_test_handler_raw( 'valid JSON body round-trips as the original string', $json_body === $raw['packets'][0]['data']['body'] );
+assert_test_handler_raw( 'raw HTML round-trips as the original string', $html_body === $raw['packets'][1]['data']['body'] );
+assert_test_handler_raw( 'unbounded result reports no truncation', false === $raw['truncation']['truncated'] );
+
+$binary = new DataPacket( array( 'body' => "image\0bytes" ), array( 'api_token' => 'secret-value' ), 'fetch' );
+$raw    = $format_raw->invoke( $ability, array( $binary ), 5, 10000 );
+
+assert_test_handler_raw( 'binary content follows omission policy', '[binary omitted]' === $raw['packets'][0]['data']['body'] );
+assert_test_handler_raw( 'secret-bearing fields are redacted', '[redacted]' === $raw['packets'][0]['metadata']['api_token'] );
+assert_test_handler_raw( 'binary and redacted paths are declared', ! empty( $raw['truncation']['binary_fields'] ) && ! empty( $raw['truncation']['redacted_fields'] ) );
+
+$secret_json = new DataPacket( array( 'body' => '{"event":"Show","api_token":"secret-value"}' ), array(), 'fetch' );
+$raw         = $format_raw->invoke( $ability, array( $secret_json ), 5, 10000 );
+$decoded     = json_decode( $raw['packets'][0]['data']['body'], true );
+assert_test_handler_raw( 'redacted JSON remains complete valid JSON', 'Show' === $decoded['event'] && '[redacted]' === $decoded['api_token'] );
+
+$oversized = new DataPacket( array( 'body' => str_repeat( 'x', 500 ) ), array(), 'fetch' );
+$raw       = $format_raw->invoke( $ability, array( $oversized ), 5, 100 );
+
+assert_test_handler_raw( 'oversized packet is omitted rather than cut', array() === $raw['packets'] );
+assert_test_handler_raw( 'byte cap reports explicit truncation', in_array( 'byte_limit', $raw['truncation']['reasons'], true ) && 1 === $raw['truncation']['omitted_packet_count'] );
+
+$raw = $format_raw->invoke( $ability, $packets, 1, 10000 );
+assert_test_handler_raw( 'packet cap returns only complete packets', 1 === count( $raw['packets'] ) );
+assert_test_handler_raw( 'packet cap reports explicit truncation', in_array( 'packet_limit', $raw['truncation']['reasons'], true ) && 1 === $raw['truncation']['omitted_packet_count'] );
+
+$command = file_get_contents( dirname( __DIR__ ) . '/inc/Cli/Commands/TestCommand.php' ) ?: '';
+assert_test_handler_raw( 'CLI adapter maps --raw to output_mode', str_contains( $command, "\$input['output_mode'] = 'raw';" ) );
+assert_test_handler_raw( 'CLI adapter forwards --byte-limit', str_contains( $command, "\$input['byte_limit'] = \$byte_limit;" ) );
+assert_test_handler_raw( 'CLI adapter renders raw mode as JSON', str_contains( $command, "\$raw && 'table' === \$format" ) );
+
+$ability_source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/Handler/TestHandlerAbility.php' ) ?: '';
+assert_test_handler_raw( 'ability schema declares raw mode and truncation contract', str_contains( $ability_source, "'output_mode'" ) && str_contains( $ability_source, "'truncation'" ) && str_contains( $ability_source, "'byte_limit'" ) );
+assert_test_handler_raw( 'direct execution remains lifecycle-read-only', str_contains( $ability_source, "get_fetch_data( 'direct', \$config, null )" ) );
+
+if ( $failed > 0 ) {
+	echo "\ntest-handler-raw-output-smoke failed: {$failed}/{$total} assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\ntest-handler-raw-output-smoke passed: {$total} assertions.\n";


### PR DESCRIPTION
## Summary
- add an explicit `output_mode=raw` contract to `datamachine/test-handler` while preserving the default compact preview shape
- return complete text/JSON packet envelopes within declared packet and byte caps, with whole-packet truncation metadata and binary/secret redaction reporting
- expose raw mode through `wp datamachine test --raw --byte-limit=<bytes>` and cover compact compatibility, JSON/HTML, caps, binary/redaction, schemas, lifecycle safety, and CLI mapping

## Verification
- `php tests/test-handler-raw-output-smoke.php` (18 passed)
- `php tests/fetch-test-cli-smoke.php` (7 passed)
- `php tests/prefix-policy-audit.php` (11 passed)
- `composer lint` (passed)
- `homeboy review ... audit` run `a4b98d23-727e-4ce1-8d9c-c70e995bcbf1` (no findings in changed runtime/CLI/new test files; repository baseline remains at 50 existing outliers)
- full Homeboy WordPress test run `9cee4640-03a1-4447-b34e-25abefab8138` could not bootstrap because the shared Codebox Composer autoloader references a missing generated class
- repository smoke sweep reached the existing `abilities-send-email-load-order-smoke.php` failure before completing

Consumer: Extra-Chill/data-machine-events#188

Fixes #2946