### PR TITLE
fix: redact nested settings credentials

### DIFF
--- a/inc/Cli/Commands/SettingsCommand.php
+++ b/inc/Cli/Commands/SettingsCommand.php
@@ -237,76 +237,7 @@ class SettingsCommand extends BaseCommand {
 	 * @return mixed Redacted or raw value.
 	 */
 	public static function redactSecretsForDisplay( string $key, mixed $value, bool $reveal = false ): mixed {
-		if ( $reveal ) {
-			return $value;
-		}
-
-		if ( self::isSecretKey( $key ) ) {
-			return self::redactedValue( $value );
-		}
-
-		if ( is_array( $value ) ) {
-			$redacted = array();
-			foreach ( $value as $nested_key => $nested_value ) {
-				$redacted[ $nested_key ] = self::redactSecretsForDisplay( (string) $nested_key, $nested_value, false );
-			}
-			return $redacted;
-		}
-
-		return $value;
-	}
-
-	private static function isSecretKey( string $key ): bool {
-		$normalized = strtolower( $key );
-		if ( 'github_pat' === $normalized ) {
-			return true;
-		}
-
-		$needles = array(
-			'api_key',
-			'app_private_key',
-			'authorization',
-			'bearer',
-			'client_secret',
-			'cookie',
-			'password',
-			'private_key',
-			'refresh_token',
-			'secret',
-			'token',
-		);
-
-		if ( 'key' === $normalized || str_ends_with( $normalized, '_key' ) ) {
-			return true;
-		}
-
-		foreach ( $needles as $needle ) {
-			if ( str_contains( $normalized, $needle ) ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	private static function redactedValue( mixed $value ): mixed {
-		if ( is_array( $value ) ) {
-			$redacted = array();
-			foreach ( $value as $key => $nested_value ) {
-				$redacted[ $key ] = self::redactedValue( $nested_value );
-			}
-			return $redacted;
-		}
-
-		if ( is_object( $value ) ) {
-			return '[redacted]';
-		}
-
-		if ( null === $value || '' === $value ) {
-			return $value;
-		}
-
-		return '[redacted]';
+		return PluginSettings::redactForDisplay( $key, $value, $reveal );
 	}
 
 	private function format_setting_value( string $key, mixed $value ): string {

--- a/inc/Core/PluginSettings.php
+++ b/inc/Core/PluginSettings.php
@@ -174,11 +174,15 @@ class PluginSettings {
 		$normalized = strtolower( $normalized );
 		$normalized = trim( preg_replace( '/[^a-z0-9]+/', '_', $normalized ) ?? $normalized, '_' );
 
-		if ( 1 === preg_match( '/(?:^|_)(?:access_|refresh_)?tokens?_(?:expires_at|expires|expiry|expiration|ttl|type)$/', $normalized ) ) {
+		if ( 1 === preg_match( '/^(?:access_|refresh_)?tokens?_(?:expires_at|expires|expiry|expiration|ttl|type)$/', $normalized ) ) {
 			return false;
 		}
 
-		if ( 1 === preg_match( '/(?:^|_)credential_(?:id|label|mode|profile_id|profiles?)$/', $normalized ) ) {
+		if ( 1 === preg_match( '/^credential_(?:id|label|mode|profile_id)$/', $normalized ) ) {
+			return false;
+		}
+
+		if ( 1 === preg_match( '/^(?:[a-z0-9]+_)*credential_profiles$/', $normalized ) ) {
 			return false;
 		}
 
@@ -187,7 +191,7 @@ class PluginSettings {
 		}
 
 		return 1 === preg_match(
-			'/(?:^|_)(?:authorization|bearer|cookie|credential|password|pat|secret|tokens?)(?:_|$)/',
+			'/(?:^|_)(?:auth|authentication|authorization|oauth|api_?key|private_key|signing_key|secret_key|access_key|bearer|cookie|passwd|password|passphrase|pat|secret|tokens?|credentials?)(?:_|$)/',
 			$normalized
 		);
 	}

--- a/inc/Core/PluginSettings.php
+++ b/inc/Core/PluginSettings.php
@@ -101,6 +101,103 @@ class PluginSettings {
 	}
 
 	/**
+	 * Redact secret-bearing settings recursively for presentation.
+	 *
+	 * Stored values are never changed. Secret keys use bounded credential-name
+	 * patterns while arrays and objects retain their serializable structure.
+	 *
+	 * @param string $key    Setting key.
+	 * @param mixed  $value  Setting value.
+	 * @param bool   $reveal Whether to reveal raw values.
+	 * @return mixed Redacted or raw value.
+	 */
+	public static function redactForDisplay( string $key, mixed $value, bool $reveal = false ): mixed {
+		if ( $reveal ) {
+			return $value;
+		}
+
+		if ( self::isSecretKey( $key ) ) {
+			return self::redactedValue( $value );
+		}
+
+		if ( is_array( $value ) ) {
+			$redacted = array();
+			foreach ( $value as $nested_key => $nested_value ) {
+				$redacted[ $nested_key ] = self::redactForDisplay( (string) $nested_key, $nested_value );
+			}
+			return $redacted;
+		}
+
+		if ( is_object( $value ) ) {
+			$redacted = new \stdClass();
+			foreach ( get_object_vars( $value ) as $nested_key => $nested_value ) {
+				$redacted->{$nested_key} = self::redactForDisplay( (string) $nested_key, $nested_value );
+			}
+			return $redacted;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Determine whether a setting key conventionally contains a credential.
+	 */
+	private static function isSecretKey( string $key ): bool {
+		$normalized = strtolower( trim( $key ) );
+		$normalized = preg_replace( '/[^a-z0-9]+/', '_', $normalized ) ?? $normalized;
+
+		if ( 'key' === $normalized || str_ends_with( $normalized, '_key' ) ) {
+			return true;
+		}
+
+		$secret_suffixes = array(
+			'authorization',
+			'bearer',
+			'cookie',
+			'credential',
+			'password',
+			'pat',
+			'secret',
+			'token',
+		);
+
+		foreach ( $secret_suffixes as $suffix ) {
+			if ( $suffix === $normalized || str_ends_with( $normalized, '_' . $suffix ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Replace every populated leaf beneath a secret key.
+	 */
+	private static function redactedValue( mixed $value ): mixed {
+		if ( is_array( $value ) ) {
+			$redacted = array();
+			foreach ( $value as $key => $nested_value ) {
+				$redacted[ $key ] = self::redactedValue( $nested_value );
+			}
+			return $redacted;
+		}
+
+		if ( is_object( $value ) ) {
+			$redacted = new \stdClass();
+			foreach ( get_object_vars( $value ) as $key => $nested_value ) {
+				$redacted->{$key} = self::redactedValue( $nested_value );
+			}
+			return $redacted;
+		}
+
+		if ( null === $value || '' === $value ) {
+			return $value;
+		}
+
+		return '[redacted]';
+	}
+
+	/**
 	 * Get a specific per-site setting value (no cascade).
 	 *
 	 * @param string $key     Setting key

--- a/inc/Core/PluginSettings.php
+++ b/inc/Core/PluginSettings.php
@@ -116,23 +116,50 @@ class PluginSettings {
 			return $value;
 		}
 
+		return self::redactForDisplayRecursive( $key, $value, new \SplObjectStorage(), 0 );
+	}
+
+	/**
+	 * Recursively redact settings with cycle and depth protection.
+	 */
+	private static function redactForDisplayRecursive( string $key, mixed $value, \SplObjectStorage $seen, int $depth ): mixed {
 		if ( self::isSecretKey( $key ) ) {
 			return self::redactedValue( $value );
+		}
+
+		if ( $depth >= 32 ) {
+			return '[redacted]';
 		}
 
 		if ( is_array( $value ) ) {
 			$redacted = array();
 			foreach ( $value as $nested_key => $nested_value ) {
-				$redacted[ $nested_key ] = self::redactForDisplay( (string) $nested_key, $nested_value );
+				$redacted[ $nested_key ] = self::redactForDisplayRecursive(
+					(string) $nested_key,
+					$nested_value,
+					$seen,
+					$depth + 1
+				);
 			}
 			return $redacted;
 		}
 
 		if ( is_object( $value ) ) {
+			if ( $seen->contains( $value ) ) {
+				return '[redacted]';
+			}
+
+			$seen->attach( $value );
 			$redacted = new \stdClass();
 			foreach ( get_object_vars( $value ) as $nested_key => $nested_value ) {
-				$redacted->{$nested_key} = self::redactForDisplay( (string) $nested_key, $nested_value );
+				$redacted->{$nested_key} = self::redactForDisplayRecursive(
+					(string) $nested_key,
+					$nested_value,
+					$seen,
+					$depth + 1
+				);
 			}
+			$seen->detach( $value );
 			return $redacted;
 		}
 
@@ -143,55 +170,38 @@ class PluginSettings {
 	 * Determine whether a setting key conventionally contains a credential.
 	 */
 	private static function isSecretKey( string $key ): bool {
-		$normalized = strtolower( trim( $key ) );
-		$normalized = preg_replace( '/[^a-z0-9]+/', '_', $normalized ) ?? $normalized;
+		$normalized = preg_replace( '/([a-z0-9])([A-Z])/', '$1_$2', trim( $key ) ) ?? $key;
+		$normalized = strtolower( $normalized );
+		$normalized = trim( preg_replace( '/[^a-z0-9]+/', '_', $normalized ) ?? $normalized, '_' );
+
+		if ( 1 === preg_match( '/(?:^|_)(?:access_|refresh_)?tokens?_(?:expires_at|expires|expiry|expiration|ttl|type)$/', $normalized ) ) {
+			return false;
+		}
+
+		if ( 1 === preg_match( '/(?:^|_)credential_(?:id|label|mode|profile_id|profiles?)$/', $normalized ) ) {
+			return false;
+		}
 
 		if ( 'key' === $normalized || str_ends_with( $normalized, '_key' ) ) {
 			return true;
 		}
 
-		$secret_suffixes = array(
-			'authorization',
-			'bearer',
-			'cookie',
-			'credential',
-			'password',
-			'pat',
-			'secret',
-			'token',
+		return 1 === preg_match(
+			'/(?:^|_)(?:authorization|bearer|cookie|credential|password|pat|secret|tokens?)(?:_|$)/',
+			$normalized
 		);
-
-		foreach ( $secret_suffixes as $suffix ) {
-			if ( $suffix === $normalized || str_ends_with( $normalized, '_' . $suffix ) ) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	/**
-	 * Replace every populated leaf beneath a secret key.
+	 * Collapse a recognized secret value so container keys cannot leak.
 	 */
 	private static function redactedValue( mixed $value ): mixed {
-		if ( is_array( $value ) ) {
-			$redacted = array();
-			foreach ( $value as $key => $nested_value ) {
-				$redacted[ $key ] = self::redactedValue( $nested_value );
-			}
-			return $redacted;
-		}
-
-		if ( is_object( $value ) ) {
-			$redacted = new \stdClass();
-			foreach ( get_object_vars( $value ) as $key => $nested_value ) {
-				$redacted->{$key} = self::redactedValue( $nested_value );
-			}
-			return $redacted;
-		}
-
-		if ( null === $value || '' === $value ) {
+		if ( null === $value || '' === $value || array() === $value ) {
 			return $value;
+		}
+
+		if ( is_object( $value ) && array() === get_object_vars( $value ) ) {
+			return new \stdClass();
 		}
 
 		return '[redacted]';

--- a/tests/Unit/Cli/Commands/SettingsCommandTest.php
+++ b/tests/Unit/Cli/Commands/SettingsCommandTest.php
@@ -78,8 +78,8 @@ class SettingsCommandTest extends WP_UnitTestCase {
 			),
 		);
 
-		$redacted = \DataMachine\Cli\Commands\SettingsCommand::redactSecretsForDisplay( 'credentials', $settings );
-		$revealed = \DataMachine\Cli\Commands\SettingsCommand::redactSecretsForDisplay( 'credentials', $settings, true );
+		$redacted = \DataMachine\Cli\Commands\SettingsCommand::redactSecretsForDisplay( 'github_credential_profiles', $settings );
+		$revealed = \DataMachine\Cli\Commands\SettingsCommand::redactSecretsForDisplay( 'github_credential_profiles', $settings, true );
 
 		$this->assertSame( 'Visible profile', $redacted['profiles'][0]['label'] );
 		$this->assertTrue( '[redacted]' === $redacted['profiles'][0]['pat'], 'Command output should redact nested PATs.' );

--- a/tests/Unit/Cli/Commands/SettingsCommandTest.php
+++ b/tests/Unit/Cli/Commands/SettingsCommandTest.php
@@ -68,6 +68,27 @@ class SettingsCommandTest extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_presentation_entry_point_redacts_nested_values_and_honors_reveal(): void {
+		$settings = array(
+			'profiles' => array(
+				array(
+					'label' => 'Visible profile',
+					'pat'   => 'SENTINEL_COMMAND_PAT',
+				),
+			),
+		);
+
+		$redacted = \DataMachine\Cli\Commands\SettingsCommand::redactSecretsForDisplay( 'credentials', $settings );
+		$revealed = \DataMachine\Cli\Commands\SettingsCommand::redactSecretsForDisplay( 'credentials', $settings, true );
+
+		$this->assertSame( 'Visible profile', $redacted['profiles'][0]['label'] );
+		$this->assertTrue( '[redacted]' === $redacted['profiles'][0]['pat'], 'Command output should redact nested PATs.' );
+		$this->assertTrue(
+			'SENTINEL_COMMAND_PAT' === $revealed['profiles'][0]['pat'],
+			'The explicit reveal flag should preserve nested values.'
+		);
+	}
+
 	public function test_get_settings_returns_settings(): void {
 		$ability = wp_get_ability( 'datamachine/get-settings' );
 		$this->assertNotNull( $ability );

--- a/tests/Unit/Core/PluginSettingsTest.php
+++ b/tests/Unit/Core/PluginSettingsTest.php
@@ -52,7 +52,7 @@ class PluginSettingsTest extends WP_UnitTestCase {
 					'pat'           => 'SENTINEL_NESTED_PAT',
 					'repositories'  => array( 'owner/repository' ),
 					'credential_id' => 'credential-1',
-					'credentials'   => (object) array(
+					'profile_data'  => (object) array(
 						'private_key'         => 'SENTINEL_PRIVATE_KEY',
 						'client_secret'       => 'SENTINEL_CLIENT_SECRET',
 						'access_token'        => 'SENTINEL_ACCESS_TOKEN',
@@ -63,11 +63,21 @@ class PluginSettingsTest extends WP_UnitTestCase {
 						'secret_value'        => 'SENTINEL_SECRET_VALUE',
 						'credential_data'     => 'SENTINEL_CREDENTIAL_DATA',
 						'access_tokens'       => array( 'SENTINEL_ACCESS_TOKENS' ),
-						'clientSecret'        => 'SENTINEL_CAMEL_CLIENT_SECRET',
-						'apiKey'              => 'SENTINEL_CAMEL_API_KEY',
-						'secret_map'          => array( 'SENTINEL_SECRET_MAP_KEY' => 'value' ),
-						'token_expires_at'    => 1234567890,
+						'clientSecret'           => 'SENTINEL_CAMEL_CLIENT_SECRET',
+						'apiKey'                 => 'SENTINEL_CAMEL_API_KEY',
+						'apikey'                 => 'SENTINEL_APIKEY_ALIAS',
+						'api_key_value'          => 'SENTINEL_API_KEY_VALUE',
+						'passwd'                 => 'SENTINEL_PASSWD_ALIAS',
+						'auth'                   => 'SENTINEL_AUTH_ALIAS',
+						'authentication'         => 'SENTINEL_AUTHENTICATION_ALIAS',
+						'private_key_passphrase' => 'SENTINEL_PRIVATE_KEY_PASSPHRASE',
+						'signing_key_value'      => 'SENTINEL_SIGNING_KEY_VALUE',
+						'secret_map'             => array( 'SENTINEL_SECRET_MAP_KEY' => 'value' ),
+						'token_expires_at'       => 1234567890,
+						'token_type'             => 'Bearer',
 					),
+					'credentials'        => (object) array( 'value' => 'SENTINEL_GENERIC_CREDENTIALS_OBJECT' ),
+					'backup_credentials' => array( 'value' => 'SENTINEL_GENERIC_CREDENTIALS_MAP' ),
 				),
 			),
 			'enabled'                    => true,
@@ -77,7 +87,7 @@ class PluginSettingsTest extends WP_UnitTestCase {
 
 		$redacted    = PluginSettings::redactForDisplay( '', PluginSettings::all() );
 		$profile     = $redacted['github_credential_profiles'][0];
-		$credentials = $profile['credentials'];
+		$credentials = $profile['profile_data'];
 
 		$this->assertTrue( '[redacted]' === $redacted['github_pat'], 'Top-level PAT should be redacted.' );
 		$this->assertTrue( '[redacted]' === $profile['pat'], 'Nested profile PAT should be redacted.' );
@@ -93,13 +103,23 @@ class PluginSettingsTest extends WP_UnitTestCase {
 		$this->assertTrue( '[redacted]' === $credentials->access_tokens, 'Plural token variants should be redacted.' );
 		$this->assertTrue( '[redacted]' === $credentials->clientSecret, 'Camel-case client secrets should be redacted.' );
 		$this->assertTrue( '[redacted]' === $credentials->apiKey, 'Camel-case API keys should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->apikey, 'Compact API key aliases should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->api_key_value, 'API key value variants should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->passwd, 'Password aliases should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->auth, 'Auth aliases should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->authentication, 'Authentication aliases should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->private_key_passphrase, 'Private-key passphrases should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->signing_key_value, 'Signing-key variants should be redacted.' );
 		$this->assertTrue( '[redacted]' === $credentials->secret_map, 'Secret containers should collapse before map keys serialize.' );
+		$this->assertTrue( '[redacted]' === $profile['credentials'], 'Generic credential objects should collapse.' );
+		$this->assertTrue( '[redacted]' === $profile['backup_credentials'], 'Generic credential maps should collapse.' );
 		$this->assertSame( 'profile-1', $profile['id'] );
 		$this->assertSame( 'Release profile', $profile['label'] );
 		$this->assertSame( 'pat', $profile['mode'] );
 		$this->assertSame( array( 'owner/repository' ), $profile['repositories'] );
 		$this->assertSame( 'credential-1', $profile['credential_id'] );
 		$this->assertSame( 1234567890, $credentials->token_expires_at );
+		$this->assertSame( 'Bearer', $credentials->token_type );
 		$this->assertTrue(
 			$settings === get_option( 'datamachine_settings', array() ),
 			'Display redaction must not mutate stored settings.'
@@ -121,7 +141,16 @@ class PluginSettingsTest extends WP_UnitTestCase {
 			'SENTINEL_ACCESS_TOKENS',
 			'SENTINEL_CAMEL_CLIENT_SECRET',
 			'SENTINEL_CAMEL_API_KEY',
+			'SENTINEL_APIKEY_ALIAS',
+			'SENTINEL_API_KEY_VALUE',
+			'SENTINEL_PASSWD_ALIAS',
+			'SENTINEL_AUTH_ALIAS',
+			'SENTINEL_AUTHENTICATION_ALIAS',
+			'SENTINEL_PRIVATE_KEY_PASSPHRASE',
+			'SENTINEL_SIGNING_KEY_VALUE',
 			'SENTINEL_SECRET_MAP_KEY',
+			'SENTINEL_GENERIC_CREDENTIALS_OBJECT',
+			'SENTINEL_GENERIC_CREDENTIALS_MAP',
 		);
 		foreach ( $sentinels as $sentinel ) {
 			$this->assertFalse(

--- a/tests/Unit/Core/PluginSettingsTest.php
+++ b/tests/Unit/Core/PluginSettingsTest.php
@@ -85,9 +85,10 @@ class PluginSettingsTest extends WP_UnitTestCase {
 		update_option( 'datamachine_settings', $settings );
 		PluginSettings::clearCache();
 
-		$redacted    = PluginSettings::redactForDisplay( '', PluginSettings::all() );
-		$profile     = $redacted['github_credential_profiles'][0];
-		$credentials = $profile['profile_data'];
+		$stored_before = maybe_serialize( get_option( 'datamachine_settings', array() ) );
+		$redacted      = PluginSettings::redactForDisplay( '', PluginSettings::all() );
+		$profile       = $redacted['github_credential_profiles'][0];
+		$credentials   = $profile['profile_data'];
 
 		$this->assertTrue( '[redacted]' === $redacted['github_pat'], 'Top-level PAT should be redacted.' );
 		$this->assertTrue( '[redacted]' === $profile['pat'], 'Nested profile PAT should be redacted.' );
@@ -120,8 +121,9 @@ class PluginSettingsTest extends WP_UnitTestCase {
 		$this->assertSame( 'credential-1', $profile['credential_id'] );
 		$this->assertSame( 1234567890, $credentials->token_expires_at );
 		$this->assertSame( 'Bearer', $credentials->token_type );
-		$this->assertTrue(
-			$settings === get_option( 'datamachine_settings', array() ),
+		$this->assertSame(
+			$stored_before,
+			maybe_serialize( get_option( 'datamachine_settings', array() ) ),
 			'Display redaction must not mutate stored settings.'
 		);
 

--- a/tests/Unit/Core/PluginSettingsTest.php
+++ b/tests/Unit/Core/PluginSettingsTest.php
@@ -46,18 +46,27 @@ class PluginSettingsTest extends WP_UnitTestCase {
 			'github_pat'                 => 'SENTINEL_TOP_LEVEL_PAT',
 			'github_credential_profiles' => array(
 				array(
-					'id'           => 'profile-1',
-					'label'        => 'Release profile',
-					'mode'         => 'pat',
-					'pat'          => 'SENTINEL_NESTED_PAT',
-					'repositories' => array( 'owner/repository' ),
-					'credentials'  => (object) array(
-						'private_key'      => 'SENTINEL_PRIVATE_KEY',
-						'client_secret'    => 'SENTINEL_CLIENT_SECRET',
-						'access_token'     => 'SENTINEL_ACCESS_TOKEN',
-						'refresh_token'    => 'SENTINEL_REFRESH_TOKEN',
-						'password'         => 'SENTINEL_PASSWORD',
-						'token_expires_at' => 1234567890,
+					'id'            => 'profile-1',
+					'label'         => 'Release profile',
+					'mode'          => 'pat',
+					'pat'           => 'SENTINEL_NESTED_PAT',
+					'repositories'  => array( 'owner/repository' ),
+					'credential_id' => 'credential-1',
+					'credentials'   => (object) array(
+						'private_key'         => 'SENTINEL_PRIVATE_KEY',
+						'client_secret'       => 'SENTINEL_CLIENT_SECRET',
+						'access_token'        => 'SENTINEL_ACCESS_TOKEN',
+						'refresh_token'       => 'SENTINEL_REFRESH_TOKEN',
+						'password'            => 'SENTINEL_PASSWORD',
+						'authorization_header' => 'SENTINEL_AUTHORIZATION_HEADER',
+						'token_value'         => 'SENTINEL_TOKEN_VALUE',
+						'secret_value'        => 'SENTINEL_SECRET_VALUE',
+						'credential_data'     => 'SENTINEL_CREDENTIAL_DATA',
+						'access_tokens'       => array( 'SENTINEL_ACCESS_TOKENS' ),
+						'clientSecret'        => 'SENTINEL_CAMEL_CLIENT_SECRET',
+						'apiKey'              => 'SENTINEL_CAMEL_API_KEY',
+						'secret_map'          => array( 'SENTINEL_SECRET_MAP_KEY' => 'value' ),
+						'token_expires_at'    => 1234567890,
 					),
 				),
 			),
@@ -77,17 +86,26 @@ class PluginSettingsTest extends WP_UnitTestCase {
 		$this->assertTrue( '[redacted]' === $credentials->access_token, 'Nested access token should be redacted.' );
 		$this->assertTrue( '[redacted]' === $credentials->refresh_token, 'Nested refresh token should be redacted.' );
 		$this->assertTrue( '[redacted]' === $credentials->password, 'Nested password should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->authorization_header, 'Authorization variants should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->token_value, 'Token variants should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->secret_value, 'Secret variants should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->credential_data, 'Credential variants should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->access_tokens, 'Plural token variants should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->clientSecret, 'Camel-case client secrets should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->apiKey, 'Camel-case API keys should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->secret_map, 'Secret containers should collapse before map keys serialize.' );
 		$this->assertSame( 'profile-1', $profile['id'] );
 		$this->assertSame( 'Release profile', $profile['label'] );
 		$this->assertSame( 'pat', $profile['mode'] );
 		$this->assertSame( array( 'owner/repository' ), $profile['repositories'] );
+		$this->assertSame( 'credential-1', $profile['credential_id'] );
 		$this->assertSame( 1234567890, $credentials->token_expires_at );
 		$this->assertTrue(
 			$settings === get_option( 'datamachine_settings', array() ),
 			'Display redaction must not mutate stored settings.'
 		);
 
-		$encoded   = wp_json_encode( $redacted );
+		$encoded   = (string) wp_json_encode( $redacted );
 		$sentinels = array(
 			'SENTINEL_TOP_LEVEL_PAT',
 			'SENTINEL_NESTED_PAT',
@@ -96,6 +114,14 @@ class PluginSettingsTest extends WP_UnitTestCase {
 			'SENTINEL_ACCESS_TOKEN',
 			'SENTINEL_REFRESH_TOKEN',
 			'SENTINEL_PASSWORD',
+			'SENTINEL_AUTHORIZATION_HEADER',
+			'SENTINEL_TOKEN_VALUE',
+			'SENTINEL_SECRET_VALUE',
+			'SENTINEL_CREDENTIAL_DATA',
+			'SENTINEL_ACCESS_TOKENS',
+			'SENTINEL_CAMEL_CLIENT_SECRET',
+			'SENTINEL_CAMEL_API_KEY',
+			'SENTINEL_SECRET_MAP_KEY',
 		);
 		foreach ( $sentinels as $sentinel ) {
 			$this->assertFalse(
@@ -103,6 +129,17 @@ class PluginSettingsTest extends WP_UnitTestCase {
 				'Serialized display settings must omit every synthetic secret.'
 			);
 		}
+	}
+
+	public function test_redact_for_display_bounds_cyclic_objects(): void {
+		$profile        = new \stdClass();
+		$profile->label = 'Cycle-safe profile';
+		$profile->self  = $profile;
+
+		$redacted = PluginSettings::redactForDisplay( 'profile', $profile );
+
+		$this->assertSame( 'Cycle-safe profile', $redacted->label );
+		$this->assertTrue( '[redacted]' === $redacted->self, 'Object cycles should terminate with a redacted marker.' );
 	}
 
 	public function test_redact_for_display_preserves_empty_secrets_and_safe_scalars(): void {

--- a/tests/Unit/Core/PluginSettingsTest.php
+++ b/tests/Unit/Core/PluginSettingsTest.php
@@ -40,4 +40,84 @@ class PluginSettingsTest extends WP_UnitTestCase {
 			get_option( 'datamachine_settings', array() )
 		);
 	}
+
+	public function test_redact_for_display_recurses_without_mutating_storage(): void {
+		$settings = array(
+			'github_pat'                 => 'SENTINEL_TOP_LEVEL_PAT',
+			'github_credential_profiles' => array(
+				array(
+					'id'           => 'profile-1',
+					'label'        => 'Release profile',
+					'mode'         => 'pat',
+					'pat'          => 'SENTINEL_NESTED_PAT',
+					'repositories' => array( 'owner/repository' ),
+					'credentials'  => (object) array(
+						'private_key'      => 'SENTINEL_PRIVATE_KEY',
+						'client_secret'    => 'SENTINEL_CLIENT_SECRET',
+						'access_token'     => 'SENTINEL_ACCESS_TOKEN',
+						'refresh_token'    => 'SENTINEL_REFRESH_TOKEN',
+						'password'         => 'SENTINEL_PASSWORD',
+						'token_expires_at' => 1234567890,
+					),
+				),
+			),
+			'enabled'                    => true,
+		);
+		update_option( 'datamachine_settings', $settings );
+		PluginSettings::clearCache();
+
+		$redacted    = PluginSettings::redactForDisplay( '', PluginSettings::all() );
+		$profile     = $redacted['github_credential_profiles'][0];
+		$credentials = $profile['credentials'];
+
+		$this->assertTrue( '[redacted]' === $redacted['github_pat'], 'Top-level PAT should be redacted.' );
+		$this->assertTrue( '[redacted]' === $profile['pat'], 'Nested profile PAT should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->private_key, 'Nested private key should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->client_secret, 'Nested client secret should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->access_token, 'Nested access token should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->refresh_token, 'Nested refresh token should be redacted.' );
+		$this->assertTrue( '[redacted]' === $credentials->password, 'Nested password should be redacted.' );
+		$this->assertSame( 'profile-1', $profile['id'] );
+		$this->assertSame( 'Release profile', $profile['label'] );
+		$this->assertSame( 'pat', $profile['mode'] );
+		$this->assertSame( array( 'owner/repository' ), $profile['repositories'] );
+		$this->assertSame( 1234567890, $credentials->token_expires_at );
+		$this->assertTrue(
+			$settings === get_option( 'datamachine_settings', array() ),
+			'Display redaction must not mutate stored settings.'
+		);
+
+		$encoded   = wp_json_encode( $redacted );
+		$sentinels = array(
+			'SENTINEL_TOP_LEVEL_PAT',
+			'SENTINEL_NESTED_PAT',
+			'SENTINEL_PRIVATE_KEY',
+			'SENTINEL_CLIENT_SECRET',
+			'SENTINEL_ACCESS_TOKEN',
+			'SENTINEL_REFRESH_TOKEN',
+			'SENTINEL_PASSWORD',
+		);
+		foreach ( $sentinels as $sentinel ) {
+			$this->assertFalse(
+				str_contains( $encoded, $sentinel ),
+				'Serialized display settings must omit every synthetic secret.'
+			);
+		}
+	}
+
+	public function test_redact_for_display_preserves_empty_secrets_and_safe_scalars(): void {
+		$settings = array(
+			'profiles' => array(
+				array(
+					'pat'       => '',
+					'token'     => null,
+					'enabled'   => false,
+					'priority'  => 10,
+					'allowlist' => array( 'owner/one', 'owner/two' ),
+				),
+			),
+		);
+
+		$this->assertSame( $settings, PluginSettings::redactForDisplay( '', $settings ) );
+	}
 }

--- a/tests/settings-command-redaction-smoke.php
+++ b/tests/settings-command-redaction-smoke.php
@@ -47,7 +47,7 @@ namespace {
 	};
 
 	$redacted = SettingsCommand::redactSecretsForDisplay(
-		'github_credentials',
+		'github_credential_profiles',
 		array(
 			'profiles' => array(
 				array(

--- a/tests/settings-command-redaction-smoke.php
+++ b/tests/settings-command-redaction-smoke.php
@@ -24,9 +24,7 @@ namespace DataMachine\Cli {
 }
 
 namespace DataMachine\Core {
-	if ( ! class_exists(PluginSettings::class) ) {
-		class PluginSettings {}
-	}
+	require_once __DIR__ . '/../inc/Core/PluginSettings.php';
 }
 
 namespace {
@@ -53,6 +51,7 @@ namespace {
 		array(
 			'profiles' => array(
 				array(
+					'pat'             => 'SENTINEL_PROFILE_PAT',
 					'id'              => 'default',
 					'app_private_key' => '-----BEGIN PRIVATE KEY-----secret',
 					'token'           => 'ghs_nested_secret',
@@ -69,6 +68,7 @@ namespace {
 	);
 
 	$encoded_default = json_encode( $redacted );
+	$assert('[redacted]' === ( $redacted['profiles'][0]['pat'] ?? null ), 'nested PAT is redacted');
 	$assert('[redacted]' === ( $redacted['profiles'][0]['app_private_key'] ?? null ), 'nested app_private_key is redacted');
 	$assert('[redacted]' === ( $redacted['profiles'][0]['token'] ?? null ), 'nested token is redacted');
 	$assert('[redacted]' === ( $redacted['profiles'][0]['password'] ?? null ), 'nested password is redacted');
@@ -76,6 +76,7 @@ namespace {
 	$assert('[redacted]' === ( $redacted['profiles'][0]['provider']['client_secret'] ?? null ), 'nested client_secret is redacted');
 	$assert('chubes4/wp-docs' === ( $redacted['profiles'][0]['default_repo'] ?? null ), 'non-secret nested values remain visible');
 	$assert(false === strpos( $encoded_default, '-----BEGIN PRIVATE KEY-----secret' ), 'default output omits private key value');
+	$assert(false === strpos( $encoded_default, 'SENTINEL_PROFILE_PAT' ), 'default output omits nested PAT value');
 	$assert(false === strpos( $encoded_default, 'ghs_nested_secret' ), 'default output omits token value');
 	$assert(false === strpos( $encoded_default, 'nested-password' ), 'default output omits password value');
 	$assert(false === strpos( $encoded_default, 'sk-provider-secret' ), 'default output omits api key value');


### PR DESCRIPTION
## Summary

- move settings presentation redaction into the shared `PluginSettings` owner
- recursively sanitize nested arrays and objects while preserving safe profile IDs, labels, modes, repository allowlists, and bounded token/credential metadata
- fail closed for PATs, tokens, auth/authentication/authorization values, API/private/signing keys, passwords/passphrases, cookies, bearer values, and generic credential containers
- collapse recognized secret containers atomically so values cannot leak through associative keys
- bound recursive object traversal with cycle and depth protection
- preserve explicit `--reveal` behavior and leave stored settings unchanged

## Root cause

The CLI had its own presentation-only redactor. Although it recursed through arrays, its key matcher did not recognize nested `pat` fields and several realistic credential aliases. It also preserved associative keys beneath recognized secret containers and did not bound object cycles. Extension-owned settings returned by `PluginSettings::all()` could therefore reach `settings get/list` without complete redaction.

## Redaction contract

Keys are normalized across camelCase and separator variants before matching. Safe exceptions are limited to token expiry/type metadata, explicit credential metadata (`credential_id`, `credential_label`, `credential_mode`, `credential_profile_id`), and named `*_credential_profiles` collections. All other auth, key, password/passphrase, PAT, secret, token, cookie/bearer, or credential concepts are treated as secret-bearing. Populated recognized values and containers become `[redacted]`; empty values remain empty. Safe arrays/objects recurse with cycle and depth bounds. Redaction operates on a presentation copy and never writes storage.

## Surface audit

- `settings get/list` are the arbitrary extension-owned settings serializers; both now delegate to the owner-level sanitizer
- settings update status messages already use the same presentation entry point
- `datamachine/get-settings` and its REST response expose a fixed safe allowlist and existing masked provider keys, not arbitrary extension settings
- admin use of `PluginSettings::all()` only reads `enabled_pages` and does not serialize stored settings
- update responses do not echo stored values
- no separate raw settings inspect/export serializer or logging/debug path was found

## Verification

- `php tests/settings-command-redaction-smoke.php`: 18 passed
- Homeboy PR-profile audit: passed with 0 introduced findings
- Homeboy PR-scoped lint: passed with 0 introduced findings
- PHP syntax checks completed for the implementation and focused tests
- focused and full PHPUnit were attempted three times, but WP Codebox timed out before executing any test while waiting for the shared WordPress 7.0.2 archive cache lock
- PHPCS and PHPStan were attempted, but the installed Homeboy WordPress extension Composer autoloader is corrupted, so those producers could not start

Only unmistakably synthetic sentinel credentials were used. No live settings command was run, and no real credential value was read, logged, tested, or included.

Closes #2947