### PR TITLE
fix: replay terminal job accounting safely

### DIFF
--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -527,11 +527,25 @@ class PipelineBatchScheduler {
 			'total'     => $total_children,
 		);
 
-		if ( ! datamachine_set_engine_data( (int) $parent_job_id, $parent_engine ) ) {
+		$persist_parent = apply_filters(
+			'datamachine_pipeline_batch_parent_engine_persister',
+			'datamachine_set_engine_data',
+			$parent_job_id,
+			$parent_engine
+		);
+		if ( ! is_callable( $persist_parent ) || false === call_user_func( $persist_parent, $parent_job_id, $parent_engine ) ) {
 			return false;
 		}
-		$parent_completed = $jobs_db->complete_job( (int) $parent_job_id, $parent_status );
-		if ( ! $parent_completed ) {
+
+		$complete_parent = apply_filters(
+			'datamachine_pipeline_batch_parent_completer',
+			static function () use ( $jobs_db, $parent_job_id, $parent_status ): bool {
+				return $jobs_db->complete_job( (int) $parent_job_id, $parent_status );
+			},
+			$parent_job_id,
+			$parent_status
+		);
+		if ( ! is_callable( $complete_parent ) || false === call_user_func( $complete_parent, $parent_job_id, $parent_status ) ) {
 			return false;
 		}
 

--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -415,23 +415,24 @@ class PipelineBatchScheduler {
 	 *
 	 * @param int    $job_id Job ID that just completed.
 	 * @param string $status The completion status.
+	 * @return bool Whether parent completion is durable or no parent work applies.
 	 */
-	public static function onChildComplete( int $job_id, string $status ): void {
+	public static function onChildComplete( int $job_id, string $status ): bool {
 		$status;
 		$jobs_db = new Jobs();
 		$job     = $jobs_db->get_job( $job_id );
 
 		if ( ! $job ) {
-			return;
+			return true;
 		}
 
 		$parent_job_id = $job['parent_job_id'] ?? 0;
 
 		if ( empty( $parent_job_id ) ) {
-			return; // Not a child job.
+			return true; // Not a child job.
 		}
 
-		self::maybeCompleteParent( (int) $parent_job_id );
+		return self::maybeCompleteParent( (int) $parent_job_id );
 	}
 
 	/**
@@ -443,26 +444,27 @@ class PipelineBatchScheduler {
 	 * no future scheduler action.
 	 *
 	 * @param int $parent_job_id Parent job ID.
+	 * @return bool Whether parent completion is durable or no completion is due.
 	 */
-	private static function maybeCompleteParent( int $parent_job_id ): void {
+	private static function maybeCompleteParent( int $parent_job_id ): bool {
 		$jobs_db = new Jobs();
 		$parent  = $jobs_db->get_job( $parent_job_id );
 
 		if ( ! $parent || JobStatus::PROCESSING !== ( $parent['status'] ?? '' ) ) {
-			return;
+			return true;
 		}
 
 		// Check parent is a pipeline batch.
 		$parent_engine = datamachine_get_engine_data( (int) $parent_job_id );
 		if ( empty( $parent_engine['batch'] ) ) {
-			return; // Not a pipeline batch parent.
+			return true; // Not a pipeline batch parent.
 		}
 
 		// Pipeline-only — system-task batches use the same engine_data
 		// shape but their parent is completed inline by TaskScheduler.
 		$context = $parent_engine['batch_context'] ?? '';
 		if ( '' !== $context && self::BATCH_CONTEXT !== $context ) {
-			return;
+			return true;
 		}
 
 		// Count child statuses.
@@ -488,7 +490,7 @@ class PipelineBatchScheduler {
 		// phpcs:enable WordPress.DB.PreparedSQLPlaceholders, WordPress.DB.PreparedSQL
 
 		if ( ! $counts ) {
-			return;
+			return false;
 		}
 
 		$total_children  = (int) $counts['total'];
@@ -498,7 +500,7 @@ class PipelineBatchScheduler {
 
 		// Still have active children or not all scheduled yet.
 		if ( $active > 0 || $batch_pending || $total_children < $batch_scheduled ) {
-			return;
+			return true;
 		}
 
 		// All children are done. Complete the parent.
@@ -525,8 +527,13 @@ class PipelineBatchScheduler {
 			'total'     => $total_children,
 		);
 
-		datamachine_set_engine_data( (int) $parent_job_id, $parent_engine );
-		$jobs_db->complete_job( (int) $parent_job_id, $parent_status );
+		if ( ! datamachine_set_engine_data( (int) $parent_job_id, $parent_engine ) ) {
+			return false;
+		}
+		$parent_completed = $jobs_db->complete_job( (int) $parent_job_id, $parent_status );
+		if ( ! $parent_completed ) {
+			return false;
+		}
 
 		$flow_name = $parent_engine['flow']['name'] ?? '';
 
@@ -547,6 +554,8 @@ class PipelineBatchScheduler {
 				'total'         => $total_children,
 			)
 		);
+
+		return true;
 	}
 
 	/**

--- a/inc/Abilities/Job/JobsSummaryAbility.php
+++ b/inc/Abilities/Job/JobsSummaryAbility.php
@@ -131,10 +131,11 @@ class JobsSummaryAbility {
 	 */
 	private function getCompactSummary( array $filters ): array {
 		return array(
-			'total'                  => $this->db_jobs->get_jobs_count( $filters ),
-			'failed_count'           => $this->db_jobs->get_jobs_count( array_merge( $filters, array( 'status' => 'failed' ) ) ),
-			'stuck_processing_count' => 0,
-			'status'                 => array(
+			'total'                                => $this->db_jobs->get_jobs_count( $filters ),
+			'failed_count'                         => $this->db_jobs->get_jobs_count( array_merge( $filters, array( 'status' => 'failed' ) ) ),
+			'stuck_processing_count'               => 0,
+			'incomplete_terminal_accounting_count' => $this->db_jobs->count_incomplete_terminal_accounting( $filters ),
+			'status'                               => array(
 				array(
 					'status' => 'processing',
 					'count'  => $this->db_jobs->get_jobs_count( array_merge( $filters, array( 'status' => 'processing' ) ) ),
@@ -148,10 +149,10 @@ class JobsSummaryAbility {
 					'count'  => $this->db_jobs->get_jobs_count( array_merge( $filters, array( 'status' => 'failed' ) ) ),
 				),
 			),
-			'pipeline'               => array(),
-			'flow'                   => array(),
-			'handler'                => array(),
-			'filters'                => $filters,
+			'pipeline'                             => array(),
+			'flow'                                 => array(),
+			'handler'                              => array(),
+			'filters'                              => $filters,
 		);
 	}
 }

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -635,6 +635,95 @@ class JobsCommand extends BaseCommand {
 	}
 
 	/**
+	 * Reconcile terminal jobs with incomplete post-commit accounting.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--dry-run]
+	 * : Report incomplete jobs without replaying accounting.
+	 *
+	 * [--limit=<limit>]
+	 * : Maximum rows to inspect.
+	 * ---
+	 * default: 100
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * @subcommand reconcile-terminal-accounting
+	 */
+	public function reconcile_terminal_accounting( array $args, array $assoc_args ): void {
+		$dry_run = isset( $assoc_args['dry-run'] );
+		$limit   = isset( $assoc_args['limit'] ) ? max( 1, min( 5000, (int) $assoc_args['limit'] ) ) : 100;
+		$format  = $assoc_args['format'] ?? 'table';
+		$jobs_db = new Jobs();
+		$rows    = $jobs_db->get_incomplete_terminal_accounting( $limit );
+		$items   = array();
+		$summary = array(
+			'incomplete' => $jobs_db->count_incomplete_terminal_accounting(),
+			'inspected'  => count( $rows ),
+			'reconciled' => 0,
+			'failed'     => 0,
+		);
+
+		foreach ( $rows as $row ) {
+			$before = (int) $row['terminal_accounting_state'];
+			$result = $dry_run
+				? array(
+					'success'  => true,
+					'state'    => $before,
+					'complete' => false,
+				)
+				: $jobs_db->reconcile_terminal_accounting( (int) $row['job_id'] );
+
+			if ( ! $dry_run ) {
+				if ( ! empty( $result['complete'] ) ) {
+					++$summary['reconciled'];
+				} else {
+					++$summary['failed'];
+				}
+			}
+
+			$items[] = array(
+				'job_id'       => (int) $row['job_id'],
+				'status'       => (string) $row['status'],
+				'before_state' => $before,
+				'after_state'  => (int) ( $result['state'] ?? $before ),
+				'action'       => $dry_run ? 'would_reconcile' : ( ! empty( $result['complete'] ) ? 'reconciled' : 'failed' ),
+			);
+		}
+
+		$output = array(
+			'success'        => 0 === $summary['failed'],
+			'dry_run'        => $dry_run,
+			'complete_state' => Jobs::TERMINAL_ACCOUNTING_COMPLETE,
+			'summary'        => $summary,
+			'jobs'           => $items,
+		);
+
+		if ( 'table' !== $format ) {
+			WP_CLI::print_value( $output, array( 'format' => $format ) );
+			return;
+		}
+
+		if ( empty( $items ) ) {
+			WP_CLI::success( 'No terminal jobs have incomplete accounting.' );
+			return;
+		}
+
+		$this->format_items( $items, array( 'job_id', 'status', 'before_state', 'after_state', 'action' ), $assoc_args, 'job_id' );
+		WP_CLI::log( sprintf( 'Inspected %d of %d incomplete terminal jobs; %d reconciled; %d failed.', $summary['inspected'], $summary['incomplete'], $summary['reconciled'], $summary['failed'] ) );
+	}
+
+	/**
 	 * Resolve the corrected terminal status for a job row.
 	 *
 	 * @param array<string,mixed> $row Job row.

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -668,36 +668,64 @@ class JobsCommand extends BaseCommand {
 		$rows    = $jobs_db->get_incomplete_terminal_accounting( $limit );
 		$items   = array();
 		$summary = array(
-			'incomplete' => $jobs_db->count_incomplete_terminal_accounting(),
-			'inspected'  => count( $rows ),
-			'reconciled' => 0,
-			'failed'     => 0,
+			'incomplete'  => $jobs_db->count_incomplete_terminal_accounting(),
+			'inspected'   => count( $rows ),
+			'reconciled'  => 0,
+			'in_progress' => 0,
+			'failed'      => 0,
 		);
 
 		foreach ( $rows as $row ) {
 			$before = (int) $row['terminal_accounting_state'];
-			$result = $dry_run
-				? array(
-					'success'  => true,
-					'state'    => $before,
-					'complete' => false,
-				)
-				: $jobs_db->reconcile_terminal_accounting( (int) $row['job_id'] );
+			try {
+				$result = $dry_run
+					? array(
+						'success'     => true,
+						'state'       => $before,
+						'complete'    => false,
+						'in_progress' => false,
+						'errors'      => array(),
+					)
+					: $jobs_db->reconcile_terminal_accounting( (int) $row['job_id'] );
+			} catch ( \Throwable $exception ) {
+				$result = array(
+					'success'     => false,
+					'state'       => $before,
+					'complete'    => false,
+					'in_progress' => false,
+					'stage'       => 'reconcile',
+					'errors'      => array(
+						array(
+							'stage'   => 'reconcile',
+							'code'    => 'reconciliation_exception',
+							'message' => $exception->getMessage(),
+						),
+					),
+				);
+			}
 
 			if ( ! $dry_run ) {
 				if ( ! empty( $result['complete'] ) ) {
 					++$summary['reconciled'];
+				} elseif ( ! empty( $result['in_progress'] ) ) {
+					++$summary['in_progress'];
 				} else {
 					++$summary['failed'];
 				}
 			}
+			$errors      = is_array( $result['errors'] ?? null ) ? $result['errors'] : array();
+			$error_codes = implode( ',', array_filter( array_column( $errors, 'code' ), 'is_string' ) );
+			$action      = $dry_run ? 'would_reconcile' : ( ! empty( $result['complete'] ) ? 'reconciled' : ( ! empty( $result['in_progress'] ) ? 'in_progress' : 'failed' ) );
 
 			$items[] = array(
 				'job_id'       => (int) $row['job_id'],
 				'status'       => (string) $row['status'],
 				'before_state' => $before,
 				'after_state'  => (int) ( $result['state'] ?? $before ),
-				'action'       => $dry_run ? 'would_reconcile' : ( ! empty( $result['complete'] ) ? 'reconciled' : 'failed' ),
+				'stage'        => (string) ( $result['stage'] ?? '' ),
+				'action'       => $action,
+				'error_codes'  => $error_codes,
+				'errors'       => $errors,
 			);
 		}
 
@@ -719,8 +747,8 @@ class JobsCommand extends BaseCommand {
 			return;
 		}
 
-		$this->format_items( $items, array( 'job_id', 'status', 'before_state', 'after_state', 'action' ), $assoc_args, 'job_id' );
-		WP_CLI::log( sprintf( 'Inspected %d of %d incomplete terminal jobs; %d reconciled; %d failed.', $summary['inspected'], $summary['incomplete'], $summary['reconciled'], $summary['failed'] ) );
+		$this->format_items( $items, array( 'job_id', 'status', 'before_state', 'after_state', 'stage', 'action', 'error_codes' ), $assoc_args, 'job_id' );
+		WP_CLI::log( sprintf( 'Inspected %d of %d incomplete terminal jobs; %d reconciled; %d in progress; %d failed.', $summary['inspected'], $summary['incomplete'], $summary['reconciled'], $summary['in_progress'], $summary['failed'] ) );
 	}
 
 	/**

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -32,6 +32,12 @@ class Jobs extends BaseRepository {
 
 	const TABLE_NAME = 'datamachine_jobs';
 
+	private const TERMINAL_ACCOUNTING_COMMITTED_HOOK = 1;
+	private const TERMINAL_ACCOUNTING_METRICS        = 2;
+	private const TERMINAL_ACCOUNTING_COMPLETE_HOOK  = 4;
+	private const TERMINAL_ACCOUNTING_LIFECYCLE      = 8;
+	public const TERMINAL_ACCOUNTING_COMPLETE        = 15;
+
 	/** Job currently owning the connection-wide terminal transaction. */
 	private static ?int $terminalizing_job = null;
 
@@ -462,7 +468,7 @@ class Jobs extends BaseRepository {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->query(
 			$this->wpdb->prepare(
-				"UPDATE %i SET status = 'pending', completed_at = NULL, operation_state = 'preparing', operation_claimed_at = NULL, operation_claim_token = NULL, operation_action_id = NULL WHERE job_id = %d AND status LIKE 'failed%'",
+				"UPDATE %i SET status = 'pending', completed_at = NULL, terminal_accounting_state = NULL, operation_state = 'preparing', operation_claimed_at = NULL, operation_claim_token = NULL, operation_action_id = NULL WHERE job_id = %d AND status LIKE 'failed%'",
 				$this->table_name,
 				$job_id
 			)
@@ -629,6 +635,41 @@ class Jobs extends BaseRepository {
 		return (int) $this->wpdb->get_var( $query );
 	}
 
+	/** Count terminal jobs whose durable post-commit accounting is incomplete. */
+	public function count_incomplete_terminal_accounting( array $args = array() ): int {
+		$where_parts  = $this->build_jobs_summary_where( $args, 'j' );
+		$where_sql    = '' === $where_parts['sql'] ? 'WHERE' : $where_parts['sql'] . ' AND';
+		$where_values = $where_parts['values'];
+		$query_args   = array_merge( array( $this->table_name ), $where_values, array( self::TERMINAL_ACCOUNTING_COMPLETE ) );
+		$query        = $this->wpdb->prepare(
+			"SELECT COUNT(j.job_id) FROM %i j {$where_sql} j.terminal_accounting_state IS NOT NULL AND j.terminal_accounting_state < %d",
+			...$query_args
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Fully prepared bounded aggregate on plugin-owned table.
+		return (int) $this->wpdb->get_var( $query );
+	}
+
+	/**
+	 * Get a bounded batch of terminal jobs needing post-commit accounting.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	public function get_incomplete_terminal_accounting( int $limit = 100 ): array {
+		$limit = max( 1, min( 5000, $limit ) );
+		$query = $this->wpdb->prepare(
+			'SELECT job_id, status, completed_at, terminal_accounting_state FROM %i WHERE terminal_accounting_state IS NOT NULL AND terminal_accounting_state < %d ORDER BY job_id ASC LIMIT %d',
+			$this->table_name,
+			self::TERMINAL_ACCOUNTING_COMPLETE,
+			$limit
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Fully prepared bounded query on plugin-owned table.
+		$rows = $this->wpdb->get_results( $query, ARRAY_A );
+
+		return is_array( $rows ) ? $rows : array();
+	}
+
 	/**
 	 * Get memory-safe aggregate job summary counts.
 	 *
@@ -644,14 +685,15 @@ class Jobs extends BaseRepository {
 		$where_values = $where_parts['values'];
 
 		return array(
-			'total'                  => $this->get_jobs_count( $args ),
-			'failed_count'           => $this->get_jobs_count( array_merge( $args, array( 'status' => 'failed' ) ) ),
-			'stuck_processing_count' => $this->get_stuck_processing_count( $args ),
-			'status'                 => $this->get_status_summary_rows( $where_sql, $where_values ),
-			'pipeline'               => $this->get_pipeline_summary_rows( $where_sql, $where_values ),
-			'flow'                   => $this->get_flow_summary_rows( $where_sql, $where_values ),
-			'handler'                => $this->get_handler_summary_rows( $args, $where_sql, $where_values ),
-			'filters'                => $this->summarize_job_filters( $args ),
+			'total'                                => $this->get_jobs_count( $args ),
+			'failed_count'                         => $this->get_jobs_count( array_merge( $args, array( 'status' => 'failed' ) ) ),
+			'stuck_processing_count'               => $this->get_stuck_processing_count( $args ),
+			'incomplete_terminal_accounting_count' => $this->count_incomplete_terminal_accounting( $args ),
+			'status'                               => $this->get_status_summary_rows( $where_sql, $where_values ),
+			'pipeline'                             => $this->get_pipeline_summary_rows( $where_sql, $where_values ),
+			'flow'                                 => $this->get_flow_summary_rows( $where_sql, $where_values ),
+			'handler'                              => $this->get_handler_summary_rows( $args, $where_sql, $where_values ),
+			'filters'                              => $this->summarize_job_filters( $args ),
 		);
 	}
 
@@ -1878,7 +1920,7 @@ class Jobs extends BaseRepository {
 	 *
 	 * Non-terminal jobs may move to another non-terminal state or to a terminal
 	 * state. Terminal jobs are immutable; repeating the same terminal state is an
-	 * idempotent success and does not run terminal side effects again.
+	 * idempotent success that replays only missing post-commit accounting stages.
 	 *
 	 * @param int    $job_id        The job ID.
 	 * @param string $status        The new status.
@@ -2015,10 +2057,12 @@ class Jobs extends BaseRepository {
 		$current_status = is_string( $job['status'] ?? null ) ? $job['status'] : '';
 		if ( $current_status === $requested_status ) {
 			$this->rollback_terminal_transition( $job_id );
+			$this->reconcile_terminal_accounting( $job_id );
 			return $this->status_transition_result( true, false, $current_status, $current_status );
 		}
 		if ( JobStatus::isStatusFinal( $current_status ) ) {
 			$this->rollback_terminal_transition( $job_id );
+			$this->reconcile_terminal_accounting( $job_id );
 			return $this->status_transition_result( false, false, $current_status, $current_status );
 		}
 
@@ -2082,14 +2126,15 @@ class Jobs extends BaseRepository {
 		$updated = $this->wpdb->update(
 			$this->table_name,
 			array(
-				'status'       => $status,
-				'completed_at' => current_time( 'mysql', true ),
+				'status'                    => $status,
+				'completed_at'              => current_time( 'mysql', true ),
+				'terminal_accounting_state' => 0,
 			),
 			array(
 				'job_id' => $job_id,
 				'status' => $current_status,
 			),
-			array( '%s', '%s' ),
+			array( '%s', '%s', '%d' ),
 			array( '%d', '%s' )
 		);
 		if ( 1 !== $updated ) {
@@ -2110,12 +2155,124 @@ class Jobs extends BaseRepository {
 			return $this->status_transition_result( $status === $winner_status, false, $winner_status, $winner_status );
 		}
 
-		do_action( 'datamachine_job_terminal_committed', $job_id, $status );
-		RunMetrics::complete( $job_id, $status );
-		do_action( 'datamachine_job_complete', $job_id, $status );
-		( new RunLifecycleStore( $this ) )->mark_job_status( $job_id, $status );
+		$this->reconcile_terminal_accounting( $job_id );
 
 		return $this->status_transition_result( true, true, $current_status, $status );
+	}
+
+	/**
+	 * Replay missing terminal post-commit accounting stages.
+	 *
+	 * Internal stores are idempotent and receive their bit after success. Hook
+	 * dispatches claim their bit first, giving arbitrary external listeners an
+	 * honest at-most-once contract: process death between the claim and callback
+	 * invocation can lose delivery, but replay never duplicates notifications.
+	 *
+	 * @return array{success:bool,job_id:int,status:?string,state:?int,complete:bool}
+	 */
+	public function reconcile_terminal_accounting( int $job_id ): array {
+		$job    = $this->get_job( $job_id );
+		$status = is_array( $job ) && is_string( $job['status'] ?? null ) ? $job['status'] : null;
+		$state  = is_array( $job ) && null !== ( $job['terminal_accounting_state'] ?? null ) ? (int) $job['terminal_accounting_state'] : null;
+
+		if ( null === $status || ! JobStatus::isStatusFinal( $status ) || null === $state ) {
+			return $this->terminal_accounting_result( false, $job_id, $status, $state );
+		}
+
+		if ( ! $this->terminal_accounting_has_bit( $job_id, self::TERMINAL_ACCOUNTING_COMMITTED_HOOK ) ) {
+			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'before', 'terminal_committed_hook' );
+			if ( $this->claim_terminal_accounting_bit( $job_id, self::TERMINAL_ACCOUNTING_COMMITTED_HOOK ) ) {
+				do_action( 'datamachine_job_terminal_committed', $job_id, $status );
+				$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'after', 'terminal_committed_hook' );
+			}
+		}
+
+		if ( ! $this->terminal_accounting_has_bit( $job_id, self::TERMINAL_ACCOUNTING_METRICS ) ) {
+			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'before', 'run_metrics' );
+			if ( ! RunMetrics::complete( $job_id, $status ) ) {
+				return $this->terminal_accounting_result( false, $job_id, $status, $this->get_terminal_accounting_state( $job_id ) );
+			}
+			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'after', 'run_metrics' );
+			if ( ! $this->claim_terminal_accounting_bit( $job_id, self::TERMINAL_ACCOUNTING_METRICS ) && ! $this->terminal_accounting_has_bit( $job_id, self::TERMINAL_ACCOUNTING_METRICS ) ) {
+				return $this->terminal_accounting_result( false, $job_id, $status, $this->get_terminal_accounting_state( $job_id ) );
+			}
+		}
+
+		if ( ! $this->terminal_accounting_has_bit( $job_id, self::TERMINAL_ACCOUNTING_COMPLETE_HOOK ) ) {
+			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'before', 'job_complete_hook' );
+			if ( $this->claim_terminal_accounting_bit( $job_id, self::TERMINAL_ACCOUNTING_COMPLETE_HOOK ) ) {
+				do_action( 'datamachine_job_complete', $job_id, $status );
+				$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'after', 'job_complete_hook' );
+			}
+		}
+
+		if ( ! $this->terminal_accounting_has_bit( $job_id, self::TERMINAL_ACCOUNTING_LIFECYCLE ) ) {
+			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'before', 'run_lifecycle' );
+			if ( ! ( new RunLifecycleStore( $this ) )->mark_job_status( $job_id, $status ) ) {
+				return $this->terminal_accounting_result( false, $job_id, $status, $this->get_terminal_accounting_state( $job_id ) );
+			}
+			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'after', 'run_lifecycle' );
+			if ( ! $this->claim_terminal_accounting_bit( $job_id, self::TERMINAL_ACCOUNTING_LIFECYCLE ) && ! $this->terminal_accounting_has_bit( $job_id, self::TERMINAL_ACCOUNTING_LIFECYCLE ) ) {
+				return $this->terminal_accounting_result( false, $job_id, $status, $this->get_terminal_accounting_state( $job_id ) );
+			}
+		}
+
+		$state = $this->get_terminal_accounting_state( $job_id );
+		return $this->terminal_accounting_result( self::TERMINAL_ACCOUNTING_COMPLETE === $state, $job_id, $status, $state );
+	}
+
+	/** Atomically claim one accounting receipt bit. */
+	private function claim_terminal_accounting_bit( int $job_id, int $bit ): bool {
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The query is prepared immediately below with typed placeholders.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier and scalar values use typed placeholders.
+		$query = $this->wpdb->prepare(
+			'UPDATE %i SET terminal_accounting_state = terminal_accounting_state | %d WHERE job_id = %d AND terminal_accounting_state IS NOT NULL AND (terminal_accounting_state & %d) = 0',
+			$this->table_name,
+			$bit,
+			$job_id,
+			$bit
+		);
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Fully prepared atomic receipt claim.
+		$claimed = 1 === (int) $this->wpdb->query( $query );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		return $claimed;
+	}
+
+	private function terminal_accounting_has_bit( int $job_id, int $bit ): bool {
+		$state = $this->get_terminal_accounting_state( $job_id );
+		// phpcs:ignore WordPress.PHP.YodaConditions.NotYoda -- Bitmask expression is clearest with the requested bit first.
+		return null !== $state && $bit === ( $state & $bit );
+	}
+
+	private function get_terminal_accounting_state( int $job_id ): ?int {
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The query is prepared immediately below with typed placeholders.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier and job ID use typed placeholders.
+		$query = $this->wpdb->prepare( 'SELECT terminal_accounting_state FROM %i WHERE job_id = %d', $this->table_name, $job_id );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Fully prepared fresh receipt read.
+		$state = $this->wpdb->get_var( $query );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		return null === $state ? null : (int) $state;
+	}
+
+	/** Deterministic interruption seam for post-commit boundary tests. */
+	private function maybe_interrupt_terminal_accounting( int $job_id, string $status, string $phase, string $stage ): void {
+		$interrupt = apply_filters( 'datamachine_job_terminal_accounting_interrupt', false, $phase . ':' . $stage, $job_id, $status );
+		if ( $interrupt ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Internal fixed stage names are diagnostic data, not rendered output.
+			throw new \RuntimeException( sprintf( 'Terminal accounting interrupted at %s:%s', $phase, $stage ) );
+		}
+	}
+
+	/** Build a machine-readable terminal accounting result. */
+	private function terminal_accounting_result( bool $success, int $job_id, ?string $status, ?int $state ): array {
+		return array(
+			'success'  => $success,
+			'job_id'   => $job_id,
+			'status'   => $status,
+			'state'    => $state,
+			'complete' => self::TERMINAL_ACCOUNTING_COMPLETE === $state,
+		);
 	}
 
 	/**
@@ -2371,6 +2528,7 @@ class Jobs extends BaseRepository {
 			operation_claim_token varchar(64) NULL DEFAULT NULL,
 			operation_generation bigint(20) unsigned NOT NULL DEFAULT 0,
 			operation_action_id bigint(20) unsigned NULL DEFAULT NULL,
+			terminal_accounting_state tinyint unsigned NULL DEFAULT NULL,
             created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
             completed_at datetime NULL DEFAULT NULL,
             PRIMARY KEY  (job_id),
@@ -2383,7 +2541,8 @@ class Jobs extends BaseRepository {
             KEY idx_created_at (created_at),
             KEY idx_flow_created (flow_id, created_at),
             KEY idx_status_created (status(50), created_at),
-            KEY idx_source_created (source, created_at),
+			KEY idx_source_created (source, created_at),
+			KEY idx_terminal_accounting (terminal_accounting_state, job_id),
             UNIQUE KEY idx_idempotency_key (idempotency_key)
         ) $charset_collate;";
 
@@ -2394,6 +2553,7 @@ class Jobs extends BaseRepository {
 		self::migrate_handler_slug_column( $table_name );
 		self::migrate_idempotency_key_column( $table_name );
 		self::migrate_operation_columns( $table_name );
+		self::migrate_terminal_accounting_column( $table_name );
 		self::migrate_indexes( $table_name );
 
 		do_action(
@@ -2825,13 +2985,13 @@ class Jobs extends BaseRepository {
 		global $wpdb;
 
 		$columns = array(
-			'request_fingerprint'  => 'char(64) NULL DEFAULT NULL',
-			'operation_state'      => 'varchar(32) NULL DEFAULT NULL',
-			'operation_step_id'    => 'varchar(191) NULL DEFAULT NULL',
-			'operation_claimed_at' => 'datetime NULL DEFAULT NULL',
+			'request_fingerprint'   => 'char(64) NULL DEFAULT NULL',
+			'operation_state'       => 'varchar(32) NULL DEFAULT NULL',
+			'operation_step_id'     => 'varchar(191) NULL DEFAULT NULL',
+			'operation_claimed_at'  => 'datetime NULL DEFAULT NULL',
 			'operation_claim_token' => 'varchar(64) NULL DEFAULT NULL',
-			'operation_generation' => 'bigint(20) unsigned NOT NULL DEFAULT 0',
-			'operation_action_id'  => 'bigint(20) unsigned NULL DEFAULT NULL',
+			'operation_generation'  => 'bigint(20) unsigned NOT NULL DEFAULT 0',
+			'operation_action_id'   => 'bigint(20) unsigned NULL DEFAULT NULL',
 		);
 
 		foreach ( $columns as $column => $definition ) {
@@ -2842,6 +3002,24 @@ class Jobs extends BaseRepository {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Fixed schema identifiers and definitions.
 			$wpdb->query( "ALTER TABLE {$table_name} ADD COLUMN {$column} {$definition}" );
 		}
+	}
+
+	/** Add the terminal post-commit receipt column. */
+	private static function migrate_terminal_accounting_column( string $table_name ): void {
+		global $wpdb;
+
+		if ( ! BaseRepository::column_exists( $table_name, 'terminal_accounting_state', $wpdb ) ) {
+			// phpcs:disable WordPress.DB.PreparedSQL -- Fixed plugin-owned schema identifier and integer constant.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+			$added = $wpdb->query( "ALTER TABLE {$table_name} ADD COLUMN terminal_accounting_state tinyint unsigned NULL DEFAULT NULL" );
+			if ( false === $added ) {
+				return;
+			}
+		}
+
+		// NULL deliberately means pre-receipt or non-terminal. Legacy terminals
+		// cannot safely replay arbitrary hooks, so only new state-0 rows reconcile.
+		self::ensure_jobs_index( $table_name, 'idx_terminal_accounting', 'INDEX', '(terminal_accounting_state, job_id)' );
 	}
 
 	/**
@@ -2901,11 +3079,12 @@ class Jobs extends BaseRepository {
 		$index_names = array_unique( array_column( $existing, 'Key_name' ) );
 
 		$indexes_to_add = array(
-			'idx_created_at'     => '(created_at)',
-			'idx_flow_created'   => '(flow_id, created_at)',
-			'idx_status_created' => '(status(50), created_at)',
-			'idx_source_created' => '(source, created_at)',
-			'idx_handler_slug'   => '(handler_slug)',
+			'idx_created_at'          => '(created_at)',
+			'idx_flow_created'        => '(flow_id, created_at)',
+			'idx_status_created'      => '(status(50), created_at)',
+			'idx_source_created'      => '(source, created_at)',
+			'idx_handler_slug'        => '(handler_slug)',
+			'idx_terminal_accounting' => '(terminal_accounting_state, job_id)',
 		);
 
 		$added = array();

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -32,11 +32,11 @@ class Jobs extends BaseRepository {
 
 	const TABLE_NAME = 'datamachine_jobs';
 
-	private const TERMINAL_ACCOUNTING_COMMITTED_HOOK = 1;
-	private const TERMINAL_ACCOUNTING_METRICS        = 2;
-	private const TERMINAL_ACCOUNTING_COMPLETE_HOOK  = 4;
-	private const TERMINAL_ACCOUNTING_LIFECYCLE      = 8;
-	public const TERMINAL_ACCOUNTING_COMPLETE        = 15;
+	private const TERMINAL_ACCOUNTING_METRICS   = 0;
+	private const TERMINAL_ACCOUNTING_CORE      = 1;
+	private const TERMINAL_ACCOUNTING_LIFECYCLE = 2;
+	private const TERMINAL_ACCOUNTING_NOTIFY    = 3;
+	public const TERMINAL_ACCOUNTING_COMPLETE   = 4;
 
 	/** Job currently owning the connection-wide terminal transaction. */
 	private static ?int $terminalizing_job = null;
@@ -359,6 +359,7 @@ class Jobs extends BaseRepository {
 		$lease_cutoff = gmdate( 'Y-m-d H:i:s', time() - max( 1, $lease_seconds ) );
 		$claimed_at   = gmdate( 'Y-m-d H:i:s' );
 		$claim_token  = bin2hex( random_bytes( 16 ) );
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The nested prepare binds the plugin table identifier and every scalar value.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->query(
 			$this->wpdb->prepare(
@@ -370,6 +371,7 @@ class Jobs extends BaseRepository {
 				$lease_cutoff
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( 1 !== (int) $updated ) {
 			return false;
@@ -394,7 +396,7 @@ class Jobs extends BaseRepository {
 
 		return is_array( $job )
 			&& 'enqueuing' === ( $job['operation_state'] ?? '' )
-			&& $generation === (int) ( $job['operation_generation'] ?? 0 )
+			&& (int) ( $job['operation_generation'] ?? 0 ) === $generation
 			&& '' !== $token
 			&& hash_equals( $token, (string) ( $job['operation_claim_token'] ?? '' ) );
 	}
@@ -410,6 +412,7 @@ class Jobs extends BaseRepository {
 			return false;
 		}
 
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The nested prepare binds the plugin table identifier and job ID.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->query(
 			$this->wpdb->prepare(
@@ -418,6 +421,7 @@ class Jobs extends BaseRepository {
 				$job_id
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		return 1 === (int) $updated;
 	}
@@ -437,6 +441,7 @@ class Jobs extends BaseRepository {
 			return false;
 		}
 
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The nested prepare binds the plugin table identifier and every scalar value.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->query(
 			$this->wpdb->prepare(
@@ -450,6 +455,7 @@ class Jobs extends BaseRepository {
 				$token
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		return 1 === (int) $updated;
 	}
@@ -465,14 +471,18 @@ class Jobs extends BaseRepository {
 			return false;
 		}
 
+		$failed_status = $this->wpdb->esc_like( 'failed' ) . '%';
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The nested prepare binds the plugin table identifier, job ID, and escaped LIKE value.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->query(
 			$this->wpdb->prepare(
-				"UPDATE %i SET status = 'pending', completed_at = NULL, terminal_accounting_state = NULL, operation_state = 'preparing', operation_claimed_at = NULL, operation_claim_token = NULL, operation_action_id = NULL WHERE job_id = %d AND status LIKE 'failed%'",
+				"UPDATE %i SET status = 'pending', completed_at = NULL, terminal_accounting_state = NULL, terminal_accounting_owner = NULL, terminal_accounting_claimed_at = NULL, terminal_accounting_processed_count = 0, operation_state = 'preparing', operation_claimed_at = NULL, operation_claim_token = NULL, operation_action_id = NULL WHERE job_id = %d AND status LIKE %s",
 				$this->table_name,
-				$job_id
+				$job_id,
+				$failed_status
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		return 1 === (int) $updated;
 	}
@@ -507,8 +517,9 @@ class Jobs extends BaseRepository {
 			return null;
 		}
 
-        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL -- The nested prepare binds the plugin table identifier and job ID.
 		$job = $this->wpdb->get_row( $this->wpdb->prepare( 'SELECT * FROM %i WHERE job_id = %d', $this->table_name, $job_id ), ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		if ( $job && isset( $job['engine_data'] ) && is_string( $job['engine_data'] ) ) {
 			$decoded = json_decode( $job['engine_data'], true );
@@ -593,15 +604,16 @@ class Jobs extends BaseRepository {
 			$where_sql = 'WHERE ' . implode( ' AND ', $where_clauses );
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:disable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders -- Dynamic clauses are fixed repository fragments; every value is passed to prepare().
 		$query = $this->wpdb->prepare(
 			"SELECT COUNT(job_id) FROM %i {$where_sql}",
 			array_merge( array( $this->table_name ), $where_values )
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:enable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above
+		// phpcs:disable WordPress.DB.PreparedSQL -- The query variable is fully prepared immediately above.
 		$count = $this->wpdb->get_var( $query );
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		return (int) $count;
 	}
@@ -622,17 +634,19 @@ class Jobs extends BaseRepository {
 	 * @return int Number of pending + processing jobs.
 	 */
 	public function count_active_jobs(): int {
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:disable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders -- The fixed query uses typed placeholders for every identifier and value.
 		$query = $this->wpdb->prepare(
 			'SELECT COUNT(job_id) FROM %i WHERE status IN (%s, %s)',
 			$this->table_name,
 			'pending',
 			'processing'
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:enable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Query is prepared above.
-		return (int) $this->wpdb->get_var( $query );
+		// phpcs:disable WordPress.DB.PreparedSQL -- The query variable is fully prepared immediately above.
+		$count = $this->wpdb->get_var( $query );
+		// phpcs:enable WordPress.DB.PreparedSQL
+		return (int) $count;
 	}
 
 	/** Count terminal jobs whose durable post-commit accounting is incomplete. */
@@ -641,13 +655,17 @@ class Jobs extends BaseRepository {
 		$where_sql    = '' === $where_parts['sql'] ? 'WHERE' : $where_parts['sql'] . ' AND';
 		$where_values = $where_parts['values'];
 		$query_args   = array_merge( array( $this->table_name ), $where_values, array( self::TERMINAL_ACCOUNTING_COMPLETE ) );
-		$query        = $this->wpdb->prepare(
+		// phpcs:disable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders -- The repository builds the WHERE fragment from fixed clauses and passes every value through prepare().
+		$query = $this->wpdb->prepare(
 			"SELECT COUNT(j.job_id) FROM %i j {$where_sql} j.terminal_accounting_state IS NOT NULL AND j.terminal_accounting_state < %d",
 			...$query_args
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Fully prepared bounded aggregate on plugin-owned table.
-		return (int) $this->wpdb->get_var( $query );
+		// phpcs:disable WordPress.DB.PreparedSQL -- The dynamic WHERE query is fully prepared immediately above.
+		$count = $this->wpdb->get_var( $query );
+		// phpcs:enable WordPress.DB.PreparedSQL
+		return (int) $count;
 	}
 
 	/**
@@ -658,14 +676,15 @@ class Jobs extends BaseRepository {
 	public function get_incomplete_terminal_accounting( int $limit = 100 ): array {
 		$limit = max( 1, min( 5000, $limit ) );
 		$query = $this->wpdb->prepare(
-			'SELECT job_id, status, completed_at, terminal_accounting_state FROM %i WHERE terminal_accounting_state IS NOT NULL AND terminal_accounting_state < %d ORDER BY job_id ASC LIMIT %d',
+			'SELECT job_id, status, completed_at, terminal_accounting_state, terminal_accounting_owner, terminal_accounting_claimed_at, terminal_accounting_processed_count FROM %i WHERE terminal_accounting_state IS NOT NULL AND terminal_accounting_state < %d ORDER BY job_id ASC LIMIT %d',
 			$this->table_name,
 			self::TERMINAL_ACCOUNTING_COMPLETE,
 			$limit
 		);
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Fully prepared bounded query on plugin-owned table.
+		// phpcs:disable WordPress.DB.PreparedSQL -- The query variable is fully prepared immediately above.
 		$rows = $this->wpdb->get_results( $query, ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		return is_array( $rows ) ? $rows : array();
 	}
@@ -774,7 +793,7 @@ class Jobs extends BaseRepository {
 	 * Get aggregate status summary rows.
 	 */
 	private function get_status_summary_rows( string $where_sql, array $where_values ): array {
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:disable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders -- Dynamic clauses are fixed repository fragments; every value is passed to prepare().
 		$query = $this->wpdb->prepare(
 			"SELECT
 				CASE
@@ -790,10 +809,11 @@ class Jobs extends BaseRepository {
 			 ORDER BY count DESC",
 			array_merge( array( $this->table_name ), $where_values )
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:enable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above from fixed SQL fragments and placeholders.
+		// phpcs:disable WordPress.DB.PreparedSQL -- The dynamic summary query is fully prepared immediately above.
 		$rows = $this->wpdb->get_results( $query, ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		return $this->normalize_summary_rows( $rows ? $rows : array(), array( 'status' ) );
 	}
@@ -804,7 +824,7 @@ class Jobs extends BaseRepository {
 	private function get_pipeline_summary_rows( string $where_sql, array $where_values ): array {
 		$pipelines_table = $this->wpdb->prefix . 'datamachine_pipelines';
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:disable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders -- Dynamic clauses are fixed repository fragments; every value is passed to prepare().
 		$query = $this->wpdb->prepare(
 			"SELECT j.pipeline_id, p.pipeline_name, COUNT(*) AS count
 			 FROM %i j
@@ -814,10 +834,11 @@ class Jobs extends BaseRepository {
 			 ORDER BY count DESC",
 			array_merge( array( $this->table_name, $pipelines_table ), $where_values )
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:enable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above from fixed SQL fragments and placeholders.
+		// phpcs:disable WordPress.DB.PreparedSQL -- The dynamic summary query is fully prepared immediately above.
 		$rows = $this->wpdb->get_results( $query, ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		return $this->normalize_summary_rows( $rows ? $rows : array(), array( 'pipeline_id', 'pipeline_name' ) );
 	}
@@ -828,7 +849,7 @@ class Jobs extends BaseRepository {
 	private function get_flow_summary_rows( string $where_sql, array $where_values ): array {
 		$flows_table = $this->wpdb->prefix . 'datamachine_flows';
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:disable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders -- Dynamic clauses are fixed repository fragments; every value is passed to prepare().
 		$query = $this->wpdb->prepare(
 			"SELECT j.flow_id, f.flow_name, j.pipeline_id, COUNT(*) AS count
 			 FROM %i j
@@ -838,10 +859,11 @@ class Jobs extends BaseRepository {
 			 ORDER BY count DESC",
 			array_merge( array( $this->table_name, $flows_table ), $where_values )
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:enable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above from fixed SQL fragments and placeholders.
+		// phpcs:disable WordPress.DB.PreparedSQL -- The dynamic summary query is fully prepared immediately above.
 		$rows = $this->wpdb->get_results( $query, ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		return $this->normalize_summary_rows( $rows ? $rows : array(), array( 'flow_id', 'flow_name', 'pipeline_id' ) );
 	}
@@ -867,7 +889,7 @@ class Jobs extends BaseRepository {
 			? "WHERE j.handler_slug IS NOT NULL AND j.handler_slug != ''"
 			: $where_sql . " AND j.handler_slug IS NOT NULL AND j.handler_slug != ''";
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:disable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders -- Dynamic clauses are fixed repository fragments; every value is passed to prepare().
 		$query = $this->wpdb->prepare(
 			"SELECT j.handler_slug AS handler_slug, COUNT(*) AS count
 			 FROM %i j
@@ -876,10 +898,11 @@ class Jobs extends BaseRepository {
 			 ORDER BY count DESC",
 			array_merge( array( $this->table_name ), $where_values )
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:enable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above from fixed SQL fragments and placeholders.
+		// phpcs:disable WordPress.DB.PreparedSQL -- The dynamic summary query is fully prepared immediately above.
 		$rows = $this->wpdb->get_results( $query, ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		return $this->normalize_summary_rows( $rows ? $rows : array(), array( 'handler_slug' ) );
 	}
@@ -895,15 +918,17 @@ class Jobs extends BaseRepository {
 		$stuck_seconds        = defined( 'HOUR_IN_SECONDS' ) ? 2 * HOUR_IN_SECONDS : 7200;
 		$where_values         = array_merge( $where_parts['values'], array( gmdate( 'Y-m-d H:i:s', time() - $stuck_seconds ) ) );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:disable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders -- Dynamic clauses are fixed repository fragments; every value is passed to prepare().
 		$query = $this->wpdb->prepare(
 			"SELECT COUNT(j.job_id) FROM %i j {$where_sql}",
 			array_merge( array( $this->table_name ), $where_values )
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:enable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above from fixed SQL fragments and placeholders.
-		return (int) $this->wpdb->get_var( $query );
+		// phpcs:disable WordPress.DB.PreparedSQL -- The dynamic summary query is fully prepared immediately above.
+		$count = $this->wpdb->get_var( $query );
+		// phpcs:enable WordPress.DB.PreparedSQL
+		return (int) $count;
 	}
 
 	/**
@@ -1111,7 +1136,7 @@ class Jobs extends BaseRepository {
 		// For direct execution jobs, LEFT JOINs will return NULL for pipeline_name/flow_name.
 		// JOIN uses j.pipeline_id (varchar) directly against CAST of p.pipeline_id (int) to varchar
 		// for index-friendly matching on the jobs table side.
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:disable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders -- Select and order fragments are allowlisted repository values; every scalar filter is prepared.
 		$query = $this->wpdb->prepare(
 			"SELECT {$select_fields}{$child_count_select}
 			 FROM %i j
@@ -1126,10 +1151,11 @@ class Jobs extends BaseRepository {
 				array( $per_page, $offset )
 			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:enable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above
+		// phpcs:disable WordPress.DB.PreparedSQL -- The dynamic listing query is fully prepared immediately above.
 		$results = $this->wpdb->get_results( $query, ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL
 		if ( $results && $decode_engine_data ) {
 			foreach ( $results as &$result ) {
 				if ( isset( $result['engine_data'] ) && is_string( $result['engine_data'] ) && '' !== $result['engine_data'] ) {
@@ -1158,12 +1184,12 @@ class Jobs extends BaseRepository {
 	 * @return array{jobs:array,total:int,scanned:int,scan_limit:int,filters:array}
 	 */
 	public function query_executions_by_metadata( array $args = array() ): array {
-		$metadata_filters = ExecutionQuery::normalize_metadata_filters( $args['metadata'] ?? array() );
-		$per_page         = max( 1, min( 500, (int) ( $args['per_page'] ?? 50 ) ) );
-		$offset           = max( 0, (int) ( $args['offset'] ?? 0 ) );
-		$run_metadata     = new RunMetadata();
-		$matching_job_ids = $run_metadata->query_job_ids( $metadata_filters, $per_page, $offset );
-		$total            = $run_metadata->count_jobs( $metadata_filters );
+		$metadata_filters    = ExecutionQuery::normalize_metadata_filters( $args['metadata'] ?? array() );
+		$per_page            = max( 1, min( 500, (int) ( $args['per_page'] ?? 50 ) ) );
+		$offset              = max( 0, (int) ( $args['offset'] ?? 0 ) );
+		$run_metadata        = new RunMetadata();
+		$matching_job_ids    = $run_metadata->query_job_ids( $metadata_filters, $per_page, $offset );
+		$total               = $run_metadata->count_jobs( $metadata_filters );
 		$has_ownership_scope = isset( $args['user_id'] ) || isset( $args['agent_id'] );
 		if ( ! $has_ownership_scope && ( ! empty( $matching_job_ids ) || $total > 0 ) ) {
 			if ( empty( $matching_job_ids ) ) {
@@ -1394,7 +1420,7 @@ class Jobs extends BaseRepository {
 		$placeholders = implode( ',', array_fill( 0, count( $flow_ids ), '%s' ) );
 
 		// Subquery to get max job_id per flow, then join to get full row
-		// phpcs:disable WordPress.DB.PreparedSQL, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:disable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders -- Dynamic IN placeholders match the filtered flow ID values passed to prepare().
 		$query = $this->wpdb->prepare(
 			"SELECT j.* FROM %i j
              INNER JOIN (
@@ -1405,7 +1431,7 @@ class Jobs extends BaseRepository {
              ) latest ON j.job_id = latest.max_job_id",
 			array_merge( array( $this->table_name, $this->table_name ), $flow_ids )
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:enable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders
 
 		// phpcs:disable WordPress.DB.PreparedSQL -- Query is prepared above.
 		$results = $this->wpdb->get_results( $query, ARRAY_A );
@@ -2120,21 +2146,32 @@ class Jobs extends BaseRepository {
 			$status = substr( $status, 0, 252 ) . '...';
 		}
 
+		try {
+			$accounting_context = apply_filters( 'datamachine_job_terminal_accounting_context', array(), $job_id, $status );
+		} catch ( \Throwable ) {
+			$this->rollback_terminal_transition( $job_id );
+			return $this->status_transition_result( false, false, $current_status, $current_status );
+		}
+		$processed_claim_count = is_array( $accounting_context ) ? max( 0, (int) ( $accounting_context['processed_claim_count'] ?? 0 ) ) : 0;
+
 		// The locked row makes this a non-retrying ownership CAS. Any failure rolls
 		// back the whole callback/claim/job unit instead of retrying one statement.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->update(
 			$this->table_name,
 			array(
-				'status'                    => $status,
-				'completed_at'              => current_time( 'mysql', true ),
-				'terminal_accounting_state' => 0,
+				'status'                              => $status,
+				'completed_at'                        => current_time( 'mysql', true ),
+				'terminal_accounting_state'           => 0,
+				'terminal_accounting_owner'           => null,
+				'terminal_accounting_claimed_at'      => null,
+				'terminal_accounting_processed_count' => $processed_claim_count,
 			),
 			array(
 				'job_id' => $job_id,
 				'status' => $current_status,
 			),
-			array( '%s', '%s', '%d' ),
+			array( '%s', '%s', '%d', null, null, '%d' ),
 			array( '%d', '%s' )
 		);
 		if ( 1 !== $updated ) {
@@ -2163,12 +2200,12 @@ class Jobs extends BaseRepository {
 	/**
 	 * Replay missing terminal post-commit accounting stages.
 	 *
-	 * Internal stores are idempotent and receive their bit after success. Hook
-	 * dispatches claim their bit first, giving arbitrary external listeners an
-	 * honest at-most-once contract: process death between the claim and callback
-	 * invocation can lose delivery, but replay never duplicates notifications.
+	 * One leased owner executes each ordered core stage. A process that dies while
+	 * owning a stage leaves the state incomplete; another process can reclaim the
+	 * lease and safely repeat that idempotent stage. Public extension hooks run
+	 * only after all core stages and are best-effort rather than exactly-once.
 	 *
-	 * @return array{success:bool,job_id:int,status:?string,state:?int,complete:bool}
+	 * @return array{success:bool,job_id:int,status:?string,state:?int,stage:?string,in_progress:bool,complete:bool,errors:array}
 	 */
 	public function reconcile_terminal_accounting( int $job_id ): array {
 		$job    = $this->get_job( $job_id );
@@ -2176,81 +2213,170 @@ class Jobs extends BaseRepository {
 		$state  = is_array( $job ) && null !== ( $job['terminal_accounting_state'] ?? null ) ? (int) $job['terminal_accounting_state'] : null;
 
 		if ( null === $status || ! JobStatus::isStatusFinal( $status ) || null === $state ) {
-			return $this->terminal_accounting_result( false, $job_id, $status, $state );
+			return $this->terminal_accounting_result( false, $job_id, $status, $state, null, false, array( $this->terminal_accounting_error( 'validation', 'invalid_terminal_receipt', 'Job is not a receipted terminal row.' ) ) );
 		}
 
-		if ( ! $this->terminal_accounting_has_bit( $job_id, self::TERMINAL_ACCOUNTING_COMMITTED_HOOK ) ) {
-			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'before', 'terminal_committed_hook' );
-			if ( $this->claim_terminal_accounting_bit( $job_id, self::TERMINAL_ACCOUNTING_COMMITTED_HOOK ) ) {
-				do_action( 'datamachine_job_terminal_committed', $job_id, $status );
-				$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'after', 'terminal_committed_hook' );
+		while ( $state < self::TERMINAL_ACCOUNTING_NOTIFY ) {
+			$stage = (string) $this->terminal_accounting_stage_name( $state );
+			$token = $this->claim_terminal_accounting_stage( $job_id, $state );
+			if ( null === $token ) {
+				$current = $this->get_terminal_accounting_state( $job_id );
+				if ( null !== $current && $current > $state ) {
+					$state = $current;
+					continue;
+				}
+				return $this->terminal_accounting_result( false, $job_id, $status, $current, $stage, true );
 			}
+
+			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'before', $stage );
+			$errors = $this->execute_terminal_accounting_stage( $stage, $job );
+			if ( ! empty( $errors ) ) {
+				$this->release_terminal_accounting_stage( $job_id, $state, $token );
+				return $this->terminal_accounting_result( false, $job_id, $status, $state, $stage, false, $errors );
+			}
+			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'after_operation', $stage );
+
+			if ( ! $this->complete_terminal_accounting_stage( $job_id, $state, $token ) ) {
+				$current = $this->get_terminal_accounting_state( $job_id );
+				if ( null === $current || $current <= $state ) {
+					return $this->terminal_accounting_result( false, $job_id, $status, $current, $stage, true );
+				}
+			}
+			++$state;
+			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'after_commit', $stage );
 		}
 
-		if ( ! $this->terminal_accounting_has_bit( $job_id, self::TERMINAL_ACCOUNTING_METRICS ) ) {
-			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'before', 'run_metrics' );
-			if ( ! RunMetrics::complete( $job_id, $status ) ) {
-				return $this->terminal_accounting_result( false, $job_id, $status, $this->get_terminal_accounting_state( $job_id ) );
+		if ( self::TERMINAL_ACCOUNTING_NOTIFY === $state ) {
+			$stage = (string) $this->terminal_accounting_stage_name( $state );
+			$token = $this->claim_terminal_accounting_stage( $job_id, $state );
+			if ( null === $token ) {
+				$current = $this->get_terminal_accounting_state( $job_id );
+				return self::TERMINAL_ACCOUNTING_COMPLETE === $current
+					? $this->terminal_accounting_result( true, $job_id, $status, $current )
+					: $this->terminal_accounting_result( false, $job_id, $status, $current, $stage, true );
 			}
-			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'after', 'run_metrics' );
-			if ( ! $this->claim_terminal_accounting_bit( $job_id, self::TERMINAL_ACCOUNTING_METRICS ) && ! $this->terminal_accounting_has_bit( $job_id, self::TERMINAL_ACCOUNTING_METRICS ) ) {
-				return $this->terminal_accounting_result( false, $job_id, $status, $this->get_terminal_accounting_state( $job_id ) );
+
+			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'before', $stage );
+			if ( ! $this->complete_terminal_accounting_stage( $job_id, $state, $token ) ) {
+				return $this->terminal_accounting_result( false, $job_id, $status, $this->get_terminal_accounting_state( $job_id ), $stage, true );
 			}
+
+			$errors = array();
+			foreach ( array( 'datamachine_job_terminal_committed', 'datamachine_job_complete' ) as $hook ) {
+				try {
+					do_action( $hook, $job_id, $status );
+				} catch ( \Throwable $exception ) {
+					$errors[] = $this->terminal_accounting_error( $stage, 'extension_notification_failed', $exception->getMessage(), $hook );
+				}
+			}
+			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'after_notification', $stage );
+			return $this->terminal_accounting_result( true, $job_id, $status, self::TERMINAL_ACCOUNTING_COMPLETE, null, false, $errors );
 		}
 
-		if ( ! $this->terminal_accounting_has_bit( $job_id, self::TERMINAL_ACCOUNTING_COMPLETE_HOOK ) ) {
-			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'before', 'job_complete_hook' );
-			if ( $this->claim_terminal_accounting_bit( $job_id, self::TERMINAL_ACCOUNTING_COMPLETE_HOOK ) ) {
-				do_action( 'datamachine_job_complete', $job_id, $status );
-				$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'after', 'job_complete_hook' );
-			}
-		}
-
-		if ( ! $this->terminal_accounting_has_bit( $job_id, self::TERMINAL_ACCOUNTING_LIFECYCLE ) ) {
-			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'before', 'run_lifecycle' );
-			if ( ! ( new RunLifecycleStore( $this ) )->mark_job_status( $job_id, $status ) ) {
-				return $this->terminal_accounting_result( false, $job_id, $status, $this->get_terminal_accounting_state( $job_id ) );
-			}
-			$this->maybe_interrupt_terminal_accounting( $job_id, $status, 'after', 'run_lifecycle' );
-			if ( ! $this->claim_terminal_accounting_bit( $job_id, self::TERMINAL_ACCOUNTING_LIFECYCLE ) && ! $this->terminal_accounting_has_bit( $job_id, self::TERMINAL_ACCOUNTING_LIFECYCLE ) ) {
-				return $this->terminal_accounting_result( false, $job_id, $status, $this->get_terminal_accounting_state( $job_id ) );
-			}
-		}
-
-		$state = $this->get_terminal_accounting_state( $job_id );
-		return $this->terminal_accounting_result( self::TERMINAL_ACCOUNTING_COMPLETE === $state, $job_id, $status, $state );
+		return $this->terminal_accounting_result( true, $job_id, $status, $state );
 	}
 
-	/** Atomically claim one accounting receipt bit. */
-	private function claim_terminal_accounting_bit( int $job_id, int $bit ): bool {
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The query is prepared immediately below with typed placeholders.
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier and scalar values use typed placeholders.
-		$query = $this->wpdb->prepare(
-			'UPDATE %i SET terminal_accounting_state = terminal_accounting_state | %d WHERE job_id = %d AND terminal_accounting_state IS NOT NULL AND (terminal_accounting_state & %d) = 0',
+	/** Execute one safely replayable core accounting stage. */
+	private function execute_terminal_accounting_stage( string $stage, array $job ): array {
+		$job_id       = (int) $job['job_id'];
+		$status       = (string) $job['status'];
+		$completed_at = is_string( $job['completed_at'] ?? null ) ? $job['completed_at'] : null;
+
+		if ( 'run_metrics' === $stage ) {
+			$completed = RunMetrics::complete( $job_id, $status, $completed_at, max( 0, (int) ( $job['terminal_accounting_processed_count'] ?? 0 ) ) );
+			return $completed ? array() : array( $this->terminal_accounting_error( $stage, 'run_metrics_failed', 'Run metrics completion failed.' ) );
+		}
+
+		if ( 'core_callbacks' === $stage ) {
+			try {
+				$callbacks = apply_filters( 'datamachine_job_terminal_core_callbacks', array(), $job_id, $status );
+			} catch ( \Throwable $exception ) {
+				return array( $this->terminal_accounting_error( $stage, 'core_callback_registry_failed', $exception->getMessage() ) );
+			}
+			$errors = array();
+			foreach ( is_array( $callbacks ) ? $callbacks : array() as $callback_id => $callback ) {
+				if ( ! is_callable( $callback ) ) {
+					$errors[] = $this->terminal_accounting_error( $stage, 'invalid_core_callback', 'Registered core callback is not callable.', (string) $callback_id );
+					continue;
+				}
+				try {
+					$result = call_user_func( $callback, $job_id, $status );
+					if ( false === $result ) {
+						$errors[] = $this->terminal_accounting_error( $stage, 'core_callback_failed', 'Core callback returned false.', (string) $callback_id );
+					}
+				} catch ( \Throwable $exception ) {
+					$errors[] = $this->terminal_accounting_error( $stage, 'core_callback_exception', $exception->getMessage(), (string) $callback_id );
+				}
+			}
+			return $errors;
+		}
+
+		if ( 'run_lifecycle' === $stage ) {
+			$completed = ( new RunLifecycleStore( $this ) )->mark_job_status( $job_id, $status, $completed_at );
+			return $completed ? array() : array( $this->terminal_accounting_error( $stage, 'run_lifecycle_failed', 'Run lifecycle completion failed.' ) );
+		}
+
+		return array( $this->terminal_accounting_error( $stage, 'unknown_stage', 'Unknown terminal accounting stage.' ) );
+	}
+
+	/** Claim the current ordered stage, reclaiming an expired owner lease. */
+	private function claim_terminal_accounting_stage( int $job_id, int $state ): ?string {
+		$lease_seconds = max( 1, (int) apply_filters( 'datamachine_job_terminal_accounting_lease_seconds', 30, $job_id, $state ) );
+		$claimed_at    = current_time( 'mysql', true );
+		$lease_cutoff  = gmdate( 'Y-m-d H:i:s', time() - $lease_seconds );
+		$token         = bin2hex( random_bytes( 16 ) );
+		$query         = $this->wpdb->prepare(
+			'UPDATE %i SET terminal_accounting_owner = %s, terminal_accounting_claimed_at = %s WHERE job_id = %d AND terminal_accounting_state = %d AND (terminal_accounting_owner IS NULL OR terminal_accounting_claimed_at IS NULL OR terminal_accounting_claimed_at < %s)',
 			$this->table_name,
-			$bit,
+			$token,
+			$claimed_at,
 			$job_id,
-			$bit
+			$state,
+			$lease_cutoff
 		);
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Fully prepared atomic receipt claim.
+		// phpcs:disable WordPress.DB.PreparedSQL -- The query variable is fully prepared immediately above.
 		$claimed = 1 === (int) $this->wpdb->query( $query );
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
-		return $claimed;
+		// phpcs:enable WordPress.DB.PreparedSQL
+		return $claimed ? $token : null;
 	}
 
-	private function terminal_accounting_has_bit( int $job_id, int $bit ): bool {
-		$state = $this->get_terminal_accounting_state( $job_id );
-		// phpcs:ignore WordPress.PHP.YodaConditions.NotYoda -- Bitmask expression is clearest with the requested bit first.
-		return null !== $state && $bit === ( $state & $bit );
+	/** Advance one stage only when the caller still owns it. */
+	private function complete_terminal_accounting_stage( int $job_id, int $state, string $token ): bool {
+		$query = $this->wpdb->prepare(
+			'UPDATE %i SET terminal_accounting_state = %d, terminal_accounting_owner = NULL, terminal_accounting_claimed_at = NULL WHERE job_id = %d AND terminal_accounting_state = %d AND terminal_accounting_owner = %s',
+			$this->table_name,
+			$state + 1,
+			$job_id,
+			$state,
+			$token
+		);
+		// phpcs:disable WordPress.DB.PreparedSQL -- The query variable is fully prepared immediately above.
+		$completed = 1 === (int) $this->wpdb->query( $query );
+		// phpcs:enable WordPress.DB.PreparedSQL
+		return $completed;
+	}
+
+	/** Release a failed stage for immediate retry without advancing it. */
+	private function release_terminal_accounting_stage( int $job_id, int $state, string $token ): void {
+		$query = $this->wpdb->prepare(
+			'UPDATE %i SET terminal_accounting_owner = NULL, terminal_accounting_claimed_at = NULL WHERE job_id = %d AND terminal_accounting_state = %d AND terminal_accounting_owner = %s',
+			$this->table_name,
+			$job_id,
+			$state,
+			$token
+		);
+		// phpcs:disable WordPress.DB.PreparedSQL -- The query variable is fully prepared immediately above.
+		$this->wpdb->query( $query );
+		// phpcs:enable WordPress.DB.PreparedSQL
 	}
 
 	private function get_terminal_accounting_state( int $job_id ): ?int {
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The query is prepared immediately below with typed placeholders.
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier and job ID use typed placeholders.
 		$query = $this->wpdb->prepare( 'SELECT terminal_accounting_state FROM %i WHERE job_id = %d', $this->table_name, $job_id );
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Fully prepared fresh receipt read.
+		// phpcs:disable WordPress.DB.PreparedSQL -- The query variable is fully prepared immediately above.
 		$state = $this->wpdb->get_var( $query );
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		return null === $state ? null : (int) $state;
 	}
@@ -2264,14 +2390,38 @@ class Jobs extends BaseRepository {
 		}
 	}
 
-	/** Build a machine-readable terminal accounting result. */
-	private function terminal_accounting_result( bool $success, int $job_id, ?string $status, ?int $state ): array {
+	private function terminal_accounting_stage_name( int $state ): ?string {
 		return array(
-			'success'  => $success,
-			'job_id'   => $job_id,
-			'status'   => $status,
-			'state'    => $state,
-			'complete' => self::TERMINAL_ACCOUNTING_COMPLETE === $state,
+			self::TERMINAL_ACCOUNTING_METRICS   => 'run_metrics',
+			self::TERMINAL_ACCOUNTING_CORE      => 'core_callbacks',
+			self::TERMINAL_ACCOUNTING_LIFECYCLE => 'run_lifecycle',
+			self::TERMINAL_ACCOUNTING_NOTIFY    => 'extension_notifications',
+		)[ $state ] ?? null;
+	}
+
+	private function terminal_accounting_error( string $stage, string $code, string $message, ?string $callback = null ): array {
+		return array_filter(
+			array(
+				'stage'    => $stage,
+				'code'     => $code,
+				'message'  => $message,
+				'callback' => $callback,
+			),
+			static fn( mixed $value ): bool => null !== $value
+		);
+	}
+
+	/** Build a machine-readable terminal accounting result. */
+	private function terminal_accounting_result( bool $success, int $job_id, ?string $status, ?int $state, ?string $stage = null, bool $in_progress = false, array $errors = array() ): array {
+		return array(
+			'success'     => $success,
+			'job_id'      => $job_id,
+			'status'      => $status,
+			'state'       => $state,
+			'stage'       => $stage,
+			'in_progress' => $in_progress,
+			'complete'    => self::TERMINAL_ACCOUNTING_COMPLETE === $state,
+			'errors'      => $errors,
 		);
 	}
 
@@ -2284,8 +2434,9 @@ class Jobs extends BaseRepository {
 	private function get_job_for_update( int $job_id ): ?array {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; value uses a typed placeholder.
 		$query = $this->wpdb->prepare( 'SELECT * FROM %i WHERE job_id = %d FOR UPDATE', $this->table_name, $job_id );
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- $query is fully prepared above; %i binds the table and %d binds the job ID.
+		// phpcs:disable WordPress.DB.PreparedSQL -- The query variable is fully prepared immediately above.
 		$job = $this->wpdb->get_row( $query, ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL
 		if ( is_array( $job ) && isset( $job['engine_data'] ) && is_string( $job['engine_data'] ) ) {
 			$decoded = json_decode( $job['engine_data'], true );
 			if ( JSON_ERROR_NONE === json_last_error() ) {
@@ -2529,6 +2680,9 @@ class Jobs extends BaseRepository {
 			operation_generation bigint(20) unsigned NOT NULL DEFAULT 0,
 			operation_action_id bigint(20) unsigned NULL DEFAULT NULL,
 			terminal_accounting_state tinyint unsigned NULL DEFAULT NULL,
+			terminal_accounting_owner varchar(64) NULL DEFAULT NULL,
+			terminal_accounting_claimed_at datetime NULL DEFAULT NULL,
+			terminal_accounting_processed_count int unsigned NOT NULL DEFAULT 0,
             created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
             completed_at datetime NULL DEFAULT NULL,
             PRIMARY KEY  (job_id),
@@ -2999,22 +3153,29 @@ class Jobs extends BaseRepository {
 				continue;
 			}
 
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Fixed schema identifiers and definitions.
+			// phpcs:disable WordPress.DB.PreparedSQL -- The migration map contains only fixed plugin-owned identifiers and definitions.
 			$wpdb->query( "ALTER TABLE {$table_name} ADD COLUMN {$column} {$definition}" );
+			// phpcs:enable WordPress.DB.PreparedSQL
 		}
 	}
 
-	/** Add the terminal post-commit receipt column. */
+	/** Add terminal post-commit receipt and lease columns. */
 	private static function migrate_terminal_accounting_column( string $table_name ): void {
 		global $wpdb;
 
-		if ( ! BaseRepository::column_exists( $table_name, 'terminal_accounting_state', $wpdb ) ) {
-			// phpcs:disable WordPress.DB.PreparedSQL -- Fixed plugin-owned schema identifier and integer constant.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
-			$added = $wpdb->query( "ALTER TABLE {$table_name} ADD COLUMN terminal_accounting_state tinyint unsigned NULL DEFAULT NULL" );
-			if ( false === $added ) {
-				return;
+		$columns = array(
+			'terminal_accounting_state'           => 'tinyint unsigned NULL DEFAULT NULL',
+			'terminal_accounting_owner'           => 'varchar(64) NULL DEFAULT NULL',
+			'terminal_accounting_claimed_at'      => 'datetime NULL DEFAULT NULL',
+			'terminal_accounting_processed_count' => 'int unsigned NOT NULL DEFAULT 0',
+		);
+		foreach ( $columns as $column => $definition ) {
+			if ( BaseRepository::column_exists( $table_name, $column, $wpdb ) ) {
+				continue;
 			}
+			// phpcs:disable WordPress.DB.PreparedSQL -- The migration map contains only fixed plugin-owned identifiers and definitions.
+			$wpdb->query( "ALTER TABLE {$table_name} ADD COLUMN {$column} {$definition}" );
+			// phpcs:enable WordPress.DB.PreparedSQL
 		}
 
 		// NULL deliberately means pre-receipt or non-terminal. Legacy terminals

--- a/inc/Core/RunLifecycleStore.php
+++ b/inc/Core/RunLifecycleStore.php
@@ -222,21 +222,22 @@ class RunLifecycleStore {
 	/**
 	 * Mirror an existing job status transition into generic run metadata.
 	 */
-	public function mark_job_status( int $job_id, string $status ): bool {
+	public function mark_job_status( int $job_id, string $status, ?string $completed_at = null ): bool {
 		if ( $job_id <= 0 || '' === $status ) {
 			return false;
 		}
 
 		$result = $this->mutate_run(
 			$job_id,
-			function ( array $meta ) use ( $status ): array {
-				if ( $status === ( $meta['status'] ?? null ) && ( ! JobStatus::isStatusFinal( $status ) || ! empty( $meta['completed_at'] ) ) ) {
+			function ( array $meta ) use ( $status, $completed_at ): array {
+				if ( ( $meta['status'] ?? null ) === $status && ( ! JobStatus::isStatusFinal( $status ) || ! empty( $meta['completed_at'] ) ) ) {
 					return $meta;
 				}
+				$terminal_time      = JobStatus::isStatusFinal( $status ) && ! empty( $completed_at ) ? $completed_at : $this->now();
 				$meta['status']     = $status;
-				$meta['updated_at'] = $this->now();
+				$meta['updated_at'] = $terminal_time;
 				if ( JobStatus::isStatusFinal( $status ) ) {
-					$meta['completed_at'] = $meta['completed_at'] ?? $meta['updated_at'];
+					$meta['completed_at'] = $meta['completed_at'] ?? $terminal_time;
 				}
 				return $meta;
 			}

--- a/inc/Core/RunLifecycleStore.php
+++ b/inc/Core/RunLifecycleStore.php
@@ -230,6 +230,9 @@ class RunLifecycleStore {
 		$result = $this->mutate_run(
 			$job_id,
 			function ( array $meta ) use ( $status ): array {
+				if ( $status === ( $meta['status'] ?? null ) && ( ! JobStatus::isStatusFinal( $status ) || ! empty( $meta['completed_at'] ) ) ) {
+					return $meta;
+				}
 				$meta['status']     = $status;
 				$meta['updated_at'] = $this->now();
 				if ( JobStatus::isStatusFinal( $status ) ) {

--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -176,7 +176,7 @@ class RunMetrics {
 		return ! empty( $result['success'] );
 	}
 
-	public static function complete( int $job_id, string $status ): bool {
+	public static function complete( int $job_id, string $status, ?string $completed_at = null, int $processed_claim_count = 0 ): bool {
 		if ( $job_id <= 0 ) {
 			return false;
 		}
@@ -186,12 +186,18 @@ class RunMetrics {
 		// snapshot — the lost-update race behind batch_state_missing. See #2762.
 		$result = EngineData::mutate(
 			$job_id,
-			static function ( array $engine ) use ( $status, $job_id ): array {
+			static function ( array $engine ) use ( $status, $job_id, $completed_at, $processed_claim_count ): array {
 				$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
+				$applied = max( 0, (int) ( $metrics['terminal_processed_claims_applied'] ?? 0 ) );
+				if ( $processed_claim_count > $applied ) {
+					$metrics['counts']['processed']              += $processed_claim_count - $applied;
+					$metrics['terminal_processed_claims_applied'] = $processed_claim_count;
+				}
 				if ( $status === $metrics['terminal_status'] && ! empty( $metrics['completed_at'] ) && is_array( $engine[ self::RUN_RESULT_KEY ] ?? null ) ) {
+					$engine[ self::KEY ] = $metrics;
 					return $engine;
 				}
-				$now     = self::now();
+				$now = ! empty( $completed_at ) ? $completed_at : self::now();
 
 				if ( empty( $metrics['started_at'] ) ) {
 					$metrics['started_at'] = $engine['started_at'] ?? ( $engine['job']['created_at'] ?? $now );
@@ -276,13 +282,14 @@ class RunMetrics {
 		}
 
 		return array(
-			'counts'           => $counts,
-			'started_at'       => isset( $metrics['started_at'] ) ? (string) $metrics['started_at'] : null,
-			'last_activity_at' => isset( $metrics['last_activity_at'] ) ? (string) $metrics['last_activity_at'] : null,
-			'completed_at'     => isset( $metrics['completed_at'] ) ? (string) $metrics['completed_at'] : null,
-			'duration_seconds' => isset( $metrics['duration_seconds'] ) ? max( 0, (int) $metrics['duration_seconds'] ) : null,
-			'terminal_status'  => isset( $metrics['terminal_status'] ) ? (string) $metrics['terminal_status'] : null,
-			'context'          => is_array( $metrics['context'] ?? null ) ? $metrics['context'] : array(),
+			'counts'                            => $counts,
+			'started_at'                        => isset( $metrics['started_at'] ) ? (string) $metrics['started_at'] : null,
+			'last_activity_at'                  => isset( $metrics['last_activity_at'] ) ? (string) $metrics['last_activity_at'] : null,
+			'completed_at'                      => isset( $metrics['completed_at'] ) ? (string) $metrics['completed_at'] : null,
+			'duration_seconds'                  => isset( $metrics['duration_seconds'] ) ? max( 0, (int) $metrics['duration_seconds'] ) : null,
+			'terminal_status'                   => isset( $metrics['terminal_status'] ) ? (string) $metrics['terminal_status'] : null,
+			'terminal_processed_claims_applied' => max( 0, (int) ( $metrics['terminal_processed_claims_applied'] ?? 0 ) ),
+			'context'                           => is_array( $metrics['context'] ?? null ) ? $metrics['context'] : array(),
 		);
 	}
 

--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -188,6 +188,9 @@ class RunMetrics {
 			$job_id,
 			static function ( array $engine ) use ( $status, $job_id ): array {
 				$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
+				if ( $status === $metrics['terminal_status'] && ! empty( $metrics['completed_at'] ) && is_array( $engine[ self::RUN_RESULT_KEY ] ?? null ) ) {
+					return $engine;
+				}
 				$now     = self::now();
 
 				if ( empty( $metrics['started_at'] ) ) {

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -66,15 +66,22 @@ function datamachine_register_core_actions() {
 
 	add_action( 'datamachine_mark_item_processed', array( MarkItemProcessedHandler::class, 'handle' ), 10, 4 );
 	add_action( 'datamachine_fail_job', array( FailJobHandler::class, 'handle' ), 10, 3 );
-	add_action( 'datamachine_job_complete', array( JobCompleteHandler::class, 'handle' ), 10, 2 );
 	add_action( 'datamachine_log', array( LogHandler::class, 'handle' ), 10, 3 );
 	add_action( 'datamachine_step_lifecycle_inline_continuation', array( StepLifecycleHandler::class, 'handleInlineContinuation' ), 10, 3 );
 	add_action( 'datamachine_step_lifecycle_completed', array( StepLifecycleHandler::class, 'handleCompleted' ), 10, 2 );
 	add_action( 'datamachine_step_lifecycle_failed', array( StepLifecycleHandler::class, 'handleFailed' ), 10, 2 );
-	add_action( 'datamachine_job_complete', array( StepLifecycleHandler::class, 'handleTerminal' ), 5, 2 );
 	add_filter( 'datamachine_job_terminal_status', array( StepLifecycleHandler::class, 'filterTerminalStatus' ), 10, 3 );
+	add_filter( 'datamachine_job_terminal_accounting_context', array( StepLifecycleHandler::class, 'filterTerminalAccountingContext' ), 10, 3 );
 	add_action( 'datamachine_job_terminal_rolled_back', array( StepLifecycleHandler::class, 'handleTerminalRollback' ) );
-	add_action( 'datamachine_job_terminal_committed', array( StepLifecycleHandler::class, 'handleTerminalCommit' ), 10, 2 );
+	add_filter(
+		'datamachine_job_terminal_core_callbacks',
+		static function ( array $callbacks ): array {
+			$callbacks['step_lifecycle'] = array( StepLifecycleHandler::class, 'handleTerminal' );
+			$callbacks['job_complete']   = array( JobCompleteHandler::class, 'handle' );
+			$callbacks['pipeline_batch'] = array( PipelineBatchScheduler::class, 'onChildComplete' );
+			return $callbacks;
+		}
+	);
 	add_action( 'datamachine_batch_items_discarded', array( StepLifecycleHandler::class, 'handleDiscardedPackets' ), 10, 4 );
 	add_filter( 'datamachine_batch_item_cleanup_context', array( StepLifecycleHandler::class, 'captureBatchItemCleanupContext' ), 10, 2 );
 	add_filter( 'datamachine_item_claim_completion_handlers', array( TrackedItems::class, 'registerClaimCompletionHandler' ) );
@@ -121,8 +128,6 @@ function datamachine_register_core_actions() {
 		10,
 		2
 	);
-	add_action( 'datamachine_job_complete', array( PipelineBatchScheduler::class, 'onChildComplete' ), 20, 2 );
-
 	// Register engine abilities (business logic) before hook bridges.
 	new EngineAbilities();
 	datamachine_register_execution_engine();

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -147,13 +147,12 @@ class StepLifecycleHandler {
 		unset( self::$pending_processed_metrics[ $job_id ] );
 	}
 
-	/** Flush deferred metrics after commit and before final metric aggregation. */
-	public static function handleTerminalCommit( int $job_id, string $status ): void {
+	/** Persist transaction-derived accounting before the terminal commit. */
+	public static function filterTerminalAccountingContext( array $context, int $job_id, string $status ): array {
 		$completed = self::$pending_processed_metrics[ $job_id ] ?? 0;
 		unset( self::$pending_processed_metrics[ $job_id ] );
-		if ( JobStatus::isStatusSuccess( $status ) && 0 < $completed ) {
-			RunMetrics::increment( $job_id, 'processed', $completed );
-		}
+		$context['processed_claim_count'] = JobStatus::isStatusSuccess( $status ) ? max( 0, $completed ) : 0;
+		return $context;
 	}
 
 	/**

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -494,6 +494,75 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'failed', $parent_job['status'] );
 	}
 
+	public function test_parent_engine_write_failure_keeps_child_core_stage_retryable(): void {
+		[ $parent_id, $child_id ] = $this->create_terminal_ready_batch();
+		$failure                  = $this->fail_parent_query_once( $parent_id, 'engine_data' );
+
+		add_filter( 'query', $failure );
+		try {
+			$this->assertTrue( $this->jobs_db->complete_job( $child_id, JobStatus::COMPLETED ) );
+		} finally {
+			remove_filter( 'query', $failure );
+		}
+
+		$this->assertSame( JobStatus::PROCESSING, $this->jobs_db->get_job( $parent_id )['status'] );
+		$this->assertSame( 1, (int) $this->jobs_db->get_job( $child_id )['terminal_accounting_state'] );
+
+		$replayed = ( new Jobs() )->reconcile_terminal_accounting( $child_id );
+		$this->assertTrue( $replayed['complete'] );
+		$this->assertSame( JobStatus::COMPLETED, $this->jobs_db->get_job( $parent_id )['status'] );
+	}
+
+	public function test_parent_completion_failure_keeps_child_core_stage_retryable(): void {
+		[ $parent_id, $child_id ] = $this->create_terminal_ready_batch();
+		$failure                  = $this->fail_parent_query_once( $parent_id, 'terminal_accounting_state' );
+
+		add_filter( 'query', $failure );
+		try {
+			$this->assertTrue( $this->jobs_db->complete_job( $child_id, JobStatus::COMPLETED ) );
+		} finally {
+			remove_filter( 'query', $failure );
+		}
+
+		$this->assertSame( JobStatus::PROCESSING, $this->jobs_db->get_job( $parent_id )['status'] );
+		$this->assertSame( 1, (int) $this->jobs_db->get_job( $child_id )['terminal_accounting_state'] );
+
+		$replayed = ( new Jobs() )->reconcile_terminal_accounting( $child_id );
+		$this->assertTrue( $replayed['complete'] );
+		$this->assertSame( JobStatus::COMPLETED, $this->jobs_db->get_job( $parent_id )['status'] );
+	}
+
+	public function test_replay_after_durable_parent_completion_is_idempotent(): void {
+		[ $parent_id, $child_id ] = $this->create_terminal_ready_batch();
+		$interrupted              = false;
+		$interrupt                = static function ( bool $should_interrupt, string $boundary, int $job_id ) use ( $child_id, &$interrupted ): bool {
+			if ( ! $interrupted && $child_id === $job_id && 'after_operation:core_callbacks' === $boundary ) {
+				$interrupted = true;
+				return true;
+			}
+			return $should_interrupt;
+		};
+
+		add_filter( 'datamachine_job_terminal_accounting_interrupt', $interrupt, 10, 3 );
+		try {
+			$this->jobs_db->complete_job( $child_id, JobStatus::COMPLETED );
+			$this->fail( 'Expected interruption after durable parent completion.' );
+		} catch ( \RuntimeException $exception ) {
+			$this->assertSame( 'Terminal accounting interrupted at after_operation:core_callbacks', $exception->getMessage() );
+		} finally {
+			remove_filter( 'datamachine_job_terminal_accounting_interrupt', $interrupt, 10 );
+		}
+
+		$parent = $this->jobs_db->get_job( $parent_id );
+		$this->assertSame( JobStatus::COMPLETED, $parent['status'] );
+		$completed_at = $parent['completed_at'];
+		$this->expire_terminal_accounting_lease( $child_id );
+
+		$replayed = ( new Jobs() )->reconcile_terminal_accounting( $child_id );
+		$this->assertTrue( $replayed['complete'] );
+		$this->assertSame( $completed_at, $this->jobs_db->get_job( $parent_id )['completed_at'] );
+	}
+
 	public function test_final_chunk_completes_parent_when_children_already_terminal(): void {
 		$parent_id = $this->create_parent_job();
 		$engine    = $this->make_engine_snapshot( $parent_id );
@@ -700,5 +769,56 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 
 		$parent_job = $this->jobs_db->get_job( $parent_id );
 		$this->assertEquals( 'processing', $parent_job['status'] );
+	}
+
+	/** @return array{int,int} */
+	private function create_terminal_ready_batch(): array {
+		$parent_id = $this->create_parent_job();
+		$engine    = datamachine_get_engine_data( $parent_id );
+		$engine['batch']           = true;
+		$engine['batch_total']     = 1;
+		$engine['batch_scheduled'] = 1;
+		$engine['batch_context']   = PipelineBatchScheduler::BATCH_CONTEXT;
+		$this->assertTrue( datamachine_set_engine_data( $parent_id, $engine ) );
+
+		$child_id = $this->jobs_db->create_job(
+			array(
+				'pipeline_id'   => $this->test_pipeline_id,
+				'flow_id'       => $this->test_flow_id,
+				'source'        => 'pipeline',
+				'label'         => 'Terminal accounting child',
+				'parent_job_id' => $parent_id,
+			)
+		);
+		$this->assertIsInt( $child_id );
+		$this->assertTrue( $this->jobs_db->start_job( $child_id ) );
+
+		return array( $parent_id, $child_id );
+	}
+
+	private function fail_parent_query_once( int $parent_id, string $required_fragment ): callable {
+		global $wpdb;
+		$table  = $wpdb->prefix . 'datamachine_jobs';
+		$failed = false;
+
+		return static function ( string $query ) use ( $parent_id, $required_fragment, $table, &$failed ): string {
+			$targets_parent = 1 === preg_match( '/(?:`job_id`|job_id)\s*=\s*[\'\"]?' . $parent_id . '[\'\"]?/', $query );
+			if ( ! $failed && str_contains( $query, 'UPDATE ' . $table ) && str_contains( $query, $required_fragment ) && $targets_parent ) {
+				$failed = true;
+				return 'INVALID SQL FOR PIPELINE PARENT FAILURE TEST';
+			}
+			return $query;
+		};
+	}
+
+	private function expire_terminal_accounting_lease( int $job_id ): void {
+		global $wpdb;
+		$wpdb->update(
+			$this->jobs_db->get_table_name(),
+			array( 'terminal_accounting_claimed_at' => '2000-01-01 00:00:00' ),
+			array( 'job_id' => $job_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
 	}
 }

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -496,13 +496,13 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 
 	public function test_parent_engine_write_failure_keeps_child_core_stage_retryable(): void {
 		[ $parent_id, $child_id ] = $this->create_terminal_ready_batch();
-		$failure                  = $this->fail_parent_query_once( $parent_id, 'engine_data' );
+		$failure                  = static fn() => static fn(): bool => false;
 
-		add_filter( 'query', $failure );
+		add_filter( 'datamachine_pipeline_batch_parent_engine_persister', $failure );
 		try {
 			$this->assertTrue( $this->jobs_db->complete_job( $child_id, JobStatus::COMPLETED ) );
 		} finally {
-			remove_filter( 'query', $failure );
+			remove_filter( 'datamachine_pipeline_batch_parent_engine_persister', $failure );
 		}
 
 		$this->assertSame( JobStatus::PROCESSING, $this->jobs_db->get_job( $parent_id )['status'] );
@@ -515,13 +515,13 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 
 	public function test_parent_completion_failure_keeps_child_core_stage_retryable(): void {
 		[ $parent_id, $child_id ] = $this->create_terminal_ready_batch();
-		$failure                  = $this->fail_parent_query_once( $parent_id, 'terminal_accounting_state' );
+		$failure                  = static fn() => static fn(): bool => false;
 
-		add_filter( 'query', $failure );
+		add_filter( 'datamachine_pipeline_batch_parent_completer', $failure );
 		try {
 			$this->assertTrue( $this->jobs_db->complete_job( $child_id, JobStatus::COMPLETED ) );
 		} finally {
-			remove_filter( 'query', $failure );
+			remove_filter( 'datamachine_pipeline_batch_parent_completer', $failure );
 		}
 
 		$this->assertSame( JobStatus::PROCESSING, $this->jobs_db->get_job( $parent_id )['status'] );
@@ -794,21 +794,6 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$this->assertTrue( $this->jobs_db->start_job( $child_id ) );
 
 		return array( $parent_id, $child_id );
-	}
-
-	private function fail_parent_query_once( int $parent_id, string $required_fragment ): callable {
-		global $wpdb;
-		$table  = $wpdb->prefix . 'datamachine_jobs';
-		$failed = false;
-
-		return static function ( string $query ) use ( $parent_id, $required_fragment, $table, &$failed ): string {
-			$targets_parent = 1 === preg_match( '/(?:`job_id`|job_id)\s*=\s*[\'\"]?' . $parent_id . '[\'\"]?/', $query );
-			if ( ! $failed && str_contains( $query, 'UPDATE ' . $table ) && str_contains( $query, $required_fragment ) && $targets_parent ) {
-				$failed = true;
-				return 'INVALID SQL FOR PIPELINE PARENT FAILURE TEST';
-			}
-			return $query;
-		};
 	}
 
 	private function expire_terminal_accounting_lease( int $job_id ): void {

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -9,6 +9,7 @@ namespace DataMachine\Tests\Unit\Core\Database;
 
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\JobStatus;
+use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
 use WP_UnitTestCase;
 
 class JobLifecycleTransitionTest extends WP_UnitTestCase {
@@ -104,83 +105,176 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 			}
 		} finally {
 			remove_filter( 'datamachine_job_terminal_accounting_interrupt', $interrupt, 10 );
-			remove_action( 'datamachine_job_terminal_committed', $committed, 10 );
-			remove_action( 'datamachine_job_complete', $complete, 10 );
 		}
 
-		$job = $this->db_jobs->get_job( $job_id );
-		$this->assertSame( JobStatus::COMPLETED, $job['status'] );
-		$this->assertLessThan( Jobs::TERMINAL_ACCOUNTING_COMPLETE, (int) $job['terminal_accounting_state'] );
-		$this->assertSame( 1, $this->db_jobs->count_incomplete_terminal_accounting() );
-		$metrics_completed_at_before   = $job['engine_data']['run_metrics']['completed_at'] ?? null;
-		$lifecycle_completed_at_before = $job['engine_data']['run_lifecycle']['completed_at'] ?? null;
-
-		add_action( 'datamachine_job_terminal_committed', $committed, 10, 1 );
-		add_action( 'datamachine_job_complete', $complete, 10, 1 );
 		try {
-			$replayed = $this->db_jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
-			$repeated = $this->db_jobs->reconcile_terminal_accounting( $job_id );
+			$job = $this->db_jobs->get_job( $job_id );
+			$this->assertSame( JobStatus::COMPLETED, $job['status'] );
+			if ( Jobs::TERMINAL_ACCOUNTING_COMPLETE !== (int) $job['terminal_accounting_state'] ) {
+				$this->expireTerminalAccountingLease( $job_id );
+			}
+			StepLifecycleHandler::handleTerminalRollback( $job_id );
+
+			$replayed = ( new Jobs() )->reconcile_terminal_accounting( $job_id );
+			$repeated = ( new Jobs() )->reconcile_terminal_accounting( $job_id );
+			$this->assertTrue( $replayed['complete'] );
+			$this->assertTrue( $repeated['complete'] );
+			$this->assertSame( 1, $committed_hooks );
+			$this->assertSame( 1, $complete_hooks );
+
+			$completed_job = $this->db_jobs->get_job( $job_id );
+			$this->assertSame( Jobs::TERMINAL_ACCOUNTING_COMPLETE, (int) $completed_job['terminal_accounting_state'] );
+			$this->assertSame( $completed_job['completed_at'], $completed_job['engine_data']['run_metrics']['completed_at'] );
+			$this->assertSame( $completed_job['completed_at'], $completed_job['engine_data']['run_lifecycle']['completed_at'] );
 		} finally {
 			remove_action( 'datamachine_job_terminal_committed', $committed, 10 );
 			remove_action( 'datamachine_job_complete', $complete, 10 );
-		}
-
-		$this->assertTrue( $replayed['success'] );
-		$this->assertFalse( $replayed['changed'] );
-		$this->assertTrue( $repeated['complete'] );
-		$this->assertSame( Jobs::TERMINAL_ACCOUNTING_COMPLETE, (int) $this->db_jobs->get_job( $job_id )['terminal_accounting_state'] );
-		$this->assertSame( 0, $this->db_jobs->count_incomplete_terminal_accounting() );
-		$this->assertSame( 1, $committed_hooks );
-		$this->assertSame( 1, $complete_hooks );
-		$completed_job = $this->db_jobs->get_job( $job_id );
-		$this->assertSame( JobStatus::COMPLETED, ( new \DataMachine\Core\RunLifecycleStore( $this->db_jobs ) )->get_run( $job_id )['status'] );
-		$this->assertSame( JobStatus::COMPLETED, \DataMachine\Core\RunMetrics::fromJob( $completed_job )['status'] );
-		if ( null !== $metrics_completed_at_before ) {
-			$this->assertSame( $metrics_completed_at_before, $completed_job['engine_data']['run_metrics']['completed_at'] );
-		}
-		if ( null !== $lifecycle_completed_at_before ) {
-			$this->assertSame( $lifecycle_completed_at_before, $completed_job['engine_data']['run_lifecycle']['completed_at'] );
 		}
 	}
 
 	/** @return array<string,array{string}> */
 	public static function terminal_accounting_interruption_boundaries(): array {
 		return array(
-			'before committed hook' => array( 'before:terminal_committed_hook' ),
-			'after committed hook'  => array( 'after:terminal_committed_hook' ),
-			'before metrics'        => array( 'before:run_metrics' ),
-			'after metrics'         => array( 'after:run_metrics' ),
-			'before complete hook'  => array( 'before:job_complete_hook' ),
-			'after complete hook'   => array( 'after:job_complete_hook' ),
-			'before lifecycle'      => array( 'before:run_lifecycle' ),
-			'after lifecycle'       => array( 'after:run_lifecycle' ),
+			'before metrics'             => array( 'before:run_metrics' ),
+			'after metrics operation'    => array( 'after_operation:run_metrics' ),
+			'after metrics commit'       => array( 'after_commit:run_metrics' ),
+			'before core callbacks'      => array( 'before:core_callbacks' ),
+			'after core callbacks'       => array( 'after_operation:core_callbacks' ),
+			'after core commit'          => array( 'after_commit:core_callbacks' ),
+			'before lifecycle'           => array( 'before:run_lifecycle' ),
+			'after lifecycle operation'  => array( 'after_operation:run_lifecycle' ),
+			'after lifecycle commit'     => array( 'after_commit:run_lifecycle' ),
+			'before notifications'       => array( 'before:extension_notifications' ),
+			'after notifications'        => array( 'after_notification:extension_notifications' ),
 		);
 	}
 
-	public function test_throwing_external_hook_is_claimed_at_most_once(): void {
-		$job_id = $this->db_jobs->create_job( array( 'label' => 'At-most-once external hook' ) );
+	public function test_throwing_core_callback_does_not_skip_later_callback_and_remains_replayable(): void {
+		$job_id = $this->db_jobs->create_job( array( 'label' => 'Replayable core callbacks' ) );
 		$this->assertIsInt( $job_id );
 
-		$calls    = 0;
-		$listener = static function ( int $hook_job_id ) use ( $job_id, &$calls ): void {
-			if ( $job_id === $hook_job_id ) {
-				++$calls;
-				throw new \RuntimeException( 'external hook failed after receipt claim' );
-			}
+		$throw_calls = 0;
+		$later_calls = 0;
+		$registry    = static function ( array $callbacks ) use ( &$throw_calls, &$later_calls ): array {
+			$callbacks['throwing_test'] = static function () use ( &$throw_calls ): void {
+				++$throw_calls;
+				if ( $throw_calls <= 2 ) {
+					throw new \RuntimeException( 'core callback interrupted' );
+				}
+			};
+			$callbacks['later_test'] = static function () use ( &$later_calls ): void {
+				++$later_calls;
+			};
+			return $callbacks;
 		};
-		add_action( 'datamachine_job_complete', $listener, 10, 1 );
+		add_filter( 'datamachine_job_terminal_core_callbacks', $registry, 100 );
 		try {
-			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED );
-			$this->fail( 'Expected external hook failure.' );
-		} catch ( \RuntimeException $exception ) {
-			$this->assertSame( 'external hook failed after receipt claim', $exception->getMessage() );
+			$this->assertTrue( $this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
+			$incomplete = $this->db_jobs->get_job( $job_id );
+			$this->assertSame( 1, (int) $incomplete['terminal_accounting_state'] );
+			$this->assertSame( 1, $later_calls, 'later core callback runs despite an earlier exception' );
+
+			$failed = ( new Jobs() )->reconcile_terminal_accounting( $job_id );
+			$this->assertFalse( $failed['success'] );
+			$this->assertSame( 'core_callbacks', $failed['stage'] );
+			$this->assertSame( 'core_callback_exception', $failed['errors'][0]['code'] );
+			$this->assertSame( 'throwing_test', $failed['errors'][0]['callback'] );
+			$this->assertSame( 2, $later_calls );
+
+			$replayed = ( new Jobs() )->reconcile_terminal_accounting( $job_id );
+			$this->assertTrue( $replayed['complete'] );
+			$this->assertSame( 3, $throw_calls );
+			$this->assertSame( 3, $later_calls );
 		} finally {
-			remove_action( 'datamachine_job_complete', $listener, 10 );
+			remove_filter( 'datamachine_job_terminal_core_callbacks', $registry, 100 );
+		}
+	}
+
+	public function test_concurrent_reconciler_cannot_overtake_owned_stage(): void {
+		$job_id          = $this->db_jobs->create_job( array( 'label' => 'Ordered concurrent accounting' ) );
+		$contender       = null;
+		$core_calls      = 0;
+		$core_at_contend = null;
+		$registry        = static function ( array $callbacks ) use ( &$core_calls ): array {
+			$callbacks['ordering_test'] = static function () use ( &$core_calls ): void {
+				++$core_calls;
+			};
+			return $callbacks;
+		};
+		$interleave      = static function ( bool $interrupt, string $boundary, int $filtered_job_id ) use ( $job_id, &$contender, &$core_at_contend, &$core_calls ): bool {
+			if ( $job_id === $filtered_job_id && 'before:run_metrics' === $boundary && null === $contender ) {
+				$contender       = ( new Jobs() )->reconcile_terminal_accounting( $job_id );
+				$core_at_contend = $core_calls;
+			}
+			return $interrupt;
+		};
+
+		add_filter( 'datamachine_job_terminal_core_callbacks', $registry, 100 );
+		add_filter( 'datamachine_job_terminal_accounting_interrupt', $interleave, 10, 3 );
+		try {
+			$this->assertTrue( $this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
+		} finally {
+			remove_filter( 'datamachine_job_terminal_accounting_interrupt', $interleave, 10 );
+			remove_filter( 'datamachine_job_terminal_core_callbacks', $registry, 100 );
 		}
 
-		$this->assertTrue( $this->db_jobs->reconcile_terminal_accounting( $job_id )['complete'] );
-		$this->assertTrue( $this->db_jobs->reconcile_terminal_accounting( $job_id )['complete'] );
-		$this->assertSame( 1, $calls );
+		$this->assertIsArray( $contender );
+		$this->assertTrue( $contender['in_progress'] );
+		$this->assertSame( 'run_metrics', $contender['stage'] );
+		$this->assertSame( 0, $core_at_contend );
+		$this->assertSame( 1, $core_calls );
+		$this->assertSame( Jobs::TERMINAL_ACCOUNTING_COMPLETE, (int) $this->db_jobs->get_job( $job_id )['terminal_accounting_state'] );
+	}
+
+	public function test_extension_listener_exception_is_best_effort_after_core_completion(): void {
+		$job_id      = $this->db_jobs->create_job( array( 'label' => 'Best effort extension notification' ) );
+		$core_calls  = 0;
+		$hook_calls  = 0;
+		$registry    = static function ( array $callbacks ) use ( &$core_calls ): array {
+			$callbacks['notification_order_test'] = static function () use ( &$core_calls ): void {
+				++$core_calls;
+			};
+			return $callbacks;
+		};
+		$listener    = static function () use ( &$hook_calls ): void {
+			++$hook_calls;
+			throw new \RuntimeException( 'extension notification failed' );
+		};
+		$interrupted = false;
+		$interrupt   = static function ( bool $should_interrupt, string $boundary, int $filtered_job_id ) use ( $job_id, &$interrupted ): bool {
+			if ( ! $interrupted && $job_id === $filtered_job_id && 'before:extension_notifications' === $boundary ) {
+				$interrupted = true;
+				return true;
+			}
+			return $should_interrupt;
+		};
+
+		add_filter( 'datamachine_job_terminal_core_callbacks', $registry, 100 );
+		add_action( 'datamachine_job_complete', $listener, 1 );
+		add_filter( 'datamachine_job_terminal_accounting_interrupt', $interrupt, 10, 3 );
+		try {
+			try {
+				$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED );
+				$this->fail( 'Expected interruption before extension notification.' );
+			} catch ( \RuntimeException $exception ) {
+				$this->assertSame( 'Terminal accounting interrupted at before:extension_notifications', $exception->getMessage() );
+			}
+			$this->assertSame( 1, $core_calls );
+			$this->assertSame( 0, $hook_calls );
+
+			remove_filter( 'datamachine_job_terminal_accounting_interrupt', $interrupt, 10 );
+			$this->expireTerminalAccountingLease( $job_id );
+			$result = ( new Jobs() )->reconcile_terminal_accounting( $job_id );
+			$this->assertTrue( $result['complete'] );
+			$this->assertSame( 'extension_notification_failed', $result['errors'][0]['code'] );
+			$this->assertSame( 1, $hook_calls );
+			$this->assertTrue( ( new Jobs() )->reconcile_terminal_accounting( $job_id )['complete'] );
+			$this->assertSame( 1, $hook_calls );
+		} finally {
+			remove_filter( 'datamachine_job_terminal_accounting_interrupt', $interrupt, 10 );
+			remove_filter( 'datamachine_job_terminal_core_callbacks', $registry, 100 );
+			remove_action( 'datamachine_job_complete', $listener, 1 );
+		}
 	}
 
 	public function test_reopening_failed_job_starts_a_fresh_accounting_receipt(): void {
@@ -266,5 +360,16 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 
 	public function test_create_or_get_job_requires_idempotency_key(): void {
 		$this->assertFalse( $this->db_jobs->create_or_get_job( array( 'label' => 'Missing idempotency key' ) ) );
+	}
+
+	private function expireTerminalAccountingLease( int $job_id ): void {
+		global $wpdb;
+		$wpdb->update(
+			$this->db_jobs->get_table_name(),
+			array( 'terminal_accounting_claimed_at' => '2000-01-01 00:00:00' ),
+			array( 'job_id' => $job_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
 	}
 }

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -63,6 +63,141 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @dataProvider terminal_accounting_interruption_boundaries
+	 */
+	public function test_terminal_accounting_replays_from_every_post_commit_boundary( string $boundary ): void {
+		$job_id = $this->db_jobs->create_job( array( 'label' => 'Terminal accounting ' . $boundary ) );
+		$this->assertIsInt( $job_id );
+		$this->assertTrue( $this->db_jobs->start_job( $job_id ) );
+
+		$committed_hooks = 0;
+		$complete_hooks  = 0;
+		$committed       = static function ( int $hook_job_id ) use ( $job_id, &$committed_hooks ): void {
+			if ( $job_id === $hook_job_id ) {
+				++$committed_hooks;
+			}
+		};
+		$complete        = static function ( int $hook_job_id ) use ( $job_id, &$complete_hooks ): void {
+			if ( $job_id === $hook_job_id ) {
+				++$complete_hooks;
+			}
+		};
+		$interrupted     = false;
+		$interrupt       = static function ( bool $should_interrupt, string $current_boundary, int $filtered_job_id ) use ( $boundary, $job_id, &$interrupted ): bool {
+			if ( ! $interrupted && $job_id === $filtered_job_id && $boundary === $current_boundary ) {
+				$interrupted = true;
+				return true;
+			}
+			return $should_interrupt;
+		};
+
+		add_action( 'datamachine_job_terminal_committed', $committed, 10, 1 );
+		add_action( 'datamachine_job_complete', $complete, 10, 1 );
+		add_filter( 'datamachine_job_terminal_accounting_interrupt', $interrupt, 10, 3 );
+		try {
+			try {
+				$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED );
+				$this->fail( 'Expected terminal accounting interruption.' );
+			} catch ( \RuntimeException $exception ) {
+				$this->assertSame( 'Terminal accounting interrupted at ' . $boundary, $exception->getMessage() );
+			}
+		} finally {
+			remove_filter( 'datamachine_job_terminal_accounting_interrupt', $interrupt, 10 );
+			remove_action( 'datamachine_job_terminal_committed', $committed, 10 );
+			remove_action( 'datamachine_job_complete', $complete, 10 );
+		}
+
+		$job = $this->db_jobs->get_job( $job_id );
+		$this->assertSame( JobStatus::COMPLETED, $job['status'] );
+		$this->assertLessThan( Jobs::TERMINAL_ACCOUNTING_COMPLETE, (int) $job['terminal_accounting_state'] );
+		$this->assertSame( 1, $this->db_jobs->count_incomplete_terminal_accounting() );
+		$metrics_completed_at_before   = $job['engine_data']['run_metrics']['completed_at'] ?? null;
+		$lifecycle_completed_at_before = $job['engine_data']['run_lifecycle']['completed_at'] ?? null;
+
+		add_action( 'datamachine_job_terminal_committed', $committed, 10, 1 );
+		add_action( 'datamachine_job_complete', $complete, 10, 1 );
+		try {
+			$replayed = $this->db_jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
+			$repeated = $this->db_jobs->reconcile_terminal_accounting( $job_id );
+		} finally {
+			remove_action( 'datamachine_job_terminal_committed', $committed, 10 );
+			remove_action( 'datamachine_job_complete', $complete, 10 );
+		}
+
+		$this->assertTrue( $replayed['success'] );
+		$this->assertFalse( $replayed['changed'] );
+		$this->assertTrue( $repeated['complete'] );
+		$this->assertSame( Jobs::TERMINAL_ACCOUNTING_COMPLETE, (int) $this->db_jobs->get_job( $job_id )['terminal_accounting_state'] );
+		$this->assertSame( 0, $this->db_jobs->count_incomplete_terminal_accounting() );
+		$this->assertSame( 1, $committed_hooks );
+		$this->assertSame( 1, $complete_hooks );
+		$completed_job = $this->db_jobs->get_job( $job_id );
+		$this->assertSame( JobStatus::COMPLETED, ( new \DataMachine\Core\RunLifecycleStore( $this->db_jobs ) )->get_run( $job_id )['status'] );
+		$this->assertSame( JobStatus::COMPLETED, \DataMachine\Core\RunMetrics::fromJob( $completed_job )['status'] );
+		if ( null !== $metrics_completed_at_before ) {
+			$this->assertSame( $metrics_completed_at_before, $completed_job['engine_data']['run_metrics']['completed_at'] );
+		}
+		if ( null !== $lifecycle_completed_at_before ) {
+			$this->assertSame( $lifecycle_completed_at_before, $completed_job['engine_data']['run_lifecycle']['completed_at'] );
+		}
+	}
+
+	/** @return array<string,array{string}> */
+	public static function terminal_accounting_interruption_boundaries(): array {
+		return array(
+			'before committed hook' => array( 'before:terminal_committed_hook' ),
+			'after committed hook'  => array( 'after:terminal_committed_hook' ),
+			'before metrics'        => array( 'before:run_metrics' ),
+			'after metrics'         => array( 'after:run_metrics' ),
+			'before complete hook'  => array( 'before:job_complete_hook' ),
+			'after complete hook'   => array( 'after:job_complete_hook' ),
+			'before lifecycle'      => array( 'before:run_lifecycle' ),
+			'after lifecycle'       => array( 'after:run_lifecycle' ),
+		);
+	}
+
+	public function test_throwing_external_hook_is_claimed_at_most_once(): void {
+		$job_id = $this->db_jobs->create_job( array( 'label' => 'At-most-once external hook' ) );
+		$this->assertIsInt( $job_id );
+
+		$calls    = 0;
+		$listener = static function ( int $hook_job_id ) use ( $job_id, &$calls ): void {
+			if ( $job_id === $hook_job_id ) {
+				++$calls;
+				throw new \RuntimeException( 'external hook failed after receipt claim' );
+			}
+		};
+		add_action( 'datamachine_job_complete', $listener, 10, 1 );
+		try {
+			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED );
+			$this->fail( 'Expected external hook failure.' );
+		} catch ( \RuntimeException $exception ) {
+			$this->assertSame( 'external hook failed after receipt claim', $exception->getMessage() );
+		} finally {
+			remove_action( 'datamachine_job_complete', $listener, 10 );
+		}
+
+		$this->assertTrue( $this->db_jobs->reconcile_terminal_accounting( $job_id )['complete'] );
+		$this->assertTrue( $this->db_jobs->reconcile_terminal_accounting( $job_id )['complete'] );
+		$this->assertSame( 1, $calls );
+	}
+
+	public function test_reopening_failed_job_starts_a_fresh_accounting_receipt(): void {
+		$job_id = $this->db_jobs->create_job( array( 'label' => 'Fresh retry accounting' ) );
+		$this->assertIsInt( $job_id );
+		$this->assertTrue( $this->db_jobs->complete_job( $job_id, JobStatus::FAILED ) );
+		$this->assertSame( Jobs::TERMINAL_ACCOUNTING_COMPLETE, (int) $this->db_jobs->get_job( $job_id )['terminal_accounting_state'] );
+
+		$this->assertTrue( $this->db_jobs->reopen_failed_job( $job_id ) );
+		$reopened = $this->db_jobs->get_job( $job_id );
+		$this->assertSame( JobStatus::PENDING, $reopened['status'] );
+		$this->assertNull( $reopened['terminal_accounting_state'] );
+
+		$this->assertTrue( $this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
+		$this->assertSame( Jobs::TERMINAL_ACCOUNTING_COMPLETE, (int) $this->db_jobs->get_job( $job_id )['terminal_accounting_state'] );
+	}
+
 	public function test_terminal_status_can_move_from_active_once(): void {
 		$job_id = $this->db_jobs->create_job( array( 'label' => 'Active to terminal' ) );
 		$this->assertIsInt( $job_id );

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -335,30 +335,39 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertSame( 'recovered-revision', $this->tracked->get( self::NAMESPACE, 'process-death-id' )['source_revision'] );
 	}
 
-	public function test_interruption_after_failure_commit_preserves_cleanup_for_replay(): void {
-		$job_id                 = $this->createProcessingJobWithTrackedClaim( 'failed-commit-crash-id', 'must-not-persist' );
-		$interrupt_after_commit = static function ( int $committed_job_id, string $status ) use ( $job_id ): void {
-			if ( $job_id !== $committed_job_id || JobStatus::isStatusSuccess( $status ) ) {
-				return;
-			}
-			throw new \RuntimeException( 'simulated interruption after commit' );
+	public function test_process_death_after_commit_replays_persisted_processed_claim_count(): void {
+		global $wpdb;
+		$job_id    = $this->createProcessingJobWithTrackedClaim( 'commit-crash-id', 'committed-revision' );
+		$interrupt = static function ( bool $should_interrupt, string $boundary, int $filtered_job_id ) use ( $job_id ): bool {
+			return $should_interrupt || ( $job_id === $filtered_job_id && 'before:run_metrics' === $boundary );
 		};
-		add_action( 'datamachine_job_terminal_committed', $interrupt_after_commit, 20, 2 );
+		add_filter( 'datamachine_job_terminal_accounting_interrupt', $interrupt, 20, 3 );
 		try {
-			$this->jobs->transition_job_status_result( $job_id, JobStatus::failed( 'crash-after-commit' )->toString(), true );
+			$this->jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
 			$this->fail( 'Expected the post-commit interruption.' );
 		} catch ( \RuntimeException $exception ) {
-			$this->assertSame( 'simulated interruption after commit', $exception->getMessage() );
+			$this->assertSame( 'Terminal accounting interrupted at before:run_metrics', $exception->getMessage() );
 		} finally {
-			remove_action( 'datamachine_job_terminal_committed', $interrupt_after_commit, 20 );
+			remove_filter( 'datamachine_job_terminal_accounting_interrupt', $interrupt, 20 );
 		}
 
-		$persisted_status = (string) $this->jobs->get_job( $job_id )['status'];
-		$this->assertStringContainsString( 'crash-after-commit', $persisted_status );
-		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'failed-commit-crash-id' ) );
-		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'failed-commit-crash-id' ) );
-		$this->assertTrue( $this->jobs->complete_job( $job_id, $persisted_status ) );
-		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'failed-commit-crash-id' ) );
+		$committed = $this->jobs->get_job( $job_id );
+		$this->assertSame( JobStatus::COMPLETED, $committed['status'] );
+		$this->assertSame( 1, (int) $committed['terminal_accounting_processed_count'] );
+		$this->assertSame( 'committed-revision', $this->tracked->get( self::NAMESPACE, 'commit-crash-id' )['source_revision'] );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'commit-crash-id' ) );
+
+		StepLifecycleHandler::handleTerminalRollback( $job_id );
+		$wpdb->update(
+			$this->jobs->get_table_name(),
+			array( 'terminal_accounting_claimed_at' => '2000-01-01 00:00:00' ),
+			array( 'job_id' => $job_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		$this->assertTrue( ( new Jobs() )->reconcile_terminal_accounting( $job_id )['complete'] );
+		$this->assertTrue( ( new Jobs() )->reconcile_terminal_accounting( $job_id )['complete'] );
+		$this->assertSame( 1, RunMetrics::fromJob( $this->jobs->get_job( $job_id ) )['counts']['processed'] );
 	}
 
 	public function test_cancellation_atomically_releases_mixed_descriptor_and_legacy_claims(): void {

--- a/tests/jobs-terminal-accounting-cli-smoke.php
+++ b/tests/jobs-terminal-accounting-cli-smoke.php
@@ -1,0 +1,88 @@
+<?php
+/** Verify terminal accounting CLI isolates reconciliation failures per job. */
+
+declare(strict_types=1);
+
+namespace DataMachine\Core\Database\Jobs {
+	class Jobs {
+		public const TERMINAL_ACCOUNTING_COMPLETE = 4;
+
+		public function get_incomplete_terminal_accounting( int $limit ): array {
+			return array(
+				array(
+					'job_id'                   => 11,
+					'status'                   => 'completed',
+					'terminal_accounting_state' => 1,
+				),
+				array(
+					'job_id'                   => 12,
+					'status'                   => 'completed',
+					'terminal_accounting_state' => 2,
+				),
+			);
+		}
+
+		public function count_incomplete_terminal_accounting(): int {
+			return 2;
+		}
+
+		public function reconcile_terminal_accounting( int $job_id ): array {
+			if ( 11 === $job_id ) {
+				throw new \RuntimeException( 'simulated reconciliation failure' );
+			}
+
+			return array(
+				'success'     => true,
+				'state'       => self::TERMINAL_ACCOUNTING_COMPLETE,
+				'complete'    => true,
+				'in_progress' => false,
+				'errors'      => array(),
+			);
+		}
+	}
+}
+
+namespace DataMachine\Cli {
+	abstract class BaseCommand {
+		protected function format_items( array $items, array $fields, array $assoc_args, string $default_orderby ): void {}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	class WP_CLI {
+		public static array $printed = array();
+
+		public static function print_value( mixed $value, array $args = array() ): void {
+			self::$printed[] = $value;
+		}
+
+		public static function success( string $message ): void {}
+
+		public static function log( string $message ): void {}
+	}
+
+	require_once dirname( __DIR__ ) . '/inc/Cli/Commands/JobsCommand.php';
+
+	$command = new \DataMachine\Cli\Commands\JobsCommand();
+	$command->reconcile_terminal_accounting( array(), array( 'format' => 'json' ) );
+	$output = WP_CLI::$printed[0] ?? null;
+
+	$assertions = array(
+		'isolation preserves both rows' => 2 === count( $output['jobs'] ?? array() ),
+		'first row is a typed failure'   => 'failed' === ( $output['jobs'][0]['action'] ?? null )
+			&& 'reconciliation_exception' === ( $output['jobs'][0]['errors'][0]['code'] ?? null ),
+		'second row still reconciles'    => 'reconciled' === ( $output['jobs'][1]['action'] ?? null ),
+		'summary counts mixed outcome'   => 1 === ( $output['summary']['failed'] ?? null )
+			&& 1 === ( $output['summary']['reconciled'] ?? null ),
+	);
+
+	$failures = 0;
+	foreach ( $assertions as $label => $passed ) {
+		fwrite( STDOUT, sprintf( "%s: %s\n", $passed ? 'PASS' : 'FAIL', $label ) );
+		$failures += $passed ? 0 : 1;
+	}
+
+	exit( $failures > 0 ? 1 : 0 );
+}

--- a/tests/processed-item-claims-smoke.php
+++ b/tests/processed-item-claims-smoke.php
@@ -142,7 +142,7 @@ assert_claims_smoke( 'claim acquisition handles duplicate contention without bar
 assert_claims_smoke( 'repository ensures claim columns', str_contains( $processed_items, 'function ensure_claim_columns' ) );
 assert_claims_smoke( 'fetch filters active claims through bulk classification', str_contains( $fetch_handler, 'classifySourceItems' ) && str_contains( $processed_items, "'actively_claimed'" ) );
 assert_claims_smoke( 'fetch claims after max_items', strpos( $fetch_handler, 'array_slice' ) < strpos( $fetch_handler, 'claimItems' ) );
-assert_claims_smoke( 'all terminal statuses use one lifecycle hook', str_contains( $actions, "add_action( 'datamachine_job_complete', array( StepLifecycleHandler::class, 'handleTerminal' )" ) );
+assert_claims_smoke( 'all terminal statuses register one replayable core lifecycle callback', str_contains( $actions, "\$callbacks['step_lifecycle'] = array( StepLifecycleHandler::class, 'handleTerminal' )" ) );
 assert_claims_smoke( 'lifecycle uses owner-conditional completion and release', str_contains( $lifecycle, 'complete_owned_claim' ) && str_contains( $lifecycle, 'release_owned_claim' ) );
 assert_claims_smoke( 'lifecycle preserves multiple inline claims', str_contains( $lifecycle, 'CLAIMS_METADATA_KEY' ) && str_contains( $lifecycle, 'uniqueClaims' ) );
 assert_claims_smoke( 'completion consumers register outside generic lifecycle', str_contains( $actions, 'datamachine_item_claim_completion_handlers' ) && ! str_contains( $lifecycle, 'TrackedItems' ) );


### PR DESCRIPTION
## Summary

- replace unordered terminal receipt bits with an ordered, owner-fenced stage machine so concurrent reconcilers cannot overtake in-flight core accounting
- persist the processed-claim count and canonical terminal timestamp before post-commit replay, preserving metrics and lifecycle state across process death
- isolate core callbacks, best-effort extension notifications, and per-job CLI failures with machine-readable reconciliation results

## Ordered lease contract

`terminal_accounting_state` is nullable and advances monotonically:

| State | Stage |
| --- | --- |
| `NULL` | non-terminal or legacy pre-receipt row; never replayed because prior notification delivery is unknowable |
| `0` | run metrics |
| `1` | replayable core callbacks |
| `2` | run lifecycle |
| `3` | best-effort extension notifications |
| `4` | complete |

Each incomplete stage is claimed with `terminal_accounting_owner` and `terminal_accounting_claimed_at`. Only the owner can advance or release the stage. Another reconciler reports `in_progress` until the lease expires, then can reclaim and safely repeat the idempotent core operation.

Core correctness callbacks are registered through `datamachine_job_terminal_core_callbacks` and run individually. One callback failure is recorded without skipping later callbacks; the stage remains replayable. Public `datamachine_job_terminal_committed` and `datamachine_job_complete` hooks run only after core stages and are marked complete before dispatch, giving them an explicit best-effort contract without claiming impossible exactly-once delivery.

## Durable accounting context

The terminal transaction persists:

- canonical `completed_at`
- initial accounting state
- lease fields
- `terminal_accounting_processed_count`

`RunMetrics::complete()` applies the persisted processed count idempotently and uses the job's canonical completion timestamp. `RunLifecycleStore::mark_job_status()` uses that same timestamp, so delayed reconciliation does not rewrite terminal history.

Failed-job reopening clears the receipt, lease, and persisted claim count for a fresh accounting lifecycle.

## CLI and health

- incomplete accounting is exposed in job summaries
- `jobs reconcile-terminal-accounting` defaults to 100 rows, caps at 5,000, and emits per-row stage/error data
- one job exception becomes `reconciliation_exception` and does not prevent later rows from reconciling
- no historical terminal rows are backfilled or replayed

## Verification

Passed:

- changed PHPCS: 0 findings
- changed PHPStan level 7: 0 findings
- `homeboy review audit --profile pr --changed-since origin/main`: 0 introduced findings
- PHP syntax for all 10 changed PHP files
- `git diff --check`
- `php tests/jobs-terminal-accounting-cli-smoke.php`: 4 assertions
- `php tests/processed-item-claims-smoke.php`: 30 assertions
- `php tests/run-metrics-smoke.php`: all pass
- `php tests/prefix-policy-audit.php`: 11 assertions

The focused WordPress-backed lease expiry, persisted claim count, callback isolation, concurrent ordering, and canonical timestamp tests are present in `JobLifecycleTransitionTest` and `ItemClaimLifecycleTest`. Local execution was attempted again but could not reach PHPUnit because WP Codebox timed out on the shared `/mnt/extrachill-workspace/playground-cache/7.0.2.zip.lock` startup lock (`wp-codebox-playground-startup-asset-unavailable`, Homeboy run `31f04b2c-9fd7-42be-9e7f-a03c5a695d20`).

The legacy `job-status-transition-smoke.php` also remains blocked by its known standalone bootstrap defect (`RunMetadata` not loaded), tracked in #2956.

No changelog or version changes.

Closes #2949.