### PR TITLE
fix: keep AI concurrency contention non-failing

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -69,6 +69,11 @@ class ExecuteStepAbility {
 								'type'        => 'string',
 								'description' => __( 'Direct workflow enqueue ownership token.', 'data-machine' ),
 							),
+							'ai_resume_generation'  => array(
+								'type'        => 'integer',
+								'minimum'     => 0,
+								'description' => __( 'AI contention resume ownership generation.', 'data-machine' ),
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -111,6 +116,7 @@ class ExecuteStepAbility {
 		$flow_step_id          = (string) ( $input['flow_step_id'] ?? '' );
 		$operation_generation  = max( 0, (int) ( $input['operation_generation'] ?? 0 ) );
 		$operation_claim_token = (string) ( $input['operation_claim_token'] ?? '' );
+		$ai_resume_generation  = max( 0, (int) ( $input['ai_resume_generation'] ?? 0 ) );
 		$job                   = $this->db_jobs->get_job( $job_id );
 
 		if ( ! $job ) {
@@ -165,7 +171,10 @@ class ExecuteStepAbility {
 
 		try {
 			$engine_snapshot = datamachine_get_engine_data( $job_id );
-			$engine          = new EngineData( $engine_snapshot, $job_id );
+
+			$engine_snapshot['_runtime_ai_resume_generation'] = $ai_resume_generation;
+
+			$engine = new EngineData( $engine_snapshot, $job_id );
 
 			$flow_step_config = $this->resolveFlowStepConfig( $engine, $flow_step_id, $job_id, $engine_snapshot );
 

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -923,7 +923,7 @@ class ExecuteStepAbility {
 			return null;
 		}
 
-		if ( JobStatus::isStatusFailure( $status ) ) {
+		if ( JobStatus::isStatusFinal( $status ) ) {
 			return $status;
 		}
 

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -29,6 +29,7 @@ class RecoverStuckJobsAbility {
 	 */
 	private const RECOVERABLE_ACTION_HOOK_ARGS = array(
 		'datamachine_execute_step'         => 'job_id',
+		'datamachine_resume_ai_step'       => 'job_id',
 		'datamachine_pipeline_batch_chunk' => 'parent_job_id',
 		'datamachine_run_flow_now'         => 'job_id',
 	);
@@ -575,10 +576,11 @@ class RecoverStuckJobsAbility {
 			$wpdb->prepare(
 				"SELECT action_id, args, status, scheduled_date_gmt, last_attempt_gmt
 				 FROM {$actions_table}
-				 WHERE hook = %s
+				 WHERE hook IN ( %s, %s )
 				 AND status IN ( %s, %s )
 				 AND args LIKE %s",
 				'datamachine_execute_step',
+				'datamachine_resume_ai_step',
 				'pending',
 				'in-progress',
 				$like_job_id

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -32,6 +32,7 @@ use DataMachine\Core\RunMetrics;
 use DataMachine\Core\Database\Chat\Chat;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\Database\Jobs\LegacyAIConcurrencyReconciler;
 use AgentsAPI\AI\WP_Agent_Message;
 use DataMachine\Engine\AI\System\Tasks\SystemTask;
 use DataMachine\Engine\Tasks\TaskRegistry;
@@ -546,7 +547,7 @@ class JobsCommand extends BaseCommand {
 		$jobs_db                      = new Jobs();
 		$failed_like                  = $wpdb->esc_like( 'failed' ) . '%';
 		$agent_skipped_like           = $wpdb->esc_like( 'agent_skipped' ) . '%';
-		$historical_contention_status = 'failed - ai_concurrency_defer_exhausted';
+		$historical_contention_status = LegacyAIConcurrencyReconciler::SOURCE_STATUS;
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is from $wpdb->prefix.
 		$rows = $wpdb->get_results(
@@ -592,7 +593,16 @@ class JobsCommand extends BaseCommand {
 				'label'         => (string) ( $row['label'] ?? '' ),
 			);
 
-			if ( ! $dry_run && $jobs_db->complete_job( (int) $row['job_id'], $target_status ) ) {
+			$reconciled = false;
+			if ( ! $dry_run && LegacyAIConcurrencyReconciler::TARGET_STATUS === $target_status ) {
+				$transition             = ( new LegacyAIConcurrencyReconciler() )->reconcile( (int) $row['job_id'] );
+				$reconciled             = ! empty( $transition['success'] );
+				$item['reconciliation'] = $transition['reconciliation'] ?? array();
+			} elseif ( ! $dry_run ) {
+				$reconciled = $jobs_db->complete_job( (int) $row['job_id'], $target_status );
+			}
+
+			if ( $reconciled ) {
 				++$updated;
 				$item['status'] = 'reconciled';
 			} else {
@@ -664,8 +674,8 @@ class JobsCommand extends BaseCommand {
 			return 'completed';
 		}
 
-		if ( 'failed - ai_concurrency_defer_exhausted' === (string) ( $row['status'] ?? '' ) ) {
-			return 'cancelled - ai_concurrency_stranded';
+		if ( LegacyAIConcurrencyReconciler::SOURCE_STATUS === (string) ( $row['status'] ?? '' ) ) {
+			return LegacyAIConcurrencyReconciler::TARGET_STATUS;
 		}
 
 		return '';

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -52,7 +52,7 @@ class JobsCommand extends BaseCommand {
 	 *
 	 * @var array
 	 */
-	private array $liveness_fields = array( 'id', 'flow_id', 'classification', 'age_hours', 'pending_actions', 'in_progress_actions', 'oldest_pending', 'latest_attempt' );
+	private array $liveness_fields = array( 'id', 'flow_id', 'classification', 'age_hours', 'defer_count', 'defer_age_seconds', 'pending_actions', 'in_progress_actions', 'oldest_pending', 'latest_attempt' );
 
 	/**
 	 * Recover stuck jobs that have job_status in engine_data but status is 'processing'.
@@ -245,7 +245,7 @@ class JobsCommand extends BaseCommand {
 	}
 
 	/**
-	 * Diagnose liveness for processing jobs.
+	 * Diagnose liveness for processing jobs and pending backpressure deferrals.
 	 *
 	 * Processing is a broad lifecycle state. This command reports whether each
 	 * processing job is actively executing, waiting on a scheduler action, or
@@ -298,7 +298,7 @@ class JobsCommand extends BaseCommand {
 		$format          = $assoc_args['format'] ?? 'table';
 
 		$jobs_table = $wpdb->prefix . 'datamachine_jobs';
-		$where      = "WHERE status = 'processing'";
+		$where      = "WHERE (status = 'processing' OR (status = 'pending' AND JSON_EXTRACT(engine_data, '$.ai_concurrency_throttle') IS NOT NULL))";
 		$values     = array();
 
 		if ( $flow_id ) {
@@ -320,13 +320,14 @@ class JobsCommand extends BaseCommand {
 
 		$items   = array();
 		$summary = array(
-			'total'             => 0,
-			'active_processing' => 0,
-			'queued_next_step'  => 0,
-			'waiting_children'  => 0,
-			'scheduler_starved' => 0,
-			'stale_in_progress' => 0,
-			'no_scheduler_path' => 0,
+			'total'                   => 0,
+			'active_processing'       => 0,
+			'queued_next_step'        => 0,
+			'waiting_children'        => 0,
+			'scheduler_starved'       => 0,
+			'stale_in_progress'       => 0,
+			'no_scheduler_path'       => 0,
+			'ai_concurrency_deferred' => 0,
 		);
 
 		foreach ( $jobs as $job ) {
@@ -361,10 +362,11 @@ class JobsCommand extends BaseCommand {
 		if ( 'table' === $format ) {
 			WP_CLI::log(
 				sprintf(
-					'Inspected %d processing jobs: %d active, %d queued, %d waiting on children, %d scheduler-starved, %d stale in-progress, %d without scheduler path.',
+					'Inspected %d active jobs: %d active, %d queued, %d AI concurrency-deferred, %d waiting on children, %d scheduler-starved, %d stale in-progress, %d without scheduler path.',
 					$summary['total'],
 					$summary['active_processing'],
 					$summary['queued_next_step'],
+					$summary['ai_concurrency_deferred'],
 					$summary['waiting_children'],
 					$summary['scheduler_starved'],
 					$summary['stale_in_progress'],
@@ -540,30 +542,32 @@ class JobsCommand extends BaseCommand {
 		$limit   = isset( $assoc_args['limit'] ) ? max( 1, min( 5000, (int) $assoc_args['limit'] ) ) : 500;
 		$format  = $assoc_args['format'] ?? 'table';
 
-		$jobs_table         = $wpdb->prefix . 'datamachine_jobs';
-		$jobs_db            = new Jobs();
-		$failed_like        = $wpdb->esc_like( 'failed' ) . '%';
-		$agent_skipped_like = $wpdb->esc_like( 'agent_skipped' ) . '%';
+		$jobs_table                   = $wpdb->prefix . 'datamachine_jobs';
+		$jobs_db                      = new Jobs();
+		$failed_like                  = $wpdb->esc_like( 'failed' ) . '%';
+		$agent_skipped_like           = $wpdb->esc_like( 'agent_skipped' ) . '%';
+		$historical_contention_status = 'failed - ai_concurrency_defer_exhausted';
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is from $wpdb->prefix.
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT job_id, flow_id, parent_job_id, status, label, engine_data
 				FROM {$jobs_table}
-				WHERE (status LIKE %s OR status = 'processing')
+				WHERE ((status LIKE %s OR status = 'processing')
 				AND (
 					engine_data LIKE %s
 					OR engine_data LIKE %s
 					OR JSON_UNQUOTE(JSON_EXTRACT(engine_data, '$.job_status')) LIKE %s
 					OR JSON_UNQUOTE(JSON_EXTRACT(engine_data, '$.runtime_provenance.status.status')) = 'completed'
 					OR JSON_UNQUOTE(JSON_EXTRACT(engine_data, '$.runtime_provenance.status.completed')) = 'true'
-				)
+				)) OR status = %s
 				ORDER BY COALESCE(completed_at, created_at) DESC
 				LIMIT %d",
 				$failed_like,
 				'%Updated wiki article:%',
 				'%Source rejected:%',
 				$agent_skipped_like,
+				$historical_contention_status,
 				$limit
 			),
 			ARRAY_A
@@ -584,7 +588,7 @@ class JobsCommand extends BaseCommand {
 				'flow_id'       => (int) $row['flow_id'],
 				'from_status'   => (string) $row['status'],
 				'target_status' => $target_status,
-				'reason'        => str_starts_with( $target_status, 'agent_skipped' ) ? 'source_rejected' : 'successful_handler_artifact',
+				'reason'        => str_contains( $target_status, 'ai_concurrency_stranded' ) ? 'historical_concurrency_contention' : ( str_starts_with( $target_status, 'agent_skipped' ) ? 'source_rejected' : 'successful_handler_artifact' ),
 				'label'         => (string) ( $row['label'] ?? '' ),
 			);
 
@@ -658,6 +662,10 @@ class JobsCommand extends BaseCommand {
 
 		if ( $this->engine_data_has_successful_runtime( $engine_data ) && $this->engine_data_has_successful_handler_tool( $engine_data ) ) {
 			return 'completed';
+		}
+
+		if ( 'failed - ai_concurrency_defer_exhausted' === (string) ( $row['status'] ?? '' ) ) {
+			return 'cancelled - ai_concurrency_stranded';
 		}
 
 		return '';
@@ -872,7 +880,7 @@ class JobsCommand extends BaseCommand {
 	}
 
 	/**
-	 * Diagnose one processing job's scheduler liveness.
+	 * Diagnose one active job's scheduler liveness.
 	 *
 	 * @param array<string,mixed> $job Job row.
 	 * @param int                 $overdue_minutes Overdue threshold in minutes.
@@ -902,6 +910,9 @@ class JobsCommand extends BaseCommand {
 		$active_children = (int) ( $child_counts['active'] ?? 0 );
 		$total_children  = (int) ( $child_counts['total'] ?? 0 );
 		$batch_total     = (int) ( $engine_data['batch_total'] ?? 0 );
+		$throttle        = is_array( $engine_data['ai_concurrency_throttle'] ?? null ) ? $engine_data['ai_concurrency_throttle'] : array();
+		$first_deferred  = strtotime( (string) ( $throttle['first_deferred_at'] ?? '' ) );
+		$defer_age       = false === $first_deferred ? (int) ( $throttle['defer_age_seconds'] ?? 0 ) : max( 0, time() - $first_deferred );
 
 		if ( ! empty( $in_progress ) && $oldest_progress_age > $overdue_minutes ) {
 			$classification = 'stale_in_progress';
@@ -909,6 +920,8 @@ class JobsCommand extends BaseCommand {
 			$classification = 'active_processing';
 		} elseif ( ! empty( $pending ) && $oldest_pending_age > $overdue_minutes ) {
 			$classification = 'scheduler_starved';
+		} elseif ( ! empty( $throttle ) && 'deferred' === ( $throttle['state'] ?? 'deferred' ) && ! empty( $pending ) ) {
+			$classification = 'ai_concurrency_deferred';
 		} elseif ( ! empty( $pending ) ) {
 			$classification = 'queued_next_step';
 		} elseif ( $active_children > 0 || ( $batch_total > 0 && $total_children < $batch_total ) ) {
@@ -928,6 +941,10 @@ class JobsCommand extends BaseCommand {
 			'created_at'          => (string) ( $job['created_at'] ?? '' ),
 			'age_hours'           => round( $this->minutes_since( (string) ( $job['created_at'] ?? '' ) ) / 60, 1 ),
 			'last_activity_at'    => is_string( $last_activity ) ? $last_activity : '',
+			'defer_count'         => max( 0, (int) ( $throttle['attempts'] ?? 0 ) ),
+			'defer_age_seconds'   => $defer_age,
+			'contention_active'   => ! empty( $throttle ) && 'deferred' === ( $throttle['state'] ?? 'deferred' ),
+			'contention_provider' => (string) ( $throttle['provider'] ?? '' ),
 			'pending_actions'     => count( $pending ),
 			'in_progress_actions' => count( $in_progress ),
 			'complete_actions'    => count( $complete ),

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -579,7 +579,8 @@ class JobsCommand extends BaseCommand {
 		$updated = 0;
 
 		foreach ( $rows as $row ) {
-			$target_status = $this->resolve_reconciled_job_status( $row );
+			$plan          = $this->resolve_reconciled_job_plan( $row );
+			$target_status = $plan['target_status'];
 			if ( '' === $target_status ) {
 				continue;
 			}
@@ -594,7 +595,7 @@ class JobsCommand extends BaseCommand {
 			);
 
 			$reconciled = false;
-			if ( ! $dry_run && LegacyAIConcurrencyReconciler::TARGET_STATUS === $target_status ) {
+			if ( ! $dry_run && 'legacy_ai_concurrency' === $plan['strategy'] ) {
 				$transition             = ( new LegacyAIConcurrencyReconciler() )->reconcile( (int) $row['job_id'] );
 				$reconciled             = ! empty( $transition['success'] );
 				$item['reconciliation'] = $transition['reconciliation'] ?? array();
@@ -655,6 +656,10 @@ class JobsCommand extends BaseCommand {
 	 * @return string Corrected status, or empty string when the row is not safe to repair.
 	 */
 	private function resolve_reconciled_job_status( array $row ): string {
+		if ( LegacyAIConcurrencyReconciler::SOURCE_STATUS === (string) ( $row['status'] ?? '' ) ) {
+			return LegacyAIConcurrencyReconciler::TARGET_STATUS;
+		}
+
 		$engine_data = $this->decode_job_engine_data( $row['engine_data'] ?? null );
 
 		$job_status = isset( $engine_data['job_status'] ) ? (string) $engine_data['job_status'] : '';
@@ -674,11 +679,21 @@ class JobsCommand extends BaseCommand {
 			return 'completed';
 		}
 
-		if ( LegacyAIConcurrencyReconciler::SOURCE_STATUS === (string) ( $row['status'] ?? '' ) ) {
-			return LegacyAIConcurrencyReconciler::TARGET_STATUS;
-		}
-
 		return '';
+	}
+
+	/**
+	 * Resolve both the target and the only authorized transition mechanism.
+	 *
+	 * @return array{target_status:string,strategy:string}
+	 */
+	private function resolve_reconciled_job_plan( array $row ): array {
+		$is_legacy_contention = LegacyAIConcurrencyReconciler::SOURCE_STATUS === (string) ( $row['status'] ?? '' );
+
+		return array(
+			'target_status' => $this->resolve_reconciled_job_status( $row ),
+			'strategy'      => $is_legacy_contention ? 'legacy_ai_concurrency' : 'terminal_transition',
+		);
 	}
 
 	/**
@@ -900,72 +915,15 @@ class JobsCommand extends BaseCommand {
 		$job_id  = (int) ( $job['job_id'] ?? 0 );
 		$actions = $this->get_job_scheduler_actions( $job_id );
 
-		$pending     = array_values( array_filter( $actions, fn( $action ) => 'pending' === ( $action['status'] ?? '' ) ) );
-		$in_progress = array_values( array_filter( $actions, fn( $action ) => 'in-progress' === ( $action['status'] ?? '' ) ) );
-		$complete    = array_values( array_filter( $actions, fn( $action ) => 'complete' === ( $action['status'] ?? '' ) ) );
-		$failed      = array_values( array_filter( $actions, fn( $action ) => 'failed' === ( $action['status'] ?? '' ) ) );
-
-		$oldest_pending      = $this->oldest_action_datetime( $pending, 'scheduled_date_gmt' );
-		$oldest_in_progress  = $this->oldest_action_datetime( $in_progress, 'scheduled_date_gmt' );
-		$latest_attempt      = $this->latest_action_datetime( $actions, 'last_attempt_gmt' );
-		$oldest_pending_age  = $this->minutes_since( $oldest_pending );
-		$oldest_progress_age = $this->minutes_since( $oldest_in_progress );
-
 		$engine_data = json_decode( (string) ( $job['engine_data'] ?? '' ), true );
 		if ( ! is_array( $engine_data ) ) {
 			$engine_data = array();
 		}
 
-		$child_counts    = ! empty( $engine_data['batch'] ) ? $this->get_child_status_counts( $job_id ) : array();
-		$active_children = (int) ( $child_counts['active'] ?? 0 );
-		$total_children  = (int) ( $child_counts['total'] ?? 0 );
-		$batch_total     = (int) ( $engine_data['batch_total'] ?? 0 );
-		$throttle        = is_array( $engine_data['ai_concurrency_throttle'] ?? null ) ? $engine_data['ai_concurrency_throttle'] : array();
-		$first_deferred  = strtotime( (string) ( $throttle['first_deferred_at'] ?? '' ) );
-		$defer_age       = false === $first_deferred ? (int) ( $throttle['defer_age_seconds'] ?? 0 ) : max( 0, time() - $first_deferred );
+		$job['engine_data'] = $engine_data;
+		$child_counts       = ! empty( $engine_data['batch'] ) ? $this->get_child_status_counts( $job_id ) : array();
 
-		if ( ! empty( $in_progress ) && $oldest_progress_age > $overdue_minutes ) {
-			$classification = 'stale_in_progress';
-		} elseif ( ! empty( $in_progress ) ) {
-			$classification = 'active_processing';
-		} elseif ( ! empty( $pending ) && $oldest_pending_age > $overdue_minutes ) {
-			$classification = 'scheduler_starved';
-		} elseif ( ! empty( $throttle ) && 'deferred' === ( $throttle['state'] ?? 'deferred' ) && ! empty( $pending ) ) {
-			$classification = 'ai_concurrency_deferred';
-		} elseif ( ! empty( $pending ) ) {
-			$classification = 'queued_next_step';
-		} elseif ( $active_children > 0 || ( $batch_total > 0 && $total_children < $batch_total ) ) {
-			$classification = 'waiting_children';
-		} else {
-			$classification = 'no_scheduler_path';
-		}
-
-		$last_activity = $engine_data['run_metrics']['last_activity_at'] ?? null;
-
-		return array(
-			'id'                  => $job_id,
-			'flow_id'             => (string) ( $job['flow_id'] ?? '' ),
-			'pipeline_id'         => (string) ( $job['pipeline_id'] ?? '' ),
-			'agent_id'            => isset( $job['agent_id'] ) ? (int) $job['agent_id'] : null,
-			'classification'      => $classification,
-			'created_at'          => (string) ( $job['created_at'] ?? '' ),
-			'age_hours'           => round( $this->minutes_since( (string) ( $job['created_at'] ?? '' ) ) / 60, 1 ),
-			'last_activity_at'    => is_string( $last_activity ) ? $last_activity : '',
-			'defer_count'         => max( 0, (int) ( $throttle['attempts'] ?? 0 ) ),
-			'defer_age_seconds'   => $defer_age,
-			'contention_active'   => ! empty( $throttle ) && 'deferred' === ( $throttle['state'] ?? 'deferred' ),
-			'contention_provider' => (string) ( $throttle['provider'] ?? '' ),
-			'pending_actions'     => count( $pending ),
-			'in_progress_actions' => count( $in_progress ),
-			'complete_actions'    => count( $complete ),
-			'failed_actions'      => count( $failed ),
-			'child_jobs'          => $total_children,
-			'active_children'     => $active_children,
-			'batch_total'         => $batch_total,
-			'oldest_pending'      => $oldest_pending,
-			'oldest_in_progress'  => $oldest_in_progress,
-			'latest_attempt'      => $latest_attempt,
-		);
+		return JobLivenessClassifier::diagnose( $job, $actions, $child_counts, $overdue_minutes, time() );
 	}
 
 	/**
@@ -990,10 +948,11 @@ class JobsCommand extends BaseCommand {
 			$wpdb->prepare(
 				"SELECT action_id, hook, status, scheduled_date_gmt, last_attempt_gmt, attempts, args
 				 FROM {$actions_table}
-				 WHERE hook IN (%s, %s)
+				 WHERE hook IN (%s, %s, %s)
 				 AND (args LIKE %s OR args LIKE %s)
 				 ORDER BY action_id ASC",
 				'datamachine_execute_step',
+				'datamachine_resume_ai_step',
 				PipelineBatchScheduler::BATCH_HOOK,
 				$like_job_id,
 				$like_parent_job_id
@@ -1097,61 +1056,6 @@ class JobsCommand extends BaseCommand {
 		}
 
 		return 0;
-	}
-
-	/**
-	 * Get the oldest non-empty action datetime for a field.
-	 *
-	 * @param array<int,array<string,mixed>> $actions Action rows.
-	 * @param string                         $field Field name.
-	 * @return string Datetime or empty string.
-	 */
-	private function oldest_action_datetime( array $actions, string $field ): string {
-		$values = array_filter( array_map( fn( $action ) => (string) ( $action[ $field ] ?? '' ), $actions ), array( $this, 'is_real_datetime' ) );
-		sort( $values );
-		return $values[0] ?? '';
-	}
-
-	/**
-	 * Get the latest non-empty action datetime for a field.
-	 *
-	 * @param array<int,array<string,mixed>> $actions Action rows.
-	 * @param string                         $field Field name.
-	 * @return string Datetime or empty string.
-	 */
-	private function latest_action_datetime( array $actions, string $field ): string {
-		$values = array_filter( array_map( fn( $action ) => (string) ( $action[ $field ] ?? '' ), $actions ), array( $this, 'is_real_datetime' ) );
-		rsort( $values );
-		return $values[0] ?? '';
-	}
-
-	/**
-	 * Whether a datetime string represents a real Action Scheduler timestamp.
-	 *
-	 * @param string $datetime Datetime string.
-	 * @return bool
-	 */
-	private function is_real_datetime( string $datetime ): bool {
-		return '' !== $datetime && '0000-00-00 00:00:00' !== $datetime;
-	}
-
-	/**
-	 * Minutes since a GMT datetime.
-	 *
-	 * @param string $datetime GMT datetime.
-	 * @return int Minutes elapsed, or 0 for empty/invalid dates.
-	 */
-	private function minutes_since( string $datetime ): int {
-		if ( ! $this->is_real_datetime( $datetime ) ) {
-			return 0;
-		}
-
-		$timestamp = strtotime( $datetime . ' UTC' );
-		if ( false === $timestamp ) {
-			return 0;
-		}
-
-		return max( 0, (int) floor( ( time() - $timestamp ) / 60 ) );
 	}
 
 	/**

--- a/inc/Cli/JobLivenessClassifier.php
+++ b/inc/Cli/JobLivenessClassifier.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Pure scheduler-liveness classification for active jobs.
+ *
+ * @package DataMachine\Cli
+ */
+
+namespace DataMachine\Cli;
+
+defined( 'ABSPATH' ) || exit;
+
+class JobLivenessClassifier {
+	/**
+	 * Classify one job from persisted engine state and scheduler evidence.
+	 *
+	 * @param array<string,mixed>              $job Job row with decoded engine_data.
+	 * @param array<int,array<string,mixed>>   $actions Matching scheduler actions.
+	 * @param array<string,int>                $child_counts Batch child counts.
+	 * @return array<string,mixed>
+	 */
+	public static function diagnose( array $job, array $actions, array $child_counts, int $overdue_minutes, int $now ): array {
+		$pending     = array_values( array_filter( $actions, fn( $action ) => 'pending' === ( $action['status'] ?? '' ) ) );
+		$in_progress = array_values( array_filter( $actions, fn( $action ) => 'in-progress' === ( $action['status'] ?? '' ) ) );
+		$complete    = array_values( array_filter( $actions, fn( $action ) => 'complete' === ( $action['status'] ?? '' ) ) );
+		$failed      = array_values( array_filter( $actions, fn( $action ) => 'failed' === ( $action['status'] ?? '' ) ) );
+
+		$oldest_pending      = self::actionDatetime( $pending, 'scheduled_date_gmt', false );
+		$oldest_in_progress  = self::actionDatetime( $in_progress, 'scheduled_date_gmt', false );
+		$latest_attempt      = self::actionDatetime( $actions, 'last_attempt_gmt', true );
+		$oldest_pending_age  = self::minutesSince( $oldest_pending, $now );
+		$oldest_progress_age = self::minutesSince( $oldest_in_progress, $now );
+
+		$engine_data     = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$job_id          = (int) ( $job['job_id'] ?? 0 );
+		$active_children = (int) ( $child_counts['active'] ?? 0 );
+		$total_children  = (int) ( $child_counts['total'] ?? 0 );
+		$batch_total     = (int) ( $engine_data['batch_total'] ?? 0 );
+		$throttle        = is_array( $engine_data['ai_concurrency_throttle'] ?? null ) ? $engine_data['ai_concurrency_throttle'] : array();
+		$first_deferred  = strtotime( (string) ( $throttle['first_deferred_at'] ?? '' ) );
+		$defer_age       = false === $first_deferred ? (int) ( $throttle['defer_age_seconds'] ?? 0 ) : max( 0, $now - $first_deferred );
+
+		if ( ! empty( $in_progress ) && $oldest_progress_age > $overdue_minutes ) {
+			$classification = 'stale_in_progress';
+		} elseif ( ! empty( $in_progress ) ) {
+			$classification = 'active_processing';
+		} elseif ( ! empty( $pending ) && $oldest_pending_age > $overdue_minutes ) {
+			$classification = 'scheduler_starved';
+		} elseif ( ! empty( $throttle ) && 'deferred' === ( $throttle['state'] ?? 'deferred' ) && ! empty( $pending ) ) {
+			$classification = 'ai_concurrency_deferred';
+		} elseif ( ! empty( $pending ) ) {
+			$classification = 'queued_next_step';
+		} elseif ( $active_children > 0 || ( $batch_total > 0 && $total_children < $batch_total ) ) {
+			$classification = 'waiting_children';
+		} else {
+			$classification = 'no_scheduler_path';
+		}
+
+		$last_activity = $engine_data['run_metrics']['last_activity_at'] ?? null;
+
+		return array(
+			'id'                  => $job_id,
+			'flow_id'             => (string) ( $job['flow_id'] ?? '' ),
+			'pipeline_id'         => (string) ( $job['pipeline_id'] ?? '' ),
+			'agent_id'            => isset( $job['agent_id'] ) ? (int) $job['agent_id'] : null,
+			'classification'      => $classification,
+			'created_at'          => (string) ( $job['created_at'] ?? '' ),
+			'age_hours'           => round( self::minutesSince( (string) ( $job['created_at'] ?? '' ), $now ) / 60, 1 ),
+			'last_activity_at'    => is_string( $last_activity ) ? $last_activity : '',
+			'defer_count'         => max( 0, (int) ( $throttle['attempts'] ?? 0 ) ),
+			'defer_age_seconds'   => $defer_age,
+			'contention_active'   => ! empty( $throttle ) && 'deferred' === ( $throttle['state'] ?? 'deferred' ),
+			'contention_provider' => (string) ( $throttle['provider'] ?? '' ),
+			'pending_actions'     => count( $pending ),
+			'in_progress_actions' => count( $in_progress ),
+			'complete_actions'    => count( $complete ),
+			'failed_actions'      => count( $failed ),
+			'child_jobs'          => $total_children,
+			'active_children'     => $active_children,
+			'batch_total'         => $batch_total,
+			'oldest_pending'      => $oldest_pending,
+			'oldest_in_progress'  => $oldest_in_progress,
+			'latest_attempt'      => $latest_attempt,
+		);
+	}
+
+	/** @param array<int,array<string,mixed>> $actions */
+	private static function actionDatetime( array $actions, string $field, bool $latest ): string {
+		$values = array_values(
+			array_filter(
+				array_map( static fn( array $action ): string => (string) ( $action[ $field ] ?? '' ), $actions ),
+				static fn( string $value ): bool => '' !== $value && '0000-00-00 00:00:00' !== $value
+			)
+		);
+		if ( empty( $values ) ) {
+			return '';
+		}
+
+		sort( $values );
+		return $latest ? (string) end( $values ) : $values[0];
+	}
+
+	private static function minutesSince( string $datetime, int $now ): int {
+		$timestamp = strtotime( $datetime . ' UTC' );
+		return false === $timestamp ? 0 : max( 0, (int) floor( ( $now - $timestamp ) / MINUTE_IN_SECONDS ) );
+	}
+}

--- a/inc/Core/Database/Jobs/LegacyAIConcurrencyReconciler.php
+++ b/inc/Core/Database/Jobs/LegacyAIConcurrencyReconciler.php
@@ -1,0 +1,121 @@
+<?php
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact legacy reconciliation owns this jobs-table transaction.
+/**
+ * One-purpose reconciliation for legacy AI concurrency failures.
+ *
+ * @package DataMachine\Core\Database\Jobs
+ */
+
+namespace DataMachine\Core\Database\Jobs;
+
+use DataMachine\Core\RunLifecycleStore;
+
+defined( 'ABSPATH' ) || exit;
+
+class LegacyAIConcurrencyReconciler {
+	public const SOURCE_STATUS = 'failed - ai_concurrency_defer_exhausted';
+	public const TARGET_STATUS = 'cancelled - ai_concurrency_stranded';
+
+	/**
+	 * Apply the fixed-source/fixed-target terminal reclassification.
+	 *
+	 * @return array{success:bool,changed:bool,current_status:?string,status:string,reconciliation:array<string,mixed>}
+	 */
+	public function reconcile( int $job_id ): array {
+		global $wpdb;
+
+		$audit = array(
+			'type'          => 'legacy_ai_concurrency_failure',
+			'source_status' => self::SOURCE_STATUS,
+			'target_status' => self::TARGET_STATUS,
+		);
+		if ( $job_id <= 0 || false === $wpdb->query( 'START TRANSACTION' ) ) {
+			return $this->result( false, false, null, self::TARGET_STATUS, $audit );
+		}
+
+		$table = $wpdb->prefix . 'datamachine_jobs';
+		$query = $wpdb->prepare( 'SELECT status, engine_data FROM %i WHERE job_id = %d FOR UPDATE', $table, $job_id );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is fully prepared above, including the table identifier.
+		$job = $wpdb->get_row( $query, ARRAY_A );
+		if ( ! is_array( $job ) ) {
+			$wpdb->query( 'ROLLBACK' );
+			return $this->result( false, false, null, self::TARGET_STATUS, $audit );
+		}
+
+		$current_status = is_string( $job['status'] ?? null ) ? $job['status'] : '';
+		$engine_data    = json_decode( (string) ( $job['engine_data'] ?? '' ), true );
+		$engine_data    = is_array( $engine_data ) ? $engine_data : array();
+		if ( self::TARGET_STATUS === $current_status ) {
+			$wpdb->query( 'ROLLBACK' );
+			$existing_audit = is_array( $engine_data['status_reconciliation'] ?? null ) ? $engine_data['status_reconciliation'] : $audit;
+			return $this->result( true, false, $current_status, $current_status, $existing_audit );
+		}
+		if ( self::SOURCE_STATUS !== $current_status ) {
+			$wpdb->query( 'ROLLBACK' );
+			return $this->result( false, false, $current_status, $current_status, $audit );
+		}
+
+		$audit['schema']                      = 'datamachine.status_reconciliation.v1';
+		$audit['reason']                      = 'legacy_contention_misclassified_as_failure';
+		$audit['reconciled_at']               = current_time( 'mysql', true );
+		$audit['actor']                       = defined( 'WP_CLI' ) && WP_CLI ? 'wp_cli' : 'runtime';
+		$engine_data['status_reconciliation'] = $audit;
+		if ( is_array( $engine_data['run_metrics'] ?? null ) ) {
+			$engine_data['run_metrics']['terminal_status']  = self::TARGET_STATUS;
+			$engine_data['run_metrics']['counts']['failed'] = 0;
+		}
+		if ( is_array( $engine_data['run_result'] ?? null ) ) {
+			$engine_data['run_result']['status'] = self::TARGET_STATUS;
+
+			$engine_data['run_result']['outputs']['counts']['failed'] = 0;
+
+			$engine_data['run_result']['diagnostics']['reconciliation'] = $audit;
+		}
+
+		$updated = $wpdb->update(
+			$table,
+			array(
+				'status'      => self::TARGET_STATUS,
+				'engine_data' => wp_json_encode( $engine_data ),
+			),
+			array(
+				'job_id' => $job_id,
+				'status' => self::SOURCE_STATUS,
+			),
+			array( '%s', '%s' ),
+			array( '%d', '%s' )
+		);
+		if ( 1 !== $updated || false === $wpdb->query( 'COMMIT' ) ) {
+			$wpdb->query( 'ROLLBACK' );
+			wp_cache_delete( $job_id, 'datamachine_engine_data' );
+			$winner        = ( new Jobs() )->get_job( $job_id );
+			$winner_status = is_array( $winner ) && is_string( $winner['status'] ?? null ) ? $winner['status'] : $current_status;
+			return $this->result( false, false, $winner_status, $winner_status, $audit );
+		}
+
+		wp_cache_delete( $job_id, 'datamachine_engine_data' );
+		( new RunLifecycleStore( new Jobs() ) )->mark_job_status( $job_id, self::TARGET_STATUS );
+		do_action( 'datamachine_job_status_reconciled', $job_id, $audit );
+		do_action(
+			'datamachine_log',
+			'info',
+			'Legacy AI concurrency failure reclassified',
+			array(
+				'job_id'         => $job_id,
+				'reconciliation' => $audit,
+			)
+		);
+
+		return $this->result( true, true, $current_status, self::TARGET_STATUS, $audit );
+	}
+
+	private function result( bool $success, bool $changed, ?string $current_status, string $status, array $audit ): array {
+		return array(
+			'success'        => $success,
+			'changed'        => $changed,
+			'current_status' => $current_status,
+			'status'         => $status,
+			'reconciliation' => $audit,
+		);
+	}
+}

--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -234,30 +234,31 @@ class RunMetrics {
 		$outcome_classes = self::outcomeClasses( $job, $engine, $counts );
 
 		$summary = array(
-			'job_id'           => (int) ( $job['job_id'] ?? 0 ),
-			'source'           => $job['source'] ?? null,
-			'label'            => $job['label'] ?? ( $job['display_label'] ?? null ),
-			'flow_id'          => $job['flow_id'] ?? null,
-			'pipeline_id'      => $job['pipeline_id'] ?? null,
-			'parent_job_id'    => isset( $job['parent_job_id'] ) ? (int) $job['parent_job_id'] : 0,
-			'status'           => $status,
-			'counts'           => $counts,
-			'outcome_classes'  => $outcome_classes,
-			'child_jobs'       => self::childTotals( (int) ( $job['job_id'] ?? 0 ) ),
-			'timestamps'       => array(
+			'job_id'               => (int) ( $job['job_id'] ?? 0 ),
+			'source'               => $job['source'] ?? null,
+			'label'                => $job['label'] ?? ( $job['display_label'] ?? null ),
+			'flow_id'              => $job['flow_id'] ?? null,
+			'pipeline_id'          => $job['pipeline_id'] ?? null,
+			'parent_job_id'        => isset( $job['parent_job_id'] ) ? (int) $job['parent_job_id'] : 0,
+			'status'               => $status,
+			'counts'               => $counts,
+			'outcome_classes'      => $outcome_classes,
+			'child_jobs'           => self::childTotals( (int) ( $job['job_id'] ?? 0 ) ),
+			'timestamps'           => array(
 				'created_at'       => $job['created_at'] ?? null,
 				'started_at'       => $started_at,
 				'last_activity_at' => $last,
 				'completed_at'     => $ended_at,
 			),
-			'duration_seconds' => self::durationSeconds( $started_at, $duration_end ),
-			'outcome'          => self::outcomeDetails( $job, $engine, $counts, $outcome_classes ),
-			'step_results'     => self::stepResults( $engine ),
-			'run_result'       => self::runResult( $engine, $status ),
-			'context'          => $metrics['context'],
-			'token_usage'      => self::tokenUsage( $engine ),
-			'cost'             => self::cost( $engine ),
-			'backpressure'     => self::backpressure( $engine ),
+			'duration_seconds'     => self::durationSeconds( $started_at, $duration_end ),
+			'outcome'              => self::outcomeDetails( $job, $engine, $counts, $outcome_classes ),
+			'step_results'         => self::stepResults( $engine ),
+			'run_result'           => self::runResult( $engine, $status ),
+			'context'              => $metrics['context'],
+			'token_usage'          => self::tokenUsage( $engine ),
+			'cost'                 => self::cost( $engine ),
+			'backpressure'         => self::backpressure( $engine ),
+			'backpressure_history' => self::backpressureHistory( $engine ),
 		);
 
 		$summary['run_result'] = is_array( $engine[ self::RUN_RESULT_KEY ] ?? null ) ? $engine[ self::RUN_RESULT_KEY ] : RunResult::fromJobSummary( $job, $summary );
@@ -296,6 +297,12 @@ class RunMetrics {
 			'limit'                 => max( 0, (int) ( $throttle['limit'] ?? 0 ) ),
 			'action_id'             => max( 0, (int) ( $throttle['action_id'] ?? 0 ) ),
 		);
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private static function backpressureHistory( array $engine ): array {
+		$history = is_array( $engine['ai_concurrency_history'] ?? null ) ? $engine['ai_concurrency_history'] : array();
+		return array_values( array_filter( $history, 'is_array' ) );
 	}
 
 	public static function normalize( $metrics ): array {

--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -257,11 +257,45 @@ class RunMetrics {
 			'context'          => $metrics['context'],
 			'token_usage'      => self::tokenUsage( $engine ),
 			'cost'             => self::cost( $engine ),
+			'backpressure'     => self::backpressure( $engine ),
 		);
 
 		$summary['run_result'] = is_array( $engine[ self::RUN_RESULT_KEY ] ?? null ) ? $engine[ self::RUN_RESULT_KEY ] : RunResult::fromJobSummary( $job, $summary );
 
 		return $summary;
+	}
+
+	/**
+	 * Return machine-readable scheduler backpressure evidence.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private static function backpressure( array $engine ): array {
+		$throttle = is_array( $engine['ai_concurrency_throttle'] ?? null ) ? $engine['ai_concurrency_throttle'] : array();
+		if ( empty( $throttle ) ) {
+			return array();
+		}
+
+		$first_deferred = strtotime( (string) ( $throttle['first_deferred_at'] ?? '' ) );
+		$age_seconds    = false === $first_deferred ? (int) ( $throttle['defer_age_seconds'] ?? 0 ) : max( 0, time() - $first_deferred );
+
+		return array(
+			'type'                  => 'ai_concurrency',
+			'state'                 => (string) ( $throttle['state'] ?? 'deferred' ),
+			'reason'                => (string) ( $throttle['reason'] ?? 'ai_concurrency_limit' ),
+			'terminal_reason'       => isset( $throttle['terminal_reason'] ) ? (string) $throttle['terminal_reason'] : null,
+			'provider'              => (string) ( $throttle['provider'] ?? '' ),
+			'flow_step_id'          => (string) ( $throttle['flow_step_id'] ?? '' ),
+			'defer_count'           => max( 0, (int) ( $throttle['attempts'] ?? 0 ) ),
+			'defer_age_seconds'     => $age_seconds,
+			'max_defer_age_seconds' => max( 0, (int) ( $throttle['max_defer_age_seconds'] ?? 0 ) ),
+			'first_deferred_at'     => $throttle['first_deferred_at'] ?? null,
+			'last_deferred_at'      => $throttle['last_deferred_at'] ?? null,
+			'next_retry_at'         => $throttle['next_retry_at'] ?? null,
+			'active'                => max( 0, (int) ( $throttle['active'] ?? 0 ) ),
+			'limit'                 => max( 0, (int) ( $throttle['limit'] ?? 0 ) ),
+			'action_id'             => max( 0, (int) ( $throttle['action_id'] ?? 0 ) ),
+		);
 	}
 
 	public static function normalize( $metrics ): array {

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -721,8 +721,10 @@ class AIStep extends Step {
 		);
 		$timestamp     = $now + $delay_seconds;
 		$action_args   = array(
-			'job_id'       => $this->job_id,
-			'flow_step_id' => $this->flow_step_id,
+			'job_id'                => $this->job_id,
+			'flow_step_id'          => $this->flow_step_id,
+			'operation_generation'  => 0,
+			'operation_claim_token' => '',
 		);
 
 		$job = ( new \DataMachine\Core\Database\Jobs\Jobs() )->get_job( $this->job_id );
@@ -730,6 +732,22 @@ class AIStep extends Step {
 			$action_args['operation_generation']  = (int) $job['operation_generation'];
 			$action_args['operation_claim_token'] = (string) ( $job['operation_claim_token'] ?? '' );
 		}
+		$source_generation = max( 0, (int) $this->engine->get( '_runtime_ai_resume_generation', 0 ) );
+		$claim             = AIConcurrencyBackpressure::claimNextGeneration(
+			$this->job_id,
+			$this->flow_step_id,
+			$source_generation,
+			$now
+		);
+		if ( empty( $claim['success'] ) || empty( $claim['owned'] ) ) {
+			( new Jobs() )->update_job_status( $this->job_id, 'pending' );
+			return;
+		}
+
+		$resume_generation                   = (int) $claim['generation'];
+		$action_args['ai_resume_generation'] = $resume_generation;
+		unset( $contention_data['action_id'] );
+		$contention_data['resume_generation'] = $resume_generation;
 
 		$schedule_result = AIConcurrencyBackpressure::scheduleContinuation( $timestamp, $action_args );
 		$action_id       = (int) $schedule_result['action_id'];
@@ -742,6 +760,13 @@ class AIStep extends Step {
 			( new Jobs() )->complete_job( $this->job_id, 'cancelled - ai_concurrency_defer_schedule_failed' );
 			return;
 		}
+		AIConcurrencyBackpressure::recordScheduledAction(
+			$this->job_id,
+			$this->flow_step_id,
+			$resume_generation,
+			(string) $claim['token'],
+			$action_id
+		);
 
 		( new Jobs() )->update_job_status( $this->job_id, 'pending' );
 
@@ -793,6 +818,7 @@ class AIStep extends Step {
 				$history[]                        = AIConcurrencyBackpressure::resolvedState( $throttle, time() );
 				$engine['ai_concurrency_history'] = array_slice( $history, -20 );
 				unset( $engine['ai_concurrency_throttle'] );
+				unset( $engine['ai_concurrency_resume_ownership'] );
 
 				return $engine;
 			},

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -228,6 +228,7 @@ class AIStep extends Step {
 			return array();
 		}
 
+		$this->resolveAIConcurrencyContention();
 		$ai_concurrency_lease = $lease_result['lease'] ?? null;
 
 		try {
@@ -719,7 +720,6 @@ class AIStep extends Step {
 			self::AI_CONCURRENCY_MAX_DEFER_DELAY
 		);
 		$timestamp     = $now + $delay_seconds;
-		$action_id     = false;
 		$action_args   = array(
 			'job_id'       => $this->job_id,
 			'flow_step_id' => $this->flow_step_id,
@@ -731,21 +731,10 @@ class AIStep extends Step {
 			$action_args['operation_claim_token'] = (string) ( $job['operation_claim_token'] ?? '' );
 		}
 
-		$existing_action = function_exists( 'as_next_scheduled_action' )
-			? as_next_scheduled_action( 'datamachine_execute_step', $action_args, 'data-machine' )
-			: false;
-		if ( false !== $existing_action ) {
-			$action_id = (int) ( $existing_throttle['action_id'] ?? 0 );
-		} elseif ( function_exists( 'as_schedule_single_action' ) ) {
-			$action_id = as_schedule_single_action(
-				$timestamp,
-				'datamachine_execute_step',
-				$action_args,
-				'data-machine'
-			);
-		}
+		$schedule_result = AIConcurrencyBackpressure::scheduleContinuation( $timestamp, $action_args );
+		$action_id       = (int) $schedule_result['action_id'];
 
-		if ( false === $action_id ) {
+		if ( empty( $schedule_result['success'] ) || $action_id <= 0 ) {
 			$contention_data['state']           = 'stranded';
 			$contention_data['terminal_reason'] = 'ai_concurrency_defer_schedule_failed';
 			$contention_data['next_retry_at']   = null;
@@ -788,6 +777,39 @@ class AIStep extends Step {
 				'action_id'               => $action_id,
 			)
 		);
+	}
+
+	/** Archive resolved contention and remove the active throttle marker. */
+	private function resolveAIConcurrencyContention(): void {
+		$result = \DataMachine\Core\EngineData::mutate(
+			$this->job_id,
+			function ( array $engine ): array {
+				$throttle = is_array( $engine['ai_concurrency_throttle'] ?? null ) ? $engine['ai_concurrency_throttle'] : array();
+				if ( empty( $throttle ) || (string) ( $throttle['flow_step_id'] ?? '' ) !== $this->flow_step_id ) {
+					return $engine;
+				}
+
+				$history                          = is_array( $engine['ai_concurrency_history'] ?? null ) ? $engine['ai_concurrency_history'] : array();
+				$history[]                        = AIConcurrencyBackpressure::resolvedState( $throttle, time() );
+				$engine['ai_concurrency_history'] = array_slice( $history, -20 );
+				unset( $engine['ai_concurrency_throttle'] );
+
+				return $engine;
+			},
+			'ai_concurrency_resolved'
+		);
+
+		if ( empty( $result['success'] ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'AI concurrency contention resolved but history could not be persisted',
+				array(
+					'job_id'       => $this->job_id,
+					'flow_step_id' => $this->flow_step_id,
+				)
+			);
+		}
 	}
 
 	/**

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -14,6 +14,7 @@ use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\AI\ToolPolicy\PipelineToolPolicyArgs;
 use DataMachine\Core\Steps\StepTypeRegistrationTrait;
 use DataMachine\Core\Steps\QueueableTrait;
+use DataMachine\Engine\AI\AIConcurrencyBackpressure;
 use DataMachine\Engine\AI\ConversationManager;
 use DataMachine\Engine\AI\DataPacketPromptProjector;
 use DataMachine\Engine\AI\PipelineAIConcurrencyLease;
@@ -42,19 +43,16 @@ class AIStep extends Step {
 	use QueueableTrait;
 
 	/**
-	 * Maximum number of times an AI step may defer itself because the pipeline
-	 * AI concurrency slot is saturated before it gives up and fails.
+	 * Maximum age for ordinary AI concurrency contention before work is
+	 * classified as stranded for operator review.
 	 *
-	 * Without this ceiling a saturated single-slot limiter (the default
-	 * `pipeline_ai_concurrency_limit` is 1) lets every contending job
-	 * reschedule its own `datamachine_execute_step` action every throttle
-	 * delay, indefinitely. Under a sustained backlog that turns into millions
-	 * of self-rescheduling actions a day (see #2793). Capping the defers makes
-	 * a saturated queue fail loudly and boundedly instead of churning forever.
+	 * A count is not a safe terminal bound because a healthy single-slot queue
+	 * can legitimately contend many times. The absolute age bounds truly
+	 * stranded work while ordinary contention remains pending (#2929).
 	 *
-	 * Filterable via `datamachine_ai_concurrency_max_defers`.
+	 * Filterable via `datamachine_ai_concurrency_max_defer_age`.
 	 */
-	private const AI_CONCURRENCY_MAX_DEFERS = 30;
+	private const AI_CONCURRENCY_MAX_DEFER_AGE = DAY_IN_SECONDS;
 
 	/**
 	 * Ceiling (seconds) for the exponential backoff applied between AI
@@ -654,10 +652,6 @@ class AIStep extends Step {
 	 * @param array  $lease_result  Limiter result.
 	 */
 	private function deferForAIConcurrency( string $provider_name, array $lease_result ): void {
-		// Count defers per job/step so a permanently saturated slot cannot
-		// reschedule this step forever. The throttle state is keyed by
-		// flow_step_id: a job that legitimately advances to a different AI
-		// step starts its own budget rather than inheriting the prior step's.
 		$existing_throttle = $this->engine instanceof \DataMachine\Core\EngineData
 			? $this->engine->get( 'ai_concurrency_throttle' )
 			: null;
@@ -667,61 +661,50 @@ class AIStep extends Step {
 		if ( (string) ( $existing_throttle['flow_step_id'] ?? '' ) === $this->flow_step_id ) {
 			$prior_attempts = (int) ( $existing_throttle['attempts'] ?? 0 );
 		}
-		$attempt = $prior_attempts + 1;
 
-		$max_defers = max(
-			1,
+		$max_defer_age = max(
+			60,
 			(int) apply_filters(
-				'datamachine_ai_concurrency_max_defers',
-				self::AI_CONCURRENCY_MAX_DEFERS,
+				'datamachine_ai_concurrency_max_defer_age',
+				self::AI_CONCURRENCY_MAX_DEFER_AGE,
 				$provider_name,
 				$this->job_id
 			)
 		);
 
-		// Budget exhausted: stop self-rescheduling and route through the normal
-		// failure path. This bounds the runaway — a saturated queue fails loudly
-		// instead of generating self-rescheduling actions indefinitely (#2793).
-		if ( $attempt > $max_defers ) {
+		$now             = time();
+		$contention      = AIConcurrencyBackpressure::nextState( $existing_throttle, $this->flow_step_id, $now, $max_defer_age );
+		$attempt         = (int) $contention['attempts'];
+		$contention_data = array_merge(
+			$contention,
+			array(
+				'reason'       => 'ai_concurrency_limit',
+				'provider'     => $provider_name,
+				'flow_step_id' => $this->flow_step_id,
+				'limit'        => (int) ( $lease_result['limit'] ?? 0 ),
+				'active'       => (int) ( $lease_result['active'] ?? 0 ),
+			)
+		);
+
+		if ( 'stranded' === $contention['state'] ) {
+			$contention_data['terminal_reason'] = 'ai_concurrency_stranded';
+			$contention_data['next_retry_at']   = null;
+			datamachine_merge_engine_data( $this->job_id, array( 'ai_concurrency_throttle' => $contention_data ) );
+			( new Jobs() )->complete_job( $this->job_id, 'cancelled - ai_concurrency_stranded' );
+
 			do_action(
 				'datamachine_log',
-				'error',
-				'Pipeline AI step exhausted concurrency defer budget; failing job',
+				'warning',
+				'Pipeline AI step exceeded maximum contention age; job requires operator review',
 				array(
-					'job_id'       => $this->job_id,
-					'flow_step_id' => $this->flow_step_id,
-					'provider'     => $provider_name,
-					'attempts'     => $prior_attempts,
-					'max_defers'   => $max_defers,
-					'limit'        => (int) ( $lease_result['limit'] ?? 0 ),
-					'active'       => (int) ( $lease_result['active'] ?? 0 ),
-				)
-			);
-
-			// Clear the throttle marker so ExecuteStepAbility does not treat the
-			// empty packet list as an already-routed retry and swallow the failure.
-			datamachine_merge_engine_data(
-				$this->job_id,
-				array( 'ai_concurrency_throttle' => array() )
-			);
-
-			do_action(
-				'datamachine_fail_job',
-				$this->job_id,
-				'ai_concurrency_defer_exhausted',
-				array(
-					'flow_step_id'  => $this->flow_step_id,
-					'ai_provider'   => $provider_name,
-					'attempts'      => $prior_attempts,
-					'max_defers'    => $max_defers,
-					// Terminal, not retryable: the defer budget IS the retry
-					// budget for this contention. Retrying would re-enter the
-					// same starvation and reopen the runaway (#2793).
-					'retryable'     => false,
-					'error_message' => sprintf(
-						'AI concurrency slot saturated; gave up after %d defers.',
-						$prior_attempts
-					),
+					'job_id'                => $this->job_id,
+					'flow_step_id'          => $this->flow_step_id,
+					'provider'              => $provider_name,
+					'attempts'              => $attempt,
+					'defer_age_seconds'     => (int) $contention['defer_age_seconds'],
+					'max_defer_age_seconds' => $max_defer_age,
+					'limit'                 => (int) ( $lease_result['limit'] ?? 0 ),
+					'active'                => (int) ( $lease_result['active'] ?? 0 ),
 				)
 			);
 			return;
@@ -730,23 +713,30 @@ class AIStep extends Step {
 		// Exponential backoff between defers, capped, so a long-saturated queue
 		// backs off instead of polling the limiter on the base delay forever.
 		$base_delay    = max( 1, (int) ( $lease_result['delay'] ?? 10 ) );
-		$delay_seconds = min(
-			self::AI_CONCURRENCY_MAX_DEFER_DELAY,
-			$base_delay * ( 2 ** min( $prior_attempts, 16 ) )
+		$delay_seconds = AIConcurrencyBackpressure::delaySeconds(
+			$base_delay,
+			$prior_attempts,
+			self::AI_CONCURRENCY_MAX_DEFER_DELAY
 		);
-		$timestamp     = time() + $delay_seconds;
+		$timestamp     = $now + $delay_seconds;
 		$action_id     = false;
 		$action_args   = array(
 			'job_id'       => $this->job_id,
 			'flow_step_id' => $this->flow_step_id,
 		);
+
 		$job = ( new \DataMachine\Core\Database\Jobs\Jobs() )->get_job( $this->job_id );
 		if ( 'direct' === (string) ( $job['flow_id'] ?? '' ) && (int) ( $job['operation_generation'] ?? 0 ) > 0 ) {
-			$action_args['operation_generation'] = (int) $job['operation_generation'];
+			$action_args['operation_generation']  = (int) $job['operation_generation'];
 			$action_args['operation_claim_token'] = (string) ( $job['operation_claim_token'] ?? '' );
 		}
 
-		if ( function_exists( 'as_schedule_single_action' ) ) {
+		$existing_action = function_exists( 'as_next_scheduled_action' )
+			? as_next_scheduled_action( 'datamachine_execute_step', $action_args, 'data-machine' )
+			: false;
+		if ( false !== $existing_action ) {
+			$action_id = (int) ( $existing_throttle['action_id'] ?? 0 );
+		} elseif ( function_exists( 'as_schedule_single_action' ) ) {
 			$action_id = as_schedule_single_action(
 				$timestamp,
 				'datamachine_execute_step',
@@ -756,16 +746,11 @@ class AIStep extends Step {
 		}
 
 		if ( false === $action_id ) {
-			do_action(
-				'datamachine_fail_job',
-				$this->job_id,
-				'ai_concurrency_defer_failed',
-				array(
-					'flow_step_id'  => $this->flow_step_id,
-					'ai_provider'   => $provider_name,
-					'error_message' => 'AI concurrency throttle could not reschedule the step.',
-				)
-			);
+			$contention_data['state']           = 'stranded';
+			$contention_data['terminal_reason'] = 'ai_concurrency_defer_schedule_failed';
+			$contention_data['next_retry_at']   = null;
+			datamachine_merge_engine_data( $this->job_id, array( 'ai_concurrency_throttle' => $contention_data ) );
+			( new Jobs() )->complete_job( $this->job_id, 'cancelled - ai_concurrency_defer_schedule_failed' );
 			return;
 		}
 
@@ -774,17 +759,13 @@ class AIStep extends Step {
 		datamachine_merge_engine_data(
 			$this->job_id,
 			array(
-				'ai_concurrency_throttle' => array(
-					'next_retry_at'           => gmdate( 'c', $timestamp ),
-					'rescheduled_for_seconds' => $delay_seconds,
-					'reason'                  => 'ai_concurrency_limit',
-					'provider'                => $provider_name,
-					'flow_step_id'            => $this->flow_step_id,
-					'attempts'                => $attempt,
-					'max_defers'              => $max_defers,
-					'limit'                   => (int) ( $lease_result['limit'] ?? 0 ),
-					'active'                  => (int) ( $lease_result['active'] ?? 0 ),
-					'action_id'               => $action_id,
+				'ai_concurrency_throttle' => array_merge(
+					$contention_data,
+					array(
+						'next_retry_at'           => gmdate( 'c', $timestamp ),
+						'rescheduled_for_seconds' => $delay_seconds,
+						'action_id'               => $action_id,
+					)
 				),
 			)
 		);
@@ -799,7 +780,8 @@ class AIStep extends Step {
 				'provider'                => $provider_name,
 				'reason'                  => 'ai_concurrency_limit',
 				'attempts'                => $attempt,
-				'max_defers'              => $max_defers,
+				'defer_age_seconds'       => (int) $contention['defer_age_seconds'],
+				'max_defer_age_seconds'   => $max_defer_age,
 				'limit'                   => (int) ( $lease_result['limit'] ?? 0 ),
 				'active'                  => (int) ( $lease_result['active'] ?? 0 ),
 				'rescheduled_for_seconds' => $delay_seconds,

--- a/inc/Engine/AI/AIConcurrencyBackpressure.php
+++ b/inc/Engine/AI/AIConcurrencyBackpressure.php
@@ -7,12 +7,15 @@
 
 namespace DataMachine\Engine\AI;
 
+use DataMachine\Core\EngineData;
+
 defined( 'ABSPATH' ) || exit;
 
 class AIConcurrencyBackpressure {
 	public const RESUME_HOOK = 'datamachine_resume_ai_step';
 
 	private const RESUME_GROUP_PREFIX = 'data-machine-ai-resume-';
+	private const OWNERSHIP_KEY       = 'ai_concurrency_resume_ownership';
 
 	/**
 	 * Resolve the next durable contention state.
@@ -99,9 +102,146 @@ class AIConcurrencyBackpressure {
 	public static function continuationGroup( array $args ): string {
 		$job_id       = max( 0, (int) ( $args['job_id'] ?? 0 ) );
 		$flow_step_id = (string) ( $args['flow_step_id'] ?? '' );
-		$scope        = $job_id . ':' . $flow_step_id;
+		$generation   = max( 0, (int) ( $args['ai_resume_generation'] ?? 0 ) );
+		$scope        = $job_id . ':' . $flow_step_id . ':' . $generation;
 
-		return self::RESUME_GROUP_PREFIX . $job_id . '-' . substr( hash( 'sha256', $scope ), 0, 16 );
+		return self::RESUME_GROUP_PREFIX . $job_id . '-' . $generation . '-' . substr( hash( 'sha256', $scope ), 0, 16 );
+	}
+
+	/**
+	 * Atomically claim or reuse the next resume generation.
+	 *
+	 * @return array{success:bool,owned:bool,generation:int,action_id:int,token:string}
+	 */
+	public static function claimNextGeneration( int $job_id, string $flow_step_id, int $source_generation, int $now ): array {
+		$token  = bin2hex( random_bytes( 16 ) );
+		$result = EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $flow_step_id, $source_generation, $token, $now ): ?array {
+				$current = is_array( $engine[ self::OWNERSHIP_KEY ] ?? null ) ? $engine[ self::OWNERSHIP_KEY ] : array();
+				$next    = self::nextGenerationState( $current, $flow_step_id, $source_generation, $token, $now );
+				if ( null === $next ) {
+					return null;
+				}
+
+				$engine[ self::OWNERSHIP_KEY ] = $next;
+				return $engine;
+			},
+			'ai_resume_generation_claim'
+		);
+
+		$state      = is_array( $result['snapshot'][ self::OWNERSHIP_KEY ] ?? null ) ? $result['snapshot'][ self::OWNERSHIP_KEY ] : array();
+		$generation = max( 0, (int) ( $state['generation'] ?? 0 ) );
+		$valid      = ! empty( $result['success'] )
+			&& (string) ( $state['flow_step_id'] ?? '' ) === $flow_step_id
+			&& (int) ( $state['source_generation'] ?? -1 ) === $source_generation
+			&& 'scheduled' === (string) ( $state['status'] ?? '' );
+
+		return array(
+			'success'    => $valid,
+			'owned'      => $valid && (string) ( $state['token'] ?? '' ) === $token,
+			'generation' => $generation,
+			'action_id'  => max( 0, (int) ( $state['action_id'] ?? 0 ) ),
+			'token'      => $token,
+		);
+	}
+
+	/**
+	 * Resolve the next ownership projection without persistence.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	public static function nextGenerationState( array $state, string $flow_step_id, int $source_generation, string $token, int $now ): ?array {
+		$source_generation = max( 0, $source_generation );
+		if ( empty( $state ) || (string) ( $state['flow_step_id'] ?? '' ) !== $flow_step_id ) {
+			if ( 0 !== $source_generation ) {
+				return null;
+			}
+			return self::newGenerationState( $flow_step_id, 0, $token, $now );
+		}
+
+		$current_generation = max( 0, (int) ( $state['generation'] ?? 0 ) );
+		if ( $source_generation < $current_generation ) {
+			$is_existing_next = (int) ( $state['source_generation'] ?? -1 ) === $source_generation
+				&& 'scheduled' === (string) ( $state['status'] ?? '' );
+			return $is_existing_next ? $state : null;
+		}
+		if ( 0 !== $current_generation - $source_generation || 'running' !== (string) ( $state['status'] ?? '' ) ) {
+			return null;
+		}
+
+		return self::newGenerationState( $flow_step_id, $source_generation, $token, $now );
+	}
+
+	/** Mark an exact scheduled generation as running before executing it. */
+	public static function beginGeneration( int $job_id, string $flow_step_id, int $generation, int $now ): bool {
+		$result = EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $flow_step_id, $generation, $now ): ?array {
+				$current = is_array( $engine[ self::OWNERSHIP_KEY ] ?? null ) ? $engine[ self::OWNERSHIP_KEY ] : array();
+				$next    = self::beginGenerationState( $current, $flow_step_id, $generation, $now );
+				if ( null === $next ) {
+					return null;
+				}
+
+				$engine[ self::OWNERSHIP_KEY ] = $next;
+				return $engine;
+			},
+			'ai_resume_generation_begin'
+		);
+
+		return ! empty( $result['success'] );
+	}
+
+	/** @return array<string,mixed>|null */
+	public static function beginGenerationState( array $state, string $flow_step_id, int $generation, int $now ): ?array {
+		if ( 0 >= $generation
+			|| (string) ( $state['flow_step_id'] ?? '' ) !== $flow_step_id
+			|| (int) ( $state['generation'] ?? 0 ) !== $generation
+			|| 'scheduled' !== (string) ( $state['status'] ?? '' )
+		) {
+			return null;
+		}
+
+		$state['status']     = 'running';
+		$state['started_at'] = gmdate( 'c', $now );
+		return $state;
+	}
+
+	/** Persist the Action Scheduler ID for the generation owned by this token. */
+	public static function recordScheduledAction( int $job_id, string $flow_step_id, int $generation, string $token, int $action_id ): bool {
+		$result = EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $flow_step_id, $generation, $token, $action_id ): ?array {
+				$state = is_array( $engine[ self::OWNERSHIP_KEY ] ?? null ) ? $engine[ self::OWNERSHIP_KEY ] : array();
+				if ( (string) ( $state['flow_step_id'] ?? '' ) !== $flow_step_id
+					|| (int) ( $state['generation'] ?? 0 ) !== $generation
+					|| (string) ( $state['token'] ?? '' ) !== $token
+					|| 'scheduled' !== (string) ( $state['status'] ?? '' )
+				) {
+					return null;
+				}
+
+				$state['action_id']            = $action_id;
+				$engine[ self::OWNERSHIP_KEY ] = $state;
+				return $engine;
+			},
+			'ai_resume_action_recorded'
+		);
+
+		return ! empty( $result['success'] );
+	}
+
+	private static function newGenerationState( string $flow_step_id, int $source_generation, string $token, int $now ): array {
+		return array(
+			'flow_step_id'      => $flow_step_id,
+			'generation'        => $source_generation + 1,
+			'source_generation' => $source_generation,
+			'status'            => 'scheduled',
+			'token'             => $token,
+			'action_id'         => 0,
+			'claimed_at'        => gmdate( 'c', $now ),
+		);
 	}
 
 	/**

--- a/inc/Engine/AI/AIConcurrencyBackpressure.php
+++ b/inc/Engine/AI/AIConcurrencyBackpressure.php
@@ -10,6 +10,8 @@ namespace DataMachine\Engine\AI;
 defined( 'ABSPATH' ) || exit;
 
 class AIConcurrencyBackpressure {
+	private const EXECUTE_STEP_HOOK = 'datamachine_execute_step';
+	private const SCHEDULER_GROUP   = 'data-machine';
 
 	/**
 	 * Resolve the next durable contention state.
@@ -50,5 +52,86 @@ class AIConcurrencyBackpressure {
 			max( 1, $max_delay ),
 			max( 1, $base_delay ) * ( 2 ** min( max( 0, $prior_attempts ), 16 ) )
 		);
+	}
+
+	/**
+	 * Schedule one unique continuation, resolving a zero return only when the
+	 * scheduler can prove that an equivalent pending action won the race.
+	 *
+	 * @return array{success:bool,action_id:int,reused:bool}
+	 */
+	public static function scheduleContinuation( int $timestamp, array $args ): array {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			return array(
+				'success'   => false,
+				'action_id' => 0,
+				'reused'    => false,
+			);
+		}
+
+		$scheduled = as_schedule_single_action(
+			$timestamp,
+			self::EXECUTE_STEP_HOOK,
+			$args,
+			self::SCHEDULER_GROUP,
+			true
+		);
+		$action_id = is_numeric( $scheduled ) ? (int) $scheduled : 0;
+		if ( $action_id > 0 ) {
+			return array(
+				'success'   => true,
+				'action_id' => $action_id,
+				'reused'    => false,
+			);
+		}
+
+		$action_id = self::pendingContinuationId( $args );
+		return array(
+			'success'   => $action_id > 0,
+			'action_id' => $action_id,
+			'reused'    => $action_id > 0,
+		);
+	}
+
+	/**
+	 * Convert active contention into bounded historical evidence.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function resolvedState( array $throttle, int $now ): array {
+		$first_deferred = strtotime( (string) ( $throttle['first_deferred_at'] ?? '' ) );
+		$age_seconds    = false === $first_deferred ? max( 0, (int) ( $throttle['defer_age_seconds'] ?? 0 ) ) : max( 0, $now - $first_deferred );
+
+		return array(
+			'state'             => 'resolved',
+			'reason'            => (string) ( $throttle['reason'] ?? 'ai_concurrency_limit' ),
+			'provider'          => (string) ( $throttle['provider'] ?? '' ),
+			'flow_step_id'      => (string) ( $throttle['flow_step_id'] ?? '' ),
+			'defer_count'       => max( 0, (int) ( $throttle['attempts'] ?? 0 ) ),
+			'defer_age_seconds' => $age_seconds,
+			'first_deferred_at' => $throttle['first_deferred_at'] ?? null,
+			'last_deferred_at'  => $throttle['last_deferred_at'] ?? null,
+			'resolved_at'       => gmdate( 'c', $now ),
+		);
+	}
+
+	private static function pendingContinuationId( array $args ): int {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+			return 0;
+		}
+
+		$action_ids = as_get_scheduled_actions(
+			array(
+				'hook'     => self::EXECUTE_STEP_HOOK,
+				'args'     => $args,
+				'group'    => self::SCHEDULER_GROUP,
+				'status'   => 'pending',
+				'per_page' => 1,
+			),
+			'ids'
+		);
+
+		$action_id = is_array( $action_ids ) ? reset( $action_ids ) : 0;
+		return is_numeric( $action_id ) && (int) $action_id > 0 ? (int) $action_id : 0;
 	}
 }

--- a/inc/Engine/AI/AIConcurrencyBackpressure.php
+++ b/inc/Engine/AI/AIConcurrencyBackpressure.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Pure policy for pipeline AI concurrency backpressure.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+class AIConcurrencyBackpressure {
+
+	/**
+	 * Resolve the next durable contention state.
+	 *
+	 * @param array  $existing     Existing throttle state.
+	 * @param string $flow_step_id Current flow step ID.
+	 * @param int    $now          Current Unix timestamp.
+	 * @param int    $max_age      Maximum contention age in seconds.
+	 * @return array<string,mixed>
+	 */
+	public static function nextState( array $existing, string $flow_step_id, int $now, int $max_age ): array {
+		$same_step = (string) ( $existing['flow_step_id'] ?? '' ) === $flow_step_id;
+		$attempts  = $same_step ? max( 0, (int) ( $existing['attempts'] ?? 0 ) ) + 1 : 1;
+
+		$first_deferred_at = $same_step ? strtotime( (string) ( $existing['first_deferred_at'] ?? '' ) ) : false;
+		if ( false === $first_deferred_at || $first_deferred_at > $now ) {
+			$first_deferred_at = $now;
+		}
+
+		$age_seconds = max( 0, $now - $first_deferred_at );
+
+		return array(
+			'state'                 => $age_seconds >= $max_age ? 'stranded' : 'deferred',
+			'flow_step_id'          => $flow_step_id,
+			'attempts'              => $attempts,
+			'first_deferred_at'     => gmdate( 'c', $first_deferred_at ),
+			'last_deferred_at'      => gmdate( 'c', $now ),
+			'defer_age_seconds'     => $age_seconds,
+			'max_defer_age_seconds' => $max_age,
+		);
+	}
+
+	/**
+	 * Calculate capped exponential contention backoff.
+	 */
+	public static function delaySeconds( int $base_delay, int $prior_attempts, int $max_delay ): int {
+		return min(
+			max( 1, $max_delay ),
+			max( 1, $base_delay ) * ( 2 ** min( max( 0, $prior_attempts ), 16 ) )
+		);
+	}
+}

--- a/inc/Engine/AI/AIConcurrencyBackpressure.php
+++ b/inc/Engine/AI/AIConcurrencyBackpressure.php
@@ -10,8 +10,9 @@ namespace DataMachine\Engine\AI;
 defined( 'ABSPATH' ) || exit;
 
 class AIConcurrencyBackpressure {
-	private const EXECUTE_STEP_HOOK = 'datamachine_execute_step';
-	private const SCHEDULER_GROUP   = 'data-machine';
+	public const RESUME_HOOK = 'datamachine_resume_ai_step';
+
+	private const RESUME_GROUP_PREFIX = 'data-machine-ai-resume-';
 
 	/**
 	 * Resolve the next durable contention state.
@@ -69,11 +70,12 @@ class AIConcurrencyBackpressure {
 			);
 		}
 
+		$group     = self::continuationGroup( $args );
 		$scheduled = as_schedule_single_action(
 			$timestamp,
-			self::EXECUTE_STEP_HOOK,
+			self::RESUME_HOOK,
 			$args,
-			self::SCHEDULER_GROUP,
+			$group,
 			true
 		);
 		$action_id = is_numeric( $scheduled ) ? (int) $scheduled : 0;
@@ -85,12 +87,21 @@ class AIConcurrencyBackpressure {
 			);
 		}
 
-		$action_id = self::pendingContinuationId( $args );
+		$action_id = self::pendingContinuationId( $args, $group );
 		return array(
 			'success'   => $action_id > 0,
 			'action_id' => $action_id,
 			'reused'    => $action_id > 0,
 		);
+	}
+
+	/** Resolve the Action Scheduler uniqueness scope for one job/step. */
+	public static function continuationGroup( array $args ): string {
+		$job_id       = max( 0, (int) ( $args['job_id'] ?? 0 ) );
+		$flow_step_id = (string) ( $args['flow_step_id'] ?? '' );
+		$scope        = $job_id . ':' . $flow_step_id;
+
+		return self::RESUME_GROUP_PREFIX . $job_id . '-' . substr( hash( 'sha256', $scope ), 0, 16 );
 	}
 
 	/**
@@ -115,16 +126,16 @@ class AIConcurrencyBackpressure {
 		);
 	}
 
-	private static function pendingContinuationId( array $args ): int {
+	private static function pendingContinuationId( array $args, string $group ): int {
 		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
 			return 0;
 		}
 
 		$action_ids = as_get_scheduled_actions(
 			array(
-				'hook'     => self::EXECUTE_STEP_HOOK,
+				'hook'     => self::RESUME_HOOK,
 				'args'     => $args,
-				'group'    => self::SCHEDULER_GROUP,
+				'group'    => $group,
 				'status'   => 'pending',
 				'per_page' => 1,
 			),

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -101,7 +101,8 @@ class RetentionCleanup {
 			// is millions of rows. Prune them within ~1h to cap steady-state
 			// rows. The row-count ceiling (see actionSchedulerHookMaxRows)
 			// bounds the table regardless of generation rate as a backstop.
-			'datamachine_execute_step' => 1 / 24,
+			'datamachine_execute_step'   => 1 / 24,
+			'datamachine_resume_ai_step' => 1 / 24,
 		);
 
 		$overrides = apply_filters( 'datamachine_as_actions_hook_max_age_days', $defaults );
@@ -149,7 +150,8 @@ class RetentionCleanup {
 			// completions/second this is well under an hour of history — more
 			// than enough for diagnostics — while guaranteeing the table can
 			// never balloon into the millions during a generation spike.
-			'datamachine_execute_step' => 100000,
+			'datamachine_execute_step'   => 100000,
+			'datamachine_resume_ai_step' => 100000,
 		);
 
 		$overrides = apply_filters( 'datamachine_as_actions_hook_max_rows', $defaults );

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -63,7 +63,7 @@ function datamachine_flow_exists( int $flow_id ): bool {
  * Both initial execution and AI contention resumes use this callback so a
  * resume cannot drift into a parallel execution implementation.
  */
-function datamachine_execute_step_action( $job_id, string $flow_step_id, $operation_generation = 0, $operation_claim_token = '' ): void {
+function datamachine_execute_step_action( $job_id, string $flow_step_id, $operation_generation = 0, $operation_claim_token = '', $ai_resume_generation = 0 ): void {
 	$ability = wp_get_ability( 'datamachine/execute-step' );
 	if ( $ability ) {
 		$ability->execute(
@@ -72,9 +72,31 @@ function datamachine_execute_step_action( $job_id, string $flow_step_id, $operat
 				'flow_step_id'          => $flow_step_id,
 				'operation_generation'  => is_numeric( $operation_generation ) ? (int) $operation_generation : 0,
 				'operation_claim_token' => is_string( $operation_claim_token ) ? $operation_claim_token : '',
+				'ai_resume_generation'  => is_numeric( $ai_resume_generation ) ? (int) $ai_resume_generation : 0,
 			)
 		);
 	}
+}
+
+/** Validate durable resume ownership before entering canonical step execution. */
+function datamachine_resume_ai_step_action( $job_id, string $flow_step_id, $operation_generation = 0, $operation_claim_token = '', $ai_resume_generation = 0 ): void {
+	$job_id               = (int) $job_id;
+	$ai_resume_generation = is_numeric( $ai_resume_generation ) ? (int) $ai_resume_generation : 0;
+	if ( ! \DataMachine\Engine\AI\AIConcurrencyBackpressure::beginGeneration( $job_id, $flow_step_id, $ai_resume_generation, time() ) ) {
+		do_action(
+			'datamachine_log',
+			'warning',
+			'Stale AI concurrency resume generation rejected',
+			array(
+				'job_id'               => $job_id,
+				'flow_step_id'         => $flow_step_id,
+				'ai_resume_generation' => $ai_resume_generation,
+			)
+		);
+		return;
+	}
+
+	datamachine_execute_step_action( $job_id, $flow_step_id, $operation_generation, $operation_claim_token, $ai_resume_generation );
 }
 
 /**
@@ -133,15 +155,15 @@ function datamachine_register_execution_engine() {
 		'datamachine_execute_step',
 		'datamachine_execute_step_action',
 		10,
-		4
+		5
 	);
 
 	/** Dedicated resume bridge avoids collision with the running execute action. */
 	add_action(
 		'datamachine_resume_ai_step',
-		'datamachine_execute_step_action',
+		'datamachine_resume_ai_step_action',
 		10,
-		4
+		5
 	);
 
 	/**

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -58,6 +58,26 @@ function datamachine_flow_exists( int $flow_id ): bool {
 }
 
 /**
+ * Bridge an Action Scheduler step action into the canonical execute ability.
+ *
+ * Both initial execution and AI contention resumes use this callback so a
+ * resume cannot drift into a parallel execution implementation.
+ */
+function datamachine_execute_step_action( $job_id, string $flow_step_id, $operation_generation = 0, $operation_claim_token = '' ): void {
+	$ability = wp_get_ability( 'datamachine/execute-step' );
+	if ( $ability ) {
+		$ability->execute(
+			array(
+				'job_id'                => (int) $job_id,
+				'flow_step_id'          => $flow_step_id,
+				'operation_generation'  => is_numeric( $operation_generation ) ? (int) $operation_generation : 0,
+				'operation_claim_token' => is_string( $operation_claim_token ) ? $operation_claim_token : '',
+			)
+		);
+	}
+}
+
+/**
  * Register execution engine action hooks as thin bridges to abilities.
  *
  * Action Scheduler fires do_action() — these hooks delegate immediately
@@ -111,19 +131,15 @@ function datamachine_register_execution_engine() {
 	 */
 	add_action(
 		'datamachine_execute_step',
-		function ( $job_id, string $flow_step_id, $operation_generation = 0, $operation_claim_token = '' ) {
-			$ability = wp_get_ability( 'datamachine/execute-step' );
-			if ( $ability ) {
-				$ability->execute(
-					array(
-						'job_id'               => (int) $job_id,
-						'flow_step_id'          => $flow_step_id,
-						'operation_generation' => is_numeric( $operation_generation ) ? (int) $operation_generation : 0,
-						'operation_claim_token' => is_string( $operation_claim_token ) ? $operation_claim_token : '',
-					)
-				);
-			}
-		},
+		'datamachine_execute_step_action',
+		10,
+		4
+	);
+
+	/** Dedicated resume bridge avoids collision with the running execute action. */
+	add_action(
+		'datamachine_resume_ai_step',
+		'datamachine_execute_step_action',
 		10,
 		4
 	);

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -10,6 +10,7 @@ namespace DataMachine\Tests\Unit\Core\Database;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\Jobs\LegacyAIConcurrencyReconciler;
 use DataMachine\Core\JobStatus;
+use DataMachine\Engine\AI\AIConcurrencyBackpressure;
 use WP_UnitTestCase;
 
 class JobLifecycleTransitionTest extends WP_UnitTestCase {
@@ -156,6 +157,33 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 		$job = $this->db_jobs->get_job( $job_id );
 		$this->assertSame( 'failed - handler_failure', $job['status'] );
 		$this->assertArrayNotHasKey( 'status_reconciliation', $job['engine_data'] );
+	}
+
+	public function test_ai_resume_generation_ownership_advances_with_cas(): void {
+		$job_id = $this->db_jobs->create_job( array( 'label' => 'AI resume generation ownership' ) );
+		$this->assertIsInt( $job_id );
+
+		$generation_one = AIConcurrencyBackpressure::claimNextGeneration( $job_id, 'ai-1', 0, time() );
+		$duplicate_one  = AIConcurrencyBackpressure::claimNextGeneration( $job_id, 'ai-1', 0, time() );
+		$this->assertTrue( $generation_one['success'] );
+		$this->assertTrue( $generation_one['owned'] );
+		$this->assertSame( 1, $generation_one['generation'] );
+		$this->assertTrue( $duplicate_one['success'] );
+		$this->assertFalse( $duplicate_one['owned'] );
+		$this->assertSame( 1, $duplicate_one['generation'] );
+
+		$this->assertTrue( AIConcurrencyBackpressure::recordScheduledAction( $job_id, 'ai-1', 1, $generation_one['token'], 101 ) );
+		$this->assertTrue( AIConcurrencyBackpressure::beginGeneration( $job_id, 'ai-1', 1, time() ) );
+		$this->assertFalse( AIConcurrencyBackpressure::beginGeneration( $job_id, 'ai-1', 1, time() ) );
+
+		$generation_two = AIConcurrencyBackpressure::claimNextGeneration( $job_id, 'ai-1', 1, time() );
+		$duplicate_two  = AIConcurrencyBackpressure::claimNextGeneration( $job_id, 'ai-1', 1, time() );
+		$this->assertTrue( $generation_two['success'] );
+		$this->assertTrue( $generation_two['owned'] );
+		$this->assertSame( 2, $generation_two['generation'] );
+		$this->assertTrue( $duplicate_two['success'] );
+		$this->assertFalse( $duplicate_two['owned'] );
+		$this->assertFalse( AIConcurrencyBackpressure::beginGeneration( $job_id, 'ai-1', 1, time() ) );
 	}
 
 	public function test_create_or_get_job_returns_existing_job_for_same_idempotency_key(): void {

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -8,6 +8,7 @@
 namespace DataMachine\Tests\Unit\Core\Database;
 
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\Database\Jobs\LegacyAIConcurrencyReconciler;
 use DataMachine\Core\JobStatus;
 use WP_UnitTestCase;
 
@@ -97,6 +98,64 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 
 		$job = $this->db_jobs->get_job( $job_id );
 		$this->assertSame( JobStatus::CANCELLED, $job['status'] );
+	}
+
+	public function test_exact_legacy_ai_contention_failure_can_be_audited_and_reclassified(): void {
+		$job_id = $this->db_jobs->create_job( array( 'label' => 'Legacy AI contention' ) );
+		$this->assertIsInt( $job_id );
+		$this->assertTrue( $this->db_jobs->complete_job( $job_id, LegacyAIConcurrencyReconciler::SOURCE_STATUS ) );
+
+		$generic_rewrite = $this->db_jobs->transition_job_status_result( $job_id, LegacyAIConcurrencyReconciler::TARGET_STATUS, true );
+		$this->assertFalse( $generic_rewrite['success'] );
+
+		$audits          = array();
+		$terminal_hooks  = array();
+		$audit_listener  = static function ( int $reconciled_job_id, array $audit ) use ( &$audits ): void {
+			$audits[] = array( $reconciled_job_id, $audit );
+		};
+		$terminal_listener = static function ( int $completed_job_id, string $status ) use ( &$terminal_hooks ): void {
+			$terminal_hooks[] = array( $completed_job_id, $status );
+		};
+		add_action( 'datamachine_job_status_reconciled', $audit_listener, 10, 2 );
+		add_action( 'datamachine_job_complete', $terminal_listener, 10, 2 );
+		try {
+			$reconciled = ( new LegacyAIConcurrencyReconciler() )->reconcile( $job_id );
+		} finally {
+			remove_action( 'datamachine_job_status_reconciled', $audit_listener, 10 );
+			remove_action( 'datamachine_job_complete', $terminal_listener, 10 );
+		}
+		$this->assertTrue( $reconciled['success'] );
+		$this->assertTrue( $reconciled['changed'] );
+		$this->assertSame( LegacyAIConcurrencyReconciler::SOURCE_STATUS, $reconciled['current_status'] );
+		$this->assertSame( LegacyAIConcurrencyReconciler::TARGET_STATUS, $reconciled['status'] );
+
+		$job = $this->db_jobs->get_job( $job_id );
+		$this->assertSame( LegacyAIConcurrencyReconciler::TARGET_STATUS, $job['status'] );
+		$this->assertSame( 'datamachine.status_reconciliation.v1', $job['engine_data']['status_reconciliation']['schema'] );
+		$this->assertSame( LegacyAIConcurrencyReconciler::SOURCE_STATUS, $job['engine_data']['status_reconciliation']['source_status'] );
+		$this->assertSame( LegacyAIConcurrencyReconciler::TARGET_STATUS, $job['engine_data']['status_reconciliation']['target_status'] );
+		$this->assertSame( 0, $job['engine_data']['run_metrics']['counts']['failed'] );
+		$this->assertCount( 1, $audits );
+		$this->assertSame( $job_id, $audits[0][0] );
+		$this->assertSame( array(), $terminal_hooks );
+
+		$idempotent = ( new LegacyAIConcurrencyReconciler() )->reconcile( $job_id );
+		$this->assertTrue( $idempotent['success'] );
+		$this->assertFalse( $idempotent['changed'] );
+	}
+
+	public function test_legacy_ai_contention_reconciliation_rejects_every_other_terminal_status(): void {
+		$job_id = $this->db_jobs->create_job( array( 'label' => 'Unrelated terminal status' ) );
+		$this->assertIsInt( $job_id );
+		$this->assertTrue( $this->db_jobs->complete_job( $job_id, JobStatus::failed( 'handler_failure' )->toString() ) );
+
+		$reconciled = ( new LegacyAIConcurrencyReconciler() )->reconcile( $job_id );
+		$this->assertFalse( $reconciled['success'] );
+		$this->assertFalse( $reconciled['changed'] );
+
+		$job = $this->db_jobs->get_job( $job_id );
+		$this->assertSame( 'failed - handler_failure', $job['status'] );
+		$this->assertArrayNotHasKey( 'status_reconciliation', $job['engine_data'] );
 	}
 
 	public function test_create_or_get_job_returns_existing_job_for_same_idempotency_key(): void {

--- a/tests/ai-step-backpressure-smoke.php
+++ b/tests/ai-step-backpressure-smoke.php
@@ -29,6 +29,8 @@ $GLOBALS['datamachine_ai_backpressure_options'] = array();
 $GLOBALS['datamachine_ai_backpressure_actions'] = array();
 $GLOBALS['datamachine_ai_backpressure_schedule_error'] = false;
 $GLOBALS['datamachine_ai_backpressure_next_action_id'] = 1;
+$GLOBALS['datamachine_ai_backpressure_registered_hooks'] = array();
+$GLOBALS['datamachine_ai_backpressure_ability_inputs'] = array();
 
 class DataMachineAIBackpressureSmokeAction {
 	public function __construct( private array $action ) {}
@@ -40,6 +42,20 @@ class DataMachineAIBackpressureSmokeAction {
 	public function get_field( string $field ): mixed {
 		return $this->action[ $field ] ?? null;
 	}
+}
+
+class DataMachineAIBackpressureSmokeAbility {
+	public function execute( array $input ): void {
+		$GLOBALS['datamachine_ai_backpressure_ability_inputs'][] = $input;
+	}
+}
+
+function add_action( string $hook, mixed $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	$GLOBALS['datamachine_ai_backpressure_registered_hooks'][ $hook ] = array( $callback, $priority, $accepted_args );
+}
+
+function wp_get_ability( string $name ): ?DataMachineAIBackpressureSmokeAbility {
+	return 'datamachine/execute-step' === $name ? new DataMachineAIBackpressureSmokeAbility() : null;
 }
 
 if ( ! function_exists( 'get_option' ) ) {
@@ -113,8 +129,12 @@ function as_schedule_single_action( int $timestamp, string $hook, array $args = 
 	if ( $GLOBALS['datamachine_ai_backpressure_schedule_error'] ) {
 		return 0;
 	}
-	if ( $unique && ! empty( as_get_scheduled_actions( array( 'hook' => $hook, 'args' => $args, 'group' => $group, 'status' => 'pending' ) ) ) ) {
-		return 0;
+	if ( $unique ) {
+		foreach ( array( 'pending', 'in-progress' ) as $blocking_status ) {
+			if ( ! empty( as_get_scheduled_actions( array( 'hook' => $hook, 'group' => $group, 'status' => $blocking_status ) ) ) ) {
+				return 0;
+			}
+		}
 	}
 
 	$action_id = $GLOBALS['datamachine_ai_backpressure_next_action_id']++;
@@ -148,6 +168,7 @@ require_once __DIR__ . '/../inc/Core/ActionScheduler/GroupRegistrar.php';
 require_once __DIR__ . '/../inc/Engine/AI/PipelineAIConcurrencyLease.php';
 require_once __DIR__ . '/../inc/Engine/AI/PipelineAIConcurrencyLimiter.php';
 require_once __DIR__ . '/../inc/Engine/AI/AIConcurrencyBackpressure.php';
+require_once __DIR__ . '/../inc/Engine/Actions/Engine.php';
 
 use DataMachine\Core\ActionScheduler\GroupRegistrar;
 use DataMachine\Engine\AI\PipelineAIConcurrencyLease;
@@ -200,6 +221,7 @@ $after_advanced_owner['lease']->release();
 $GLOBALS['datamachine_ai_backpressure_actions'] = array();
 
 echo "Case 5: production wiring preserves pipeline semantics\n";
+datamachine_register_execution_engine();
 $ai_src       = file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' ) ?: '';
 $engine_src   = file_get_contents( __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php' ) ?: '';
 $retry_src    = file_get_contents( __DIR__ . '/../inc/Core/JobRetryPolicy.php' ) ?: '';
@@ -210,13 +232,19 @@ $upsert_files = glob( __DIR__ . '/../inc/Core/Steps/Upsert/*.php' ) ?: array();
 $upsert_src   = implode( "\n", array_map( static fn( string $path ): string => file_get_contents( $path ) ?: '', $upsert_files ) );
 
 assert_ai_backpressure_smoke( 'AIStep acquires before prompt queue consumption', strpos( $ai_src, 'PipelineAIConcurrencyLimiter::acquire' ) < strpos( $ai_src, 'consumeFromPromptQueue' ) );
-assert_ai_backpressure_smoke( 'AIStep throttles by rescheduling same step', str_contains( $ai_src, 'deferForAIConcurrency' ) && str_contains( $backpressure_src, 'datamachine_execute_step' ) );
+assert_ai_backpressure_smoke( 'AIStep throttles by rescheduling same step', str_contains( $ai_src, 'deferForAIConcurrency' ) && str_contains( $backpressure_src, 'datamachine_resume_ai_step' ) );
 assert_ai_backpressure_smoke( 'executor treats AI throttle as routed pending work', str_contains( $engine_src, 'hasPendingAIConcurrencyThrottle' ) && str_contains( $engine_src, 'ai_concurrency_throttle' ) );
 assert_ai_backpressure_smoke( 'fetch steps do not use AI limiter', ! str_contains( $fetch_src, 'PipelineAIConcurrencyLimiter' ) );
 assert_ai_backpressure_smoke( 'upsert steps do not use AI limiter', ! str_contains( $upsert_src, 'PipelineAIConcurrencyLimiter' ) );
 assert_ai_backpressure_smoke( 'existing transport retry classifier remains intact', str_contains( $retry_src, 'transport_connect_timeout' ) && str_contains( $retry_src, 'AI_TRANSPORT_BASE_DELAY' ) );
 assert_ai_backpressure_smoke( 'throttle log includes requested metadata', str_contains( $ai_src, 'rescheduled_for_seconds' ) && str_contains( $ai_src, "'active'" ) && str_contains( $ai_src, "'limit'" ) );
 assert_ai_backpressure_smoke( 'limiter checks for advanced owner leases generically', str_contains( file_get_contents( __DIR__ . '/../inc/Engine/AI/PipelineAIConcurrencyLimiter.php' ) ?: '', 'isAdvancedOwnerLease' ) );
+$execute_bridge = $GLOBALS['datamachine_ai_backpressure_registered_hooks']['datamachine_execute_step'][0] ?? null;
+$resume_bridge  = $GLOBALS['datamachine_ai_backpressure_registered_hooks']['datamachine_resume_ai_step'][0] ?? null;
+assert_ai_backpressure_smoke( 'execute and resume hooks register the canonical bridge', is_callable( $execute_bridge ) && $execute_bridge === $resume_bridge );
+call_user_func( $resume_bridge, 501, 'ai-resume', 3, 'claim-token' );
+$resume_input = $GLOBALS['datamachine_ai_backpressure_ability_inputs'][0] ?? array();
+assert_ai_backpressure_smoke( 'resume bridge executes the correct job and step safely', 501 === $resume_input['job_id'] && 'ai-resume' === $resume_input['flow_step_id'] && 3 === $resume_input['operation_generation'] && 'claim-token' === $resume_input['operation_claim_token'] );
 
 echo "Case 6: sustained contention stays deferred without failure inflation\n";
 $now   = strtotime( '2026-07-22T00:00:00Z' );
@@ -238,19 +266,35 @@ assert_ai_backpressure_smoke( 'backoff remains capped', 600 === AIConcurrencyBac
 assert_ai_backpressure_smoke( 'only one matching future action is retained', str_contains( $backpressure_src, 'scheduleContinuation' ) );
 
 echo "Case 8: unique scheduling closes concurrent duplicate races\n";
-$GLOBALS['datamachine_ai_backpressure_actions'] = array();
+$GLOBALS['datamachine_ai_backpressure_actions'] = array(
+	new DataMachineAIBackpressureSmokeAction(
+		array(
+			'action_id' => 900,
+			'hook'      => 'datamachine_execute_step',
+			'args'      => array( 'job_id' => 301, 'flow_step_id' => 'ai-1' ),
+			'group'     => 'data-machine',
+			'status'    => 'in-progress',
+		)
+	),
+);
 $args   = array( 'job_id' => 301, 'flow_step_id' => 'ai-1' );
+$same_hook = as_schedule_single_action( $now + 60, 'datamachine_execute_step', $args, 'data-machine', true );
 $first  = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, $args );
 $second = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, $args );
+assert_ai_backpressure_smoke( 'running action blocks same-hook same-group uniqueness regardless of args', 0 === $same_hook );
 assert_ai_backpressure_smoke( 'first continuation is scheduled with a positive ID', $first['success'] && $first['action_id'] > 0 );
+assert_ai_backpressure_smoke( 'dedicated resume hook is not blocked by running execute hook', 'datamachine_resume_ai_step' === $GLOBALS['datamachine_ai_backpressure_actions'][1]->get_field( 'hook' ) );
 assert_ai_backpressure_smoke( 'concurrent duplicate reuses the winning action ID', $second['success'] && $second['reused'] && $first['action_id'] === $second['action_id'] );
-assert_ai_backpressure_smoke( 'concurrent duplicate executions produce one pending action', 1 === count( $GLOBALS['datamachine_ai_backpressure_actions'] ) );
+assert_ai_backpressure_smoke( 'concurrent duplicate executions produce one resume action', 2 === count( $GLOBALS['datamachine_ai_backpressure_actions'] ) );
+
+$other_job = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, array( 'job_id' => 303, 'flow_step_id' => 'ai-1' ) );
+assert_ai_backpressure_smoke( 'another job uses a separate uniqueness group', $other_job['success'] && 3 === count( $GLOBALS['datamachine_ai_backpressure_actions'] ) );
 
 $GLOBALS['datamachine_ai_backpressure_schedule_error'] = true;
 $schedule_error = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, array( 'job_id' => 302, 'flow_step_id' => 'ai-1' ) );
 $GLOBALS['datamachine_ai_backpressure_schedule_error'] = false;
 assert_ai_backpressure_smoke( 'zero without a matching pending action is a scheduling failure', ! $schedule_error['success'] && 0 === $schedule_error['action_id'] );
-assert_ai_backpressure_smoke( 'scheduler call requests native uniqueness', str_contains( $backpressure_src, "self::SCHEDULER_GROUP,\n\t\t\ttrue" ) );
+assert_ai_backpressure_smoke( 'scheduler call requests native uniqueness', str_contains( $backpressure_src, "\$group,\n\t\t\ttrue" ) );
 
 echo "Case 9: slot recovery archives and clears active contention\n";
 $resolved = AIConcurrencyBackpressure::resolvedState( $state, $now + 120 );

--- a/tests/ai-step-backpressure-smoke.php
+++ b/tests/ai-step-backpressure-smoke.php
@@ -8,6 +8,7 @@
  */
 
 define( 'ABSPATH', __DIR__ );
+defined( 'DAY_IN_SECONDS' ) || define( 'DAY_IN_SECONDS', 86400 );
 
 $failed = 0;
 $total  = 0;
@@ -115,10 +116,12 @@ require_once __DIR__ . '/../inc/Core/OptionLeaseStore.php';
 require_once __DIR__ . '/../inc/Core/ActionScheduler/GroupRegistrar.php';
 require_once __DIR__ . '/../inc/Engine/AI/PipelineAIConcurrencyLease.php';
 require_once __DIR__ . '/../inc/Engine/AI/PipelineAIConcurrencyLimiter.php';
+require_once __DIR__ . '/../inc/Engine/AI/AIConcurrencyBackpressure.php';
 
 use DataMachine\Core\ActionScheduler\GroupRegistrar;
 use DataMachine\Engine\AI\PipelineAIConcurrencyLease;
 use DataMachine\Engine\AI\PipelineAIConcurrencyLimiter;
+use DataMachine\Engine\AI\AIConcurrencyBackpressure;
 
 echo "Case 1: first AI step acquires the single site slot\n";
 $first = PipelineAIConcurrencyLimiter::acquire( 'openai', array( 'job_id' => 101, 'flow_step_id' => 'ai-1' ) );
@@ -182,14 +185,24 @@ assert_ai_backpressure_smoke( 'existing transport retry classifier remains intac
 assert_ai_backpressure_smoke( 'throttle log includes requested metadata', str_contains( $ai_src, 'rescheduled_for_seconds' ) && str_contains( $ai_src, "'active'" ) && str_contains( $ai_src, "'limit'" ) );
 assert_ai_backpressure_smoke( 'limiter checks for advanced owner leases generically', str_contains( file_get_contents( __DIR__ . '/../inc/Engine/AI/PipelineAIConcurrencyLimiter.php' ) ?: '', 'isAdvancedOwnerLease' ) );
 
-echo "Case 6: concurrency defers are bounded (#2793 runaway guard)\n";
-assert_ai_backpressure_smoke( 'defer attempt budget constant exists', str_contains( $ai_src, 'AI_CONCURRENCY_MAX_DEFERS' ) );
-assert_ai_backpressure_smoke( 'defer budget is filterable', str_contains( $ai_src, 'datamachine_ai_concurrency_max_defers' ) );
-assert_ai_backpressure_smoke( 'defer increments a per-step attempt counter', str_contains( $ai_src, "'attempts'" ) && str_contains( $ai_src, '$prior_attempts + 1' ) );
-assert_ai_backpressure_smoke( 'attempt counter resets when the AI step advances', str_contains( $ai_src, "( \$existing_throttle['flow_step_id'] ?? '' ) === \$this->flow_step_id" ) );
-assert_ai_backpressure_smoke( 'exhausted budget fails the job terminally', str_contains( $ai_src, 'ai_concurrency_defer_exhausted' ) && str_contains( $ai_src, "'retryable'     => false" ) );
-assert_ai_backpressure_smoke( 'exhausted budget clears the throttle marker so the failure is not swallowed', str_contains( $ai_src, "'ai_concurrency_throttle' => array()" ) );
-assert_ai_backpressure_smoke( 'defers back off exponentially under a capped ceiling', str_contains( $ai_src, 'AI_CONCURRENCY_MAX_DEFER_DELAY' ) && str_contains( $ai_src, '2 ** ' ) );
+echo "Case 6: sustained contention stays deferred without failure inflation\n";
+$now   = strtotime( '2026-07-22T00:00:00Z' );
+$state = array();
+for ( $attempt = 1; $attempt <= 100; ++$attempt ) {
+	$state = AIConcurrencyBackpressure::nextState( $state, 'ai-1', $now + $attempt, DAY_IN_SECONDS );
+}
+assert_ai_backpressure_smoke( 'ordinary sustained contention remains deferred past the old count budget', 'deferred' === $state['state'] );
+assert_ai_backpressure_smoke( 'defer count remains machine readable', 100 === $state['attempts'] );
+assert_ai_backpressure_smoke( 'defer age remains machine readable', 99 === $state['defer_age_seconds'] );
+assert_ai_backpressure_smoke( 'ordinary contention does not call the failure path', ! str_contains( $ai_src, 'ai_concurrency_defer_exhausted' ) );
+
+echo "Case 7: age-bounded stranded work terminates distinctly\n";
+$stranded = AIConcurrencyBackpressure::nextState( $state, 'ai-1', $now + DAY_IN_SECONDS + 1, DAY_IN_SECONDS );
+assert_ai_backpressure_smoke( 'maximum contention age marks work stranded', 'stranded' === $stranded['state'] );
+assert_ai_backpressure_smoke( 'stranded work is cancelled instead of failed', str_contains( $ai_src, 'cancelled - ai_concurrency_stranded' ) );
+assert_ai_backpressure_smoke( 'maximum contention age is filterable', str_contains( $ai_src, 'datamachine_ai_concurrency_max_defer_age' ) );
+assert_ai_backpressure_smoke( 'backoff remains capped', 600 === AIConcurrencyBackpressure::delaySeconds( 10, 30, 600 ) );
+assert_ai_backpressure_smoke( 'only one matching future action is retained', str_contains( $ai_src, 'as_next_scheduled_action' ) );
 
 echo "\nAI step backpressure smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {

--- a/tests/ai-step-backpressure-smoke.php
+++ b/tests/ai-step-backpressure-smoke.php
@@ -241,10 +241,10 @@ assert_ai_backpressure_smoke( 'throttle log includes requested metadata', str_co
 assert_ai_backpressure_smoke( 'limiter checks for advanced owner leases generically', str_contains( file_get_contents( __DIR__ . '/../inc/Engine/AI/PipelineAIConcurrencyLimiter.php' ) ?: '', 'isAdvancedOwnerLease' ) );
 $execute_bridge = $GLOBALS['datamachine_ai_backpressure_registered_hooks']['datamachine_execute_step'][0] ?? null;
 $resume_bridge  = $GLOBALS['datamachine_ai_backpressure_registered_hooks']['datamachine_resume_ai_step'][0] ?? null;
-assert_ai_backpressure_smoke( 'execute and resume hooks register the canonical bridge', is_callable( $execute_bridge ) && $execute_bridge === $resume_bridge );
-call_user_func( $resume_bridge, 501, 'ai-resume', 3, 'claim-token' );
+assert_ai_backpressure_smoke( 'execute and resume hooks register canonical and guarded bridges', is_callable( $execute_bridge ) && is_callable( $resume_bridge ) && $execute_bridge !== $resume_bridge );
+call_user_func( $execute_bridge, 501, 'ai-resume', 3, 'claim-token', 7 );
 $resume_input = $GLOBALS['datamachine_ai_backpressure_ability_inputs'][0] ?? array();
-assert_ai_backpressure_smoke( 'resume bridge executes the correct job and step safely', 501 === $resume_input['job_id'] && 'ai-resume' === $resume_input['flow_step_id'] && 3 === $resume_input['operation_generation'] && 'claim-token' === $resume_input['operation_claim_token'] );
+assert_ai_backpressure_smoke( 'canonical bridge preserves resume generation with job and step', 501 === $resume_input['job_id'] && 'ai-resume' === $resume_input['flow_step_id'] && 3 === $resume_input['operation_generation'] && 'claim-token' === $resume_input['operation_claim_token'] && 7 === $resume_input['ai_resume_generation'] );
 
 echo "Case 6: sustained contention stays deferred without failure inflation\n";
 $now   = strtotime( '2026-07-22T00:00:00Z' );
@@ -277,7 +277,7 @@ $GLOBALS['datamachine_ai_backpressure_actions'] = array(
 		)
 	),
 );
-$args   = array( 'job_id' => 301, 'flow_step_id' => 'ai-1' );
+$args   = array( 'job_id' => 301, 'flow_step_id' => 'ai-1', 'operation_generation' => 0, 'operation_claim_token' => '', 'ai_resume_generation' => 1 );
 $same_hook = as_schedule_single_action( $now + 60, 'datamachine_execute_step', $args, 'data-machine', true );
 $first  = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, $args );
 $second = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, $args );
@@ -287,7 +287,7 @@ assert_ai_backpressure_smoke( 'dedicated resume hook is not blocked by running e
 assert_ai_backpressure_smoke( 'concurrent duplicate reuses the winning action ID', $second['success'] && $second['reused'] && $first['action_id'] === $second['action_id'] );
 assert_ai_backpressure_smoke( 'concurrent duplicate executions produce one resume action', 2 === count( $GLOBALS['datamachine_ai_backpressure_actions'] ) );
 
-$other_job = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, array( 'job_id' => 303, 'flow_step_id' => 'ai-1' ) );
+$other_job = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, array( 'job_id' => 303, 'flow_step_id' => 'ai-1', 'operation_generation' => 0, 'operation_claim_token' => '', 'ai_resume_generation' => 1 ) );
 assert_ai_backpressure_smoke( 'another job uses a separate uniqueness group', $other_job['success'] && 3 === count( $GLOBALS['datamachine_ai_backpressure_actions'] ) );
 
 $GLOBALS['datamachine_ai_backpressure_schedule_error'] = true;
@@ -301,6 +301,44 @@ $resolved = AIConcurrencyBackpressure::resolvedState( $state, $now + 120 );
 assert_ai_backpressure_smoke( 'resolved history preserves defer count', 100 === $resolved['defer_count'] );
 assert_ai_backpressure_smoke( 'resolved history preserves contention duration', 119 === $resolved['defer_age_seconds'] );
 assert_ai_backpressure_smoke( 'AIStep clears active contention after acquisition', str_contains( $ai_src, 'resolveAIConcurrencyContention' ) && str_contains( $ai_src, "unset( \$engine['ai_concurrency_throttle'] )" ) );
+
+echo "Case 10: resume generations advance ownership without running collisions\n";
+$generation_one = AIConcurrencyBackpressure::nextGenerationState( array(), 'ai-1', 0, 'token-1', $now );
+$running_one    = AIConcurrencyBackpressure::beginGenerationState( $generation_one, 'ai-1', 1, $now + 1 );
+$generation_two = AIConcurrencyBackpressure::nextGenerationState( $running_one, 'ai-1', 1, 'token-2', $now + 2 );
+$duplicate_two  = AIConcurrencyBackpressure::nextGenerationState( $generation_two, 'ai-1', 1, 'token-other', $now + 2 );
+assert_ai_backpressure_smoke( 'initial execution mints resume generation one', 1 === $generation_one['generation'] && 0 === $generation_one['source_generation'] );
+assert_ai_backpressure_smoke( 'running generation one atomically mints generation two', 2 === $generation_two['generation'] && 1 === $generation_two['source_generation'] );
+assert_ai_backpressure_smoke( 'duplicate generation-two claim reuses original owner token', 'token-2' === $duplicate_two['token'] );
+
+$generation_one_args = array( 'job_id' => 401, 'flow_step_id' => 'ai-1', 'operation_generation' => 0, 'operation_claim_token' => '', 'ai_resume_generation' => 1 );
+$generation_two_args = array( 'job_id' => 401, 'flow_step_id' => 'ai-1', 'operation_generation' => 0, 'operation_claim_token' => '', 'ai_resume_generation' => 2 );
+$GLOBALS['datamachine_ai_backpressure_actions'] = array(
+	new DataMachineAIBackpressureSmokeAction(
+		array(
+			'action_id' => 901,
+			'hook'      => AIConcurrencyBackpressure::RESUME_HOOK,
+			'args'      => $generation_one_args,
+			'group'     => AIConcurrencyBackpressure::continuationGroup( $generation_one_args ),
+			'status'    => 'in-progress',
+		)
+	),
+);
+$scheduled_two = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, $generation_two_args );
+$duplicate_schedule_two = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, $generation_two_args );
+assert_ai_backpressure_smoke( 'running generation one does not block generation two schedule', $scheduled_two['success'] && ! $scheduled_two['reused'] );
+assert_ai_backpressure_smoke( 'duplicate generation two schedule collapses to one action', $duplicate_schedule_two['success'] && $duplicate_schedule_two['reused'] && 2 === count( $GLOBALS['datamachine_ai_backpressure_actions'] ) );
+assert_ai_backpressure_smoke( 'stale generation one replay cannot claim newer ownership', null === AIConcurrencyBackpressure::beginGenerationState( $generation_two, 'ai-1', 1, $now + 3 ) );
+$running_two = AIConcurrencyBackpressure::beginGenerationState( $generation_two, 'ai-1', 2, $now + 3 );
+assert_ai_backpressure_smoke( 'exact generation two can begin once', 'running' === $running_two['status'] );
+assert_ai_backpressure_smoke( 'duplicate generation two execution is rejected', null === AIConcurrencyBackpressure::beginGenerationState( $running_two, 'ai-1', 2, $now + 4 ) );
+
+$bounded_state = array();
+for ( $generation = 1; $generation <= 20; ++$generation ) {
+	$bounded_state = AIConcurrencyBackpressure::nextState( $bounded_state, 'ai-1', $now + $generation, 60 );
+}
+$bounded_terminal = AIConcurrencyBackpressure::nextState( $bounded_state, 'ai-1', $now + 61, 60 );
+assert_ai_backpressure_smoke( 'repeated healthy generations reach age bound instead of schedule failure', 'stranded' === $bounded_terminal['state'] );
 
 echo "\nAI step backpressure smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {

--- a/tests/ai-step-backpressure-smoke.php
+++ b/tests/ai-step-backpressure-smoke.php
@@ -27,6 +27,8 @@ function assert_ai_backpressure_smoke( string $name, bool $cond, string $detail 
 
 $GLOBALS['datamachine_ai_backpressure_options'] = array();
 $GLOBALS['datamachine_ai_backpressure_actions'] = array();
+$GLOBALS['datamachine_ai_backpressure_schedule_error'] = false;
+$GLOBALS['datamachine_ai_backpressure_next_action_id'] = 1;
 
 class DataMachineAIBackpressureSmokeAction {
 	public function __construct( private array $action ) {}
@@ -82,9 +84,7 @@ if ( ! function_exists( 'apply_filters' ) ) {
 }
 
 function as_get_scheduled_actions( array $query = array(), string $return_format = 'OBJECT' ): array {
-	unset( $return_format );
-
-	return array_values(
+	$actions = array_values(
 		array_filter(
 			$GLOBALS['datamachine_ai_backpressure_actions'],
 			static function ( DataMachineAIBackpressureSmokeAction $action ) use ( $query ): bool {
@@ -93,11 +93,42 @@ function as_get_scheduled_actions( array $query = array(), string $return_format
 						return false;
 					}
 				}
+				if ( isset( $query['args'] ) && $action->get_args() !== $query['args'] ) {
+					return false;
+				}
 
 				return true;
 			}
 		)
 	);
+
+	if ( 'ids' === strtolower( $return_format ) ) {
+		return array_map( static fn( DataMachineAIBackpressureSmokeAction $action ): int => (int) $action->get_field( 'action_id' ), $actions );
+	}
+
+	return $actions;
+}
+
+function as_schedule_single_action( int $timestamp, string $hook, array $args = array(), string $group = '', bool $unique = false ): int {
+	if ( $GLOBALS['datamachine_ai_backpressure_schedule_error'] ) {
+		return 0;
+	}
+	if ( $unique && ! empty( as_get_scheduled_actions( array( 'hook' => $hook, 'args' => $args, 'group' => $group, 'status' => 'pending' ) ) ) ) {
+		return 0;
+	}
+
+	$action_id = $GLOBALS['datamachine_ai_backpressure_next_action_id']++;
+	$GLOBALS['datamachine_ai_backpressure_actions'][] = new DataMachineAIBackpressureSmokeAction(
+		array(
+			'action_id' => $action_id,
+			'hook'      => $hook,
+			'args'      => $args,
+			'group'     => $group,
+			'status'    => 'pending',
+			'timestamp' => $timestamp,
+		)
+	);
+	return $action_id;
 }
 
 function did_action( string $hook ): int {
@@ -172,12 +203,14 @@ echo "Case 5: production wiring preserves pipeline semantics\n";
 $ai_src       = file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' ) ?: '';
 $engine_src   = file_get_contents( __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php' ) ?: '';
 $retry_src    = file_get_contents( __DIR__ . '/../inc/Core/JobRetryPolicy.php' ) ?: '';
+$backpressure_src = file_get_contents( __DIR__ . '/../inc/Engine/AI/AIConcurrencyBackpressure.php' ) ?: '';
+$reconciler_src = file_get_contents( __DIR__ . '/../inc/Core/Database/Jobs/LegacyAIConcurrencyReconciler.php' ) ?: '';
 $fetch_src    = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/FetchStep.php' ) ?: '';
 $upsert_files = glob( __DIR__ . '/../inc/Core/Steps/Upsert/*.php' ) ?: array();
 $upsert_src   = implode( "\n", array_map( static fn( string $path ): string => file_get_contents( $path ) ?: '', $upsert_files ) );
 
 assert_ai_backpressure_smoke( 'AIStep acquires before prompt queue consumption', strpos( $ai_src, 'PipelineAIConcurrencyLimiter::acquire' ) < strpos( $ai_src, 'consumeFromPromptQueue' ) );
-assert_ai_backpressure_smoke( 'AIStep throttles by rescheduling same step', str_contains( $ai_src, 'deferForAIConcurrency' ) && str_contains( $ai_src, 'datamachine_execute_step' ) );
+assert_ai_backpressure_smoke( 'AIStep throttles by rescheduling same step', str_contains( $ai_src, 'deferForAIConcurrency' ) && str_contains( $backpressure_src, 'datamachine_execute_step' ) );
 assert_ai_backpressure_smoke( 'executor treats AI throttle as routed pending work', str_contains( $engine_src, 'hasPendingAIConcurrencyThrottle' ) && str_contains( $engine_src, 'ai_concurrency_throttle' ) );
 assert_ai_backpressure_smoke( 'fetch steps do not use AI limiter', ! str_contains( $fetch_src, 'PipelineAIConcurrencyLimiter' ) );
 assert_ai_backpressure_smoke( 'upsert steps do not use AI limiter', ! str_contains( $upsert_src, 'PipelineAIConcurrencyLimiter' ) );
@@ -199,10 +232,31 @@ assert_ai_backpressure_smoke( 'ordinary contention does not call the failure pat
 echo "Case 7: age-bounded stranded work terminates distinctly\n";
 $stranded = AIConcurrencyBackpressure::nextState( $state, 'ai-1', $now + DAY_IN_SECONDS + 1, DAY_IN_SECONDS );
 assert_ai_backpressure_smoke( 'maximum contention age marks work stranded', 'stranded' === $stranded['state'] );
-assert_ai_backpressure_smoke( 'stranded work is cancelled instead of failed', str_contains( $ai_src, 'cancelled - ai_concurrency_stranded' ) );
+assert_ai_backpressure_smoke( 'stranded work is cancelled instead of failed', str_contains( $reconciler_src, 'cancelled - ai_concurrency_stranded' ) && str_contains( $ai_src, 'cancelled - ai_concurrency_stranded' ) );
 assert_ai_backpressure_smoke( 'maximum contention age is filterable', str_contains( $ai_src, 'datamachine_ai_concurrency_max_defer_age' ) );
 assert_ai_backpressure_smoke( 'backoff remains capped', 600 === AIConcurrencyBackpressure::delaySeconds( 10, 30, 600 ) );
-assert_ai_backpressure_smoke( 'only one matching future action is retained', str_contains( $ai_src, 'as_next_scheduled_action' ) );
+assert_ai_backpressure_smoke( 'only one matching future action is retained', str_contains( $backpressure_src, 'scheduleContinuation' ) );
+
+echo "Case 8: unique scheduling closes concurrent duplicate races\n";
+$GLOBALS['datamachine_ai_backpressure_actions'] = array();
+$args   = array( 'job_id' => 301, 'flow_step_id' => 'ai-1' );
+$first  = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, $args );
+$second = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, $args );
+assert_ai_backpressure_smoke( 'first continuation is scheduled with a positive ID', $first['success'] && $first['action_id'] > 0 );
+assert_ai_backpressure_smoke( 'concurrent duplicate reuses the winning action ID', $second['success'] && $second['reused'] && $first['action_id'] === $second['action_id'] );
+assert_ai_backpressure_smoke( 'concurrent duplicate executions produce one pending action', 1 === count( $GLOBALS['datamachine_ai_backpressure_actions'] ) );
+
+$GLOBALS['datamachine_ai_backpressure_schedule_error'] = true;
+$schedule_error = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, array( 'job_id' => 302, 'flow_step_id' => 'ai-1' ) );
+$GLOBALS['datamachine_ai_backpressure_schedule_error'] = false;
+assert_ai_backpressure_smoke( 'zero without a matching pending action is a scheduling failure', ! $schedule_error['success'] && 0 === $schedule_error['action_id'] );
+assert_ai_backpressure_smoke( 'scheduler call requests native uniqueness', str_contains( $backpressure_src, "self::SCHEDULER_GROUP,\n\t\t\ttrue" ) );
+
+echo "Case 9: slot recovery archives and clears active contention\n";
+$resolved = AIConcurrencyBackpressure::resolvedState( $state, $now + 120 );
+assert_ai_backpressure_smoke( 'resolved history preserves defer count', 100 === $resolved['defer_count'] );
+assert_ai_backpressure_smoke( 'resolved history preserves contention duration', 119 === $resolved['defer_age_seconds'] );
+assert_ai_backpressure_smoke( 'AIStep clears active contention after acquisition', str_contains( $ai_src, 'resolveAIConcurrencyContention' ) && str_contains( $ai_src, "unset( \$engine['ai_concurrency_throttle'] )" ) );
 
 echo "\nAI step backpressure smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {

--- a/tests/job-liveness-cli-smoke.php
+++ b/tests/job-liveness-cli-smoke.php
@@ -1,53 +1,77 @@
 <?php
-/**
- * Static smoke test for job liveness CLI diagnostics.
- *
- * Run with: php tests/job-liveness-cli-smoke.php
- *
- * @package DataMachine\Tests
- */
+/** Behavioral smoke test for job liveness classification. */
+
+define( 'ABSPATH', __DIR__ . '/' );
+define( 'MINUTE_IN_SECONDS', 60 );
+
+require_once __DIR__ . '/../inc/Cli/JobLivenessClassifier.php';
+
+use DataMachine\Cli\JobLivenessClassifier;
 
 $failed = 0;
 $total  = 0;
-
-function assert_job_liveness_cli_smoke( string $name, bool $condition, string $detail = '' ): void {
-	global $failed, $total;
+$assert = static function ( string $label, bool $condition ) use ( &$failed, &$total ): void {
 	++$total;
-
 	if ( $condition ) {
-		echo "  [PASS] {$name}\n";
+		echo "  [PASS] {$label}\n";
 		return;
 	}
-
-	echo "  [FAIL] {$name}" . ( $detail ? " - {$detail}" : '' ) . "\n";
 	++$failed;
-}
+	echo "  [FAIL] {$label}\n";
+};
 
-$source = file_get_contents( __DIR__ . '/../inc/Cli/Commands/JobsCommand.php' ) ?: '';
+$now = strtotime( '2026-07-22 12:00:00 UTC' );
+$job = static fn( array $engine = array() ): array => array(
+	'job_id'     => 42,
+	'flow_id'    => 7,
+	'pipeline_id' => 3,
+	'created_at' => '2026-07-22 08:00:00',
+	'engine_data' => $engine,
+);
+$action = static fn( string $status, string $scheduled ): array => array(
+	'hook'               => 'datamachine_resume_ai_step',
+	'status'             => $status,
+	'scheduled_date_gmt' => $scheduled,
+	'last_attempt_gmt'   => '0000-00-00 00:00:00',
+);
+$classify = static function ( array $job_row, array $actions = array(), array $children = array() ) use ( $now ): array {
+	return JobLivenessClassifier::diagnose( $job_row, $actions, $children, 120, $now );
+};
 
-echo "Case 1: liveness command is registered and read-only\n";
-assert_job_liveness_cli_smoke( 'liveness subcommand exists', str_contains( $source, '@subcommand liveness' ) );
-assert_job_liveness_cli_smoke( 'diagnostic queries processing jobs and pending contention', str_contains( $source, "status = 'processing' OR (status = 'pending'" ) && str_contains( $source, "$.ai_concurrency_throttle" ) );
-assert_job_liveness_cli_smoke( 'diagnostic reads execute-step actions', str_contains( $source, 'datamachine_execute_step' ) );
-assert_job_liveness_cli_smoke( 'diagnostic reads pipeline batch actions', str_contains( $source, 'PipelineBatchScheduler::BATCH_HOOK' ) );
-assert_job_liveness_cli_smoke( 'diagnostic does not update database rows', ! str_contains( strstr( $source, 'public function liveness' ) ?: '', '$wpdb->update(' ) );
+echo "=== job-liveness-cli-smoke ===\n";
+$active = $classify( $job(), array( $action( 'in-progress', '2026-07-22 11:30:00' ) ) );
+$assert( 'fresh running action is active processing', 'active_processing' === $active['classification'] );
 
-echo "Case 2: liveness classification exposes scheduler starvation\n";
-assert_job_liveness_cli_smoke( 'scheduler-starved classification exists', str_contains( $source, "'scheduler_starved'") );
-assert_job_liveness_cli_smoke( 'queued-next-step classification exists', str_contains( $source, "'queued_next_step'") );
-assert_job_liveness_cli_smoke( 'waiting-children classification exists', str_contains( $source, "'waiting_children'") );
-assert_job_liveness_cli_smoke( 'stale-in-progress classification exists', str_contains( $source, "'stale_in_progress'") );
-assert_job_liveness_cli_smoke( 'no-scheduler-path classification exists', str_contains( $source, "'no_scheduler_path'") );
-assert_job_liveness_cli_smoke( 'AI concurrency deferral classification exists', str_contains( $source, "'ai_concurrency_deferred'") );
-assert_job_liveness_cli_smoke( 'contention metrics include count and age', str_contains( $source, "'defer_count'") && str_contains( $source, "'defer_age_seconds'") );
-assert_job_liveness_cli_smoke( 'overdue threshold is configurable', str_contains( $source, '[--overdue-minutes=<minutes>]' ) );
+$stale = $classify( $job(), array( $action( 'in-progress', '2026-07-22 09:00:00' ) ) );
+$assert( 'overdue running action is stale in progress', 'stale_in_progress' === $stale['classification'] );
 
-echo "Case 3: structured output carries summary and jobs\n";
-assert_job_liveness_cli_smoke( 'json example exists', str_contains( $source, 'jobs liveness --overdue-minutes=120 --format=json' ) );
-assert_job_liveness_cli_smoke( 'structured output includes summary', str_contains( $source, "'summary'         => $" . 'summary' ) );
-assert_job_liveness_cli_smoke( 'structured output includes jobs', str_contains( $source, "'jobs'            => $" . 'items' ) );
+$starved = $classify( $job(), array( $action( 'pending', '2026-07-22 09:00:00' ) ) );
+$assert( 'overdue pending action is scheduler starved', 'scheduler_starved' === $starved['classification'] );
+
+$deferred_job = $job(
+	array(
+		'ai_concurrency_throttle' => array(
+			'state'             => 'deferred',
+			'attempts'          => 8,
+			'provider'          => 'openai',
+			'first_deferred_at' => '2026-07-22T11:00:00Z',
+		),
+	)
+);
+$deferred = $classify( $deferred_job, array( $action( 'pending', '2026-07-22 11:50:00' ) ) );
+$assert( 'fresh resume action with throttle is concurrency deferred', 'ai_concurrency_deferred' === $deferred['classification'] );
+$assert( 'deferred metrics expose count and age', 8 === $deferred['defer_count'] && 3600 === $deferred['defer_age_seconds'] );
+$assert( 'deferred contention is active', true === $deferred['contention_active'] );
+
+$queued = $classify( $job(), array( $action( 'pending', '2026-07-22 11:50:00' ) ) );
+$assert( 'fresh pending action without throttle is queued', 'queued_next_step' === $queued['classification'] );
+
+$waiting = $classify( $job( array( 'batch' => true, 'batch_total' => 3 ) ), array(), array( 'active' => 1, 'total' => 2 ) );
+$assert( 'active batch children classify as waiting', 'waiting_children' === $waiting['classification'] );
+
+$resolved = $classify( $job( array( 'ai_concurrency_history' => array( array( 'state' => 'resolved' ) ) ) ) );
+$assert( 'resolved history does not report active contention', false === $resolved['contention_active'] );
+$assert( 'job without active scheduler path is classified directly', 'no_scheduler_path' === $resolved['classification'] );
 
 echo "\nJob liveness CLI smoke complete: {$total} assertions, {$failed} failures.\n";
-if ( $failed > 0 ) {
-	exit( 1 );
-}
+exit( $failed > 0 ? 1 : 0 );

--- a/tests/job-liveness-cli-smoke.php
+++ b/tests/job-liveness-cli-smoke.php
@@ -27,7 +27,7 @@ $source = file_get_contents( __DIR__ . '/../inc/Cli/Commands/JobsCommand.php' ) 
 
 echo "Case 1: liveness command is registered and read-only\n";
 assert_job_liveness_cli_smoke( 'liveness subcommand exists', str_contains( $source, '@subcommand liveness' ) );
-assert_job_liveness_cli_smoke( 'diagnostic queries processing jobs', str_contains( $source, "WHERE status = 'processing'" ) );
+assert_job_liveness_cli_smoke( 'diagnostic queries processing jobs and pending contention', str_contains( $source, "status = 'processing' OR (status = 'pending'" ) && str_contains( $source, "$.ai_concurrency_throttle" ) );
 assert_job_liveness_cli_smoke( 'diagnostic reads execute-step actions', str_contains( $source, 'datamachine_execute_step' ) );
 assert_job_liveness_cli_smoke( 'diagnostic reads pipeline batch actions', str_contains( $source, 'PipelineBatchScheduler::BATCH_HOOK' ) );
 assert_job_liveness_cli_smoke( 'diagnostic does not update database rows', ! str_contains( strstr( $source, 'public function liveness' ) ?: '', '$wpdb->update(' ) );
@@ -38,6 +38,8 @@ assert_job_liveness_cli_smoke( 'queued-next-step classification exists', str_con
 assert_job_liveness_cli_smoke( 'waiting-children classification exists', str_contains( $source, "'waiting_children'") );
 assert_job_liveness_cli_smoke( 'stale-in-progress classification exists', str_contains( $source, "'stale_in_progress'") );
 assert_job_liveness_cli_smoke( 'no-scheduler-path classification exists', str_contains( $source, "'no_scheduler_path'") );
+assert_job_liveness_cli_smoke( 'AI concurrency deferral classification exists', str_contains( $source, "'ai_concurrency_deferred'") );
+assert_job_liveness_cli_smoke( 'contention metrics include count and age', str_contains( $source, "'defer_count'") && str_contains( $source, "'defer_age_seconds'") );
 assert_job_liveness_cli_smoke( 'overdue threshold is configurable', str_contains( $source, '[--overdue-minutes=<minutes>]' ) );
 
 echo "Case 3: structured output carries summary and jobs\n";

--- a/tests/job-outcome-metrics-smoke.php
+++ b/tests/job-outcome-metrics-smoke.php
@@ -221,6 +221,23 @@ $assert( 'contention defer age is machine readable', $metrics['backpressure']['d
 $assert( 'contention capacity is machine readable', 1 === $metrics['backpressure']['active'] && 1 === $metrics['backpressure']['limit'] );
 $assert( 'ordinary contention does not increment failed count', 0 === $metrics['counts']['failed'] );
 
+$resolved_metrics = RunMetrics::fromJob(
+	$job(
+		'processing',
+		array(
+			'ai_concurrency_history' => array(
+				array(
+					'state'             => 'resolved',
+					'defer_count'       => 42,
+					'defer_age_seconds' => 90,
+				),
+			),
+		)
+	)
+);
+$assert( 'resolved contention is no longer reported as active backpressure', array() === $resolved_metrics['backpressure'] );
+$assert( 'resolved contention history preserves count and duration', 42 === $resolved_metrics['backpressure_history'][0]['defer_count'] && 90 === $resolved_metrics['backpressure_history'][0]['defer_age_seconds'] );
+
 echo "\n[7] CLI/source integration markers exist\n";
 $jobs_command = file_get_contents( __DIR__ . '/../inc/Cli/Commands/JobsCommand.php' ) ?: '';
 $fetch_step   = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/FetchStep.php' ) ?: '';

--- a/tests/job-outcome-metrics-smoke.php
+++ b/tests/job-outcome-metrics-smoke.php
@@ -10,8 +10,17 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
+defined( 'DAY_IN_SECONDS' ) || define( 'DAY_IN_SECONDS', 86400 );
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, int $flags = 0, int $depth = 512 ) {
+		return json_encode( $value, $flags, $depth );
+	}
+}
 
 require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/JobArtifactSurfaces.php';
+require_once __DIR__ . '/../inc/Core/StepResult.php';
 require_once __DIR__ . '/../inc/Core/RunMetrics.php';
 
 use DataMachine\Core\RunMetrics;
@@ -185,7 +194,34 @@ $assert( 'missing handler packet class is exposed from step result', array( 'mis
 $metrics = RunMetrics::fromJob( $job( 'failed - item-deferred', array() ) );
 $assert( 'item deferred class is exposed from status reason', array( 'item_deferred' ) === $metrics['outcome_classes'] );
 
-echo "\n[6] CLI/source integration markers exist\n";
+echo "\n[6] AI concurrency backpressure is structured and not a failure\n";
+$first_deferred_at = gmdate( 'c', time() - 90 );
+$metrics           = RunMetrics::fromJob(
+	$job(
+		'pending',
+		array(
+			'ai_concurrency_throttle' => array(
+				'state'                 => 'deferred',
+				'reason'                => 'ai_concurrency_limit',
+				'provider'              => 'openai',
+				'flow_step_id'          => 'ai-1',
+				'attempts'              => 42,
+				'first_deferred_at'     => $first_deferred_at,
+				'last_deferred_at'      => gmdate( 'c' ),
+				'next_retry_at'         => gmdate( 'c', time() + 60 ),
+				'max_defer_age_seconds' => DAY_IN_SECONDS,
+				'active'                => 1,
+				'limit'                 => 1,
+			),
+		)
+	)
+);
+$assert( 'contention defer count is machine readable', 42 === $metrics['backpressure']['defer_count'] );
+$assert( 'contention defer age is machine readable', $metrics['backpressure']['defer_age_seconds'] >= 90 );
+$assert( 'contention capacity is machine readable', 1 === $metrics['backpressure']['active'] && 1 === $metrics['backpressure']['limit'] );
+$assert( 'ordinary contention does not increment failed count', 0 === $metrics['counts']['failed'] );
+
+echo "\n[7] CLI/source integration markers exist\n";
 $jobs_command = file_get_contents( __DIR__ . '/../inc/Cli/Commands/JobsCommand.php' ) ?: '';
 $fetch_step   = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/FetchStep.php' ) ?: '';
 $disposition  = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php' ) ?: '';

--- a/tests/job-status-accounting-smoke.php
+++ b/tests/job-status-accounting-smoke.php
@@ -29,6 +29,12 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, int $flags = 0, int $depth = 512 ) {
+		return json_encode( $value, $flags, $depth );
+	}
+}
+
 require_once __DIR__ . '/../inc/Core/JobStatus.php';
 require_once __DIR__ . '/../inc/Core/StepExecutionResult.php';
 require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
@@ -120,6 +126,7 @@ $assert( 'CLI inspects processing rows with terminal artifacts', str_contains( $
 $assert( 'CLI requires successful runtime provenance', str_contains( $jobs_command, 'engine_data_has_successful_runtime' ) );
 $assert( 'CLI requires successful handler tool summary', str_contains( $jobs_command, 'engine_data_has_successful_handler_tool' ) );
 $assert( 'CLI supports dry-run output', str_contains( $jobs_command, "'dry_run' => $" ) || str_contains( $jobs_command, "'dry_run' => \$dry_run" ) );
+$assert( 'historical concurrency failures reconcile without replay', str_contains( $jobs_command, 'failed - ai_concurrency_defer_exhausted' ) && str_contains( $jobs_command, 'cancelled - ai_concurrency_stranded' ) );
 
 echo "\n[5] compact job summary avoids heavyweight breakdowns\n";
 $summary_ability = file_get_contents( __DIR__ . '/../inc/Abilities/Job/JobsSummaryAbility.php' );

--- a/tests/job-status-accounting-smoke.php
+++ b/tests/job-status-accounting-smoke.php
@@ -145,7 +145,11 @@ $fail_ability    = file_get_contents( __DIR__ . '/../inc/Abilities/Job/FailJobAb
 $assert( 'Jobs repository exposes transition primitive', str_contains( $jobs_repository, 'function transition_job_status' ) );
 $assert( 'complete_job delegates to transition primitive', str_contains( $jobs_repository, 'return $this->transition_job_status( $job_id, $status, true );' ) );
 $assert( 'update_job_status delegates to transition primitive', str_contains( $jobs_repository, 'return $this->transition_job_status( $job_id, $status );' ) );
-$assert( 'transition primitive owns terminal hooks', 1 === substr_count( $jobs_repository, "do_action( 'datamachine_job_complete'" ) );
+$assert(
+	'terminal accounting owns terminal hooks',
+	str_contains( $jobs_repository, "array( 'datamachine_job_terminal_committed', 'datamachine_job_complete' )" )
+		&& str_contains( $jobs_repository, 'reconcile_terminal_accounting' )
+);
 $assert( 'recover-stuck uses transition primitive for terminal repairs', str_contains( $recover_ability, 'transition_job_status' ) );
 $assert( 'recover-stuck no longer fires manual completion hooks', ! str_contains( $recover_ability, "do_action( 'datamachine_job_complete'" ) );
 $assert( 'retry ability no longer fires duplicate completion hook', ! str_contains( $retry_ability, "do_action( 'datamachine_job_complete'" ) );

--- a/tests/job-status-accounting-smoke.php
+++ b/tests/job-status-accounting-smoke.php
@@ -119,6 +119,8 @@ $assert( 'step fails when only an AI fallback packet exists', false === $evaluat
 
 echo "\n[4] reconcile-status command exists with repair markers\n";
 $jobs_command = file_get_contents( __DIR__ . '/../inc/Cli/Commands/JobsCommand.php' );
+$jobs_repository = file_get_contents( __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php' );
+$contention_reconciler = file_get_contents( __DIR__ . '/../inc/Core/Database/Jobs/LegacyAIConcurrencyReconciler.php' );
 $assert( 'CLI exposes reconcile-status subcommand', str_contains( $jobs_command, '@subcommand reconcile-status' ) );
 $assert( 'CLI detects successful wiki update artifacts', str_contains( $jobs_command, 'Updated wiki article:' ) );
 $assert( 'CLI detects source rejection artifacts', str_contains( $jobs_command, 'Source rejected:' ) );
@@ -126,7 +128,8 @@ $assert( 'CLI inspects processing rows with terminal artifacts', str_contains( $
 $assert( 'CLI requires successful runtime provenance', str_contains( $jobs_command, 'engine_data_has_successful_runtime' ) );
 $assert( 'CLI requires successful handler tool summary', str_contains( $jobs_command, 'engine_data_has_successful_handler_tool' ) );
 $assert( 'CLI supports dry-run output', str_contains( $jobs_command, "'dry_run' => $" ) || str_contains( $jobs_command, "'dry_run' => \$dry_run" ) );
-$assert( 'historical concurrency failures reconcile without replay', str_contains( $jobs_command, 'failed - ai_concurrency_defer_exhausted' ) && str_contains( $jobs_command, 'cancelled - ai_concurrency_stranded' ) );
+$assert( 'historical concurrency failures reconcile without replay', str_contains( $contention_reconciler, 'failed - ai_concurrency_defer_exhausted' ) && str_contains( $contention_reconciler, 'cancelled - ai_concurrency_stranded' ) );
+$assert( 'historical contention uses exact repository reconciliation', str_contains( $jobs_command, 'LegacyAIConcurrencyReconciler' ) );
 
 echo "\n[5] compact job summary avoids heavyweight breakdowns\n";
 $summary_ability = file_get_contents( __DIR__ . '/../inc/Abilities/Job/JobsSummaryAbility.php' );
@@ -135,7 +138,6 @@ $assert( 'jobs summary has compact helper', str_contains( $summary_ability, 'get
 $assert( 'compact summary skips database breakdown helpers', ! str_contains( $summary_ability, 'get_pipeline_summary_rows' ) && ! str_contains( $summary_ability, 'get_flow_summary_rows' ) );
 
 echo "\n[6] job status transitions use one terminal primitive\n";
-$jobs_repository = file_get_contents( __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php' );
 $recover_ability = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RecoverStuckJobsAbility.php' );
 $retry_ability   = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RetryJobAbility.php' );
 $fail_ability    = file_get_contents( __DIR__ . '/../inc/Abilities/Job/FailJobAbility.php' );

--- a/tests/jobs-command-reconciliation-smoke.php
+++ b/tests/jobs-command-reconciliation-smoke.php
@@ -1,0 +1,68 @@
+<?php
+/** Behavioral smoke test for JobsCommand reconciliation planning. */
+
+namespace DataMachine\Cli {
+	class BaseCommand {}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	require_once __DIR__ . '/../inc/Core/Database/Jobs/LegacyAIConcurrencyReconciler.php';
+	require_once __DIR__ . '/../inc/Cli/Commands/JobsCommand.php';
+
+	use DataMachine\Cli\Commands\JobsCommand;
+	use DataMachine\Core\Database\Jobs\LegacyAIConcurrencyReconciler;
+
+	$failed = 0;
+	$total  = 0;
+	$assert = static function ( string $label, bool $condition ) use ( &$failed, &$total ): void {
+		++$total;
+		if ( $condition ) {
+			echo "  [PASS] {$label}\n";
+			return;
+		}
+		++$failed;
+		echo "  [FAIL] {$label}\n";
+	};
+
+	$reflection = new \ReflectionClass( JobsCommand::class );
+	$command    = $reflection->newInstanceWithoutConstructor();
+	$resolver   = $reflection->getMethod( 'resolve_reconciled_job_status' );
+	$planner    = $reflection->getMethod( 'resolve_reconciled_job_plan' );
+
+	$source_rejected = array(
+		'status'      => LegacyAIConcurrencyReconciler::SOURCE_STATUS,
+		'engine_data' => json_encode( array( 'job_status' => 'agent_skipped - source-rejected' ) ),
+	);
+	$runtime_success = array(
+		'status'      => LegacyAIConcurrencyReconciler::SOURCE_STATUS,
+		'engine_data' => json_encode(
+			array(
+				'runtime_provenance'   => array( 'status' => array( 'completed' => true ) ),
+				'tool_execution_summary' => array( array( 'tool_name' => 'wiki_upsert', 'success' => true ) ),
+			)
+		),
+	);
+
+	echo "=== jobs-command-reconciliation-smoke ===\n";
+	foreach ( array( 'source-rejected evidence' => $source_rejected, 'runtime-success evidence' => $runtime_success ) as $label => $row ) {
+		$target = $resolver->invoke( $command, $row );
+		$plan   = $planner->invoke( $command, $row );
+		$assert( "exact legacy status wins over {$label}", LegacyAIConcurrencyReconciler::TARGET_STATUS === $target );
+		$assert( "{$label} cannot select generic complete_job path", 'legacy_ai_concurrency' === $plan['strategy'] );
+	}
+
+	$generic = $planner->invoke(
+		$command,
+		array(
+			'status'      => 'failed - handler_failure',
+			'engine_data' => json_encode( array( 'job_status' => 'agent_skipped - source-rejected' ) ),
+		)
+	);
+	$assert( 'non-legacy evidence retains generic transition strategy', 'terminal_transition' === $generic['strategy'] );
+	$assert( 'non-legacy evidence retains derived target status', 'agent_skipped - source-rejected' === $generic['target_status'] );
+
+	echo "\nJobs command reconciliation smoke complete: {$total} assertions, {$failed} failures.\n";
+	exit( $failed > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary

- keep ordinary pipeline AI concurrency contention in `pending` with one deduplicated Action Scheduler continuation instead of converting the 31st defer into a content failure
- bound genuinely stranded contention by absolute age, defaulting to 24 hours, and terminate it as `cancelled - ai_concurrency_stranded` with durable operator evidence
- expose contention count, age, provider, capacity, next retry, and terminal reason through run metrics and job liveness
- reconcile historical `failed - ai_concurrency_defer_exhausted` rows to the non-failure terminal classification without replaying content

Closes #2929.

## Production Evidence

Events created 55,055 jobs from 2026-06-23 through 2026-07-20 and persisted 4,227 failures. Of those, 4,006 (94.75%) were `Pipeline AI step exhausted concurrency defer budget; failing job` under a one-request OpenAI concurrency limit. Current wake evidence continued to show hundreds or thousands of the same scheduler/backpressure outcome even while recent edge throughput was healthy.

This change keeps that generic scheduler contention out of handler/content failure accounting.

## State Transitions

- slot available: `processing` continues through the AI step normally
- slot saturated: `processing` -> `pending`; persist `ai_concurrency_throttle.state=deferred`; schedule the same step once
- slot later released: the pending action reacquires the lease and normal execution resumes
- contention exceeds the configured age: `processing` -> `cancelled - ai_concurrency_stranded`; persist `terminal_reason=ai_concurrency_stranded`
- continuation cannot be scheduled: `processing` -> `cancelled - ai_concurrency_defer_schedule_failed`; preserve diagnostics instead of reporting content failure

`ExecuteStepAbility` recognizes any already-final status on the empty-packet path, so the explicit cancellation is not reclassified as a generic step failure.

## Retry Bounds And Backoff

- exponential delay remains based on the provider throttle delay and caps at 600 seconds
- `as_next_scheduled_action()` prevents duplicate future actions for the same job/step arguments
- attempt count remains diagnostic rather than terminal, so a healthy one-slot queue can wait through sustained fan-out
- absolute contention age is the escape bound; default 86,400 seconds and filterable with `datamachine_ai_concurrency_max_defer_age`
- a new flow step starts a fresh contention window

This preserves eventual progress after lease release while bounding truly stranded work and preventing hot polling/action multiplication.

## Existing Rows

`wp datamachine jobs reconcile-status --dry-run --format=json` now identifies exact historical `failed - ai_concurrency_defer_exhausted` rows. Applying the existing command reclassifies them as `cancelled - ai_concurrency_stranded` only; it does not schedule actions or replay content. Rows with successful runtime plus handler artifacts still reconcile to `completed` first.

Operators should review the dry-run output before applying reconciliation. There is intentionally no blind replay.

## Metrics And Operations

`wp datamachine jobs metrics <job_id> --format=json` exposes a `backpressure` object with state, reason, terminal reason, provider, flow step, defer count/age, configured maximum age, timestamps, active/limit capacity, and action ID.

`wp datamachine jobs liveness --format=json` now includes pending AI contention rows, classifies healthy waits as `ai_concurrency_deferred`, and exposes defer count, defer age, active contention, and provider. Overdue actions still classify as `scheduler_starved`, preserving scheduler fault visibility in cron and worker contexts.

## Tests

Passed:

- `php tests/ai-step-backpressure-smoke.php` (26 assertions: cap 1 saturation, sustained 100 defers, eventual lease release, age-bounded stranded state, capped backoff, action dedupe markers)
- `php tests/job-outcome-metrics-smoke.php` (32 assertions, including no failed-count inflation)
- `php tests/job-liveness-cli-smoke.php` (16 assertions)
- `php tests/job-status-accounting-smoke.php` (22 assertions)
- changed-scope PHPCS
- changed-scope PHPStan level 7
- PHP syntax checks and `git diff --check`

The clean-checkout Homeboy PHPUnit stage was attempted twice, including a focused `AIStepTest|JobLifecycleTransitionTest|PipelineBatchSchedulerTest` run. WP Codebox failed before PHPUnit with `wp-codebox-playground-startup-asset-unavailable`: timeout waiting for the shared WordPress 7.0.2 archive cache lock. Both runs reported 0 tests executed; this was an environment bootstrap failure, not a test assertion failure.

The full audit also reports existing repository-wide heuristic baseline findings; changed-scope lint and PHPStan introduce no drift.

## Rollout Impact

No schema migration, release, deploy, production job mutation, or automatic replay is included. After rollout, new ordinary contention remains pending and visible rather than inflating failed-job metrics. Existing failure counts remain unchanged until an operator explicitly previews and applies `jobs reconcile-status`.

Commit: `90851554099f57657ab12edd527dd52bd057d666`