### PR TITLE
fix: load job liveness classifier correctly

### DIFF
--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -16,6 +16,7 @@ use WP_CLI;
 use DataMachine\Cli\AbilityRunner;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Cli\AgentResolver;
+use DataMachine\Cli\JobLivenessClassifier;
 use DataMachine\Cli\UserResolver;
 use DataMachine\Abilities\Job\DeleteJobsAbility;
 use DataMachine\Abilities\Job\FailJobAbility;

--- a/tests/job-liveness-autoload-smoke.php
+++ b/tests/job-liveness-autoload-smoke.php
@@ -1,0 +1,33 @@
+<?php
+/** Autoload smoke test for the jobs liveness command dependencies. */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+class WP_CLI_Command {}
+
+require_once dirname( __DIR__ ) . '/vendor/composer/ClassLoader.php';
+
+$loader = new Composer\Autoload\ClassLoader();
+$loader->addPsr4( 'DataMachine\\', dirname( __DIR__ ) . '/inc/' );
+$loader->register();
+
+use DataMachine\Cli\Commands\JobsCommand;
+use DataMachine\Cli\JobLivenessClassifier;
+
+$failures = 0;
+
+$assert = static function ( string $label, bool $condition ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	++$failures;
+	echo "FAIL: {$label}\n";
+};
+
+$assert( 'classifier autoloads from its declared namespace', class_exists( JobLivenessClassifier::class ) );
+$assert( 'jobs command autoloads with the classifier import', class_exists( JobsCommand::class ) );
+$assert( 'real jobs command can be instantiated', new JobsCommand() instanceof JobsCommand );
+
+exit( $failures > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary
- import the liveness classifier from its declared CLI namespace
- add a Composer classloader smoke that instantiates the real jobs command
- restore machine-readable job liveness after v0.168.2

## Verification
- liveness autoload smoke: 3 assertions
- liveness behavior smoke: 10 assertions
- changed PHPCS and diff check pass

Closes #2961