### PR TITLE
fix: serialize argument-bearing schedule updates

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -133,6 +133,8 @@ if ( ! class_exists( 'ActionScheduler' ) ) {
 	require_once __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';
 }
 
+\DataMachine\Engine\Tasks\RecurringScheduler::registerGenerationFence();
+
 add_action(
 	'action_scheduler_init',
 	array( \DataMachine\Core\ActionScheduler\GroupRegistrar::class, 'ensureDataMachineGroup' ),

--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -173,7 +173,7 @@ class RunFlowAbility {
 		}
 
 		if ( isset( $scheduling_config['datamachine_last_suppressed_run'] ) ) {
-			$this->clearSuppressedRun( $flow_id, $scheduling_config );
+			$this->clearSuppressedRun( $flow_id );
 		}
 
 		$agent_identity = null;
@@ -541,7 +541,7 @@ class RunFlowAbility {
 	private function recordSuppressedRun( int $flow_id, array $scheduling_config, array $skip ): void {
 		$suppressed_at = current_time( 'mysql', true );
 
-		$scheduling_config['datamachine_last_suppressed_run'] = array(
+		$suppressed_run = array(
 			'reason'        => (string) ( $skip['reason'] ?? 'empty_drain_queue' ),
 			'flow_step_id'  => (string) ( $skip['flow_step_id'] ?? '' ),
 			'queue_mode'    => (string) ( $skip['queue_mode'] ?? 'drain' ),
@@ -549,18 +549,19 @@ class RunFlowAbility {
 			'backoff_until' => $this->getSuppressedRunBackoffUntil( $scheduling_config, $suppressed_at ),
 		);
 
-		$this->db_flows->update_flow_scheduling( $flow_id, $scheduling_config );
+		$this->db_flows->update_flow_scheduling_metadata(
+			$flow_id,
+			array( 'datamachine_last_suppressed_run' => $suppressed_run )
+		);
 	}
 
 	/**
 	 * Clear stale suppression metadata once the flow can start normally.
 	 *
-	 * @param int   $flow_id           Flow ID.
-	 * @param array $scheduling_config Current scheduling config.
+	 * @param int $flow_id Flow ID.
 	 */
-	private function clearSuppressedRun( int $flow_id, array $scheduling_config ): void {
-		unset( $scheduling_config['datamachine_last_suppressed_run'] );
-		$this->db_flows->update_flow_scheduling( $flow_id, $scheduling_config );
+	private function clearSuppressedRun( int $flow_id ): void {
+		$this->db_flows->update_flow_scheduling_metadata( $flow_id, array(), array( 'datamachine_last_suppressed_run' ) );
 	}
 
 	/**

--- a/inc/Abilities/Engine/ScheduleFlowAbility.php
+++ b/inc/Abilities/Engine/ScheduleFlowAbility.php
@@ -271,16 +271,9 @@ class ScheduleFlowAbility {
 	 * Preserve scheduler retry/status metadata at the ability boundary.
 	 */
 	private function scheduleError( \WP_Error $error ): array {
-		$data = $error->get_error_data();
-		$data = is_array( $data ) ? $data : array();
-
-		return array(
-			'success'        => false,
-			'error'          => $error->get_error_message(),
-			'error_code'     => $error->get_error_code(),
-			'status'         => (int) ( $data['status'] ?? 500 ),
-			'retryable'      => (bool) ( $data['retryable'] ?? false ),
-			'retry_after_ms' => (int) ( $data['retry_after_ms'] ?? 0 ),
+		return array_merge(
+			array( 'success' => false ),
+			\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $error )
 		);
 	}
 }

--- a/inc/Abilities/Engine/ScheduleFlowAbility.php
+++ b/inc/Abilities/Engine/ScheduleFlowAbility.php
@@ -159,18 +159,8 @@ class ScheduleFlowAbility {
 		if ( is_wp_error( $result ) ) {
 			return $this->scheduleError( $result );
 		}
-		$action_ids      = as_get_scheduled_actions(
-			array(
-				'hook'     => 'datamachine_run_flow_now',
-				'args'     => array( $flow_id ),
-				'group'    => 'data-machine',
-				'status'   => 'pending',
-				'per_page' => 1,
-			),
-			'ids'
-		);
-		$first_action_id = reset( $action_ids );
-		$action_id       = false !== $first_action_id ? (int) $first_action_id : 0;
+		$scheduling = ( new \DataMachine\Core\Database\Flows\Flows() )->get_flow_scheduling( $flow_id );
+		$action_id  = is_array( $scheduling ) ? (int) ( $scheduling['action_id'] ?? 0 ) : 0;
 
 		do_action(
 			'datamachine_log',

--- a/inc/Abilities/Engine/ScheduleFlowAbility.php
+++ b/inc/Abilities/Engine/ScheduleFlowAbility.php
@@ -60,6 +60,10 @@ class ScheduleFlowAbility {
 							'action_id'      => array( 'type' => 'integer' ),
 							'scheduled_time' => array( 'type' => 'string' ),
 							'error'          => array( 'type' => 'string' ),
+							'error_code'     => array( 'type' => 'string' ),
+							'status'         => array( 'type' => 'integer' ),
+							'retryable'      => array( 'type' => 'boolean' ),
+							'retry_after_ms' => array( 'type' => 'integer' ),
 						),
 					),
 					'execute_callback'    => array( $this, 'execute' ),
@@ -89,9 +93,6 @@ class ScheduleFlowAbility {
 		$flow_id               = (int) ( $input['flow_id'] ?? 0 );
 		$interval_or_timestamp = $input['interval_or_timestamp'] ?? null;
 
-		// Always unschedule existing to prevent duplicates.
-		as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
-
 		if ( 'manual' === $interval_or_timestamp ) {
 			return $this->clearSchedule( $flow_id );
 		}
@@ -117,9 +118,14 @@ class ScheduleFlowAbility {
 	 * @return array Result.
 	 */
 	private function clearSchedule( int $flow_id ): array {
-		$scheduling_config = array( 'interval' => 'manual' );
-		$this->db_flows->update_flow_scheduling( $flow_id, $scheduling_config );
-
+		$result = \DataMachine\Api\Flows\FlowScheduling::handle_scheduling_update(
+			$flow_id,
+			array( 'interval' => 'manual' ),
+			true
+		);
+		if ( is_wp_error( $result ) ) {
+			return $this->scheduleError( $result );
+		}
 		do_action(
 			'datamachine_log',
 			'info',
@@ -142,19 +148,29 @@ class ScheduleFlowAbility {
 	 * @return array Result.
 	 */
 	private function scheduleOneTime( int $flow_id, int $timestamp ): array {
-		$action_id = as_schedule_single_action(
-			$timestamp,
-			'datamachine_run_flow_now',
-			array( $flow_id ),
-			'data-machine'
+		$result = \DataMachine\Api\Flows\FlowScheduling::handle_scheduling_update(
+			$flow_id,
+			array(
+				'interval'  => 'one_time',
+				'timestamp' => $timestamp,
+			),
+			true
 		);
-
-		$scheduling_config = array(
-			'interval'       => 'one_time',
-			'timestamp'      => $timestamp,
-			'scheduled_time' => wp_date( 'c', $timestamp ),
+		if ( is_wp_error( $result ) ) {
+			return $this->scheduleError( $result );
+		}
+		$action_ids      = as_get_scheduled_actions(
+			array(
+				'hook'     => 'datamachine_run_flow_now',
+				'args'     => array( $flow_id ),
+				'group'    => 'data-machine',
+				'status'   => 'pending',
+				'per_page' => 1,
+			),
+			'ids'
 		);
-		$this->db_flows->update_flow_scheduling( $flow_id, $scheduling_config );
+		$first_action_id = reset( $action_ids );
+		$action_id       = false !== $first_action_id ? (int) $first_action_id : 0;
 
 		do_action(
 			'datamachine_log',
@@ -197,10 +213,7 @@ class ScheduleFlowAbility {
 		);
 
 		if ( is_wp_error( $result ) ) {
-			return array(
-				'success' => false,
-				'error'   => $result->get_error_message(),
-			);
+			return $this->scheduleError( $result );
 		}
 
 		// Read back the scheduling config to get the computed next run.
@@ -236,10 +249,7 @@ class ScheduleFlowAbility {
 		);
 
 		if ( is_wp_error( $result ) ) {
-			return array(
-				'success' => false,
-				'error'   => $result->get_error_message(),
-			);
+			return $this->scheduleError( $result );
 		}
 
 		// Read back the scheduling config to get the computed first_run.
@@ -254,6 +264,23 @@ class ScheduleFlowAbility {
 			'flow_id'        => $flow_id,
 			'schedule_type'  => 'recurring',
 			'scheduled_time' => $scheduling_config['first_run'] ?? null,
+		);
+	}
+
+	/**
+	 * Preserve scheduler retry/status metadata at the ability boundary.
+	 */
+	private function scheduleError( \WP_Error $error ): array {
+		$data = $error->get_error_data();
+		$data = is_array( $data ) ? $data : array();
+
+		return array(
+			'success'        => false,
+			'error'          => $error->get_error_message(),
+			'error_code'     => $error->get_error_code(),
+			'status'         => (int) ( $data['status'] ?? 500 ),
+			'retryable'      => (bool) ( $data['retryable'] ?? false ),
+			'retry_after_ms' => (int) ( $data['retry_after_ms'] ?? 0 ),
 		);
 	}
 }

--- a/inc/Abilities/Flow/CreateFlowAbility.php
+++ b/inc/Abilities/Flow/CreateFlowAbility.php
@@ -332,8 +332,14 @@ class CreateFlowAbility {
 		}
 
 		if ( $validate_only ) {
-			$this->compensateFlowSchedule( $flow_id );
+			$schedule_error = $this->compensateFlowSchedule( $flow_id );
 			$this->rollbackCreationTransactionScope( $transaction_scope );
+			if ( $schedule_error ) {
+				return array_merge(
+					array( 'success' => false ),
+					RecurringScheduler::errorMetadata( $schedule_error )
+				);
+			}
 
 			return array(
 				'success'      => true,
@@ -394,7 +400,7 @@ class CreateFlowAbility {
 	 * @return array Failure result.
 	 */
 	private function rollbackCreation( array $transaction_scope, int $flow_id, string $error, array $configuration_errors = array() ): array {
-		$this->compensateFlowSchedule( $flow_id );
+		$schedule_error = $this->compensateFlowSchedule( $flow_id );
 		$this->rollbackCreationTransactionScope( $transaction_scope );
 
 		$result = array(
@@ -404,6 +410,9 @@ class CreateFlowAbility {
 
 		if ( ! empty( $configuration_errors ) ) {
 			$result['configuration_errors'] = $configuration_errors;
+		}
+		if ( $schedule_error ) {
+			$result['schedule_cleanup'] = RecurringScheduler::errorMetadata( $schedule_error );
 		}
 
 		return $result;
@@ -491,8 +500,9 @@ class CreateFlowAbility {
 	 *
 	 * @param int $flow_id Flow ID allocated in this scope.
 	 */
-	private function compensateFlowSchedule( int $flow_id ): void {
-		RecurringScheduler::ensureSchedule( FlowScheduling::FLOW_HOOK, array( $flow_id ), 'manual' );
+	private function compensateFlowSchedule( int $flow_id ): ?\WP_Error {
+		$result = RecurringScheduler::ensureSchedule( FlowScheduling::FLOW_HOOK, array( $flow_id ), 'manual' );
+		return is_wp_error( $result ) ? $result : null;
 	}
 
 	/**

--- a/inc/Abilities/Flow/CreateFlowAbility.php
+++ b/inc/Abilities/Flow/CreateFlowAbility.php
@@ -332,13 +332,8 @@ class CreateFlowAbility {
 		}
 
 		if ( $validate_only ) {
-			$schedule_error = $this->compensateFlowSchedule(
-				$flow_id,
-				function () use ( $transaction_scope ): bool {
-					$this->rollbackCreationTransactionScope( $transaction_scope );
-					return true;
-				}
-			);
+			$this->rollbackCreationTransactionScope( $transaction_scope );
+			$schedule_error = $this->compensateFlowSchedule( $flow_id );
 			if ( $schedule_error ) {
 				return array_merge(
 					array( 'success' => false ),
@@ -405,13 +400,8 @@ class CreateFlowAbility {
 	 * @return array Failure result.
 	 */
 	private function rollbackCreation( array $transaction_scope, int $flow_id, string $error, array $configuration_errors = array() ): array {
-		$schedule_error = $this->compensateFlowSchedule(
-			$flow_id,
-			function () use ( $transaction_scope ): bool {
-				$this->rollbackCreationTransactionScope( $transaction_scope );
-				return true;
-			}
-		);
+		$this->rollbackCreationTransactionScope( $transaction_scope );
+		$schedule_error = $this->compensateFlowSchedule( $flow_id );
 
 		$result = array(
 			'success' => false,
@@ -508,27 +498,10 @@ class CreateFlowAbility {
 	/**
 	 * Remove any Action Scheduler side effect created for a rolled-back flow.
 	 *
-	 * @param int      $flow_id Flow ID allocated in this scope.
-	 * @param callable $rollback Desired-state rollback executed under the schedule lease.
+	 * @param int $flow_id Flow ID allocated in this scope.
 	 */
-	private function compensateFlowSchedule( int $flow_id, callable $rollback ): ?\WP_Error {
-		$rolled_back = false;
-		$result      = RecurringScheduler::commitDesiredSchedule(
-			FlowScheduling::FLOW_HOOK,
-			array( $flow_id ),
-			'manual',
-			array(),
-			true,
-			static function () use ( $rollback, &$rolled_back ): bool {
-				$rollback();
-				$rolled_back = true;
-				return true;
-			},
-			static fn(): bool => true
-		);
-		if ( ! $rolled_back ) {
-			$rollback();
-		}
+	private function compensateFlowSchedule( int $flow_id ): ?\WP_Error {
+		$result = RecurringScheduler::ensureSchedule( FlowScheduling::FLOW_HOOK, array( $flow_id ), 'manual' );
 		return is_wp_error( $result ) ? $result : null;
 	}
 

--- a/inc/Abilities/Flow/CreateFlowAbility.php
+++ b/inc/Abilities/Flow/CreateFlowAbility.php
@@ -332,8 +332,13 @@ class CreateFlowAbility {
 		}
 
 		if ( $validate_only ) {
-			$schedule_error = $this->compensateFlowSchedule( $flow_id );
-			$this->rollbackCreationTransactionScope( $transaction_scope );
+			$schedule_error = $this->compensateFlowSchedule(
+				$flow_id,
+				function () use ( $transaction_scope ): bool {
+					$this->rollbackCreationTransactionScope( $transaction_scope );
+					return true;
+				}
+			);
 			if ( $schedule_error ) {
 				return array_merge(
 					array( 'success' => false ),
@@ -400,8 +405,13 @@ class CreateFlowAbility {
 	 * @return array Failure result.
 	 */
 	private function rollbackCreation( array $transaction_scope, int $flow_id, string $error, array $configuration_errors = array() ): array {
-		$schedule_error = $this->compensateFlowSchedule( $flow_id );
-		$this->rollbackCreationTransactionScope( $transaction_scope );
+		$schedule_error = $this->compensateFlowSchedule(
+			$flow_id,
+			function () use ( $transaction_scope ): bool {
+				$this->rollbackCreationTransactionScope( $transaction_scope );
+				return true;
+			}
+		);
 
 		$result = array(
 			'success' => false,
@@ -498,10 +508,27 @@ class CreateFlowAbility {
 	/**
 	 * Remove any Action Scheduler side effect created for a rolled-back flow.
 	 *
-	 * @param int $flow_id Flow ID allocated in this scope.
+	 * @param int      $flow_id Flow ID allocated in this scope.
+	 * @param callable $rollback Desired-state rollback executed under the schedule lease.
 	 */
-	private function compensateFlowSchedule( int $flow_id ): ?\WP_Error {
-		$result = RecurringScheduler::ensureSchedule( FlowScheduling::FLOW_HOOK, array( $flow_id ), 'manual' );
+	private function compensateFlowSchedule( int $flow_id, callable $rollback ): ?\WP_Error {
+		$rolled_back = false;
+		$result      = RecurringScheduler::commitDesiredSchedule(
+			FlowScheduling::FLOW_HOOK,
+			array( $flow_id ),
+			'manual',
+			array(),
+			true,
+			static function () use ( $rollback, &$rolled_back ): bool {
+				$rollback();
+				$rolled_back = true;
+				return true;
+			},
+			static fn(): bool => true
+		);
+		if ( ! $rolled_back ) {
+			$rollback();
+		}
 		return is_wp_error( $result ) ? $result : null;
 	}
 

--- a/inc/Abilities/Flow/CreateFlowAbility.php
+++ b/inc/Abilities/Flow/CreateFlowAbility.php
@@ -333,6 +333,7 @@ class CreateFlowAbility {
 
 		if ( $validate_only ) {
 			$this->rollbackCreationTransactionScope( $transaction_scope );
+			RecurringScheduler::invalidateGenerationCache( FlowScheduling::FLOW_HOOK, array( $flow_id ) );
 			$schedule_error = $this->compensateFlowSchedule( $flow_id );
 			if ( $schedule_error ) {
 				return array_merge(
@@ -401,6 +402,7 @@ class CreateFlowAbility {
 	 */
 	private function rollbackCreation( array $transaction_scope, int $flow_id, string $error, array $configuration_errors = array() ): array {
 		$this->rollbackCreationTransactionScope( $transaction_scope );
+		RecurringScheduler::invalidateGenerationCache( FlowScheduling::FLOW_HOOK, array( $flow_id ) );
 		$schedule_error = $this->compensateFlowSchedule( $flow_id );
 
 		$result = array(
@@ -501,7 +503,12 @@ class CreateFlowAbility {
 	 * @param int $flow_id Flow ID allocated in this scope.
 	 */
 	private function compensateFlowSchedule( int $flow_id ): ?\WP_Error {
-		$result = RecurringScheduler::ensureSchedule( FlowScheduling::FLOW_HOOK, array( $flow_id ), 'manual' );
+		$result = RecurringScheduler::ensureSchedule(
+			FlowScheduling::FLOW_HOOK,
+			array( $flow_id ),
+			'manual',
+			array( 'generation_argument_index' => FlowScheduling::GENERATION_ARGUMENT_INDEX )
+		);
 		return is_wp_error( $result ) ? $result : null;
 	}
 

--- a/inc/Abilities/Flow/CreateFlowAbility.php
+++ b/inc/Abilities/Flow/CreateFlowAbility.php
@@ -492,7 +492,7 @@ class CreateFlowAbility {
 	 * @param int $flow_id Flow ID allocated in this scope.
 	 */
 	private function compensateFlowSchedule( int $flow_id ): void {
-		RecurringScheduler::unschedule( FlowScheduling::FLOW_HOOK, array( $flow_id ), RecurringScheduler::GROUP );
+		RecurringScheduler::ensureSchedule( FlowScheduling::FLOW_HOOK, array( $flow_id ), 'manual' );
 	}
 
 	/**

--- a/inc/Abilities/Flow/DeleteFlowAbility.php
+++ b/inc/Abilities/Flow/DeleteFlowAbility.php
@@ -91,7 +91,11 @@ class DeleteFlowAbility {
 
 		$pipeline_id = (int) ( $flow['pipeline_id'] ?? 0 );
 
-		as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
+		\DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
+			'datamachine_run_flow_now',
+			array( $flow_id ),
+			'manual'
+		);
 
 		$success = $this->db_flows->delete_flow( $flow_id );
 

--- a/inc/Abilities/Flow/DeleteFlowAbility.php
+++ b/inc/Abilities/Flow/DeleteFlowAbility.php
@@ -95,7 +95,7 @@ class DeleteFlowAbility {
 			'datamachine_run_flow_now',
 			array( $flow_id ),
 			'manual',
-			array(),
+			array( 'generation_argument_index' => \DataMachine\Api\Flows\FlowScheduling::GENERATION_ARGUMENT_INDEX ),
 			true,
 			fn(): bool => $this->db_flows->delete_flow( $flow_id ),
 			static function ( $result ) use ( $flow_id ): bool {

--- a/inc/Abilities/Flow/DeleteFlowAbility.php
+++ b/inc/Abilities/Flow/DeleteFlowAbility.php
@@ -91,11 +91,17 @@ class DeleteFlowAbility {
 
 		$pipeline_id = (int) ( $flow['pipeline_id'] ?? 0 );
 
-		\DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
+		$schedule_result = \DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
 			'datamachine_run_flow_now',
 			array( $flow_id ),
 			'manual'
 		);
+		if ( is_wp_error( $schedule_result ) ) {
+			return array_merge(
+				array( 'success' => false ),
+				\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $schedule_result )
+			);
+		}
 
 		$success = $this->db_flows->delete_flow( $flow_id );
 

--- a/inc/Abilities/Flow/DeleteFlowAbility.php
+++ b/inc/Abilities/Flow/DeleteFlowAbility.php
@@ -91,43 +91,53 @@ class DeleteFlowAbility {
 
 		$pipeline_id = (int) ( $flow['pipeline_id'] ?? 0 );
 
-		$schedule_result = \DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
+		$schedule_result = \DataMachine\Engine\Tasks\RecurringScheduler::commitDesiredSchedule(
 			'datamachine_run_flow_now',
 			array( $flow_id ),
-			'manual'
+			'manual',
+			array(),
+			true,
+			fn(): bool => $this->db_flows->delete_flow( $flow_id ),
+			static function ( $result ) use ( $flow_id ): bool {
+				if ( is_wp_error( $result ) ) {
+					do_action(
+						'datamachine_log',
+						'error',
+						'Deleted flow has schedule reconciliation drift',
+						array_merge(
+							array( 'flow_id' => $flow_id ),
+							\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $result )
+						)
+					);
+				}
+				return true;
+			}
 		);
 		if ( is_wp_error( $schedule_result ) ) {
 			return array_merge(
-				array( 'success' => false ),
+				array(
+					'success'                 => false,
+					'desired_state_committed' => null === $this->db_flows->get_flow( $flow_id ),
+				),
 				\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $schedule_result )
 			);
 		}
 
-		$success = $this->db_flows->delete_flow( $flow_id );
-
-		if ( $success ) {
-			do_action(
-				'datamachine_log',
-				'info',
-				'Flow deleted successfully',
-				array(
-					'flow_id'     => $flow_id,
-					'pipeline_id' => $pipeline_id,
-				)
-			);
-
-			return array(
-				'success'     => true,
+		do_action(
+			'datamachine_log',
+			'info',
+			'Flow deleted successfully',
+			array(
 				'flow_id'     => $flow_id,
 				'pipeline_id' => $pipeline_id,
-				'message'     => 'Flow deleted successfully',
-			);
-		}
+			)
+		);
 
-		do_action( 'datamachine_log', 'error', 'Failed to delete flow', array( 'flow_id' => $flow_id ) );
 		return array(
-			'success' => false,
-			'error'   => 'Failed to delete flow',
+			'success'     => true,
+			'flow_id'     => $flow_id,
+			'pipeline_id' => $pipeline_id,
+			'message'     => 'Flow deleted successfully',
 		);
 	}
 }

--- a/inc/Abilities/Flow/PauseFlowAbility.php
+++ b/inc/Abilities/Flow/PauseFlowAbility.php
@@ -105,6 +105,7 @@ class PauseFlowAbility {
 
 		$paused  = 0;
 		$skipped = 0;
+		$errors  = 0;
 		$details = array();
 
 		foreach ( $flows as $flow ) {
@@ -121,16 +122,35 @@ class PauseFlowAbility {
 				continue;
 			}
 
-			// Set enabled=false, preserving all other scheduling fields.
-			$scheduling['enabled'] = false;
-			$this->db_flows->update_flow_scheduling( $fid, $scheduling );
-
-			// Unschedule Action Scheduler hooks so paused flows don't fire.
-			\DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
+			// Fence the recurrence before reporting or persisting a successful pause.
+			$schedule_result = \DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
 				'datamachine_run_flow_now',
 				array( $fid ),
 				'manual'
 			);
+			if ( is_wp_error( $schedule_result ) ) {
+				++$errors;
+				$details[] = array_merge(
+					array(
+						'flow_id' => $fid,
+						'status'  => 'pause_error',
+					),
+					\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $schedule_result )
+				);
+				continue;
+			}
+
+			$scheduling['enabled'] = false;
+			if ( ! $this->db_flows->update_flow_scheduling( $fid, $scheduling ) ) {
+				++$errors;
+				$details[] = array(
+					'flow_id'    => $fid,
+					'status'     => 'pause_error',
+					'error'      => 'Failed to persist paused scheduling state.',
+					'error_code' => 'pause_persistence_failed',
+				);
+				continue;
+			}
 
 			++$paused;
 			$details[] = array(
@@ -148,13 +168,15 @@ class PauseFlowAbility {
 			array(
 				'paused'  => $paused,
 				'skipped' => $skipped,
+				'errors'  => $errors,
 			)
 		);
 
 		return array(
-			'success' => true,
+			'success' => 0 === $errors,
 			'paused'  => $paused,
 			'skipped' => $skipped,
+			'errors'  => $errors,
 			'flows'   => $details,
 			'message' => sprintf( 'Paused %d flow(s), skipped %d (already paused).', $paused, $skipped ),
 		);

--- a/inc/Abilities/Flow/PauseFlowAbility.php
+++ b/inc/Abilities/Flow/PauseFlowAbility.php
@@ -122,12 +122,8 @@ class PauseFlowAbility {
 				continue;
 			}
 
-			// Fence the recurrence before reporting or persisting a successful pause.
-			$schedule_result = \DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
-				'datamachine_run_flow_now',
-				array( $fid ),
-				'manual'
-			);
+			$scheduling['enabled'] = false;
+			$schedule_result       = FlowScheduling::handle_scheduling_update( $fid, $scheduling, true );
 			if ( is_wp_error( $schedule_result ) ) {
 				++$errors;
 				$details[] = array_merge(
@@ -136,18 +132,6 @@ class PauseFlowAbility {
 						'status'  => 'pause_error',
 					),
 					\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $schedule_result )
-				);
-				continue;
-			}
-
-			$scheduling['enabled'] = false;
-			if ( ! $this->db_flows->update_flow_scheduling( $fid, $scheduling ) ) {
-				++$errors;
-				$details[] = array(
-					'flow_id'    => $fid,
-					'status'     => 'pause_error',
-					'error'      => 'Failed to persist paused scheduling state.',
-					'error_code' => 'pause_persistence_failed',
 				);
 				continue;
 			}

--- a/inc/Abilities/Flow/PauseFlowAbility.php
+++ b/inc/Abilities/Flow/PauseFlowAbility.php
@@ -127,11 +127,11 @@ class PauseFlowAbility {
 			if ( is_wp_error( $schedule_result ) ) {
 				++$errors;
 				$details[] = array_merge(
+					\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $schedule_result ),
 					array(
 						'flow_id' => $fid,
 						'status'  => 'pause_error',
-					),
-					\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $schedule_result )
+					)
 				);
 				continue;
 			}

--- a/inc/Abilities/Flow/PauseFlowAbility.php
+++ b/inc/Abilities/Flow/PauseFlowAbility.php
@@ -126,7 +126,11 @@ class PauseFlowAbility {
 			$this->db_flows->update_flow_scheduling( $fid, $scheduling );
 
 			// Unschedule Action Scheduler hooks so paused flows don't fire.
-			as_unschedule_all_actions( 'datamachine_run_flow_now', array( $fid ), 'data-machine' );
+			\DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
+				'datamachine_run_flow_now',
+				array( $fid ),
+				'manual'
+			);
 
 			++$paused;
 			$details[] = array(

--- a/inc/Abilities/Flow/ResumeFlowAbility.php
+++ b/inc/Abilities/Flow/ResumeFlowAbility.php
@@ -122,23 +122,19 @@ class ResumeFlowAbility {
 				continue;
 			}
 
-			// Remove the enabled key (default is enabled) and re-register schedule.
+			// Commit resumed intent and reconcile under the shared schedule lease.
 			unset( $scheduling['enabled'] );
-			$this->db_flows->update_flow_scheduling( $fid, $scheduling );
-
-			// Re-register Action Scheduler hooks from the preserved schedule.
-			$interval = $scheduling['interval'] ?? 'manual';
-			if ( 'manual' !== $interval ) {
-				$result = FlowScheduling::handle_scheduling_update( $fid, $scheduling, true );
-				if ( is_wp_error( $result ) ) {
-					++$errors;
-					$details[] = array(
+			$result = FlowScheduling::handle_scheduling_update( $fid, $scheduling, true );
+			if ( is_wp_error( $result ) ) {
+				++$errors;
+				$details[] = array_merge(
+					array(
 						'flow_id' => $fid,
 						'status'  => 'resume_error',
-						'error'   => $result->get_error_message(),
-					);
-					continue;
-				}
+					),
+					\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $result )
+				);
+				continue;
 			}
 
 			++$resumed;

--- a/inc/Abilities/Flow/ResumeFlowAbility.php
+++ b/inc/Abilities/Flow/ResumeFlowAbility.php
@@ -128,11 +128,11 @@ class ResumeFlowAbility {
 			if ( is_wp_error( $result ) ) {
 				++$errors;
 				$details[] = array_merge(
+					\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $result ),
 					array(
 						'flow_id' => $fid,
 						'status'  => 'resume_error',
-					),
-					\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $result )
+					)
 				);
 				continue;
 			}

--- a/inc/Abilities/Pipeline/DeletePipelineAbility.php
+++ b/inc/Abilities/Pipeline/DeletePipelineAbility.php
@@ -102,7 +102,11 @@ class DeletePipelineAbility {
 				continue;
 			}
 
-			as_unschedule_all_actions( 'datamachine_run_flow_now', array( (int) $flow_id ), 'data-machine' );
+			\DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
+				'datamachine_run_flow_now',
+				array( (int) $flow_id ),
+				'manual'
+			);
 
 			$this->db_flows->delete_flow( (int) $flow_id );
 		}

--- a/inc/Abilities/Pipeline/DeletePipelineAbility.php
+++ b/inc/Abilities/Pipeline/DeletePipelineAbility.php
@@ -10,6 +10,7 @@
 
 namespace DataMachine\Abilities\Pipeline;
 
+use DataMachine\Api\Flows\FlowScheduling;
 use DataMachine\Core\FilesRepository\FileCleanup;
 
 defined( 'ABSPATH' ) || exit;
@@ -96,18 +97,38 @@ class DeletePipelineAbility {
 		$affected_flows = $this->db_flows->get_flows_for_pipeline( $pipeline_id );
 		$flow_count     = count( $affected_flows );
 
+		// Fence every recurrence before deleting any flow so a lock failure cannot
+		// produce a partially deleted pipeline with surviving schedules.
+		$fenced_flows = array();
 		foreach ( $affected_flows as $flow ) {
 			$flow_id = $flow['flow_id'] ?? null;
 			if ( ! $flow_id ) {
 				continue;
 			}
 
-			\DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
+			$fenced_flows[]  = $flow;
+			$schedule_result = \DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
 				'datamachine_run_flow_now',
 				array( (int) $flow_id ),
 				'manual'
 			);
+			if ( is_wp_error( $schedule_result ) ) {
+				return array_merge(
+					array(
+						'success'                 => false,
+						'flow_id'                 => (int) $flow_id,
+						'schedule_reconciliation' => $this->reconcileFlowSchedules( $fenced_flows ),
+					),
+					\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $schedule_result )
+				);
+			}
+		}
 
+		foreach ( $affected_flows as $flow ) {
+			$flow_id = $flow['flow_id'] ?? null;
+			if ( ! $flow_id ) {
+				continue;
+			}
 			$this->db_flows->delete_flow( (int) $flow_id );
 		}
 
@@ -155,5 +176,31 @@ class DeletePipelineAbility {
 				$flow_count
 			),
 		);
+	}
+
+	/**
+	 * Restore persisted schedules after a multi-flow preflight fails partway.
+	 *
+	 * @param array $flows Flows whose schedule may have been fenced already.
+	 */
+	private function reconcileFlowSchedules( array $flows ): array {
+		$results = array();
+		foreach ( $flows as $flow ) {
+			$flow_id = (int) ( $flow['flow_id'] ?? 0 );
+			if ( $flow_id <= 0 ) {
+				continue;
+			}
+
+			$result              = FlowScheduling::handle_scheduling_update(
+				$flow_id,
+				$flow['scheduling_config'] ?? array( 'interval' => 'manual' ),
+				true
+			);
+			$results[ $flow_id ] = is_wp_error( $result )
+				? array_merge( array( 'success' => false ), \DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $result ) )
+				: array( 'success' => true );
+		}
+
+		return $results;
 	}
 }

--- a/inc/Abilities/Pipeline/DeletePipelineAbility.php
+++ b/inc/Abilities/Pipeline/DeletePipelineAbility.php
@@ -107,7 +107,7 @@ class DeletePipelineAbility {
 				'datamachine_run_flow_now',
 				array( $flow_id ),
 				'manual',
-				array(),
+				array( 'generation_argument_index' => \DataMachine\Api\Flows\FlowScheduling::GENERATION_ARGUMENT_INDEX ),
 				true,
 				fn(): bool => $this->db_flows->delete_flow( $flow_id ),
 				static function ( $result ) use ( $flow_id ): bool {

--- a/inc/Abilities/Pipeline/DeletePipelineAbility.php
+++ b/inc/Abilities/Pipeline/DeletePipelineAbility.php
@@ -10,7 +10,6 @@
 
 namespace DataMachine\Abilities\Pipeline;
 
-use DataMachine\Api\Flows\FlowScheduling;
 use DataMachine\Core\FilesRepository\FileCleanup;
 
 defined( 'ABSPATH' ) || exit;
@@ -95,41 +94,59 @@ class DeletePipelineAbility {
 
 		$pipeline_name  = $pipeline['pipeline_name'];
 		$affected_flows = $this->db_flows->get_flows_for_pipeline( $pipeline_id );
-		$flow_count     = count( $affected_flows );
 
-		// Fence every recurrence before deleting any flow so a lock failure cannot
-		// produce a partially deleted pipeline with surviving schedules.
-		$fenced_flows = array();
+		$deleted_flows     = 0;
+		$schedule_failures = array();
 		foreach ( $affected_flows as $flow ) {
-			$flow_id = $flow['flow_id'] ?? null;
-			if ( ! $flow_id ) {
+			$flow_id = (int) ( $flow['flow_id'] ?? 0 );
+			if ( $flow_id <= 0 ) {
 				continue;
 			}
 
-			$fenced_flows[]  = $flow;
-			$schedule_result = \DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
+			$schedule_result = \DataMachine\Engine\Tasks\RecurringScheduler::commitDesiredSchedule(
 				'datamachine_run_flow_now',
-				array( (int) $flow_id ),
-				'manual'
+				array( $flow_id ),
+				'manual',
+				array(),
+				true,
+				fn(): bool => $this->db_flows->delete_flow( $flow_id ),
+				static function ( $result ) use ( $flow_id ): bool {
+					if ( is_wp_error( $result ) ) {
+						do_action(
+							'datamachine_log',
+							'error',
+							'Deleted pipeline flow has schedule reconciliation drift',
+							array_merge(
+								array( 'flow_id' => $flow_id ),
+								\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $result )
+							)
+						);
+					}
+					return true;
+				}
 			);
 			if ( is_wp_error( $schedule_result ) ) {
-				return array_merge(
-					array(
-						'success'                 => false,
-						'flow_id'                 => (int) $flow_id,
-						'schedule_reconciliation' => $this->reconcileFlowSchedules( $fenced_flows ),
-					),
-					\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $schedule_result )
+				$schedule_failures[ $flow_id ] = array_merge(
+					\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $schedule_result ),
+					array( 'desired_state_committed' => null === $this->db_flows->get_flow( $flow_id ) )
 				);
-			}
-		}
-
-		foreach ( $affected_flows as $flow ) {
-			$flow_id = $flow['flow_id'] ?? null;
-			if ( ! $flow_id ) {
 				continue;
 			}
-			$this->db_flows->delete_flow( (int) $flow_id );
+			++$deleted_flows;
+		}
+
+		$commit_failures = array_filter(
+			$schedule_failures,
+			static fn(array $failure): bool => empty( $failure['desired_state_committed'] )
+		);
+		if ( ! empty( $commit_failures ) ) {
+			return array(
+				'success'           => false,
+				'error'             => 'Pipeline deletion did not commit every flow deletion.',
+				'error_code'        => 'pipeline_flow_deletion_incomplete',
+				'schedule_failures' => $schedule_failures,
+				'deleted_flows'     => $deleted_flows,
+			);
 		}
 
 		$cleanup            = new FileCleanup();
@@ -161,46 +178,28 @@ class DeletePipelineAbility {
 			array(
 				'pipeline_id'   => $pipeline_id,
 				'pipeline_name' => $pipeline_name,
-				'deleted_flows' => $flow_count,
+				'deleted_flows' => $deleted_flows,
 			)
 		);
 
-		return array(
-			'success'       => true,
-			'pipeline_id'   => $pipeline_id,
-			'pipeline_name' => $pipeline_name,
-			'deleted_flows' => $flow_count,
-			'message'       => sprintf(
+		$result = array(
+			'success'          => empty( $schedule_failures ),
+			'pipeline_id'      => $pipeline_id,
+			'pipeline_name'    => $pipeline_name,
+			'deleted_flows'    => $deleted_flows,
+			'pipeline_deleted' => true,
+			'message'          => sprintf(
 				'Pipeline "%s" deleted successfully. %d flows were also deleted.',
 				$pipeline_name,
-				$flow_count
+				$deleted_flows
 			),
 		);
-	}
-
-	/**
-	 * Restore persisted schedules after a multi-flow preflight fails partway.
-	 *
-	 * @param array $flows Flows whose schedule may have been fenced already.
-	 */
-	private function reconcileFlowSchedules( array $flows ): array {
-		$results = array();
-		foreach ( $flows as $flow ) {
-			$flow_id = (int) ( $flow['flow_id'] ?? 0 );
-			if ( $flow_id <= 0 ) {
-				continue;
-			}
-
-			$result              = FlowScheduling::handle_scheduling_update(
-				$flow_id,
-				$flow['scheduling_config'] ?? array( 'interval' => 'manual' ),
-				true
-			);
-			$results[ $flow_id ] = is_wp_error( $result )
-				? array_merge( array( 'success' => false ), \DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $result ) )
-				: array( 'success' => true );
+		if ( ! empty( $schedule_failures ) ) {
+			$result['error']             = 'Pipeline was deleted with retryable schedule reconciliation drift.';
+			$result['error_code']        = 'pipeline_schedule_reconciliation_drift';
+			$result['schedule_failures'] = $schedule_failures;
 		}
 
-		return $results;
+		return $result;
 	}
 }

--- a/inc/Api/Flows/FlowScheduleReconciler.php
+++ b/inc/Api/Flows/FlowScheduleReconciler.php
@@ -69,13 +69,20 @@ class FlowScheduleReconciler {
 	private function reconcileUnlocked( bool $apply, ?int $spread_hours, ?string $lock_token ): array {
 		$eligible       = array();
 		$invalid        = array();
+		$drift_cleanup  = array();
 		$excluded_count = 0;
 
 		foreach ( $this->flows->get_flow_schedules() as $flow ) {
 			$scheduling = $flow['scheduling_config'] ?? array();
 			$interval   = $scheduling['interval'] ?? null;
 
+			$has_drift = ! empty( $scheduling['schedule_reconciliation'] );
 			if ( ! Flows::is_flow_enabled( $scheduling ) || empty( $interval ) || in_array( $interval, array( 'manual', 'one_time' ), true ) ) {
+				if ( $has_drift ) {
+					$flow['force_reconcile'] = true;
+					$drift_cleanup[]         = $flow;
+					continue;
+				}
 				++$excluded_count;
 				continue;
 			}
@@ -88,6 +95,7 @@ class FlowScheduleReconciler {
 			}
 
 			$flow['expected_recurrence'] = $expected;
+			$flow['force_reconcile']     = $has_drift;
 			$eligible[]                  = $flow;
 		}
 
@@ -104,10 +112,11 @@ class FlowScheduleReconciler {
 			if ( isset( $coverage['blocked'][ $flow_id ] ) ) {
 				$flow['blocked_reason'] = $coverage['blocked'][ $flow_id ];
 				$blocked[]              = $flow;
-			} elseif ( ! isset( $coverage['covered'][ $flow_id ] ) ) {
+			} elseif ( ! isset( $coverage['covered'][ $flow_id ] ) || ! empty( $flow['force_reconcile'] ) ) {
 				$missing[] = $flow;
 			}
 		}
+		$missing = array_merge( $missing, $drift_cleanup );
 
 		$missing_count = count( $missing );
 		$window_hours  = $spread_hours;
@@ -149,12 +158,16 @@ class FlowScheduleReconciler {
 					$options['cron_expression'] = $scheduling['cron_expression'];
 				}
 
-				$result = RecurringScheduler::ensureSchedule(
-					FlowScheduling::FLOW_HOOK,
-					array( $flow_id ),
-					(string) $scheduling['interval'],
-					$options
-				);
+				if ( ! empty( $flow['force_reconcile'] ) ) {
+					$result = FlowScheduling::handle_scheduling_update( $flow_id, $scheduling, true );
+				} else {
+					$result = RecurringScheduler::ensureSchedule(
+						FlowScheduling::FLOW_HOOK,
+						array( $flow_id ),
+						(string) $scheduling['interval'],
+						$options
+					);
+				}
 
 				if ( is_wp_error( $result ) ) {
 					++$failed;
@@ -173,7 +186,7 @@ class FlowScheduleReconciler {
 			'success'                   => 0 === $failed && empty( $blocked ),
 			'transient'                 => $failed > 0 || ! empty( $blocked ),
 			'applied'                   => $apply,
-			'total'                     => count( $eligible ) + count( $invalid ) + $excluded_count,
+			'total'                     => count( $eligible ) + count( $invalid ) + count( $drift_cleanup ) + $excluded_count,
 			'eligible'                  => count( $eligible ),
 			'covered'                   => count( $coverage['covered'] ),
 			'missing'                   => $missing_count,

--- a/inc/Api/Flows/FlowScheduleReconciler.php
+++ b/inc/Api/Flows/FlowScheduleReconciler.php
@@ -150,7 +150,10 @@ class FlowScheduleReconciler {
 					return $this->failure( 'Flow schedule reconciliation lost its apply lock.', true, 'flow_schedule_reconciliation_lock_lost' );
 				}
 
-				$options = array( 'stagger_seed' => $flow_id );
+				$options = array(
+					'stagger_seed'              => $flow_id,
+					'generation_argument_index' => FlowScheduling::GENERATION_ARGUMENT_INDEX,
+				);
 				if ( null !== $window_hours ) {
 					$options['distribution_window_seconds'] = $window_hours * HOUR_IN_SECONDS;
 				}
@@ -378,7 +381,7 @@ class FlowScheduleReconciler {
 		$coverage = array();
 		foreach ( $rows as $row ) {
 			$args    = $row['action_args'] ?? $this->decodeActionArgs( $row );
-			$flow_id = is_array( $args ) && 1 === count( $args ) ? (int) reset( $args ) : 0;
+			$flow_id = is_array( $args ) && isset( $args[0] ) ? (int) $args[0] : 0;
 			if ( $flow_id <= 0 || ! array_key_exists( $flow_id, $expected ) ) {
 				continue;
 			}
@@ -390,6 +393,15 @@ class FlowScheduleReconciler {
 				);
 			}
 			++$coverage[ $flow_id ]['total'];
+			if ( isset( $args[ FlowScheduling::GENERATION_ARGUMENT_INDEX ] )
+				&& ! RecurringScheduler::isActionGenerationCurrent(
+					FlowScheduling::FLOW_HOOK,
+					array( $flow_id ),
+					RecurringScheduler::GROUP,
+					$args[ FlowScheduling::GENERATION_ARGUMENT_INDEX ]
+				) ) {
+				continue;
+			}
 
 			if ( 'in-progress' === ( $row['status'] ?? '' ) ) {
 				++$coverage[ $flow_id ]['in_progress'];

--- a/inc/Api/Flows/FlowScheduling.php
+++ b/inc/Api/Flows/FlowScheduling.php
@@ -174,14 +174,17 @@ class FlowScheduling {
 					);
 				}
 				if ( is_wp_error( $schedule_result ) ) {
+					$error_metadata                = RecurringScheduler::errorMetadata( $schedule_result );
+					$error_metadata['http_status'] = $error_metadata['status'];
+					unset( $error_metadata['status'] );
 					$updates = array(
 						self::RECONCILIATION_KEY => array_merge(
+							$error_metadata,
 							array(
 								'status'     => 'drift',
 								'token'      => $operation_token,
 								'updated_at' => time(),
-							),
-							RecurringScheduler::errorMetadata( $schedule_result )
+							)
 						),
 					);
 					$remove  = array();

--- a/inc/Api/Flows/FlowScheduling.php
+++ b/inc/Api/Flows/FlowScheduling.php
@@ -17,6 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class FlowScheduling {
+	private const RECONCILIATION_KEY = 'schedule_reconciliation';
 
 	/**
 	 * Action Scheduler hook fired when a flow is due to run.
@@ -124,7 +125,15 @@ class FlowScheduling {
 			}
 		}
 
-		// Delegate AS scheduling to the primitive.
+		$desired             = $scheduling_config;
+		$desired['interval'] = $interval ?? 'manual';
+		foreach ( array( 'interval_seconds', 'first_run', 'scheduled_time', 'action_id' ) as $derived_key ) {
+			unset( $desired[ $derived_key ] );
+		}
+
+		$effective_interval = false === ( $desired['enabled'] ?? true ) ? 'manual' : $interval;
+		$operation_token    = wp_generate_uuid4();
+
 		$options = array(
 			'stagger_seed'     => (int) $flow_id,
 			'force_reschedule' => $force,
@@ -136,57 +145,100 @@ class FlowScheduling {
 			$options['cron_expression'] = $cron_expression;
 		}
 
-		$result = RecurringScheduler::ensureSchedule(
+		$result = RecurringScheduler::commitDesiredSchedule(
 			self::FLOW_HOOK,
 			array( (int) $flow_id ),
-			$interval,
+			$effective_interval,
 			$options,
-			true
+			true,
+			static function () use ( $db_flows, $flow_id, $desired, $operation_token ): bool {
+				$pending                             = $desired;
+				$pending[ self::RECONCILIATION_KEY ] = array(
+					'status'     => 'pending',
+					'token'      => $operation_token,
+					'updated_at' => time(),
+				);
+				return $db_flows->update_flow_scheduling( (int) $flow_id, $pending );
+			},
+			static function ( $schedule_result ) use ( $db_flows, $flow_id, $operation_token ): bool|\WP_Error {
+				$stored = $db_flows->get_flow_scheduling( (int) $flow_id );
+				if ( ! is_array( $stored ) || ( $stored[ self::RECONCILIATION_KEY ]['token'] ?? '' ) !== $operation_token ) {
+					return new \WP_Error(
+						'schedule_desired_state_superseded',
+						'Desired schedule state changed before reconciliation completed.',
+						array(
+							'status'         => 409,
+							'retryable'      => true,
+							'retry_after_ms' => 250,
+						)
+					);
+				}
+				if ( is_wp_error( $schedule_result ) ) {
+					$updates = array(
+						self::RECONCILIATION_KEY => array_merge(
+							array(
+								'status'     => 'drift',
+								'token'      => $operation_token,
+								'updated_at' => time(),
+							),
+							RecurringScheduler::errorMetadata( $schedule_result )
+						),
+					);
+					$remove  = array();
+				} else {
+					$updates = self::scheduleMetadataUpdates( $stored, $schedule_result );
+					$remove  = array( self::RECONCILIATION_KEY );
+				}
+
+				if ( ! $db_flows->update_flow_scheduling_metadata( (int) $flow_id, $updates, $remove ) ) {
+					return new \WP_Error(
+						'schedule_reconciliation_record_failed',
+						'Desired schedule was committed but reconciliation status could not be recorded.',
+						array(
+							'status'         => 503,
+							'retryable'      => true,
+							'retry_after_ms' => 250,
+						)
+					);
+				}
+
+				return true;
+			}
 		);
 
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
 
-		// Persist to flows table based on what was actually scheduled.
-		$storage = array( 'interval' => $result['interval'] );
-		switch ( $result['interval'] ) {
-			case 'manual':
-				$db_flows->update_flow_scheduling( $flow_id, $storage );
-				break;
-
-			case 'one_time':
-				$storage['timestamp']      = $result['timestamp'];
-				$storage['scheduled_time'] = $result['scheduled_time'];
-				$db_flows->update_flow_scheduling( $flow_id, $storage );
-				break;
-
-			case 'cron':
-				$storage['cron_expression'] = $result['cron_expression'];
-				$storage['first_run']       = $result['first_run'];
-				$db_flows->update_flow_scheduling( $flow_id, $storage );
-
-				do_action(
-					'datamachine_log',
-					'info',
-					'Flow scheduled with cron expression',
-					array(
-						'flow_id'         => $flow_id,
-						'cron_expression' => $result['cron_expression'],
-						'next_run'        => $result['first_run'],
-						'action_id'       => $result['action_id'] ?? null,
-					)
-				);
-				break;
-
-			default:
-				// Recurring by interval key.
-				$storage['interval_seconds'] = $result['interval_seconds'];
-				$storage['first_run']        = $result['first_run'];
-				$db_flows->update_flow_scheduling( $flow_id, $storage );
-				break;
+		if ( 'cron' === $result['interval'] ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				'Flow scheduled with cron expression',
+				array(
+					'flow_id'         => $flow_id,
+					'cron_expression' => $result['cron_expression'],
+					'next_run'        => $result['first_run'],
+					'action_id'       => $result['action_id'] ?? null,
+				)
+			);
 		}
 
 		return true;
+	}
+
+	private static function scheduleMetadataUpdates( array $desired, array $result ): array {
+		$updates = array();
+		if ( false !== ( $desired['enabled'] ?? true ) ) {
+			$updates['interval'] = $result['interval'];
+		}
+
+		foreach ( array( 'timestamp', 'scheduled_time', 'cron_expression', 'interval_seconds', 'first_run', 'action_id' ) as $key ) {
+			if ( array_key_exists( $key, $result ) ) {
+				$updates[ $key ] = $result[ $key ];
+			}
+		}
+
+		return $updates;
 	}
 }

--- a/inc/Api/Flows/FlowScheduling.php
+++ b/inc/Api/Flows/FlowScheduling.php
@@ -46,10 +46,10 @@ class FlowScheduling {
 			return false;
 		}
 
-		// Both manual — no change.
+		// Both manual — only unchanged when no stale schedule still owns coverage.
 		if ( ( 'manual' === $current_interval || null === $current_interval )
 			&& ( 'manual' === $interval || null === $interval ) ) {
-			return true;
+			return $flow_id <= 0 || ! RecurringScheduler::hasCoverage( self::FLOW_HOOK, array( $flow_id ) );
 		}
 
 		// Config matches — but verify the AS action actually exists.
@@ -126,7 +126,8 @@ class FlowScheduling {
 
 		// Delegate AS scheduling to the primitive.
 		$options = array(
-			'stagger_seed' => (int) $flow_id,
+			'stagger_seed'     => (int) $flow_id,
+			'force_reschedule' => $force,
 		);
 		if ( 'one_time' === $interval ) {
 			$options['timestamp'] = $scheduling_config['timestamp'] ?? null;

--- a/inc/Api/Flows/FlowScheduling.php
+++ b/inc/Api/Flows/FlowScheduling.php
@@ -17,7 +17,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class FlowScheduling {
-	private const RECONCILIATION_KEY = 'schedule_reconciliation';
+	private const RECONCILIATION_KEY       = 'schedule_reconciliation';
+	public const GENERATION_ARGUMENT_INDEX = 2;
 
 	/**
 	 * Action Scheduler hook fired when a flow is due to run.
@@ -50,7 +51,7 @@ class FlowScheduling {
 		// Both manual — only unchanged when no stale schedule still owns coverage.
 		if ( ( 'manual' === $current_interval || null === $current_interval )
 			&& ( 'manual' === $interval || null === $interval ) ) {
-			return $flow_id <= 0 || ! RecurringScheduler::hasCoverage( self::FLOW_HOOK, array( $flow_id ) );
+			return $flow_id <= 0 || ! RecurringScheduler::hasLogicalCoverage( self::FLOW_HOOK, array( $flow_id ) );
 		}
 
 		// Config matches — but verify the AS action actually exists.
@@ -76,7 +77,7 @@ class FlowScheduling {
 		}
 
 		// Verify AS action is actually pending.
-		if ( $flow_id > 0 && ! RecurringScheduler::hasCoverage( self::FLOW_HOOK, array( $flow_id ) ) ) {
+		if ( $flow_id > 0 && ! RecurringScheduler::hasLogicalCoverage( self::FLOW_HOOK, array( $flow_id ) ) ) {
 			return false;
 		}
 
@@ -94,7 +95,7 @@ class FlowScheduling {
 	 * @param bool  $force             Skip the unchanged guard.
 	 * @return bool|\WP_Error True on success, WP_Error on failure
 	 */
-	public static function handle_scheduling_update( $flow_id, $scheduling_config, bool $force = false ) {
+	public static function handle_scheduling_update( $flow_id, $scheduling_config, bool $force = false, bool $legacy_adoption = false ) {
 		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
 
 		$flow = $db_flows->get_flow( $flow_id );
@@ -106,8 +107,12 @@ class FlowScheduling {
 			);
 		}
 
-		$interval        = $scheduling_config['interval'] ?? null;
-		$cron_expression = $scheduling_config['cron_expression'] ?? null;
+		$interval           = $scheduling_config['interval'] ?? null;
+		$cron_expression    = $scheduling_config['cron_expression'] ?? null;
+		$current_scheduling = $flow['scheduling_config'] ?? array();
+		if ( is_string( $current_scheduling ) ) {
+			$current_scheduling = json_decode( $current_scheduling, true ) ?? array();
+		}
 
 		// Resolve aliases before any comparison.
 		if ( null !== $interval ) {
@@ -116,10 +121,6 @@ class FlowScheduling {
 
 		// Skip re-scheduling if unchanged (prevents timer resets on flow updates).
 		if ( ! $force ) {
-			$current_scheduling = $flow['scheduling_config'] ?? array();
-			if ( is_string( $current_scheduling ) ) {
-				$current_scheduling = json_decode( $current_scheduling, true ) ?? array();
-			}
 			if ( self::scheduling_unchanged( $current_scheduling, $interval, $cron_expression, $scheduling_config, (int) $flow_id ) ) {
 				return true;
 			}
@@ -135,8 +136,10 @@ class FlowScheduling {
 		$operation_token    = wp_generate_uuid4();
 
 		$options = array(
-			'stagger_seed'     => (int) $flow_id,
-			'force_reschedule' => $force,
+			'stagger_seed'              => (int) $flow_id,
+			'force_reschedule'          => $force,
+			'generation_argument_index' => self::GENERATION_ARGUMENT_INDEX,
+			'legacy_adoption'           => $legacy_adoption,
 		);
 		if ( 'one_time' === $interval ) {
 			$options['timestamp'] = $scheduling_config['timestamp'] ?? null;
@@ -151,7 +154,14 @@ class FlowScheduling {
 			$effective_interval,
 			$options,
 			true,
-			static function () use ( $db_flows, $flow_id, $desired, $operation_token ): bool {
+			static function () use ( $db_flows, $flow_id, $desired, $operation_token, $legacy_adoption, $scheduling_config ) {
+				if ( $legacy_adoption && $db_flows->get_flow_scheduling( (int) $flow_id ) !== $scheduling_config ) {
+					return new \WP_Error(
+						'legacy_schedule_generation_conflict',
+						'Legacy action adoption is blocked by newer desired schedule state.',
+						array( 'status' => 409 )
+					);
+				}
 				$pending                             = $desired;
 				$pending[ self::RECONCILIATION_KEY ] = array(
 					'status'     => 'pending',
@@ -228,6 +238,32 @@ class FlowScheduling {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Transition one legacy Action Scheduler execution to generated identity.
+	 *
+	 * The legacy action may run once only when no generated owner exists. Forced
+	 * reconciliation installs the generated successor, and native repeat cleanup
+	 * cancels the legacy successor exactly.
+	 *
+	 * @return bool|\WP_Error
+	 */
+	public static function adopt_legacy_action( int $flow_id ) {
+		$flows      = new \DataMachine\Core\Database\Flows\Flows();
+		$scheduling = $flows->get_flow_scheduling( $flow_id );
+		if ( ! is_array( $scheduling ) ) {
+			return new \WP_Error( 'flow_not_found', "Flow {$flow_id} not found", array( 'status' => 404 ) );
+		}
+		if ( ! empty( $scheduling[ self::RECONCILIATION_KEY ] ) ) {
+			return new \WP_Error(
+				'legacy_schedule_generation_conflict',
+				'Legacy action adoption is blocked by a newer desired schedule generation.',
+				array( 'status' => 409 )
+			);
+		}
+
+		return self::handle_scheduling_update( $flow_id, $scheduling, true, true );
 	}
 
 	private static function scheduleMetadataUpdates( array $desired, array $result ): array {

--- a/inc/Core/Admin/FlowFormatter.php
+++ b/inc/Core/Admin/FlowFormatter.php
@@ -162,7 +162,11 @@ class FlowFormatter {
 			return null;
 		}
 
-		$next_timestamp = as_next_scheduled_action( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
+		$next_timestamp = \DataMachine\Engine\Tasks\RecurringScheduler::nextLogicalScheduledAction(
+			'datamachine_run_flow_now',
+			array( $flow_id ),
+			'data-machine'
+		);
 
 		return $next_timestamp ? wp_date( 'Y-m-d H:i:s', $next_timestamp, new \DateTimeZone( 'UTC' ) ) : null;
 	}

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -996,6 +996,61 @@ class Flows extends BaseRepository {
 		return true;
 	}
 
+	/**
+	 * Patch non-authoritative scheduling metadata without overwriting desired state.
+	 *
+	 * @param int   $flow_id Flow ID.
+	 * @param array $set     Metadata keys to set.
+	 * @param array $remove  Metadata keys to remove.
+	 */
+	public function update_flow_scheduling_metadata( int $flow_id, array $set = array(), array $remove = array() ): bool {
+		for ( $attempt = 0; $attempt < 3; ++$attempt ) {
+			$query = $this->wpdb->prepare( 'SELECT scheduling_config FROM %i WHERE flow_id = %d', $this->table_name, $flow_id );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Prepared immediately above.
+			$current_json = $this->wpdb->get_var( $query );
+			if ( ! is_string( $current_json ) ) {
+				return false;
+			}
+
+			$current = json_decode( $current_json, true );
+			$current = is_array( $current ) ? $current : array();
+			foreach ( $set as $key => $value ) {
+				$current[ $key ] = $value;
+			}
+			foreach ( $remove as $key ) {
+				unset( $current[ $key ] );
+			}
+
+			$replacement = wp_json_encode( $current );
+			if ( false === $replacement ) {
+				return false;
+			}
+			if ( $replacement === $current_json ) {
+				return true;
+			}
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$updated = $this->wpdb->update(
+				$this->table_name,
+				array( 'scheduling_config' => $replacement ),
+				array(
+					'flow_id'           => $flow_id,
+					'scheduling_config' => $current_json,
+				),
+				array( '%s' ),
+				array( '%d', '%s' )
+			);
+			if ( 1 === $updated ) {
+				return true;
+			}
+			if ( false === $updated ) {
+				return false;
+			}
+		}
+
+		return false;
+	}
+
 	public function get_flow_scheduling( int $flow_id ): ?array {
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$scheduling_config_json = $this->wpdb->get_var( $this->wpdb->prepare( 'SELECT scheduling_config FROM %i WHERE flow_id = %d', $this->table_name, $flow_id ) );

--- a/inc/Core/OptionLeaseStore.php
+++ b/inc/Core/OptionLeaseStore.php
@@ -182,6 +182,60 @@ class OptionLeaseStore {
 	}
 
 	/**
+	 * Atomically extend a lease only while the caller still owns its token.
+	 *
+	 * @param string   $option_name Option name.
+	 * @param string   $token       Current owner token.
+	 * @param int      $ttl         Extension in seconds.
+	 * @param int|null $now         Current timestamp.
+	 */
+	public static function refresh( string $option_name, string $token, int $ttl, ?int $now = null ): bool {
+		if ( '' === $token ) {
+			return false;
+		}
+
+		$current = get_option( $option_name, array() );
+		if ( ! is_array( $current ) || ! hash_equals( (string) ( $current['token'] ?? '' ), $token ) ) {
+			return false;
+		}
+
+		$replacement               = $current;
+		$replacement['expires_at'] = max(
+			(int) ( $current['expires_at'] ?? 0 ) + 1,
+			( $now ?? time() ) + max( 1, $ttl )
+		);
+
+		global $wpdb;
+		if ( isset( $wpdb->options ) && method_exists( $wpdb, 'query' ) && method_exists( $wpdb, 'prepare' ) ) {
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Conditional update is the fencing primitive.
+			$updated = $wpdb->query(
+				$wpdb->prepare(
+					'UPDATE %i SET option_value = %s WHERE option_name = %s AND option_value = %s',
+					$wpdb->options,
+					maybe_serialize( $replacement ),
+					$option_name,
+					maybe_serialize( $current )
+				)
+			);
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+			if ( 1 !== $updated ) {
+				return false;
+			}
+
+			wp_cache_delete( $option_name, 'options' );
+			return true;
+		}
+
+		// Lightweight test runtimes may not provide wpdb; retain token verification.
+		if ( ! update_option( $option_name, $replacement, false ) ) {
+			return false;
+		}
+		$stored = get_option( $option_name, array() );
+		return is_array( $stored ) && hash_equals( $token, (string) ( $stored['token'] ?? '' ) );
+	}
+
+	/**
 	 * Delete a stale lease when present.
 	 */
 	public static function cleanupStale(

--- a/inc/Core/OptionLeaseStore.php
+++ b/inc/Core/OptionLeaseStore.php
@@ -190,6 +190,15 @@ class OptionLeaseStore {
 	 * @param int|null $now         Current timestamp.
 	 */
 	public static function refresh( string $option_name, string $token, int $ttl, ?int $now = null ): bool {
+		return false !== self::refreshOwned( $option_name, $token, $ttl, $now );
+	}
+
+	/**
+	 * Atomically extend and return the exact refreshed owner payload.
+	 *
+	 * @return array<string,mixed>|false Refreshed payload, or false after ownership loss.
+	 */
+	public static function refreshOwned( string $option_name, string $token, int $ttl, ?int $now = null ) {
 		if ( '' === $token ) {
 			return false;
 		}
@@ -198,11 +207,15 @@ class OptionLeaseStore {
 		if ( ! is_array( $current ) || ! hash_equals( (string) ( $current['token'] ?? '' ), $token ) ) {
 			return false;
 		}
+		$now = $now ?? time();
+		if ( (int) ( $current['expires_at'] ?? 0 ) <= $now ) {
+			return false;
+		}
 
 		$replacement               = $current;
 		$replacement['expires_at'] = max(
 			(int) ( $current['expires_at'] ?? 0 ) + 1,
-			( $now ?? time() ) + max( 1, $ttl )
+			$now + max( 1, $ttl )
 		);
 
 		global $wpdb;
@@ -224,7 +237,7 @@ class OptionLeaseStore {
 			}
 
 			wp_cache_delete( $option_name, 'options' );
-			return true;
+			return $replacement;
 		}
 
 		// Lightweight test runtimes may not provide wpdb; retain token verification.
@@ -232,7 +245,65 @@ class OptionLeaseStore {
 			return false;
 		}
 		$stored = get_option( $option_name, array() );
-		return is_array( $stored ) && hash_equals( $token, (string) ( $stored['token'] ?? '' ) );
+		return is_array( $stored ) && hash_equals( $token, (string) ( $stored['token'] ?? '' ) )
+			? $replacement
+			: false;
+	}
+
+	/**
+	 * Compare-and-swap an option only while an exact, unexpired lease is stored.
+	 *
+	 * @param string              $option_name  Target option.
+	 * @param mixed               $expected     Exact target value expected.
+	 * @param mixed               $replacement  New target value.
+	 * @param string              $lease_name   Lease option.
+	 * @param array<string,mixed> $lease_payload Exact refreshed lease payload.
+	 * @param int|null            $now           Current timestamp.
+	 */
+	public static function compareAndSwapWhileOwned(
+		string $option_name,
+		$expected,
+		$replacement,
+		string $lease_name,
+		array $lease_payload,
+		?int $now = null
+	): bool {
+		$now = $now ?? time();
+		if ( (int) ( $lease_payload['expires_at'] ?? 0 ) <= $now ) {
+			return false;
+		}
+
+		global $wpdb;
+		if ( isset( $wpdb->options ) && method_exists( $wpdb, 'query' ) && method_exists( $wpdb, 'prepare' ) ) {
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Atomic target CAS is fenced by the exact lease row.
+			$updated = $wpdb->query(
+				$wpdb->prepare(
+					'UPDATE %i SET option_value = %s WHERE option_name = %s AND option_value = %s AND EXISTS (SELECT 1 FROM %i WHERE option_name = %s AND option_value = %s)',
+					$wpdb->options,
+					maybe_serialize( $replacement ),
+					$option_name,
+					maybe_serialize( $expected ),
+					$wpdb->options,
+					$lease_name,
+					maybe_serialize( $lease_payload )
+				)
+			);
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+			if ( 1 !== $updated ) {
+				return false;
+			}
+
+			wp_cache_delete( $option_name, 'options' );
+			return true;
+		}
+
+		// Lightweight test fallback preserves both exact comparisons.
+		if ( get_option( $lease_name, null ) !== $lease_payload || get_option( $option_name, null ) !== $expected ) {
+			return false;
+		}
+		update_option( $option_name, $replacement, false );
+		return get_option( $lease_name, null ) === $lease_payload && get_option( $option_name, null ) === $replacement;
 	}
 
 	/**

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -123,7 +123,11 @@ function datamachine_register_execution_engine() {
 			// If flow was deleted without cleaning up scheduled actions,
 			// cancel the orphaned actions to prevent recurring errors.
 			if ( ! datamachine_flow_exists( $flow_id ) ) {
-				as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
+				\DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
+					'datamachine_run_flow_now',
+					array( $flow_id ),
+					'manual'
+				);
 				do_action(
 					'datamachine_log',
 					'warning',

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -116,8 +116,31 @@ function datamachine_register_execution_engine() {
 	 */
 	add_action(
 		'datamachine_run_flow_now',
-		function ( $flow_id, $job_id = null ) {
+		function ( $flow_id, $job_id = null, $schedule_generation = null ) {
 			$flow_id = (int) $flow_id;
+			if ( null !== $schedule_generation
+				&& ! \DataMachine\Engine\Tasks\RecurringScheduler::isActionGenerationCurrent(
+					\DataMachine\Api\Flows\FlowScheduling::FLOW_HOOK,
+					array( $flow_id ),
+					\DataMachine\Engine\Tasks\RecurringScheduler::GROUP,
+					$schedule_generation
+				) ) {
+				do_action( 'datamachine_log', 'warning', 'Stale schedule generation skipped', array( 'flow_id' => $flow_id ) );
+				return;
+			}
+
+			if ( null === $schedule_generation && \DataMachine\Engine\Tasks\RecurringScheduler::isExecutingRecurringAction() ) {
+				$adopted = \DataMachine\Api\Flows\FlowScheduling::adopt_legacy_action( $flow_id );
+				if ( is_wp_error( $adopted ) ) {
+					do_action(
+						'datamachine_log',
+						'warning',
+						'Legacy scheduled action skipped during bounded generation adoption',
+						array_merge( array( 'flow_id' => $flow_id ), \DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $adopted ) )
+					);
+					return;
+				}
+			}
 
 			// Defensive: Check if flow exists before executing.
 			// If flow was deleted without cleaning up scheduled actions,
@@ -126,7 +149,8 @@ function datamachine_register_execution_engine() {
 				$schedule_result = \DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
 					'datamachine_run_flow_now',
 					array( $flow_id ),
-					'manual'
+					'manual',
+					array( 'generation_argument_index' => \DataMachine\Api\Flows\FlowScheduling::GENERATION_ARGUMENT_INDEX )
 				);
 				if ( is_wp_error( $schedule_result ) ) {
 					do_action(
@@ -161,7 +185,7 @@ function datamachine_register_execution_engine() {
 			}
 		},
 		10,
-		2
+		3
 	);
 
 	/**

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -123,11 +123,23 @@ function datamachine_register_execution_engine() {
 			// If flow was deleted without cleaning up scheduled actions,
 			// cancel the orphaned actions to prevent recurring errors.
 			if ( ! datamachine_flow_exists( $flow_id ) ) {
-				\DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
+				$schedule_result = \DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
 					'datamachine_run_flow_now',
 					array( $flow_id ),
 					'manual'
 				);
+				if ( is_wp_error( $schedule_result ) ) {
+					do_action(
+						'datamachine_log',
+						'error',
+						'Orphaned schedule cleanup deferred after ownership failure',
+						array_merge(
+							array( 'flow_id' => $flow_id ),
+							\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $schedule_result )
+						)
+					);
+					return;
+				}
 				do_action(
 					'datamachine_log',
 					'warning',

--- a/inc/Engine/Actions/Handlers/JobCompleteHandler.php
+++ b/inc/Engine/Actions/Handlers/JobCompleteHandler.php
@@ -50,15 +50,28 @@ class JobCompleteHandler {
 			return;
 		}
 
-		$scheduling = is_string( $flow->scheduling_config )
-			? json_decode( $flow->scheduling_config, true )
-			: (array) $flow->scheduling_config;
+		$stored_scheduling = $flow['scheduling_config'] ?? array();
+		$scheduling        = is_string( $stored_scheduling )
+			? json_decode( $stored_scheduling, true )
+			: (array) $stored_scheduling;
 
 		if ( ( $scheduling['interval'] ?? '' ) === 'one_time' ) {
-			$db_flows->update_flow_scheduling(
-				$job->flow_id,
-				array( 'interval' => 'manual' )
+			$result = \DataMachine\Api\Flows\FlowScheduling::handle_scheduling_update(
+				(int) $job->flow_id,
+				array( 'interval' => 'manual' ),
+				true
 			);
+			if ( is_wp_error( $result ) ) {
+				do_action(
+					'datamachine_log',
+					'error',
+					'One-time flow completion left schedule reconciliation drift',
+					array_merge(
+						array( 'flow_id' => (int) $job->flow_id ),
+						\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $result )
+					)
+				);
+			}
 		}
 	}
 }

--- a/inc/Engine/Tasks/GenerationFencedAction.php
+++ b/inc/Engine/Tasks/GenerationFencedAction.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Action Scheduler action fenced by a persisted schedule generation.
+ *
+ * @package DataMachine\Engine\Tasks
+ */
+
+namespace DataMachine\Engine\Tasks;
+
+defined( 'ABSPATH' ) || exit;
+
+class GenerationFencedAction extends \ActionScheduler_Action {
+
+	private string $generation_option;
+	private string $expected_generation;
+
+	/**
+	 * @param string                    $hook                Action hook.
+	 * @param array                     $args                Action arguments.
+	 * @param \ActionScheduler_Schedule $schedule            Original schedule.
+	 * @param string                    $group               Action group.
+	 * @param string                    $generation_option   Persisted generation option.
+	 * @param string                    $expected_generation Generation captured when fetched.
+	 */
+	public function __construct(
+		string $hook,
+		array $args,
+		\ActionScheduler_Schedule $schedule,
+		string $group,
+		string $generation_option,
+		string $expected_generation
+	) {
+		parent::__construct( $hook, $args, $schedule, $group );
+		$this->generation_option   = $generation_option;
+		$this->expected_generation = $expected_generation;
+	}
+
+	/**
+	 * Prevent Action Scheduler from repeating a superseded fetched recurrence.
+	 *
+	 * Action Scheduler fetches the action before invoking its callback and asks
+	 * this object for its schedule again afterward. A transition that advances
+	 * the generation during callback execution therefore turns the old fetched
+	 * schedule into a non-recurring canceled schedule before AS can clone it.
+	 *
+	 * @return \ActionScheduler_Schedule
+	 */
+	public function get_schedule(): \ActionScheduler_Schedule {
+		$schedule = parent::get_schedule();
+		$current  = get_option( $this->generation_option, '' );
+
+		if ( is_string( $current ) && hash_equals( $this->expected_generation, $current ) ) {
+			return $schedule;
+		}
+
+		return new \ActionScheduler_CanceledSchedule( $schedule->get_date() );
+	}
+}

--- a/inc/Engine/Tasks/GenerationFencedAction.php
+++ b/inc/Engine/Tasks/GenerationFencedAction.php
@@ -55,4 +55,12 @@ class GenerationFencedAction extends \ActionScheduler_Action {
 
 		return new \ActionScheduler_CanceledSchedule( $schedule->get_date() );
 	}
+
+	public function getGenerationOption(): string {
+		return $this->generation_option;
+	}
+
+	public function getExpectedGeneration(): string {
+		return $this->expected_generation;
+	}
 }

--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -358,7 +358,11 @@ class RecurringScheduler {
 	 * @return array{option_name:string,token:string}|\WP_Error
 	 */
 	private static function acquireScheduleLock( string $hook, array $args, string $group ) {
-		$option_name = self::SCHEDULE_LOCK_PREFIX . md5( serialize( array( $hook, $args, $group ) ) );
+		$signature = wp_json_encode( array( $hook, $args, $group ) );
+		if ( false === $signature ) {
+			return self::error( 'invalid_schedule_signature', 'Schedule arguments must be JSON-serializable.' );
+		}
+		$option_name = self::SCHEDULE_LOCK_PREFIX . md5( $signature );
 
 		for ( $attempt = 0; $attempt < self::SCHEDULE_LOCK_RETRY_ATTEMPTS; ++$attempt ) {
 			$now     = time();

--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -52,7 +52,18 @@ class RecurringScheduler {
 	 */
 	public const MAX_DISTRIBUTION_WINDOW_SECONDS = 86400;
 
-	private const SCHEDULE_LOCK_PREFIX         = 'datamachine_schedule_lock_';
+	private const SCHEDULE_LOCK_PREFIX = 'datamachine_schedule_lock_';
+	/**
+	 * Durable, non-autoloaded tombstones keyed by schedule identity.
+	 *
+	 * They are intentionally retained after manual/delete transitions: a fetched
+	 * running recurrence can repeat after its callback, so deleting its generation
+	 * would remove the only resurrection fence. Retention is therefore unbounded in
+	 * time, while storage is bounded to one non-autoloaded scalar per distinct
+	 * schedule signature rather than one row per execution. Do not bulk-delete these
+	 * options without first proving no pending, running, or fetched action for the
+	 * signature can repeat.
+	 */
 	private const SCHEDULE_GENERATION_PREFIX   = 'datamachine_schedule_generation_';
 	private const SCHEDULE_LOCK_TTL            = 30;
 	private const SCHEDULE_LOCK_RETRY_ATTEMPTS = 5;
@@ -436,7 +447,7 @@ class RecurringScheduler {
 	 * @param string $hook  Action Scheduler hook.
 	 * @param array  $args  Action arguments.
 	 * @param string $group Action Scheduler group.
-	 * @return array{option_name:string,generation_option:string,token:string}|\WP_Error
+	 * @return array{option_name:string,generation_option:string,token:string,lease_payload:array<string,mixed>}|\WP_Error
 	 */
 	private static function acquireScheduleLock( string $hook, array $args, string $group ) {
 		$options = self::scheduleOptionNames( $hook, $args, $group );
@@ -446,10 +457,17 @@ class RecurringScheduler {
 
 		$generation = get_option( $options['generation_option'], false );
 		if ( false === $generation ) {
-			$initial_generation = wp_generate_uuid4();
-			if ( ! add_option( $options['generation_option'], $initial_generation, '', false ) ) {
+			for ( $attempt = 0; $attempt < self::SCHEDULE_LOCK_RETRY_ATTEMPTS && false === $generation; ++$attempt ) {
+				$initial_generation = wp_generate_uuid4();
+				if ( add_option( $options['generation_option'], $initial_generation, '', false ) ) {
+					$generation = $initial_generation;
+					break;
+				}
 				$generation = get_option( $options['generation_option'], false );
 			}
+		}
+		if ( ! is_string( $generation ) || '' === $generation ) {
+			return self::error( 'schedule_generation_unavailable', 'Unable to initialize schedule generation.', array( 'status' => 503 ) );
 		}
 		$option_name = $options['lock_option'];
 
@@ -468,6 +486,7 @@ class RecurringScheduler {
 					'option_name'       => $option_name,
 					'generation_option' => $options['generation_option'],
 					'token'             => $token,
+					'lease_payload'     => $payload,
 				);
 			}
 
@@ -512,15 +531,26 @@ class RecurringScheduler {
 	 * @return array|\WP_Error Updated lease or ownership error.
 	 */
 	private static function beginScheduleMutation( array $lock ) {
-		if ( ! self::refreshScheduleLock( $lock ) ) {
+		$lease_payload = self::refreshScheduleLock( $lock );
+		if ( false === $lease_payload ) {
 			return self::lockLostError();
 		}
 
-		$generation = wp_generate_uuid4();
-		update_option( $lock['generation_option'], $generation, false );
-		$lock['generation'] = $generation;
+		$current_generation = get_option( $lock['generation_option'], '' );
+		$generation         = wp_generate_uuid4();
+		if ( ! OptionLeaseStore::compareAndSwapWhileOwned(
+			$lock['generation_option'],
+			$current_generation,
+			$generation,
+			$lock['option_name'],
+			$lease_payload
+		) ) {
+			return self::lockLostError();
+		}
+		$lock['generation']    = $generation;
+		$lock['lease_payload'] = $lease_payload;
 
-		return self::refreshScheduleLock( $lock ) && self::isMutationGenerationCurrent( $lock )
+		return false !== self::refreshScheduleLock( $lock ) && self::isMutationGenerationCurrent( $lock )
 			? $lock
 			: self::lockLostError();
 	}
@@ -529,11 +559,14 @@ class RecurringScheduler {
 	 * Refresh and verify ownership immediately before a destructive mutation.
 	 */
 	private static function assertMutationOwner( array $lock ): bool {
-		return self::refreshScheduleLock( $lock ) && self::isMutationGenerationCurrent( $lock );
+		return false !== self::refreshScheduleLock( $lock ) && self::isMutationGenerationCurrent( $lock );
 	}
 
-	private static function refreshScheduleLock( array $lock ): bool {
-		return OptionLeaseStore::refresh( $lock['option_name'], $lock['token'], self::SCHEDULE_LOCK_TTL );
+	/**
+	 * @return array<string,mixed>|false
+	 */
+	private static function refreshScheduleLock( array $lock ) {
+		return OptionLeaseStore::refreshOwned( $lock['option_name'], $lock['token'], self::SCHEDULE_LOCK_TTL );
 	}
 
 	private static function isMutationGenerationCurrent( array $lock ): bool {
@@ -562,7 +595,10 @@ class RecurringScheduler {
 		if ( ! self::assertMutationOwner( $lock ) ) {
 			return self::lockLostError();
 		}
-		self::unschedule( $hook, $args, $group );
+		self::rawUnschedule( $hook, $args, $group );
+		if ( ! self::assertMutationOwner( $lock ) ) {
+			return self::lockLostError();
+		}
 		return true;
 	}
 
@@ -573,7 +609,8 @@ class RecurringScheduler {
 		if ( ! self::assertMutationOwner( $lock ) ) {
 			return self::lockLostError();
 		}
-		return as_schedule_single_action( $timestamp, $hook, $args, $group );
+		$action_id = as_schedule_single_action( $timestamp, $hook, $args, $group );
+		return self::assertMutationOwner( $lock ) ? $action_id : self::lockLostError();
 	}
 
 	/**
@@ -583,7 +620,8 @@ class RecurringScheduler {
 		if ( ! self::assertMutationOwner( $lock ) ) {
 			return self::lockLostError();
 		}
-		return as_schedule_recurring_action( $timestamp, $interval, $hook, $args, $group, $unique );
+		$action_id = as_schedule_recurring_action( $timestamp, $interval, $hook, $args, $group, $unique );
+		return self::assertMutationOwner( $lock ) ? $action_id : self::lockLostError();
 	}
 
 	/**
@@ -593,18 +631,26 @@ class RecurringScheduler {
 		if ( ! self::assertMutationOwner( $lock ) ) {
 			return self::lockLostError();
 		}
-		return as_schedule_cron_action( $timestamp, $expression, $hook, $args, $group, $unique );
+		$action_id = as_schedule_cron_action( $timestamp, $expression, $hook, $args, $group, $unique );
+		return self::assertMutationOwner( $lock ) ? $action_id : self::lockLostError();
 	}
 
 	/**
-	 * Unschedule all Action Scheduler actions matching (hook, args, group).
+	 * Preserve the public unschedule API while routing through the fenced path.
 	 *
 	 * @param string $hook  Hook name.
 	 * @param array  $args  Action args (signature).
 	 * @param string $group AS group.
 	 * @return void
 	 */
-	private static function unschedule( string $hook, array $args, string $group = self::GROUP ): void {
+	public static function unschedule( string $hook, array $args, string $group = self::GROUP ): void {
+		self::ensureSchedule( $hook, $args, 'manual', array( 'group' => $group ) );
+	}
+
+	/**
+	 * Unschedule pending actions after ownership has already been fenced.
+	 */
+	private static function rawUnschedule( string $hook, array $args, string $group ): void {
 		if ( function_exists( 'as_unschedule_all_actions' ) ) {
 			as_unschedule_all_actions( $hook, $args, $group );
 		}
@@ -670,6 +716,22 @@ class RecurringScheduler {
 	 */
 	public static function isReady(): bool {
 		return self::isActionSchedulerDataStoreReady();
+	}
+
+	/**
+	 * Normalize scheduler error metadata for ability and cleanup callers.
+	 */
+	public static function errorMetadata( \WP_Error $error ): array {
+		$data = $error->get_error_data();
+		$data = is_array( $data ) ? $data : array();
+
+		return array(
+			'error'          => $error->get_error_message(),
+			'error_code'     => $error->get_error_code(),
+			'status'         => (int) ( $data['status'] ?? 500 ),
+			'retryable'      => (bool) ( $data['retryable'] ?? false ),
+			'retry_after_ms' => (int) ( $data['retry_after_ms'] ?? 0 ),
+		);
 	}
 
 	/**

--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -69,8 +69,6 @@ class RecurringScheduler {
 	 * signature can repeat.
 	 */
 	private const SCHEDULE_GENERATION_PREFIX   = 'datamachine_schedule_generation_';
-	private const GENERATION_ARGUMENT_KEY      = '_datamachine_schedule_generation';
-	private const SIGNATURE_ARGUMENT_COUNT_KEY = '_datamachine_signature_argument_count';
 	private const SCHEDULE_LOCK_TTL            = 30;
 	private const SCHEDULE_LOCK_RETRY_ATTEMPTS = 5;
 	private const SCHEDULE_LOCK_RETRY_DELAY_US = 25000;
@@ -177,7 +175,7 @@ class RecurringScheduler {
 				? max( count( $args ), (int) $options['generation_argument_index'] )
 				: null;
 			if ( ! empty( $options['legacy_adoption'] )
-				&& self::getCoveringAction( $hook, self::scheduleActionArgs( $args, $lock ), (string) ( $options['group'] ?? self::GROUP ) ) ) {
+				&& ScheduleActionIdentity::exactAction( $hook, self::scheduleActionArgs( $args, $lock ), (string) ( $options['group'] ?? self::GROUP ), array( 'pending', 'in-progress' ) ) ) {
 				return self::error(
 					'stale_legacy_schedule_generation',
 					'A generated schedule already owns this flow; the legacy action is stale.',
@@ -506,7 +504,7 @@ class RecurringScheduler {
 		self::$executed_recurrence_generations[ $key ] = array(
 			'generation_option'   => $action->getGenerationOption(),
 			'expected_generation' => $action->getExpectedGeneration(),
-			'legacy'              => null === self::generationFromActionArgs( $action->get_args() ),
+			'legacy'              => null === ScheduleActionIdentity::generationFromArgs( $action->get_args() ),
 		);
 	}
 
@@ -536,7 +534,7 @@ class RecurringScheduler {
 			return;
 		}
 
-		self::cancelExactAction( $action_id );
+		ScheduleActionIdentity::cancelExact( $action_id );
 	}
 
 	/**
@@ -558,13 +556,13 @@ class RecurringScheduler {
 			return $action;
 		}
 
-		$logical_args = self::logicalArgsFromActionArgs( $args );
+		$logical_args = ScheduleActionIdentity::logicalArgs( $args );
 		$options      = self::scheduleOptionNames( $hook, $logical_args, $group );
 		if ( is_wp_error( $options ) ) {
 			return $action;
 		}
 
-		$generation = self::generationFromActionArgs( $args );
+		$generation = ScheduleActionIdentity::generationFromArgs( $args );
 		if ( null === $generation ) {
 			$generation = get_option( $options['generation_option'], false );
 		}
@@ -690,7 +688,7 @@ class RecurringScheduler {
 	 * here; the flow handler performs the bounded legacy transition.
 	 */
 	public static function isActionGenerationCurrent( string $hook, array $args, string $group, $generation_argument ): bool {
-		$generation = self::generationFromArgument( $generation_argument );
+		$generation = ScheduleActionIdentity::generationFromArgument( $generation_argument );
 		if ( null === $generation ) {
 			return false;
 		}
@@ -712,43 +710,7 @@ class RecurringScheduler {
 			return $args;
 		}
 
-		$logical_count = count( $args );
-		$target_count  = (int) $lock['generation_argument_index'];
-		for ( $argument_count = $logical_count; $argument_count < $target_count; ++$argument_count ) {
-			$args[] = null;
-		}
-		$args[] = array(
-			self::GENERATION_ARGUMENT_KEY      => (string) $lock['generation'],
-			self::SIGNATURE_ARGUMENT_COUNT_KEY => $logical_count,
-		);
-
-		return $args;
-	}
-
-	private static function generationFromArgument( $argument ): ?string {
-		if ( ! is_array( $argument ) || empty( $argument[ self::GENERATION_ARGUMENT_KEY ] ) || ! is_string( $argument[ self::GENERATION_ARGUMENT_KEY ] ) ) {
-			return null;
-		}
-
-		return $argument[ self::GENERATION_ARGUMENT_KEY ];
-	}
-
-	private static function generationFromActionArgs( array $args ): ?string {
-		return empty( $args ) ? null : self::generationFromArgument( end( $args ) );
-	}
-
-	private static function logicalArgsFromActionArgs( array $args ): array {
-		if ( empty( $args ) ) {
-			return $args;
-		}
-
-		$marker = end( $args );
-		if ( null === self::generationFromArgument( $marker ) ) {
-			return $args;
-		}
-
-		$count = isset( $marker[ self::SIGNATURE_ARGUMENT_COUNT_KEY ] ) ? (int) $marker[ self::SIGNATURE_ARGUMENT_COUNT_KEY ] : count( $args ) - 1;
-		return array_slice( $args, 0, max( 0, $count ) );
+		return ScheduleActionIdentity::withGeneration( $args, (string) $lock['generation'], (int) $lock['generation_argument_index'] );
 	}
 
 	private static function scheduleSignatureKey( string $hook, array $args, string $group ): ?string {
@@ -875,7 +837,7 @@ class RecurringScheduler {
 	 * Cancel only the action returned by a store call after ownership was lost.
 	 */
 	private static function cleanupAfterLostScheduleOwnership( int $action_id ): \WP_Error {
-		if ( $action_id > 0 && self::cancelExactAction( $action_id ) ) {
+		if ( $action_id > 0 && ScheduleActionIdentity::cancelExact( $action_id ) ) {
 			return self::lockLostError();
 		}
 
@@ -889,21 +851,6 @@ class RecurringScheduler {
 				'action_id'      => $action_id,
 			)
 		);
-	}
-
-	private static function cancelExactAction( int $action_id ): bool {
-		if ( $action_id <= 0 || ! class_exists( '\\ActionScheduler_Store' ) ) {
-			return false;
-		}
-
-		try {
-			$store = \ActionScheduler_Store::instance();
-			$store->cancel_action( $action_id );
-			return \ActionScheduler_Store::STATUS_CANCELED === $store->get_status( $action_id );
-		} catch ( \Throwable $throwable ) {
-			unset( $throwable );
-			return false;
-		}
 	}
 
 	/**
@@ -935,31 +882,18 @@ class RecurringScheduler {
 			return self::retryableError( 'scheduler_unavailable', 'Action Scheduler exact cleanup is unavailable.' );
 		}
 
-		$actions = as_get_scheduled_actions(
-			array(
-				'hook'     => $hook,
-				'group'    => $group,
-				'status'   => 'pending',
-				'per_page' => -1,
-			),
-			'OBJECT'
-		);
-		foreach ( $actions as $action_id => $action ) {
-			if ( ! is_object( $action ) || ! method_exists( $action, 'get_args' ) || self::logicalArgsFromActionArgs( $action->get_args() ) !== $args ) {
-				continue;
-			}
-			if ( ! self::cancelExactAction( (int) $action_id ) ) {
-				return self::error(
-					'schedule_exact_cleanup_failed',
-					'Unable to cancel an exact superseded schedule action.',
-					array(
-						'status'         => 503,
-						'retryable'      => true,
-						'retry_after_ms' => 250,
-						'action_id'      => (int) $action_id,
-					)
-				);
-			}
+		$failed_action_id = ScheduleActionIdentity::cancelPending( $hook, $args, $group );
+		if ( $failed_action_id > 0 ) {
+			return self::error(
+				'schedule_exact_cleanup_failed',
+				'Unable to cancel an exact superseded schedule action.',
+				array(
+					'status'         => 503,
+					'retryable'      => true,
+					'retry_after_ms' => 250,
+					'action_id'      => $failed_action_id,
+				)
+			);
 		}
 
 		return true;
@@ -1030,29 +964,7 @@ class RecurringScheduler {
 			return false;
 		}
 
-		foreach ( array( 'pending', 'in-progress' ) as $status ) {
-			$actions = as_get_scheduled_actions(
-				array(
-					'hook'     => $hook,
-					'group'    => $group,
-					'status'   => $status,
-					'per_page' => -1,
-				),
-				'OBJECT'
-			);
-			foreach ( $actions as $action ) {
-				if ( ! is_object( $action ) || ! method_exists( $action, 'get_args' ) ) {
-					continue;
-				}
-				$action_args = $action->get_args();
-				if ( self::logicalArgsFromActionArgs( $action_args ) === $args
-					&& ( ! $generated_only || null !== self::generationFromActionArgs( $action_args ) ) ) {
-					return true;
-				}
-			}
-		}
-
-		return false;
+		return ScheduleActionIdentity::hasCoverage( $hook, $args, $group, $generated_only );
 	}
 
 	/**
@@ -1065,26 +977,7 @@ class RecurringScheduler {
 			return false;
 		}
 
-		$actions = as_get_scheduled_actions(
-			array(
-				'hook'     => $hook,
-				'group'    => $group,
-				'status'   => 'pending',
-				'orderby'  => 'date',
-				'order'    => 'ASC',
-				'per_page' => -1,
-			),
-			'OBJECT'
-		);
-		foreach ( $actions as $action ) {
-			if ( ! is_object( $action ) || ! method_exists( $action, 'get_args' ) || self::logicalArgsFromActionArgs( $action->get_args() ) !== $args ) {
-				continue;
-			}
-			$date = $action->get_schedule()->get_date();
-			return $date ? $date->getTimestamp() : false;
-		}
-
-		return false;
+		return ScheduleActionIdentity::nextTimestamp( $hook, $args, $group );
 	}
 
 	/**
@@ -1153,132 +1046,15 @@ class RecurringScheduler {
 		);
 	}
 
-	/**
-	 * Find the next pending action object for a schedule slot.
-	 *
-	 * @param string $hook  Hook name.
-	 * @param array  $args  Action args.
-	 * @param string $group AS group.
-	 * @return object|null ActionScheduler_Action-like object, or null.
-	 */
-	private static function getPendingAction( string $hook, array $args, string $group ): ?object {
-		return self::getActionByStatuses( $hook, $args, $group, array( 'pending' ) );
-	}
-
-	/**
-	 * Find the next pending or running action that owns a schedule slot.
-	 *
-	 * @param string $hook  Hook name.
-	 * @param array  $args  Action args.
-	 * @param string $group AS group.
-	 * @return object|null ActionScheduler_Action-like object, or null.
-	 */
-	private static function getCoveringAction( string $hook, array $args, string $group ): ?object {
-		return self::getActionByStatuses( $hook, $args, $group, array( 'pending', 'in-progress' ) );
-	}
-
-	/**
-	 * Find the next action matching one of the supplied statuses.
-	 *
-	 * @param string   $hook     Hook name.
-	 * @param array    $args     Action args.
-	 * @param string   $group    AS group.
-	 * @param string[] $statuses Action Scheduler statuses in priority order.
-	 * @return object|null ActionScheduler_Action-like object, or null.
-	 */
-	private static function getActionByStatuses( string $hook, array $args, string $group, array $statuses ): ?object {
-		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
-			return null;
-		}
-
-		if ( ! self::isActionSchedulerDataStoreReady() ) {
-			return null;
-		}
-
-		foreach ( $statuses as $status ) {
-			$actions = as_get_scheduled_actions(
-				array(
-					'hook'     => $hook,
-					'args'     => $args,
-					'group'    => $group,
-					'status'   => $status,
-					'orderby'  => 'date',
-					'order'    => 'ASC',
-					'per_page' => 1,
-				),
-				'OBJECT'
-			);
-
-			$action = reset( $actions );
-			if ( is_object( $action ) ) {
-				return $action;
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * Count ALL pending Action Scheduler actions matching (hook, args, group).
-	 *
-	 * Used to detect duplicate recurring/cron chains for the same signature so
-	 * ensureSchedule can self-heal (collapse N>1 chains to exactly one) even on
-	 * the preserve fast path. Unlike getPendingAction() (per_page=1), this asks
-	 * for more than one row so duplicates are visible.
-	 *
-	 * @param string $hook  Hook name.
-	 * @param array  $args  Action args.
-	 * @param string $group AS group.
-	 * @return int Number of matching pending actions (0 when AS is not ready).
-	 */
-	private static function countMatchingPendingActions( string $hook, array $args, string $group ): int {
-		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
-			return 0;
-		}
-
-		if ( ! self::isActionSchedulerDataStoreReady() ) {
-			return 0;
-		}
-
-		$actions = as_get_scheduled_actions(
-			array(
-				'hook'     => $hook,
-				'args'     => $args,
-				'group'    => $group,
-				'status'   => 'pending',
-				'per_page' => 100,
-			),
-			'ids'
-		);
-
-		return is_array( $actions ) ? count( $actions ) : 0;
-	}
-
 	private static function countPendingActionsForSignature( string $hook, array $logical_args, array $schedule_args, string $group, array $lock ): int {
 		if ( null === ( $lock['generation_argument_index'] ?? null ) ) {
-			return self::countMatchingPendingActions( $hook, $schedule_args, $group );
+			return ScheduleActionIdentity::countExactPending( $hook, $schedule_args, $group );
 		}
 		if ( ! function_exists( 'as_get_scheduled_actions' ) || ! self::isActionSchedulerDataStoreReady() ) {
 			return 0;
 		}
 
-		$actions = as_get_scheduled_actions(
-			array(
-				'hook'     => $hook,
-				'group'    => $group,
-				'status'   => 'pending',
-				'per_page' => -1,
-			),
-			'OBJECT'
-		);
-		$count   = 0;
-		foreach ( $actions as $action ) {
-			if ( is_object( $action ) && method_exists( $action, 'get_args' ) && self::logicalArgsFromActionArgs( $action->get_args() ) === $logical_args ) {
-				++$count;
-			}
-		}
-
-		return $count;
+		return ScheduleActionIdentity::countPending( $hook, $logical_args, $group );
 	}
 
 	/**
@@ -1291,7 +1067,7 @@ class RecurringScheduler {
 	 * @return bool True when the existing pending action already matches.
 	 */
 	private static function hasMatchingSingleAction( string $hook, array $args, string $group, int $timestamp ): bool {
-		$action = self::getCoveringAction( $hook, $args, $group );
+		$action = ScheduleActionIdentity::exactAction( $hook, $args, $group, array( 'pending', 'in-progress' ) );
 		if ( ! $action || ! method_exists( $action, 'get_schedule' ) ) {
 			return false;
 		}
@@ -1314,7 +1090,7 @@ class RecurringScheduler {
 	 * @return bool True when the existing pending action already matches.
 	 */
 	private static function hasMatchingRecurringAction( string $hook, array $args, string $group, int $interval_seconds ): bool {
-		$action = self::getCoveringAction( $hook, $args, $group );
+		$action = ScheduleActionIdentity::exactAction( $hook, $args, $group, array( 'pending', 'in-progress' ) );
 		if ( ! $action || ! method_exists( $action, 'get_schedule' ) ) {
 			return false;
 		}
@@ -1340,7 +1116,7 @@ class RecurringScheduler {
 	 * @return bool True when the existing pending action already matches.
 	 */
 	private static function hasMatchingCronAction( string $hook, array $args, string $group, string $cron_expression ): bool {
-		$action = self::getCoveringAction( $hook, $args, $group );
+		$action = ScheduleActionIdentity::exactAction( $hook, $args, $group, array( 'pending', 'in-progress' ) );
 		if ( ! $action || ! method_exists( $action, 'get_schedule' ) ) {
 			return false;
 		}

--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -33,6 +33,8 @@ use DataMachine\Core\OptionLeaseStore;
 defined( 'ABSPATH' ) || exit;
 
 class RecurringScheduler {
+	/** @var array<string,array{generation_option:string,expected_generation:string}> */
+	private static array $executed_recurrence_generations = array();
 
 	/**
 	 * Default Action Scheduler group for all DM-managed schedules.
@@ -142,6 +144,52 @@ class RecurringScheduler {
 	}
 
 	/**
+	 * Persist desired state and reconcile its schedule under one signature lease.
+	 *
+	 * The commit runs before any Action Scheduler mutation. The recorder runs after
+	 * reconciliation, while the same lease is still held, and may persist drift or
+	 * derived scheduling metadata.
+	 *
+	 * @param callable $commit Desired-state commit. Return true or WP_Error.
+	 * @param callable $record Reconciliation recorder receiving array|WP_Error.
+	 * @return array|\WP_Error
+	 */
+	public static function commitDesiredSchedule(
+		string $hook,
+		array $args,
+		?string $interval,
+		array $options,
+		bool $enabled,
+		callable $commit,
+		callable $record
+	) {
+		$lock = self::acquireScheduleLock( $hook, $args, (string) ( $options['group'] ?? self::GROUP ) );
+		if ( is_wp_error( $lock ) ) {
+			return $lock;
+		}
+
+		try {
+			$committed = $commit();
+			if ( is_wp_error( $committed ) ) {
+				return $committed;
+			}
+			if ( true !== $committed ) {
+				return self::retryableError( 'schedule_state_commit_failed', 'Failed to persist desired schedule state.' );
+			}
+
+			$result   = self::ensureScheduleUnlocked( $hook, $args, $interval, $options, $enabled, $lock );
+			$recorded = $record( $result );
+			if ( is_wp_error( $recorded ) ) {
+				return $recorded;
+			}
+
+			return $result;
+		} finally {
+			OptionLeaseStore::release( $lock['option_name'], $lock['token'] );
+		}
+	}
+
+	/**
 	 * Reconcile one schedule while its signature lease is held.
 	 *
 	 * @param string      $hook     Action Scheduler hook.
@@ -190,10 +238,9 @@ class RecurringScheduler {
 			}
 
 			if ( ! function_exists( 'as_schedule_single_action' ) ) {
-				return self::error(
+				return self::retryableError(
 					'scheduler_unavailable',
-					'Action Scheduler not available',
-					array( 'status' => 500 )
+					'Action Scheduler not available'
 				);
 			}
 
@@ -202,10 +249,9 @@ class RecurringScheduler {
 			// unschedule would be a no-op while the schedule later succeeds,
 			// creating a duplicate chain. Bail so the caller retries later.
 			if ( ! self::isActionSchedulerDataStoreReady() ) {
-				return self::error(
+				return self::retryableError(
 					'datastore_not_ready',
-					'Action Scheduler datastore not ready; deferring schedule to avoid creating a duplicate chain.',
-					array( 'status' => 503 )
+					'Action Scheduler datastore not ready; deferring schedule to avoid creating a duplicate chain.'
 				);
 			}
 
@@ -274,10 +320,9 @@ class RecurringScheduler {
 		}
 
 		if ( ! function_exists( 'as_schedule_recurring_action' ) ) {
-			return self::error(
+			return self::retryableError(
 				'scheduler_unavailable',
-				'Action Scheduler not available',
-				array( 'status' => 500 )
+				'Action Scheduler not available'
 			);
 		}
 
@@ -287,10 +332,9 @@ class RecurringScheduler {
 		// later succeeds in the same request — creating a SECOND parallel
 		// recurring chain. Bail so the caller retries when AS is ready.
 		if ( ! self::isActionSchedulerDataStoreReady() ) {
-			return self::error(
+			return self::retryableError(
 				'datastore_not_ready',
-				'Action Scheduler datastore not ready; deferring schedule to avoid creating a duplicate chain.',
-				array( 'status' => 503 )
+				'Action Scheduler datastore not ready; deferring schedule to avoid creating a duplicate chain.'
 			);
 		}
 
@@ -336,10 +380,9 @@ class RecurringScheduler {
 				}
 
 				if ( ! self::isScheduled( $hook, $args, $group ) ) {
-					return self::error(
+					return self::retryableError(
 						'schedule_not_persisted',
-						'Action Scheduler accepted the schedule but no pending action was found. AS tables may not be ready.',
-						array( 'status' => 500 )
+						'Action Scheduler accepted the schedule but no pending action was found. AS tables may not be ready.'
 					);
 				}
 
@@ -378,10 +421,9 @@ class RecurringScheduler {
 		// Verify persistence. AS can silently drop actions when its tables
 		// aren't ready (e.g. CLI context during plugin activation).
 		if ( ! self::isScheduled( $hook, $args, $group ) ) {
-			return self::error(
+			return self::retryableError(
 				'schedule_not_persisted',
-				'Action Scheduler accepted the schedule but no pending action was found. AS tables may not be ready.',
-				array( 'status' => 500 )
+				'Action Scheduler accepted the schedule but no pending action was found. AS tables may not be ready.'
 			);
 		}
 
@@ -398,6 +440,62 @@ class RecurringScheduler {
 	 */
 	public static function registerGenerationFence(): void {
 		add_filter( 'action_scheduler_stored_action_instance', array( self::class, 'fenceStoredAction' ), 10, 6 );
+		add_action( 'action_scheduler_before_execute', array( self::class, 'clearExecutedRecurrenceGenerations' ), 0, 0 );
+		add_action( 'action_scheduler_after_execute', array( self::class, 'captureExecutedRecurrenceGeneration' ), PHP_INT_MAX, 2 );
+		add_action( 'action_scheduler_stored_action', array( self::class, 'reconcileStoredRecurrenceSuccessor' ), PHP_INT_MAX );
+	}
+
+	public static function clearExecutedRecurrenceGenerations(): void {
+		self::$executed_recurrence_generations = array();
+	}
+
+	/**
+	 * Capture the generation that native Action Scheduler repeat() is about to clone.
+	 */
+	public static function captureExecutedRecurrenceGeneration( int $action_id, $action ): void {
+		unset( $action_id );
+		if ( ! $action instanceof GenerationFencedAction || ! $action->get_schedule()->is_recurring() ) {
+			return;
+		}
+
+		$key = self::scheduleSignatureKey( $action->get_hook(), $action->get_args(), $action->get_group() );
+		if ( null === $key ) {
+			return;
+		}
+
+		self::$executed_recurrence_generations[ $key ] = array(
+			'generation_option'   => $action->getGenerationOption(),
+			'expected_generation' => $action->getExpectedGeneration(),
+		);
+	}
+
+	/**
+	 * Cancel a successor stored from a stale schedule cached inside repeat().
+	 */
+	public static function reconcileStoredRecurrenceSuccessor( int $action_id ): void {
+		if ( empty( self::$executed_recurrence_generations ) ) {
+			return;
+		}
+
+		try {
+			$action = \ActionScheduler_Store::instance()->fetch_action( $action_id );
+		} catch ( \Throwable $exception ) {
+			return;
+		}
+
+		$key = self::scheduleSignatureKey( $action->get_hook(), $action->get_args(), $action->get_group() );
+		if ( null === $key || ! isset( self::$executed_recurrence_generations[ $key ] ) ) {
+			return;
+		}
+
+		$context = self::$executed_recurrence_generations[ $key ];
+		unset( self::$executed_recurrence_generations[ $key ] );
+		$current = get_option( $context['generation_option'], '' );
+		if ( is_string( $current ) && hash_equals( $context['expected_generation'], $current ) ) {
+			return;
+		}
+
+		\ActionScheduler_Store::instance()->cancel_action( $action_id );
 	}
 
 	/**
@@ -512,16 +610,20 @@ class RecurringScheduler {
 	 * @return array{lock_option:string,generation_option:string}|\WP_Error
 	 */
 	private static function scheduleOptionNames( string $hook, array $args, string $group ) {
-		$signature = wp_json_encode( array( $hook, $args, $group ) );
-		if ( false === $signature ) {
+		$hash = self::scheduleSignatureKey( $hook, $args, $group );
+		if ( null === $hash ) {
 			return self::error( 'invalid_schedule_signature', 'Schedule arguments must be JSON-serializable.', array( 'status' => 400 ) );
 		}
 
-		$hash = md5( $signature );
 		return array(
 			'lock_option'       => self::SCHEDULE_LOCK_PREFIX . $hash,
 			'generation_option' => self::SCHEDULE_GENERATION_PREFIX . $hash,
 		);
+	}
+
+	private static function scheduleSignatureKey( string $hook, array $args, string $group ): ?string {
+		$signature = wp_json_encode( array( $hook, $args, $group ) );
+		return false === $signature ? null : md5( $signature );
 	}
 
 	/**
@@ -641,10 +743,11 @@ class RecurringScheduler {
 	 * @param string $hook  Hook name.
 	 * @param array  $args  Action args (signature).
 	 * @param string $group AS group.
-	 * @return void
+	 * @return array|\WP_Error Observable reconciliation result. Existing callers
+	 *                         may continue ignoring the return value.
 	 */
-	public static function unschedule( string $hook, array $args, string $group = self::GROUP ): void {
-		self::ensureSchedule( $hook, $args, 'manual', array( 'group' => $group ) );
+	public static function unschedule( string $hook, array $args, string $group = self::GROUP ) {
+		return self::ensureSchedule( $hook, $args, 'manual', array( 'group' => $group ) );
 	}
 
 	/**
@@ -761,6 +864,18 @@ class RecurringScheduler {
 	 */
 	private static function error( string $code, string $message, array $data = array() ): \WP_Error {
 		return new \WP_Error( $code, $message, $data );
+	}
+
+	private static function retryableError( string $code, string $message, int $status = 503 ): \WP_Error {
+		return self::error(
+			$code,
+			$message,
+			array(
+				'status'         => $status,
+				'retryable'      => true,
+				'retry_after_ms' => 250,
+			)
+		);
 	}
 
 	/**
@@ -1120,10 +1235,9 @@ class RecurringScheduler {
 		}
 
 		if ( ! function_exists( 'as_schedule_cron_action' ) ) {
-			return self::error(
+			return self::retryableError(
 				'scheduler_unavailable',
-				'Action Scheduler not available',
-				array( 'status' => 500 )
+				'Action Scheduler not available'
 			);
 		}
 
@@ -1131,10 +1245,9 @@ class RecurringScheduler {
 		// branches: a not-ready unschedule is a no-op but the schedule succeeds,
 		// duplicating the chain. Bail and let the caller retry when AS is ready.
 		if ( ! self::isActionSchedulerDataStoreReady() ) {
-			return self::error(
+			return self::retryableError(
 				'datastore_not_ready',
-				'Action Scheduler datastore not ready; deferring cron schedule to avoid creating a duplicate chain.',
-				array( 'status' => 503 )
+				'Action Scheduler datastore not ready; deferring cron schedule to avoid creating a duplicate chain.'
 			);
 		}
 
@@ -1160,10 +1273,9 @@ class RecurringScheduler {
 				}
 
 				if ( ! self::isScheduled( $hook, $args, $group ) ) {
-					return self::error(
+					return self::retryableError(
 						'schedule_not_persisted',
-						'Action Scheduler accepted the cron schedule but no pending action was found.',
-						array( 'status' => 500 )
+						'Action Scheduler accepted the cron schedule but no pending action was found.'
 					);
 				}
 
@@ -1199,10 +1311,9 @@ class RecurringScheduler {
 		}
 
 		if ( ! self::isScheduled( $hook, $args, $group ) ) {
-			return self::error(
+			return self::retryableError(
 				'schedule_not_persisted',
-				'Action Scheduler accepted the cron schedule but no pending action was found.',
-				array( 'status' => 500 )
+				'Action Scheduler accepted the cron schedule but no pending action was found.'
 			);
 		}
 

--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -33,8 +33,10 @@ use DataMachine\Core\OptionLeaseStore;
 defined( 'ABSPATH' ) || exit;
 
 class RecurringScheduler {
-	/** @var array<string,array{generation_option:string,expected_generation:string}> */
+	/** @var array<string,array{generation_option:string,expected_generation:string,legacy:bool}> */
 	private static array $executed_recurrence_generations = array();
+	private static ?int $executing_action_id              = null;
+	private static bool $executing_recurring_action       = false;
 
 	/**
 	 * Default Action Scheduler group for all DM-managed schedules.
@@ -67,6 +69,8 @@ class RecurringScheduler {
 	 * signature can repeat.
 	 */
 	private const SCHEDULE_GENERATION_PREFIX   = 'datamachine_schedule_generation_';
+	private const GENERATION_ARGUMENT_KEY      = '_datamachine_schedule_generation';
+	private const SIGNATURE_ARGUMENT_COUNT_KEY = '_datamachine_signature_argument_count';
 	private const SCHEDULE_LOCK_TTL            = 30;
 	private const SCHEDULE_LOCK_RETRY_ATTEMPTS = 5;
 	private const SCHEDULE_LOCK_RETRY_DELAY_US = 25000;
@@ -169,6 +173,18 @@ class RecurringScheduler {
 		}
 
 		try {
+			$lock['generation_argument_index'] = isset( $options['generation_argument_index'] )
+				? max( count( $args ), (int) $options['generation_argument_index'] )
+				: null;
+			if ( ! empty( $options['legacy_adoption'] )
+				&& self::getCoveringAction( $hook, self::scheduleActionArgs( $args, $lock ), (string) ( $options['group'] ?? self::GROUP ) ) ) {
+				return self::error(
+					'stale_legacy_schedule_generation',
+					'A generated schedule already owns this flow; the legacy action is stale.',
+					array( 'status' => 409 )
+				);
+			}
+
 			$committed = $commit();
 			if ( is_wp_error( $committed ) ) {
 				return $committed;
@@ -208,7 +224,11 @@ class RecurringScheduler {
 		bool $enabled,
 		array $lock
 	) {
-		$group = $options['group'] ?? self::GROUP;
+		$group                             = $options['group'] ?? self::GROUP;
+		$lock['generation_argument_index'] = isset( $options['generation_argument_index'] )
+			? max( count( $args ), (int) $options['generation_argument_index'] )
+			: null;
+		$schedule_args                     = self::scheduleActionArgs( $args, $lock );
 
 		// Disabled / manual / null → unschedule and return.
 		if ( ! $enabled || null === $interval || 'manual' === $interval ) {
@@ -255,7 +275,7 @@ class RecurringScheduler {
 				);
 			}
 
-			if ( empty( $options['force_reschedule'] ) && self::hasMatchingSingleAction( $hook, $args, $group, (int) $timestamp ) ) {
+			if ( empty( $options['force_reschedule'] ) && self::hasMatchingSingleAction( $hook, $schedule_args, $group, (int) $timestamp ) ) {
 				return array(
 					'interval'       => 'one_time',
 					'scheduled'      => true,
@@ -361,11 +381,11 @@ class RecurringScheduler {
 		// Preserve independent schedules that share a hook but have distinct args.
 		$unique = empty( $args );
 
-		if ( empty( $options['force_reschedule'] ) && self::hasMatchingRecurringAction( $hook, $args, $group, (int) $interval_seconds ) ) {
+		if ( empty( $options['force_reschedule'] ) && self::hasMatchingRecurringAction( $hook, $schedule_args, $group, (int) $interval_seconds ) ) {
 			// Self-healing dedup: if a previous call already created MORE THAN
 			// ONE matching pending chain for this signature, collapse them to a
 			// single chain now instead of preserving the duplicates.
-			if ( self::countMatchingPendingActions( $hook, $args, $group ) > 1 ) {
+			if ( self::countPendingActionsForSignature( $hook, $args, $schedule_args, $group, $lock ) > 1 ) {
 				$lock = self::beginScheduleMutation( $lock );
 				if ( is_wp_error( $lock ) ) {
 					return $lock;
@@ -379,7 +399,7 @@ class RecurringScheduler {
 					return $scheduled;
 				}
 
-				if ( ! self::isScheduled( $hook, $args, $group ) ) {
+				if ( ! self::isExactScheduled( $hook, self::scheduleActionArgs( $args, $lock ), $group ) ) {
 					return self::retryableError(
 						'schedule_not_persisted',
 						'Action Scheduler accepted the schedule but no pending action was found. AS tables may not be ready.'
@@ -420,7 +440,7 @@ class RecurringScheduler {
 
 		// Verify persistence. AS can silently drop actions when its tables
 		// aren't ready (e.g. CLI context during plugin activation).
-		if ( ! self::isScheduled( $hook, $args, $group ) ) {
+		if ( ! self::isExactScheduled( $hook, self::scheduleActionArgs( $args, $lock ), $group ) ) {
 			return self::retryableError(
 				'schedule_not_persisted',
 				'Action Scheduler accepted the schedule but no pending action was found. AS tables may not be ready.'
@@ -440,13 +460,31 @@ class RecurringScheduler {
 	 */
 	public static function registerGenerationFence(): void {
 		add_filter( 'action_scheduler_stored_action_instance', array( self::class, 'fenceStoredAction' ), 10, 6 );
-		add_action( 'action_scheduler_before_execute', array( self::class, 'clearExecutedRecurrenceGenerations' ), 0, 0 );
+		add_action( 'action_scheduler_before_execute', array( self::class, 'clearExecutedRecurrenceGenerations' ), 0, 1 );
 		add_action( 'action_scheduler_after_execute', array( self::class, 'captureExecutedRecurrenceGeneration' ), PHP_INT_MAX, 2 );
 		add_action( 'action_scheduler_stored_action', array( self::class, 'reconcileStoredRecurrenceSuccessor' ), PHP_INT_MAX );
 	}
 
-	public static function clearExecutedRecurrenceGenerations(): void {
+	public static function clearExecutedRecurrenceGenerations( int $action_id = 0 ): void {
 		self::$executed_recurrence_generations = array();
+		self::$executing_action_id             = $action_id > 0 ? $action_id : null;
+		self::$executing_recurring_action      = false;
+		if ( $action_id <= 0 || ! class_exists( '\\ActionScheduler_Store' ) ) {
+			return;
+		}
+
+		try {
+			$action                           = \ActionScheduler_Store::instance()->fetch_action( $action_id );
+			self::$executing_recurring_action = is_object( $action )
+				&& method_exists( $action, 'get_schedule' )
+				&& $action->get_schedule()->is_recurring();
+		} catch ( \Throwable $throwable ) {
+			unset( $throwable );
+		}
+	}
+
+	public static function isExecutingRecurringAction(): bool {
+		return null !== self::$executing_action_id && self::$executing_recurring_action;
 	}
 
 	/**
@@ -454,6 +492,8 @@ class RecurringScheduler {
 	 */
 	public static function captureExecutedRecurrenceGeneration( int $action_id, $action ): void {
 		unset( $action_id );
+		self::$executing_action_id        = null;
+		self::$executing_recurring_action = false;
 		if ( ! $action instanceof GenerationFencedAction || ! $action->get_schedule()->is_recurring() ) {
 			return;
 		}
@@ -466,6 +506,7 @@ class RecurringScheduler {
 		self::$executed_recurrence_generations[ $key ] = array(
 			'generation_option'   => $action->getGenerationOption(),
 			'expected_generation' => $action->getExpectedGeneration(),
+			'legacy'              => null === self::generationFromActionArgs( $action->get_args() ),
 		);
 	}
 
@@ -491,11 +532,11 @@ class RecurringScheduler {
 		$context = self::$executed_recurrence_generations[ $key ];
 		unset( self::$executed_recurrence_generations[ $key ] );
 		$current = get_option( $context['generation_option'], '' );
-		if ( is_string( $current ) && hash_equals( $context['expected_generation'], $current ) ) {
+		if ( empty( $context['legacy'] ) && is_string( $current ) && hash_equals( $context['expected_generation'], $current ) ) {
 			return;
 		}
 
-		\ActionScheduler_Store::instance()->cancel_action( $action_id );
+		self::cancelExactAction( $action_id );
 	}
 
 	/**
@@ -517,12 +558,16 @@ class RecurringScheduler {
 			return $action;
 		}
 
-		$options = self::scheduleOptionNames( $hook, $args, $group );
+		$logical_args = self::logicalArgsFromActionArgs( $args );
+		$options      = self::scheduleOptionNames( $hook, $logical_args, $group );
 		if ( is_wp_error( $options ) ) {
 			return $action;
 		}
 
-		$generation = get_option( $options['generation_option'], false );
+		$generation = self::generationFromActionArgs( $args );
+		if ( null === $generation ) {
+			$generation = get_option( $options['generation_option'], false );
+		}
 		if ( false === $generation && self::GROUP === $group ) {
 			$generation = wp_generate_uuid4();
 			if ( ! add_option( $options['generation_option'], $generation, '', false ) ) {
@@ -583,6 +628,7 @@ class RecurringScheduler {
 				return array(
 					'option_name'       => $option_name,
 					'generation_option' => $options['generation_option'],
+					'generation'        => $generation,
 					'token'             => $token,
 					'lease_payload'     => $payload,
 				);
@@ -619,6 +665,90 @@ class RecurringScheduler {
 			'lock_option'       => self::SCHEDULE_LOCK_PREFIX . $hash,
 			'generation_option' => self::SCHEDULE_GENERATION_PREFIX . $hash,
 		);
+	}
+
+	/**
+	 * Invalidate only the cached generation value for a logical signature.
+	 *
+	 * Transaction rollback can remove an option row while leaving WordPress's
+	 * option cache populated. Deleting the cache entry forces the compensation
+	 * path to reread the database without risking deletion of a concurrent row.
+	 */
+	public static function invalidateGenerationCache( string $hook, array $args, string $group = self::GROUP ): bool {
+		$options = self::scheduleOptionNames( $hook, $args, $group );
+		if ( is_wp_error( $options ) ) {
+			return false;
+		}
+
+		return wp_cache_delete( $options['generation_option'], 'options' );
+	}
+
+	/**
+	 * Check whether a persisted action generation still owns its signature.
+	 *
+	 * Missing markers identify legacy actions and are deliberately not adopted
+	 * here; the flow handler performs the bounded legacy transition.
+	 */
+	public static function isActionGenerationCurrent( string $hook, array $args, string $group, $generation_argument ): bool {
+		$generation = self::generationFromArgument( $generation_argument );
+		if ( null === $generation ) {
+			return false;
+		}
+
+		$options = self::scheduleOptionNames( $hook, $args, $group );
+		if ( is_wp_error( $options ) ) {
+			return false;
+		}
+
+		$current = get_option( $options['generation_option'], '' );
+		return is_string( $current ) && hash_equals( $generation, $current );
+	}
+
+	/**
+	 * Build Action Scheduler args carrying the owned mutation generation.
+	 */
+	private static function scheduleActionArgs( array $args, array $lock ): array {
+		if ( ! isset( $lock['generation_argument_index'] ) || null === $lock['generation_argument_index'] ) {
+			return $args;
+		}
+
+		$logical_count = count( $args );
+		$target_count  = (int) $lock['generation_argument_index'];
+		for ( $argument_count = $logical_count; $argument_count < $target_count; ++$argument_count ) {
+			$args[] = null;
+		}
+		$args[] = array(
+			self::GENERATION_ARGUMENT_KEY      => (string) $lock['generation'],
+			self::SIGNATURE_ARGUMENT_COUNT_KEY => $logical_count,
+		);
+
+		return $args;
+	}
+
+	private static function generationFromArgument( $argument ): ?string {
+		if ( ! is_array( $argument ) || empty( $argument[ self::GENERATION_ARGUMENT_KEY ] ) || ! is_string( $argument[ self::GENERATION_ARGUMENT_KEY ] ) ) {
+			return null;
+		}
+
+		return $argument[ self::GENERATION_ARGUMENT_KEY ];
+	}
+
+	private static function generationFromActionArgs( array $args ): ?string {
+		return empty( $args ) ? null : self::generationFromArgument( end( $args ) );
+	}
+
+	private static function logicalArgsFromActionArgs( array $args ): array {
+		if ( empty( $args ) ) {
+			return $args;
+		}
+
+		$marker = end( $args );
+		if ( null === self::generationFromArgument( $marker ) ) {
+			return $args;
+		}
+
+		$count = isset( $marker[ self::SIGNATURE_ARGUMENT_COUNT_KEY ] ) ? (int) $marker[ self::SIGNATURE_ARGUMENT_COUNT_KEY ] : count( $args ) - 1;
+		return array_slice( $args, 0, max( 0, $count ) );
 	}
 
 	private static function scheduleSignatureKey( string $hook, array $args, string $group ): ?string {
@@ -697,7 +827,11 @@ class RecurringScheduler {
 		if ( ! self::assertMutationOwner( $lock ) ) {
 			return self::lockLostError();
 		}
-		self::rawUnschedule( $hook, $args, $group );
+		$generation_aware = isset( $lock['generation_argument_index'] );
+		$unscheduled      = self::rawUnschedule( $hook, $args, $group, $generation_aware );
+		if ( is_wp_error( $unscheduled ) ) {
+			return $unscheduled;
+		}
 		if ( ! self::assertMutationOwner( $lock ) ) {
 			return self::lockLostError();
 		}
@@ -711,8 +845,8 @@ class RecurringScheduler {
 		if ( ! self::assertMutationOwner( $lock ) ) {
 			return self::lockLostError();
 		}
-		$action_id = as_schedule_single_action( $timestamp, $hook, $args, $group );
-		return self::assertMutationOwner( $lock ) ? $action_id : self::lockLostError();
+		$action_id = as_schedule_single_action( $timestamp, $hook, self::scheduleActionArgs( $args, $lock ), $group );
+		return self::assertMutationOwner( $lock ) ? $action_id : self::cleanupAfterLostScheduleOwnership( (int) $action_id );
 	}
 
 	/**
@@ -722,8 +856,8 @@ class RecurringScheduler {
 		if ( ! self::assertMutationOwner( $lock ) ) {
 			return self::lockLostError();
 		}
-		$action_id = as_schedule_recurring_action( $timestamp, $interval, $hook, $args, $group, $unique );
-		return self::assertMutationOwner( $lock ) ? $action_id : self::lockLostError();
+		$action_id = as_schedule_recurring_action( $timestamp, $interval, $hook, self::scheduleActionArgs( $args, $lock ), $group, $unique );
+		return self::assertMutationOwner( $lock ) ? $action_id : self::cleanupAfterLostScheduleOwnership( (int) $action_id );
 	}
 
 	/**
@@ -733,8 +867,43 @@ class RecurringScheduler {
 		if ( ! self::assertMutationOwner( $lock ) ) {
 			return self::lockLostError();
 		}
-		$action_id = as_schedule_cron_action( $timestamp, $expression, $hook, $args, $group, $unique );
-		return self::assertMutationOwner( $lock ) ? $action_id : self::lockLostError();
+		$action_id = as_schedule_cron_action( $timestamp, $expression, $hook, self::scheduleActionArgs( $args, $lock ), $group, $unique );
+		return self::assertMutationOwner( $lock ) ? $action_id : self::cleanupAfterLostScheduleOwnership( (int) $action_id );
+	}
+
+	/**
+	 * Cancel only the action returned by a store call after ownership was lost.
+	 */
+	private static function cleanupAfterLostScheduleOwnership( int $action_id ): \WP_Error {
+		if ( $action_id > 0 && self::cancelExactAction( $action_id ) ) {
+			return self::lockLostError();
+		}
+
+		return self::error(
+			'schedule_exact_cleanup_failed',
+			'Schedule ownership changed during persistence and the exact stale action could not be canceled.',
+			array(
+				'status'         => 503,
+				'retryable'      => true,
+				'retry_after_ms' => 250,
+				'action_id'      => $action_id,
+			)
+		);
+	}
+
+	private static function cancelExactAction( int $action_id ): bool {
+		if ( $action_id <= 0 || ! class_exists( '\\ActionScheduler_Store' ) ) {
+			return false;
+		}
+
+		try {
+			$store = \ActionScheduler_Store::instance();
+			$store->cancel_action( $action_id );
+			return \ActionScheduler_Store::STATUS_CANCELED === $store->get_status( $action_id );
+		} catch ( \Throwable $throwable ) {
+			unset( $throwable );
+			return false;
+		}
 	}
 
 	/**
@@ -746,17 +915,54 @@ class RecurringScheduler {
 	 * @return array|\WP_Error Observable reconciliation result. Existing callers
 	 *                         may continue ignoring the return value.
 	 */
-	public static function unschedule( string $hook, array $args, string $group = self::GROUP ) {
-		return self::ensureSchedule( $hook, $args, 'manual', array( 'group' => $group ) );
+	public static function unschedule( string $hook, array $args, string $group = self::GROUP, array $options = array() ) {
+		$options['group'] = $group;
+		return self::ensureSchedule( $hook, $args, 'manual', $options );
 	}
 
 	/**
 	 * Unschedule pending actions after ownership has already been fenced.
 	 */
-	private static function rawUnschedule( string $hook, array $args, string $group ): void {
-		if ( function_exists( 'as_unschedule_all_actions' ) ) {
-			as_unschedule_all_actions( $hook, $args, $group );
+	private static function rawUnschedule( string $hook, array $args, string $group, bool $generation_aware = false ) {
+		if ( ! $generation_aware ) {
+			if ( function_exists( 'as_unschedule_all_actions' ) ) {
+				as_unschedule_all_actions( $hook, $args, $group );
+			}
+			return true;
 		}
+
+		if ( ! function_exists( 'as_get_scheduled_actions' ) || ! class_exists( '\\ActionScheduler_Store' ) ) {
+			return self::retryableError( 'scheduler_unavailable', 'Action Scheduler exact cleanup is unavailable.' );
+		}
+
+		$actions = as_get_scheduled_actions(
+			array(
+				'hook'     => $hook,
+				'group'    => $group,
+				'status'   => 'pending',
+				'per_page' => -1,
+			),
+			'OBJECT'
+		);
+		foreach ( $actions as $action_id => $action ) {
+			if ( ! is_object( $action ) || ! method_exists( $action, 'get_args' ) || self::logicalArgsFromActionArgs( $action->get_args() ) !== $args ) {
+				continue;
+			}
+			if ( ! self::cancelExactAction( (int) $action_id ) ) {
+				return self::error(
+					'schedule_exact_cleanup_failed',
+					'Unable to cancel an exact superseded schedule action.',
+					array(
+						'status'         => 503,
+						'retryable'      => true,
+						'retry_after_ms' => 250,
+						'action_id'      => (int) $action_id,
+					)
+				);
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -768,6 +974,10 @@ class RecurringScheduler {
 	 * @return bool True if a pending action exists.
 	 */
 	public static function isScheduled( string $hook, array $args, string $group = self::GROUP ): bool {
+		return self::isExactScheduled( $hook, $args, $group ) || self::hasLogicalCoverage( $hook, $args, $group );
+	}
+
+	private static function isExactScheduled( string $hook, array $args, string $group ): bool {
 		if ( ! function_exists( 'as_next_scheduled_action' ) ) {
 			return false;
 		}
@@ -807,6 +1017,71 @@ class RecurringScheduler {
 			if ( ! empty( $actions ) ) {
 				return true;
 			}
+		}
+
+		return self::hasLogicalCoverage( $hook, $args, $group );
+	}
+
+	/**
+	 * Check coverage for a logical signature across legacy and generated args.
+	 */
+	public static function hasLogicalCoverage( string $hook, array $args, string $group = self::GROUP, bool $generated_only = false ): bool {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) || ! self::isReady() ) {
+			return false;
+		}
+
+		foreach ( array( 'pending', 'in-progress' ) as $status ) {
+			$actions = as_get_scheduled_actions(
+				array(
+					'hook'     => $hook,
+					'group'    => $group,
+					'status'   => $status,
+					'per_page' => -1,
+				),
+				'OBJECT'
+			);
+			foreach ( $actions as $action ) {
+				if ( ! is_object( $action ) || ! method_exists( $action, 'get_args' ) ) {
+					continue;
+				}
+				$action_args = $action->get_args();
+				if ( self::logicalArgsFromActionArgs( $action_args ) === $args
+					&& ( ! $generated_only || null !== self::generationFromActionArgs( $action_args ) ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Find the next pending timestamp across legacy and generated identities.
+	 *
+	 * @return int|false
+	 */
+	public static function nextLogicalScheduledAction( string $hook, array $args, string $group = self::GROUP ) {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) || ! self::isReady() ) {
+			return false;
+		}
+
+		$actions = as_get_scheduled_actions(
+			array(
+				'hook'     => $hook,
+				'group'    => $group,
+				'status'   => 'pending',
+				'orderby'  => 'date',
+				'order'    => 'ASC',
+				'per_page' => -1,
+			),
+			'OBJECT'
+		);
+		foreach ( $actions as $action ) {
+			if ( ! is_object( $action ) || ! method_exists( $action, 'get_args' ) || self::logicalArgsFromActionArgs( $action->get_args() ) !== $args ) {
+				continue;
+			}
+			$date = $action->get_schedule()->get_date();
+			return $date ? $date->getTimestamp() : false;
 		}
 
 		return false;
@@ -977,6 +1252,33 @@ class RecurringScheduler {
 		);
 
 		return is_array( $actions ) ? count( $actions ) : 0;
+	}
+
+	private static function countPendingActionsForSignature( string $hook, array $logical_args, array $schedule_args, string $group, array $lock ): int {
+		if ( null === ( $lock['generation_argument_index'] ?? null ) ) {
+			return self::countMatchingPendingActions( $hook, $schedule_args, $group );
+		}
+		if ( ! function_exists( 'as_get_scheduled_actions' ) || ! self::isActionSchedulerDataStoreReady() ) {
+			return 0;
+		}
+
+		$actions = as_get_scheduled_actions(
+			array(
+				'hook'     => $hook,
+				'group'    => $group,
+				'status'   => 'pending',
+				'per_page' => -1,
+			),
+			'OBJECT'
+		);
+		$count   = 0;
+		foreach ( $actions as $action ) {
+			if ( is_object( $action ) && method_exists( $action, 'get_args' ) && self::logicalArgsFromActionArgs( $action->get_args() ) === $logical_args ) {
+				++$count;
+			}
+		}
+
+		return $count;
 	}
 
 	/**
@@ -1226,6 +1528,7 @@ class RecurringScheduler {
 	 */
 	private static function scheduleCron( string $hook, array $args, string $cron_expression, string $group, array $options, array $lock ) {
 		$force_reschedule = ! empty( $options['force_reschedule'] );
+		$schedule_args    = self::scheduleActionArgs( $args, $lock );
 		if ( ! self::isValidCronExpression( $cron_expression ) ) {
 			return self::error(
 				'invalid_cron_expression',
@@ -1255,10 +1558,10 @@ class RecurringScheduler {
 		// Preserve independent schedules that share a hook but have distinct args.
 		$unique = empty( $args );
 
-		if ( ! $force_reschedule && self::hasMatchingCronAction( $hook, $args, $group, $cron_expression ) ) {
+		if ( ! $force_reschedule && self::hasMatchingCronAction( $hook, $schedule_args, $group, $cron_expression ) ) {
 			// Self-healing dedup: collapse an already-duplicated signature to a
 			// single chain instead of preserving the duplicates.
-			if ( self::countMatchingPendingActions( $hook, $args, $group ) > 1 ) {
+			if ( self::countPendingActionsForSignature( $hook, $args, $schedule_args, $group, $lock ) > 1 ) {
 				$lock = self::beginScheduleMutation( $lock );
 				if ( is_wp_error( $lock ) ) {
 					return $lock;
@@ -1272,7 +1575,7 @@ class RecurringScheduler {
 					return $action_id;
 				}
 
-				if ( ! self::isScheduled( $hook, $args, $group ) ) {
+				if ( ! self::isExactScheduled( $hook, self::scheduleActionArgs( $args, $lock ), $group ) ) {
 					return self::retryableError(
 						'schedule_not_persisted',
 						'Action Scheduler accepted the cron schedule but no pending action was found.'
@@ -1310,7 +1613,7 @@ class RecurringScheduler {
 			return $action_id;
 		}
 
-		if ( ! self::isScheduled( $hook, $args, $group ) ) {
+		if ( ! self::isExactScheduled( $hook, self::scheduleActionArgs( $args, $lock ), $group ) ) {
 			return self::retryableError(
 				'schedule_not_persisted',
 				'Action Scheduler accepted the cron schedule but no pending action was found.'

--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -28,6 +28,8 @@
 
 namespace DataMachine\Engine\Tasks;
 
+use DataMachine\Core\OptionLeaseStore;
+
 defined( 'ABSPATH' ) || exit;
 
 class RecurringScheduler {
@@ -49,6 +51,11 @@ class RecurringScheduler {
 	 * Maximum explicit fleet distribution window in seconds.
 	 */
 	public const MAX_DISTRIBUTION_WINDOW_SECONDS = 86400;
+
+	private const SCHEDULE_LOCK_PREFIX         = 'datamachine_schedule_lock_';
+	private const SCHEDULE_LOCK_TTL            = 30;
+	private const SCHEDULE_LOCK_RETRY_ATTEMPTS = 5;
+	private const SCHEDULE_LOCK_RETRY_DELAY_US = 25000;
 
 	/**
 	 * Ensure an Action Scheduler schedule matches the requested configuration.
@@ -109,6 +116,35 @@ class RecurringScheduler {
 		?string $interval,
 		array $options = array(),
 		bool $enabled = true
+	) {
+		$lock = self::acquireScheduleLock( $hook, $args, (string) ( $options['group'] ?? self::GROUP ) );
+		if ( is_wp_error( $lock ) ) {
+			return $lock;
+		}
+
+		try {
+			return self::ensureScheduleUnlocked( $hook, $args, $interval, $options, $enabled );
+		} finally {
+			OptionLeaseStore::release( $lock['option_name'], $lock['token'] );
+		}
+	}
+
+	/**
+	 * Reconcile one schedule while its signature lease is held.
+	 *
+	 * @param string      $hook     Action Scheduler hook.
+	 * @param array       $args     Action arguments.
+	 * @param string|null $interval Requested interval.
+	 * @param array       $options  Scheduling options.
+	 * @param bool        $enabled  Whether the schedule is enabled.
+	 * @return array|\WP_Error Schedule metadata or an error.
+	 */
+	private static function ensureScheduleUnlocked(
+		string $hook,
+		array $args,
+		?string $interval,
+		array $options,
+		bool $enabled
 	) {
 		$group = $options['group'] ?? self::GROUP;
 
@@ -310,6 +346,50 @@ class RecurringScheduler {
 	}
 
 	/**
+	 * Acquire the option-row lease for one hook/args/group signature.
+	 *
+	 * Argument-bearing actions cannot use Action Scheduler's native uniqueness,
+	 * because it is scoped to hook and group. This lease serializes the complete
+	 * read/unschedule/create sequence without coupling independent argument sets.
+	 *
+	 * @param string $hook  Action Scheduler hook.
+	 * @param array  $args  Action arguments.
+	 * @param string $group Action Scheduler group.
+	 * @return array{option_name:string,token:string}|\WP_Error
+	 */
+	private static function acquireScheduleLock( string $hook, array $args, string $group ) {
+		$option_name = self::SCHEDULE_LOCK_PREFIX . md5( serialize( array( $hook, $args, $group ) ) );
+
+		for ( $attempt = 0; $attempt < self::SCHEDULE_LOCK_RETRY_ATTEMPTS; ++$attempt ) {
+			$now     = time();
+			$token   = function_exists( 'wp_generate_uuid4' ) ? wp_generate_uuid4() : uniqid( 'dm-schedule-', true );
+			$payload = array(
+				'token'      => $token,
+				'started_at' => $now,
+				'expires_at' => $now + self::SCHEDULE_LOCK_TTL,
+			);
+			$lease   = OptionLeaseStore::acquire( $option_name, $payload, self::SCHEDULE_LOCK_TTL, $now, null, true );
+
+			if ( $lease['acquired'] ) {
+				return array(
+					'option_name' => $option_name,
+					'token'       => $token,
+				);
+			}
+
+			if ( $attempt + 1 < self::SCHEDULE_LOCK_RETRY_ATTEMPTS ) {
+				usleep( self::SCHEDULE_LOCK_RETRY_DELAY_US );
+			}
+		}
+
+		return self::error(
+			'schedule_lock_timeout',
+			'Another request is updating this schedule; retry shortly.',
+			array( 'status' => 409 )
+		);
+	}
+
+	/**
 	 * Unschedule all Action Scheduler actions matching (hook, args, group).
 	 *
 	 * @param string $hook  Hook name.
@@ -424,6 +504,31 @@ class RecurringScheduler {
 	 * @return object|null ActionScheduler_Action-like object, or null.
 	 */
 	private static function getPendingAction( string $hook, array $args, string $group ): ?object {
+		return self::getActionByStatuses( $hook, $args, $group, array( 'pending' ) );
+	}
+
+	/**
+	 * Find the next pending or running action that owns a schedule slot.
+	 *
+	 * @param string $hook  Hook name.
+	 * @param array  $args  Action args.
+	 * @param string $group AS group.
+	 * @return object|null ActionScheduler_Action-like object, or null.
+	 */
+	private static function getCoveringAction( string $hook, array $args, string $group ): ?object {
+		return self::getActionByStatuses( $hook, $args, $group, array( 'pending', 'in-progress' ) );
+	}
+
+	/**
+	 * Find the next action matching one of the supplied statuses.
+	 *
+	 * @param string   $hook     Hook name.
+	 * @param array    $args     Action args.
+	 * @param string   $group    AS group.
+	 * @param string[] $statuses Action Scheduler statuses in priority order.
+	 * @return object|null ActionScheduler_Action-like object, or null.
+	 */
+	private static function getActionByStatuses( string $hook, array $args, string $group, array $statuses ): ?object {
 		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
 			return null;
 		}
@@ -432,21 +537,27 @@ class RecurringScheduler {
 			return null;
 		}
 
-		$actions = as_get_scheduled_actions(
-			array(
-				'hook'     => $hook,
-				'args'     => $args,
-				'group'    => $group,
-				'status'   => 'pending',
-				'orderby'  => 'date',
-				'order'    => 'ASC',
-				'per_page' => 1,
-			),
-			'OBJECT'
-		);
+		foreach ( $statuses as $status ) {
+			$actions = as_get_scheduled_actions(
+				array(
+					'hook'     => $hook,
+					'args'     => $args,
+					'group'    => $group,
+					'status'   => $status,
+					'orderby'  => 'date',
+					'order'    => 'ASC',
+					'per_page' => 1,
+				),
+				'OBJECT'
+			);
 
-		$action = reset( $actions );
-		return is_object( $action ) ? $action : null;
+			$action = reset( $actions );
+			if ( is_object( $action ) ) {
+				return $action;
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -495,7 +606,7 @@ class RecurringScheduler {
 	 * @return bool True when the existing pending action already matches.
 	 */
 	private static function hasMatchingSingleAction( string $hook, array $args, string $group, int $timestamp ): bool {
-		$action = self::getPendingAction( $hook, $args, $group );
+		$action = self::getCoveringAction( $hook, $args, $group );
 		if ( ! $action || ! method_exists( $action, 'get_schedule' ) ) {
 			return false;
 		}
@@ -518,7 +629,7 @@ class RecurringScheduler {
 	 * @return bool True when the existing pending action already matches.
 	 */
 	private static function hasMatchingRecurringAction( string $hook, array $args, string $group, int $interval_seconds ): bool {
-		$action = self::getPendingAction( $hook, $args, $group );
+		$action = self::getCoveringAction( $hook, $args, $group );
 		if ( ! $action || ! method_exists( $action, 'get_schedule' ) ) {
 			return false;
 		}
@@ -544,7 +655,7 @@ class RecurringScheduler {
 	 * @return bool True when the existing pending action already matches.
 	 */
 	private static function hasMatchingCronAction( string $hook, array $args, string $group, string $cron_expression ): bool {
-		$action = self::getPendingAction( $hook, $args, $group );
+		$action = self::getCoveringAction( $hook, $args, $group );
 		if ( ! $action || ! method_exists( $action, 'get_schedule' ) ) {
 			return false;
 		}

--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -53,6 +53,7 @@ class RecurringScheduler {
 	public const MAX_DISTRIBUTION_WINDOW_SECONDS = 86400;
 
 	private const SCHEDULE_LOCK_PREFIX         = 'datamachine_schedule_lock_';
+	private const SCHEDULE_GENERATION_PREFIX   = 'datamachine_schedule_generation_';
 	private const SCHEDULE_LOCK_TTL            = 30;
 	private const SCHEDULE_LOCK_RETRY_ATTEMPTS = 5;
 	private const SCHEDULE_LOCK_RETRY_DELAY_US = 25000;
@@ -123,7 +124,7 @@ class RecurringScheduler {
 		}
 
 		try {
-			return self::ensureScheduleUnlocked( $hook, $args, $interval, $options, $enabled );
+			return self::ensureScheduleUnlocked( $hook, $args, $interval, $options, $enabled, $lock );
 		} finally {
 			OptionLeaseStore::release( $lock['option_name'], $lock['token'] );
 		}
@@ -137,6 +138,7 @@ class RecurringScheduler {
 	 * @param string|null $interval Requested interval.
 	 * @param array       $options  Scheduling options.
 	 * @param bool        $enabled  Whether the schedule is enabled.
+	 * @param array       $lock     Owned schedule lease.
 	 * @return array|\WP_Error Schedule metadata or an error.
 	 */
 	private static function ensureScheduleUnlocked(
@@ -144,13 +146,21 @@ class RecurringScheduler {
 		array $args,
 		?string $interval,
 		array $options,
-		bool $enabled
+		bool $enabled,
+		array $lock
 	) {
 		$group = $options['group'] ?? self::GROUP;
 
 		// Disabled / manual / null → unschedule and return.
 		if ( ! $enabled || null === $interval || 'manual' === $interval ) {
-			self::unschedule( $hook, $args, $group );
+			$lock = self::beginScheduleMutation( $lock );
+			if ( is_wp_error( $lock ) ) {
+				return $lock;
+			}
+			$unscheduled = self::mutateUnschedule( $lock, $hook, $args, $group );
+			if ( is_wp_error( $unscheduled ) ) {
+				return $unscheduled;
+			}
 			return array(
 				'interval'  => 'manual',
 				'scheduled' => false,
@@ -198,15 +208,26 @@ class RecurringScheduler {
 				);
 			}
 
-			self::unschedule( $hook, $args, $group );
+			$lock = self::beginScheduleMutation( $lock );
+			if ( is_wp_error( $lock ) ) {
+				return $lock;
+			}
+			$unscheduled = self::mutateUnschedule( $lock, $hook, $args, $group );
+			if ( is_wp_error( $unscheduled ) ) {
+				return $unscheduled;
+			}
 
-			as_schedule_single_action( $timestamp, $hook, $args, $group );
+			$action_id = self::mutateScheduleSingle( $lock, (int) $timestamp, $hook, $args, $group );
+			if ( is_wp_error( $action_id ) ) {
+				return $action_id;
+			}
 
 			return array(
 				'interval'       => 'one_time',
 				'scheduled'      => true,
 				'timestamp'      => $timestamp,
 				'scheduled_time' => wp_date( 'c', $timestamp ),
+				'action_id'      => $action_id,
 			);
 		}
 
@@ -220,12 +241,12 @@ class RecurringScheduler {
 					array( 'status' => 400 )
 				);
 			}
-			return self::scheduleCron( $hook, $args, $cron_expression, $group, $options );
+			return self::scheduleCron( $hook, $args, $cron_expression, $group, $options, $lock );
 		}
 
 		// Auto-detect cron expression passed as the interval value.
 		if ( self::looksLikeCronExpression( $interval ) ) {
-			return self::scheduleCron( $hook, $args, $interval, $group, $options );
+			return self::scheduleCron( $hook, $args, $interval, $group, $options, $lock );
 		}
 
 		// Recurring by interval key (with alias resolution).
@@ -290,8 +311,18 @@ class RecurringScheduler {
 			// ONE matching pending chain for this signature, collapse them to a
 			// single chain now instead of preserving the duplicates.
 			if ( self::countMatchingPendingActions( $hook, $args, $group ) > 1 ) {
-				self::unschedule( $hook, $args, $group );
-				as_schedule_recurring_action( $first_run_time, $interval_seconds, $hook, $args, $group, $unique );
+				$lock = self::beginScheduleMutation( $lock );
+				if ( is_wp_error( $lock ) ) {
+					return $lock;
+				}
+				$unscheduled = self::mutateUnschedule( $lock, $hook, $args, $group );
+				if ( is_wp_error( $unscheduled ) ) {
+					return $unscheduled;
+				}
+				$scheduled = self::mutateScheduleRecurring( $lock, $first_run_time, (int) $interval_seconds, $hook, $args, $group, $unique );
+				if ( is_wp_error( $scheduled ) ) {
+					return $scheduled;
+				}
 
 				if ( ! self::isScheduled( $hook, $args, $group ) ) {
 					return self::error(
@@ -319,13 +350,19 @@ class RecurringScheduler {
 			);
 		}
 
-		if ( self::getPendingAction( $hook, $args, $group ) ) {
-			self::unschedule( $hook, $args, $group );
+		$lock = self::beginScheduleMutation( $lock );
+		if ( is_wp_error( $lock ) ) {
+			return $lock;
+		}
+		$unscheduled = self::mutateUnschedule( $lock, $hook, $args, $group );
+		if ( is_wp_error( $unscheduled ) ) {
+			return $unscheduled;
 		}
 
-		// A reconciliation can race another request during activation, upgrades,
-		// or cron. Let Action Scheduler atomically preserve the first chain.
-		as_schedule_recurring_action( $first_run_time, $interval_seconds, $hook, $args, $group, $unique );
+		$scheduled = self::mutateScheduleRecurring( $lock, $first_run_time, (int) $interval_seconds, $hook, $args, $group, $unique );
+		if ( is_wp_error( $scheduled ) ) {
+			return $scheduled;
+		}
 
 		// Verify persistence. AS can silently drop actions when its tables
 		// aren't ready (e.g. CLI context during plugin activation).
@@ -346,23 +383,75 @@ class RecurringScheduler {
 	}
 
 	/**
-	 * Acquire the option-row lease for one hook/args/group signature.
+	 * Register the fetched-action generation fence.
+	 */
+	public static function registerGenerationFence(): void {
+		add_filter( 'action_scheduler_stored_action_instance', array( self::class, 'fenceStoredAction' ), 10, 6 );
+	}
+
+	/**
+	 * Wrap a managed fetched recurrence with its current generation snapshot.
 	 *
-	 * Argument-bearing actions cannot use Action Scheduler's native uniqueness,
-	 * because it is scoped to hook and group. This lease serializes the complete
-	 * read/unschedule/create sequence without coupling independent argument sets.
+	 * @param object $action   Stored Action Scheduler action.
+	 * @param string $hook     Action hook.
+	 * @param array  $args     Action arguments.
+	 * @param object $schedule Action Scheduler schedule.
+	 * @param string $group    Action group.
+	 * @param int    $priority Action priority.
+	 * @return object Original or generation-fenced action.
+	 */
+	public static function fenceStoredAction( $action, string $hook, array $args, $schedule, string $group, int $priority ) {
+		if ( $action instanceof GenerationFencedAction
+			|| ! $schedule instanceof \ActionScheduler_Schedule
+			|| ! $schedule->is_recurring()
+		) {
+			return $action;
+		}
+
+		$options = self::scheduleOptionNames( $hook, $args, $group );
+		if ( is_wp_error( $options ) ) {
+			return $action;
+		}
+
+		$generation = get_option( $options['generation_option'], false );
+		if ( false === $generation && self::GROUP === $group ) {
+			$generation = wp_generate_uuid4();
+			if ( ! add_option( $options['generation_option'], $generation, '', false ) ) {
+				$generation = get_option( $options['generation_option'], false );
+			}
+		}
+
+		if ( ! is_string( $generation ) || '' === $generation ) {
+			return $action;
+		}
+
+		$fenced = new GenerationFencedAction( $hook, $args, $schedule, $group, $options['generation_option'], $generation );
+		$fenced->set_priority( $priority );
+		return $fenced;
+	}
+
+	/**
+	 * Acquire the option-row lease for one hook/args/group signature.
 	 *
 	 * @param string $hook  Action Scheduler hook.
 	 * @param array  $args  Action arguments.
 	 * @param string $group Action Scheduler group.
-	 * @return array{option_name:string,token:string}|\WP_Error
+	 * @return array{option_name:string,generation_option:string,token:string}|\WP_Error
 	 */
 	private static function acquireScheduleLock( string $hook, array $args, string $group ) {
-		$signature = wp_json_encode( array( $hook, $args, $group ) );
-		if ( false === $signature ) {
-			return self::error( 'invalid_schedule_signature', 'Schedule arguments must be JSON-serializable.' );
+		$options = self::scheduleOptionNames( $hook, $args, $group );
+		if ( is_wp_error( $options ) ) {
+			return $options;
 		}
-		$option_name = self::SCHEDULE_LOCK_PREFIX . md5( $signature );
+
+		$generation = get_option( $options['generation_option'], false );
+		if ( false === $generation ) {
+			$initial_generation = wp_generate_uuid4();
+			if ( ! add_option( $options['generation_option'], $initial_generation, '', false ) ) {
+				$generation = get_option( $options['generation_option'], false );
+			}
+		}
+		$option_name = $options['lock_option'];
 
 		for ( $attempt = 0; $attempt < self::SCHEDULE_LOCK_RETRY_ATTEMPTS; ++$attempt ) {
 			$now     = time();
@@ -376,8 +465,9 @@ class RecurringScheduler {
 
 			if ( $lease['acquired'] ) {
 				return array(
-					'option_name' => $option_name,
-					'token'       => $token,
+					'option_name'       => $option_name,
+					'generation_option' => $options['generation_option'],
+					'token'             => $token,
 				);
 			}
 
@@ -389,8 +479,121 @@ class RecurringScheduler {
 		return self::error(
 			'schedule_lock_timeout',
 			'Another request is updating this schedule; retry shortly.',
-			array( 'status' => 409 )
+			array(
+				'status'         => 409,
+				'retryable'      => true,
+				'retry_after_ms' => ( self::SCHEDULE_LOCK_RETRY_ATTEMPTS - 1 ) * (int) ( self::SCHEDULE_LOCK_RETRY_DELAY_US / 1000 ),
+			)
 		);
+	}
+
+	/**
+	 * Resolve stable option names for one schedule signature.
+	 *
+	 * @return array{lock_option:string,generation_option:string}|\WP_Error
+	 */
+	private static function scheduleOptionNames( string $hook, array $args, string $group ) {
+		$signature = wp_json_encode( array( $hook, $args, $group ) );
+		if ( false === $signature ) {
+			return self::error( 'invalid_schedule_signature', 'Schedule arguments must be JSON-serializable.', array( 'status' => 400 ) );
+		}
+
+		$hash = md5( $signature );
+		return array(
+			'lock_option'       => self::SCHEDULE_LOCK_PREFIX . $hash,
+			'generation_option' => self::SCHEDULE_GENERATION_PREFIX . $hash,
+		);
+	}
+
+	/**
+	 * Advance the persisted generation before the first schedule mutation.
+	 *
+	 * @param array $lock Owned lease, updated with the mutation generation.
+	 * @return array|\WP_Error Updated lease or ownership error.
+	 */
+	private static function beginScheduleMutation( array $lock ) {
+		if ( ! self::refreshScheduleLock( $lock ) ) {
+			return self::lockLostError();
+		}
+
+		$generation = wp_generate_uuid4();
+		update_option( $lock['generation_option'], $generation, false );
+		$lock['generation'] = $generation;
+
+		return self::refreshScheduleLock( $lock ) && self::isMutationGenerationCurrent( $lock )
+			? $lock
+			: self::lockLostError();
+	}
+
+	/**
+	 * Refresh and verify ownership immediately before a destructive mutation.
+	 */
+	private static function assertMutationOwner( array $lock ): bool {
+		return self::refreshScheduleLock( $lock ) && self::isMutationGenerationCurrent( $lock );
+	}
+
+	private static function refreshScheduleLock( array $lock ): bool {
+		return OptionLeaseStore::refresh( $lock['option_name'], $lock['token'], self::SCHEDULE_LOCK_TTL );
+	}
+
+	private static function isMutationGenerationCurrent( array $lock ): bool {
+		$current = get_option( $lock['generation_option'], '' );
+		return isset( $lock['generation'] ) && is_string( $current ) && hash_equals( (string) $lock['generation'], $current );
+	}
+
+	private static function lockLostError(): \WP_Error {
+		return self::error(
+			'schedule_lock_lost',
+			'Schedule ownership changed during reconciliation; retry without mutating the existing schedule.',
+			array(
+				'status'         => 409,
+				'retryable'      => true,
+				'retry_after_ms' => 100,
+			)
+		);
+	}
+
+	/**
+	 * Unschedule pending actions only while the mutation generation is owned.
+	 *
+	 * @return true|\WP_Error
+	 */
+	private static function mutateUnschedule( array $lock, string $hook, array $args, string $group ) {
+		if ( ! self::assertMutationOwner( $lock ) ) {
+			return self::lockLostError();
+		}
+		self::unschedule( $hook, $args, $group );
+		return true;
+	}
+
+	/**
+	 * @return int|\WP_Error
+	 */
+	private static function mutateScheduleSingle( array $lock, int $timestamp, string $hook, array $args, string $group ) {
+		if ( ! self::assertMutationOwner( $lock ) ) {
+			return self::lockLostError();
+		}
+		return as_schedule_single_action( $timestamp, $hook, $args, $group );
+	}
+
+	/**
+	 * @return int|\WP_Error
+	 */
+	private static function mutateScheduleRecurring( array $lock, int $timestamp, int $interval, string $hook, array $args, string $group, bool $unique ) {
+		if ( ! self::assertMutationOwner( $lock ) ) {
+			return self::lockLostError();
+		}
+		return as_schedule_recurring_action( $timestamp, $interval, $hook, $args, $group, $unique );
+	}
+
+	/**
+	 * @return int|\WP_Error
+	 */
+	private static function mutateScheduleCron( array $lock, int $timestamp, string $expression, string $hook, array $args, string $group, bool $unique ) {
+		if ( ! self::assertMutationOwner( $lock ) ) {
+			return self::lockLostError();
+		}
+		return as_schedule_cron_action( $timestamp, $expression, $hook, $args, $group, $unique );
 	}
 
 	/**
@@ -401,7 +604,7 @@ class RecurringScheduler {
 	 * @param string $group AS group.
 	 * @return void
 	 */
-	public static function unschedule( string $hook, array $args, string $group = self::GROUP ): void {
+	private static function unschedule( string $hook, array $args, string $group = self::GROUP ): void {
 		if ( function_exists( 'as_unschedule_all_actions' ) ) {
 			as_unschedule_all_actions( $hook, $args, $group );
 		}
@@ -487,7 +690,7 @@ class RecurringScheduler {
 	}
 
 	/**
-	 * Create a WP_Error with optional data without tripping scoped PHPStan stubs.
+	 * Create a WP_Error with status and retry metadata when supplied.
 	 *
 	 * @param string $code    Error code.
 	 * @param string $message Error message.
@@ -495,8 +698,7 @@ class RecurringScheduler {
 	 * @return \WP_Error Error object.
 	 */
 	private static function error( string $code, string $message, array $data = array() ): \WP_Error {
-		unset( $data );
-		return new \WP_Error( $code, $message );
+		return new \WP_Error( $code, $message, $data );
 	}
 
 	/**
@@ -842,9 +1044,10 @@ class RecurringScheduler {
 	 * @param string $cron_expression Cron expression.
 	 * @param string $group           AS group.
 	 * @param array  $options         Scheduling options.
+	 * @param array  $lock            Owned schedule lease.
 	 * @return array{interval:'cron',scheduled:true,cron_expression:string,first_run?:string|null,action_id?:int,preserved?:bool}|\WP_Error
 	 */
-	private static function scheduleCron( string $hook, array $args, string $cron_expression, string $group, array $options = array() ) {
+	private static function scheduleCron( string $hook, array $args, string $cron_expression, string $group, array $options, array $lock ) {
 		$force_reschedule = ! empty( $options['force_reschedule'] );
 		if ( ! self::isValidCronExpression( $cron_expression ) ) {
 			return self::error(
@@ -881,8 +1084,18 @@ class RecurringScheduler {
 			// Self-healing dedup: collapse an already-duplicated signature to a
 			// single chain instead of preserving the duplicates.
 			if ( self::countMatchingPendingActions( $hook, $args, $group ) > 1 ) {
-				self::unschedule( $hook, $args, $group );
-				$action_id = as_schedule_cron_action( self::cronStartTimestamp( $options ), $cron_expression, $hook, $args, $group, $unique );
+				$lock = self::beginScheduleMutation( $lock );
+				if ( is_wp_error( $lock ) ) {
+					return $lock;
+				}
+				$unscheduled = self::mutateUnschedule( $lock, $hook, $args, $group );
+				if ( is_wp_error( $unscheduled ) ) {
+					return $unscheduled;
+				}
+				$action_id = self::mutateScheduleCron( $lock, self::cronStartTimestamp( $options ), $cron_expression, $hook, $args, $group, $unique );
+				if ( is_wp_error( $action_id ) ) {
+					return $action_id;
+				}
 
 				if ( ! self::isScheduled( $hook, $args, $group ) ) {
 					return self::error(
@@ -909,11 +1122,19 @@ class RecurringScheduler {
 			);
 		}
 
-		if ( self::getPendingAction( $hook, $args, $group ) ) {
-			self::unschedule( $hook, $args, $group );
+		$lock = self::beginScheduleMutation( $lock );
+		if ( is_wp_error( $lock ) ) {
+			return $lock;
+		}
+		$unscheduled = self::mutateUnschedule( $lock, $hook, $args, $group );
+		if ( is_wp_error( $unscheduled ) ) {
+			return $unscheduled;
 		}
 
-		$action_id = as_schedule_cron_action( self::cronStartTimestamp( $options ), $cron_expression, $hook, $args, $group, $unique );
+		$action_id = self::mutateScheduleCron( $lock, self::cronStartTimestamp( $options ), $cron_expression, $hook, $args, $group, $unique );
+		if ( is_wp_error( $action_id ) ) {
+			return $action_id;
+		}
 
 		if ( ! self::isScheduled( $hook, $args, $group ) ) {
 			return self::error(

--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -974,7 +974,7 @@ class RecurringScheduler {
 	 * @return bool True if a pending action exists.
 	 */
 	public static function isScheduled( string $hook, array $args, string $group = self::GROUP ): bool {
-		return self::isExactScheduled( $hook, $args, $group ) || self::hasLogicalCoverage( $hook, $args, $group );
+		return self::isExactScheduled( $hook, $args, $group );
 	}
 
 	private static function isExactScheduled( string $hook, array $args, string $group ): bool {

--- a/inc/Engine/Tasks/ScheduleActionIdentity.php
+++ b/inc/Engine/Tasks/ScheduleActionIdentity.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Generation-aware Action Scheduler identity helpers.
+ *
+ * @package DataMachine\Engine\Tasks
+ */
+
+namespace DataMachine\Engine\Tasks;
+
+defined( 'ABSPATH' ) || exit;
+
+final class ScheduleActionIdentity {
+	private const GENERATION_KEY    = '_datamachine_schedule_generation';
+	private const LOGICAL_COUNT_KEY = '_datamachine_signature_argument_count';
+
+	public static function withGeneration( array $args, string $generation, int $argument_index ): array {
+		$logical_count = count( $args );
+		$target_count  = max( $logical_count, $argument_index );
+		for ( $argument_count = $logical_count; $argument_count < $target_count; ++$argument_count ) {
+			$args[] = null;
+		}
+		$args[] = array(
+			self::GENERATION_KEY    => $generation,
+			self::LOGICAL_COUNT_KEY => $logical_count,
+		);
+
+		return $args;
+	}
+
+	public static function generationFromArgument( $argument ): ?string {
+		if ( ! is_array( $argument ) || empty( $argument[ self::GENERATION_KEY ] ) || ! is_string( $argument[ self::GENERATION_KEY ] ) ) {
+			return null;
+		}
+
+		return $argument[ self::GENERATION_KEY ];
+	}
+
+	public static function generationFromArgs( array $args ): ?string {
+		return empty( $args ) ? null : self::generationFromArgument( end( $args ) );
+	}
+
+	public static function logicalArgs( array $args ): array {
+		if ( empty( $args ) ) {
+			return $args;
+		}
+
+		$marker = end( $args );
+		if ( null === self::generationFromArgument( $marker ) ) {
+			return $args;
+		}
+
+		$count = isset( $marker[ self::LOGICAL_COUNT_KEY ] ) ? (int) $marker[ self::LOGICAL_COUNT_KEY ] : count( $args ) - 1;
+		return array_slice( $args, 0, max( 0, $count ) );
+	}
+
+	public static function hasCoverage( string $hook, array $args, string $group, bool $generated_only = false ): bool {
+		foreach ( array( 'pending', 'in-progress' ) as $status ) {
+			foreach ( self::actions( $hook, $group, $status ) as $action ) {
+				if ( ! is_object( $action ) || ! method_exists( $action, 'get_args' ) ) {
+					continue;
+				}
+				$action_args = $action->get_args();
+				if ( self::logicalArgs( $action_args ) === $args
+					&& ( ! $generated_only || null !== self::generationFromArgs( $action_args ) ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @return int|false
+	 */
+	public static function nextTimestamp( string $hook, array $args, string $group ) {
+		foreach ( self::actions( $hook, $group, 'pending', true ) as $action ) {
+			if ( ! is_object( $action ) || ! method_exists( $action, 'get_args' ) || self::logicalArgs( $action->get_args() ) !== $args ) {
+				continue;
+			}
+			$date = $action->get_schedule()->get_date();
+			return $date ? $date->getTimestamp() : false;
+		}
+
+		return false;
+	}
+
+	public static function countPending( string $hook, array $args, string $group ): int {
+		$count = 0;
+		foreach ( self::actions( $hook, $group, 'pending' ) as $action ) {
+			if ( is_object( $action ) && method_exists( $action, 'get_args' ) && self::logicalArgs( $action->get_args() ) === $args ) {
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+
+	public static function exactAction( string $hook, array $args, string $group, array $statuses ): ?object {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+			return null;
+		}
+
+		foreach ( $statuses as $status ) {
+			$actions = as_get_scheduled_actions(
+				array(
+					'hook'     => $hook,
+					'args'     => $args,
+					'group'    => $group,
+					'status'   => $status,
+					'orderby'  => 'date',
+					'order'    => 'ASC',
+					'per_page' => 1,
+				),
+				'OBJECT'
+			);
+
+			$action = reset( $actions );
+			if ( is_object( $action ) ) {
+				return $action;
+			}
+		}
+
+		return null;
+	}
+
+	public static function countExactPending( string $hook, array $args, string $group ): int {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+			return 0;
+		}
+
+		$actions = as_get_scheduled_actions(
+			array(
+				'hook'     => $hook,
+				'args'     => $args,
+				'group'    => $group,
+				'status'   => 'pending',
+				'per_page' => 100,
+			),
+			'ids'
+		);
+
+		return is_array( $actions ) ? count( $actions ) : 0;
+	}
+
+	public static function cancelExact( int $action_id ): bool {
+		if ( $action_id <= 0 || ! class_exists( '\\ActionScheduler_Store' ) ) {
+			return false;
+		}
+
+		try {
+			$store = \ActionScheduler_Store::instance();
+			$store->cancel_action( $action_id );
+			return \ActionScheduler_Store::STATUS_CANCELED === $store->get_status( $action_id );
+		} catch ( \Throwable $throwable ) {
+			unset( $throwable );
+			return false;
+		}
+	}
+
+	/**
+	 * Cancel pending actions matching one logical identity by exact action ID.
+	 *
+	 * @return int Zero on success, or the exact action ID that failed cleanup.
+	 */
+	public static function cancelPending( string $hook, array $args, string $group ): int {
+		foreach ( self::actions( $hook, $group, 'pending' ) as $action_id => $action ) {
+			if ( ! is_object( $action ) || ! method_exists( $action, 'get_args' ) || self::logicalArgs( $action->get_args() ) !== $args ) {
+				continue;
+			}
+			if ( ! self::cancelExact( (int) $action_id ) ) {
+				return (int) $action_id;
+			}
+		}
+
+		return 0;
+	}
+
+	private static function actions( string $hook, string $group, string $status, bool $ordered = false ): array {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+			return array();
+		}
+
+		$query = array(
+			'hook'     => $hook,
+			'group'    => $group,
+			'status'   => $status,
+			'per_page' => -1,
+		);
+		if ( $ordered ) {
+			$query['orderby'] = 'date';
+			$query['order']   = 'ASC';
+		}
+
+		$actions = as_get_scheduled_actions( $query, 'OBJECT' );
+		return is_array( $actions ) ? $actions : array();
+	}
+}

--- a/tests/Unit/Abilities/ScheduleMutationFailureTest.php
+++ b/tests/Unit/Abilities/ScheduleMutationFailureTest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Schedule mutation failure integration tests.
+ *
+ * @package DataMachine\Tests\Unit\Abilities
+ */
+
+namespace DataMachine\Tests\Unit\Abilities;
+
+use DataMachine\Abilities\Flow\CreateFlowAbility;
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Engine\Tasks\RecurringScheduler;
+use ReflectionMethod;
+use WP_UnitTestCase;
+
+class ScheduleMutationFailureTest extends WP_UnitTestCase {
+
+	private const FLOW_HOOK = 'datamachine_run_flow_now';
+
+	private Flows $flows;
+	private Pipelines $pipelines;
+	private int $pipeline_id;
+	private int $flow_id;
+	private array $managed_flow_ids = array();
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$this->flows       = new Flows();
+		$this->pipelines   = new Pipelines();
+		$this->pipeline_id = (int) $this->pipelines->create_pipeline(
+			array(
+				'pipeline_name'   => 'Schedule mutation failure fixture',
+				'pipeline_config' => array(),
+			)
+		);
+		$this->flow_id     = (int) $this->flows->create_flow(
+			array(
+				'pipeline_id'       => $this->pipeline_id,
+				'flow_name'         => 'Schedule mutation failure flow',
+				'flow_config'       => array(),
+				'scheduling_config' => array(
+					'enabled'  => true,
+					'interval' => 'hourly',
+				),
+			)
+		);
+		$this->managed_flow_ids[] = $this->flow_id;
+
+		$this->assertNotInstanceOf(
+			\WP_Error::class,
+			RecurringScheduler::ensureSchedule( self::FLOW_HOOK, array( $this->flow_id ), 'hourly' )
+		);
+	}
+
+	public function tear_down(): void {
+		foreach ( $this->managed_flow_ids as $flow_id ) {
+			$this->releaseScheduleLock( $flow_id );
+			RecurringScheduler::ensureSchedule( self::FLOW_HOOK, array( $flow_id ), 'manual' );
+		}
+
+		parent::tear_down();
+	}
+
+	public function test_delete_flow_keeps_record_when_recurrence_cannot_be_fenced(): void {
+		$this->holdScheduleLock( $this->flow_id );
+
+		$result = wp_get_ability( 'datamachine/delete-flow' )->execute( array( 'flow_id' => $this->flow_id ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'schedule_lock_timeout', $result['error_code'] );
+		$this->assertTrue( $result['retryable'] );
+		$this->assertNotNull( $this->flows->get_flow( $this->flow_id ) );
+		$this->assertNotFalse( as_next_scheduled_action( self::FLOW_HOOK, array( $this->flow_id ), RecurringScheduler::GROUP ) );
+	}
+
+	public function test_pause_flow_keeps_enabled_state_when_recurrence_cannot_be_fenced(): void {
+		$this->holdScheduleLock( $this->flow_id );
+
+		$result = wp_get_ability( 'datamachine/pause-flow' )->execute( array( 'flow_id' => $this->flow_id ) );
+		$flow   = $this->flows->get_flow( $this->flow_id );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 1, $result['errors'] );
+		$this->assertSame( 'pause_error', $result['flows'][0]['status'] );
+		$this->assertTrue( $flow['scheduling_config']['enabled'] );
+		$this->assertNotFalse( as_next_scheduled_action( self::FLOW_HOOK, array( $this->flow_id ), RecurringScheduler::GROUP ) );
+	}
+
+	public function test_delete_pipeline_keeps_database_records_when_any_recurrence_cannot_be_fenced(): void {
+		$blocked_flow_id          = (int) $this->flows->create_flow(
+			array(
+				'pipeline_id'       => $this->pipeline_id,
+				'flow_name'         => 'Blocked pipeline deletion flow',
+				'flow_config'       => array(),
+				'scheduling_config' => array(
+					'enabled'  => true,
+					'interval' => 'hourly',
+				),
+			)
+		);
+		$this->managed_flow_ids[] = $blocked_flow_id;
+		RecurringScheduler::ensureSchedule( self::FLOW_HOOK, array( $blocked_flow_id ), 'hourly' );
+		$this->holdScheduleLock( $blocked_flow_id );
+
+		$result = wp_get_ability( 'datamachine/delete-pipeline' )->execute( array( 'pipeline_id' => $this->pipeline_id ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'schedule_lock_timeout', $result['error_code'] );
+		$this->assertTrue( $result['schedule_reconciliation'][ $this->flow_id ]['success'] );
+		$this->assertFalse( $result['schedule_reconciliation'][ $blocked_flow_id ]['success'] );
+		$this->assertNotNull( $this->pipelines->get_pipeline( $this->pipeline_id ) );
+		$this->assertNotNull( $this->flows->get_flow( $this->flow_id ) );
+		$this->assertNotNull( $this->flows->get_flow( $blocked_flow_id ) );
+		$this->assertNotFalse( as_next_scheduled_action( self::FLOW_HOOK, array( $this->flow_id ), RecurringScheduler::GROUP ) );
+		$this->assertNotFalse( as_next_scheduled_action( self::FLOW_HOOK, array( $blocked_flow_id ), RecurringScheduler::GROUP ) );
+	}
+
+	public function test_creation_rollback_records_failed_schedule_compensation(): void {
+		$ability = new CreateFlowAbility();
+		$scope   = ( new ReflectionMethod( $ability, 'beginCreationTransactionScope' ) )->invoke( $ability );
+		$flow_id = (int) $this->flows->create_flow(
+			array(
+				'pipeline_id'       => $this->pipeline_id,
+				'flow_name'         => 'Failed rollback fixture',
+				'flow_config'       => array(),
+				'scheduling_config' => array(
+					'enabled'  => true,
+					'interval' => 'hourly',
+				),
+			)
+		);
+		$this->managed_flow_ids[] = $flow_id;
+		RecurringScheduler::ensureSchedule( self::FLOW_HOOK, array( $flow_id ), 'hourly' );
+		$this->holdScheduleLock( $flow_id );
+
+		$result = ( new ReflectionMethod( $ability, 'rollbackCreation' ) )->invoke( $ability, $scope, $flow_id, 'Forced rollback' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'schedule_lock_timeout', $result['schedule_cleanup']['error_code'] );
+		$this->assertTrue( $result['schedule_cleanup']['retryable'] );
+		$this->assertNull( $this->flows->get_flow( $flow_id ) );
+	}
+
+	private function holdScheduleLock( int $flow_id ): void {
+		$lock_option = $this->scheduleOptionNames( $flow_id )['lock'];
+		delete_option( $lock_option );
+		add_option(
+			$lock_option,
+			array(
+				'token'      => 'competing-test-owner',
+				'started_at' => time(),
+				'expires_at' => time() + 300,
+			),
+			'',
+			false
+		);
+	}
+
+	private function releaseScheduleLock( int $flow_id ): void {
+		delete_option( $this->scheduleOptionNames( $flow_id )['lock'] );
+	}
+
+	/**
+	 * @return array{lock:string,generation:string}
+	 */
+	private function scheduleOptionNames( int $flow_id ): array {
+		$signature = wp_json_encode( array( self::FLOW_HOOK, array( $flow_id ), RecurringScheduler::GROUP ) );
+		$hash      = md5( (string) $signature );
+
+		return array(
+			'lock'       => 'datamachine_schedule_lock_' . $hash,
+			'generation' => 'datamachine_schedule_generation_' . $hash,
+		);
+	}
+}

--- a/tests/Unit/Abilities/ScheduleMutationFailureTest.php
+++ b/tests/Unit/Abilities/ScheduleMutationFailureTest.php
@@ -10,6 +10,7 @@ namespace DataMachine\Tests\Unit\Abilities;
 use DataMachine\Abilities\Flow\CreateFlowAbility;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Engine\Tasks\GenerationFencedAction;
 use DataMachine\Engine\Tasks\RecurringScheduler;
 use ReflectionMethod;
 use WP_UnitTestCase;
@@ -76,6 +77,28 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['retryable'] );
 		$this->assertNotNull( $this->flows->get_flow( $this->flow_id ) );
 		$this->assertNotFalse( as_next_scheduled_action( self::FLOW_HOOK, array( $this->flow_id ), RecurringScheduler::GROUP ) );
+	}
+
+	public function test_actual_action_scheduler_fetched_recurrence_cannot_repeat_after_generation_change(): void {
+		$generation_option = 'datamachine_test_generation_' . wp_generate_uuid4();
+		$generation        = wp_generate_uuid4();
+		add_option( $generation_option, $generation, '', false );
+		$schedule = new \ActionScheduler_IntervalSchedule( new \DateTime( '+1 hour' ), HOUR_IN_SECONDS );
+		$action   = new GenerationFencedAction(
+			self::FLOW_HOOK,
+			array( $this->flow_id ),
+			$schedule,
+			RecurringScheduler::GROUP,
+			$generation_option,
+			$generation
+		);
+
+		$this->assertTrue( $action->get_schedule()->is_recurring() );
+		update_option( $generation_option, wp_generate_uuid4(), false );
+		$this->assertInstanceOf( \ActionScheduler_CanceledSchedule::class, $action->get_schedule() );
+		$this->assertFalse( $action->get_schedule()->is_recurring() );
+
+		delete_option( $generation_option );
 	}
 
 	public function test_pause_flow_keeps_enabled_state_when_recurrence_cannot_be_fenced(): void {

--- a/tests/Unit/Abilities/ScheduleMutationFailureTest.php
+++ b/tests/Unit/Abilities/ScheduleMutationFailureTest.php
@@ -8,12 +8,22 @@
 namespace DataMachine\Tests\Unit\Abilities;
 
 use DataMachine\Abilities\Flow\CreateFlowAbility;
+use DataMachine\Api\Flows\FlowScheduling;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Engine\Tasks\GenerationFencedAction;
 use DataMachine\Engine\Tasks\RecurringScheduler;
 use ReflectionMethod;
 use WP_UnitTestCase;
+
+class GenerationTransitionActionFactory extends \ActionScheduler_ActionFactory {
+	public \Closure $before_store;
+
+	protected function store( \ActionScheduler_Action $action ) {
+		( $this->before_store )();
+		return parent::store( $action );
+	}
+}
 
 class ScheduleMutationFailureTest extends WP_UnitTestCase {
 
@@ -79,24 +89,44 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 		$this->assertNotFalse( as_next_scheduled_action( self::FLOW_HOOK, array( $this->flow_id ), RecurringScheduler::GROUP ) );
 	}
 
-	public function test_actual_action_scheduler_fetched_recurrence_cannot_repeat_after_generation_change(): void {
+	public function test_stale_successor_is_canceled_when_generation_changes_between_repeat_read_and_store(): void {
 		$generation_option = 'datamachine_test_generation_' . wp_generate_uuid4();
 		$generation        = wp_generate_uuid4();
 		add_option( $generation_option, $generation, '', false );
 		$schedule = new \ActionScheduler_IntervalSchedule( new \DateTime( '+1 hour' ), HOUR_IN_SECONDS );
 		$action   = new GenerationFencedAction(
-			self::FLOW_HOOK,
+			'datamachine_test_repeat_race',
 			array( $this->flow_id ),
 			$schedule,
 			RecurringScheduler::GROUP,
 			$generation_option,
 			$generation
 		);
+		RecurringScheduler::captureExecutedRecurrenceGeneration( 123, $action );
 
-		$this->assertTrue( $action->get_schedule()->is_recurring() );
-		update_option( $generation_option, wp_generate_uuid4(), false );
-		$this->assertInstanceOf( \ActionScheduler_CanceledSchedule::class, $action->get_schedule() );
-		$this->assertFalse( $action->get_schedule()->is_recurring() );
+		$factory               = new GenerationTransitionActionFactory();
+		$factory->before_store = static function () use ( $generation_option ): void {
+			update_option( $generation_option, wp_generate_uuid4(), false );
+		};
+		$successor_id          = (int) $factory->repeat( $action );
+
+		$this->assertGreaterThan( 0, $successor_id );
+		$this->assertSame( \ActionScheduler_Store::STATUS_CANCELED, \ActionScheduler_Store::instance()->get_status( $successor_id ) );
+
+		$current_generation    = (string) get_option( $generation_option );
+		$current_action        = new GenerationFencedAction(
+			'datamachine_test_repeat_race',
+			array( $this->flow_id ),
+			$schedule,
+			RecurringScheduler::GROUP,
+			$generation_option,
+			$current_generation
+		);
+		RecurringScheduler::captureExecutedRecurrenceGeneration( 124, $current_action );
+		$factory->before_store = static function (): void {};
+		$current_successor_id  = (int) $factory->repeat( $current_action );
+		$this->assertSame( \ActionScheduler_Store::STATUS_PENDING, \ActionScheduler_Store::instance()->get_status( $current_successor_id ) );
+		\ActionScheduler_Store::instance()->cancel_action( $current_successor_id );
 
 		delete_option( $generation_option );
 	}
@@ -112,6 +142,21 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 		$this->assertSame( 'pause_error', $result['flows'][0]['status'] );
 		$this->assertTrue( $flow['scheduling_config']['enabled'] );
 		$this->assertNotFalse( as_next_scheduled_action( self::FLOW_HOOK, array( $this->flow_id ), RecurringScheduler::GROUP ) );
+	}
+
+	public function test_desired_state_records_reconciliation_drift_after_scheduler_failure(): void {
+		$result = FlowScheduling::handle_scheduling_update(
+			$this->flow_id,
+			array( 'interval' => 'one_time' ),
+			true
+		);
+		$flow = $this->flows->get_flow( $this->flow_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'missing_timestamp', $result->get_error_code() );
+		$this->assertSame( 'one_time', $flow['scheduling_config']['interval'] );
+		$this->assertSame( 'drift', $flow['scheduling_config']['schedule_reconciliation']['status'] );
+		$this->assertSame( 'missing_timestamp', $flow['scheduling_config']['schedule_reconciliation']['error_code'] );
 	}
 
 	public function test_delete_pipeline_keeps_database_records_when_any_recurrence_cannot_be_fenced(): void {
@@ -133,13 +178,13 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 		$result = wp_get_ability( 'datamachine/delete-pipeline' )->execute( array( 'pipeline_id' => $this->pipeline_id ) );
 
 		$this->assertFalse( $result['success'] );
-		$this->assertSame( 'schedule_lock_timeout', $result['error_code'] );
-		$this->assertTrue( $result['schedule_reconciliation'][ $this->flow_id ]['success'] );
-		$this->assertFalse( $result['schedule_reconciliation'][ $blocked_flow_id ]['success'] );
+		$this->assertSame( 'pipeline_flow_deletion_incomplete', $result['error_code'] );
+		$this->assertSame( 1, $result['deleted_flows'] );
+		$this->assertSame( 'schedule_lock_timeout', $result['schedule_failures'][ $blocked_flow_id ]['error_code'] );
 		$this->assertNotNull( $this->pipelines->get_pipeline( $this->pipeline_id ) );
-		$this->assertNotNull( $this->flows->get_flow( $this->flow_id ) );
+		$this->assertNull( $this->flows->get_flow( $this->flow_id ) );
 		$this->assertNotNull( $this->flows->get_flow( $blocked_flow_id ) );
-		$this->assertNotFalse( as_next_scheduled_action( self::FLOW_HOOK, array( $this->flow_id ), RecurringScheduler::GROUP ) );
+		$this->assertFalse( as_next_scheduled_action( self::FLOW_HOOK, array( $this->flow_id ), RecurringScheduler::GROUP ) );
 		$this->assertNotFalse( as_next_scheduled_action( self::FLOW_HOOK, array( $blocked_flow_id ), RecurringScheduler::GROUP ) );
 	}
 

--- a/tests/Unit/Abilities/ScheduleMutationFailureTest.php
+++ b/tests/Unit/Abilities/ScheduleMutationFailureTest.php
@@ -18,10 +18,12 @@ use WP_UnitTestCase;
 
 class GenerationTransitionActionFactory extends \ActionScheduler_ActionFactory {
 	public \Closure $before_store;
+	public int $last_stored_id = 0;
 
 	protected function store( \ActionScheduler_Action $action ) {
-		( $this->before_store )();
-		return parent::store( $action );
+		( $this->before_store )( $action );
+		$this->last_stored_id = (int) parent::store( $action );
+		return $this->last_stored_id;
 	}
 }
 
@@ -64,15 +66,27 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 
 		$this->assertNotInstanceOf(
 			\WP_Error::class,
-			RecurringScheduler::ensureSchedule( self::FLOW_HOOK, array( $this->flow_id ), 'hourly' )
+			RecurringScheduler::ensureSchedule(
+				self::FLOW_HOOK,
+				array( $this->flow_id ),
+				'hourly',
+				array( 'generation_argument_index' => FlowScheduling::GENERATION_ARGUMENT_INDEX )
+			)
 		);
 	}
 
 	public function tear_down(): void {
 		foreach ( $this->managed_flow_ids as $flow_id ) {
 			$this->releaseScheduleLock( $flow_id );
-			RecurringScheduler::ensureSchedule( self::FLOW_HOOK, array( $flow_id ), 'manual' );
+			RecurringScheduler::ensureSchedule(
+				self::FLOW_HOOK,
+				array( $flow_id ),
+				'manual',
+				array( 'generation_argument_index' => FlowScheduling::GENERATION_ARGUMENT_INDEX )
+			);
+			$this->flows->delete_flow( $flow_id );
 		}
+		$this->pipelines->delete_pipeline( $this->pipeline_id );
 
 		parent::tear_down();
 	}
@@ -86,7 +100,7 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 		$this->assertSame( 'schedule_lock_timeout', $result['error_code'] );
 		$this->assertTrue( $result['retryable'] );
 		$this->assertNotNull( $this->flows->get_flow( $this->flow_id ) );
-		$this->assertNotFalse( as_next_scheduled_action( self::FLOW_HOOK, array( $this->flow_id ), RecurringScheduler::GROUP ) );
+		$this->assertTrue( RecurringScheduler::hasLogicalCoverage( self::FLOW_HOOK, array( $this->flow_id ) ) );
 	}
 
 	public function test_stale_successor_is_canceled_when_generation_changes_between_repeat_read_and_store(): void {
@@ -94,9 +108,17 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 		$generation        = wp_generate_uuid4();
 		add_option( $generation_option, $generation, '', false );
 		$schedule = new \ActionScheduler_IntervalSchedule( new \DateTime( '+1 hour' ), HOUR_IN_SECONDS );
-		$action   = new GenerationFencedAction(
+		$generated_args = array(
+			$this->flow_id,
+			null,
+			array(
+				'_datamachine_schedule_generation'      => $generation,
+				'_datamachine_signature_argument_count' => 1,
+			),
+		);
+		$action = new GenerationFencedAction(
 			'datamachine_test_repeat_race',
-			array( $this->flow_id ),
+			$generated_args,
 			$schedule,
 			RecurringScheduler::GROUP,
 			$generation_option,
@@ -114,9 +136,10 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 		$this->assertSame( \ActionScheduler_Store::STATUS_CANCELED, \ActionScheduler_Store::instance()->get_status( $successor_id ) );
 
 		$current_generation    = (string) get_option( $generation_option );
-		$current_action        = new GenerationFencedAction(
+		$generated_args[2]['_datamachine_schedule_generation'] = $current_generation;
+		$current_action = new GenerationFencedAction(
 			'datamachine_test_repeat_race',
-			array( $this->flow_id ),
+			$generated_args,
 			$schedule,
 			RecurringScheduler::GROUP,
 			$generation_option,
@@ -131,6 +154,97 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 		delete_option( $generation_option );
 	}
 
+	public function test_legacy_adoption_is_bounded_once_current_generation_exists(): void {
+		RecurringScheduler::ensureSchedule(
+			self::FLOW_HOOK,
+			array( $this->flow_id ),
+			'manual',
+			array( 'generation_argument_index' => FlowScheduling::GENERATION_ARGUMENT_INDEX )
+		);
+		$legacy_ids = array(
+			as_schedule_recurring_action( time() + 60, HOUR_IN_SECONDS, self::FLOW_HOOK, array( $this->flow_id ), RecurringScheduler::GROUP ),
+			as_schedule_recurring_action( time() + 120, HOUR_IN_SECONDS, self::FLOW_HOOK, array( $this->flow_id ), RecurringScheduler::GROUP ),
+		);
+
+		$first  = FlowScheduling::adopt_legacy_action( $this->flow_id );
+		$second = FlowScheduling::adopt_legacy_action( $this->flow_id );
+
+		$this->assertTrue( $first );
+		$this->assertWPError( $second );
+		$this->assertSame( 'stale_legacy_schedule_generation', $second->get_error_code() );
+		foreach ( $legacy_ids as $legacy_id ) {
+			$this->assertSame( \ActionScheduler_Store::STATUS_CANCELED, \ActionScheduler_Store::instance()->get_status( $legacy_id ) );
+		}
+		$this->assertTrue( RecurringScheduler::hasLogicalCoverage( self::FLOW_HOOK, array( $this->flow_id ), RecurringScheduler::GROUP, true ) );
+	}
+
+	public function test_legacy_adoption_cannot_overwrite_newer_manual_state(): void {
+		$snapshot = $this->flows->get_flow_scheduling( $this->flow_id );
+		$this->assertIsArray( $snapshot );
+		RecurringScheduler::ensureSchedule(
+			self::FLOW_HOOK,
+			array( $this->flow_id ),
+			'manual',
+			array( 'generation_argument_index' => FlowScheduling::GENERATION_ARGUMENT_INDEX )
+		);
+		$this->assertTrue( $this->flows->update_flow_scheduling( $this->flow_id, array( 'interval' => 'manual' ) ) );
+
+		$result = FlowScheduling::handle_scheduling_update( $this->flow_id, $snapshot, true, true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'legacy_schedule_generation_conflict', $result->get_error_code() );
+		$this->assertSame( 'manual', $this->flows->get_flow_scheduling( $this->flow_id )['interval'] );
+		$this->assertFalse( RecurringScheduler::hasLogicalCoverage( self::FLOW_HOOK, array( $this->flow_id ) ) );
+	}
+
+	public function test_store_takeover_cancels_exact_stale_action_and_preserves_current_action(): void {
+		$options            = $this->scheduleOptionNames( $this->flow_id );
+		$factory_property   = new \ReflectionProperty( \ActionScheduler::class, 'factory' );
+		$original_factory   = $factory_property->getValue();
+		$factory            = new GenerationTransitionActionFactory();
+		$current_action_id  = 0;
+		$factory->before_store = static function ( \ActionScheduler_Action $action ) use ( $options, &$current_action_id ): void {
+			$current_generation = wp_generate_uuid4();
+			update_option(
+				$options['lock'],
+				array(
+					'token'      => 'takeover-owner',
+					'started_at' => time(),
+					'expires_at' => time() + 300,
+				),
+				false
+			);
+			update_option( $options['generation'], $current_generation, false );
+
+			$args = $action->get_args();
+			$args[2]['_datamachine_schedule_generation'] = $current_generation;
+			$current = new \ActionScheduler_Action( $action->get_hook(), $args, $action->get_schedule(), $action->get_group() );
+			$current_action_id = (int) \ActionScheduler_Store::instance()->save_action( $current );
+		};
+		$factory_property->setValue( null, $factory );
+
+		try {
+			$result = RecurringScheduler::ensureSchedule(
+				self::FLOW_HOOK,
+				array( $this->flow_id ),
+				'daily',
+				array(
+					'force_reschedule'          => true,
+					'generation_argument_index' => FlowScheduling::GENERATION_ARGUMENT_INDEX,
+				)
+			);
+		} finally {
+			$factory_property->setValue( null, $original_factory );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'schedule_lock_lost', $result->get_error_code() );
+		$this->assertGreaterThan( 0, $factory->last_stored_id );
+		$this->assertSame( \ActionScheduler_Store::STATUS_CANCELED, \ActionScheduler_Store::instance()->get_status( $factory->last_stored_id ) );
+		$this->assertGreaterThan( 0, $current_action_id );
+		$this->assertSame( \ActionScheduler_Store::STATUS_PENDING, \ActionScheduler_Store::instance()->get_status( $current_action_id ) );
+	}
+
 	public function test_pause_flow_keeps_enabled_state_when_recurrence_cannot_be_fenced(): void {
 		$this->holdScheduleLock( $this->flow_id );
 
@@ -141,7 +255,7 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $result['errors'] );
 		$this->assertSame( 'pause_error', $result['flows'][0]['status'] );
 		$this->assertTrue( $flow['scheduling_config']['enabled'] );
-		$this->assertNotFalse( as_next_scheduled_action( self::FLOW_HOOK, array( $this->flow_id ), RecurringScheduler::GROUP ) );
+		$this->assertTrue( RecurringScheduler::hasLogicalCoverage( self::FLOW_HOOK, array( $this->flow_id ) ) );
 	}
 
 	public function test_desired_state_records_reconciliation_drift_after_scheduler_failure(): void {
@@ -172,7 +286,12 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 			)
 		);
 		$this->managed_flow_ids[] = $blocked_flow_id;
-		RecurringScheduler::ensureSchedule( self::FLOW_HOOK, array( $blocked_flow_id ), 'hourly' );
+		RecurringScheduler::ensureSchedule(
+			self::FLOW_HOOK,
+			array( $blocked_flow_id ),
+			'hourly',
+			array( 'generation_argument_index' => FlowScheduling::GENERATION_ARGUMENT_INDEX )
+		);
 		$this->holdScheduleLock( $blocked_flow_id );
 
 		$result = wp_get_ability( 'datamachine/delete-pipeline' )->execute( array( 'pipeline_id' => $this->pipeline_id ) );
@@ -184,8 +303,8 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 		$this->assertNotNull( $this->pipelines->get_pipeline( $this->pipeline_id ) );
 		$this->assertNull( $this->flows->get_flow( $this->flow_id ) );
 		$this->assertNotNull( $this->flows->get_flow( $blocked_flow_id ) );
-		$this->assertFalse( as_next_scheduled_action( self::FLOW_HOOK, array( $this->flow_id ), RecurringScheduler::GROUP ) );
-		$this->assertNotFalse( as_next_scheduled_action( self::FLOW_HOOK, array( $blocked_flow_id ), RecurringScheduler::GROUP ) );
+		$this->assertFalse( RecurringScheduler::hasLogicalCoverage( self::FLOW_HOOK, array( $this->flow_id ) ) );
+		$this->assertTrue( RecurringScheduler::hasLogicalCoverage( self::FLOW_HOOK, array( $blocked_flow_id ) ) );
 	}
 
 	public function test_creation_rollback_records_failed_schedule_compensation(): void {
@@ -203,7 +322,12 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 			)
 		);
 		$this->managed_flow_ids[] = $flow_id;
-		RecurringScheduler::ensureSchedule( self::FLOW_HOOK, array( $flow_id ), 'hourly' );
+		RecurringScheduler::ensureSchedule(
+			self::FLOW_HOOK,
+			array( $flow_id ),
+			'hourly',
+			array( 'generation_argument_index' => FlowScheduling::GENERATION_ARGUMENT_INDEX )
+		);
 		$this->holdScheduleLock( $flow_id );
 
 		$result = ( new ReflectionMethod( $ability, 'rollbackCreation' ) )->invoke( $ability, $scope, $flow_id, 'Forced rollback' );

--- a/tests/Unit/Api/Flows/FlowScheduleReconcilerTest.php
+++ b/tests/Unit/Api/Flows/FlowScheduleReconcilerTest.php
@@ -368,6 +368,7 @@ class FlowScheduleReconcilerTest extends WP_UnitTestCase {
 		);
 
 		$flow_id = (int) $result['flow_id'];
+		$this->deleteLogicalActions( $flow_id );
 		$this->flows->update_flow_scheduling( $flow_id, $scheduling );
 		$this->flow_ids[] = $flow_id;
 		$this->flows->flow_ids[] = $flow_id;
@@ -392,5 +393,13 @@ class FlowScheduleReconcilerTest extends WP_UnitTestCase {
 				static fn($action): bool => is_object( $action ) && (int) ( $action->get_args()[0] ?? 0 ) === $flow_id
 			)
 		);
+	}
+
+	private function deleteLogicalActions( int $flow_id ): void {
+		foreach ( array( 'pending', 'in-progress' ) as $status ) {
+			foreach ( $this->logicalActionIds( $flow_id, $status ) as $action_id ) {
+				\ActionScheduler_Store::instance()->delete_action( (int) $action_id );
+			}
+		}
 	}
 }

--- a/tests/Unit/Api/Flows/FlowScheduleReconcilerTest.php
+++ b/tests/Unit/Api/Flows/FlowScheduleReconcilerTest.php
@@ -137,9 +137,15 @@ class FlowScheduleReconcilerTest extends WP_UnitTestCase {
 		wp_cache_flush();
 
 		$result = ( new FlowScheduleReconciler( $this->flows ) )->reconcile();
-		$this->assertTrue( $result['success'] );
-		$this->assertSame( 1, $result['covered'] );
-		$this->assertSame( 0, $result['missing'] );
+		if ( 'ActionScheduler_DBStore' === get_class( \ActionScheduler::store() ) ) {
+			$this->assertTrue( $result['success'] );
+			$this->assertSame( 1, $result['covered'] );
+			$this->assertSame( 0, $result['missing'] );
+		} else {
+			$this->assertFalse( $result['success'] );
+			$this->assertSame( 1, $result['blocked'] );
+			$this->assertTrue( $result['transient'] );
+		}
 	}
 
 	public function test_stale_in_progress_action_does_not_cover_schedule(): void {
@@ -177,7 +183,7 @@ class FlowScheduleReconcilerTest extends WP_UnitTestCase {
 		$this->assertTrue( $applied['transient'] );
 		$this->assertSame( 1, $applied['blocked'] );
 		$this->assertSame( 0, $applied['repaired'] );
-		$this->assertFalse( RecurringScheduler::isScheduled( FlowScheduling::FLOW_HOOK, array( $flow_id ) ) );
+		$this->assertSame( array(), $this->logicalActionIds( $flow_id, 'pending' ) );
 
 		$second = ( new FlowScheduleReconciler( $this->flows ) )->reconcile();
 		$this->assertSame( 1, $second['blocked'] );
@@ -205,7 +211,7 @@ class FlowScheduleReconcilerTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['transient'] );
 		$this->assertSame( 1, $result['blocked'] );
 		$this->assertSame( 0, $result['repaired'] );
-		$this->assertFalse( RecurringScheduler::isScheduled( FlowScheduling::FLOW_HOOK, array( $flow_id ) ) );
+		$this->assertSame( array(), $this->logicalActionIds( $flow_id, 'pending' ) );
 	}
 
 	public function test_fresh_in_progress_plus_pending_action_blocks_apply_without_changes(): void {

--- a/tests/Unit/Api/Flows/FlowScheduleReconcilerTest.php
+++ b/tests/Unit/Api/Flows/FlowScheduleReconcilerTest.php
@@ -14,10 +14,25 @@ use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Engine\Tasks\RecurringScheduler;
 use WP_UnitTestCase;
 
+class ScopedFlowSchedules extends Flows {
+	/** @var int[] */
+	public array $flow_ids = array();
+
+	public function get_flow_schedules(): array {
+		$flow_ids = array_flip( $this->flow_ids );
+		return array_values(
+			array_filter(
+				parent::get_flow_schedules(),
+				static fn(array $flow): bool => isset( $flow_ids[ (int) $flow['flow_id'] ] )
+			)
+		);
+	}
+}
+
 class FlowScheduleReconcilerTest extends WP_UnitTestCase {
 
 	private int $pipeline_id;
-	private Flows $flows;
+	private ScopedFlowSchedules $flows;
 	private array $flow_ids = array();
 
 	public function set_up(): void {
@@ -26,13 +41,20 @@ class FlowScheduleReconcilerTest extends WP_UnitTestCase {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		$pipeline         = wp_get_ability( 'datamachine/create-pipeline' )->execute( array( 'pipeline_name' => 'Schedule reconciliation' ) );
 		$this->pipeline_id = (int) $pipeline['pipeline_id'];
-		$this->flows       = new Flows();
+		$this->flows       = new ScopedFlowSchedules();
 	}
 
 	public function tear_down(): void {
 		foreach ( $this->flow_ids as $flow_id ) {
-			RecurringScheduler::unschedule( FlowScheduling::FLOW_HOOK, array( $flow_id ) );
+			RecurringScheduler::unschedule(
+				FlowScheduling::FLOW_HOOK,
+				array( $flow_id ),
+				RecurringScheduler::GROUP,
+				array( 'generation_argument_index' => FlowScheduling::GENERATION_ARGUMENT_INDEX )
+			);
+			$this->flows->delete_flow( $flow_id );
 		}
+		( new \DataMachine\Core\Database\Pipelines\Pipelines() )->delete_pipeline( $this->pipeline_id );
 		delete_option( 'datamachine_flow_schedule_reconciliation_lock' );
 
 		parent::tear_down();
@@ -289,17 +311,26 @@ class FlowScheduleReconcilerTest extends WP_UnitTestCase {
 		$applied = ( new FlowScheduleReconciler( $this->flows ) )->reconcile( true );
 		$this->assertTrue( $applied['success'] );
 		$this->assertSame( 1, $applied['repaired'] );
-		$action_ids = as_get_scheduled_actions(
-			array(
-				'hook'     => FlowScheduling::FLOW_HOOK,
-				'args'     => array( $flow_id ),
-				'group'    => RecurringScheduler::GROUP,
-				'status'   => 'pending',
-				'per_page' => 10,
-			),
-			'ids'
-		);
+		$action_ids = $this->logicalActionIds( $flow_id, 'pending' );
 		$this->assertCount( 1, $action_ids );
+	}
+
+	public function test_current_generation_plus_legacy_row_converges_to_one_action(): void {
+		$flow_id = $this->create_flow( 'Generated plus legacy', array( 'interval' => 'hourly' ) );
+		$this->assertTrue( FlowScheduling::handle_scheduling_update( $flow_id, array( 'interval' => 'hourly' ), true ) );
+		as_schedule_recurring_action( time() + 120, HOUR_IN_SECONDS, FlowScheduling::FLOW_HOOK, array( $flow_id ), RecurringScheduler::GROUP, false );
+
+		$dry_run = ( new FlowScheduleReconciler( $this->flows ) )->reconcile();
+		$this->assertSame( 1, $dry_run['missing'] );
+
+		$applied = ( new FlowScheduleReconciler( $this->flows ) )->reconcile( true );
+		$this->assertTrue( $applied['success'] );
+		$this->assertSame( 1, $applied['repaired'] );
+		$this->assertCount( 1, $this->logicalActionIds( $flow_id, 'pending' ) );
+
+		$verified = ( new FlowScheduleReconciler( $this->flows ) )->reconcile();
+		$this->assertSame( 1, $verified['covered'] );
+		$this->assertSame( 0, $verified['missing'] );
 	}
 
 	public function test_invalid_definitions_are_reported_without_failing_apply(): void {
@@ -339,7 +370,27 @@ class FlowScheduleReconcilerTest extends WP_UnitTestCase {
 		$flow_id = (int) $result['flow_id'];
 		$this->flows->update_flow_scheduling( $flow_id, $scheduling );
 		$this->flow_ids[] = $flow_id;
+		$this->flows->flow_ids[] = $flow_id;
 
 		return $flow_id;
+	}
+
+	private function logicalActionIds( int $flow_id, string $status ): array {
+		$actions = as_get_scheduled_actions(
+			array(
+				'hook'     => FlowScheduling::FLOW_HOOK,
+				'group'    => RecurringScheduler::GROUP,
+				'status'   => $status,
+				'per_page' => 100,
+			),
+			'OBJECT'
+		);
+
+		return array_keys(
+			array_filter(
+				$actions,
+				static fn($action): bool => is_object( $action ) && (int) ( $action->get_args()[0] ?? 0 ) === $flow_id
+			)
+		);
 	}
 }

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -28,6 +28,7 @@ use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Store;
 use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Store_Capabilities;
 use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Write_Result;
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Api\Flows\FlowScheduling;
 use DataMachine\Core\Agents\AgentBundler;
 use DataMachine\Core\ActionScheduler\GroupRegistrar;
 use DataMachine\Core\Database\Agents\Agents as AgentsRepository;
@@ -38,6 +39,7 @@ use DataMachine\Core\Database\Pipelines\Pipelines as PipelinesRepository;
 use DataMachine\Abilities\Engine\RunFlowAbility;
 use DataMachine\Engine\AI\Tools\Global\AgentDailyMemory;
 use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
+use DataMachine\Engine\Tasks\RecurringScheduler;
 use DataMachine\Engine\Bundle\AgentBundleArtifactState;
 use DataMachine\Engine\Bundle\AgentBundleDirectory;
 use DataMachine\Engine\Bundle\AgentBundleInstalledArtifact;
@@ -632,8 +634,13 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$flow     = $this->flows_repo->get_by_portable_slug( (int) $pipeline['pipeline_id'], 'static-site-flow' );
 		$flow_id  = (int) $flow['flow_id'];
 
-		as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), GroupRegistrar::GROUP );
-		$this->assertFalse( as_next_scheduled_action( 'datamachine_run_flow_now', array( $flow_id ), GroupRegistrar::GROUP ), 'Test setup removes the scheduled action while preserving flow row scheduling.' );
+		RecurringScheduler::unschedule(
+			FlowScheduling::FLOW_HOOK,
+			array( $flow_id ),
+			GroupRegistrar::GROUP,
+			array( 'generation_argument_index' => FlowScheduling::GENERATION_ARGUMENT_INDEX )
+		);
+		$this->assertFalse( RecurringScheduler::hasLogicalCoverage( FlowScheduling::FLOW_HOOK, array( $flow_id ), GroupRegistrar::GROUP ), 'Test setup removes the scheduled action while preserving flow row scheduling.' );
 
 		$second = $this->bundler->import(
 			$bundle,
@@ -644,7 +651,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		);
 
 		$this->assertTrue( (bool) $second['success'], 'Upgrade import succeeds when only the scheduled action is missing.' );
-		$this->assertNotFalse( as_next_scheduled_action( 'datamachine_run_flow_now', array( $flow_id ), GroupRegistrar::GROUP ), 'Importer re-creates the missing scheduled action for an enabled non-manual flow.' );
+		$this->assertTrue( RecurringScheduler::hasLogicalCoverage( FlowScheduling::FLOW_HOOK, array( $flow_id ), GroupRegistrar::GROUP ), 'Importer re-creates the missing scheduled action for an enabled non-manual flow.' );
 	}
 
 	public function test_reconcile_runtime_replaces_local_modified_flow_queue_and_schedule(): void {

--- a/tests/flow-schedule-reconciler-smoke.php
+++ b/tests/flow-schedule-reconciler-smoke.php
@@ -24,6 +24,7 @@ namespace DataMachine\Core\Database\Flows {
 namespace DataMachine\Api\Flows {
 	class FlowScheduling {
 		public const FLOW_HOOK = 'datamachine_run_flow_now';
+		public const GENERATION_ARGUMENT_INDEX = 2;
 		public static array $calls = array();
 
 		public static function handle_scheduling_update( int $flow_id, array $scheduling, bool $force = false ) {

--- a/tests/flow-schedule-reconciler-smoke.php
+++ b/tests/flow-schedule-reconciler-smoke.php
@@ -24,6 +24,19 @@ namespace DataMachine\Core\Database\Flows {
 namespace DataMachine\Api\Flows {
 	class FlowScheduling {
 		public const FLOW_HOOK = 'datamachine_run_flow_now';
+		public static array $calls = array();
+
+		public static function handle_scheduling_update( int $flow_id, array $scheduling, bool $force = false ) {
+			self::$calls[] = compact( 'flow_id', 'scheduling', 'force' );
+			$interval      = false === ( $scheduling['enabled'] ?? true )
+				? 'manual'
+				: (string) ( $scheduling['interval'] ?? 'manual' );
+			return \DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
+				self::FLOW_HOOK,
+				array( $flow_id ),
+				$interval
+			);
+		}
 	}
 
 	class FlowScheduleReconciliationLock {
@@ -437,6 +450,24 @@ namespace {
 	$fresh_mixed_result = ( new FlowScheduleReconciler( $fresh_mixed ) )->reconcile( true );
 	datamachine_reconciler_assert( 1 === $fresh_mixed_result['blocked'] && true === $fresh_mixed_result['transient'], 'fresh in-progress plus pending mixed ownership blocks apply' );
 	datamachine_reconciler_assert( $calls_before_fresh_mixed === count( RecurringScheduler::$calls ), 'mixed fresh in-progress apply schedules nothing' );
+
+	$paused_drift            = new Flows();
+	$paused_drift->schedules = array(
+		datamachine_reconciler_flow(
+			408,
+			array(
+				'interval'                => 'hourly',
+				'enabled'                 => false,
+				'schedule_reconciliation' => array( 'status' => 'drift' ),
+			)
+		),
+	);
+	$paused_drift_audit = ( new FlowScheduleReconciler( $paused_drift ) )->reconcile();
+	datamachine_reconciler_assert( 1 === $paused_drift_audit['missing'], 'paused desired-state drift remains visible to reconciliation' );
+	$paused_drift_apply = ( new FlowScheduleReconciler( $paused_drift ) )->reconcile( true );
+	$drift_call         = \DataMachine\Api\Flows\FlowScheduling::$calls[ count( \DataMachine\Api\Flows\FlowScheduling::$calls ) - 1 ];
+	datamachine_reconciler_assert( 1 === $paused_drift_apply['repaired'], 'reconciler retries paused schedule cleanup' );
+	datamachine_reconciler_assert( true === $drift_call['force'] && false === $drift_call['scheduling']['enabled'], 'drift repair replays authoritative persisted intent' );
 
 	echo "\nAll flow schedule reconciler assertions passed.\n";
 }

--- a/tests/recurring-scheduler-as-readiness-smoke.php
+++ b/tests/recurring-scheduler-as-readiness-smoke.php
@@ -36,6 +36,7 @@ function as_next_scheduled_action( string $hook, ?array $args = null, string $gr
 	return time() + 3600;
 }
 
+require_once __DIR__ . '/../inc/Engine/Tasks/ScheduleActionIdentity.php';
 require_once __DIR__ . '/../inc/Engine/Tasks/RecurringScheduler.php';
 
 use DataMachine\Engine\Tasks\RecurringScheduler;

--- a/tests/recurring-scheduler-idempotency-smoke.php
+++ b/tests/recurring-scheduler-idempotency-smoke.php
@@ -83,6 +83,52 @@ if ( ! function_exists( 'apply_filters' ) ) {
 	}
 }
 
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+}
+
+$GLOBALS['datamachine_rs_options']            = array();
+$GLOBALS['datamachine_rs_add_option_failures'] = 0;
+$GLOBALS['datamachine_rs_add_option_calls']    = 0;
+
+function get_option( string $name, $default = false ) {
+	return $GLOBALS['datamachine_rs_options'][ $name ] ?? $default;
+}
+
+function add_option( string $name, $value, string $deprecated = '', bool $autoload = false ): bool {
+	unset( $deprecated, $autoload );
+	++$GLOBALS['datamachine_rs_add_option_calls'];
+	if ( $GLOBALS['datamachine_rs_add_option_failures'] > 0 ) {
+		--$GLOBALS['datamachine_rs_add_option_failures'];
+		return false;
+	}
+	if ( isset( $GLOBALS['datamachine_rs_options'][ $name ] ) ) {
+		return false;
+	}
+	$GLOBALS['datamachine_rs_options'][ $name ] = $value;
+	return true;
+}
+
+function update_option( string $name, $value, bool $autoload = false ): bool {
+	unset( $autoload );
+	$GLOBALS['datamachine_rs_options'][ $name ] = $value;
+	return true;
+}
+
+function delete_option( string $name ): bool {
+	if ( ! isset( $GLOBALS['datamachine_rs_options'][ $name ] ) ) {
+		return false;
+	}
+	unset( $GLOBALS['datamachine_rs_options'][ $name ] );
+	return true;
+}
+
+function wp_generate_uuid4(): string {
+	return uniqid( 'dm-test-', true );
+}
+
 /**
  * Action Scheduler datastore-readiness stub.
  *
@@ -150,6 +196,8 @@ $GLOBALS['datamachine_rs_unscheduled']         = 0;
 $GLOBALS['datamachine_rs_recurring_unique']    = array();
 $GLOBALS['datamachine_rs_cron_unique']         = array();
 $GLOBALS['datamachine_rs_schedule_race']       = false;
+$GLOBALS['datamachine_rs_reentrant_race']      = false;
+$GLOBALS['datamachine_rs_reentrant_result']    = null;
 
 function datamachine_rs_key( string $hook, array $args, string $group ): string {
 	return $group . '|' . $hook . '|' . serialize( $args );
@@ -161,17 +209,17 @@ function datamachine_rs_key( string $hook, array $args, string $group ): string 
  * The store keeps a LIST per signature so the harness can model the live
  * duplicate-chain bug (two parallel pending actions for one hook/args/group).
  */
-function datamachine_rs_seed_action( string $hook, array $args, string $group, DmRecurringSchedulerFakeSchedule $schedule ): void {
+function datamachine_rs_seed_action( string $hook, array $args, string $group, DmRecurringSchedulerFakeSchedule $schedule, string $status = 'pending' ): void {
 	$key = datamachine_rs_key( $hook, $args, $group );
-	if ( ! isset( $GLOBALS['datamachine_rs_actions'][ $key ] ) ) {
-		$GLOBALS['datamachine_rs_actions'][ $key ] = array();
+	if ( ! isset( $GLOBALS['datamachine_rs_actions'][ $key ][ $status ] ) ) {
+		$GLOBALS['datamachine_rs_actions'][ $key ][ $status ] = array();
 	}
-	$GLOBALS['datamachine_rs_actions'][ $key ][] = new DmRecurringSchedulerFakeAction( $schedule );
+	$GLOBALS['datamachine_rs_actions'][ $key ][ $status ][] = new DmRecurringSchedulerFakeAction( $schedule );
 }
 
 function datamachine_rs_pending_count( string $hook, array $args, string $group ): int {
 	$key = datamachine_rs_key( $hook, $args, $group );
-	return isset( $GLOBALS['datamachine_rs_actions'][ $key ] ) ? count( $GLOBALS['datamachine_rs_actions'][ $key ] ) : 0;
+	return isset( $GLOBALS['datamachine_rs_actions'][ $key ]['pending'] ) ? count( $GLOBALS['datamachine_rs_actions'][ $key ]['pending'] ) : 0;
 }
 
 function datamachine_rs_reset(): void {
@@ -183,6 +231,11 @@ function datamachine_rs_reset(): void {
 	$GLOBALS['datamachine_rs_recurring_unique']    = array();
 	$GLOBALS['datamachine_rs_cron_unique']         = array();
 	$GLOBALS['datamachine_rs_schedule_race']       = false;
+	$GLOBALS['datamachine_rs_reentrant_race']      = false;
+	$GLOBALS['datamachine_rs_reentrant_result']    = null;
+	$GLOBALS['datamachine_rs_options']             = array();
+	$GLOBALS['datamachine_rs_add_option_failures'] = 0;
+	$GLOBALS['datamachine_rs_add_option_calls']    = 0;
 	ActionScheduler::$initialized         = true;
 }
 
@@ -192,7 +245,8 @@ function datamachine_rs_counter( string $key ): int {
 
 function as_get_scheduled_actions( array $args = array(), $return_format = OBJECT ): array {
 	$key      = datamachine_rs_key( $args['hook'], $args['args'] ?? array(), $args['group'] ?? '' );
-	$matches  = $GLOBALS['datamachine_rs_actions'][ $key ] ?? array();
+	$status   = $args['status'] ?? 'pending';
+	$matches  = $GLOBALS['datamachine_rs_actions'][ $key ][ $status ] ?? array();
 	$per_page = isset( $args['per_page'] ) ? (int) $args['per_page'] : count( $matches );
 	if ( $per_page > 0 ) {
 		$matches = array_slice( $matches, 0, $per_page );
@@ -207,17 +261,17 @@ function as_get_scheduled_actions( array $args = array(), $return_format = OBJEC
 
 function as_next_scheduled_action( string $hook, ?array $args = null, string $group = '' ) {
 	$key = datamachine_rs_key( $hook, $args ?? array(), $group );
-	if ( empty( $GLOBALS['datamachine_rs_actions'][ $key ] ) ) {
+	if ( empty( $GLOBALS['datamachine_rs_actions'][ $key ]['pending'] ) ) {
 		return false;
 	}
 
-	$first = reset( $GLOBALS['datamachine_rs_actions'][ $key ] );
+	$first = reset( $GLOBALS['datamachine_rs_actions'][ $key ]['pending'] );
 	return $first->get_schedule()->get_date()->getTimestamp();
 }
 
 function as_unschedule_all_actions( string $hook, array $args = array(), string $group = '' ): void {
 	++$GLOBALS['datamachine_rs_unscheduled'];
-	unset( $GLOBALS['datamachine_rs_actions'][ datamachine_rs_key( $hook, $args, $group ) ] );
+	unset( $GLOBALS['datamachine_rs_actions'][ datamachine_rs_key( $hook, $args, $group ) ]['pending'] );
 }
 
 function as_schedule_single_action( int $timestamp, string $hook, array $args = array(), string $group = '' ): int {
@@ -229,6 +283,10 @@ function as_schedule_single_action( int $timestamp, string $hook, array $args = 
 function as_schedule_recurring_action( int $timestamp, int $interval, string $hook, array $args = array(), string $group = '', bool $unique = false ): int {
 	++$GLOBALS['datamachine_rs_scheduled_recurring'];
 	$GLOBALS['datamachine_rs_recurring_unique'][] = $unique;
+	if ( $GLOBALS['datamachine_rs_reentrant_race'] ) {
+		$GLOBALS['datamachine_rs_reentrant_race']   = false;
+		$GLOBALS['datamachine_rs_reentrant_result'] = \DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule( $hook, $args, 'hourly', array( 'group' => $group ) );
+	}
 	if ( $GLOBALS['datamachine_rs_schedule_race'] ) {
 		$GLOBALS['datamachine_rs_schedule_race'] = false;
 		datamachine_rs_seed_action( $hook, $args, $group, new DmRecurringSchedulerFakeSchedule( true, $interval, $timestamp ) );
@@ -248,6 +306,7 @@ function as_schedule_cron_action( int $timestamp, string $expression, string $ho
 	return 303;
 }
 
+require_once __DIR__ . '/../inc/Core/OptionLeaseStore.php';
 require_once __DIR__ . '/../inc/Engine/Tasks/RecurringScheduler.php';
 
 use DataMachine\Engine\Tasks\RecurringScheduler;
@@ -414,5 +473,27 @@ datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamac
 datamachine_assert( array( false, false ) === $GLOBALS['datamachine_rs_recurring_unique'], 'argument-bearing schedules do not use hook/group-only Action Scheduler uniqueness' );
 datamachine_assert( 1 === datamachine_rs_pending_count( 'datamachine_per_flow', array( 'flow_id' => 1 ), RecurringScheduler::GROUP ), 'first argument tuple has its own pending chain' );
 datamachine_assert( 1 === datamachine_rs_pending_count( 'datamachine_per_flow', array( 'flow_id' => 2 ), RecurringScheduler::GROUP ), 'second argument tuple has its own pending chain' );
+
+echo "\n[18] reentrant argument-bearing reconciliation cannot create a parallel chain\n";
+datamachine_rs_reset();
+$GLOBALS['datamachine_rs_reentrant_race'] = true;
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_per_flow', array( 42 ), 'hourly' ) );
+datamachine_assert( $GLOBALS['datamachine_rs_reentrant_result'] instanceof WP_Error, 'contending reconciliation receives a retryable lock error' );
+datamachine_assert( 'schedule_lock_timeout' === $GLOBALS['datamachine_rs_reentrant_result']->get_error_code(), 'contention reports schedule_lock_timeout' );
+datamachine_assert( 1 === datamachine_rs_pending_count( 'datamachine_per_flow', array( 42 ), RecurringScheduler::GROUP ), 'outer owner creates exactly one pending chain' );
+
+echo "\n[19] transient lease contention retries before scheduling\n";
+datamachine_rs_reset();
+$GLOBALS['datamachine_rs_add_option_failures'] = 1;
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_retry', array( 7 ), 'hourly' ) );
+datamachine_assert( $GLOBALS['datamachine_rs_add_option_calls'] >= 2, 'scheduler retries after losing the first atomic lease attempt' );
+datamachine_assert( 1 === datamachine_rs_pending_count( 'datamachine_retry', array( 7 ), RecurringScheduler::GROUP ), 'retry creates one pending chain without action loss' );
+
+echo "\n[20] matching running recurrence owns coverage\n";
+datamachine_rs_reset();
+datamachine_rs_seed_action( 'datamachine_running', array( 9 ), RecurringScheduler::GROUP, new DmRecurringSchedulerFakeSchedule( true, 3600, time() ), 'in-progress' );
+$result = datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_running', array( 9 ), 'hourly' ) );
+datamachine_assert( true === ( $result['preserved'] ?? false ), 'running recurrence is preserved as the current owner' );
+datamachine_assert( 0 === datamachine_rs_counter( 'datamachine_rs_scheduled_recurring' ), 'running recurrence does not spawn a parallel pending chain' );
 
 echo "\nAll recurring scheduler idempotency assertions passed.\n";

--- a/tests/recurring-scheduler-idempotency-smoke.php
+++ b/tests/recurring-scheduler-idempotency-smoke.php
@@ -398,6 +398,7 @@ function as_schedule_cron_action( int $timestamp, string $expression, string $ho
 
 require_once __DIR__ . '/../inc/Core/OptionLeaseStore.php';
 require_once __DIR__ . '/../inc/Engine/Tasks/GenerationFencedAction.php';
+require_once __DIR__ . '/../inc/Engine/Tasks/ScheduleActionIdentity.php';
 require_once __DIR__ . '/../inc/Engine/Tasks/RecurringScheduler.php';
 
 use DataMachine\Engine\Tasks\RecurringScheduler;
@@ -730,11 +731,12 @@ echo "\n[32] generation fence matches bundled Action Scheduler repeat order\n";
 $queue_runner_source = file_get_contents( __DIR__ . '/../vendor/woocommerce/action-scheduler/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php' ) ?: '';
 $factory_source      = file_get_contents( __DIR__ . '/../vendor/woocommerce/action-scheduler/classes/ActionScheduler_ActionFactory.php' ) ?: '';
 $scheduler_source    = file_get_contents( __DIR__ . '/../inc/Engine/Tasks/RecurringScheduler.php' ) ?: '';
+$identity_source     = file_get_contents( __DIR__ . '/../inc/Engine/Tasks/ScheduleActionIdentity.php' ) ?: '';
 $execute_position    = strpos( $queue_runner_source, '$action->execute()' );
 $repeat_position     = strpos( $queue_runner_source, '$action->get_schedule()->is_recurring()' );
 datamachine_assert( false !== $execute_position && false !== $repeat_position && $execute_position < $repeat_position, 'bundled AS re-reads the fetched action schedule after callback execution' );
 datamachine_assert( str_contains( $factory_source, '$schedule = $action->get_schedule();' ) && str_contains( $factory_source, '$this->store( $new_action )' ), 'bundled AS repeats from the fetched action schedule object' );
-datamachine_assert( str_contains( $scheduler_source, "'action_scheduler_stored_action'" ) && str_contains( $scheduler_source, 'cancelExactAction( $action_id )' ), 'post-store reconciliation cancels a stale native successor by exact action ID' );
+datamachine_assert( str_contains( $scheduler_source, "'action_scheduler_stored_action'" ) && str_contains( $scheduler_source, 'ScheduleActionIdentity::cancelExact( $action_id )' ) && str_contains( $identity_source, 'cancel_action( $action_id )' ), 'post-store reconciliation cancels a stale native successor by exact action ID' );
 
 echo "\n[33] desired-state persistence failure prevents schedule mutation\n";
 datamachine_rs_reset();

--- a/tests/recurring-scheduler-idempotency-smoke.php
+++ b/tests/recurring-scheduler-idempotency-smoke.php
@@ -256,6 +256,7 @@ $GLOBALS['datamachine_rs_reentrant_race']      = false;
 $GLOBALS['datamachine_rs_reentrant_result']    = null;
 $GLOBALS['datamachine_rs_single_reentrant']    = null;
 $GLOBALS['datamachine_rs_steal_lock_on_query'] = false;
+$GLOBALS['datamachine_rs_expire_lock_on_query'] = false;
 
 function datamachine_rs_key( string $hook, array $args, string $group ): string {
 	return $group . '|' . $hook . '|' . serialize( $args );
@@ -293,6 +294,7 @@ function datamachine_rs_reset(): void {
 	$GLOBALS['datamachine_rs_reentrant_result']    = null;
 	$GLOBALS['datamachine_rs_single_reentrant']    = null;
 	$GLOBALS['datamachine_rs_steal_lock_on_query'] = false;
+	$GLOBALS['datamachine_rs_expire_lock_on_query'] = false;
 	$GLOBALS['datamachine_rs_options']             = array();
 	$GLOBALS['datamachine_rs_add_option_failures'] = 0;
 	$GLOBALS['datamachine_rs_add_option_calls']    = 0;
@@ -304,6 +306,15 @@ function datamachine_rs_counter( string $key ): int {
 }
 
 function as_get_scheduled_actions( array $args = array(), $return_format = OBJECT ): array {
+	if ( $GLOBALS['datamachine_rs_expire_lock_on_query'] ) {
+		$GLOBALS['datamachine_rs_expire_lock_on_query'] = false;
+		foreach ( $GLOBALS['datamachine_rs_options'] as $name => $payload ) {
+			if ( str_starts_with( $name, 'datamachine_schedule_lock_' ) && is_array( $payload ) ) {
+				$GLOBALS['datamachine_rs_options'][ $name ]['expires_at'] = time() - 1;
+				break;
+			}
+		}
+	}
 	if ( $GLOBALS['datamachine_rs_steal_lock_on_query'] ) {
 		$GLOBALS['datamachine_rs_steal_lock_on_query'] = false;
 		foreach ( $GLOBALS['datamachine_rs_options'] as $name => $payload ) {
@@ -669,5 +680,57 @@ datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamac
 datamachine_assert( ! $old_action->get_schedule()->is_recurring(), 'cron transition invalidates the old fetched interval recurrence' );
 $new_action = reset( $GLOBALS['datamachine_rs_actions'][ $key ]['pending'] );
 datamachine_assert( '0 0 * * *' === $new_action->get_schedule()->get_recurrence(), 'cron transition installs only the desired cron successor' );
+
+echo "\n[29] expired owner cannot revive its lease or overwrite generation\n";
+datamachine_rs_reset();
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_expired_owner', array( 18 ), 'hourly' ) );
+$generation_before = '';
+foreach ( $GLOBALS['datamachine_rs_options'] as $name => $value ) {
+	if ( str_starts_with( $name, 'datamachine_schedule_generation_' ) ) {
+		$generation_before = $value;
+		break;
+	}
+}
+$GLOBALS['datamachine_rs_expire_lock_on_query'] = true;
+$result = RecurringScheduler::ensureSchedule( 'datamachine_expired_owner', array( 18 ), 'daily' );
+datamachine_assert( $result instanceof WP_Error, 'expired owner returns an ownership error' );
+datamachine_assert( 'schedule_lock_lost' === $result->get_error_code(), 'expired owner cannot refresh after expiry' );
+$generation_after = '';
+foreach ( $GLOBALS['datamachine_rs_options'] as $name => $value ) {
+	if ( str_starts_with( $name, 'datamachine_schedule_generation_' ) ) {
+		$generation_after = $value;
+		break;
+	}
+}
+datamachine_assert( $generation_before === $generation_after, 'expired owner cannot overwrite the persisted generation' );
+
+echo "\n[30] public unschedule compatibility uses the fenced primitive\n";
+datamachine_rs_reset();
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_public_unschedule', array( 19 ), 'hourly' ) );
+$GLOBALS['datamachine_rs_unscheduled'] = 0;
+RecurringScheduler::unschedule( 'datamachine_public_unschedule', array( 19 ) );
+datamachine_assert( 0 === datamachine_rs_pending_count( 'datamachine_public_unschedule', array( 19 ), RecurringScheduler::GROUP ), 'legacy public unschedule removes the pending schedule' );
+datamachine_assert( 1 === datamachine_rs_counter( 'datamachine_rs_unscheduled' ), 'legacy public unschedule performs one fenced mutation' );
+
+echo "\n[31] destructive callers reject or record scheduler failures\n";
+$delete_flow_source     = file_get_contents( __DIR__ . '/../inc/Abilities/Flow/DeleteFlowAbility.php' ) ?: '';
+$delete_pipeline_source = file_get_contents( __DIR__ . '/../inc/Abilities/Pipeline/DeletePipelineAbility.php' ) ?: '';
+$pause_flow_source      = file_get_contents( __DIR__ . '/../inc/Abilities/Flow/PauseFlowAbility.php' ) ?: '';
+$create_flow_source     = file_get_contents( __DIR__ . '/../inc/Abilities/Flow/CreateFlowAbility.php' ) ?: '';
+$engine_source          = file_get_contents( __DIR__ . '/../inc/Engine/Actions/Engine.php' ) ?: '';
+datamachine_assert( str_contains( $delete_flow_source, 'is_wp_error( $schedule_result )' ), 'flow deletion stops on scheduler failure' );
+datamachine_assert( strpos( $delete_pipeline_source, 'is_wp_error( $schedule_result )' ) < strpos( $delete_pipeline_source, 'delete_flow( (int) $flow_id )' ), 'pipeline deletion fences every flow before database deletion' );
+datamachine_assert( str_contains( $pause_flow_source, "'status'  => 'pause_error'" ), 'pause reports scheduler failure instead of success' );
+datamachine_assert( str_contains( $create_flow_source, "'schedule_cleanup'" ), 'creation rollback records failed schedule compensation' );
+datamachine_assert( str_contains( $engine_source, 'Orphaned schedule cleanup deferred after ownership failure' ), 'orphan cleanup records retryable scheduler failure' );
+datamachine_assert( str_contains( $schedule_flow_source, 'SCHEDULE_GENERATION_PREFIX' ) || str_contains( file_get_contents( __DIR__ . '/../inc/Engine/Tasks/RecurringScheduler.php' ) ?: '', 'Do not bulk-delete' ), 'generation tombstones document bounded retention and prohibit blind deletion' );
+
+echo "\n[32] generation fence matches bundled Action Scheduler repeat order\n";
+$queue_runner_source = file_get_contents( __DIR__ . '/../vendor/woocommerce/action-scheduler/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php' ) ?: '';
+$factory_source      = file_get_contents( __DIR__ . '/../vendor/woocommerce/action-scheduler/classes/ActionScheduler_ActionFactory.php' ) ?: '';
+$execute_position    = strpos( $queue_runner_source, '$action->execute()' );
+$repeat_position     = strpos( $queue_runner_source, '$action->get_schedule()->is_recurring()' );
+datamachine_assert( false !== $execute_position && false !== $repeat_position && $execute_position < $repeat_position, 'bundled AS re-reads the fetched action schedule after callback execution' );
+datamachine_assert( str_contains( $factory_source, '$schedule = $action->get_schedule();' ) && str_contains( $factory_source, '$this->store( $new_action )' ), 'bundled AS repeats from the fetched action schedule object' );
 
 echo "\nAll recurring scheduler idempotency assertions passed.\n";

--- a/tests/recurring-scheduler-idempotency-smoke.php
+++ b/tests/recurring-scheduler-idempotency-smoke.php
@@ -15,11 +15,12 @@ if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
 		private string $code;
 		private string $message;
+		private array $data;
 
 		public function __construct( string $code = '', string $message = '', array $data = array() ) {
 			$this->code    = $code;
 			$this->message = $message;
-			unset( $data );
+			$this->data    = $data;
 		}
 
 		public function get_error_code(): string {
@@ -31,7 +32,11 @@ if ( ! class_exists( 'WP_Error' ) ) {
 		}
 
 		public function add_data( array $data ): void {
-			unset( $data );
+			$this->data = $data;
+		}
+
+		public function get_error_data(): array {
+			return $this->data;
 		}
 	}
 }
@@ -155,7 +160,52 @@ class ActionScheduler {
 	}
 }
 
-class DmRecurringSchedulerFakeSchedule {
+if ( ! class_exists( 'ActionScheduler_Schedule' ) ) {
+	abstract class ActionScheduler_Schedule {
+		abstract public function is_recurring(): bool;
+		abstract public function get_date(): DateTimeImmutable;
+	}
+}
+
+if ( ! class_exists( 'ActionScheduler_Action' ) ) {
+	class ActionScheduler_Action {
+		private ActionScheduler_Schedule $schedule;
+		private int $priority = 10;
+
+		public function __construct( string $hook, array $args, ActionScheduler_Schedule $schedule, string $group ) {
+			unset( $hook, $args, $group );
+			$this->schedule = $schedule;
+		}
+
+		public function get_schedule(): ActionScheduler_Schedule {
+			return $this->schedule;
+		}
+
+		public function set_priority( int $priority ): void {
+			$this->priority = $priority;
+		}
+	}
+}
+
+if ( ! class_exists( 'ActionScheduler_CanceledSchedule' ) ) {
+	class ActionScheduler_CanceledSchedule extends ActionScheduler_Schedule {
+		private DateTimeImmutable $date;
+
+		public function __construct( DateTimeImmutable $date ) {
+			$this->date = $date;
+		}
+
+		public function is_recurring(): bool {
+			return false;
+		}
+
+		public function get_date(): DateTimeImmutable {
+			return $this->date;
+		}
+	}
+}
+
+class DmRecurringSchedulerFakeSchedule extends ActionScheduler_Schedule {
 	private bool $recurring;
 	/**
 	 * @var int|string|null
@@ -204,6 +254,8 @@ $GLOBALS['datamachine_rs_cron_unique']         = array();
 $GLOBALS['datamachine_rs_schedule_race']       = false;
 $GLOBALS['datamachine_rs_reentrant_race']      = false;
 $GLOBALS['datamachine_rs_reentrant_result']    = null;
+$GLOBALS['datamachine_rs_single_reentrant']    = null;
+$GLOBALS['datamachine_rs_steal_lock_on_query'] = false;
 
 function datamachine_rs_key( string $hook, array $args, string $group ): string {
 	return $group . '|' . $hook . '|' . serialize( $args );
@@ -239,6 +291,8 @@ function datamachine_rs_reset(): void {
 	$GLOBALS['datamachine_rs_schedule_race']       = false;
 	$GLOBALS['datamachine_rs_reentrant_race']      = false;
 	$GLOBALS['datamachine_rs_reentrant_result']    = null;
+	$GLOBALS['datamachine_rs_single_reentrant']    = null;
+	$GLOBALS['datamachine_rs_steal_lock_on_query'] = false;
 	$GLOBALS['datamachine_rs_options']             = array();
 	$GLOBALS['datamachine_rs_add_option_failures'] = 0;
 	$GLOBALS['datamachine_rs_add_option_calls']    = 0;
@@ -250,6 +304,15 @@ function datamachine_rs_counter( string $key ): int {
 }
 
 function as_get_scheduled_actions( array $args = array(), $return_format = OBJECT ): array {
+	if ( $GLOBALS['datamachine_rs_steal_lock_on_query'] ) {
+		$GLOBALS['datamachine_rs_steal_lock_on_query'] = false;
+		foreach ( $GLOBALS['datamachine_rs_options'] as $name => $payload ) {
+			if ( str_starts_with( $name, 'datamachine_schedule_lock_' ) && is_array( $payload ) ) {
+				$GLOBALS['datamachine_rs_options'][ $name ]['token'] = 'stale-owner-taken-over';
+				break;
+			}
+		}
+	}
 	$key      = datamachine_rs_key( $args['hook'], $args['args'] ?? array(), $args['group'] ?? '' );
 	$status   = $args['status'] ?? 'pending';
 	$matches  = $GLOBALS['datamachine_rs_actions'][ $key ][ $status ] ?? array();
@@ -282,6 +345,16 @@ function as_unschedule_all_actions( string $hook, array $args = array(), string 
 
 function as_schedule_single_action( int $timestamp, string $hook, array $args = array(), string $group = '' ): int {
 	++$GLOBALS['datamachine_rs_scheduled_single'];
+	if ( is_array( $GLOBALS['datamachine_rs_single_reentrant'] ) ) {
+		$requested                                  = $GLOBALS['datamachine_rs_single_reentrant'];
+		$GLOBALS['datamachine_rs_single_reentrant'] = null;
+		$GLOBALS['datamachine_rs_reentrant_result'] = \DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule(
+			$hook,
+			$args,
+			$requested['interval'],
+			$requested['options'] + array( 'group' => $group )
+		);
+	}
 	datamachine_rs_seed_action( $hook, $args, $group, new DmRecurringSchedulerFakeSchedule( false, null, $timestamp ) );
 	return 101;
 }
@@ -313,6 +386,7 @@ function as_schedule_cron_action( int $timestamp, string $expression, string $ho
 }
 
 require_once __DIR__ . '/../inc/Core/OptionLeaseStore.php';
+require_once __DIR__ . '/../inc/Engine/Tasks/GenerationFencedAction.php';
 require_once __DIR__ . '/../inc/Engine/Tasks/RecurringScheduler.php';
 
 use DataMachine\Engine\Tasks\RecurringScheduler;
@@ -458,7 +532,7 @@ $GLOBALS['datamachine_rs_schedule_race'] = true;
 $result                                  = datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_recurring_retention_as_actions', array(), 'hourly' ) );
 datamachine_assert( 1 === datamachine_rs_pending_count( 'datamachine_recurring_retention_as_actions', array(), RecurringScheduler::GROUP ), 'concurrent reconciliation preserves exactly one pending chain' );
 datamachine_assert( array( true ) === $GLOBALS['datamachine_rs_recurring_unique'], 'recurring reconciliation requests Action Scheduler uniqueness' );
-datamachine_assert( 0 === datamachine_rs_counter( 'datamachine_rs_unscheduled' ), 'initial reconciliation does not cancel a concurrent healthy chain' );
+datamachine_assert( 1 === datamachine_rs_counter( 'datamachine_rs_unscheduled' ), 'fenced reconciliation clears the pre-existing slot before atomic unique creation' );
 
 echo "\n[15] all recurring and cron replacement paths request Action Scheduler uniqueness (#2892)\n";
 datamachine_rs_reset();
@@ -486,6 +560,9 @@ $GLOBALS['datamachine_rs_reentrant_race'] = true;
 datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_per_flow', array( 42 ), 'hourly' ) );
 datamachine_assert( $GLOBALS['datamachine_rs_reentrant_result'] instanceof WP_Error, 'contending reconciliation receives a retryable lock error' );
 datamachine_assert( 'schedule_lock_timeout' === $GLOBALS['datamachine_rs_reentrant_result']->get_error_code(), 'contention reports schedule_lock_timeout' );
+$lock_data = $GLOBALS['datamachine_rs_reentrant_result']->get_error_data();
+datamachine_assert( 409 === ( $lock_data['status'] ?? 0 ), 'lock timeout preserves conflict status metadata' );
+datamachine_assert( true === ( $lock_data['retryable'] ?? false ), 'lock timeout is explicitly retryable' );
 datamachine_assert( 1 === datamachine_rs_pending_count( 'datamachine_per_flow', array( 42 ), RecurringScheduler::GROUP ), 'outer owner creates exactly one pending chain' );
 
 echo "\n[19] transient lease contention retries before scheduling\n";
@@ -501,5 +578,96 @@ datamachine_rs_seed_action( 'datamachine_running', array( 9 ), RecurringSchedule
 $result = datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_running', array( 9 ), 'hourly' ) );
 datamachine_assert( true === ( $result['preserved'] ?? false ), 'running recurrence is preserved as the current owner' );
 datamachine_assert( 0 === datamachine_rs_counter( 'datamachine_rs_scheduled_recurring' ), 'running recurrence does not spawn a parallel pending chain' );
+
+echo "\n[21] concurrent one-time callers create exactly one action\n";
+datamachine_rs_reset();
+$one_time = time() + 3600;
+$GLOBALS['datamachine_rs_single_reentrant'] = array(
+	'interval' => 'one_time',
+	'options'  => array( 'timestamp' => $one_time ),
+);
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_once_race', array( 11 ), 'one_time', array( 'timestamp' => $one_time ) ) );
+datamachine_assert( $GLOBALS['datamachine_rs_reentrant_result'] instanceof WP_Error, 'second one-time caller is fenced while the owner schedules' );
+datamachine_assert( 1 === datamachine_rs_pending_count( 'datamachine_once_race', array( 11 ), RecurringScheduler::GROUP ), 'one-time race leaves exactly one pending action' );
+
+echo "\n[22] cross-caller mutation cannot cancel a locked one-time owner\n";
+datamachine_rs_reset();
+$GLOBALS['datamachine_rs_single_reentrant'] = array(
+	'interval' => 'hourly',
+	'options'  => array(),
+);
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_cross_caller', array( 12 ), 'one_time', array( 'timestamp' => $one_time ) ) );
+datamachine_assert( 'schedule_lock_timeout' === $GLOBALS['datamachine_rs_reentrant_result']->get_error_code(), 'cross-caller cadence update cannot enter the owner mutation' );
+datamachine_assert( 1 === datamachine_rs_pending_count( 'datamachine_cross_caller', array( 12 ), RecurringScheduler::GROUP ), 'locked one-time action survives the contending cadence update' );
+
+echo "\n[23] manual transition fences a running recurrence before AS repeat\n";
+datamachine_rs_reset();
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_running_disable', array( 13 ), 'hourly' ) );
+$old_schedule = new DmRecurringSchedulerFakeSchedule( true, 3600, time() );
+$old_action   = RecurringScheduler::fenceStoredAction( new ActionScheduler_Action( 'datamachine_running_disable', array( 13 ), $old_schedule, RecurringScheduler::GROUP ), 'datamachine_running_disable', array( 13 ), $old_schedule, RecurringScheduler::GROUP, 10 );
+datamachine_assert( $old_action->get_schedule()->is_recurring(), 'fetched running action starts on the current generation' );
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_running_disable', array( 13 ), 'manual' ) );
+datamachine_assert( ! $old_action->get_schedule()->is_recurring(), 'manual transition makes the fetched old action non-recurring before repeat' );
+datamachine_assert( 0 === datamachine_rs_pending_count( 'datamachine_running_disable', array( 13 ), RecurringScheduler::GROUP ), 'manual transition leaves no successor' );
+
+echo "\n[24] cadence transition fences the old running schedule\n";
+datamachine_rs_reset();
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_running_change', array( 14 ), 'hourly' ) );
+$old_schedule = new DmRecurringSchedulerFakeSchedule( true, 3600, time() );
+$old_action   = RecurringScheduler::fenceStoredAction( new ActionScheduler_Action( 'datamachine_running_change', array( 14 ), $old_schedule, RecurringScheduler::GROUP ), 'datamachine_running_change', array( 14 ), $old_schedule, RecurringScheduler::GROUP, 10 );
+$key          = datamachine_rs_key( 'datamachine_running_change', array( 14 ), RecurringScheduler::GROUP );
+$GLOBALS['datamachine_rs_actions'][ $key ]['pending'] = array();
+datamachine_rs_seed_action( 'datamachine_running_change', array( 14 ), RecurringScheduler::GROUP, $old_schedule, 'in-progress' );
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_running_change', array( 14 ), 'daily' ) );
+datamachine_assert( ! $old_action->get_schedule()->is_recurring(), 'old fetched hourly action cannot repeat after daily transition' );
+$new_action = reset( $GLOBALS['datamachine_rs_actions'][ $key ]['pending'] );
+datamachine_assert( 86400 === $new_action->get_schedule()->get_recurrence(), 'exactly one daily successor owns the new generation' );
+
+echo "\n[25] stale owner cannot mutate after lease takeover during a slow query\n";
+datamachine_rs_reset();
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_stale_owner', array( 15 ), 'hourly' ) );
+$GLOBALS['datamachine_rs_steal_lock_on_query'] = true;
+$result = RecurringScheduler::ensureSchedule( 'datamachine_stale_owner', array( 15 ), 'daily' );
+datamachine_assert( $result instanceof WP_Error, 'owner that lost its lease returns an error' );
+datamachine_assert( 'schedule_lock_lost' === $result->get_error_code(), 'stale owner reports schedule_lock_lost' );
+datamachine_assert( true === ( $result->get_error_data()['retryable'] ?? false ), 'lost ownership propagates retry metadata' );
+datamachine_assert( 1 === datamachine_rs_pending_count( 'datamachine_stale_owner', array( 15 ), RecurringScheduler::GROUP ), 'stale owner leaves the existing cadence untouched' );
+
+echo "\n[26] ScheduleFlowAbility has no direct Action Scheduler mutation path\n";
+$schedule_flow_source    = file_get_contents( __DIR__ . '/../inc/Abilities/Engine/ScheduleFlowAbility.php' ) ?: '';
+$plugin_source           = file_get_contents( __DIR__ . '/../data-machine.php' ) ?: '';
+$flow_scheduling_source = file_get_contents( __DIR__ . '/../inc/Api/Flows/FlowScheduling.php' ) ?: '';
+datamachine_assert( ! str_contains( $schedule_flow_source, 'as_unschedule_all_actions' ), 'schedule-flow ability does not unschedule outside the primitive' );
+datamachine_assert( ! str_contains( $schedule_flow_source, 'as_schedule_single_action' ), 'schedule-flow ability does not create one-time actions outside the primitive' );
+datamachine_assert( str_contains( $schedule_flow_source, "array( 'interval' => 'manual' )" ), 'manual transition delegates to FlowScheduling' );
+datamachine_assert( str_contains( $schedule_flow_source, "'interval'  => 'one_time'" ), 'one-time transition delegates to FlowScheduling' );
+datamachine_assert( str_contains( $schedule_flow_source, "'retry_after_ms'" ), 'ability response preserves retry/status metadata' );
+datamachine_assert( str_contains( $plugin_source, 'RecurringScheduler::registerGenerationFence()' ), 'generation fence is registered for every Action Scheduler runner request' );
+datamachine_assert( str_contains( $flow_scheduling_source, "'force_reschedule' => \$force" ), 'flow force transitions reach the fenced primitive' );
+
+echo "\n[27] forced replacement fences the fetched running generation\n";
+datamachine_rs_reset();
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_running_force', array( 16 ), 'hourly' ) );
+$old_schedule = new DmRecurringSchedulerFakeSchedule( true, 3600, time() );
+$old_action   = RecurringScheduler::fenceStoredAction( new ActionScheduler_Action( 'datamachine_running_force', array( 16 ), $old_schedule, RecurringScheduler::GROUP ), 'datamachine_running_force', array( 16 ), $old_schedule, RecurringScheduler::GROUP, 10 );
+$key          = datamachine_rs_key( 'datamachine_running_force', array( 16 ), RecurringScheduler::GROUP );
+$GLOBALS['datamachine_rs_actions'][ $key ]['pending'] = array();
+datamachine_rs_seed_action( 'datamachine_running_force', array( 16 ), RecurringScheduler::GROUP, $old_schedule, 'in-progress' );
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_running_force', array( 16 ), 'hourly', array( 'force_reschedule' => true ) ) );
+datamachine_assert( ! $old_action->get_schedule()->is_recurring(), 'forced replacement invalidates the old fetched recurrence' );
+datamachine_assert( 1 === datamachine_rs_pending_count( 'datamachine_running_force', array( 16 ), RecurringScheduler::GROUP ), 'forced replacement installs exactly one successor' );
+
+echo "\n[28] cron transition fences the fetched interval generation\n";
+datamachine_rs_reset();
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_running_cron', array( 17 ), 'hourly' ) );
+$old_schedule = new DmRecurringSchedulerFakeSchedule( true, 3600, time() );
+$old_action   = RecurringScheduler::fenceStoredAction( new ActionScheduler_Action( 'datamachine_running_cron', array( 17 ), $old_schedule, RecurringScheduler::GROUP ), 'datamachine_running_cron', array( 17 ), $old_schedule, RecurringScheduler::GROUP, 10 );
+$key          = datamachine_rs_key( 'datamachine_running_cron', array( 17 ), RecurringScheduler::GROUP );
+$GLOBALS['datamachine_rs_actions'][ $key ]['pending'] = array();
+datamachine_rs_seed_action( 'datamachine_running_cron', array( 17 ), RecurringScheduler::GROUP, $old_schedule, 'in-progress' );
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_running_cron', array( 17 ), 'cron', array( 'cron_expression' => '0 0 * * *' ) ) );
+datamachine_assert( ! $old_action->get_schedule()->is_recurring(), 'cron transition invalidates the old fetched interval recurrence' );
+$new_action = reset( $GLOBALS['datamachine_rs_actions'][ $key ]['pending'] );
+datamachine_assert( '0 0 * * *' === $new_action->get_schedule()->get_recurrence(), 'cron transition installs only the desired cron successor' );
 
 echo "\nAll recurring scheduler idempotency assertions passed.\n";

--- a/tests/recurring-scheduler-idempotency-smoke.php
+++ b/tests/recurring-scheduler-idempotency-smoke.php
@@ -70,6 +70,12 @@ if ( ! function_exists( 'wp_date' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value ) {
+		return json_encode( $value );
+	}
+}
+
 if ( ! function_exists( 'apply_filters' ) ) {
 	function apply_filters( string $hook, $value ) {
 		if ( 'datamachine_scheduler_intervals' === $hook ) {

--- a/tests/recurring-scheduler-idempotency-smoke.php
+++ b/tests/recurring-scheduler-idempotency-smoke.php
@@ -654,7 +654,7 @@ datamachine_assert( str_contains( $schedule_flow_source, "array( 'interval' => '
 datamachine_assert( str_contains( $schedule_flow_source, "'interval'  => 'one_time'" ), 'one-time transition delegates to FlowScheduling' );
 datamachine_assert( str_contains( $schedule_flow_source, "'retry_after_ms'" ), 'ability response preserves retry/status metadata' );
 datamachine_assert( str_contains( $plugin_source, 'RecurringScheduler::registerGenerationFence()' ), 'generation fence is registered for every Action Scheduler runner request' );
-datamachine_assert( str_contains( $flow_scheduling_source, "'force_reschedule' => \$force" ), 'flow force transitions reach the fenced primitive' );
+datamachine_assert( str_contains( $flow_scheduling_source, "'force_reschedule'" ) && str_contains( $flow_scheduling_source, '$force' ), 'flow force transitions reach the fenced primitive' );
 
 echo "\n[27] forced replacement fences the fetched running generation\n";
 datamachine_rs_reset();
@@ -734,7 +734,7 @@ $execute_position    = strpos( $queue_runner_source, '$action->execute()' );
 $repeat_position     = strpos( $queue_runner_source, '$action->get_schedule()->is_recurring()' );
 datamachine_assert( false !== $execute_position && false !== $repeat_position && $execute_position < $repeat_position, 'bundled AS re-reads the fetched action schedule after callback execution' );
 datamachine_assert( str_contains( $factory_source, '$schedule = $action->get_schedule();' ) && str_contains( $factory_source, '$this->store( $new_action )' ), 'bundled AS repeats from the fetched action schedule object' );
-datamachine_assert( str_contains( $scheduler_source, "'action_scheduler_stored_action'" ) && str_contains( $scheduler_source, 'cancel_action( $action_id )' ), 'post-store reconciliation cancels a stale native successor' );
+datamachine_assert( str_contains( $scheduler_source, "'action_scheduler_stored_action'" ) && str_contains( $scheduler_source, 'cancelExactAction( $action_id )' ), 'post-store reconciliation cancels a stale native successor by exact action ID' );
 
 echo "\n[33] desired-state persistence failure prevents schedule mutation\n";
 datamachine_rs_reset();

--- a/tests/recurring-scheduler-idempotency-smoke.php
+++ b/tests/recurring-scheduler-idempotency-smoke.php
@@ -708,7 +708,8 @@ echo "\n[30] public unschedule compatibility uses the fenced primitive\n";
 datamachine_rs_reset();
 datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_public_unschedule', array( 19 ), 'hourly' ) );
 $GLOBALS['datamachine_rs_unscheduled'] = 0;
-RecurringScheduler::unschedule( 'datamachine_public_unschedule', array( 19 ) );
+$unschedule_result = RecurringScheduler::unschedule( 'datamachine_public_unschedule', array( 19 ) );
+datamachine_assert_schedule_result( $unschedule_result );
 datamachine_assert( 0 === datamachine_rs_pending_count( 'datamachine_public_unschedule', array( 19 ), RecurringScheduler::GROUP ), 'legacy public unschedule removes the pending schedule' );
 datamachine_assert( 1 === datamachine_rs_counter( 'datamachine_rs_unscheduled' ), 'legacy public unschedule performs one fenced mutation' );
 
@@ -718,8 +719,8 @@ $delete_pipeline_source = file_get_contents( __DIR__ . '/../inc/Abilities/Pipeli
 $pause_flow_source      = file_get_contents( __DIR__ . '/../inc/Abilities/Flow/PauseFlowAbility.php' ) ?: '';
 $create_flow_source     = file_get_contents( __DIR__ . '/../inc/Abilities/Flow/CreateFlowAbility.php' ) ?: '';
 $engine_source          = file_get_contents( __DIR__ . '/../inc/Engine/Actions/Engine.php' ) ?: '';
-datamachine_assert( str_contains( $delete_flow_source, 'is_wp_error( $schedule_result )' ), 'flow deletion stops on scheduler failure' );
-datamachine_assert( strpos( $delete_pipeline_source, 'is_wp_error( $schedule_result )' ) < strpos( $delete_pipeline_source, 'delete_flow( (int) $flow_id )' ), 'pipeline deletion fences every flow before database deletion' );
+datamachine_assert( str_contains( $delete_flow_source, 'commitDesiredSchedule' ), 'flow deletion commits desired absence under the schedule lease' );
+datamachine_assert( str_contains( $delete_pipeline_source, "'schedule_failures'" ), 'pipeline deletion aggregates schedule reconciliation failures' );
 datamachine_assert( str_contains( $pause_flow_source, "'status'  => 'pause_error'" ), 'pause reports scheduler failure instead of success' );
 datamachine_assert( str_contains( $create_flow_source, "'schedule_cleanup'" ), 'creation rollback records failed schedule compensation' );
 datamachine_assert( str_contains( $engine_source, 'Orphaned schedule cleanup deferred after ownership failure' ), 'orphan cleanup records retryable scheduler failure' );
@@ -728,9 +729,59 @@ datamachine_assert( str_contains( $schedule_flow_source, 'SCHEDULE_GENERATION_PR
 echo "\n[32] generation fence matches bundled Action Scheduler repeat order\n";
 $queue_runner_source = file_get_contents( __DIR__ . '/../vendor/woocommerce/action-scheduler/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php' ) ?: '';
 $factory_source      = file_get_contents( __DIR__ . '/../vendor/woocommerce/action-scheduler/classes/ActionScheduler_ActionFactory.php' ) ?: '';
+$scheduler_source    = file_get_contents( __DIR__ . '/../inc/Engine/Tasks/RecurringScheduler.php' ) ?: '';
 $execute_position    = strpos( $queue_runner_source, '$action->execute()' );
 $repeat_position     = strpos( $queue_runner_source, '$action->get_schedule()->is_recurring()' );
 datamachine_assert( false !== $execute_position && false !== $repeat_position && $execute_position < $repeat_position, 'bundled AS re-reads the fetched action schedule after callback execution' );
 datamachine_assert( str_contains( $factory_source, '$schedule = $action->get_schedule();' ) && str_contains( $factory_source, '$this->store( $new_action )' ), 'bundled AS repeats from the fetched action schedule object' );
+datamachine_assert( str_contains( $scheduler_source, "'action_scheduler_stored_action'" ) && str_contains( $scheduler_source, 'cancel_action( $action_id )' ), 'post-store reconciliation cancels a stale native successor' );
+
+echo "\n[33] desired-state persistence failure prevents schedule mutation\n";
+datamachine_rs_reset();
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_commit_failure', array( 20 ), 'hourly' ) );
+$GLOBALS['datamachine_rs_unscheduled'] = 0;
+$result = RecurringScheduler::commitDesiredSchedule(
+	'datamachine_commit_failure',
+	array( 20 ),
+	'daily',
+	array(),
+	true,
+	static fn(): bool => false,
+	static fn(): bool => true
+);
+datamachine_assert( $result instanceof WP_Error, 'failed desired-state commit returns an error' );
+datamachine_assert( 'schedule_state_commit_failed' === $result->get_error_code(), 'persistence failure is observable' );
+datamachine_assert( true === ( $result->get_error_data()['retryable'] ?? false ), 'persistence failure is explicitly retryable' );
+datamachine_assert( 0 === datamachine_rs_counter( 'datamachine_rs_unscheduled' ), 'persistence failure performs no destructive AS mutation' );
+$key = datamachine_rs_key( 'datamachine_commit_failure', array( 20 ), RecurringScheduler::GROUP );
+$preserved_action = reset( $GLOBALS['datamachine_rs_actions'][ $key ]['pending'] );
+datamachine_assert( 3600 === $preserved_action->get_schedule()->get_recurrence(), 'old schedule remains intact when desired state cannot commit' );
+
+echo "\n[34] desired commit and drift recording remain inside the signature lease\n";
+datamachine_rs_reset();
+datamachine_assert_schedule_result( RecurringScheduler::ensureSchedule( 'datamachine_commit_race', array( 21 ), 'hourly' ) );
+$commit_contender = null;
+$record_contender = null;
+$result = RecurringScheduler::commitDesiredSchedule(
+	'datamachine_commit_race',
+	array( 21 ),
+	'daily',
+	array(),
+	true,
+	static function () use ( &$commit_contender ): bool {
+		$commit_contender = RecurringScheduler::ensureSchedule( 'datamachine_commit_race', array( 21 ), 'manual' );
+		return true;
+	},
+	static function () use ( &$record_contender ): bool {
+		$record_contender = RecurringScheduler::ensureSchedule( 'datamachine_commit_race', array( 21 ), 'manual' );
+		return true;
+	}
+);
+datamachine_assert_schedule_result( $result );
+datamachine_assert( $commit_contender instanceof WP_Error && 'schedule_lock_timeout' === $commit_contender->get_error_code(), 'contender cannot mutate between desired commit and reconciliation' );
+datamachine_assert( $record_contender instanceof WP_Error && 'schedule_lock_timeout' === $record_contender->get_error_code(), 'contender cannot mutate before reconciliation status persistence' );
+$key = datamachine_rs_key( 'datamachine_commit_race', array( 21 ), RecurringScheduler::GROUP );
+$committed_action = reset( $GLOBALS['datamachine_rs_actions'][ $key ]['pending'] );
+datamachine_assert( 86400 === $committed_action->get_schedule()->get_recurrence(), 'committed desired cadence wins both races' );
 
 echo "\nAll recurring scheduler idempotency assertions passed.\n";

--- a/tests/run-flow-empty-drain-queue-smoke.php
+++ b/tests/run-flow-empty-drain-queue-smoke.php
@@ -9,6 +9,7 @@
 
 $run_flow_file = __DIR__ . '/../inc/Abilities/Engine/RunFlowAbility.php';
 $run_flow_src  = file_get_contents( $run_flow_file ) ?: '';
+$queue_src     = file_get_contents( __DIR__ . '/../inc/Abilities/Flow/QueueAbility.php' ) ?: '';
 
 $assertions = 0;
 
@@ -29,11 +30,12 @@ function assert_run_flow_empty_drain_contains( string $needle, string $haystack,
 assert_run_flow_empty_drain_contains( 'use DataMachine\\Abilities\\Flow\\QueueAbility;', $run_flow_src, 'run-flow ability imports queue slot constants' );
 assert_run_flow_empty_drain_contains( '$empty_drain_skip = $this->getEmptyDrainQueueSkip( $flow_config );', $run_flow_src, 'run-flow checks empty drain queues' );
 assert_run_flow_empty_drain_contains( "'reason'     => 'empty_drain_queue'", $run_flow_src, 'empty drain skip returns explicit reason' );
-assert_run_flow_empty_drain_contains( '\'drain\' !== (string) ( $first_step[\'queue_mode\'] ?? \'static\' )', $run_flow_src, 'skip is scoped to drain mode' );
-assert_run_flow_empty_drain_contains( 'QueueAbility::SLOT_CONFIG_PATCH_QUEUE', $run_flow_src, 'skip checks the config patch queue slot' );
+assert_run_flow_empty_drain_contains( 'QueueAbility::firstDrainQueueWorkAvailability( $flow_config )', $run_flow_src, 'skip delegates drain-mode and queue-slot resolution' );
+assert_run_flow_empty_drain_contains( 'self::SLOT_CONFIG_PATCH_QUEUE', $queue_src, 'queue availability checks the config patch queue slot' );
 assert_run_flow_empty_drain_contains( '$this->recordSuppressedRun( $flow_id, $scheduling_config, $empty_drain_skip );', $run_flow_src, 'empty drain skip records scheduler suppression metadata' );
 assert_run_flow_empty_drain_contains( "'datamachine_last_suppressed_run'", $run_flow_src, 'suppression marker uses explicit Data Machine scheduling key' );
 assert_run_flow_empty_drain_contains( "'backoff_until'", $run_flow_src, 'suppression marker records backoff boundary for status' );
+assert_run_flow_empty_drain_contains( 'update_flow_scheduling_metadata(', $run_flow_src, 'suppression metadata cannot overwrite concurrent desired scheduling state' );
 
 $skip_pos       = strpos( $run_flow_src, '$empty_drain_skip = $this->getEmptyDrainQueueSkip( $flow_config );' );
 $create_job_pos = strpos( $run_flow_src, '$job_id = $this->db_jobs->create_job( $job_data );' );

--- a/tests/worker-lock-smoke.php
+++ b/tests/worker-lock-smoke.php
@@ -95,6 +95,13 @@ $before_refresh = (int) $GLOBALS['datamachine_worker_lock_options']['datamachine
 assert_worker_lock_true( OptionLeaseStore::refresh( 'datamachine_worker_runtime_lock', (string) $first['lock_token'], 120, time() + 5 ), 'owned lease refresh succeeds' );
 assert_worker_lock_true( (int) $GLOBALS['datamachine_worker_lock_options']['datamachine_worker_runtime_lock']['expires_at'] > $before_refresh, 'refresh extends the owned lease' );
 assert_worker_lock_true( ! OptionLeaseStore::refresh( 'datamachine_worker_runtime_lock', 'wrong-token', 120 ), 'wrong token cannot refresh a lease' );
+$lease_payload = OptionLeaseStore::refreshOwned( 'datamachine_worker_runtime_lock', (string) $first['lock_token'], 120 );
+add_option( 'datamachine_test_generation', 'generation-1', '', 'no' );
+assert_worker_lock_true( is_array( $lease_payload ), 'refresh returns the exact owned lease payload' );
+assert_worker_lock_true( OptionLeaseStore::compareAndSwapWhileOwned( 'datamachine_test_generation', 'generation-1', 'generation-2', 'datamachine_worker_runtime_lock', $lease_payload ), 'generation CAS succeeds under the exact lease payload' );
+$GLOBALS['datamachine_worker_lock_options']['datamachine_worker_runtime_lock']['token'] = 'takeover-token';
+assert_worker_lock_true( ! OptionLeaseStore::compareAndSwapWhileOwned( 'datamachine_test_generation', 'generation-2', 'generation-3', 'datamachine_worker_runtime_lock', $lease_payload ), 'stale owner cannot CAS generation after takeover' );
+$GLOBALS['datamachine_worker_lock_options']['datamachine_worker_runtime_lock'] = $lease_payload;
 
 $second = WorkerLock::acquire( 'worker two', 120 );
 assert_worker_lock_true( false === $second['acquired'], 'overlapping worker skips cleanly' );

--- a/tests/worker-lock-smoke.php
+++ b/tests/worker-lock-smoke.php
@@ -74,6 +74,7 @@ require_once __DIR__ . '/../inc/Core/OptionLeaseStore.php';
 require_once __DIR__ . '/../inc/Cli/WorkerLock.php';
 
 use DataMachine\Cli\WorkerLock;
+use DataMachine\Core\OptionLeaseStore;
 
 $assertions = 0;
 
@@ -90,6 +91,10 @@ $first = WorkerLock::acquire( 'worker one', 120 );
 assert_worker_lock_true( true === $first['acquired'], 'first worker acquires the lock' );
 assert_worker_lock_true( 'held' === $first['lock_status'], 'acquired lock reports held status' );
 assert_worker_lock_true( 'worker one' === $first['lock_owner'], 'lock reports owner' );
+$before_refresh = (int) $GLOBALS['datamachine_worker_lock_options']['datamachine_worker_runtime_lock']['expires_at'];
+assert_worker_lock_true( OptionLeaseStore::refresh( 'datamachine_worker_runtime_lock', (string) $first['lock_token'], 120, time() + 5 ), 'owned lease refresh succeeds' );
+assert_worker_lock_true( (int) $GLOBALS['datamachine_worker_lock_options']['datamachine_worker_runtime_lock']['expires_at'] > $before_refresh, 'refresh extends the owned lease' );
+assert_worker_lock_true( ! OptionLeaseStore::refresh( 'datamachine_worker_runtime_lock', 'wrong-token', 120 ), 'wrong token cannot refresh a lease' );
 
 $second = WorkerLock::acquire( 'worker two', 120 );
 assert_worker_lock_true( false === $second['acquired'], 'overlapping worker skips cleanly' );


### PR DESCRIPTION
## Summary
- serialize each generic `(hook, args, group)` schedule reconciliation with the existing option-backed lease primitive
- preserve a matching in-progress action as the current schedule owner instead of creating a parallel pending chain
- cover reentrant races, transient lease retry, running ownership, independent argument tuples, and existing recurring/cron/one-time behavior

## Production revalidation
Read-only evidence from `events.extrachill.com` on 2026-07-22 UTC:

| Signal | Historical incident | Current |
|---|---:|---:|
| Action creation | ~3.2M/day initially; peak ~8M/day | 5,358 in trailing 24h; 3,588 in trailing 1h |
| `datamachine_run_flow_now` coverage | 687 pending / 665 distinct flows | 659 pending / 659 distinct args |
| Duplicate flow signatures | 22 duplicate flows historically | 0 pending or in-progress duplicates |
| Flow coverage audit | not available during incident | 659 eligible, 659 covered, 0 missing/blocked/invalid |
| Far-future pending actions | one 2030 action | 0 beyond one year |
| AS actions table | 25.6M rows / ~21.6GB | ~10.3k rows / 17MB |
| AS logs table | 76M rows / ~9GB | ~30k rows / 7MB |
| Sampled orphan logs | historical concern | 0 in latest 10,000 nonzero log rows |

The original #2793 runaway was the uncapped AI concurrency defer loop fixed by #2795 and is not recurring. Current creation is concentrated in ordinary `datamachine_execute_step` / `datamachine_resume_ai_step` work, not duplicate flow schedules.

## Remaining root cause
Action Scheduler uniqueness is hook+group scoped. Data Machine therefore correctly disables native uniqueness for argument-bearing schedules so hundreds of flows sharing `datamachine_run_flow_now` remain independent. However, `RecurringScheduler::ensureSchedule()` still used an unlocked read/unschedule/create sequence for those signatures. Concurrent updates could both observe no matching action and create parallel chains.

This PR puts that generic sequence behind a short tokened lease keyed by the complete hook/args/group signature. Contenders retry boundedly and then return `schedule_lock_timeout`; they never touch the existing action. Empty-args schedules retain Action Scheduler native uniqueness as a second guard.

## No-action-loss argument
- the lease is acquired before any schedule read, cancellation, or creation
- a losing contender cannot unschedule the owner's action
- matching pending or running work is preserved
- changed schedules are replaced only by the lease owner
- lock timeout leaves all actions unchanged and is retryable
- release is token-safe and runs in `finally`; stale takeover is handled by the existing `OptionLeaseStore`
- independent flow args receive independent lease keys, so one flow cannot suppress another flow's recurrence

## Retention / #2792
- native Action Scheduler retention resolves to 30 days
- Data Machine AS retention is enabled at 2 days plus per-hook windows
- exactly one `datamachine_recurring_retention_as_actions` action is pending
- bounded AS preview found 248 actions and 744 attached logs eligible
- the stored worker/drain lock expired on 2026-07-19 and reports `stale`; `WorkerLock::acquire()` atomically takes over stale leases, so no lock clearing is needed
- no retention code change is justified here: actions+logs are already bounded and owned by the existing generic retention layer

Operator dry-run plan after merge: first run `wp --url=events.extrachill.com datamachine retention run --dry-run --format=json`, review per-domain counts, then separately inspect AS table counts/sizes and the retention recurrence before any `--yes` run. During this investigation that all-domain dry-run exceeded 120 seconds and was terminated without output; diagnose that read-only preview before applying cleanup. Do not optimize tables or clear locks as part of this PR.

## Verification
Passed:
- `php tests/recurring-scheduler-idempotency-smoke.php`
- `php tests/flow-schedule-reconciler-smoke.php`
- `php tests/flow-schedule-reconciliation-wiring-smoke.php`
- `php tests/recurring-scheduler-as-readiness-smoke.php`
- `php tests/prefix-policy-audit.php`
- `vendor/bin/phpcs inc/Engine/Tasks/RecurringScheduler.php tests/recurring-scheduler-idempotency-smoke.php`
- PHP syntax checks and `git diff --check`

Limitations:
- `homeboy review --changed-only --summary` was refused before execution by the warm-machine resource policy (load 8.1/8 CPUs)
- PHPStan is not installed in this checkout (`vendor/bin` contains PHPCS/PHPCBF only)
- `tests/retention-action-scheduler-batching-smoke.php` has 36 passing functional assertions and 2 pre-existing whitespace-sensitive source assertions; tracked in #2963, with no diff from `origin/main` in the retention files

Closes #2793
Refs #2792