### PR TITLE
fix: recover pathless child jobs safely

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -74,6 +74,15 @@ class ExecuteStepAbility {
 								'minimum'     => 0,
 								'description' => __( 'AI contention resume ownership generation.', 'data-machine' ),
 							),
+							'recovery_generation'   => array(
+								'type'        => 'integer',
+								'minimum'     => 0,
+								'description' => __( 'Pathless-child recovery ownership generation.', 'data-machine' ),
+							),
+							'recovery_claim_token'  => array(
+								'type'        => 'string',
+								'description' => __( 'Pathless-child recovery ownership token.', 'data-machine' ),
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -117,12 +126,21 @@ class ExecuteStepAbility {
 		$operation_generation  = max( 0, (int) ( $input['operation_generation'] ?? 0 ) );
 		$operation_claim_token = (string) ( $input['operation_claim_token'] ?? '' );
 		$ai_resume_generation  = max( 0, (int) ( $input['ai_resume_generation'] ?? 0 ) );
+		$recovery_generation   = max( 0, (int) ( $input['recovery_generation'] ?? 0 ) );
+		$recovery_claim_token  = (string) ( $input['recovery_claim_token'] ?? '' );
 		$job                   = $this->db_jobs->get_job( $job_id );
 
 		if ( ! $job ) {
 			return array(
 				'success' => false,
 				'error'   => sprintf( 'Job %d not found.', $job_id ),
+			);
+		}
+		if ( $recovery_generation > 0 && ! $this->recoveryGenerationAdmission( $job, $recovery_generation, $recovery_claim_token ) ) {
+			return array(
+				'success'              => false,
+				'stale_recovery_owner' => true,
+				'error'                => sprintf( 'Job %d recovery generation %d is stale or lacks a committed receipt.', $job_id, $recovery_generation ),
 			);
 		}
 
@@ -387,6 +405,18 @@ class ExecuteStepAbility {
 		}
 
 		return 'enqueuing' === ( $job['operation_state'] ?? '' ) ? 'pending_commit' : 'stale';
+	}
+
+	private function recoveryGenerationAdmission( array $job, int $generation, string $token ): bool {
+		$engine  = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$owner   = is_array( $engine['scheduler_recovery'] ?? null ) ? $engine['scheduler_recovery'] : array();
+		$receipt = is_array( $owner['receipt'] ?? null ) ? $owner['receipt'] : array();
+
+		return '' !== $token
+			&& 'requeued' === (string) ( $owner['state'] ?? '' )
+			&& (int) ( $owner['generation'] ?? 0 ) === $generation
+			&& (int) ( $receipt['generation'] ?? 0 ) === $generation
+			&& hash_equals( $token, (string) ( $owner['token'] ?? '' ) );
 	}
 
 	private function deferOperationGeneration( int $job_id, string $flow_step_id, int $generation, string $token ): array {

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -16,10 +16,12 @@ namespace DataMachine\Abilities\Engine;
 
 use DataMachine\Abilities\StepTypeAbilities;
 use DataMachine\Core\EngineData;
+use DataMachine\Core\ChildJobRecoveryPolicy;
 use DataMachine\Core\FilesRepository\FileCleanup;
 use DataMachine\Core\FilesRepository\FileRetrieval;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\RunMetrics;
+use DataMachine\Core\RecoveryExecutionFence;
 use DataMachine\Core\StepExecutionResult;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\Step;
@@ -137,11 +139,7 @@ class ExecuteStepAbility {
 			);
 		}
 		if ( $recovery_generation > 0 && ! $this->recoveryGenerationAdmission( $job, $recovery_generation, $recovery_claim_token ) ) {
-			return array(
-				'success'              => false,
-				'stale_recovery_owner' => true,
-				'error'                => sprintf( 'Job %d recovery generation %d is stale or lacks a committed receipt.', $job_id, $recovery_generation ),
-			);
+			return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'is stale or lacks a committed receipt' );
 		}
 
 		if ( $operation_generation > 0 ) {
@@ -162,6 +160,7 @@ class ExecuteStepAbility {
 				'terminal_state' => $current_status,
 			);
 		}
+		$recovery_fence = $recovery_generation > 0 ? new RecoveryExecutionFence( $job_id, $recovery_claim_token, $recovery_generation ) : null;
 
 		// Transition job to 'processing' now that Action Scheduler is actually
 		// executing it. For parent jobs this is a no-op (already processing via
@@ -197,6 +196,9 @@ class ExecuteStepAbility {
 			$flow_step_config = $this->resolveFlowStepConfig( $engine, $flow_step_id, $job_id, $engine_snapshot );
 
 			if ( ! isset( $flow_step_config['flow_id'] ) || empty( $flow_step_config['flow_id'] ) ) {
+				if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+					return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before missing-flow failure routing' );
+				}
 				do_action(
 					'datamachine_fail_job',
 					$job_id,
@@ -226,6 +228,9 @@ class ExecuteStepAbility {
 			}
 
 			if ( ! isset( $flow_step_config['step_type'] ) || empty( $flow_step_config['step_type'] ) ) {
+				if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+					return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before missing-step failure routing' );
+				}
 				do_action(
 					'datamachine_fail_job',
 					$job_id,
@@ -242,9 +247,22 @@ class ExecuteStepAbility {
 			}
 
 			$step_type       = $flow_step_config['step_type'];
-			$step_definition = $this->resolveStepDefinition( $step_type, $flow_step_id, $job_id );
+			$step_definition = $this->resolveStepDefinition( $step_type );
 
 			if ( ! $step_definition ) {
+				if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+					return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before registry failure routing' );
+				}
+				do_action(
+					'datamachine_fail_job',
+					$job_id,
+					'step_execution_failure',
+					array(
+						'flow_step_id' => $flow_step_id,
+						'step_type'    => $step_type,
+						'reason'       => 'step_type_not_found_in_registry',
+					)
+				);
 				return array(
 					'success' => false,
 					'error'   => sprintf( 'Step type "%s" not found in registry.', $step_type ),
@@ -265,6 +283,9 @@ class ExecuteStepAbility {
 			);
 
 			$step_output = $flow_step->execute( $payload );
+			if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+				return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded during execution' );
+			}
 			if ( $operation_generation > 0 ) {
 				$job_after_execution = $this->db_jobs->get_job( $job_id );
 				if ( ! is_array( $job_after_execution ) || 'committed' !== $this->operationGenerationAdmission( $job_after_execution, $operation_generation, $operation_claim_token ) ) {
@@ -315,6 +336,9 @@ class ExecuteStepAbility {
 					return $this->staleOperationGeneration( $job_id, $operation_generation, 'was superseded before routing' );
 				}
 			}
+			if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+				return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before routing' );
+			}
 
 			$result = $this->routeAfterExecution(
 				$job_id,
@@ -327,8 +351,13 @@ class ExecuteStepAbility {
 				$payload,
 				$step_success,
 				$status_override,
-				$execution_result
+				$execution_result,
+				$recovery_generation,
+				$recovery_claim_token
 			);
+			if ( ! empty( $result['stale_recovery_owner'] ) ) {
+				return $result;
+			}
 
 			$recorded_status = $status_override ? $status_override : ( $result['outcome'] ?? null );
 
@@ -349,6 +378,9 @@ class ExecuteStepAbility {
 
 			return $result;
 		} catch ( \Throwable $e ) {
+			if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+				return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'threw after being superseded' );
+			}
 			if ( $operation_generation > 0 ) {
 				$job_after_exception = $this->db_jobs->get_job( $job_id );
 				if ( ! is_array( $job_after_exception ) || 'committed' !== $this->operationGenerationAdmission( $job_after_exception, $operation_generation, $operation_claim_token ) ) {
@@ -408,15 +440,43 @@ class ExecuteStepAbility {
 	}
 
 	private function recoveryGenerationAdmission( array $job, int $generation, string $token ): bool {
-		$engine  = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
-		$owner   = is_array( $engine['scheduler_recovery'] ?? null ) ? $engine['scheduler_recovery'] : array();
-		$receipt = is_array( $owner['receipt'] ?? null ) ? $owner['receipt'] : array();
+		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		return ChildJobRecoveryPolicy::recoveryExecutionMatches( $engine, $generation, $token );
+	}
 
-		return '' !== $token
-			&& 'requeued' === (string) ( $owner['state'] ?? '' )
-			&& (int) ( $owner['generation'] ?? 0 ) === $generation
-			&& (int) ( $receipt['generation'] ?? 0 ) === $generation
-			&& hash_equals( $token, (string) ( $owner['token'] ?? '' ) );
+	private function recoveryGenerationStillOwned( int $job_id, int $generation, string $token ): bool {
+		if ( $generation <= 0 ) {
+			return true;
+		}
+
+		$job = $this->db_jobs->get_job( $job_id );
+		return is_array( $job ) && $this->recoveryGenerationAdmission( $job, $generation, $token );
+	}
+
+	private function staleRecoveryGeneration( int $job_id, int $generation, string $reason ): array {
+		return array(
+			'success'              => true,
+			'step_success'         => false,
+			'outcome'              => 'stale_recovery_noop',
+			'stale_recovery_owner' => true,
+			'reason'               => sprintf( 'Job %d recovery generation %d %s.', $job_id, $generation, $reason ),
+		);
+	}
+
+	private function transitionTerminalWithRecoveryFence( int $job_id, string $status, int $generation, string $token ): array {
+		if ( $generation <= 0 ) {
+			return $this->db_jobs->transition_job_status_result( $job_id, $status, true );
+		}
+
+		return $this->db_jobs->transition_recovery_execution_owned_job( $job_id, $status, $token, $generation );
+	}
+
+	private function staleRejectedTerminalTransition( int $job_id, int $generation, string $token, array $transition ): ?array {
+		if ( $generation <= 0 || ! empty( $transition['success'] ) || $this->recoveryGenerationStillOwned( $job_id, $generation, $token ) ) {
+			return null;
+		}
+
+		return $this->staleRecoveryGeneration( $job_id, $generation, 'lost ownership at the terminal commit fence' );
 	}
 
 	private function deferOperationGeneration( int $job_id, string $flow_step_id, int $generation, string $token ): array {
@@ -484,29 +544,13 @@ class ExecuteStepAbility {
 	 * Resolve and validate step type definition from the abilities registry.
 	 *
 	 * @param string $step_type    Step type identifier.
-	 * @param string $flow_step_id Flow step ID (for error context).
-	 * @param int    $job_id       Job ID (for error context).
 	 * @return array|null Step definition or null on failure.
 	 */
-	private function resolveStepDefinition( string $step_type, string $flow_step_id, int $job_id ): ?array {
+	private function resolveStepDefinition( string $step_type ): ?array {
 		$step_type_abilities = new StepTypeAbilities();
 		$step_definition     = $step_type_abilities->getStepType( $step_type );
 
-		if ( ! $step_definition ) {
-			do_action(
-				'datamachine_fail_job',
-				$job_id,
-				'step_execution_failure',
-				array(
-					'flow_step_id' => $flow_step_id,
-					'step_type'    => $step_type,
-					'reason'       => 'step_type_not_found_in_registry',
-				)
-			);
-			return null;
-		}
-
-		return $step_definition;
+		return $step_definition ? $step_definition : null;
 	}
 
 	/**
@@ -592,7 +636,9 @@ class ExecuteStepAbility {
 		array $payload,
 		bool $step_success,
 		$status_override,
-		array $execution_result = array()
+		array $execution_result = array(),
+		int $recovery_generation = 0,
+		string $recovery_claim_token = ''
 	): array {
 		$pipeline_id = $flow_step_config['pipeline_id'] ?? null;
 
@@ -618,7 +664,14 @@ class ExecuteStepAbility {
 
 		// Status override: complete with override status and clean up.
 		if ( $status_override ) {
-			$transition = $this->db_jobs->transition_job_status_result( $job_id, $status_override, true );
+			if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+				return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before override terminal routing' );
+			}
+			$transition       = $this->transitionTerminalWithRecoveryFence( $job_id, $status_override, $recovery_generation, $recovery_claim_token );
+			$stale_transition = $this->staleRejectedTerminalTransition( $job_id, $recovery_generation, $recovery_claim_token, $transition );
+			if ( null !== $stale_transition ) {
+				return $stale_transition;
+			}
 			if ( $transition['changed'] ) {
 				$cleanup = new FileCleanup();
 				$context = datamachine_get_file_context( $flow_id );
@@ -677,6 +730,9 @@ class ExecuteStepAbility {
 
 				if ( 'fail' === $transition_route['mode'] ) {
 					$transition_failure_reason = $transition_route['reason'] ?? 'transition_route_failed';
+					if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+						return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before transition failure routing' );
+					}
 					do_action(
 						'datamachine_fail_job',
 						$job_id,
@@ -711,8 +767,14 @@ class ExecuteStepAbility {
 				// producing one packet per event). A single packet is just
 				// the same job continuing to the next step.
 				if ( 'inline' === $transition_route['mode'] || $packet_count <= 1 ) {
+					if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+						return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before inline lifecycle routing' );
+					}
 					$this->handleStepLifecycleInlineContinuation( $job_id, $flow_step_config, $routed_packets );
 
+					if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+						return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before next-step scheduling' );
+					}
 					do_action(
 						'datamachine_schedule_next_step',
 						$job_id,
@@ -745,6 +807,9 @@ class ExecuteStepAbility {
 
 				$engine_snapshot = datamachine_get_engine_data( $job_id );
 				$adapter         = new ParallelMapFanoutAdapter();
+				if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+					return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before fan-out routing' );
+				}
 				$parallel_result = $adapter->dispatch(
 					$parallel_step,
 					$job_id,
@@ -756,8 +821,14 @@ class ExecuteStepAbility {
 				// continuation — the routed packets continue on this job
 				// instead of spawning children.
 				if ( ParallelMapFanoutAdapter::SHAPE_INLINE === ( $parallel_result['shape'] ?? '' ) ) {
+					if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+						return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before gated inline lifecycle routing' );
+					}
 					$this->handleStepLifecycleInlineContinuation( $job_id, $flow_step_config, $routed_packets );
 
+					if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+						return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before gated next-step scheduling' );
+					}
 					do_action(
 						'datamachine_schedule_next_step',
 						$job_id,
@@ -782,7 +853,14 @@ class ExecuteStepAbility {
 				);
 			}
 
-			$transition = $this->db_jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
+			if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+				return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before successful terminal routing' );
+			}
+			$transition       = $this->transitionTerminalWithRecoveryFence( $job_id, JobStatus::COMPLETED, $recovery_generation, $recovery_claim_token );
+			$stale_transition = $this->staleRejectedTerminalTransition( $job_id, $recovery_generation, $recovery_claim_token, $transition );
+			if ( null !== $stale_transition ) {
+				return $stale_transition;
+			}
 			if ( $transition['changed'] ) {
 				$cleanup = new FileCleanup();
 				$context = datamachine_get_file_context( $flow_id );
@@ -848,7 +926,14 @@ class ExecuteStepAbility {
 		// Fetch/event_import legacy empty outputs classify this way, and explicit
 		// result-shaped step returns can also choose it without emitting packets.
 		if ( 'completed_no_items' === ( $execution_result['status'] ?? '' ) ) {
-			$transition = $this->db_jobs->transition_job_status_result( $job_id, JobStatus::COMPLETED_NO_ITEMS, true );
+			if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+				return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before no-items terminal routing' );
+			}
+			$transition       = $this->transitionTerminalWithRecoveryFence( $job_id, JobStatus::COMPLETED_NO_ITEMS, $recovery_generation, $recovery_claim_token );
+			$stale_transition = $this->staleRejectedTerminalTransition( $job_id, $recovery_generation, $recovery_claim_token, $transition );
+			if ( null !== $stale_transition ) {
+				return $stale_transition;
+			}
 			if ( ! $transition['success'] || ! JobStatus::isStatusSuccess( $transition['status'] ) ) {
 				return array(
 					'success'      => false,
@@ -889,6 +974,9 @@ class ExecuteStepAbility {
 		// and (when the second reason is non-retryable) trigger
 		// `cleanup_job_data_packets` even though a retry is still pending,
 		// orphaning the next attempt with no input data.
+		if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+			return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before empty-packet failure routing' );
+		}
 		do_action(
 			'datamachine_log',
 			'error',

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -282,6 +282,9 @@ class ExecuteStepAbility {
 				'engine'       => $engine,
 			);
 
+			if ( $recovery_generation > 0 && ! $this->db_jobs->renew_recovery_execution_owner( $job_id, $recovery_claim_token, $recovery_generation ) ) {
+				return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'lost ownership before handler execution' );
+			}
 			$step_output = $flow_step->execute( $payload );
 			if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
 				return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded during execution' );

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -24,7 +24,10 @@ class RecoverStuckJobsAbility {
 	private const CANDIDATE_BATCH_SIZE = 50;
 	private const JOB_DETAIL_LIMIT     = 100;
 	private const ACTION_HISTORY_LIMIT = 20;
+	private const ACTION_SCAN_PAGE_SIZE = 50;
 	private const RECOVERY_CLAIM_TTL   = 300;
+	private const DEFAULT_APPLY_LIMIT   = 25;
+	private const MAX_APPLY_LIMIT       = 100;
 
 	/**
 	 * Data Machine-owned Action Scheduler hooks that may be reconciled.
@@ -64,6 +67,23 @@ class RecoverStuckJobsAbility {
 								'type'        => array( 'integer', 'null' ),
 								'description' => __( 'Filter to recover jobs only for a specific flow ID', 'data-machine' ),
 							),
+							'job_id'        => array(
+								'type'        => array( 'integer', 'null' ),
+								'minimum'     => 1,
+								'description' => __( 'Recover one exact job ID', 'data-machine' ),
+							),
+							'limit'         => array(
+								'type'        => 'integer',
+								'minimum'     => 1,
+								'maximum'     => self::MAX_APPLY_LIMIT,
+								'default'     => self::DEFAULT_APPLY_LIMIT,
+								'description' => __( 'Hard maximum mutations in one invocation', 'data-machine' ),
+							),
+							'recover_pathless_children' => array(
+								'type'        => 'boolean',
+								'default'     => false,
+								'description' => __( 'Explicitly authorize applying pathless child recovery', 'data-machine' ),
+							),
 							'timeout_hours' => array(
 								'type'        => 'integer',
 								'default'     => 2,
@@ -88,6 +108,11 @@ class RecoverStuckJobsAbility {
 							'pathless_terminal' => array( 'type' => 'integer' ),
 							'pathless_requeued' => array( 'type' => 'integer' ),
 							'claimed_elsewhere' => array( 'type' => 'integer' ),
+							'pathless_policy_skipped' => array( 'type' => 'integer' ),
+							'mutations'     => array( 'type' => 'integer' ),
+							'apply_limit'   => array( 'type' => 'integer' ),
+							'limit_reached' => array( 'type' => 'boolean' ),
+							'scope'         => array( 'type' => 'object' ),
 							'dry_run'       => array( 'type' => 'boolean' ),
 							'jobs'          => array( 'type' => 'array' ),
 							'message'       => array( 'type' => 'string' ),
@@ -116,16 +141,28 @@ class RecoverStuckJobsAbility {
 	public function execute( array $input ): array {
 		global $wpdb;
 		$table = $wpdb->prefix . 'datamachine_jobs';
+		$requested_job_id = array_key_exists( 'job_id', $input ) && null !== $input['job_id'] ? filter_var( $input['job_id'], FILTER_VALIDATE_INT ) : null;
+		if ( array_key_exists( 'job_id', $input ) && null !== $input['job_id'] && ( false === $requested_job_id || $requested_job_id <= 0 ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'job_id must be a positive integer.',
+			);
+		}
 
 		$dry_run       = ! empty( $input['dry_run'] );
 		$flow_id       = isset( $input['flow_id'] ) && is_numeric( $input['flow_id'] ) ? (int) $input['flow_id'] : null;
+		$job_id_scope  = is_int( $requested_job_id ) ? $requested_job_id : null;
 		$timeout_hours = isset( $input['timeout_hours'] ) && is_numeric( $input['timeout_hours'] ) ? max( 1, (int) $input['timeout_hours'] ) : 2;
+		$apply_limit   = isset( $input['limit'] ) && is_numeric( $input['limit'] ) ? max( 1, min( self::MAX_APPLY_LIMIT, (int) $input['limit'] ) ) : self::DEFAULT_APPLY_LIMIT;
+		$recover_pathless_children = ! empty( $input['recover_pathless_children'] );
 
 		$recovered      = 0;
 		$skipped        = 0;
 		$jobs           = array();
 		$jobs_omitted   = 0;
 		$jobs_truncated = false;
+		$mutations      = 0;
+		$limit_reached  = false;
 
 		$last_job_id = 0;
 		while ( true ) {
@@ -136,6 +173,9 @@ class RecoverStuckJobsAbility {
 			);
 			if ( $flow_id ) {
 				$where_clause .= $wpdb->prepare( ' AND flow_id = %d', $flow_id );
+			}
+			if ( $job_id_scope ) {
+				$where_clause .= $wpdb->prepare( ' AND job_id = %d', $job_id_scope );
 			}
 
 			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Dynamic WHERE clause is prepared above; limit is an internal constant.
@@ -153,6 +193,10 @@ class RecoverStuckJobsAbility {
 			}
 
 			foreach ( $stuck_jobs as $job ) {
+				if ( ! $dry_run && $mutations >= $apply_limit ) {
+					$limit_reached = true;
+					break 2;
+				}
 				$last_job_id = max( $last_job_id, (int) $job->job_id );
 				$engine_data = $this->getJobEngineData( (int) $job->job_id );
 				$status      = $engine_data['job_status'] ?? null;
@@ -186,6 +230,7 @@ class RecoverStuckJobsAbility {
 
 					if ( $result ) {
 						++$recovered;
+						++$mutations;
 						$this->appendJobDetail( $jobs, $jobs_omitted, array(
 							'job_id'        => (int) $job->job_id,
 							'flow_id'       => (int) $job->flow_id,
@@ -212,6 +257,7 @@ class RecoverStuckJobsAbility {
 		$pathless_terminal = 0;
 		$pathless_requeued = 0;
 		$claimed_elsewhere = 0;
+		$pathless_policy_skipped = 0;
 		$recovery_trigger = isset( $input['recovery_trigger'] ) ? sanitize_key( (string) $input['recovery_trigger'] ) : 'operator';
 
 		$last_job_id = 0;
@@ -224,6 +270,9 @@ class RecoverStuckJobsAbility {
 			);
 			if ( $flow_id ) {
 				$timeout_where .= $wpdb->prepare( ' AND flow_id = %d', $flow_id );
+			}
+			if ( $job_id_scope ) {
+				$timeout_where .= $wpdb->prepare( ' AND job_id = %d', $job_id_scope );
 			}
 
 			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Dynamic WHERE clause is prepared above; limit is an internal constant.
@@ -241,6 +290,10 @@ class RecoverStuckJobsAbility {
 			}
 
 			foreach ( $timed_out_jobs as $job ) {
+				if ( ! $dry_run && $mutations >= $apply_limit ) {
+					$limit_reached = true;
+					break 2;
+				}
 				$last_job_id = max( $last_job_id, (int) $job->job_id );
 				$engine_data = $this->getJobEngineData( (int) $job->job_id );
 
@@ -277,6 +330,12 @@ class RecoverStuckJobsAbility {
 						$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, $planned_status, $recovery_trigger ) );
 						continue;
 					}
+					if ( ! $recover_pathless_children ) {
+						++$skipped;
+						++$pathless_policy_skipped;
+						$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'skipped', $recovery_trigger, 'pathless_child_apply_policy_required' ) );
+						continue;
+					}
 
 					$claim = $this->claimPathlessChildRecovery( $job_id, $recovery_trigger );
 					if ( empty( $claim['owned'] ) ) {
@@ -292,17 +351,30 @@ class RecoverStuckJobsAbility {
 					$child_diagnosis = ChildJobRecoveryPolicy::diagnose( $claimed_job, $engine_data, $this->getStepActionHistory( $job_id ), $timeout_hours * HOUR_IN_SECONDS, time() );
 					if ( ! empty( $child_diagnosis['has_active_path'] ) ) {
 						++$skipped;
-						$this->finishPathlessChildRecovery( $job_id, (string) $claim['token'], 'scheduler_path_observed', array() );
+						$this->finishPathlessChildRecovery( $job_id, (string) $claim['token'], (int) $claim['generation'], 'scheduler_path_observed', array() );
 						$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'skipped', $recovery_trigger, 'scheduler_path_appeared_after_claim' ) );
 						continue;
 					}
 
 					if ( ! empty( $child_diagnosis['retry_eligible'] ) ) {
-						$action_id = as_schedule_single_action( time(), 'datamachine_execute_step', $child_diagnosis['retry_args'], 'data-machine', true );
-						if ( is_numeric( $action_id ) && (int) $action_id > 0 && $this->db_jobs->update_job_status( $job_id, JobStatus::PENDING ) ) {
+						$retry_args = array_merge(
+							$child_diagnosis['retry_args'],
+							array(
+								'recovery_generation'  => (int) $claim['generation'],
+								'recovery_claim_token' => (string) $claim['token'],
+							)
+						);
+						$requeue = $this->db_jobs->commit_recovery_owned_requeue(
+							$job_id,
+							(string) $claim['token'],
+							(int) $claim['generation'],
+							static fn(): int => (int) as_schedule_single_action( time(), 'datamachine_execute_step', $retry_args, 'data-machine', true )
+						);
+						$action_id = (int) ( $requeue['action_id'] ?? 0 );
+						if ( ! empty( $requeue['success'] ) && $action_id > 0 ) {
 							++$requeued;
 							++$pathless_requeued;
-							$this->finishPathlessChildRecovery( $job_id, (string) $claim['token'], 'requeued', array( 'action_id' => (int) $action_id ) );
+							++$mutations;
 							$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'requeued_pathless_child', $recovery_trigger ) + array( 'recovery_action_id' => (int) $action_id ) );
 							continue;
 						}
@@ -311,16 +383,16 @@ class RecoverStuckJobsAbility {
 						$race_diagnosis = ChildJobRecoveryPolicy::diagnose( $race_job, $this->getJobEngineData( $job_id ), $this->getStepActionHistory( $job_id ), $timeout_hours * HOUR_IN_SECONDS, time() );
 						if ( ! empty( $race_diagnosis['has_active_path'] ) ) {
 							++$skipped;
-							$this->finishPathlessChildRecovery( $job_id, (string) $claim['token'], 'scheduler_path_observed', array() );
+							$this->finishPathlessChildRecovery( $job_id, (string) $claim['token'], (int) $claim['generation'], 'scheduler_path_observed', array() );
 							$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $race_diagnosis, 'skipped', $recovery_trigger, 'concurrent_scheduler_path_won' ) );
 							continue;
 						}
 					}
 
-					$this->finishPathlessChildRecovery( $job_id, (string) $claim['token'], 'terminal_transition', array() );
-					$result = $this->db_jobs->transition_job_status( $job_id, JobStatus::failed( 'scheduler_path_lost' )->toString(), true );
-					if ( $result ) {
+					$result = $this->db_jobs->transition_recovery_owned_child( $job_id, JobStatus::failed( 'scheduler_path_lost' )->toString(), (string) $claim['token'], (int) $claim['generation'] );
+					if ( ! empty( $result['success'] ) ) {
 						++$pathless_terminal;
+						++$mutations;
 						$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'transitioned_pathless_child', $recovery_trigger ) );
 					} else {
 						++$skipped;
@@ -355,6 +427,7 @@ class RecoverStuckJobsAbility {
 
 					if ( $result ) {
 						++$timed_out;
+						++$mutations;
 						$this->appendJobDetail( $jobs, $jobs_omitted, array(
 							'job_id'  => $job_id,
 							'flow_id' => $job_flow_id,
@@ -377,8 +450,12 @@ class RecoverStuckJobsAbility {
 			}
 		}
 
-		$terminal_actions = $this->getTerminalBackedInProgressActions( $flow_id );
+		$terminal_actions = $this->getTerminalBackedInProgressActions( $flow_id, $job_id_scope );
 		foreach ( $terminal_actions as $action ) {
+			if ( ! $dry_run && $mutations >= $apply_limit ) {
+				$limit_reached = true;
+				break;
+			}
 			$job_id         = (int) $action['job_id'];
 			$action_id      = (int) $action['action_id'];
 			$job_flow_id    = (int) $action['flow_id'];
@@ -400,6 +477,7 @@ class RecoverStuckJobsAbility {
 
 			if ( $this->completeTerminalBackedAction( $action_id, $action_hook, $job_id, $terminal_state ) ) {
 				++$stale_actions;
+				++$mutations;
 				$this->appendJobDetail( $jobs, $jobs_omitted, array(
 					'job_id'        => $job_id,
 					'flow_id'       => $job_flow_id,
@@ -424,10 +502,10 @@ class RecoverStuckJobsAbility {
 		$jobs_truncated = $jobs_omitted > 0;
 
 		$message = $dry_run
-			? sprintf( 'Dry run complete. Would recover %d jobs, timeout %d jobs, reconcile %d terminal-backed actions.', $recovered, $timed_out, $stale_actions )
-			: sprintf( 'Recovery complete. Recovered: %d, Timed out: %d, Reconciled actions: %d, Requeued: %d', $recovered, $timed_out, $stale_actions, $requeued );
+			? sprintf( 'Dry run complete. Would recover %d jobs, timeout %d jobs, requeue %d pathless children, terminalize %d pathless children, and reconcile %d terminal-backed actions.', $recovered, $timed_out, $pathless_requeued, $pathless_terminal, $stale_actions )
+			: sprintf( 'Recovery complete. Mutations: %d/%d, Recovered: %d, Timed out: %d, Pathless requeued: %d, Pathless terminal: %d, Reconciled actions: %d, Policy-skipped: %d', $mutations, $apply_limit, $recovered, $timed_out, $pathless_requeued, $pathless_terminal, $stale_actions, $pathless_policy_skipped );
 
-		if ( ! $dry_run && ( $recovered > 0 || $timed_out > 0 || $stale_actions > 0 ) ) {
+		if ( ! $dry_run && ( $mutations > 0 || $claimed_elsewhere > 0 || $pathless_policy_skipped > 0 ) ) {
 			do_action(
 				'datamachine_log',
 				'info',
@@ -437,6 +515,14 @@ class RecoverStuckJobsAbility {
 					'timed_out'     => $timed_out,
 					'stale_actions' => $stale_actions,
 					'requeued'      => $requeued,
+					'pathless_requeued' => $pathless_requeued,
+					'pathless_terminal' => $pathless_terminal,
+					'claimed_elsewhere' => $claimed_elsewhere,
+					'pathless_policy_skipped' => $pathless_policy_skipped,
+					'mutations'     => $mutations,
+					'apply_limit'   => $apply_limit,
+					'limit_reached' => $limit_reached,
+					'job_id'        => $job_id_scope,
 					'flow_id'       => $flow_id,
 				)
 			);
@@ -452,6 +538,17 @@ class RecoverStuckJobsAbility {
 			'pathless_terminal' => $pathless_terminal,
 			'pathless_requeued' => $pathless_requeued,
 			'claimed_elsewhere' => $claimed_elsewhere,
+			'pathless_policy_skipped' => $pathless_policy_skipped,
+			'mutations'      => $mutations,
+			'apply_limit'    => $apply_limit,
+			'limit_reached'  => $limit_reached,
+			'scope'          => array(
+				'job_id'                    => $job_id_scope,
+				'flow_id'                   => $flow_id,
+				'statuses'                  => array( 'processing' ),
+				'includes_pending_ai'       => false,
+				'recover_pathless_children' => $recover_pathless_children,
+			),
 			'dry_run'        => $dry_run,
 			'jobs'           => $jobs,
 			'jobs_omitted'   => $jobs_omitted,
@@ -491,45 +588,65 @@ class RecoverStuckJobsAbility {
 	private function getStepActionHistory( int $job_id ): array {
 		global $wpdb;
 		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
-		$like_job_id   = '%"job_id":' . $wpdb->esc_like( (string) $job_id ) . '%';
+		$job_arg_prefix = '%"job_id":' . $wpdb->esc_like( (string) $job_id );
+		$like_job_comma = $job_arg_prefix . ',%';
+		$like_job_end   = $job_arg_prefix . '}%';
+		$history      = array();
+		$history_count = 0;
+		$before_id    = PHP_INT_MAX;
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix; limit is internal.
-		$rows = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT action_id, hook, status, claim_id, scheduled_date_gmt, last_attempt_gmt, attempts, args
-				 FROM {$actions_table}
-				 WHERE hook IN (%s, %s)
-				 AND args LIKE %s
-				 ORDER BY action_id DESC
-				 LIMIT %d",
-				'datamachine_execute_step',
-				'datamachine_resume_ai_step',
-				$like_job_id,
-				self::ACTION_HISTORY_LIMIT
-			),
-			ARRAY_A
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-
-		$history = array();
-		foreach ( $rows as $row ) {
-			$args = json_decode( (string) ( $row['args'] ?? '' ), true );
-			if ( ! is_array( $args ) || (int) ( $args['job_id'] ?? 0 ) !== $job_id ) {
-				continue;
+		while ( $history_count < self::ACTION_HISTORY_LIMIT ) {
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT action_id, hook, status, claim_id, scheduled_date_gmt, last_attempt_gmt, attempts, args
+					 FROM {$actions_table}
+					 WHERE hook IN (%s, %s)
+					 AND (args LIKE %s OR args LIKE %s)
+					 AND action_id < %d
+					 ORDER BY action_id DESC
+					 LIMIT %d",
+					'datamachine_execute_step',
+					'datamachine_resume_ai_step',
+					$like_job_comma,
+					$like_job_end,
+					$before_id,
+					self::ACTION_SCAN_PAGE_SIZE
+				),
+				ARRAY_A
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			if ( empty( $rows ) ) {
+				break;
 			}
-			$row['decoded_args'] = $args;
-			$history[]           = $row;
+
+			$last_row  = end( $rows );
+			$before_id = is_array( $last_row ) ? (int) ( $last_row['action_id'] ?? 0 ) : 0;
+			foreach ( $rows as $row ) {
+				$args = json_decode( (string) ( $row['args'] ?? '' ), true );
+				if ( ! is_array( $args ) || ! ChildJobRecoveryPolicy::actionBelongsToJob( $args, $job_id ) ) {
+					continue;
+				}
+				$row['decoded_args'] = $args;
+				$history[]           = $row;
+				++$history_count;
+				if ( self::ACTION_HISTORY_LIMIT <= $history_count ) {
+					break;
+				}
+			}
 		}
 		return $history;
 	}
 
-	/** @return array{owned:bool,token:string} */
+	/** @return array{owned:bool,token:string,generation:int,expires_at:string} */
 	private function claimPathlessChildRecovery( int $job_id, string $trigger ): array {
 		$job = $this->db_jobs->get_job( $job_id );
 		if ( ! is_array( $job ) || JobStatus::PROCESSING !== ( $job['status'] ?? '' ) || (int) ( $job['parent_job_id'] ?? 0 ) <= 0 ) {
 			return array(
 				'owned' => false,
 				'token' => '',
+				'generation' => 0,
+				'expires_at' => '',
 			);
 		}
 
@@ -538,9 +655,9 @@ class RecoverStuckJobsAbility {
 		$result = EngineData::mutate(
 			$job_id,
 			static function ( array $engine ) use ( $token, $trigger, $now ): ?array {
-				$current    = is_array( $engine['scheduler_recovery'] ?? null ) ? $engine['scheduler_recovery'] : array();
-				$claimed_at = strtotime( (string) ( $current['claimed_at'] ?? '' ) );
-				if ( 'claimed' === ( $current['state'] ?? '' ) && false !== $claimed_at && ( $now - $claimed_at ) < self::RECOVERY_CLAIM_TTL ) {
+				$current = is_array( $engine['scheduler_recovery'] ?? null ) ? $engine['scheduler_recovery'] : array();
+				$expiry  = strtotime( (string) ( $current['expires_at'] ?? '' ) );
+				if ( 'claimed' === ( $current['state'] ?? '' ) && false !== $expiry && $now < $expiry ) {
 					return null;
 				}
 				$engine['scheduler_recovery'] = array(
@@ -550,6 +667,7 @@ class RecoverStuckJobsAbility {
 					'generation' => max( 0, (int) ( $current['generation'] ?? 0 ) ) + 1,
 					'trigger'    => $trigger,
 					'claimed_at' => gmdate( 'c', $now ),
+					'expires_at' => gmdate( 'c', $now + self::RECOVERY_CLAIM_TTL ),
 				);
 				return $engine;
 			},
@@ -560,16 +678,19 @@ class RecoverStuckJobsAbility {
 		return array(
 			'owned' => ! empty( $result['success'] ) && hash_equals( $token, (string) ( $state['token'] ?? '' ) ),
 			'token' => $token,
+			'generation' => (int) ( $state['generation'] ?? 0 ),
+			'expires_at' => (string) ( $state['expires_at'] ?? '' ),
 		);
 	}
 
 	/** @param array<string,mixed> $extra */
-	private function finishPathlessChildRecovery( int $job_id, string $token, string $state, array $extra ): bool {
+	private function finishPathlessChildRecovery( int $job_id, string $token, int $generation, string $state, array $extra ): bool {
 		$result = EngineData::mutate(
 			$job_id,
-			static function ( array $engine ) use ( $token, $state, $extra ): ?array {
+			static function ( array $engine ) use ( $token, $generation, $state, $extra ): ?array {
 				$current = is_array( $engine['scheduler_recovery'] ?? null ) ? $engine['scheduler_recovery'] : array();
-				if ( ! hash_equals( $token, (string) ( $current['token'] ?? '' ) ) || 'claimed' !== ( $current['state'] ?? '' ) ) {
+				$expiry  = strtotime( (string) ( $current['expires_at'] ?? '' ) );
+				if ( ! hash_equals( $token, (string) ( $current['token'] ?? '' ) ) || (int) ( $current['generation'] ?? 0 ) !== $generation || 'claimed' !== ( $current['state'] ?? '' ) || false === $expiry || $expiry <= time() ) {
 					return null;
 				}
 				$engine['scheduler_recovery'] = array_merge(
@@ -589,22 +710,49 @@ class RecoverStuckJobsAbility {
 
 	/** @return array<string,mixed> */
 	private function childRecoveryEvidence( array $job, array $diagnosis, string $status, string $trigger, string $reason = '' ): array {
+		$current_job = $this->db_jobs->get_job( (int) ( $job['job_id'] ?? 0 ) );
+		if ( is_array( $current_job ) ) {
+			$job = $current_job;
+		}
 		$action = is_array( $diagnosis['active_action'] ?? null ) ? $diagnosis['active_action'] : ( is_array( $diagnosis['latest_action'] ?? null ) ? $diagnosis['latest_action'] : array() );
-		$created = strtotime( (string) ( $job['created_at'] ?? '' ) . ' UTC' );
+		$args    = is_array( $action['decoded_args'] ?? null ) ? $action['decoded_args'] : array();
+		$engine  = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$lease   = is_array( $engine['scheduler_recovery'] ?? null ) ? $engine['scheduler_recovery'] : array();
+		$receipt = is_array( $lease['receipt'] ?? null ) ? $lease['receipt'] : array();
+		$item_claim = is_array( $engine['_datamachine_item_claim'] ?? null ) ? $engine['_datamachine_item_claim'] : array();
+		$created    = strtotime( (string) ( $job['created_at'] ?? '' ) . ' UTC' );
+		$claimed_at = strtotime( (string) ( $lease['claimed_at'] ?? '' ) );
+		$lease_at   = strtotime( (string) ( $lease['renewed_at'] ?? $lease['claimed_at'] ?? '' ) );
+		$token      = (string) ( $lease['token'] ?? '' );
 		return array(
 			'job_id'             => (int) ( $job['job_id'] ?? 0 ),
 			'flow_id'            => (int) ( $job['flow_id'] ?? 0 ),
 			'parent_job_id'      => (int) ( $job['parent_job_id'] ?? 0 ),
 			'status'             => $status,
+			'disposition'        => $status,
 			'reason'             => '' !== $reason ? $reason : (string) ( $diagnosis['reason'] ?? '' ),
+			'owner'              => '' === $token ? 'none' : substr( hash( 'sha256', $token ), 0, 16 ),
 			'job_age_seconds'    => false === $created ? 0 : max( 0, time() - $created ),
 			'scheduler_path'     => ! empty( $diagnosis['has_active_path'] ) ? 'active' : 'none',
 			'action_id'          => (int) ( $action['action_id'] ?? 0 ),
 			'action_hook'        => (string) ( $action['hook'] ?? '' ),
 			'action_status'      => (string) ( $action['status'] ?? '' ),
 			'action_claim_id'    => (int) ( $action['claim_id'] ?? 0 ),
+			'action_generation'  => (int) ( $args['recovery_generation'] ?? $args['ai_resume_generation'] ?? $args['operation_generation'] ?? 0 ),
 			'operation_state'    => (string) ( $job['operation_state'] ?? '' ),
 			'operation_generation' => (int) ( $job['operation_generation'] ?? 0 ),
+			'recovery_lease_state' => (string) ( $lease['state'] ?? 'none' ),
+			'recovery_lease_generation' => (int) ( $lease['generation'] ?? 0 ),
+			'recovery_lease_token_state' => '' === $token ? 'missing' : 'present',
+			'recovery_lease_age_seconds' => false === $lease_at ? 0 : max( 0, time() - $lease_at ),
+			'recovery_lease_claim_age_seconds' => false === $claimed_at ? 0 : max( 0, time() - $claimed_at ),
+			'recovery_lease_expires_at' => (string) ( $lease['expires_at'] ?? '' ),
+			'receipt_state'      => empty( $receipt ) ? 'missing' : 'committed',
+			'receipt_action_id'  => (int) ( $receipt['action_id'] ?? 0 ),
+			'item_claim_state'   => empty( $item_claim ) ? 'none' : 'owned',
+			'item_claim_job_id'  => (int) ( $item_claim['job_id'] ?? 0 ),
+			'terminal_accounting_state' => isset( $job['terminal_accounting_state'] ) ? (int) $job['terminal_accounting_state'] : null,
+			'terminal_accounting_owner_state' => empty( $job['terminal_accounting_owner'] ) ? 'none' : 'present',
 			'retry_eligible'     => ! empty( $diagnosis['retry_eligible'] ),
 			'recovery_trigger'   => $trigger,
 		);
@@ -655,7 +803,7 @@ class RecoverStuckJobsAbility {
 	 * @param int|null $flow_id Optional flow filter.
 	 * @return array<int,array{action_id:int,hook:string,job_id:int,flow_id:int,job_status:string}>
 	 */
-	private function getTerminalBackedInProgressActions( ?int $flow_id ): array {
+	private function getTerminalBackedInProgressActions( ?int $flow_id, ?int $job_id_scope = null ): array {
 		global $wpdb;
 
 		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
@@ -710,6 +858,10 @@ class RecoverStuckJobsAbility {
 		if ( $flow_id ) {
 			$sql         .= ' AND flow_id = %d';
 			$query_args[] = $flow_id;
+		}
+		if ( $job_id_scope ) {
+			$sql         .= ' AND job_id = %d';
+			$query_args[] = $job_id_scope;
 		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Dynamic placeholder list is prepared below.

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -26,7 +26,7 @@ class RecoverStuckJobsAbility {
 	private const ACTION_HISTORY_LIMIT = 20;
 	private const ACTION_SCAN_PAGE_SIZE = 50;
 	private const RECOVERY_CLAIM_TTL   = 300;
-	private const DEFAULT_APPLY_LIMIT   = 25;
+	private const DEFAULT_APPLY_LIMIT   = 3;
 	private const MAX_APPLY_LIMIT       = 100;
 
 	/**
@@ -635,7 +635,7 @@ class RecoverStuckJobsAbility {
 	}
 
 	/** @return array<int,array<string,mixed>> */
-	private function getStepActionHistory( int $job_id ): array {
+	private function getStepActionHistory( int $job_id, int $required_action_id = 0 ): array {
 		global $wpdb;
 		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
 		$job_arg_prefix = '%"job_id":' . $wpdb->esc_like( (string) $job_id );
@@ -685,6 +685,25 @@ class RecoverStuckJobsAbility {
 				}
 			}
 		}
+
+		if ( $required_action_id > 0 && ! in_array( $required_action_id, array_map( 'intval', array_column( $history, 'action_id' ) ), true ) ) {
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
+			$required = $wpdb->get_row(
+				$wpdb->prepare(
+					"SELECT action_id, hook, status, claim_id, scheduled_date_gmt, last_attempt_gmt, attempts, args FROM {$actions_table} WHERE action_id = %d AND hook IN (%s, %s)",
+					$required_action_id,
+					'datamachine_execute_step',
+					'datamachine_resume_ai_step'
+				),
+				ARRAY_A
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$args = is_array( $required ) ? json_decode( (string) ( $required['args'] ?? '' ), true ) : null;
+			if ( is_array( $required ) && is_array( $args ) && ChildJobRecoveryPolicy::actionBelongsToJob( $args, $job_id ) ) {
+				$required['decoded_args'] = $args;
+				$history[]                = $required;
+			}
+		}
 		return $history;
 	}
 
@@ -699,15 +718,35 @@ class RecoverStuckJobsAbility {
 				'expires_at' => '',
 			);
 		}
+		$engine_data       = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$owner             = is_array( $engine_data['scheduler_recovery'] ?? null ) ? $engine_data['scheduler_recovery'] : array();
+		$receipt           = is_array( $owner['receipt'] ?? null ) ? $owner['receipt'] : array();
+		$actions           = $this->getStepActionHistory( $job_id, (int) ( $receipt['action_id'] ?? 0 ) );
+		if ( ! ChildJobRecoveryPolicy::canClaimNextGeneration( $job, $engine_data, $actions, time() ) ) {
+			return array(
+				'owned'      => false,
+				'token'      => '',
+				'generation' => 0,
+				'expires_at' => '',
+			);
+		}
+		$observed_owner = is_array( $engine_data['scheduler_recovery'] ?? null ) ? $engine_data['scheduler_recovery'] : array();
 
 		$token = bin2hex( random_bytes( 16 ) );
 		$now   = time();
 		$result = EngineData::mutate(
 			$job_id,
-			static function ( array $engine ) use ( $token, $trigger, $now ): ?array {
+			static function ( array $engine ) use ( $token, $trigger, $now, $job, $actions, $observed_owner ): ?array {
 				$current = is_array( $engine['scheduler_recovery'] ?? null ) ? $engine['scheduler_recovery'] : array();
-				$expiry  = strtotime( (string) ( $current['expires_at'] ?? '' ) );
-				if ( 'claimed' === ( $current['state'] ?? '' ) && false !== $expiry && $now < $expiry ) {
+				if ( empty( $observed_owner ) !== empty( $current ) ) {
+					return null;
+				}
+				if ( ! empty( $observed_owner ) && ( (int) ( $current['generation'] ?? 0 ) !== (int) ( $observed_owner['generation'] ?? 0 ) || ! hash_equals( (string) ( $observed_owner['token'] ?? '' ), (string) ( $current['token'] ?? '' ) ) ) ) {
+					return null;
+				}
+				$current_job                = $job;
+				$current_job['engine_data'] = $engine;
+				if ( ! ChildJobRecoveryPolicy::canClaimNextGeneration( $current_job, $engine, $actions, $now ) ) {
 					return null;
 				}
 				$engine['scheduler_recovery'] = array(

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -77,7 +77,7 @@ class RecoverStuckJobsAbility {
 								'minimum'     => 1,
 								'maximum'     => self::MAX_APPLY_LIMIT,
 								'default'     => self::DEFAULT_APPLY_LIMIT,
-								'description' => __( 'Hard maximum mutations in one invocation', 'data-machine' ),
+								'description' => __( 'Hard maximum attempted storage touches in one invocation', 'data-machine' ),
 							),
 							'recover_pathless_children' => array(
 								'type'        => 'boolean',
@@ -110,6 +110,9 @@ class RecoverStuckJobsAbility {
 							'claimed_elsewhere' => array( 'type' => 'integer' ),
 							'pathless_policy_skipped' => array( 'type' => 'integer' ),
 							'mutations'     => array( 'type' => 'integer' ),
+							'attempted'     => array( 'type' => 'integer' ),
+							'touched'       => array( 'type' => 'integer' ),
+							'mutated'       => array( 'type' => 'integer' ),
 							'apply_limit'   => array( 'type' => 'integer' ),
 							'limit_reached' => array( 'type' => 'boolean' ),
 							'scope'         => array( 'type' => 'object' ),
@@ -162,6 +165,9 @@ class RecoverStuckJobsAbility {
 		$jobs_omitted   = 0;
 		$jobs_truncated = false;
 		$mutations      = 0;
+		$attempted      = 0;
+		$touched        = 0;
+		$mutated        = 0;
 		$limit_reached  = false;
 
 		$last_job_id = 0;
@@ -193,7 +199,7 @@ class RecoverStuckJobsAbility {
 			}
 
 			foreach ( $stuck_jobs as $job ) {
-				if ( ! $dry_run && $mutations >= $apply_limit ) {
+				if ( ! $dry_run && $touched >= $apply_limit ) {
 					$limit_reached = true;
 					break 2;
 				}
@@ -226,11 +232,16 @@ class RecoverStuckJobsAbility {
 						'target_status' => $status,
 					) );
 				} else {
+					if ( ! $this->consumeTouchBudget( $attempted, $touched, $apply_limit ) ) {
+						$limit_reached = true;
+						break 2;
+					}
 					$result = $this->db_jobs->transition_job_status( (int) $job->job_id, $status, true );
 
 					if ( $result ) {
 						++$recovered;
 						++$mutations;
+						++$mutated;
 						$this->appendJobDetail( $jobs, $jobs_omitted, array(
 							'job_id'        => (int) $job->job_id,
 							'flow_id'       => (int) $job->flow_id,
@@ -290,7 +301,7 @@ class RecoverStuckJobsAbility {
 			}
 
 			foreach ( $timed_out_jobs as $job ) {
-				if ( ! $dry_run && $mutations >= $apply_limit ) {
+				if ( ! $dry_run && $touched >= $apply_limit ) {
 					$limit_reached = true;
 					break 2;
 				}
@@ -336,6 +347,12 @@ class RecoverStuckJobsAbility {
 						$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'skipped', $recovery_trigger, 'pathless_child_apply_policy_required' ) );
 						continue;
 					}
+					// Diagnosis can change after claiming, so reserve claim + rollback/requeue + finish/terminal.
+					$required_touches = 3;
+					if ( ! $this->hasTouchCapacity( $touched, $apply_limit, $required_touches ) || ! $this->consumeTouchBudget( $attempted, $touched, $apply_limit ) ) {
+						$limit_reached = true;
+						break 2;
+					}
 
 					$claim = $this->claimPathlessChildRecovery( $job_id, $recovery_trigger );
 					if ( empty( $claim['owned'] ) ) {
@@ -344,6 +361,7 @@ class RecoverStuckJobsAbility {
 						$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'skipped', $recovery_trigger, 'recovery_claim_not_owned' ) );
 						continue;
 					}
+					++$mutated;
 
 					$engine_data  = $this->getJobEngineData( $job_id );
 					$claimed_job  = $this->db_jobs->get_job( $job_id );
@@ -351,12 +369,16 @@ class RecoverStuckJobsAbility {
 					$child_diagnosis = ChildJobRecoveryPolicy::diagnose( $claimed_job, $engine_data, $this->getStepActionHistory( $job_id ), $timeout_hours * HOUR_IN_SECONDS, time() );
 					if ( ! empty( $child_diagnosis['has_active_path'] ) ) {
 						++$skipped;
-						$this->finishPathlessChildRecovery( $job_id, (string) $claim['token'], (int) $claim['generation'], 'scheduler_path_observed', array() );
+						$this->consumeTouchBudget( $attempted, $touched, $apply_limit );
+						if ( $this->finishPathlessChildRecovery( $job_id, (string) $claim['token'], (int) $claim['generation'], 'scheduler_path_observed', array() ) ) {
+							++$mutated;
+						}
 						$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'skipped', $recovery_trigger, 'scheduler_path_appeared_after_claim' ) );
 						continue;
 					}
 
 					if ( ! empty( $child_diagnosis['retry_eligible'] ) ) {
+						$this->consumeTouchBudget( $attempted, $touched, $apply_limit );
 						$retry_args = array_merge(
 							$child_diagnosis['retry_args'],
 							array(
@@ -375,6 +397,7 @@ class RecoverStuckJobsAbility {
 							++$requeued;
 							++$pathless_requeued;
 							++$mutations;
+							++$mutated;
 							$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'requeued_pathless_child', $recovery_trigger ) + array( 'recovery_action_id' => (int) $action_id ) );
 							continue;
 						}
@@ -383,16 +406,21 @@ class RecoverStuckJobsAbility {
 						$race_diagnosis = ChildJobRecoveryPolicy::diagnose( $race_job, $this->getJobEngineData( $job_id ), $this->getStepActionHistory( $job_id ), $timeout_hours * HOUR_IN_SECONDS, time() );
 						if ( ! empty( $race_diagnosis['has_active_path'] ) ) {
 							++$skipped;
-							$this->finishPathlessChildRecovery( $job_id, (string) $claim['token'], (int) $claim['generation'], 'scheduler_path_observed', array() );
+							$this->consumeTouchBudget( $attempted, $touched, $apply_limit );
+							if ( $this->finishPathlessChildRecovery( $job_id, (string) $claim['token'], (int) $claim['generation'], 'scheduler_path_observed', array() ) ) {
+								++$mutated;
+							}
 							$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $race_diagnosis, 'skipped', $recovery_trigger, 'concurrent_scheduler_path_won' ) );
 							continue;
 						}
 					}
 
+					$this->consumeTouchBudget( $attempted, $touched, $apply_limit );
 					$result = $this->db_jobs->transition_recovery_owned_child( $job_id, JobStatus::failed( 'scheduler_path_lost' )->toString(), (string) $claim['token'], (int) $claim['generation'] );
 					if ( ! empty( $result['success'] ) ) {
 						++$pathless_terminal;
 						++$mutations;
+						++$mutated;
 						$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'transitioned_pathless_child', $recovery_trigger ) );
 					} else {
 						++$skipped;
@@ -423,20 +451,31 @@ class RecoverStuckJobsAbility {
 						'status'  => 'would_timeout',
 					) );
 				} else {
+					$backup = $engine_data['queued_prompt_backup'] ?? array();
+					$required_touches = empty( $backup ) ? 1 : 2;
+					if ( ! $this->hasTouchCapacity( $touched, $apply_limit, $required_touches ) || ! $this->consumeTouchBudget( $attempted, $touched, $apply_limit ) ) {
+						$limit_reached = true;
+						break 2;
+					}
 					$result = $this->db_jobs->transition_job_status( $job_id, JobStatus::FAILED, true );
 
 					if ( $result ) {
 						++$timed_out;
 						++$mutations;
+						++$mutated;
 						$this->appendJobDetail( $jobs, $jobs_omitted, array(
 							'job_id'  => $job_id,
 							'flow_id' => $job_flow_id,
 							'status'  => 'timed_out',
 						) );
 						// Restore drain-mode queued_prompt_backup if the prior run removed an entry.
-						$backup = $engine_data['queued_prompt_backup'] ?? array();
-						if ( ! empty( $backup ) && $this->restoreQueuedPromptBackup( $job_flow_id, $backup ) ) {
-							++$requeued;
+						if ( ! empty( $backup ) ) {
+							$this->consumeTouchBudget( $attempted, $touched, $apply_limit );
+							if ( $this->restoreQueuedPromptBackup( $job_flow_id, $backup ) ) {
+								++$requeued;
+								++$mutations;
+								++$mutated;
+							}
 						}
 					} else {
 						$this->appendJobDetail( $jobs, $jobs_omitted, array(
@@ -452,7 +491,11 @@ class RecoverStuckJobsAbility {
 
 		$terminal_actions = $this->getTerminalBackedInProgressActions( $flow_id, $job_id_scope );
 		foreach ( $terminal_actions as $action ) {
-			if ( ! $dry_run && $mutations >= $apply_limit ) {
+			if ( ! $dry_run && $touched >= $apply_limit ) {
+				$limit_reached = true;
+				break;
+			}
+			if ( ! $dry_run && ! $this->consumeTouchBudget( $attempted, $touched, $apply_limit ) ) {
 				$limit_reached = true;
 				break;
 			}
@@ -478,6 +521,7 @@ class RecoverStuckJobsAbility {
 			if ( $this->completeTerminalBackedAction( $action_id, $action_hook, $job_id, $terminal_state ) ) {
 				++$stale_actions;
 				++$mutations;
+				++$mutated;
 				$this->appendJobDetail( $jobs, $jobs_omitted, array(
 					'job_id'        => $job_id,
 					'flow_id'       => $job_flow_id,
@@ -503,7 +547,7 @@ class RecoverStuckJobsAbility {
 
 		$message = $dry_run
 			? sprintf( 'Dry run complete. Would recover %d jobs, timeout %d jobs, requeue %d pathless children, terminalize %d pathless children, and reconcile %d terminal-backed actions.', $recovered, $timed_out, $pathless_requeued, $pathless_terminal, $stale_actions )
-			: sprintf( 'Recovery complete. Mutations: %d/%d, Recovered: %d, Timed out: %d, Pathless requeued: %d, Pathless terminal: %d, Reconciled actions: %d, Policy-skipped: %d', $mutations, $apply_limit, $recovered, $timed_out, $pathless_requeued, $pathless_terminal, $stale_actions, $pathless_policy_skipped );
+			: sprintf( 'Recovery complete. Attempted/touched/mutated: %d/%d/%d (limit %d), outcomes: %d, recovered: %d, timed out: %d, pathless requeued: %d, pathless terminal: %d, reconciled actions: %d, policy-skipped: %d', $attempted, $touched, $mutated, $apply_limit, $mutations, $recovered, $timed_out, $pathless_requeued, $pathless_terminal, $stale_actions, $pathless_policy_skipped );
 
 		if ( ! $dry_run && ( $mutations > 0 || $claimed_elsewhere > 0 || $pathless_policy_skipped > 0 ) ) {
 			do_action(
@@ -520,6 +564,9 @@ class RecoverStuckJobsAbility {
 					'claimed_elsewhere' => $claimed_elsewhere,
 					'pathless_policy_skipped' => $pathless_policy_skipped,
 					'mutations'     => $mutations,
+					'attempted'     => $attempted,
+					'touched'       => $touched,
+					'mutated'       => $mutated,
 					'apply_limit'   => $apply_limit,
 					'limit_reached' => $limit_reached,
 					'job_id'        => $job_id_scope,
@@ -540,6 +587,9 @@ class RecoverStuckJobsAbility {
 			'claimed_elsewhere' => $claimed_elsewhere,
 			'pathless_policy_skipped' => $pathless_policy_skipped,
 			'mutations'      => $mutations,
+			'attempted'      => $attempted,
+			'touched'        => $touched,
+			'mutated'        => $mutated,
 			'apply_limit'    => $apply_limit,
 			'limit_reached'  => $limit_reached,
 			'scope'          => array(
@@ -716,14 +766,15 @@ class RecoverStuckJobsAbility {
 		}
 		$action = is_array( $diagnosis['active_action'] ?? null ) ? $diagnosis['active_action'] : ( is_array( $diagnosis['latest_action'] ?? null ) ? $diagnosis['latest_action'] : array() );
 		$args    = is_array( $action['decoded_args'] ?? null ) ? $action['decoded_args'] : array();
-		$engine  = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
-		$lease   = is_array( $engine['scheduler_recovery'] ?? null ) ? $engine['scheduler_recovery'] : array();
-		$receipt = is_array( $lease['receipt'] ?? null ) ? $lease['receipt'] : array();
-		$item_claim = is_array( $engine['_datamachine_item_claim'] ?? null ) ? $engine['_datamachine_item_claim'] : array();
+		$action_generation = (int) ( $args['recovery_generation'] ?? $args['ai_resume_generation'] ?? $args['operation_generation'] ?? 0 );
+		$action_generation_valid = 0 < $action_generation && ( ! empty( $diagnosis['has_active_path'] ) || ! empty( $diagnosis['retry_eligible'] ) );
+		$engine     = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$ownership  = ChildJobRecoveryPolicy::recoveryOwnershipEvidence( $engine, time() );
+		$claim      = $this->activeClaimEvidence( $engine, (int) ( $job['job_id'] ?? 0 ) );
 		$created    = strtotime( (string) ( $job['created_at'] ?? '' ) . ' UTC' );
-		$claimed_at = strtotime( (string) ( $lease['claimed_at'] ?? '' ) );
-		$lease_at   = strtotime( (string) ( $lease['renewed_at'] ?? $lease['claimed_at'] ?? '' ) );
-		$token      = (string) ( $lease['token'] ?? '' );
+		$claimed_at = strtotime( (string) ( $ownership['claimed_at'] ?? '' ) );
+		$lease_at   = strtotime( (string) ( $ownership['renewed_at'] ?? $ownership['claimed_at'] ?? '' ) );
+		$token      = (string) ( $ownership['token'] ?? '' );
 		return array(
 			'job_id'             => (int) ( $job['job_id'] ?? 0 ),
 			'flow_id'            => (int) ( $job['flow_id'] ?? 0 ),
@@ -738,23 +789,61 @@ class RecoverStuckJobsAbility {
 			'action_hook'        => (string) ( $action['hook'] ?? '' ),
 			'action_status'      => (string) ( $action['status'] ?? '' ),
 			'action_claim_id'    => (int) ( $action['claim_id'] ?? 0 ),
-			'action_generation'  => (int) ( $args['recovery_generation'] ?? $args['ai_resume_generation'] ?? $args['operation_generation'] ?? 0 ),
+			'action_generation'  => $action_generation_valid ? $action_generation : 0,
+			'action_generation_state' => $action_generation_valid ? 'valid' : ( 0 === $action_generation ? 'legacy_unfenced' : 'invalid' ),
 			'operation_state'    => (string) ( $job['operation_state'] ?? '' ),
 			'operation_generation' => (int) ( $job['operation_generation'] ?? 0 ),
-			'recovery_lease_state' => (string) ( $lease['state'] ?? 'none' ),
-			'recovery_lease_generation' => (int) ( $lease['generation'] ?? 0 ),
-			'recovery_lease_token_state' => '' === $token ? 'missing' : 'present',
+			'recovery_lease_state' => (string) ( $ownership['state'] ?? 'none' ),
+			'recovery_lease_generation' => (int) ( $ownership['generation'] ?? 0 ),
+			'recovery_lease_token_state' => '' === $token ? 'invalid_or_missing' : 'valid',
 			'recovery_lease_age_seconds' => false === $lease_at ? 0 : max( 0, time() - $lease_at ),
 			'recovery_lease_claim_age_seconds' => false === $claimed_at ? 0 : max( 0, time() - $claimed_at ),
-			'recovery_lease_expires_at' => (string) ( $lease['expires_at'] ?? '' ),
-			'receipt_state'      => empty( $receipt ) ? 'missing' : 'committed',
-			'receipt_action_id'  => (int) ( $receipt['action_id'] ?? 0 ),
-			'item_claim_state'   => empty( $item_claim ) ? 'none' : 'owned',
-			'item_claim_job_id'  => (int) ( $item_claim['job_id'] ?? 0 ),
+			'recovery_lease_expires_at' => (string) ( $ownership['expires_at'] ?? '' ),
+			'receipt_state'      => (string) ( $ownership['receipt_state'] ?? 'missing' ),
+			'receipt_action_id'  => (int) ( $ownership['receipt_action_id'] ?? 0 ),
+			'item_claim_state'   => (string) $claim['state'],
+			'item_claim_job_id'  => $claim['active'] > 0 ? (int) ( $job['job_id'] ?? 0 ) : 0,
+			'item_claim_declared_count' => $claim['declared'],
+			'item_claim_active_count' => $claim['active'],
 			'terminal_accounting_state' => isset( $job['terminal_accounting_state'] ) ? (int) $job['terminal_accounting_state'] : null,
 			'terminal_accounting_owner_state' => empty( $job['terminal_accounting_owner'] ) ? 'none' : 'present',
 			'retry_eligible'     => ! empty( $diagnosis['retry_eligible'] ),
 			'recovery_trigger'   => $trigger,
+		);
+	}
+
+	/** Validate persisted claim descriptors against current repository ownership. */
+	private function activeClaimEvidence( array $engine, int $job_id ): array {
+		$candidates = array();
+		if ( is_array( $engine['_datamachine_item_claim'] ?? null ) ) {
+			$candidates[] = $engine['_datamachine_item_claim'];
+		}
+		if ( is_array( $engine['_datamachine_item_claims'] ?? null ) ) {
+			$candidates = array_merge( $candidates, $engine['_datamachine_item_claims'] );
+		}
+
+		$declared = 0;
+		$active   = 0;
+		$seen     = array();
+		foreach ( $candidates as $claim ) {
+			if ( ! is_array( $claim ) ) {
+				continue;
+			}
+			$token = (string) ( $claim['ownership_token'] ?? '' );
+			if ( '' === $token || isset( $seen[ $token ] ) ) {
+				continue;
+			}
+			$seen[ $token ] = true;
+			++$declared;
+			if ( $this->db_processed_items->owns_active_claim( $claim, $job_id ) ) {
+				++$active;
+			}
+		}
+
+		return array(
+			'state'    => 0 < $active ? 'active_owned' : ( 0 < $declared ? 'stale_or_unowned' : 'none' ),
+			'declared' => $declared,
+			'active'   => $active,
 		);
 	}
 
@@ -795,6 +884,22 @@ class RecoverStuckJobsAbility {
 		}
 
 		++$jobs_omitted;
+	}
+
+	/** Reserve one attempted storage touch before invoking it. */
+	private function consumeTouchBudget( int &$attempted, int &$touched, int $limit ): bool {
+		if ( $touched >= $limit ) {
+			return false;
+		}
+
+		++$attempted;
+		++$touched;
+		return true;
+	}
+
+	/** Ensure a compound recovery path can finish without touching N+1. */
+	private function hasTouchCapacity( int $touched, int $limit, int $required ): bool {
+		return $required > 0 && ( $touched + $required ) <= $limit;
 	}
 
 	/**

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -1,5 +1,5 @@
 <?php
-// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Data Machine owns custom operational tables and these paths require fresh runtime state or one-time schema mutation.
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,Generic.Formatting.MultipleStatementAlignment,WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned -- Data Machine owns custom operational tables; recovery evidence uses descriptive keys.
 /**
  * Recover Stuck Jobs Ability
  *
@@ -12,6 +12,8 @@
 namespace DataMachine\Abilities\Job;
 
 use DataMachine\Core\JobStatus;
+use DataMachine\Core\ChildJobRecoveryPolicy;
+use DataMachine\Core\EngineData;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -21,6 +23,8 @@ class RecoverStuckJobsAbility {
 
 	private const CANDIDATE_BATCH_SIZE = 50;
 	private const JOB_DETAIL_LIMIT     = 100;
+	private const ACTION_HISTORY_LIMIT = 20;
+	private const RECOVERY_CLAIM_TTL   = 300;
 
 	/**
 	 * Data Machine-owned Action Scheduler hooks that may be reconciled.
@@ -65,6 +69,11 @@ class RecoverStuckJobsAbility {
 								'default'     => 2,
 								'description' => __( 'Hours before a processing job without status override is considered timed out', 'data-machine' ),
 							),
+							'recovery_trigger' => array(
+								'type'        => 'string',
+								'default'     => 'operator',
+								'description' => __( 'Recovery initiator used in machine-readable evidence', 'data-machine' ),
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -76,6 +85,9 @@ class RecoverStuckJobsAbility {
 							'timed_out'     => array( 'type' => 'integer' ),
 							'stale_actions' => array( 'type' => 'integer' ),
 							'requeued'      => array( 'type' => 'integer' ),
+							'pathless_terminal' => array( 'type' => 'integer' ),
+							'pathless_requeued' => array( 'type' => 'integer' ),
+							'claimed_elsewhere' => array( 'type' => 'integer' ),
 							'dry_run'       => array( 'type' => 'boolean' ),
 							'jobs'          => array( 'type' => 'array' ),
 							'message'       => array( 'type' => 'string' ),
@@ -197,6 +209,10 @@ class RecoverStuckJobsAbility {
 		$timed_out     = 0;
 		$stale_actions = 0;
 		$requeued      = 0;
+		$pathless_terminal = 0;
+		$pathless_requeued = 0;
+		$claimed_elsewhere = 0;
+		$recovery_trigger = isset( $input['recovery_trigger'] ) ? sanitize_key( (string) $input['recovery_trigger'] ) : 'operator';
 
 		$last_job_id = 0;
 		while ( true ) {
@@ -231,14 +247,99 @@ class RecoverStuckJobsAbility {
 				$job_id      = (int) $job->job_id;
 				$job_flow_id = (int) $job->flow_id;
 
+				$job_row = $this->db_jobs->get_job( $job_id );
+				$child_diagnosis = null;
+				if ( is_array( $job_row ) && (int) ( $job_row['parent_job_id'] ?? 0 ) > 0 ) {
+					$child_diagnosis = ChildJobRecoveryPolicy::diagnose(
+						$job_row,
+						$engine_data,
+						$this->getStepActionHistory( $job_id ),
+						$timeout_hours * HOUR_IN_SECONDS,
+						time()
+					);
+				}
+
+				if ( is_array( $child_diagnosis ) && ! empty( $child_diagnosis['has_active_path'] ) ) {
+					++$skipped;
+					$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'skipped', $recovery_trigger ) );
+					continue;
+				}
+
+				if ( is_array( $child_diagnosis ) ) {
+					$planned_status = ! empty( $child_diagnosis['retry_eligible'] ) ? 'would_requeue_pathless_child' : 'would_transition_pathless_child';
+					if ( $dry_run ) {
+						if ( ! empty( $child_diagnosis['retry_eligible'] ) ) {
+							++$requeued;
+							++$pathless_requeued;
+						} else {
+							++$pathless_terminal;
+						}
+						$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, $planned_status, $recovery_trigger ) );
+						continue;
+					}
+
+					$claim = $this->claimPathlessChildRecovery( $job_id, $recovery_trigger );
+					if ( empty( $claim['owned'] ) ) {
+						++$skipped;
+						++$claimed_elsewhere;
+						$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'skipped', $recovery_trigger, 'recovery_claim_not_owned' ) );
+						continue;
+					}
+
+					$engine_data  = $this->getJobEngineData( $job_id );
+					$claimed_job  = $this->db_jobs->get_job( $job_id );
+					$claimed_job  = is_array( $claimed_job ) ? $claimed_job : array();
+					$child_diagnosis = ChildJobRecoveryPolicy::diagnose( $claimed_job, $engine_data, $this->getStepActionHistory( $job_id ), $timeout_hours * HOUR_IN_SECONDS, time() );
+					if ( ! empty( $child_diagnosis['has_active_path'] ) ) {
+						++$skipped;
+						$this->finishPathlessChildRecovery( $job_id, (string) $claim['token'], 'scheduler_path_observed', array() );
+						$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'skipped', $recovery_trigger, 'scheduler_path_appeared_after_claim' ) );
+						continue;
+					}
+
+					if ( ! empty( $child_diagnosis['retry_eligible'] ) ) {
+						$action_id = as_schedule_single_action( time(), 'datamachine_execute_step', $child_diagnosis['retry_args'], 'data-machine', true );
+						if ( is_numeric( $action_id ) && (int) $action_id > 0 && $this->db_jobs->update_job_status( $job_id, JobStatus::PENDING ) ) {
+							++$requeued;
+							++$pathless_requeued;
+							$this->finishPathlessChildRecovery( $job_id, (string) $claim['token'], 'requeued', array( 'action_id' => (int) $action_id ) );
+							$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'requeued_pathless_child', $recovery_trigger ) + array( 'recovery_action_id' => (int) $action_id ) );
+							continue;
+						}
+						$race_job       = $this->db_jobs->get_job( $job_id );
+						$race_job       = is_array( $race_job ) ? $race_job : array();
+						$race_diagnosis = ChildJobRecoveryPolicy::diagnose( $race_job, $this->getJobEngineData( $job_id ), $this->getStepActionHistory( $job_id ), $timeout_hours * HOUR_IN_SECONDS, time() );
+						if ( ! empty( $race_diagnosis['has_active_path'] ) ) {
+							++$skipped;
+							$this->finishPathlessChildRecovery( $job_id, (string) $claim['token'], 'scheduler_path_observed', array() );
+							$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $race_diagnosis, 'skipped', $recovery_trigger, 'concurrent_scheduler_path_won' ) );
+							continue;
+						}
+					}
+
+					$this->finishPathlessChildRecovery( $job_id, (string) $claim['token'], 'terminal_transition', array() );
+					$result = $this->db_jobs->transition_job_status( $job_id, JobStatus::failed( 'scheduler_path_lost' )->toString(), true );
+					if ( $result ) {
+						++$pathless_terminal;
+						$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'transitioned_pathless_child', $recovery_trigger ) );
+					} else {
+						++$skipped;
+					}
+					continue;
+				}
+
 				if ( $this->hasActiveSchedulerWork( $job_id, $engine_data, $timeout_hours ) ) {
 					++$skipped;
-					$this->appendJobDetail( $jobs, $jobs_omitted, array(
-						'job_id'  => $job_id,
-						'flow_id' => $job_flow_id,
-						'status'  => 'skipped',
-						'reason'  => 'Pending or in-progress scheduler work exists',
-					) );
+					$this->appendJobDetail(
+						$jobs,
+						$jobs_omitted,
+						array(
+							'job_id'  => $job_id,
+							'flow_id' => $job_flow_id,
+							'status'  => 'skipped',
+							'reason'  => 'Pending or in-progress scheduler work exists',
+						)
+					);
 					continue;
 				}
 
@@ -348,6 +449,9 @@ class RecoverStuckJobsAbility {
 			'timed_out'      => $timed_out,
 			'stale_actions'  => $stale_actions,
 			'requeued'       => $requeued,
+			'pathless_terminal' => $pathless_terminal,
+			'pathless_requeued' => $pathless_requeued,
+			'claimed_elsewhere' => $claimed_elsewhere,
 			'dry_run'        => $dry_run,
 			'jobs'           => $jobs,
 			'jobs_omitted'   => $jobs_omitted,
@@ -381,6 +485,129 @@ class RecoverStuckJobsAbility {
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic WHERE clause is prepared above.
 		return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table} {$where}" );
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private function getStepActionHistory( int $job_id ): array {
+		global $wpdb;
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$like_job_id   = '%"job_id":' . $wpdb->esc_like( (string) $job_id ) . '%';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix; limit is internal.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT action_id, hook, status, claim_id, scheduled_date_gmt, last_attempt_gmt, attempts, args
+				 FROM {$actions_table}
+				 WHERE hook IN (%s, %s)
+				 AND args LIKE %s
+				 ORDER BY action_id DESC
+				 LIMIT %d",
+				'datamachine_execute_step',
+				'datamachine_resume_ai_step',
+				$like_job_id,
+				self::ACTION_HISTORY_LIMIT
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$history = array();
+		foreach ( $rows as $row ) {
+			$args = json_decode( (string) ( $row['args'] ?? '' ), true );
+			if ( ! is_array( $args ) || (int) ( $args['job_id'] ?? 0 ) !== $job_id ) {
+				continue;
+			}
+			$row['decoded_args'] = $args;
+			$history[]           = $row;
+		}
+		return $history;
+	}
+
+	/** @return array{owned:bool,token:string} */
+	private function claimPathlessChildRecovery( int $job_id, string $trigger ): array {
+		$job = $this->db_jobs->get_job( $job_id );
+		if ( ! is_array( $job ) || JobStatus::PROCESSING !== ( $job['status'] ?? '' ) || (int) ( $job['parent_job_id'] ?? 0 ) <= 0 ) {
+			return array(
+				'owned' => false,
+				'token' => '',
+			);
+		}
+
+		$token = bin2hex( random_bytes( 16 ) );
+		$now   = time();
+		$result = EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $token, $trigger, $now ): ?array {
+				$current    = is_array( $engine['scheduler_recovery'] ?? null ) ? $engine['scheduler_recovery'] : array();
+				$claimed_at = strtotime( (string) ( $current['claimed_at'] ?? '' ) );
+				if ( 'claimed' === ( $current['state'] ?? '' ) && false !== $claimed_at && ( $now - $claimed_at ) < self::RECOVERY_CLAIM_TTL ) {
+					return null;
+				}
+				$engine['scheduler_recovery'] = array(
+					'schema'     => 'datamachine.scheduler-recovery.v1',
+					'state'      => 'claimed',
+					'token'      => $token,
+					'generation' => max( 0, (int) ( $current['generation'] ?? 0 ) ) + 1,
+					'trigger'    => $trigger,
+					'claimed_at' => gmdate( 'c', $now ),
+				);
+				return $engine;
+			},
+			'scheduler_recovery_claim'
+		);
+
+		$state = is_array( $result['snapshot']['scheduler_recovery'] ?? null ) ? $result['snapshot']['scheduler_recovery'] : array();
+		return array(
+			'owned' => ! empty( $result['success'] ) && hash_equals( $token, (string) ( $state['token'] ?? '' ) ),
+			'token' => $token,
+		);
+	}
+
+	/** @param array<string,mixed> $extra */
+	private function finishPathlessChildRecovery( int $job_id, string $token, string $state, array $extra ): bool {
+		$result = EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $token, $state, $extra ): ?array {
+				$current = is_array( $engine['scheduler_recovery'] ?? null ) ? $engine['scheduler_recovery'] : array();
+				if ( ! hash_equals( $token, (string) ( $current['token'] ?? '' ) ) || 'claimed' !== ( $current['state'] ?? '' ) ) {
+					return null;
+				}
+				$engine['scheduler_recovery'] = array_merge(
+					$current,
+					$extra,
+					array(
+						'state'        => $state,
+						'completed_at' => gmdate( 'c' ),
+					)
+				);
+				return $engine;
+			},
+			'scheduler_recovery_finish'
+		);
+		return ! empty( $result['success'] );
+	}
+
+	/** @return array<string,mixed> */
+	private function childRecoveryEvidence( array $job, array $diagnosis, string $status, string $trigger, string $reason = '' ): array {
+		$action = is_array( $diagnosis['active_action'] ?? null ) ? $diagnosis['active_action'] : ( is_array( $diagnosis['latest_action'] ?? null ) ? $diagnosis['latest_action'] : array() );
+		$created = strtotime( (string) ( $job['created_at'] ?? '' ) . ' UTC' );
+		return array(
+			'job_id'             => (int) ( $job['job_id'] ?? 0 ),
+			'flow_id'            => (int) ( $job['flow_id'] ?? 0 ),
+			'parent_job_id'      => (int) ( $job['parent_job_id'] ?? 0 ),
+			'status'             => $status,
+			'reason'             => '' !== $reason ? $reason : (string) ( $diagnosis['reason'] ?? '' ),
+			'job_age_seconds'    => false === $created ? 0 : max( 0, time() - $created ),
+			'scheduler_path'     => ! empty( $diagnosis['has_active_path'] ) ? 'active' : 'none',
+			'action_id'          => (int) ( $action['action_id'] ?? 0 ),
+			'action_hook'        => (string) ( $action['hook'] ?? '' ),
+			'action_status'      => (string) ( $action['status'] ?? '' ),
+			'action_claim_id'    => (int) ( $action['claim_id'] ?? 0 ),
+			'operation_state'    => (string) ( $job['operation_state'] ?? '' ),
+			'operation_generation' => (int) ( $job['operation_generation'] ?? 0 ),
+			'retry_eligible'     => ! empty( $diagnosis['retry_eligible'] ),
+			'recovery_trigger'   => $trigger,
+		);
 	}
 
 	/**

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -97,7 +97,7 @@ class JobsCommand extends BaseCommand {
 	 * [--limit=<limit>]
 	 * : Hard attempted storage-touch limit for this invocation (maximum 100).
 	 * ---
-	 * default: 25
+	 * default: 3
 	 * ---
 	 *
 	 * [--recover-pathless-children]
@@ -112,7 +112,7 @@ class JobsCommand extends BaseCommand {
 	 *     wp datamachine jobs recover-stuck
 	 *
 	 *     # Recover one reviewed pathless child
-	 *     wp datamachine jobs recover-stuck --job-id=123 --recover-pathless-children --limit=1
+	 *     wp datamachine jobs recover-stuck --job-id=123 --recover-pathless-children --limit=3
 	 *
 	 *     # Recover stuck jobs for a specific flow
 	 *     wp datamachine jobs recover-stuck --flow=98
@@ -136,7 +136,7 @@ class JobsCommand extends BaseCommand {
 			return;
 		}
 		$job_id  = is_int( $requested_job_id ) ? $requested_job_id : null;
-		$limit   = isset( $assoc_args['limit'] ) ? max( 1, min( 100, (int) $assoc_args['limit'] ) ) : 25;
+		$limit   = isset( $assoc_args['limit'] ) ? max( 1, min( 100, (int) $assoc_args['limit'] ) ) : 3;
 		$recover_pathless_children = isset( $assoc_args['recover-pathless-children'] );
 
 		$result = AbilityRunner::execute(

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -95,7 +95,7 @@ class JobsCommand extends BaseCommand {
 	 * : Scope recovery to one exact job ID.
 	 *
 	 * [--limit=<limit>]
-	 * : Hard mutation limit for this invocation (maximum 100).
+	 * : Hard attempted storage-touch limit for this invocation (maximum 100).
 	 * ---
 	 * default: 25
 	 * ---
@@ -195,7 +195,7 @@ class JobsCommand extends BaseCommand {
 		);
 		WP_CLI::log(
 			sprintf(
-				'Recovery scope: processing jobs only; pending AI deferrals excluded; job=%s flow=%s mutation-limit=%d pathless-apply=%s.',
+				'Recovery scope: processing jobs only; pending AI deferrals excluded; job=%s flow=%s touch-limit=%d pathless-apply=%s.',
 				$job_id ? (string) $job_id : 'all',
 				$flow_id ? (string) $flow_id : 'all',
 				$limit,
@@ -297,6 +297,9 @@ class JobsCommand extends BaseCommand {
 		$claimed_elsewhere = (int) ( $result['claimed_elsewhere'] ?? 0 );
 		$pathless_policy_skipped = (int) ( $result['pathless_policy_skipped'] ?? 0 );
 		$mutations         = (int) ( $result['mutations'] ?? 0 );
+		$attempted         = (int) ( $result['attempted'] ?? 0 );
+		$touched           = (int) ( $result['touched'] ?? 0 );
+		$mutated           = (int) ( $result['mutated'] ?? 0 );
 
 		return array(
 			'recovered'     => $recovered,
@@ -308,6 +311,9 @@ class JobsCommand extends BaseCommand {
 			'claimed_elsewhere' => $claimed_elsewhere,
 			'pathless_policy_skipped' => $pathless_policy_skipped,
 			'mutations'     => $mutations,
+			'attempted'     => $attempted,
+			'touched'       => $touched,
+			'mutated'       => $mutated,
 			'apply_limit'   => (int) ( $result['apply_limit'] ?? 0 ),
 			'limit_reached' => ! empty( $result['limit_reached'] ) ? 1 : 0,
 			'actionable'    => $recovered + $timed_out + $stale_actions + $pathless_requeued + $pathless_terminal,
@@ -1155,6 +1161,14 @@ class JobsCommand extends BaseCommand {
 			ARRAY_A
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		foreach ( $rows as &$row ) {
+			$args = json_decode( (string) ( $row['args'] ?? '' ), true );
+			if ( is_array( $args ) ) {
+				$row['decoded_args'] = $args;
+			}
+		}
+		unset( $row );
 
 		return array_values(
 			array_filter(

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable Generic.Formatting.MultipleStatementAlignment,WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned -- Structured command summaries use descriptive keys.
 // phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Data Machine owns custom operational tables and these paths require fresh runtime state or one-time schema mutation.
 /**
  * WP-CLI Jobs Command
@@ -233,14 +234,18 @@ class JobsCommand extends BaseCommand {
 		$timed_out     = (int) ( $result['timed_out'] ?? 0 );
 		$stale_actions = (int) ( $result['stale_actions'] ?? 0 );
 		$skipped       = (int) ( $result['skipped'] ?? 0 );
+		$pathless_requeued = (int) ( $result['pathless_requeued'] ?? 0 );
+		$pathless_terminal = (int) ( $result['pathless_terminal'] ?? 0 );
 
 		return array(
 			'recovered'     => $recovered,
 			'timed_out'     => $timed_out,
 			'stale_actions' => $stale_actions,
 			'skipped'       => $skipped,
-			'actionable'    => $recovered + $timed_out + $stale_actions,
-			'total'         => $recovered + $timed_out + $stale_actions + $skipped,
+			'pathless_requeued' => $pathless_requeued,
+			'pathless_terminal' => $pathless_terminal,
+			'actionable'    => $recovered + $timed_out + $stale_actions + $pathless_requeued + $pathless_terminal,
+			'total'         => $recovered + $timed_out + $stale_actions + $pathless_requeued + $pathless_terminal + $skipped,
 			'requeued'      => (int) ( $result['requeued'] ?? 0 ),
 			'jobs_omitted'  => (int) ( $result['jobs_omitted'] ?? 0 ),
 		);

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -91,13 +91,28 @@ class JobsCommand extends BaseCommand {
 	 *   - yaml
 	 * ---
 	 *
+	 * [--job-id=<job-id>]
+	 * : Scope recovery to one exact job ID.
+	 *
+	 * [--limit=<limit>]
+	 * : Hard mutation limit for this invocation (maximum 100).
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--recover-pathless-children]
+	 * : Explicitly authorize applying historical pathless-child recovery. Dry-runs diagnose them without this flag.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Preview stuck jobs recovery
 	 *     wp datamachine jobs recover-stuck --dry-run
 	 *
-	 *     # Recover all stuck jobs
+	 *     # Recover up to the default mutation limit (pathless children remain guarded)
 	 *     wp datamachine jobs recover-stuck
+	 *
+	 *     # Recover one reviewed pathless child
+	 *     wp datamachine jobs recover-stuck --job-id=123 --recover-pathless-children --limit=1
 	 *
 	 *     # Recover stuck jobs for a specific flow
 	 *     wp datamachine jobs recover-stuck --flow=98
@@ -115,6 +130,14 @@ class JobsCommand extends BaseCommand {
 		$flow_id = isset( $assoc_args['flow'] ) ? (int) $assoc_args['flow'] : null;
 		$timeout = isset( $assoc_args['timeout'] ) ? max( 1, (int) $assoc_args['timeout'] ) : 2;
 		$format  = $assoc_args['format'] ?? 'table';
+		$requested_job_id = isset( $assoc_args['job-id'] ) ? filter_var( $assoc_args['job-id'], FILTER_VALIDATE_INT ) : null;
+		if ( isset( $assoc_args['job-id'] ) && ( false === $requested_job_id || $requested_job_id <= 0 ) ) {
+			WP_CLI::error( '--job-id must be a positive integer.' );
+			return;
+		}
+		$job_id  = is_int( $requested_job_id ) ? $requested_job_id : null;
+		$limit   = isset( $assoc_args['limit'] ) ? max( 1, min( 100, (int) $assoc_args['limit'] ) ) : 25;
+		$recover_pathless_children = isset( $assoc_args['recover-pathless-children'] );
 
 		$result = AbilityRunner::execute(
 			'datamachine/recover-stuck-jobs',
@@ -122,6 +145,10 @@ class JobsCommand extends BaseCommand {
 				'dry_run'       => $dry_run,
 				'flow_id'       => $flow_id,
 				'timeout_hours' => $timeout,
+				'job_id'        => $job_id,
+				'limit'         => $limit,
+				'recover_pathless_children' => $recover_pathless_children,
+				'recovery_trigger' => 'operator_cli',
 			)
 		);
 
@@ -145,6 +172,7 @@ class JobsCommand extends BaseCommand {
 					'jobs_omitted'   => (int) ( $result['jobs_omitted'] ?? 0 ),
 					'jobs_truncated' => ! empty( $result['jobs_truncated'] ),
 					'message'        => $result['message'] ?? '',
+					'scope'          => $result['scope'] ?? array(),
 				),
 				array(
 					'format' => $format,
@@ -165,6 +193,15 @@ class JobsCommand extends BaseCommand {
 				$summary['skipped']
 			)
 		);
+		WP_CLI::log(
+			sprintf(
+				'Recovery scope: processing jobs only; pending AI deferrals excluded; job=%s flow=%s mutation-limit=%d pathless-apply=%s.',
+				$job_id ? (string) $job_id : 'all',
+				$flow_id ? (string) $flow_id : 'all',
+				$limit,
+				$recover_pathless_children ? 'enabled' : 'disabled'
+			)
+		);
 
 		if ( $dry_run ) {
 			WP_CLI::log( 'Dry run - no changes will be made.' );
@@ -172,6 +209,27 @@ class JobsCommand extends BaseCommand {
 		}
 
 		foreach ( $jobs as $job ) {
+			if ( isset( $job['disposition'] ) ) {
+				WP_CLI::log(
+					sprintf(
+						'Job %d disposition=%s reason=%s action=%s/%d generation=%d lease=%s:%d age=%ds receipt=%s:%d claim=%s owner=%s',
+						(int) $job['job_id'],
+						(string) $job['disposition'],
+						(string) ( $job['reason'] ?? '' ),
+						(string) ( $job['action_status'] ?? 'none' ),
+						(int) ( $job['action_id'] ?? 0 ),
+						(int) ( $job['action_generation'] ?? 0 ),
+						(string) ( $job['recovery_lease_state'] ?? 'none' ),
+						(int) ( $job['recovery_lease_generation'] ?? 0 ),
+						(int) ( $job['recovery_lease_age_seconds'] ?? 0 ),
+						(string) ( $job['receipt_state'] ?? 'missing' ),
+						(int) ( $job['receipt_action_id'] ?? 0 ),
+						(string) ( $job['item_claim_state'] ?? 'none' ),
+						(string) ( $job['owner'] ?? 'none' )
+					)
+				);
+				continue;
+			}
 			if ( 'skipped' === $job['status'] ) {
 				WP_CLI::warning( sprintf( 'Job %d: %s', $job['job_id'], $job['reason'] ?? 'Unknown reason' ) );
 			} elseif ( 'would_recover' === $job['status'] ) {
@@ -236,6 +294,9 @@ class JobsCommand extends BaseCommand {
 		$skipped       = (int) ( $result['skipped'] ?? 0 );
 		$pathless_requeued = (int) ( $result['pathless_requeued'] ?? 0 );
 		$pathless_terminal = (int) ( $result['pathless_terminal'] ?? 0 );
+		$claimed_elsewhere = (int) ( $result['claimed_elsewhere'] ?? 0 );
+		$pathless_policy_skipped = (int) ( $result['pathless_policy_skipped'] ?? 0 );
+		$mutations         = (int) ( $result['mutations'] ?? 0 );
 
 		return array(
 			'recovered'     => $recovered,
@@ -244,6 +305,11 @@ class JobsCommand extends BaseCommand {
 			'skipped'       => $skipped,
 			'pathless_requeued' => $pathless_requeued,
 			'pathless_terminal' => $pathless_terminal,
+			'claimed_elsewhere' => $claimed_elsewhere,
+			'pathless_policy_skipped' => $pathless_policy_skipped,
+			'mutations'     => $mutations,
+			'apply_limit'   => (int) ( $result['apply_limit'] ?? 0 ),
+			'limit_reached' => ! empty( $result['limit_reached'] ) ? 1 : 0,
 			'actionable'    => $recovered + $timed_out + $stale_actions + $pathless_requeued + $pathless_terminal,
 			'total'         => $recovered + $timed_out + $stale_actions + $pathless_requeued + $pathless_terminal + $skipped,
 			'requeued'      => (int) ( $result['requeued'] ?? 0 ),
@@ -351,6 +417,11 @@ class JobsCommand extends BaseCommand {
 				array(
 					'success'         => true,
 					'overdue_minutes' => $overdue_minutes,
+					'scope'           => array(
+						'statuses'            => array( 'processing', 'pending' ),
+						'pending_requirement' => 'ai_concurrency_throttle',
+						'note'                => 'Recovery scope excludes pending AI deferrals and inspects processing jobs only.',
+					),
 					'summary'         => $summary,
 					'jobs'            => $items,
 				),
@@ -367,6 +438,7 @@ class JobsCommand extends BaseCommand {
 		$this->format_items( $items, $this->liveness_fields, $assoc_args, 'id' );
 
 		if ( 'table' === $format ) {
+			WP_CLI::log( 'Liveness scope includes processing jobs plus pending AI concurrency deferrals; recover-stuck applies only to processing jobs.' );
 			WP_CLI::log(
 				sprintf(
 					'Inspected %d active jobs: %d active, %d queued, %d AI concurrency-deferred, %d waiting on children, %d scheduler-starved, %d stale in-progress, %d without scheduler path.',

--- a/inc/Cli/Commands/WorkerCommand.php
+++ b/inc/Cli/Commands/WorkerCommand.php
@@ -244,6 +244,9 @@ class WorkerCommand extends BaseCommand {
 		$recovery_mutations = 0;
 		$recovery_requeued = 0;
 		$recovery_skipped = 0;
+		$recovery_attempted = 0;
+		$recovery_touched = 0;
+		$recovery_mutated = 0;
 		$recovery_limit_reached = 0;
 		$recovery_ran = false;
 		$completions = 0;
@@ -298,6 +301,9 @@ class WorkerCommand extends BaseCommand {
 						$recovery_mutations += (int) ( $recovery['mutations'] ?? 0 );
 						$recovery_requeued += (int) ( $recovery['requeued'] ?? 0 );
 						$recovery_skipped += (int) ( $recovery['skipped'] ?? 0 );
+						$recovery_attempted += (int) ( $recovery['attempted'] ?? 0 );
+						$recovery_touched += (int) ( $recovery['touched'] ?? 0 );
+						$recovery_mutated += (int) ( $recovery['mutated'] ?? 0 );
 						$recovery_limit_reached += ! empty( $recovery['limit_reached'] ) ? 1 : 0;
 					}
 				}
@@ -346,6 +352,9 @@ class WorkerCommand extends BaseCommand {
 				'recovery_mutations'         => $recovery_mutations,
 				'recovery_requeued'           => $recovery_requeued,
 				'recovery_skipped'            => $recovery_skipped,
+				'recovery_attempted'          => $recovery_attempted,
+				'recovery_touched'            => $recovery_touched,
+				'recovery_mutated'            => $recovery_mutated,
 				'recovery_limit_reached'     => $recovery_limit_reached,
 				'action_completions'       => $completions,
 				'action_failures'          => $failures,
@@ -395,6 +404,9 @@ class WorkerCommand extends BaseCommand {
 		$recovery_mutations = 0;
 		$recovery_requeued = 0;
 		$recovery_skipped = 0;
+		$recovery_attempted = 0;
+		$recovery_touched = 0;
+		$recovery_mutated = 0;
 		$recovery_limit_reached = 0;
 		$recovery_ran = false;
 		$job_claims  = 0;
@@ -451,6 +463,9 @@ class WorkerCommand extends BaseCommand {
 					$recovery_mutations += (int) ( $recovery['mutations'] ?? 0 );
 					$recovery_requeued += (int) ( $recovery['requeued'] ?? 0 );
 					$recovery_skipped += (int) ( $recovery['skipped'] ?? 0 );
+					$recovery_attempted += (int) ( $recovery['attempted'] ?? 0 );
+					$recovery_touched += (int) ( $recovery['touched'] ?? 0 );
+					$recovery_mutated += (int) ( $recovery['mutated'] ?? 0 );
 					$recovery_limit_reached += ! empty( $recovery['limit_reached'] ) ? 1 : 0;
 				}
 			}
@@ -520,6 +535,9 @@ class WorkerCommand extends BaseCommand {
 			'recovery_mutations'         => $recovery_mutations,
 			'recovery_requeued'           => $recovery_requeued,
 			'recovery_skipped'            => $recovery_skipped,
+			'recovery_attempted'          => $recovery_attempted,
+			'recovery_touched'            => $recovery_touched,
+			'recovery_mutated'            => $recovery_mutated,
 			'recovery_limit_reached'     => $recovery_limit_reached,
 			'job_claims'               => $job_claims,
 			'job_completions'          => $completed,

--- a/inc/Cli/Commands/WorkerCommand.php
+++ b/inc/Cli/Commands/WorkerCommand.php
@@ -1,5 +1,5 @@
 <?php
-// phpcs:disable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned -- Worker option keys are intentionally descriptive.
+// phpcs:disable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned,Generic.Formatting.MultipleStatementAlignment -- Worker result and option keys are intentionally descriptive.
 /**
  * WP-CLI Data Machine worker command.
  *
@@ -237,6 +237,15 @@ class WorkerCommand extends BaseCommand {
 		$recoveries  = 0;
 		$timed_out   = 0;
 		$reconciled  = 0;
+		$pathless_requeued = 0;
+		$pathless_terminal = 0;
+		$recovery_claim_conflicts = 0;
+		$pathless_policy_skipped = 0;
+		$recovery_mutations = 0;
+		$recovery_requeued = 0;
+		$recovery_skipped = 0;
+		$recovery_limit_reached = 0;
+		$recovery_ran = false;
 		$completions = 0;
 		$failures    = 0;
 		$warnings    = 0;
@@ -264,12 +273,15 @@ class WorkerCommand extends BaseCommand {
 
 				++$passes;
 
-				if ( $recover_stuck ) {
+				if ( $recover_stuck && ! $recovery_ran ) {
+					$recovery_ran = true;
 					$recovery = ( new RecoverStuckJobsAbility() )->execute(
 						array(
 							'dry_run'       => false,
 							'timeout_hours' => $stuck_timeout,
 							'recovery_trigger' => 'automatic_worker',
+							'limit'         => 5,
+							'recover_pathless_children' => false,
 						)
 					);
 
@@ -279,6 +291,14 @@ class WorkerCommand extends BaseCommand {
 						$recoveries += (int) ( $recovery['recovered'] ?? 0 );
 						$timed_out  += (int) ( $recovery['timed_out'] ?? 0 );
 						$reconciled += (int) ( $recovery['stale_actions'] ?? 0 );
+						$pathless_requeued += (int) ( $recovery['pathless_requeued'] ?? 0 );
+						$pathless_terminal += (int) ( $recovery['pathless_terminal'] ?? 0 );
+						$recovery_claim_conflicts += (int) ( $recovery['claimed_elsewhere'] ?? 0 );
+						$pathless_policy_skipped += (int) ( $recovery['pathless_policy_skipped'] ?? 0 );
+						$recovery_mutations += (int) ( $recovery['mutations'] ?? 0 );
+						$recovery_requeued += (int) ( $recovery['requeued'] ?? 0 );
+						$recovery_skipped += (int) ( $recovery['skipped'] ?? 0 );
+						$recovery_limit_reached += ! empty( $recovery['limit_reached'] ) ? 1 : 0;
 					}
 				}
 
@@ -319,6 +339,14 @@ class WorkerCommand extends BaseCommand {
 				'job_recoveries'           => $recoveries,
 				'job_timeouts'             => $timed_out,
 				'stale_actions_reconciled' => $reconciled,
+				'pathless_children_requeued' => $pathless_requeued,
+				'pathless_children_terminal' => $pathless_terminal,
+				'recovery_claim_conflicts'   => $recovery_claim_conflicts,
+				'pathless_policy_skipped'    => $pathless_policy_skipped,
+				'recovery_mutations'         => $recovery_mutations,
+				'recovery_requeued'           => $recovery_requeued,
+				'recovery_skipped'            => $recovery_skipped,
+				'recovery_limit_reached'     => $recovery_limit_reached,
 				'action_completions'       => $completions,
 				'action_failures'          => $failures,
 				'pending_actions'          => (int) $status['pending_actions'],
@@ -360,6 +388,15 @@ class WorkerCommand extends BaseCommand {
 		$recoveries  = 0;
 		$timed_out   = 0;
 		$reconciled  = 0;
+		$pathless_requeued = 0;
+		$pathless_terminal = 0;
+		$recovery_claim_conflicts = 0;
+		$pathless_policy_skipped = 0;
+		$recovery_mutations = 0;
+		$recovery_requeued = 0;
+		$recovery_skipped = 0;
+		$recovery_limit_reached = 0;
+		$recovery_ran = false;
 		$job_claims  = 0;
 		$bootstraps  = 0;
 		$completed   = 0;
@@ -389,12 +426,15 @@ class WorkerCommand extends BaseCommand {
 
 			++$passes;
 
-			if ( $recover_stuck ) {
+			if ( $recover_stuck && ! $recovery_ran ) {
+				$recovery_ran = true;
 				$recovery = ( new RecoverStuckJobsAbility() )->execute(
 					array(
 						'dry_run'       => false,
 						'timeout_hours' => $stuck_timeout,
 						'recovery_trigger' => 'automatic_worker',
+						'limit'         => 5,
+						'recover_pathless_children' => false,
 					)
 				);
 
@@ -404,6 +444,14 @@ class WorkerCommand extends BaseCommand {
 					$recoveries += (int) ( $recovery['recovered'] ?? 0 );
 					$timed_out  += (int) ( $recovery['timed_out'] ?? 0 );
 					$reconciled += (int) ( $recovery['stale_actions'] ?? 0 );
+					$pathless_requeued += (int) ( $recovery['pathless_requeued'] ?? 0 );
+					$pathless_terminal += (int) ( $recovery['pathless_terminal'] ?? 0 );
+					$recovery_claim_conflicts += (int) ( $recovery['claimed_elsewhere'] ?? 0 );
+					$pathless_policy_skipped += (int) ( $recovery['pathless_policy_skipped'] ?? 0 );
+					$recovery_mutations += (int) ( $recovery['mutations'] ?? 0 );
+					$recovery_requeued += (int) ( $recovery['requeued'] ?? 0 );
+					$recovery_skipped += (int) ( $recovery['skipped'] ?? 0 );
+					$recovery_limit_reached += ! empty( $recovery['limit_reached'] ) ? 1 : 0;
 				}
 			}
 
@@ -465,6 +513,14 @@ class WorkerCommand extends BaseCommand {
 			'job_recoveries'           => $recoveries,
 			'job_timeouts'             => $timed_out,
 			'stale_actions_reconciled' => $reconciled,
+			'pathless_children_requeued' => $pathless_requeued,
+			'pathless_children_terminal' => $pathless_terminal,
+			'recovery_claim_conflicts'   => $recovery_claim_conflicts,
+			'pathless_policy_skipped'    => $pathless_policy_skipped,
+			'recovery_mutations'         => $recovery_mutations,
+			'recovery_requeued'           => $recovery_requeued,
+			'recovery_skipped'            => $recovery_skipped,
+			'recovery_limit_reached'     => $recovery_limit_reached,
 			'job_claims'               => $job_claims,
 			'job_completions'          => $completed,
 			'bootstrap_actions'        => $bootstraps,

--- a/inc/Cli/Commands/WorkerCommand.php
+++ b/inc/Cli/Commands/WorkerCommand.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned -- Worker option keys are intentionally descriptive.
 /**
  * WP-CLI Data Machine worker command.
  *
@@ -268,6 +269,7 @@ class WorkerCommand extends BaseCommand {
 						array(
 							'dry_run'       => false,
 							'timeout_hours' => $stuck_timeout,
+							'recovery_trigger' => 'automatic_worker',
 						)
 					);
 
@@ -392,6 +394,7 @@ class WorkerCommand extends BaseCommand {
 					array(
 						'dry_run'       => false,
 						'timeout_hours' => $stuck_timeout,
+						'recovery_trigger' => 'automatic_worker',
 					)
 				);
 

--- a/inc/Cli/JobLivenessClassifier.php
+++ b/inc/Cli/JobLivenessClassifier.php
@@ -7,6 +7,8 @@
 
 namespace DataMachine\Cli;
 
+use DataMachine\Core\ChildJobRecoveryPolicy;
+
 defined( 'ABSPATH' ) || exit;
 
 class JobLivenessClassifier {
@@ -19,6 +21,17 @@ class JobLivenessClassifier {
 	 * @return array<string,mixed>
 	 */
 	public static function diagnose( array $job, array $actions, array $child_counts, int $overdue_minutes, int $now ): array {
+		$engine_data = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$actions     = array_values(
+			array_filter(
+				$actions,
+				static function ( array $action ) use ( $job, $engine_data ): bool {
+					$hook = (string) ( $action['hook'] ?? '' );
+					return ! in_array( $hook, array( 'datamachine_execute_step', 'datamachine_resume_ai_step' ), true )
+						|| ChildJobRecoveryPolicy::actionGenerationMatches( $job, $engine_data, $action );
+				}
+			)
+		);
 		$pending     = array_values( array_filter( $actions, fn( $action ) => 'pending' === ( $action['status'] ?? '' ) ) );
 		$in_progress = array_values( array_filter( $actions, fn( $action ) => 'in-progress' === ( $action['status'] ?? '' ) ) );
 		$complete    = array_values( array_filter( $actions, fn( $action ) => 'complete' === ( $action['status'] ?? '' ) ) );
@@ -30,7 +43,6 @@ class JobLivenessClassifier {
 		$oldest_pending_age  = self::minutesSince( $oldest_pending, $now );
 		$oldest_progress_age = self::minutesSince( $oldest_in_progress, $now );
 
-		$engine_data     = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
 		$job_id          = (int) ( $job['job_id'] ?? 0 );
 		$active_children = (int) ( $child_counts['active'] ?? 0 );
 		$total_children  = (int) ( $child_counts['total'] ?? 0 );

--- a/inc/Core/ChildJobRecoveryPolicy.php
+++ b/inc/Core/ChildJobRecoveryPolicy.php
@@ -1,0 +1,95 @@
+<?php
+// phpcs:disable Generic.Formatting.MultipleStatementAlignment,WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned -- Keep recovery evidence keys readable without spacing-only churn.
+/**
+ * Pure ownership policy for recovering pathless batch children.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+class ChildJobRecoveryPolicy {
+
+	/**
+	 * Diagnose scheduler ownership and replay eligibility.
+	 *
+	 * @param array<string,mixed>            $job Job row.
+	 * @param array<string,mixed>            $engine_data Decoded engine data.
+	 * @param array<int,array<string,mixed>> $actions Exact job action history, newest first.
+	 * @param int                            $timeout_seconds In-progress freshness window.
+	 * @param int                            $now Current timestamp.
+	 * @return array<string,mixed>
+	 */
+	public static function diagnose( array $job, array $engine_data, array $actions, int $timeout_seconds, int $now ): array {
+		$active = null;
+		foreach ( $actions as $action ) {
+			if ( self::ownsContinuation( $job, $engine_data, $action, $timeout_seconds, $now ) ) {
+				$active = $action;
+				break;
+			}
+		}
+
+		$latest = $actions[0] ?? array();
+		$args   = is_array( $latest['decoded_args'] ?? null ) ? $latest['decoded_args'] : array();
+		$step   = (string) ( $args['flow_step_id'] ?? '' );
+		$replay = null === $active
+			&& 'failed' === (string) ( $latest['status'] ?? '' )
+			&& 'datamachine_execute_step' === (string) ( $latest['hook'] ?? '' )
+			&& '' !== $step
+			&& isset( $engine_data['flow_config'][ $step ] )
+			&& self::operationGenerationMatches( $job, $args );
+
+		return array(
+			'has_active_path' => null !== $active,
+			'active_action'   => $active,
+			'latest_action'   => $latest,
+			'retry_eligible'  => $replay,
+			'retry_args'      => $replay ? $args : array(),
+			'reason'          => null !== $active ? 'active_scheduler_path' : ( $replay ? 'failed_action_replayable' : ( empty( $latest ) ? 'missing_action' : 'no_replay_safe_action' ) ),
+		);
+	}
+
+	private static function ownsContinuation( array $job, array $engine_data, array $action, int $timeout_seconds, int $now ): bool {
+		$status = (string) ( $action['status'] ?? '' );
+		if ( ! in_array( $status, array( 'pending', 'in-progress' ), true ) ) {
+			return false;
+		}
+
+		if ( 'in-progress' === $status ) {
+			$reference = (string) ( $action['last_attempt_gmt'] ?? $action['scheduled_date_gmt'] ?? '' );
+			$started   = strtotime( $reference . ' UTC' );
+			if ( false !== $started && ( $now - $started ) >= max( 1, $timeout_seconds ) ) {
+				return false;
+			}
+		}
+
+		$args = is_array( $action['decoded_args'] ?? null ) ? $action['decoded_args'] : array();
+		if ( 'datamachine_resume_ai_step' === (string) ( $action['hook'] ?? '' ) ) {
+			$owner      = is_array( $engine_data['ai_concurrency_resume_ownership'] ?? null ) ? $engine_data['ai_concurrency_resume_ownership'] : array();
+			$generation = (int) ( $args['ai_resume_generation'] ?? 0 );
+			$owner_state = 'pending' === $status ? 'scheduled' : 'running';
+
+			return 0 < $generation
+				&& (int) ( $owner['generation'] ?? 0 ) === $generation
+				&& (string) ( $owner['status'] ?? '' ) === $owner_state
+				&& (string) ( $args['flow_step_id'] ?? '' ) === (string) ( $owner['flow_step_id'] ?? '' )
+				&& ( 0 === (int) ( $owner['action_id'] ?? 0 ) || (int) ( $action['action_id'] ?? 0 ) === (int) $owner['action_id'] );
+		}
+
+		return self::operationGenerationMatches( $job, $args );
+	}
+
+	private static function operationGenerationMatches( array $job, array $args ): bool {
+		$generation = (int) ( $args['operation_generation'] ?? 0 );
+		if ( 0 === $generation ) {
+			return true;
+		}
+
+		return 'enqueued' === (string) ( $job['operation_state'] ?? '' )
+			&& (int) ( $job['operation_generation'] ?? 0 ) === $generation
+			&& '' !== (string) ( $args['operation_claim_token'] ?? '' )
+			&& hash_equals( (string) ( $job['operation_claim_token'] ?? '' ), (string) $args['operation_claim_token'] );
+	}
+}

--- a/inc/Core/ChildJobRecoveryPolicy.php
+++ b/inc/Core/ChildJobRecoveryPolicy.php
@@ -16,6 +16,79 @@ class ChildJobRecoveryPolicy {
 		return $job_id > 0 && (int) ( $args['job_id'] ?? 0 ) === $job_id;
 	}
 
+	/** Validate one scheduler action against current operation, AI, and recovery ownership. */
+	public static function actionGenerationMatches( array $job, array $engine_data, array $action ): bool {
+		$args = is_array( $action['decoded_args'] ?? null ) ? $action['decoded_args'] : array();
+		if ( 'datamachine_resume_ai_step' === (string) ( $action['hook'] ?? '' ) ) {
+			$owner       = is_array( $engine_data['ai_concurrency_resume_ownership'] ?? null ) ? $engine_data['ai_concurrency_resume_ownership'] : array();
+			$generation  = (int) ( $args['ai_resume_generation'] ?? 0 );
+			$owner_state = 'pending' === (string) ( $action['status'] ?? '' ) ? 'scheduled' : 'running';
+
+			return 0 < $generation
+				&& (int) ( $owner['generation'] ?? 0 ) === $generation
+				&& (string) ( $owner['status'] ?? '' ) === $owner_state
+				&& (string) ( $args['flow_step_id'] ?? '' ) === (string) ( $owner['flow_step_id'] ?? '' )
+				&& ( 0 === (int) ( $owner['action_id'] ?? 0 ) || (int) ( $action['action_id'] ?? 0 ) === (int) $owner['action_id'] );
+		}
+
+		return self::recoveryGenerationMatches( $engine_data, $action, $args )
+			&& self::operationGenerationMatches( $job, $args );
+	}
+
+	/** Describe only validated lease and receipt ownership evidence. */
+	public static function recoveryOwnershipEvidence( array $engine_data, int $now ): array {
+		$owner      = is_array( $engine_data['scheduler_recovery'] ?? null ) ? $engine_data['scheduler_recovery'] : array();
+		$receipt    = is_array( $owner['receipt'] ?? null ) ? $owner['receipt'] : array();
+		$token      = (string) ( $owner['token'] ?? '' );
+		$generation = (int) ( $owner['generation'] ?? 0 );
+		$expiry     = strtotime( (string) ( $owner['expires_at'] ?? '' ) );
+		$lease_valid = 'claimed' === (string) ( $owner['state'] ?? '' )
+			&& '' !== $token
+			&& 0 < $generation
+			&& false !== $expiry
+			&& $now < $expiry;
+		$action_receipt_valid = 'requeued' === (string) ( $owner['state'] ?? '' )
+			&& '' !== $token
+			&& 0 < $generation
+			&& (int) ( $receipt['generation'] ?? 0 ) === $generation
+			&& 0 < (int) ( $receipt['action_id'] ?? 0 );
+		$terminal_receipt_valid = 'terminalized' === (string) ( $owner['state'] ?? '' )
+			&& '' !== $token
+			&& 0 < $generation
+			&& (int) ( $receipt['generation'] ?? 0 ) === $generation
+			&& '' !== (string) ( $receipt['terminal_status'] ?? '' );
+		$receipt_valid = $action_receipt_valid || $terminal_receipt_valid;
+
+		$state = 'none';
+		if ( ! empty( $owner ) ) {
+			$state = $lease_valid ? 'active' : ( $receipt_valid ? 'committed' : ( 'claimed' === (string) ( $owner['state'] ?? '' ) && false !== $expiry && $now >= $expiry ? 'expired' : 'invalid' ) );
+		}
+
+		return array(
+			'state'          => $state,
+			'lease_valid'    => $lease_valid,
+			'receipt_valid'  => $receipt_valid,
+			'token'          => ( $lease_valid || $receipt_valid ) ? $token : '',
+			'generation'     => ( $lease_valid || $receipt_valid ) ? $generation : 0,
+			'expires_at'     => $lease_valid ? (string) ( $owner['expires_at'] ?? '' ) : '',
+			'claimed_at'     => $lease_valid ? (string) ( $owner['claimed_at'] ?? '' ) : '',
+			'renewed_at'     => $lease_valid ? (string) ( $owner['renewed_at'] ?? '' ) : '',
+			'receipt_action_id' => $action_receipt_valid ? (int) $receipt['action_id'] : 0,
+			'receipt_state'  => $action_receipt_valid ? 'committed' : ( $terminal_receipt_valid ? 'terminal_committed' : ( empty( $receipt ) ? 'missing' : 'invalid' ) ),
+		);
+	}
+
+	/** Validate a committed recovery action generation after execution. */
+	public static function recoveryExecutionMatches( array $engine_data, int $generation, string $token ): bool {
+		$evidence = self::recoveryOwnershipEvidence( $engine_data, time() );
+
+		return 0 < $generation
+			&& 'committed' === $evidence['state']
+			&& $generation === (int) $evidence['generation']
+			&& '' !== $token
+			&& hash_equals( (string) $evidence['token'], $token );
+	}
+
 	/**
 	 * Diagnose scheduler ownership and replay eligibility.
 	 *
@@ -70,23 +143,7 @@ class ChildJobRecoveryPolicy {
 			}
 		}
 
-		$args = is_array( $action['decoded_args'] ?? null ) ? $action['decoded_args'] : array();
-		if ( 'datamachine_resume_ai_step' === (string) ( $action['hook'] ?? '' ) ) {
-			$owner      = is_array( $engine_data['ai_concurrency_resume_ownership'] ?? null ) ? $engine_data['ai_concurrency_resume_ownership'] : array();
-			$generation = (int) ( $args['ai_resume_generation'] ?? 0 );
-			$owner_state = 'pending' === $status ? 'scheduled' : 'running';
-
-			return 0 < $generation
-				&& (int) ( $owner['generation'] ?? 0 ) === $generation
-				&& (string) ( $owner['status'] ?? '' ) === $owner_state
-				&& (string) ( $args['flow_step_id'] ?? '' ) === (string) ( $owner['flow_step_id'] ?? '' )
-				&& ( 0 === (int) ( $owner['action_id'] ?? 0 ) || (int) ( $action['action_id'] ?? 0 ) === (int) $owner['action_id'] );
-		}
-		if ( ! self::recoveryGenerationMatches( $engine_data, $action, $args ) ) {
-			return false;
-		}
-
-		return self::operationGenerationMatches( $job, $args );
+		return self::actionGenerationMatches( $job, $engine_data, $action );
 	}
 
 	private static function recoveryGenerationMatches( array $engine_data, array $action, array $args ): bool {
@@ -104,7 +161,8 @@ class ChildJobRecoveryPolicy {
 			&& (int) ( $owner['generation'] ?? 0 ) === $generation
 			&& (int) ( $receipt['generation'] ?? 0 ) === $generation
 			&& hash_equals( $token, (string) ( $owner['token'] ?? '' ) )
-			&& ( 0 === (int) ( $receipt['action_id'] ?? 0 ) || (int) ( $action['action_id'] ?? 0 ) === (int) $receipt['action_id'] );
+			&& 0 < (int) ( $receipt['action_id'] ?? 0 )
+			&& (int) ( $action['action_id'] ?? 0 ) === (int) $receipt['action_id'];
 	}
 
 	private static function operationGenerationMatches( array $job, array $args ): bool {

--- a/inc/Core/ChildJobRecoveryPolicy.php
+++ b/inc/Core/ChildJobRecoveryPolicy.php
@@ -35,6 +35,47 @@ class ChildJobRecoveryPolicy {
 			&& self::operationGenerationMatches( $job, $args );
 	}
 
+	/** Exact pending/in-progress action ownership is a timeout-independent heartbeat. */
+	public static function hasActiveGenerationAction( array $job, array $engine_data, array $actions ): bool {
+		foreach ( $actions as $action ) {
+			if ( in_array( (string) ( $action['status'] ?? '' ), array( 'pending', 'in-progress' ), true ) && self::actionGenerationMatches( $job, $engine_data, $action ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/** Detect a failed exact action that makes its generation reclaimable immediately. */
+	public static function hasFailedGenerationAction( array $job, array $engine_data, array $actions ): bool {
+		foreach ( $actions as $action ) {
+			if ( 'failed' === (string) ( $action['status'] ?? '' ) && self::actionGenerationMatches( $job, $engine_data, $action ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/** Decide whether a new recovery generation may replace current ownership. */
+	public static function canClaimNextGeneration( array $job, array $engine_data, array $actions, int $now ): bool {
+		if ( self::hasActiveGenerationAction( $job, $engine_data, $actions ) ) {
+			return false;
+		}
+
+		$owner = is_array( $engine_data['scheduler_recovery'] ?? null ) ? $engine_data['scheduler_recovery'] : array();
+		if ( empty( $owner ) ) {
+			return true;
+		}
+		if ( 'terminalized' === (string) ( $owner['state'] ?? '' ) ) {
+			return false;
+		}
+		if ( self::hasFailedGenerationAction( $job, $engine_data, $actions ) ) {
+			return true;
+		}
+
+		$expiry = strtotime( (string) ( $owner['expires_at'] ?? '' ) );
+		return false === $expiry || $expiry <= $now;
+	}
+
 	/** Describe only validated lease and receipt ownership evidence. */
 	public static function recoveryOwnershipEvidence( array $engine_data, int $now ): array {
 		$owner      = is_array( $engine_data['scheduler_recovery'] ?? null ) ? $engine_data['scheduler_recovery'] : array();
@@ -47,7 +88,7 @@ class ChildJobRecoveryPolicy {
 			&& 0 < $generation
 			&& false !== $expiry
 			&& $now < $expiry;
-		$action_receipt_valid = 'requeued' === (string) ( $owner['state'] ?? '' )
+		$action_receipt_valid = in_array( (string) ( $owner['state'] ?? '' ), array( 'requeued', 'running' ), true )
 			&& '' !== $token
 			&& 0 < $generation
 			&& (int) ( $receipt['generation'] ?? 0 ) === $generation
@@ -157,7 +198,7 @@ class ChildJobRecoveryPolicy {
 		$token   = (string) ( $args['recovery_claim_token'] ?? '' );
 
 		return '' !== $token
-			&& 'requeued' === (string) ( $owner['state'] ?? '' )
+			&& in_array( (string) ( $owner['state'] ?? '' ), array( 'requeued', 'running' ), true )
 			&& (int) ( $owner['generation'] ?? 0 ) === $generation
 			&& (int) ( $receipt['generation'] ?? 0 ) === $generation
 			&& hash_equals( $token, (string) ( $owner['token'] ?? '' ) )

--- a/inc/Core/ChildJobRecoveryPolicy.php
+++ b/inc/Core/ChildJobRecoveryPolicy.php
@@ -11,6 +11,10 @@ namespace DataMachine\Core;
 defined( 'ABSPATH' ) || exit;
 
 class ChildJobRecoveryPolicy {
+	/** Exact decoded scheduler ownership check; avoids numeric-prefix collisions. */
+	public static function actionBelongsToJob( array $args, int $job_id ): bool {
+		return $job_id > 0 && (int) ( $args['job_id'] ?? 0 ) === $job_id;
+	}
 
 	/**
 	 * Diagnose scheduler ownership and replay eligibility.
@@ -39,6 +43,7 @@ class ChildJobRecoveryPolicy {
 			&& 'datamachine_execute_step' === (string) ( $latest['hook'] ?? '' )
 			&& '' !== $step
 			&& isset( $engine_data['flow_config'][ $step ] )
+			&& self::recoveryGenerationMatches( $engine_data, $latest, $args )
 			&& self::operationGenerationMatches( $job, $args );
 
 		return array(
@@ -77,8 +82,29 @@ class ChildJobRecoveryPolicy {
 				&& (string) ( $args['flow_step_id'] ?? '' ) === (string) ( $owner['flow_step_id'] ?? '' )
 				&& ( 0 === (int) ( $owner['action_id'] ?? 0 ) || (int) ( $action['action_id'] ?? 0 ) === (int) $owner['action_id'] );
 		}
+		if ( ! self::recoveryGenerationMatches( $engine_data, $action, $args ) ) {
+			return false;
+		}
 
 		return self::operationGenerationMatches( $job, $args );
+	}
+
+	private static function recoveryGenerationMatches( array $engine_data, array $action, array $args ): bool {
+		$generation = (int) ( $args['recovery_generation'] ?? 0 );
+		if ( 0 === $generation ) {
+			return true;
+		}
+
+		$owner   = is_array( $engine_data['scheduler_recovery'] ?? null ) ? $engine_data['scheduler_recovery'] : array();
+		$receipt = is_array( $owner['receipt'] ?? null ) ? $owner['receipt'] : array();
+		$token   = (string) ( $args['recovery_claim_token'] ?? '' );
+
+		return '' !== $token
+			&& 'requeued' === (string) ( $owner['state'] ?? '' )
+			&& (int) ( $owner['generation'] ?? 0 ) === $generation
+			&& (int) ( $receipt['generation'] ?? 0 ) === $generation
+			&& hash_equals( $token, (string) ( $owner['token'] ?? '' ) )
+			&& ( 0 === (int) ( $receipt['action_id'] ?? 0 ) || (int) ( $action['action_id'] ?? 0 ) === (int) $receipt['action_id'] );
 	}
 
 	private static function operationGenerationMatches( array $job, array $args ): bool {

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -20,6 +20,7 @@ use DataMachine\Core\Database\BaseRepository;
 use DataMachine\Core\Database\LifecycleStateTransition;
 use DataMachine\Core\Database\RunMetadata\RunMetadata;
 use DataMachine\Core\ExecutionQuery;
+use DataMachine\Core\ChildJobRecoveryPolicy;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\RunMetrics;
 use DataMachine\Core\RunLifecycleStore;
@@ -41,6 +42,37 @@ class Jobs extends BaseRepository {
 
 	/** Job currently owning the connection-wide terminal transaction. */
 	private static ?int $terminalizing_job = null;
+	/** @var array<int,array<int,array{token:string,generation:int,mode:string}>> */
+	private static array $recovery_execution_fences = array();
+
+	/** Fence every terminal callback issued while a recovery action executes. */
+	public static function begin_recovery_execution_fence( int $job_id, string $token, int $generation ): void {
+		if ( 0 < $job_id && '' !== $token && 0 < $generation ) {
+			self::$recovery_execution_fences[ $job_id ][] = array(
+				'token'      => $token,
+				'generation' => $generation,
+				'mode'       => 'execution',
+			);
+		}
+	}
+
+	/** Clear only the exact request-local recovery execution fence owner. */
+	public static function end_recovery_execution_fence( int $job_id, string $token, int $generation ): void {
+		$stack = self::$recovery_execution_fences[ $job_id ] ?? array();
+		for ( $index = count( $stack ) - 1; $index >= 0; --$index ) {
+			$current = $stack[ $index ];
+			if ( (int) ( $current['generation'] ?? 0 ) !== $generation || ! hash_equals( $token, (string) ( $current['token'] ?? '' ) ) ) {
+				continue;
+			}
+			unset( $stack[ $index ] );
+			break;
+		}
+		if ( empty( $stack ) ) {
+			unset( self::$recovery_execution_fences[ $job_id ] );
+		} else {
+			self::$recovery_execution_fences[ $job_id ] = array_values( $stack );
+		}
+	}
 
 	/**
 	 * Known compound status suffixes for exact-match queries.
@@ -1959,6 +1991,24 @@ class Jobs extends BaseRepository {
 			array(
 				'token'      => $token,
 				'generation' => $generation,
+				'mode'       => 'lease',
+			)
+		);
+	}
+
+	/** Commit a terminal execution result only while its recovery generation still owns the job. */
+	public function transition_recovery_execution_owned_job( int $job_id, string $status, string $token, int $generation ): array {
+		if ( ! JobStatus::isStatusFinal( $status ) || '' === $token || $generation <= 0 ) {
+			return $this->status_transition_result( false, false, null, $status );
+		}
+
+		return $this->transition_terminal_job_status_result(
+			$job_id,
+			$status,
+			array(
+				'token'      => $token,
+				'generation' => $generation,
+				'mode'       => 'execution',
 			)
 		);
 	}
@@ -2195,6 +2245,11 @@ class Jobs extends BaseRepository {
 	 * @return array{success: bool, changed: bool, current_status: ?string, status: string}
 	 */
 	private function transition_terminal_job_status_result( int $job_id, string $requested_status, ?array $recovery_owner = null ): array {
+		if ( null === $recovery_owner && isset( self::$recovery_execution_fences[ $job_id ] ) ) {
+			$fence_stack    = self::$recovery_execution_fences[ $job_id ];
+			$recovery_owner = end( $fence_stack );
+			$recovery_owner = is_array( $recovery_owner ) ? $recovery_owner : null;
+		}
 		if ( null !== self::$terminalizing_job ) {
 			return $this->status_transition_result( false, false, null, $requested_status );
 		}
@@ -2211,7 +2266,7 @@ class Jobs extends BaseRepository {
 			$this->rollback_terminal_transition( $job_id );
 			return $this->status_transition_result( false, false, null, $requested_status );
 		}
-		if ( is_array( $recovery_owner ) && ! $this->recovery_owner_matches( $job, (string) ( $recovery_owner['token'] ?? '' ), (int) ( $recovery_owner['generation'] ?? 0 ) ) ) {
+		if ( is_array( $recovery_owner ) && ! $this->terminal_recovery_owner_matches( $job, $recovery_owner ) ) {
 			$this->rollback_terminal_transition( $job_id );
 			return $this->status_transition_result( false, false, (string) ( $job['status'] ?? '' ), $requested_status );
 		}
@@ -2290,8 +2345,11 @@ class Jobs extends BaseRepository {
 		}
 		$processed_claim_count = is_array( $accounting_context ) ? max( 0, (int) ( $accounting_context['processed_claim_count'] ?? 0 ) ) : 0;
 		if ( is_array( $recovery_owner ) ) {
-			$latest_job = $this->get_job_for_update( $job_id );
-			if ( ! $this->renew_recovery_owner_on_locked_job( $latest_job, (string) ( $recovery_owner['token'] ?? '' ), (int) ( $recovery_owner['generation'] ?? 0 ) ) ) {
+			$latest_job  = $this->get_job_for_update( $job_id );
+			$owner_valid = 'execution' === (string) ( $recovery_owner['mode'] ?? '' )
+				? $this->terminal_recovery_owner_matches( $latest_job, $recovery_owner )
+				: $this->renew_recovery_owner_on_locked_job( $latest_job, (string) ( $recovery_owner['token'] ?? '' ), (int) ( $recovery_owner['generation'] ?? 0 ) );
+			if ( ! $owner_valid ) {
 				$this->rollback_terminal_transition( $job_id );
 				return $this->status_transition_result( false, false, $current_status, $current_status );
 			}
@@ -2625,6 +2683,22 @@ class Jobs extends BaseRepository {
 			&& hash_equals( $token, (string) ( $lease['token'] ?? '' ) )
 			&& false !== $expiry
 			&& time() < $expiry;
+	}
+
+	/** Validate either a recovery lease owner or a committed recovery action owner. */
+	private function terminal_recovery_owner_matches( ?array $job, array $owner ): bool {
+		if ( ! is_array( $job ) ) {
+			return false;
+		}
+
+		$token      = (string) ( $owner['token'] ?? '' );
+		$generation = (int) ( $owner['generation'] ?? 0 );
+		if ( 'execution' !== (string) ( $owner['mode'] ?? '' ) ) {
+			return $this->recovery_owner_matches( $job, $token, $generation );
+		}
+
+		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		return ChildJobRecoveryPolicy::recoveryExecutionMatches( $engine, $generation, $token );
 	}
 
 	/** Atomically renew an exact recovery owner while its jobs row is locked. */

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -37,6 +37,7 @@ class Jobs extends BaseRepository {
 	private const TERMINAL_ACCOUNTING_LIFECYCLE = 2;
 	private const TERMINAL_ACCOUNTING_NOTIFY    = 3;
 	public const TERMINAL_ACCOUNTING_COMPLETE   = 4;
+	private const RECOVERY_LEASE_TTL            = 300;
 
 	/** Job currently owning the connection-wide terminal transaction. */
 	private static ?int $terminalizing_job = null;
@@ -1942,6 +1943,137 @@ class Jobs extends BaseRepository {
 	}
 
 	/**
+	 * Commit a pathless-child terminal transition while its recovery lease owns the locked row.
+	 *
+	 * @return array{success:bool,changed:bool,current_status:?string,status:string}
+	 */
+	// phpcs:disable Generic.Formatting.MultipleStatementAlignment,WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned -- Recovery receipts use descriptive keys.
+	public function transition_recovery_owned_child( int $job_id, string $status, string $token, int $generation ): array {
+		if ( ! JobStatus::isStatusFinal( $status ) || '' === $token || $generation <= 0 ) {
+			return $this->status_transition_result( false, false, null, $status );
+		}
+
+		return $this->transition_terminal_job_status_result(
+			$job_id,
+			$status,
+			array(
+				'token'      => $token,
+				'generation' => $generation,
+			)
+		);
+	}
+
+	/**
+	 * Schedule and receipt one child requeue inside the recovery owner's locked transaction.
+	 *
+	 * The scheduler callback uses the same database transaction, so a crash or failed receipt
+	 * rolls back both the Action Scheduler insert and the jobs-row mutation.
+	 *
+	 * @param callable():int $schedule Scheduler callback returning an action ID.
+	 * @return array{success:bool,action_id:int,reason:string}
+	 */
+	public function commit_recovery_owned_requeue( int $job_id, string $token, int $generation, callable $schedule ): array {
+		$result = array(
+			'success'   => false,
+			'action_id' => 0,
+			'reason'    => 'lease_not_owned',
+		);
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		if ( false === $this->wpdb->query( 'START TRANSACTION' ) ) {
+			$result['reason'] = 'transaction_start_failed';
+			return $result;
+		}
+
+		$job = $this->get_job_for_update( $job_id );
+		if ( JobStatus::PROCESSING !== ( $job['status'] ?? '' ) || (int) ( $job['parent_job_id'] ?? 0 ) <= 0 || ! $this->renew_recovery_owner_on_locked_job( $job, $token, $generation ) ) {
+			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			return $result;
+		}
+
+		$engine  = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$receipt = is_array( $engine['scheduler_recovery']['receipt'] ?? null ) ? $engine['scheduler_recovery']['receipt'] : array();
+		if ( (int) ( $receipt['generation'] ?? 0 ) === $generation && (int) ( $receipt['action_id'] ?? 0 ) > 0 ) {
+			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			return array(
+				'success'   => true,
+				'action_id' => (int) $receipt['action_id'],
+				'reason'    => 'receipt_reused',
+			);
+		}
+
+		try {
+			$action_id = (int) $schedule();
+		} catch ( \Throwable ) {
+			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result['reason'] = 'scheduler_exception';
+			return $result;
+		}
+		if ( $action_id <= 0 ) {
+			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result['reason'] = 'schedule_failed';
+			return $result;
+		}
+		if ( ! $this->recovery_owner_matches( $job, $token, $generation ) ) {
+			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result['reason'] = 'lease_expired_after_schedule';
+			return $result;
+		}
+
+		$engine['scheduler_recovery']['state']        = 'requeued';
+		$engine['scheduler_recovery']['completed_at'] = gmdate( 'c' );
+		$engine['scheduler_recovery']['receipt']      = array(
+			'generation'   => $generation,
+			'action_id'    => $action_id,
+			'committed_at' => gmdate( 'c' ),
+		);
+		$run_lifecycle = is_array( $engine['run_lifecycle'] ?? null ) ? $engine['run_lifecycle'] : array();
+		$run_lifecycle['run_id']        = (string) ( $run_lifecycle['run_id'] ?? 'job:' . $job_id );
+		$run_lifecycle['job_id']        = $job_id;
+		$run_lifecycle['attempt']       = max( 1, (int) ( $run_lifecycle['attempt'] ?? 1 ) );
+		$run_lifecycle['replay_events'] = is_array( $run_lifecycle['replay_events'] ?? null ) ? array_values( $run_lifecycle['replay_events'] ) : array();
+		$run_lifecycle['artifact_refs'] = is_array( $run_lifecycle['artifact_refs'] ?? null ) ? array_values( $run_lifecycle['artifact_refs'] ) : array();
+		$run_lifecycle['status']        = JobStatus::PENDING;
+		$run_lifecycle['updated_at']    = current_time( 'mysql', true );
+		$engine['run_lifecycle']        = $run_lifecycle;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $this->wpdb->update(
+			$this->table_name,
+			array(
+				'status'      => JobStatus::PENDING,
+				'engine_data' => wp_json_encode( $engine ),
+			),
+			array(
+				'job_id' => $job_id,
+				'status' => JobStatus::PROCESSING,
+			),
+			array( '%s', '%s' ),
+			array( '%d', '%s' )
+		);
+		if ( 1 !== (int) $updated ) {
+			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result['reason'] = 'receipt_commit_failed';
+			return $result;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		if ( false === $this->wpdb->query( 'COMMIT' ) ) {
+			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result['reason'] = 'transaction_commit_failed';
+			return $result;
+		}
+
+		wp_cache_delete( $job_id, 'datamachine_engine_data' );
+		return array(
+			'success'   => true,
+			'action_id' => $action_id,
+			'reason'    => 'requeued',
+		);
+	}
+	// phpcs:enable Generic.Formatting.MultipleStatementAlignment,WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
+
+	/**
 	 * Transition a job status with compare-and-set/idempotent lifecycle details.
 	 *
 	 * Non-terminal jobs may move to another non-terminal state or to a terminal
@@ -2062,7 +2194,7 @@ class Jobs extends BaseRepository {
 	 * @param string $requested_status Requested final status.
 	 * @return array{success: bool, changed: bool, current_status: ?string, status: string}
 	 */
-	private function transition_terminal_job_status_result( int $job_id, string $requested_status ): array {
+	private function transition_terminal_job_status_result( int $job_id, string $requested_status, ?array $recovery_owner = null ): array {
 		if ( null !== self::$terminalizing_job ) {
 			return $this->status_transition_result( false, false, null, $requested_status );
 		}
@@ -2078,6 +2210,10 @@ class Jobs extends BaseRepository {
 		if ( ! is_array( $job ) ) {
 			$this->rollback_terminal_transition( $job_id );
 			return $this->status_transition_result( false, false, null, $requested_status );
+		}
+		if ( is_array( $recovery_owner ) && ! $this->recovery_owner_matches( $job, (string) ( $recovery_owner['token'] ?? '' ), (int) ( $recovery_owner['generation'] ?? 0 ) ) ) {
+			$this->rollback_terminal_transition( $job_id );
+			return $this->status_transition_result( false, false, (string) ( $job['status'] ?? '' ), $requested_status );
 		}
 
 		$current_status = is_string( $job['status'] ?? null ) ? $job['status'] : '';
@@ -2153,25 +2289,49 @@ class Jobs extends BaseRepository {
 			return $this->status_transition_result( false, false, $current_status, $current_status );
 		}
 		$processed_claim_count = is_array( $accounting_context ) ? max( 0, (int) ( $accounting_context['processed_claim_count'] ?? 0 ) ) : 0;
+		if ( is_array( $recovery_owner ) ) {
+			$latest_job = $this->get_job_for_update( $job_id );
+			if ( ! $this->renew_recovery_owner_on_locked_job( $latest_job, (string) ( $recovery_owner['token'] ?? '' ), (int) ( $recovery_owner['generation'] ?? 0 ) ) ) {
+				$this->rollback_terminal_transition( $job_id );
+				return $this->status_transition_result( false, false, $current_status, $current_status );
+			}
+			$job = $latest_job;
+		}
 
 		// The locked row makes this a non-retrying ownership CAS. Any failure rolls
 		// back the whole callback/claim/job unit instead of retrying one statement.
+		// phpcs:disable Generic.Formatting.MultipleStatementAlignment,WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned -- Terminal recovery receipt extends the existing update envelope.
+		$update_data = array(
+			'status'                              => $status,
+			'completed_at'                        => current_time( 'mysql', true ),
+			'terminal_accounting_state'           => 0,
+			'terminal_accounting_owner'           => null,
+			'terminal_accounting_claimed_at'      => null,
+			'terminal_accounting_processed_count' => $processed_claim_count,
+		);
+		$update_formats = array( '%s', '%s', '%d', null, null, '%d' );
+		if ( is_array( $recovery_owner ) ) {
+			$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+			$engine['scheduler_recovery']['state']        = 'terminalized';
+			$engine['scheduler_recovery']['completed_at'] = gmdate( 'c' );
+			$engine['scheduler_recovery']['receipt']      = array(
+				'generation'      => (int) ( $recovery_owner['generation'] ?? 0 ),
+				'terminal_status' => $status,
+				'committed_at'    => gmdate( 'c' ),
+			);
+			$update_data['engine_data'] = wp_json_encode( $engine );
+			$update_formats[]           = '%s';
+		}
+		// phpcs:enable Generic.Formatting.MultipleStatementAlignment,WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->update(
 			$this->table_name,
-			array(
-				'status'                              => $status,
-				'completed_at'                        => current_time( 'mysql', true ),
-				'terminal_accounting_state'           => 0,
-				'terminal_accounting_owner'           => null,
-				'terminal_accounting_claimed_at'      => null,
-				'terminal_accounting_processed_count' => $processed_claim_count,
-			),
+			$update_data,
 			array(
 				'job_id' => $job_id,
 				'status' => $current_status,
 			),
-			array( '%s', '%s', '%d', null, null, '%d' ),
+			$update_formats,
 			array( '%d', '%s' )
 		);
 		if ( 1 !== $updated ) {
@@ -2190,6 +2350,9 @@ class Jobs extends BaseRepository {
 			$winner        = $this->get_job( $job_id );
 			$winner_status = is_array( $winner ) && is_string( $winner['status'] ?? null ) ? $winner['status'] : $current_status;
 			return $this->status_transition_result( $status === $winner_status, false, $winner_status, $winner_status );
+		}
+		if ( is_array( $recovery_owner ) ) {
+			wp_cache_delete( $job_id, 'datamachine_engine_data' );
 		}
 
 		$this->reconcile_terminal_accounting( $job_id );
@@ -2445,6 +2608,54 @@ class Jobs extends BaseRepository {
 		}
 
 		return is_array( $job ) ? $job : null;
+	}
+
+	/** Check the exact unexpired recovery fence on a locked jobs row. */
+	private function recovery_owner_matches( ?array $job, string $token, int $generation ): bool {
+		if ( ! is_array( $job ) || '' === $token || $generation <= 0 ) {
+			return false;
+		}
+
+		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$lease  = is_array( $engine['scheduler_recovery'] ?? null ) ? $engine['scheduler_recovery'] : array();
+		$expiry = strtotime( (string) ( $lease['expires_at'] ?? '' ) );
+
+		return 'claimed' === (string) ( $lease['state'] ?? '' )
+			&& (int) ( $lease['generation'] ?? 0 ) === $generation
+			&& hash_equals( $token, (string) ( $lease['token'] ?? '' ) )
+			&& false !== $expiry
+			&& time() < $expiry;
+	}
+
+	/** Atomically renew an exact recovery owner while its jobs row is locked. */
+	private function renew_recovery_owner_on_locked_job( ?array &$job, string $token, int $generation ): bool {
+		if ( ! $this->recovery_owner_matches( $job, $token, $generation ) ) {
+			return false;
+		}
+
+		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$now    = time();
+
+		$engine['scheduler_recovery']['renewed_at'] = gmdate( 'c', $now );
+		$engine['scheduler_recovery']['expires_at'] = gmdate( 'c', $now + self::RECOVERY_LEASE_TTL );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Locked transactional lease renewal.
+		$updated = $this->wpdb->update(
+			$this->table_name,
+			array( 'engine_data' => wp_json_encode( $engine ) ),
+			array(
+				'job_id' => (int) $job['job_id'],
+				'status' => JobStatus::PROCESSING,
+			),
+			array( '%s' ),
+			array( '%d', '%s' )
+		);
+		if ( 1 !== (int) $updated ) {
+			return false;
+		}
+
+		$job['engine_data'] = $engine;
+		return true;
 	}
 
 	/** Roll back a terminal ownership boundary and clear request-shared state. */

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -2013,6 +2013,56 @@ class Jobs extends BaseRepository {
 		);
 	}
 
+	/** Renew the exact recovery generation immediately before handler execution. */
+	public function renew_recovery_execution_owner( int $job_id, string $token, int $generation ): bool {
+		if ( $job_id <= 0 || '' === $token || $generation <= 0 ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		if ( false === $this->wpdb->query( 'START TRANSACTION' ) ) {
+			return false;
+		}
+
+		$job   = $this->get_job_for_update( $job_id );
+		$owner = array(
+			'token'      => $token,
+			'generation' => $generation,
+			'mode'       => 'execution',
+		);
+		if ( ! is_array( $job ) || JobStatus::PROCESSING !== ( $job['status'] ?? '' ) || ! $this->terminal_recovery_owner_matches( $job, $owner ) ) {
+			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			return false;
+		}
+
+		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$now    = time();
+		$engine['scheduler_recovery']['state']        = 'running';
+		$engine['scheduler_recovery']['heartbeat_at'] = gmdate( 'c', $now );
+		$engine['scheduler_recovery']['expires_at']   = gmdate( 'c', $now + self::RECOVERY_LEASE_TTL );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $this->wpdb->update(
+			$this->table_name,
+			array( 'engine_data' => wp_json_encode( $engine ) ),
+			array(
+				'job_id' => $job_id,
+				'status' => JobStatus::PROCESSING,
+			),
+			array( '%s' ),
+			array( '%d', '%s' )
+		);
+		if ( 1 !== (int) $updated ) {
+			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$committed = false !== $this->wpdb->query( 'COMMIT' );
+		wp_cache_delete( $job_id, 'datamachine_engine_data' );
+		return $committed;
+	}
+
 	/**
 	 * Schedule and receipt one child requeue inside the recovery owner's locked transaction.
 	 *

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -505,6 +505,35 @@ class ProcessedItems extends BaseRepository {
 		return false !== $this->wpdb->query( 'COMMIT' ) ? $claim_token : false;
 	}
 
+	/** Validate that one persisted descriptor is still actively owned by a job. */
+	public function owns_active_claim( array $claim, int $job_id ): bool {
+		$identity_scope  = (string) ( $claim['identity_scope'] ?? '' );
+		$source_type     = (string) ( $claim['source_type'] ?? '' );
+		$item_identifier = (string) ( $claim['item_identifier'] ?? '' );
+		$token           = (string) ( $claim['ownership_token'] ?? '' );
+		if ( $job_id <= 0 || '' === $identity_scope || '' === $source_type || '' === $item_identifier || '' === $token ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
+		$query = $this->wpdb->prepare(
+			'SELECT claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND job_id = %d AND status = %s AND claim_expires_at > %s LIMIT 1',
+			$this->table_name,
+			$identity_scope,
+			$source_type,
+			$item_identifier,
+			$job_id,
+			self::STATUS_CLAIMED,
+			current_time( 'mysql', true )
+		);
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Query is fully prepared above with an escaped identifier and typed values.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Evidence-only exact ownership query.
+		$owned = $this->wpdb->get_var( $query );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		return is_string( $owned ) && hash_equals( $token, $owned );
+	}
+
 	/**
 	 * Complete a descriptor-less claim while the completing job still owns it.
 	 *

--- a/inc/Core/RecoveryExecutionFence.php
+++ b/inc/Core/RecoveryExecutionFence.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Request-local lifetime guard for recovery-owned step execution.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+use DataMachine\Core\Database\Jobs\Jobs;
+
+defined( 'ABSPATH' ) || exit;
+
+final class RecoveryExecutionFence {
+	public function __construct(
+		private readonly int $job_id,
+		private readonly string $token,
+		private readonly int $generation
+	) {
+		Jobs::begin_recovery_execution_fence( $job_id, $token, $generation );
+	}
+
+	public function __destruct() {
+		Jobs::end_recovery_execution_fence( $this->job_id, $this->token, $this->generation );
+	}
+}

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -63,7 +63,7 @@ function datamachine_flow_exists( int $flow_id ): bool {
  * Both initial execution and AI contention resumes use this callback so a
  * resume cannot drift into a parallel execution implementation.
  */
-function datamachine_execute_step_action( $job_id, string $flow_step_id, $operation_generation = 0, $operation_claim_token = '', $ai_resume_generation = 0 ): void {
+function datamachine_execute_step_action( $job_id, string $flow_step_id, $operation_generation = 0, $operation_claim_token = '', $ai_resume_generation = 0, $recovery_generation = 0, $recovery_claim_token = '' ): void {
 	$ability = wp_get_ability( 'datamachine/execute-step' );
 	if ( $ability ) {
 		$ability->execute(
@@ -73,6 +73,8 @@ function datamachine_execute_step_action( $job_id, string $flow_step_id, $operat
 				'operation_generation'  => is_numeric( $operation_generation ) ? (int) $operation_generation : 0,
 				'operation_claim_token' => is_string( $operation_claim_token ) ? $operation_claim_token : '',
 				'ai_resume_generation'  => is_numeric( $ai_resume_generation ) ? (int) $ai_resume_generation : 0,
+				'recovery_generation'   => is_numeric( $recovery_generation ) ? (int) $recovery_generation : 0,
+				'recovery_claim_token'  => is_string( $recovery_claim_token ) ? $recovery_claim_token : '',
 			)
 		);
 	}
@@ -155,7 +157,7 @@ function datamachine_register_execution_engine() {
 		'datamachine_execute_step',
 		'datamachine_execute_step_action',
 		10,
-		5
+		7
 	);
 
 	/** Dedicated resume bridge avoids collision with the running execute action. */

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -12,6 +12,7 @@ use DataMachine\Core\Database\Jobs\LegacyAIConcurrencyReconciler;
 use DataMachine\Core\JobStatus;
 use DataMachine\Engine\AI\AIConcurrencyBackpressure;
 use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
+use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use WP_UnitTestCase;
 
 class JobLifecycleTransitionTest extends WP_UnitTestCase {
@@ -40,6 +41,23 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 
 		$job = $this->db_jobs->get_job( $job_id );
 		$this->assertSame( JobStatus::FAILED, $job['status'] );
+	}
+
+	public function test_concurrent_pathless_child_recovery_has_one_owner(): void {
+		$parent_id = $this->db_jobs->create_job( array( 'label' => 'Recovery parent' ) );
+		$child_id  = $this->db_jobs->create_job( array( 'label' => 'Recovery child', 'parent_job_id' => $parent_id ) );
+		$this->assertIsInt( $parent_id );
+		$this->assertIsInt( $child_id );
+		$this->assertTrue( $this->db_jobs->start_job( $child_id ) );
+
+		$ability = new RecoverStuckJobsAbility();
+		$method  = new \ReflectionMethod( $ability, 'claimPathlessChildRecovery' );
+		$first   = $method->invoke( $ability, $child_id, 'test' );
+		$second  = $method->invoke( $ability, $child_id, 'test' );
+
+		$this->assertTrue( $first['owned'] );
+		$this->assertFalse( $second['owned'] );
+		$this->assertNotSame( $first['token'], $second['token'] );
 	}
 
 	public function test_terminal_transition_hook_only_fires_when_status_changes(): void {

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -60,6 +60,103 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 		$this->assertNotSame( $first['token'], $second['token'] );
 	}
 
+	public function test_stale_recovery_owner_cannot_finish_or_terminalize_after_reclaim(): void {
+		$parent_id = $this->db_jobs->create_job( array( 'label' => 'Stale recovery parent' ) );
+		$child_id  = $this->db_jobs->create_job( array( 'label' => 'Stale recovery child', 'parent_job_id' => $parent_id ) );
+		$this->assertTrue( $this->db_jobs->start_job( $child_id ) );
+
+		$ability = new RecoverStuckJobsAbility();
+		$claim   = new \ReflectionMethod( $ability, 'claimPathlessChildRecovery' );
+		$finish  = new \ReflectionMethod( $ability, 'finishPathlessChildRecovery' );
+		$first   = $claim->invoke( $ability, $child_id, 'test' );
+		$engine  = datamachine_get_engine_data( $child_id );
+		$engine['scheduler_recovery']['expires_at'] = gmdate( 'c', time() - 1 );
+		$this->assertTrue( datamachine_set_engine_data( $child_id, $engine ) );
+
+		$second = $claim->invoke( $ability, $child_id, 'test' );
+		$this->assertTrue( $second['owned'] );
+		$this->assertGreaterThan( $first['generation'], $second['generation'] );
+		$this->assertFalse( $finish->invoke( $ability, $child_id, $first['token'], $first['generation'], 'stale_finish', array() ) );
+
+		$stale_terminal = $this->db_jobs->transition_recovery_owned_child( $child_id, 'failed - stale_owner', $first['token'], $first['generation'] );
+		$this->assertFalse( $stale_terminal['success'] );
+		$this->assertSame( JobStatus::PROCESSING, $this->db_jobs->get_job( $child_id )['status'] );
+
+		$winner = $this->db_jobs->transition_recovery_owned_child( $child_id, 'failed - scheduler_path_lost', $second['token'], $second['generation'] );
+		$this->assertTrue( $winner['success'] );
+	}
+
+	public function test_recovery_requeue_rolls_back_scheduler_exception_and_can_retry(): void {
+		$parent_id = $this->db_jobs->create_job( array( 'label' => 'Receipt parent' ) );
+		$child_id  = $this->db_jobs->create_job( array( 'label' => 'Receipt child', 'parent_job_id' => $parent_id ) );
+		$this->assertTrue( $this->db_jobs->start_job( $child_id ) );
+
+		$ability = new RecoverStuckJobsAbility();
+		$claim   = ( new \ReflectionMethod( $ability, 'claimPathlessChildRecovery' ) )->invoke( $ability, $child_id, 'test' );
+		$crashed = $this->db_jobs->commit_recovery_owned_requeue(
+			$child_id,
+			$claim['token'],
+			$claim['generation'],
+			static function () use ( $child_id ): int {
+				as_schedule_single_action( time(), 'datamachine_execute_step', array( 'job_id' => $child_id, 'flow_step_id' => 'crashed' ), 'data-machine' );
+				throw new \RuntimeException( 'simulated crash' );
+			}
+		);
+		$this->assertFalse( $crashed['success'] );
+		$this->assertSame( JobStatus::PROCESSING, $this->db_jobs->get_job( $child_id )['status'] );
+		$this->assertArrayNotHasKey( 'receipt', datamachine_get_engine_data( $child_id )['scheduler_recovery'] );
+		$this->assertFalse( as_has_scheduled_action( 'datamachine_execute_step', array( 'job_id' => $child_id, 'flow_step_id' => 'crashed' ), 'data-machine' ) );
+
+		$retried = $this->db_jobs->commit_recovery_owned_requeue(
+			$child_id,
+			$claim['token'],
+			$claim['generation'],
+			static fn(): int => (int) as_schedule_single_action( time(), 'datamachine_execute_step', array( 'job_id' => $child_id, 'flow_step_id' => 'retried' ), 'data-machine', true )
+		);
+		$this->assertTrue( $retried['success'] );
+		$this->assertGreaterThan( 0, $retried['action_id'] );
+		$this->assertSame( JobStatus::PENDING, $this->db_jobs->get_job( $child_id )['status'] );
+		$this->assertSame( $retried['action_id'], datamachine_get_engine_data( $child_id )['scheduler_recovery']['receipt']['action_id'] );
+		$this->assertSame( JobStatus::PENDING, datamachine_get_engine_data( $child_id )['run_lifecycle']['status'] );
+	}
+
+	public function test_recovery_apply_limit_bounds_multiple_candidate_batches(): void {
+		$job_ids = array();
+		for ( $index = 0; $index < 55; ++$index ) {
+			$job_id = $this->db_jobs->create_job( array( 'label' => 'Bounded recovery ' . $index ) );
+			$this->assertTrue( $this->db_jobs->start_job( $job_id ) );
+			datamachine_merge_engine_data( $job_id, array( 'job_status' => 'failed - bounded_recovery' ) );
+			$job_ids[] = $job_id;
+		}
+
+		$result = ( new RecoverStuckJobsAbility() )->execute( array( 'dry_run' => false, 'limit' => 52 ) );
+		$this->assertSame( 52, $result['mutations'] );
+		$this->assertSame( 52, $result['recovered'] );
+		$this->assertTrue( $result['limit_reached'] );
+
+		$processing = array_filter( $job_ids, fn( int $job_id ): bool => JobStatus::PROCESSING === $this->db_jobs->get_job( $job_id )['status'] );
+		$this->assertCount( 3, $processing );
+	}
+
+	public function test_action_history_overfetches_past_numeric_prefix_collisions(): void {
+		$exact_id = as_schedule_single_action( time(), 'datamachine_execute_step', array( 'job_id' => 42, 'flow_step_id' => 'exact' ), 'data-machine' );
+		for ( $index = 0; $index < 75; ++$index ) {
+			as_schedule_single_action( time(), 'datamachine_execute_step', array( 'job_id' => 420, 'flow_step_id' => 'collision-' . $index ), 'data-machine' );
+		}
+
+		$ability = new RecoverStuckJobsAbility();
+		$history = ( new \ReflectionMethod( $ability, 'getStepActionHistory' ) )->invoke( $ability, 42 );
+		$this->assertCount( 1, $history );
+		$this->assertSame( $exact_id, (int) $history[0]['action_id'] );
+		$this->assertSame( 42, (int) $history[0]['decoded_args']['job_id'] );
+	}
+
+	public function test_recovery_rejects_invalid_exact_job_scope(): void {
+		$result = ( new RecoverStuckJobsAbility() )->execute( array( 'job_id' => '1.5' ) );
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'job_id must be a positive integer.', $result['error'] );
+	}
+
 	public function test_terminal_transition_hook_only_fires_when_status_changes(): void {
 		$job_id = $this->db_jobs->create_job( array( 'label' => 'Terminal hook idempotency' ) );
 		$this->assertIsInt( $job_id );

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -206,7 +206,7 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 		$this->assertSame( 2, $result['touched'] );
 		$this->assertSame( 2, $result['mutated'] );
 		$this->assertSame( 1, $result['pathless_terminal'] );
-		$this->assertSame( JobStatus::FAILED, $this->db_jobs->get_job( $child_id )['status'] );
+		$this->assertSame( JobStatus::failed( 'scheduler_path_lost' )->toString(), $this->db_jobs->get_job( $child_id )['status'] );
 	}
 
 	public function test_long_running_recovery_takeover_blocks_terminal_callbacks(): void {

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -191,6 +191,22 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 		$this->assertSame( 0, $result['mutated'] );
 		$this->assertArrayNotHasKey( 'scheduler_recovery', datamachine_get_engine_data( $child_id ) );
 		$this->assertSame( JobStatus::PROCESSING, $this->db_jobs->get_job( $child_id )['status'] );
+
+		$result = ( new RecoverStuckJobsAbility() )->execute(
+			array(
+				'job_id'                    => $child_id,
+				'limit'                     => 3,
+				'timeout_hours'             => 1,
+				'recover_pathless_children' => true,
+			)
+		);
+		$this->assertFalse( $result['limit_reached'] );
+		$this->assertSame( 1, $result['mutations'] );
+		$this->assertSame( 2, $result['attempted'] );
+		$this->assertSame( 2, $result['touched'] );
+		$this->assertSame( 2, $result['mutated'] );
+		$this->assertSame( 1, $result['pathless_terminal'] );
+		$this->assertSame( JobStatus::FAILED, $this->db_jobs->get_job( $child_id )['status'] );
 	}
 
 	public function test_long_running_recovery_takeover_blocks_terminal_callbacks(): void {

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -10,9 +10,13 @@ namespace DataMachine\Tests\Unit\Core\Database;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\Jobs\LegacyAIConcurrencyReconciler;
 use DataMachine\Core\JobStatus;
+use DataMachine\Core\RecoveryExecutionFence;
+use DataMachine\Core\ChildJobRecoveryPolicy;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Engine\AI\AIConcurrencyBackpressure;
 use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
 use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
+use DataMachine\Abilities\Engine\ExecuteStepAbility;
 use WP_UnitTestCase;
 
 class JobLifecycleTransitionTest extends WP_UnitTestCase {
@@ -131,6 +135,9 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 
 		$result = ( new RecoverStuckJobsAbility() )->execute( array( 'dry_run' => false, 'limit' => 52 ) );
 		$this->assertSame( 52, $result['mutations'] );
+		$this->assertSame( 52, $result['attempted'] );
+		$this->assertSame( 52, $result['touched'] );
+		$this->assertSame( 52, $result['mutated'] );
 		$this->assertSame( 52, $result['recovered'] );
 		$this->assertTrue( $result['limit_reached'] );
 
@@ -155,6 +162,138 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 		$result = ( new RecoverStuckJobsAbility() )->execute( array( 'job_id' => '1.5' ) );
 		$this->assertFalse( $result['success'] );
 		$this->assertSame( 'job_id must be a positive integer.', $result['error'] );
+	}
+
+	public function test_touch_limit_stops_before_partial_pathless_claim(): void {
+		global $wpdb;
+		$parent_id = $this->db_jobs->create_job( array( 'label' => 'Touch-bound parent' ) );
+		$child_id  = $this->db_jobs->create_job( array( 'label' => 'Touch-bound child', 'parent_job_id' => $parent_id ) );
+		$this->assertTrue( $this->db_jobs->start_job( $child_id ) );
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_jobs',
+			array( 'created_at' => gmdate( 'Y-m-d H:i:s', time() - 3 * HOUR_IN_SECONDS ) ),
+			array( 'job_id' => $child_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		$result = ( new RecoverStuckJobsAbility() )->execute(
+			array(
+				'job_id'                    => $child_id,
+				'limit'                     => 2,
+				'timeout_hours'             => 1,
+				'recover_pathless_children' => true,
+			)
+		);
+		$this->assertTrue( $result['limit_reached'] );
+		$this->assertSame( 0, $result['attempted'] );
+		$this->assertSame( 0, $result['touched'] );
+		$this->assertSame( 0, $result['mutated'] );
+		$this->assertArrayNotHasKey( 'scheduler_recovery', datamachine_get_engine_data( $child_id ) );
+		$this->assertSame( JobStatus::PROCESSING, $this->db_jobs->get_job( $child_id )['status'] );
+	}
+
+	public function test_long_running_recovery_takeover_blocks_terminal_callbacks(): void {
+		$parent_id = $this->db_jobs->create_job( array( 'label' => 'Generation parent' ) );
+		$child_id  = $this->db_jobs->create_job( array( 'label' => 'Generation child', 'parent_job_id' => $parent_id ) );
+		$this->assertTrue( $this->db_jobs->start_job( $child_id ) );
+		$engine = datamachine_get_engine_data( $child_id );
+		$engine['scheduler_recovery'] = array(
+			'schema'     => 'datamachine.scheduler-recovery.v1',
+			'state'      => 'requeued',
+			'token'      => 'generation-one',
+			'generation' => 1,
+			'receipt'    => array( 'generation' => 1, 'action_id' => 101 ),
+		);
+		$this->assertTrue( datamachine_set_engine_data( $child_id, $engine ) );
+
+		$terminal_callbacks = 0;
+		$callback = static function ( string $status ) use ( &$terminal_callbacks ): string {
+			++$terminal_callbacks;
+			return $status;
+		};
+		add_filter( 'datamachine_job_terminal_status', $callback, 1, 1 );
+		$fence = new RecoveryExecutionFence( $child_id, 'generation-one', 1 );
+		$nested_fence = new RecoveryExecutionFence( $child_id, 'generation-one', 1 );
+		unset( $nested_fence );
+
+		$takeover = datamachine_get_engine_data( $child_id );
+		$takeover['scheduler_recovery'] = array(
+			'schema'     => 'datamachine.scheduler-recovery.v1',
+			'state'      => 'claimed',
+			'token'      => 'generation-two',
+			'generation' => 2,
+			'claimed_at' => gmdate( 'c' ),
+			'expires_at' => gmdate( 'c', time() + 300 ),
+		);
+		$this->assertTrue( datamachine_set_engine_data( $child_id, $takeover ) );
+
+		$this->assertFalse( $this->db_jobs->transition_job_status( $child_id, JobStatus::COMPLETED, true ) );
+		$this->assertSame( 0, $terminal_callbacks );
+		$this->assertSame( JobStatus::PROCESSING, $this->db_jobs->get_job( $child_id )['status'] );
+		$executor = new ExecuteStepAbility();
+		$still_owned = ( new \ReflectionMethod( $executor, 'recoveryGenerationStillOwned' ) )->invoke( $executor, $child_id, 1, 'generation-one' );
+		$noop = ( new \ReflectionMethod( $executor, 'staleRejectedTerminalTransition' ) )->invoke(
+			$executor,
+			$child_id,
+			1,
+			'generation-one',
+			array( 'success' => false )
+		);
+		$this->assertFalse( $still_owned );
+		$this->assertTrue( $noop['success'] );
+		$this->assertSame( 'stale_recovery_noop', $noop['outcome'] );
+		unset( $fence );
+		remove_filter( 'datamachine_job_terminal_status', $callback, 1 );
+	}
+
+	public function test_recovery_evidence_validates_active_claim_ownership(): void {
+		$job_id    = $this->db_jobs->create_job( array( 'label' => 'Claim evidence' ) );
+		$processed = new ProcessedItems();
+		$token     = $processed->claim_item_owned( 'scope', 'source', 'item', $job_id, 600 );
+		$this->assertIsString( $token );
+		$claim = array(
+			'identity_scope'  => 'scope',
+			'source_type'     => 'source',
+			'item_identifier' => 'item',
+			'ownership_token' => $token,
+		);
+		$ability  = new RecoverStuckJobsAbility();
+		$evidence = ( new \ReflectionMethod( $ability, 'activeClaimEvidence' ) )->invoke( $ability, array( '_datamachine_item_claim' => $claim ), $job_id );
+		$this->assertSame( 'active_owned', $evidence['state'] );
+		$this->assertSame( 1, $evidence['active'] );
+
+		$this->assertSame( 1, $processed->release_owned_claim( 'scope', 'source', 'item', $token ) );
+		$stale = ( new \ReflectionMethod( $ability, 'activeClaimEvidence' ) )->invoke( $ability, array( '_datamachine_item_claim' => $claim ), $job_id );
+		$this->assertSame( 'stale_or_unowned', $stale['state'] );
+		$this->assertSame( 0, $stale['active'] );
+	}
+
+	public function test_recovery_evidence_does_not_label_absent_generation_valid(): void {
+		$parent_id = $this->db_jobs->create_job( array( 'label' => 'Evidence parent' ) );
+		$child_id  = $this->db_jobs->create_job( array( 'label' => 'Evidence child', 'parent_job_id' => $parent_id ) );
+		$engine    = datamachine_get_engine_data( $child_id );
+		$engine['flow_config'] = array( 'step' => array( 'step_type' => 'fetch' ) );
+		$this->assertTrue( datamachine_set_engine_data( $child_id, $engine ) );
+		$job = $this->db_jobs->get_job( $child_id );
+		$diagnosis = ChildJobRecoveryPolicy::diagnose(
+			$job,
+			$engine,
+			array(
+				array(
+					'action_id'   => 77,
+					'hook'        => 'datamachine_execute_step',
+					'status'      => 'failed',
+					'decoded_args' => array( 'job_id' => $child_id, 'flow_step_id' => 'step' ),
+				),
+			),
+			HOUR_IN_SECONDS,
+			time()
+		);
+		$ability  = new RecoverStuckJobsAbility();
+		$evidence = ( new \ReflectionMethod( $ability, 'childRecoveryEvidence' ) )->invoke( $ability, $job, $diagnosis, 'would_requeue_pathless_child', 'test' );
+		$this->assertSame( 0, $evidence['action_generation'] );
+		$this->assertSame( 'legacy_unfenced', $evidence['action_generation_state'] );
 	}
 
 	public function test_terminal_transition_hook_only_fires_when_status_changes(): void {

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -480,7 +480,12 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$job_id = $this->createJobWithClaim( $claim, true );
 		datamachine_merge_engine_data( $job_id, array( 'job_status' => JobStatus::failed( 'stale' )->toString() ) );
 
-		$result = ( new RecoverStuckJobsAbility() )->execute( array( 'dry_run' => false ) );
+		$result = ( new RecoverStuckJobsAbility() )->execute(
+			array(
+				'dry_run' => false,
+				'job_id'  => $job_id,
+			)
+		);
 
 		$this->assertGreaterThanOrEqual( 1, $result['recovered'] );
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'stale-id' ) );
@@ -647,7 +652,12 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertTrue( $this->processed->claim_item( self::SCOPE, self::SOURCE, 'legacy-recovery', $job_id ) );
 		datamachine_merge_engine_data( $job_id, array( 'job_status' => JobStatus::failed( 'stale' )->toString() ) );
 
-		( new RecoverStuckJobsAbility() )->execute( array( 'dry_run' => false ) );
+		( new RecoverStuckJobsAbility() )->execute(
+			array(
+				'dry_run' => false,
+				'job_id'  => $job_id,
+			)
+		);
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'legacy-recovery' ) );
 	}
 

--- a/tests/child-job-recovery-policy-smoke.php
+++ b/tests/child-job-recovery-policy-smoke.php
@@ -72,5 +72,23 @@ $assert( 'batch child with pending canonical action remains guarded', $batch_chi
 $assert( 'job 42 does not own job 420 action args', ! ChildJobRecoveryPolicy::actionBelongsToJob( array( 'job_id' => 420 ), 42 ) );
 $assert( 'job 42 owns only exact decoded args', ChildJobRecoveryPolicy::actionBelongsToJob( array( 'job_id' => 42 ), 42 ) );
 
+$active_lease = ChildJobRecoveryPolicy::recoveryOwnershipEvidence(
+	array( 'scheduler_recovery' => array( 'state' => 'claimed', 'token' => 'lease', 'generation' => 2, 'claimed_at' => '2026-07-22T11:59:00Z', 'expires_at' => '2026-07-22T12:05:00Z' ) ),
+	strtotime( '2026-07-22T12:00:00Z' )
+);
+$assert( 'only unexpired exact lease is reported active', 'active' === $active_lease['state'] && 2 === $active_lease['generation'] );
+
+$expired_lease = ChildJobRecoveryPolicy::recoveryOwnershipEvidence(
+	array( 'scheduler_recovery' => array( 'state' => 'claimed', 'token' => 'lease', 'generation' => 2, 'expires_at' => '2026-07-22T11:55:00Z' ) ),
+	strtotime( '2026-07-22T12:00:00Z' )
+);
+$assert( 'expired lease does not expose token or generation as valid', 'expired' === $expired_lease['state'] && '' === $expired_lease['token'] && 0 === $expired_lease['generation'] );
+
+$invalid_receipt = ChildJobRecoveryPolicy::recoveryOwnershipEvidence(
+	array( 'scheduler_recovery' => array( 'state' => 'requeued', 'token' => 'owner', 'generation' => 3, 'receipt' => array( 'generation' => 2, 'action_id' => 99 ) ) ),
+	time()
+);
+$assert( 'mismatched receipt is reported invalid', 'invalid' === $invalid_receipt['state'] && 'invalid' === $invalid_receipt['receipt_state'] );
+
 echo "\nChild job recovery policy smoke complete: {$total} assertions, {$failed} failures.\n";
 exit( $failed > 0 ? 1 : 0 );

--- a/tests/child-job-recovery-policy-smoke.php
+++ b/tests/child-job-recovery-policy-smoke.php
@@ -1,0 +1,73 @@
+<?php
+/** Behavioral tests for pathless child recovery policy. */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+require_once __DIR__ . '/../inc/Core/ChildJobRecoveryPolicy.php';
+
+use DataMachine\Core\ChildJobRecoveryPolicy;
+
+$failed = 0;
+$total  = 0;
+$assert = static function ( string $label, bool $condition ) use ( &$failed, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$label}\n";
+		return;
+	}
+	++$failed;
+	echo "  [FAIL] {$label}\n";
+};
+
+$now = strtotime( '2026-07-22 20:00:00 UTC' );
+$job = array(
+	'job_id'              => 42,
+	'parent_job_id'       => 7,
+	'operation_state'     => '',
+	'operation_generation' => 0,
+	'operation_claim_token' => '',
+);
+$step = 'pipeline-step-2';
+$engine = array( 'flow_config' => array( $step => array( 'step_type' => 'upsert' ) ) );
+$action = static fn( int $id, string $hook, string $status, array $args ): array => array(
+	'action_id'         => $id,
+	'hook'              => $hook,
+	'status'            => $status,
+	'scheduled_date_gmt' => '2026-07-22 19:55:00',
+	'last_attempt_gmt'  => '2026-07-22 19:56:00',
+	'decoded_args'      => $args,
+);
+$diagnose = static fn( array $job_row, array $engine_data, array $actions ): array => ChildJobRecoveryPolicy::diagnose( $job_row, $engine_data, $actions, 7200, $now );
+
+echo "=== child-job-recovery-policy-smoke ===\n";
+
+$failed_action = $diagnose( $job, $engine, array( $action( 10, 'datamachine_execute_step', 'failed', array( 'job_id' => 42, 'flow_step_id' => $step ) ) ) );
+$assert( 'failed canonical action is replayable', $failed_action['retry_eligible'] && ! $failed_action['has_active_path'] );
+
+$missing = $diagnose( $job, $engine, array() );
+$assert( 'missing action requires terminal transition', 'missing_action' === $missing['reason'] && ! $missing['retry_eligible'] );
+
+$stale_generation_job = array_merge( $job, array( 'operation_state' => 'enqueued', 'operation_generation' => 2, 'operation_claim_token' => 'current' ) );
+$stale_action = $action( 11, 'datamachine_execute_step', 'pending', array( 'job_id' => 42, 'flow_step_id' => $step, 'operation_generation' => 1, 'operation_claim_token' => 'old' ) );
+$stale = $diagnose( $stale_generation_job, $engine, array( $stale_action ) );
+$assert( 'stale operation action is not a valid path', ! $stale['has_active_path'] && ! $stale['retry_eligible'] );
+
+$ai_engine = $engine + array(
+	'ai_concurrency_resume_ownership' => array(
+		'flow_step_id' => $step,
+		'generation'   => 3,
+		'status'       => 'scheduled',
+		'action_id'    => 12,
+	),
+);
+$ai = $diagnose( $job, $ai_engine, array( $action( 12, 'datamachine_resume_ai_step', 'pending', array( 'job_id' => 42, 'flow_step_id' => $step, 'ai_resume_generation' => 3 ) ) ) );
+$assert( 'active AI resume generation remains owned', $ai['has_active_path'] && ! $ai['retry_eligible'] );
+
+$wrong_ai = $diagnose( $job, $ai_engine, array( $action( 13, 'datamachine_resume_ai_step', 'pending', array( 'job_id' => 42, 'flow_step_id' => $step, 'ai_resume_generation' => 2 ) ) ) );
+$assert( 'historical AI generation is irrelevant', ! $wrong_ai['has_active_path'] );
+
+$batch_child = $diagnose( $job, $engine, array( $action( 14, 'datamachine_execute_step', 'pending', array( 'job_id' => 42, 'flow_step_id' => $step ) ) ) );
+$assert( 'batch child with pending canonical action remains guarded', $batch_child['has_active_path'] );
+
+echo "\nChild job recovery policy smoke complete: {$total} assertions, {$failed} failures.\n";
+exit( $failed > 0 ? 1 : 0 );

--- a/tests/child-job-recovery-policy-smoke.php
+++ b/tests/child-job-recovery-policy-smoke.php
@@ -90,5 +90,44 @@ $invalid_receipt = ChildJobRecoveryPolicy::recoveryOwnershipEvidence(
 );
 $assert( 'mismatched receipt is reported invalid', 'invalid' === $invalid_receipt['state'] && 'invalid' === $invalid_receipt['receipt_state'] );
 
+$generation_job = array( 'job_id' => 42, 'operation_state' => '' );
+$running_engine = array(
+	'scheduler_recovery' => array(
+		'state'      => 'running',
+		'token'      => 'generation-n',
+		'generation' => 4,
+		'expires_at' => '2026-07-22T11:55:00Z',
+		'receipt'    => array( 'generation' => 4, 'action_id' => 55 ),
+	),
+);
+$running_action = array(
+	'action_id'    => 55,
+	'hook'         => 'datamachine_execute_step',
+	'status'       => 'in-progress',
+	'decoded_args' => array( 'job_id' => 42, 'flow_step_id' => 'step', 'recovery_generation' => 4, 'recovery_claim_token' => 'generation-n' ),
+);
+$assert(
+	'N+1 claim is denied while exact N action is in progress despite expired lease',
+	! ChildJobRecoveryPolicy::canClaimNextGeneration( $generation_job, $running_engine, array( $running_action ), strtotime( '2026-07-22T12:00:00Z' ) )
+);
+
+$failed_action           = $running_action;
+$failed_action['status'] = 'failed';
+$assert(
+	'N+1 claim is allowed after exact N action fails',
+	ChildJobRecoveryPolicy::canClaimNextGeneration( $generation_job, $running_engine, array( $failed_action ), strtotime( '2026-07-22T12:00:00Z' ) )
+);
+$assert(
+	'N+1 claim is allowed after exact N action disappears and lease is stale',
+	ChildJobRecoveryPolicy::canClaimNextGeneration( $generation_job, $running_engine, array(), strtotime( '2026-07-22T12:00:00Z' ) )
+);
+
+$fresh_running_engine = $running_engine;
+$fresh_running_engine['scheduler_recovery']['expires_at'] = '2026-07-22T12:05:00Z';
+$assert(
+	'N+1 claim remains denied without action while execution heartbeat is fresh',
+	! ChildJobRecoveryPolicy::canClaimNextGeneration( $generation_job, $fresh_running_engine, array(), strtotime( '2026-07-22T12:00:00Z' ) )
+);
+
 echo "\nChild job recovery policy smoke complete: {$total} assertions, {$failed} failures.\n";
 exit( $failed > 0 ? 1 : 0 );

--- a/tests/child-job-recovery-policy-smoke.php
+++ b/tests/child-job-recovery-policy-smoke.php
@@ -69,5 +69,8 @@ $assert( 'historical AI generation is irrelevant', ! $wrong_ai['has_active_path'
 $batch_child = $diagnose( $job, $engine, array( $action( 14, 'datamachine_execute_step', 'pending', array( 'job_id' => 42, 'flow_step_id' => $step ) ) ) );
 $assert( 'batch child with pending canonical action remains guarded', $batch_child['has_active_path'] );
 
+$assert( 'job 42 does not own job 420 action args', ! ChildJobRecoveryPolicy::actionBelongsToJob( array( 'job_id' => 420 ), 42 ) );
+$assert( 'job 42 owns only exact decoded args', ChildJobRecoveryPolicy::actionBelongsToJob( array( 'job_id' => 42 ), 42 ) );
+
 echo "\nChild job recovery policy smoke complete: {$total} assertions, {$failed} failures.\n";
 exit( $failed > 0 ? 1 : 0 );

--- a/tests/job-liveness-cli-smoke.php
+++ b/tests/job-liveness-cli-smoke.php
@@ -4,6 +4,7 @@
 define( 'ABSPATH', __DIR__ . '/' );
 define( 'MINUTE_IN_SECONDS', 60 );
 
+require_once __DIR__ . '/../inc/Core/ChildJobRecoveryPolicy.php';
 require_once __DIR__ . '/../inc/Cli/JobLivenessClassifier.php';
 
 use DataMachine\Cli\JobLivenessClassifier;
@@ -28,11 +29,13 @@ $job = static fn( array $engine = array() ): array => array(
 	'created_at' => '2026-07-22 08:00:00',
 	'engine_data' => $engine,
 );
-$action = static fn( string $status, string $scheduled ): array => array(
-	'hook'               => 'datamachine_resume_ai_step',
+$action = static fn( string $status, string $scheduled, array $args = array(), string $hook = 'datamachine_execute_step', int $action_id = 0 ): array => array(
+	'action_id'          => $action_id,
+	'hook'               => $hook,
 	'status'             => $status,
 	'scheduled_date_gmt' => $scheduled,
 	'last_attempt_gmt'   => '0000-00-00 00:00:00',
+	'decoded_args'       => array_merge( array( 'job_id' => 42, 'flow_step_id' => 'step' ), $args ),
 );
 $classify = static function ( array $job_row, array $actions = array(), array $children = array() ) use ( $now ): array {
 	return JobLivenessClassifier::diagnose( $job_row, $actions, $children, 120, $now );
@@ -56,9 +59,15 @@ $deferred_job = $job(
 			'provider'          => 'openai',
 			'first_deferred_at' => '2026-07-22T11:00:00Z',
 		),
+		'ai_concurrency_resume_ownership' => array(
+			'generation'   => 3,
+			'status'       => 'scheduled',
+			'flow_step_id' => 'step',
+			'action_id'    => 99,
+		),
 	)
 );
-$deferred = $classify( $deferred_job, array( $action( 'pending', '2026-07-22 11:50:00' ) ) );
+$deferred = $classify( $deferred_job, array( $action( 'pending', '2026-07-22 11:50:00', array( 'ai_resume_generation' => 3 ), 'datamachine_resume_ai_step', 99 ) ) );
 $assert( 'fresh resume action with throttle is concurrency deferred', 'ai_concurrency_deferred' === $deferred['classification'] );
 $assert( 'deferred metrics expose count and age', 8 === $deferred['defer_count'] && 3600 === $deferred['defer_age_seconds'] );
 $assert( 'deferred contention is active', true === $deferred['contention_active'] );
@@ -72,6 +81,30 @@ $assert( 'active batch children classify as waiting', 'waiting_children' === $wa
 $resolved = $classify( $job( array( 'ai_concurrency_history' => array( array( 'state' => 'resolved' ) ) ) ) );
 $assert( 'resolved history does not report active contention', false === $resolved['contention_active'] );
 $assert( 'job without active scheduler path is classified directly', 'no_scheduler_path' === $resolved['classification'] );
+
+$stale_generation = $classify(
+	array_merge( $job(), array( 'operation_state' => 'enqueued', 'operation_generation' => 4, 'operation_claim_token' => 'current' ) ),
+	array( $action( 'pending', '2026-07-22 11:50:00', array( 'operation_generation' => 3, 'operation_claim_token' => 'stale' ) ) )
+);
+$assert( 'stale operation generation is not a liveness path', 'no_scheduler_path' === $stale_generation['classification'] );
+
+$recovery_engine = array(
+	'scheduler_recovery' => array(
+		'state'      => 'requeued',
+		'token'      => 'current-recovery',
+		'generation' => 8,
+		'receipt'    => array( 'generation' => 8, 'action_id' => 108 ),
+	),
+);
+$valid_recovery = $classify( $job( $recovery_engine ), array( $action( 'pending', '2026-07-22 11:50:00', array( 'recovery_generation' => 8, 'recovery_claim_token' => 'current-recovery' ), 'datamachine_execute_step', 108 ) ) );
+$stale_recovery = $classify( $job( $recovery_engine ), array( $action( 'pending', '2026-07-22 11:50:00', array( 'recovery_generation' => 7, 'recovery_claim_token' => 'stale-recovery' ), 'datamachine_execute_step', 107 ) ) );
+$assert( 'current recovery generation is a liveness path', 'queued_next_step' === $valid_recovery['classification'] );
+$assert( 'stale recovery generation is not a liveness path', 'no_scheduler_path' === $stale_recovery['classification'] );
+
+$invalid_receipt_engine = $recovery_engine;
+$invalid_receipt_engine['scheduler_recovery']['receipt']['action_id'] = 0;
+$invalid_receipt = $classify( $job( $invalid_receipt_engine ), array( $action( 'pending', '2026-07-22 11:50:00', array( 'recovery_generation' => 8, 'recovery_claim_token' => 'current-recovery' ), 'datamachine_execute_step', 108 ) ) );
+$assert( 'zero action receipt is not a liveness path', 'no_scheduler_path' === $invalid_receipt['classification'] );
 
 echo "\nJob liveness CLI smoke complete: {$total} assertions, {$failed} failures.\n";
 exit( $failed > 0 ? 1 : 0 );

--- a/tests/recover-stuck-active-action-guard-smoke.php
+++ b/tests/recover-stuck-active-action-guard-smoke.php
@@ -29,7 +29,7 @@ $timeout_loop = strstr( $source, 'foreach ( $timed_out_jobs as $job )' ) ?: '';
 echo "Case 1: timed-out recovery skips jobs with active scheduler work\n";
 assert_recover_stuck_guard_smoke( 'active scheduler work method exists', str_contains( $source, 'private function hasActiveSchedulerWork' ) );
 assert_recover_stuck_guard_smoke( 'active step guard method exists', str_contains( $source, 'private function hasActiveStepAction' ) );
-assert_recover_stuck_guard_smoke( 'timeout loop invokes scheduler guard before dry-run timeout', strpos( $timeout_loop, '$this->hasActiveSchedulerWork( $job_id, $engine_data, $timeout_hours )' ) < strpos( $timeout_loop, 'if ( $dry_run )' ) );
+assert_recover_stuck_guard_smoke( 'timeout loop diagnoses child ownership before dry-run recovery', strpos( $timeout_loop, 'ChildJobRecoveryPolicy::diagnose' ) < strpos( $timeout_loop, 'if ( $dry_run )' ) );
 assert_recover_stuck_guard_smoke( 'guard records skipped status', str_contains( $source, "'status'  => 'skipped'") && str_contains( $source, 'Pending or in-progress scheduler work exists' ) );
 
 echo "Case 2: guard is limited to executable Data Machine step actions\n";

--- a/tests/recover-stuck-bounded-apply-smoke.php
+++ b/tests/recover-stuck-bounded-apply-smoke.php
@@ -17,10 +17,12 @@ $ability = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RecoverStuckJobsA
 $worker  = file_get_contents( __DIR__ . '/../inc/Cli/Commands/WorkerCommand.php' ) ?: '';
 $jobs    = file_get_contents( __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php' ) ?: '';
 $cli     = file_get_contents( __DIR__ . '/../inc/Cli/Commands/JobsCommand.php' ) ?: '';
+$execute = file_get_contents( __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php' ) ?: '';
 
 echo "=== recover-stuck-bounded-apply-smoke ===\n";
 $assert( 'ability exposes exact job scope and hard touch limit', str_contains( $ability, "'job_id'" ) && str_contains( $ability, 'MAX_APPLY_LIMIT' ) && str_contains( $ability, '$touched >= $apply_limit' ) && str_contains( $ability, 'consumeTouchBudget' ) );
 $assert( 'pathless apply requires explicit policy', str_contains( $ability, 'recover_pathless_children' ) && str_contains( $ability, 'pathless_child_apply_policy_required' ) );
+$assert( 'one compound job defaults and documents three touches', str_contains( $ability, 'DEFAULT_APPLY_LIMIT   = 3' ) && str_contains( $cli, '--recover-pathless-children --limit=3' ) );
 $assert( 'compound touches reserve capacity before claim or queue restoration', str_contains( $ability, 'hasTouchCapacity' ) && str_contains( $ability, 'queued_prompt_backup' ) && str_contains( $ability, '$required_touches' ) );
 $assert( 'worker runs recovery once with bounded mutations', str_contains( $worker, '! $recovery_ran' ) && str_contains( $worker, "'limit'         => 5") );
 $assert( 'worker does not auto-apply historical children', str_contains( $worker, "'recover_pathless_children' => false") );
@@ -28,8 +30,11 @@ $assert( 'worker reports every recovery disposition', str_contains( $worker, 'pa
 $assert( 'requeue schedule and receipt share locked transaction', str_contains( $jobs, 'commit_recovery_owned_requeue' ) && str_contains( $jobs, 'get_job_for_update' ) && str_contains( $jobs, "'receipt_commit_failed'") );
 $assert( 'terminal recovery validates locked owner', str_contains( $jobs, 'transition_recovery_owned_child' ) && str_contains( $jobs, 'recovery_owner_matches' ) );
 $assert( 'locked owner is renewed before side effects', str_contains( $jobs, 'renew_recovery_owner_on_locked_job' ) && str_contains( $jobs, 'RECOVERY_LEASE_TTL' ) );
+$assert( 'execution generation renews immediately before Step execute', str_contains( $execute, 'renew_recovery_execution_owner' ) && strpos( $execute, 'renew_recovery_execution_owner' ) < strpos( $execute, '$flow_step->execute' ) );
+$assert( 'post-execution and route fences remain active', str_contains( $execute, 'was superseded during execution' ) && str_contains( $execute, 'was superseded before next-step scheduling' ) && str_contains( $execute, 'transitionTerminalWithRecoveryFence' ) );
 $assert( 'atomic requeue mirrors run lifecycle', str_contains( $jobs, '$engine[\'run_lifecycle\']' ) && str_contains( $jobs, '$run_lifecycle[\'status\']' ) );
 $assert( 'action scan keysets exact numeric boundaries before decode', str_contains( $ability, 'action_id < %d' ) && str_contains( $ability, '$like_job_comma' ) && str_contains( $ability, '$like_job_end' ) && str_contains( $ability, 'actionBelongsToJob' ) );
+$assert( 'claim policy includes exact receipt action beyond history cap', str_contains( $ability, '$required_action_id' ) && str_contains( $ability, "['receipt']" ) && str_contains( $ability, 'canClaimNextGeneration' ) );
 $assert( 'CLI prints scope and ownership evidence', str_contains( $cli, 'Recovery scope:' ) && str_contains( $cli, 'recovery_lease_age_seconds' ) && str_contains( $cli, 'receipt_state' ) );
 
 echo "\nBounded recovery apply smoke complete: {$total} assertions, {$failed} failures.\n";

--- a/tests/recover-stuck-bounded-apply-smoke.php
+++ b/tests/recover-stuck-bounded-apply-smoke.php
@@ -1,0 +1,35 @@
+<?php
+/** Static contract checks for bounded, explicitly scoped recovery apply. */
+
+$failed = 0;
+$total  = 0;
+$assert = static function ( string $label, bool $condition ) use ( &$failed, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$label}\n";
+		return;
+	}
+	++$failed;
+	echo "  [FAIL] {$label}\n";
+};
+
+$ability = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RecoverStuckJobsAbility.php' ) ?: '';
+$worker  = file_get_contents( __DIR__ . '/../inc/Cli/Commands/WorkerCommand.php' ) ?: '';
+$jobs    = file_get_contents( __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php' ) ?: '';
+$cli     = file_get_contents( __DIR__ . '/../inc/Cli/Commands/JobsCommand.php' ) ?: '';
+
+echo "=== recover-stuck-bounded-apply-smoke ===\n";
+$assert( 'ability exposes exact job scope and hard limit', str_contains( $ability, "'job_id'" ) && str_contains( $ability, 'MAX_APPLY_LIMIT' ) && str_contains( $ability, '$mutations >= $apply_limit' ) );
+$assert( 'pathless apply requires explicit policy', str_contains( $ability, 'recover_pathless_children' ) && str_contains( $ability, 'pathless_child_apply_policy_required' ) );
+$assert( 'worker runs recovery once with bounded mutations', str_contains( $worker, '! $recovery_ran' ) && str_contains( $worker, "'limit'         => 5") );
+$assert( 'worker does not auto-apply historical children', str_contains( $worker, "'recover_pathless_children' => false") );
+$assert( 'worker reports every recovery disposition', str_contains( $worker, 'pathless_children_requeued' ) && str_contains( $worker, 'pathless_children_terminal' ) && str_contains( $worker, 'recovery_claim_conflicts' ) && str_contains( $worker, 'pathless_policy_skipped' ) && str_contains( $worker, 'recovery_mutations' ) && str_contains( $worker, 'recovery_requeued' ) && str_contains( $worker, 'recovery_skipped' ) );
+$assert( 'requeue schedule and receipt share locked transaction', str_contains( $jobs, 'commit_recovery_owned_requeue' ) && str_contains( $jobs, 'get_job_for_update' ) && str_contains( $jobs, "'receipt_commit_failed'") );
+$assert( 'terminal recovery validates locked owner', str_contains( $jobs, 'transition_recovery_owned_child' ) && str_contains( $jobs, 'recovery_owner_matches' ) );
+$assert( 'locked owner is renewed before side effects', str_contains( $jobs, 'renew_recovery_owner_on_locked_job' ) && str_contains( $jobs, 'RECOVERY_LEASE_TTL' ) );
+$assert( 'atomic requeue mirrors run lifecycle', str_contains( $jobs, '$engine[\'run_lifecycle\']' ) && str_contains( $jobs, '$run_lifecycle[\'status\']' ) );
+$assert( 'action scan keysets exact numeric boundaries before decode', str_contains( $ability, 'action_id < %d' ) && str_contains( $ability, '$like_job_comma' ) && str_contains( $ability, '$like_job_end' ) && str_contains( $ability, 'actionBelongsToJob' ) );
+$assert( 'CLI prints scope and ownership evidence', str_contains( $cli, 'Recovery scope:' ) && str_contains( $cli, 'recovery_lease_age_seconds' ) && str_contains( $cli, 'receipt_state' ) );
+
+echo "\nBounded recovery apply smoke complete: {$total} assertions, {$failed} failures.\n";
+exit( $failed > 0 ? 1 : 0 );

--- a/tests/recover-stuck-bounded-apply-smoke.php
+++ b/tests/recover-stuck-bounded-apply-smoke.php
@@ -19,11 +19,12 @@ $jobs    = file_get_contents( __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php' ) 
 $cli     = file_get_contents( __DIR__ . '/../inc/Cli/Commands/JobsCommand.php' ) ?: '';
 
 echo "=== recover-stuck-bounded-apply-smoke ===\n";
-$assert( 'ability exposes exact job scope and hard limit', str_contains( $ability, "'job_id'" ) && str_contains( $ability, 'MAX_APPLY_LIMIT' ) && str_contains( $ability, '$mutations >= $apply_limit' ) );
+$assert( 'ability exposes exact job scope and hard touch limit', str_contains( $ability, "'job_id'" ) && str_contains( $ability, 'MAX_APPLY_LIMIT' ) && str_contains( $ability, '$touched >= $apply_limit' ) && str_contains( $ability, 'consumeTouchBudget' ) );
 $assert( 'pathless apply requires explicit policy', str_contains( $ability, 'recover_pathless_children' ) && str_contains( $ability, 'pathless_child_apply_policy_required' ) );
+$assert( 'compound touches reserve capacity before claim or queue restoration', str_contains( $ability, 'hasTouchCapacity' ) && str_contains( $ability, 'queued_prompt_backup' ) && str_contains( $ability, '$required_touches' ) );
 $assert( 'worker runs recovery once with bounded mutations', str_contains( $worker, '! $recovery_ran' ) && str_contains( $worker, "'limit'         => 5") );
 $assert( 'worker does not auto-apply historical children', str_contains( $worker, "'recover_pathless_children' => false") );
-$assert( 'worker reports every recovery disposition', str_contains( $worker, 'pathless_children_requeued' ) && str_contains( $worker, 'pathless_children_terminal' ) && str_contains( $worker, 'recovery_claim_conflicts' ) && str_contains( $worker, 'pathless_policy_skipped' ) && str_contains( $worker, 'recovery_mutations' ) && str_contains( $worker, 'recovery_requeued' ) && str_contains( $worker, 'recovery_skipped' ) );
+$assert( 'worker reports every recovery disposition', str_contains( $worker, 'pathless_children_requeued' ) && str_contains( $worker, 'pathless_children_terminal' ) && str_contains( $worker, 'recovery_claim_conflicts' ) && str_contains( $worker, 'pathless_policy_skipped' ) && str_contains( $worker, 'recovery_mutations' ) && str_contains( $worker, 'recovery_requeued' ) && str_contains( $worker, 'recovery_skipped' ) && str_contains( $worker, 'recovery_attempted' ) && str_contains( $worker, 'recovery_touched' ) && str_contains( $worker, 'recovery_mutated' ) );
 $assert( 'requeue schedule and receipt share locked transaction', str_contains( $jobs, 'commit_recovery_owned_requeue' ) && str_contains( $jobs, 'get_job_for_update' ) && str_contains( $jobs, "'receipt_commit_failed'") );
 $assert( 'terminal recovery validates locked owner', str_contains( $jobs, 'transition_recovery_owned_child' ) && str_contains( $jobs, 'recovery_owner_matches' ) );
 $assert( 'locked owner is renewed before side effects', str_contains( $jobs, 'renew_recovery_owner_on_locked_job' ) && str_contains( $jobs, 'RECOVERY_LEASE_TTL' ) );


### PR DESCRIPTION
## Summary
- classify exact Action Scheduler and generation ownership before recovering timed-out batch children
- serialize recovery with a bounded engine-data CAS claim, requeue replay-safe failed actions, and terminally account children with no safe continuation
- expose job age, parent, scheduler action/claim, operation generation, retry eligibility, trigger, and recovery outcome in dry-run/apply output

Closes #2930.

## Root cause
The prior #2180 fix correctly kept children `pending` until Action Scheduler began execution, but `recover-stuck` still only had a binary pending/in-progress guard. Once an executing child's action failed or its retained action history was purged, the child stayed `processing` until the generic timeout path bulk-failed it. Conversely, the guard did not validate direct-operation or AI resume generations, so stale historical actions could be mistaken for current ownership.

`jobs liveness` and `recover-stuck` also report different populations: liveness includes pending AI-deferral rows and labels active batch parents `waiting_children`, while recovery inspects timed-out `processing` rows and reports those parents as skipped due to active children. The live count mismatch was therefore partly cohort scope, while the actual unowned cohort was processing children.

## Live cohort mapping
Read-only Events inspection on 2026-07-22 found:
- 76 processing jobs: 65 batch parents and 11 children
- 60 recovery skips were parents with active pending/processing children
- 14 actionable timeout rows were 11 pathless children plus 3 pathless parents
- 10 of the 11 child action histories had already been purged
- child `771344` retained six completed actions followed by failed `datamachine_execute_step` action `71729468`
- liveness additionally included pending AI contention rows, explaining the larger `no_scheduler_path` total

No production jobs, actions, claims, or locks were mutated.

## Recovery contract
1. Inspect at most 20 newest execute/resume actions for each timed-out child candidate.
2. Accept pending/fresh-running work only when exact job args and operation generation/token or AI resume generation ownership match.
3. Acquire a five-minute CAS recovery claim in `engine_data`; concurrent workers cannot both recover the child.
4. Recheck scheduler ownership after claiming.
5. Requeue only a failed canonical execute action whose step still exists in the child snapshot and whose operation generation remains current.
6. If action creation loses a race, recheck and defer to the winning scheduler path.
7. If no replay-safe continuation exists, transition through normal terminal accounting as `failed - scheduler_path_lost`, preserving receipt, claim, and parent-completion semantics.

Batch parents retain their existing active-child/chunk guards and generic timeout behavior.

## Query bounds
- processing candidates remain keyset-paginated in batches of 50
- action history is bounded to 20 rows per child and filtered to exact decoded `job_id`
- machine-readable job detail output remains capped at 100 rows with omission metadata

## Tests
- `php tests/child-job-recovery-policy-smoke.php`
- focused recovery, liveness, terminal accounting, processed-item claim, AI resume-generation, and batch-parent smoke suites
- `homeboy review lint ... --changed-only`: PHPCS and PHPStan passed with no findings
- WP unit coverage adds concurrent recovery ownership; local `vendor/bin/phpunit` was unavailable in this worktree
- Homeboy audit reached `dead_code` but did not return within two attempts (180s and 600s)

## Safe post-deploy recovery
1. Run `wp datamachine jobs recover-stuck --dry-run --format=json` and review `pathless_requeued`, `pathless_terminal`, `claimed_elsewhere`, and per-job scheduler evidence.
2. Apply one bounded recovery pass through the normal command/worker only after the dry-run cohort is understood.
3. Re-run `jobs liveness` after Action Scheduler drains; gate rollout on zero unowned processing children beyond the configured timeout.