### PR TITLE
fix: read normalized flow scheduling responses

### DIFF
--- a/inc/Abilities/Engine/ScheduleFlowAbility.php
+++ b/inc/Abilities/Engine/ScheduleFlowAbility.php
@@ -208,10 +208,9 @@ class ScheduleFlowAbility {
 
 		// Read back the scheduling config to get the computed next run.
 		$flow              = $this->db_flows->get_flow( $flow_id );
-		$scheduling_config = array();
-		if ( $flow ) {
-			$scheduling_config = json_decode( $flow['scheduling_config'] ?? '{}', true );
-		}
+		$scheduling_config = $flow && is_array( $flow['scheduling_config'] ?? null )
+			? $flow['scheduling_config']
+			: array();
 
 		return array(
 			'success'         => true,
@@ -244,10 +243,9 @@ class ScheduleFlowAbility {
 
 		// Read back the scheduling config to get the computed first_run.
 		$flow              = $this->db_flows->get_flow( $flow_id );
-		$scheduling_config = array();
-		if ( $flow ) {
-			$scheduling_config = json_decode( $flow['scheduling_config'] ?? '{}', true );
-		}
+		$scheduling_config = $flow && is_array( $flow['scheduling_config'] ?? null )
+			? $flow['scheduling_config']
+			: array();
 
 		return array(
 			'success'        => true,

--- a/tests/Unit/Abilities/ScheduleMutationFailureTest.php
+++ b/tests/Unit/Abilities/ScheduleMutationFailureTest.php
@@ -7,6 +7,7 @@
 
 namespace DataMachine\Tests\Unit\Abilities;
 
+use DataMachine\Abilities\Engine\ScheduleFlowAbility;
 use DataMachine\Abilities\Flow\CreateFlowAbility;
 use DataMachine\Api\Flows\FlowScheduling;
 use DataMachine\Core\Database\Flows\Flows;
@@ -101,6 +102,34 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['retryable'] );
 		$this->assertNotNull( $this->flows->get_flow( $this->flow_id ) );
 		$this->assertTrue( RecurringScheduler::hasLogicalCoverage( self::FLOW_HOOK, array( $this->flow_id ) ) );
+	}
+
+	public function test_recurring_schedule_response_reads_normalized_config(): void {
+		$result = ( new ScheduleFlowAbility() )->execute(
+			array(
+				'flow_id'               => $this->flow_id,
+				'interval_or_timestamp' => 'daily',
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'recurring', $result['schedule_type'] );
+		$this->assertNotEmpty( $result['scheduled_time'] );
+		$this->assertIsArray( $this->flows->get_flow( $this->flow_id )['scheduling_config'] );
+	}
+
+	public function test_cron_schedule_response_reads_normalized_config(): void {
+		$result = ( new ScheduleFlowAbility() )->execute(
+			array(
+				'flow_id'               => $this->flow_id,
+				'interval_or_timestamp' => '0 9 * * 1-5',
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'cron', $result['schedule_type'] );
+		$this->assertNotEmpty( $result['scheduled_time'] );
+		$this->assertIsArray( $this->flows->get_flow( $this->flow_id )['scheduling_config'] );
 	}
 
 	public function test_stale_successor_is_canceled_when_generation_changes_between_repeat_read_and_store(): void {


### PR DESCRIPTION
## Summary
- read already-normalized scheduling arrays directly in recurring and cron ability responses
- prevent post-commit TypeErrors after successful schedule mutations
- cover both response paths through the real schedule-flow ability

## Verification
- all 34 recurring scheduler race sections pass
- changed PHPCS, PHP syntax, and diff checks pass

Closes #2967