### PR TITLE
Make post identity reservations crash-safe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
 	},
 	"config": {
 		"process-timeout": 0,
+		"platform": {
+			"php": "8.2.0"
+		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		}

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
 		"automattic/blocks-engine-php-transformer": "0.1.0"
 	},
 	"require-dev": {
+		"phpunit/phpunit": "^9.6",
 		"php-stubs/wordpress-stubs": "^6.9",
 		"wp-coding-standards/wpcs": "^3.1",
 		"phpcsstandards/phpcsutils": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6335a3968260ef5692cb4fb3a99fca4c",
+    "content-hash": "1bb4b776947f4826fe0c862339e8a92b",
     "packages": [
         {
             "name": "automattic/blocks-engine-php-transformer",
@@ -1058,29 +1058,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.1.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.4"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^14",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpunit/phpunit": "^10.5.58"
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -1107,7 +1108,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -1123,7 +1124,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T06:47:08+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -3432,5 +3433,8 @@
         "php": ">=8.2"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.2.0"
+    },
     "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9636364c8090b9d2a60860bcb1c4bcde",
+    "content-hash": "6335a3968260ef5692cb4fb3a99fca4c",
     "packages": [
         {
             "name": "automattic/blocks-engine-php-transformer",
@@ -1057,6 +1057,310 @@
             "time": "2025-11-11T04:32:07+00:00"
         },
         {
+            "name": "doctrine/instantiator",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.4"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.58"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-05T06:47:08+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
             "name": "php-stubs/wordpress-stubs",
             "version": "v6.9.1",
             "source": {
@@ -1497,6 +1801,1431 @@
             "time": "2025-12-08T14:27:58+00:00"
         },
         {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.35"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-06T14:48:07+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.13.5",
             "source": {
@@ -1574,6 +3303,56 @@
                 }
             ],
             "time": "2025-11-04T16:30:35+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/data-machine.php
+++ b/data-machine.php
@@ -890,6 +890,7 @@ function datamachine_ensure_all_tables() {
 
 	$db_identity_index = new \DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex();
 	$db_identity_index->create_table();
+	\DataMachine\Core\Database\PostIdentityReservations\PostIdentityReservations::create_table();
 
 	\DataMachine\Core\Database\BundleArtifacts\InstalledBundleArtifacts::create_table();
 	\DataMachine\Core\Database\RunMetadata\RunMetadata::create_table();

--- a/docs/development/post-identity-reservations.md
+++ b/docs/development/post-identity-reservations.md
@@ -1,0 +1,42 @@
+# Post Identity Reservations
+
+When `identity_meta` is the selected identity path, `datamachine/upsert-post`
+uses a per-site reservation table and a deterministic MySQL advisory lock. A
+valid explicit `post_id` remains the highest-priority identity and bypasses the
+reservation path and identity metadata mirror for backward compatibility.
+
+The durable reservation is the mathematical one-post-ID guarantee: after a
+reservation links a post, every retry uses that post ID and cannot allocate a
+second shell. The advisory lock provides best-effort linearization for the
+later normal WordPress update, metadata, taxonomy, and hook phase without
+holding an SQL transaction across arbitrary WordPress behavior. Because MySQL
+named locks are connection-scoped, a wpdb reconnect can lose that ordering
+fence; the implementation does not claim full-operation exclusion across a
+reconnect. The reservation remains authoritative after such a loss.
+
+## Rolling Deployment
+
+Releases predating the reservation table use lookup followed by
+`wp_insert_post()` and do not acquire the advisory lock. There is no generic
+legacy lock name or protocol those processes participate in. Operators must
+drain or stop in-flight old workers before enabling the new schema guarantee.
+The guarantee applies once all writers run the reservation-aware release; it
+does not claim cross-version exclusion against old code still executing.
+
+## Hook Semantics
+
+First population preallocates a draft shell and then calls the normal WordPress
+write path with its explicit ID. WordPress therefore emits update and draft-to-
+target-status transition hooks, while the ability reports the logical action as
+`created`. Callers must use the ability result contract rather than relying on
+core hook `$update === false` for identity-backed creation.
+
+## Concurrency Evidence
+
+The WordPress integration tests exercise retries through the real allocator and
+use independent MySQL connections to prove reservation-row serialization and
+advisory-lock exclusion. They do not yet invoke the PHP allocator itself from
+two independent worker processes: the repository is bound to WordPress's global
+`$wpdb`, and the local Codebox WordPress bootstrap needed for a subprocess test
+is not currently available. That process-level allocator evidence belongs in a
+working WordPress/Codebox integration environment rather than a mocked test.

--- a/inc/Abilities/Content/UpsertPostAbility.php
+++ b/inc/Abilities/Content/UpsertPostAbility.php
@@ -26,6 +26,7 @@ namespace DataMachine\Abilities\Content;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Content\ContentFormat;
+use DataMachine\Core\Database\PostIdentityReservations\PostIdentityReservations;
 use DataMachine\Core\SourceDate;
 use DataMachine\Core\WordPress\ResolvePostByPath;
 use DataMachine\Core\WordPress\PostTracking;
@@ -388,12 +389,51 @@ class UpsertPostAbility {
 			$parent_id = (int) $resolved;
 		}
 
-		// Resolve existing post.
+		$write_context = array(
+			'post_type'         => $post_type,
+			'title'             => $title,
+			'stored_content'    => $stored_content,
+			'slug'              => $slug,
+			'parent_id'         => $parent_id,
+			'content_hash'      => $content_hash,
+			'raw_source'        => $raw_source,
+			'source_url'        => $source_url,
+			'original_date_gmt' => $original_date_gmt,
+			'post_status'       => $post_status,
+			'post_author'       => $post_author,
+			'post_excerpt'      => $post_excerpt,
+			'taxonomies'        => $taxonomies,
+			'meta_input'        => $meta_input,
+		);
+
+		if ( $post_id > 0 ) {
+			$existing_id = self::resolve_existing_post( $post_id, $slug, $parent_id, is_array( $identity_meta ) ? $identity_meta : array(), $post_type );
+			if ( is_wp_error( $existing_id ) ) {
+				return array(
+					'success' => false,
+					'error'   => $existing_id->get_error_message(),
+				);
+			}
+
+			return self::execute_resolved_write( $write_context, (int) $existing_id );
+		}
+
+		if ( self::has_usable_identity_meta( $identity_meta ) ) {
+			return self::execute_identity_backed(
+				$write_context,
+				$identity_meta,
+				$slug,
+				$parent_id
+			);
+		}
+
+		// Preserve explicit > identity > slug resolution for omitted, partial,
+		// empty, and otherwise unusable identity_meta direct-execute inputs.
 		$existing_id = self::resolve_existing_post(
 			$post_id,
 			$slug,
 			$parent_id,
-			$identity_meta,
+			is_array( $identity_meta ) ? $identity_meta : array(),
 			$post_type
 		);
 
@@ -404,6 +444,154 @@ class UpsertPostAbility {
 			);
 		}
 
+		return self::execute_resolved_write( $write_context, (int) $existing_id );
+	}
+
+	/**
+	 * Execute an identity-backed write while holding its advisory fence.
+	 *
+	 * @param array $context       Normalized write context.
+	 * @param array $identity_meta Identity meta input.
+	 * @param string $slug         Slug fallback.
+	 * @param int   $parent_id     Slug parent scope.
+	 * @return array
+	 */
+	private static function execute_identity_backed(
+		array $context,
+		array $identity_meta,
+		string $slug,
+		int $parent_id
+	): array {
+		$post_type = $context['post_type'];
+
+		$slug_fallback_id = 0;
+		if ( '' !== $slug ) {
+			$slug_fallback_id = self::resolve_existing_post( 0, $slug, $parent_id, array(), $post_type );
+			if ( is_wp_error( $slug_fallback_id ) ) {
+				return array(
+					'success'    => false,
+					'error'      => $slug_fallback_id->get_error_message(),
+					'error_code' => $slug_fallback_id->get_error_code(),
+				);
+			}
+		}
+
+		$identity = PostIdentityReservations::normalize_identity( $post_type, $identity_meta );
+		if ( is_wp_error( $identity ) ) {
+			return array(
+				'success'    => false,
+				'error'      => $identity->get_error_message(),
+				'error_code' => $identity->get_error_code(),
+				'error_data' => $identity->get_error_data(),
+			);
+		}
+
+		$shell = array(
+			'post_author'    => $context['post_author'] > 0 ? $context['post_author'] : get_current_user_id(),
+			'comment_status' => get_default_comment_status( $post_type ),
+			'ping_status'    => get_default_comment_status( $post_type, 'pingback' ),
+			'post_date'      => current_time( 'mysql' ),
+			'post_date_gmt'  => current_time( 'mysql', true ),
+			'guid'           => 'urn:uuid:' . wp_generate_uuid4(),
+		);
+
+		$reservations = new PostIdentityReservations();
+		$locked       = $reservations->acquire_lock( $identity['identity_hash'] );
+		if ( is_wp_error( $locked ) ) {
+			return array(
+				'success'    => false,
+				'error'      => $locked->get_error_message(),
+				'error_code' => $locked->get_error_code(),
+				'error_data' => $locked->get_error_data(),
+			);
+		}
+
+		$result   = array();
+		$released = false;
+		try {
+			$reservation = $reservations->reserve_and_resolve(
+				$post_type,
+				$identity_meta,
+				0,
+				(int) $slug_fallback_id,
+				$shell
+			);
+			if ( is_wp_error( $reservation ) ) {
+				$result = array(
+					'success'    => false,
+					'error'      => $reservation->get_error_message(),
+					'error_code' => $reservation->get_error_code(),
+					'error_data' => $reservation->get_error_data(),
+				);
+			} else {
+				do_action( 'datamachine_upsert_post_identity_before_population', (int) $reservation['post_id'] );
+
+				$result = self::execute_resolved_write( $context, (int) $reservation['post_id'], $reservation, $reservations );
+			}
+		} catch ( \Throwable ) {
+			try {
+				$reservations->record_error( $identity['identity_hash'], 'identity_population_exception' );
+			} catch ( \Throwable $diagnostic_exception ) {
+				// Diagnostic persistence must not replace the retryable ability result.
+				unset( $diagnostic_exception );
+			}
+			$result = array(
+				'success'    => false,
+				'error'      => 'Post identity population failed unexpectedly; retry is required.',
+				'error_code' => 'identity_population_exception',
+				'error_data' => array( 'retryable' => true ),
+			);
+		} finally {
+			try {
+				$released = $reservations->release_lock( $identity['identity_hash'] );
+			} catch ( \Throwable ) {
+				$released = false;
+			}
+		}
+
+		if ( ! $released ) {
+			return array(
+				'success'    => false,
+				'error'      => 'Post identity lock release is uncertain; retry is required.',
+				'error_code' => 'identity_lock_release_uncertain',
+				'error_data' => array( 'retryable' => true ),
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Populate or update one already-resolved post through normal WordPress APIs.
+	 *
+	 * @param array                         $context      Normalized write context.
+	 * @param int                           $existing_id  Existing or linked post ID.
+	 * @param array|null                    $reservation Reservation outcome.
+	 * @param PostIdentityReservations|null $reservations Reservation repository.
+	 * @return array
+	 */
+	private static function execute_resolved_write(
+		array $context,
+		int $existing_id,
+		?array $reservation = null,
+		?PostIdentityReservations $reservations = null
+	): array {
+		$post_type         = $context['post_type'];
+		$title             = $context['title'];
+		$stored_content    = $context['stored_content'];
+		$slug              = $context['slug'];
+		$parent_id         = $context['parent_id'];
+		$content_hash      = $context['content_hash'];
+		$raw_source        = $context['raw_source'];
+		$source_url        = $context['source_url'];
+		$original_date_gmt = $context['original_date_gmt'];
+		$post_status       = $context['post_status'];
+		$post_author       = $context['post_author'];
+		$post_excerpt      = $context['post_excerpt'];
+		$taxonomies        = $context['taxonomies'];
+		$meta_input        = $context['meta_input'];
+		$has_reservation   = null !== $reservation && $reservations instanceof PostIdentityReservations;
+
 		// Idempotency check. Parent/slug changes still need a write even when
 		// the content hash is unchanged.
 		if ( $existing_id > 0 && '' !== $content_hash ) {
@@ -411,8 +599,21 @@ class UpsertPostAbility {
 			$post        = get_post( $existing_id );
 			$same_parent = ! $post instanceof \WP_Post || $parent_id <= 0 || (int) $post->post_parent === $parent_id;
 			$same_slug   = ! $post instanceof \WP_Post || '' === $slug || (string) $post->post_name === $slug;
-			if ( $stored_hash === $content_hash && $same_parent && $same_slug ) {
+
+			$identity_complete = ! $has_reservation
+				|| (string) get_post_meta( $existing_id, $reservation['identity']['meta_key'], true ) === $reservation['identity']['meta_value'];
+			if ( $stored_hash === $content_hash && $same_parent && $same_slug && $identity_complete ) {
 				self::applySourceMetadata( $existing_id, $source_url, $original_date_gmt );
+				if ( $has_reservation ) {
+					$completed = $reservations->mark_complete( $reservation['identity'], $existing_id );
+					if ( is_wp_error( $completed ) ) {
+						return array(
+							'success'    => false,
+							'error'      => $completed->get_error_message(),
+							'error_code' => $completed->get_error_code(),
+						);
+					}
+				}
 				$post_title = $post instanceof \WP_Post ? $post->post_title : $title;
 				return array(
 					'success'  => true,
@@ -452,7 +653,13 @@ class UpsertPostAbility {
 
 		if ( $existing_id > 0 ) {
 			$post_data['ID'] = $existing_id;
-			$action          = 'updated';
+			$was_allocated   = $has_reservation && ! empty( $reservation['allocated'] );
+			$action          = $was_allocated ? 'created' : 'updated';
+			if ( $was_allocated ) {
+				$post_data['post_author']    = $reservation['shell']['post_author'];
+				$post_data['comment_status'] = $reservation['shell']['comment_status'];
+				$post_data['ping_status']    = $reservation['shell']['ping_status'];
+			}
 		} else {
 			$action = 'created';
 			if ( $post_author > 0 ) {
@@ -462,6 +669,9 @@ class UpsertPostAbility {
 
 		// Merge caller-supplied meta_input.
 		$all_meta = is_array( $meta_input ) ? $meta_input : array();
+		if ( $has_reservation ) {
+			$all_meta[ $reservation['identity']['meta_key'] ] = wp_slash( $reservation['identity']['meta_value'] );
+		}
 
 		if ( '' !== $content_hash ) {
 			$all_meta[ self::META_CONTENT_HASH ] = $content_hash;
@@ -486,6 +696,9 @@ class UpsertPostAbility {
 		$id = wp_insert_post( $post_data, true );
 
 		if ( is_wp_error( $id ) ) {
+			if ( $has_reservation ) {
+				$reservations->record_error( $reservation['identity']['identity_hash'], (string) $id->get_error_code() );
+			}
 			return array(
 				'success' => false,
 				'error'   => $id->get_error_message(),
@@ -527,6 +740,17 @@ class UpsertPostAbility {
 			}
 		}
 
+		if ( $has_reservation ) {
+			$completed = $reservations->mark_complete( $reservation['identity'], (int) $id );
+			if ( is_wp_error( $completed ) ) {
+				return array(
+					'success'    => false,
+					'error'      => $completed->get_error_message(),
+					'error_code' => $completed->get_error_code(),
+				);
+			}
+		}
+
 		$post       = get_post( (int) $id );
 		$post_title = $post instanceof \WP_Post ? $post->post_title : $title;
 
@@ -538,6 +762,16 @@ class UpsertPostAbility {
 			'post_url' => get_permalink( (int) $id ),
 			'path'     => ResolvePostByPath::build_path( (int) $id ),
 		);
+	}
+
+	/** Match the historical direct-execute identity_meta truthiness contract. */
+	private static function has_usable_identity_meta( $identity_meta ): bool {
+		if ( ! is_array( $identity_meta ) || empty( $identity_meta['key'] ) || empty( $identity_meta['value'] ) ) {
+			return false;
+		}
+
+		return '' !== sanitize_key( (string) $identity_meta['key'] )
+			&& '' !== sanitize_text_field( (string) $identity_meta['value'] );
 	}
 
 	/**

--- a/inc/Core/Database/PostIdentityReservations/PostIdentityReservations.php
+++ b/inc/Core/Database/PostIdentityReservations/PostIdentityReservations.php
@@ -213,19 +213,80 @@ class PostIdentityReservations extends BaseRepository {
 		}
 
 		$required_columns = array(
-			'identity_hash'     => array( 'type' => 'char', 'length' => 64, 'unsigned' => false, 'nullable' => false ),
-			'post_type_hash'    => array( 'type' => 'char', 'length' => 64, 'unsigned' => false, 'nullable' => false ),
-			'meta_key_hash'     => array( 'type' => 'char', 'length' => 64, 'unsigned' => false, 'nullable' => false ),
-			'meta_value_hash'   => array( 'type' => 'char', 'length' => 64, 'unsigned' => false, 'nullable' => false ),
-			'post_id'           => array( 'type' => 'bigint', 'unsigned' => true, 'nullable' => true ),
-			'state'             => array( 'type' => 'varchar', 'length' => 20, 'unsigned' => false, 'nullable' => false, 'default' => 'reserved' ),
-			'attempt_count'     => array( 'type' => 'bigint', 'unsigned' => true, 'nullable' => false, 'default' => '1' ),
-			'last_attempt_at'   => array( 'type' => 'datetime', 'unsigned' => false, 'nullable' => false ),
-			'last_error_code'   => array( 'type' => 'varchar', 'length' => 64, 'unsigned' => false, 'nullable' => true ),
-			'last_error_message'=> array( 'type' => 'varchar', 'length' => 255, 'unsigned' => false, 'nullable' => true ),
-			'created_at'        => array( 'type' => 'datetime', 'unsigned' => false, 'nullable' => false ),
-			'updated_at'        => array( 'type' => 'datetime', 'unsigned' => false, 'nullable' => false ),
-			'completed_at'      => array( 'type' => 'datetime', 'unsigned' => false, 'nullable' => true ),
+			'identity_hash'      => array(
+				'type'     => 'char',
+				'length'   => 64,
+				'unsigned' => false,
+				'nullable' => false,
+			),
+			'post_type_hash'     => array(
+				'type'     => 'char',
+				'length'   => 64,
+				'unsigned' => false,
+				'nullable' => false,
+			),
+			'meta_key_hash'      => array(
+				'type'     => 'char',
+				'length'   => 64,
+				'unsigned' => false,
+				'nullable' => false,
+			),
+			'meta_value_hash'    => array(
+				'type'     => 'char',
+				'length'   => 64,
+				'unsigned' => false,
+				'nullable' => false,
+			),
+			'post_id'            => array(
+				'type'     => 'bigint',
+				'unsigned' => true,
+				'nullable' => true,
+			),
+			'state'              => array(
+				'type'     => 'varchar',
+				'length'   => 20,
+				'unsigned' => false,
+				'nullable' => false,
+				'default'  => 'reserved',
+			),
+			'attempt_count'      => array(
+				'type'     => 'bigint',
+				'unsigned' => true,
+				'nullable' => false,
+				'default'  => '1',
+			),
+			'last_attempt_at'    => array(
+				'type'     => 'datetime',
+				'unsigned' => false,
+				'nullable' => false,
+			),
+			'last_error_code'    => array(
+				'type'     => 'varchar',
+				'length'   => 64,
+				'unsigned' => false,
+				'nullable' => true,
+			),
+			'last_error_message' => array(
+				'type'     => 'varchar',
+				'length'   => 255,
+				'unsigned' => false,
+				'nullable' => true,
+			),
+			'created_at'         => array(
+				'type'     => 'datetime',
+				'unsigned' => false,
+				'nullable' => false,
+			),
+			'updated_at'         => array(
+				'type'     => 'datetime',
+				'unsigned' => false,
+				'nullable' => false,
+			),
+			'completed_at'       => array(
+				'type'     => 'datetime',
+				'unsigned' => false,
+				'nullable' => true,
+			),
 		);
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$columns = $this->wpdb->get_results( $this->wpdb->prepare( 'SHOW COLUMNS FROM %i', $this->table_name ), ARRAY_A );
@@ -343,11 +404,13 @@ class PostIdentityReservations extends BaseRepository {
 			if ( '' === $name ) {
 				continue;
 			}
-			$indexes[ $name ] ??= array(
-				'non_unique' => 1 === (int) ( $row['Non_unique'] ?? $row['non_unique'] ?? 0 ),
-				'parts'      => array(),
-			);
-			$sequence = (int) ( $row['Seq_in_index'] ?? $row['seq_in_index'] ?? 0 );
+			if ( ! isset( $indexes[ $name ] ) ) {
+				$indexes[ $name ] = array(
+					'non_unique' => 1 === (int) ( $row['Non_unique'] ?? $row['non_unique'] ?? 0 ),
+					'parts'      => array(),
+				);
+			}
+			$sequence                               = (int) ( $row['Seq_in_index'] ?? $row['seq_in_index'] ?? 0 );
 			$indexes[ $name ]['parts'][ $sequence ] = (string) ( $row['Column_name'] ?? $row['column_name'] ?? '' );
 		}
 		foreach ( $indexes as &$index ) {

--- a/inc/Core/Database/PostIdentityReservations/PostIdentityReservations.php
+++ b/inc/Core/Database/PostIdentityReservations/PostIdentityReservations.php
@@ -1,0 +1,818 @@
+<?php
+/**
+ * Durable identity reservations for post upserts.
+ *
+ * @package DataMachine\Core\Database\PostIdentityReservations
+ */
+
+namespace DataMachine\Core\Database\PostIdentityReservations;
+
+use DataMachine\Core\Database\BaseRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+// All identifiers and values below pass through wpdb::prepare(). WPCS does not
+// recognize nested prepare() calls using WordPress's %i identifier placeholder.
+// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+class PostIdentityReservations extends BaseRepository {
+
+	public const TABLE_NAME     = 'datamachine_post_identity_reservations';
+	public const SCHEMA_VERSION = 1;
+	public const LOCK_TIMEOUT   = 2;
+
+	/** @var array<string,true> Request-local advisory lock ownership. */
+	private static array $held_locks = array();
+
+	/** @var array<string,string> Exact lock names acquired by this repository. */
+	private array $acquired_locks = array();
+
+	public static function create_table(): void {
+		global $wpdb;
+
+		$table_name      = $wpdb->prefix . self::TABLE_NAME;
+		$charset_collate = $wpdb->get_charset_collate();
+		$sql             = "CREATE TABLE {$table_name} (
+			identity_hash char(64) NOT NULL,
+			post_type_hash char(64) NOT NULL,
+			meta_key_hash char(64) NOT NULL,
+			meta_value_hash char(64) NOT NULL,
+			post_id bigint(20) unsigned DEFAULT NULL,
+			state varchar(20) NOT NULL DEFAULT 'reserved',
+			attempt_count bigint(20) unsigned NOT NULL DEFAULT 1,
+			last_attempt_at datetime NOT NULL,
+			last_error_code varchar(64) DEFAULT NULL,
+			last_error_message varchar(255) DEFAULT NULL,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			completed_at datetime DEFAULT NULL,
+			PRIMARY KEY  (identity_hash),
+			KEY post_id (post_id)
+		) ENGINE=InnoDB {$charset_collate};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+
+		$repository = new self();
+		if ( ! BaseRepository::database_table_exists( $table_name, $wpdb ) ) {
+			$repository->log_failure( 'install_schema', 'reservation_table_install_failed' );
+			return;
+		}
+
+		if ( ! $repository->repair_schema() ) {
+			$repository->log_failure( 'repair_schema', 'reservation_table_repair_failed' );
+			return;
+		}
+
+		$validation = $repository->validate_schema();
+		if ( is_wp_error( $validation ) ) {
+			$repository->log_failure( 'install_schema', (string) $validation->get_error_code() );
+		}
+	}
+
+	/**
+	 * Normalize unslashed caller input and hash length-delimited components.
+	 *
+	 * @return array|\WP_Error
+	 */
+	public static function normalize_identity( string $post_type, array $identity ) {
+		if ( ! isset( $identity['key'], $identity['value'] ) || ! is_string( $identity['key'] ) || ! is_string( $identity['value'] ) ) {
+			return new \WP_Error( 'invalid_identity_meta', 'identity_meta requires a valid non-empty key and value.' );
+		}
+
+		$post_type  = sanitize_key( $post_type );
+		$meta_key   = sanitize_key( $identity['key'] );
+		$meta_value = sanitize_text_field( $identity['value'] );
+
+		if ( '' === $post_type || '' === $meta_key || '' === $meta_value ) {
+			return new \WP_Error( 'invalid_identity_meta', 'identity_meta requires a valid non-empty key and value.' );
+		}
+
+		$meta_value = sanitize_meta( $meta_key, $meta_value, 'post', $post_type );
+		if ( ! is_scalar( $meta_value ) ) {
+			return new \WP_Error( 'invalid_identity_meta', 'identity_meta value is not valid for the registered post meta field.' );
+		}
+		$meta_value = (string) $meta_value;
+		if ( '' === $meta_value ) {
+			return new \WP_Error( 'invalid_identity_meta', 'identity_meta value is empty after registered post meta sanitization.' );
+		}
+
+		$sanitized_again = sanitize_meta( $meta_key, $meta_value, 'post', $post_type );
+		if ( ! is_scalar( $sanitized_again ) || (string) $sanitized_again !== $meta_value ) {
+			return new \WP_Error( 'identity_meta_sanitizer_unstable', 'Registered post meta sanitization must be idempotent for identity_meta.' );
+		}
+
+		$canonical = self::canonical_component( $post_type )
+			. self::canonical_component( $meta_key )
+			. self::canonical_component( $meta_value );
+
+		return array(
+			'post_type'       => $post_type,
+			'meta_key'        => $meta_key,
+			'meta_value'      => $meta_value,
+			'identity_hash'   => hash( 'sha256', $canonical ),
+			'post_type_hash'  => hash( 'sha256', $post_type ),
+			'meta_key_hash'   => hash( 'sha256', $meta_key ),
+			'meta_value_hash' => hash( 'sha256', $meta_value ),
+		);
+	}
+
+	/** Build a deterministic MySQL-safe lock name for one database/site. */
+	public static function build_lock_name( string $database, string $table, string $identity_hash ): string {
+		$scope = strlen( $database ) . ':' . $database
+			. ';' . strlen( $table ) . ':' . $table
+			. ';' . $identity_hash;
+
+		return 'dm-post-identity:' . substr( hash( 'sha256', $scope ), 0, 47 );
+	}
+
+	/** Resolve the current site's scoped advisory lock name. */
+	public function lock_name( string $identity_hash ): string {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$database = (string) $this->wpdb->get_var( 'SELECT DATABASE()' );
+		return self::build_lock_name( $database, $this->table_name, $identity_hash );
+	}
+
+	/** @return true|\WP_Error */
+	public function acquire_lock( string $identity_hash ) {
+		$lock_name = $this->lock_name( $identity_hash );
+		if ( isset( self::$held_locks[ $lock_name ] ) ) {
+			return new \WP_Error(
+				'identity_lock_reentrant',
+				'Recursive post identity acquisition is not allowed; retry is required.',
+				array( 'retryable' => true )
+			);
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$acquired = $this->wpdb->get_var(
+			$this->wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_name, self::LOCK_TIMEOUT )
+		);
+
+		if ( '1' === (string) $acquired ) {
+			self::$held_locks[ $lock_name ]         = true;
+			$this->acquired_locks[ $identity_hash ] = $lock_name;
+			return true;
+		}
+
+		$this->log_failure( 'acquire_lock', 'advisory_lock_unavailable', 'warning' );
+		return new \WP_Error(
+			'identity_lock_unavailable',
+			'Post identity is currently locked; retry is required.',
+			array( 'retryable' => true )
+		);
+	}
+
+	/** Release the connection-scoped identity fence. */
+	public function release_lock( string $identity_hash ): bool {
+		$lock_name = $this->acquired_locks[ $identity_hash ] ?? $this->lock_name( $identity_hash );
+		if ( ! isset( self::$held_locks[ $lock_name ] ) ) {
+			unset( $this->acquired_locks[ $identity_hash ] );
+			$this->log_failure( 'release_lock', 'advisory_lock_not_owned', 'warning' );
+			return false;
+		}
+
+		$released = null;
+		try {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$released = $this->wpdb->get_var( $this->wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) );
+		} finally {
+			unset( self::$held_locks[ $lock_name ] );
+			unset( $this->acquired_locks[ $identity_hash ] );
+		}
+		if ( '1' === (string) $released ) {
+			return true;
+		}
+
+		$this->log_failure( 'release_lock', 'advisory_lock_release_failed', 'warning' );
+		return false;
+	}
+
+	/**
+	 * Validate the complete reservation schema contract for the current site.
+	 *
+	 * @return true|\WP_Error
+	 */
+	public function validate_schema() {
+		if ( ! BaseRepository::database_table_exists( $this->table_name, $this->wpdb ) ) {
+			return new \WP_Error( 'identity_schema_missing', 'Post identity reservation table is missing.' );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$database = (string) $this->wpdb->get_var( 'SELECT DATABASE()' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$engine = $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				'SELECT ENGINE FROM information_schema.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s',
+				$database,
+				$this->table_name
+			)
+		);
+		if ( 'INNODB' !== strtoupper( (string) $engine ) ) {
+			return new \WP_Error( 'identity_schema_engine', 'Post identity reservation table must use InnoDB.' );
+		}
+
+		$required_columns = array(
+			'identity_hash'     => array( 'type' => 'char', 'length' => 64, 'unsigned' => false, 'nullable' => false ),
+			'post_type_hash'    => array( 'type' => 'char', 'length' => 64, 'unsigned' => false, 'nullable' => false ),
+			'meta_key_hash'     => array( 'type' => 'char', 'length' => 64, 'unsigned' => false, 'nullable' => false ),
+			'meta_value_hash'   => array( 'type' => 'char', 'length' => 64, 'unsigned' => false, 'nullable' => false ),
+			'post_id'           => array( 'type' => 'bigint', 'unsigned' => true, 'nullable' => true ),
+			'state'             => array( 'type' => 'varchar', 'length' => 20, 'unsigned' => false, 'nullable' => false, 'default' => 'reserved' ),
+			'attempt_count'     => array( 'type' => 'bigint', 'unsigned' => true, 'nullable' => false, 'default' => '1' ),
+			'last_attempt_at'   => array( 'type' => 'datetime', 'unsigned' => false, 'nullable' => false ),
+			'last_error_code'   => array( 'type' => 'varchar', 'length' => 64, 'unsigned' => false, 'nullable' => true ),
+			'last_error_message'=> array( 'type' => 'varchar', 'length' => 255, 'unsigned' => false, 'nullable' => true ),
+			'created_at'        => array( 'type' => 'datetime', 'unsigned' => false, 'nullable' => false ),
+			'updated_at'        => array( 'type' => 'datetime', 'unsigned' => false, 'nullable' => false ),
+			'completed_at'      => array( 'type' => 'datetime', 'unsigned' => false, 'nullable' => true ),
+		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$columns = $this->wpdb->get_results( $this->wpdb->prepare( 'SHOW COLUMNS FROM %i', $this->table_name ), ARRAY_A );
+		$columns = array_column( array_map( array( self::class, 'normalize_column_metadata' ), $columns ), null, 'name' );
+		foreach ( $required_columns as $name => $expected ) {
+			if ( empty( $columns[ $name ] ) || ! self::column_matches( $columns[ $name ], $expected ) ) {
+				return new \WP_Error( 'identity_schema_columns', 'Post identity reservation table has an invalid required column.' );
+			}
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$indexes = self::normalize_index_metadata( $this->wpdb->get_results( $this->wpdb->prepare( 'SHOW INDEX FROM %i', $this->table_name ), ARRAY_A ) );
+		$primary = $indexes['PRIMARY'] ?? null;
+		if ( ! is_array( $primary ) || $primary['non_unique'] || array( 'identity_hash' ) !== $primary['columns'] ) {
+			return new \WP_Error( 'identity_schema_primary_key', 'Post identity reservation identity_hash primary key is invalid.' );
+		}
+
+		$has_nonunique_post_id = false;
+		$has_unique_post_id    = false;
+		foreach ( $indexes as $name => $index ) {
+			if ( 'PRIMARY' === $name || array( 'post_id' ) !== $index['columns'] ) {
+				continue;
+			}
+			if ( $index['non_unique'] ) {
+				$has_nonunique_post_id = true;
+			} else {
+				$has_unique_post_id = true;
+			}
+		}
+		if ( ! $has_nonunique_post_id || $has_unique_post_id ) {
+			return new \WP_Error( 'identity_schema_post_index', 'Post identity reservation post_id requires a nonunique index.' );
+		}
+
+		return true;
+	}
+
+	/** Repair schema details that dbDelta does not reliably reconcile. */
+	private function repair_schema(): bool {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$database = (string) $this->wpdb->get_var( 'SELECT DATABASE()' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$engine = $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				'SELECT ENGINE FROM information_schema.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s',
+				$database,
+				$this->table_name
+			)
+		);
+		if ( 'INNODB' !== strtoupper( (string) $engine ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			if ( false === $this->wpdb->query( $this->wpdb->prepare( 'ALTER TABLE %i ENGINE=InnoDB', $this->table_name ) ) ) {
+				return false;
+			}
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$indexes = self::normalize_index_metadata( $this->wpdb->get_results( $this->wpdb->prepare( 'SHOW INDEX FROM %i', $this->table_name ), ARRAY_A ) );
+		foreach ( $indexes as $name => $index ) {
+			if ( 'PRIMARY' === $name || $index['non_unique'] || array( 'post_id' ) !== $index['columns'] ) {
+				continue;
+			}
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			if ( false === $this->wpdb->query( $this->wpdb->prepare( 'ALTER TABLE %i DROP INDEX %i', $this->table_name, $name ) ) ) {
+				return false;
+			}
+		}
+
+		// Re-read after drops because dbDelta can leave a same-name malformed index.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$indexes = self::normalize_index_metadata( $this->wpdb->get_results( $this->wpdb->prepare( 'SHOW INDEX FROM %i', $this->table_name ), ARRAY_A ) );
+		foreach ( $indexes as $name => $index ) {
+			if ( 'PRIMARY' !== $name && $index['non_unique'] && array( 'post_id' ) === $index['columns'] ) {
+				return true;
+			}
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return false !== $this->wpdb->query(
+			$this->wpdb->prepare( 'ALTER TABLE %i ADD INDEX %i (post_id)', $this->table_name, 'datamachine_post_id_lookup' )
+		);
+	}
+
+	/** Normalize SHOW COLUMNS output across MySQL and MariaDB spellings. */
+	private static function normalize_column_metadata( array $column ): array {
+		$type = strtolower( preg_replace( '/\s+/', ' ', trim( (string) ( $column['Type'] ?? $column['type'] ?? '' ) ) ) );
+		preg_match( '/^([a-z]+)(?:\((\d+)(?:,\d+)?\))?/', $type, $matches );
+
+		return array(
+			'name'     => (string) ( $column['Field'] ?? $column['field'] ?? '' ),
+			'type'     => $matches[1] ?? '',
+			'length'   => isset( $matches[2] ) ? (int) $matches[2] : null,
+			'unsigned' => (bool) preg_match( '/(?:^| )unsigned(?: |$)/', $type ),
+			'nullable' => 'YES' === strtoupper( (string) ( $column['Null'] ?? $column['null'] ?? '' ) ),
+			'default'  => $column['Default'] ?? $column['default'] ?? null,
+		);
+	}
+
+	private static function column_matches( array $actual, array $expected ): bool {
+		foreach ( array( 'type', 'unsigned', 'nullable' ) as $property ) {
+			if ( $actual[ $property ] !== $expected[ $property ] ) {
+				return false;
+			}
+		}
+		if ( isset( $expected['length'] ) && $actual['length'] !== $expected['length'] ) {
+			return false;
+		}
+		return ! array_key_exists( 'default', $expected ) || (string) $actual['default'] === (string) $expected['default'];
+	}
+
+	/** Group ordered SHOW INDEX rows into exact index definitions. */
+	private static function normalize_index_metadata( array $rows ): array {
+		$indexes = array();
+		foreach ( $rows as $row ) {
+			$name = (string) ( $row['Key_name'] ?? $row['key_name'] ?? '' );
+			if ( '' === $name ) {
+				continue;
+			}
+			$indexes[ $name ] ??= array(
+				'non_unique' => 1 === (int) ( $row['Non_unique'] ?? $row['non_unique'] ?? 0 ),
+				'parts'      => array(),
+			);
+			$sequence = (int) ( $row['Seq_in_index'] ?? $row['seq_in_index'] ?? 0 );
+			$indexes[ $name ]['parts'][ $sequence ] = (string) ( $row['Column_name'] ?? $row['column_name'] ?? '' );
+		}
+		foreach ( $indexes as &$index ) {
+			ksort( $index['parts'], SORT_NUMERIC );
+			$index['columns'] = array_values( $index['parts'] );
+			unset( $index['parts'] );
+		}
+		unset( $index );
+
+		return $indexes;
+	}
+
+	/**
+	 * Reserve an identity and return its one durable post ID.
+	 *
+	 * @return array|\WP_Error
+	 */
+	public function reserve_and_resolve(
+		string $post_type,
+		array $identity,
+		int $explicit_post_id = 0,
+		int $slug_fallback_id = 0,
+		array $shell = array()
+	) {
+		$identity = self::normalize_identity( $post_type, $identity );
+		if ( is_wp_error( $identity ) ) {
+			return $identity;
+		}
+
+		$storage = $this->verify_transactional_storage();
+		if ( is_wp_error( $storage ) ) {
+			return $storage;
+		}
+
+		$now = current_time( 'mysql', true );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$reserved = $this->wpdb->query(
+			$this->wpdb->prepare(
+				"INSERT INTO %i
+				(identity_hash, post_type_hash, meta_key_hash, meta_value_hash, state, attempt_count, last_attempt_at, created_at, updated_at)
+				VALUES (%s, %s, %s, %s, 'reserved', 1, %s, %s, %s)
+				ON DUPLICATE KEY UPDATE attempt_count = attempt_count + 1, last_attempt_at = VALUES(last_attempt_at), updated_at = VALUES(updated_at)",
+				$this->table_name,
+				$identity['identity_hash'],
+				$identity['post_type_hash'],
+				$identity['meta_key_hash'],
+				$identity['meta_value_hash'],
+				$now,
+				$now,
+				$now
+			)
+		);
+		if ( false === $reserved ) {
+			$this->log_failure( 'reserve', 'reservation_insert_failed' );
+			return new \WP_Error( 'identity_reservation_failed', 'Could not reserve post identity.' );
+		}
+
+		$row = $this->get_reservation( $identity['identity_hash'] );
+		if ( null === $row ) {
+			$this->log_failure( 'reserve_reread', 'reservation_read_failed' );
+			return new \WP_Error( 'identity_reservation_unavailable', 'Post identity reservation could not be read after writing.' );
+		}
+		if ( ! $this->components_match( $row, $identity ) ) {
+			return new \WP_Error( 'identity_integrity_conflict', 'Post identity reservation component mismatch.' );
+		}
+
+		do_action( 'datamachine_post_identity_before_allocation', $identity['identity_hash'] );
+
+		return $this->resolve_locked( $identity, $explicit_post_id, $slug_fallback_id, $shell );
+	}
+
+	/** @return true|\WP_Error */
+	public function mark_complete( array $identity, int $post_id ) {
+		$post = get_post( $post_id );
+		if ( ! $post instanceof \WP_Post || $post->post_type !== $identity['post_type'] ) {
+			$this->record_error( $identity['identity_hash'], 'identity_link_invalid', 'Linked post is missing or has the wrong post type.' );
+			return new \WP_Error( 'identity_link_invalid', 'Linked post is missing or has the wrong post type.' );
+		}
+
+		if ( (string) get_post_meta( $post_id, $identity['meta_key'], true ) !== $identity['meta_value'] ) {
+			$this->record_error( $identity['identity_hash'], 'identity_meta_incomplete', 'Linked post identity metadata is incomplete.' );
+			return new \WP_Error( 'identity_meta_incomplete', 'Linked post identity metadata is incomplete.' );
+		}
+
+		$now = current_time( 'mysql', true );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $this->wpdb->query(
+			$this->wpdb->prepare(
+				"UPDATE %i SET state = 'complete', completed_at = %s, updated_at = %s, last_error_code = NULL, last_error_message = NULL WHERE identity_hash = %s AND post_id = %d",
+				$this->table_name,
+				$now,
+				$now,
+				$identity['identity_hash'],
+				$post_id
+			)
+		);
+
+		if ( false === $updated ) {
+			$this->log_failure( 'mark_complete', 'reservation_completion_failed' );
+			return new \WP_Error( 'identity_completion_failed', 'Could not complete post identity reservation.' );
+		}
+
+		$row = $this->get_reservation( $identity['identity_hash'] );
+		if ( null === $row || 'complete' !== $row['state'] || $post_id !== (int) $row['post_id'] ) {
+			$this->log_failure( 'mark_complete_verify', 'reservation_completion_verify_failed' );
+			return new \WP_Error( 'identity_completion_failed', 'Could not complete post identity reservation.' );
+		}
+
+		return true;
+	}
+
+	/** Record bounded diagnostics without persisting identity input. */
+	public function record_error( string $identity_hash, string $code, string $message = 'Post upsert failed.' ): void {
+		$code    = substr( sanitize_key( $code ), 0, 64 );
+		$message = substr( sanitize_text_field( $message ), 0, 255 );
+		$now     = current_time( 'mysql', true );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $this->wpdb->query(
+			$this->wpdb->prepare(
+				'UPDATE %i SET last_error_code = %s, last_error_message = %s, updated_at = %s WHERE identity_hash = %s',
+				$this->table_name,
+				$code,
+				$message,
+				$now,
+				$identity_hash
+			)
+		);
+		if ( false === $updated ) {
+			$this->log_failure( 'record_error', 'reservation_error_record_failed' );
+		}
+	}
+
+	public function get_reservation( string $identity_hash ): ?array {
+		return $this->find_by_id( 'identity_hash', $identity_hash );
+	}
+
+	/** @return array|\WP_Error */
+	protected function resolve_locked(
+		array $identity,
+		int $explicit_post_id = 0,
+		int $slug_fallback_id = 0,
+		array $shell = array()
+	) {
+		if ( ! $this->start_transaction() ) {
+			$this->log_failure( 'start_transaction', 'transaction_start_failed' );
+			$this->record_error( $identity['identity_hash'], 'identity_transaction_failed', 'Could not start post identity transaction.' );
+			return new \WP_Error( 'identity_transaction_failed', 'Could not start post identity transaction.' );
+		}
+
+		$commit_attempted = false;
+		try {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$row = $this->wpdb->get_row(
+				$this->wpdb->prepare( 'SELECT * FROM %i WHERE identity_hash = %s FOR UPDATE', $this->table_name, $identity['identity_hash'] ),
+				ARRAY_A
+			);
+			if ( ! is_array( $row ) || ! $this->components_match( $row, $identity ) ) {
+				$this->rollback_transaction();
+				return new \WP_Error( 'identity_integrity_conflict', 'Post identity reservation component mismatch.' );
+			}
+
+			$post_id   = (int) ( $row['post_id'] ?? 0 );
+			$allocated = false;
+			$adopted   = false;
+			if ( $post_id > 0 ) {
+				if ( $explicit_post_id > 0 && $post_id !== $explicit_post_id ) {
+					$this->set_locked_error( $identity['identity_hash'], 'identity_explicit_conflict', 'Explicit post conflicts with the linked identity reservation.' );
+					$commit_attempted = true;
+					if ( ! $this->commit_transaction() ) {
+						return $this->commit_uncertain_error();
+					}
+					return new \WP_Error(
+						'identity_explicit_conflict',
+						'Explicit post conflicts with the linked identity reservation.',
+						array(
+							'linked_post_id'   => $post_id,
+							'explicit_post_id' => $explicit_post_id,
+						)
+					);
+				}
+
+				$linked_type = $this->linked_post_type( $post_id );
+				if ( null === $linked_type || $linked_type !== $identity['post_type'] ) {
+					$this->set_locked_error( $identity['identity_hash'], 'identity_link_invalid', 'Linked post is missing or has the wrong post type.' );
+					$commit_attempted = true;
+					if ( ! $this->commit_transaction() ) {
+						return $this->commit_uncertain_error();
+					}
+					return new \WP_Error( 'identity_link_invalid', 'Linked post is missing or has the wrong post type.', array( 'post_id' => $post_id ) );
+				}
+			} else {
+				$candidates = array();
+				if ( $explicit_post_id > 0 ) {
+					$post_id = $explicit_post_id;
+					$adopted = true;
+				} else {
+					$candidates = $this->find_legacy_candidates( $identity );
+				}
+
+				if ( $explicit_post_id <= 0 && count( $candidates ) > 1 ) {
+					$bounded = array_slice( $candidates, 0, 20 );
+					$message = sprintf( 'Multiple posts claim this identity (candidate IDs: %s).', implode( ',', $bounded ) );
+					$this->set_locked_conflict( $identity['identity_hash'], $message );
+					$commit_attempted = true;
+					if ( ! $this->commit_transaction() ) {
+						return $this->commit_uncertain_error();
+					}
+					return new \WP_Error(
+						'identity_legacy_conflict',
+						'Multiple posts claim this identity.',
+						array(
+							'candidate_count' => count( $candidates ),
+							'candidate_ids'   => $bounded,
+						)
+					);
+				}
+
+				if ( $explicit_post_id <= 0 ) {
+					if ( 1 === count( $candidates ) ) {
+						$post_id = (int) $candidates[0];
+						$adopted = true;
+					} elseif ( $slug_fallback_id > 0 ) {
+						$post_id = $slug_fallback_id;
+						$adopted = true;
+					} else {
+						$post_id   = $this->insert_draft_shell( $identity['post_type'], $shell );
+						$allocated = true;
+					}
+				}
+
+				$resolved_type = $post_id > 0 ? $this->linked_post_type( $post_id ) : null;
+				if ( null === $resolved_type || $resolved_type !== $identity['post_type'] ) {
+					$this->rollback_transaction();
+					$this->record_error( $identity['identity_hash'], 'identity_candidate_invalid', 'Resolved post is missing or has the wrong post type.' );
+					return new \WP_Error( 'identity_candidate_invalid', 'Resolved post is missing or has the wrong post type.' );
+				}
+
+				if ( ! $this->link_locked_reservation( $identity['identity_hash'], $post_id ) ) {
+					$this->rollback_transaction();
+					$this->log_failure( 'link_reservation', 'reservation_link_failed' );
+					$this->record_error( $identity['identity_hash'], 'identity_allocation_failed', 'Could not atomically allocate the post identity.' );
+					return new \WP_Error( 'identity_allocation_failed', 'Could not atomically allocate the post identity.' );
+				}
+			}
+
+			$commit_attempted = true;
+			if ( ! $this->commit_transaction() ) {
+				$this->log_failure( 'commit_allocation', 'transaction_commit_uncertain' );
+				return $this->commit_uncertain_error();
+			}
+		} catch ( \Throwable $throwable ) {
+			if ( $commit_attempted ) {
+				return $this->commit_uncertain_error();
+			}
+			$this->rollback_transaction();
+			$this->record_error( $identity['identity_hash'], 'identity_allocation_failed', 'Could not atomically allocate the post identity.' );
+			return new \WP_Error( 'identity_allocation_failed', 'Could not atomically allocate the post identity.' );
+		}
+
+		clean_post_cache( $post_id );
+
+		return array(
+			'post_id'   => $post_id,
+			'allocated' => $allocated,
+			'adopted'   => $adopted,
+			'identity'  => $identity,
+			'shell'     => $shell,
+		);
+	}
+
+	/** @return true|\WP_Error */
+	protected function verify_transactional_storage() {
+		if ( self::is_sqlite() ) {
+			return new \WP_Error( 'identity_storage_unsupported', 'Identity-backed post upserts require transactional InnoDB storage.' );
+		}
+		$schema = $this->validate_schema();
+		if ( is_wp_error( $schema ) ) {
+			$this->log_failure( 'validate_schema', (string) $schema->get_error_code() );
+			return $schema;
+		}
+
+		$tables = array( $this->table_name, $this->wpdb->posts );
+		foreach ( $tables as $table ) {
+			if ( ! preg_match( '/^[A-Za-z0-9_]+$/', $table ) ) {
+				return new \WP_Error( 'identity_storage_invalid', 'Post identity storage has an invalid table name.' );
+			}
+		}
+
+		$placeholders = implode( ',', array_fill( 0, count( $tables ), '%s' ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$database_name = (string) $this->wpdb->get_var( 'SELECT DATABASE()' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$engines = $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				"SELECT TABLE_NAME, ENGINE FROM information_schema.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME IN ({$placeholders})",
+				$database_name,
+				...$tables
+			),
+			OBJECT_K
+		);
+
+		foreach ( $tables as $table ) {
+			if ( empty( $engines[ $table ] ) || 'INNODB' !== strtoupper( (string) $engines[ $table ]->ENGINE ) ) {
+				$this->log_failure( 'verify_storage', 'transactional_storage_unavailable' );
+				return new \WP_Error( 'identity_storage_unsupported', 'Identity-backed post upserts require transactional InnoDB storage.' );
+			}
+		}
+
+		return true;
+	}
+
+	/** @return int[] */
+	protected function find_legacy_candidates( array $identity ): array {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$ids = $this->wpdb->get_col(
+			$this->wpdb->prepare(
+				'SELECT DISTINCT p.ID FROM %i p INNER JOIN %i pm ON pm.post_id = p.ID WHERE p.post_type = %s AND pm.meta_key = %s AND pm.meta_value = %s ORDER BY p.ID ASC LIMIT 51',
+				$this->wpdb->posts,
+				$this->wpdb->postmeta,
+				$identity['post_type'],
+				$identity['meta_key'],
+				$identity['meta_value']
+			)
+		);
+
+		return array_map( 'intval', $ids );
+	}
+
+	protected function insert_draft_shell( string $post_type, array $shell = array() ): int {
+		$author         = absint( $shell['post_author'] ?? 0 );
+		$comment_status = sanitize_key( $shell['comment_status'] ?? 'closed' );
+		$ping_status    = sanitize_key( $shell['ping_status'] ?? 'closed' );
+		$now_local      = (string) ( $shell['post_date'] ?? '' );
+		$now_gmt        = (string) ( $shell['post_date_gmt'] ?? '' );
+		$guid           = (string) ( $shell['guid'] ?? '' );
+		if ( '' === $now_local || '' === $now_gmt || '' === $guid ) {
+			return 0;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$inserted = $this->wpdb->query(
+			$this->wpdb->prepare(
+				"INSERT INTO %i
+				(post_author, post_date, post_date_gmt, post_content, post_title, post_excerpt, post_status, comment_status, ping_status, post_password, post_name, to_ping, pinged, post_modified, post_modified_gmt, post_content_filtered, post_parent, guid, menu_order, post_type, post_mime_type, comment_count)
+				VALUES (%d, %s, %s, '', '', '', 'draft', %s, %s, '', '', '', '', %s, %s, '', 0, %s, 0, %s, '', 0)",
+				$this->wpdb->posts,
+				$author,
+				$now_local,
+				$now_gmt,
+				$comment_status,
+				$ping_status,
+				$now_local,
+				$now_gmt,
+				$guid,
+				$post_type
+			)
+		);
+		if ( false === $inserted ) {
+			$this->log_failure( 'insert_shell', 'shell_insert_failed' );
+		}
+
+		return false === $inserted ? 0 : (int) $this->wpdb->insert_id;
+	}
+
+	protected function linked_post_type( int $post_id ): ?string {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$value = $this->wpdb->get_var( $this->wpdb->prepare( 'SELECT post_type FROM %i WHERE ID = %d', $this->wpdb->posts, $post_id ) );
+		return null === $value ? null : (string) $value;
+	}
+
+	protected function link_locked_reservation( string $identity_hash, int $post_id ): bool {
+		$now = current_time( 'mysql', true );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $this->wpdb->query(
+			$this->wpdb->prepare(
+				"UPDATE %i SET post_id = %d, state = 'linked', updated_at = %s, last_error_code = NULL, last_error_message = NULL WHERE identity_hash = %s AND post_id IS NULL",
+				$this->table_name,
+				$post_id,
+				$now,
+				$identity_hash
+			)
+		);
+		return 1 === $result;
+	}
+
+	protected function set_locked_conflict( string $identity_hash, string $message ): void {
+		$now = current_time( 'mysql', true );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$this->wpdb->query(
+			$this->wpdb->prepare(
+				"UPDATE %i SET state = 'conflict', last_error_code = 'identity_legacy_conflict', last_error_message = %s, updated_at = %s WHERE identity_hash = %s",
+				$this->table_name,
+				substr( $message, 0, 255 ),
+				$now,
+				$identity_hash
+			)
+		);
+	}
+
+	protected function set_locked_error( string $identity_hash, string $code, string $message ): void {
+		$now = current_time( 'mysql', true );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$this->wpdb->query(
+			$this->wpdb->prepare(
+				'UPDATE %i SET last_error_code = %s, last_error_message = %s, updated_at = %s WHERE identity_hash = %s',
+				$this->table_name,
+				substr( sanitize_key( $code ), 0, 64 ),
+				substr( sanitize_text_field( $message ), 0, 255 ),
+				$now,
+				$identity_hash
+			)
+		);
+	}
+
+	protected function start_transaction(): bool {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return false !== $this->wpdb->query( 'START TRANSACTION' );
+	}
+
+	protected function commit_transaction(): bool {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return false !== $this->wpdb->query( 'COMMIT' );
+	}
+
+	protected function rollback_transaction(): void {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$this->wpdb->query( 'ROLLBACK' );
+	}
+
+	private function commit_uncertain_error(): \WP_Error {
+		return new \WP_Error(
+			'identity_commit_uncertain',
+			'Post identity transaction commit outcome is uncertain; retry is required.',
+			array( 'retryable' => true )
+		);
+	}
+
+	private static function canonical_component( string $value ): string {
+		return strlen( $value ) . ':' . $value . ';';
+	}
+
+	private function components_match( array $row, array $identity ): bool {
+		return hash_equals( (string) $row['post_type_hash'], $identity['post_type_hash'] )
+			&& hash_equals( (string) $row['meta_key_hash'], $identity['meta_key_hash'] )
+			&& hash_equals( (string) $row['meta_value_hash'], $identity['meta_value_hash'] );
+	}
+
+	/** Log privacy-safe database diagnostics without SQL or identity material. */
+	private function log_failure( string $operation, string $fallback_error, string $level = 'error' ): void {
+		$error = trim( (string) $this->wpdb->last_error );
+		if ( '' === $error ) {
+			$error = $fallback_error;
+		}
+		$error = preg_replace( '/\b[a-f0-9]{64}\b/i', '[redacted]', $error );
+
+		do_action(
+			'datamachine_log',
+			$level,
+			'Post identity database operation failed',
+			array(
+				'operation' => $operation,
+				'table'     => $this->table_name,
+				'error'     => substr( (string) $error, 0, 255 ),
+			)
+		);
+	}
+}

--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -37,6 +37,30 @@ function datamachine_run_schema_migrations(): void {
 }
 
 /**
+ * Install the independently versioned post identity reservation schema.
+ *
+ * Identity-backed writes fail closed until this table exists on the current
+ * site, so its rollout does not depend on the general plugin version gate.
+ */
+function datamachine_maybe_install_post_identity_reservations(): void {
+	$version    = \DataMachine\Core\Database\PostIdentityReservations\PostIdentityReservations::SCHEMA_VERSION;
+	$repository = new \DataMachine\Core\Database\PostIdentityReservations\PostIdentityReservations();
+	$validation = $repository->validate_schema();
+	if ( (int) get_option( 'datamachine_post_identity_reservations_schema', 0 ) === $version && true === $validation ) {
+		return;
+	}
+	if ( true !== $validation ) {
+		update_option( 'datamachine_post_identity_reservations_schema', 0, true );
+	}
+
+	\DataMachine\Core\Database\PostIdentityReservations\PostIdentityReservations::create_table();
+	$repository = new \DataMachine\Core\Database\PostIdentityReservations\PostIdentityReservations();
+	if ( true === $repository->validate_schema() ) {
+		update_option( 'datamachine_post_identity_reservations_schema', $version, true );
+	}
+}
+
+/**
  * Maybe ensure current schema on plugins_loaded.
  *
  * Reads the persisted `datamachine_db_version` option and compares it to
@@ -88,3 +112,4 @@ function datamachine_maybe_run_deferred_migrations(): void {
 // and upgraded installs; the option-gate inside the function avoids
 // double-running when activation already migrated this request.
 add_action( 'plugins_loaded', 'datamachine_maybe_run_deferred_migrations', 5 );
+add_action( 'plugins_loaded', 'datamachine_maybe_install_post_identity_reservations', 5 );

--- a/tests/Unit/Abilities/Content/UpsertPostAbilityTest.php
+++ b/tests/Unit/Abilities/Content/UpsertPostAbilityTest.php
@@ -1,0 +1,485 @@
+<?php
+/**
+ * Identity-backed upsert ability tests.
+ *
+ * @package DataMachine\Tests\Unit\Abilities\Content
+ */
+
+namespace DataMachine\Tests\Unit\Abilities\Content;
+
+use DataMachine\Abilities\Content\UpsertPostAbility;
+use DataMachine\Core\Database\PostIdentityReservations\PostIdentityReservations;
+use WP_UnitTestCase;
+
+class UpsertPostAbilityTest extends WP_UnitTestCase {
+
+	private PostIdentityReservations $repository;
+
+	public function set_up(): void {
+		parent::set_up();
+		PostIdentityReservations::create_table();
+		$this->repository = new PostIdentityReservations();
+
+		global $wpdb;
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i', $this->repository->get_table_name() ) );
+	}
+
+	public function test_identity_less_create_behavior_is_unchanged(): void {
+		$result = UpsertPostAbility::execute(
+			array(
+				'post_type' => 'post',
+				'title'     => 'Identity-less',
+				'content'   => '<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'created', $result['action'] );
+		$this->assertSame( 'publish', get_post_status( $result['post_id'] ) );
+	}
+
+	public function test_first_identity_upsert_populates_shell_and_completes_reservation(): void {
+		$result = UpsertPostAbility::execute( $this->input( 'complete-one', 'First title' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'created', $result['action'] );
+		$this->assertSame( 'complete-one', get_post_meta( $result['post_id'], '_source', true ) );
+		$this->assertSame( 'First title', get_post( $result['post_id'] )->post_title );
+		$identity = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'complete-one' ) );
+		$row      = $this->repository->get_reservation( $identity['identity_hash'] );
+		$this->assertSame( 'complete', $row['state'] );
+		$this->assertSame( (string) $result['post_id'], (string) $row['post_id'] );
+		$this->assertNotEmpty( $row['completed_at'] );
+	}
+
+	public function test_retry_updates_same_linked_post(): void {
+		$first = UpsertPostAbility::execute( $this->input( 'retry-one', 'First title' ) );
+		$retry = UpsertPostAbility::execute( $this->input( 'retry-one', 'Second title' ) );
+
+		$this->assertTrue( $retry['success'] );
+		$this->assertSame( 'updated', $retry['action'] );
+		$this->assertSame( $first['post_id'], $retry['post_id'] );
+		$this->assertSame( 'Second title', get_post( $first['post_id'] )->post_title );
+
+		global $wpdb;
+		$reservation_count = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $this->repository->get_table_name() ) );
+		$claimant_count    = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(DISTINCT post_id) FROM %i WHERE meta_key = %s AND meta_value = %s',
+				$wpdb->postmeta,
+				'_source',
+				'retry-one'
+			)
+		);
+		$identity = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'retry-one' ) );
+		$this->assertSame( 1, $reservation_count );
+		$this->assertSame( 1, $claimant_count );
+		$this->assertSame( 'complete', $this->repository->get_reservation( $identity['identity_hash'] )['state'] );
+	}
+
+	public function test_ordinary_wordpress_failure_retains_link_then_retry_completes(): void {
+		$fail = static fn() => true;
+		add_filter( 'wp_insert_post_empty_content', $fail );
+		$failed = UpsertPostAbility::execute( $this->input( 'write-failure', 'Will retry' ) );
+		remove_filter( 'wp_insert_post_empty_content', $fail );
+
+		$this->assertFalse( $failed['success'] );
+		$identity = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'write-failure' ) );
+		$row      = $this->repository->get_reservation( $identity['identity_hash'] );
+		$this->assertSame( 'linked', $row['state'] );
+		$this->assertNotEmpty( $row['post_id'] );
+		$this->assertNotEmpty( $row['last_error_code'] );
+		$this->assertStringNotContainsString( 'write-failure', (string) $row['last_error_message'] );
+		$this->assertIdentityLockIsFree( 'write-failure' );
+
+		$retry = UpsertPostAbility::execute( $this->input( 'write-failure', 'Will retry' ) );
+		$this->assertTrue( $retry['success'] );
+		$this->assertSame( (int) $row['post_id'], $retry['post_id'] );
+		$this->assertSame( 'complete', $this->repository->get_reservation( $identity['identity_hash'] )['state'] );
+	}
+
+	public function test_linked_shell_retry_reconciles_full_post_behavior(): void {
+		$reserved = $this->repository->reserve_and_resolve(
+			'post',
+			array( 'key' => '_source', 'value' => 'shell-retry' ),
+			0,
+			0,
+			array(
+				'post_author'    => get_current_user_id(),
+				'comment_status' => get_default_comment_status( 'post' ),
+				'ping_status'    => get_default_comment_status( 'post', 'pingback' ),
+				'post_date'      => current_time( 'mysql' ),
+				'post_date_gmt'  => current_time( 'mysql', true ),
+				'guid'           => 'urn:uuid:' . wp_generate_uuid4(),
+			)
+		);
+		$result   = UpsertPostAbility::execute(
+			array_merge(
+				$this->input( 'shell-retry', 'Populated shell' ),
+				array(
+					'meta_input' => array( '_extra' => 'value' ),
+					'taxonomies' => array( 'category' => array( 'Shell Category' ) ),
+				)
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $reserved['post_id'], $result['post_id'] );
+		$this->assertSame( 'value', get_post_meta( $result['post_id'], '_extra', true ) );
+		$this->assertNotEmpty( wp_get_post_terms( $result['post_id'], 'category' ) );
+	}
+
+	public function test_content_hash_no_change_still_completes_same_reservation(): void {
+		$input                 = $this->input( 'no-change', 'Stable title' );
+		$input['content_hash'] = hash( 'sha256', $input['content'] );
+		$first                 = UpsertPostAbility::execute( $input );
+		$retry                 = UpsertPostAbility::execute( $input );
+
+		$this->assertTrue( $retry['success'] );
+		$this->assertSame( 'no_change', $retry['action'] );
+		$this->assertSame( $first['post_id'], $retry['post_id'] );
+		$identity = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'no-change' ) );
+		$this->assertSame( 'complete', $this->repository->get_reservation( $identity['identity_hash'] )['state'] );
+	}
+
+	public function test_empty_partial_and_zero_identity_values_keep_slug_fallback_behavior(): void {
+		$cases = array(
+			array(),
+			array( 'key' => '_source' ),
+			array( 'value' => 'partial' ),
+			array( 'key' => '', 'value' => 'empty-key' ),
+			array( 'key' => '_source', 'value' => '' ),
+			array( 'key' => '_source', 'value' => '0' ),
+		);
+
+		foreach ( $cases as $index => $identity_meta ) {
+			$slug    = 'identity-fallback-' . $index;
+			$post_id = self::factory()->post->create(
+				array(
+					'post_type' => 'post',
+					'post_name' => $slug,
+				)
+			);
+			$input                  = $this->input( 'unused-' . $index, 'Fallback' );
+			$input['slug']          = $slug;
+			$input['identity_meta'] = $identity_meta;
+			$result                 = UpsertPostAbility::execute( $input );
+
+			$this->assertTrue( $result['success'] );
+			$this->assertSame( $post_id, $result['post_id'], 'Unusable identity_meta must retain slug lookup behavior.' );
+		}
+
+		global $wpdb;
+		$count = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $this->repository->get_table_name() ) );
+		$this->assertSame( 0, $count );
+	}
+
+	public function test_explicit_post_bypasses_identity_reservation_and_metadata(): void {
+		$explicit_id = self::factory()->post->create( array( 'post_type' => 'post' ) );
+		$identity_id = self::factory()->post->create( array( 'post_type' => 'post' ) );
+		$slug_id     = self::factory()->post->create( array( 'post_type' => 'post', 'post_name' => 'priority-slug' ) );
+		update_post_meta( $identity_id, '_source', 'priority-explicit' );
+		$identity_title = get_post( $identity_id )->post_title;
+		$input            = $this->input( 'priority-explicit', 'Explicit wins' );
+		$input['post_id'] = $explicit_id;
+		$input['slug']    = 'priority-slug';
+
+		$result = UpsertPostAbility::execute( $input );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $explicit_id, $result['post_id'] );
+		$this->assertSame( 'Explicit wins', get_post( $explicit_id )->post_title );
+		$this->assertSame( '', get_post_meta( $explicit_id, '_source', true ) );
+		$this->assertSame( 'priority-explicit', get_post_meta( $identity_id, '_source', true ) );
+		$this->assertSame( $identity_title, get_post( $identity_id )->post_title );
+		$this->assertNotSame( 'Explicit wins', get_post( $slug_id )->post_title );
+
+		$identity = PostIdentityReservations::normalize_identity( 'post', $input['identity_meta'] );
+		$this->assertNull( $this->repository->get_reservation( $identity['identity_hash'] ) );
+	}
+
+	public function test_wrong_type_explicit_post_fails_before_reservation(): void {
+		$page_id          = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		$input            = $this->input( 'wrong-explicit-type', 'Wrong type' );
+		$input['post_id'] = $page_id;
+
+		$result = UpsertPostAbility::execute( $input );
+
+		$this->assertFalse( $result['success'] );
+		$identity = PostIdentityReservations::normalize_identity( 'post', $input['identity_meta'] );
+		$this->assertNull( $this->repository->get_reservation( $identity['identity_hash'] ) );
+	}
+
+	public function test_legacy_identity_candidate_wins_over_slug_candidate(): void {
+		$identity_id = self::factory()->post->create( array( 'post_type' => 'post' ) );
+		$slug_id     = self::factory()->post->create( array( 'post_type' => 'post', 'post_name' => 'identity-vs-slug' ) );
+		update_post_meta( $identity_id, '_source', 'identity-vs-slug' );
+		$input         = $this->input( 'identity-vs-slug', 'Identity wins' );
+		$input['slug'] = 'identity-vs-slug';
+
+		$result = UpsertPostAbility::execute( $input );
+
+		$this->assertSame( $identity_id, $result['post_id'] );
+		$this->assertNotSame( $slug_id, $result['post_id'] );
+	}
+
+	public function test_slug_candidate_is_adopted_when_identity_has_no_legacy_match(): void {
+		$slug_id       = self::factory()->post->create( array( 'post_type' => 'post', 'post_name' => 'identity-miss-slug' ) );
+		$input         = $this->input( 'identity-miss', 'Slug wins' );
+		$input['slug'] = 'identity-miss-slug';
+
+		$result = UpsertPostAbility::execute( $input );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $slug_id, $result['post_id'] );
+		$this->assertSame( 'identity-miss', get_post_meta( $slug_id, '_source', true ) );
+	}
+
+	public function test_explicit_post_bypasses_an_existing_link_without_rebinding_it(): void {
+		$first       = UpsertPostAbility::execute( $this->input( 'linked-conflict', 'First' ) );
+		$other_id    = self::factory()->post->create( array( 'post_type' => 'post' ) );
+		$retry_input = $this->input( 'linked-conflict', 'Other' );
+		$retry_input['post_id'] = $other_id;
+
+		$result = UpsertPostAbility::execute( $retry_input );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $other_id, $result['post_id'] );
+		$this->assertSame( '', get_post_meta( $other_id, '_source', true ) );
+		$identity = PostIdentityReservations::normalize_identity( 'post', $retry_input['identity_meta'] );
+		$row      = $this->repository->get_reservation( $identity['identity_hash'] );
+		$this->assertSame( $first['post_id'], (int) $row['post_id'] );
+		$this->assertSame( 'linked-conflict', get_post_meta( $first['post_id'], '_source', true ) );
+	}
+
+	public function test_identity_meta_round_trips_backslashes_and_quotes(): void {
+		$value  = "C:\\Music\\O'Reilly";
+		$input  = $this->input( $value, 'Slash semantics' );
+		$result = UpsertPostAbility::execute( $input );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $value, get_post_meta( $result['post_id'], '_source', true ) );
+		$retry = UpsertPostAbility::execute( $input );
+		$this->assertSame( $result['post_id'], $retry['post_id'] );
+	}
+
+	public function test_registered_meta_sanitizer_is_part_of_canonical_identity(): void {
+		register_post_meta(
+			'post',
+			'_canonical_identity',
+			array( 'sanitize_callback' => static fn( $value ) => strtolower( (string) $value ) )
+		);
+		$input                         = $this->input( 'unused', 'Sanitized identity' );
+		$input['identity_meta']['key']   = '_canonical_identity';
+		$input['identity_meta']['value'] = 'Mixed-CASE';
+
+		$result = UpsertPostAbility::execute( $input );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'mixed-case', get_post_meta( $result['post_id'], '_canonical_identity', true ) );
+		$normalized = PostIdentityReservations::normalize_identity( 'post', $input['identity_meta'] );
+		$this->assertSame( 'mixed-case', $normalized['meta_value'] );
+	}
+
+	public function test_unstable_registered_meta_sanitizer_fails_before_reservation(): void {
+		register_post_meta(
+			'post',
+			'_unstable_identity',
+			array( 'sanitize_callback' => static fn( $value ) => $value . 'x' )
+		);
+		$input                         = $this->input( 'unused', 'Unstable identity' );
+		$input['identity_meta']['key']   = '_unstable_identity';
+		$input['identity_meta']['value'] = 'value';
+
+		$result = UpsertPostAbility::execute( $input );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'identity_meta_sanitizer_unstable', $result['error_code'] );
+	}
+
+	public function test_advisory_fence_spans_population_and_releases_on_success(): void {
+		$identity = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'fenced-success' ) );
+		$lock_name = $this->repository->lock_name( $identity['identity_hash'] );
+		$observed = false;
+		$observer = function () use ( $lock_name, &$observed ): void {
+			global $wpdb;
+			$owner   = $wpdb->get_var( $wpdb->prepare( 'SELECT IS_USED_LOCK(%s)', $lock_name ) );
+			$current = $wpdb->get_var( 'SELECT CONNECTION_ID()' );
+			$observed = (string) $owner === (string) $current;
+		};
+		add_action( 'datamachine_upsert_post_identity_before_population', $observer );
+		$result = UpsertPostAbility::execute( $this->input( 'fenced-success', 'Fenced' ) );
+		remove_action( 'datamachine_upsert_post_identity_before_population', $observer );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertTrue( $observed );
+		$this->assertIdentityLockIsFree( 'fenced-success' );
+	}
+
+	public function test_population_exception_returns_retryable_failure_and_releases_fence(): void {
+		$throw = static function (): void {
+			throw new \RuntimeException( 'Injected population exception.' );
+		};
+		add_action( 'datamachine_upsert_post_identity_before_population', $throw );
+		$result = UpsertPostAbility::execute( $this->input( 'fenced-exception', 'Exception' ) );
+		remove_action( 'datamachine_upsert_post_identity_before_population', $throw );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'identity_population_exception', $result['error_code'] );
+		$this->assertTrue( $result['error_data']['retryable'] );
+		$this->assertStringNotContainsString( 'Injected population exception', $result['error'] );
+		$this->assertIdentityLockIsFree( 'fenced-exception' );
+	}
+
+	public function test_record_error_exception_cannot_replace_population_failure(): void {
+		$table = $this->repository->get_table_name();
+		$throw_population = static function (): void {
+			throw new \RuntimeException( 'Injected population exception.' );
+		};
+		$throw_diagnostic = static function ( string $query ) use ( $table ): string {
+			if ( str_contains( $query, "UPDATE `{$table}` SET last_error_code") ) {
+				throw new \RuntimeException( 'Injected record_error exception.' );
+			}
+			return $query;
+		};
+		add_action( 'datamachine_upsert_post_identity_before_population', $throw_population );
+		add_filter( 'query', $throw_diagnostic );
+		try {
+			$result = UpsertPostAbility::execute( $this->input( 'diagnostic-exception', 'Diagnostic exception' ) );
+		} finally {
+			remove_filter( 'query', $throw_diagnostic );
+			remove_action( 'datamachine_upsert_post_identity_before_population', $throw_population );
+		}
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'identity_population_exception', $result['error_code'] );
+		$this->assertTrue( $result['error_data']['retryable'] );
+		$this->assertIdentityLockIsFree( 'diagnostic-exception' );
+	}
+
+	public function test_recursive_same_request_upsert_is_rejected_without_mysql_reentry(): void {
+		$recursive_result = null;
+		$callback         = function () use ( &$recursive_result ): void {
+			$recursive_result = UpsertPostAbility::execute( $this->input( 'recursive-identity', 'Recursive inner' ) );
+		};
+		add_action( 'datamachine_upsert_post_identity_before_population', $callback );
+		$outer = UpsertPostAbility::execute( $this->input( 'recursive-identity', 'Recursive outer' ) );
+		remove_action( 'datamachine_upsert_post_identity_before_population', $callback );
+
+		$this->assertTrue( $outer['success'] );
+		$this->assertFalse( $recursive_result['success'] );
+		$this->assertSame( 'identity_lock_reentrant', $recursive_result['error_code'] );
+		$this->assertTrue( $recursive_result['error_data']['retryable'] );
+		$this->assertIdentityLockIsFree( 'recursive-identity' );
+	}
+
+	public function test_release_ownership_loss_replaces_success_with_retryable_uncertainty(): void {
+		$identity  = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'release-lost' ) );
+		$lock_name = $this->repository->lock_name( $identity['identity_hash'] );
+		$release   = static function () use ( $lock_name ): void {
+			global $wpdb;
+			$wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) );
+		};
+		add_action( 'datamachine_upsert_post_identity_before_population', $release );
+		$result = UpsertPostAbility::execute( $this->input( 'release-lost', 'Release lost' ) );
+		remove_action( 'datamachine_upsert_post_identity_before_population', $release );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'identity_lock_release_uncertain', $result['error_code'] );
+		$this->assertTrue( $result['error_data']['retryable'] );
+		$this->assertIdentityLockIsFree( 'release-lost' );
+	}
+
+	public function test_busy_advisory_fence_returns_retryable_ability_error(): void {
+		$connection = $this->open_mysql_connection();
+		if ( ! $connection instanceof \mysqli ) {
+			$this->markTestSkipped( 'A direct test database connection is unavailable.' );
+		}
+
+		$identity  = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'fenced-busy' ) );
+		$lock_name = $connection->real_escape_string( $this->repository->lock_name( $identity['identity_hash'] ) );
+		$connection->query( "SELECT GET_LOCK('{$lock_name}', 0)" );
+		try {
+			$result = UpsertPostAbility::execute( $this->input( 'fenced-busy', 'Busy' ) );
+			$this->assertFalse( $result['success'] );
+			$this->assertSame( 'identity_lock_unavailable', $result['error_code'] );
+			$this->assertTrue( $result['error_data']['retryable'] );
+		} finally {
+			$connection->query( "SELECT RELEASE_LOCK('{$lock_name}')" );
+			$connection->close();
+		}
+	}
+
+	public function test_preallocated_shell_preserves_create_defaults_but_uses_update_hooks(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $user_id );
+		$expected_comment = get_default_comment_status( 'post' );
+		$expected_ping    = get_default_comment_status( 'post', 'pingback' );
+		$updates          = array();
+		$transitions      = array();
+		$after_insert     = static function ( $post_id, $post, $update ) use ( &$updates ): void {
+			unset( $post_id, $post );
+			$updates[] = $update;
+		};
+		$transition = static function ( $new_status, $old_status ) use ( &$transitions ): void {
+			$transitions[] = array( $old_status, $new_status );
+		};
+		add_action( 'wp_after_insert_post', $after_insert, 10, 3 );
+		add_action( 'transition_post_status', $transition, 10, 2 );
+		$result = UpsertPostAbility::execute( $this->input( 'hook-contract', 'Hook contract' ) );
+		remove_action( 'wp_after_insert_post', $after_insert, 10 );
+		remove_action( 'transition_post_status', $transition, 10 );
+
+		$post = get_post( $result['post_id'] );
+		$this->assertSame( 'created', $result['action'] );
+		$this->assertSame( $user_id, (int) $post->post_author );
+		$this->assertSame( $expected_comment, $post->comment_status );
+		$this->assertSame( $expected_ping, $post->ping_status );
+		$this->assertContains( true, $updates, 'First population is intentionally a WordPress update.' );
+		$this->assertContains( array( 'draft', 'publish' ), $transitions );
+	}
+
+	private function input( string $value, string $title ): array {
+		return array(
+			'post_type'     => 'post',
+			'title'         => $title,
+			'content'       => '<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->',
+			'identity_meta' => array(
+				'key'   => '_source',
+				'value' => $value,
+			),
+		);
+	}
+
+	private function assertIdentityLockIsFree( string $value ): void {
+		global $wpdb;
+
+		$identity = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => $value ) );
+		$is_free  = $wpdb->get_var( $wpdb->prepare( 'SELECT IS_FREE_LOCK(%s)', $this->repository->lock_name( $identity['identity_hash'] ) ) );
+		$this->assertSame( '1', (string) $is_free );
+	}
+
+	private function open_mysql_connection(): ?\mysqli {
+		if ( ! class_exists( '\mysqli' ) ) {
+			return null;
+		}
+
+		$host   = DB_HOST;
+		$port   = null;
+		$socket = null;
+		if ( preg_match( '/^([^:]+):(\d+)$/', $host, $matches ) ) {
+			$host = $matches[1];
+			$port = (int) $matches[2];
+		} elseif ( preg_match( '/^([^:]+):(.+)$/', $host, $matches ) ) {
+			$host   = $matches[1];
+			$socket = $matches[2];
+		}
+
+		$connection = \mysqli_init();
+		if ( false === $connection || ! @$connection->real_connect( $host, DB_USER, DB_PASSWORD, DB_NAME, $port, $socket ) ) {
+			return null;
+		}
+
+		return $connection;
+	}
+}

--- a/tests/Unit/Core/Database/PostIdentityReservations/PostIdentityReservationsTest.php
+++ b/tests/Unit/Core/Database/PostIdentityReservations/PostIdentityReservationsTest.php
@@ -1,0 +1,543 @@
+<?php
+/**
+ * Post identity reservation integration tests.
+ *
+ * @package DataMachine\Tests\Unit\Core\Database\PostIdentityReservations
+ */
+
+namespace DataMachine\Tests\Unit\Core\Database\PostIdentityReservations;
+
+use DataMachine\Core\Database\PostIdentityReservations\PostIdentityReservations;
+use WP_UnitTestCase;
+
+class PostIdentityReservationsTest extends WP_UnitTestCase {
+
+	private PostIdentityReservations $repository;
+
+	public function set_up(): void {
+		parent::set_up();
+		PostIdentityReservations::create_table();
+		$this->repository = new PostIdentityReservations();
+
+		global $wpdb;
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i', $this->repository->get_table_name() ) );
+	}
+
+	public function test_schema_is_site_scoped_minimal_and_innodb(): void {
+		global $wpdb;
+
+		$this->assertSame( $wpdb->prefix . PostIdentityReservations::TABLE_NAME, $this->repository->get_table_name() );
+		$engine = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT ENGINE FROM information_schema.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s',
+				DB_NAME,
+				$this->repository->get_table_name()
+			)
+		);
+		$this->assertSame( 'INNODB', strtoupper( (string) $engine ) );
+
+		$columns = $wpdb->get_results( $wpdb->prepare( 'SHOW COLUMNS FROM %i', $this->repository->get_table_name() ), ARRAY_A );
+		$columns = array_column( $columns, null, 'Field' );
+		$this->assertSame( 'char(64)', strtolower( $columns['identity_hash']['Type'] ) );
+		$this->assertSame( 'NO', $columns['identity_hash']['Null'] );
+		$this->assertMatchesRegularExpression( '/^bigint(?:\(20\))? unsigned$/', strtolower( $columns['post_id']['Type'] ) );
+		$this->assertSame( 'YES', $columns['post_id']['Null'] );
+		$this->assertSame( 'reserved', $columns['state']['Default'] );
+		$this->assertSame( '1', (string) $columns['attempt_count']['Default'] );
+		$this->assertArrayNotHasKey( 'meta_value', $columns, 'Raw identity values must not be persisted.' );
+
+		$indexes = $wpdb->get_results( $wpdb->prepare( 'SHOW INDEX FROM %i', $this->repository->get_table_name() ) );
+		$post_id_indexes = array_filter( $indexes, static fn( $index ) => 'post_id' === $index->Column_name );
+		$this->assertNotEmpty( $post_id_indexes );
+		$this->assertSame( '1', (string) reset( $post_id_indexes )->Non_unique, 'post_id must not be unique.' );
+		$this->assertTrue( $this->repository->validate_schema() );
+	}
+
+	public function test_multisite_uses_the_switched_site_prefix(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite test suite is not active.' );
+		}
+
+		global $wpdb;
+		$identity       = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'site-lock-scope' ) );
+		$main_lock_name = $this->repository->lock_name( $identity['identity_hash'] );
+		$blog_id = self::factory()->blog->create();
+		switch_to_blog( $blog_id );
+		try {
+			PostIdentityReservations::create_table();
+			$repository = new PostIdentityReservations();
+			$this->assertSame( $wpdb->prefix . PostIdentityReservations::TABLE_NAME, $repository->get_table_name() );
+			$this->assertNotSame( $wpdb->base_prefix . PostIdentityReservations::TABLE_NAME, $repository->get_table_name() );
+			$this->assertNotSame( $main_lock_name, $repository->lock_name( $identity['identity_hash'] ) );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	public function test_lock_scope_separates_databases_and_site_tables(): void {
+		$identity_hash = str_repeat( 'a', 64 );
+		$first         = PostIdentityReservations::build_lock_name( 'database_one', 'wp_datamachine_post_identity_reservations', $identity_hash );
+		$other_site    = PostIdentityReservations::build_lock_name( 'database_one', 'wp_2_datamachine_post_identity_reservations', $identity_hash );
+		$other_database = PostIdentityReservations::build_lock_name( 'database_two', 'wp_datamachine_post_identity_reservations', $identity_hash );
+
+		$this->assertLessThanOrEqual( 64, strlen( $first ) );
+		$this->assertNotSame( $first, $other_site );
+		$this->assertNotSame( $first, $other_database );
+	}
+
+	public function test_missing_table_fails_identity_write_closed(): void {
+		global $wpdb;
+
+		$wpdb->query( $wpdb->prepare( 'DROP TABLE %i', $this->repository->get_table_name() ) );
+		$validation = $this->repository->validate_schema();
+		$result = $this->repository->reserve_and_resolve( 'post', array( 'key' => '_source', 'value' => 'no-table' ) );
+
+		$this->assertWPError( $validation );
+		$this->assertSame( 'identity_schema_missing', $validation->get_error_code() );
+		$this->assertWPError( $result );
+		$this->assertSame( 'identity_schema_missing', $result->get_error_code() );
+	}
+
+	public function test_nontransactional_reservation_table_fails_closed(): void {
+		global $wpdb;
+
+		$changed = $wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ENGINE=MyISAM', $this->repository->get_table_name() ) );
+		$this->assertNotFalse( $changed );
+		try {
+			$validation = $this->repository->validate_schema();
+			$result = $this->repository->reserve_and_resolve( 'post', array( 'key' => '_source', 'value' => 'wrong-engine' ) );
+			$this->assertWPError( $validation );
+			$this->assertSame( 'identity_schema_engine', $validation->get_error_code() );
+			$this->assertWPError( $result );
+			$this->assertSame( 'identity_schema_engine', $result->get_error_code() );
+		} finally {
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ENGINE=InnoDB', $this->repository->get_table_name() ) );
+		}
+	}
+
+	public function test_create_table_repairs_myisam_to_innodb(): void {
+		global $wpdb;
+
+		$this->assertNotFalse( $wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ENGINE=MyISAM', $this->repository->get_table_name() ) ) );
+		PostIdentityReservations::create_table();
+
+		$this->assertTrue( ( new PostIdentityReservations() )->validate_schema() );
+		$engine = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT ENGINE FROM information_schema.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s',
+				DB_NAME,
+				$this->repository->get_table_name()
+			)
+		);
+		$this->assertSame( 'INNODB', strtoupper( (string) $engine ) );
+	}
+
+	public function test_schema_validation_rejects_partial_table(): void {
+		global $wpdb;
+
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP COLUMN completed_at', $this->repository->get_table_name() ) );
+		$validation = $this->repository->validate_schema();
+
+		$this->assertWPError( $validation );
+		$this->assertSame( 'identity_schema_columns', $validation->get_error_code() );
+	}
+
+	public function test_schema_validation_requires_nonunique_post_id_index(): void {
+		global $wpdb;
+
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP INDEX post_id', $this->repository->get_table_name() ) );
+		$validation = $this->repository->validate_schema();
+
+		$this->assertWPError( $validation );
+		$this->assertSame( 'identity_schema_post_index', $validation->get_error_code() );
+	}
+
+	public function test_schema_validation_rejects_unique_post_id_index(): void {
+		global $wpdb;
+
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP INDEX post_id, ADD UNIQUE KEY post_id_unique (post_id)', $this->repository->get_table_name() ) );
+		try {
+			$validation = $this->repository->validate_schema();
+
+			$this->assertWPError( $validation );
+			$this->assertSame( 'identity_schema_post_index', $validation->get_error_code() );
+		} finally {
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP INDEX post_id_unique, ADD KEY post_id (post_id)', $this->repository->get_table_name() ) );
+		}
+	}
+
+	public function test_schema_validation_rejects_malformed_column_contract_and_create_table_repairs_it(): void {
+		global $wpdb;
+
+		$wpdb->query(
+			$wpdb->prepare(
+				"ALTER TABLE %i
+				MODIFY identity_hash char(63) NOT NULL,
+				MODIFY post_id bigint(20) DEFAULT NULL,
+				MODIFY state varchar(40) NOT NULL DEFAULT 'broken',
+				MODIFY attempt_count bigint(20) unsigned NOT NULL DEFAULT 2,
+				MODIFY completed_at datetime NOT NULL",
+				$this->repository->get_table_name()
+			)
+		);
+
+		$validation = $this->repository->validate_schema();
+		$this->assertWPError( $validation );
+		$this->assertSame( 'identity_schema_columns', $validation->get_error_code() );
+
+		PostIdentityReservations::create_table();
+		$this->assertTrue( ( new PostIdentityReservations() )->validate_schema() );
+	}
+
+	public function test_create_table_repairs_exact_unique_post_id_index_only(): void {
+		global $wpdb;
+
+		$wpdb->query(
+			$wpdb->prepare(
+				'ALTER TABLE %i DROP INDEX post_id, ADD UNIQUE KEY conflicting_post_id (post_id), ADD KEY retained_post_state (post_id, state)',
+				$this->repository->get_table_name()
+			)
+		);
+
+		PostIdentityReservations::create_table();
+		$indexes = $wpdb->get_results( $wpdb->prepare( 'SHOW INDEX FROM %i', $this->repository->get_table_name() ), ARRAY_A );
+		$grouped = array();
+		foreach ( $indexes as $index ) {
+			$grouped[ $index['Key_name'] ]['non_unique'] = (int) $index['Non_unique'];
+			$grouped[ $index['Key_name'] ]['columns'][ (int) $index['Seq_in_index'] ] = $index['Column_name'];
+		}
+		foreach ( $grouped as &$index ) {
+			ksort( $index['columns'] );
+			$index['columns'] = array_values( $index['columns'] );
+		}
+		unset( $index );
+
+		$this->assertArrayNotHasKey( 'conflicting_post_id', $grouped );
+		$this->assertSame( array( 'post_id', 'state' ), $grouped['retained_post_state']['columns'] );
+		$this->assertNotEmpty(
+			array_filter(
+				$grouped,
+				static fn( $index ) => 1 === $index['non_unique'] && array( 'post_id' ) === $index['columns']
+			)
+		);
+		$this->assertTrue( ( new PostIdentityReservations() )->validate_schema() );
+	}
+
+	public function test_identity_hash_is_deterministic_and_unambiguous(): void {
+		$first  = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'ab:c' ) );
+		$repeat = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'ab:c' ) );
+		$other  = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_sourcea', 'value' => 'b:c' ) );
+
+		$this->assertSame( $first['identity_hash'], $repeat['identity_hash'] );
+		$this->assertNotSame( $first['identity_hash'], $other['identity_hash'] );
+		$this->assertSame( 64, strlen( $first['identity_hash'] ) );
+	}
+
+	public function test_first_allocation_and_retry_converge_on_one_shell(): void {
+		$identity = array( 'key' => '_source', 'value' => 'one' );
+		$first    = $this->repository->reserve_and_resolve( 'post', $identity, 0, 0, $this->shell() );
+		$retry    = $this->repository->reserve_and_resolve( 'post', $identity, 0, 0, $this->shell() );
+
+		$this->assertFalse( is_wp_error( $first ) );
+		$this->assertTrue( $first['allocated'] );
+		$this->assertSame( $first['post_id'], $retry['post_id'] );
+		$this->assertFalse( $retry['allocated'] );
+		$this->assertSame( 'draft', get_post_status( $first['post_id'] ) );
+
+		$row = $this->repository->get_reservation( $first['identity']['identity_hash'] );
+		$this->assertSame( 'linked', $row['state'] );
+		$this->assertSame( '2', (string) $row['attempt_count'] );
+	}
+
+	public function test_two_connections_serialize_on_the_reservation_row(): void {
+		if ( ! class_exists( '\mysqli' ) || ! defined( 'MYSQLI_ASYNC' ) ) {
+			$this->markTestSkipped( 'MySQLi async support is unavailable.' );
+		}
+
+		$first_connection  = $this->open_mysql_connection();
+		$second_connection = $this->open_mysql_connection();
+		if ( ! $first_connection instanceof \mysqli || ! $second_connection instanceof \mysqli ) {
+			$this->markTestSkipped( 'Two direct test database connections are unavailable.' );
+		}
+
+		global $wpdb;
+		$identity = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'two-connections' ) );
+		$now      = current_time( 'mysql', true );
+		$wpdb->insert(
+			$this->repository->get_table_name(),
+			array(
+				'identity_hash'   => $identity['identity_hash'],
+				'post_type_hash'  => $identity['post_type_hash'],
+				'meta_key_hash'   => $identity['meta_key_hash'],
+				'meta_value_hash' => $identity['meta_value_hash'],
+				'state'           => 'reserved',
+				'attempt_count'   => 1,
+				'last_attempt_at' => $now,
+				'created_at'      => $now,
+				'updated_at'      => $now,
+			)
+		);
+		$post_id = self::factory()->post->create( array( 'post_type' => 'post' ) );
+		$table   = $this->repository->get_table_name();
+		$hash    = $first_connection->real_escape_string( $identity['identity_hash'] );
+
+		try {
+			$first_connection->query( 'START TRANSACTION' );
+			$first_connection->query( "SELECT identity_hash FROM `{$table}` WHERE identity_hash = '{$hash}' FOR UPDATE" );
+			$first_connection->query( "UPDATE `{$table}` SET post_id = {$post_id}, state = 'linked' WHERE identity_hash = '{$hash}'" );
+
+			$second_connection->query( 'START TRANSACTION' );
+			$second_connection->query( "SELECT post_id, state FROM `{$table}` WHERE identity_hash = '{$hash}' FOR UPDATE", MYSQLI_ASYNC );
+			$read   = array( $second_connection );
+			$error  = array();
+			$reject = array();
+			$this->assertSame( 0, \mysqli_poll( $read, $error, $reject, 0, 100000 ), 'Second allocator must wait for the row lock.' );
+
+			$first_connection->query( 'COMMIT' );
+			$ready = 0;
+			for ( $attempt = 0; $attempt < 20 && 0 === $ready; ++$attempt ) {
+				$read   = array( $second_connection );
+				$error  = array();
+				$reject = array();
+				$ready  = \mysqli_poll( $read, $error, $reject, 0, 100000 );
+			}
+			$this->assertSame( 1, $ready, 'Second allocator should resume after commit.' );
+			$result = $second_connection->reap_async_query();
+			$this->assertInstanceOf( \mysqli_result::class, $result );
+			$row = $result->fetch_assoc();
+			$this->assertSame( (string) $post_id, (string) $row['post_id'] );
+			$this->assertSame( 'linked', $row['state'] );
+		} finally {
+			$first_connection->query( 'ROLLBACK' );
+			$second_connection->query( 'ROLLBACK' );
+			$first_connection->close();
+			$second_connection->close();
+		}
+	}
+
+	public function test_advisory_lock_fences_an_independent_connection_and_releases(): void {
+		$connection = $this->open_mysql_connection();
+		if ( ! $connection instanceof \mysqli ) {
+			$this->markTestSkipped( 'A direct test database connection is unavailable.' );
+		}
+
+		$identity  = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'advisory-fence' ) );
+		$lock_name = $this->repository->lock_name( $identity['identity_hash'] );
+		$this->assertLessThanOrEqual( 64, strlen( $lock_name ) );
+		$this->assertTrue( $this->repository->acquire_lock( $identity['identity_hash'] ) );
+		try {
+			$escaped = $connection->real_escape_string( $lock_name );
+			$result  = $connection->query( "SELECT GET_LOCK('{$escaped}', 0) AS acquired" );
+			$this->assertSame( '0', (string) $result->fetch_assoc()['acquired'] );
+		} finally {
+			$this->assertTrue( $this->repository->release_lock( $identity['identity_hash'] ) );
+		}
+
+		$result = $connection->query( "SELECT GET_LOCK('{$escaped}', 0) AS acquired" );
+		$this->assertSame( '1', (string) $result->fetch_assoc()['acquired'] );
+		$connection->query( "SELECT RELEASE_LOCK('{$escaped}')" );
+		$connection->close();
+	}
+
+	public function test_unavailable_advisory_lock_returns_retryable_error(): void {
+		$connection = $this->open_mysql_connection();
+		if ( ! $connection instanceof \mysqli ) {
+			$this->markTestSkipped( 'A direct test database connection is unavailable.' );
+		}
+
+		$identity  = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'advisory-busy' ) );
+		$lock_name = $connection->real_escape_string( $this->repository->lock_name( $identity['identity_hash'] ) );
+		$connection->query( "SELECT GET_LOCK('{$lock_name}', 0)" );
+		try {
+			$result = $this->repository->acquire_lock( $identity['identity_hash'] );
+			$this->assertWPError( $result );
+			$this->assertSame( 'identity_lock_unavailable', $result->get_error_code() );
+			$this->assertTrue( $result->get_error_data()['retryable'] );
+		} finally {
+			$connection->query( "SELECT RELEASE_LOCK('{$lock_name}')" );
+			$connection->close();
+		}
+	}
+
+	public function test_exact_legacy_post_is_adopted(): void {
+		$post_id = self::factory()->post->create( array( 'post_type' => 'post' ) );
+		update_post_meta( $post_id, '_source', 'legacy-one' );
+
+		$result = $this->repository->reserve_and_resolve( 'post', array( 'key' => '_source', 'value' => 'legacy-one' ) );
+
+		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertTrue( $result['adopted'] );
+		$this->assertFalse( $result['allocated'] );
+	}
+
+	public function test_duplicate_legacy_claimants_are_visible_conflict(): void {
+		$ids = array(
+			self::factory()->post->create( array( 'post_type' => 'post' ) ),
+			self::factory()->post->create( array( 'post_type' => 'post' ) ),
+		);
+		foreach ( $ids as $post_id ) {
+			update_post_meta( $post_id, '_source', 'legacy-duplicate' );
+		}
+
+		$result = $this->repository->reserve_and_resolve( 'post', array( 'key' => '_source', 'value' => 'legacy-duplicate' ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'identity_legacy_conflict', $result->get_error_code() );
+		$this->assertSame( $ids, $result->get_error_data()['candidate_ids'] );
+		$identity = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'legacy-duplicate' ) );
+		$row      = $this->repository->get_reservation( $identity['identity_hash'] );
+		$this->assertSame( 'conflict', $row['state'] );
+		$this->assertStringNotContainsString( 'legacy-duplicate', $row['last_error_message'] );
+	}
+
+	public function test_missing_link_fails_without_allocating_a_second_post(): void {
+		global $wpdb;
+
+		$identity = array( 'key' => '_source', 'value' => 'missing-link' );
+		$first    = $this->repository->reserve_and_resolve( 'post', $identity, 0, 0, $this->shell() );
+		$wpdb->delete( $wpdb->posts, array( 'ID' => $first['post_id'] ), array( '%d' ) );
+		$retry = $this->repository->reserve_and_resolve( 'post', $identity, 0, 0, $this->shell() );
+
+		$this->assertWPError( $retry );
+		$this->assertSame( 'identity_link_invalid', $retry->get_error_code() );
+		$this->assertSame( $first['post_id'], $retry->get_error_data()['post_id'] );
+		$row = $this->repository->get_reservation( $first['identity']['identity_hash'] );
+		$this->assertSame( (string) $first['post_id'], (string) $row['post_id'] );
+	}
+
+	public function test_wrong_post_type_link_fails_without_reallocation(): void {
+		global $wpdb;
+
+		$first = $this->repository->reserve_and_resolve( 'post', array( 'key' => '_source', 'value' => 'wrong-type' ), 0, 0, $this->shell() );
+		$wpdb->update( $wpdb->posts, array( 'post_type' => 'page' ), array( 'ID' => $first['post_id'] ) );
+
+		$retry = $this->repository->reserve_and_resolve( 'post', array( 'key' => '_source', 'value' => 'wrong-type' ), 0, 0, $this->shell() );
+		$this->assertWPError( $retry );
+		$this->assertSame( 'identity_link_invalid', $retry->get_error_code() );
+		$this->assertSame( $first['post_id'], $retry->get_error_data()['post_id'] );
+	}
+
+	public function test_component_mismatch_is_integrity_conflict(): void {
+		global $wpdb;
+
+		$first = $this->repository->reserve_and_resolve( 'post', array( 'key' => '_source', 'value' => 'component-proof' ), 0, 0, $this->shell() );
+		$wpdb->update(
+			$this->repository->get_table_name(),
+			array( 'meta_key_hash' => str_repeat( '0', 64 ) ),
+			array( 'identity_hash' => $first['identity']['identity_hash'] )
+		);
+
+		$retry = $this->repository->reserve_and_resolve( 'post', array( 'key' => '_source', 'value' => 'component-proof' ), 0, 0, $this->shell() );
+		$this->assertWPError( $retry );
+		$this->assertSame( 'identity_integrity_conflict', $retry->get_error_code() );
+	}
+
+	public function test_allocation_failure_rolls_back_shell_but_keeps_reservation(): void {
+		global $wpdb;
+		$logs   = array();
+		$logger = static function ( $level, $message, $context ) use ( &$logs ): void {
+			if ( 'Post identity database operation failed' === $message ) {
+				$logs[] = array( $level, $context );
+			}
+		};
+		add_action( 'datamachine_log', $logger, 10, 3 );
+
+		$repository = new class() extends PostIdentityReservations {
+			protected function link_locked_reservation( string $identity_hash, int $post_id ): bool {
+				unset( $identity_hash, $post_id );
+				return false;
+			}
+		};
+		$before = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->posts}" );
+		$result = $repository->reserve_and_resolve( 'post', array( 'key' => '_source', 'value' => 'rollback' ), 0, 0, $this->shell() );
+		remove_action( 'datamachine_log', $logger, 10 );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'identity_allocation_failed', $result->get_error_code() );
+		$this->assertSame( $before, (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->posts}" ) );
+		$identity = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'rollback' ) );
+		$this->assertSame( 'reserved', $repository->get_reservation( $identity['identity_hash'] )['state'] );
+		$this->assertNotEmpty( $logs );
+		$this->assertSame( 'link_reservation', $logs[0][1]['operation'] );
+		$this->assertSame( $repository->get_table_name(), $logs[0][1]['table'] );
+		$this->assertArrayHasKey( 'error', $logs[0][1] );
+		$this->assertStringNotContainsString( 'rollback', wp_json_encode( $logs ) );
+		$this->assertStringNotContainsString( $identity['identity_hash'], wp_json_encode( $logs ) );
+	}
+
+	public function test_commit_uncertainty_does_not_claim_rollback(): void {
+		global $wpdb;
+
+		$repository = new class() extends PostIdentityReservations {
+			public bool $rolled_back = false;
+
+			protected function commit_transaction(): bool {
+				throw new \RuntimeException( 'Connection result unavailable.' );
+			}
+
+			protected function rollback_transaction(): void {
+				$this->rolled_back = true;
+				parent::rollback_transaction();
+			}
+		};
+		$result = $repository->reserve_and_resolve( 'post', array( 'key' => '_source', 'value' => 'uncertain' ), 0, 0, $this->shell() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'identity_commit_uncertain', $result->get_error_code() );
+		$this->assertTrue( $result->get_error_data()['retryable'] );
+		$this->assertFalse( $repository->rolled_back );
+		$wpdb->query( 'ROLLBACK' );
+	}
+
+	public function test_failure_after_reservation_leaves_retryable_reserved_checkpoint(): void {
+		$repository = new class() extends PostIdentityReservations {
+			protected function resolve_locked(
+				array $identity,
+				int $explicit_post_id = 0,
+				int $slug_fallback_id = 0,
+				array $shell = array()
+			) {
+				unset( $identity, $explicit_post_id, $slug_fallback_id, $shell );
+				return new \WP_Error( 'injected_stop', 'Injected stop after reservation.' );
+			}
+		};
+		$result = $repository->reserve_and_resolve( 'post', array( 'key' => '_source', 'value' => 'reserved-stop' ) );
+
+		$this->assertWPError( $result );
+		$identity = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'reserved-stop' ) );
+		$row      = $repository->get_reservation( $identity['identity_hash'] );
+		$this->assertSame( 'reserved', $row['state'] );
+		$this->assertNull( $row['post_id'] );
+	}
+
+	private function open_mysql_connection(): ?\mysqli {
+		$host   = DB_HOST;
+		$port   = null;
+		$socket = null;
+		if ( preg_match( '/^([^:]+):(\d+)$/', $host, $matches ) ) {
+			$host = $matches[1];
+			$port = (int) $matches[2];
+		} elseif ( preg_match( '/^([^:]+):(.+)$/', $host, $matches ) ) {
+			$host   = $matches[1];
+			$socket = $matches[2];
+		}
+
+		$connection = \mysqli_init();
+		if ( false === $connection || ! @$connection->real_connect( $host, DB_USER, DB_PASSWORD, DB_NAME, $port, $socket ) ) {
+			return null;
+		}
+
+		return $connection;
+	}
+
+	private function shell(): array {
+		return array(
+			'post_author'    => get_current_user_id(),
+			'comment_status' => get_default_comment_status( 'post' ),
+			'ping_status'    => get_default_comment_status( 'post', 'pingback' ),
+			'post_date'      => current_time( 'mysql' ),
+			'post_date_gmt'  => current_time( 'mysql', true ),
+			'guid'           => 'urn:uuid:' . wp_generate_uuid4(),
+		);
+	}
+}

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -49,6 +49,11 @@ function assert_runtime( string $name, bool $condition ): void {
 $GLOBALS['__test_options']      = array();
 $GLOBALS['__test_actions']      = array();
 $GLOBALS['__test_schema_calls'] = array();
+$GLOBALS['__test_identity_table_exists'] = false;
+$GLOBALS['__test_identity_schema_valid'] = false;
+$GLOBALS['__test_identity_create_success'] = true;
+$GLOBALS['__test_identity_create_calls'] = array();
+$GLOBALS['wpdb'] = (object) array( 'prefix' => 'wp_' );
 
 if ( ! function_exists( 'get_option' ) ) {
 	function get_option( $name, $default_value = false ) {
@@ -76,6 +81,7 @@ if ( ! function_exists( 'add_action' ) ) {
 
 $schema_chain = array(
 	'datamachine_migrate_bundle_artifacts_table',
+	'datamachine_migrate_run_metadata_table',
 	'datamachine_migrate_processed_item_claims',
 	'datamachine_migrate_pending_actions_table',
 	'datamachine_migrate_chat_sessions_to_network',
@@ -87,6 +93,41 @@ foreach ( $schema_chain as $fn ) {
 	}
 	$captured = $fn;
 	eval( "function {$fn}() { \$GLOBALS['__test_schema_calls'][] = '{$captured}'; }" );
+}
+
+if ( ! class_exists( '\DataMachine\Core\Database\PostIdentityReservations\PostIdentityReservations' ) ) {
+	eval(
+		'namespace DataMachine\Core\Database\PostIdentityReservations;
+		class PostIdentityReservations {
+			public const SCHEMA_VERSION = 1;
+			public static function create_table(): void {
+				$GLOBALS["__test_identity_create_calls"][] = $GLOBALS["wpdb"]->prefix;
+				if ($GLOBALS["__test_identity_create_success"]) {
+					$GLOBALS["__test_identity_table_exists"] = true;
+					$GLOBALS["__test_identity_schema_valid"] = true;
+				}
+			}
+			public function get_table_name(): string {
+				return $GLOBALS["wpdb"]->prefix . "datamachine_post_identity_reservations";
+			}
+			public function validate_schema() {
+				$GLOBALS["__test_identity_checked_table"] = $this->get_table_name();
+				return $GLOBALS["__test_identity_table_exists"] && $GLOBALS["__test_identity_schema_valid"];
+			}
+		}'
+	);
+}
+
+if ( ! class_exists( '\DataMachine\Core\Database\BaseRepository' ) ) {
+	eval(
+		'namespace DataMachine\Core\Database;
+		class BaseRepository {
+			public static function database_table_exists(string $table_name): bool {
+				$GLOBALS["__test_identity_checked_table"] = $table_name;
+				return $GLOBALS["__test_identity_table_exists"];
+			}
+		}'
+	);
 }
 
 require_once dirname( __DIR__ ) . '/inc/migrations/runtime.php';
@@ -110,6 +151,65 @@ $GLOBALS['__test_options']['datamachine_db_version'] = '0.1.0-stale';
 datamachine_maybe_run_deferred_migrations();
 assert_runtime( 'current schema ensures called when option lags', $schema_chain === $GLOBALS['__test_schema_calls'] );
 assert_runtime( 'option bumped to current DATAMACHINE_VERSION', DATAMACHINE_VERSION === $GLOBALS['__test_options']['datamachine_db_version'] );
+
+echo "\n[identity-schema:1] Option/table mismatch installs and records schema\n";
+$GLOBALS['__test_identity_table_exists'] = false;
+$GLOBALS['__test_identity_schema_valid'] = false;
+$GLOBALS['__test_identity_create_success'] = true;
+$GLOBALS['__test_identity_create_calls'] = array();
+$GLOBALS['__test_options']['datamachine_post_identity_reservations_schema'] = 0;
+datamachine_maybe_install_post_identity_reservations();
+assert_runtime( 'missing table triggers one install', array( 'wp_' ) === $GLOBALS['__test_identity_create_calls'] );
+assert_runtime( 'successful install stores schema version', 1 === $GLOBALS['__test_options']['datamachine_post_identity_reservations_schema'] );
+
+echo "\n[identity-schema:2] Failed install does not advance option\n";
+$GLOBALS['__test_identity_table_exists'] = false;
+$GLOBALS['__test_identity_schema_valid'] = false;
+$GLOBALS['__test_identity_create_success'] = false;
+$GLOBALS['__test_identity_create_calls'] = array();
+$GLOBALS['__test_options']['datamachine_post_identity_reservations_schema'] = 0;
+datamachine_maybe_install_post_identity_reservations();
+assert_runtime( 'failed install was attempted', array( 'wp_' ) === $GLOBALS['__test_identity_create_calls'] );
+assert_runtime( 'failed install leaves option stale', 0 === $GLOBALS['__test_options']['datamachine_post_identity_reservations_schema'] );
+
+echo "\n[identity-schema:3] Matching option and table are idempotent\n";
+$GLOBALS['__test_identity_table_exists'] = true;
+$GLOBALS['__test_identity_schema_valid'] = true;
+$GLOBALS['__test_identity_create_success'] = true;
+$GLOBALS['__test_identity_create_calls'] = array();
+$GLOBALS['__test_options']['datamachine_post_identity_reservations_schema'] = 1;
+datamachine_maybe_install_post_identity_reservations();
+assert_runtime( 'matching option and table skip dbDelta', array() === $GLOBALS['__test_identity_create_calls'] );
+
+echo "\n[identity-schema:4] Matching option with missing table repairs current site\n";
+$GLOBALS['wpdb']->prefix = 'wp_2_';
+$GLOBALS['__test_identity_table_exists'] = false;
+$GLOBALS['__test_identity_schema_valid'] = false;
+$GLOBALS['__test_identity_create_calls'] = array();
+datamachine_maybe_install_post_identity_reservations();
+assert_runtime( 'switched-site prefix is used for install', array( 'wp_2_' ) === $GLOBALS['__test_identity_create_calls'] );
+assert_runtime( 'switched-site table name is checked', 'wp_2_datamachine_post_identity_reservations' === $GLOBALS['__test_identity_checked_table'] );
+$GLOBALS['wpdb']->prefix = 'wp_';
+
+echo "\n[identity-schema:5] Matching option with malformed schema repairs before advancing\n";
+$GLOBALS['__test_identity_table_exists'] = true;
+$GLOBALS['__test_identity_schema_valid'] = false;
+$GLOBALS['__test_identity_create_success'] = true;
+$GLOBALS['__test_identity_create_calls'] = array();
+$GLOBALS['__test_options']['datamachine_post_identity_reservations_schema'] = 1;
+datamachine_maybe_install_post_identity_reservations();
+assert_runtime( 'malformed schema triggers dbDelta repair', array( 'wp_' ) === $GLOBALS['__test_identity_create_calls'] );
+assert_runtime( 'option remains current only after successful validation', 1 === $GLOBALS['__test_options']['datamachine_post_identity_reservations_schema'] && $GLOBALS['__test_identity_schema_valid'] );
+
+echo "\n[identity-schema:6] Failed malformed-schema repair leaves option stale\n";
+$GLOBALS['__test_identity_table_exists'] = true;
+$GLOBALS['__test_identity_schema_valid'] = false;
+$GLOBALS['__test_identity_create_success'] = false;
+$GLOBALS['__test_identity_create_calls'] = array();
+$GLOBALS['__test_options']['datamachine_post_identity_reservations_schema'] = 1;
+datamachine_maybe_install_post_identity_reservations();
+assert_runtime( 'failed malformed repair was attempted', array( 'wp_' ) === $GLOBALS['__test_identity_create_calls'] );
+assert_runtime( 'failed malformed repair resets option stale', 0 === $GLOBALS['__test_options']['datamachine_post_identity_reservations_schema'] );
 
 echo "\n[hook:1] Runtime is hooked before main bootstrap\n";
 $matching_hook = null;

--- a/uninstall.php
+++ b/uninstall.php
@@ -51,6 +51,7 @@ function datamachine_uninstall_site() {
 	delete_option( \DataMachine\Abilities\SettingsAbilities::HANDLER_DEFAULTS_OPTION );
 	delete_option( 'datamachine_agent_ping_callback_token' );
 	delete_option( 'datamachine_page_hook_suffixes' );
+	delete_option( 'datamachine_post_identity_reservations_schema' );
 
 	// Unified auth data.
 	delete_option( 'datamachine_auth_data' );
@@ -69,6 +70,7 @@ function datamachine_uninstall_site() {
 		// datamachine_uninstall_network_tables(), not here — dropping it per-site
 		// would destroy the shared table on the first subsite uninstall.
 		$datamachine_tables_to_drop = array(
+			$wpdb->prefix . 'datamachine_post_identity_reservations',
 			$wpdb->prefix . 'datamachine_processed_items',
 			$wpdb->prefix . 'datamachine_jobs',
 			$wpdb->prefix . 'datamachine_flows',


### PR DESCRIPTION
## Summary
- reserve identity-backed post upserts in a site-scoped InnoDB table before post population
- atomically link each identity to one preallocated draft shell and reuse it across retries
- preserve explicit post ID and legacy identity behavior
- add schema repair, diagnostics, recovery documentation, and an explicit PHPUnit development dependency

## Verification
- migration runtime smoke: 27 assertions passed
- changed-file PHPCS and PHPStan passed
- 46 focused tests now discover and execute after the PHPUnit dependency fix
- local Playground: 13 pass, 1 skip, 32 fail closed because WP Codebox substituted SQLite despite the declared MySQL backend
- MySQL/InnoDB CI is authoritative; runtime mismatch tracked at Automattic/wp-codebox#1986

Refs #2971
Blocks Extra-Chill/data-machine-events#528 and Extra-Chill/extrachill-events#297.