### PR TITLE
fix: bootstrap canonical chat abilities

### DIFF
--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -75,6 +75,7 @@ use DataMachine\Engine\AI\Actions\PendingActionStore;
 use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
 use DataMachine\Abilities\AbilityScopePermissionFilter;
 use DataMachine\Abilities\AgentAbilities;
+use DataMachine\Abilities\ChatAbilities;
 use DataMachine\Core\Content\ContentFormat;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Auth\AgentAccessFilterBridge;
@@ -86,6 +87,7 @@ use DataMachine\Core\PluginSettings;
 add_action( 'plugins_loaded', array( WpAiClientCache::class, 'install' ), 20 );
 AbilityScopePermissionFilter::register();
 ContentFormat::register();
+new ChatAbilities();
 
 add_filter( 'wp_agent_runtime_import_bundle', array( AgentAbilities::class, 'importRuntimeAgentBundle' ), 5, 4 );
 add_filter( 'wp_agent_runtime_run_bundle', array( AgentAbilities::class, 'runRuntimeAgentBundle' ), 10, 4 );

--- a/tests/agents-chat-handler-smoke.php
+++ b/tests/agents-chat-handler-smoke.php
@@ -74,9 +74,11 @@ $root           = dirname( __DIR__ );
 $handler_source = (string) file_get_contents( $root . '/inc/Abilities/Chat/AgentsChatHandler.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Source smoke fixture.
 $orchestrator   = (string) file_get_contents( $root . '/inc/Api/Chat/ChatOrchestrator.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Source smoke fixture.
 $chat_abilities = (string) file_get_contents( $root . '/inc/Abilities/ChatAbilities.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Source smoke fixture.
+$bootstrap      = (string) file_get_contents( $root . '/inc/bootstrap.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Source smoke fixture.
 $chat_api       = (string) file_get_contents( $root . '/inc/Api/Chat/Chat.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Source smoke fixture.
 
 $assert( str_contains( $chat_abilities, 'new AgentsChatHandler();' ), 'ChatAbilities registers Data Machine as the Agents API chat handler' );
+$assert( str_contains( $bootstrap, 'new ChatAbilities();' ), 'Plugin bootstrap initializes canonical chat abilities' );
 $assert( str_contains( $handler_source, "register_chat_handler( array( $" . "this, 'execute' ) )" ), 'AgentsChatHandler attaches to canonical Agents API chat handler seam' );
 $assert( ! str_contains( $handler_source, "wp_agent_chat_handler" ), 'AgentsChatHandler no longer falls back to legacy chat handler filter' );
 $assert( str_contains( $handler_source, 'ChatOrchestrator::processChat(' ), 'AgentsChatHandler owns the single ChatOrchestrator runtime call' );


### PR DESCRIPTION
## Summary

- initialize `ChatAbilities` during normal plugin bootstrap so Data Machine registers its canonical chat handler and permission adapter
- retain the existing idempotent facade guard
- cover the production bootstrap path in the canonical chat smoke test

## Verification

- `php tests/agents-chat-handler-smoke.php` (28 passed)
- PHPCS on changed files
- verified in Roadie multisite E2E run `53842385-d805-46e9-8080-a6a11539a6de`

Closes #2968