### PR TITLE
fix: accept worker recovery negation flag

### DIFF
--- a/inc/Cli/Commands/WorkerCommand.php
+++ b/inc/Cli/Commands/WorkerCommand.php
@@ -68,8 +68,8 @@ class WorkerCommand extends BaseCommand {
 	 * default: 2
 	 * ---
 	 *
-	 * [--no-recover-stuck]
-	 * : Skip stuck-job recovery.
+	 * [--[no-]recover-stuck]
+	 * : Run stuck-job recovery before draining. Enabled by default; use --no-recover-stuck to skip it.
 	 *
 	 * [--stop-on-pending-actions]
 	 * : Stop when pending approval actions exist.
@@ -138,7 +138,7 @@ class WorkerCommand extends BaseCommand {
 			'drain_time_limit'        => isset( $assoc_args['drain-time-limit'] ) ? max( 1, (int) $assoc_args['drain-time-limit'] ) : 120,
 			'sleep'                   => isset( $assoc_args['sleep'] ) ? max( 0, (int) $assoc_args['sleep'] ) : 30,
 			'stuck_timeout'           => isset( $assoc_args['stuck-timeout'] ) ? max( 1, (int) $assoc_args['stuck-timeout'] ) : 2,
-			'recover_stuck'           => ! isset( $assoc_args['no-recover-stuck'] ),
+			'recover_stuck'           => \WP_CLI\Utils\get_flag_value( $assoc_args, 'recover-stuck', true ),
 			'stop_on_pending_actions' => isset( $assoc_args['stop-on-pending-actions'] ),
 			'max_passes'              => isset( $assoc_args['max-passes'] ) ? max( 0, (int) $assoc_args['max-passes'] ) : 0,
 			'stop_before_timeout'     => isset( $assoc_args['stop-before-timeout'] ) ? max( 0, (int) $assoc_args['stop-before-timeout'] ) : 30,

--- a/tests/worker-no-recover-stuck-cli-smoke.php
+++ b/tests/worker-no-recover-stuck-cli-smoke.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Worker negatable recovery flag contract smoke test.
+ */
+
+$source = (string) file_get_contents( __DIR__ . '/../inc/Cli/Commands/WorkerCommand.php' );
+$passes = 0;
+$failures = 0;
+
+$assert = static function ( string $name, bool $condition ) use ( &$passes, &$failures ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+
+	++$failures;
+	echo "  [FAIL] {$name}\n";
+};
+
+echo "=== worker-no-recover-stuck-cli-smoke ===\n";
+
+$assert( 'worker declares canonical negatable recovery flag', str_contains( $source, '[--[no-]recover-stuck]' ) );
+$assert( 'worker reads normalized positive recovery key', str_contains( $source, "get_flag_value( \$assoc_args, 'recover-stuck', true )" ) );
+$assert( 'worker does not inspect an impossible negative key', ! str_contains( $source, "\$assoc_args['no-recover-stuck']" ) );
+$assert( 'help documents recovery as enabled by default', str_contains( $source, 'Enabled by default; use --no-recover-stuck to skip it.' ) );
+
+echo "\nWorker recovery flag contract: {$passes} passed, {$failures} failed.\n";
+exit( $failures > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary
- declare worker recovery as a canonical WP-CLI negatable flag
- read the normalized positive option key with recovery enabled by default
- lock the synopsis and option mapping with a focused regression smoke

## Verification
- worker flag contract smoke: 4/4
- bounded recovery smoke: 16/16
- worker lock smoke: 33 assertions
- changed-scope PHPCS, PHPStan level 7, syntax, and diff checks pass

Closes #2975