### PR TITLE
fix: defer disposition claims to terminal lifecycle

### DIFF
--- a/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
+++ b/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
@@ -3,9 +3,8 @@
  * Fetch Item Disposition Tool
  *
  * Handler tool that allows the pipeline agent to explicitly reject or defer
- * a fetched source item. Rejections mark the source as processed so it will
- * not be refetched; deferrals release the source claim so the item remains
- * eligible for a later retry.
+ * a fetched source item. The terminal job lifecycle completes rejected claims
+ * or releases deferred claims after the disposition status is committed.
  *
  * This provides a safety net when keyword exclusions or other filters
  * miss items that shouldn't be processed (e.g., non-music events).
@@ -45,7 +44,7 @@ class FetchItemDispositionTool {
 	}
 
 	/**
-	 * Mark the current source item as rejected/processed.
+	 * Mark the current source item as rejected.
 	 *
 	 * @param array $parameters Tool parameters from AI.
 	 * @param array $tool_def Tool definition with handler_config.
@@ -95,43 +94,6 @@ class FetchItemDispositionTool {
 		$source_type     = $engine->get( 'source_type' );
 		$flow_step_id    = $this->resolveFetchFlowStepId( $engine ) ?? ( $parameters['flow_step_id'] ?? $engine->get( 'flow_step_id' ) );
 		$diagnostic      = $this->buildDispositionDiagnostic( self::DISPOSITION_REJECT_SOURCE, $tool_name, $reason, $flow_step_id, $item_identifier, $source_type, $parameters );
-
-		// Mark item as processed so it won't be refetched
-		if ( $flow_step_id && $item_identifier && $source_type ) {
-			do_action(
-				'datamachine_mark_item_processed',
-				$flow_step_id,
-				$source_type,
-				$item_identifier,
-				$job_id
-			);
-
-			do_action(
-				'datamachine_log',
-				'info',
-				'FetchItemDispositionTool: Source rejected and marked as processed',
-				array(
-					'job_id'          => $job_id,
-					'flow_step_id'    => $flow_step_id,
-					'item_identifier' => $item_identifier,
-					'source_type'     => $source_type,
-					'reason'          => $reason,
-				)
-			);
-		} else {
-			do_action(
-				'datamachine_log',
-				'warning',
-				'FetchItemDispositionTool: Could not mark rejected source as processed - missing identifiers',
-				array(
-					'job_id'          => $job_id,
-					'flow_step_id'    => $flow_step_id,
-					'item_identifier' => $item_identifier,
-					'source_type'     => $source_type,
-					'reason'          => $reason,
-				)
-			);
-		}
 
 		// Set job status override for engine to use at completion
 		$status = JobStatus::agentSkipped( 'source-rejected' );
@@ -188,7 +150,7 @@ class FetchItemDispositionTool {
 	}
 
 	/**
-	 * Release the current source item claim without marking it processed.
+	 * Defer the current source item without marking it processed.
 	 *
 	 * @param array $parameters Tool parameters from AI.
 	 * @param array $tool_def Tool definition with handler_config.
@@ -236,12 +198,7 @@ class FetchItemDispositionTool {
 		$item_identifier = $engine->get( 'item_identifier' );
 		$source_type     = $engine->get( 'source_type' );
 		$flow_step_id    = $this->resolveFetchFlowStepId( $engine ) ?? ( $parameters['flow_step_id'] ?? $engine->get( 'flow_step_id' ) );
-		$released        = null;
 		$diagnostic      = $this->buildDispositionDiagnostic( self::DISPOSITION_DEFER_ITEM, $tool_name, $reason, $flow_step_id, $item_identifier, $source_type, $parameters );
-
-		if ( $flow_step_id && $item_identifier && $source_type ) {
-			$released = ( new \DataMachine\Core\Database\ProcessedItems\ProcessedItems() )->release_claim( $flow_step_id, (string) $source_type, (string) $item_identifier );
-		}
 
 		$status = JobStatus::failed( 'item-deferred' );
 		datamachine_merge_engine_data(
@@ -277,14 +234,13 @@ class FetchItemDispositionTool {
 		do_action(
 			'datamachine_log',
 			'info',
-			'FetchItemDispositionTool: Item deferred and source claim released',
+			'FetchItemDispositionTool: Item deferred for terminal claim release',
 			array(
 				'job_id'          => $job_id,
 				'flow_step_id'    => $flow_step_id,
 				'item_identifier' => $item_identifier,
 				'source_type'     => $source_type,
 				'reason'          => $reason,
-				'released'        => $released,
 				'status'          => $status->toString(),
 			)
 		);
@@ -297,7 +253,6 @@ class FetchItemDispositionTool {
 			'tool_name'       => $tool_name,
 			'disposition'     => self::DISPOSITION_DEFER_ITEM,
 			'reason'          => $reason,
-			'released'        => $released,
 		);
 	}
 

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -18,6 +18,7 @@ use DataMachine\Core\Database\TrackedItems\TrackedItems;
 use DataMachine\Core\ExecutionContext;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\RunMetrics;
+use DataMachine\Core\Steps\Fetch\Tools\FetchItemDispositionTool;
 use DataMachine\Engine\Actions\Handlers\FailJobHandler;
 use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
 use Closure;
@@ -305,6 +306,59 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertSame( JobStatus::COMPLETED, $owner_result['status'] );
 		$this->assertSame( 1, $callback_count );
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'concurrent-terminal-id' ) );
+	}
+
+	public function test_reject_source_defers_owned_claim_completion_to_terminal_lifecycle(): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$claim  = $this->claim( 'rejected-by-agent', $job_id, 'rejected-revision' );
+		datamachine_set_engine_data(
+			$job_id,
+			array_merge(
+				$this->legacyEngineData( 'rejected-by-agent' ),
+				array( ProcessedItems::CLAIM_METADATA_KEY => $claim )
+			)
+		);
+
+		$result = ( new FetchItemDispositionTool() )->handle_tool_call(
+			array(
+				'job_id' => $job_id,
+				'reason' => 'not an event',
+			),
+			array( 'disposition' => 'reject_source' )
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertTrue( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'rejected-by-agent' ) );
+		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::agentSkipped( 'source-rejected' )->toString() ) );
+		$this->assertSame( 'rejected-revision', $this->tracked->get( self::NAMESPACE, 'rejected-by-agent' )['source_revision'] );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'rejected-by-agent' ) );
+		$this->assertStringNotContainsString( 'item_claim_completion_failed', $this->jobs->get_job( $job_id )['status'] );
+	}
+
+	public function test_defer_item_defers_owned_claim_release_to_terminal_lifecycle(): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$claim  = $this->claim( 'deferred-by-agent', $job_id, 'deferred-revision' );
+		datamachine_set_engine_data(
+			$job_id,
+			array_merge(
+				$this->legacyEngineData( 'deferred-by-agent' ),
+				array( ProcessedItems::CLAIM_METADATA_KEY => $claim )
+			)
+		);
+
+		$result = ( new FetchItemDispositionTool() )->handle_tool_call(
+			array(
+				'job_id' => $job_id,
+				'reason' => 'temporary tool failure',
+			),
+			array( 'disposition' => 'defer_item' )
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertTrue( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'deferred-by-agent' ) );
+		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::failed( 'item-deferred' )->toString() ) );
+		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'deferred-by-agent' ) );
+		$this->assertIsArray( $this->context( 'deferred-retry-step', $job_id + 3000 )->claimItemOwnership( self::SCOPE, 'deferred-by-agent' ) );
 	}
 
 	public function test_interleaved_status_write_before_terminal_cas_rolls_back_and_recovers(): void {

--- a/tests/fetch-item-dispositions-smoke.php
+++ b/tests/fetch-item-dispositions-smoke.php
@@ -158,7 +158,7 @@ namespace {
 		),
 	);
 
-	echo "Case 1: reject_source marks processed\n";
+	echo "Case 1: reject_source defers claim completion to terminal lifecycle\n";
 	$reject = $tool->handle_tool_call(
 		array(
 			'job_id'       => 1814,
@@ -171,7 +171,7 @@ namespace {
 	);
 	assert_fetch_disposition_smoke( 'reject_source succeeds', true === ( $reject['success'] ?? false ) );
 	assert_fetch_disposition_smoke( 'reject_source reports explicit tool name', 'reject_source' === ( $reject['tool_name'] ?? '' ) );
-	assert_fetch_disposition_smoke( 'reject_source marks fetch step processed', array( 'fetch-step_7', 'rss', 'source-123', 1814 ) === ( $GLOBALS['fetch_disposition_smoke_processed'][0] ?? null ) );
+	assert_fetch_disposition_smoke( 'reject_source does not eagerly mark the claim processed', array() === $GLOBALS['fetch_disposition_smoke_processed'] );
 	assert_fetch_disposition_smoke( 'reject_source sets source-rejected status', 'agent_skipped - source-rejected' === ( $GLOBALS['fetch_disposition_smoke_engine'][1814]['job_status'] ?? '' ) );
 	$reject_diagnostic = $GLOBALS['fetch_disposition_smoke_engine'][1814]['disposition_diagnostic'] ?? array();
 	assert_fetch_disposition_smoke( 'reject_source persists disposition diagnostic', 'reject_source' === ( $reject_diagnostic['disposition'] ?? '' ) && 'duplicate-source' === ( $reject_diagnostic['reason'] ?? '' ) );
@@ -179,7 +179,7 @@ namespace {
 	assert_fetch_disposition_smoke( 'reject_source diagnostic includes packet count and bounded excerpt', 1 === ( $reject_diagnostic['packet_count'] ?? 0 ) && 1200 === ( $reject_diagnostic['excerpt_limit'] ?? 0 ) && 1200 >= strlen( $reject_diagnostic['excerpt'] ?? '' ) );
 	assert_fetch_disposition_smoke( 'reject_source diagnostic redacts obvious secrets', ! str_contains( $reject_diagnostic['excerpt'] ?? '', 'secret-value' ) && ! str_contains( $reject_diagnostic['source_url'] ?? '', 'secret-value' ) );
 
-	echo "Case 2: defer_item releases claim without marking processed\n";
+	echo "Case 2: defer_item defers claim release to terminal lifecycle\n";
 	$GLOBALS['fetch_disposition_smoke_processed'] = array();
 	$defer = $tool->handle_tool_call(
 		array(
@@ -193,7 +193,7 @@ namespace {
 	);
 	assert_fetch_disposition_smoke( 'defer_item succeeds', true === ( $defer['success'] ?? false ) );
 	assert_fetch_disposition_smoke( 'defer_item reports explicit tool name', 'defer_item' === ( $defer['tool_name'] ?? '' ) );
-	assert_fetch_disposition_smoke( 'defer_item releases fetch step claim', array( 'fetch-step_7', 'rss', 'source-123' ) === ( $GLOBALS['fetch_disposition_smoke_released'][0] ?? null ) );
+	assert_fetch_disposition_smoke( 'defer_item does not eagerly release the claim', array() === $GLOBALS['fetch_disposition_smoke_released'] );
 	assert_fetch_disposition_smoke( 'defer_item does not mark processed', array() === $GLOBALS['fetch_disposition_smoke_processed'] );
 	assert_fetch_disposition_smoke( 'tool-error deferral remains retry eligible', 'failed - item-deferred' === ( $GLOBALS['fetch_disposition_smoke_engine'][1815]['job_status'] ?? '' ) );
 	$defer_diagnostic = $GLOBALS['fetch_disposition_smoke_engine'][1815]['disposition_diagnostic'] ?? array();
@@ -219,7 +219,7 @@ namespace {
 		array( 'disposition' => 'reject_source' )
 	);
 	assert_fetch_disposition_smoke( 'reject_source succeeds with persisted engine data', true === ( $reject_hydrated['success'] ?? false ) );
-	assert_fetch_disposition_smoke( 'persisted engine data marks processed source identity', array( 'fetch-step_8', 'mcp', 'source-456', 1816 ) === ( $GLOBALS['fetch_disposition_smoke_processed'][0] ?? null ) );
+	assert_fetch_disposition_smoke( 'persisted engine data still defers claim completion', array() === $GLOBALS['fetch_disposition_smoke_processed'] );
 
 	echo "Case 2c: dispositions are first-write-wins (#2609)\n";
 	$GLOBALS['fetch_disposition_smoke_processed'] = array();
@@ -260,11 +260,12 @@ namespace {
 
 	echo "Case 2d: disposition tools declare terminal completion signal (#2609)\n";
 	$fetch_handler_src = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/FetchHandler.php' );
-	assert_fetch_disposition_smoke( 'both disposition tool definitions declare runtime completion_signal terminal', 2 === substr_count( $fetch_handler_src, "'runtime'                 => array( 'completion_signal' => 'terminal' )" ) );
+	assert_fetch_disposition_smoke( 'both disposition tool definitions declare runtime completion_signal terminal', 2 === substr_count( $fetch_handler_src, "'completion_signal' => 'terminal'" ) );
 
 	echo "Case 3: production tool surface exposes positive affordances\n";
 	$fetch_handler = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/FetchHandler.php' );
-	$execute_step  = file_get_contents( __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php' );
+	$disposition   = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php' );
+	$lifecycle     = file_get_contents( __DIR__ . '/../inc/Engine/Actions/Handlers/StepLifecycleHandler.php' );
 	assert_fetch_disposition_smoke( 'fetch surface exposes reject_source', str_contains( $fetch_handler, "'reject_source'" ) );
 	assert_fetch_disposition_smoke( 'fetch surface exposes defer_item', str_contains( $fetch_handler, "'defer_item'" ) );
 	assert_fetch_disposition_smoke( 'fetch surface avoids legacy skip tool registration', ! str_contains( $fetch_handler, "'skip_item'" ) );
@@ -273,7 +274,7 @@ namespace {
 	assert_fetch_disposition_smoke( 'fetch disposition schemas avoid property-level required flags', ! str_contains( $fetch_handler, "'required'    => true" ) );
 	assert_fetch_disposition_smoke( 'reject_source describes reasoned content/source rejection', str_contains( $fetch_handler, 'reasoned content/source evaluation' ) );
 	assert_fetch_disposition_smoke( 'defer_item describes safe completion and retry eligibility', str_contains( $fetch_handler, 'cannot safely complete processing now' ) && str_contains( $fetch_handler, 'remain eligible' ) );
-	assert_fetch_disposition_smoke( 'normal completion still marks processed', str_contains( $execute_step, '$this->markCompletedItemProcessed( $job_id );' ) && str_contains( $execute_step, 'JobStatus::COMPLETED' ) );
+	assert_fetch_disposition_smoke( 'terminal lifecycle owns claim completion and release', ! str_contains( $disposition, 'datamachine_mark_item_processed' ) && ! str_contains( $disposition, 'release_claim(' ) && str_contains( $lifecycle, 'complete_owned_claim_in_transaction' ) && str_contains( $lifecycle, 'release_owned_claim(' ) );
 
 	echo "\nFetch item dispositions smoke complete: {$total} assertions, {$failed} failures.\n";
 	if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary
- stop `reject_source` and `defer_item` from mutating owned claims before terminal job commit
- delegate completion and release to the token-fenced `StepLifecycleHandler`
- add behavioral coverage for rejection completion, deferral release, retry reacquisition, and the production failure signature

Closes #2978.

## Production Evidence
The London burst produced 17 jobs where `reject_source` eagerly changed the row to `processed` and cleared its claim token before terminalization. The owner-safe terminal lifecycle then correctly rejected the missing token and replaced `agent_skipped - source-rejected` with `failed - item_claim_completion_failed`.

## Verification
- `php tests/fetch-item-dispositions-smoke.php` (38 assertions)
- changed-path PHPCS
- Homeboy lint: no new findings
- Homeboy real-WordPress smoke: 1 passed
- independent review: no findings

The Codebox PHPUnit runner could not start because its bundled PHPUnit is missing `PHPUnit\\Runner\\DefaultTestResultCache`; no test assertion ran in that failed infrastructure attempt.