### PR TITLE
fix: recover AI continuation scheduling failures

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -900,6 +900,19 @@ class ExecuteStepAbility {
 			);
 		}
 
+		if ( 'blocked' === ( $execution_result['status'] ?? '' ) ) {
+			$current_job    = $this->db_jobs->get_job( $job_id );
+			$current_status = is_array( $current_job ) ? (string) ( $current_job['status'] ?? '' ) : '';
+			if ( ! JobStatus::isStatusFinal( $current_status ) ) {
+				return array(
+					'success'      => true,
+					'step_success' => false,
+					'outcome'      => 'blocked',
+					'reason'       => $execution_result['reason'] ?? 'blocked',
+				);
+			}
+		}
+
 		$prior_status = $this->getPriorTerminalStatus( $job_id );
 		if ( null !== $prior_status ) {
 			do_action(

--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -184,12 +184,12 @@ class ScheduleNextStepAbility {
 					'job_id'       => $job_id,
 					'flow_step_id' => $flow_step_id,
 					'action_id'    => $action_id,
-					'success'      => ( false !== $action_id ),
+					'success'      => is_numeric( $action_id ) && (int) $action_id > 0,
 				)
 			);
 		}
 
-		if ( false === $action_id ) {
+		if ( ! is_numeric( $action_id ) || (int) $action_id <= 0 ) {
 			$this->failScheduling(
 				$job_id,
 				$flow_step_id,
@@ -199,7 +199,7 @@ class ScheduleNextStepAbility {
 		}
 
 		return array(
-			'success'   => false !== $action_id,
+			'success'   => is_numeric( $action_id ) && (int) $action_id > 0,
 			'action_id' => $action_id,
 		);
 	}

--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -162,9 +162,9 @@ class ScheduleNextStepAbility {
 			'job_id'       => $job_id,
 			'flow_step_id' => $flow_step_id,
 		);
-		$job = $this->db_jobs->get_job( $job_id );
+		$job         = $this->db_jobs->get_job( $job_id );
 		if ( 'direct' === (string) ( $job['flow_id'] ?? '' ) && (int) ( $job['operation_generation'] ?? 0 ) > 0 ) {
-			$action_args['operation_generation'] = (int) $job['operation_generation'];
+			$action_args['operation_generation']  = (int) $job['operation_generation'];
 			$action_args['operation_claim_token'] = (string) ( $job['operation_claim_token'] ?? '' );
 		}
 

--- a/inc/Core/JobRetryPolicy.php
+++ b/inc/Core/JobRetryPolicy.php
@@ -112,7 +112,7 @@ class JobRetryPolicy {
 			'flow_step_id' => $flow_step_id,
 		);
 		if ( 'direct' === (string) ( $job['flow_id'] ?? '' ) && (int) ( $job['operation_generation'] ?? 0 ) > 0 ) {
-			$action_args['operation_generation'] = (int) $job['operation_generation'];
+			$action_args['operation_generation']  = (int) $job['operation_generation'];
 			$action_args['operation_claim_token'] = (string) ( $job['operation_claim_token'] ?? '' );
 		}
 

--- a/inc/Core/JobRetryPolicy.php
+++ b/inc/Core/JobRetryPolicy.php
@@ -57,6 +57,7 @@ class JobRetryPolicy {
 		$max_attempts = max( 1, (int) ( $policy['max_attempts'] ?? self::DEFAULT_MAX_ATTEMPTS ) );
 
 		if ( empty( $policy['retryable'] ) ) {
+			self::clearPendingRetryOwnership( $job_id );
 			return array(
 				'retried'      => false,
 				'exhausted'    => false,
@@ -67,6 +68,7 @@ class JobRetryPolicy {
 		}
 
 		if ( $attempt >= $max_attempts ) {
+			self::clearPendingRetryOwnership( $job_id );
 			self::recordPoisonItem( $job_id, $reason, $context_data, $engine_data, $attempt, $max_attempts );
 
 			return array(
@@ -95,6 +97,7 @@ class JobRetryPolicy {
 		}
 
 		if ( '' === $flow_step_id ) {
+			self::clearPendingRetryOwnership( $job_id );
 			return array(
 				'retried'      => false,
 				'exhausted'    => false,
@@ -120,7 +123,8 @@ class JobRetryPolicy {
 			'data-machine'
 		);
 
-		if ( false === $action_id ) {
+		if ( ! is_numeric( $action_id ) || (int) $action_id <= 0 ) {
+			self::clearPendingRetryOwnership( $job_id );
 			return array(
 				'retried'      => false,
 				'exhausted'    => false,
@@ -159,6 +163,22 @@ class JobRetryPolicy {
 			'next_retry_at' => gmdate( 'c', $timestamp ),
 			'retry_after'   => $delay_seconds,
 			'retry_class'   => $policy['retry_class'] ?? 'generic',
+		);
+	}
+
+	/** Clear scheduler ownership metadata before a terminal failure path. */
+	private static function clearPendingRetryOwnership( int $job_id ): void {
+		EngineData::mutate(
+			$job_id,
+			static function ( array $engine ): ?array {
+				if ( empty( $engine['retry']['next_retry_at'] ) ) {
+					return null;
+				}
+
+				unset( $engine['retry']['next_retry_at'] );
+				return $engine;
+			},
+			'retry_schedule_ownership_cleared'
 		);
 	}
 

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -15,6 +15,7 @@ use DataMachine\Core\Steps\AI\ToolPolicy\PipelineToolPolicyArgs;
 use DataMachine\Core\Steps\StepTypeRegistrationTrait;
 use DataMachine\Core\Steps\QueueableTrait;
 use DataMachine\Engine\AI\AIConcurrencyBackpressure;
+use DataMachine\Engine\AI\AIConcurrencyScheduleFailure;
 use DataMachine\Engine\AI\ConversationManager;
 use DataMachine\Engine\AI\DataPacketPromptProjector;
 use DataMachine\Engine\AI\PipelineAIConcurrencyLease;
@@ -757,63 +758,14 @@ class AIStep extends Step {
 		$action_id       = (int) $schedule_result['action_id'];
 
 		if ( empty( $schedule_result['success'] ) || $action_id <= 0 ) {
-			$released = AIConcurrencyBackpressure::releaseUnscheduledGeneration(
+			AIConcurrencyScheduleFailure::handle(
 				$this->job_id,
 				$this->flow_step_id,
+				$provider_name,
 				$resume_generation,
-				(string) $claim['token']
-			);
-			if ( ! $released ) {
-				$execution_state = AIConcurrencyBackpressure::generationExecutionState( $this->job_id, $this->flow_step_id, $resume_generation, (string) $claim['token'] );
-				if ( 'scheduled' === $execution_state ) {
-					( new Jobs() )->update_job_status( $this->job_id, 'pending' );
-				}
-				do_action(
-					'datamachine_log',
-					'' === $execution_state ? 'error' : 'info',
-					'' === $execution_state
-						? 'AI continuation scheduling failed and generation ownership could not be released'
-						: 'AI continuation scheduling raced existing generation execution',
-					array(
-						'job_id'            => $this->job_id,
-						'flow_step_id'      => $this->flow_step_id,
-						'resume_generation' => $resume_generation,
-						'execution_state'   => $execution_state,
-						'scheduler'         => $schedule_result,
-					)
-				);
-				return;
-			}
-			$contention_data['state']           = 'deferred';
-			$contention_data['terminal_reason'] = 'ai_concurrency_defer_schedule_failed';
-			$contention_data['next_retry_at']   = null;
-			$contention_data['action_id']       = null;
-			$contention_data['scheduler']       = array(
-				'attempts'      => (int) ( $schedule_result['attempts'] ?? 0 ),
-				'error_message' => (string) ( $schedule_result['error_message'] ?? '' ),
-				'claim_released' => $released,
-			);
-			EngineData::mutate(
-				$this->job_id,
-				static function ( array $engine ) use ( $contention_data ): array {
-					$engine['ai_concurrency_throttle'] = $contention_data;
-					return $engine;
-				},
-				'ai_concurrency_defer_schedule_failed'
-			);
-			do_action(
-				'datamachine_fail_job',
-				$this->job_id,
-				'ai_concurrency_defer_schedule_failed',
-				array(
-					'flow_step_id'    => $this->flow_step_id,
-					'ai_provider'     => $provider_name,
-					'retryable'       => $released,
-					'resume_generation' => $resume_generation,
-					'scheduler_attempts' => (int) ( $schedule_result['attempts'] ?? 0 ),
-					'error_message'   => (string) ( $schedule_result['error_message'] ?? '' ),
-					'claim_released'  => $released,
-				)
+				(string) $claim['token'],
+				$contention_data,
+				$schedule_result
 			);
 			return;
 		}

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -225,7 +225,11 @@ class AIStep extends Step {
 
 		if ( empty( $lease_result['acquired'] ) ) {
 			$this->deferForAIConcurrency( $provider_name, $lease_result );
-			return array();
+			return array(
+				'status'  => 'blocked',
+				'packets' => array(),
+				'reason'  => 'ai_concurrency_deferred',
+			);
 		}
 
 		$this->resolveAIConcurrencyContention();
@@ -753,22 +757,79 @@ class AIStep extends Step {
 		$action_id       = (int) $schedule_result['action_id'];
 
 		if ( empty( $schedule_result['success'] ) || $action_id <= 0 ) {
-			$contention_data['state']           = 'stranded';
+			$released = AIConcurrencyBackpressure::releaseUnscheduledGeneration(
+				$this->job_id,
+				$this->flow_step_id,
+				$resume_generation,
+				(string) $claim['token']
+			);
+			if ( ! $released ) {
+				$execution_state = AIConcurrencyBackpressure::generationExecutionState( $this->job_id, $this->flow_step_id, $resume_generation, (string) $claim['token'] );
+				if ( 'scheduled' === $execution_state ) {
+					( new Jobs() )->update_job_status( $this->job_id, 'pending' );
+				}
+				do_action(
+					'datamachine_log',
+					'' === $execution_state ? 'error' : 'info',
+					'' === $execution_state
+						? 'AI continuation scheduling failed and generation ownership could not be released'
+						: 'AI continuation scheduling raced existing generation execution',
+					array(
+						'job_id'            => $this->job_id,
+						'flow_step_id'      => $this->flow_step_id,
+						'resume_generation' => $resume_generation,
+						'execution_state'   => $execution_state,
+						'scheduler'         => $schedule_result,
+					)
+				);
+				return;
+			}
+			$contention_data['state']           = 'deferred';
 			$contention_data['terminal_reason'] = 'ai_concurrency_defer_schedule_failed';
 			$contention_data['next_retry_at']   = null;
-			datamachine_merge_engine_data( $this->job_id, array( 'ai_concurrency_throttle' => $contention_data ) );
-			( new Jobs() )->complete_job( $this->job_id, 'cancelled - ai_concurrency_defer_schedule_failed' );
+			$contention_data['action_id']       = null;
+			$contention_data['scheduler']       = array(
+				'attempts'      => (int) ( $schedule_result['attempts'] ?? 0 ),
+				'error_message' => (string) ( $schedule_result['error_message'] ?? '' ),
+				'claim_released' => $released,
+			);
+			EngineData::mutate(
+				$this->job_id,
+				static function ( array $engine ) use ( $contention_data ): array {
+					$engine['ai_concurrency_throttle'] = $contention_data;
+					return $engine;
+				},
+				'ai_concurrency_defer_schedule_failed'
+			);
+			do_action(
+				'datamachine_fail_job',
+				$this->job_id,
+				'ai_concurrency_defer_schedule_failed',
+				array(
+					'flow_step_id'    => $this->flow_step_id,
+					'ai_provider'     => $provider_name,
+					'retryable'       => $released,
+					'resume_generation' => $resume_generation,
+					'scheduler_attempts' => (int) ( $schedule_result['attempts'] ?? 0 ),
+					'error_message'   => (string) ( $schedule_result['error_message'] ?? '' ),
+					'claim_released'  => $released,
+				)
+			);
 			return;
 		}
-		AIConcurrencyBackpressure::recordScheduledAction(
-			$this->job_id,
-			$this->flow_step_id,
-			$resume_generation,
-			(string) $claim['token'],
-			$action_id
-		);
+		if ( 'in-progress' !== (string) ( $schedule_result['action_status'] ?? '' ) ) {
+			AIConcurrencyBackpressure::recordScheduledAction(
+				$this->job_id,
+				$this->flow_step_id,
+				$resume_generation,
+				(string) $claim['token'],
+				$action_id
+			);
 
-		( new Jobs() )->update_job_status( $this->job_id, 'pending' );
+			( new Jobs() )->update_job_status( $this->job_id, 'pending' );
+		} else {
+			return;
+		}
 
 		datamachine_merge_engine_data(
 			$this->job_id,

--- a/inc/Engine/AI/AIConcurrencyBackpressure.php
+++ b/inc/Engine/AI/AIConcurrencyBackpressure.php
@@ -16,6 +16,7 @@ class AIConcurrencyBackpressure {
 
 	private const RESUME_GROUP_PREFIX = 'data-machine-ai-resume-';
 	private const OWNERSHIP_KEY       = 'ai_concurrency_resume_ownership';
+	private const SCHEDULE_ATTEMPTS   = 3;
 
 	/**
 	 * Resolve the next durable contention state.
@@ -62,39 +63,75 @@ class AIConcurrencyBackpressure {
 	 * Schedule one unique continuation, resolving a zero return only when the
 	 * scheduler can prove that an equivalent pending action won the race.
 	 *
-	 * @return array{success:bool,action_id:int,reused:bool}
+	 * @return array{success:bool,action_id:int,action_status:string,reused:bool,attempts:int,retryable:bool,error_message:string}
 	 */
 	public static function scheduleContinuation( int $timestamp, array $args ): array {
 		if ( ! function_exists( 'as_schedule_single_action' ) ) {
 			return array(
-				'success'   => false,
-				'action_id' => 0,
-				'reused'    => false,
+				'success'       => false,
+				'action_id'     => 0,
+				'action_status' => '',
+				'reused'        => false,
+				'attempts'      => 0,
+				'retryable'     => true,
+				'error_message' => 'Action Scheduler is unavailable.',
 			);
 		}
 
-		$group     = self::continuationGroup( $args );
-		$scheduled = as_schedule_single_action(
-			$timestamp,
-			self::RESUME_HOOK,
-			$args,
-			$group,
-			true
-		);
-		$action_id = is_numeric( $scheduled ) ? (int) $scheduled : 0;
-		if ( $action_id > 0 ) {
-			return array(
-				'success'   => true,
-				'action_id' => $action_id,
-				'reused'    => false,
+		$group         = self::continuationGroup( $args );
+		$error_message = '';
+		for ( $attempt = 1; $attempt <= self::SCHEDULE_ATTEMPTS; ++$attempt ) {
+			$scheduled = as_schedule_single_action(
+				$timestamp,
+				self::RESUME_HOOK,
+				$args,
+				$group,
+				true
 			);
+			$action_id = is_numeric( $scheduled ) ? (int) $scheduled : 0;
+			if ( $action_id > 0 ) {
+				return array(
+					'success'       => true,
+					'action_id'     => $action_id,
+					'action_status' => 'pending',
+					'reused'        => false,
+					'attempts'      => $attempt,
+					'retryable'     => false,
+					'error_message' => '',
+				);
+			}
+
+			global $wpdb;
+			if ( isset( $wpdb ) && is_string( $wpdb->last_error ?? null ) && '' !== $wpdb->last_error ) {
+				$error_message = $wpdb->last_error;
+			}
+
+			$active = self::activeContinuation( $args, $group );
+			if ( $active['action_id'] > 0 ) {
+				return array(
+					'success'       => true,
+					'action_id'     => $active['action_id'],
+					'action_status' => $active['status'],
+					'reused'        => true,
+					'attempts'      => $attempt,
+					'retryable'     => false,
+					'error_message' => $error_message,
+				);
+			}
+
+			if ( $attempt < self::SCHEDULE_ATTEMPTS ) {
+				usleep( random_int( 10000, 50000 ) );
+			}
 		}
 
-		$action_id = self::pendingContinuationId( $args, $group );
 		return array(
-			'success'   => $action_id > 0,
-			'action_id' => $action_id,
-			'reused'    => $action_id > 0,
+			'success'       => false,
+			'action_id'     => 0,
+			'action_status' => '',
+			'reused'        => false,
+			'attempts'      => self::SCHEDULE_ATTEMPTS,
+			'retryable'     => true,
+			'error_message' => $error_message ?: 'Action Scheduler returned no action ID.',
 		);
 	}
 
@@ -232,6 +269,53 @@ class AIConcurrencyBackpressure {
 		return ! empty( $result['success'] );
 	}
 
+	/** Release an exact generation that never acquired scheduler ownership. */
+	public static function releaseUnscheduledGeneration( int $job_id, string $flow_step_id, int $generation, string $token ): bool {
+		$result = EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $flow_step_id, $generation, $token ): ?array {
+				$state = is_array( $engine[ self::OWNERSHIP_KEY ] ?? null ) ? $engine[ self::OWNERSHIP_KEY ] : array();
+				if ( ! self::isReleasableUnscheduledGeneration( $state, $flow_step_id, $generation, $token ) ) {
+					return null;
+				}
+
+				unset( $engine[ self::OWNERSHIP_KEY ] );
+				return $engine;
+			},
+			'ai_resume_generation_schedule_failed'
+		);
+
+		return ! empty( $result['success'] );
+	}
+
+	/** Determine whether the caller owns an exact actionless scheduled generation. */
+	public static function isReleasableUnscheduledGeneration( array $state, string $flow_step_id, int $generation, string $token ): bool {
+		return (string) ( $state['flow_step_id'] ?? '' ) === $flow_step_id
+			&& (int) ( $state['generation'] ?? 0 ) === $generation
+			&& (string) ( $state['token'] ?? '' ) === $token
+			&& 'scheduled' === (string) ( $state['status'] ?? '' )
+			&& 0 === (int) ( $state['action_id'] ?? 0 );
+	}
+
+	/** Resolve scheduler or runner ownership after an ambiguous release. */
+	public static function generationExecutionState( int $job_id, string $flow_step_id, int $generation, string $token ): string {
+		$engine = EngineData::retrieve( $job_id );
+		$state  = is_array( $engine[ self::OWNERSHIP_KEY ] ?? null ) ? $engine[ self::OWNERSHIP_KEY ] : array();
+
+		if ( (string) ( $state['flow_step_id'] ?? '' ) !== $flow_step_id
+			|| (int) ( $state['generation'] ?? 0 ) !== $generation
+			|| (string) ( $state['token'] ?? '' ) !== $token
+		) {
+			return '';
+		}
+
+		if ( 'running' === (string) ( $state['status'] ?? '' ) ) {
+			return 'running';
+		}
+
+		return (int) ( $state['action_id'] ?? 0 ) > 0 ? 'scheduled' : '';
+	}
+
 	private static function newGenerationState( string $flow_step_id, int $source_generation, string $token, int $now ): array {
 		return array(
 			'flow_step_id'      => $flow_step_id,
@@ -266,23 +350,30 @@ class AIConcurrencyBackpressure {
 		);
 	}
 
-	private static function pendingContinuationId( array $args, string $group ): int {
+	/** @return array{action_id:int,status:string} */
+	private static function activeContinuation( array $args, string $group ): array {
 		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
-			return 0;
+			return array( 'action_id' => 0, 'status' => '' );
 		}
 
-		$action_ids = as_get_scheduled_actions(
-			array(
-				'hook'     => self::RESUME_HOOK,
-				'args'     => $args,
-				'group'    => $group,
-				'status'   => 'pending',
-				'per_page' => 1,
-			),
-			'ids'
-		);
+		foreach ( array( 'pending', 'in-progress' ) as $status ) {
+			$action_ids = as_get_scheduled_actions(
+				array(
+					'hook'     => self::RESUME_HOOK,
+					'args'     => $args,
+					'group'    => $group,
+					'status'   => $status,
+					'per_page' => 1,
+				),
+				'ids'
+			);
 
-		$action_id = is_array( $action_ids ) ? reset( $action_ids ) : 0;
-		return is_numeric( $action_id ) && (int) $action_id > 0 ? (int) $action_id : 0;
+			$action_id = is_array( $action_ids ) ? reset( $action_ids ) : 0;
+			if ( is_numeric( $action_id ) && (int) $action_id > 0 ) {
+				return array( 'action_id' => (int) $action_id, 'status' => $status );
+			}
+		}
+
+		return array( 'action_id' => 0, 'status' => '' );
 	}
 }

--- a/inc/Engine/AI/AIConcurrencyBackpressure.php
+++ b/inc/Engine/AI/AIConcurrencyBackpressure.php
@@ -8,6 +8,7 @@
 namespace DataMachine\Engine\AI;
 
 use DataMachine\Core\EngineData;
+use DataMachine\Engine\Tasks\ScheduleActionIdentity;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -67,15 +68,7 @@ class AIConcurrencyBackpressure {
 	 */
 	public static function scheduleContinuation( int $timestamp, array $args ): array {
 		if ( ! function_exists( 'as_schedule_single_action' ) ) {
-			return array(
-				'success'       => false,
-				'action_id'     => 0,
-				'action_status' => '',
-				'reused'        => false,
-				'attempts'      => 0,
-				'retryable'     => true,
-				'error_message' => 'Action Scheduler is unavailable.',
-			);
+			return self::scheduleFailure( 0, 'Action Scheduler is unavailable.' );
 		}
 
 		$group         = self::continuationGroup( $args );
@@ -124,14 +117,9 @@ class AIConcurrencyBackpressure {
 			}
 		}
 
-		return array(
-			'success'       => false,
-			'action_id'     => 0,
-			'action_status' => '',
-			'reused'        => false,
-			'attempts'      => self::SCHEDULE_ATTEMPTS,
-			'retryable'     => true,
-			'error_message' => $error_message ?: 'Action Scheduler returned no action ID.',
+		return self::scheduleFailure(
+			self::SCHEDULE_ATTEMPTS,
+			'' !== $error_message ? $error_message : 'Action Scheduler returned no action ID.'
 		);
 	}
 
@@ -352,28 +340,32 @@ class AIConcurrencyBackpressure {
 
 	/** @return array{action_id:int,status:string} */
 	private static function activeContinuation( array $args, string $group ): array {
-		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
-			return array( 'action_id' => 0, 'status' => '' );
-		}
-
 		foreach ( array( 'pending', 'in-progress' ) as $status ) {
-			$action_ids = as_get_scheduled_actions(
-				array(
-					'hook'     => self::RESUME_HOOK,
-					'args'     => $args,
-					'group'    => $group,
-					'status'   => $status,
-					'per_page' => 1,
-				),
-				'ids'
-			);
-
-			$action_id = is_array( $action_ids ) ? reset( $action_ids ) : 0;
-			if ( is_numeric( $action_id ) && (int) $action_id > 0 ) {
-				return array( 'action_id' => (int) $action_id, 'status' => $status );
+			$action_id = ScheduleActionIdentity::exactActionId( self::RESUME_HOOK, $args, $group, $status );
+			if ( $action_id > 0 ) {
+				return array(
+					'action_id' => $action_id,
+					'status'    => $status,
+				);
 			}
 		}
 
-		return array( 'action_id' => 0, 'status' => '' );
+		return array(
+			'action_id' => 0,
+			'status'    => '',
+		);
+	}
+
+	/** @return array{success:bool,action_id:int,action_status:string,reused:bool,attempts:int,retryable:bool,error_message:string} */
+	private static function scheduleFailure( int $attempts, string $error_message ): array {
+		return array(
+			'success'       => false,
+			'action_id'     => 0,
+			'action_status' => '',
+			'reused'        => false,
+			'attempts'      => $attempts,
+			'retryable'     => true,
+			'error_message' => $error_message,
+		);
 	}
 }

--- a/inc/Engine/AI/AIConcurrencyScheduleFailure.php
+++ b/inc/Engine/AI/AIConcurrencyScheduleFailure.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Recover AI continuation scheduling failures without violating generation ownership.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\EngineData;
+
+defined( 'ABSPATH' ) || exit;
+
+final class AIConcurrencyScheduleFailure {
+
+	public static function handle( int $job_id, string $flow_step_id, string $provider, int $generation, string $token, array $contention, array $scheduler ): void {
+		$released = AIConcurrencyBackpressure::releaseUnscheduledGeneration( $job_id, $flow_step_id, $generation, $token );
+		if ( ! $released ) {
+			self::handleAmbiguousRelease( $job_id, $flow_step_id, $generation, $token, $scheduler );
+			return;
+		}
+
+		$contention['state']           = 'deferred';
+		$contention['terminal_reason'] = 'ai_concurrency_defer_schedule_failed';
+		$contention['next_retry_at']   = null;
+		$contention['action_id']       = null;
+		$contention['scheduler']       = array(
+			'attempts'       => (int) ( $scheduler['attempts'] ?? 0 ),
+			'error_message'  => (string) ( $scheduler['error_message'] ?? '' ),
+			'claim_released' => true,
+		);
+		EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $contention ): array {
+				$engine['ai_concurrency_throttle'] = $contention;
+				return $engine;
+			},
+			'ai_concurrency_defer_schedule_failed'
+		);
+		do_action(
+			'datamachine_fail_job',
+			$job_id,
+			'ai_concurrency_defer_schedule_failed',
+			array(
+				'flow_step_id'       => $flow_step_id,
+				'ai_provider'        => $provider,
+				'retryable'          => true,
+				'resume_generation'  => $generation,
+				'scheduler_attempts' => (int) ( $scheduler['attempts'] ?? 0 ),
+				'error_message'      => (string) ( $scheduler['error_message'] ?? '' ),
+				'claim_released'     => true,
+			)
+		);
+	}
+
+	private static function handleAmbiguousRelease( int $job_id, string $flow_step_id, int $generation, string $token, array $scheduler ): void {
+		$execution_state = AIConcurrencyBackpressure::generationExecutionState( $job_id, $flow_step_id, $generation, $token );
+		if ( 'scheduled' === $execution_state ) {
+			( new Jobs() )->update_job_status( $job_id, 'pending' );
+		}
+
+		do_action(
+			'datamachine_log',
+			'' === $execution_state ? 'error' : 'info',
+			'' === $execution_state
+				? 'AI continuation scheduling failed and generation ownership could not be released'
+				: 'AI continuation scheduling raced existing generation execution',
+			array(
+				'job_id'            => $job_id,
+				'flow_step_id'      => $flow_step_id,
+				'resume_generation' => $generation,
+				'execution_state'   => $execution_state,
+				'scheduler'         => $scheduler,
+			)
+		);
+	}
+}

--- a/inc/Engine/Actions/Handlers/FailJobHandler.php
+++ b/inc/Engine/Actions/Handlers/FailJobHandler.php
@@ -128,7 +128,8 @@ class FailJobHandler {
 
 		$cleanup_files = \DataMachine\Core\PluginSettings::get( 'cleanup_job_data_on_failure', true );
 		$files_cleaned = false;
-		$retry_pending = self::hasPendingRetry( $engine_data );
+		$terminal_job  = $db_jobs->get_job( $job_id );
+		$retry_pending = self::hasPendingRetry( $engine_data, is_array( $terminal_job ) ? (string) ( $terminal_job['status'] ?? '' ) : '' );
 
 		// Skip cleanup whenever a retry is already scheduled for this job.
 		// JobRetryPolicy::recordRetry writes next_retry_at only after Action
@@ -170,11 +171,12 @@ class FailJobHandler {
 	 * only after Action Scheduler accepts the next attempt. Any non-empty value
 	 * means the policy has taken ownership of the failure path.
 	 *
-	 * @param array $engine_data Engine snapshot read prior to fail finalization.
+	 * @param array  $engine_data Engine snapshot read prior to fail finalization.
+	 * @param string $job_status  Current persisted job status.
 	 * @return bool
 	 */
-	private static function hasPendingRetry( array $engine_data ): bool {
+	private static function hasPendingRetry( array $engine_data, string $job_status ): bool {
 		$retry = is_array( $engine_data['retry'] ?? null ) ? $engine_data['retry'] : array();
-		return ! empty( $retry['next_retry_at'] );
+		return 'pending' === $job_status && ! empty( $retry['next_retry_at'] );
 	}
 }

--- a/inc/Engine/Tasks/ScheduleActionIdentity.php
+++ b/inc/Engine/Tasks/ScheduleActionIdentity.php
@@ -139,7 +139,7 @@ final class ScheduleActionIdentity {
 			),
 			'ids'
 		);
-		$action_id = is_array( $action_ids ) ? reset( $action_ids ) : 0;
+		$action_id  = is_array( $action_ids ) ? reset( $action_ids ) : 0;
 
 		return is_numeric( $action_id ) && (int) $action_id > 0 ? (int) $action_id : 0;
 	}

--- a/inc/Engine/Tasks/ScheduleActionIdentity.php
+++ b/inc/Engine/Tasks/ScheduleActionIdentity.php
@@ -124,6 +124,26 @@ final class ScheduleActionIdentity {
 		return null;
 	}
 
+	public static function exactActionId( string $hook, array $args, string $group, string $status ): int {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+			return 0;
+		}
+
+		$action_ids = as_get_scheduled_actions(
+			array(
+				'hook'     => $hook,
+				'args'     => $args,
+				'group'    => $group,
+				'status'   => $status,
+				'per_page' => 1,
+			),
+			'ids'
+		);
+		$action_id = is_array( $action_ids ) ? reset( $action_ids ) : 0;
+
+		return is_numeric( $action_id ) && (int) $action_id > 0 ? (int) $action_id : 0;
+	}
+
 	public static function countExactPending( string $hook, array $args, string $group ): int {
 		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
 			return 0;

--- a/tests/ai-step-backpressure-smoke.php
+++ b/tests/ai-step-backpressure-smoke.php
@@ -28,6 +28,7 @@ function assert_ai_backpressure_smoke( string $name, bool $cond, string $detail 
 $GLOBALS['datamachine_ai_backpressure_options'] = array();
 $GLOBALS['datamachine_ai_backpressure_actions'] = array();
 $GLOBALS['datamachine_ai_backpressure_schedule_error'] = false;
+$GLOBALS['datamachine_ai_backpressure_schedule_calls'] = 0;
 $GLOBALS['datamachine_ai_backpressure_next_action_id'] = 1;
 $GLOBALS['datamachine_ai_backpressure_registered_hooks'] = array();
 $GLOBALS['datamachine_ai_backpressure_ability_inputs'] = array();
@@ -126,7 +127,12 @@ function as_get_scheduled_actions( array $query = array(), string $return_format
 }
 
 function as_schedule_single_action( int $timestamp, string $hook, array $args = array(), string $group = '', bool $unique = false ): int {
-	if ( $GLOBALS['datamachine_ai_backpressure_schedule_error'] ) {
+	++$GLOBALS['datamachine_ai_backpressure_schedule_calls'];
+	if ( true === $GLOBALS['datamachine_ai_backpressure_schedule_error'] ) {
+		return 0;
+	}
+	if ( is_int( $GLOBALS['datamachine_ai_backpressure_schedule_error'] ) && $GLOBALS['datamachine_ai_backpressure_schedule_error'] > 0 ) {
+		--$GLOBALS['datamachine_ai_backpressure_schedule_error'];
 		return 0;
 	}
 	if ( $unique ) {
@@ -234,6 +240,8 @@ $upsert_src   = implode( "\n", array_map( static fn( string $path ): string => f
 assert_ai_backpressure_smoke( 'AIStep acquires before prompt queue consumption', strpos( $ai_src, 'PipelineAIConcurrencyLimiter::acquire' ) < strpos( $ai_src, 'consumeFromPromptQueue' ) );
 assert_ai_backpressure_smoke( 'AIStep throttles by rescheduling same step', str_contains( $ai_src, 'deferForAIConcurrency' ) && str_contains( $backpressure_src, 'datamachine_resume_ai_step' ) );
 assert_ai_backpressure_smoke( 'executor treats AI throttle as routed pending work', str_contains( $engine_src, 'hasPendingAIConcurrencyThrottle' ) && str_contains( $engine_src, 'ai_concurrency_throttle' ) );
+assert_ai_backpressure_smoke( 'blocked AI handoff bypasses empty-packet failure routing', str_contains( $ai_src, "'status'  => 'blocked'" ) && str_contains( $engine_src, "'blocked' === ( \$execution_result['status'] ?? '' )" ) );
+assert_ai_backpressure_smoke( 'nonterminal blocked handoff is routed before pending retry fallback', strpos( $engine_src, "'blocked' === ( \$execution_result['status'] ?? '' )" ) < strpos( $engine_src, '$prior_status = $this->getPriorTerminalStatus' ) && str_contains( $engine_src, 'JobStatus::isStatusFinal( $current_status )' ) );
 assert_ai_backpressure_smoke( 'fetch steps do not use AI limiter', ! str_contains( $fetch_src, 'PipelineAIConcurrencyLimiter' ) );
 assert_ai_backpressure_smoke( 'upsert steps do not use AI limiter', ! str_contains( $upsert_src, 'PipelineAIConcurrencyLimiter' ) );
 assert_ai_backpressure_smoke( 'existing transport retry classifier remains intact', str_contains( $retry_src, 'transport_connect_timeout' ) && str_contains( $retry_src, 'AI_TRANSPORT_BASE_DELAY' ) );
@@ -293,8 +301,25 @@ assert_ai_backpressure_smoke( 'another job uses a separate uniqueness group', $o
 $GLOBALS['datamachine_ai_backpressure_schedule_error'] = true;
 $schedule_error = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, array( 'job_id' => 302, 'flow_step_id' => 'ai-1' ) );
 $GLOBALS['datamachine_ai_backpressure_schedule_error'] = false;
-assert_ai_backpressure_smoke( 'zero without a matching pending action is a scheduling failure', ! $schedule_error['success'] && 0 === $schedule_error['action_id'] );
-assert_ai_backpressure_smoke( 'scheduler call requests native uniqueness', str_contains( $backpressure_src, "\$group,\n\t\t\ttrue" ) );
+assert_ai_backpressure_smoke( 'zero without a matching pending action is a retryable scheduling failure', ! $schedule_error['success'] && 0 === $schedule_error['action_id'] && 3 === $schedule_error['attempts'] && $schedule_error['retryable'] );
+assert_ai_backpressure_smoke( 'scheduler call requests native uniqueness', 1 === preg_match( '/\$group,\s+true/', $backpressure_src ) );
+
+$GLOBALS['datamachine_ai_backpressure_schedule_error'] = 1;
+$transient_schedule = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, array( 'job_id' => 304, 'flow_step_id' => 'ai-1' ) );
+assert_ai_backpressure_smoke( 'transient scheduler failure succeeds on a bounded retry', $transient_schedule['success'] && 2 === $transient_schedule['attempts'] && ! $transient_schedule['reused'] );
+
+$running_args = array( 'job_id' => 305, 'flow_step_id' => 'ai-1', 'ai_resume_generation' => 1 );
+$GLOBALS['datamachine_ai_backpressure_actions'][] = new DataMachineAIBackpressureSmokeAction(
+	array(
+		'action_id' => 905,
+		'hook'      => AIConcurrencyBackpressure::RESUME_HOOK,
+		'args'      => $running_args,
+		'group'     => AIConcurrencyBackpressure::continuationGroup( $running_args ),
+		'status'    => 'in-progress',
+	)
+);
+$running_schedule = AIConcurrencyBackpressure::scheduleContinuation( $now + 60, $running_args );
+assert_ai_backpressure_smoke( 'equivalent in-progress continuation is reused without pending handoff', $running_schedule['success'] && $running_schedule['reused'] && 905 === $running_schedule['action_id'] && 'in-progress' === $running_schedule['action_status'] );
 
 echo "Case 9: slot recovery archives and clears active contention\n";
 $resolved = AIConcurrencyBackpressure::resolvedState( $state, $now + 120 );
@@ -332,6 +357,13 @@ assert_ai_backpressure_smoke( 'stale generation one replay cannot claim newer ow
 $running_two = AIConcurrencyBackpressure::beginGenerationState( $generation_two, 'ai-1', 2, $now + 3 );
 assert_ai_backpressure_smoke( 'exact generation two can begin once', 'running' === $running_two['status'] );
 assert_ai_backpressure_smoke( 'duplicate generation two execution is rejected', null === AIConcurrencyBackpressure::beginGenerationState( $running_two, 'ai-1', 2, $now + 4 ) );
+
+assert_ai_backpressure_smoke( 'only exact actionless scheduled generation can be released', AIConcurrencyBackpressure::isReleasableUnscheduledGeneration( $generation_two, 'ai-1', 2, 'token-2' ) );
+assert_ai_backpressure_smoke( 'wrong token cannot release generation ownership', ! AIConcurrencyBackpressure::isReleasableUnscheduledGeneration( $generation_two, 'ai-1', 2, 'token-other' ) );
+assert_ai_backpressure_smoke( 'running generation cannot be released as unscheduled', ! AIConcurrencyBackpressure::isReleasableUnscheduledGeneration( $running_two, 'ai-1', 2, 'token-2' ) );
+assert_ai_backpressure_smoke( 'schedule exhaustion routes through retryable fail-job instead of cancellation', str_contains( $ai_src, "'datamachine_fail_job'" ) && str_contains( $ai_src, "'ai_concurrency_defer_schedule_failed'" ) && ! str_contains( $ai_src, "cancelled - ai_concurrency_defer_schedule_failed" ) );
+assert_ai_backpressure_smoke( 'in-progress continuation does not regress job status to pending', str_contains( $ai_src, "'in-progress' !== (string) ( \$schedule_result['action_status'] ?? '' )" ) );
+assert_ai_backpressure_smoke( 'in-progress continuation returns before stale throttle merge', str_contains( $ai_src, "} else {\n\t\t\treturn;\n\t\t}" ) );
 
 $bounded_state = array();
 for ( $generation = 1; $generation <= 20; ++$generation ) {

--- a/tests/ai-step-backpressure-smoke.php
+++ b/tests/ai-step-backpressure-smoke.php
@@ -171,6 +171,7 @@ require_once __DIR__ . '/../inc/Core/NetworkSettings.php';
 require_once __DIR__ . '/../inc/Core/PluginSettings.php';
 require_once __DIR__ . '/../inc/Core/OptionLeaseStore.php';
 require_once __DIR__ . '/../inc/Core/ActionScheduler/GroupRegistrar.php';
+require_once __DIR__ . '/../inc/Engine/Tasks/ScheduleActionIdentity.php';
 require_once __DIR__ . '/../inc/Engine/AI/PipelineAIConcurrencyLease.php';
 require_once __DIR__ . '/../inc/Engine/AI/PipelineAIConcurrencyLimiter.php';
 require_once __DIR__ . '/../inc/Engine/AI/AIConcurrencyBackpressure.php';
@@ -232,6 +233,7 @@ $ai_src       = file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' 
 $engine_src   = file_get_contents( __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php' ) ?: '';
 $retry_src    = file_get_contents( __DIR__ . '/../inc/Core/JobRetryPolicy.php' ) ?: '';
 $backpressure_src = file_get_contents( __DIR__ . '/../inc/Engine/AI/AIConcurrencyBackpressure.php' ) ?: '';
+$schedule_failure_src = file_get_contents( __DIR__ . '/../inc/Engine/AI/AIConcurrencyScheduleFailure.php' ) ?: '';
 $reconciler_src = file_get_contents( __DIR__ . '/../inc/Core/Database/Jobs/LegacyAIConcurrencyReconciler.php' ) ?: '';
 $fetch_src    = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/FetchStep.php' ) ?: '';
 $upsert_files = glob( __DIR__ . '/../inc/Core/Steps/Upsert/*.php' ) ?: array();
@@ -361,7 +363,7 @@ assert_ai_backpressure_smoke( 'duplicate generation two execution is rejected', 
 assert_ai_backpressure_smoke( 'only exact actionless scheduled generation can be released', AIConcurrencyBackpressure::isReleasableUnscheduledGeneration( $generation_two, 'ai-1', 2, 'token-2' ) );
 assert_ai_backpressure_smoke( 'wrong token cannot release generation ownership', ! AIConcurrencyBackpressure::isReleasableUnscheduledGeneration( $generation_two, 'ai-1', 2, 'token-other' ) );
 assert_ai_backpressure_smoke( 'running generation cannot be released as unscheduled', ! AIConcurrencyBackpressure::isReleasableUnscheduledGeneration( $running_two, 'ai-1', 2, 'token-2' ) );
-assert_ai_backpressure_smoke( 'schedule exhaustion routes through retryable fail-job instead of cancellation', str_contains( $ai_src, "'datamachine_fail_job'" ) && str_contains( $ai_src, "'ai_concurrency_defer_schedule_failed'" ) && ! str_contains( $ai_src, "cancelled - ai_concurrency_defer_schedule_failed" ) );
+assert_ai_backpressure_smoke( 'schedule exhaustion routes through retryable fail-job instead of cancellation', str_contains( $schedule_failure_src, "'datamachine_fail_job'" ) && str_contains( $schedule_failure_src, "'ai_concurrency_defer_schedule_failed'" ) && ! str_contains( $ai_src, "cancelled - ai_concurrency_defer_schedule_failed" ) );
 assert_ai_backpressure_smoke( 'in-progress continuation does not regress job status to pending', str_contains( $ai_src, "'in-progress' !== (string) ( \$schedule_result['action_status'] ?? '' )" ) );
 assert_ai_backpressure_smoke( 'in-progress continuation returns before stale throttle merge', str_contains( $ai_src, "} else {\n\t\t\treturn;\n\t\t}" ) );
 

--- a/tests/retry-schedule-lifecycle-smoke.php
+++ b/tests/retry-schedule-lifecycle-smoke.php
@@ -24,6 +24,22 @@ namespace DataMachine\Core\Database\Jobs {
 	}
 }
 
+namespace DataMachine\Core {
+	class EngineData {
+		public static function mutate( int $job_id, callable $callback, string $event_type = 'mutation' ): array {
+			unset( $job_id, $event_type );
+			$current = $GLOBALS['engine_data'] ?? array();
+			$next    = $callback( $current );
+			if ( null === $next ) {
+				return array( 'success' => false );
+			}
+
+			$GLOBALS['engine_data'] = $next;
+			return array( 'success' => true );
+		}
+	}
+}
+
 namespace {
 	define( 'ABSPATH', __DIR__ );
 
@@ -78,7 +94,7 @@ namespace {
 	echo "Case 1: scheduler failure leaves no pending retry metadata\n";
 	$GLOBALS['engine_data']           = array();
 	$GLOBALS['merged_engine_data']    = array();
-	$GLOBALS['schedule_retry_result'] = false;
+	$GLOBALS['schedule_retry_result'] = 0;
 	$GLOBALS['scheduled_retry']       = null;
 	$jobs                             = new \DataMachine\Core\Database\Jobs\Jobs();
 	$result                           = \DataMachine\Core\JobRetryPolicy::maybeRetry(
@@ -96,6 +112,18 @@ namespace {
 	assert_retry_schedule_lifecycle( 'job status remains processing when no retry action exists', 'processing' === $jobs->status );
 	assert_retry_schedule_lifecycle( 'next_retry_at is not exposed in result', ! isset( $result['next_retry_at'] ) );
 	assert_retry_schedule_lifecycle( 'next_retry_at is not persisted without action', ! isset( $GLOBALS['merged_engine_data']['retry']['next_retry_at'] ) );
+
+	$GLOBALS['engine_data'] = array( 'retry' => array( 'next_retry_at' => '2026-07-23T12:00:00Z' ) );
+	\DataMachine\Core\JobRetryPolicy::maybeRetry(
+		123,
+		'transient_failure',
+		array(
+			'flow_step_id' => 'step-1',
+			'retryable'    => true,
+		),
+		$jobs
+	);
+	assert_retry_schedule_lifecycle( 'failed later schedule clears stale retry ownership', ! isset( $GLOBALS['engine_data']['retry']['next_retry_at'] ) );
 
 	echo "Case 2: scheduler success publishes pending retry metadata\n";
 	$GLOBALS['engine_data']           = array();

--- a/tests/schedule-next-step-failure-smoke.php
+++ b/tests/schedule-next-step-failure-smoke.php
@@ -29,9 +29,9 @@ $helper  = strstr( $source, 'private function failScheduling' ) ?: '';
 
 echo "Case 1: schedule-next-step owns Action Scheduler failures\n";
 assert_schedule_next_step_failure_smoke( 'helper exists', str_contains( $source, 'private function failScheduling' ) );
-assert_schedule_next_step_failure_smoke( 'action scheduler failure is checked', str_contains( $execute, 'if ( false === $action_id )' ) );
+assert_schedule_next_step_failure_smoke( 'non-positive action scheduler result is checked', str_contains( $execute, '(int) $action_id <= 0' ) );
 assert_schedule_next_step_failure_smoke( 'failed scheduling routes through helper', str_contains( $execute, "'next_step_schedule_failed'") );
-assert_schedule_next_step_failure_smoke( 'helper failure happens before returning action result', strpos( $execute, 'if ( false === $action_id )' ) < strpos( $execute, "'success'   => false !== $" . 'action_id' ) );
+assert_schedule_next_step_failure_smoke( 'helper failure happens before returning action result', strpos( $execute, 'if ( ! is_numeric( $action_id )' ) < strrpos( $execute, "'success'   => is_numeric( $" . 'action_id' ) );
 
 echo "Case 2: unscheduled jobs are requeued or finalized through fail-job\n";
 assert_schedule_next_step_failure_smoke( 'helper calls fail-job action', str_contains( $helper, "'datamachine_fail_job'") );


### PR DESCRIPTION
## Summary
- retry unexplained Action Scheduler zero IDs with native uniqueness and reuse pending or in-progress winners
- release only the exact actionless AI generation before generic retry, preserving ambiguous active ownership
- route deferred AI work through the existing blocked execution contract instead of empty-packet failure
- treat non-positive scheduler IDs as failures in generic retry and next-step handoff
- clear stale retry ownership and gate cleanup on current persisted job status

Closes #2979.

## Production Evidence
Four London burst jobs were cancelled after MariaDB returned `Failed to read auto-increment value from storage engine`. Action Scheduler swallowed the insert exception and returned `0`; Data Machine treated that transient result as terminal and left generation ownership at `scheduled/action_id=0`.

## Verification
- `php tests/ai-step-backpressure-smoke.php` (58 assertions)
- `php tests/retry-schedule-lifecycle-smoke.php` (10 assertions)
- `php tests/schedule-next-step-failure-smoke.php` (10 assertions)
- `php tests/step-execution-result-contract-smoke.php` (25 assertions)
- changed-path PHPCS and `git diff --check`
- Homeboy lint: no new findings
- repeated independent review: no remaining high or medium findings

The broader Codebox PHPUnit run failed in bootstrap because its bundled PHPUnit is missing `PHPUnit\\Runner\\DefaultTestResultCache`; no test assertion ran in that infrastructure attempt.