### PR TITLE
fix: align AI concurrency fallback with plugin defaults

### DIFF
--- a/inc/Engine/AI/PipelineAIConcurrencyLimiter.php
+++ b/inc/Engine/AI/PipelineAIConcurrencyLimiter.php
@@ -17,7 +17,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class PipelineAIConcurrencyLimiter {
 
-	private const DEFAULT_LIMIT          = 1;
 	private const DEFAULT_THROTTLE_DELAY = 10;
 	private const DEFAULT_TTL            = 600;
 	private const OPTION_PREFIX          = 'datamachine_pipeline_ai_lease_';
@@ -58,7 +57,7 @@ class PipelineAIConcurrencyLimiter {
 		return array(
 			'acquired' => true,
 			'lease'    => new PipelineAIConcurrencyLease( $acquired, $token ),
-			'limit'    => $scopes[0]['limit'] ?? self::DEFAULT_LIMIT,
+			'limit'    => $scopes[0]['limit'],
 			'active'   => count( $acquired ),
 			'delay'    => self::throttleDelay( $provider, $context ),
 			'provider' => $provider,
@@ -71,7 +70,7 @@ class PipelineAIConcurrencyLimiter {
 	 * @return array<int,array{name:string,limit:int}>
 	 */
 	private static function resolveScopes( string $provider, array $context ): array {
-		$site_limit = max( 1, (int) PluginSettings::resolve( 'pipeline_ai_concurrency_limit', self::DEFAULT_LIMIT ) );
+		$site_limit = max( 1, (int) PluginSettings::resolve( 'pipeline_ai_concurrency_limit', PluginSettings::DEFAULT_PIPELINE_AI_CONCURRENCY_LIMIT ) );
 
 		/**
 		 * Filter site-wide pipeline AI concurrency.

--- a/tests/ai-step-backpressure-smoke.php
+++ b/tests/ai-step-backpressure-smoke.php
@@ -7,22 +7,25 @@
  * @package DataMachine\Tests
  */
 
-define( 'ABSPATH', __DIR__ );
+$is_wordpress_runtime = defined( 'WPINC' );
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ );
 defined( 'DAY_IN_SECONDS' ) || define( 'DAY_IN_SECONDS', 86400 );
 
 $failed = 0;
 $total  = 0;
 
-function assert_ai_backpressure_smoke( string $name, bool $cond, string $detail = '' ): void {
-	global $failed, $total;
-	++$total;
-	if ( $cond ) {
-		echo "  [PASS] $name\n";
-		return;
-	}
+if ( ! function_exists( 'assert_ai_backpressure_smoke' ) ) {
+	function assert_ai_backpressure_smoke( string $name, bool $cond, string $detail = '' ): void {
+		global $failed, $total;
+		++$total;
+		if ( $cond ) {
+			echo "  [PASS] $name\n";
+			return;
+		}
 
-	echo "  [FAIL] $name" . ( $detail ? " - $detail" : '' ) . "\n";
-	++$failed;
+		echo "  [FAIL] $name" . ( $detail ? " - $detail" : '' ) . "\n";
+		++$failed;
+	}
 }
 
 $GLOBALS['datamachine_ai_backpressure_options'] = array();
@@ -34,30 +37,38 @@ $GLOBALS['datamachine_ai_backpressure_registered_hooks'] = array();
 $GLOBALS['datamachine_ai_backpressure_ability_inputs'] = array();
 $GLOBALS['datamachine_ai_backpressure_concurrency_limit_filter'] = null;
 
-class DataMachineAIBackpressureSmokeAction {
-	public function __construct( private array $action ) {}
+if ( ! class_exists( 'DataMachineAIBackpressureSmokeAction' ) ) {
+	class DataMachineAIBackpressureSmokeAction {
+		public function __construct( private array $action ) {}
 
-	public function get_args(): array {
-		return $this->action['args'] ?? array();
-	}
+		public function get_args(): array {
+			return $this->action['args'] ?? array();
+		}
 
-	public function get_field( string $field ): mixed {
-		return $this->action[ $field ] ?? null;
-	}
-}
-
-class DataMachineAIBackpressureSmokeAbility {
-	public function execute( array $input ): void {
-		$GLOBALS['datamachine_ai_backpressure_ability_inputs'][] = $input;
+		public function get_field( string $field ): mixed {
+			return $this->action[ $field ] ?? null;
+		}
 	}
 }
 
-function add_action( string $hook, mixed $callback, int $priority = 10, int $accepted_args = 1 ): void {
-	$GLOBALS['datamachine_ai_backpressure_registered_hooks'][ $hook ] = array( $callback, $priority, $accepted_args );
+if ( ! class_exists( 'DataMachineAIBackpressureSmokeAbility' ) ) {
+	class DataMachineAIBackpressureSmokeAbility {
+		public function execute( array $input ): void {
+			$GLOBALS['datamachine_ai_backpressure_ability_inputs'][] = $input;
+		}
+	}
 }
 
-function wp_get_ability( string $name ): ?DataMachineAIBackpressureSmokeAbility {
-	return 'datamachine/execute-step' === $name ? new DataMachineAIBackpressureSmokeAbility() : null;
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, mixed $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['datamachine_ai_backpressure_registered_hooks'][ $hook ] = array( $callback, $priority, $accepted_args );
+	}
+}
+
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $name ): ?DataMachineAIBackpressureSmokeAbility {
+		return 'datamachine/execute-step' === $name ? new DataMachineAIBackpressureSmokeAbility() : null;
+	}
 }
 
 if ( ! function_exists( 'get_option' ) ) {
@@ -101,65 +112,71 @@ if ( ! function_exists( 'apply_filters' ) ) {
     }
 }
 
-function as_get_scheduled_actions( array $query = array(), string $return_format = 'OBJECT' ): array {
-	$actions = array_values(
-		array_filter(
-			$GLOBALS['datamachine_ai_backpressure_actions'],
-			static function ( DataMachineAIBackpressureSmokeAction $action ) use ( $query ): bool {
-				foreach ( array( 'hook', 'group', 'status' ) as $field ) {
-					if ( isset( $query[ $field ] ) && $action->get_field( $field ) !== $query[ $field ] ) {
+if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+	function as_get_scheduled_actions( array $query = array(), string $return_format = 'OBJECT' ): array {
+		$actions = array_values(
+			array_filter(
+				$GLOBALS['datamachine_ai_backpressure_actions'],
+				static function ( DataMachineAIBackpressureSmokeAction $action ) use ( $query ): bool {
+					foreach ( array( 'hook', 'group', 'status' ) as $field ) {
+						if ( isset( $query[ $field ] ) && $action->get_field( $field ) !== $query[ $field ] ) {
+							return false;
+						}
+					}
+					if ( isset( $query['args'] ) && $action->get_args() !== $query['args'] ) {
 						return false;
 					}
-				}
-				if ( isset( $query['args'] ) && $action->get_args() !== $query['args'] ) {
-					return false;
-				}
 
-				return true;
-			}
-		)
-	);
+					return true;
+				}
+			)
+		);
 
-	if ( 'ids' === strtolower( $return_format ) ) {
-		return array_map( static fn( DataMachineAIBackpressureSmokeAction $action ): int => (int) $action->get_field( 'action_id' ), $actions );
+		if ( 'ids' === strtolower( $return_format ) ) {
+			return array_map( static fn( DataMachineAIBackpressureSmokeAction $action ): int => (int) $action->get_field( 'action_id' ), $actions );
+		}
+
+		return $actions;
 	}
-
-	return $actions;
 }
 
-function as_schedule_single_action( int $timestamp, string $hook, array $args = array(), string $group = '', bool $unique = false ): int {
-	++$GLOBALS['datamachine_ai_backpressure_schedule_calls'];
-	if ( true === $GLOBALS['datamachine_ai_backpressure_schedule_error'] ) {
-		return 0;
-	}
-	if ( is_int( $GLOBALS['datamachine_ai_backpressure_schedule_error'] ) && $GLOBALS['datamachine_ai_backpressure_schedule_error'] > 0 ) {
-		--$GLOBALS['datamachine_ai_backpressure_schedule_error'];
-		return 0;
-	}
-	if ( $unique ) {
-		foreach ( array( 'pending', 'in-progress' ) as $blocking_status ) {
-			if ( ! empty( as_get_scheduled_actions( array( 'hook' => $hook, 'group' => $group, 'status' => $blocking_status ) ) ) ) {
-				return 0;
+if ( ! function_exists( 'as_schedule_single_action' ) ) {
+	function as_schedule_single_action( int $timestamp, string $hook, array $args = array(), string $group = '', bool $unique = false ): int {
+		++$GLOBALS['datamachine_ai_backpressure_schedule_calls'];
+		if ( true === $GLOBALS['datamachine_ai_backpressure_schedule_error'] ) {
+			return 0;
+		}
+		if ( is_int( $GLOBALS['datamachine_ai_backpressure_schedule_error'] ) && $GLOBALS['datamachine_ai_backpressure_schedule_error'] > 0 ) {
+			--$GLOBALS['datamachine_ai_backpressure_schedule_error'];
+			return 0;
+		}
+		if ( $unique ) {
+			foreach ( array( 'pending', 'in-progress' ) as $blocking_status ) {
+				if ( ! empty( as_get_scheduled_actions( array( 'hook' => $hook, 'group' => $group, 'status' => $blocking_status ) ) ) ) {
+					return 0;
+				}
 			}
 		}
-	}
 
-	$action_id = $GLOBALS['datamachine_ai_backpressure_next_action_id']++;
-	$GLOBALS['datamachine_ai_backpressure_actions'][] = new DataMachineAIBackpressureSmokeAction(
-		array(
-			'action_id' => $action_id,
-			'hook'      => $hook,
-			'args'      => $args,
-			'group'     => $group,
-			'status'    => 'pending',
-			'timestamp' => $timestamp,
-		)
-	);
-	return $action_id;
+		$action_id = $GLOBALS['datamachine_ai_backpressure_next_action_id']++;
+		$GLOBALS['datamachine_ai_backpressure_actions'][] = new DataMachineAIBackpressureSmokeAction(
+			array(
+				'action_id' => $action_id,
+				'hook'      => $hook,
+				'args'      => $args,
+				'group'     => $group,
+				'status'    => 'pending',
+				'timestamp' => $timestamp,
+			)
+		);
+		return $action_id;
+	}
 }
 
-function did_action( string $hook ): int {
-	return 'action_scheduler_init' === $hook ? 1 : 0;
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( string $hook ): int {
+		return 'action_scheduler_init' === $hook ? 1 : 0;
+	}
 }
 
 if ( ! function_exists( 'sanitize_key' ) ) {
@@ -182,6 +199,56 @@ use DataMachine\Core\ActionScheduler\GroupRegistrar;
 use DataMachine\Engine\AI\PipelineAIConcurrencyLease;
 use DataMachine\Engine\AI\PipelineAIConcurrencyLimiter;
 use DataMachine\Engine\AI\AIConcurrencyBackpressure;
+
+if ( $is_wordpress_runtime ) {
+	$missing_settings  = new stdClass();
+	$original_settings = get_option( 'datamachine_settings', $missing_settings );
+	delete_option( 'datamachine_settings' );
+	\DataMachine\Core\PluginSettings::clearCache();
+
+	$concurrency_filter = static function ( int $limit ): int {
+		return null === $GLOBALS['datamachine_ai_backpressure_concurrency_limit_filter']
+			? $limit
+			: (int) $GLOBALS['datamachine_ai_backpressure_concurrency_limit_filter'];
+	};
+	$throttle_filter = static fn(): int => 7;
+	add_filter( 'datamachine_pipeline_ai_concurrency_limit', $concurrency_filter, PHP_INT_MAX );
+	add_filter( 'datamachine_pipeline_ai_throttle_delay', $throttle_filter, PHP_INT_MAX );
+
+	echo "WordPress runtime: concurrency settings use the canonical default and preserve overrides\n";
+	$default_limit = PipelineAIConcurrencyLimiter::acquire( 'openai' );
+	assert_ai_backpressure_smoke( 'absent concurrency setting uses canonical default', 3 === ( $default_limit['limit'] ?? 0 ) );
+	$default_limit['lease']->release();
+
+	update_option( 'datamachine_settings', array( 'pipeline_ai_concurrency_limit' => 2 ) );
+	\DataMachine\Core\PluginSettings::clearCache();
+	$explicit_limit = PipelineAIConcurrencyLimiter::acquire( 'openai' );
+	assert_ai_backpressure_smoke( 'explicit concurrency setting overrides canonical default', 2 === ( $explicit_limit['limit'] ?? 0 ) );
+	$explicit_limit['lease']->release();
+
+	$GLOBALS['datamachine_ai_backpressure_concurrency_limit_filter'] = 1;
+	$first = PipelineAIConcurrencyLimiter::acquire( 'openai' );
+	assert_ai_backpressure_smoke( 'concurrency filter overrides explicit setting', 1 === ( $first['limit'] ?? 0 ) );
+	$second = PipelineAIConcurrencyLimiter::acquire( 'openai' );
+	assert_ai_backpressure_smoke( 'filtered site limit enforces real-runtime backpressure', false === $second['acquired'] );
+	assert_ai_backpressure_smoke( 'throttle delay remains filterable in real runtime', 7 === ( $second['delay'] ?? 0 ) );
+	$first['lease']->release();
+
+	remove_filter( 'datamachine_pipeline_ai_concurrency_limit', $concurrency_filter, PHP_INT_MAX );
+	remove_filter( 'datamachine_pipeline_ai_throttle_delay', $throttle_filter, PHP_INT_MAX );
+	if ( $missing_settings === $original_settings ) {
+		delete_option( 'datamachine_settings' );
+	} else {
+		update_option( 'datamachine_settings', $original_settings );
+	}
+	\DataMachine\Core\PluginSettings::clearCache();
+
+	echo "\nAI step backpressure WordPress smoke complete: {$total} assertions, {$failed} failures.\n";
+	if ( $failed > 0 ) {
+		exit( 1 );
+	}
+	return;
+}
 
 echo "Case 0: concurrency settings use the canonical default and preserve overrides\n";
 $default_limit = PipelineAIConcurrencyLimiter::acquire( 'openai' );

--- a/tests/ai-step-backpressure-smoke.php
+++ b/tests/ai-step-backpressure-smoke.php
@@ -32,6 +32,7 @@ $GLOBALS['datamachine_ai_backpressure_schedule_calls'] = 0;
 $GLOBALS['datamachine_ai_backpressure_next_action_id'] = 1;
 $GLOBALS['datamachine_ai_backpressure_registered_hooks'] = array();
 $GLOBALS['datamachine_ai_backpressure_ability_inputs'] = array();
+$GLOBALS['datamachine_ai_backpressure_concurrency_limit_filter'] = null;
 
 class DataMachineAIBackpressureSmokeAction {
 	public function __construct( private array $action ) {}
@@ -90,9 +91,9 @@ if ( ! function_exists( 'delete_option' ) ) {
 if ( ! function_exists( 'apply_filters' ) ) {
     function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
     	unset( $args );
-    	if ( 'datamachine_pipeline_ai_concurrency_limit' === $hook ) {
-    		return 1;
-    	}
+		if ( 'datamachine_pipeline_ai_concurrency_limit' === $hook && null !== $GLOBALS['datamachine_ai_backpressure_concurrency_limit_filter'] ) {
+			return $GLOBALS['datamachine_ai_backpressure_concurrency_limit_filter'];
+		}
     	if ( 'datamachine_pipeline_ai_throttle_delay' === $hook ) {
     		return 7;
     	}
@@ -182,10 +183,24 @@ use DataMachine\Engine\AI\PipelineAIConcurrencyLease;
 use DataMachine\Engine\AI\PipelineAIConcurrencyLimiter;
 use DataMachine\Engine\AI\AIConcurrencyBackpressure;
 
+echo "Case 0: concurrency settings use the canonical default and preserve overrides\n";
+$default_limit = PipelineAIConcurrencyLimiter::acquire( 'openai' );
+assert_ai_backpressure_smoke( 'absent concurrency setting uses canonical default', 3 === ( $default_limit['limit'] ?? 0 ) );
+$default_limit['lease']->release();
+
+$GLOBALS['datamachine_ai_backpressure_options']['datamachine_settings'] = array( 'pipeline_ai_concurrency_limit' => 2 );
+\DataMachine\Core\PluginSettings::clearCache();
+$explicit_limit = PipelineAIConcurrencyLimiter::acquire( 'openai' );
+assert_ai_backpressure_smoke( 'explicit concurrency setting overrides canonical default', 2 === ( $explicit_limit['limit'] ?? 0 ) );
+$explicit_limit['lease']->release();
+
+$GLOBALS['datamachine_ai_backpressure_concurrency_limit_filter'] = 1;
+
 echo "Case 1: first AI step acquires the single site slot\n";
 $first = PipelineAIConcurrencyLimiter::acquire( 'openai', array( 'job_id' => 101, 'flow_step_id' => 'ai-1' ) );
 assert_ai_backpressure_smoke( 'first acquire succeeds', true === $first['acquired'] );
 assert_ai_backpressure_smoke( 'first acquire returns lease', ( $first['lease'] ?? null ) instanceof PipelineAIConcurrencyLease );
+assert_ai_backpressure_smoke( 'concurrency filter overrides explicit setting', 1 === ( $first['limit'] ?? 0 ) );
 
 echo "Case 2: second concurrent AI step is throttled\n";
 $second = PipelineAIConcurrencyLimiter::acquire( 'openai', array( 'job_id' => 102, 'flow_step_id' => 'ai-1' ) );


### PR DESCRIPTION
## Summary
- Resolve the site-wide pipeline AI concurrency fallback from `PluginSettings::DEFAULT_PIPELINE_AI_CONCURRENCY_LIMIT` instead of a divergent limiter-local value.
- Remove duplicate default ownership from the limiter while preserving explicit settings, provider caps, filters, lease fencing, and backpressure behavior.
- Make the AI backpressure smoke harness dual-context: standalone mode retains the full in-memory scheduler suite, while loaded WordPress uses real APIs without redeclaring core or Action Scheduler functions.

## Production Evidence
Production event-import proof jobs had no stored `pipeline_ai_concurrency_limit`, yet throttle metadata reported `limit: 1`. The European proof cohort included 83 jobs repeatedly deferred behind `datamachine_resume_ai_step`, with roughly 1,000 resume actions queued while fixed scheduler failure signatures remained zero.

## Root Cause
`PluginSettings::getDefaults()` declares the concurrency default as 3, but `PipelineAIConcurrencyLimiter::resolveScopes()` passed its own private fallback of 1 to `PluginSettings::resolve()`. Because concurrency is a site-local setting and no value was stored, `resolve()` correctly returned the caller-provided fallback, making the runtime limit disagree with the settings API and admin default.

## Ownership
Data Machine's limiter owns admission to pipeline AI capacity, while `PluginSettings` owns canonical plugin defaults. The fix keeps resolution in the limiter but points it at the settings-owned constant, rather than duplicating or synchronizing another default.

## Behavior
Before: an absent stored setting resolved to 1 at runtime even though settings surfaces declared 3.

After: an absent stored setting resolves to 3. Explicit site values still win, the site-wide filter still runs after setting resolution, and provider-specific scopes, lease cleanup/fencing, and retry backpressure are unchanged.

## Verification
- `php tests/ai-step-backpressure-smoke.php` - 61 assertions, 0 failures.
- Loaded-WordPress Homeboy Test job - passed on commit `46c12b4cdfac842d9d9f98b894dd36b396cc8445`.
- `php -l tests/ai-step-backpressure-smoke.php` - passed.
- `vendor/bin/phpcs tests/ai-step-backpressure-smoke.php` - passed.
- `git diff --check origin/main...HEAD` - passed.
- Fresh PR CI run `30059142561` - Plan, Test, Lint, Refactor, Audit, and prefix-policy all passed.
- Independent final diff review found no behavioral or layer-ownership regressions.

## Residual Risk
The test changes are isolated to harness context detection and temporary sandbox settings/filter cleanup. Production limiter behavior remains covered in both standalone and loaded-WordPress execution paths.

Fixes #2982