### PR TITLE
Move generic WordPress guidance to wp-coding-agents

### DIFF
--- a/inc/migrations/agents-md.php
+++ b/inc/migrations/agents-md.php
@@ -84,10 +84,9 @@ function datamachine_register_agents_md_file(): void {
  * off this is a no-op, so even if a stray AGENTS.md file exists it composes to
  * nothing from core.
  *
- * Sections registered here are the generic shell DMC historically owned plus
- * the reflected `datamachine` section this change introduces. Data Machine Code
- * keeps only its own `datamachine-code` section (and the workspace inventory),
- * which slot in by priority when DMC is active.
+ * Sections registered here describe Data Machine itself. The external coding
+ * runtime installer owns generic WordPress coding guidance, while Data Machine
+ * Code owns its `datamachine-code` section and workspace inventory.
  *
  * @return void
  */
@@ -98,7 +97,7 @@ function datamachine_register_agents_md_sections(): void {
 
 	$wp = datamachine_agents_md_wp_cli_cmd();
 
-	$generic_meta = array(
+	$core_meta = array(
 		'owner'      => 'data-machine',
 		'freshness'  => 'static',
 		'conditions' => 'Registered when DATAMACHINE_COMPOSE_AGENTS_MD is enabled.',
@@ -117,7 +116,7 @@ function datamachine_register_agents_md_sections(): void {
 <!-- edit registered sections in their owning plugins, not this file -->
 MD;
 		},
-		array_merge( $generic_meta, array( 'freshness' => 'generated' ) )
+		array_merge( $core_meta, array( 'freshness' => 'generated' ) )
 	);
 
 	// The reflected `datamachine` command-surface section.
@@ -131,42 +130,6 @@ MD;
 			'freshness'  => 'snapshot',
 			'conditions' => 'Registered when DATAMACHINE_COMPOSE_AGENTS_MD is enabled; command list reflected from registered command classes.',
 		)
-	);
-
-	// Abilities.
-	SectionRegistry::register(
-		'AGENTS.md',
-		'abilities',
-		20,
-		function () {
-			return <<<'MD'
-## Abilities
-
-WordPress Abilities are the universal tool surface. Plugins register abilities that are automatically available via REST API, MCP, and chat.
-
-Use the active runtime tool listings exposed to MCP/chat/REST, and plugin-specific `--help` output, before assuming what's available.
-MD;
-		},
-		$generic_meta
-	);
-
-	// WordPress source (read-only reference).
-	SectionRegistry::register(
-		'AGENTS.md',
-		'wordpress-source',
-		30,
-		function () {
-			return <<<'MD'
-## WordPress Source (Read-Only Reference)
-
-These directories are **read-only reference material** — grep and read them to understand code, but never edit them directly.
-
-- `wp-content/plugins/` — plugin source (read-only)
-- `wp-content/themes/` — theme source (read-only)
-- `wp-includes/` — WordPress core (read-only)
-MD;
-		},
-		$generic_meta
 	);
 
 	// Multisite (only on multisite installs).
@@ -186,7 +149,7 @@ This is a WordPress multisite. Use `--url` to target specific sites:
 Without `--url`, commands default to the main site.
 MD;
 			},
-			array_merge( $generic_meta, array( 'conditions' => 'Only registered on multisite installs when the gate is enabled.' ) )
+			array_merge( $core_meta, array( 'conditions' => 'Only registered on multisite installs when the gate is enabled.' ) )
 		);
 	}
 }

--- a/tests/agents-md-section-ownership-smoke.php
+++ b/tests/agents-md-section-ownership-smoke.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace DataMachine\Engine\AI {
+	final class MemoryFileRegistry {
+		public const LAYER_SHARED = 'shared';
+		public const MODE_ALL = 'all';
+
+		public static function register( string $file, int $priority, array $metadata ): void {}
+	}
+
+	final class SectionRegistry {
+		public static array $sections = array();
+
+		public static function register( string $file, string $section, int $priority, callable $callback, array $metadata ): void {
+			self::$sections[ $section ] = compact( 'file', 'section', 'priority', 'callback', 'metadata' );
+		}
+	}
+}
+
+namespace DataMachine\Cli {
+	final class CommandRegistry {
+		public static function map(): array {
+			return array();
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', '/var/www/html/' );
+	define( 'DATAMACHINE_COMPOSE_AGENTS_MD', true );
+
+	function apply_filters( string $hook, mixed $value ): mixed {
+		return $value;
+	}
+
+	function add_action( string $hook, callable $callback, int $priority = 10 ): void {}
+
+	function is_multisite(): bool {
+		return false;
+	}
+
+	require_once dirname( __DIR__ ) . '/inc/migrations/agents-md.php';
+
+	datamachine_register_agents_md_sections();
+	$sections = \DataMachine\Engine\AI\SectionRegistry::$sections;
+
+	if ( ! isset( $sections['auto-generated-marker'], $sections['datamachine'] ) ) {
+		throw new \RuntimeException( 'Data Machine-owned AGENTS.md sections were not registered.' );
+	}
+	if ( isset( $sections['abilities'] ) || isset( $sections['wordpress-source'] ) ) {
+		throw new \RuntimeException( 'Generic WordPress guidance must be registered by wp-coding-agents.' );
+	}
+
+	fwrite( STDOUT, "agents-md section ownership smoke passed\n" );
+}


### PR DESCRIPTION
## Summary
- stop Data Machine core from registering generic WordPress Source and Abilities sections
- keep Data Machine focused on its own reflected command surface and composition substrate
- add an ownership smoke test proving generic sections are absent

## Dependency
Merge after https://github.com/Extra-Chill/wp-coding-agents/pull/293 so managed installs retain the sections throughout rollout.

## Verification
- php tests/agents-md-gated-composition-smoke.php
- php tests/agents-md-section-ownership-smoke.php
- php -l inc/migrations/agents-md.php

## AI assistance
OpenAI gpt-5.6-sol via OpenCode drafted the implementation, tests, and PR description. Chris Huber reviewed the architecture and remains responsible for the changes.