### PR TITLE
fix: preserve meaningful colon title suffixes

### DIFF
--- a/inc/Core/Similarity/SimilarityEngine.php
+++ b/inc/Core/Similarity/SimilarityEngine.php
@@ -129,6 +129,9 @@ class SimilarityEngine {
 	 * 2. Prefix match (one core title starts with the other, min 5 chars)
 	 * 3. Levenshtein distance (≤15% diff for titles ≥15 chars)
 	 *
+	 * Distinct meaningful suffixes on two colon-delimited titles short-circuit
+	 * this cascade with a no-match result and score 0.0. Thresholds are unchanged.
+	 *
 	 * Returns a SimilarityResult with match, score, and strategy.
 	 *
 	 * @param string $title1 First title.
@@ -138,6 +141,30 @@ class SimilarityEngine {
 	public static function titlesMatch( string $title1, string $title2 ): SimilarityResult {
 		$core1 = self::normalizeTitle( $title1 );
 		$core2 = self::normalizeTitle( $title2 );
+
+		// When both titles have meaningful colon suffixes, require those suffixes
+		// to be equivalent before the shared prefix can produce a match. Prefix
+		// matching is intentionally excluded because added suffix words may carry
+		// the distinguishing identity.
+		$colon1 = strpos( $title1, ':' );
+		$colon2 = strpos( $title2, ':' );
+		if ( false !== $colon1 && false !== $colon2 ) {
+			$suffix1 = self::normalizeTitle( substr( $title1, $colon1 + 1 ) );
+			$suffix2 = self::normalizeTitle( substr( $title2, $colon2 + 1 ) );
+			$suffix1 = preg_match( '/[a-z0-9]/i', $suffix1 ) ? $suffix1 : '';
+			$suffix2 = preg_match( '/[a-z0-9]/i', $suffix2 ) ? $suffix2 : '';
+
+			if ( '' !== $suffix1 && '' !== $suffix2 && $suffix1 !== $suffix2 ) {
+				$max_suffix_length = max( strlen( $suffix1 ), strlen( $suffix2 ) );
+				$suffixes_match    = strlen( $suffix1 ) >= self::MIN_LEVENSHTEIN_LENGTH
+					&& strlen( $suffix2 ) >= self::MIN_LEVENSHTEIN_LENGTH
+					&& levenshtein( $suffix1, $suffix2 ) <= (int) ( $max_suffix_length * self::DEFAULT_LEVENSHTEIN_TOLERANCE );
+
+				if ( ! $suffixes_match ) {
+					return SimilarityResult::noMatch( $core1, $core2 );
+				}
+			}
+		}
 
 		// Strategy 1: Exact match after normalization.
 		if ( $core1 === $core2 ) {
@@ -230,7 +257,7 @@ class SimilarityEngine {
 	 * - Unicode dash normalization
 	 * - Subreddit reference removal (core DuplicateDetection)
 	 * - Reaction/attribution suffix removal (core DuplicateDetection)
-	 * - Delimiter splitting: dashes, colons, pipes, featuring/with/+
+	 * - Delimiter splitting: dashes, pipes, featuring/with/+
 	 *   (events EventIdentifierGenerator)
 	 * - Comma-separated artist list handling (events EventIdentifierGenerator)
 	 * - Article removal, non-alnum stripping, whitespace collapse
@@ -277,8 +304,6 @@ class SimilarityEngine {
 			' - ',           // ASCII hyphen with spaces (catches normalized em/en dash)
 			' — ',           // em dash with spaces (pre-normalization)
 			' – ',           // en dash with spaces (pre-normalization)
-			' : ',           // colon with spaces
-			': ',            // colon
 			' | ',           // pipe with spaces
 			'|',             // pipe
 			' featuring ',
@@ -305,6 +330,10 @@ class SimilarityEngine {
 		if ( null !== $best_delim ) {
 			$text = substr( $text, 0, $best_pos );
 		}
+
+		// Colons separate meaningful title segments rather than disposable
+		// supporting information. Preserve each segment as normalized words.
+		$text = str_replace( ':', ' ', $text );
 
 		// Comma-separated artist lists: treat first segment as the headliner.
 		// "Comfort Club, Valories, Barb" → "Comfort Club"

--- a/tests/Unit/Core/Similarity/SimilarityEngineTest.php
+++ b/tests/Unit/Core/Similarity/SimilarityEngineTest.php
@@ -100,6 +100,14 @@ class SimilarityEngineTest extends WP_UnitTestCase {
 		$this->assertSame( 'andy frasco', $result );
 	}
 
+	public function test_normalize_title_preserves_colon_segments(): void {
+		$this->assertSame( 'archive chapter one', SimilarityEngine::normalizeTitle( 'Archive: Chapter One' ) );
+	}
+
+	public function test_normalize_title_handles_empty_and_repeated_colon_segments(): void {
+		$this->assertSame( 'archive chapter one', SimilarityEngine::normalizeTitle( 'Archive:: Chapter One:' ) );
+	}
+
 	public function test_normalize_title_short_fallback(): void {
 		// Very short title falls back to normalizeBasic.
 		$result = SimilarityEngine::normalizeTitle( 'Hi' );
@@ -176,6 +184,75 @@ class SimilarityEngineTest extends WP_UnitTestCase {
 			'Andy Frasco & The U.N.'
 		);
 		$this->assertTrue( $result->match );
+	}
+
+	/**
+	 * @dataProvider colon_titles_provider
+	 */
+	public function test_colon_title_matching( string $title1, string $title2, bool $expected ): void {
+		$result = SimilarityEngine::titlesMatch( $title1, $title2 );
+
+		$this->assertSame( $expected, $result->match );
+		if ( ! $expected ) {
+			$this->assertSame( 0.0, $result->score );
+			$this->assertSame( SimilarityResult::STRATEGY_NONE, $result->strategy );
+		}
+	}
+
+	public function colon_titles_provider(): array {
+		return array(
+			'distinct suffixes after shared prefix' => array(
+				'Burgundy: Soul Nite',
+				'Burgundy: Funk Nite',
+				false,
+			),
+			'distinct suffixes after long prefix'   => array(
+				'The Complete Archive Collection: Chapter One',
+				'The Complete Archive Collection: Chapter Two',
+				false,
+			),
+			'distinct nested colon suffixes'        => array(
+				'Archive: Volume One: Red Edition',
+				'Archive: Volume One: Blue Edition',
+				false,
+			),
+			'added meaningful suffix words'          => array(
+				'Archive: Holiday Special',
+				'Archive: Holiday Special Extended Edition',
+				false,
+			),
+			'distinct short suffixes'               => array( 'Series: A', 'Series: B', false ),
+			'equivalent case and punctuation'       => array(
+				'Archive: The Holiday Special!',
+				'archive : holiday special',
+				true,
+			),
+			'equivalent whitespace'                 => array(
+				'Archive:   Holiday Special',
+				'Archive : Holiday   Special',
+				true,
+			),
+			'equivalent without colon'              => array(
+				'Archive: Holiday Special',
+				'Archive Holiday Special',
+				true,
+			),
+			'empty suffix'                          => array( 'Archive:', 'Archive', true ),
+			'empty suffixes on both titles'          => array( 'Archive:', 'Archive::', true ),
+			'punctuation-only suffixes'              => array( 'Archive: :', 'Archive:::', true ),
+			'repeated empty suffixes'               => array( 'Archive::', 'Archive', true ),
+			'repeated meaningful segments'           => array(
+				'Archive:: Volume One:: Red Edition',
+				'Archive: Volume One: Blue Edition',
+				false,
+			),
+			'one-sided meaningful suffix'           => array( 'Jazz Night: Holiday Special', 'Jazz Night', true ),
+			'close meaningful suffix variants'      => array(
+				'Series: Advanced Programming Techniques',
+				'Series: Advanced Programing Techniques',
+				true,
+			),
+		);
 	}
 
 	public function test_titles_match_returns_similarity_result(): void {


### PR DESCRIPTION
## Summary
- preserve normalized text after colons so a shared series prefix cannot erase distinguishing identity
- require two meaningful colon suffixes to be equivalent without allowing prefix-only suffix matches
- cover distinct, equivalent, missing, empty, short, punctuation-only, repeated, and nested colon segments

## Verification
- focused SimilarityEngine suite: 60 tests, 100 assertions passed
- downstream Data Machine Events title identity fixtures: 10 passed, including the Burgundy Soul/Funk pair
- changed-file PHPCS and PHPStan level 7: passed
- changed-scope architectural audit: passed with no introduced findings
- full PHPStan: passed with zero findings
- full WordPress suite attempted but blocked before bootstrap by MySQL Docker provisioning (`homeboy-extensions#2006`)
- unscoped lint reached 115 pre-existing findings in unrelated files; changed-file lint is clean

Closes #2985