### PR TITLE
fix: report real job counts in worker status

### DIFF
--- a/inc/Cli/Commands/WorkerCommand.php
+++ b/inc/Cli/Commands/WorkerCommand.php
@@ -9,10 +9,10 @@
 namespace DataMachine\Cli\Commands;
 
 use DataMachine\Abilities\Engine\DrainJobAbility;
-use DataMachine\Abilities\Job\JobsSummaryAbility;
 use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Cli\WorkerLock;
+use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 use WP_CLI;
 
@@ -614,8 +614,7 @@ class WorkerCommand extends BaseCommand {
 		$lane            = self::normalizeLane( $lane );
 		$pending_summary = PendingActionStore::summary( array( 'status' => 'pending' ) );
 		$drain_status    = DrainCommand::status( array( 'lane' => $lane ) );
-		$jobs_summary    = ( new JobsSummaryAbility() )->execute( array( 'compact' => true ) );
-		$jobs            = ! empty( $jobs_summary['success'] ) && is_array( $jobs_summary['summary'] ?? null ) ? $jobs_summary['summary'] : array();
+		$job_counts      = self::jobStatusCounts();
 		$stuck_jobs      = RecoverStuckJobsAbility::countStuckCandidates();
 		$lock            = WorkerLock::snapshot( null, 600, $lane );
 
@@ -625,29 +624,30 @@ class WorkerCommand extends BaseCommand {
 			'due_actions'           => (int) ( $drain_status['due_pending'] ?? 0 ),
 			'total_pending_actions' => (int) ( $drain_status['total_pending'] ?? 0 ),
 			'action_hooks'          => (string) ( $drain_status['hooks'] ?? '' ),
-			'processing_jobs'       => self::jobStatusCount( $jobs, 'processing' ),
-			'pending_jobs'          => self::jobStatusCount( $jobs, 'pending' ),
-			'failed_jobs'           => (int) ( $jobs['failed_count'] ?? self::jobStatusCount( $jobs, 'failed' ) ),
+			'processing_jobs'       => $job_counts['processing'],
+			'pending_jobs'          => $job_counts['pending'],
+			'failed_jobs'           => $job_counts['failed'],
 			'stuck_jobs'            => $stuck_jobs,
 			'lane'                  => $lane,
 		) + self::publicLockStatus( $lock );
 	}
 
 	/**
-	 * Read one normalized status bucket from a jobs summary result.
+	 * Count global job status buckets for the operator worker process.
 	 *
-	 * @param array<string,mixed> $jobs   Jobs summary payload.
-	 * @param string              $status Normalized status bucket.
-	 * @return int Bucket count.
+	 * This intentionally uses the repository rather than the user-facing jobs
+	 * summary ability, whose ownership checks require an acting user.
+	 *
+	 * @return array{processing:int,pending:int,failed:int} Status counts.
 	 */
-	private static function jobStatusCount( array $jobs, string $status ): int {
-		foreach ( (array) ( $jobs['status'] ?? array() ) as $row ) {
-			if ( (string) ( $row['status'] ?? '' ) === $status ) {
-				return (int) ( $row['count'] ?? 0 );
-			}
-		}
+	private static function jobStatusCounts(): array {
+		$jobs = new Jobs();
 
-		return 0;
+		return array(
+			'processing' => $jobs->get_jobs_count( array( 'status' => 'processing' ), true ),
+			'pending'    => $jobs->get_jobs_count( array( 'status' => 'pending' ), true ),
+			'failed'     => $jobs->get_jobs_count( array( 'status' => 'failed' ), true ),
+		);
 	}
 
 	/**
@@ -834,7 +834,7 @@ class WorkerCommand extends BaseCommand {
 	 * Count pending approval actions.
 	 */
 	private static function pendingActionCount(): int {
-		$status = self::statusSnapshot();
-		return (int) $status['pending_actions'];
+		$summary = PendingActionStore::summary( array( 'status' => 'pending' ) );
+		return (int) ( $summary['total'] ?? 0 );
 	}
 }

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -567,13 +567,14 @@ class Jobs extends BaseRepository {
 	/**
 	 * Get jobs count with optional filtering.
 	 *
-	 * @param array $args Filter arguments:
+	 * @param array $args          Filter arguments:
 	 *                    - flow_id: Filter by flow ID or 'direct' (optional)
 	 *                    - pipeline_id: Filter by pipeline ID or 'direct' (optional)
 	 *                    - status: Filter by status (optional)
+	 * @param bool  $fail_on_error Throw when the database query fails.
 	 * @return int Total count
 	 */
-	public function get_jobs_count( array $args = array() ): int {
+	public function get_jobs_count( array $args = array(), bool $fail_on_error = false ): int {
 		$where_clauses = array();
 		$where_values  = array();
 
@@ -647,6 +648,10 @@ class Jobs extends BaseRepository {
 		// phpcs:disable WordPress.DB.PreparedSQL -- The query variable is fully prepared immediately above.
 		$count = $this->wpdb->get_var( $query );
 		// phpcs:enable WordPress.DB.PreparedSQL
+		if ( null === $count && $fail_on_error ) {
+			$error = (string) $this->wpdb->last_error;
+			throw new \RuntimeException( '' !== $error ? 'Unable to count jobs: ' . esc_html( $error ) : 'Unable to count jobs: database query returned no result.' );
+		}
 
 		return (int) $count;
 	}

--- a/tests/worker-cli-smoke.php
+++ b/tests/worker-cli-smoke.php
@@ -46,9 +46,12 @@ assert_worker_contains( 'DrainCommand::ensureCliMemoryLimit()', $worker_src, 'wo
 assert_worker_contains( "'acquire_lock' => false", $worker_src, 'worker internal drain does not fight outer lock' );
 assert_worker_contains( 'PendingActionStore::summary', $worker_src, 'worker reads pending-action gate through the store' );
 assert_worker_contains( 'if ( $stop_on_pending_actions && self::pendingActionCount() > 0 )', $worker_src, 'worker only reads pending-action gate when the stop option is enabled' );
-assert_worker_contains( 'JobsSummaryAbility', $worker_src, 'worker reads job status through the existing summary ability' );
-assert_worker_contains( "'compact' => true", $worker_src, 'worker status uses compact job summary' );
-assert_worker_contains( 'jobStatusCount', $worker_src, 'worker reads normalized job status buckets' );
+assert_worker_contains( 'jobStatusCounts', $worker_src, 'worker reads global job status through the repository' );
+assert_worker_contains( "get_jobs_count( array( 'status' => 'processing' ), true )", $worker_src, 'worker counts processing jobs without loading job rows' );
+assert_worker_contains( "get_jobs_count( array( 'status' => 'pending' ), true )", $worker_src, 'worker counts pending jobs without loading job rows' );
+assert_worker_contains( "get_jobs_count( array( 'status' => 'failed' ), true )", $worker_src, 'worker counts failed jobs without loading job rows' );
+assert_worker_not_contains( 'JobsSummaryAbility', $worker_src, 'worker does not cross the ownership-gated jobs summary ability' );
+assert_worker_contains( "PendingActionStore::summary( array( 'status' => 'pending' ) )", $worker_src, 'pending-action gate avoids building the full worker status snapshot' );
 assert_worker_contains( 'stop_on_pending_actions', $worker_src, 'worker can stop at approval gates' );
 assert_worker_contains( 'max_passes', $worker_src, 'worker supports bounded pass counts' );
 assert_worker_contains( 'stop_before_timeout', $worker_src, 'worker exits before external supervisor timeouts' );

--- a/tests/worker-status-job-counts-smoke.php
+++ b/tests/worker-status-job-counts-smoke.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Regression coverage for global worker status job counts.
+ *
+ * Run with: php tests/worker-status-job-counts-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ . '/' );
+define( 'ARRAY_A', 'ARRAY_A' );
+
+class WP_CLI_Command {}
+
+function sanitize_text_field( $value ): string {
+	return trim( (string) $value );
+}
+
+function esc_html( $value ): string {
+	return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+}
+
+final class WorkerStatusCountsWpdb {
+	public string $prefix = 'wp_';
+	public string $last_error = '';
+	/** @var int[] */
+	public array $counts = array( 9, 1122, 5739 );
+	/** @var array<int,array<int,mixed>> */
+	public array $prepare_calls = array();
+
+	public function esc_like( string $value ): string {
+		return $value;
+	}
+
+	public function prepare( string $query, ...$args ): string {
+		$this->prepare_calls[] = 1 === count( $args ) && is_array( $args[0] ) ? $args[0] : $args;
+		return $query;
+	}
+
+	public function get_var( string $query ) {
+		unset( $query );
+		return array_shift( $this->counts );
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
+require_once __DIR__ . '/../inc/Cli/BaseCommand.php';
+require_once __DIR__ . '/../inc/Cli/Commands/WorkerCommand.php';
+
+use DataMachine\Cli\Commands\WorkerCommand;
+
+$assertions = 0;
+$assert     = static function ( bool $condition, string $message ) use ( &$assertions ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+};
+
+$wpdb            = new WorkerStatusCountsWpdb();
+$GLOBALS['wpdb'] = $wpdb;
+$method          = new ReflectionMethod( WorkerCommand::class, 'jobStatusCounts' );
+$counts          = $method->invoke( null );
+
+$assert( array( 'processing' => 9, 'pending' => 1122, 'failed' => 5739 ) === $counts, 'operator status returns global repository counts without an acting user' );
+$assert( 3 === count( $wpdb->prepare_calls ), 'operator status performs only three COUNT queries' );
+$assert( 'processing%' === $wpdb->prepare_calls[0][1], 'processing count uses the normalized status prefix' );
+$assert( 'pending%' === $wpdb->prepare_calls[1][1], 'pending count uses the normalized status prefix' );
+$assert( 'failed%' === $wpdb->prepare_calls[2][1], 'failed count includes compound failure statuses' );
+
+$wpdb->counts     = array( null );
+$wpdb->last_error = 'simulated count failure';
+
+try {
+	$method->invoke( null );
+	$assert( false, 'count failures must not become healthy-looking zeros' );
+} catch ( RuntimeException $exception ) {
+	$assert( str_contains( $exception->getMessage(), 'simulated count failure' ), 'count failure is surfaced with database context' );
+}
+
+echo "OK ({$assertions} assertions)\n";


### PR DESCRIPTION
## Summary
- read worker job status directly from the global jobs repository instead of crossing the ownership-gated jobs summary ability
- report pending, processing, and failed status-prefix counts through lightweight indexed `COUNT` queries
- surface worker count query failures instead of converting authorization or database failures into healthy-looking zeros
- keep the pending-approval gate lightweight by querying `PendingActionStore` directly

## Production Evidence
On `events.extrachill.com`, unauthenticated operator status reported:

```json
{"processing_jobs":0,"pending_jobs":0,"failed_jobs":0}
```

An authenticated `wp --user=1 datamachine jobs summary --format=json` reported 1,122 pending jobs and `failed_count` 5,739. Without `--user`, the jobs summary correctly returned `An authenticated acting caller is required to list owned jobs`.

## Root Cause
`WorkerCommand::statusSnapshot()` called `JobsSummaryAbility::execute()` without an acting user. The ability correctly rejected that ownership-less request, but worker status silently replaced the unsuccessful result with an empty array and rendered all job buckets as zero.

## Ownership Rationale
The user-facing jobs summary ability and its ownership checks are unchanged. Worker status is an operator-only WP-CLI path, so it now calls the internal/global `Jobs` repository directly rather than impersonating a user or weakening generic access controls.

## Before / After
- Before: an ownership error was discarded and pending, processing, and failed jobs appeared as zero.
- After: worker status returns global status-prefix counts; a failed count query throws with database context and cannot masquerade as zero.
- Lane normalization, drain status, stuck-job counting, and worker lock reporting are unchanged.

## Query And Performance Implications
Worker status performs three `SELECT COUNT(job_id)` queries filtered by the existing indexed status prefix (`processing%`, `pending%`, and `failed%`). It does not hydrate job rows, decode `engine_data`, or load the full 115k-job summary. The stop-on-pending-actions loop continues to query only the pending-action store rather than rebuilding the worker snapshot.

## Tests
- `php tests/worker-status-job-counts-smoke.php`
- `php tests/jobs-list-efficiency-smoke.php`
- `php tests/recover-stuck-bounded-memory-smoke.php`
- PHP syntax checks for all changed PHP files
- PHPCS on all changed files
- Homeboy changed-file lint and PHPStan passed
- Independent final review found no remaining permission, performance, or layering regression

The full Homeboy test gate could not start because its managed MySQL 8.4 Docker service failed provisioning before test execution. The existing `tests/worker-cli-smoke.php` also has an unrelated stale lock-source assertion on `origin/main`, tracked in #2987.

## Residual Risks
There is no end-to-end WP-CLI fixture against a real jobs table in this change. Focused coverage exercises the exact global count helper, status-prefix semantics, no-acting-user path, strict query failure behavior, and lightweight query count.

Fixes #2986