### PR TITLE
fix: reconcile status during post upserts

### DIFF
--- a/inc/Abilities/Content/UpsertPostAbility.php
+++ b/inc/Abilities/Content/UpsertPostAbility.php
@@ -592,17 +592,18 @@ class UpsertPostAbility {
 		$meta_input        = $context['meta_input'];
 		$has_reservation   = null !== $reservation && $reservations instanceof PostIdentityReservations;
 
-		// Idempotency check. Parent/slug changes still need a write even when
-		// the content hash is unchanged.
+		// Idempotency check. Parent/slug/status changes still need a write even
+		// when the content hash is unchanged.
 		if ( $existing_id > 0 && '' !== $content_hash ) {
 			$stored_hash = get_post_meta( $existing_id, self::META_CONTENT_HASH, true );
 			$post        = get_post( $existing_id );
 			$same_parent = ! $post instanceof \WP_Post || $parent_id <= 0 || (int) $post->post_parent === $parent_id;
 			$same_slug   = ! $post instanceof \WP_Post || '' === $slug || (string) $post->post_name === $slug;
+			$same_status = ! $post instanceof \WP_Post || (string) $post->post_status === $post_status;
 
 			$identity_complete = ! $has_reservation
 				|| (string) get_post_meta( $existing_id, $reservation['identity']['meta_key'], true ) === $reservation['identity']['meta_value'];
-			if ( $stored_hash === $content_hash && $same_parent && $same_slug && $identity_complete ) {
+			if ( $stored_hash === $content_hash && $same_parent && $same_slug && $same_status && $identity_complete ) {
 				self::applySourceMetadata( $existing_id, $source_url, $original_date_gmt );
 				if ( $has_reservation ) {
 					$completed = $reservations->mark_complete( $reservation['identity'], $existing_id );

--- a/inc/Abilities/Content/UpsertPostAbility.php
+++ b/inc/Abilities/Content/UpsertPostAbility.php
@@ -591,12 +591,12 @@ class UpsertPostAbility {
 		$taxonomies        = $context['taxonomies'];
 		$meta_input        = $context['meta_input'];
 		$has_reservation   = null !== $reservation && $reservations instanceof PostIdentityReservations;
+		$post              = $existing_id > 0 ? get_post( $existing_id ) : null;
 
 		// Idempotency check. Parent/slug/status changes still need a write even
 		// when the content hash is unchanged.
 		if ( $existing_id > 0 && '' !== $content_hash ) {
 			$stored_hash = get_post_meta( $existing_id, self::META_CONTENT_HASH, true );
-			$post        = get_post( $existing_id );
 			$same_parent = ! $post instanceof \WP_Post || $parent_id <= 0 || (int) $post->post_parent === $parent_id;
 			$same_slug   = ! $post instanceof \WP_Post || '' === $slug || (string) $post->post_name === $slug;
 			$same_status = ! $post instanceof \WP_Post || (string) $post->post_status === $post_status;
@@ -623,6 +623,17 @@ class UpsertPostAbility {
 					'post_id'  => $existing_id,
 					'post_url' => get_permalink( $existing_id ),
 					'path'     => ResolvePostByPath::build_path( $existing_id ),
+				);
+			}
+		}
+
+		if ( $post instanceof \WP_Post && 'trash' === $post->post_status && 'trash' !== $post_status ) {
+			$untrashed = wp_untrash_post( $existing_id );
+			if ( ! $untrashed || 'trash' === get_post_status( $existing_id ) ) {
+				return array(
+					'success'    => false,
+					'error'      => 'Post could not be restored from the Trash.',
+					'error_code' => 'post_untrash_failed',
 				);
 			}
 		}

--- a/tests/Unit/Abilities/Content/UpsertPostAbilityTest.php
+++ b/tests/Unit/Abilities/Content/UpsertPostAbilityTest.php
@@ -142,6 +142,36 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( 'complete', $this->repository->get_reservation( $identity['identity_hash'] )['state'] );
 	}
 
+	public function test_trashed_post_with_matching_content_is_republished(): void {
+		$post_id = $this->create_hashed_post( 'trash' );
+
+		$result = UpsertPostAbility::execute( $this->status_input( $post_id, 'publish' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'updated', $result['action'] );
+		$this->assertSame( 'publish', get_post_status( $post_id ) );
+	}
+
+	public function test_draft_post_with_matching_content_is_published(): void {
+		$post_id = $this->create_hashed_post( 'draft' );
+
+		$result = UpsertPostAbility::execute( $this->status_input( $post_id, 'publish' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'updated', $result['action'] );
+		$this->assertSame( 'publish', get_post_status( $post_id ) );
+	}
+
+	public function test_matching_status_and_content_remains_no_change(): void {
+		$post_id = $this->create_hashed_post( 'publish' );
+
+		$result = UpsertPostAbility::execute( $this->status_input( $post_id, 'publish' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'no_change', $result['action'] );
+		$this->assertSame( 'publish', get_post_status( $post_id ) );
+	}
+
 	public function test_empty_partial_and_zero_identity_values_keep_slug_fallback_behavior(): void {
 		$cases = array(
 			array(),
@@ -448,6 +478,36 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 				'key'   => '_source',
 				'value' => $value,
 			),
+		);
+	}
+
+	private function create_hashed_post( string $post_status ): int {
+		$content = '<!-- wp:paragraph --><p>Status body</p><!-- /wp:paragraph -->';
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Status reconciliation',
+				'post_content' => $content,
+				'post_status'  => 'trash' === $post_status ? 'publish' : $post_status,
+			)
+		);
+		if ( 'trash' === $post_status ) {
+			wp_trash_post( $post_id );
+		}
+		update_post_meta( $post_id, UpsertPostAbility::META_CONTENT_HASH, hash( 'sha256', $content ) );
+
+		return $post_id;
+	}
+
+	private function status_input( int $post_id, string $post_status ): array {
+		$content = '<!-- wp:paragraph --><p>Status body</p><!-- /wp:paragraph -->';
+
+		return array(
+			'post_type'    => 'post',
+			'post_id'      => $post_id,
+			'title'        => 'Status reconciliation',
+			'content'      => $content,
+			'content_hash' => hash( 'sha256', $content ),
+			'post_status'  => $post_status,
 		);
 	}
 

--- a/tests/Unit/Abilities/Content/UpsertPostAbilityTest.php
+++ b/tests/Unit/Abilities/Content/UpsertPostAbilityTest.php
@@ -142,14 +142,46 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( 'complete', $this->repository->get_reservation( $identity['identity_hash'] )['state'] );
 	}
 
-	public function test_trashed_post_with_matching_content_is_republished(): void {
-		$post_id = $this->create_hashed_post( 'trash' );
+	public function test_trashed_post_is_untrashed_before_republishing(): void {
+		$post_id    = $this->create_hashed_post( 'publish' );
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+			)
+		);
+		wp_trash_post( $post_id );
 
-		$result = UpsertPostAbility::execute( $this->status_input( $post_id, 'publish' ) );
+		$this->assertSame( 'publish', get_post_meta( $post_id, '_wp_trash_meta_status', true ) );
+		$this->assertNotEmpty( get_post_meta( $post_id, '_wp_trash_meta_time', true ) );
+		$this->assertSame( 'post-trashed', get_comment( $comment_id )->comment_approved );
+
+		$before_hooks = array();
+		$after_hooks  = array();
+		$before_hook  = static function ( int $hook_post_id, string $previous_status ) use ( &$before_hooks ): void {
+			$before_hooks[] = array( $hook_post_id, $previous_status, get_post_status( $hook_post_id ) );
+		};
+		$after_hook   = static function ( int $hook_post_id, string $previous_status ) use ( &$after_hooks ): void {
+			$after_hooks[] = array( $hook_post_id, $previous_status, get_post_status( $hook_post_id ) );
+		};
+		add_action( 'untrash_post', $before_hook, 10, 2 );
+		add_action( 'untrashed_post', $after_hook, 10, 2 );
+		try {
+			$result = UpsertPostAbility::execute( $this->status_input( $post_id, 'publish' ) );
+		} finally {
+			remove_action( 'untrash_post', $before_hook, 10 );
+			remove_action( 'untrashed_post', $after_hook, 10 );
+		}
 
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( 'updated', $result['action'] );
 		$this->assertSame( 'publish', get_post_status( $post_id ) );
+		$this->assertSame( '', get_post_meta( $post_id, '_wp_trash_meta_status', true ) );
+		$this->assertSame( '', get_post_meta( $post_id, '_wp_trash_meta_time', true ) );
+		$this->assertSame( '', get_post_meta( $post_id, '_wp_trash_meta_comments_status', true ) );
+		$this->assertSame( '1', get_comment( $comment_id )->comment_approved );
+		$this->assertSame( array( array( $post_id, 'publish', 'trash' ) ), $before_hooks );
+		$this->assertSame( array( array( $post_id, 'publish', 'draft' ) ), $after_hooks );
 	}
 
 	public function test_draft_post_with_matching_content_is_published(): void {
@@ -487,12 +519,9 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 			array(
 				'post_title'   => 'Status reconciliation',
 				'post_content' => $content,
-				'post_status'  => 'trash' === $post_status ? 'publish' : $post_status,
+				'post_status'  => $post_status,
 			)
 		);
-		if ( 'trash' === $post_status ) {
-			wp_trash_post( $post_id );
-		}
 		update_post_meta( $post_id, UpsertPostAbility::META_CONTENT_HASH, hash( 'sha256', $content ) );
 
 		return $post_id;


### PR DESCRIPTION
## Summary
- include requested post status in the content-hash idempotency decision
- restore trashed posts through WordPress core's `wp_untrash_post()` lifecycle before applying the requested final status
- cover trash lifecycle cleanup/restoration, draft-to-publish, and matching-status no-change behavior

## Root cause
`UpsertPostAbility::execute_resolved_write()` returned `no_change` when content hash, parent, slug, and identity metadata matched, without comparing the resolved post's current status to the normalized requested `post_status`.

The first revision correctly routed status-only differences into a write, but direct `wp_insert_post()` updates from `trash` to `publish` bypass WordPress's untrash lifecycle. That left `_wp_trash_meta_status`, `_wp_trash_meta_time`, `_wp_trash_meta_comments_status`, trashed comment statuses, and untrash hooks unresolved.

## Implementation
WordPress core `wp_untrash_post()` in `wp-includes/post.php` owns restoration semantics: it fires `untrash_post`, removes trash metadata, transitions ordinary posts to `draft`, restores comments through `wp_untrash_post_comments()`, and fires `untrashed_post`. The generic upsert now calls that core primitive whenever an existing post is `trash` and the requested final status is not `trash`, verifies restoration succeeded, and then uses the existing write path to apply the caller's final status and remaining fields.

This remains generic across post types and identity strategies. It does not reimplement trash cleanup, add event-specific behavior, or alter ordinary status transitions.

## Regression coverage
`UpsertPostAbilityTest` now verifies:
- trash-to-publish returns `updated` and ends at `publish`
- `_wp_trash_meta_status`, `_wp_trash_meta_time`, and `_wp_trash_meta_comments_status` are removed
- approved comments move through `post-trashed` and return to their original status
- `untrash_post` runs while status is `trash`, and `untrashed_post` runs after core assigns `draft`
- draft-to-publish remains an ordinary update
- matching content and status remains `no_change`

## Tests
Exact head: `9d64de55d56c807a0d2beaf7944cb08c91ca893c`

- PASS: `php -l inc/Abilities/Content/UpsertPostAbility.php`
- PASS: `php -l tests/Unit/Abilities/Content/UpsertPostAbilityTest.php`
- PASS: `vendor/bin/phpcs inc/Abilities/Content/UpsertPostAbility.php tests/Unit/Abilities/Content/UpsertPostAbilityTest.php`
- PASS: `composer lint`
- PASS: `php tests/prefix-policy-audit.php` (11 passed, 0 failed)
- PASS: `homeboy review lint data-machine --path /var/lib/datamachine/workspace/data-machine@fix-2993-upsert-status --changed-since origin/main --placement local --json-summary` (PHPCS and PHPStan; no findings)
- BLOCKED before PHPUnit: `homeboy review test data-machine --path /var/lib/datamachine/workspace/data-machine@fix-2993-upsert-status --placement local -- --filter UpsertPostAbilityTest` could not provision Homeboy's managed MySQL 8.4 service because this host has no Docker binary. GitHub PR CI is the executable WordPress integration gate for these regressions.

## Residual risk
The intentional behavior change is limited to existing trashed posts requested in a non-trash status: they now execute WordPress's standard two-step restoration/final-status lifecycle, including its hooks. Local WordPress unit execution remains unavailable due to the host runtime dependency; fresh exact-head CI must confirm the lifecycle assertions in the repository's WordPress test environment.

Closes #2993

## Exact-head CI
GitHub Actions run `30162026538` executed against `9d64de55d56c807a0d2beaf7944cb08c91ca893c`. `prefix-policy` passed. Homeboy Audit, Lint, Refactor, and Test each failed at the action-output contract because the expected structured JSON result was missing or malformed; no code finding or PHPUnit assertion result was emitted. Local syntax, PHPCS, repository lint, prefix policy, and Homeboy lint/PHPStan results above remain the available executable evidence.