### PR TITLE
fix: preserve metadata for HTTP error responses

### DIFF
--- a/inc/Core/HttpClient.php
+++ b/inc/Core/HttpClient.php
@@ -45,7 +45,7 @@ class HttpClient {
 	 *                        - auth_ref: string - Optional provider:account credential reference resolved through registered auth providers
 	 *                        - browser_mode: bool - Use browser-like headers (default false)
 	 *                        - context: string - Context for logging (default 'HTTP Request')
-	 * @return array Response array.
+	 * @return array{success: true, data: string, status_code: int, headers: mixed, response: array}|array{success: false, error: string, data?: string, status_code?: int, headers?: mixed, response?: array} Response array. Received non-2xx responses include HTTP metadata; transport failures do not.
 	 */
 	public static function request( string $method, string $url, array $options = array() ): array {
 		$method       = strtoupper( $method );
@@ -102,7 +102,7 @@ class HttpClient {
 		$success_codes = self::SUCCESS_CODES[ $method ];
 
 		if ( ! in_array( $status_code, $success_codes, true ) ) {
-			return self::handleHttpError( $status_code, $body, $method, $url, $context );
+			return self::handleHttpError( $response, $status_code, $body, $method, $url, $context );
 		}
 
 		return array(
@@ -391,7 +391,7 @@ class HttpClient {
 	/**
 	 * Handle non-success HTTP status code
 	 */
-	private static function handleHttpError( int $status_code, string $body, string $method, string $url, string $context ): array {
+	private static function handleHttpError( array $response, int $status_code, string $body, string $method, string $url, string $context ): array {
 		$error_message = sprintf(
 			'%1$s %2$s returned HTTP %3$d',
 			$context,
@@ -423,8 +423,12 @@ class HttpClient {
 		);
 
 		return array(
-			'success' => false,
-			'error'   => $error_message,
+			'success'     => false,
+			'error'       => $error_message,
+			'data'        => $body,
+			'status_code' => $status_code,
+			'headers'     => wp_remote_retrieve_headers( $response ),
+			'response'    => $response,
 		);
 	}
 

--- a/inc/Core/Steps/Handlers/HttpRequestHelpers.php
+++ b/inc/Core/Steps/Handlers/HttpRequestHelpers.php
@@ -23,7 +23,7 @@ trait HttpRequestHelpers {
 	 * @param string $method  HTTP method (GET, POST, PUT, DELETE, PATCH).
 	 * @param string $url     Request URL.
 	 * @param array  $options Request options.
-	 * @return array{success: bool, data?: string, status_code?: int, headers?: array, response?: array, error?: string}
+	 * @return array{success: bool, data?: string, status_code?: int, headers?: mixed, response?: array, error?: string} Received non-2xx responses include HTTP metadata; transport failures do not.
 	 */
 	protected function httpRequest( string $method, string $url, array $options = array() ): array {
 		if ( ! isset( $options['context'] ) ) {

--- a/tests/http-client-error-response-contract-smoke.php
+++ b/tests/http-client-error-response-contract-smoke.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Smoke coverage for HttpClient error response metadata.
+ *
+ * Run with: php tests/http-client-error-response-contract-smoke.php
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url(): string {
+		return 'https://example.test';
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct(
+			private string $code = '',
+			private string $message = ''
+		) {}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( 'wp_remote_get' ) ) {
+	function wp_remote_get( string $url, array $args = array() ): array|WP_Error {
+		unset( $url, $args );
+		return array_shift( $GLOBALS['datamachine_http_client_responses'] );
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_response_code' ) ) {
+	function wp_remote_retrieve_response_code( array $response ): int {
+		return (int) ( $response['response']['code'] ?? 0 );
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
+	function wp_remote_retrieve_body( array $response ): string {
+		return (string) ( $response['body'] ?? '' );
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_headers' ) ) {
+	function wp_remote_retrieve_headers( array $response ): array {
+		return $response['headers'] ?? array();
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, mixed ...$args ): void {
+		if ( 'datamachine_log' === $hook ) {
+			$GLOBALS['datamachine_http_client_logs'][] = $args;
+		}
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/HttpClient.php';
+
+use DataMachine\Core\HttpClient;
+
+$failed = 0;
+$total  = 0;
+
+function http_client_error_contract_assert( string $label, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	++$failed;
+	echo "FAIL: {$label}\n";
+}
+
+$normal_response = array(
+	'headers'  => array( 'Content-Type' => 'application/json' ),
+	'body'     => '{"message":"Invalid request"}',
+	'response' => array( 'code' => 400, 'message' => 'Bad Request' ),
+);
+
+$rate_limit_response = array(
+	'headers'  => array(
+		'Retry-After' => '120',
+		'Set-Cookie'  => 'session=secret',
+	),
+	'body'     => '{"error":"Rate limited"}',
+	'response' => array( 'code' => 429, 'message' => 'Too Many Requests' ),
+);
+
+$GLOBALS['datamachine_http_client_responses'] = array(
+	$normal_response,
+	$rate_limit_response,
+	new WP_Error( 'http_request_failed', 'Connection timed out' ),
+);
+$GLOBALS['datamachine_http_client_logs'] = array();
+
+echo "\n[1] Received non-2xx response\n";
+$normal_result = HttpClient::get( 'https://example.test/invalid', array( 'context' => 'Contract Test' ) );
+
+http_client_error_contract_assert( 'non-2xx response fails', false === $normal_result['success'] );
+http_client_error_contract_assert( 'non-2xx response preserves status code', 400 === $normal_result['status_code'] );
+http_client_error_contract_assert( 'non-2xx response preserves headers', 'application/json' === ( $normal_result['headers']['Content-Type'] ?? null ) );
+http_client_error_contract_assert( 'non-2xx response preserves body as data', $normal_response['body'] === $normal_result['data'] );
+http_client_error_contract_assert( 'non-2xx response preserves raw response', $normal_response === $normal_result['response'] );
+http_client_error_contract_assert( 'non-2xx response retains normalized error', str_contains( $normal_result['error'], 'Invalid request' ) );
+
+echo "\n[2] Rate limit metadata\n";
+$rate_limit_result = HttpClient::get( 'https://example.test/limited', array( 'context' => 'Contract Test' ) );
+
+http_client_error_contract_assert( '429 response preserves status code', 429 === $rate_limit_result['status_code'] );
+http_client_error_contract_assert( '429 response preserves Retry-After', '120' === ( $rate_limit_result['headers']['Retry-After'] ?? null ) );
+http_client_error_contract_assert( 'response headers are not copied into logs', ! str_contains( serialize( $GLOBALS['datamachine_http_client_logs'] ), 'session=secret' ) );
+
+echo "\n[3] Transport failure distinction\n";
+$transport_result = HttpClient::get( 'https://example.test/unreachable', array( 'context' => 'Contract Test' ) );
+
+http_client_error_contract_assert( 'transport failure fails', false === $transport_result['success'] );
+http_client_error_contract_assert( 'transport failure has a non-empty error', '' !== $transport_result['error'] );
+http_client_error_contract_assert( 'transport failure has no status code', ! array_key_exists( 'status_code', $transport_result ) );
+http_client_error_contract_assert( 'transport failure has no response headers', ! array_key_exists( 'headers', $transport_result ) );
+http_client_error_contract_assert( 'transport failure has no raw response', ! array_key_exists( 'response', $transport_result ) );
+
+echo "\n{$total} assertions, {$failed} failures\n";
+exit( $failed > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary
- preserve status codes, response headers, response bodies, and raw WordPress response arrays for received non-2xx responses
- keep the existing normalized, non-empty error string and leave transport failures distinguishable by omitting HTTP response metadata
- document the contract and add focused standalone smoke coverage

Fixes #2995

## Root Cause

`HttpClient::request()` extracted the status and body from every received response, but passed only those scalar values to `handleHttpError()`. That handler returned only `success: false` and `error`, discarding the response metadata before callers could inspect it.

## Response Contract

Before:
- successful response: `success`, `data`, `status_code`, `headers`, `response`
- received non-2xx response: `success`, `error`
- transport failure: `success`, `error`

After:
- successful response: unchanged
- received non-2xx response: `success`, `error`, `data`, `status_code`, `headers`, `response`
- transport failure: unchanged, with no `status_code`, `headers`, or `response`

## Security And Redaction

The change returns response facts to the direct caller using the same WordPress response shape already exposed on successful requests. It does not add response headers to logs. Existing request credential redaction remains unchanged, and focused coverage verifies that a `Set-Cookie` value in response headers is not copied into emitted log context.

## Tests

- `php tests/http-client-error-response-contract-smoke.php` - 14 assertions, 0 failures
- `php tests/http-client-proxy-auth-smoke.php` - all 12 assertions passed
- `php -l inc/Core/HttpClient.php && php -l inc/Core/Steps/Handlers/HttpRequestHelpers.php && php -l tests/http-client-error-response-contract-smoke.php` - no syntax errors
- `git diff --check` - passed

No dependency installation was needed. Global PHPCS was not available in the disk-conscious worktree.

## Compatibility And Residual Risks

The existing `success` and `error` keys and message normalization are unchanged, so consumers that only inspect those fields remain compatible. The change is additive for received HTTP errors and intentionally does not implement retry policy. Response bodies and raw response arrays retain their existing in-memory size and sensitivity characteristics from the success contract; callers remain responsible for not logging or persisting sensitive upstream response data.