### PR TITLE
fix: distinguish fetch suppression outcomes

### DIFF
--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -30,6 +30,9 @@ class RunMetrics {
 		'fetch_packets',
 		'no_content',
 		'true_empty_query',
+		'lifecycle_suppressed',
+		'claim_contention',
+		'fetch_empty_unclassified',
 		'provider_error',
 		'hydration_failed',
 		'hydration_partial',
@@ -432,6 +435,7 @@ class RunMetrics {
 				'classes'                 => $outcome_classes,
 				'class_counts'            => $class_counts,
 				'fetch_packet_count'      => (int) ( $counts['fetch_packets'] ?? 0 ),
+				'fetch_stages'            => self::firstStepField( $engine, 'fetch_stages' ),
 				'no_content'              => ! empty( $counts['no_content'] ) || JobStatus::COMPLETED_NO_ITEMS === $job_status->getBaseStatus(),
 				'source_rejected'         => $is_source_rejected,
 				'source_rejection_reason' => $source_rejection['reason'] ?? ( $is_source_rejected ? $job_status->getReason() : null ),
@@ -452,7 +456,7 @@ class RunMetrics {
 			$classes = array_merge( $classes, self::classesFromStepResult( $step_result, $status ) );
 		}
 
-		foreach ( array( 'true_empty_query', 'provider_error', 'hydration_failed', 'hydration_partial', 'ai_empty_packet', 'ai_required_handler_not_called', 'ai_handler_tool_failed', 'ai_empty_response', 'ai_completion_assertions_missing', 'missing_handler_packet', 'source_rejected', 'item_deferred' ) as $class ) {
+		foreach ( array( 'true_empty_query', 'lifecycle_suppressed', 'claim_contention', 'fetch_empty_unclassified', 'provider_error', 'hydration_failed', 'hydration_partial', 'ai_empty_packet', 'ai_required_handler_not_called', 'ai_handler_tool_failed', 'ai_empty_response', 'ai_completion_assertions_missing', 'missing_handler_packet', 'source_rejected', 'item_deferred' ) as $class ) {
 			if ( ! empty( $counts[ $class ] ) ) {
 				$classes[] = $class;
 			}
@@ -470,7 +474,7 @@ class RunMetrics {
 		}
 
 		if ( in_array( $result, array( 'no_content', 'completed_no_items' ), true ) ) {
-			$classes[] = 'true_empty_query';
+			$classes = array_merge( $classes, self::fetchEmptyClasses( $step_result ) );
 		}
 		if ( 'source_rejected' === $result || ! empty( $step_result['source_rejection_reason'] ) ) {
 			$classes[] = 'source_rejected';
@@ -486,11 +490,39 @@ class RunMetrics {
 		$job_status = JobStatus::fromString( $status );
 		$classes    = self::classesFromReason( (string) $job_status->getReason() );
 
-		if ( JobStatus::COMPLETED_NO_ITEMS === $job_status->getBaseStatus() ) {
-			$classes[] = 'true_empty_query';
+		return array_values( array_unique( array_filter( $classes ) ) );
+	}
+
+	/**
+	 * Classify a no-content fetch from time-aligned stage diagnostics.
+	 *
+	 * @param array $step_result Persisted step result.
+	 * @return string[] Generic outcome classes.
+	 */
+	private static function fetchEmptyClasses( array $step_result ): array {
+		$stages = is_array( $step_result['fetch_stages'] ?? null ) ? $step_result['fetch_stages'] : array();
+		if ( empty( $stages ) ) {
+			return array( 'fetch_empty_unclassified' );
 		}
 
-		return array_values( array_unique( array_filter( $classes ) ) );
+		$source_items    = max( 0, (int) ( $stages['source_materialized'] ?? 0 ) );
+		$final_packets   = max( 0, (int) ( $stages['final_packets'] ?? 0 ) );
+		$claim_conflicts = max( 0, (int) ( $stages['claim_conflicts'] ?? 0 ) );
+		$lifecycle_skips = max( 0, (int) ( $stages['processed_skipped'] ?? 0 ) )
+			+ max( 0, (int) ( $stages['actively_claimed'] ?? 0 ) );
+
+		$classes = array();
+		if ( 0 === $source_items ) {
+			$classes[] = 'true_empty_query';
+		}
+		if ( 0 === $final_packets && $claim_conflicts > 0 ) {
+			$classes[] = 'claim_contention';
+		}
+		if ( 0 === $final_packets && $lifecycle_skips > 0 ) {
+			$classes[] = 'lifecycle_suppressed';
+		}
+
+		return empty( $classes ) ? array( 'fetch_empty_unclassified' ) : $classes;
 	}
 
 	private static function classesFromReason( string $reason ): array {

--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -22,6 +22,7 @@ use DataMachine\Core\DataPacket;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\ExecutionContext;
 use DataMachine\Core\FilesRepository\FileStorage;
+use DataMachine\Core\RunMetrics;
 use DataMachine\Core\Steps\Fetch\Tools\FetchItemDispositionTool;
 use DataMachine\Core\Steps\Handlers\HttpRequestHelpers;
 use DataMachine\Engine\AI\Tools\ToolManager;
@@ -64,10 +65,14 @@ abstract class FetchHandler {
 	final public function get_fetch_data( int|string $pipeline_id, array $handler_config, ?string $job_id = null ): array {
 		$config  = $this->extractConfig( $handler_config );
 		$context = ExecutionContext::fromConfig( $handler_config, $job_id, $this->handler_type );
+		$stages  = $this->initialFetchDiagnostics( $config, $context );
+		$max_items = (int) ( $config['max_items'] ?? $this->getDefaultMaxItems() );
+		$stages['max_items'] = max( 0, $max_items );
 
 		$result = $this->executeFetch( $config, $context );
 
 		if ( empty( $result ) || ! is_array( $result ) ) {
+			$this->recordFetchDiagnostics( $context, $stages );
 			return array();
 		}
 
@@ -78,26 +83,28 @@ abstract class FetchHandler {
 		$items = ( isset( $result['items'] ) && is_array( $result['items'] ) )
 			? $result['items']
 			: array( $result );
+		$stages['source_materialized'] = count( $items );
 
 		// Dedup: filter out already-processed and actively claimed items.
 		// Items with metadata['item_identifier'] are checked against the processed items
 		// database. Already-processed/claimed items are removed. New items are NOT yet
 		// claimed — claim creation happens after the max_items cap so we don't block
 		// items that simply didn't fit in this batch.
-		$items = $this->filterProcessed( $items, $context );
+		$items = $this->filterProcessed( $items, $context, $stages );
 
 		// Apply max_items cap.
 		// Default comes from getDefaultMaxItems() which subclasses can override.
 		// Set to 0 for unlimited.
-		$max_items = (int) ( $config['max_items'] ?? $this->getDefaultMaxItems() );
 		if ( $max_items > 0 && count( $items ) > $max_items ) {
+			$stages['eligible_outside_max_items'] = count( $items ) - $max_items;
 			$items = array_slice( $items, 0, $max_items );
 		}
+		$stages['selected_after_max_items'] = count( $items );
 
 		// Claim only the items this fetch will actually schedule. Claims close the
 		// race between parallel parent flow ticks while still deferring final
 		// processed marking until the downstream pipeline completes successfully.
-		$items = $this->claimItems( $items, $context );
+		$items = $this->claimItems( $items, $context, $stages );
 
 		// NOTE: Items are NOT marked as processed here. Marking is deferred
 		// to ExecuteStepAbility::markCompletedItemProcessed() which runs when
@@ -109,7 +116,11 @@ abstract class FetchHandler {
 		// Items cut by max_items remain naturally unmarked and will be picked
 		// up in future fetch cycles.
 
-		return $this->toDataPackets( $items, $pipeline_id, $flow_id );
+		$packets                 = $this->toDataPackets( $items, $pipeline_id, $flow_id );
+		$stages['final_packets'] = count( $packets );
+		$this->recordFetchDiagnostics( $context, $stages );
+
+		return $packets;
 	}
 
 	/**
@@ -125,14 +136,19 @@ abstract class FetchHandler {
 	 *
 	 * @param array            $items   Normalized items array.
 	 * @param ExecutionContext $context Execution context.
+	 * @param array|null       $diagnostics Optional aggregate diagnostics populated by reference.
 	 * @return array Filtered items array (new items only).
 	 */
-	private function filterProcessed( array $items, ExecutionContext $context ): array {
+	private function filterProcessed( array $items, ExecutionContext $context, ?array &$diagnostics = null ): array {
 		$identifiers = array();
 		$candidates  = array();
+		$valid_items = 0;
 		foreach ( $items as $item ) {
 			if ( ! is_array( $item ) ) {
 				continue;
+			}
+			if ( ! empty( $item['title'] ) || ! empty( $item['content'] ) || ! empty( $item['file_info'] ) ) {
+				++$valid_items;
 			}
 			$item_identifier = $item['metadata']['item_identifier'] ?? null;
 			$candidates[]    = array(
@@ -146,8 +162,23 @@ abstract class FetchHandler {
 
 		$classification = $context->classifySourceItems( $identifiers );
 		$decisions      = $classification['classifications'];
+		$counts         = $classification['diagnostics'];
 		$decision_index = 0;
 		$result         = array();
+
+		if ( is_array( $diagnostics ) ) {
+			$identifierless_items                        = count( $candidates ) - count( $identifiers );
+			$diagnostics['valid_items']                  = $valid_items;
+			$diagnostics['invalid_items']                = max( 0, (int) $diagnostics['source_materialized'] - $valid_items );
+			$diagnostics['identified_items']             = count( $identifiers );
+			$diagnostics['identifierless_items']         = $identifierless_items;
+			$diagnostics['unique_identifiers']           = (int) ( $counts['unique'] ?? 0 );
+			$diagnostics['duplicate_identifiers']        = (int) ( $counts['duplicates'] ?? 0 );
+			$diagnostics['eligible_before_max_items']    = (int) ( $counts['eligible'] ?? 0 ) + $identifierless_items;
+			$diagnostics['processed_skipped']            = (int) ( $counts['processed_skipped'] ?? 0 );
+			$diagnostics['reprocess_eligible']           = (int) ( $counts['processed_reprocess_eligible'] ?? 0 );
+			$diagnostics['actively_claimed']             = (int) ( $counts['actively_claimed'] ?? 0 );
+		}
 
 		foreach ( $candidates as $candidate ) {
 			$item            = $candidate['item'];
@@ -180,10 +211,12 @@ abstract class FetchHandler {
 	 *
 	 * @param array            $items   Items selected for scheduling.
 	 * @param ExecutionContext $context Execution context.
+	 * @param array|null       $diagnostics Optional aggregate diagnostics populated by reference.
 	 * @return array Items whose claim was acquired, plus identifier-less items.
 	 */
-	private function claimItems( array $items, ExecutionContext $context ): array {
-		$result = array();
+	private function claimItems( array $items, ExecutionContext $context, ?array &$diagnostics = null ): array {
+		$result                = array();
+		$attempted_identifiers = array();
 
 		foreach ( $items as $item ) {
 			if ( ! is_array( $item ) ) {
@@ -198,9 +231,24 @@ abstract class FetchHandler {
 				continue;
 			}
 
+			if ( is_array( $diagnostics ) ) {
+				++$diagnostics['claim_attempts'];
+			}
+			$is_duplicate                            = isset( $attempted_identifiers[ (string) $item_identifier ] );
+			$attempted_identifiers[ (string) $item_identifier ] = true;
 			$claim = $context->claimItemOwnership( (string) $context->getFlowStepId(), (string) $item_identifier );
 			if ( false === $claim ) {
+				if ( is_array( $diagnostics ) ) {
+					if ( $is_duplicate ) {
+						++$diagnostics['duplicate_claim_conflicts'];
+					} else {
+						++$diagnostics['claim_conflicts'];
+					}
+				}
 				continue;
+			}
+			if ( is_array( $diagnostics ) ) {
+				++$diagnostics['claims_acquired'];
 			}
 
 			$item['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] = $claim;
@@ -209,6 +257,116 @@ abstract class FetchHandler {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Build the bounded diagnostic envelope for one fetch invocation.
+	 *
+	 * @param array            $config  Effective handler configuration.
+	 * @param ExecutionContext $context Execution context.
+	 * @return array<string,int|string>
+	 */
+	private function initialFetchDiagnostics( array $config, ExecutionContext $context ): array {
+		return array(
+			'schema_version'                 => 'datamachine.fetch_stages.v1',
+			'handler_type'                   => $this->handler_type,
+			'execution_mode'                 => $context->getMode(),
+			'config_hash'                    => $this->configHash( $config ),
+			'source_materialized'            => 0,
+			'valid_items'                    => 0,
+			'invalid_items'                  => 0,
+			'identified_items'               => 0,
+			'identifierless_items'            => 0,
+			'unique_identifiers'             => 0,
+			'duplicate_identifiers'          => 0,
+			'eligible_before_max_items'      => 0,
+			'processed_skipped'              => 0,
+			'reprocess_eligible'             => 0,
+			'actively_claimed'               => 0,
+			'max_items'                      => 0,
+			'eligible_outside_max_items'     => 0,
+			'selected_after_max_items'       => 0,
+			'claim_attempts'                 => 0,
+			'claims_acquired'                => 0,
+			'claim_conflicts'                => 0,
+			'duplicate_claim_conflicts'      => 0,
+			'final_packets'                  => 0,
+		);
+	}
+
+	/**
+	 * Persist aggregate fetch-stage evidence in the existing step result.
+	 *
+	 * @param ExecutionContext           $context Execution context.
+	 * @param array<string,int|string>   $stages  Aggregate stage counts.
+	 */
+	private function recordFetchDiagnostics( ExecutionContext $context, array $stages ): void {
+		$job_id       = (int) ( $context->getJobId() ?? 0 );
+		$flow_step_id = (string) ( $context->getFlowStepId() ?? '' );
+		if ( $job_id <= 0 || '' === $flow_step_id ) {
+			return;
+		}
+
+		RunMetrics::recordStepResult(
+			$job_id,
+			$flow_step_id,
+			array(
+				'fetch_stages' => $stages,
+			)
+		);
+	}
+
+	/**
+	 * Hash effective configuration without persisting secret-bearing values.
+	 *
+	 * @param array $config Effective handler configuration.
+	 * @return string SHA-256 configuration hash.
+	 */
+	private function configHash( array $config ): string {
+		$remaining  = 1000;
+		$normalized = $this->normalizeConfigForHash( $config, $remaining );
+		$encoded    = wp_json_encode( $normalized );
+		return hash( 'sha256', false === $encoded ? '' : $encoded );
+	}
+
+	/**
+	 * Build a bounded, secret-redacted configuration shape for hashing.
+	 *
+	 * @param mixed  $value     Configuration value.
+	 * @param int    $remaining Remaining global traversal budget.
+	 * @param int    $depth     Current nesting depth.
+	 * @param string $key       Current configuration key.
+	 * @return mixed Sorted value.
+	 */
+	private function normalizeConfigForHash( mixed $value, int &$remaining, int $depth = 0, string $key = '' ): mixed {
+		if ( $remaining <= 0 ) {
+			return '[entry-limit]';
+		}
+		--$remaining;
+
+		$segmented_key = preg_replace( '/([a-z0-9])([A-Z])/', '$1_$2', $key ) ?? $key;
+		$normalized_key = strtolower( str_replace( '-', '_', $segmented_key ) );
+		if ( '' !== $normalized_key && ( 'key' === $normalized_key || str_ends_with( $normalized_key, '_key' ) || preg_match( '/(?:^|_)(?:auth|authentication|authorization|oauth|api_?key|private_key|signing_key|secret_key|access_key|bearer|cookie|passwd|password|passphrase|pat|secret|tokens?|credentials?)(?:_|$)/', $normalized_key ) ) ) {
+			return '[redacted]';
+		}
+		if ( $depth >= 8 ) {
+			return '[depth-limit]';
+		}
+		if ( ! is_array( $value ) ) {
+			return is_string( $value ) && strlen( $value ) > 1024 ? substr( $value, 0, 1024 ) . '[truncated]' : $value;
+		}
+
+		if ( ! array_is_list( $value ) ) {
+			ksort( $value, SORT_STRING );
+		}
+		$value      = array_slice( $value, 0, 200, true );
+		$normalized = array();
+
+		foreach ( $value as $child_key => $child ) {
+			$normalized[ $child_key ] = $this->normalizeConfigForHash( $child, $remaining, $depth + 1, (string) $child_key );
+		}
+
+		return $normalized;
 	}
 
 	/**

--- a/tests/Unit/Core/ExecutionContextSourceEligibilityTest.php
+++ b/tests/Unit/Core/ExecutionContextSourceEligibilityTest.php
@@ -8,6 +8,7 @@
 namespace DataMachine\Tests\Unit\Core;
 
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\ExecutionContext;
 use DataMachine\Core\Steps\Fetch\Handlers\FetchHandler;
 use WP_UnitTestCase;
@@ -146,6 +147,117 @@ class ExecutionContextSourceEligibilityTest extends WP_UnitTestCase {
 			array( 'fresh' ),
 			$this->context->classifySourceItems( array( 'fresh', 'processed', 'claimed' ) )['selected_identifiers']
 		);
+	}
+
+	public function test_fetch_handler_records_bounded_stage_diagnostics(): void {
+		$jobs   = new Jobs();
+		$job_id = $jobs->create_job(
+			array(
+				'source'      => 'pipeline',
+				'label'       => 'Fetch stage diagnostics',
+				'pipeline_id' => 29,
+				'flow_id'     => 45,
+			)
+		);
+		$this->assertIsInt( $job_id );
+
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'processed', 1 );
+		$this->db->claim_item( $this->flow_step_id, $this->source_type, 'claimed', 2 );
+
+		$items = array(
+			array( 'title' => 'Fresh one', 'metadata' => array( 'item_identifier' => 'fresh-1' ) ),
+			array( 'title' => 'Untracked' ),
+			array( 'title' => 'Processed', 'metadata' => array( 'item_identifier' => 'processed' ) ),
+			array( 'title' => 'Claimed', 'metadata' => array( 'item_identifier' => 'claimed' ) ),
+			array( 'title' => 'Fresh two', 'metadata' => array( 'item_identifier' => 'fresh-2' ) ),
+			array( 'title' => 'Outside cap', 'metadata' => array( 'item_identifier' => 'fresh-3' ) ),
+		);
+		$handler = new class( $this->source_type, $items ) extends FetchHandler {
+			private array $items;
+
+			public function __construct( string $handler_type, array $items ) {
+				parent::__construct( $handler_type );
+				$this->items = $items;
+			}
+
+			protected function executeFetch( array $config, ExecutionContext $context ): array {
+				return array( 'items' => $this->items );
+			}
+		};
+
+		$packets = $handler->get_fetch_data(
+			29,
+			array(
+				'pipeline_id' => 29,
+				'flow_id' => 45,
+				'flow_step_id' => $this->flow_step_id,
+				'max_items' => 3,
+			),
+			(string) $job_id
+		);
+
+		$this->assertCount( 3, $packets );
+		$engine = datamachine_get_engine_data( $job_id );
+		$stages = $engine['step_results'][ $this->flow_step_id ]['fetch_stages'] ?? array();
+
+		$this->assertSame( 'datamachine.fetch_stages.v1', $stages['schema_version'] ?? '' );
+		$this->assertSame( 6, $stages['source_materialized'] ?? null );
+		$this->assertSame( 6, $stages['valid_items'] ?? null );
+		$this->assertSame( 0, $stages['invalid_items'] ?? null );
+		$this->assertSame( 1, $stages['identifierless_items'] ?? null );
+		$this->assertSame( 4, $stages['eligible_before_max_items'] ?? null );
+		$this->assertSame( 1, $stages['processed_skipped'] ?? null );
+		$this->assertSame( 1, $stages['actively_claimed'] ?? null );
+		$this->assertSame( 1, $stages['eligible_outside_max_items'] ?? null );
+		$this->assertSame( 3, $stages['selected_after_max_items'] ?? null );
+		$this->assertSame( 2, $stages['claim_attempts'] ?? null );
+		$this->assertSame( 2, $stages['claims_acquired'] ?? null );
+		$this->assertSame( 0, $stages['claim_conflicts'] ?? null );
+		$this->assertSame( 3, $stages['final_packets'] ?? null );
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{64}$/', $stages['config_hash'] ?? '' );
+	}
+
+	public function test_duplicate_identifier_claims_do_not_report_external_contention(): void {
+		$jobs   = new Jobs();
+		$job_id = $jobs->create_job(
+			array(
+				'source'      => 'pipeline',
+				'label'       => 'Duplicate claim diagnostics',
+				'pipeline_id' => 29,
+				'flow_id'     => 45,
+			)
+		);
+		$this->assertIsInt( $job_id );
+
+		$handler = new class( $this->source_type ) extends FetchHandler {
+			protected function executeFetch( array $config, ExecutionContext $context ): array {
+				return array(
+					'items' => array(
+						array( 'title' => 'First', 'metadata' => array( 'item_identifier' => 'duplicate' ) ),
+						array( 'title' => 'Second', 'metadata' => array( 'item_identifier' => 'duplicate' ) ),
+					),
+				);
+			}
+		};
+
+		$packets = $handler->get_fetch_data(
+			29,
+			array(
+				'pipeline_id' => 29,
+				'flow_id' => 45,
+				'flow_step_id' => $this->flow_step_id,
+				'max_items' => 0,
+			),
+			(string) $job_id
+		);
+
+		$this->assertCount( 1, $packets );
+		$engine = datamachine_get_engine_data( $job_id );
+		$stages = $engine['step_results'][ $this->flow_step_id ]['fetch_stages'] ?? array();
+		$this->assertSame( 2, $stages['claim_attempts'] ?? null );
+		$this->assertSame( 1, $stages['claims_acquired'] ?? null );
+		$this->assertSame( 0, $stages['claim_conflicts'] ?? null );
+		$this->assertSame( 1, $stages['duplicate_claim_conflicts'] ?? null );
 	}
 
 	/** @return array<int,array<string,mixed>> */

--- a/tests/Unit/Core/Steps/Fetch/FetchHandlerDataPacketTest.php
+++ b/tests/Unit/Core/Steps/Fetch/FetchHandlerDataPacketTest.php
@@ -178,6 +178,41 @@ class FetchHandlerDataPacketTest extends TestCase {
 		$this->assertSame( 'github', $packets[0]['metadata']['handler'] );
 	}
 
+	public function test_config_hash_redacts_secrets_but_tracks_source_changes(): void {
+		$handler = $this->createStubHandler( 'generic', array() );
+		$method  = new ReflectionMethod( FetchHandler::class, 'configHash' );
+		$method->setAccessible( true );
+
+		$first = $method->invoke(
+			$handler,
+			array(
+				'source_url'  => 'https://example.com/feed',
+				'api_key'     => 'first-secret',
+				'accessToken' => 'first-camel-secret',
+			)
+		);
+		$secret_changed = $method->invoke(
+			$handler,
+			array(
+				'api_key'     => 'second-secret',
+				'accessToken' => 'camel-case-secret',
+				'source_url'  => 'https://example.com/feed',
+			)
+		);
+		$source_changed = $method->invoke(
+			$handler,
+			array(
+				'source_url'  => 'https://example.com/other-feed',
+				'api_key'     => 'first-secret',
+				'accessToken' => 'first-camel-secret',
+			)
+		);
+
+		$this->assertSame( $first, $secret_changed );
+		$this->assertNotSame( $first, $source_changed );
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{64}$/', $first );
+	}
+
 	public function test_zero_items_returns_empty(): void {
 		$handler = $this->createStubHandler( 'rss', array() );
 		$method  = $this->getToDataPackets();

--- a/tests/job-outcome-metrics-smoke.php
+++ b/tests/job-outcome-metrics-smoke.php
@@ -97,8 +97,72 @@ $metrics = RunMetrics::fromJob(
 );
 $assert( 'base status is completed_no_items', 'completed_no_items' === $metrics['outcome']['base_status'] );
 $assert( 'no_content boolean is true', true === $metrics['outcome']['no_content'] );
-$assert( 'true empty query class is exposed', in_array( 'true_empty_query', $metrics['outcome_classes'], true ) );
-$assert( 'true empty query count is exposed', 1 === $metrics['counts']['true_empty_query'] );
+$assert( 'legacy empty fetch is explicitly unclassified', in_array( 'fetch_empty_unclassified', $metrics['outcome_classes'], true ) );
+$assert( 'legacy empty fetch is not asserted source-empty', 0 === $metrics['counts']['true_empty_query'] );
+
+echo "\n[2a] fetch stage diagnostics distinguish empty outcomes\n";
+$empty_step = static function ( array $stages ): array {
+	return array(
+		'flow_step_id' => 'fetch_1',
+		'step_type'    => 'fetch',
+		'result'       => 'no_content',
+		'packet_count' => 0,
+		'fetch_stages' => array_merge(
+			array(
+				'source_materialized'        => 0,
+				'processed_skipped'           => 0,
+				'actively_claimed'            => 0,
+				'claim_conflicts'             => 0,
+				'final_packets'               => 0,
+			),
+			$stages
+		),
+	);
+};
+
+$metrics = RunMetrics::fromJob(
+	$job(
+		'completed_no_items',
+		array( 'step_results' => array( 'fetch_1' => $empty_step( array() ) ) )
+	)
+);
+$assert( 'source count zero is true empty query', array( 'true_empty_query' ) === $metrics['outcome_classes'] );
+$assert( 'fetch stage diagnostics are machine readable', 0 === ( $metrics['outcome']['fetch_stages']['source_materialized'] ?? -1 ) );
+
+$metrics = RunMetrics::fromJob(
+	$job(
+		'completed_no_items',
+		array(
+			'step_results' => array(
+				'fetch_1' => $empty_step(
+					array(
+						'source_materialized' => 5,
+						'processed_skipped'    => 5,
+					)
+				),
+			),
+		)
+	)
+);
+$assert( 'processed suppression is lifecycle class', array( 'lifecycle_suppressed' ) === $metrics['outcome_classes'] );
+
+$metrics = RunMetrics::fromJob(
+	$job(
+		'completed_no_items',
+		array(
+			'step_results' => array(
+				'fetch_1' => $empty_step(
+					array(
+						'source_materialized' => 5,
+						'processed_skipped'    => 2,
+						'claim_conflicts'      => 5,
+					)
+				),
+			),
+		)
+	)
+);
+$assert( 'mixed lifecycle and claim loss retains both classes', array( 'claim_contention', 'lifecycle_suppressed' ) === $metrics['outcome_classes'] );
 
 echo "\n[3] failed status exposes failure base status\n";
 $metrics = RunMetrics::fromJob( $job( 'failed - api-timeout', array() ) );


### PR DESCRIPTION
## Summary

- persist bounded generic fetch-stage counts in the existing step-result envelope
- distinguish actual source-empty runs from lifecycle suppression, atomic claim contention, and legacy unclassified empties
- expose time-aligned stage evidence through existing job outcome metrics without storing packet bodies or adding a table
- hash a bounded, secret-redacted effective config shape for execution provenance

Fixes #2997.

## Why

A final packet count of zero previously collapsed several materially different outcomes into `true_empty_query`: the source returned nothing, every item was already processed/claimed, or atomic claims lost after observational classification. Historical jobs therefore could not explain production-versus-handler-test divergence without rerunning a mutable external source.

The generic fetch template now records:

- source materialized, valid/invalid, identified/identifier-less, unique, and duplicate counts
- processed, reprocess-eligible, and active-claim counts
- effective `max_items`, selected, and outside-cap counts
- claim attempts, acquired claims, external conflicts, and duplicate self-conflicts
- final packet count, execution mode, handler type, and a bounded redacted config hash

`RunMetrics` uses those counts to emit `true_empty_query`, `lifecycle_suppressed`, and `claim_contention` honestly. Legacy no-content step results become `fetch_empty_unclassified` instead of asserting evidence they never stored.

## Layering

This change stays entirely in Data Machine because lifecycle filtering, `max_items`, atomic claims, step results, and outcome classification are generic execution concerns. No event/vendor names, consumer hooks, parallel metrics tables, or packet payload persistence were added.

## Verification

Passed:

- PHP syntax checks on all changed PHP files
- WordPress PHPCS on all changed files
- `php tests/job-outcome-metrics-smoke.php` — 38 assertions
- `php tests/run-metrics-smoke.php`
- `php tests/step-execution-result-contract-smoke.php` — 25 assertions
- `git diff --check`
- two independent code-review passes; duplicate accounting, identifier-less totals, mixed outcome classes, and config-hash bounding/redaction findings were addressed

Added WordPress PHPUnit coverage for mixed lifecycle stages, duplicate self-claims, and config-hash redaction. The authoritative focused Codebox run was attempted as Homeboy run `9f35a23d-28f3-404b-b962-0bceb3e96992`, but failed before PHPUnit bootstrap because the managed `wordpress-database` Docker MySQL service could not provision. No test assertion failed and no structured test results were produced.

## Operational effect

This is observational only. It does not alter lifecycle decisions, source selection, claim ownership, scheduling, retry, or terminal status semantics. Existing jobs remain untouched; newly executed fetches gain bounded stage evidence.