### PR TITLE
feat: add delegated operation contract

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -364,6 +364,7 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\Job\HydrateJobArtifactAbility();
 	new \DataMachine\Abilities\Job\DeleteJobsAbility();
 	new \DataMachine\Abilities\Job\ExecuteWorkflowAbility();
+	new \DataMachine\Abilities\Job\DelegatedOperationAbilities();
 	new \DataMachine\Abilities\Job\ExecuteAgentWorkflowAbility();
 	new \DataMachine\Abilities\Job\FlowHealthAbility();
 	new \DataMachine\Abilities\Job\ProblemFlowsAbility();

--- a/docs/DELEGATED_OPERATIONS.md
+++ b/docs/DELEGATED_OPERATIONS.md
@@ -1,0 +1,139 @@
+# Delegated Operations
+
+Delegated operations let an authenticated caller invoke one action registered by
+its owning plugin without receiving Data Machine workflow, task, job, or agent
+management authority.
+
+## Register An Action
+
+Register actions on `datamachine_delegated_operation_actions`. Action IDs use
+`owner/action` syntax and are part of the durable operation identity.
+
+```php
+add_filter(
+	'datamachine_delegated_operation_actions',
+	static function ( array $actions ): array {
+		$actions['owner/create-record'] = array(
+			'version'         => '1',
+			'normalize_input' => static function ( array $input, array $context ) {
+				// Return a bounded, deterministic array or WP_Error.
+				return array( 'record_key' => sanitize_key( $input['record_key'] ?? '' ) );
+			},
+			'authorize'       => static function ( array $context ) {
+				// Authorize every submit, reconcile, retry, and cancel phase.
+				// Data Machine management capabilities do not bypass this callback.
+				return current_user_can( 'create_owner_records' )
+					? true
+					: new WP_Error( 'owner_action_forbidden', 'Not authorized.' );
+			},
+			'prepare'         => static function ( array $input, array $context ): array {
+				return array(
+					'owner_user_id' => 123,
+					'agent_slug'    => 'stable-owner', // Optional; its owner becomes user_id.
+					'label'         => 'Create owner record',
+					'workflow'      => array( 'steps' => array( /* owner workflow */ ) ),
+					'initial_data'  => array( 'owner_request' => $input ),
+				);
+			},
+			'project'         => static function ( array $run_result, array $context ): array {
+				// Return only owner-approved identifiers, codes, and references.
+				return array(
+					'effect_count' => 1,
+					'record_ref'   => 'rec_123',
+				);
+			},
+			'retry'           => static function ( array $run_result, array $context ) {
+				// Reconcile the owner's durable effect receipt. Return true only when
+				// replaying the frozen request cannot duplicate consequential work.
+				return true;
+			},
+		);
+		return $actions;
+	}
+);
+```
+
+`normalize_input` and `prepare` execute only on submission. Their deterministic
+output, the registration version, stable execution owner, workflow, initial
+data, and requested timestamp form the frozen request fingerprint. The first
+successful submission attests the initiating user/agent separately from the
+stable execution owner. Initiator identity does not affect deduplication.
+
+`authorize` receives `phase`, `action`, `operation_id`, `operation_ref`, `actor`,
+and normalized `input`. It must return `true` or `WP_Error`. The owner remains
+responsible for resource authorization in every phase.
+
+Callback signatures are:
+
+```php
+normalize_input( array $input, array $context ): array|WP_Error
+authorize( array $context ): true|WP_Error
+prepare( array $normalized_input, array $context ): array|WP_Error
+project( array $canonical_run_result, array $context ): array|WP_Error
+retry( array $failed_canonical_run_result, array $context ): true|WP_Error // Optional.
+```
+
+`prepare` returns `workflow`, `owner_user_id` and/or `agent_id`/`agent_slug`,
+plus optional `initial_data` and `label`. When an agent is supplied, its
+registered owner is the authoritative execution user. Callers cannot provide or
+override any execution descriptor field.
+
+`project` receives the canonical `datamachine.run_result.v1` envelope and must
+return a redacted JSON-safe object no larger than 32 KiB. Raw jobs, diagnostics,
+workflow state, task classes, and scheduler records are never public inputs or
+outputs. Set `effect_count` to `0` when successful execution produced no
+consequential effect; Data Machine then reports `no-op`.
+
+Data Machine also reports `no-op` for canonical skipped/no-items statuses and
+for a canonical integer `outputs.effect_count` of `0`.
+
+`retry` is optional. Without it, explicit retry fails closed. When registered,
+it receives the failed canonical run result and frozen operation context. It
+must reconcile the owner's durable effect receipt and return `true` only when
+rerunning cannot duplicate consequential work. Automatic engine retries retain
+their existing generation fence and owner handler idempotency requirements.
+
+## Submit
+
+Execute `datamachine/submit-delegated-operation` with:
+
+```json
+{
+  "action": "owner/create-record",
+  "operation_id": "caller-stable-request-42",
+  "input": { "record_key": "example" },
+  "timestamp": 1780000000
+}
+```
+
+The response contains an opaque `operation_ref`, `status`, replay flag, and the
+owner projection. Repeating the same action and operation ID from any authorized
+WordPress user atomically returns the same operation. Reuse with changed input,
+policy, owner, workflow, or schedule returns `delegated_operation_conflict`.
+
+Successful responses have `success`, `operation_ref`, `status`, and `replayed`,
+with optional `projection` and bounded `retry` metadata. Failures have `success:
+false`, `error_code`, `error`, and optional `retryable`. No ability accepts or
+returns a job ID, workflow specification, task type, class name, or scheduler
+record.
+
+## Reconcile, Retry, And Cancel
+
+Use these abilities with only `action` and `operation_ref`:
+
+- `datamachine/get-delegated-operation`
+- `datamachine/retry-delegated-operation`
+- `datamachine/cancel-delegated-operation`
+
+Statuses are `submitted`, `executing`, `executed`, `no-op`, `failed`,
+`cancelled`, and `retrying`. Automatic retry metadata is bounded to attempt,
+maximum attempts, and next retry time. Explicit retry reopens only failed work
+after its owner retry callback proves replay safety, and preserves its operation
+identity. Cancellation succeeds only before work
+starts; it atomically fences the queued generation before removing its scheduled
+action. An executing operation cannot claim safe cancellation.
+
+Delegated operation envelopes are excluded from short-window terminal
+`engine_data` shedding because the frozen authorization context and redacted
+canonical reconciliation remain part of the durable operation contract. Normal
+whole-row retention still defines the operation's final storage lifetime.

--- a/inc/Abilities/Job/DelegatedOperationAbilities.php
+++ b/inc/Abilities/Job/DelegatedOperationAbilities.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Public delegated operation abilities.
+ *
+ * @package DataMachine\Abilities\Job
+ */
+
+namespace DataMachine\Abilities\Job;
+
+use DataMachine\Abilities\AbilityRegistration;
+use DataMachine\Abilities\ExecutionScope;
+use DataMachine\Core\DelegatedOperations\DelegatedOperationService;
+
+defined( 'ABSPATH' ) || exit;
+
+final class DelegatedOperationAbilities {
+
+	private DelegatedOperationService $service;
+
+	public function __construct( ?DelegatedOperationService $service = null ) {
+		$this->service = $service ?? new DelegatedOperationService();
+		AbilityRegistration::on_abilities_api_init( array( $this, 'register' ) );
+	}
+
+	public function register(): void {
+		$identity = array(
+			'action' => array( 'type' => 'string', 'maxLength' => 129 ),
+			'operation_ref' => array( 'type' => 'string', 'pattern' => '^dop_[a-f0-9]{64}$' ),
+		);
+		$output = array(
+			'type'       => 'object',
+			'required'   => array( 'success' ),
+			'properties' => array(
+				'success'       => array( 'type' => 'boolean' ),
+				'operation_ref' => array( 'type' => 'string' ),
+				'status'        => array( 'type' => 'string', 'enum' => array( 'submitted', 'executing', 'executed', 'no-op', 'failed', 'cancelled', 'retrying' ) ),
+				'replayed'      => array( 'type' => 'boolean' ),
+				'projection'    => array( 'type' => 'object' ),
+				'retry'         => array( 'type' => 'object' ),
+				'retryable'     => array( 'type' => 'boolean' ),
+				'error_code'    => array( 'type' => 'string' ),
+				'error'         => array( 'type' => 'string' ),
+			),
+			'additionalProperties' => false,
+		);
+
+		wp_register_ability(
+			'datamachine/submit-delegated-operation',
+			array(
+				'label'               => __( 'Submit Delegated Operation', 'data-machine' ),
+				'description'         => __( 'Submit one owner-registered operation without gaining general workflow authority.', 'data-machine' ),
+				'category'            => 'datamachine-jobs',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'action', 'operation_id', 'input' ),
+					'properties' => array(
+						'action'       => $identity['action'],
+						'operation_id' => array( 'type' => 'string', 'minLength' => 1, 'maxLength' => 191 ),
+						'input'        => array( 'type' => 'object' ),
+						'timestamp'    => array( 'type' => array( 'integer', 'null' ) ),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => $output,
+				'execute_callback'    => array( $this->service, 'submit' ),
+				'permission_callback' => array( $this, 'checkPermission' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		foreach ( array( 'get' => 'reconcile', 'retry' => 'retry', 'cancel' => 'cancel' ) as $verb => $method ) {
+			wp_register_ability(
+				'datamachine/' . $verb . '-delegated-operation',
+				array(
+					'label'               => sprintf( __( '%s Delegated Operation', 'data-machine' ), ucfirst( $verb ) ),
+					'description'         => __( 'Act on one owner-authorized delegated operation reference.', 'data-machine' ),
+					'category'            => 'datamachine-jobs',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'action', 'operation_ref' ),
+						'properties' => $identity,
+						'additionalProperties' => false,
+					),
+					'output_schema'       => $output,
+					'execute_callback'    => array( $this->service, $method ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		}
+	}
+
+	/** Require identity only; the action owner supplies all downstream authority. */
+	public function checkPermission(): bool {
+		$scope = ExecutionScope::current( 'manage_flows' );
+		return $scope->acting_user_id() > 0 || (int) ( $scope->acting_agent_id() ?? 0 ) > 0;
+	}
+}

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -1952,6 +1952,15 @@ class Jobs extends BaseRepository {
 	}
 
 	/**
+	 * Cancel a pending direct operation while atomically fencing its generation.
+	 *
+	 * @return array{success: bool, changed: bool, current_status: ?string, status: string}
+	 */
+	public function cancel_pending_direct_operation( int $job_id ): array {
+		return $this->transition_terminal_job_status_result( $job_id, JobStatus::CANCELLED, null, true );
+	}
+
+	/**
 	 * Update job status.
 	 *
 	 * @param int    $job_id The job ID.
@@ -2299,7 +2308,7 @@ class Jobs extends BaseRepository {
 	 * @param string $requested_status Requested final status.
 	 * @return array{success: bool, changed: bool, current_status: ?string, status: string}
 	 */
-	private function transition_terminal_job_status_result( int $job_id, string $requested_status, ?array $recovery_owner = null ): array {
+	private function transition_terminal_job_status_result( int $job_id, string $requested_status, ?array $recovery_owner = null, bool $pending_direct_cancel = false ): array {
 		if ( null === $recovery_owner && isset( self::$recovery_execution_fences[ $job_id ] ) ) {
 			$fence_stack    = self::$recovery_execution_fences[ $job_id ];
 			$recovery_owner = end( $fence_stack );
@@ -2327,6 +2336,10 @@ class Jobs extends BaseRepository {
 		}
 
 		$current_status = is_string( $job['status'] ?? null ) ? $job['status'] : '';
+		if ( $pending_direct_cancel && ( 'direct' !== (string) ( $job['flow_id'] ?? '' ) || JobStatus::PENDING !== $current_status ) ) {
+			$this->rollback_terminal_transition( $job_id );
+			return $this->status_transition_result( false, false, $current_status, $current_status );
+		}
 		if ( $current_status === $requested_status ) {
 			$this->rollback_terminal_transition( $job_id );
 			$this->reconcile_terminal_accounting( $job_id );
@@ -2423,6 +2436,14 @@ class Jobs extends BaseRepository {
 			'terminal_accounting_processed_count' => $processed_claim_count,
 		);
 		$update_formats = array( '%s', '%s', '%d', null, null, '%d' );
+		if ( $pending_direct_cancel ) {
+			$update_data['operation_state']       = 'cancelled';
+			$update_data['operation_claimed_at']  = null;
+			$update_data['operation_claim_token'] = null;
+			$update_data['operation_action_id']   = null;
+			$update_data['operation_generation']  = max( 0, (int) ( $job['operation_generation'] ?? 0 ) ) + 1;
+			array_push( $update_formats, '%s', null, null, null, '%d' );
+		}
 		if ( is_array( $recovery_owner ) ) {
 			$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
 			$engine['scheduler_recovery']['state']        = 'terminalized';

--- a/inc/Core/DelegatedOperations/DelegatedOperationRegistry.php
+++ b/inc/Core/DelegatedOperations/DelegatedOperationRegistry.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Owner-registered delegated operation actions.
+ *
+ * @package DataMachine\Core\DelegatedOperations
+ */
+
+namespace DataMachine\Core\DelegatedOperations;
+
+defined( 'ABSPATH' ) || exit;
+
+final class DelegatedOperationRegistry {
+
+	public const FILTER = 'datamachine_delegated_operation_actions';
+
+	/**
+	 * Resolve and validate one owner action.
+	 *
+	 * @return array|\WP_Error
+	 */
+	public function get( string $action_id ) {
+		if ( ! preg_match( '/^[a-z0-9][a-z0-9_-]{0,63}\/[a-z0-9][a-z0-9_-]{0,63}$/', $action_id ) ) {
+			return new \WP_Error( 'delegated_action_invalid', __( 'The delegated action identifier is invalid.', 'data-machine' ) );
+		}
+
+		$actions = apply_filters( self::FILTER, array() );
+		$action  = is_array( $actions ) && is_array( $actions[ $action_id ] ?? null ) ? $actions[ $action_id ] : null;
+		if ( null === $action ) {
+			return new \WP_Error( 'delegated_action_unavailable', __( 'The delegated action is not registered.', 'data-machine' ) );
+		}
+
+		foreach ( array( 'normalize_input', 'authorize', 'prepare', 'project' ) as $callback ) {
+			if ( ! is_callable( $action[ $callback ] ?? null ) ) {
+				return new \WP_Error( 'delegated_action_invalid', __( 'The delegated action registration is incomplete.', 'data-machine' ) );
+			}
+		}
+
+		$version = trim( (string) ( $action['version'] ?? '' ) );
+		if ( '' === $version || strlen( $version ) > 64 ) {
+			return new \WP_Error( 'delegated_action_invalid', __( 'The delegated action version is invalid.', 'data-machine' ) );
+		}
+
+		$action['version'] = $version;
+		return $action;
+	}
+}

--- a/inc/Core/DelegatedOperations/DelegatedOperationService.php
+++ b/inc/Core/DelegatedOperations/DelegatedOperationService.php
@@ -1,0 +1,478 @@
+<?php
+/**
+ * Delegated operation submission and reconciliation.
+ *
+ * @package DataMachine\Core\DelegatedOperations
+ */
+
+namespace DataMachine\Core\DelegatedOperations;
+
+use DataMachine\Abilities\ExecutionScope;
+use DataMachine\Core\Agents\AgentIdentityResolver;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\DirectJobEnqueuer;
+use DataMachine\Core\EngineData;
+use DataMachine\Core\JobRetryPolicy;
+use DataMachine\Core\JobStatus;
+use DataMachine\Core\RunMetrics;
+use DataMachine\Core\Steps\WorkflowConfigFactory;
+use DataMachine\Core\Steps\WorkflowSpecValidator;
+use DataMachine\Engine\ExecutionPlan;
+
+defined( 'ABSPATH' ) || exit;
+
+final class DelegatedOperationService {
+
+	private const IDEMPOTENCY_PREFIX = 'delegated:';
+	private const REFERENCE_PREFIX   = 'dop_';
+	private const MAX_INPUT_BYTES    = 65536;
+	private const MAX_PROJECTION_BYTES = 32768;
+
+	private Jobs $jobs;
+	private DelegatedOperationRegistry $registry;
+
+	public function __construct( ?Jobs $jobs = null, ?DelegatedOperationRegistry $registry = null ) {
+		$this->jobs     = $jobs ?? new Jobs();
+		$this->registry = $registry ?? new DelegatedOperationRegistry();
+	}
+
+	/** Submit an owner-registered operation. */
+	public function submit( array $request ): array {
+		$action_id   = trim( (string) ( $request['action'] ?? '' ) );
+		$operation_id = trim( (string) ( $request['operation_id'] ?? '' ) );
+		$raw_input   = is_array( $request['input'] ?? null ) ? $request['input'] : array();
+		$timestamp   = isset( $request['timestamp'] ) && is_numeric( $request['timestamp'] ) ? max( 0, (int) $request['timestamp'] ) : null;
+		if ( '' === $operation_id || strlen( $operation_id ) > 191 ) {
+			return $this->failure( 'delegated_operation_id_invalid', __( 'A bounded operation_id is required.', 'data-machine' ) );
+		}
+
+		$actor = $this->actor();
+		if ( 0 === $actor['user_id'] && 0 === $actor['agent_id'] ) {
+			return $this->failure( 'delegated_actor_required', __( 'An authenticated initiating actor is required.', 'data-machine' ) );
+		}
+
+		$action = $this->registry->get( $action_id );
+		if ( is_wp_error( $action ) ) {
+			return $this->fromError( $action );
+		}
+
+		$operation_ref = $this->reference( $action_id, $operation_id );
+		$context       = $this->context( 'submit', $action_id, $operation_id, $operation_ref, $actor );
+		$normalized    = $this->invoke( $action['normalize_input'], array( $raw_input, $context ), 'delegated_input_invalid' );
+		if ( is_wp_error( $normalized ) ) {
+			return $this->fromError( $normalized );
+		}
+		if ( ! is_array( $normalized ) || ! $this->isBoundedJson( $normalized, self::MAX_INPUT_BYTES ) ) {
+			return $this->failure( 'delegated_input_invalid', __( 'The action owner returned invalid normalized input.', 'data-machine' ) );
+		}
+		$context['input'] = $normalized;
+
+		$authorized = $this->authorize( $action, $context );
+		if ( is_wp_error( $authorized ) ) {
+			return $this->fromError( $authorized );
+		}
+
+		$prepared = $this->invoke( $action['prepare'], array( $normalized, $context ), 'delegated_action_prepare_failed' );
+		if ( is_wp_error( $prepared ) ) {
+			return $this->fromError( $prepared );
+		}
+		$execution = $this->prepareExecution( $prepared );
+		if ( is_wp_error( $execution ) ) {
+			return $this->fromError( $execution );
+		}
+
+		$engine_data = is_array( $execution['initial_data'] ?? null ) ? $execution['initial_data'] : array();
+		$engine_data['flow_config']     = $execution['configs']['flow_config'];
+		$engine_data['pipeline_config'] = $execution['configs']['pipeline_config'];
+		$engine_data['user_id']         = $execution['user_id'];
+		$engine_data['calling_user_id'] = $actor['user_id'];
+		$engine_data['job']             = is_array( $engine_data['job'] ?? null ) ? $engine_data['job'] : array();
+		$engine_data['job']['user_id']  = $execution['user_id'];
+		if ( $execution['agent_id'] > 0 ) {
+			$engine_data['job']['agent_id']   = $execution['agent_id'];
+			$engine_data['job']['agent_slug'] = $execution['agent_slug'];
+		}
+		$engine_data['delegated_operation'] = array(
+			'action'       => $action_id,
+			'version'      => $action['version'],
+			'operation_id' => $operation_id,
+			'operation_ref' => $operation_ref,
+			'input'        => $normalized,
+			'initiator'    => $actor,
+			'execution_owner' => array(
+				'user_id'    => $execution['user_id'],
+				'agent_id'   => $execution['agent_id'],
+				'agent_slug' => $execution['agent_slug'],
+			),
+			'timestamp'    => $timestamp,
+		);
+
+		$fingerprint_payload = array(
+			'action'          => $action_id,
+			'version'         => $action['version'],
+			'input'           => $normalized,
+			'execution_owner' => $engine_data['delegated_operation']['execution_owner'],
+			'workflow'        => $execution['workflow'],
+			'initial_data'    => $execution['initial_data'],
+			'timestamp'       => $timestamp,
+		);
+		$fingerprint = hash( 'sha256', (string) wp_json_encode( $this->canonicalize( $fingerprint_payload ) ) );
+		$create_args = array(
+			'pipeline_id'        => 'direct',
+			'flow_id'            => 'direct',
+			'source'             => 'delegated',
+			'label'              => isset( $prepared['label'] ) ? (string) $prepared['label'] : $action_id,
+			'user_id'            => $execution['user_id'],
+			'idempotency_key'    => $this->idempotencyKey( $operation_ref ),
+			'request_fingerprint' => $fingerprint,
+			'operation_state'    => 'preparing',
+			'operation_step_id'  => $execution['first_step_id'],
+			'engine_data'        => $engine_data,
+		);
+		if ( $execution['agent_id'] > 0 ) {
+			$create_args['agent_id'] = $execution['agent_id'];
+		}
+
+		$creation = $this->jobs->create_or_get_job( $create_args );
+		if ( ! is_array( $creation ) || empty( $creation['job_id'] ) ) {
+			return $this->failure( 'delegated_operation_create_failed', __( 'The delegated operation could not be created.', 'data-machine' ), true );
+		}
+		if ( ! empty( $creation['already_exists'] ) ) {
+			$existing_fingerprint = (string) ( $creation['job']['request_fingerprint'] ?? '' );
+			if ( '' === $existing_fingerprint || ! hash_equals( $existing_fingerprint, $fingerprint ) ) {
+				return $this->failure( 'delegated_operation_conflict', __( 'The operation identity is already frozen with different input or policy.', 'data-machine' ) );
+			}
+		}
+
+		$job_id = (int) $creation['job_id'];
+		$job    = $this->jobs->get_job( $job_id );
+		if ( ! is_array( $job ) ) {
+			return $this->failure( 'delegated_operation_load_failed', __( 'The delegated operation could not be loaded.', 'data-machine' ), true );
+		}
+		$job_status = (string) ( $job['status'] ?? '' );
+		if ( ! JobStatus::isStatusFinal( $job_status ) && ! in_array( $job_status, array( JobStatus::PROCESSING, JobStatus::WAITING ), true ) ) {
+			if ( ! empty( $creation['created'] ) && ! $this->persistJobReference( $job_id ) ) {
+				return $this->failure( 'delegated_operation_persist_failed', __( 'The delegated operation could not be persisted.', 'data-machine' ), true );
+			}
+			$enqueue = ( new DirectJobEnqueuer( $this->jobs ) )->enqueue( $job_id, $execution['first_step_id'], $timestamp );
+			if ( empty( $enqueue['success'] ) ) {
+				return $this->failure( (string) ( $enqueue['error'] ?? 'delegated_enqueue_failed' ), __( 'The delegated operation is awaiting enqueue recovery.', 'data-machine' ), ! empty( $enqueue['retryable'] ) );
+			}
+			$job = $this->jobs->get_job( $job_id );
+		}
+
+		return $this->response( $job, $action, $context, ! empty( $creation['already_exists'] ) );
+	}
+
+	/** Reconcile one operation through its owner-controlled projection. */
+	public function reconcile( array $request ): array {
+		$resolved = $this->resolve( $request, 'reconcile' );
+		return is_array( $resolved ) && isset( $resolved['error_result'] ) ? $resolved['error_result'] : $this->response( $resolved['job'], $resolved['action'], $resolved['context'], true );
+	}
+
+	/** Retry a failed operation without creating another job. */
+	public function retry( array $request ): array {
+		$resolved = $this->resolve( $request, 'retry' );
+		if ( isset( $resolved['error_result'] ) ) {
+			return $resolved['error_result'];
+		}
+		$job    = $resolved['job'];
+		$job_id = (int) $job['job_id'];
+		if ( ! JobStatus::isStatusFailure( (string) ( $job['status'] ?? '' ) ) ) {
+			return $this->failure( 'delegated_operation_not_retryable', __( 'Only failed delegated operations may be retried.', 'data-machine' ) );
+		}
+		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$step_id = JobRetryPolicy::resolveDirectResumeStepId( $engine );
+		if ( ! is_callable( $resolved['action']['retry'] ?? null ) ) {
+			return $this->failure( 'delegated_operation_retry_unsupported', __( 'The action owner has not registered safe retry reconciliation.', 'data-machine' ) );
+		}
+		$summary    = RunMetrics::fromJob( $job );
+		$run_result = is_array( $summary['run_result'] ?? null ) ? $summary['run_result'] : array();
+		$retry_safe = $this->invoke( $resolved['action']['retry'], array( $run_result, $resolved['context'] ), 'delegated_operation_retry_unsafe' );
+		if ( true !== $retry_safe ) {
+			return is_wp_error( $retry_safe )
+				? $this->fromError( $retry_safe )
+				: $this->failure( 'delegated_operation_retry_unsafe', __( 'The action owner could not prove this operation safe to retry.', 'data-machine' ) );
+		}
+		if ( '' === $step_id || ! $this->jobs->reopen_failed_job( $job_id ) ) {
+			return $this->failure( 'delegated_operation_retry_failed', __( 'The delegated operation could not be reopened safely.', 'data-machine' ) );
+		}
+		$enqueue = ( new DirectJobEnqueuer( $this->jobs ) )->enqueue( $job_id, $step_id );
+		if ( empty( $enqueue['success'] ) ) {
+			$this->jobs->complete_job( $job_id, 'failed - delegated_retry_enqueue_failed' );
+			return $this->failure( 'delegated_operation_retry_failed', __( 'The delegated operation retry could not be enqueued.', 'data-machine' ), ! empty( $enqueue['retryable'] ) );
+		}
+		RunMetrics::increment( $job_id, 'retried' );
+		return $this->response( $this->jobs->get_job( $job_id ), $resolved['action'], $resolved['context'], true );
+	}
+
+	/** Cancel work that has not started, atomically fencing its generation. */
+	public function cancel( array $request ): array {
+		$resolved = $this->resolve( $request, 'cancel' );
+		if ( isset( $resolved['error_result'] ) ) {
+			return $resolved['error_result'];
+		}
+		$job       = $resolved['job'];
+		$job_id    = (int) $job['job_id'];
+		$step_id   = (string) ( $job['operation_step_id'] ?? '' );
+		$generation = (int) ( $job['operation_generation'] ?? 0 );
+		$token     = (string) ( $job['operation_claim_token'] ?? '' );
+		$transition = $this->jobs->cancel_pending_direct_operation( $job_id );
+		if ( empty( $transition['success'] ) ) {
+			return $this->failure( 'delegated_operation_not_cancellable', __( 'Only submitted or delayed operations can be cancelled safely.', 'data-machine' ) );
+		}
+		if ( function_exists( 'as_unschedule_action' ) && '' !== $step_id && $generation > 0 && '' !== $token ) {
+			as_unschedule_action(
+				'datamachine_execute_step',
+				array(
+					'job_id'                 => $job_id,
+					'flow_step_id'           => $step_id,
+					'operation_generation'   => $generation,
+					'operation_claim_token'  => $token,
+				),
+				'data-machine'
+			);
+		}
+		return $this->response( $this->jobs->get_job( $job_id ), $resolved['action'], $resolved['context'], true );
+	}
+
+	/** Resolve, attest, and owner-authorize an existing operation. */
+	private function resolve( array $request, string $phase ): array {
+		$action_id    = trim( (string) ( $request['action'] ?? '' ) );
+		$operation_ref = trim( (string) ( $request['operation_ref'] ?? '' ) );
+		$action       = $this->registry->get( $action_id );
+		if ( is_wp_error( $action ) ) {
+			return array( 'error_result' => $this->fromError( $action ) );
+		}
+		if ( ! preg_match( '/^dop_[a-f0-9]{64}$/', $operation_ref ) ) {
+			return array( 'error_result' => $this->failure( 'delegated_operation_ref_invalid', __( 'The operation reference is invalid.', 'data-machine' ) ) );
+		}
+		$job = $this->jobs->get_job_by_idempotency_key( $this->idempotencyKey( $operation_ref ) );
+		if ( ! is_array( $job ) ) {
+			return array( 'error_result' => $this->failure( 'delegated_operation_not_found', __( 'The delegated operation was not found.', 'data-machine' ) ) );
+		}
+		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$stored = is_array( $engine['delegated_operation'] ?? null ) ? $engine['delegated_operation'] : array();
+		if ( $action_id !== (string) ( $stored['action'] ?? '' ) || $operation_ref !== (string) ( $stored['operation_ref'] ?? '' ) ) {
+			return array( 'error_result' => $this->failure( 'delegated_operation_not_found', __( 'The delegated operation was not found.', 'data-machine' ) ) );
+		}
+		if ( (string) $action['version'] !== (string) ( $stored['version'] ?? '' ) ) {
+			return array( 'error_result' => $this->failure( 'delegated_action_version_conflict', __( 'The operation requires its frozen action contract version.', 'data-machine' ) ) );
+		}
+
+		$actor   = $this->actor();
+		$context = $this->context( $phase, $action_id, (string) ( $stored['operation_id'] ?? '' ), $operation_ref, $actor );
+		$context['input'] = is_array( $stored['input'] ?? null ) ? $stored['input'] : array();
+		$authorized = $this->authorize( $action, $context );
+		if ( is_wp_error( $authorized ) ) {
+			return array( 'error_result' => $this->fromError( $authorized ) );
+		}
+
+		return compact( 'action', 'job', 'context' );
+	}
+
+	/** Validate the private execution descriptor returned by an action owner. */
+	private function prepareExecution( $prepared ) {
+		if ( ! is_array( $prepared ) || ! is_array( $prepared['workflow'] ?? null ) ) {
+			return new \WP_Error( 'delegated_action_prepare_failed', __( 'The action owner returned no workflow.', 'data-machine' ) );
+		}
+		$validation = WorkflowSpecValidator::validate( $prepared['workflow'] );
+		if ( empty( $validation['valid'] ) ) {
+			do_action( 'datamachine_log', 'error', 'Delegated operation workflow validation failed', array( 'error' => (string) ( $validation['error'] ?? '' ) ) );
+			return new \WP_Error( 'delegated_action_prepare_failed', __( 'The owner workflow is invalid.', 'data-machine' ) );
+		}
+		$configs = WorkflowConfigFactory::buildEphemeralConfigs( $prepared['workflow'] );
+		try {
+			$first_step_id = ExecutionPlan::from_flow_config( $configs['flow_config'] )->first_step_id();
+		} catch ( \InvalidArgumentException $exception ) {
+			do_action( 'datamachine_log', 'error', 'Delegated operation workflow validation failed', array( 'exception' => $exception->getMessage() ) );
+			return new \WP_Error( 'delegated_action_prepare_failed', __( 'The owner workflow is invalid.', 'data-machine' ) );
+		}
+		if ( ! $first_step_id ) {
+			return new \WP_Error( 'delegated_action_prepare_failed', __( 'The owner workflow has no executable step.', 'data-machine' ) );
+		}
+
+		$user_id    = max( 0, (int) ( $prepared['owner_user_id'] ?? 0 ) );
+		$agent_id   = max( 0, (int) ( $prepared['agent_id'] ?? 0 ) );
+		$agent_slug = trim( (string) ( $prepared['agent_slug'] ?? '' ) );
+		if ( $agent_id > 0 || '' !== $agent_slug ) {
+			try {
+				$identity = ( new AgentIdentityResolver() )->resolve_agent_identity( array( 'agent_id' => $agent_id, 'agent_slug' => $agent_slug ) );
+			} catch ( \InvalidArgumentException $exception ) {
+				do_action( 'datamachine_log', 'error', 'Delegated operation owner resolution failed', array( 'exception' => $exception->getMessage() ) );
+				return new \WP_Error( 'delegated_execution_owner_invalid', __( 'The registered execution owner is invalid.', 'data-machine' ) );
+			}
+			$agent_id   = $identity->agent_id;
+			$agent_slug = $identity->agent_slug;
+			$user_id    = $identity->owner_id;
+		}
+		if ( $user_id <= 0 ) {
+			return new \WP_Error( 'delegated_execution_owner_invalid', __( 'The action owner must resolve a stable execution owner.', 'data-machine' ) );
+		}
+
+		return array(
+			'workflow'      => $prepared['workflow'],
+			'initial_data'  => is_array( $prepared['initial_data'] ?? null ) ? $prepared['initial_data'] : array(),
+			'configs'       => $configs,
+			'first_step_id' => (string) $first_step_id,
+			'user_id'       => $user_id,
+			'agent_id'      => $agent_id,
+			'agent_slug'    => $agent_slug,
+		);
+	}
+
+	/** Build the bounded public response from canonical run truth. */
+	private function response( ?array $job, array $action, array $context, bool $replayed ): array {
+		if ( ! is_array( $job ) ) {
+			return $this->failure( 'delegated_operation_load_failed', __( 'The delegated operation could not be loaded.', 'data-machine' ), true );
+		}
+		$summary    = RunMetrics::fromJob( $job );
+		$run_result = JobStatus::isStatusFinal( (string) ( $job['status'] ?? '' ) ) && is_array( $summary['run_result'] ?? null ) ? $summary['run_result'] : array();
+		$projection = $this->invoke( $action['project'], array( $run_result, $context ), 'delegated_projection_failed' );
+		if ( is_wp_error( $projection ) || ! is_array( $projection ) || array_is_list( $projection ) || ! $this->isBoundedJson( $projection, self::MAX_PROJECTION_BYTES ) ) {
+			$projection = array();
+		}
+		$status = $this->publicStatus( $job, $run_result, $projection );
+		$result = array(
+			'success'       => true,
+			'operation_ref' => (string) $context['operation_ref'],
+			'status'        => $status,
+			'replayed'      => $replayed,
+		);
+		if ( array() !== $projection ) {
+			$result['projection'] = $projection;
+		}
+		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		if ( 'retrying' === $status && is_array( $engine['retry'] ?? null ) ) {
+			$result['retry'] = array_filter(
+				array(
+					'attempt'       => max( 0, (int) ( $engine['retry']['attempt'] ?? 0 ) ),
+					'max_attempts'  => max( 0, (int) ( $engine['retry']['max_attempts'] ?? 0 ) ),
+					'next_retry_at' => isset( $engine['retry']['next_retry_at'] ) ? (string) $engine['retry']['next_retry_at'] : null,
+				),
+				static fn( $value ) => null !== $value
+			);
+		}
+		return $result;
+	}
+
+	private function publicStatus( array $job, array $run_result, array $projection ): string {
+		$status = (string) ( $job['status'] ?? '' );
+		$base   = JobStatus::fromString( $status );
+		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		if ( JobStatus::PENDING === $status && ! empty( $engine['retry']['next_retry_at'] ) ) {
+			return 'retrying';
+		}
+		if ( ! $base->isFinal() ) {
+			return in_array( $status, array( JobStatus::PROCESSING, JobStatus::WAITING ), true ) ? 'executing' : 'submitted';
+		}
+		if ( $base->isFailure() ) {
+			return 'failed';
+		}
+		if ( str_starts_with( $status, JobStatus::CANCELLED ) ) {
+			return 'cancelled';
+		}
+		$canonical_status = strtolower( (string) ( $run_result['status'] ?? '' ) );
+		$canonical_no_op = in_array( $canonical_status, array( 'agent_skipped', 'skipped', 'completed_no_items', 'no_items', 'no-op' ), true );
+		$projected_zero  = isset( $projection['effect_count'] ) && is_int( $projection['effect_count'] ) && 0 === $projection['effect_count'];
+		$canonical_count = $run_result['outputs']['effect_count'] ?? null;
+		$canonical_zero  = is_int( $canonical_count ) && 0 === $canonical_count;
+		if ( $base->isAgentSkipped() || $base->isCompletedNoItems() || $canonical_no_op || $canonical_zero || $projected_zero ) {
+			return 'no-op';
+		}
+		return 'executed';
+	}
+
+	private function authorize( array $action, array $context ) {
+		$result = $this->invoke( $action['authorize'], array( $context ), 'delegated_action_forbidden' );
+		return true === $result ? true : ( is_wp_error( $result ) ? $result : new \WP_Error( 'delegated_action_forbidden', __( 'The action owner denied this operation.', 'data-machine' ) ) );
+	}
+
+	private function actor(): array {
+		$scope     = ExecutionScope::current( 'manage_flows' );
+		$principal = $scope->principal();
+		return array(
+			'user_id'  => max( 0, $principal ? (int) $principal->acting_user_id : $scope->acting_user_id() ),
+			'agent_id' => max( 0, (int) ( $scope->acting_agent_id() ?? 0 ) ),
+			'token_id' => max( 0, (int) ( $scope->acting_token_id() ?? 0 ) ),
+		);
+	}
+
+	private function context( string $phase, string $action, string $operation_id, string $operation_ref, array $actor ): array {
+		return compact( 'phase', 'action', 'operation_id', 'operation_ref', 'actor' );
+	}
+
+	private function reference( string $action, string $operation_id ): string {
+		return self::REFERENCE_PREFIX . hash( 'sha256', $action . "\0" . $operation_id );
+	}
+
+	private function idempotencyKey( string $operation_ref ): string {
+		return self::IDEMPOTENCY_PREFIX . substr( $operation_ref, strlen( self::REFERENCE_PREFIX ) );
+	}
+
+	private function invoke( callable $callback, array $arguments, string $error_code ) {
+		try {
+			return $callback( ...$arguments );
+		} catch ( \Throwable $exception ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Delegated operation owner callback failed',
+				array(
+					'error_code' => $error_code,
+					'exception'  => $exception->getMessage(),
+				)
+			);
+			return new \WP_Error( $error_code, __( 'The delegated action owner could not complete the request.', 'data-machine' ) );
+		}
+	}
+
+	/** Persist the generated job reference without replacing concurrent engine state. */
+	private function persistJobReference( int $job_id ): bool {
+		$result = EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $job_id ): array {
+				$engine['job']           = is_array( $engine['job'] ?? null ) ? $engine['job'] : array();
+				$engine['job']['job_id'] = $job_id;
+				return $engine;
+			},
+			'delegated_operation_job_reference'
+		);
+		return ! empty( $result['success'] );
+	}
+
+	private function canonicalize( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+		if ( ! array_is_list( $value ) ) {
+			ksort( $value, SORT_STRING );
+		}
+		foreach ( $value as $key => $item ) {
+			$value[ $key ] = $this->canonicalize( $item );
+		}
+		return $value;
+	}
+
+	private function isBoundedJson( array $value, int $max_bytes ): bool {
+		$encoded = wp_json_encode( $value );
+		return is_string( $encoded ) && strlen( $encoded ) <= $max_bytes;
+	}
+
+	private function fromError( \WP_Error $error ): array {
+		$data = $error->get_error_data();
+		return $this->failure( (string) $error->get_error_code(), $error->get_error_message(), is_array( $data ) && ! empty( $data['retryable'] ) );
+	}
+
+	private function failure( string $code, string $message, bool $retryable = false ): array {
+		$result = array(
+			'success'    => false,
+			'error_code' => sanitize_key( $code ),
+			'error'      => $message,
+		);
+		if ( $retryable ) {
+			$result['retryable'] = true;
+		}
+		return $result;
+	}
+}

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -477,7 +477,7 @@ class RetentionCleanup {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		return (int) $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT(*) FROM %i WHERE completed_at IS NOT NULL AND completed_at < %s AND engine_data IS NOT NULL AND engine_data != ''",
+				"SELECT COUNT(*) FROM %i WHERE completed_at IS NOT NULL AND completed_at < %s AND source != 'delegated' AND engine_data IS NOT NULL AND engine_data != ''",
 				$table,
 				$cutoff
 			)
@@ -512,7 +512,7 @@ class RetentionCleanup {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		return (int) $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COALESCE(SUM(LENGTH(engine_data)), 0) FROM %i WHERE completed_at IS NOT NULL AND completed_at < %s AND engine_data IS NOT NULL AND engine_data != ''",
+				"SELECT COALESCE(SUM(LENGTH(engine_data)), 0) FROM %i WHERE completed_at IS NOT NULL AND completed_at < %s AND source != 'delegated' AND engine_data IS NOT NULL AND engine_data != ''",
 				$table,
 				$cutoff
 			)
@@ -575,7 +575,7 @@ class RetentionCleanup {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$affected = $wpdb->query(
 				$wpdb->prepare(
-					"UPDATE %i SET engine_data = NULL WHERE job_id IN ( SELECT job_id FROM ( SELECT job_id FROM %i WHERE completed_at IS NOT NULL AND completed_at < %s AND engine_data IS NOT NULL AND engine_data != '' LIMIT %d ) AS tmp )",
+					"UPDATE %i SET engine_data = NULL WHERE job_id IN ( SELECT job_id FROM ( SELECT job_id FROM %i WHERE completed_at IS NOT NULL AND completed_at < %s AND source != 'delegated' AND engine_data IS NOT NULL AND engine_data != '' LIMIT %d ) AS tmp )",
 					$table,
 					$table,
 					$cutoff,

--- a/tests/Unit/Abilities/Job/DelegatedOperationTest.php
+++ b/tests/Unit/Abilities/Job/DelegatedOperationTest.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * Delegated operation contract coverage.
+ *
+ * @package DataMachine\Tests\Unit\Abilities\Job
+ */
+
+namespace DataMachine\Tests\Unit\Abilities\Job;
+
+use DataMachine\Abilities\Job\DelegatedOperationAbilities;
+use DataMachine\Abilities\Job\ExecuteWorkflowAbility;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\DelegatedOperations\DelegatedOperationRegistry;
+use DataMachine\Core\DelegatedOperations\DelegatedOperationService;
+use WP_UnitTestCase;
+
+final class DelegatedOperationTest extends WP_UnitTestCase {
+
+	private int $first_actor;
+	private int $second_actor;
+	private int $execution_owner;
+	private int $manager;
+	private array $authorized = array();
+	private array $projection = array();
+	private bool $retry_safe = true;
+
+	public function set_up(): void {
+		parent::set_up();
+		datamachine_register_capabilities();
+		$this->first_actor     = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->second_actor    = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->execution_owner = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->manager         = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->authorized      = array( $this->first_actor, $this->second_actor );
+		$this->projection      = array(
+			'effect_count' => 1,
+			'record_ref'   => 'rec_public',
+		);
+		add_filter( DelegatedOperationRegistry::FILTER, array( $this, 'registerAction' ) );
+	}
+
+	public function tear_down(): void {
+		remove_filter( DelegatedOperationRegistry::FILTER, array( $this, 'registerAction' ) );
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function registerAction( array $actions ): array {
+		$actions['owner/write-record'] = array(
+			'version'         => '1',
+			'normalize_input' => static fn( array $input ): array => array(
+				'record_key' => sanitize_key( (string) ( $input['record_key'] ?? '' ) ),
+				'value'      => sanitize_text_field( (string) ( $input['value'] ?? '' ) ),
+			),
+			'authorize'       => function ( array $context ) {
+				return in_array( (int) ( $context['actor']['user_id'] ?? 0 ), $this->authorized, true )
+					? true
+					: new \WP_Error( 'owner_action_forbidden', 'Owner policy denied the actor.' );
+			},
+			'prepare'         => function ( array $input ): array {
+				return array(
+					'owner_user_id' => $this->execution_owner,
+					'label'         => 'Write owner record',
+					'workflow'      => $this->workflow( $input['value'] ),
+					'initial_data'  => array( 'owner_record_key' => $input['record_key'] ),
+				);
+			},
+			'project'         => fn(): array => $this->projection,
+			'retry'           => fn(): bool => $this->retry_safe,
+		);
+		return $actions;
+	}
+
+	public function test_two_authorized_users_share_one_owner_neutral_operation(): void {
+		$service = new DelegatedOperationService();
+		wp_set_current_user( $this->first_actor );
+		$first = $service->submit( $this->submission( 'shared-operation' ) );
+		wp_set_current_user( $this->second_actor );
+		$second = $service->submit( $this->submission( 'shared-operation' ) );
+		$job    = $this->job( 'shared-operation' );
+
+		$this->assertTrue( $first['success'] );
+		$this->assertTrue( $second['success'] );
+		$this->assertSame( $first['operation_ref'], $second['operation_ref'] );
+		$this->assertFalse( $first['replayed'] );
+		$this->assertTrue( $second['replayed'] );
+		$this->assertSame( $this->execution_owner, (int) $job['user_id'] );
+		$this->assertSame( $this->first_actor, (int) $job['engine_data']['delegated_operation']['initiator']['user_id'] );
+		$this->assertSame( $this->execution_owner, (int) $job['engine_data']['delegated_operation']['execution_owner']['user_id'] );
+	}
+
+	public function test_receipt_recovery_and_fingerprint_conflict(): void {
+		$service = new DelegatedOperationService();
+		wp_set_current_user( $this->first_actor );
+		$fail_schedule = static fn() => false;
+		add_filter( 'pre_as_schedule_single_action', $fail_schedule );
+		$interrupted = $service->submit( $this->submission( 'crash-recovery' ) );
+		remove_filter( 'pre_as_schedule_single_action', $fail_schedule );
+
+		$recovered = $service->submit( $this->submission( 'crash-recovery' ) );
+		$conflict  = $service->submit( $this->submission( 'crash-recovery', 'changed' ) );
+
+		$this->assertFalse( $interrupted['success'] );
+		$this->assertTrue( $interrupted['retryable'] );
+		$this->assertTrue( $recovered['success'] );
+		$this->assertTrue( $recovered['replayed'] );
+		$this->assertFalse( $conflict['success'] );
+		$this->assertSame( 'delegated_operation_conflict', $conflict['error_code'] );
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{64}$/', (string) $this->job( 'crash-recovery' )['request_fingerprint'] );
+	}
+
+	public function test_action_authority_is_bounded_and_manager_has_no_owner_authority(): void {
+		$service = new DelegatedOperationService();
+		wp_set_current_user( $this->first_actor );
+		$this->assertTrue( ( new DelegatedOperationAbilities( $service ) )->checkPermission() );
+		$this->assertFalse( ( new ExecuteWorkflowAbility() )->checkPermission() );
+		$this->assertTrue( $service->submit( $this->submission( 'bounded-authority' ) )['success'] );
+
+		wp_set_current_user( $this->manager );
+		$this->assertTrue( ( new ExecuteWorkflowAbility() )->checkPermission() );
+		$denied = $service->submit( $this->submission( 'manager-denied' ) );
+		$this->assertFalse( $denied['success'] );
+		$this->assertSame( 'owner_action_forbidden', $denied['error_code'] );
+		$this->assertSame( 'delegated_action_unavailable', $service->submit( array_replace( $this->submission( 'arbitrary-action' ), array( 'action' => 'owner/arbitrary' ) ) )['error_code'] );
+	}
+
+	public function test_registered_public_ability_executes_the_bounded_contract(): void {
+		wp_set_current_user( $this->first_actor );
+		$submit = wp_get_ability( 'datamachine/submit-delegated-operation' );
+		$get    = wp_get_ability( 'datamachine/get-delegated-operation' );
+		$retry  = wp_get_ability( 'datamachine/retry-delegated-operation' );
+		$cancel = wp_get_ability( 'datamachine/cancel-delegated-operation' );
+		$this->assertNotNull( $submit );
+		$this->assertNotNull( $get );
+		$this->assertNotNull( $retry );
+		$this->assertNotNull( $cancel );
+
+		$result = $submit->execute( $this->submission( 'public-ability' ) );
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertMatchesRegularExpression( '/^dop_[a-f0-9]{64}$/', $result['operation_ref'] );
+		$this->assertArrayNotHasKey( 'job_id', $result );
+		$this->assertTrue( is_wp_error( $submit->execute( array_merge( $this->submission( 'undeclared-input' ), array( 'job_id' => 123 ) ) ) ) );
+	}
+
+	public function test_active_replay_returns_execution_state_without_reenqueue(): void {
+		$service = new DelegatedOperationService();
+		wp_set_current_user( $this->first_actor );
+		$submitted = $service->submit( $this->submission( 'active-replay' ) );
+		$job       = $this->job( 'active-replay' );
+		$this->assertTrue( ( new Jobs() )->start_job( (int) $job['job_id'] ) );
+
+		$replayed = $service->submit( $this->submission( 'active-replay' ) );
+		$this->assertTrue( $replayed['success'] );
+		$this->assertTrue( $replayed['replayed'] );
+		$this->assertSame( $submitted['operation_ref'], $replayed['operation_ref'] );
+		$this->assertSame( 'executing', $replayed['status'] );
+	}
+
+	public function test_canonical_no_op_and_owner_redaction_are_public_truth(): void {
+		$service = new DelegatedOperationService();
+		wp_set_current_user( $this->first_actor );
+		$submitted = $service->submit( $this->submission( 'redacted-result' ) );
+		$job       = $this->job( 'redacted-result' );
+		$this->assertTrue( ( new Jobs() )->complete_job( (int) $job['job_id'], 'completed_no_items' ) );
+		$job       = $this->job( 'redacted-result' );
+		$engine    = $job['engine_data'];
+		$engine['run_result'] = array(
+			'schema_version' => 'datamachine.run_result.v1',
+			'status'         => 'completed_no_items',
+			'diagnostics'    => array( 'private_value' => 'must-not-cross-boundary' ),
+		);
+		$this->assertTrue( ( new Jobs() )->store_engine_data( (int) $job['job_id'], $engine ) );
+		$this->projection = array( 'effect_count' => 1, 'record_ref' => 'rec_none' );
+
+		$result = $service->reconcile( array( 'action' => 'owner/write-record', 'operation_ref' => $submitted['operation_ref'] ) );
+		$this->assertSame( 'no-op', $result['status'] );
+		$this->assertSame( array( 'effect_count' => 1, 'record_ref' => 'rec_none' ), $result['projection'] );
+		$this->assertStringNotContainsString( 'must-not-cross-boundary', wp_json_encode( $result ) );
+		$this->assertArrayNotHasKey( 'job_id', $result );
+	}
+
+	public function test_canonical_skipped_and_zero_effect_results_are_independent_no_ops(): void {
+		$service = new DelegatedOperationService();
+		wp_set_current_user( $this->first_actor );
+		$submitted = $service->submit( $this->submission( 'canonical-zero' ) );
+		$job       = $this->job( 'canonical-zero' );
+		$this->assertTrue( ( new Jobs() )->complete_job( (int) $job['job_id'], 'completed' ) );
+		$job       = $this->job( 'canonical-zero' );
+		$engine    = $job['engine_data'];
+		$engine['run_result'] = array(
+			'schema_version' => 'datamachine.run_result.v1',
+			'status'         => 'succeeded',
+			'outputs'        => array( 'effect_count' => 0 ),
+		);
+		$this->assertTrue( ( new Jobs() )->store_engine_data( (int) $job['job_id'], $engine ) );
+		$this->projection = array( 'record_ref' => 'rec_zero' );
+		$zero = $service->reconcile( array( 'action' => 'owner/write-record', 'operation_ref' => $submitted['operation_ref'] ) );
+		$this->assertSame( 'no-op', $zero['status'] );
+
+		$submitted = $service->submit( $this->submission( 'canonical-skipped' ) );
+		$job       = $this->job( 'canonical-skipped' );
+		$this->assertTrue( ( new Jobs() )->complete_job( (int) $job['job_id'], 'completed' ) );
+		$job       = $this->job( 'canonical-skipped' );
+		$engine    = $job['engine_data'];
+		$engine['run_result'] = array( 'schema_version' => 'datamachine.run_result.v1', 'status' => 'skipped' );
+		$this->assertTrue( ( new Jobs() )->store_engine_data( (int) $job['job_id'], $engine ) );
+		$skipped = $service->reconcile( array( 'action' => 'owner/write-record', 'operation_ref' => $submitted['operation_ref'] ) );
+		$this->assertSame( 'no-op', $skipped['status'] );
+	}
+
+	public function test_delayed_cancel_fences_generation_and_executing_cancel_fails(): void {
+		$service = new DelegatedOperationService();
+		wp_set_current_user( $this->first_actor );
+		$delayed = $this->submission( 'delayed-cancel' );
+		$delayed['timestamp'] = time() + HOUR_IN_SECONDS;
+		$submitted = $service->submit( $delayed );
+		$before    = $this->job( 'delayed-cancel' );
+
+		$cancelled = $service->cancel( array( 'action' => 'owner/write-record', 'operation_ref' => $submitted['operation_ref'] ) );
+		$after     = $this->job( 'delayed-cancel' );
+		$this->assertSame( 'cancelled', $cancelled['status'] );
+		$this->assertSame( 'cancelled', $after['operation_state'] );
+		$this->assertGreaterThan( (int) $before['operation_generation'], (int) $after['operation_generation'] );
+		$this->assertEmpty( $after['operation_claim_token'] );
+
+		$running = $service->submit( $this->submission( 'executing-cancel' ) );
+		$job     = $this->job( 'executing-cancel' );
+		$this->assertTrue( ( new Jobs() )->start_job( (int) $job['job_id'] ) );
+		$denied = $service->cancel( array( 'action' => 'owner/write-record', 'operation_ref' => $running['operation_ref'] ) );
+		$this->assertSame( 'delegated_operation_not_cancellable', $denied['error_code'] );
+		$this->assertSame( 'processing', $this->job( 'executing-cancel' )['status'] );
+	}
+
+	public function test_failed_retry_reuses_operation_and_retrying_is_distinct(): void {
+		$service = new DelegatedOperationService();
+		wp_set_current_user( $this->first_actor );
+		$submitted = $service->submit( $this->submission( 'retry-operation' ) );
+		$job       = $this->job( 'retry-operation' );
+		$this->assertTrue( ( new Jobs() )->complete_job( (int) $job['job_id'], 'failed - test' ) );
+
+		$retried = $service->retry( array( 'action' => 'owner/write-record', 'operation_ref' => $submitted['operation_ref'] ) );
+		$this->assertTrue( $retried['success'] );
+		$this->assertSame( 'submitted', $retried['status'] );
+		$this->assertSame( (int) $job['job_id'], (int) $this->job( 'retry-operation' )['job_id'] );
+
+		$retrying_job = $this->job( 'retry-operation' );
+		$engine       = $retrying_job['engine_data'];
+		$engine['retry'] = array( 'attempt' => 1, 'max_attempts' => 3, 'next_retry_at' => gmdate( 'c', time() + 60 ) );
+		$this->assertTrue( ( new Jobs() )->store_engine_data( (int) $retrying_job['job_id'], $engine ) );
+		$retrying = $service->reconcile( array( 'action' => 'owner/write-record', 'operation_ref' => $submitted['operation_ref'] ) );
+		$this->assertSame( 'retrying', $retrying['status'] );
+		$this->assertSame( 1, $retrying['retry']['attempt'] );
+
+		$this->assertTrue( ( new Jobs() )->complete_job( (int) $retrying_job['job_id'], 'failed - retry-fence' ) );
+		$this->retry_safe = false;
+		$unsafe = $service->retry( array( 'action' => 'owner/write-record', 'operation_ref' => $submitted['operation_ref'] ) );
+		$this->assertSame( 'delegated_operation_retry_unsafe', $unsafe['error_code'] );
+	}
+
+	private function submission( string $operation_id, string $value = 'stable' ): array {
+		return array(
+			'action'       => 'owner/write-record',
+			'operation_id' => $operation_id,
+			'input'        => array( 'record_key' => 'example', 'value' => $value ),
+		);
+	}
+
+	private function job( string $operation_id ): array {
+		$key = 'delegated:' . hash( 'sha256', 'owner/write-record' . "\0" . $operation_id );
+		$job = ( new Jobs() )->get_job_by_idempotency_key( $key );
+		$this->assertIsArray( $job );
+		return $job;
+	}
+
+	private function workflow( string $value ): array {
+		return array(
+			'steps' => array(
+				array(
+					'step_type'     => 'ai',
+					'system_prompt' => $value,
+				),
+			),
+		);
+	}
+}

--- a/tests/retention-engine-data-shedding-smoke.php
+++ b/tests/retention-engine-data-shedding-smoke.php
@@ -117,8 +117,8 @@ namespace {
 			&& str_contains( $cleanup, 'LIMIT %d' )
 	);
 	assert_eds(
-		'shed targets terminal rows via completed_at + non-empty engine_data',
-		str_contains( $cleanup, "completed_at IS NOT NULL AND completed_at < %s AND engine_data IS NOT NULL AND engine_data != ''" )
+		'shed targets terminal non-delegated rows with non-empty engine_data',
+		str_contains( $cleanup, "completed_at IS NOT NULL AND completed_at < %s AND source != 'delegated' AND engine_data IS NOT NULL AND engine_data != ''" )
 	);
 	assert_eds(
 		'shed reuses shared batch / iteration / runtime caps (#2617)',
@@ -257,6 +257,9 @@ namespace {
 		private function matching_jobs( string $cutoff ): array {
 			$out = array();
 			foreach ( $this->jobs as $id => $row ) {
+				if ( 'delegated' === ( $row['source'] ?? '' ) ) {
+					continue;
+				}
 				if ( null === $row['completed_at'] ) {
 					continue;
 				}
@@ -284,6 +287,7 @@ namespace {
 	for ( $i = 0; $i < 2500; $i++ ) {
 		$fake_wpdb->jobs[ $jid ] = array(
 			'job_id'       => $jid,
+			'source'       => 'direct',
 			'completed_at' => $two_days,
 			'engine_data'  => $blob,
 		);
@@ -292,6 +296,7 @@ namespace {
 	for ( $i = 0; $i < 5; $i++ ) {
 		$fake_wpdb->jobs[ $jid ] = array(
 			'job_id'       => $jid,
+			'source'       => 'direct',
 			'completed_at' => $one_hour,
 			'engine_data'  => $blob,
 		);
@@ -300,7 +305,17 @@ namespace {
 	for ( $i = 0; $i < 10; $i++ ) {
 		$fake_wpdb->jobs[ $jid ] = array(
 			'job_id'       => $jid,
+			'source'       => 'direct',
 			'completed_at' => null,
+			'engine_data'  => $blob,
+		);
+		++$jid;
+	}
+	for ( $i = 0; $i < 3; $i++ ) {
+		$fake_wpdb->jobs[ $jid ] = array(
+			'job_id'       => $jid,
+			'source'       => 'delegated',
+			'completed_at' => $two_days,
 			'engine_data'  => $blob,
 		);
 		++$jid;
@@ -356,12 +371,12 @@ namespace {
 		2500 === count( $shed )
 	);
 	assert_eds(
-		'fresh + in-flight jobs kept engine_data (15)',
-		15 === count( $kept )
+		'fresh, in-flight, and delegated jobs kept engine_data (18)',
+		18 === count( $kept )
 	);
 	assert_eds(
 		'shedding keeps the row (no jobs deleted)',
-		2515 === $rows,
+		2518 === $rows,
 		"rows={$rows}"
 	);
 


### PR DESCRIPTION
## Summary
- add a generic owner-registered delegated operation substrate with cross-user atomic identity, frozen fingerprints, initiating-actor attestation, stable execution ownership, delayed scheduling, and durable opaque references
- expose bounded submit, reconcile, retry, and pre-execution cancel abilities without exposing workflows, tasks, schedulers, raw jobs, or internal execution entrypoints
- derive public lifecycle and owner-redacted projections from canonical run results, preserve delegated envelopes through short-window engine-data shedding, and atomically fence cancelled generations

Closes #2999.

## Public Contract

Owners register `owner/action` definitions through `datamachine_delegated_operation_actions` with:

- `version`
- `normalize_input( array $input, array $context ): array|WP_Error`
- `authorize( array $context ): true|WP_Error`
- `prepare( array $normalized_input, array $context ): array|WP_Error`
- `project( array $canonical_run_result, array $context ): array|WP_Error`
- optional `retry( array $failed_canonical_run_result, array $context ): true|WP_Error`

`prepare` returns the private workflow plus a stable `owner_user_id` and/or registered `agent_id`/`agent_slug`; callers cannot provide execution descriptors. Explicit retry fails closed unless the owner reconciles its durable effect receipt and proves replay safe.

Public abilities:

- `datamachine/submit-delegated-operation`: `action`, caller-stable `operation_id`, owner input, optional delayed `timestamp`
- `datamachine/get-delegated-operation`: `action`, opaque `operation_ref`
- `datamachine/retry-delegated-operation`: `action`, opaque `operation_ref`
- `datamachine/cancel-delegated-operation`: `action`, opaque `operation_ref`

Responses expose only `success`, `operation_ref`, lifecycle `status`, `replayed`, optional owner `projection`, bounded retry metadata, or structured public errors. Full registration and response details are in `docs/DELEGATED_OPERATIONS.md`, ready for Data Machine Socials #203 and Extra Chill Newsletter #29 to bind their owner actions.

## Correctness
- global Jobs uniqueness makes two authorized WordPress users converge on one operation/job
- fingerprints freeze normalized input, contract version, workflow, initial data, stable execution owner, and schedule while excluding the initiating actor
- enqueue generation/claim recovery handles interrupted receipt persistence and concurrent replay without blind engine-state replacement
- owner authorization runs for submit, reconcile, retry, and cancel; Data Machine management capability is never an owner-policy bypass
- cancellation accepts pending work only and atomically advances the execution generation before unscheduling
- terminal statuses map to `executed`, `no-op`, `failed`, or `cancelled`; pending retries remain distinct as `retrying`
- only associative owner projections up to 32 KiB cross the boundary; internal diagnostics and callback exceptions are redacted

## Verification
- `vendor/bin/phpcs` passed for the full repository
- `npm run build` passed
- `php tests/retention-engine-data-shedding-smoke.php` passed: 24 assertions
- `php tests/direct-job-generation-smoke.php` passed: 13 assertions
- retry scheduling, retry policy, run metrics, job outcome metrics, and step-result CAS smoke suites passed
- focused `DelegatedOperationTest` runner exited 0; the local runner emitted no PHPUnit report
- independent final review found no blocking issues

Homeboy's managed WordPress/MySQL test gate could not bootstrap because its Docker MySQL service was unavailable on this host, so no real multi-process MySQL race run was available. The acceptance suite uses the real Jobs repository when run in the repository WordPress test environment, and the existing unique-key `create_or_get_job()` race path remains the atomic concurrency primitive.