### PR TITLE
fix: harden delegated operation lifecycle

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -364,7 +364,7 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\Job\HydrateJobArtifactAbility();
 	new \DataMachine\Abilities\Job\DeleteJobsAbility();
 	new \DataMachine\Abilities\Job\ExecuteWorkflowAbility();
-	new \DataMachine\Abilities\Job\DelegatedOperationAbilities();
+	new \DataMachine\Abilities\DelegatedOperationAbilities();
 	new \DataMachine\Abilities\Job\ExecuteAgentWorkflowAbility();
 	new \DataMachine\Abilities\Job\FlowHealthAbility();
 	new \DataMachine\Abilities\Job\ProblemFlowsAbility();

--- a/docs/DELEGATED_OPERATIONS.md
+++ b/docs/DELEGATED_OPERATIONS.md
@@ -15,6 +15,10 @@ add_filter(
 	static function ( array $actions ): array {
 		$actions['owner/create-record'] = array(
 			'version'         => '1',
+			'versions'        => array(
+				// Full prior callback contracts remain addressable by frozen version.
+				'0' => $version_zero_contract,
+			),
 			'normalize_input' => static function ( array $input, array $context ) {
 				// Return a bounded, deterministic array or WP_Error.
 				return array( 'record_key' => sanitize_key( $input['record_key'] ?? '' ) );
@@ -58,6 +62,9 @@ output, the registration version, stable execution owner, workflow, initial
 data, and requested timestamp form the frozen request fingerprint. The first
 successful submission attests the initiating user/agent separately from the
 stable execution owner. Initiator identity does not affect deduplication.
+Keep complete prior callback contracts in `versions` for at least the whole-row
+retention window so pending and retained operations can resolve their frozen
+authorization, projection, and retry policy after an owner upgrade.
 
 `authorize` receives `phase`, `action`, `operation_id`, `operation_ref`, `actor`,
 and normalized `input`. It must return `true` or `WP_Error`. The owner remains
@@ -84,8 +91,12 @@ workflow state, task classes, and scheduler records are never public inputs or
 outputs. Set `effect_count` to `0` when successful execution produced no
 consequential effect; Data Machine then reports `no-op`.
 
-Data Machine also reports `no-op` for canonical skipped/no-items statuses and
-for a canonical integer `outputs.effect_count` of `0`.
+Data Machine validates exact `datamachine.run_result.v1` envelopes before owner
+projection, retry, or terminal status mapping. Active operations receive a
+canonical active envelope rather than an empty array. Data Machine reports
+`no-op` for canonical skipped/no-items statuses and for a canonical integer
+`outputs.effect_count` of `0`; malformed or legacy terminal envelopes fail
+closed.
 
 `retry` is optional. Without it, explicit retry fails closed. When registered,
 it receives the failed canonical run result and frozen operation context. It
@@ -106,10 +117,16 @@ Execute `datamachine/submit-delegated-operation` with:
 }
 ```
 
-The response contains an opaque `operation_ref`, `status`, replay flag, and the
+The response contains a secret-keyed opaque `operation_ref`, `status`, replay flag, and the
 owner projection. Repeating the same action and operation ID from any authorized
 WordPress user atomically returns the same operation. Reuse with changed input,
 policy, owner, workflow, or schedule returns `delegated_operation_conflict`.
+
+Internal idempotency uses a stable one-way request identity. The public receipt
+is independently keyed by a lazily generated durable site secret, so both
+identity and receipt derivation survive WordPress auth-salt rotation. Reconcile,
+retry, and cancel look up only a stored hash of the public receipt, so knowing
+or guessing an action and operation ID does not reveal a usable receipt.
 
 Successful responses have `success`, `operation_ref`, `status`, and `replayed`,
 with optional `projection` and bounded `retry` metadata. Failures have `success:
@@ -126,14 +143,23 @@ Use these abilities with only `action` and `operation_ref`:
 - `datamachine/cancel-delegated-operation`
 
 Statuses are `submitted`, `executing`, `executed`, `no-op`, `failed`,
-`cancelled`, and `retrying`. Automatic retry metadata is bounded to attempt,
-maximum attempts, and next retry time. Explicit retry reopens only failed work
+`cancelled`, and `retrying`. Automatic retry and AI-concurrency deferral metadata
+is bounded to type, attempt, maximum attempts, and next retry time. Explicit retry reopens only failed work
 after its owner retry callback proves replay safety, and preserves its operation
 identity. Cancellation succeeds only before work
 starts; it atomically fences the queued generation before removing its scheduled
 action. An executing operation cannot claim safe cancellation.
 
-Delegated operation envelopes are excluded from short-window terminal
-`engine_data` shedding because the frozen authorization context and redacted
-canonical reconciliation remain part of the durable operation contract. Normal
-whole-row retention still defines the operation's final storage lifetime.
+The bounded operation envelope is stored separately from executable workflow
+state. Short-window terminal `engine_data` shedding removes normalized runtime,
+workflow, and diagnostic state while preserving the frozen authorization context
+and validated canonical result. Canonical capture is a replayable terminal core
+accounting stage; a failed envelope write prevents that stage from advancing.
+Normal completed/failed/cancelled whole-row retention defines the operation's
+final storage lifetime, with cancelled age measured from cancellation completion.
+
+Cancellation is intentionally conservative. A monotonic row marker is committed
+immediately before the first owner step can execute and survives retry/defer
+transitions. Only a pending operation with no effects-begun marker can be
+cancelled; retrying, concurrency-deferred, later-step, and executing work cannot
+claim safe pre-execution cancellation.

--- a/inc/Abilities/DelegatedOperationAbilities.php
+++ b/inc/Abilities/DelegatedOperationAbilities.php
@@ -2,13 +2,11 @@
 /**
  * Public delegated operation abilities.
  *
- * @package DataMachine\Abilities\Job
+ * @package DataMachine\Abilities
  */
 
-namespace DataMachine\Abilities\Job;
+namespace DataMachine\Abilities;
 
-use DataMachine\Abilities\AbilityRegistration;
-use DataMachine\Abilities\ExecutionScope;
 use DataMachine\Core\DelegatedOperations\DelegatedOperationService;
 
 defined( 'ABSPATH' ) || exit;
@@ -24,16 +22,25 @@ final class DelegatedOperationAbilities {
 
 	public function register(): void {
 		$identity = array(
-			'action' => array( 'type' => 'string', 'maxLength' => 129 ),
-			'operation_ref' => array( 'type' => 'string', 'pattern' => '^dop_[a-f0-9]{64}$' ),
+			'action'        => array(
+				'type'      => 'string',
+				'maxLength' => 129,
+			),
+			'operation_ref' => array(
+				'type'    => 'string',
+				'pattern' => '^dop_[a-f0-9]{64}$',
+			),
 		);
-		$output = array(
-			'type'       => 'object',
-			'required'   => array( 'success' ),
-			'properties' => array(
+		$output   = array(
+			'type'                 => 'object',
+			'required'             => array( 'success' ),
+			'properties'           => array(
 				'success'       => array( 'type' => 'boolean' ),
 				'operation_ref' => array( 'type' => 'string' ),
-				'status'        => array( 'type' => 'string', 'enum' => array( 'submitted', 'executing', 'executed', 'no-op', 'failed', 'cancelled', 'retrying' ) ),
+				'status'        => array(
+					'type' => 'string',
+					'enum' => array( 'submitted', 'executing', 'executed', 'no-op', 'failed', 'cancelled', 'retrying' ),
+				),
 				'replayed'      => array( 'type' => 'boolean' ),
 				'projection'    => array( 'type' => 'object' ),
 				'retry'         => array( 'type' => 'object' ),
@@ -51,11 +58,15 @@ final class DelegatedOperationAbilities {
 				'description'         => __( 'Submit one owner-registered operation without gaining general workflow authority.', 'data-machine' ),
 				'category'            => 'datamachine-jobs',
 				'input_schema'        => array(
-					'type'       => 'object',
-					'required'   => array( 'action', 'operation_id', 'input' ),
-					'properties' => array(
+					'type'                 => 'object',
+					'required'             => array( 'action', 'operation_id', 'input' ),
+					'properties'           => array(
 						'action'       => $identity['action'],
-						'operation_id' => array( 'type' => 'string', 'minLength' => 1, 'maxLength' => 191 ),
+						'operation_id' => array(
+							'type'      => 'string',
+							'minLength' => 1,
+							'maxLength' => 191,
+						),
 						'input'        => array( 'type' => 'object' ),
 						'timestamp'    => array( 'type' => array( 'integer', 'null' ) ),
 					),
@@ -68,17 +79,22 @@ final class DelegatedOperationAbilities {
 			)
 		);
 
-		foreach ( array( 'get' => 'reconcile', 'retry' => 'retry', 'cancel' => 'cancel' ) as $verb => $method ) {
+		foreach ( array(
+			'get'    => 'reconcile',
+			'retry'  => 'retry',
+			'cancel' => 'cancel',
+		) as $verb => $method ) {
 			wp_register_ability(
 				'datamachine/' . $verb . '-delegated-operation',
 				array(
+					/* translators: %s: delegated operation action, such as Get, Retry, or Cancel. */
 					'label'               => sprintf( __( '%s Delegated Operation', 'data-machine' ), ucfirst( $verb ) ),
 					'description'         => __( 'Act on one owner-authorized delegated operation reference.', 'data-machine' ),
 					'category'            => 'datamachine-jobs',
 					'input_schema'        => array(
-						'type'       => 'object',
-						'required'   => array( 'action', 'operation_ref' ),
-						'properties' => $identity,
+						'type'                 => 'object',
+						'required'             => array( 'action', 'operation_ref' ),
+						'properties'           => $identity,
 						'additionalProperties' => false,
 					),
 					'output_schema'       => $output,

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -285,6 +285,9 @@ class ExecuteStepAbility {
 			if ( $recovery_generation > 0 && ! $this->db_jobs->renew_recovery_execution_owner( $job_id, $recovery_claim_token, $recovery_generation ) ) {
 				return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'lost ownership before handler execution' );
 			}
+			if ( $operation_generation > 0 && ! $this->db_jobs->mark_operation_effects_begun( $job_id, $operation_generation, $operation_claim_token ) ) {
+				return $this->staleOperationGeneration( $job_id, $operation_generation, 'lost ownership before owner effects began' );
+			}
 			$step_output = $flow_step->execute( $payload );
 			if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
 				return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded during execution' );
@@ -982,9 +985,9 @@ class ExecuteStepAbility {
 		// Some steps (notably AIStep) call datamachine_fail_job with a precise
 		// reason and then return no packets. The defensive check here covers
 		// two shapes:
-		//   - The step's failure was finalized → status starts with `failed`.
-		//   - The step's failure was caught by JobRetryPolicy, which parked the
-		//     job back to `pending` and scheduled a retry via Action Scheduler.
+		// - The step's failure was finalized → status starts with `failed`.
+		// - The step's failure was caught by JobRetryPolicy, which parked the
+		// job back to `pending` and scheduled a retry via Action Scheduler.
 		// In both cases the per-step failure has already been routed; firing
 		// `datamachine_fail_job` again here would double-record the failure
 		// and (when the second reason is non-retryable) trigger

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -257,13 +257,21 @@ class Jobs extends BaseRepository {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$job = $this->wpdb->get_row( $this->wpdb->prepare( 'SELECT * FROM %i WHERE idempotency_key = %s LIMIT 1', $this->table_name, $idempotency_key ), ARRAY_A );
 
-		if ( $job && isset( $job['engine_data'] ) && is_string( $job['engine_data'] ) ) {
-			$decoded = json_decode( $job['engine_data'], true );
-			if ( json_last_error() === JSON_ERROR_NONE ) {
-				$job['engine_data'] = $decoded;
-			}
+		$job = $this->decode_job_json( $job );
+
+		return $job ? $job : null;
+	}
+
+	/** Fetch a job by the hash of its public operation receipt. */
+	public function get_job_by_operation_ref_hash( string $operation_ref_hash ): ?array {
+		if ( ! preg_match( '/^[a-f0-9]{64}$/', $operation_ref_hash ) ) {
+			return null;
 		}
 
+		// phpcs:disable WordPress.DB.PreparedSQL -- The nested prepare binds the plugin table identifier and receipt hash.
+		$job = $this->wpdb->get_row( $this->wpdb->prepare( 'SELECT * FROM %i WHERE operation_ref_hash = %s LIMIT 1', $this->table_name, $operation_ref_hash ), ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL
+		$job = $this->decode_job_json( $job );
 		return $job ? $job : null;
 	}
 
@@ -359,7 +367,16 @@ class Jobs extends BaseRepository {
 			$format[]            = '%s';
 		}
 
-		foreach ( array( 'request_fingerprint', 'operation_state', 'operation_step_id' ) as $operation_field ) {
+		if ( isset( $job_data['operation_envelope'] ) && is_array( $job_data['operation_envelope'] ) ) {
+			$encoded_envelope = wp_json_encode( $job_data['operation_envelope'] );
+			if ( false === $encoded_envelope ) {
+				return false;
+			}
+			$data['operation_envelope'] = $encoded_envelope;
+			$format[]                   = '%s';
+		}
+
+		foreach ( array( 'request_fingerprint', 'operation_state', 'operation_step_id', 'operation_ref_hash' ) as $operation_field ) {
 			if ( isset( $job_data[ $operation_field ] ) && is_scalar( $job_data[ $operation_field ] ) ) {
 				$data[ $operation_field ] = sanitize_text_field( (string) $job_data[ $operation_field ] );
 				$format[]                 = '%s';
@@ -394,6 +411,7 @@ class Jobs extends BaseRepository {
 		$claim_token  = bin2hex( random_bytes( 16 ) );
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The nested prepare binds the plugin table identifier and every scalar value.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL -- The nested prepare binds the plugin table identifier and every scalar value.
 		$updated = $this->wpdb->query(
 			$this->wpdb->prepare(
 				"UPDATE %i SET operation_state = 'enqueuing', operation_claimed_at = %s, operation_claim_token = %s, operation_generation = COALESCE(operation_generation, 0) + 1 WHERE job_id = %d AND (operation_state IN ('preparing', 'enqueue_failed') OR (operation_state = 'enqueuing' AND (operation_claimed_at IS NULL OR operation_claimed_at < %s)))",
@@ -404,6 +422,7 @@ class Jobs extends BaseRepository {
 				$lease_cutoff
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( 1 !== (int) $updated ) {
@@ -445,7 +464,7 @@ class Jobs extends BaseRepository {
 			return false;
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The nested prepare binds the plugin table identifier and job ID.
+		// phpcs:disable WordPress.DB.PreparedSQL -- The nested prepare binds the plugin table identifier and job ID.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->query(
 			$this->wpdb->prepare(
@@ -454,7 +473,7 @@ class Jobs extends BaseRepository {
 				$job_id
 			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		return 1 === (int) $updated;
 	}
@@ -474,7 +493,7 @@ class Jobs extends BaseRepository {
 			return false;
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The nested prepare binds the plugin table identifier and every scalar value.
+		// phpcs:disable WordPress.DB.PreparedSQL -- The nested prepare binds the plugin table identifier and every scalar value.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->query(
 			$this->wpdb->prepare(
@@ -488,7 +507,7 @@ class Jobs extends BaseRepository {
 				$token
 			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		return 1 === (int) $updated;
 	}
@@ -505,7 +524,7 @@ class Jobs extends BaseRepository {
 		}
 
 		$failed_status = $this->wpdb->esc_like( 'failed' ) . '%';
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The nested prepare binds the plugin table identifier, job ID, and escaped LIKE value.
+		// phpcs:disable WordPress.DB.PreparedSQL -- The nested prepare binds the plugin table identifier, job ID, and escaped LIKE value.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->query(
 			$this->wpdb->prepare(
@@ -515,9 +534,48 @@ class Jobs extends BaseRepository {
 				$failed_status
 			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		return 1 === (int) $updated;
+	}
+
+	/** Mark that a direct operation may have entered owner-controlled effects. */
+	public function mark_operation_effects_begun( int $job_id, int $generation, string $token ): bool {
+		if ( 0 >= $job_id || 0 >= $generation || '' === $token ) {
+			return false;
+		}
+		// phpcs:disable WordPress.DB.PreparedSQL -- The nested prepare binds the plugin table identifier and every scalar value.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $this->wpdb->query(
+			$this->wpdb->prepare(
+				"UPDATE %i SET operation_effects_begun_at = COALESCE(operation_effects_begun_at, %s) WHERE job_id = %d AND flow_id = 'direct' AND operation_generation = %d AND operation_claim_token = %s AND operation_state = 'enqueued' AND completed_at IS NULL",
+				$this->table_name,
+				current_time( 'mysql', true ),
+				$job_id,
+				$generation,
+				$token
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL
+		if ( 1 === (int) $updated ) {
+			return true;
+		}
+		$job = false !== $updated ? $this->get_job( $job_id ) : null;
+		return is_array( $job )
+			&& 'enqueued' === (string) ( $job['operation_state'] ?? '' )
+			&& (int) ( $job['operation_generation'] ?? 0 ) === $generation
+			&& hash_equals( $token, (string) ( $job['operation_claim_token'] ?? '' ) )
+			&& ! empty( $job['operation_effects_begun_at'] )
+			&& empty( $job['completed_at'] );
+	}
+
+	/** Persist the bounded delegated reconciliation envelope. */
+	public function store_operation_envelope( int $job_id, array $envelope ): bool {
+		$encoded = wp_json_encode( $envelope );
+		if ( $job_id <= 0 || ! is_string( $encoded ) || strlen( $encoded ) > 262144 ) {
+			return false;
+		}
+		return false !== $this->wpdb->update( $this->table_name, array( 'operation_envelope' => $encoded ), array( 'job_id' => $job_id ), array( '%s' ), array( '%d' ) );
 	}
 
 	/**
@@ -554,13 +612,24 @@ class Jobs extends BaseRepository {
 		$job = $this->wpdb->get_row( $this->wpdb->prepare( 'SELECT * FROM %i WHERE job_id = %d', $this->table_name, $job_id ), ARRAY_A );
 		// phpcs:enable WordPress.DB.PreparedSQL
 
-		if ( $job && isset( $job['engine_data'] ) && is_string( $job['engine_data'] ) ) {
-			$decoded = json_decode( $job['engine_data'], true );
-			if ( json_last_error() === JSON_ERROR_NONE ) {
-				$job['engine_data'] = $decoded;
+		$job = $this->decode_job_json( $job );
+
+		return $job;
+	}
+
+	/** Decode JSON-backed columns returned by direct row reads. */
+	private function decode_job_json( $job ) {
+		if ( ! is_array( $job ) ) {
+			return $job;
+		}
+		foreach ( array( 'engine_data', 'operation_envelope' ) as $column ) {
+			if ( isset( $job[ $column ] ) && is_string( $job[ $column ] ) ) {
+				$decoded = json_decode( $job[ $column ], true );
+				if ( JSON_ERROR_NONE === json_last_error() ) {
+					$job[ $column ] = $decoded;
+				}
 			}
 		}
-
 		return $job;
 	}
 
@@ -1535,13 +1604,14 @@ class Jobs extends BaseRepository {
 
 		$cutoff_datetime = gmdate( 'Y-m-d H:i:s', time() - ( $older_than_days * DAY_IN_SECONDS ) );
 		$match           = $this->resolve_status_match( $status_pattern );
+		$age_column      = 'cancelled' === $status_pattern ? 'completed_at' : 'created_at';
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 		if ( 'in' === $match['type'] ) {
 			$placeholders = implode( ',', array_fill( 0, count( $match['values'] ), '%s' ) );
 			$args         = array_merge(
-				array( "DELETE FROM %i WHERE status IN ({$placeholders}) AND created_at < %s", $this->table_name ),
+				array( "DELETE FROM %i WHERE status IN ({$placeholders}) AND {$age_column} < %s", $this->table_name ),
 				$match['values'],
 				array( $cutoff_datetime )
 			);
@@ -1549,7 +1619,7 @@ class Jobs extends BaseRepository {
 		} else {
 			$result = $this->wpdb->query(
 				$this->wpdb->prepare(
-					'DELETE FROM %i WHERE status LIKE %s AND created_at < %s',
+					"DELETE FROM %i WHERE status LIKE %s AND {$age_column} < %s",
 					$this->table_name,
 					$match['pattern'],
 					$cutoff_datetime
@@ -1590,13 +1660,14 @@ class Jobs extends BaseRepository {
 
 		$cutoff_datetime = gmdate( 'Y-m-d H:i:s', time() - ( $older_than_days * DAY_IN_SECONDS ) );
 		$match           = $this->resolve_status_match( $status_pattern );
+		$age_column      = 'cancelled' === $status_pattern ? 'completed_at' : 'created_at';
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 		if ( 'in' === $match['type'] ) {
 			$placeholders = implode( ',', array_fill( 0, count( $match['values'] ), '%s' ) );
 			$args         = array_merge(
-				array( "SELECT COUNT(*) FROM %i WHERE status IN ({$placeholders}) AND created_at < %s", $this->table_name ),
+				array( "SELECT COUNT(*) FROM %i WHERE status IN ({$placeholders}) AND {$age_column} < %s", $this->table_name ),
 				$match['values'],
 				array( $cutoff_datetime )
 			);
@@ -1604,7 +1675,7 @@ class Jobs extends BaseRepository {
 		} else {
 			$count = $this->wpdb->get_var(
 				$this->wpdb->prepare(
-					'SELECT COUNT(*) FROM %i WHERE status LIKE %s AND created_at < %s',
+					"SELECT COUNT(*) FROM %i WHERE status LIKE %s AND {$age_column} < %s",
 					$this->table_name,
 					$match['pattern'],
 					$cutoff_datetime
@@ -2336,7 +2407,7 @@ class Jobs extends BaseRepository {
 		}
 
 		$current_status = is_string( $job['status'] ?? null ) ? $job['status'] : '';
-		if ( $pending_direct_cancel && ( 'direct' !== (string) ( $job['flow_id'] ?? '' ) || JobStatus::PENDING !== $current_status ) ) {
+		if ( $pending_direct_cancel && ( 'direct' !== (string) ( $job['flow_id'] ?? '' ) || JobStatus::PENDING !== $current_status || ! empty( $job['operation_effects_begun_at'] ) ) ) {
 			$this->rollback_terminal_transition( $job_id );
 			return $this->status_transition_result( false, false, $current_status, $current_status );
 		}
@@ -3040,6 +3111,9 @@ class Jobs extends BaseRepository {
 			operation_claim_token varchar(64) NULL DEFAULT NULL,
 			operation_generation bigint(20) unsigned NOT NULL DEFAULT 0,
 			operation_action_id bigint(20) unsigned NULL DEFAULT NULL,
+			operation_ref_hash char(64) NULL DEFAULT NULL,
+			operation_effects_begun_at datetime NULL DEFAULT NULL,
+			operation_envelope longtext NULL,
 			terminal_accounting_state tinyint unsigned NULL DEFAULT NULL,
 			terminal_accounting_owner varchar(64) NULL DEFAULT NULL,
 			terminal_accounting_claimed_at datetime NULL DEFAULT NULL,
@@ -3058,7 +3132,8 @@ class Jobs extends BaseRepository {
             KEY idx_status_created (status(50), created_at),
 			KEY idx_source_created (source, created_at),
 			KEY idx_terminal_accounting (terminal_accounting_state, job_id),
-            UNIQUE KEY idx_idempotency_key (idempotency_key)
+			UNIQUE KEY idx_idempotency_key (idempotency_key),
+			UNIQUE KEY idx_operation_ref_hash (operation_ref_hash)
         ) $charset_collate;";
 
 		dbDelta( $sql );
@@ -3500,13 +3575,16 @@ class Jobs extends BaseRepository {
 		global $wpdb;
 
 		$columns = array(
-			'request_fingerprint'   => 'char(64) NULL DEFAULT NULL',
-			'operation_state'       => 'varchar(32) NULL DEFAULT NULL',
-			'operation_step_id'     => 'varchar(191) NULL DEFAULT NULL',
-			'operation_claimed_at'  => 'datetime NULL DEFAULT NULL',
-			'operation_claim_token' => 'varchar(64) NULL DEFAULT NULL',
-			'operation_generation'  => 'bigint(20) unsigned NOT NULL DEFAULT 0',
-			'operation_action_id'   => 'bigint(20) unsigned NULL DEFAULT NULL',
+			'request_fingerprint'        => 'char(64) NULL DEFAULT NULL',
+			'operation_state'            => 'varchar(32) NULL DEFAULT NULL',
+			'operation_step_id'          => 'varchar(191) NULL DEFAULT NULL',
+			'operation_claimed_at'       => 'datetime NULL DEFAULT NULL',
+			'operation_claim_token'      => 'varchar(64) NULL DEFAULT NULL',
+			'operation_generation'       => 'bigint(20) unsigned NOT NULL DEFAULT 0',
+			'operation_action_id'        => 'bigint(20) unsigned NULL DEFAULT NULL',
+			'operation_ref_hash'         => 'char(64) NULL DEFAULT NULL',
+			'operation_effects_begun_at' => 'datetime NULL DEFAULT NULL',
+			'operation_envelope'         => 'longtext NULL',
 		);
 
 		foreach ( $columns as $column => $definition ) {
@@ -3518,6 +3596,7 @@ class Jobs extends BaseRepository {
 			$wpdb->query( "ALTER TABLE {$table_name} ADD COLUMN {$column} {$definition}" );
 			// phpcs:enable WordPress.DB.PreparedSQL
 		}
+		self::ensure_jobs_index( $table_name, 'idx_operation_ref_hash', 'UNIQUE INDEX', '(operation_ref_hash)' );
 	}
 
 	/** Add terminal post-commit receipt and lease columns. */

--- a/inc/Core/DelegatedOperations/DelegatedOperationRegistry.php
+++ b/inc/Core/DelegatedOperations/DelegatedOperationRegistry.php
@@ -18,7 +18,7 @@ final class DelegatedOperationRegistry {
 	 *
 	 * @return array|\WP_Error
 	 */
-	public function get( string $action_id ) {
+	public function get( string $action_id, ?string $version = null ) {
 		if ( ! preg_match( '/^[a-z0-9][a-z0-9_-]{0,63}\/[a-z0-9][a-z0-9_-]{0,63}$/', $action_id ) ) {
 			return new \WP_Error( 'delegated_action_invalid', __( 'The delegated action identifier is invalid.', 'data-machine' ) );
 		}
@@ -28,14 +28,30 @@ final class DelegatedOperationRegistry {
 		if ( null === $action ) {
 			return new \WP_Error( 'delegated_action_unavailable', __( 'The delegated action is not registered.', 'data-machine' ) );
 		}
+		$current_version = is_string( $action['version'] ?? null ) || is_int( $action['version'] ?? null ) ? trim( (string) $action['version'] ) : '';
+		if ( null !== $version && $version !== $current_version ) {
+			$versions = is_array( $action['versions'] ?? null ) ? $action['versions'] : array();
+			$action   = is_array( $versions[ $version ] ?? null ) ? $versions[ $version ] : null;
+			if ( null === $action ) {
+				return new \WP_Error( 'delegated_action_version_unavailable', __( 'The delegated action contract version is not registered.', 'data-machine' ) );
+			}
+			$action['version'] = $version;
+		}
 
 		foreach ( array( 'normalize_input', 'authorize', 'prepare', 'project' ) as $callback ) {
 			if ( ! is_callable( $action[ $callback ] ?? null ) ) {
 				return new \WP_Error( 'delegated_action_invalid', __( 'The delegated action registration is incomplete.', 'data-machine' ) );
 			}
 		}
+		if ( array_key_exists( 'retry', $action ) && ! is_callable( $action['retry'] ) ) {
+			return new \WP_Error( 'delegated_action_invalid', __( 'The delegated action retry callback is invalid.', 'data-machine' ) );
+		}
 
-		$version = trim( (string) ( $action['version'] ?? '' ) );
+		$raw_version = $action['version'] ?? null;
+		if ( ! is_string( $raw_version ) && ! is_int( $raw_version ) ) {
+			return new \WP_Error( 'delegated_action_invalid', __( 'The delegated action version is invalid.', 'data-machine' ) );
+		}
+		$version = trim( (string) $raw_version );
 		if ( '' === $version || strlen( $version ) > 64 ) {
 			return new \WP_Error( 'delegated_action_invalid', __( 'The delegated action version is invalid.', 'data-machine' ) );
 		}

--- a/inc/Core/DelegatedOperations/DelegatedOperationService.php
+++ b/inc/Core/DelegatedOperations/DelegatedOperationService.php
@@ -291,14 +291,14 @@ final class DelegatedOperationService {
 		}
 		if ( function_exists( 'as_unschedule_action' ) && '' !== $step_id && 0 < $generation && '' !== $token ) {
 			as_unschedule_action(
-				'datamachine_execute_step',
+				DirectJobEnqueuer::HOOK,
 				array(
 					'job_id'                => $job_id,
 					'flow_step_id'          => $step_id,
 					'operation_generation'  => $generation,
 					'operation_claim_token' => $token,
 				),
-				'data-machine'
+				DirectJobEnqueuer::GROUP
 			);
 		}
 		return $this->response( $this->jobs->get_job( $job_id ), $resolved['action'], $resolved['context'], true );

--- a/inc/Core/DelegatedOperations/DelegatedOperationService.php
+++ b/inc/Core/DelegatedOperations/DelegatedOperationService.php
@@ -15,6 +15,7 @@ use DataMachine\Core\EngineData;
 use DataMachine\Core\JobRetryPolicy;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\RunMetrics;
+use DataMachine\Core\RunResult;
 use DataMachine\Core\Steps\WorkflowConfigFactory;
 use DataMachine\Core\Steps\WorkflowSpecValidator;
 use DataMachine\Engine\ExecutionPlan;
@@ -23,25 +24,30 @@ defined( 'ABSPATH' ) || exit;
 
 final class DelegatedOperationService {
 
-	private const IDEMPOTENCY_PREFIX = 'delegated:';
-	private const REFERENCE_PREFIX   = 'dop_';
-	private const MAX_INPUT_BYTES    = 65536;
+	private const IDEMPOTENCY_PREFIX   = 'delegated:';
+	private const REFERENCE_PREFIX     = 'dop_';
+	private const MAX_INPUT_BYTES      = 65536;
 	private const MAX_PROJECTION_BYTES = 32768;
 
 	private Jobs $jobs;
 	private DelegatedOperationRegistry $registry;
+	private static bool $hooks_registered = false;
 
 	public function __construct( ?Jobs $jobs = null, ?DelegatedOperationRegistry $registry = null ) {
 		$this->jobs     = $jobs ?? new Jobs();
 		$this->registry = $registry ?? new DelegatedOperationRegistry();
+		if ( ! self::$hooks_registered ) {
+			add_filter( 'datamachine_job_terminal_core_callbacks', array( $this, 'registerTerminalCallback' ), 20, 3 );
+			self::$hooks_registered = true;
+		}
 	}
 
 	/** Submit an owner-registered operation. */
 	public function submit( array $request ): array {
-		$action_id   = trim( (string) ( $request['action'] ?? '' ) );
+		$action_id    = trim( (string) ( $request['action'] ?? '' ) );
 		$operation_id = trim( (string) ( $request['operation_id'] ?? '' ) );
-		$raw_input   = is_array( $request['input'] ?? null ) ? $request['input'] : array();
-		$timestamp   = isset( $request['timestamp'] ) && is_numeric( $request['timestamp'] ) ? max( 0, (int) $request['timestamp'] ) : null;
+		$raw_input    = is_array( $request['input'] ?? null ) ? $request['input'] : array();
+		$timestamp    = isset( $request['timestamp'] ) && is_numeric( $request['timestamp'] ) ? max( 0, (int) $request['timestamp'] ) : null;
 		if ( '' === $operation_id || strlen( $operation_id ) > 191 ) {
 			return $this->failure( 'delegated_operation_id_invalid', __( 'A bounded operation_id is required.', 'data-machine' ) );
 		}
@@ -56,9 +62,35 @@ final class DelegatedOperationService {
 			return $this->fromError( $action );
 		}
 
-		$operation_ref = $this->reference( $action_id, $operation_id );
-		$context       = $this->context( 'submit', $action_id, $operation_id, $operation_ref, $actor );
-		$normalized    = $this->invoke( $action['normalize_input'], array( $raw_input, $context ), 'delegated_input_invalid' );
+		$idempotency_key = $this->idempotencyKey( $action_id, $operation_id );
+		$existing_job    = $this->jobs->get_job_by_idempotency_key( $idempotency_key );
+		$operation_ref   = '';
+		if ( is_array( $existing_job ) ) {
+			$existing_envelope  = is_array( $existing_job['operation_envelope'] ?? null ) ? $existing_job['operation_envelope'] : array();
+			$existing_operation = is_array( $existing_envelope['delegated_operation'] ?? null ) ? $existing_envelope['delegated_operation'] : array();
+			$stored_ref         = (string) ( $existing_operation['operation_ref'] ?? '' );
+			if ( preg_match( '/^dop_[a-f0-9]{64}$/', $stored_ref ) ) {
+				$operation_ref = $stored_ref;
+			}
+		}
+		if ( '' === $operation_ref ) {
+			try {
+				$operation_ref = $this->reference( $action_id, $operation_id );
+			} catch ( \Throwable ) {
+				return $this->failure( 'delegated_receipt_secret_invalid', __( 'The delegated operation receipt secret is unavailable.', 'data-machine' ), true );
+			}
+		}
+		$context    = $this->context( 'submit', $action_id, $operation_id, $operation_ref, $actor );
+		$normalized = $this->invoke(
+			$action['normalize_input'],
+			array( $raw_input, $context ),
+			'delegated_input_invalid',
+			array(
+				'callback' => 'normalize_input',
+				'action'   => $action_id,
+				'phase'    => 'submit',
+			)
+		);
 		if ( is_wp_error( $normalized ) ) {
 			return $this->fromError( $normalized );
 		}
@@ -72,7 +104,16 @@ final class DelegatedOperationService {
 			return $this->fromError( $authorized );
 		}
 
-		$prepared = $this->invoke( $action['prepare'], array( $normalized, $context ), 'delegated_action_prepare_failed' );
+		$prepared = $this->invoke(
+			$action['prepare'],
+			array( $normalized, $context ),
+			'delegated_action_prepare_failed',
+			array(
+				'callback' => 'prepare',
+				'action'   => $action_id,
+				'phase'    => 'submit',
+			)
+		);
 		if ( is_wp_error( $prepared ) ) {
 			return $this->fromError( $prepared );
 		}
@@ -81,7 +122,7 @@ final class DelegatedOperationService {
 			return $this->fromError( $execution );
 		}
 
-		$engine_data = is_array( $execution['initial_data'] ?? null ) ? $execution['initial_data'] : array();
+		$engine_data                    = is_array( $execution['initial_data'] ?? null ) ? $execution['initial_data'] : array();
 		$engine_data['flow_config']     = $execution['configs']['flow_config'];
 		$engine_data['pipeline_config'] = $execution['configs']['pipeline_config'];
 		$engine_data['user_id']         = $execution['user_id'];
@@ -93,19 +134,20 @@ final class DelegatedOperationService {
 			$engine_data['job']['agent_slug'] = $execution['agent_slug'];
 		}
 		$engine_data['delegated_operation'] = array(
-			'action'       => $action_id,
-			'version'      => $action['version'],
-			'operation_id' => $operation_id,
-			'operation_ref' => $operation_ref,
-			'input'        => $normalized,
-			'initiator'    => $actor,
+			'action'          => $action_id,
+			'version'         => $action['version'],
+			'operation_id'    => $operation_id,
+			'operation_ref'   => $operation_ref,
+			'input'           => $normalized,
+			'initiator'       => $actor,
 			'execution_owner' => array(
 				'user_id'    => $execution['user_id'],
 				'agent_id'   => $execution['agent_id'],
 				'agent_slug' => $execution['agent_slug'],
 			),
-			'timestamp'    => $timestamp,
+			'timestamp'       => $timestamp,
 		);
+		$operation_envelope                 = array( 'delegated_operation' => $engine_data['delegated_operation'] );
 
 		$fingerprint_payload = array(
 			'action'          => $action_id,
@@ -116,18 +158,20 @@ final class DelegatedOperationService {
 			'initial_data'    => $execution['initial_data'],
 			'timestamp'       => $timestamp,
 		);
-		$fingerprint = hash( 'sha256', (string) wp_json_encode( $this->canonicalize( $fingerprint_payload ) ) );
-		$create_args = array(
-			'pipeline_id'        => 'direct',
-			'flow_id'            => 'direct',
-			'source'             => 'delegated',
-			'label'              => isset( $prepared['label'] ) ? (string) $prepared['label'] : $action_id,
-			'user_id'            => $execution['user_id'],
-			'idempotency_key'    => $this->idempotencyKey( $operation_ref ),
+		$fingerprint         = hash( 'sha256', (string) wp_json_encode( $this->canonicalize( $fingerprint_payload ) ) );
+		$create_args         = array(
+			'pipeline_id'         => 'direct',
+			'flow_id'             => 'direct',
+			'source'              => 'delegated',
+			'label'               => isset( $prepared['label'] ) ? (string) $prepared['label'] : $action_id,
+			'user_id'             => $execution['user_id'],
+			'idempotency_key'     => $idempotency_key,
+			'operation_ref_hash'  => $this->receiptHash( $operation_ref ),
+			'operation_envelope'  => $operation_envelope,
 			'request_fingerprint' => $fingerprint,
-			'operation_state'    => 'preparing',
-			'operation_step_id'  => $execution['first_step_id'],
-			'engine_data'        => $engine_data,
+			'operation_state'     => 'preparing',
+			'operation_step_id'   => $execution['first_step_id'],
+			'engine_data'         => $engine_data,
 		);
 		if ( $execution['agent_id'] > 0 ) {
 			$create_args['agent_id'] = $execution['agent_id'];
@@ -149,9 +193,22 @@ final class DelegatedOperationService {
 		if ( ! is_array( $job ) ) {
 			return $this->failure( 'delegated_operation_load_failed', __( 'The delegated operation could not be loaded.', 'data-machine' ), true );
 		}
-		$job_status = (string) ( $job['status'] ?? '' );
-		if ( ! JobStatus::isStatusFinal( $job_status ) && ! in_array( $job_status, array( JobStatus::PROCESSING, JobStatus::WAITING ), true ) ) {
-			if ( ! empty( $creation['created'] ) && ! $this->persistJobReference( $job_id ) ) {
+		$job_status    = (string) ( $job['status'] ?? '' );
+		$stored_job_id = (int) ( $job['engine_data']['job']['job_id'] ?? 0 );
+		if ( ! JobStatus::isStatusFinal( $job_status ) && 0 === $stored_job_id && ! $this->persistJobReference( $job_id ) ) {
+			return $this->failure( 'delegated_operation_persist_failed', __( 'The delegated operation could not be persisted.', 'data-machine' ), true );
+		}
+		$job = $this->jobs->get_job( $job_id );
+		if ( ! empty( $creation['already_exists'] ) ) {
+			$stored_envelope  = is_array( $job['operation_envelope'] ?? null ) ? $job['operation_envelope'] : array();
+			$stored_operation = is_array( $stored_envelope['delegated_operation'] ?? null ) ? $stored_envelope['delegated_operation'] : array();
+			$stored_ref       = (string) ( $stored_operation['operation_ref'] ?? '' );
+			if ( preg_match( '/^dop_[a-f0-9]{64}$/', $stored_ref ) ) {
+				$context['operation_ref'] = $stored_ref;
+			}
+		}
+		if ( ! JobStatus::isStatusFinal( $job_status ) && ! in_array( $job_status, array( JobStatus::PROCESSING, JobStatus::WAITING ), true ) && ! $this->executionAlreadyStarted( $job ) ) {
+			if ( ! is_array( $job ) ) {
 				return $this->failure( 'delegated_operation_persist_failed', __( 'The delegated operation could not be persisted.', 'data-machine' ), true );
 			}
 			$enqueue = ( new DirectJobEnqueuer( $this->jobs ) )->enqueue( $job_id, $execution['first_step_id'], $timestamp );
@@ -181,14 +238,25 @@ final class DelegatedOperationService {
 		if ( ! JobStatus::isStatusFailure( (string) ( $job['status'] ?? '' ) ) ) {
 			return $this->failure( 'delegated_operation_not_retryable', __( 'Only failed delegated operations may be retried.', 'data-machine' ) );
 		}
-		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$engine  = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
 		$step_id = JobRetryPolicy::resolveDirectResumeStepId( $engine );
 		if ( ! is_callable( $resolved['action']['retry'] ?? null ) ) {
 			return $this->failure( 'delegated_operation_retry_unsupported', __( 'The action owner has not registered safe retry reconciliation.', 'data-machine' ) );
 		}
-		$summary    = RunMetrics::fromJob( $job );
-		$run_result = is_array( $summary['run_result'] ?? null ) ? $summary['run_result'] : array();
-		$retry_safe = $this->invoke( $resolved['action']['retry'], array( $run_result, $resolved['context'] ), 'delegated_operation_retry_unsafe' );
+		$run_result = $this->terminalRunResult( $job );
+		if ( is_wp_error( $run_result ) || ! str_starts_with( (string) $run_result['status'], JobStatus::FAILED ) ) {
+			return $this->failure( 'delegated_run_result_invalid', __( 'The failed operation has no valid canonical run result.', 'data-machine' ) );
+		}
+		$retry_safe = $this->invoke(
+			$resolved['action']['retry'],
+			array( $run_result, $resolved['context'] ),
+			'delegated_operation_retry_unsafe',
+			array(
+				'callback' => 'retry',
+				'action'   => $resolved['context']['action'],
+				'phase'    => 'retry',
+			)
+		);
 		if ( true !== $retry_safe ) {
 			return is_wp_error( $retry_safe )
 				? $this->fromError( $retry_safe )
@@ -212,23 +280,23 @@ final class DelegatedOperationService {
 		if ( isset( $resolved['error_result'] ) ) {
 			return $resolved['error_result'];
 		}
-		$job       = $resolved['job'];
-		$job_id    = (int) $job['job_id'];
-		$step_id   = (string) ( $job['operation_step_id'] ?? '' );
+		$job        = $resolved['job'];
+		$job_id     = (int) $job['job_id'];
+		$step_id    = (string) ( $job['operation_step_id'] ?? '' );
 		$generation = (int) ( $job['operation_generation'] ?? 0 );
-		$token     = (string) ( $job['operation_claim_token'] ?? '' );
+		$token      = (string) ( $job['operation_claim_token'] ?? '' );
 		$transition = $this->jobs->cancel_pending_direct_operation( $job_id );
 		if ( empty( $transition['success'] ) ) {
 			return $this->failure( 'delegated_operation_not_cancellable', __( 'Only submitted or delayed operations can be cancelled safely.', 'data-machine' ) );
 		}
-		if ( function_exists( 'as_unschedule_action' ) && '' !== $step_id && $generation > 0 && '' !== $token ) {
+		if ( function_exists( 'as_unschedule_action' ) && '' !== $step_id && 0 < $generation && '' !== $token ) {
 			as_unschedule_action(
 				'datamachine_execute_step',
 				array(
-					'job_id'                 => $job_id,
-					'flow_step_id'           => $step_id,
-					'operation_generation'   => $generation,
-					'operation_claim_token'  => $token,
+					'job_id'                => $job_id,
+					'flow_step_id'          => $step_id,
+					'operation_generation'  => $generation,
+					'operation_claim_token' => $token,
 				),
 				'data-machine'
 			);
@@ -238,32 +306,33 @@ final class DelegatedOperationService {
 
 	/** Resolve, attest, and owner-authorize an existing operation. */
 	private function resolve( array $request, string $phase ): array {
-		$action_id    = trim( (string) ( $request['action'] ?? '' ) );
+		$action_id     = trim( (string) ( $request['action'] ?? '' ) );
 		$operation_ref = trim( (string) ( $request['operation_ref'] ?? '' ) );
-		$action       = $this->registry->get( $action_id );
+		$action        = $this->registry->get( $action_id );
 		if ( is_wp_error( $action ) ) {
 			return array( 'error_result' => $this->fromError( $action ) );
 		}
 		if ( ! preg_match( '/^dop_[a-f0-9]{64}$/', $operation_ref ) ) {
 			return array( 'error_result' => $this->failure( 'delegated_operation_ref_invalid', __( 'The operation reference is invalid.', 'data-machine' ) ) );
 		}
-		$job = $this->jobs->get_job_by_idempotency_key( $this->idempotencyKey( $operation_ref ) );
+		$job = $this->jobs->get_job_by_operation_ref_hash( $this->receiptHash( $operation_ref ) );
 		if ( ! is_array( $job ) ) {
 			return array( 'error_result' => $this->failure( 'delegated_operation_not_found', __( 'The delegated operation was not found.', 'data-machine' ) ) );
 		}
-		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
-		$stored = is_array( $engine['delegated_operation'] ?? null ) ? $engine['delegated_operation'] : array();
-		if ( $action_id !== (string) ( $stored['action'] ?? '' ) || $operation_ref !== (string) ( $stored['operation_ref'] ?? '' ) ) {
+		$envelope = is_array( $job['operation_envelope'] ?? null ) ? $job['operation_envelope'] : array();
+		$stored   = is_array( $envelope['delegated_operation'] ?? null ) ? $envelope['delegated_operation'] : array();
+		if ( (string) ( $stored['action'] ?? '' ) !== $action_id || (string) ( $stored['operation_ref'] ?? '' ) !== $operation_ref ) {
 			return array( 'error_result' => $this->failure( 'delegated_operation_not_found', __( 'The delegated operation was not found.', 'data-machine' ) ) );
 		}
-		if ( (string) $action['version'] !== (string) ( $stored['version'] ?? '' ) ) {
-			return array( 'error_result' => $this->failure( 'delegated_action_version_conflict', __( 'The operation requires its frozen action contract version.', 'data-machine' ) ) );
+		$action = $this->registry->get( $action_id, (string) ( $stored['version'] ?? '' ) );
+		if ( is_wp_error( $action ) ) {
+			return array( 'error_result' => $this->fromError( $action ) );
 		}
 
-		$actor   = $this->actor();
-		$context = $this->context( $phase, $action_id, (string) ( $stored['operation_id'] ?? '' ), $operation_ref, $actor );
+		$actor            = $this->actor();
+		$context          = $this->context( $phase, $action_id, (string) ( $stored['operation_id'] ?? '' ), $operation_ref, $actor );
 		$context['input'] = is_array( $stored['input'] ?? null ) ? $stored['input'] : array();
-		$authorized = $this->authorize( $action, $context );
+		$authorized       = $this->authorize( $action, $context );
 		if ( is_wp_error( $authorized ) ) {
 			return array( 'error_result' => $this->fromError( $authorized ) );
 		}
@@ -297,16 +366,33 @@ final class DelegatedOperationService {
 		$agent_slug = trim( (string) ( $prepared['agent_slug'] ?? '' ) );
 		if ( $agent_id > 0 || '' !== $agent_slug ) {
 			try {
-				$identity = ( new AgentIdentityResolver() )->resolve_agent_identity( array( 'agent_id' => $agent_id, 'agent_slug' => $agent_slug ) );
+				$resolver = new AgentIdentityResolver();
+				$identity = $resolver->resolve_agent_identity(
+					array(
+						'agent_id'   => $agent_id,
+						'agent_slug' => $agent_slug,
+					)
+				);
+				if ( $agent_id > 0 && '' !== $agent_slug ) {
+					$by_id   = $resolver->resolve_agent_identity( $agent_id );
+					$by_slug = $resolver->resolve_agent_identity( $agent_slug );
+					if ( $by_id->agent_id !== $by_slug->agent_id ) {
+						throw new \InvalidArgumentException( 'Agent identifiers disagree.' );
+					}
+				}
 			} catch ( \InvalidArgumentException $exception ) {
-				do_action( 'datamachine_log', 'error', 'Delegated operation owner resolution failed', array( 'exception' => $exception->getMessage() ) );
+				unset( $exception );
+				do_action( 'datamachine_log', 'error', 'Delegated operation owner resolution failed', array( 'error_code' => 'delegated_execution_owner_invalid' ) );
 				return new \WP_Error( 'delegated_execution_owner_invalid', __( 'The registered execution owner is invalid.', 'data-machine' ) );
+			}
+			if ( $user_id > 0 && $user_id !== $identity->owner_id ) {
+				return new \WP_Error( 'delegated_execution_owner_invalid', __( 'The registered execution owner is inconsistent.', 'data-machine' ) );
 			}
 			$agent_id   = $identity->agent_id;
 			$agent_slug = $identity->agent_slug;
 			$user_id    = $identity->owner_id;
 		}
-		if ( $user_id <= 0 ) {
+		if ( $user_id <= 0 || ! get_user_by( 'id', $user_id ) ) {
 			return new \WP_Error( 'delegated_execution_owner_invalid', __( 'The action owner must resolve a stable execution owner.', 'data-machine' ) );
 		}
 
@@ -326,9 +412,25 @@ final class DelegatedOperationService {
 		if ( ! is_array( $job ) ) {
 			return $this->failure( 'delegated_operation_load_failed', __( 'The delegated operation could not be loaded.', 'data-machine' ), true );
 		}
-		$summary    = RunMetrics::fromJob( $job );
-		$run_result = JobStatus::isStatusFinal( (string) ( $job['status'] ?? '' ) ) && is_array( $summary['run_result'] ?? null ) ? $summary['run_result'] : array();
-		$projection = $this->invoke( $action['project'], array( $run_result, $context ), 'delegated_projection_failed' );
+		$status = $this->pendingStatus( $job );
+		if ( JobStatus::isStatusFinal( (string) ( $job['status'] ?? '' ) ) ) {
+			$run_result = $this->terminalRunResult( $job );
+			if ( is_wp_error( $run_result ) ) {
+				return $this->failure( 'delegated_run_result_invalid', __( 'The operation has no valid canonical run result.', 'data-machine' ) );
+			}
+		} else {
+			$run_result = RunResult::active( $status );
+		}
+		$projection = $this->invoke(
+			$action['project'],
+			array( $run_result, $context ),
+			'delegated_projection_failed',
+			array(
+				'callback' => 'project',
+				'action'   => $context['action'],
+				'phase'    => $context['phase'],
+			)
+		);
 		if ( is_wp_error( $projection ) || ! is_array( $projection ) || array_is_list( $projection ) || ! $this->isBoundedJson( $projection, self::MAX_PROJECTION_BYTES ) ) {
 			$projection = array();
 		}
@@ -343,12 +445,15 @@ final class DelegatedOperationService {
 			$result['projection'] = $projection;
 		}
 		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
-		if ( 'retrying' === $status && is_array( $engine['retry'] ?? null ) ) {
+		if ( 'retrying' === $status ) {
+			$retry_data      = is_array( $engine['retry'] ?? null ) ? $engine['retry'] : array();
+			$defer_data      = is_array( $engine['ai_concurrency_throttle'] ?? null ) ? $engine['ai_concurrency_throttle'] : array();
 			$result['retry'] = array_filter(
 				array(
-					'attempt'       => max( 0, (int) ( $engine['retry']['attempt'] ?? 0 ) ),
-					'max_attempts'  => max( 0, (int) ( $engine['retry']['max_attempts'] ?? 0 ) ),
-					'next_retry_at' => isset( $engine['retry']['next_retry_at'] ) ? (string) $engine['retry']['next_retry_at'] : null,
+					'type'          => ! empty( $retry_data['next_retry_at'] ) ? 'retry' : 'ai_concurrency',
+					'attempt'       => max( 0, (int) ( $retry_data['attempts'] ?? ( $defer_data['attempts'] ?? 0 ) ) ),
+					'max_attempts'  => isset( $retry_data['max_attempts'] ) ? max( 0, (int) $retry_data['max_attempts'] ) : null,
+					'next_retry_at' => isset( $retry_data['next_retry_at'] ) ? (string) $retry_data['next_retry_at'] : ( isset( $defer_data['next_retry_at'] ) ? (string) $defer_data['next_retry_at'] : null ),
 				),
 				static fn( $value ) => null !== $value
 			);
@@ -360,11 +465,11 @@ final class DelegatedOperationService {
 		$status = (string) ( $job['status'] ?? '' );
 		$base   = JobStatus::fromString( $status );
 		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
-		if ( JobStatus::PENDING === $status && ! empty( $engine['retry']['next_retry_at'] ) ) {
+		if ( JobStatus::PENDING === $status && ( ! empty( $engine['retry']['next_retry_at'] ) || 'deferred' === ( $engine['ai_concurrency_throttle']['state'] ?? '' ) ) ) {
 			return 'retrying';
 		}
 		if ( ! $base->isFinal() ) {
-			return in_array( $status, array( JobStatus::PROCESSING, JobStatus::WAITING ), true ) ? 'executing' : 'submitted';
+			return in_array( $status, array( JobStatus::PROCESSING, JobStatus::WAITING ), true ) || ! empty( $job['operation_effects_begun_at'] ) ? 'executing' : 'submitted';
 		}
 		if ( $base->isFailure() ) {
 			return 'failed';
@@ -373,10 +478,10 @@ final class DelegatedOperationService {
 			return 'cancelled';
 		}
 		$canonical_status = strtolower( (string) ( $run_result['status'] ?? '' ) );
-		$canonical_no_op = in_array( $canonical_status, array( 'agent_skipped', 'skipped', 'completed_no_items', 'no_items', 'no-op' ), true );
-		$projected_zero  = isset( $projection['effect_count'] ) && is_int( $projection['effect_count'] ) && 0 === $projection['effect_count'];
-		$canonical_count = $run_result['outputs']['effect_count'] ?? null;
-		$canonical_zero  = is_int( $canonical_count ) && 0 === $canonical_count;
+		$canonical_no_op  = in_array( $canonical_status, array( 'agent_skipped', 'skipped', JobStatus::COMPLETED_NO_ITEMS, 'no_items', 'no-op' ), true );
+		$projected_zero   = isset( $projection['effect_count'] ) && is_int( $projection['effect_count'] ) && 0 === $projection['effect_count'];
+		$canonical_count  = $run_result['outputs']['effect_count'] ?? null;
+		$canonical_zero   = is_int( $canonical_count ) && 0 === $canonical_count;
 		if ( $base->isAgentSkipped() || $base->isCompletedNoItems() || $canonical_no_op || $canonical_zero || $projected_zero ) {
 			return 'no-op';
 		}
@@ -384,7 +489,16 @@ final class DelegatedOperationService {
 	}
 
 	private function authorize( array $action, array $context ) {
-		$result = $this->invoke( $action['authorize'], array( $context ), 'delegated_action_forbidden' );
+		$result = $this->invoke(
+			$action['authorize'],
+			array( $context ),
+			'delegated_action_forbidden',
+			array(
+				'callback' => 'authorize',
+				'action'   => $context['action'],
+				'phase'    => $context['phase'],
+			)
+		);
 		return true === $result ? true : ( is_wp_error( $result ) ? $result : new \WP_Error( 'delegated_action_forbidden', __( 'The action owner denied this operation.', 'data-machine' ) ) );
 	}
 
@@ -399,29 +513,62 @@ final class DelegatedOperationService {
 	}
 
 	private function context( string $phase, string $action, string $operation_id, string $operation_ref, array $actor ): array {
-		return compact( 'phase', 'action', 'operation_id', 'operation_ref', 'actor' );
+		return array(
+			'phase'         => $phase,
+			'action'        => $action,
+			'operation_id'  => $operation_id,
+			'operation_ref' => $operation_ref,
+			'actor'         => $actor,
+		);
 	}
 
 	private function reference( string $action, string $operation_id ): string {
-		return self::REFERENCE_PREFIX . hash( 'sha256', $action . "\0" . $operation_id );
+		return self::REFERENCE_PREFIX . $this->keyedHash( 'receipt', $action . "\0" . $operation_id );
 	}
 
-	private function idempotencyKey( string $operation_ref ): string {
-		return self::IDEMPOTENCY_PREFIX . substr( $operation_ref, strlen( self::REFERENCE_PREFIX ) );
+	private function idempotencyKey( string $action, string $operation_id ): string {
+		return self::IDEMPOTENCY_PREFIX . hash( 'sha256', "delegated-idempotency\0" . $action . "\0" . $operation_id );
 	}
 
-	private function invoke( callable $callback, array $arguments, string $error_code ) {
+	private function receiptHash( string $operation_ref ): string {
+		return hash( 'sha256', $operation_ref );
+	}
+
+	private function keyedHash( string $purpose, string $payload ): string {
+		return hash_hmac( 'sha256', 'delegated-' . $purpose . "\0" . $payload, $this->receiptSecret() );
+	}
+
+	/** Resolve the durable site secret used only for opaque operation receipts. */
+	private function receiptSecret(): string {
+		global $wpdb;
+		$option = 'datamachine_delegated_operation_secret';
+		$secret = get_option( $option );
+		if ( is_string( $secret ) && preg_match( '/^[a-f0-9]{64}$/', $secret ) ) {
+			return $secret;
+		}
+		$generated = bin2hex( random_bytes( 32 ) );
+		// phpcs:disable WordPress.DB.PreparedSQL -- INSERT IGNORE gives first initialization one durable winner.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( $wpdb->prepare( 'INSERT IGNORE INTO %i (option_name, option_value, autoload) VALUES (%s, %s, %s)', $wpdb->options, $option, $generated, 'off' ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$secret = $wpdb->get_var( $wpdb->prepare( 'SELECT option_value FROM %i WHERE option_name = %s', $wpdb->options, $option ) );
+		// phpcs:enable WordPress.DB.PreparedSQL
+		wp_cache_delete( $option, 'options' );
+		if ( ! is_string( $secret ) || ! preg_match( '/^[a-f0-9]{64}$/', $secret ) ) {
+			throw new \RuntimeException( 'Delegated operation receipt secret is unavailable.' );
+		}
+		return $secret;
+	}
+
+	private function invoke( callable $callback, array $arguments, string $error_code, array $log_context = array() ) {
 		try {
 			return $callback( ...$arguments );
-		} catch ( \Throwable $exception ) {
+		} catch ( \Throwable ) {
 			do_action(
 				'datamachine_log',
 				'error',
 				'Delegated operation owner callback failed',
-				array(
-					'error_code' => $error_code,
-					'exception'  => $exception->getMessage(),
-				)
+				array_merge( $log_context, array( 'error_code' => $error_code ) )
 			);
 			return new \WP_Error( $error_code, __( 'The delegated action owner could not complete the request.', 'data-machine' ) );
 		}
@@ -439,6 +586,55 @@ final class DelegatedOperationService {
 			'delegated_operation_job_reference'
 		);
 		return ! empty( $result['success'] );
+	}
+
+	/** Whether a pending row belongs to work that already passed initial admission. */
+	private function executionAlreadyStarted( array $job ): bool {
+		if ( ! empty( $job['operation_effects_begun_at'] ) ) {
+			return true;
+		}
+		$generation = max( 0, (int) ( $job['operation_generation'] ?? 0 ) );
+		$token      = (string) ( $job['operation_claim_token'] ?? '' );
+		return 'none' !== ( new DirectJobEnqueuer( $this->jobs ) )->liveGenerationExecution( (int) $job['job_id'], $generation, $token );
+	}
+
+	private function pendingStatus( array $job ): string {
+		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		if ( JobStatus::PENDING === (string) ( $job['status'] ?? '' ) && ( ! empty( $engine['retry']['next_retry_at'] ) || 'deferred' === ( $engine['ai_concurrency_throttle']['state'] ?? '' ) ) ) {
+			return 'retrying';
+		}
+		return in_array( (string) ( $job['status'] ?? '' ), array( JobStatus::PROCESSING, JobStatus::WAITING ), true ) || ! empty( $job['operation_effects_begun_at'] ) ? 'executing' : 'submitted';
+	}
+
+	/** Resolve a validated canonical terminal result from the bounded envelope. */
+	private function terminalRunResult( array $job ) {
+		$envelope   = is_array( $job['operation_envelope'] ?? null ) ? $job['operation_envelope'] : array();
+		$run_result = $envelope['run_result'] ?? null;
+		return RunResult::validate( $run_result ) ? $run_result : new \WP_Error( 'delegated_run_result_invalid' );
+	}
+
+	/** Register durable terminal capture in the replayable core accounting stage. */
+	public function registerTerminalCallback( array $callbacks, int $job_id, string $status ): array {
+		unset( $job_id, $status );
+		$callbacks['delegated_operation_envelope'] = array( $this, 'captureTerminalEnvelope' );
+		return $callbacks;
+	}
+
+	/** Capture canonical terminal truth before short-window engine-data shedding. */
+	public function captureTerminalEnvelope( int $job_id, string $status ): bool {
+		unset( $status );
+		$job = $this->jobs->get_job( $job_id );
+		if ( ! is_array( $job ) || 'delegated' !== (string) ( $job['source'] ?? '' ) ) {
+			return true;
+		}
+		$envelope = is_array( $job['operation_envelope'] ?? null ) ? $job['operation_envelope'] : array();
+		$summary  = RunMetrics::fromJob( $job );
+		$result   = RunResult::fromJobSummary( $job, $summary );
+		if ( ! RunResult::validate( $result ) ) {
+			return false;
+		}
+		$envelope['run_result'] = $result;
+		return $this->jobs->store_operation_envelope( $job_id, $envelope );
 	}
 
 	private function canonicalize( $value ) {

--- a/inc/Core/DirectJobEnqueuer.php
+++ b/inc/Core/DirectJobEnqueuer.php
@@ -43,10 +43,10 @@ class DirectJobEnqueuer {
 			return $this->failure( 'invalid_enqueue_target' );
 		}
 
-		$job        = $this->jobs->get_job( $job_id );
-		$generation = max( 0, (int) ( $job['operation_generation'] ?? 0 ) );
-		$token      = (string) ( $job['operation_claim_token'] ?? '' );
-		$args       = $this->actionArgs( $job_id, $flow_step_id, $generation, $token );
+		$job                 = $this->jobs->get_job( $job_id );
+		$generation          = max( 0, (int) ( $job['operation_generation'] ?? 0 ) );
+		$token               = (string) ( $job['operation_claim_token'] ?? '' );
+		$args                = $this->actionArgs( $job_id, $flow_step_id, $generation, $token );
 		$scheduled_action_id = in_array( (string) ( $job['operation_state'] ?? '' ), array( 'enqueued', 'enqueuing' ), true )
 			? $this->scheduledActionId( $args )
 			: 0;
@@ -109,34 +109,46 @@ class DirectJobEnqueuer {
 	 * Check for any pending/in-progress step in an operation generation.
 	 */
 	public function hasLiveGenerationAction( int $job_id, int $generation, string $token ): bool {
+		return 'none' !== $this->liveGenerationExecution( $job_id, $generation, $token );
+	}
+
+	/** Find any current-generation step, retry, or AI continuation. */
+	public function liveGenerationExecution( int $job_id, int $generation, string $token ): string {
 		if ( ! function_exists( 'as_get_scheduled_actions' ) || $job_id <= 0 || $generation <= 0 || '' === $token ) {
-			return false;
+			return 'none';
 		}
 
-		$action_ids = as_get_scheduled_actions(
-			array(
-				'hook'                  => self::HOOK,
-				'group'                 => self::GROUP,
-				'args'                  => array(
-					'job_id'               => $job_id,
-					'operation_generation' => $generation,
-					'operation_claim_token' => $token,
+		foreach ( array(
+			self::HOOK                   => 'step',
+			'datamachine_resume_ai_step' => 'ai_continuation',
+		) as $hook => $type ) {
+			$action_ids = as_get_scheduled_actions(
+				array(
+					'hook'                  => $hook,
+					'args'                  => array(
+						'job_id'                => $job_id,
+						'operation_generation'  => $generation,
+						'operation_claim_token' => $token,
+					),
+					'partial_args_matching' => 'like',
+					'status'                => array( 'pending', 'in-progress' ),
+					'per_page'              => 1,
 				),
-				'partial_args_matching' => 'like',
-				'status'                => array( 'pending', 'in-progress' ),
-				'per_page'              => 1,
-			),
-			'ids'
-		);
+				'ids'
+			);
+			if ( ! empty( $action_ids ) ) {
+				return $type;
+			}
+		}
 
-		return ! empty( $action_ids );
+		return 'none';
 	}
 
 	private function actionArgs( int $job_id, string $flow_step_id, int $generation, string $token ): array {
 		return array(
-			'job_id'               => $job_id,
-			'flow_step_id'         => $flow_step_id,
-			'operation_generation' => $generation,
+			'job_id'                => $job_id,
+			'flow_step_id'          => $flow_step_id,
+			'operation_generation'  => $generation,
 			'operation_claim_token' => $token,
 		);
 	}
@@ -182,12 +194,12 @@ class DirectJobEnqueuer {
 	}
 
 	private function reconcileScheduledAction( int $job_id, ?array $job, int $action_id, int $generation, string $token ): array {
-		if ( ! is_array( $job ) || $generation <= 0 || '' === $token ) {
+		if ( ! is_array( $job ) || 0 >= $generation || '' === $token ) {
 			return $this->inProgress( $generation );
 		}
 
 		if ( 'enqueued' === ( $job['operation_state'] ?? '' )
-			&& $generation === (int) ( $job['operation_generation'] ?? 0 )
+			&& (int) ( $job['operation_generation'] ?? 0 ) === $generation
 			&& hash_equals( $token, (string) ( $job['operation_claim_token'] ?? '' ) ) ) {
 			return $this->success( $action_id, $generation );
 		}
@@ -200,7 +212,7 @@ class DirectJobEnqueuer {
 		$reloaded = $this->jobs->get_job( $job_id );
 		if ( is_array( $reloaded )
 			&& 'enqueued' === ( $reloaded['operation_state'] ?? '' )
-			&& $generation === (int) ( $reloaded['operation_generation'] ?? 0 )
+			&& (int) ( $reloaded['operation_generation'] ?? 0 ) === $generation
 			&& hash_equals( $token, (string) ( $reloaded['operation_claim_token'] ?? '' ) ) ) {
 			return $this->success( $action_id, $generation );
 		}

--- a/inc/Core/DirectJobEnqueuer.php
+++ b/inc/Core/DirectJobEnqueuer.php
@@ -13,8 +13,8 @@ defined( 'ABSPATH' ) || exit;
 
 class DirectJobEnqueuer {
 
-	private const HOOK  = 'datamachine_execute_step';
-	private const GROUP = 'data-machine';
+	public const HOOK  = 'datamachine_execute_step';
+	public const GROUP = 'data-machine';
 
 	private Jobs $jobs;
 	private \Closure $scheduler;

--- a/inc/Core/RunResult.php
+++ b/inc/Core/RunResult.php
@@ -16,7 +16,32 @@ defined( 'ABSPATH' ) || exit;
  */
 class RunResult {
 
-	public const SCHEMA_VERSION = 'datamachine.run_result.v1';
+	public const SCHEMA_VERSION      = 'datamachine.run_result.v1';
+	private const MAX_ENVELOPE_BYTES = 163840;
+
+	/** Build a canonical nonterminal projection envelope. */
+	public static function active( string $status ): array {
+		return self::fromStepResults( array(), array( 'status' => $status ) );
+	}
+
+	/** Validate the portable envelope before it crosses a public boundary. */
+	public static function validate( $value ): bool {
+		if ( ! is_array( $value ) || self::SCHEMA_VERSION !== ( $value['schema_version'] ?? null ) || ! is_string( $value['status'] ?? null ) || '' === trim( $value['status'] ) ) {
+			return false;
+		}
+		foreach ( array( 'outputs', 'diagnostics', 'replay' ) as $object_key ) {
+			if ( isset( $value[ $object_key ] ) && ( ! is_array( $value[ $object_key ] ) || ( array() !== $value[ $object_key ] && array_is_list( $value[ $object_key ] ) ) ) ) {
+				return false;
+			}
+		}
+		foreach ( array( 'artifact_refs', 'packet_refs', 'step_results', 'steps', 'child_job_refs', 'child_job_envelopes' ) as $list_key ) {
+			if ( isset( $value[ $list_key ] ) && ( ! is_array( $value[ $list_key ] ) || ! array_is_list( $value[ $list_key ] ) ) ) {
+				return false;
+			}
+		}
+		$encoded = wp_json_encode( $value );
+		return is_string( $encoded ) && strlen( $encoded ) <= self::MAX_ENVELOPE_BYTES;
+	}
 
 	/**
 	 * Build a run envelope from step result envelopes.

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -430,13 +430,16 @@ class RetentionCleanup {
 	}
 
 	public static function countFailedJobs(): int {
-		return ( new Jobs() )->count_old_jobs( 'failed', self::failedJobsMaxAgeDays() );
+		$jobs = new Jobs();
+		return $jobs->count_old_jobs( 'failed', self::failedJobsMaxAgeDays() ) + $jobs->count_old_jobs( 'cancelled', self::failedJobsMaxAgeDays() );
 	}
 
 	public static function cleanupFailedJobs(): array {
-		$max_age_days = self::failedJobsMaxAgeDays();
-		$deleted      = ( new Jobs() )->delete_old_jobs( 'failed', $max_age_days );
-		$deleted      = false !== $deleted ? (int) $deleted : 0;
+		$max_age_days      = self::failedJobsMaxAgeDays();
+		$jobs              = new Jobs();
+		$failed_deleted    = $jobs->delete_old_jobs( 'failed', $max_age_days );
+		$cancelled_deleted = $jobs->delete_old_jobs( 'cancelled', $max_age_days );
+		$deleted           = ( false !== $failed_deleted ? (int) $failed_deleted : 0 ) + ( false !== $cancelled_deleted ? (int) $cancelled_deleted : 0 );
 
 		if ( $deleted > 0 ) {
 			self::log(
@@ -477,7 +480,7 @@ class RetentionCleanup {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		return (int) $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT(*) FROM %i WHERE completed_at IS NOT NULL AND completed_at < %s AND source != 'delegated' AND engine_data IS NOT NULL AND engine_data != ''",
+				"SELECT COUNT(*) FROM %i WHERE completed_at IS NOT NULL AND completed_at < %s AND engine_data IS NOT NULL AND engine_data != ''",
 				$table,
 				$cutoff
 			)
@@ -512,7 +515,7 @@ class RetentionCleanup {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		return (int) $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COALESCE(SUM(LENGTH(engine_data)), 0) FROM %i WHERE completed_at IS NOT NULL AND completed_at < %s AND source != 'delegated' AND engine_data IS NOT NULL AND engine_data != ''",
+				"SELECT COALESCE(SUM(LENGTH(engine_data)), 0) FROM %i WHERE completed_at IS NOT NULL AND completed_at < %s AND engine_data IS NOT NULL AND engine_data != ''",
 				$table,
 				$cutoff
 			)
@@ -575,7 +578,7 @@ class RetentionCleanup {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$affected = $wpdb->query(
 				$wpdb->prepare(
-					"UPDATE %i SET engine_data = NULL WHERE job_id IN ( SELECT job_id FROM ( SELECT job_id FROM %i WHERE completed_at IS NOT NULL AND completed_at < %s AND source != 'delegated' AND engine_data IS NOT NULL AND engine_data != '' LIMIT %d ) AS tmp )",
+					"UPDATE %i SET engine_data = NULL WHERE job_id IN ( SELECT job_id FROM ( SELECT job_id FROM %i WHERE completed_at IS NOT NULL AND completed_at < %s AND engine_data IS NOT NULL AND engine_data != '' LIMIT %d ) AS tmp )",
 					$table,
 					$table,
 					$cutoff,

--- a/tests/Unit/Abilities/Job/DelegatedOperationTest.php
+++ b/tests/Unit/Abilities/Job/DelegatedOperationTest.php
@@ -13,7 +13,9 @@ use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\DelegatedOperations\DelegatedOperationRegistry;
 use DataMachine\Core\DelegatedOperations\DelegatedOperationService;
+use DataMachine\Core\DirectJobEnqueuer;
 use DataMachine\Core\JobStatus;
+use DataMachine\Engine\AI\AIConcurrencyBackpressure;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionCleanup;
 use WP_UnitTestCase;
 
@@ -261,18 +263,18 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 			'operation_generation'  => (int) $job['operation_generation'],
 			'operation_claim_token' => (string) $job['operation_claim_token'],
 		);
-		as_unschedule_action( 'datamachine_execute_step', $args, 'data-machine' );
+		as_unschedule_action( DirectJobEnqueuer::HOOK, $args, DirectJobEnqueuer::GROUP );
 		$args['flow_step_id'] = 'ephemeral_step_1';
-		as_schedule_single_action( time() + 60, 'datamachine_execute_step', $args, 'data-machine' );
+		as_schedule_single_action( time() + 60, DirectJobEnqueuer::HOOK, $args, DirectJobEnqueuer::GROUP );
 		$replayed = $service->submit( $this->submission( 'later-step-live' ) );
 		$this->assertTrue( $replayed['success'] );
 		$this->assertSame( $submitted['operation_ref'], $replayed['operation_ref'] );
 		$this->assertSame( 'submitted', $replayed['status'] );
 
 		$job = $this->job( 'later-step-live' );
-		as_unschedule_action( 'datamachine_execute_step', $args, 'data-machine' );
+		as_unschedule_action( DirectJobEnqueuer::HOOK, $args, DirectJobEnqueuer::GROUP );
 		$args['ai_resume_generation'] = 1;
-		as_schedule_single_action( time() + 60, 'datamachine_resume_ai_step', $args, 'data-machine-ai-resume-test' );
+		as_schedule_single_action( time() + 60, AIConcurrencyBackpressure::RESUME_HOOK, $args, 'data-machine-ai-resume-test' );
 		$engine                            = $job['engine_data'];
 		$engine['ai_concurrency_throttle'] = array(
 			'state'         => 'deferred',
@@ -431,12 +433,7 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 		$this->assertTrue( ( new Jobs() )->complete_job( (int) $job['job_id'], 'failed - test' ) );
 		$this->assertArrayHasKey( 'run_result', $this->job( 'retry-operation' )['operation_envelope'] );
 
-		$retried = $service->retry(
-			array(
-				'action'        => 'owner/write-record',
-				'operation_ref' => $submitted['operation_ref'],
-			)
-		);
+		$retried = $service->retry( $this->operationRequest( $submitted ) );
 		$this->assertTrue( $retried['success'] );
 		$this->assertSame( 'submitted', $retried['status'] );
 		$this->assertSame( (int) $job['job_id'], (int) $this->job( 'retry-operation' )['job_id'] );
@@ -449,12 +446,7 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 			'next_retry_at' => gmdate( 'c', time() + 60 ),
 		);
 		$this->assertTrue( ( new Jobs() )->store_engine_data( (int) $retrying_job['job_id'], $engine ) );
-		$retrying = $service->reconcile(
-			array(
-				'action'        => 'owner/write-record',
-				'operation_ref' => $submitted['operation_ref'],
-			)
-		);
+		$retrying = $service->reconcile( $this->operationRequest( $submitted ) );
 		$this->assertSame( 'retrying', $retrying['status'] );
 		$this->assertSame( 1, $retrying['retry']['attempt'] );
 		$cancel_retry = $service->cancel(
@@ -544,11 +536,13 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 	}
 
 	private function reconcile( DelegatedOperationService $service, array $submitted ): array {
-		return $service->reconcile(
-			array(
-				'action'        => 'owner/write-record',
-				'operation_ref' => $submitted['operation_ref'],
-			)
+		return $service->reconcile( $this->operationRequest( $submitted ) );
+	}
+
+	private function operationRequest( array $submitted ): array {
+		return array(
+			'action'        => 'owner/write-record',
+			'operation_ref' => $submitted['operation_ref'],
 		);
 	}
 

--- a/tests/Unit/Abilities/Job/DelegatedOperationTest.php
+++ b/tests/Unit/Abilities/Job/DelegatedOperationTest.php
@@ -7,11 +7,14 @@
 
 namespace DataMachine\Tests\Unit\Abilities\Job;
 
-use DataMachine\Abilities\Job\DelegatedOperationAbilities;
+use DataMachine\Abilities\DelegatedOperationAbilities;
 use DataMachine\Abilities\Job\ExecuteWorkflowAbility;
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\DelegatedOperations\DelegatedOperationRegistry;
 use DataMachine\Core\DelegatedOperations\DelegatedOperationService;
+use DataMachine\Core\JobStatus;
+use DataMachine\Engine\AI\System\Tasks\Retention\RetentionCleanup;
 use WP_UnitTestCase;
 
 final class DelegatedOperationTest extends WP_UnitTestCase {
@@ -20,9 +23,14 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 	private int $second_actor;
 	private int $execution_owner;
 	private int $manager;
-	private array $authorized = array();
-	private array $projection = array();
-	private bool $retry_safe = true;
+	private int $execution_agent;
+	private array $authorized           = array();
+	private array $projection           = array();
+	private bool $retry_safe            = true;
+	private bool $throw_project         = false;
+	private ?int $prepared_owner        = null;
+	private array $projected_run_result = array();
+	private string $action_version      = '1';
 
 	public function set_up(): void {
 		parent::set_up();
@@ -31,6 +39,7 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 		$this->second_actor    = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		$this->execution_owner = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		$this->manager         = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->execution_agent = ( new Agents() )->create_if_missing( 'delegated-contract-owner', 'Delegated Contract Owner', $this->execution_owner );
 		$this->authorized      = array( $this->first_actor, $this->second_actor );
 		$this->projection      = array(
 			'effect_count' => 1,
@@ -46,8 +55,8 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 	}
 
 	public function registerAction( array $actions ): array {
-		$actions['owner/write-record'] = array(
-			'version'         => '1',
+		$contract = array(
+			'version'         => $this->action_version,
 			'normalize_input' => static fn( array $input ): array => array(
 				'record_key' => sanitize_key( (string) ( $input['record_key'] ?? '' ) ),
 				'value'      => sanitize_text_field( (string) ( $input['value'] ?? '' ) ),
@@ -59,15 +68,26 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 			},
 			'prepare'         => function ( array $input ): array {
 				return array(
-					'owner_user_id' => $this->execution_owner,
+					'owner_user_id' => $this->prepared_owner ?? $this->execution_owner,
+					'agent_id'      => $this->execution_agent,
 					'label'         => 'Write owner record',
 					'workflow'      => $this->workflow( $input['value'] ),
 					'initial_data'  => array( 'owner_record_key' => $input['record_key'] ),
 				);
 			},
-			'project'         => fn(): array => $this->projection,
+			'project'         => function ( array $run_result ): array {
+				$this->projected_run_result = $run_result;
+				if ( $this->throw_project ) {
+					throw new \RuntimeException( 'secret-owner-callback-value' );
+				}
+				return $this->projection;
+			},
 			'retry'           => fn(): bool => $this->retry_safe,
 		);
+		if ( '1' !== $this->action_version ) {
+			$contract['versions'] = array( '1' => array_replace( $contract, array( 'version' => '1' ) ) );
+		}
+		$actions['owner/write-record'] = $contract;
 		return $actions;
 	}
 
@@ -85,6 +105,7 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 		$this->assertFalse( $first['replayed'] );
 		$this->assertTrue( $second['replayed'] );
 		$this->assertSame( $this->execution_owner, (int) $job['user_id'] );
+		$this->assertSame( $this->execution_agent, (int) $job['agent_id'] );
 		$this->assertSame( $this->first_actor, (int) $job['engine_data']['delegated_operation']['initiator']['user_id'] );
 		$this->assertSame( $this->execution_owner, (int) $job['engine_data']['delegated_operation']['execution_owner']['user_id'] );
 	}
@@ -94,7 +115,7 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->first_actor );
 		$fail_schedule = static fn() => false;
 		add_filter( 'pre_as_schedule_single_action', $fail_schedule );
-		$interrupted = $service->submit( $this->submission( 'crash-recovery' ) );
+		$interrupted   = $service->submit( $this->submission( 'crash-recovery' ) );
 		remove_filter( 'pre_as_schedule_single_action', $fail_schedule );
 
 		$recovered = $service->submit( $this->submission( 'crash-recovery' ) );
@@ -107,6 +128,52 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 		$this->assertFalse( $conflict['success'] );
 		$this->assertSame( 'delegated_operation_conflict', $conflict['error_code'] );
 		$this->assertMatchesRegularExpression( '/^[a-f0-9]{64}$/', (string) $this->job( 'crash-recovery' )['request_fingerprint'] );
+	}
+
+	public function test_replay_repairs_missing_job_reference(): void {
+		$service = new DelegatedOperationService();
+		wp_set_current_user( $this->first_actor );
+		$first  = $service->submit( $this->submission( 'missing-job-reference' ) );
+		$job    = $this->job( 'missing-job-reference' );
+		$engine = $job['engine_data'];
+		unset( $engine['job']['job_id'] );
+		$this->assertTrue( ( new Jobs() )->store_engine_data( (int) $job['job_id'], $engine ) );
+
+		$replayed = $service->submit( $this->submission( 'missing-job-reference' ) );
+		$this->assertTrue( $replayed['success'] );
+		$this->assertSame( $first['operation_ref'], $replayed['operation_ref'] );
+		$this->assertSame( (int) $job['job_id'], (int) $this->job( 'missing-job-reference' )['engine_data']['job']['job_id'] );
+	}
+
+	public function test_public_receipt_is_secret_keyed_and_independent_from_idempotency(): void {
+		$service = new DelegatedOperationService();
+		wp_set_current_user( $this->first_actor );
+		$result  = $service->submit( $this->submission( 'guessable-id' ) );
+		$guessed = 'dop_' . hash( 'sha256', 'owner/write-record' . "\0guessable-id" );
+		$this->assertNotSame( $guessed, $result['operation_ref'] );
+		$this->assertNotSame( 'delegated:' . substr( $result['operation_ref'], 4 ), $this->job( 'guessable-id' )['idempotency_key'] );
+		$denied = $service->reconcile(
+			array(
+				'action'        => 'owner/write-record',
+				'operation_ref' => $guessed,
+			)
+		);
+		$this->assertSame( 'delegated_operation_not_found', $denied['error_code'] );
+	}
+
+	public function test_frozen_contract_version_remains_resolvable_after_upgrade(): void {
+		$service = new DelegatedOperationService();
+		wp_set_current_user( $this->first_actor );
+		$submitted            = $service->submit( $this->submission( 'version-upgrade' ) );
+		$this->action_version = '2';
+		$resolved             = $service->reconcile(
+			array(
+				'action'        => 'owner/write-record',
+				'operation_ref' => $submitted['operation_ref'],
+			)
+		);
+		$this->assertTrue( $resolved['success'] );
+		$this->assertSame( $submitted['operation_ref'], $resolved['operation_ref'] );
 	}
 
 	public function test_action_authority_is_bounded_and_manager_has_no_owner_authority(): void {
@@ -143,6 +210,30 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 		$this->assertTrue( is_wp_error( $submit->execute( array_merge( $this->submission( 'undeclared-input' ), array( 'job_id' => 123 ) ) ) ) );
 	}
 
+	public function test_registration_and_execution_owner_validation_fail_closed(): void {
+		$registry  = new DelegatedOperationRegistry();
+		$malformed = static function ( array $actions ): array {
+			$actions['owner/write-record']['version'] = array( 'invalid' );
+			return $actions;
+		};
+		add_filter( DelegatedOperationRegistry::FILTER, $malformed, 20 );
+		$this->assertSame( 'delegated_action_invalid', $registry->get( 'owner/write-record' )->get_error_code() );
+		remove_filter( DelegatedOperationRegistry::FILTER, $malformed, 20 );
+
+		$malformed_retry = static function ( array $actions ): array {
+			$actions['owner/write-record']['retry'] = 'not-callable';
+			return $actions;
+		};
+		add_filter( DelegatedOperationRegistry::FILTER, $malformed_retry, 20 );
+		$this->assertSame( 'delegated_action_invalid', $registry->get( 'owner/write-record' )->get_error_code() );
+		remove_filter( DelegatedOperationRegistry::FILTER, $malformed_retry, 20 );
+
+		$this->prepared_owner = 999999999;
+		wp_set_current_user( $this->first_actor );
+		$invalid_owner = ( new DelegatedOperationService() )->submit( $this->submission( 'missing-owner' ) );
+		$this->assertSame( 'delegated_execution_owner_invalid', $invalid_owner['error_code'] );
+	}
+
 	public function test_active_replay_returns_execution_state_without_reenqueue(): void {
 		$service = new DelegatedOperationService();
 		wp_set_current_user( $this->first_actor );
@@ -155,6 +246,43 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 		$this->assertTrue( $replayed['replayed'] );
 		$this->assertSame( $submitted['operation_ref'], $replayed['operation_ref'] );
 		$this->assertSame( 'executing', $replayed['status'] );
+		$this->assertSame( 'datamachine.run_result.v1', $this->projected_run_result['schema_version'] );
+		$this->assertSame( 'executing', $this->projected_run_result['status'] );
+	}
+
+	public function test_later_step_retry_and_ai_continuation_block_initial_reenqueue(): void {
+		$service = new DelegatedOperationService();
+		wp_set_current_user( $this->first_actor );
+		$submitted = $service->submit( $this->submission( 'later-step-live' ) );
+		$job       = $this->job( 'later-step-live' );
+		$args      = array(
+			'job_id'                => (int) $job['job_id'],
+			'flow_step_id'          => 'ephemeral_step_0',
+			'operation_generation'  => (int) $job['operation_generation'],
+			'operation_claim_token' => (string) $job['operation_claim_token'],
+		);
+		as_unschedule_action( 'datamachine_execute_step', $args, 'data-machine' );
+		$args['flow_step_id'] = 'ephemeral_step_1';
+		as_schedule_single_action( time() + 60, 'datamachine_execute_step', $args, 'data-machine' );
+		$replayed = $service->submit( $this->submission( 'later-step-live' ) );
+		$this->assertTrue( $replayed['success'] );
+		$this->assertSame( $submitted['operation_ref'], $replayed['operation_ref'] );
+		$this->assertSame( 'submitted', $replayed['status'] );
+
+		$job = $this->job( 'later-step-live' );
+		as_unschedule_action( 'datamachine_execute_step', $args, 'data-machine' );
+		$args['ai_resume_generation'] = 1;
+		as_schedule_single_action( time() + 60, 'datamachine_resume_ai_step', $args, 'data-machine-ai-resume-test' );
+		$engine                            = $job['engine_data'];
+		$engine['ai_concurrency_throttle'] = array(
+			'state'         => 'deferred',
+			'attempts'      => 2,
+			'next_retry_at' => gmdate( 'c', time() + 60 ),
+		);
+		$this->assertTrue( ( new Jobs() )->store_engine_data( (int) $job['job_id'], $engine ) );
+		$deferred = $service->submit( $this->submission( 'later-step-live' ) );
+		$this->assertSame( 'retrying', $deferred['status'] );
+		$this->assertSame( 'ai_concurrency', $deferred['retry']['type'] );
 	}
 
 	public function test_canonical_no_op_and_owner_redaction_are_public_truth(): void {
@@ -162,20 +290,36 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->first_actor );
 		$submitted = $service->submit( $this->submission( 'redacted-result' ) );
 		$job       = $this->job( 'redacted-result' );
-		$this->assertTrue( ( new Jobs() )->complete_job( (int) $job['job_id'], 'completed_no_items' ) );
-		$job       = $this->job( 'redacted-result' );
-		$engine    = $job['engine_data'];
-		$engine['run_result'] = array(
+		$this->assertTrue( ( new Jobs() )->complete_job( (int) $job['job_id'], JobStatus::COMPLETED_NO_ITEMS ) );
+		$job                    = $this->job( 'redacted-result' );
+		$engine                 = $job['engine_data'];
+		$envelope               = $job['operation_envelope'];
+		$envelope['run_result'] = array(
 			'schema_version' => 'datamachine.run_result.v1',
-			'status'         => 'completed_no_items',
+			'status'         => JobStatus::COMPLETED_NO_ITEMS,
+			'outputs'        => array(),
 			'diagnostics'    => array( 'private_value' => 'must-not-cross-boundary' ),
 		);
-		$this->assertTrue( ( new Jobs() )->store_engine_data( (int) $job['job_id'], $engine ) );
-		$this->projection = array( 'effect_count' => 1, 'record_ref' => 'rec_none' );
+		$this->assertTrue( ( new Jobs() )->store_operation_envelope( (int) $job['job_id'], $envelope ) );
+		$this->projection = array(
+			'effect_count' => 1,
+			'record_ref'   => 'rec_none',
+		);
 
-		$result = $service->reconcile( array( 'action' => 'owner/write-record', 'operation_ref' => $submitted['operation_ref'] ) );
+		$result = $service->reconcile(
+			array(
+				'action'        => 'owner/write-record',
+				'operation_ref' => $submitted['operation_ref'],
+			)
+		);
 		$this->assertSame( 'no-op', $result['status'] );
-		$this->assertSame( array( 'effect_count' => 1, 'record_ref' => 'rec_none' ), $result['projection'] );
+		$this->assertSame(
+			array(
+				'effect_count' => 1,
+				'record_ref'   => 'rec_none',
+			),
+			$result['projection']
+		);
 		$this->assertStringNotContainsString( 'must-not-cross-boundary', wp_json_encode( $result ) );
 		$this->assertArrayNotHasKey( 'job_id', $result );
 	}
@@ -186,38 +330,68 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 		$submitted = $service->submit( $this->submission( 'canonical-zero' ) );
 		$job       = $this->job( 'canonical-zero' );
 		$this->assertTrue( ( new Jobs() )->complete_job( (int) $job['job_id'], 'completed' ) );
-		$job       = $this->job( 'canonical-zero' );
-		$engine    = $job['engine_data'];
-		$engine['run_result'] = array(
+		$job                    = $this->job( 'canonical-zero' );
+		$engine                 = $job['engine_data'];
+		$envelope               = $job['operation_envelope'];
+		$envelope['run_result'] = array(
 			'schema_version' => 'datamachine.run_result.v1',
 			'status'         => 'succeeded',
 			'outputs'        => array( 'effect_count' => 0 ),
 		);
-		$this->assertTrue( ( new Jobs() )->store_engine_data( (int) $job['job_id'], $engine ) );
+		$this->assertTrue( ( new Jobs() )->store_operation_envelope( (int) $job['job_id'], $envelope ) );
 		$this->projection = array( 'record_ref' => 'rec_zero' );
-		$zero = $service->reconcile( array( 'action' => 'owner/write-record', 'operation_ref' => $submitted['operation_ref'] ) );
+		$zero             = $this->reconcile( $service, $submitted );
 		$this->assertSame( 'no-op', $zero['status'] );
 
 		$submitted = $service->submit( $this->submission( 'canonical-skipped' ) );
 		$job       = $this->job( 'canonical-skipped' );
 		$this->assertTrue( ( new Jobs() )->complete_job( (int) $job['job_id'], 'completed' ) );
-		$job       = $this->job( 'canonical-skipped' );
-		$engine    = $job['engine_data'];
-		$engine['run_result'] = array( 'schema_version' => 'datamachine.run_result.v1', 'status' => 'skipped' );
-		$this->assertTrue( ( new Jobs() )->store_engine_data( (int) $job['job_id'], $engine ) );
-		$skipped = $service->reconcile( array( 'action' => 'owner/write-record', 'operation_ref' => $submitted['operation_ref'] ) );
+		$job                    = $this->job( 'canonical-skipped' );
+		$engine                 = $job['engine_data'];
+		$envelope               = $job['operation_envelope'];
+		$envelope['run_result'] = array(
+			'schema_version' => 'datamachine.run_result.v1',
+			'status'         => 'skipped',
+			'outputs'        => array(),
+		);
+		$this->assertTrue( ( new Jobs() )->store_operation_envelope( (int) $job['job_id'], $envelope ) );
+		$skipped = $this->reconcile( $service, $submitted );
 		$this->assertSame( 'no-op', $skipped['status'] );
+	}
+
+	public function test_malformed_terminal_envelope_is_rejected(): void {
+		$service = new DelegatedOperationService();
+		wp_set_current_user( $this->first_actor );
+		$submitted = $service->submit( $this->submission( 'malformed-envelope' ) );
+		$job       = $this->job( 'malformed-envelope' );
+		$this->assertTrue( ( new Jobs() )->complete_job( (int) $job['job_id'], 'completed' ) );
+		$job                                      = $this->job( 'malformed-envelope' );
+		$envelope                                 = $job['operation_envelope'];
+		$envelope['run_result']['schema_version'] = 'legacy.result';
+		$this->assertTrue( ( new Jobs() )->store_operation_envelope( (int) $job['job_id'], $envelope ) );
+		$result = $service->reconcile(
+			array(
+				'action'        => 'owner/write-record',
+				'operation_ref' => $submitted['operation_ref'],
+			)
+		);
+		$this->assertSame( 'delegated_run_result_invalid', $result['error_code'] );
 	}
 
 	public function test_delayed_cancel_fences_generation_and_executing_cancel_fails(): void {
 		$service = new DelegatedOperationService();
 		wp_set_current_user( $this->first_actor );
-		$delayed = $this->submission( 'delayed-cancel' );
+		$delayed              = $this->submission( 'delayed-cancel' );
 		$delayed['timestamp'] = time() + HOUR_IN_SECONDS;
-		$submitted = $service->submit( $delayed );
-		$before    = $this->job( 'delayed-cancel' );
+		$submitted            = $service->submit( $delayed );
+		$before               = $this->job( 'delayed-cancel' );
 
-		$cancelled = $service->cancel( array( 'action' => 'owner/write-record', 'operation_ref' => $submitted['operation_ref'] ) );
+		$cancelled = $service->cancel(
+			array(
+				'action'        => 'owner/write-record',
+				'operation_ref' => $submitted['operation_ref'],
+			)
+		);
 		$after     = $this->job( 'delayed-cancel' );
 		$this->assertSame( 'cancelled', $cancelled['status'] );
 		$this->assertSame( 'cancelled', $after['operation_state'] );
@@ -227,9 +401,26 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 		$running = $service->submit( $this->submission( 'executing-cancel' ) );
 		$job     = $this->job( 'executing-cancel' );
 		$this->assertTrue( ( new Jobs() )->start_job( (int) $job['job_id'] ) );
-		$denied = $service->cancel( array( 'action' => 'owner/write-record', 'operation_ref' => $running['operation_ref'] ) );
+		$denied = $service->cancel(
+			array(
+				'action'        => 'owner/write-record',
+				'operation_ref' => $running['operation_ref'],
+			)
+		);
 		$this->assertSame( 'delegated_operation_not_cancellable', $denied['error_code'] );
 		$this->assertSame( 'processing', $this->job( 'executing-cancel' )['status'] );
+
+		$started = $service->submit( $this->submission( 'effects-started-cancel' ) );
+		$job     = $this->job( 'effects-started-cancel' );
+		$this->assertTrue( ( new Jobs() )->mark_operation_effects_begun( (int) $job['job_id'], (int) $job['operation_generation'], (string) $job['operation_claim_token'] ) );
+		$this->assertTrue( ( new Jobs() )->mark_operation_effects_begun( (int) $job['job_id'], (int) $job['operation_generation'], (string) $job['operation_claim_token'] ) );
+		$denied = $service->cancel(
+			array(
+				'action'        => 'owner/write-record',
+				'operation_ref' => $started['operation_ref'],
+			)
+		);
+		$this->assertSame( 'delegated_operation_not_cancellable', $denied['error_code'] );
 	}
 
 	public function test_failed_retry_reuses_operation_and_retrying_is_distinct(): void {
@@ -238,36 +429,131 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 		$submitted = $service->submit( $this->submission( 'retry-operation' ) );
 		$job       = $this->job( 'retry-operation' );
 		$this->assertTrue( ( new Jobs() )->complete_job( (int) $job['job_id'], 'failed - test' ) );
+		$this->assertArrayHasKey( 'run_result', $this->job( 'retry-operation' )['operation_envelope'] );
 
-		$retried = $service->retry( array( 'action' => 'owner/write-record', 'operation_ref' => $submitted['operation_ref'] ) );
+		$retried = $service->retry(
+			array(
+				'action'        => 'owner/write-record',
+				'operation_ref' => $submitted['operation_ref'],
+			)
+		);
 		$this->assertTrue( $retried['success'] );
 		$this->assertSame( 'submitted', $retried['status'] );
 		$this->assertSame( (int) $job['job_id'], (int) $this->job( 'retry-operation' )['job_id'] );
 
-		$retrying_job = $this->job( 'retry-operation' );
-		$engine       = $retrying_job['engine_data'];
-		$engine['retry'] = array( 'attempt' => 1, 'max_attempts' => 3, 'next_retry_at' => gmdate( 'c', time() + 60 ) );
+		$retrying_job    = $this->job( 'retry-operation' );
+		$engine          = $retrying_job['engine_data'];
+		$engine['retry'] = array(
+			'attempts'      => 1,
+			'max_attempts'  => 3,
+			'next_retry_at' => gmdate( 'c', time() + 60 ),
+		);
 		$this->assertTrue( ( new Jobs() )->store_engine_data( (int) $retrying_job['job_id'], $engine ) );
-		$retrying = $service->reconcile( array( 'action' => 'owner/write-record', 'operation_ref' => $submitted['operation_ref'] ) );
+		$retrying = $service->reconcile(
+			array(
+				'action'        => 'owner/write-record',
+				'operation_ref' => $submitted['operation_ref'],
+			)
+		);
 		$this->assertSame( 'retrying', $retrying['status'] );
 		$this->assertSame( 1, $retrying['retry']['attempt'] );
+		$cancel_retry = $service->cancel(
+			array(
+				'action'        => 'owner/write-record',
+				'operation_ref' => $submitted['operation_ref'],
+			)
+		);
+		$this->assertSame( 'delegated_operation_not_cancellable', $cancel_retry['error_code'] );
 
 		$this->assertTrue( ( new Jobs() )->complete_job( (int) $retrying_job['job_id'], 'failed - retry-fence' ) );
 		$this->retry_safe = false;
-		$unsafe = $service->retry( array( 'action' => 'owner/write-record', 'operation_ref' => $submitted['operation_ref'] ) );
+		$unsafe           = $service->retry(
+			array(
+				'action'        => 'owner/write-record',
+				'operation_ref' => $submitted['operation_ref'],
+			)
+		);
 		$this->assertSame( 'delegated_operation_retry_unsafe', $unsafe['error_code'] );
+	}
+
+	public function test_callback_exception_logging_redacts_secret_text(): void {
+		$logs   = array();
+		$logger = static function ( $level, $message, $context ) use ( &$logs ): void {
+			$logs[] = compact( 'level', 'message', 'context' );
+		};
+		add_action( 'datamachine_log', $logger, 10, 3 );
+		$this->throw_project = true;
+		wp_set_current_user( $this->first_actor );
+		( new DelegatedOperationService() )->submit( $this->submission( 'callback-log-redaction' ) );
+		remove_action( 'datamachine_log', $logger, 10 );
+		$this->assertStringNotContainsString( 'secret-owner-callback-value', wp_json_encode( $logs ) );
+		$this->assertSame( 'delegated_projection_failed', $logs[0]['context']['error_code'] );
+	}
+
+	public function test_bounded_envelope_survives_shedding_and_cancelled_row_expires(): void {
+		global $wpdb;
+		$service = new DelegatedOperationService();
+		wp_set_current_user( $this->first_actor );
+		$submission              = $this->submission( 'retained-cancelled' );
+		$submission['timestamp'] = time() + HOUR_IN_SECONDS;
+		$submitted               = $service->submit( $submission );
+		$this->assertSame(
+			'cancelled',
+			$service->cancel(
+				array(
+					'action'        => 'owner/write-record',
+					'operation_ref' => $submitted['operation_ref'],
+				)
+			)['status']
+		);
+		$job = $this->job( 'retained-cancelled' );
+		$old = '2000-01-01 00:00:00';
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_jobs',
+			array( 'created_at' => $old ),
+			array( 'job_id' => $job['job_id'] )
+		);
+		$this->assertSame( 0, ( new Jobs() )->delete_old_jobs( 'cancelled', 1 ) );
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_jobs',
+			array(
+				'completed_at' => $old,
+			),
+			array( 'job_id' => $job['job_id'] )
+		);
+		RetentionCleanup::cleanupEngineData();
+		$shed = ( new Jobs() )->get_job( (int) $job['job_id'] );
+		$this->assertEmpty( $shed['engine_data'] );
+		$this->assertSame( $submitted['operation_ref'], $shed['operation_envelope']['delegated_operation']['operation_ref'] );
+		$replayed = $service->submit( $submission );
+		$this->assertSame( $submitted['operation_ref'], $replayed['operation_ref'] );
+		$this->assertEmpty( ( new Jobs() )->get_job( (int) $job['job_id'] )['engine_data'] );
+		$this->assertSame( 1, ( new Jobs() )->delete_old_jobs( 'cancelled', 1 ) );
+		$this->assertNull( ( new Jobs() )->get_job( (int) $job['job_id'] ) );
 	}
 
 	private function submission( string $operation_id, string $value = 'stable' ): array {
 		return array(
 			'action'       => 'owner/write-record',
 			'operation_id' => $operation_id,
-			'input'        => array( 'record_key' => 'example', 'value' => $value ),
+			'input'        => array(
+				'record_key' => 'example',
+				'value'      => $value,
+			),
+		);
+	}
+
+	private function reconcile( DelegatedOperationService $service, array $submitted ): array {
+		return $service->reconcile(
+			array(
+				'action'        => 'owner/write-record',
+				'operation_ref' => $submitted['operation_ref'],
+			)
 		);
 	}
 
 	private function job( string $operation_id ): array {
-		$key = 'delegated:' . hash( 'sha256', 'owner/write-record' . "\0" . $operation_id );
+		$key = 'delegated:' . hash( 'sha256', "delegated-idempotency\0owner/write-record\0" . $operation_id );
 		$job = ( new Jobs() )->get_job_by_idempotency_key( $key );
 		$this->assertIsArray( $job );
 		return $job;

--- a/tests/retention-engine-data-shedding-smoke.php
+++ b/tests/retention-engine-data-shedding-smoke.php
@@ -117,8 +117,8 @@ namespace {
 			&& str_contains( $cleanup, 'LIMIT %d' )
 	);
 	assert_eds(
-		'shed targets terminal non-delegated rows with non-empty engine_data',
-		str_contains( $cleanup, "completed_at IS NOT NULL AND completed_at < %s AND source != 'delegated' AND engine_data IS NOT NULL AND engine_data != ''" )
+		'shed targets terminal rows via completed_at + non-empty engine_data',
+		str_contains( $cleanup, "completed_at IS NOT NULL AND completed_at < %s AND engine_data IS NOT NULL AND engine_data != ''" )
 	);
 	assert_eds(
 		'shed reuses shared batch / iteration / runtime caps (#2617)',
@@ -153,7 +153,7 @@ namespace {
 	);
 	assert_eds(
 		'Jobs promotes handler_slug column + populates it from engine_data',
-		str_contains( $jobs, "ADD COLUMN handler_slug varchar(100)" )
+		str_contains( $jobs, 'ADD COLUMN handler_slug varchar(100)' )
 			&& str_contains( $jobs, 'extract_handler_slug' )
 			&& str_contains( $jobs, "\$update_data['handler_slug']" )
 	);
@@ -257,9 +257,6 @@ namespace {
 		private function matching_jobs( string $cutoff ): array {
 			$out = array();
 			foreach ( $this->jobs as $id => $row ) {
-				if ( 'delegated' === ( $row['source'] ?? '' ) ) {
-					continue;
-				}
 				if ( null === $row['completed_at'] ) {
 					continue;
 				}
@@ -311,15 +308,6 @@ namespace {
 		);
 		++$jid;
 	}
-	for ( $i = 0; $i < 3; $i++ ) {
-		$fake_wpdb->jobs[ $jid ] = array(
-			'job_id'       => $jid,
-			'source'       => 'delegated',
-			'completed_at' => $two_days,
-			'engine_data'  => $blob,
-		);
-		++$jid;
-	}
 
 	$GLOBALS['wpdb'] = $fake_wpdb;
 
@@ -363,20 +351,20 @@ namespace {
 		"updated={$result['updated']}"
 	);
 
-	$shed   = array_filter( $fake_wpdb->jobs, static fn( $r ) => null === $r['engine_data'] );
-	$kept   = array_filter( $fake_wpdb->jobs, static fn( $r ) => null !== $r['engine_data'] );
-	$rows   = count( $fake_wpdb->jobs );
+	$shed = array_filter( $fake_wpdb->jobs, static fn( $r ) => null === $r['engine_data'] );
+	$kept = array_filter( $fake_wpdb->jobs, static fn( $r ) => null !== $r['engine_data'] );
+	$rows = count( $fake_wpdb->jobs );
 	assert_eds(
 		'all old terminal jobs had engine_data shed (2500)',
 		2500 === count( $shed )
 	);
 	assert_eds(
-		'fresh, in-flight, and delegated jobs kept engine_data (18)',
-		18 === count( $kept )
+		'fresh + in-flight jobs kept engine_data (15)',
+		15 === count( $kept )
 	);
 	assert_eds(
 		'shedding keeps the row (no jobs deleted)',
-		2518 === $rows,
+		2515 === $rows,
 		"rows={$rows}"
 	);
 


### PR DESCRIPTION
## Summary
- harden delegated operation receipts, idempotency, owner/version validation, replay, retry admission, and cancellation fencing
- persist canonical terminal envelopes through replayable accounting and retain them independently from shed engine state
- cover later-step/AI continuations, no-op truth, callback redaction, retention, salt rotation, and repeated effects admission

## Why This Follow-Up Is Mandatory
PR #3002 was merged at `89410d65` before the reviewed hardening commits were pushed. Current `main` therefore contains the initial delegated-operation contract but not commits `fef783de` and `2862d036`, leaving the lifecycle and security blockers fixed here unresolved.

## Verification
- Homeboy scoped PHPCS/PHPStan lint: pass, zero findings
- delegated-operation focused PHPUnit command: exit 0 (runner emitted no assertion report)
- retention engine shedding smoke: 24 assertions pass
- direct generation fencing smoke: 13 checks pass
- retry lifecycle/policy, run metrics, outcome metrics, and step-result CAS smokes: pass
- `npm run build`: pass
- independent exact-diff review: all applicable findings resolved

Closes #2999