### PR TITLE
test: remove delegated retry duplication

### DIFF
--- a/tests/Unit/Abilities/Job/DelegatedOperationTest.php
+++ b/tests/Unit/Abilities/Job/DelegatedOperationTest.php
@@ -449,22 +449,12 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 		$retrying = $service->reconcile( $this->operationRequest( $submitted ) );
 		$this->assertSame( 'retrying', $retrying['status'] );
 		$this->assertSame( 1, $retrying['retry']['attempt'] );
-		$cancel_retry = $service->cancel(
-			array(
-				'action'        => 'owner/write-record',
-				'operation_ref' => $submitted['operation_ref'],
-			)
-		);
+		$cancel_retry = $service->cancel( $this->operationRequest( $submitted ) );
 		$this->assertSame( 'delegated_operation_not_cancellable', $cancel_retry['error_code'] );
 
 		$this->assertTrue( ( new Jobs() )->complete_job( (int) $retrying_job['job_id'], 'failed - retry-fence' ) );
 		$this->retry_safe = false;
-		$unsafe           = $service->retry(
-			array(
-				'action'        => 'owner/write-record',
-				'operation_ref' => $submitted['operation_ref'],
-			)
-		);
+		$unsafe           = $service->retry( $this->operationRequest( $submitted ) );
 		$this->assertSame( 'delegated_operation_retry_unsafe', $unsafe['error_code'] );
 	}
 


### PR DESCRIPTION
## Summary
- replace the final duplicated delegated-operation request fixtures with the existing helper
- clear the sole change-owned Homeboy Audit finding from merged PR #3003

## Why This Follow-Up Is Mandatory
PR #3003 was merged by another actor at `2862d036` while its Test job was still stuck and after Audit reported one introduced intra-method duplication finding. Commit `6e0d64a3` resolves that exact finding and was not included in the merge.

## Verification
- exact failed Audit artifact inspected: 1 introduced finding, 114 contextual baseline findings
- follow-up Homeboy Audit: pass
- Homeboy Lint/Refactor/Plan/prefix-policy: pass
- focused delegated-operation PHPUnit command: local exit 0
- GitHub Test infrastructure failure: WP Codebox `wordpress.phpunit` timed out after 1,500,002 ms in PHP-WASM `mysqli_poll`; zero assertion failures (`test_failures: []`)
- `git diff --check`: pass

Infrastructure ownership: Automattic/wp-codebox#2010 and WordPress/wordpress-playground#4161. Homeboy cancellation evidence: Extra-Chill/homeboy#10217.

Closes #3008. Follow-up to #2999 and #3003.