### PR TITLE
fix: finish delegated operation hardening

### DIFF
--- a/inc/Core/DelegatedOperations/DelegatedOperationService.php
+++ b/inc/Core/DelegatedOperations/DelegatedOperationService.php
@@ -353,8 +353,8 @@ final class DelegatedOperationService {
 		$configs = WorkflowConfigFactory::buildEphemeralConfigs( $prepared['workflow'] );
 		try {
 			$first_step_id = ExecutionPlan::from_flow_config( $configs['flow_config'] )->first_step_id();
-		} catch ( \InvalidArgumentException $exception ) {
-			do_action( 'datamachine_log', 'error', 'Delegated operation workflow validation failed', array( 'exception' => $exception->getMessage() ) );
+		} catch ( \InvalidArgumentException ) {
+			do_action( 'datamachine_log', 'error', 'Delegated operation workflow validation failed', array( 'error_code' => 'delegated_action_prepare_failed' ) );
 			return new \WP_Error( 'delegated_action_prepare_failed', __( 'The owner workflow is invalid.', 'data-machine' ) );
 		}
 		if ( ! $first_step_id ) {

--- a/tests/Unit/Abilities/Job/DelegatedOperationTest.php
+++ b/tests/Unit/Abilities/Job/DelegatedOperationTest.php
@@ -491,13 +491,13 @@ final class DelegatedOperationTest extends WP_UnitTestCase {
 		$job = $this->job( 'retained-cancelled' );
 		$old = '2000-01-01 00:00:00';
 		$wpdb->update(
-			$wpdb->prefix . 'datamachine_jobs',
+			$wpdb->prefix . Jobs::TABLE_NAME,
 			array( 'created_at' => $old ),
 			array( 'job_id' => $job['job_id'] )
 		);
 		$this->assertSame( 0, ( new Jobs() )->delete_old_jobs( 'cancelled', 1 ) );
 		$wpdb->update(
-			$wpdb->prefix . 'datamachine_jobs',
+			$wpdb->prefix . Jobs::TABLE_NAME,
 			array(
 				'completed_at' => $old,
 			),


### PR DESCRIPTION
## Summary
- redact delegated workflow exception details at the final owner-callback boundary
- keep delegated retention coverage portable through the canonical jobs table constant

## Verification
- Homeboy lint and audit passed
- delegated runtime-result smoke: 14/14
- retention shedding smoke: 24/24
- direct-job generation smoke passed
- exact-diff independent review found no remaining blockers

Follow-up to #3002 and #3003.