### PR TITLE
fix: establish delegated owner context for system tasks

### DIFF
--- a/inc/Core/Steps/SystemTask/SystemTaskStep.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskStep.php
@@ -186,17 +186,26 @@ class SystemTaskStep extends Step {
 		// SystemTask::requiresAgentContext().
 		$parent_job_snapshot = $this->engine->getJobContext();
 		$identity            = $this->resolveAgentIdentityForExecution( $parent_job_snapshot );
-		if ( null === $identity && $task_for_passthrough->requiresAgentContext() ) {
+		$jobs_db             = new Jobs();
+		$parent_job          = $jobs_db->get_job( $this->job_id );
+		$delegated_owner_id  = $this->resolveAgentlessDelegatedOwnerForExecution( $parent_job );
+		if ( is_wp_error( $delegated_owner_id ) ) {
+			$this->failInvalidDelegatedOwner( $parent_job_snapshot, $task_type, $delegated_owner_id );
+			return array();
+		}
+		if ( null !== $delegated_owner_id ) {
+			$identity = null;
+		}
+		if ( null === $identity && null === $delegated_owner_id && $task_for_passthrough->requiresAgentContext() ) {
 			$this->failMissingAgentContext( $parent_job_snapshot, $task_type );
 			return array();
 		}
 
 		$parent_agent_id   = null !== $identity ? $identity->agent_id : 0;
 		$parent_agent_slug = null !== $identity ? $identity->agent_slug : '';
-		$parent_user_id    = null !== $identity ? $identity->owner_id : 0;
+		$parent_user_id    = null !== $identity ? $identity->owner_id : ( $delegated_owner_id ?? 0 );
 
 		// Create a child job for independent tracking.
-		$jobs_db      = new Jobs();
 		$job_context  = $parent_job_snapshot;
 		$child_job_id = (int) $jobs_db->create_job(
 			array(
@@ -310,15 +319,18 @@ class SystemTaskStep extends Step {
 		// context, never a broad user-only fallback.
 		$owner_id = $parent_user_id;
 
-		$previous_user_id = get_current_user_id();
-		$context_set      = false;
+		$previous_user_id      = get_current_user_id();
+		$previous_switch_depth = count( $GLOBALS['_wp_switched_stack'] ?? array() );
+		$context_set           = false;
 
 		// Execute the task synchronously via executeTask().
 		$success   = true;
 		$error_msg = '';
 
 		try {
-			if ( $owner_id > 0 && $parent_agent_id > 0 ) {
+			if ( $delegated_owner_id > 0 ) {
+				wp_set_current_user( $delegated_owner_id );
+			} elseif ( $owner_id > 0 && $parent_agent_id > 0 ) {
 				wp_set_current_user( $owner_id );
 				PermissionHelper::set_agent_context( $parent_agent_id, $owner_id );
 				$context_set = true;
@@ -348,6 +360,15 @@ class SystemTaskStep extends Step {
 		} finally {
 			if ( $context_set ) {
 				PermissionHelper::clear_agent_context();
+			}
+			if ( $delegated_owner_id > 0 ) {
+				$current_switch_depth = count( $GLOBALS['_wp_switched_stack'] ?? array() );
+				while ( $current_switch_depth > $previous_switch_depth ) {
+					if ( ! restore_current_blog() ) {
+						break;
+					}
+					--$current_switch_depth;
+				}
 			}
 			if ( $owner_id > 0 && $previous_user_id !== $owner_id ) {
 				wp_set_current_user( $previous_user_id );
@@ -482,6 +503,56 @@ class SystemTaskStep extends Step {
 		} catch ( \InvalidArgumentException $e ) {
 			return null;
 		}
+	}
+
+	/**
+	 * Resolve the frozen user owner for an agentless delegated operation.
+	 *
+	 * @param array|null $parent_job Persisted parent job row.
+	 * @return int|\WP_Error|null Owner ID, validation failure, or null for non-delegated/agent-backed work.
+	 */
+	private function resolveAgentlessDelegatedOwnerForExecution( ?array $parent_job ): int|\WP_Error|null {
+		if ( 'delegated' !== ( $parent_job['source'] ?? '' ) ) {
+			return null;
+		}
+
+		$operation_envelope  = is_array( $parent_job['operation_envelope'] ?? null ) ? $parent_job['operation_envelope'] : array();
+		$delegated_operation = is_array( $operation_envelope['delegated_operation'] ?? null ) ? $operation_envelope['delegated_operation'] : array();
+		$execution_owner     = is_array( $delegated_operation['execution_owner'] ?? null ) ? $delegated_operation['execution_owner'] : array();
+		if ( ! empty( $execution_owner['agent_id'] ) || ! empty( $execution_owner['agent_slug'] ) ) {
+			return null;
+		}
+
+		$owner_id = (int) ( $execution_owner['user_id'] ?? 0 );
+		if ( $owner_id <= 0 || ! get_user_by( 'id', $owner_id ) ) {
+			return new \WP_Error(
+				'system_task_delegated_owner_invalid',
+				__( 'The delegated system task execution owner is missing or invalid.', 'data-machine' )
+			);
+		}
+
+		return $owner_id;
+	}
+
+	/**
+	 * Fail an agentless delegated task whose frozen execution owner is invalid.
+	 *
+	 * @param array     $parent_job_snapshot Parent job snapshot from engine data.
+	 * @param string    $task_type           System task type currently executing.
+	 * @param \WP_Error $error               Owner validation failure.
+	 */
+	private function failInvalidDelegatedOwner( array $parent_job_snapshot, string $task_type, \WP_Error $error ): void {
+		do_action(
+			'datamachine_fail_job',
+			$this->job_id,
+			$error->get_error_code(),
+			array(
+				'parent_job_id' => $this->job_id,
+				'flow_id'       => (int) ( $parent_job_snapshot['flow_id'] ?? 0 ),
+				'task_type'     => $task_type,
+				'error_message' => $error->get_error_message(),
+			)
+		);
 	}
 
 	/**

--- a/tests/Unit/Core/Steps/SystemTask/SystemTaskDelegatedOwnerContextTest.php
+++ b/tests/Unit/Core/Steps/SystemTask/SystemTaskDelegatedOwnerContextTest.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * Agentless delegated SystemTask owner-context integration coverage.
+ *
+ * @package DataMachine\Tests\Unit\Core\Steps\SystemTask
+ */
+
+namespace DataMachine\Tests\Unit\Core\Steps\SystemTask;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\EngineData;
+use DataMachine\Core\Steps\SystemTask\SystemTaskStep;
+use DataMachine\Core\Steps\WorkflowConfigFactory;
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
+use DataMachine\Engine\Tasks\TaskRegistry;
+use WP_UnitTestCase;
+
+final class DelegatedOwnerContextTask extends SystemTask {
+
+	public static array $observations = array();
+	public static bool $requires_agent_context = true;
+	public static $during_execution = null;
+
+	public function getTaskType(): string {
+		return 'delegated_owner_context_fixture';
+	}
+
+	public function requiresAgentContext(): bool {
+		return self::$requires_agent_context;
+	}
+
+	public function executeTask( int $jobId, array $params ): void {
+		$label = (string) ( $params['label'] ?? 'task' );
+		$this->observe( $label . ':before' );
+
+		if ( is_callable( self::$during_execution ) ) {
+			( self::$during_execution )();
+			$this->observe( $label . ':after' );
+		}
+
+		if ( ! empty( $params['switch_blog_id'] ) ) {
+			switch_to_blog( (int) $params['switch_blog_id'] );
+			$this->observe( $label . ':switched' );
+		}
+
+		if ( ! empty( $params['wp_error'] ) ) {
+			self::$observations[] = new \WP_Error( 'fixture_effect_error', 'Fixture effect failed.' );
+		}
+
+		if ( ! empty( $params['throw'] ) ) {
+			throw new \RuntimeException( 'Fixture task exception.' );
+		}
+
+		$this->completeJob( $jobId, array( 'fixture_complete' => true ) );
+	}
+
+	private function observe( string $label ): void {
+		self::$observations[] = array(
+			'label'            => $label,
+			'user_id'          => get_current_user_id(),
+			'blog_id'          => get_current_blog_id(),
+			'can_manage'       => current_user_can( 'manage_options' ),
+			'in_agent_context' => PermissionHelper::in_agent_context(),
+			'agent_id'         => PermissionHelper::get_acting_agent_id(),
+		);
+	}
+}
+
+final class SystemTaskDelegatedOwnerContextTest extends WP_UnitTestCase {
+	private ?EngineData $last_engine = null;
+	private int $last_parent_id = 0;
+	private string $last_step_id = '';
+
+	public function set_up(): void {
+		parent::set_up();
+		Jobs::create_table();
+		DelegatedOwnerContextTask::$observations           = array();
+		DelegatedOwnerContextTask::$requires_agent_context = true;
+		DelegatedOwnerContextTask::$during_execution       = null;
+		add_filter( 'datamachine_tasks', array( $this, 'registerFixtureTask' ) );
+		TaskRegistry::reset();
+	}
+
+	public function tear_down(): void {
+		remove_filter( 'datamachine_tasks', array( $this, 'registerFixtureTask' ) );
+		TaskRegistry::reset();
+		PermissionHelper::clear_agent_context();
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function registerFixtureTask( array $tasks ): array {
+		$tasks['delegated_owner_context_fixture'] = DelegatedOwnerContextTask::class;
+		return $tasks;
+	}
+
+	public function test_valid_frozen_owner_executes_with_wordpress_capabilities_and_restores_ambient_user(): void {
+		$owner = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$actor = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$stale_agent = ( new Agents() )->create_if_missing( 'stale-delegated-owner-context-agent', 'Stale Delegated Owner Context Agent', $actor );
+		wp_set_current_user( $actor );
+
+		$this->runTask( $owner, array( 'label' => 'valid', 'owner_user_id' => $actor ), $actor, true, 0, null, $stale_agent );
+
+		$this->assertSame( $owner, DelegatedOwnerContextTask::$observations[0]['user_id'] );
+		$this->assertTrue( DelegatedOwnerContextTask::$observations[0]['can_manage'] );
+		$this->assertFalse( DelegatedOwnerContextTask::$observations[0]['in_agent_context'] );
+		$this->assertSame( $actor, get_current_user_id() );
+		$this->assertFalse( current_user_can( 'manage_options' ) );
+	}
+
+	public function test_missing_and_deleted_frozen_owners_fail_closed_before_effects(): void {
+		$deleted_owner = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_delete_user( $deleted_owner );
+		$failures = array();
+		$capture  = static function ( $job_id, $code ) use ( &$failures ): void {
+			unset( $job_id );
+			$failures[] = $code;
+		};
+		add_action( 'datamachine_fail_job', $capture, 1, 2 );
+
+		$this->runTask( null, array( 'label' => 'missing' ) );
+		$this->runTask( $deleted_owner, array( 'label' => 'deleted' ) );
+		remove_action( 'datamachine_fail_job', $capture, 1 );
+
+		$this->assertSame( array(), DelegatedOwnerContextTask::$observations );
+		$this->assertSame(
+			array( 'system_task_delegated_owner_invalid', 'system_task_delegated_owner_invalid' ),
+			$failures
+		);
+	}
+
+	public function test_nested_owner_context_restores_outer_owner_then_ambient_user(): void {
+		$outer_owner = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$inner_owner = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$ambient     = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $ambient );
+
+		DelegatedOwnerContextTask::$during_execution = function () use ( $inner_owner ): void {
+			$callback = DelegatedOwnerContextTask::$during_execution;
+			DelegatedOwnerContextTask::$during_execution = null;
+			$this->runTask( $inner_owner, array( 'label' => 'inner' ) );
+			DelegatedOwnerContextTask::$during_execution = $callback;
+		};
+		$this->runTask( $outer_owner, array( 'label' => 'outer' ) );
+
+		$this->assertSame(
+			array( $outer_owner, $inner_owner, $outer_owner ),
+			array_column( DelegatedOwnerContextTask::$observations, 'user_id' )
+		);
+		$this->assertSame( array( 'outer:before', 'inner:before', 'outer:after' ), array_column( DelegatedOwnerContextTask::$observations, 'label' ) );
+		$this->assertSame( $ambient, get_current_user_id() );
+	}
+
+	public function test_exception_and_wp_error_paths_restore_ambient_user(): void {
+		$owner   = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$ambient = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $ambient );
+
+		$this->runTask( $owner, array( 'label' => 'wp-error', 'wp_error' => true ) );
+		$this->assertInstanceOf( \WP_Error::class, DelegatedOwnerContextTask::$observations[1] );
+		$this->assertSame( $ambient, get_current_user_id() );
+
+		$this->runTask( $owner, array( 'label' => 'exception', 'throw' => true ) );
+		$this->assertSame( $owner, DelegatedOwnerContextTask::$observations[2]['user_id'] );
+		$this->assertSame( $ambient, get_current_user_id() );
+	}
+
+	public function test_retry_resume_reestablishes_frozen_owner_without_leaking_between_jobs(): void {
+		$first_owner  = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$second_owner = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$first_actor  = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$second_actor = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		wp_set_current_user( $first_actor );
+		$this->runTask( $first_owner, array( 'label' => 'attempt-1' ) );
+		$this->assertSame( $first_actor, get_current_user_id() );
+
+		wp_set_current_user( $second_actor );
+		$this->resumeLastTask();
+		$this->runTask( $second_owner, array( 'label' => 'next-job' ) );
+
+		$this->assertSame(
+			array( $first_owner, $first_owner, $second_owner ),
+			array_column( DelegatedOwnerContextTask::$observations, 'user_id' )
+		);
+		$this->assertSame( $second_actor, get_current_user_id() );
+	}
+
+	public function test_cross_site_exception_restores_blog_user_and_capability_state(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite test suite is not active.' );
+		}
+
+		$main_blog_id = get_current_blog_id();
+		$other_blog   = self::factory()->blog->create();
+		$owner        = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$ambient      = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		add_user_to_blog( $other_blog, $owner, 'administrator' );
+		switch_to_blog( $other_blog );
+		try {
+			Jobs::create_table();
+			wp_set_current_user( $ambient );
+			$this->runTask(
+				$owner,
+				array(
+					'label'          => 'cross-site',
+					'switch_blog_id' => $main_blog_id,
+					'throw'          => true,
+				)
+			);
+
+			$this->assertSame( $other_blog, DelegatedOwnerContextTask::$observations[0]['blog_id'] );
+			$this->assertTrue( DelegatedOwnerContextTask::$observations[0]['can_manage'] );
+			$this->assertSame( $main_blog_id, DelegatedOwnerContextTask::$observations[1]['blog_id'] );
+			$this->assertFalse( DelegatedOwnerContextTask::$observations[1]['can_manage'] );
+			$this->assertSame( $other_blog, get_current_blog_id() );
+			$this->assertSame( $ambient, get_current_user_id() );
+			$this->assertFalse( current_user_can( 'manage_options' ) );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	public function test_ordinary_and_agent_backed_tasks_keep_existing_context_rules(): void {
+		$ambient = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$spoofed = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $ambient );
+		DelegatedOwnerContextTask::$requires_agent_context = false;
+		$this->runTask( null, array( 'label' => 'ordinary' ), null, false, 0, $spoofed );
+		$this->assertSame( $ambient, DelegatedOwnerContextTask::$observations[0]['user_id'] );
+		$this->assertFalse( DelegatedOwnerContextTask::$observations[0]['in_agent_context'] );
+
+		$owner    = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$agent_id = ( new Agents() )->create_if_missing( 'delegated-owner-context-agent', 'Delegated Owner Context Agent', $owner );
+		DelegatedOwnerContextTask::$requires_agent_context = true;
+		$this->runTask( $owner, array( 'label' => 'agent' ), null, true, $agent_id );
+
+		$this->assertSame( $owner, DelegatedOwnerContextTask::$observations[1]['user_id'] );
+		$this->assertTrue( DelegatedOwnerContextTask::$observations[1]['in_agent_context'] );
+		$this->assertSame( $agent_id, DelegatedOwnerContextTask::$observations[1]['agent_id'] );
+		$this->assertSame( $ambient, get_current_user_id() );
+		$this->assertFalse( PermissionHelper::in_agent_context() );
+	}
+
+	private function runTask( ?int $owner_id, array $params, ?int $job_user_id = null, bool $delegated = true, int $agent_id = 0, ?int $engine_owner_override = null, int $engine_agent_override = 0 ): array {
+		$workflow  = ( new DelegatedOwnerContextTask() )->getWorkflow( $params );
+		$configs   = WorkflowConfigFactory::buildEphemeralConfigs( $workflow );
+		$step_id   = (string) array_key_first( $configs['flow_config'] );
+		$jobs      = new Jobs();
+		$operation = array(
+			'action'          => 'fixture/effect',
+			'initiator'       => array( 'user_id' => 999999 ),
+			'execution_owner' => array(
+				'user_id'  => $owner_id,
+				'agent_id' => $agent_id,
+			),
+		);
+		$create_args = array(
+			'pipeline_id' => 'direct',
+			'flow_id'     => 'direct',
+			'source'      => $delegated ? 'delegated' : 'test',
+			'label'       => 'Delegated owner context fixture',
+			'user_id'     => $job_user_id ?? ( $owner_id ?? 0 ),
+		);
+		if ( $delegated ) {
+			$create_args['operation_envelope'] = array( 'delegated_operation' => $operation );
+		}
+		$parent_id = (int) $jobs->create_job( $create_args );
+
+		$job = array(
+			'job_id'      => $parent_id,
+			'user_id'     => $job_user_id ?? ( $owner_id ?? 0 ),
+			'flow_id'     => 'direct',
+			'pipeline_id' => 'direct',
+		);
+		$engine_agent_id = $engine_agent_override > 0 ? $engine_agent_override : $agent_id;
+		if ( $engine_agent_id > 0 ) {
+			$job['agent_id'] = $engine_agent_id;
+		}
+
+		$engine_data = array(
+			'flow_config'     => $configs['flow_config'],
+			'pipeline_config' => $configs['pipeline_config'],
+			'job'             => $job,
+		);
+		if ( $delegated ) {
+			$engine_data['delegated_operation'] = $operation;
+		} elseif ( null !== $engine_owner_override ) {
+			$engine_data['delegated_operation'] = array(
+				'action'          => 'fixture/spoofed-effect',
+				'initiator'       => array( 'user_id' => $engine_owner_override ),
+				'execution_owner' => array( 'user_id' => $engine_owner_override ),
+			);
+		}
+		$this->last_parent_id = $parent_id;
+		$this->last_step_id   = $step_id;
+		$this->last_engine    = new EngineData( $engine_data, $parent_id );
+
+		return ( new SystemTaskStep() )->execute(
+			array(
+				'job_id'       => $parent_id,
+				'flow_step_id' => $step_id,
+				'data'         => array(),
+				'engine'       => $this->last_engine,
+			)
+		);
+	}
+
+	private function resumeLastTask(): array {
+		$this->assertNotNull( $this->last_engine );
+
+		return ( new SystemTaskStep() )->execute(
+			array(
+				'job_id'       => $this->last_parent_id,
+				'flow_step_id' => $this->last_step_id,
+				'data'         => array(),
+				'engine'       => $this->last_engine,
+			)
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- resolve agentless delegated SystemTask owners exclusively from the persisted delegated job envelope, preventing caller-controlled engine data from selecting an execution user
- establish the frozen WordPress user immediately around task effects, fail closed for missing/deleted owners, and restore nested user and multisite blog context in `finally`
- preserve existing ordinary and agent-backed SystemTask behavior while keeping initiator attestation separate from execution ownership

## Regression Coverage
- valid owner and WordPress capability state
- missing and deleted owner failures before effects
- nested owner contexts and exception/WP_Error restoration
- retry/resume and no leakage between jobs
- cross-site capability, user, and blog restoration
- spoofed engine owner rejection and stale agent-data precedence
- unchanged ordinary and agent-backed context behavior

## Verification
- `homeboy review lint data-machine --changed-since origin/main` (PHPCS and PHPStan): pass
- `homeboy review audit data-machine --profile pr --changed-since origin/main`: pass, no introduced findings
- `php tests/system-task-agent-context-smoke.php`: pass, 47 assertions
- `php tests/system-task-contract-smoke.php`: pass, 8 assertions
- `php tests/small-orchestration-bugs-smoke.php`: pass, 20 assertions
- `php tests/job-retry-policy-smoke.php`: pass, 46 assertions
- `npm run build`: pass
- WordPress integration suite added; local Homeboy test provisioning was blocked before bootstrap because this host has no Docker database service
- Homeboy build wrapper was blocked by the tracked missing local workspace helper (Extra-Chill/homeboy#10232); direct project build passes

Closes #3005