### PR TITLE
fix: harden dispatcher health evidence

### DIFF
--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -244,7 +244,7 @@ class SystemAbilities {
 	private function runSchedulerDiagnostics( array $options = array() ): array {
 		$stale_threshold = max( 60, (int) ( $options['stale_threshold_seconds'] ?? 900 ) );
 		$now             = time();
-		$wp_cron_next    = wp_next_scheduled( 'action_scheduler_run_queue' );
+		$wp_cron_next    = wp_next_scheduled( 'action_scheduler_run_queue', array( 'WP Cron' ) );
 		$wp_cron_overdue = is_int( $wp_cron_next ) ? max( 0, $now - $wp_cron_next ) : null;
 		$pending         = $this->getActionSchedulerGroupStats( 'pending' );
 		$complete        = $this->getActionSchedulerGroupStats( 'complete' );

--- a/inc/Cli/Commands/WorkerCommand.php
+++ b/inc/Cli/Commands/WorkerCommand.php
@@ -275,7 +275,10 @@ class WorkerCommand extends BaseCommand {
 					break;
 				}
 
-				WorkerLock::heartbeat( $lock_token, $lane );
+				if ( ! WorkerLock::heartbeat( $lock_token, $lane ) ) {
+					$stop_reason = 'lock_lost';
+					break;
+				}
 
 				++$passes;
 
@@ -371,7 +374,7 @@ class WorkerCommand extends BaseCommand {
 				'duration_seconds'         => time() - $started_at,
 				'stop_reason'              => $stop_reason,
 				'lane'                     => $lane,
-			) + self::publicLockStatus( $lock );
+			) + self::publicLockStatus( $status );
 		} finally {
 			WorkerLock::release( (string) ( $lock['lock_token'] ?? '' ), $lane );
 		}
@@ -614,36 +617,45 @@ class WorkerCommand extends BaseCommand {
 	 * @return array<string,mixed>
 	 */
 	private static function statusSnapshot( string $lane = '' ): array {
-		$lane            = self::normalizeLane( $lane );
-		$pending_summary = PendingActionStore::summary( array( 'status' => 'pending' ) );
-		$drain_status    = DrainCommand::status( array( 'lane' => $lane ) );
-		$job_counts      = self::jobStatusCounts();
-		$stuck_jobs      = RecoverStuckJobsAbility::countStuckCandidates();
-		$lock            = WorkerLock::snapshot( null, 600, $lane );
-		$now             = time();
-		$threshold       = 900;
-		$oldest_due_gmt  = is_string( $drain_status['oldest_due_gmt'] ?? null ) ? $drain_status['oldest_due_gmt'] : null;
-		$oldest_due_at   = null === $oldest_due_gmt ? false : strtotime( $oldest_due_gmt . ' UTC' );
-		$oldest_due_age  = false === $oldest_due_at ? null : max( 0, $now - $oldest_due_at );
-		$latest_attempt  = is_string( $drain_status['latest_in_progress_attempt_gmt'] ?? null ) ? $drain_status['latest_in_progress_attempt_gmt'] : null;
-		$latest_attempt_at = null === $latest_attempt ? false : strtotime( $latest_attempt . ' UTC' );
-		$action_heartbeat_age = false === $latest_attempt_at ? null : max( 0, $now - $latest_attempt_at );
-		$queue_trigger   = self::queueTriggerEvidence( $now, $threshold );
+		$lane               = self::normalizeLane( $lane );
+		$pending_summary    = PendingActionStore::summary( array( 'status' => 'pending' ) );
+		$drain_status       = DrainCommand::status( array( 'lane' => $lane ) );
+		$job_counts         = self::jobStatusCounts();
+		$stuck_jobs         = RecoverStuckJobsAbility::countStuckCandidates();
+		$lock               = WorkerLock::snapshot( null, 600, $lane );
+		$now                = time();
+		$threshold          = 900;
+		$stale_due_sample     = is_string( $drain_status['stale_due_sample_gmt'] ?? null ) ? $drain_status['stale_due_sample_gmt'] : null;
+		$stale_due_sample_at  = null === $stale_due_sample ? false : strtotime( $stale_due_sample . ' UTC' );
+		$stale_due_sample_age = false === $stale_due_sample_at ? null : max( 0, $now - $stale_due_sample_at );
+		$attempt_sample       = is_string( $drain_status['in_progress_attempt_sample_gmt'] ?? null ) ? $drain_status['in_progress_attempt_sample_gmt'] : null;
+		$attempt_sample_at    = null === $attempt_sample ? false : strtotime( $attempt_sample . ' UTC' );
+		$attempt_sample_age   = false === $attempt_sample_at ? null : max( 0, $now - $attempt_sample_at );
+		$queue_trigger      = '' === $lane
+			? self::queueTriggerEvidence( $now, $threshold )
+			: array(
+				'queue_trigger_state'           => 'not_applicable',
+				'queue_trigger_next_gmt'        => null,
+				'queue_trigger_overdue_seconds' => null,
+			);
 		$heartbeat_age   = isset( $lock['heartbeat_age_seconds'] ) ? (int) $lock['heartbeat_age_seconds'] : null;
 		$heartbeat_state = 'held' !== (string) ( $lock['lock_status'] ?? '' )
 			? 'absent'
 			: ( null !== $heartbeat_age && $heartbeat_age <= $threshold ? 'fresh' : 'stale' );
 		$dispatch_evidence = array(
-			'due_count'                    => (int) ( $drain_status['due_pending'] ?? 0 ),
-			'oldest_due_gmt'               => $oldest_due_gmt,
-			'oldest_due_age_seconds'       => $oldest_due_age,
-			'in_progress_count'            => (int) ( $drain_status['in_progress_actions'] ?? 0 ),
-			'latest_in_progress_attempt_gmt' => $latest_attempt,
-			'action_heartbeat_state'       => null !== $action_heartbeat_age && $action_heartbeat_age <= $threshold ? 'fresh' : 'absent',
-			'worker_heartbeat_state'       => $heartbeat_state,
-			'worker_heartbeat_at_gmt'      => isset( $lock['heartbeat_at'] ) && (int) $lock['heartbeat_at'] > 0 ? gmdate( 'Y-m-d H:i:s', (int) $lock['heartbeat_at'] ) : null,
-			'worker_heartbeat_age_seconds' => $heartbeat_age,
-			'concurrency_deferred_actions' => (int) ( $drain_status['concurrency_deferred_actions'] ?? 0 ),
+			'scope'                                  => '' === $lane ? 'global' : 'lane',
+			'due_count'                              => (int) ( $drain_status['due_pending'] ?? 0 ),
+			'stale_due_sample_gmt'                   => $stale_due_sample,
+			'stale_due_sample_age_seconds'           => $stale_due_sample_age,
+			'in_progress_count'                      => (int) ( $drain_status['in_progress_actions'] ?? 0 ),
+			'in_progress_attempt_sample_gmt'         => $attempt_sample,
+			'in_progress_attempt_sample_age_seconds' => $attempt_sample_age,
+			'worker_heartbeat_state'                 => $heartbeat_state,
+			'worker_heartbeat_at_gmt'                => isset( $lock['heartbeat_at'] ) && (int) $lock['heartbeat_at'] > 0 ? gmdate( 'Y-m-d H:i:s', (int) $lock['heartbeat_at'] ) : null,
+			'worker_heartbeat_age_seconds'           => $heartbeat_age,
+			'in_progress_actions_capped'             => (bool) ( $drain_status['in_progress_actions_capped'] ?? false ),
+			'concurrency_deferred_actions'           => (int) ( $drain_status['concurrency_deferred_actions'] ?? 0 ),
+			'concurrency_deferred_actions_capped'   => (bool) ( $drain_status['concurrency_deferred_actions_capped'] ?? false ),
 		) + $queue_trigger;
 		$health = WorkerHealth::classify( $dispatch_evidence, $threshold );
 
@@ -669,7 +681,7 @@ class WorkerCommand extends BaseCommand {
 	 * @return array{queue_trigger_state:string,queue_trigger_next_gmt:?string,queue_trigger_overdue_seconds:?int}
 	 */
 	private static function queueTriggerEvidence( int $now, int $stale_threshold_seconds ): array {
-		$next    = wp_next_scheduled( 'action_scheduler_run_queue' );
+		$next    = wp_next_scheduled( 'action_scheduler_run_queue', array( 'WP Cron' ) );
 		$overdue = is_int( $next ) ? max( 0, $now - $next ) : null;
 
 		if ( ! is_int( $next ) ) {

--- a/inc/Cli/WorkerHealth.php
+++ b/inc/Cli/WorkerHealth.php
@@ -19,18 +19,26 @@ class WorkerHealth {
 	 */
 	public static function classify( array $evidence, int $stale_threshold_seconds = 900 ): array {
 		$stale_threshold_seconds = max( 60, $stale_threshold_seconds );
+		$scope                   = (string) ( $evidence['scope'] ?? 'global' );
+		if ( 'global' !== $scope ) {
+			return array(
+				'condition'                    => 'lane_scope_unclassified',
+				'scheduler_dispatcher_starved' => false,
+				'stale_threshold_seconds'      => $stale_threshold_seconds,
+				'recommendation'               => null,
+			);
+		}
+
 		$due_count               = max( 0, (int) ( $evidence['due_count'] ?? 0 ) );
-		$in_progress             = max( 0, (int) ( $evidence['in_progress_count'] ?? 0 ) );
 		$deferred                = max( 0, (int) ( $evidence['concurrency_deferred_actions'] ?? 0 ) );
-		$oldest_due_age          = isset( $evidence['oldest_due_age_seconds'] ) ? max( 0, (int) $evidence['oldest_due_age_seconds'] ) : null;
+		$stale_due_sample_age    = isset( $evidence['stale_due_sample_age_seconds'] ) ? max( 0, (int) $evidence['stale_due_sample_age_seconds'] ) : null;
 		$queue_trigger_state     = (string) ( $evidence['queue_trigger_state'] ?? 'unknown' );
 		$heartbeat_state         = (string) ( $evidence['worker_heartbeat_state'] ?? 'absent' );
-		$action_heartbeat_state  = (string) ( $evidence['action_heartbeat_state'] ?? 'absent' );
-		$worker_claimed          = 'fresh' === $heartbeat_state || ( $in_progress > 0 && 'fresh' === $action_heartbeat_state );
+		$worker_claimed          = 'fresh' === $heartbeat_state;
 		$dispatcher_starved      = $due_count > 0
 			&& ! $worker_claimed
-			&& null !== $oldest_due_age
-			&& $oldest_due_age > $stale_threshold_seconds
+			&& null !== $stale_due_sample_age
+			&& $stale_due_sample_age > $stale_threshold_seconds
 			&& in_array( $queue_trigger_state, array( 'overdue', 'missing' ), true );
 
 		if ( $dispatcher_starved ) {

--- a/inc/Core/ActionScheduler/ScopedDrainService.php
+++ b/inc/Core/ActionScheduler/ScopedDrainService.php
@@ -15,6 +15,8 @@ defined( 'ABSPATH' ) || exit;
 class ScopedDrainService {
 
 	private const GROUP = 'data-machine';
+	private const DISPATCH_EVIDENCE_LIMIT = 100;
+	private const DISPATCH_STALE_THRESHOLD = 900;
 
 	public const HOOK_BATCH_CHUNK = 'datamachine_pipeline_batch_chunk';
 
@@ -136,7 +138,7 @@ class ScopedDrainService {
 	 * Return a read-only status snapshot for a drain scope.
 	 *
 	 * @param array{hooks?:string[],job_ids?:string|int[],lane?:string} $options Status options.
-	 * @return array<string,int|string> Status stats.
+	 * @return array<string,mixed> Status stats.
 	 */
 	public function status( array $options = array() ): array {
 		$hooks   = $this->normalizeHooks( $options['hooks'] ?? null );
@@ -160,11 +162,11 @@ class ScopedDrainService {
 	}
 
 	/**
-	 * Return aggregate claim evidence for active actions in the drain scope.
+	 * Return bounded claim evidence for active actions in the drain scope.
 	 *
 	 * @param string[]|null $hooks   Optional hook scope.
 	 * @param int[]         $job_ids Optional job scope.
-	 * @return array{oldest_due_gmt:?string,in_progress_actions:int,latest_in_progress_attempt_gmt:?string,concurrency_deferred_actions:int}
+	 * @return array{stale_due_sample_gmt:?string,in_progress_actions:int,in_progress_actions_capped:bool,in_progress_attempt_sample_gmt:?string,concurrency_deferred_actions:int,concurrency_deferred_actions_capped:bool}
 	 */
 	private function getDispatchEvidence( ?array $hooks, array $job_ids ): array {
 		global $wpdb;
@@ -172,37 +174,92 @@ class ScopedDrainService {
 		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
 		$groups_table  = $wpdb->prefix . 'actionscheduler_groups';
 		$hook_sql      = $this->hookWhereSql( $hooks, $job_ids );
-		$now_gmt       = gmdate( 'Y-m-d H:i:s' );
-		$values        = array_merge(
-			array( $now_gmt, $actions_table, $groups_table ),
+		$stale_gmt     = gmdate( 'Y-m-d H:i:s', time() - self::DISPATCH_STALE_THRESHOLD );
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$group_id = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT group_id FROM %i WHERE slug = %s LIMIT 1',
+				array( $groups_table, self::GROUP )
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		if ( $group_id <= 0 ) {
+			return array(
+				'stale_due_sample_gmt'                   => null,
+				'in_progress_actions'                    => 0,
+				'in_progress_actions_capped'             => false,
+				'in_progress_attempt_sample_gmt'         => null,
+				'concurrency_deferred_actions'           => 0,
+				'concurrency_deferred_actions_capped'    => false,
+			);
+		}
+
+		$stale_values = array_merge(
+			array( $actions_table ),
 			$hook_sql['values'],
-			array( self::GROUP )
+			array( $group_id, $stale_gmt )
+		);
+		$active_values = array_merge(
+			array( $actions_table ),
+			$hook_sql['values'],
+			array( $group_id, self::DISPATCH_EVIDENCE_LIMIT + 1 )
 		);
 
-		// Only active rows are aggregated; Action Scheduler's status/group/date indexes bound this read independently of history size.
+		// Each read stops after the evidence needed for health classification; stale and claimed reads exclude future and historical rows.
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic hook scope is constructed from normalized placeholders and values.
-		$row = $wpdb->get_row(
+		$stale_row = $wpdb->get_row(
 			$wpdb->prepare(
-				'SELECT
-				MIN(CASE WHEN a.status = \'pending\' AND a.scheduled_date_gmt <= %s THEN a.scheduled_date_gmt END) AS oldest_due_gmt,
-				SUM(CASE WHEN a.status = \'in-progress\' THEN 1 ELSE 0 END) AS in_progress_actions,
-				MAX(CASE WHEN a.status = \'in-progress\' THEN a.last_attempt_gmt END) AS latest_in_progress_attempt_gmt,
-				SUM(CASE WHEN a.status = \'pending\' AND a.hook = \'datamachine_resume_ai_step\' THEN 1 ELSE 0 END) AS concurrency_deferred_actions
+				'SELECT a.scheduled_date_gmt AS stale_due_sample_gmt
 				FROM %i a
-				INNER JOIN %i g ON g.group_id = a.group_id
-				WHERE ' . $hook_sql['sql'] . 'g.slug = %s
-				AND a.status IN (\'pending\', \'in-progress\')',
-				$values
+				WHERE ' . $hook_sql['sql'] . 'a.group_id = %d
+				AND a.status = \'pending\'
+				AND a.scheduled_date_gmt <= %s
+				LIMIT 1',
+				$stale_values
+			),
+			ARRAY_A
+		);
+		$in_progress_row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT COUNT(*) AS in_progress_actions, MAX(active.last_attempt_gmt) AS in_progress_attempt_sample_gmt
+				FROM (
+					SELECT a.last_attempt_gmt
+					FROM %i a
+					WHERE ' . $hook_sql['sql'] . 'a.group_id = %d
+					AND a.status = \'in-progress\'
+					LIMIT %d
+				) active',
+				$active_values
+			),
+			ARRAY_A
+		);
+		$deferred_row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT COUNT(*) AS concurrency_deferred_actions
+				FROM (
+					SELECT a.action_id
+					FROM %i a
+					WHERE ' . $hook_sql['sql'] . 'a.group_id = %d
+					AND a.status = \'pending\'
+					AND a.hook = \'datamachine_resume_ai_step\'
+					LIMIT %d
+				) deferred',
+				$active_values
 			),
 			ARRAY_A
 		);
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$in_progress_count = (int) ( $in_progress_row['in_progress_actions'] ?? 0 );
+		$deferred_count    = (int) ( $deferred_row['concurrency_deferred_actions'] ?? 0 );
 
 		return array(
-			'oldest_due_gmt'                 => $this->normalizeNullableDate( $row['oldest_due_gmt'] ?? null ),
-			'in_progress_actions'            => (int) ( $row['in_progress_actions'] ?? 0 ),
-			'latest_in_progress_attempt_gmt' => $this->normalizeNullableDate( $row['latest_in_progress_attempt_gmt'] ?? null ),
-			'concurrency_deferred_actions'   => (int) ( $row['concurrency_deferred_actions'] ?? 0 ),
+			'stale_due_sample_gmt'                => $this->normalizeNullableDate( $stale_row['stale_due_sample_gmt'] ?? null ),
+			'in_progress_actions'                 => min( self::DISPATCH_EVIDENCE_LIMIT, $in_progress_count ),
+			'in_progress_actions_capped'          => $in_progress_count > self::DISPATCH_EVIDENCE_LIMIT,
+			'in_progress_attempt_sample_gmt'      => $this->normalizeNullableDate( $in_progress_row['in_progress_attempt_sample_gmt'] ?? null ),
+			'concurrency_deferred_actions'        => min( self::DISPATCH_EVIDENCE_LIMIT, $deferred_count ),
+			'concurrency_deferred_actions_capped' => $deferred_count > self::DISPATCH_EVIDENCE_LIMIT,
 		);
 	}
 

--- a/tests/system-health-scheduler-smoke.php
+++ b/tests/system-health-scheduler-smoke.php
@@ -30,7 +30,7 @@ if ( false === $system_abilities || false === $system_command ) {
 }
 
 datamachine_scheduler_health_assert_contains( "'scheduler' => array", $system_abilities, 'scheduler check is registered' );
-datamachine_scheduler_health_assert_contains( "wp_next_scheduled( 'action_scheduler_run_queue' )", $system_abilities, 'WP-Cron runner lag is inspected' );
+datamachine_scheduler_health_assert_contains( "wp_next_scheduled( 'action_scheduler_run_queue', array( 'WP Cron' ) )", $system_abilities, 'the exact Action Scheduler WP-Cron runner lag is inspected' );
 datamachine_scheduler_health_assert_contains( 'RecurringScheduler::GROUP', $system_abilities, 'diagnostics scope to Data Machine actions' );
 datamachine_scheduler_health_assert_contains( 'FlowScheduleReconciler', $system_abilities, 'flow schedule coverage is audited' );
 datamachine_scheduler_health_assert_contains( 'flows reconcile-schedules', $system_abilities, 'missing coverage includes operator repair guidance' );

--- a/tests/worker-cli-smoke.php
+++ b/tests/worker-cli-smoke.php
@@ -81,10 +81,9 @@ assert_worker_contains( 'lock_age_seconds', $worker_src, 'worker status reports 
 assert_worker_contains( 'lock_owner', $worker_src, 'worker status reports lock owner' );
 assert_worker_contains( 'lock_lane', $worker_src, 'worker status reports lock lane' );
 assert_worker_contains( "'stop_reason'              => 'locked'", $worker_src, 'worker exits cleanly when lock is held' );
-assert_worker_contains( "'stale' === \$existing['lock_status']", $lock_src, 'worker lock identifies stale lock payloads during acquisition' );
-assert_worker_contains( 'delete_option( $option_name )', $lock_src, 'worker lock clears stale option payloads before reclaiming' );
-assert_worker_contains( "add_option( \$option_name, \$payload, '', false )", $lock_src, 'worker lock reclaims stale locks through the normal add-option path' );
-assert_worker_contains( 'update_option( $option_name, $payload, false )', $lock_src, 'worker lock falls back when stale option delete is not reflected immediately' );
+assert_worker_contains( 'OptionLeaseStore::acquire', $lock_src, 'worker lock uses the shared atomic lease acquisition primitive' );
+assert_worker_contains( 'OptionLeaseStore::refresh', $lock_src, 'worker lock refreshes only its owned lease' );
+assert_worker_contains( 'OptionLeaseStore::release', $lock_src, 'worker lock releases only its owned lease' );
 assert_worker_contains( 'OPTION_NAME . \'_\' . $lane', $lock_src, 'worker lock uses lane-specific option names' );
 assert_worker_not_contains( 'action-scheduler action run ', $worker_src, 'worker does not shell directly to Action Scheduler' );
 assert_worker_not_contains( 'datamachine_jobs', $worker_src, 'worker does not query jobs tables directly' );

--- a/tests/worker-dispatch-health-smoke.php
+++ b/tests/worker-dispatch-health-smoke.php
@@ -23,22 +23,35 @@ final class WorkerDispatchHealthWpdb {
 	/** @var array<int,mixed> */
 	public array $prepare_args = array();
 	public string $query = '';
+	/** @var string[] */
+	public array $queries = array();
 
 	public function prepare( string $query, array $args ): string {
 		$this->query        = $query;
 		$this->prepare_args = $args;
+		$this->queries[]    = $query;
 		return $query;
+	}
+
+	public function get_var( string $query ): int {
+		unset( $query );
+		return 7;
 	}
 
 	/** @return array<string,string|int> */
 	public function get_row( string $query, string $format ): array {
-		unset( $query, $format );
-		return array(
-			'oldest_due_gmt'                 => '2026-07-12 01:45:52',
-			'in_progress_actions'             => 0,
-			'latest_in_progress_attempt_gmt'  => '0000-00-00 00:00:00',
-			'concurrency_deferred_actions'     => 3,
-		);
+		unset( $format );
+		if ( str_contains( $query, 'AS stale_due_sample_gmt' ) ) {
+			return array( 'stale_due_sample_gmt' => '2026-07-12 01:45:52' );
+		}
+		if ( str_contains( $query, 'AS in_progress_actions' ) ) {
+			return array(
+				'in_progress_actions'            => 0,
+				'in_progress_attempt_sample_gmt' => '0000-00-00 00:00:00',
+			);
+		}
+
+		return array( 'concurrency_deferred_actions' => 3 );
 	}
 }
 
@@ -53,17 +66,20 @@ $assert     = static function ( bool $condition, string $message ) use ( &$asser
 
 $worker_source = file_get_contents( __DIR__ . '/../inc/Cli/Commands/WorkerCommand.php' ) ?: '';
 $lock_source   = file_get_contents( __DIR__ . '/../inc/Cli/WorkerLock.php' ) ?: '';
+$system_source = file_get_contents( __DIR__ . '/../inc/Abilities/SystemAbilities.php' ) ?: '';
 $assert( str_contains( $worker_source, 'WorkerLock::heartbeat( $lock_token, $lane )' ), 'worker loop refreshes its lease heartbeat before each pass' );
+$assert( str_contains( $worker_source, 'if ( ! WorkerLock::heartbeat( $lock_token, $lane ) )' ), 'worker loop fences itself when lease refresh loses ownership' );
 $assert( str_contains( $lock_source, 'OptionLeaseStore::refresh' ), 'worker heartbeat uses the existing atomic lease refresh primitive' );
 $assert( str_contains( $lock_source, "'heartbeat_age_seconds'" ), 'worker lock snapshots expose heartbeat age' );
+$assert( str_contains( $worker_source, "wp_next_scheduled( 'action_scheduler_run_queue', array( 'WP Cron' ) )" ), 'worker diagnostics query the exact Action Scheduler WP-Cron event identity' );
+$assert( str_contains( $system_source, "wp_next_scheduled( 'action_scheduler_run_queue', array( 'WP Cron' ) )" ), 'system diagnostics query the exact Action Scheduler WP-Cron event identity' );
 
 $starved = WorkerHealth::classify(
 	array(
-		'due_count'                 => 1,
-		'oldest_due_age_seconds'    => 7200,
-		'queue_trigger_state'       => 'overdue',
-		'worker_heartbeat_state'    => 'absent',
-		'action_heartbeat_state'    => 'absent',
+		'due_count'                    => 1,
+		'stale_due_sample_age_seconds' => 7200,
+		'queue_trigger_state'          => 'overdue',
+		'worker_heartbeat_state'       => 'absent',
 		'concurrency_deferred_actions' => 0,
 	)
 );
@@ -74,13 +90,25 @@ $assert( 'wp datamachine worker run --once' === $starved['recommendation']['comm
 $claimed = WorkerHealth::classify(
 	array(
 		'due_count'              => 4,
-		'oldest_due_age_seconds' => 7200,
+		'stale_due_sample_age_seconds' => 7200,
 		'queue_trigger_state'    => 'overdue',
 		'worker_heartbeat_state' => 'fresh',
 	)
 );
 $assert( 'worker_claimed_with_heartbeat' === $claimed['condition'], 'a current worker lease heartbeat proves claimed work' );
 $assert( false === $claimed['scheduler_dispatcher_starved'], 'claimed work is not mislabeled as dispatcher starvation' );
+
+$attempt_only = WorkerHealth::classify(
+	array(
+		'due_count'                              => 4,
+		'stale_due_sample_age_seconds'           => 7200,
+		'queue_trigger_state'                    => 'overdue',
+		'worker_heartbeat_state'                 => 'absent',
+		'in_progress_count'                      => 1,
+		'in_progress_attempt_sample_age_seconds' => 10,
+	)
+);
+$assert( 'scheduler_dispatcher_starved' === $attempt_only['condition'], 'an Action Scheduler attempt timestamp does not prove current worker ownership' );
 
 $idle = WorkerHealth::classify(
 	array(
@@ -106,22 +134,39 @@ $assert( 'wp datamachine jobs liveness --format=json' === $deferred['recommendat
 $unclaimed = WorkerHealth::classify(
 	array(
 		'due_count'              => 1,
-		'oldest_due_age_seconds' => 30,
+		'stale_due_sample_age_seconds' => 30,
 		'queue_trigger_state'    => 'due',
 		'worker_heartbeat_state' => 'absent',
 	)
 );
 $assert( 'due_work_unclaimed' === $unclaimed['condition'], 'recent due work without a claim is distinct from starvation' );
 
+$lane = WorkerHealth::classify(
+	array(
+		'scope'                  => 'lane',
+		'due_count'              => 1,
+		'queue_trigger_state'    => 'overdue',
+		'worker_heartbeat_state' => 'absent',
+	)
+);
+$assert( 'lane_scope_unclassified' === $lane['condition'], 'lane evidence does not assert global dispatcher health' );
+$assert( false === $lane['scheduler_dispatcher_starved'], 'lane evidence cannot report global dispatcher starvation' );
+
 $wpdb            = new WorkerDispatchHealthWpdb();
 $GLOBALS['wpdb'] = $wpdb;
 $method          = new ReflectionMethod( ScopedDrainService::class, 'getDispatchEvidence' );
 $evidence        = $method->invoke( new ScopedDrainService(), null, array() );
-$assert( '2026-07-12 01:45:52' === $evidence['oldest_due_gmt'], 'dispatch evidence exposes the oldest due Data Machine action time' );
+$assert( '2026-07-12 01:45:52' === $evidence['stale_due_sample_gmt'], 'dispatch evidence exposes a bounded stale-due sample' );
 $assert( 0 === $evidence['in_progress_actions'], 'dispatch evidence exposes Action Scheduler claim state' );
-$assert( null === $evidence['latest_in_progress_attempt_gmt'], 'unavailable claim heartbeat time remains null' );
+$assert( null === $evidence['in_progress_attempt_sample_gmt'], 'unavailable attempt sample time remains null' );
 $assert( 3 === $evidence['concurrency_deferred_actions'], 'dispatch evidence distinguishes downstream concurrency resume actions' );
-$assert( 'wp_actionscheduler_actions' === $wpdb->prepare_args[1], 'Action Scheduler reads use the current site table prefix' );
-$assert( str_contains( $wpdb->query, "a.status IN ('pending', 'in-progress')" ), 'dispatch evidence scans only active scheduler rows' );
+$assert( false === $evidence['in_progress_actions_capped'], 'claim evidence reports whether its bounded count was capped' );
+$assert( false === $evidence['concurrency_deferred_actions_capped'], 'deferred evidence reports whether its bounded count was capped' );
+$queries = implode( "\n", $wpdb->queries );
+$assert( 4 === count( $wpdb->queries ), 'dispatch evidence resolves its group then uses separate indexable reads for stale, claimed, and deferred work' );
+$assert( str_contains( $queries, 'AS stale_due_sample_gmt' ) && str_contains( $queries, 'LIMIT 1' ), 'stale due evidence stops after the first matching action without sorting the backlog' );
+$assert( ! str_contains( $queries, 'ORDER BY a.scheduled_date_gmt' ), 'stale due evidence does not filesort the current backlog' );
+$assert( 2 === substr_count( $queries, 'LIMIT %d' ), 'claim and deferred evidence are independently capped' );
+$assert( ! str_contains( $queries, "a.status IN ('pending', 'in-progress')" ), 'future pending actions are not scanned with claimed work' );
 
 echo "OK ({$assertions} assertions)\n";


### PR DESCRIPTION
## Summary
- query the exact Action Scheduler `['WP Cron']` event and classify ownership only from a fresh worker lease
- fence workers after lease loss and keep lane-scoped status from asserting global dispatcher health
- replace unbounded active-action aggregation with bounded, truthfully labeled dispatcher evidence
- update focused scheduler and worker regression coverage

## Context
Follow-up to #3001. That PR was squash-merged while its independent review was still in progress; this PR contains only the reviewed corrections on top of current `main`.

## Verification
- exact-head independent review: no findings
- PHP syntax checks passed for all seven changed files
- PHPCS passed for all seven changed files
- worker dispatcher health smoke: 29 assertions
- worker lock smoke: 33 assertions
- worker status counts smoke: 6 assertions
- worker CLI smoke: 54 assertions
- scheduler health smoke passed
- `git diff --check origin/main...HEAD` passed