### PR TITLE
fix: prevent non-CLI command autoload during introspection

### DIFF
--- a/inc/Engine/AI/CliCommandIntrospector.php
+++ b/inc/Engine/AI/CliCommandIntrospector.php
@@ -4,9 +4,9 @@
  *
  * Context-safe introspection of WP-CLI command classes for AGENTS.md section
  * generators. Given a WP-CLI command class (or a namespace => class map), it
- * reflects over the class's public methods and returns each subcommand's name
- * and short description — derived from the same `@subcommand` annotation and
- * PHPDoc summary that WP-CLI itself uses to build `--help`.
+ * reads the class's public methods and returns each subcommand's name and short
+ * description — derived from the same `@subcommand` annotation and PHPDoc
+ * summary that WP-CLI itself uses to build `--help`.
  *
  * Why reflection instead of the live WP-CLI runtime registry?
  *
@@ -16,7 +16,9 @@
  * live `WP_CLI::get_runner()->find_command_to_run()` tree sees nothing when
  * composing from a web request. Reflecting over the command classes works
  * regardless of whether the WP-CLI runner is loaded — the docblocks live in the
- * class source and are always available. This makes generated AGENTS.md command
+ * class source and are always available. Unloaded command classes are parsed
+ * directly from their Composer source file so resolving WP-CLI-only inheritance
+ * is never required in a web request. This makes generated AGENTS.md command
  * lists derive from registered truth in every execution context.
  *
  * This helper is pure read/derive: no side effects, no WP-CLI invocation, no
@@ -71,17 +73,29 @@ class CliCommandIntrospector {
 	 *         array when the class does not exist.
 	 */
 	public static function describe_class( string $command_class, array $args = array() ): array {
-		if ( ! class_exists( $command_class ) ) {
-			return array();
-		}
-
 		$include_undocumented = ! empty( $args['include_undocumented'] );
 
-		try {
-			$reflection = new ReflectionClass( $command_class );
-		} catch ( \ReflectionException $e ) {
-			return array();
+		if ( class_exists( $command_class, false ) ) {
+			try {
+				$reflection = new ReflectionClass( $command_class );
+			} catch ( \ReflectionException $e ) {
+				return array();
+			}
+
+			return self::describe_reflection( $reflection, $include_undocumented );
 		}
+
+		return self::describe_source( $command_class, $include_undocumented );
+	}
+
+	/**
+	 * Describe a command class that is already loaded.
+	 *
+	 * @param ReflectionClass $reflection            Reflected command class.
+	 * @param bool            $include_undocumented Whether to include undocumented methods.
+	 * @return array<int, array{name: string, description: string}>
+	 */
+	private static function describe_reflection( ReflectionClass $reflection, bool $include_undocumented ): array {
 
 		$subcommands = array();
 
@@ -111,6 +125,204 @@ class CliCommandIntrospector {
 		ksort( $subcommands, SORT_STRING );
 
 		return array_values( $subcommands );
+	}
+
+	/**
+	 * Describe an unloaded command class from its Composer source metadata.
+	 *
+	 * Composer's findFile() resolves a class to a path without requiring the file,
+	 * which keeps WP_CLI_Command inheritance out of normal WordPress requests.
+	 *
+	 * @param class-string $command_class         Fully-qualified command class name.
+	 * @param bool         $include_undocumented Whether to include undocumented methods.
+	 * @return array<int, array{name: string, description: string}>
+	 */
+	private static function describe_source( string $command_class, bool $include_undocumented ): array {
+		$source_file = self::find_source_file( $command_class );
+		if ( null === $source_file ) {
+			return array();
+		}
+
+		$source = file_get_contents( $source_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local PHP source metadata without executing it.
+		if ( false === $source ) {
+			return array();
+		}
+
+		$tokens         = token_get_all( $source );
+		$target_class   = ltrim( $command_class, '\\' );
+		$namespace      = '';
+		$brace_depth    = 0;
+		$class_depth    = null;
+		$pending_class  = false;
+		$doc_comment    = '';
+		$visibility     = null;
+		$is_static      = false;
+		$subcommands    = array();
+		$previous_token = null;
+
+		foreach ( $tokens as $index => $token ) {
+			if ( is_string( $token ) ) {
+				if ( '{' === $token ) {
+					++$brace_depth;
+					if ( $pending_class ) {
+						$class_depth   = $brace_depth;
+						$pending_class = false;
+					}
+				} elseif ( '}' === $token ) {
+					if ( null !== $class_depth && $brace_depth === $class_depth ) {
+						break;
+					}
+					--$brace_depth;
+				} elseif ( ';' === $token && null !== $class_depth && $brace_depth === $class_depth ) {
+					$doc_comment = '';
+					$visibility  = null;
+					$is_static   = false;
+				}
+
+				continue;
+			}
+
+			$id = $token[0];
+
+			if ( T_NAMESPACE === $id && null === $class_depth ) {
+				$namespace = self::source_namespace( $tokens, $index + 1 );
+			} elseif ( T_CLASS === $id && T_DOUBLE_COLON !== $previous_token ) {
+				$class_name    = self::next_source_identifier( $tokens, $index + 1 );
+				$full_name     = '' === $namespace ? $class_name : $namespace . '\\' . $class_name;
+				$pending_class = $target_class === $full_name;
+			} elseif ( null !== $class_depth && $brace_depth === $class_depth ) {
+				if ( T_DOC_COMMENT === $id ) {
+					$doc_comment = $token[1];
+				} elseif ( T_PUBLIC === $id || T_PROTECTED === $id || T_PRIVATE === $id ) {
+					$visibility = $id;
+				} elseif ( T_STATIC === $id ) {
+					$is_static = true;
+				} elseif ( T_FUNCTION === $id ) {
+					$method_name = self::next_source_identifier( $tokens, $index + 1 );
+					$is_public   = null === $visibility || T_PUBLIC === $visibility;
+
+					if ( $is_public && ! $is_static && self::is_source_subcommand( $method_name ) && ( '' !== $doc_comment || $include_undocumented ) ) {
+						$name = self::source_subcommand_name( $method_name, $doc_comment );
+
+						$subcommands[ $name ] = array(
+							'name'        => $name,
+							'description' => self::short_description( $doc_comment ),
+						);
+					}
+
+					$doc_comment = '';
+					$visibility  = null;
+					$is_static   = false;
+				} elseif ( T_VARIABLE === $id || T_CONST === $id || T_USE === $id ) {
+					$doc_comment = '';
+					$visibility  = null;
+					$is_static   = false;
+				}
+			}
+
+			if ( T_WHITESPACE !== $id && T_COMMENT !== $id && T_DOC_COMMENT !== $id ) {
+				$previous_token = $id;
+			}
+		}
+
+		ksort( $subcommands, SORT_STRING );
+
+		return array_values( $subcommands );
+	}
+
+	/**
+	 * Find a class source file through registered Composer autoloaders.
+	 *
+	 * @param class-string $class_name Fully-qualified class name.
+	 * @return string|null
+	 */
+	private static function find_source_file( string $class_name ): ?string {
+		foreach ( spl_autoload_functions() as $autoload ) {
+			if ( ! is_array( $autoload ) || ! is_object( $autoload[0] ?? null ) || ! is_callable( array( $autoload[0], 'findFile' ) ) ) {
+				continue;
+			}
+
+			$source_file = $autoload[0]->findFile( $class_name );
+			if ( is_string( $source_file ) && is_readable( $source_file ) ) {
+				return $source_file;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Read the namespace following a T_NAMESPACE token.
+	 *
+	 * @param array $tokens PHP source tokens.
+	 * @param int   $offset First token after T_NAMESPACE.
+	 * @return string
+	 */
+	private static function source_namespace( array $tokens, int $offset ): string {
+		$namespace = '';
+
+		for ( $index = $offset, $count = count( $tokens ); $index < $count; ++$index ) {
+			$token = $tokens[ $index ];
+			if ( is_string( $token ) ) {
+				if ( ';' === $token || '{' === $token ) {
+					break;
+				}
+				continue;
+			}
+
+			if ( T_STRING === $token[0] || T_NS_SEPARATOR === $token[0] || ( defined( 'T_NAME_QUALIFIED' ) && T_NAME_QUALIFIED === $token[0] ) ) {
+				$namespace .= $token[1];
+			}
+		}
+
+		return trim( $namespace, '\\' );
+	}
+
+	/**
+	 * Read the next identifier from PHP source tokens.
+	 *
+	 * @param array $tokens PHP source tokens.
+	 * @param int   $offset Search offset.
+	 * @return string
+	 */
+	private static function next_source_identifier( array $tokens, int $offset ): string {
+		for ( $index = $offset, $count = count( $tokens ); $index < $count; ++$index ) {
+			if ( is_array( $tokens[ $index ] ) && T_STRING === $tokens[ $index ][0] ) {
+				return $tokens[ $index ][1];
+			}
+
+			if ( '(' === $tokens[ $index ] || '{' === $tokens[ $index ] || ';' === $tokens[ $index ] ) {
+				break;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Determine whether a source method is a command candidate.
+	 *
+	 * @param string $method_name Method name.
+	 * @return bool
+	 */
+	private static function is_source_subcommand( string $method_name ): bool {
+		return '__invoke' === $method_name || ( '' !== $method_name && 0 !== strpos( $method_name, '__' ) );
+	}
+
+	/**
+	 * Resolve a source method's command name.
+	 *
+	 * @param string $method_name Method name.
+	 * @param string $doc_comment Raw doc comment.
+	 * @return string
+	 */
+	private static function source_subcommand_name( string $method_name, string $doc_comment ): string {
+		$tag = self::get_tag( $doc_comment, 'subcommand' );
+		if ( '' !== $tag ) {
+			return $tag;
+		}
+
+		return '__invoke' === $method_name ? '__default' : str_replace( '_', '-', $method_name );
 	}
 
 	/**

--- a/tests/Unit/Engine/AI/CliCommandIntrospectorTest.php
+++ b/tests/Unit/Engine/AI/CliCommandIntrospectorTest.php
@@ -14,6 +14,7 @@ namespace DataMachine\Tests\Unit\Engine\AI;
 use DataMachine\Engine\AI\CliCommandIntrospector;
 use DataMachine\Tests\Unit\Engine\AI\Fixtures\FixtureCommand;
 use DataMachine\Tests\Unit\Engine\AI\Fixtures\SecondFixtureCommand;
+use DataMachine\Tests\Unit\Engine\AI\Fixtures\WpCliOnlyFixtureCommand;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -99,6 +100,26 @@ class CliCommandIntrospectorTest extends TestCase {
 	 */
 	public function test_describe_class_unknown_class_returns_empty(): void {
 		$this->assertSame( array(), CliCommandIntrospector::describe_class( '\\This\\Class\\Does\\Not\\Exist' ) );
+	}
+
+	/**
+	 * Non-CLI introspection reads source without loading WP-CLI inheritance.
+	 */
+	public function test_describe_class_does_not_autoload_wp_cli_only_command(): void {
+		$this->assertFalse( class_exists( 'WP_CLI_Command', false ) );
+		$this->assertFalse( class_exists( WpCliOnlyFixtureCommand::class, false ) );
+
+		$this->assertSame(
+			array(
+				array(
+					'name'        => 'inspect',
+					'description' => 'Inspect command metadata without loading WP-CLI inheritance.',
+				),
+			),
+			CliCommandIntrospector::describe_class( WpCliOnlyFixtureCommand::class )
+		);
+
+		$this->assertFalse( class_exists( WpCliOnlyFixtureCommand::class, false ) );
 	}
 
 	/**

--- a/tests/Unit/Engine/AI/Fixtures/WpCliOnlyFixtureCommand.php
+++ b/tests/Unit/Engine/AI/Fixtures/WpCliOnlyFixtureCommand.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * WP-CLI-only fixture that must never load in a non-CLI test process.
+ *
+ * @package DataMachine\Tests\Unit\Engine\AI\Fixtures
+ */
+
+namespace DataMachine\Tests\Unit\Engine\AI\Fixtures;
+
+class WpCliOnlyFixtureCommand extends \WP_CLI_Command {
+
+	/**
+	 * Inspect command metadata without loading WP-CLI inheritance.
+	 *
+	 * @subcommand inspect
+	 */
+	public function inspect( array $args, array $assoc_args ): void {
+	}
+}

--- a/tests/cli-command-introspector-non-cli-smoke.php
+++ b/tests/cli-command-introspector-non-cli-smoke.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Non-CLI smoke test for WP-CLI command source introspection.
+ *
+ * @package DataMachine\Tests
+ */
+
+require_once __DIR__ . '/bootstrap-unit.php';
+
+use DataMachine\Engine\AI\CliCommandIntrospector;
+use DataMachine\Tests\Unit\Engine\AI\Fixtures\WpCliOnlyFixtureCommand;
+
+if ( class_exists( 'WP_CLI_Command', false ) ) {
+	fwrite( STDERR, "FAIL: WP_CLI_Command must be absent in the non-CLI smoke process\n" );
+	exit( 1 );
+}
+
+$subcommands = CliCommandIntrospector::describe_class( WpCliOnlyFixtureCommand::class );
+
+if (
+	array(
+		array(
+			'name'        => 'inspect',
+			'description' => 'Inspect command metadata without loading WP-CLI inheritance.',
+		),
+	) !== $subcommands
+) {
+	fwrite( STDERR, "FAIL: source metadata was not parsed from the unloaded command\n" );
+	exit( 1 );
+}
+
+if ( class_exists( WpCliOnlyFixtureCommand::class, false ) ) {
+	fwrite( STDERR, "FAIL: introspection autoloaded the WP-CLI-only command\n" );
+	exit( 1 );
+}
+
+fwrite( STDOUT, "PASS: non-CLI introspection reads command metadata without autoloading WP-CLI inheritance\n" );


### PR DESCRIPTION
## Summary
- stop `CliCommandIntrospector` from autoloading unloaded WP-CLI command classes during generic AGENTS.md composition
- resolve unloaded classes to Composer source files and parse public command metadata without executing their inheritance chain
- preserve reflection for already-loaded commands and add focused non-CLI regression coverage

## Production trace
Production AGENTS.md shutdown invalidation repeatedly reached `CliCommandIntrospector::describe_class()` from generic multisite section composition. Its autoloading `class_exists()` call loaded Data Machine Business's `GoogleAnalyticsCommand`, then Data Machine's `BaseCommand`, which fatally failed at `extends WP_CLI_Command` because the request was not running under WP-CLI.

This fixes the boundary in Data Machine, the canonical owner of generic command introspection, rather than adding a Data Machine Business workaround.

## Approach
Already-loaded classes continue to use reflection. Unloaded classes are located through Composer's non-loading `findFile()` API and tokenized directly, preserving `@subcommand`, PHPDoc short-description, visibility, static-method, magic-method, and `__invoke` behavior without resolving WP-CLI-only inheritance. Classes that cannot be safely located fail closed with an empty result.

## Verification
- `vendor/bin/phpunit --bootstrap tests/bootstrap-unit.php tests/Unit/Engine/AI/CliCommandIntrospectorTest.php`
- `php tests/cli-command-introspector-non-cli-smoke.php`
- `php tests/cli-command-introspector-invoke-smoke.php`
- `homeboy --placement local review lint --changed-only --summary`

The dedicated non-CLI smoke process asserts that `WP_CLI_Command` is absent, extracts metadata from a fixture extending it, and confirms the command class remains unloaded afterward. This exercises the same `describe_class()` boundary used by scheduled/shutdown composition without running or modifying a live scheduled job; deployment remains outside this PR.

Closes #3013