### PR TITLE
fix: defer task registry initialization

### DIFF
--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -57,7 +57,6 @@ class SystemAgentServiceProvider {
 	public function __construct() {
 		$this->registerTaskHandlers();
 		$this->registerBuiltInSchedules();
-		$this->initializeRegistry();
 		$this->registerActionSchedulerHooks();
 		// Bootstrap immediately after AS initializes, then let AS's native daily
 		// recurring-ensure action repair schedules that are later interrupted.
@@ -277,15 +276,6 @@ class SystemAgentServiceProvider {
 				)
 			),
 		);
-	}
-
-	/**
-	 * Initialize the TaskRegistry.
-	 *
-	 * @since 0.37.0
-	 */
-	private function initializeRegistry(): void {
-		TaskRegistry::load();
 	}
 
 	/**

--- a/tests/Unit/AI/System/SystemAgentServiceProviderTest.php
+++ b/tests/Unit/AI/System/SystemAgentServiceProviderTest.php
@@ -10,6 +10,7 @@ namespace DataMachine\Tests\Unit\AI\System;
 
 use DataMachine\Engine\AI\System\SystemAgentServiceProvider;
 use DataMachine\Engine\AI\System\Tasks\ImageGenerationTask;
+use DataMachine\Engine\Tasks\TaskRegistry;
 use WP_UnitTestCase;
 
 class SystemAgentServiceProviderTest extends WP_UnitTestCase {
@@ -32,6 +33,21 @@ class SystemAgentServiceProviderTest extends WP_UnitTestCase {
 		$tasks = $this->provider->getBuiltInTasks( $existing );
 		$this->assertArrayHasKey( 'custom_task', $tasks );
 		$this->assertArrayHasKey( 'image_generation', $tasks );
+	}
+
+	public function test_registry_remains_lazy_for_extension_task_filters(): void {
+		TaskRegistry::reset();
+		new SystemAgentServiceProvider();
+		$callback = static function ( array $tasks ): array {
+			$tasks['extension_task'] = 'ExtensionTaskClass';
+			return $tasks;
+		};
+		add_filter( 'datamachine_tasks', $callback, 30 );
+
+		$this->assertTrue( TaskRegistry::isRegistered( 'extension_task' ) );
+
+		remove_filter( 'datamachine_tasks', $callback, 30 );
+		TaskRegistry::reset();
 	}
 
 	public function test_task_retry_action_is_registered(): void {


### PR DESCRIPTION
## Summary
- stop eagerly freezing `TaskRegistry` during Data Machine's own plugin load
- retain the registry's existing lazy first-read behavior so extension filters registered later in WordPress bootstrap are included
- add a regression test matching third-party provider construction and task registration order

## Live evidence
Extra Chill Events registers `extrachill_local_scene_digest` through the documented filter, and direct filter inspection sees it, but `datamachine/run-task` rejects it because the request cache was populated before Events loaded.

## Verification
- focused service-provider PHPUnit command exited successfully
- both changed files pass targeted Homeboy lint; runtime PHPCS and PHPStan level 7 passed
- PHP syntax and `git diff --check` passed

Closes #3017