### PR TITLE
fix: report persisted terminal transition state

### DIFF
--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -2386,7 +2386,9 @@ class Jobs extends BaseRepository {
 			$recovery_owner = is_array( $recovery_owner ) ? $recovery_owner : null;
 		}
 		if ( null !== self::$terminalizing_job ) {
-			return $this->status_transition_result( false, false, null, $requested_status );
+			$job            = $this->get_job( $job_id );
+			$current_status = is_array( $job ) && is_string( $job['status'] ?? null ) ? $job['status'] : null;
+			return $this->status_transition_result( false, false, $current_status, $current_status ?? $requested_status );
 		}
 
 		self::$terminalizing_job = $job_id;

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -304,9 +304,17 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertTrue( $owner_result['success'] );
 		$this->assertIsArray( $contender_result );
 		$this->assertFalse( $contender_result['success'] );
+		$this->assertSame( JobStatus::PROCESSING, $contender_result['status'] );
+		$this->assertSame( JobStatus::PROCESSING, $contender_result['current_status'] );
 		$this->assertSame( JobStatus::COMPLETED, $owner_result['status'] );
 		$this->assertSame( 1, $callback_count );
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'concurrent-terminal-id' ) );
+
+		$retry_result = ( new Jobs() )->transition_job_status_result( $job_id, JobStatus::COMPLETED, true );
+		$this->assertTrue( $retry_result['success'] );
+		$this->assertFalse( $retry_result['changed'] );
+		$this->assertSame( JobStatus::COMPLETED, $retry_result['status'] );
+		$this->assertSame( 1, $callback_count );
 	}
 
 	public function test_reject_source_defers_owned_claim_completion_to_terminal_lifecycle(): void {

--- a/tests/processed-item-claims-smoke.php
+++ b/tests/processed-item-claims-smoke.php
@@ -127,6 +127,7 @@ echo "Case 5: production files expose the claim contract\n";
 $processed_items = file_get_contents( __DIR__ . '/../inc/Core/Database/ProcessedItems/ProcessedItems.php' );
 $fetch_handler   = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/FetchHandler.php' );
 $lifecycle       = file_get_contents( __DIR__ . '/../inc/Engine/Actions/Handlers/StepLifecycleHandler.php' );
+$execute_step    = file_get_contents( __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php' );
 $actions         = file_get_contents( __DIR__ . '/../inc/Engine/Actions/DataMachineActions.php' );
 $batch_scheduler = file_get_contents( __DIR__ . '/../inc/Core/ActionScheduler/BatchScheduler.php' );
 $packet_store    = file_get_contents( __DIR__ . '/../inc/Core/DataPacketStore.php' );
@@ -144,6 +145,7 @@ assert_claims_smoke( 'fetch filters active claims through bulk classification', 
 assert_claims_smoke( 'fetch claims after max_items', strpos( $fetch_handler, 'array_slice' ) < strpos( $fetch_handler, 'claimItems' ) );
 assert_claims_smoke( 'all terminal statuses register one replayable core lifecycle callback', str_contains( $actions, "\$callbacks['step_lifecycle'] = array( StepLifecycleHandler::class, 'handleTerminal' )" ) );
 assert_claims_smoke( 'lifecycle uses owner-conditional completion and release', str_contains( $lifecycle, 'complete_owned_claim' ) && str_contains( $lifecycle, 'release_owned_claim' ) );
+assert_claims_smoke( 'terminal callers reject lost transitions before reporting success', 3 === substr_count( $execute_step, "! \$transition['success'] || ! JobStatus::isStatusSuccess( \$transition['status'] )" ) );
 assert_claims_smoke( 'lifecycle preserves multiple inline claims', str_contains( $lifecycle, 'CLAIMS_METADATA_KEY' ) && str_contains( $lifecycle, 'uniqueClaims' ) );
 assert_claims_smoke( 'completion consumers register outside generic lifecycle', str_contains( $actions, 'datamachine_item_claim_completion_handlers' ) && ! str_contains( $lifecycle, 'TrackedItems' ) );
 assert_claims_smoke( 'legacy jobs retain terminal job-id cleanup', str_contains( $lifecycle, 'release_claims_for_job' ) );


### PR DESCRIPTION
## Summary
- report the currently persisted job status when a request-local terminal caller is rejected behind an active terminal transaction, rather than echoing its requested success status
- lock in idempotent retry behavior after the owning terminal caller commits, without replaying claim completion callbacks
- verify every successful `ExecuteStepAbility` terminal route rejects a lost transition before reporting success

## Race And Invariant

Issue #2943 was filed against intermediate PR #2937 head `542c262`, where claim completion committed before the job status compare-and-set. Later commits in that PR moved claim callbacks, claim mutation, and terminal job persistence into one transaction guarded by a locked job row. That owning-layer transaction now guarantees that committed claim completion cannot coexist with a false `item_claim_completion_failed` status caused solely by a duplicate terminal caller.

One result-envelope gap remained: the connection-wide reentrancy guard returned the requested terminal status even though that caller did not own or persist it. This change reads the current job row and returns that persisted state. Once the owner commits, retrying the same terminal request observes the persisted winner as an idempotent success.

## Failure Semantics

- Real claim callback, ownership, transition, and release failures still roll back and retain their existing failure statuses.
- A terminal write failure still rolls back claim completion and reports the persisted post-rollback winner.
- Stale ownership and recovery-token fences are unchanged.
- A duplicate/reentrant caller cannot report requested success while another terminal transaction owns the boundary.
- Crash/retry remains recoverable because claim completion and terminal persistence share the transaction; a pre-commit disconnect rolls both back, while a post-commit retry observes the terminal row.

## Tests

- extended `ItemClaimLifecycleTest::test_concurrent_terminal_callers_share_one_persisted_success()` to assert the overlapping caller reports `processing`, then an after-commit retry reports idempotent `completed` without a second callback
- retained deterministic lost-CAS coverage proving claim callback and claim mutation roll back together
- added smoke coverage that all three `ExecuteStepAbility` success terminal routes check transition success and the returned persisted status

Verification:

- `php tests/processed-item-claims-smoke.php` (31 assertions)
- PHP syntax checks for all changed files
- changed-file PHPCS
- `git diff --check`
- focused PHPUnit command completed successfully in the local checkout
- Homeboy review run `9002ae5a-7f1c-4c25-befe-a04e7bcffa12`: audit passed with no introduced findings; PHPCS, ESLint, and PHPStan passed with no findings. Its changed-test harness exited before discovery with 0 tests and no test failures; the selected smoke test passed directly.

Closes #2943