### PR TITLE
fix: recover missing direct job actions

### DIFF
--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -13,6 +13,7 @@ namespace DataMachine\Abilities\Job;
 
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\ChildJobRecoveryPolicy;
+use DataMachine\Core\DirectJobEnqueuer;
 use DataMachine\Core\EngineData;
 
 defined( 'ABSPATH' ) || exit;
@@ -321,6 +322,95 @@ class RecoverStuckJobsAbility {
 						$timeout_hours * HOUR_IN_SECONDS,
 						time()
 					);
+				}
+				$direct_recovery = is_array( $job_row ) ? $this->diagnoseMissingDirectOperation( $job_row ) : null;
+				if ( is_array( $direct_recovery ) ) {
+					$effects_begun = ! empty( $job_row['operation_effects_begun_at'] );
+					$children      = $effects_begun ? $this->getProcessingSystemTaskChildren( $job_id ) : array();
+					$disposition   = $effects_begun ? 'terminalize' : 'requeue';
+					if ( $dry_run ) {
+						if ( $effects_begun ) {
+							++$timed_out;
+						} else {
+							++$requeued;
+						}
+						$this->appendJobDetail( $jobs, $jobs_omitted, $this->directRecoveryEvidence( $job_row, $direct_recovery, 'would_' . $disposition . '_missing_direct_action', $recovery_trigger, count( $children ) ) );
+						continue;
+					}
+
+					$required_touches = 1 + count( $children );
+					if ( ! $this->hasTouchCapacity( $touched, $apply_limit, $required_touches ) || ! $this->consumeTouchBudget( $attempted, $touched, $apply_limit ) ) {
+						$limit_reached = true;
+						break 2;
+					}
+
+					if ( ! $effects_begun ) {
+						$step_id = (string) $job_row['operation_step_id'];
+						$result  = $this->db_jobs->commit_missing_direct_operation_requeue(
+							$job_id,
+							(int) $job_row['operation_action_id'],
+							(int) $job_row['operation_generation'],
+							(string) $job_row['operation_claim_token'],
+							$recovery_trigger,
+							static fn( int $generation, string $token ): int => (int) as_schedule_single_action(
+								time(),
+								DirectJobEnqueuer::HOOK,
+								array(
+									'job_id'                => $job_id,
+									'flow_step_id'          => $step_id,
+									'operation_generation'  => $generation,
+									'operation_claim_token' => $token,
+								),
+								DirectJobEnqueuer::GROUP,
+								true
+							)
+						);
+						if ( ! empty( $result['success'] ) ) {
+							++$requeued;
+							++$mutations;
+							++$mutated;
+							$this->appendJobDetail(
+								$jobs,
+								$jobs_omitted,
+								$this->directRecoveryEvidence( $job_row, $direct_recovery, 'requeued_missing_direct_action', $recovery_trigger, 0 ) + array(
+									'recovery_action_id'             => (int) $result['action_id'],
+									'recovery_operation_generation' => (int) $result['generation'],
+								)
+							);
+						} else {
+							++$skipped;
+							$this->appendJobDetail( $jobs, $jobs_omitted, $this->directRecoveryEvidence( $job_row, $direct_recovery, 'skipped', $recovery_trigger, 0 ) + array( 'reason' => (string) ( $result['reason'] ?? 'direct_operation_requeue_failed' ) ) );
+						}
+						continue;
+					}
+
+					$status = JobStatus::failed( 'scheduler_path_lost_after_effects' )->toString();
+					$result = $this->db_jobs->transition_missing_direct_operation(
+						$job_id,
+						$status,
+						(int) $job_row['operation_action_id'],
+						(int) $job_row['operation_generation'],
+						(string) $job_row['operation_claim_token'],
+						$recovery_trigger
+					);
+					if ( empty( $result['success'] ) ) {
+						++$skipped;
+						$this->appendJobDetail( $jobs, $jobs_omitted, $this->directRecoveryEvidence( $job_row, $direct_recovery, 'skipped', $recovery_trigger, count( $children ) ) + array( 'reason' => 'direct_operation_owner_changed' ) );
+						continue;
+					}
+					++$timed_out;
+					++$mutations;
+					++$mutated;
+					$children_terminalized = 0;
+					foreach ( $children as $child_id ) {
+						$this->consumeTouchBudget( $attempted, $touched, $apply_limit );
+						if ( $this->db_jobs->complete_job( $child_id, $status ) ) {
+							++$children_terminalized;
+							++$mutated;
+						}
+					}
+					$this->appendJobDetail( $jobs, $jobs_omitted, $this->directRecoveryEvidence( $job_row, $direct_recovery, 'terminalized_missing_direct_action', $recovery_trigger, $children_terminalized ) );
+					continue;
 				}
 
 				if ( is_array( $child_diagnosis ) && ! empty( $child_diagnosis['has_active_path'] ) ) {
@@ -632,6 +722,90 @@ class RecoverStuckJobsAbility {
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic WHERE clause is prepared above.
 		return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table} {$where}" );
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	/** Return recovery evidence only for an absent, fully fenced direct-operation receipt. */
+	private function diagnoseMissingDirectOperation( array $job ): ?array {
+		$job_id     = (int) ( $job['job_id'] ?? 0 );
+		$action_id  = (int) ( $job['operation_action_id'] ?? 0 );
+		$generation = (int) ( $job['operation_generation'] ?? 0 );
+		$token      = (string) ( $job['operation_claim_token'] ?? '' );
+		$step_id    = (string) ( $job['operation_step_id'] ?? '' );
+		if ( $job_id <= 0
+			|| 'direct' !== (string) ( $job['flow_id'] ?? '' )
+			|| JobStatus::PROCESSING !== (string) ( $job['status'] ?? '' )
+			|| 'enqueued' !== (string) ( $job['operation_state'] ?? '' )
+			|| $action_id <= 0
+			|| $generation <= 0
+			|| '' === $token
+			|| '' === $step_id ) {
+			return null;
+		}
+
+		$execution = ( new DirectJobEnqueuer( $this->db_jobs ) )->liveGenerationExecution( $job_id, $generation, $token );
+		if ( 'none' !== $execution || $this->recordedActionExists( $action_id ) ) {
+			return null;
+		}
+
+		return array(
+			'action_id'  => $action_id,
+			'generation' => $generation,
+			'step_id'    => $step_id,
+			'live_generation_execution' => $execution,
+		);
+	}
+
+	/** Check the durable Action Scheduler receipt by primary key, regardless of current status. */
+	private function recordedActionExists( int $action_id ): bool {
+		global $wpdb;
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
+		$found = $wpdb->get_var( $wpdb->prepare( "SELECT action_id FROM {$actions_table} WHERE action_id = %d", $action_id ) );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return null !== $found;
+	}
+
+	/** @return array<int,int> */
+	private function getProcessingSystemTaskChildren( int $parent_job_id ): array {
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_jobs';
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT job_id FROM {$table} WHERE parent_job_id = %d AND source = %s AND status = %s ORDER BY job_id ASC",
+				$parent_job_id,
+				'pipeline_system_task',
+				JobStatus::PROCESSING
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return array_map( 'intval', $ids );
+	}
+
+	/** @return array<string,mixed> */
+	private function directRecoveryEvidence( array $job, array $diagnosis, string $status, string $trigger, int $children_terminalized ): array {
+		$created = strtotime( (string) ( $job['created_at'] ?? '' ) . ' UTC' );
+		return array(
+			'job_id'                       => (int) ( $job['job_id'] ?? 0 ),
+			'flow_id'                      => (string) ( $job['flow_id'] ?? '' ),
+			'parent_job_id'                => (int) ( $job['parent_job_id'] ?? 0 ),
+			'status'                       => $status,
+			'disposition'                  => $status,
+			'reason'                       => 'recorded_operation_action_missing',
+			'job_age_seconds'              => false === $created ? 0 : max( 0, time() - $created ),
+			'scheduler_path'               => 'none',
+			'action_id'                    => (int) $diagnosis['action_id'],
+			'action_status'                => 'missing',
+			'action_generation'            => (int) $diagnosis['generation'],
+			'action_generation_state'      => 'current',
+			'operation_state'              => (string) ( $job['operation_state'] ?? '' ),
+			'operation_generation'         => (int) ( $job['operation_generation'] ?? 0 ),
+			'operation_effects_begun'      => ! empty( $job['operation_effects_begun_at'] ),
+			'operation_step_id'            => (string) $diagnosis['step_id'],
+			'live_generation_execution'    => (string) $diagnosis['live_generation_execution'],
+			'system_children_terminalized' => $children_terminalized,
+			'recovery_trigger'             => $trigger,
+		);
 	}
 
 	/** @return array<int,array<string,mixed>> */

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -14,6 +14,7 @@ namespace DataMachine\Abilities\Job;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\ChildJobRecoveryPolicy;
 use DataMachine\Core\DirectJobEnqueuer;
+use DataMachine\Core\DirectOperationRecoveryPolicy;
 use DataMachine\Core\EngineData;
 
 defined( 'ABSPATH' ) || exit;
@@ -323,10 +324,20 @@ class RecoverStuckJobsAbility {
 						time()
 					);
 				}
-				$direct_recovery = is_array( $job_row ) ? $this->diagnoseMissingDirectOperation( $job_row ) : null;
+				$direct_recovery = null;
+				if ( is_array( $job_row ) ) {
+					$operation_generation = (int) ( $job_row['operation_generation'] ?? 0 );
+					$operation_token      = (string) ( $job_row['operation_claim_token'] ?? '' );
+					$live_execution       = ( new DirectJobEnqueuer( $this->db_jobs ) )->liveGenerationExecution( $job_id, $operation_generation, $operation_token );
+					$direct_recovery      = DirectOperationRecoveryPolicy::diagnose(
+						$job_row,
+						$live_execution,
+						DirectOperationRecoveryPolicy::recordedActionExists( (int) ( $job_row['operation_action_id'] ?? 0 ) )
+					);
+				}
 				if ( is_array( $direct_recovery ) ) {
 					$effects_begun = ! empty( $job_row['operation_effects_begun_at'] );
-					$children      = $effects_begun ? $this->getProcessingSystemTaskChildren( $job_id ) : array();
+					$children      = $effects_begun ? DirectOperationRecoveryPolicy::getProcessingSystemTaskChildren( $job_id ) : array();
 					$disposition   = $effects_begun ? 'terminalize' : 'requeue';
 					if ( $dry_run ) {
 						if ( $effects_begun ) {
@@ -334,7 +345,7 @@ class RecoverStuckJobsAbility {
 						} else {
 							++$requeued;
 						}
-						$this->appendJobDetail( $jobs, $jobs_omitted, $this->directRecoveryEvidence( $job_row, $direct_recovery, 'would_' . $disposition . '_missing_direct_action', $recovery_trigger, count( $children ) ) );
+						$this->appendJobDetail( $jobs, $jobs_omitted, DirectOperationRecoveryPolicy::evidence( $job_row, $direct_recovery, 'would_' . $disposition . '_missing_direct_action', $recovery_trigger, count( $children ) ) );
 						continue;
 					}
 
@@ -372,14 +383,14 @@ class RecoverStuckJobsAbility {
 							$this->appendJobDetail(
 								$jobs,
 								$jobs_omitted,
-								$this->directRecoveryEvidence( $job_row, $direct_recovery, 'requeued_missing_direct_action', $recovery_trigger, 0 ) + array(
+								DirectOperationRecoveryPolicy::evidence( $job_row, $direct_recovery, 'requeued_missing_direct_action', $recovery_trigger, 0 ) + array(
 									'recovery_action_id'             => (int) $result['action_id'],
 									'recovery_operation_generation' => (int) $result['generation'],
 								)
 							);
 						} else {
 							++$skipped;
-							$this->appendJobDetail( $jobs, $jobs_omitted, $this->directRecoveryEvidence( $job_row, $direct_recovery, 'skipped', $recovery_trigger, 0 ) + array( 'reason' => (string) ( $result['reason'] ?? 'direct_operation_requeue_failed' ) ) );
+							$this->appendJobDetail( $jobs, $jobs_omitted, DirectOperationRecoveryPolicy::evidence( $job_row, $direct_recovery, 'skipped', $recovery_trigger, 0 ) + array( 'reason' => (string) ( $result['reason'] ?? 'direct_operation_requeue_failed' ) ) );
 						}
 						continue;
 					}
@@ -395,7 +406,7 @@ class RecoverStuckJobsAbility {
 					);
 					if ( empty( $result['success'] ) ) {
 						++$skipped;
-						$this->appendJobDetail( $jobs, $jobs_omitted, $this->directRecoveryEvidence( $job_row, $direct_recovery, 'skipped', $recovery_trigger, count( $children ) ) + array( 'reason' => 'direct_operation_owner_changed' ) );
+						$this->appendJobDetail( $jobs, $jobs_omitted, DirectOperationRecoveryPolicy::evidence( $job_row, $direct_recovery, 'skipped', $recovery_trigger, count( $children ) ) + array( 'reason' => 'direct_operation_owner_changed' ) );
 						continue;
 					}
 					++$timed_out;
@@ -409,7 +420,7 @@ class RecoverStuckJobsAbility {
 							++$mutated;
 						}
 					}
-					$this->appendJobDetail( $jobs, $jobs_omitted, $this->directRecoveryEvidence( $job_row, $direct_recovery, 'terminalized_missing_direct_action', $recovery_trigger, $children_terminalized ) );
+					$this->appendJobDetail( $jobs, $jobs_omitted, DirectOperationRecoveryPolicy::evidence( $job_row, $direct_recovery, 'terminalized_missing_direct_action', $recovery_trigger, $children_terminalized ) );
 					continue;
 				}
 
@@ -722,90 +733,6 @@ class RecoverStuckJobsAbility {
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic WHERE clause is prepared above.
 		return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table} {$where}" );
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-	}
-
-	/** Return recovery evidence only for an absent, fully fenced direct-operation receipt. */
-	private function diagnoseMissingDirectOperation( array $job ): ?array {
-		$job_id     = (int) ( $job['job_id'] ?? 0 );
-		$action_id  = (int) ( $job['operation_action_id'] ?? 0 );
-		$generation = (int) ( $job['operation_generation'] ?? 0 );
-		$token      = (string) ( $job['operation_claim_token'] ?? '' );
-		$step_id    = (string) ( $job['operation_step_id'] ?? '' );
-		if ( $job_id <= 0
-			|| 'direct' !== (string) ( $job['flow_id'] ?? '' )
-			|| JobStatus::PROCESSING !== (string) ( $job['status'] ?? '' )
-			|| 'enqueued' !== (string) ( $job['operation_state'] ?? '' )
-			|| $action_id <= 0
-			|| $generation <= 0
-			|| '' === $token
-			|| '' === $step_id ) {
-			return null;
-		}
-
-		$execution = ( new DirectJobEnqueuer( $this->db_jobs ) )->liveGenerationExecution( $job_id, $generation, $token );
-		if ( 'none' !== $execution || $this->recordedActionExists( $action_id ) ) {
-			return null;
-		}
-
-		return array(
-			'action_id'  => $action_id,
-			'generation' => $generation,
-			'step_id'    => $step_id,
-			'live_generation_execution' => $execution,
-		);
-	}
-
-	/** Check the durable Action Scheduler receipt by primary key, regardless of current status. */
-	private function recordedActionExists( int $action_id ): bool {
-		global $wpdb;
-		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
-		$found = $wpdb->get_var( $wpdb->prepare( "SELECT action_id FROM {$actions_table} WHERE action_id = %d", $action_id ) );
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return null !== $found;
-	}
-
-	/** @return array<int,int> */
-	private function getProcessingSystemTaskChildren( int $parent_job_id ): array {
-		global $wpdb;
-		$table = $wpdb->prefix . 'datamachine_jobs';
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
-		$ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT job_id FROM {$table} WHERE parent_job_id = %d AND source = %s AND status = %s ORDER BY job_id ASC",
-				$parent_job_id,
-				'pipeline_system_task',
-				JobStatus::PROCESSING
-			)
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return array_map( 'intval', $ids );
-	}
-
-	/** @return array<string,mixed> */
-	private function directRecoveryEvidence( array $job, array $diagnosis, string $status, string $trigger, int $children_terminalized ): array {
-		$created = strtotime( (string) ( $job['created_at'] ?? '' ) . ' UTC' );
-		return array(
-			'job_id'                       => (int) ( $job['job_id'] ?? 0 ),
-			'flow_id'                      => (string) ( $job['flow_id'] ?? '' ),
-			'parent_job_id'                => (int) ( $job['parent_job_id'] ?? 0 ),
-			'status'                       => $status,
-			'disposition'                  => $status,
-			'reason'                       => 'recorded_operation_action_missing',
-			'job_age_seconds'              => false === $created ? 0 : max( 0, time() - $created ),
-			'scheduler_path'               => 'none',
-			'action_id'                    => (int) $diagnosis['action_id'],
-			'action_status'                => 'missing',
-			'action_generation'            => (int) $diagnosis['generation'],
-			'action_generation_state'      => 'current',
-			'operation_state'              => (string) ( $job['operation_state'] ?? '' ),
-			'operation_generation'         => (int) ( $job['operation_generation'] ?? 0 ),
-			'operation_effects_begun'      => ! empty( $job['operation_effects_begun_at'] ),
-			'operation_step_id'            => (string) $diagnosis['step_id'],
-			'live_generation_execution'    => (string) $diagnosis['live_generation_execution'],
-			'system_children_terminalized' => $children_terminalized,
-			'recovery_trigger'             => $trigger,
-		);
 	}
 
 	/** @return array<int,array<string,mixed>> */

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -513,6 +513,101 @@ class Jobs extends BaseRepository {
 	}
 
 	/**
+	 * Replace a missing direct-operation action while the recorded generation owns the locked row.
+	 *
+	 * @param callable(int,string):int $schedule Scheduler callback receiving the new generation and token.
+	 * @return array{success:bool,action_id:int,generation:int,token:string,reason:string}
+	 */
+	public function commit_missing_direct_operation_requeue( int $job_id, int $action_id, int $generation, string $token, string $trigger, callable $schedule ): array {
+		$result = array(
+			'success'    => false,
+			'action_id'  => 0,
+			'generation' => 0,
+			'token'      => '',
+			'reason'     => 'operation_not_owned',
+		);
+		if ( $job_id <= 0 || $action_id <= 0 || $generation <= 0 || '' === $token ) {
+			return $result;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		if ( false === $this->wpdb->query( 'START TRANSACTION' ) ) {
+			$result['reason'] = 'transaction_start_failed';
+			return $result;
+		}
+
+		$job = $this->get_job_for_update( $job_id );
+		if ( ! $this->missing_direct_operation_owner_matches( $job, $action_id, $generation, $token ) || ! empty( $job['operation_effects_begun_at'] ) ) {
+			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result['reason'] = ! empty( $job['operation_effects_begun_at'] ) ? 'operation_effects_begun' : 'operation_not_owned';
+			return $result;
+		}
+
+		$new_generation = $generation + 1;
+		$new_token      = bin2hex( random_bytes( 16 ) );
+		try {
+			$new_action_id = (int) $schedule( $new_generation, $new_token );
+		} catch ( \Throwable ) {
+			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result['reason'] = 'scheduler_exception';
+			return $result;
+		}
+		if ( $new_action_id <= 0 ) {
+			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result['reason'] = 'schedule_failed';
+			return $result;
+		}
+		$engine                              = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$engine['direct_operation_recovery'] = array(
+			'schema'                        => 'datamachine.direct-operation-recovery.v1',
+			'state'                         => 'requeued',
+			'trigger'                       => sanitize_key( $trigger ),
+			'missing_action_id'             => $action_id,
+			'previous_operation_generation' => $generation,
+			'action_id'                     => $new_action_id,
+			'operation_generation'          => $new_generation,
+			'recovered_at'                  => gmdate( 'c' ),
+		);
+		$run_lifecycle                       = is_array( $engine['run_lifecycle'] ?? null ) ? $engine['run_lifecycle'] : array();
+		$run_lifecycle['status']             = JobStatus::PENDING;
+		$run_lifecycle['updated_at']         = current_time( 'mysql', true );
+		$engine['run_lifecycle']             = $run_lifecycle;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $this->wpdb->update(
+			$this->table_name,
+			array(
+				'status'                => JobStatus::PENDING,
+				'operation_state'       => 'enqueued',
+				'operation_claimed_at'  => null,
+				'operation_claim_token' => $new_token,
+				'operation_generation'  => $new_generation,
+				'operation_action_id'   => $new_action_id,
+				'engine_data'           => wp_json_encode( $engine ),
+			),
+			array(
+				'job_id' => $job_id,
+				'status' => JobStatus::PROCESSING,
+			),
+			array( '%s', '%s', null, '%s', '%d', '%d', '%s' ),
+			array( '%d', '%s' )
+		);
+		if ( 1 !== (int) $updated || false === $this->wpdb->query( 'COMMIT' ) ) {
+			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result['reason'] = 'receipt_commit_failed';
+			return $result;
+		}
+
+		return array(
+			'success'    => true,
+			'action_id'  => $new_action_id,
+			'generation' => $new_generation,
+			'token'      => $new_token,
+			'reason'     => 'requeued',
+		);
+	}
+
+	/**
 	 * Reopen a failed job for an explicit retry.
 	 *
 	 * @param int $job_id Job ID.
@@ -2098,6 +2193,25 @@ class Jobs extends BaseRepository {
 		);
 	}
 
+	/** Commit a terminal direct-operation recovery only while the recorded action generation owns the row. */
+	public function transition_missing_direct_operation( int $job_id, string $status, int $action_id, int $generation, string $token, string $trigger ): array {
+		if ( ! JobStatus::isStatusFinal( $status ) || $action_id <= 0 || $generation <= 0 || '' === $token ) {
+			return $this->status_transition_result( false, false, null, $status );
+		}
+
+		return $this->transition_terminal_job_status_result(
+			$job_id,
+			$status,
+			array(
+				'action_id'  => $action_id,
+				'generation' => $generation,
+				'token'      => $token,
+				'trigger'    => sanitize_key( $trigger ),
+				'mode'       => 'operation',
+			)
+		);
+	}
+
 	/** Renew the exact recovery generation immediately before handler execution. */
 	public function renew_recovery_execution_owner( int $job_id, string $token, int $generation ): bool {
 		if ( $job_id <= 0 || '' === $token || $generation <= 0 ) {
@@ -2487,9 +2601,10 @@ class Jobs extends BaseRepository {
 		$processed_claim_count = is_array( $accounting_context ) ? max( 0, (int) ( $accounting_context['processed_claim_count'] ?? 0 ) ) : 0;
 		if ( is_array( $recovery_owner ) ) {
 			$latest_job  = $this->get_job_for_update( $job_id );
-			$owner_valid = 'execution' === (string) ( $recovery_owner['mode'] ?? '' )
-				? $this->terminal_recovery_owner_matches( $latest_job, $recovery_owner )
-				: $this->renew_recovery_owner_on_locked_job( $latest_job, (string) ( $recovery_owner['token'] ?? '' ), (int) ( $recovery_owner['generation'] ?? 0 ) );
+			$owner_mode  = (string) ( $recovery_owner['mode'] ?? '' );
+			$owner_valid = 'lease' === $owner_mode
+				? $this->renew_recovery_owner_on_locked_job( $latest_job, (string) ( $recovery_owner['token'] ?? '' ), (int) ( $recovery_owner['generation'] ?? 0 ) )
+				: $this->terminal_recovery_owner_matches( $latest_job, $recovery_owner );
 			if ( ! $owner_valid ) {
 				$this->rollback_terminal_transition( $job_id );
 				return $this->status_transition_result( false, false, $current_status, $current_status );
@@ -2509,7 +2624,8 @@ class Jobs extends BaseRepository {
 			'terminal_accounting_processed_count' => $processed_claim_count,
 		);
 		$update_formats = array( '%s', '%s', '%d', null, null, '%d' );
-		if ( $pending_direct_cancel ) {
+		$operation_recovery = is_array( $recovery_owner ) && 'operation' === (string) ( $recovery_owner['mode'] ?? '' );
+		if ( $pending_direct_cancel || $operation_recovery ) {
 			$update_data['operation_state']       = 'cancelled';
 			$update_data['operation_claimed_at']  = null;
 			$update_data['operation_claim_token'] = null;
@@ -2517,7 +2633,21 @@ class Jobs extends BaseRepository {
 			$update_data['operation_generation']  = max( 0, (int) ( $job['operation_generation'] ?? 0 ) ) + 1;
 			array_push( $update_formats, '%s', null, null, null, '%d' );
 		}
-		if ( is_array( $recovery_owner ) ) {
+		if ( $operation_recovery ) {
+			$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+			$engine['direct_operation_recovery'] = array(
+				'schema'                        => 'datamachine.direct-operation-recovery.v1',
+				'state'                         => 'terminalized',
+				'trigger'                       => (string) ( $recovery_owner['trigger'] ?? '' ),
+				'missing_action_id'             => (int) ( $recovery_owner['action_id'] ?? 0 ),
+				'previous_operation_generation' => (int) ( $recovery_owner['generation'] ?? 0 ),
+				'terminal_status'               => $status,
+				'recovered_at'                  => gmdate( 'c' ),
+			);
+			$update_data['engine_data'] = wp_json_encode( $engine );
+			$update_formats[]           = '%s';
+		}
+		if ( is_array( $recovery_owner ) && ! $operation_recovery ) {
 			$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
 			$engine['scheduler_recovery']['state']        = 'terminalized';
 			$engine['scheduler_recovery']['completed_at'] = gmdate( 'c' );
@@ -2842,12 +2972,30 @@ class Jobs extends BaseRepository {
 
 		$token      = (string) ( $owner['token'] ?? '' );
 		$generation = (int) ( $owner['generation'] ?? 0 );
-		if ( 'execution' !== (string) ( $owner['mode'] ?? '' ) ) {
+		$mode       = (string) ( $owner['mode'] ?? '' );
+		if ( 'operation' === $mode ) {
+			return $this->missing_direct_operation_owner_matches( $job, (int) ( $owner['action_id'] ?? 0 ), $generation, $token );
+		}
+		if ( 'execution' !== $mode ) {
 			return $this->recovery_owner_matches( $job, $token, $generation );
 		}
 
 		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
 		return ChildJobRecoveryPolicy::recoveryExecutionMatches( $engine, $generation, $token );
+	}
+
+	/** Validate the exact durable direct-operation receipt on a locked jobs row. */
+	private function missing_direct_operation_owner_matches( ?array $job, int $action_id, int $generation, string $token ): bool {
+		return is_array( $job )
+			&& 'direct' === (string) ( $job['flow_id'] ?? '' )
+			&& JobStatus::PROCESSING === (string) ( $job['status'] ?? '' )
+			&& 'enqueued' === (string) ( $job['operation_state'] ?? '' )
+			&& $action_id > 0
+			&& (int) ( $job['operation_action_id'] ?? 0 ) === $action_id
+			&& $generation > 0
+			&& (int) ( $job['operation_generation'] ?? 0 ) === $generation
+			&& '' !== $token
+			&& hash_equals( $token, (string) ( $job['operation_claim_token'] ?? '' ) );
 	}
 
 	/** Atomically renew an exact recovery owner while its jobs row is locked. */

--- a/inc/Core/DirectOperationRecoveryPolicy.php
+++ b/inc/Core/DirectOperationRecoveryPolicy.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Diagnosis and evidence policy for missing direct-operation actions.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+use DataMachine\Core\Database\Jobs\Jobs;
+
+defined( 'ABSPATH' ) || exit;
+
+class DirectOperationRecoveryPolicy {
+
+	/** Return recovery evidence only for an absent, fully fenced direct-operation receipt. */
+	public static function diagnose( array $job, string $live_execution, bool $recorded_action_exists ): ?array {
+		$job_id     = (int) ( $job['job_id'] ?? 0 );
+		$action_id  = (int) ( $job['operation_action_id'] ?? 0 );
+		$generation = (int) ( $job['operation_generation'] ?? 0 );
+		$token      = (string) ( $job['operation_claim_token'] ?? '' );
+		$step_id    = (string) ( $job['operation_step_id'] ?? '' );
+		if ( $job_id <= 0
+			|| 'direct' !== (string) ( $job['flow_id'] ?? '' )
+			|| JobStatus::PROCESSING !== (string) ( $job['status'] ?? '' )
+			|| 'enqueued' !== (string) ( $job['operation_state'] ?? '' )
+			|| $action_id <= 0
+			|| $generation <= 0
+			|| '' === $token
+			|| '' === $step_id
+			|| 'none' !== $live_execution
+			|| $recorded_action_exists ) {
+			return null;
+		}
+
+		return array(
+			'action_id'                 => $action_id,
+			'generation'                => $generation,
+			'step_id'                   => $step_id,
+			'live_generation_execution' => $live_execution,
+		);
+	}
+
+	/** Check the durable Action Scheduler receipt by primary key, regardless of current status. */
+	public static function recordedActionExists( int $action_id ): bool {
+		global $wpdb;
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
+		$found = $wpdb->get_var( $wpdb->prepare( "SELECT action_id FROM {$actions_table} WHERE action_id = %d", $action_id ) );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return null !== $found;
+	}
+
+	/** @return array<int,int> */
+	public static function getProcessingSystemTaskChildren( int $parent_job_id ): array {
+		global $wpdb;
+		$table = $wpdb->prefix . Jobs::TABLE_NAME;
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT job_id FROM {$table} WHERE parent_job_id = %d AND source = %s AND status = %s ORDER BY job_id ASC",
+				$parent_job_id,
+				'pipeline_system_task',
+				JobStatus::PROCESSING
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return array_map( 'intval', $ids );
+	}
+
+	/** @return array<string,mixed> */
+	public static function evidence( array $job, array $diagnosis, string $status, string $trigger, int $children_terminalized, int $now = 0 ): array {
+		$created = strtotime( (string) ( $job['created_at'] ?? '' ) . ' UTC' );
+		$now     = $now > 0 ? $now : time();
+		return array(
+			'job_id'                       => (int) ( $job['job_id'] ?? 0 ),
+			'flow_id'                      => (string) ( $job['flow_id'] ?? '' ),
+			'parent_job_id'                => (int) ( $job['parent_job_id'] ?? 0 ),
+			'status'                       => $status,
+			'disposition'                  => $status,
+			'reason'                       => 'recorded_operation_action_missing',
+			'job_age_seconds'              => false === $created ? 0 : max( 0, $now - $created ),
+			'scheduler_path'               => 'none',
+			'action_id'                    => (int) $diagnosis['action_id'],
+			'action_status'                => 'missing',
+			'action_generation'            => (int) $diagnosis['generation'],
+			'action_generation_state'      => 'current',
+			'operation_state'              => (string) ( $job['operation_state'] ?? '' ),
+			'operation_generation'         => (int) ( $job['operation_generation'] ?? 0 ),
+			'operation_effects_begun'      => ! empty( $job['operation_effects_begun_at'] ),
+			'operation_step_id'            => (string) $diagnosis['step_id'],
+			'live_generation_execution'    => (string) $diagnosis['live_generation_execution'],
+			'system_children_terminalized' => $children_terminalized,
+			'recovery_trigger'             => $trigger,
+		);
+	}
+}

--- a/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
+++ b/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
@@ -13,6 +13,7 @@ use DataMachine\Abilities\Job\FailJobAbility;
 use DataMachine\Abilities\Job\GetJobsAbility;
 use DataMachine\Abilities\Job\HydrateJobArtifactAbility;
 use DataMachine\Abilities\Job\JobsSummaryAbility;
+use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Abilities\Job\RetryJobAbility;
 use DataMachine\Abilities\Job\RunMetricsAbility;
 use DataMachine\Abilities\PermissionHelper;
@@ -21,6 +22,7 @@ use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\DirectJobEnqueuer;
 use DataMachine\Core\JobRetryPolicy;
+use DataMachine\Core\JobStatus;
 use WP_UnitTestCase;
 
 class DirectJobOwnershipTest extends WP_UnitTestCase {
@@ -565,6 +567,100 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 			)
 		);
 		$this->assertTrue( $stale['stale_generation'] );
+	}
+
+	public function test_stuck_recovery_requeues_missing_direct_operation_action_with_new_generation(): void {
+		global $wpdb;
+		wp_set_current_user( $this->owner_id );
+		$created = $this->execute( 'missing-direct-action-recovery' );
+		$jobs    = new Jobs();
+		$job_id  = (int) $created['job_id'];
+		$before  = $jobs->get_job( $job_id );
+		$old_args = array(
+			'job_id'                => $job_id,
+			'flow_step_id'          => (string) $before['operation_step_id'],
+			'operation_generation'  => (int) $before['operation_generation'],
+			'operation_claim_token' => (string) $before['operation_claim_token'],
+		);
+		$this->assertTrue( $jobs->start_job( $job_id ) );
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_jobs',
+			array( 'created_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ) ),
+			array( 'job_id' => $job_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		$this->assertSame( 1, $wpdb->delete( $wpdb->prefix . 'actionscheduler_actions', array( 'action_id' => (int) $before['operation_action_id'] ), array( '%d' ) ) );
+
+		$result = ( new RecoverStuckJobsAbility() )->execute(
+			array(
+				'job_id'        => $job_id,
+				'timeout_hours' => 1,
+				'limit'         => 3,
+			)
+		);
+		$after = $jobs->get_job( $job_id );
+
+		$this->assertSame( 1, $result['requeued'] );
+		$this->assertSame( JobStatus::PENDING, $after['status'] );
+		$this->assertSame( 'enqueued', $after['operation_state'] );
+		$this->assertGreaterThan( (int) $before['operation_generation'], (int) $after['operation_generation'] );
+		$this->assertNotSame( (int) $before['operation_action_id'], (int) $after['operation_action_id'] );
+		$this->assertSame( 'requeued', $after['engine_data']['direct_operation_recovery']['state'] );
+		$this->assertSame( (int) $before['operation_action_id'], (int) $after['engine_data']['direct_operation_recovery']['missing_action_id'] );
+		$this->assertSame( JobStatus::PENDING, $after['engine_data']['run_lifecycle']['status'] );
+		$this->assertSame( 'requeued_missing_direct_action', $result['jobs'][0]['status'] );
+
+		$stale = ( new ExecuteStepAbility() )->execute( $old_args );
+		$this->assertTrue( $stale['stale_generation'] );
+	}
+
+	public function test_missing_direct_action_after_effects_terminalizes_parent_and_system_child(): void {
+		global $wpdb;
+		wp_set_current_user( $this->owner_id );
+		$created = $this->execute( 'missing-direct-action-after-effects' );
+		$jobs    = new Jobs();
+		$job_id  = (int) $created['job_id'];
+		$parent  = $jobs->get_job( $job_id );
+		$this->assertTrue( $jobs->start_job( $job_id ) );
+		$this->assertTrue( $jobs->mark_operation_effects_begun( $job_id, (int) $parent['operation_generation'], (string) $parent['operation_claim_token'] ) );
+		$child_id = $jobs->create_job(
+			array(
+				'pipeline_id'  => 'direct',
+				'flow_id'      => 'direct',
+				'source'       => 'pipeline_system_task',
+				'label'        => 'Interrupted system task',
+				'parent_job_id' => $job_id,
+			)
+		);
+		$this->assertTrue( $jobs->start_job( $child_id ) );
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_jobs',
+			array( 'created_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ) ),
+			array( 'job_id' => $job_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		$this->assertSame( 1, $wpdb->delete( $wpdb->prefix . 'actionscheduler_actions', array( 'action_id' => (int) $parent['operation_action_id'] ), array( '%d' ) ) );
+
+		$result = ( new RecoverStuckJobsAbility() )->execute(
+			array(
+				'job_id'        => $job_id,
+				'timeout_hours' => 1,
+				'limit'         => 3,
+			)
+		);
+		$parent_after = $jobs->get_job( $job_id );
+		$child_after  = $jobs->get_job( $child_id );
+
+		$this->assertSame( 1, $result['timed_out'] );
+		$this->assertTrue( JobStatus::isStatusFailure( $parent_after['status'] ) );
+		$this->assertTrue( JobStatus::isStatusFailure( $child_after['status'] ) );
+		$this->assertSame( 'cancelled', $parent_after['operation_state'] );
+		$this->assertGreaterThan( (int) $parent['operation_generation'], (int) $parent_after['operation_generation'] );
+		$this->assertSame( 'terminalized', $parent_after['engine_data']['direct_operation_recovery']['state'] );
+		$this->assertSame( (int) $parent['operation_action_id'], (int) $parent_after['engine_data']['direct_operation_recovery']['missing_action_id'] );
+		$this->assertSame( 1, $result['jobs'][0]['system_children_terminalized'] );
 	}
 
 	public function test_legacy_unowned_job_retains_capability_gated_access(): void {

--- a/tests/direct-operation-missing-action-recovery-smoke.php
+++ b/tests/direct-operation-missing-action-recovery-smoke.php
@@ -1,0 +1,59 @@
+<?php
+/** Deterministic regression for missing direct-operation action recovery. */
+
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ );
+
+require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/DirectOperationRecoveryPolicy.php';
+
+use DataMachine\Core\DirectOperationRecoveryPolicy;
+
+$failures = 0;
+$assert   = static function ( string $name, bool $condition ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+	++$failures;
+	echo "  [FAIL] {$name}\n";
+};
+
+$job = array(
+	'job_id'                 => 42,
+	'flow_id'                => 'direct',
+	'status'                 => 'processing',
+	'created_at'             => '2026-07-27 10:00:00',
+	'operation_state'        => 'enqueued',
+	'operation_action_id'    => 9342876,
+	'operation_generation'   => 7,
+	'operation_claim_token'  => 'current-token',
+	'operation_step_id'      => 'ephemeral_step_0',
+);
+
+echo "=== direct-operation-missing-action-recovery-smoke ===\n";
+
+$missing = DirectOperationRecoveryPolicy::diagnose( $job, 'none', false );
+$assert( 'absent recorded action is recoverable', is_array( $missing ) );
+$assert( 'diagnosis preserves current action receipt', 9342876 === (int) ( $missing['action_id'] ?? 0 ) && 7 === (int) ( $missing['generation'] ?? 0 ) );
+$assert( 'pending current-generation step wins over recovery', null === DirectOperationRecoveryPolicy::diagnose( $job, 'step', false ) );
+$assert( 'pending current-generation AI continuation wins over recovery', null === DirectOperationRecoveryPolicy::diagnose( $job, 'ai_continuation', false ) );
+$assert( 'existing recorded action wins over recovery regardless of status', null === DirectOperationRecoveryPolicy::diagnose( $job, 'none', true ) );
+$assert( 'stale operation states are not reclaimable', null === DirectOperationRecoveryPolicy::diagnose( array_merge( $job, array( 'operation_state' => 'cancelled' ) ), 'none', false ) );
+
+$evidence = DirectOperationRecoveryPolicy::evidence( $job, $missing, 'requeued_missing_direct_action', 'automatic_worker', 0, strtotime( '2026-07-27 12:00:00 UTC' ) );
+$assert( 'evidence records missing action and current generation', 'missing' === $evidence['action_status'] && 9342876 === $evidence['action_id'] && 7 === $evidence['action_generation'] );
+$assert( 'evidence records deterministic age and trigger', 7200 === $evidence['job_age_seconds'] && 'automatic_worker' === $evidence['recovery_trigger'] );
+
+$post_effects = array_merge( $job, array( 'operation_effects_begun_at' => '2026-07-27 10:01:00' ) );
+$terminal     = DirectOperationRecoveryPolicy::evidence( $post_effects, $missing, 'terminalized_missing_direct_action', 'automatic_worker', 1, strtotime( '2026-07-27 12:00:00 UTC' ) );
+$assert( 'post-effects evidence prohibits replay and accounts for child cleanup', true === $terminal['operation_effects_begun'] && 1 === $terminal['system_children_terminalized'] );
+
+$jobs_source = file_get_contents( __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php' ) ?: '';
+$assert( 'requeue schedules and receipts while holding the jobs-row transaction', str_contains( $jobs_source, 'commit_missing_direct_operation_requeue' ) && str_contains( $jobs_source, "query( 'START TRANSACTION' )" ) && str_contains( $jobs_source, '$schedule( $new_generation, $new_token )' ) );
+$assert( 'requeue advances generation and restores pending lifecycle', str_contains( $jobs_source, '$new_generation = $generation + 1' ) && str_contains( $jobs_source, "\$run_lifecycle['status']" ) && str_contains( $jobs_source, 'JobStatus::PENDING' ) );
+$assert( 'terminal recovery fences the exact recorded action owner', str_contains( $jobs_source, 'missing_direct_operation_owner_matches' ) && str_contains( $jobs_source, "'operation' === \$mode" ) );
+
+echo sprintf( "\nMissing direct-operation recovery smoke complete: %d failures.\n", $failures );
+exit( $failures > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary

- detect stale direct jobs whose durable `operation_action_id` no longer exists while preserving any live current-generation step or AI continuation
- atomically requeue pre-effects work under a new operation generation and action receipt, making the disappeared generation stale
- terminalize post-effects operations and their synchronous processing system-task children instead of risking side-effect replay
- persist machine-readable direct recovery evidence and restore requeued run lifecycle state to `pending`

## Root Cause

Direct enqueueing already persisted `operation_action_id`, `operation_generation`, and `operation_claim_token`, but stuck-job recovery did not reconcile that receipt when Action Scheduler removed the referenced row. The job therefore fell through to generic timeout handling. For system tasks, the interrupted action could already have created a synchronous child, leaving both the direct parent and child in `processing` with no scheduler owner.

## State-Machine Invariants

- A recorded direct action is considered missing only when its exact Action Scheduler primary key is absent and no pending/in-progress action owns the current operation generation and token.
- Pending/running current-generation step actions and AI continuations always win over recovery.
- Pre-effects recovery schedules and receipts generation N+1 in the same database transaction that replaces generation N; generation N can no longer pass worker admission.
- Post-effects recovery never replays business effects. It atomically fences and terminalizes the exact recorded operation owner, then terminalizes synchronous processing `pipeline_system_task` children.
- Recovery ownership is compare-and-set against job ID, status, flow, operation state, action ID, generation, and token. A stale observer cannot replace newer work.
- Successful recovery persists `direct_operation_recovery` evidence containing the missing action, prior/current generation, trigger, disposition, and timestamp.

## Test Evidence

- PHP syntax: changed PHP files pass `php -l`
- Changed-file quality gate: Homeboy PHPCS and PHPStan pass with no findings
- `git diff --check` passes
- `tests/direct-job-generation-smoke.php`: pass
- `tests/child-job-recovery-policy-smoke.php`: 15 assertions, pass
- `tests/job-liveness-cli-smoke.php`: 14 assertions, pass
- `tests/recover-stuck-active-action-guard-smoke.php`: 15 assertions, pass
- `tests/recover-stuck-bounded-apply-smoke.php`: 16 assertions, pass
- `tests/recover-stuck-terminal-actions-smoke.php`: pass
- Added WordPress regression coverage for a deleted direct action receipt, stale-generation rejection, and post-effects parent/child terminalization in `DirectJobOwnershipTest`

The configured local `wp-codebox-phpunit` Homeboy surface exits before running tests and captures no runner diagnostics. This tooling issue is tracked in Extra-Chill/homeboy-extensions#2449; CI should execute the added WordPress tests in its configured runtime.

## Production Verification Plan

Do not mutate jobs 165953 or 165963 manually.

1. After a future approved release/deploy, let the scheduled worker invoke normal stuck-job recovery.
2. Inspect jobs 165953 and 165963 read-only through job/liveness commands and confirm neither remains `processing` with `no_scheduler_path`.
3. Inspect parent engine data for `direct_operation_recovery`: it should identify missing action 9342876 and record either `requeued` with a newer operation generation/action ID or `terminalized` if effects had begun.
4. If requeued, verify the replacement action uses the recorded current generation/token and the old generation is rejected as stale.
5. If terminalized, verify the synchronous child reaches the same truthful failure family and no replacement action was scheduled.
6. Confirm unrelated queued/running direct actions and AI deferrals remain active and unchanged.

Closes #3016